### PR TITLE
fix(ci): cascade through priority levels in bug-fixer issue selection

### DIFF
--- a/.github/workflows/scheduled-bug-fixer.yml
+++ b/.github/workflows/scheduled-bug-fixer.yml
@@ -1,7 +1,8 @@
-# Daily bot-fix agent for low-priority bugs.
-# Picks the oldest open issue with priority/p3-low + type/bug (excluding
-# bot-fix/attempted), then invokes soleur:fix-issue to attempt a single-file
-# fix and open a PR for human review.
+# Daily bot-fix agent for open bugs.
+# Cascades through priority levels (p3-low → p2-medium → p1-high), picking
+# the oldest open issue with type/bug (excluding bot-fix/attempted), then
+# invokes soleur:fix-issue to attempt a single-file fix and open a PR for
+# human review.
 # Phase 2 of #370. Runs after daily triage (04:00 UTC).
 # To test manually: gh workflow run scheduled-bug-fixer.yml
 #
@@ -62,19 +63,22 @@ jobs:
             exit 0
           fi
 
-          ISSUE=$(gh issue list \
-            --label "priority/p3-low" \
-            --label "type/bug" \
-            --state open \
-            --json number,title,labels,createdAt \
-            --jq '[.[] | select(.labels | map(.name) | index("bot-fix/attempted") | not)] | sort_by(.createdAt) | .[0].number // empty')
+          for PRIORITY in priority/p3-low priority/p2-medium priority/p1-high; do
+            ISSUE=$(gh issue list \
+              --label "$PRIORITY" \
+              --label "type/bug" \
+              --state open \
+              --json number,title,labels,createdAt \
+              --jq '[.[] | select(.labels | map(.name) | index("bot-fix/attempted") | not)] | sort_by(.createdAt) | .[0].number // empty')
 
-          if [[ -z "$ISSUE" ]]; then
-            echo "No qualifying issues found"
-            exit 0
-          fi
+            if [[ -n "$ISSUE" ]]; then
+              echo "Selected issue #$ISSUE from $PRIORITY"
+              echo "issue=$ISSUE" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
 
-          echo "issue=$ISSUE" >> "$GITHUB_OUTPUT"
+          echo "No qualifying issues found at any priority level"
 
       - name: Fix issue
         if: steps.select.outputs.issue

--- a/knowledge-base/learnings/2026-03-03-scheduled-bot-fix-workflow-patterns.md
+++ b/knowledge-base/learnings/2026-03-03-scheduled-bot-fix-workflow-patterns.md
@@ -6,13 +6,26 @@ Designing a daily automated agent that picks up low-priority bugs and opens PRs 
 
 ## Solution
 
