### PR TITLE
docs: consolidate Skills page from 8 categories to 4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.12.3"
+      placeholder: "2.12.4"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.12.3-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.12.4-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.12.3",
+  "version": "2.12.4",
   "description": "AI-powered development tools for Claude Code that get smarter with every use. 28 agents, 8 commands, and 37 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.4] - 2026-02-17
+
+### Changed
+
+- Consolidate Skills page from 8 categories to 4: Content & Release, Development, Review & Planning, Workflow
+- Order skill categories alphabetically to match Agents page convention
+- Update release-docs skill to reference new skill category names
+
 ## [2.12.3] - 2026-02-17
 
 ### Fixed

--- a/plugins/soleur/README.md
+++ b/plugins/soleur/README.md
@@ -204,107 +204,62 @@ All commands use the `soleur:` prefix to avoid collisions with built-in commands
 
 ## Skills
 
-### Architecture & Design
+### Content & Release
+
+| Skill | Description |
+|-------|-------------|
+| `brainstorming` | Explore intent, approaches, and design decisions |
+| `changelog` | Create engaging changelogs for recent merges |
+| `compound-docs` | Capture solved problems as categorized documentation |
+| `deploy-docs` | Validate and prepare documentation for deployment |
+| `discord-content` | Create and post brand-consistent community content to Discord |
+| `every-style-editor` | Review copy for Every's style guide compliance |
+| `feature-video` | Record video walkthroughs and add to PR description |
+| `file-todos` | File-based todo tracking system |
+| `gemini-imagegen` | Generate and edit images using Google's Gemini API |
+| `release-announce` | Announce releases to Discord and GitHub Releases |
+| `release-docs` | Build and update documentation site with current components |
+| `triage` | Triage and categorize findings for the CLI todo system |
+
+### Development
 
 | Skill | Description |
 |-------|-------------|
 | `agent-native-architecture` | Build AI agents using prompt-native architecture |
-
-### Engineering Methodology
-
-| Skill | Description |
-|-------|-------------|
-| `atdd-developer` | Acceptance Test Driven Development with RED/GREEN/REFACTOR permission gates |
-| `user-story-writer` | Decompose features into INVEST-compliant stories using Elephant Carpaccio |
-
-### Development Tools
-
-| Skill | Description |
-|-------|-------------|
+| `agent-native-audit` | Run comprehensive agent-native architecture review |
 | `andrew-kane-gem-writer` | Write Ruby gems following Andrew Kane's patterns |
-| `compound-docs` | Capture solved problems as categorized documentation |
+| `atdd-developer` | Acceptance Test Driven Development with RED/GREEN/REFACTOR permission gates |
 | `dhh-rails-style` | Write Ruby/Rails code in DHH's 37signals style |
 | `dspy-ruby` | Build type-safe LLM applications with DSPy.rb |
 | `frontend-design` | Create production-grade frontend interfaces |
 | `skill-creator` | Create, refine, audit, and package Claude Code skills |
+| `spec-templates` | Structured feature specifications and task tracking |
+| `user-story-writer` | Decompose features into INVEST-compliant stories using Elephant Carpaccio |
 
-### Planning & Review
+### Review & Planning
 
 | Skill | Description |
 |-------|-------------|
-| `changelog` | Create engaging changelogs for recent merges |
 | `deepen-plan` | Enhance plans with parallel research agents |
-| `deploy-docs` | Validate and prepare documentation for deployment |
-| `plan-review` | Multi-agent plan review in parallel |
-| `release-announce` | Announce releases to Discord and GitHub Releases |
-| `release-docs` | Build and update documentation site with current components |
-
-### Resolution & Automation
-
-| Skill | Description |
-|-------|-------------|
-| `resolve-parallel` | Resolve TODO comments in parallel |
-| `resolve-pr-parallel` | Resolve PR comments in parallel |
-| `resolve-todo-parallel` | Resolve CLI todos in parallel |
-| `triage` | Triage and categorize findings for the CLI todo system |
-
-### Testing & QA
-
-| Skill | Description |
-|-------|-------------|
-| `agent-native-audit` | Run comprehensive agent-native architecture review |
-| `feature-video` | Record video walkthroughs and add to PR description |
 | `heal-skill` | Fix skill documentation issues |
