### PR TITLE
feat: add setup sub-command to community skill

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.14.0"
+      placeholder: "2.14.1"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.14.0-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.14.1-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/knowledge-base/learnings/2026-02-18-token-env-var-not-cli-arg.md
+++ b/knowledge-base/learnings/2026-02-18-token-env-var-not-cli-arg.md
@@ -1,0 +1,34 @@
+---
+title: "Pass secrets via env var, never as CLI arguments"
+category: implementation-patterns
+tags: [security, bash, secrets, discord, cli]
+module: community
+symptom: "Bot token visible in ps aux and shell history"
+root_cause: "Passing token as positional argument to script"
+---
+
+# Pass secrets via env var, never as CLI arguments
+
+## Problem
+
+When a bash script accepts a secret (e.g., Discord bot token) as a CLI argument, that value is visible to any user on the system via `ps aux` and persists in shell history files.
+
+## Solution
+
+Use a dedicated environment variable (e.g., `DISCORD_BOT_TOKEN_INPUT`) instead:
+
+```bash
+# BAD: token visible in ps aux and ~/.bash_history
+./discord-setup.sh validate-token "MTIz.abc.xyz"
+
+# GOOD: token only in process environment
+DISCORD_BOT_TOKEN_INPUT="MTIz.abc.xyz" ./discord-setup.sh validate-token
+```
+
+The script validates the env var is set and refuses to accept the token as a positional argument.
+
+## Additional measures
+
+- Suppress `curl` stderr (`2>/dev/null`) during requests with auth headers to prevent debug output leaking the token
+- Write `.env` files with `chmod 600` (set permissions before writing secrets, not after)
+- Never echo the token value in error messages

