### PR TITLE
fix(telegram-bridge): fix health check STATUS double-output and increase retries

### DIFF
--- a/.github/workflows/telegram-bridge-release.yml
+++ b/.github/workflows/telegram-bridge-release.yml
@@ -76,16 +76,16 @@ jobs:
               -p 127.0.0.1:8080:8080 \
               "$IMAGE:$TAG"
             echo "Waiting for health endpoint (container liveness)..."
-            for i in $(seq 1 12); do
-              STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/health || echo "000")
+            for i in $(seq 1 24); do
+              STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/health 2>/dev/null) || STATUS="000"
               if [ "$STATUS" = "200" ] || [ "$STATUS" = "503" ]; then
                 BODY=$(curl -s http://localhost:8080/health)
                 echo "Health endpoint responded: HTTP $STATUS - $BODY"
                 exit 0
               fi
-              echo "Attempt $i: HTTP $STATUS (waiting for health endpoint...)"
+              echo "Attempt $i/24: HTTP $STATUS (waiting for health endpoint...)"
               sleep 5
             done
-            echo "Health check failed - endpoint not responding"
+            echo "Health check failed - endpoint not responding after 120s"
             docker logs soleur-bridge --tail 30
             exit 1


### PR DESCRIPTION
## Summary
- Fix STATUS capture bug: `|| echo "000"` appended to curl's own stdout, producing `000000` instead of `000`. Changed to `|| STATUS="000"` assignment.
- Increase retries from 12 to 24 (120s window). The Bun server takes ~60s to start inside Docker -- 12 retries (60s) wasn't enough headroom. With 503 acceptance, the check passes immediately when the server responds; the 120s is headroom.

Closes #763

## Changelog
- **telegram-bridge:** Fix deploy health check STATUS variable double-output on curl connection failure
- **telegram-bridge:** Increase deploy health check retries from 12 to 24 (120s window) for Bun server startup time

## Test plan
- [x] Deploy workflow ran with previous PR (#790) and failed due to these bugs
- [ ] This fix addresses both root causes observed in the CI logs

Generated with [Claude Code](https://claude.com/claude-code)