### PR TITLE
feat(plugin): add automated tests for plugin markdown components

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.0.1"
+      placeholder: "2.1.0"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.0.1-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.1.0-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,14 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "devDependencies": {
+        "yaml": "^2.8.2",
+      },
+    },
+  },
+  "packages": {
+    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+  }
+}

--- a/knowledge-base/plans/2026-02-12-feat-plugin-component-tests-plan.md
+++ b/knowledge-base/plans/2026-02-12-feat-plugin-component-tests-plan.md
@@ -1,0 +1,226 @@
+---
+title: "feat: Add automated tests for plugin markdown components"
+type: feat
+date: 2026-02-12
+issue: "#62"
+version-bump: MINOR
+deepened: 2026-02-12
+---
+
+# Add Automated Tests for Plugin Markdown Components
+
+## Enhancement Summary
+
+**Deepened on:** 2026-02-12
+**Research agents used:** test-design-reviewer, code-simplicity-reviewer, codebase explorer, Context7 (Bun docs)
+
+### Key Improvements
+1. Simplified from 5 files to 2 files (components.test.ts + helpers.ts)
+2. Removed YAGNI: root package.json, test tsconfig, heading hierarchy checks, reference file existence checks
+3. Added granular assertion pattern: describe per file, test per field, custom error messages
+
+## Overview
+
+The plugin has 65 markdown components (22 agents, 8 commands, 35 skills) with zero automated tests. YAML frontmatter errors, broken markdown structure, and convention violations are only caught during manual use. This plan adds a `bun:test` suite that validates component structure and integrates with the pre-commit hook.
+
+## Problem Statement
+
+Broken frontmatter silently degrades agent/skill discovery with no error feedback. Missing required fields (`model`, `argument-hint`) go unnoticed. Convention violations (backtick references, wrong voice) accumulate. The telegram-bridge app has 84 tests, but plugin components have none.
+
+## Proposed Solution
+
+Create a test suite in `plugins/soleur/test/` using `bun:test` that validates all plugin markdown components. Fix known violations. Update the pre-commit hook to trigger tests on `.md` file changes under `plugins/soleur/`.
+
+## Technical Approach
+
+### Test Location & Infrastructure
+
+- **Test directory:** `plugins/soleur/test/`
+- **No root package.json needed.** Bun discovers `*.test.ts` files recursively. Lefthook runs `bun test plugins/soleur/test/` directly.
+- **No test-specific tsconfig needed.** Bun's defaults handle ESNext + TypeScript out of the box.
+
+### Test File Structure
+
+```
+plugins/soleur/test/
+  components.test.ts    # All validation: frontmatter, structure, conventions
+  helpers.ts            # File discovery, YAML parsing, shared utilities
+```
+
+Two files. One test file with logical `describe` blocks, one helper module. Bun supports `--test-name-pattern` filtering for debugging specific categories.
+
+### Component Discovery (`helpers.ts`)
+
+Glob patterns matching plugin loader behavior:
+
+- **Agents:** `plugins/soleur/agents/**/*.md` (recursive -- loader recurses into subdirectories)
+- **Commands:** `plugins/soleur/commands/soleur/*.md` (flat)
+- **Skills:** `plugins/soleur/skills/*/SKILL.md` (one level only -- loader does NOT recurse skills)
+
+Exclude: README.md, CHANGELOG.md, AGENTS.md, CLAUDE.md, LICENSE at plugin root.
+
+```typescript
+// helpers.ts
+import { Glob } from "bun";
+
+const PLUGIN_ROOT = "plugins/soleur";
+
+export function discoverAgents(): string[] {
+  return Array.from(new Glob(`${PLUGIN_ROOT}/agents/**/*.md`).scanSync("."))
+    .filter(f => !f.endsWith("README.md"));
+}
+
+export function discoverCommands(): string[] {
+  return Array.from(new Glob(`${PLUGIN_ROOT}/commands/soleur/*.md`).scanSync("."));
+}
+
+export function discoverSkills(): string[] {
+  return Array.from(new Glob(`${PLUGIN_ROOT}/skills/*/SKILL.md`).scanSync("."));
+}
+
+export function parseFrontmatter(filePath: string): Record<string, unknown> {
+  const content = Bun.file(filePath).text();
+  // Parse YAML between --- delimiters
+}
+```
+
+### Test Categories
+
+All in `components.test.ts` with describe blocks:
+
+**1. YAML Frontmatter Validation**
+
+| Component | Required Fields | Allowed Values |
+|-----------|----------------|----------------|
+| Agent | `name`, `description`, `model` | model: `inherit`, `haiku`, `sonnet`, `opus` |
+| Command | `name`, `description`, `argument-hint` | argument-hint: string (may be empty for commands that take no args) |
+| Skill | `name`, `description` | -- |
+
+**Granular assertion pattern** (from test design review -- improves failure messages):
+
+```typescript
+describe("Agent frontmatter", () => {
+  const agents = discoverAgents();
+
+  agents.forEach(agentPath => {
+    describe(agentPath, () => {
+      const fm = parseFrontmatter(agentPath);
+
+      test("has name field", () => {
+        expect(fm.name).toBeDefined();
+      });
+
+      test("has description field", () => {
+        expect(fm.description).toBeDefined();
+      });
+
+      test("has valid model field", () => {
+        expect(["inherit", "haiku", "sonnet", "opus"]).toContain(fm.model);
+      });
+    });
+  });
+});
+```
+
+This produces failures like: `Agent frontmatter > agents/research/foo.md > has valid model field` -- pinpointing exact file and field.
+
+**2. Markdown Structure**
+
+- Content exists after frontmatter (not empty body)
+
+That's it. No heading hierarchy checks -- these are prompt instructions, not documentation. Heading jumps don't break agent execution.
+
+**3. Convention Compliance**
+
+- **Third-person voice:** Skill `description` fields must start with "This skill" (per constitution line 9)
+- **Kebab-case filenames:** Agent `.md` filenames, command `.md` filenames, and skill directory names match `/^[a-z0-9]+(-[a-z0-9]+)*$/`
+- **Backtick reference detection:** No inline backtick references matching `` `(references|assets|scripts)/[^`]+` `` in skill SKILL.md content. Simple regex -- no code block exclusion logic needed. The constitution bans backtick references unconditionally.
+- **Agent example blocks:** Agent `description` fields contain at least one `<example>` block (per constitution line 13)
+
+### Known Violations to Fix
+
+These must be fixed in the same PR so tests pass on merge:
+
+| Component | Violation | Fix |
+|-----------|-----------|-----|
+| `skills/agent-browser/SKILL.md` | Description doesn't start with "This skill" | Rewrite to "This skill should be used when automating browser interactions..." |
+| `skills/rclone/SKILL.md` | Description doesn't start with "This skill" | Rewrite to "This skill should be used when uploading, syncing, or managing files..." |
+| `commands/soleur/help.md` | Missing `argument-hint` | Add `argument-hint: ""` |
+| `commands/soleur/one-shot.md` | Missing `argument-hint` | Add `argument-hint: "[feature description or issue reference]"` |
+| Skills with backtick refs | Backtick paths instead of markdown links | Convert to `[filename](./references/filename)` format |
+
+### Pre-commit Hook Update
+
+Add to `lefthook.yml` after existing `bun-test` (priority 5):
+
+```yaml
+plugin-component-test:
+  priority: 6
+  glob: "plugins/soleur/**/*.md"
+  run: bun test plugins/soleur/test/
+```
+
+Runs only when `.md` files under `plugins/soleur/` are staged. Sequential execution (existing `parallel: false` setting).
+
+## Acceptance Criteria
+
+- [ ] Test suite covers all plugin component types (agents, commands, skills)
+- [ ] Tests run via `bun test plugins/soleur/test/`
+- [ ] Pre-commit hook catches regressions when `.md` files under `plugins/soleur/` change
+- [ ] All 65 existing components pass all tests
+- [ ] Known violations fixed
+- [ ] Test execution under 2 seconds
+
+## Test Scenarios
+
+- Given a new agent file without a `model` field, when `bun test` runs, then the test fails with `agents/path/file.md > has valid model field`
+- Given a skill description starting with "Use when", when `bun test` runs, then the test fails identifying the third-person voice violation with file path
+- Given a skill with `` `references/guide.md` `` in content, when `bun test` runs, then the backtick detection test fails with file path and matched pattern
+- Given all components are valid, when `bun test` runs, then all tests pass in under 2 seconds
+- Given a `.md` file under `plugins/soleur/` is staged, when committing, then lefthook triggers the plugin-component-test hook
+- Given a malformed YAML frontmatter, when `bun test` runs, then the test fails with a clear parse error and file path
+
+## Non-Goals
+
+- Validating semantic content of prompts/instructions
+- Testing that agents/skills work when invoked by Claude
+- CI/CD pipeline integration (future work)
+- Auto-fix capability for violations
+- Reference link file existence checks (fails gracefully at runtime)
+- Heading hierarchy validation (cosmetic, not functional)
+
+## Dependencies & Risks
+
+- **Violation fixes:** Changing skill descriptions changes the text Claude Code users see. Keep changes minimal and semantically equivalent.
+- **False positives:** Third-person voice check ("This skill") is strict. If any skill legitimately needs a different pattern, add an explicit exception list in the test helpers.
+- **Bun glob API:** Uses `Bun.Glob` for file discovery. Verify it handles the recursive agent directory structure correctly.
+
+## Implementation Phases
+
+### Phase 1: Test Infrastructure
+1. Create `plugins/soleur/test/helpers.ts` -- file discovery (3 glob functions) + YAML frontmatter parser
+2. Create `plugins/soleur/test/components.test.ts` -- all validation tests with granular describe/test blocks
+3. Verify `bun test plugins/soleur/test/` discovers and runs tests
+
+### Phase 2: Fix Violations
+4. Fix skill descriptions (agent-browser, rclone, and any others discovered by tests)
+5. Fix command frontmatter (help, one-shot argument-hint)
+6. Fix backtick references in skills (dspy-ruby, compound-docs, skill-creator, others)
+7. Run full test suite -- all 65 components must pass
+
+### Phase 3: Hook Integration & Ship
+8. Update `lefthook.yml` with plugin-component-test hook
+9. Version bump (MINOR -- new test infrastructure)
+10. Update plugin README with test section
+11. Commit, push, PR referencing #62
+
+## References
+
+- Issue: #62
+- Technical debt: `knowledge-base/learnings/technical-debt/2026-02-12-plugin-components-untested.md`
+- Pre-commit gap: `knowledge-base/learnings/technical-debt/2026-02-12-precommit-hooks-missing-test-execution.md`
+- Backtick violations: `knowledge-base/learnings/technical-debt/2026-02-12-backtick-references-in-skills.md`
+- Plugin loader recursion: `knowledge-base/learnings/2026-02-12-plugin-loader-agent-vs-skill-recursion.md`
+- Constitution testing section: `knowledge-base/overview/constitution.md:76-96`
+- Existing test patterns: `apps/telegram-bridge/test/helpers.test.ts`
+- Bun test runner: `https://bun.sh/docs/test`

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,3 +24,7 @@ pre-commit:
       priority: 5
       glob: "*.{ts,tsx,js,jsx}"
       run: bun test
