### PR TITLE
fix: update hero copy to reflect correct department count

### DIFF
--- a/plugins/soleur/docs/index.njk
+++ b/plugins/soleur/docs/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Soleur
-description: "You're doing 8 jobs. Soleur helps you tackle 7 of them -- marketing, legal, finance, sales, and more -- with AI agents that remember everything about your business."
+description: "You're wearing 9 hats. Soleur takes 8 off your head -- marketing, legal, finance, sales, and more -- with AI agents that remember everything about your business."
 layout: base.njk
 permalink: index.html
 ---
@@ -8,7 +8,7 @@ permalink: index.html
     <!-- Hero -->
     <section class="landing-hero">
       <h1>Build a Billion-Dollar Company. Alone.</h1>
-      <p class="hero-sub">You&rsquo;re doing 8 jobs. Soleur helps you tackle 7 of them &mdash; marketing campaigns, legal contracts, competitive analysis, financial planning &mdash; delegated to AI agents that remember everything about your business.</p>
+      <p class="hero-sub">You&rsquo;re wearing 9 hats. Soleur takes 8 off your head &mdash; marketing campaigns, legal contracts, competitive analysis, financial planning &mdash; delegated to AI agents that remember everything about your business.</p>
       <p class="hero-trust">Human-in-the-loop. Your expertise, amplified.</p>
       <form class="newsletter-form hero-waitlist-form" id="homepage-waitlist-form"
         action="https://buttondown.com/api/emails/embed-subscribe/soleur"
@@ -166,7 +166,7 @@ permalink: index.html
           </details>
           <details class="faq-item">
             <summary class="faq-question">Who is Soleur for?</summary>
-            <p class="faq-answer">Solo founders doing 8 jobs who want to delegate 7 of them. Especially founders at the hire-or-don&rsquo;t-hire decision point &mdash; Soleur gives you the capacity of a team before you have the budget for one. Your knowledge compounds across departments and sessions, so the more you use it, the more it knows about your business.</p>
+            <p class="faq-answer">Solo founders wearing 9 hats who want to hand off 8 of them. Especially founders at the hire-or-don&rsquo;t-hire decision point &mdash; Soleur gives you the capacity of a team before you have the budget for one. Your knowledge compounds across departments and sessions, so the more you use it, the more it knows about your business.</p>
           </details>
           <details class="faq-item">
             <summary class="faq-question">How do I get started?</summary>
@@ -226,7 +226,7 @@ permalink: index.html
           "name": "Who is Soleur for?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Solo founders doing 8 jobs who want to delegate 7 of them. Especially founders at the hire-or-don't-hire decision point — Soleur gives you the capacity of a team before you have the budget for one. Your knowledge compounds across departments and sessions, so the more you use it, the more it knows about your business."
+            "text": "Solo founders wearing 9 hats who want to hand off 8 of them. Especially founders at the hire-or-don't-hire decision point — Soleur gives you the capacity of a team before you have the budget for one. Your knowledge compounds across departments and sessions, so the more you use it, the more it knows about your business."
           }
         },
         {


### PR DESCRIPTION
## Summary
- Update landing page hero tagline from "doing 8 jobs / tackle 7" to "wearing 9 hats / takes 8 off" to match actual department count (8 departments + 1 CEO role = 9 hats)
- Update meta description, hero subtitle, FAQ answer (HTML + JSON-LD) — all 4 locations

## Changelog
- Fixed: Landing page hero copy now correctly reflects 9 hats (8 departments + founder role) instead of 8 jobs

## Test plan
- [x] Eleventy build passes (43 pages, 0 errors)
- [x] `grep` confirms "wearing 9 hats" appears in built output
- [x] All 4 copy locations updated (meta description, hero-sub, FAQ HTML, FAQ JSON-LD)
- [x] Full test suite passes (1381/1381)

🤖 Generated with [Claude Code](https://claude.com/claude-code)