### PR TITLE
fix: auto-clean stale Claude tmpfs task outputs

### DIFF
--- a/knowledge-base/learnings/2026-03-20-claude-tmpfs-task-output-memory-leak.md
+++ b/knowledge-base/learnings/2026-03-20-claude-tmpfs-task-output-memory-leak.md
@@ -1,0 +1,23 @@
+# Learning: Claude Code tmpfs task output can exhaust system RAM
+
+## Problem
+A stale Claude Code session left a 16 GB task output file in `/tmp/claude-<uid>/`. Because `/tmp` is typically a tmpfs (RAM-backed filesystem), this single file consumed over half of a 30 GB system's memory, leaving only 4.4 GB free. The user perceived the system as "almost out of memory" despite only running Warp and Claude.
+
+The file was `bmdjeb18h.output` inside a session's `tasks/` directory. Claude stores task/subagent output in `/tmp/claude-<uid>/<project-path>/<session-uuid>/tasks/`. When a task produces unbounded output (e.g., a runaway subagent or a large file read piped to output), the file grows without limit on tmpfs.
+
+## Solution
+Added a `cleanup_claude_tmp` function to `worktree-manager.sh` that:
+
+1. Enumerates all session directories under `/tmp/claude-<uid>/`
+2. Identifies active Claude sessions by reading `/proc/<pid>/cmdline` for running `claude` processes and extracting `--resume <session-id>`
+3. For stale (non-running) sessions, removes task output files larger than 1 MB
+4. Cleans up empty session and project directories
+
+The function is called automatically from `cleanup_merged_worktrees` (which runs at every session start and after every PR merge) and is also available as a standalone `cleanup-tmp` command.
+
+## Key Insight
+Claude Code's tmpfs usage is invisible to typical memory debugging (it doesn't show as process RSS in `ps aux`). The `Shmem` line in `/proc/meminfo` and `du -sh /tmp/claude-*` are the diagnostic tools. Since `cleanup-merged` already runs at session boundaries, hooking tmpfs cleanup into it ensures the problem self-heals without manual intervention.
+
+## Tags
+category: runtime-errors
+module: worktree-manager

