### PR TITLE
fix(skills): remove non-existent marketplace.json references (v2.23.16)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.23.15"
+      placeholder: "2.23.16"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.23.15-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.23.16-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.23.15",
+  "version": "2.23.16",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 45 agents, 8 commands, and 45 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.23.16] - 2026-02-22
+
+### Fixed
+
+- Remove non-existent `marketplace.json` references from release-docs skill (#218)
+
 ## [2.23.15] - 2026-02-22
 
 ### Fixed

--- a/plugins/soleur/skills/release-docs/SKILL.md
+++ b/plugins/soleur/skills/release-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-docs
-description: This skill should be used when updating documentation metadata after adding or removing plugin components. It updates plugin.json description, marketplace.json, and README.md counts, then verifies the Eleventy build produces correct output. Triggers on "update docs", "release documentation", "sync docs site", "regenerate docs", "documentation release".
+description: This skill should be used when updating documentation metadata after adding or removing plugin components. It updates plugin.json description and README.md counts, then verifies the Eleventy build produces correct output. Triggers on "update docs", "release documentation", "sync docs site", "regenerate docs", "documentation release".
 ---
 
 # Release Documentation
@@ -18,7 +18,6 @@ The documentation site auto-generates agent and skill catalog pages from source 
 
 **What still needs manual updates:**
 - `plugins/soleur/.claude-plugin/plugin.json` description with counts
-- `.claude-plugin/marketplace.json` description with counts
 - `plugins/soleur/README.md` component tables and counts
 - `knowledge-base/overview/brand-guide.md` agent/skill counts (if it exists)
 
@@ -39,10 +38,7 @@ Ensure counts are consistent across:
 1. **`plugins/soleur/.claude-plugin/plugin.json`**
    - Update `description` with correct counts
 
-2. **`.claude-plugin/marketplace.json`**
-   - Update plugin `description` with correct counts
-
-3. **`plugins/soleur/README.md`**
+2. **`plugins/soleur/README.md`**
    - Update intro paragraph with counts
    - Update component lists and tables
 
@@ -84,7 +80,6 @@ Provide a summary of what was updated:
 
 ### Files Updated
 - plugin.json - Updated counts
-- marketplace.json - Updated description
 - README.md - Updated component lists
 - _data/skills.js - Updated category mapping (if applicable)
 ```


### PR DESCRIPTION
## Summary

- Remove 4 references to non-existent `.claude-plugin/marketplace.json` from `release-docs` SKILL.md
- The file never existed -- only `plugin.json` is in `.claude-plugin/`
- Agents following the skill would silently attempt to update a ghost file

Closes #218

## Files Changed

| File | Change |
|------|--------|
| `plugins/soleur/skills/release-docs/SKILL.md` | Removed marketplace.json from description, overview, step 2, and report template |
| `plugins/soleur/.claude-plugin/plugin.json` | Version bump 2.23.15 -> 2.23.16 |
| `plugins/soleur/CHANGELOG.md` | Added 2.23.16 entry |
| `README.md` | Updated version badge |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Updated version placeholder |

## Test plan

- [ ] Verify `release-docs` SKILL.md has no `marketplace.json` references
- [ ] Verify no other skills reference a local `marketplace.json`
- [ ] Verify version bump is consistent across all 5 locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)