### PR TITLE
fix(workflow): weekly roadmap review with bidirectional integrity gate

### DIFF
--- a/.github/workflows/scheduled-roadmap-review.yml
+++ b/.github/workflows/scheduled-roadmap-review.yml
@@ -1,8 +1,8 @@
-name: "Scheduled: Monthly Roadmap Review"
+name: "Scheduled: Weekly Roadmap Review"
 
 on:
   schedule:
-    - cron: '0 9 1 * *'
+    - cron: '0 9 * * 1'
   workflow_dispatch: {}
 
 concurrency:
@@ -28,7 +28,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh label create "scheduled-roadmap-review" \
-            --description "Scheduled: Monthly Roadmap Review" \
+            --description "Scheduled: Weekly Roadmap Review" \
             --color "0E8A16" 2>/dev/null || true
 
       - name: Run roadmap review
@@ -42,32 +42,51 @@ jobs:
             --max-turns 40
             --allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch
           prompt: |
-            You are the CPO performing a monthly roadmap consistency review.
+            You are the CPO performing a weekly roadmap consistency review.
+
+            ## Part 1: Issue-to-Milestone Alignment
 
             1. Read knowledge-base/product/roadmap.md
-            2. Fetch all GitHub milestones: gh api repos/jikig-ai/soleur/milestones --jq '.[] | {number, title, open_issues, closed_issues}'
-            3. Fetch all open issues: gh issue list --state open --limit 100 --json number,title,labels,milestone
+            2. Fetch all GitHub milestones (open and closed): gh api 'repos/jikig-ai/soleur/milestones?state=all&per_page=100' --jq '.[] | {number, title, state, open_issues, closed_issues}'
+            3. Fetch all open issues with milestones: gh api 'repos/jikig-ai/soleur/issues?state=open&per_page=100' --paginate --jq '.[] | {number, title, milestone: .milestone.title}'
             4. For each open issue, check:
                - Is it assigned to the correct milestone per the roadmap?
                - Is it stale (superseded by roadmap decisions, no activity in 30+ days, references deprecated features)?
                - Does it have a priority label that matches its phase placement?
-            5. For each roadmap feature, check:
-               - Does a corresponding GitHub issue exist?
-               - Is the issue in the correct milestone?
-            6. Flag any inconsistencies found.
+
+            ## Part 2: Bidirectional Integrity Gate (milestones <-> issues)
+
+            5. For each roadmap phase table, check:
+               - Does EVERY feature row have a linked GitHub issue in the Issue column?
+               - Does that issue actually exist and is it in the correct milestone?
+               - If an issue is missing, flag it as MISSING_ISSUE
+            6. For each open milestone, check:
+               - Does it have at least one open issue? An open milestone with 0 open issues is either stale (should be closed) or incomplete (features defined but no issues created)
+               - Flag empty milestones as EMPTY_MILESTONE
+            7. For each roadmap feature status, check:
+               - Does the status column match the actual issue state? (e.g., "Not started" but issue is closed = stale status)
+               - Flag mismatches as STALE_STATUS
+
+            ## Rules
 
             MILESTONE RULE: Every gh issue create command must include --milestone.
             Use --milestone "Post-MVP / Later" for operational/maintenance issues.
             For feature issues, read knowledge-base/product/roadmap.md for available milestones and assign the one matching the relevant phase.
 
+            BIDIRECTIONAL RULE: Every feature in a roadmap phase table MUST have a linked GitHub issue. Every milestone MUST have at least one issue. These are both enforced -- violations are flagged as high severity.
+
+            ## Output
+
             After your analysis, create a GitHub issue summarizing your findings.
-            Use the title format: [Scheduled] Monthly Roadmap Review - YYYY-MM-DD
+            Use the title format: [Scheduled] Weekly Roadmap Review - YYYY-MM-DD
             Add the label: scheduled-roadmap-review
+            Add --milestone "Post-MVP / Later"
 
             The issue body should contain:
-            - Summary table of findings (consistent, inconsistent, stale, missing)
-            - List of recommended actions (close, move, create, relabel)
+            - Health summary: X consistent, Y inconsistent, Z stale, W missing
+            - Bidirectional gate results: empty milestones, missing issues, stale statuses
+            - Recommended actions table (close, move, create, relabel)
             - Any roadmap.md updates needed
 
-            If inconsistencies are found that can be fixed automatically (milestone reassignment, stale issue closure),
+            If inconsistencies are found that can be fixed automatically (milestone reassignment, stale issue closure, roadmap status updates),
             create a branch, apply the fixes, and open a PR. If only the review issue is needed, skip the PR.


### PR DESCRIPTION
## Summary

- Changes roadmap review schedule from monthly (1st of month) to **weekly** (every Monday 9am UTC)
- Adds **bidirectional integrity gate** as Part 2 of the review, checking:
  - `MISSING_ISSUE`: roadmap features without linked GitHub issues
  - `EMPTY_MILESTONE`: open milestones with zero issues
  - `STALE_STATUS`: roadmap status column mismatches vs actual issue state
- Fixes: review issue itself now includes `--milestone "Post-MVP / Later"` (was missing)
- Uses `gh api` with pagination instead of `gh issue list` for more reliable data

Closes the gap that allowed Phase 5 to exist as an empty milestone for weeks undetected.

## Test plan

- [ ] Trigger manual run via `gh workflow run scheduled-roadmap-review.yml` after merge
- [ ] Verify it creates a review issue with bidirectional gate results
- [ ] Verify YAML parses correctly (no heredoc/indentation issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)