### PR TITLE
fix(docs): expand Adding a New Domain Leader checklist (v2.31.1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.31.0"
+      placeholder: "2.31.1"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.31.0-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.31.1-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.31.0",
+  "version": "2.31.1",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 54 agents, 8 commands, and 46 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/AGENTS.md
+++ b/plugins/soleur/AGENTS.md
@@ -157,11 +157,14 @@ Domain leaders are agents that orchestrate a business domain's specialist team. 
 
 ### Adding a New Domain Leader
 
-1. Create `agents/<domain>/<role>.md` at the domain root level
-2. Follow the 4-phase contract in the agent body
-3. Add a domain assessment question to the brainstorm command's Phase 0.5
-4. Optionally create a `/soleur:<domain>` skill as standalone entry point
-5. Update README counts and CHANGELOG
+1. Create `agents/<domain>/` with leader + specialist `.md` files
+2. Follow the 3-phase contract (Assess, Recommend/Delegate, Sharp Edges) -- use `agents/legal/clo.md` as template
+3. Add brainstorm routing to `commands/soleur/brainstorm.md` Phase 0.5 (assessment question, routing block, participation block)
+4. Add disambiguation sentences to agents with overlapping scope in adjacent domains (both directions)
+5. Verify token budget: `shopt -s globstar && grep -h 'description:' agents/**/*.md | wc -w` (under 2,500)
+6. Update docs data files: `agents.js` (DOMAIN_LABELS, DOMAIN_CSS_VARS, domainOrder), `style.css` (CSS variable)
+7. Update AGENTS.md (directory tree, domain leader table) and README.md (agent section, counts)
+8. Version bump (MINOR) and CHANGELOG
 
 ## Documentation
 

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.31.1] - 2026-02-22
+
+### Fixed
+
+- Fix stale "Adding a New Domain Leader" checklist in AGENTS.md (expanded from 5 to 8 steps, corrected 3-phase contract reference)
+
 ## [2.31.0] - 2026-02-22
 
 ### Added


### PR DESCRIPTION
## Summary

- Expand the "Adding a New Domain Leader" checklist in `AGENTS.md` from 5 stale steps to 8 accurate steps
- Fix leftover "4-phase" reference to correct "3-phase" contract
- Add missing steps: brainstorm routing, disambiguation sentences, token budget verification, docs data files update

Discovered during `/soleur:compound` route-to-definition phase after shipping #250 (Sales domain).

## Test plan

- [ ] Verify AGENTS.md checklist matches the actual steps followed when adding the Sales domain
- [ ] Verify version triad updated (plugin.json, CHANGELOG.md, README.md)
- [ ] Verify root README badge and bug_report.yml placeholder updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)