+    plugin-component-test:
+      priority: 6
+      glob: "plugins/soleur/**/*.md"
+      run: bun test plugins/soleur/test/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {},
+  "devDependencies": {
+    "yaml": "^2.8.2"
+  }
+}

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "AI-powered development tools for Claude Code that get smarter with every use. 22 agents, 8 commands, and 34 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-02-12
+
+### Added
+
+- Automated test suite for plugin markdown components (`plugins/soleur/test/`)
+  - `helpers.ts`: Component discovery (agents, commands, skills) and YAML frontmatter parsing using `yaml` library
+  - `components.test.ts`: 443 tests validating frontmatter fields, naming conventions, description voice, and reference links
+- Lefthook pre-commit hook (`plugin-component-test`, priority 6) runs tests on `plugins/soleur/**/*.md` changes
+- Root `package.json` with `yaml` dev dependency for frontmatter parsing
+
+### Fixed
+
+- `agent-browser` skill description: changed to third-person voice ("This skill should be used when...")
+- `rclone` skill description: changed to third-person voice ("This skill should be used when...")
+- `help` command: added missing `argument-hint` frontmatter field
+- `one-shot` command: added missing `argument-hint` frontmatter field
+- `skill-creator` skill: converted 3 backtick file references to proper markdown links
+
 ## [2.0.1] - 2026-02-12
 
 ### Changed

