### PR TITLE
fix(ci): move report push into agent prompt to bypass branch protection (v3.7.14)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "soleur",
       "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. Agents, skills, and MCP servers that compound your company knowledge over time.",
-      "version": "3.7.13",
+      "version": "3.7.14",
       "author": {
         "name": "Jean Deruelle",
         "email": "jean.deruelle@jikigai.com"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "3.7.13"
+      placeholder: "3.7.14"
     validations:
       required: true
   - type: input

--- a/.github/workflows/scheduled-competitive-analysis.yml
+++ b/.github/workflows/scheduled-competitive-analysis.yml
@@ -49,35 +49,10 @@ jobs:
             "[Scheduled] Competitive Analysis - <today's date in YYYY-MM-DD format>"
             with the label "scheduled-competitive-analysis" summarizing your findings.
 
-      - name: Persist competitive intelligence report
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-        run: |
-          FILE="knowledge-base/overview/competitive-intelligence.md"
-          if [ ! -f "$FILE" ]; then
-            echo "::warning::Report file not found, skipping persist step"
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          # Re-authenticate after claude-code-action revokes the installation token
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
-
-          git add "$FILE"
-
-          # Skip if report content is identical to what's on main
-          if git diff --cached --quiet; then
-            echo "::notice::Report unchanged, skipping"
-            exit 0
-          fi
-
-          git commit -m "docs: update competitive intelligence report"
-
-          # Retry with rebase if main has diverged during the run
-          git push origin main || {
-            git pull --rebase origin main
-            git push origin main
-          }
+            After creating the issue, persist the report to main by running these
+            bash commands in order:
+            1. git add knowledge-base/overview/competitive-intelligence.md
+            2. If `git diff --cached --quiet` succeeds (exit 0), the file is unchanged — skip the remaining steps.
+            3. git commit -m "docs: update competitive intelligence report"
+            4. git push origin main
+            If the push fails, retry: git pull --rebase origin main && git push origin main

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Company-as-a-Service platform. Collapse the friction between a startup idea 
 
 61 agents across engineering, finance, marketing, legal, operations, product, sales, and support -- compounding your company knowledge with every session.
 
-[![Version](https://img.shields.io/badge/version-3.7.13-blue)](https://github.com/jikig-ai/soleur/releases)
+[![Version](https://img.shields.io/badge/version-3.7.14-blue)](https://github.com/jikig-ai/soleur/releases)
 [![License](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/PYZbPBKMUY)
 [![Website](https://img.shields.io/badge/website-soleur.ai-C9A962)](https://soleur.ai)

--- a/knowledge-base/learnings/2026-03-02-claude-code-action-token-revocation-breaks-persist-step.md
+++ b/knowledge-base/learnings/2026-03-02-claude-code-action-token-revocation-breaks-persist-step.md
@@ -13,25 +13,30 @@ The `claude-code-action` post-step cleanup revokes the GitHub App installation t
 
 ## Solution
 
-Re-authenticate in the persist step using `${{ github.token }}` (GITHUB_TOKEN), which is scoped to the job and survives third-party action cleanup:
+Move the `git push` into the Claude agent's prompt so it executes **during** the `claude-code-action` step, while the App installation token is still valid.
+
+Two blockers prevent a separate post-action persist step:
+
+1. **Token revocation** — `claude-code-action` revokes the App installation token in its post-step cleanup. Re-authenticating with `GITHUB_TOKEN` solves auth but hits blocker #2.
+2. **Branch protection** — The CLA Required ruleset blocks direct pushes to main unless the actor has bypass privileges. `GITHUB_TOKEN` pushes as `github-actions[bot]`, which can't be added as a bypass actor via API (it's a platform-builtin, not an installed integration). The Claude App **can** be added as a bypass actor through the GitHub UI.
+
+By pushing inside the agent, the push uses the Claude App's identity (which has bypass) and the token hasn't been revoked yet.
 
 ```yaml
-- name: Persist competitive intelligence report
-  env:
-    GH_TOKEN: ${{ github.token }}
-    REPO: ${{ github.repository }}
-  run: |
-    git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
-    # ... git add, commit, push as before
+prompt: |
+  ... run the analysis ...
+  After creating the issue, persist the report to main by running:
+  1. git add knowledge-base/overview/competitive-intelligence.md
+  2. git diff --cached --quiet (if exit 0, skip — unchanged)
+  3. git commit -m "docs: update competitive intelligence report"
+  4. git push origin main
 ```
-
-Pass both values via `env:` to avoid expression injection in `run:` blocks.
 
 ## Key Insight
 
-Any GitHub Actions workflow step that runs **after** `claude-code-action` (or similar actions that manage their own installation tokens) cannot rely on `actions/checkout` credentials. Always re-authenticate with `${{ github.token }}` via `git remote set-url` before any git push in post-action steps.
+When `claude-code-action` needs to push generated files, the push must happen **inside the agent prompt** — not in a subsequent workflow step. Two independent issues prevent post-action pushes: (1) the action revokes its own token in cleanup, and (2) `github-actions[bot]` cannot be granted ruleset bypass via the GitHub API (only through the UI, and only for installed Apps).
 
-This applies to any workflow that: (1) uses `claude-code-action` to generate files, then (2) has a separate step to commit/push those files.
+The general pattern: any file persistence from `claude-code-action` should be part of the agent's instructions, not a separate shell step.
 
 ## Session Errors
 

--- a/knowledge-base/learnings/2026-03-02-github-actions-auto-push-vs-pr-for-bot-content.md
+++ b/knowledge-base/learnings/2026-03-02-github-actions-auto-push-vs-pr-for-bot-content.md
@@ -12,7 +12,7 @@ Three blockers made the PR approach unworkable:
 
 1. **`allow_auto_merge` is OFF** — `gh pr merge --squash --auto` fails immediately with "auto-merge is not allowed for this repository"
 2. **GITHUB_TOKEN cascade limitation** — PRs created by `GITHUB_TOKEN` don't trigger other workflows (`pull_request`, `pull_request_target` events are suppressed). CI and CLA checks never run, so required status checks never pass, and auto-merge waits forever.
-3. **No branch protection blocks regular pushes** — the repo's rulesets only prevent force-push and branch deletion on main. Regular `git push origin main` is allowed.
+3. **Branch protection now blocks bot pushes (OUTDATED)** — originally, rulesets only prevented force-push and branch deletion. The CLA Required ruleset (added later) blocks all pushes lacking the `cla-check` status. `github-actions[bot]` can't be granted bypass via API. Solution: push inside the `claude-code-action` agent prompt using the Claude App's identity (which has bypass). See `2026-03-02-claude-code-action-token-revocation-breaks-persist-step.md`.
 
 ## Key Insight
 

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "3.7.13",
+  "version": "3.7.14",
   "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. 61 agents, 3 commands, 54 skills, and 3 MCP servers that compound your company knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.7.14] - 2026-03-02
+
+### Fixed
+
+- **scheduled-competitive-analysis workflow** -- Move git push into the Claude agent prompt instead of a separate workflow step. The Claude App has bypass privileges on the CLA Required ruleset, and its token is only valid during the agent step (revoked in post-step cleanup). Supersedes the v3.7.12 fix which solved auth but not branch protection.
+
+### Changed
+
+- **competitive-analysis skill** -- Updated Scheduled Execution docs to explain why persistence must happen inside the agent.
+
 ## [3.7.13] - 2026-03-02
 
 ### Changed

--- a/plugins/soleur/skills/competitive-analysis/SKILL.md
+++ b/plugins/soleur/skills/competitive-analysis/SKILL.md
@@ -38,4 +38,4 @@ After the agent completes:
 
 ## Scheduled Execution
 
-The `scheduled-competitive-analysis.yml` workflow runs this skill monthly via `claude-code-action`. After the agent writes the report, a shell step pushes it directly to main — making `knowledge-base/overview/competitive-intelligence.md` a living document updated each run. The persist step re-authenticates with `github.token` because `claude-code-action` revokes the App installation token in its post-step cleanup. The GitHub Issue is still created as an audit trail.
+The `scheduled-competitive-analysis.yml` workflow runs this skill monthly via `claude-code-action`. The agent's prompt includes instructions to commit and push the report to main after creating the audit trail issue. The push must happen inside the agent (not a separate workflow step) because: (1) `claude-code-action` revokes the App installation token in its post-step cleanup, and (2) the Claude App is a bypass actor on the CLA Required ruleset, so only pushes under its identity succeed. The GitHub Issue is still created as an audit trail.


### PR DESCRIPTION
## Summary

- Move `git push` from a separate workflow step into the Claude agent's prompt
- The Claude App (bypass actor on CLA Required ruleset) pushes while its token is still valid
- Removes the broken persist step entirely — two independent blockers made it unworkable:
  1. Token revocation: `claude-code-action` revokes its App token in post-step cleanup
  2. Branch protection: `github-actions[bot]` can't be added as a ruleset bypass actor via API

## Changes

| File | Change |
|------|--------|
| `scheduled-competitive-analysis.yml` | Remove persist step, add push instructions to agent prompt |
| `competitive-analysis/SKILL.md` | Update docs explaining why push must be inside the agent |
| Learning docs (2) | Updated with full root cause and corrected outdated claims |
| Version files (5) | Bump to v3.7.14 |

## Test plan

- [ ] Merge this PR
- [ ] Run `gh workflow run scheduled-competitive-analysis.yml`
- [ ] Verify the agent pushes the report to main (no separate persist step)
- [ ] Verify `knowledge-base/overview/competitive-intelligence.md` appears on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)