### PR TITLE
fix(docs): increase prose reading width from 75ch to 85ch (v2.23.11)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.23.10"
+      placeholder: "2.23.11"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.23.10-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.23.11-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.23.10",
+  "version": "2.23.11",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 45 agents, 8 commands, and 45 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.23.11] - 2026-02-21
+
+### Changed
+
+- Increase `.prose` reading width from 75ch to 85ch for better desktop screen utilization
+
 ## [2.23.10] - 2026-02-21
 
 ### Changed

--- a/plugins/soleur/docs/css/style.css
+++ b/plugins/soleur/docs/css/style.css
@@ -781,7 +781,7 @@
 
   /* Prose reading width and vertical rhythm */
   .prose {
-    max-width: 75ch;
+    max-width: 85ch;
     margin: 0 auto;
   }
   .prose h2,


### PR DESCRIPTION
## Summary
- Increase `.prose` max-width from 75ch to 85ch for better desktop screen utilization
- Content still centered and readable, but fills more of the 1200px container

## Checklist
- [x] Visual verification (Getting Started, Changelog)
- [x] Version bumped (2.23.11)
- [x] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)