### PR TITLE
fix(git-worktree): add plugin hooks to bare repo sync list

### DIFF
--- a/knowledge-base/learnings/2026-03-20-bare-repo-plugin-hook-sync-gap.md
+++ b/knowledge-base/learnings/2026-03-20-bare-repo-plugin-hook-sync-gap.md
@@ -1,0 +1,21 @@
+# Learning: Bare repo plugin hook sync gap
+
+## Problem
+The `cleanup-merged` function in `worktree-manager.sh` syncs critical on-disk files from `git HEAD` after merging worktrees back to main. However, the sync list only included `.claude/hooks/*` (user hooks) and a handful of explicitly listed files. Plugin hooks at `plugins/soleur/hooks/` were not in the sync list.
+
+In a bare repo, the working tree files on disk are not automatically updated by git operations. This meant `plugins/soleur/hooks/stop-hook.sh` on disk was stuck at an old version (167 lines, 20-char stuck threshold) while HEAD had the fully hardened version (315 lines, PID-based, 150-char threshold, similarity detection). The stale stop hook caused an infinite "finish all slash commands" loop because its 20-char stuck detection couldn't catch substantive-looking responses.
+
+## Solution
+Added all plugin hook files to the `cleanup-merged` sync list:
+- `plugins/soleur/hooks/hooks.json`
+- `plugins/soleur/hooks/stop-hook.sh`
+- `plugins/soleur/hooks/welcome-hook.sh`
+
+Also added `chmod +x` for plugin hook scripts after sync, matching the existing pattern for `.claude/hooks/`.
+
+## Key Insight
+In a bare repo, any file that Claude Code reads at runtime (not from a worktree checkout) must be in the `cleanup-merged` sync list. The sync list was designed for config files (CLAUDE.md, settings.json) and the worktree manager itself, but plugin hooks execute from the bare repo root via `${CLAUDE_PLUGIN_ROOT}` and were overlooked. When adding new runtime-critical files to `plugins/soleur/`, always check if they need to be added to the sync list.
+
+## Tags
+category: integration-issues
+module: git-worktree, ralph-loop

--- a/plugins/soleur/skills/git-worktree/SKILL.md
+++ b/plugins/soleur/skills/git-worktree/SKILL.md
@@ -156,9 +156,13 @@ bash ./plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh sync-bare-
 **What it syncs:**
 - `AGENTS.md`, `CLAUDE.md` (session-start instructions)
 - `plugins/soleur/AGENTS.md`, `plugins/soleur/CLAUDE.md`
+- `plugins/soleur/hooks/*` (plugin hooks: stop-hook, welcome-hook, hooks.json)
 - `.claude/settings.json` (permission rules)
 - `.claude/hooks/*.sh` (PreToolUse hooks)
+- `plugins/soleur/scripts/resolve-git-root.sh`
 - The `worktree-manager.sh` script itself
+
+**Important:** Any file that Claude Code executes at runtime from the bare repo root (via `${CLAUDE_PLUGIN_ROOT}` or direct path) must be added to the sync list in `worktree-manager.sh`. Stale on-disk files cause silent regressions.
 
 ## Workflow Examples
 

--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -701,6 +701,9 @@ sync_bare_files() {
     ".claude/settings.json"
     "plugins/soleur/AGENTS.md"
     "plugins/soleur/CLAUDE.md"
+    "plugins/soleur/hooks/hooks.json"
+    "plugins/soleur/hooks/stop-hook.sh"
+    "plugins/soleur/hooks/welcome-hook.sh"
     "plugins/soleur/scripts/resolve-git-root.sh"
     "plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh"
   )
@@ -731,6 +734,7 @@ sync_bare_files() {
 
   # Restore execute permissions on scripts
   chmod +x "$GIT_ROOT/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh" 2>/dev/null || true
+  chmod +x "$GIT_ROOT/plugins/soleur/hooks/"*.sh 2>/dev/null || true
 
   # Sync hook scripts and restore execute permissions
   local hook_files


### PR DESCRIPTION
## Summary
- Add `plugins/soleur/hooks/*` (stop-hook.sh, welcome-hook.sh, hooks.json) to the `cleanup-merged` bare repo sync list
- Add `chmod +x` for plugin hooks after sync
- Update SKILL.md sync documentation with complete file list and maintenance note

Closes #866

## Changelog
- Plugin hooks are now synced from git HEAD during `cleanup-merged`, preventing stale on-disk hooks in bare repos
- The `sync-bare-files` documentation now lists all synced files and includes a note about adding new runtime-critical files

## Root Cause
The `cleanup-merged` function syncs critical files from `git HEAD` to disk in bare repos, but `plugins/soleur/hooks/` was not in the sync list. After the stop-hook was hardened (#729, #766) with PID-based naming and 150-char stuck detection, the on-disk version remained at the old 20-char threshold version, causing infinite ralph loop cycles.

## Test plan
- [x] All 99 ralph-loop tests pass
- [x] web-platform tests pass (33/33)
- [x] telegram-bridge tests pass (99/99)
- [ ] Verify `cleanup-merged` syncs plugin hooks after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)