### PR TITLE
fix(agent): verify conversation ownership before saving message

### DIFF
--- a/apps/web-platform/server/agent-runner.ts
+++ b/apps/web-platform/server/agent-runner.ts
@@ -549,10 +549,8 @@ export async function sendUserMessage(
   conversationId: string,
   content: string,
 ): Promise<void> {
-  // Save user message to DB
-  await saveMessage(conversationId, "user", content);
-
-  // Load conversation with ownership check
+  // Verify conversation ownership BEFORE saving the message to prevent
+  // cross-user writes (the message insert has no user_id check itself).
   const { data: conv, error: convErr } = await supabase
     .from("conversations")
     .select("domain_leader, session_id")
@@ -561,6 +559,9 @@ export async function sendUserMessage(
     .single();
 
   if (convErr || !conv) throw new Error("Conversation not found");
+
+  // Save user message to DB (after ownership verified)
+  await saveMessage(conversationId, "user", content);
 
   // Check for an in-memory session with a captured session_id
   const key = sessionKey(userId, conversationId);


### PR DESCRIPTION
## Summary

- Move conversation ownership check (user_id filter) before saveMessage()
- Prevents cross-user message writes when a client sends a chat message with another user's conversationId

## Changelog

- Reorder sendUserMessage to verify ownership before persisting the message

## Related issues

- Found during post-merge review of #1190
- Filed #1194 (race condition on concurrent start_session) and #1195 (review gate selection validation) for pre-existing issues

## Test plan

- [x] All 236 tests pass
- [x] TypeScript compiles clean

Generated with [Claude Code](https://claude.com/claude-code)