### PR TITLE
chore: update ops tracking and docs site with missing agents (v2.11.2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.11.1"
+      placeholder: "2.11.2"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.11.1-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.11.2-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/knowledge-base/ops/domains.md
+++ b/knowledge-base/ops/domains.md
@@ -7,3 +7,24 @@ last_updated: 2026-02-16
 | Domain | Registrar | Renewal Date | Nameservers | Notes |
 |--------|-----------|--------------|-------------|-------|
 | soleur.ai | Cloudflare | 2028-02-16 | ns1.cloudflare.com, ns2.cloudflare.com | Primary brand domain |
+
+## DNS Records
+
+| Type | Name | Content | Proxied | Notes |
+|------|------|---------|---------|-------|
+| A | soleur.ai | 185.199.108.153 | Yes | GitHub Pages |
+| A | soleur.ai | 185.199.109.153 | Yes | GitHub Pages |
+| A | soleur.ai | 185.199.110.153 | Yes | GitHub Pages |
+| A | soleur.ai | 185.199.111.153 | Yes | GitHub Pages |
+| CNAME | www.soleur.ai | jikig-ai.github.io | Yes | GitHub Pages |
+| TXT | _github-pages-challenge-jikig-ai.soleur.ai | 8fcc2ac37a5abcac6cd2c71556053f | No | Domain verification |
+
+## Security Configuration
+
+| Setting | Value |
+|---------|-------|
+| SSL Mode | Full (Strict) |
+| Always Use HTTPS | On |
+| Minimum TLS Version | 1.2 |
+| HSTS | max-age=31536000; includeSubDomains; preload |
+| X-Content-Type-Options | nosniff |

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "AI-powered development tools for Claude Code that get smarter with every use. 28 agents, 8 commands, and 37 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.2] - 2026-02-16
+
+### Changed
+
+- Update docs site with 3 missing agents: infra-security, ops-advisor, ops-research
+- Add Operations category to agents page
+- Update agent count from 25 to 28 across all pages
+- Update landing page stats to 28 agents and 37 skills
+
 ## [2.11.1] - 2026-02-16
 
 ### Changed

--- a/plugins/soleur/docs/index.html
+++ b/plugins/soleur/docs/index.html
@@ -54,11 +54,11 @@
         <div class="landing-stat-label">Automated Workflow</div>
       </div>
       <div class="landing-stat">
-        <div class="landing-stat-value">23+</div>
+        <div class="landing-stat-value">28</div>
         <div class="landing-stat-label">AI Agents</div>
       </div>
       <div class="landing-stat">
-        <div class="landing-stat-value">36+</div>
+        <div class="landing-stat-value">37</div>
         <div class="landing-stat-label">Skills</div>
       </div>
       <div class="landing-stat">

--- a/plugins/soleur/docs/pages/agents.html
+++ b/plugins/soleur/docs/pages/agents.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="25 specialized agents for code review, research, architecture, design, and workflow automation.">
+  <meta name="description" content="28 specialized agents for code review, research, architecture, infrastructure, operations, design, and workflow automation.">
   <meta property="og:title" content="Agents - Soleur">
-  <meta property="og:description" content="25 specialized agents for code review, research, architecture, design, and workflow automation.">
+  <meta property="og:description" content="28 specialized agents for code review, research, architecture, infrastructure, operations, design, and workflow automation.">
   <meta property="og:url" content="https://soleur.ai/pages/agents.html">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://soleur.ai/images/og-image.png">
@@ -36,7 +36,7 @@
     <section class="page-hero">
       <div class="container">
         <h1>Agents</h1>
-        <p>25 specialized agents for code review, research, architecture, design, and workflow automation.</p>
+        <p>28 specialized agents for code review, research, architecture, infrastructure, operations, design, and workflow automation.</p>
       </div>
     </section>
 
@@ -47,6 +47,7 @@
         <a href="pages/agents.html#engineering-infra" class="category-pill">Engineering / Infra</a>
         <a href="pages/agents.html#research" class="category-pill">Research</a>
         <a href="pages/agents.html#workflow" class="category-pill">Workflow</a>
+        <a href="pages/agents.html#operations" class="category-pill">Operations</a>
         <a href="pages/agents.html#marketing" class="category-pill">Marketing</a>
         <a href="pages/agents.html#design" class="category-pill">Design</a>
       </nav>
@@ -195,9 +196,17 @@
       <section id="engineering-infra" class="category-section">
         <div class="category-header">
           <h2 class="category-title">Engineering / Infra</h2>
-          <span class="category-count">1 agent</span>
+          <span class="category-count">2 agents</span>
         </div>
         <div class="catalog-grid">
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-infra)"></span>
+              <span class="card-category">Engineering / Infra</span>
+            </div>
+            <h3 class="card-title">infra-security</h3>
+            <p class="card-description">Domain security auditing, DNS configuration, and service wiring via Cloudflare</p>
+          </article>
           <article class="component-card">
             <div class="card-header">
               <span class="card-dot" style="background: var(--cat-infra)"></span>
@@ -281,6 +290,32 @@
             </div>
             <h3 class="card-title">spec-flow-analyzer</h3>
             <p class="card-description">User flow analysis and gap identification for specs</p>
+          </article>
+        </div>
+      </section>
+
+      <!-- Operations -->
+      <section id="operations" class="category-section">
+        <div class="category-header">
+          <h2 class="category-title">Operations</h2>
+          <span class="category-count">2 agents</span>
+        </div>
+        <div class="catalog-grid">
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-workflow)"></span>
+              <span class="card-category">Operations</span>
+            </div>
+            <h3 class="card-title">ops-advisor</h3>
+            <p class="card-description">Tracks operational expenses, domain registrations, and hosting recommendations</p>
+          </article>
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-workflow)"></span>
+              <span class="card-category">Operations</span>
+            </div>
+            <h3 class="card-title">ops-research</h3>
+            <p class="card-description">Live research for domains, hosting providers, and cost optimization</p>
           </article>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Add DNS records and Cloudflare security configuration to `knowledge-base/ops/domains.md`
- Add 3 missing agents to docs site: `infra-security`, `ops-advisor`, `ops-research`
- Add new Operations category to agents page
- Update agent count from 25 to 28 across agents page
- Update landing page stats: 28 agents, 37 skills
- Bump version to v2.11.2

## Test plan
- [ ] Verify https://www.soleur.ai/pages/agents.html shows 28 agents with Operations category
- [ ] Verify landing page stats show 28 agents and 37 skills
- [ ] Verify ops/domains.md has DNS and security details

🤖 Generated with [Claude Code](https://claude.com/claude-code)