### PR TITLE
fix(telegram-bridge): inject env vars from secrets before deploy

### DIFF
--- a/.github/workflows/telegram-bridge-release.yml
+++ b/.github/workflows/telegram-bridge-release.yml
@@ -37,6 +37,22 @@ jobs:
     if: needs.release.outputs.released == 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: Ensure telegram env vars on server
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.WEB_PLATFORM_HOST }}
+          username: root
+          key: ${{ secrets.WEB_PLATFORM_SSH_KEY }}
+          envs: TELEGRAM_BOT_TOKEN,TELEGRAM_ALLOWED_USER_ID
+          script: |
+            ENV_FILE="/mnt/data/.env"
+            grep -q "^TELEGRAM_BOT_TOKEN=" "$ENV_FILE" || echo "TELEGRAM_BOT_TOKEN=$TELEGRAM_BOT_TOKEN" >> "$ENV_FILE"
+            grep -q "^TELEGRAM_ALLOWED_USER_ID=" "$ENV_FILE" || echo "TELEGRAM_ALLOWED_USER_ID=$TELEGRAM_ALLOWED_USER_ID" >> "$ENV_FILE"
+            grep -q "^SOLEUR_PLUGIN_DIR=" "$ENV_FILE" || echo "SOLEUR_PLUGIN_DIR=/app/shared/plugins/soleur" >> "$ENV_FILE"
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_ALLOWED_USER_ID: ${{ secrets.TELEGRAM_ALLOWED_USER_ID }}
+
       - name: Deploy to server
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
@@ -54,6 +70,7 @@ jobs:
               --restart unless-stopped \
               --env-file /mnt/data/.env \
               -v /mnt/data:/home/soleur/data \
+              -v /mnt/data/plugins/soleur:/app/shared/plugins/soleur:ro \
               -p 127.0.0.1:8080:8080 \
               "$IMAGE:$TAG"
             echo "Waiting for health check..."


### PR DESCRIPTION
## Summary

- Add pre-deploy step that injects `TELEGRAM_BOT_TOKEN`, `TELEGRAM_ALLOWED_USER_ID`, and `SOLEUR_PLUGIN_DIR` into server's `/mnt/data/.env` from GitHub secrets
- Uses `appleboy/ssh-action`'s `envs` parameter to pass secrets to the SSH session
- Idempotent: only appends vars if they're missing (uses `grep -q` guard)
- Also mounts shared plugins volume for claude-code CLI access

## Changelog

- **Fixed:** Telegram bridge deploy failing because env vars were missing from the co-located server's `.env` file

## Test plan

- [ ] `workflow_dispatch` for telegram-bridge-release.yml deploys successfully with health check passing

Generated with [Claude Code](https://claude.com/claude-code)