### PR TITLE
fix(infra): use absolute path for plan-output.txt in drift workflow

### DIFF
--- a/.github/workflows/scheduled-terraform-drift.yml
+++ b/.github/workflows/scheduled-terraform-drift.yml
@@ -87,12 +87,12 @@ jobs:
 
           echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
 
-          printf '%s' "$PLAN_OUTPUT" | head -c 60000 > plan-output.txt
+          printf '%s' "$PLAN_OUTPUT" | head -c 60000 > ${RUNNER_TEMP}/plan-output.txt
           sed -i \
             -e 's/\(token\s*=\s*\)"[^"]*"/\1"***"/gi' \
             -e 's/\(secret\s*=\s*\)"[^"]*"/\1"***"/gi' \
             -e 's/\(password\s*=\s*\)"[^"]*"/\1"***"/gi' \
-            plan-output.txt
+            ${RUNNER_TEMP}/plan-output.txt
 
           STACK_NAME=$(echo "$MATRIX_DIR" | sed 's|apps/||;s|/infra||')
           echo "stack_name=$STACK_NAME" >> "$GITHUB_OUTPUT"
@@ -137,7 +137,7 @@ jobs:
               echo "<details><summary>Plan output</summary>"
               echo ""
               echo '```'
-              cat plan-output.txt
+              cat ${RUNNER_TEMP}/plan-output.txt
               echo '```'
               echo ""
               echo "</details>"
@@ -157,7 +157,7 @@ jobs:
               echo "<details><summary>Plan output</summary>"
               echo ""
               echo '```'
-              cat plan-output.txt
+              cat ${RUNNER_TEMP}/plan-output.txt
               echo '```'
               echo ""
               echo "</details>"


### PR DESCRIPTION
## Summary
- Fix `plan-output.txt` path mismatch: plan step writes to `working-directory` (`apps/*/infra/`), but issue creation step reads from repo root
- Use `$RUNNER_TEMP/plan-output.txt` as an absolute path accessible from all steps

Closes #977

## Changelog
- Fixed: Plan output file now uses absolute path (`$RUNNER_TEMP`) so issue creation and Discord notification steps can read it

## Test plan
- [ ] Trigger manual workflow run: `gh workflow run scheduled-terraform-drift.yml`
- [ ] Verify both matrix jobs complete successfully
- [ ] Verify drift issues are created (if drift exists) or no errors occur

Generated with [Claude Code](https://claude.com/claude-code)