### PR TITLE
refactor(docs): make department cards and legal doc counts data-driven (v2.36.1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "2.36.0"
+      placeholder: "2.36.1"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 60 agents across engineering, finance, marketing, legal, operations, product, sales, and support -- compounding your company knowledge with every session.
 
-[![Version](https://img.shields.io/badge/version-2.36.0-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-2.36.1-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "2.36.0",
+  "version": "2.36.1",
   "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. 60 agents, 9 commands, 46 skills, and 3 MCP servers that compound your company knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/AGENTS.md
+++ b/plugins/soleur/AGENTS.md
@@ -59,9 +59,13 @@ skills/
 To add a new domain (e.g., product, growth):
 
 1. Create `agents/<domain>/` for domain-specific agents
-2. Skills stay flat at root level (the skill loader does not recurse into subdirectories)
-3. Commands stay under `commands/soleur/` (they are domain-agnostic workflow orchestrators)
-4. The plugin loader discovers agents recursively -- no config changes needed
+2. Add `DOMAIN_META` entry in `docs/_data/agents.js` (label, icon, card description)
+3. Add key to `domainOrder` and `DOMAIN_CSS_VARS` in the same file
+4. Add CSS variable in `docs/css/style.css`
+5. Skills stay flat at root level (the skill loader does not recurse into subdirectories)
+6. Commands stay under `commands/soleur/` (they are domain-agnostic workflow orchestrators)
+7. The plugin loader discovers agents recursively -- no config changes needed
+8. Landing page department cards, stats, and legal doc counts update automatically from data
 
 ## Command Naming Convention
 
@@ -166,7 +170,7 @@ Domain leaders are agents that orchestrate a business domain's specialist team. 
 3. Add a row to the Domain Config table in `commands/soleur/brainstorm.md` Phase 0.5 with: domain name, assessment question, leader name, routing prompt, options, and task prompt
 4. Add disambiguation sentences to agents with overlapping scope in adjacent domains (both directions)
 5. Verify token budget: `shopt -s globstar && grep -h 'description:' agents/**/*.md | wc -w` (under 2,500)
-6. Update docs data files: `agents.js` (DOMAIN_LABELS, DOMAIN_CSS_VARS, domainOrder), `style.css` (CSS variable)
+6. Update docs data files: `agents.js` (DOMAIN_META, DOMAIN_CSS_VARS, domainOrder), `style.css` (CSS variable). Landing page and legal docs update automatically from data.
 7. Update AGENTS.md (directory tree, domain leader table) and README.md (agent section, counts)
 8. Version bump (MINOR) and CHANGELOG
 

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.36.1] - 2026-02-22
+
+### Changed
+
+- Make landing page department cards, count, and inline list data-driven from `agents.js` DOMAIN_META
+- Make legal doc agent/skill counts and domain lists data-driven via Eleventy template variables
+- Add `departments` count to `stats.js` (computed from non-empty agent directories)
+- Add `departmentList` string export to `agents.js` (comma-separated domain names)
+- Replace `DOMAIN_LABELS` with richer `DOMAIN_META` constant (label, icon, card description)
+- Update "Adding a New Domain" checklist to reflect auto-generated landing page and legal docs
+
+### Fixed
+
+- Fix stale counts in privacy-policy.md (was "45 agents, 45 skills") and acceptable-use-policy.md (was "45 agents and 45 skills")
+
 ## [2.36.0] - 2026-02-22
 
 ### Added

--- a/plugins/soleur/docs/_data/agents.js
+++ b/plugins/soleur/docs/_data/agents.js
@@ -2,15 +2,50 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join, resolve, relative } from "node:path";
 import yaml from "yaml";
 
-const DOMAIN_LABELS = {
-  engineering: "Engineering",
-  finance: "Finance",
-  legal: "Legal",
-  marketing: "Marketing",
-  operations: "Operations",
-  product: "Product",
-  sales: "Sales",
-  support: "Support",
+// Domain metadata: single source of truth for labels, landing-page icons, and card descriptions.
+// Adding a domain here (+ domainOrder + DOMAIN_CSS_VARS) is all that's needed --
+// the landing page and legal docs render from this data automatically.
+const DOMAIN_META = {
+  engineering: {
+    label: "Engineering",
+    icon: "&#x1F4BB;",
+    cardDescription: "Code review, architecture, security, quality testing. Specialized agents shipping production-grade code on your command.",
+  },
+  finance: {
+    label: "Finance",
+    icon: "&#x1F4CA;",
+    cardDescription: "Budget planning, revenue analysis, financial reporting. Data-driven financial oversight without the back office.",
+  },
+  legal: {
+    label: "Legal",
+    icon: "&#x2696;&#xFE0F;",
+    cardDescription: "Terms, privacy policies, compliance audits. Legal documents generated, reviewed, and kept current automatically.",
+  },
+  marketing: {
+    label: "Marketing",
+    icon: "&#x1F4E3;",
+    cardDescription: "Brand identity, community content, release announcements. Your public presence runs on autopilot.",
+  },
+  operations: {
+    label: "Operations",
+    icon: "&#x2699;&#xFE0F;",
+    cardDescription: "Vendor research, expense tracking, tool provisioning. Operational infrastructure that runs without overhead.",
+  },
+  product: {
+    label: "Product",
+    icon: "&#x1F4DA;",
+    cardDescription: "Product management, competitive analysis, planning &amp; specs, UX design. From market insight to shipped experience.",
+  },
+  sales: {
+    label: "Sales",
+    icon: "&#x1F4B0;",
+    cardDescription: "Outbound campaigns, deal qualification, pipeline analytics. AI-powered revenue operations from first outreach to closed-won.",
+  },
+  support: {
+    label: "Support",
+    icon: "&#x1F6E0;&#xFE0F;",
+    cardDescription: "Issue triage, community management, ticket routing. Customer-facing operations that scale without headcount.",
+  },
 };
 
 const SUB_LABELS = {
@@ -121,7 +156,7 @@ export default function () {
     const agent = {
       name: data.name || filename,
       description: extractSummary(body),
-      domain: DOMAIN_LABELS[domain] || domain,
+      domain: DOMAIN_META[domain]?.label || domain || domain,
       domainKey: domain,
       sub: sub ? (SUB_LABELS[sub] || sub) : null,
       subKey: sub,
@@ -169,14 +204,19 @@ export default function () {
     group.agents.sort((a, b) => a.name.localeCompare(b.name));
 
     domains.push({
-      name: DOMAIN_LABELS[key],
+      name: DOMAIN_META[key]?.label || key,
       key,
       count: totalCount,
+      icon: DOMAIN_META[key]?.icon || "",
+      cardDescription: DOMAIN_META[key]?.cardDescription || "",
       agents: group.agents,
       subcategories,
       cssVar: DOMAIN_CSS_VARS[key] || "var(--accent)",
     });
   }
 
-  return { domains };
+  return {
+    domains,
+    departmentList: domains.map((d) => d.name).join(", "),
+  };
 }

--- a/plugins/soleur/docs/_data/stats.js
+++ b/plugins/soleur/docs/_data/stats.js
@@ -20,6 +20,12 @@ export default function () {
 
   const agents = countMdFilesRecursive(agentsDir);
 
+  // Departments: count non-empty top-level directories under agents/
+  const departments = readdirSync(agentsDir, { withFileTypes: true })
+    .filter(
+      (e) => e.isDirectory() && countMdFilesRecursive(join(agentsDir, e.name)) > 0
+    ).length;
+
   // Skills: count directories that contain SKILL.md (flat, no recursion)
   let skills = 0;
   for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
@@ -38,5 +44,5 @@ export default function () {
     f.endsWith(".md")
   ).length;
 
-  return { agents, skills, commands };
+  return { agents, skills, commands, departments };
 }

--- a/plugins/soleur/docs/index.njk
+++ b/plugins/soleur/docs/index.njk
@@ -22,7 +22,7 @@ permalink: index.html
     <!-- Stats Strip -->
     <section class="landing-stats" aria-label="Platform statistics">
       <div class="landing-stat">
-        <div class="landing-stat-value">8</div>
+        <div class="landing-stat-value">{{ stats.departments }}</div>
         <div class="landing-stat-label">Departments</div>
       </div>
       <div class="landing-stat">
@@ -54,7 +54,7 @@ permalink: index.html
           <div class="problem-card">
             <div class="problem-card-icon" aria-hidden="true">&#x26A1;</div>
             <h3>Agents Execute</h3>
-            <p>Engineering, finance, marketing, sales, legal, operations, product, support &mdash; every department, running autonomously on your command.</p>
+            <p>{{ agents.departmentList | lower }} &mdash; every department, running autonomously on your command.</p>
           </div>
           <div class="problem-card">
             <div class="problem-card-icon" aria-hidden="true">&#x1F504;</div>
@@ -84,46 +84,13 @@ permalink: index.html
         <p class="section-label">Your AI Organization</p>
         <h2 class="section-title">Every department. From idea to shipped.</h2>
         <div class="feature-grid-departments">
+          {%- for domain in agents.domains %}
           <div class="feature-card">
-            <div class="feature-card-icon" aria-hidden="true">&#x1F4DA;</div>
-            <h3>Product</h3>
-            <p>Product management, competitive analysis, planning &amp; specs, UX design. From market insight to shipped experience.</p>
+            <div class="feature-card-icon" aria-hidden="true">{{ domain.icon | safe }}</div>
+            <h3>{{ domain.name }}</h3>
+            <p>{{ domain.cardDescription | safe }}</p>
           </div>
-          <div class="feature-card">
-            <div class="feature-card-icon" aria-hidden="true">&#x1F4BB;</div>
-            <h3>Engineering</h3>
-            <p>Code review, architecture, security, quality testing. Specialized agents shipping production-grade code on your command.</p>
-          </div>
-          <div class="feature-card">
-            <div class="feature-card-icon" aria-hidden="true">&#x1F4E3;</div>
-            <h3>Marketing</h3>
-            <p>Brand identity, community content, release announcements. Your public presence runs on autopilot.</p>
-          </div>
-          <div class="feature-card">
-            <div class="feature-card-icon" aria-hidden="true">&#x1F4B0;</div>
-            <h3>Sales</h3>
-            <p>Outbound campaigns, deal qualification, pipeline analytics. AI-powered revenue operations from first outreach to closed-won.</p>
-          </div>
-          <div class="feature-card">
-            <div class="feature-card-icon" aria-hidden="true">&#x2696;&#xFE0F;</div>
-            <h3>Legal</h3>
-            <p>Terms, privacy policies, compliance audits. Legal documents generated, reviewed, and kept current automatically.</p>
-          </div>
-          <div class="feature-card">
-            <div class="feature-card-icon" aria-hidden="true">&#x2699;&#xFE0F;</div>
-            <h3>Operations</h3>
-            <p>Vendor research, expense tracking, tool provisioning. Operational infrastructure that runs without overhead.</p>
-          </div>
-          <div class="feature-card">
-            <div class="feature-card-icon" aria-hidden="true">&#x1F4CA;</div>
-            <h3>Finance</h3>
-            <p>Budget planning, revenue analysis, financial reporting. Data-driven financial oversight without the back office.</p>
-          </div>
-          <div class="feature-card">
-            <div class="feature-card-icon" aria-hidden="true">&#x1F6E0;&#xFE0F;</div>
-            <h3>Support</h3>
-            <p>Issue triage, community management, ticket routing. Customer-facing operations that scale without headcount.</p>
-          </div>
+          {%- endfor %}
         </div>
         <h3 class="feature-grid-sublabel">The Workflow</h3>
         <div class="feature-grid-workflow">

--- a/plugins/soleur/docs/pages/legal/acceptable-use-policy.md
+++ b/plugins/soleur/docs/pages/legal/acceptable-use-policy.md
@@ -41,7 +41,7 @@ This Policy applies to all users globally, with specific provisions addressing c
 
 This Policy applies to all use of the Soleur platform, including but not limited to:
 
-- Interaction with Soleur's 45 AI agents and 45 skills;
+- Interaction with Soleur's {{ stats.agents }} AI agents and {{ stats.skills }} skills;
 - Execution of shell commands, code generation, and file manipulation through agents;
 - Browser automation via the agent-browser subsystem;
 - API interactions initiated by or through Soleur agents;

--- a/plugins/soleur/docs/pages/legal/privacy-policy.md
+++ b/plugins/soleur/docs/pages/legal/privacy-policy.md
@@ -38,7 +38,7 @@ For privacy inquiries, you may contact us at legal@jikigai.com (include "Privacy
 
 ## 3. What the Plugin Does
 
-Soleur is a locally installed Claude Code plugin. It provides 45 AI agents, 45 skills, and a compounding knowledge base to support structured software development workflows. The Plugin is installed via the Claude Code CLI and runs entirely on your local machine.
+Soleur is a locally installed Claude Code plugin. It provides {{ stats.agents }} AI agents, {{ stats.skills }} skills, and a compounding knowledge base to support structured software development workflows. The Plugin is installed via the Claude Code CLI and runs entirely on your local machine.
 
 ## 4. Data We Collect
 

--- a/plugins/soleur/docs/pages/legal/terms-and-conditions.md
+++ b/plugins/soleur/docs/pages/legal/terms-and-conditions.md
@@ -53,8 +53,8 @@ If you are using the Plugin on behalf of an organization, you represent and warr
 
 Soleur is a locally installed Claude Code plugin that provides:
 
-- **60 AI agents** organized across eight domains (Engineering, Finance, Legal, Marketing, Operations, Product, Sales, Support)
-- **46 skills** for structured software development workflows
+- **{{ stats.agents }} AI agents** organized across {{ stats.departments }} domains ({{ agents.departmentList }})
+- **{{ stats.skills }} skills** for structured software development workflows
 - A **compounding knowledge base** that stores project context locally
 - **Commands** for orchestrating development workflows (brainstorm, plan, review, work, ship)
 


### PR DESCRIPTION
## Summary

- Replace `DOMAIN_LABELS` in `agents.js` with `DOMAIN_META` (label + icon + card description) -- single source of truth for all domain metadata
- Add `departmentList` string export to `agents.js` and `departments` count to `stats.js`
- Replace 8 hardcoded department cards on landing page with `{% for domain in agents.domains %}` loop
- Replace hardcoded department count ("8") and inline list with template variables
- Replace hardcoded agent/skill counts in 3 legal docs with `{{ stats.agents }}` / `{{ stats.skills }}` / `{{ agents.departmentList }}`
- Update "Adding a New Domain" checklist in AGENTS.md

## Why

The landing page and legal docs kept getting missed when domains were added (#265 Finance, #269 Support, #270 fixup). Root cause: hardcoded values in templates while the data pipeline already had the correct counts. Now adding a domain requires only `agents.js` changes -- everything else renders from data.

## Also fixed

- `privacy-policy.md` still said "45 AI agents, 45 skills" (from initial generation)
- `acceptable-use-policy.md` still said "45 AI agents and 45 skills"

## Test plan

- [x] Eleventy build passes (18 pages, no errors)
- [x] Landing page: stats strip shows "8 Departments", "60 AI Agents", "46 Skills"
- [x] Landing page: 8 department cards rendered from data (14 total icons = 8 dept + 6 workflow)
- [x] Landing page: inline list shows all 8 domains lowercase
- [x] Terms & conditions: "60 AI agents organized across 8 domains (Engineering, Finance, ...Support)"
- [x] Privacy policy: "60 AI agents, 46 skills"
- [x] Acceptable use policy: "60 AI agents and 46 skills"
- [x] No double-escaping of HTML entities (icons render as emoji, `&amp;` renders correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)