### PR TITLE
fix: remove remaining $() command substitution from plugin markdown (v2.27.1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.27.0"
+      placeholder: "2.27.1"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.27.0-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.27.1-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/knowledge-base/learnings/2026-02-22-command-substitution-in-plugin-markdown.md
+++ b/knowledge-base/learnings/2026-02-22-command-substitution-in-plugin-markdown.md
@@ -1,0 +1,54 @@
+# Learning: $() command substitution in plugin markdown triggers Claude Code permission prompts
+
+## Problem
+
+Claude Code's security mechanism prompts users with "Command contains $() command substitution" when the Bash tool receives commands containing `$()`. Plugin markdown files (commands, skills, agents, and reference docs) contain bash code blocks with `$()` that agents try to execute, triggering this permission prompt repeatedly and breaking autonomous workflows.
+
+This issue recurred three times:
+- v2.23.15: one-shot command
+- v2.23.18: 4 commands, 9 skills, AGENTS.md
+- v2.26.1: merge-pr skill, community-manager agent, 2 reference files
+
+Each fix caught the files known at the time but missed others because the search scope was too narrow.
+
+## Solution
+
+Replace `$()` in bash code blocks with one of these patterns:
+
+| Original pattern | Replacement |
+|-----------------|-------------|
+| `VAR=$(command)` | Separate bash block with just `command`, then prose: "Store the result as VAR" |
+| `$(cat <<'EOF' ... EOF)` | Inline string with `--body "..."` (no subshell) |
+| `$(command \| jq ...)` | Separate bash block, then prose: "Parse the output to extract..." |
+| Complex `$(eval ...)` | Change code fence from `bash` to `text` and use comments |
+
+Key principle: bash code blocks in plugin markdown are instructions for Claude, not scripts. They don't need to be valid standalone bash -- they need to be individual commands that Claude executes one at a time via the Bash tool.
+
+## Key Insight
+
+The root cause of recurrence is **incomplete search scope**. Each prior fix searched only the files that triggered the immediate complaint (commands, then skills) but missed:
+- Agent definition files (`agents/**/*.md`)
+- Reference documents (`skills/*/references/*.md`)
+- Any new files added after the previous fix
+
+The correct fix is to search the ENTIRE `plugins/soleur/` directory for `$()` in all `.md` files, not just the category that triggered the report. The grep command:
+
+```text
+grep -rn '\$(' plugins/soleur/ --include='*.md'
+```
+
+Then filter out non-bash contexts (prose mentions in changelogs, etc.) and fix all bash code blocks.
+
+## Prevention
+
+When fixing a pattern across files, always search the widest reasonable scope. For plugin markdown issues, that means all `.md` files under `plugins/soleur/`, including subdirectories for agents, skills (with references/), and commands.
+
+## Session Errors
+
+1. Attempted to Edit worktree files without reading them first (tool requires a Read before Edit)
+2. First edit to merge-pr SKILL.md was incomplete -- left `$(cat <<'EOF')` in the PR creation block, requiring a second edit pass
+
+## Tags
+category: integration-issues
+module: plugins/soleur
+symptoms: "Command contains $() command substitution" permission prompt

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -66,6 +66,7 @@ Project principles organized by domain. Add principles as you learn them.
 - Before adding new GitHub Actions workflows, audit existing ones with `gh run list --workflow=<name>.yml` -- remove workflows that are always skipped (condition never matches) or superseded by newer workflows that absorbed their functionality
 - Agent descriptions for agents with overlapping scope must include a one-line disambiguation sentence: "Use [sibling] for [its scope]; use this agent for [this scope]." When adding a new agent to a domain, update ALL existing sibling descriptions to cross-reference the new agent -- disambiguation is a graph property, not just a property of the new node
 - The project uses Bun as the JavaScript runtime with ESM modules (`"type": "module"`); pre-commit hooks are managed by lefthook (not Husky)
+- When fixing a pattern across plugin files (e.g., removing `$()`, renaming a reference), search ALL `.md` files under `plugins/soleur/` -- not just the category (commands/, skills/, agents/) that triggered the report; reference docs, SKILL.md, and agent definitions all contain executable bash blocks
 
 ### Never
 

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 46 agents, 8 commands, and 47 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.27.1] - 2026-02-22
+
+### Fixed
+
+- Remove remaining `$()` command substitution from merge-pr skill, community-manager agent, and 2 reference docs
+- Add constitution rule: when fixing patterns across plugin files, search all `.md` under `plugins/soleur/` -- not just the category that triggered the report
+
 ## [2.27.0] - 2026-02-22
 
 ### Added

