### PR TITLE
fix: update archive-kb.sh and worktree-manager.sh to search current KB paths (#600)

### DIFF
--- a/knowledge-base/learnings/2026-03-13-archive-kb-stale-path-resolution.md
+++ b/knowledge-base/learnings/2026-03-13-archive-kb-stale-path-resolution.md
@@ -1,0 +1,76 @@
+---
+title: "Archive-KB and Worktree-Manager Stale Path Resolution"
+date: 2026-03-13
+category: workflow-issues
+tags: [shell-scripting, knowledge-base, path-hardcoding, archive-kb, worktree-manager, migration-debt]
+module: plugins/soleur/skills/archive-kb, plugins/soleur/skills/git-worktree
+---
+
+# Learning: Archive-KB and Worktree-Manager Stale Path Resolution
+
+## Problem
+
+After the knowledge-base restructure (#566, #568), artifacts moved from `knowledge-base/project/` subdirectories to top-level paths:
+
+- `knowledge-base/project/brainstorms/` -> `knowledge-base/brainstorms/`
+- `knowledge-base/project/plans/` -> `knowledge-base/plans/`
+- `knowledge-base/project/specs/` -> `knowledge-base/specs/` and `knowledge-base/features/specs/`
+
+Two shell scripts still hardcoded the legacy `knowledge-base/project/` prefixes:
+
+1. **`archive-kb.sh`** -- `discover_artifacts()` searched only three legacy paths (`knowledge-base/project/brainstorms/`, `knowledge-base/project/plans/`, `knowledge-base/project/specs/`). After the restructure, it silently reported "No artifacts found" for every feature, even when brainstorms, plans, and specs existed at the new locations.
+
+2. **`worktree-manager.sh`** -- `cleanup_merged_worktrees()` hardcoded `knowledge-base/project/specs/` for archiving and `knowledge-base/project/brainstorms/` and `knowledge-base/project/plans/` for `archive_kb_files()` calls. `create_for_feature()` created new spec directories at the legacy path. Both functions silently skipped artifacts at current paths.
+
+The failure mode was silent: no errors, no warnings, just "No artifacts found" when artifacts existed. This meant merged features left unarchived artifacts scattered across the knowledge base.
+
+## Solution
+
+Replaced hardcoded single-path lookups with directory arrays that search current paths first, then legacy paths:
+
+**archive-kb.sh `discover_artifacts()`:**
+```bash
+local file_dirs=(
+  "knowledge-base/brainstorms"
+  "knowledge-base/project/brainstorms"
+  "knowledge-base/plans"
+  "knowledge-base/project/plans"
+)
+for dir in "${file_dirs[@]}"; do
+  for f in "$dir"/*"${slug}"*; do
+    [[ -f "$f" && "$f" != */archive/* ]] && artifacts+=("$f")
+  done
+done
+
+local spec_dirs=(
+  "knowledge-base/specs"
+  "knowledge-base/features/specs"
+  "knowledge-base/project/specs"
+)
+for dir in "${spec_dirs[@]}"; do
+  if [[ -d "$dir/feat-${slug}" ]]; then
+    artifacts+=("$dir/feat-${slug}")
+  fi
+done
+```
+
+**worktree-manager.sh `cleanup_merged_worktrees()`:**
+- Spec archiving iterates over a `spec_candidates` array (current + legacy paths), archiving into a sibling `archive/` directory relative to where the spec was found (using `dirname`).
+- `archive_kb_files()` calls doubled: each legacy path call paired with the equivalent current path call.
+
+**worktree-manager.sh `create_for_feature()`:**
+- Updated to create new specs at `knowledge-base/specs/` only (the current canonical path). No reason to create at the legacy path.
+
+`nullglob` (already set in `discover_artifacts()`) handles nonexistent directories gracefully -- empty globs expand to nothing rather than producing literal glob strings.
+
+## Key Insight
+
+Directory restructures create invisible breakage in shell scripts that construct paths from string literals. The scripts had no test coverage and no runtime validation that the paths they searched actually existed. The failure was silent because `for f in nonexistent-dir/*; do` with `nullglob` simply iterates zero times -- correct behavior for the shell, incorrect behavior for the user.
+
+The fix pattern -- array of candidate paths with current-first ordering -- is the right approach when a codebase must support both pre-migration and post-migration layouts during a transition period. It avoids a hard cutover (which would break any in-flight worktrees with specs at legacy paths) while ensuring new artifacts are created at the canonical location.
+
+Filed #604 to track broader SKILL.md reference cleanup for stale `knowledge-base/project/` paths in documentation across the repository.
+
+## Tags
+category: workflow-issues
+module: plugins/soleur/skills/archive-kb, plugins/soleur/skills/git-worktree

--- a/knowledge-base/plans/2026-03-13-fix-archive-kb-stale-paths-plan.md
+++ b/knowledge-base/plans/2026-03-13-fix-archive-kb-stale-paths-plan.md
@@ -186,23 +186,23 @@ Update the "What It Archives" table in `plugins/soleur/skills/archive-kb/SKILL.m
 ## Acceptance Criteria
 
 ### archive-kb.sh
-- [ ] `archive-kb.sh` discovers artifacts in `knowledge-base/brainstorms/` (current path)
-- [ ] `archive-kb.sh` discovers artifacts in `knowledge-base/plans/` (current path)
-- [ ] `archive-kb.sh` discovers artifacts in `knowledge-base/specs/feat-<slug>/` (current path)
-- [ ] `archive-kb.sh` discovers artifacts in `knowledge-base/features/specs/feat-<slug>/` (alternate current path)
-- [ ] `archive-kb.sh` still discovers artifacts in `knowledge-base/project/brainstorms/` (legacy path)
-- [ ] `archive-kb.sh` still discovers artifacts in `knowledge-base/project/plans/` (legacy path)
-- [ ] `archive-kb.sh` still discovers artifacts in `knowledge-base/project/specs/feat-<slug>/` (legacy path)
-- [ ] `archive/` subdirectories are excluded from all paths
-- [ ] `--dry-run` flag works correctly with new paths
-- [ ] `SKILL.md` documentation reflects the updated search paths
+- [x] `archive-kb.sh` discovers artifacts in `knowledge-base/brainstorms/` (current path)
+- [x] `archive-kb.sh` discovers artifacts in `knowledge-base/plans/` (current path)
+- [x] `archive-kb.sh` discovers artifacts in `knowledge-base/specs/feat-<slug>/` (current path)
+- [x] `archive-kb.sh` discovers artifacts in `knowledge-base/features/specs/feat-<slug>/` (alternate current path)
+- [x] `archive-kb.sh` still discovers artifacts in `knowledge-base/project/brainstorms/` (legacy path)
+- [x] `archive-kb.sh` still discovers artifacts in `knowledge-base/project/plans/` (legacy path)
+- [x] `archive-kb.sh` still discovers artifacts in `knowledge-base/project/specs/feat-<slug>/` (legacy path)
+- [x] `archive/` subdirectories are excluded from all paths
+- [x] `--dry-run` flag works correctly with new paths
+- [x] `SKILL.md` documentation reflects the updated search paths
 
 ### worktree-manager.sh
-- [ ] `create_for_feature()` creates spec dirs at `knowledge-base/specs/` (not `knowledge-base/project/specs/`)
-- [ ] `cleanup_merged_worktrees()` archives specs from all three spec locations
-- [ ] `cleanup_merged_worktrees()` archives brainstorms from both current and legacy paths
-- [ ] `cleanup_merged_worktrees()` archives plans from both current and legacy paths
-- [ ] Display message in `create_for_feature()` shows correct current path
+- [x] `create_for_feature()` creates spec dirs at `knowledge-base/specs/` (not `knowledge-base/project/specs/`)
+- [x] `cleanup_merged_worktrees()` archives specs from all three spec locations
+- [x] `cleanup_merged_worktrees()` archives brainstorms from both current and legacy paths
+- [x] `cleanup_merged_worktrees()` archives plans from both current and legacy paths
+- [x] Display message in `create_for_feature()` shows correct current path
 
 ## Test Scenarios
 

--- a/knowledge-base/specs/feat-fix-archive-kb-paths/session-state.md
+++ b/knowledge-base/specs/feat-fix-archive-kb-paths/session-state.md
@@ -1,0 +1,21 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-fix-archive-kb-paths/knowledge-base/plans/2026-03-13-fix-archive-kb-stale-paths-plan.md
+- Status: complete
+
+### Errors
+None
+
+### Decisions
+- Expanded scope to include `worktree-manager.sh`: discovered same stale `knowledge-base/project/` paths in 4 locations
+- Search both legacy and current paths rather than removing legacy ones — `nullglob` handles nonexistent directories gracefully
+- No changes needed to `archive_artifact()` or `print_archive_path()` — they use `dirname` and work for any source directory
+- SKILL.md reference cleanup deferred — 60+ stale references exist but agents can adapt; tracked as separate issue
+- Three spec directory locations must be searched: `knowledge-base/specs/`, `knowledge-base/features/specs/`, `knowledge-base/project/specs/`
+
+### Components Invoked
+- `soleur:plan` (skill)
+- `soleur:deepen-plan` (skill)
+- `gh issue view 600`
+- grep/read research across archive-kb.sh, worktree-manager.sh, SKILL.md files

--- a/knowledge-base/specs/feat-fix-archive-kb-paths/tasks.md
+++ b/knowledge-base/specs/feat-fix-archive-kb-paths/tasks.md
@@ -9,34 +9,34 @@ plan: knowledge-base/plans/2026-03-13-fix-archive-kb-stale-paths-plan.md
 
 ## Phase 1: Core Fix -- archive-kb.sh
 
-- [ ] 1.1 Update `discover_artifacts()` in `plugins/soleur/skills/archive-kb/scripts/archive-kb.sh`
-  - [ ] 1.1.1 Add current brainstorm path: `knowledge-base/brainstorms/`
-  - [ ] 1.1.2 Add current plans path: `knowledge-base/plans/`
-  - [ ] 1.1.3 Add current specs path: `knowledge-base/specs/`
-  - [ ] 1.1.4 Add alternate specs path: `knowledge-base/features/specs/`
-  - [ ] 1.1.5 Keep legacy paths: `knowledge-base/project/{brainstorms,plans,specs}/`
+- [x] 1.1 Update `discover_artifacts()` in `plugins/soleur/skills/archive-kb/scripts/archive-kb.sh`
+  - [x] 1.1.1 Add current brainstorm path: `knowledge-base/brainstorms/`
+  - [x] 1.1.2 Add current plans path: `knowledge-base/plans/`
+  - [x] 1.1.3 Add current specs path: `knowledge-base/specs/`
+  - [x] 1.1.4 Add alternate specs path: `knowledge-base/features/specs/`
+  - [x] 1.1.5 Keep legacy paths: `knowledge-base/project/{brainstorms,plans,specs}/`
 
 ## Phase 2: Core Fix -- worktree-manager.sh
 
-- [ ] 2.1 Update `create_for_feature()` in `plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh`
-  - [ ] 2.1.1 Change spec_dir from `knowledge-base/project/specs/` to `knowledge-base/specs/` (line 152)
-  - [ ] 2.1.2 Update display message to show current path (line 194)
-- [ ] 2.2 Update `cleanup_merged_worktrees()` spec archival (lines 426-427)
-  - [ ] 2.2.1 Search all three spec locations: `knowledge-base/specs/`, `knowledge-base/features/specs/`, `knowledge-base/project/specs/`
-- [ ] 2.3 Update `cleanup_merged_worktrees()` brainstorm/plan archival (lines 465-466)
-  - [ ] 2.3.1 Add current brainstorm path: `knowledge-base/brainstorms`
-  - [ ] 2.3.2 Add current plans path: `knowledge-base/plans`
-  - [ ] 2.3.3 Keep legacy paths for both
+- [x] 2.1 Update `create_for_feature()` in `plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh`
+  - [x] 2.1.1 Change spec_dir from `knowledge-base/project/specs/` to `knowledge-base/specs/` (line 152)
+  - [x] 2.1.2 Update display message to show current path (line 194)
+- [x] 2.2 Update `cleanup_merged_worktrees()` spec archival (lines 426-427)
+  - [x] 2.2.1 Search all three spec locations: `knowledge-base/specs/`, `knowledge-base/features/specs/`, `knowledge-base/project/specs/`
+- [x] 2.3 Update `cleanup_merged_worktrees()` brainstorm/plan archival (lines 465-466)
+  - [x] 2.3.1 Add current brainstorm path: `knowledge-base/brainstorms`
+  - [x] 2.3.2 Add current plans path: `knowledge-base/plans`
+  - [x] 2.3.3 Keep legacy paths for both
 
 ## Phase 3: Documentation
 
-- [ ] 3.1 Update `plugins/soleur/skills/archive-kb/SKILL.md`
-  - [ ] 3.1.1 Update "What It Archives" table to list all searched directories
-  - [ ] 3.1.2 Note that both current and legacy paths are searched
+- [x] 3.1 Update `plugins/soleur/skills/archive-kb/SKILL.md`
+  - [x] 3.1.1 Update "What It Archives" table to list all searched directories
+  - [x] 3.1.2 Note that both current and legacy paths are searched
 
 ## Phase 4: Verification
 
-- [ ] 4.1 Run `archive-kb.sh --dry-run` against a slug with artifacts in current paths
-- [ ] 4.2 Verify artifacts in legacy `knowledge-base/project/` paths are still discovered
-- [ ] 4.3 Verify `archive/` subdirectories are excluded from all paths
-- [ ] 4.4 Verify `worktree-manager.sh` create_for_feature creates spec dir at correct path
+- [x] 4.1 Run `archive-kb.sh --dry-run` against a slug with artifacts in current paths
+- [x] 4.2 Verify artifacts in legacy `knowledge-base/project/` paths are still discovered
+- [x] 4.3 Verify `archive/` subdirectories are excluded from all paths
+- [x] 4.4 Verify `worktree-manager.sh` create_for_feature creates spec dir at correct path

--- a/plugins/soleur/skills/archive-kb/SKILL.md
+++ b/plugins/soleur/skills/archive-kb/SKILL.md
@@ -25,13 +25,17 @@ To archive a specific slug (override branch detection):
 
 ## What It Archives
 
-The script discovers artifacts matching the feature slug in three locations:
+The script discovers artifacts matching the feature slug across current and legacy paths:
 
 | Directory | Match Pattern | Type |
 |-----------|--------------|------|
-| `knowledge-base/project/brainstorms/` | Filename contains slug | File glob |
-| `knowledge-base/project/plans/` | Filename contains slug | File glob |
-| `knowledge-base/project/specs/feat-<slug>/` | Exact directory name | Directory match |
+| `knowledge-base/brainstorms/` | Filename contains slug | File glob |
+| `knowledge-base/project/brainstorms/` | Filename contains slug | File glob (legacy) |
+| `knowledge-base/plans/` | Filename contains slug | File glob |
+| `knowledge-base/project/plans/` | Filename contains slug | File glob (legacy) |
+| `knowledge-base/specs/feat-<slug>/` | Exact directory name | Directory match |
+| `knowledge-base/features/specs/feat-<slug>/` | Exact directory name | Directory match |
+| `knowledge-base/project/specs/feat-<slug>/` | Exact directory name | Directory match (legacy) |
 
 All `archive/` subdirectories are excluded from discovery.
 

--- a/plugins/soleur/skills/archive-kb/scripts/archive-kb.sh
+++ b/plugins/soleur/skills/archive-kb/scripts/archive-kb.sh
@@ -94,20 +94,30 @@ discover_artifacts() {
   # Enable nullglob so empty globs expand to nothing
   shopt -s nullglob
 
-  # Brainstorms: files matching *slug* excluding archive/
-  for f in knowledge-base/project/brainstorms/*"${slug}"*; do
-    [[ -f "$f" && "$f" != */archive/* ]] && artifacts+=("$f")
+  # Brainstorms and plans: current paths first, legacy paths second
+  local file_dirs=(
+    "knowledge-base/brainstorms"
+    "knowledge-base/project/brainstorms"
+    "knowledge-base/plans"
+    "knowledge-base/project/plans"
+  )
+  for dir in "${file_dirs[@]}"; do
+    for f in "$dir"/*"${slug}"*; do
+      [[ -f "$f" && "$f" != */archive/* ]] && artifacts+=("$f")
+    done
   done
 
-  # Plans: files matching *slug* excluding archive/
-  for f in knowledge-base/project/plans/*"${slug}"*; do
-    [[ -f "$f" && "$f" != */archive/* ]] && artifacts+=("$f")
+  # Specs: current paths first, legacy paths second
+  local spec_dirs=(
+    "knowledge-base/specs"
+    "knowledge-base/features/specs"
+    "knowledge-base/project/specs"
+  )
+  for dir in "${spec_dirs[@]}"; do
+    if [[ -d "$dir/feat-${slug}" ]]; then
+      artifacts+=("$dir/feat-${slug}")
+    fi
   done
-
-  # Specs: exact directory match feat-<slug>
-  if [[ -d "knowledge-base/project/specs/feat-${slug}" ]]; then
-    artifacts+=("knowledge-base/project/specs/feat-${slug}")
-  fi
 
   shopt -u nullglob
 

--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -149,7 +149,7 @@ create_for_feature() {
 
   local branch_name="feat-$name"
   local worktree_path="$WORKTREE_DIR/$branch_name"
-  local spec_dir="$GIT_ROOT/knowledge-base/project/specs/$branch_name"
+  local spec_dir="$GIT_ROOT/knowledge-base/specs/$branch_name"
 
   # Check if worktree already exists
   if [[ -d "$worktree_path" ]]; then
@@ -191,7 +191,7 @@ create_for_feature() {
   echo ""
   echo "Next steps:"
   echo -e "  1. ${BLUE}cd $worktree_path${NC}"
-  echo -e "  2. Create spec: ${BLUE}knowledge-base/project/specs/$branch_name/spec.md${NC}"
+  echo -e "  2. Create spec: ${BLUE}knowledge-base/specs/$branch_name/spec.md${NC}"
   echo ""
 }
 
@@ -423,9 +423,6 @@ cleanup_merged_worktrees() {
     local worktree_path="${branch_to_worktree[$branch]:-}"
     local safe_branch
     safe_branch=$(echo "$branch" | tr '/' '-')
-    local spec_dir="$GIT_ROOT/knowledge-base/project/specs/$safe_branch"
-    local archive_dir="$GIT_ROOT/knowledge-base/project/specs/archive"
-
     # Skip if active worktree
     if [[ -n "$worktree_path" && "$PWD" == "$worktree_path"* ]]; then
       [[ "$verbose" == "true" ]] && echo -e "${YELLOW}(skip) $branch - currently active${NC}"
@@ -443,17 +440,25 @@ cleanup_merged_worktrees() {
       fi
     fi
 
-    # Archive spec directory if exists (timestamp prevents collisions)
-    if [[ -d "$spec_dir" ]]; then
-      local archive_name
-      archive_name="$(date +%Y-%m-%d-%H%M%S)-$safe_branch"
-      local archive_path="$archive_dir/$archive_name"
+    # Archive spec directories: current paths first, legacy paths second
+    local spec_candidates=(
+      "$GIT_ROOT/knowledge-base/specs/$safe_branch"
+      "$GIT_ROOT/knowledge-base/features/specs/$safe_branch"
+      "$GIT_ROOT/knowledge-base/project/specs/$safe_branch"
+    )
+    for spec_dir in "${spec_candidates[@]}"; do
+      if [[ -d "$spec_dir" ]]; then
+        local archive_dir archive_name archive_path
+        archive_dir="$(dirname "$spec_dir")/archive"
+        archive_name="$(date +%Y-%m-%d-%H%M%S)-$safe_branch"
+        archive_path="$archive_dir/$archive_name"
 
-      mkdir -p "$archive_dir"
-      if ! mv "$spec_dir" "$archive_path" 2>/dev/null; then
-        [[ "$verbose" == "true" ]] && echo -e "${YELLOW}Warning: Could not archive spec for $branch${NC}"
+        mkdir -p "$archive_dir"
+        if ! mv "$spec_dir" "$archive_path" 2>/dev/null; then
+          [[ "$verbose" == "true" ]] && echo -e "${YELLOW}Warning: Could not archive spec for $branch${NC}"
+        fi
       fi
-    fi
+    done
 
     # Extract feature slug by stripping all known branch prefixes
     local feature_slug="$safe_branch"
@@ -461,8 +466,10 @@ cleanup_merged_worktrees() {
     feature_slug="${feature_slug#fix-}"
     feature_slug="${feature_slug#feature-}"
 
-    # Archive brainstorms and plans matching the feature slug
+    # Archive brainstorms and plans matching the feature slug (current + legacy paths)
+    archive_kb_files "$GIT_ROOT/knowledge-base/brainstorms" "$feature_slug" "brainstorm" "$verbose"
     archive_kb_files "$GIT_ROOT/knowledge-base/project/brainstorms" "$feature_slug" "brainstorm" "$verbose"
+    archive_kb_files "$GIT_ROOT/knowledge-base/plans" "$feature_slug" "plan" "$verbose"
     archive_kb_files "$GIT_ROOT/knowledge-base/project/plans" "$feature_slug" "plan" "$verbose"
 
     # Remove worktree if exists (use actual path from git, not constructed path)
@@ -614,7 +621,7 @@ Commands:
   create <branch-name> [from-branch]  Create new worktree (copies .env files automatically)
                                       (from-branch defaults to main)
   feature | feat <name> [from-branch] Create worktree for feature with spec directory
-                                      (creates feat-<name> branch + knowledge-base/project/specs/feat-<name>/)
+                                      (creates feat-<name> branch + knowledge-base/specs/feat-<name>/)
   list | ls                           List all worktrees
   switch | go [name]                  Switch to worktree
   copy-env | env [name]               Copy .env files from main repo to worktree


### PR DESCRIPTION
## Summary

- `archive-kb.sh` and `worktree-manager.sh` hardcoded legacy `knowledge-base/project/` paths that became stale after the KB restructure (#566, #568)
- Both scripts now search current and legacy paths using directory arrays (current paths first)
- `create_for_feature()` creates new specs at `knowledge-base/specs/` (current canonical path)
- SKILL.md documentation updated to reflect all 7 search paths

Closes #600

## Changelog

- **Fixed** `archive-kb.sh` `discover_artifacts()` to search `knowledge-base/brainstorms/`, `knowledge-base/plans/`, `knowledge-base/specs/`, and `knowledge-base/features/specs/` alongside legacy `knowledge-base/project/` paths
- **Fixed** `worktree-manager.sh` `cleanup_merged_worktrees()` to archive specs, brainstorms, and plans from both current and legacy paths
- **Fixed** `worktree-manager.sh` `create_for_feature()` to create spec dirs at `knowledge-base/specs/` instead of stale `knowledge-base/project/specs/`
- **Updated** `archive-kb/SKILL.md` documentation table to list all searched directories

## Test plan

- [x] `bash archive-kb.sh --dry-run hn-presence` discovers artifacts at current paths (previously missed)
- [x] `bash archive-kb.sh --dry-run finance-domain` still discovers artifacts at legacy paths
- [x] `bash archive-kb.sh --dry-run nonexistent-xyz` reports "No artifacts found" cleanly
- [x] Both scripts pass `bash -n` syntax check
- [x] All 1045 tests pass (`bun test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)