### PR TITLE
fix(infra): conditionally pass ssh_key_path in CI workflows

### DIFF
--- a/.github/workflows/infra-validation.yml
+++ b/.github/workflows/infra-validation.yml
@@ -165,9 +165,13 @@ jobs:
           DOPPLER_PROJECT: soleur
           DOPPLER_CONFIG: prd_terraform
         run: |
+          VAR_ARGS=()
+          if grep -q 'variable "ssh_key_path"' variables.tf 2>/dev/null; then
+            VAR_ARGS+=(-var="ssh_key_path=/tmp/ci_ssh_key.pub")
+          fi
           PLAN_OUTPUT=$(doppler run --name-transformer tf-var -- \
             terraform plan -no-color -input=false \
-            -var="ssh_key_path=/tmp/ci_ssh_key.pub" 2>&1)
+            "${VAR_ARGS[@]}" 2>&1)
           PLAN_EXIT=$?
 
           if [[ ${#PLAN_OUTPUT} -gt 60000 ]]; then

--- a/.github/workflows/scheduled-terraform-drift.yml
+++ b/.github/workflows/scheduled-terraform-drift.yml
@@ -79,9 +79,15 @@ jobs:
           MATRIX_DIR: ${{ matrix.directory }}
         run: |
           set +e
+          # Only pass ssh_key_path to stacks that define it (web-platform needs it,
+          # telegram-bridge does not — it has no Hetzner resources).
+          VAR_ARGS=()
+          if grep -q 'variable "ssh_key_path"' variables.tf 2>/dev/null; then
+            VAR_ARGS+=(-var="ssh_key_path=${CI_SSH_PUB}")
+          fi
           PLAN_OUTPUT=$(doppler run --name-transformer tf-var -- \
             terraform plan -detailed-exitcode -no-color -input=false \
-            -var="ssh_key_path=${CI_SSH_PUB}" 2>&1)
+            "${VAR_ARGS[@]}" 2>&1)
           EXIT_CODE=$?
           set -e
 


### PR DESCRIPTION
## Summary

- Only pass `-var="ssh_key_path=..."` to Terraform stacks that define the variable
- Fixes CI plan failure (exit 1) for telegram-bridge after #993 removed its Hetzner resources
- Applied to both `scheduled-terraform-drift.yml` and `infra-validation.yml`

## Test plan

- [ ] Trigger drift workflow after merge — both stacks should pass
- [ ] telegram-bridge plan should return exit code 0 (no changes)
- [ ] web-platform plan should return exit code 2 (notification policy only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)