### PR TITLE
fix: KB shows no-project CTA when repo not connected, fix link callback

### DIFF
--- a/apps/web-platform/app/(auth)/callback/route.ts
+++ b/apps/web-platform/app/(auth)/callback/route.ts
@@ -57,11 +57,17 @@ export async function GET(request: NextRequest) {
       );
 
       // If this was an identity linking attempt (from connect-repo), redirect
-      // back to connect-repo with an error instead of dumping the user on login
-      const from = searchParams.get("from");
-      if (from === "link") {
+      // back to connect-repo with an error instead of dumping the user on login.
+      // Check both cookie (reliable — survives OAuth chain) and query param (fallback).
+      const isLinkAttempt =
+        request.cookies.get("soleur_link_attempt")?.value === "1" ||
+        searchParams.get("from") === "link";
+      if (isLinkAttempt) {
         const linkError = encodeURIComponent(error.message ?? "Failed to link GitHub account");
-        return redirectWithCookies(`${origin}/connect-repo?link_error=${linkError}`, pendingCookies);
+        const response = redirectWithCookies(`${origin}/connect-repo?link_error=${linkError}`, pendingCookies);
+        // Clear the link attempt cookie
+        response.cookies.set("soleur_link_attempt", "", { maxAge: 0, path: "/" });
+        return response;
       }
 
       // Return specific error so the login page can show a helpful message

--- a/apps/web-platform/app/api/kb/tree/route.ts
+++ b/apps/web-platform/app/api/kb/tree/route.ts
@@ -17,11 +17,11 @@ export async function GET() {
   const serviceClient = createServiceClient();
   const { data: userData, error: fetchError } = await serviceClient
     .from("users")
-    .select("workspace_path, workspace_status")
+    .select("workspace_path, workspace_status, repo_status")
     .eq("id", user.id)
     .single();
 
-  if (fetchError || !userData?.workspace_path) {
+  if (fetchError || !userData?.workspace_path || userData.repo_status === "not_connected") {
     return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
   }
 

--- a/apps/web-platform/components/connect-repo/link-github-state.tsx
+++ b/apps/web-platform/components/connect-repo/link-github-state.tsx
@@ -22,11 +22,15 @@ export function LinkGitHubState({ onBack, onSkip, initialError }: LinkGitHubStat
     setLoading(true);
     setError(null);
 
+    // Set a cookie so the callback knows this was a link attempt
+    // (query params get lost through the Supabase → GitHub → callback chain)
+    document.cookie = "soleur_link_attempt=1; path=/; max-age=300; SameSite=Lax";
+
     const supabase = createClient();
     const { error: linkError } = await supabase.auth.linkIdentity({
       provider: "github",
       options: {
-        redirectTo: `${window.location.origin}/callback?from=link`,
+        redirectTo: `${window.location.origin}/callback`,
       },
     });
 


### PR DESCRIPTION
## Summary

- KB tree API now checks `repo_status` — returns 404 when `"not_connected"` so the page shows the "No Project Connected" CTA instead of the misleading "Nothing Here Yet" empty state
- LinkGitHubState uses a cookie (`soleur_link_attempt`) instead of query param for the `from=link` flag — query params get lost through Supabase's OAuth redirect chain
- Callback route checks both cookie and query param, redirects back to `/connect-repo?link_error=...` on failure instead of dumping user on login page

## Test plan

- [x] 24 tests pass (connect-repo + CSRF coverage)
- [ ] Manual: Sign in with email-only account with `repo_status: "not_connected"` → KB page should show "No Project Connected" CTA
- [ ] Manual: Click "Link GitHub Account" → on failure, should redirect back to connect-repo with error (not login page)

## Changelog

### Fixed

- Knowledge Base page now shows "No Project Connected" CTA when no repository is connected, instead of the misleading "Nothing Here Yet" empty state
- GitHub identity linking failures now redirect back to the connect-repo page with an error message instead of the login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)