### PR TITLE
fix: prevent --delete-branch on merge when worktrees are active (v2.15.3)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.15.2"
+      placeholder: "2.15.3"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.15.2-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.15.3-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.15.2",
+  "version": "2.15.3",
   "description": "AI-powered development tools for Claude Code that get smarter with every use. 31 agents, 8 commands, and 40 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.3] - 2026-02-19
+
+### Fixed
+
+- Ship skill: added explicit warning not to use `--delete-branch` on merge when worktrees are active
+
 ## [2.15.2] - 2026-02-19
 
 ### Added

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -338,6 +338,8 @@ After the PR is created, ask the user:
 - **Merge now** -> Run `gh pr merge <number> --squash` then proceed to cleanup below
 - **Later** -> Stop here. Cleanup will happen via SessionStart hook next session.
 
+**CRITICAL: Do NOT use `--delete-branch` on merge.** The worktree is still active and the guardrails hook will block it. Merge with `--squash` only, then `cleanup-merged` handles branch deletion after removing the worktree.
+
 **If merged (either now or user says "merge PR" later in the session):**
 
 1. **Release creation is automatic.** When a merge to main includes a plugin.json version change, the `auto-release.yml` GitHub Actions workflow creates a GitHub Release and posts to Discord. No manual step needed.


### PR DESCRIPTION
## Summary
- Add explicit CRITICAL warning to ship skill Phase 8 to never use `--delete-branch` flag with `gh pr merge`
- The guardrails hook blocks `--delete-branch` when a worktree exists for the branch, causing every PR merge to fail on first attempt
- Merge with `--squash` only -- `cleanup-merged` handles branch deletion after worktree removal

## Checklist
- [x] Artifacts committed
- [x] Learnings captured (N/A -- simple docs fix)
- [x] Documentation updated
- [x] Version bumped (2.15.2 -> 2.15.3)
- [x] Tests pass (no source changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)