### PR TITLE
fix: enforce branch isolation before any file edits

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.12.4"
+      placeholder: "2.12.5"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.12.4-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.12.5-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/knowledge-base/learnings/logic-errors/2026-02-17-parallel-agents-on-main-cause-conflicts.md
+++ b/knowledge-base/learnings/logic-errors/2026-02-17-parallel-agents-on-main-cause-conflicts.md
@@ -1,0 +1,56 @@
+---
+title: "Parallel agents working on main cause merge conflicts"
+category: logic-errors
+tags:
+  - parallel-agents
+  - git-branching
+  - worktree
+  - workflow
+  - merge-conflicts
+module: workflow-commands
+created: 2026-02-17
+severity: high
+synced_to:
+  - plugins/soleur/commands/soleur/work.md
+  - plugins/soleur/commands/soleur/one-shot.md
+---
+
+# Learning: Agents must branch before editing, even for trivial fixes
+
+## Problem
+
+When an agent skips brainstorm (which normally creates a worktree in Phase 3) and goes directly to `/soleur:work` or is invoked ad-hoc for a quick fix, the `work` command offers "Option C: Continue on the default branch." This allows agents to edit files directly on main.
+
+When two agents run in parallel on the same repo -- both on main or both touching the same files -- the second agent's rebase silently drops its changes because the first agent already modified the same lines. In one session, a complete set of edits (agents page reorder, getting-started fix, version bump) was lost after rebase because a parallel agent had already made equivalent changes to the same files.
+
+The root cause is that `work.md` Phase 1 treats branch creation as optional (3 options including "stay on main"), and `one-shot.md` doesn't enforce branch creation at all before delegating to plan/work.
+
+## Solution
+
+1. **Remove Option C from `work.md`** -- never allow working directly on the default branch. The only options should be: create a new branch (Option A) or use a worktree (Option B). CLAUDE.md already mandates "never commit directly to main."
+
+2. **Add branch/worktree creation to `one-shot.md`** before the plan step -- since one-shot skips brainstorm (which normally handles worktree creation), it must ensure isolation before any work begins.
+
+3. **Default to worktree (Option B)** when parallel development is detected (e.g., other worktrees exist or other agents are active).
+
+## Key Insight
+
+Branch creation must happen BEFORE the first file edit, not as an optional step during setup. When brainstorm is skipped, the worktree creation that brainstorm normally handles never runs, leaving agents to work on main. Every entry point to implementation (work, one-shot, ad-hoc fixes) must enforce isolation as a precondition, not a recommendation.
+
+## Prevention
+
+- Remove all "continue on default branch" options from workflow commands
+- Add a hard gate in work.md Phase 1: if on default branch, MUST branch before proceeding
+- one-shot should create branch/worktree as step 0 before plan
+
+## Cross-references
+
+- CLAUDE.md Working Agreement: "Never commit directly to main"
+- [2026-02-17-truncated-changelog-during-rebase-conflict-resolution.md](../integration-issues/2026-02-17-truncated-changelog-during-rebase-conflict-resolution.md) -- related rebase conflict from same session
+- PR #121 session: parallel agent conflict that triggered this learning
+
+## Tags
+
+category: logic-errors
+module: workflow-commands
+symptoms: changes lost after rebase, parallel agent conflicts, zero diff after rebase, silent change loss

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -48,6 +48,7 @@ Project principles organized by domain. Add principles as you learn them.
 - Never state conventions in constitution.md without tooling enforcement (config files, pre-commit hooks, or CI checks)
 - Never commit local config files that may contain secrets (`.claude/settings.local.json`, `.env`, `*.local.*`) -- add them to `.gitignore` at project initialization
 - Never edit files in the main repo root when a worktree is active for the current feature -- verify `pwd` shows `.worktrees/<name>/` before writing; place feature-scoped directories (todos, reports) inside the app directory within the worktree
