### PR TITLE
fix: remove redundant Soleur prefix from landing H1

### DIFF
--- a/plugins/soleur/docs/index.njk
+++ b/plugins/soleur/docs/index.njk
@@ -7,7 +7,7 @@ permalink: index.html
 
     <!-- Hero -->
     <section class="landing-hero">
-      <h1>Soleur: Build a Billion-Dollar Company. Alone.</h1>
+      <h1>Build a Billion-Dollar Company. Alone.</h1>
       <p class="hero-sub">The company-as-a-service platform for solo founders. {{ stats.agents }} AI agents across {{ stats.departments }} departments &mdash; engineering, marketing, legal, finance, sales, and more &mdash; orchestrated from a single Claude Code plugin.</p>
       <div class="hero-cta">
         <a href="pages/getting-started.html" class="btn btn-primary">Start Building</a>


### PR DESCRIPTION
## Summary

- Remove "Soleur:" prefix from homepage H1, reverting to the original "Build a Billion-Dollar Company. Alone."
- Brand name is already present in `<title>`, header nav, OG tags, and JSON-LD — repeating it in the H1 weakens the headline

## Changelog

- Removed redundant "Soleur:" prefix from landing page H1

## Test plan

- [ ] `npm run docs:build` passes
- [ ] Homepage H1 reads "Build a Billion-Dollar Company. Alone." (no prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)