### PR TITLE
feat: add programmatic no-post guard to linkedin-community.sh

### DIFF
--- a/.github/workflows/scheduled-content-publisher.yml
+++ b/.github/workflows/scheduled-content-publisher.yml
@@ -54,6 +54,7 @@ jobs:
           X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
           LINKEDIN_ACCESS_TOKEN: ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
           LINKEDIN_PERSON_URN: ${{ secrets.LINKEDIN_PERSON_URN }}
+          # TODO(#590): Add LINKEDIN_ALLOW_POST: "true" when content-publisher.sh gains LinkedIn channel support
           GH_TOKEN: ${{ github.token }}
         run: |
           exit_code=0

--- a/knowledge-base/learnings/2026-03-15-env-var-post-guard-defense-in-depth.md
+++ b/knowledge-base/learnings/2026-03-15-env-var-post-guard-defense-in-depth.md
@@ -1,0 +1,57 @@
+# Learning: Environment Variable Post Guard as Defense-in-Depth
+
+## Problem
+
+The scheduled community monitor workflow tells the agent via prompt instructions not to post to LinkedIn. But prompt instructions are a soft guard -- if the agent disobeys (hallucination, misparse, prompt injection), `cmd_post_content()` in `linkedin-community.sh` would execute successfully and publish content autonomously. There was no programmatic barrier between the agent deciding to post and the post actually happening.
+
+This mirrors a gap already present in the X/Twitter integration, where the only defense-in-depth is the API tier itself (Free tier returns HTTP 403 on posting endpoints). That API-level block is accidental, not designed -- it would vanish if the account were upgraded.
+
+## Solution
+
+Added a `LINKEDIN_ALLOW_POST` environment variable guard at the top of `cmd_post_content()` in `plugins/soleur/skills/community/scripts/linkedin-community.sh`. The guard checks `"${LINKEDIN_ALLOW_POST:-}" != "true"` and returns 1 with an error message if the variable is not set to exactly `"true"`.
+
+Design decisions:
+
+1. **Strict string equality (`!= "true"`)** over a set/unset check -- prevents accidental enabling via empty string, `"1"`, `"TRUE"`, or any other truthy-looking value. Only the exact string `true` passes.
+2. **`return 1` instead of `exit 1`** -- the script uses a `BASH_SOURCE` guard at line 327 to allow sourcing for testing. `exit 1` would kill the sourcing shell; `return 1` safely aborts just the function.
+3. **Guard in the script, not the workflow** -- the monitoring workflow does NOT set `LINKEDIN_ALLOW_POST`, making autonomous posting structurally impossible regardless of what the agent prompt says. A future publishing workflow that intentionally posts would set the variable explicitly.
+4. **6 lines, not 10** -- initial implementation had a redundant comment and an extra echo line. Code-simplicity review compressed it without losing clarity.
+
+Collateral changes:
+- Added `LINKEDIN_ALLOW_POST` to the script header's environment variable documentation block.
+- Added `TODO(#590)` breadcrumb in `scheduled-content-publisher.yml` for the future env change (deferred because `channel_to_section()` only maps discord and x -- LinkedIn is dead code there).
+- Filed #629 for X/Bluesky post guard parity (pre-existing gap discovered during this work).
+
+## Key Insight
+
+Agent prompt instructions are necessary but not sufficient for safety-critical operations. They are a "please don't" guard -- they work when the agent cooperates and fail silently when it doesn't. For destructive or irreversible actions (publishing content, sending messages, deleting data), add a programmatic guard that makes the unsafe action structurally impossible without explicit opt-in.
+
+The pattern is:
+
+```bash
+if [[ "${ACTION_ALLOW_VAR:-}" != "true" ]]; then
+  echo "ERROR: $ACTION_ALLOW_VAR must be 'true' to proceed" >&2
+  return 1
+fi
+```
+
+This creates a two-key system: the agent must both decide to act AND the environment must be configured to permit the action. Neither alone is sufficient. The monitoring workflow omits the key; the publishing workflow provides it. The separation is structural, not behavioral.
+
+This is the same defense-in-depth principle as the `BASH_SOURCE` guard (prevents accidental direct execution), the PreToolUse hooks (prevent commits to main), and the guardrails.sh guards (prevent destructive git operations). The common thread: never rely on a single layer of protection for irreversible actions.
+
+## Session Errors
+
+1. **`setup-ralph-loop.sh` path wrong in one-shot skill** -- tried `./plugins/soleur/skills/one-shot/scripts/setup-ralph-loop.sh` but the script lives at `./plugins/soleur/scripts/setup-ralph-loop.sh`. Same class of error documented in `2026-03-14-bare-repo-helper-extraction-patterns.md` (plan-prescribed paths implemented verbatim without tracing).
+2. **`shellcheck` not installed** -- fell back to `bash -n` for syntax validation. `bash -n` catches syntax errors but misses the class of issues shellcheck detects (unquoted variables, unused variables, POSIX compatibility). Not a blocker for this change but a tooling gap.
+
+## Related
+
+- `2026-03-13-shell-script-defensive-patterns.md` -- authoring-time defensive patterns for shell scripts (complementary: that learning covers code quality; this one covers access control)
+- `2026-03-10-x-api-pay-per-use-billing-and-web-fallback.md` -- X API 402/403 as accidental defense-in-depth (this learning formalizes the pattern as intentional)
+- `2026-03-13-platform-integration-scope-calibration.md` -- LinkedIn scope decisions that deferred API posting (this learning implements the guard for the deferred scope)
+- `2026-02-24-guardrails-chained-commit-bypass.md` -- guardrails.sh as defense-in-depth for git operations (same principle, different domain)
+- GitHub issue #629 -- X/Bluesky post guard parity (filed during this session)
+
+## Tags
+category: prevention
+module: plugins/soleur/skills/community

