### PR TITLE
fix: use PR workflow for weekly analytics snapshot

### DIFF
--- a/.github/workflows/scheduled-weekly-analytics.yml
+++ b/.github/workflows/scheduled-weekly-analytics.yml
@@ -28,6 +28,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   snapshot:
@@ -42,14 +43,24 @@ jobs:
           PLAUSIBLE_SITE_ID: ${{ secrets.PLAUSIBLE_SITE_ID }}
         run: bash scripts/weekly-analytics.sh
 
-      - name: Commit and push
+      - name: Create PR with snapshot
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add knowledge-base/marketing/analytics/
           git diff --cached --quiet && echo "No changes to commit" && exit 0
+          BRANCH="ci/weekly-analytics-$(date -u +%Y-%m-%d)"
+          git checkout -b "$BRANCH"
           git commit -m "ci: weekly analytics snapshot [skip ci]"
-          git push origin main || { git pull --rebase origin main && git push origin main; }
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "ci: weekly analytics snapshot $(date -u +%Y-%m-%d)" \
+            --body "Automated weekly analytics snapshot from Plausible API." \
+            --base main \
+            --head "$BRANCH"
+          gh pr merge "$BRANCH" --squash --auto
 
       - name: Discord notification (failure)
         if: failure()


### PR DESCRIPTION
## Summary

- Switch weekly analytics workflow from direct push to main to PR-based flow
- Creates a `ci/weekly-analytics-YYYY-MM-DD` branch, opens a PR, and queues auto-merge
- Fixes GH013 rejection caused by CLA Required ruleset blocking `GITHUB_TOKEN` pushes to main

## Changelog

- Changed "Commit and push" step to "Create PR with snapshot" — creates branch, commits, pushes branch, creates PR via `gh pr create`, queues `gh pr merge --squash --auto`
- Added `pull-requests: write` permission for PR creation

## Test plan

- [x] Verified direct push fails with `GH013: Required status check "cla-check" is expected`
- [ ] Re-run `workflow_dispatch` to verify PR-based flow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)