### PR TITLE
feat: add ops-provisioner agent for guided SaaS tool setup (v2.25.0)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.24.0"
+      placeholder: "2.25.0"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.24.0-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.25.0-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)
 
 ## What is Soleur?
 
-Soleur gives a single founder the leverage of a full organization. **45 agents**, **8 commands**, and **45 skills** that compound your company knowledge over time -- every problem you solve makes the next one easier.
+Soleur gives a single founder the leverage of a full organization. **46 agents**, **8 commands**, and **45 skills** that compound your company knowledge over time -- every problem you solve makes the next one easier.
 
 ## Installation
 

--- a/knowledge-base/brainstorms/2026-02-22-ops-provisioner-brainstorm.md
+++ b/knowledge-base/brainstorms/2026-02-22-ops-provisioner-brainstorm.md
@@ -1,0 +1,65 @@
+# Brainstorm: Operations Provisioner Agent
+
+**Date:** 2026-02-22
+**Status:** Active
+**Related:** #212 (Plausible Analytics setup)
+
+## What We're Building
+
+A generic operations agent (`ops-provisioner`) that guides users through SaaS account setup and plan purchase for any tool. It uses agent-browser to navigate signup flows, fills non-sensitive fields, pauses for manual payment, then resumes for configuration and verification.
+
+This fills the gap between "we decided to use tool X" (ops-research) and "tool X is tracked in expenses" (ops-advisor). Currently this middle step -- signup, payment, initial config, verification -- is fully manual.
+
+## Why This Approach
+
+**Pure generic agent over tool-specific recipes or scripts because:**
+
+- Agent-browser snapshots let the agent adapt to any signup page dynamically
+- No per-tool maintenance burden (unlike Discord setup's bash script approach)
+- Aligns with the ops-research pattern of browser navigation with safety gates
+- First use case (Plausible) is simple enough to validate the generic approach
+
+**Post-decision scope only:**
+
+- Tool evaluation belongs to ops-research (already handles it)
+- This agent assumes the tool is already chosen
+- Keeps the agent focused: setup + configure + verify + record
+
+## Key Decisions
+
+1. **Agent type:** New operations agent at `agents/operations/ops-provisioner.md` (not a skill, not extending existing agents)
+2. **Payment boundary:** Agent fills non-sensitive signup fields (email, org name, plan selection) using agent-browser. Stops at payment fields. User completes payment manually.
+3. **Verification:** Browser screenshot of dashboard + integration test (e.g., visit site, check analytics dashboard shows the hit). No API verification required.
+4. **Expense recording:** After setup is verified, invoke ops-advisor to record the expense in `knowledge-base/ops/expenses.md`.
+5. **No tool-specific recipes:** Agent relies entirely on agent-browser snapshots to navigate any signup flow.
+
+## 5-Phase Workflow
+
+| Phase | Name | Description |
+|-------|------|-------------|
+| 1 | Context | Read tool name + purpose from user. Check expenses.md for duplicates. Gather signup URL. |
+| 2 | Navigate | Open signup page with agent-browser. Fill non-sensitive fields. Select plan. Stop at payment. |
+| 3 | Pause | Announce "Complete payment manually." Wait for user confirmation that payment is done. |
+| 4 | Configure | Resume in tool dashboard. Guide through initial config using agent-browser (add site, copy snippet, set options). Update codebase if needed (e.g., update script tag). |
+| 5 | Verify + Record | Browser screenshot of working dashboard. Integration test if applicable. Invoke ops-advisor to record expense. |
+
+## Existing Patterns to Follow
+
+- **Discord setup wizard** (community skill): 4-phase guided flow with manual steps between automated ones
+- **ops-research agent**: Browser navigation with safety gates (never clicks purchase buttons)
+- **infra-security agent**: Cloudflare API verification after setup
+- **GitHub Pages wiring workflow** (learnings): 10-step autonomous sequence with verification polling
+
+## Safety Constraints
+
+- Never enter credentials, passwords, or payment information
+- Never click purchase/payment/submit-order buttons
+- All sensitive fields are left for the user
+- Token/API key handling follows existing patterns (env vars, not CLI args)
+- Screenshot dashboard state as proof of setup
+
+## Resolved Questions
+
+- **Code changes during Configure phase?** Yes. Agent reads the tool's setup instructions and makes corresponding code changes (update script tags, add env vars, etc.).
+- **Email verification loops?** Pause and wait, same pattern as the payment pause. Agent says "Check your email and verify, then tell me when done."
+- **Dry run mode?** Not in v1. Keep it simple.

--- a/knowledge-base/learnings/2026-02-22-three-way-agent-disambiguation.md
+++ b/knowledge-base/learnings/2026-02-22-three-way-agent-disambiguation.md
@@ -1,0 +1,23 @@
+# Learning: Three-way agent disambiguation when adding a third domain agent
+
+## Problem
+
+When adding a third agent (`ops-provisioner`) to an existing two-agent domain (`ops-research` + `ops-advisor`), the plan initially only included disambiguation in the new agent's description. The Kieran reviewer caught that both existing sibling descriptions needed updating too -- they only referenced each other, not the new agent.
+
+## Solution
+
+When adding agent N to a domain with N-1 existing agents, update ALL N agent descriptions to cross-reference each other. For ops-provisioner:
+
+- `ops-provisioner` disambiguates against `ops-research` and `ops-advisor`
+- `ops-research` disambiguates against `ops-advisor` and `ops-provisioner` (updated)
+- `ops-advisor` disambiguates against `ops-research` and `ops-provisioner` (updated)
+
+## Key Insight
+
+Disambiguation is a graph property, not a node property. Adding one node requires updating all edges. The constitution rule ("agents with overlapping scope must include disambiguation") applies to siblings, not just the new agent. Plan reviewers (especially convention-focused ones like Kieran) reliably catch this.
+
+## Tags
+
+category: integration-issues
+module: agents/operations
+symptoms: routing accuracy degrades, tasks sent to wrong agent

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -62,7 +62,7 @@ Project principles organized by domain. Add principles as you learn them.
 - Plans that create worktrees and invoke Task agents must include explicit `cd ${WORKTREE_PATH}` + `pwd` verification between worktree creation and agent invocation
 - When adding or integrating new agents, verify the cumulative agent description token count stays under 15k tokens -- agent descriptions are injected into the system prompt on every turn and bloated descriptions degrade all conversations
 - Before adding new GitHub Actions workflows, audit existing ones with `gh run list --workflow=<name>.yml` -- remove workflows that are always skipped (condition never matches) or superseded by newer workflows that absorbed their functionality
-- Agent descriptions for agents with overlapping scope must include a one-line disambiguation sentence: "Use [sibling] for [its scope]; use this agent for [this scope]."
+- Agent descriptions for agents with overlapping scope must include a one-line disambiguation sentence: "Use [sibling] for [its scope]; use this agent for [this scope]." When adding a new agent to a domain, update ALL existing sibling descriptions to cross-reference the new agent -- disambiguation is a graph property, not just a property of the new node
 - The project uses Bun as the JavaScript runtime with ESM modules (`"type": "module"`); pre-commit hooks are managed by lefthook (not Husky)
 
 ### Never

--- a/knowledge-base/plans/2026-02-22-feat-ops-provisioner-agent-plan.md
+++ b/knowledge-base/plans/2026-02-22-feat-ops-provisioner-agent-plan.md
@@ -1,0 +1,99 @@
+---
+title: "feat: Add ops-provisioner agent for guided SaaS tool setup"
+type: feat
+date: 2026-02-22
+---
+
+# feat: Add ops-provisioner agent for guided SaaS tool setup
+
+## Overview
+
+Add a new `ops-provisioner` agent to `agents/operations/` that guides users through SaaS account signup, payment, initial configuration, verification, and expense recording. This fills the gap between ops-research (tool evaluation) and ops-advisor (expense tracking).
+
+## Problem Statement
+
+After choosing a SaaS tool via ops-research, the actual account creation, plan purchase, initial configuration, and verification are fully manual. Issue #212 (Plausible Analytics) is a concrete example: the evaluation is done, legal docs are updated, but no account exists.
+
+## Proposed Solution
+
+A single agent file at `plugins/soleur/agents/operations/ops-provisioner.md` with a guided workflow using agent-browser to navigate signup flows generically (no per-tool recipes). Three sections: Setup, Configure, Verify + Record.
+
+## Non-goals
+
+- Per-tool signup recipes (the agent is generic -- no recipes directory)
+- Automated payment (always manual -- agent never enters credentials or clicks purchase buttons)
+- Tool evaluation or comparison (handled by ops-research)
+- SSO/SAML/enterprise configuration
+- Ongoing tool administration
+
+## Technical Considerations
+
+- **agent-browser dependency:** Check availability, degrade gracefully to URLs + manual instructions (one-liner, same as ops-research)
+- **Safety model:** Follows ops-research precedent -- never enters credentials, never clicks payment buttons
+- **ops-advisor integration:** After verification, invoke ops-advisor via Task tool to record the expense
+- **Pause pattern:** One general rule for any user action outside the browser (payment, email verification, MFA): pause and ask the user to complete it
+
+## Acceptance Criteria
+
+- [x] Agent file exists at `plugins/soleur/agents/operations/ops-provisioner.md`
+- [x] YAML frontmatter: name, description (with disambiguation against both siblings), model
+- [x] Body uses topical sections (Setup, Configure, Verify + Record) matching sibling style
+- [x] Safety rules: never enters credentials, never clicks payment buttons
+- [x] Invokes ops-advisor to record expense after setup
+- [x] Sibling agents updated with disambiguation mentioning ops-provisioner
+- [x] Version bump: MINOR (new agent)
+
+## Rollback
+
+Revert the commit. The agent file is self-contained with no external state.
+
+## Implementation
+
+### Step 1: Create the agent file
+
+Create `plugins/soleur/agents/operations/ops-provisioner.md` following the same structure as `ops-research.md`:
+
+**Frontmatter:**
+
+```yaml
+---
+name: ops-provisioner
+description: "Use this agent when you need to set up a new SaaS tool account, purchase a plan, configure the tool, and verify the integration works. This agent guides through signup, pauses for manual payment, resumes for configuration and verification, then records the expense. Use ops-research for evaluating alternatives before choosing a tool; use ops-advisor for reading and updating the expense ledger directly."
+model: inherit
+---
+```
+
+**Body sections (topical, matching sibling style):**
+
+- **Role statement:** "You are an operations provisioning agent that guides users through SaaS tool account setup."
+- **Data files table:** Same as ops-research (expenses.md, domains.md)
+- **Setup:** Accept tool name, purpose, signup URL. Check expenses.md for duplicates. Check agent-browser availability. If available: open signup URL, snapshot, fill non-sensitive fields, stop at payment. If unavailable: provide URLs and instructions.
+- **Configure:** After user confirms payment/email verification, navigate to dashboard. Guide initial config using agent-browser. Make code changes if needed (edit templates, add env vars).
+- **Verify + Record:** Browser screenshot of dashboard. Integration test if applicable. Invoke ops-advisor via Task tool to record expense. Summarize what was set up, the plan/cost, and dashboard URL.
+- **Safety rules:** Same as ops-research. Never credentials, never payment buttons. When any step requires user action outside the browser, pause and ask.
+
+### Step 2: Update sibling disambiguation
+
+Update descriptions in both sibling agents to mention ops-provisioner:
+
+- `ops-research.md`: Add "use ops-provisioner for guided account setup and configuration"
+- `ops-advisor.md`: Add "use ops-provisioner for guided account setup and configuration"
+
+### Step 3: Plugin infrastructure
+
+1. Verify cumulative agent description word count under 2500
+2. Update `plugins/soleur/README.md` agent count (45 -> 46)
+3. Update `plugins/soleur/CHANGELOG.md` with `### Added` entry
+4. Bump version in `plugins/soleur/.claude-plugin/plugin.json` (MINOR)
+5. Update `plugins/soleur/.claude-plugin/plugin.json` description (agent count 45 -> 46)
+6. Update root `README.md` version badge
+7. Update `.github/ISSUE_TEMPLATE/bug_report.yml` version placeholder
+
+## References
+
+- Brainstorm: `knowledge-base/brainstorms/2026-02-22-ops-provisioner-brainstorm.md`
+- Spec: `knowledge-base/specs/feat-ops-provisioner/spec.md`
+- Sibling: `plugins/soleur/agents/operations/ops-research.md`
+- Sibling: `plugins/soleur/agents/operations/ops-advisor.md`
+- Pattern: `plugins/soleur/skills/community/SKILL.md` (Discord setup wizard)
+- Issue: #212

--- a/knowledge-base/specs/feat-ops-provisioner/spec.md
+++ b/knowledge-base/specs/feat-ops-provisioner/spec.md
@@ -1,0 +1,44 @@
+# Spec: Operations Provisioner Agent
+
+**Date:** 2026-02-22
+**Issue:** #212
+**Status:** Draft
+
+## Problem Statement
+
+When a new SaaS tool is chosen for the project (after evaluation via ops-research), the signup, payment, initial configuration, and verification steps are entirely manual. There is no agent-assisted workflow to guide users through account creation, ensure proper setup, verify the integration works, and record the expense.
+
+## Goals
+
+- G1: Provide a generic guided workflow for setting up any SaaS tool account
+- G2: Use agent-browser to automate non-sensitive signup steps
+- G3: Verify tool setup with browser screenshots and integration tests
+- G4: Automatically record expenses via ops-advisor after successful setup
+
+## Non-Goals
+
+- NG1: Tool evaluation or alternative comparison (handled by ops-research)
+- NG2: Entering credentials, passwords, or payment information
+- NG3: Tool-specific recipes or per-tool setup scripts
+- NG4: Managing ongoing tool administration or configuration changes
+
+## Functional Requirements
+
+- FR1: Agent accepts tool name, purpose, and signup URL as input
+- FR2: Agent checks expenses.md for existing entries to prevent duplicate setup
+- FR3: Agent navigates signup pages using agent-browser, filling non-sensitive fields
+- FR4: Agent pauses for manual payment completion with clear instructions
+- FR5: Agent resumes after payment to guide initial tool configuration
+- FR6: Agent takes browser screenshots of the configured dashboard as verification
+- FR7: Agent performs integration tests when applicable (e.g., visit site + check analytics)
+- FR8: Agent invokes ops-advisor to record the new expense entry
+- FR9: Agent makes corresponding code changes when tool setup requires them (e.g., update script tags, add env vars)
+- FR10: Agent pauses for email verification loops with same pattern as payment pause
+
+## Technical Requirements
+
+- TR1: Agent definition at `plugins/soleur/agents/operations/ops-provisioner.md`
+- TR2: Uses agent-browser for all web interaction (graceful degradation if unavailable)
+- TR3: Follows existing safety patterns: never enters credentials, never clicks payment buttons
+- TR4: Uses AskUserQuestion for all pause/confirmation points
+- TR5: Follows ops-advisor conventions for expense recording (no $ symbols, ISO dates, category tags)

--- a/knowledge-base/specs/feat-ops-provisioner/tasks.md
+++ b/knowledge-base/specs/feat-ops-provisioner/tasks.md
@@ -1,0 +1,16 @@
+# Tasks: ops-provisioner agent
+
+## Phase 1: Core Implementation
+
+- [ ] 1.1 Create `plugins/soleur/agents/operations/ops-provisioner.md` (frontmatter + body sections)
+- [ ] 1.2 Update `plugins/soleur/agents/operations/ops-research.md` disambiguation
+- [ ] 1.3 Update `plugins/soleur/agents/operations/ops-advisor.md` disambiguation
+
+## Phase 2: Plugin Infrastructure
+
+- [ ] 2.1 Verify cumulative agent description word count under 2500
+- [ ] 2.2 Update `plugins/soleur/README.md` agent count
+- [ ] 2.3 Update `plugins/soleur/CHANGELOG.md`
+- [ ] 2.4 Bump version in `plugins/soleur/.claude-plugin/plugin.json` (MINOR)
+- [ ] 2.5 Update root `README.md` version badge
+- [ ] 2.6 Update `.github/ISSUE_TEMPLATE/bug_report.yml` version placeholder

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "soleur",
-  "version": "2.24.0",
-  "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 45 agents, 8 commands, and 45 skills that compound your engineering knowledge over time.",
+  "version": "2.25.0",
+  "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 46 agents, 8 commands, and 45 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",
     "email": "jean.deruelle@jikigai.com",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.25.0] - 2026-02-22
