### PR TITLE
fix: add disconnect route select-error test case

### DIFF
--- a/apps/web-platform/test/disconnect-route.test.ts
+++ b/apps/web-platform/test/disconnect-route.test.ts
@@ -70,13 +70,14 @@ const TEST_USER_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 /** Sets up Supabase mock chain for the users table. */
 function setupUserMocks(opts: {
   repoStatus?: string;
+  selectError?: { message: string } | null;
   updateError?: { message: string } | null;
 }) {
-  const { repoStatus = "ready", updateError = null } = opts;
+  const { repoStatus = "ready", selectError = null, updateError = null } = opts;
 
   const mockSelectSingle = vi.fn().mockResolvedValue({
-    data: { repo_status: repoStatus },
-    error: null,
+    data: selectError ? null : { repo_status: repoStatus },
+    error: selectError,
   });
   const mockSelectEq = vi.fn(() => ({ single: mockSelectSingle }));
   const mockSelect = vi.fn(() => ({ eq: mockSelectEq }));
@@ -148,6 +149,16 @@ describe("DELETE /api/repo/disconnect", () => {
 
     const body = await res.json();
     expect(body.error).toMatch(/in progress/i);
+  });
+
+  test("returns 500 when select query fails", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
+    setupUserMocks({ selectError: { message: "database unreachable" } });
+
+    const res = await DELETE(makeRequest());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/failed to disconnect/i);
   });
 
   test("returns 200 and clears all repo fields on successful disconnect", async () => {


### PR DESCRIPTION
## Summary
- Adds `selectError` parameter to `setupUserMocks` helper in disconnect route tests
- Adds test case covering the 500 response when the initial `select` query to read `repo_status` fails (route.ts lines 51-59)
- All 8 tests pass (7 existing + 1 new)

Closes #1660

## Test plan
- [x] `npx vitest run test/disconnect-route.test.ts` passes with all 8 tests green
- [x] New test verifies 500 status and "failed to disconnect" error message when select returns an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)