--- a/plugins/soleur/commands/soleur/help.md
+++ b/plugins/soleur/commands/soleur/help.md
@@ -1,6 +1,7 @@
 ---
 name: soleur:help
 description: "List all available Soleur commands, agents, and skills"
+argument-hint: ""
 ---
 
 # Soleur Help

--- a/plugins/soleur/commands/soleur/one-shot.md
+++ b/plugins/soleur/commands/soleur/one-shot.md
@@ -1,6 +1,7 @@
 ---
 name: soleur:one-shot
 description: Full autonomous engineering workflow from plan to PR with video
+argument-hint: "[feature description or issue reference]"
 ---
 
 Run these slash commands in order. Do not do anything else.

--- a/plugins/soleur/skills/agent-browser/SKILL.md
+++ b/plugins/soleur/skills/agent-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-browser
-description: Browser automation using Vercel's agent-browser CLI. Use when you need to interact with web pages, fill forms, take screenshots, or scrape data. Alternative to Playwright MCP - uses Bash commands with ref-based element selection. Triggers on "browse website", "fill form", "click button", "take screenshot", "scrape page", "web automation".
+description: This skill should be used when automating browser interactions via Vercel's agent-browser CLI. It handles web page navigation, form filling, screenshots, and data scraping using Bash commands with ref-based element selection. Triggers on "browse website", "fill form", "click button", "take screenshot", "scrape page", "web automation".
 ---
 
 # agent-browser: CLI Browser Automation

