### PR TITLE
fix(docs): match header logo style to footer (v2.23.8)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.23.7"
+      placeholder: "2.23.8"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.23.7-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.23.8-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.23.7",
+  "version": "2.23.8",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 45 agents, 8 commands, and 45 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.23.8] - 2026-02-21
+
+### Changed
+
+- Replace header logo image with CSS-styled mark matching footer (gold-bordered S + uppercase spaced wordmark)
+
 ## [2.23.7] - 2026-02-21
 
 ### Changed

--- a/plugins/soleur/docs/_includes/base.njk
+++ b/plugins/soleur/docs/_includes/base.njk
@@ -68,8 +68,8 @@
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <header class="site-header">
     <a href="index.html" class="logo">
-      <img src="images/logo-mark-512.png" width="24" height="24" alt="">
-      {{ site.name }}
+      <div class="header-mark">S</div>
+      <span class="header-name">{{ site.name }}</span>
     </a>
     <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-hidden="true">
     <label for="nav-toggle" class="nav-toggle-label" aria-label="Toggle navigation">&#9776;</label>

--- a/plugins/soleur/docs/css/style.css
+++ b/plugins/soleur/docs/css/style.css
@@ -152,15 +152,30 @@
     border-bottom: 1px solid var(--color-border);
   }
   .site-header .logo {
-    font-weight: 700;
-    font-size: var(--text-lg);
-    color: var(--color-text);
     text-decoration: none;
     display: flex;
     align-items: center;
-    gap: var(--space-2);
+    gap: var(--space-3);
   }
-  .site-header .logo:hover { color: var(--color-text); text-decoration: none; }
+  .site-header .logo:hover { text-decoration: none; }
+  .header-mark {
+    width: 24px;
+    height: 24px;
+    border-radius: 6px;
+    border: 1px solid var(--color-accent);
+    display: grid;
+    place-items: center;
+    font-family: var(--font-display);
+    font-size: var(--text-sm);
+    color: var(--color-accent);
+  }
+  .header-name {
+    font-size: var(--text-xs);
+    font-weight: 500;
+    letter-spacing: 3px;
+    color: var(--color-text-secondary);
+    text-transform: uppercase;
+  }
   .nav-links { display: flex; align-items: center; gap: var(--space-4); list-style: none; }
   .nav-links a {
     font-size: var(--text-sm);


### PR DESCRIPTION
## Summary
- Replace `<img src="logo-mark-512.png">` in header with CSS-styled mark matching footer
- Gold-bordered rounded square with "S" letter + uppercase spaced "SOLEUR" wordmark
- Header and footer now have identical branding treatment

## Before / After
Header previously used a raster PNG image. Now uses the same CSS approach as the footer: `.header-mark` (gold border, display grid, font-based S) + `.header-name` (uppercase, letter-spacing: 3px).

## Checklist
- [x] Version bumped (2.23.7 -> 2.23.8)
- [x] Build verified
- [x] Visual verification (header matches footer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)