### PR TITLE
feat: auto-run plan review in /soleur:plan workflow (v2.10.1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.10.0"
+      placeholder: "2.10.1"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.10.0-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.10.1-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "AI-powered development tools for Claude Code that get smarter with every use. 27 agents, 8 commands, and 37 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.1] - 2026-02-16
+
+### Changed
+
+- `/soleur:plan` now automatically runs plan review (DHH, Kieran, Simplicity reviewers) after plan generation instead of offering it as an optional post-generation choice
+
 ## [2.10.0] - 2026-02-16
 
 ### Added

--- a/plugins/soleur/commands/soleur/plan.md
+++ b/plugins/soleur/commands/soleur/plan.md
@@ -600,27 +600,41 @@ fi
 
 - Plan saved to `knowledge-base/plans/` only (current behavior)
 
+## Plan Review (Always Runs)
+
+After writing the plan file, automatically run `/plan_review <plan_file_path>` to get feedback from three specialized reviewers in parallel:
+
+- **DHH Rails Reviewer** - Challenges overengineering, enforces simplicity
+- **Kieran Rails Reviewer** - Checks correctness, completeness, convention adherence
+- **Code Simplicity Reviewer** - Ensures YAGNI, flags unnecessary complexity
+
+**After review completes:**
+
+1. Present consolidated feedback (agreements first, then disagreements)
+2. Ask: "Apply these changes?" (Yes / Partially / Skip)
+3. If Yes: apply all changes to the plan file
+4. If Partially: ask which changes to apply, then apply selected changes
+5. If Skip: continue unchanged
+
 ## Post-Generation Options
 
-After writing the plan file, use the **AskUserQuestion tool** to present these options:
+After plan review, use the **AskUserQuestion tool** to present these options:
 
-**Question:** "Plan ready at `knowledge-base/plans/YYYY-MM-DD-<type>-<name>-plan.md`. What would you like to do next?"
+**Question:** "Plan reviewed and ready at `knowledge-base/plans/YYYY-MM-DD-<type>-<name>-plan.md`. What would you like to do next?"
 
 **Options:**
 
 1. **Open plan in editor** - Open the plan file for review
 2. **Run `/deepen-plan`** - Enhance each section with parallel research agents (best practices, performance, UI)
-3. **Run `/plan_review`** - Get feedback from reviewers (DHH, Kieran, Simplicity)
-4. **Start `/soleur:work`** - Begin implementing this plan locally
-5. **Start `/soleur:work` on remote** - Begin implementing in Claude Code on the web (use `&` to run in background)
-6. **Create Issue** - Create issue in project tracker (GitHub/Linear)
-7. **Simplify** - Reduce detail level
+3. **Start `/soleur:work`** - Begin implementing this plan locally
+4. **Start `/soleur:work` on remote** - Begin implementing in Claude Code on the web (use `&` to run in background)
+5. **Create Issue** - Create issue in project tracker (GitHub/Linear)
+6. **Simplify** - Reduce detail level
 
 Based on selection:
 
 - **Open plan in editor** → Run `open knowledge-base/plans/<plan_filename>.md` to open the file in the user's default editor
 - **`/deepen-plan`** → Call the /deepen-plan command with the plan file path to enhance with research
-- **`/plan_review`** → Call the /plan_review command with the plan file path
 - **`/soleur:work`** → Call the /soleur:work command with the plan file path
 - **`/soleur:work` on remote** → Run `/soleur:work knowledge-base/plans/<plan_filename>.md &` to start work in background for Claude Code web
 - **Create Issue** → See "Issue Creation" section below
@@ -629,7 +643,7 @@ Based on selection:
 
 **Note:** If running `/soleur:plan` with ultrathink enabled, automatically run `/deepen-plan` after plan creation for maximum depth and grounding.
 
-Loop back to options after Simplify or Other changes until user selects `/soleur:work` or `/plan_review`.
+Loop back to options after Simplify or Other changes until user selects `/soleur:work`.
 
 ## Issue Creation
 


### PR DESCRIPTION
## Summary
- `/soleur:plan` now automatically runs plan review (DHH, Kieran, Simplicity reviewers) after plan generation
- Removed `/plan_review` from the post-generation options menu (no longer needed as a manual choice)
- Version bump 2.10.0 → 2.10.1

## Context
During the ops-research feature (PR #97), we ran `/plan_review` manually and it caught significant issues (55% plan reduction). Making it automatic ensures every plan gets this quality gate.

## Test plan
- [ ] Run `/soleur:plan` with a feature description and verify plan review runs automatically after plan generation
- [ ] Verify post-generation options no longer include `/plan_review` as a separate choice
- [ ] Verify all 583 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)