### PR TITLE
feat: layer semgrep alongside security-sentinel for SAST coverage (v2.20.0)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.19.0"
+      placeholder: "2.20.0"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.19.0-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.20.0-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)
@@ -25,7 +25,7 @@ Currently at phase of being an Orchestration engine for Claude Code -- agents, w
 Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo founders (soloentrepreneurs) to collapse the friction between a startup idea and a $1B outcome
 
 AI-powered company orchestration for Claude Code (and Bring Your Own Model later) that get smarter with every use. 
-Soleur currently provides **33 agents**, **8 commands**, and **42 skills** that compound your company knowledge (currently only engineering so far) over time -- every problem you solve makes the next one easier.
+Soleur currently provides **34 agents**, **8 commands**, and **42 skills** that compound your company knowledge (currently only engineering so far) over time -- every problem you solve makes the next one easier.
 
 ## Installation
 

--- a/knowledge-base/plans/2026-02-20-feat-semgrep-sast-coverage-plan.md
+++ b/knowledge-base/plans/2026-02-20-feat-semgrep-sast-coverage-plan.md
@@ -1,0 +1,121 @@
+---
+title: Layer semgrep alongside security-sentinel for SAST coverage
+type: feat
+date: 2026-02-20
+issue: "#163"
+version-bump: MINOR
+---
+
+# Layer semgrep alongside security-sentinel for SAST coverage
+
+## Overview
+
+Add a semgrep-based SAST agent to the review workflow, running alongside security-sentinel as a conditional agent. security-sentinel handles LLM-driven architectural security review; semgrep handles deterministic rule-based static analysis (hardcoded secrets, SQL injection patterns, insecure function calls).
+
+## Problem Statement
+
+security-sentinel uses LLM heuristics (grep + reasoning) to find architectural security issues. It excels at business logic flaws, authorization patterns, and OWASP compliance reasoning. But it misses the low-level pattern-matching catches that dedicated SAST tools find -- known vulnerability signatures, CWE matches, taint analysis across call chains.
+
+## Proposed Solution
+
+Create a new conditional review agent (`semgrep-sast`) that wraps the `semgrep` CLI. Add it to the `<conditional_agents>` block in `commands/soleur/review.md`. The agent checks if semgrep is installed, runs it on changed files, and formats findings inline.
+
+### Design Decisions
+
+| Question | Decision | Rationale |
+|----------|----------|-----------|
+| Trigger condition | `which semgrep` succeeds | If installed, user wants it. No complex heuristics needed. |
+| CLI not installed | Warn and skip | Constitution: degrade gracefully, don't abort. |
+| Scan scope | Changed files only (PR diff) | Review is about PR changes, not full-repo audit. |
+| Default rulesets | `semgrep --config=auto` | Auto-detects language, applies security rules. Zero config. |
+| Output format | Agent formats findings like other review agents | Consistency. Agent is LLM that receives semgrep JSON and structures it. |
+| Timeout | Bash default (2 min) | Sufficient for PR-scoped scans. |
+| Error handling | Warn and continue | Semgrep failure must not block the review. |
+| Documentation | Agent description + README table | Follows existing pattern. |
+| Deduplication | No | Review synthesis already consolidates. Each agent reports independently. |
+| OSS vs Cloud | OSS CLI only | No auth, no MCP server, no registry dependency. |
+| Inline-only enforcement | Agent prompt instruction | Constitution requires no persisted security aggregation. |
+
+### Non-Goals
+
+- Installing semgrep automatically (user responsibility)
+- Bundling semgrep as an MCP server in plugin.json
+- Replacing security-sentinel
+- Evaluating CodeRabbit (deferred -- issue #163 lists it as "consider")
+- Custom semgrep rulesets shipped with the plugin
+
+## Acceptance Criteria
+
+- [x] `plugins/soleur/agents/engineering/review/semgrep-sast.md` created with proper frontmatter
+- [x] `plugins/soleur/commands/soleur/review.md` updated with semgrep conditional agent block
+- [x] Agent gracefully handles missing semgrep CLI (warns, continues)
+- [x] Agent scans only changed files (not full repo)
+- [x] Agent outputs findings inline (never writes to files)
+- [x] README.md agent table includes semgrep-sast with role clarification
+- [x] security-sentinel unchanged and still in always-run parallel list
+- [x] Version bumped: plugin.json, CHANGELOG.md, README.md
+
+## Test Scenarios
+
+- Given semgrep is installed and PR has code changes, when `/soleur:review` runs, then semgrep-sast agent launches and reports findings inline
+- Given semgrep is NOT installed, when `/soleur:review` runs, then a warning is logged and review continues without SAST
+- Given semgrep finds zero issues, when agent completes, then it reports "0 findings" (not silent)
+- Given semgrep CLI errors (bad config, crash), when agent runs, then it warns and review continues
+- Given security-sentinel and semgrep both find an SQL injection, when review synthesizes, then both findings appear (no silent dedup)
+
+## MVP
+
+### 1. Create agent file
+
+`plugins/soleur/agents/engineering/review/semgrep-sast.md`
+
+```markdown
+---
+name: semgrep-sast
+description: "Use this agent when you need deterministic static analysis..."
+model: inherit
+---
+
+Agent prompt that:
+1. Checks `which semgrep` -- if missing, return warning with install instructions
+2. Gets list of changed files from git diff
+3. Runs `semgrep --config=auto --json <files>`
+4. Parses JSON output
+5. Formats findings as structured report (severity, file, line, rule, description)
+6. Returns findings inline -- never writes to files
+```
+
+### 2. Update review command
+
+`plugins/soleur/commands/soleur/review.md`
+
+Add to `<conditional_agents>` block after test-design-reviewer (agent #13):
+
+```markdown
+**If semgrep CLI is installed (`which semgrep` succeeds):**
+
+14. Task semgrep-sast(PR content) - Deterministic SAST scanning for known vulnerability patterns
+
+**When to run SAST agent:**
+- `which semgrep` returns 0 (semgrep binary found in PATH)
+- PR modifies source code files (not just markdown/config)
+
+**What this agent checks:**
+- `semgrep-sast`: Known vulnerability signatures (CWE patterns), hardcoded secrets,
+  insecure function calls, taint analysis. Complements security-sentinel's architectural review.
+```
+
+### 3. Version bump
+
+- `plugin.json`: 2.19.0 -> 2.20.0 (MINOR -- new agent)
+- `CHANGELOG.md`: Added section with semgrep-sast
+- `README.md`: Agent count 33 -> 34, add table row
+- `plugin.json` description: Update agent count
+
+## References
+
+- security-sentinel: `plugins/soleur/agents/engineering/review/security-sentinel.md`
+- Review command: `plugins/soleur/commands/soleur/review.md`
+- Inline-only learning: `knowledge-base/learnings/2026-02-16-inline-only-output-for-security-agents.md`
+- Landscape audit: `knowledge-base/learnings/2026-02-19-full-landscape-discovery-audit.md`
+- Issue: #163

--- a/knowledge-base/specs/feat-semgrep-sast/tasks.md
+++ b/knowledge-base/specs/feat-semgrep-sast/tasks.md
@@ -1,0 +1,33 @@
+---
+feature: feat-semgrep-sast
+plan: knowledge-base/plans/2026-02-20-feat-semgrep-sast-coverage-plan.md
+issue: "#163"
+---
+
+# Tasks: Layer semgrep alongside security-sentinel
+
+## Phase 1: Core Implementation
+
+- [ ] 1.1 Create `plugins/soleur/agents/engineering/review/semgrep-sast.md` agent file
+  - YAML frontmatter: name, description (with examples), model: inherit
+  - Agent prompt: check semgrep installed, get changed files, run semgrep, format findings
+  - Graceful degradation when CLI missing
+  - Inline-only output (never write findings to files)
+
+- [ ] 1.2 Update `plugins/soleur/commands/soleur/review.md`
+  - Add semgrep-sast to `<conditional_agents>` block
+  - Condition: `which semgrep` succeeds
+  - Follow existing conditional agent format (heading, task, when-to-run, what-it-checks)
+
+## Phase 2: Documentation and Versioning
+
+- [ ] 2.1 Update `plugins/soleur/README.md`
+  - Add semgrep-sast row to agents table
+  - Update agent count (33 -> 34)
+  - Document security-sentinel vs semgrep-sast roles
+
+- [ ] 2.2 Version bump
+  - `plugins/soleur/.claude-plugin/plugin.json`: 2.19.0 -> 2.20.0, update agent count in description
+  - `plugins/soleur/CHANGELOG.md`: Add v2.20.0 entry
+  - Root `README.md`: Update version badge
+  - `.github/ISSUE_TEMPLATE/bug_report.yml`: Update version placeholder

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "soleur",
-  "version": "2.19.0",
-  "description": "AI-powered development tools for Claude Code that get smarter with every use. 33 agents, 8 commands, and 42 skills that compound your engineering knowledge over time.",
+  "version": "2.20.0",
+  "description": "AI-powered development tools for Claude Code that get smarter with every use. 34 agents, 8 commands, and 42 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",
     "email": "jean.deruelle@jikigai.com",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.20.0] - 2026-02-20
+
+### Added
+
+- New `semgrep-sast` review agent for deterministic SAST scanning using semgrep CLI, complementing security-sentinel's LLM-based architectural review
+- Conditional semgrep invocation in `/soleur:review` command (runs when semgrep CLI is installed and PR modifies source code)
+
 ## [2.19.0] - 2026-02-19
 
 ### Added

--- a/plugins/soleur/README.md
+++ b/plugins/soleur/README.md
@@ -106,7 +106,7 @@ Full autonomous engineering workflow that goes from plan to PR in a single comma
 
 | Component | Count |
 |-----------|-------|
-| Agents | 33 |
+| Agents | 34 |
 | Commands | 8 |
 | Skills | 42 |
 | MCP Servers | 1 |
@@ -124,9 +124,9 @@ Agents are organized by domain, then by function.
 | `growth-strategist` | Content strategy analysis and execution: keyword research, content auditing, gap analysis, AI agent consumability, and applying fixes |
 | `seo-aeo-analyst` | Audit Eleventy docs sites for SEO and AEO (AI Engine Optimization) issues |
 
-### Engineering (25)
+### Engineering (26)
 
-#### Review (14)
+#### Review (15)
 
 | Agent | Description |
 |-------|-------------|
@@ -143,6 +143,7 @@ Agents are organized by domain, then by function.
 | `pattern-recognition-specialist` | Analyze code for patterns and anti-patterns |
 | `performance-oracle` | Performance analysis and optimization |
 | `security-sentinel` | Security audits and vulnerability assessments |
+| `semgrep-sast` | Deterministic SAST scanning using semgrep CLI for known vulnerability patterns |
 | `test-design-reviewer` | Score test quality using Farley's 8 properties with weighted rubric |
 
 #### Discovery (2)

--- a/plugins/soleur/agents/engineering/review/semgrep-sast.md
+++ b/plugins/soleur/agents/engineering/review/semgrep-sast.md
@@ -1,0 +1,20 @@
+---
+name: semgrep-sast
+description: "Use this agent when you need deterministic static analysis security scanning using semgrep. This agent complements security-sentinel by running rule-based pattern matching to catch known vulnerability signatures, hardcoded secrets, insecure function calls, and CWE patterns that LLM-based review may miss. Requires the semgrep CLI to be installed. <example>Context: The user wants a thorough security review that includes both architectural analysis and SAST scanning.\nuser: \"Run a full security review on this PR including static analysis\"\nassistant: \"I'll use the semgrep-sast agent to run deterministic SAST scanning alongside the security-sentinel's architectural review.\"\n<commentary>The user wants comprehensive security coverage. semgrep-sast provides deterministic pattern matching that complements security-sentinel's LLM-based architectural analysis.</commentary></example> <example>Context: The user is concerned about hardcoded secrets or known vulnerability patterns in their code.\nuser: \"Check if there are any hardcoded API keys or known vulnerability patterns in this code\"\nassistant: \"I'll launch the semgrep-sast agent to scan for known vulnerability signatures and hardcoded secrets using semgrep's rule database.\"\n<commentary>Hardcoded secrets and known vulnerability patterns are exactly what SAST tools excel at finding through deterministic pattern matching.</commentary></example>"
+model: inherit
+---
+
+You are a SAST specialist that uses semgrep to find known vulnerability patterns in code. You complement security-sentinel's LLM-based architectural review with deterministic, rule-based scanning.
+
+## Execution Protocol
+
+1. Check if semgrep is available (`which semgrep`). If not found, report that SAST scanning is skipped with installation instructions and stop.
+2. Identify source code files changed in the PR using `git diff --name-only --diff-filter=ACMR`. Filter to source code extensions only.
+3. Run `semgrep --config=auto --json` on changed files only. Exit code 1 means findings were found (normal). Handle errors gracefully.
+4. Parse JSON output. Group findings by severity (ERROR > WARNING > INFO). For each finding: file/line, rule ID, CWE if available, description, code snippet, recommendation. If zero findings, report completion with file count.
+
+## Critical Constraints
+
+- **Inline-only output.** Never write findings to files or commit semgrep output. Aggregated security findings in open-source repos create an attack surface.
+- **Changed files only.** Scan only files in the PR diff, not the entire repository.
+- **Graceful degradation.** If semgrep is missing or crashes, warn and continue. Never block the review.

--- a/plugins/soleur/commands/soleur/review.md
+++ b/plugins/soleur/commands/soleur/review.md
@@ -135,6 +135,20 @@ These agents are run ONLY when the PR matches specific criteria. Check the PR fi
 
 - `test-design-reviewer`: Scores tests against Farley's 8 properties, produces a weighted Test Quality Score with letter grade and top 3 improvement recommendations
 
+**If semgrep CLI is installed (`which semgrep` succeeds) and PR modifies source code files:**
+
+14. Task semgrep-sast(PR content) - Deterministic SAST scanning for known vulnerability patterns
+
+**When to run SAST agent:**
+
+- `which semgrep` returns 0 (semgrep binary found in PATH)
+- PR modifies source code files (*.py, *.js, *.ts, *.rb, *.go, *.java, *.rs, *.swift, *.kt, etc.)
+- Not needed for documentation-only or config-only changes
+
+**What this agent checks:**
+
+- `semgrep-sast`: Known vulnerability signatures (CWE patterns), hardcoded secrets, insecure function calls, taint analysis. Complements security-sentinel's LLM-based architectural review with deterministic rule-based scanning.
+
 </conditional_agents>
 
 ### 4. Ultra-Thinking Deep Dive Phases


### PR DESCRIPTION
## Summary

- New `semgrep-sast` conditional review agent that wraps semgrep CLI for deterministic SAST scanning
- Conditional invocation in `/soleur:review` -- runs when semgrep is installed and PR modifies source code
- Complements security-sentinel's LLM-based architectural review with rule-based pattern matching

## Changes

| File | Change |
|------|--------|
| `agents/engineering/review/semgrep-sast.md` | New agent (20 lines, sharp-edges-only) |
| `commands/soleur/review.md` | Added conditional agent #14 |
| `plugin.json` | 2.19.0 -> 2.20.0, agent count 33 -> 34 |
| `CHANGELOG.md` | v2.20.0 entry |
| `README.md` (plugin + root) | Agent count + table row + version badge |
| `bug_report.yml` | Version placeholder |

## Design decisions

- **Conditional on `which semgrep`** -- if installed, user wants it
- **Changed files only** -- scans PR diff, not full repo
- **Inline-only output** -- never persists security findings to files
- **Graceful degradation** -- warns and continues if semgrep missing or crashes
- **OSS CLI only** -- no MCP server, no auth, no registry dependency

## Test plan

- [ ] Verify agent file discovered by plugin loader (check `/soleur:help` lists semgrep-sast)
- [ ] Run `/soleur:review` without semgrep installed -- should warn and continue
- [ ] Run `/soleur:review` with semgrep installed on a PR with source code changes -- should produce findings
- [ ] Verify security-sentinel still runs unchanged in parallel list

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)