### PR TITLE
fix: derive agent count dynamically at build time

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -266,6 +266,14 @@ jobs:
           printf 'released=%s\n' "true" >> "$GITHUB_OUTPUT"
           echo "Created release $TAG"
 
+      - name: Count plugin components
+        id: plugin_stats
+        if: steps.version.outputs.next != '' && inputs.docker_image != ''
+        run: |
+          AGENT_COUNT=$(find plugins/soleur/agents -name "*.md" 2>/dev/null | wc -l)
+          printf 'agent_count=%s\n' "$AGENT_COUNT" >> "$GITHUB_OUTPUT"
+          echo "Counted $AGENT_COUNT agents"
+
       - name: Docker login
         id: docker_login
         if: steps.version.outputs.next != '' && inputs.docker_image != ''
@@ -295,6 +303,7 @@ jobs:
             SENTRY_ORG=${{ secrets.SENTRY_ORG }}
             SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}
             BUILD_VERSION=${{ steps.version.outputs.next }}
+            NEXT_PUBLIC_AGENT_COUNT=${{ steps.plugin_stats.outputs.agent_count }}
 
       - name: Set docker_pushed output
         id: docker_pushed

--- a/apps/web-platform/.env.example
+++ b/apps/web-platform/.env.example
@@ -59,6 +59,12 @@ NEXT_PUBLIC_SENTRY_DSN=
 # AZURE_CLIENT_ID=
 # AZURE_CLIENT_SECRET=
 
+# --- Plugin Stats ---
+# Agent count displayed in the connect-repo page. Computed automatically
+# by CI from plugins/soleur/agents/**/*.md. For local dev, generate with:
+#   find ../../plugins/soleur/agents -name "*.md" | wc -l
+# NEXT_PUBLIC_AGENT_COUNT=63
+
 # --- Optional ---
 # PORT=3000
 # WORKSPACES_ROOT=/workspaces

--- a/apps/web-platform/Dockerfile
+++ b/apps/web-platform/Dockerfile
@@ -14,6 +14,8 @@ ARG NEXT_PUBLIC_SUPABASE_URL
 ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
 ARG NEXT_PUBLIC_SENTRY_DSN
 ARG NEXT_PUBLIC_GITHUB_APP_SLUG
+# Plugin stats (computed by CI from plugins/soleur/agents/)
+ARG NEXT_PUBLIC_AGENT_COUNT
 # Sentry source map upload (builder stage only — not present in runner image)
 ARG SENTRY_AUTH_TOKEN
 ARG SENTRY_ORG

--- a/apps/web-platform/app/(auth)/connect-repo/page.tsx
+++ b/apps/web-platform/app/(auth)/connect-repo/page.tsx
@@ -857,7 +857,7 @@ function ReadyState({
           </div>
           <div className="flex items-center justify-between gap-8">
             <span className="text-sm text-neutral-500">Agents</span>
-            <span className="text-sm font-medium text-green-400">61 ready</span>
+            <span className="text-sm font-medium text-green-400">{process.env.NEXT_PUBLIC_AGENT_COUNT || "60+"} ready</span>
           </div>
         </div>
       </Card>


### PR DESCRIPTION
## Summary
- Replace hardcoded "61 ready" agent count in connect-repo ReadyState with NEXT_PUBLIC_AGENT_COUNT
- Count computed at CI build time from plugins/soleur/agents/**/*.md via reusable-release.yml
- Passed as Docker build arg, inlined by Next.js at build time
- Falls back to "60+" for local dev when env var is unset

Closes #1515, Closes #1471

## Changelog
### Web Platform
- Agent count in connect-repo ReadyState is now derived dynamically at build time instead of hardcoded
- Adding or removing an agent automatically updates the displayed count on next deploy

## Test plan
- [x] All tests pass locally (test-all.sh)
- [x] Pre-commit hooks pass (typecheck + bun test)
- [x] Code review confirms ARG is visible to RUN npm run build in Dockerfile
- [ ] Verify next web-platform release shows correct count (63) instead of stale 61

Generated with [Claude Code](https://claude.com/claude-code)