### PR TITLE
fix: update outdated Claude 3 model IDs to Claude 4.x (v2.23.17)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.23.16"
+      placeholder: "2.23.17"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.23.16-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.23.17-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/knowledge-base/learnings/2026-02-22-model-id-update-patterns.md
+++ b/knowledge-base/learnings/2026-02-22-model-id-update-patterns.md
@@ -1,0 +1,57 @@
+---
+title: Model ID Update Patterns
+category: configuration-fixes
+tags: [model-ids, claude-api, find-and-replace, reference-files, verification]
+module: skills
+symptom: "Outdated Claude 3.x model IDs in reference files causing deprecation warnings"
+root_cause: "Model IDs hardcoded across multiple reference files without centralized constant"
+date: 2026-02-22
+---
+
+# Learning: Model ID Update Patterns
+
+## Problem
+
+Reference files across `plugins/soleur/skills/` contained outdated Claude 3/3.5 model IDs. Issue #219 listed 7 files, but the actual count was 9 -- two files were missed in the initial inventory.
+
+## Key Insights
+
+### 1. Issue inventories undercount -- always grep independently
+
+The issue listed 7 affected files. A full `grep -rn "claude-3" plugins/soleur/skills/` found 8 files (module-template.rb was missing). Post-edit verification found a 9th (skill-creator/references/official-spec.md had a stale Claude 4.0 ID). Never trust an issue's file list as exhaustive -- always run your own search.
+
+### 2. "Already updated" doesn't mean "up to date"
+
+Lines 238-239 of `agent-execution-patterns.md` used `claude-sonnet-4-20250514` and `claude-opus-4-20250514`, which appeared to be current Claude 4.x IDs. They were actually stale Claude 4.0 model IDs -- the latest are `claude-sonnet-4-6` and `claude-opus-4-6`. Always verify model IDs against the official docs at https://platform.claude.com/docs/en/about-claude/models/overview.
+
+### 3. replace_all is prefix-sensitive
+
+Using `replace_all` for `anthropic/claude-3-5-sonnet-20241022` caught all instances with the `anthropic/` prefix but missed line 309 in config-template.rb which used `model: 'claude-3-5-sonnet-20241022'` (no provider prefix). Always run a post-edit grep to catch variant formats.
+
+### 4. Current Claude model IDs (Feb 2026)
+
+| Tier | API Alias | Dated ID | Pricing |
+|------|-----------|----------|---------|
+| Opus 4.6 | `claude-opus-4-6` | `claude-opus-4-6` | $5/1M input, $25/1M output |
+| Sonnet 4.6 | `claude-sonnet-4-6` | `claude-sonnet-4-6` | $3/1M input, $15/1M output |
+| Haiku 4.5 | `claude-haiku-4-5` | `claude-haiku-4-5-20251001` | $1/1M input, $5/1M output |
+
+## Solution
+
+1. Run `grep -rn "claude-3" plugins/soleur/skills/` to find ALL occurrences
+2. Verify target IDs against official Anthropic model docs
+3. Edit each file, using `replace_all` where same string appears multiple times
+4. Run post-edit grep for BOTH old patterns AND variant formats
+5. Fix any stragglers caught by verification
+
+## Prevention
+
+- When updating hardcoded values across a codebase, never trust a pre-compiled list -- always search independently
+- Post-edit verification grep is mandatory, not optional
+- Check for variant formats of the same string (with/without prefix, in comments vs code)
+
+## Session Errors
+
+1. `git pull` failed due to missing pull strategy -- use `git fetch + reset` instead
+2. Initial plan used stale 4.0 IDs as targets -- caught by verifying against official docs during deepen-plan
+3. `replace_all` missed one occurrence due to different prefix format -- caught by post-edit grep

