### PR TITLE
fix: re-enable community-monitor GHA with Doppler secrets

### DIFF
--- a/.github/workflows/scheduled-community-monitor.yml
+++ b/.github/workflows/scheduled-community-monitor.yml
@@ -16,10 +16,8 @@ name: "Scheduled: Community Monitor"
 
 on:
   workflow_dispatch:
-  # MIGRATED TO CLOUD SCHEDULED TASK — 2026-03-25
-  # Uncomment schedule to revert to GHA execution
-  # schedule:
-  #   - cron: '0 8 * * *'
+  schedule:
+    - cron: '0 8 * * *'
 
 concurrency:
   group: schedule-community-monitor
@@ -48,21 +46,21 @@ jobs:
             --description "Daily community monitoring report" \
             --color "0E8A16" 2>/dev/null || true
 
+      - name: Inject Doppler secrets
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+        run: |
+          curl -Ls https://cli.doppler.com/install.sh | sh
+          doppler secrets download --project soleur --config prd_scheduled --no-file --format env-no-quotes | while IFS='=' read -r key value; do
+            [ -z "$key" ] && continue
+            printf '::add-mask::%s\n' "$value"
+            printf '%s=%s\n' "$key" "$value" >> "$GITHUB_ENV"
+          done
+
       - name: Run community monitor
         uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1.0.75
         env:
           GH_TOKEN: ${{ github.token }}
-          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
-          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          X_API_KEY: ${{ secrets.X_API_KEY }}
-          X_API_SECRET: ${{ secrets.X_API_SECRET }}
-          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
-          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
-          LINKEDIN_ACCESS_TOKEN: ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
-          LINKEDIN_PERSON_URN: ${{ secrets.LINKEDIN_PERSON_URN }}
-          BSKY_HANDLE: ${{ secrets.BSKY_HANDLE }}
-          BSKY_APP_PASSWORD: ${{ secrets.BSKY_APP_PASSWORD }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: 'https://github.com/jikig-ai/soleur.git'


### PR DESCRIPTION
## Summary

- Re-enable community-monitor GHA schedule (reverted from Cloud task — secrets can't be securely handled in Cloud)
- Switch from 12 individual GHA secrets to Doppler `prd_scheduled` config
- Doppler CLI installed at runtime, all secrets masked via `::add-mask::`

## Changelog

- Re-enabled `schedule:` trigger for community-monitor
- Replaced 12 individual `${{ secrets.* }}` env vars with Doppler CLI injection step
- Added `::add-mask::` for all Doppler-fetched values

## Test plan

- [ ] Trigger via `gh workflow run scheduled-community-monitor.yml` after merge
- [ ] Verify all 6 platforms produce data in the digest

Generated with [Claude Code](https://claude.com/claude-code)