### PR TITLE
fix(ci): add id-token:write permission for claude-code-action OIDC (v3.7.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "soleur",
       "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. Agents, skills, and MCP servers that compound your company knowledge over time.",
-      "version": "3.7.3",
+      "version": "3.7.4",
       "author": {
         "name": "Jean Deruelle",
         "email": "jean.deruelle@jikigai.com"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "3.7.3"
+      placeholder: "3.7.4"
     validations:
       required: true
   - type: input

--- a/.github/workflows/scheduled-competitive-analysis.yml
+++ b/.github/workflows/scheduled-competitive-analysis.yml
@@ -17,6 +17,7 @@ concurrency:
 permissions:
   issues: write
   contents: read
+  id-token: write
 
 jobs:
   competitive-analysis:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 61 agents across engineering, finance, marketing, legal, operations, product, sales, and support -- compounding your company knowledge with every session.
 
-[![Version](https://img.shields.io/badge/version-3.7.3-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-3.7.4-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/knowledge-base/learnings/2026-02-27-schedule-skill-template-gaps-first-consumer.md
+++ b/knowledge-base/learnings/2026-02-27-schedule-skill-template-gaps-first-consumer.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-The `soleur:schedule` skill generates workflow YAML from a fixed template, but the first real consumer (`competitive-analysis`) exposed four gaps that required manual post-generation edits.
+The `soleur:schedule` skill generates workflow YAML from a fixed template, but the first real consumer (`competitive-analysis`) exposed five gaps that required manual post-generation edits.
 
 ## Solution
 
@@ -25,9 +25,11 @@ After generating the workflow with `/soleur:schedule create`, manually apply the
 
 4. **`timeout-minutes`**: The template has no job-level timeout. LLM-backed workflows should set `timeout-minutes: 30` (or similar) to prevent runaway billing if the agent gets stuck.
 
+5. **`id-token: write` permission**: `claude-code-action` requires OIDC token access for authentication. Without `id-token: write` in the permissions block, the action fails immediately with "Could not fetch an OIDC token." The existing `claude-code-review.yml` includes this permission, but the schedule skill template did not. [Updated 2026-02-27]
+
 ## Key Insight
 
-The schedule skill template is a starting point, not a complete workflow. Every generated workflow needs a review pass for: argument passthrough, turn limits, label existence, and timeout caps. These should be added to the template itself in a future iteration.
+The schedule skill template is a starting point, not a complete workflow. Every generated workflow needs a review pass for: argument passthrough, turn limits, label existence, timeout caps, and OIDC permissions. These should be added to the template itself in a future iteration.
 
 ## Session Errors
 

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -82,6 +82,7 @@ Project principles organized by domain. Add principles as you learn them.
 - When fixing a pattern across plugin files (e.g., removing `$()`, renaming a reference), search ALL `.md` files under `plugins/soleur/` -- not just the category (commands/, skills/, agents/) that triggered the report; reference docs, SKILL.md, and agent definitions all contain executable bash blocks
 - GitHub Actions workflows that create issues with labels must pre-create labels via `gh label create <name> ... 2>/dev/null || true` -- `gh issue create --label` fails if the label does not exist; it does NOT auto-create labels
 - GitHub Actions workflows invoking LLM agents (claude-code-action) must set `timeout-minutes` on the job to cap runaway billing -- without it, a stuck agent runs for the 6-hour GitHub default
+- GitHub Actions workflows using `claude-code-action` must include `id-token: write` in the permissions block -- the action requires OIDC token access for authentication and fails immediately without it
 
 ### Never
 

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. 61 agents, 3 commands, 54 skills, and 3 MCP servers that compound your company knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.7.4] - 2026-02-27
+
+### Fixed
+
+- **Scheduled competitive analysis workflow** -- Added missing `id-token: write` permission required by `claude-code-action` for OIDC authentication. Without it, the action fails immediately with "Could not fetch an OIDC token." (#338 follow-up)
+- **schedule skill template** -- Added `id-token: write` to the template permissions block so future generated workflows include this required permission.
+
 ## [3.7.3] - 2026-02-27
 
 ### Added

--- a/plugins/soleur/skills/schedule/SKILL.md
+++ b/plugins/soleur/skills/schedule/SKILL.md
@@ -80,6 +80,7 @@ concurrency:
 permissions:
   contents: read
   issues: write
+  id-token: write
 
 jobs:
   run-schedule:


### PR DESCRIPTION
## Summary

- Add missing `id-token: write` permission to scheduled competitive analysis workflow — `claude-code-action` requires OIDC token access and fails immediately without it
- Update schedule skill template to include `id-token: write` in generated workflows
- Add constitution principle: `claude-code-action` workflows require `id-token: write`
- Update learning with 5th template gap discovered during dogfooding

**Root cause:** The first `workflow_dispatch` run of the scheduled competitive analysis workflow (#338) failed with: "Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?" The existing `claude-code-review.yml` includes this permission, but the schedule skill template did not.

## Test plan

- [ ] After merge, re-trigger `gh workflow run scheduled-competitive-analysis.yml`
- [ ] Verify the workflow passes the OIDC authentication step
- [ ] Monitor full run completion and GitHub Issue creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)