### PR TITLE
fix(architecture): use proper C4 model Mermaid syntax for diagrams

### DIFF
--- a/knowledge-base/engineering/architecture/diagrams/component-plugin.md
+++ b/knowledge-base/engineering/architecture/diagrams/component-plugin.md
@@ -1,0 +1,65 @@
+# Soleur Plugin — Component Diagram (C4 Level 3)
+
+Generated: 2026-03-27
+
+```mermaid
+C4Component
+title Component diagram for Soleur Plugin
+
+Container(claude, "Agent Runtime", "Claude Code", "Executes agent workflows")
+Container(hooks, "Hook Engine", "PreToolUse Guards", "Syntactic enforcement")
+ContainerDb(kb, "Knowledge Base", "Markdown", "Conventions, learnings, ADRs")
+
+Container_Boundary(plugin, "Soleur Plugin (plugins/soleur/)") {
+
+    Component(go, "go command", "Entry Point", "Classifies intent and routes to workflow skills")
+    Component(sync, "sync command", "Entry Point", "Populates knowledge-base from existing codebase")
+    Component(help, "help command", "Entry Point", "Lists all available commands, skills, and agents")
+
+    Component(brainstorm, "brainstorm skill", "Workflow", "Explores requirements with domain leader assessment")
+    Component(plan, "plan skill", "Workflow", "Creates implementation plans with research and domain review")
+    Component(work, "work skill", "Workflow", "Executes plans with incremental commits and test-first")
+    Component(review, "review skill", "Workflow", "Multi-agent code review with 8 parallel reviewers")
+    Component(compound, "compound skill", "Workflow", "Captures learnings and promotes to constitution")
+    Component(ship, "ship skill", "Workflow", "Validates artifacts, creates PR, manages merge lifecycle")
+    Component(oneshot, "one-shot skill", "Orchestrator", "Full autonomous pipeline: plan, work, review, compound, ship")
+    Component(architecture, "architecture skill", "Documentation", "ADR lifecycle and C4 diagram generation")
+
+    Component(cto, "CTO agent", "Domain Leader", "Engineering assessment, architecture decision detection")
+    Component(cmo, "CMO agent", "Domain Leader", "Marketing assessment, content opportunities")
+    Component(cpo, "CPO agent", "Domain Leader", "Product strategy, UX flow analysis")
+    Component(archstrat, "architecture-strategist", "Review Agent", "Architectural compliance and ADR coverage check")
+
+    Rel(go, brainstorm, "Routes explore/generate")
+    Rel(go, oneshot, "Routes build")
+    Rel(oneshot, plan, "Step 1")
+    Rel(oneshot, work, "Step 2")
+    Rel(oneshot, review, "Step 3")
+    Rel(oneshot, compound, "Step 4")
+    Rel(oneshot, ship, "Step 5")
+    Rel(brainstorm, cto, "Phase 0.5 assessment")
+    Rel(brainstorm, cmo, "Phase 0.5 assessment")
+    Rel(brainstorm, cpo, "Phase 0.5 assessment")
+    Rel(plan, cto, "Phase 2.5 domain review")
+    Rel(review, archstrat, "Parallel review agent")
+    Rel(cto, architecture, "Recommends ADR creation")
+    Rel(archstrat, architecture, "Checks ADR coverage")
+}
+
+Rel(claude, go, "User invokes /soleur:go")
+Rel(hooks, claude, "Guards tool calls")
+Rel(brainstorm, kb, "Writes brainstorms")
+Rel(plan, kb, "Writes plans and specs")
+Rel(work, kb, "Reads plans, writes code")
+Rel(compound, kb, "Writes learnings, promotes to constitution")
+Rel(architecture, kb, "Writes ADRs and diagrams")
+```
+
+## Notes
+
+- Three commands (go, sync, help) are the only user-facing entry points (ADR-016)
+- One-shot orchestrates the full pipeline: plan → work → review → compound → ship (ADR-015)
+- Domain leaders (CTO, CMO, CPO) participate in brainstorm Phase 0.5 and plan Phase 2.5 (ADR-013)
+- CTO agent detects architectural decisions and recommends `/soleur:architecture create`
+- Architecture-strategist checks ADR coverage during review as advisory finding
+- 8 review agents run in parallel during `/soleur:review` — only architecture-strategist shown here