--- a/plugins/soleur/agents/marketing/community-manager.md
+++ b/plugins/soleur/agents/marketing/community-manager.md
@@ -43,19 +43,21 @@ Run scripts to gather raw data:
 
 ```bash
 SCRIPT_DIR="plugins/soleur/skills/community/scripts"
+```
 
-# Discord: fetch messages from monitored channels
-# If DISCORD_CHANNEL_IDS is set, use those channels; otherwise list all text channels
-if [[ -n "${DISCORD_CHANNEL_IDS:-}" ]]; then
-  IFS=',' read -ra CHANNELS <<< "$DISCORD_CHANNEL_IDS"
-else
-  CHANNELS=$(${SCRIPT_DIR}/discord-community.sh channels | jq -r '.[].id')
-fi
+Discord: fetch messages from monitored channels. If DISCORD_CHANNEL_IDS is set, split it by comma and use those channel IDs. Otherwise, list all text channels first:
 
-# For each channel, fetch last 100 messages
-for channel_id in "${CHANNELS[@]}"; do
-  ${SCRIPT_DIR}/discord-community.sh messages "$channel_id" 100
-done
+```bash
+plugins/soleur/skills/community/scripts/discord-community.sh channels | jq -r '.[].id'
+```
+
+Then for each channel ID from the output, fetch the last 100 messages:
+
+```bash
+plugins/soleur/skills/community/scripts/discord-community.sh messages "<channel_id>" 100
+```
+
+Run this for each channel.
 
 # Discord: fetch guild info and members
 ${SCRIPT_DIR}/discord-community.sh guild-info

--- a/plugins/soleur/skills/agent-native-architecture/references/action-parity-discipline.md
+++ b/plugins/soleur/skills/agent-native-architecture/references/action-parity-discipline.md
@@ -280,22 +280,21 @@ For each screen in your app:
 
 ### Git Hooks / CI Checks
 
-```bash
+```text
 #!/bin/bash
 # pre-commit hook: check for new UI actions without tools
 
-# Find new SwiftUI Button/onTapGesture additions
-NEW_ACTIONS=$(git diff --cached --name-only | xargs grep -l "Button\|onTapGesture")
+# Find new SwiftUI Button/onTapGesture additions in staged files
+# Run: git diff --cached --name-only | xargs grep -l "Button\|onTapGesture"
+# Store the result in NEW_ACTIONS
 
