### PR TITLE
fix: ralph-loop state file lost on worktree cleanup

### DIFF
--- a/plugins/soleur/hooks/stop-hook.sh
+++ b/plugins/soleur/hooks/stop-hook.sh
@@ -9,10 +9,15 @@
 
 set -euo pipefail
 
-# Resolve project root (worktree-safe: CWD may be .worktrees/feat-* instead of repo root)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../scripts/resolve-git-root.sh"
-PROJECT_ROOT="$GIT_ROOT"
+# Resolve shared repo root (not worktree root) so state file path matches setup-ralph-loop.sh.
+# git rev-parse --git-common-dir returns the shared .git dir across all worktrees.
+# May return a relative path, so resolve to absolute first, then strip trailing /.git.
+_common_dir=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" && pwd) || {
+  # Not in a git repo -- allow exit
+  exit 0
+}
+PROJECT_ROOT="${_common_dir%/.git}"
+unset _common_dir
 RALPH_STATE_FILE="${PROJECT_ROOT}/.claude/ralph-loop.local.md"
 
 # Check if ralph-loop is active BEFORE reading stdin

--- a/plugins/soleur/scripts/setup-ralph-loop.sh
+++ b/plugins/soleur/scripts/setup-ralph-loop.sh
@@ -8,10 +8,15 @@
 
 set -euo pipefail
 
-# Resolve project root (worktree-safe: CWD may be .worktrees/feat-* instead of repo root)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/resolve-git-root.sh"
-PROJECT_ROOT="$GIT_ROOT"
+# Resolve shared repo root (not worktree root) so state file survives worktree cleanup.
+# git rev-parse --git-common-dir returns the shared .git dir across all worktrees.
+# May return a relative path, so resolve to absolute first, then strip trailing /.git.
+_common_dir=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" && pwd) || {
+  echo "Error: Not inside a git repository." >&2
+  exit 1
+}
+PROJECT_ROOT="${_common_dir%/.git}"
+unset _common_dir
 
 # Parse arguments
 PROMPT_PARTS=()


### PR DESCRIPTION
## Summary
- Use `git rev-parse --git-common-dir` instead of `resolve-git-root.sh` for ralph-loop state file path
- State file now stored at shared repo root, not worktree root
- Survives worktree cleanup by `cleanup-merged`

## Root Cause
`setup-ralph-loop.sh` used `resolve-git-root.sh` which calls `git rev-parse --show-toplevel`. From a worktree, this returns the **worktree** root (e.g., `.worktrees/feat-x/`). When `cleanup-merged` deletes the worktree, the state file is deleted with it. The stop hook then fails with `sed: can't read .claude/ralph-loop.local.md`.

## Fix
Both `setup-ralph-loop.sh` and `stop-hook.sh` now use `git rev-parse --git-common-dir` which returns the **shared** `.git` directory across all worktrees. After stripping the trailing `/.git`, both scripts resolve to the same repo root regardless of whether they run from a worktree or the main checkout.

## Changelog
- `setup-ralph-loop.sh`: resolve state file path via `--git-common-dir` (not `--show-toplevel`)
- `stop-hook.sh`: same resolution change for consistent path matching

## Test plan
- [x] `git rev-parse --git-common-dir` resolves to same path from worktree and bare root
- [x] State file created at repo root (not worktree root) after `setup-ralph-loop.sh`
- [x] State file persists after worktree removal
- [x] Stop hook finds state file from main checkout after worktree cleanup

Generated with [Claude Code](https://claude.com/claude-code)