### PR TITLE
fix(security): add owner/repo format validation for GitHub API URL interpolation

### DIFF
--- a/apps/web-platform/server/agent-runner.ts
+++ b/apps/web-platform/server/agent-runner.ts
@@ -375,6 +375,14 @@ When you need user input for important decisions, use the AskUserQuestion tool.`
         repo = "";
       }
 
+      // Validate owner/repo contain only safe GitHub name characters
+      // to prevent path-traversal or injection in API URL interpolation.
+      const GITHUB_NAME_RE = /^[a-zA-Z0-9._-]+$/;
+      if (!GITHUB_NAME_RE.test(owner) || !GITHUB_NAME_RE.test(repo)) {
+        owner = "";
+        repo = "";
+      }
+
       if (owner && repo) {
         const createPr = tool(
           "create_pull_request",

--- a/apps/web-platform/test/agent-runner-tools.test.ts
+++ b/apps/web-platform/test/agent-runner-tools.test.ts
@@ -238,6 +238,71 @@ describe("agent-runner MCP tool wiring", () => {
     expect(result.behavior).toBe("deny");
   });
 
+  test("omits mcpServers when repo_url owner contains URL-encoded traversal", async () => {
+    // %2F decodes to '/' inside a segment — the regex rejects '%'
+    setupSupabaseMock({
+      workspace_path: "/tmp/test-workspace",
+      repo_status: "ready",
+      github_installation_id: 12345,
+      repo_url: "https://github.com/..%2F..%2Fetc/passwd",
+    });
+    setupQueryMockImmediate();
+
+    await startAgentSession("user-1", "conv-1", "cpo");
+
+    expect(mockQuery).toHaveBeenCalledOnce();
+    const options = mockQuery.mock.calls[0][0].options;
+    expect(options.mcpServers).toBeUndefined();
+  });
+
+  test("omits mcpServers when repo_url has missing segments", async () => {
+    setupSupabaseMock({
+      workspace_path: "/tmp/test-workspace",
+      repo_status: "ready",
+      github_installation_id: 12345,
+      repo_url: "https://github.com/owner-only",
+    });
+    setupQueryMockImmediate();
+
+    await startAgentSession("user-1", "conv-1", "cpo");
+
+    expect(mockQuery).toHaveBeenCalledOnce();
+    const options = mockQuery.mock.calls[0][0].options;
+    expect(options.mcpServers).toBeUndefined();
+  });
+
+  test("omits mcpServers when repo_url is not a valid URL", async () => {
+    setupSupabaseMock({
+      workspace_path: "/tmp/test-workspace",
+      repo_status: "ready",
+      github_installation_id: 12345,
+      repo_url: "not-a-url",
+    });
+    setupQueryMockImmediate();
+
+    await startAgentSession("user-1", "conv-1", "cpo");
+
+    expect(mockQuery).toHaveBeenCalledOnce();
+    const options = mockQuery.mock.calls[0][0].options;
+    expect(options.mcpServers).toBeUndefined();
+  });
+
+  test("omits mcpServers when repo_url owner contains special characters", async () => {
+    setupSupabaseMock({
+      workspace_path: "/tmp/test-workspace",
+      repo_status: "ready",
+      github_installation_id: 12345,
+      repo_url: "https://github.com/owner%2F..%2F/repo",
+    });
+    setupQueryMockImmediate();
+
+    await startAgentSession("user-1", "conv-1", "cpo");
+
+    expect(mockQuery).toHaveBeenCalledOnce();
+    const options = mockQuery.mock.calls[0][0].options;
+    expect(options.mcpServers).toBeUndefined();
+  });
+
   test("canUseTool still denies non-mcp unrecognized tools", async () => {
     setupSupabaseMock({
       workspace_path: "/tmp/test-workspace",


### PR DESCRIPTION
## Summary

- Add `GITHUB_NAME_RE` regex validation after URL parsing of `owner`/`repo` in `agent-runner.ts` to prevent path-traversal or injection via malformed `repo_url` values before they reach GitHub API URL interpolation in `github-app.ts`
- Add 4 test cases covering URL-encoded traversal, missing path segments, invalid URLs, and special characters in owner/repo

Closes #1661

## Test plan

- [x] All 9 tests in `agent-runner-tools.test.ts` pass (4 new + 5 existing)
- [x] Regex rejects `%2F`-encoded path traversal attempts
- [x] Regex rejects URLs with missing owner or repo segments
- [x] Regex allows valid GitHub names (alphanumeric, dots, hyphens, underscores)

🤖 Generated with [Claude Code](https://claude.com/claude-code)