### PR TITLE
fix: handle token-auth URLs in github-community.sh

### DIFF
--- a/plugins/soleur/skills/community/scripts/github-community.sh
+++ b/plugins/soleur/skills/community/scripts/github-community.sh
@@ -30,6 +30,12 @@ validate_gh() {
 }
 
 detect_repo() {
+  # Fast path: GITHUB_REPOSITORY is always set in GitHub Actions
+  if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
+    echo "$GITHUB_REPOSITORY"
+    return 0
+  fi
+
   local remote_url
   remote_url=$(git remote get-url origin 2>/dev/null) || {
     echo "Error: No git remote 'origin' found." >&2
@@ -37,8 +43,11 @@ detect_repo() {
   }
 
   # Extract owner/repo from SSH or HTTPS URL
+  # Handles: https://github.com/owner/repo.git
+  #          git@github.com:owner/repo.git
+  #          https://x-access-token:TOKEN@github.com/owner/repo.git
   local repo
-  repo=$(echo "$remote_url" | sed -E 's#(https://github\.com/|git@github\.com:)##' | sed 's/\.git$//')
+  repo=$(echo "$remote_url" | sed -E 's#https?://([^@]+@)?github\.com/##' | sed -E 's#git@github\.com:##' | sed 's/\.git$//')
 
   if [[ -z "$repo" || "$repo" == "$remote_url" ]]; then
     echo "Error: Could not parse GitHub repo from remote URL: ${remote_url}" >&2


### PR DESCRIPTION
## Summary
- `github-community.sh` fails in CI with `unsupported protocol scheme ""` because `detect_repo` can't parse token-authenticated URLs (`https://x-access-token:TOKEN@github.com/...`)
- Added `GITHUB_REPOSITORY` env var fast path (always set in GitHub Actions)
- Broadened the sed regex to handle auth token URLs

Closes #634

## Changelog
- Fixed `github-community.sh` URL parsing for CI environments where `claude-code-action` rewrites the git remote with an auth token

## Test plan
- [x] Verified sed pattern handles all 3 URL formats: plain HTTPS, SSH, token-auth HTTPS
- [x] All 1112 tests pass
- [ ] Next community monitor run should use `github-community.sh` directly without gh CLI fallback

Generated with [Claude Code](https://claude.com/claude-code)