### PR TITLE
fix(telegram-bridge): fix Dockerfile npm and use shared deploy secrets

### DIFF
--- a/.github/workflows/telegram-bridge-release.yml
+++ b/.github/workflows/telegram-bridge-release.yml
@@ -40,9 +40,9 @@ jobs:
       - name: Deploy to server
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
-          host: ${{ secrets.TELEGRAM_BRIDGE_HOST }}
+          host: ${{ secrets.WEB_PLATFORM_HOST }}
           username: root
-          key: ${{ secrets.TELEGRAM_BRIDGE_SSH_KEY }}
+          key: ${{ secrets.WEB_PLATFORM_SSH_KEY }}
           script: |
             IMAGE="ghcr.io/jikig-ai/soleur-telegram-bridge"
             TAG="v${{ needs.release.outputs.version }}"

--- a/apps/telegram-bridge/Dockerfile
+++ b/apps/telegram-bridge/Dockerfile
@@ -1,8 +1,8 @@
 FROM oven/bun:latest
 
-# Install system dependencies
+# Install system dependencies (nodejs/npm needed for claude-code CLI)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git curl openssh-client && \
+    apt-get install -y --no-install-recommends git curl openssh-client nodejs npm && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Claude Code CLI via npm (avoids curl-pipe-shell antipattern)


### PR DESCRIPTION
## Summary

- Install `nodejs` and `npm` in telegram-bridge Dockerfile — `oven/bun:latest` doesn't include npm, causing `npm install -g @anthropic-ai/claude-code` to fail with exit code 127
- Use `WEB_PLATFORM_HOST` / `WEB_PLATFORM_SSH_KEY` for deploy since telegram-bridge is co-located on the same server

Closes #751

## Changelog

- **Fixed:** Telegram bridge Docker build failing in CI (npm not found)
- **Changed:** Telegram bridge deploys to same server as web-platform (shared secrets)

## Test plan

- [ ] `workflow_dispatch` for telegram-bridge-release.yml builds Docker image successfully
- [ ] Release `telegram-v0.1.1` created on GitHub

Generated with [Claude Code](https://claude.com/claude-code)