### PR TITLE
feat(ci): move Discord release notification to GitHub Actions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.2.1"
+      placeholder: "2.2.2"
     validations:
       required: true
   - type: input

--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -1,0 +1,40 @@
+name: Release Announce
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  discord:
+    runs-on: ubuntu-latest
+    if: vars.DISCORD_WEBHOOK_URL != ''
+
+    steps:
+      - name: Post to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ vars.DISCORD_WEBHOOK_URL }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+        run: |
+          # Truncate body to 1900 chars for Discord's 2000 char limit
+          if [ ${#RELEASE_BODY} -gt 1900 ]; then
+            RELEASE_BODY="${RELEASE_BODY:0:1897}..."
+          fi
+
+          MESSAGE=$(printf '**Soleur %s released!**\n\n%s\n\nFull release notes: %s' \
+            "$RELEASE_TAG" "$RELEASE_BODY" "$RELEASE_URL")
+
+          # Build JSON payload safely with jq
+          PAYLOAD=$(jq -n --arg content "$MESSAGE" '{content: $content}')
+
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            "$DISCORD_WEBHOOK_URL")
+
+          if [[ "$HTTP_CODE" =~ ^2 ]]; then
+            echo "Discord notification sent (HTTP $HTTP_CODE)"
+          else
+            echo "::warning::Discord notification failed (HTTP $HTTP_CODE)"
+          fi

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.2.1-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.2.2-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "AI-powered development tools for Claude Code that get smarter with every use. 22 agents, 8 commands, and 35 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2026-02-12
+
+### Changed
+
+- Discord notification moved from `release-announce` skill to GitHub Actions workflow
+  - Triggered automatically on `release: published` event
+  - `DISCORD_WEBHOOK_URL` is now a GitHub repository variable, not a local env var
+  - Skill simplified to GitHub Release creation only; CI handles Discord
+- Added `.github/workflows/release-announce.yml` for automated Discord posting
+
 ## [2.2.1] - 2026-02-12
 
 ### Added


### PR DESCRIPTION
## Summary
- Move Discord release notification from local `release-announce` skill to GitHub Actions workflow
- New `.github/workflows/release-announce.yml` triggers on `release: published`
- `DISCORD_WEBHOOK_URL` is now a GitHub repository variable (Settings > Secrets and variables > Actions > Variables), not a local env var
- `release-announce` skill simplified to GitHub Release creation only; CI handles Discord
- Bumps to v2.2.2

## Setup
After merging, add `DISCORD_WEBHOOK_URL` as a repository **variable** (not secret) in GitHub Settings > Secrets and variables > Actions > Variables.

## Test plan
- [ ] Merge PR and create a GitHub Release
- [ ] Verify Discord notification is posted by the workflow
- [ ] Verify workflow skips gracefully when `DISCORD_WEBHOOK_URL` is not set

Generated with [Claude Code](https://claude.com/claude-code)