--- a/plugins/soleur/skills/rclone/SKILL.md
+++ b/plugins/soleur/skills/rclone/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rclone
-description: Upload, sync, and manage files across cloud storage providers using rclone. Use when uploading files (images, videos, documents) to S3, Cloudflare R2, Backblaze B2, Google Drive, Dropbox, or any S3-compatible storage. Triggers on "upload to S3", "sync to cloud", "rclone", "backup files", "upload video/image to bucket", or requests to transfer files to remote storage.
+description: This skill should be used when uploading, syncing, or managing files across cloud storage providers using rclone. It handles transfers to S3, Cloudflare R2, Backblaze B2, Google Drive, Dropbox, or any S3-compatible storage. Triggers on "upload to S3", "sync to cloud", "rclone", "backup files", "upload video/image to bucket", or requests to transfer files to remote storage.
 ---
 
 # rclone File Transfer Skill

--- a/plugins/soleur/skills/skill-creator/SKILL.md
+++ b/plugins/soleur/skills/skill-creator/SKILL.md
@@ -115,17 +115,17 @@ To turn concrete examples into an effective skill, analyze each example by:
 Example: When building a `pdf-editor` skill to handle queries like "Help me rotate this PDF," the analysis shows:
 
 1. Rotating a PDF requires re-writing the same code each time
-2. A `scripts/rotate_pdf.py` script would be helpful to store in the skill
+2. A [scripts/rotate_pdf.py](./scripts/rotate_pdf.py) script would be helpful to store in the skill
 
 Example: When designing a `frontend-webapp-builder` skill for queries like "Build me a todo app" or "Build me a dashboard to track my steps," the analysis shows:
 
 1. Writing a frontend webapp requires the same boilerplate HTML/React each time
-2. An `assets/hello-world/` template containing the boilerplate HTML/React project files would be helpful to store in the skill
+2. An [assets/hello-world/](./assets/hello-world/) template containing the boilerplate HTML/React project files would be helpful to store in the skill
 
 Example: When building a `big-query` skill to handle queries like "How many users have logged in today?" the analysis shows:
 
 1. Querying BigQuery requires re-discovering the table schemas and relationships each time
-2. A `references/schema.md` file documenting the table schemas would be helpful to store in the skill
+2. A [references/schema.md](./references/schema.md) file documenting the table schemas would be helpful to store in the skill
 
 To establish the skill's contents, analyze each concrete example to create a list of the reusable resources to include: scripts, references, and assets.
 

