### PR TITLE
fix(connect-repo): prompt email-only users to link GitHub identity

### DIFF
--- a/apps/web-platform/app/(auth)/callback/route.ts
+++ b/apps/web-platform/app/(auth)/callback/route.ts
@@ -55,6 +55,15 @@ export async function GET(request: NextRequest) {
         { err: error, status: error.status, errorName: error.name },
         "exchangeCodeForSession failed",
       );
+
+      // If this was an identity linking attempt (from connect-repo), redirect
+      // back to connect-repo with an error instead of dumping the user on login
+      const from = searchParams.get("from");
+      if (from === "link") {
+        const linkError = encodeURIComponent(error.message ?? "Failed to link GitHub account");
+        return redirectWithCookies(`${origin}/connect-repo?link_error=${linkError}`, pendingCookies);
+      }
+
       // Return specific error so the login page can show a helpful message
       const errorCode = error.message?.includes("code verifier")
         ? "code_verifier_missing"

--- a/apps/web-platform/app/(auth)/connect-repo/page.tsx
+++ b/apps/web-platform/app/(auth)/connect-repo/page.tsx
@@ -15,6 +15,7 @@ import { SettingUpState } from "@/components/connect-repo/setting-up-state";
 import { ReadyState } from "@/components/connect-repo/ready-state";
 import { FailedState } from "@/components/connect-repo/failed-state";
 import { InterruptedState } from "@/components/connect-repo/interrupted-state";
+import { LinkGitHubState } from "@/components/connect-repo/link-github-state";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -23,6 +24,7 @@ type State =
   | "choose"
   | "create_project"
   | "github_redirect"
+  | "link_github"
   | "select_project"
   | "no_projects"
   | "setting_up"
@@ -51,12 +53,16 @@ export default function ConnectRepoPage() {
   const searchParams = useSearchParams();
 
   const [state, setState] = useState<State>(() => {
-    // Avoid flashing the "choose" screen when returning from GitHub App install
     if (typeof window !== "undefined") {
       const params = new URLSearchParams(window.location.search);
+      // Returning from GitHub App install callback
       const action = params.get("setup_action");
       if (params.get("installation_id") && (action === "install" || action === "update")) {
         return "github_redirect";
+      }
+      // Returning from failed identity linking attempt
+      if (params.get("link_error")) {
+        return "link_github";
       }
     }
     return "choose";
@@ -111,6 +117,8 @@ export default function ConnectRepoPage() {
           } else {
             setState("no_projects");
           }
+        } else if (!data.installed && data.reason === "no_github_identity") {
+          setState("link_github");
         }
       } catch {
         // Silent — user can still proceed manually via choose screen
@@ -389,6 +397,11 @@ export default function ConnectRepoPage() {
           }
           return;
         }
+        // No GitHub identity linked — prompt to link
+        if (!detectData.installed && detectData.reason === "no_github_identity") {
+          setState("link_github");
+          return;
+        }
       }
     } catch {
       // Network error — fall through to GitHub redirect
@@ -560,6 +573,13 @@ export default function ConnectRepoPage() {
           <GitHubRedirectState
             onContinue={handleGitHubRedirectContinue}
             onBack={handleGitHubRedirectBack}
+          />
+        )}
+        {state === "link_github" && (
+          <LinkGitHubState
+            onBack={() => setState("choose")}
+            onSkip={handleSkip}
+            initialError={searchParams.get("link_error")}
           />
         )}
         {state === "select_project" && (

--- a/apps/web-platform/components/connect-repo/link-github-state.tsx
+++ b/apps/web-platform/components/connect-repo/link-github-state.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { Badge } from "@/components/ui/badge";
+import { GoldButton } from "@/components/ui/gold-button";
+import { OutlinedButton } from "@/components/ui/outlined-button";
+import { Card } from "@/components/ui/card";
+import { serif } from "./fonts";
+
+interface LinkGitHubStateProps {
+  onBack: () => void;
+  onSkip: () => void;
+  initialError?: string | null;
+}
+
+export function LinkGitHubState({ onBack, onSkip, initialError }: LinkGitHubStateProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(initialError ?? null);
+
+  async function handleLinkGitHub() {
+    setLoading(true);
+    setError(null);
+
+    const supabase = createClient();
+    const { error: linkError } = await supabase.auth.linkIdentity({
+      provider: "github",
+      options: {
+        redirectTo: `${window.location.origin}/callback?from=link`,
+      },
+    });
+
+    if (linkError) {
+      setLoading(false);
+      setError(linkError.message);
+    }
+    // If no error, browser is redirecting to GitHub OAuth
+  }
+
+  return (
+    <div className="mx-auto max-w-lg space-y-8">
+      <div className="space-y-4 text-center">
+        <Badge>ACCOUNT SETUP</Badge>
+        <h1 className={`${serif.className} text-4xl font-semibold`}>
+          Connect Your GitHub Account
+        </h1>
+        <p className="text-base text-neutral-400">
+          Your Soleur account was created with email. To connect a project,
+          we need to link your GitHub account so we can access your
+          repositories.
+        </p>
+      </div>
+
+      <Card>
+        <h3 className="mb-4 text-sm font-medium text-neutral-200">
+          What happens next
+        </h3>
+        <ol className="space-y-4">
+          <li className="flex items-start gap-3">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-neutral-700 text-xs font-medium text-neutral-300">
+              1
+            </span>
+            <span className="text-sm text-neutral-300">
+              Sign in to GitHub to link your account
+            </span>
+          </li>
+          <li className="flex items-start gap-3">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-neutral-700 text-xs font-medium text-neutral-300">
+              2
+            </span>
+            <span className="text-sm text-neutral-300">
+              Return here to select or create a project
+            </span>
+          </li>
+        </ol>
+      </Card>
+
+      {error && (
+        <Card className="border-red-900/50 bg-red-950/20">
+          <p className="text-sm text-red-400">{error}</p>
+          <p className="mt-2 text-xs text-neutral-500">
+            If this GitHub account is already linked to another Soleur
+            account, please sign in with that account instead.
+          </p>
+        </Card>
+      )}
+
+      <div className="flex items-center gap-3">
+        <GoldButton onClick={handleLinkGitHub} disabled={loading}>
+          {loading ? (
+            "Redirecting..."
+          ) : (
+            "Link GitHub Account"
+          )}
+        </GoldButton>
+        <OutlinedButton onClick={onBack}>Go Back</OutlinedButton>
+        <button
+          onClick={onSkip}
+          className="text-sm text-neutral-500 transition-colors hover:text-neutral-300"
+        >
+          Skip
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-platform/test/connect-repo-page.test.tsx
+++ b/apps/web-platform/test/connect-repo-page.test.tsx
@@ -24,6 +24,14 @@ vi.mock("next/font/google", () => ({
   Inter: () => ({ className: "mock-sans", variable: "--font-sans" }),
 }));
 
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      linkIdentity: vi.fn().mockResolvedValue({ data: {}, error: null }),
+    },
+  }),
+}));
+
 import ConnectRepoPage from "@/app/(auth)/connect-repo/page";
 
 // ---------------------------------------------------------------------------
