### PR TITLE
fix: prevent flash of choose screen on GitHub install callback

### DIFF
--- a/apps/web-platform/app/(auth)/connect-repo/page.tsx
+++ b/apps/web-platform/app/(auth)/connect-repo/page.tsx
@@ -994,7 +994,16 @@ export default function ConnectRepoPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const [state, setState] = useState<State>("choose");
+  const [state, setState] = useState<State>(() => {
+    // Avoid flashing the "choose" screen when returning from GitHub App install
+    if (typeof window !== "undefined") {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get("installation_id") && params.get("setup_action") === "install") {
+        return "github_redirect";
+      }
+    }
+    return "choose";
+  });
   const [repos, setRepos] = useState<Repo[]>([]);
   const [reposLoading, setReposLoading] = useState(false);
   const [connectedRepoName, setConnectedRepoName] = useState("");


### PR DESCRIPTION
## Summary
- Initialize connect-repo page state to `github_redirect` when `installation_id` is present in URL params
- Prevents 1-2s flash of the two-card choose screen before the useEffect processes the GitHub callback

## Changelog

### Web Platform
- fix: use lazy useState initializer to detect GitHub install callback params

## Test plan
- [x] All web-platform tests pass
- [x] TypeScript build clean

Generated with [Claude Code](https://claude.com/claude-code)