### PR TITLE
docs(architecture): add Stripe, Plausible, Telegram to C4 diagrams

### DIFF
--- a/knowledge-base/engineering/architecture/diagrams/container.md
+++ b/knowledge-base/engineering/architecture/diagrams/container.md
@@ -12,6 +12,9 @@ System_Ext(anthropic, "Anthropic API", "Claude LLM")
 System_Ext(github, "GitHub", "Source control and CI/CD")
 System_Ext(cloudflare, "Cloudflare", "DNS, CDN, Tunnel, R2")
 System_Ext(doppler, "Doppler", "Secrets management")
+System_Ext(stripe, "Stripe", "Payment processing")
+System_Ext(plausible, "Plausible", "Privacy-focused analytics")
+System_Ext(telegram_api, "Telegram Bot API", "Messaging")
 
 Enterprise_Boundary(b0, "Soleur Platform") {
 
@@ -33,10 +36,14 @@ Enterprise_Boundary(b0, "Soleur Platform") {
         Container(kb, "Knowledge Base", "Markdown + YAML", "Conventions, learnings, ADRs, specs, plans, brainstorms")
     }
 
+    Container_Boundary(tgbridge, "Telegram Bridge") {
+        Container(tgbot, "Telegram Bot", "grammy, TypeScript", "Bridges Telegram messages to Claude Code CLI sessions")
+    }
+
     Container_Boundary(infra, "Infrastructure") {
         ContainerDb(supabase, "Supabase PostgreSQL", "PostgreSQL", "Users, BYOK-encrypted API keys, conversation sessions")
         Container(tunnel, "Cloudflare Tunnel", "cloudflared", "Zero-trust inbound access — no exposed ports")
-        Container(hetzner, "Compute", "Hetzner Cloud", "Docker containers running web app and CLI engine")
+        Container(hetzner, "Compute", "Hetzner Cloud", "Docker containers running web app, CLI engine, and telegram bridge")
     }
 }
 
@@ -57,6 +64,11 @@ Rel(tunnel, api, "Routes traffic", "HTTPS")
 Rel(hetzner, claude, "Hosts", "Docker")
 Rel(doppler, claude, "Injects secrets", "CLI")
 Rel(auth, supabase, "Validates tokens", "HTTPS")
+Rel(api, stripe, "Checkout and webhooks", "HTTPS")
+Rel(dashboard, plausible, "Page view events", "JS snippet")
+Rel(tgbot, telegram_api, "Receives/sends messages", "grammy SDK")
+Rel(tgbot, claude, "Bridges to CLI", "Subprocess")
+Rel(hetzner, tgbot, "Hosts", "Docker")
 ```
 
 ## Notes
@@ -66,3 +78,6 @@ Rel(auth, supabase, "Validates tokens", "HTTPS")
 - Knowledge base compounds ADRs, learnings, and conventions across sessions
 - Worktree isolation enforced via PreToolUse hooks (ADR-009)
 - Version derived from git tags at merge time, not committed files (ADR-017)
+- Stripe handles subscription checkout sessions and payment webhooks (test mode)
+- Plausible analytics embedded as JS snippet in the web dashboard (no cookies, GDPR-compliant)
+- Telegram bridge is a separate app (apps/telegram-bridge/) running as its own Docker container on Hetzner

--- a/knowledge-base/engineering/architecture/diagrams/system-context.md
+++ b/knowledge-base/engineering/architecture/diagrams/system-context.md
@@ -19,16 +19,24 @@ System_Ext(github, "GitHub", "Source control, CI/CD, issue tracking, and release
 System_Ext(cloudflare, "Cloudflare", "DNS, CDN, R2 storage, and zero-trust tunnel")
 System_Ext(doppler, "Doppler", "Centralized secrets management with runtime injection")
 System_Ext(discord, "Discord", "Community notifications and release announcements")
+System_Ext(stripe, "Stripe", "Payment processing and subscription billing")
+System_Ext(plausible, "Plausible Analytics", "Privacy-focused website analytics")
+System_Ext(telegram, "Telegram Bot API", "Messaging bridge for CLI access via Telegram")
 
 Rel(founder, webapp, "Interacts via browser", "HTTPS")
+Rel(founder, telegram, "Messages via Telegram", "Bot API")
 Rel(webapp, engine, "Thin view/control layer", "WebSocket")
 Rel(webapp, supabase, "Auth and data", "HTTPS")
+Rel(webapp, stripe, "Checkout and billing", "HTTPS")
+Rel(webapp, plausible, "Page view events", "JS snippet")
 Rel(engine, anthropic, "LLM calls with BYOK keys", "HTTPS")
 Rel(engine, github, "Git operations and CI", "HTTPS/SSH")
 Rel(engine, supabase, "Sessions and encrypted keys", "HTTPS")
 Rel(engine, discord, "Notifications", "Webhook")
+Rel(telegram, engine, "Bridges messages to CLI", "grammy SDK")
 Rel(cloudflare, webapp, "Tunnel, DNS, CDN", "HTTPS")
 Rel(doppler, engine, "Runtime secrets", "CLI")
+Rel(stripe, webapp, "Payment webhooks", "HTTPS")
 ```
 
 ## Notes
@@ -39,3 +47,6 @@ Rel(doppler, engine, "Runtime secrets", "CLI")
 - All infrastructure provisioned via Terraform with R2 remote backend (ADR-006, ADR-019)
 - Secrets managed via Doppler with runtime injection — no plaintext .env on disk (ADR-007)
 - Zero-trust access via Cloudflare Tunnel — server invisible to port scanners (ADR-008)
+- Stripe in test mode — subscription billing via checkout sessions and webhooks
+- Plausible Analytics for privacy-focused tracking (no cookies, GDPR-compliant)
+- Telegram bridge is a separate app (apps/telegram-bridge/) using grammy SDK


### PR DESCRIPTION
## Summary

- Add Stripe, Plausible Analytics, and Telegram Bot API as external systems to C4 diagrams
- Add Telegram Bridge as a separate container boundary in the container diagram
- Add relationships: Stripe checkout/webhooks, Plausible JS snippet, Telegram grammy SDK bridge

## Changelog

- **Changed** system-context diagram — added 3 external systems (Stripe, Plausible, Telegram) and their relationships
- **Changed** container diagram — added Telegram Bridge container boundary, Stripe/Plausible/Telegram relationships

## Test plan

- [x] Markdown lint passes
- [x] Diagrams use valid C4 Mermaid syntax
- [x] All active external providers now represented

🤖 Generated with [Claude Code](https://claude.com/claude-code)