### PR TITLE
fix(ralph-loop): scope frontmatter parser and sed substitution to YAML block

### DIFF
--- a/knowledge-base/learnings/2026-03-05-awk-scoping-yaml-frontmatter-shell.md
+++ b/knowledge-base/learnings/2026-03-05-awk-scoping-yaml-frontmatter-shell.md
@@ -1,0 +1,45 @@
+# Learning: awk scoping for YAML frontmatter parsing in shell scripts
+
+## Problem
+
+`plugins/soleur/hooks/stop-hook.sh` used `sed` to extract and update YAML frontmatter in Ralph state files. The file format is YAML frontmatter delimited by `---` lines, followed by a freeform prompt body. Two bugs resulted:
+
+1. **Extraction leak:** `sed -n '/^---$/,/^---$/...'` matched ALL `---`-delimited blocks, not just the first one. If the prompt body contained a bare `---` line (e.g., as a Markdown horizontal rule), content after it leaked into the `FRONTMATTER` variable, corrupting parsed values.
+
+2. **Global substitution bleed:** `sed -e "s/^iteration: .*/..."` replaced patterns anywhere in the file. Prompt body text like `iteration: check status` was silently mutated.
+
+Both bugs stem from the same root cause: `sed` range patterns and global substitutions have no concept of "first block only."
+
+## Solution
+
+Replaced both `sed` operations with `awk` using a counter variable `c` that increments on each `---` delimiter line. Only lines where `c==1` (between the first and second `---`) are treated as frontmatter.
+
+**Extraction:** `awk '/^---$/{c++; next} c==1'`
+
+**Update pass:**
+```bash
+awk -v iter="$NEXT_ITERATION" -v sc="$STUCK_COUNT" '
+  /^---$/ { c++; print; next }
+  c==1 && /^iteration:/ { print "iteration: " iter; next }
+  c==1 && /^stuck_count:/ { print "stuck_count: " sc; next }
+  { print }
+' "$RALPH_STATE_FILE" > "$TEMP_FILE"
+```
+
+## Key Insight
+
+`sed` range expressions (`/start/,/stop/`) match every occurrence of the start/stop pair, not just the first. For file formats that use the same delimiter to mark a single block (like YAML frontmatter's `---`), `awk` with an explicit counter is the correct tool. The pattern `'/^---$/{c++; next} c==1'` is a reliable idiom for "extract only the first `---`-delimited block" and should be the default choice over `sed` for frontmatter parsing in shell scripts.
+
+## Session Errors
+
+Test 13 initially asserted that a bare `---` line in the prompt body would appear in the awk-extracted prompt. However, the existing prompt extractor (line 133: `awk '/^---$/{i++; next} i>=2'`) also consumes `---` lines. The test was corrected to verify against the raw state file instead.
+
+## Related
+
+- `knowledge-base/learnings/2026-03-05-ralph-loop-stuck-detection-shell-counter.md`
+- `knowledge-base/learnings/2026-02-14-sed-insertion-fails-silently-on-missing-pattern.md`
+- `knowledge-base/learnings/2026-03-05-bulk-yaml-frontmatter-migration-patterns.md`
+
+## Tags
+category: logic-errors
+module: ralph-loop

--- a/knowledge-base/plans/2026-03-05-fix-ralph-frontmatter-scope-plan.md
+++ b/knowledge-base/plans/2026-03-05-fix-ralph-frontmatter-scope-plan.md
@@ -98,12 +98,12 @@ The proposed parser uses `c`. For readability, normalize both the new parser and
 
 ## Acceptance Criteria
 
-- [ ] Frontmatter parser (`FRONTMATTER=...`) only reads lines between the first and second `---` markers in `plugins/soleur/hooks/stop-hook.sh`
-- [ ] sed update pass is replaced with awk that only substitutes `iteration:` and `stuck_count:` inside the first frontmatter block in `plugins/soleur/hooks/stop-hook.sh`
-- [ ] Prompt text containing `---`, `iteration:`, or `stuck_count:` is preserved verbatim through a loop iteration
-- [ ] All existing tests in `plugins/soleur/test/ralph-loop-stuck-detection.test.sh` continue to pass
-- [ ] New test cases cover the two bug scenarios (prompt with `---`, prompt with `iteration:` text)
-- [ ] Comments on the changed lines updated to reflect awk usage
+- [x] Frontmatter parser (`FRONTMATTER=...`) only reads lines between the first and second `---` markers in `plugins/soleur/hooks/stop-hook.sh`
+- [x] sed update pass is replaced with awk that only substitutes `iteration:` and `stuck_count:` inside the first frontmatter block in `plugins/soleur/hooks/stop-hook.sh`
+- [x] Prompt text containing `---`, `iteration:`, or `stuck_count:` is preserved verbatim through a loop iteration
+- [x] All existing tests in `plugins/soleur/test/ralph-loop-stuck-detection.test.sh` continue to pass
+- [x] New test cases cover the two bug scenarios (prompt with `---`, prompt with `iteration:` text)
+- [x] Comments on the changed lines updated to reflect awk usage
 
 ## Test Scenarios
 

--- a/knowledge-base/specs/feat-ralph-frontmatter-scope/session-state.md
+++ b/knowledge-base/specs/feat-ralph-frontmatter-scope/session-state.md
@@ -1,0 +1,21 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-ralph-frontmatter-scope/knowledge-base/plans/2026-03-05-fix-ralph-frontmatter-scope-plan.md
+- Status: complete
+
+### Errors
+None
+
+### Decisions
+- MINIMAL detail level -- focused 2-line bug fix in a single shell script with a clear proposed solution
+- Skipped external research -- strong local context (full source code, existing tests, related learning)
+- awk over sed -- confirmed by edge-case testing against 8 scenarios; awk is POSIX-compatible and exits 0
+- Variable naming: `c` (counter) for both new awk blocks, leaving existing `i` on line 133 untouched (out of scope)
+- Added explicit Non-goal: refactoring grep-based field extraction (lines 25-35) is out of scope
+
+### Components Invoked
+- skill: soleur:plan
+- skill: soleur:deepen-plan
+- Manual awk edge-case verification via Bash (8 scenarios tested)
+- Git commit + push (2 commits: initial plan, deepened plan)

--- a/knowledge-base/specs/feat-ralph-frontmatter-scope/tasks.md
+++ b/knowledge-base/specs/feat-ralph-frontmatter-scope/tasks.md
@@ -5,16 +5,16 @@ Issue: #455
 
 ## Phase 1: Core Fix
 
-- [ ] 1.1 Replace sed frontmatter parser with scoped awk (`plugins/soleur/hooks/stop-hook.sh` line 24)
-- [ ] 1.2 Replace sed update pass with scoped awk (`plugins/soleur/hooks/stop-hook.sh` lines 146-148)
-- [ ] 1.3 Update inline comments to reflect awk usage
+- [x] 1.1 Replace sed frontmatter parser with scoped awk (`plugins/soleur/hooks/stop-hook.sh` line 24)
+- [x] 1.2 Replace sed update pass with scoped awk (`plugins/soleur/hooks/stop-hook.sh` lines 146-148)
+- [x] 1.3 Update inline comments to reflect awk usage
 
 ## Phase 2: Testing
 
-- [ ] 2.1 Add test: prompt body containing `---` does not leak into FRONTMATTER (`plugins/soleur/test/ralph-loop-stuck-detection.test.sh`)
-- [ ] 2.2 Add test: prompt body containing `iteration:` text is preserved verbatim after update
-- [ ] 2.3 Add test: prompt body containing `stuck_count:` text is preserved verbatim after update
-- [ ] 2.4 Run full existing test suite to verify no regressions
+- [x] 2.1 Add test: prompt body containing `---` does not leak into FRONTMATTER (`plugins/soleur/test/ralph-loop-stuck-detection.test.sh`)
+- [x] 2.2 Add test: prompt body containing `iteration:` text is preserved verbatim after update
+- [x] 2.3 Add test: prompt body containing `stuck_count:` text is preserved verbatim after update
+- [x] 2.4 Run full existing test suite to verify no regressions
 
 ## Phase 3: Ship
 

--- a/plugins/soleur/hooks/stop-hook.sh
+++ b/plugins/soleur/hooks/stop-hook.sh
@@ -20,8 +20,8 @@ if [[ ! -f "$RALPH_STATE_FILE" ]]; then
   exit 0
 fi
 
-# Parse markdown frontmatter (YAML between ---) and extract values
-FRONTMATTER=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$RALPH_STATE_FILE")
+# Parse markdown frontmatter (YAML between first and second --- only)
+FRONTMATTER=$(awk '/^---$/{c++; next} c==1' "$RALPH_STATE_FILE")
 ITERATION=$(echo "$FRONTMATTER" | grep '^iteration:' | sed 's/iteration: *//')
 MAX_ITERATIONS=$(echo "$FRONTMATTER" | grep '^max_iterations:' | sed 's/max_iterations: *//')
 # Extract completion_promise and strip surrounding quotes if present
@@ -138,14 +138,17 @@ if [[ -z "$PROMPT_TEXT" ]]; then
   exit 0
 fi
 
-# Update iteration and stuck_count in frontmatter (single sed pass, portable across macOS and Linux)
-# Note: on legacy state files without stuck_count field, the sed is a no-op for that line.
+# Update iteration and stuck_count in first frontmatter block only (awk scoped to c==1)
+# Note: on legacy state files without stuck_count field, the awk match is a no-op for that line.
 # The counter will not persist across iterations. Acceptable because legacy files are only
 # created by pre-stuck-detection versions of setup-ralph-loop.sh; all new loops include the field.
 TEMP_FILE="${RALPH_STATE_FILE}.tmp.$$"
-sed -e "s/^iteration: .*/iteration: $NEXT_ITERATION/" \
-    -e "s/^stuck_count: .*/stuck_count: $STUCK_COUNT/" \
-    "$RALPH_STATE_FILE" > "$TEMP_FILE"
+awk -v iter="$NEXT_ITERATION" -v sc="$STUCK_COUNT" '
+  /^---$/ { c++; print; next }
+  c==1 && /^iteration:/ { print "iteration: " iter; next }
+  c==1 && /^stuck_count:/ { print "stuck_count: " sc; next }
+  { print }
+' "$RALPH_STATE_FILE" > "$TEMP_FILE"
 mv "$TEMP_FILE" "$RALPH_STATE_FILE"
 
 # Build system message with iteration count and completion promise info

--- a/plugins/soleur/test/ralph-loop-stuck-detection.test.sh
+++ b/plugins/soleur/test/ralph-loop-stuck-detection.test.sh
@@ -311,6 +311,93 @@ assert_eq "0" "$STUCK_COUNT" "corrupted stuck_count reset to 0"
 cleanup_test "$TEST_DIR"
 echo ""
 
+# Test 13: Prompt containing --- does not leak into FRONTMATTER
+echo "Test 13: Prompt body with --- does not leak into frontmatter"
+TEST_DIR=$(setup_test)
+cat > "$TEST_DIR/.claude/ralph-loop.local.md" <<'EOF'
+---
+active: true
+iteration: 1
+max_iterations: 0
+completion_promise: null
+stuck_count: 0
+stuck_threshold: 3
+started_at: "2026-03-05T00:00:00Z"
+---
+
+Build a REST API with proper error handling.
+---
+Use standard HTTP status codes.
+EOF
+TRANSCRIPT=$(create_transcript "$TEST_DIR" "This is a substantive response with plenty of content to exceed the threshold.")
+run_hook "$TEST_DIR" "$TRANSCRIPT"
+assert_file_exists "$TEST_DIR/.claude/ralph-loop.local.md" "state file still exists"
+ITERATION=$(grep '^iteration:' "$TEST_DIR/.claude/ralph-loop.local.md" | head -1 | sed 's/iteration: *//')
+assert_eq "2" "$ITERATION" "iteration updated to 2"
+# Verify the raw state file preserves --- and text after it in the prompt body
+# (The awk prompt extractor on line 133 consumes bare --- lines -- that's pre-existing behavior.)
+RAW_FILE=$(cat "$TEST_DIR/.claude/ralph-loop.local.md")
+assert_contains "$RAW_FILE" "Build a REST API with proper error handling." "prompt text before --- preserved in state file"
+assert_contains "$RAW_FILE" "Use standard HTTP status codes." "prompt text after --- preserved in state file"
+# Verify frontmatter was not corrupted by prompt --- leaking into parser
+FRONTMATTER=$(awk '/^---$/{c++; next} c==1' "$TEST_DIR/.claude/ralph-loop.local.md")
+assert_contains "$FRONTMATTER" "iteration: 2" "frontmatter contains updated iteration"
+assert_contains "$FRONTMATTER" "stuck_count: 0" "frontmatter contains correct stuck_count"
+cleanup_test "$TEST_DIR"
+echo ""
+
+# Test 14: Prompt containing iteration: text is preserved after update
+echo "Test 14: Prompt body with iteration: text is preserved verbatim"
+TEST_DIR=$(setup_test)
+cat > "$TEST_DIR/.claude/ralph-loop.local.md" <<'EOF'
+---
+active: true
+iteration: 1
+max_iterations: 0
+completion_promise: null
+stuck_count: 0
+stuck_threshold: 3
+started_at: "2026-03-05T00:00:00Z"
+---
+
+Check iteration: current status of deployment.
+EOF
+TRANSCRIPT=$(create_transcript "$TEST_DIR" "This is a substantive response with plenty of content to exceed the threshold.")
+run_hook "$TEST_DIR" "$TRANSCRIPT"
+assert_file_exists "$TEST_DIR/.claude/ralph-loop.local.md" "state file still exists"
+ITERATION=$(grep '^iteration:' "$TEST_DIR/.claude/ralph-loop.local.md" | head -1 | sed 's/iteration: *//')
+assert_eq "2" "$ITERATION" "frontmatter iteration updated to 2"
+PROMPT_BODY=$(awk '/^---$/{i++; next} i>=2' "$TEST_DIR/.claude/ralph-loop.local.md")
+assert_contains "$PROMPT_BODY" "iteration: current status of deployment" "prompt iteration: text preserved"
+cleanup_test "$TEST_DIR"
+echo ""
+
+# Test 15: Prompt containing stuck_count: text is preserved after update
+echo "Test 15: Prompt body with stuck_count: text is preserved verbatim"
+TEST_DIR=$(setup_test)
+cat > "$TEST_DIR/.claude/ralph-loop.local.md" <<'EOF'
+---
+active: true
+iteration: 1
+max_iterations: 0
+completion_promise: null
+stuck_count: 0
+stuck_threshold: 3
+started_at: "2026-03-05T00:00:00Z"
+---
+
+Monitor stuck_count: should be zero.
+EOF
+TRANSCRIPT=$(create_transcript "$TEST_DIR" "This is a substantive response with plenty of content to exceed the threshold.")
+run_hook "$TEST_DIR" "$TRANSCRIPT"
+assert_file_exists "$TEST_DIR/.claude/ralph-loop.local.md" "state file still exists"
+STUCK_COUNT_FM=$(grep '^stuck_count:' "$TEST_DIR/.claude/ralph-loop.local.md" | head -1 | sed 's/stuck_count: *//')
+assert_eq "0" "$STUCK_COUNT_FM" "frontmatter stuck_count reset to 0"
+PROMPT_BODY=$(awk '/^---$/{i++; next} i>=2' "$TEST_DIR/.claude/ralph-loop.local.md")
+assert_contains "$PROMPT_BODY" "stuck_count: should be zero" "prompt stuck_count: text preserved"
+cleanup_test "$TEST_DIR"
+echo ""
+
 # --- Summary ---
 
 echo "=== Results ==="


### PR DESCRIPTION
## Summary
- Replace sed frontmatter parser with awk scoped to first `---` block (`c==1`)
- Replace sed update pass with awk that only substitutes `iteration:` and `stuck_count:` inside frontmatter
- Prompt body text containing `---`, `iteration:`, or `stuck_count:` is now preserved verbatim
- Add 3 regression tests covering prompt-body collision scenarios

Closes #455

## Changelog
- **Fixed**: Frontmatter parser no longer reads beyond the first `---` block when prompt body contains markdown separators
- **Fixed**: Frontmatter update pass no longer mutates `iteration:` or `stuck_count:` patterns in the prompt body
- **Added**: Tests 13-15 in `ralph-loop-stuck-detection.test.sh` for frontmatter scoping edge cases

## Test plan
- [x] All 33 tests pass (12 existing + 3 new)
- [x] Test 13: Prompt body with `---` does not corrupt frontmatter
- [x] Test 14: Prompt body with `iteration:` text preserved after update
- [x] Test 15: Prompt body with `stuck_count:` text preserved after update

Generated with [Claude Code](https://claude.com/claude-code)