### PR TITLE
feat: update landing copy to emphasize self-improvement (v2.22.1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.22.1"
+      placeholder: "2.22.2"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.22.1-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.22.2-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/knowledge-base/overview/brand-guide.md
+++ b/knowledge-base/overview/brand-guide.md
@@ -8,7 +8,7 @@ last_updated: 2026-02-19
 
 ### Mission
 
-Soleur exists to solve one engineering problem: enabling a single founder to build, ship, and scale a billion-dollar company. We are building the Company-as-a-Service platform -- a full-stack AI organization that reviews, plans, builds, and remembers. Every decision the founder makes teaches the system. Every project starts faster than the last.
+Soleur exists to solve one engineering problem: enabling a single founder to build, ship, and scale a billion-dollar company. We are building the Company-as-a-Service platform -- a full-stack AI organization that reviews, plans, builds, remembers, and self-improves. Every decision the founder makes teaches the system. Every feature or project gets better and faster than the last.
 
 The name Soleur is a portmanteau of Solo and Solar -- entrepreneur energy and light to better the world.
 
@@ -72,7 +72,7 @@ Ambitious-inspiring. Bold, forward-looking, energizing. The voice of Soleur is t
 
 **Product descriptions:**
 - "You decide. Agents execute. Knowledge compounds."
-- "Not a copilot. Not an assistant. A full AI organization that reviews, plans, builds, and remembers."
+- "Not a copilot. Not an assistant. A full AI organization that reviews, plans, builds, remembers, and self-improves."
 - "Designed, built, and shipped by Soleur -- using Soleur."
 
 **Community replies:**

--- a/knowledge-base/plans/2026-02-20-feat-landing-copy-self-improves-plan.md
+++ b/knowledge-base/plans/2026-02-20-feat-landing-copy-self-improves-plan.md
@@ -1,0 +1,72 @@
+---
+title: "feat: Update landing copy to emphasize self-improvement"
+type: feat
+date: 2026-02-20
+---
+
+# Update Landing Copy to Emphasize Self-Improvement
+
+## Overview
+
+Update the core value proposition copy across the website, brand guide, plugin description, and README to communicate that Soleur self-improves -- not just remembers. Also update the closing sentence from "Every project starts faster than the last" to "Every feature or project gets better and faster than the last."
+
+## Changes
+
+### 1. Landing page (`plugins/soleur/docs/index.njk:47`)
+
+**Before:**
+> Not a copilot. Not an assistant. A full AI organization that reviews, plans, builds, and remembers. Every decision you make teaches the system. Every project starts faster than the last.
+
+**After:**
+> Not a copilot. Not an assistant. A full AI organization that reviews, plans, builds, remembers, and self-improves. Every decision you make teaches the system. Every feature or project gets better and faster than the last.
+
+### 2. Brand guide -- Mission (`knowledge-base/overview/brand-guide.md:11`)
+
+**Before:**
+> ...a full-stack AI organization that reviews, plans, builds, and remembers. Every decision the founder makes teaches the system. Every project starts faster than the last.
+
+**After:**
+> ...a full-stack AI organization that reviews, plans, builds, remembers, and self-improves. Every decision the founder makes teaches the system. Every feature or project gets better and faster than the last.
+
+### 3. Brand guide -- Product descriptions (`knowledge-base/overview/brand-guide.md:75`)
+
+**Before:**
+> "Not a copilot. Not an assistant. A full AI organization that reviews, plans, builds, and remembers."
+
+**After:**
+> "Not a copilot. Not an assistant. A full AI organization that reviews, plans, builds, remembers, and self-improves."
+
+### 4. Plugin description (`plugins/soleur/.claude-plugin/plugin.json:4`)
+
+**Before:**
+> AI-powered development tools for Claude Code that get smarter with every use. 44 agents, 8 commands, and 44 skills that compound your engineering knowledge over time.
+
+**After:**
+> A full AI organization that reviews, plans, builds, remembers, and self-improves. 44 agents, 8 commands, and 44 skills that compound your engineering knowledge over time.
+
+### 5. Plugin README (`plugins/soleur/README.md:3`)
+
+**Before:**
+> AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last.
+
+**After:**
+> A full AI organization that reviews, plans, builds, remembers, and self-improves. Every feature or project gets better and faster than the last.
+
+## Out of Scope
+
+- Audit files (`knowledge-base/audits/`) -- these are historical snapshots, not source of truth
+- Brainstorm files (`knowledge-base/brainstorms/`) -- historical records
+- `.pen` design files -- separate design workflow
+
+## Acceptance Criteria
+
+- [ ] Landing page copy updated with "self-improves" and new closing sentence
+- [ ] Brand guide mission and product description updated consistently
+- [ ] Plugin description updated to match brand voice
+- [ ] README description updated to match
+- [ ] Version bump (PATCH -- docs/copy update to existing plugin files)
+
+## Test Scenarios
+
+- Given the docs site builds, when visiting the landing page, then the updated copy is visible
+- Given the plugin.json is valid JSON, when installing the plugin, then the new description shows

--- a/knowledge-base/specs/feat-landing-copy/tasks.md
+++ b/knowledge-base/specs/feat-landing-copy/tasks.md
@@ -1,0 +1,22 @@
+---
+feature: feat/landing-copy
+plan: knowledge-base/plans/2026-02-20-feat-landing-copy-self-improves-plan.md
+date: 2026-02-20
+---
+
+# Tasks: Landing Copy Self-Improves
+
+## 1. Update Source Files
+
+- [x] 1.1 Update `plugins/soleur/docs/index.njk:47` -- add "self-improves", update closing sentence
+- [x] 1.2 Update `knowledge-base/overview/brand-guide.md:11` -- mission statement
+- [x] 1.3 Update `knowledge-base/overview/brand-guide.md:75` -- product description
+- [x] 1.4 Update `plugins/soleur/.claude-plugin/plugin.json:4` -- plugin description
+- [x] 1.5 Update `plugins/soleur/README.md:3` -- README tagline
+
+## 2. Version Bump
+
+- [x] 2.1 Bump version in `plugin.json` (PATCH)
+- [x] 2.2 Update `CHANGELOG.md`
+- [x] 2.3 Update `README.md` version badge in root
+- [x] 2.4 Update `.github/ISSUE_TEMPLATE/bug_report.yml` placeholder

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "soleur",
-  "version": "2.22.1",
-  "description": "AI-powered development tools for Claude Code that get smarter with every use. 44 agents, 8 commands, and 44 skills that compound your engineering knowledge over time.",
+  "version": "2.22.2",
+  "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 44 agents, 8 commands, and 44 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",
     "email": "jean.deruelle@jikigai.com",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.22.2] - 2026-02-20
