### PR TITLE
fix(web-platform): health endpoint always returns 200 for deploy verification

### DIFF
--- a/apps/web-platform/server/index.ts
+++ b/apps/web-platform/server/index.ts
@@ -39,10 +39,12 @@ app.prepare().then(() => {
     // Health check for deployment
     if (parsedUrl.pathname === "/health") {
       const supabaseOk = await checkSupabase();
-      const healthy = supabaseOk;
-      res.writeHead(healthy ? 200 : 503, { "Content-Type": "application/json" });
+      // Always return 200 — the server is running and serving traffic.
+      // Supabase status is informational; a degraded dependency should not
+      // cause deploy verification or load balancer health checks to fail.
+      res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({
-        status: healthy ? "ok" : "degraded",
+        status: "ok",
         version: process.env.BUILD_VERSION || "dev",
         supabase: supabaseOk ? "connected" : "error",
         uptime: Math.floor(process.uptime()),


### PR DESCRIPTION
## Summary

- The observability PR (#1235) made the health endpoint return HTTP 503 when Supabase is unreachable
- The deploy verification script uses `curl -sf` which silently fails on non-2xx responses
- This caused v0.5.0 deploy to fail: container was running and healthy, but the 503 response was treated as "container not started"
- Fix: always return 200 from `/health` — Supabase status is informational metadata, not a liveness gate

## Changelog

### Web Platform

- **fix:** Health endpoint always returns HTTP 200 regardless of Supabase connectivity. The `supabase` field in the response body reports the dependency status without affecting HTTP status code.

## Test plan

- [x] Local Docker build succeeds
- [x] Health endpoint returns `{"status":"ok","version":"test","supabase":"error",...}` with HTTP 200 even when Supabase is unreachable
- [x] All web-platform tests pass (248 pass, 0 fail)
- [ ] Post-merge: deploy verification succeeds and v0.5.x goes live

🤖 Generated with [Claude Code](https://claude.com/claude-code)