-if [ -n "$NEW_ACTIONS" ]; then
-    echo "⚠️  New UI actions detected. Did you add corresponding agent tools?"
-    echo "Files: $NEW_ACTIONS"
-    echo ""
-    echo "Checklist:"
-    echo "  [ ] Agent tool exists for new action"
-    echo "  [ ] System prompt documents new capability"
-    echo "  [ ] Capability map updated"
-fi
+# If NEW_ACTIONS is non-empty, warn:
+#   "New UI actions detected. Did you add corresponding agent tools?"
+#   "Files: <list>"
+#   Checklist:
+#     [ ] Agent tool exists for new action
+#     [ ] System prompt documents new capability
+#     [ ] Capability map updated
 ```
 
 ### Automated Parity Testing

--- a/plugins/soleur/skills/merge-pr/SKILL.md
+++ b/plugins/soleur/skills/merge-pr/SKILL.md
@@ -13,14 +13,29 @@ description: This skill should be used when merging a feature branch to main wit
 
 ## Phase 0: Context Detection
 
-Detect the current environment and record the starting state for rollback:
+Detect the current environment and record the starting state for rollback. Run these commands separately and store the results:
 
+1. Get current branch name:
 ```bash
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
-STARTING_SHA=$(git rev-parse HEAD)
-WORKTREE_PATH=$(pwd)
-REPO_ROOT=$(git worktree list | head -1 | awk '{print $1}')
+git rev-parse --abbrev-ref HEAD
 ```
+
+2. Get current commit SHA (this is the rollback point):
+```bash
+git rev-parse HEAD
+```
+
+3. Get current working directory path (worktree path):
+```bash
+pwd
+```
+
+4. Get the main repo root (first path from worktree list output):
+```bash
+git worktree list
+```
+
+Store these four values as BRANCH, STARTING_SHA, WORKTREE_PATH, and REPO_ROOT for use throughout the pipeline.
 
 Load project conventions:
 
@@ -279,10 +294,10 @@ gh pr list --head ${BRANCH} --json number,state --jq '.[] | select(.state == "OP
 
 **If a PR exists:** Announce the PR number and proceed.
 
-**If no PR exists:** Create one:
+**If no PR exists:** Create one with `gh pr create`. Pass the body via HEREDOC to preserve formatting:
 
 ```bash
-gh pr create --title "<type>: <description>" --body "$(cat <<'EOF'
+gh pr create --title "<type>: <description>" --body "
 ## Summary
 <bullet points summarizing changes>
 
@@ -291,8 +306,7 @@ gh pr create --title "<type>: <description>" --body "$(cat <<'EOF'
 - [ ] Manual verification of merge pipeline
 
 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
+"
 ```
 
 Derive the title from the branch name and changes. Use `feat:` for features, `fix:` for bug fixes.

--- a/plugins/soleur/skills/skill-creator/references/api-security.md
+++ b/plugins/soleur/skills/skill-creator/references/api-security.md
@@ -58,12 +58,13 @@ esac
 
 2. **Add profile support to the wrapper** (if service needs multiple accounts):
 
-```bash
+```text
 # In secure-api.sh, add to profile remapping section:
 yourservice)
     SERVICE_UPPER="YOURSERVICE"
-    YOURSERVICE_API_KEY=$(eval echo \$${SERVICE_UPPER}_${PROFILE_UPPER}_API_KEY)
-    YOURSERVICE_ACCOUNT_ID=$(eval echo \$${SERVICE_UPPER}_${PROFILE_UPPER}_ACCOUNT_ID)
+    # Dynamically resolve the env var name using the profile:
+    # YOURSERVICE_API_KEY = value of YOURSERVICE_<PROFILE>_API_KEY
+    # YOURSERVICE_ACCOUNT_ID = value of YOURSERVICE_<PROFILE>_ACCOUNT_ID
     ;;
 ```
 


### PR DESCRIPTION
## Summary
- Remove `$()` command substitution from merge-pr skill (Phase 0 context detection + PR body heredoc), community-manager agent (channel list), and 2 reference docs (api-security, action-parity-discipline)
- Add constitution rule: when fixing cross-file patterns, search ALL `.md` under `plugins/soleur/` -- not just the triggering category
- Add learning documenting the 3-fix recurrence pattern and prevention strategy

## Context
Third fix for the same recurring issue. Prior fixes (v2.23.15, v2.23.18) caught commands and skills but missed agents, reference docs, and newly added skills.

## Test plan
- [ ] CI passes
- [ ] No `$()` remains in any `.md` under `plugins/soleur/` (verified via grep)

Generated with [Claude Code](https://claude.com/claude-code)