### PR TITLE
feat: add Article 30 processing register generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ node_modules/
 .env
 _site/
 _site_test/
+
+# Article 30 register (private -- do not commit)
+article-30-register*.md
+knowledge-base/private/

--- a/knowledge-base/learnings/2026-02-21-private-document-generation-pattern.md
+++ b/knowledge-base/learnings/2026-02-21-private-document-generation-pattern.md
@@ -1,0 +1,37 @@
+---
+title: Private document generation pattern
+category: integration-issues
+tags: [gdpr, compliance, gitignore, private-documents, shell-script]
+module: legal
+severity: low
+date: 2026-02-21
+---
+
+# Learning: Private document generation pattern
+
+## Problem
+
+GDPR Article 30 requires maintaining a processing register that must NOT be in a public repository but must be reproducible on regulatory request. The template content belongs in the repo (for versioning and review), but the filled output does not.
+
+## Solution
+
+Separate the template (versioned, public) from the generated output (gitignored, private):
+
+1. Template lives in `knowledge-base/specs/archive/` -- versioned, reviewable
+2. Shell script in `scripts/` reads template, fills placeholders with `sed`, writes to repo root
+3. `.gitignore` entry prevents accidental commits of the output
+4. Script prints private storage instructions after generation
+
+```bash
+# Pattern: versioned template + gitignored output
+sed "s/\[DATE\]/$TODAY/g" "$TEMPLATE" > "$OUTPUT"
+```
+
+## Key Insight
+
+When compliance requires a private document derived from a public template, version the tooling (script + template) but gitignore the output. The script itself serves as documentation of how to reproduce the document -- no separate README needed.
+
+## Tags
+
+category: integration-issues
+module: legal

