### PR TITLE
fix: set unpublished content files to status: scheduled

### DIFF
--- a/knowledge-base/specs/feat-product-strategy/distribution-content/02-operations-management.md
+++ b/knowledge-base/specs/feat-product-strategy/distribution-content/02-operations-management.md
@@ -3,7 +3,7 @@ title: "Building an Operations Department for a One-Person Company"
 type: case-study
 publish_date: 2026-03-17
 channels: discord, x
-status: published
+status: scheduled
 ---
 
 ## Discord

--- a/knowledge-base/specs/feat-product-strategy/distribution-content/03-competitive-intelligence.md
+++ b/knowledge-base/specs/feat-product-strategy/distribution-content/03-competitive-intelligence.md
@@ -3,7 +3,7 @@ title: "Tracking 17 Competitors in One Session -- With Battlecards"
 type: case-study
 publish_date: 2026-03-19
 channels: discord, x
-status: published
+status: scheduled
 ---
 
 ## Discord

--- a/knowledge-base/specs/feat-product-strategy/distribution-content/04-brand-guide-creation.md
+++ b/knowledge-base/specs/feat-product-strategy/distribution-content/04-brand-guide-creation.md
@@ -3,7 +3,7 @@ title: "From Scattered Positioning to a Full Brand Guide in Two Sessions"
 type: case-study
 publish_date: 2026-03-24
 channels: discord, x
-status: published
+status: scheduled
 ---
 
 ## Discord

--- a/knowledge-base/specs/feat-product-strategy/distribution-content/05-business-validation.md
+++ b/knowledge-base/specs/feat-product-strategy/distribution-content/05-business-validation.md
@@ -3,7 +3,7 @@ title: "Running a Business Validation Workshop With AI Gates"
 type: case-study
 publish_date: 2026-03-26
 channels: discord, x
-status: published
+status: scheduled
 ---
 
 ## Discord


### PR DESCRIPTION
## Summary

Files 02-05 have future publish dates and were incorrectly set to `status: published` during the frontmatter migration in #556. This prevents the daily cron from publishing them on the correct date.

Flips `status: published` to `status: scheduled` for:
- 02-operations-management.md (2026-03-17)
- 03-competitive-intelligence.md (2026-03-19)
- 04-brand-guide-creation.md (2026-03-24)
- 05-business-validation.md (2026-03-26)

## Changelog

### Fixed
- Content files 02-05 now have `status: scheduled` so the daily cron publishes them on their declared dates

## Test plan
- [x] Verify frontmatter shows `status: scheduled` in all 4 files
- [x] Files 01 and 06 remain `status: published` (already distributed)

Generated with [Claude Code](https://claude.com/claude-code)