### PR TITLE
fix: add TTL to ralph loop stop hook for crash recovery

### DIFF
--- a/knowledge-base/learnings/2026-03-09-ralph-loop-crash-orphan-recovery.md
+++ b/knowledge-base/learnings/2026-03-09-ralph-loop-crash-orphan-recovery.md
@@ -27,7 +27,7 @@ rm .claude/ralph-loop.local.md
 
 ## Prevention
 
-The stop hook should detect stale state files using the existing `started_at` timestamp. A loop older than 4 hours is almost certainly a crash orphan. Implementation belongs in the `feat-fix-ralph-loop-stop-hook` worktree alongside the other stop hook fixes (PR #465).
+Implemented: the stop hook now checks `started_at` against a 4-hour TTL before reading stdin. State files older than 4 hours are auto-removed with a diagnostic message to stderr. See `plugins/soleur/hooks/stop-hook.sh` lines 22-37.
 
 ## Key Insight
 

--- a/plugins/soleur/hooks/stop-hook.sh
+++ b/plugins/soleur/hooks/stop-hook.sh
@@ -19,6 +19,23 @@ if [[ ! -f "$RALPH_STATE_FILE" ]]; then
   exit 0
 fi
 
+# --- TTL Check: Auto-remove stale state files from crashed sessions ---
+# When a session crashes or context is exhausted, the state file persists and
+# traps all subsequent sessions in an infinite loop. The started_at timestamp
+# lets us detect orphaned state files and clean them up automatically.
+TTL_HOURS=4
+STARTED_AT=$(awk '/^---$/{c++; next} c==1' "$RALPH_STATE_FILE" | grep '^started_at:' | sed 's/started_at: *//' | sed 's/^"\(.*\)"$/\1/' || true)
+if [[ -n "$STARTED_AT" ]]; then
+  STARTED_EPOCH=$(date -d "$STARTED_AT" +%s 2>/dev/null || true)
+  NOW_EPOCH=$(date +%s)
+  if [[ -n "$STARTED_EPOCH" ]] && [[ $((NOW_EPOCH - STARTED_EPOCH)) -gt $((TTL_HOURS * 3600)) ]]; then
+    AGE_HOURS=$(( (NOW_EPOCH - STARTED_EPOCH) / 3600 ))
+    echo "Ralph loop: stale state file detected (started ${AGE_HOURS}h ago, TTL=${TTL_HOURS}h). Auto-removing." >&2
+    rm "$RALPH_STATE_FILE"
+    exit 0
+  fi
+fi
+
 # Read hook input from stdin (advanced stop hook API)
 HOOK_INPUT=$(cat)
 


### PR DESCRIPTION
## Summary

- Add 4-hour TTL check to `stop-hook.sh` that auto-removes stale ralph loop state files before they can trap new sessions in an infinite loop
- Update the learning document to reflect the prevention is now implemented

## Problem

When a session crashes or exhausts context, `.claude/ralph-loop.local.md` persists on disk. Every subsequent session's stop hook finds it, treats the loop as active, and blocks exit by re-injecting "finish all slash commands" — creating an infinite loop that makes the session unusable. This has occurred 3+ times.

## Fix

The state file already contains a `started_at` timestamp. The stop hook now reads it and compares against a 4-hour TTL. Files older than 4 hours are auto-removed with a diagnostic message to stderr, before stdin is even read.

## Changelog

- **Fixed:** Ralph loop stop hook stale state file infinite loop (crash recovery)

## Test plan

- [x] Bash syntax validation (`bash -n`)
- [x] TTL logic tested: stale timestamp (24h old) correctly detected, fresh timestamp correctly preserved
- [x] `set -euo pipefail` compatibility: all new commands have `|| true` guards where needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)