### PR TITLE
fix(health): update comment to reflect deploy verification gating

### DIFF
--- a/apps/web-platform/server/index.ts
+++ b/apps/web-platform/server/index.ts
@@ -27,9 +27,9 @@ app.prepare().then(() => {
 
     // Health check for deployment
     if (parsedUrl.pathname === "/health") {
-      // Always return 200 — the server is running and serving traffic.
-      // Supabase/Sentry status is informational; a degraded dependency should not
-      // cause deploy verification or load balancer health checks to fail.
+      // Always return 200 for load balancer probes.
+      // CI deploy verification (web-platform-release.yml) reads the response body
+      // to gate on version match and supabase connectivity.
       const health = await buildHealthResponse();
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(health));

--- a/knowledge-base/project/plans/2026-04-07-fix-health-endpoint-comment-plan.md
+++ b/knowledge-base/project/plans/2026-04-07-fix-health-endpoint-comment-plan.md
@@ -37,10 +37,10 @@ Suggested replacement comment:
 
 ## Acceptance Criteria
 
-- [ ] Comment in `apps/web-platform/server/index.ts` accurately reflects that deploy verification gates on supabase status
-- [ ] Comment still explains why HTTP 200 is always returned (load balancer compatibility)
-- [ ] No code logic changes -- comment-only update
-- [ ] Sentry mention removed from the comment (Sentry status is not gated by CI; it remains purely informational in the response body)
+- [x] Comment in `apps/web-platform/server/index.ts` accurately reflects that deploy verification gates on supabase status
+- [x] Comment still explains why HTTP 200 is always returned (load balancer compatibility)
+- [x] No code logic changes -- comment-only update
+- [x] Sentry mention removed from the comment (Sentry status is not gated by CI; it remains purely informational in the response body)
 
 ## Test Scenarios
 

--- a/knowledge-base/project/specs/feat-one-shot-1709-health-comment/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-1709-health-comment/session-state.md
@@ -1,0 +1,22 @@
+# Session State
+
+## Plan Phase
+
+- Plan file: knowledge-base/project/plans/2026-04-07-fix-health-endpoint-comment-plan.md
+- Status: complete
+
+### Errors
+
+None
+
+### Decisions
+
+- Comment-only change, no code logic modifications
+- Remove Sentry mention from the comment (Sentry status is not gated by CI)
+- Clarify dual-purpose design: HTTP 200 for load balancer probes, response body for CI gating
+- Reference the specific workflow file (web-platform-release.yml) in the comment
+
+### Components Invoked
+
+- soleur:plan
+- soleur:deepen-plan (plan-review with DHH, Kieran, code-simplicity reviewers)

--- a/knowledge-base/project/specs/feat-one-shot-1709-health-comment/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-1709-health-comment/tasks.md
@@ -4,11 +4,11 @@ Source: `knowledge-base/project/plans/2026-04-07-fix-health-endpoint-comment-pla
 
 ## Phase 1: Implementation
 
-- [ ] 1.1 Update comment block in `apps/web-platform/server/index.ts` (lines 30-32)
+- [x] 1.1 Update comment block in `apps/web-platform/server/index.ts` (lines 30-32)
   - Replace existing 3-line comment with updated wording reflecting dual-purpose design
   - Keep line 29 (`// Health check for deployment`) unchanged
 
 ## Phase 2: Verification
 
-- [ ] 2.1 Run `npx tsc --noEmit` in `apps/web-platform/` to confirm no TypeScript errors
-- [ ] 2.2 Visual review: confirm comment accurately describes both load balancer and CI gating behavior
+- [x] 2.1 Run `npx tsc --noEmit` in `apps/web-platform/` to confirm no TypeScript errors
+- [x] 2.2 Visual review: confirm comment accurately describes both load balancer and CI gating behavior


### PR DESCRIPTION
## Summary

- Update health endpoint comment in `apps/web-platform/server/index.ts` to accurately reflect the dual-purpose design introduced by PR #1706
- Old comment incorrectly stated Supabase status was purely informational; CI deploy verification now gates on `supabase == "connected"`
- New comment clarifies: HTTP 200 always returned for load balancer probes, CI reads response body to gate on version match and supabase connectivity

Closes #1709

## Changelog

- Updated health endpoint comment to reflect that CI deploy verification (web-platform-release.yml) gates on supabase connectivity status
- Removed stale Sentry mention from comment (Sentry status remains in response body but is not gated by CI)

## Test plan

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] Comment accuracy verified against `health.ts` and `web-platform-release.yml`
- [x] All test suites pass (9/9)

Generated with [Claude Code](https://claude.com/claude-code)