### PR TITLE
feat: add pillar blog post to content publisher pipeline

### DIFF
--- a/.github/workflows/scheduled-content-publisher.yml
+++ b/.github/workflows/scheduled-content-publisher.yml
@@ -1,4 +1,4 @@
-# Scheduled content publisher for the 3-week case study distribution campaign.
+# Scheduled content publisher for blog and case study distribution.
 # Posts pre-generated content to Discord (webhook), X/Twitter (API), and
 # creates GitHub issues for manual platforms (IndieHackers, Reddit, HN).
 # Implements #530: scheduled content publisher workflow.
@@ -7,7 +7,7 @@
 # Phase 2: add cron triggers after validation.
 #
 # Security: This workflow does NOT use untrusted event inputs in run: commands.
-# The CASE_STUDY env var originates from a constrained choice input (1-5) and
+# The CASE_STUDY env var originates from a constrained choice input (1-6) and
 # is validated by the content-publisher.sh case statement before use.
 
 name: "Scheduled: Content Publisher"
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       case_study:
-        description: 'Case study number (1-5)'
+        description: 'Content number (1-5: case studies, 6: agentic tools plateau)'
         required: true
         type: choice
         options:
@@ -25,6 +25,7 @@ on:
           - '3'
           - '4'
           - '5'
+          - '6'
 
 concurrency:
   group: scheduled-content-publisher

