### PR TITLE
fix(docs): fix landing page layout and conversion per CMO/UX review (v2.31.6)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.31.5"
+      placeholder: "2.31.6"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 54 agents across engineering, marketing, legal, operations, and product -- compounding your company knowledge with every session.
 
-[![Version](https://img.shields.io/badge/version-2.31.5-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.31.6-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.31.5",
+  "version": "2.31.6",
   "description": "A full AI organization across engineering, marketing, legal, operations, and product. 54 agents, 8 commands, and 46 skills that compound your company knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.31.6] - 2026-02-22
+
+### Fixed
+
+- Fix orphaned "Knowledge Compounds" card at tablet breakpoint (769-1024px) by removing broken 2-col rule for problem-cards
+- Add 2-column responsive rule for department/workflow grids at tablet for clean 3x2 layout
+- Replace confusing "1 Automated Workflow" stat with "6 Departments" for clearer value communication
+- Add mid-page CTA between quote and features section per CMO conversion assessment
+- Increase spacing between department and workflow grid sections to reduce "wall of cards" effect
+
 ## [2.31.5] - 2026-02-22
 
 ### Fixed

--- a/plugins/soleur/docs/css/style.css
+++ b/plugins/soleur/docs/css/style.css
@@ -452,7 +452,7 @@
     display: flex;
     justify-content: space-around;
     align-items: center;
-    padding: var(--space-8) var(--space-5);
+    padding: var(--space-10) var(--space-5);
     background: var(--color-bg-secondary);
     border-top: 1px solid var(--color-border);
     border-bottom: 1px solid var(--color-border);
@@ -565,6 +565,12 @@
     color: var(--color-accent);
   }
 
+  /* Landing page: Mid-page CTA */
+  .landing-cta-mid {
+    text-align: center;
+    padding: var(--space-6) var(--space-5);
+  }
+
   /* Landing page: Feature grids (departments + workflow) */
   .feature-grid-departments,
   .feature-grid-workflow {
@@ -581,8 +587,8 @@
     color: var(--color-accent);
     text-transform: uppercase;
     text-align: center;
-    margin-top: var(--space-8);
-    margin-bottom: var(--space-4);
+    margin-top: var(--space-10);
+    margin-bottom: var(--space-5);
     max-width: 1200px;
     margin-inline: auto;
   }
@@ -932,7 +938,8 @@
   }
 
   @media (min-width: 769px) and (max-width: 1024px) {
-    .problem-cards { grid-template-columns: 1fr 1fr; }
+    .feature-grid-departments,
+    .feature-grid-workflow { grid-template-columns: repeat(2, 1fr); }
   }
 }
 

--- a/plugins/soleur/docs/index.njk
+++ b/plugins/soleur/docs/index.njk
@@ -22,8 +22,8 @@ permalink: index.html
     <!-- Stats Strip -->
     <section class="landing-stats" aria-label="Platform statistics">
       <div class="landing-stat">
-        <div class="landing-stat-value">1</div>
-        <div class="landing-stat-label">Automated Workflow</div>
+        <div class="landing-stat-value">6</div>
+        <div class="landing-stat-label">Departments</div>
       </div>
       <div class="landing-stat">
         <div class="landing-stat-value">{{ stats.agents }}</div>
@@ -71,6 +71,11 @@ permalink: index.html
         &ldquo;The first billion-dollar company run by one person isn&rsquo;t science fiction. It&rsquo;s an engineering problem. We&rsquo;re solving it.&rdquo;
       </blockquote>
       <cite>&mdash; The Soleur Thesis</cite>
+    </section>
+
+    <!-- Mid-page CTA -->
+    <section class="landing-cta-mid">
+      <a href="pages/getting-started.html" class="btn btn-primary">Start Building</a>
     </section>
 
     <!-- Features Section -->


### PR DESCRIPTION
## Summary

- Fix orphaned "Knowledge Compounds" card at tablet breakpoint (769-1024px) -- removed broken `1fr 1fr` rule for problem-cards that created 2+1 orphan
- Add `repeat(2, 1fr)` for department/workflow grids at tablet for clean 3x2 layout at every breakpoint
- Replace confusing "1 Automated Workflow" stat with "6 Departments" for clearer value communication (CMO flagged this as high-impact conversion issue)
- Add mid-page CTA ("Start Building") between quote and features sections -- catches visitors at peak interest before 12-card scroll
- Increase spacing between department and workflow grid sections to reduce "wall of cards" effect

### Breakpoint coverage (all clean, no orphans)

| Breakpoint | Problem cards (3) | Feature grids (6 each) |
|---|---|---|
| Desktop >1024px | 3x1 row | 3x2 grid |
| Tablet 769-1024px | 3x1 row | 2x3 grid |
| Mobile <=768px | 1-col stacked | 2x3 grid |

## Test plan

- [x] Desktop screenshot (1280px) -- verified 3x2 grids, mid-page CTA visible
- [x] Tablet screenshot (900px) -- verified no orphaned cards, clean 2-col grids
- [x] Mobile screenshot (375px) -- verified stacked/2-col layouts
- [x] CMO assessment completed with conversion-optimizer recommendations
- [x] All changes guided by CMO domain leader assessment

🤖 Generated with [Claude Code](https://claude.com/claude-code)