### PR TITLE
fix: add persistSession:false to service client and error handling

### DIFF
--- a/apps/web-platform/app/api/repo/install/route.ts
+++ b/apps/web-platform/app/api/repo/install/route.ts
@@ -47,15 +47,32 @@ export async function POST(request: Request) {
   // NOTE: PostgREST does not expose the auth schema, so querying
   // auth.identities via .schema("auth") silently fails in production.
   const serviceClient = createServiceClient();
-  const { data: adminUser } = await serviceClient.auth.admin.getUserById(
-    user.id,
-  );
-  const githubIdentity = adminUser?.user?.identities?.find(
-    (i) => i.provider === "github",
-  );
-  const githubLogin = githubIdentity?.identity_data?.user_name as
-    | string
-    | undefined;
+  let githubLogin: string | undefined;
+  try {
+    const { data: adminUser, error: adminError } =
+      await serviceClient.auth.admin.getUserById(user.id);
+    if (adminError) {
+      logger.error(
+        { err: adminError, userId: user.id },
+        "auth.admin.getUserById failed",
+      );
+    }
+    const githubIdentity = adminUser?.user?.identities?.find(
+      (i) => i.provider === "github",
+    );
+    githubLogin = githubIdentity?.identity_data?.user_name as
+      | string
+      | undefined;
+  } catch (err) {
+    logger.error(
+      { err, userId: user.id },
+      "auth.admin.getUserById threw — check SUPABASE_SERVICE_ROLE_KEY and server connectivity",
+    );
+    return NextResponse.json(
+      { error: "Failed to resolve GitHub identity" },
+      { status: 500 },
+    );
+  }
 
   if (!githubLogin) {
     logger.warn(

--- a/apps/web-platform/lib/supabase/server.ts
+++ b/apps/web-platform/lib/supabase/server.ts
@@ -42,5 +42,11 @@ export function createServiceClient() {
   return createSupabaseClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    },
   );
 }

--- a/apps/web-platform/test/install-route-handler.test.ts
+++ b/apps/web-platform/test/install-route-handler.test.ts
@@ -173,4 +173,25 @@ describe("POST /api/repo/install — identity resolution", () => {
     const body = await res.json();
     expect(body.error).toMatch(/no github identity/i);
   });
+
+  test("returns 500 with descriptive error when getUserById throws", async () => {
+    mockGetUser.mockResolvedValue({
+      data: {
+        user: {
+          id: "user-crash",
+          identities: null,
+          app_metadata: { providers: ["email", "github"] },
+        },
+      },
+    });
+
+    mockAdminGetUserById.mockRejectedValue(
+      new Error("localStorage is not defined"),
+    );
+
+    const res = await POST(makeRequest({ installationId: 100 }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/failed to resolve/i);
+  });
 });


### PR DESCRIPTION
## Summary
- `createServiceClient()` was missing `auth: { persistSession: false, autoRefreshToken: false }`, causing `auth.admin.getUserById()` to throw in the server bundle (500 on `POST /api/repo/install`)
- Add try-catch around `getUserById()` so failures return a descriptive 500 JSON error instead of crashing the route handler

Closes #1461

## Changelog

### Web Platform
- fix: configure service client for server-side use (`persistSession: false`)
- fix: catch `getUserById` exceptions with descriptive error response

## Test plan
- [x] 5 install route handler tests pass (including new crash-handling test)
- [x] TypeScript build clean
- [x] All pre-commit hooks pass
- [ ] ⏳ Production verification: complete GitHub project setup flow after deploy

Generated with [Claude Code](https://claude.com/claude-code)