### PR TITLE
fix(docs): move Pricing first in nav, fix self-hosted anchor link

### DIFF
--- a/plugins/soleur/docs/_data/site.json
+++ b/plugins/soleur/docs/_data/site.json
@@ -13,10 +13,10 @@
     "username": "soleur"
   },
   "nav": [
+    { "label": "Pricing", "url": "pages/pricing.html" },
     { "label": "Get Started", "url": "pages/getting-started.html" },
     { "label": "Agents", "url": "pages/agents.html" },
     { "label": "Skills", "url": "pages/skills.html" },
-    { "label": "Pricing", "url": "pages/pricing.html" },
     { "label": "Community", "url": "pages/community.html" },
     { "label": "Blog", "url": "blog/" },
     { "label": "Vision", "url": "pages/vision.html" },

--- a/plugins/soleur/docs/pages/getting-started.njk
+++ b/plugins/soleur/docs/pages/getting-started.njk
@@ -40,7 +40,7 @@ permalink: pages/getting-started.html
               <span class="path-card-badge path-card-badge--available">AVAILABLE NOW</span>
             </div>
             <p class="path-card-desc">Install the Claude Code extension and run your AI organization locally. Full access to all {{ stats.agents }} agents and {{ stats.skills }} skills. Free and open source.</p>
-            <a href="#self-hosted" class="btn btn-secondary path-card-cta">Get Started &rarr;</a>
+            <a href="pages/getting-started.html#self-hosted" class="btn btn-secondary path-card-cta">Get Started &rarr;</a>
           </div>
 
         </div>


### PR DESCRIPTION
## Summary

- Move Pricing to first position in top navigation to prioritize the conversion funnel
- Fix the Self-Hosted "Get Started" button on the Getting Started page — the bare `#self-hosted` anchor resolved to the homepage due to `<base href="/">`, now uses full page path `pages/getting-started.html#self-hosted`

## Changelog

- **Navigation:** Pricing is now the first nav item, ahead of Get Started
- **Getting Started:** Self-Hosted card CTA correctly anchors to the Installation section on the same page

## Test plan

- [x] Eleventy build passes (41 files, 0 errors)
- [x] Pricing appears first in nav bar on all pages
- [x] Self-Hosted "Get Started" button scrolls to Installation section (not homepage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)