### PR TITLE
fix(telegram-bridge): increase deploy health check timeout for CLI spawn

### DIFF
--- a/.github/workflows/telegram-bridge-release.yml
+++ b/.github/workflows/telegram-bridge-release.yml
@@ -73,13 +73,13 @@ jobs:
               -v /mnt/data/plugins/soleur:/app/shared/plugins/soleur:ro \
               -p 127.0.0.1:8080:8080 \
               "$IMAGE:$TAG"
-            echo "Waiting for health check..."
-            for i in $(seq 1 10); do
+            echo "Waiting for health check (CLI spawn takes ~60s)..."
+            for i in $(seq 1 20); do
               if curl -sf http://localhost:8080/health; then
                 echo " OK"
                 exit 0
               fi
-              sleep 3
+              sleep 5
             done
             echo "Health check failed"
             docker logs soleur-bridge --tail 30


### PR DESCRIPTION
## Summary

Claude CLI subprocess takes ~60s to initialize. Previous health check timeout of 30s (10 retries * 3s) was insufficient, causing deploys to report failure even though the bot starts correctly.

Increase to 100s (20 retries * 5s).

## Changelog

- **Fixed:** Telegram bridge deploy health check timing out before CLI finishes spawning

## Test plan

- [ ] `workflow_dispatch` for telegram-bridge-release.yml completes with health check passing

Generated with [Claude Code](https://claude.com/claude-code)