### PR TITLE
feat(pencil-setup): prefer Desktop MCP binary when accessible (v3.7.8)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "soleur",
       "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. Agents, skills, and MCP servers that compound your company knowledge over time.",
-      "version": "3.7.7",
+      "version": "3.7.8",
       "author": {
         "name": "Jean Deruelle",
         "email": "jean.deruelle@jikigai.com"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "3.7.7"
+      placeholder: "3.7.8"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 61 agents across engineering, finance, marketing, legal, operations, product, sales, and support -- compounding your company knowledge with every session.
 
-[![Version](https://img.shields.io/badge/version-3.7.7-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-3.7.8-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/knowledge-base/learnings/2026-02-27-pencil-desktop-ships-mcp-binary.md
+++ b/knowledge-base/learnings/2026-02-27-pencil-desktop-ships-mcp-binary.md
@@ -1,0 +1,36 @@
+# Learning: Pencil Desktop ships its own MCP server binary
+
+## Problem
+
+The `check_deps.sh` script treated all MCP binaries as coming from the IDE extension only. When investigating whether Pencil Desktop should be preferred, we needed to know if Desktop ships its own MCP server binary and whether it's accessible.
+
+## Solution
+
+Extracted the Pencil Desktop AppImage (`--appimage-extract`) and found:
+- Desktop ships `mcp-server-linux-x64` at `resources/app.asar.unpacked/out/`
+- The binary is a different build from the extension's (different SHA256, same size)
+- Desktop also bundles `@anthropic-ai/claude-agent-sdk` and `@openai/codex-sdk`
+- The binary accepts the same `-app` flag as the extension's
+
+### Platform accessibility
+
+- **macOS**: Desktop binary is directly accessible at `/Applications/Pencil.app/Contents/Resources/app.asar.unpacked/out/mcp-server-darwin-*`
+- **Linux AppImage**: Binary is trapped inside the AppImage; only accessible if the user runs `--appimage-extract` to create `squashfs-root/`
+
+### Extension binary platform filter bug
+
+The `detect_extension()` function used `sort -V | tail -1` across all platform binaries (darwin, linux, windows). On Linux this returned `mcp-server-windows-x64.exe` (last alphabetically). Fixed by filtering with OS prefix and architecture suffix.
+
+## Key Insight
+
+When a tool ships binaries through multiple distribution channels (IDE extension, Desktop app), prefer the Desktop binary when directly accessible — it's likely more tightly coupled to the Desktop's version. But on Linux with AppImage distribution, the binary isn't accessible without extraction, so gracefully fall back to the extension binary. Always filter platform-specific binaries by the current OS and architecture, never rely on alphabetical sort order.
+
+## Session Errors
+
+1. Shell syntax error: `&;` is invalid bash (backgrounding doesn't use semicolon)
+2. Pre-existing bug: `detect_extension()` returned Windows binary on Linux (fixed)
+3. CWD drifted to `/tmp` after AppImage extraction (had to cd back to worktree)
+
+## Tags
+category: integration-issues
+module: pencil-setup

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "3.7.7",
+  "version": "3.7.8",
   "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. 61 agents, 3 commands, 54 skills, and 3 MCP servers that compound your company knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.7.8] - 2026-02-27
+
+### Added
+
+- **pencil-setup: check_deps.sh** -- Prefer Pencil Desktop's MCP binary over the IDE extension when directly accessible (macOS app bundle, Linux extracted AppImage). Show richer status: capabilities when Desktop is found, "recommended" with unlock details when missing. Output `PREFERRED_BINARY=<path>` for SKILL.md consumption.
+
+### Fixed
+
+- **pencil-setup: check_deps.sh** -- Extension binary detection now filters by OS and architecture (`mcp-server-linux-x64`) instead of picking the last alphabetical match (`mcp-server-windows-x64.exe`).
+
 ## [3.7.7] - 2026-02-27
 
 ### Fixed

--- a/plugins/soleur/skills/pencil-setup/SKILL.md
+++ b/plugins/soleur/skills/pencil-setup/SKILL.md
@@ -30,7 +30,9 @@ bash ./plugins/soleur/skills/pencil-setup/scripts/check_deps.sh --auto
 If the script exits non-zero, a required dependency is missing. Stop and
 inform the user with the printed instructions.
 
-If all checks pass, proceed to Step 1 (Check if Already Registered).
+If all checks pass, capture the `PREFERRED_BINARY=<path>` line from the
+script output — this is the best available MCP binary (Desktop's binary when
+accessible, otherwise the extension's). Proceed to Step 1.
 
 ## Step 1: Check if Already Registered
 
@@ -90,7 +92,7 @@ claude mcp remove pencil -s user 2>/dev/null
 claude mcp add -s user pencil -- <BINARY_PATH> --app <IDE>
 ```
 
-Replace `<BINARY_PATH>` with the path found in Step 3, and `<IDE>` with `cursor` or `code` from Step 2.
+Replace `<BINARY_PATH>` with the `PREFERRED_BINARY` value from Phase 0 (falls back to Step 3 if Phase 0 was skipped), and `<IDE>` with `cursor` or `code` from Step 2.
 
 ## Step 5: Verify
 

--- a/plugins/soleur/skills/pencil-setup/scripts/check_deps.sh
+++ b/plugins/soleur/skills/pencil-setup/scripts/check_deps.sh
@@ -6,10 +6,17 @@
 AUTO_INSTALL=false
 [[ "${1:-}" == "--auto" ]] && AUTO_INSTALL=true
 
-# Detect OS for platform-specific checks
+# Detect OS and architecture for platform-specific checks
 OS="unknown"
 [[ "$(uname -s)" == "Darwin" ]] && OS="macos"
 [[ "$(uname -s)" == "Linux" ]] && OS="linux"
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)  MCP_SUFFIX="x64" ;;
+  aarch64|arm64) MCP_SUFFIX="arm64" ;;
+  *)       MCP_SUFFIX="x64" ;;
+esac
 
 # -- Detection Functions --
 
@@ -34,6 +41,26 @@ detect_pencil_desktop() {
   return 1
 }
 
+# Returns the MCP binary path from Pencil Desktop if directly accessible
+detect_desktop_binary() {
+  local binary=""
+  case "$OS" in
+    macos)
+      # App bundle exposes the binary at a stable path
+      binary=$(ls "/Applications/Pencil.app/Contents/Resources/app.asar.unpacked/out/mcp-server-darwin-${MCP_SUFFIX}" 2>/dev/null)
+      ;;
+    linux)
+      # AppImage binary is not directly accessible without extraction.
+      # Check if user extracted the AppImage to a known location.
+      for dir in "$HOME/Applications" "$HOME/.local/bin" "/opt"; do
+        binary=$(ls "$dir"/squashfs-root/resources/app.asar.unpacked/out/mcp-server-linux-"${MCP_SUFFIX}" 2>/dev/null | head -1)
+        [[ -n "$binary" ]] && break
+      done
+      ;;
+  esac
+  [[ -n "$binary" && -x "$binary" ]] && echo "$binary"
+}
+
 detect_ide() {
   # Prefer Cursor over VS Code (Pencil docs recommend Cursor)
   command -v cursor >/dev/null 2>&1 && echo "cursor" && return 0
@@ -43,13 +70,18 @@ detect_ide() {
 
 detect_extension() {
   local ide="$1"
-  local extdir
+  local extdir os_prefix
   case "$ide" in
     cursor) extdir="$HOME/.cursor/extensions" ;;
     code)   extdir="$HOME/.vscode/extensions" ;;
     *)      return 1 ;;
   esac
-  ls -d "${extdir}/highagency.pencildev-"*/out/mcp-server-* 2>/dev/null | sort -V | tail -1
+  case "$OS" in
+    macos) os_prefix="darwin" ;;
+    linux) os_prefix="linux" ;;
+    *)     os_prefix="linux" ;;
+  esac
+  ls -d "${extdir}/highagency.pencildev-"*/out/mcp-server-"${os_prefix}-${MCP_SUFFIX}" 2>/dev/null | sort -V | tail -1
 }
 
 echo "=== Pencil Setup Dependency Check ==="
@@ -96,11 +128,24 @@ else
   fi
 fi
 
-# 3. Informational: Pencil Desktop app (not required for MCP setup)
+# 3. Pencil Desktop: optional but preferred when available
+DESKTOP_BINARY=$(detect_desktop_binary)
 if detect_pencil_desktop; then
-  echo "  [ok] Pencil Desktop"
+  if [[ -n "$DESKTOP_BINARY" ]]; then
+    echo "  [ok] Pencil Desktop (MCP binary available)"
+    echo "    Provides: standalone .pen editing, pencil CLI, bundled AI SDKs"
+    echo "    MCP binary: $DESKTOP_BINARY"
+    BINARY="$DESKTOP_BINARY"
+  else
+    echo "  [ok] Pencil Desktop"
+    echo "    Provides: standalone .pen editing, pencil CLI"
+    if [[ "$OS" == "linux" ]]; then
+      echo "    Tip: extract AppImage with --appimage-extract for direct MCP binary access"
+    fi
+  fi
 else
-  echo "  [info] Pencil Desktop not found (optional)"
+  echo "  [info] Pencil Desktop not found (recommended)"
+  echo "    Unlocks: standalone .pen editing, pencil CLI, bundled AI SDKs"
   case "$OS" in
     macos) echo "    Download: https://www.pencil.dev/downloads (macOS .dmg)" ;;
     linux) echo "    Download: https://www.pencil.dev/downloads (Linux AppImage)" ;;
@@ -118,3 +163,7 @@ fi
 
 echo
 echo "=== Check Complete ==="
+
+# Output preferred binary for SKILL.md consumption
+echo
+echo "PREFERRED_BINARY=$BINARY"


### PR DESCRIPTION
## Summary
- When Pencil Desktop is installed and its MCP binary is directly accessible (macOS app bundle, or extracted Linux AppImage), `check_deps.sh` now prefers it over the IDE extension binary and outputs `PREFERRED_BINARY=<path>`
- Fixes pre-existing bug where `detect_extension()` returned the Windows binary on Linux due to unfiltered `sort -V` across all platform binaries — now filters by OS prefix and architecture suffix
- Adds architecture detection (`x64`/`arm64`) for correct platform binary matching
- Richer Desktop status output: shows capabilities when found, download link + unlocks when missing
- Updates SKILL.md to reference `PREFERRED_BINARY` from Phase 0

## Test plan
- [x] Tested with Desktop installed + extracted AppImage (prefers Desktop binary)
- [x] Tested with Desktop installed but no extracted binary (falls back to extension)
- [x] Tested without Desktop (extension binary used, info message shown)
- [x] Tested with `--auto` flag (non-interactive mode)
- [x] Tested without IDE (exits 1 with install instructions)
- [x] Verified platform filter returns correct OS+arch binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)