### PR TITLE
fix: enforce Playwright MCP for browser tasks instead of manual labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ This repository contains the Soleur Claude Code plugin. Detailed conventions liv
 - The host terminal is Warp. Do not attempt automated terminal manipulation via escape sequences (cursor position queries, TUI rendering, and similar sequences are intercepted by Warp's tmux control mode and silently fail).
 - The Bash tool runs in a non-interactive shell without `sudo` access. Do not attempt commands requiring elevated privileges -- provide manual instructions instead.
 - Exhaust all automated options before suggesting manual steps to the user. The founder is a solo operator -- every manual step is a context switch. If credentials, APIs, or CLI tools exist to complete a task programmatically (Discord API, `gh` CLI, `curl`, etc.), use them. Only fall back to manual instructions when automation is genuinely impossible (e.g., no API exists, requires browser-only OAuth consent).
+- Never label a browser task as "manual" without first attempting Playwright MCP. Account signups, credential generation, settings configuration, and form submissions are all automatable via Playwright. The only genuinely manual browser steps are CAPTCHA solving and interactive OAuth consent screens — and even those should be driven to the CAPTCHA/consent step via Playwright, then handed to the user for that single interaction. Plans and task lists that say "manual — browser" are a code smell.
 
 ## Workflow Gates
 

--- a/knowledge-base/project/learnings/2026-03-13-browser-tasks-require-playwright-not-manual-labels.md
+++ b/knowledge-base/project/learnings/2026-03-13-browser-tasks-require-playwright-not-manual-labels.md
@@ -1,0 +1,42 @@
+---
+topic: Browser tasks require Playwright MCP, not "manual" labels
+category: workflow
+severity: high
+related_issues: ["#139"]
+---
+
+# Browser Tasks Require Playwright MCP, Not "Manual" Labels
+
+## Problem
+
+Plans and task lists repeatedly labeled browser-based tasks (account creation, credential generation, settings configuration) as "manual — browser" without first attempting Playwright MCP automation. This pattern surfaced in multiple sessions and wasted the founder's time on tasks the agent could have automated.
+
+## Root Cause
+
+The planning phase had no check for browser task automation. Once a task was labeled "manual" in the plan, the execution phase trusted that label and asked the user to do it by hand — even when Playwright MCP was available and capable of completing the task.
+
+## What Actually Works
+
+Playwright MCP can automate ~95% of browser tasks:
+- Account signups (navigate, fill forms, click buttons)
+- App password generation (navigate settings, create, copy)
+- Settings configuration (toggle switches, fill fields)
+- Form submissions of all kinds
+
+The only genuinely manual steps are:
+- **CAPTCHA solving** (image-based challenges like hCaptcha)
+- **Interactive OAuth consent screens** (Google, GitHub OAuth dialogs)
+
+Even these should be automated up to the CAPTCHA/consent gate, then handed to the user for just that single interaction.
+
+## Prevention
+
+Three layers now prevent this anti-pattern:
+
+1. **AGENTS.md hard rule** — Agents must attempt Playwright MCP before labeling any browser task as manual
+2. **Plan skill pre-submission check** — Step 6 checklist scans for "manual"/"browser" labels and rewrites them as Playwright automation steps
+3. **This learning** — `learnings-researcher` surfaces this document during future brainstorms and plans involving browser tasks, catching the pattern before it enters the plan
+
+## Key Insight
+
+The cost asymmetry is extreme: 30 seconds of Playwright setup vs. minutes of user context-switching. For a solo operator, every "manual" label is a broken promise of automation.

--- a/plugins/soleur/skills/plan/SKILL.md
+++ b/plugins/soleur/skills/plan/SKILL.md
@@ -273,6 +273,7 @@ end
 - [ ] Acceptance criteria are measurable
 - [ ] Add names of files in pseudo code examples and todo lists
 - [ ] Add an ERD mermaid diagram if applicable for new model changes
+- [ ] **Browser task automation check:** Scan all tasks for steps labeled "manual", "browser", or "user must". If any task involves browser interaction (account creation, form submission, settings configuration, credential generation), rewrite it as a Playwright MCP automation step. The only genuinely manual browser steps are CAPTCHA solving and interactive OAuth consent -- and even those should be automated up to the CAPTCHA/consent gate, then handed to the user for that single interaction.
 
 ## Output Format
 


### PR DESCRIPTION
## Summary
- Adds AGENTS.md hard rule requiring Playwright MCP before labeling any browser task as "manual"
- Adds browser task automation check to plan skill pre-submission checklist (Step 6)
- Adds learning document so `learnings-researcher` surfaces this pattern in future sessions

Closes #139

## Changelog
- **fix:** Three-layer prevention for the recurring anti-pattern of labeling browser tasks as "manual" when Playwright MCP can automate them

## Test plan
- [ ] Verify AGENTS.md rule is loaded in new sessions
- [ ] Verify plan skill checklist includes browser automation check
- [ ] Verify `learnings-researcher` finds the new learning when planning browser-related features

🤖 Generated with [Claude Code](https://claude.com/claude-code)