+| `plan-review` | Multi-agent plan review in parallel |
 | `report-bug` | Report a bug in the plugin |
-| `reproduce-bug` | Reproduce bugs using logs, console, and browser screenshots |
-| `test-browser` | Run browser tests on PR-affected pages |
-| `xcode-test` | Build and test iOS apps on simulator |
 
-### Content & Workflow
-
-| Skill | Description |
-|-------|-------------|
-| `discord-content` | Create and post brand-consistent community content to Discord |
-| `every-style-editor` | Review copy for Every's style guide compliance |
-| `file-todos` | File-based todo tracking system |
-| `git-worktree` | Manage Git worktrees for parallel development |
-| `ship` | Enforce feature lifecycle checklist before creating PRs |
-
-### Deployment
-
-| Skill | Description |
-|-------|-------------|
-| `deploy` | Deploy containerized applications via Docker build, GHCR push, and SSH |
-
-### File Transfer
-
-| Skill | Description |
-|-------|-------------|
-| `rclone` | Upload files to S3, Cloudflare R2, Backblaze B2, and cloud storage |
-
-### Browser Automation
+### Workflow
 
 | Skill | Description |
 |-------|-------------|
 | `agent-browser` | CLI-based browser automation using Vercel's agent-browser |
-
-### Image Generation
-
-| Skill | Description |
-|-------|-------------|
-| `gemini-imagegen` | Generate and edit images using Google's Gemini API |
-
-**gemini-imagegen features:**
-
-- Text-to-image generation
-- Image editing and manipulation
-- Multi-turn refinement
-- Multiple reference image composition (up to 14 images)
-
-**Requirements:**
-
-- `GEMINI_API_KEY` environment variable
-- Python packages: `google-genai`, `pillow`
+| `deploy` | Deploy containerized applications via Docker build, GHCR push, and SSH |
+| `git-worktree` | Manage Git worktrees for parallel development |
+| `rclone` | Upload files to S3, Cloudflare R2, Backblaze B2, and cloud storage |
+| `reproduce-bug` | Reproduce bugs using logs, console, and browser screenshots |
+| `resolve-parallel` | Resolve TODO comments in parallel |
+| `resolve-pr-parallel` | Resolve PR comments in parallel |
+| `resolve-todo-parallel` | Resolve CLI todos in parallel |
+| `ship` | Enforce feature lifecycle checklist before creating PRs |
+| `test-browser` | Run browser tests on PR-affected pages |
+| `xcode-test` | Build and test iOS apps on simulator |
 
 ## MCP Servers
 

--- a/plugins/soleur/docs/pages/skills.html
+++ b/plugins/soleur/docs/pages/skills.html
@@ -40,151 +40,23 @@
 
     <div class="container">
       <nav class="category-nav" aria-label="Skill categories">
-        <a href="pages/skills.html#development-tools" class="category-pill">Development Tools</a>
-        <a href="pages/skills.html#browser-testing" class="category-pill">Browser &amp; Testing</a>
-        <a href="pages/skills.html#content-workflow" class="category-pill">Content &amp; Workflow</a>
+        <a href="pages/skills.html#content-release" class="category-pill">Content &amp; Release</a>
+        <a href="pages/skills.html#development" class="category-pill">Development</a>
         <a href="pages/skills.html#review-planning" class="category-pill">Review &amp; Planning</a>
-        <a href="pages/skills.html#git-devops" class="category-pill">Git &amp; DevOps</a>
-        <a href="pages/skills.html#resolution-automation" class="category-pill">Resolution &amp; Automation</a>
-        <a href="pages/skills.html#documentation-release" class="category-pill">Documentation &amp; Release</a>
-        <a href="pages/skills.html#image-generation" class="category-pill">Image Generation</a>
+        <a href="pages/skills.html#workflow" class="category-pill">Workflow</a>
       </nav>
 