--- a/knowledge-base/plans/2026-02-18-feat-community-setup-wizard-plan.md
+++ b/knowledge-base/plans/2026-02-18-feat-community-setup-wizard-plan.md
@@ -1,0 +1,205 @@
+---
+title: "feat: Add setup sub-command to community skill"
+type: feat
+date: 2026-02-18
+issue: "#129"
+version_bump: PATCH
+deepened: 2026-02-18
+---
+
+# feat: Add setup sub-command to community skill
+
+## Enhancement Summary
+
+**Deepened on:** 2026-02-18
+**Agents used:** security-sentinel, Discord API researcher, plan reviewers (DHH, code-simplicity)
+
+### Key Improvements
+1. Token passed via env var (`DISCORD_BOT_TOKEN_INPUT`), never as CLI argument (prevents ps/history leakage)
+2. .env written with chmod 600 permissions (owner-only)
+3. Concrete curl patterns for all 6 Discord API operations
+
+## Overview
+
+Add a `/soleur:community setup` sub-command that automates Discord bot configuration. Opens the Discord Developer Portal for the user, guides them through bot creation, then automates guild discovery, webhook creation, and .env persistence via the Discord API.
+
+## Problem Statement
+
+The community skill requires three environment variables (DISCORD_BOT_TOKEN, DISCORD_GUILD_ID, DISCORD_WEBHOOK_URL) that users must configure manually. This involves navigating the Discord Developer Portal, enabling intents, generating OAuth2 URLs, and finding guild/channel IDs -- a tedious, error-prone process that blocks adoption.
+
+## Proposed Solution
+
+A bash script (`discord-setup.sh`) with thin sub-commands. The SKILL.md orchestrates user interaction (AskUserQuestion, agent-browser) and calls script sub-commands for API operations. Token is passed via `DISCORD_BOT_TOKEN_INPUT` environment variable, never as a CLI argument.
+
+Flow:
+1. Check if vars already exist -> prompt to reconfigure
+2. Open Discord Developer Portal via agent-browser -> print instructions -> user pastes token
+3. Validate token via API call (skip regex -- API is the source of truth)
+4. Generate OAuth2 URL -> open via agent-browser -> user authorizes
+5. Discover guilds -> user picks if multiple
+6. List channels -> user picks
+7. Create webhook
+8. Write all three vars to .env (chmod 600)
+9. Verify with guild-info -> strict pass/fail
+
+## Technical Approach
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `plugins/soleur/skills/community/SKILL.md` | Add `setup` sub-command section |
+| `plugins/soleur/skills/community/scripts/discord-setup.sh` | New script: API operations |
+| `plugins/soleur/agents/marketing/community-manager.md` | Add setup capability |
+
+### discord-setup.sh Design
+
+Sub-commands called by SKILL.md between user interaction points. Token via env var only.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# discord-setup.sh -- Discord bot setup API operations
+#
+# SECURITY: Token MUST be in DISCORD_BOT_TOKEN_INPUT env var.
+# Never pass tokens as CLI arguments (visible in ps/history).
+#
+# Usage: discord-setup.sh <command> [args]
+# Commands:
+#   validate-token                  - Verify token via API, output app ID
+#   discover-guilds                 - List guilds as JSON
+#   list-channels <guild_id>        - List text channels as JSON
+#   create-webhook <channel_id>     - Create webhook, output webhook URL
+#   write-env <guild_id> <webhook>  - Write to .env with chmod 600
+#   verify                          - Run guild-info check
+```
+
+**Why sub-commands:** The skill (SKILL.md) needs to interject AskUserQuestion prompts between API calls (guild selection, channel selection). A monolithic script cannot pause for AI-mediated user input. Sub-commands are the minimal API boundary.
+
+**Security model:**
+- Token in `DISCORD_BOT_TOKEN_INPUT` env var (not CLI arg -- invisible to `ps aux`)
+- curl stderr suppressed during token operations (prevents debug leakage)
+- .env created with umask 077 / chmod 600 (owner read/write only)
+- Token never echoed in error messages
+
+### SKILL.md Setup Flow
+
+```
+## Sub-command: setup
+
+### Phase 0: Check Existing Config
+
+Check if DISCORD_BOT_TOKEN, DISCORD_GUILD_ID, and DISCORD_WEBHOOK_URL are all set.
+- If all three present: AskUserQuestion "Discord is already configured. Reconfigure?"
+  - If No: exit
+- If missing any: proceed
+
+### Phase 1: Create Bot (agent-browser + instructions)
+
+1. Open https://discord.com/developers/applications via agent-browser (headed mode)
+2. Print instructions:
+   - Click "New Application" -> name it -> Create
+   - Go to Bot tab -> Reset Token -> copy token
+   - Enable SERVER MEMBERS INTENT and MESSAGE CONTENT INTENT -> Save
+3. AskUserQuestion: "Paste your bot token"
+4. Validate securely:
+   DISCORD_BOT_TOKEN_INPUT="$token" discord-setup.sh validate-token
+   - If fails: "Invalid or expired token. Re-copy from portal." Re-prompt once.
+5. Extract app ID from validate-token output
+
+### Phase 2: Invite Bot
+
+1. Generate OAuth2 URL: https://discord.com/oauth2/authorize?client_id={APP_ID}&scope=bot&permissions=536939520
+2. Navigate agent-browser to OAuth2 URL
+3. Print: "Select your server and click 'Authorize'"
+4. AskUserQuestion: "Continue after authorizing"
+
+### Phase 3: Configure
+
+1. DISCORD_BOT_TOKEN_INPUT="$token" discord-setup.sh discover-guilds
+   - If 0: "Bot not in any servers. Complete the invite step first." Exit.
+   - If 1: auto-select
+   - If 2+: AskUserQuestion with guild names
+2. DISCORD_BOT_TOKEN_INPUT="$token" discord-setup.sh list-channels <guild_id>
+   - AskUserQuestion with channel names (first 10 text channels)
+3. DISCORD_BOT_TOKEN_INPUT="$token" discord-setup.sh create-webhook <channel_id>
+   - If 400 (limit reached): suggest different channel, re-prompt
+
+### Phase 4: Persist & Verify
+
+1. DISCORD_BOT_TOKEN_INPUT="$token" discord-setup.sh write-env <guild_id> <webhook_url>
+2. discord-setup.sh verify
+   - If success: display guild name, member count
+   - If failure: exit 1 with error
+3. Display summary:
+   Setup complete!
+   Guild: <name> (<count> members)
+   Channel: #<name>
+   Webhook: soleur-community
+   Config: .env (3 variables written, permissions 600)
+   Next: Run /soleur:community health to see metrics.
+```
+
+### API Endpoint Reference
+
+| Command | Endpoint | Method | Auth |
+|---------|----------|--------|------|
+| validate-token | `/users/@me` + `/oauth2/applications/@me` | GET | Bot token |
+| discover-guilds | `/users/@me/guilds?with_counts=true` | GET | Bot token |
+| list-channels | `/guilds/{id}/channels` | GET | Bot token |
+| create-webhook | `/channels/{id}/webhooks` | POST | Bot token |
+
+## Non-Goals
+
+- Automating clicks inside Discord Developer Portal (too fragile)
+- Supporting multiple Discord servers simultaneously
+- Custom permission integer selection
+- Webhook reuse detection (just create new -- webhooks are free)
+- Token format regex (API validates for free)
+- CI/CD integration (local-only)
+- Secret management integration (pass, 1Password -- future)
+
+## Acceptance Criteria
+
+- [ ] `setup` sub-command appears in community skill sub-command table
+- [ ] Running setup with no env vars walks through full wizard
+- [ ] Running setup with existing vars prompts for reconfiguration
+- [ ] Bot token passed via env var, never as CLI argument
+- [ ] Bot token validated via Discord API before proceeding
+- [ ] Guild auto-discovered from bot token
+- [ ] Channel selection presented via AskUserQuestion
+- [ ] Webhook created with name "soleur-community"
+- [ ] All three vars written to .env with chmod 600
+- [ ] Verification runs guild-info with strict pass/fail
+
+## Test Scenarios
+
+- Given no env vars, when running setup, then full wizard executes
+- Given all three vars set, when running setup, then reconfiguration prompt appears
+- Given expired bot token, when API check runs, then clear error with re-prompt (no token in message)
+- Given bot not in any guilds, when discovery runs, then error about incomplete invite
+- Given bot in multiple guilds, when discovery runs, then selection prompt
+- Given channel at webhook limit, when create fails, then suggest different channel
+- Given successful setup, when verify runs, then guild name and member count displayed
+- Given .env written, when checking permissions, then file is chmod 600
+
+## Dependencies & Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Token in CLI args | Pass via DISCORD_BOT_TOKEN_INPUT env var |
+| Token in debug output | Suppress curl stderr during sensitive operations |
+| .env world-readable | Create with umask 077, chmod 600 |
+| Portal UI changes | Instructions are text-based, not selector-dependent |
+| agent-browser not installed | Print URL as fallback, user opens manually |
+| Rate limiting | discord_request pattern handles 429 with retry |
+
+## References
+
+- Discord API v10: https://discord.com/developers/docs
+- Permissions integer 536939520 = VIEW_CHANNEL (1<<10) + SEND_MESSAGES (1<<11) + READ_MESSAGE_HISTORY (1<<16) + MANAGE_WEBHOOKS (1<<29)
+- Existing: `plugins/soleur/skills/community/scripts/discord-community.sh`
+- Learning: `knowledge-base/learnings/runtime-errors/2026-02-13-bash-operator-precedence-ssh-deploy-fallback.md`
+- Learning: `knowledge-base/learnings/implementation-patterns/2026-02-18-skill-cannot-invoke-skill.md`
+- Issue: #129

--- a/knowledge-base/specs/feat-community-setup/tasks.md
+++ b/knowledge-base/specs/feat-community-setup/tasks.md
@@ -1,0 +1,31 @@
+---
+feature: community-setup
+date: 2026-02-18
+issue: "#129"
+---
+
+# Tasks: Community Setup Wizard
+
+## Phase 1: Setup Script
+
+- [ ] 1.1 Create `discord-setup.sh` with validate-token command (API call, output app ID)
+- [ ] 1.2 Add discover-guilds command (GET /users/@me/guilds, output JSON)
+- [ ] 1.3 Add list-channels command (GET /guilds/{id}/channels, filter type=0, output JSON)
+- [ ] 1.4 Add create-webhook command (POST /channels/{id}/webhooks, output URL)
+- [ ] 1.5 Add write-env command (append three vars to .env)
+- [ ] 1.6 Add verify command (source .env, run guild-info)
+
+## Phase 2: Skill Update
+
+- [ ] 2.1 Add `setup` sub-command section to SKILL.md with full flow
+- [ ] 2.2 Add setup to sub-command table
+
+## Phase 3: Agent Update
+
+- [ ] 3.1 Add setup capability to community-manager.md
+
+## Phase 4: Version Bump
+
+- [ ] 4.1 Bump version in plugin.json (PATCH)
+- [ ] 4.2 Update CHANGELOG.md
+- [ ] 4.3 Verify README.md component counts

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "AI-powered development tools for Claude Code that get smarter with every use. 30 agents, 8 commands, and 38 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.1] - 2026-02-18
+
+### Added
+
+- New `setup` sub-command for the community skill that automates Discord bot configuration
+- New `discord-setup.sh` script with sub-commands: validate-token, discover-guilds, list-channels, create-webhook, write-env, verify
+- Bot token passed via `DISCORD_BOT_TOKEN_INPUT` env var (never as CLI argument) for security
+- .env written with chmod 600 permissions (owner-only read/write)
+- Browser-guided bot creation via agent-browser (opens Discord Developer Portal)
+
+### Changed
+
+- Community skill Phase 0 env var errors now direct users to `/soleur:community setup`
+- Community-manager agent prerequisites now reference the setup sub-command
+
 ## [2.14.0] - 2026-02-18
 
 ### Added

--- a/plugins/soleur/README.md
+++ b/plugins/soleur/README.md
@@ -220,7 +220,7 @@ All commands use the `soleur:` prefix to avoid collisions with built-in commands
 |-------|-------------|
 | `brainstorming` | Explore intent, approaches, and design decisions |
 | `changelog` | Create engaging changelogs for recent merges |
-| `community` | Manage community engagement across Discord and GitHub (digests, health, welcome) |
+| `community` | Manage community engagement across Discord and GitHub (setup, digests, health, welcome) |
 | `compound-docs` | Capture solved problems as categorized documentation |
 | `deploy-docs` | Validate and prepare documentation for deployment |
 | `docs-site` | Scaffold Eleventy documentation sites with data-driven catalogs |

--- a/plugins/soleur/agents/marketing/community-manager.md
+++ b/plugins/soleur/agents/marketing/community-manager.md
@@ -14,12 +14,12 @@ Before executing any workflow, verify these environment variables:
 2. **DISCORD_GUILD_ID** -- Required for Discord API access
 3. **DISCORD_WEBHOOK_URL** -- Required for posting digests to Discord
 
-If any required variable is missing, display setup instructions and stop. Use the same instruction format as the scripts:
+If any required variable is missing, direct the user to run `/soleur:community setup` and stop.
 
 ```bash
 # Check prerequisites
 if [[ -z "${DISCORD_BOT_TOKEN:-}" ]]; then
