### PR TITLE
fix: remove unnecessary "use client" from pure UI wrappers (#1521)

### DIFF
--- a/apps/web-platform/components/ui/badge.tsx
+++ b/apps/web-platform/components/ui/badge.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 export function Badge({ children }: { children: React.ReactNode }) {
   return (
     <span className="text-xs font-medium uppercase tracking-widest text-amber-500/70">

--- a/apps/web-platform/components/ui/card.tsx
+++ b/apps/web-platform/components/ui/card.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 export function Card({ children, className }: { children: React.ReactNode; className?: string }) {
   return (
     <div className={`rounded-xl border border-neutral-800 bg-neutral-900/50 p-6 ${className ?? ""}`}>


### PR DESCRIPTION
## Summary
- Remove unnecessary "use client" from badge.tsx and card.tsx (pure markup wrappers with no hooks/handlers)
- gold-button.tsx and outlined-button.tsx retain "use client" (onClick handlers)

## Test plan
- [ ] Verify badge.tsx and card.tsx no longer have "use client"
- [ ] Verify gold-button.tsx and outlined-button.tsx still have "use client"
- [ ] TypeScript compiles without errors

Closes #1521

🤖 Generated with [Claude Code](https://claude.com/claude-code)