### PR TITLE
docs: dogfood architecture skill — 20 ADRs and 2 C4 diagrams

### DIFF
--- a/knowledge-base/engineering/architecture/decisions/ADR-001-pwa-first-platform-architecture.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-001-pwa-first-platform-architecture.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-001
+title: PWA-First Platform Architecture
+status: active
+date: 2026-03-27
+---
+
+# ADR-001: PWA-First Platform Architecture
+
+## Context
+
+Cloud platform must be accessible across web, mobile, and desktop without installation friction. Native apps add development cost and App Store gatekeeping.
+
+## Decision
+
+Deploy as a Progressive Web App (PWA). One Next.js codebase covers web browsers, mobile (installable PWA), and desktop (installable PWA). Native apps (Electron, React Native) deferred unless PWA hits real user limits.
+
+## Consequences
+
+Faster iteration with single codebase. iOS limitations (push notifications require 16.4+, no background execution, service worker cache evicted after ~14 days) require email fallback for notifications. Desktop users get installable PWA without Electron overhead.

--- a/knowledge-base/engineering/architecture/decisions/ADR-002-three-tier-service-automation.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-002-three-tier-service-automation.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-002
+title: Three-Tier Service Automation
+status: active
+date: 2026-03-27
+---
+
+# ADR-002: Three-Tier Service Automation
+
+## Context
+
+Founders validated service automation as high-value. Server-side Playwright was rejected as HIGH risk by CTO, CLO, and CFO due to SSRF risk, agency liability, and 2-4x infra cost.
+
+## Decision
+
+Three-tier approach — Tier 1 (API + MCP, ~80% of services via direct REST APIs with BYOK tokens), Tier 2 (Local Playwright, ~15% via desktop native app on user's machine), Tier 3 (Guided instructions, ~5% with deep links and review gates as web/mobile fallback).
+
+## Consequences
+
+API-first eliminates SSRF risk, agency liability, and 2-4x infra cost. Desktop app justified solely for local browser automation capability. 5% of services have degraded UX with guided instructions instead of automation.

--- a/knowledge-base/engineering/architecture/decisions/ADR-003-cloud-cli-engine.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-003-cloud-cli-engine.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-003
+title: Cloud CLI Engine
+status: active
+date: 2026-03-27
+---
+
+# ADR-003: Cloud CLI Engine
+
+## Context
+
+Users need both visibility (web dashboard) and autonomous execution (orchestration tools like Task, Skill, Bash). Full web-native platform loses 65-70% of agent capability.
+
+## Decision
+
+Agents execute on cloud-hosted Claude Code instances. Web app is a thin view/control layer over the CLI engine. Preserves 100% of orchestration value.
+
+## Consequences
+
+67.7% of agent code is prose (portable). 57.9% of skills are non-portable (depend on orchestration tools). Cloud CLI sidesteps portability by keeping the engine unchanged. Adds infrastructure complexity of managing CLI instances.

--- a/knowledge-base/engineering/architecture/decisions/ADR-004-byok-encryption-model.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-004-byok-encryption-model.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-004
+title: BYOK Encryption Model
+status: active
+date: 2026-03-27
+---
+
+# ADR-004: BYOK Encryption Model
+
+## Context
+
+Users provide their own Anthropic API keys. Need strong encryption and per-user isolation. Supabase pgcrypto has cardinality mismatch (one vault secret per user doesn't scale).
+
+## Decision
+
+AES-256-GCM encryption in application layer (Node.js crypto). HKDF per-user key derivation with empty salt and user_id in info field for domain separation. Envelope encryption for master key (future Supabase Vault, currently password-manager backup).
+
+## Consequences
+
+Per-user cryptographic isolation without database-level encryption dependency. RFC 5869 compliant. Master key is single point of failure — requires offline backup regardless. Column type alignment needed (bytea → text for encrypted_key to match iv and auth_tag).

--- a/knowledge-base/engineering/architecture/decisions/ADR-005-persistent-session-architecture.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-005-persistent-session-architecture.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-005
+title: Persistent Session Architecture
+status: active
+date: 2026-03-27
+---
+
+# ADR-005: Persistent Session Architecture
+
+## Context
+
+Agent currently has amnesia — each message spawns fresh agent with no memory. P1 blocker for product viability. Users need continuous conversations across messages.
+
+## Decision
+
+Hybrid approach — SDK resume as primary mechanism for full context fidelity including tool execution history, with message replay from Supabase as fallback when SDK session expires. Three close triggers: inactivity timeout, explicit new chat, work completion. TTL with user control.
+
+## Consequences
+
+Full context continuity for users within session lifetime. Graceful degradation when SDK session expires. Downstream impact on GDPR account deletion, session timeout policy, conversation inbox, and tag-and-route features.

--- a/knowledge-base/engineering/architecture/decisions/ADR-006-terraform-remote-backend-r2.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-006-terraform-remote-backend-r2.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-006
+title: Terraform Remote Backend on Cloudflare R2
+status: active
+date: 2026-03-27
+---
+
+# ADR-006: Terraform Remote Backend on Cloudflare R2
+
+## Context
+
+Both Terraform stacks used local backend with no locking and no backup. State was lost (issue #967). Need reliable, versioned remote state.
+
+## Decision
+
+Cloudflare R2 as remote backend with bucket versioning. Single bucket `soleur-terraform-state` with per-app key paths (e.g., `telegram-bridge/terraform.tfstate`). Doppler-first secrets (only DOPPLER_TOKEN in GitHub Secrets, rest pulled at runtime). Every new Terraform root must include R2 remote backend block.
+
+## Consequences
+
+State loss eliminated via bucket versioning. Per-app key paths enable clean multi-stack management. Zero egress cost (R2 has free egress). Requires `terraform import` for existing resources during migration.

--- a/knowledge-base/engineering/architecture/decisions/ADR-007-doppler-secrets-management.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-007-doppler-secrets-management.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-007
+title: Doppler Secrets Management
+status: active
+date: 2026-03-27
+---
+
+# ADR-007: Doppler Secrets Management
+
+## Context
+
+Secrets scattered across 4 surfaces (GitHub Actions, local .env, server /mnt/data/.env, Terraform). No rotation mechanism. Plaintext root credentials on disk.
+
+## Decision
+
+Doppler as centralized secrets manager (free tier: 10 projects, 4 environments, 50 service tokens). Runtime injection via `doppler run` — no plaintext .env files on disk. Incremental migration by surface. One bootstrap credential: DOPPLER_TOKEN as the "turtles all the way down" manual secret.
+
+## Consequences
+
+Single source of truth for secrets. Rotation and versioning built in. Free tier sufficient for current scale. BYOK_ENCRYPTION_KEY gets offline backup regardless (urgent, independent of migration).

--- a/knowledge-base/engineering/architecture/decisions/ADR-008-cloudflare-tunnel-deployment.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-008-cloudflare-tunnel-deployment.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-008
+title: Cloudflare Tunnel Deployment
+status: active
+date: 2026-03-27
+---
+
+# ADR-008: Cloudflare Tunnel Deployment
+
+## Context
+
+SSH-based CI deploy exposed server IP with 0.0.0.0/0 firewall rule. Need zero-trust network architecture.
+
+## Decision
+
+cloudflared daemon creates outbound tunnel to Cloudflare. Three routes: app.soleur.ai → localhost:3000, deploy.soleur.ai (webhook) → localhost:9000, SSH via cloudflared access. Webhook listener validates GitHub HMAC signatures, invokes existing ci-deploy.sh. ALL inbound firewall rules removed except ICMP.
+
+## Consequences
+
+Server becomes invisible to port scanners. Zero-trust access via Cloudflare. Preserved exact version pinning, health checks, deploy serialization through ci-deploy.sh. Adds Cloudflare as infrastructure dependency.

--- a/knowledge-base/engineering/architecture/decisions/ADR-009-git-worktree-isolation.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-009-git-worktree-isolation.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-009
+title: Git Worktree Isolation
+status: active
+date: 2026-03-27
+---
+
+# ADR-009: Git Worktree Isolation
+
+## Context
+
+Need isolated branches for parallel feature development without conflicts on main. Repo uses core.bare=true where git pull and git checkout are unavailable from root.
+
+## Decision
+
+Never commit directly to main (hook-enforced). Create worktrees via `git worktree add .worktrees/feat-<name> -b feat/<name>`. At session start, run cleanup-merged. Never git stash in worktrees (commit WIP first). Never rm -rf on worktree paths (hook-enforced). MCP tools resolve paths from repo root — always pass absolute paths.
+
+## Consequences
+
+Clean parallel development with full isolation. Hook enforcement prevents accidental main commits. worktree-manager.sh handles lifecycle (create, cleanup-merged, draft-pr). All PreToolUse hooks block destructive operations on worktrees.

--- a/knowledge-base/engineering/architecture/decisions/ADR-010-brainstorm-default-routing.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-010-brainstorm-default-routing.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-010
+title: Brainstorm Default Routing
+status: active
+date: 2026-03-27
+---
+
+# ADR-010: Brainstorm Default Routing
+
+## Context
+
+/soleur:go router was lumping features and bugs together, sending both to one-shot. Features skipped domain leader assessment, leading to missed CMO/CTO concerns.
+
+## Decision
+
+Three intents: explore, generate, build. Everything except bugs routes to brainstorm (which has a Phase 0 escape hatch for trivially clear features). Bug detection via keywords ("fix", "bug", "broken") or issue label check (type/bug). No confirmation step — users invoke commands directly if router misclassifies.
+
+## Consequences
+
+Domain leaders (Phase 0.5) catch blind spots early. Features always get domain assessment before implementation. Bugs get fast-tracked via one-shot. Users can bypass routing by invoking skills directly.

--- a/knowledge-base/engineering/architecture/decisions/ADR-011-three-tier-enforcement-model.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-011-three-tier-enforcement-model.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-011
+title: Three-Tier Enforcement Model
+status: active
+date: 2026-03-27
+---
+
+# ADR-011: Three-Tier Enforcement Model
+
+## Context
+
+Constitution rules requiring semantic judgment (e.g., "detect UI signals in the plan") cannot be enforced by PreToolUse hooks, which are syntactic only.
+
+## Decision
+
+Three enforcement tiers — PreToolUse hooks (syntactic, strongest, mechanical prevention), skill instructions (semantic, medium, LLM-evaluated at specific phases), prose rules (advisory, weakest, requires agent compliance). Annotate constitution rules with `[skill-enforced: <skill> <phase>]` when elevated from prose to skill. Place gates at workflow phases where the LLM already has relevant context.
+
+## Consequences
+
+Semantic rules get real enforcement without requiring new hooks. Clear hierarchy for deciding where to place new rules. Constitution annotations make enforcement level visible. Risk of over-relying on LLM compliance for skill-tier rules.

--- a/knowledge-base/engineering/architecture/decisions/ADR-012-tier0-lifecycle-parallelism.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-012-tier0-lifecycle-parallelism.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-012
+title: Tier-0 Lifecycle Parallelism
+status: active
+date: 2026-03-27
+---
+
+# ADR-012: Tier-0 Lifecycle Parallelism
+
+## Context
+
+Sequential RED-GREEN-REFACTOR lifecycle is the bottleneck, not task independence. Code-then-tests is serial because tests depend on implementation.
+
+## Decision
+
+Generate an interface contract (markdown: File Scopes + Public Interfaces) before spawning agents. Spawn two parallel agents — Agent 1 (Code) implements features to satisfy public interfaces, Agent 2 (Tests) writes ATDD RED phase from contract alone without reading source. Coordinator waits for both, commits combined output, runs test-fix-loop until GREEN. Docs written sequentially after GREEN.
+
+## Consequences
+
+ATDD inverts dependency arrow — tests depend on contract, not implementation, enabling lifecycle parallelism. Contract must be minimal (2 sections only) to avoid speculative work. Agents explicitly constrained from running git commands (coordinator commits only).

--- a/knowledge-base/engineering/architecture/decisions/ADR-013-multi-phase-domain-gate-enforcement.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-013-multi-phase-domain-gate-enforcement.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-013
+title: Multi-Phase Domain Gate Enforcement
+status: active
+date: 2026-03-27
+---
+
+# ADR-013: Multi-Phase Domain Gate Enforcement
+
+## Context
+
+Features shipping without CMO, CTO, CLO assessment. Platform complexity requires cross-domain coordination at brainstorm and ship time.
+
+## Decision
+
+Before shipping (/soleur:ship Phase 5.5), three conditional domain leader gates run in parallel — CMO content-opportunity gate (triggers on research/marketing changes), CMO website framing review gate (triggers on brand-guide positioning changes), COO expense-tracking gate (triggers on new service signups). New user-facing capabilities require CPO and CMO assessment at minimum during brainstorm.
+
+## Consequences
+
+Cross-domain concerns caught before merge. Parallel execution keeps gate overhead low. CMO and COO gaps that were discovered in #1173 are now systematically prevented. Risk of gate fatigue if too many domains are always-relevant.

--- a/knowledge-base/engineering/architecture/decisions/ADR-014-subagent-output-merging.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-014-subagent-output-merging.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-014
+title: Subagent Output Merging
+status: active
+date: 2026-03-27
+---
+
+# ADR-014: Subagent Output Merging
+
+## Context
+
+Parallel fan-out of 6 subagents exceeded the 5-subagent constitution limit. Need to reduce count without losing parallelism.
+
+## Decision
+
+When a parallel subagent's output feeds exclusively to one other subagent (producer-consumer pair), merge producer into consumer. Example: Category Classifier merged into Documentation Writer (exclusive dependency). Preserves parallelism while reducing inter-agent data flow.
+
+## Consequences
+
+Respects resource guardrails without sacrificing parallel performance. Skill SKILL.md must have zero references to removed subagent names. Constitution uses generic language for limits rather than hardcoded counts, enabling future adjustment.

--- a/knowledge-base/engineering/architecture/decisions/ADR-015-decoupled-work-ship-for-review-gates.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-015-decoupled-work-ship-for-review-gates.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-015
+title: Decoupled Work/Ship for Review Gates
+status: active
+date: 2026-03-27
+---
+
+# ADR-015: Decoupled Work/Ship for Review Gates
+
+## Context
+
+Review running after work/ship had already merged PR left findings unactionable. Need review to run between work and ship.
+
+## Decision
+
+Work's Phase 4 behavior depends on invocation context — via one-shot, hand off control (one-shot orchestrates: work -> review -> resolve -> compound -> ship); direct invocation by user, continue automatically through compound -> ship. Heuristic: hand off if there is a caller, finish if there is not.
+
+## Consequences
+
+Review gates run before merge in orchestrated pipelines. Direct invocations still complete the full lifecycle without requiring explicit orchestration. The heuristic must be reliably detectable from conversation context.

--- a/knowledge-base/engineering/architecture/decisions/ADR-016-skills-over-commands.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-016-skills-over-commands.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-016
+title: Skills Over Commands
+status: active
+date: 2026-03-27
+---
+
+# ADR-016: Skills Over Commands
+
+## Context
+
+Core workflow stages (brainstorm, plan, work, review, compound) need to be discoverable by agents and invocable via the Skill tool. Commands are invisible to agents.
+
+## Decision
+
+Core workflow stages are skills under plugins/soleur/skills/, not commands. Only three commands remain: go, sync, help using soleur: prefix. Skills get soleur: prefix automatically from plugin namespace. The name field in frontmatter should NOT include the prefix.
+
+## Consequences
+
+Skills are discoverable in the plugin system and invocable via Skill tool. Agents can chain workflows (e.g., one-shot sequences plan then work). Command namespace stays clean. Skill loader does not recurse into subdirectories — skills must be flat.

--- a/knowledge-base/engineering/architecture/decisions/ADR-017-version-from-git-tags.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-017-version-from-git-tags.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-017
+title: Version From Git Tags
+status: active
+date: 2026-03-27
+---
+
+# ADR-017: Version From Git Tags
+
+## Context
+
+Manual version bumps caused drift between plugin.json and actual releases. Feature branches accidentally bumped versions.
+
+## Decision
+
+Version derived from git tags at merge time via CI (version-bump-and-release.yml). plugin.json and marketplace.json versions are frozen sentinels (0.0.0-dev). Set semver:patch/minor/major labels on PRs. CI determines version bump, creates GitHub Release with vX.Y.Z tag, and posts to Discord. Never edit version fields in feature branches.
+
+## Consequences
+
+Zero manual version management. Eliminates version drift. Requires semver label on every PR touching plugins/soleur/. CI is the single source of truth for versioning.

--- a/knowledge-base/engineering/architecture/decisions/ADR-018-passive-domain-routing.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-018-passive-domain-routing.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-018
+title: Passive Domain Routing
+status: active
+date: 2026-03-27
+---
+
+# ADR-018: Passive Domain Routing
+
+## Context
+
+User messages during engineering tasks sometimes contain unrelated domain signals (expense mentions, legal commitments, marketing opportunities) that should be captured without blocking the primary task.
+
+## Decision
+
+When user message contains a clear, actionable domain signal unrelated to the current task, spawn the relevant domain leader as a background agent (run_in_background: true). Use brainstorm-domain-config.md to detect relevance. Continue primary task without waiting. Do not route on trivial messages or when the domain signal IS the current task.
+
+## Consequences
+
+Domain signals captured opportunistically without context switching. Background agents can file issues, update documents, or alert the user. Risk of false positive routing on ambiguous messages.

--- a/knowledge-base/engineering/architecture/decisions/ADR-019-terraform-only-for-infrastructure.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-019-terraform-only-for-infrastructure.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-019
+title: Terraform Only for Infrastructure
+status: active
+date: 2026-03-27
+---
+
+# ADR-019: Terraform Only for Infrastructure
+
+## Context
+
+Vendor-specific APIs (Hetzner API, AWS CLI) were used for creating servers, volumes, firewalls. This creates non-reproducible, non-portable infrastructure.
+
+## Decision
+
+Always use Terraform for infrastructure provisioning — never vendor-specific APIs for creating servers, volumes, firewalls, or DNS records. Use vendor APIs only for read-only operations (checking availability, listing resources) or account-level tasks that Terraform doesn't cover. Existing patterns live in apps/telegram-bridge/infra/ and apps/web-platform/infra/.
+
+## Consequences
+
+Reproducible infrastructure across environments. Portable across cloud providers. State tracked in remote backend (ADR-006). Vendor APIs still useful for discovery and account management. Slightly more setup overhead for simple one-off resources.

--- a/knowledge-base/engineering/architecture/decisions/ADR-020-exact-version-pinning-agent-sdk.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-020-exact-version-pinning-agent-sdk.md
@@ -1,0 +1,20 @@
+---
+adr: ADR-020
+title: Exact Version Pinning for Agent SDK
+status: active
+date: 2026-03-27
+---
+
+# ADR-020: Exact Version Pinning for Agent SDK
+
+## Context
+
+Agent SDK uses unstable API versions (unstable_v2_createSession) that can break between patch releases. Caret ranges (^0.2.80) allow surprise API breakage.
+
+## Decision
+
+Pin Agent SDK to exact version (e.g., 0.2.80, not ^0.2.80). Enables reproducible builds. Allows deliberate evaluation of new SDK versions before upgrading.
+
+## Consequences
+
+No surprise breakage from SDK updates. Requires manual version bump when upgrading. May miss security patches if not actively monitoring releases.

--- a/knowledge-base/engineering/architecture/diagrams/container.md
+++ b/knowledge-base/engineering/architecture/diagrams/container.md
@@ -1,0 +1,53 @@
+# Container Diagram
+
+Generated: 2026-03-27
+
+````mermaid
+graph TB
+    subgraph "Web Application (Next.js PWA)"
+        dashboard["Dashboard<br/>(React)"]
+        auth["Auth Module<br/>(Supabase Auth)"]
+        api["API Routes<br/>(Next.js)"]
+    end
+
+    subgraph "Cloud CLI Engine"
+        claude["Claude Code<br/>(Agent Runtime)"]
+        skillloader["Skill Loader<br/>(Plugin Discovery)"]
+        hookengine["Hook Engine<br/>(PreToolUse Guards)"]
+    end
+
+    subgraph "Soleur Plugin (plugins/soleur/)"
+        commands["Commands<br/>(go, sync, help)"]
+        skills["Skills<br/>(61 workflow skills)"]
+        agents["Agents<br/>(65 domain agents)"]
+        kb["Knowledge Base<br/>(Conventions, Learnings)"]
+    end
+
+    subgraph "Infrastructure"
+        supabase_db["Supabase PostgreSQL<br/>(Users, Keys, Sessions)"]
+        r2["Cloudflare R2<br/>(Terraform State)"]
+        tunnel["Cloudflare Tunnel<br/>(Zero-Trust Access)"]
+        hetzner["Hetzner Cloud<br/>(Compute)"]
+    end
+
+    dashboard --> api
+    api --> claude
+    claude --> skillloader
+    skillloader --> skills
+    skillloader --> agents
+    skillloader --> commands
+    hookengine --> claude
+    skills --> kb
+    agents --> kb
+    api --> supabase_db
+    claude --> supabase_db
+    tunnel --> api
+    hetzner --> claude
+````
+
+## Notes
+
+- Plugin has flat skill structure (skills don't nest) and recursive agent discovery
+- Three enforcement tiers: hooks (syntactic), skills (semantic), prose (advisory) — see ADR-011
+- Knowledge base compounds decisions (ADRs), learnings, and conventions
+- Worktree isolation enforced via hooks (ADR-009)

--- a/knowledge-base/engineering/architecture/diagrams/system-context.md
+++ b/knowledge-base/engineering/architecture/diagrams/system-context.md
@@ -1,0 +1,42 @@
+# System Context Diagram
+
+Generated: 2026-03-27
+
+````mermaid
+graph TB
+    subgraph "External Actors"
+        founder["Founder (User)"]
+        anthropic["Anthropic API"]
+        github["GitHub"]
+        cloudflare["Cloudflare"]
+        doppler["Doppler"]
+        discord["Discord"]
+    end
+
+    subgraph "Soleur Platform"
+        webapp["Web App<br/>(Next.js PWA)"]
+        cliengine["Cloud CLI Engine<br/>(Claude Code Instances)"]
+        plugin["Soleur Plugin<br/>(61 Skills, 65 Agents)"]
+        supabase["Supabase<br/>(Auth, DB, Storage)"]
+    end
+
+    founder -->|"Interacts via browser"| webapp
+    webapp -->|"Thin view/control layer"| cliengine
+    cliengine -->|"Loads"| plugin
+    cliengine -->|"LLM calls"| anthropic
+    cliengine -->|"Git operations"| github
+    plugin -->|"Domain routing"| cliengine
+    webapp -->|"Auth, data"| supabase
+    cliengine -->|"BYOK keys, sessions"| supabase
+    cloudflare -->|"Tunnel, DNS, CDN"| webapp
+    doppler -->|"Runtime secrets"| cliengine
+    cliengine -->|"Notifications"| discord
+````
+
+## Notes
+
+- Web App is a thin view/control layer over the CLI engine (ADR-003)
+- CLI engine preserves 100% of orchestration capability
+- BYOK encryption isolates per-user API keys (ADR-004)
+- All infrastructure provisioned via Terraform (ADR-019)
+- Secrets managed via Doppler (ADR-007)


### PR DESCRIPTION
## Summary

- Dogfoods the new `soleur:architecture` skill by formalizing 20 existing architectural decisions as ADRs
- Generates system-context (C4 L1) and container (C4 L2) Mermaid architecture diagrams
- Decisions sourced from brainstorms, learnings, constitution, roadmap, and AGENTS.md

## ADRs Created

| ADR | Decision |
|-----|----------|
| ADR-001 | PWA-first platform architecture |
| ADR-002 | Three-tier service automation |
| ADR-003 | Cloud CLI engine with web dashboard |
| ADR-004 | BYOK encryption with HKDF per-user derivation |
| ADR-005 | Persistent session architecture (SDK resume + message replay) |
| ADR-006 | Terraform remote backend via Cloudflare R2 |
| ADR-007 | Doppler secrets management |
| ADR-008 | Cloudflare tunnel-based deployment |
| ADR-009 | Git worktree isolation for feature development |
| ADR-010 | Brainstorm as default routing |
| ADR-011 | Three-tier enforcement model (hooks/skills/prose) |
| ADR-012 | Tier 0 lifecycle parallelism (contract-first) |
| ADR-013 | Multi-phase domain gate enforcement |
| ADR-014 | Subagent output merging (producer-consumer) |
| ADR-015 | Decoupled work/ship for review gates |
| ADR-016 | Skills over commands |
| ADR-017 | Version from git tags (no manual bumps) |
| ADR-018 | Passive domain routing |
| ADR-019 | Terraform-only for infrastructure |
| ADR-020 | Exact version pinning for Agent SDK |

## Changelog

- **Added** 20 Architecture Decision Records covering product, infrastructure, engineering, and governance decisions
- **Added** System context diagram (C4 Level 1) showing external actors and platform boundaries
- **Added** Container diagram (C4 Level 2) showing internal component relationships

## Test plan

- [x] All ADR files follow template (YAML frontmatter + Context/Decision/Consequences)
- [x] Diagrams use valid Mermaid syntax with cross-references to ADRs
- [x] Markdown lint passes
- [x] No plugin code changes (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)