--- a/knowledge-base/engineering/architecture/diagrams/container.md
+++ b/knowledge-base/engineering/architecture/diagrams/container.md
@@ -1,53 +1,68 @@
-# Container Diagram
+# Soleur Platform — Container Diagram (C4 Level 2)
 
 Generated: 2026-03-27
 
-````mermaid
-graph TB
-    subgraph "Web Application (Next.js PWA)"
-        dashboard["Dashboard<br/>(React)"]
-        auth["Auth Module<br/>(Supabase Auth)"]
-        api["API Routes<br/>(Next.js)"]
-    end
+```mermaid
+C4Container
+title Container diagram for Soleur Platform
 
-    subgraph "Cloud CLI Engine"
-        claude["Claude Code<br/>(Agent Runtime)"]
-        skillloader["Skill Loader<br/>(Plugin Discovery)"]
-        hookengine["Hook Engine<br/>(PreToolUse Guards)"]
-    end
+Person(founder, "Founder", "Solo founder using Soleur")
 
-    subgraph "Soleur Plugin (plugins/soleur/)"
-        commands["Commands<br/>(go, sync, help)"]
-        skills["Skills<br/>(61 workflow skills)"]
-        agents["Agents<br/>(65 domain agents)"]
-        kb["Knowledge Base<br/>(Conventions, Learnings)"]
-    end
+System_Ext(anthropic, "Anthropic API", "Claude LLM")
+System_Ext(github, "GitHub", "Source control and CI/CD")
+System_Ext(cloudflare, "Cloudflare", "DNS, CDN, Tunnel, R2")
+System_Ext(doppler, "Doppler", "Secrets management")
 
-    subgraph "Infrastructure"
-        supabase_db["Supabase PostgreSQL<br/>(Users, Keys, Sessions)"]
-        r2["Cloudflare R2<br/>(Terraform State)"]
-        tunnel["Cloudflare Tunnel<br/>(Zero-Trust Access)"]
-        hetzner["Hetzner Cloud<br/>(Compute)"]
-    end
+Enterprise_Boundary(b0, "Soleur Platform") {
 
-    dashboard --> api
-    api --> claude
-    claude --> skillloader
-    skillloader --> skills
-    skillloader --> agents
-    skillloader --> commands
-    hookengine --> claude
-    skills --> kb
-    agents --> kb
-    api --> supabase_db
-    claude --> supabase_db
-    tunnel --> api
-    hetzner --> claude
-````
+    Container_Boundary(web, "Web Application") {
+        Container(dashboard, "Dashboard", "React, Next.js", "Conversation UI, knowledge base viewer, session management")
+        Container(api, "API Routes", "Next.js API", "REST endpoints for auth, sessions, and agent control")
+        Container(auth, "Auth Module", "Supabase Auth", "JWT authentication, OAuth providers, session tokens")
+    }
+
+    Container_Boundary(cli, "Cloud CLI Engine") {
+        Container(claude, "Agent Runtime", "Claude Code", "Executes agent workflows with full orchestration tools")
+        Container(skillloader, "Skill Loader", "Plugin Discovery", "Discovers and loads skills, agents, commands from plugin directory")
+        Container(hooks, "Hook Engine", "PreToolUse Guards", "Enforces syntactic rules — blocks commits to main, rm -rf, etc.")
+    }
+
+    Container_Boundary(plugin, "Soleur Plugin") {
+        Container(skills, "Skills", "Markdown SKILL.md", "61 workflow skills — brainstorm, plan, work, review, compound, etc.")
+        Container(agents, "Agents", "Markdown Agent Defs", "65 domain agents across 8 departments")
+        Container(kb, "Knowledge Base", "Markdown + YAML", "Conventions, learnings, ADRs, specs, plans, brainstorms")
+    }
+
+    Container_Boundary(infra, "Infrastructure") {
+        ContainerDb(supabase, "Supabase PostgreSQL", "PostgreSQL", "Users, BYOK-encrypted API keys, conversation sessions")
+        Container(tunnel, "Cloudflare Tunnel", "cloudflared", "Zero-trust inbound access — no exposed ports")
+        Container(hetzner, "Compute", "Hetzner Cloud", "Docker containers running web app and CLI engine")
+    }
+}
+
+Rel(founder, dashboard, "Browses and converses", "HTTPS")
+Rel(dashboard, api, "Calls", "HTTPS")
+Rel(api, claude, "Spawns agent sessions", "WebSocket")
+Rel(claude, skillloader, "Loads plugin", "File I/O")
+Rel(skillloader, skills, "Discovers", "Directory scan")
+Rel(skillloader, agents, "Discovers", "Recursive scan")
+Rel(hooks, claude, "Guards tool calls", "Event hook")
+Rel(skills, kb, "Reads/writes", "File I/O")
+Rel(agents, kb, "Reads", "File I/O")
+Rel(api, supabase, "Auth and data", "HTTPS")
+Rel(claude, supabase, "Sessions and keys", "HTTPS")
+Rel(claude, anthropic, "LLM calls", "HTTPS")
+Rel(claude, github, "Git operations", "HTTPS/SSH")
+Rel(tunnel, api, "Routes traffic", "HTTPS")
+Rel(hetzner, claude, "Hosts", "Docker")
+Rel(doppler, claude, "Injects secrets", "CLI")
+Rel(auth, supabase, "Validates tokens", "HTTPS")
+```
 
 ## Notes
 
