### PR TITLE
fix(ci): use preflight check for Plausible 402 handling

### DIFF
--- a/knowledge-base/project/learnings/2026-03-30-plausible-http-402-graceful-skip.md
+++ b/knowledge-base/project/learnings/2026-03-30-plausible-http-402-graceful-skip.md
@@ -6,20 +6,21 @@ The weekly analytics CI workflow (`scheduled-weekly-analytics.yml`) failed with 
 
 ## Solution
 
-Added HTTP 402 handling to both scripts:
+Added preflight API access checks to both scripts that run outside `$()` command substitution:
 
-- `scripts/weekly-analytics.sh` `api_get()`: exit 0 with message explaining Stats API requires Business plan
-- `scripts/provision-plausible-goals.sh` `api_request()`: exit 0 with message explaining endpoint requires higher plan
+- `scripts/weekly-analytics.sh`: preflight curl check before `api_get` calls; exits 0 on HTTP 402
+- `scripts/provision-plausible-goals.sh`: preflight curl check before `api_request` calls; exits 0 on HTTP 401/402
 
-This matches the existing 401 graceful-skip pattern already in `provision-plausible-goals.sh`. Exit 0 prevents CI failure notifications; the informative message explains what was skipped and when it will auto-resolve.
+The preflight pattern is necessary because both `api_get` and `api_request` are called inside `$()` (e.g., `RESULT=$(api_get "...")`), which creates a subshell. `exit 0` inside a subshell only exits the subshell -- the parent script continues with the error message text as the "response", causing jq parse failures downstream. The preflight runs in the main shell where `exit 0` terminates the script.
 
 ## Key Insight
 
-When integrating third-party APIs with tiered plans, map each non-2xx status code to either "code issue" (exit 1) or "account/config issue" (exit 0). Plan-tier restrictions (402) and authentication mismatches (401) are account issues that cannot be fixed by code changes -- they should skip gracefully, not alarm on-call.
+Never rely on `exit 0` inside a bash function to gracefully terminate a script if that function is called inside `$()` command substitution. The `$()` creates a subshell where `exit` only exits the subshell. `exit 1` works because `set -e` catches it in the parent, but `exit 0` is invisible to `set -e`. For graceful-skip patterns, check the condition before entering `$()` or use a non-zero return code with explicit handling.
 
 ## Session Errors
 
 - **Stale bare-repo read:** Read `expenses.md` from the bare repo root instead of the worktree, showing outdated data (`free-trial` instead of `active`). Caught before any wrong action was taken. **Prevention:** Already covered by AGENTS.md rule: "After merging a PR, always read files from the merged branch... rather than reading from the bare repo directory."
+- **exit 0 in $() subshell:** First attempt (#1323) added `exit 0` inside `api_get` for 402 handling, but `api_get` is called inside `$()`. The`exit 0` only exited the subshell; the parent script continued with the error message as jq input, causing `jq: parse error`. Required a v2 fix with a preflight check outside`$()`. **Prevention:** When adding exit handlers to bash functions, trace all call sites to check if any use `$()` command substitution. If so, use a preflight check or non-zero return code pattern instead of `exit 0`.
 
 ## Tags
 

--- a/scripts/provision-plausible-goals.sh
+++ b/scripts/provision-plausible-goals.sh
@@ -87,16 +87,12 @@ api_request() {
       cat "$response_file"
       ;;
     401)
-      echo "Plausible API returned 401 -- Sites API requires an Enterprise plan."
-      echo "Skipping goal provisioning. Goals can be configured manually in the dashboard."
-      echo "This workflow will provision goals automatically once the plan includes Sites API access."
-      exit 0
+      echo "Plausible API returned 401 -- Sites API may require a higher plan." >&2
+      exit 1
       ;;
     402)
-      echo "Plausible API returned 402 -- this API endpoint requires a higher plan."
-      echo "Skipping goal provisioning. Goals can be configured manually in the dashboard."
-      echo "This workflow will provision goals automatically once the plan includes API access."
-      exit 0
+      echo "Plausible API returned 402 -- this API endpoint requires a higher plan." >&2
+      exit 1
       ;;
     429)
       echo "Error: Plausible API rate limited (HTTP 429). Try again later." >&2