--- a/plugins/soleur/test/components.test.ts
+++ b/plugins/soleur/test/components.test.ts
@@ -1,0 +1,196 @@
+import { describe, test, expect } from "bun:test";
+import {
+  discoverAgents,
+  discoverCommands,
+  discoverSkills,
+  parseComponent,
+  getComponentName,
+} from "./helpers";
+
+const VALID_MODELS = ["inherit", "haiku", "sonnet", "opus"];
+const KEBAB_CASE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+// ---------------------------------------------------------------------------
+// Agent Frontmatter
+// ---------------------------------------------------------------------------
+
+describe("Agent frontmatter", () => {
+  const agents = discoverAgents();
+
+  test("discovers agents", () => {
+    expect(agents.length).toBeGreaterThan(0);
+  });
+
+  for (const agentPath of agents) {
+    describe(agentPath, () => {
+      const { frontmatter, body } = parseComponent(agentPath);
+
+      test("has frontmatter", () => {
+        expect(Object.keys(frontmatter).length).toBeGreaterThan(0);
+      });
+
+      test("has name field", () => {
+        expect(frontmatter.name).toBeDefined();
+        expect(String(frontmatter.name).length).toBeGreaterThan(0);
+      });
+
+      test("has description field", () => {
+        expect(frontmatter.description).toBeDefined();
+        expect(String(frontmatter.description).length).toBeGreaterThan(0);
+      });
+
+      test("has valid model field", () => {
+        expect(frontmatter.model).toBeDefined();
+        expect(VALID_MODELS).toContain(frontmatter.model);
+      });
+
+      test("description contains <example> block", () => {
+        const desc = String(frontmatter.description);
+        expect(desc).toContain("<example>");
+      });
+
+      test("has non-empty body", () => {
+        expect(body.trim().length).toBeGreaterThan(0);
+      });
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Command Frontmatter
+// ---------------------------------------------------------------------------
+
+describe("Command frontmatter", () => {
+  const commands = discoverCommands();
+
+  test("discovers commands", () => {
+    expect(commands.length).toBeGreaterThan(0);
+  });
+
+  for (const cmdPath of commands) {
+    describe(cmdPath, () => {
+      const { frontmatter, body } = parseComponent(cmdPath);
+
+      test("has frontmatter", () => {
+        expect(Object.keys(frontmatter).length).toBeGreaterThan(0);
+      });
+
+      test("has name field", () => {
+        expect(frontmatter.name).toBeDefined();
+        expect(String(frontmatter.name).length).toBeGreaterThan(0);
+      });
+
+      test("has description field", () => {
+        expect(frontmatter.description).toBeDefined();
+        expect(String(frontmatter.description).length).toBeGreaterThan(0);
+      });
+
+      test("has argument-hint field", () => {
+        expect("argument-hint" in frontmatter).toBe(true);
+      });
+
+      test("has non-empty body", () => {
+        expect(body.trim().length).toBeGreaterThan(0);
+      });
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Skill Frontmatter
+// ---------------------------------------------------------------------------
+
+describe("Skill frontmatter", () => {
+  const skills = discoverSkills();
+
+  test("discovers skills", () => {
+    expect(skills.length).toBeGreaterThan(0);
+  });
+
+  for (const skillPath of skills) {
+    describe(skillPath, () => {
+      const { frontmatter, body } = parseComponent(skillPath);
+
+      test("has frontmatter", () => {
+        expect(Object.keys(frontmatter).length).toBeGreaterThan(0);
+      });
+
+      test("has name field", () => {
+        expect(frontmatter.name).toBeDefined();
+        expect(String(frontmatter.name).length).toBeGreaterThan(0);
+      });
+
+      test("has description field", () => {
+        expect(frontmatter.description).toBeDefined();
+        expect(String(frontmatter.description).length).toBeGreaterThan(0);
+      });
+
+      test("has non-empty body", () => {
+        expect(body.trim().length).toBeGreaterThan(0);
+      });
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Convention: Third-person voice in skill descriptions
+// ---------------------------------------------------------------------------
+
+describe("Skill description voice", () => {
+  const skills = discoverSkills();
+
+  for (const skillPath of skills) {
+    test(`${skillPath} starts with "This skill"`, () => {
+      const { frontmatter } = parseComponent(skillPath);
+      const desc = String(frontmatter.description || "");
+      expect(desc.startsWith("This skill")).toBe(true);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Convention: Kebab-case filenames
+// ---------------------------------------------------------------------------
+
+describe("Kebab-case filenames", () => {
+  const agents = discoverAgents();
+  const commands = discoverCommands();
+  const skills = discoverSkills();
+
+  for (const agentPath of agents) {
+    const name = getComponentName(agentPath, "agent");
+    test(`agent ${name} is kebab-case`, () => {
+      expect(name).toMatch(KEBAB_CASE);
+    });
+  }
+
+  for (const cmdPath of commands) {
+    const name = getComponentName(cmdPath, "command");
+    test(`command ${name} is kebab-case`, () => {
+      expect(name).toMatch(KEBAB_CASE);
+    });
+  }
+
+  for (const skillPath of skills) {
+    const name = getComponentName(skillPath, "skill");
+    test(`skill ${name} is kebab-case`, () => {
+      expect(name).toMatch(KEBAB_CASE);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Convention: No backtick references to references/, assets/, scripts/
+// ---------------------------------------------------------------------------
+
+describe("No backtick file references in skills", () => {
+  const skills = discoverSkills();
+
+  for (const skillPath of skills) {
+    test(`${skillPath} uses markdown links, not backticks`, () => {
+      const { body } = parseComponent(skillPath);
+      const backtickRefs = body.match(/`(?:references|assets|scripts)\/[^`]+`/g);
+      expect(backtickRefs).toBeNull();
+    });
+  }
+});

--- a/plugins/soleur/test/helpers.ts
+++ b/plugins/soleur/test/helpers.ts
@@ -1,0 +1,53 @@
+import { Glob } from "bun";
+import { parse as parseYaml } from "yaml";
+import { resolve, basename, dirname } from "path";
+import { readFileSync } from "fs";
+
+const PLUGIN_ROOT = resolve(import.meta.dir, "..");
+
+// Agents recurse into subdirectories (loader behavior)
+export function discoverAgents(): string[] {
+  return Array.from(new Glob("agents/**/*.md").scanSync(PLUGIN_ROOT)).filter(
+    (f) => !basename(f).startsWith("README"),
+  );
+}
+
+// Commands are flat under commands/soleur/
+export function discoverCommands(): string[] {
+  return Array.from(new Glob("commands/soleur/*.md").scanSync(PLUGIN_ROOT));
+}
+
+// Skills are one level only (loader does NOT recurse)
+export function discoverSkills(): string[] {
+  return Array.from(new Glob("skills/*/SKILL.md").scanSync(PLUGIN_ROOT));
+}
+
+interface ParsedComponent {
+  frontmatter: Record<string, unknown>;
+  body: string;
+}
+
+export function parseComponent(relativePath: string): ParsedComponent {
+  const raw = readFileSync(resolve(PLUGIN_ROOT, relativePath), "utf-8");
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+
+  if (!match) {
+    return { frontmatter: {}, body: raw };
+  }
+
+  return {
+    frontmatter: parseYaml(match[1]) ?? {},
+    body: match[2],
+  };
+}
+
+// kebab-case name: agents/commands use basename, skills use directory name
+export function getComponentName(
+  relativePath: string,
+  type: "agent" | "command" | "skill",
+): string {
+  if (type === "skill") return basename(dirname(relativePath));
+  return basename(relativePath, ".md");
+}
+
+export { PLUGIN_ROOT };


### PR DESCRIPTION
## Summary

Closes #62

- **443 automated tests** validate all 22 agents, 8 commands, and 34 skills for YAML frontmatter correctness, naming conventions, description voice, and reference link format
- **Test infrastructure**: `helpers.ts` (component discovery via Bun Glob + YAML parsing via `yaml` library) and `components.test.ts` (per-file describe blocks with per-field assertions)
- **Lefthook pre-commit hook** (priority 6) runs plugin tests when `plugins/soleur/**/*.md` files change
- **5 convention violations fixed** that were caught by the new tests:
  - `agent-browser` and `rclone` skill descriptions rewritten to third-person voice
  - `help` and `one-shot` commands: added missing `argument-hint` frontmatter
  - `skill-creator`: converted backtick file references to proper markdown links

## Test plan

- [x] `bun test` passes (527 tests, 0 failures)
- [x] Plugin component tests: 443 pass across 6 describe sections
- [x] Telegram-bridge tests unaffected: 84 pass
- [x] Lefthook hook triggers on markdown changes in plugins/soleur/

🤖 Generated with [Claude Code](https://claude.com/claude-code)