### PR TITLE
fix: add optional milestone param to create_dedup_issue()

### DIFF
--- a/scripts/content-publisher.sh
+++ b/scripts/content-publisher.sh
@@ -468,6 +468,7 @@ create_dedup_issue() {
   local title="$1"
   local body="$2"
   local labels="$3"
+  local milestone="${4:-Post-MVP / Later}"
 
   # Check for existing open issue with exact title match
   local existing
@@ -479,7 +480,7 @@ create_dedup_issue() {
     return 0
   fi
 
-  if gh issue create --title "$title" --label "$labels" --milestone "Post-MVP / Later" --body "$body"; then
+  if gh issue create --title "$title" --label "$labels" --milestone "$milestone" --body "$body"; then
     echo "[ok] Issue created: $title"
   else
     echo "Error: Failed to create issue: $title" >&2


### PR DESCRIPTION
## Summary
- Add `--milestone` parameter to `create_dedup_issue()` with default "Post-MVP / Later"
- Ensures all fallback issues created by content publisher include a milestone

## Test plan
- [x] `create_dedup_issue` includes --milestone in gh issue create
- [x] All callers work with the default milestone
- [x] No other `gh issue create` calls in the file are missing --milestone

Closes #1374

🤖 Generated with [Claude Code](https://claude.com/claude-code)