### PR TITLE
fix: docs site UX/UI fixes (v2.11.3)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.11.2"
+      placeholder: "2.11.3"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.11.2-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.11.3-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/knowledge-base/learnings/2026-02-17-backdrop-filter-breaks-fixed-positioning.md
+++ b/knowledge-base/learnings/2026-02-17-backdrop-filter-breaks-fixed-positioning.md
@@ -1,0 +1,63 @@
+---
+title: backdrop-filter creates containing block for fixed-position descendants
+date: 2026-02-17
+category: css
+tags: [css, backdrop-filter, position-fixed, mobile-nav, stacking-context]
+module: docs
+symptoms: [fixed-element-height-zero, fixed-element-wrong-position, mobile-nav-not-full-height]
+---
+
+# backdrop-filter Creates Containing Block for Fixed-Position Descendants
+
+## Problem
+
+Mobile navigation panel and backdrop overlay had `position: fixed; top: 56px; bottom: 0` but computed height was 0px. The panel appeared to be contained within the 56px-tall header instead of spanning the viewport.
+
+## Root Cause
+
+The `.site-header` had `backdrop-filter: blur(12px)` for a frosted glass effect. Per CSS spec, `backdrop-filter` (like `filter`, `transform`, and `perspective`) establishes a new containing block for fixed-position descendants. This means `position: fixed` children are positioned relative to the header, not the viewport.
+
+With the header being 56px tall, `top: 56px; bottom: 0` computed to 0px height (top offset equals container height, leaving no space).
+
+## Diagnostic
+
+```js
+// In browser console:
+const navLinks = document.querySelector('.nav-links');
+console.log(window.getComputedStyle(navLinks).height); // "32px" (content-only, not full viewport)
+
+const label = document.querySelector('.nav-toggle-label');
+console.log(window.getComputedStyle(label, '::before').height); // "0px"
+```
+
+## Fix
+
+Replace `bottom: 0` with explicit viewport-relative height using `calc(100vh - var(--header-h))`. Viewport units (`vh`) always resolve against the viewport regardless of containing block.
+
+```css
+/* BEFORE -- broken by backdrop-filter containing block */
+.nav-links {
+  position: fixed;
+  top: var(--header-h);
+  bottom: 0; /* resolves to 0 height inside header */
+}
+
+/* AFTER -- viewport units bypass the containing block issue */
+.nav-links {
+  position: fixed;
+  top: var(--header-h);
+  height: calc(100vh - var(--header-h));
+}
+```
+
+## Key Takeaway
+
+When using `backdrop-filter` on a parent, never rely on `inset` properties (`top`/`bottom` or `left`/`right` pairs) for fixed-position children. Use explicit `width`/`height` with viewport units instead.
+
+Properties that create containing blocks for fixed descendants:
+- `transform` (any non-none value)
+- `filter` (any non-none value)
+- `backdrop-filter` (any non-none value)
+- `perspective` (any non-none value)
+- `contain: paint` or `contain: layout`
+- `will-change` referencing any of the above

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "description": "AI-powered development tools for Claude Code that get smarter with every use. 28 agents, 8 commands, and 37 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.3] - 2026-02-17
+
+### Fixed
+
+- Fix color mismatch between Quick Commands (white) and Workflow (gold) on Getting Started page
+- Fix command card text overlap on Commands page by switching from fixed to auto grid columns
+- Fix mobile nav panel and backdrop not spanning full viewport height (backdrop-filter containing block issue)
+- Add mobile nav backdrop overlay with click-to-dismiss
+- Fix MCP badge stretching full width inside flex container
+- Remove empty usage code element from /soleur:help command card
+
+### Changed
+
+- Add border-radius to problem cards and feature cards for visual consistency
+- Add scroll fade indicator to category pill navigation
+- Restyle Learn More links as card grid on Getting Started page
+- Switch feature grid from rigid 5-column to responsive auto-fill layout
+
 ## [2.11.2] - 2026-02-16
 
 ### Changed

--- a/plugins/soleur/docs/css/style.css
+++ b/plugins/soleur/docs/css/style.css
@@ -191,8 +191,8 @@
       position: fixed;
       top: var(--header-h);
       right: 0;
-      bottom: 0;
       width: 260px;
+      height: calc(100vh - var(--header-h));
       flex-direction: column;
       align-items: stretch;
       gap: 0;
@@ -201,9 +201,22 @@
       padding: var(--space-4);
       transform: translateX(100%);
       transition: transform 0.2s ease;
+      z-index: 2;
     }
     .nav-links a { padding: var(--space-3) var(--space-4); border-bottom: none; }
     .nav-toggle:checked ~ .nav-links { transform: translateX(0); }
+    /* Backdrop overlay -- uses viewport units because backdrop-filter on header
+       creates a containing block that breaks bottom:0 on fixed children */
+    .nav-toggle:checked ~ .nav-toggle-label::before {
+      content: '';
+      position: fixed;
+      top: var(--header-h);
+      left: 0;
+      width: 100vw;
+      height: calc(100vh - var(--header-h));
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 1;
+    }
   }
 
   /* Stat cards (docs pages) */
