### PR TITLE
fix(git-worktree): run ensure_bare_config in cleanup-merged

### DIFF
--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -597,6 +597,9 @@ cleanup_orphan_worktree_dirs() {
 
 # Clean up worktrees for merged branches (detects [gone] and merged-to-main)
 cleanup_merged_worktrees() {
+  # Fix bare repo config if broken (defense-in-depth on every session start)
+  ensure_bare_config
+
   # Determine output mode: verbose if TTY, quiet otherwise
   local verbose=false
   [[ -t 1 ]] && verbose=true


### PR DESCRIPTION
## Summary

- Added `ensure_bare_config` call at the top of `cleanup_merged_worktrees()` so the bare repo config is verified on every session start, not only during worktree creation

Closes #1416

## Changelog

- Fixed `core.bare=true` config regression by running the defense-in-depth check on every `cleanup-merged` call (session start gate)

## Test plan

- [x] Manually verified: broke config (`core.bare=true`, `repositoryformatversion=0`), ran `cleanup-merged`, confirmed config fixed
- [x] Pre-commit hooks pass

Generated with [Claude Code](https://claude.com/claude-code)