### PR TITLE
fix(ci): skip issues that already have open bot-fix PRs

### DIFF
--- a/.github/workflows/scheduled-bug-fixer.yml
+++ b/.github/workflows/scheduled-bug-fixer.yml
@@ -1,8 +1,8 @@
 # Daily bot-fix agent for open bugs.
 # Cascades through priority levels (p3-low → p2-medium → p1-high), picking
-# the oldest open issue with type/bug (excluding bot-fix/attempted), then
-# invokes soleur:fix-issue to attempt a single-file fix and open a PR for
-# human review.
+# the oldest open issue with type/bug (excluding bot-fix/attempted and issues
+# that already have an open bot-fix PR), then invokes soleur:fix-issue to
+# attempt a single-file fix and open a PR for human review.
 # Phase 2 of #370. Runs after daily triage (04:00 UTC).
 # To test manually: gh workflow run scheduled-bug-fixer.yml
 #
@@ -63,13 +63,25 @@ jobs:
             exit 0
           fi
 
+          # Collect issue numbers that already have open bot-fix PRs
+          OPEN_FIXES=$(gh pr list \
+            --state open \
+            --json headRefName \
+            --jq '[.[].headRefName | select(startswith("bot-fix/")) | split("/")[1] | split("-")[0]] | unique | join(",")')
+          echo "Issues with open bot-fix PRs: ${OPEN_FIXES:-none}"
+
           for PRIORITY in priority/p3-low priority/p2-medium priority/p1-high; do
             ISSUE=$(gh issue list \
               --label "$PRIORITY" \
               --label "type/bug" \
               --state open \
               --json number,title,labels,createdAt \
-              --jq '[.[] | select(.labels | map(.name) | index("bot-fix/attempted") | not)] | sort_by(.createdAt) | .[0].number // empty')
+              --jq --arg skip "$OPEN_FIXES" '
+                ($skip | split(",") | map(select(length > 0)) | map(tonumber? // empty)) as $skip_nums |
+                [.[] | select(
+                  (.labels | map(.name) | index("bot-fix/attempted") | not) and
+                  (.number | IN($skip_nums[]) | not)
+                )] | sort_by(.createdAt) | .[0].number // empty')
 
             if [[ -n "$ISSUE" ]]; then
               echo "Selected issue #$ISSUE from $PRIORITY"

--- a/knowledge-base/learnings/2026-03-03-scheduled-bot-fix-workflow-patterns.md
+++ b/knowledge-base/learnings/2026-03-03-scheduled-bot-fix-workflow-patterns.md
@@ -6,7 +6,7 @@ Designing a daily automated agent that picks up low-priority bugs and opens PRs 
 
 ## Solution
 
-Four key patterns emerged during the supervised bug-fix agent implementation (#376, #385):
+Five key patterns emerged during the supervised bug-fix agent implementation (#376, #385):
 
 ### 1. Test Baseline Before Changes
 
@@ -25,7 +25,23 @@ done
 
 This ensures the bot always attempts the lowest-priority available bug first, but escalates when the backlog at lower levels is empty. Discovered during dogfooding when both open bugs were p2-medium and the bot found nothing to fix.
 
-### 3. Label-Based Retry Prevention
+### 3. Skip Issues With Open Bot-Fix PRs
+
+The `bot-fix/attempted` label only covers failures. Successful fixes leave no exclusion marker, so the bot can re-select an issue that already has an open PR — wasting a run and risking merge conflicts when two PRs touch the same file. Fix: before the priority loop, collect issue numbers from open `bot-fix/*` branches and exclude them from selection via jq's `IN()`:
+
+```bash
+OPEN_FIXES=$(gh pr list --state open --json headRefName \
+  --jq '[.[].headRefName | select(startswith("bot-fix/")) | split("/")[1] | split("-")[0]] | unique | join(",")')
+
+# In the jq filter:
+--jq --arg skip "$OPEN_FIXES" '
+  ($skip | split(",") | map(select(length > 0)) | map(tonumber? // empty)) as $skip_nums |
+  [.[] | select(.number | IN($skip_nums[]) | not)] | ...'
+```
+
+Note: use `select(length > 0)` not `select(. != "")` — the `!=` operator gets mangled by shell escaping in GitHub Actions `run:` blocks.
+
+### 4. Label-Based Retry Prevention
 
 Add `bot-fix/attempted` label on failure. Filter with `--jq` since `gh issue list` has no `--exclude-label` flag:
 
@@ -37,7 +53,7 @@ gh issue list --label "priority/p3-low" --label "type/bug" --state open \
 
 Note: `gh issue list` returns newest-first by default. Use `sort_by(.createdAt) | .[0]` to get the oldest issue (FIFO backlog processing).
 
-### 4. Ref Not Closes in Bot PRs
+### 5. Ref Not Closes in Bot PRs
 
 Use `Ref #N` in PR body, never `Closes #N`, `Fixes #N`, or `Resolves #N`. Bot PRs must not auto-close issues. The human reviewer verifies the fix works and manually closes the issue. This prevents premature closure of issues that the bot only partially fixed.
 


### PR DESCRIPTION
## Summary

- Bug-fixer now excludes issues that already have an open `bot-fix/*` PR from selection
- Prevents wasted runs re-fixing already-fixed issues and merge conflicts when two PRs touch the same file
- Discovered during dogfooding: both #367 and #368 produced PRs touching the same file (`skills/work/SKILL.md`)

## Test plan

- [x] Tested jq filter locally with simulated data — correctly skips issues in the exclusion list
- [x] Verified empty skip list returns oldest issue (no false exclusions)
- [ ] After merge, trigger `gh workflow run scheduled-bug-fixer.yml` with open bot-fix PRs to verify skip behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)