### PR TITLE
feat(content): backfill Bluesky and LinkedIn Company Page for existing articles

### DIFF
--- a/knowledge-base/marketing/distribution-content/01-legal-document-generation.md
+++ b/knowledge-base/marketing/distribution-content/01-legal-document-generation.md
@@ -1,9 +1,9 @@
 ---
 title: "How We Generated 9 Legal Documents in Days, Not Months"
 type: case-study
-publish_date: 2026-03-12
-channels: discord, x
-status: published
+publish_date: 2026-03-19
+channels: bluesky, linkedin-company
+status: scheduled
 ---
 
 ## Discord
@@ -109,3 +109,23 @@ Anyone else found cost-effective approaches to legal compliance as a solo founde
 
 **Title:** How We Generated 9 Legal Documents in Days, Not Months
 **URL:** https://soleur.ai/blog/case-study-legal-document-generation/
+
+---
+
+## Bluesky
+
+9 legal documents. 17,761 words. Dual-jurisdiction. Two AI agents caught governing law set to Delaware and fixed it across all docs. https://soleur.ai/blog/case-study-legal-document-generation/?utm_source=bluesky&utm_medium=social&utm_campaign=case-study-legal
+
+---
+
+## LinkedIn Company Page
+
+Soleur's legal agents generated a complete compliance suite in days — 9 documents covering Terms & Conditions, Privacy Policy, GDPR Policy, Cookie Policy, Acceptable Use Policy, Data Protection Disclosure, Disclaimer, and two Contributor License Agreements.
+
+The system uses two specialized agents: a legal-document-generator that drafts from company context, and a legal-compliance-auditor that benchmarks against GDPR Articles 13/14, CCPA, ICO cookie guidance, and CNIL recommendations. The auditor caught governing law incorrectly set to Delaware (inherited from US templates) and corrected it to French law across all 9 documents.
+
+Result: 17,761 words of structured, cross-referenced legal documentation with dual-jurisdiction coverage. A technology lawyer prices this scope at EUR 9,000-25,000.
+
+The compound effect: the legal-compliance-auditor is now a reusable capability that auto-joins brainstorm sessions when legal implications are detected.
+
+Full case study: https://soleur.ai/blog/case-study-legal-document-generation/?utm_source=linkedin-company&utm_medium=social&utm_campaign=case-study-legal-document-generation

--- a/knowledge-base/marketing/distribution-content/02-operations-management.md
+++ b/knowledge-base/marketing/distribution-content/02-operations-management.md
@@ -1,9 +1,9 @@
 ---
 title: "Building an Operations Department for a One-Person Company"
 type: case-study
-publish_date: 2026-03-17
-channels: discord, x
-status: published
+publish_date: 2026-03-19
+channels: bluesky, linkedin-company
+status: scheduled
 ---
 
 ## Discord
@@ -64,3 +64,21 @@ Not scheduled for Reddit distribution. Use Discord + X only.
 ## Hacker News
 
 Not scheduled for Hacker News distribution. Use Discord + X only.
+
+---
+
+## Bluesky
+
+Solo founders lose ops state after two weeks away. We built an AI ops department: expense tracking, DNS inventory, hosting eval. The analytics choice simplified three legal docs. https://soleur.ai/blog/case-study-operations-management/?utm_source=bluesky&utm_medium=social&utm_campaign=ops
+
+---
+
+## LinkedIn Company Page
+
+Soleur now includes a complete operations department powered by AI agents — a COO domain leader, ops advisor, ops researcher, and ops provisioner.
+
+What the system produces: structured expense tracking with provider details and renewal dates, domain and DNS inventory with record-level documentation, hosting evaluation (Hetzner CX22 at EUR 5.83/mo — researched and compared, not just picked), and analytics selection (Plausible — cookie-free, which simplified three legal documents by eliminating tracking cookie disclosures).
+
+The compound effect: the analytics decision cascaded into the Cookie Policy, GDPR Policy, and Privacy Policy. The expense tracker informed the business model evaluation. The COO auto-joins brainstorm sessions when operational decisions arise. No context reconstruction required when returning to ops after weeks of engineering focus.
+
+Full case study: https://soleur.ai/blog/case-study-operations-management/?utm_source=linkedin-company&utm_medium=social&utm_campaign=case-study-operations-management

--- a/knowledge-base/marketing/distribution-content/03-competitive-intelligence.md
+++ b/knowledge-base/marketing/distribution-content/03-competitive-intelligence.md
@@ -2,8 +2,8 @@
 title: "Tracking 17 Competitors in One Session -- With Battlecards"
 type: case-study
 publish_date: 2026-03-19
