### PR TITLE
feat: add session error analysis to compound (v2.22.3)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.22.2"
+      placeholder: "2.22.3"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.22.2-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.22.3-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/knowledge-base/plans/2026-02-20-feat-compound-session-error-analysis-plan.md
+++ b/knowledge-base/plans/2026-02-20-feat-compound-session-error-analysis-plan.md
@@ -1,0 +1,115 @@
+---
+title: "feat: Add session error analysis to compound"
+type: feat
+date: 2026-02-20
+issue: "#168"
+version_bump: PATCH
+---
+
+# feat: Add session error analysis to compound
+
+## Overview
+
+Extend the `/soleur:compound` skill to scan the conversation history for ALL errors that occurred during the session -- not just the target problem's investigation attempts. Capture process mistakes, failed commands, and dead-end approaches as documented learnings, preventing repeated workflow errors across sessions.
+
+## Problem Statement
+
+Compound captures the problem that was intentionally solved (root cause, solution, prevention). Step 2 extracts "investigation attempts: what didn't work and why" -- but only for the TARGET problem.
+
+Session-level errors go undocumented:
+- Bash commands that failed (wrong flags, missing tools, path errors)
+- Wrong hypotheses investigated and abandoned
+- Process mistakes (editing wrong file, wrong branch, forgetting to stage)
+- Repeated mistakes across the session
+
+Without capturing these, the same workflow mistakes repeat session after session, wasting tokens and time.
+
+## Proposed Solution
+
+Extend Step 2 of compound-docs to also scan for session-level errors, and add a section to the resolution template. Three small edits, no new files, no new schema, no new abstractions.
+
+### What changes
+
+**1. `plugins/soleur/skills/compound-docs/SKILL.md`** -- Extend Step 2 (Gather Context)
+
+Add a sub-section to Step 2's "Extract from conversation history" block:
+
+```markdown
+**Session errors (beyond the target problem):**
+
+Scan conversation history for errors unrelated to the main problem investigation. Only capture errors that are NOT part of the investigation attempts documented above. Skip trivial errors immediately corrected (typos in commands, expected test failures during TDD).
+
+Extract for each error:
+- Description of what went wrong (1 sentence)
+- What was done to recover
+- How to prevent it in future sessions (1 sentence)
+
+If no session errors found, skip this extraction silently.
+```
+
+**2. `plugins/soleur/skills/compound-docs/assets/resolution-template.md`** -- Add "Session Errors" section
+
+Add after "What Didn't Work" and before "Solution", using the same bold-heading + bullet format:
+
+```markdown
+## Session Errors
+
+[Process mistakes and command failures encountered during this session, beyond the main problem investigation. Omit this section entirely if no session errors occurred.]
+
+**[Brief error description]**
+- **Recovery:** [What fixed it]
+- **Prevention:** [How to avoid in future]
+
+[Repeat for each session error]
+```
+
+**3. `plugins/soleur/commands/soleur/compound.md`** -- Add bullet to "What It Captures"
+
+Add to the existing bullet list at line 209:
+```
+- **Session errors**: Process mistakes, failed commands, and wrong approaches from the session
+```
+
+No new subagent. The session error scan is part of Step 2's context gathering, not a separate parallel unit.
+
+## Technical Considerations
+
+- **No schema changes.** Session errors live in the markdown body as prose, not YAML frontmatter. No validation changes needed.
+- **Conversation history is the only data source.** Same pattern as Step 2 and Step 8.
+- **Deduplication is implicit.** The instruction "errors unrelated to the main problem investigation" is sufficient. Step 2 handles the target problem; the new sub-section handles everything else.
+- **The extraction is optional.** Clean sessions produce unchanged documents.
+
+## Non-Goals
+
+- No new YAML frontmatter fields or schema changes
+- No new categories, directories, or error taxonomy enums
+- No separate learning files for session errors
+- No new subagent in compound.md
+- No automated session error detection outside compound
+
+## Acceptance Criteria
+
+- [ ] Step 2 scans conversation history for errors beyond the target problem
+- [ ] Session errors appear in the learning document using bold-heading + bullet format
+- [ ] Errors already in "What Didn't Work" are not duplicated
+- [ ] Trivial/expected errors are filtered out
+- [ ] Section is omitted when no session errors are found
+- [ ] compound.md "What It Captures" list includes session errors
+
+## Test Scenarios
+
+- Given a session with bash command failures, when compound runs, then the learning document includes those failures in a Session Errors section
+- Given a session with no errors beyond the target problem, when compound runs, then no Session Errors section appears
+- Given a session where Step 2 already captured "wrong approach X" as an investigation attempt, when Step 2 runs, then "wrong approach X" is not duplicated in Session Errors
+- Given a session with a typo in a command immediately re-run correctly, when compound runs, then the typo is filtered out as trivial
+
+## Rollback Plan
+
+Revert the commit. All changes are additive to existing files with no schema or directory changes.
+
+## References
+
+- `plugins/soleur/skills/compound-docs/SKILL.md:57` -- Step 2 (Gather Context), the extension point
+- `plugins/soleur/commands/soleur/compound.md:202` -- "What It Captures" list
+- `plugins/soleur/skills/compound-docs/assets/resolution-template.md:32` -- "What Didn't Work" section (format reference)
+- Issue: #168

