### PR TITLE
fix(guardrails): catch git commit in chained commands on main

### DIFF
--- a/.claude/hooks/guardrails.sh
+++ b/.claude/hooks/guardrails.sh
@@ -8,7 +8,9 @@ INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
 
 # Guard 1: Block git commit on main branch
-if echo "$COMMAND" | grep -qE '^\s*git\s+commit'; then
+# Match git commit at start of string OR after chain operators (&&, ||, ;)
+# so chained commands like "git add && git commit" are caught.
+if echo "$COMMAND" | grep -qE '(^|&&|\|\||;)\s*git\s+commit'; then
   BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
   if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
     echo '{"decision":"block","reason":"BLOCKED: Committing directly to main/master is not allowed. Create a feature branch first."}'

--- a/knowledge-base/learnings/2026-02-24-guardrails-chained-commit-bypass.md
+++ b/knowledge-base/learnings/2026-02-24-guardrails-chained-commit-bypass.md
@@ -1,0 +1,31 @@
+# Learning: Guard 1 bypassed by chained git commands
+
+## Problem
+
+Guard 1 in `.claude/hooks/guardrails.sh` used `^\s*git\s+commit` to block commits on main. The `^` anchor only matches `git commit` at the start of the command string. Chained commands like `git add file && git commit -m "msg"` start with `git add`, so the anchor never matches and the commit goes through unblocked.
+
+This allowed two commits directly to main in violation of the branching hard rule.
+
+## Solution
+
+Replace the `^` anchor with an alternation that matches `git commit` at command boundaries:
+
+```bash
+# Before (bypassed by chaining)
+grep -qE '^\s*git\s+commit'
+
+# After (catches chained commands)
+grep -qE '(^|&&|\|\||;)\s*git\s+commit'
+```
+
+The pattern now matches `git commit` at start of string OR after `&&`, `||`, or `;` chain operators.
+
+## Key Insight
+
+When guarding against specific commands in a shell string, never anchor to `^` alone. The Bash tool routinely chains commands with `&&` for sequential execution. A `^`-anchored pattern only catches the first command in the chain, leaving subsequent commands unguarded. Match at command boundaries instead: `(^|&&|\|\||;)`.
+
+This is the third guardrail grep pattern bug in this file -- all three had the same root cause of insufficient context matching. Guard patterns should be reviewed holistically whenever one is fixed.
+
+## Tags
+category: safety-mechanisms
+module: .claude/hooks/guardrails.sh

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -29,6 +29,7 @@ Project principles organized by domain. Add principles as you learn them.
 
 - Avoid second person ("you should") - use objective language ("To accomplish X, do Y")
 - Never use shell variable expansion (`${VAR}`, `$VAR`, `$()`) in bash code blocks within skill, command, or agent .md files -- use angle-bracket prose placeholders (`<variable-name>`) with substitution instructions instead, or relative paths (e.g., `./plugins/soleur/...`) for plugin-relative paths; the ship skill's "No command substitution" pattern is the reference implementation
+- Never anchor guardrail grep patterns to `^` alone -- the Bash tool chains commands with `&&`, `;`, and `||`, so a `^`-anchored pattern only catches the first command; match at command boundaries with `(^|&&|\|\||;)` instead
 
 ### Prefer
 


### PR DESCRIPTION
## Summary
- Guard 1 in `guardrails.sh` used `^\s*git\s+commit` which only matched `git commit` at the start of a command string
- Chained commands like `git add && git commit` bypassed the guard, allowing 2 direct commits to main
- Fixed by replacing `^` anchor with `(^|&&|\|\||;)` to match at command boundaries

## Changes
- `.claude/hooks/guardrails.sh` — Guard 1 pattern updated
- `knowledge-base/learnings/` — New learning documenting the bypass
- `knowledge-base/overview/constitution.md` — New "Never" principle for guardrail anchoring

## Test plan
- [x] `git commit -m "msg"` at start of string: MATCH
- [x] `git add && git commit -m "msg"` chained: MATCH
- [x] `git add ; git commit -m "msg"` semicolon chain: MATCH
- [x] `echo "git commit"` in unrelated text: NO MATCH
- [x] `gh issue comment --body "git commit"` in comment body: NO MATCH

🤖 Generated with [Claude Code](https://claude.com/claude-code)