-channels: discord, x
-status: published
+channels: bluesky, linkedin-company
+status: scheduled
 ---
 
 ## Discord
@@ -114,3 +114,23 @@ What's your approach to competitive intelligence as a founder? Especially intere
 ## Hacker News
 
 Not scheduled for Hacker News distribution. Use Discord + X + IndieHackers + Reddit.
+
+---
+
+## Bluesky
+
+17 competitors tracked in one session. 2,843-word report, overlap matrices, 37 cited sources, 4 battlecards. Changed our validation from PASS to CONDITIONAL PASS. https://soleur.ai/blog/case-study-competitive-intelligence/?utm_source=bluesky&utm_medium=social&utm_campaign=ci
+
+---
+
+## LinkedIn Company Page
+
+Soleur's competitive intelligence function analyzed 17 competitors in a single session — producing a 2,843-word report with structured overlap matrices, 37 cited research sources, and four cascade outputs: competitive pricing matrix, sales battlecards, content gap analysis, and SEO refresh queue.
+
+The system identified 7 platform-tier threats (Anthropic, Cursor, GitHub Copilot, OpenAI, Notion AI) and 10 full-stack competitors, plus 3 new market entrants. A competitive intelligence consultant prices this scope at $8,000-22,000 and 4-8 weeks.
+
+The most significant outcome: the analysis directly changed the business validation verdict from PASS to CONDITIONAL PASS based on Tier 0 threat materialization. The system surfaced a strategic risk the founder had rationalized away.
+
+The analysis compounds — the next quarterly scan starts from the existing framework, not from scratch.
+
+Full case study: https://soleur.ai/blog/case-study-competitive-intelligence/?utm_source=linkedin-company&utm_medium=social&utm_campaign=case-study-competitive-intelligence

--- a/knowledge-base/marketing/distribution-content/04-brand-guide-creation.md
+++ b/knowledge-base/marketing/distribution-content/04-brand-guide-creation.md
@@ -2,7 +2,7 @@
 title: "From Scattered Positioning to a Full Brand Guide in Two Sessions"
 type: case-study
 publish_date: 2026-03-24
-channels: discord, x
+channels: discord, x, bluesky, linkedin-company
 status: scheduled
 ---
 
@@ -62,3 +62,23 @@ Not scheduled for Reddit distribution. Use Discord + X only.
 ## Hacker News
 
 Not scheduled for Hacker News distribution. Use Discord + X only.
+
+---
+
+## Bluesky
+
+Brand positioning scattered across READMEs. Two AI sessions later: full identity, voice definition, 9-color palette, typography system. A reviewer agent now audits all content against it. https://soleur.ai/blog/case-study-brand-guide-creation/?utm_source=bluesky&utm_medium=social&utm_campaign=brand
+
+---
+
+## LinkedIn Company Page
+
+Soleur formalized its brand identity in two AI-assisted sessions — moving from scattered positioning across READMEs and commit messages to a complete brand guide covering identity, voice, visual direction, and channel guidelines.
+
+The brand-architect agent produced: mission and positioning statements, a voice definition with tone spectrum across 5 contexts (7 do's, 7 don'ts), a 9-color Solar Forge palette with hex values, a 5-row typography system (Cormorant Garamond headlines, Inter body, JetBrains Mono code), and channel-specific guidelines for Discord, GitHub, and the website.
+
+Four visual concepts were explored and evaluated against positioning before selecting Solar Forge. A brand-voice-reviewer agent now audits all content against the guide before publishing. A brand strategy agency charges $5,000-15,000 for this scope.
+
+The guide is the single most referenced document in the knowledge base — legal docs use its voice, the site implements its palette, Discord announcements are reviewed against its tone spectrum.
+
+Full case study: https://soleur.ai/blog/case-study-brand-guide-creation/?utm_source=linkedin-company&utm_medium=social&utm_campaign=case-study-brand-guide-creation

--- a/knowledge-base/marketing/distribution-content/05-business-validation.md
+++ b/knowledge-base/marketing/distribution-content/05-business-validation.md
@@ -2,7 +2,7 @@
 title: "Running a Business Validation Workshop With AI Gates"
 type: case-study
 publish_date: 2026-03-26
-channels: discord, x
+channels: discord, x, bluesky, linkedin-company
 status: scheduled
 ---
 
@@ -132,3 +132,25 @@ Anyone else used a structured validation approach to test their own assumptions?
 
 **Title:** Running a Business Validation Workshop With AI Gates
 **URL:** https://soleur.ai/blog/case-study-business-validation/?utm_source=hackernews&utm_medium=community&utm_campaign=case-study-business-validation
