### PR TITLE
feat(guardrails): add worktree write guard hook (v3.3.2)

### DIFF
--- a/.claude/hooks/worktree-write-guard.sh
+++ b/.claude/hooks/worktree-write-guard.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# PreToolUse hook for Write and Edit tools.
+# Blocks file writes to the main repo checkout when worktrees exist.
+# Prevents the recurring problem of agents creating files on main instead of
+# in the active worktree (screenshots, knowledge-base artifacts, etc.).
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
+
+# Nothing to check if no file path
+[[ -z "$FILE_PATH" ]] && exit 0
+
+# Get the main repo root (not the worktree root).
+# --show-toplevel returns the worktree when called from one, so we use
+# --git-common-dir which always points to the main .git directory.
+GIT_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||' || exit 0)
+
+# If file path is not under the repo root, allow it (e.g., memory files, external paths)
+[[ "$FILE_PATH" != "$GIT_ROOT"* ]] && exit 0
+
+# If file path is inside a worktree, allow it (correct behavior)
+[[ "$FILE_PATH" == *"/.worktrees/"* ]] && exit 0
+
+# Allow writes to .claude/ directory (settings, hooks, memory)
+RELATIVE_PATH="${FILE_PATH#"$GIT_ROOT"/}"
+[[ "$RELATIVE_PATH" == .claude/* ]] && exit 0
+
+# Check if any worktrees exist
+WORKTREE_DIR="$GIT_ROOT/.worktrees"
+if [[ -d "$WORKTREE_DIR" ]] && [[ -n "$(ls -A "$WORKTREE_DIR" 2>/dev/null)" ]]; then
+  # Worktrees exist but write targets main checkout -- block it
+  WORKTREE_NAMES=$(ls "$WORKTREE_DIR" 2>/dev/null | head -3 | tr '\n' ', ' | sed 's/,$//')
+  echo "{\"decision\":\"block\",\"reason\":\"BLOCKED: Writing to main repo checkout while worktrees exist ($WORKTREE_NAMES). Write to the worktree path instead: $GIT_ROOT/.worktrees/<name>/$RELATIVE_PATH\"}"
+  exit 0
+fi
+
+# No worktrees exist, allow the write
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,15 @@
             "command": ".claude/hooks/guardrails.sh"
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/worktree-write-guard.sh"
+          }
+        ]
       }
     ]
   }

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "3.3.1"
+      placeholder: "3.3.2"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 60 agents across engineering, finance, marketing, legal, operations, product, sales, and support -- compounding your company knowledge with every session.
 
-[![Version](https://img.shields.io/badge/version-3.3.1-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-3.3.2-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/knowledge-base/learnings/2026-02-26-worktree-enforcement-pretooluse-hook.md
+++ b/knowledge-base/learnings/2026-02-26-worktree-enforcement-pretooluse-hook.md
@@ -1,0 +1,42 @@
+# Learning: Worktree Write Guard — Enforce File Isolation via PreToolUse Hook
+
+## Problem
+
+Agents repeatedly write files (screenshots, knowledge-base artifacts, temp analysis) to the main repo checkout instead of the active worktree, despite AGENTS.md hard rules stating "Never edit files in the main repo when a worktree is active." Documentation-only rules are insufficient — agents violate them under complex reasoning chains.
+
+Secondary issue: `cleanup_merged_worktrees()` used `git status --porcelain` which includes untracked files, causing the post-cleanup `git pull` to be skipped whenever screenshots or temp artifacts existed in the main checkout.
+
+## Solution
+
+### PreToolUse Hook (`worktree-write-guard.sh`)
+
+Created a hook that intercepts `Write` and `Edit` tool calls before execution. Key design:
+
+- Uses `git rev-parse --git-common-dir` to reliably find the main repo root (works from both main checkout and worktrees)
+- Allows: writes outside the repo, writes inside `.worktrees/`, writes to `.claude/` (settings, hooks, memory)
+- Blocks: any write to the main repo checkout when `.worktrees/` directory contains active worktrees
+- Returns actionable error: shows the correct worktree path the agent should use instead
+
+Registered in `.claude/settings.json` with matcher `Write|Edit`.
+
+### cleanup-merged Fix
+
+Replaced `git status --porcelain` with `git diff --quiet HEAD` + `git diff --cached --quiet` to only check tracked file changes. Untracked files cannot conflict with a fast-forward pull and should not block the update.
+
+## Key Insight
+
+**Hook-based enforcement > documentation-based rules.** PreToolUse hooks make violations impossible rather than aspirational. This is the same pattern as `guardrails.sh` (which blocks `git commit` on main), extended to file write operations. The progression: Guard 1 (commit on main) → Guard 2 (rm -rf worktrees) → Guard 3 (--delete-branch with worktrees) → Guard 4 (write to main with worktrees active).
+
+For `git status --porcelain` checks that gate further operations: consider whether untracked files actually conflict with the gated operation. For fast-forward pulls, they don't.
+
+## Related Learnings
+
+- `2026-02-24-guardrails-chained-commit-bypass.md` — Guard 1 pattern matching lessons
+- `2026-02-24-guardrails-grep-false-positive-worktree-text.md` — Guard 2 false positive fix
+- `2026-02-17-worktree-not-enforced-for-new-work.md` — Why worktree enforcement is a hard rule
+- `2026-02-22-worktree-loss-stash-merge-pop.md` — Consequences of improper worktree state management
+- `2026-02-21-stale-worktrees-accumulate-across-sessions.md` — Why cleanup-merged runs at session start
+
+## Tags
+category: integration-issues
+module: git-worktree, guardrails

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -152,6 +152,7 @@ Project principles organized by domain. Add principles as you learn them.
 - Add explicit compaction checkpoints to multi-phase workflows -- if context truncation occurs, write an inventory to a known file path (e.g., session-state.md) so downstream phases can recover; silent compaction has caused missing learnings and undocumented errors in pipelines
 - When fixing a prefix-stripping or pattern-matching bug, verify the fix code does not repeat the same single-variant assumption being corrected -- the initial worktree-manager.sh fix reproduced the exact `feat-`-only bug it was supposed to fix; multi-agent review catches this reliably but self-review often misses it
 - Prefer single-pattern grep guards over ANDing separate greps -- independent substring checks cannot enforce syntactic context (e.g., that `.worktrees/` is an `rm` argument, not comment text); combine into one regex that enforces proximity
+- Prefer hook-based enforcement over documentation-only rules for agent discipline -- PreToolUse hooks make violations impossible rather than aspirational; reserve AGENTS.md hard rules for cases where hooks cannot intercept (e.g., reasoning errors, not tool calls)
 
 ## Testing
 

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. 60 agents, 3 commands, 51 skills, and 3 MCP servers that compound your company knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.3.2] - 2026-02-26
+
+### Added
+
+- **Worktree write guard hook**: New PreToolUse hook (`.claude/hooks/worktree-write-guard.sh`) that blocks `Write` and `Edit` tool calls targeting the main repo checkout when worktrees exist, preventing the recurring problem of agents creating files on main instead of in the active worktree
+
+### Fixed
+
+- **cleanup-merged untracked file false positive**: Change uncommitted-changes check in `cleanup_merged_worktrees()` to only consider tracked file changes (`git diff --quiet HEAD` + `git diff --cached --quiet`), so untracked files (screenshots, temp artifacts) no longer block the post-cleanup `git pull`
+
 ## [3.3.1] - 2026-02-25
 
 ### Fixed

--- a/plugins/soleur/skills/git-worktree/SKILL.md
+++ b/plugins/soleur/skills/git-worktree/SKILL.md
@@ -16,6 +16,7 @@ This skill provides a unified interface for managing Git worktrees across your d
 - **Interactive confirmations** at each step
 - **Automatic .gitignore management** for worktree directory
 - **Automatic .env file copying** from main repo to new worktrees
+- **Write guard enforcement** via PreToolUse hook (`.claude/hooks/worktree-write-guard.sh`) -- blocks Write/Edit to main checkout when worktrees exist
 
 ## CRITICAL: Always Use the Manager Script
 

--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -468,10 +468,10 @@ cleanup_merged_worktrees() {
     echo -e "${GREEN}Cleaned ${#cleaned[@]} merged worktree(s): ${cleaned[*]}${NC}"
 
     # After cleanup, update main checkout so next worktree branches from latest
-    local main_status
-    main_status=$(git -C "$GIT_ROOT" status --porcelain 2>/dev/null)
-    if [[ -n "$main_status" ]]; then
-      echo -e "${YELLOW}Warning: Main checkout has uncommitted changes -- skipping pull${NC}"
+    # Only check tracked file changes (staged + unstaged) -- untracked files cannot
+    # conflict with a fast-forward pull and should not block the update
+    if ! git -C "$GIT_ROOT" diff --quiet HEAD 2>/dev/null || ! git -C "$GIT_ROOT" diff --cached --quiet 2>/dev/null; then
+      echo -e "${YELLOW}Warning: Main checkout has uncommitted changes to tracked files -- skipping pull${NC}"
     else
       local current_branch
       current_branch=$(git -C "$GIT_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null)


### PR DESCRIPTION
## Summary
- Add PreToolUse hook (`worktree-write-guard.sh`) that blocks `Write`/`Edit` tool calls targeting the main repo checkout when worktrees exist — enforces file isolation via tooling rather than documentation alone
- Fix `cleanup_merged_worktrees()` to use `git diff --quiet` instead of `git status --porcelain`, so untracked files (screenshots, temp artifacts) no longer block the post-cleanup `git pull`
- Version bump to 3.3.2, constitution principle added, learning captured

## Test plan
- [ ] Create a worktree, then attempt to Write a file to the main repo root — should be blocked with actionable error
- [ ] Write a file inside the worktree — should be allowed
- [ ] Write to `.claude/` directory — should be allowed
- [ ] Run `cleanup-merged` with untracked files in main checkout — pull should succeed
- [ ] Remove all worktrees, then Write to main repo — should be allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)