### PR TITLE
fix(worktree): replace bare repo sync whitelist with full-tree extraction

### DIFF
--- a/knowledge-base/project/learnings/2026-03-20-bare-repo-plugin-hook-sync-gap.md
+++ b/knowledge-base/project/learnings/2026-03-20-bare-repo-plugin-hook-sync-gap.md
@@ -1,26 +1,28 @@
-# Learning: Bare repo plugin hook sync gap
+# Learning: Bare repo sync must use full-tree extraction, not a hardcoded whitelist
 
 ## Problem
 
-The `cleanup-merged` function in `worktree-manager.sh` syncs critical on-disk files from `git HEAD` after merging worktrees back to main. However, the sync list only included `.claude/hooks/*` (user hooks) and a handful of explicitly listed files. Plugin hooks at `plugins/soleur/hooks/` were not in the sync list.
+The `sync_bare_files` function in `worktree-manager.sh` used a hardcoded whitelist of ~11 files to sync from git HEAD to the bare repo root. This was the third occurrence of the same class of bug:
 
-In a bare repo, the working tree files on disk are not automatically updated by git operations. This meant `plugins/soleur/hooks/stop-hook.sh` on disk was stuck at an old version (167 lines, 20-char stuck threshold) while HEAD had the fully hardened version (315 lines, PID-based, 150-char threshold, similarity detection). The stale stop hook caused an infinite "finish all slash commands" loop because its 20-char stuck detection couldn't catch substantive-looking responses.
+1. **2026-03-13:** Initial sync function created with whitelist of config files (CLAUDE.md, settings.json, worktree-manager.sh)
+2. **2026-03-20:** Plugin hooks added to whitelist after stop-hook.sh staleness caused infinite loop
+3. **2026-03-27:** Commands (`go.md`), skills, agents, and docs still missing — 49 stale files + 13 missing files. The updated `/soleur:go` routing (brainstorm-first, no confirmation) was committed to main but never reached the bare root, causing the old 4-intent routing with confirmation to run instead.
+
+Each fix added more files to the whitelist, but the whitelist always fell behind as new files were added to the plugin.
 
 ## Solution
 
-Added all plugin hook files to the `cleanup-merged` sync list:
-
-- `plugins/soleur/hooks/hooks.json`
-- `plugins/soleur/hooks/stop-hook.sh`
-- `plugins/soleur/hooks/welcome-hook.sh`
-
-Also added `chmod +x` for plugin hook scripts after sync, matching the existing pattern for `.claude/hooks/`.
+[Updated 2026-03-27] Replaced the hardcoded whitelist with `git archive HEAD -- plugins/ CLAUDE.md AGENTS.md README.md .claude-plugin .claude/settings.json | tar -xC "$GIT_ROOT"`. This extracts the entire plugin tree in one shot — no whitelist to maintain, no files to miss.
 
 ## Key Insight
 
-In a bare repo, any file that Claude Code reads at runtime (not from a worktree checkout) must be in the `cleanup-merged` sync list. The sync list was designed for config files (CLAUDE.md, settings.json) and the worktree manager itself, but plugin hooks execute from the bare repo root via `${CLAUDE_PLUGIN_ROOT}` and were overlooked. When adding new runtime-critical files to `plugins/soleur/`, always check if they need to be added to the sync list.
+A hardcoded sync whitelist is a maintenance trap. Every new file requires remembering to update the list, and forgetting is silent — the stale file works fine until someone changes it. The fix is to sync entire directory trees (`git archive | tar -x`), not individual files. This is the same principle as "don't enumerate cases when you can match a pattern."
+
+## Session Errors
+
+- `/soleur:go` loaded stale instructions (old 4-intent routing with confirmation) because `go.md` was not in the sync whitelist. User had to manually select "Explore" to override the wrong default.
 
 ## Tags
 
 category: integration-issues
-module: git-worktree, ralph-loop
+module: git-worktree

