### PR TITLE
fix: use marketplace-based plugin install for reliable loading

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
-# SessionStart hook: preinstall the Soleur plugin from the local workspace
+# SessionStart hook: register the local Soleur marketplace and install the plugin
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-PLUGIN_DIR="$REPO_ROOT/plugins/soleur"
+MARKETPLACE_DIR="$REPO_ROOT"
 
-if [ -d "$PLUGIN_DIR" ]; then
-  claude plugin install "$PLUGIN_DIR" 2>/dev/null || true
+# Only proceed if the marketplace manifest exists
+if [ ! -f "$MARKETPLACE_DIR/.claude-plugin/marketplace.json" ]; then
+  exit 0
 fi
+
+# Add the local marketplace (idempotent — no-ops if already added)
+claude plugin marketplace add "$MARKETPLACE_DIR" 2>/dev/null || true
+
+# Install the soleur plugin from the local marketplace into local scope
+# --scope local keeps it gitignored and per-user
+claude plugin install "soleur@soleur" --scope local 2>/dev/null || true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,17 @@
   "env": {
     "CLAUDE_CODE_EFFORT_LEVEL": "high"
   },
+  "extraKnownMarketplaces": {
+    "soleur": {
+      "source": {
+        "source": "github",
+        "repo": "jikig-ai/soleur"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "soleur@soleur": true
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
The previous SessionStart hook used `claude plugin install <path>` which
only works for marketplace plugins, not local directories. The plugin
silently failed to load (skills, agents, commands all missing).

Fix:
- Add extraKnownMarketplaces + enabledPlugins to project settings so
  the plugin auto-loads when users trust the project folder
- Rewrite SessionStart hook to register the local marketplace first,
  then install soleur@soleur via the marketplace API

https://claude.ai/code/session_01KSJ3FJzFcGoce3wBzuCczz