### PR TITLE
feat(plugin): add ux-design-lead agent and design domain (v2.8.0)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.7.0"
+      placeholder: "2.8.0"
     validations:
       required: true
   - type: input

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ node_modules/
 .codex/
 .worktrees
 .claude/settings.local.json
+.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.7.0-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.8.0-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)
@@ -25,7 +25,7 @@ Currently at phase of being an Orchestration engine for Claude Code -- agents, w
 Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo founders (soloentrepreneurs) to collapse the friction between a startup idea and a $1B outcome
 
 AI-powered company orchestration for Claude Code (and Bring Your Own Model later) that get smarter with every use. 
-Soleur currently provides **24 agents**, **8 commands**, and **37 skills** that compound your company knowledge (currently only engineering so far) over time -- every problem you solve makes the next one easier.
+Soleur currently provides **25 agents**, **8 commands**, and **37 skills** that compound your company knowledge (currently only engineering so far) over time -- every problem you solve makes the next one easier.
 
 ## Installation
 

--- a/knowledge-base/brainstorms/archive/20260214-133317-2026-02-14-ux-design-lead-brainstorm.md
+++ b/knowledge-base/brainstorms/archive/20260214-133317-2026-02-14-ux-design-lead-brainstorm.md
@@ -1,0 +1,59 @@
+# UX Design Lead Agent + Pencil MCP Integration
+
+**Date:** 2026-02-14
+**Status:** Captured
+**Participants:** Jean, Claude
+
+## What We're Building
+
+Three things bundled into one feature:
+
+1. **Commit missing PR #82 artifacts** -- The .pen design file at `knowledge-base/design/brand/` was left untracked when PR #82 merged. Also gitignore `.playwright-mcp/` as ephemeral session data.
+
+2. **Bundle Pencil MCP server in the plugin** -- Add the pencil.dev MCP server to `plugin.json` alongside the existing `context7` server, giving all Soleur users access to .pen file design tools.
+
+3. **New `ux-design-lead` agent** -- A full UX workflow agent under `agents/design/` that handles wireframes, visual design, and design systems using Pencil (.pen files). This replaces the visual design responsibilities previously handled ad-hoc by the brand-architect.
+
+## Why This Approach
+
+- **Separation of concerns:** brand-architect stays focused on text-based brand identity (voice, tone, positioning). ux-design-lead handles all visual design work in .pen files. Clear ownership.
+- **Chained workflow:** brand-architect produces the brand guide, then optionally hands off to ux-design-lead for visual exploration. This mirrors how real teams work (brand strategist -> designer).
+- **Bundled MCP:** Making pencil a first-class MCP server means design capabilities are available out of the box, not an optional extra users have to discover and configure.
+- **Top-level domain:** `agents/design/` as a new top-level domain (like `marketing/`, `research/`) reflects that design is cross-cutting, not strictly engineering or marketing.
+
+## Key Decisions
+
+1. **Agent name:** `ux-design-lead` -- conveys the full UX workflow scope without overlapping brand-architect (brand identity) or frontend-design skill (code generation).
+
+2. **Location:** `agents/design/ux-design-lead.md` -- new top-level `design/` domain under agents.
+
+3. **Pencil MCP:** Bundled in `plugin.json` mcpServers, same as context7. Available to all users automatically.
+
+4. **Brand routing chain:** brainstorm's brand routing calls brand-architect first, then offers to chain to ux-design-lead for visual exploration in .pen files.
+
+5. **.pen file convention:** Files organized by domain under `knowledge-base/design/{domain}/` (e.g., `design/brand/`, `design/onboarding/`, `design/dashboard/`). Convention added to constitution.
+
+6. **.playwright-mcp/:** Added to .gitignore as ephemeral session artifacts.
+
+## Open Questions
+
+- What specific Pencil MCP operations should the ux-design-lead agent know how to use? (get_guidelines, get_style_guide, batch_design, get_screenshot for validation?)
+- Should the agent auto-detect existing brand-guide.md and use it for color/typography decisions?
+- How does the ux-design-lead interact with the existing frontend-design skill? (Design in .pen -> generate code from .pen?)
+- Should we define .pen file naming conventions beyond the directory structure?
+
+## Scope
+
+### In Scope
+- New `ux-design-lead` agent with .pen file design capabilities
+- Pencil MCP server in plugin.json
+- .pen directory convention in constitution
+- .gitignore update for .playwright-mcp/
+- Commit existing .pen file from PR #82
+- Update brainstorm command to chain brand-architect -> ux-design-lead
+
+### Out of Scope
+- Modifying brand-architect's core functionality
+- Code generation from .pen files (that's frontend-design's job)
+- Design system creation (future enhancement)
+- Automated design review agent

