### PR TITLE
feat(content): auto-generate article 2026-03-24

### DIFF
--- a/knowledge-base/marketing/distribution-content/ai-agents-for-solo-founders.md
+++ b/knowledge-base/marketing/distribution-content/ai-agents-for-solo-founders.md
@@ -1,0 +1,135 @@
+---
+title: "AI Agents for Solo Founders: The Definitive Guide"
+type: pillar
+publish_date: ""
+channels: discord, x, bluesky, linkedin-company
+status: draft
+---
+
+## Discord
+
+The solo founder's AI stack breaks at 1 domain. New article: the 8 domains every company needs, why point solutions plateau, and how compound knowledge changes the equation.
+
+Every function that isn't engineering is still manual for most solo founders. Legal can't reference what marketing published. Marketing doesn't reflect what engineering decided. Each tool starts from a blank slate.
+
+Agentic engineering fixes this: 63 agents, 9 departments, one knowledge base that compounds with every task. The legal agent knows what the product spec says. The marketing brief reflects the latest engineering decisions.
+
+The guide covers:
+→ What makes an AI agent (vs. a fast chatbot)
+→ The 8 domains a solo company needs covered
+→ Why cross-domain context matters more than individual agent capability
+→ Compound knowledge in practice
+
+Read: https://soleur.ai/blog/ai-agents-for-solo-founders/?utm_source=discord&utm_medium=community&utm_campaign=ai-agents-for-solo-founders
+
+---
+
+## X/Twitter Thread
+
+**Tweet 1 (hook):** Most solopreneur AI tools solve one domain. Running a company requires eight. That gap is the plateau every solo founder eventually hits. (139/280 chars)
+
+**Tweet 2:** 2/ The 8 domains: engineering, product, marketing, legal, finance, operations, sales, support. A coding tool handles one. The other seven stay manual until agents share a knowledge base. (187/280 chars)
+
+**Tweet 3:** 3/ Cross-domain context is the deciding factor. The marketing agent should know what engineering decided. Legal should reference what marketing published. Without this, you have faster tools — not an organization. (211/280 chars)
+
+**Tweet 4:** 4/ Compound knowledge closes the gap. Each task generates a learning. Each learning routes back into domain rules. After 100 tasks, the system is structurally better than after 10. That doesn't happen with session-based tools. (228/280 chars)
+
+**Tweet 5 (CTA):** 5/ Definitive guide: what makes a real agent, the 8 domains, how to start, and what a full AI organization looks like in practice.
+
+https://soleur.ai/blog/ai-agents-for-solo-founders/?utm_source=x&utm_medium=social&utm_campaign=ai-agents-for-solo-founders
+
+#solofounder (164/280 chars)
+
+---
+
+## IndieHackers
+
+**Title:** I wrote the definitive guide to AI agents for solo founders
+
+**Body:**
+
+Running Soleur as a solo founder means I think about this constantly: most AI tools solve one function. Running a company needs eight.
+
+The new article covers what I've learned building an AI organization with 63 agents across 9 departments:
+
+- What actually makes an AI agent vs. a chatbot with extra steps
+- The 8 domains every company needs covered (and why most founders only have 1-2)
+- Why cross-domain context matters more than any individual agent capability
+- How compound knowledge works in practice (the loop that makes agents measurably better over time)
+
+The hardest insight: the value isn't in the agents themselves. It's in the connections between them. A legal agent that knows what marketing published is worth 10x a legal agent that doesn't.
+
+Building in public here. All questions welcome.
+
+https://soleur.ai/blog/ai-agents-for-solo-founders/?utm_source=indiehackers&utm_medium=community&utm_campaign=ai-agents-for-solo-founders
+
+---
+
+## Reddit
+
+**Subreddit:** r/SaaS, r/solopreneur, r/startups, r/artificial
+**Title:** Why most AI tools plateau for solo founders (and what actually fixes it)
+
+**Body:**
+
+Running a company solo means you need coverage across 8 domains: engineering, product, marketing, legal, finance, ops, sales, and support.
+
+Most AI tools cover one. The rest stay manual.
+
+After spending months building an AI organization that covers all 8, the key insight wasn't about individual AI capability — it was about cross-domain context. A marketing tool that doesn't know what engineering decided, a legal tool that doesn't reference the product spec — they're faster tools, not an organization.
+
+What changed things: agents that share a knowledge base. Each task generates a learning. Each learning routes back into the domain's rules. After 100 tasks, the system is structurally better than after 10.
+
+Wrote up the full breakdown here if anyone's working on similar problems: https://soleur.ai/blog/ai-agents-for-solo-founders/?utm_source=reddit
+
+---
+
+## Hacker News
+
+**Title:** AI agents for solo founders: the 8-domain problem and compound knowledge (73/80 chars)
+**URL:** https://soleur.ai/blog/ai-agents-for-solo-founders/?utm_source=hackernews&utm_medium=community&utm_campaign=ai-agents-for-solo-founders
+
+---
+
+## LinkedIn Personal
+
+Most AI tools solve 30% of running a company. The rest — legal, marketing, finance, ops, sales, support — stays manual.
+
+I built Soleur to close that gap: 63 agents across 9 departments, sharing a knowledge base that compounds with every task. Here's what I've learned about why cross-domain context matters more than any individual agent capability.
+
+The insight that changed how I think about this: the value isn't in the agents themselves. It's in the connections between them.
+
+A legal agent that knows what the marketing team published is worth 10x a legal agent that operates in isolation. A marketing brief that automatically reflects the latest engineering decisions is more useful than one the founder has to manually sync. The connection is where the leverage lives.
+
+Most solopreneur AI tool stacks are collections of fast tools, not organizations. They perform the same function at the same level indefinitely. An agent stack that compounds — where every task generates a learning that improves the next one — is a fundamentally different thing.
+
+I wrote the full breakdown for founders thinking through this:
+
+https://soleur.ai/blog/ai-agents-for-solo-founders/?utm_source=linkedin-personal&utm_medium=social&utm_campaign=ai-agents-for-solo-founders
+
+#solofounder #AIagents
+
+---
+
+## LinkedIn Company Page
+
+Running a company solo means covering 8 domains: engineering, product, marketing, legal, finance, operations, sales, and support. Most AI tools cover one.
+
+Soleur's new definitive guide for solo founders breaks down:
+
+- What makes a true AI agent (vs. a faster chatbot)
+- The 8 domains every company needs covered
+- Why cross-domain context matters more than individual agent capability
+- How compound knowledge works in practice: 63 agents, 9 departments, one knowledge base that improves with every task
+
+The guide is for founders who have seen what AI can do for one function and want to understand what it means to run an entire company with agents.
+
+Read the full guide: https://soleur.ai/blog/ai-agents-for-solo-founders/?utm_source=linkedin-company&utm_medium=social&utm_campaign=ai-agents-for-solo-founders
+
+#solofounder #AIagents
+
+---
+
+## Bluesky
+
+Solo founders hit the same plateau: AI solves one domain. Running a company needs 8. New guide: what makes agents compound vs. plateau, the 8-domain problem, and how to start. soleur.ai/blog/ai-agents-for-solo-founders/?utm_source=bluesky&utm_medium=social&utm_campaign=ai-agents-for-solo-founders (281/300 chars)

