### PR TITLE
fix: move permissions to job level in reusable release workflow

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -50,13 +50,12 @@ concurrency:
   group: release-${{ inputs.component }}
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  packages: write
-
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     outputs:
       version: ${{ steps.version.outputs.next }}
       tag: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/telegram-bridge-release.yml
+++ b/.github/workflows/telegram-bridge-release.yml
@@ -14,6 +14,10 @@ on:
           - minor
           - major
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   release:
     uses: ./.github/workflows/reusable-release.yml

--- a/.github/workflows/web-platform-release.yml
+++ b/.github/workflows/web-platform-release.yml
@@ -19,6 +19,10 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   release:
     uses: ./.github/workflows/reusable-release.yml


### PR DESCRIPTION
## Summary

- Move `permissions` from workflow level to job level in `reusable-release.yml` — workflow-level permissions in reusable workflows cause `startup_failure`
- Add explicit `permissions: contents: write, packages: write` to both caller workflows

## Changelog

- **Fixed:** Release workflows failing with `startup_failure` due to workflow-level permissions block in reusable workflow

## Test plan

- [ ] `workflow_dispatch` for web-platform-release.yml succeeds
- [ ] `workflow_dispatch` for telegram-bridge-release.yml succeeds

Generated with [Claude Code](https://claude.com/claude-code)