@@ -301,7 +314,7 @@
   }
   .command-card:hover { border-color: var(--color-border-strong); }
   @media (min-width: 640px) {
-    .command-card { grid-template-columns: 200px 1fr; }
+    .command-card { grid-template-columns: auto 1fr; }
   }
   .command-name {
     font-family: var(--font-mono);
@@ -335,6 +348,8 @@
     padding: var(--space-4) 0;
     overflow-x: auto;
     scrollbar-width: none;
+    mask-image: linear-gradient(to right, black calc(100% - 2rem), transparent);
+    -webkit-mask-image: linear-gradient(to right, black calc(100% - 2rem), transparent);
   }
   .category-nav::-webkit-scrollbar { display: none; }
   .category-pill {
@@ -480,6 +495,7 @@
   .problem-card {
     padding: var(--space-6);
     border: 1px solid var(--color-border);
+    border-radius: 8px;
   }
   .problem-card-icon {
     color: var(--color-accent);
@@ -525,7 +541,7 @@
   /* Landing page: Feature grid */
   .feature-grid {
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     gap: var(--space-5);
     max-width: 1200px;
     margin-inline: auto;
@@ -533,6 +549,7 @@
   .feature-card {
     padding: var(--space-5);
     border: 1px solid var(--color-border);
+    border-radius: 8px;
   }
   .feature-card-icon {
     color: var(--color-accent);
@@ -594,6 +611,7 @@
   /* Badge */
   .badge {
     display: inline-block;
+    align-self: flex-start;
     font-family: var(--font-mono);
     font-size: var(--text-xs);
     padding: 0.1em 0.5em;
@@ -796,22 +814,32 @@
     background: var(--color-bg-secondary);
     border-radius: 8px;
   }
-  .command-item code { font-weight: 600; white-space: nowrap; }
+  .command-item code { font-weight: 600; white-space: nowrap; color: var(--color-accent); }
   .learn-more-links {
     list-style: none;
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     gap: var(--space-3);
     margin-top: var(--space-5);
   }
   .learn-more-links a {
-    padding: var(--space-2) var(--space-4);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    padding: var(--space-4);
     border: 1px solid var(--color-border);
     border-radius: 8px;
     font-size: var(--text-sm);
+    font-weight: 600;
     transition: border-color 0.15s;
   }
   .learn-more-links a:hover { border-color: var(--color-accent); text-decoration: none; }
+  .learn-more-desc {
+    display: block;
+    font-weight: 400;
+    font-size: var(--text-xs);
+    color: var(--color-text-secondary);
+  }
 
   /* Changelog note */
   .changelog-note {
@@ -831,7 +859,6 @@
     .landing-hero h1 { font-size: var(--text-3xl); }
     .landing-stats { flex-direction: column; gap: var(--space-6); }
     .problem-cards { grid-template-columns: 1fr; }
-    .feature-grid { grid-template-columns: 1fr; }
     .landing-quote blockquote { font-size: var(--text-xl); }
     .section-title { font-size: var(--text-2xl); }
     .footer-inner { flex-direction: column; gap: var(--space-4); text-align: center; }
@@ -839,7 +866,6 @@
 
   @media (min-width: 769px) and (max-width: 1024px) {
     .problem-cards { grid-template-columns: 1fr 1fr; }
-    .feature-grid { grid-template-columns: repeat(3, 1fr); }
   }
 }
 

--- a/plugins/soleur/docs/pages/commands.html
+++ b/plugins/soleur/docs/pages/commands.html
@@ -68,7 +68,6 @@
           </div>
           <div>
             <p class="command-description">List all available Soleur commands, agents, and skills.</p>
-            <code class="card-usage"></code>
           </div>
         </article>
 

--- a/plugins/soleur/docs/pages/getting-started.html
+++ b/plugins/soleur/docs/pages/getting-started.html
@@ -87,9 +87,9 @@
 
         <h2>Learn More</h2>
         <ul class="learn-more-links">
-          <li><a href="pages/agents.html">Agents</a> -- Specialized AI agents for engineering, research, and workflow tasks</li>
-          <li><a href="pages/commands.html">Commands</a> -- Quick-access commands for common operations</li>
-          <li><a href="pages/skills.html">Skills</a> -- Multi-step skills for complex workflows</li>
+          <li><a href="pages/agents.html">Agents <span class="learn-more-desc">Specialized AI agents for engineering, research, and workflow</span></a></li>
+          <li><a href="pages/commands.html">Commands <span class="learn-more-desc">Quick-access commands for common operations</span></a></li>
+          <li><a href="pages/skills.html">Skills <span class="learn-more-desc">Multi-step skills for complex workflows</span></a></li>
         </ul>
 
       </div>


### PR DESCRIPTION
## Summary

- Fix color mismatch between Quick Commands (white) and Workflow (gold) sections on Getting Started page
- Fix command card text overlap on Commands page (fixed 200px grid column -> auto)
- Add mobile nav backdrop overlay with click-to-dismiss, fix panel/backdrop height (backdrop-filter containing block workaround)
- Fix MCP badge stretching full width in flex container
- Remove empty usage code element from /soleur:help card
- Add border-radius to problem and feature cards for visual consistency
- Add scroll fade indicator to category pill navigation
- Restyle Learn More links as responsive card grid
- Switch feature grid from rigid 5-column to responsive auto-fill layout
- Document backdrop-filter CSS learning

## Test plan

- [ ] Verify Getting Started page: gold color on command codes matches workflow section
- [ ] Verify Commands page: no text overlap on command names at any viewport width
- [ ] Verify mobile (375px): hamburger opens nav with dark backdrop, tapping backdrop dismisses nav
- [ ] Verify MCP page: badge stays compact, not full-width
- [ ] Verify homepage: feature cards and problem cards have rounded corners
- [ ] Verify agents/skills pages: category pills show right-edge fade indicator
- [ ] Verify Getting Started: Learn More section displays as card grid
- [ ] Verify homepage: feature grid wraps responsively at all viewport sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)