### PR TITLE
fix: use imperative voice in 3 agent descriptions (v2.23.14)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.23.13"
+      placeholder: "2.23.14"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.23.13-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.23.14-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/knowledge-base/learnings/2026-02-22-agent-description-voice-convention.md
+++ b/knowledge-base/learnings/2026-02-22-agent-description-voice-convention.md
@@ -1,0 +1,31 @@
+---
+title: Agent vs Skill description voice convention
+date: 2026-02-22
+category: conventions
+tags: [agents, skills, descriptions, voice]
+module: plugins/soleur
+---
+
+# Agent vs Skill Description Voice Convention
+
+## Convention
+
+- **Agents** use imperative form: `"Use this agent when..."`
+- **Skills** use third person: `"This skill should be used when..."`
+
+## Detection
+
+Run this to find non-compliant agent descriptions:
+
+```bash
+grep -rn '^description:' plugins/soleur/agents/ | grep -v 'Use this agent'
+```
+
+## Context
+
+Three agents were found using wrong voice forms during a `/soleur:sync` audit (2026-02-21). The patterns were:
+- "This agent should be used when..." (passive, belongs in skills)
+- "This agent performs..." (third person declarative)
+- "This agent analyzes..." (third person declarative)
+
+All three were corrected to "Use this agent when..." in #222.

--- a/knowledge-base/plans/2026-02-22-fix-agent-description-voice-plan.md
+++ b/knowledge-base/plans/2026-02-22-fix-agent-description-voice-plan.md
@@ -1,0 +1,39 @@
+# Plan: Fix Agent Description Voice (#222)
+
+**Date:** 2026-02-22
+**Issue:** #222 - Fix agent description voice: use imperative form for 3 agents
+**Type:** Bug fix (PATCH bump)
+
+## Problem
+
+Three agent descriptions use third-person phrasing instead of the required imperative form per AGENTS.md compliance checklist. Agent descriptions must use "Use this agent when..." format.
+
+## Changes
+
+### 1. `plugins/soleur/agents/engineering/discovery/functional-discovery.md` (line 3)
+
+**Before:** `"This agent should be used when running /plan to check whether..."`
+**After:** `"Use this agent when running /plan and the project uses a stack not covered by built-in agents. This agent queries external registries for community agents and skills matching the detected stack gap, presents trusted suggestions, and installs approved artifacts with provenance tracking. Use agent-finder for stack-gap detection; use this agent to find agents for a missing tech stack."`
+
+Wait -- re-reading the issue more carefully. The current description says "This agent should be used when running /plan to check whether community registries already have skills or agents with similar functionality to the feature being planned." The fix is simpler: just change "This agent should be used when" to "Use this agent when".
+
+**Before:** `"This agent should be used when running /plan to check..."`
+**After:** `"Use this agent when running /plan to check..."`
+
+### 2. `plugins/soleur/agents/marketing/growth-strategist.md` (line 3)
+
+**Before:** `"This agent performs content strategy analysis including keyword research..."`
+**After:** `"Use this agent when you need content strategy analysis including keyword research, content auditing for search intent alignment, content gap analysis, content planning, and GEO/AEO (Generative Engine Optimization / AI Engine Optimization) auditing at the content level. It complements the seo-aeo-analyst (which handles technical SEO correctness) by focusing on whether content matches what people actually search for."`
+
+### 3. `plugins/soleur/agents/marketing/seo-aeo-analyst.md` (line 3)
+
+**Before:** `"This agent analyzes Eleventy documentation sites for SEO and AEO..."`
+**After:** `"Use this agent when you need to analyze Eleventy documentation sites for SEO and AEO (AI Engine Optimization) opportunities. It audits structured data, meta tags, AI discoverability signals, and content quality, then produces actionable reports or generates fixes. Use growth-strategist for content strategy and keyword research; use programmatic-seo-specialist for scalable page generation; use this agent for technical SEO audits."`
+
+## Version Bump
+
+PATCH bump (bug fix). Update plugin.json, CHANGELOG.md, README.md.
+
+## Risk
+
+Zero. Text-only changes to YAML frontmatter description fields. No behavioral change.

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.23.13",
+  "version": "2.23.14",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 45 agents, 8 commands, and 45 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.23.14] - 2026-02-22
+
+### Fixed
+
+- Fix agent description voice: 3 agents now use imperative "Use this agent when..." form per AGENTS.md compliance
+
 ## [2.23.13] - 2026-02-21
 
 ### Changed

--- a/plugins/soleur/agents/engineering/discovery/functional-discovery.md
+++ b/plugins/soleur/agents/engineering/discovery/functional-discovery.md
@@ -1,6 +1,6 @@
 ---
 name: functional-discovery
-description: "This agent should be used when running /plan to check whether community registries already have skills or agents with similar functionality to the feature being planned. It queries external registries using the feature description, applies trust filtering, and presents install/skip suggestions to prevent redundant development. Use agent-finder for stack-gap detection; use this agent to check if a planned feature already exists in registries."
+description: "Use this agent when running /plan to check whether community registries already have skills or agents with similar functionality to the feature being planned. It queries external registries using the feature description, applies trust filtering, and presents install/skip suggestions to prevent redundant development. Use agent-finder for stack-gap detection; use this agent to check if a planned feature already exists in registries."
 model: inherit
 ---
 

--- a/plugins/soleur/agents/marketing/growth-strategist.md
+++ b/plugins/soleur/agents/marketing/growth-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: growth-strategist
-description: "This agent performs content strategy analysis including keyword research, content auditing for search intent alignment, content gap analysis, content planning, and GEO/AEO (Generative Engine Optimization / AI Engine Optimization) auditing at the content level. It complements the seo-aeo-analyst (which handles technical SEO correctness) by focusing on whether content matches what people actually search for."
+description: "Use this agent when you need content strategy analysis including keyword research, content auditing for search intent alignment, content gap analysis, content planning, and GEO/AEO (Generative Engine Optimization / AI Engine Optimization) auditing at the content level. It complements the seo-aeo-analyst (which handles technical SEO correctness) by focusing on whether content matches what people actually search for."
 model: inherit
 ---
 

--- a/plugins/soleur/agents/marketing/seo-aeo-analyst.md
+++ b/plugins/soleur/agents/marketing/seo-aeo-analyst.md
@@ -1,6 +1,6 @@
 ---
 name: seo-aeo-analyst
-description: "This agent analyzes Eleventy documentation sites for SEO and AEO (AI Engine Optimization) opportunities. It audits structured data, meta tags, AI discoverability signals, and content quality, then produces actionable reports or generates fixes. Use growth-strategist for content strategy and keyword research; use programmatic-seo-specialist for scalable page generation; use this agent for technical SEO audits."
+description: "Use this agent when you need to analyze Eleventy documentation sites for SEO and AEO (AI Engine Optimization) opportunities. It audits structured data, meta tags, AI discoverability signals, and content quality, then produces actionable reports or generates fixes. Use growth-strategist for content strategy and keyword research; use programmatic-seo-specialist for scalable page generation; use this agent for technical SEO audits."
 model: inherit
 ---
 


### PR DESCRIPTION
## Summary

- Fix 3 agent descriptions to use imperative "Use this agent when..." form per AGENTS.md compliance checklist
- Affected agents: `functional-discovery`, `growth-strategist`, `seo-aeo-analyst`
- PATCH version bump to 2.23.14

Closes #222

## Test plan

- [ ] Verify each agent description starts with "Use this agent when..."
- [ ] Verify no other agent descriptions regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)