### PR TITLE
fix: handle already-clean PR status in weekly analytics auto-merge

### DIFF
--- a/.github/workflows/scheduled-weekly-analytics.yml
+++ b/.github/workflows/scheduled-weekly-analytics.yml
@@ -101,7 +101,7 @@ jobs:
             --body "Automated weekly analytics snapshot from Plausible API." \
             --base main \
             --head "$BRANCH"
-          gh pr merge "$BRANCH" --squash --auto
+          gh pr merge "$BRANCH" --squash --auto || gh pr merge "$BRANCH" --squash
 
       - name: Discord notification (failure)
         if: failure()


### PR DESCRIPTION
## Summary
- The weekly analytics workflow fails because `--auto` merge flag errors when the PR is already in "clean" status (all required checks already passed)
- Added fallback to direct squash merge when auto-merge enablement fails

## Changelog
- Fixed weekly analytics CI workflow to handle the race condition where CLA status is set before PR creation, causing the PR to be immediately "clean" and rejecting auto-merge enablement

## Test plan
- [x] Verified the one-line change: `gh pr merge "$BRANCH" --squash --auto || gh pr merge "$BRANCH" --squash`
- [x] All 1112 tests pass
- [ ] Re-run the weekly analytics workflow after merge to confirm fix

Generated with [Claude Code](https://claude.com/claude-code)