### PR TITLE
fix(schedule): add timeout-minutes, max-turns, and label pre-creation to template

### DIFF
--- a/knowledge-base/learnings/2026-02-27-schedule-skill-template-gaps-first-consumer.md
+++ b/knowledge-base/learnings/2026-02-27-schedule-skill-template-gaps-first-consumer.md
@@ -13,32 +13,23 @@ The `soleur:schedule` skill generates workflow YAML from a fixed template, but t
 
 ## Solution
 
-After generating the workflow with `/soleur:schedule create`, manually apply these fixes:
+All six gaps have been resolved in the template. Five are now generated automatically; one remains manual:
 
-1. **Skill-specific arguments**: The template prompt says `Run /soleur:<SKILL_NAME> on this repository.` with no way to pass arguments like `--tiers 0,3`. Edit the prompt line to include them.
+1. **Skill-specific arguments** (MANUAL): The template prompt says `Run /soleur:<SKILL_NAME> on this repository.` with no way to pass arguments like `--tiers 0,3`. Edit the prompt line to include them after generation.
 
-2. **`--max-turns` in `claude_args`**: The template only includes `--model`. For agents that perform multiple WebSearch/WebFetch calls (competitive intelligence, growth analysis), add `--max-turns 30` (or more) to prevent premature termination.
+2. ~~**`--max-turns` in `claude_args`**~~: Fixed in #443. Template now includes `--max-turns <MAX_TURNS>` (default 30) in `claude_args` using `>-` block scalar format.
 
-3. **Label pre-creation**: The template instructs the agent to create an issue with a label, but `gh issue create --label foo` fails if the label doesn't exist. Add a pre-step:
-   ```yaml
-   - name: Ensure label exists
-     env:
-       GH_TOKEN: ${{ github.token }}
-     run: |
-       gh label create scheduled-<name> \
-         --description "Description" \
-         --color "0E8A16" 2>/dev/null || true
-   ```
+3. ~~**Label pre-creation**~~: Fixed in #443. Template now includes an "Ensure label exists" step with `gh label create ... 2>/dev/null || true`.
 
-4. **`timeout-minutes`**: The template has no job-level timeout. LLM-backed workflows should set `timeout-minutes: 30` (or similar) to prevent runaway billing if the agent gets stuck.
+4. ~~**`timeout-minutes`**~~: Fixed in #443. Template now includes `timeout-minutes: <TIMEOUT>` (default 30) on the job block.
 
-5. **`id-token: write` permission**: `claude-code-action` requires OIDC token access for authentication. Without `id-token: write` in the permissions block, the action fails immediately with "Could not fetch an OIDC token." The existing `claude-code-review.yml` includes this permission, but the schedule skill template did not. [Updated 2026-02-27]
+5. ~~**`id-token: write` permission**~~: Fixed in #341. Template includes `id-token: write` in the permissions block.
 
-6. **`--allowedTools` in `claude_args`**: `claude-code-action` blocks Bash, Write, WebSearch, and WebFetch by default. The agent generated a full competitive analysis report but all 3 `gh issue create` attempts were silently permission-denied. Add `--allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch` to `claude_args`. Without this, the workflow completes "successfully" (exit 0) but produces no output artifact. [Updated 2026-02-27]
+6. ~~**`--allowedTools` in `claude_args`**~~: Fixed in #344. Template includes `--allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch` in `claude_args`.
 
 ## Key Insight
 
-The schedule skill template is a starting point, not a complete workflow. Every generated workflow needs a review pass for: argument passthrough, turn limits, label existence, timeout caps, OIDC permissions, and tool allowlists. The `claude-code-action` sandbox is restrictive by default — the most dangerous gap is `--allowedTools` because the workflow reports success even when all Bash commands are silently blocked.
+After #443 (and prior fixes #321, #341, #344), the schedule skill template generates complete workflows that match the reference implementations. The only remaining manual step is skill-specific argument passthrough. The `claude-code-action` sandbox is restrictive by default — the most dangerous gap was `--allowedTools` because the workflow reports success even when all Bash commands are silently blocked (now fixed in the template).
 
 ## Session Errors
 

--- a/knowledge-base/plans/2026-03-05-fix-schedule-template-remaining-gaps-plan.md
+++ b/knowledge-base/plans/2026-03-05-fix-schedule-template-remaining-gaps-plan.md
@@ -225,15 +225,15 @@ After this fix, the template achieves parity with all three reference workflows 
 
 ## Acceptance Criteria
 
