### PR TITLE
fix: replace predictable /tmp paths with mktemp in release workflow

### DIFF
--- a/.github/workflows/version-bump-and-release.yml
+++ b/.github/workflows/version-bump-and-release.yml
@@ -51,6 +51,15 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
 
+      - name: Create secure temp files
+        if: steps.check_plugin.outputs.changed == 'true'
+        id: tmpfiles
+        run: |
+          echo "pr_body=$(mktemp)" >> $GITHUB_OUTPUT
+          echo "release_notes=$(mktemp)" >> $GITHUB_OUTPUT
+          echo "current_tag=$(mktemp)" >> $GITHUB_OUTPUT
+          echo "gh_err=$(mktemp)" >> $GITHUB_OUTPUT
+
       - name: Find merged PR
         if: steps.check_plugin.outputs.changed == 'true'
         id: pr
@@ -58,6 +67,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
           COMMIT_MSG: ${{ github.event.head_commit.message }}
+          PR_BODY_FILE: ${{ steps.tmpfiles.outputs.pr_body }}
         run: |
           # Fallback: emit empty PR metadata and use commit message as title
           give_up() {
@@ -66,8 +76,8 @@ jobs:
             echo "number=" >> $GITHUB_OUTPUT
             echo "title=$(echo "$COMMIT_MSG" | head -1)" >> $GITHUB_OUTPUT
             echo "labels=" >> $GITHUB_OUTPUT
-            echo "" > /tmp/pr_body.txt
-            echo "body_file=/tmp/pr_body.txt" >> $GITHUB_OUTPUT
+            echo "" > "$PR_BODY_FILE"
+            echo "body_file=$PR_BODY_FILE" >> $GITHUB_OUTPUT
             exit 0
           }
 
@@ -75,8 +85,8 @@ jobs:
             echo "number=" >> $GITHUB_OUTPUT
             echo "title=Manual version bump" >> $GITHUB_OUTPUT
             echo "labels=" >> $GITHUB_OUTPUT
-            echo "" > /tmp/pr_body.txt
-            echo "body_file=/tmp/pr_body.txt" >> $GITHUB_OUTPUT
+            echo "" > "$PR_BODY_FILE"
+            echo "body_file=$PR_BODY_FILE" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -107,8 +117,8 @@ jobs:
           echo "number=$PR_NUM" >> $GITHUB_OUTPUT
           echo "title=$(echo "$PR_JSON" | jq -r '.title')" >> $GITHUB_OUTPUT
           echo "labels=$(echo "$PR_JSON" | jq -r '[.labels[].name] | join(",")')" >> $GITHUB_OUTPUT
-          echo "$PR_JSON" | jq -r '.body // ""' > /tmp/pr_body.txt
-          echo "body_file=/tmp/pr_body.txt" >> $GITHUB_OUTPUT
+          echo "$PR_JSON" | jq -r '.body // ""' > "$PR_BODY_FILE"
+          echo "body_file=$PR_BODY_FILE" >> $GITHUB_OUTPUT
 
       - name: Determine bump type
         if: steps.check_plugin.outputs.changed == 'true'
@@ -140,18 +150,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           BUMP_TYPE: ${{ steps.bump.outputs.type }}
+          CURRENT_TAG_FILE: ${{ steps.tmpfiles.outputs.current_tag }}
+          GH_ERR_FILE: ${{ steps.tmpfiles.outputs.gh_err }}
         run: |
           # Separate "no releases yet" from "API error"
-          if ! gh release view --json tagName --jq '.tagName' > /tmp/current_tag 2>/tmp/gh_err; then
-            if grep -q "release not found" /tmp/gh_err; then
+          if ! gh release view --json tagName --jq '.tagName' > "$CURRENT_TAG_FILE" 2>"$GH_ERR_FILE"; then
+            if grep -q "release not found" "$GH_ERR_FILE"; then
               CURRENT="0.0.0"
               echo "No existing releases, starting from 0.0.0"
             else
-              echo "::error::gh release view failed: $(cat /tmp/gh_err)"
+              echo "::error::gh release view failed: $(cat "$GH_ERR_FILE")"
               exit 1
             fi
           else
-            CURRENT=$(sed 's/^v//' /tmp/current_tag)
+            CURRENT=$(sed 's/^v//' "$CURRENT_TAG_FILE")
           fi
           echo "current=$CURRENT" >> $GITHUB_OUTPUT
 
@@ -193,9 +205,9 @@ jobs:
         id: changelog
         env:
           PR_TITLE: ${{ steps.pr.outputs.title }}
