### PR TITLE
fix(ci): add --allowedTools and upgrade to opus for scheduled workflow (v3.7.6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "soleur",
       "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. Agents, skills, and MCP servers that compound your company knowledge over time.",
-      "version": "3.7.5",
+      "version": "3.7.6",
       "author": {
         "name": "Jean Deruelle",
         "email": "jean.deruelle@jikigai.com"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "3.7.5"
+      placeholder: "3.7.6"
     validations:
       required: true
   - type: input

--- a/.github/workflows/scheduled-competitive-analysis.yml
+++ b/.github/workflows/scheduled-competitive-analysis.yml
@@ -41,7 +41,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: 'https://github.com/jikig-ai/soleur.git'
           plugins: 'soleur@soleur'
-          claude_args: '--model claude-sonnet-4-6 --max-turns 30'
+          claude_args: '--model claude-opus-4-6 --max-turns 30 --allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch'
           prompt: |
             Run /soleur:competitive-analysis --tiers 0,3 on this repository.
             After your analysis is complete, create a GitHub issue titled

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 61 agents across engineering, finance, marketing, legal, operations, product, sales, and support -- compounding your company knowledge with every session.
 
-[![Version](https://img.shields.io/badge/version-3.7.5-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-3.7.6-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/knowledge-base/learnings/2026-02-27-schedule-skill-template-gaps-first-consumer.md
+++ b/knowledge-base/learnings/2026-02-27-schedule-skill-template-gaps-first-consumer.md
@@ -27,9 +27,11 @@ After generating the workflow with `/soleur:schedule create`, manually apply the
 
 5. **`id-token: write` permission**: `claude-code-action` requires OIDC token access for authentication. Without `id-token: write` in the permissions block, the action fails immediately with "Could not fetch an OIDC token." The existing `claude-code-review.yml` includes this permission, but the schedule skill template did not. [Updated 2026-02-27]
 
+6. **`--allowedTools` in `claude_args`**: `claude-code-action` blocks Bash, Write, WebSearch, and WebFetch by default. The agent generated a full competitive analysis report but all 3 `gh issue create` attempts were silently permission-denied. Add `--allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch` to `claude_args`. Without this, the workflow completes "successfully" (exit 0) but produces no output artifact. [Updated 2026-02-27]
+
 ## Key Insight
 
-The schedule skill template is a starting point, not a complete workflow. Every generated workflow needs a review pass for: argument passthrough, turn limits, label existence, timeout caps, and OIDC permissions. These should be added to the template itself in a future iteration.
+The schedule skill template is a starting point, not a complete workflow. Every generated workflow needs a review pass for: argument passthrough, turn limits, label existence, timeout caps, OIDC permissions, and tool allowlists. The `claude-code-action` sandbox is restrictive by default — the most dangerous gap is `--allowedTools` because the workflow reports success even when all Bash commands are silently blocked.
 
 ## Session Errors
 

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -83,6 +83,7 @@ Project principles organized by domain. Add principles as you learn them.
 - GitHub Actions workflows that create issues with labels must pre-create labels via `gh label create <name> ... 2>/dev/null || true` -- `gh issue create --label` fails if the label does not exist; it does NOT auto-create labels
 - GitHub Actions workflows invoking LLM agents (claude-code-action) must set `timeout-minutes` on the job to cap runaway billing -- without it, a stuck agent runs for the 6-hour GitHub default
 - GitHub Actions workflows using `claude-code-action` must include `id-token: write` in the permissions block -- the action requires OIDC token access for authentication and fails immediately without it
+- GitHub Actions workflows using `claude-code-action` where the agent needs to run shell commands (gh issue create, gh pr create, etc.) or web research must include `--allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch` in `claude_args` -- the sandbox blocks Bash, Write, WebSearch, and WebFetch by default and silently drops denied tool calls (workflow reports success with no output)
 
 ### Never
 

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "3.7.5",
+  "version": "3.7.6",
   "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. 61 agents, 3 commands, 54 skills, and 3 MCP servers that compound your company knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.7.6] - 2026-02-27
+
+### Fixed
+
+- **Scheduled competitive analysis workflow** -- Added `--allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch` to `claude_args`. The `claude-code-action` sandbox blocks Bash and web tools by default, causing all `gh issue create` attempts to be silently permission-denied. Upgraded model from `claude-sonnet-4-6` to `claude-opus-4-6` for deeper competitive research.
+- **schedule skill template** -- Added `--allowedTools` to the template `claude_args` so future generated workflows include the required tool permissions. Documented as 6th known limitation.
+
 ## [3.7.5] - 2026-02-27
 
 ### Added

--- a/plugins/soleur/skills/schedule/SKILL.md
+++ b/plugins/soleur/skills/schedule/SKILL.md
@@ -95,7 +95,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: 'https://github.com/<REPO_OWNER>/<REPO_NAME>.git'
           plugins: 'soleur@soleur'
-          claude_args: '--model <MODEL>'
+          claude_args: '--model <MODEL> --allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch'
           prompt: |
             Run /soleur:<SKILL_NAME> on this repository.
             After your analysis is complete, create a GitHub issue titled
@@ -171,3 +171,4 @@ Remove a scheduled workflow.
 - **No `--max-turns` in `claude_args`** — The template only includes `--model`. Skills that perform multiple WebSearch/WebFetch calls may need `--max-turns 30` added manually.
 - **No label pre-creation** — The template instructs issue creation with a label but does not pre-create it. Add a `gh label create ... || true` step manually.
 - **No `timeout-minutes`** — The template does not set a job-level timeout. LLM-backed workflows should add `timeout-minutes` to prevent runaway billing.
+- **No `--allowedTools` in `claude_args`** — `claude-code-action` blocks Bash, Write, WebSearch, and WebFetch by default. Skills that create GitHub issues or perform web research silently fail without `--allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch` in `claude_args`.


### PR DESCRIPTION
## Summary
- Added `--allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch` to `claude_args` in the scheduled competitive analysis workflow — `claude-code-action` blocks these tools by default, silently dropping all `gh issue create` attempts
- Upgraded model from `claude-sonnet-4-6` to `claude-opus-4-6` for deeper competitive research
- Updated schedule skill template to include `--allowedTools` for future generated workflows
- Documented as 6th known limitation in the learning doc
- Added constitution principle for `--allowedTools` requirement

## Root Cause
Workflow run 22494799343 completed "successfully" but created no GitHub Issue. Investigation revealed all 9 Bash tool calls (including 3 `gh issue create` attempts) were in the `permission_denials` array. The `claude-code-action` sandbox only allows read-only tools (Read, Glob, Grep) by default.

## Test plan
- [x] All 921 tests pass
- [ ] Trigger workflow manually via `gh workflow run scheduled-competitive-analysis.yml`
- [ ] Verify GitHub Issue is created with `scheduled-competitive-analysis` label
- [ ] Verify competitive analysis report includes web research (WebSearch/WebFetch now allowed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)