### PR TITLE
fix(web): bundle next.config.ts imports to fix Docker crash

### DIFF
--- a/apps/web-platform/Dockerfile
+++ b/apps/web-platform/Dockerfile
@@ -16,7 +16,7 @@ ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
 RUN npm run build
 RUN npm run build:server
 # Compile next.config.ts to .mjs so the runner stage doesn't need TypeScript
-RUN ./node_modules/.bin/esbuild next.config.ts --format=esm --outfile=next.config.mjs
+RUN ./node_modules/.bin/esbuild next.config.ts --bundle --format=esm --platform=node --outfile=next.config.mjs
 
 # Stage 3: Production image with only runtime artifacts
 FROM node:22-slim@sha256:4f77a690f2f8946ab16fe1e791a3ac0667ae1c3575c3e4d0d4589e9ed5bfaf3d AS runner


### PR DESCRIPTION
## Summary

- Add `--bundle` flag to esbuild command that compiles `next.config.ts` to `.mjs`
- Without bundling, the `./lib/security-headers` import stays as an external reference
- The `lib/` directory is not copied to the Docker runner stage, causing a crash on startup

Closes #989

## Changelog

### Fixed
- Web platform Docker container crash: `Cannot find module '/app/lib/security-headers'`

## Test plan

- [ ] Docker build succeeds
- [ ] Container starts without module errors
- [ ] Health check passes at `/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)