+          BODY_FILE: ${{ steps.tmpfiles.outputs.pr_body }}
+          RELEASE_NOTES_FILE: ${{ steps.tmpfiles.outputs.release_notes }}
         run: |
-          BODY_FILE="/tmp/pr_body.txt"
-
           # Extract content between ## Changelog and next ## heading
           CHANGELOG=""
           if [ -f "$BODY_FILE" ] && [ -s "$BODY_FILE" ]; then
@@ -211,30 +223,32 @@ jobs:
           fi
 
           # Write release notes (just the body, no heading)
-          echo "$CHANGELOG" > /tmp/release_notes.txt
+          echo "$CHANGELOG" > "$RELEASE_NOTES_FILE"
 
       - name: Create GitHub Release
         if: steps.check_plugin.outputs.changed == 'true' && steps.idempotency.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
+          RELEASE_NOTES_FILE: ${{ steps.tmpfiles.outputs.release_notes }}
         run: |
           gh release create "$TAG" \
             --title "$TAG" \
-            --notes-file /tmp/release_notes.txt
+            --notes-file "$RELEASE_NOTES_FILE"
 
       - name: Post to Discord
         if: steps.check_plugin.outputs.changed == 'true' && steps.idempotency.outputs.exists == 'false'
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           TAG: ${{ steps.version.outputs.tag }}
+          RELEASE_NOTES_FILE: ${{ steps.tmpfiles.outputs.release_notes }}
         run: |
           if [ -z "$DISCORD_WEBHOOK_URL" ]; then
             echo "DISCORD_WEBHOOK_URL secret not set, skipping Discord notification"
             exit 0
           fi
 
-          BODY=$(cat /tmp/release_notes.txt)
+          BODY=$(cat "$RELEASE_NOTES_FILE")
           REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
           RELEASE_URL="${REPO_URL}/releases/tag/${TAG}"
 

--- a/knowledge-base/plans/2026-03-04-sec-secure-tmp-paths-in-release-workflow-plan.md
+++ b/knowledge-base/plans/2026-03-04-sec-secure-tmp-paths-in-release-workflow-plan.md
@@ -144,14 +144,14 @@ Then replace every `/tmp/pr_body.txt` with `${{ steps.tmpfiles.outputs.pr_body }
 
 ## Acceptance Criteria
 
-- [ ] No hardcoded `/tmp/` paths remain in `version-bump-and-release.yml`
-- [ ] All temp files are created via `mktemp` in a dedicated step
-- [ ] Temp file paths are passed between steps via `GITHUB_OUTPUT`
-- [ ] Existing step conditions (`if:`) and logic are unchanged
-- [ ] The `give_up()` function uses the secure path via `$PR_BODY_FILE` env var
-- [ ] The workflow_dispatch branch uses the secure path via `$PR_BODY_FILE` env var
-- [ ] The tmpfiles step has the same `if:` guard as downstream steps
-- [ ] `grep -n '/tmp/' .github/workflows/version-bump-and-release.yml` returns zero results
+- [x] No hardcoded `/tmp/` paths remain in `version-bump-and-release.yml`
+- [x] All temp files are created via `mktemp` in a dedicated step
+- [x] Temp file paths are passed between steps via `GITHUB_OUTPUT`
+- [x] Existing step conditions (`if:`) and logic are unchanged
+- [x] The `give_up()` function uses the secure path via `$PR_BODY_FILE` env var
+- [x] The workflow_dispatch branch uses the secure path via `$PR_BODY_FILE` env var
+- [x] The tmpfiles step has the same `if:` guard as downstream steps
+- [x] `grep -n '/tmp/' .github/workflows/version-bump-and-release.yml` returns zero results
 
 ## Test Scenarios
 

--- a/knowledge-base/specs/feat-secure-tmp-paths/session-state.md
+++ b/knowledge-base/specs/feat-secure-tmp-paths/session-state.md
@@ -1,0 +1,23 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-secure-tmp-paths/knowledge-base/plans/2026-03-04-sec-secure-tmp-paths-in-release-workflow-plan.md
+- Status: complete
+
+### Errors
+None
+
+### Decisions
+- Selected `mktemp` over `$RUNNER_TEMP` and `$GITHUB_WORKSPACE/.github/tmp/` -- `mktemp` provides the core security property (unpredictable filenames via `O_CREAT|O_EXCL`) that the other alternatives lack
+- Placed tmpfiles step after `check_plugin` with matching `if:` guard -- avoids creating unnecessary temp files when workflow short-circuits
+- Pass temp paths via `env:` blocks, not inline `${{ }}` in shell functions -- env vars are the correct mechanism for shell function access
+- MINIMAL detail level -- single-file, mechanical substitution fix with clear scope
+- Semver label: `patch` -- security hardening fix with no user-facing behavior change
+
+### Components Invoked
+- `skill: soleur:plan` -- created initial plan and tasks
+- `skill: soleur:deepen-plan` -- enhanced plan with security research, edge cases, and institutional learnings
+- GitHub issue #426 fetch via `gh issue view`
+- Web searches for `mktemp` best practices, `RUNNER_TEMP`, CWE-377, and GitHub Actions `GITHUB_OUTPUT` patterns
+- Read of `security-sentinel.md` and `code-simplicity-reviewer.md` agent specs
+- Read of 4 institutional learnings

--- a/knowledge-base/specs/feat-secure-tmp-paths/tasks.md
+++ b/knowledge-base/specs/feat-secure-tmp-paths/tasks.md
@@ -8,9 +8,9 @@ Add a new step `Create secure temp files` (id: `tmpfiles`) after checkout and be
 
 **File:** `.github/workflows/version-bump-and-release.yml`
 
-- [ ] Add step with `id: tmpfiles`
-- [ ] Create `pr_body`, `release_notes`, `current_tag`, `gh_err` via `mktemp`
-- [ ] Export all four paths to `$GITHUB_OUTPUT`
+- [x] Add step with `id: tmpfiles`
+- [x] Create `pr_body`, `release_notes`, `current_tag`, `gh_err` via `mktemp`
+- [x] Export all four paths to `$GITHUB_OUTPUT`
 
 ### 1.2 Update "Find merged PR" step
 
@@ -18,11 +18,11 @@ Replace all `/tmp/pr_body.txt` references with the secure path from `steps.tmpfi
 
 **File:** `.github/workflows/version-bump-and-release.yml`
 