-Three key patterns emerged during the supervised bug-fix agent implementation (#376):
+Four key patterns emerged during the supervised bug-fix agent implementation (#376, #385):
 
 ### 1. Test Baseline Before Changes
 
 Run `bun test` before making any changes. Record pass/fail state. After the fix, compare against baseline. Only new failures introduced by the fix are grounds for aborting -- pre-existing failures are acceptable. Without this, agents abort on repos with any pre-existing test failures.
 
-### 2. Label-Based Retry Prevention
+### 2. Cascading Priority Selection
+
+Don't hardcode a single priority level. If no p3-low bugs exist, the bot sits idle. Instead, cascade through priority levels:
+
+```bash
+for PRIORITY in priority/p3-low priority/p2-medium priority/p1-high; do
+  ISSUE=$(gh issue list --label "$PRIORITY" --label "type/bug" ...)
+  if [[ -n "$ISSUE" ]]; then break; fi
+done
+```
+
+This ensures the bot always attempts the lowest-priority available bug first, but escalates when the backlog at lower levels is empty. Discovered during dogfooding when both open bugs were p2-medium and the bot found nothing to fix.
+
+### 3. Label-Based Retry Prevention
 
 Add `bot-fix/attempted` label on failure. Filter with `--jq` since `gh issue list` has no `--exclude-label` flag:
 
@@ -24,7 +37,7 @@ gh issue list --label "priority/p3-low" --label "type/bug" --state open \
 
 Note: `gh issue list` returns newest-first by default. Use `sort_by(.createdAt) | .[0]` to get the oldest issue (FIFO backlog processing).
 
-### 3. Ref Not Closes in Bot PRs
+### 4. Ref Not Closes in Bot PRs
 
 Use `Ref #N` in PR body, never `Closes #N`, `Fixes #N`, or `Resolves #N`. Bot PRs must not auto-close issues. The human reviewer verifies the fix works and manually closes the issue. This prevents premature closure of issues that the bot only partially fixed.
 

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -96,6 +96,7 @@ Project principles organized by domain. Add principles as you learn them.
 - Use `gh pr merge <number> --squash --auto` instead of `gh pr checks --watch` followed by `gh pr merge` -- `--watch` exits immediately with "no checks reported" when CI hasn't registered yet, causing premature merge attempts; `--auto` queues the merge and GitHub handles waiting for all branch protection requirements
 - Run SpecFlow analysis (spec-flow-analyzer agent) on features that modify CI workflows or GitHub Actions -- it catches repo configuration blockers (auto-merge settings, rulesets, token permissions) before implementation begins
 - Multi-agent cascades (one agent spawning specialists via Task tool) require a pre-flight checklist: (1) `Task` must be in `--allowedTools` for CI workflows, (2) every specialist must have an explicit write target path in the delegation table, (3) every specialist must produce a writable artifact -- read-only analysis tasks need a concrete output file. Cascade failures are silent: missing tools, unspecified write targets, and no-output specialists all fail without error messages
+- Scheduled workflows that select issues by label must cascade through priority levels (p3-low → p2-medium → p1-high) rather than hardcoding a single tier -- a fixed filter produces idle runs when the target tier is empty while higher-priority bugs accumulate
 
 ### Never
 

--- a/knowledge-base/specs/feat-bug-fix-agent/spec.md
+++ b/knowledge-base/specs/feat-bug-fix-agent/spec.md
@@ -2,11 +2,11 @@
 
 ## Problem Statement
 
-Low-priority bugs accumulate in the issue tracker because human developers prioritize higher-impact work. An automated agent can pick up trivial, single-file bug fixes and open PRs for human review, reducing the backlog without requiring developer time for the initial fix attempt.
+Bugs accumulate in the issue tracker because human developers prioritize higher-impact work. An automated agent can pick up trivial, single-file bug fixes and open PRs for human review, reducing the backlog without requiring developer time for the initial fix attempt.
 
 ## Goals
 
-- Automatically attempt fixes for `priority/p3-low` + `type/bug` issues daily
+- Automatically attempt fixes for `type/bug` issues daily, cascading from p3-low through p2-medium to p1-high
 - Open PRs with clear descriptions linking to the source issue
 - Require human merge approval on every bot PR (no auto-merge)
 - Keep cost bounded with `--max-turns` and `timeout-minutes`
@@ -27,7 +27,7 @@ Low-priority bugs accumulate in the issue tracker because human developers prior
 
 ### FR1: Issue Selection
 
-The agent selects the oldest open issue matching `priority/p3-low` + `type/bug` that has not been previously attempted. Issues with a `bot-fix/attempted` label (if retry prevention is adopted) are skipped.
+The agent cascades through priority levels in order: `priority/p3-low`, then `priority/p2-medium`, then `priority/p1-high`. At each level, it selects the oldest open issue matching that priority + `type/bug` that has not been previously attempted. Issues with a `bot-fix/attempted` label are skipped. The first match found wins — the agent does not process multiple issues per run.
 
 ### FR2: Fix Attempt
 


### PR DESCRIPTION
## Summary

- Bug-fixer workflow now cascades through priority levels (p3-low → p2-medium → p1-high) instead of hardcoding p3-low only
- Discovered during dogfooding: both open bugs were p2-medium, so the bot found nothing to fix
- Updated spec, learnings, and constitution to reflect cascading selection pattern

## Test plan

- [x] Triggered workflow manually — confirmed it completes without error
- [ ] After merge, trigger `gh workflow run scheduled-bug-fixer.yml` to verify it picks up a p2-medium bug
- [ ] Verify override path still works: `gh workflow run scheduled-bug-fixer.yml -f issue_number=367`

🤖 Generated with [Claude Code](https://claude.com/claude-code)