@@ -135,6 +131,20 @@ provision_goal() {
 
   echo "[ok] Goal ready: ${display_name}"
 }
+
+# --- Preflight: Check API Plan Access ---
+# api_request is called inside $() (subshell) where exit only exits the subshell,
+# so plan-limitation checks must happen here before any $() calls.
+
+_preflight_code=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer ${PLAUSIBLE_API_KEY}" \
+  "${PLAUSIBLE_BASE_URL}/api/v1/sites/goals?site_id=${PLAUSIBLE_SITE_ID}" 2>/dev/null)
+if [[ "$_preflight_code" == "401" || "$_preflight_code" == "402" ]]; then
+  echo "Plausible API returned ${_preflight_code} -- Sites/Goals API requires a higher plan."
+  echo "Skipping goal provisioning. Goals can be configured manually in the dashboard."
+  echo "This workflow will provision goals automatically once the plan includes API access."
+  exit 0
+fi
 
 # --- Provision Goals ---
 

--- a/scripts/weekly-analytics.sh
+++ b/scripts/weekly-analytics.sh
@@ -212,11 +212,9 @@ main() {
     fi
 
     if [[ "$http_code" == "402" ]]; then
-      echo "Plausible API returned 402 -- Stats API requires a Business plan or higher."
-      echo "Skipping analytics snapshot. The dashboard remains available at https://plausible.io/soleur.ai"
-      echo "This workflow will generate snapshots automatically once the plan includes Stats API access."
+      echo "Plausible API returned 402 -- Stats API requires a Business plan or higher." >&2
       rm -f "$response_file"
-      exit 0
+      exit 1
     fi
 
     if [[ "$http_code" == "429" ]]; then
@@ -246,6 +244,21 @@ main() {
       echo "${secs}s"
     fi
   }
+
+  # --- Preflight: Check API Plan Access ---
+  # Runs outside $() so exit 0 terminates the script gracefully.
+  # api_get is called inside $() (subshell) where exit only exits the subshell,
+  # so plan-limitation checks must happen here before any $() calls.
+
+  _preflight_code=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer ${PLAUSIBLE_API_KEY}" \
+    "${PLAUSIBLE_BASE_URL}/api/v1/stats/aggregate?site_id=${PLAUSIBLE_SITE_ID}&period=day&metrics=visitors")
+  if [[ "$_preflight_code" == "402" ]]; then
+    echo "Plausible API returned 402 -- Stats API requires a Business plan or higher."
+    echo "Skipping analytics snapshot. The dashboard remains available at https://plausible.io/${PLAUSIBLE_SITE_ID}"
+    echo "This workflow will generate snapshots automatically once the plan includes Stats API access."
+    exit 0
+  fi
 
   # --- Fetch Data ---
 


### PR DESCRIPTION
## Summary

- Fixes the subshell bug from #1323 where `exit 0` inside `api_get`/`api_request` (called via `$()`) only exited the subshell, not the script
- Adds preflight curl checks outside `$()` that catch HTTP 402 (and 401 for goals) and exit 0 gracefully
- The `api_get`/`api_request` 402 handlers now use `exit 1` as defensive fallback (preflight should always catch it first)

## Changelog

- **CI:** `weekly-analytics.sh` preflight check catches HTTP 402 before any `$()` calls
- **CI:** `provision-plausible-goals.sh` preflight check catches HTTP 401/402 before any `$()` calls
- **CI:** Fixed pre-existing `exit 0` subshell bug in `provision-plausible-goals.sh` 401 handler
- **Docs:** Updated learning with bash subshell insight and session error

## Test plan

- [x] `scripts/test-weekly-analytics.sh` passes (52/52 tests)
- [x] Verified preflight runs outside `$()` where `exit 0` terminates the script
- [ ] Re-run `scheduled-weekly-analytics.yml` after merge to confirm clean exit on 402

Generated with [Claude Code](https://claude.com/claude-code)