### PR TITLE
fix(ci): use secret for Discord webhook URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.2.2"
+      placeholder: "2.2.3"
     validations:
       required: true
   - type: input

--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -7,16 +7,20 @@ on:
 jobs:
   discord:
     runs-on: ubuntu-latest
-    if: vars.DISCORD_WEBHOOK_URL != ''
 
     steps:
       - name: Post to Discord
         env:
-          DISCORD_WEBHOOK_URL: ${{ vars.DISCORD_WEBHOOK_URL }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_BODY: ${{ github.event.release.body }}
           RELEASE_URL: ${{ github.event.release.html_url }}
         run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "DISCORD_WEBHOOK_URL secret not set, skipping Discord notification"
+            exit 0
+          fi
+
           # Truncate body to 1900 chars for Discord's 2000 char limit
           if [ ${#RELEASE_BODY} -gt 1900 ]; then
             RELEASE_BODY="${RELEASE_BODY:0:1897}..."

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.2.2-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.2.3-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "AI-powered development tools for Claude Code that get smarter with every use. 22 agents, 8 commands, and 35 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.3] - 2026-02-12
+
+### Fixed
+
+- `release-announce` workflow: `DISCORD_WEBHOOK_URL` changed from repository variable to secret
+  - Secrets cannot be checked in job-level `if` conditions, so the check moves inside the step
+  - Workflow now always runs and shows "success" instead of "skipped" when secret is absent
+
 ## [2.2.2] - 2026-02-12
 
 ### Changed

--- a/plugins/soleur/skills/release-announce/SKILL.md
+++ b/plugins/soleur/skills/release-announce/SKILL.md
@@ -43,4 +43,4 @@ description: This skill should be used when announcing a new plugin release. It 
 
 5. Report results:
    - Print the GitHub Release URL if created
-   - Note that Discord notification will be posted automatically by CI
+   - Note that Discord notification will be posted automatically by CI (requires `DISCORD_WEBHOOK_URL` repository secret)


### PR DESCRIPTION
## Summary
- `DISCORD_WEBHOOK_URL` changed from repository **variable** to **secret** (webhook URLs are API keys)
- Job-level `if: vars.DISCORD_WEBHOOK_URL != ''` replaced with in-step empty check (secrets can't be evaluated in `if` conditions)
- Workflow now shows "success" instead of "skipped" when the secret is absent
- Bumps to v2.2.3

## Setup
Add `DISCORD_WEBHOOK_URL` as a repository **secret** in Settings > Secrets and variables > Actions > Secrets.

## Test plan
- [ ] Verify workflow runs and succeeds when secret is not set (graceful skip)
- [ ] Verify workflow posts to Discord when secret is set

Generated with [Claude Code](https://claude.com/claude-code)