--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -827,78 +827,49 @@ sync_bare_files() {
     return 0
   fi
 
-  echo -e "${BLUE}Syncing critical on-disk files from git HEAD...${NC}"
+  echo -e "${BLUE}Syncing on-disk files from git HEAD...${NC}"
 
-  # Create a temp directory on the same filesystem for atomic writes
-  local tmpdir
-  tmpdir=$(mktemp -d "${GIT_ROOT}/.sync-tmp.XXXXXX")
-  # shellcheck disable=SC2064  # Intentional: expand tmpdir NOW so the trap works after local scope ends
-  trap "rm -rf '$tmpdir'" EXIT
-
-  # Files that Claude Code reads from the bare repo root
-  local files=(
-    "AGENTS.md"
+  # Extract all plugin-loadable trees from HEAD in one shot.
+  # The old approach used a hardcoded whitelist that missed commands, skills,
+  # agents, and docs -- causing stale files after every merge (#1188 regression).
+  # git archive | tar -x overwrites in-place and adds new files atomically.
+  local trees=(
+    "plugins/"
     "CLAUDE.md"
+    "AGENTS.md"
+    "README.md"
     ".claude-plugin"
     ".claude/settings.json"
-    "plugins/soleur/AGENTS.md"
-    "plugins/soleur/CLAUDE.md"
-    "plugins/soleur/hooks/hooks.json"
-    "plugins/soleur/hooks/stop-hook.sh"
-    "plugins/soleur/hooks/welcome-hook.sh"
-    "plugins/soleur/scripts/resolve-git-root.sh"
-    "plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh"
   )
 
-  local synced=0
-  for file in "${files[@]}"; do
-    # Verify file exists in git HEAD
-    if ! git cat-file -e "HEAD:$file" 2>/dev/null; then
-      continue
-    fi
-
-    # Ensure parent directory exists on disk
-    local dir
-    dir=$(dirname "$GIT_ROOT/$file")
-    mkdir -p "$dir"
-
-    # Atomic write: extract to temp file, then mv into place
-    local safe_name="${file//\//_}"
-    local tmpfile="$tmpdir/${safe_name}"
-    if git show "HEAD:$file" > "$tmpfile" 2>/dev/null; then
-      mv "$tmpfile" "$GIT_ROOT/$file"
-      synced=$((synced + 1))
-    else
-      rm -f "$tmpfile"
-      echo -e "${YELLOW}Warning: Could not sync $file${NC}"
+  # Build archive args, skipping trees that don't exist in HEAD
+  local archive_args=()
+  for tree in "${trees[@]}"; do
+    if git cat-file -e "HEAD:$tree" 2>/dev/null; then
+      archive_args+=("$tree")
     fi
   done
 
-  # Restore execute permissions on scripts
-  chmod +x "$GIT_ROOT/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh" 2>/dev/null || true
-  chmod +x "$GIT_ROOT/plugins/soleur/hooks/"*.sh 2>/dev/null || true
+  if [[ ${#archive_args[@]} -eq 0 ]]; then
+    echo -e "${YELLOW}No syncable trees found in HEAD${NC}"
+    return 0
+  fi
 
-  # Sync hook scripts and restore execute permissions
+  # Extract directly into the bare repo root
+  if ! git archive HEAD -- "${archive_args[@]}" | tar -xC "$GIT_ROOT" 2>/dev/null; then
+    echo -e "${RED}Error: git archive extraction failed${NC}"
+    return 1
+  fi
+
+  # Sync hook scripts from .claude/hooks/ and restore execute permissions
   local hook_files
   hook_files=$(git ls-tree --name-only HEAD .claude/hooks/ 2>/dev/null || true)
   if [[ -n "$hook_files" ]]; then
     mkdir -p "$GIT_ROOT/.claude/hooks"
-    while IFS= read -r hook_file; do
-      # Validate path prefix to prevent unexpected writes
-      [[ "$hook_file" == .claude/hooks/* ]] || continue
-      local tmpfile="$tmpdir/$(basename "$hook_file").$$"
-      if git show "HEAD:$hook_file" > "$tmpfile" 2>/dev/null; then
-        mv "$tmpfile" "$GIT_ROOT/$hook_file"
-        chmod +x "$GIT_ROOT/$hook_file" 2>/dev/null || true
-        synced=$((synced + 1))
-      else
-        rm -f "$tmpfile"
-      fi
-    done <<< "$hook_files"
-  fi
+    git archive HEAD -- .claude/hooks/ | tar -xC "$GIT_ROOT" 2>/dev/null || true
+    chmod +x "$GIT_ROOT/.claude/hooks/"*.sh 2>/dev/null || true
 
-  # Remove stale hook files that no longer exist in git HEAD
-  if [[ -d "$GIT_ROOT/.claude/hooks" ]]; then
+    # Remove stale hook files that no longer exist in git HEAD
     for on_disk_hook in "$GIT_ROOT/.claude/hooks"/*; do
       [[ -f "$on_disk_hook" ]] || continue
       local hook_name
@@ -910,8 +881,11 @@ sync_bare_files() {
     done
   fi
 
+  # Restore execute permissions on scripts
+  find "$GIT_ROOT/plugins/" -name "*.sh" -exec chmod +x {} + 2>/dev/null || true
+  chmod +x "$GIT_ROOT/plugins/soleur/hooks/"*.sh 2>/dev/null || true
 
-  echo -e "${GREEN}Synced $synced file(s) from git HEAD${NC}"
+  echo -e "${GREEN}Synced on-disk files from git HEAD${NC}"
 }
 
 # Main command handler


### PR DESCRIPTION
## Summary

- Replace hardcoded 11-file whitelist in `sync_bare_files` with `git archive | tar -x` for entire `plugins/` tree
- Fixes stale `go.md` that caused old 4-intent routing to persist after #1189 merged
- Updates learning doc to capture the pattern: whitelists are maintenance traps for sync operations

Closes #1188

## Changelog

- **Fixed:** `sync_bare_files` now syncs all plugin files via full-tree extraction instead of a hardcoded whitelist. Prevents stale commands, skills, agents, and docs in bare repo roots after merges.

## Test plan

- [x] Verified syntax with `bash -n`
- [x] Tested `sync-bare` command: created stale marker in go.md, ran sync, verified marker removed
- [x] Verified zero drift: `diff -rq` between git HEAD and bare root shows 0 stale, 0 missing files
- [x] Full test suite passes (1411/1411)

🤖 Generated with [Claude Code](https://claude.com/claude-code)