### PR TITLE
fix: update CI ruleset script and required-checks comments

### DIFF
--- a/scripts/create-ci-required-ruleset.sh
+++ b/scripts/create-ci-required-ruleset.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Create the "CI Required" repository ruleset on jikig-ai/soleur.
 #
-# This script adds the `test` status check as a required check on main,
-# preventing auto-merge when CI fails or is skipped.
+# This script adds the `test`, `dependency-review`, and `e2e` status checks
+# as required checks on main, preventing auto-merge when CI fails or is skipped.
 #
 # IMPORTANT: Run this AFTER the bot workflow updates have merged to main.
 # If run before, bot PRs using [skip ci] will be permanently blocked
-# because the `test` check remains in "Pending" state forever.
+# because the required checks remain in "Pending" state forever.
 #
 # Refs: #826, #820
 

--- a/scripts/required-checks.txt
+++ b/scripts/required-checks.txt
@@ -1,17 +1,24 @@
 # Required synthetic check-run names for bot PRs.
 #
+# These checks span multiple GitHub rulesets:
+#   - "CI Required" ruleset: test, dependency-review, e2e
+#     (managed by scripts/create-ci-required-ruleset.sh)
+#   - "CLA Required" ruleset: cla-check
+#
 # Every scheduled-*.yml workflow that creates PRs via GITHUB_TOKEN must post
 # synthetic check-runs for each name listed here. GITHUB_TOKEN PRs do not
 # trigger CI (GitHub prevents infinite loops), so without synthetics the
-# CI Required ruleset blocks auto-merge indefinitely.
+# rulesets block auto-merge indefinitely.
 #
-# When adding a new required check to the CI Required ruleset
-# (scripts/create-ci-required-ruleset.sh), add it here too.
+# When adding a new required check to any ruleset, add it here too.
 #
 # Format: one check name per line, blank lines and # comments ignored.
 # Refs: #826, #1468
 
+# CI Required ruleset
 test
-cla-check
 dependency-review
 e2e
+
+# CLA Required ruleset
+cla-check


### PR DESCRIPTION
## Summary
- Updated `scripts/create-ci-required-ruleset.sh` header comment to mention all three required checks (test, dependency-review, e2e) instead of only `test`
- Updated `scripts/required-checks.txt` comment to clarify multi-ruleset scope: CI Required (test, dependency-review, e2e) vs CLA Required (cla-check), and grouped checks by ruleset

## Test plan
- [x] Verify `create-ci-required-ruleset.sh` header accurately describes the three checks in the JSON payload
- [x] Verify `required-checks.txt` groups checks by ruleset with clear section comments
- [x] No functional changes -- comment/doc fixes only

Closes #1656

🤖 Generated with [Claude Code](https://claude.com/claude-code)