-      <!-- Development Tools -->
-      <section id="development-tools" class="category-section">
+      <!-- Content & Release -->
+      <section id="content-release" class="category-section">
         <div class="category-header">
-          <h2 class="category-title">Development Tools</h2>
-          <span class="category-count">10 skills</span>
-        </div>
-        <div class="catalog-grid">
-          <article class="component-card">
-            <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-tools)"></span>
-              <span class="card-category">Development Tools</span>
-            </div>
-            <h3 class="card-title">agent-native-architecture</h3>
-            <p class="card-description">Design agent-native applications</p>
-          </article>
-          <article class="component-card">
-            <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-tools)"></span>
-              <span class="card-category">Development Tools</span>
-            </div>
-            <h3 class="card-title">agent-native-audit</h3>
-            <p class="card-description">Comprehensive agent-native architecture review with scored principles</p>
-          </article>
-          <article class="component-card">
-            <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-tools)"></span>
-              <span class="card-category">Development Tools</span>
-            </div>
-            <h3 class="card-title">andrew-kane-gem-writer</h3>
-            <p class="card-description">Write Ruby gems following Andrew Kane's patterns</p>
-          </article>
-          <article class="component-card">
-            <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-tools)"></span>
-              <span class="card-category">Development Tools</span>
-            </div>
-            <h3 class="card-title">atdd-developer</h3>
-            <p class="card-description">Acceptance Test Driven Development with RED/GREEN/REFACTOR</p>
-          </article>
-          <article class="component-card">
-            <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-tools)"></span>
-              <span class="card-category">Development Tools</span>
-            </div>
-            <h3 class="card-title">dhh-rails-style</h3>
-            <p class="card-description">Ruby and Rails code in DHH's distinctive style</p>
-          </article>
-          <article class="component-card">
-            <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-tools)"></span>
-              <span class="card-category">Development Tools</span>
-            </div>
-            <h3 class="card-title">dspy-ruby</h3>
-            <p class="card-description">DSPy.rb framework for type-safe LLM applications</p>
-          </article>
-          <article class="component-card">
-            <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-tools)"></span>
-              <span class="card-category">Development Tools</span>
-            </div>
-            <h3 class="card-title">frontend-design</h3>
-            <p class="card-description">Create distinctive, production-grade frontend interfaces</p>
-          </article>
-          <article class="component-card">
-            <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-tools)"></span>
-              <span class="card-category">Development Tools</span>
-            </div>
-            <h3 class="card-title">skill-creator</h3>
-            <p class="card-description">Create, refine, and audit Claude Code Skills</p>
-          </article>
-          <article class="component-card">
-            <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-tools)"></span>
-              <span class="card-category">Development Tools</span>
-            </div>
-            <h3 class="card-title">spec-templates</h3>
-            <p class="card-description">Structured feature specifications and task tracking</p>
-          </article>
-          <article class="component-card">
-            <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-tools)"></span>
-              <span class="card-category">Development Tools</span>
-            </div>
-            <h3 class="card-title">user-story-writer</h3>
-            <p class="card-description">Decompose requirements into implementable user stories</p>
-          </article>
-        </div>
-      </section>
-
-      <!-- Browser & Testing -->
-      <section id="browser-testing" class="category-section">
-        <div class="category-header">
-          <h2 class="category-title">Browser &amp; Testing</h2>
-          <span class="category-count">3 skills</span>
-        </div>
-        <div class="catalog-grid">
-          <article class="component-card">
-            <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-review)"></span>
-              <span class="card-category">Browser &amp; Testing</span>
-            </div>
-            <h3 class="card-title">agent-browser</h3>
-            <p class="card-description">Browser automation via agent-browser CLI</p>
-          </article>
-          <article class="component-card">
-            <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-review)"></span>
-              <span class="card-category">Browser &amp; Testing</span>
-            </div>
-            <h3 class="card-title">test-browser</h3>
-            <p class="card-description">End-to-end browser tests on PR-affected pages</p>
-          </article>
-          <article class="component-card">
-            <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-review)"></span>
-              <span class="card-category">Browser &amp; Testing</span>
-            </div>
-            <h3 class="card-title">xcode-test</h3>
-            <p class="card-description">Build and test iOS apps on simulator</p>
-          </article>
-        </div>
-      </section>
-
-      <!-- Content & Workflow -->
-      <section id="content-workflow" class="category-section">
-        <div class="category-header">
-          <h2 class="category-title">Content &amp; Workflow</h2>
-          <span class="category-count">7 skills</span>
+          <h2 class="category-title">Content &amp; Release</h2>
+          <span class="category-count">12 skills</span>
         </div>
         <div class="catalog-grid">
           <article class="component-card">
             <div class="card-header">
               <span class="card-dot" style="background: var(--cat-content)"></span>