--- a/knowledge-base/specs/feat-product-strategy/distribution-content/06-why-most-agentic-tools-plateau.md
+++ b/knowledge-base/specs/feat-product-strategy/distribution-content/06-why-most-agentic-tools-plateau.md
@@ -1,0 +1,128 @@
+# Why Most Agentic Tools Plateau -- Distribution Content
+
+**Blog post:** https://soleur.ai/blog/why-most-agentic-tools-plateau/
+**Title:** "Why Most Agentic Engineering Tools Plateau"
+**Publish date:** Fri 2026-03-14
+
+---
+
+## Discord
+
+Your AI coding tools stop getting better after week two. Session one hundred starts from the same blank slate as session one.
+
+We wrote about why -- and what breaks through.
+
+The industry moved from vibe coding to agentic engineering. Specs, structured workflows, agent orchestration. Real advances. But none of them solve the deeper problem: does your system actually get better with use?
+
+Soleur does. Every task generates knowledge that feeds back into the system's rules, agents, and workflows. Not documentation. Behavior.
+
+Four proof points from real incidents:
+
+-> An agent edited files outside its workspace. Two hours lost. The failure triggered a four-stage response: documentation, governance rule, enforcement hook, routing. Seventeen days from failure to mechanical prevention. The system can never make that mistake again.
+
+-> Documentation-only rules fail. Every enforcement hook exists because a written rule was insufficient. Agents rationalize skipping prose instructions the way developers rationalize skipping code review at 5 PM on a Friday.
+
+-> Plan review reduced scope by 30-96% across eight features. 65 tasks became 4. The system generated its own evidence that plan review should be mandatory.
+
+-> The governance document grew from 26 lines to 200+ rules, each triggered by a real failure. The compound step routes insights back to the specific agent that was active.
+
+This is what compound knowledge looks like. Not a feature. An architectural property.
+
+Read the full breakdown: https://soleur.ai/blog/why-most-agentic-tools-plateau/
+
+---
+
+## X/Twitter Thread
+
+**Tweet 1 (Hook) -- 254 chars:**
+Your AI coding tools stop getting better after week two.
+
+Session 100 starts from the same blank slate as session 1. The models improve. The system around them does not.
+
+This is the plateau. Here is what breaks through.
+
+**Tweet 2 (Body) -- 275 chars:**
+2/ The industry went from vibe coding to agentic engineering. Specs, workflows, agent orchestration. Real advances.
+
+But none solve the deeper problem: does your system actually get better with use? Can you prove it?
+
+Most cannot.
+
+**Tweet 3 (Body) -- 272 chars:**
+3/ Soleur compounds knowledge into behavior, not documentation.
+
+An agent edited files outside its sandbox. Two hours lost. The response: document, add governance rule, add enforcement hook. 17 days to mechanical prevention.
+
+The system can never make that mistake again.
+
+**Tweet 4 (Body) -- 267 chars:**
+4/ Plan review reduced scope by 30-96% across 8 features. 65 tasks became 4. The governance document grew from 26 lines to 200+ rules -- each triggered by a real failure.
+
+The system generated its own evidence that its workflow works.
+
+**Tweet 5 (Final) -- 236 chars:**
+5/ Spec-driven tools capture intent. Compound engineering captures learnings. Soleur compounds both -- and feeds them back into the system's behavior.
+
+Full breakdown with proof points and data:
+
+https://soleur.ai/blog/why-most-agentic-tools-plateau/
+
+---
+
+## IndieHackers
+
+**Title:** Most AI coding tools plateau after week two. Here's why -- and what I built to fix it.
+
+**Body:**
+
+I've been building Soleur -- a Company-as-a-Service platform with 62 AI agents across 9 departments. The engineering depth alone took hundreds of sessions to compound. Here's what I learned about why most agentic tools hit a ceiling.
+
+The problem is simple: your hundredth session starts from the same blank slate as your first. The autocomplete gets faster. The models improve. But the accumulated knowledge of what works, what broke, what to avoid -- it resets every time.
+
+The industry responded with specs (Spec Kit, OpenSpec, Kiro) and compound engineering (Every). These are real advances. But specs describe what to build. They don't describe what you learned while building it.
+
+Here's where it gets interesting. In Soleur, an agent once edited files outside its workspace. Two hours of work disappeared. In most systems, that's a lesson learned by a human and forgotten by the next session.
+
+In ours, the failure triggered four stages: documentation, governance rule, enforcement hook, routing. Seventeen days later, the mistake was mechanically impossible. Not discouraged. Not documented. Impossible.
+
+That pattern repeated. Every enforcement hook exists because a written rule was insufficient. Agents rationalize skipping prose instructions just like developers skip code review at 5 PM on Friday.
+
+The numbers back it up. Plan review reduced scope by 30-96% across eight features. The governance document grew from 26 lines to 200+ rules, each triggered by a real failure.
+
+The compound step doesn't just capture learnings. It routes insights back to the specific agent that was active during the session. A lesson from planning makes the planning workflow permanently better.
+
+Full article with the data table and comparison against competitors: https://soleur.ai/blog/why-most-agentic-tools-plateau/
+
+Has anyone else noticed their AI tools plateauing? What approaches have you tried to make them accumulate knowledge?
+
+---
+
+## Reddit
+
+**Subreddit:** r/solopreneur
+**Title:** After hundreds of AI coding sessions, I found the reason most tools stop getting better after week two
+
+**Body:**
+
+Most AI-assisted development tools hit a plateau. Session 100 starts from the same blank slate as session 1. The models improve, but the system around them -- the accumulated knowledge of what works, what broke, what to avoid -- resets every time.
+
+I've been tracking this across the industry. The progression went from vibe coding (ad-hoc prompting, no memory) to agentic engineering (specs, structured workflows, agent orchestration). Tools like Spec Kit, OpenSpec, and Kiro solved the intent capture problem. Every's Compound Engineering plugin introduced a learning capture step.
+
+But here's the gap: capturing learnings into documentation files is a starting point, not an endpoint. The question is whether those learnings change how the system *behaves*.
+
+I found one contrarian insight from running hundreds of sessions: documentation-only rules fail. AI agents rationalize skipping prose instructions the same way developers rationalize skipping code review at 5 PM on a Friday. Every enforcement hook I've built exists because a written rule was insufficient.
+
+The escalation path that actually works: prose rule fails, incident documented, code guardrail added that makes the mistake mechanically impossible. Not discouraged. Impossible.
+
+I tracked this across eight features. Plan review (where specialized reviewers analyze a plan before coding) reduced scope by 30-96%. 65 planned tasks became 4. The system generated its own evidence that the workflow gate should be mandatory.
+
+I wrote up the full analysis with a comparison table and data: https://soleur.ai/blog/why-most-agentic-tools-plateau/
+
+Curious whether others have found ways to make their AI development tools accumulate institutional knowledge rather than resetting each session.
+
+---
+
+## Hacker News
+
+**Title:** Why Most Agentic Engineering Tools Plateau
+**URL:** https://soleur.ai/blog/why-most-agentic-tools-plateau/

