### PR TITLE
fix: resolve 4 code-review issues — WS validation, error logging, concurrency comments

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/chat/[conversationId]/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/chat/[conversationId]/page.tsx
@@ -64,8 +64,9 @@ export default function ChatPage() {
             content: data.content,
           });
         }
-      } catch {
+      } catch (err) {
         // Graceful degradation: proceed without context
+        console.error("KB context fetch failed:", err);
       } finally {
         if (!cancelled) setContextLoading(false);
       }

--- a/apps/web-platform/server/context-validation.ts
+++ b/apps/web-platform/server/context-validation.ts
@@ -1,0 +1,51 @@
+import type { ConversationContext } from "@/lib/types";
+
+/** Safe path pattern: alphanumeric, hyphens, underscores, slashes, ending in .md */
+const SAFE_PATH_RE = /^[a-zA-Z0-9_\-/]+\.md$/;
+/** Allowed context types */
+const ALLOWED_CONTEXT_TYPES = new Set(["kb-viewer"]);
+/** Max context content length (matches kb-reader MAX_FILE_SIZE) */
+const MAX_CONTEXT_CONTENT_LENGTH = 1024 * 1024; // 1MB
+
+/**
+ * Validate a ConversationContext payload from the client.
+ * Returns the validated context, or undefined if the input is nullish.
+ * Throws on invalid input.
+ */
+export function validateConversationContext(
+  raw: unknown,
+): ConversationContext | undefined {
+  if (raw === undefined || raw === null) return undefined;
+
+  if (typeof raw !== "object") {
+    throw new Error("Invalid context: expected object");
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  // path: required, must match safe pattern (no traversal sequences)
+  if (typeof obj.path !== "string" || !SAFE_PATH_RE.test(obj.path)) {
+    throw new Error("Invalid context: path must match [a-zA-Z0-9_-/]+.md");
+  }
+
+  // type: required, must be from allowed set
+  if (typeof obj.type !== "string" || !ALLOWED_CONTEXT_TYPES.has(obj.type)) {
+    throw new Error(`Invalid context: type must be one of ${[...ALLOWED_CONTEXT_TYPES].join(", ")}`);
+  }
+
+  // content: optional, but bounded
+  if (obj.content !== undefined) {
+    if (typeof obj.content !== "string") {
+      throw new Error("Invalid context: content must be a string");
+    }
+    if (obj.content.length > MAX_CONTEXT_CONTENT_LENGTH) {
+      throw new Error("Invalid context: content exceeds 1MB limit");
+    }
+  }
+
+  return {
+    path: obj.path,
+    type: obj.type,
+    content: obj.content as string | undefined,
+  };
+}

--- a/apps/web-platform/server/kb-reader.ts
+++ b/apps/web-platform/server/kb-reader.ts
@@ -228,6 +228,9 @@ export async function searchKb(
   const escapedQuery = escapeRegex(query);
   const mdFiles = await collectMdFiles(kbRoot, kbRoot);
 
+  // Flat-parallel: every file is read concurrently via Promise.all, unlike collectMdFiles
+  // and buildTree which use tree-recursive parallelism (bounded by directory depth).
+  // For very large KBs (10,000+ files), this is the first bottleneck — apply p-limit here.
   const searchResults = await Promise.all(
     mdFiles.map(async (relativePath): Promise<SearchResult | null> => {
       const fullPath = path.join(kbRoot, relativePath);
@@ -240,6 +243,8 @@ export async function searchKb(
         return null;
       }
 
+      // Created per-callback to avoid lastIndex contention across concurrent callbacks.
+      // Do not hoist — RegExp with /g flag is stateful and shared instances would skip matches.
       const regex = new RegExp(escapedQuery, "gi");
       const lines = raw.split("\n");
       const matches: SearchMatch[] = [];

--- a/apps/web-platform/server/ws-handler.ts
+++ b/apps/web-platform/server/ws-handler.ts
@@ -4,6 +4,8 @@ import { parse } from "url";
 import { randomUUID } from "crypto";
 
 import { KeyInvalidError, WS_CLOSE_CODES, type WSMessage, type Conversation } from "@/lib/types";
+import type { ConversationContext } from "@/lib/types";
+import { validateConversationContext } from "./context-validation";
 import { createServiceClient } from "@/lib/supabase/service";
 import type { DomainLeaderId } from "@/server/domain-leaders";
 import { TC_VERSION } from "@/lib/legal/tc-version";
@@ -187,6 +189,18 @@ async function handleMessage(userId: string, raw: string): Promise<void> {
       }
 
       try {
+        // Validate context payload before any side effects
+        let validatedContext: ConversationContext | undefined;
+        try {
+          validatedContext = validateConversationContext(msg.context);
+        } catch (validationErr) {
+          sendToClient(userId, {
+            type: "error",
+            message: (validationErr as Error).message,
+          });
+          return;
+        }
+
         abortActiveSession(userId, session);
 
         log.info({ userId, leaderId: msg.leaderId ?? "auto-route" }, "start_session");
@@ -197,7 +211,7 @@ async function handleMessage(userId: string, raw: string): Promise<void> {
         // which triggers sendUserMessage -> routeMessage -> dispatchToLeaders.
         if (msg.leaderId) {
           log.info({ conversationId, leaderId: msg.leaderId }, "Directed session, booting agent");
-          startAgentSession(userId, conversationId, msg.leaderId, undefined, undefined, msg.context).catch(
+          startAgentSession(userId, conversationId, msg.leaderId, undefined, undefined, validatedContext).catch(
             (err) => {
               Sentry.captureException(err);
               log.error({ userId, err }, "startAgentSession error");

--- a/apps/web-platform/test/chat-page.test.tsx
+++ b/apps/web-platform/test/chat-page.test.tsx
@@ -372,6 +372,24 @@ describe("ChatPage", () => {
       });
     });
 
+    it("gracefully degrades and logs when fetch rejects (network error)", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      fetchSpy.mockRejectedValueOnce(new Error("network failure"));
+      mockSearchParams.set("context", "product/roadmap.md");
+      wsReturn.status = "connected";
+
+      await renderChatPage();
+
+      await waitFor(() => {
+        expect(mockStartSession).toHaveBeenCalledWith(undefined, undefined);
+      });
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "KB context fetch failed:",
+        expect.any(Error),
+      );
+      consoleSpy.mockRestore();
+    });
+
     it("treats empty ?context= as no context", async () => {
       mockSearchParams.set("context", "");
       wsReturn.status = "connected";

--- a/apps/web-platform/test/ws-context-validation.test.ts
+++ b/apps/web-platform/test/ws-context-validation.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { validateConversationContext } from "@/server/context-validation";
+
+describe("validateConversationContext", () => {
+  it("returns undefined for undefined input", () => {
+    expect(validateConversationContext(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for null input", () => {
+    expect(validateConversationContext(null)).toBeUndefined();
+  });
+
+  it("accepts valid context with content", () => {
+    const result = validateConversationContext({
+      path: "product/roadmap.md",
+      type: "kb-viewer",
+      content: "# Roadmap",
+    });
+    expect(result).toEqual({
+      path: "product/roadmap.md",
+      type: "kb-viewer",
+      content: "# Roadmap",
+    });
+  });
+
+  it("accepts valid context without content", () => {
+    const result = validateConversationContext({
+      path: "knowledge-base/overview.md",
+      type: "kb-viewer",
+    });
+    expect(result).toEqual({
+      path: "knowledge-base/overview.md",
+      type: "kb-viewer",
+      content: undefined,
+    });
+  });
+
+  it("rejects non-object input", () => {
+    expect(() => validateConversationContext("string")).toThrow("expected object");
+    expect(() => validateConversationContext(42)).toThrow("expected object");
+  });
+
+  it("rejects path with traversal sequences", () => {
+    expect(() =>
+      validateConversationContext({
+        path: "../../../etc/passwd",
+        type: "kb-viewer",
+      }),
+    ).toThrow("path must match");
+  });
+
+  it("rejects path with dot-dot segments", () => {
+    expect(() =>
+      validateConversationContext({
+        path: "knowledge-base/../../secret.md",
+        type: "kb-viewer",
+      }),
+    ).toThrow("path must match");
+  });
+
+  it("rejects non-.md path extensions", () => {
+    expect(() =>
+      validateConversationContext({
+        path: "file.js",
+        type: "kb-viewer",
+      }),
+    ).toThrow("path must match");
+  });
+
+  it("rejects path with null bytes", () => {
+    expect(() =>
+      validateConversationContext({
+        path: "file\0.md",
+        type: "kb-viewer",
+      }),
+    ).toThrow("path must match");
+  });
+
+  it("rejects path with spaces", () => {
+    expect(() =>
+      validateConversationContext({
+        path: "my file.md",
+        type: "kb-viewer",
+      }),
+    ).toThrow("path must match");
+  });
+
+  it("rejects unknown context type", () => {
+    expect(() =>
+      validateConversationContext({
+        path: "file.md",
+        type: "admin-panel",
+      }),
+    ).toThrow("type must be one of");
+  });
+
+  it("rejects missing type", () => {
+    expect(() =>
+      validateConversationContext({
+        path: "file.md",
+      }),
+    ).toThrow("type must be one of");
+  });
+
+  it("rejects content exceeding 1MB", () => {
+    expect(() =>
+      validateConversationContext({
+        path: "file.md",
+        type: "kb-viewer",
+        content: "x".repeat(1024 * 1024 + 1),
+      }),
+    ).toThrow("content exceeds 1MB limit");
+  });
+
+  it("accepts content at exactly 1MB", () => {
+    const result = validateConversationContext({
+      path: "file.md",
+      type: "kb-viewer",
+      content: "x".repeat(1024 * 1024),
+    });
+    expect(result?.content?.length).toBe(1024 * 1024);
+  });
+
+  it("rejects non-string content", () => {
+    expect(() =>
+      validateConversationContext({
+        path: "file.md",
+        type: "kb-viewer",
+        content: 12345,
+      }),
+    ).toThrow("content must be a string");
+  });
+});

--- a/knowledge-base/project/learnings/2026-04-07-code-review-batch-ws-validation-error-logging-concurrency-comments.md
+++ b/knowledge-base/project/learnings/2026-04-07-code-review-batch-ws-validation-error-logging-concurrency-comments.md
@@ -1,0 +1,76 @@
+# Learning: Code review batch fixes — WS validation, error logging, concurrency comments
+
+## Problem
+
+Four code-review GitHub issues (#1733, #1734, #1735, #1736) identified gaps in the web-platform's KB reader and chat WebSocket handling:
+
+1. **Silent error suppression** — Empty catch block in KB context fetch swallowed network errors with no logging, making production debugging impossible
+2. **Missing runtime validation** — ConversationContext WS payload accepted arbitrary path, type, and content with only a type assertion (`as WSMessage`), enabling path traversal and token cost inflation
+3. **Undocumented concurrency requirement** — Per-callback RegExp instantiation in searchKb was a correctness requirement (stateful /g flag) with no comment, inviting accidental hoisting
+4. **Undocumented scaling asymmetry** — searchKb uses flat Promise.all (unbounded) while buildTree/collectMdFiles use tree-recursive parallelism (depth-bounded), but the difference was not documented
+
+## Solution
+
+### #1734: Per-callback RegExp comment (kb-reader.ts:245-246)
+
+Added inline comment explaining concurrency safety requirement:
+
+```typescript
+// Created per-callback to avoid lastIndex contention across concurrent callbacks.
+// Do not hoist — RegExp with /g flag is stateful and shared instances would skip matches.
+const regex = new RegExp(escapedQuery, "gi");
+```
+
+### #1733: Flat-parallel scaling comment (kb-reader.ts:231-233)
+
+Added comment documenting scaling asymmetry and deferred p-limit:
+
+```typescript
+// Flat-parallel: every file is read concurrently via Promise.all, unlike collectMdFiles
+// and buildTree which use tree-recursive parallelism (bounded by directory depth).
+// For very large KBs (10,000+ files), this is the first bottleneck — apply p-limit here.
+```
+
+### #1736: Error logging + network error test (page.tsx:67, chat-page.test.tsx)
+
+Changed empty catch to logged catch:
+
+```typescript
+} catch (err) {
+  // Graceful degradation: proceed without context
+  console.error("KB context fetch failed:", err);
+}
+```
+
+Added test for fetch rejection path (not just HTTP error):
+
+```typescript
+fetchSpy.mockRejectedValueOnce(new Error("network failure"));
+// Verifies graceful degradation AND error logging
+```
+
+### #1735: ConversationContext validation (context-validation.ts, ws-handler.ts)
+
+Created `server/context-validation.ts` with `validateConversationContext()`:
+- Path: `^[a-zA-Z0-9_\-/]+\.md$` (blocks traversal, null bytes, spaces)
+- Type: allowlist enum (`"kb-viewer"`)
+- Content: max 1MB (matches kb-reader MAX_FILE_SIZE)
+
+Extracted to separate module because ws-handler.ts triggers Supabase initialization at module load, preventing pure unit testing. Applied in start_session **before side effects** (before abortActiveSession). 15 test cases covering all rejection paths.
+
+## Key Insight
+
+Security-critical validation and modules with heavy initialization dependencies (database clients, SDK connections) should be separated at the module level. This enables pure unit testing of validation logic without mocking infrastructure. The pattern matches existing extractions in the codebase (sandbox.ts, error-sanitizer.ts).
+
+Empty catch blocks at system boundaries are a code smell — even when graceful degradation is correct, the error should be observable (logged, metricated) so production failures are diagnosable.
+
+## Related
+
+- [2026-03-20-websocket-first-message-auth-toctou-race.md](2026-03-20-websocket-first-message-auth-toctou-race.md) — WS async-with-timeout TOCTOU race pattern
+- [2026-03-20-cwe22-path-traversal-canusertool-sandbox.md](2026-03-20-cwe22-path-traversal-canusertool-sandbox.md) — Module extraction for testability pattern
+- GitHub #1662 — Tracking issue for MCP tool extraction from agent-runner.ts
+
+## Tags
+
+category: security-issues
+module: web-platform


### PR DESCRIPTION
## Summary
- Add ConversationContext validation at WS boundary with path regex, type enum, content 1MB limit (#1735)
- Add console.error logging for KB context fetch failures + network error test (#1736)
- Document per-callback RegExp concurrency requirement in searchKb (#1734)
- Document flat-parallel scaling asymmetry in searchKb (#1733)

Closes #1733, Closes #1734, Closes #1735, Closes #1736

## Changelog
- **Security:** ConversationContext WS payloads are now validated before processing — path traversal, invalid types, and oversized content are rejected
- **Observability:** KB context fetch network errors are now logged to console
- **Documentation:** Inline comments explain searchKb concurrency and scaling behavior

## Test plan
- [x] 15 new validation tests pass (ws-context-validation.test.ts)
- [x] 1 new network error test passes (chat-page.test.tsx)
- [x] All existing tests pass (77 total across 4 test files)
- [x] TypeScript compiles cleanly
- [x] Full test suite passes (scripts/test-all.sh)

Generated with [Claude Code](https://claude.com/claude-code)