-              <span class="card-category">Content &amp; Workflow</span>
+              <span class="card-category">Content &amp; Release</span>
             </div>
             <h3 class="card-title">brainstorming</h3>
             <p class="card-description">Explore intent, approaches, and design decisions</p>
@@ -192,7 +64,7 @@
           <article class="component-card">
             <div class="card-header">
               <span class="card-dot" style="background: var(--cat-content)"></span>
-              <span class="card-category">Content &amp; Workflow</span>
+              <span class="card-category">Content &amp; Release</span>
             </div>
             <h3 class="card-title">changelog</h3>
             <p class="card-description">Create engaging changelogs for recent merges</p>
@@ -200,7 +72,7 @@
           <article class="component-card">
             <div class="card-header">
               <span class="card-dot" style="background: var(--cat-content)"></span>
-              <span class="card-category">Content &amp; Workflow</span>
+              <span class="card-category">Content &amp; Release</span>
             </div>
             <h3 class="card-title">compound-docs</h3>
             <p class="card-description">Capture solved problems as categorized documentation</p>
@@ -208,7 +80,15 @@
           <article class="component-card">
             <div class="card-header">
               <span class="card-dot" style="background: var(--cat-content)"></span>
-              <span class="card-category">Content &amp; Workflow</span>
+              <span class="card-category">Content &amp; Release</span>
+            </div>
+            <h3 class="card-title">deploy-docs</h3>
+            <p class="card-description">Validate docs for GitHub Pages deployment</p>
+          </article>
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-content)"></span>
+              <span class="card-category">Content &amp; Release</span>
             </div>
             <h3 class="card-title">discord-content</h3>
             <p class="card-description">Create and post community content to Discord</p>
@@ -216,7 +96,7 @@
           <article class="component-card">
             <div class="card-header">
               <span class="card-dot" style="background: var(--cat-content)"></span>
-              <span class="card-category">Content &amp; Workflow</span>
+              <span class="card-category">Content &amp; Release</span>
             </div>
             <h3 class="card-title">every-style-editor</h3>
             <p class="card-description">Review copy for Every's style guide compliance</p>
@@ -224,7 +104,15 @@
           <article class="component-card">
             <div class="card-header">
               <span class="card-dot" style="background: var(--cat-content)"></span>
-              <span class="card-category">Content &amp; Workflow</span>
+              <span class="card-category">Content &amp; Release</span>
+            </div>
+            <h3 class="card-title">feature-video</h3>
+            <p class="card-description">Record video walkthroughs for PRs</p>
+          </article>
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-content)"></span>
+              <span class="card-category">Content &amp; Release</span>
             </div>
             <h3 class="card-title">file-todos</h3>
             <p class="card-description">Manage file-based todo tracking system</p>
@@ -232,10 +120,124 @@
           <article class="component-card">
             <div class="card-header">
               <span class="card-dot" style="background: var(--cat-content)"></span>