--- a/knowledge-base/specs/feat-compound-error-analysis/tasks.md
+++ b/knowledge-base/specs/feat-compound-error-analysis/tasks.md
@@ -1,0 +1,28 @@
+---
+feature: compound-error-analysis
+issue: "#168"
+branch: feat-compound-error-analysis
+---
+
+# Tasks: Compound Session Error Analysis
+
+## Phase 1: Core Implementation
+
+- [x] 1.1 Extend Step 2 (Gather Context) in `plugins/soleur/skills/compound-docs/SKILL.md`
+  - Add "Session errors" sub-section to the "Extract from conversation history" block
+  - Use imperative form for all instruction bullets
+  - Include: extraction criteria, skip conditions, output format
+
+- [x] 1.2 Add "Session Errors" section to `plugins/soleur/skills/compound-docs/assets/resolution-template.md`
+  - Insert after "What Didn't Work", before "Solution"
+  - Use bold-heading + bullet format (matching "What Didn't Work" style)
+  - Include conditional note: omit section when no errors found
+
+- [x] 1.3 Add "Session errors" bullet to "What It Captures" in `plugins/soleur/commands/soleur/compound.md`
+
+## Phase 2: Finalize
+
+- [x] 2.1 Version bump (PATCH) -- update plugin.json, CHANGELOG.md, README.md
+- [x] 2.2 Run code review on changes
+- [x] 2.3 Run /soleur:compound (no significant learnings -- straightforward markdown edits)
+- [ ] 2.4 Commit, push, create PR referencing #168

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.22.2",
+  "version": "2.22.3",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 44 agents, 8 commands, and 44 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Soleur plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.22.3] - 2026-02-20
+
+### Changed
+
+- Extended compound skill to capture session-level errors (failed commands, wrong approaches, process mistakes) alongside the target problem documentation (#168)
+
 ## [2.22.2] - 2026-02-20
 
 ### Changed

--- a/plugins/soleur/commands/soleur/compound.md
+++ b/plugins/soleur/commands/soleur/compound.md
@@ -206,6 +206,7 @@ git worktree remove .worktrees/feat-<name>
 - **Root cause analysis**: Technical explanation
 - **Working solution**: Step-by-step fix with code examples
 - **Prevention strategies**: How to avoid in future
+- **Session errors**: Process mistakes, failed commands, and wrong approaches from the session
 - **Cross-references**: Links to related issues and docs
 
 ## Preconditions

--- a/plugins/soleur/skills/compound-docs/SKILL.md
+++ b/plugins/soleur/skills/compound-docs/SKILL.md
@@ -68,6 +68,17 @@ Extract from conversation history:
 - **Solution**: What fixed it (code/config changes)
 - **Prevention**: How to avoid in future
 
+**Session errors (beyond the target problem):**
+
+Scan conversation history for errors unrelated to the main problem investigation documented above. Only capture errors that are NOT part of the investigation attempts. Skip trivial errors immediately corrected (typos in commands, expected test failures during TDD).
+
+Extract for each error found:
+- Describe what went wrong (1 sentence)
+- Note what was done to recover
+- Suggest how to prevent it in future sessions (1 sentence)
+
+If no session errors are found, skip this extraction silently.
+
 **Environment details:**
 
 - Rails version

--- a/plugins/soleur/skills/compound-docs/assets/resolution-template.md
+++ b/plugins/soleur/skills/compound-docs/assets/resolution-template.md
@@ -42,6 +42,16 @@ tags: [keyword1, keyword2, keyword3]
 [If nothing else was attempted first, write:]
 **Direct solution:** The problem was identified and fixed on the first attempt.
 
+## Session Errors
+
+[Process mistakes and command failures encountered during this session, beyond the main problem investigation. Omit this section entirely if no session errors occurred.]
+
+**[Brief error description]**
+- **Recovery:** [What fixed it]
+- **Prevention:** [How to avoid in future]
+
+[Repeat for each session error]
+
 ## Solution
 
 [The actual fix that worked - provide specific details]


### PR DESCRIPTION
## Summary

- Extended `/soleur:compound` to capture session-level errors (failed commands, wrong approaches, process mistakes) alongside the target problem documentation
- Added "Session Errors" section to the resolution template using the same bold-heading + bullet format as "What Didn't Work"
- Updated compound command description to reflect the new capability

Closes #168

## Changes

| File | Change |
|------|--------|
| `plugins/soleur/skills/compound-docs/SKILL.md` | Added session error extraction to Step 2 (Gather Context) |
| `plugins/soleur/skills/compound-docs/assets/resolution-template.md` | Added "Session Errors" section template |
| `plugins/soleur/commands/soleur/compound.md` | Added "Session errors" to "What It Captures" list |
| Version files | PATCH bump 2.22.2 -> 2.22.3 |

## Design decisions

- **Folded into Step 2** (not a separate step) -- keeps context gathering in one place, avoids fractional step numbering
- **No category taxonomy** -- natural language descriptions are sufficient; no programmatic consumer exists for categories
- **Bullet format** (not table) -- consistent with existing "What Didn't Work" section, handles variable-length content
- **No new subagent** -- session error scan is part of context gathering, not an independent parallel unit
- **No schema changes** -- session errors live in markdown body, not YAML frontmatter

## Test plan

- [ ] Run `/soleur:compound` after a session with command failures -- verify Session Errors section appears in the learning document
- [ ] Run `/soleur:compound` after a clean session -- verify no Session Errors section is added
- [ ] Verify errors already in "What Didn't Work" are not duplicated in Session Errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)