### PR TITLE
docs: add CaaS tier to competitive landscape

### DIFF
--- a/knowledge-base/overview/business-validation.md
+++ b/knowledge-base/overview/business-validation.md
@@ -43,7 +43,7 @@ The user can name 2-3 real contacts who fit the profile, falling short of the 5-
 
 ## Competitive Landscape
 
-The competitive landscape spans four tiers, from closest substitutes to loosest alternatives.
+The competitive landscape spans five tiers, from closest substitutes to loosest alternatives.
 
 **Tier 1: Claude Code plugins (closest substitutes)**
 
@@ -58,14 +58,29 @@ The competitive landscape spans four tiers, from closest substitutes to loosest 
 | [Lindy.ai](https://lindy.ai) | No-code AI agent builder for business workflows (email, scheduling, sales) | Horizontal agent builder, not integrated into the development workflow. Agents are standalone, not part of a unified organization with shared memory. |
 | [Relevance AI](https://relevanceai.com) | AI workforce platform with agent teams for sales, support, and research | Enterprise-focused, sales-heavy. No engineering domain. Not designed for solo founders. |
 
-**Tier 3: AI agent frameworks**
+**Tier 3: Company-as-a-Service / full-stack business platforms**
+
+| Competitor | Approach | Differentiation from Soleur |
+|---|---|---|
+| [SoloCEO](https://soloceoai.com) | AI executive board: 12 AI board members (CFO, CMO, COO, etc.) analyze business simultaneously. $2,000 diagnostic, beta 2026. | Closest CaaS competitor. Advisory-only (diagnostic + recommendations), not operational. One-time analysis, not an ongoing workflow. No engineering domain, no compounding knowledge base. |
+| [Tanka](https://tanka.ai) | AI co-founder platform with persistent memory, smart replies, landing page generation. Integrates Slack, WhatsApp, Gmail, Notion. | Memory-native like Soleur, but communication-centric. No engineering workflow, no legal domain, no structured knowledge base that compounds across business domains. |
+| [Lovable.dev](https://lovable.dev) | AI full-stack React app builder. $20M ARR in 2 months. | Website/app generation only. No legal, marketing, ops, or finance domains. No institutional memory across sessions. |
+| [Bolt.new](https://bolt.new) | AI web app builder with framework flexibility. ~$100M ARR projected 2025. | Fastest to prototype but engineering-only. No cross-domain agents or compounding knowledge base. |
+| [v0.dev](https://v0.dev) | Vercel's AI Next.js app generator with built-in databases. | Highest code quality but engineering-only. No business operations, no multi-domain workflow. |
+| [Replit Agent](https://replit.com) | Autonomous coding agent with 30+ integrations. Cloud-hosted. | Most autonomous for coding but no marketing, legal, or product domains. Cloud-hosted, not local-first. |
+| [Notion AI 3.0](https://notion.com) | Autonomous AI agents across workspace (docs, databases, projects). Multi-model (GPT-5.2, Claude Opus, Gemini). | Broadest platform but shallow per domain. No engineering workflow (code review, deployment), no legal, no structured business validation. Workspace tool, not a business operating system. |
+| [Systeme.io](https://systeme.io) | All-in-one marketing platform: funnels, email, courses, websites. $17/month. | Marketing and sales only. No engineering, legal, or product domains. Workflow automation, not AI intelligence. |
+| [Stripe Atlas](https://stripe.com/atlas) | Delaware C-corp formation + banking + payments. $500 one-time. | Legal formation only. One-time event, not ongoing operations. No AI, no agents, no compounding knowledge. |
+| [Firstbase](https://firstbase.io) | Global company formation with banking, payroll, accounting integrations. | Broader than Atlas but still formation-focused. No engineering, marketing, or product domains. No AI workflow. |
+
+**Tier 4: AI agent frameworks**
 
 | Competitor | Approach | Differentiation from Soleur |
 |-----------|----------|---------------------------|
 | [Crew AI](https://crewai.com) | Multi-agent orchestration framework for building AI teams | Framework, not a product. Requires significant setup. No built-in business domains. |
 | [AutoGPT / AgentGPT](https://agentgpt.rber.dev) | Autonomous AI agents that chain tasks | General-purpose autonomy, not domain-specific. No institutional memory, no knowledge base that compounds. |
 
-**Tier 4: DIY stack (AI coding tools used individually)**
+**Tier 5: DIY stack (AI coding tools used individually)**
 
 | Competitor | Platform | Overlap |
 |-----------|----------|---------|
@@ -77,13 +92,15 @@ The competitive landscape spans four tiers, from closest substitutes to loosest 
 
 1. **Compounding knowledge base:** Every domain feeds a shared institutional memory that persists across sessions. The brand guide informs marketing content, the legal audit references the privacy policy, the business validation draws on the competitive landscape. This cross-domain coherence is not possible when using separate tools for each function. The 100th session is dramatically more productive than the 1st.
 2. **Full-stack 8-domain integration:** Engineering, marketing, legal, operations, product, finance, sales, and support agents share context within a single workflow. Competitors either do engineering well but nothing else, or do business automation well but not engineering.
+3. **Operational continuity vs. one-time diagnostics:** SoloCEO and Stripe Atlas provide point-in-time outputs (a diagnostic report, incorporation papers). Soleur operates continuously -- agents learn from prior decisions and cross-domain coherence deepens over time.
+4. **Full-domain coverage vs. partial overlap:** Every CaaS competitor covers 1-3 domains. Lovable/Bolt/v0 cover engineering. Systeme.io covers marketing/sales. Tanka covers communication. SoloCEO covers advisory across domains but not execution. Only Soleur covers all 8 domains as an integrated operating system.
 
 **Vulnerabilities:**
 
 1. **Platform dependency:** Anthropic could build multi-domain capabilities into Claude Code directly. Mitigation: Soleur's value is in the curated agent behaviors and accumulated knowledge, not in the plugin infrastructure.
 2. **Breadth vs. depth trade-off:** 65+ agents across 8 domains means each domain gets fewer resources than a dedicated tool. Mitigation: The integration IS the product -- a mediocre-but-connected marketing agent is more valuable to a solo founder than an excellent-but-isolated marketing tool.
 
-**Assessment:** PASS. The competitive landscape validates the thesis. Multiple funded companies are building AI agent workforces, confirming the market direction. None combine engineering depth with business breadth the way Soleur does. The structural advantages (compounding knowledge, cross-domain coherence) are genuine moats that competitors cannot easily replicate without rebuilding from scratch.
+**Assessment:** PASS. The expanded five-tier competitive landscape validates the thesis. The new CaaS tier reveals more competitors than previously mapped, but none achieve full 8-domain integration with a compounding knowledge base. The closest competitor (SoloCEO) offers multi-domain advisory but not operational execution. The closest operational competitor (Tanka) has memory but lacks domain breadth. Multiple funded companies are building AI agent workforces, confirming the market direction. The structural advantages (compounding knowledge, cross-domain coherence, operational continuity) are genuine moats that competitors cannot easily replicate without rebuilding from scratch.
 
 ## Demand Evidence
 

--- a/knowledge-base/plans/archive/20260224-081618-2026-02-24-fix-competitive-landscape-tables-and-tiers-plan.md
+++ b/knowledge-base/plans/archive/20260224-081618-2026-02-24-fix-competitive-landscape-tables-and-tiers-plan.md
@@ -1,0 +1,187 @@
+---
+title: "fix: Competitive Landscape table formatting and missing CaaS tier"
+type: fix
+date: 2026-02-24
+---
+
+# fix: Competitive Landscape table formatting and missing CaaS tier
+
+## Enhancement Summary
+
+**Deepened on:** 2026-02-24
+**Sections enhanced:** 4 (Proposed Solution, Acceptance Criteria, Test Scenarios, Context)
+**Research conducted:** Markdown table formatting best practices, competitive landscape analysis frameworks, AI website/app builders (Lovable, Bolt, v0, Replit), AI co-founder platforms (Tanka, SoloCEO), all-in-one business platforms (Systeme.io), company formation services (Stripe Atlas, Firstbase), Notion AI 3.0 agents
+
+### Key Improvements
+1. Added SoloCEO as a critical competitor -- the closest direct competitor to Soleur's "AI executive board" positioning, with 12 AI board members analyzing business simultaneously ($2,000 diagnostic, beta in 2026)
+2. Added Notion AI 3.0 as a competitor -- autonomous agents across workspace, integrates with Claude via MCP, broad but shallow across domains
+3. Restructured tier numbering recommendation: insert new tier as Tier 3 (renumber current Tiers 3-4 to 4-5) rather than appending as Tier 5, since CaaS platforms are closer substitutes than agent frameworks
+4. Added concrete markdown formatting rules from GitHub docs: minimum 3 hyphens per separator column, blank line before tables, consistent pipe delimiters
+5. Added competitive landscape framework guidance: primary/secondary/tertiary categorization maps to the tiered structure
+
+### New Considerations Discovered
+- SoloCEO ($2,000 diagnostic, 12 AI board members) is the most direct CaaS competitor and was missing from the original plan
+- Notion AI 3.0 (launched Sep 2025) added autonomous agents that can execute multi-step workflows -- broader platform overlap than previously assessed
+- The sub-category structure may be over-engineering the tier; consider a flat Tier 3 table with all CaaS competitors in one table, using the "Approach" column to distinguish website builders vs operations vs formation
+- The "Assessment" update should note that while more competitors now overlap, none achieve full 8-domain integration, preserving the PASS verdict
+
+## Overview
+
+The Competitive Landscape section of `knowledge-base/overview/business-validation.md` has two issues:
+
+1. **Table formatting problems** -- The markdown tables in Tiers 1-4 use inconsistent column headers across tiers (Tier 1 uses "Overlap", Tier 4 uses "Platform" and "Overlap" instead of "Approach" and "Differentiation from Soleur"). The separator lines use unbalanced dash counts that may render poorly in some markdown renderers. Column content is also unevenly distributed -- some cells contain 2-3 sentences while headers suggest short entries.
+
+2. **Missing CaaS/full-stack platform tier** -- The four tiers cover Claude Code plugins (Tier 1), no-code AI agent platforms (Tier 2), AI agent frameworks (Tier 3), and DIY AI coding tools (Tier 4). None cover the category Soleur is actually creating: Company-as-a-Service / "website + business as a service" platforms. These are platforms that combine website/app building with business operations (legal, marketing, ops) into an integrated offering for solo founders. This is a significant gap because Soleur's brand positioning is explicitly "The Company-as-a-Service Platform" -- the competitive landscape should include the closest competitors in that same category.
+
+## Problem Statement
+
+The current competitive landscape has a blind spot: it only benchmarks Soleur against AI coding tools and agent platforms, not against the emerging category of full-stack "company builder" platforms that combine website generation, business operations, and AI automation. Competitors like Lovable.dev, Bolt.new, v0.dev (website-as-a-service), Systeme.io (all-in-one business platform), Tanka (AI co-founder), SoloCEO (AI executive board), and Stripe Atlas / Firstbase (company formation-as-a-service) all overlap with parts of what Soleur does. Without this tier, the assessment overstates the competitive moat.
+
+### Research Insights
+
+**Competitive landscape analysis best practices:**
+
+Standard competitive analysis frameworks (SWOT, Porter's Five Forces, Strategic Group Analysis) categorize competitors into primary, secondary, and tertiary groups. The current 4-tier structure maps well to this: Tier 1 = primary (closest substitutes), Tiers 2-3 = secondary (partial overlap), Tier 4 = tertiary (loosest alternatives). The missing CaaS tier is arguably primary or high-secondary -- platforms that target the exact same customer (solo founders wanting to run a full company) with partial domain overlap.
+
+**Market validation for the CaaS category:**
+
+- Solo-founder-led startups grew from 23.7% (2019) to 36.3% (mid-2025) of new US companies ([Carta Solo Founders Report 2025](https://carta.com/data/solo-founders-report/))
+- Vibe coding platforms (Lovable, Bolt, v0) reached massive scale rapidly: Lovable $20M ARR in 2 months, Bolt projected $100M ARR by end of 2025
+- AI co-founder platforms are an emerging category: Tanka launched at TechCrunch Sessions: AI (June 2025), SoloCEO entered beta in early 2026
+- The "AI chief of staff" concept is gaining traction, with founders using Claude projects as persistent business advisors
+
+## Proposed Solution
+
+### Fix 1: Normalize table formatting
+
+- Standardize all four tiers to use the same three columns: `Competitor | Approach | Differentiation from Soleur`
+- Balance separator line dash counts to match column width proportionally
+- Keep cell content concise -- one sentence per cell where possible, two maximum
+
+### Research Insights: Markdown Table Formatting
+
+**GitHub Flavored Markdown (GFM) table rules ([GitHub Docs](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables)):**
+
+- Each column in the separator row requires a minimum of 3 hyphens (`---`)
+- A blank line must precede the table for correct rendering
+- Outer pipes (at start and end of each row) are optional but improve readability and make git diffs cleaner
+- Column alignment uses colons: `:---` (left), `:---:` (center), `---:` (right)
+- Cells can vary in width -- they do not need to be perfectly aligned in source
+- Links, bold, code, and other inline formatting work inside cells
+
+**Recommended format for all tiers:**
+
+```markdown
+| Competitor | Approach | Differentiation from Soleur |
+|---|---|---|
+| [Name](url) | One-sentence description. | One-sentence differentiation. |
+```
+
+The minimal `|---|---|---|` separator is the most maintainable. Do not attempt to align dash counts to column widths -- GitHub ignores visual alignment in source and renders proportionally based on content.
+
+### Fix 2: Add new tier -- Company-as-a-Service / Full-stack business platforms
+
+**Tier placement decision:** Insert as **Tier 3** (renumber current Tier 3 "AI agent frameworks" to Tier 4, current Tier 4 "DIY stack" to Tier 5). Rationale: CaaS platforms are closer substitutes to Soleur than agent frameworks or individual coding tools -- they target the same customer (solo founders) with the same promise (run a company without a team). The tier ordering should reflect proximity of substitution, not technology category.
+
+**Structure decision:** Use a flat table (all competitors in one tier) rather than sub-category tables. Sub-categories fragment the comparison and make it harder to scan. The "Approach" column naturally distinguishes website builders from operations platforms from formation services. This follows the existing document's pattern where each tier is one table.
+
+**Complete Tier 3 table:**
+
+| Competitor | Approach | Differentiation from Soleur |
+|---|---|---|
+| [SoloCEO](https://soloceoai.com) | AI executive board: 12 AI board members (CFO, CMO, COO, etc.) analyze business simultaneously. $2,000 diagnostic, beta 2026. | Closest CaaS competitor. Advisory-only (diagnostic + recommendations), not operational. One-time analysis, not an ongoing workflow. No engineering domain, no compounding knowledge base. |
+| [Tanka](https://tanka.ai) | AI co-founder platform with persistent memory, smart replies, landing page generation. Integrates Slack, WhatsApp, Gmail, Notion. | Memory-native like Soleur, but communication-centric. No engineering workflow, no legal domain, no structured knowledge base that compounds across business domains. |
+| [Lovable.dev](https://lovable.dev) | AI full-stack React app builder. $20M ARR in 2 months. | Website/app generation only. No legal, marketing, ops, or finance domains. No institutional memory across sessions. |
+| [Bolt.new](https://bolt.new) | AI web app builder with framework flexibility. ~$100M ARR projected 2025. | Fastest to prototype but engineering-only. No cross-domain agents or compounding knowledge base. |
+| [v0.dev](https://v0.dev) | Vercel's AI Next.js app generator with built-in databases. | Highest code quality but engineering-only. No business operations, no multi-domain workflow. |
+| [Replit Agent](https://replit.com) | Autonomous coding agent with 30+ integrations. Cloud-hosted. | Most autonomous for coding but no marketing, legal, or product domains. Cloud-hosted, not local-first. |
+| [Notion AI 3.0](https://notion.com) | Autonomous AI agents across workspace (docs, databases, projects). Multi-model (GPT-5.2, Claude Opus, Gemini). | Broadest platform but shallow per domain. No engineering workflow (code review, deployment), no legal, no structured business validation. Workspace tool, not a business operating system. |
+| [Systeme.io](https://systeme.io) | All-in-one marketing platform: funnels, email, courses, websites. $17/month. | Marketing and sales only. No engineering, legal, or product domains. Workflow automation, not AI intelligence. |
+| [Stripe Atlas](https://stripe.com/atlas) | Delaware C-corp formation + banking + payments. $500 one-time. | Legal formation only. One-time event, not ongoing operations. No AI, no agents, no compounding knowledge. |
+| [Firstbase](https://firstbase.io) | Global company formation with banking, payroll, accounting integrations. | Broader than Atlas but still formation-focused. No engineering, marketing, or product domains. No AI workflow. |
+
+### Fix 3: Update structural advantages and assessment
+
+After adding the new tier, update the "Structural advantages" and "Assessment" sections to acknowledge the new competitors:
+
+**Structural advantages -- additions:**
+
+3. **Operational continuity vs. one-time diagnostics:** SoloCEO and Stripe Atlas provide point-in-time outputs (a diagnostic report, incorporation papers). Soleur operates continuously -- the 100th session builds on the 99th. The knowledge base compounds, agents learn from prior decisions, and cross-domain coherence deepens over time.
+4. **Full-domain coverage vs. partial overlap:** Every CaaS competitor covers 1-3 domains. Lovable/Bolt/v0 cover engineering. Systeme.io covers marketing/sales. Tanka covers communication. SoloCEO covers advisory across domains but not execution. Only Soleur covers engineering + marketing + legal + operations + product + finance + sales + support as an integrated operating system.
+
+**Assessment update -- key sentence to add:**
+
+"The new CaaS tier reveals more competitors than previously mapped, but none achieve full 8-domain integration with a compounding knowledge base. The closest competitor (SoloCEO) offers multi-domain advisory but not operational execution. The closest operational competitor (Tanka) has memory but lacks domain breadth. The competitive moat remains: integrated breadth + compounding depth is structurally difficult to replicate."
+
+## Acceptance Criteria
+
+- [ ] All markdown tables in the Competitive Landscape section render correctly in GitHub markdown preview
+- [ ] All tiers use consistent column headers: `Competitor | Approach | Differentiation from Soleur`
+- [ ] Table separator lines use `|---|---|---|` format (minimum 3 hyphens, consistent across all tiers)
+- [ ] Blank line precedes every table (GitHub rendering requirement)
+- [ ] A new Tier 3 covers CaaS / full-stack business platforms (SoloCEO, Tanka, Lovable, Bolt, v0, Replit Agent, Notion AI, Systeme.io, Stripe Atlas, Firstbase)
+- [ ] Current Tier 3 (AI agent frameworks) renumbered to Tier 4
+- [ ] Current Tier 4 (DIY stack) renumbered to Tier 5
+- [ ] Each competitor entry includes a working URL, a concise approach description, and clear differentiation from Soleur
+- [ ] The "Structural advantages" section adds points about operational continuity and full-domain coverage
+- [ ] The "Assessment" section acknowledges the expanded landscape while preserving the PASS verdict
+- [ ] The `last_updated` frontmatter date is updated to 2026-02-24
+
+## Test Scenarios
+
+- Given the updated business-validation.md, when rendered in GitHub's markdown preview, then all tables display with properly aligned columns and no broken formatting
+- Given the new CaaS tier, when a reader scans the competitive landscape, then they can find the closest competitors to Soleur's "Company-as-a-Service" positioning (SoloCEO, Tanka at the top)
+- Given the updated structural advantages, when compared against the new tier's competitors, then Soleur's differentiation (8-domain integration + compounding knowledge base + operational continuity) is clearly articulated
+- Given the tier renumbering, when reading tiers in order (1 through 5), then proximity of substitution decreases monotonically (closest competitors first, loosest alternatives last)
+- Given the normalized tables, when all tier tables are compared, then every table uses the same 3-column format (`Competitor | Approach | Differentiation from Soleur`)
+
+## Context
+
+- **File to modify:** `knowledge-base/overview/business-validation.md` (lines 44-86, expanding to approximately lines 44-120 after additions)
+- **Brand guide positioning:** "The Company-as-a-Service Platform" -- the competitive landscape must benchmark against this category
+- **Existing learning:** `knowledge-base/learnings/2026-02-19-full-landscape-discovery-audit.md` confirms that Soleur's differentiation is lifecycle integration and domain-specific tooling, not individual features. This aligns with the new tier's analysis: CaaS competitors each cover 1-3 domains, but none integrate 8 domains with a compounding knowledge base.
+- **Business validation agent pattern:** `knowledge-base/learnings/2026-02-22-business-validation-agent-pattern.md` documents the heading contract (`##` headings) used by the business-validator agent. Preserve all existing `##` headings to maintain parsing compatibility.
+
+### Research sources
+
+**Competitive landscape frameworks:**
+- [Competitive Landscape Analysis for Startups: Guide 2026](https://qubit.capital/blog/competitive-landscape-analysis) -- primary/secondary/tertiary tier framework
+- [How to Do a Competitive Landscape Analysis (Klue)](https://klue.com/blog/competitive-landscape-analysis-guide) -- categorization best practices
+
+**Markdown formatting:**
+- [GitHub Docs: Organizing information with tables](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables) -- GFM table spec
+- [Tables in Markdown: Complete Guide](https://www.glukhov.org/post/2025/11/tables-in-markdown/) -- formatting best practices
+
+**Competitor research:**
+- [SoloCEO](https://soloceoai.com) -- AI executive board, 12 board members, $2,000 diagnostic
+- [Tanka AI](https://tanka.ai) -- AI co-founder, launched TechCrunch Sessions June 2025, memory-native
+- [Lovable.dev](https://lovable.dev) -- $20M ARR in 2 months, fastest-growing European startup
+- [Bolt.new](https://bolt.new) -- $40M ARR by March 2025, projected $100M by end 2025
+- [v0.dev](https://v0.dev) -- Vercel's Next.js AI generator, 9/10 code quality rating
+- [Replit Agent](https://replit.com) -- 30+ integrations, most autonomous coding agent
+- [Notion 3.0 AI Agents](https://www.notion.com/releases/2025-09-18) -- autonomous workspace agents, Sep 2025
+- [Systeme.io](https://systeme.io) -- $17/month, bootstrapped by solo founder Aurelian Amacker
+- [Stripe Atlas](https://stripe.com/atlas) -- $500 one-time, Delaware C-corp formation
+- [Firstbase](https://firstbase.io) -- global company formation, banking/payroll integrations
+- [Carta Solo Founders Report 2025](https://carta.com/data/solo-founders-report/) -- 36.3% solo-founded companies
+
+**Market context:**
+- [Best AI App Builder 2026](https://getmocha.com/blog/best-ai-app-builder-2026/) -- Lovable vs Bolt vs v0 vs Mocha comparison
+- [AI Co-Founder: Is Tanka the Answer?](https://entrepreneurloop.com/ai-co-founder-tanka-solo-founder-overload-2026/) -- Tanka positioning analysis
+- [12 AI Tools Every Solo Founder Needs](https://entrepreneurloop.com/ai-tools-to-scale-solo-business/) -- tool landscape overview
+
+## Non-goals
+
+- Do not restructure sections outside the Competitive Landscape (Problem, Customer, Demand Evidence, Business Model, etc.)
+- Do not change the overall PASS assessment for Competitive Landscape -- the new tier reveals more competitors but none achieve full-domain integration, preserving the moat thesis
+- Do not add competitors that are purely engineering tools (already covered in Tiers 1 and 4/5)
+- Do not add Devin AI ($500/month enterprise autonomous agent) -- engineering-only, enterprise-focused, already covered by the coding tools tier
+- This is a content fix, not a code change -- no plugin version bump required
+- Do not break the heading contract (`##` headings) used by the business-validator agent for document parsing
+
+## References
+
+- `knowledge-base/overview/business-validation.md` -- the file to modify
+- `knowledge-base/overview/brand-guide.md` -- CaaS positioning reference ("The Company-as-a-Service Platform")
+- `knowledge-base/learnings/2026-02-19-full-landscape-discovery-audit.md` -- validates lifecycle integration as the moat
+- `knowledge-base/learnings/2026-02-22-business-validation-agent-pattern.md` -- heading contract to preserve

--- a/knowledge-base/specs/archive/20260224-081618-feat-fix-competitive-landscape/session-state.md
+++ b/knowledge-base/specs/archive/20260224-081618-feat-fix-competitive-landscape/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/plans/2026-02-24-fix-competitive-landscape-tables-and-tiers-plan.md
+- Status: complete
+
+### Errors
+None
+
+### Decisions
+- Tier placement: Insert CaaS competitors as new Tier 3 (renumber existing Tiers 3-4 to 4-5)
+- Flat table over sub-categories: Use a single flat table for the CaaS tier
+- Added two critical missing competitors: SoloCEO and Notion AI 3.0
+- Preserve PASS verdict: The new tier reveals more competitors but none achieve full 8-domain integration
+- Heading contract preservation: ## headings must be preserved for business-validator agent parsing
+- USER UPDATE: Table formatting is fine (was a Warp rendering issue, not a markdown issue) -- skip Fix 1
+
+### Components Invoked
+- soleur:plan
+- soleur:deepen-plan

--- a/knowledge-base/specs/archive/20260224-081618-feat-fix-competitive-landscape/tasks.md
+++ b/knowledge-base/specs/archive/20260224-081618-feat-fix-competitive-landscape/tasks.md
@@ -1,0 +1,33 @@
+# Tasks: Fix Competitive Landscape Tables and Tiers
+
+## Phase 1: Table Formatting Normalization
+
+- [ ] 1.1 Standardize all existing tier tables to use `Competitor | Approach | Differentiation from Soleur` headers
+- [ ] 1.2 Fix Tier 1 table: rename "Overlap" column to "Approach"
+- [ ] 1.3 Fix current Tier 4 table: rename "Platform" to "Approach", rename "Overlap" to "Differentiation from Soleur"
+- [ ] 1.4 Normalize all separator lines to `|---|---|---|` format
+- [ ] 1.5 Ensure blank line precedes every table (GFM rendering requirement)
+- [ ] 1.6 Trim verbose cell content to 1-2 sentences maximum per cell
+
+## Phase 2: Add CaaS Tier (New Tier 3)
+
+- [ ] 2.1 Insert new section: **Tier 3: Company-as-a-Service / Full-stack business platforms**
+- [ ] 2.2 Add flat table with 10 competitors: SoloCEO, Tanka, Lovable.dev, Bolt.new, v0.dev, Replit Agent, Notion AI 3.0, Systeme.io, Stripe Atlas, Firstbase
+- [ ] 2.3 Verify all competitor URLs are valid and working
+- [ ] 2.4 Renumber current Tier 3 (AI agent frameworks) to Tier 4
+- [ ] 2.5 Renumber current Tier 4 (DIY stack) to Tier 5
+
+## Phase 3: Update Analysis Sections
+
+- [ ] 3.1 Add structural advantage #3: operational continuity vs. one-time diagnostics
+- [ ] 3.2 Add structural advantage #4: full-domain coverage vs. partial overlap
+- [ ] 3.3 Update "Assessment" to acknowledge expanded landscape while preserving PASS verdict
+- [ ] 3.4 Update `last_updated` frontmatter date to 2026-02-24
+
+## Phase 4: Verification
+
+- [ ] 4.1 Render markdown in GitHub preview to verify all tables display correctly
+- [ ] 4.2 Verify no broken links across all competitor URLs
+- [ ] 4.3 Verify `##` heading contract is preserved (business-validator agent parsing compatibility)
+- [ ] 4.4 Verify tier ordering reflects proximity of substitution (closest first, loosest last)
+- [ ] 4.5 Verify all tiers use consistent 3-column format


### PR DESCRIPTION
## Summary
- Adds new **Tier 3: Company-as-a-Service / full-stack business platforms** with 10 competitors (SoloCEO, Tanka, Lovable, Bolt, v0, Replit Agent, Notion AI 3.0, Systeme.io, Stripe Atlas, Firstbase)
- Renumbers existing Tiers 3-4 to Tiers 4-5 to maintain proximity-of-substitution ordering
- Adds two new structural advantages: operational continuity and full-domain coverage
- Updates assessment to acknowledge expanded 5-tier landscape while preserving PASS verdict

## Test plan
- [ ] Verify all markdown tables render correctly in GitHub preview
- [ ] Verify tier numbering is sequential (1-5)
- [ ] Verify `##` heading structure preserved for business-validator agent compatibility
- [ ] Verify all competitor URLs are valid links

🤖 Generated with [Claude Code](https://claude.com/claude-code)