-              <span class="card-category">Content &amp; Workflow</span>
+              <span class="card-category">Content &amp; Release</span>
+            </div>
+            <h3 class="card-title">gemini-imagegen</h3>
+            <p class="card-description">Generate and edit images with Gemini API</p>
+          </article>
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-content)"></span>
+              <span class="card-category">Content &amp; Release</span>
+            </div>
+            <h3 class="card-title">release-announce</h3>
+            <p class="card-description">Announce releases to GitHub and Discord</p>
+          </article>
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-content)"></span>
+              <span class="card-category">Content &amp; Release</span>
+            </div>
+            <h3 class="card-title">release-docs</h3>
+            <p class="card-description">Update documentation site with component inventories</p>
+          </article>
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-content)"></span>
+              <span class="card-category">Content &amp; Release</span>
             </div>
             <h3 class="card-title">triage</h3>
             <p class="card-description">Triage and categorize findings for CLI todo system</p>
+          </article>
+        </div>
+      </section>
+
+      <!-- Development -->
+      <section id="development" class="category-section">
+        <div class="category-header">
+          <h2 class="category-title">Development</h2>
+          <span class="category-count">10 skills</span>
+        </div>
+        <div class="catalog-grid">
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-tools)"></span>
+              <span class="card-category">Development</span>
+            </div>
+            <h3 class="card-title">agent-native-architecture</h3>
+            <p class="card-description">Design agent-native applications</p>
+          </article>
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-tools)"></span>
+              <span class="card-category">Development</span>
+            </div>
+            <h3 class="card-title">agent-native-audit</h3>
+            <p class="card-description">Comprehensive agent-native architecture review with scored principles</p>
+          </article>
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-tools)"></span>
+              <span class="card-category">Development</span>
+            </div>
+            <h3 class="card-title">andrew-kane-gem-writer</h3>
+            <p class="card-description">Write Ruby gems following Andrew Kane's patterns</p>
+          </article>
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-tools)"></span>
+              <span class="card-category">Development</span>
+            </div>
+            <h3 class="card-title">atdd-developer</h3>
+            <p class="card-description">Acceptance Test Driven Development with RED/GREEN/REFACTOR</p>
+          </article>
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-tools)"></span>
+              <span class="card-category">Development</span>
+            </div>
+            <h3 class="card-title">dhh-rails-style</h3>
+            <p class="card-description">Ruby and Rails code in DHH's distinctive style</p>
+          </article>
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-tools)"></span>
+              <span class="card-category">Development</span>
+            </div>
+            <h3 class="card-title">dspy-ruby</h3>
+            <p class="card-description">DSPy.rb framework for type-safe LLM applications</p>
+          </article>
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-tools)"></span>
+              <span class="card-category">Development</span>
+            </div>
+            <h3 class="card-title">frontend-design</h3>
+            <p class="card-description">Create distinctive, production-grade frontend interfaces</p>
+          </article>
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-tools)"></span>
+              <span class="card-category">Development</span>
+            </div>
+            <h3 class="card-title">skill-creator</h3>
+            <p class="card-description">Create, refine, and audit Claude Code Skills</p>
+          </article>
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-tools)"></span>
+              <span class="card-category">Development</span>
+            </div>
+            <h3 class="card-title">spec-templates</h3>
+            <p class="card-description">Structured feature specifications and task tracking</p>
+          </article>
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-tools)"></span>
+              <span class="card-category">Development</span>
+            </div>
+            <h3 class="card-title">user-story-writer</h3>
+            <p class="card-description">Decompose requirements into implementable user stories</p>
           </article>
         </div>
       </section>
@@ -282,59 +284,49 @@
         </div>
       </section>
 
-      <!-- Git & DevOps -->
-      <section id="git-devops" class="category-section">
+      <!-- Workflow -->
+      <section id="workflow" class="category-section">
         <div class="category-header">
