### PR TITLE
fix(ship): add post-merge workflow validation

### DIFF
--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -404,7 +404,37 @@ Poll every 10 seconds until state is `MERGED`.
 
    If the workflow did not fire (e.g., no semver label was set), run `/release-announce` manually as a fallback.
 
-2. Clean up worktree and local branch:
+2. **Post-merge validation of new workflows.** If the PR added new GitHub Actions workflow files (`.github/workflows/*.yml`), validate them by triggering each new workflow via `workflow_dispatch` and polling for completion. This is mandatory — never leave validation as a manual step for the user.
+
+   **Step 1:** Detect new workflow files added in this PR. Use the merge base hash from Phase 3:
+
+   ```bash
+   git diff --name-only --diff-filter=A HASH..HEAD -- .github/workflows/
+   ```
+
+   **Step 2:** For each new workflow file, trigger it:
+
+   ```bash
+   gh workflow run <workflow-filename>
+   ```
+
+   **Step 3:** Poll each triggered run until completion (check every 30 seconds):
+
+   ```bash
+   gh run list --workflow <workflow-filename> --limit 1 --json databaseId,status,conclusion --jq '.[0]'
+   ```
+
+   Poll until `status` is `completed`. Then check `conclusion`:
+   - **success**: Report pass and continue
+   - **failure**: Report failure, fetch logs with `gh run view <id> --log | tail -50`, and present the error to the user. Do NOT silently proceed.
+
+   **Step 4:** Report summary: "Post-merge validation: N/N workflows passed" or "Post-merge validation: X/N workflows failed — [details]"
+
+   **If no new workflow files were added:** Skip this step.
+
+   **Why this matters:** The founder is a solo operator. Every "please run this manually" is a context switch. `gh workflow run` exists — use it. This rule already exists in AGENTS.md ("Exhaust all automated options before suggesting manual steps") but was not enforced in the ship skill until this fix.
+
+3. Clean up worktree and local branch:
 
    Navigate to the repository root directory, then run `bash ./plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh cleanup-merged`.
 


### PR DESCRIPTION
## Summary

- Ship skill now auto-triggers `workflow_dispatch` for new workflow files after merge
- Polls for completion and reports success/failure
- Prevents the anti-pattern of telling the user to manually validate

**Root cause:** Ship skill had no post-merge validation phase. When workflows were added, the agent told the user "run `gh workflow run` to test" instead of doing it automatically — violating the AGENTS.md rule "Exhaust all automated options before suggesting manual steps."

## Changelog

- Add Phase 7 Step 2: post-merge validation of new workflows via `workflow_dispatch`
- Detect new `.github/workflows/*.yml` files from the PR diff
- Trigger each via `gh workflow run`, poll until completion, report results

## Test plan

- [ ] Ship a PR that adds a new workflow file — verify the workflow is triggered automatically
- [ ] Ship a PR with no workflow changes — verify the step is skipped

Generated with [Claude Code](https://claude.com/claude-code)