### PR TITLE
fix(infra): replace pipe-to-shell Docker install with GPG-verified APT repo

### DIFF
--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -182,8 +182,14 @@ runcmd:
   - chmod 600 /etc/default/webhook-deploy
   - chown deploy:deploy /etc/default/webhook-deploy
 
-  # Install Docker
-  - curl -fsSL https://get.docker.com | sh
+  # Install Docker via official APT repository with GPG key verification (#1615).
+  # Replaces pipe-to-shell (curl | sh) with signed APT repo -- same pattern as cloudflared above.
+  - install -m 0755 -d /etc/apt/keyrings
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+  - chmod a+r /etc/apt/keyrings/docker.asc
+  - echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu noble stable" > /etc/apt/sources.list.d/docker.list
+  - apt-get update
+  - apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin
 
   # Configure Docker log rotation
   - |


### PR DESCRIPTION
## Summary
- Replace `curl | sh` Docker install with GPG-verified APT repository
- Uses Docker's official GPG key at `/etc/apt/keyrings/docker.asc` with signed APT source
- Eliminates supply-chain risk from pipe-to-shell pattern (same class as #1500 Doppler fix)
- Matches existing cloudflared GPG + APT pattern already in cloud-init

## Test plan
- [ ] Docker install uses official APT repo with GPG key verification
- [ ] No pipe-to-shell pattern remains in cloud-init.yml
- [ ] cloud-init YAML structure is preserved

Closes #1615

🤖 Generated with [Claude Code](https://claude.com/claude-code)