-- [ ] Pass `PR_BODY_FILE: ${{ steps.tmpfiles.outputs.pr_body }}` via `env:`
-- [ ] Update `give_up()` function to use `$PR_BODY_FILE` instead of `/tmp/pr_body.txt`
-- [ ] Update `workflow_dispatch` branch to use `$PR_BODY_FILE`
-- [ ] Update PR metadata write to use `$PR_BODY_FILE`
-- [ ] Update `body_file=` output to reference the env var
+- [x] Pass `PR_BODY_FILE: ${{ steps.tmpfiles.outputs.pr_body }}` via `env:`
+- [x] Update `give_up()` function to use `$PR_BODY_FILE` instead of `/tmp/pr_body.txt`
+- [x] Update `workflow_dispatch` branch to use `$PR_BODY_FILE`
+- [x] Update PR metadata write to use `$PR_BODY_FILE`
+- [x] Update `body_file=` output to reference the env var
 
 ### 1.3 Update "Compute next version" step
 
@@ -30,10 +30,10 @@ Replace `/tmp/current_tag` and `/tmp/gh_err` with secure paths.
 
 **File:** `.github/workflows/version-bump-and-release.yml`
 
-- [ ] Pass `CURRENT_TAG_FILE: ${{ steps.tmpfiles.outputs.current_tag }}` via `env:`
-- [ ] Pass `GH_ERR_FILE: ${{ steps.tmpfiles.outputs.gh_err }}` via `env:`
-- [ ] Update `gh release view` redirect to use `$CURRENT_TAG_FILE` and `$GH_ERR_FILE`
-- [ ] Update `grep` and `sed` commands to reference the new paths
+- [x] Pass `CURRENT_TAG_FILE: ${{ steps.tmpfiles.outputs.current_tag }}` via `env:`
+- [x] Pass `GH_ERR_FILE: ${{ steps.tmpfiles.outputs.gh_err }}` via `env:`
+- [x] Update `gh release view` redirect to use `$CURRENT_TAG_FILE` and `$GH_ERR_FILE`
+- [x] Update `grep` and `sed` commands to reference the new paths
 
 ### 1.4 Update "Extract changelog" step
 
@@ -41,10 +41,10 @@ Replace `/tmp/pr_body.txt` and `/tmp/release_notes.txt` with secure paths.
 
 **File:** `.github/workflows/version-bump-and-release.yml`
 
