### PR TITLE
fix: add allowed-tools to one-shot command for ralph-loop setup (v2.28.1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.28.0"
+      placeholder: "2.28.1"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.28.0-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.28.1-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 47 agents, 8 commands, and 46 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.28.1] - 2026-02-22
+
+### Fixed
+
+- Add missing `allowed-tools` to one-shot command frontmatter so the ralph-loop setup script executes without permission prompts
+
 ## [2.28.0] - 2026-02-22
 
 ### Added

--- a/plugins/soleur/commands/soleur/one-shot.md
+++ b/plugins/soleur/commands/soleur/one-shot.md
@@ -2,6 +2,7 @@
 name: soleur:one-shot
 description: Full autonomous engineering workflow from plan to PR with video
 argument-hint: "[feature description or issue reference]"
+allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh:*)"]
 ---
 
 ```!


### PR DESCRIPTION
## Summary

- Add missing `allowed-tools` frontmatter field to `one-shot.md` so the ralph-loop setup script bang block executes without permission prompts
- Matches the pattern used by the official `ralph-loop` plugin command

Fixes the permission error: `Bash command permission check failed for pattern "setup-ralph-loop.sh"` when running `/soleur:one-shot`.

## Test plan

- [ ] Run `/soleur:one-shot` and verify the ralph-loop setup script executes without a permission prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)