### PR TITLE
fix(docs): add table border styles to prose sections

### DIFF
--- a/plugins/soleur/docs/css/style.css
+++ b/plugins/soleur/docs/css/style.css
@@ -796,6 +796,22 @@
   .prose li {
     margin-bottom: var(--space-2);
   }
+  .prose table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: var(--space-4);
+    font-size: var(--text-sm);
+  }
+  .prose th,
+  .prose td {
+    border: 1px solid var(--color-border);
+    padding: var(--space-2) var(--space-3);
+    text-align: left;
+  }
+  .prose th {
+    background: var(--color-bg-secondary);
+    font-weight: 600;
+  }
 
   /* Changelog overrides -- applied alongside .prose on #changelog-content */
   #changelog-content h2 {


### PR DESCRIPTION
## Summary

- Added `.prose table`, `.prose th`, and `.prose td` CSS rules with borders, padding, and header background
- Tables in blog posts (like the CaaS comparison table) were rendering without any borders or visual structure

## Changelog

- fix: add missing table border/padding styles to `.prose` CSS

## Test plan

- [x] Verified table renders with borders on the CaaS blog post via Playwright screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)