--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -623,7 +623,99 @@ cleanup_merged_worktrees() {
     fi
   fi
 
+  # Always clean up stale Claude tmp files (RAM-backed, can be huge)
+  cleanup_claude_tmp
+
   return 0
+}
+
+# Clean up stale Claude Code temp files to reclaim RAM.
+# Claude stores task output in /tmp/claude-<uid>/<project>/<session>/tasks/.
+# These files sit on tmpfs (RAM-backed). Runaway task outputs can consume tens
+# of GB and starve the system. This function identifies session directories that
+# no longer correspond to a running Claude process and removes their task output.
+cleanup_claude_tmp() {
+  local uid
+  uid=$(id -u)
+  local claude_tmp="/tmp/claude-$uid"
+
+  if [[ ! -d "$claude_tmp" ]]; then
+    return 0
+  fi
+
+  # Collect session IDs from running Claude processes (--resume <id> or conversation ID)
+  local active_sessions=()
+  while IFS= read -r pid; do
+    # Read /proc/<pid>/cmdline -- args are NUL-separated
+    local cmdline
+    cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null) || continue
+    # Extract --resume argument (session ID)
+    local session_id
+    session_id=$(echo "$cmdline" | grep -oP '(?<=--resume )[0-9a-f-]+' || true)
+    if [[ -n "$session_id" ]]; then
+      active_sessions+=("$session_id")
+    fi
+  done < <(pgrep -u "$uid" -x claude 2>/dev/null || true)
+
+  local total_freed=0
+  local files_removed=0
+
+  # Walk each project directory
+  for project_dir in "$claude_tmp"/*/; do
+    [[ -d "$project_dir" ]] || continue
+
+    for session_dir in "$project_dir"/*/; do
+      [[ -d "$session_dir" ]] || continue
+      local session_id
+      session_id=$(basename "$session_dir")
+
+      # Skip active sessions
+      local is_active=false
+      for active in "${active_sessions[@]+"${active_sessions[@]}"}"; do
+        if [[ "$active" == "$session_id" ]]; then
+          is_active=true
+          break
+        fi
+      done
+      if [[ "$is_active" == "true" ]]; then
+        continue
+      fi
+
+      # Remove task output files from stale sessions
+      local tasks_dir="$session_dir/tasks"
+      if [[ -d "$tasks_dir" ]]; then
+        for output_file in "$tasks_dir"/*.output; do
+          [[ -f "$output_file" ]] || continue
+          # Skip symlinks (they point to subagent logs and are tiny)
+          [[ -L "$output_file" ]] && continue
+          local size_kb
+          size_kb=$(stat -c%s "$output_file" 2>/dev/null || echo 0)
+          size_kb=$((size_kb / 1024))
+          # Only remove files > 1 MB to avoid removing small, harmless files
+          if [[ $size_kb -gt 1024 ]]; then
+            local size_mb=$((size_kb / 1024))
+            rm -f "$output_file"
+            total_freed=$((total_freed + size_mb))
+            files_removed=$((files_removed + 1))
+          fi
+        done
+      fi
+
+      # If the session directory is now empty (or only has empty subdirs), remove it
+      if [[ -z "$(find "$session_dir" -type f 2>/dev/null | head -1)" ]]; then
+        rm -rf "$session_dir" 2>/dev/null || true
+      fi
+    done
+
+    # Remove project dir if empty
+    if [[ -z "$(ls -A "$project_dir" 2>/dev/null)" ]]; then
+      rmdir "$project_dir" 2>/dev/null || true
+    fi
+  done
+
+  if [[ $files_removed -gt 0 ]]; then
+    echo -e "${GREEN}Cleaned $files_removed stale Claude task output(s), freed ~${total_freed} MB${NC}"
+  fi
 }
 
 # Create a draft PR for the current branch
@@ -798,6 +890,9 @@ main() {
     cleanup-merged)
       cleanup_merged_worktrees
       ;;
+    cleanup-tmp)
+      cleanup_claude_tmp
+      ;;
     draft-pr)
       create_draft_pr
       ;;
@@ -836,7 +931,10 @@ Commands:
                                       (if name omitted, uses current worktree)
   cleanup | clean                     Clean up inactive worktrees
   cleanup-merged                      Clean up worktrees for merged branches
-                                      (detects [gone] branches, archives specs)
+                                      (detects [gone] branches, archives specs,
+                                      removes stale Claude tmp files)
+  cleanup-tmp                         Remove stale Claude task output files
+                                      (reclaims RAM from /tmp/claude-<uid>/)
   draft-pr                            Create empty commit, push, and open draft PR
                                       (idempotent: skips if PR already exists)
   sync-bare | sync-bare-files | sync  Sync stale on-disk files from git HEAD


### PR DESCRIPTION
## Summary
- Adds `cleanup_claude_tmp` function to `worktree-manager.sh` that removes large (>1 MB) task output files from stale Claude sessions in `/tmp/claude-<uid>/`
- Runs automatically during `cleanup-merged` (session start + post-merge) to prevent RAM exhaustion
- Available as standalone `cleanup-tmp` command for on-demand use

Incident: a single 16 GB `bmdjeb18h.output` file from a dead session consumed half of 30 GB system RAM via tmpfs, invisible to `ps aux` (only visible in `/proc/meminfo` Shmem and `du /tmp/claude-*`).

## Changelog
- Added `cleanup_claude_tmp` function that identifies dead Claude sessions via `/proc/<pid>/cmdline` and removes their large task output files
- Integrated into `cleanup-merged` workflow for automatic cleanup at session boundaries
- Added standalone `cleanup-tmp` command to worktree-manager
- Documented learning in knowledge-base

## Test plan
- [x] `bash -n` syntax check passes
- [x] `bun test` — all 1189 tests pass
- [x] Tested `cleanup-tmp` command on live system (no-op when no stale files exist)
- [x] Verified 16 GB file removal freed memory (4.4 GB → 19 GB free)

Generated with [Claude Code](https://claude.com/claude-code)