### PR TITLE
feat(plugin): add brand-architect agent and discord-content skill

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.2.3"
+      placeholder: "2.3.0"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.2.3-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.3.0-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)
@@ -25,7 +25,7 @@ Currently at phase of being an Orchestration engine for Claude Code -- agents, w
 Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo founders (soloentrepreneurs) to collapse the friction between a startup idea and a $1B outcome
 
 AI-powered company orchestration for Claude Code (and Bring Your Own Model later) that get smarter with every use. 
-Soleur currently provides **22 agents**, **8 commands**, and **35 skills** that compound your company knowledge (currently only engineering so far) over time -- every problem you solve makes the next one easier.
+Soleur currently provides **23 agents**, **8 commands**, and **36 skills** that compound your company knowledge (currently only engineering so far) over time -- every problem you solve makes the next one easier.
 
 ## Installation
 

--- a/knowledge-base/brainstorms/archive/20260212-170256-brand-marketing-brainstorm.md
+++ b/knowledge-base/brainstorms/archive/20260212-170256-brand-marketing-brainstorm.md
@@ -1,0 +1,118 @@
+# Brand Vision, Strategy & Marketing Tools
+
+**Date:** 2026-02-12
+**Status:** Accepted
+**Participants:** Jean, Claude
+
+## Context
+
+Soleur has made significant progress as a product. A Discord Community Server is live, and release announcements are being automated (issue #59). Before ramping up marketing, we need to design the brand vision and strategy -- and build the tools to enforce it consistently.
+
+The README already has strong positioning language ("Company-as-a-Service", "infinite leverage", soloentrepreneurs) but nothing is formalized. No brand guide, no marketing agents, no content creation workflow exists.
+
+## What We're Building
+
+### 1. Brand Architect Agent (`agents/marketing/brand-architect.md`)
+
+An interactive agent that guides users through a brand identity workshop:
+
+- **Mission, vision, values** -- Why Soleur exists, where it's going, what it stands for
+- **Positioning** -- Target audience, competitive differentiation, key messaging
+- **Voice and tone** -- How Soleur sounds across channels (ambitious-inspiring externally, challenge-reasoning internally)
+- **Messaging pillars** -- Core themes that all content should reinforce
+- **Visual direction** -- Color palette suggestions, typography recommendations, logo direction (uses `gemini-imagegen` for explorations)
+
+**Output:** A structured brand guide document at `knowledge-base/overview/brand-guide.md`
+
+### 2. Brand Voice Reviewer Agent (`agents/marketing/brand-voice-reviewer.md`)
+
+Reviews any outbound content against the brand guide before posting. Modeled after `every-style-editor` but for Soleur's brand:
+
+- Checks voice/tone alignment
+- Validates messaging pillar coverage
+- Flags off-brand language
+- Suggests improvements
+
+### 3. Discord Content Skill (`skills/discord-content/`)
+
+Creates and posts Discord community content with two modes:
+
+- **Auto-send** (routine): Release summaries, weekly project updates, milestone celebrations
+- **Approval required** (novel): Community engagement posts, thought pieces, announcements
+
+References the brand guide for consistent voice. Uses `DISCORD_WEBHOOK_URL` env var for posting.
+
+### 4. GitHub Presence Skill (`skills/github-presence/`)
+
+Improves Soleur's public-facing GitHub artifacts:
+
+- Enriches release notes with brand-consistent language
+- Manages repo metadata (description, topics, social preview)
+- Polishes README sections
+- Engages with discussions and issues in brand voice
+
+### 5. Brand Guide Document (`knowledge-base/overview/brand-guide.md`)
+
+The single source of truth for Soleur's brand identity. Generated via the brand-architect agent, referenced by all marketing tools. Structured sections:
+
+- Company identity (mission, vision, values)
+- Positioning and messaging framework
+- Voice and tone guidelines
+- Visual identity direction
+- Content guidelines per channel
+
+## Why This Approach
+
+**Brand-first, tools-second.** The brand guide is a small artifact (one document) but high-leverage -- it prevents content inconsistency without over-engineering a full marketing platform.
+
+**Semi-autonomous model.** Routine content auto-sends (release notes, weekly updates). Novel content pauses for human approval. This builds trust while maximizing leverage.
+
+**Start where users are.** Discord and GitHub are where early adopters already engage. Twitter/X deferred to v2 to avoid OAuth complexity.
+
+**New agent domain.** `agents/marketing/` is a natural extension alongside `engineering/`, `research/`, `workflow/`. The brand architect and voice reviewer are genuinely different capabilities from anything in the existing domains.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Brand voice | Ambitious-inspiring | Like Vercel's marketing. Bold, forward-looking, energizing. Contrasts with internal dev culture (challenge-reasoning, no flattery). |
+| First channels | Discord + GitHub | Existing infrastructure, where early adopters are. Lowest friction to first post. |
+| V2 channel | Twitter/X | High reach for dev tools but requires OAuth setup. Deferred. |
+| Autonomy model | Semi-autonomous | Routine auto-sends, novel requires approval. Builds trust during brand-establishment phase. |
+| Agent architecture | New `marketing/` domain | Clean separation. Agents: brand-architect, brand-voice-reviewer. Skills stay flat per convention. |
+| Brand guide location | `knowledge-base/overview/brand-guide.md` | Accessible to all agents. Next to constitution and other foundational docs. |
+| Visual identity | Included (simple) | Color palette, typography, logo direction via gemini-imagegen. Iterate as company evolves. |
+
+## Open Questions
+
+1. **Content cadence** -- How often should Discord community posts go out? Weekly? After every release? Need to establish a rhythm without being noisy.
+2. **Release-announce integration** -- Issue #59 already plans Discord release announcements. How does `discord-content` relate? Should release-announce become a sub-workflow of discord-content, or stay separate?
+3. **Brand guide evolution** -- How do we handle brand guide updates as the company matures? Version the document? Track changes?
+4. **Multi-channel adapter** -- Issue #43 proposed messaging platform adapters. Does this influence the discord-content skill design, or is that premature?
+
+## Existing Assets to Leverage
+
+- `every-style-editor` -- Pattern for brand voice reviewer (editorial review against a reference document)
+- `gemini-imagegen` -- Visual exploration for brand identity
+- `feature-video` -- Demo/marketing video creation
+- `changelog` -- Audience-aware tone guidance, Discord webhook pattern
+- README positioning language -- Starting point for brand messaging
+
+## Phasing
+
+**Phase 1 (This feature):**
+- Brand architect agent
+- Brand voice reviewer agent
+- Brand guide document (generated via workshop)
+- Discord content skill
+- GitHub presence skill
+
+**Phase 2 (Future):**
+- Twitter/X content skill
+- Content calendar/scheduling
+- Analytics and engagement tracking
+
+**Phase 3 (Future):**
+- Full marketing campaign orchestration
+- Multi-channel content strategy agent
+- A/B testing for messaging

--- a/knowledge-base/learnings/2026-02-06-parallel-plan-review-catches-overengineering.md
+++ b/knowledge-base/learnings/2026-02-06-parallel-plan-review-catches-overengineering.md
@@ -63,11 +63,29 @@ DHH's verdict: "You have 2 agents out of 10 that are Rails-specific. The plan pr
 
 The fix: move 2 agents into the existing conditional section of review.md, using the same pattern already established for migration and test agents.
 
+## Third Case: Brand Marketing Tools (#71) [Updated 2026-02-12]
+
+Same pattern, third confirmation. Plan for brand vision and marketing tools:
+
+| Aspect | Original | After Review |
+|--------|----------|--------------|
+| Phases | 5 | 2 |
+| New agents | 2 (brand-architect + brand-voice-reviewer) | 1 (brand-architect) |
+| New skills | 2 (discord-content + github-presence) | 1 (discord-content) |
+| Total components | 4 | 2 |
+
+All three reviewers converged again:
+- **DHH**: "brand-voice-reviewer is premature -- inline it. github-presence conflates two unrelated things."
+- **Kieran**: "Brand guide parsing contract underspecified. Skill-to-agent invocation unresolved."
+- **Simplicity**: "Cut reviewer (inline instead), defer github-presence, slim brand guide to 3 sections. ~50% scope reduction."
+
+Key cut: brand voice validation moved from a separate agent to an inline step within the discord-content skill. Simpler, no cross-component invocation needed.
+
 ## Key Insight
 
 **Parallel specialized reviews are force multipliers.** A single reviewer sees some issues. Three reviewers with different perspectives (architecture, technical accuracy, simplicity) catch nearly everything. Same wall-clock time, dramatically better outcome.
 
-This pattern has now been confirmed across 2 features (#12, #46). Both times the plan shrunk by 70-90% after review.
+This pattern has now been confirmed across 3 features (#12, #46, #71). Every time the plan shrunk by 50-90% after review.
 
 ## Prevention
 

--- a/knowledge-base/learnings/2026-02-12-brand-guide-contract-and-inline-validation.md
+++ b/knowledge-base/learnings/2026-02-12-brand-guide-contract-and-inline-validation.md
@@ -1,0 +1,50 @@
+---
+module: soleur
+date: 2026-02-12
+problem_type: architecture
+component: marketing
+tags: [brand-guide, contract, inline-validation, agent-design]
+severity: medium
+---
+
+# Brand Guide Contract and Inline Validation Pattern
+
+## Problem
+
+Building downstream tools (discord-content skill) that depend on a structured document (brand-guide.md) produced by an upstream tool (brand-architect agent). How do you ensure the document structure is stable enough for parsing without over-engineering a schema system?
+
+## Solution
+
+### 1. Brand Guide Contract
+
+Define exact `##` heading names in a contract table within the producing agent:
+
+| Heading | Required | Purpose |
+|---------|----------|---------|
+| `## Identity` | Yes | Mission, values, positioning |
+| `## Voice` | Yes | Tone, do's/don'ts |
+| `## Visual Direction` | No | Colors, typography, imagery |
+| `## Channel Notes` | Yes | Platform-specific guidance |
+
+Downstream tools grep for these exact headings. The contract is documented in the agent that produces the document, so changes propagate through plan review.
+
+### 2. Inline Validation Over Separate Agent
+
+Three reviewers independently recommended against building a separate `brand-voice-reviewer` agent. The alternative: inline brand voice validation as a step within each content skill.
+
+The discord-content skill reads `## Voice` and `## Channel Notes > ### Discord`, then validates its own draft against the do's/don'ts before presenting to the user. No cross-component invocation needed.
+
+**Why this is better:**
+- No skill-to-agent invocation complexity (skills can't directly call agents)
+- Faster feedback loop (validation happens in the same context)
+- Simpler dependency graph (skill only needs to read a file, not coordinate with another component)
+
+## Key Insight
+
+**Contracts beat schemas for human-produced documents.** A contract (table of exact headings with required/optional) is lightweight enough that an agent can follow it during generation, and downstream tools can parse it with simple grep. No YAML parsing, no JSON schema, no validation library.
+
+**Inline validation beats separate reviewers for single-document checks.** If the validation context fits in one file (brand guide), inline it. Separate agents are for cross-cutting concerns that span multiple files or require specialized knowledge.
+
+## Related
+
+- [parallel-plan-review-catches-overengineering.md](./2026-02-06-parallel-plan-review-catches-overengineering.md) - Third case: brand marketing scope reduction

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -74,6 +74,7 @@ Project principles organized by domain. Add principles as you learn them.
 - Before planning large directory restructures, run a Phase 0 loader test -- move one component, reload, verify it is still discoverable. Different component types have different recursion behavior (agents recurse, skills do not)
 - Extend `/ship` with conditional skill invocations rather than inlining domain logic -- ship should remain a thin orchestration layer
 - Mechanical notifications (webhooks, emails) belong in CI workflows; keep local skills for AI-powered work that needs Claude -- secrets live in GitHub Actions, not local env vars
+- When one agent/skill produces a structured document consumed by others, define a heading-level contract (exact `##` names, required/optional flags) in the producer -- consumers parse by heading name, not by position
 
 ## Testing
 

--- a/knowledge-base/plans/archive/20260212-170256-feat-brand-marketing-tools-plan.md
+++ b/knowledge-base/plans/archive/20260212-170256-feat-brand-marketing-tools-plan.md
@@ -1,0 +1,298 @@
+---
+title: "feat: Brand vision, strategy & marketing tools"
+type: feat
+date: 2026-02-12
+issue: "#71"
+updated: 2026-02-12
+---
+
+# Brand Vision, Strategy & Marketing Tools
+
+[Updated 2026-02-12] Revised after plan review -- scope reduced ~50% per DHH, Kieran, and Simplicity reviewer feedback. Cut brand-voice-reviewer agent (inline instead) and github-presence skill (deferred to v2). Kept visual direction per user request.
+
+## Overview
+
+Build the brand identity foundation and first marketing content tool for Soleur. This establishes a new `agents/marketing/` domain with one agent (brand-architect) and one skill (discord-content), anchored by a structured brand guide document.
+
+## Problem Statement
+
+Soleur has no formalized brand identity, voice guidelines, or marketing content infrastructure. The README contains strong but informal positioning language ("Company-as-a-Service", "infinite leverage", soloentrepreneurs). A Discord Community Server exists but has no content creation workflow. Before ramping marketing, the brand needs to be codified and tools need to enforce it consistently.
+
+## Proposed Solution
+
+### Architecture
+
+```
+plugins/soleur/
+  agents/
+    marketing/                          # New domain
+      brand-architect.md                # Interactive brand identity workshop
+  skills/
+    discord-content/
+      SKILL.md                          # Discord community content creation + posting
+
+knowledge-base/
+  overview/
+    brand-guide.md                      # Single source of truth (output of brand-architect)
+```
+
+### Key Design Decisions
+
+**1. Bootstrap dependency.** discord-content checks for `brand-guide.md` existence at invocation. If missing, it warns and exits: "No brand guide found. Run the brand architect agent first." This makes the dependency explicit.
+
+**2. Discord overlap with changelog and release-announce (#59).** discord-content is self-contained for v1. It does not subsume the changelog skill or release-announce (#59). Each has a distinct concern:
+- `changelog` = generates formatted changelog from git history (content generation)
+- `release-announce` (#59) = posts release announcements to Discord/GitHub (distribution, not yet built)
+- `discord-content` = creates community content beyond releases (engagement, updates, tips)
+
+**3. Brand voice review is inline, not a separate agent.** [Changed from original plan] Per reviewer feedback, a standalone brand-voice-reviewer agent is premature -- there is no content corpus to review yet. Instead, discord-content includes an inline "Brand Voice Check" section that validates drafts against the brand guide's Voice section before presenting to the user. If a standalone reviewer is needed later, it can be extracted when there are multiple consumers.
+
+**4. Brand guide format: structured markdown with a parsing contract.** The brand guide uses consistent `##` headings that downstream tools depend on. See "Brand Guide Contract" section below for the exact specification.
+
+**5. Content cadence: all user-initiated.** Claude Code plugins have no scheduling mechanism. All content generation is triggered by the user running the skill with a topic description.
+
+**6. All content requires user approval in v1.** [Changed from brainstorm's semi-autonomous proposal] Deferred auto-send until trust is established with the brand voice. Simpler and safer.
+
+**7. github-presence deferred to v2.** [Changed from original plan] Per reviewer feedback, release notes enrichment overlaps with future release-announce (#59), and repo metadata is a one-time `gh repo edit` command. Defer until there is demonstrated need.
+
+**8. Visual assets stored ephemerally.** Brand visual explorations generated during the workshop are saved to a user-specified directory and shown inline. They are NOT committed to git. The brand guide references visual direction in prose (color hex codes, font names, style descriptions). Users can save generated assets separately for Discord/GitHub branding use.
+
+**9. Model selection: `model: inherit`.** The user's session model determines quality/cost.
+
+**10. Brand guide written atomically.** The brand architect collects all workshop answers, then writes the complete brand-guide.md at the end. No partial documents can exist. Git history serves as version control.
+
+### Brand Guide Contract
+
+Downstream tools (discord-content, future skills) depend on these exact heading names:
+
+| Heading | Required | Purpose |
+|---------|----------|---------|
+| `## Identity` | Yes | Mission, audience, positioning context |
+| `## Voice` | Yes | Tone, do's/don'ts, example phrases -- primary reference for content generation |
+| `## Visual Direction` | No | Color palette, typography, style -- used for visual asset generation |
+| `## Channel Notes` | No | Channel-specific tweaks (Discord length, GitHub formality) |
+
+**Rules:**
+- The brand architect MUST use these exact `##` headings (no variations like "Voice and Tone" or "Brand Voice")
+- Downstream tools match headings via exact string: `^## Voice$`, `^## Channel Notes$`, etc.
+- If a required section is missing, downstream tools warn: "Brand guide is incomplete -- missing [section]. Run brand architect to update."
+- If an optional section is missing, downstream tools proceed without it (no warning)
+- `### ` subsections within each `##` section are freeform -- no parsing contract on subsections
+
+## Implementation Phases
+
+### Phase 1: Brand Architect Agent + Brand Guide
+
+Create the interactive agent that runs brand identity workshops and outputs a structured brand guide.
+
+**Files to create:**
+
+- `plugins/soleur/agents/marketing/brand-architect.md`
+
+**Draft YAML frontmatter:**
+
+```yaml
+---
+name: brand-architect
+description: "Use this agent when you need to define or refine a brand identity. It guides an interactive workshop covering company identity, positioning, voice and tone, visual direction, and channel-specific guidelines. Outputs a structured brand guide document to knowledge-base/overview/brand-guide.md. <example>Context: The user wants to establish brand identity for their project.\\nuser: \"We need to define our brand voice and visual identity before launching marketing.\"\\nassistant: \"I'll use the brand-architect agent to guide a brand identity workshop and produce a brand guide.\"\\n<commentary>\\nThe user needs a structured brand identity definition, which is the core purpose of the brand-architect agent.\\n</commentary>\\n</example>\\n\\n<example>Context: The user wants to update their existing brand guide.\\nuser: \"Our positioning has evolved. I want to update the brand guide.\"\\nassistant: \"I'll launch the brand-architect agent to review and update the existing brand guide section by section.\"\\n<commentary>\\nThe brand architect detects existing brand guides and offers section-by-section updates rather than starting from scratch.\\n</commentary>\\n</example>"
+model: inherit
+---
+```
+
+**Agent behavior:**
+
+1. Check if `knowledge-base/overview/brand-guide.md` exists
+2. **If exists:** Read it, present a summary, and ask which section to update. Present the current content of the selected section, then ask the user for changes. Repeat until the user is done. Write the full document atomically.
+3. **If not exists:** Run full interactive workshop using AskUserQuestion, one section at a time:
+   - **Identity:** Mission, vision, values, target audience, competitive positioning
+   - **Voice:** Brand voice description, tone spectrum, do's and don'ts with concrete examples, example phrases for common scenarios
+   - **Visual Direction:** Color palette (hex codes), typography (font names), style description. Optionally invoke `gemini-imagegen` for explorations if `GEMINI_API_KEY` is set. If not set, skip image generation and collect text descriptions only.
+   - **Channel Notes:** Discord-specific tone/length guidance, GitHub-specific formality level
+4. Write complete brand guide atomically to `knowledge-base/overview/brand-guide.md`
+
+**Brand guide document structure:**
+
+```markdown
+---
+last_updated: YYYY-MM-DD
+---
+
+# Soleur Brand Guide
+
+## Identity
+
+### Mission
+[Why Soleur exists]
+
+### Target Audience
+[Who Soleur serves]
+
+### Positioning
+[Competitive differentiation and key messaging]
+
+## Voice
+
+### Brand Voice
+[Core voice description -- e.g., "Ambitious-inspiring: bold, forward-looking, energizing"]
+
+### Tone Spectrum
+[How tone varies by context -- e.g., "Discord: casual-enthusiastic, GitHub: professional-precise"]
+
+### Do's and Don'ts
+
+**Do:**
+- [Example of on-brand language]
+
+**Don't:**
+- [Example of off-brand language]
+
+### Example Phrases
+[Concrete examples for common scenarios -- announcements, replies, descriptions]
+
+## Visual Direction
+
+### Color Palette
+[Primary and secondary colors with hex codes]
+
+### Typography
+[Font families and usage guidelines]
+
+### Style
+[Overall visual style description -- e.g., "Clean, modern, developer-focused"]
+
+## Channel Notes
+
+### Discord
+[Discord-specific guidelines -- tone, length limits, emoji usage]
+
+### GitHub
+[GitHub-specific guidelines -- formality, technical depth]
+```
+
+### Phase 2: Discord Content Skill
+
+Create the skill for generating and posting Discord community content.
+
+**Files to create:**
+
+- `plugins/soleur/skills/discord-content/SKILL.md`
+
+**Draft YAML frontmatter:**
+
+```yaml
+---
+name: discord-content
+description: "This skill should be used when creating and posting community content to Discord. It generates brand-consistent posts (project updates, tips, milestones, or custom topics), validates them against the brand guide, and posts via webhook after user approval. Triggers on \"post to Discord\", \"Discord update\", \"community post\", \"Discord announcement\", \"write Discord content\"."
+---
+```
+
+**Skill behavior:**
+
+1. **Prerequisite check:** Verify `knowledge-base/overview/brand-guide.md` exists (warn and exit if missing). Verify `DISCORD_WEBHOOK_URL` env var is set (warn with setup instructions and exit if missing).
+2. **Topic input:** Ask the user "What would you like to post about?" Accept freeform description. Optionally offer: "Summarize recent git activity?" as a shortcut for project updates.
+3. **Content generation:** Read brand guide's `## Voice` and `## Channel Notes > ### Discord` sections. Generate draft in brand voice. Enforce 2000-char limit during generation.
+4. **Inline brand voice check:** Before presenting to the user, validate the draft against the brand guide's Do's and Don'ts. If issues are found, revise the draft and note what was adjusted.
+5. **User approval:** Present final draft with Accept/Edit/Reject options via AskUserQuestion.
+   - **Accept:** Proceed to post.
+   - **Edit:** User provides feedback, skill regenerates.
+   - **Reject:** Discard draft, exit.
+6. **Post:** On approval, post via `curl` using plain `content` field (not rich embeds):
+   ```bash
+   curl -H "Content-Type: application/json" \
+     -d "{\"content\": \"$CONTENT\"}" \
+     "$DISCORD_WEBHOOK_URL"
+   ```
+   Content must be properly JSON-escaped before posting.
+7. **Error handling:** If webhook returns 4xx/5xx, display the error and the draft content so the user can copy-paste manually. Do not retry.
+
+**Discord webhook payload:** Plain `content` field, consistent with the existing changelog skill pattern. No rich embeds in v1 -- keeps the implementation simple and the content format predictable.
+
+## Acceptance Criteria
+
+- [ ] Given no brand guide exists, when brand architect is invoked, then it runs the full workshop and writes `brand-guide.md` with all four `##` sections (Identity, Voice, Visual Direction, Channel Notes)
+- [ ] Given a brand guide exists, when brand architect is invoked, then it reads the existing guide, presents a summary, and allows section-by-section updates without overwriting untouched sections
+- [ ] Given the user skips visual direction, when the workshop completes, then the Visual Direction section contains a placeholder noting it was skipped
+- [ ] Given `GEMINI_API_KEY` is not set, when visual direction step runs, then image generation is skipped and text descriptions are collected instead (no error)
+- [ ] Given `DISCORD_WEBHOOK_URL` is set and brand guide exists, when discord-content runs, then the generated content is under 2000 characters and posted after user approval
+- [ ] Given `DISCORD_WEBHOOK_URL` is not set, when discord-content is invoked, then it warns with webhook setup instructions and exits
+- [ ] Given brand guide is missing, when discord-content is invoked, then it warns "No brand guide found. Run the brand architect agent first." and exits
+- [ ] Given the webhook returns 429/5xx, when posting, then the error is displayed and the draft content is shown for manual copy-paste
+- [ ] Given the user selects "Reject", when the approval prompt is dismissed, then no content is posted
+- [ ] All new files have correct YAML frontmatter per constitution (agent: name, description with examples, model; skill: name, third-person description)
+- [ ] Plugin version bumped (MINOR intent) with CHANGELOG.md, README.md, and plugin.json updated consistently
+
+## Test Scenarios
+
+### Brand Architect Agent
+
+- Given no brand guide exists, when the brand architect is invoked, then it runs the full interactive workshop and writes brand-guide.md atomically with all four required sections and a `last_updated` frontmatter field.
+- Given a brand guide already exists, when the brand architect is invoked, then it reads the existing guide, presents its contents, and asks which section to update.
+- Given the user updates only the Voice section, when the workshop completes, then Identity, Visual Direction, and Channel Notes are preserved unchanged.
+- Given the user skips visual direction, when the workshop completes, then the Visual Direction section contains placeholder text: "Not yet defined. Run brand architect to add visual direction."
+- Given `GEMINI_API_KEY` is not set, when the visual direction step runs, then the agent collects text descriptions only and does not attempt image generation.
+
+### Discord Content Skill
+
+- Given `DISCORD_WEBHOOK_URL` is set and brand guide exists, when the user describes a topic, then the skill generates a draft under 2000 characters, performs an inline brand voice check, and presents it for approval.
+- Given `DISCORD_WEBHOOK_URL` is not set, when the skill is invoked, then it displays webhook setup instructions and exits.
+- Given brand guide is missing, when the skill is invoked, then it warns about the missing brand guide and exits.
+- Given the Discord webhook returns a 429 rate limit error, when posting, then the draft is displayed for manual copy-paste and the error is shown.
+- Given the user selects "Reject" after reviewing, then no content is posted to Discord.
+- Given the user selects "Edit" after reviewing, then the skill accepts feedback and regenerates the draft.
+
+## Dependencies and Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Brand guide quality depends on user input | High | Medium | Agent provides defaults and examples; guide can be re-run |
+| Discord webhook URL not configured | Medium | Low | Clear setup instructions in error message |
+| Gemini API unavailable for visual direction | Low | Low | Degrades to text-only descriptions |
+
+## Non-Goals
+
+- Brand voice reviewer as a separate agent (inline in skills instead)
+- GitHub presence skill (deferred to v2)
+- Twitter/X integration (v2)
+- Content calendar or scheduling
+- Analytics or engagement tracking
+- Multi-channel campaign orchestration
+- Full visual design system (logo files, icon sets)
+- Blog/long-form content creation
+- Issue/discussion engagement via GitHub (v2)
+- Auto-send without user approval (v2)
+- Rich Discord embeds (plain content field in v1)
+
+## Deferred to v2
+
+| Component | Rationale |
+|-----------|-----------|
+| brand-voice-reviewer agent | Extract from inline when multiple skills need it |
+| github-presence skill | Overlaps with release-announce (#59); repo metadata is a one-time `gh repo edit` |
+| Twitter/X content skill | Requires OAuth setup |
+| Auto-send for routine content | Build trust with brand voice first |
+| Rich Discord embeds | Plain content is sufficient for v1 |
+
+## Version Bump
+
+**Type:** MINOR (new agent + new skill)
+**Intent:** 2.1.1 -> 2.2.0
+
+**Files to update:**
+- `plugins/soleur/.claude-plugin/plugin.json` -- version + description counts (23 agents, 35 skills)
+- `plugins/soleur/CHANGELOG.md` -- v2.2.0 section
+- `plugins/soleur/README.md` -- add marketing agents section, add discord-content to skills table, update counts
+- Root `README.md` -- version badge
+- `.github/ISSUE_TEMPLATE/bug_report.yml` -- version placeholder
+
+## References
+
+- Brainstorm: `knowledge-base/brainstorms/2026-02-12-brand-marketing-brainstorm.md`
+- Spec: `knowledge-base/specs/feat-brand-marketing/spec.md`
+- Issue: [#71](https://github.com/jikig-ai/soleur/issues/71)
+- Related: Issue #59 (release-announce), Issue #43 (multi-platform adapters)
+- Pattern references:
+  - `plugins/soleur/agents/engineering/design/ddd-architect.md` -- agent frontmatter + structure example
+  - `plugins/soleur/skills/every-style-editor/SKILL.md` -- editorial review pattern (for future reviewer extraction)
+  - `plugins/soleur/skills/changelog/SKILL.md` -- Discord webhook + audience-aware tone pattern
+  - `plugins/soleur/skills/gemini-imagegen/SKILL.md` -- image generation reference
+- Plan review feedback: DHH, Kieran, Simplicity reviewers (2026-02-12)

--- a/knowledge-base/specs/archive/20260212-170256-feat-brand-marketing/spec.md
+++ b/knowledge-base/specs/archive/20260212-170256-feat-brand-marketing/spec.md
@@ -1,0 +1,81 @@
+# Spec: Brand Vision, Strategy & Marketing Tools
+
+**Feature:** Brand identity foundation and marketing content tools
+**Branch:** `feat-brand-marketing`
+**Status:** Draft
+
+## Problem Statement
+
+Soleur has no formalized brand identity, voice guidelines, or marketing content infrastructure. The README contains strong but informal positioning language. A Discord Community Server exists but only has planned (not implemented) release announcement automation. There are no tools to create, review, or distribute brand-consistent content across channels.
+
+## Goals
+
+1. Define and codify Soleur's brand identity (positioning, voice, messaging, visual direction)
+2. Build an interactive agent that guides brand identity workshops and produces brand guides
+3. Create a content review agent that enforces brand consistency on outbound content
+4. Build skills for Discord community content creation and GitHub presence improvement
+5. Establish a semi-autonomous content workflow (routine auto-sends, novel requires approval)
+
+## Non-Goals
+
+- Twitter/X integration (v2)
+- Content calendar or scheduling system
+- Analytics or engagement tracking
+- Multi-channel campaign orchestration
+- Full visual design system (logo files, icon sets, etc.)
+- Blog/long-form content creation
+
+## Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR1 | Brand architect agent guides users through interactive brand identity workshop | Must |
+| FR2 | Brand architect outputs structured brand guide to `knowledge-base/overview/brand-guide.md` | Must |
+| FR3 | Brand architect supports visual exploration via `gemini-imagegen` | Should |
+| FR4 | Brand voice reviewer agent checks content against brand guide | Must |
+| FR5 | Brand voice reviewer provides specific improvement suggestions | Must |
+| FR6 | Discord content skill creates community posts (updates, tips, engagement) | Must |
+| FR7 | Discord content skill auto-sends routine content, pauses for novel content approval | Must |
+| FR8 | Discord content skill posts via `DISCORD_WEBHOOK_URL` env var | Must |
+| FR9 | GitHub presence skill enriches release notes with brand-consistent language | Should |
+| FR10 | GitHub presence skill manages repo metadata and README polish | Should |
+
+## Technical Requirements
+
+| ID | Requirement |
+|----|------------|
+| TR1 | New `agents/marketing/` domain directory for marketing agents |
+| TR2 | Brand architect and voice reviewer follow existing agent conventions (YAML frontmatter, examples) |
+| TR3 | Discord and GitHub skills follow flat skill directory convention (`skills/<name>/SKILL.md`) |
+| TR4 | Brand guide document is plain markdown, accessible to all agents |
+| TR5 | Discord posting uses curl + webhook (consistent with changelog skill pattern) |
+| TR6 | Plugin version bump required (new agents + skills = MINOR bump) |
+
+## Architecture
+
+```
+plugins/soleur/
+  agents/
+    marketing/                    # New domain
+      brand-architect.md          # FR1, FR2, FR3
+      brand-voice-reviewer.md     # FR4, FR5
+  skills/
+    discord-content/              # FR6, FR7, FR8
+      SKILL.md
+    github-presence/              # FR9, FR10
+      SKILL.md
+
+knowledge-base/
+  overview/
+    brand-guide.md                # FR2 output artifact
+```
+
+## Acceptance Criteria
+
+- [ ] Running the brand architect agent produces a complete brand guide document
+- [ ] Brand voice reviewer correctly flags off-brand content and suggests improvements
+- [ ] Discord content skill can create and post routine community updates
+- [ ] Discord content skill pauses for approval on novel content
+- [ ] GitHub presence skill can enrich release notes with brand-consistent language
+- [ ] All new components follow existing plugin conventions (frontmatter, naming, directory structure)
+- [ ] Plugin version bumped with changelog and README updated

--- a/knowledge-base/specs/archive/20260212-170256-feat-brand-marketing/tasks.md
+++ b/knowledge-base/specs/archive/20260212-170256-feat-brand-marketing/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: Brand Vision, Strategy & Marketing Tools
+
+**Feature:** feat-brand-marketing
+**Issue:** #71
+**Plan:** `knowledge-base/plans/2026-02-12-feat-brand-marketing-tools-plan.md`
+
+## Phase 1: Brand Architect Agent + Brand Guide
+
+- [x] 1.1 Create `plugins/soleur/agents/marketing/` directory
+- [x] 1.2 Write `brand-architect.md` with YAML frontmatter (name, description with 2 example blocks, model: inherit)
+- [x] 1.3 Implement full workshop flow: Identity, Voice, Visual Direction, Channel Notes -- one section at a time via AskUserQuestion
+- [x] 1.4 Implement visual direction step with gemini-imagegen (graceful skip when GEMINI_API_KEY missing)
+- [x] 1.5 Implement atomic write of brand-guide.md with last_updated frontmatter and all four ## sections per Brand Guide Contract
+- [x] 1.6 Implement update mode: detect existing brand-guide.md, present summary, allow section-by-section editing, preserve untouched sections
+
+## Phase 2: Discord Content Skill
+
+- [x] 2.1 Create `plugins/soleur/skills/discord-content/` directory
+- [x] 2.2 Write `SKILL.md` with YAML frontmatter (name, third-person description with triggers)
+- [x] 2.3 Implement prerequisite checks (brand-guide.md exists, DISCORD_WEBHOOK_URL set -- with setup instructions on failure)
+- [x] 2.4 Implement freeform topic input with optional git activity summary shortcut
+- [x] 2.5 Implement content generation referencing brand guide ## Voice and ## Channel Notes > ### Discord sections
+- [x] 2.6 Implement inline brand voice check (validate against Do's/Don'ts before presenting)
+- [x] 2.7 Implement 2000-char limit enforcement
+- [x] 2.8 Implement user approval flow (Accept/Edit/Reject via AskUserQuestion)
+- [x] 2.9 Implement Discord webhook posting via curl with JSON-escaped plain content field
+- [x] 2.10 Implement error handling (display error + draft for manual copy-paste on webhook failure)
+
+## Phase 3: Plugin Versioning and Documentation
+
+- [x] 3.1 Bump version in `plugins/soleur/.claude-plugin/plugin.json` (MINOR: 2.1.1 -> 2.2.0)
+- [x] 3.2 Update description counts in plugin.json (23 agents, 35 skills)
+- [x] 3.3 Update `plugins/soleur/CHANGELOG.md` with v2.2.0 section
+- [x] 3.4 Update `plugins/soleur/README.md` -- add marketing agents section, add discord-content to skills table, update counts
+- [x] 3.5 Update root `README.md` version badge
+- [x] 3.6 Update `.github/ISSUE_TEMPLATE/bug_report.yml` version placeholder
+- [ ] 3.7 Run code review on all changes
+- [ ] 3.8 Run `/soleur:compound` to capture learnings

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "soleur",
-  "version": "2.2.3",
-  "description": "AI-powered development tools for Claude Code that get smarter with every use. 22 agents, 8 commands, and 35 skills that compound your engineering knowledge over time.",
+  "version": "2.3.0",
+  "description": "AI-powered development tools for Claude Code that get smarter with every use. 23 agents, 8 commands, and 36 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",
     "email": "jean.deruelle@jikigai.com",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2026-02-12
+
+### Added
+
+- New `agents/marketing/` domain for brand and marketing agents
+- `brand-architect` agent -- interactive brand identity workshop that produces a structured brand guide document at `knowledge-base/overview/brand-guide.md`, covering identity, voice, visual direction, and channel notes
+- `discord-content` skill -- creates and posts brand-consistent community content to Discord via webhook, with inline brand voice validation and user approval before posting
+- Brand Guide Contract defining exact `##` heading names that downstream tools depend on
+
 ## [2.2.3] - 2026-02-12
 
 ### Fixed

--- a/plugins/soleur/README.md
+++ b/plugins/soleur/README.md
@@ -106,14 +106,20 @@ Full autonomous engineering workflow that goes from plan to PR in a single comma
 
 | Component | Count |
 |-----------|-------|
-| Agents | 22 |
+| Agents | 23 |
 | Commands | 8 |
-| Skills | 35 |
+| Skills | 36 |
 | MCP Servers | 1 |
 
 ## Agents
 
 Agents are organized by domain, then by function. Cross-domain agents stay at root level.
+
+### Marketing (1)
+
+| Agent | Description |
+|-------|-------------|
+| `brand-architect` | Interactive brand identity workshop producing structured brand guides |
 
 ### Engineering (15)
 
@@ -238,6 +244,7 @@ All commands use the `soleur:` prefix to avoid collisions with built-in commands
 
 | Skill | Description |
 |-------|-------------|
+| `discord-content` | Create and post brand-consistent community content to Discord |
 | `every-style-editor` | Review copy for Every's style guide compliance |
 | `file-todos` | File-based todo tracking system |
 | `git-worktree` | Manage Git worktrees for parallel development |

--- a/plugins/soleur/agents/marketing/brand-architect.md
+++ b/plugins/soleur/agents/marketing/brand-architect.md
@@ -1,0 +1,179 @@
+---
+name: brand-architect
+description: "Use this agent when you need to define or refine a brand identity. It guides an interactive workshop covering company identity, positioning, voice and tone, visual direction, and channel-specific guidelines. Outputs a structured brand guide document to knowledge-base/overview/brand-guide.md. <example>Context: The user wants to establish brand identity for their project.\\nuser: \"We need to define our brand voice and visual identity before launching marketing.\"\\nassistant: \"I'll use the brand-architect agent to guide a brand identity workshop and produce a brand guide.\"\\n<commentary>\\nThe user needs a structured brand identity definition, which is the core purpose of the brand-architect agent.\\n</commentary>\\n</example>\\n\\n<example>Context: The user wants to update their existing brand guide.\\nuser: \"Our positioning has evolved. I want to update the brand guide.\"\\nassistant: \"I'll launch the brand-architect agent to review and update the existing brand guide section by section.\"\\n<commentary>\\nThe brand architect detects existing brand guides and offers section-by-section updates rather than starting from scratch.\\n</commentary>\\n</example>"
+model: inherit
+---
+
+A brand identity architect that guides interactive workshops to define or refine a project's brand. The workshop covers company identity, voice and tone, visual direction, and channel-specific guidelines, then outputs a structured brand guide document.
+
+## Brand Guide Contract
+
+The output document uses these exact `##` headings. Downstream tools (discord-content, future marketing skills) depend on these names:
+
+| Heading | Required | Purpose |
+|---------|----------|---------|
+| `## Identity` | Yes | Mission, audience, positioning context |
+| `## Voice` | Yes | Tone, do's/don'ts, example phrases |
+| `## Visual Direction` | No | Color palette, typography, style |
+| `## Channel Notes` | No | Channel-specific tweaks |
+
+NEVER use heading variations (e.g., "Voice and Tone" instead of "Voice"). Downstream tools match via exact string.
+
+## Workflow
+
+### Step 0: Detect Existing Brand Guide
+
+Check if `knowledge-base/overview/brand-guide.md` exists.
+
+**If it exists:** Read the document, present a brief summary of each section, and use the **AskUserQuestion tool** to ask: "Which section would you like to update?" with options for each `##` section plus "Full refresh" and "Done."
+
+For the selected section:
+1. Display current content
+2. Ask what should change
+3. Collect the updated content
+4. Repeat for additional sections if requested
+5. Write the full document atomically (preserve all untouched sections exactly as they are)
+
+**If it does not exist:** Proceed to the full workshop (Step 1).
+
+### Step 1: Identity
+
+Use the **AskUserQuestion tool** to explore the company identity, one question at a time:
+
+1. **Mission:** "What problem does this project solve? Who does it serve?"
+2. **Target Audience:** "Who is the primary user? Describe them in one sentence."
+3. **Positioning:** "What makes this project different from alternatives? What is the key value proposition?"
+
+Synthesize responses into the `## Identity` section with subsections: `### Mission`, `### Target Audience`, `### Positioning`.
+
+### Step 2: Voice
+
+Explore brand voice and tone:
+
+1. **Brand Voice:** "If this project were a person, how would they speak? Pick 3-5 adjectives." Offer example sets:
+   - Builder-pragmatic: direct, no-hype, show-don't-tell
+   - Ambitious-inspiring: bold, forward-looking, energizing
+   - Approachable-nerdy: casual, technically deep, community-first
+
+2. **Do's and Don'ts:** "What language should the brand always use? What should it avoid?" Provide concrete examples based on the chosen voice.
+
+3. **Example Phrases:** Generate 5-7 example phrases that demonstrate the brand voice for common scenarios: announcements, community replies, product descriptions, error messages.
+
+Present the examples and ask for approval or refinement.
+
+Synthesize into `## Voice` with subsections: `### Brand Voice`, `### Tone Spectrum`, `### Do's and Don'ts`, `### Example Phrases`.
+
+### Step 3: Visual Direction
+
+Use the **AskUserQuestion tool** to offer the visual direction step:
+
+"Would you like to define visual direction (color palette, typography, style)?"
+
+Options:
+- **Yes, with AI exploration** -- Generate visual concepts using gemini-imagegen (requires GEMINI_API_KEY)
+- **Yes, text only** -- Describe visual direction without generating images
+- **Skip for now** -- Add placeholder text: "Not yet defined. Run brand architect to add visual direction."
+
+**If "Yes, with AI exploration":**
+
+1. Check if `GEMINI_API_KEY` environment variable is set
+2. If not set, inform the user and fall back to text-only mode
+3. If set, ask about style preferences: "Describe the visual feel. Modern? Minimal? Bold? Developer-focused?"
+4. Use the `gemini-imagegen` skill to generate logo concepts, color palette explorations, or style samples based on the brand identity established in Steps 1-2
+5. Present results and ask for feedback
+6. Record final decisions as text in the brand guide (hex codes, font names, style descriptions)
+
+**If "Yes, text only":**
+
+1. Ask about color preferences: "What colors represent the brand? Provide hex codes if known, or describe the palette (e.g., 'dark with electric blue accents')."
+2. Ask about typography: "What font style fits the brand? (e.g., 'clean sans-serif like Inter', 'monospace for developer feel')"
+3. Ask about overall style: "Describe the visual style in one sentence."
+
+Synthesize into `## Visual Direction` with subsections: `### Color Palette`, `### Typography`, `### Style`.
+
+### Step 4: Channel Notes
+
+Ask about channel-specific communication guidelines:
+
+1. **Discord:** "How should the brand sound on Discord? Consider: formality level, emoji usage, message length, engagement style."
+2. **GitHub:** "How should the brand sound on GitHub? Consider: technical depth, formality, response style for issues and PRs."
+
+If additional channels are relevant, ask about them. Otherwise, include Discord and GitHub as the default channels.
+
+Synthesize into `## Channel Notes` with a `###` subsection per channel.
+
+### Step 5: Write Brand Guide
+
+Assemble all sections into the final document and write it atomically to `knowledge-base/overview/brand-guide.md`.
+
+**Document template:**
+
+```markdown
+---
+last_updated: YYYY-MM-DD
+---
+
+# [Project Name] Brand Guide
+
+## Identity
+
+### Mission
+[From Step 1]
+
+### Target Audience
+[From Step 1]
+
+### Positioning
+[From Step 1]
+
+## Voice
+
+### Brand Voice
+[From Step 2]
+
+### Tone Spectrum
+[From Step 2]
+
+### Do's and Don'ts
+
+**Do:**
+- [On-brand examples]
+
+**Don't:**
+- [Off-brand examples]
+
+### Example Phrases
+[From Step 2]
+
+## Visual Direction
+
+### Color Palette
+[From Step 3, or placeholder if skipped]
+
+### Typography
+[From Step 3, or placeholder if skipped]
+
+### Style
+[From Step 3, or placeholder if skipped]
+
+## Channel Notes
+
+### Discord
+[From Step 4]
+
+### GitHub
+[From Step 4]
+```
+
+Ensure the `last_updated` frontmatter field is set to today's date.
+
+After writing, announce: "Brand guide saved to `knowledge-base/overview/brand-guide.md`. This document is now referenced by the discord-content skill and future marketing tools."
+
+## Important Guidelines
+
+- Ask one question at a time using the AskUserQuestion tool
+- Provide concrete examples and defaults -- do not ask open-ended questions without guidance
+- Respect the Brand Guide Contract -- use exact `##` headings, never variations
+- Write the document atomically at the end, not progressively during the workshop
+- When updating an existing guide, preserve untouched sections exactly as they are
+- Keep each section concise -- a brand guide is a reference document, not an essay

--- a/plugins/soleur/skills/discord-content/SKILL.md
+++ b/plugins/soleur/skills/discord-content/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: discord-content
+description: "This skill should be used when creating and posting community content to Discord. It generates brand-consistent posts (project updates, tips, milestones, or custom topics), validates them against the brand guide, and posts via webhook after user approval. Triggers on \"post to Discord\", \"Discord update\", \"community post\", \"Discord announcement\", \"write Discord content\"."
+---
+
+# Discord Content
+
+Create and post brand-consistent community content to Discord. Content is generated from a user-provided topic, validated against the brand guide, and posted via webhook after explicit user approval.
+
+## Prerequisites
+
+Before generating content, verify both prerequisites. If either fails, display the error message and stop.
+
+### 1. Brand Guide
+
+Check if `knowledge-base/overview/brand-guide.md` exists.
+
+**If missing:**
+> No brand guide found. Run the brand architect agent first to establish brand identity:
+> `Use the brand-architect agent to define our brand.`
+
+Stop execution.
+
+### 2. Discord Webhook URL
+
+Check if the `DISCORD_WEBHOOK_URL` environment variable is set.
+
+**If missing:**
+> `DISCORD_WEBHOOK_URL` is not set. To configure:
+> 1. Open Discord server > Server Settings > Integrations > Webhooks
+> 2. Click "New Webhook" and configure the target channel
+> 3. Copy the webhook URL
+> 4. Set the environment variable: `export DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."`
+
+Stop execution.
+
+## Content Generation
+
+### Phase 1: Topic Input
+
+Ask the user: "What would you like to post about?"
+
+Accept a freeform topic description. Optionally offer: "Summarize recent git activity?" -- if accepted, run `git log --oneline -20` to gather recent commits and PRs as source material.
+
+### Phase 2: Generate Draft
+
+Read the brand guide sections that inform content generation:
+
+1. Read `## Voice` -- apply brand voice, tone, do's and don'ts
+2. Read `## Channel Notes > ### Discord` -- apply Discord-specific guidelines (if the section exists)
+
+Generate a draft post that:
+- Addresses the user's topic
+- Matches the brand voice from `## Voice`
+- Follows Discord channel guidelines from `## Channel Notes`
+- Stays within the 2000-character Discord message limit
+
+### Phase 3: Inline Brand Voice Check
+
+Before presenting the draft to the user, validate it against the brand guide:
+
+1. Check the draft against the `### Do's and Don'ts` section
+2. If any "Don't" patterns are found, revise the draft to remove them
+3. If the draft exceeds 2000 characters, trim it while preserving key messages
+4. Note any adjustments made
+
+### Phase 4: User Approval
+
+Present the final draft to the user with character count displayed. Use the **AskUserQuestion tool** with three options:
+
+- **Accept** -- Post this content to Discord
+- **Edit** -- Provide feedback to revise the draft (return to Phase 2 with feedback)
+- **Reject** -- Discard the draft and exit
+
+### Phase 5: Post to Discord
+
+On acceptance, post the content via webhook:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "Content-Type: application/json" \
+  -d "{\"content\": \"ESCAPED_CONTENT\"}" \
+  "$DISCORD_WEBHOOK_URL"
+```
+
+**Content must be properly JSON-escaped** before inserting into the payload. Escape double quotes, backslashes, and newlines.
+
+**Payload format:** Plain `content` field only. No rich embeds in v1.
+
+### Phase 6: Result
+
+**On success (HTTP 2xx):**
+> Posted to Discord successfully.
+
+**On failure (HTTP 4xx/5xx):**
+> Failed to post to Discord (HTTP [status_code]).
+>
+> Draft content (copy-paste manually):
+> ```
+> [full draft content]
+> ```
+
+Display the draft so the user can post it manually. Do not retry automatically.
+
+## Important Guidelines
+
+- All content requires explicit user approval before posting -- no auto-send
+- The 2000-character limit is enforced during generation, not as a post-hoc check
+- Content uses the plain `content` field, not Discord rich embeds
+- JSON-escape all content before inserting into the webhook payload
+- If the brand guide's `## Channel Notes > ### Discord` section is missing, generate content using only the `## Voice` section (no error)
+- If the user selects "Edit", incorporate their feedback and regenerate -- do not present the same draft


### PR DESCRIPTION
## Summary

- New `agents/marketing/` domain with **brand-architect** agent -- interactive brand identity workshop that produces a structured brand guide document (`knowledge-base/overview/brand-guide.md`)
- New **discord-content** skill -- creates and posts brand-consistent community content to Discord via webhook, with inline brand voice validation and user approval before posting
- Brand Guide Contract defining exact `##` heading names (`Identity`, `Voice`, `Visual Direction`, `Channel Notes`) that downstream tools depend on
- Plugin version bumped to v2.2.0 (23 agents, 35 skills)

Closes #71

## Test plan

- [x] 541/541 tests pass (`bun test`)
- [ ] Run `/soleur:marketing:brand-architect` to generate a brand guide -- verify all 4 sections present
- [ ] Run `/soleur:marketing:brand-architect` with existing brand guide -- verify update mode works
- [ ] Set `DISCORD_WEBHOOK_URL` and run `discord-content` skill -- verify draft generation, brand voice check, and posting
- [ ] Run `discord-content` without brand guide -- verify prerequisite check and setup instructions
- [ ] Run `discord-content` without `DISCORD_WEBHOOK_URL` -- verify env var check and setup instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)