--- a/knowledge-base/marketing/seo-refresh-queue.md
+++ b/knowledge-base/marketing/seo-refresh-queue.md
@@ -122,7 +122,7 @@ Pages that do not exist but should, based on keyword research and competitive po
 | **What Is Company-as-a-Service?** | company as a service, CaaS platform | Informational | P1 | **PUBLISHED** (SAP 5.0/5.0) |
 | **Why Most Agentic Tools Plateau** | agentic engineering, compound knowledge | Informational | P1 | **PUBLISHED** (SAP 4.8/5.0) |
 | **Vibe Coding vs Agentic Engineering** | vibe coding vs agentic engineering, agentic coding | Informational | P1 | Month 1. Audit P2-1, score 18/20. generated_date: 2026-03-24 |
-| **AI Agents for Solo Founders: The Definitive Guide** | AI agents for solo founders, solopreneur AI tools 2026 | Commercial | P1 | Month 1-2. Audit P2-2, score 18/20. |
+| **AI Agents for Solo Founders: The Definitive Guide** | AI agents for solo founders, solopreneur AI tools 2026 | Commercial | P1 | Month 1-2. Audit P2-2, score 18/20. generated_date: 2026-03-24 |
 | **One-Person Billion-Dollar Company** | one person billion dollar company, solo founder AI | Informational | P2 | Month 2. |
 | **Knowledge Compounding in AI Development** | knowledge compounding AI, compound engineering | Informational | P2 | Month 2-3. |
 

