### PR TITLE
fix: replace --jq with piped jq to prevent quoted flag warnings (v2.28.2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.28.1"
+      placeholder: "2.28.2"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.28.1-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.28.2-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.28.1",
+  "version": "2.28.2",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 47 agents, 8 commands, and 46 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.28.2] - 2026-02-22
+
+### Fixed
+
+- Replace `--jq` inline flags with piped `| jq` in ship, merge-pr, and brainstorm to prevent Claude Code "quoted characters in flag names" warnings
+- Add explicit `gh pr create` template to ship skill with unquoted flag names
+
 ## [2.28.1] - 2026-02-22
 
 ### Fixed

--- a/plugins/soleur/commands/soleur/brainstorm.md
+++ b/plugins/soleur/commands/soleur/brainstorm.md
@@ -294,7 +294,7 @@ Ensure the brainstorms directory exists before writing.
 
    Parse the feature description for `#N` patterns (e.g., `#42`). Extract the first issue number found.
 
-   **If issue reference found**, validate its state by running `gh issue view <number> --json state --jq .state`:
+   **If issue reference found**, validate its state by running `gh issue view <number> --json state` and pipe to `jq .state`:
 
    - **If OPEN:** Use existing issue -- skip creation, proceed to step 3
    - **If CLOSED:** Warn the user, then create a new issue with "Replaces closed #N" in the body (proceed to step 2)
@@ -316,7 +316,7 @@ Ensure the brainstorms directory exists before writing.
 
 3. **Update existing issue with artifact links** (if using existing issue):
 
-   Fetch the existing issue body with `gh issue view <number> --json body --jq .body`. Append an Artifacts section with links to the brainstorm document, spec file, and branch name. Then update with `gh issue edit <number> --body "<updated body>"`.
+   Fetch the existing issue body with `gh issue view <number> --json body` piped to `jq .body`. Append an Artifacts section with links to the brainstorm document, spec file, and branch name. Then update with `gh issue edit <number> --body "<updated body>"`.
 
 4. **Generate spec.md** using `spec-templates` skill template:
    - Fill in Problem Statement from brainstorm

--- a/plugins/soleur/skills/merge-pr/SKILL.md
+++ b/plugins/soleur/skills/merge-pr/SKILL.md
@@ -289,7 +289,7 @@ git push -u origin ${BRANCH}
 Check for an existing PR:
 
 ```bash
-gh pr list --head ${BRANCH} --json number,state --jq '.[] | select(.state == "OPEN") | .number'
+gh pr list --head ${BRANCH} --json number,state | jq '.[] | select(.state == "OPEN") | .number'
 ```
 
 **If a PR exists:** Announce the PR number and proceed.
@@ -326,7 +326,7 @@ gh pr checks --watch --fail-fast
 **If a check fails:**
 
 ```bash
-gh pr checks --json name,state,description --jq '.[] | select(.state != "SUCCESS")'
+gh pr checks --json name,state,description | jq '.[] | select(.state != "SUCCESS")'
 ```
 
 Stop and report:

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -210,7 +210,22 @@ If any unarchived artifacts are found, BLOCK the push and instruct the user to r
 
 Push the branch to remote: run `git rev-parse --abbrev-ref HEAD` to get the branch name, then `git push -u origin <branch-name>`.
 
-Create the PR using `gh pr create` with a title and body containing a summary and checklist. Use a HEREDOC for the body to preserve formatting.
+Create the PR:
+
+```bash
+gh pr create --title "the pr title" --body "$(cat <<'EOF'
+## Summary
+<bullet points>
+
+## Test plan
+<checklist>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+IMPORTANT: Do not quote flag names. Write `--title` not `"--title"`.
 
 Present the PR URL to the user.
 
@@ -219,11 +234,8 @@ Present the PR URL to the user.
 After pushing (or after any subsequent push), verify the PR has no merge conflicts with the base branch:
 
 ```bash
-# Fetch latest base branch
 git fetch origin main
-
-# Check PR mergeability
-gh pr view --json mergeable,mergeStateStatus --jq '{mergeable, mergeStateStatus}'
+gh pr view --json mergeable,mergeStateStatus | jq '{mergeable, mergeStateStatus}'
 ```
 
 **If `mergeable` is `MERGEABLE`:** Continue to Phase 8.
@@ -259,7 +271,7 @@ gh pr view --json mergeable,mergeStateStatus --jq '{mergeable, mergeStateStatus}
 
    ```bash
    git push
-   gh pr view --json mergeable --jq '.mergeable'
+   gh pr view --json mergeable | jq '.mergeable'
    ```
 
 6. If still `CONFLICTING` after resolution: stop and ask the user for help.
@@ -281,7 +293,7 @@ gh pr checks --watch --fail-fast
 1. Read the failure details:
 
    ```bash
-   gh pr checks --json name,state,description --jq '.[] | select(.state != "SUCCESS")'
+   gh pr checks --json name,state,description | jq '.[] | select(.state != "SUCCESS")'
    ```
 
 2. If the failure is in tests: investigate the failing test, fix locally, commit, push, and re-run this phase.


### PR DESCRIPTION
## Summary
- Replace all `--jq` inline flags with piped `| jq` in ship, merge-pr, and brainstorm skills/commands
- Add explicit `gh pr create` template to ship skill with unquoted flag names
- The `--jq` flag requires complex quoting that causes Claude Code to defensively quote flag names, triggering "Command contains quoted characters in flag names" warnings

## Files changed
- `plugins/soleur/skills/ship/SKILL.md` -- 4 `--jq` replaced, added explicit PR create template
- `plugins/soleur/skills/merge-pr/SKILL.md` -- 2 `--jq` replaced
- `plugins/soleur/commands/soleur/brainstorm.md` -- 2 inline `--jq` references replaced

## Test plan
- [ ] CI passes
- [ ] Run `/ship` on next feature and verify no "quoted characters in flag names" warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)