### PR TITLE
fix(docs): restructure landing page grids to 3x2 layout (v2.31.4)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.31.3"
+      placeholder: "2.31.4"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 54 agents across engineering, marketing, legal, operations, and product -- compounding your company knowledge with every session.
 
-[![Version](https://img.shields.io/badge/version-2.31.3-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.31.4-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.31.3",
+  "version": "2.31.4",
   "description": "A full AI organization across engineering, marketing, legal, operations, and product. 54 agents, 8 commands, and 46 skills that compound your company knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.31.4] - 2026-02-22
+
+### Fixed
+
+- Fix broken landing page grid layout: replace `auto-fill` with `repeat(3, 1fr)` for clean 3x2 grids
+- Replace aspirational department cards (Strategy, Support) with real plugin domains (Legal, Operations)
+- Add missing "Review" workflow card and rename "Learn & Grow" to "Compound" to match actual workflow
+- Tighten Sales card copy per CMO recommendation
+
 ## [2.31.3] - 2026-02-22
 
 ### Fixed

--- a/plugins/soleur/docs/css/style.css
+++ b/plugins/soleur/docs/css/style.css
@@ -569,7 +569,7 @@
   .feature-grid-departments,
   .feature-grid-workflow {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    grid-template-columns: repeat(3, 1fr);
     gap: var(--space-5);
     max-width: 1200px;
     margin-inline: auto;

--- a/plugins/soleur/docs/index.njk
+++ b/plugins/soleur/docs/index.njk
@@ -80,11 +80,6 @@ permalink: index.html
         <h2 class="section-title">Every department. From idea to shipped.</h2>
         <div class="feature-grid-departments">
           <div class="feature-card">
-            <div class="feature-card-icon" aria-hidden="true">&#x1F3AF;</div>
-            <h3>Strategy</h3>
-            <p>Vision, positioning, market analysis. The strategic foundation that guides every decision your AI organization makes.</p>
-          </div>
-          <div class="feature-card">
             <div class="feature-card-icon" aria-hidden="true">&#x1F4DA;</div>
             <h3>Product</h3>
             <p>Product management, competitive analysis, planning &amp; specs, UX design. From market insight to shipped experience.</p>
@@ -102,12 +97,17 @@ permalink: index.html
           <div class="feature-card">
             <div class="feature-card-icon" aria-hidden="true">&#x1F4B0;</div>
             <h3>Sales</h3>
-            <p>Outbound strategy, deal architecture, pipeline analytics. Revenue generation that scales from first customer to enterprise.</p>
+            <p>Outbound campaigns, deal qualification, pipeline analytics. AI-powered revenue operations from first outreach to closed-won.</p>
           </div>
           <div class="feature-card">
-            <div class="feature-card-icon" aria-hidden="true">&#x1F3A7;</div>
-            <h3>Support</h3>
-            <p>Troubleshooting, documentation, issue triage. Support that resolves problems before they escalate.</p>
+            <div class="feature-card-icon" aria-hidden="true">&#x2696;&#xFE0F;</div>
+            <h3>Legal</h3>
+            <p>Terms, privacy policies, compliance audits. Legal documents generated, reviewed, and kept current automatically.</p>
+          </div>
+          <div class="feature-card">
+            <div class="feature-card-icon" aria-hidden="true">&#x2699;&#xFE0F;</div>
+            <h3>Operations</h3>
+            <p>Vendor research, expense tracking, tool provisioning. Operational infrastructure that runs without overhead.</p>
           </div>
         </div>
         <h3 class="feature-grid-sublabel">The Workflow</h3>
@@ -128,13 +128,18 @@ permalink: index.html
             <p>Parallel agents writing, reviewing, and refining code. Production-grade engineering on your command.</p>
           </div>
           <div class="feature-card">
+            <div class="feature-card-icon" aria-hidden="true">&#x1F50D;</div>
+            <h3>Review</h3>
+            <p>Multi-agent code review catches what humans miss. Security, performance, and style &mdash; checked in parallel.</p>
+          </div>
+          <div class="feature-card">
             <div class="feature-card-icon" aria-hidden="true">&#x1F680;</div>
             <h3>Ship</h3>
-            <p>One command. Tests, review, commit, deploy, announce. Done.</p>
+            <p>One command. Tests, version bump, commit, deploy, announce. Done.</p>
           </div>
           <div class="feature-card">
             <div class="feature-card-icon" aria-hidden="true">&#x1F4C8;</div>
-            <h3>Learn &amp; Grow</h3>
+            <h3>Compound</h3>
             <p>Every decision captured, every pattern compounded. Your organization gets smarter with every project &mdash; permanently.</p>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Fix broken landing page grid layout caused by adding a 6th card to a 5-column auto-fill grid (#253)
- Replace `repeat(auto-fill, minmax(200px, 1fr))` with `repeat(3, 1fr)` for clean 3x2 grids
- Replace aspirational department cards (Strategy, Support) with real plugin domains (Legal, Operations) -- all 6 cards now map to actual plugin domains
- Add missing "Review" workflow card between Build and Ship, rename "Learn & Grow" to "Compound" -- workflow now matches the actual 6-step lifecycle
- Tighten Sales card copy per CMO assessment

## Test plan

- [x] Built site locally with `npx @11ty/eleventy --serve`
- [x] Verified 3x2 grid renders correctly for both departments and workflow sections
- [x] Verified mobile breakpoint (2-column) handles 6 cards cleanly
- [x] CMO agent reviewed and approved all copy changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)