@@ -660,5 +668,109 @@ describe("Phase 4: Auto-detect existing installation", () => {
 
     // Should NOT have redirected to GitHub
     expect(hrefSetter).not.toHaveBeenCalled();
+  });
+});
+
+// ===========================================================================
+// Phase 5: Link GitHub identity for email-only accounts
+// ===========================================================================
+
+describe("Phase 5: Link GitHub identity", () => {
+  test("on mount: shows link_github state when no GitHub identity", async () => {
+    setupFetchMock({
+      "/api/repo/detect-installation": () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ installed: false, reason: "no_github_identity" }),
+            { status: 200 },
+          ),
+        ),
+    });
+
+    render(<ConnectRepoPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Connect Your GitHub Account")).toBeInTheDocument();
+    });
+  });
+
+  test("Connect Existing: shows link_github when no GitHub identity", async () => {
+    let detectCount = 0;
+    setupFetchMock({
+      "/api/repo/repos": () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ error: "GitHub App not installed" }),
+            { status: 400 },
+          ),
+        ),
+      "/api/repo/detect-installation": () => {
+        detectCount++;
+        if (detectCount === 1) {
+          // Mount detection: not installed (show choose first)
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ installed: false, reason: "not_installed" }),
+              { status: 200 },
+            ),
+          );
+        }
+        // Click detection: no GitHub identity
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ installed: false, reason: "no_github_identity" }),
+            { status: 200 },
+          ),
+        );
+      },
+    });
+
+    render(<ConnectRepoPage />);
+
+    const connectBtn = await screen.findByText("Connect Project");
+    await userEvent.click(connectBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Connect Your GitHub Account")).toBeInTheDocument();
+    });
+  });
+
+  test("link_github state shows error from link_error query param", async () => {
+    setCallbackParams("?link_error=Identity+already+linked");
+    setupFetchMock();
+
+    render(<ConnectRepoPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Connect Your GitHub Account")).toBeInTheDocument();
+      expect(screen.getByText("Identity already linked")).toBeInTheDocument();
+    });
+  });
+
+  test("link_github Go Back returns to choose state", async () => {
+    setupFetchMock({
+      "/api/repo/detect-installation": () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ installed: false, reason: "no_github_identity" }),
+            { status: 200 },
+          ),
+        ),
+    });
+
+    render(<ConnectRepoPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Connect Your GitHub Account")).toBeInTheDocument();
+    });
+
+    const goBackBtn = screen.getByText("Go Back");
+    await userEvent.click(goBackBtn);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Give Your AI Team the Full Picture"),
+      ).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds a `LinkGitHubState` component that prompts email-only users to link their GitHub account via `supabase.auth.linkIdentity()`
- Detects `no_github_identity` response from the detect-installation endpoint and shows the link prompt instead of the choose screen
- Updates the callback route to redirect back to `/connect-repo?link_error=...` when identity linking fails (instead of dumping users on `/login?error=auth_failed`)
- Handles the case where the GitHub identity is already linked to another Soleur account with a clear error message

Ref #1760

## Test plan

- [x] 23 page tests pass (19 existing + 4 new for link_github state)
- [x] CSRF coverage test passes
- [ ] Manual: Sign in with email-only account → should see "Connect Your GitHub Account" screen
- [ ] Manual: Click "Link GitHub Account" → redirects to GitHub OAuth → returns to connect-repo → auto-detects installation
- [ ] Manual: Try linking a GitHub identity already used by another account → should show error on connect-repo page

## Changelog

### Fixed

- Email-only users no longer get stuck in the project setup flow. They are now prompted to link their GitHub account, which enables automatic installation detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)