### PR TITLE
docs(architecture): add NFR reference guide

### DIFF
--- a/plugins/soleur/skills/architecture/SKILL.md
+++ b/plugins/soleur/skills/architecture/SKILL.md
@@ -82,7 +82,7 @@ Create a new ADR with the next sequential number.
    - **Decision:** Which option was chosen and why?
    - **Consequences:** What becomes easier or harder?
    - **Cost Impacts:** How much does this change increase or reduce costs? (reference `knowledge-base/operations/expenses.md` for baseline; use "None" if no impact)
-   - **NFR Impacts:** Which non-functional requirements are affected? (reference NFR IDs from `knowledge-base/engineering/architecture/nfr-register.md`; use "None" if no impact)
+   - **NFR Impacts:** Which non-functional requirements are affected? Read [nfr-reference.md](./references/nfr-reference.md) for the assessment checklist and common patterns by decision type. Reference NFR IDs from `knowledge-base/engineering/architecture/nfr-register.md`. Use "None" if no impact.
    - **Diagram:** (optional) Should a Mermaid C4 diagram be included?
 
 7. **Write the ADR body** with the gathered context. If a diagram was requested, generate using proper C4 syntax from [c4-reference.md](./references/c4-reference.md).

--- a/plugins/soleur/skills/architecture/references/nfr-reference.md
+++ b/plugins/soleur/skills/architecture/references/nfr-reference.md
@@ -1,0 +1,72 @@
+# Non-Functional Requirements — Reference Guide
+
+Non-Functional Requirements (NFRs) define how the system should behave rather than what it should do. Every architecture decision should consider its impact on NFRs.
+
+## NFR Categories
+
+| Category | Scope | Example NFRs |
+|----------|-------|-------------|
+| Observability | Can we see what the system is doing? | Logging, monitoring, tracing, dashboards |
+| Resilience | Does the system recover from failures? | Circuit breakers, graceful shutdown, auto-healing |
+| Testing | Can we verify the system works? | Functional tests, performance tests, synthetic monitoring |
+| Configuration & Delivery | Can we deploy and configure safely? | Externalized config, CI/CD, canary upgrades |
+| Scaling & Recovery | Can the system grow and recover? | Auto-scaling, readiness/liveness probes |
+| Security | Is the system protected? | Encryption, rate limiting, attack detection |
+| Data Quality | Is the data trustworthy? | Freshness, accuracy, consistency |
+
+## NFR Register Location
+
+The canonical NFR register lives at `knowledge-base/engineering/architecture/nfr-register.md`. It contains all 30 NFRs with current status (Implemented, Partial, Not Implemented, N/A) and the tool that enforces each.
+
+## How to Reference NFRs in ADRs
+
+When writing the `## NFR Impacts` section of an ADR, reference NFRs by their ID and describe the status change:
+
+```markdown
+## NFR Impacts
+
+- **NFR-014 (Externalized Configuration):** Maintained — new service uses Doppler for secrets (no change)
+- **NFR-026 (Encryption In-Transit):** Improved from Partial to Implemented — all new endpoints use HTTPS via Cloudflare Tunnel
+- **NFR-007 (Circuit Breaker):** Risk introduced — new external API dependency has no circuit breaker; filed as follow-up
+```
+
+### Assessment Checklist
+
+When evaluating NFR impacts for a decision, check each category:
+
+1. **Observability:** Does this change add services, APIs, or components that need monitoring? Will existing logging capture the new behavior?
+2. **Resilience:** Does this introduce new failure modes? Are there fallbacks for external dependencies?
+3. **Testing:** Can the change be tested automatically? Does it need new test types (load, integration, E2E)?
+4. **Configuration & Delivery:** Does this add new environment variables, secrets, or deployment steps?
+5. **Scaling & Recovery:** Does this change the system's scaling characteristics? Are there new stateful components?
+6. **Security:** Does this expose new attack surfaces, handle sensitive data, or change authentication/authorization?
+7. **Data Quality:** Does this change how data is created, stored, or accessed? Are there new consistency requirements?
+
+### When to Update the NFR Register
+
+Update `knowledge-base/engineering/architecture/nfr-register.md` when:
+
+- An ADR changes the status of an NFR (e.g., Partial → Implemented)
+- A new NFR is identified that is not in the register
+- The enforcement tool changes (e.g., migrating from one monitoring service to another)
+- An NFR becomes N/A or newly relevant due to architecture changes
+
+## NFR Status Definitions
+
+| Status | Criteria |
+|--------|----------|
+| **Implemented** | Actively enforced by a tool or mechanism. Verified working. |
+| **Partial** | Some coverage but known gaps. Document what is and is not covered. |
+| **Not Implemented** | Acknowledged but no mechanism in place. May have a roadmap item. |
+| **N/A** | Not applicable at current scale or architecture. Revisit when conditions change. |
+
+## Common NFR Patterns by Decision Type
+
+| Decision Type | Typically Affects |
+|---------------|------------------|
+| New external service integration | NFR-001 (Logging), NFR-007 (Circuit Breaker), NFR-026 (Encryption In-Transit) |
+| Infrastructure change | NFR-002-004 (Monitoring), NFR-010 (Scalability), NFR-016 (CD), NFR-019 (Auto-scaling) |
+| New user-facing feature | NFR-008 (Latency), NFR-011 (Functional Testing), NFR-025 (Rate Limiting) |
+| Data model change | NFR-027 (Encryption At-Rest), NFR-029 (Data Freshness), NFR-030 (Data Accuracy) |
+| Security change | NFR-023-027 (full security category) |
+| Deployment change | NFR-016-018 (CD, Graceful Shutdown, Canary), NFR-021-022 (Readiness/Liveness) |


### PR DESCRIPTION
## Summary

- Add `nfr-reference.md` to `plugins/soleur/skills/architecture/references/` alongside `adr-template.md` and `c4-reference.md`
- Link from SKILL.md create sub-command for NFR impact assessment

## Changelog

- **Added** NFR reference guide covering categories, assessment checklist, status definitions, how to reference NFRs in ADRs, and common NFR patterns by decision type
- **Changed** SKILL.md create sub-command to reference the NFR guide when prompting for NFR impacts

## Test plan

- [x] All 964 tests pass
- [x] Markdown lint passes
- [x] Reference linked with proper markdown syntax (not bare backticks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)