### PR TITLE
fix: add mandatory session error inventory to compound (v2.23.2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.23.1"
+      placeholder: "2.23.2"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Soleur is meant to be a "Company-as-a-Service" platform designed to allow solo f
 
 Currently at phase of being an Orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.23.1-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.23.2-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![With ❤️ by Soleur](https://img.shields.io/badge/with%20❤️%20by-Soleur-yellow)](https://github.com/jikig-ai/soleur)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 45 agents, 8 commands, and 45 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.23.2] - 2026-02-21
+
+### Fixed
+
+- Add mandatory Session Error Inventory step (Phase 0.5) to compound command -- forces enumeration of all session errors before writing learnings, preventing silent omission in pipeline mode
+
 ## [2.23.1] - 2026-02-21
 
 ### Fixed

--- a/plugins/soleur/commands/soleur/compound.md
+++ b/plugins/soleur/commands/soleur/compound.md
@@ -34,6 +34,26 @@ fi
 
 Read `CLAUDE.md` if it exists - apply project conventions during documentation.
 
+## Phase 0.5: Session Error Inventory (MANDATORY)
+
+HARD RULE: Before writing any learning, enumerate ALL errors encountered in this session. Output a numbered list to the user. This step cannot be skipped even if the session felt clean.
+
+Include:
+
+- Skill or command not found errors (e.g., wrong plugin namespace)
+- Wrong file paths, directories, or branch confusion
+- Failed bash commands or unexpected exit codes
+- API errors or unexpected responses
+- Wrong assumptions that required backtracking
+- Tools or agents that returned errors
+- Permission denials or hook rejections
+
+If genuinely no errors occurred, output: "Session error inventory: none detected."
+
+This list feeds directly into the Session Errors section of the learning document. Every item on this list MUST appear in the final output unless the user explicitly excludes it.
+
+FAILURE MODE THIS PREVENTS: Compound runs in pipeline mode, the model judges the session as "clean," and silently drops errors that happened earlier in the conversation (e.g., a skill-not-found error from one-shot Step 1 gets omitted because compound focuses only on the main implementation task).
+
 ## Execution Strategy: Parallel Subagents
 
 This command launches multiple specialized subagents IN PARALLEL to maximize efficiency:


### PR DESCRIPTION
## Summary

- Adds Phase 0.5 "Session Error Inventory" to the compound command as a mandatory step before any learning gets written
- Forces the model to enumerate ALL errors from the session in a numbered list, preventing silent omission in pipeline mode
- Includes a FAILURE MODE description explaining the exact scenario this prevents (ralph-loop namespace error dropped during one-shot pipeline)

## Context

During a `/soleur:one-shot` run, compound ran but missed the ralph-loop `skill not found` error because the model judged the session as "clean" and focused only on the main implementation. The session error scanning instructions existed in compound-docs but were advisory -- the model optimized them away. This fix makes enumeration structural rather than advisory.

## Test plan

- [ ] Run `/soleur:compound` after a session with errors -- Phase 0.5 should output a numbered list before any learning is written
- [ ] Run `/soleur:compound` after a clean session -- Phase 0.5 should output "Session error inventory: none detected."

🤖 Generated with [Claude Code](https://claude.com/claude-code)