-- [ ] Pass `BODY_FILE: ${{ steps.tmpfiles.outputs.pr_body }}` via `env:` (replace hardcoded assignment)
-- [ ] Pass `RELEASE_NOTES_FILE: ${{ steps.tmpfiles.outputs.release_notes }}` via `env:`
-- [ ] Update `BODY_FILE=` assignment to use the env var
-- [ ] Update release notes write to use `$RELEASE_NOTES_FILE`
+- [x] Pass `BODY_FILE: ${{ steps.tmpfiles.outputs.pr_body }}` via `env:` (replace hardcoded assignment)
+- [x] Pass `RELEASE_NOTES_FILE: ${{ steps.tmpfiles.outputs.release_notes }}` via `env:`
+- [x] Update `BODY_FILE=` assignment to use the env var
+- [x] Update release notes write to use `$RELEASE_NOTES_FILE`
 
 ### 1.5 Update "Create GitHub Release" step
 
@@ -52,8 +52,8 @@ Replace `/tmp/release_notes.txt` with secure path.
 
 **File:** `.github/workflows/version-bump-and-release.yml`
 
-- [ ] Pass `RELEASE_NOTES_FILE: ${{ steps.tmpfiles.outputs.release_notes }}` via `env:`
-- [ ] Update `--notes-file` to reference `$RELEASE_NOTES_FILE`
+- [x] Pass `RELEASE_NOTES_FILE: ${{ steps.tmpfiles.outputs.release_notes }}` via `env:`
+- [x] Update `--notes-file` to reference `$RELEASE_NOTES_FILE`
 
 ### 1.6 Update "Post to Discord" step
 
@@ -61,17 +61,17 @@ Replace `/tmp/release_notes.txt` with secure path.
 
 **File:** `.github/workflows/version-bump-and-release.yml`
 
-- [ ] Pass `RELEASE_NOTES_FILE: ${{ steps.tmpfiles.outputs.release_notes }}` via `env:`
-- [ ] Update `cat` command to reference `$RELEASE_NOTES_FILE`
+- [x] Pass `RELEASE_NOTES_FILE: ${{ steps.tmpfiles.outputs.release_notes }}` via `env:`
+- [x] Update `cat` command to reference `$RELEASE_NOTES_FILE`
 
 ## Phase 2: Verification
 
 ### 2.1 Grep verification
 
-- [ ] Run `grep -n '/tmp/' .github/workflows/version-bump-and-release.yml` -- must return zero results
-- [ ] Run `grep -c 'tmpfiles.outputs' .github/workflows/version-bump-and-release.yml` -- must return count matching all temp path references
+- [x] Run `grep -n '/tmp/' .github/workflows/version-bump-and-release.yml` -- must return zero results
+- [x] Run `grep -c 'tmpfiles.outputs' .github/workflows/version-bump-and-release.yml` -- must return count matching all temp path references (7)
 
 ### 2.2 YAML validation
 
-- [ ] Verify workflow YAML is valid (no syntax errors from the edits)
-- [ ] Verify all `steps.tmpfiles.outputs.*` references match the keys defined in the tmpfiles step
+- [x] Verify workflow YAML is valid (no syntax errors from the edits)
+- [x] Verify all `steps.tmpfiles.outputs.*` references match the keys defined in the tmpfiles step


### PR DESCRIPTION
## Summary

- Replace all hardcoded `/tmp` paths in `version-bump-and-release.yml` with `mktemp`-generated secure paths
- New "Create secure temp files" step creates 4 temp files via `mktemp` and exports paths via `GITHUB_OUTPUT`
- All downstream steps receive paths through `env:` blocks, ensuring `give_up()` and other shell functions can access them

Fixes #426 (CWE-377: Insecure Temporary File)

## Changelog

- Fixed predictable `/tmp` paths in the version-bump-and-release workflow by replacing them with `mktemp`-generated paths passed between steps via `GITHUB_OUTPUT` (CWE-377)

## Test plan

- [ ] Push to main with plugin changes triggers workflow — temp files created with unpredictable names, release created normally
- [ ] `workflow_dispatch` trigger creates temp files and manual bump succeeds
- [ ] No plugin changes — workflow short-circuits at `check_plugin`, tmpfiles step skipped
- [ ] `gh release view` failure — error captured in secure `$GH_ERR_FILE` path
- [ ] `give_up()` path — writes to `$PR_BODY_FILE` (mktemp path, not hardcoded)
- [ ] `grep -n '/tmp/' .github/workflows/version-bump-and-release.yml` returns zero results

Generated with [Claude Code](https://claude.com/claude-code)