### PR TITLE
fix(git-worktree): cleanup-merged silent pull failure (v3.2.1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "3.2.0"
+      placeholder: "3.2.1"
     validations:
       required: true
   - type: input

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ This repository contains the Soleur Claude Code plugin. Detailed conventions liv
 - Never `git stash` in worktrees. Commit WIP first, then merge.
 - Never `rm -rf` on the current directory, a worktree path, or the repo root.
 - MCP tools (Playwright, etc.) resolve paths from the repo root, not the shell CWD. Always pass absolute paths to MCP tools when in a worktree.
+- When a command exits non-zero or prints a warning, investigate before proceeding. Never treat a failed step as success.
 
 ## Workflow Gates
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 60 agents across engineering, finance, marketing, legal, operations, product, sales, and support -- compounding your company knowledge with every session.
 
-[![Version](https://img.shields.io/badge/version-3.2.0-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-3.2.1-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. 60 agents, 3 commands, 51 skills, and 3 MCP servers that compound your company knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.2.1] - 2026-02-25
+
+### Fixed
+
+- **cleanup-merged pull failure**: Fix silent pull failure in `worktree-manager.sh cleanup-merged` -- stderr was suppressed (`2>/dev/null`), verbose guard hid messages in non-TTY mode, and missing `return 0` let failed pull exit code leak as script exit code
+- Pull success/failure messages now always print (removed TTY-only verbose guard)
+- Pull errors captured in variable and displayed in warning message for diagnosis
+
 ## [3.2.0] - 2026-02-24
 
 ### Added

--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -471,20 +471,23 @@ cleanup_merged_worktrees() {
     local main_status
     main_status=$(git -C "$GIT_ROOT" status --porcelain 2>/dev/null)
     if [[ -n "$main_status" ]]; then
-      [[ "$verbose" == "true" ]] && echo -e "${YELLOW}Warning: Main checkout has uncommitted changes -- skipping pull${NC}"
+      echo -e "${YELLOW}Warning: Main checkout has uncommitted changes -- skipping pull${NC}"
     else
       local current_branch
       current_branch=$(git -C "$GIT_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null)
       if [[ "$current_branch" != "main" && "$current_branch" != "master" ]]; then
         git -C "$GIT_ROOT" checkout main 2>/dev/null || git -C "$GIT_ROOT" checkout master 2>/dev/null || true
       fi
-      if ! git -C "$GIT_ROOT" pull --ff-only origin main 2>/dev/null; then
-        [[ "$verbose" == "true" ]] && echo -e "${YELLOW}Warning: Could not pull latest main${NC}"
+      local pull_output
+      if pull_output=$(git -C "$GIT_ROOT" pull --ff-only origin main 2>&1); then
+        echo -e "${GREEN}Updated main to latest${NC}"
       else
-        [[ "$verbose" == "true" ]] && echo -e "${GREEN}Updated main to latest${NC}"
+        echo -e "${YELLOW}Warning: Could not pull latest main: $pull_output${NC}"
       fi
     fi
   fi
+
+  return 0
 }
 
 # Main command handler


### PR DESCRIPTION
## Summary
- Fix silent pull failure in `worktree-manager.sh cleanup-merged` -- stderr was suppressed, verbose guard hid messages in non-TTY mode, and missing `return 0` let failed pull exit code leak as script exit code
- Pull success/failure messages now always print (removed TTY-only verbose guard)
- Pull errors captured in variable and displayed in warning for diagnosis
- Add AGENTS.md hard rule: "When a command exits non-zero or prints a warning, investigate before proceeding"

## Test plan
- [ ] Run `cleanup-merged` after merging a PR -- verify "Updated main to latest" prints
- [ ] Run `cleanup-merged` with no network -- verify warning includes the actual error message
- [ ] Verify script exits 0 even when pull fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)