### PR TITLE
fix(docs): update landing page and legal docs for Finance and Support domains (v2.35.1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.35.0"
+      placeholder: "2.35.1"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 60 agents across engineering, finance, marketing, legal, operations, product, sales, and support -- compounding your company knowledge with every session.
 
-[![Version](https://img.shields.io/badge/version-2.35.0-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.35.1-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.35.0",
+  "version": "2.35.1",
   "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. 60 agents, 8 commands, 46 skills, and 3 MCP servers that compound your company knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.35.1] - 2026-02-22
+
+### Fixed
+
+- Update landing page department count from 7 to 8 and add Finance and Support department cards
+- Update landing page inline department list to include all 8 domains
+- Update landing page departments grid to 4-column layout for 8 cards (2 perfect rows)
+- Update terms and conditions from "58 AI agents across seven domains" to "60 AI agents across eight domains"
+
 ## [2.35.0] - 2026-02-22
 
 ### Added

--- a/plugins/soleur/docs/css/style.css
+++ b/plugins/soleur/docs/css/style.css
@@ -574,7 +574,13 @@
   }
 
   /* Landing page: Feature grids (departments + workflow) */
-  .feature-grid-departments,
+  .feature-grid-departments {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: var(--space-5);
+    max-width: 1200px;
+    margin-inline: auto;
+  }
   .feature-grid-workflow {
     display: grid;
     grid-template-columns: repeat(3, 1fr);

--- a/plugins/soleur/docs/index.njk
+++ b/plugins/soleur/docs/index.njk
@@ -22,7 +22,7 @@ permalink: index.html
     <!-- Stats Strip -->
     <section class="landing-stats" aria-label="Platform statistics">
       <div class="landing-stat">
-        <div class="landing-stat-value">7</div>
+        <div class="landing-stat-value">8</div>
         <div class="landing-stat-label">Departments</div>
       </div>
       <div class="landing-stat">
@@ -54,7 +54,7 @@ permalink: index.html
           <div class="problem-card">
             <div class="problem-card-icon" aria-hidden="true">&#x26A1;</div>
             <h3>Agents Execute</h3>
-            <p>Engineering, finance, marketing, sales, legal, operations &mdash; every department, running autonomously on your command.</p>
+            <p>Engineering, finance, marketing, sales, legal, operations, product, support &mdash; every department, running autonomously on your command.</p>
           </div>
           <div class="problem-card">
             <div class="problem-card-icon" aria-hidden="true">&#x1F504;</div>
@@ -113,6 +113,16 @@ permalink: index.html
             <div class="feature-card-icon" aria-hidden="true">&#x2699;&#xFE0F;</div>
             <h3>Operations</h3>
             <p>Vendor research, expense tracking, tool provisioning. Operational infrastructure that runs without overhead.</p>
+          </div>
+          <div class="feature-card">
+            <div class="feature-card-icon" aria-hidden="true">&#x1F4CA;</div>
+            <h3>Finance</h3>
+            <p>Budget planning, revenue analysis, financial reporting. Data-driven financial oversight without the back office.</p>
+          </div>
+          <div class="feature-card">
+            <div class="feature-card-icon" aria-hidden="true">&#x1F6E0;&#xFE0F;</div>
+            <h3>Support</h3>
+            <p>Issue triage, community management, ticket routing. Customer-facing operations that scale without headcount.</p>
           </div>
         </div>
         <h3 class="feature-grid-sublabel">The Workflow</h3>

--- a/plugins/soleur/docs/pages/legal/terms-and-conditions.md
+++ b/plugins/soleur/docs/pages/legal/terms-and-conditions.md
@@ -53,7 +53,7 @@ If you are using the Plugin on behalf of an organization, you represent and warr
 
 Soleur is a locally installed Claude Code plugin that provides:
 
-- **58 AI agents** organized across seven domains (Engineering, Finance, Legal, Marketing, Operations, Product, Sales)
+- **60 AI agents** organized across eight domains (Engineering, Finance, Legal, Marketing, Operations, Product, Sales, Support)
 - **46 skills** for structured software development workflows
 - A **compounding knowledge base** that stores project context locally
 - **Commands** for orchestrating development workflows (brainstorm, plan, review, work, ship)


### PR DESCRIPTION
## Summary

- Update landing page department count from 7 to 8
- Add Finance and Support department cards to landing page
- Update inline department list to include all 8 domains (was missing Product and Support)
- Change departments grid from 3-column to 4-column layout (8 cards = 2 perfect rows of 4)
- Update terms and conditions: "58 AI agents across seven domains" -> "60 AI agents across eight domains" + Support

## Context

These references were missed in #269 (Support domain) and #265 (Finance domain). The landing page `index.njk` and `terms-and-conditions.md` had hardcoded counts that weren't updated when the new domains were added.

## Test plan

- [x] Eleventy docs build passes (18 pages, no errors)
- [ ] Verify landing page renders 8 department cards in 4-column grid
- [ ] Verify stats strip shows "8 Departments"
- [ ] Verify terms and conditions shows "60 AI agents across eight domains"

🤖 Generated with [Claude Code](https://claude.com/claude-code)