### PR TITLE
fix(docs): center prose content and page hero subtitles (v2.23.10)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.23.9"
+      placeholder: "2.23.10"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.23.9-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.23.10-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.23.9",
+  "version": "2.23.10",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 45 agents, 8 commands, and 45 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.23.10] - 2026-02-21
+
+### Changed
+
+- Center `.prose` content with `margin: 0 auto` for balanced reading layout on desktop
+- Center `.page-hero` text and subtitle paragraphs to match `.hero` section styling
+
 ## [2.23.9] - 2026-02-21
 
 ### Added

--- a/plugins/soleur/docs/css/style.css
+++ b/plugins/soleur/docs/css/style.css
@@ -111,11 +111,12 @@
     padding: var(--space-10) 0 var(--space-8);
     margin-top: var(--header-h);
     position: relative;
+    text-align: center;
     border-bottom: 1px solid var(--color-border);
   }
   .page-hero .container { position: relative; z-index: 1; }
   .page-hero h1 { font-size: var(--text-4xl); margin-bottom: var(--space-4); letter-spacing: -0.02em; }
-  .page-hero p { font-size: var(--text-lg); color: var(--color-text-secondary); max-width: 600px; }
+  .page-hero p { font-size: var(--text-lg); color: var(--color-text-secondary); max-width: 600px; margin-inline: auto; }
 
   .page-section { padding: var(--space-8) 0; }
   .page-section + .page-section { border-top: 1px solid var(--color-border); }
@@ -781,6 +782,7 @@
   /* Prose reading width and vertical rhythm */
   .prose {
     max-width: 75ch;
+    margin: 0 auto;
   }
   .prose h2,
   .prose h3 {


### PR DESCRIPTION
## Summary
- Center `.prose` content with `margin: 0 auto` for balanced reading layout on desktop
- Center `.page-hero` subtitle text with `text-align: center` and `margin-inline: auto` to match `.hero` section styling
- Fixes the left-aligned appearance on Getting Started, Changelog, Legal pages, and Agents/Skills subtitle paragraphs

Closes #201

## Checklist
- [x] Visual verification (Getting Started, Agents, Changelog, Privacy Policy)
- [x] Version bumped (2.23.10)
- [x] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)