### PR TITLE
fix: move Docker build-args from caller input to reusable workflow secrets

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -27,10 +27,6 @@ on:
         description: "Docker build context path (e.g., apps/web-platform)"
         type: string
         default: ""
-      docker_build_args:
-        description: "Docker build args, newline-delimited"
-        type: string
-        default: ""
       bump_type:
         description: "Override bump type (empty = use PR labels)"
         type: string
@@ -285,7 +281,9 @@ jobs:
             ${{ inputs.docker_image }}:v${{ steps.version.outputs.next }}
             ${{ inputs.docker_image }}:${{ github.sha }}
             ${{ inputs.docker_image }}:latest
-          build-args: ${{ inputs.docker_build_args }}
+          build-args: |
+            NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+            NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
 
       - name: Post to Discord
         if: steps.create_release.outputs.released == 'true'

--- a/.github/workflows/web-platform-release.yml
+++ b/.github/workflows/web-platform-release.yml
@@ -29,9 +29,6 @@ jobs:
       tag_prefix: "web-v"
       docker_image: "ghcr.io/jikig-ai/soleur-web-platform"
       docker_context: "apps/web-platform"
-      docker_build_args: |
-        NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-        NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
       bump_type: ${{ inputs.bump_type || '' }}
       force_run: ${{ github.event_name == 'workflow_dispatch' }}
     secrets: inherit


### PR DESCRIPTION
## Summary

- Remove `docker_build_args` input from `reusable-release.yml` — GitHub Actions does not allow `secrets.*` references in `workflow_call` `with:` inputs
- Move build args directly into the reusable workflow's Docker build step, accessed via `secrets: inherit`
- Empty secrets are harmless for apps that don't need them (telegram-bridge)

## Changelog

- **Fixed:** Release workflow parse error caused by `secrets.*` in `with:` block — build args now read from inherited secrets directly

## Test plan

- [ ] `workflow_dispatch` for web-platform-release.yml succeeds (previously errored with HTTP 422)
- [ ] telegram-bridge-release.yml still works (empty build args are harmless)

Generated with [Claude Code](https://claude.com/claude-code)