### PR TITLE
sync: populate constitution and route learnings to definitions (v2.23.13)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.23.12"
+      placeholder: "2.23.13"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.23.12-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.23.13-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/knowledge-base/learnings/2026-02-17-playwright-screenshots-land-in-main-repo.md
+++ b/knowledge-base/learnings/2026-02-17-playwright-screenshots-land-in-main-repo.md
@@ -3,6 +3,7 @@ title: Playwright MCP screenshots write to main repo, not active worktree
 date: 2026-02-17
 category: workflow
 tags: [playwright, worktree, screenshots, browser-testing, cleanup]
+synced_to: [test-browser]
 module: docs
 symptoms: [screenshots-in-wrong-directory, playwright-mcp-in-main-repo, loose-png-files-in-repo-root]
 ---

--- a/knowledge-base/learnings/2026-02-18-token-env-var-not-cli-arg.md
+++ b/knowledge-base/learnings/2026-02-18-token-env-var-not-cli-arg.md
@@ -5,6 +5,7 @@ tags: [security, bash, secrets, discord, cli]
 module: community
 symptom: "Bot token visible in ps aux and shell history"
 root_cause: "Passing token as positional argument to script"
+synced_to: [infra-security]
 ---
 
 # Pass secrets via env var, never as CLI arguments

--- a/knowledge-base/learnings/2026-02-19-growth-strategist-agent-skill-development.md
+++ b/knowledge-base/learnings/2026-02-19-growth-strategist-agent-skill-development.md
@@ -1,3 +1,7 @@
+---
+synced_to: [skill-creator]
+---
+
 # Learning: Growth Strategist Agent & Skill Development
 
 ## Problem

--- a/knowledge-base/learnings/2026-02-19-never-use-delete-branch-with-parallel-worktrees.md
+++ b/knowledge-base/learnings/2026-02-19-never-use-delete-branch-with-parallel-worktrees.md
@@ -1,3 +1,7 @@
+---
+synced_to: [ship]
+---
+
 # Learning: Never use --delete-branch with parallel worktrees
 
 ## Problem

--- a/knowledge-base/learnings/2026-02-20-dogfood-legal-agents-cross-document-consistency.md
+++ b/knowledge-base/learnings/2026-02-20-dogfood-legal-agents-cross-document-consistency.md
@@ -1,3 +1,7 @@
+---
+synced_to: [legal-document-generator]
+---
+
 # Learning: Legal Agent Dogfooding -- Cross-Document Consistency
 
 ## Problem

--- a/knowledge-base/learnings/2026-02-21-github-actions-workflow-security-patterns.md
+++ b/knowledge-base/learnings/2026-02-21-github-actions-workflow-security-patterns.md
@@ -7,6 +7,7 @@ tags:
   - ci-cd
 module: infrastructure
 date: 2026-02-21
+synced_to: [security-sentinel]
 ---
 
 # Learning: GitHub Actions Workflow Security Patterns

--- a/knowledge-base/learnings/2026-02-21-marketing-audit-brand-violation-cascade.md
+++ b/knowledge-base/learnings/2026-02-21-marketing-audit-brand-violation-cascade.md
@@ -1,3 +1,7 @@
+---
+synced_to: [cmo]
+---
+
 # Marketing Audit: Brand Violation Cascade Patterns
 
 Date: 2026-02-21

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -14,6 +14,16 @@ Project principles organized by domain. Add principles as you learn them.
 - Agent prompts must contain only instructions the LLM would get wrong without them -- omit general domain knowledge, error handling, and boilerplate the model already knows
 - Agent frontmatter must include a `model` field (`inherit`, `haiku`, `sonnet`, or `opus`) to control execution model
 - Command frontmatter must include an `argument-hint` field describing expected arguments
+- Shell scripts must use `#!/usr/bin/env bash` shebang and declare `set -euo pipefail` at the top
+- Shell scripts use snake_case for function names and local variables, SCREAMING_SNAKE_CASE for global constants
+- Shell functions must declare all variables with `local`; error messages go to stderr (`>&2`)
+- Shell scripts use `[[ ]]` double-bracket tests and validate required arguments early with exit 1 and usage message
+- TypeScript, JSON, and HTML templates use 2-space indentation throughout
+- TypeScript uses `import type` for type-only imports
+- TypeScript uses inline `export` at declaration site, not separate `export {}` blocks
+- CSS is organized into `@layer` cascade layers in order: reset, tokens, base, layout, components, utilities; custom properties follow semantic naming (`--color-*`, `--font-*`, `--text-*`, `--space-*`)
+- CHANGELOG follows Keep a Changelog format with `### Added`, `### Changed`, `### Fixed`, `### Removed` section headers under `## [X.Y.Z] - YYYY-MM-DD` version entries
+- Plan files use `YYYY-MM-DD-<type>-<descriptive-name>-plan.md` filename format; learning files use `YYYY-MM-DD-<descriptive-slug>.md` format
 
 ### Never
 