--- a/knowledge-base/design/brand/brand-visual-identity-brainstorm.pen
+++ b/knowledge-base/design/brand/brand-visual-identity-brainstorm.pen
@@ -1,0 +1,4197 @@
+{
+  "version": "2.8",
+  "children": [
+    {
+      "type": "frame",
+      "id": "0Ja8a",
+      "x": 0,
+      "y": 0,
+      "name": "1 — Solar Forge",
+      "width": 1440,
+      "fill": "#0A0A0A",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "jrnC9",
+          "name": "Nav",
+          "width": "fill_container",
+          "height": 72,
+          "padding": [
+            0,
+            80
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "IQzCb",
+              "name": "logo",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "0mlBD",
+                  "name": "logoMark",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 18,
+                  "stroke": {
+                    "thickness": 1.5,
+                    "fill": "#C9A962"
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "BCmdJ",
+                      "name": "logoLetter",
+                      "fill": "#C9A962",
+                      "content": "S",
+                      "fontFamily": "Cormorant Garamond",
+                      "fontSize": 20,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "oESNl",
+                  "name": "logoText",
+                  "fill": "#FFFFFF",
+                  "content": "SOLEUR",
+                  "fontFamily": "Inter",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "letterSpacing": 4
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "g7ozQ",
+              "name": "navLinks",
+              "gap": 32,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "g9Z8g",
+                  "name": "navGithub",
+                  "width": 20,
+                  "height": 20,
+                  "iconFontName": "github",
+                  "iconFontFamily": "lucide",
+                  "fill": "#848484"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "LMSvV",
+                  "name": "navDiscord",
+                  "width": 20,
+                  "height": 20,
+                  "iconFontName": "bot",
+                  "iconFontFamily": "lucide",
+                  "fill": "#848484"
+                },
+                {
+                  "type": "frame",
+                  "id": "Ds1Sd",
+                  "name": "navCta",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#D4B36A",
+                        "position": 0
+                      },
+                      {
+                        "color": "#B8923E",
+                        "position": 1
+                      }
+                    ]
+                  },
+                  "padding": [
+                    10,
+                    24
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "IUmed",
+                      "name": "navCtaText",
+                      "fill": "#0A0A0A",
+                      "content": "Get Started",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "VMiJW",
+          "name": "Hero",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 32,
+          "padding": [
+            100,
+            80,
+            80,
+            80
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "tLo8Q",
+              "name": "badge",
+              "stroke": {
+                "thickness": 1,
+                "fill": "#C9A96240"
+              },
+              "gap": 8,
+              "padding": [
+                8,
+                20
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "pTmTl",
+                  "name": "badgeDot",
+                  "fill": "#C9A962",
+                  "width": 8,
+                  "height": 8,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#C9A96280",
+                    "blur": 8
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "6lv62",
+                  "name": "badgeText",
+                  "fill": "#C9A962",
+                  "content": "The Company-as-a-Service Platform",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "WcWT1",
+              "name": "headline",
+              "fill": "#FFFFFF",
+              "textGrowth": "fixed-width",
+              "width": 900,
+              "content": "Build a Billion-Dollar Company.\nAlone.",
+              "lineHeight": 1.05,
+              "textAlign": "center",
+              "fontFamily": "Cormorant Garamond",
+              "fontSize": 72,
+              "fontWeight": "500",
+              "letterSpacing": -1
+            },
+            {
+              "type": "text",
+              "id": "iG7x6",
+              "name": "subline",
+              "fill": "#848484",
+              "textGrowth": "fixed-width",
+              "width": 700,
+              "content": "Everything you need to build, ship, and scale — powered by AI teams.\nFor founders who think in billions.",
+              "lineHeight": 1.6,
+              "textAlign": "center",
+              "fontFamily": "Inter",
+              "fontSize": 18
+            },
+            {
+              "type": "frame",
+              "id": "bDgIg",
+              "name": "ctaRow",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "UYxDw",
+                  "name": "ctaPrimary",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#D4B36A",
+                        "position": 0
+                      },
+                      {
+                        "color": "#B8923E",
+                        "position": 1
+                      }
+                    ]
+                  },
+                  "padding": [
+                    16,
+                    40
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "wupP7",
+                      "name": "ctaPrimaryText",
+                      "fill": "#0A0A0A",
+                      "content": "Start Building",
+                      "fontFamily": "Inter",
+                      "fontSize": 15,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "lyjxG",
+          "name": "Stats Strip",
+          "width": "fill_container",
+          "fill": "#0E0E0E",
+          "stroke": {
+            "thickness": {
+              "top": 1,
+              "bottom": 1
+            },
+            "fill": "#2A2A2A"
+          },
+          "padding": [
+            48,
+            80
+          ],
+          "justifyContent": "space_around",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "QO08t",
+              "name": "stat1",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "GOcAG",
+                  "name": "stat1v",
+                  "fill": "#C9A962",
+                  "content": "1",
+                  "fontFamily": "Cormorant Garamond",
+                  "fontSize": 40,
+                  "fontWeight": "500",
+                  "letterSpacing": -1
+                },
+                {
+                  "type": "text",
+                  "id": "Hym1I",
+                  "name": "stat1l",
+                  "fill": "#848484",
+                  "content": "Automated Workflow",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "xDWEw",
+              "name": "stat2",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "bB69k",
+                  "name": "stat2v",
+                  "fill": "#C9A962",
+                  "content": "23+",
+                  "fontFamily": "Cormorant Garamond",
+                  "fontSize": 40,
+                  "fontWeight": "500",
+                  "letterSpacing": -1
+                },
+                {
+                  "type": "text",
+                  "id": "GDFT7",
+                  "name": "stat2l",
+                  "fill": "#848484",
+                  "content": "AI Agents",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "V308Y",
+              "name": "stat3",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "j43SY",
+                  "name": "stat3v",
+                  "fill": "#C9A962",
+                  "content": "36+",
+                  "fontFamily": "Cormorant Garamond",
+                  "fontSize": 40,
+                  "fontWeight": "500",
+                  "letterSpacing": -1
+                },
+                {
+                  "type": "text",
+                  "id": "EwCyD",
+                  "name": "stat3l",
+                  "fill": "#848484",
+                  "content": "Skills",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "yw6Zc",
+              "name": "stat4",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "YSFV6",
+                  "name": "stat4v",
+                  "fill": "#C9A962",
+                  "content": "∞",
+                  "fontFamily": "Cormorant Garamond",
+                  "fontSize": 40,
+                  "fontWeight": "500",
+                  "letterSpacing": -1
+                },
+                {
+                  "type": "text",
+                  "id": "2ZS5n",
+                  "name": "stat4l",
+                  "fill": "#848484",
+                  "content": "Compounding Knowledge",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "cO3ck",
+          "name": "Problem Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 48,
+          "padding": [
+            80,
+            120
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "fKd3I",
+              "name": "probHead",
+              "layout": "vertical",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "qTseb",
+                  "name": "probLabel",
+                  "fill": "#C9A962",
+                  "content": "THIS IS THE WAY",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "600",
+                  "letterSpacing": 3
+                },
+                {
+                  "type": "text",
+                  "id": "pdkfh",
+                  "name": "probTitle",
+                  "fill": "#FFFFFF",
+                  "textGrowth": "fixed-width",
+                  "width": 800,
+                  "content": "One founder powered by\na full-stack AI organization.",
+                  "textAlign": "center",
+                  "fontFamily": "Cormorant Garamond",
+                  "fontSize": 42,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "4MoCi",
+                  "name": "probDesc",
+                  "fill": "#848484",
+                  "textGrowth": "fixed-width",
+                  "width": 640,
+                  "content": "Not a copilot. Not an assistant.\nA full AI organization that reviews, plans, builds, and remembers.\nEvery decision you make teaches the system.\nEvery project starts faster than the last.",
+                  "lineHeight": 1.7,
+                  "textAlign": "center",
+                  "fontFamily": "Inter",
+                  "fontSize": 17,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "jcEQe",
+              "name": "Cards",
+              "width": "fill_container",
+              "gap": 24,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "5Otn2",
+                  "name": "card1",
+                  "width": "fill_container",
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#2A2A2A"
+                  },
+                  "layout": "vertical",
+                  "gap": 20,
+                  "padding": 32,
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "f3iDU",
+                      "name": "card1Icon",
+                      "width": 28,
+                      "height": 28,
+                      "iconFontName": "brain",
+                      "iconFontFamily": "lucide",
+                      "fill": "#C9A962"
+                    },
+                    {
+                      "type": "text",
+                      "id": "AdcrR",
+                      "name": "card1Title",
+                      "fill": "#FFFFFF",
+                      "content": "You Decide",
+                      "fontFamily": "Cormorant Garamond",
+                      "fontSize": 24,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Vnn8e",
+                      "name": "card1Desc",
+                      "fill": "#848484",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Taste, vision, and timing. The things no machine can replace. You set the direction — everything else follows.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "pXZTM",
+                  "name": "card2",
+                  "width": "fill_container",
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#2A2A2A"
+                  },
+                  "layout": "vertical",
+                  "gap": 20,
+                  "padding": 32,
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Hr0kJ",
+                      "name": "card2Icon",
+                      "width": 28,
+                      "height": 28,
+                      "iconFontName": "zap",
+                      "iconFontFamily": "lucide",
+                      "fill": "#C9A962"
+                    },
+                    {
+                      "type": "text",
+                      "id": "icYXG",
+                      "name": "card2Title",
+                      "fill": "#FFFFFF",
+                      "content": "Agents Execute",
+                      "fontFamily": "Cormorant Garamond",
+                      "fontSize": 24,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ekvdY",
+                      "name": "card2Desc",
+                      "fill": "#848484",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Engineering, marketing, legal, operations — every department, running autonomously on your command.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "OXgtV",
+                  "name": "card3",
+                  "width": "fill_container",
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#2A2A2A"
+                  },
+                  "layout": "vertical",
+                  "gap": 20,
+                  "padding": 32,
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "0brVk",
+                      "name": "card3Icon",
+                      "width": 28,
+                      "height": 28,
+                      "iconFontName": "repeat",
+                      "iconFontFamily": "lucide",
+                      "fill": "#C9A962"
+                    },
+                    {
+                      "type": "text",
+                      "id": "6GSSq",
+                      "name": "card3Title",
+                      "fill": "#FFFFFF",
+                      "content": "Knowledge Compounds",
+                      "fontFamily": "Cormorant Garamond",
+                      "fontSize": 24,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "7oLNS",
+                      "name": "card3Desc",
+                      "fill": "#848484",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Solutions compound into patterns. Patterns compound into playbooks. Your AI organization gets smarter with every project — permanently.",
+                      "lineHeight": 1.6,
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "2cX6a",
+          "name": "Quote Section",
+          "width": "fill_container",
+          "fill": "#0E0E0E",
+          "stroke": {
+            "thickness": {
+              "top": 1,
+              "bottom": 1
+            },
+            "fill": "#2A2A2A"
+          },
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            80,
+            200
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "TDZGq",
+              "name": "quoteText",
+              "fill": "#FFFFFF",
+              "textGrowth": "fixed-width",
+              "width": 800,
+              "content": "“The first trillion-dollar company run by one person\nisn't science fiction. It's an engineering problem.\nWe're solving it.”",
+              "lineHeight": 1.5,
+              "textAlign": "center",
+              "fontFamily": "Cormorant Garamond",
+              "fontSize": 28,
+              "fontStyle": "italic"
+            },
+            {
+              "type": "text",
+              "id": "FNN8W",
+              "name": "quoteAttr",
+              "fill": "#C9A962",
+              "content": "— The Soleur Thesis",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Dy5ww",
+          "name": "Features Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 48,
+          "padding": [
+            80,
+            120
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "qOqhQ",
+              "name": "featHead",
+              "layout": "vertical",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "j9E1G",
+                  "name": "featLabel",
+                  "fill": "#C9A962",
+                  "content": "YOUR AI ORGANIZATION",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "600",
+                  "letterSpacing": 3
+                },
+                {
+                  "type": "text",
+                  "id": "je85c",
+                  "name": "featTitle",
+                  "fill": "#FFFFFF",
+                  "textGrowth": "fixed-width",
+                  "width": 800,
+                  "content": "Every department. From idea to shipped.",
+                  "textAlign": "center",
+                  "fontFamily": "Cormorant Garamond",
+                  "fontSize": 42,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "vRj88",
+              "name": "Feature Grid",
+              "width": "fill_container",
+              "gap": 24,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "GlLBq",
+                  "name": "fRow1",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 24,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "TwypZ",
+                      "name": "f2",
+                      "width": "fill_container",
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2A2A2A"
+                      },
+                      "layout": "vertical",
+                      "gap": 16,
+                      "padding": 28,
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "sx4Ra",
+                          "name": "f2i",
+                          "width": 24,
+                          "height": 24,
+                          "iconFontName": "target",
+                          "iconFontFamily": "lucide",
+                          "fill": "#C9A962"
+                        },
+                        {
+                          "type": "text",
+                          "id": "BofXF",
+                          "name": "f2t",
+                          "fill": "#FFFFFF",
+                          "content": "Strategy",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ALbdL",
+                          "name": "f2d",
+                          "fill": "#6A6A6A",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Vision, positioning, market analysis. The strategic foundation that guides every decision your AI organization makes.",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "IIQBG",
+                      "name": "f3",
+                      "width": "fill_container",
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2A2A2A"
+                      },
+                      "layout": "vertical",
+                      "gap": 16,
+                      "padding": 28,
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "JWaRb",
+                          "name": "f3i",
+                          "width": 24,
+                          "height": 24,
+                          "iconFontName": "layers",
+                          "iconFontFamily": "lucide",
+                          "fill": "#C9A962"
+                        },
+                        {
+                          "type": "text",
+                          "id": "cmbhS",
+                          "name": "f3t",
+                          "fill": "#FFFFFF",
+                          "content": "Product",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "jn2XZ",
+                          "name": "f3d",
+                          "fill": "#6A6A6A",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Product management, competitive analysis, planning & specs, UX design. From market insight to shipped experience.",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Z8ZKO",
+                      "name": "f1",
+                      "width": "fill_container",
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2A2A2A"
+                      },
+                      "layout": "vertical",
+                      "gap": 16,
+                      "padding": 28,
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "PkkVf",
+                          "name": "f1i",
+                          "width": 24,
+                          "height": 24,
+                          "iconFontName": "code",
+                          "iconFontFamily": "lucide",
+                          "fill": "#C9A962"
+                        },
+                        {
+                          "type": "text",
+                          "id": "mhZk0",
+                          "name": "f1t",
+                          "fill": "#FFFFFF",
+                          "content": "Engineering",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "PFGL8",
+                          "name": "f1d",
+                          "fill": "#6A6A6A",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Code review, architecture, security, quality testing. Specialized agents shipping production-grade code on your command.",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "clxwA",
+                      "name": "f3b",
+                      "width": "fill_container",
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2A2A2A"
+                      },
+                      "layout": "vertical",
+                      "gap": 16,
+                      "padding": 28,
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "Z4Dco",
+                          "name": "f4i",
+                          "width": 24,
+                          "height": 24,
+                          "iconFontName": "megaphone",
+                          "iconFontFamily": "lucide",
+                          "fill": "#C9A962"
+                        },
+                        {
+                          "type": "text",
+                          "id": "e28Ux",
+                          "name": "f4t",
+                          "fill": "#FFFFFF",
+                          "content": "Marketing & Support",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Y9xYz",
+                          "name": "f4d",
+                          "fill": "#6A6A6A",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Brand identity, community content, release announcements. Your public presence runs on autopilot.",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "zR0OF",
+                      "name": "f8",
+                      "width": "fill_container",
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2A2A2A"
+                      },
+                      "layout": "vertical",
+                      "gap": 16,
+                      "padding": 28,
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "9nPEx",
+                          "name": "f5li",
+                          "width": 24,
+                          "height": 24,
+                          "iconFontName": "headphones",
+                          "iconFontFamily": "lucide",
+                          "fill": "#C9A962"
+                        },
+                        {
+                          "type": "text",
+                          "id": "0Afqn",
+                          "name": "f5lt",
+                          "fill": "#FFFFFF",
+                          "content": "Customer Support",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "hiwHS",
+                          "name": "f5ld",
+                          "fill": "#6A6A6A",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Troubleshooting, documentation, issue triage. AI-powered support that resolves problems before they escalate.",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "TAD1t",
+                  "name": "fRow2",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 24,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "mJgc1",
+                      "name": "f4",
+                      "width": "fill_container",
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2A2A2A"
+                      },
+                      "layout": "vertical",
+                      "gap": 16,
+                      "padding": 28,
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "ajh3u",
+                          "name": "f4i",
+                          "width": 24,
+                          "height": 24,
+                          "iconFontName": "lightbulb",
+                          "iconFontFamily": "lucide",
+                          "fill": "#C9A962"
+                        },
+                        {
+                          "type": "text",
+                          "id": "18oB3",
+                          "name": "f4t",
+                          "fill": "#FFFFFF",
+                          "content": "Think",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Goys9",
+                          "name": "f4d",
+                          "fill": "#6A6A6A",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Brainstorm, explore, challenge assumptions. Structured dialogue before any commitment.",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "OJKcX",
+                      "name": "f5",
+                      "width": "fill_container",
+                      "height": 170,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2A2A2A"
+                      },
+                      "layout": "vertical",
+                      "gap": 16,
+                      "padding": 28,
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "fyJUv",
+                          "name": "f5i",
+                          "width": 24,
+                          "height": 24,
+                          "iconFontName": "compass",
+                          "iconFontFamily": "lucide",
+                          "fill": "#C9A962"
+                        },
+                        {
+                          "type": "text",
+                          "id": "rx60r",
+                          "name": "f5t",
+                          "fill": "#FFFFFF",
+                          "content": "Plan",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "De6Og",
+                          "name": "f5d",
+                          "fill": "#6A6A6A",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Specs, architecture, task breakdowns. Every detail mapped before execution begins.",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "6Pn6f",
+                      "name": "f6",
+                      "width": "fill_container",
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2A2A2A"
+                      },
+                      "layout": "vertical",
+                      "gap": 16,
+                      "padding": 28,
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "1bQ6m",
+                          "name": "f6i",
+                          "width": 24,
+                          "height": 24,
+                          "iconFontName": "code",
+                          "iconFontFamily": "lucide",
+                          "fill": "#C9A962"
+                        },
+                        {
+                          "type": "text",
+                          "id": "9QaaW",
+                          "name": "f6t",
+                          "fill": "#FFFFFF",
+                          "content": "Build",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "gRDRa",
+                          "name": "f6d",
+                          "fill": "#6A6A6A",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Parallel agents writing, reviewing, and refining code. Production-grade engineering on your command.",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "mgIHT",
+                      "name": "f7",
+                      "width": "fill_container",
+                      "height": 170,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2A2A2A"
+                      },
+                      "layout": "vertical",
+                      "gap": 16,
+                      "padding": 28,
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "FPoqg",
+                          "name": "f4ri",
+                          "width": 24,
+                          "height": 24,
+                          "iconFontName": "rocket",
+                          "iconFontFamily": "lucide",
+                          "fill": "#C9A962"
+                        },
+                        {
+                          "type": "text",
+                          "id": "dtUZY",
+                          "name": "f4rt",
+                          "fill": "#FFFFFF",
+                          "content": "Ship",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Ym2Cf",
+                          "name": "f4rd",
+                          "fill": "#6A6A6A",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "One command. Tests, review, commit, deploy, announce. Done.",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "kwRfJ",
+                      "name": "f9",
+                      "width": "fill_container",
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2A2A2A"
+                      },
+                      "layout": "vertical",
+                      "gap": 16,
+                      "padding": 28,
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "5Yvqw",
+                          "name": "f5ri",
+                          "width": 24,
+                          "height": 24,
+                          "iconFontName": "trending-up",
+                          "iconFontFamily": "lucide",
+                          "fill": "#C9A962"
+                        },
+                        {
+                          "type": "text",
+                          "id": "s7Uxu",
+                          "name": "f5rt",
+                          "fill": "#FFFFFF",
+                          "content": "Learn & Grow",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "RXXQ1",
+                          "name": "f5rd",
+                          "fill": "#6A6A6A",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Every decision captured, every pattern compounded. Your organization gets smarter with every project — permanently.",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "XN9rs",
+          "name": "Final CTA",
+          "width": "fill_container",
+          "fill": {
+            "type": "gradient",
+            "gradientType": "linear",
+            "enabled": true,
+            "rotation": 180,
+            "size": {
+              "height": 1
+            },
+            "colors": [
+              {
+                "color": "#0A0A0A",
+                "position": 0
+              },
+              {
+                "color": "#141414",
+                "position": 1
+              }
+            ]
+          },
+          "layout": "vertical",
+          "gap": 32,
+          "padding": [
+            100,
+            80
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "RjrEq",
+              "name": "ctaTitle",
+              "fill": "#FFFFFF",
+              "content": "Ready to build at scale?",
+              "textAlign": "center",
+              "fontFamily": "Cormorant Garamond",
+              "fontSize": 48,
+              "fontWeight": "500"
+            },
+            {
+              "type": "text",
+              "id": "phWKb",
+              "name": "ctaSub",
+              "fill": "#848484",
+              "content": "Your AI organization is ready. Are you?",
+              "textAlign": "center",
+              "fontFamily": "Inter",
+              "fontSize": 17,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "Hj2uE",
+              "name": "ctaBtn",
+              "fill": {
+                "type": "gradient",
+                "gradientType": "linear",
+                "enabled": true,
+                "rotation": 180,
+                "size": {
+                  "height": 1
+                },
+                "colors": [
+                  {
+                    "color": "#D4B36A",
+                    "position": 0
+                  },
+                  {
+                    "color": "#B8923E",
+                    "position": 1
+                  }
+                ]
+              },
+              "padding": [
+                18,
+                48
+              ],
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "xkCJI",
+                  "name": "ctaBtnText",
+                  "fill": "#0A0A0A",
+                  "content": "Start Building",
+                  "fontFamily": "Inter",
+                  "fontSize": 16,
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Aa9eA",
+          "name": "Footer",
+          "width": "fill_container",
+          "stroke": {
+            "thickness": {
+              "top": 1
+            },
+            "fill": "#2A2A2A"
+          },
+          "padding": [
+            40,
+            80
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "krSyN",
+              "name": "footerLeft",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "eNnkh",
+                  "name": "footerMark",
+                  "width": 24,
+                  "height": 24,
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#C9A962"
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "0Vi8h",
+                      "name": "footerS",
+                      "fill": "#C9A962",
+                      "content": "S",
+                      "fontFamily": "Cormorant Garamond",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "hzltt",
+                  "name": "footerName",
+                  "fill": "#848484",
+                  "content": "SOLEUR",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500",
+                  "letterSpacing": 3
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Yip9o",
+              "name": "footerLinks",
+              "gap": 24,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "tOh1E",
+                  "name": "fl1",
+                  "fill": "#848484",
+                  "content": "GitHub",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "o1rAq",
+                  "name": "fl2",
+                  "fill": "#848484",
+                  "content": "Discord",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "pWvTc",
+                  "name": "fl3",
+                  "fill": "#848484",
+                  "content": "Docs",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "nsnpV",
+              "name": "footerRight",
+              "fill": "#4A4A4A",
+              "content": "Designed, built, and shipped by Soleur — using Soleur.",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontStyle": "italic"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "T3QQE",
+      "x": 1540,
+      "y": 0,
+      "name": "2 — First Light",
+      "width": 1440,
+      "fill": "#FFFBF5",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "DsfRA",
+          "name": "Nav",
+          "width": "fill_container",
+          "height": 72,
+          "padding": [
+            0,
+            80
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "3nLKe",
+              "name": "logo2",
+              "gap": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "3gAPu",
+                  "name": "logoMark2",
+                  "width": 32,
+                  "height": 32,
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#F59E0B",
+                        "position": 0
+                      },
+                      {
+                        "color": "#EA580C",
+                        "position": 1
+                      }
+                    ]
+                  },
+                  "cornerRadius": 16,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "eDYa1",
+                      "name": "logoLetter2",
+                      "fill": "#FFFFFF",
+                      "content": "S",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "Mw4vB",
+                  "name": "logoText2",
+                  "fill": "#1A1A1A",
+                  "content": "Soleur",
+                  "fontFamily": "Inter",
+                  "fontSize": 18,
+                  "fontWeight": "700"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "3xFSV",
+              "name": "navLinks2",
+              "gap": 32,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Fk1Rl",
+                  "name": "navL12",
+                  "fill": "#71717A",
+                  "content": "Platform",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "nWjWO",
+                  "name": "navL22",
+                  "fill": "#71717A",
+                  "content": "Docs",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "e2hPF",
+                  "name": "navL32",
+                  "fill": "#71717A",
+                  "content": "Community",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "k7W0r",
+                  "name": "navCta2",
+                  "fill": "#1A1A1A",
+                  "cornerRadius": 8,
+                  "padding": [
+                    10,
+                    24
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "8UrYB",
+                      "name": "navCtaText2",
+                      "fill": "#FFFFFF",
+                      "content": "Get Started",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "0cfHY",
+          "name": "Hero",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 32,
+          "padding": [
+            100,
+            80,
+            80,
+            80
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "tBY1H",
+              "name": "badge2",
+              "fill": "#FEF3C7",
+              "cornerRadius": 20,
+              "gap": 8,
+              "padding": [
+                8,
+                20
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ak8na",
+                  "name": "badgeText2",
+                  "fill": "#B45309",
+                  "content": "Now in Public Beta",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "w7p3J",
+              "name": "headline2",
+              "fill": "#1A1A1A",
+              "textGrowth": "fixed-width",
+              "width": 900,
+              "content": "Build Your Empire.\nStay Solo.",
+              "lineHeight": 1.05,
+              "textAlign": "center",
+              "fontFamily": "Inter",
+              "fontSize": 72,
+              "fontWeight": "800",
+              "letterSpacing": -2
+            },
+            {
+              "type": "text",
+              "id": "aPPAb",
+              "name": "subline2",
+              "fill": "#71717A",
+              "textGrowth": "fixed-width",
+              "width": 700,
+              "content": "Soleur is the Company-as-a-Service platform that gives solo founders\nthe leverage of a 1,000-person organization.",
+              "lineHeight": 1.6,
+              "textAlign": "center",
+              "fontFamily": "Inter",
+              "fontSize": 18
+            },
+            {
+              "type": "frame",
+              "id": "N0ipN",
+              "name": "ctaRow2",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "e2Wlu",
+                  "name": "ctaPrimary2",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#F59E0B",
+                        "position": 0
+                      },
+                      {
+                        "color": "#EA580C",
+                        "position": 1
+                      }
+                    ]
+                  },
+                  "cornerRadius": 10,
+                  "padding": [
+                    16,
+                    40
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "OUHyw",
+                      "name": "ctaPrimaryText2",
+                      "fill": "#FFFFFF",
+                      "content": "Start Building",
+                      "fontFamily": "Inter",
+                      "fontSize": 15,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "5hDqU",
+                  "name": "ctaSecondary2",
+                  "cornerRadius": 10,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E4E4E7"
+                  },
+                  "padding": [
+                    16,
+                    40
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "DTyAL",
+                      "name": "ctaSecondaryText2",
+                      "fill": "#71717A",
+                      "content": "Read the Docs",
+                      "fontFamily": "Inter",
+                      "fontSize": 15,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "faePp",
+          "name": "div2",
+          "width": "fill_container",
+          "height": 1,
+          "fill": "#E4E4E7"
+        },
+        {
+          "type": "frame",
+          "id": "kGhyQ",
+          "name": "Color Palette",
+          "width": "fill_container",
+          "gap": 24,
+          "padding": [
+            40,
+            80
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "yVW6J",
+              "name": "palLbl2",
+              "fill": "#A1A1AA",
+              "content": "PALETTE",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "700",
+              "letterSpacing": 2
+            },
+            {
+              "type": "frame",
+              "id": "sy2LG",
+              "name": "s2w1",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "dPAT3",
+                  "name": "s2w1c",
+                  "fill": "#FFFBF5",
+                  "width": 64,
+                  "height": 40,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E4E4E7"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "FhNqj",
+                  "name": "s2w1t",
+                  "fill": "#A1A1AA",
+                  "content": "#FFFBF5",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "w38Ro",
+              "name": "s2w2",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "sh9XS",
+                  "name": "s2w2c",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#F59E0B",
+                        "position": 0
+                      },
+                      {
+                        "color": "#EA580C",
+                        "position": 1
+                      }
+                    ]
+                  },
+                  "width": 64,
+                  "height": 40
+                },
+                {
+                  "type": "text",
+                  "id": "FePBB",
+                  "name": "s2w2t",
+                  "fill": "#A1A1AA",
+                  "content": "Amber→Orange",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "LKaHD",
+              "name": "s2w3",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "zUqLl",
+                  "name": "s2w3c",
+                  "fill": "#1A1A1A",
+                  "width": 64,
+                  "height": 40
+                },
+                {
+                  "type": "text",
+                  "id": "WerYA",
+                  "name": "s2w3t",
+                  "fill": "#A1A1AA",
+                  "content": "#1A1A1A",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "wf4jp",
+              "name": "s2w4",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "HQO9g",
+                  "name": "s2w4c",
+                  "fill": "#FEF3C7",
+                  "width": 64,
+                  "height": 40,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E4E4E7"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "Bdkqr",
+                  "name": "s2w4t",
+                  "fill": "#A1A1AA",
+                  "content": "#FEF3C7",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "C0U7f",
+              "name": "s2w5",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "XHFqL",
+                  "name": "s2w5c",
+                  "fill": "#71717A",
+                  "width": 64,
+                  "height": 40
+                },
+                {
+                  "type": "text",
+                  "id": "cBShM",
+                  "name": "s2w5t",
+                  "fill": "#A1A1AA",
+                  "content": "#71717A",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "jbJgV",
+              "name": "typo2a",
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ZAKZR",
+                  "name": "typo2a1",
+                  "fill": "#1A1A1A",
+                  "content": "Inter — All type",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "PLYDO",
+                  "name": "typo2a2",
+                  "fill": "#71717A",
+                  "content": "Weight contrast (800 vs 400)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "Utec3",
+      "x": 3080,
+      "y": 0,
+      "name": "3 — Stellar",
+      "width": 1440,
+      "fill": "#0C0C14",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "qPJFP",
+          "name": "Nav",
+          "width": "fill_container",
+          "height": 72,
+          "padding": [
+            0,
+            80
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Mgcbd",
+              "name": "logo3",
+              "gap": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "gQMTl",
+                  "name": "logoMark3",
+                  "width": 32,
+                  "height": 32,
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "radial",
+                    "enabled": true,
+                    "rotation": 0,
+                    "size": {
+                      "width": 1,
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#E0D4FF",
+                        "position": 0
+                      },
+                      {
+                        "color": "#7C3AED",
+                        "position": 1
+                      }
+                    ]
+                  },
+                  "cornerRadius": 16,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ypiNU",
+                      "name": "logoLetter3",
+                      "fill": "#FFFFFF",
+                      "content": "S",
+                      "fontFamily": "Sora",
+                      "fontSize": 15,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "5hxm1",
+                  "name": "logoText3",
+                  "fill": "#FFFFFF",
+                  "content": "SOLEUR",
+                  "fontFamily": "Sora",
+                  "fontSize": 15,
+                  "fontWeight": "700",
+                  "letterSpacing": 3
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "1qSef",
+              "name": "navLinks3",
+              "gap": 32,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "US2Va",
+                  "name": "navL13",
+                  "fill": "#8A8A8A",
+                  "content": "Platform",
+                  "fontFamily": "Inter",
+                  "fontSize": 14
+                },
+                {
+                  "type": "text",
+                  "id": "Oo2XU",
+                  "name": "navL23",
+                  "fill": "#8A8A8A",
+                  "content": "Docs",
+                  "fontFamily": "Inter",
+                  "fontSize": 14
+                },
+                {
+                  "type": "text",
+                  "id": "tYiUR",
+                  "name": "navL33",
+                  "fill": "#8A8A8A",
+                  "content": "Community",
+                  "fontFamily": "Inter",
+                  "fontSize": 14
+                },
+                {
+                  "type": "frame",
+                  "id": "3N1yO",
+                  "name": "navCta3",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#7C3AED",
+                        "position": 0
+                      },
+                      {
+                        "color": "#4F46E5",
+                        "position": 1
+                      }
+                    ]
+                  },
+                  "cornerRadius": 6,
+                  "padding": [
+                    10,
+                    24
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "51tNj",
+                      "name": "navCtaText3",
+                      "fill": "#FFFFFF",
+                      "content": "Get Started",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Z8T7F",
+          "name": "Hero",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 32,
+          "padding": [
+            100,
+            80,
+            80,
+            80
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Uiurv",
+              "name": "badge3",
+              "fill": "#7C3AED20",
+              "cornerRadius": 20,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#7C3AED40"
+              },
+              "gap": 8,
+              "padding": [
+                8,
+                20
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "LS7GQ",
+                  "name": "badgeDot3",
+                  "fill": "#A78BFA",
+                  "width": 8,
+                  "height": 8,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#A78BFA80",
+                    "blur": 10
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "vB8Zg",
+                  "name": "badgeText3",
+                  "fill": "#A78BFA",
+                  "content": "The Company-as-a-Service Platform",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "jMQs0",
+              "name": "headline3",
+              "fill": "#FFFFFF",
+              "textGrowth": "fixed-width",
+              "width": 900,
+              "content": "One Mind.\nUnlimited Scale.",
+              "lineHeight": 1.05,
+              "textAlign": "center",
+              "fontFamily": "Sora",
+              "fontSize": 72,
+              "fontWeight": "700",
+              "letterSpacing": -2
+            },
+            {
+              "type": "text",
+              "id": "9SLIy",
+              "name": "subline3",
+              "fill": "#8A8A8A",
+              "textGrowth": "fixed-width",
+              "width": 700,
+              "content": "Soleur collapses the friction between a startup idea and a billion-dollar outcome.\nThe full power of a thousand-person org, commanded by one.",
+              "lineHeight": 1.6,
+              "textAlign": "center",
+              "fontFamily": "Inter",
+              "fontSize": 18
+            },
+            {
+              "type": "frame",
+              "id": "y7N2h",
+              "name": "ctaRow3",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "CNcsd",
+                  "name": "ctaPrimary3",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#7C3AED",
+                        "position": 0
+                      },
+                      {
+                        "color": "#4F46E5",
+                        "position": 1
+                      }
+                    ]
+                  },
+                  "cornerRadius": 8,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#7C3AED40",
+                    "blur": 24
+                  },
+                  "padding": [
+                    16,
+                    40
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "8ywxC",
+                      "name": "ctaPrimaryText3",
+                      "fill": "#FFFFFF",
+                      "content": "Start Building",
+                      "fontFamily": "Inter",
+                      "fontSize": 15,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "L6bpI",
+                  "name": "ctaSecondary3",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#2A2A3A"
+                  },
+                  "padding": [
+                    16,
+                    40
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "siraI",
+                      "name": "ctaSecondaryText3",
+                      "fill": "#8A8A8A",
+                      "content": "Read the Docs",
+                      "fontFamily": "Inter",
+                      "fontSize": 15
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "fANWN",
+          "name": "div3",
+          "width": "fill_container",
+          "height": 1,
+          "fill": "#2A2A3A"
+        },
+        {
+          "type": "frame",
+          "id": "MyUCH",
+          "name": "Color Palette",
+          "width": "fill_container",
+          "gap": 24,
+          "padding": [
+            40,
+            80
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "75UDN",
+              "name": "palLbl3",
+              "fill": "#8A8A8A",
+              "content": "PALETTE",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "700",
+              "letterSpacing": 2
+            },
+            {
+              "type": "frame",
+              "id": "HSNcu",
+              "name": "s3w1",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "CCSqi",
+                  "name": "s3w1c",
+                  "fill": "#0C0C14",
+                  "width": 64,
+                  "height": 40,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#2A2A3A"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "UEEbj",
+                  "name": "s3w1t",
+                  "fill": "#8A8A8A",
+                  "content": "#0C0C14",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "JGPrM",
+              "name": "s3w2",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "wsvMk",
+                  "name": "s3w2c",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#7C3AED",
+                        "position": 0
+                      },
+                      {
+                        "color": "#4F46E5",
+                        "position": 1
+                      }
+                    ]
+                  },
+                  "width": 64,
+                  "height": 40
+                },
+                {
+                  "type": "text",
+                  "id": "PjJQj",
+                  "name": "s3w2t",
+                  "fill": "#8A8A8A",
+                  "content": "Violet→Indigo",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "K6tuI",
+              "name": "s3w3",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "ZTrpn",
+                  "name": "s3w3c",
+                  "fill": "#A78BFA",
+                  "width": 64,
+                  "height": 40
+                },
+                {
+                  "type": "text",
+                  "id": "NUtVk",
+                  "name": "s3w3t",
+                  "fill": "#8A8A8A",
+                  "content": "#A78BFA",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "0hkj6",
+              "name": "s3w4",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "L131r",
+                  "name": "s3w4c",
+                  "fill": "#FFFFFF",
+                  "width": 64,
+                  "height": 40
+                },
+                {
+                  "type": "text",
+                  "id": "zyPQj",
+                  "name": "s3w4t",
+                  "fill": "#8A8A8A",
+                  "content": "#FFFFFF",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "k5IQt",
+              "name": "s3w5",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "2nQSz",
+                  "name": "s3w5c",
+                  "fill": "#1A1A2E",
+                  "width": 64,
+                  "height": 40,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#2A2A3A"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "Fgg1M",
+                  "name": "s3w5t",
+                  "fill": "#8A8A8A",
+                  "content": "#1A1A2E",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "WHbLB",
+              "name": "typo3a",
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "fIFhN",
+                  "name": "typo3a1",
+                  "fill": "#FFFFFF",
+                  "content": "Sora — Headlines",
+                  "fontFamily": "Sora",
+                  "fontSize": 14,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "jxSps",
+                  "name": "typo3a2",
+                  "fill": "#8A8A8A",
+                  "content": "Inter — UI / Body",
+                  "fontFamily": "Inter",
+                  "fontSize": 12
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "62SZM",
+      "x": 4620,
+      "y": 0,
+      "name": "4 — Solar Radiance",
+      "width": 1440,
+      "fill": "#FFFAF0",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "GlJnc",
+          "name": "Nav",
+          "width": "fill_container",
+          "height": 72,
+          "padding": [
+            0,
+            80
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "uJPIe",
+              "name": "logo4",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "fH3n6",
+                  "name": "sunMark",
+                  "width": 40,
+                  "height": 40,
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "radial",
+                    "enabled": true,
+                    "rotation": 0,
+                    "size": {
+                      "width": 1,
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#FFF7ED",
+                        "position": 0
+                      },
+                      {
+                        "color": "#F59E0B",
+                        "position": 0.5
+                      },
+                      {
+                        "color": "#D97706",
+                        "position": 1
+                      }
+                    ]
+                  },
+                  "cornerRadius": 20,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#F59E0B60",
+                    "blur": 16
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "TQTun",
+                      "name": "sunCore",
+                      "fill": "#FFFFFF",
+                      "width": 16,
+                      "height": 16
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "Odd0H",
+                  "name": "logoText4",
+                  "fill": "#1C1917",
+                  "content": "Soleur",
+                  "fontFamily": "DM Sans",
+                  "fontSize": 20,
+                  "fontWeight": "700"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "PEete",
+              "name": "navLinks4",
+              "gap": 32,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "xeRLw",
+                  "name": "navL14",
+                  "fill": "#78716C",
+                  "content": "Platform",
+                  "fontFamily": "DM Sans",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "LYoCk",
+                  "name": "navL24",
+                  "fill": "#78716C",
+                  "content": "Docs",
+                  "fontFamily": "DM Sans",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "Zt8wI",
+                  "name": "navL34",
+                  "fill": "#78716C",
+                  "content": "Community",
+                  "fontFamily": "DM Sans",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "xPoXi",
+                  "name": "navCta4",
+                  "fill": "#1C1917",
+                  "cornerRadius": 24,
+                  "padding": [
+                    10,
+                    24
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ByqLq",
+                      "name": "navCtaText4",
+                      "fill": "#FFFFFF",
+                      "content": "Get Started",
+                      "fontFamily": "DM Sans",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "MsrzD",
+          "name": "Hero",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 40,
+          "padding": [
+            60,
+            80,
+            80,
+            80
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "O1ucb",
+              "name": "sunVisual",
+              "width": 200,
+              "height": 200,
+              "fill": {
+                "type": "gradient",
+                "gradientType": "radial",
+                "enabled": true,
+                "rotation": 0,
+                "size": {
+                  "width": 1,
+                  "height": 1
+                },
+                "colors": [
+                  {
+                    "color": "#FFFBEB",
+                    "position": 0
+                  },
+                  {
+                    "color": "#FCD34D",
+                    "position": 0.3
+                  },
+                  {
+                    "color": "#F59E0B",
+                    "position": 0.6
+                  },
+                  {
+                    "color": "#D97706",
+                    "position": 0.85
+                  },
+                  {
+                    "color": "#92400E30",
+                    "position": 1
+                  }
+                ]
+              },
+              "cornerRadius": 100,
+              "effect": [
+                {
+                  "type": "shadow",
+                  "shadowType": "outer",
+                  "color": "#F59E0B40",
+                  "blur": 80,
+                  "spread": 20
+                },
+                {
+                  "type": "shadow",
+                  "shadowType": "outer",
+                  "color": "#FCD34D20",
+                  "blur": 160,
+                  "spread": 40
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "rRzP1",
+              "name": "headline4",
+              "fill": "#1C1917",
+              "textGrowth": "fixed-width",
+              "width": 900,
+              "content": "One Source of Light.\nEndless Reach.",
+              "lineHeight": 1.1,
+              "textAlign": "center",
+              "fontFamily": "DM Sans",
+              "fontSize": 64,
+              "fontWeight": "800",
+              "letterSpacing": -2
+            },
+            {
+              "type": "text",
+              "id": "TDC1i",
+              "name": "subline4",
+              "fill": "#78716C",
+              "textGrowth": "fixed-width",
+              "width": 680,
+              "content": "Soleur is the Company-as-a-Service platform for solo founders.\nThe full power of a thousand-person org, radiating from one.",
+              "lineHeight": 1.6,
+              "textAlign": "center",
+              "fontFamily": "DM Sans",
+              "fontSize": 18
+            },
+            {
+              "type": "frame",
+              "id": "h7Ta1",
+              "name": "ctaRow4",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "6tRw2",
+                  "name": "ctaPrimary4",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#F59E0B",
+                        "position": 0
+                      },
+                      {
+                        "color": "#D97706",
+                        "position": 1
+                      }
+                    ]
+                  },
+                  "cornerRadius": 28,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#F59E0B50",
+                    "blur": 20
+                  },
+                  "padding": [
+                    16,
+                    40
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "8ITVC",
+                      "name": "ctaPrimaryText4",
+                      "fill": "#FFFFFF",
+                      "content": "Start Building",
+                      "fontFamily": "DM Sans",
+                      "fontSize": 15,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "S8xj2",
+                  "name": "ctaSecondary4",
+                  "cornerRadius": 28,
+                  "stroke": {
+                    "thickness": 1.5,
+                    "fill": "#D6D3D1"
+                  },
+                  "padding": [
+                    16,
+                    40
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "WZtT1",
+                      "name": "ctaSecondaryText4",
+                      "fill": "#78716C",
+                      "content": "Read the Docs",
+                      "fontFamily": "DM Sans",
+                      "fontSize": 15,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "fjXeB",
+          "name": "div4",
+          "width": "fill_container",
+          "height": 1,
+          "fill": "#E7E5E4"
+        },
+        {
+          "type": "frame",
+          "id": "S6FDx",
+          "name": "Color Palette",
+          "width": "fill_container",
+          "gap": 24,
+          "padding": [
+            40,
+            80
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "PLUkk",
+              "name": "palLbl4",
+              "fill": "#A8A29E",
+              "content": "PALETTE",
+              "fontFamily": "DM Sans",
+              "fontSize": 11,
+              "fontWeight": "700",
+              "letterSpacing": 2
+            },
+            {
+              "type": "frame",
+              "id": "syynQ",
+              "name": "s4w1",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "ZFx8f",
+                  "name": "s4w1c",
+                  "fill": "#FFFAF0",
+                  "width": 64,
+                  "height": 40,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E7E5E4"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "GIVeY",
+                  "name": "s4w1t",
+                  "fill": "#A8A29E",
+                  "content": "#FFFAF0",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "bMB95",
+              "name": "s4w2",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "jA8pd",
+                  "name": "s4w2c",
+                  "fill": "#F59E0B",
+                  "width": 64,
+                  "height": 40
+                },
+                {
+                  "type": "text",
+                  "id": "mYhuu",
+                  "name": "s4w2t",
+                  "fill": "#A8A29E",
+                  "content": "#F59E0B",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "4V6OL",
+              "name": "s4w3",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "40ySR",
+                  "name": "s4w3c",
+                  "fill": "#D97706",
+                  "width": 64,
+                  "height": 40
+                },
+                {
+                  "type": "text",
+                  "id": "MWNxl",
+                  "name": "s4w3t",
+                  "fill": "#A8A29E",
+                  "content": "#D97706",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "2YPrL",
+              "name": "s4w4",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "kYD4s",
+                  "name": "s4w4c",
+                  "fill": "#1C1917",
+                  "width": 64,
+                  "height": 40
+                },
+                {
+                  "type": "text",
+                  "id": "bCFXQ",
+                  "name": "s4w4t",
+                  "fill": "#A8A29E",
+                  "content": "#1C1917",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "DUXf2",
+              "name": "s4w5",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "DaCME",
+                  "name": "s4w5c",
+                  "fill": "#FCD34D",
+                  "width": 64,
+                  "height": 40
+                },
+                {
+                  "type": "text",
+                  "id": "gZbBe",
+                  "name": "s4w5t",
+                  "fill": "#A8A29E",
+                  "content": "#FCD34D",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "AVm5Y",
+              "name": "typo4a",
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "zxmqV",
+                  "name": "typo4a1",
+                  "fill": "#1C1917",
+                  "content": "DM Sans — All type",
+                  "fontFamily": "DM Sans",
+                  "fontSize": 14,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "wCSdZ",
+                  "name": "typo4a2",
+                  "fill": "#78716C",
+                  "content": "Warm, geometric, humanist",
+                  "fontFamily": "DM Sans",
+                  "fontSize": 12
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "w1G4s",
+      "x": 0,
+      "y": 3811,
+      "name": "Logo Explorations — Solar Forge",
+      "width": 1440,
+      "fill": "#0A0A0A",
+      "layout": "vertical",
+      "gap": 48,
+      "padding": [
+        48,
+        80
+      ],
+      "children": [
+        {
+          "type": "text",
+          "id": "GKiZ9",
+          "name": "logosTitle",
+          "fill": "#FFFFFF",
+          "content": "Logo Explorations",
+          "fontFamily": "Cormorant Garamond",
+          "fontSize": 32,
+          "fontWeight": "500"
+        },
+        {
+          "type": "frame",
+          "id": "tU4kM",
+          "name": "logosRow",
+          "width": "fill_container",
+          "gap": 80,
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "fyJZx",
+              "name": "v1",
+              "layout": "vertical",
+              "gap": 20,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "2lQOb",
+                  "name": "v1label",
+                  "fill": "#848484",
+                  "content": "A — Bordered Square",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 2
+                },
+                {
+                  "type": "frame",
+                  "id": "ZSHKN",
+                  "name": "v1mark",
+                  "width": 80,
+                  "height": 80,
+                  "stroke": {
+                    "thickness": 2,
+                    "fill": "#C9A962"
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "3GKOV",
+                      "name": "v1letter",
+                      "fill": "#C9A962",
+                      "content": "S",
+                      "fontFamily": "Cormorant Garamond",
+                      "fontSize": 44,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "K222q",
+                  "name": "v1word",
+                  "fill": "#FFFFFF",
+                  "content": "SOLEUR",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 4
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "MuhfV",
+              "name": "v2",
+              "layout": "vertical",
+              "gap": 20,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "woEpz",
+                  "name": "v2label",
+                  "fill": "#848484",
+                  "content": "B — Gold Circle",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 2
+                },
+                {
+                  "type": "frame",
+                  "id": "uY5RN",
+                  "name": "v2mark",
+                  "width": 80,
+                  "height": 80,
+                  "cornerRadius": 40,
+                  "stroke": {
+                    "thickness": 2,
+                    "fill": "#C9A962"
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "j8MwV",
+                      "name": "v2letter",
+                      "fill": "#C9A962",
+                      "content": "S",
+                      "fontFamily": "Cormorant Garamond",
+                      "fontSize": 44,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "FnjSL",
+                  "name": "v2word",
+                  "fill": "#FFFFFF",
+                  "content": "SOLEUR",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 4
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "eT8LY",
+              "name": "v3",
+              "layout": "vertical",
+              "gap": 20,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "lGbT3",
+                  "name": "v3label",
+                  "fill": "#848484",
+                  "content": "C — Filled Gold",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 2
+                },
+                {
+                  "type": "frame",
+                  "id": "FOjL4",
+                  "name": "v3mark",
+                  "width": 80,
+                  "height": 80,
+                  "fill": "#C9A962",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "RJgca",
+                      "name": "v3letter",
+                      "fill": "#0A0A0A",
+                      "content": "S",
+                      "fontFamily": "Cormorant Garamond",
+                      "fontSize": 44,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "EFNI2",
+                  "name": "v3word",
+                  "fill": "#FFFFFF",
+                  "content": "SOLEUR",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 4
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "IbMuU",
+              "name": "v4",
+              "layout": "vertical",
+              "gap": 20,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "mQqhF",
+                  "name": "v4label",
+                  "fill": "#848484",
+                  "content": "D — Solar Glow",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 2
+                },
+                {
+                  "type": "frame",
+                  "id": "21R9v",
+                  "name": "v4mark",
+                  "width": 80,
+                  "height": 80,
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "radial",
+                    "enabled": true,
+                    "rotation": 0,
+                    "size": {
+                      "width": 1,
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#FFFBEB",
+                        "position": 0
+                      },
+                      {
+                        "color": "#C9A962",
+                        "position": 0.6
+                      },
+                      {
+                        "color": "#8B6914",
+                        "position": 1
+                      }
+                    ]
+                  },
+                  "cornerRadius": 40,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#C9A96260",
+                    "blur": 32
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "eZjTm",
+                      "name": "v4letter",
+                      "fill": "#0A0A0A",
+                      "content": "S",
+                      "fontFamily": "Cormorant Garamond",
+                      "fontSize": 44,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "Gb7Au",
+                  "name": "v4word",
+                  "fill": "#FFFFFF",
+                  "content": "SOLEUR",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 4
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "28CdU",
+              "name": "v5",
+              "layout": "vertical",
+              "gap": 20,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "1Eyhe",
+                  "name": "v5label",
+                  "fill": "#848484",
+                  "content": "E — Monogram",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 2
+                },
+                {
+                  "type": "text",
+                  "id": "6ODGK",
+                  "name": "v5mark",
+                  "fill": "#C9A962",
+                  "content": "S",
+                  "lineHeight": 0.9,
+                  "fontFamily": "Cormorant Garamond",
+                  "fontSize": 80,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "pwR1K",
+                  "name": "v5word",
+                  "fill": "#FFFFFF",
+                  "content": "SOLEUR",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 4
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "fEGnr",
+          "name": "divider",
+          "width": 1440,
+          "height": 1,
+          "fill": "#2A2A2A"
+        },
+        {
+          "type": "frame",
+          "id": "Jv8Tw",
+          "name": "Color Palette",
+          "width": 1440,
+          "gap": 24,
+          "padding": [
+            40,
+            80
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "vTC38",
+              "name": "palLabel",
+              "fill": "#848484",
+              "content": "PALETTE",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "700",
+              "letterSpacing": 2
+            },
+            {
+              "type": "frame",
+              "id": "u4pWG",
+              "name": "sw1",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "pPTw2",
+                  "name": "sw1c",
+                  "fill": "#0A0A0A",
+                  "width": 64,
+                  "height": 40,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#2A2A2A"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "A761G",
+                  "name": "sw1t",
+                  "fill": "#848484",
+                  "content": "#0A0A0A",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "A8dpw",
+              "name": "sw2",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "yM0hf",
+                  "name": "sw2c",
+                  "fill": "#C9A962",
+                  "width": 64,
+                  "height": 40
+                },
+                {
+                  "type": "text",
+                  "id": "yl0gF",
+                  "name": "sw2t",
+                  "fill": "#848484",
+                  "content": "#C9A962",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "RHK3J",
+              "name": "sw3",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "ga5Cg",
+                  "name": "sw3c",
+                  "fill": "#FFFFFF",
+                  "width": 64,
+                  "height": 40
+                },
+                {
+                  "type": "text",
+                  "id": "KWNLl",
+                  "name": "sw3t",
+                  "fill": "#848484",
+                  "content": "#FFFFFF",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "BX8ED",
+              "name": "sw4",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "2mN5V",
+                  "name": "sw4c",
+                  "fill": "#141414",
+                  "width": 64,
+                  "height": 40,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#2A2A2A"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "TKno6",
+                  "name": "sw4t",
+                  "fill": "#848484",
+                  "content": "#141414",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "sjlXt",
+              "name": "sw5",
+              "layout": "vertical",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "7lvBc",
+                  "name": "sw5c",
+                  "fill": "#2A2A2A",
+                  "width": 64,
+                  "height": 40
+                },
+                {
+                  "type": "text",
+                  "id": "Ir7hi",
+                  "name": "sw5t",
+                  "fill": "#848484",
+                  "content": "#2A2A2A",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "kp6RU",
+              "name": "typo",
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "6qIri",
+                  "name": "typo1",
+                  "fill": "#FFFFFF",
+                  "content": "Cormorant Garamond — Headlines",
+                  "fontFamily": "Cormorant Garamond",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "kd7PB",
+                  "name": "typo2",
+                  "fill": "#848484",
+                  "content": "Inter — UI / Body",
+                  "fontFamily": "Inter",
+                  "fontSize": 12
+                },
+                {
+                  "type": "text",
+                  "id": "mmhsn",
+                  "name": "typo3",
+                  "fill": "#848484",
+                  "content": "JetBrains Mono — Data",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 12
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "g31nK",
+      "x": 0,
+      "y": 4482,
+      "name": "Logo Variations",
+      "width": 1440,
+      "fill": "#0A0A0A",
+      "layout": "vertical",
+      "gap": 48,
+      "padding": [
+        48,
+        80
+      ],
+      "children": [
+        {
+          "type": "text",
+          "id": "uWefL",
+          "name": "title",
+          "fill": "#FFFFFF",
+          "content": "Logo Variations",
+          "fontFamily": "Cormorant Garamond",
+          "fontSize": 32,
+          "fontWeight": "500"
+        },
+        {
+          "type": "frame",
+          "id": "mPAG5",
+          "name": "row1",
+          "gap": 40,
+          "children": [
+            {
+              "type": "frame",
+              "id": "ZASIU",
+              "name": "faviconGroup",
+              "layout": "vertical",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "rVsCs",
+                  "name": "favLabel",
+                  "fill": "#848484",
+                  "content": "Favicon",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 2
+                },
+                {
+                  "type": "frame",
+                  "id": "NXCZM",
+                  "name": "favicon",
+                  "width": 64,
+                  "height": 64,
+                  "fill": "#0A0A0A",
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#2A2A2A"
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "MUkon",
+                      "name": "favMark",
+                      "width": 36,
+                      "height": 36,
+                      "cornerRadius": 18,
+                      "stroke": {
+                        "thickness": 1.5,
+                        "fill": "#C9A962"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ffAH3",
+                          "name": "favS",
+                          "fill": "#C9A962",
+                          "content": "S",
+                          "fontFamily": "Cormorant Garamond",
+                          "fontSize": 20,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "MQ01C",
+                  "name": "favSize",
+                  "fill": "#6A6A6A",
+                  "content": "32x32 / 64x64",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "q00ap",
+              "name": "avatarGroup",
+              "layout": "vertical",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Hxrj9",
+                  "name": "avLabel",
+                  "fill": "#848484",
+                  "content": "Square Avatar",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 2
+                },
+                {
+                  "type": "frame",
+                  "id": "joReW",
+                  "name": "avatar",
+                  "width": 160,
+                  "height": 160,
+                  "fill": "#0A0A0A",
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#2A2A2A"
+                  },
+                  "layout": "vertical",
+                  "gap": 12,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "tSYON",
+                      "name": "avMark",
+                      "width": 56,
+                      "height": 56,
+                      "cornerRadius": 28,
+                      "stroke": {
+                        "thickness": 2,
+                        "fill": "#C9A962"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "vSseW",
+                          "name": "avS",
+                          "fill": "#C9A962",
+                          "content": "S",
+                          "fontFamily": "Cormorant Garamond",
+                          "fontSize": 32,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "lMqav",
+                      "name": "avName",
+                      "fill": "#FFFFFF",
+                      "content": "SOLEUR",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500",
+                      "letterSpacing": 4
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "UH5Gs",
+                  "name": "avSize",
+                  "fill": "#6A6A6A",
+                  "content": "512x512",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "v7AcB",
+              "name": "markGroup",
+              "layout": "vertical",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "E4swL",
+                  "name": "mkLabel",
+                  "fill": "#848484",
+                  "content": "Mark Only",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 2
+                },
+                {
+                  "type": "frame",
+                  "id": "zLrMg",
+                  "name": "markOnly",
+                  "width": 120,
+                  "height": 120,
+                  "fill": "#0A0A0A",
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#2A2A2A"
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "XblDg",
+                      "name": "mkCircle",
+                      "width": 72,
+                      "height": 72,
+                      "cornerRadius": 36,
+                      "stroke": {
+                        "thickness": 2,
+                        "fill": "#C9A962"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "PO2k3",
+                          "name": "mkS",
+                          "fill": "#C9A962",
+                          "content": "S",
+                          "fontFamily": "Cormorant Garamond",
+                          "fontSize": 42,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "8wgpd",
+                  "name": "mkSize",
+                  "fill": "#6A6A6A",
+                  "content": "App icon / Watermark",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "aRdrv",
+          "name": "row2",
+          "gap": 40,
+          "children": [
+            {
+              "type": "frame",
+              "id": "5lpl2",
+              "name": "hDarkGroup",
+              "layout": "vertical",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "C18ka",
+                  "name": "hdLabel",
+                  "fill": "#848484",
+                  "content": "Horizontal — Dark BG",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 2
+                },
+                {
+                  "type": "frame",
+                  "id": "jUo5O",
+                  "name": "logoDark",
+                  "width": 360,
+                  "height": 120,
+                  "fill": "#0A0A0A",
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#2A2A2A"
+                  },
+                  "gap": 16,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "6dDfv",
+                      "name": "hdMark",
+                      "width": 44,
+                      "height": 44,
+                      "cornerRadius": 22,
+                      "stroke": {
+                        "thickness": 1.5,
+                        "fill": "#C9A962"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "wyvl4",
+                          "name": "hdS",
+                          "fill": "#C9A962",
+                          "content": "S",
+                          "fontFamily": "Cormorant Garamond",
+                          "fontSize": 26,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "ablsh",
+                      "name": "hdName",
+                      "fill": "#FFFFFF",
+                      "content": "SOLEUR",
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "500",
+                      "letterSpacing": 6
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Jl2xk",
+              "name": "hLightGroup",
+              "layout": "vertical",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "OMoEl",
+                  "name": "hlLabel",
+                  "fill": "#848484",
+                  "content": "Horizontal — Light BG",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 2
+                },
+                {
+                  "type": "frame",
+                  "id": "FZXUW",
+                  "name": "logoLight",
+                  "width": 360,
+                  "height": 120,
+                  "fill": "#FAFAFA",
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E0E0E0"
+                  },
+                  "gap": 16,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "LCqU1",
+                      "name": "hlMark",
+                      "width": 44,
+                      "height": 44,
+                      "cornerRadius": 22,
+                      "stroke": {
+                        "thickness": 1.5,
+                        "fill": "#0A0A0A"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "fUAAF",
+                          "name": "hlS",
+                          "fill": "#0A0A0A",
+                          "content": "S",
+                          "fontFamily": "Cormorant Garamond",
+                          "fontSize": 26,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "6IR8Q",
+                      "name": "hlName",
+                      "fill": "#0A0A0A",
+                      "content": "SOLEUR",
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "500",
+                      "letterSpacing": 6
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "kPvOr",
+          "name": "row3",
+          "gap": 40,
+          "children": [
+            {
+              "type": "frame",
+              "id": "TV48t",
+              "name": "ogGroup",
+              "layout": "vertical",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "FuItY",
+                  "name": "ogLabel",
+                  "fill": "#848484",
+                  "content": "Social Preview / OG Image",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 2
+                },
+                {
+                  "type": "frame",
+                  "id": "GkxG2",
+                  "name": "ogImage",
+                  "width": 600,
+                  "height": 315,
+                  "fill": "#0A0A0A",
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#2A2A2A"
+                  },
+                  "layout": "vertical",
+                  "gap": 20,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "V1rjh",
+                      "name": "ogMark",
+                      "width": 56,
+                      "height": 56,
+                      "cornerRadius": 28,
+                      "stroke": {
+                        "thickness": 2,
+                        "fill": "#C9A962"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "r56K7",
+                          "name": "ogS",
+                          "fill": "#C9A962",
+                          "content": "S",
+                          "fontFamily": "Cormorant Garamond",
+                          "fontSize": 32,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "q8Pqz",
+                      "name": "ogName",
+                      "fill": "#FFFFFF",
+                      "content": "SOLEUR",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "500",
+                      "letterSpacing": 8
+                    },
+                    {
+                      "type": "text",
+                      "id": "OExO7",
+                      "name": "ogTag",
+                      "fill": "#848484",
+                      "content": "The Company-as-a-Service Platform",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "flt3E",
+                  "name": "ogSize",
+                  "fill": "#6A6A6A",
+                  "content": "1200x630",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/knowledge-base/learnings/2026-02-14-pencil-mcp-local-binary-constraint.md
+++ b/knowledge-base/learnings/2026-02-14-pencil-mcp-local-binary-constraint.md
@@ -1,0 +1,23 @@
+# Learning: Pencil MCP is a Local Binary, Not a Bundleable Service
+
+## Problem
+
+When planning to bundle the Pencil MCP server in plugin.json mcpServers (like context7 which uses HTTP), we discovered that Pencil MCP is a local stdio binary bundled with the IDE extension (VS Code/Cursor). There is no npm package, no HTTP endpoint, and no way to reference it portably in plugin.json.
+
+## Solution
+
+Instead of trying to bundle Pencil MCP:
+1. Document it as an optional dependency in the README
+2. Have the agent check for tool availability and degrade gracefully with a clear error message
+3. Link to installation docs: https://docs.pencil.dev/getting-started/installation
+
+The agent's Prerequisites section checks if `mcp__pencil__*` tools are available and stops with installation instructions if not.
+
+## Key Insight
+
+Not all MCP servers can be distributed via plugin.json. HTTP servers (like context7) can be bundled. Stdio servers that depend on IDE extensions cannot -- they require separate installation. When designing agents that depend on external MCP tools, always include a graceful degradation path and clear installation instructions.
+
+## Tags
+category: integration-issues
+module: plugin-architecture
+symptoms: MCP server cannot be bundled in plugin.json

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -81,6 +81,7 @@ Project principles organized by domain. Add principles as you learn them.
 - When one agent/skill produces a structured document consumed by others, define a heading-level contract (exact `##` names, required/optional flags) in the producer -- consumers parse by heading name, not by position
 - Route users to specialized agents through existing commands (e.g., brainstorm routes to brand-architect) rather than creating new entry points -- keeps the user workflow unified and avoids proliferating slash commands
 - Inventory component counts and descriptions from source file frontmatter rather than hardcoding -- docs stay accurate when the same files the plugin loader reads are the source of truth
+- Agents that depend on external MCP servers (stdio binaries from IDE extensions) must include a graceful degradation check -- only HTTP MCP servers can be bundled in plugin.json; stdio servers require separate installation and the agent must detect unavailability and stop with clear installation instructions
 
 ## Testing
 

--- a/knowledge-base/plans/archive/20260214-133317-2026-02-14-feat-ux-design-lead-plan.md
+++ b/knowledge-base/plans/archive/20260214-133317-2026-02-14-feat-ux-design-lead-plan.md
@@ -1,0 +1,116 @@
+---
+title: UX Design Lead Agent + Pencil MCP Integration
+type: feat
+date: 2026-02-14
+---
+
+# UX Design Lead Agent + Pencil MCP Integration
+
+[Updated 2026-02-14 after plan review -- simplified from 5 phases to 2, agent workflow from 6 steps to 3]
+
+## Overview
+
+Add a `ux-design-lead` agent that creates visual designs in .pen files using Pencil MCP tools. Also commit missing PR #82 artifacts and add a minimal handoff suggestion in the brainstorm command.
+
+## Problem Statement
+
+Soleur has no dedicated agent for visual design work. The brand-architect handles text-based brand identity. The frontend-design skill generates code. There is a gap between brand strategy and code where visual design exploration should happen. PR #82 left .pen design files and playwright session data untracked.
+
+## Proposed Solution
+
+### Phase 1: Agent + Housekeeping
+
+**1.1 Create agent file**
+
+File: `plugins/soleur/agents/design/ux-design-lead.md`
+
+New top-level `design/` domain directory. The plugin loader discovers agents recursively -- no config changes needed. Target size: ~50-60 lines (comparable to ddd-architect at 95 lines, but sharper).
+
+**Frontmatter:**
+
+```yaml
+---
+name: ux-design-lead
+description: "Use this agent when you need to create visual designs in .pen files using Pencil MCP tools. It handles wireframes, high-fidelity screens, and component design, optionally using brand-guide.md for design tokens. <example>Context: The user wants to create a landing page wireframe after defining their brand identity.\nuser: \"I want to create a visual design for the landing page based on our brand guide.\"\nassistant: \"I'll use the ux-design-lead agent to create a .pen design using the brand tokens from your brand guide.\"\n<commentary>\nThe user wants visual design artifacts (.pen files), not code. The ux-design-lead handles Pencil MCP design work.\n</commentary>\n</example>\n\n<example>\nContext: The user wants to explore screen layouts for a new feature.\nuser: \"Design the onboarding flow screens -- I need wireframes for the 3-step signup.\"\nassistant: \"I'll launch the ux-design-lead agent to create wireframe designs in .pen format.\"\n<commentary>\nScreen design and wireframing in .pen files is the core use case for ux-design-lead.\n</commentary>\n</example>"
+model: inherit
+---
+```
+
+**Agent workflow (3 steps, sharp edges only):**
+
+1. **Design Brief** -- Check if `knowledge-base/overview/brand-guide.md` exists. If found, read `## Visual Direction` and extract color palette, typography, and style as primary design constraints. Use AskUserQuestion to clarify:
+   - **Scope:** Single screen / Multi-screen flow / Component
+   - **Platform:** Desktop / Mobile / Both
+   - **Fidelity:** Wireframe / High-fidelity
+
+2. **Design** -- Call `get_style_guide_tags` + `get_style_guide(tags)` for inspiration. Call `get_guidelines(topic)` for the design type (landing-page, design-system, table). Use `open_document` to create or open a .pen file. Iterative loop: `batch_design` to build, `get_screenshot` to check, adjust until correct. Use `snapshot_layout(problemsOnly=true)` to catch layout issues.
+
+3. **Deliver** -- Present final `get_screenshot` to user. Save .pen file to `knowledge-base/design/{domain}/{descriptive-name}.pen` (e.g., `design/brand/landing-page.pen`, `design/onboarding/signup-flow.pen`). Announce file location.
+
+**Graceful degradation:** If Pencil MCP tools are unavailable, inform the user that the Pencil extension (VS Code/Cursor) is required and stop. Link: https://docs.pencil.dev/getting-started/installation
+
+**1.2 Housekeeping (included in same commit)**
+
+- Add `.playwright-mcp/` to `.gitignore`
+- Stage `knowledge-base/design/brand/brand-visual-identity-brainstorm.pen` for tracking
+
+**1.3 Minimal brainstorm handoff**
+
+File: `plugins/soleur/commands/soleur/brainstorm.md`
+
+In Phase 4 (Handoff) AskUserQuestion options, add one option: "Create visual designs -- Run ux-design-lead agent for .pen file design". This is a suggestion, not a routing block. No changes to Phase 0.5 brand routing.
+
+### Phase 2: Version Bump + Documentation
+
+**Version:** MINOR bump (2.7.0 -> 2.8.0) -- new agent + new domain directory.
+
+Update atomically:
+1. `plugins/soleur/.claude-plugin/plugin.json` -- version to 2.8.0, update description (24 -> 25 agents)
+2. `plugins/soleur/CHANGELOG.md` -- new `## [2.8.0]` entry
+3. `plugins/soleur/README.md`:
+   - Agent count 24 -> 25 in components table
+   - Add `### Design (1)` section under Agents with ux-design-lead row
+   - Add Pencil as optional dependency note (one line: "The `ux-design-lead` agent requires the [Pencil extension](https://docs.pencil.dev/getting-started/installation) installed in VS Code or Cursor.")
+4. Root `README.md` -- version badge if present
+5. `.github/ISSUE_TEMPLATE/bug_report.yml` -- version placeholder if present
+6. `plugins/soleur/docs/pages/agents.html` -- add Design category with ux-design-lead
+7. Grep HTML docs for hardcoded version strings and update
+
+## Non-Goals
+
+- Modifying brand-architect's core workflow
+- Generating code from .pen designs (frontend-design skill's job)
+- Full design system creation
+- Adding .pen convention to constitution (deferred until enforcement exists)
+- Full brainstorm routing block for design (v2 if users request it)
+
+## Acceptance Criteria
+
+- [x] `plugins/soleur/agents/design/ux-design-lead.md` exists with frontmatter (2+ examples), 3-step workflow
+- [x] Agent reads brand-guide.md `## Visual Direction` when available
+- [x] Agent warns and stops when Pencil MCP is unavailable
+- [x] Brainstorm Phase 4 includes ux-design-lead as a handoff option
+- [x] `.playwright-mcp/` in .gitignore, .pen file tracked
+- [x] Version bump to 2.8.0 across plugin.json, CHANGELOG.md, README.md
+
+## Test Scenarios
+
+- Given Pencil MCP is available and brand-guide.md exists, when ux-design-lead is invoked with "create a landing page wireframe", then it reads brand tokens and creates a .pen file in `knowledge-base/design/`
+- Given Pencil MCP is NOT available, when ux-design-lead is invoked, then it warns the user to install the Pencil extension and stops
+- Given the .gitignore is updated, when `.playwright-mcp/` files are created during a session, then they are not tracked by git
+
+## Dependencies & Risks
+
+- **Pencil MCP availability:** Agent requires Pencil extension. Mitigated by clear error message.
+- **Brand guide format:** Depends on exact `## Visual Direction` heading. Already enforced by brand-architect's contract.
+- **Plugin loader:** New `agents/design/` directory should auto-discover. Verify empirically.
+
+## References
+
+- Brainstorm: `knowledge-base/brainstorms/2026-02-14-ux-design-lead-brainstorm.md`
+- Spec: `knowledge-base/specs/feat-ux-design-lead/spec.md`
+- Issue: #87
+- Brand-architect pattern: `plugins/soleur/agents/marketing/brand-architect.md`
+- DDD-architect pattern: `plugins/soleur/agents/engineering/design/ddd-architect.md`
+- Pencil docs: https://docs.pencil.dev/getting-started/installation
+- Learning - agent prompts: `knowledge-base/learnings/agent-prompt-sharp-edges-only.md`

--- a/knowledge-base/specs/archive/20260214-133317-feat-ux-design-lead/spec.md
+++ b/knowledge-base/specs/archive/20260214-133317-feat-ux-design-lead/spec.md
@@ -1,0 +1,60 @@
+# feat: UX Design Lead Agent + Pencil MCP Integration
+
+**Issue:** #87
+**Branch:** feat-ux-design-lead
+**Brainstorm:** [2026-02-14-ux-design-lead-brainstorm.md](../../brainstorms/2026-02-14-ux-design-lead-brainstorm.md)
+
+## Problem Statement
+
+PR #82 (brand identity) left design artifacts untracked (.pen files, playwright session data). More broadly, Soleur has no dedicated agent for visual design work. The brand-architect handles brand identity but doesn't create visual designs. The frontend-design skill generates code but doesn't produce design artifacts. There's a gap between brand strategy and code implementation where visual design exploration should happen.
+
+## Goals
+
+- G1: Commit missing design artifacts from PR #82 and establish conventions for .pen files
+- G2: Bundle the Pencil MCP server so design tools are available out of the box
+- G3: Create a ux-design-lead agent that handles the full UX design workflow in .pen files
+- G4: Chain brand-architect -> ux-design-lead in the brainstorm brand routing
+
+## Non-Goals
+
+- Modifying brand-architect's core text-based workflow
+- Generating code from .pen designs (frontend-design skill's responsibility)
+- Building a full design system (future work)
+- Automated design review capabilities
+
+## Functional Requirements
+
+- FR1: `.playwright-mcp/` added to .gitignore
+- FR2: `knowledge-base/design/brand/brand-visual-identity-brainstorm.pen` committed
+- FR3: Constitution updated with .pen file directory convention (`knowledge-base/design/{domain}/`)
+- FR4: Pencil MCP server added to `plugin.json` mcpServers
+- FR5: New `agents/design/ux-design-lead.md` agent file with full UX workflow instructions
+- FR6: Brainstorm command updated to chain brand-architect -> ux-design-lead
+
+## Technical Requirements
+
+- TR1: Agent uses Pencil MCP tools (get_guidelines, get_style_guide, batch_design, get_screenshot)
+- TR2: Agent reads brand-guide.md for color/typography decisions when available
+- TR3: .pen files follow naming convention: `{descriptive-name}.pen` within domain directories
+- TR4: Plugin version bumped (MINOR -- new agent + MCP server)
+- TR5: CHANGELOG.md, README.md, plugin.json all updated
+
+## Implementation Notes
+
+### Agent Capabilities (ux-design-lead)
+
+The agent should handle:
+1. **Wireframes** -- Low-fidelity layout exploration
+2. **Visual design** -- High-fidelity screens using brand colors/typography
+3. **Design system components** -- Reusable components in .pen format
+4. **Design validation** -- Screenshot-based visual QA
+
+### Pencil MCP Server Config
+
+Add to plugin.json mcpServers alongside context7. Reference the pencil.dev MCP endpoint.
+
+### Brainstorm Chain
+
+In `commands/soleur/brainstorm.md`, after brand-architect completes:
+- Ask user: "Would you like to explore visual design based on this brand identity?"
+- If yes, spawn ux-design-lead with the brand-guide.md context

--- a/knowledge-base/specs/archive/20260214-133317-feat-ux-design-lead/tasks.md
+++ b/knowledge-base/specs/archive/20260214-133317-feat-ux-design-lead/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: UX Design Lead Agent + Pencil MCP Integration
+
+**Issue:** #87
+**Plan:** [2026-02-14-feat-ux-design-lead-plan.md](../../plans/2026-02-14-feat-ux-design-lead-plan.md)
+
+## Phase 1: Agent + Housekeeping
+
+- [ ] 1.1 Create `plugins/soleur/agents/design/ux-design-lead.md` (~50-60 lines)
+  - [ ] 1.1.1 YAML frontmatter with 2 example blocks
+  - [ ] 1.1.2 3-step workflow: Design Brief, Design, Deliver
+  - [ ] 1.1.3 Graceful degradation when Pencil MCP unavailable
+- [ ] 1.2 Add `.playwright-mcp/` to `.gitignore`
+- [ ] 1.3 Stage `knowledge-base/design/brand/brand-visual-identity-brainstorm.pen`
+- [ ] 1.4 Add ux-design-lead as handoff option in brainstorm Phase 4
+
+## Phase 2: Version Bump + Documentation
+
+- [ ] 2.1 Bump `plugins/soleur/.claude-plugin/plugin.json` to 2.8.0, update description (25 agents)
+- [ ] 2.2 Add `## [2.8.0]` to `plugins/soleur/CHANGELOG.md`
+- [ ] 2.3 Update `plugins/soleur/README.md` (count 25, Design section, Pencil dependency note)
+- [ ] 2.4 Update `plugins/soleur/docs/pages/agents.html` with Design category
+- [ ] 2.5 Verify root README badge, bug report template, HTML docs version strings
+
+## Phase 3: Ship
+
+- [ ] 3.1 Verify plugin loader discovers `agents/design/ux-design-lead.md`
+- [ ] 3.2 Run code review on unstaged changes
+- [ ] 3.3 Run `/soleur:compound`
+- [ ] 3.4 Stage all artifacts, commit, push, create PR

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "soleur",
-  "version": "2.7.0",
-  "description": "AI-powered development tools for Claude Code that get smarter with every use. 24 agents, 8 commands, and 37 skills that compound your engineering knowledge over time.",
+  "version": "2.8.0",
+  "description": "AI-powered development tools for Claude Code that get smarter with every use. 25 agents, 8 commands, and 37 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",
     "email": "jean.deruelle@jikigai.com",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0] - 2026-02-14
+
+### Added
+
+- New `ux-design-lead` agent under `agents/design/` for visual design in .pen files using Pencil MCP
+- New `design/` top-level agent domain for cross-cutting visual design work
+- `knowledge-base/design/brand/` with .pen design file from brand identity brainstorm
+- Brainstorm command Phase 4 handoff now includes "Create visual designs" option
+- `.playwright-mcp/` added to .gitignore (ephemeral browser session artifacts)
+
 ## [2.7.0] - 2026-02-13
 
 ### Added

--- a/plugins/soleur/README.md
+++ b/plugins/soleur/README.md
@@ -106,7 +106,7 @@ Full autonomous engineering workflow that goes from plan to PR in a single comma
 
 | Component | Count |
 |-----------|-------|
-| Agents | 24 |
+| Agents | 25 |
 | Commands | 8 |
 | Skills | 37 |
 | MCP Servers | 1 |
@@ -120,6 +120,12 @@ Agents are organized by domain, then by function. Cross-domain agents stay at ro
 | Agent | Description |
 |-------|-------------|
 | `brand-architect` | Interactive brand identity workshop producing structured brand guides |
+
+### Design (1)
+
+| Agent | Description |
+|-------|-------------|
+| `ux-design-lead` | Visual design in .pen files using Pencil MCP (wireframes, screens, components). Requires [Pencil extension](https://docs.pencil.dev/getting-started/installation). |
 
 ### Engineering (16)
 

--- a/plugins/soleur/agents/design/ux-design-lead.md
+++ b/plugins/soleur/agents/design/ux-design-lead.md
@@ -1,0 +1,56 @@
+---
+name: ux-design-lead
+description: "Use this agent when you need to create visual designs in .pen files using Pencil MCP tools. It handles wireframes, high-fidelity screens, and component design, optionally reading brand-guide.md for design tokens. Requires the Pencil extension (VS Code/Cursor). <example>Context: The user wants to create a landing page design after defining their brand identity.\nuser: \"Create a visual design for our landing page based on the brand guide.\"\nassistant: \"I'll use the ux-design-lead agent to create a .pen design using the brand tokens from your brand guide.\"\n<commentary>\nThe user wants visual design artifacts (.pen files), not code. The ux-design-lead handles Pencil MCP design work.\n</commentary>\n</example>\n\n<example>\nContext: The user wants wireframes for a new feature's screens.\nuser: \"Design the onboarding flow -- I need wireframes for the 3-step signup.\"\nassistant: \"I'll launch the ux-design-lead agent to create wireframe designs in .pen format.\"\n<commentary>\nScreen design and wireframing in .pen files is the core use case for ux-design-lead.\n</commentary>\n</example>"
+model: inherit
+---
+
+A visual design agent that creates .pen files using Pencil MCP tools. It produces wireframes, high-fidelity screens, and components, optionally using brand identity tokens from brand-guide.md.
+
+## Prerequisites
+
+This agent requires the Pencil extension installed in VS Code or Cursor. If Pencil MCP tools (`mcp__pencil__batch_design`, `mcp__pencil__batch_get`, etc.) are unavailable, inform the user: "The Pencil extension is required for visual design. Install it from https://docs.pencil.dev/getting-started/installation" and stop.
+
+## Workflow
+
+### Step 1: Design Brief
+
+Check if `knowledge-base/overview/brand-guide.md` exists. If found, read the `## Visual Direction` section and extract color palette, typography, and style as primary design constraints.
+
+Use the **AskUserQuestion tool** to clarify the design scope:
+
+1. **Scope:** "What are you designing?"
+   - Single screen
+   - Multi-screen flow
+   - Component or pattern
+
+2. **Platform:** "What platform?"
+   - Desktop
+   - Mobile
+   - Both
+
+3. **Fidelity:** "What fidelity level?"
+   - Wireframe (layout and structure only)
+   - High-fidelity (final visual design with brand tokens)
+
+### Step 2: Design
+
+1. Call `get_style_guide_tags` then `get_style_guide(tags)` for design inspiration. If brand tokens were extracted in Step 1, use those as primary constraints.
+2. Call `get_guidelines(topic)` for the relevant design type (`landing-page`, `design-system`, or `table`).
+3. Use `open_document` to create a new .pen file or open an existing one.
+4. Iterative design loop:
+   - Use `batch_design` to build frames, components, and content
+   - Use `get_screenshot` to check visual output
+   - Use `snapshot_layout(problemsOnly=true)` to catch layout issues
+   - Adjust and repeat until the design is correct
+
+### Step 3: Deliver
+
+1. Present final `get_screenshot` to the user for approval.
+2. Save the .pen file to `knowledge-base/design/{domain}/{descriptive-name}.pen` (e.g., `design/brand/landing-page.pen`, `design/onboarding/signup-flow.pen`).
+3. Announce the file location.
+
+## Important Guidelines
+
+- Only use Pencil MCP tools for .pen file operations -- do not read .pen files with the Read tool
+- When brand-guide.md exists, the `## Visual Direction` section is the source of truth for colors, fonts, and style
+- Save all .pen files under `knowledge-base/design/{domain}/` organized by domain

--- a/plugins/soleur/commands/soleur/brainstorm.md
+++ b/plugins/soleur/commands/soleur/brainstorm.md
@@ -311,8 +311,9 @@ Use **AskUserQuestion tool** to present next steps:
 **Options:**
 
 1. **Proceed to planning** - Run `/soleur:plan` (will auto-detect this brainstorm)
-2. **Refine design further** - Continue exploring
-3. **Done for now** - Return later
+2. **Create visual designs** - Run ux-design-lead agent for .pen file design (requires Pencil extension)
+3. **Refine design further** - Continue exploring
+4. **Done for now** - Return later
 
 ## Output Summary
 

--- a/plugins/soleur/docs/404.html
+++ b/plugins/soleur/docs/404.html
@@ -16,7 +16,7 @@
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <header class="site-header">
-    <a href="index.html" class="logo">Soleur <span class="version-badge">v2.7.0</span></a>
+    <a href="index.html" class="logo">Soleur <span class="version-badge">v2.8.0</span></a>
     <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-hidden="true">
     <label for="nav-toggle" class="nav-toggle-label" aria-label="Toggle navigation">&#9776;</label>
     <ul class="nav-links">

--- a/plugins/soleur/docs/index.html
+++ b/plugins/soleur/docs/index.html
@@ -16,7 +16,7 @@
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <header class="site-header">
-    <a href="index.html" class="logo">Soleur <span class="version-badge">v2.7.0</span></a>
+    <a href="index.html" class="logo">Soleur <span class="version-badge">v2.8.0</span></a>
     <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-hidden="true">
     <label for="nav-toggle" class="nav-toggle-label" aria-label="Toggle navigation">&#9776;</label>
     <ul class="nav-links">
@@ -39,7 +39,7 @@
 
     <section class="stats-grid">
       <div class="stat-card">
-        <span class="stat-number">24</span>
+        <span class="stat-number">25</span>
         <span class="stat-label">Agents</span>
       </div>
       <div class="stat-card">

--- a/plugins/soleur/docs/pages/agents.html
+++ b/plugins/soleur/docs/pages/agents.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="24 specialized agents for code review, research, architecture, and workflow automation.">
+  <meta name="description" content="25 specialized agents for code review, research, architecture, design, and workflow automation.">
   <meta property="og:title" content="Agents - Soleur">
-  <meta property="og:description" content="24 specialized agents for code review, research, architecture, and workflow automation.">
+  <meta property="og:description" content="25 specialized agents for code review, research, architecture, design, and workflow automation.">
   <meta property="og:url" content="https://jikig-ai.github.io/soleur/pages/agents.html">
   <meta property="og:type" content="website">
   <base href="/soleur/">
@@ -16,7 +16,7 @@
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <header class="site-header">
-    <a href="index.html" class="logo">Soleur <span class="version-badge">v2.7.0</span></a>
+    <a href="index.html" class="logo">Soleur <span class="version-badge">v2.8.0</span></a>
     <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-hidden="true">
     <label for="nav-toggle" class="nav-toggle-label" aria-label="Toggle navigation">&#9776;</label>
     <ul class="nav-links">
@@ -35,7 +35,7 @@
     <section class="page-hero">
       <div class="container">
         <h1>Agents</h1>
-        <p>24 specialized agents for code review, research, architecture, and workflow automation.</p>
+        <p>25 specialized agents for code review, research, architecture, design, and workflow automation.</p>
       </div>
     </section>
 
@@ -47,6 +47,7 @@
         <a href="#research" class="category-pill">Research</a>
         <a href="#workflow" class="category-pill">Workflow</a>
         <a href="#marketing" class="category-pill">Marketing</a>
+        <a href="#design" class="category-pill">Design</a>
       </nav>
 
       <!-- Engineering / Review -->
@@ -297,6 +298,24 @@
             </div>
             <h3 class="card-title">brand-architect</h3>
             <p class="card-description">Interactive brand identity workshop</p>
+          </article>
+        </div>
+      </section>
+
+      <!-- Design -->
+      <section id="design" class="category-section">
+        <div class="category-header">
+          <h2 class="category-title">Design</h2>
+          <span class="category-count">1 agent</span>
+        </div>
+        <div class="catalog-grid">
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-design, var(--accent))"></span>
+              <span class="card-category">Design</span>
+            </div>
+            <h3 class="card-title">ux-design-lead</h3>
+            <p class="card-description">Visual design in .pen files using Pencil MCP (wireframes, screens, components)</p>
           </article>
         </div>
       </section>

--- a/plugins/soleur/docs/pages/changelog.html
+++ b/plugins/soleur/docs/pages/changelog.html
@@ -12,7 +12,7 @@
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <header class="site-header">
-    <a href="index.html" class="logo">Soleur <span class="version-badge">v2.7.0</span></a>
+    <a href="index.html" class="logo">Soleur <span class="version-badge">v2.8.0</span></a>
     <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-hidden="true">
     <label for="nav-toggle" class="nav-toggle-label" aria-label="Toggle navigation">&#9776;</label>
     <ul class="nav-links">

--- a/plugins/soleur/docs/pages/commands.html
+++ b/plugins/soleur/docs/pages/commands.html
@@ -16,7 +16,7 @@
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <header class="site-header">
-    <a href="index.html" class="logo">Soleur <span class="version-badge">v2.7.0</span></a>
+    <a href="index.html" class="logo">Soleur <span class="version-badge">v2.8.0</span></a>
     <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-hidden="true">
     <label for="nav-toggle" class="nav-toggle-label" aria-label="Toggle navigation">&#9776;</label>
     <ul class="nav-links">

--- a/plugins/soleur/docs/pages/getting-started.html
+++ b/plugins/soleur/docs/pages/getting-started.html
@@ -12,7 +12,7 @@
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <header class="site-header">
-    <a href="index.html" class="logo">Soleur <span class="version-badge">v2.7.0</span></a>
+    <a href="index.html" class="logo">Soleur <span class="version-badge">v2.8.0</span></a>
     <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-hidden="true">
     <label for="nav-toggle" class="nav-toggle-label" aria-label="Toggle navigation">&#9776;</label>
     <ul class="nav-links">

--- a/plugins/soleur/docs/pages/mcp-servers.html
+++ b/plugins/soleur/docs/pages/mcp-servers.html
@@ -12,7 +12,7 @@
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <header class="site-header">
-    <a href="index.html" class="logo">Soleur <span class="version-badge">v2.7.0</span></a>
+    <a href="index.html" class="logo">Soleur <span class="version-badge">v2.8.0</span></a>
     <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-hidden="true">
     <label for="nav-toggle" class="nav-toggle-label" aria-label="Toggle navigation">&#9776;</label>
     <ul class="nav-links">

--- a/plugins/soleur/docs/pages/skills.html
+++ b/plugins/soleur/docs/pages/skills.html
@@ -16,7 +16,7 @@
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <header class="site-header">
-    <a href="index.html" class="logo">Soleur <span class="version-badge">v2.7.0</span></a>
+    <a href="index.html" class="logo">Soleur <span class="version-badge">v2.8.0</span></a>
     <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-hidden="true">
     <label for="nav-toggle" class="nav-toggle-label" aria-label="Toggle navigation">&#9776;</label>
     <ul class="nav-links">


### PR DESCRIPTION
## Summary
- Add `ux-design-lead` agent under new `agents/design/` domain for visual design in .pen files using Pencil MCP
- Add `.playwright-mcp/` to `.gitignore` (ephemeral browser session artifacts from PR #82)
- Stage `knowledge-base/design/brand/brand-visual-identity-brainstorm.pen` (left untracked by PR #82)
- Add minimal brainstorm-to-design handoff option in Phase 4
- Version bump 2.7.0 -> 2.8.0 across all version references (plugin.json, CHANGELOG, READMEs, HTML docs, bug template)

Closes #87

## Test plan
- [ ] Verify `ux-design-lead` agent is discoverable by the plugin loader (agents recurse into subdirectories)
- [ ] Verify `.pen` file renders correctly in Pencil extension
- [ ] Verify `.playwright-mcp/` is excluded by `.gitignore`
- [ ] Verify brainstorm Phase 4 shows "Create visual designs" option
- [ ] Verify version badge shows v2.8.0 on GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)