### PR TITLE
fix(infra): move seccomp to per-container --security-opt

### DIFF
--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -136,6 +136,7 @@ case "$COMPONENT" in
       --name soleur-web-platform-canary \
       --restart no \
       --security-opt apparmor=unconfined \
+      --security-opt seccomp=/etc/docker/seccomp-profiles/soleur-bwrap.json \
       --env-file "$ENV_FILE" \
       -v /mnt/data/workspaces:/workspaces \
       -v /mnt/data/plugins/soleur:/app/shared/plugins/soleur:ro \
@@ -178,6 +179,7 @@ case "$COMPONENT" in
         --name soleur-web-platform \
         --restart unless-stopped \
         --security-opt apparmor=unconfined \
+        --security-opt seccomp=/etc/docker/seccomp-profiles/soleur-bwrap.json \
         --env-file "$ENV_FILE" \
         -v /mnt/data/workspaces:/workspaces \
         -v /mnt/data/plugins/soleur:/app/shared/plugins/soleur:ro \

--- a/apps/web-platform/infra/server.tf
+++ b/apps/web-platform/infra/server.tf
@@ -122,10 +122,10 @@ resource "terraform_data" "deploy_pipeline_fix" {
   }
 }
 
-# Deploy custom seccomp profile and update Docker daemon config (#1557).
+# Deploy custom seccomp profile for per-container use (#1557, #1569).
 # Enables bubblewrap sandbox inside containers by allowing CLONE_NEWUSER.
-# ci-deploy.sh is deployed by deploy_pipeline_fix above; this resource
-# only handles the seccomp profile and daemon.json configuration.
+# ci-deploy.sh applies the profile via --security-opt seccomp=<path>;
+# this resource only provisions the profile file and kernel sysctl.
 # Shows as "will be created" in CI drift reports -- expected behavior.
 resource "terraform_data" "docker_seccomp_config" {
   triggers_replace = sha256(file("${path.module}/seccomp-bwrap.json"))
@@ -150,13 +150,11 @@ resource "terraform_data" "docker_seccomp_config" {
 
   provisioner "remote-exec" {
     inline = [
-      "python3 -c \"import json; f='/etc/docker/daemon.json'; d=json.load(open(f)); d['seccomp-profile']='/etc/docker/seccomp-profiles/soleur-bwrap.json'; json.dump(d,open(f,'w'),indent=2); print('daemon.json updated')\"",
       # Ubuntu 24.04 kernel restricts uid_map writes inside unprivileged user namespaces
       # even with apparmor=unconfined. Disable this kernel-level restriction for bwrap (#1557).
       "sysctl -w kernel.apparmor_restrict_unprivileged_userns=0",
       "echo 'kernel.apparmor_restrict_unprivileged_userns=0' > /etc/sysctl.d/99-bwrap-userns.conf",
-      "systemctl restart docker",
-      "echo 'Docker restarted with custom seccomp profile and userns sysctl'",
+      "echo 'Seccomp profile provisioned and userns sysctl applied'",
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Move seccomp from daemon-wide daemon.json to per-container --security-opt
- Only soleur-web-platform gets the custom seccomp profile; telegram-bridge uses Docker defaults
- Remove daemon.json mutation and Docker restart from Terraform provisioner

## Test plan
- [ ] docker run includes --security-opt seccomp=path for web-platform only
- [ ] Terraform provisioner only copies seccomp profile file (no daemon.json, no restart)
- [ ] telegram-bridge unaffected by custom seccomp

Closes #1569

🤖 Generated with [Claude Code](https://claude.com/claude-code)