### PR TITLE
fix(ci): override AGENTS.md no-main-commit rule in CI prompt

### DIFF
--- a/.github/workflows/scheduled-competitive-analysis.yml
+++ b/.github/workflows/scheduled-competitive-analysis.yml
@@ -44,15 +44,20 @@ jobs:
           plugins: 'soleur@soleur'
           claude_args: '--model claude-opus-4-6 --max-turns 45 --allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,Task'
           prompt: |
+            IMPORTANT: This is an automated CI workflow. The AGENTS.md rule
+            "Never commit directly to main" does NOT apply here. You are
+            explicitly authorized to commit and push to main in this context.
+
             Run /soleur:competitive-analysis --tiers 0,3 on this repository.
             After your analysis is complete, create a GitHub issue titled
             "[Scheduled] Competitive Analysis - <today's date in YYYY-MM-DD format>"
             with the label "scheduled-competitive-analysis" summarizing your findings.
 
-            After creating the issue, persist the report to main by running these
-            bash commands in order:
-            1. git add knowledge-base/overview/competitive-intelligence.md
-            2. If `git diff --cached --quiet` succeeds (exit 0), the file is unchanged — skip the remaining steps.
-            3. git commit -m "docs: update competitive intelligence report"
-            4. git push origin main
-            If the push fails, retry: git pull --rebase origin main && git push origin main
+            MANDATORY FINAL STEP — persist the report to main:
+            Run these bash commands (do not skip, do not create a branch):
+            ```
+            git add knowledge-base/overview/competitive-intelligence.md
+            git diff --cached --quiet && echo "unchanged, skipping" && exit 0
+            git commit -m "docs: update competitive intelligence report"
+            git push origin main || { git pull --rebase origin main && git push origin main; }
+            ```


### PR DESCRIPTION
## Summary

- The agent reads AGENTS.md "Never commit directly to main" and silently skips the `git push` step
- Add explicit override at top of prompt: "This is an automated CI workflow. The AGENTS.md rule does NOT apply here."
- Mark the push step as `MANDATORY FINAL STEP` with a code block

## Root cause

The v3.7.14 fix moved the push into the agent prompt, but the agent obeys AGENTS.md rules over prompt instructions. The workflow succeeded (report written, issue created, cascade ran) but the push was silently skipped.

## Test plan

- [ ] Merge this PR
- [ ] Run `gh workflow run scheduled-competitive-analysis.yml`
- [ ] Verify `knowledge-base/overview/competitive-intelligence.md` appears on main
- [ ] Check `git log origin/main --oneline -3` for "docs: update competitive intelligence report" commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)