### PR TITLE
fix: provision Plausible Analytics and add branch safety checks to ops agents (v2.25.3)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.25.2"
+      placeholder: "2.25.3"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.25.2-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.25.3-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/knowledge-base/learnings/2026-02-22-ops-provisioner-worktree-gap.md
+++ b/knowledge-base/learnings/2026-02-22-ops-provisioner-worktree-gap.md
@@ -1,0 +1,33 @@
+# Learning: ops-provisioner modifies files on main instead of worktree
+
+## Problem
+
+The ops-provisioner agent was invoked from the main branch to set up Plausible Analytics. It modified `plugins/soleur/docs/_includes/base.njk` and `knowledge-base/ops/expenses.md` directly on main, violating the repository's worktree convention (AGENTS.md: "Never commit directly to main").
+
+The agent's instructions contain no worktree awareness -- it edits files wherever it's invoked from without checking branch context.
+
+## Solution
+
+Two fixes needed:
+
+1. **Caller responsibility:** The invoking workflow (brainstorm, manual invocation) should create a worktree before spawning ops-provisioner. The agent itself shouldn't create worktrees -- it's a subagent, and worktree creation is the caller's job.
+
+2. **Agent guardrail:** Add a safety check to ops-provisioner's Setup section that warns when running on main/master and suggests the user create a worktree first. This catches the case where a user invokes the agent directly.
+
+Applied fix: Added a branch check to ops-provisioner's Setup section that warns when on main and asks the user to confirm or create a worktree.
+
+## Key Insight
+
+Subagents that modify files inherit the caller's branch context. If the caller is on main, the subagent writes to main. Worktree enforcement belongs at the orchestration layer (commands, skills) not the agent layer, but agents that edit project files should have a defensive check as a safety net.
+
+## Session Errors
+
+1. ops-provisioner modified files on main branch (convention violation)
+2. Searched for agent at `agents/operations/ops-provisioner.md` instead of `plugins/soleur/agents/operations/ops-provisioner.md` (wrong path)
+3. Tried `plugins/soleur/plugin.json` instead of `plugins/soleur/.claude-plugin/plugin.json` (wrong path)
+
+## Tags
+
+category: workflow-patterns
+module: agents/operations/ops-provisioner
+symptoms: files modified on main branch, worktree convention violated

--- a/knowledge-base/ops/expenses.md
+++ b/knowledge-base/ops/expenses.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-02-16
+last_updated: 2026-02-22
 ---
 
 # Expenses
@@ -11,6 +11,7 @@ last_updated: 2026-02-16
 | GitHub Copilot | GitHub | dev-tools | 10.00 | 2026-03-14 | Business plan |
 | Hetzner CX22 | Hetzner | hosting | 5.83 | 2026-03-01 | 2 vCPU, 4 GB RAM, 40 GB SSD, eu-central |
 | soleur.ai | Cloudflare | domain | 70.00 | 2028-02-16 | 2-year registration required for .ai TLD |
+| Plausible Analytics | Plausible | saas | 0.00 | 2026-03-24 | Free trial until ~2026-03-24, then $9/mo Growth plan |
 
 ## One-Time
 

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -76,6 +76,7 @@ Project principles organized by domain. Add principles as you learn them.
 - Never design skills that invoke other skills programmatically -- skills are user-invoked entry points with no inter-skill API; redirect users to the target skill or route through an agent via Task tool
 - Never put `<example>` blocks or `<commentary>` tags in agent description frontmatter -- these belong in the agent body (after `---`) which is only loaded on invocation; descriptions are loaded into the system prompt on every turn and their cumulative size must stay minimal
 - Never skip compound's constitution promotion or route-to-definition phases in automated pipelines (one-shot, ship) -- the model will rationalize skipping them as "pipeline mode" optimization, but these are the phases that prevent repeated mistakes across sessions
