### PR TITLE
fix: add dedup guard to follow-through issue creation in /ship Step 3.5

### DIFF
--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -683,6 +683,14 @@ Poll every 10 seconds until state is `MERGED`.
 
    Then read `knowledge-base/product/roadmap.md` to determine the appropriate milestone. Default to "Post-MVP / Later" if unclear.
 
+   Before creating each follow-through issue, check for duplicates:
+
+   ```bash
+   gh issue list --label follow-through --state open --search "Source PR: #<PR_NUMBER>" --json title --jq '.[].title'
+   ```
+
+   If an issue with a matching title prefix already exists, skip creation and note "Dedup: skipped [title] -- existing issue found."
+
    For each item, write the issue body to a temp file (do NOT use heredocs in this step — write with `{ echo "..."; } > /tmp/follow-through-body.md`), then create the issue:
 
    ```bash


### PR DESCRIPTION
## Summary
- Add dedup check before follow-through issue creation in /ship Step 3.5
- Prevents duplicate issues when /ship Phase 7 reruns for the same PR

## Test plan
- [x] Step 3.5 includes dedup check before issue creation
- [x] Markdown lint passes

Closes #1460

🤖 Generated with [Claude Code](https://claude.com/claude-code)