### PR TITLE
docs: PWA content brief and content strategy update

### DIFF
--- a/knowledge-base/marketing/content-strategy.md
+++ b/knowledge-base/marketing/content-strategy.md
@@ -255,6 +255,7 @@ All content maps to one of four pillars. Each pillar targets a specific audience
 | Case Study: Competitive Intelligence | Case study | ~1,500 | P1 | **PUBLISHED** (2026-03-10). Lacks FAQ section (P1 fix). |
 | About/Founder Page | Authority page | 500-800 | P1 | Month 1. Gap 11. Low effort, high E-E-A-T impact. |
 | From Department Offices to Command Center | Build-in-public narrative | 1,500-2,000 | P1 | Month 1. Gap 13. Hero content for command center launch. Explains UX paradigm shift, auto-routing, multi-leader threading. Link target for social distribution. |
+| PWA Installability Milestone Announcement | Distribution (social) | N/A | P1 | **DRAFT** (2026-03-29). Social announcement for PWA shipping (PR #1256). Reinforces "accessible anywhere" positioning. Draft at `distribution-content/2026-03-29-pwa-installability-milestone.md`. |
 | How to Build a SaaS as a Solo Founder | Tutorial | 2,500-3,000 | P3 | Month 3+. |
 
 ---

--- a/knowledge-base/marketing/distribution-content/2026-03-29-pwa-installability-milestone.md
+++ b/knowledge-base/marketing/distribution-content/2026-03-29-pwa-installability-milestone.md
@@ -1,0 +1,85 @@
+---
+title: "Platform Milestone: Soleur Is Now Installable on Any Device"
+type: milestone-announcement
+publish_date: "2026-03-29"
+channels: discord, x, bluesky, linkedin-personal, linkedin-company
+status: draft
+pr_reference: "#1256"
+issue_reference: "#1042"
+roadmap_item: "Phase 1 item 1.6"
+---
+
+## Discord
+
+Soleur is now installable as an app on iOS, Android, and desktop.
+
+Open app.soleur.ai in your browser, tap "Install" or "Add to Home Screen," and the full AI organization lives on your device. No app store. No download. One tap.
+
+What this means:
+
+- Your phone becomes a direct line to 61 agents across 8 departments
+- The same compounding knowledge base, the same cross-domain coherence -- accessible from wherever you are
+- Works offline for cached content, syncs when you reconnect
+
+This is Phase 1 of the web platform. The mission has not changed: one founder, full AI organization, no compromises. What changed is where you access it.
+
+<https://app.soleur.ai>
+
+---
+
+## X/Twitter Thread
+
+Soleur is now installable as an app on any device. iOS, Android, desktop. No app store required.
+
+2/ Open app.soleur.ai in your browser. Tap "Add to Home Screen." Done. The full AI organization -- 61 agents across 8 departments -- lives on your device like a native app.
+
+3/ This matters because the web platform means Soleur is no longer tied to a terminal. Same compounding knowledge base. Same cross-domain coherence. Accessible from wherever you make decisions.
+
+4/ One codebase. Three surfaces. Progressive Web App architecture means we ship once and it works everywhere -- no separate iOS, Android, or desktop builds to maintain.
+
+Solo founder constraint applied to the delivery surface itself.
+
+<https://app.soleur.ai>
+
+<!-- markdownlint-disable-next-line MD018 -->
+#solofounder
+
+---
+
+## Bluesky
+
+Soleur is now installable on any device -- iOS, Android, desktop. Open app.soleur.ai, tap install, done. 61 agents across 8 departments, accessible from wherever you make decisions. No app store. No terminal required.
+
+---
+
+## LinkedIn Personal
+
+Six months ago, every interaction with Soleur happened in a terminal.
+
+That worked for me -- I built the product there. But when I talked to other solo founders, the terminal was a barrier. They wanted the AI organization accessible from their phone during a commute, from a tablet at a coffee shop, from whatever device they had in front of them when a decision needed to be made.
+
+So we rebuilt the access layer. Today, Soleur is installable as an app on iOS, Android, and desktop. No app store. No download. Open app.soleur.ai in a browser, tap install, and the full organization -- 61 agents across 8 departments with compounding knowledge -- lives on your device.
+
+The architecture decision was deliberate: Progressive Web App. One codebase, three surfaces. A solo founder building the delivery layer the same way a solo founder would want to use it -- no separate iOS and Android teams needed.
+
+The mission has not changed. What changed is that "accessible anywhere" is no longer a roadmap item. It shipped.
+
+<https://app.soleur.ai>
+
+<!-- markdownlint-disable-next-line MD018 -->
+#solofounder #buildinpublic
+
+---
+
+## LinkedIn Company Page
+
+Soleur is now installable as an app on iOS, Android, and desktop.
+
+The web platform at app.soleur.ai supports Progressive Web App installation -- open in a browser, tap install, and the full AI organization is accessible from any device. No app store required.
+
+This is Phase 1 of the platform delivery surface. 61 agents across 8 departments, compounding knowledge base, cross-domain coherence -- now accessible from wherever founders make decisions.
+
+<https://app.soleur.ai>
+
+<!-- markdownlint-disable-next-line MD018 -->
+#solofounder


### PR DESCRIPTION
## Summary

- Add distribution content draft for PWA installability milestone (Discord, X, Bluesky, LinkedIn copy)
- Update content-strategy.md pipeline with PWA entry

Retroactive CMO gate application for PR #1256 — PWA shipped without content consideration because the CMO gate's file-path-only triggers missed it.

## Changelog

- **Content strategy:** Added PWA installability milestone to Pillar 4 pipeline table
- **Distribution content:** New draft at `distribution-content/2026-03-29-pwa-installability-milestone.md`

## Test plan

- [x] Content draft has valid YAML frontmatter
- [x] Content-strategy.md pipeline entry references the draft file
- [x] Markdown lint passes

Generated with [Claude Code](https://claude.com/claude-code)