### PR TITLE
ci: add weekly LinkedIn token expiry check

### DIFF
--- a/.github/workflows/scheduled-linkedin-token-check.yml
+++ b/.github/workflows/scheduled-linkedin-token-check.yml
@@ -1,0 +1,103 @@
+# Check LinkedIn OAuth token expiry and create a renewal issue when
+# the token is expired or invalid.
+# Runs weekly on Mondays at 09:00 UTC and on manual dispatch.
+# To test manually: gh workflow run scheduled-linkedin-token-check.yml
+#
+# Security: This workflow does NOT use untrusted event inputs in run: commands.
+# The only secret used is LINKEDIN_ACCESS_TOKEN for the API introspection call.
+
+name: "Scheduled: LinkedIn Token Check"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 9 * * 1'
+
+concurrency:
+  group: scheduled-linkedin-token-check
+  cancel-in-progress: false
+
+permissions:
+  issues: write
+
+jobs:
+  check-token:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check token expiry
+        env:
+          LINKEDIN_ACCESS_TOKEN: ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if [[ -z "${LINKEDIN_ACCESS_TOKEN:-}" ]]; then
+            echo "::warning::LINKEDIN_ACCESS_TOKEN secret is not set. Skipping check."
+            exit 0
+          fi
+
+          # Call LinkedIn introspection endpoint
+          HTTP_CODE=$(curl -s -o /tmp/li-response.json -w "%{http_code}" \
+            -H "Authorization: Bearer ${LINKEDIN_ACCESS_TOKEN}" \
+            "https://api.linkedin.com/v2/userinfo")
+
+          if [[ "$HTTP_CODE" == "401" ]]; then
+            echo "::error::LinkedIn token is expired or invalid (HTTP 401)."
+            TITLE="[Action Required] LinkedIn OAuth token has expired"
+            BODY=$(cat <<'ISSUE_BODY'
+          ## LinkedIn Token Expired
+
+          The scheduled token check detected that `LINKEDIN_ACCESS_TOKEN` is **expired or invalid** (API returned HTTP 401).
+
+          Content publisher LinkedIn posting is currently **non-functional**.
+
+          ### Renewal steps
+
+          1. Go to https://www.linkedin.com/developers/tools/oauth/token-generator?clientId=78wtm2wu15iikn
+          2. Select scopes: openid, profile, w_member_social, email
+          3. Accept redirect URL confirmation -> Request access token -> Sign in -> Allow
+          4. Copy the new token and run:
+             ```bash
+             echo "<new-token>" | gh secret set LINKEDIN_ACCESS_TOKEN
+             ```
+
+          **Person URN** (`LINKEDIN_PERSON_URN`) does not expire and does not need renewal.
+          ISSUE_BODY
+          )
+
+            # Dedup: check for existing open issue
+            EXISTING=$(gh issue list --repo "$GH_REPO" --state open \
+              --search "in:title \"[Action Required] LinkedIn OAuth token\"" \
+              --json number --jq '.[0].number // empty')
+
+            if [[ -n "$EXISTING" ]]; then
+              echo "Issue already exists: #$EXISTING -- adding comment."
+              gh issue comment "$EXISTING" --repo "$GH_REPO" \
+                --body "Token check ran $(date -u '+%Y-%m-%d %H:%M UTC') -- token is still expired."
+            else
+              gh issue create --repo "$GH_REPO" \
+                --title "$TITLE" \
+                --label "action-required" \
+                --body "$BODY"
+            fi
+            exit 0
+          fi
+
+          if [[ ! "$HTTP_CODE" =~ ^2 ]]; then
+            echo "::warning::Unexpected HTTP $HTTP_CODE from LinkedIn API. Token status unknown."
+            exit 0
+          fi
+
+          echo "LinkedIn token is valid (HTTP $HTTP_CODE)."
+          echo "Token holder: $(jq -r '.name // "unknown"' /tmp/li-response.json)"
+
+          # Close any stale renewal issues since the token is now valid
+          STALE=$(gh issue list --repo "$GH_REPO" --state open \
+            --search "in:title \"[Action Required] LinkedIn OAuth token\"" \
+            --json number --jq '.[0].number // empty')
+
+          if [[ -n "$STALE" ]]; then
+            echo "Closing stale renewal issue #$STALE -- token is valid."
+            gh issue close "$STALE" --repo "$GH_REPO" \
+              --comment "Token check ran $(date -u '+%Y-%m-%d %H:%M UTC') -- token is valid. Auto-closing."
+          fi


### PR DESCRIPTION
## Summary
- Adds a weekly GitHub Actions workflow that checks if the LinkedIn OAuth token is still valid
- Creates a dedup GitHub issue with renewal instructions when the token expires
- Auto-closes stale renewal issues when the token is renewed

Closes #621

## Changelog
- New workflow: `scheduled-linkedin-token-check.yml` runs every Monday at 09:00 UTC
- Calls LinkedIn `/v2/userinfo` to verify token validity
- On HTTP 401: creates/comments on a `[Action Required]` issue with step-by-step renewal instructions
- On HTTP 2xx: auto-closes any stale renewal issues

## Test plan
- [x] Workflow syntax is valid YAML
- [x] No untrusted inputs in `run:` commands (only `secrets.*` and `github.token`)
- [ ] Manual trigger via `gh workflow run scheduled-linkedin-token-check.yml` after merge

Generated with [Claude Code](https://claude.com/claude-code)