### PR TITLE
fix: correct ralph-loop plugin namespace in one-shot command (v2.23.1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.23.0"
+      placeholder: "2.23.1"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.23.0-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.23.1-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 45 agents, 8 commands, and 45 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.23.1] - 2026-02-21
+
+### Fixed
+
+- Fix ralph-loop plugin namespace in one-shot command (`ralph-wiggum:ralph-loop` -> `ralph-loop:ralph-loop`)
+
 ## [2.23.0] - 2026-02-21
 
 ### Added

--- a/plugins/soleur/commands/soleur/one-shot.md
+++ b/plugins/soleur/commands/soleur/one-shot.md
@@ -20,7 +20,7 @@ if [ "$current_branch" = "$default_branch" ]; then
 fi
 ```
 
-1. `/ralph-wiggum:ralph-loop "finish all slash commands" --completion-promise "DONE"`
+1. `/ralph-loop:ralph-loop "finish all slash commands" --completion-promise "DONE"`
 2. `/soleur:plan $ARGUMENTS`
 3. `/deepen-plan`
 4. `/soleur:work`


### PR DESCRIPTION
## Summary

- Fixes `/ralph-wiggum:ralph-loop` -> `/ralph-loop:ralph-loop` in the one-shot command
- The installed plugin is `ralph-loop@claude-plugins-official`, not `ralph-wiggum` -- the stale namespace caused a skill-not-found error on every `/soleur:one-shot` run

## Test plan

- [ ] Run `/soleur:one-shot` on a test issue -- Step 1 should invoke ralph-loop successfully instead of erroring with "skill not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)