### PR TITLE
fix: enforce roadmap-milestone sync + move tag-and-route to P1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ This repository contains the Soleur Claude Code plugin. Detailed conventions liv
 
 ## Workflow Gates
 
+- When moving GitHub issues between milestones, deferring features, changing priorities, or making any roadmap decision, update `knowledge-base/product/roadmap.md` in the same action. The roadmap document is the canonical product truth -- if it contradicts the issue tracker, neither can be trusted. Never change a milestone assignment without updating the corresponding roadmap phase table. **Why:** In the #1064 roadmap session, tag-and-route was deferred from P1 to P3 but the roadmap document was not updated, creating three conflicting sources of truth (roadmap, milestones, conversation). The CPO had to flag this on re-review.
 - Zero agents until user confirms direction. Present a concise summary first, ask if they want to go deeper, only then launch research. Exception: passive domain routing (see below).
 - Before every commit, run compound (`skill: soleur:compound`). Do not ask whether to run it -- just run it.
 - Never bump version files in feature branches. Version is derived from git tags — CI creates GitHub Releases with `vX.Y.Z` tags at merge time via semver labels. Set labels with `/ship`. Do NOT edit `plugin.json` version (frozen sentinel) or `marketplace.json` version.

--- a/knowledge-base/product/roadmap.md
+++ b/knowledge-base/product/roadmap.md
@@ -99,14 +99,16 @@ This roadmap was reviewed by CTO, CLO, CFO, and CMO before finalization.
 | 1.8 | **Multi-turn conversation continuity** (architecture choice deferred to CTO during spec) | P1 | [#1044](https://github.com/jikig-ai/soleur/issues/1044) | **Broken** — agent has amnesia between turns (CTO review) |
 | 1.9 | Pin Agent SDK to exact version (`0.2.80`) | P1 | [#1045](https://github.com/jikig-ai/soleur/issues/1045) | Not started |
 | 1.10 | **Project repo connection** — clone founder's public git repo, install latest Soleur plugin, keep plugin updated | P1 | [#1060](https://github.com/jikig-ai/soleur/issues/1060) | Not started |
+| 1.11 | **Tag-and-route conversation model** — one chat input, system routes to relevant leaders, no dedicated domain leader pages | P1 | [#1059](https://github.com/jikig-ai/soleur/issues/1059) | Not started |
 
 **Why 1.8 is P1 (CTO review):** "A chat product where the agent forgets everything after one turn is not viable even for beta. It will be the first thing every user notices." Each message currently spawns a fresh agent with no memory of prior exchange. `persistSession: false` is explicitly set. **Dependency note:** The multi-turn architecture choice (CTO decision during spec) has downstream implications for 2.4 (GDPR account deletion — what conversation data must be purged?), 2.9 (privacy docs — what is stored?), and 3.3 (conversation inbox — what is displayed?).
 
 **Why 1.10 is P1:** Without the founder's actual project repo and the Soleur plugin installed, agents operate in a vacuum — no codebase context, no skills, no domain leaders, no institutional memory. The workspace must be the founder's real project, not an empty shell. Scoped to **public repos only** for P1 — private repo support (OAuth/deploy keys) deferred to a later phase.
 
+**Why 1.11 is P1:** The current domain leader selector page consumes significant UI real estate and will be torn down for tag-and-route in P3 — building throwaway pages is wasted effort. The tag-and-route model is simpler for P1: one chat input with system routing (same pattern as the brainstorm skill's domain assessment) instead of 8 dedicated domain leader pages. Build the right UX once rather than building and tearing down the wrong one.
+
 **Deferred from P1:**
 
-- ~~1.10 Tag-and-route data model~~ → Moved to Phase 3. Zero users have tested per-leader chat. Let user behavior inform the data model.
 - ~~1.12 Telegram bridge~~ → Deferred to a later phase. Reach is meaningless with 0 users.
 - Private repo support for 1.10 → Deferred. Public repos prove the pattern in 3 days.
 
@@ -120,6 +122,7 @@ This roadmap was reviewed by CTO, CLO, CFO, and CMO before finalization.
 - New user completes signup, BYOK, multi-turn conversation on mobile browser
 - Agent runs against the founder's actual project repo with Soleur plugin installed
 - Agent remembers context across turns within a conversation
+- Conversations route to relevant domain leaders automatically (no dedicated department pages)
 - PWA installable on iOS, Android, desktop Chrome/Edge
 - Lighthouse mobile score > 80
 
@@ -176,8 +179,8 @@ This roadmap was reviewed by CTO, CLO, CFO, and CMO before finalization.
 | 3.6 | Usage/cost indicator (BYOK spending) | P2 | [#672](https://github.com/jikig-ai/soleur/issues/672) | Not started |
 | 3.7 | Review gate notifications (PWA push + email fallback for iOS) | P2 | [#1049](https://github.com/jikig-ai/soleur/issues/1049) | Not started |
 | 3.8 | Guided instructions fallback (deep links + review gates for services without API/MCP) | P2 | New | Not started |
-| 3.9 | Tag-and-route UX (@-mentions, auto-routing, multi-leader threads) | P1 | [#1059](https://github.com/jikig-ai/soleur/issues/1059) | Not started |
-| 3.10 | CI/CD integration (agents trigger deploys, run tests, open PRs on founder's repo) | P1 | New | Not started |
+| 3.9 | Tag-and-route UX enhancements (@-mentions syntax, multi-leader threads, context-aware suggestions) | P2 | [#1059](https://github.com/jikig-ai/soleur/issues/1059) | Depends on P1 foundation |
+| 3.10 | CI/CD integration (agents trigger deploys, run tests, open PRs on founder's repo) | P1 | [#1062](https://github.com/jikig-ai/soleur/issues/1062) | Not started |
 | 3.11 | Product analytics instrumentation for P4 validation metrics (domain engagement, session frequency, KB growth) | P1 | [#1063](https://github.com/jikig-ai/soleur/issues/1063) | Not started |
 | 3.12 | Pricing page (soleur.ai) | P1 | [#656](https://github.com/jikig-ai/soleur/issues/656) | Not started |
 | 3.13 | Subscription management (cancel, upgrade/downgrade) | P1 | New | Not started |

--- a/plugins/soleur/agents/product/cpo.md
+++ b/plugins/soleur/agents/product/cpo.md
@@ -19,6 +19,7 @@ Evaluate current product state before making recommendations.
 - If the task references a GitHub issue (`#N`), verify its state via `gh issue view <N> --json state` before asserting whether work is pending or complete.
 - If both `business-validation.md` and `brand-guide.md` exist, cross-reference the validation's framing against the brand's Identity and Positioning sections. If the validation treats stated product features as "scope creep" or contradicts the brand's positioning, flag: "Validation may be misaligned with current brand positioning (last updated: [date]). Consider revalidation." Recommend revalidation but allow the user to proceed.
 - Check for spec files in `knowledge-base/project/specs/` -- assess what has been specified and what gaps remain.
+- **Roadmap consistency check:** If `knowledge-base/product/roadmap.md` exists, cross-reference it against GitHub milestones (`gh api repos/{owner}/{repo}/milestones`) and open issues. Flag any inconsistency: issues assigned to milestones that don't match their roadmap phase, features listed in the roadmap with no corresponding issue, or deferred items still showing in active phases. The roadmap document and the issue tracker must tell the same story.
 - Determine product maturity stage: pre-idea, idea (unvalidated), validated, building, launched.
 - Report product state in a structured table (area, status, next action).
 


### PR DESCRIPTION
## Summary

- New AGENTS.md workflow gate: roadmap.md must be updated whenever milestone assignments change
- CPO agent: added roadmap consistency check to Assess phase (cross-references milestones vs roadmap)
- Tag-and-route moved from P3 back to P1 (building throwaway domain leader pages is wasted effort)

Closes the gap where milestone changes were made 3 times in a session without updating the roadmap document.

**Why:** In #1064, tag-and-route was deferred, Telegram bridge removed, billing added — all without updating the roadmap. The CPO had to flag the inconsistency on re-review.

## Test plan

- [x] 948 plugin component tests pass
- [x] Markdown lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)