### PR TITLE
ci: add monthly Plausible goal provisioning workflow

### DIFF
--- a/.github/workflows/scheduled-plausible-goals.yml
+++ b/.github/workflows/scheduled-plausible-goals.yml
@@ -1,0 +1,72 @@
+# Scheduled Plausible goal provisioning.
+# Ensures conversion goals stay configured in Plausible Analytics.
+# The script is idempotent (PUT find-or-create), so re-running is safe.
+#
+# Schedule: 1st of every month at 07:00 UTC.
+# Manual trigger: workflow_dispatch (no inputs).
+#
+# Required secrets:
+#   PLAUSIBLE_API_KEY  - Plausible API key
+#   PLAUSIBLE_SITE_ID  - Site ID (typically the domain, e.g. soleur.ai)
+#   DISCORD_WEBHOOK_URL - (optional) Discord webhook for failure notifications
+#
+# Security: No external code execution. Shell script + curl + jq only.
+#   No untrusted input is used in run: commands -- all inputs come from
+#   repository secrets (not event payloads). server_url and repository are
+#   safe GitHub context values (not user-controlled).
+
+name: "Scheduled: Plausible Goals"
+
+on:
+  schedule:
+    - cron: '0 7 1 * *'  # 1st of every month at 07:00 UTC
+  workflow_dispatch: {}
+
+concurrency:
+  group: plausible-goals
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Provision Plausible goals
+        env:
+          PLAUSIBLE_API_KEY: ${{ secrets.PLAUSIBLE_API_KEY }}
+          PLAUSIBLE_SITE_ID: ${{ secrets.PLAUSIBLE_SITE_ID }}
+        run: bash scripts/provision-plausible-goals.sh
+
+      - name: Discord notification (failure)
+        if: failure()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          if [[ -z "${DISCORD_WEBHOOK_URL:-}" ]]; then
+            echo "DISCORD_WEBHOOK_URL not set, skipping failure notification"
+            exit 0
+          fi
+          RUN_URL="${REPO_URL}/actions/runs/${RUN_ID}"
+          MESSAGE=$(printf '**Plausible goal provisioning failed**\n\nWorkflow run: %s\n\nCheck logs for details.' \
+            "$RUN_URL")
+          PAYLOAD=$(jq -n \
+            --arg content "$MESSAGE" \
+            --arg username "Sol" \
+            --arg avatar_url "https://raw.githubusercontent.com/jikig-ai/soleur/main/plugins/soleur/docs/images/logo-mark-512.png" \
+            '{content: $content, username: $username, avatar_url: $avatar_url, allowed_mentions: {parse: []}}')
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            "$DISCORD_WEBHOOK_URL")
+          if [[ "$HTTP_CODE" =~ ^2 ]]; then
+            echo "Discord failure notification sent (HTTP $HTTP_CODE)"
+          else
+            echo "::warning::Discord failure notification failed (HTTP $HTTP_CODE)"
+          fi


### PR DESCRIPTION
## Summary

- Add scheduled GitHub Actions workflow that runs `scripts/provision-plausible-goals.sh` monthly (1st at 07:00 UTC)
- Supports `workflow_dispatch` for manual dogfooding
- Discord failure notification follows `scheduled-weekly-analytics.yml` pattern
- Read-only permissions (no file writes, no PR creation needed)

Closes #578

## Changelog

- **Added** `.github/workflows/scheduled-plausible-goals.yml` — monthly goal provisioning with manual trigger

## Test plan

- [ ] Trigger manually via `workflow_dispatch` after merge to dogfood the provisioning script
- [x] Follows `scheduled-weekly-analytics.yml` patterns (pinned action SHA, Discord notification, security comment header)
- [x] No untrusted input in `run:` commands

Generated with [Claude Code](https://claude.com/claude-code)