### PR TITLE
feat(brainstorm): add learnings-researcher, conversational tone, and anti-sycophancy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "1.15.1"
+      placeholder: "1.16.0"
     validations:
       required: true
   - type: input

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,11 +32,14 @@ When working with git worktrees, ALWAYS make edits in the worktree directory, NO
 
 After completing implementation work, follow this checklist before creating a PR:
 
-1. Run `/soleur:compound` to capture learnings (ask user first).
-2. Commit all artifacts (brainstorms, specs, plans, learnings).
-3. Update `plugins/soleur/README.md` if new commands, skills, or agents were added.
-4. Bump version per plugin `AGENTS.md` rules.
-5. Push and create PR.
+1. Run code review on unstaged changes (catch issues before commit).
+2. Run `/soleur:compound` to capture learnings (ask user first).
+3. Commit all artifacts (brainstorms, specs, plans, learnings).
+4. Update `plugins/soleur/README.md` if new commands, skills, or agents were added.
+5. Bump version per plugin `AGENTS.md` rules.
+6. Push and create PR.
+
+**The commit is the gate.** Review and compound must happen before step 3, not after. Do not propose committing until review and compound are done.
 
 Use the `/ship` skill to automate this checklist.
 
@@ -47,6 +50,12 @@ When the user gives a brainstorm or planning request, do NOT launch parallel res
 - Present a concise summary first (2-3 sentences), then ask if they want to go deeper.
 - Bad: Immediately spawning 5 research agents without user confirmation.
 - Good: "Here's my initial take: [summary]. Want me to research deeper?"
+
+## Communication Style
+
+- Challenge reasoning instead of validating by default -- explain the counter-argument, then let the user decide.
+- Stop excessive validation. If something looks wrong, say so directly.
+- Avoid flattery or unnecessary praise. Acknowledge good work briefly, then move on.
 
 ## Plugin Versioning
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is a "Company-as-a-Service" platform designed to collapse the friction be
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-1.15.1-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-1.16.0-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/knowledge-base/brainstorms/2026-02-12-improve-brainstorm-brainstorm.md
+++ b/knowledge-base/brainstorms/2026-02-12-improve-brainstorm-brainstorm.md
@@ -1,0 +1,45 @@
+---
+date: 2026-02-12
+topic: improve-brainstorm
+---
+
+# Improve the Brainstorm Command
+
+## What We're Building
+
+Enhancing `/soleur:brainstorm` with parallel research agents and an OpenSpec-inspired conversational philosophy. Currently the brainstorm command is the least parallelized Soleur command (1 agent vs. 10+ in review, 40+ in deepen-plan). We're adding a multi-agent research layer and shifting the brainstorming skill's tone from structured/prescriptive to curious/adaptive.
+
+## Why This Approach
+
+We evaluated three approaches:
+
+- **A: Parallel agents + philosophy update** -- Good impact but misses gap detection.
+- **B: Command-only parallel agents** -- Quick win but misses the conversational quality lift.
+- **C: Full research + spec-flow analysis (chosen)** -- Maximum impact. Parallel research agents gather context before dialogue, OpenSpec-inspired philosophy improves question quality, and spec-flow-analyzer catches gaps before the brainstorm doc is finalized.
+
+Approach C was chosen because it addresses both the *depth* problem (not enough research context) and the *quality* problem (prescriptive question style) while adding gap detection.
+
+We moved `framework-docs-researcher` to the plan phase only to avoid overlap -- `/soleur:plan` already runs it conditionally.
+
+## Key Decisions
+
+- **3 parallel research agents in Phase 1**: `repo-research-analyst`, `learnings-researcher`, `best-practices-researcher` -- all run before asking user any questions, so the brainstorm starts with informed context.
+- **framework-docs-researcher stays in plan phase only**: Avoids duplication since plan already runs it. Best-practices-researcher covers enough external context for brainstorming.
+- **spec-flow-analyzer after approach selection**: Runs after Phase 2 (user picks an approach) to validate completeness and surface gaps before writing the brainstorm doc.
+- **OpenSpec conversational philosophy adopted**: "Curious, not prescriptive" stance, ASCII diagrams for visual thinking, adaptive thread-following, "explore not prescribe" guardrail. Applied to the brainstorming SKILL.md.
+- **DDD architect excluded**: Domain modeling analysis belongs in the planning phase, not brainstorming.
+- **Agents run before dialogue, not after**: Gathering context first means the brainstorm asks sharper, more informed questions from the start.
+
+## Files to Modify
+
+1. `plugins/soleur/commands/soleur/brainstorm.md` -- Add parallel agent invocation in Phase 1, add spec-flow-analyzer in Phase 2.5 (new), update phase structure.
+2. `plugins/soleur/skills/brainstorming/SKILL.md` -- Adopt OpenSpec-inspired conversational philosophy: curious tone, ASCII diagrams, adaptive threading, explore-not-prescribe guardrail.
+
+## Resolved Questions
+
+- **Research results presentation**: Show a brief 3-5 line context summary to the user before starting dialogue. Transparency helps the user steer the conversation.
+- **Spec-flow-analyzer**: Always run, even for simple features. Consistency matters and the overhead is minimal.
+
+## Next Steps
+
+> `/soleur:plan` for implementation details

