### PR TITLE
fix(docs): remove max-width from .community-text for full-width alignment (v2.23.12)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.23.11"
+      placeholder: "2.23.12"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.23.11-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.23.12-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.23.11",
+  "version": "2.23.12",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 45 agents, 8 commands, and 45 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.23.12] - 2026-02-21
+
+### Changed
+
+- Remove max-width constraint from `.community-text` so paragraphs fill full section width and align naturally
+
 ## [2.23.11] - 2026-02-21
 
 ### Changed

--- a/plugins/soleur/docs/css/style.css
+++ b/plugins/soleur/docs/css/style.css
@@ -321,7 +321,6 @@
   .community-text {
     color: var(--color-text-secondary);
     line-height: 1.6;
-    max-width: 65ch;
   }
   .community-text + .community-text {
     margin-top: var(--space-4);


### PR DESCRIPTION
## Summary
- Remove `max-width: 65ch` from `.community-text` CSS class so paragraphs fill the full section width and align naturally instead of being constrained
- Affects Community (Contributing, Code of Conduct), Vision (CaaS paragraphs), and Legal (Documents intro) pages
- Part of UX/UI review #201

## Test plan
- [ ] Verify Community page Contributing and Code of Conduct paragraphs fill full section width
- [ ] Verify Vision page CaaS paragraphs fill full section width
- [ ] Verify Legal page Documents intro paragraph fills full section width
- [ ] Confirm no layout regressions on other pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)