### PR TITLE
feat(docs): add Bluesky card to community page and footer

### DIFF
--- a/plugins/soleur/docs/_data/site.json
+++ b/plugins/soleur/docs/_data/site.json
@@ -8,6 +8,7 @@
   "x": "https://x.com/soleur_ai",
   "linkedin": "https://linkedin.com/company/soleur",
   "linkedinCompany": "https://www.linkedin.com/company/jikigai/",
+  "bluesky": "https://bsky.app/profile/soleur.bsky.social",
   "newsletter": {
     "username": "soleur"
   },

--- a/plugins/soleur/docs/_includes/base.njk
+++ b/plugins/soleur/docs/_includes/base.njk
@@ -110,6 +110,7 @@
         <a href="{{ site.github }}" target="_blank" rel="noopener" aria-label="GitHub">GitHub</a>
         <a href="{{ site.x }}" target="_blank" rel="noopener" aria-label="X / Twitter">X</a>
         <a href="{{ site.linkedinCompany }}" target="_blank" rel="noopener" aria-label="LinkedIn">LinkedIn</a>
+        <a href="{{ site.bluesky }}" target="_blank" rel="noopener" aria-label="Bluesky">Bluesky</a>
       </div>
       <span class="footer-tagline">Designed, built, and shipped by {{ site.name }} &mdash; using {{ site.name }}.</span>
     </div>

--- a/plugins/soleur/docs/pages/community.njk
+++ b/plugins/soleur/docs/pages/community.njk
@@ -42,6 +42,14 @@ permalink: pages/community.html
             <h3 class="card-title">LinkedIn</h3>
             <p class="card-description">Follow the Soleur company page for product updates, feature announcements, and engineering insights.</p>
           </a>
+          <a href="{{ site.bluesky }}" target="_blank" rel="noopener" class="component-card community-card-link">
+            <div class="card-header">
+              <span class="card-dot" style="background: #0085FF"></span>
+              <span class="card-category">Social</span>
+            </div>
+            <h3 class="card-title">Bluesky</h3>
+            <p class="card-description">Follow @soleur.bsky.social for updates in the open social web.</p>
+          </a>
           <a href="{{ site.github }}" target="_blank" rel="noopener" class="component-card community-card-link">
             <div class="card-header">
               <span class="card-dot" style="background: #F0F0F0"></span>


### PR DESCRIPTION
## Summary
- Add `bluesky` URL to `site.json` pointing to `https://bsky.app/profile/soleur.bsky.social`
- Add Bluesky card to community page Connect section with #0085FF brand blue dot and "Social" category
- Add Bluesky link to site-wide footer social links with aria-label

## Changelog
- Added Bluesky card to docs site community page following existing card pattern
- Added Bluesky to site-wide footer social links
- Community page now shows all 5 active platforms: Discord, X, LinkedIn, Bluesky, GitHub

## Test plan
- [x] Eleventy build succeeds (30 files written)
- [x] Bluesky card renders in community.html Connect section
- [x] Bluesky link renders in footer on all pages
- [x] Full test suite passes (1112/1112)

Generated with [Claude Code](https://claude.com/claude-code)