### PR TITLE
fix(ci): restore packages:write permission for plugin release workflow

### DIFF
--- a/.github/workflows/version-bump-and-release.yml
+++ b/.github/workflows/version-bump-and-release.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:


### PR DESCRIPTION
## Summary
- Restores `packages: write` permission to `version-bump-and-release.yml` that was removed in #823
- The reusable workflow's job declares `packages: write` at the job level; GitHub Actions requires callers to grant all permissions the callee requests, even for conditionally-used steps
- Without this permission, the workflow fails with `startup_failure` (no jobs run, no error message)

## Changelog
- Fixed plugin release workflow `startup_failure` by restoring required `packages: write` permission

## Test plan
- [ ] Verify workflow no longer fails with `startup_failure` on push to main
- [ ] Trigger `workflow_dispatch` with `bump_type=patch` to verify full release flow

Generated with [Claude Code](https://claude.com/claude-code)