### PR TITLE
fix: correct blog author name "Jean Jikig" to "Jean Deruelle"

### DIFF
--- a/knowledge-base/marketing/brand-guide.md
+++ b/knowledge-base/marketing/brand-guide.md
@@ -31,6 +31,14 @@ Soleur is not a copilot. Not an assistant. It is a full AI organization -- 61 ag
 
 > **[2026-03-22 Business Validation Review]** The positioning statement, tagline, and thesis remain valid -- user research confirmed the CaaS vision resonates strongly with founders. However, "terminal-first workflow" is no longer a positioning asset. The positioning must be delivery-agnostic: accessible from any device, not tied to a specific development environment. The phrase "operates as every department from strategy to shipping" holds. What changes is the access surface, not the mission. When the web platform ships, positioning language should emphasize "accessible anywhere" alongside the existing "full AI organization" framing. No changes to mission or thesis required.
 
+## Founder
+
+- **Name:** Jean Deruelle
+- **Role:** Founder & CEO
+- **Company:** Jikigai (legal entity), operating Soleur (product)
+
+Use this section as the authoritative source when any skill or agent needs to attribute content, generate About pages, produce author schema, or write LinkedIn Personal posts in the founder's voice. Never infer the founder's name from org names, GitHub handles, or domain slugs.
+
 ## Voice
 
 ### Brand Voice

--- a/knowledge-base/project/learnings/2026-03-24-agent-hallucinated-author-name-from-org-context.md
+++ b/knowledge-base/project/learnings/2026-03-24-agent-hallucinated-author-name-from-org-context.md
@@ -1,0 +1,32 @@
+# Learning: Agent hallucinated author name from org/company name context
+
+## Problem
+
+The blog author name in `plugins/soleur/docs/_data/site.json` was set to "Jean Jikig" -- a hallucinated name that combined the founder's first name "Jean" with the company name "Jikigai" (from the GitHub org `jikig-ai`). This incorrect name appeared on all blog posts, in BlogPosting JSON-LD structured data, and in the Atom feed.
+
+## Root Cause
+
+The `docs-site` skill template (`plugins/soleur/skills/docs-site/SKILL.md`) did not include an `author` field in its `site.json` template. When blog infrastructure was added later, the agent inferred the author name from available context (GitHub org name, company name) rather than asking the user explicitly. The inference produced a plausible but fabricated name.
+
+## Solution
+
+1. Changed `site.json` author name from "Jean Jikig" to "Jean Deruelle"
+2. Added `author` field (name + url) to the `docs-site` skill's `site.json` template so future scaffolding asks for it explicitly
+3. Added "Author name" as item #3 in the docs-site skill's "Gather Project Info" step
+
+## Key Insight
+
+Personal names are proper identity data that should never be inferred from org names, GitHub handles, email prefixes, company names, or URL slugs. Any derivation is a hallucination risk. When a task requires a person's name, either read it from a canonical source or ask the user explicitly. A missing field is always less harmful than a fabricated one.
+
+## Prevention Strategies
+
+- Add a `## Founder` section to the brand guide with the canonical name, so content-generating skills have an authoritative source
+- Content-generating skills (content-writer, social-distribute) should read `site.author.name` from `site.json` rather than inferring
+- The `seo-aeo` audit should validate author field values against `site.json`, not just check for presence
+- Scaffold templates should treat author/personal-name fields as required inputs, never optional with agent-derived defaults
+
+## Tags
+
+category: content-quality
+module: docs-site
+severity: medium

--- a/plugins/soleur/docs/_data/site.json
+++ b/plugins/soleur/docs/_data/site.json
@@ -22,7 +22,7 @@
     { "label": "Changelog", "url": "pages/changelog.html" }
   ],
   "author": {
-    "name": "Jean Jikig",
+    "name": "Jean Deruelle",
     "url": "https://soleur.ai"
   },
   "footerLinks": [

--- a/plugins/soleur/skills/docs-site/SKILL.md
+++ b/plugins/soleur/skills/docs-site/SKILL.md
@@ -18,9 +18,10 @@ Ask the user:
 
 1. **Project name** -- Used in site title, footer, nav logo
 2. **Site URL** -- For meta tags, sitemap, og:url (e.g., `https://example.com`)
-3. **Docs input directory** -- Where docs source files live (e.g., `docs/`)
-4. **GitHub repository URL** -- For nav link and deployment
-5. **Pages to create** -- Which pages beyond index (e.g., getting-started, changelog, API reference)
+3. **Author name** -- For blog attribution, structured data, and E-E-A-T signals (e.g., `Jean Deruelle`)
+4. **Docs input directory** -- Where docs source files live (e.g., `docs/`)
+5. **GitHub repository URL** -- For nav link and deployment
+6. **Pages to create** -- Which pages beyond index (e.g., getting-started, changelog, API reference)
 
 ## Step 2: Install Dependencies
 
@@ -91,6 +92,10 @@ Add `_site/` to `.gitignore`.
 {
   "name": "<Project Name>",
   "url": "<site-url>",
+  "author": {
+    "name": "<Author Name>",
+    "url": "<site-url>"
+  },
   "nav": [
     { "label": "Get Started", "url": "pages/getting-started.html" }
   ]
@@ -100,6 +105,7 @@ Add `_site/` to `.gitignore`.
 ### `_includes/base.njk`
 
 Create a minimal HTML shell with:
+
 - Head: charset, viewport, description meta, title, CSS link
 - Header: logo linking to index.html, nav from `site.nav`
 - Main: `{{ content | safe }}`
@@ -191,6 +197,7 @@ npx @11ty/eleventy --serve
 ```
 
 Open `http://localhost:8080` and verify:
+
 - All pages render correctly
 - CSS loads
 - Navigation works with `aria-current="page"`


### PR DESCRIPTION
## Summary

- Fix blog author name from hallucinated "Jean Jikig" to "Jean Deruelle" in `site.json`
- Add `author` field to `docs-site` skill template so future scaffolding asks for it explicitly
- Add `## Founder` section to brand guide as canonical source for content-generating skills

## Why

The `docs-site` skill template omitted an author field from `site.json`. When blog infrastructure was added, the agent inferred "Jean Jikig" by combining the founder's first name with the company name "Jikigai" — a hallucinated name that appeared on all blog posts, JSON-LD, and the Atom feed.

## Changelog

- **fix:** Corrected blog author name from "Jean Jikig" to "Jean Deruelle"
- **fix:** Added author field to docs-site skill template to prevent inference
- **docs:** Added Founder section to brand guide as canonical name source
- **docs:** Added learning about agent hallucination of personal names from org context

## Test plan

- [x] Eleventy build passes (38 files, no errors)
- [x] Built HTML contains "Jean Deruelle" in blog post author attribution
- [x] All pre-commit hooks pass (markdown-lint, plugin-component-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)