--- a/knowledge-base/plans/2026-02-21-legal-article-30-register-plan.md
+++ b/knowledge-base/plans/2026-02-21-legal-article-30-register-plan.md
@@ -1,0 +1,108 @@
+---
+title: Create Article 30 Processing Register from Template
+type: feat
+date: 2026-02-21
+issue: "#202"
+version-bump: PATCH
+deepened: 2026-02-21
+---
+
+# Create Article 30 Processing Register from Template
+
+## Overview
+
+Create a shell script that generates the GDPR Article 30 processing register from the existing template, filling in dates automatically. Add `.gitignore` protection to prevent accidental commits. The generated register is a private document -- the script and safeguards live in the repo, but the output does not.
+
+## Problem Statement
+
+Per the GDPR Article 30 compliance audit (#187, resolved in #200), Jikigai must maintain an internal record of processing activities. The template exists at `knowledge-base/specs/archive/20260221-044654-feat-cnil-article-30/article-30-register-template.md` but no tooling exists to:
+
+1. Generate the register with actual dates filled in
+2. Prevent accidental commits of the private register
+3. Guide personnel on private storage requirements
+
+## Proposed Solution
+
+Minimal approach -- three changes:
+
+1. **Shell script** (`scripts/generate-article-30-register.sh`) that copies the template, fills `[DATE]` placeholders with today's date, and writes to a gitignored output path
+2. **`.gitignore` entry** for the output file pattern (`article-30-register*.md` and `knowledge-base/private/`)
+3. **Instructions in script header** for private storage (no separate docs file needed)
+
+## Non-Goals
+
+- Encrypted storage or vault integration -- overkill for a single markdown document
+- A new skill or agent -- this is a one-time generation, a shell script suffices
+- Automated private repo creation -- user decides where to store it
+- Modifying existing legal documents -- PR #200 already added Article 30 references
+
+## Acceptance Criteria
+
+- [x] Script generates register from template with current date filled in
+- [x] Output file is gitignored (cannot be accidentally committed)
+- [x] Script prints clear instructions for private storage after generation
+- [x] Running script twice overwrites cleanly (idempotent)
+
+## Test Scenarios
+
+- Given the template exists, when running the script, then a register file is created with today's date replacing all `[DATE]` placeholders
+- Given the register was already generated, when running the script again, then it overwrites without error
+- Given a user runs `git add -A`, when the register exists locally, then `git status` does NOT show the register file (gitignore works)
+- Given the script is run, when it completes, then it prints private storage instructions to stdout
+
+## MVP
+
+### scripts/generate-article-30-register.sh
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Navigate to repo root so the script works from any directory
+cd "$(git rev-parse --show-toplevel)"
+
+TEMPLATE="knowledge-base/specs/archive/20260221-044654-feat-cnil-article-30/article-30-register-template.md"
+OUTPUT="article-30-register.md"
+TODAY=$(date +%Y-%m-%d)
+
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "Error: Template not found at $TEMPLATE" >&2
+  echo "Are you running this from the soleur repository?" >&2
+  exit 1
+fi
+
+sed "s/\[DATE\]/$TODAY/g" "$TEMPLATE" > "$OUTPUT"
+
+echo ""
+echo "Article 30 register generated: $(pwd)/$OUTPUT"
+echo ""
+echo "IMPORTANT: This file is gitignored and must NOT be committed."
+echo "Store it in one of these private locations:"
+echo "  - Private Notion page"
+echo "  - Password-protected cloud folder (Google Drive, Dropbox)"
+echo "  - Private GitHub repository"
+echo "  - Internal document management system"
+echo ""
+echo "The register must be producible on CNIL request during an inspection."
+```
+
+### Research Insights
+
+- Script uses `cd "$(git rev-parse --show-toplevel)"` to work from any directory (worktrees, subdirectories)
+- Uses `echo` instead of heredoc for the output message so the output path can include `$(pwd)` for clarity
+- The `.gitignore` pattern is scoped to the repo root only since gitignore patterns without `/` match anywhere -- but `article-30-register*.md` is specific enough to avoid false positives
+
+### .gitignore addition
+
+```gitignore
+# Article 30 register (private -- do not commit)
+article-30-register*.md
+knowledge-base/private/
+```
+
+## References
+
+- Template: `knowledge-base/specs/archive/20260221-044654-feat-cnil-article-30/article-30-register-template.md`
+- Compliance audit: #187
+- Compliance fixes: #200
+- Learning: `knowledge-base/learnings/2026-02-21-gdpr-article-30-compliance-audit-pattern.md`

--- a/knowledge-base/specs/feat-article-30-register/tasks.md
+++ b/knowledge-base/specs/feat-article-30-register/tasks.md
@@ -1,0 +1,23 @@
+---
+feature: article-30-register
+issue: "#202"
+date: 2026-02-21
+---
+
+# Tasks: Article 30 Processing Register
+
+## Phase 1: Setup
+
+- [x] 1.1 Add `.gitignore` entries for `article-30-register*.md` and `knowledge-base/private/`
+
+## Phase 2: Core Implementation
+
+- [x] 2.1 Create `scripts/generate-article-30-register.sh` that reads the template, replaces `[DATE]` placeholders with today's date, writes output to `article-30-register.md`
+- [x] 2.2 Script prints private storage instructions after generation
+- [x] 2.3 Make script executable (`chmod +x`)
+
+## Phase 3: Testing
+
+- [x] 3.1 Run script and verify register is generated with correct dates
+- [x] 3.2 Verify gitignore prevents `git add -A` from staging the register
+- [x] 3.3 Run script a second time to verify idempotent overwrite

--- a/scripts/generate-article-30-register.sh
+++ b/scripts/generate-article-30-register.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Navigate to repo root so the script works from any directory
+cd "$(git rev-parse --show-toplevel)"
+
+TEMPLATE="knowledge-base/specs/archive/20260221-044654-feat-cnil-article-30/article-30-register-template.md"
+OUTPUT="article-30-register.md"
+TODAY=$(date +%Y-%m-%d)
+
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "Error: Template not found at $TEMPLATE" >&2
+  echo "Are you running this from the soleur repository?" >&2
+  exit 1
+fi
+
+sed "s/\[DATE\]/$TODAY/g" "$TEMPLATE" > "$OUTPUT"
+
+echo ""
+echo "Article 30 register generated: $(pwd)/$OUTPUT"
+echo ""
+echo "IMPORTANT: This file is gitignored and must NOT be committed."
+echo "Store it in one of these private locations:"
+echo "  - Private Notion page"
+echo "  - Password-protected cloud folder (Google Drive, Dropbox)"
+echo "  - Private GitHub repository"
+echo "  - Internal document management system"
+echo ""
+echo "The register must be producible on CNIL request during an inspection."


### PR DESCRIPTION
## Summary

- Add `scripts/generate-article-30-register.sh` that generates the GDPR Article 30 processing register from the existing template, filling `[DATE]` placeholders with the current date
- Add `.gitignore` entries to prevent accidental commits of the private register output
- Script prints private storage instructions after generation

Closes #202

## Test plan

- [ ] Run `bash scripts/generate-article-30-register.sh` and verify `article-30-register.md` is created with dates filled in
- [ ] Run the script a second time to verify idempotent overwrite
- [ ] Run `git add -A && git status` and verify the register file is NOT staged (gitignored)
- [ ] Store the generated register in a private location per the script's instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)