### PR TITLE
fix(web-platform): use .then(onFulfilled, onRejected) for Supabase PromiseLike

### DIFF
--- a/apps/web-platform/server/ws-handler.ts
+++ b/apps/web-platform/server/ws-handler.ts
@@ -60,19 +60,23 @@ export function abortActiveSession(userId: string, session: ClientSession): void
 
   abortSession(userId, oldConvId, "superseded");
 
-  // Fire-and-forget — orphan cleanup catches failures on restart
+  // Fire-and-forget — orphan cleanup catches failures on restart.
+  // Supabase query builders return PromiseLike (not Promise), so use
+  // .then(onFulfilled, onRejected) instead of .then().catch().
   supabase
     .from("conversations")
     .update({ status: "completed", last_active: new Date().toISOString() })
     .eq("id", oldConvId)
-    .then(({ error }) => {
-      if (error) {
-        console.error(`[ws] Failed to mark conversation ${oldConvId} as completed: ${error.message}`);
-      }
-    })
-    .catch((err) => {
-      console.error(`[ws] Failed to update conversation ${oldConvId}: ${err}`);
-    });
+    .then(
+      ({ error }) => {
+        if (error) {
+          console.error(`[ws] Failed to mark conversation ${oldConvId} as completed: ${error.message}`);
+        }
+      },
+      (err) => {
+        console.error(`[ws] Failed to update conversation ${oldConvId}: ${err}`);
+      },
+    );
 
   session.conversationId = undefined;
 }


### PR DESCRIPTION
## Summary

- Supabase query builders return `PromiseLike` (not `Promise`), so `.catch()` doesn't exist on the chained result
- Use the two-argument form of `.then(onFulfilled, onRejected)` instead
- Fixes TypeScript build error that blocked deployment of the CSP nonce fix (#1213)

## Changelog

### Web Platform
- **Fixed:** TypeScript error in `ws-handler.ts` where `.catch()` was called on Supabase `PromiseLike`

## Test plan

- [x] Local type-check passes (ws-handler.ts error resolved)
- [x] Pre-commit hooks pass
- [ ] CI Docker build succeeds (the failing step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)