+
+### Added
+
+- Add `ops-provisioner` agent for guided SaaS tool account setup, plan purchase, configuration, and verification (#212)
+- Update `ops-research` and `ops-advisor` agent descriptions with three-way disambiguation
+
 ## [2.24.0] - 2026-02-22
 
 ### Added

--- a/plugins/soleur/README.md
+++ b/plugins/soleur/README.md
@@ -201,11 +201,12 @@ Agents are organized by domain, then by function.
 |-------|-------------|
 | `pr-comment-resolver` | Address PR comments and implement fixes |
 
-### Operations (2)
+### Operations (3)
 
 | Agent | Description |
 |-------|-------------|
 | `ops-advisor` | Track expenses, manage domains, advise on hosting |
+| `ops-provisioner` | Guide SaaS tool account setup, purchase, configuration, and verification |
 | `ops-research` | Research domains, hosting, tools/SaaS, and cost optimization with browser automation |
 
 ### Product (2)

--- a/plugins/soleur/agents/operations/ops-advisor.md
+++ b/plugins/soleur/agents/operations/ops-advisor.md
@@ -1,6 +1,6 @@
 ---
 name: ops-advisor
-description: "Use this agent when you need to track operational expenses, manage domain registrations, or get hosting recommendations. This agent reads and updates structured markdown files in knowledge-base/ops/ to maintain an operational ledger for recurring costs, one-time purchases, and domain registrations. Use ops-research for live web research and provider comparison; use this agent for reading and updating the expense ledger."
+description: "Use this agent when you need to track operational expenses, manage domain registrations, or get hosting recommendations. This agent reads and updates structured markdown files in knowledge-base/ops/ to maintain an operational ledger for recurring costs, one-time purchases, and domain registrations. Use ops-research for live web research and provider comparison; use ops-provisioner for guided account setup and configuration; use this agent for reading and updating the expense ledger."
 model: inherit
 ---
 

--- a/plugins/soleur/agents/operations/ops-provisioner.md
+++ b/plugins/soleur/agents/operations/ops-provisioner.md
@@ -1,0 +1,79 @@
+---
+name: ops-provisioner
+description: "Use this agent when you need to set up a new SaaS tool account, purchase a plan, configure the tool, and verify the integration works. This agent guides through signup, pauses for manual payment, resumes for configuration and verification, then records the expense. Use ops-research for evaluating alternatives before choosing a tool; use ops-advisor for reading and updating the expense ledger directly."
+model: inherit
+---
+
+You are an operations provisioning agent that guides users through SaaS tool account setup, from signup to verified configuration and expense recording.
+
+## Data Files
+
+Read existing operations data before starting:
+
+| File | Purpose |
+|------|---------|
+| `knowledge-base/ops/expenses.md` | Check for existing entries to prevent duplicate setup |
+| `knowledge-base/ops/domains.md` | Reference if the tool involves domain configuration |
+
+If files do not exist, proceed without baseline context.
+
+## Setup
+
+Accept the tool name, purpose, and signup URL from the user. Check `knowledge-base/ops/expenses.md` for existing entries matching this tool. If an entry exists, warn the user and ask whether to proceed (upgrade/reconfigure) or stop.
+
+Check if agent-browser is available by running `agent-browser --help`.
+
+**If agent-browser is available:**
+
+1. Open the signup page: `agent-browser open <signup_url>`
+2. Take a snapshot: `agent-browser snapshot -i`
+3. Fill non-sensitive fields (email, organization name, plan selection) using `agent-browser fill` and `agent-browser click`
+4. When reaching payment fields (credit card, billing address), stop and move to the pause step
+
+**If agent-browser is not available:**
+
+Provide the signup URL and step-by-step instructions for the user to complete signup manually.
+
+**Pause for user action:**
+
+When the flow requires user action outside the browser (payment, email verification, MFA), use the AskUserQuestion tool: "Complete this step manually, then tell me when done." Wait for confirmation before continuing.
+
+## Configure
+
+After the user confirms payment is complete:
+
+1. Navigate to the tool's dashboard or settings page using agent-browser (or provide the URL if unavailable)
+2. Take a snapshot to understand the current state
+3. Guide through initial configuration steps (add site/project, copy integration snippet, configure options)
+4. If the tool requires code changes in the project (script tags, env vars, config files), make those changes using the Edit or Write tools
+
+## Verify + Record
+
+**Verification:**
+
+1. Take a browser screenshot of the configured dashboard as proof of setup
+2. If an integration test is applicable (e.g., visit the project's site, then check the tool's dashboard for the recorded event), perform it and screenshot the result
+
+**Record the expense:**
+
+After verification, gather the expense details:
+
+1. Ask for the actual amount paid and billing cycle (monthly/annual)
+2. Ask for the category (suggest `saas` as default)
+3. Update `knowledge-base/ops/expenses.md` following ops-advisor conventions:
+   - Amounts: plain numbers in USD, no currency symbol
+   - Dates: ISO 8601 (YYYY-MM-DD)
+   - Categories: hosting, domain, dev-tools, saas, api
+   - Update `last_updated` in YAML frontmatter
+
+**Summary:**
+
+After recording, summarize: the tool name, plan and cost, dashboard URL, verification status, and any code changes made.
+
+## Safety Rules
+
+NEVER enter credentials, passwords, API keys, or payment information.
+NEVER click buttons that trigger purchases, payments, or charges.
+NEVER fill payment form fields (credit card, CVV, billing address).
+
+When reaching any sensitive field or action, pause and ask the user to complete it manually.

--- a/plugins/soleur/agents/operations/ops-research.md
+++ b/plugins/soleur/agents/operations/ops-research.md
@@ -1,6 +1,6 @@
 ---
 name: ops-research
-description: "Use this agent when you need to research domains, hosting providers, tools/SaaS options, or find cost optimization opportunities. This agent performs live web research, compares alternatives, and can navigate to checkout pages using browser automation. It stops before any purchase for human confirmation, then records the transaction in ops data files. Use ops-advisor for reading and updating the expense ledger; use this agent for live research and price comparison."
+description: "Use this agent when you need to research domains, hosting providers, tools/SaaS options, or find cost optimization opportunities. This agent performs live web research, compares alternatives, and can navigate to checkout pages using browser automation. It stops before any purchase for human confirmation, then records the transaction in ops data files. Use ops-advisor for reading and updating the expense ledger; use ops-provisioner for guided account setup and configuration; use this agent for live research and price comparison."
 model: inherit
 ---
 


### PR DESCRIPTION
## Summary

- Add `ops-provisioner` agent to guide users through SaaS account signup, payment, configuration, verification, and expense recording
- Fill the gap between `ops-research` (tool evaluation) and `ops-advisor` (expense tracking)
- Update both sibling agents with three-way disambiguation
- Strengthen constitution rule: disambiguation is a graph property -- adding an agent requires updating all siblings

## Changes

| File | Change |
|------|--------|
| `plugins/soleur/agents/operations/ops-provisioner.md` | New agent: guided SaaS tool setup |
| `plugins/soleur/agents/operations/ops-research.md` | Add ops-provisioner disambiguation |
| `plugins/soleur/agents/operations/ops-advisor.md` | Add ops-provisioner disambiguation |
| `knowledge-base/overview/constitution.md` | Strengthen disambiguation rule |
| `knowledge-base/learnings/2026-02-22-three-way-agent-disambiguation.md` | New learning |
| `knowledge-base/brainstorms/2026-02-22-ops-provisioner-brainstorm.md` | Brainstorm doc |
| `knowledge-base/plans/2026-02-22-feat-ops-provisioner-agent-plan.md` | Plan doc |
| `knowledge-base/specs/feat-ops-provisioner/` | Spec + tasks |
| Version triad + README + bug template | v2.25.0, 46 agents |

Closes #212

## Test plan

- [ ] Verify `ops-provisioner` agent is discoverable by the plugin loader
- [ ] Verify cumulative agent description word count stays under 2500
- [ ] Verify sibling disambiguation sentences are correct
- [ ] Test agent invocation with Plausible Analytics as first use case

🤖 Generated with [Claude Code](https://claude.com/claude-code)