-- [ ] Generated workflow YAML includes `timeout-minutes` on the job block (`plugins/soleur/skills/schedule/SKILL.md` Step 3 template)
-- [ ] Generated workflow YAML includes `--max-turns` in `claude_args` (`plugins/soleur/skills/schedule/SKILL.md` Step 3 template)
-- [ ] Generated workflow YAML includes a label pre-creation step with `gh label create ... || true` (`plugins/soleur/skills/schedule/SKILL.md` Step 3 template)
-- [ ] `claude_args` uses `>-` block scalar format for readability (`plugins/soleur/skills/schedule/SKILL.md` Step 3 template)
-- [ ] Known Limitations section accurately reflects current state -- stale items removed (`plugins/soleur/skills/schedule/SKILL.md` lines 166-176)
-- [ ] Step 1 collects timeout (default 30) and max-turns (default 30) inputs (`plugins/soleur/skills/schedule/SKILL.md` Step 1)
-- [ ] Step 0 `$ARGUMENTS` bypass supports `--timeout` and `--max-turns` flags (`plugins/soleur/skills/schedule/SKILL.md` Step 0)
-- [ ] Step 4 confirmation summary displays timeout and max-turns values (`plugins/soleur/skills/schedule/SKILL.md` Step 4)
-- [ ] Existing scheduled workflows remain unaffected (template change only -- verify with `git diff` that only SKILL.md is modified)
+- [x] Generated workflow YAML includes `timeout-minutes` on the job block (`plugins/soleur/skills/schedule/SKILL.md` Step 3 template)
+- [x] Generated workflow YAML includes `--max-turns` in `claude_args` (`plugins/soleur/skills/schedule/SKILL.md` Step 3 template)
+- [x] Generated workflow YAML includes a label pre-creation step with `gh label create ... || true` (`plugins/soleur/skills/schedule/SKILL.md` Step 3 template)
+- [x] `claude_args` uses `>-` block scalar format for readability (`plugins/soleur/skills/schedule/SKILL.md` Step 3 template)
+- [x] Known Limitations section accurately reflects current state -- stale items removed (`plugins/soleur/skills/schedule/SKILL.md` lines 166-176)
+- [x] Step 1 collects timeout (default 30) and max-turns (default 30) inputs (`plugins/soleur/skills/schedule/SKILL.md` Step 1)
+- [x] Step 0 `$ARGUMENTS` bypass supports `--timeout` and `--max-turns` flags (`plugins/soleur/skills/schedule/SKILL.md` Step 0)
+- [x] Step 4 confirmation summary displays timeout and max-turns values (`plugins/soleur/skills/schedule/SKILL.md` Step 4)
+- [x] Existing scheduled workflows remain unaffected (template change only -- verify with `git diff` that only SKILL.md is modified)
 
 ## Test Scenarios
 