--- a/knowledge-base/project/learnings/2026-03-24-content-generator-pipeline-learnings.md
+++ b/knowledge-base/project/learnings/2026-03-24-content-generator-pipeline-learnings.md
@@ -1,0 +1,28 @@
+# Learning: Content Generator Pipeline — Skill Invocation and Blog Date Formats
+
+## Problem
+
+The automated content generator pipeline invoked `soleur:content-writer`, `soleur:social-distribute`, and `soleur:compound` via the `Skill tool`, receiving `Unknown skill` errors for all three. Additionally, the Eleventy build failed on the first attempt due to a quoted date string in blog post frontmatter.
+
+## Solution
+
+1. **Skill invocation:** Read the SKILL.md file at `plugins/soleur/skills/<skill-name>/SKILL.md` and execute the instructions directly. The `Skill tool` only resolves skills registered with the Claude Code harness — plugin skills defined as markdown instruction files must be executed inline.
+2. **Blog date format:** Use unquoted YAML date literals in frontmatter: `date: 2026-03-24`, not `date: "2026-03-24"`. Eleventy's `dateToRfc3339` filter requires a JavaScript Date object, which YAML produces for unquoted ISO dates but not for quoted strings.
+3. **Worktree from bare repo:** After creating a worktree with `git worktree add`, run `git fetch origin main && git merge origin/main` to ensure the worktree is at the latest commit. The local `master` branch may be stale if only `origin/main` has been updated.
+
+## Key Insight
+
+Plugin skills (SKILL.md files) are instruction documents for the agent, not registered CLI commands. The Skill tool only works for skills registered in the harness (like built-in Soleur skills). For plugin-level skills, the agent must read the file and follow it directly.
+
+## Session Errors
+
+1. **`Unknown skill: soleur:content-writer`** — Recovery: Read SKILL.md directly and followed instructions. Prevention: In automated pipelines, never invoke plugin skills via `Skill tool`; read and execute SKILL.md inline.
+2. **`Unknown skill: soleur:social-distribute`** — Same as above.
+3. **`Unknown skill: soleur:compound`** — Same as above.
+4. **Eleventy build failure: `dateObj.toISOString is not a function`** — Recovery: Removed quotes from `date` frontmatter field. Prevention: Blog post frontmatter must use unquoted YAML date literals for `date` fields.
+5. **Worktree at stale commit** — Recovery: `git fetch origin main && git merge origin/main`. Prevention: After creating worktree from bare repo, always fetch and merge origin/main before writing files.
+
+## Tags
+
+category: pipeline
+module: content-generator, skills, eleventy

