### PR TITLE
fix(ci): filter plugin release tags in version-bump workflow

### DIFF
--- a/.github/workflows/version-bump-and-release.yml
+++ b/.github/workflows/version-bump-and-release.yml
@@ -153,17 +153,22 @@ jobs:
           CURRENT_TAG_FILE: ${{ steps.tmpfiles.outputs.current_tag }}
           GH_ERR_FILE: ${{ steps.tmpfiles.outputs.gh_err }}
         run: |
-          # Separate "no releases yet" from "API error"
-          if ! gh release view --json tagName --jq '.tagName' > "$CURRENT_TAG_FILE" 2>"$GH_ERR_FILE"; then
-            if grep -q "release not found" "$GH_ERR_FILE"; then
-              CURRENT="0.0.0"
-              echo "No existing releases, starting from 0.0.0"
-            else
-              echo "::error::gh release view failed: $(cat "$GH_ERR_FILE")"
+          # Find the latest plugin release (v* tags only, not web-v* or telegram-v*)
+          # gh release list returns all releases; filter for plugin's vX.Y.Z pattern
+          LATEST_TAG=$(gh release list --limit 100 --json tagName --jq '
+            [.[] | select(.tagName | test("^v[0-9]"))][0].tagName // empty
+          ' 2>"$GH_ERR_FILE")
+
+          if [ -z "$LATEST_TAG" ]; then
+            if [ -s "$GH_ERR_FILE" ] && ! grep -q "release not found" "$GH_ERR_FILE"; then
+              echo "::error::gh release list failed: $(cat "$GH_ERR_FILE")"
               exit 1
             fi
+            CURRENT="0.0.0"
+            echo "No plugin releases found (v* tags), starting from 0.0.0"
           else
-            CURRENT=$(sed 's/^v//' "$CURRENT_TAG_FILE")
+            CURRENT=$(echo "$LATEST_TAG" | sed 's/^v//')
+            echo "Latest plugin release: $LATEST_TAG"
           fi
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
 

--- a/knowledge-base/learnings/2026-03-19-gh-release-view-multi-component-collision.md
+++ b/knowledge-base/learnings/2026-03-19-gh-release-view-multi-component-collision.md
@@ -1,0 +1,43 @@
+# Learning: `gh release view` returns wrong tag in multi-component repos
+
+## Problem
+
+The "Version Bump and Release" workflow failed on every push to main with:
+
+```
+Invalid version components: MAJOR=web-v0 MINOR=1 PATCH=2 (from web-v0.1.2)
+```
+
+Four consecutive CI runs failed after component-specific release workflows (`web-v*`, `telegram-v*`) were introduced.
+
+## Root Cause
+
+`gh release view` without arguments returns the **latest release across all tag prefixes**. The plugin release workflow assumed it would only ever see `v*` tags, but once `web-v0.1.2` became the latest release, `sed 's/^v//'` stripped nothing (no leading `v`), leaving `web-v0.1.2` which failed numeric validation.
+
+## Solution
+
+Replace `gh release view` with `gh release list` + jq filter that selects only `v[0-9]*` tags:
+
+```bash
+LATEST_TAG=$(gh release list --limit 100 --json tagName --jq '
+  [.[] | select(.tagName | test("^v[0-9]"))][0].tagName // empty
+')
+```
+
+Falls back to `0.0.0` when no matching release exists (current state).
+
+## Key Insight
+
+When a monorepo uses multiple release tag prefixes (`v*`, `web-v*`, `telegram-v*`), any workflow using `gh release view` (unqualified) will break as soon as a non-matching prefix becomes the latest release. Always filter by tag pattern when looking up component-specific versions.
+
+## Session Errors
+
+1. Edited workflow file in bare repo path before creating worktree (worktree-write-guard should block this but bare repo has no working tree so git checkout to revert also failed)
+2. Attempted `git checkout` in bare repo — failed with "fatal: this operation must be run in a work tree"
+
+## Tags
+category: build-errors
+module: ci-release
+tags: [github-actions, versioning, gh-cli, multi-component-releases, monorepo]
+severity: high
+first_seen: 2026-03-19


### PR DESCRIPTION
## Summary
- `gh release view` (unqualified) returns the latest release across all tag prefixes
- Once `web-v*` and `telegram-v*` releases existed, it returned `web-v0.1.2` instead of a `v*` plugin tag
- Version parsing failed: `MAJOR=web-v0` is not numeric — 4 consecutive CI failures
- Replace with `gh release list` + jq filter for `^v[0-9]` tags only

## Changelog
- Fix version-bump-and-release workflow to filter for plugin `v*` tags only, ignoring `web-v*` and `telegram-v*` component releases

## Test plan
- [ ] Merge triggers version-bump-and-release workflow
- [ ] Workflow correctly starts from `0.0.0` (no `v*` releases exist yet)
- [ ] Creates `v0.0.1` release successfully
- [ ] Future `web-v*` / `telegram-v*` releases don't interfere

🤖 Generated with [Claude Code](https://claude.com/claude-code)