### PR TITLE
chore: sync knowledge-base with codebase state (v3.8.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "soleur",
       "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. Agents, skills, and MCP servers that compound your company knowledge over time.",
-      "version": "3.8.1",
+      "version": "3.8.2",
       "author": {
         "name": "Jean Deruelle",
         "email": "jean.deruelle@jikigai.com"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Plugin version
       description: "Run `claude plugin list` to check"
-      placeholder: "3.8.1"
+      placeholder: "3.8.2"
     validations:
       required: true
   - type: input

--- a/knowledge-base/learnings/2026-03-03-scheduled-bot-fix-workflow-patterns.md
+++ b/knowledge-base/learnings/2026-03-03-scheduled-bot-fix-workflow-patterns.md
@@ -1,3 +1,7 @@
+---
+synced_to: [schedule]
+---
+
 # Learning: Scheduled Bot-Fix Workflow Patterns
 
 ## Problem

--- a/knowledge-base/learnings/technical-debt/2026-03-03-community-skill-missing-skill-md.md
+++ b/knowledge-base/learnings/technical-debt/2026-03-03-community-skill-missing-skill-md.md
@@ -1,0 +1,23 @@
+---
+title: Community skill directory missing SKILL.md
+date: 2026-03-03
+category: technical-debt
+tags: [plugin-structure, skills, community]
+severity: low
+---
+
+# Community Skill Missing SKILL.md
+
+## Problem
+
+The `plugins/soleur/skills/community/` directory contains only `scripts/` with no `SKILL.md` file. This makes it structurally incomplete -- it would fail the `components.test.ts` validation test that requires every skill directory to have a `SKILL.md`.
+
+The skill likely avoids the test because skill discovery looks for `skills/*/SKILL.md` and skips directories without one.
+
+## Key Insight
+
+Either add a `SKILL.md` to make it a proper skill, or move the scripts to a shared `scripts/` location if they are utility scripts not meant to be a standalone skill.
+
+## Tags
+
+plugin-structure, skills, community

--- a/knowledge-base/learnings/technical-debt/2026-03-03-no-unified-test-runner-from-repo-root.md
+++ b/knowledge-base/learnings/technical-debt/2026-03-03-no-unified-test-runner-from-repo-root.md
@@ -1,0 +1,26 @@
+---
+title: No unified test runner from repo root
+date: 2026-03-03
+category: technical-debt
+tags: [testing, bun, ci, developer-experience]
+severity: low
+---
+
+# No Unified Test Runner from Repo Root
+
+## Problem
+
+The repository has two completely separate test suites with no top-level test script to run them together. The root `package.json` has no `test` script (only `docs:dev` and `docs:build`). Each suite must be run independently:
+
+- `apps/telegram-bridge/` -- `bun test` (3 test files, ~130 tests)
+- `plugins/soleur/test/` -- `bun test` (component validation tests)
+
+There is no single command that exercises both suites from the repo root.
+
+## Key Insight
+
+CI already runs both suites separately in `ci.yml` (different `working-directory` values), so correctness is not at risk. The gap is developer experience -- contributors must know to run tests in both locations manually.
+
+## Tags
+
+testing, developer-experience, ci

--- a/knowledge-base/learnings/technical-debt/2026-03-03-telegram-bridge-index-ts-mixed-concerns.md
+++ b/knowledge-base/learnings/technical-debt/2026-03-03-telegram-bridge-index-ts-mixed-concerns.md
@@ -1,0 +1,27 @@
+---
+title: Telegram bridge index.ts mixes three concerns with no test coverage
+date: 2026-03-03
+category: technical-debt
+tags: [telegram-bridge, code-organization, testing]
+severity: medium
+---
+
+# Telegram Bridge index.ts Mixes Three Concerns
+
+## Problem
+
+`apps/telegram-bridge/src/index.ts` is 402 lines handling three distinct concerns:
+
+1. Environment variable validation and configuration
+2. grammY bot setup and message routing
+3. Claude CLI process lifecycle management (spawn, restart loop with exponential backoff, stdout parsing)
+
+The core logic module `bridge.ts` (438 lines) is well-tested with ~130 tests, but `index.ts` has zero test coverage and no corresponding `index.test.ts`.
+
+## Key Insight
+
+The process-management logic (exponential backoff, restart loop, stdout stream parsing) is complex enough to warrant extraction into a testable module. Entry points are inherently harder to test, but extracting the process manager would bring the untested surface area under control.
+
+## Tags
+
+telegram-bridge, code-organization, testing

--- a/knowledge-base/learnings/technical-debt/2026-03-03-timer-based-async-settling-in-bridge-tests.md
+++ b/knowledge-base/learnings/technical-debt/2026-03-03-timer-based-async-settling-in-bridge-tests.md
@@ -1,0 +1,27 @@
+---
+title: Timer-based async settling in bridge tests
+date: 2026-03-03
+category: technical-debt
+tags: [testing, async, flaky-tests, telegram-bridge]
+severity: medium
+---
+
+# Timer-Based Async Settling in Bridge Tests
+
+## Problem
+
+11 test cases in `apps/telegram-bridge/test/bridge.test.ts` use `await new Promise((r) => setTimeout(r, 50))` to wait for fire-and-forget async operations to settle. One test uses a 200ms wait for a watchdog timer.
+
+Affected lines: 372, 397, 489, 513, 674, 700, 733, 745, 814, 822, 844.
+
+## Root Cause
+
+`Bridge` methods like `startTurnStatus` and `sendUserMessage` fire-and-forget their async work without returning a handle. Tests have no way to await completion other than time-based settling.
+
+## Key Insight
+
+Timer-based settling is sensitive to machine load and could produce false negatives on slow CI runners. The fix is to return `Promise` handles from fire-and-forget methods, but this requires changing the Bridge API contract.
+
+## Tags
+
+testing, async, flaky-tests, telegram-bridge

--- a/knowledge-base/learnings/technical-debt/2026-03-03-unverified-pencil-desktop-bundle-id.md
+++ b/knowledge-base/learnings/technical-debt/2026-03-03-unverified-pencil-desktop-bundle-id.md
@@ -1,0 +1,29 @@
+---
+title: Unverified Pencil Desktop bundle ID in check_deps.sh
+date: 2026-03-03
+category: technical-debt
+tags: [pencil, macos, dependency-detection]
+severity: low
+synced_to: [pencil-setup]
+---
+
+# Unverified Pencil Desktop Bundle ID
+
+## Problem
+
+`plugins/soleur/skills/pencil-setup/scripts/check_deps.sh:28` contains a TODO acknowledging an unverified assumption:
+
+```bash
+# TODO: verify bundle ID 'dev.pencil.desktop' against actual Pencil.app Info.plist
+mdfind "kMDItemCFBundleIdentifier == 'dev.pencil.desktop'" 2>/dev/null | grep -q . && return 0
+```
+
+If the actual Pencil Desktop bundle ID differs, the macOS detection path silently fails and falls back to PATH-based detection.
+
+## Key Insight
+
+This is the only actionable TODO in the entire TypeScript and shell codebase. Low risk since PATH-based fallback works, but should be verified against a real Pencil Desktop installation on macOS.
+
+## Tags
+
+pencil, macos, dependency-detection

--- a/knowledge-base/learnings/technical-debt/2026-03-03-validate-seo-misses-wildcard-user-agent.md
+++ b/knowledge-base/learnings/technical-debt/2026-03-03-validate-seo-misses-wildcard-user-agent.md
@@ -1,0 +1,32 @@
+---
+title: validate-seo.sh misses wildcard User-agent blocks
+date: 2026-03-03
+category: technical-debt
+tags: [seo, robots-txt, validation]
+severity: low
+synced_to: [seo-aeo]
+---
+
+# validate-seo.sh Misses Wildcard User-agent Blocks
+
+## Problem
+
+`plugins/soleur/skills/seo-aeo/scripts/validate-seo.sh` only checks for named AI bot entries in `robots.txt` (e.g., `User-agent: GPTBot`). It does not detect wildcard `User-agent: *` blocks that disallow all bots, producing false negatives when a site blocks everything via wildcard.
+
+## Evidence
+
+A test explicitly documents this limitation:
+
+```typescript
+// plugins/soleur/test/validate-seo.test.ts:111-117
+"does not flag wildcard User-agent block (known limitation)"
+// Script only checks named AI bots, not wildcard rules
+```
+
+## Key Insight
+
+The fix is straightforward (parse `User-agent: *` blocks for `Disallow: /`), but needs care to avoid false positives since many sites use `User-agent: *` with specific path restrictions that are benign.
+
+## Tags
+
+seo, robots-txt, validation

--- a/knowledge-base/overview/README.md
+++ b/knowledge-base/overview/README.md
@@ -91,9 +91,9 @@ Workflow stages are skills, invocable directly or via `/soleur:go`:
 
 | Component | Count | Description |
 |-----------|-------|-------------|
-| [Agents](./components/agents.md) | 45 | AI agents for specialized tasks |
+| [Agents](./components/agents.md) | 61 | AI agents for specialized tasks |
 | [Commands](./components/commands.md) | 3 | Slash commands for entry points |
-| [Skills](./components/skills.md) | 45 | Specialized capabilities |
+| [Skills](./components/skills.md) | 55 | Specialized capabilities |
 | [Knowledge Base](./components/knowledge-base.md) | 1 | Documentation system |
 
 Each component has detailed documentation in [components/](./components/) covering its purpose, available items, usage patterns, and conventions. See individual component docs for full reference.
@@ -108,17 +108,24 @@ Workflow skills like plan and work read the constitution automatically to guide 
 
 ```
 soleur/
+  apps/                     # Standalone applications
+    telegram-bridge/        # Telegram bot bridge to Claude
   plugins/soleur/           # The Claude Code plugin
-    agents/                 # AI agents by category
-      engineering/
-        review/             # Code review agents
-        design/             # Design agents
-      research/             # Research and analysis
-      workflow/             # Workflow automation
+    agents/                 # AI agents by domain (61 agents)
+      engineering/          # review/, design/, discovery/, infra/, research/, workflow/
+      finance/              # CFO, budget, revenue, reporting
+      legal/                # CLO, compliance auditor, document generator
+      marketing/            # CMO + 10 specialists
+      operations/           # COO, ops advisor/research/provisioner
+      product/              # CPO, business validator, competitive intel, design/
+      sales/                # CRO, deal architect, outbound, pipeline
+      support/              # CCO, community manager, ticket triage
     commands/               # Slash commands
-      soleur/               # Core workflow commands
-    skills/                 # Specialized capabilities
+      soleur/               # Core workflow commands (go, sync, help)
+    skills/                 # Specialized capabilities (56 skills)
     .claude-plugin/         # Plugin manifest
+  docs/                     # Documentation and legal content
+    legal/                  # Legal documents (ToS, privacy, GDPR, CLA)
   knowledge-base/           # Project documentation
     learnings/              # Documented solutions
     specs/                  # Feature specifications
@@ -126,6 +133,7 @@ soleur/
     plans/                  # Implementation plans
     overview/               # This documentation
       constitution.md       # Coding conventions
+  scripts/                  # Repo-level utility scripts
 ```
 
 ## Key Concepts
@@ -136,10 +144,16 @@ Every solved problem contributes to the knowledge base. Future similar problems 
 
 ### Agent Hierarchy
 
-Agents are organized by function:
-- **Review agents** catch issues before PR
-- **Research agents** gather context and best practices
-- **Workflow agents** automate repetitive tasks
+Agents are organized by domain first, then by function. Each business domain has a domain leader (C-level agent) that orchestrates specialists:
+
+- **Engineering** (27): CTO + review, design, discovery, infra, research, workflow agents
+- **Finance** (4): CFO + budget, revenue, reporting agents
+- **Legal** (3): CLO + compliance auditor, document generator
+- **Marketing** (11): CMO + brand, SEO, content, conversion, paid, pricing, retention agents
+- **Operations** (4): COO + ops advisor, research, provisioner
+- **Product** (5): CPO + business validator, competitive intel, spec flow, UX design
+- **Sales** (4): CRO + deal architect, outbound, pipeline
+- **Support** (3): CCO + community manager, ticket triage
 
 ### Knowledge-Base Lifecycle
 

--- a/knowledge-base/overview/components/agents.md
+++ b/knowledge-base/overview/components/agents.md
@@ -1,6 +1,6 @@
 ---
 component: agents
-updated: 2026-02-12
+updated: 2026-03-03
 primary_location: plugins/soleur/agents/
 ---
 
@@ -10,11 +10,11 @@ AI agents that perform specialized tasks during the development workflow. Each a
 
 ## Purpose
 
-Provide specialized AI capabilities for specific tasks like code review, research, design verification, and workflow automation. Agents allow the main workflow commands to delegate complex analysis to focused, expert-level AI personas.
+Provide specialized AI capabilities across 8 business domains. Each domain has a leader agent (C-level) that orchestrates specialists, enabling a Company-as-a-Service architecture where any business function can be delegated to an AI agent.
 
 ## Responsibilities
 
-- Perform deep analysis within a specific domain (security, performance, patterns)
+- Perform deep analysis within a specific domain (security, performance, legal, marketing, etc.)
 - Provide consistent, reproducible results following defined instructions
 - Return structured findings for use by other commands
 - Execute in parallel when multiple perspectives are needed
@@ -32,8 +32,8 @@ Task({
 ```
 
 **Naming convention:** Agents are named by their directory path under `agents/`:
-- Engineering agents: `soleur:engineering:review:<name>` or `soleur:engineering:design:<name>`
-- Cross-domain agents: `soleur:research:<name>` or `soleur:workflow:<name>`
+- Domain agents: `soleur:<domain>:<name>` (e.g., `soleur:finance:cfo`)
+- Nested agents: `soleur:<domain>:<function>:<name>` (e.g., `soleur:engineering:review:security-sentinel`)
 
 ## Data Flow
 
@@ -50,13 +50,17 @@ graph LR
 3. Agent reads relevant files, analyzes, and returns findings
 4. Parent command consolidates results
 
-## Categories
+## Categories (61 agents across 8 domains)
 
-Agents are organized by domain first, then by function. Cross-domain agents stay at root level.
+### Engineering (27 agents)
 
-### Engineering (15 agents)
+#### CTO (1)
 
-#### Review (14)
+| Agent | Purpose |
+|-------|---------|
+| `cto` | Assess technical implications, flag architecture concerns during planning |
+
+#### Review (15)
 
 Code review specialists that catch issues before PR:
 
@@ -71,23 +75,34 @@ Code review specialists that catch issues before PR:
 | `deployment-verification-agent` | Go/No-Go deployment checklists |
 | `dhh-rails-reviewer` | Rails review from DHH's perspective |
 | `kieran-rails-reviewer` | Rails code with strict conventions |
-| `legacy-code-expert` | Safely modify untested legacy code using Feathers' dependency-breaking techniques |
+| `legacy-code-expert` | Safely modify untested legacy code using Feathers' techniques |
 | `pattern-recognition-specialist` | Design patterns and anti-patterns |
 | `performance-oracle` | Performance analysis and optimization |
 | `security-sentinel` | Security audits and vulnerabilities |
-| `test-design-reviewer` | Score test quality using Farley's 8 properties with weighted rubric |
+| `semgrep-sast` | Deterministic static analysis using semgrep rules |
+| `test-design-reviewer` | Score test quality using Farley's 8 properties |
 
 #### Design (1)
 
 | Agent | Purpose |
 |-------|---------|
-| `ddd-architect` | Domain-Driven Design with strategic bounded contexts and tactical patterns |
+| `ddd-architect` | Domain-Driven Design with bounded contexts and aggregate design |
 
-### Cross-domain (7 agents)
+#### Discovery (2)
+
+| Agent | Purpose |
+|-------|---------|
+| `agent-finder` | Find community agents for missing tech stack coverage |
+| `functional-discovery` | Check if planned features already exist in registries |
+
+#### Infrastructure (2)
+
+| Agent | Purpose |
+|-------|---------|
+| `infra-security` | Audit domain security, configure DNS/Cloudflare via MCP |
+| `terraform-architect` | Generate and review Terraform configurations |
 
 #### Research (5)
-
-Gather context and best practices:
 
 | Agent | Purpose |
 |-------|---------|
@@ -97,42 +112,96 @@ Gather context and best practices:
 | `learnings-researcher` | Search knowledge-base/learnings/ for relevant solutions |
 | `repo-research-analyst` | Repository structure and conventions |
 
-#### Workflow (2)
-
-Automate repetitive tasks:
+#### Workflow (1)
 
 | Agent | Purpose |
 |-------|---------|
 | `pr-comment-resolver` | Address PR review comments |
+
+### Finance (4 agents)
+
+| Agent | Purpose |
+|-------|---------|
+| `cfo` | Orchestrate finance domain, assess financial posture |
+| `budget-analyst` | Budget plans, spending allocation, burn rate modeling |
+| `financial-reporter` | Financial summaries, cash flow, investor-ready reports |
+| `revenue-analyst` | Revenue tracking, P&L projections, financial forecasts |
+
+### Legal (3 agents)
+
+| Agent | Purpose |
+|-------|---------|
+| `clo` | Orchestrate legal domain, assess legal posture |
+| `legal-compliance-auditor` | Audit documents for compliance gaps and consistency |
+| `legal-document-generator` | Generate draft legal documents |
+
+### Marketing (11 agents)
+
+| Agent | Purpose |
+|-------|---------|
+| `cmo` | Orchestrate marketing domain, unified strategy |
+| `analytics-analyst` | Tracking implementations, event taxonomies, A/B tests |
+| `brand-architect` | Brand identity workshops, voice and tone, visual direction |
+| `conversion-optimizer` | Landing pages, signup flows, paywall optimization |
+| `copywriter` | Landing pages, email sequences, cold outreach, social content |
+| `growth-strategist` | Content strategy, keyword research, content auditing |
+| `paid-media-strategist` | Google/Meta/LinkedIn campaign structure and targeting |
+| `pricing-strategist` | SaaS pricing, tier design, value metric selection |
+| `programmatic-seo-specialist` | Template-driven SEO page generation at scale |
+| `retention-strategist` | Churn prevention, payment recovery, referral programs |
+| `seo-aeo-analyst` | Technical SEO and AI Engine Optimization audits |
+
+### Operations (4 agents)
+
+| Agent | Purpose |
+|-------|---------|
+| `coo` | Orchestrate operations domain, recommend actions |
+| `ops-advisor` | Track operational expenses, manage domains |
+| `ops-provisioner` | Set up SaaS accounts, configure tools |
+| `ops-research` | Research domains, hosting providers, cost optimization |
+
+### Product (5 agents)
+
+| Agent | Purpose |
+|-------|---------|
+| `cpo` | Orchestrate product domain, validate business models |
+| `business-validator` | Structured market research and business model assessment |
+| `competitive-intelligence` | Recurring competitive landscape monitoring |
 | `spec-flow-analyzer` | Analyze specifications for gaps and edge cases |
+| `ux-design-lead` | Visual designs in .pen files using Pencil MCP tools |
+
+### Sales (4 agents)
+
+| Agent | Purpose |
+|-------|---------|
+| `cro` | Orchestrate sales domain, pipeline strategy |
+| `deal-architect` | Proposals, SOWs, battlecards, objection handling |
+| `outbound-strategist` | Outbound prospecting sequences, ICP targeting |
+| `pipeline-analyst` | Pipeline health, deal velocity, stage criteria |
+
+### Support (3 agents)
+
+| Agent | Purpose |
+|-------|---------|
+| `cco` | Orchestrate support domain, assess support posture |
+| `community-manager` | Community engagement analysis, weekly digests |
+| `ticket-triage` | Classify and route GitHub issues by severity and domain |
 
 ## Dependencies
 
 - **Internal**: None (agents are standalone)
 - **External**: Claude Code Task tool, various CLI tools per agent
 
-## Examples
-
-**Run security review:**
-
-```markdown
-Task security-sentinel("Review authentication changes in src/auth/")
-```
-
-**Run multiple reviewers in parallel:**
-
-```markdown
-Task kieran-rails-reviewer("Review controller changes")
-Task code-simplicity-reviewer("Check for over-engineering")
-Task security-sentinel("Audit permission checks")
-```
-
 ## Related Files
 
-- `plugins/soleur/agents/engineering/review/` - Engineering review agents
-- `plugins/soleur/agents/engineering/design/` - Engineering design agents
-- `plugins/soleur/agents/research/` - Research agents
-- `plugins/soleur/agents/workflow/` - Workflow agents
+- `plugins/soleur/agents/engineering/` - Engineering agents (review, design, discovery, infra, research, workflow)
+- `plugins/soleur/agents/finance/` - Finance agents
+- `plugins/soleur/agents/legal/` - Legal agents
+- `plugins/soleur/agents/marketing/` - Marketing agents
+- `plugins/soleur/agents/operations/` - Operations agents
+- `plugins/soleur/agents/product/` - Product agents (includes design/ subdirectory)
+- `plugins/soleur/agents/sales/` - Sales agents
+- `plugins/soleur/agents/support/` - Support agents
 
 ## See Also
 

--- a/knowledge-base/overview/components/skills.md
+++ b/knowledge-base/overview/components/skills.md
@@ -1,6 +1,6 @@
 ---
 component: skills
-updated: 2026-02-12
+updated: 2026-03-03
 primary_location: plugins/soleur/skills/
 ---
 
@@ -10,7 +10,7 @@ Specialized capabilities that extend Claude's knowledge in specific domains. Ski
 
 ## Purpose
 
-Provide domain expertise and specialized workflows that can be loaded on-demand. Unlike agents (which are invoked programmatically), skills are loaded into context to augment Claude's capabilities for specific tasks.
+Provide domain expertise and specialized workflows that can be loaded on-demand. Unlike agents (which are invoked programmatically via Task tool), skills are loaded into context to augment Claude's capabilities for specific tasks.
 
 ## Responsibilities
 
@@ -65,129 +65,140 @@ graph LR
 4. Claude's capabilities enhanced for the domain
 5. Higher quality output in that domain
 
-## Categories (35 skills)
+## Categories (55 skills)
 
-### Architecture & Design
+### Core Workflow (6)
 
-| Skill | Purpose |
-|-------|---------|
-| `agent-native-architecture` | Build AI agents with prompt-native architecture |
-| `frontend-design` | Create production-grade frontend interfaces |
-
-### Engineering Methodology
+The primary development lifecycle, invocable directly or via `/soleur:go`:
 
 | Skill | Purpose |
 |-------|---------|
-| `atdd-developer` | Acceptance Test Driven Development with RED/GREEN/REFACTOR permission gates |
-| `user-story-writer` | Decompose features into INVEST-compliant stories using Elephant Carpaccio |
+| `brainstorm` | Clarify requirements, explore approaches, route to domain experts |
+| `plan` | Transform features into structured implementation plans |
+| `work` | Execute plans systematically with incremental commits |
+| `review` | Multi-agent code review before PR |
+| `compound` | Capture learnings and promote knowledge to definitions |
+| `one-shot` | Full autonomous workflow from plan to PR with video |
 
-### Development Tools
-
-| Skill | Purpose |
-|-------|---------|
-| `andrew-kane-gem-writer` | Write Ruby gems following Andrew Kane's patterns |
-| `compound-docs` | Capture solved problems as categorized documentation |
-| `create-agent-skills` | Expert guidance for creating Claude Code skills |
-| `dhh-rails-style` | Write Ruby/Rails in DHH's 37signals style |
-| `dspy-ruby` | Build type-safe LLM applications with DSPy.rb |
-| `skill-creator` | Guide for creating effective skills |
-
-### Planning & Review
+### Shipping & Release (6)
 
 | Skill | Purpose |
 |-------|---------|
+| `ship` | Enforce feature lifecycle checklist before creating PRs |
+| `merge-pr` | Merge feature branch to main with conflict resolution and cleanup |
 | `changelog` | Create engaging changelogs for recent merges |
-| `deepen-plan` | Enhance plans with parallel research agents |
-| `deploy-docs` | Validate and prepare documentation for deployment |
-| `plan-review` | Multi-agent plan review in parallel |
-| `release-docs` | Build and update documentation site with current components |
+| `release-announce` | Generate GitHub Releases from CHANGELOG.md |
+| `release-docs` | Update documentation metadata after component changes |
+| `deploy` | Build Docker images, push to GHCR, deploy via SSH |
 
-### Resolution & Automation
-
-| Skill | Purpose |
-|-------|---------|
-| `resolve-parallel` | Resolve TODO comments in parallel |
-| `resolve-pr-parallel` | Resolve PR comments in parallel |
-| `resolve-todo-parallel` | Resolve CLI todos in parallel |
-| `triage` | Triage and categorize findings for the CLI todo system |
-
-### Testing & QA
+### Code Quality & Testing (7)
 
 | Skill | Purpose |
 |-------|---------|
-| `agent-native-audit` | Run comprehensive agent-native architecture review |
-| `feature-video` | Record video walkthroughs and add to PR description |
-| `heal-skill` | Fix skill documentation issues |
-| `report-bug` | Report a bug in the plugin |
-| `reproduce-bug` | Reproduce bugs using logs, console, and browser screenshots |
+| `atdd-developer` | Acceptance Test Driven Development with RED/GREEN/REFACTOR gates |
+| `test-fix-loop` | Iterate on test failures until all pass |
 | `test-browser` | Run browser tests on PR-affected pages |
+| `reproduce-bug` | Reproduce bugs using logs, console, and browser screenshots |
+| `fix-issue` | Automated single-file fix for GitHub issues |
+| `agent-native-audit` | Comprehensive agent-native architecture review |
 | `xcode-test` | Build and test iOS apps on simulator |
 
-### Content & Workflow
+### Planning & Review (4)
 
 | Skill | Purpose |
 |-------|---------|
-| `brainstorming` | Question techniques for effective brainstorming |
-| `every-style-editor` | Review copy for Every's style guide compliance |
+| `plan-review` | Multi-agent plan review in parallel |
+| `deepen-plan` | Enhance plans with parallel research agents |
+| `brainstorm-techniques` | Question techniques for effective brainstorming |
+| `user-story-writer` | Decompose features into INVEST-compliant stories |
+
+### Resolution & Automation (5)
+
+| Skill | Purpose |
+|-------|---------|
+| `resolve-parallel` | Resolve TODO comments in codebase in parallel |
+| `resolve-pr-parallel` | Resolve PR review comments in parallel |
+| `resolve-todo-parallel` | Resolve CLI todos in parallel |
+| `triage` | Triage and categorize findings for the CLI todo system |
+| `schedule` | Create scheduled agent tasks via GitHub Actions cron workflows |
+
+### Knowledge Management (4)
+
+| Skill | Purpose |
+|-------|---------|
+| `compound-capture` | Capture solved problems as categorized documentation |
+| `archive-kb` | Archive completed knowledge-base artifacts |
+| `spec-templates` | Templates for specs, tasks, and component docs |
 | `file-todos` | File-based todo tracking system |
+
+### Documentation & Content (4)
+
+| Skill | Purpose |
+|-------|---------|
+| `deploy-docs` | Validate and prepare documentation for GitHub Pages |
+| `docs-site` | Scaffold Markdown-based documentation site using Eleventy |
+| `content-writer` | Generate article drafts with brand-consistent voice |
+| `every-style-editor` | Review copy for Every's style guide compliance |
+
+### SEO & Growth (3)
+
+| Skill | Purpose |
+|-------|---------|
+| `seo-aeo` | Audit and fix SEO and AI Engine Optimization for Eleventy sites |
+| `growth` | Content strategy, keyword research, content gap analysis |
+| `competitive-analysis` | Competitive intelligence scans and market research |
+
+### Legal (2)
+
+| Skill | Purpose |
+|-------|---------|
+| `legal-generate` | Generate draft legal documents |
+| `legal-audit` | Audit existing legal documents for compliance gaps |
+
+### Social & Community (2)
+
+| Skill | Purpose |
+|-------|---------|
+| `discord-content` | Create and post community content to Discord |
+| `community` | Community engagement scripts (structurally incomplete -- no SKILL.md) |
+
+### Development Style (4)
+
+| Skill | Purpose |
+|-------|---------|
+| `dhh-rails-style` | Write Ruby/Rails in DHH's 37signals style |
+| `andrew-kane-gem-writer` | Write Ruby gems following Andrew Kane's patterns |
+| `dspy-ruby` | Build type-safe LLM applications with DSPy.rb |
+| `frontend-design` | Create production-grade frontend interfaces |
+
+### Architecture (2)
+
+| Skill | Purpose |
+|-------|---------|
+| `agent-native-architecture` | Design agent-native applications |
+| `skill-creator` | Expert guidance for creating Claude Code skills |
+
+### Infrastructure & Tools (5)
+
+| Skill | Purpose |
+|-------|---------|
 | `git-worktree` | Manage Git worktrees for parallel development |
-| `ship` | Enforce feature lifecycle checklist before creating PRs |
-| `spec-templates` | Templates for specs and tasks |
-
-### File Transfer
-
-| Skill | Purpose |
-|-------|---------|
-| `rclone` | Upload files to S3, Cloudflare R2, Backblaze B2, and cloud storage |
-
-### Browser Automation
-
-| Skill | Purpose |
-|-------|---------|
 | `agent-browser` | CLI-based browser automation using Vercel's agent-browser |
+| `rclone` | Upload files to S3, Cloudflare R2, Backblaze B2 |
+| `gemini-imagegen` | Generate and edit images using Google's Gemini API |
+| `pencil-setup` | Install and register Pencil MCP server |
 
-### Image Generation
+### Video & Media (1)
 
 | Skill | Purpose |
 |-------|---------|
-| `gemini-imagegen` | Generate and edit images using Google's Gemini API |
+| `feature-video` | Record video walkthroughs and add to PR descriptions |
 
-## Skill Structure Example
+### Meta (1)
 
-```
-skills/dhh-rails-style/
-  SKILL.md              # Main instructions
-  references/
-    conventions.md      # Rails conventions
-    examples.md         # Code examples
-  scripts/
-    check-style.sh      # Validation script
-```
-
-## Dependencies
-
-- **Internal**: May reference other skills or use scripts
-- **External**: Various CLI tools per skill (rclone, agent-browser, etc.)
-
-## Examples
-
-**Load Rails style guide:**
-
-```
-skill: soleur:dhh-rails-style
-```
-
-**Create a new skill:**
-
-```
-skill: soleur:skill-creator
-```
-
-**Use browser automation:**
-
-```
-skill: soleur:agent-browser
-```
+| Skill | Purpose |
+|-------|---------|
+| `heal-skill` | Fix skill documentation issues discovered during execution |
 
 ## Conventions
 
@@ -201,7 +212,6 @@ From `constitution.md`:
 ## Related Files
 
 - `plugins/soleur/skills/` - All skill directories
-- `plugins/soleur/AGENTS.md` - Skill compliance checklist
 
 ## See Also
 

--- a/knowledge-base/overview/components/telegram-bridge.md
+++ b/knowledge-base/overview/components/telegram-bridge.md
@@ -1,0 +1,88 @@
+---
+component: telegram-bridge
+updated: 2026-03-03
+primary_location: apps/telegram-bridge/
+---
+
+# Telegram Bridge
+
+A standalone Bun/TypeScript application that bridges Telegram to the Claude Code CLI via stdin/stdout. Messages sent to a Telegram bot are forwarded to a Claude Code session running with the Soleur plugin, and responses stream back in real time.
+
+## Purpose
+
+Provide a mobile-accessible interface to Claude Code + Soleur. The bot uses long-polling (outbound only), so no public HTTP endpoint or TLS certificate is required. Single-user lockdown via `TELEGRAM_ALLOWED_USER_ID`.
+
+## Responsibilities
+
+- Forward Telegram messages to Claude Code CLI via NDJSON stdio
+- Stream responses back to Telegram using progressive `editMessageText` calls
+- Manage Claude CLI process lifecycle (spawn, restart with exponential backoff)
+- Provide health check endpoint for monitoring
+
+## Key Interfaces
+
+**Runtime:** Bun + grammY bot framework + `@grammyjs/parse-mode`
+
+**Architecture:**
+
+```
+Telegram App --> (Bot API, long polling) --> Bridge Server (Bun + grammY)
+    --> (stdin/stdout, NDJSON) --> Claude Code CLI + Soleur Plugin
+    --> Project Files
+```
+
+**Infrastructure:** Hetzner Cloud CX22 with Terraform provisioning:
+- `infra/main.tf` - Hetzner provider and network
+- `infra/server.tf` - CX22 instance with cloud-init
+- `infra/firewall.tf` - SSH + health check firewall rules
+- `infra/variables.tf` / `infra/outputs.tf` - Configuration
+- Monthly cost: ~EUR 4.43 (~$4.80 USD)
+
+## Data Flow
+
+```mermaid
+graph LR
+    TG[Telegram App] -->|Bot API| BR[Bridge Server]
+    BR -->|NDJSON stdio| CLI[Claude Code CLI]
+    CLI -->|Reads/Writes| FS[Project Files]
+    CLI -->|Streaming| BR
+    BR -->|editMessageText| TG
+```
+
+## Source Structure
+
+```
+apps/telegram-bridge/
+  src/
+    index.ts          # Entry point: env validation, grammY setup, CLI lifecycle
+    bridge.ts         # Core logic: message handling, streaming, status management
+    health.ts         # Health check HTTP server
+    types.ts          # Shared type definitions
+  test/
+    bridge.test.ts    # ~130 tests covering bridge logic
+    health.test.ts    # Health endpoint tests
+  infra/              # Terraform for Hetzner Cloud
+  scripts/            # deploy.sh, remote.sh for operations
+  Dockerfile          # Production container
+```
+
+## Dependencies
+
+- **Internal**: Soleur plugin (loaded into Claude Code CLI)
+- **External**: grammY (Telegram Bot API), Bun runtime, Docker, Hetzner Cloud
+
+## Testing
+
+- `bun test` from `apps/telegram-bridge/` runs the test suite
+- CI enforces coverage via `bun test --coverage` in `ci.yml`
+- Tests use factory functions (`createMockApi()`) and `beforeEach`/`afterEach` lifecycle
+
+## Related Files
+
+- `apps/telegram-bridge/README.md` - Setup and operations guide
+- `.github/workflows/ci.yml` - CI job for bridge tests
+
+## See Also
+
+- [Skills](./skills.md) - Skills invoked through the bridge
+- [Agents](./agents.md) - Agents available via the bridge

--- a/knowledge-base/overview/constitution.md
+++ b/knowledge-base/overview/constitution.md
@@ -30,6 +30,9 @@ Project principles organized by domain. Add principles as you learn them.
 - CSS is organized into `@layer` cascade layers in order: reset, tokens, base, layout, components, utilities; custom properties follow semantic naming (`--color-*`, `--font-*`, `--text-*`, `--space-*`)
 - CHANGELOG follows Keep a Changelog format with `### Added`, `### Changed`, `### Fixed`, `### Removed` section headers under `## [X.Y.Z] - YYYY-MM-DD` version entries
 - Plan files use `YYYY-MM-DD-<type>-<descriptive-name>-plan.md` filename format; learning files use `YYYY-MM-DD-<descriptive-slug>.md` format
+- Learning files must include YAML frontmatter with `title`, `date`, `category`, and `tags` fields; optional fields include `symptoms`, `module`, and `synced_to`
+- Plan files must include YAML frontmatter with `title` (conventional commit prefix), `type` (fix/feat), and `date` fields
+- Linting configuration overrides (`.markdownlint.json`, `.eslintrc`, etc.) must include inline comments or a companion doc explaining the rationale for each disabled rule
 
 ### Never
 
@@ -49,6 +52,7 @@ Project principles organized by domain. Add principles as you learn them.
 - Prefer numeric literal underscores as thousand separators for readability (e.g., `3_000` instead of `3000`)
 - Prefer a language identifier after triple backticks in code blocks (e.g., ```bash, ```yaml -- never bare ```)
 - Prefer verb-noun naming for skill directories where applicable (e.g., `deploy-docs`, `release-announce`, `resolve-pr-parallel`)
+- Prefer `# --- Section Name ---` comment headers in shell scripts to separate logical sections
 
 ## Architecture
 
@@ -61,7 +65,7 @@ Project principles organized by domain. Add principles as you learn them.
 - When adding a new skill, manually register it in `docs/_data/skills.js` SKILL_CATEGORIES -- skill discovery does not recurse and the docs site will silently omit unregistered skills
 - After version bumps, diff root README agent/skill counts against plugin README counts -- they drift independently and have diverged multiple times
 - Organize agents by domain first (engineering/, etc.), then by function (review/, design/). Cross-domain agents stay at root level (research/, workflow/)
-- Skills must have a SKILL.md file and may include scripts/, references/, and assets/ subdirectories
+- Skills must have a SKILL.md file and may include scripts/, references/, and assets/ subdirectories; directories under `skills/` without SKILL.md must be deleted or converted to proper skills
 - Every SKILL.md interactive prompt (AskUserQuestion) must accept an `$ARGUMENTS` bypass path for programmatic callers -- agents and pipeline skills cannot answer interactive prompts; provide flag-based argument passthrough (e.g., `--name`, `--yes`) that skips the prompt when present
 - Lifecycle workflows with hooks must cover every state transition with a cleanup trigger; verify no gaps between create, ship, merge, and session-start
 - At session start, run `worktree-manager.sh cleanup-merged` to remove worktrees whose remote branches are [gone]; this is the recovery mechanism for the merge-then-session-end gap where cleanup was deferred

--- a/plugins/soleur/.claude-plugin/plugin.json
+++ b/plugins/soleur/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "soleur",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support. 61 agents, 3 commands, 55 skills, and 3 MCP servers that compound your company knowledge over time.",
   "author": {
     "name": "Jean Deruelle",

--- a/plugins/soleur/CHANGELOG.md
+++ b/plugins/soleur/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.8.2] - 2026-03-03
+
+### Changed
+
+- **knowledge-base overview** -- Full refresh of agents.md (22 -> 61 agents, 2 -> 9 domain categories), skills.md (35 -> 55 skills in 14 categories), and README.md counts
+- **constitution** -- Added 5 new rules: learning file frontmatter, plan file frontmatter, linting config rationale, shell section headers, and skill directory SKILL.md enforcement
+- **seo-aeo skill** -- Added known-limitation note about wildcard User-agent detection gap
+- **pencil-setup skill** -- Added known-limitation note about unverified macOS bundle ID
+- **schedule skill** -- Added known-limitation note about cascading priority selection
+
+### Added
+
+- **telegram-bridge component doc** -- New component documentation for the standalone Telegram bridge app
+- **6 technical debt learnings** -- No unified test runner, timer-based async settling, Pencil bundle ID, index.ts mixed concerns, validate-seo wildcard gap, community skill missing SKILL.md
+
 ## [3.8.1] - 2026-03-03
 
 ### Fixed

--- a/plugins/soleur/skills/pencil-setup/SKILL.md
+++ b/plugins/soleur/skills/pencil-setup/SKILL.md
@@ -9,6 +9,8 @@ Auto-detect, install, and register the Pencil MCP server with Claude Code CLI.
 
 **Prerequisite:** VS Code or Cursor must be installed. Pencil MCP requires a running IDE with the Pencil extension active. Pencil Desktop is optional.
 
+**Known limitation:** macOS detection uses unverified bundle ID `dev.pencil.desktop` -- falls back to PATH-based detection if incorrect.
+
 ## Phase 0: Dependency Check
 
 Run [check_deps.sh](./scripts/check_deps.sh) before proceeding. When invoked

--- a/plugins/soleur/skills/schedule/SKILL.md
+++ b/plugins/soleur/skills/schedule/SKILL.md
@@ -172,3 +172,4 @@ Remove a scheduled workflow.
 - **No label pre-creation** — The template instructs issue creation with a label but does not pre-create it. Add a `gh label create ... || true` step manually.
 - **No `timeout-minutes`** — The template does not set a job-level timeout. LLM-backed workflows should add `timeout-minutes` to prevent runaway billing.
 - **No `--allowedTools` in `claude_args`** — `claude-code-action` blocks Bash, Write, WebSearch, and WebFetch by default. Skills that create GitHub issues or perform web research silently fail without `--allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch` in `claude_args`.
+- **No cascading priority selection** — Generated workflows that select issues by label hardcode a single priority tier. When that tier is empty, the bot sits idle while higher-priority bugs accumulate. Manually add a priority cascade loop (p3 -> p2 -> p1) after generation.

--- a/plugins/soleur/skills/seo-aeo/SKILL.md
+++ b/plugins/soleur/skills/seo-aeo/SKILL.md
@@ -107,3 +107,5 @@ Run the standalone validation script against built output.
    - **Exit 1:** Show failing checks and recommend running `seo-aeo fix`
 
 Validation script: [validate-seo.sh](./scripts/validate-seo.sh)
+
+**Known limitation:** validate-seo.sh only checks named AI bot entries -- wildcard `User-agent: *` blocks are not detected. A site blocking all bots via wildcard will pass validation.


### PR DESCRIPTION
## Summary

- Full refresh of overview docs: agents.md (22 -> 61 agents, 2 -> 9 domain categories), skills.md (35 -> 55 skills, 14 categories), README.md counts
- 5 new constitution rules: learning frontmatter, plan frontmatter, linting config rationale, shell section headers, skill directory SKILL.md enforcement
- 6 technical debt learnings: no unified test runner, timer-based async settling, Pencil bundle ID, index.ts mixed concerns, validate-seo wildcard gap, community skill missing SKILL.md
- New telegram-bridge component doc
- 3 definition sync bullets: seo-aeo wildcard limitation, pencil-setup bundle ID, schedule cascading priority

## Test plan

- [ ] Verify `bun test` passes (plugin component tests validate frontmatter)
- [ ] Verify markdownlint passes on new/modified .md files
- [ ] Spot-check agents.md and skills.md counts match `find` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)