--- a/knowledge-base/plans/2026-02-22-fix-update-outdated-model-ids-plan.md
+++ b/knowledge-base/plans/2026-02-22-fix-update-outdated-model-ids-plan.md
@@ -1,0 +1,136 @@
+---
+title: Update outdated Claude 3 model IDs to Claude 4.x
+type: fix
+date: 2026-02-22
+issue: "#219"
+---
+
+# Update Outdated Claude 3 Model IDs to Claude 4.x
+
+## Overview
+
+Multiple reference files contain hardcoded Claude 3/3.5 model IDs that are now outdated. Users copying code examples get deprecation warnings or failures. Update all 8 affected files (~32 references) to current Claude 4.x identifiers.
+
+## Acceptance Criteria
+
+- [ ] Zero occurrences of `claude-3-haiku-20240307`, `claude-3-sonnet-20240229`, `claude-3-opus-20240229`, `claude-3-5-sonnet-20241022` remain in the codebase
+- [ ] Zero occurrences of shorthand `claude-3-haiku`, `claude-3-sonnet`, `claude-3-opus`, `claude-3-5-sonnet`, `claude-3.5-sonnet` remain
+- [ ] All replacements use correct current model IDs
+- [ ] Stale pricing comments updated where present
+- [ ] Stale Claude 4.0 IDs (`claude-sonnet-4-20250514`, `claude-opus-4-20250514`) on lines 238-239 of `agent-execution-patterns.md` updated to latest 4.6
+
+## Research Enhancement (2026-02-22)
+
+Verified model IDs against official Anthropic documentation at https://platform.claude.com/docs/en/about-claude/models/overview
+
+**Key correction:** Lines 238-239 of `agent-execution-patterns.md` were flagged as "already updated" but use old Claude 4.0 IDs (`claude-sonnet-4-20250514`, `claude-opus-4-20250514`). These must also be updated to the latest 4.6 aliases.
+
+## Test Scenarios
+
+- Given a full `grep -r "claude-3"` across the repo, when run after changes, then zero matches in `plugins/soleur/skills/` directories
+- Given a full `grep -r "claude-.*-4-20250514"` across the repo, when run after changes, then zero matches (old 4.0 IDs removed)
+
+## Model ID Mapping
+
+Source: https://platform.claude.com/docs/en/about-claude/models/overview
+
+### Code examples (where exact model ID is used in API calls)
+
+Use the latest model aliases. These are the current production IDs.
+
+| Old ID | New ID (latest alias) |
+|--------|--------|
+| `claude-3-haiku-20240307` | `claude-haiku-4-5` |
+| `claude-3-sonnet-20240229` | `claude-sonnet-4-6` |
+| `claude-3-opus-20240229` | `claude-opus-4-6` |
+| `claude-3-5-sonnet-20241022` | `claude-sonnet-4-6` |
+| `claude-sonnet-4-20250514` | `claude-sonnet-4-6` |
+| `claude-opus-4-20250514` | `claude-opus-4-6` |
+| `claude-3.5-sonnet` (OpenRouter format) | `claude-sonnet-4-6` |
+
+### Comments and descriptive text (use generic tier names)
+
+| Old Reference | New Reference |
+|---------------|---------------|
+| `claude-3-haiku: Quick, cheap...` | `claude-haiku-4-5: Quick, cheap...` |
+| `claude-3-sonnet: Good balance...` | `claude-sonnet-4-6: Good balance...` |
+| `claude-3-opus: Complex reasoning...` | `claude-opus-4-6: Complex reasoning...` |
+| `claude-3-5-sonnet` (in prose) | `claude-sonnet-4-6` |
+
+### Pricing updates (where pricing is mentioned)
+
+| Tier | Old Price | Current Price (Feb 2026) |
+|------|-----------|---------------|
+| Fast (Haiku 4.5) | ~$0.25/1M tokens | $1/1M input, $5/1M output |
+| Balanced (Sonnet 4.6) | ~$3/1M tokens | $3/1M input, $15/1M output |
+| Powerful (Opus 4.6) | ~$15/1M tokens | $5/1M input, $25/1M output |
+
+## MVP
+
+### File-by-file changes
+
+#### 1. `plugins/soleur/skills/agent-native-architecture/references/agent-execution-patterns.md`
+
+- Line 231: `claude-3-haiku` -> `claude-haiku-4-5` (comment)
+- Line 237: `claude-3-haiku-20240307` -> `claude-haiku-4-5` (code)
+- Line 238: `claude-sonnet-4-20250514` -> `claude-sonnet-4-6` (stale 4.0 ID)
+- Line 239: `claude-opus-4-20250514` -> `claude-opus-4-6` (stale 4.0 ID)
+
+#### 2. `plugins/soleur/skills/agent-native-architecture/references/mobile-patterns.md`
+
+- Lines 465-467: Update all three tier comments to 4.x names and pricing
+- Lines 471-473: Update all three `return` string values to 4.x dated IDs
+
+#### 3. `plugins/soleur/skills/agent-native-architecture/references/agent-native-testing.md`
+
+- Line 487: `claude-3-haiku` -> `claude-haiku-4-5`, `claude-3-opus` -> `claude-opus-4-6`
+- Line 518: `claude-3-haiku` -> `claude-haiku-4-5`
+
+#### 4. `plugins/soleur/skills/agent-native-architecture/references/architecture-patterns.md`
+
+- Lines 426-428: Update three tier comment references to 4.x names
+
+#### 5. `plugins/soleur/skills/dspy-ruby/SKILL.md`
+
+- Line 164: `claude-3-5-sonnet-20241022` -> `claude-sonnet-4-6`
+- Lines 200-201: Update model names in prose list
+
+#### 6. `plugins/soleur/skills/dspy-ruby/references/providers.md`
+
+- Lines 53, 57, 61, 65: Update all four Anthropic `DSPy::LM.new` calls
+- Line 115: Update OpenRouter Anthropic reference
+- Line 183: Update powerful_lm reference
+- Lines 225, 227: Update prose model name references
+- Line 245: Update config example
+
+#### 7. `plugins/soleur/skills/dspy-ruby/assets/config-template.rb`
+
+- Lines 24, 42, 66, 99, 219: Update all `DSPy::LM.new` Anthropic model IDs
+- Line 309: Update comment model reference
+
+#### 8. `plugins/soleur/skills/dspy-ruby/assets/module-template.rb`
+
+- Line 230: Update Anthropic model ID
+
+## Verification
+
+After all changes:
+
+```bash
+# Must return zero results in plugins/soleur/skills/
+grep -rn "claude-3" plugins/soleur/skills/ | grep -v "claude-3\." | head -20
+grep -rn "claude-3-" plugins/soleur/skills/
+grep -rn "claude-3\." plugins/soleur/skills/
+
+# Verify correct new IDs are present
+grep -rn "claude-haiku-4-5" plugins/soleur/skills/
+grep -rn "claude-sonnet-4" plugins/soleur/skills/
+grep -rn "claude-opus-4" plugins/soleur/skills/
+```
+
+## References
+
+- Issue: #219
+- Existing 4.x convention: `apps/telegram-bridge/` uses `claude-opus-4-6`
+- Official model docs: https://platform.claude.com/docs/en/about-claude/models/overview
+- Lines 238-239 of `agent-execution-patterns.md` had stale Claude 4.0 IDs -- updated to 4.6

