### PR TITLE
fix(worktree): fix bare repo cleanup-merged fetch refspec and trap scoping

### DIFF
--- a/knowledge-base/project/constitution.md
+++ b/knowledge-base/project/constitution.md
@@ -123,7 +123,7 @@ Project principles organized by domain. Add principles as you learn them.
 - All `workflow_dispatch` inputs must be validated against a strict regex before use in shell commands or `$GITHUB_OUTPUT` writes -- inputs are string-typed and accept arbitrary content including newlines; use `exit 1` on validation failure, not just a warning
 - Workflows that perform git operations against specific commits (revert, cherry-pick) must use `fetch-depth: 0` and validate that HEAD matches the expected SHA before acting -- `fetch-depth: 2` creates a race condition when additional commits land between trigger and execution
 - Always use absolute paths or verify CWD is repo root before `git worktree add` -- relative `.worktrees/` paths resolve from CWD, creating nested worktrees when run from inside an existing worktree
-- Run `worktree-manager.sh cleanup-merged` from inside any active worktree, not from the bare repo root -- bare checkouts lack a work tree and git commands fail with `fatal: this operation must be run in a work tree`
+- `worktree-manager.sh cleanup-merged` works from both worktrees and the bare repo root -- the `IS_BARE` guard routes bare repos to `git fetch origin main:main` (updates local ref) + `sync_bare_files` (refreshes stale on-disk files)
 
 ### Never
 

--- a/knowledge-base/project/learnings/2026-03-18-bare-repo-cleanup-stale-script-and-fetch-refspec.md
+++ b/knowledge-base/project/learnings/2026-03-18-bare-repo-cleanup-stale-script-and-fetch-refspec.md
@@ -1,0 +1,29 @@
+# Learning: bare repo cleanup runs stale on-disk scripts and fetch needs refspec
+
+## Problem
+
+After merging a PR via `cleanup-merged`, the warning "Main checkout has uncommitted changes to tracked files -- skipping pull" appeared even though there are no uncommitted changes in a bare repo. Main was not updated, so subsequent worktrees branched from stale commits.
+
+Two root causes:
+
+1. **Stale on-disk script:** Bare repos have no working tree, so files on disk (including `worktree-manager.sh` itself) never update after merges. The script running was an old version that lacked the `IS_BARE` guard added in a recent PR. It fell through to `git -C "$GIT_ROOT" diff --quiet HEAD` which returns exit code 128 ("must be run in a work tree"), which the `!` inversion treated as "has changes."
+
+2. **Fetch without refspec:** Even in the fixed version, `git fetch origin main` only updates `FETCH_HEAD` and `origin/main` -- it does NOT advance the local `main` ref. New worktrees created with `git worktree add ... main` branch from the **local** main, which stays stale.
+
+3. **Trap scoping bug:** `sync_bare_files` set `trap 'rm -rf "$tmpdir"' EXIT` with single quotes, deferring `$tmpdir` expansion. Since `tmpdir` is a `local` variable, it's out of scope when the trap fires at script exit, causing `set -u` to crash with "unbound variable."
+
+## Solution
+
+1. **fetch refspec:** Changed `git fetch origin main` to `git fetch origin main:main` so the local ref advances.
+2. **trap early-expansion:** Changed single quotes to double quotes (`trap "rm -rf '$tmpdir'" EXIT`) so `$tmpdir` is expanded at set-time, not fire-time. Added shellcheck disable comment explaining the intentional early expansion.
+3. **Manual sync:** Ran `git show HEAD:<file> > <file>` to bootstrap the bare repo's on-disk files to the current version.
+
+## Key Insight
+
+Bare repos are a chicken-and-egg problem: the script that syncs files is itself one of the files that needs syncing. Any fix to the sync mechanism only takes effect after a manual bootstrap. The `sync_bare_files` function exists for this purpose but must be bootstrapped once when first deployed.
+
+Also: `git fetch origin <branch>` and `git fetch origin <branch>:<branch>` are fundamentally different. The former updates tracking refs only; the latter advances the local ref. In bare repos where `git pull` is unavailable, the refspec form is essential.
+
+## Tags
+category: shell-scripts
+module: worktree-manager

--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -540,9 +540,14 @@ cleanup_merged_worktrees() {
     # After cleanup, update main checkout so next worktree branches from latest
     # Skip entirely for bare repos -- there is no working tree to update
     if [[ "$IS_BARE" == "true" ]]; then
-      # Bare repos have no working tree -- use git fetch to update the main ref
-      if git fetch origin main 2>/dev/null; then
-        echo -e "${GREEN}Fetched latest main${NC}"
+      # Bare repos have no working tree -- use fetch with refspec to update the
+      # local main ref directly (plain "fetch origin main" only updates FETCH_HEAD
+      # and origin/main, leaving local main stale for new worktree creation)
+      if git fetch origin main:main 2>/dev/null; then
+        echo -e "${GREEN}Updated main to latest${NC}"
+      elif git fetch origin main 2>/dev/null; then
+        # Fallback: non-fast-forward (e.g., force-push) -- at least update origin/main
+        echo -e "${YELLOW}Warning: Could not fast-forward local main -- fetched origin/main only${NC}"
       fi
       # Auto-sync stale on-disk files so the next session reads current versions
       sync_bare_files
@@ -634,7 +639,8 @@ sync_bare_files() {
   # Create a temp directory on the same filesystem for atomic writes
   local tmpdir
   tmpdir=$(mktemp -d "${GIT_ROOT}/.sync-tmp.XXXXXX")
-  trap 'rm -rf "$tmpdir"' EXIT
+  # shellcheck disable=SC2064  # Intentional: expand tmpdir NOW so the trap works after local scope ends
+  trap "rm -rf '$tmpdir'" EXIT
 
   # Files that Claude Code reads from the bare repo root
   local files=(


### PR DESCRIPTION
## Summary
- `git fetch origin main` in bare repos only updated tracking refs, not the local `main` ref — new worktrees branched from stale commits. Fixed with `git fetch origin main:main`
- `sync_bare_files` trap crashed with "unbound variable" because `$tmpdir` was a local var expanded after function scope ended. Fixed with early expansion

Closes #699

## Changelog
- Fixed: `cleanup-merged` now correctly advances local `main` ref in bare repos via fetch refspec
- Fixed: `sync_bare_files` trap no longer crashes from unbound local variable

## Test plan
- [x] 920 component tests pass
- [x] Manual verification: `git fetch origin main:main` updates local ref in bare repo
- [x] Manual verification: trap expansion doesn't crash under `set -u`

🤖 Generated with [Claude Code](https://claude.com/claude-code)