### PR TITLE
fix(ci): add contents:write permission to auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'plugins/soleur/.claude-plugin/plugin.json'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `permissions: contents: write` to `auto-release.yml`
- Without this, `gh release create` fails with HTTP 403 ("Resource not accessible by integration")

## Context
Follow-up to #77. The auto-release workflow triggered correctly on merge but failed to create the release due to missing token permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)