### PR TITLE
fix: use dynamic import in delete route to avoid build-time Supabase init

### DIFF
--- a/apps/web-platform/app/api/account/delete/route.ts
+++ b/apps/web-platform/app/api/account/delete/route.ts
@@ -2,8 +2,6 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 import { SlidingWindowCounter } from "@/server/rate-limiter";
-import { deleteAccount } from "@/server/account-delete";
-import logger from "@/server/logger";
 
 // Rate limit: 1 deletion attempt per 60 seconds per user
 const deletionLimiter = new SlidingWindowCounter({
@@ -43,11 +41,17 @@ export async function POST(request: Request) {
     );
   }
 
+  // Dynamic import to avoid module-level Supabase client creation during build
+  // (account-delete imports agent-runner which creates a client at module scope)
+  const { deleteAccount } = await import("@/server/account-delete");
+  const { createChildLogger } = await import("@/server/logger");
+  const log = createChildLogger("account-delete-route");
+
   // Execute deletion cascade
   const result = await deleteAccount(user.id, body.confirmEmail);
 
   if (!result.success) {
-    logger.warn(
+    log.warn(
       { userId: user.id, error: result.error },
       "Account deletion failed",
     );


### PR DESCRIPTION
## Summary

- Use dynamic `import()` for `@/server/account-delete` and `@/server/logger` in the account deletion API route
- The static import chain (`account-delete` -> `agent-runner` -> module-level `createClient()`) caused `supabaseUrl is required` error during `next build` page data collection

Closes the release failure from #1361 merge.

## Changelog

### Web Platform
- **Fixed:** Account deletion route build failure caused by module-level Supabase client initialization

## Test plan

- [ ] `npm run build` succeeds (no `supabaseUrl is required` error)
- [ ] `npx vitest run test/account-delete.test.ts` passes (11 tests)
- [ ] Web Platform Release workflow succeeds after merge

Generated with [Claude Code](https://claude.com/claude-code)