### PR TITLE
fix(ci): increase community monitor max-turns from 30 to 50

### DIFF
--- a/.github/workflows/scheduled-community-monitor.yml
+++ b/.github/workflows/scheduled-community-monitor.yml
@@ -63,7 +63,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: 'https://github.com/jikig-ai/soleur.git'
           plugins: 'soleur@soleur'
-          claude_args: '--model claude-sonnet-4-6 --max-turns 30 --allowedTools Bash,Read,Write,Edit,Glob,Grep'
+          claude_args: '--model claude-sonnet-4-6 --max-turns 50 --allowedTools Bash,Read,Write,Edit,Glob,Grep'
           prompt: |
             You are a community monitoring agent. Your job is to generate a daily
             community digest and create a GitHub Issue summarizing the findings.
@@ -81,22 +81,19 @@ jobs:
                "[Scheduled] Community Monitor - FAILED" with label
                "scheduled-community-monitor" explaining the misconfiguration, then stop.
 
-            2. **Collect data** from enabled platforms using the router. Set:
-               ROUTER="plugins/soleur/skills/community/scripts/community-router.sh"
-               Then run:
-               - Discord (if enabled): $ROUTER discord guild-info, $ROUTER discord members,
-                 $ROUTER discord channels (to list channel IDs),
-                 then $ROUTER discord messages <channel_id> 100 for each channel.
-               - X/Twitter (if enabled): $ROUTER x fetch-metrics ONLY.
-                 Do NOT call fetch-mentions or fetch-timeline (they return 403 on
-                 Free tier and waste turns). TODO: re-enable when paid API tier is activated.
-               - LinkedIn (if enabled): Do NOT post or fetch data -- log as
-                 "enabled (posting only)" and skip.
-               - GitHub: $ROUTER github activity 1, $ROUTER github contributors 1,
-                 $ROUTER github discussions 1. Use a 1-day lookback window.
-               - Hacker News: $ROUTER hn mentions --query soleur --limit 20,
-                 $ROUTER hn trending --limit 30. No secrets needed (public API).
-               - If a script fails, log the error and continue with other platforms.
+            2. **Collect data** from enabled platforms. IMPORTANT: batch commands
+               into as few Bash calls as possible to conserve turns. Use `;` (not
+               `&&`) to chain commands so failures don't halt the batch.
+               Set: ROUTER="plugins/soleur/skills/community/scripts/community-router.sh"
+               Batch 1 (Discord + X — single Bash call):
+               - Discord (if enabled): `bash $ROUTER discord guild-info; bash $ROUTER discord members; bash $ROUTER discord channels`
+                 Then one more call to fetch messages for each channel ID from the output above.
+               - X/Twitter (if enabled): append `bash $ROUTER x fetch-metrics` to the same call.
+                 Do NOT call fetch-mentions or fetch-timeline (403 on Free tier).
+               - LinkedIn (if enabled): skip — log "enabled (posting only)".
+               Batch 2 (GitHub + HN — single Bash call):
+               - `bash $ROUTER github activity 1; bash $ROUTER github contributors 1; bash $ROUTER github discussions 1; bash $ROUTER hn mentions --query soleur --limit 20; bash $ROUTER hn trending --limit 30`
+               If any command in a batch fails, log the error and continue.
 
             3. **Read brand guide** at knowledge-base/marketing/brand-guide.md (section ## Voice)
                before writing any content. Match the brand voice in the digest.

--- a/knowledge-base/learnings/2026-03-20-claude-code-action-max-turns-budget.md
+++ b/knowledge-base/learnings/2026-03-20-claude-code-action-max-turns-budget.md
@@ -1,0 +1,37 @@
+# Learning: claude-code-action max-turns budget for Soleur plugin workflows
+
+## Problem
+
+The `scheduled-community-monitor.yml` workflow failed with `error_max_turns` after exhausting its 30-turn limit. The agent needed to:
+- Read plugin files (AGENTS.md, constitution, brand guide) — ~5 turns overhead
+- Detect platforms (1 turn)
+- Collect data from 5 platforms (Discord, X, GitHub, HN, LinkedIn) — ~10 turns
+- Write digest file (1 turn)
+- Persist via PR (branch, commit, push, status checks, PR create, auto-merge) — ~5 turns
+- Create GitHub Issue (1 turn)
+
+Total: ~23+ turns, exceeding the 30-turn budget.
+
+## Solution
+
+1. Increased `--max-turns` from 30 to 50 to provide adequate headroom
+2. Restructured the prompt to instruct batching data collection commands with `;` separators, reducing the number of tool calls needed for data collection from ~10 to ~3
+
+## Key Insight
+
+When setting `--max-turns` for `claude-code-action` workflows that load the Soleur plugin (`plugins: 'soleur@soleur'`), account for ~10 turns of plugin overhead (reading AGENTS.md, constitution.md, brand guide, and other project files) on top of the actual task turns. The formula:
+
+**Required turns = plugin overhead (~10) + task tool calls + error/retry buffer (~5)**
+
+Current workflow turn budgets for reference:
+- Bug fixer: 25 (at risk — consider increasing)
+- Community monitor: 50 (fixed from 30)
+- Ship/merge: 40
+- Competitive analysis: 45
+- Daily triage: 80
+
+Batching shell commands with `;` (not `&&` — failures shouldn't halt the batch) is the most effective way to reduce turn consumption for data-collection-heavy workflows.
+
+## Tags
+category: ci-workflows
+module: github-actions

--- a/plugins/soleur/skills/schedule/SKILL.md
+++ b/plugins/soleur/skills/schedule/SKILL.md
@@ -40,7 +40,7 @@ Use the **AskUserQuestion tool** to gather missing inputs one at a time:
 
 5. **Timeout (minutes)** — Job-level timeout to prevent runaway billing. Default: 30. Validate: positive integer, minimum 5 minutes.
 
-6. **Max turns** — Maximum number of agent turns before stopping. Default: 30. Validate: positive integer, minimum 5 turns.
+6. **Max turns** — Maximum number of agent turns before stopping. Default: 30. Validate: positive integer, minimum 5 turns. Budget formula: plugin overhead (~10 turns) + task tool calls + error buffer (~5). Multi-platform data collection or PR-based persist workflows typically need 40-50 turns.
 
 **Step 2: Resolve action SHAs**
 


### PR DESCRIPTION
## Summary
- Increased `--max-turns` from 30 to 50 for the community monitor workflow that was failing with `error_max_turns`
- Restructured prompt to batch data collection commands with `;` separators, reducing turn consumption
- Added turn budget formula to the schedule skill's max-turns input documentation

## Changelog
- fix: community monitor workflow no longer exhausts turn limit during daily runs
- docs: added max-turns budget formula to schedule skill (plugin overhead + task calls + error buffer)
- docs: new learning on claude-code-action turn budgeting for Soleur plugin workflows

## Test plan
- [ ] Trigger manual run: `gh workflow run scheduled-community-monitor.yml`
- [ ] Verify workflow completes without `error_max_turns`
- [ ] Verify daily digest PR is created and auto-merged

Generated with [Claude Code](https://claude.com/claude-code)