### PR TITLE
security: add SSH keepalive directives and migrate telegram-bridge hardening

### DIFF
--- a/apps/telegram-bridge/infra/cloud-init.yml
+++ b/apps/telegram-bridge/infra/cloud-init.yml
@@ -4,7 +4,24 @@ packages:
   - curl
   - jq
 
+write_files:
+  - path: /etc/ssh/sshd_config.d/01-hardening.conf
+    content: |
+      PasswordAuthentication no
+      KbdInteractiveAuthentication no
+      MaxAuthTries 3
+      LoginGraceTime 30
+      PermitRootLogin prohibit-password
+      AllowUsers root
+      ClientAliveInterval 300
+      ClientAliveCountMax 2
+    owner: root:root
+    permissions: '0644'
+
 runcmd:
+  # Apply SSH hardening immediately (drop-in written by write_files above)
+  - systemctl restart sshd
+
   # Install Docker
   - curl -fsSL https://get.docker.com | sh
 
@@ -39,8 +56,3 @@ runcmd:
       -v /mnt/data:/home/soleur/data \
       -p 127.0.0.1:8080:8080 \
       ${image_name}
-
-  # SSH hardening
-  - sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
-  - sed -i 's/PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
-  - systemctl restart sshd

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -13,6 +13,8 @@ write_files:
       LoginGraceTime 30
       PermitRootLogin prohibit-password
       AllowUsers root
+      ClientAliveInterval 300
+      ClientAliveCountMax 2
     owner: root:root
     permissions: '0644'
 

--- a/knowledge-base/plans/2026-03-19-security-add-ssh-keepalive-directives-plan.md
+++ b/knowledge-base/plans/2026-03-19-security-add-ssh-keepalive-directives-plan.md
@@ -122,11 +122,11 @@ These sessions complete in seconds and never hit the 10-minute idle timeout. The
 
 ## Acceptance Criteria
 
-- [ ] `apps/web-platform/infra/cloud-init.yml` `01-hardening.conf` includes `ClientAliveInterval 300` and `ClientAliveCountMax 2`
-- [ ] `apps/telegram-bridge/infra/cloud-init.yml` migrated from `sed` to `write_files` with `01-hardening.conf` matching web-platform
-- [ ] `apps/telegram-bridge/infra/cloud-init.yml` `01-hardening.conf` includes `ClientAliveInterval 300` and `ClientAliveCountMax 2`
-- [ ] Telegram-bridge `runcmd` sed commands removed and replaced with `systemctl restart sshd` as first entry
-- [ ] Both cloud-init files produce identical SSH hardening configuration
+- [x] `apps/web-platform/infra/cloud-init.yml` `01-hardening.conf` includes `ClientAliveInterval 300` and `ClientAliveCountMax 2`
+- [x] `apps/telegram-bridge/infra/cloud-init.yml` migrated from `sed` to `write_files` with `01-hardening.conf` matching web-platform
+- [x] `apps/telegram-bridge/infra/cloud-init.yml` `01-hardening.conf` includes `ClientAliveInterval 300` and `ClientAliveCountMax 2`
+- [x] Telegram-bridge `runcmd` sed commands removed and replaced with `systemctl restart sshd` as first entry
+- [x] Both cloud-init files produce identical SSH hardening configuration
 
 ## Test Scenarios
 

--- a/knowledge-base/specs/feat-ssh-keepalive/session-state.md
+++ b/knowledge-base/specs/feat-ssh-keepalive/session-state.md
@@ -1,0 +1,23 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-ssh-keepalive/knowledge-base/plans/2026-03-19-security-add-ssh-keepalive-directives-plan.md
+- Status: complete
+
+### Errors
+None
+
+### Decisions
+- MINIMAL template chosen -- two-line config addition plus telegram-bridge migration to write_files pattern
+- Telegram-bridge migration bundled into scope -- migrating from fragile sed pattern to write_files + 01-hardening.conf for parity with web-platform
+- AllowUsers root confirmed safe for telegram-bridge -- verified via CI workflow using appleboy/ssh-action with username: root
+- ClientAliveCountMax 0 gotcha documented -- setting to 0 disables termination entirely (counterintuitive)
+- External research skipped for irrelevant skills/agents -- focused on Context7 cloud-init docs, OpenSSH man pages, and SSH hardening guides
+
+### Components Invoked
+- soleur:plan (Skill tool)
+- soleur:deepen-plan (Skill tool)
+- mcp__plugin_soleur_context7__resolve-library-id (cloud-init library lookup)
+- mcp__plugin_soleur_context7__query-docs (cloud-init write_files/runcmd ordering)
+- WebSearch (SSH keepalive best practices, TCPKeepAlive interaction)
+- Local research: Grep, Glob, Read across cloud-init files, Terraform configs, CI workflows, and knowledge-base learnings