--- a/knowledge-base/specs/feat-fix-schedule-template/session-state.md
+++ b/knowledge-base/specs/feat-fix-schedule-template/session-state.md
@@ -1,0 +1,22 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-fix-schedule-template/knowledge-base/plans/2026-03-05-fix-schedule-template-remaining-gaps-plan.md
+- Status: complete
+
+### Errors
+None
+
+### Decisions
+- Issue #382 is partially stale: 4 of 6 gaps already fixed in prior PRs (#321, #341, #344). Remaining work is 3 gaps (timeout-minutes, max-turns, label pre-creation) plus Known Limitations cleanup.
+- MINIMAL detail level: single-file fix to SKILL.md template with clear acceptance criteria.
+- `>-` block scalar for `claude_args` adopted from scheduled-bug-fixer.yml pattern.
+- Defaults of 30/30: 30 minutes timeout and 30 max-turns as sensible defaults.
+- `contents: read` kept as default permission -- documented as Known Limitation.
+
+### Components Invoked
+- skill: soleur:plan (issue #382 research, plan generation, tasks.md creation)
+- skill: soleur:deepen-plan (Context7 docs, learnings analysis, reference workflow comparison)
+- Context7 MCP: resolve-library-id and query-docs for /anthropics/claude-code-action
+- 5 institutional learnings analyzed
+- 3 reference workflows analyzed

--- a/knowledge-base/specs/feat-fix-schedule-template/tasks.md
+++ b/knowledge-base/specs/feat-fix-schedule-template/tasks.md
@@ -5,39 +5,39 @@ Plan: `knowledge-base/plans/2026-03-05-fix-schedule-template-remaining-gaps-plan
 
 ## Phase 1: Template Updates (`plugins/soleur/skills/schedule/SKILL.md`)
 
-- [ ] 1.1 Add `timeout-minutes` input to Step 1 (interactive collection) with default 30
+- [x] 1.1 Add `timeout-minutes` input to Step 1 (interactive collection) with default 30
   - Add as item 5 after model input
   - Validate: positive integer, minimum 5 minutes
-- [ ] 1.2 Add `--max-turns` input to Step 1 (interactive collection) with default 30
+- [x] 1.2 Add `--max-turns` input to Step 1 (interactive collection) with default 30
   - Add as item 6 after timeout input
   - Validate: positive integer, minimum 5 turns
-- [ ] 1.3 Add `--timeout` and `--max-turns` flags to Step 0 argument bypass path (~line 18)
+- [x] 1.3 Add `--timeout` and `--max-turns` flags to Step 0 argument bypass path (~line 18)
   - Update the conditional: "If `$ARGUMENTS` contains `--name`, `--skill`, `--cron`, `--model`, `--timeout`, and `--max-turns` flags"
   - Make `--timeout` and `--max-turns` optional with defaults (only `--name`, `--skill`, `--cron`, `--model` required)
-- [ ] 1.4 Update template YAML in Step 3 (~lines 68-104):
-  - [ ] 1.4.1 Add `timeout-minutes: <TIMEOUT>` to the job block (after `runs-on`)
-  - [ ] 1.4.2 Convert `claude_args` from single-line string to `>-` block scalar format
-  - [ ] 1.4.3 Add `--max-turns <MAX_TURNS>` to `claude_args`
-  - [ ] 1.4.4 Add label pre-creation step between checkout and claude-code-action step
+- [x] 1.4 Update template YAML in Step 3 (~lines 68-104):
+  - [x] 1.4.1 Add `timeout-minutes: <TIMEOUT>` to the job block (after `runs-on`)
+  - [x] 1.4.2 Convert `claude_args` from single-line string to `>-` block scalar format
+  - [x] 1.4.3 Add `--max-turns <MAX_TURNS>` to `claude_args`
+  - [x] 1.4.4 Add label pre-creation step between checkout and claude-code-action step
 
 ## Phase 2: Known Limitations Cleanup (`plugins/soleur/skills/schedule/SKILL.md` lines 166-176)
 
-- [ ] 2.1 Remove stale Known Limitations:
+- [x] 2.1 Remove stale Known Limitations:
   - Remove "No `--allowedTools` in `claude_args`" (fixed in #344)
   - Remove "No `timeout-minutes`" (fixed in this PR)
   - Remove "No `--max-turns` in `claude_args`" (fixed in this PR)
   - Remove "No label pre-creation" (fixed in this PR)
-- [ ] 2.2 Verify remaining limitations are still accurate:
+- [x] 2.2 Verify remaining limitations are still accurate:
   - "Skills only" -- still true
   - "Issue output only" -- still true
   - "No state across runs" -- still true
   - "No skill-specific arguments" -- still true
   - "No cascading priority selection" -- still true
-- [ ] 2.3 Update Step 4 confirmation summary (~lines 117-131) to display timeout and max-turns values
+- [x] 2.3 Update Step 4 confirmation summary (~lines 117-131) to display timeout and max-turns values
 
 ## Phase 3: Validation
 
-- [ ] 3.1 Run markdownlint on updated SKILL.md
-- [ ] 3.2 Verify template YAML is valid (manual review of indentation, `>-` scalar correctness)
-- [ ] 3.3 Compare generated template structure against all 3 reference workflows for parity
-- [ ] 3.4 Verify `>-` block scalar produces correct single-line string (no trailing newline)
+- [x] 3.1 Run markdownlint on updated SKILL.md
+- [x] 3.2 Verify template YAML is valid (manual review of indentation, `>-` scalar correctness)
+- [x] 3.3 Compare generated template structure against all 3 reference workflows for parity
+- [x] 3.4 Verify `>-` block scalar produces correct single-line string (no trailing newline)

--- a/plugins/soleur/skills/schedule/SKILL.md
+++ b/plugins/soleur/skills/schedule/SKILL.md
@@ -15,7 +15,7 @@ Generate a new scheduled workflow.
 
 **Step 0: Check arguments**
 
-If `$ARGUMENTS` contains `--name`, `--skill`, `--cron`, and `--model` flags, extract values directly and skip to Step 2. Validate each value using the same rules below. If any required flag is missing, proceed to Step 1 for the missing parameters only.
+If `$ARGUMENTS` contains `--name`, `--skill`, `--cron`, and `--model` flags, extract values directly and skip to Step 2. Validate each value using the same rules below. If any required flag is missing, proceed to Step 1 for the missing parameters only. Optional flags: `--timeout` (minutes, default 30) and `--max-turns` (default 30).
 
 **Step 1: Collect inputs**
 
@@ -37,6 +37,10 @@ Use the **AskUserQuestion tool** to gather missing inputs one at a time:
    - Note: GitHub Actions cron has ~15-minute variance in trigger timing
 
 4. **Model** — Which Claude model to use. Default: `claude-sonnet-4-6` (good balance of cost and capability). Accept any valid Anthropic model identifier.
+
+5. **Timeout (minutes)** — Job-level timeout to prevent runaway billing. Default: 30. Validate: positive integer, minimum 5 minutes.
+
+6. **Max turns** — Maximum number of agent turns before stopping. Default: 30. Validate: positive integer, minimum 5 turns.
 
 **Step 2: Resolve action SHAs**
 
@@ -85,9 +89,18 @@ permissions:
 jobs:
   run-schedule:
     runs-on: ubuntu-latest
+    timeout-minutes: <TIMEOUT>
     steps:
       - name: Checkout repository
         uses: actions/checkout@<CHECKOUT_SHA> # v4
+
+      - name: Ensure label exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create "scheduled-<NAME>" \
+            --description "Scheduled: <DISPLAY_NAME>" \
+            --color "0E8A16" 2>/dev/null || true
 
       - name: Run scheduled skill
         uses: anthropics/claude-code-action@<ACTION_SHA> # v1
@@ -95,7 +108,10 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: 'https://github.com/<REPO_OWNER>/<REPO_NAME>.git'
           plugins: 'soleur@soleur'
-          claude_args: '--model <MODEL> --allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch'
+          claude_args: >-
+            --model <MODEL>
+            --max-turns <MAX_TURNS>
+            --allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch
           prompt: |
             Run /soleur:<SKILL_NAME> on this repository.
             After your analysis is complete, create a GitHub issue titled
@@ -113,14 +129,16 @@ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/scheduled-<NAME>
 
 Display a summary:
 
-```
+```text
 Schedule created: .github/workflows/scheduled-<NAME>.yml
 
-  Name:     <DISPLAY_NAME>
-  Skill:    /soleur:<SKILL_NAME>
-  Cron:     <CRON_EXPRESSION>
-  Model:    <MODEL>
-  Output:   GitHub Issues
+  Name:      <DISPLAY_NAME>
+  Skill:     /soleur:<SKILL_NAME>
+  Cron:      <CRON_EXPRESSION>
+  Model:     <MODEL>
+  Timeout:   <TIMEOUT> minutes
+  Max turns: <MAX_TURNS>
+  Output:    GitHub Issues
 
 Prerequisites:
   - ANTHROPIC_API_KEY must be set as a repository secret
@@ -168,8 +186,4 @@ Remove a scheduled workflow.
 - **Issue output only** — All scheduled runs report findings via GitHub Issues. PR and Discord output modes planned for v2.
 - **No state across runs** — Each scheduled run starts fresh. No mechanism to carry state between executions.
 - **No skill-specific arguments** — The template prompt does not pass arguments (e.g., `--tiers 0,3`) to the invoked skill. Manual prompt edit required after generation.
-- **No `--max-turns` in `claude_args`** — The template only includes `--model`. Skills that perform multiple WebSearch/WebFetch calls may need `--max-turns 30` added manually.
-- **No label pre-creation** — The template instructs issue creation with a label but does not pre-create it. Add a `gh label create ... || true` step manually.
-- **No `timeout-minutes`** — The template does not set a job-level timeout. LLM-backed workflows should add `timeout-minutes` to prevent runaway billing.
-- **No `--allowedTools` in `claude_args`** — `claude-code-action` blocks Bash, Write, WebSearch, and WebFetch by default. Skills that create GitHub issues or perform web research silently fail without `--allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch` in `claude_args`.
 - **No cascading priority selection** — Generated workflows that select issues by label hardcode a single priority tier. When that tier is empty, the bot sits idle while higher-priority bugs accumulate. Manually add a priority cascade loop (p3 -> p2 -> p1) after generation.


### PR DESCRIPTION
## Summary

- Add `timeout-minutes` input (default 30) to job block to prevent runaway billing
- Add `--max-turns` input (default 30) to `claude_args` via `>-` block scalar
- Add label pre-creation step (`gh label create ... || true`) between checkout and claude-code-action
- Remove 4 stale Known Limitations that were resolved in prior PRs (#321, #341, #344) and this PR
- Update Step 0 argument bypass, Step 1 interactive collection, and Step 4 confirmation summary

Closes #382

## Changelog

### Fixed
- Schedule skill template now generates complete workflows matching all 3 reference implementations
- Known Limitations section accurately reflects current state (5 genuine limitations remain)

### Changed
- `claude_args` uses `>-` block scalar format for multi-flag readability
- Updated existing learning document to reflect resolved gaps

## Test plan

- [x] Markdownlint passes on updated SKILL.md
- [x] Template YAML indentation and `>-` scalar verified correct
- [x] Template structure matches all 3 reference workflows (daily-triage, bug-fixer, competitive-analysis)
- [x] Only SKILL.md and knowledge-base files modified (existing workflows untouched)
- [x] Code simplicity review: already minimal
- [x] Architecture review: all constitution lines 101-104 satisfied
- [x] Security review: no blocking findings

Generated with [Claude Code](https://claude.com/claude-code)