### PR TITLE
fix: replace ! code block with explicit LLM step in one-shot (v2.28.3)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.28.2"
+      placeholder: "2.28.3"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.28.2-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.28.3-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.28.2",
+  "version": "2.28.3",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 47 agents, 8 commands, and 46 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.28.3] - 2026-02-22
+
+### Fixed
+
+- Replace `!` code block in one-shot command with explicit LLM-executed Bash step -- the `!` auto-execution syntax fails permission checks even with `allowed-tools` frontmatter (#241 follow-up)
+- Remove unused `allowed-tools` frontmatter from one-shot command
+- Update bundle-ralph-loop learning to document `!` block permission failure pattern
+
 ## [2.28.2] - 2026-02-22
 
 ### Fixed

--- a/plugins/soleur/commands/soleur/one-shot.md
+++ b/plugins/soleur/commands/soleur/one-shot.md
@@ -2,16 +2,17 @@
 name: soleur:one-shot
 description: Full autonomous engineering workflow from plan to PR with video
 argument-hint: "[feature description or issue reference]"
-allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh:*)"]
 ---
-
-```!
-"${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh" "finish all slash commands" --completion-promise "DONE"
-```
 
 Run these steps in order. Do not do anything else.
 
-**Step 0: Ensure branch isolation.** Check the current branch with `git branch --show-current`. If on the default branch (main or master), pull latest and create a feature branch named `feat/one-shot-<slugified-arguments>` before proceeding. Parallel agents on the same repo cause silent merge conflicts when both work on main.
+**Step 0a: Activate Ralph Loop.** Run this command via the Bash tool:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh "finish all slash commands" --completion-promise "DONE"
+```
+
+**Step 0b: Ensure branch isolation.** Check the current branch with `git branch --show-current`. If on the default branch (main or master), pull latest and create a feature branch named `feat/one-shot-<slugified-arguments>` before proceeding. Parallel agents on the same repo cause silent merge conflicts when both work on main.
 
 1. `/soleur:plan $ARGUMENTS`
 2. `/deepen-plan`


### PR DESCRIPTION
## Summary

- The `!` auto-execution syntax in one-shot command fails permission checks because it bypasses the normal Bash tool approval flow
- Two prior fixes attempted: removing `$()` substitutions (#225) and adding `allowed-tools` frontmatter (#241) -- neither worked
- Convert to an explicit Step 0a instruction that the LLM runs via the Bash tool with normal permission approval

## Test plan

- [ ] Run `/soleur:one-shot` and verify the ralph loop setup script executes without permission errors
- [ ] Verify the stop hook still activates after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)