### PR TITLE
fix(worktree): make create/feature commands work from bare repo root

### DIFF
--- a/knowledge-base/learnings/2026-03-18-worktree-create-feature-bare-root.md
+++ b/knowledge-base/learnings/2026-03-18-worktree-create-feature-bare-root.md
@@ -1,0 +1,21 @@
+# Learning: worktree create/feature commands fail from bare repo root
+
+## Problem
+
+The `create` and `feature` commands in `worktree-manager.sh` fail with `fatal: this operation must be run in a work tree` when run from a bare repo root. Both functions call `require_working_tree()` as an early guard, then use `git checkout $from_branch && git pull origin $from_branch` — all working-tree operations unavailable at the bare root.
+
+## Solution
+
+Extracted `update_branch_ref()` helper that branches on context:
+- **Bare repo root** (`IS_BARE=true && IS_IN_WORKTREE!=true`): uses `git fetch origin main:main` (refspec form, same pattern as `cleanup_merged_worktrees`)
+- **Non-bare or inside worktree**: retains `git checkout && git pull`
+
+Removed `require_working_tree` from `create_worktree()` and `create_for_feature()` since `git worktree add` works fine from bare roots. Kept it in `create_draft_pr()` which genuinely needs a working tree.
+
+## Key Insight
+
+`git worktree add` itself works from bare repos — only the pre-creation branch update was broken. Functions that update a branch ref should detect bare-vs-non-bare and use the appropriate primitive: `git fetch origin ref:ref` (plumbing, no working tree needed) vs `git checkout && git pull` (porcelain, requires working tree). The fix pattern already existed in the same file's `cleanup_merged_worktrees`.
+
+## Tags
+category: runtime-errors
+module: plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh

--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -73,6 +73,25 @@ ensure_gitignore() {
   fi
 }
 
+# Update a branch ref to latest remote, handling bare vs non-bare repos.
+# In bare repos: uses fetch with refspec (no working tree needed).
+# In non-bare repos: uses checkout + pull.
+update_branch_ref() {
+  local branch="$1"
+  echo -e "${BLUE}Updating $branch...${NC}"
+  if [[ "$IS_BARE" == "true" && "$IS_IN_WORKTREE" != "true" ]]; then
+    # Bare repo root: no working tree, so use fetch with refspec
+    if git fetch origin "$branch:$branch" 2>/dev/null; then
+      echo -e "${GREEN}Updated $branch to latest (via fetch)${NC}"
+    elif git fetch origin "$branch" 2>/dev/null; then
+      echo -e "${YELLOW}Warning: Could not fast-forward local $branch -- using origin/$branch${NC}"
+    fi
+  else
+    git checkout "$branch"
+    git pull origin "$branch" || true
+  fi
+}
+
 # Copy .env files from main repo to worktree
 copy_env_files() {
   local worktree_path="$1"
@@ -147,8 +166,6 @@ create_worktree() {
   local branch_name="$1"
   local from_branch="${2:-main}"
 
-  require_working_tree
-
   if [[ -z "$branch_name" ]]; then
     echo -e "${RED}Error: Branch name required${NC}"
     exit 1
@@ -189,10 +206,8 @@ create_worktree() {
     return
   fi
 
-  # Update main branch
-  echo -e "${BLUE}Updating $from_branch...${NC}"
-  git checkout "$from_branch"
-  git pull origin "$from_branch" || true
+  # Update base branch (bare-aware)
+  update_branch_ref "$from_branch"
 
   # Create worktree
   mkdir -p "$WORKTREE_DIR"
@@ -220,8 +235,6 @@ create_for_feature() {
   local name="$1"
   local from_branch="${2:-main}"
 
-  require_working_tree
-
   if [[ -z "$name" ]]; then
     echo -e "${RED}Error: Feature name required${NC}"
     echo "Usage: worktree-manager.sh feature <name> [from-branch]"
@@ -245,10 +258,8 @@ create_for_feature() {
   echo "  Spec dir: $spec_dir"
   echo ""
 
-  # Update base branch before creating worktree
-  echo -e "${BLUE}Updating $from_branch...${NC}"
-  git checkout "$from_branch"
-  git pull origin "$from_branch" || true
+  # Update base branch (bare-aware)
+  update_branch_ref "$from_branch"
 
   # Ensure directories exist
   mkdir -p "$WORKTREE_DIR"


### PR DESCRIPTION
## Summary

- Extracted `update_branch_ref()` helper that uses `git fetch origin ref:ref` for bare repos (no working tree needed) and `git checkout && git pull` for non-bare repos
- Removed `require_working_tree` guard from `create_worktree()` and `create_for_feature()` since `git worktree add` works from bare roots
- Kept `require_working_tree` in `create_draft_pr()` where it's genuinely needed

Closes the gap where `worktree-manager.sh feature <name>` fails with `fatal: this operation must be run in a work tree` when invoked from the bare repo root.

## Changelog

- **fix:** `worktree-manager.sh create` and `feature` commands now work from bare repo roots by using `git fetch origin ref:ref` instead of `git checkout && git pull`

## Test plan

- [ ] Run `worktree-manager.sh feature test-bare` from the bare repo root — should succeed
- [ ] Run `worktree-manager.sh feature test-wt` from inside a worktree — should still work (checkout/pull path)
- [ ] Verify `worktree-manager.sh draft-pr` still requires a working tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)