### PR TITLE
chore: add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ node_modules/
 .worktrees
 .claude/settings.local.json
 .playwright-mcp/
+.env


### PR DESCRIPTION
## Summary
- Adds `.env` to `.gitignore` to prevent Cloudflare credentials from being committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)