+- Never allow agents to work directly on the default branch -- create a feature branch or worktree before the first file edit, even for trivial fixes; parallel agents on main cause silent merge conflicts
 - Never persist aggregated security findings (audit reports, posture assessments) to files in an open-source repository -- output inline in conversation only; the aggregation is the risk, not the individual facts
 
 ### Prefer

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.12.4",
+  "version": "2.12.5",
   "description": "AI-powered development tools for Claude Code that get smarter with every use. 28 agents, 8 commands, and 37 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.5] - 2026-02-17
+
+### Fixed
+
+- Remove Option C ("continue on default branch") from work command -- agents must always branch before editing
+- Add Step 0 branch isolation to one-shot command -- creates feature branch before plan when on default branch
+
 ## [2.12.4] - 2026-02-17
 
 ### Changed

--- a/plugins/soleur/commands/soleur/one-shot.md
+++ b/plugins/soleur/commands/soleur/one-shot.md
@@ -4,7 +4,21 @@ description: Full autonomous engineering workflow from plan to PR with video
 argument-hint: "[feature description or issue reference]"
 ---
 
-Run these slash commands in order. Do not do anything else.
+Run these steps in order. Do not do anything else.
+
+**Step 0: Ensure branch isolation.** If on the default branch (main/master), create a feature branch before proceeding. Parallel agents on the same repo cause silent merge conflicts when both work on main.
+
+```bash
+current_branch=$(git branch --show-current)
+default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+if [ -z "$default_branch" ]; then
+  default_branch=$(git rev-parse --verify origin/main >/dev/null 2>&1 && echo "main" || echo "master")
+fi
+if [ "$current_branch" = "$default_branch" ]; then
+  git pull origin "$default_branch"
+  git checkout -b feat/one-shot-$(echo "$ARGUMENTS" | tr ' ' '-' | tr '[:upper:]' '[:lower:]' | head -c 40)
+fi
+```
 
 1. `/ralph-wiggum:ralph-loop "finish all slash commands" --completion-promise "DONE"`
 2. `/soleur:plan $ARGUMENTS`

--- a/plugins/soleur/commands/soleur/work.md
+++ b/plugins/soleur/commands/soleur/work.md
@@ -98,9 +98,9 @@ fi
    - If continuing, proceed to step 3
    - If creating new, follow Option A or B below
 
-   **If on the default branch**, choose how to proceed:
+   **If on the default branch**, you MUST create a branch before proceeding. Never edit files on the default branch -- parallel agents cause silent merge conflicts.
 
-   **Option A: Create a new branch**
+   **Option A: Create a new branch (default)**
 
    ```bash
    git pull origin [default_branch]
@@ -116,15 +116,7 @@ fi
    # The skill will create a new branch from the default branch in an isolated worktree
    ```
 
-   **Option C: Continue on the default branch**
-   - Requires explicit user confirmation
-   - Only proceed after user explicitly says "yes, commit to [default_branch]"
-   - Never commit directly to the default branch without explicit permission
-
-   **Recommendation**: Use worktree if:
-   - You want to work on multiple features simultaneously
-   - You want to keep the default branch clean while experimenting
-   - You plan to switch between branches frequently
+   Prefer worktree if other worktrees already exist or multiple features are in-flight.
 
 3. **Create Todo List**
    - Use TodoWrite to break plan into actionable tasks


### PR DESCRIPTION
## Summary
- Remove Option C ("continue on default branch") from `work` command -- agents must always create a branch before editing files
- Add Step 0 branch isolation to `one-shot` command -- auto-creates feature branch when on default branch
- Add constitution rule: never allow agents to work directly on the default branch
- Document learning: parallel agents on main cause silent merge conflicts during rebase

## Context
In a recent session, two agents ran in parallel on main. When the second agent rebased, all its changes were silently dropped because the first agent had already modified the same files. Branch isolation prevents this class of conflict entirely.

## Test plan
- [ ] `work` command no longer offers "continue on default branch" option
- [ ] `one-shot` creates a feature branch before delegating to plan/work
- [ ] Constitution updated with Never rule about agents on default branch
- [ ] Learning documented in `knowledge-base/learnings/logic-errors/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)