### PR TITLE
fix: update docs site for soleur.ai custom domain (v2.11.1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.11.0"
+      placeholder: "2.11.1"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.11.0-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.11.1-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "AI-powered development tools for Claude Code that get smarter with every use. 28 agents, 8 commands, and 37 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.1] - 2026-02-16
+
+### Changed
+
+- Update docs site for custom domain: replace `jikig-ai.github.io/soleur/` base paths and OG URLs with `soleur.ai/`
+- Add `CNAME` file for GitHub Pages custom domain persistence
+
 ## [2.11.0] - 2026-02-16
 
 ### Added

--- a/plugins/soleur/docs/404.html
+++ b/plugins/soleur/docs/404.html
@@ -6,10 +6,10 @@
   <meta name="description" content="Page not found - Soleur documentation">
   <meta property="og:title" content="404 - Soleur">
   <meta property="og:description" content="Page not found - Soleur documentation">
-  <meta property="og:url" content="https://jikig-ai.github.io/soleur/">
+  <meta property="og:url" content="https://soleur.ai/">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="https://jikig-ai.github.io/soleur/images/og-image.png">
-  <base href="/soleur/">
+  <meta property="og:image" content="https://soleur.ai/images/og-image.png">
+  <base href="/">
   <link rel="icon" type="image/png" href="images/favicon.png">
   <title>404 - Page Not Found | Soleur</title>
   <link rel="stylesheet" href="css/style.css">

--- a/plugins/soleur/docs/CNAME
+++ b/plugins/soleur/docs/CNAME
@@ -1,0 +1,1 @@
+soleur.ai

--- a/plugins/soleur/docs/index.html
+++ b/plugins/soleur/docs/index.html
@@ -6,11 +6,11 @@
   <meta name="description" content="The company-as-a-service platform. Build, ship, and scale powered by AI teams.">
   <meta property="og:title" content="Soleur - The Company-as-a-Service Platform">
   <meta property="og:description" content="Build, ship, and scale powered by AI teams. For founders who think in billions.">
-  <meta property="og:url" content="https://jikig-ai.github.io/soleur/">
+  <meta property="og:url" content="https://soleur.ai/">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="https://jikig-ai.github.io/soleur/images/og-image.png">
+  <meta property="og:image" content="https://soleur.ai/images/og-image.png">
   <link rel="icon" type="image/png" href="images/favicon.png">
-  <base href="/soleur/">
+  <base href="/">
   <title>Soleur - The Company-as-a-Service Platform</title>
   <link rel="stylesheet" href="css/style.css">
 </head>

--- a/plugins/soleur/docs/pages/agents.html
+++ b/plugins/soleur/docs/pages/agents.html
@@ -6,10 +6,10 @@
   <meta name="description" content="25 specialized agents for code review, research, architecture, design, and workflow automation.">
   <meta property="og:title" content="Agents - Soleur">
   <meta property="og:description" content="25 specialized agents for code review, research, architecture, design, and workflow automation.">
-  <meta property="og:url" content="https://jikig-ai.github.io/soleur/pages/agents.html">
+  <meta property="og:url" content="https://soleur.ai/pages/agents.html">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="https://jikig-ai.github.io/soleur/images/og-image.png">
-  <base href="/soleur/">
+  <meta property="og:image" content="https://soleur.ai/images/og-image.png">
+  <base href="/">
   <link rel="icon" type="image/png" href="images/favicon.png">
   <title>Agents - Soleur</title>
   <link rel="stylesheet" href="css/style.css">

--- a/plugins/soleur/docs/pages/changelog.html
+++ b/plugins/soleur/docs/pages/changelog.html
@@ -4,9 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Changelog - All notable changes to the Soleur plugin.">
-  <meta property="og:image" content="https://jikig-ai.github.io/soleur/images/og-image.png">
+  <meta property="og:image" content="https://soleur.ai/images/og-image.png">
   <link rel="icon" type="image/png" href="images/favicon.png">
-  <base href="/soleur/">
+  <base href="/">
   <title>Changelog - Soleur</title>
   <link rel="stylesheet" href="css/style.css">
 </head>

--- a/plugins/soleur/docs/pages/commands.html
+++ b/plugins/soleur/docs/pages/commands.html
@@ -6,10 +6,10 @@
   <meta name="description" content="All 8 Soleur slash commands for the complete development workflow.">
   <meta property="og:title" content="Commands - Soleur">
   <meta property="og:description" content="All 8 Soleur slash commands for the complete development workflow.">
-  <meta property="og:url" content="https://jikig-ai.github.io/soleur/pages/commands.html">
+  <meta property="og:url" content="https://soleur.ai/pages/commands.html">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="https://jikig-ai.github.io/soleur/images/og-image.png">
-  <base href="/soleur/">
+  <meta property="og:image" content="https://soleur.ai/images/og-image.png">
+  <base href="/">
   <link rel="icon" type="image/png" href="images/favicon.png">
   <title>Commands - Soleur</title>
   <link rel="stylesheet" href="css/style.css">

--- a/plugins/soleur/docs/pages/getting-started.html
+++ b/plugins/soleur/docs/pages/getting-started.html
@@ -4,9 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Getting Started - Install Soleur and start building smarter.">
-  <meta property="og:image" content="https://jikig-ai.github.io/soleur/images/og-image.png">
+  <meta property="og:image" content="https://soleur.ai/images/og-image.png">
   <link rel="icon" type="image/png" href="images/favicon.png">
-  <base href="/soleur/">
+  <base href="/">
   <title>Getting Started - Soleur</title>
   <link rel="stylesheet" href="css/style.css">
 </head>

--- a/plugins/soleur/docs/pages/mcp-servers.html
+++ b/plugins/soleur/docs/pages/mcp-servers.html
@@ -4,9 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="MCP Servers - Model Context Protocol servers that extend Claude's capabilities with Soleur.">
-  <meta property="og:image" content="https://jikig-ai.github.io/soleur/images/og-image.png">
+  <meta property="og:image" content="https://soleur.ai/images/og-image.png">
   <link rel="icon" type="image/png" href="images/favicon.png">
-  <base href="/soleur/">
+  <base href="/">
   <title>MCP Servers - Soleur</title>
   <link rel="stylesheet" href="css/style.css">
 </head>

--- a/plugins/soleur/docs/pages/skills.html
+++ b/plugins/soleur/docs/pages/skills.html
@@ -6,10 +6,10 @@
   <meta name="description" content="37 specialized skills for development, content, deployment, and more.">
   <meta property="og:title" content="Skills - Soleur">
   <meta property="og:description" content="37 specialized skills for development, content, deployment, and more.">
-  <meta property="og:url" content="https://jikig-ai.github.io/soleur/pages/skills.html">
+  <meta property="og:url" content="https://soleur.ai/pages/skills.html">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="https://jikig-ai.github.io/soleur/images/og-image.png">
-  <base href="/soleur/">
+  <meta property="og:image" content="https://soleur.ai/images/og-image.png">
+  <base href="/">
   <link rel="icon" type="image/png" href="images/favicon.png">
   <title>Skills - Soleur</title>
   <link rel="stylesheet" href="css/style.css">

--- a/plugins/soleur/docs/robots.txt
+++ b/plugins/soleur/docs/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://jikig-ai.github.io/soleur/sitemap.xml
+Sitemap: https://soleur.ai/sitemap.xml

--- a/plugins/soleur/docs/sitemap.xml
+++ b/plugins/soleur/docs/sitemap.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://jikig-ai.github.io/soleur/</loc>
+    <loc>https://soleur.ai/</loc>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://jikig-ai.github.io/soleur/pages/agents.html</loc>
+    <loc>https://soleur.ai/pages/agents.html</loc>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jikig-ai.github.io/soleur/pages/commands.html</loc>
+    <loc>https://soleur.ai/pages/commands.html</loc>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jikig-ai.github.io/soleur/pages/skills.html</loc>
+    <loc>https://soleur.ai/pages/skills.html</loc>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jikig-ai.github.io/soleur/pages/mcp-servers.html</loc>
+    <loc>https://soleur.ai/pages/mcp-servers.html</loc>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jikig-ai.github.io/soleur/pages/changelog.html</loc>
+    <loc>https://soleur.ai/pages/changelog.html</loc>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://jikig-ai.github.io/soleur/pages/getting-started.html</loc>
+    <loc>https://soleur.ai/pages/getting-started.html</loc>
     <priority>0.9</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- Replace `<base href="/soleur/">` with `<base href="/">` across all 8 HTML pages + 404
- Update all `og:url` and `og:image` meta tags from `jikig-ai.github.io/soleur/` to `soleur.ai/`
- Update `sitemap.xml` and `robots.txt` URLs to `soleur.ai`
- Add `CNAME` file for GitHub Pages custom domain persistence
- Bump version to v2.11.1

## Context
After wiring `soleur.ai` to GitHub Pages, CSS/fonts/images failed to load because the `<base href="/soleur/">` tag prepended `/soleur/` to all relative asset paths. With the custom domain, the site is served from `/` not `/soleur/`.

## Test plan
- [ ] Verify https://soleur.ai loads with full styling after deploy
- [ ] Verify https://www.soleur.ai redirects to https://soleur.ai
- [ ] Check all subpages load CSS and images correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)