### PR TITLE
compound: expand Playwright screenshot cleanup learning

### DIFF
--- a/knowledge-base/learnings/2026-02-17-playwright-screenshots-land-in-main-repo.md
+++ b/knowledge-base/learnings/2026-02-17-playwright-screenshots-land-in-main-repo.md
@@ -2,16 +2,21 @@
 title: Playwright MCP screenshots write to main repo, not active worktree
 date: 2026-02-17
 category: workflow
-tags: [playwright, worktree, screenshots, browser-testing]
+tags: [playwright, worktree, screenshots, browser-testing, cleanup]
 module: docs
-symptoms: [screenshots-in-wrong-directory, playwright-mcp-in-main-repo]
+symptoms: [screenshots-in-wrong-directory, playwright-mcp-in-main-repo, loose-png-files-in-repo-root]
 ---
 
 # Playwright MCP Screenshots Write to Main Repo, Not Active Worktree
 
 ## Problem
 
-When using Playwright MCP tools (browser_take_screenshot, browser_snapshot) while working in a git worktree, screenshots and console logs are saved to `.playwright-mcp/` in the main repository root, not in the active worktree directory.
+When using Playwright MCP tools while working in a git worktree, screenshots land in the **main repository root**, not the active worktree directory. This happens in two ways:
+
+1. **Auto-named screenshots** (no `filename` param): saved to `.playwright-mcp/` in the main repo root
+2. **Custom-named screenshots** (with `filename` param like `desktop-homepage.png`): saved as loose files directly in the main repo root
+
+Both are invisible to `git status` inside the worktree but clutter the main repo. In this session, 15 named audit screenshots (`desktop-homepage.png`, `mobile-nav-open.png`, `tablet-commands.png`, etc.) accumulated in the repo root unnoticed until after the PR was merged.
 
 ## Root Cause
 
@@ -19,19 +24,24 @@ Playwright MCP resolves its output directory relative to the project root (the g
 
 ## Impact
 
-- Screenshots accumulate in the main repo and show up as untracked files on `git status`
-- Must manually clean `.playwright-mcp/` after visual verification sessions
-- Screenshots are not co-located with the worktree branch they belong to
+- Loose `.png` files accumulate in the main repo root
+- `.playwright-mcp/` directory fills with timestamped screenshots and logs
+- Easy to miss during cleanup because `git status` in the worktree won't show them
+- Can accidentally get committed if a future `git add .` is run from main
 
 ## Workaround
 
-After completing browser-based visual verification in a worktree session, clean up the screenshots directory in the main repo:
+After completing browser-based visual verification, clean up **both** locations in the main repo:
 
 ```bash
+# Clean auto-named screenshots and logs
 rm /path/to/main-repo/.playwright-mcp/*.png
 rm /path/to/main-repo/.playwright-mcp/*.log
+
+# Clean custom-named screenshots from repo root
+rm /path/to/main-repo/*.png  # review first with ls *.png to avoid deleting legitimate files
 ```
 
 ## Key Takeaway
 
-When using Playwright MCP for visual verification during worktree-based development, remember to clean `.playwright-mcp/` in the main repo as part of post-merge cleanup. Add this to the mental checklist alongside worktree removal and branch deletion.
+Add screenshot cleanup to the post-merge checklist alongside worktree removal and branch deletion. Always check the main repo root for loose `.png` files after any Playwright-based visual verification session -- they will NOT appear in the worktree's `git status`.


### PR DESCRIPTION
## Summary

- Expand the Playwright worktree learning to cover both `.playwright-mcp/` auto-named files AND loose custom-named `.png` files in the repo root
- Add concrete cleanup steps for both locations
- Document that loose files are invisible to `git status` inside the worktree

## Test plan

- [ ] Learning file has correct YAML frontmatter and accurate content

🤖 Generated with [Claude Code](https://claude.com/claude-code)