--- a/knowledge-base/specs/feat-update-model-ids/tasks.md
+++ b/knowledge-base/specs/feat-update-model-ids/tasks.md
@@ -1,0 +1,27 @@
+---
+title: Update Outdated Model IDs - Tasks
+feature: feat-update-model-ids
+date: 2026-02-22
+---
+
+# Tasks
+
+## Phase 1: Agent-Native Architecture References
+
+- [ ] 1.1 Update `agent-execution-patterns.md` (2 changes: line 231 comment, line 237 code)
+- [ ] 1.2 Update `mobile-patterns.md` (6 changes: 3 comments + pricing, 3 return values)
+- [ ] 1.3 Update `agent-native-testing.md` (2 changes: lines 487, 518)
+- [ ] 1.4 Update `architecture-patterns.md` (3 changes: comment-only tier names)
+
+## Phase 2: DSPy Ruby References
+
+- [ ] 2.1 Update `SKILL.md` (3 changes: code example + prose references)
+- [ ] 2.2 Update `references/providers.md` (9 changes: code examples + prose)
+- [ ] 2.3 Update `assets/config-template.rb` (6 changes: all LM.new calls + comment)
+- [ ] 2.4 Update `assets/module-template.rb` (1 change: model ID)
+
+## Phase 3: Verification
+
+- [ ] 3.1 Run grep verification: zero `claude-3` references remain in `plugins/soleur/skills/`
+- [ ] 3.2 Run grep verification: correct 4.x IDs are present
+- [ ] 3.3 Version bump (patch) for plugin.json, CHANGELOG.md, README.md

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.23.16",
+  "version": "2.23.17",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 45 agents, 8 commands, and 45 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.23.17] - 2026-02-22
+
+### Fixed
+
+- Update outdated Claude 3/3.5 model IDs to Claude 4.x across 9 reference files (#219)
+- Update stale Claude 4.0 IDs (`claude-sonnet-4-20250514`, `claude-opus-4-20250514`) to latest 4.6 aliases
+- Update stale pricing comments to current Feb 2026 rates
+
 ## [2.23.16] - 2026-02-22
 
 ### Fixed

--- a/plugins/soleur/skills/agent-native-architecture/references/agent-execution-patterns.md
+++ b/plugins/soleur/skills/agent-native-architecture/references/agent-execution-patterns.md
@@ -228,15 +228,15 @@ Different agents need different intelligence levels. Use the cheapest model that
 
 ```swift
 enum ModelTier {
-    case fast      // claude-3-haiku: Quick, cheap, simple tasks
-    case balanced  // claude-sonnet: Good balance for most tasks
-    case powerful  // claude-opus: Complex reasoning, synthesis
+    case fast      // claude-haiku-4-5: Quick, cheap, simple tasks
+    case balanced  // claude-sonnet-4-6: Good balance for most tasks
+    case powerful  // claude-opus-4-6: Complex reasoning, synthesis
 
     var modelId: String {
         switch self {
-        case .fast: return "claude-3-haiku-20240307"
-        case .balanced: return "claude-sonnet-4-20250514"
-        case .powerful: return "claude-opus-4-20250514"
+        case .fast: return "claude-haiku-4-5"
+        case .balanced: return "claude-sonnet-4-6"
+        case .powerful: return "claude-opus-4-6"
         }
     }
 }

--- a/plugins/soleur/skills/agent-native-architecture/references/agent-native-testing.md
+++ b/plugins/soleur/skills/agent-native-architecture/references/agent-native-testing.md
@@ -484,7 +484,7 @@ Agent tests cost API tokens. Strategies to manage:
 ```typescript
 // Use smaller models for basic tests
 const testConfig = {
-  model: process.env.CI ? "claude-3-haiku" : "claude-3-opus",
+  model: process.env.CI ? "claude-haiku-4-5" : "claude-opus-4-6",
   maxTokens: 500,  // Limit output length
 };
 
@@ -515,7 +515,7 @@ class AgentTestHarness {
     this.mockServices = createMockServices();
     this.agent = await createAgent({
       services: this.mockServices,
-      model: "claude-3-haiku",  // Cheaper for tests
+      model: "claude-haiku-4-5",  // Cheaper for tests
     });
   }
 

--- a/plugins/soleur/skills/agent-native-architecture/references/architecture-patterns.md
+++ b/plugins/soleur/skills/agent-native-architecture/references/architecture-patterns.md
@@ -423,9 +423,9 @@ Different agents need different intelligence levels. Use the cheapest model that
 
 ```swift
 enum ModelTier {
-    case fast      // claude-3-haiku: Quick, cheap, simple tasks
-    case balanced  // claude-3-sonnet: Good balance for most tasks
-    case powerful  // claude-3-opus: Complex reasoning, synthesis
+    case fast      // claude-haiku-4-5: Quick, cheap, simple tasks
+    case balanced  // claude-sonnet-4-6: Good balance for most tasks
+    case powerful  // claude-opus-4-6: Complex reasoning, synthesis
 }
 
 struct AgentConfig {

--- a/plugins/soleur/skills/agent-native-architecture/references/mobile-patterns.md
+++ b/plugins/soleur/skills/agent-native-architecture/references/mobile-patterns.md
@@ -462,15 +462,15 @@ Use the cheapest model that achieves the outcome:
 
 ```swift
 enum ModelTier {
-    case fast      // claude-3-haiku: ~$0.25/1M tokens
-    case balanced  // claude-3-sonnet: ~$3/1M tokens
-    case powerful  // claude-3-opus: ~$15/1M tokens
+    case fast      // claude-haiku-4-5: ~$1/1M input, $5/1M output
+    case balanced  // claude-sonnet-4-6: ~$3/1M input, $15/1M output
+    case powerful  // claude-opus-4-6: ~$5/1M input, $25/1M output
 
     var modelId: String {
         switch self {
-        case .fast: return "claude-3-haiku-20240307"
-        case .balanced: return "claude-3-sonnet-20240229"
-        case .powerful: return "claude-3-opus-20240229"
+        case .fast: return "claude-haiku-4-5"
+        case .balanced: return "claude-sonnet-4-6"
+        case .powerful: return "claude-opus-4-6"
         }
     }
 }

--- a/plugins/soleur/skills/dspy-ruby/SKILL.md
+++ b/plugins/soleur/skills/dspy-ruby/SKILL.md
@@ -161,7 +161,7 @@ end
 
 # Anthropic Claude
 DSPy.configure do |c|
-  c.lm = DSPy::LM.new('anthropic/claude-3-5-sonnet-20241022',
+  c.lm = DSPy::LM.new('anthropic/claude-sonnet-4-6',
     api_key: ENV['ANTHROPIC_API_KEY'])
 end
 
@@ -197,8 +197,8 @@ end
 **Cost optimization strategy**:
 - Development: Ollama (free) or gpt-4o-mini (cheap)
 - Testing: gpt-4o-mini with temperature=0.0
-- Production simple tasks: gpt-4o-mini, claude-3-haiku, gemini-1.5-flash
-- Production complex tasks: gpt-4o, claude-3-5-sonnet, gemini-1.5-pro
+- Production simple tasks: gpt-4o-mini, claude-haiku-4-5, gemini-1.5-flash
+- Production complex tasks: gpt-4o, claude-sonnet-4-6, gemini-1.5-pro
 
 **Full documentation**: See [providers.md](./references/providers.md) for all configuration options, provider-specific features, and troubleshooting.
 

--- a/plugins/soleur/skills/dspy-ruby/assets/config-template.rb
+++ b/plugins/soleur/skills/dspy-ruby/assets/config-template.rb
@@ -21,7 +21,7 @@ end
 
 # Anthropic Claude
 DSPy.configure do |c|
-  c.lm = DSPy::LM.new('anthropic/claude-3-5-sonnet-20241022',
+  c.lm = DSPy::LM.new('anthropic/claude-sonnet-4-6',
     api_key: ENV['ANTHROPIC_API_KEY'])
 end
 
@@ -39,7 +39,7 @@ end
 
 # OpenRouter (access to 200+ models)
 DSPy.configure do |c|
-  c.lm = DSPy::LM.new('openrouter/anthropic/claude-3.5-sonnet',
+  c.lm = DSPy::LM.new('openrouter/anthropic/claude-sonnet-4-6',
     api_key: ENV['OPENROUTER_API_KEY'],
     base_url: 'https://openrouter.ai/api/v1')
 end
@@ -63,7 +63,7 @@ elsif Rails.env.test?
 else
   # Use powerful model for production
   DSPy.configure do |c|
-    c.lm = DSPy::LM.new('anthropic/claude-3-5-sonnet-20241022',
+    c.lm = DSPy::LM.new('anthropic/claude-sonnet-4-6',
       api_key: ENV['ANTHROPIC_API_KEY'])
   end
 end
@@ -96,7 +96,7 @@ module MyApp
   )
 
   # Powerful model for complex tasks
-  POWERFUL_LM = DSPy::LM.new('anthropic/claude-3-5-sonnet-20241022',
+  POWERFUL_LM = DSPy::LM.new('anthropic/claude-sonnet-4-6',
     api_key: ENV['ANTHROPIC_API_KEY'],
     temperature: 0.7
   )
@@ -216,7 +216,7 @@ class FallbackConfig
   end
 
   def self.create_lm_with_fallback
-    primary = DSPy::LM.new('anthropic/claude-3-5-sonnet-20241022',
+    primary = DSPy::LM.new('anthropic/claude-sonnet-4-6',
       api_key: ENV['ANTHROPIC_API_KEY'])
 
     fallback = DSPy::LM.new('openai/gpt-4o',
@@ -306,7 +306,7 @@ BudgetTrackedConfig.configure(monthly_budget_usd: 100)
 #   when :test
 #     { provider: 'openai', model: 'gpt-4o-mini', temperature: 0.0 }
 #   when :production
-#     { provider: 'anthropic', model: 'claude-3-5-sonnet-20241022' }
+#     { provider: 'anthropic', model: 'claude-sonnet-4-6' }
 #   end
 #
 #   # Configure language model

--- a/plugins/soleur/skills/dspy-ruby/assets/module-template.rb
+++ b/plugins/soleur/skills/dspy-ruby/assets/module-template.rb
@@ -227,7 +227,7 @@ class MultiModelModule < DSPy::Module
 
     # Powerful model for complex analysis
     @powerful_predictor = create_predictor(
-      'anthropic/claude-3-5-sonnet-20241022',
+      'anthropic/claude-sonnet-4-6',
       ComplexAnalysisSignature
     )
   end

--- a/plugins/soleur/skills/dspy-ruby/references/providers.md
+++ b/plugins/soleur/skills/dspy-ruby/references/providers.md
@@ -7,7 +7,7 @@ DSPy.rb provides unified support across multiple LLM providers through adapter g
 ### Provider Overview
 
 - **OpenAI**: GPT-4, GPT-4o, GPT-4o-mini, GPT-3.5-turbo
-- **Anthropic**: Claude 3 family (Sonnet, Opus, Haiku), Claude 3.5 Sonnet
+- **Anthropic**: Claude 4.x family (Opus 4.6, Sonnet 4.6, Haiku 4.5)
 - **Google Gemini**: Gemini 1.5 Pro, Gemini 1.5 Flash, other versions
 - **Ollama**: Local model support via OpenAI compatibility layer
 - **OpenRouter**: Unified multi-provider API for 200+ models
@@ -49,20 +49,16 @@ end
 
 ```ruby
 DSPy.configure do |c|
-  # Claude 3.5 Sonnet (latest, most capable)
-  c.lm = DSPy::LM.new('anthropic/claude-3-5-sonnet-20241022',
+  # Claude Opus 4.6 (most intelligent, best for agents and coding)
+  c.lm = DSPy::LM.new('anthropic/claude-opus-4-6',
     api_key: ENV['ANTHROPIC_API_KEY'])
 
-  # Claude 3 Opus (most capable in Claude 3 family)
-  c.lm = DSPy::LM.new('anthropic/claude-3-opus-20240229',
+  # Claude Sonnet 4.6 (best speed/intelligence balance)
+  c.lm = DSPy::LM.new('anthropic/claude-sonnet-4-6',
     api_key: ENV['ANTHROPIC_API_KEY'])
 
-  # Claude 3 Sonnet (balanced)
-  c.lm = DSPy::LM.new('anthropic/claude-3-sonnet-20240229',
-    api_key: ENV['ANTHROPIC_API_KEY'])
-
-  # Claude 3 Haiku (fast, cost-effective)
-  c.lm = DSPy::LM.new('anthropic/claude-3-haiku-20240307',
+  # Claude Haiku 4.5 (fastest, cost-effective)
+  c.lm = DSPy::LM.new('anthropic/claude-haiku-4-5',
     api_key: ENV['ANTHROPIC_API_KEY'])
 end
 ```
@@ -112,7 +108,7 @@ end
 ```ruby
 DSPy.configure do |c|
   # Access 200+ models through OpenRouter
-  c.lm = DSPy::LM.new('openrouter/anthropic/claude-3.5-sonnet',
+  c.lm = DSPy::LM.new('openrouter/anthropic/claude-sonnet-4-6',
     api_key: ENV['OPENROUTER_API_KEY'],
     base_url: 'https://openrouter.ai/api/v1')
 
@@ -180,7 +176,7 @@ Use different models for different tasks:
 fast_lm = DSPy::LM.new('openai/gpt-4o-mini', api_key: ENV['OPENAI_API_KEY'])
 
 # Powerful model for complex tasks
-powerful_lm = DSPy::LM.new('anthropic/claude-3-5-sonnet-20241022',
+powerful_lm = DSPy::LM.new('anthropic/claude-sonnet-4-6',
   api_key: ENV['ANTHROPIC_API_KEY'])
 
 # Use different models in different modules
@@ -222,9 +218,9 @@ result2 = predictor.forward(
 
 ### Model Selection Strategy
 
-1. **Development**: Use cheaper, faster models (gpt-4o-mini, claude-3-haiku, gemini-1.5-flash)
+1. **Development**: Use cheaper, faster models (gpt-4o-mini, claude-haiku-4-5, gemini-1.5-flash)
 2. **Production Simple Tasks**: Continue with cheaper models if quality is sufficient
-3. **Production Complex Tasks**: Upgrade to more capable models (gpt-4o, claude-3.5-sonnet, gemini-1.5-pro)
+3. **Production Complex Tasks**: Upgrade to more capable models (gpt-4o, claude-sonnet-4-6, gemini-1.5-pro)
 4. **Local Development**: Use Ollama for privacy and zero API costs
 
 ### Example Cost-Conscious Setup
@@ -242,7 +238,7 @@ elsif Rails.env.test?
   end
 else  # production
   DSPy.configure do |c|
-    c.lm = DSPy::LM.new('anthropic/claude-3-5-sonnet-20241022',
+    c.lm = DSPy::LM.new('anthropic/claude-sonnet-4-6',
       api_key: ENV['ANTHROPIC_API_KEY'])
   end
 end
@@ -259,7 +255,8 @@ end
 
 ### Anthropic
 
-- Claude 3.5 Sonnet is currently the most capable model
+- Claude Sonnet 4.6 offers the best speed/intelligence balance
+- Claude Opus 4.6 is the most intelligent for agents and coding
 - Excellent for complex reasoning and analysis
 - Strong safety features and helpful outputs
 - Requires base64 for images (no URL support)

--- a/plugins/soleur/skills/skill-creator/references/official-spec.md
+++ b/plugins/soleur/skills/skill-creator/references/official-spec.md
@@ -30,7 +30,7 @@ Show concrete examples of using this Skill.
 | `name` | Yes | Skill name using lowercase letters, numbers, and hyphens only (max 64 characters). Should match the directory name. |
 | `description` | Yes | What the Skill does and when to use it (max 1024 characters). Claude uses this to decide when to apply the Skill. |
 | `allowed-tools` | No | Tools Claude can use without asking permission when this Skill is active. Example: `Read, Grep, Glob` |
-| `model` | No | Specific model to use when this Skill is active (e.g., `claude-sonnet-4-20250514`). Defaults to the conversation's model. |
+| `model` | No | Specific model to use when this Skill is active (e.g., `claude-sonnet-4-6`). Defaults to the conversation's model. |
 
 ## Skill Locations & Priority
 


### PR DESCRIPTION
## Summary

- Update ~35 outdated Claude 3/3.5 model ID references across 9 files to current Claude 4.x identifiers
- Also update stale Claude 4.0 IDs (`claude-sonnet-4-20250514`, `claude-opus-4-20250514`) to latest 4.6 aliases
- Update stale pricing comments to current Feb 2026 rates
- Verified all IDs against official Anthropic model docs

Closes #219

## Changes

| Old ID | New ID |
|--------|--------|
| `claude-3-haiku-20240307` | `claude-haiku-4-5` |
| `claude-3-sonnet-20240229` | `claude-sonnet-4-6` |
| `claude-3-opus-20240229` | `claude-opus-4-6` |
| `claude-3-5-sonnet-20241022` | `claude-sonnet-4-6` |
| `claude-sonnet-4-20250514` | `claude-sonnet-4-6` |
| `claude-opus-4-20250514` | `claude-opus-4-6` |

## Files Changed

- `agent-native-architecture/references/agent-execution-patterns.md`
- `agent-native-architecture/references/mobile-patterns.md`
- `agent-native-architecture/references/agent-native-testing.md`
- `agent-native-architecture/references/architecture-patterns.md`
- `dspy-ruby/SKILL.md`
- `dspy-ruby/references/providers.md`
- `dspy-ruby/assets/config-template.rb`
- `dspy-ruby/assets/module-template.rb`
- `skill-creator/references/official-spec.md` (bonus -- had stale 4.0 ID)

## Test plan

- [x] `grep -rn "claude-3[-.]" plugins/soleur/skills/` returns zero matches
- [x] `grep -rn "claude-.*-4-20250514" plugins/soleur/skills/` returns zero matches
- [x] All new IDs verified against https://platform.claude.com/docs/en/about-claude/models/overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)