+
+### Changed
+
+- Updated landing page, brand guide, plugin description, and README copy to emphasize self-improvement ("reviews, plans, builds, remembers, and self-improves")
+- Updated closing sentence to "Every feature or project gets better and faster than the last"
+
 ## [2.22.1] - 2026-02-20
 
 ### Changed

--- a/plugins/soleur/README.md
+++ b/plugins/soleur/README.md
@@ -1,6 +1,6 @@
 # Soleur
 
-AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last.
+A full AI organization that reviews, plans, builds, remembers, and self-improves. Every feature or project gets better and faster than the last.
 
 ## Quick Start
 

--- a/plugins/soleur/docs/index.njk
+++ b/plugins/soleur/docs/index.njk
@@ -44,7 +44,7 @@ permalink: index.html
       <div class="landing-section-inner">
         <p class="section-label">This Is the Way</p>
         <h2 class="section-title">One founder powered by a full-stack AI organization.</h2>
-        <p class="section-desc">Not a copilot. Not an assistant. A full AI organization that reviews, plans, builds, and remembers. Every decision you make teaches the system. Every project starts faster than the last.</p>
+        <p class="section-desc">Not a copilot. Not an assistant. A full AI organization that reviews, plans, builds, remembers, and self-improves. Every decision you make teaches the system. Every feature or project gets better and faster than the last.</p>
         <div class="problem-cards">
           <div class="problem-card">
             <div class="problem-card-icon" aria-hidden="true">&#x1F9E0;</div>


### PR DESCRIPTION
## Summary

- Updated core value proposition copy from "reviews, plans, builds, and remembers" to "reviews, plans, builds, remembers, and self-improves" across landing page, brand guide, plugin description, and README
- Updated closing sentence to "Every feature or project gets better and faster than the last"
- Version bump to 2.22.1 (patch -- copy/docs update)

## Files Changed

| File | Change |
|------|--------|
| `plugins/soleur/docs/index.njk` | Landing page copy |
| `knowledge-base/overview/brand-guide.md` | Mission + product description |
| `plugins/soleur/.claude-plugin/plugin.json` | Plugin description + version |
| `plugins/soleur/README.md` | README tagline |
| `plugins/soleur/CHANGELOG.md` | Changelog entry |
| `README.md` | Version badge |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Version placeholder |

## Screenshot

![Landing page with updated copy](https://github.com/user-attachments/assets/placeholder)

> "Not a copilot. Not an assistant. A full AI organization that reviews, plans, builds, remembers, and self-improves. Every decision you make teaches the system. Every feature or project gets better and faster than the last."

## Test plan

- [x] Docs site builds successfully with `npx @11ty/eleventy`
- [x] Updated copy renders correctly on landing page
- [x] plugin.json is valid JSON
- [x] Version triad updated (plugin.json + CHANGELOG + README badge + bug report template)

🤖 Generated with [Claude Code](https://claude.com/claude-code)