--- a/knowledge-base/learnings/2026-02-12-review-compound-before-commit-workflow.md
+++ b/knowledge-base/learnings/2026-02-12-review-compound-before-commit-workflow.md
@@ -1,0 +1,45 @@
+---
+module: soleur-plugin
+date: 2026-02-12
+problem_type: workflow-issue
+component: brainstorm, compound, review
+tags: [workflow, review, compound, commit-protocol, anti-sycophancy]
+severity: medium
+---
+
+# Run Review and Compound Before Commit, Not After
+
+## Problem
+
+During the brainstorm improvement feature, we completed all implementation and version bumps, then almost committed without running code review or `/soleur:compound`. The Workflow Completion Protocol in AGENTS.md listed compound as step 1 but did not explicitly include code review, and the ordering was easy to skip in practice.
+
+## Root Cause
+
+1. **Review was implicit, not explicit**: The protocol assumed review would happen naturally. It didn't -- momentum toward "commit and PR" skipped it.
+2. **Compound was listed but easy to forget**: Step 1 said "Run `/soleur:compound`" but nothing enforced it before step 2 ("Commit all artifacts").
+3. **No gate between implementation and commit**: The workflow went straight from "done implementing" to "let me commit."
+
+## Solution
+
+Updated AGENTS.md Workflow Completion Protocol to explicitly gate review and compound before commit:
+
+1. Run code review on changes (catch issues before they're committed)
+2. Run `/soleur:compound` to capture learnings (ask user first)
+3. Then commit, push, and PR
+
+## Key Insight
+
+**The commit is the gate, not the PR.** By the time you're creating a PR, you've already committed. Review and compound must happen before the commit, not after. This is the same principle as pre-commit hooks: catch problems at the earliest possible point.
+
+## Secondary Learning: Anti-Sycophancy Split
+
+When adding behavioral guidance (like anti-sycophancy), split by scope:
+- **Skill-specific guidance** (e.g., "challenge assumptions in brainstorming") goes in the skill's SKILL.md
+- **Project-wide guidance** (e.g., "don't flatter, challenge reasoning") goes in AGENTS.md
+
+This prevents scoping behavioral directives too narrowly to one command when they apply everywhere.
+
+## Related
+
+- [parallel-plan-review-catches-overengineering.md](./2026-02-06-parallel-plan-review-catches-overengineering.md) - Same session pattern: 3 reviewers unanimously simplified an over-scoped plan
+- [spec-workflow-implementation.md](./2026-02-06-spec-workflow-implementation.md) - "Human-in-the-loop v1, automate v2"

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -30,6 +30,7 @@ Project principles organized by domain. Add principles as you learn them.
 - Lifecycle workflows with hooks must cover every state transition with a cleanup trigger; verify no gaps between create, ship, merge, and session-start
 - Operations that modify the knowledge-base or move files must use `git mv` to preserve history and produce a single atomic commit that can be reverted with `git revert`
 - New commands must be idempotent -- running the same command twice must not create duplicates or corrupt state
+- Run code review and `/soleur:compound` before committing -- the commit is the gate, not the PR
 - Network and external service failures must degrade gracefully -- warn (if interactive) and continue rather than abort the workflow
 
 ### Never

--- a/knowledge-base/plans/2026-02-12-feat-improve-brainstorm-parallel-agents-plan.md
+++ b/knowledge-base/plans/2026-02-12-feat-improve-brainstorm-parallel-agents-plan.md
@@ -1,0 +1,159 @@
+---
+title: "feat: Improve brainstorm with learnings agent and conversational tone"
+type: feat
+date: 2026-02-12
+updated: 2026-02-12
+---
+
+# Improve Brainstorm with Learnings Agent and Conversational Tone
+
+[Updated 2026-02-12] Simplified after parallel review by DHH, Kieran, and Simplicity reviewers. Dropped `best-practices-researcher`, `spec-flow-analyzer`, and the 4-principle philosophy section. Kept `learnings-researcher` and conversational tone guidance.
+
+## Overview
+
+Add `learnings-researcher` alongside `repo-research-analyst` in brainstorm Phase 1, and add conversational tone guidance with a before/after example to the brainstorming skill. Small, focused change that improves context and question quality without duplicating the planning phase.
+
+## Problem Statement
+
+The brainstorm command follows a rigid, prescriptive question script. It runs a single research agent and has no access to institutional learnings (past gotchas, documented solutions). The tone guidance in the skill file is formulaic rather than conversational.
+
+## Proposed Solution
+
+**Three files, four changes:**
+
+1. **`brainstorm.md`** -- Add `learnings-researcher` alongside `repo-research-analyst` in Phase 1.1
+2. **`SKILL.md`** -- Add conversational tone guidance + before/after example + "challenge assumptions" technique + one anti-pattern row
+3. **`AGENTS.md`** -- Add project-wide anti-sycophancy guidance to Interaction Style section
+4. **Version bump** -- MINOR (check current version at implementation time) across plugin.json, CHANGELOG.md, README.md
+
+## Technical Approach
+
+### Change 1: Add learnings-researcher in brainstorm.md
+
+**Current Phase 1.1** (lines ~54-57):
+```markdown
+#### 1.1 Repository Research (Lightweight)
+Run a quick repo scan to understand existing patterns:
+- Task repo-research-analyst("Understand existing patterns related to: <feature_description>")
+Focus on: similar features, established patterns, CLAUDE.md guidance.
+```
+
+**New Phase 1.1** -- Replace with:
+```markdown
+#### 1.1 Research (Context Gathering)
+
+Run these agents **in parallel** to gather context before dialogue:
+
+- Task repo-research-analyst(feature_description)
+- Task learnings-researcher(feature_description)
+
+**What to look for:**
+- **Repo research:** existing patterns, similar features, CLAUDE.md guidance
+- **Learnings:** documented solutions in `knowledge-base/learnings/` -- past gotchas, patterns, lessons learned that might inform WHAT to build
+
+If either agent fails or returns empty, proceed with whatever results are available. Weave findings naturally into your first question rather than presenting a formal summary.
+```
+
+**Why `learnings-researcher` and not others:**
+- `learnings-researcher` is cheap (haiku model), local-only, and answers WHAT questions ("we tried this before and hit X gotcha")
+- `best-practices-researcher` answers HOW questions (community standards, framework conventions) -- belongs in `/soleur:plan` Phase 1.5b where it already runs
+- `framework-docs-researcher` is a planning concern -- already in `/soleur:plan` Phase 1.5b
+- `spec-flow-analyzer` needs a spec to analyze -- brainstorm output is intentionally incomplete; plan already runs it in Step 3
+
+**AGENTS.md compliance:** Two lightweight agents (one existing, one haiku-model) is consistent with the interaction style guidance. The key change is weaving findings into the first question naturally, not presenting a formal research summary phase.
+
+### Change 2: Conversational Tone in SKILL.md
+
+**Add to the existing "Question Techniques" section** (around line 49), not as a new section:
+
+```markdown
+5. **Be curious, not prescriptive**
+   Follow the user's energy -- if they light up about an aspect, explore it
+   deeper. If they seem decided, don't interrogate. The goal is collaborative
+   exploration, not an interview.
+
+   Old (prescriptive):
+   > "For authentication, you should use JWT tokens with refresh tokens
+   > stored in httpOnly cookies."
+
+   New (curious):
+   > "What security constraints are you working with? Have you weighed
+   > session-based vs token-based auth for your use case?"
+```
+
+**Add to Anti-Patterns table** (around line 174):
+
+| Forcing scripted questions when user leads elsewhere | Follow the user's thread, return to structure later |
+
+**Add a second technique** for challenging assumptions honestly:
+
+```markdown
+6. **Challenge assumptions honestly**
+   If the user's idea has a flaw or an unexplored risk, say so directly.
+   Don't fold your argument just because the user pushes back -- explain
+   your reasoning and let them decide. A brainstorm that only validates
+   is a wasted brainstorm.
+```
+
+**Reconcile with existing guidance:** The current SKILL.md line 102 says "Lead with a recommendation and explain why." This stays -- leading with a recommendation is fine when presenting approaches in Phase 2. The new "curious, not prescriptive" guidance applies to Phase 1 dialogue (understanding the idea), not Phase 2 (presenting approaches). No conflict. "Challenge assumptions" reinforces both -- recommend honestly, don't just agree.
+
+### Change 3: Anti-Sycophancy in AGENTS.md
+
+**Add to the existing "Interaction Style" section** (after the current content about research agents):
+
+```markdown
+## Communication Style
+
+- Challenge reasoning instead of validating by default -- explain the counter-argument, then let the user decide.
+- Stop excessive validation. If something looks wrong, say so directly.
+- Avoid flattery or unnecessary praise. Acknowledge good work briefly, then move on.
+```
+
+**Why AGENTS.md and not SKILL.md:** These are general behavior directives that apply to all Soleur interactions (planning, review, work, brainstorm). Putting them in the brainstorm skill would scope them too narrowly. The brainstorm-specific version ("challenge assumptions honestly") lives in the skill; the broader stance lives here.
+
+### Change 4: Version Bump
+
+Check current version in `plugins/soleur/.claude-plugin/plugin.json` at implementation time (defer exact number per learnings). This is a MINOR bump -- wiring a new agent into a command changes user-facing behavior.
+
+**Files to update:**
+- `plugins/soleur/.claude-plugin/plugin.json` -- bump version
+- `plugins/soleur/CHANGELOG.md` -- add entry with: Added learnings-researcher to brainstorm Phase 1; Changed brainstorming skill question techniques with conversational tone guidance
+- `plugins/soleur/README.md` -- verify component counts (no new agents/commands/skills, just wiring)
+
+## Acceptance Criteria
+
+- [ ] Phase 1.1 launches `repo-research-analyst` and `learnings-researcher` in parallel
+- [ ] Research findings woven into first question naturally (no formal summary phase)
+- [ ] If either agent fails or returns empty, brainstorm proceeds without interruption
+- [ ] SKILL.md Question Techniques includes "Be curious, not prescriptive" with before/after example
+- [ ] SKILL.md Question Techniques includes "Challenge assumptions honestly"
+- [ ] SKILL.md anti-patterns table includes "forcing scripted questions" row
+- [ ] AGENTS.md has "Communication Style" section with anti-sycophancy guidance
+- [ ] Plugin version bumped (MINOR) across plugin.json, CHANGELOG.md, README.md
+- [ ] `best-practices-researcher` NOT present in brainstorm
+- [ ] `spec-flow-analyzer` NOT present in brainstorm
+- [ ] `framework-docs-researcher` NOT present in brainstorm
+
+## Test Scenarios
+
+- Given a feature description, when brainstorm runs, then both repo-research-analyst and learnings-researcher execute in parallel before dialogue begins
+- Given an empty knowledge-base/learnings/ directory, when brainstorm runs, then learnings-researcher returns empty and brainstorm proceeds normally with repo-research findings only
+- Given a feature with documented learnings, when brainstorm runs, then relevant gotchas are woven into the first question
+- Given the updated SKILL.md, when brainstorm enters dialogue, then questions are open-ended and exploratory rather than formulaic
+- Given a user proposes an approach with a clear flaw, when brainstorm is in dialogue, then the agent flags the flaw directly rather than validating the approach
+
+## What Was Cut (and Why)
+
+| Cut | Reason | Where it lives instead |
+|-----|--------|----------------------|
+| `best-practices-researcher` | Answers HOW, not WHAT | `/soleur:plan` Phase 1.5b |
+| `spec-flow-analyzer` (Phase 2.5) | No spec to analyze yet; plan already runs it | `/soleur:plan` Step 3 |
+| Formal research summary phase (1.1b) | Contradicts AGENTS.md interaction style; natural weaving is better | N/A -- findings woven into dialogue |
+| 4-principle Conversational Philosophy section | Overlapping abstractions for one idea; examples teach better than manifestos | Condensed to 1 technique + 1 example |
+
+## References
+
+- Brainstorm: `knowledge-base/brainstorms/2026-02-12-improve-brainstorm-brainstorm.md`
+- Spec: `knowledge-base/specs/feat-improve-brainstorm/spec.md`
+- Issue: #52
+- Review feedback: DHH, Kieran, Simplicity reviewers (2026-02-12)

--- a/knowledge-base/specs/feat-improve-brainstorm/spec.md
+++ b/knowledge-base/specs/feat-improve-brainstorm/spec.md
@@ -1,0 +1,40 @@
+---
+feature: improve-brainstorm
+status: draft
+date: 2026-02-12
+---
+
+# Improve Brainstorm Command
+
+## Problem Statement
+
+The `/soleur:brainstorm` command currently runs a single research agent (`repo-research-analyst`) and follows a structured, prescriptive question flow. This means brainstorming sessions start with limited context and follow a rigid script rather than adapting to the problem at hand. Other Soleur commands (review, plan, deepen-plan) leverage parallel sub-agents extensively, but brainstorm does not.
+
+## Goals
+
+- G1: Run 3 parallel research agents before user dialogue to gather rich context upfront
+- G2: Adopt an OpenSpec-inspired conversational philosophy (curious, visual, adaptive)
+- G3: Add spec-flow-analyzer after approach selection to catch gaps early
+- G4: Maintain clean separation with plan phase (no framework-docs-researcher overlap)
+
+## Non-Goals
+
+- NG1: Adding DDD analysis to brainstorming (belongs in plan phase)
+- NG2: Running framework-docs-researcher in brainstorm (plan already handles this)
+- NG3: Changing the worktree/spec/issue creation workflow (Phase 3+)
+- NG4: Modifying other commands (plan, review, etc.)
+
+## Functional Requirements
+
+- FR1: Phase 1 launches `repo-research-analyst`, `learnings-researcher`, and `best-practices-researcher` in parallel before any user dialogue
+- FR2: Research results are synthesized into context that informs the brainstorm questions
+- FR3: After user selects an approach (Phase 2), `spec-flow-analyzer` runs to validate completeness
+- FR4: Brainstorming skill adopts curious/adaptive tone, ASCII diagram guidance, and thread-following behavior
+- FR5: The "explore not prescribe" guardrail is explicit in the skill
+
+## Technical Requirements
+
+- TR1: All 3 research agents must be invoked using Task tool in a single message (parallel execution)
+- TR2: Spec-flow-analyzer receives the chosen approach + research context as input
+- TR3: Changes are limited to 2 files: `brainstorm.md` (command) and `SKILL.md` (skill)
+- TR4: Version bump required per plugin AGENTS.md (MINOR bump -- new capability)

--- a/knowledge-base/specs/feat-improve-brainstorm/tasks.md
+++ b/knowledge-base/specs/feat-improve-brainstorm/tasks.md
@@ -1,0 +1,38 @@
+---
+feature: improve-brainstorm
+status: pending
+date: 2026-02-12
+updated: 2026-02-12
+---
+
+# Tasks: Improve Brainstorm Command
+
+## Phase 1: Command Changes (brainstorm.md)
+
+- [ ] 1.1 Add `learnings-researcher` to Phase 1.1 alongside `repo-research-analyst`
+  - Replace single agent block with 2 parallel agents
+  - Add "What to look for" guidance per agent
+  - Add failure handling: proceed with whatever succeeds
+  - Remove formal summary phase -- weave findings into first question naturally
+
+## Phase 2: Skill Changes (SKILL.md)
+
+- [ ] 2.1 Add "Be curious, not prescriptive" to Question Techniques section
+  - Add as technique #5 with before/after example (auth question)
+  - Keep existing "Lead with a recommendation" for Phase 2 -- no conflict
+- [ ] 2.2 Add "Challenge assumptions honestly" to Question Techniques section
+  - Add as technique #6 -- flag flaws directly, don't fold under pushback
+- [ ] 2.3 Add anti-pattern row for "forcing scripted questions"
+
+## Phase 3: Project-Wide Changes (AGENTS.md)
+
+- [ ] 3.1 Add "Communication Style" section to AGENTS.md
+  - Challenge reasoning instead of validating by default
+  - Stop excessive validation
+  - Avoid flattery or unnecessary praise
+
+## Phase 4: Version Bump
+
+- [ ] 4.1 Check current version in plugin.json, bump MINOR
+- [ ] 4.2 Add CHANGELOG.md entry
+- [ ] 4.3 Verify README.md counts and version badge

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "AI-powered development tools for Claude Code that get smarter with every use. 22 agents, 26 commands, and 19 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - 2026-02-12
+
+### Added
+
+- `learnings-researcher` wired into `/soleur:brainstorm` Phase 1.1 alongside `repo-research-analyst` -- past gotchas and documented solutions now inform brainstorming dialogue
+- "Challenge assumptions honestly" technique added to brainstorming skill -- brainstorms now push back on flawed reasoning instead of only validating
+
+### Changed
+
+- `/soleur:brainstorm` Phase 1.1 runs 2 research agents in parallel (repo-research + learnings) instead of 1
+- Brainstorming skill Question Techniques updated with "Be curious, not prescriptive" guidance and before/after example
+- Brainstorming skill Anti-Patterns table includes "forcing scripted questions" row
+- `AGENTS.md` adds project-wide "Communication Style" section: challenge reasoning, stop excessive validation, avoid flattery
+
 ## [1.15.1] - 2026-02-11
 
 ### Changed

--- a/plugins/soleur/commands/soleur/brainstorm.md
+++ b/plugins/soleur/commands/soleur/brainstorm.md
@@ -49,13 +49,18 @@ Use **AskUserQuestion tool** to suggest: "Your requirements seem detailed enough
 
 ### Phase 1: Understand the Idea
 
-#### 1.1 Repository Research (Lightweight)
+#### 1.1 Research (Context Gathering)
 
-Run a quick repo scan to understand existing patterns:
+Run these agents **in parallel** to gather context before dialogue:
 
-- Task repo-research-analyst("Understand existing patterns related to: <feature_description>")
+- Task repo-research-analyst(feature_description)
+- Task learnings-researcher(feature_description)
 
-Focus on: similar features, established patterns, CLAUDE.md guidance.
+**What to look for:**
+- **Repo research:** existing patterns, similar features, CLAUDE.md guidance
+- **Learnings:** documented solutions in `knowledge-base/learnings/` -- past gotchas, patterns, lessons learned that might inform WHAT to build
+
+If either agent fails or returns empty, proceed with whatever results are available. Weave findings naturally into your first question rather than presenting a formal summary.
 
 #### 1.2 Collaborative Dialogue
 

--- a/plugins/soleur/skills/brainstorming/SKILL.md
+++ b/plugins/soleur/skills/brainstorming/SKILL.md
@@ -63,6 +63,25 @@ Ask questions **one at a time** to understand the user's intent. Avoid overwhelm
 4. **Ask about success criteria early**
    - "How will you know this feature is working well?"
 
+5. **Be curious, not prescriptive**
+   Follow the user's energy -- if they light up about an aspect, explore it
+   deeper. If they seem decided, don't interrogate. The goal is collaborative
+   exploration, not an interview.
+
+   Old (prescriptive):
+   > "For authentication, you should use JWT tokens with refresh tokens
+   > stored in httpOnly cookies."
+
+   New (curious):
+   > "What security constraints are you working with? Have you weighed
+   > session-based vs token-based auth for your use case?"
+
+6. **Challenge assumptions honestly**
+   If the user's idea has a flaw or an unexplored risk, say so directly.
+   Don't fold your argument just because the user pushes back -- explain
+   your reasoning and let them decide. A brainstorm that only validates
+   is a wasted brainstorm.
+
 **Key Topics to Explore:**
 
 | Topic | Example Questions |
@@ -179,6 +198,7 @@ When the request is "analyze this problem" rather than "brainstorm approaches," 
 | Ignoring existing codebase patterns | Research what exists first |
 | Making assumptions without validating | State assumptions explicitly and confirm |
 | Creating lengthy design documents | Keep it concise—details go in the plan |
+| Forcing scripted questions when user leads elsewhere | Follow the user's thread, return to structure later |
 
 ## Integration with Planning
 


### PR DESCRIPTION
## Summary

- Wire `learnings-researcher` into `/soleur:brainstorm` Phase 1.1 alongside `repo-research-analyst` -- past gotchas and documented solutions now inform brainstorming dialogue
- Add "Be curious, not prescriptive" (with before/after example) and "Challenge assumptions honestly" techniques to brainstorming skill
- Add project-wide "Communication Style" section to `AGENTS.md` -- challenge reasoning, stop excessive validation, avoid flattery
- Update Workflow Completion Protocol to enforce code review + `/soleur:compound` before committing
- Promote review-before-commit rule to constitution

## Test plan

- [ ] Run `/soleur:brainstorm` on a new feature -- verify both `repo-research-analyst` and `learnings-researcher` execute in parallel before dialogue
- [ ] Run `/soleur:brainstorm` on a project with empty `knowledge-base/learnings/` -- verify brainstorm proceeds normally with only repo-research findings
- [ ] Verify brainstorm questions feel open-ended and exploratory rather than formulaic
- [ ] Verify version is 1.16.0 in plugin.json, CHANGELOG.md, README.md badge, and bug_report.yml

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)