### PR TITLE
fix(ci): re-authenticate persist step after token revocation (v3.7.12)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "soleur",
       "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. Agents, skills, and MCP servers that compound your company knowledge over time.",
-      "version": "3.7.11",
+      "version": "3.7.12",
       "author": {
         "name": "Jean Deruelle",
         "email": "jean.deruelle@jikigai.com"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "3.7.11"
+      placeholder: "3.7.12"
     validations:
       required: true
   - type: input

--- a/.github/workflows/scheduled-competitive-analysis.yml
+++ b/.github/workflows/scheduled-competitive-analysis.yml
@@ -50,6 +50,9 @@ jobs:
             with the label "scheduled-competitive-analysis" summarizing your findings.
 
       - name: Persist competitive intelligence report
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
           FILE="knowledge-base/overview/competitive-intelligence.md"
           if [ ! -f "$FILE" ]; then
@@ -59,6 +62,9 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Re-authenticate after claude-code-action revokes the installation token
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
 
           git add "$FILE"
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 61 agents across engineering, finance, marketing, legal, operations, product, sales, and support -- compounding your company knowledge with every session.
 
-[![Version](https://img.shields.io/badge/version-3.7.11-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-3.7.12-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/knowledge-base/learnings/2026-03-02-claude-code-action-token-revocation-breaks-persist-step.md
+++ b/knowledge-base/learnings/2026-03-02-claude-code-action-token-revocation-breaks-persist-step.md
@@ -1,0 +1,55 @@
+# Learning: claude-code-action Post-Step Revokes Token Before Persist Step
+
+## Problem
+
+The `scheduled-competitive-analysis.yml` workflow has a persist step that pushes the competitive intelligence report to `main` after `claude-code-action` generates it. The push fails with:
+
+```
+remote: Invalid username or token. Password authentication is not supported for Git operations.
+fatal: Authentication failed for 'https://github.com/jikig-ai/soleur.git/'
+```
+
+The `claude-code-action` post-step cleanup revokes the GitHub App installation token via `curl -X DELETE .../installation/token`. This runs **after** the action step completes but **before** subsequent workflow steps execute. The persist step inherits revoked credentials from `actions/checkout`.
+
+## Solution
+
+Re-authenticate in the persist step using `${{ github.token }}` (GITHUB_TOKEN), which is scoped to the job and survives third-party action cleanup:
+
+```yaml
+- name: Persist competitive intelligence report
+  env:
+    GH_TOKEN: ${{ github.token }}
+    REPO: ${{ github.repository }}
+  run: |
+    git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+    # ... git add, commit, push as before
+```
+
+Pass both values via `env:` to avoid expression injection in `run:` blocks.
+
+## Key Insight
+
+Any GitHub Actions workflow step that runs **after** `claude-code-action` (or similar actions that manage their own installation tokens) cannot rely on `actions/checkout` credentials. Always re-authenticate with `${{ github.token }}` via `git remote set-url` before any git push in post-action steps.
+
+This applies to any workflow that: (1) uses `claude-code-action` to generate files, then (2) has a separate step to commit/push those files.
+
+## Session Errors
+
+1. CI workflow auth failure — persist step exit code 128 (the bug itself)
+2. Misunderstood user intent — attempted local agent run instead of GitHub Actions dispatch
+3. Background task output retrieval failed — TaskOutput and Read both missed the output file
+4. Wrong plugin.json path — used `plugins/soleur/plugin.json` instead of `plugins/soleur/.claude-plugin/plugin.json`
+5. Wrong agent file path — tried `competitive-intelligence/AGENT.md` instead of `competitive-intelligence.md`
+
+## Related
+
+- [GitHub Actions auto-push vs PR for bot content](2026-03-02-github-actions-auto-push-vs-pr-for-bot-content.md) — GITHUB_TOKEN cascade limitations
+- [GitHub Actions auto-release permissions](integration-issues/github-actions-auto-release-permissions.md) — explicit `permissions: contents: write`
+- [Multi-agent cascade orchestration checklist](2026-03-02-multi-agent-cascade-orchestration-checklist.md) — Task tool allowedTools requirement
+- [Schedule skill CI plugin discovery](2026-02-27-schedule-skill-ci-plugin-discovery-and-version-hygiene.md) — claude-code-action plugin setup
+
+## Tags
+
+category: integration-issues
+module: ci-workflows
+severity: high

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "3.7.11",
+  "version": "3.7.12",
   "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. 61 agents, 3 commands, 54 skills, and 3 MCP servers that compound your company knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.7.12] - 2026-03-02
+
+### Fixed
+
+- **scheduled-competitive-analysis workflow** -- Re-authenticate with `github.token` in the persist step. The `claude-code-action` post-step revokes the GitHub App installation token, causing `git push` to fail with auth errors.
+
+### Changed
+
+- **competitive-analysis skill** -- Added note about token revocation in Scheduled Execution section.
+
 ## [3.7.11] - 2026-03-02
 
 ### Added

--- a/plugins/soleur/skills/competitive-analysis/SKILL.md
+++ b/plugins/soleur/skills/competitive-analysis/SKILL.md
@@ -38,4 +38,4 @@ After the agent completes:
 
 ## Scheduled Execution
 
-The `scheduled-competitive-analysis.yml` workflow runs this skill monthly via `claude-code-action`. After the agent writes the report, a shell step pushes it directly to main — making `knowledge-base/overview/competitive-intelligence.md` a living document updated each run. The GitHub Issue is still created as an audit trail.
+The `scheduled-competitive-analysis.yml` workflow runs this skill monthly via `claude-code-action`. After the agent writes the report, a shell step pushes it directly to main — making `knowledge-base/overview/competitive-intelligence.md` a living document updated each run. The persist step re-authenticates with `github.token` because `claude-code-action` revokes the App installation token in its post-step cleanup. The GitHub Issue is still created as an audit trail.


### PR DESCRIPTION
## Summary

- Fix `git push` auth failure in the scheduled competitive analysis workflow's persist step
- The `claude-code-action` post-step revokes the GitHub App installation token before subsequent steps run
- Re-authenticate using `github.token` via `git remote set-url` before pushing

## Root Cause

The `claude-code-action` cleanup phase calls `curl -X DELETE .../installation/token`, revoking the credential that `actions/checkout` configured. The persist step inherits the revoked credential and fails with `fatal: Authentication failed`.

## Changes

| File | Change |
|------|--------|
| `scheduled-competitive-analysis.yml` | Add `GH_TOKEN`/`REPO` env vars and `git remote set-url` before push |
| `competitive-analysis/SKILL.md` | Document token revocation behavior in Scheduled Execution section |
| `knowledge-base/learnings/...` | New learning documenting the failure mode |
| Version files (5) | Bump to v3.7.12 |

## Test plan

- [ ] Re-run `gh workflow run scheduled-competitive-analysis.yml` after merge
- [ ] Verify persist step pushes successfully (no auth error)
- [ ] Verify report appears at `knowledge-base/overview/competitive-intelligence.md` on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)