### PR TITLE
fix: use export + $ENV in scheduled-bug-fixer jq expression

### DIFF
--- a/.github/workflows/scheduled-bug-fixer.yml
+++ b/.github/workflows/scheduled-bug-fixer.yml
@@ -68,6 +68,7 @@ jobs:
             --state open \
             --json headRefName \
             --jq '[.[].headRefName | select(startswith("bot-fix/")) | split("/")[1] | split("-")[0]] | unique | join(",")')
+          export OPEN_FIXES
           echo "Issues with open bot-fix PRs: ${OPEN_FIXES:-none}"
 
           for PRIORITY in priority/p3-low priority/p2-medium priority/p1-high; do
@@ -76,8 +77,8 @@ jobs:
               --label "type/bug" \
               --state open \
               --json number,title,labels,createdAt \
-              --jq --arg skip "$OPEN_FIXES" '
-                ($skip | split(",") | map(select(length > 0)) | map(tonumber? // empty)) as $skip_nums |
+              --jq '
+                ($ENV.OPEN_FIXES | split(",") | map(select(length > 0)) | map(tonumber? // empty)) as $skip_nums |
                 [.[] | select(
                   (.labels | map(.name) | index("bot-fix/attempted") | not) and
                   (.number | IN($skip_nums[]) | not)

--- a/knowledge-base/learnings/2026-03-03-scheduled-bot-fix-workflow-patterns.md
+++ b/knowledge-base/learnings/2026-03-03-scheduled-bot-fix-workflow-patterns.md
@@ -36,12 +36,15 @@ The `bot-fix/attempted` label only covers failures. Successful fixes leave no ex
 ```bash
 OPEN_FIXES=$(gh pr list --state open --json headRefName \
   --jq '[.[].headRefName | select(startswith("bot-fix/")) | split("/")[1] | split("-")[0]] | unique | join(",")')
+export OPEN_FIXES
 
-# In the jq filter:
---jq --arg skip "$OPEN_FIXES" '
-  ($skip | split(",") | map(select(length > 0)) | map(tonumber? // empty)) as $skip_nums |
+# In the jq filter — use $ENV.OPEN_FIXES, NOT --arg:
+--jq '
+  ($ENV.OPEN_FIXES | split(",") | map(select(length > 0)) | map(tonumber? // empty)) as $skip_nums |
   [.[] | select(.number | IN($skip_nums[]) | not)] | ...'
 ```
+
+**Important:** `gh --jq` accepts only a single jq expression string. It does NOT support jq flags like `--arg`, `--argjson`, etc. — those get parsed as unknown `gh` arguments. Use `export` + `$ENV.variable_name` to pass shell variables into jq expressions with `gh`.
 
 Note: use `select(length > 0)` not `select(. != "")` — the `!=` operator gets mangled by shell escaping in GitHub Actions `run:` blocks.
 

--- a/knowledge-base/plans/2026-03-04-fix-gh-issue-list-jq-arg-unsupported-plan.md
+++ b/knowledge-base/plans/2026-03-04-fix-gh-issue-list-jq-arg-unsupported-plan.md
@@ -33,10 +33,10 @@ unknown arguments ["skip" "" "\n ($skip | split(\",\") ..."]
 
 ## Acceptance Criteria
 
-- [ ] The `Select issue` step in `scheduled-bug-fixer.yml` no longer uses `--arg` with `--jq`
-- [ ] The `OPEN_FIXES` shell variable is exported and accessed via `$ENV.OPEN_FIXES` in the jq expression
-- [ ] The jq filter logic (split, tonumber, IN exclusion) remains functionally identical
-- [ ] The learnings doc `knowledge-base/learnings/2026-03-03-scheduled-bot-fix-workflow-patterns.md` is updated to reflect the correct pattern (no `--arg`, use `$ENV`)
+- [x] The `Select issue` step in `scheduled-bug-fixer.yml` no longer uses `--arg` with `--jq`
+- [x] The `OPEN_FIXES` shell variable is exported and accessed via `$ENV.OPEN_FIXES` in the jq expression
+- [x] The jq filter logic (split, tonumber, IN exclusion) remains functionally identical
+- [x] The learnings doc `knowledge-base/learnings/2026-03-03-scheduled-bot-fix-workflow-patterns.md` is updated to reflect the correct pattern (no `--arg`, use `$ENV`)
 - [ ] Workflow runs successfully on `workflow_dispatch` trigger (or at next scheduled run)
 
 ## Test Scenarios

--- a/knowledge-base/specs/feat-fix-issue-jq-args/session-state.md
+++ b/knowledge-base/specs/feat-fix-issue-jq-args/session-state.md
@@ -1,0 +1,21 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-fix-issue-jq-args/knowledge-base/plans/2026-03-04-fix-gh-issue-list-jq-arg-unsupported-plan.md
+- Status: complete
+
+### Errors
+None
+
+### Decisions
+- Chose `export` + `$ENV.OPEN_FIXES` over quote-unquote-quote shell interpolation — cleaner separation of shell and jq concerns, no quoting gymnastics, no shell injection surface, standard jq feature
+- Validated all edge cases with actual jq binary execution — empty string, single number, and comma-separated list all produce correct results
+- Identified two files requiring changes — the workflow file and the learnings document which contains the same broken pattern
+- Selected MINIMAL plan template — focused two-file bug fix with clear root cause and known solution
+- Confirmed `gh` CLI's go-jq implementation supports `$ENV` — tested locally that `gh --jq '$ENV.OPEN_FIXES'` reads exported environment variables correctly
+
+### Components Invoked
+- soleur:plan
+- soleur:deepen-plan
+- gh run view, gh issue list --help
+- Local jq binary for edge case validation

--- a/knowledge-base/specs/feat-fix-issue-jq-args/tasks.md
+++ b/knowledge-base/specs/feat-fix-issue-jq-args/tasks.md
@@ -2,7 +2,7 @@
 
 ## Phase 1: Core Fix
 
-- [ ] 1.1 Update `scheduled-bug-fixer.yml` "Select issue" step to use `export` + `$ENV.OPEN_FIXES` instead of `--arg skip`
+- [x] 1.1 Update `scheduled-bug-fixer.yml` "Select issue" step to use `export` + `$ENV.OPEN_FIXES` instead of `--arg skip`
   - Add `export OPEN_FIXES` after the `OPEN_FIXES=$(gh pr list ...)` assignment (after line 70)
   - Remove `--arg skip "$OPEN_FIXES"` from the `--jq` flag (line 79)
   - Replace `$skip` with `$ENV.OPEN_FIXES` in the jq expression (line 80)
@@ -10,7 +10,7 @@
 
 ## Phase 2: Documentation
 
-- [ ] 2.1 Update learnings document to reflect the corrected pattern
+- [x] 2.1 Update learnings document to reflect the corrected pattern
   - Fix the code example in section "3. Skip Issues With Open Bot-Fix PRs" to use `export OPEN_FIXES` + `$ENV.OPEN_FIXES`
   - Remove the `--arg skip` from the example
   - Add a note that `gh --jq` does not support jq flags like `--arg`; use `$ENV` instead
@@ -19,4 +19,4 @@
 ## Phase 3: Verification
 
 - [ ] 3.1 Run compound skill before commit
-- [ ] 3.2 Edge cases already validated locally with jq binary (empty string, single number, comma-separated list all produce correct results)
+- [x] 3.2 Edge cases already validated locally with jq binary (empty string, single number, comma-separated list all produce correct results)


### PR DESCRIPTION
## Summary
- Fix the scheduled bug-fixer overnight run failure where the "Select issue" step crashed with `unknown arguments`
- `gh issue list --jq` does not support jq flags like `--arg` — they get parsed as unknown positional arguments
- Replace `--arg skip "$OPEN_FIXES"` with `export OPEN_FIXES` + `$ENV.OPEN_FIXES` in the jq expression

## Changelog
- Fix: scheduled-bug-fixer workflow now correctly passes shell variables to jq via `$ENV` instead of unsupported `--arg` flag
- Docs: updated learnings doc with correct pattern and explicit warning about `gh --jq` limitation

## Test plan
- [x] Verified jq edge cases locally: empty string, single number, comma-separated list all produce correct results
- [x] All 953 tests pass (`bun test`)
- [ ] Trigger `workflow_dispatch` on main after merge to verify end-to-end

Ref: https://github.com/jikig-ai/soleur/actions/runs/22657970844/job/65671713661

Generated with [Claude Code](https://claude.com/claude-code)