### PR TITLE
feat: add marketplace manifest for plugin installation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,33 @@
+{
+  "name": "soleur",
+  "owner": {
+    "name": "Jikig AI",
+    "email": "jean.deruelle@jikigai.com"
+  },
+  "metadata": {
+    "description": "Soleur: A full AI organization framework for Claude Code"
+  },
+  "plugins": [
+    {
+      "name": "soleur",
+      "source": "./plugins/soleur",
+      "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. 60 agents, 3 commands, 51 skills, and 3 MCP servers that compound your company knowledge over time.",
+      "version": "3.3.0",
+      "author": {
+        "name": "Jean Deruelle",
+        "email": "jean.deruelle@jikigai.com"
+      },
+      "homepage": "https://soleur.ai",
+      "repository": "https://github.com/jikig-ai/soleur",
+      "license": "BUSL-1.1",
+      "keywords": [
+        "soleur",
+        "claude-code",
+        "ai-agents",
+        "company-as-a-service",
+        "solo-founder",
+        "orchestration"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Enables `claude plugin install soleur` by providing a marketplace.json
that registers the plugin with Claude Code's marketplace system.

https://claude.ai/code/session_01VUVFatiz8Fq4Jsy4j2jHtB