### PR TITLE
ci: enable daily cron for community monitor

### DIFF
--- a/.github/workflows/scheduled-community-monitor.yml
+++ b/.github/workflows/scheduled-community-monitor.yml
@@ -3,7 +3,7 @@
 # committed to knowledge-base/community/, and creates a GitHub Issue
 # with the daily report. No autonomous posting -- human approval preserved.
 # Implements #145: Run Community Agent continuously.
-# Start with workflow_dispatch only; add cron after validating end-to-end.
+# Runs daily at 08:00 UTC and on manual dispatch.
 # To test manually: gh workflow run scheduled-community-monitor.yml
 #
 # Security: This workflow does NOT use any untrusted event inputs
@@ -14,9 +14,8 @@ name: "Scheduled: Community Monitor"
 
 on:
   workflow_dispatch:
-  # TODO: Add cron after validating end-to-end with manual dispatch
-  # schedule:
-  #   - cron: '0 8 * * *'
+  schedule:
+    - cron: '0 8 * * *'
 
 concurrency:
   group: schedule-community-monitor


### PR DESCRIPTION
## Summary

- Uncomments the `schedule` trigger (`0 8 * * *`) in `scheduled-community-monitor.yml`
- Validated end-to-end via manual dispatch — run [#22907686128](https://github.com/jikig-ai/soleur/actions/runs/22907686128) succeeded, produced issue #517 and committed digest

## Changelog

- **Changed:** Enable daily 08:00 UTC cron schedule for community monitor workflow

## Test plan

- [x] Manual dispatch validated (run #22907686128 — success, digest committed, issue created)
- [ ] Verify cron fires at next 08:00 UTC window

🤖 Generated with [Claude Code](https://claude.com/claude-code)