### PR TITLE
legal: clarify email provider DPA for legal@jikigai.com (v2.23.6)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.23.5"
+      placeholder: "2.23.6"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.23.5-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.23.6-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/docs/legal/gdpr-policy.md
+++ b/docs/legal/gdpr-policy.md
@@ -87,6 +87,7 @@ The following data may be processed by third-party services when users interact 
 | IP address, browser metadata | GitHub (via GitHub Pages) | Hosting documentation site |
 | Prompts, code context | Anthropic (via Claude API) | Powering AI agent responses (user authenticates with own credentials) |
 | GitHub account data | GitHub (via repository) | Issue tracking, contributions |
+| Name, email, inquiry content | Proton AG (via Proton Mail) | Handling legal and GDPR inquiries (legal@jikigai.com) |
 
 Users are responsible for reviewing the privacy policies of these third-party services.
 
@@ -199,7 +200,7 @@ In the event of a personal data breach affecting data for which Jikigai acts as 
 
 ### 11.2 Practical Context
 
-Given Jikigai's minimal processing activities, the most likely breach scenario would involve unauthorized access to the email provider handling legal@jikigai.com or a compromise of the GitHub organization. In both cases, the third-party provider (email service, GitHub) would typically be the first to detect and communicate the breach.
+Given Jikigai's minimal processing activities, the most likely breach scenario would involve unauthorized access to Proton AG (Proton Mail), the email provider handling legal@jikigai.com, or a compromise of the GitHub organization. In both cases, the third-party provider (Proton Mail, GitHub) would typically be the first to detect and communicate the breach.
 
 ---
 

--- a/knowledge-base/learnings/2026-02-21-gdpr-article-30-email-provider-documentation.md
+++ b/knowledge-base/learnings/2026-02-21-gdpr-article-30-email-provider-documentation.md
@@ -1,0 +1,56 @@
+---
+title: "GDPR Article 30: Email Provider Documentation Pattern"
+category: integration-issues
+tags: [gdpr, article-30, dpa, email-provider, proton-mail, legal-compliance]
+module: legal-agents
+problem_type: documentation-gap
+date: 2026-02-21
+---
+
+# GDPR Article 30: Email Provider Documentation Pattern
+
+## Problem
+
+The Article 30 register had placeholder values ("fournisseur email") for the email provider handling GDPR inquiries. Updating required identifying the provider, verifying DPA status, and propagating changes across multiple legal documents that must stay in sync.
+
+## Solution
+
+1. **Identify provider via DNS**: `dig MX jikigai.com +short` confirmed Proton Mail (mail.protonmail.ch).
+2. **Verify DPA**: Proton's DPA at proton.me/legal/dpa applies to "any business or organization regardless of legal form" and is automatically accepted via Terms and Conditions.
+3. **Document transfer mechanism**: Switzerland has EU adequacy decision (Commission Decision 2000/518/CE). Germany (where Proton also stores data) is EU -- does NOT belong in "Transferts hors UE".
+4. **Update all locations**: Article 30 register, GDPR policy (both sync locations), audit report.
+
+## Key Insights
+
+### EU vs non-EU transfer distinction matters
+
+When documenting data storage in the Article 30 register's "Transferts hors UE" field, only list countries that are actually outside the EU/EEA. Switzerland requires a transfer justification (adequacy decision). Germany does not -- it is an EU member state. Listing EU countries in the non-EU transfer field is structurally incoherent under Article 46 GDPR.
+
+Correct pattern: "Suisse (decision d'adequation CE 2000/518/CE); donnees stockees en Suisse et dans l'UE (Allemagne)"
+
+### Cross-document consistency requires checking ALL sections
+
+When naming a new processor in legal documents, check ALL sections that reference it -- not just the section you're primarily updating. In this case, adding Proton to the breach notification section (11.2) also required adding it to the third-party data table (Section 4.2). Review agents caught this; manual editing would have missed it.
+
+### Proton DPA applies broadly
+
+Proton's DPA is not limited to business/enterprise accounts. It applies to "any business or organization using the Services, regardless of its legal form" and is incorporated by reference into the standard Terms and Conditions. This reduces the risk assessment for account-tier uncertainty.
+
+## Session Errors
+
+- Edit tool requires reading files before editing -- attempted an edit without prior read
+- "Transferts hors UE" field initially included Germany (EU member) -- structural legal error caught by review
+- Third-party data table in GDPR policy Section 4.2 was missed in initial implementation -- caught by code-simplicity-reviewer
+
+## Prevention
+
+- When updating Article 30 registers, grep for ALL references to the entity being documented across all legal files
+- Use review agents even for documentation-only changes -- they catch cross-document consistency gaps
+- For "Transferts hors UE" fields, explicitly verify whether each country is EU/EEA before listing
+
+## References
+
+- Issue #204
+- PR #200 (GDPR Article 30 compliance fixes)
+- Proton DPA: https://proton.me/legal/dpa
+- EU adequacy decision for Switzerland: Commission Decision 2000/518/EC

