### PR TITLE
fix: use proxy headers for callback redirect origin

### DIFF
--- a/apps/web-platform/app/(auth)/callback/route.ts
+++ b/apps/web-platform/app/(auth)/callback/route.ts
@@ -3,8 +3,12 @@ import { provisionWorkspace } from "@/server/workspace";
 import { NextResponse } from "next/server";
 
 export async function GET(request: Request) {
-  const { searchParams, origin } = new URL(request.url);
+  const { searchParams } = new URL(request.url);
   const code = searchParams.get("code");
+  const forwardedHost = request.headers.get("x-forwarded-host");
+  const forwardedProto = request.headers.get("x-forwarded-proto") ?? "https";
+  const host = forwardedHost ?? request.headers.get("host") ?? "app.soleur.ai";
+  const origin = `${forwardedProto}://${host}`;
 
   if (code) {
     const supabase = await createClient();


### PR DESCRIPTION
## Summary
- Fix auth callback redirecting to `localhost:3000` instead of `app.soleur.ai`
- Behind Cloudflare/Docker reverse proxy, `new URL(request.url).origin` gives the internal container origin (`http://localhost:3000`)
- Now uses `x-forwarded-host` and `x-forwarded-proto` headers to construct the correct public origin

Closes #678

## Changelog
- Auth callback redirects (dashboard, setup-key, login error) now use the public origin from proxy headers instead of the internal container origin

## Test plan
- [ ] Sign up at app.soleur.ai, click magic link, verify redirect goes to app.soleur.ai (not localhost)
- [ ] Login flow same behavior
- [ ] Local dev (localhost:3000) still works (no x-forwarded-host header = falls back to Host header)

Generated with [Claude Code](https://claude.com/claude-code)