--- a/knowledge-base/plans/2026-03-15-feat-linkedin-post-guard-plan.md
+++ b/knowledge-base/plans/2026-03-15-feat-linkedin-post-guard-plan.md
@@ -80,13 +80,13 @@ The `linkedin-community.sh` script is being implemented in the `feat-linkedin-ap
 
 ## Acceptance Criteria
 
-- [ ] `cmd_post_content()` in `linkedin-community.sh` checks `LINKEDIN_ALLOW_POST` before any posting logic
-- [ ] When `LINKEDIN_ALLOW_POST` is unset, `post-content` exits with code 1 and prints an informational message to stderr
-- [ ] When `LINKEDIN_ALLOW_POST=false`, `post-content` exits with code 1
-- [ ] When `LINKEDIN_ALLOW_POST=true`, `post-content` proceeds normally
-- [ ] `scheduled-community-monitor.yml` does NOT set `LINKEDIN_ALLOW_POST`
-- [ ] `scheduled-content-publisher.yml` does NOT set `LINKEDIN_ALLOW_POST` yet (deferred to #590 when `content-publisher.sh` gains LinkedIn channel support)
-- [ ] Guard message references `LINKEDIN_ALLOW_POST=true` so operators know how to enable posting
+- [x] `cmd_post_content()` in `linkedin-community.sh` checks `LINKEDIN_ALLOW_POST` before any posting logic
+- [x] When `LINKEDIN_ALLOW_POST` is unset, `post-content` exits with code 1 and prints an informational message to stderr
+- [x] When `LINKEDIN_ALLOW_POST=false`, `post-content` exits with code 1
+- [x] When `LINKEDIN_ALLOW_POST=true`, `post-content` proceeds normally
+- [x] `scheduled-community-monitor.yml` does NOT set `LINKEDIN_ALLOW_POST`
+- [x] `scheduled-content-publisher.yml` does NOT set `LINKEDIN_ALLOW_POST` yet (deferred to #590 when `content-publisher.sh` gains LinkedIn channel support)
+- [x] Guard message references `LINKEDIN_ALLOW_POST=true` so operators know how to enable posting
 
 ## Test Scenarios
 

--- a/knowledge-base/specs/feat-linkedin-post-guard/session-state.md
+++ b/knowledge-base/specs/feat-linkedin-post-guard/session-state.md
@@ -1,0 +1,19 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-linkedin-post-guard/knowledge-base/plans/2026-03-15-feat-linkedin-post-guard-plan.md
+- Status: complete
+
+### Errors
+None
+
+### Decisions
+- MINIMAL template selected -- this is a 3-line env var guard, not a complex feature
+- Content-publisher workflow change deferred -- `content-publisher.sh` has no LinkedIn channel support, so adding `LINKEDIN_ALLOW_POST=true` would be dead code; deferred to issue #590
+- Strict equality check (`!= "true"`) over set/unset check -- prevents accidental enabling via empty string or `1`
+- Return code 1 (not 0) -- per constitution rule about fallback functions masking failures from CI
+
+### Components Invoked
+- `soleur:plan` -- created initial plan and tasks
+- `soleur:plan-review` -- DHH, Kieran, and Code Simplicity reviewers ran in parallel
+- `soleur:deepen-plan` -- corrected content-publisher scope gap

--- a/knowledge-base/specs/feat-linkedin-post-guard/tasks.md
+++ b/knowledge-base/specs/feat-linkedin-post-guard/tasks.md
@@ -2,22 +2,22 @@
 
 ## Phase 1: Setup
 
-- [ ] 1.1 Verify `linkedin-community.sh` exists (may need to coordinate with feat-linkedin-api-scripts branch or merge its changes first)
-- [ ] 1.2 Read `cmd_post_content()` function to identify exact insertion point for the guard
+- [x] 1.1 Verify `linkedin-community.sh` exists (may need to coordinate with feat-linkedin-api-scripts branch or merge its changes first)
+- [x] 1.2 Read `cmd_post_content()` function to identify exact insertion point for the guard
 
 ## Phase 2: Core Implementation
 
-- [ ] 2.1 Add `LINKEDIN_ALLOW_POST` guard as the first statement in `cmd_post_content()` in `plugins/soleur/skills/community/scripts/linkedin-community.sh`
-  - [ ] 2.1.1 Check `"${LINKEDIN_ALLOW_POST:-}" != "true"` (strict string equality, not just set/unset)
-  - [ ] 2.1.2 Print informational error message to stderr naming the variable and required value
-  - [ ] 2.1.3 Return 1 (not 0) to signal failure to callers
-- [ ] 2.2 Verify `scheduled-community-monitor.yml` does NOT set `LINKEDIN_ALLOW_POST` (confirm by reading the file)
-- [ ] 2.3 Verify `scheduled-content-publisher.yml` does NOT set `LINKEDIN_ALLOW_POST` yet (deferred to #590 when `content-publisher.sh` gains LinkedIn channel support)
+- [x] 2.1 Add `LINKEDIN_ALLOW_POST` guard as the first statement in `cmd_post_content()` in `plugins/soleur/skills/community/scripts/linkedin-community.sh`
+  - [x] 2.1.1 Check `"${LINKEDIN_ALLOW_POST:-}" != "true"` (strict string equality, not just set/unset)
+  - [x] 2.1.2 Print informational error message to stderr naming the variable and required value
+  - [x] 2.1.3 Return 1 (not 0) to signal failure to callers
+- [x] 2.2 Verify `scheduled-community-monitor.yml` does NOT set `LINKEDIN_ALLOW_POST` (confirm by reading the file)
+- [x] 2.3 Verify `scheduled-content-publisher.yml` does NOT set `LINKEDIN_ALLOW_POST` yet (deferred to #590 when `content-publisher.sh` gains LinkedIn channel support)
 
 ## Phase 3: Testing & Validation
 
-- [ ] 3.1 Run `shellcheck plugins/soleur/skills/community/scripts/linkedin-community.sh` -- zero new warnings
-- [ ] 3.2 Source the script and verify guard blocks posting when `LINKEDIN_ALLOW_POST` is unset
-- [ ] 3.3 Source the script and verify guard blocks posting when `LINKEDIN_ALLOW_POST=false`
-- [ ] 3.4 Source the script and verify guard allows posting when `LINKEDIN_ALLOW_POST=true`
-- [ ] 3.5 Verify `scheduled-community-monitor.yml` has no `LINKEDIN_ALLOW_POST` in env block
+- [x] 3.1 Run `shellcheck plugins/soleur/skills/community/scripts/linkedin-community.sh` -- zero new warnings (shellcheck not installed; bash -n syntax check passed)
+- [x] 3.2 Source the script and verify guard blocks posting when `LINKEDIN_ALLOW_POST` is unset
+- [x] 3.3 Source the script and verify guard blocks posting when `LINKEDIN_ALLOW_POST=false`
+- [x] 3.4 Source the script and verify guard allows posting when `LINKEDIN_ALLOW_POST=true`
+- [x] 3.5 Verify `scheduled-community-monitor.yml` has no `LINKEDIN_ALLOW_POST` in env block

--- a/plugins/soleur/skills/community/SKILL.md
+++ b/plugins/soleur/skills/community/SKILL.md
@@ -147,6 +147,7 @@ If no sub-command is provided, present options using the AskUserQuestion tool:
 - The `community-manager` agent handles data collection, analysis, and output formatting
 - This skill is the entry point; the agent does the work
 - Ownership boundary: community = monitoring + engagement. Broadcasting/distribution is handled by the `social-distribute` skill.
+- LinkedIn posting requires `LINKEDIN_ALLOW_POST=true` in the environment (defense-in-depth guard). Monitoring workflows omit this variable intentionally.
 
 ## Platform Surface Check
 

--- a/plugins/soleur/skills/community/scripts/linkedin-community.sh
+++ b/plugins/soleur/skills/community/scripts/linkedin-community.sh
@@ -10,6 +10,7 @@
 # Environment variables (required):
 #   LINKEDIN_ACCESS_TOKEN  - OAuth 2.0 Bearer token (60-day TTL)
 #   LINKEDIN_PERSON_URN    - Person URN for posting (urn:li:person:{id})
+#   LINKEDIN_ALLOW_POST    - Set to "true" to enable posting (safety guard, default: disabled)
 #
 # Exit codes:
 #   0 - Success
@@ -221,6 +222,13 @@ post_request() {
 # --- Commands ---
 
 cmd_post_content() {
+  # Guard: require explicit opt-in to post.
+  if [[ "${LINKEDIN_ALLOW_POST:-}" != "true" ]]; then
+    echo "Error: LINKEDIN_ALLOW_POST is not set to 'true'." >&2
+    echo "Set LINKEDIN_ALLOW_POST=true to enable posting." >&2
+    return 1
+  fi
+
   local text=""
 
   while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## Summary

- Add `LINKEDIN_ALLOW_POST` environment variable guard to `cmd_post_content()` in `linkedin-community.sh`
- When the variable is not set to exactly `"true"`, posting is blocked with exit code 1 and an informational error message
- Defense-in-depth: makes autonomous posting structurally impossible during monitoring runs
- Monitoring workflow does NOT set the variable; future content-publisher workflow will set it when #590 lands

Closes #623

## Changelog

- **Added**: `LINKEDIN_ALLOW_POST` env var guard as first statement in `cmd_post_content()` -- blocks posting unless explicitly opted in
- **Added**: `LINKEDIN_ALLOW_POST` documentation in script header environment variables block
- **Added**: `TODO(#590)` breadcrumb comment in `scheduled-content-publisher.yml` for future LinkedIn channel support
- **Added**: Guard note in community `SKILL.md` Important Guidelines section
- **Added**: Learning document capturing the defense-in-depth env var guard pattern

## Test plan

- [x] Guard blocks when `LINKEDIN_ALLOW_POST` is unset (exit 1)
- [x] Guard blocks when `LINKEDIN_ALLOW_POST=false` (exit 1)
- [x] Guard blocks when `LINKEDIN_ALLOW_POST=""` (exit 1)
- [x] Guard blocks when `LINKEDIN_ALLOW_POST=1` (exit 1)
- [x] Guard allows when `LINKEDIN_ALLOW_POST=true` (proceeds to posting logic)
- [x] `scheduled-community-monitor.yml` does NOT set `LINKEDIN_ALLOW_POST`
- [x] `scheduled-content-publisher.yml` does NOT set `LINKEDIN_ALLOW_POST` (deferred to #590)
- [x] Bash syntax check passes (`bash -n`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)