### PR TITLE
fix: add claude commit identity to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -31,7 +31,7 @@ jobs:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://soleur.ai/pages/legal/individual-cla.html"
           branch: "cla-signatures"
-          allowlist: "dependabot[bot],github-actions[bot],renovate[bot],deruelle,app/claude"
+          allowlist: "dependabot[bot],github-actions[bot],renovate[bot],deruelle,app/claude,claude"
           custom-notsigned-prcomment: |
             Thank you for your contribution! Before we can accept it, you need to sign our [Contributor License Agreement](https://soleur.ai/pages/legal/individual-cla.html).
 


### PR DESCRIPTION
## Summary

- Cloud tasks commit as `claude` (noreply@anthropic.com), not `app/claude`
- CLA check validates commit authors, not PR authors
- This fixes CLA failures on all Cloud scheduled task PRs (#1099, #1097)

## Changelog

- Added `claude` to CLA allowlist alongside existing `app/claude` and `deruelle`

## Test plan

- [ ] Retrigger CLA on PR #1099 after merge — should pass

Generated with [Claude Code](https://claude.com/claude-code)