-  echo "DISCORD_BOT_TOKEN is not set. See discord-community.sh for setup."
+  echo "DISCORD_BOT_TOKEN is not set. Run /soleur:community setup to configure."
   # Stop
 fi
 ```
@@ -206,6 +206,7 @@ Display 3-5 content suggestions with:
 
 ## Important Guidelines
 
+- For initial setup, direct users to `/soleur:community setup` which handles bot creation, token validation, and .env configuration via `discord-setup.sh`
 - All Discord API calls go through `discord-community.sh` -- do not call the API directly
 - All GitHub API calls go through `github-community.sh` -- do not call `gh` directly
 - Do not store raw message content in digest files -- summarize and aggregate

--- a/plugins/soleur/skills/community/scripts/discord-setup.sh
+++ b/plugins/soleur/skills/community/scripts/discord-setup.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# discord-setup.sh -- Discord bot setup API operations
+#
+# SECURITY: Token MUST be in DISCORD_BOT_TOKEN_INPUT env var.
+# Never pass tokens as CLI arguments (visible in ps/history).
+#
+# Usage: discord-setup.sh <command> [args]
+# Commands:
+#   validate-token                  - Verify token via API, output app ID
+#   discover-guilds                 - List guilds as JSON
+#   list-channels <guild_id>        - List text channels as JSON
+#   create-webhook <channel_id>     - Create webhook, output webhook URL
+#   write-env <guild_id> <webhook>  - Write to .env with chmod 600
+#   verify                          - Run guild-info check
+#
+# Environment variables:
+#   DISCORD_BOT_TOKEN_INPUT  - Bot token (required for API commands)
+#
+# Exit codes:
+#   0 - Success
+#   1 - General error
+#   2 - Retryable error (e.g., webhook limit on channel)
+#
+# Output: JSON or plain text to stdout
+# Errors: Messages to stderr, exit 1
+
+set -euo pipefail
+
+DISCORD_API="https://discord.com/api/v10"
+
+# --- Helpers ---
+
+require_token() {
+  if [[ -z "${DISCORD_BOT_TOKEN_INPUT:-}" ]]; then
+    echo "Error: DISCORD_BOT_TOKEN_INPUT env var is not set." >&2
+    echo "Pass the token via environment variable, not as a CLI argument." >&2
+    exit 1
+  fi
+}
+
+require_jq() {
+  if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required but not installed." >&2
+    echo "Install it: https://jqlang.github.io/jq/download/" >&2
+    exit 1
+  fi
+}
+
+# Make a Discord API request. Suppresses curl stderr to prevent token leakage
+# in debug output. Returns body on 2xx, handles errors.
+#
+# For create-webhook (POST to /channels/{id}/webhooks), HTTP 400 returns
+# exit code 2 so the SKILL.md orchestrator can retry with a different channel.
+discord_request() {
+  local endpoint="$1"
+  local method="${2:-GET}"
+  local data="${3:-}"
+  local response http_code body
+  local curl_args=(
+    -s -w "\n%{http_code}"
+    -X "$method"
+    -H "Authorization: Bot ${DISCORD_BOT_TOKEN_INPUT}"
+    -H "Content-Type: application/json"
+  )
+
+  if [[ -n "$data" ]]; then
+    curl_args+=(-d "$data")
+  fi
+
+  # Suppress stderr to prevent token leakage in curl debug output
+  if ! response=$(curl "${curl_args[@]}" "${DISCORD_API}${endpoint}" 2>/dev/null); then
+    echo "Error: Failed to connect to Discord API (endpoint: ${endpoint})." >&2
+    echo "Check your network connection and try again." >&2
+    exit 1
+  fi
+
+  http_code=$(echo "$response" | tail -1)
+  body=$(echo "$response" | sed '$d')
+
+  case "$http_code" in
+    2[0-9][0-9])
+      echo "$body"
+      ;;
+    401)
+      echo "Error: Invalid or expired bot token." >&2
+      exit 1
+      ;;
+    400)
+      local message
+      message=$(echo "$body" | jq -r '.message // "Bad request"' 2>/dev/null || echo "Bad request")
+      echo "Error: Discord API returned HTTP 400: ${message}" >&2
+      exit 2
+      ;;
+    429)
+      local retry_after
+      retry_after=$(echo "$body" | jq -r '.retry_after // 5' 2>/dev/null)
+      if [[ -z "$retry_after" ]] || [[ "$retry_after" == "null" ]]; then
+        retry_after=5
+      fi
+      echo "Rate limited. Retrying after ${retry_after}s..." >&2
+      sleep "$retry_after"
+      discord_request "$endpoint" "$method" "$data"
+      ;;
+    *)
+      local message
+      message=$(echo "$body" | jq -r '.message // "Unknown error"' 2>/dev/null || echo "Unknown error")
+      echo "Error: Discord API returned HTTP ${http_code}: ${message}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+# --- Commands ---
+
+cmd_validate_token() {
+  require_token
+
+  # Verify token via /users/@me
+  discord_request "/users/@me" > /dev/null
+
+  # Get application info for app ID
+  local app_info
+  app_info=$(discord_request "/oauth2/applications/@me")
+
+  local app_id app_name
+  app_id=$(echo "$app_info" | jq -r '.id // empty')
+  app_name=$(echo "$app_info" | jq -r '.name // empty')
+
+  if [[ -z "$app_id" ]]; then
+    echo "Error: Could not extract application ID from Discord API response." >&2
+    exit 1
+  fi
+
+  # Output app ID on stdout (used by SKILL.md for OAuth2 URL)
+  echo "${app_id}"
+  echo "Token valid. Application: ${app_name}" >&2
+}
+
+cmd_discover_guilds() {
+  require_token
+
+  discord_request "/users/@me/guilds?with_counts=true" | \
+    jq '[.[] | {id, name, approximate_member_count}]'
+}
+
+cmd_list_channels() {
+  local guild_id="${1:?Usage: discord-setup.sh list-channels <guild_id>}"
+  require_token
+
+  discord_request "/guilds/${guild_id}/channels" | \
+    jq '[.[] | select(.type == 0) | {id, name, position}] | sort_by(.position)'
+}
+
+cmd_create_webhook() {
+  local channel_id="${1:?Usage: discord-setup.sh create-webhook <channel_id>}"
+  require_token
+
+  local result
+  result=$(discord_request "/channels/${channel_id}/webhooks" "POST" '{"name":"soleur-community"}')
+
+  local webhook_id webhook_token
+  webhook_id=$(echo "$result" | jq -r '.id // empty')
+  webhook_token=$(echo "$result" | jq -r '.token // empty')
+
+  if [[ -z "$webhook_id" ]] || [[ -z "$webhook_token" ]]; then
+    echo "Error: Could not extract webhook ID or token from API response." >&2
+    exit 1
+  fi
+
+  # Output the full webhook URL
+  echo "https://discord.com/api/webhooks/${webhook_id}/${webhook_token}"
+}
+
+cmd_write_env() {
+  local guild_id="${1:?Usage: discord-setup.sh write-env <guild_id> <webhook_url>}"
+  local webhook_url="${2:?Usage: discord-setup.sh write-env <guild_id> <webhook_url>}"
+  require_token
+
+  local env_file=".env"
+
+  # Remove existing Discord vars if .env exists
+  if [[ -f "$env_file" ]]; then
+    local tmp
+    tmp=$(mktemp) || { echo "Error: Failed to create temp file." >&2; exit 1; }
+    grep -v '^DISCORD_BOT_TOKEN=' "$env_file" | \
+      grep -v '^DISCORD_GUILD_ID=' | \
+      grep -v '^DISCORD_WEBHOOK_URL=' > "$tmp" || true
+    mv "$tmp" "$env_file"
+  fi
+
+  # Set restrictive permissions BEFORE writing secrets
+  touch "$env_file"
+  chmod 600 "$env_file"
+
+  # Append Discord vars (file already has correct permissions)
+  {
+    echo "DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN_INPUT}"
+    echo "DISCORD_GUILD_ID=${guild_id}"
+    echo "DISCORD_WEBHOOK_URL=${webhook_url}"
+  } >> "$env_file"
+
+  echo "Wrote 3 variables to ${env_file} (permissions: 600)" >&2
+}
+
+cmd_verify() {
+  # Verify .env configuration by running guild-info
+  if [[ ! -f ".env" ]]; then
+    echo "Error: .env file not found." >&2
+    exit 1
+  fi
+
+  # shellcheck disable=SC1091
+  set -a
+  source .env
+  set +a
+
+  if [[ -z "${DISCORD_BOT_TOKEN:-}" ]] || [[ -z "${DISCORD_GUILD_ID:-}" ]]; then
+    echo "Error: .env is missing DISCORD_BOT_TOKEN or DISCORD_GUILD_ID." >&2
+    exit 1
+  fi
+
+  local script_dir
+  script_dir="$(cd "$(dirname "$0")" && pwd)"
+
+  local community_script="${script_dir}/discord-community.sh"
+  if [[ ! -x "$community_script" ]]; then
+    echo "Error: Required script not found: ${community_script}" >&2
+    exit 1
+  fi
+
+  local guild_info
+  guild_info=$("${community_script}" guild-info)
+
+  local name member_count
+  name=$(echo "$guild_info" | jq -r '.name // empty')
+  member_count=$(echo "$guild_info" | jq -r '.approximate_member_count // empty')
+
+  if [[ -z "$name" ]]; then
+    echo "Error: Could not extract guild info from API response." >&2
+    exit 1
+  fi
+
+  echo "${name}"
+  echo "${member_count:-0}"
+}
+
+# --- Main ---
+
+main() {
+  local command="${1:-}"
+  shift || true
+
+  if [[ -z "$command" ]]; then
+    echo "Usage: discord-setup.sh <command> [args]" >&2
+    echo "" >&2
+    echo "Commands:" >&2
+    echo "  validate-token                  - Verify token via API, output app ID" >&2
+    echo "  discover-guilds                 - List guilds as JSON" >&2
+    echo "  list-channels <guild_id>        - List text channels as JSON" >&2
+    echo "  create-webhook <channel_id>     - Create webhook, output webhook URL" >&2
+    echo "  write-env <guild_id> <webhook>  - Write to .env with chmod 600" >&2
+    echo "  verify                          - Run guild-info check" >&2
+    exit 1
+  fi
+
+  require_jq
+
+  case "$command" in
+    validate-token)  cmd_validate_token ;;
+    discover-guilds) cmd_discover_guilds ;;
+    list-channels)   cmd_list_channels "$@" ;;
+    create-webhook)  cmd_create_webhook "$@" ;;
+    write-env)       cmd_write_env "$@" ;;
+    verify)          cmd_verify ;;
+    *)
+      echo "Error: Unknown command '${command}'" >&2
+      echo "Run 'discord-setup.sh' without arguments for usage." >&2
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Add `/soleur:community setup` sub-command that automates Discord bot configuration
- New `discord-setup.sh` script with 6 sub-commands: validate-token, discover-guilds, list-channels, create-webhook, write-env, verify
- Browser-guided bot creation via agent-browser (opens Discord Developer Portal)
- Bot token passed via `DISCORD_BOT_TOKEN_INPUT` env var (never as CLI argument) for security
- .env written with chmod 600 permissions before secrets are written
- HTTP 400 on webhook creation returns exit code 2 for orchestrator retry
- Phase 0 env var errors now direct users to `/soleur:community setup`

Closes #129

## Test plan

- [ ] Run `/soleur:community setup` with no env vars -- full wizard executes
- [ ] Run `/soleur:community setup` with existing vars -- reconfiguration prompt appears
- [ ] Run `discord-setup.sh validate-token` without env var -- clear error message
- [ ] Run `discord-setup.sh` with no args -- usage displayed
- [ ] Verify `bash -n discord-setup.sh` passes syntax check
- [ ] Verify version 2.14.1 across plugin.json, CHANGELOG.md, README.md, bug_report.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)