--- a/knowledge-base/plans/2026-02-21-legal-email-provider-dpa-plan.md
+++ b/knowledge-base/plans/2026-02-21-legal-email-provider-dpa-plan.md
@@ -1,0 +1,109 @@
+---
+title: "legal: Clarify email provider DPA for legal@jikigai.com"
+type: feat
+date: 2026-02-21
+issue: "#204"
+deepened: 2026-02-21
+---
+
+# Clarify Email Provider DPA for legal@jikigai.com
+
+## Enhancement Summary
+
+**Deepened on:** 2026-02-21
+**Key improvements:**
+1. DNS verification confirmed Proton Mail (MX: mail.protonmail.ch, mailsec.protonmail.ch)
+2. Proton DPA verified -- applies to "any business or organization regardless of legal form" (reduces account-tier risk)
+3. Proton AG legal entity confirmed: CHE-354.686.492, Route de la Galaise 32, 1228 Plan-les-Ouates, Switzerland
+4. Exact file locations and line numbers identified for all replacements
+
+## Overview
+
+Identify the email provider for legal@jikigai.com, verify DPA status under GDPR Article 28, document international transfer mechanisms, and update the Article 30 register (Treatment N.3) with concrete provider details replacing current placeholders.
+
+## Problem Statement
+
+The GDPR Article 30 compliance audit (#187, resolved in #200) identified that Treatment N.3 (legal inquiry handling via legal@jikigai.com) has placeholder values for the email provider. The register currently says "fournisseur email" and "Selon fournisseur email" -- these must be replaced with the actual provider identity, DPA reference, and transfer mechanism.
+
+## Proposed Solution
+
+1. Confirm the email provider via DNS MX lookup (preliminary research indicates Proton Mail / Proton AG, Geneva, Switzerland)
+2. Document Proton's DPA terms and data residency
+3. Update the Article 30 register template with concrete values
+4. Update GDPR policy references from generic "the email provider" to named provider
+5. Sync all changes across both legal document locations
+
+## Technical Approach
+
+### Phase 1: Verify Provider
+
+```bash
+dig MX jikigai.com +short
+dig TXT jikigai.com +short  # Check SPF for provider confirmation
+```
+
+**Verified result:**
+- MX: `10 mail.protonmail.ch.` and `20 mailsec.protonmail.ch.`
+- Provider: Proton Mail (Proton AG, Geneva, Switzerland)
+- Legal entity: Proton AG, Route de la Galaise 32, 1228 Plan-les-Ouates, Switzerland (CHE-354.686.492)
+- DPA: https://proton.me/legal/dpa -- applies to "any business or organization using the Services, regardless of its legal form"; automatically accepted as part of Proton's Terms and Conditions
+- Data residency: Switzerland, EU, and adequacy-decision countries only
+- Transfer mechanism: SCCs for any transfers outside CH/EU/adequacy countries
+- Switzerland adequacy: Commission Decision 2000/518/EC
+
+### Phase 2: Update Documents
+
+**Task 2.1: Update Article 30 register Treatment N.3**
+
+File: `knowledge-base/specs/archive/20260221-044654-feat-cnil-article-30/article-30-register-template.md`
+
+Replace placeholder values and fill `[DATE]` placeholders with `2026-02-21`:
+
+| Field | Current Value | New Value |
+|-------|--------------|-----------|
+| Destinataires | "fournisseur email" | "Proton AG (Proton Mail)" |
+| Transferts hors UE | "Selon fournisseur email pour legal@jikigai.com" | "Suisse (decision d'adequation CE 2000/518/CE); donnees chiffrees stockees en Suisse et Allemagne" |
+| Sous-traitant (if field exists) | N/A | "Proton AG, Route de la Galaise 32, 1228 Plan-les-Ouates, Geneve, Suisse" |
+
+**Task 2.2: Update GDPR policy in both locations**
+
+In Section 11.2 (breach notification scenario) of both `docs/legal/gdpr-policy.md` and `plugins/soleur/docs/pages/legal/gdpr-policy.md`, replace "the email provider handling legal@jikigai.com" with "Proton AG (Proton Mail), the email provider handling legal@jikigai.com". Keep generic phrasing in other sections.
+
+**Task 2.3: Mark audit recommendation as resolved**
+
+File: `knowledge-base/specs/archive/20260221-044654-feat-cnil-article-30/audit-report.md`
+
+Update Recommendation 3 ("Clarify email provider") status to resolved with a reference to this PR.
+
+## Acceptance Criteria
+
+- [ ] Email provider confirmed as Proton Mail (Proton AG) via DNS MX records
+- [ ] Proton's DPA terms documented (link to https://proton.me/legal/dpa)
+- [ ] Switzerland adequacy decision referenced (2000/518/EC)
+- [ ] Article 30 register Treatment N.3 updated with provider details
+- [ ] GDPR policy Section 11.2 updated in both locations (`docs/legal/` and `plugins/soleur/docs/pages/legal/`)
+- [ ] Audit report recommendation 3 marked as resolved
+
+## Non-Goals
+
+- Verifying whether the Proton account is business vs. consumer tier (operational task requiring admin access -- flagged as follow-up if DPA requires business tier)
+- Fixing the `data-processing-agreement.md` vs `data-protection-disclosure.md` naming mismatch between sync locations (pre-existing issue, separate scope)
+
+## Dependencies and Risks
+
+- **Risk: Account tier uncertainty (mitigated).** Proton's DPA applies to "any business or organization using the Services, regardless of its legal form" and is automatically accepted as part of the Terms and Conditions. This reduces the risk that a consumer-tier account lacks DPA coverage, though confirming the account type remains good practice.
+- **Risk: Worktree conflicts.** Three related worktrees (`feat-legal-email-dpa`, `feat-article-30-register`, `feat-github-dpa-verify`) may touch overlapping files. Mitigation: This branch merges first; others rebase after.
+- **Dual-location sync.** Both `docs/legal/` and `plugins/soleur/docs/pages/legal/` must be updated. Use grep to verify consistency post-edit.
+
+## Version Bump
+
+PATCH bump (documentation update to existing legal files under `plugins/soleur/`).
+
+## References
+
+- Issue #204: Clarify email provider DPA for legal@jikigai.com
+- Issue #187: CNIL registration check (original audit)
+- PR #200: GDPR Article 30 compliance fixes (v2.23.4)
+- Proton DPA: https://proton.me/legal/dpa
+- EU adequacy decision for Switzerland: Commission Decision 2000/518/EC
+- Article 30 register template: `knowledge-base/specs/archive/20260221-044654-feat-cnil-article-30/article-30-register-template.md`

--- a/knowledge-base/specs/archive/20260221-044654-feat-cnil-article-30/article-30-register-template.md
+++ b/knowledge-base/specs/archive/20260221-044654-feat-cnil-article-30/article-30-register-template.md
@@ -13,8 +13,8 @@
 - Adresse: 25 rue de Ponthieu, 75008 Paris, France
 - Contact: legal@jikigai.com
 
-**Date de creation:** [DATE]
-**Derniere mise a jour:** [DATE]
+**Date de creation:** 2026-02-21
+**Derniere mise a jour:** 2026-02-21
 
 ---
 
@@ -56,10 +56,11 @@
 | Base legale | Obligation legale (Art. 6(1)(c)) pour les demandes RGPD; interet legitime (Art. 6(1)(f)) pour les autres |
 | Categories de personnes concernees | Personnes soumettant des demandes |
 | Categories de donnees | Nom, adresse email, contenu de la demande |
-| Destinataires | Personnel interne Jikigai; fournisseur email |
-| Transferts hors UE | Selon fournisseur email pour legal@jikigai.com |
+| Destinataires | Personnel interne Jikigai; Proton AG (Proton Mail) -- sous-traitant email |
+| Transferts hors UE | Suisse (decision d'adequation CE 2000/518/CE); donnees stockees en Suisse et dans l'UE (Allemagne) par Proton AG |
 | Delai de conservation | Duree necessaire pour resoudre la demande + 3 ans (prescription civile francaise) |
-| Mesures de securite | Securite email; acces restreint au personnel autorise |
+| Mesures de securite | Chiffrement de bout en bout (Proton Mail); acces restreint au personnel autorise |
+| Sous-traitant | Proton AG, Route de la Galaise 32, 1228 Plan-les-Ouates, Geneve, Suisse (CHE-354.686.492); DPA: https://proton.me/legal/dpa |
 
 ---
 

--- a/knowledge-base/specs/archive/20260221-044654-feat-cnil-article-30/audit-report.md
+++ b/knowledge-base/specs/archive/20260221-044654-feat-cnil-article-30/audit-report.md
@@ -41,7 +41,7 @@ No CNIL registration or notification is required (abolished in 2018 reform).
 
 1. **Create the Article 30 register** -- Store privately (not in the public repo). Template provided as `article-30-register-template.md`.
 2. **Verify GitHub DPA** -- Confirm Jikigai has accepted GitHub's Data Protection Agreement at https://github.com/customer-terms.
-3. **Clarify email provider** -- Verify DPA with email provider for legal@jikigai.com.
+3. **Clarify email provider** -- Verify DPA with email provider for legal@jikigai.com. **Resolved:** Proton AG (Proton Mail) confirmed via DNS MX records; DPA at https://proton.me/legal/dpa applies automatically; Switzerland adequacy decision 2000/518/CE covers international transfers. See #204.
 4. **Consider breach notification procedure** -- Document internal procedure for handling a potential data breach (Article 33/34).
 5. **No CNIL registration needed** -- The 2018 reform eliminated the declaration system entirely.
 

--- a/knowledge-base/specs/feat-legal-email-dpa/tasks.md
+++ b/knowledge-base/specs/feat-legal-email-dpa/tasks.md
@@ -1,0 +1,23 @@
+---
+title: "Tasks: Clarify email provider DPA for legal@jikigai.com"
+issue: "#204"
+date: 2026-02-21
+---
+
+# Tasks: Clarify Email Provider DPA
+
+## Phase 1: Verify Provider
+
+- [x] 1.1 Run DNS MX lookup for jikigai.com to confirm Proton Mail
+
+## Phase 2: Update Documents
+
+- [x] 2.1 Update Article 30 register Treatment N.3 -- replace placeholders with Proton AG details and fill `[DATE]` values
+- [x] 2.2 Update GDPR policy Section 11.2 in both `docs/legal/gdpr-policy.md` and `plugins/soleur/docs/pages/legal/gdpr-policy.md`
+- [x] 2.3 Mark audit report Recommendation 3 as resolved
+
+## Phase 3: Verification
+
+- [x] 3.1 Grep all legal files for "fournisseur email" -- expect zero matches
+- [x] 3.2 Verify both GDPR policy locations match
+- [x] 3.3 Run markdownlint on modified files

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.23.5",
+  "version": "2.23.6",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 45 agents, 8 commands, and 45 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.23.6] - 2026-02-21
+
+### Changed
+
+- Name Proton AG (Proton Mail) as email provider in GDPR policy and Article 30 register (#204)
+- Add Proton Mail to third-party data table in GDPR policy Section 4.2
+- Update Article 30 register Treatment N.3 with provider details, DPA reference, and adequacy decision
+- Mark audit report Recommendation 3 (email provider clarification) as resolved
+
 ## [2.23.5] - 2026-02-21
 
 ### Changed

--- a/plugins/soleur/docs/pages/legal/gdpr-policy.md
+++ b/plugins/soleur/docs/pages/legal/gdpr-policy.md
@@ -97,6 +97,7 @@ The following data may be processed by third-party services when users interact 
 | IP address, browser metadata | GitHub (via GitHub Pages) | Hosting documentation site |
 | Prompts, code context | Anthropic (via Claude API) | Powering AI agent responses (user authenticates with own credentials) |
 | GitHub account data | GitHub (via repository) | Issue tracking, contributions |
+| Name, email, inquiry content | Proton AG (via Proton Mail) | Handling legal and GDPR inquiries (legal@jikigai.com) |
 
 Users are responsible for reviewing the privacy policies of these third-party services.
 
@@ -209,7 +210,7 @@ In the event of a personal data breach affecting data for which Jikigai acts as 
 
 ### 11.2 Practical Context
 
-Given Jikigai's minimal processing activities, the most likely breach scenario would involve unauthorized access to the email provider handling legal@jikigai.com or a compromise of the GitHub organization. In both cases, the third-party provider (email service, GitHub) would typically be the first to detect and communicate the breach.
+Given Jikigai's minimal processing activities, the most likely breach scenario would involve unauthorized access to Proton AG (Proton Mail), the email provider handling legal@jikigai.com, or a compromise of the GitHub organization. In both cases, the third-party provider (Proton Mail, GitHub) would typically be the first to detect and communicate the breach.
 
 ---
 


### PR DESCRIPTION
## Summary

- Identify Proton AG (Proton Mail) as the email provider for legal@jikigai.com via DNS MX records
- Update Article 30 register Treatment N.3 with provider details, DPA reference, and Switzerland adequacy decision
- Add Proton Mail to GDPR policy third-party data table (Section 4.2) and breach notification section (Section 11.2)
- Mark audit report Recommendation 3 as resolved

## Changes

**Legal documents (synced across both locations):**
- `docs/legal/gdpr-policy.md` -- Named Proton AG in Section 11.2 and added to Section 4.2 table
- `plugins/soleur/docs/pages/legal/gdpr-policy.md` -- Same changes (Eleventy docs copy)

**Article 30 register:**
- Treatment N.3: Replaced placeholder values with Proton AG details
- Added Sous-traitant row with address (CHE-354.686.492) and DPA link
- Filled [DATE] placeholders with 2026-02-21
- Fixed: Germany correctly listed as EU (not in "Transferts hors UE")

**Audit report:**
- Recommendation 3 marked as resolved with details

## Test plan

- [x] Grep confirms zero remaining "fournisseur email" placeholders in legal files
- [x] Both GDPR policy locations have identical Proton AG references
- [x] Article 30 register has complete provider details
- [x] Audit report recommendation marked resolved

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)