### PR TITLE
feat(ci): auto-create GitHub Releases on merge to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.3.0"
+      placeholder: "2.3.1"
     validations:
       required: true
   - type: input

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,101 @@
+name: Auto Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'plugins/soleur/.claude-plugin/plugin.json'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version from plugin.json
+        id: version
+        run: |
+          VERSION=$(jq -r '.version' plugins/soleur/.claude-plugin/plugin.json)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if release already exists
+        id: check
+        run: |
+          if gh release view "$TAG" &>/dev/null; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+
+      - name: Extract changelog
+        if: steps.check.outputs.exists == 'false'
+        id: changelog
+        run: |
+          # Extract the section for this version (between ## [$VERSION] and next ## [)
+          BODY=$(awk "/^## \[${VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" plugins/soleur/CHANGELOG.md)
+
+          if [ -z "$BODY" ]; then
+            BODY="Release v${VERSION}"
+          fi
+
+          # Use delimiter for multiline output
+          echo "body<<CHANGELOG_EOF" >> $GITHUB_OUTPUT
+          echo "$BODY" >> $GITHUB_OUTPUT
+          echo "CHANGELOG_EOF" >> $GITHUB_OUTPUT
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          echo "$RELEASE_BODY" > /tmp/release-notes.md
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file /tmp/release-notes.md
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+          RELEASE_BODY: ${{ steps.changelog.outputs.body }}
+
+      # Post to Discord directly because releases created by GITHUB_TOKEN
+      # do not trigger other workflows (release-announce.yml won't fire)
+      - name: Post to Discord
+        if: steps.check.outputs.exists == 'false'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          TAG: ${{ steps.version.outputs.tag }}
+          BODY: ${{ steps.changelog.outputs.body }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "DISCORD_WEBHOOK_URL secret not set, skipping Discord notification"
+            exit 0
+          fi
+
+          REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+          RELEASE_URL="${REPO_URL}/releases/tag/${TAG}"
+
+          # Truncate body to 1900 chars for Discord's 2000 char limit
+          if [ ${#BODY} -gt 1900 ]; then
+            BODY="${BODY:0:1897}..."
+          fi
+
+          MESSAGE=$(printf '**Soleur %s released!**\n\n%s\n\nFull release notes: %s' \
+            "$TAG" "$BODY" "$RELEASE_URL")
+
+          PAYLOAD=$(jq -n --arg content "$MESSAGE" '{content: $content}')
+
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            "$DISCORD_WEBHOOK_URL")
+
+          if [[ "$HTTP_CODE" =~ ^2 ]]; then
+            echo "Discord notification sent (HTTP $HTTP_CODE)"
+          else
+            echo "::warning::Discord notification failed (HTTP $HTTP_CODE)"
+          fi

--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -1,5 +1,9 @@
 name: Release Announce
 
+# Handles Discord notifications for manually-created releases.
+# Automated releases on merge are handled by auto-release.yml (which posts
+# to Discord directly, since GITHUB_TOKEN releases don't trigger this workflow).
+
 on:
   release:
     types: [published]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.3.0-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.3.1-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "AI-powered development tools for Claude Code that get smarter with every use. 23 agents, 8 commands, and 36 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2026-02-12
+
+### Added
+
+- `auto-release.yml` GitHub Actions workflow -- automatically creates GitHub Releases and posts to Discord when plugin.json version changes on merge to main
+  - Reads version from plugin.json, extracts changelog section, creates release via `gh release create`
+  - Posts to Discord directly (GITHUB_TOKEN releases don't trigger other workflows)
+  - Idempotent: skips if release already exists
+
+### Changed
+
+- `/ship` Phase 8: release creation is now automatic via CI; manual `/release-announce` retained as fallback
+- `release-announce.yml`: added comment clarifying it handles manually-created releases only
+
 ## [2.3.0] - 2026-02-12
 
 ### Added

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -314,13 +314,9 @@ After the PR is created, ask the user:
 
 **If merged (either now or user says "merge PR" later in the session):**
 
-1. Check if a plugin version bump was part of this branch:
+1. **Release creation is automatic.** When a merge to main includes a plugin.json version change, the `auto-release.yml` GitHub Actions workflow creates a GitHub Release and posts to Discord. No manual step needed.
 
-   ```bash
-   git diff --name-only $(git merge-base HEAD origin/main)..HEAD -- plugins/soleur/.claude-plugin/plugin.json
-   ```
-
-   If plugin.json was modified: run `/release-announce` to post announcements to Discord and create a GitHub Release. The skill operates via APIs (webhook + `gh release create`) so it works from the worktree.
+   If the workflow did not fire (e.g., path filter didn't match), run `/release-announce` manually as a fallback.
 
 2. Clean up worktree and local branch:
 


### PR DESCRIPTION
## Summary
- Adds `auto-release.yml` workflow that triggers on push to main when `plugin.json` changes
- Automatically creates GitHub Release with changelog content and posts to Discord
- Posts to Discord directly in the same workflow (GITHUB_TOKEN releases don't trigger other workflows)
- Updates ship skill Phase 8 to note release creation is now automatic
- Adds clarifying comment to `release-announce.yml` (handles manual releases only)
- Bumps version 2.3.0 -> 2.3.1

## Context
v2.3.0 was merged without a GitHub Release because the release step was manual (depended on running `/release-announce` after merge). This caused the Discord notification to never fire.

## Test plan
- [x] v2.3.0 release created manually to fix immediate gap
- [x] Tests pass (548/548)
- [ ] Verify `auto-release.yml` fires on next merge that bumps plugin.json
- [ ] Verify Discord notification is posted by the new workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)