### PR TITLE
fix(soleur): enforce ATDD across plan/work/ship workflow commands

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "1.15.0"
+      placeholder: "1.15.1"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is a "Company-as-a-Service" platform designed to collapse the friction be
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-1.15.0-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-1.15.1-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -69,10 +69,17 @@ Project principles organized by domain. Add principles as you learn them.
 
 - Run `bun test` before merging changes that affect parsing, conversion, or output
 - All markdown files must pass markdownlint checks before commit
+- New modules and source files must have corresponding test files before shipping
+- Plans must include a "Test Scenarios" section with Given/When/Then acceptance tests
 
 ### Never
 
+- Ship feature branches with zero test files for new source code
+
 ### Prefer
+
+- RED/GREEN/REFACTOR cycle over write-code-then-test -- use `/atdd-developer` skill for guided TDD
+- Interface-level mocking over implementation-level mocking -- define a minimal interface (e.g., BotApi) and inject it, enabling tests without external dependencies
 
 ## Proposals
 

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "AI-powered development tools for Claude Code that get smarter with every use. 22 agents, 26 commands, and 19 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.1] - 2026-02-11
+
+### Changed
+
+- `/soleur:plan` now includes "Test Scenarios" section in all 3 detail templates (MINIMAL, MORE, A LOT) with Given/When/Then format
+- `/soleur:work` task execution loop rewritten with explicit RED/GREEN/REFACTOR steps and test-first enforcement
+- `/soleur:work` "Test Continuously" section updated with TDD guidance and `/atdd-developer` skill reference
+- `/soleur:work` quality checklist now requires test files for new source files
+- `/ship` Phase 5 checklist includes test existence verification
+- `/ship` Phase 6 checks for missing test files before running the suite, warns and asks before proceeding
+- Constitution Testing section expanded with ATDD rules: test file requirements, test scenario mandates, no-zero-tests gate, RED/GREEN/REFACTOR preference, and interface-level mocking guidance
+
 ## [1.15.0] - 2026-02-10
 
 ### Added

--- a/plugins/soleur/commands/soleur/plan.md
+++ b/plugins/soleur/commands/soleur/plan.md
@@ -236,6 +236,13 @@ date: YYYY-MM-DD
 - [ ] Core requirement 1
 - [ ] Core requirement 2
 
+## Test Scenarios
+
+Derive from acceptance criteria. Use Given/When/Then format:
+
+- Given [precondition], when [action], then [expected result]
+- Given [edge case], when [action], then [expected handling]
+
 ## Context
 
 [Any critical information]
@@ -304,6 +311,15 @@ date: YYYY-MM-DD
 - [ ] Detailed requirement 1
 - [ ] Detailed requirement 2
 - [ ] Testing requirements
+
+## Test Scenarios
+
+Translate each acceptance criterion into a testable scenario:
+
+- Given [precondition], when [action], then [expected result]
+- Given [error condition], when [action], then [graceful handling]
+
+Include regression scenarios for any bugs this work addresses.
 
 ## Success Metrics
 
@@ -404,6 +420,24 @@ date: YYYY-MM-DD
 - [ ] Test coverage requirements
 - [ ] Documentation completeness
 - [ ] Code review approval
+
+## Test Scenarios
+
+### Acceptance Tests (RED phase targets)
+
+For each functional requirement, write a Given/When/Then scenario:
+
+- Given [precondition], when [action], then [expected result]
+
+### Regression Tests
+
+For each bug fix included, write a scenario proving the fix:
+
+- Given [bug trigger condition], when [action], then [correct behavior]
+
+### Edge Cases
+
+- Given [boundary condition], when [action], then [expected handling]
 
 ## Success Metrics
 

--- a/plugins/soleur/commands/soleur/work.md
+++ b/plugins/soleur/commands/soleur/work.md
@@ -321,13 +321,16 @@ fi
      - Mark task as in_progress in TodoWrite
      - Read any referenced files from the plan
      - Look for similar patterns in codebase
-     - Implement following existing conventions
-     - Write tests for new functionality
-     - Run tests after changes
+     - RED: Write failing test(s) for this task's acceptance criteria
+     - GREEN: Write minimum code to make the test(s) pass
+     - REFACTOR: Improve code while keeping tests green
+     - Run full test suite after changes
      - Mark task as completed in TodoWrite
      - Mark off the corresponding checkbox in the plan file ([ ] → [x])
      - Evaluate for incremental commit (see below)
    ```
+
+   **Test-First Enforcement**: If the plan includes a "Test Scenarios" section, write tests for each scenario BEFORE writing implementation code. If no test scenarios exist in the plan, derive them from acceptance criteria. For infrastructure-only tasks (config, CI, scaffolding), tests may be skipped.
 
    **IMPORTANT**: Always update the original plan document by checking off completed items. Use the Edit tool to change `- [ ]` to `- [x]` for each task you finish. This keeps the plan as a living document showing progress and ensures no checkboxes are left unchecked.
 
@@ -371,10 +374,12 @@ fi
 
 5. **Test Continuously**
 
-   - Run relevant tests after each significant change
-   - Don't wait until the end to test
-   - Fix failures immediately
-   - Add new tests for new functionality
+   - **RED**: Write a failing test before implementing any new behavior
+   - **GREEN**: Write the minimum code to make the test pass
+   - **REFACTOR**: Improve code while keeping tests green
+   - Run the full test suite after each RED/GREEN/REFACTOR cycle
+   - Fix failures immediately -- never move to the next task with failing tests
+   - When a class becomes hard to test (too many dependencies), extract an interface and inject dependencies. See the `/atdd-developer` skill for detailed TDD guidance.
 
 6. **Track Progress**
    - Keep TodoWrite updated as you complete tasks
@@ -498,6 +503,7 @@ Before entering Phase 4, verify these Phase 2-3 items are complete:
 - [ ] All clarifying questions asked and answered
 - [ ] All TodoWrite tasks marked completed
 - [ ] Tests pass (run project's test command)
+- [ ] New source files have corresponding test files
 - [ ] Linting passes (use linting-agent)
 - [ ] Code follows existing patterns
 - [ ] Figma designs match implementation (if applicable)


### PR DESCRIPTION
## Summary

- `/plan` now includes a **Test Scenarios** section (Given/When/Then) in all 3 detail templates so `/work` has testable scenarios to implement RED-first
- `/work` task execution loop rewritten with explicit **RED/GREEN/REFACTOR** steps and test-first enforcement; "Test Continuously" section references `/atdd-developer` skill; quality checklist requires test files for new source files
- `/ship` Phase 6 verifies test files exist for new source files before running the suite -- warns and asks before proceeding silently
- **Constitution** Testing section expanded: 2 new Always rules (test files + test scenarios required), 1 Never rule (no zero-test feature branches), 2 Prefer rules (RED/GREEN/REFACTOR cycle, interface-level mocking with DI)

## Motivation

The telegram-bridge feature shipped with zero tests because no workflow command enforced test-first development. The `/atdd-developer` skill existed but was orphaned -- never referenced by `/plan`, `/work`, or `/ship`. This PR closes 4 gaps so ATDD cannot be silently skipped again.

## Test plan

- [x] `grep -c "Test Scenarios" plugins/soleur/commands/soleur/plan.md` returns 3
- [x] `grep "RED" plugins/soleur/commands/soleur/work.md` matches task loop and test section
- [x] `grep "test files" plugins/soleur/skills/ship/SKILL.md` matches Phase 6
- [x] `grep "atdd-developer" knowledge-base/overview/constitution.md` matches Prefer rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)