### PR TITLE
feat: add infra-security agent for domain security and DNS management (v2.11.0)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.10.2"
+      placeholder: "2.11.0"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.10.2-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.11.0-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/knowledge-base/brainstorms/archive/20260216-151715-2026-02-16-infra-security-agent-brainstorm.md
+++ b/knowledge-base/brainstorms/archive/20260216-151715-2026-02-16-infra-security-agent-brainstorm.md
@@ -1,0 +1,71 @@
+# Brainstorm: Infra-Security Agent
+
+**Date:** 2026-02-16
+**Issue:** #100
+**Status:** Complete
+
+## What We're Building
+
+A full-scope infrastructure security agent (`soleur:engineering:infra:infra-security`) that audits domain security posture, configures DNS records and security settings, and wires domains to services. It fills the gap between ops-research (purchases domains) and terraform-architect (provisions compute/network) where no agent handles live DNS/SSL/WAF configuration and verification.
+
+## Why This Approach
+
+### The Gap
+
+During the soleur.ai domain purchase workflow, we identified that:
+- **ops-advisor** tracks domain costs and registrations (ledger)
+- **ops-research** researches and purchases domains (acquisition)
+- **terraform-architect** generates IaC for Hetzner/AWS (compute provisioning)
+- **Nobody** handles DNS records, SSL/TLS, DNSSEC, WAF, or security auditing
+
+### Why Not Extend terraform-architect?
+
+Terraform has Cloudflare/Route53 providers and can manage DNS records and security settings declaratively. However:
+
+1. **Auditing is awkward in Terraform** -- checking live state requires importing resources first
+2. **Verification is outside scope** -- DNS propagation checks (dig), SSL cert chain validation, DNSSEC probing aren't Terraform's strength
+3. **One-off checks are overkill** -- "is DNSSEC enabled?" shouldn't require .tf state management
+4. **Different mental model** -- Terraform is declarative desired state; security auditing is imperative observation
+
+### Why One Agent, Not Two?
+
+Considered splitting into infra-audit (read-only) and infra-config (write) agents. Rejected per the ops-advisor consolidation learning: "split when it hurts." The scope isn't large enough yet to justify two agents. Internal mode separation (audit vs. configure) achieves the same safety boundary.
+
+## Key Decisions
+
+1. **API-first tool strategy** -- Cloudflare REST API via curl for configuration. CLI tools (dig, nslookup, curl) for read-only auditing. No agent-browser dependency.
+2. **Methodology-driven provider support** -- Agent prompt covers Cloudflare as primary provider. No formal abstraction layer. Extend by adding provider sections to the prompt when needed.
+3. **Lives at `agents/engineering/infra/`** -- Alongside terraform-architect. Name: `soleur:engineering:infra:infra-security`.
+4. **Inline audit output only** -- Security posture reports stay in conversation. Nothing persisted to disk or committed. Aggregated security findings in an open-source repo would be an attacker roadmap.
+5. **Three operating modes:**
+   - **Audit** -- Read-only security posture assessment (SSL mode, DNSSEC, headers, WAF, DNS records)
+   - **Configure** -- Create/update DNS records, toggle security settings via API
+   - **Wire** -- Preconfigured recipes for common patterns (GitHub Pages, Hetzner server, Cloudflare Workers)
+6. **Environment variables required:** `CF_API_TOKEN`, `CF_ZONE_ID` for Cloudflare operations.
+
+## Scope
+
+### In Scope
+- DNS record management (A, AAAA, CNAME, TXT, MX)
+- SSL/TLS mode configuration and verification
+- DNSSEC enablement and validation
+- HSTS and security header checks
+- WAF rule overview
+- Bot protection status
+- GitHub Pages / Hetzner / Workers wiring recipes
+- DNS propagation verification (dig)
+- SSL certificate chain validation
+
+### Out of Scope
+- IaC generation (terraform-architect's domain)
+- Domain purchase or registration (ops-research's domain)
+- Cost tracking (ops-advisor's domain)
+- Application-level security (security-sentinel's domain)
+- Cloudflare Workers code deployment
+- Email routing configuration (future scope)
+
+## Open Questions
+
+- Should the agent auto-detect the DNS provider from nameserver records, or require explicit provider specification?
+- Should wire recipes be hardcoded in the prompt or loaded from a config file?
+- What's the minimum Cloudflare API token scope needed? (Likely: Zone.DNS read/write + Zone.Settings read/write)

--- a/knowledge-base/learnings/2026-02-16-inline-only-output-for-security-agents.md
+++ b/knowledge-base/learnings/2026-02-16-inline-only-output-for-security-agents.md
@@ -1,0 +1,24 @@
+# Learning: Security agents in open-source repos must output inline-only
+
+## Problem
+
+When designing the infra-security agent (issue #100), we needed to decide where to persist audit results -- security posture reports covering SSL/TLS mode, DNSSEC status, WAF configuration, HSTS headers, and other domain security settings.
+
+## Solution
+
+Audit results are output inline in the conversation only. Nothing is written to files or committed to the repository.
+
+## Key Insight
+
+Individual security facts (DNS records, SSL mode, DNSSEC status) are publicly queryable via dig, SSL Labs, or browser inspection. But a consolidated report that says "WAF is disabled, these security headers are missing, DNSSEC is off" is an actionable roadmap for an attacker. **The aggregation is the risk, not the individual facts.**
+
+This applies to any security-adjacent agent or tool in an open-source repository. Options if persistence is needed:
+- `.gitignore`d local directory (available locally, not committed)
+- Private repository or separate tracking system
+- Encrypted at rest with a project-specific key
+
+## Tags
+
+category: architecture-decisions
+module: agents/engineering/infra
+symptoms: security audit data exposure, sensitive aggregated findings in public repos

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -47,6 +47,7 @@ Project principles organized by domain. Add principles as you learn them.
 - Never state conventions in constitution.md without tooling enforcement (config files, pre-commit hooks, or CI checks)
 - Never commit local config files that may contain secrets (`.claude/settings.local.json`, `.env`, `*.local.*`) -- add them to `.gitignore` at project initialization
 - Never edit files in the main repo root when a worktree is active for the current feature -- verify `pwd` shows `.worktrees/<name>/` before writing; place feature-scoped directories (todos, reports) inside the app directory within the worktree
+- Never persist aggregated security findings (audit reports, posture assessments) to files in an open-source repository -- output inline in conversation only; the aggregation is the risk, not the individual facts
 
 ### Prefer
 

--- a/knowledge-base/plans/archive/20260216-151715-2026-02-16-feat-infra-security-agent-plan.md
+++ b/knowledge-base/plans/archive/20260216-151715-2026-02-16-feat-infra-security-agent-plan.md
@@ -1,0 +1,67 @@
+---
+title: "feat: infra-security agent for domain security, DNS wiring, and auditing"
+type: feat
+date: 2026-02-16
+issue: "#100"
+version_bump: MINOR
+---
+
+# feat: infra-security agent
+
+## Overview
+
+Create a new agent at `plugins/soleur/agents/engineering/infra/infra-security.md` that audits domain security posture, configures DNS records and security settings via Cloudflare REST API, and wires domains to services with preconfigured recipes. This fills the gap between ops-research (acquisition) and terraform-architect (IaC) where no agent manages live DNS/SSL/WAF configuration.
+
+## Problem Statement
+
+After purchasing soleur.ai, manual Cloudflare dashboard navigation was required for DNS records, SSL/TLS, DNSSEC, and security headers. The existing agent trio (ops-advisor, ops-research, terraform-architect) covers purchase, tracking, and IaC -- but nobody handles live infrastructure configuration or security auditing.
+
+## Proposed Solution
+
+Single agent matching the terraform-architect prompt structure (~100 lines) with sections for:
+
+- **Audit Protocol** -- Read-only security posture assessment via Cloudflare API + CLI tools (dig, openssl). Severity-graded output (Critical/High/Medium/Low), matching terraform-architect's pattern.
+- **Configure Protocol** -- CRUD for DNS records and security settings via Cloudflare REST API. Confirmation required before every mutation.
+- **Wire Recipes** -- GitHub Pages recipe (Cloudflare-side CNAME + optional apex A records + SSL Full; instruct user for GitHub-side setup). Hetzner is just a proxied A record -- covered as a configure example, not a separate recipe. Workers deferred to v2.
+
+## Key Decisions
+
+- **Confirmation before mutations.** Show preview of all planned changes and wait for explicit user approval before executing any API write.
+- **Graceful degradation.** Two tiers: both env vars present = full operations; missing env vars = CLI-only audit (dig, openssl). No middle tier.
+- **Workers recipe deferred.** Modern Workers routing uses Custom Domains, not CNAME. Defer until actually needed.
+- **Single-zone via env var.** `CF_ZONE_ID` for v1. Multi-zone via domain name lookup is a v2 concern.
+- **Include proxy defaults and severity guidelines in the prompt.** Let the LLM reason about specifics; provide the general framework (web records proxied, mail DNS-only; SSL Off = Critical, no HSTS = High).
+
+## Environment Variables
+
+- `CF_API_TOKEN` -- Cloudflare API token (minimum scope: Zone:DNS:Edit + Zone:Settings:Read + Zone:Settings:Edit)
+- `CF_ZONE_ID` -- Cloudflare Zone ID for the target domain
+
+## Acceptance Criteria
+
+- [ ] Agent file at `plugins/soleur/agents/engineering/infra/infra-security.md` with proper YAML frontmatter
+- [ ] Description includes 3 examples (audit, configure, wire) with `<example>` + `<commentary>` tags
+- [ ] Audit Protocol section with Cloudflare API queries + CLI tool fallback when env vars missing
+- [ ] Configure Protocol section with confirmation-before-mutation safety rule
+- [ ] GitHub Pages wire recipe (Cloudflare-side only)
+- [ ] Scope section delineating boundaries with terraform-architect, security-sentinel, ops-advisor
+- [ ] Plugin version bumped 2.10.2 -> 2.11.0
+- [ ] CHANGELOG.md updated with v2.11.0 entry
+- [ ] README.md updated: agent count 27 -> 28, Infra table updated
+
+## Files to Create/Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `plugins/soleur/agents/engineering/infra/infra-security.md` | Create | New agent file (~100 lines) |
+| `plugins/soleur/plugin.json` | Modify | Bump version 2.10.2 -> 2.11.0, update description count |
+| `plugins/soleur/CHANGELOG.md` | Modify | Add v2.11.0 entry |
+| `plugins/soleur/README.md` | Modify | Agent count 27 -> 28, add to Infra table |
+
+## References
+
+- Brainstorm: `knowledge-base/brainstorms/2026-02-16-infra-security-agent-brainstorm.md`
+- Spec: `knowledge-base/specs/feat-infra-security/spec.md`
+- Sibling agent (structural reference): `plugins/soleur/agents/engineering/infra/terraform-architect.md`
+- Issue: #100
+- Cloudflare API v4: `https://api.cloudflare.com/client/v4/`

--- a/knowledge-base/specs/archive/20260216-151715-feat-infra-security/spec.md
+++ b/knowledge-base/specs/archive/20260216-151715-feat-infra-security/spec.md
@@ -1,0 +1,53 @@
+# Spec: infra-security agent
+
+**Issue:** #100
+**Branch:** feat-infra-security
+**Date:** 2026-02-16
+
+## Problem Statement
+
+After purchasing the soleur.ai domain, there is no agent to handle live infrastructure configuration and security auditing. The existing ops agents (ops-advisor, ops-research) handle acquisition and tracking, and terraform-architect handles IaC provisioning, but nobody manages DNS records, SSL/TLS settings, DNSSEC, WAF rules, or verifies that configurations propagated correctly.
+
+## Goals
+
+- G1: Audit a domain's security posture (SSL, DNSSEC, headers, WAF) via API and CLI tools
+- G2: Configure DNS records and security settings via Cloudflare REST API
+- G3: Wire domains to services (GitHub Pages, Hetzner, Workers) with preconfigured recipes
+- G4: Provide inline security reports without persisting sensitive findings to disk
+
+## Non-Goals
+
+- IaC generation (terraform-architect)
+- Domain purchase or cost tracking (ops-research, ops-advisor)
+- Application-level security review (security-sentinel)
+- Email routing configuration
+- Cloudflare Workers code deployment
+
+## Functional Requirements
+
+- FR1: Agent can query Cloudflare API for zone settings, DNS records, and security configuration
+- FR2: Agent can create, update, and delete DNS records (A, AAAA, CNAME, TXT, MX)
+- FR3: Agent can check and toggle SSL/TLS mode, DNSSEC, Always Use HTTPS
+- FR4: Agent can verify DNS propagation using dig/nslookup
+- FR5: Agent can validate SSL certificate chains using curl/openssl
+- FR6: Agent provides wiring recipes for GitHub Pages, Hetzner servers, Cloudflare Workers
+- FR7: Audit results are output inline in conversation only (never written to files)
+
+## Technical Requirements
+
+- TR1: Agent file at `plugins/soleur/agents/engineering/infra/infra-security.md`
+- TR2: Requires `CF_API_TOKEN` and `CF_ZONE_ID` environment variables
+- TR3: Uses Bash tool for curl (Cloudflare API), dig, nslookup, openssl s_client
+- TR4: Uses WebSearch for provider documentation lookup when needed
+- TR5: Follows existing agent YAML frontmatter conventions (name, description with examples, model: inherit)
+- TR6: Agent name resolves to `soleur:engineering:infra:infra-security`
+
+## Acceptance Criteria
+
+- [ ] Agent file exists at TR1 path with proper frontmatter
+- [ ] Agent can audit a Cloudflare zone's security posture given CF_API_TOKEN + CF_ZONE_ID
+- [ ] Agent can create DNS records for GitHub Pages wiring
+- [ ] Agent produces a formatted security checklist inline
+- [ ] Agent description includes 2-3 usage examples
+- [ ] Plugin version bumped, CHANGELOG and README updated
+- [ ] Docs updated with new agent count

--- a/knowledge-base/specs/archive/20260216-151715-feat-infra-security/tasks.md
+++ b/knowledge-base/specs/archive/20260216-151715-feat-infra-security/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: infra-security agent
+
+**Plan:** `knowledge-base/plans/2026-02-16-feat-infra-security-agent-plan.md`
+**Issue:** #100
+**Branch:** feat-infra-security
+
+## Phase 1: Core Implementation
+
+- [x] 1.1 Create agent file at `plugins/soleur/agents/engineering/infra/infra-security.md`
+  - YAML frontmatter (name, description with 3 examples, model: inherit)
+  - Environment Setup section (CF_API_TOKEN, CF_ZONE_ID, graceful degradation)
+  - Audit Protocol section (Cloudflare API queries, dig/openssl fallback, severity grading)
+  - Configure Protocol section (CRUD DNS records, toggle settings, confirmation gate)
+  - GitHub Pages wire recipe (CNAME, apex A records, SSL Full, user instructions for GitHub side)
+  - Scope section (boundaries with sibling agents)
+
+## Phase 2: Version Bump and Documentation
+
+- [x] 2.1 Bump `plugins/soleur/plugin.json` version 2.10.2 -> 2.11.0
+- [x] 2.2 Add v2.11.0 entry to `plugins/soleur/CHANGELOG.md`
+- [x] 2.3 Update `plugins/soleur/README.md` agent count (27 -> 28), add to Infra table
+
+## Phase 3: Quality Gates
+
+- [ ] 3.1 Code review, compound, stage all artifacts, commit, push, PR

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "soleur",
-  "version": "2.10.2",
-  "description": "AI-powered development tools for Claude Code that get smarter with every use. 27 agents, 8 commands, and 37 skills that compound your engineering knowledge over time.",
+  "version": "2.11.0",
+  "description": "AI-powered development tools for Claude Code that get smarter with every use. 28 agents, 8 commands, and 37 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",
     "email": "jean.deruelle@jikigai.com",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.0] - 2026-02-16
+
+### Added
+
+- `infra-security` agent (`soleur:engineering:infra:infra-security`) for domain security auditing, DNS configuration, and service wiring via Cloudflare REST API (closes #100)
+  - Audit Protocol: security posture assessment with severity-graded findings (SSL/TLS, DNSSEC, HSTS, WAF)
+  - Configure Protocol: DNS record CRUD with confirmation-before-mutation safety gate
+  - Wire Recipes: GitHub Pages wiring (CNAME, apex A records, SSL configuration)
+  - Graceful degradation: falls back to CLI tools (dig, openssl) when API credentials unavailable
+
 ## [2.10.2] - 2026-02-16
 
 ### Added

--- a/plugins/soleur/README.md
+++ b/plugins/soleur/README.md
@@ -106,7 +106,7 @@ Full autonomous engineering workflow that goes from plan to PR in a single comma
 
 | Component | Count |
 |-----------|-------|
-| Agents | 27 |
+| Agents | 28 |
 | Commands | 8 |
 | Skills | 37 |
 | MCP Servers | 1 |
@@ -127,7 +127,7 @@ Agents are organized by domain, then by function. Cross-domain agents stay at ro
 |-------|-------------|
 | `ux-design-lead` | Visual design in .pen files using Pencil MCP (wireframes, screens, components). Requires [Pencil extension](https://docs.pencil.dev/getting-started/installation). |
 
-### Engineering (16)
+### Engineering (17)
 
 #### Review (14)
 
@@ -154,10 +154,11 @@ Agents are organized by domain, then by function. Cross-domain agents stay at ro
 |-------|-------------|
 | `ddd-architect` | Domain-Driven Design with strategic bounded contexts and tactical patterns |
 
-#### Infra (1)
+#### Infra (2)
 
 | Agent | Description |
 |-------|-------------|
+| `infra-security` | Audit domain security posture, configure DNS records, and wire domains to services via Cloudflare API |
 | `terraform-architect` | Generate and review Terraform configurations for Hetzner Cloud and AWS |
 
 ### Operations (2)

--- a/plugins/soleur/agents/engineering/infra/infra-security.md
+++ b/plugins/soleur/agents/engineering/infra/infra-security.md
@@ -1,0 +1,97 @@
+---
+name: infra-security
+description: "Use this agent when you need to audit domain security posture, configure DNS records and security settings, or wire domains to services like GitHub Pages or Hetzner servers. This agent uses the Cloudflare REST API for configuration and CLI tools (dig, openssl) for verification. <example>Context: The user wants to check the security configuration of a domain.\nuser: \"Audit the security posture of soleur.ai\"\nassistant: \"I'll use the infra-security agent to audit SSL/TLS, DNSSEC, security headers, and DNS configuration for soleur.ai.\"\n<commentary>\nSecurity posture audits are the core use case. The agent queries Cloudflare API for zone settings and runs dig/openssl for external verification. Results are displayed inline, never written to files.\n</commentary>\n</example>\n\n<example>\nContext: The user wants to point a domain to GitHub Pages.\nuser: \"Wire soleur.ai to our GitHub Pages site\"\nassistant: \"I'll use the infra-security agent to create the DNS records and configure SSL for GitHub Pages.\"\n<commentary>\nWiring domains to services combines DNS record creation with SSL configuration. The agent handles the Cloudflare side and instructs the user on the GitHub side.\n</commentary>\n</example>\n\n<example>\nContext: The user needs to create or update DNS records.\nuser: \"Add an A record for api.soleur.ai pointing to 1.2.3.4\"\nassistant: \"I'll use the infra-security agent to create the DNS record via the Cloudflare API.\"\n<commentary>\nDNS record management (create, update, delete) for any supported record type. The agent confirms changes before executing.\n</commentary>\n</example>"
+model: inherit
+---
+
+You are an Infrastructure Security specialist for domain configuration and auditing. Audit domain security posture, configure DNS records and security settings via the Cloudflare REST API, and wire domains to services.
+
+## Environment Setup
+
+This agent requires two environment variables for Cloudflare API operations:
+
+- `CF_API_TOKEN` -- Cloudflare API token (minimum scope: Zone:DNS:Edit, Zone:Settings:Read, Zone:Settings:Edit)
+- `CF_ZONE_ID` -- Cloudflare Zone ID for the target domain
+
+**Before any API call**, validate the token with `GET https://api.cloudflare.com/client/v4/user/tokens/verify`. If validation fails, report the error and stop.
+
+**Graceful degradation:** If environment variables are missing, fall back to CLI-only checks (dig, openssl s_client). Announce which checks are skipped and why. Never fail entirely when CLI tools can still provide value.
+
+**Tool availability:** Check `which dig` and `which openssl` before using them. If missing, provide platform-specific install guidance.
+
+**Security:** Never display the API token in curl commands or debug output. Show only API responses, not request headers.
+
+## Audit Protocol
+
+When auditing a domain's security posture, check these areas and report findings grouped by severity:
+
+**Critical:** SSL/TLS mode set to Off or Flexible (exposes traffic to downgrade attacks), DNSSEC disabled on domains handling authentication or payments.
+
+**High:** HSTS not enabled, Always Use HTTPS disabled, DNSSEC disabled.
+
+**Medium:** SSL mode Full instead of Full (Strict), WAF not configured (if plan supports it), no Bot Fight Mode.
+
+**Low:** Suboptimal TTL values, missing CAA records, no page rules for redirects.
+
+**API checks** (require CF_API_TOKEN + CF_ZONE_ID):
+
+- `GET /zones/{zone_id}/settings` -- SSL mode, Always Use HTTPS, HSTS, security headers
+- `GET /zones/{zone_id}/dns_records` -- All DNS records
+- `GET /zones/{zone_id}/dnssec` -- DNSSEC status
+
+**CLI checks** (no credentials needed):
+
+- `dig +short <domain>` -- DNS resolution verification
+- `dig +trace <domain>` -- DNS delegation chain
+- `openssl s_client -connect <domain>:443 -servername <domain>` -- SSL certificate chain
+- `curl -sI https://<domain>` -- HTTP security headers (HSTS, X-Frame-Options, CSP)
+
+Output all findings inline in the conversation. Never write audit results to files -- aggregated security findings in an open-source repository would be an attacker roadmap.
+
+## Configure Protocol
+
+Manage DNS records and security settings via the Cloudflare API.
+
+**Supported record types:** A, AAAA, CNAME, TXT, MX.
+
+**Proxy defaults:** Web-serving records (A, AAAA, CNAME) are proxied by default (orange cloud). MX records are always DNS-only (grey cloud) -- proxying mail breaks delivery. TXT records are never proxied.
+
+**Confirmation required:** Before executing any mutating API call (create, update, delete, or settings change), present a summary of the planned changes and wait for explicit user confirmation. Include the record type, name, content, proxy status, and TTL in the preview.
+
+**Idempotent operations:** Before creating a record, check if a matching record already exists via `GET /zones/{zone_id}/dns_records?type={type}&name={name}`. If it exists, update it. If not, create it. This makes operations safe to retry.
+
+**API endpoints:**
+
+- Create: `POST /zones/{zone_id}/dns_records`
+- Update: `PUT /zones/{zone_id}/dns_records/{record_id}`
+- Delete: `DELETE /zones/{zone_id}/dns_records/{record_id}`
+- Settings: `PATCH /zones/{zone_id}/settings/{setting_name}`
+
+**Error handling:** Map Cloudflare error codes to actionable guidance. Common errors: 401 (invalid/expired token), 403 (insufficient permissions -- suggest adding the required scope), 409/81058 (record already exists -- switch to update), 429 (rate limited -- respect Retry-After header).
+
+## Wire Recipes
+
+### GitHub Pages
+
+Wire a domain to GitHub Pages. This recipe handles the Cloudflare side only.
+
+**Steps:**
+
+1. Create proxied CNAME record: `www.<domain>` pointing to `<username>.github.io`
+2. Create A records for apex domain (if requested): `185.199.108.153`, `185.199.109.153`, `185.199.110.153`, `185.199.111.153` (all proxied)
+3. Set SSL mode to Full (not Full Strict -- GitHub's cert may not match during initial provisioning)
+4. Enable Always Use HTTPS
+
+**User instructions for GitHub side:** After DNS is configured, add the custom domain in the GitHub repository settings (Settings > Pages > Custom domain). GitHub will provision an SSL certificate, which can take up to 24 hours. Once provisioned, consider upgrading SSL mode to Full (Strict).
+
+**Post-wiring verification:** Run `dig +short <domain>` and `curl -sI https://<domain>` to confirm DNS propagation and HTTPS response. Note that propagation may take minutes to hours depending on TTL and resolver caching.
+
+## Scope
+
+This agent handles live infrastructure configuration and security auditing. Out of scope:
+
+- Infrastructure as Code generation (refer to terraform-architect)
+- Domain purchase, registration, or cost tracking (refer to ops-research and ops-advisor)
+- Application-level security review (refer to security-sentinel)
+- Cloudflare Workers deployment or routing
+- Email routing configuration


### PR DESCRIPTION
## Summary

- Add `infra-security` agent (`soleur:engineering:infra:infra-security`) for domain security auditing, DNS record management, and service wiring via Cloudflare REST API
- **Audit Protocol:** Security posture assessment with severity-graded findings (SSL/TLS, DNSSEC, HSTS, WAF). Graceful degradation to CLI tools (dig, openssl) when API credentials unavailable
- **Configure Protocol:** DNS record CRUD with confirmation-before-mutation safety gate. Idempotent operations (check-then-create/update)
- **Wire Recipes:** GitHub Pages wiring (CNAME, apex A records, SSL configuration)
- Version bump 2.10.2 -> 2.11.0 (new agent = MINOR)

Closes #100

## Key Design Decisions

- **API-first:** Cloudflare REST API via curl, no browser automation dependency
- **Inline audit output only:** Security findings never persisted to files in this open-source repo (aggregated findings = attacker roadmap)
- **Confirmation gate:** All mutations require explicit user approval before executing
- **Two-tier degradation:** Full ops with env vars, CLI-only audit without them

## Checklist

- [x] Artifacts committed and archived (brainstorm, spec, plan)
- [x] Learnings captured (inline-only output for security agents)
- [x] Constitution updated (new "Never" principle for security findings)
- [x] Documentation updated (agent count 27->28, Infra table)
- [x] Version bumped (plugin.json + CHANGELOG + README triad)
- [x] Version synced (root README badge + bug report template)

🤖 Generated with [Claude Code](https://claude.com/claude-code)