### PR TITLE
fix: document Docker stop timeout relationship with SIGTERM handler

### DIFF
--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -171,7 +171,7 @@ case "$COMPONENT" in
     if [[ "$CANARY_HEALTHY" == "true" ]]; then
       # SUCCESS: swap canary to production
       echo "Canary passed, swapping to production..."
-      { docker stop soleur-web-platform 2>/dev/null || true; }
+      { docker stop --time=12 soleur-web-platform 2>/dev/null || true; }
       { docker rm soleur-web-platform 2>/dev/null || true; }
 
       if docker run -d \

--- a/apps/web-platform/server/index.ts
+++ b/apps/web-platform/server/index.ts
@@ -73,6 +73,7 @@ app.prepare().then(() => {
     }
   });
 
+  // Must be less than Docker stop --time (12s) to allow graceful drain before SIGKILL
   const SHUTDOWN_TIMEOUT_MS = 8_000;
   let shuttingDown = false;
 


### PR DESCRIPTION
## Summary
- Add explicit `--time=12` to `docker stop` in ci-deploy.sh
- Add comment documenting the 8s app timeout / 12s Docker timeout relationship

## Test plan
- [ ] `docker stop` includes explicit --time=12
- [ ] Comment documents the timeout relationship in server/index.ts

Closes #1555

🤖 Generated with [Claude Code](https://claude.com/claude-code)