### PR TITLE
fix: add ca-certificates to Docker runner for git HTTPS clone

### DIFF
--- a/apps/web-platform/Dockerfile
+++ b/apps/web-platform/Dockerfile
@@ -33,8 +33,9 @@ FROM node:22-slim@sha256:4f77a690f2f8946ab16fe1e791a3ac0667ae1c3575c3e4d0d4589e9
 RUN npm install -g @anthropic-ai/claude-code@2.1.79
 
 # Install git (workspace provisioning) + bubblewrap/socat (Agent SDK sandbox)
+# ca-certificates: required for git HTTPS clone — node:22-slim omits it (#1645)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git bubblewrap socat \
+    ca-certificates git bubblewrap socat \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/knowledge-base/project/learnings/2026-04-06-node-slim-missing-ca-certificates.md
+++ b/knowledge-base/project/learnings/2026-04-06-node-slim-missing-ca-certificates.md
@@ -1,0 +1,67 @@
+---
+title: "node:22-slim missing ca-certificates breaks git HTTPS clone"
+date: 2026-04-06
+category: runtime-errors
+tags: [docker, git, ssl, ca-certificates, node-slim, workspace-provisioning]
+severity: high
+module: web-platform
+symptoms: ["Git clone failed: server certificate verification failed", "CAfile: none CRLfile: none"]
+root_cause: "node:22-slim Docker image does not include ca-certificates package"
+---
+
+# node:22-slim Missing ca-certificates Breaks Git HTTPS Clone
+
+## Problem
+
+Project setup (`provisionWorkspaceWithRepo` in `apps/web-platform/server/workspace.ts`) fails in the Docker container with:
+
+```text
+Git clone failed: server certificate verification failed. CAfile: none CRLfile: none
+```
+
+All HTTPS git operations inside the container are broken. Users cannot connect repositories.
+
+## Root Cause Analysis
+
+The `node:22-slim` Docker base image does NOT include the `ca-certificates` package. Git's HTTPS transport uses GnuTLS which looks for the CA bundle at `/etc/ssl/certs/ca-certificates.crt`. Without this file, all HTTPS git operations fail.
+
+**Why Node.js itself was unaffected:** Node.js bundles its own Mozilla CA certificates in the binary. Node's `fetch()`, `https`, and npm operations use this internal bundle -- they do not depend on the system CA store.
+
+**AppArmor ruled out:** The AppArmor profile allows broad `file` access and does not restrict reading from `/etc/ssl/`.
+
+## Solution
+
+Add `ca-certificates` to the existing `apt-get install` line in `apps/web-platform/Dockerfile` runner stage (~400KB addition):
+
+```diff
+ # Install git (workspace provisioning) + bubblewrap/socat (Agent SDK sandbox)
++# ca-certificates: required for git HTTPS clone -- node:22-slim omits it (#1645)
+ RUN apt-get update && apt-get install -y --no-install-recommends \
+-    git bubblewrap socat \
++    ca-certificates git bubblewrap socat \
+     && rm -rf /var/lib/apt/lists/*
+```
+
+No code changes needed in `workspace.ts` -- git just needs its CA bundle on the filesystem.
+
+## Key Insight
+
+`-slim` Docker images strip packages you might assume are always present. When adding system binaries to a slim image (like `git`), audit their runtime dependencies -- not just whether the binary installs. `git` installed fine but its HTTPS transport silently depended on `ca-certificates`. The failure only appeared at clone time, not at install time.
+
+General pattern: any tool making outbound TLS connections via the system TLS library needs `ca-certificates` on Debian-slim images (`git`, `curl`, `wget`, `openssl s_client`).
+
+## Session Errors
+
+1. **Subagent rate limit during plan+deepen phase** -- Planning subagent hit API rate limits, so planning was completed inline. No impact on the fix itself.
+   - **Prevention:** No workflow change possible -- rate limits are external. The inline fallback worked correctly.
+
+## Cross-References
+
+- `knowledge-base/project/learnings/2026-03-20-node-slim-missing-curl-healthcheck.md` -- Same root cause pattern (slim image missing packages)
+- `knowledge-base/project/learnings/2026-03-20-multistage-docker-build-esbuild-server-compilation.md` -- Multi-stage Dockerfile rewrite where runner `apt-get install` was first added
+- `knowledge-base/project/learnings/2026-03-20-docker-nonroot-user-with-volume-mounts.md` -- Git config for the non-root user that runs the clone
+
+## Tags
+
+category: runtime-errors
+module: web-platform

