### PR TITLE
fix: handle identity linking failures when callback has no code

### DIFF
--- a/apps/web-platform/app/(auth)/callback/route.ts
+++ b/apps/web-platform/app/(auth)/callback/route.ts
@@ -120,6 +120,19 @@ export async function GET(request: NextRequest) {
     }
   }
 
+  // If this was an identity linking attempt that failed before a code was issued
+  // (e.g., Supabase redirected back with ?error=... but no ?code=), redirect to
+  // connect-repo instead of dumping the user on the login page.
+  const isLinkAttempt = request.cookies.get("soleur_link_attempt")?.value === "1";
+  if (isLinkAttempt) {
+    const errorDesc = searchParams.get("error_description") ?? searchParams.get("error") ?? "Failed to link GitHub account";
+    const linkError = encodeURIComponent(errorDesc);
+    logger.warn({ origin, error: errorDesc }, "Identity linking failed — redirecting to connect-repo");
+    const response = NextResponse.redirect(`${origin}/connect-repo?link_error=${linkError}`);
+    response.cookies.set("soleur_link_attempt", "", { maxAge: 0, path: "/" });
+    return response;
+  }
+
   // Auth failed — redirect to login with error
   logger.error({ codePresent: !!code, origin }, "Auth failed — no code or exchange error");
   return NextResponse.redirect(`${origin}/login?error=auth_failed`);


### PR DESCRIPTION
## Summary

When `linkIdentity` fails on Supabase's side before a code is issued, the callback receives `?error=...` params but no `?code=`. The `soleur_link_attempt` cookie check was only inside the `if (code)` block, so these failures fell through to the generic login-page redirect.

Adds the cookie check to the no-code fallback path, extracting the error description from Supabase's `error_description` or `error` params and redirecting to `/connect-repo?link_error=...`.

## Test plan

- [x] 24 tests pass
- [ ] Manual: Sign in with `ops@jikigai.com`, click "Link GitHub Account" → on any failure, should redirect back to connect-repo with error (not login page)

## Changelog

### Fixed

- Identity linking failures no longer dump users on the login page — they redirect back to the connect-repo page with the error message from Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)