@@ -26,6 +36,9 @@ Project principles organized by domain. Add principles as you learn them.
 - When spawning parallel subagents to generate HTML pages, provide an explicit CSS class name reference list (not the full CSS file) -- subagents independently invent class names that don't match the shared stylesheet
 - After version bumps, grep all HTML docs for hardcoded version strings (`grep -r "vX.Y.Z" plugins/soleur/docs/`) and update them -- the versioning triad extends to any file displaying version badges
 - Prefer numbered phase sections (Phase 1, Phase 2) in SKILL.md for multi-step workflows, with XML semantic tags (`<critical_sequence>`, `<decision_gate>`, `<validation_gate>`) to mark control flow
+- Prefer numeric literal underscores as thousand separators for readability (e.g., `3_000` instead of `3000`)
+- Prefer a language identifier after triple backticks in code blocks (e.g., ```bash, ```yaml -- never bare ```)
+- Prefer verb-noun naming for skill directories where applicable (e.g., `deploy-docs`, `release-announce`, `resolve-pr-parallel`)
 
 ## Architecture
 
@@ -50,6 +63,7 @@ Project principles organized by domain. Add principles as you learn them.
 - When adding or integrating new agents, verify the cumulative agent description token count stays under 15k tokens -- agent descriptions are injected into the system prompt on every turn and bloated descriptions degrade all conversations
 - Before adding new GitHub Actions workflows, audit existing ones with `gh run list --workflow=<name>.yml` -- remove workflows that are always skipped (condition never matches) or superseded by newer workflows that absorbed their functionality
 - Agent descriptions for agents with overlapping scope must include a one-line disambiguation sentence: "Use [sibling] for [its scope]; use this agent for [this scope]."
+- The project uses Bun as the JavaScript runtime with ESM modules (`"type": "module"`); pre-commit hooks are managed by lefthook (not Husky)
 
 ### Never
 
@@ -115,6 +129,7 @@ Project principles organized by domain. Add principles as you learn them.
 - All markdown files must pass markdownlint checks before commit
 - New modules and source files must have corresponding test files before shipping
 - Plans must include a "Test Scenarios" section with Given/When/Then acceptance tests
+- Test files live in a `test/` sibling directory (not co-located with source), named `<module>.test.ts` -- no `.spec.ts` pattern
 
 ### Never
 

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.23.12",
+  "version": "2.23.13",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 45 agents, 8 commands, and 45 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.23.13] - 2026-02-21
+
+### Changed
+
+- Sync codebase conventions to constitution: 16 new rules (shell, TypeScript, CSS, changelog, filename formats)
+- Sync learnings to 8 definitions: skill-creator, test-browser, legal-document-generator, legal-compliance-auditor, security-sentinel, cmo, ship, infra-security
+- Add `synced_to` frontmatter to 7 learnings for definition sync tracking
+
 ## [2.23.12] - 2026-02-21
 
 ### Changed

--- a/plugins/soleur/agents/engineering/infra/infra-security.md
+++ b/plugins/soleur/agents/engineering/infra/infra-security.md
@@ -13,6 +13,8 @@ This agent requires two environment variables for Cloudflare API operations:
 - `CF_API_TOKEN` -- Cloudflare API token (minimum scope: Zone:DNS:Edit, Zone:Settings:Read, Zone:Settings:Edit)
 - `CF_ZONE_ID` -- Cloudflare Zone ID for the target domain
 
+Never instruct the user to pass `CF_API_TOKEN` as a CLI argument or include it in a command string -- it will appear in `ps aux` output and shell history; it must be set as an environment variable before invoking the agent.
+
 **Before any API call**, validate the token with `GET https://api.cloudflare.com/client/v4/user/tokens/verify`. If validation fails, report the error and stop.
 
 **Graceful degradation:** If environment variables are missing, fall back to CLI-only checks (dig, openssl s_client). Announce which checks are skipped and why. Never fail entirely when CLI tools can still provide value.

--- a/plugins/soleur/agents/engineering/review/security-sentinel.md
+++ b/plugins/soleur/agents/engineering/review/security-sentinel.md
@@ -10,6 +10,8 @@ Your mission is to perform comprehensive security audits with laser focus on fin
 
 ## Core Security Scanning Protocol
 
+- In GitHub Actions workflows, flag mutable action tags (`@v4`) as HIGH severity -- they must be pinned to a commit SHA (`@<sha> # v4.2.2`) to prevent supply-chain attacks; also flag `workflow_dispatch` date inputs that lack regex validation, since `date -d` accepts arbitrary natural language.
+
 You will systematically execute these security scans:
 
 1. **Input Validation Analysis**

--- a/plugins/soleur/agents/legal/legal-compliance-auditor.md
+++ b/plugins/soleur/agents/legal/legal-compliance-auditor.md
@@ -8,6 +8,8 @@ A legal compliance auditor that analyzes existing legal documents and produces s
 
 ## Sharp Edges
 
+- When this repo pattern applies (legal source markdown in `docs/legal/` AND embedded Eleventy copies in `plugins/soleur/docs/pages/legal/`), flag both locations -- the docs site copies are NOT generated from source, so editing only one location leaves contradictory legal text at the other.
+
 ### 1. Finding Format
 
 Present each finding using this exact format:

--- a/plugins/soleur/agents/legal/legal-document-generator.md
+++ b/plugins/soleur/agents/legal/legal-document-generator.md
@@ -12,6 +12,9 @@ Terms & Conditions, Privacy Policy, Cookie Policy, GDPR Policy, Acceptable Use P
 
 ## Sharp Edges
 
+- Before generating any documents, collect entity name, contact email, jurisdiction, and architecture type (SaaS vs local-only vs open-source) upfront -- the generator creates each document independently, so missing this context produces cross-document inconsistencies that require a full audit cycle to fix.
+- For local-only or open-source tools with no data processing on behalf of third parties, offer "Data Protection Disclosure" instead of "Data Processing Agreement" -- a binding DPA implies a processor relationship that does not exist and will be flagged CRITICAL by the compliance auditor.
+
 ### 1. Disclaimer Placement
 
 Every generated document MUST include this blockquote at the very top and very bottom:

--- a/plugins/soleur/agents/marketing/cmo.md
+++ b/plugins/soleur/agents/marketing/cmo.md
@@ -14,6 +14,7 @@ Follow this 4-phase pattern for every engagement:
 
 Evaluate current marketing state before making recommendations.
 
+- Before proposing brand copy fixes, grep each prohibited term across the full repo first (docs, legal, commands, SKILL.md, knowledge-base) -- a single banned term typically appears in 10+ files, and file-by-file review consistently misses locations, causing mid-implementation scope surprises.
 - Check for `knowledge-base/overview/brand-guide.md` -- read Voice + Identity sections if present. If missing, flag as a gap.
 - Inventory marketing artifacts: existing content, SEO state, community presence, conversion surfaces.
 - Report gaps and strengths in a structured table (area, status, priority).

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -357,7 +357,7 @@ gh pr checks --watch --fail-fast
 gh pr merge <number> --squash
 ```
 
-**CRITICAL: Do NOT use `--delete-branch` on merge.** The worktree is still active and the guardrails hook will block it. Merge with `--squash` only, then `cleanup-merged` handles branch deletion after removing the worktree.
+**CRITICAL: Do NOT use `--delete-branch` on merge.** The guardrails hook blocks `--delete-branch` whenever ANY worktree exists in the repo -- not just the one for the branch being merged -- so the restriction applies unconditionally during parallel development. Merge with `--squash` only, then `cleanup-merged` handles branch deletion after removing the worktree.
 
 **If merged (either now or user says "merge PR" later in the session):**
 

--- a/plugins/soleur/skills/skill-creator/SKILL.md
+++ b/plugins/soleur/skills/skill-creator/SKILL.md
@@ -152,6 +152,9 @@ The script:
 
 After initialization, customize or remove the generated SKILL.md and example files as needed.
 
+- After creating a new skill, manually add it to `plugins/soleur/docs/_data/skills.js` in the `SKILL_CATEGORIES` map -- skills are NOT auto-discovered, and missing this step silently removes the skill from the docs site with no build error.
+- New agent files created mid-session cannot be invoked via `subagent_type` because the plugin registry is stale at session start; for live testing, use `general-purpose` agent type and embed the full instructions in the task prompt.
+
 ### Step 4: Edit the Skill
 
 When editing the (newly-generated or existing) skill, remember that the skill is being created for another instance of Claude to use. Focus on including information that would be beneficial and non-obvious to Claude. Consider what procedural knowledge, domain-specific details, or reusable assets would help another Claude instance execute these tasks more effectively.

--- a/plugins/soleur/skills/test-browser/SKILL.md
+++ b/plugins/soleur/skills/test-browser/SKILL.md
@@ -15,6 +15,8 @@ This skill uses the `agent-browser` CLI exclusively. The agent-browser CLI is a 
 
 If calling `mcp__claude-in-chrome__*` tools, STOP. Use `agent-browser` Bash commands instead.
 
+- When working in a worktree, always pass absolute paths to Playwright MCP screenshot tools -- relative filenames are resolved from the main repo root (the MCP server's CWD), so screenshots land in the main repo instead of the active worktree.
+
 ## Introduction
 
 <role>QA Engineer specializing in browser-based end-to-end testing</role>


### PR DESCRIPTION
## Summary

- `/soleur:sync` full codebase analysis: 16 new constitution rules added (shell scripting conventions, TypeScript style, CSS layer ordering, changelog format, filename patterns)
- 10 learning bullets routed to 8 definitions (skill-creator, test-browser, legal-document-generator, legal-compliance-auditor, security-sentinel, cmo, ship, infra-security)
- 7 learnings marked with `synced_to` frontmatter to prevent re-proposal on future runs
- 5 GitHub issues created for tech debt: #218 (missing marketplace.json), #219 (outdated model IDs), #220 (stale .claude/ paths), #221 (bundle ralph-loop), #222 (agent description voice)

## Test plan

- [ ] `bun test` passes (no source code changes, only markdown instruction updates)
- [ ] Verify constitution.md renders correctly with new rules
- [ ] Spot-check 2-3 definition files for bullet placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)