### PR TITLE
docs: add community digest and webhook identity learning

### DIFF
--- a/knowledge-base/community/2026-02-19-digest.md
+++ b/knowledge-base/community/2026-02-19-digest.md
@@ -1,0 +1,136 @@
+---
+period_start: 2026-02-12
+period_end: 2026-02-19
+generated_at: 2026-02-19T02:00:00Z
+channels_analyzed:
+  - "1468999491662123020"  # general
+  - "1471227307384504351"  # announcements
+  - "1471233854529339558"  # rules
+  - "1471234041574588669"  # show-us-what-you-built
+  - "1471234314795745556"  # introduce-yourself
+  - "1471234613727858803"  # ai-news
+  - "1471234655788208323"  # random
+---
+
+## Period
+
+2026-02-12 to 2026-02-19
+
+## Activity Summary
+
+| Metric | Value |
+|--------|-------|
+| Discord members | 5 |
+| Discord messages (7d) | 43 |
+| Active Discord channels | 3 of 7 |
+| Unique Discord contributors | 4 |
+| GitHub PRs merged (7d) | 50 |
+| GitHub issues closed (7d) | 28 |
+| GitHub issues opened (7d) | 16 |
+| GitHub commit authors (7d) | 1 |
+| Total GitHub commits (7d) | 91 |
+
+The community is in early-stage growth with 5 members. Discord activity concentrated in three channels: general (11 messages), announcements (29 messages, mostly automated release notes), and ai-news (3 messages). GitHub saw an exceptionally active development week with 50 PRs merged across features, fixes, and documentation -- a major buildout sprint covering infrastructure, branding, documentation, and community tooling.
+
+## Top Contributors
+
+### Discord
+
+| Member | Messages | Notable Activity |
+|--------|----------|-----------------|
+| jean.deruelle | 18 | Led discussions on Claude Code + Ollama, licensing, Telegram bridge, release announcements |
+| ivelin.eth | 4 | Shared AI news, discussed open-source coding agents and UX |
+| scottbarstow | 1 | Asked about Apache vs MIT licensing choice |
+| dagan123 | 1 | Active in general discussion |
+
+### GitHub
+
+| Contributor | Commits | PRs Merged | Focus Areas |
+|-------------|---------|------------|-------------|
+| deruelle | 91 | 50 | Full-stack: agents, skills, docs, CI/CD, infra, brand |
+
+## Trending Topics
+
+### 1. Community Management Tooling
+
+The community management agent and skill were built and shipped this week (PRs #128, #130, #132). This includes Discord bot integration, GitHub activity collection, and the setup sub-command. Eight new issues were opened to extend the community agent to X, Reddit, Product Hunt, LinkedIn, Bluesky, Hacker News, Instagram, and TikTok (issues #127, #133-#140).
+
+### 2. Open-Source Coding Agents and Model Flexibility
+
+Discussion in #general about running Claude Code with Ollama and alternative models. ivelin.eth shared experience with opencode, kilocode, cline, and openclaw running local models on DGX Spark. jean.deruelle noted Claude Code has the best UX but explored Ollama support (issue #109 tracks this).
+
+### 3. Documentation and Brand Overhaul
+
+Major documentation migration from custom HTML to Markdown + Eleventy (PR #126), Solar Forge brand website published (PR #92), GitHub Pages deployed (PR #86), and site navigation restructured (PR #118). The docs site is now live at soleur.ai.
+
+### 4. Platform Architecture Evolution
+
+Breaking v2.0.0 release reorganized agents into a domain-first directory structure with 5 company domains: Design, Engineering, Marketing, Operations, Product. Commands consolidated into skills under the soleur: namespace. New agents added: ux-design-lead, terraform-architect, ops-advisor, ops-research, infra-security, brand-architect.
+
+### 5. Licensing Discussion
+
+scottbarstow asked about the Apache vs MIT license choice. jean.deruelle explained Apache is less permissive than MIT (requires sublicensing under same terms) and plans to move to BSL 1.1 at a future milestone, reflecting the business-building intent behind the project.
+
+## Unanswered Questions
+
+| Channel | Author | Question | Timestamp |
+|---------|--------|----------|-----------|
+| general | jean.deruelle | "Did any of you guys ran Claude Code with ollama and other models?" | 2026-02-17 |
+
+This question received partial engagement (ivelin.eth shared local model experiences) but no definitive answer about Claude Code + Ollama compatibility. The Ollama blog post was shared as reference.
+
+## GitHub Activity
+
+### PRs Merged (50 total)
+
+**Features (30):**
+
+- Community management agent and skill with Discord/GitHub integration (#128, #130, #132)
+- Documentation migration to Markdown + Eleventy (#126)
+- MCP integration audit (#125)
+- Agent consolidation to 5 company domains (#124)
+- Compound learning routes to skill/agent definitions (#115, #117)
+- Operations domain: ops-research agent (#97), ops-advisor (#91)
+- Infrastructure: infra-security agent (#103), terraform-architect (#84)
+- Design: ux-design-lead agent (#90)
+- Marketing: brand-architect agent, discord-content skill (#74)
+- CI/CD: auto-release workflow (#77), code coverage (#69), Discord notifications (#72)
+- Deploy skill (#79), release-announce skill (#70)
+- Domain-first directory structure v2.0.0 (#61)
+- Solar Forge brand website (#92)
+- GitHub Pages documentation site (#86)
+
+**Fixes (6):**
+
+- Branch isolation enforcement (#123)
+- Consistent messaging updates (#95)
+- Docs site UX/UI fixes (#111)
+- Custom domain configuration (#106)
+- CI permissions (#78, #73)
+
+**Maintenance (14):**
+
+- Learnings documentation (compound PRs: #108, #112, #113, #119, #122)
+- Navigation restructuring (#118, #121)
+- Ops tracking updates (#101, #102, #107)
+- Brainstorm artifacts (#80, #82)
+- Research: skill registry evaluation (#57)
+- Skill consolidation (#65)
+
+### Issues
+
+**Opened (16):**
+
+- Community agent platform extensions: X (#127), Reddit (#136), Product Hunt (#137), LinkedIn (#138), Bluesky (#139), Hacker News (#140), TikTok (#135), Instagram (#134)
+- Waitlist signup form for website (#133)
+- SEO/AEO for docs (#131)
+- Legal agents and skills (#114)
+- Ollama model support (#109)
+- Backstage setup (#83)
+- Bootstrap skill (#75)
+- Zero trust investigation (#51)
+- Beads/Ticket integration (#50)
+
+**Closed (28):**
+
+All 28 issues were resolved via merged PRs, covering community setup, documentation migration, MCP audit, compound learning routing, infrastructure security, brand publishing, and multiple workflow improvements.

--- a/knowledge-base/learnings/2026-02-19-discord-bot-identity-and-webhook-behavior.md
+++ b/knowledge-base/learnings/2026-02-19-discord-bot-identity-and-webhook-behavior.md
@@ -1,0 +1,72 @@
+---
+title: Discord Bot Identity and Webhook Behavior
+category: integration-issues
+tags:
+  - discord-automation
+  - bot-configuration
+  - community-management
+  - brand-consistency
+  - webhook-api
+module: community
+symptoms:
+  - Bot avatar too low resolution (32x32) with clipped borders
+  - Bot user identity separate from webhook identity
+  - Webhook messages freeze author identity at post time
+  - Multiple webhooks with inconsistent identities
+date: 2026-02-19
+---
+
+# Learning: Discord Bot Identity and Webhook Behavior
+
+## Problem
+
+During Discord community setup, several identity-related issues surfaced:
+
+1. **Low-res avatar** -- The 32x32 favicon was used as the bot avatar. Discord needs 512x512 minimum, and its circular crop clipped the gold ring border.
+2. **Bot vs webhook identity separation** -- Updating the bot user's name/avatar via `PATCH /users/@me` did not update webhook-posted messages. These are separate identity records in Discord.
+3. **Frozen message identity** -- Updating a webhook's default name/avatar does not retroactively change previously posted messages. The author identity is frozen at post time.
+4. **Multiple webhooks, inconsistent identity** -- The community webhook (#general) and release webhook (#announcements) had different names and avatars.
+
+## Solution
+
+### Avatar sizing
+Generate a 512x512 PNG with padding inside the gold ring so Discord's circular crop doesn't clip borders. Saved as `plugins/soleur/docs/images/logo-mark-512.png`.
+
+### Update both bot AND webhook
+Bot user and webhook identities must be updated separately:
+
+```bash
+# Bot user
+curl -X PATCH https://discord.com/api/v10/users/@me \
+  -H "Authorization: Bot $TOKEN" \
+  -d '{"username": "Sol", "avatar": "data:image/png;base64,..."}'
+
+# Webhook (no auth header needed, token is in URL)
+curl -X PATCH https://discord.com/api/webhooks/{id}/{token} \
+  -d '{"name": "Sol", "avatar": "data:image/png;base64,..."}'
+```
+
+### Content edits vs identity changes
+- **Content only**: `PATCH /webhooks/{id}/{token}/messages/{msg_id}` -- identity unchanged
+- **Identity change**: Must `DELETE` then re-`POST` the message
+
+### Consistent identity across webhooks
+Use bot token with Manage Webhooks permission to list and update all guild webhooks:
+
+```bash
+curl -H "Authorization: Bot $TOKEN" \
+  https://discord.com/api/v10/guilds/{guild_id}/webhooks
+```
+
+Then PATCH each with the same name and avatar.
+
+## Key Insight
+
+Discord treats bot users and webhooks as independent identity systems. Webhook messages snapshot the author identity at post time. The only way to fix stale identity on existing messages is delete + repost. All webhook payloads should include explicit `username` and `avatar_url` fields rather than relying on webhook defaults.
+
+## Related
+
+- `knowledge-base/learnings/2026-02-18-token-env-var-not-cli-arg.md` -- token security
+- `knowledge-base/learnings/implementation-patterns/2026-02-12-ci-for-notifications-and-infrastructure-setup.md` -- CI webhook patterns
+- `knowledge-base/learnings/2026-02-12-brand-guide-contract-and-inline-validation.md` -- brand guide contract
+- GitHub Issue #142 -- brand assets directory research


### PR DESCRIPTION
## Summary

- First community digest (`knowledge-base/community/2026-02-19-digest.md`) generated from Discord + GitHub activity
- Compound learning documenting Discord bot identity vs webhook identity separation (`knowledge-base/learnings/2026-02-19-discord-bot-identity-and-webhook-behavior.md`)

These were created during the Discord community setup session and left untracked on main.

## Test plan

- [ ] Verify digest file has correct YAML frontmatter and heading contract
- [ ] Verify learning file has searchable tags and frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)