--- a/plugins/soleur/skills/social-distribute/SKILL.md
+++ b/plugins/soleur/skills/social-distribute/SKILL.md
@@ -7,6 +7,15 @@ description: "This skill should be used when distributing a blog article across 
 
 Generate platform-specific content variants from a blog article and distribute across social channels. Discord is posted via webhook after approval. All other platforms output formatted text for manual posting.
 
+## Distribution Pipeline Gate
+
+Before generating content or posting manually, check if a content file already exists for this blog post in `knowledge-base/specs/feat-product-strategy/distribution-content/`. If `content-publisher.sh` and the `scheduled-content-publisher.yml` workflow can handle this content, route through the automated pipeline instead of posting ad-hoc. Ad-hoc posting bypasses thread recovery, fallback issue creation, and deduplication.
+
+**Check:** `ls knowledge-base/specs/feat-product-strategy/distribution-content/*<slug>* 2>/dev/null` where `<slug>` is derived from the blog post filename.
+
+- **If content file exists:** Inform the user and suggest triggering the workflow: `gh workflow run "Scheduled: Content Publisher" -f case_study=<number>`. Do not post manually.
+- **If no content file exists:** Continue with ad-hoc generation, but recommend creating a content file and extending `content-publisher.sh` for future use. Output a warning: "No distribution content file found. Consider creating one in `distribution-content/` for automated distribution."
+
 ## Prerequisites
 
 Before generating content, verify all prerequisites. If a hard prerequisite fails, display the error message and stop. Soft prerequisites display a warning and continue.

--- a/scripts/content-publisher.sh
+++ b/scripts/content-publisher.sh
@@ -111,7 +111,10 @@ resolve_content() {
     5) CONTENT_FILE="$CONTENT_DIR/05-business-validation.md"
        CASE_NAME="Business Validation"
        MANUAL_PLATFORMS="indiehackers,reddit,hackernews" ;;
-    *) echo "Error: Invalid case study number: $num (expected 1-5)" >&2
+    6) CONTENT_FILE="$CONTENT_DIR/06-why-most-agentic-tools-plateau.md"
+       CASE_NAME="Why Most Agentic Tools Plateau"
+       MANUAL_PLATFORMS="indiehackers,reddit,hackernews" ;;
+    *) echo "Error: Invalid content number: $num (expected 1-6)" >&2
        exit 1 ;;
   esac
 


### PR DESCRIPTION
## Summary

- Add distribution content file for the pillar blog post "Why Most Agentic Tools Plateau" (entry 6)
- Extend `content-publisher.sh` to handle entry 6 with Discord, X thread, IH, Reddit, HN variants
- Update `scheduled-content-publisher.yml` to include entry 6 in the workflow_dispatch choice input
- Add a distribution pipeline gate to the `social-distribute` skill that checks for existing content files before allowing ad-hoc posting

The pipeline gate prevents the mistake that happened in this session: the social-distribute skill was used to post manually to Discord and X, bypassing the content-publisher's thread recovery, fallback issue creation, and deduplication.

## Changelog

- Add `distribution-content/06-why-most-agentic-tools-plateau.md` with all 5 platform variants
- Update `scripts/content-publisher.sh` with entry 6
- Update `.github/workflows/scheduled-content-publisher.yml` with choice option 6
- Update `plugins/soleur/skills/social-distribute/SKILL.md` with pipeline gate

## Test plan

- [ ] Trigger workflow_dispatch with case_study=6 to distribute to Discord + X
- [x] content-publisher.sh accepts input 6 without error
- [x] Workflow YAML validates (choice input includes '6')
- [x] social-distribute skill has pipeline gate text

Generated with [Claude Code](https://claude.com/claude-code)