-- Plugin has flat skill structure (skills don't nest) and recursive agent discovery
-- Three enforcement tiers: hooks (syntactic), skills (semantic), prose (advisory) — see ADR-011
-- Knowledge base compounds decisions (ADRs), learnings, and conventions
-- Worktree isolation enforced via hooks (ADR-009)
+- Plugin has flat skill structure (skills don't nest) and recursive agent discovery (ADR-016)
+- Three enforcement tiers: hooks (syntactic), skills (semantic), prose (advisory) — ADR-011
+- Knowledge base compounds ADRs, learnings, and conventions across sessions
+- Worktree isolation enforced via PreToolUse hooks (ADR-009)
+- Version derived from git tags at merge time, not committed files (ADR-017)

--- a/knowledge-base/engineering/architecture/diagrams/system-context.md
+++ b/knowledge-base/engineering/architecture/diagrams/system-context.md
@@ -1,42 +1,41 @@
-# System Context Diagram
+# Soleur Platform — System Context (C4 Level 1)
 
 Generated: 2026-03-27
 
-````mermaid
-graph TB
-    subgraph "External Actors"
-        founder["Founder (User)"]
-        anthropic["Anthropic API"]
-        github["GitHub"]
-        cloudflare["Cloudflare"]
-        doppler["Doppler"]
-        discord["Discord"]
-    end
+```mermaid
+C4Context
+title System Context diagram for Soleur Platform
 
-    subgraph "Soleur Platform"
-        webapp["Web App<br/>(Next.js PWA)"]
-        cliengine["Cloud CLI Engine<br/>(Claude Code Instances)"]
-        plugin["Soleur Plugin<br/>(61 Skills, 65 Agents)"]
-        supabase["Supabase<br/>(Auth, DB, Storage)"]
-    end
+Person(founder, "Founder", "Solo founder using Soleur as their AI organization")
 
-    founder -->|"Interacts via browser"| webapp
-    webapp -->|"Thin view/control layer"| cliengine
-    cliengine -->|"Loads"| plugin
-    cliengine -->|"LLM calls"| anthropic
-    cliengine -->|"Git operations"| github
-    plugin -->|"Domain routing"| cliengine
-    webapp -->|"Auth, data"| supabase
-    cliengine -->|"BYOK keys, sessions"| supabase
-    cloudflare -->|"Tunnel, DNS, CDN"| webapp
-    doppler -->|"Runtime secrets"| cliengine
-    cliengine -->|"Notifications"| discord
-````
+Enterprise_Boundary(b0, "Soleur Platform") {
+    System(webapp, "Web Application", "Next.js PWA providing dashboard and conversation UI")
+    System(engine, "Cloud CLI Engine", "Claude Code instances executing agent workflows")
+    SystemDb(supabase, "Supabase", "Auth, PostgreSQL database, and file storage")
+}
+
+System_Ext(anthropic, "Anthropic API", "Claude LLM for agent reasoning and tool use")
+System_Ext(github, "GitHub", "Source control, CI/CD, issue tracking, and releases")
+System_Ext(cloudflare, "Cloudflare", "DNS, CDN, R2 storage, and zero-trust tunnel")
+System_Ext(doppler, "Doppler", "Centralized secrets management with runtime injection")
+System_Ext(discord, "Discord", "Community notifications and release announcements")
+
+Rel(founder, webapp, "Interacts via browser", "HTTPS")
+Rel(webapp, engine, "Thin view/control layer", "WebSocket")
+Rel(webapp, supabase, "Auth and data", "HTTPS")
+Rel(engine, anthropic, "LLM calls with BYOK keys", "HTTPS")
+Rel(engine, github, "Git operations and CI", "HTTPS/SSH")
+Rel(engine, supabase, "Sessions and encrypted keys", "HTTPS")
+Rel(engine, discord, "Notifications", "Webhook")
+Rel(cloudflare, webapp, "Tunnel, DNS, CDN", "HTTPS")
+Rel(doppler, engine, "Runtime secrets", "CLI")
+```
 
 ## Notes
 
 - Web App is a thin view/control layer over the CLI engine (ADR-003)
-- CLI engine preserves 100% of orchestration capability
-- BYOK encryption isolates per-user API keys (ADR-004)
-- All infrastructure provisioned via Terraform (ADR-019)
-- Secrets managed via Doppler (ADR-007)
+- CLI engine preserves 100% of orchestration capability — agents execute on cloud-hosted Claude Code instances
+- BYOK encryption isolates per-user API keys via AES-256-GCM with HKDF derivation (ADR-004)
+- All infrastructure provisioned via Terraform with R2 remote backend (ADR-006, ADR-019)
+- Secrets managed via Doppler with runtime injection — no plaintext .env on disk (ADR-007)
+- Zero-trust access via Cloudflare Tunnel — server invisible to port scanners (ADR-008)

--- a/plugins/soleur/skills/architecture/SKILL.md
+++ b/plugins/soleur/skills/architecture/SKILL.md
@@ -14,7 +14,7 @@ Create, manage, and query Architecture Decision Records (ADRs) and generate Merm
 | `architecture create [title]` | Create a new ADR with the next sequential number |
 | `architecture list` | Display all ADRs with status, title, and date |
 | `architecture supersede <N> [title]` | Mark ADR-N as superseded and create its replacement |
-| `architecture diagram [type]` | Generate a Mermaid C4 diagram (system-context or container) |
+| `architecture diagram [type]` | Generate a Mermaid C4 diagram (context, container, or component) |
 
 If no sub-command is provided, display the table above and ask which sub-command to run.
 
@@ -143,41 +143,57 @@ Mark an existing ADR as superseded and create its replacement.
 
 ## Sub-command: diagram
 
-Generate a Mermaid C4 architecture diagram.
+Generate a Mermaid C4 model architecture diagram using the proper C4 diagram syntax.
+
+**Read [c4-reference.md](./references/c4-reference.md) now** for the complete C4 Mermaid syntax reference before generating any diagram.
 
 ### Steps
 
 1. **Determine diagram type.** If provided in `$ARGUMENTS`, use it. Otherwise, use AskUserQuestion:
 
-   | Type | Description |
-   |------|-------------|
-   | `system-context` | C4 Level 1 — system boundaries and external actors |
-   | `container` | C4 Level 2 — containers (apps, databases, services) within the system |
+   | Type | C4 Level | Mermaid Keyword | Description |
+   |------|----------|-----------------|-------------|
+   | `context` | Level 1 | `C4Context` | System boundaries, external actors, and system-to-system relationships |
+   | `container` | Level 2 | `C4Container` | Applications, databases, and services within the system boundary |
+   | `component` | Level 3 | `C4Component` | Internal components of a single container |
 
 2. **Gather context.** Read relevant project files to understand the system:
+
    - `knowledge-base/project/README.md` for system overview
    - `knowledge-base/project/components/` for component documentation
    - Existing ADRs in `knowledge-base/engineering/architecture/decisions/` for architectural decisions
+   - Existing diagrams in `knowledge-base/engineering/architecture/diagrams/` for consistency
 
-3. **Generate the Mermaid diagram.** Use `graph TB` with subgraphs for system boundaries. Follow existing Mermaid conventions in the codebase (see `knowledge-base/project/components/` for examples).
+3. **Generate the Mermaid diagram** using proper C4 syntax from [c4-reference.md](./references/c4-reference.md). Key rules:
+
+   - Use the correct diagram keyword (`C4Context`, `C4Container`, or `C4Component`)
+   - Use C4 shapes: `Person`, `System`, `System_Ext`, `Container`, `ContainerDb`, `Component`, etc.
+   - Use `Rel(from, to, label, ?protocol)` for relationships — NOT `-->`
+   - Use `Enterprise_Boundary`, `System_Boundary`, or `Container_Boundary` for grouping
+   - Use `_Ext` suffix for external systems/actors
 
 4. **Write the diagram file.** Save to `knowledge-base/engineering/architecture/diagrams/<type>.md`:
 
    ````markdown
-   # <Type> Diagram
+   # <Title> (C4 Level N)
 
    Generated: YYYY-MM-DD
 
    ```mermaid
-   graph TB
-       subgraph "System Boundary"
-           ...
-       end
+   C4Context
+   title System Context diagram for [System Name]
+
+   Person(user, "User Role", "Description")
+   System(sys, "System Name", "Description")
+   System_Ext(ext, "External System", "Description")
+
+   Rel(user, sys, "Uses", "HTTPS")
+   Rel(sys, ext, "Sends data to", "API")
    ```
 
    ## Notes
 
-   [Any relevant context about the diagram]
+   [Context about the diagram, references to relevant ADRs]
    ````
 
 5. **Announce:** "Diagram saved to `knowledge-base/engineering/architecture/diagrams/<type>.md`"

--- a/plugins/soleur/skills/architecture/references/c4-reference.md
+++ b/plugins/soleur/skills/architecture/references/c4-reference.md
@@ -1,0 +1,111 @@
+# C4 Model — Mermaid Syntax Reference
+
+Mermaid supports native C4 diagram types. Use these instead of generic `graph` diagrams for architecture documentation.
+
+## Diagram Types
+
+| Level | Keyword | Purpose |
+|-------|---------|---------|
+| 1 — Context | `C4Context` | Who uses the system and what other systems it interacts with |
+| 2 — Container | `C4Container` | Applications, data stores, and services inside the system boundary |
+| 3 — Component | `C4Component` | Internal components within a single container |
+| Dynamic | `C4Dynamic` | Runtime interaction sequences (numbered steps) |
+| Deployment | `C4Deployment` | Infrastructure mapping (nodes, environments) |
+
+## Element Syntax
+
+### Persons
+
+```text
+Person(alias, "Label", "Description")
+Person_Ext(alias, "Label", "Description")
+```
+
+### Systems (Level 1)
+
+```text
+System(alias, "Label", "Description")
+System_Ext(alias, "Label", "Description")
+SystemDb(alias, "Label", "Description")
+SystemDb_Ext(alias, "Label", "Description")
+SystemQueue(alias, "Label", "Description")
+```
+
+### Containers (Level 2)
+
+```text
+Container(alias, "Label", "Technology", "Description")
+Container_Ext(alias, "Label", "Technology", "Description")
+ContainerDb(alias, "Label", "Technology", "Description")
+ContainerDb_Ext(alias, "Label", "Technology", "Description")
+ContainerQueue(alias, "Label", "Technology", "Description")
+```
+
+### Components (Level 3)
+
+```text
+Component(alias, "Label", "Technology", "Description")
+Component_Ext(alias, "Label", "Technology", "Description")
+ComponentDb(alias, "Label", "Technology", "Description")
+ComponentQueue(alias, "Label", "Technology", "Description")
+```
+
+## Boundaries
+
+```text
+Enterprise_Boundary(alias, "Label") { ... }
+System_Boundary(alias, "Label") { ... }
+Container_Boundary(alias, "Label") { ... }
+Boundary(alias, "Label", "type") { ... }
+```
+
+## Relationships
+
+```text
+Rel(from, to, "Label")
+Rel(from, to, "Label", "Protocol/Technology")
+Rel_Back(from, to, "Label")
+Rel_Neighbor(from, to, "Label")
+BiRel(from, to, "Label")
+```
+
+## Styling
+
+```text
+UpdateElementStyle(alias, $fontColor="red", $bgColor="grey", $borderColor="red")
+UpdateRelStyle(from, to, $textColor="blue", $lineColor="blue", $offsetX="10", $offsetY="-40")
+UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+## Complete Example (System Context)
+
+```mermaid
+C4Context
+title System Context diagram for E-Commerce Platform
+
+Person(customer, "Customer", "Buys products online")
+Person(admin, "Admin", "Manages inventory and orders")
+
+Enterprise_Boundary(b0, "E-Commerce Platform") {
+    System(store, "Online Store", "Handles browsing, cart, and checkout")
+    SystemDb(db, "Product Database", "Stores products, orders, and customers")
+}
+
+System_Ext(payment, "Payment Provider", "Processes credit card payments")
+System_Ext(shipping, "Shipping Service", "Handles order fulfillment")
+System_Ext(email, "Email Service", "Sends transactional emails")
+
+Rel(customer, store, "Browses and purchases", "HTTPS")
+Rel(admin, store, "Manages", "HTTPS")
+Rel(store, db, "Reads/writes", "SQL")
+Rel(store, payment, "Processes payments", "API")
+Rel(store, shipping, "Creates shipments", "API")
+Rel(store, email, "Sends notifications", "SMTP")
+```
+
+## C4 Level Guidelines
+
+- **Level 1 (Context)**: Show the system as a single box. Focus on external actors and systems.
+- **Level 2 (Container)**: Zoom into the system. Show applications, databases, message queues.
+- **Level 3 (Component)**: Zoom into one container. Show internal classes/modules. Use sparingly — these rot fast.
+- **Avoid Level 4 (Code)**: Class diagrams at this level are better served by IDE tools.


### PR DESCRIPTION
## Summary

- Replace generic `graph TB` / subgraph diagrams with proper Mermaid C4 syntax (`C4Context`, `C4Container`, `C4Component`)
- Add C4 reference guide at `plugins/soleur/skills/architecture/references/c4-reference.md`
- Add new Level 3 component diagram for the Soleur Plugin
- Update SKILL.md diagram sub-command with C4-specific instructions and `component` type

## Changelog

- **Changed** system-context diagram to use `C4Context` with `Person`, `System`, `System_Ext`, `Enterprise_Boundary`, `Rel`
- **Changed** container diagram to use `C4Container` with `Container`, `ContainerDb`, `Container_Boundary`, `Rel`
- **Added** component-plugin diagram using `C4Component` showing workflow skills, domain leaders, and review agents
- **Added** C4 Mermaid syntax reference at `references/c4-reference.md` covering all 5 diagram types, element syntax, boundaries, relationships, and styling
- **Changed** SKILL.md diagram sub-command to reference C4 guide and support `context`, `container`, and `component` types

## Test plan

- [x] All 964 component tests pass
- [x] Markdown lint passes
- [x] Diagrams use valid C4 Mermaid syntax (C4Context, C4Container, C4Component keywords)
- [x] C4 reference covers all element types from Mermaid v11 docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)