### PR TITLE
feat: add SessionStart hook to preinstall soleur plugin

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# SessionStart hook: preinstall the Soleur plugin from the local workspace
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PLUGIN_DIR="$REPO_ROOT/plugins/soleur"
+
+if [ -d "$PLUGIN_DIR" ]; then
+  claude plugin install "$PLUGIN_DIR" 2>/dev/null || true
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,16 @@
     "CLAUDE_CODE_EFFORT_LEVEL": "high"
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
Adds a SessionStart hook that runs `claude plugin install` against
the local plugins/soleur/ directory at the beginning of each session,
so the plugin is always available without manual installation.

https://claude.ai/code/session_01NPc2veGooSBVku3469duW9