### PR TITLE
docs: persist bare repo hardening learnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This repository contains the Soleur Claude Code plugin. Detailed conventions liv
 - When a command exits non-zero or prints a warning, investigate before proceeding. Never treat a failed step as success.
 - Before merging any PR, merge origin/main into the feature branch [hook-enforced: pre-merge-rebase.sh] (`git fetch origin main && git merge origin/main`).
 - Always read a file before editing it. The Edit tool rejects unread files, but context compaction erases prior reads -- re-read after any compaction event.
+- When a plan specifies relative paths (e.g., `source "$SCRIPT_DIR/../../..."`), trace each `../` step to verify the final target before implementing. Plans have prescribed wrong paths that were implemented verbatim and only caught by review agents.
 - PreToolUse hooks block: commits on main, rm -rf on worktrees, --delete-branch with active worktrees, writes to main repo when worktrees exist, commits with conflict markers in staged content. Work with these guards, not around them.
 - The host terminal is Warp. Do not attempt automated terminal manipulation via escape sequences (cursor position queries, TUI rendering, and similar sequences are intercepted by Warp's tmux control mode and silently fail).
 - The Bash tool runs in a non-interactive shell without `sudo` access. Do not attempt commands requiring elevated privileges -- provide manual instructions instead.

--- a/knowledge-base/learnings/2026-03-14-bare-repo-helper-extraction-patterns.md
+++ b/knowledge-base/learnings/2026-03-14-bare-repo-helper-extraction-patterns.md
@@ -6,11 +6,11 @@ When extracting a shared sourceable helper (`resolve-git-root.sh`) for bare repo
 ## Solution
 
 ### Path arithmetic for source statements
-Count directory levels from the script to the helper. Community scripts at `plugins/soleur/skills/community/scripts/` need 3 levels up (`../../../`) to reach `plugins/soleur/scripts/`, not 4. Verify by tracing: `../` = `community/`, `../../` = `skills/`, `../../../` = `soleur/`, `../../../scripts/` = target.
+Count directory levels from the script to the helper by tracing each `../` step explicitly. Community scripts at `plugins/soleur/skills/community/scripts/` need 3 levels up (`../../../`) to reach `plugins/soleur/scripts/`, not 4. Verify by tracing: `../` = `community/`, `../../` = `skills/`, `../../../` = `soleur/`, `../../../scripts/` = target. The plan prescribed the wrong path and it was implemented verbatim -- review agents caught it, but neither the plan phase, implementation, nor tests did.
 
 ### Sourceable helper design constraints
-- Use `return` not `exit` (exit kills the caller)
-- Never call `set` (overrides caller's options)
+- Use `return` not `exit` (exit kills the caller when sourced)
+- Never call `set` (overrides caller's shell options)
 - Use `unset` on temp variables to avoid namespace pollution
 - Include a `BASH_SOURCE[0]` guard for accidental direct execution
 - Validate resolved paths exist on disk (`[[ -d "$GIT_ROOT" ]]`)
@@ -21,11 +21,17 @@ When hooks start sourcing a helper that calls `git rev-parse`, test harnesses th
 ### Temp file naming with basename collisions
 `$(basename "$file").$$` collides when the file list contains files with the same name in different directories (e.g., `AGENTS.md` and `plugins/soleur/AGENTS.md`). Use `${file//\//_}` to create unique names from the full path.
 
-### Shell CWD corruption
-Never `cd` to a temp directory in a persistent shell session without a subshell. Use `(cd "$dir" && command)` instead of `cd "$dir" && command`. A deleted CWD makes all subsequent commands fail with no recovery path.
+### Shell CWD corruption in persistent shells
+Never `cd` to a temp directory in a persistent shell session without wrapping in a subshell. Use `(cd "$dir" && command)` instead of `cd "$dir" && command`. A deleted CWD makes all subsequent commands fail with no recovery path except spawning a new agent.
 
 ## Key Insight
-Plan-generated relative paths must be verified by tracing each `../` step. Review agents caught a path arithmetic error that the plan phase, implementation, and tests all missed. The error was in the plan itself (deepen-plan prescribed the wrong path), and was implemented verbatim. This validates the multi-agent review step as a critical safety net.
+Plan-generated relative paths must be verified by tracing each `../` step. Review agents caught a path arithmetic error that the plan phase, implementation, and tests all missed. The error was in the plan itself (deepen-plan prescribed the wrong path), and was implemented verbatim. This validates the multi-agent review step as a critical safety net for plan-level errors, not just implementation errors.
+
+## Session Errors
+1. Plan prescribed wrong path (../../../../ instead of ../../../) -- caught only by review agents
+2. Plan claimed tests would pass without modification -- false, required adding git init to test setup
+3. Shell CWD corrupted by cd to deleted temp dir -- required subagent to recover
+4. Temp file naming collision from basename on same-named files in different dirs -- caught by review agents
 
 ## Tags
 category: shell-scripts


### PR DESCRIPTION
## Summary
- Enrich existing learning file with session errors section documenting 4 errors from PR #613 bare repo hardening
- Add hard rule to AGENTS.md: verify plan-generated relative paths by tracing each `../` step before implementing

These details were identified during the #613 session but the learning file was only partially persisted (missing session errors and some detail).

## Test plan
- [x] No code changes, documentation only

Generated with [Claude Code](https://claude.com/claude-code)