### PR TITLE
fix(pricing): use full URL in waitlist anchor links (#1139)

### DIFF
--- a/plugins/soleur/docs/pages/pricing.njk
+++ b/plugins/soleur/docs/pages/pricing.njk
@@ -187,7 +187,7 @@ ogImageAlt: "Soleur Pricing — Every department. One price."
               <li>Email support</li>
             </ul>
             <span class="pricing-card-badge">Coming Soon</span>
-            <a href="#waitlist" class="btn btn-secondary pricing-card-cta">Join the Waitlist</a>
+            <a href="pages/pricing.html#waitlist" class="btn btn-secondary pricing-card-cta">Join the Waitlist</a>
           </div>
 
           <div class="pricing-card">
@@ -202,7 +202,7 @@ ogImageAlt: "Soleur Pricing — Every department. One price."
               <li>Shared knowledge base</li>
             </ul>
             <span class="pricing-card-badge">Coming Soon</span>
-            <a href="#waitlist" class="btn btn-secondary pricing-card-cta">Join the Waitlist</a>
+            <a href="pages/pricing.html#waitlist" class="btn btn-secondary pricing-card-cta">Join the Waitlist</a>
           </div>
 
           <div class="pricing-card">
@@ -217,7 +217,7 @@ ogImageAlt: "Soleur Pricing — Every department. One price."
               <li>Custom agent configuration</li>
             </ul>
             <span class="pricing-card-badge">Coming Soon</span>
-            <a href="#waitlist" class="btn btn-secondary pricing-card-cta">Join the Waitlist</a>
+            <a href="pages/pricing.html#waitlist" class="btn btn-secondary pricing-card-cta">Join the Waitlist</a>
           </div>
 
           <div class="pricing-card">


### PR DESCRIPTION
## Summary

- Fix waitlist anchor links on pricing page tier cards that navigated to homepage instead of scrolling to the waitlist form section
- The `<base href="/">` tag in base.njk causes fragment-only hrefs (`#waitlist`) to resolve relative to `/`, navigating away from the pricing page
- Changed `href="#waitlist"` to `href="pages/pricing.html#waitlist"` on all tier card CTAs

Closes #1139

## Changelog

- Fixed "Join the Waitlist" links on Solo, Startup, and Scale tier cards to correctly scroll to the waitlist form section instead of navigating to the homepage

## Test plan

- [x] Browser tested: clicking "Join the Waitlist" on Solo tier stays on pricing page and scrolls to #waitlist section
- [x] Verified URL changes to `pages/pricing.html#waitlist` (not `/#waitlist`)

Generated with [Claude Code](https://claude.com/claude-code)