### PR TITLE
fix: community-monitor Doppler CLI action + remove Discord notification

### DIFF
--- a/.github/workflows/scheduled-community-monitor.yml
+++ b/.github/workflows/scheduled-community-monitor.yml
@@ -46,11 +46,13 @@ jobs:
             --description "Daily community monitoring report" \
             --color "0E8A16" 2>/dev/null || true
 
+      - name: Install Doppler CLI
+        uses: DopplerHQ/cli-action@014df23b1329b615816a38eb5f473bb9000700b1 # v3
+
       - name: Inject Doppler secrets
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: |
-          curl -Ls https://cli.doppler.com/install.sh | sh
           doppler secrets download --project soleur --config prd_scheduled --no-file --format env-no-quotes | while IFS='=' read -r key value; do
             [ -z "$key" ] && continue
             printf '::add-mask::%s\n' "$value"
@@ -137,32 +139,5 @@ jobs:
                with label "scheduled-community-monitor". Include a condensed summary:
                platform status, key metrics, notable items, and a link to the digest file.
 
-      - name: Discord notification (failure)
-        if: failure()
-        env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
-        run: |
-          if [[ -z "$DISCORD_WEBHOOK_URL" ]]; then
-            echo "DISCORD_WEBHOOK_URL not set, skipping failure notification"
-            exit 0
-          fi
-
-          RUN_URL="${REPO_URL}/actions/runs/${RUN_ID}"
-          MESSAGE=$(printf '**Community Monitor failed**\n\nWorkflow run: %s\n\nCheck logs for details.' \
-            "$RUN_URL")
-          PAYLOAD=$(jq -n \
-            --arg content "$MESSAGE" \
-            --arg username "Sol" \
-            --arg avatar_url "https://raw.githubusercontent.com/jikig-ai/soleur/main/plugins/soleur/docs/images/logo-mark-512.png" \
-            '{content: $content, username: $username, avatar_url: $avatar_url, allowed_mentions: {parse: []}}')
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD" \
-            "$DISCORD_WEBHOOK_URL")
-          if [[ "$HTTP_CODE" =~ ^2 ]]; then
-            echo "Discord failure notification sent (HTTP $HTTP_CODE)"
-          else
-            echo "::warning::Discord failure notification failed (HTTP $HTTP_CODE)"
-          fi
+      # Failure notifications: GitHub sends email on workflow failure.
+      # Discord community notifications removed per #1094 brainstorm decision.


### PR DESCRIPTION
## Summary

- Use `DopplerHQ/cli-action` (SHA-pinned) instead of `curl install.sh` (requires sudo)
- Remove Discord community server failure notification (GitHub email suffices)

## Changelog

- Replaced `curl -Ls https://cli.doppler.com/install.sh | sh` with `DopplerHQ/cli-action@v3`
- Removed 30-line Discord failure notification step

## Test plan

- [ ] Trigger `gh workflow run scheduled-community-monitor.yml` after merge
- [ ] Verify Doppler secrets inject correctly (all 6 platforms produce data)

Generated with [Claude Code](https://claude.com/claude-code)