--- a/plugins/soleur/docs/blog/2026-03-24-ai-agents-for-solo-founders.md
+++ b/plugins/soleur/docs/blog/2026-03-24-ai-agents-for-solo-founders.md
@@ -1,0 +1,211 @@
+---
+title: "AI Agents for Solo Founders: The Definitive Guide"
+date: 2026-03-24
+description: "The complete guide to AI agents for solo founders in 2026. What makes a true AI agent, the 8 domains every company needs, and why compound knowledge is the only path to solo-founder scale."
+tags:
+  - ai-agents
+  - solo-founder
+  - solopreneur
+  - agentic-engineering
+  - company-as-a-service
+---
+
+Most solo founders discover AI tools the same way: a demo of something that writes code, generates copy, or drafts a legal template. It saves an hour. Then two. Then the plateau arrives.
+
+The problem is not the tools. The problem is that running a company requires eight distinct domains — engineering, marketing, legal, finance, operations, product, sales, and support — and a collection of single-function tools never adds up to a working organization.
+
+AI agents are different. An agent does not wait for prompts. It operates with a goal, uses tools to execute, and works alongside other agents toward a shared objective. For a solo founder, the difference is the difference between a faster keyboard and an actual organization.
+
+This guide is for founders who have moved past the demo. You have seen what AI can do for one function. Now you want to understand what it means to run an entire company with agents — and what separates the approaches that scale from the ones that plateau.
+
+## What Makes an AI Agent Different
+
+A chatbot answers a question. An AI agent completes a task.
+
+The distinction sounds semantic until you try to ship something. A chatbot can explain how to write a terms of service. An agent writes the terms of service, checks it against your jurisdiction's requirements, flags clauses for review, and files a task to revisit it when regulations change. The output is not a response — it is a work product.
+
+Four properties define a true agent:
+
+**Goal-orientation.** The agent has a defined outcome, not just a prompt. It knows what done looks like and works toward it.
+
+**Tool use.** The agent can read files, write code, search the web, make API calls, and coordinate with other agents. It is not limited to generating text.
+
+**Memory.** The agent can access context from previous sessions — prior decisions, known constraints, existing work products, and accumulated learnings.
+
+**Accountability.** The agent's output can be verified against a specification. This matters more for solo founders than for teams, because there is no one else checking. An agent without an accountability mechanism is a sophisticated autocomplete.
+
+## The Eight Domains of a Company
+
+Running a company requires expertise across eight distinct domains. No founder — and no AI tool — is competent in all eight from day one. The question is how you close the gaps.
+
+**Engineering** builds and ships the product. Code review, architecture decisions, infrastructure provisioning, test coverage, release management.
+
+**Product** translates user need into specification. Feature prioritization, user research, UX decisions, business validation, roadmap management.
+
+**Marketing** creates demand. Brand voice, content strategy, SEO, social distribution, competitive positioning.
+
+**Legal** manages exposure. Contract drafting, compliance monitoring, privacy policy, terms of service, IP protection, regulatory updates.
+
+**Finance** models the business. Revenue forecasting, expense tracking, burn rate, unit economics, pricing decisions.
+
+**Operations** keeps the machine running. Vendor management, process documentation, tooling reliability, infrastructure maintenance.
+
+**Sales** converts attention into revenue. Outbound strategy, pipeline management, deal architecture, revenue operations.
+
+**Support** retains customers and closes the feedback loop. Ticket triage, community management, knowledge base maintenance.
+
+A solo founder with a collection of coding tools has handled one domain. The other seven are still manual.
+
+## Why Point Solutions Fail
+
+The promise of solopreneur AI tools is speed. A code generator writes code faster. A copywriting tool drafts faster. A contract template saves legal fees. Each tool delivers on its narrow promise.
+
+What they cannot deliver is coordination.
+
+Legal cannot reference what marketing published. Marketing cannot reflect what engineering decided. Engineering cannot anticipate what compliance requires. Each domain operates in isolation, which means the same decision gets made — and sometimes reversed — across multiple contexts without any of them knowing.
+
+This is not a workflow problem. It is an architecture problem. Point solutions are stateless by design. They begin fresh with each session, in each domain, with each tool. The knowledge one function generates never reaches the others.
+
+For a team, this is manageable. Team members talk. A senior engineer remembers the architectural decisions that constrained the marketing roadmap. The legal counsel reads the product brief before drafting the contract. The institutional memory lives in people.
+
+A solo founder has none of that coordination infrastructure. Every handoff between domains requires the founder to carry the context manually. As the company grows, the cost of those handoffs grows with it.
+
+## What to Look For in AI Agents
+
+Not every AI agent is useful for a solo founder. The properties that matter most differ from what matters in enterprise deployments.
+
+**Cross-domain context.** The most important question to ask about any AI agent stack: what does the marketing agent know about what the engineering agent decided last week? If the answer is "nothing," you have a collection of tools, not an organization.
+
+**Persistent knowledge.** Agents that start from a blank slate on each session require the founder to re-supply context manually every time. Agents with persistent memory across sessions accumulate knowledge and reduce the founder's coordination cost over time. This distinction compounds — a system that remembers three months of decisions is dramatically more useful than one that forgets at session end.
+
+**Verifiable output.** An agent's output should be checkable against a specification. Quality gates built into the workflow replace the code review, legal review, and editorial review that a team provides. Without those gates, the founder becomes the bottleneck for every domain, every time.
+
+**Compound improvement.** The most valuable agents get better with use. Each task generates a learning. Each learning routes back into the system's rules. Each subsequent task starts from a more informed baseline. An agent that performs at the same level after 100 tasks as it did after 10 is a tool with a more complicated interface.
+
+## The Compound Knowledge Advantage
+
+The gap between a useful AI stack and a scalable one comes down to what happens to knowledge after a task is complete.
+
+Most AI tools discard it. The session ends. The output remains. The reasoning that produced the output — the decisions made, the tradeoffs considered, the edge cases encountered — disappears.
+
+[Compound knowledge]({{ site.url }}/blog/why-most-agentic-tools-plateau/) captures it. Every task generates a learning. The learning is routed to the domain where it belongs — engineering rules, marketing constraints, legal requirements. The next task in that domain starts with that learning already incorporated.
+
+For a solo founder, compound knowledge solves the coordination problem that point solutions cannot. When the legal agent captures a compliance requirement, it does not just document it — it enforces it in every future task that touches the affected domain. When the engineering agent learns that a particular integration is fragile, every future task that depends on it starts with that warning already in place.
+
+Over time, the AI organization does not just remember more. It makes better decisions, catches more edge cases, and requires less founder intervention. The founder's job shifts from doing and coordinating to deciding and directing.
+
+This is why [agentic engineering]({{ site.url }}/blog/vibe-coding-vs-agentic-engineering/) matters more for solo founders than for anyone else. A system that gets smarter with each task is not a convenience — it is the only path to building at company scale without a company.
+
+## What a Full AI Organization Looks Like
+
+[Company-as-a-Service]({{ site.url }}/blog/what-is-company-as-a-service/) is the model where a single AI organization covers all eight domains with agents that share a compounding knowledge base.
+
+In practice, this means:
+
+- An engineering review that checks code against the product spec, the legal constraints, and the compliance requirements — simultaneously, without the founder acting as the relay
+- A marketing brief that automatically reflects the latest competitive intelligence from the product and engineering teams
+- A contract draft that incorporates the business model, jurisdiction requirements, and pricing decisions already captured in the knowledge base
+- A financial report that draws on operational data, sales pipeline, and engineering velocity to produce an accurate view of the business
+
+Each of these is an agent operating within shared context. The result is an organization that behaves coherently across domains — not because the founder coordinated the handoffs, but because the knowledge base did.
+
+Soleur is built on this model: 61 agents across 8 departments, sharing a knowledge base that compounds with every task completed.
+
+## Getting Started
+
+The path from solo founder to AI organization does not begin with replacing all your tools at once. It begins with establishing the knowledge layer.
+
+**Step 1: Define your knowledge base.** Document what your company knows: the architecture decisions, the brand voice, the legal constraints, the pricing model. This is the ground truth every agent reads from and writes to.
+
+**Step 2: Start with one domain.** Pick the domain where manual work costs you the most. Engineering is the natural starting point for technical founders, but marketing, legal, and finance are equally valid entry points. Deploy agents there first. Let the knowledge compound.
+
+**Step 3: Connect the domains.** Once one domain is running, introduce the adjacent ones. The key is ensuring agents share context — a marketing agent that knows what engineering decided, a legal agent that knows what marketing published. The connections matter more than the individual capabilities.
+
+**Step 4: Build the feedback loop.** Every task should generate a learning. Every learning should route back into the relevant domain's rules. The system should be measurably more effective after 100 tasks than after 10.
+
+The goal is not AI tools that make you faster today. It is an AI organization that makes you more capable every month.
+
+[Start building →]({{ site.url }})
+
+## Frequently Asked Questions
+
+### What is an AI agent for a solo founder?
+
+An AI agent is a system that operates with a defined goal, uses tools to complete tasks, maintains memory across sessions, and can be verified against a specification. For solo founders, agents replace team functions that a single person cannot fill alone — code review, legal review, marketing execution, financial modeling — while sharing context across all domains so the organization behaves coherently.
+
+### How are AI agents different from AI tools like chatbots or coding assistants?
+
+Most AI tools are session-based and single-function. They generate responses to prompts but do not maintain memory, execute multi-step workflows, or coordinate with other tools. AI agents are designed to complete tasks, not just answer questions. The best agents accumulate knowledge over time so each subsequent task benefits from everything the system has previously learned.
+
+### What are the most important solopreneur AI tools in 2026?
+
+The highest-leverage agents cover the functions a solo founder cannot easily replicate: code review, legal document generation, competitive intelligence monitoring, financial modeling, and marketing execution. But individual agent capability matters less than cross-domain coordination. An agent stack where each domain shares context with the others compounds faster than a collection of specialized tools that cannot communicate.
+
+### How does compound knowledge work in practice?
+
+Compound knowledge means every task generates a learning, and every learning is routed back into the relevant domain's rules or constraints. If the legal agent learns your jurisdiction requires a specific clause in employment agreements, that requirement is captured and applied to every future contract automatically. If the engineering agent encounters a fragile integration, that knowledge is documented and every future task touching the same integration starts with the warning already in place. The system improves structurally, not just incrementally.
+
+### Is Soleur only for technical founders?
+
+No. Soleur covers all eight departments of a company — engineering, marketing, legal, finance, operations, product, sales, and support. Many founders start with the engineering domain, but legal, marketing, finance, and product agents operate independently and compound knowledge in their own domains. A founder with no engineering background can start with marketing or legal and build from there.
+
+### How do I get started with AI agents as a solo founder?
+
+Start by defining your knowledge base: the decisions you have made, the constraints you operate within, the brand voice you want to maintain. Then deploy agents in the domain where manual work costs you the most. Connect domains as you add them, ensuring agents share context. Build the feedback loop so every task generates a learning that improves the next one. The goal is an AI organization that compounds — not a set of tools performing the same function at the same level indefinitely.
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is an AI agent for a solo founder?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "An AI agent is a system that operates with a defined goal, uses tools to complete tasks, maintains memory across sessions, and can be verified against a specification. For solo founders, agents replace team functions that a single person cannot fill alone — code review, legal review, marketing execution, financial modeling — while sharing context across all domains so the organization behaves coherently."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How are AI agents different from AI tools like chatbots or coding assistants?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Most AI tools are session-based and single-function. They generate responses to prompts but do not maintain memory, execute multi-step workflows, or coordinate with other tools. AI agents are designed to complete tasks, not just answer questions. The best agents accumulate knowledge over time so each subsequent task benefits from everything the system has previously learned."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What are the most important solopreneur AI tools in 2026?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The highest-leverage agents cover the functions a solo founder cannot easily replicate: code review, legal document generation, competitive intelligence monitoring, financial modeling, and marketing execution. Individual agent capability matters less than cross-domain coordination — an agent stack where each domain shares context with the others compounds faster than specialized tools that cannot communicate."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does compound knowledge work in practice?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Compound knowledge means every task generates a learning, and every learning is routed back into the relevant domain's rules or constraints. If the legal agent learns a specific compliance requirement, it is applied to every future task in that domain automatically. If the engineering agent encounters a fragile integration, every future task touching it starts with that warning already in place. The system improves structurally, not just incrementally."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Soleur only for technical founders?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Soleur covers all eight departments of a company — engineering, marketing, legal, finance, operations, product, sales, and support. Many founders start with the engineering domain, but legal, marketing, finance, and product agents operate independently and compound knowledge in their own domains."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I get started with AI agents as a solo founder?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Start by defining your knowledge base: the decisions you have made, the constraints you operate within, the brand voice you want to maintain. Then deploy agents in the domain where manual work costs you the most. Connect domains as you add them, ensuring agents share context. Build the feedback loop so every task generates a learning that improves the next one."
+      }
+    }
+  ]
+}
+</script>


### PR DESCRIPTION
## Summary

- Add P1 pillar blog post: **AI Agents for Solo Founders: The Definitive Guide** (`/blog/ai-agents-for-solo-founders/`) — covers 8-domain problem, compound knowledge, FAQPage JSON-LD, UTM-tagged social links
- Add distribution content file with Discord, X/Twitter, IndieHackers, Reddit, HN, LinkedIn, Bluesky variants
- Mark `generated_date: 2026-03-24` in SEO queue for this entry
- Add compound learning: content generator pipeline errors and fixes

## Changelog

- **feat:** new blog article `2026-03-24-ai-agents-for-solo-founders.md` (P1, score 18/20)
- **feat:** distribution content `ai-agents-for-solo-founders.md` (channels: discord, x, bluesky, linkedin-company queued for cron)
- **fix:** SEO queue `generated_date` annotation applied

## Validation

- Eleventy build: ✅ PASS (40 files)
- Blog link validation: ✅ PASS (all links valid)
- Citation verification: ⚠️ skipped (fact-checker agent unavailable)

Closes #1102

Automated commit from content generator.

https://claude.ai/code/session_012VBSLdp8PNCCGre6tcndV5