### PR TITLE
fix: add disconnect route update-error test case

### DIFF
--- a/apps/web-platform/test/disconnect-route.test.ts
+++ b/apps/web-platform/test/disconnect-route.test.ts
@@ -190,6 +190,16 @@ describe("DELETE /api/repo/disconnect", () => {
     expect(body.ok).toBe(true);
   });
 
+  test("returns 500 when database update fails", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
+    setupUserMocks({ repoStatus: "ready", updateError: { message: "constraint violation" } });
+
+    const res = await DELETE(makeRequest());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/failed to disconnect/i);
+  });
+
   test("returns 200 idempotently when user has no connected repo", async () => {
     mockGetUser.mockResolvedValue({
       data: { user: { id: TEST_USER_ID } },


### PR DESCRIPTION
## Summary
- Add test case exercising the `updateError` parameter of `setupUserMocks` in `disconnect-route.test.ts`
- Verifies the route returns 500 with "Failed to disconnect repository" when the Supabase update fails (lines 83-91 of route.ts)
- The mock helper already supported `updateError` but no test used it

Closes #1659

## Test plan
- [x] New test passes locally (`npx vitest run test/disconnect-route.test.ts` -- 8/8 passing)
- [x] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)