### PR TITLE
feat: add Phase 0.5 pre-flight validation checks to /soleur:work (v2.25.2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.25.1"
+      placeholder: "2.25.2"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.25.1-blue)](https://github.com/jikig-ai/soleur/releases)
->>>>>>> origin/main
+[![Version](https://img.shields.io/badge/version-2.25.2-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/knowledge-base/learnings/2026-02-22-plan-review-collapses-agent-architecture.md
+++ b/knowledge-base/learnings/2026-02-22-plan-review-collapses-agent-architecture.md
@@ -1,0 +1,30 @@
+# Learning: Plan review collapses agent architecture to inline instructions
+
+## Problem
+
+Issue #215 proposed three parallel pre-flight agents (environment-guard, convention-checker, scope-validator) to run before implementation in `/soleur:work`. The original plan specified 3 new agent files, a severity matrix, a result aggregation truth table, and a fast-path bypass system -- approximately 150 lines of new code across 4 files.
+
+## Solution
+
+Three plan reviewers (DHH, code-simplicity, Kieran) independently converged on the same conclusion: the pre-flight checks are deterministic shell commands (`pwd`, `git branch`, `git status`, `git stash list`, `git diff`) and context verification, not LLM reasoning tasks. They don't need agents.
+
+The final implementation: 23 lines of inline instructions added to work.md Phase 0.5, plus a one-line convention reminder in Phase 1. No new files. PATCH bump instead of MINOR.
+
+## Key Insight
+
+When checks are deterministic (shell commands with binary pass/fail outcomes), inline instructions in the existing command are simpler and faster than spawning Task agents. Agents add LLM round-trip latency to what would otherwise be millisecond shell commands. The existing pattern in work.md (`cleanup-merged` runs inline in Phase 0 without an agent) already demonstrated this.
+
+The review also caught an inverted git command: `git log origin/main..HEAD` (files changed on current branch) vs `git diff --name-only HEAD...origin/main` (files diverged between branch and main). The original command would have compared the wrong set of files.
+
+## Session Errors
+
+- SpecFlow analyzer wrote temp files to wrong location (worktree root)
+- Pre-existing merge conflict marker in README.md HEAD
+- Stale branch version required merge before bump (2.23.18 vs 2.25.1)
+- Glob tool returned empty for files that existed (required find fallback)
+- Edit tool required explicit Read even after Grep had searched the file
+
+## Tags
+
+category: architecture-decisions
+module: plugins/soleur/commands

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -100,6 +100,7 @@ Project principles organized by domain. Add principles as you learn them.
 - When adopting external components (agents, skills, libraries), trim to essentials that leverage the model's built-in knowledge rather than embedding encyclopedic reference material
 - Run `/soleur:plan_review` after brainstorm-generated plans to catch scope bloat -- plans consistently shrink by 30-50% after review (e.g., 9 components to 6, 3 parallel agents to 1, multi-file to single-file)
 - When merging or consolidating duplicate functionality, prefer a single inline implementation over separate files/agents/skills until complexity demands extraction
+- Prefer inline instructions over Task agents for deterministic checks (shell commands with binary pass/fail outcomes) -- agents add LLM round-trip latency to what would otherwise be millisecond operations
 - Plans should specify version bump intent (MINOR/PATCH/MAJOR) not exact version numbers, to avoid conflicts between parallel feature branches
 - Experimental feature flags should self-manage within execution scope -- activate on user consent, deactivate on completion or failure -- never require manual setup for features that already have a consent prompt
 - Before designing new infrastructure (metadata schemas, detection engines, new directories), check if the existing codebase already has a pattern that solves the problem -- e.g., the review command's conditional agents section was sufficient for project-aware filtering without a metadata system

--- a/knowledge-base/plans/2026-02-22-feat-preflight-review-agents-plan.md
+++ b/knowledge-base/plans/2026-02-22-feat-preflight-review-agents-plan.md
@@ -1,0 +1,122 @@
+---
+title: "feat: Pre-flight validation checks in /soleur:work"
+type: feat
+date: 2026-02-22
+issue: "#215"
+version-bump: PATCH
+---
+
+# Pre-Flight Validation Checks
+
+## Overview
+
+Add inline pre-flight assertions to `/soleur:work` Phase 0 that catch environment, convention, and scope issues before implementation begins. These are deterministic checks (shell commands + context verification), not LLM reasoning tasks -- they belong as inline instructions in the command, not as separate agents.
+
+## Problem Statement
+
+From Claude Code Insights (2026-01-29 to 2026-02-21):
+- "wrong_approach" is the #1 friction type (45 instances)
+- "misunderstood_request" accounts for 12 more incidents
+- Wrong branch/worktree edits recurred across 4-5 sessions
+- Convention violations (YAML vs markdown) required manual correction
+
+Current state: AGENTS.md has instructions for worktree discipline, but nothing validates them before work begins. The `ship` skill has post-implementation gates, but by then the damage is done.
+
+## Proposed Solution
+
+Add a **Phase 0.5: Pre-Flight Checks** section to `plugins/soleur/commands/soleur/work.md`, immediately after existing Phase 0 (context loading) and before Phase 1 (quick start). The section contains inline assertions -- no new agents, no new files.
+
+### Phase 0.5 Content
+
+```markdown
+### Phase 0.5: Pre-Flight Checks
+
+Run these checks before proceeding. FAIL blocks with remediation. WARN displays and continues. All pass continues silently.
+
+**Environment checks:**
+
+1. Run `git branch --show-current`. If the result is the default branch (main or master), FAIL: "On default branch -- create a worktree before starting work. Run: `bash ./plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh feature <name>`"
+2. Run `pwd`. If the path does NOT contain `.worktrees/`, WARN: "Not in a worktree directory. Phase 1 will offer to create one."
+3. Run `git status --short`. If output is non-empty, WARN: "Uncommitted changes detected. Consider committing or stashing before starting new work."
+4. Run `git stash list`. If output is non-empty, WARN: "Stashed changes found. Review stash list to avoid forgotten work."
+
+**Scope checks:**
+
+5. If a plan file was provided as input, verify it exists and is readable. If not, FAIL: "Plan file not found at the specified path."
+6. Run `git fetch origin main && git log origin/main..HEAD --name-only --pretty=format:""` to identify files changed on the current branch. Cross-reference with files likely to be modified by the plan. If overlap exists with recent changes on main, WARN: "Potential merge conflict zones detected in: [file list]. Consider merging main before starting."
+
+**Convention reminder (in Phase 1, not Phase 0.5):**
+
+In Phase 1's "Read Plan and Clarify" step, add: "Before proceeding, verify the plan does not contradict conventions in AGENTS.md (file format: markdown tables not YAML, kebab-case naming, directory structure)."
+```
+
+## Non-Goals
+
+- No new agents -- these are deterministic checks, not LLM reasoning tasks
+- No new skill -- checks are inline in work.md
+- No changes to `/soleur:plan` -- plan runs before implementation; adding pre-flight there would be redundant validation
+- No persistent reporting -- results displayed inline only
+- No fast-path bypass -- the checks run in milliseconds; no evidence that pre-flight friction on trivial changes is a problem
+
+## Acceptance Criteria
+
+- [x] `/soleur:work` has a Phase 0.5 section with pre-flight assertions
+- [x] Being on the default branch (main/master) is a FAIL that blocks with remediation
+- [x] Not being in a worktree directory is a WARN (Phase 1 creates worktrees)
+- [x] Uncommitted changes produce a WARN
+- [x] Stashed changes produce a WARN
+- [x] Missing plan file is a FAIL
+- [x] Merge conflict zone detection produces a WARN with file list
+- [x] Phase 1 includes a convention verification reminder
+- [x] Version bump: PATCH (2.25.1 -> 2.25.2)
+
+## Test Scenarios
+
+- Given a session on the default branch (main), when `/soleur:work` runs, then Phase 0.5 FAILS with "On default branch -- create a worktree"
+- Given a session in the main repo root with no worktree, when `/soleur:work` runs, then Phase 0.5 WARNS "Not in a worktree directory"
+- Given uncommitted changes in the worktree, when Phase 0.5 runs, then it WARNS "Uncommitted changes detected"
+- Given stashed changes exist, when Phase 0.5 runs, then it WARNS "Stashed changes found"
+- Given a plan file path that does not exist, when Phase 0.5 runs, then it FAILS "Plan file not found"
+- Given files changed on main that overlap with the plan's target files, when Phase 0.5 runs, then it WARNS about merge conflict zones
+- Given a clean environment (feature branch, worktree, no changes), when Phase 0.5 runs, then all checks pass silently and Phase 1 begins
+- Given a detached HEAD state, when Phase 0.5 runs, then it FAILS "Detached HEAD state -- checkout a feature branch"
+- Given ad-hoc work with a text description (not a file path), when Phase 0.5 runs, then it WARNS "Input appears to be a description, not a file path. Scope validation limited."
+
+## Dependencies and Risks
+
+- **Risk:** Added instructions in work.md increase command length. Mitigation: Phase 0.5 is ~15 lines of instruction, minimal impact.
+- **Risk:** Merge conflict zone detection requires `git fetch` which adds network latency. Mitigation: Phase 0 already runs `cleanup-merged` which may fetch. If fetch fails (offline), skip the conflict check with a WARN.
+
+## Enhancement Summary
+
+**Deepened on:** 2026-02-22
+
+### Implementation Details
+
+**Exact insertion point in work.md:** Between line 54 (`- Continue with standard work flow (use input document only)`) and line 56 (`### Phase 1: Quick Start`). The new Phase 0.5 section goes immediately after Phase 0's knowledge-base loading and before Phase 1.
+
+**Ad-hoc work handling:** The `<input_document>` comes from `#$ARGUMENTS`. If the argument is a text description (not a file path), check 5 (plan file existence) should detect this: if the argument does not end in `.md` or does not start with a path-like pattern, skip the file existence check and WARN: "Input appears to be a description, not a file path. Scope validation limited."
+
+**Git fetch deduplication:** Phase 0 runs `cleanup-merged` which internally runs `git fetch`. The scope check in Phase 0.5 can skip the redundant `git fetch origin main` and just run `git log origin/main..HEAD --name-only --pretty=format:""` since the fetch already happened. If cleanup-merged was skipped (no knowledge-base), include the fetch.
+
+**Convention reminder specificity:** The Phase 1 convention reminder should check these concrete conventions from AGENTS.md and constitution.md:
+- File format: markdown tables, not YAML files (constitution.md "Markdown-first" rule)
+- Naming: kebab-case for files and directories
+- Directory structure: agents recurse, skills flat at root level
+- Frontmatter: `name`, `description`, `model` fields required for agents; `name`, `description` for skills
+- Shell scripts: `#!/usr/bin/env bash` shebang, `set -euo pipefail`
+
+### Edge Cases
+
+- **Phase 0.5 + Phase 1 overlap:** Phase 1 Step 2 also checks the branch and offers to create a worktree. Phase 0.5 does this earlier with FAIL/WARN semantics. If Phase 0.5 fails (on default branch), Phase 1 never runs. If Phase 0.5 warns (no worktree), Phase 1's worktree creation path handles it. No conflict.
+- **Empty git stash list:** `git stash list` returns empty string with exit code 0 when no stashes exist. Safe to check for non-empty output.
+- **Detached HEAD:** `git branch --show-current` returns empty string on detached HEAD. Treat as FAIL: "Detached HEAD state -- checkout a feature branch or create a worktree."
+
+## References
+
+- Issue: #215
+- Target file: `plugins/soleur/commands/soleur/work.md` (insertion between lines 54-56)
+- Worktree validation instructions: `AGENTS.md` "Worktree Awareness" section
+- Learnings on duplicate validation gates: `knowledge-base/learnings/2026-02-19-plan-review-catches-redundant-validation-gates.md`
+- Learnings on worktree discipline: `knowledge-base/learnings/workflow-patterns/2026-02-11-worktree-edit-discipline.md`
+- Plan review feedback: DHH, Kieran, and simplicity reviewers all converged on inline checks over agents

--- a/knowledge-base/specs/feat-preflight-agents/spec.md
+++ b/knowledge-base/specs/feat-preflight-agents/spec.md
@@ -1,0 +1,47 @@
+# Feature: Pre-Flight Validation Checks
+
+## Problem Statement
+
+"wrong_approach" is the #1 friction type (45 of 139 sessions). Worktree discipline, convention compliance, and scope alignment are currently advisory-only -- nothing validates them before implementation begins. Post-implementation gates in `/ship` catch errors too late.
+
+## Goals
+
+- Catch environment errors (wrong branch, wrong directory) before any code is written
+- Surface stashed/uncommitted changes before starting new work
+- Detect merge conflict zones before implementation begins
+- Add convention verification reminder to the plan reading step
+
+## Non-Goals
+
+- No new agents (checks are deterministic, not LLM reasoning)
+- No changes to `/soleur:plan` (avoid redundant validation gates)
+- No fast-path bypass (checks run in milliseconds)
+- No persistent reporting (results displayed inline only)
+
+## Functional Requirements
+
+### FR1: Environment Assertions
+
+Phase 0.5 in work.md runs `git branch`, `pwd`, `git status`, and `git stash list` to validate the working environment. Default branch = FAIL. No worktree = WARN. Uncommitted/stashed changes = WARN.
+
+### FR2: Scope Assertions
+
+Verify plan file exists. Detect merge conflict zones via `git log` comparison. Missing plan = FAIL. Conflict zones = WARN.
+
+### FR3: Convention Reminder
+
+Phase 1 "Read Plan and Clarify" step includes explicit instruction to verify plan against AGENTS.md conventions.
+
+## Technical Requirements
+
+### TR1: Inline Instructions Only
+
+All checks are inline in work.md. No new files created.
+
+### TR2: Graceful Network Failure
+
+If `git fetch` fails (offline), skip conflict zone check with a WARN.
+
+### TR3: Non-Blocking Warnings
+
+Only FAIL blocks execution. WARN displays and proceeds. All pass continues silently.

--- a/knowledge-base/specs/feat-preflight-agents/tasks.md
+++ b/knowledge-base/specs/feat-preflight-agents/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: Pre-Flight Validation Checks
+
+## Phase 1: Core Implementation
+
+- [ ] 1.1 Add Phase 0.5 section to `plugins/soleur/commands/soleur/work.md` between Phase 0 and Phase 1
+  - [ ] 1.1.1 Environment checks: git branch, pwd, git status, git stash list
+  - [ ] 1.1.2 Scope checks: plan file existence, merge conflict zone detection
+  - [ ] 1.1.3 Result handling: FAIL blocks, WARN displays, all-pass continues silently
+- [ ] 1.2 Add convention verification reminder to Phase 1 "Read Plan and Clarify" step
+
+## Phase 2: Testing
+
+- [ ] 2.1 Verify work.md Phase 0.5 instructions are complete and unambiguous
+- [ ] 2.2 Run `bun test` to ensure no regressions
+
+## Phase 3: Documentation and Versioning
+
+- [ ] 3.1 Update `plugins/soleur/CHANGELOG.md` with new version entry
+- [ ] 3.2 Bump version in `plugins/soleur/.claude-plugin/plugin.json` (PATCH)
+- [ ] 3.3 Update `plugins/soleur/README.md` if needed (no new agents, likely no change)
+- [ ] 3.4 Update root `README.md` version badge
+- [ ] 3.5 Update `.github/ISSUE_TEMPLATE/bug_report.yml` version placeholder

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 46 agents, 8 commands, and 45 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.25.2] - 2026-02-22
+
+### Added
+
+- Add Phase 0.5 pre-flight validation checks to `/soleur:work` command (#215)
+- Environment checks: default branch detection (FAIL), worktree verification (WARN), uncommitted changes (WARN), stashed changes (WARN), detached HEAD (FAIL)
+- Scope checks: plan file existence (FAIL), merge conflict zone detection (WARN), ad-hoc work detection (WARN)
+- Convention verification reminder in Phase 1 "Read Plan and Clarify" step
+
 ## [2.25.1] - 2026-02-22
 
 ### Fixed

--- a/plugins/soleur/commands/soleur/work.md
+++ b/plugins/soleur/commands/soleur/work.md
@@ -53,12 +53,35 @@ Check if `knowledge-base/` directory exists. If it does:
 
 - Continue with standard work flow (use input document only)
 
+### Phase 0.5: Pre-Flight Checks
+
+Run these checks before proceeding to Phase 1. A FAIL blocks execution with a remediation message. A WARN displays and continues. If all checks pass, proceed silently.
+
+**Environment checks:**
+
+1. Run `git branch --show-current`. If the result is empty (detached HEAD), FAIL: "Detached HEAD state -- checkout a feature branch or create a worktree." If the result is the default branch (main or master), FAIL: "On default branch -- create a worktree before starting work. Run: `bash ./plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh feature <name>`"
+2. Run `pwd`. If the path does NOT contain `.worktrees/`, WARN: "Not in a worktree directory. You can create one via `git-worktree` skill in Phase 1."
+3. Run `git status --short`. If output is non-empty, WARN: "Uncommitted changes detected. Consider committing or stashing before starting new work."
+4. Run `git stash list`. If output is non-empty, WARN: "Stashed changes found. Review stash list to avoid forgotten work."
+
+**Scope checks:**
+
+5. If a plan file path was provided as input (ends in `.md` or starts with a path-like pattern), verify it exists and is readable. If not, FAIL: "Plan file not found at the specified path." If the input appears to be a text description rather than a file path, WARN: "Input appears to be a description, not a file path. Scope validation limited."
+6. Run `git diff --name-only HEAD...origin/main` to identify files that diverged between this branch and main. If output is non-empty, WARN: "Branch has diverged from main in [N] files: [file list]. Consider merging main before starting." If the git command fails (e.g., offline, no remote), skip this check silently.
+
+**On FAIL:** Display the failure message with remediation steps and stop. Do not proceed to Phase 1.
+
+**On WARN only:** Display all warnings together and proceed to Phase 1.
+
+**On all pass:** Proceed silently to Phase 1.
+
 ### Phase 1: Quick Start
 
 1. **Read Plan and Clarify**
 
    - Read the work document completely
    - Review any references or links provided in the plan
+   - Before proceeding, verify the plan does not contradict conventions in AGENTS.md and constitution.md: file format (markdown tables not YAML), kebab-case naming, directory structure (agents recurse, skills flat), required frontmatter fields, shell script conventions
    - If anything is unclear or ambiguous, ask clarifying questions now
    - Get user approval to proceed
    - **Do not skip this** - better to ask questions now than build the wrong thing


### PR DESCRIPTION
## Summary

- Adds inline pre-flight assertions to `/soleur:work` Phase 0.5 that catch environment, convention, and scope issues before implementation begins
- Deterministic shell command checks (not LLM agents) -- runs in milliseconds with FAIL/WARN/PASS semantics
- Adds convention verification reminder to Phase 1 "Read Plan and Clarify" step
- Constitution principle added: prefer inline instructions over Task agents for deterministic checks

## Pre-Flight Checks Added

| Check | Severity | Command |
|-------|----------|---------|
| Default branch (main/master) | FAIL | `git branch --show-current` |
| Detached HEAD | FAIL | `git branch --show-current` (empty) |
| Not in worktree | WARN | `pwd` |
| Uncommitted changes | WARN | `git status --short` |
| Stashed changes | WARN | `git stash list` |
| Plan file missing | FAIL | File existence check |
| Branch diverged from main | WARN | `git diff --name-only HEAD...origin/main` |

## Key Decision

Issue #215 proposed 3 parallel Task agents (~150 lines across 4 files). Three plan reviewers (DHH, simplicity, Kieran) independently converged: these checks are deterministic shell commands, not LLM reasoning tasks. Final implementation: 23 lines of inline instructions in one existing file. PATCH bump instead of MINOR.

Closes #215

## Test plan

- [ ] Run `/soleur:work` on the default branch (main) -- should FAIL with remediation
- [ ] Run `/soleur:work` in a worktree on a feature branch -- should pass silently
- [ ] Run `/soleur:work` with uncommitted changes -- should WARN and continue
- [ ] Run `/soleur:work` with a non-existent plan file path -- should FAIL
- [ ] Run `/soleur:work` with a text description (not file path) -- should WARN about limited scope validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)