### PR TITLE
fix(ci): handle Plausible API HTTP 402 gracefully

### DIFF
--- a/knowledge-base/project/learnings/2026-03-30-plausible-http-402-graceful-skip.md
+++ b/knowledge-base/project/learnings/2026-03-30-plausible-http-402-graceful-skip.md
@@ -1,0 +1,27 @@
+# Learning: Plausible HTTP 402 Graceful Skip in CI Workflows
+
+## Problem
+
+The weekly analytics CI workflow (`scheduled-weekly-analytics.yml`) failed with HTTP 402 from the Plausible Stats API. The account is on the Growth plan ($9/mo) which does not include Stats API v1 access -- that requires the Business plan ($19/mo). The `provision-plausible-goals.sh` script had the same exposure. Both scripts treated any non-2xx response (except 401/429) as a hard failure (exit 1), triggering Discord failure notifications for what is actually a plan-tier limitation.
+
+## Solution
+
+Added HTTP 402 handling to both scripts:
+
+- `scripts/weekly-analytics.sh` `api_get()`: exit 0 with message explaining Stats API requires Business plan
+- `scripts/provision-plausible-goals.sh` `api_request()`: exit 0 with message explaining endpoint requires higher plan
+
+This matches the existing 401 graceful-skip pattern already in `provision-plausible-goals.sh`. Exit 0 prevents CI failure notifications; the informative message explains what was skipped and when it will auto-resolve.
+
+## Key Insight
+
+When integrating third-party APIs with tiered plans, map each non-2xx status code to either "code issue" (exit 1) or "account/config issue" (exit 0). Plan-tier restrictions (402) and authentication mismatches (401) are account issues that cannot be fixed by code changes -- they should skip gracefully, not alarm on-call.
+
+## Session Errors
+
+- **Stale bare-repo read:** Read `expenses.md` from the bare repo root instead of the worktree, showing outdated data (`free-trial` instead of `active`). Caught before any wrong action was taken. **Prevention:** Already covered by AGENTS.md rule: "After merging a PR, always read files from the merged branch... rather than reading from the bare repo directory."
+
+## Tags
+
+category: integration-issues
+module: ci/plausible-analytics

--- a/scripts/provision-plausible-goals.sh
+++ b/scripts/provision-plausible-goals.sh
@@ -92,6 +92,12 @@ api_request() {
       echo "This workflow will provision goals automatically once the plan includes Sites API access."
       exit 0
       ;;
+    402)
+      echo "Plausible API returned 402 -- this API endpoint requires a higher plan."
+      echo "Skipping goal provisioning. Goals can be configured manually in the dashboard."
+      echo "This workflow will provision goals automatically once the plan includes API access."
+      exit 0
+      ;;
     429)
       echo "Error: Plausible API rate limited (HTTP 429). Try again later." >&2
       exit 1

--- a/scripts/weekly-analytics.sh
+++ b/scripts/weekly-analytics.sh
@@ -211,6 +211,14 @@ main() {
       exit 1
     fi
 
+    if [[ "$http_code" == "402" ]]; then
+      echo "Plausible API returned 402 -- Stats API requires a Business plan or higher."
+      echo "Skipping analytics snapshot. The dashboard remains available at https://plausible.io/soleur.ai"
+      echo "This workflow will generate snapshots automatically once the plan includes Stats API access."
+      rm -f "$response_file"
+      exit 0
+    fi
+
     if [[ "$http_code" == "429" ]]; then
       echo "Plausible API rate limited (HTTP 429). Try again later." >&2
       rm -f "$response_file"


### PR DESCRIPTION
## Summary

- Plausible Growth plan does not include Stats API v1 (requires Business plan, $19/mo)
- `weekly-analytics.sh` and `provision-plausible-goals.sh` now exit 0 on HTTP 402 with an informative message instead of exit 1
- Prevents false Discord failure notifications every week while on the Growth plan

## Changelog

- **CI:** `weekly-analytics.sh` gracefully skips analytics snapshot on HTTP 402 (plan limitation)
- **CI:** `provision-plausible-goals.sh` gracefully skips goal provisioning on HTTP 402 (plan limitation)
- **Docs:** Added learning documenting the Plausible API tier limitations and graceful-skip pattern

## Test plan

- [x] `scripts/test-weekly-analytics.sh` passes (52/52 tests)
- [x] Verified 402 handler follows existing 401 graceful-skip pattern in provision-plausible-goals.sh
- [ ] Re-run `scheduled-weekly-analytics.yml` after merge to confirm it exits cleanly

Generated with [Claude Code](https://claude.com/claude-code)