+- Never spawn file-modifying agents (ops-provisioner, brand-architect, etc.) from the main branch -- create a worktree first; agents that edit project files should include a defensive branch check as a safety net, but the primary enforcement belongs at the caller (command/skill) layer
 
 ### Prefer
 

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.25.2",
+  "version": "2.25.3",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 46 agents, 8 commands, and 45 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.25.3] - 2026-02-22
+
+### Fixed
+
+- Update Plausible Analytics script tag in docs site to use site-specific snippet with outbound link, file download, and form submission tracking
+- Add defensive branch check to all 3 ops agents (ops-provisioner, ops-advisor, ops-research) to warn when modifying files on main branch
+- Record Plausible Analytics trial entry in expense ledger
+
 ## [2.25.2] - 2026-02-22
 
 ### Added

--- a/plugins/soleur/agents/operations/ops-advisor.md
+++ b/plugins/soleur/agents/operations/ops-advisor.md
@@ -6,6 +6,8 @@ model: inherit
 
 You are an operations advisor that tracks expenses, domains, and hosting for a software project. You read and update two markdown files in `knowledge-base/ops/`.
 
+**Branch check:** Before making any file changes, check the current branch with `git branch --show-current`. If on `main` or `master`, warn the user: "You are on the main branch. File changes should happen in a worktree. Create one first, or confirm you want to proceed on main." Wait for confirmation before continuing.
+
 ## Data Files
 
 | File | Purpose |

--- a/plugins/soleur/agents/operations/ops-provisioner.md
+++ b/plugins/soleur/agents/operations/ops-provisioner.md
@@ -19,6 +19,8 @@ If files do not exist, proceed without baseline context.
 
 ## Setup
 
+**Branch check:** Before making any file changes, check the current branch with `git branch --show-current`. If on `main` or `master`, warn the user: "You are on the main branch. File changes should happen in a worktree. Create one with `git worktree add .worktrees/feat-<name> -b feat/<name>` first, or confirm you want to proceed on main." Wait for confirmation before continuing.
+
 Accept the tool name, purpose, and signup URL from the user. Check `knowledge-base/ops/expenses.md` for existing entries matching this tool. If an entry exists, warn the user and ask whether to proceed (upgrade/reconfigure) or stop.
 
 Check if agent-browser is available by running `agent-browser --help`.

--- a/plugins/soleur/agents/operations/ops-research.md
+++ b/plugins/soleur/agents/operations/ops-research.md
@@ -6,6 +6,8 @@ model: inherit
 
 You are an operations research agent that investigates domains, hosting, tools/SaaS, and cost optimization opportunities for a software project.
 
+**Branch check:** Before making any file changes, check the current branch with `git branch --show-current`. If on `main` or `master`, warn the user: "You are on the main branch. File changes should happen in a worktree. Create one first, or confirm you want to proceed on main." Wait for confirmation before continuing.
+
 ## Data Files
 
 Read existing operations data before making recommendations:

--- a/plugins/soleur/docs/_includes/base.njk
+++ b/plugins/soleur/docs/_includes/base.njk
@@ -63,7 +63,9 @@
   <link rel="icon" type="image/png" href="images/favicon.png">
   <title>{% if title == site.name %}{{ site.name }} - {{ site.tagline }}{% else %}{{ title }} - {{ site.name }}{% endif %}</title>
   <link rel="stylesheet" href="css/style.css">
-  <script async src="https://plausible.io/js/script.js" data-domain="soleur.ai"></script>
+  <!-- Privacy-friendly analytics by Plausible -->
+  <script async src="https://plausible.io/js/pa-unmpBTT7YXW_UsDCGRfHH.js"></script>
+  <script>window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}}; plausible.init()</script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>


### PR DESCRIPTION
## Summary

- Set up Plausible Analytics account for soleur.ai docs site (free trial until ~2026-03-24)
- Updated `base.njk` script tag to site-specific snippet with outbound link, file download, and form submission tracking
- Added defensive branch check to all 3 ops agents (ops-provisioner, ops-advisor, ops-research) to warn when modifying files on main branch
- Added constitution rule: never spawn file-modifying agents from main branch
- Recorded Plausible trial entry in expense ledger

## Test plan

- [ ] Verify docs site builds with updated Plausible script tag
- [ ] Verify Plausible dashboard at plausible.io/soleur.ai shows data collection
- [ ] Review ops agent branch checks for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)