### PR TITLE
feat: enforce workflow verification after creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ This repository contains the Soleur Claude Code plugin. Detailed conventions liv
 - At session start, from any active worktree (not the bare repo root): run `bash ../../plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh cleanup-merged && git worktree list`. If no worktree exists, run `git worktree list` from the bare root to verify.
 - When an audit identifies pre-existing issues, create GitHub issues to track them before fixing. Don't just note them in conversation -- file them.
 - When creating PRs that resolve a GitHub issue, include `Closes #N` in the PR **body** (not just the title). Parenthetical `(#N)` in titles creates a link but does NOT trigger auto-close.
+- After merging a PR that adds or modifies a GitHub Actions workflow, trigger a manual run (`gh workflow run <file>.yml`), poll until complete (`gh run view <id> --json status,conclusion`), and investigate failures before moving on. New workflows must be verified working, not just syntactically valid.
 
 ## Passive Domain Routing
 

--- a/plugins/soleur/skills/schedule/SKILL.md
+++ b/plugins/soleur/skills/schedule/SKILL.md
@@ -147,8 +147,32 @@ Prerequisites:
   - .claude-plugin/marketplace.json must exist at the repo root
 
 The schedule activates once this file is merged to the default branch.
-To test manually: gh workflow run scheduled-<NAME>.yml
 ```
+
+**Step 5: Verify workflow after merge**
+
+After the PR containing the new workflow is merged to the default branch, trigger a manual run and verify it succeeds:
+
+```bash
+# Trigger the workflow
+gh workflow run scheduled-<NAME>.yml
+
+# Wait for the run to appear (may take a few seconds)
+sleep 5
+RUN_ID=$(gh run list --workflow=scheduled-<NAME>.yml --limit=1 --json databaseId --jq '.[0].databaseId')
+
+# Poll until complete
+gh run watch "$RUN_ID"
+
+# Check conclusion
+CONCLUSION=$(gh run view "$RUN_ID" --json conclusion --jq '.conclusion')
+if [ "$CONCLUSION" != "success" ]; then
+  echo "WORKFLOW FAILED — investigate before moving on"
+  gh run view "$RUN_ID" --log-failed | tail -50
+fi
+```
+
+If the run fails, diagnose the issue, fix the workflow file, and re-run. Do not close the task until the workflow has completed successfully at least once.
 
 ### `list`
 


### PR DESCRIPTION
## Summary
- Adds AGENTS.md Workflow Gate: after merging a PR that adds/modifies a GitHub Actions workflow, trigger a manual run and poll until success before moving on
- Updates the `soleur:schedule` skill with a Step 5 verification procedure (`gh workflow run` + `gh run watch` + failure investigation)
- Motivated by the growth audit workflow (PR #651) being merged without a verification run

## Changelog
- **Added:** Workflow verification gate in AGENTS.md
- **Updated:** Schedule skill with Step 5 post-merge verification

## Test plan
- [ ] AGENTS.md rule is syntactically consistent with existing gates
- [ ] Schedule skill Step 5 bash commands are valid
- [ ] Growth audit workflow (#651) manual run completes successfully (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)