### PR TITLE
fix: add allow rule for worktree-manager.sh command substitution

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,8 @@
       "Bash(git add -A && git commit:*)",
       "Bash(git add && git commit:*)",
       "Bash(git commit -m:*)",
-      "Bash(git commit -F:*)"
+      "Bash(git commit -F:*)",
+      "Bash(bash $(git rev-parse --show-toplevel)/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh *)"
     ]
   },
   "env": {

--- a/knowledge-base/learnings/2026-02-26-allow-rule-for-session-start-command-substitution.md
+++ b/knowledge-base/learnings/2026-02-26-allow-rule-for-session-start-command-substitution.md
@@ -1,0 +1,31 @@
+# Learning: Allow rule for session-start command substitution
+
+## Problem
+
+The AGENTS.md session-start rule requires running `bash $(git rev-parse --show-toplevel)/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh cleanup-merged` at the beginning of every session. Claude Code's security model prompts for confirmation whenever a Bash command contains `$()` command substitution, causing a blocking permission dialog on every session start.
+
+Unlike skill-embedded `$()` (which can be extracted into scripts per the `extract-command-substitution-into-scripts` learning), this command inherently needs `$(git rev-parse --show-toplevel)` to resolve the repo root — it can't be simplified further.
+
+## Solution
+
+Add a glob-style allow rule to `.claude/settings.json` (project-level):
+
+```json
+"Bash(bash $(git rev-parse --show-toplevel)/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh *)"
+```
+
+The trailing `*` matches any subcommand (`cleanup-merged`, `feature`, `draft-pr`, etc.), so a single rule covers all worktree-manager invocations.
+
+## Key Insight
+
+There are two categories of `$()` in Claude Code workflows:
+
+1. **Skill-embedded `$()`** — extract into scripts (per existing learning)
+2. **Structural `$()`** that resolve environment context (repo root, branch name) — allow-list them in project settings
+
+Session-start commands fall into category 2. They run before any skill context exists, and the `$(git rev-parse --show-toplevel)` pattern is the standard cross-platform way to resolve repo root regardless of CWD.
+
+## Tags
+category: integration-issues
+module: .claude/settings.json
+symptoms: "Command contains $() command substitution" prompt on every session start

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -14,6 +14,7 @@ Project principles organized by domain. Add principles as you learn them.
 - Agent prompts must contain only instructions the LLM would get wrong without them -- omit general domain knowledge, error handling, and boilerplate the model already knows
 - Agent frontmatter must include a `model` field (`inherit`, `haiku`, `sonnet`, or `opus`) to control execution model
 - Command frontmatter must include an `argument-hint` field describing expected arguments
+- Add allow rules to `.claude/settings.json` for session-start commands that inherently require `$()` -- don't extract them into scripts
 - Shell scripts must use `#!/usr/bin/env bash` shebang and declare `set -euo pipefail` at the top
 - Shell scripts use snake_case for function names and local variables, SCREAMING_SNAKE_CASE for global constants
 - Shell functions must declare all variables with `local`; error messages go to stderr (`>&2`)


### PR DESCRIPTION
## Summary
- Add project-level allow rule in `.claude/settings.json` for `worktree-manager.sh` invocations that use `$(git rev-parse --show-toplevel)`
- Eliminates the "Command contains $() command substitution" permission prompt on every session start
- Document learning and add constitution principle

## Test plan
- [x] Start a new Claude Code session and verify the worktree cleanup command runs without a permission prompt
- [x] `bun test` passes (893/893)

Generated with [Claude Code](https://claude.com/claude-code)