-          <h2 class="category-title">Git &amp; DevOps</h2>
-          <span class="category-count">4 skills</span>
+          <h2 class="category-title">Workflow</h2>
+          <span class="category-count">11 skills</span>
         </div>
         <div class="catalog-grid">
           <article class="component-card">
             <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-infra)"></span>
-              <span class="card-category">Git &amp; DevOps</span>
+              <span class="card-dot" style="background: var(--cat-workflow)"></span>
+              <span class="card-category">Workflow</span>
+            </div>
+            <h3 class="card-title">agent-browser</h3>
+            <p class="card-description">Browser automation via agent-browser CLI</p>
+          </article>
+          <article class="component-card">
+            <div class="card-header">
+              <span class="card-dot" style="background: var(--cat-workflow)"></span>
+              <span class="card-category">Workflow</span>
             </div>
             <h3 class="card-title">deploy</h3>
             <p class="card-description">Deploy containerized applications to remote servers</p>
           </article>
           <article class="component-card">
             <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-infra)"></span>
-              <span class="card-category">Git &amp; DevOps</span>
+              <span class="card-dot" style="background: var(--cat-workflow)"></span>
+              <span class="card-category">Workflow</span>
             </div>
             <h3 class="card-title">git-worktree</h3>
             <p class="card-description">Manage Git worktrees for parallel development</p>
           </article>
           <article class="component-card">
             <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-infra)"></span>
-              <span class="card-category">Git &amp; DevOps</span>
+              <span class="card-dot" style="background: var(--cat-workflow)"></span>
+              <span class="card-category">Workflow</span>
             </div>
             <h3 class="card-title">rclone</h3>
             <p class="card-description">Upload and sync files across cloud storage</p>
           </article>
           <article class="component-card">
             <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-infra)"></span>
-              <span class="card-category">Git &amp; DevOps</span>
-            </div>
-            <h3 class="card-title">ship</h3>
-            <p class="card-description">Prepare features for production deployment</p>
-          </article>
-        </div>
-      </section>
-
-      <!-- Resolution & Automation -->
-      <section id="resolution-automation" class="category-section">
-        <div class="category-header">
-          <h2 class="category-title">Resolution &amp; Automation</h2>
-          <span class="category-count">4 skills</span>
-        </div>
-        <div class="catalog-grid">
-          <article class="component-card">
-            <div class="card-header">
               <span class="card-dot" style="background: var(--cat-workflow)"></span>
-              <span class="card-category">Resolution &amp; Automation</span>
+              <span class="card-category">Workflow</span>
             </div>
             <h3 class="card-title">reproduce-bug</h3>
             <p class="card-description">Investigate bugs with logs, code, and browser screenshots</p>
@@ -342,7 +334,7 @@
           <article class="component-card">
             <div class="card-header">
               <span class="card-dot" style="background: var(--cat-workflow)"></span>
-              <span class="card-category">Resolution &amp; Automation</span>
+              <span class="card-category">Workflow</span>
             </div>
             <h3 class="card-title">resolve-parallel</h3>
             <p class="card-description">Resolve all TODO comments using parallel processing</p>
@@ -350,7 +342,7 @@
           <article class="component-card">
             <div class="card-header">
               <span class="card-dot" style="background: var(--cat-workflow)"></span>
-              <span class="card-category">Resolution &amp; Automation</span>
+              <span class="card-category">Workflow</span>
             </div>
             <h3 class="card-title">resolve-pr-parallel</h3>
             <p class="card-description">Resolve PR comments using parallel agents</p>
@@ -358,70 +350,34 @@
           <article class="component-card">
             <div class="card-header">
               <span class="card-dot" style="background: var(--cat-workflow)"></span>
-              <span class="card-category">Resolution &amp; Automation</span>
+              <span class="card-category">Workflow</span>
             </div>
             <h3 class="card-title">resolve-todo-parallel</h3>
             <p class="card-description">Resolve pending CLI todos in parallel</p>
           </article>