--- a/knowledge-base/specs/feat-ssh-keepalive/tasks.md
+++ b/knowledge-base/specs/feat-ssh-keepalive/tasks.md
@@ -2,16 +2,16 @@
 
 ## Phase 1: Web-Platform Update
 
-- [ ] 1.1 Add `ClientAliveInterval 300` and `ClientAliveCountMax 2` to `apps/web-platform/infra/cloud-init.yml` `write_files` block for `01-hardening.conf`
+- [x] 1.1 Add `ClientAliveInterval 300` and `ClientAliveCountMax 2` to `apps/web-platform/infra/cloud-init.yml` `write_files` block for `01-hardening.conf`
 
 ## Phase 2: Telegram-Bridge Migration and Update
 
-- [ ] 2.1 Add `write_files` section to `apps/telegram-bridge/infra/cloud-init.yml` with `01-hardening.conf` containing all hardening directives (matching web-platform) plus keepalive directives
-- [ ] 2.2 Remove `sed` commands from telegram-bridge `runcmd` section (lines 43-46)
-- [ ] 2.3 Add `systemctl restart sshd` as first `runcmd` entry in telegram-bridge cloud-init
+- [x] 2.1 Add `write_files` section to `apps/telegram-bridge/infra/cloud-init.yml` with `01-hardening.conf` containing all hardening directives (matching web-platform) plus keepalive directives
+- [x] 2.2 Remove `sed` commands from telegram-bridge `runcmd` section (lines 43-46)
+- [x] 2.3 Add `systemctl restart sshd` as first `runcmd` entry in telegram-bridge cloud-init
 
 ## Phase 3: Verification
 
-- [ ] 3.1 Verify both cloud-init files produce identical `01-hardening.conf` content
-- [ ] 3.2 Verify telegram-bridge `runcmd` no longer contains `sed` commands for sshd_config
-- [ ] 3.3 Verify `systemctl restart sshd` ordering is consistent between both files
+- [x] 3.1 Verify both cloud-init files produce identical `01-hardening.conf` content
+- [x] 3.2 Verify telegram-bridge `runcmd` no longer contains `sed` commands for sshd_config
+- [x] 3.3 Verify `systemctl restart sshd` ordering is consistent between both files


### PR DESCRIPTION
## Summary

- Add `ClientAliveInterval 300` and `ClientAliveCountMax 2` to SSH hardening config on both web-platform and telegram-bridge servers
- Migrate telegram-bridge from fragile `sed`-based SSH hardening to `write_files` + `01-hardening.conf` drop-in pattern (matching web-platform)
- Telegram-bridge gains 5 previously missing hardening directives: `KbdInteractiveAuthentication no`, `MaxAuthTries 3`, `LoginGraceTime 30`, `PermitRootLogin prohibit-password`, `AllowUsers root`

Closes #778

## Changelog

- **web-platform**: Added `ClientAliveInterval 300` and `ClientAliveCountMax 2` to existing `01-hardening.conf` drop-in
- **telegram-bridge**: Replaced `sed`-based SSH hardening with declarative `write_files` drop-in, added keepalive directives, moved `systemctl restart sshd` to first `runcmd` entry (minimizes unhardened window)
- Both servers now produce identical SSH hardening configuration

## Test plan

- [ ] CI infra-validation workflow passes (cloud-init schema validation on both files)
- [ ] Verify both cloud-init files produce identical `01-hardening.conf` content
- [ ] On next server provision, verify `sshd -T` shows `clientaliveinterval 300` and `clientalivecountmax 2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)