### PR TITLE
fix: add session confirmation timeout for silent failure case (#1484)

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/chat/[conversationId]/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/chat/[conversationId]/page.tsx
@@ -37,6 +37,7 @@ export default function ChatPage() {
 
   const [sessionStarted, setSessionStarted] = useState(false);
   const [initialMsgSent, setInitialMsgSent] = useState(false);
+  const [sessionStartTimeout, setSessionStartTimeout] = useState(false);
   const [atQuery, setAtQuery] = useState("");
   const [atVisible, setAtVisible] = useState(false);
   const [atPosition, setAtPosition] = useState(0);
@@ -66,6 +67,17 @@ export default function ChatPage() {
       router.replace(pathname, { scroll: false });
     }
   }, [sessionConfirmed, msgParam, initialMsgSent, sendMessage, router, pathname]);
+
+  // Session confirmation timeout: if server never confirms, show error
+  useEffect(() => {
+    if (!sessionStarted || sessionConfirmed) return;
+
+    const timer = setTimeout(() => {
+      setSessionStartTimeout(true);
+    }, 10_000);
+
+    return () => clearTimeout(timer);
+  }, [sessionStarted, sessionConfirmed]);
 
   // Derive leader names for routing badge
   const respondingLeaders = messages
@@ -168,6 +180,17 @@ export default function ChatPage() {
               onRetry={lastError.code !== "key_invalid" ? reconnect : undefined}
               retryLabel="Reconnect"
               action={lastError.action}
+            />
+          </div>
+        )}
+
+        {sessionStartTimeout && !sessionConfirmed && (
+          <div className="mx-auto mb-4 max-w-3xl">
+            <ErrorCard
+              title="Session Failed to Start"
+              message="The server did not confirm the session within 10 seconds. Please try again."
+              onRetry={reconnect}
+              retryLabel="Reconnect"
             />
           </div>
         )}


### PR DESCRIPTION
## Summary

- Add 10-second timeout for session confirmation after sessionStarted
- Shows error if server never confirms session (prevents silent message drop)
- Timer cleared on confirmation or unmount

## Test plan

- [ ] Error shown if sessionConfirmed doesn't arrive within 10s
- [ ] Timer cleared when sessionConfirmed arrives (no false positives)
- [ ] Timer cleared on unmount (no memory leaks)
- [ ] Manual handleSend unaffected

Closes #1484

🤖 Generated with [Claude Code](https://claude.com/claude-code)