--- a/knowledge-base/project/plans/archive/20260406-160050-2026-04-06-fix-ssl-cert-verification-plan.md
+++ b/knowledge-base/project/plans/archive/20260406-160050-2026-04-06-fix-ssl-cert-verification-plan.md
@@ -1,0 +1,39 @@
+# Fix: SSL Certificate Verification Failure in Project Setup
+
+## Problem
+
+Project setup fails with:
+
+```
+Git clone failed: server certificate verification failed. CAfile: none CRLfile: none
+```
+
+## Root Cause
+
+The `node:22-slim` Docker base image does NOT include the `ca-certificates` package.
+Git's HTTPS transport (via libcurl/GnuTLS) requires the system CA bundle at
+`/etc/ssl/certs/ca-certificates.crt` to verify server certificates. Without it,
+all HTTPS git operations fail.
+
+Verified: `docker run --rm node:22-slim dpkg -l ca-certificates` shows status `un` (not installed).
+
+## Fix
+
+Add `ca-certificates` to the `apt-get install` line in the Dockerfile runner stage (line 36-38).
+
+### Files to Change
+
+| File | Change |
+|------|--------|
+| `apps/web-platform/Dockerfile` | Add `ca-certificates` to `apt-get install` |
+
+### Test Scenarios
+
+- Docker build succeeds with the added package
+- `git clone https://github.com/...` works inside the built container (CA bundle exists)
+
+## Risk Assessment
+
+- **Blast radius**: Docker image only, production deploy required
+- **Reversibility**: Trivial — revert one line
+- **Package size impact**: ~400KB (CA certificates bundle)

--- a/knowledge-base/project/specs/archive/20260406-feat-fix-ssl-cert-verification/session-state.md
+++ b/knowledge-base/project/specs/archive/20260406-feat-fix-ssl-cert-verification/session-state.md
@@ -1,0 +1,24 @@
+# Session State
+
+## Plan Phase
+
+- Plan file: knowledge-base/project/plans/2026-04-06-fix-ssl-cert-verification-plan.md
+- Status: complete (fallback — subagent hit rate limit)
+
+### Errors
+
+- Subagent hit rate limit during plan+deepen phase; planning done inline
+
+### Decisions
+
+- Root cause confirmed: `ca-certificates` package missing from `node:22-slim` Docker image
+- Fix is a one-line Dockerfile change — add `ca-certificates` to `apt-get install`
+- AppArmor profile ruled out — it allows broad `file` access
+- No code changes needed in `workspace.ts` — the git binary just needs its CA bundle
+
+### Components Invoked
+
+- Dockerfile analysis
+- Docker image inspection (`docker run --rm node:22-slim dpkg -l ca-certificates`)
+- AppArmor profile review
+- workspace.ts and route.ts code review


### PR DESCRIPTION
## Summary

- Add `ca-certificates` package to Dockerfile runner stage `apt-get install`
- `node:22-slim` omits this package, causing all git HTTPS operations to fail with "server certificate verification failed"
- One-line fix, ~400KB image size increase (Mozilla CA bundle)

Closes #1645

## Changelog

- **fix:** Install `ca-certificates` in Docker runner stage so git can verify HTTPS server certificates during workspace provisioning

## Test plan

- [x] Docker build succeeds with the added package
- [x] All test suites pass (9/9)
- [x] Security review: no findings (safe standard Debian package)
- [x] Architecture review: correct layer, no Node.js TLS conflict
- [ ] Post-deploy: verify `git clone https://...` works inside container

Generated with [Claude Code](https://claude.com/claude-code)