### PR TITLE
fix(cla): use GITHUB_TOKEN instead of PAT for signature storage

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,14 +27,12 @@ jobs:
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://soleur.ai/pages/legal/individual-cla.html"
           branch: "cla-signatures"
           allowlist: "dependabot[bot],github-actions[bot],renovate[bot]"
-          remote-organization-name: "jikig-ai"
-          remote-repository-name: "soleur"
           custom-notsigned-prcomment: |
             Thank you for your contribution! Before we can accept it, you need to sign our [Contributor License Agreement](https://soleur.ai/pages/legal/individual-cla.html).
 


### PR DESCRIPTION
## Summary

- Switch CLA workflow from `secrets.PERSONAL_ACCESS_TOKEN` to `secrets.GITHUB_TOKEN` for signature storage
- Repo-based storage on `cla-signatures` branch works with GITHUB_TOKEN since the workflow already has `contents: write` and runs under `pull_request_target` context
- Eliminates the need to create and manage a long-lived PAT
- Also created `CLA Required` branch ruleset requiring `cla-check` status on PRs to main

## Test plan

- [ ] This PR itself serves as the smoke test -- CLA bot should comment asking for signature
- [ ] Verify CLA bot can write to `cla-signatures` branch after signing

🤖 Generated with [Claude Code](https://claude.com/claude-code)