+
+---
+
+## Bluesky
+
+280+ PRs. 65+ agents. Zero external users. We ran a 6-gate AI validation against our own assumptions. Kill criterion triggered. Verdict: stop building, start validating. https://soleur.ai/blog/case-study-business-validation/?utm_source=bluesky&utm_medium=social&utm_campaign=bv
+
+---
+
+## LinkedIn Company Page
+
+Soleur ran a structured 6-gate business validation workshop against its own product using a business-validator agent — and the system recommended a pivot.
+
+The framework evaluated: problem definition (PASS), customer profiling (CONDITIONAL PASS — named contacts below threshold), competitive landscape (CONDITIONAL PASS — Tier 0 platform threats), demand evidence (FLAG — kill criterion triggered), business model (CONDITIONAL PASS), and minimum viable scope (PASS).
+
+The kill criterion at Gate 4 was the most significant finding: only 1-2 informal conversations vs. the 5+ threshold required. The AI system told the founder to stop building features and start validating the thesis with real users.
+
+Final verdict: PIVOT — not from the product, but from feature development to user validation. A startup strategy consultant charges $4,000-16,000 for structured validation of this scope.
+
+The validation function persists and re-derives its verdict as new evidence arrives — competitive data, user conversations, demand signals.
+
+Full case study: https://soleur.ai/blog/case-study-business-validation/?utm_source=linkedin-company&utm_medium=social&utm_campaign=case-study-business-validation

--- a/knowledge-base/marketing/distribution-content/06-why-most-agentic-tools-plateau.md
+++ b/knowledge-base/marketing/distribution-content/06-why-most-agentic-tools-plateau.md
@@ -1,9 +1,9 @@
 ---
 title: "Why Most Agentic Engineering Tools Plateau"
 type: pillar
-publish_date: 2026-03-14
-channels: discord, x
-status: published
+publish_date: 2026-03-19
+channels: bluesky, linkedin-company
+status: scheduled
 ---
 
 ## Discord
@@ -126,3 +126,27 @@ Curious whether others have found ways to make their AI development tools accumu
 
 **Title:** Why Most Agentic Engineering Tools Plateau
 **URL:** https://soleur.ai/blog/why-most-agentic-tools-plateau/
+
+---
+
+## Bluesky
+
+Your AI coding tools stop getting better after week two. Session 100 starts from the same blank slate as session 1. We wrote about why — and what breaks through. https://soleur.ai/blog/why-most-agentic-tools-plateau/?utm_source=bluesky&utm_medium=social&utm_campaign=why-most-agentic-tools-plateau
+
+---
+
+## LinkedIn Company Page
+
+Most agentic engineering tools plateau. Session 100 starts from the same blank slate as session 1. The models improve. The system around them does not.
+
+Soleur takes a different approach: compound knowledge into behavior, not documentation. Every task generates insights that feed back into the system's rules, agents, and workflows.
+
+Four proof points from real incidents:
+
+An agent edited files outside its workspace. Two hours lost. The failure triggered a four-stage response: documentation, governance rule, enforcement hook, routing. Seventeen days from failure to mechanical prevention. The system can never make that mistake again.
+
+Documentation-only rules fail. Every enforcement hook exists because a written rule was insufficient. Plan review reduced scope by 30-96% across eight features — 65 tasks became 4. The governance document grew from 26 lines to 200+ rules, each triggered by a real failure.
+
+This is what compound knowledge looks like. Not a feature. An architectural property.
+
+Full breakdown: https://soleur.ai/blog/why-most-agentic-tools-plateau/?utm_source=linkedin-company&utm_medium=social&utm_campaign=why-most-agentic-tools-plateau


### PR DESCRIPTION
## Summary
- Add Bluesky and LinkedIn Company Page sections to all 6 existing distribution content files
- Already-published articles (01, 02, 03, 06) set to `channels: bluesky, linkedin-company` with today's date for immediate backfill publishing
- Scheduled articles (04, 05) have expanded channels for future publishing

## Changelog
- Added `## Bluesky` sections (all within 300-char limit) to 6 content files
- Added `## LinkedIn Company Page` sections (~1300 chars) to 6 content files
- Updated frontmatter for published articles to trigger Bluesky/LinkedIn publishing

## Test plan
- [x] All Bluesky posts within 300-char limit (260-299 chars)
- [x] All LinkedIn Company Page posts within 3000-char limit
- [x] UTM tracking URLs use correct platform sources
- [x] Published articles (01, 02, 03, 06) have channels: bluesky, linkedin-company only
- [x] Scheduled articles (04, 05) have expanded channels: discord, x, bluesky, linkedin-company

Generated with [Claude Code](https://claude.com/claude-code)