### PR TITLE
fix(docs): normalize pricing table total row font size

### DIFF
--- a/plugins/soleur/docs/css/style.css
+++ b/plugins/soleur/docs/css/style.css
@@ -1120,7 +1120,8 @@
   }
   .hiring-total-row td {
     border-top: 2px solid var(--color-accent);
-    font-size: var(--text-lg);
+    padding-top: var(--space-4);
+    padding-bottom: var(--space-4);
   }
   .hiring-footnote {
     font-size: var(--text-xs);


### PR DESCRIPTION
## Summary

- Remove the `font-size: var(--text-lg)` bump from the hiring comparison total row on the pricing page
- Replace with extra vertical padding — the gold top border and bold text already provide clean visual hierarchy without the jarring size jump

## Changelog

- **Pricing page:** Total row in "What You Replace" table no longer uses an oversized font; uses consistent sizing with extra padding instead

## Test plan

- [x] Eleventy build passes
- [x] Before/after screenshots of the pricing table total row

🤖 Generated with [Claude Code](https://claude.com/claude-code)