### PR TITLE
fix(web-platform): add type annotation for callback cookie parameter

### DIFF
--- a/apps/web-platform/app/(auth)/callback/route.ts
+++ b/apps/web-platform/app/(auth)/callback/route.ts
@@ -34,7 +34,13 @@ export async function GET(request: NextRequest) {
           getAll() {
             return request.cookies.getAll();
           },
-          setAll(cookiesToSet) {
+          setAll(
+            cookiesToSet: {
+              name: string;
+              value: string;
+              options: CookieOptions;
+            }[],
+          ) {
             cookiesToSet.forEach((cookie) => pendingCookies.push(cookie));
           },
         },


### PR DESCRIPTION
## Summary

- Docker build uses stricter TypeScript settings than local dev
- `cookiesToSet` parameter in the callback's `setAll` handler needed explicit typing
- Fixes build failure from #1219

## Test plan

- [x] Pre-commit hooks pass
- [ ] CI Docker build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)