### PR TITLE
fix(functional-discovery): prevent approval prompt from quoted dash-strings (v3.2.2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "3.2.1"
+      placeholder: "3.2.2"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 60 agents across engineering, finance, marketing, legal, operations, product, sales, and support -- compounding your company knowledge with every session.
 
-[![Version](https://img.shields.io/badge/version-3.2.1-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-3.2.2-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/knowledge-base/learnings/2026-02-25-quoted-dash-strings-trigger-approval-prompts.md
+++ b/knowledge-base/learnings/2026-02-25-quoted-dash-strings-trigger-approval-prompts.md
@@ -1,0 +1,23 @@
+# Learning: Quoted dash strings in agent bash blocks trigger approval prompts
+
+## Problem
+The `functional-discovery` agent had two separate bash code blocks for checking already-installed community artifacts. At runtime, the agent model combined them into a single command using `echo "---"` as a separator. Claude Code's CLI safety heuristic flagged `"---"` as "quoted characters in flag names" and prompted the user for approval, blocking autonomous execution.
+
+## Solution
+Merged the two separate bash blocks into a single `;`-joined command in the agent prompt. Added an explicit note warning against `echo "---"` separators:
+
+```bash
+# Before (two blocks, agent adds echo "---" at runtime)
+ls plugins/soleur/agents/community/ 2>/dev/null
+ls -d plugins/soleur/skills/community-*/ 2>/dev/null
+
+# After (single block, no separator needed)
+ls plugins/soleur/agents/community/ 2>/dev/null; ls -d plugins/soleur/skills/community-*/ 2>/dev/null
+```
+
+## Key Insight
+When agent prompts contain multiple bash code blocks that the model might combine at runtime, pre-combine them into a single block. Avoid any quoted strings that start with dashes (e.g., `"---"`, `"-flag"`) as Claude Code's CLI heuristic interprets these as potentially dangerous flag manipulation and triggers an approval prompt. The heuristic is "Command contains quoted characters in flag names."
+
+## Tags
+category: agent-prompt-design
+module: functional-discovery

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -30,6 +30,7 @@ Project principles organized by domain. Add principles as you learn them.
 - Avoid second person ("you should") - use objective language ("To accomplish X, do Y")
 - Never use shell variable expansion (`${VAR}`, `$VAR`, `$()`) in bash code blocks within skill, command, or agent .md files -- use angle-bracket prose placeholders (`<variable-name>`) with substitution instructions instead, or relative paths (e.g., `./plugins/soleur/...`) for plugin-relative paths; the ship skill's "No command substitution" pattern is the reference implementation
 - Never anchor guardrail grep patterns to `^` alone -- the Bash tool chains commands with `&&`, `;`, and `||`, so a `^`-anchored pattern only catches the first command; match at command boundaries with `(^|&&|\|\||;)` instead
+- Never write bash code blocks in agent/skill prompts that trigger Claude Code's approval heuristics -- pre-combine multiple blocks into a single `;`-joined command (models insert `echo "---"` separators otherwise), avoid quoted strings starting with dashes (`"---"`, `"-flag"`), and keep commands simple enough to auto-approve; if a command requires user consent, the agent blocks waiting for input it will never receive when running as a subagent
 
 ### Prefer
 

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. 60 agents, 3 commands, 51 skills, and 3 MCP servers that compound your company knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.2.2] - 2026-02-25
+
+### Fixed
+
+- **functional-discovery approval prompt**: Merge two separate bash blocks in "Already-Installed Check" into a single command, preventing the agent from inserting `echo "---"` separators that trigger Claude Code's "quoted characters in flag names" approval prompt
+
 ## [3.2.1] - 2026-02-25
 
 ### Fixed

--- a/plugins/soleur/agents/engineering/discovery/functional-discovery.md
+++ b/plugins/soleur/agents/engineering/discovery/functional-discovery.md
@@ -70,14 +70,10 @@ After filtering, deduplicate across registries using `name + author/namespace` (
 
 ### Already-Installed Check
 
-Before presenting results, check if any matching artifacts are already installed locally:
+Before presenting results, check if any matching artifacts are already installed locally. Run as a single Bash call (do not add separators like `echo "---"` between commands -- quoted dash strings trigger approval prompts):
 
 ```bash
-# Check community agents
-ls plugins/soleur/agents/community/ 2>/dev/null
-
-# Check community skills
-ls -d plugins/soleur/skills/community-*/ 2>/dev/null
+ls plugins/soleur/agents/community/ 2>/dev/null; ls -d plugins/soleur/skills/community-*/ 2>/dev/null
 ```
 
 Filter out any results whose name matches an already-installed artifact.


### PR DESCRIPTION
## Summary
- Merge two separate bash code blocks in functional-discovery agent's "Already-Installed Check" into a single `;`-joined command, preventing the model from inserting `echo "---"` separators that trigger Claude Code's "quoted characters in flag names" approval prompt
- Add constitution rule: agent/skill bash blocks must use auto-approvable patterns (no quoted dash-strings, pre-combine multiple blocks)
- Document the pattern in `knowledge-base/learnings/`

## Test plan
- [ ] Run `/soleur:plan` on a feature that triggers functional-discovery agent — verify no approval prompt appears for the already-installed check command
- [ ] Verify the agent still correctly detects already-installed community artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)