### PR TITLE
fix(docs): add Sales department card to landing page (v2.31.2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.31.1"
+      placeholder: "2.31.2"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 Currently: an orchestration engine for Claude Code -- agents, workflows, and compounding knowledge.
 
-[![Version](https://img.shields.io/badge/version-2.31.1-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.31.2-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.31.1",
+  "version": "2.31.2",
   "description": "A full AI organization that reviews, plans, builds, remembers, and self-improves. 54 agents, 8 commands, and 46 skills that compound your engineering knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.31.2] - 2026-02-22
+
+### Fixed
+
+- Add missing Sales department card to landing page and update "Agents Execute" text to include sales
+
 ## [2.31.1] - 2026-02-22
 
 ### Fixed

--- a/plugins/soleur/docs/index.njk
+++ b/plugins/soleur/docs/index.njk
@@ -54,7 +54,7 @@ permalink: index.html
           <div class="problem-card">
             <div class="problem-card-icon" aria-hidden="true">&#x26A1;</div>
             <h3>Agents Execute</h3>
-            <p>Engineering, marketing, legal, operations &mdash; every department, running autonomously on your command.</p>
+            <p>Engineering, marketing, sales, legal, operations &mdash; every department, running autonomously on your command.</p>
           </div>
           <div class="problem-card">
             <div class="problem-card-icon" aria-hidden="true">&#x1F504;</div>
@@ -98,6 +98,11 @@ permalink: index.html
             <div class="feature-card-icon" aria-hidden="true">&#x1F4E3;</div>
             <h3>Marketing</h3>
             <p>Brand identity, community content, release announcements. Your public presence runs on autopilot.</p>
+          </div>
+          <div class="feature-card">
+            <div class="feature-card-icon" aria-hidden="true">&#x1F4B0;</div>
+            <h3>Sales</h3>
+            <p>Outbound strategy, deal architecture, pipeline analytics. Revenue generation that scales from first customer to enterprise.</p>
           </div>
           <div class="feature-card">
             <div class="feature-card-icon" aria-hidden="true">&#x1F3A7;</div>


### PR DESCRIPTION
## Summary

- Add Sales department card to the "Your AI Organization" grid on the landing page
- Update "Agents Execute" text to include "sales" in the department list
- Sales domain was added in v2.31.0 (#250) but the landing page was not updated

## Test plan

- [ ] Verify docs build succeeds with `npx @11ty/eleventy`
- [ ] Verify Sales card appears in the departments grid on the landing page
- [ ] Verify version triad updated (plugin.json, CHANGELOG.md, README.md badge, bug_report.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)