-        </div>
-      </section>
-
-      <!-- Documentation & Release -->
-      <section id="documentation-release" class="category-section">
-        <div class="category-header">
-          <h2 class="category-title">Documentation &amp; Release</h2>
-          <span class="category-count">4 skills</span>
-        </div>
-        <div class="catalog-grid">
           <article class="component-card">
             <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-design)"></span>
-              <span class="card-category">Documentation &amp; Release</span>
+              <span class="card-dot" style="background: var(--cat-workflow)"></span>
+              <span class="card-category">Workflow</span>
             </div>
-            <h3 class="card-title">deploy-docs</h3>
-            <p class="card-description">Validate docs for GitHub Pages deployment</p>
+            <h3 class="card-title">ship</h3>
+            <p class="card-description">Prepare features for production deployment</p>
           </article>
           <article class="component-card">
             <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-design)"></span>
-              <span class="card-category">Documentation &amp; Release</span>
+              <span class="card-dot" style="background: var(--cat-workflow)"></span>
+              <span class="card-category">Workflow</span>
             </div>
-            <h3 class="card-title">feature-video</h3>
-            <p class="card-description">Record video walkthroughs for PRs</p>
+            <h3 class="card-title">test-browser</h3>
+            <p class="card-description">End-to-end browser tests on PR-affected pages</p>
           </article>
           <article class="component-card">
             <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-design)"></span>
-              <span class="card-category">Documentation &amp; Release</span>
+              <span class="card-dot" style="background: var(--cat-workflow)"></span>
+              <span class="card-category">Workflow</span>
             </div>
-            <h3 class="card-title">release-announce</h3>
-            <p class="card-description">Announce releases to GitHub and Discord</p>
-          </article>
-          <article class="component-card">
-            <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-design)"></span>
-              <span class="card-category">Documentation &amp; Release</span>
-            </div>
-            <h3 class="card-title">release-docs</h3>
-            <p class="card-description">Update documentation site with component inventories</p>
-          </article>
-        </div>
-      </section>
-
-      <!-- Image Generation -->
-      <section id="image-generation" class="category-section">
-        <div class="category-header">
-          <h2 class="category-title">Image Generation</h2>
-          <span class="category-count">1 skill</span>
-        </div>
-        <div class="catalog-grid">
-          <article class="component-card">
-            <div class="card-header">
-              <span class="card-dot" style="background: var(--cat-marketing)"></span>
-              <span class="card-category">Image Generation</span>
-            </div>
-            <h3 class="card-title">gemini-imagegen</h3>
-            <p class="card-description">Generate and edit images with Gemini API</p>
+            <h3 class="card-title">xcode-test</h3>
+            <p class="card-description">Build and test iOS apps on simulator</p>
           </article>
         </div>
       </section>

--- a/plugins/soleur/skills/release-docs/SKILL.md
+++ b/plugins/soleur/skills/release-docs/SKILL.md
@@ -86,7 +86,7 @@ Regenerate the complete agents reference page:
 ### 2c. Update `docs/pages/skills.html`
 
 Regenerate the complete skills reference page:
-- Group skills by category (Development Tools, Content & Workflow, Image Generation)
+- Group skills by category (Content & Release, Development, Review & Planning, Workflow)
 - Include for each skill:
   - Name and description
   - Usage: `claude skill [skill-name]`


### PR DESCRIPTION
## Summary
- Consolidate Skills page from 8 granular categories to 4 broader groups: **Content & Release** (12), **Development** (10), **Review & Planning** (4), **Workflow** (11)
- Order categories alphabetically to match the Agents page convention
- Align plugin README skill tables with the same 4 categories
- Add 2 previously missing skills to README (brainstorming, spec-templates)
- Update release-docs skill to reference new category names

## Test plan
- [ ] Verify Skills page renders correctly with 4 category pills
- [ ] Verify all 37 skills are listed (12 + 10 + 4 + 11)
- [ ] Verify categories are alphabetical: Content & Release, Development, Review & Planning, Workflow
- [ ] Verify deploy-docs CI validation passes
- [ ] Verify plugin README skill tables match docs page grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)