### PR TITLE
feat: port 15 GREEN skills to OpenHands plugin format

### DIFF
--- a/.plugin/skills/agent-browser/SKILL.md
+++ b/.plugin/skills/agent-browser/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: agent-browser
+description: "Automate browser interactions via Vercel's agent-browser CLI. Handles web page navigation, form filling, screenshots, and data scraping using ref-based element selection."
+triggers:
+- agent-browser
+- browser automation
+- headless browser
+- web scraping
+---
+
+# agent-browser: CLI Browser Automation
+
+Vercel's headless browser automation CLI designed for AI agents. Uses ref-based selection (@e1, @e2) from accessibility snapshots.
+
+## Setup Check
+
+```bash
+# Check installation
+command -v agent-browser >/dev/null 2>&1 && echo "Installed" || echo "NOT INSTALLED - run: npm install --prefix ~/.local -g agent-browser@0.22.3 && agent-browser install"
+```
+
+### Install if needed
+
+```bash
+npm install --prefix ~/.local -g agent-browser@0.22.3
+agent-browser install  # Downloads Chrome for Testing (~300MB)
+# On Linux if system deps missing:
+# agent-browser install --with-deps
+```
+
+### Troubleshooting: version mismatch
+
+If you see "Version mismatch between agent-browser (expects 1200) and installed Playwright (1208)":
+
+1. Check which binary is running: `which agent-browser && agent-browser --version`
+2. If it resolves to `/usr/bin/agent-browser` (version 0.5.0), a stale system install is shadowing the correct version
+3. Fix: `sudo npm uninstall -g agent-browser` to remove the system binary
+4. Verify: `which agent-browser` should now resolve to `~/.local/bin/agent-browser` (0.22.3)
+
+## Core Workflow
+
+**The snapshot + ref pattern is optimal for LLMs:**
+
+1. **Navigate** to URL
+2. **Snapshot** to get interactive elements with refs
+3. **Interact** using refs (@e1, @e2, etc.)
+4. **Re-snapshot** after navigation or DOM changes
+
+```bash
+# Step 1: Open URL
+agent-browser open https://example.com
+
+# Step 2: Get interactive elements with refs
+agent-browser snapshot -i --json
+
+# Step 3: Interact using refs
+agent-browser click @e1
+agent-browser fill @e2 "search query"
+
+# Step 4: Re-snapshot after changes
+agent-browser snapshot -i
+```
+
+## Key Commands
+
+### Navigation
+
+```bash
+agent-browser open <url>       # Navigate to URL
+agent-browser back             # Go back
+agent-browser forward          # Go forward
+agent-browser reload           # Reload page
+agent-browser close            # Close browser
+```
+
+### Snapshots (Essential for AI)
+
+```bash
+agent-browser snapshot              # Full accessibility tree
+agent-browser snapshot -i           # Interactive elements only (recommended)
+agent-browser snapshot -i --json    # JSON output for parsing
+agent-browser snapshot -c           # Compact (remove empty elements)
+agent-browser snapshot -d 3         # Limit depth
+```
+
+### Interactions
+
+```bash
+agent-browser click @e1                    # Click element
+agent-browser dblclick @e1                 # Double-click
+agent-browser fill @e1 "text"              # Clear and fill input
+agent-browser type @e1 "text"              # Type without clearing
+agent-browser press Enter                  # Press key
+agent-browser hover @e1                    # Hover element
+agent-browser check @e1                    # Check checkbox
+agent-browser uncheck @e1                  # Uncheck checkbox
+agent-browser select @e1 "option"          # Select dropdown option
+agent-browser scroll down 500              # Scroll (up/down/left/right)
+agent-browser scrollintoview @e1           # Scroll element into view
+```
+
+### Get Information
+
+```bash
+agent-browser get text @e1          # Get element text
+agent-browser get html @e1          # Get element HTML
+agent-browser get value @e1         # Get input value
+agent-browser get attr href @e1     # Get attribute
+agent-browser get title             # Get page title
+agent-browser get url               # Get current URL
+agent-browser get count "button"    # Count matching elements
+```
+
+### Screenshots & PDFs
+
+```bash
+agent-browser screenshot                      # Viewport screenshot
+agent-browser screenshot --full               # Full page
+agent-browser screenshot output.png           # Save to file
+agent-browser screenshot --full output.png    # Full page to file
+agent-browser pdf output.pdf                  # Save as PDF
+```
+
+### Wait
+
+```bash
+agent-browser wait @e1              # Wait for element
+agent-browser wait 2000             # Wait milliseconds
+agent-browser wait "text"           # Wait for text to appear
+```
+
+## Semantic Locators (Alternative to Refs)
+
+```bash
+agent-browser find role button click --name "Submit"
+agent-browser find text "Sign up" click
+agent-browser find label "Email" fill "user@example.com"
+agent-browser find placeholder "Search..." fill "query"
+```
+
+## Sessions (Parallel Browsers)
+
+```bash
+# Run multiple independent browser sessions
+agent-browser --session-name browser1 open https://site1.com
+agent-browser --session-name browser2 open https://site2.com
+
+# List saved states
+agent-browser state list
+```
+
+## Examples
+
+### Login Flow
+
+```bash
+agent-browser open https://app.example.com/login
+agent-browser snapshot -i
+# Output shows: textbox "Email" [ref=e1], textbox "Password" [ref=e2], button "Sign in" [ref=e3]
+agent-browser fill @e1 "user@example.com"
+agent-browser fill @e2 "password123"
+agent-browser click @e3
+agent-browser wait 2000
+agent-browser snapshot -i  # Verify logged in
+```
+
+### Search and Extract
+
+```bash
+agent-browser open https://news.ycombinator.com
+agent-browser snapshot -i --json
+# Parse JSON to find story links
+agent-browser get text @e12  # Get headline text
+agent-browser click @e12     # Click to open story
+```
+
+### Form Filling
+
+```bash
+agent-browser open https://forms.example.com
+agent-browser snapshot -i
+agent-browser fill @e1 "John Doe"
+agent-browser fill @e2 "john@example.com"
+agent-browser select @e3 "United States"
+agent-browser check @e4  # Agree to terms
+agent-browser click @e5  # Submit button
+agent-browser screenshot confirmation.png
+```
+
+### Debug Mode
+
+```bash
+# Run with visible browser window
+agent-browser --headed open https://example.com
+agent-browser --headed snapshot -i
+agent-browser --headed click @e1
+```
+
+## JSON Output
+
+Add `--json` for structured output:
+
+```bash
+agent-browser snapshot -i --json
+```
+
+Returns:
+
+```json
+{
+  "success": true,
+  "data": {
+    "refs": {
+      "e1": {"name": "Submit", "role": "button"},
+      "e2": {"name": "Email", "role": "textbox"}
+    },
+    "snapshot": "- button \"Submit\" [ref=e1]\n- textbox \"Email\" [ref=e2]"
+  }
+}
+```
+
+## vs Playwright MCP
+
+| Feature | agent-browser (CLI) | Playwright MCP |
+|---------|---------------------|----------------|
+| Interface | Bash commands | MCP tools |
+| Selection | Refs (@e1) | Refs (e1) |
+| Output | Text/JSON | Tool responses |
+| Parallel | Session names | Tabs |
+| Browser | Chrome for Testing | Chromium |
+| Runtime | Rust native | Node.js |
+| Best for | Quick automation | Tool integration |
+
+Use agent-browser when:
+
+- You prefer Bash-based workflows
+- You want simpler CLI commands
+- You need quick one-off automation
+
+Use Playwright MCP when:
+
+- You need deep MCP tool integration
+- You want tool-based responses
+- You're building complex automation

--- a/.plugin/skills/archive-kb/SKILL.md
+++ b/.plugin/skills/archive-kb/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: archive-kb
+description: "Archive completed knowledge-base artifacts (brainstorms, plans, specs) to their archive/ subdirectories with timestamp prefixes and git history preservation."
+triggers:
+- archive knowledge base
+- archive-kb
+- archive brainstorm
+- archive artifacts
+---
+
+# Archive Knowledge-Base Artifacts
+
+Archive brainstorms, plans, and spec directories for a completed feature branch.
+The script generates timestamps internally and uses `git mv` to preserve history.
+
+## Usage
+
+Run the archive script from the repository root. It derives the feature slug
+from the current branch name automatically:
+
+```bash
+bash ./plugins/soleur/skills/archive-kb/scripts/archive-kb.sh
+```
+
+To preview what would be archived without making changes:
+
+```bash
+bash ./plugins/soleur/skills/archive-kb/scripts/archive-kb.sh --dry-run
+```
+
+To archive a specific slug (override branch detection):
+
+```bash
+bash ./plugins/soleur/skills/archive-kb/scripts/archive-kb.sh my-feature-slug
+```
+
+## What It Archives
+
+The script discovers artifacts matching the feature slug:
+
+| Directory | Match Pattern | Type |
+|-----------|--------------|------|
+| `knowledge-base/project/brainstorms/` | Filename contains slug | File glob |
+| `knowledge-base/project/plans/` | Filename contains slug | File glob |
+| `knowledge-base/project/specs/feat-<slug>/` | Exact directory name | Directory match |
+
+All `archive/` subdirectories are excluded from discovery.
+
+## When to Use
+
+- After completing a feature when brainstorm/plan artifacts should be archived
+- During the ship workflow to archive feature artifacts before merge
+
+## Notes
+
+- The script calls `git add` before `git mv` to handle untracked files
+- A single timestamp is generated per invocation for consistency
+- Exit code 0 for success (including "no artifacts found")
+- Exit code 1 for errors (not in git repo, invalid arguments)
+- Spec directories are moved as a whole via `git mv` on the directory

--- a/.plugin/skills/archive-kb/scripts/archive-kb.sh
+++ b/.plugin/skills/archive-kb/scripts/archive-kb.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Archive knowledge-base artifacts for a feature branch.
+# Moves brainstorms, plans, and specs to archive/ subdirectories
+# with timestamped prefixes, preserving git history.
+#
+# Usage: archive-kb.sh [--dry-run] [slug]
+#   --dry-run  Show what would be archived without executing
+#   slug       Feature slug (default: derived from current branch)
+
+readonly SCRIPT_NAME="archive-kb.sh"
+
+# --- Argument Parsing ---
+
+DRY_RUN=false
+EXPLICIT_SLUG=""
+
+usage() {
+  echo "Usage: ${SCRIPT_NAME} [--dry-run] [slug]" >&2
+  echo "  --dry-run  Show what would be archived without executing" >&2
+  echo "  slug       Feature slug (default: derived from current branch)" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      ;;
+    -*)
+      echo "Error: Unknown flag: $1" >&2
+      usage
+      ;;
+    *)
+      if [[ -n "$EXPLICIT_SLUG" ]]; then
+        echo "Error: Multiple slug arguments provided" >&2
+        usage
+      fi
+      EXPLICIT_SLUG="$1"
+      shift
+      ;;
+  esac
+done
+
+# --- Environment Checks ---
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Error: Not inside a git repository" >&2
+  exit 1
+fi
+
+if [[ ! -d "knowledge-base" ]]; then
+  echo "No knowledge-base directory found"
+  exit 0
+fi
+
+# --- Slug Derivation ---
+
+derive_slug() {
+  local branch safe slug
+  branch=$(git rev-parse --abbrev-ref HEAD)
+  # Normalize slashes to hyphens
+  safe=$(echo "$branch" | tr '/' '-')
+  slug="$safe"
+  # Strip prefixes in sequence (order matters: feature- before feat-)
+  slug="${slug#feature-}"
+  slug="${slug#feat-}"
+  slug="${slug#fix-}"
+  echo "$slug"
+}
+
+if [[ -n "$EXPLICIT_SLUG" ]]; then
+  SLUG="$EXPLICIT_SLUG"
+else
+  SLUG=$(derive_slug)
+fi
+
+if [[ -z "$SLUG" ]]; then
+  echo "Error: Could not derive feature slug from branch name" >&2
+  exit 1
+fi
+
+# --- Discovery ---
+
+discover_artifacts() {
+  local slug="$1"
+  local artifacts=()
+
+  # Enable nullglob so empty globs expand to nothing
+  shopt -s nullglob
+
+  # Brainstorms and plans
+  local file_dirs=(
+    "knowledge-base/project/brainstorms"
+    "knowledge-base/project/plans"
+  )
+  for dir in "${file_dirs[@]}"; do
+    for f in "$dir"/*"${slug}"*; do
+      [[ -f "$f" && "$f" != */archive/* ]] && artifacts+=("$f")
+    done
+  done
+
+  # Specs
+  if [[ -d "knowledge-base/project/specs/feat-${slug}" ]]; then
+    artifacts+=("knowledge-base/project/specs/feat-${slug}")
+  fi
+
+  shopt -u nullglob
+
+  printf '%s\n' "${artifacts[@]}"
+}
+
+ARTIFACTS=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && ARTIFACTS+=("$line")
+done < <(discover_artifacts "$SLUG")
+
+# --- No artifacts case ---
+
+if [[ ${#ARTIFACTS[@]} -eq 0 ]]; then
+  echo "No artifacts found for slug \"${SLUG}\""
+  exit 0
+fi
+
+# --- Timestamp (generated once for consistency) ---
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+
+# --- Dry-run mode ---
+
+print_archive_path() {
+  local artifact="$1"
+  local ts="$2"
+  local name dest_dir
+  name=$(basename "$artifact")
+  dest_dir=$(dirname "$artifact")
+  echo "  ${artifact} -> ${dest_dir}/archive/${ts}-${name}"
+}
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "Dry run -- would archive ${#ARTIFACTS[@]} artifact(s) for slug \"${SLUG}\":"
+  for artifact in "${ARTIFACTS[@]}"; do
+    print_archive_path "$artifact" "$TIMESTAMP"
+  done
+  exit 0
+fi
+
+# --- Archival Execution ---
+
+archive_artifact() {
+  local artifact="$1"
+  local ts="$2"
+  local name dest_dir archive_dir
+  name=$(basename "$artifact")
+  dest_dir=$(dirname "$artifact")
+  archive_dir="${dest_dir}/archive"
+
+  mkdir -p "$archive_dir"
+  # git add handles both untracked files and already-tracked files (no-op)
+  git add "$artifact"
+  git mv "$artifact" "${archive_dir}/${ts}-${name}"
+  echo "  ${archive_dir}/${ts}-${name}"
+}
+
+echo "Archived ${#ARTIFACTS[@]} artifact(s) for slug \"${SLUG}\":"
+
+for artifact in "${ARTIFACTS[@]}"; do
+  archive_artifact "$artifact" "$TIMESTAMP"
+done

--- a/.plugin/skills/changelog/SKILL.md
+++ b/.plugin/skills/changelog/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: changelog
+description: "Create changelogs for recent merges to main. Analyzes PR labels, issues, and descriptions to generate formatted summaries with breaking changes, new features, bug fixes, and contributor shoutouts."
+triggers:
+- changelog
+- change log
+- release notes
+- daily changes
+- weekly summary
+---
+
+# Changelog Generator
+
+Generate a fun, engaging changelog for an internal development team by summarizing the latest merges to the main branch, highlighting new features, bug fixes, and giving credit to the developers.
+
+## Time Period
+
+- For daily changelogs: Look at PRs merged in the last 24 hours
+- For weekly summaries: Look at PRs merged in the last 7 days
+- Always specify the time period in the title (e.g., "Daily" vs "Weekly")
+- Default: Get the latest changes from the last day from the main branch of the repository
+
+## PR Analysis
+
+Analyze the provided GitHub changes and related issues. Look for:
+
+1. New features that have been added
+2. Bug fixes that have been implemented
+3. Any other significant changes or improvements
+4. References to specific issues and their details
+5. Names of contributors who made the changes
+6. Use gh cli to lookup the PRs as well and the description of the PRs
+7. Check PR labels to identify feature type (feature, bug, chore, etc.)
+8. Look for breaking changes and highlight them prominently
+9. Include PR numbers for traceability
+10. Check if PRs are linked to issues and include issue context
+
+## Content Priorities
+
+1. Breaking changes (if any) - MUST be at the top
+2. User-facing features
+3. Critical bug fixes
+4. Performance improvements
+5. Developer experience improvements
+6. Documentation updates
+
+## Formatting Guidelines
+
+Create a changelog summary with the following guidelines:
+
+1. Keep it concise and to the point
+2. Highlight the most important changes first
+3. Group similar changes together (e.g., all new features, all bug fixes)
+4. Include issue references where applicable
+5. Mention the names of contributors, giving them credit for their work
+6. Add a touch of humor or playfulness to make it engaging
+7. Use emojis sparingly to add visual interest
+8. Keep total message under 2000 characters for Discord
+9. Use consistent emoji for each section
+10. Format code/technical terms in backticks
+11. Include PR numbers in parentheses (e.g., "Fixed login bug (#123)")
+
+## Deployment Notes
+
+When relevant, include:
+
+- Database migrations required
+- Environment variable updates needed
+- Manual intervention steps post-deploy
+- Dependencies that need updating
+
+The final output should be formatted as follows:
+
+```markdown
+# 🚀 [Daily/Weekly] Change Log: [Current Date]
+
+## 🚨 Breaking Changes (if any)
+
+[List any breaking changes that require immediate attention]
+
+## 🌟 New Features
+
+[List new features here with PR numbers]
+
+## 🐛 Bug Fixes
+
+[List bug fixes here with PR numbers]
+
+## 🛠️ Other Improvements
+
+[List other significant changes or improvements]
+
+## 🙌 Shoutouts
+
+[Mention contributors and their contributions]
+
+## 🎉 Fun Fact of the Day
+
+[Include a brief, work-related fun fact or joke]
+```
+
+## Error Handling
+
+- If no changes in the time period, post a "quiet day" message: "🌤️ Quiet day! No new changes merged."
+- If unable to fetch PR details, list the PR numbers for manual review
+- Always validate message length before posting to Discord (max 2000 chars)
+
+## Schedule Recommendations
+
+- Run daily at 6 AM NY time for previous day's changes
+- Run weekly summary on Mondays for the previous week
+- Special runs after major releases or deployments
+
+## Audience Considerations
+
+Adjust the tone and detail level based on the channel:
+
+- **Dev team channels**: Include technical details, performance metrics, code snippets
+- **Product team channels**: Focus on user-facing changes and business impact
+- **Leadership channels**: Highlight progress on key initiatives and blockers

--- a/.plugin/skills/deploy-docs/SKILL.md
+++ b/.plugin/skills/deploy-docs/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: deploy-docs
+description: "Validate the documentation build and prepare for GitHub Pages deployment. Runs the Eleventy build, validates output, checks component counts, and provides deployment instructions."
+triggers:
+- deploy docs
+- deploy documentation
+- eleventy build
+- github pages deploy
+---
+
+# Deploy Documentation Command
+
+Validate the documentation build and prepare it for GitHub Pages deployment.
+
+## Step 1: Build and Validate
+
+```bash
+# Install dependencies (if needed)
+npm ci
+
+# Run Eleventy build
+npx @11ty/eleventy
+
+# Verify build output
+test -f _site/index.html && echo "OK index.html"
+test -f "_site/pages/agents.html" && echo "OK agents.html"
+test -f "_site/pages/skills.html" && echo "OK skills.html"
+test -f "_site/pages/changelog.html" && echo "OK changelog.html"
+test -f "_site/pages/getting-started.html" && echo "OK getting-started.html"
+test -f _site/404.html && echo "OK 404.html"
+test -f _site/css/style.css && echo "OK style.css"
+test -f _site/CNAME && echo "OK CNAME"
+test -f _site/sitemap.xml && echo "OK sitemap.xml"
+```
+
+## Step 2: Verify Component Counts
+
+Use grep to count occurrences of `component-card` in `_site/pages/agents.html` and `_site/pages/skills.html`.
+
+Then compare with source counts:
+
+- Agent files: count `.md` files (excluding README.md) under `plugins/soleur/agents/`
+- Skill files: count `SKILL.md` files under `plugins/soleur/skills/*/`
+
+If counts diverge, investigate missing or extra catalog entries.
+
+## Step 3: Verify Assets
+
+```bash
+# Check CSS is not empty
+test -s _site/css/style.css && echo "CSS OK" || echo "CSS EMPTY"
+
+# Check for broken internal links (optional)
+grep -r 'href="/' _site/ | grep -v 'http' | head -20
+```
+
+## Step 4: Deploy
+
+The site deploys automatically via GitHub Actions when changes are pushed to `main`. For manual deployment:
+
+```bash
+# Push to trigger the deploy workflow
+git push origin main
+
+# Or trigger manually
+gh workflow run deploy-docs.yml
+```
+
+## Verification Checklist
+
+- [ ] All expected HTML files present in `_site/`
+- [ ] Component counts match source file counts
+- [ ] CSS loads correctly
+- [ ] No broken internal links
+- [ ] CNAME file present for custom domain
+- [ ] Sitemap includes all pages

--- a/.plugin/skills/docs-site/SKILL.md
+++ b/.plugin/skills/docs-site/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: docs-site
+description: "Scaffold a Markdown-based documentation site using Eleventy. Generates a complete docs setup with base layout, data files, GitHub Pages deployment workflow, and passthrough copy configuration."
+triggers:
+- docs site
+- documentation site
+- eleventy scaffold
+- scaffold docs
+---
+
+# docs-site Skill
+
+Scaffold a Markdown + Eleventy documentation site with build-time data injection and GitHub Pages deployment.
+
+## Prerequisites
+
+- Node.js 20+
+- A `package.json` in the project root (or willingness to create one)
+
+## Step 1: Gather Project Info
+
+Ask the user:
+
+1. **Project name** -- Used in site title, footer, nav logo
+2. **Site URL** -- For meta tags, sitemap, og:url (e.g., `https://example.com`)
+3. **Author name** -- For blog attribution, structured data, and E-E-A-T signals (e.g., `Jean Deruelle`)
+4. **Docs input directory** -- Where docs source files live (e.g., `docs/`)
+5. **GitHub repository URL** -- For nav link and deployment
+6. **Pages to create** -- Which pages beyond index (e.g., getting-started, changelog, API reference)
+
+## Step 2: Install Dependencies
+
+```bash
+npm install --save-dev @11ty/eleventy
+```
+
+Add scripts to `package.json`:
+
+```json
+{
+  "scripts": {
+    "docs:dev": "npx @11ty/eleventy --serve",
+    "docs:build": "npx @11ty/eleventy"
+  }
+}
+```
+
+Ensure `"type": "module"` is set in `package.json` for ESM config.
+
+## Step 3: Create Eleventy Config
+
+Create `eleventy.config.js` at the project root:
+
+```javascript
+const INPUT = "<docs-input-dir>";
+
+export default function (eleventyConfig) {
+  eleventyConfig.addPassthroughCopy({ [`${INPUT}/css`]: "css" });
+  eleventyConfig.addPassthroughCopy({ [`${INPUT}/images`]: "images" });
+}
+
+export const config = {
+  dir: {
+    input: INPUT,
+    output: "_site",
+    includes: "_includes",
+    data: "_data",
+  },
+  markdownTemplateEngine: "njk",
+  htmlTemplateEngine: "njk",
+  templateFormats: ["md", "njk"],
+};
+```
+
+Add `_site/` to `.gitignore`.
+
+## Step 4: Create Directory Structure
+
+```text
+<docs-input-dir>/
+  _data/
+    site.json          # Site metadata (name, url, nav)
+  _includes/
+    base.njk           # Base HTML layout
+  css/
+    style.css          # Minimal starter CSS
+  images/              # Static images
+  index.njk            # Landing page
+  pages/
+    getting-started.md # First content page
+```
+
+### `_data/site.json`
+
+```json
+{
+  "name": "<Project Name>",
+  "url": "<site-url>",
+  "author": {
+    "name": "<Author Name>",
+    "url": "<site-url>"
+  },
+  "nav": [
+    { "label": "Get Started", "url": "pages/getting-started.html" }
+  ]
+}
+```
+
+### `_includes/base.njk`
+
+Create a minimal HTML shell with:
+
+- Head: charset, viewport, description meta, title, CSS link
+- Header: logo linking to index.html, nav from `site.nav`
+- Main: `{{ content | safe }}`
+- Footer: project name, links
+
+Use `page.url` comparison for `aria-current="page"` on nav links.
+
+### `css/style.css`
+
+Provide a minimal starter stylesheet with CSS custom properties for easy theming.
+
+### Content pages
+
+Create `.md` files with YAML frontmatter:
+
+```yaml
+---
+title: Getting Started
+description: "How to get started with <Project Name>"
+layout: base.njk
+permalink: pages/getting-started.html
+---
+```
+
+## Step 5: Data Files (Optional)
+
+If the project has components to catalog at build time, create data files in `_data/`:
+
+```javascript
+// _data/version.js -- reads version from package.json
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export default function () {
+  const pkg = JSON.parse(readFileSync(resolve("package.json"), "utf-8"));
+  return pkg.version;
+}
+```
+
+Data files export a function that returns data available in all templates.
+
+## Step 6: GitHub Pages Workflow
+
+Create `.github/workflows/deploy-docs.yml`:
+
+```yaml
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '<docs-input-dir>/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx @11ty/eleventy
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+      - uses: actions/deploy-pages@v4
+```
+
+## Step 7: Verify
+
+```bash
+npx @11ty/eleventy --serve
+```
+
+Open `http://localhost:8080` and verify:
+
+- All pages render correctly
+- CSS loads
+- Navigation works with `aria-current="page"`
+- Data variables resolve in templates
+
+## Notes
+
+- Nunjucks variables (`{{ var }}`) are NOT resolved inside YAML frontmatter. Use static strings for `description` in frontmatter, and template variables only in the page body.
+- Passthrough copy paths in `addPassthroughCopy()` are relative to the project root, NOT the input directory. Use the mapping format: `{ "source/path": "output/path" }`.
+- Eleventy v3 uses ESM (`export default`) -- do not use CommonJS (`module.exports`).

--- a/.plugin/skills/every-style-editor/SKILL.md
+++ b/.plugin/skills/every-style-editor/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: every-style-editor
+description: "Review or edit copy for adherence to Every's style guide. Provides systematic line-by-line review for grammar, punctuation, mechanics, and style compliance."
+triggers:
+- style editor
+- copy editing
+- style guide review
+- every style
+- grammar review
+---
+
+# Every Style Editor
+
+This skill provides a systematic approach to reviewing copy against Every's comprehensive style guide. It transforms the agent into a meticulous line editor and proofreader specializing in grammar, mechanics, and style guide compliance.
+
+## When to Use This Skill
+
+Use this skill when:
+
+- Reviewing articles, blog posts, newsletters, or any written content
+- Ensuring copy follows Every's specific style conventions
+- Providing feedback on grammar, punctuation, and mechanics
+- Flagging deviations from the Every style guide
+- Preparing clean copy for human editorial review
+
+## Skill Overview
+
+This skill enables performing a comprehensive review of written content in four phases:
+
+1. **Initial Assessment** - Understanding context and document type
+2. **Detailed Line Edit** - Checking every sentence for compliance
+3. **Mechanical Review** - Verifying formatting and consistency
+4. **Recommendations** - Providing actionable improvement suggestions
+
+## How to Use This Skill
+
+### Step 1: Initial Assessment
+
+Begin by reading the entire piece to understand:
+
+- Document type (article, knowledge base entry, social post, etc.)
+- Target audience
+- Overall tone and voice
+- Content context
+
+### Step 2: Detailed Line Edit
+
+Review each paragraph systematically, checking for:
+
+- Sentence structure and grammar correctness
+- Punctuation usage (commas, semicolons, em dashes, etc.)
+- Capitalization rules (especially job titles, headlines)
+- Word choice and usage (overused words, passive voice)
+- Adherence to Every style guide rules
+
+Reference the complete [EVERY_WRITE_STYLE.md](./references/EVERY_WRITE_STYLE.md) for specific rules when in doubt.
+
+### Step 3: Mechanical Review
+
+Verify:
+
+- Spacing and formatting consistency
+- Style choices applied uniformly throughout
+- Special elements (lists, quotes, citations)
+- Proper use of italics and formatting
+- Number formatting (numerals vs. spelled out)
+- Link formatting and descriptions
+
+### Step 4: Output Results
+
+Present findings using this structure:
+
+```text
+DOCUMENT REVIEW SUMMARY
+=====================
+Document Type: [type]
+Word Count: [approximate]
+Overall Assessment: [brief overview]
+
+ERRORS FOUND: [total number]
+
+DETAILED CORRECTIONS
+===================
+
+[For each error found:]
+
+**Location**: [Paragraph #, Sentence #]
+**Issue Type**: [Grammar/Punctuation/Mechanics/Style Guide]
+**Original**: "[exact text with error]"
+**Correction**: "[corrected text]"
+**Rule Reference**: [Specific style guide rule violated]
+**Explanation**: [Brief explanation of why this is an error]
+
+---
+
+RECURRING ISSUES
+===============
+[List patterns of errors that appear multiple times]
+
+STYLE GUIDE COMPLIANCE CHECKLIST
+==============================
+✓ [Rule followed correctly]
+✗ [Rule violated - with count of violations]
+
+FINAL RECOMMENDATIONS
+===================
+[2-3 actionable suggestions for improving the draft]
+```
+
+## Style Guide Reference
+
+The complete Every style guide is included in [EVERY_WRITE_STYLE.md](./references/EVERY_WRITE_STYLE.md). Key areas to focus on:
+
+- **Quick Rules**: Title case for headlines, sentence case elsewhere
+- **Tone**: Active voice, avoid overused words (actually, very, just), be specific
+- **Numbers**: Spell out one through nine; use numerals for 10+
+- **Punctuation**: Oxford commas, em dashes without spaces, proper quotation mark usage
+- **Capitalization**: Lowercase job titles, company as singular (it), teams as plural (they)
+- **Emphasis**: Italics only (no bold for emphasis)
+- **Links**: 2-4 words, don't say "click here"
+
+## Key Principles
+
+- **Be specific**: Always quote the exact text with the error
+- **Reference rules**: Cite the specific style guide rule for each correction
+- **Maintain voice**: Preserve the author's voice while correcting errors
+- **Prioritize clarity**: Focus on changes that improve readability
+- **Be constructive**: Frame feedback to help writers improve
+- **Flag ambiguous cases**: When style guide doesn't address an issue, explain options and recommend the clearest choice
+
+## Common Areas to Focus On
+
+Based on Every's style guide, pay special attention to:
+
+- Punctuation (comma usage, semicolons, apostrophes, quotation marks)
+- Capitalization (proper nouns, titles, sentence starts)
+- Numbers (when to spell out vs. use numerals)
+- Passive voice (replace with active whenever possible)
+- Overused words (actually, very, just)
+- Lists (parallel structure, punctuation, capitalization)
+- Hyphenation (compound adjectives, except adverbs)
+- Word usage (fewer vs. less, they vs. them)
+- Company references (singular "it", teams as plural "they")
+- Job title capitalization

--- a/.plugin/skills/every-style-editor/references/EVERY_WRITE_STYLE.md
+++ b/.plugin/skills/every-style-editor/references/EVERY_WRITE_STYLE.md
@@ -1,0 +1,529 @@
+# Every Style Guide
+
+## Quick-and-dirty Every style guide
+
+Always use the following style guide, go though the items one by one and suggest edits.
+
+- **Title case** for headlines, **sentence case** for everything else.
+- Refer to **companies as singular** ("it" instead of "they" or "them") and teams or people within companies as plural ("they").
+- Don't overuse "**actually**," "**very**," or "**just**" (they can almost always be deleted).
+- When linking to another source, **hyperlink** between 2-4 words.
+- You can generally **cut adverbs**.
+- Watch out for **passive voice**—use active whenever possible.
+- Spell out **numbers** one through nine. Spell out a number if it is the first word of a sentence, unless it's a year. Use numerals for numbers 10 and greater.
+- You may use _italics_ for emphasis, but never **bold** or underline.
+- **Image credits** in captions are italicized, like this: _Source: X/Name_ (if Twitter), _Source: Website name._
+- Don't capitalize **job titles**.
+- **Colons** determine capitalization rules. When a colon introduces an independent clause, the first word of that clause should be capitalized. When a colon introduces a dependent clause, the first word of the clause should not be capitalized.
+- Use an **Oxford comma** for serialization (x, y, and z).
+- Use a comma to separate **independent clauses** but not dependent clauses.
+- Do not use a space after an **ellipsis**.
+- Use an **em dash** (—) to set off a parenthetical statement. Do not put spaces around an em dash. Generally, don't use em dashes more than twice in a paragraph.
+- Use **hyphens** in compound adjectives, with the exception of adverbs (i.e., words ending in "ly"). Example: fine-tuned vs. finely tuned.
+- **Italicize titles** of books, newspapers, periodicals, movies, TV shows, and video games. Do not italicize "the" before _New York Times_ or "magazine" after _New York_.
+- Identify people by their full names on first mention, last name thereafter. In newsletter and social media communications, use first names rather than last names.
+- **Percentages** always use numerals, and spell out percent: 7 percent.
+- **Numbers over three digits** take a comma: 1,000.
+- Punctuation goes outside of a **parentheses** unless the text in parentheses is a full sentence, or there's a question or exclamation within the parenthetical.
+- Place periods and commas inside **quotation marks**.
+- Quotes within quotations should be placed in **single quotation marks** (' ').
+- If the text preceding a quote **introduces the quote**, include a comma before the quote. If the text before the quote leads directly into the quote, don't include a comma. Capitalize the first letter in the quote when it's a full sentence or when following "said," "says," or other introductory language.
+- Rather than "above" or "below," use terms like **"earlier," "later," "previously,"** etc.
+- Rather than "over" or "under," use **"more" or "less"/"fewer"** when referring to numbers or quantities.
+- Try to avoid slashes (like and/or), and use **hyphens** instead when needed.
+- **Avoid starting sentences with "This,"** and be specific with what you're referring to.
+- **Avoid starting sentences with "We have" or "We get,"** and instead, say directly what is happening.
+- **Avoid cliches or jargon.**
+- **Write out "times"** when referring to more powerful software: "two times faster." You can write "10x" in reference to the common trope.
+- Use a **dollar sign** instead of writing out "dollars": $1 billion.
+- **Identify most people** by company and/or job title: Stripe's Patrick McKenzie. (Exception: Mark Zuckerberg)
+
+## Our grammar and mechanics
+
+Every generally follows Merriam-Webster and the AP Stylebook.
+
+### Abbreviations and acronyms
+
+#### First Usage Rule
+
+If there's a chance a reader won't recognize an abbreviation or acronym, then spell it out the first time. When you write out an entity's full name the first time, include an abbreviation in brackets if you plan to use it again: United States Air Force (USAAF). If the abbreviation is more common than the long form, then just use the short form (CMS, DVD, FTP).
+
+#### Common Abbreviations
+
+Abbreviate words, phrases, and titles that are almost always abbreviated in English: a.m., p.m., et al., i.e. and e.g. (both of which are followed by a comma), vs., etc.
+
+#### Established Acronyms
+
+Abbreviate firmly established shortened forms, acronyms, and similar abbreviations: AI, TV, UK, UN
+
+#### Punctuation in Abbreviations
+
+Set most abbreviations without points, though there are some exceptions: U.S.A., U.S., L.A., N.Y.C., D.C.
+
+#### Plural Abbreviations
+
+When forming plurals of abbreviations, add an s to those without points, an apostrophe and s to those with points: LLMs, TVs, Ph.D.'s, M.B.A.'s
+
+#### Specific Abbreviations
+
+Specific abbreviations: LGBTQIA+
+
+#### Geography
+
+Spell out cities and states in full. Include the state when referring to non-major cities or for specificity. Offset the state with commas: They were born in Paris, Texas, and moved to San Francisco in 1995.
+
+#### Time Format
+
+Spell out the day and the month, and separate them with a comma: Sunday, January 21
+
+### Ampersands
+
+#### Usage Rule
+
+Avoid using them unless they're part of a proper noun or company name. Write out "and" instead. In the event of a joint byline, the same rule applies: She interned for the law firm of Wilson Sonsini Goodrich & Rosati. By Dan Shipper and Evan Armstrong
+
+### Bold, italics, underline
+
+#### Emphasis Guidelines
+
+Italics may be used in rare cases for emphasis, especially if doing so will increase clarity. Bold and underline should not be used for emphasis: Hosting a meeting with all 20 team members *seemed* like a good idea, but the conversation quickly got out of hand.
+
+### Buttons
+
+#### Button Text
+
+Use the sentence case in CTA buttons: Register for the course
+
+### Bylines
+
+#### Guest Author Biography
+
+Pieces written by guest authors include a biography for the author at the bottom of the piece. If a piece was previously published, cite and link to the original source. Use italics: *Leo Polovets is a general partner at [Humba Ventures](https://humbaventures.com/), an early-stage deep tech fund in the Susa Ventures fund family. Before cofounding Susa and Humba, Leo spent 10 years as a software engineer. Previously, he was the second engineering hire at LinkedIn, among other roles. This piece was originally published [in his newsletter](https://www.codingvc.com/p/betting-on-deep-tech).*
+
+#### Guest Author Introduction
+
+Pieces written by guest authors also include an introduction from an Every staff member that identifies the author, their background, the subject of the piece, and why we recommend it. The introduction is signed by the staff member who wrote it. Use italics: *When I was coming up in tech, the conventional wisdom was that working at or investing in software companies was a great way to make money, while doing so with companies that took on scientific risk or produced hardware components were a wonderful way to lose every cent to your name. This has always struck me as, you know, wrong, which is why this piece by venture capitalist Leo Polovets resonated with me. He takes a data-driven approach to understanding how deep tech companies can produce superior financial returns. If you're on the fence with your career—perhaps facing temptation to do something relatively safe in B2B SaaS—take this piece as a rational encouragement to dream bigger. —[Evan](https://twitter.com/itsurboyevan)*
+
+### Capitalization
+
+#### General Rule
+
+Use common sense. When in doubt, don't capitalize. Do not capitalize these words: website, internet, online, email, web3, custom instructions
+
+#### Job Titles
+
+Do not capitalize job titles, whether on their own or preceding names, unless they're very unusual: He accepted the position of director of business operations. Director of business operations Lucas Crespo manages Every's ad sales. Lucas Crespo, director of business operations, manages Every's ad sales. Chief Happiness Officer
+
+#### Colons
+
+Colons (:) determine capitalization rules. When a colon introduces: An independent clause, the first word of that clause should be capitalized. A dependent clause, the first word of the clause should not be capitalized.
+
+#### Civic Titles
+
+Capitalize civic titles only when they precede a name and function as a proper title: Secretary of State Antony Blinken. Lowercase such titles when they appear as a common noun: a senator (common noun), Senator Schumer (title preceding name), Chuck Schumer, senator from New York (common noun), New York senator Schumer (common noun used in apposition), the president, President Biden, former president Obama, the mayor, Mayor Adams, New York mayor Eric Adams
+
+#### Academia
+
+Capitalize course titles mentioned in text, and don't enclose them in quotation marks: She took Computer Science and Maximize Your Mind With ChatGPT. Lowercase the names of academic disciplines: One job requirement is a master's in computer science.
+
+#### Geography Names
+
+Lowercase the initial the in place names and in the names of bands, bars, restaurants, hotels, products, and the like: the Netherlands, the Pixies, the Pentagon
+
+### Captions
+
+#### Caption Format
+
+Capitalize the first word of a caption, and end with a period, whether or not the body of the caption is a full sentence.
+
+#### Identifying Names
+
+When a caption consists of nothing but an identifying name, however, omit the end punctuation. If the identifying caption includes any language beyond just a name, though, use the final punctuation: Dan Shipper. Dan Shipper, Every CEO.
+
+#### Image Credits
+
+When a caption includes an image credit, the credit should be formatted as DALL-E/Every illustration.
+
+### Commas
+
+#### Serial Comma
+
+Use the serial or Oxford comma before the conjunction in a series: x, y, and z
+
+#### Independent vs Dependent Clauses
+
+Use a comma to separate independent clauses but not dependent clauses: He helped trouble-shoot an issue, and she wrote code. She signed up for Every and became a subscriber.
+
+#### Restrictive Elements
+
+Set off nonrestrictive elements with commas; don't set off restrictive elements. The most frequent example is the that/which difference: The piece, which garnered 15,000 readers, is one of Every's most successful. The piece that garnered 15,000 readers is one of Every's most successful.
+
+#### Too Usage
+
+Include a comma before "too" when used to mean "in addition." Don't use a comma when "too" refers to the subject of the sentence: I ate a bowl of ice cream. I had a cookie, too. You're a cat person? I am too.
+
+#### Names
+
+Don't include commas before "Jr." or "Sr.": Hank Aaron Jr.
+
+#### Repetition
+
+Don't include commas before words repeated for emphasis: It's what makes you you.
+
+#### General Comma Usage
+
+Otherwise, follow common sense with commas. Read the sentence out loud. If you need to take a breath, use a comma.
+
+### Dates
+
+#### Date Formats
+
+Write dates as follows: April 13, 2018, The 19th of April was a nice day, March 2020, Thanksgiving 2023, summer 1999, the years 1980–85
+
+#### Decades
+
+When referring to a decade, write out the full year numerically at first mention and abbreviate on the second: She was born in the 1980s. The '80s was a wild decade.
+
+### Ellipses
+
+#### Usage
+
+Use ellipses (…) to show that you're omitting words or trailing off before the end of a thought. Don't use an ellipsis for emphasis or drama. Don't use ellipses in titles or headers, nor when you should be using a colon (a list is to follow). There is no space before an ellipsis, and one space after… like this.
+
+### Em dashes
+
+#### Usage and Spacing
+
+Use an em dash ( — ) for a true break or to set off a parenthetical statement. Do not put spaces around them. Try not to use em dashes more than twice in a paragraph. Don't use hyphens in place of an em dash: It's an anxious time to be an independent bookseller—but a recent upswing in sales is cause for optimism.
+
+### En dash
+
+#### Usage
+
+Use them in compound adjectives, compound noun constructions, or when indicating spans or ranges: 5°C–10°C, from 10 a.m.–2 p.m., January 2019–November 2020, Texas–Mexico border, then–VP of engineering
+
+### Filenames
+
+#### File Types
+
+When referring to a file type, use the appropriate acronym in all caps: GIF, PDF
+
+#### Specific Files
+
+When referring to a specific file, specify the filename followed by a period and the file type, all lowercase: important-graph.jpg
+
+### Headlines
+
+#### Title Case
+
+Use title case for headlines. Use sentence case for subtitles and subheadings. Capitalize important words — everything but articles, conjunctions (for, and, nor, but, or, yet, so), and prepositions under four letters — in headings. Capitalize the first word only in subtitles and subheadings.
+
+#### Prepositions
+
+Capitalize short prepositions that form an integral part of a verb: Growing Up in China
+
+#### Internal Punctuation
+
+Capitalize all words following an internal punctuation mark: My Company Died — Learn From My Mistakes
+
+#### First and Last Words
+
+The first and last words of a headline are capitalized, no matter their parts of speech. Don't use punctuation in a title unless it's a question or exclamatory sentence.
+
+#### Handwritten Letters
+
+Headlines include one handwritten letter: The Secret [F]ather of Modern Computing
+
+#### Subheadings
+
+In general, start with h2 heading size and go smaller as needed for subheads. Some things to keep in mind: make sure that the hed doesn't run on too long (or onto a second line), or look out of place on the page. If it does, go smaller. For interview questions, use h5 heading size.
+
+### Hyphens
+
+#### Compound Adjectives
+
+Use hyphens in compound adjectives, with the exception of adverbs (words ending in "-ly" or modifying a verb). A compound adjective that contains another compound adjective calls for an en dash: first-time founder, state-of-the-art design, open-source project, Pulitzer Prize–winning novelist, newly released program
+
+#### Post-Noun Usage
+
+Don't use hyphens when the compound adjective is placed after the noun it modifies or when the adjective is made up of nouns: The team is world class. video game console, The feature is first of its kind. toilet paper roll
+
+#### Suspended Hyphens
+
+Use a suspended hyphen for multiple hyphenated compounds or words: NewYork- and San Francisco-based company, university-owned and -operated bookstore
+
+#### Percentages and Amounts
+
+Hyphenation is usually unnecessary when expressing percentage, degree, or dollar amounts in figures: a 50 percent decline, $50 billion investment. But: a 50- to 60-percent decline, a $1-million-a-month burn rate
+
+#### Fractions
+
+Use hyphens in fractions, no matter their part of speech: three-fourths of the team, a share of one-third, one-third the size, a three-fourths share, one-third slower
+
+### Italics
+
+#### Titles
+
+Italicize titles of books, newspapers, periodicals, movies, TV shows, and video games, with the following rules: If a magazine title must be followed by "magazine" to distinguish it from other publications, do not italicize "magazine" unless it is formally included in the title: *New York* magazine vs. *The New York Times Magazine*. For magazine titles, italicize the article if it is a formal part of the title: *The New Yorker*. For newspapers, do not italicize the article: the *New York Times*
+
+#### Short Works
+
+Titles of short works (poems, songs, TV episodes, book chapters) take quotation marks.
+
+#### Punctuation After Italics
+
+Do not italicize punctuation that follows an italicized term: Stewart Brand published the first issue of his seminal magazine, the *Whole Earth Catalogue*, in 1968. Which earned more at the box office, *Barbie* or *Oppenheimer*?
+
+#### Websites
+
+Italicize a website's title if it is also the name of a print newspaper or magazine. Otherwise, leave it unitalicized.
+
+### Linking
+
+#### Link Guidelines
+
+Provide a link when referring to a website. Don't capitalize links or words within links, and don't say things like "Click here!" or "Click for more information." Write the sentence as you normally would, and link relevant keywords.
+
+#### Link Text Length
+
+Include only links you need and make the links as useful as possible. Keep the link text short, ideally two to four words. But not too short: Just one word can be difficult to click or tap on, especially if you're reading on a phone.
+
+#### URL Format
+
+URLs included in print should appear as is (i.e., not shortened by a URL shortener). The URL should be all lowercase, unless adding camel caps would increase readability. Don't include "www." or anything preceding it: You can read more on every.to. She's the founder of GetOutTheVoteNewYork.com.
+
+### Lists
+
+#### Usage
+
+Use lists to present groups of information. Only number lists when order is important (describing steps of a process).
+
+#### Numbering Format
+
+Preferred format of lists is: 1., not 1)
+
+#### Punctuation in Lists
+
+If one of the list items is a complete sentence, use punctuation on all of the items. Otherwise, don't use punctuation in lists: 1. Enter your email. 2. Input your credit card information.
+
+#### Numbered Lists
+
+If the items are numbered, a period follows the numeral and each item begins with a capital letter.
+
+#### Bulleted Lists
+
+Don't use numbers when the list's order doesn't matter: Here are some chatbots that we created for the course: Hidden Premise Finder, Reflective Coach, Motivational Interviewing
+
+### Naming
+
+#### Name References
+
+Identify people by their full names on first mention, last name thereafter. In newsletter and social media communications, use first names rather than last names.
+
+#### Special Titles
+
+By convention, the sitting U.S. president, active senior religious leaders, and living royalty should be referred to as Title (Last)Name: Pope Francis, John Paul II, King Charles, Elizabeth II, President Biden (but Donald Trump), Rishi Sunak, Dr. Jill Biden (not First Lady Biden), Mike Johnson (not Speaker Johnson or Congressman Johnson), Madonna, Andre the Giant
+
+### Numbers
+
+#### Spelling Out Numbers
+
+Spell out one through nine and first through ninth, and spell out a number if it's the first word of a sentence. Use numerals below 10 only if decimal accuracy is required (5.6 miles) or for currency ($8), or when writing whole numbers greater than a million (4 million). Figures are also used when an abbreviation or symbol is used as the unit of measure: 75 mph, 15 km, 6'3", -40º Celsius
+
+#### Percentages
+
+Percentages always use numerals and spell out "percent": 7 percent
+
+#### Ages
+
+Ages always use numerals: He had a 5-year-old daughter.
+
+#### Bitcoin
+
+Write "bitcoin" for the generic currency but "bitcoins" for quantities of them: Since the company began accepting bitcoin, it has raked in over 1,000 bitcoins.
+
+#### Other Figure Usage
+
+There are a few more exceptions. Use figures for the following: the 1990s or the '90s, 70 degrees, chapter 16
+
+#### Time of Day
+
+Expressions of the time of day — even, half, and quarter hours, for example — may be spelled out. If you want to indicate the hour more specifically or to emphasize exactness, figures are used: ten o'clock, Eight-thirty, quarter past nine, 11:37 p.m., the 10:15 standup, Dan scheduled the meeting for 9:00 a.m. sharp.
+
+#### Starting Sentences
+
+Spell out any number that starts a sentence, unless it's a year. (Alternatively, revise the sentence so it doesn't start with a number.) Hyphens should be used in spelled-out numbers to join parts of a two-digit number: Twenty-five engineers joined the company in January. Ten thousand five hundred people signed up in a single day. 2020 was a tough year.
+
+#### Commas in Numbers
+
+Except in years, use a comma to separate 000's: 1,440,434. Numbers over three digits take commas: 1,000
+
+#### Charts and Tables
+
+Use figures for all numbers in charts and tables.
+
+#### Ratios
+
+Ratios are spelled out without hyphens: one in five, or one in 20.
+
+### Parentheses
+
+#### Usage
+
+Use them only when the clause or phrase is non-essential, or when used for clarification or as an editorial aside: The investigation revealed groundbreaking information (though it has yet to be widely publicized). Please include the following information (if available)
+
+#### Punctuation Placement
+
+Punctuation goes outside of the parentheses unless the text in parentheses is a full sentence, or there's a question or exclamation within the parenthetical: How many hours per week do your developers spend on maintenance (i.e., debugging, refactoring, modifying)? She wondered if the world was out to get her. (Don't we all?)
+
+### Plurals
+
+#### Names Ending in S
+
+For singular names and words that end in s, add 's, not just an apostrophe: Leo Polovets's fund, Paris's bridges
+
+#### Entities Ending in S
+
+For entities that end in s, add an 's as well: the New York Times's readers
+
+#### Plural Names
+
+For plural names and words, add just an apostrophe: the Williamses' farm, the Joneses' printer
+
+#### Plural Words Not Ending in S
+
+For plural words that don't end in s, treat them like singular nouns: men's, women's, children's
+
+#### Figures and Characters
+
+Use an apostrophe and s to form the plural of figures, lowercase characters, and symbols: two o's, two k's, and two e's in bookkeeper (but the three Rs; the five Ws), five @'s, a fleet of 747B's, stolen .22's
+
+#### Exceptions
+
+There are some exceptions: the 2000s, a woman in her 20s, temperature in the 70s, a fleet of 747s
+
+### Pronouns
+
+#### Singular They
+
+Use the singular "they" (not "he or she") when making a gender-neutral statement. Use "it" for companies and brands: If a team member is feeling burnt out, consider how you can help support them. The company released its new product on Monday.
+
+#### Pronoun References
+
+Use the terms "he/him pronouns" and "she/her pronouns" when referring to a person's pronouns, not "male pronouns" and "female pronouns." Avoid the term "preferred pronouns."
+
+### Proper nouns and names
+
+#### Every Capitalization
+
+"Every" is always capitalized. The only times Every appears in lowercase are in social media handles and URLs.
+
+#### Geography
+
+Capitalize place names, but use lowercase for general directions or regions: the East (world and U.S.), the West (world and U.S.), the South, the North, Western United States, Southeast Asia, Northern Hemisphere, eastern Long Island, the Bay Area, Westerner, Easterner, Northerner, Southerner, the Midwest, Midwestern, Southwestern (referring to style of art), southwestern (all other uses), Western Europe, Eastern Europe, southern California, northern California, west Texas, east Tennessee, south Florida, the South of France, Continental Europe, Washington State
+
+#### Neighborhoods
+
+Neighborhood nicknames are also capitalized: Midtown, Soho, Tribeca, the Tenderloin
+
+#### Earth
+
+Capitalize Earth when writing about it as a planet ("Venus, Mars, and Earth"), but lowercase in phrases like "salt of the earth."
+
+#### Initials in Names
+
+For proper names written with initials, use periods and no spaces: E.L. James, J.K. Simmons, J.Crew. But when the initials comprise the whole name, no periods are used (FDR, DFW).
+
+### Punctuation
+
+#### Exclamation Points
+
+Use exclamation points sparingly. Seriously! (Unless you're quoting someone.) Use emojis with discretion.
+
+### Quotation marks
+
+#### Basic Usage
+
+Spoken text should be placed in double quotation marks (" "). Quotes within quotations should be placed in single quotation marks (' '): "He told me, 'That's a fantastic idea.'" "You may find it hard to prioritize the 'I got problems' meeting at first."
+
+#### Tense Usage
+
+Use the present tense when the quote was spoken directly to the author. Use the past tense when the quote is a recollection or happened at a specific time in the past. Treat thoughts the same way: "That was a long day," she recalls. She remembers the frustrations of that day well. It began when her manager said, "I'm afraid we've got trouble." I thought, "What's next?"
+
+#### Punctuation Placement
+
+Place periods and commas inside quotation marks. If a question mark or exclamation mark is part of the quote, place it within the quotation marks. If the question or exclamation refers to the quote itself, place the punctuation outside of the quote: She asked, "Who else is taking the week of Christmas off?" Who said, "To thine own self be true"?
+
+#### Introducing Quotes
+
+If the text preceding a quote introduces the quote, include a comma before the quote. If the text before the quote leads directly into the quote, don't include a comma. Capitalize the first letter in the quote when it's a full sentence or when following "said," "says," or other introductory language. Generally avoid using a colon to introduce a quote unless it's more than two sentences long: When doing strategic planning for the year, "it's important to carve out time to solicit everyone' feedback," she says. Every's mission is "to feed the minds and hearts of the people who build the internet," says Shipper. He recalls, "We had no choice but to start from scratch."
+
+#### Multi-Paragraph Quotes
+
+When a quote continues across multiple paragraphs, the quote is left open at the end of each paragraph. A new open-quote mark is to start the next paragraph, only closing the quote when the full quote is finished: Guillermo has noticed developers at Vercel becoming more full stack. "I think it's an important asset to have. They can bring context, data, copywriting into their creations that otherwise would have required chatting with other people and crowdsourcing ideas. "The trend has been away from the implementation detail, which is the code, and toward the end goal, which is to deliver a great product or a great experience."
+
+#### Edited Text
+
+Use square brackets to indicate edited text in a quote. Keep text in square brackets to a minimum—use only when the edit would increase clarity and comprehension or add necessary context. If you need to place an entire sentence in square brackets, it's probably better to paraphrase: "It was difficult [to prioritize addressing tech debt] because we had so many features to work on."
+
+#### Block Quotes
+
+Use block quotes when a quotation is more than four lines long. Introduce it with a colon, and include quotation marks.
+
+### References to other parts of the text
+
+#### Directional References
+
+Rather than "above" or "below," use terms like "earlier," "later," "previously," etc.: As I mentioned earlier,
+
+### Semicolons
+
+#### Usage Guidelines
+
+Go easy on semicolons. When appropriate, use an em dash ( — ) instead, or simply start a new sentence. Never use a semicolon in site or email copy.
+
+### Slashes
+
+#### Usage
+
+Try to avoid them, and minimize constructions like "and/or." Use hyphens instead when needed. However, slashes should always be used when referring to an individual's pronouns: We needed all of our designers and illustrators to sign the contract. She's an accomplished singer-songwriter. they/them pronouns, We had a team of 20 engineers and developers.
+
+### Spelling
+
+#### American Spelling
+
+Use American spellings (i.e., color, not colour).
+
+#### Unconventional Spellings
+
+Do not follow unconventional or artistic spellings of names, products, and corporations: Questlove (not ?uestlove), Kesha (not Ke$ha), India Arie (not India.Arie), E.E. Cummings (not e e cummings), Kiss (not KISS), Adidas (not adidas), Yahoo (not Yahoo!)
+
+#### Common Exceptions
+
+The common exceptions are: ChatGPT, WhatsApp, iPod, iPhone, iMac, etc., TikTok, eBay, PayPal, BuzzFeed
+
+### Time zones
+
+#### Abbreviations
+
+Abbreviate time zones within the continental United States, and spell out the rest: Eastern Time (ET), Central Time (CT), Mountain Time (MT), Pacific Time (PT)
+
+### Usage
+
+#### Collective Nouns
+
+Collective nouns can be construed as plural if you want to emphasize the individuals forming the group, but most often they should be treated as singular. Subsequent pronouns should agree with the verb tense chosen. The Every trivia squad is considered one of the league's strongest teams. But: The lucky trio are collecting their Amazon gift cards. The Grammys are coming to Los Angeles.
+
+#### Fewer vs Less
+
+Use "fewer" instead of "less" with nouns for countable objects and concepts. Don't use "over" or "under" when referring to numbers or quantities: Fewer than seven days remain until the quarter ends. In less than an hour, more than an inch of rain fell.
+
+#### Overused Words
+
+Don't overuse "actually," "very," or "just" (they can almost always be deleted).
+
+### Word and phrase bank
+
+#### Standard Terms
+
+add on (verb), add-on (noun, adjective), back end (noun), back-end (adjective), beta (lowercase unless it's part of a proper noun), cofounder, Covid-19, coworker, double-click, drop-down, e-commerce, front end (noun), front-end (adjective), geolocation, hashtag, homepage, large language model, login (noun, adjective), log in (verb), millennial, nonprofit, Online, open source, open-source software, opt in (verb), opt-in (noun, adjective), pop-up (noun, adjective), pop up (verb), signup (noun, adjective), sign up (verb), startup, sync, username, URL (always uppercase), web3, well-being, WiFi, workspace

--- a/.plugin/skills/frontend-design/SKILL.md
+++ b/.plugin/skills/frontend-design/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: frontend-design
+description: "Create distinctive, production-grade frontend interfaces. Generates creative, polished web components, pages, or applications that avoid generic AI aesthetics with high design quality."
+license: Complete terms in LICENSE.txt
+triggers:
+- frontend design
+- web design
+- UI design
+- build interface
+- landing page
+- web component
+---
+
+This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+
+The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
+- **Constraints**: Technical requirements (framework, performance, accessibility).
+- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+
+**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+
+Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+
+- Production-grade and functional
+- Visually striking and memorable
+- Cohesive with a clear aesthetic point-of-view
+- Meticulously refined in every detail
+
+## Frontend Aesthetics Guidelines
+
+Focus on:
+
+- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
+- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
+- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
+- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+
+NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+
+Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
+
+**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
+
+Remember: extraordinary creative work is possible. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.

--- a/.plugin/skills/gemini-imagegen/SKILL.md
+++ b/.plugin/skills/gemini-imagegen/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: gemini-imagegen
+description: "Generate or edit images using the Gemini API. Supports text-to-image, image editing, multi-turn refinement, style transfer, logos with text, stickers, product mockups, and composition from multiple reference images."
+triggers:
+- gemini image
+- image generation
+- text to image
+- generate image
+- gemini api image
+- imagegen
+---
+
+# Gemini Image Generation (Nano Banana Pro)
+
+Generate and edit images using Google's Gemini API. The environment variable `GEMINI_API_KEY` must be set.
+
+## Phase 0: Pre-Flight Checks
+
+Before generating images, verify both environment and quota:
+
+1. **Environment:** Confirm `GEMINI_API_KEY` is set (the scripts check this)
+2. **Python dependencies:** Install in a venv (`python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt`) -- bare `pip install` is blocked by PEP 668 on modern Linux; versions are pinned to exact releases for supply chain security
+3. **Image generation quota:** Free-tier API keys authenticate successfully but may have zero quota for image generation. Run a minimal test request before building the full pipeline:
+
+```bash
+python3 -c "
+import os
+from google import genai
+from google.genai import types
+client = genai.Client(api_key=os.environ['GEMINI_API_KEY'])
+try:
+    r = client.models.generate_content(
+        model='gemini-2.5-flash-image',
+        contents=['Generate a 1x1 pixel red square'],
+        config=types.GenerateContentConfig(response_modalities=['TEXT', 'IMAGE']),
+    )
+    print('[ok] Image generation quota available')
+except Exception as e:
+    print(f'[FAIL] Image generation quota: {e}')
+"
+```
+
+If quota is unavailable, fall back to Pillow-only generation (solid/gradient backgrounds with text overlay).
+
+## Default Model
+
+| Model | Resolution | Best For |
+|-------|------------|----------|
+| `gemini-3-pro-image-preview` | 1K-4K | All image generation (default) |
+
+**Note:** Always use this Pro model. Only use a different model if explicitly requested.
+
+## Quick Reference
+
+### Default Settings
+
+- **Model:** `gemini-3-pro-image-preview`
+- **Resolution:** 1K (default, options: 1K, 2K, 4K)
+- **Aspect Ratio:** 1:1 (default)
+
+### Available Aspect Ratios
+
+`1:1`, `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9`
+
+### Available Resolutions
+
+`1K` (default), `2K`, `4K`
+
+## Core API Pattern
+
+```python
+import os
+from google import genai
+from google.genai import types
+
+client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+
+# Basic generation (1K, 1:1 - defaults)
+response = client.models.generate_content(
+    model="gemini-3-pro-image-preview",
+    contents=["Your prompt here"],
+    config=types.GenerateContentConfig(
+        response_modalities=['TEXT', 'IMAGE'],
+    ),
+)
+
+for part in response.parts:
+    if part.text:
+        print(part.text)
+    elif part.inline_data:
+        image = part.as_image()
+        image.save("output.png")
+```
+
+## Custom Resolution & Aspect Ratio
+
+```python
+from google.genai import types
+
+response = client.models.generate_content(
+    model="gemini-3-pro-image-preview",
+    contents=[prompt],
+    config=types.GenerateContentConfig(
+        response_modalities=['TEXT', 'IMAGE'],
+        image_config=types.ImageConfig(
+            aspect_ratio="16:9",  # Wide format
+            image_size="2K"       # Higher resolution
+        ),
+    )
+)
+```
+
+### Resolution Examples
+
+```python
+# 1K (default) - Fast, good for previews
+image_config=types.ImageConfig(image_size="1K")
+
+# 2K - Balanced quality/speed
+image_config=types.ImageConfig(image_size="2K")
+
+# 4K - Maximum quality, slower
+image_config=types.ImageConfig(image_size="4K")
+```
+
+### Aspect Ratio Examples
+
+```python
+# Square (default)
+image_config=types.ImageConfig(aspect_ratio="1:1")
+
+# Landscape wide
+image_config=types.ImageConfig(aspect_ratio="16:9")
+
+# Ultra-wide panoramic
+image_config=types.ImageConfig(aspect_ratio="21:9")
+
+# Portrait
+image_config=types.ImageConfig(aspect_ratio="9:16")
+
+# Photo standard
+image_config=types.ImageConfig(aspect_ratio="4:3")
+```
+
+## Editing Images
+
+Pass existing images with text prompts:
+
+```python
+from PIL import Image
+
+img = Image.open("input.png")
+response = client.models.generate_content(
+    model="gemini-3-pro-image-preview",
+    contents=["Add a sunset to this scene", img],
+    config=types.GenerateContentConfig(
+        response_modalities=['TEXT', 'IMAGE'],
+    ),
+)
+```
+
+## Multi-Turn Refinement
+
+Use chat for iterative editing:
+
+```python
+from google.genai import types
+
+chat = client.chats.create(
+    model="gemini-3-pro-image-preview",
+    config=types.GenerateContentConfig(response_modalities=['TEXT', 'IMAGE'])
+)
+
+response = chat.send_message("Create a logo for 'Acme Corp'")
+# Save first image...
+
+response = chat.send_message("Make the text bolder and add a blue gradient")
+# Save refined image...
+```
+
+## Prompting Best Practices
+
+### Photorealistic Scenes
+
+Include camera details: lens type, lighting, angle, mood.
+> "A photorealistic close-up portrait, 85mm lens, soft golden hour light, shallow depth of field"
+
+### Stylized Art
+
+Specify style explicitly:
+> "A kawaii-style sticker of a happy red panda, bold outlines, cel-shading, white background"
+
+### Text in Images
+
+Be explicit about font style and placement:
+> "Create a logo with text 'Daily Grind' in clean sans-serif, black and white, coffee bean motif"
+
+### Product Mockups
+
+Describe lighting setup and surface:
+> "Studio-lit product photo on polished concrete, three-point softbox setup, 45-degree angle"
+
+## Advanced Features
+
+### Google Search Grounding
+
+Generate images based on real-time data:
+
+```python
+response = client.models.generate_content(
+    model="gemini-3-pro-image-preview",
+    contents=["Visualize today's weather in Tokyo as an infographic"],
+    config=types.GenerateContentConfig(
+        response_modalities=['TEXT', 'IMAGE'],
+        tools=[{"google_search": {}}]
+    )
+)
+```
+
+### Multiple Reference Images (Up to 14)
+
+Combine elements from multiple sources:
+
+```python
+response = client.models.generate_content(
+    model="gemini-3-pro-image-preview",
+    contents=[
+        "Create a group photo of these people in an office",
+        Image.open("person1.png"),
+        Image.open("person2.png"),
+        Image.open("person3.png"),
+    ],
+    config=types.GenerateContentConfig(
+        response_modalities=['TEXT', 'IMAGE'],
+    ),
+)
+```
+
+## Important: File Format & Media Type
+
+**CRITICAL:** The Gemini API returns images in JPEG format by default. When saving, always use `.jpg` extension to avoid media type mismatches.
+
+```python
+# CORRECT - Use .jpg extension (Gemini returns JPEG)
+image.save("output.jpg")
+
+# WRONG - Will cause "Image does not match media type" errors
+image.save("output.png")  # Creates JPEG with PNG extension!
+```
+
+### Converting to PNG (if needed)
+
+If you specifically need PNG format:
+
+```python
+from PIL import Image
+
+# Generate with Gemini
+for part in response.parts:
+    if part.inline_data:
+        img = part.as_image()
+        # Convert to PNG by saving with explicit format
+        img.save("output.png", format="PNG")
+```
+
+### Verifying Image Format
+
+Check actual format vs extension with the `file` command:
+
+```bash
+file image.png
+# If output shows "JPEG image data" - rename to .jpg!
+```
+
+## Notes
+
+- All generated images include SynthID watermarks
+- Gemini returns **JPEG format by default** - always use `.jpg` extension
+- Image-only mode (`responseModalities: ["IMAGE"]`) won't work with Google Search grounding
+- For editing, describe changes conversationally—the model understands semantic masking
+- Default to 1K resolution for speed; use 2K/4K when quality is critical

--- a/.plugin/skills/gemini-imagegen/requirements.txt
+++ b/.plugin/skills/gemini-imagegen/requirements.txt
@@ -1,0 +1,5 @@
+# Pinned to exact versions for supply chain security (#1174).
+# Full hash verification (--require-hashes) requires pip-compile for
+# transitive dependencies -- tracked as future enhancement.
+google-genai==1.66.0
+Pillow==12.1.1

--- a/.plugin/skills/gemini-imagegen/scripts/_error_handling.py
+++ b/.plugin/skills/gemini-imagegen/scripts/_error_handling.py
@@ -1,0 +1,146 @@
+"""Shared error handling for Gemini image generation scripts.
+
+Error messages include raw API responses intentionally for CLI debugging.
+Sanitize before surfacing in user-facing web contexts.
+"""
+
+from typing import NoReturn
+
+from google.genai import errors
+
+
+class QuotaExhaustedError(RuntimeError):
+    """API key has zero or exceeded image generation quota."""
+
+    pass
+
+
+class PermissionDeniedError(RuntimeError):
+    """API key lacks image generation access."""
+
+    pass
+
+
+class SafetyFilterError(RuntimeError):
+    """Image was blocked by content policy."""
+
+    pass
+
+
+class NoImageError(RuntimeError):
+    """Model returned no image in response."""
+
+    pass
+
+
+_SAFETY_KEYWORDS = ("blocked", "safety", "policy", "prohibited", "harmful")
+
+
+def handle_api_error(e: errors.APIError) -> NoReturn:
+    """Raise a descriptive error based on API error code.
+
+    Converts google.genai SDK exceptions into specific error types.
+    """
+    if isinstance(e, errors.ClientError):
+        if e.code == 429:
+            raise QuotaExhaustedError(
+                "QUOTA EXHAUSTED: Image generation quota is zero or exceeded. "
+                "Free-tier keys may not include image generation.\n"
+                f"API error: {e.message}"
+            ) from e
+        elif e.code == 403:
+            raise PermissionDeniedError(
+                "PERMISSION DENIED: API key lacks image generation access. "
+                "Check your Gemini API tier.\n"
+                f"API error: {e.message}"
+            ) from e
+        else:
+            raise RuntimeError(
+                f"API CLIENT ERROR ({e.code}): {e.message}"
+            ) from e
+    elif isinstance(e, errors.ServerError):
+        raise RuntimeError(
+            f"API SERVER ERROR ({e.code}): {e.message}"
+        ) from e
+    # Forward-compatibility guard for future APIError subclasses
+    raise RuntimeError(f"API ERROR: {e.message}") from e
+
+
+def parse_image_response(response) -> tuple[object | None, str | None]:
+    """Parse a Gemini response for image and text parts.
+
+    Does NOT access response.candidates[N].finish_reason to avoid
+    SDK hang bug (issue #2024).
+
+    Args:
+        response: The GenerateContentResponse or SendMessageResponse.
+
+    Returns:
+        Tuple of (PIL Image or None, text_response or None).
+
+    Raises:
+        NoImageError: If response contains no image parts.
+        SafetyFilterError: If image was blocked by content policy.
+    """
+    if not response.parts:
+        raise NoImageError(
+            "NO IMAGE IN RESPONSE: Model returned empty response. "
+            "Try a different model or prompt."
+        )
+
+    text_response = None
+    image_result = None
+
+    for part in response.parts:
+        if part.text is not None:
+            text_response = part.text
+        elif part.inline_data is not None:
+            image_result = part.as_image()
+
+    if image_result is None:
+        response_text = text_response or ""
+        if any(kw in response_text.lower() for kw in _SAFETY_KEYWORDS):
+            raise SafetyFilterError(
+                "SAFETY FILTER: Image was blocked by content policy. "
+                "Rephrase the prompt."
+            )
+        raise NoImageError(
+            "NO IMAGE IN RESPONSE: Model returned text only. "
+            "Try a different model or prompt."
+        )
+
+    return image_result, text_response
+
+
+def check_quota(client, model: str = "gemini-2.5-flash-image") -> None:
+    """Verify image generation quota with a minimal test request.
+
+    Sends a trivial prompt and checks if the API returns an image.
+    Prints status and raises on failure.
+
+    Args:
+        client: An initialized genai.Client instance.
+        model: The model to test against.
+    """
+    from google.genai import types
+
+    try:
+        response = client.models.generate_content(
+            model=model,
+            contents=["Generate a 1x1 pixel red square"],
+            config=types.GenerateContentConfig(
+                response_modalities=["TEXT", "IMAGE"]
+            ),
+        )
+    except errors.APIError as e:
+        handle_api_error(e)
+
+    has_image = response.parts and any(
+        p.inline_data is not None for p in response.parts
+    )
+    if has_image:
+        print(f"[ok] Image generation quota available (model: {model})")
+    else:
+        raise NoImageError(
+            f"[FAIL] No image in response -- quota may be unavailable (model: {model})"
+        )

--- a/.plugin/skills/gemini-imagegen/scripts/compose_images.py
+++ b/.plugin/skills/gemini-imagegen/scripts/compose_images.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Compose multiple images into a new image using Gemini API.
+
+Usage:
+    python compose_images.py "instruction" output.png image1.png [image2.png ...]
+
+Examples:
+    python compose_images.py "Create a group photo of these people" group.png person1.png person2.png
+    python compose_images.py "Put the cat from the first image on the couch from the second" result.png cat.png couch.png
+    python compose_images.py "Apply the art style from the first image to the scene in the second" styled.png style.png photo.png
+
+Note: Supports up to 14 reference images (Gemini 3 Pro only).
+
+Environment:
+    GEMINI_API_KEY - Required API key
+"""
+
+import argparse
+import os
+import sys
+
+from PIL import Image
+from google import genai
+from google.genai import errors, types
+
+from _error_handling import handle_api_error, parse_image_response
+
+
+def compose_images(
+    instruction: str,
+    output_path: str,
+    image_paths: list[str],
+    model: str = "gemini-3-pro-image-preview",
+    aspect_ratio: str | None = None,
+    image_size: str | None = None,
+) -> str | None:
+    """Compose multiple images based on instructions.
+    
+    Args:
+        instruction: Text description of how to combine images
+        output_path: Path to save the result
+        image_paths: List of input image paths (up to 14)
+        model: Gemini model to use (pro recommended)
+        aspect_ratio: Output aspect ratio
+        image_size: Output resolution
+    
+    Returns:
+        Any text response from the model, or None
+    """
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        raise EnvironmentError("GEMINI_API_KEY environment variable not set")
+    
+    if len(image_paths) > 14:
+        raise ValueError("Maximum 14 reference images supported")
+    
+    if len(image_paths) < 1:
+        raise ValueError("At least one image is required")
+    
+    # Verify all images exist
+    for path in image_paths:
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"Image not found: {path}")
+    
+    client = genai.Client(api_key=api_key)
+    
+    # Load images
+    images = [Image.open(path) for path in image_paths]
+    
+    # Build contents: instruction first, then images
+    contents = [instruction] + images
+    
+    # Build config
+    config_kwargs = {"response_modalities": ["TEXT", "IMAGE"]}
+    
+    image_config_kwargs = {}
+    if aspect_ratio:
+        image_config_kwargs["aspect_ratio"] = aspect_ratio
+    if image_size:
+        image_config_kwargs["image_size"] = image_size
+    
+    if image_config_kwargs:
+        config_kwargs["image_config"] = types.ImageConfig(**image_config_kwargs)
+    
+    config = types.GenerateContentConfig(**config_kwargs)
+    
+    try:
+        response = client.models.generate_content(
+            model=model,
+            contents=contents,
+            config=config,
+        )
+    except errors.APIError as e:
+        handle_api_error(e)
+
+    image, text_response = parse_image_response(response)
+    image.save(output_path)
+    return text_response
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compose multiple images using Gemini API",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    parser.add_argument("instruction", help="Composition instruction")
+    parser.add_argument("output", help="Output file path")
+    parser.add_argument("images", nargs="+", help="Input images (up to 14)")
+    parser.add_argument(
+        "--model", "-m",
+        default="gemini-3-pro-image-preview",
+        choices=["gemini-2.5-flash-image", "gemini-3-pro-image-preview"],
+        help="Model to use (pro recommended for composition)"
+    )
+    parser.add_argument(
+        "--aspect", "-a",
+        choices=["1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+        help="Output aspect ratio"
+    )
+    parser.add_argument(
+        "--size", "-s",
+        choices=["1K", "2K", "4K"],
+        help="Output resolution"
+    )
+    
+    args = parser.parse_args()
+    
+    try:
+        text = compose_images(
+            instruction=args.instruction,
+            output_path=args.output,
+            image_paths=args.images,
+            model=args.model,
+            aspect_ratio=args.aspect,
+            image_size=args.size,
+        )
+        
+        print(f"Composed image saved to: {args.output}")
+        if text:
+            print(f"Model response: {text}")
+            
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.plugin/skills/gemini-imagegen/scripts/edit_image.py
+++ b/.plugin/skills/gemini-imagegen/scripts/edit_image.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Edit existing images using Gemini API.
+
+Usage:
+    python edit_image.py input.png "edit instruction" output.png [options]
+
+Examples:
+    python edit_image.py photo.png "Add a rainbow in the sky" edited.png
+    python edit_image.py room.jpg "Change the sofa to red leather" room_edited.jpg
+    python edit_image.py portrait.png "Make it look like a Van Gogh painting" artistic.png --model gemini-3-pro-image-preview
+
+Environment:
+    GEMINI_API_KEY - Required API key
+"""
+
+import argparse
+import os
+import sys
+
+from PIL import Image
+from google import genai
+from google.genai import errors, types
+
+from _error_handling import handle_api_error, parse_image_response
+
+
+def edit_image(
+    input_path: str,
+    instruction: str,
+    output_path: str,
+    model: str = "gemini-2.5-flash-image",
+    aspect_ratio: str | None = None,
+    image_size: str | None = None,
+) -> str | None:
+    """Edit an existing image based on text instructions.
+    
+    Args:
+        input_path: Path to the input image
+        instruction: Text description of edits to make
+        output_path: Path to save the edited image
+        model: Gemini model to use
+        aspect_ratio: Output aspect ratio
+        image_size: Output resolution
+    
+    Returns:
+        Any text response from the model, or None
+    """
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        raise EnvironmentError("GEMINI_API_KEY environment variable not set")
+    
+    if not os.path.exists(input_path):
+        raise FileNotFoundError(f"Input image not found: {input_path}")
+    
+    client = genai.Client(api_key=api_key)
+    
+    # Load input image
+    input_image = Image.open(input_path)
+    
+    # Build config
+    config_kwargs = {"response_modalities": ["TEXT", "IMAGE"]}
+    
+    image_config_kwargs = {}
+    if aspect_ratio:
+        image_config_kwargs["aspect_ratio"] = aspect_ratio
+    if image_size:
+        image_config_kwargs["image_size"] = image_size
+    
+    if image_config_kwargs:
+        config_kwargs["image_config"] = types.ImageConfig(**image_config_kwargs)
+    
+    config = types.GenerateContentConfig(**config_kwargs)
+    
+    try:
+        response = client.models.generate_content(
+            model=model,
+            contents=[instruction, input_image],
+            config=config,
+        )
+    except errors.APIError as e:
+        handle_api_error(e)
+
+    image, text_response = parse_image_response(response)
+    image.save(output_path)
+    return text_response
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Edit images using Gemini API",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    parser.add_argument("input", help="Input image path")
+    parser.add_argument("instruction", help="Edit instruction")
+    parser.add_argument("output", help="Output file path")
+    parser.add_argument(
+        "--model", "-m",
+        default="gemini-2.5-flash-image",
+        choices=["gemini-2.5-flash-image", "gemini-3-pro-image-preview"],
+        help="Model to use (default: gemini-2.5-flash-image)"
+    )
+    parser.add_argument(
+        "--aspect", "-a",
+        choices=["1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+        help="Output aspect ratio"
+    )
+    parser.add_argument(
+        "--size", "-s",
+        choices=["1K", "2K", "4K"],
+        help="Output resolution"
+    )
+    
+    args = parser.parse_args()
+    
+    try:
+        text = edit_image(
+            input_path=args.input,
+            instruction=args.instruction,
+            output_path=args.output,
+            model=args.model,
+            aspect_ratio=args.aspect,
+            image_size=args.size,
+        )
+        
+        print(f"Edited image saved to: {args.output}")
+        if text:
+            print(f"Model response: {text}")
+            
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.plugin/skills/gemini-imagegen/scripts/gemini_images.py
+++ b/.plugin/skills/gemini-imagegen/scripts/gemini_images.py
@@ -1,0 +1,256 @@
+"""
+Gemini Image Generation Library
+
+A simple Python library for generating and editing images with the Gemini API.
+
+Usage:
+    from gemini_images import GeminiImageGenerator
+    
+    gen = GeminiImageGenerator()
+    gen.generate("A sunset over mountains", "sunset.png")
+    gen.edit("input.png", "Add clouds", "output.png")
+
+Environment:
+    GEMINI_API_KEY - Required API key
+"""
+
+import os
+from pathlib import Path
+from typing import Literal
+
+from PIL import Image
+from google import genai
+from google.genai import errors, types
+
+from _error_handling import handle_api_error, parse_image_response
+
+
+AspectRatio = Literal["1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"]
+ImageSize = Literal["1K", "2K", "4K"]
+Model = Literal["gemini-2.5-flash-image", "gemini-3-pro-image-preview"]
+
+
+class GeminiImageGenerator:
+    """High-level interface for Gemini image generation."""
+    
+    FLASH = "gemini-2.5-flash-image"
+    PRO = "gemini-3-pro-image-preview"
+    
+    def __init__(self, api_key: str | None = None, model: Model = FLASH):
+        """Initialize the generator.
+        
+        Args:
+            api_key: Gemini API key (defaults to GEMINI_API_KEY env var)
+            model: Default model to use
+        """
+        self.api_key = api_key or os.environ.get("GEMINI_API_KEY")
+        if not self.api_key:
+            raise EnvironmentError("GEMINI_API_KEY not set")
+        
+        self.client = genai.Client(api_key=self.api_key)
+        self.model = model
+    
+    def _build_config(
+        self,
+        aspect_ratio: AspectRatio | None = None,
+        image_size: ImageSize | None = None,
+        google_search: bool = False,
+    ) -> types.GenerateContentConfig:
+        """Build generation config."""
+        kwargs = {"response_modalities": ["TEXT", "IMAGE"]}
+        
+        img_config = {}
+        if aspect_ratio:
+            img_config["aspect_ratio"] = aspect_ratio
+        if image_size:
+            img_config["image_size"] = image_size
+        
+        if img_config:
+            kwargs["image_config"] = types.ImageConfig(**img_config)
+        
+        if google_search:
+            kwargs["tools"] = [{"google_search": {}}]
+        
+        return types.GenerateContentConfig(**kwargs)
+    
+    def generate(
+        self,
+        prompt: str,
+        output: str | Path,
+        *,
+        model: Model | None = None,
+        aspect_ratio: AspectRatio | None = None,
+        image_size: ImageSize | None = None,
+        google_search: bool = False,
+    ) -> tuple[Path, str | None]:
+        """Generate an image from a text prompt.
+        
+        Args:
+            prompt: Text description
+            output: Output file path
+            model: Override default model
+            aspect_ratio: Output aspect ratio
+            image_size: Output resolution
+            google_search: Enable Google Search grounding (Pro only)
+        
+        Returns:
+            Tuple of (output path, optional text response)
+        """
+        output = Path(output)
+        config = self._build_config(aspect_ratio, image_size, google_search)
+
+        try:
+            response = self.client.models.generate_content(
+                model=model or self.model,
+                contents=[prompt],
+                config=config,
+            )
+        except errors.APIError as e:
+            handle_api_error(e)
+
+        image, text = parse_image_response(response)
+        image.save(output)
+        return output, text
+
+    def edit(
+        self,
+        input_image: str | Path | Image.Image,
+        instruction: str,
+        output: str | Path,
+        *,
+        model: Model | None = None,
+        aspect_ratio: AspectRatio | None = None,
+        image_size: ImageSize | None = None,
+    ) -> tuple[Path, str | None]:
+        """Edit an existing image.
+        
+        Args:
+            input_image: Input image (path or PIL Image)
+            instruction: Edit instruction
+            output: Output file path
+            model: Override default model
+            aspect_ratio: Output aspect ratio
+            image_size: Output resolution
+        
+        Returns:
+            Tuple of (output path, optional text response)
+        """
+        output = Path(output)
+
+        if isinstance(input_image, (str, Path)):
+            input_image = Image.open(input_image)
+
+        config = self._build_config(aspect_ratio, image_size)
+
+        try:
+            response = self.client.models.generate_content(
+                model=model or self.model,
+                contents=[instruction, input_image],
+                config=config,
+            )
+        except errors.APIError as e:
+            handle_api_error(e)
+
+        image, text = parse_image_response(response)
+        image.save(output)
+        return output, text
+
+    def compose(
+        self,
+        instruction: str,
+        images: list[str | Path | Image.Image],
+        output: str | Path,
+        *,
+        model: Model | None = None,
+        aspect_ratio: AspectRatio | None = None,
+        image_size: ImageSize | None = None,
+    ) -> tuple[Path, str | None]:
+        """Compose multiple images into one.
+        
+        Args:
+            instruction: Composition instruction
+            images: List of input images (up to 14)
+            output: Output file path
+            model: Override default model (Pro recommended)
+            aspect_ratio: Output aspect ratio
+            image_size: Output resolution
+        
+        Returns:
+            Tuple of (output path, optional text response)
+        """
+        output = Path(output)
+
+        # Load images
+        loaded = []
+        for img in images:
+            if isinstance(img, (str, Path)):
+                loaded.append(Image.open(img))
+            else:
+                loaded.append(img)
+
+        config = self._build_config(aspect_ratio, image_size)
+        contents = [instruction] + loaded
+
+        try:
+            response = self.client.models.generate_content(
+                model=model or self.PRO,  # Pro recommended for composition
+                contents=contents,
+                config=config,
+            )
+        except errors.APIError as e:
+            handle_api_error(e)
+
+        image, text = parse_image_response(response)
+        image.save(output)
+        return output, text
+    
+    def chat(self) -> "ImageChat":
+        """Start an interactive chat session for iterative refinement."""
+        return ImageChat(self.client, self.model)
+
+
+class ImageChat:
+    """Multi-turn chat session for iterative image generation."""
+    
+    def __init__(self, client: genai.Client, model: Model):
+        self.client = client
+        self.model = model
+        self._chat = client.chats.create(
+            model=model,
+            config=types.GenerateContentConfig(response_modalities=["TEXT", "IMAGE"]),
+        )
+        self.current_image: Image.Image | None = None
+    
+    def send(
+        self,
+        message: str,
+        image: Image.Image | str | Path | None = None,
+    ) -> tuple[Image.Image | None, str | None]:
+        """Send a message and optionally an image.
+        
+        Returns:
+            Tuple of (generated image or None, text response or None)
+        """
+        contents = [message]
+        if image:
+            if isinstance(image, (str, Path)):
+                image = Image.open(image)
+            contents.append(image)
+
+        try:
+            response = self._chat.send_message(contents)
+        except errors.APIError as e:
+            handle_api_error(e)
+
+        img, text = parse_image_response(response)
+        self.current_image = img
+
+        return img, text
+    
+    def reset(self):
+        """Reset the chat session."""
+        self._chat = self.client.chats.create(
+            model=self.model,
+            config=types.GenerateContentConfig(response_modalities=["TEXT", "IMAGE"]),
+        )
+        self.current_image = None

--- a/.plugin/skills/gemini-imagegen/scripts/generate_image.py
+++ b/.plugin/skills/gemini-imagegen/scripts/generate_image.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Generate images from text prompts using Gemini API.
+
+Usage:
+    python generate_image.py "prompt" output.png [--model MODEL] [--aspect RATIO] [--size SIZE]
+
+Examples:
+    python generate_image.py "A cat in space" cat.png
+    python generate_image.py "A logo for Acme Corp" logo.png --model gemini-3-pro-image-preview --aspect 1:1
+    python generate_image.py "Epic landscape" landscape.png --aspect 16:9 --size 2K
+
+Environment:
+    GEMINI_API_KEY - Required API key
+"""
+
+import argparse
+import os
+import sys
+
+from google import genai
+from google.genai import errors, types
+
+from _error_handling import check_quota, handle_api_error, parse_image_response
+
+
+def generate_image(
+    prompt: str,
+    output_path: str,
+    model: str = "gemini-2.5-flash-image",
+    aspect_ratio: str | None = None,
+    image_size: str | None = None,
+) -> str | None:
+    """Generate an image from a text prompt.
+    
+    Args:
+        prompt: Text description of the image to generate
+        output_path: Path to save the generated image
+        model: Gemini model to use
+        aspect_ratio: Aspect ratio (1:1, 16:9, 9:16, etc.)
+        image_size: Resolution (1K, 2K, 4K - 4K only for pro model)
+    
+    Returns:
+        Any text response from the model, or None
+    """
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        raise EnvironmentError("GEMINI_API_KEY environment variable not set")
+    
+    client = genai.Client(api_key=api_key)
+    
+    # Build config
+    config_kwargs = {"response_modalities": ["TEXT", "IMAGE"]}
+    
+    image_config_kwargs = {}
+    if aspect_ratio:
+        image_config_kwargs["aspect_ratio"] = aspect_ratio
+    if image_size:
+        image_config_kwargs["image_size"] = image_size
+    
+    if image_config_kwargs:
+        config_kwargs["image_config"] = types.ImageConfig(**image_config_kwargs)
+    
+    config = types.GenerateContentConfig(**config_kwargs)
+    
+    try:
+        response = client.models.generate_content(
+            model=model,
+            contents=[prompt],
+            config=config,
+        )
+    except errors.APIError as e:
+        handle_api_error(e)
+
+    image, text_response = parse_image_response(response)
+    image.save(output_path)
+    return text_response
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate images from text prompts using Gemini API",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    parser.add_argument("prompt", nargs="?", help="Text prompt describing the image")
+    parser.add_argument("output", nargs="?", help="Output file path (e.g., output.png)")
+    parser.add_argument(
+        "--model", "-m",
+        default="gemini-2.5-flash-image",
+        choices=["gemini-2.5-flash-image", "gemini-3-pro-image-preview"],
+        help="Model to use (default: gemini-2.5-flash-image)"
+    )
+    parser.add_argument(
+        "--aspect", "-a",
+        choices=["1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+        help="Aspect ratio"
+    )
+    parser.add_argument(
+        "--size", "-s",
+        choices=["1K", "2K", "4K"],
+        help="Image resolution (4K only available with pro model)"
+    )
+    parser.add_argument(
+        "--check-quota",
+        action="store_true",
+        help="Verify image generation quota without generating an image"
+    )
+
+    args = parser.parse_args()
+
+    if not args.check_quota and (not args.prompt or not args.output):
+        parser.error("prompt and output are required (unless --check-quota is used)")
+
+    if args.check_quota:
+        try:
+            api_key = os.environ.get("GEMINI_API_KEY")
+            if not api_key:
+                print("GEMINI_API_KEY environment variable not set", file=sys.stderr)
+                sys.exit(1)
+            client = genai.Client(api_key=api_key)
+            check_quota(client, model=args.model)
+        except Exception as e:
+            print(f"[FAIL] {e}", file=sys.stderr)
+            sys.exit(1)
+        return
+
+    try:
+        text = generate_image(
+            prompt=args.prompt,
+            output_path=args.output,
+            model=args.model,
+            aspect_ratio=args.aspect,
+            image_size=args.size,
+        )
+
+        print(f"Image saved to: {args.output}")
+        if text:
+            print(f"Model response: {text}")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.plugin/skills/gemini-imagegen/scripts/multi_turn_chat.py
+++ b/.plugin/skills/gemini-imagegen/scripts/multi_turn_chat.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+Interactive multi-turn image generation and refinement using Gemini API.
+
+Usage:
+    python multi_turn_chat.py [--model MODEL] [--output-dir DIR]
+
+This starts an interactive session where you can:
+- Generate images from prompts
+- Iteratively refine images through conversation
+- Load existing images for editing
+- Save images at any point
+
+Commands:
+    /save [filename]  - Save current image
+    /load <path>      - Load an image into the conversation
+    /clear            - Start fresh conversation
+    /quit             - Exit
+
+Environment:
+    GEMINI_API_KEY - Required API key
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from PIL import Image
+from google import genai
+from google.genai import errors, types
+
+from _error_handling import NoImageError, handle_api_error, parse_image_response
+
+
+class ImageChat:
+    """Interactive chat session for image generation and refinement."""
+    
+    def __init__(
+        self,
+        model: str = "gemini-2.5-flash-image",
+        output_dir: str = ".",
+    ):
+        api_key = os.environ.get("GEMINI_API_KEY")
+        if not api_key:
+            raise EnvironmentError("GEMINI_API_KEY environment variable not set")
+        
+        self.client = genai.Client(api_key=api_key)
+        self.model = model
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        
+        self.chat = None
+        self.current_image = None
+        self.image_count = 0
+        
+        self._init_chat()
+    
+    def _init_chat(self):
+        """Initialize or reset the chat session."""
+        config = types.GenerateContentConfig(
+            response_modalities=["TEXT", "IMAGE"]
+        )
+        self.chat = self.client.chats.create(
+            model=self.model,
+            config=config,
+        )
+        self.current_image = None
+    
+    def send_message(self, message: str, image: Image.Image | None = None) -> tuple[str | None, Image.Image | None]:
+        """Send a message and optionally an image, return response text and image."""
+        contents = []
+        if message:
+            contents.append(message)
+        if image:
+            contents.append(image)
+        
+        if not contents:
+            return None, None
+
+        try:
+            response = self.chat.send_message(contents)
+        except errors.APIError as e:
+            handle_api_error(e)
+
+        try:
+            image_response, text_response = parse_image_response(response)
+            self.current_image = image_response
+        except NoImageError:
+            # In interactive chat, text-only responses are normal
+            text_response = None
+            if response.parts:
+                for part in response.parts:
+                    if part.text is not None:
+                        text_response = part.text
+            image_response = None
+
+        return text_response, image_response
+    
+    def save_image(self, filename: str | None = None) -> str | None:
+        """Save the current image to a file."""
+        if self.current_image is None:
+            return None
+        
+        if filename is None:
+            self.image_count += 1
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            filename = f"image_{timestamp}_{self.image_count}.png"
+        
+        filepath = self.output_dir / filename
+        self.current_image.save(filepath)
+        return str(filepath)
+    
+    def load_image(self, path: str) -> Image.Image:
+        """Load an image from disk."""
+        img = Image.open(path)
+        self.current_image = img
+        return img
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Interactive multi-turn image generation",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    parser.add_argument(
+        "--model", "-m",
+        default="gemini-2.5-flash-image",
+        choices=["gemini-2.5-flash-image", "gemini-3-pro-image-preview"],
+        help="Model to use"
+    )
+    parser.add_argument(
+        "--output-dir", "-o",
+        default=".",
+        help="Directory to save images"
+    )
+    
+    args = parser.parse_args()
+    
+    try:
+        chat = ImageChat(model=args.model, output_dir=args.output_dir)
+    except Exception as e:
+        print(f"Error initializing: {e}", file=sys.stderr)
+        sys.exit(1)
+    
+    print(f"Gemini Image Chat ({args.model})")
+    print("Commands: /save [name], /load <path>, /clear, /quit")
+    print("-" * 50)
+    
+    while True:
+        try:
+            user_input = input("\nYou: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\nGoodbye!")
+            break
+        
+        if not user_input:
+            continue
+        
+        # Handle commands
+        if user_input.startswith("/"):
+            parts = user_input.split(maxsplit=1)
+            cmd = parts[0].lower()
+            arg = parts[1] if len(parts) > 1 else None
+            
+            if cmd == "/quit":
+                print("Goodbye!")
+                break
+            
+            elif cmd == "/clear":
+                chat._init_chat()
+                print("Conversation cleared.")
+                continue
+            
+            elif cmd == "/save":
+                path = chat.save_image(arg)
+                if path:
+                    print(f"Image saved to: {path}")
+                else:
+                    print("No image to save.")
+                continue
+            
+            elif cmd == "/load":
+                if not arg:
+                    print("Usage: /load <path>")
+                    continue
+                try:
+                    chat.load_image(arg)
+                    print(f"Loaded: {arg}")
+                    print("You can now describe edits to make.")
+                except Exception as e:
+                    print(f"Error loading image: {e}")
+                continue
+            
+            else:
+                print(f"Unknown command: {cmd}")
+                continue
+        
+        # Send message to model
+        try:
+            # If we have a loaded image and this is first message, include it
+            image_to_send = None
+            if chat.current_image and not chat.chat.history:
+                image_to_send = chat.current_image
+            
+            text, image = chat.send_message(user_input, image_to_send)
+            
+            if text:
+                print(f"\nGemini: {text}")
+            
+            if image:
+                # Auto-save
+                path = chat.save_image()
+                print(f"\n[Image generated: {path}]")
+            
+        except Exception as e:
+            print(f"\nError: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.plugin/skills/gemini-imagegen/scripts/test_error_handling.py
+++ b/.plugin/skills/gemini-imagegen/scripts/test_error_handling.py
@@ -1,0 +1,179 @@
+"""Tests for _error_handling module."""
+
+import unittest
+from unittest.mock import MagicMock
+
+from google.genai import errors
+
+from _error_handling import (
+    NoImageError,
+    PermissionDeniedError,
+    QuotaExhaustedError,
+    SafetyFilterError,
+    check_quota,
+    handle_api_error,
+    parse_image_response,
+)
+
+
+def _make_client_error(code: int, message: str = "test error"):
+    """Create a ClientError with the given code using the real constructor."""
+    response_json = {"error": {"message": message, "code": code}}
+    return errors.ClientError(code, response_json)
+
+
+def _make_server_error(code: int = 500, message: str = "server error"):
+    """Create a ServerError with the given code using the real constructor."""
+    response_json = {"error": {"message": message, "code": code}}
+    return errors.ServerError(code, response_json)
+
+
+def _make_response(parts=None):
+    """Create a mock response with the given parts."""
+    response = MagicMock()
+    response.parts = parts
+    return response
+
+
+def _make_text_part(text: str):
+    """Create a mock text part."""
+    part = MagicMock()
+    part.text = text
+    part.inline_data = None
+    return part
+
+
+def _make_image_part():
+    """Create a mock image part that returns a saveable image."""
+    part = MagicMock()
+    part.text = None
+    part.inline_data = MagicMock()
+    mock_image = MagicMock()
+    part.as_image.return_value = mock_image
+    return part
+
+
+class TestHandleApiError(unittest.TestCase):
+    def test_quota_exhausted_on_429(self):
+        err = _make_client_error(429, "Rate limit exceeded")
+        with self.assertRaises(QuotaExhaustedError) as ctx:
+            handle_api_error(err)
+        self.assertIn("QUOTA EXHAUSTED", str(ctx.exception))
+
+    def test_permission_denied_on_403(self):
+        err = _make_client_error(403, "Forbidden")
+        with self.assertRaises(PermissionDeniedError) as ctx:
+            handle_api_error(err)
+        self.assertIn("PERMISSION DENIED", str(ctx.exception))
+
+    def test_generic_client_error_on_400(self):
+        err = _make_client_error(400, "Invalid request")
+        with self.assertRaises(RuntimeError) as ctx:
+            handle_api_error(err)
+        self.assertIn("API CLIENT ERROR (400)", str(ctx.exception))
+
+    def test_server_error_on_500(self):
+        err = _make_server_error(500, "Internal server error")
+        with self.assertRaises(RuntimeError) as ctx:
+            handle_api_error(err)
+        self.assertIn("API SERVER ERROR (500)", str(ctx.exception))
+
+    def test_chains_original_exception(self):
+        err = _make_client_error(429, "Rate limit")
+        with self.assertRaises(QuotaExhaustedError) as ctx:
+            handle_api_error(err)
+        self.assertIs(ctx.exception.__cause__, err)
+
+
+class TestParseImageResponse(unittest.TestCase):
+    def test_raises_on_empty_parts(self):
+        response = _make_response(parts=None)
+        with self.assertRaises(NoImageError) as ctx:
+            parse_image_response(response)
+        self.assertIn("empty response", str(ctx.exception))
+
+    def test_raises_on_empty_list(self):
+        response = _make_response(parts=[])
+        with self.assertRaises(NoImageError):
+            parse_image_response(response)
+
+    def test_returns_image_and_text(self):
+        text_part = _make_text_part("Here's your image")
+        image_part = _make_image_part()
+        response = _make_response(parts=[text_part, image_part])
+
+        image, text = parse_image_response(response)
+
+        self.assertEqual(text, "Here's your image")
+        self.assertIsNotNone(image)
+
+    def test_safety_filter_detected_via_text(self):
+        text_part = _make_text_part("The image was blocked by safety policy")
+        response = _make_response(parts=[text_part])
+
+        with self.assertRaises(SafetyFilterError) as ctx:
+            parse_image_response(response)
+        self.assertIn("SAFETY FILTER", str(ctx.exception))
+
+    def test_no_image_text_only(self):
+        text_part = _make_text_part("Here is some text about your request")
+        response = _make_response(parts=[text_part])
+
+        with self.assertRaises(NoImageError) as ctx:
+            parse_image_response(response)
+        self.assertIn("text only", str(ctx.exception))
+
+    def test_image_only_no_text(self):
+        image_part = _make_image_part()
+        response = _make_response(parts=[image_part])
+
+        image, text = parse_image_response(response)
+
+        self.assertIsNone(text)
+        self.assertIsNotNone(image)
+
+    def test_safety_keywords_case_insensitive(self):
+        text_part = _make_text_part("This content was BLOCKED by our POLICY")
+        response = _make_response(parts=[text_part])
+
+        with self.assertRaises(SafetyFilterError):
+            parse_image_response(response)
+
+    def test_no_false_positive_on_unrelated_text(self):
+        text_part = _make_text_part("Just text, no special keywords present")
+        response = _make_response(parts=[text_part])
+
+        with self.assertRaises(NoImageError):
+            parse_image_response(response)
+
+
+class TestCheckQuota(unittest.TestCase):
+    def test_quota_available(self):
+        client = MagicMock()
+        image_part = _make_image_part()
+        response = _make_response(parts=[image_part])
+        client.models.generate_content.return_value = response
+
+        # Should not raise
+        check_quota(client, model="gemini-2.5-flash-image")
+
+    def test_quota_exhausted_via_api_error(self):
+        client = MagicMock()
+        err = _make_client_error(429, "Quota exceeded")
+        client.models.generate_content.side_effect = err
+
+        with self.assertRaises(QuotaExhaustedError):
+            check_quota(client, model="gemini-2.5-flash-image")
+
+    def test_no_image_in_response_raises(self):
+        client = MagicMock()
+        text_part = _make_text_part("no image here")
+        response = _make_response(parts=[text_part])
+        client.models.generate_content.return_value = response
+
+        with self.assertRaises(NoImageError):
+            check_quota(client, model="gemini-2.5-flash-image")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.plugin/skills/kb-search/SKILL.md
+++ b/.plugin/skills/kb-search/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: kb-search
+description: "Search the knowledge base for files matching keywords across all domains."
+triggers:
+- kb search
+- knowledge base search
+- search knowledge base
+- find in kb
+---
+
+# KB Search
+
+Search the knowledge base across all domains. Returns title matches first (tier 1), then content matches (tier 2).
+
+## Usage
+
+Provide a search query when invoking this skill. If no query is provided, ask: "What would you like to search for in the knowledge base?"
+
+## Execution
+
+### Phase 1: Title Search (Tier 1 — High Relevance)
+
+Search `knowledge-base/INDEX.md` for title matches. INDEX.md contains one line per file in the format `- [Title](path)`.
+
+Run grep on `knowledge-base/INDEX.md` with the search keywords. Use case-insensitive matching. Each match is a file whose title contains the query terms.
+
+Display tier 1 results:
+
+```text
+## Title Matches
+
+1. [Title](knowledge-base/path) — title match
+2. [Title](knowledge-base/path) — title match
+```
+
+If INDEX.md does not exist, skip to Phase 2 and note: "INDEX.md not found — run `bash scripts/generate-kb-index.sh` to generate it."
+
+### Phase 2: Content Search (Tier 2 — Lower Relevance)
+
+Run grep across `knowledge-base/` for the search keywords in file contents. Use case-insensitive matching. Exclude `knowledge-base/INDEX.md` and `knowledge-base/**/archive/**` from results.
+
+Filter out any files already found in tier 1. Display tier 2 results:
+
+```text
+## Content Matches
+
+3. [path](knowledge-base/path) — content match (line N: "...context snippet...")
+4. [path](knowledge-base/path) — content match (line N: "...context snippet...")
+```
+
+### Phase 3: Summary
+
+Cap total results at 20 (tier 1 + tier 2 combined). If more than 20 matches exist, note: "Showing top 20 of N matches. Narrow the query for more specific results."
+
+If zero results, suggest:
+
+- Check spelling
+- Try broader or alternative keywords
+- Run `bash scripts/generate-kb-index.sh` to ensure INDEX.md is current

--- a/.plugin/skills/pencil-setup/SKILL.md
+++ b/.plugin/skills/pencil-setup/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: pencil-setup
+description: "Set up Pencil MCP tools when they are unavailable. Detects Pencil Desktop or an IDE with the Pencil extension and configures the MCP server in the OpenHands mcp_config."
+triggers:
+- pencil setup
+- pencil mcp
+- pencil install
+---
+
+# Pencil Setup
+
+Auto-detect, install, and register the Pencil MCP server.
+
+**Prerequisite:** One of: (1) the headless CLI (no GUI required, recommended for agents), (2) Pencil Desktop, or (3) an IDE (Cursor/VS Code) with the Pencil extension.
+
+**Known limitation:** macOS detection uses unverified bundle ID `dev.pencil.desktop` -- falls back to PATH-based detection if incorrect.
+
+## Phase 0: Dependency Check
+
+Run the dependency check script before proceeding. When invoked from a pipeline, pass `--auto` to skip interactive prompts, auto-install the IDE extension, and auto-launch Pencil Desktop.
+
+For interactive use:
+
+```bash
+bash ./plugins/soleur/skills/pencil-setup/scripts/check_deps.sh
+```
+
+For pipeline/automated use:
+
+```bash
+bash ./plugins/soleur/skills/pencil-setup/scripts/check_deps.sh --auto
+```
+
+If the script exits non-zero, no Pencil MCP source is available. Stop and inform the user with the printed instructions (both Desktop and IDE options).
+
+If all checks pass, capture these values from the script output:
+
+- `PREFERRED_MODE` -- `headless_cli`, `cli`, `desktop_binary`, or `ide`
+- `PREFERRED_BINARY` -- path to binary (adapter for headless, `pencil` for CLI mode)
+- `PREFERRED_APP` -- `--app` flag value (empty for CLI and headless modes)
+- `PREFERRED_NODE` -- (headless_cli only) path to Node >= 22.9.0 binary
+
+Proceed to Step 1.
+
+## Step 1: Check if Already Registered
+
+Check the project's `.mcp.json` or `mcp_config` for an existing `pencil` server entry:
+
+```bash
+grep -q "pencil" .mcp.json 2>/dev/null && echo "REGISTERED" || echo "NOT_REGISTERED"
+```
+
+If REGISTERED, check the registered binary path still exists on disk. If it does, tell the user:
+
+- **Headless CLI mode:** "Pencil MCP is already configured via headless CLI adapter. Restart the agent for tools to become available."
+- **CLI/Desktop mode:** "Pencil MCP is already configured. Make sure Pencil Desktop is running, then restart the agent."
+- **IDE mode:** "Pencil MCP is already configured. Make sure your IDE is running with Pencil active, then restart the agent."
+
+Then stop.
+
+If the path does not exist or NOT_REGISTERED, continue to Step 2.
+
+## Step 2: Register MCP Server
+
+Add the Pencil MCP server to the project's `.mcp.json` configuration. The format depends on `PREFERRED_MODE` from Phase 0.
+
+### Headless CLI mode (`PREFERRED_MODE=headless_cli`)
+
+The adapter requires `PENCIL_CLI_KEY` in the MCP environment. Add to `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "pencil": {
+      "command": "<PREFERRED_NODE>",
+      "args": ["<PREFERRED_BINARY>"],
+      "env": {
+        "PENCIL_CLI_KEY": "<key>"
+      }
+    }
+  }
+}
+```
+
+### CLI mode (`PREFERRED_MODE=cli`)
+
+```json
+{
+  "mcpServers": {
+    "pencil": {
+      "command": "pencil",
+      "args": ["mcp-server"]
+    }
+  }
+}
+```
+
+### Desktop binary mode (`PREFERRED_MODE=desktop_binary`)
+
+```json
+{
+  "mcpServers": {
+    "pencil": {
+      "command": "<PREFERRED_BINARY>",
+      "args": ["--app", "<PREFERRED_APP>"]
+    }
+  }
+}
+```
+
+### IDE mode (`PREFERRED_MODE=ide`)
+
+```json
+{
+  "mcpServers": {
+    "pencil": {
+      "command": "<PREFERRED_BINARY>",
+      "args": ["--app", "<PREFERRED_APP>"]
+    }
+  }
+}
+```
+
+## Step 3: Verify
+
+```bash
+grep pencil .mcp.json
+```
+
+If the `pencil` entry appears, tell the user:
+
+- **Headless CLI mode:** "Pencil MCP registered via headless adapter. Restart the agent for tools to become available. No GUI required."
+- **CLI/Desktop mode:** "Pencil MCP registered. Restart the agent for tools to become available. Make sure Pencil Desktop is running."
+- **IDE mode:** "Pencil MCP registered. Restart the agent for tools to become available. Make sure your IDE is open with Pencil active."
+
+If it does not appear, tell the user the registration failed and suggest adding the configuration manually.
+
+## Sharp Edges
+
+- **IDE mode -- WebSocket requires visible editor**: In IDE mode, the MCP server connects via WebSocket to the IDE's editor webview. `batch_design`/`batch_get`/`open_document` calls fail with `WebSocket not connected to app` unless the .pen file tab is open and visible in the IDE.
+- **Desktop mode -- app must be running**: In CLI or Desktop binary mode, Pencil Desktop must be running. The MCP server connects to the Desktop app directly. If Desktop is not running, tools fail silently.
+- **No programmatic save (Desktop/IDE only)**: In Desktop or IDE mode, after `batch_design` operations, changes exist in editor memory only. The user must Ctrl+S (IDE) or Cmd+S/Ctrl+S (Desktop) to flush to disk. In headless CLI mode, the adapter auto-calls `save()` after mutating operations.
+- **Read before write**: Mockup property values (padding, colors, fonts) may diverge from live CSS. Always `batch_get` the current value before `batch_design` updates.
+- **pencil CLI collision**: The `pencil` binary name collides with evolus/pencil. The check_deps.sh script guards against this by verifying the version string.
+- **Headless CLI has programmatic save**: Unlike Desktop/IDE modes, `pencil interactive --out` supports a `save()` command that writes to disk without manual Ctrl+S.
+- **Text nodes do not support `padding`**: Passing `padding` to a `batch_design` operation on a text node produces "Invalid properties: /padding unexpected property". Wrap the text in a frame and apply padding to the frame instead.

--- a/.plugin/skills/pencil-setup/scripts/check_deps.sh
+++ b/.plugin/skills/pencil-setup/scripts/check_deps.sh
@@ -1,0 +1,485 @@
+#!/usr/bin/env bash
+# pencil-setup dependency checker with four-tier MCP detection
+# Priority: (0) Headless CLI, (1) pencil CLI, (2) Desktop binary, (3) IDE extension
+# No set -euo pipefail: soft dependency checks and install failures
+# must not abort the script. Each check uses explicit if/then.
+
+AUTO_INSTALL=false
+[[ "${1:-}" == "--auto" ]] && AUTO_INSTALL=true
+
+# Detect OS and architecture for platform-specific checks
+_UNAME=$(uname -s)
+OS="unknown"
+[[ "$_UNAME" == "Darwin" ]] && OS="macos"
+[[ "$_UNAME" == "Linux" ]] && OS="linux"
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)  MCP_SUFFIX="x64" ;;
+  aarch64|arm64) MCP_SUFFIX="arm64" ;;
+  *)       MCP_SUFFIX="x64" ;;
+esac
+
+# Output variables (consumed by SKILL.md)
+PREFERRED_BINARY=""
+PREFERRED_APP=""
+PREFERRED_MODE=""
+PREFERRED_NODE=""
+
+# Common AppImage search directories (single source of truth)
+APPIMAGE_DIRS=("$HOME/Applications" "$HOME/.local/bin" "/opt")
+
+# -- Shared Helpers --
+
+# Find the first Pencil AppImage in known directories
+find_appimage() {
+  local dir match
+  for dir in "${APPIMAGE_DIRS[@]}"; do
+    for match in "$dir"/Pencil*.AppImage; do
+      [[ -e "$match" ]] && echo "$match" && return 0
+    done
+  done
+  return 1
+}
+
+# Find extracted AppImage MCP binary in known directories
+find_extracted_mcp_binary() {
+  local dir binary
+  for dir in "${APPIMAGE_DIRS[@]}"; do
+    binary="$dir/squashfs-root/resources/app.asar.unpacked/out/mcp-server-linux-${MCP_SUFFIX}"
+    [[ -x "$binary" ]] && echo "$binary" && return 0
+  done
+  return 1
+}
+
+# -- Detection Functions --
+
+# Find a Node binary >= 22.9.0 (checks system, nvm, fnm)
+find_node22() {
+  local node_bin version major minor
+  # Check system node first
+  node_bin=$(command -v node 2>/dev/null)
+  if [[ -n "$node_bin" ]]; then
+    version=$("$node_bin" --version 2>/dev/null | sed 's/^v//')
+    major=${version%%.*}
+    minor=$(echo "$version" | cut -d. -f2)
+    if [[ "$major" -gt 22 || ("$major" -eq 22 && "$minor" -ge 9) ]]; then
+      echo "$node_bin"
+      return 0
+    fi
+  fi
+  # Check nvm
+  local nvm_dir="${NVM_DIR:-$HOME/.nvm}"
+  if [[ -d "$nvm_dir/versions/node" ]]; then
+    local nvm_node
+    for nvm_node in "$nvm_dir"/versions/node/v2[2-9]*/bin/node "$nvm_dir"/versions/node/v[3-9]*/bin/node; do
+      [[ -x "$nvm_node" ]] || continue
+      version=$("$nvm_node" --version 2>/dev/null | sed 's/^v//')
+      major=${version%%.*}
+      minor=$(echo "$version" | cut -d. -f2)
+      if [[ "$major" -gt 22 || ("$major" -eq 22 && "$minor" -ge 9) ]]; then
+        echo "$nvm_node"
+        return 0
+      fi
+    done
+  fi
+  # Check fnm
+  local fnm_dir="${FNM_DIR:-$HOME/.local/share/fnm}"
+  if [[ -d "$fnm_dir/node-versions" ]]; then
+    local fnm_node
+    for fnm_node in "$fnm_dir"/node-versions/v2[2-9]*/installation/bin/node "$fnm_dir"/node-versions/v[3-9]*/installation/bin/node; do
+      [[ -x "$fnm_node" ]] || continue
+      version=$("$fnm_node" --version 2>/dev/null | sed 's/^v//')
+      major=${version%%.*}
+      minor=$(echo "$version" | cut -d. -f2)
+      if [[ "$major" -gt 22 || ("$major" -eq 22 && "$minor" -ge 9) ]]; then
+        echo "$fnm_node"
+        return 0
+      fi
+    done
+  fi
+  return 1
+}
+
+# Detect headless CLI installed at ~/.local/node_modules/.bin/pencil
+# Does NOT run the binary (requires Node 22+) — checks existence and symlink target
+detect_headless_cli() {
+  local pencil_bin="$HOME/.local/node_modules/.bin/pencil"
+  [[ -e "$pencil_bin" ]] || return 1
+  # Verify it's the headless CLI package by checking the symlink target
+  # The headless CLI links to @pencil.dev/cli/dist/index.cjs
+  local target
+  target=$(readlink -f "$pencil_bin" 2>/dev/null) || return 1
+  # Must contain the pencil CLI package path (not Desktop CLI)
+  [[ "$target" == *"@pencil.dev/cli"* || "$target" == *"pencil-cli"* ]] || return 1
+  return 0
+}
+
+# Check if the pencil CLI in PATH is pencil.dev (not evolus/pencil)
+detect_pencil_cli() {
+  command -v pencil >/dev/null 2>&1 || return 1
+  # Negative guard: if the PATH pencil resolves to the headless CLI package,
+  # skip it for Tier 1 (handled by Tier 0)
+  local resolved
+  resolved=$(readlink -f "$(command -v pencil)" 2>/dev/null)
+  if [[ "$resolved" == *"@pencil.dev/cli"* || "$resolved" == *"pencil-cli"* ]]; then
+    return 1
+  fi
+  # Guard against evolus/pencil name collision
+  if pencil --version 2>&1 | grep -qi "pencil\.dev\|pencil v"; then
+    return 0
+  fi
+  # If --version doesn't confirm pencil.dev, check if mcp-server subcommand exists
+  pencil mcp-server --help >/dev/null 2>&1 && return 0
+  return 1
+}
+
+detect_pencil_desktop() {
+  case "$OS" in
+    macos)
+      [[ -d "/Applications/Pencil.app" ]] && return 0
+      # Spotlight fallback for non-standard install locations
+      mdfind "kMDItemCFBundleIdentifier == 'dev.pencil.desktop'" 2>/dev/null | grep -q . && return 0
+      ;;
+    linux)
+      # Check .deb installation
+      dpkg -s pencil 2>/dev/null | grep -q "Status:.*installed" && return 0
+      # Check AppImage
+      find_appimage >/dev/null && return 0
+      ;;
+  esac
+  return 1
+}
+
+# Returns the MCP binary path from Pencil Desktop if directly accessible
+detect_desktop_binary() {
+  local binary=""
+  case "$OS" in
+    macos)
+      binary="/Applications/Pencil.app/Contents/Resources/app.asar.unpacked/out/mcp-server-darwin-${MCP_SUFFIX}"
+      [[ -x "$binary" ]] && echo "$binary" && return 0
+      ;;
+    linux)
+      # .deb install: check system path
+      binary="/usr/lib/pencil/resources/app.asar.unpacked/out/mcp-server-linux-${MCP_SUFFIX}"
+      [[ -x "$binary" ]] && echo "$binary" && return 0
+      # AppImage: binary is only accessible if user extracted it
+      find_extracted_mcp_binary && return 0
+      ;;
+  esac
+  return 1
+}
+
+detect_ide() {
+  # Prefer Cursor over VS Code (Pencil docs recommend Cursor)
+  command -v cursor >/dev/null 2>&1 && echo "cursor" && return 0
+  command -v code >/dev/null 2>&1 && echo "code" && return 0
+  return 1
+}
+
+# Map IDE command name to --app flag value
+ide_to_app_value() {
+  case "$1" in
+    cursor) echo "cursor" ;;
+    code)   echo "visual_studio_code" ;;
+    *)      echo "ERROR: unknown IDE '$1'" >&2; return 1 ;;
+  esac
+}
+
+detect_extension() {
+  local ide="$1"
+  local extdir os_prefix
+  case "$ide" in
+    cursor) extdir="$HOME/.cursor/extensions" ;;
+    code)   extdir="$HOME/.vscode/extensions" ;;
+    *)      return 1 ;;
+  esac
+  case "$OS" in
+    macos) os_prefix="darwin" ;;
+    linux) os_prefix="linux" ;;
+    *)     os_prefix="linux" ;;
+  esac
+  ls -d "${extdir}/highagency.pencildev-"*/out/mcp-server-"${os_prefix}-${MCP_SUFFIX}" 2>/dev/null | sort -V | tail -1
+}
+
+# Check if Pencil Desktop is currently running (platform-specific to avoid false positives)
+is_pencil_running() {
+  case "$OS" in
+    macos)
+      pgrep -f "Pencil.app/Contents/MacOS" >/dev/null 2>&1
+      ;;
+    linux)
+      # Match exact process name (from .deb) or AppImage pattern
+      pgrep -x pencil >/dev/null 2>&1 || pgrep -f "Pencil.*AppImage" >/dev/null 2>&1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# Attempt to install IDE extension (prompt or auto-install)
+attempt_extension_install() {
+  local ide="$1"
+  local response=""
+  if [[ "$AUTO_INSTALL" != "true" ]]; then
+    if [[ -t 0 ]]; then
+      echo "  Install extension? (y/N)"
+      read -r response
+    else
+      echo "  [info] Non-interactive shell -- use --auto to install automatically"
+      return 1
+    fi
+    if [[ ! "$response" =~ ^[Yy]$ ]]; then
+      echo "  [MISSING] Pencil extension (declined)"
+      return 1
+    fi
+  fi
+  echo "  [installing] Pencil extension..."
+  if "$ide" --install-extension highagency.pencildev 2>&1; then
+    local binary
+    binary=$(detect_extension "$ide")
+    if [[ -n "$binary" ]]; then
+      echo "  [ok] Pencil extension (installed)"
+      echo "$binary"
+      return 0
+    else
+      echo "  [FAILED] Extension installed but binary not found -- restart $ide and re-run"
+      return 1
+    fi
+  else
+    echo "  [FAILED] Extension install command returned non-zero -- try manually from IDE marketplace"
+    echo "    Search for 'Pencil' in the $ide Extensions panel, or visit:"
+    echo "    https://docs.pencil.dev/getting-started/installation"
+    return 1
+  fi
+}
+
+# Launch Pencil Desktop if installed but not running (requires --auto)
+auto_launch_desktop() {
+  if is_pencil_running; then
+    echo "  [ok] Pencil Desktop is running"
+    return 0
+  fi
+  if [[ "$AUTO_INSTALL" != "true" ]]; then
+    echo "  [info] Pencil Desktop is not running -- use --auto to launch automatically"
+    return 1
+  fi
+  echo "  [info] Starting Pencil Desktop..."
+  case "$OS" in
+    macos)
+      if [[ -d "/Applications/Pencil.app" ]]; then
+        open "/Applications/Pencil.app"
+      else
+        echo "  [FAILED] Cannot locate Pencil.app to launch"
+        return 1
+      fi
+      ;;
+    linux)
+      # Check if display server is available
+      if [[ -z "${DISPLAY:-}" && -z "${WAYLAND_DISPLAY:-}" ]]; then
+        echo "  [FAILED] No display server available (DISPLAY and WAYLAND_DISPLAY unset)"
+        return 1
+      fi
+      # Only launch the validated pencil.dev binary or AppImage (not arbitrary 'pencil' in PATH)
+      if detect_pencil_cli; then
+        nohup pencil >/dev/null 2>&1 &
+      else
+        local appimage
+        appimage=$(find_appimage)
+        if [[ -n "$appimage" ]]; then
+          echo "  [info] Launching $appimage"
+          nohup "$appimage" >/dev/null 2>&1 &
+        else
+          echo "  [FAILED] Cannot locate Pencil binary to launch"
+          return 1
+        fi
+      fi
+      ;;
+    *)
+      echo "  [FAILED] Unsupported OS for auto-launch"
+      return 1
+      ;;
+  esac
+  # Wait for Desktop to initialize (poll up to 3 times at 2s intervals)
+  local attempts=0
+  while [[ $attempts -lt 3 ]]; do
+    sleep 2
+    if is_pencil_running; then
+      echo "  [ok] Pencil Desktop started"
+      return 0
+    fi
+    attempts=$((attempts + 1))
+  done
+  echo "  [FAILED] Pencil Desktop did not start within 6 seconds"
+  return 1
+}
+
+# -- Tier Functions (early-exit pattern) --
+
+try_headless_cli_tier() {
+  detect_headless_cli || return 1
+  # Node version gate
+  local node_bin
+  node_bin=$(find_node22)
+  if [[ -z "$node_bin" ]]; then
+    echo "  [skip] Headless CLI found but Node >= 22.9.0 not available"
+    echo "    Install Node 22+ via nvm: nvm install 22"
+    return 1
+  fi
+  # Auth check — must use the found Node 22+ binary to run pencil
+  local pencil_bin="$HOME/.local/node_modules/.bin/pencil"
+  local pencil_target
+  pencil_target=$(readlink -f "$pencil_bin" 2>/dev/null)
+  if ! PENCIL_CLI_KEY="${PENCIL_CLI_KEY:-}" "$node_bin" "$pencil_target" status >/dev/null 2>&1; then
+    echo "  [skip] Headless CLI found but auth failed"
+    echo "    Run: $pencil_bin login"
+    echo "    Or set PENCIL_CLI_KEY environment variable"
+    return 1
+  fi
+  echo "  [ok] Headless CLI (Tier 0)"
+  # Adapter path is relative to check_deps.sh location
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  PREFERRED_MODE="headless_cli"
+  PREFERRED_BINARY="$script_dir/pencil-mcp-adapter.mjs"
+  PREFERRED_APP=""
+  PREFERRED_NODE="$node_bin"
+  return 0
+}
+
+# Auto-install headless CLI if --auto and not found
+attempt_headless_install() {
+  if [[ "$AUTO_INSTALL" != "true" ]]; then
+    return 1
+  fi
+  local node_bin
+  node_bin=$(find_node22)
+  if [[ -z "$node_bin" ]]; then
+    echo "  [skip] Cannot auto-install headless CLI: Node >= 22.9.0 not available"
+    return 1
+  fi
+  local npm_bin
+  npm_bin="$(dirname "$node_bin")/npm"
+  [[ -x "$npm_bin" ]] || npm_bin=$(command -v npm 2>/dev/null)
+  if [[ -z "$npm_bin" || ! -x "$npm_bin" ]]; then
+    echo "  [skip] Cannot auto-install headless CLI: npm not found"
+    return 1
+  fi
+  echo "  [installing] Headless CLI to ~/.local..."
+  if "$npm_bin" install --prefix "$HOME/.local" @anthropic-ai/pencil-cli 2>&1; then
+    detect_headless_cli && return 0
+    echo "  [FAILED] Install succeeded but binary not found"
+  else
+    echo "  [FAILED] npm install returned non-zero"
+  fi
+  return 1
+}
+
+try_cli_tier() {
+  detect_pencil_cli || return 1
+  echo "  [ok] pencil CLI (pencil.dev)"
+  PREFERRED_MODE="cli"
+  PREFERRED_BINARY="pencil"
+  PREFERRED_APP=""
+  # Auto-launch Desktop if installed (CLI needs Desktop running to connect)
+  if detect_pencil_desktop; then
+    auto_launch_desktop
+  fi
+  return 0
+}
+
+try_desktop_tier() {
+  detect_pencil_desktop || return 1
+  local binary
+  binary=$(detect_desktop_binary)
+  if [[ -n "$binary" ]]; then
+    echo "  [ok] Pencil Desktop (MCP binary available)"
+    echo "    MCP binary: $binary"
+    PREFERRED_MODE="desktop_binary"
+    PREFERRED_BINARY="$binary"
+    PREFERRED_APP="pencil"
+    auto_launch_desktop
+    return 0
+  fi
+  # Desktop installed but binary not directly accessible
+  echo "  [ok] Pencil Desktop (no direct MCP binary access)"
+  if [[ "$OS" == "linux" ]]; then
+    echo "    Tip: extract AppImage with --appimage-extract for direct MCP binary access"
+    echo "    Or install pencil CLI: Pencil Desktop > File > Install pencil command into PATH"
+  else
+    echo "    Install pencil CLI: Pencil Desktop > File > Install pencil command into PATH"
+  fi
+  return 1
+}
+
+try_ide_tier() {
+  local ide binary
+  ide=$(detect_ide) || return 1
+  echo "  [ok] IDE: $ide"
+  binary=$(detect_extension "$ide")
+  if [[ -n "$binary" ]]; then
+    echo "  [ok] Pencil extension"
+    PREFERRED_MODE="ide"
+    PREFERRED_BINARY="$binary"
+    PREFERRED_APP=$(ide_to_app_value "$ide")
+    return 0
+  fi
+  echo "  [MISSING] Pencil IDE extension"
+  binary=$(attempt_extension_install "$ide") || return 1
+  PREFERRED_MODE="ide"
+  PREFERRED_BINARY="$binary"
+  PREFERRED_APP=$(ide_to_app_value "$ide")
+  return 0
+}
+
+# -- Main Flow --
+
+echo "=== Pencil Setup Dependency Check ==="
+echo
+
+# Warn about evolus/pencil collision
+if ! detect_pencil_cli && ! detect_headless_cli && command -v pencil >/dev/null 2>&1; then
+  echo "  [info] pencil CLI found but is not pencil.dev (possible evolus/pencil)"
+fi
+
+# Try tiers in priority order -- first success wins
+# Tier 0: Headless CLI (no GUI required)
+# Tier 1: Desktop CLI (needs Desktop running)
+# Tier 2: Desktop binary (needs Desktop running)
+# Tier 3: IDE extension
+if ! try_headless_cli_tier; then
+  # Auto-install headless CLI if --auto
+  if [[ "$AUTO_INSTALL" == "true" ]] && ! detect_headless_cli; then
+    attempt_headless_install && try_headless_cli_tier
+  fi
+fi
+[[ -n "$PREFERRED_MODE" ]] || try_cli_tier || try_desktop_tier || try_ide_tier
+
+# -- Result --
+echo
+if [[ -n "$PREFERRED_MODE" ]]; then
+  echo "=== Check Complete ==="
+  echo
+  echo "PREFERRED_MODE=$PREFERRED_MODE"
+  echo "PREFERRED_BINARY=$PREFERRED_BINARY"
+  echo "PREFERRED_APP=$PREFERRED_APP"
+  [[ -n "$PREFERRED_NODE" ]] && echo "PREFERRED_NODE=$PREFERRED_NODE"
+else
+  echo "=== Check Failed ==="
+  echo
+  echo "  No Pencil MCP source available. Install one of:"
+  echo
+  echo "  Option 1 (recommended): Pencil Desktop"
+  case "$OS" in
+    macos) echo "    Download: https://www.pencil.dev/downloads (macOS .dmg)" ;;
+    linux) echo "    Download: https://www.pencil.dev/downloads (Linux .deb or AppImage)" ;;
+    *)     echo "    Download: https://www.pencil.dev/downloads" ;;
+  esac
+  echo "    Then: File > Install pencil command into PATH"
+  echo
+  echo "  Option 2: IDE extension"
+  echo "    Install Cursor (https://cursor.com) or VS Code (https://code.visualstudio.com)"
+  echo "    Then install the Pencil extension from the marketplace"
+  exit 1
+fi

--- a/.plugin/skills/pencil-setup/scripts/package-lock.json
+++ b/.plugin/skills/pencil-setup/scripts/package-lock.json
@@ -1,0 +1,1138 @@
+{
+  "name": "pencil-mcp-adapter",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pencil-mcp-adapter",
+      "version": "0.0.1",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/.plugin/skills/pencil-setup/scripts/package.json
+++ b/.plugin/skills/pencil-setup/scripts/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pencil-mcp-adapter",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "zod": "^4.0.0"
+  }
+}

--- a/.plugin/skills/pencil-setup/scripts/pencil-error-enrichment.mjs
+++ b/.plugin/skills/pencil-setup/scripts/pencil-error-enrichment.mjs
@@ -1,0 +1,21 @@
+// Pure function: enriches known Pencil API error messages with actionable hints.
+// Extracted for testability — no external dependencies.
+
+export function enrichErrorMessage(text) {
+  if (text.includes("alignSelf") && text.includes("unexpected property")) {
+    return text + "\n\n[adapter hint] alignSelf is not supported on frames. " +
+      "Use parent container alignment or layout properties instead. See #1106.";
+  }
+  if (text.includes("padding") && text.includes("unexpected property")) {
+    return text + "\n\n[adapter hint] Text nodes do not support padding. " +
+      "Wrap the text in a frame and apply padding to the frame. See #1107.";
+  }
+  if (text.includes("/id missing required property")) {
+    return text + "\n\n[adapter hint] This error often occurs when passing a " +
+      "third positional argument to I() (e.g., {after: \"nodeId\"}). Positional " +
+      "insertion is not supported. Nodes are appended at end of parent. Use " +
+      "M(nodeId, parent, index) to reorder after insertion. Discover the target " +
+      "index with batch_get on the parent. See #1117.";
+  }
+  return text;
+}

--- a/.plugin/skills/pencil-setup/scripts/pencil-mcp-adapter.mjs
+++ b/.plugin/skills/pencil-setup/scripts/pencil-mcp-adapter.mjs
@@ -1,0 +1,654 @@
+#!/usr/bin/env node
+
+// pencil-mcp-adapter.mjs — MCP server bridging Claude Code to pencil interactive REPL
+// Architecture: Claude Code ←(MCP stdio)→ this adapter ←(stdin/stdout REPL)→ pencil interactive
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { spawn as nodeSpawn } from "node:child_process";
+import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { enrichErrorMessage } from "./pencil-error-enrichment.mjs";
+import { sanitizeFilename } from "./sanitize-filename.mjs";
+
+// --- Node version gate ---
+
+const [major, minor] = process.version.slice(1).split(".").map(Number);
+if (major < 22 || (major === 22 && minor < 9)) {
+  process.stderr.write(
+    `[pencil-adapter] Node >= 22.9.0 required, got ${process.version}\n`
+  );
+  process.exit(1);
+}
+
+// --- Defense-in-depth: parse -e KEY=VALUE from argv ---
+// If `claude mcp add` passes -e flags as args instead of env vars
+// (e.g., -e placed after -- separator), inject them into process.env.
+
+for (let i = 2; i < process.argv.length; i++) {
+  if (process.argv[i] === "-e" && i + 1 < process.argv.length) {
+    const eqIdx = process.argv[i + 1].indexOf("=");
+    if (eqIdx > 0) {
+      const key = process.argv[i + 1].slice(0, eqIdx);
+      const val = process.argv[i + 1].slice(eqIdx + 1);
+      if (!process.env[key]) {
+        process.env[key] = val;
+      }
+    }
+    i++; // skip the value arg
+  }
+}
+
+// --- Env allowlist ---
+
+function buildPencilEnv() {
+  const allowed = [
+    "HOME",
+    "PATH",
+    "NODE_ENV",
+    "LANG",
+    "TERM",
+    "USER",
+    "SHELL",
+    "TMPDIR",
+    "PENCIL_CLI_KEY",
+  ];
+  const env = {};
+  for (const key of allowed) {
+    if (process.env[key] !== undefined) {
+      env[key] = process.env[key];
+    }
+  }
+  // Prepend the adapter's own Node directory to PATH so that pencil's
+  // `#!/usr/bin/env node` shebang resolves to the same Node version (22+)
+  // that runs the adapter, not an incompatible system Node.
+  const nodeDir = dirname(process.execPath);
+  if (env.PATH) {
+    env.PATH = `${nodeDir}:${env.PATH}`;
+  } else {
+    env.PATH = nodeDir;
+  }
+  return env;
+}
+
+// --- ANSI stripping ---
+
+function stripAnsi(str) {
+  return str.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
+}
+
+// --- Response parsing ---
+
+function parseResponse(raw) {
+  const text = stripAnsi(raw).trim();
+  const isError =
+    /^Error:/m.test(text) || /^\[ERROR\]/m.test(text) || /^Invalid properties:/m.test(text);
+  return { text, isError };
+}
+
+// --- Node ID extraction ---
+
+function extractNodeIds(response) {
+  const entries = [];
+  const pattern = /Inserted node `([A-Za-z0-9_-]+)`/g;
+  let match;
+  while ((match = pattern.exec(response)) !== null) {
+    entries.push(match[1]);
+  }
+  return entries;
+}
+
+// --- Screenshot persistence ---
+
+function saveScreenshot(base64Data, nodeId) {
+  const penFile = pencilProcess.outputFile;
+  if (!penFile) return null;
+  const screenshotDir = join(dirname(penFile), "screenshots");
+  mkdirSync(screenshotDir, { recursive: true });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+  const filename = `${nodeId}-${timestamp}.png`;
+  const filePath = join(screenshotDir, filename);
+  writeFileSync(filePath, Buffer.from(base64Data, "base64"));
+  return filePath;
+}
+
+// --- Binary resolution ---
+
+function findPencilBinary() {
+  const localPath = join(homedir(), ".local", "node_modules", ".bin", "pencil");
+  if (existsSync(localPath)) return localPath;
+  // Fall back to PATH lookup — spawn will resolve it
+  return "pencil";
+}
+
+// --- PencilProcess class ---
+
+class PencilProcess {
+  constructor() {
+    this.child = null;
+    this.ready = false;
+    this.buffer = "";
+    this.stderrBuffer = "";
+    this.outputFile = null;
+    this.inputFile = null;
+    this.nodeIdMap = new Map();
+    this._dataHandler = null;
+  }
+
+  async spawn(outFile, inFile = null) {
+    const binary = process.env.PENCIL_BINARY || findPencilBinary();
+    const args = ["interactive", "--out", outFile];
+    if (inFile) {
+      args.push("--in", inFile);
+    }
+
+    this.outputFile = outFile;
+    this.inputFile = inFile;
+    this.buffer = "";
+    this.nodeIdMap.clear();
+
+    // Spawn pencil using the adapter's own Node binary (process.execPath)
+    // instead of relying on the pencil script's #!/usr/bin/env node shebang,
+    // which resolves to the system Node (potentially <22) and fails with
+    // ERR_REQUIRE_ESM. This guarantees the child process uses the same
+    // Node version (22+) that runs the adapter.
+    this.child = nodeSpawn(process.execPath, [binary, ...args], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: buildPencilEnv(),
+    });
+
+    // Capture child stderr for error reporting AND pipe to adapter stderr
+    this.child.stderr.on("data", (chunk) => {
+      this.stderrBuffer += chunk.toString();
+      process.stderr.write(chunk);
+    });
+
+    // Crash detection
+    this.child.on("exit", (code, signal) => {
+      this.ready = false;
+      this.child = null;
+      process.stderr.write(
+        `[pencil-adapter] pencil process exited: code=${code} signal=${signal}\n`
+      );
+    });
+
+    this.child.on("error", (err) => {
+      this.ready = false;
+      this.child = null;
+      process.stderr.write(
+        `[pencil-adapter] pencil process error: ${err.message}\n`
+      );
+    });
+
+    // Consume welcome banner + initial prompt
+    await this.waitForPrompt(30000);
+    this.ready = true;
+  }
+
+  async kill() {
+    if (this.child) {
+      this.child.kill("SIGTERM");
+      this.child = null;
+      this.ready = false;
+    }
+  }
+
+  async restart(outFile, inFile = null) {
+    await this.kill();
+    // Brief delay to let the old process clean up
+    await new Promise((r) => setTimeout(r, 200));
+    await this.spawn(outFile, inFile);
+  }
+
+  async sendCommand(cmd) {
+    if (!this.child || !this.ready) {
+      throw new Error("Pencil process is not running");
+    }
+    this.buffer = "";
+    this.stderrBuffer = "";
+    this.child.stdin.write(cmd + "\n");
+    const raw = await this.waitForPrompt(30000);
+    // If stdout response is empty but stderr has content, use stderr
+    if (!raw && this.stderrBuffer) {
+      return this.stderrBuffer;
+    }
+    return raw;
+  }
+
+  waitForPrompt(timeoutMs = 30000) {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        if (this._dataHandler && this.child) {
+          this.child.stdout.removeListener("data", this._dataHandler);
+        }
+        this._dataHandler = null;
+        reject(
+          new Error(
+            `[pencil-adapter] Timed out waiting for prompt after ${timeoutMs}ms`
+          )
+        );
+      }, timeoutMs);
+
+      this._dataHandler = (chunk) => {
+        this.buffer += chunk.toString();
+        const stripped = stripAnsi(this.buffer);
+        // Detect prompt: "pencil > " at start or after newline
+        const promptIdx = stripped.indexOf("\npencil > ");
+        const startsWithPrompt = stripped.startsWith("pencil > ");
+
+        if (promptIdx !== -1 || startsWithPrompt) {
+          clearTimeout(timeout);
+          if (this.child) {
+            this.child.stdout.removeListener("data", this._dataHandler);
+          }
+          this._dataHandler = null;
+
+          let response;
+          if (promptIdx !== -1) {
+            response = stripped.substring(0, promptIdx);
+          } else {
+            // Buffer starts with prompt — empty response (initial prompt)
+            response = "";
+          }
+          resolve(response.trim());
+        }
+      };
+
+      if (this.child) {
+        this.child.stdout.on("data", this._dataHandler);
+      } else {
+        clearTimeout(timeout);
+        reject(new Error("[pencil-adapter] No child process to listen to"));
+      }
+    });
+  }
+}
+
+// --- Command Queue ---
+
+class CommandQueue {
+  constructor(pencilProcess) {
+    this.process = pencilProcess;
+    this.queue = [];
+    this.running = false;
+  }
+
+  async enqueue(command) {
+    return new Promise((resolve, reject) => {
+      this.queue.push({ command, resolve, reject });
+      if (!this.running) this._drain();
+    });
+  }
+
+  async _drain() {
+    this.running = true;
+    while (this.queue.length > 0) {
+      const { command, resolve: res, reject: rej } = this.queue.shift();
+      try {
+        // Auto-restart if process died
+        if (!this.process.ready && !this.process.child) {
+          if (this.process.outputFile) {
+            await this.process.spawn(
+              this.process.outputFile,
+              this.process.inputFile
+            );
+          } else {
+            throw new Error(
+              "Pencil process not running and no file to restart with"
+            );
+          }
+        }
+        const result = await this.process.sendCommand(command);
+        res(result);
+      } catch (err) {
+        rej(err);
+      }
+    }
+    this.running = false;
+  }
+}
+
+// --- REPL command formatting ---
+
+function formatReplCommand(toolName, params) {
+  if (!params || Object.keys(params).length === 0) {
+    return `${toolName}()`;
+  }
+  if (toolName === "batch_design") {
+    return `batch_design({ operations: ${JSON.stringify(params.operations)} })`;
+  }
+  return `${toolName}(${JSON.stringify(params)})`;
+}
+
+// --- Lazy spawn helper ---
+
+const pencilProcess = new PencilProcess();
+const commandQueue = new CommandQueue(pencilProcess);
+
+async function ensureProcess() {
+  if (!pencilProcess.ready && !pencilProcess.child) {
+    if (pencilProcess.outputFile) {
+      await pencilProcess.spawn(
+        pencilProcess.outputFile,
+        pencilProcess.inputFile
+      );
+    } else {
+      // No document opened yet — use a temp file
+      const tempFile = join(
+        tmpdir(),
+        `pencil-adapter-${process.pid}.pen`
+      );
+      await pencilProcess.spawn(tempFile);
+    }
+  }
+}
+
+// --- MCP Server setup ---
+
+const server = new McpServer({
+  name: "pencil-mcp-adapter",
+  version: "0.0.1",
+});
+
+// --- Read-only tool handler factory ---
+
+function registerReadOnlyTool(name, schema, handler) {
+  server.tool(name, schema, async (params) => {
+    await ensureProcess();
+    const cmd = formatReplCommand(name, params);
+    const raw = await commandQueue.enqueue(cmd);
+    const { text, isError } = parseResponse(raw);
+    if (handler) {
+      return handler(text, isError);
+    }
+    return { content: [{ type: "text", text }], isError };
+  });
+}
+
+// --- Mutating tool handler factory ---
+
+function registerMutatingTool(name, schema, postHandler) {
+  server.tool(name, schema, async (params) => {
+    await ensureProcess();
+    const cmd = formatReplCommand(name, params);
+    const raw = await commandQueue.enqueue(cmd);
+    const { text, isError } = parseResponse(raw);
+    if (isError) {
+      return { content: [{ type: "text", text: enrichErrorMessage(text) }], isError: true };
+    }
+    if (postHandler) {
+      postHandler(text);
+    }
+    // Auto-save after mutating operations
+    await commandQueue.enqueue("save()");
+    return { content: [{ type: "text", text }] };
+  });
+}
+
+// --- Read-only tools ---
+
+registerReadOnlyTool("batch_get", {
+  patterns: z.array(z.record(z.string(), z.unknown())).optional(),
+  nodeIds: z.array(z.string()).optional(),
+  readDepth: z.number().optional(),
+});
+
+registerReadOnlyTool("get_editor_state", {
+  include_schema: z.boolean(),
+});
+
+registerReadOnlyTool("get_guidelines", {
+  topic: z.enum([
+    "code",
+    "table",
+    "tailwind",
+    "landing-page",
+    "design-system",
+    "slides",
+    "mobile-app",
+    "web-app",
+  ]),
+});
+
+// get_screenshot — special handling for base64 image data + auto-save to disk
+server.tool("get_screenshot", { nodeId: z.string() }, async ({ nodeId }) => {
+  await ensureProcess();
+  const cmd = formatReplCommand("get_screenshot", { nodeId });
+  const raw = await commandQueue.enqueue(cmd);
+  const { text, isError } = parseResponse(raw);
+  if (isError) {
+    return { content: [{ type: "text", text }], isError: true };
+  }
+
+  // Try parsing as JSON — pencil returns {"image":"<base64>","mimeType":"image/png"}
+  let base64Data = null;
+  let mimeType = "image/png";
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed.image && parsed.mimeType) {
+      base64Data = parsed.image;
+      mimeType = parsed.mimeType;
+    }
+  } catch {
+    // Not JSON — try data URI pattern
+    const base64Match = text.match(
+      /data:image\/(png|jpeg);base64,([A-Za-z0-9+/=]+)/
+    );
+    if (base64Match) {
+      base64Data = base64Match[2];
+      mimeType = `image/${base64Match[1]}`;
+    }
+  }
+
+  if (!base64Data) {
+    return { content: [{ type: "text", text }] };
+  }
+
+  // Auto-save screenshot to disk
+  const savedPath = saveScreenshot(base64Data, nodeId);
+  const content = [{ type: "image", data: base64Data, mimeType }];
+  if (savedPath) {
+    content.push({ type: "text", text: `Screenshot saved: ${savedPath}` });
+  }
+  return { content };
+});
+
+registerReadOnlyTool("get_style_guide", {
+  name: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+});
+
+registerReadOnlyTool("get_style_guide_tags", {});
+
+registerReadOnlyTool("get_variables", {});
+
+registerReadOnlyTool("find_empty_space_on_canvas", {
+  direction: z.enum(["top", "right", "bottom", "left"]),
+  height: z.number(),
+  width: z.number(),
+  padding: z.number(),
+  nodeId: z.string().optional(),
+});
+
+registerReadOnlyTool("search_all_unique_properties", {
+  parents: z.array(z.string()),
+  properties: z.array(z.string()),
+});
+
+registerReadOnlyTool("snapshot_layout", {
+  parentId: z.string().optional(),
+  maxDepth: z.number().optional(),
+  problemsOnly: z.boolean().optional(),
+});
+
+// export_nodes — custom handler to rename exported files using node names
+server.tool(
+  "export_nodes",
+  {
+    nodeIds: z.array(z.string()),
+    outputDir: z.string(),
+    format: z.enum(["png", "jpeg", "webp", "pdf"]).optional(),
+    scale: z.number().optional(),
+    quality: z.number().optional(),
+  },
+  async ({ nodeIds, outputDir, format, scale, quality }) => {
+    await ensureProcess();
+    const ext = format || "png";
+
+    // Step 1: Try to get node names via batch_get
+    let nameMap = new Map();
+    try {
+      const batchCmd = formatReplCommand("batch_get", { nodeIds });
+      const batchRaw = await commandQueue.enqueue(batchCmd);
+      const { text: batchText } = parseResponse(batchRaw);
+      const parsed = JSON.parse(batchText);
+      if (parsed.nodes && Array.isArray(parsed.nodes)) {
+        for (const node of parsed.nodes) {
+          if (node.id && node.name) {
+            nameMap.set(node.id, node.name);
+          }
+        }
+      }
+    } catch (err) {
+      process.stderr.write(`[pencil-adapter] batch_get for node names failed: ${err.message}\n`);
+    }
+
+    // Step 2: Run the original export_nodes command
+    const cmd = formatReplCommand("export_nodes", { nodeIds, outputDir, format, scale, quality });
+    const raw = await commandQueue.enqueue(cmd);
+    const { text, isError } = parseResponse(raw);
+    if (isError) {
+      return { content: [{ type: "text", text }], isError: true };
+    }
+
+    // Step 3: Rename exported files from nodeId to sanitized name
+    const renamedFiles = [];
+    for (const nodeId of nodeIds) {
+      const nodeName = nameMap.get(nodeId);
+      const sanitized = nodeName ? sanitizeFilename(nodeName) : "";
+      if (!sanitized) {
+        renamedFiles.push(`${nodeId}.${ext}`);
+        continue;
+      }
+      const oldPath = join(outputDir, `${nodeId}.${ext}`);
+      const newPath = join(outputDir, `${sanitized}.${ext}`);
+      try {
+        renameSync(oldPath, newPath);
+        renamedFiles.push(`${sanitized}.${ext}`);
+      } catch (err) {
+        process.stderr.write(`[pencil-adapter] rename ${oldPath} -> ${newPath} failed: ${err.message}\n`);
+        renamedFiles.push(`${nodeId}.${ext}`);
+      }
+    }
+
+    const summary = `\nExported files: ${renamedFiles.join(", ")}`;
+    return { content: [{ type: "text", text: text + summary }] };
+  }
+);
+
+// --- Mutating tools (auto-save after) ---
+
+registerMutatingTool(
+  "batch_design",
+  { operations: z.string() },
+  (text) => {
+    // Extract and track node IDs
+    const nodeIds = extractNodeIds(text);
+    for (const id of nodeIds) {
+      pencilProcess.nodeIdMap.set(id, id);
+    }
+  }
+);
+
+registerMutatingTool("replace_all_matching_properties", {
+  parents: z.array(z.string()),
+  properties: z.record(z.string(), z.unknown()),
+});
+
+// set_variables — auto-coerce bare values into {type, value} objects
+server.tool(
+  "set_variables",
+  {
+    variables: z.record(z.string(), z.unknown()),
+    replace: z.boolean().optional(),
+  },
+  async ({ variables, replace }) => {
+    await ensureProcess();
+    // Coerce bare values: "#hex" → {type:"color"}, number → {type:"number"}, string → {type:"string"}
+    const coerced = {};
+    for (const [key, val] of Object.entries(variables)) {
+      if (val && typeof val === "object" && val.type && val.value !== undefined) {
+        coerced[key] = val; // already typed
+      } else if (typeof val === "string" && /^#[0-9a-fA-F]{3,8}$/.test(val)) {
+        coerced[key] = { type: "color", value: val };
+      } else if (typeof val === "number") {
+        coerced[key] = { type: "number", value: val };
+      } else if (typeof val === "string") {
+        coerced[key] = { type: "string", value: val };
+      } else {
+        coerced[key] = val; // pass through unknown shapes
+      }
+    }
+    const params = { variables: coerced };
+    if (replace !== undefined) params.replace = replace;
+    const cmd = formatReplCommand("set_variables", params);
+    const raw = await commandQueue.enqueue(cmd);
+    const { text, isError } = parseResponse(raw);
+    if (isError) {
+      let enriched = text;
+      if (/does not have a valid definition/i.test(text)) {
+        enriched += '\nExpected: { "type": "color" | "string" | "number", "value": <value> }';
+      } else if (/invalid type property/i.test(text)) {
+        enriched += "\nValid types: color, string, number";
+      }
+      return { content: [{ type: "text", text: enriched }], isError: true };
+    }
+    await commandQueue.enqueue("save()");
+    return { content: [{ type: "text", text }] };
+  }
+);
+
+// --- Meta tools ---
+
+server.tool(
+  "open_document",
+  {
+    filePath: z.string(),
+    inputPath: z.string().optional(),
+  },
+  async ({ filePath, inputPath }) => {
+    // Save current document first if process is running
+    if (pencilProcess.ready) {
+      try {
+        await commandQueue.enqueue("save()");
+      } catch {
+        // Process may have died — proceed with restart
+      }
+    }
+    await pencilProcess.restart(filePath, inputPath);
+    return {
+      content: [{ type: "text", text: `Opened ${filePath}` }],
+    };
+  }
+);
+
+server.tool("save", {}, async () => {
+  await ensureProcess();
+  const raw = await commandQueue.enqueue("save()");
+  const { text, isError } = parseResponse(raw);
+  return { content: [{ type: "text", text }], isError };
+});
+
+// --- Start server ---
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+process.stderr.write("[pencil-adapter] MCP server started on stdio\n");
+if (!process.env.PENCIL_CLI_KEY) {
+  process.stderr.write(
+    "[pencil-adapter] WARNING: PENCIL_CLI_KEY not set. Auth will fail.\n" +
+    "[pencil-adapter] If you used `claude mcp add`, ensure -e appears BEFORE --\n"
+  );
+}

--- a/.plugin/skills/pencil-setup/scripts/sanitize-filename.mjs
+++ b/.plugin/skills/pencil-setup/scripts/sanitize-filename.mjs
@@ -1,0 +1,25 @@
+// sanitize-filename.mjs — filesystem-safe filename sanitization for pencil node names
+
+/**
+ * Sanitize a node name for use as a filename.
+ * Replaces path separators and filesystem-unsafe characters with hyphens,
+ * collapses consecutive hyphens, trims, and truncates.
+ * Returns empty string if the result is empty (caller handles fallback to node ID).
+ */
+export function sanitizeFilename(name) {
+  if (!name) return "";
+  let result = name
+    // Replace unsafe characters with hyphens
+    .replace(/[/\\:*?"<>|]/g, "-")
+    // Collapse consecutive hyphens
+    .replace(/-{2,}/g, "-")
+    // Trim hyphens and whitespace from edges
+    .replace(/^[-\s]+|[-\s]+$/g, "");
+  // Truncate to 200 characters
+  if (result.length > 200) {
+    result = result.slice(0, 200);
+  }
+  // Guard against dot-dot traversal (a node named ".." would pass through otherwise)
+  if (result === "." || result === "..") return "";
+  return result;
+}

--- a/.plugin/skills/plan-review/SKILL.md
+++ b/.plugin/skills/plan-review/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: plan-review
+description: "Have multiple specialized agents review a plan in parallel. Spawns DHH, Kieran, and code simplicity reviewers to provide diverse feedback on implementation plans."
+triggers:
+- plan review
+- review plan
+- review implementation
+- review my plan
+---
+
+# Plan Review
+
+Spawn multiple specialist reviewers to evaluate a plan in parallel. Use the delegation tool to run the following agents concurrently:
+
+1. **DHH Rails Reviewer** -- Reviews for Rails conventions, simplicity, and pragmatism
+2. **Kieran Rails Reviewer** -- Reviews for architecture patterns and scalability
+3. **Code Simplicity Reviewer** -- Reviews for unnecessary complexity and over-engineering
+
+Collect all feedback and present a consolidated summary with areas of agreement and disagreement.

--- a/.plugin/skills/rclone/SKILL.md
+++ b/.plugin/skills/rclone/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: rclone
+description: "Upload, sync, or manage files across cloud storage providers using rclone. Handles transfers to S3, Cloudflare R2, Backblaze B2, Google Drive, Dropbox, or any S3-compatible storage."
+triggers:
+- rclone
+- cloud storage transfer
+- file sync remote
+- s3 upload
+---
+
+# rclone File Transfer Skill
+
+## Setup Check (Always Run First)
+
+Before any rclone operation, verify installation and configuration:
+
+```bash
+# Check if rclone is installed
+command -v rclone >/dev/null 2>&1 && rclone version || echo "NOT INSTALLED"
+
+# List configured remotes
+rclone listremotes 2>/dev/null || echo "NO REMOTES CONFIGURED"
+```
+
+### If rclone is NOT installed
+
+Guide the user to install:
+
+```bash
+# macOS
+brew install rclone
+
+# Linux (static binary to ~/.local/bin)
+mkdir -p ~/.local/bin && curl -sfL https://downloads.rclone.org/rclone-current-linux-amd64.zip -o /tmp/rclone.zip && unzip -q /tmp/rclone.zip -d /tmp && cp /tmp/rclone-*/rclone ~/.local/bin/ && chmod +x ~/.local/bin/rclone
+# For arm64: replace amd64 with arm64 in the URL above
+```
+
+### If NO remotes are configured
+
+Walk the user through interactive configuration:
+
+```bash
+rclone config
+```
+
+**Common provider setup quick reference:**
+
+| Provider | Type | Key Settings |
+|----------|------|--------------|
+| AWS S3 | `s3` | access_key_id, secret_access_key, region |
+| Cloudflare R2 | `s3` | access_key_id, secret_access_key, endpoint (account_id.r2.cloudflarestorage.com) |
+| Backblaze B2 | `b2` | account (keyID), key (applicationKey) |
+| DigitalOcean Spaces | `s3` | access_key_id, secret_access_key, endpoint (region.digitaloceanspaces.com) |
+| Google Drive | `drive` | OAuth flow (opens browser) |
+| Dropbox | `dropbox` | OAuth flow (opens browser) |
+
+**Example: Configure Cloudflare R2**
+
+```bash
+rclone config create r2 s3 \
+  provider=Cloudflare \
+  access_key_id=YOUR_ACCESS_KEY \
+  secret_access_key=YOUR_SECRET_KEY \
+  endpoint=ACCOUNT_ID.r2.cloudflarestorage.com \
+  acl=private
+```
+
+**Example: Configure AWS S3**
+
+```bash
+rclone config create aws s3 \
+  provider=AWS \
+  access_key_id=YOUR_ACCESS_KEY \
+  secret_access_key=YOUR_SECRET_KEY \
+  region=us-east-1
+```
+
+## Common Operations
+
+### Upload single file
+
+```bash
+rclone copy /path/to/file.mp4 remote:bucket/path/ --progress
+```
+
+### Upload directory
+
+```bash
+rclone copy /path/to/folder remote:bucket/folder/ --progress
+```
+
+### Sync directory (mirror, deletes removed files)
+
+```bash
+rclone sync /local/path remote:bucket/path/ --progress
+```
+
+### List remote contents
+
+```bash
+rclone ls remote:bucket/
+rclone lsd remote:bucket/  # directories only
+```
+
+### Check what would be transferred (dry run)
+
+```bash
+rclone copy /path remote:bucket/ --dry-run
+```
+
+## Useful Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--progress` | Show transfer progress |
+| `--dry-run` | Preview without transferring |
+| `-v` | Verbose output |
+| `--transfers=N` | Parallel transfers (default 4) |
+| `--bwlimit=RATE` | Bandwidth limit (e.g., `10M`) |
+| `--checksum` | Compare by checksum, not size/time |
+| `--exclude="*.tmp"` | Exclude patterns |
+| `--include="*.mp4"` | Include only matching |
+| `--min-size=SIZE` | Skip files smaller than SIZE |
+| `--max-size=SIZE` | Skip files larger than SIZE |
+
+## Large File Uploads
+
+For videos and large files, use chunked uploads:
+
+```bash
+# S3 multipart upload (automatic for >200MB)
+rclone copy large_video.mp4 remote:bucket/ --s3-chunk-size=64M --progress
+
+# Resume interrupted transfers
+rclone copy /path remote:bucket/ --progress --retries=5
+```
+
+## Verify Upload
+
+```bash
+# Check file exists and matches
+rclone check /local/file remote:bucket/file
+
+# Get file info
+rclone lsl remote:bucket/path/to/file
+```
+
+## Troubleshooting
+
+```bash
+# Test connection
+rclone lsd remote:
+
+# Debug connection issues
+rclone lsd remote: -vv
+
+# Check config
+rclone config show remote
+```

--- a/.plugin/skills/rclone/scripts/check_setup.sh
+++ b/.plugin/skills/rclone/scripts/check_setup.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# rclone setup checker - verifies installation and configuration
+
+set -euo pipefail
+
+echo "=== rclone Setup Check ==="
+echo
+
+# Check if rclone is installed
+if command -v rclone >/dev/null 2>&1; then
+    echo "✓ rclone installed"
+    rclone version | head -1
+    echo
+else
+    echo "✗ rclone NOT INSTALLED"
+    echo
+    echo "Install with:"
+    echo "  macOS:  brew install rclone"
+    echo "  Linux:  mkdir -p ~/.local/bin && curl -sfL https://downloads.rclone.org/rclone-current-linux-amd64.zip -o /tmp/rclone.zip && unzip -q /tmp/rclone.zip -d /tmp && cp /tmp/rclone-*/rclone ~/.local/bin/ && chmod +x ~/.local/bin/rclone"
+    echo "          (for arm64: replace amd64 with arm64 in the URL)"
+    exit 1
+fi
+
+# Check for configured remotes
+REMOTES=$(rclone listremotes 2>/dev/null || true)
+
+if [[ -z "$REMOTES" ]]; then
+    echo "✗ No remotes configured"
+    echo
+    echo "Run 'rclone config' to set up a remote, or use:"
+    echo
+    echo "  # Cloudflare R2"
+    echo "  rclone config create r2 s3 provider=Cloudflare \\"
+    echo "    access_key_id=KEY secret_access_key=SECRET \\"
+    echo "    endpoint=ACCOUNT_ID.r2.cloudflarestorage.com"
+    echo
+    echo "  # AWS S3"
+    echo "  rclone config create aws s3 provider=AWS \\"
+    echo "    access_key_id=KEY secret_access_key=SECRET region=us-east-1"
+    echo
+    exit 1
+else
+    echo "✓ Configured remotes:"
+    echo "$REMOTES" | sed 's/^/  /'
+    echo
+fi
+
+# Test connectivity for each remote
+echo "Testing remote connectivity..."
+for remote in $REMOTES; do
+    remote_name="${remote%:}"
+    if rclone lsd "$remote" >/dev/null 2>&1; then
+        echo "  ✓ $remote_name - connected"
+    else
+        echo "  ✗ $remote_name - connection failed (check credentials)"
+    fi
+done
+
+echo
+echo "=== Setup Complete ==="

--- a/.plugin/skills/release-announce/SKILL.md
+++ b/.plugin/skills/release-announce/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: release-announce
+description: "Announce a new release. Parses CHANGELOG.md, generates a summary, and creates a GitHub Release. Discord notification is handled automatically by CI on release publish."
+triggers:
+- release announce
+- github release
+- create release
+- announce release
+---
+
+# release-announce Skill
+
+> **Manual fallback only.** The `version-bump-and-release.yml` GitHub Action now handles version bumping and GitHub Release creation automatically at merge time. This skill is only needed if the Action fails or for manual re-announcements of existing versions.
+
+**Purpose:** Generate a release announcement from CHANGELOG.md and create a GitHub Release. Discord notification is handled by the `release-announce` GitHub Actions workflow, triggered automatically when the release is published.
+
+## Step 1: Read Version and Changelog
+
+1. Read the current version from `plugins/soleur/.claude-plugin/plugin.json`:
+
+   Read `plugins/soleur/.claude-plugin/plugin.json` and extract the `version` field value.
+
+2. Extract the `## [<version>]` section from `plugins/soleur/CHANGELOG.md`. Parse from the `## [<version>]` heading to the next `## [` heading (exclusive). If no matching section exists, error with "Changelog section for v<version> not found" and stop. Replace `<version>` with the actual version from step 1.
+
+3. Generate a detailed summary of the extracted changelog section:
+   - Include all categories present (Added, Changed, Fixed, Removed)
+   - Tone: enthusiastic but professional
+   - This summary is used as the GitHub Release body
+
+## Step 2: Create GitHub Release
+
+1. Check if a release for this version already exists:
+
+   ```bash
+   gh release view "v<version>" 2>/dev/null
+   ```
+
+   Replace `<version>` with the actual version number (e.g., `2.32.1`).
+
+2. If the release already exists: warn "Release v<version> already exists, skipping" and stop.
+
+3. Create the release:
+
+   ```bash
+   gh release create "v<version>" --title "v<version>" --notes "<full summary>"
+   ```
+
+4. If the command fails: warn with the error message.
+
+5. Report results:
+   - Print the GitHub Release URL if created
+   - Note that Discord notification will be posted automatically by CI (requires `DISCORD_WEBHOOK_URL` repository secret)

--- a/.plugin/skills/release-docs/SKILL.md
+++ b/.plugin/skills/release-docs/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: release-docs
+description: "Update documentation metadata after adding or removing plugin components. Updates plugin.json description and README.md counts, then verifies the Eleventy build produces correct output."
+triggers:
+- release docs
+- release documentation
+- update doc metadata
+- documentation metadata
+---
+
+# Release Documentation
+
+Update documentation metadata and verify the docs site builds correctly after plugin component changes.
+
+## Overview
+
+The documentation site auto-generates agent and skill catalog pages from source file frontmatter via Eleventy. This skill handles the metadata files that still need manual updates.
+
+**What is automated (no action needed):**
+
+- Agent catalog page (`pages/agents.html`) -- built from `agents/**/*.md` frontmatter
+- Skill catalog page (`pages/skills.html`) -- built from `skills/*/SKILL.md` frontmatter
+- Stats on landing page -- counted from file system at build time
+
+**What still needs manual updates:**
+
+- `plugins/soleur/.claude-plugin/plugin.json` description with counts
+- `knowledge-base/marketing/brand-guide.md` agent/skill counts (if it exists)
+
+## Step 1: Sync README Counts
+
+Run the automated sync script to update counts in both `README.md` and `plugins/soleur/README.md`:
+
+```bash
+bash scripts/sync-readme-counts.sh
+```
+
+This updates: root README intro line, root README "What is Soleur?" counts, plugin README component count table, and plugin README domain section headers.
+
+## Step 2: Update plugin.json
+
+Update `plugins/soleur/.claude-plugin/plugin.json` description with correct counts (not covered by the sync script).
+
+## Step 3: Update Skill Category Mapping (if needed)
+
+If skills were added, removed, or recategorized, update the category mapping in:
+
+```text
+plugins/soleur/docs/_data/skills.js
+```
+
+The `SKILL_CATEGORIES` object maps each skill name to its display category. New skills must be added here or they will appear as "Uncategorized" in the catalog.
+
+## Step 4: Verify Build
+
+```bash
+# Run the Eleventy build
+npx @11ty/eleventy
+```
+
+After the build completes, verify counts by using grep to count occurrences of `component-card` in `_site/pages/agents.html` and `_site/pages/skills.html`.
+
+Verify JSON files are well-formed:
+
+```bash
+cat plugins/soleur/.claude-plugin/plugin.json | jq .
+```
+
+## Step 5: Report Changes
+
+Provide a summary of what was updated:
+
+```text
+## Documentation Release Summary
+
+### Component Counts
+- Agents: X (previously Y)
+- Commands: X (previously Y)
+- Skills: X (previously Y)
+
+### Files Updated
+- plugin.json - Updated counts
+- README.md - Updated component lists
+- _data/skills.js - Updated category mapping (if applicable)
+```
+
+## Post-Release
+
+After successful release:
+
+1. Suggest updating CHANGELOG.md with documentation changes
+2. Remind to commit with message: `docs: Update documentation metadata to match plugin components`
+3. Remind to push changes -- the deploy workflow will rebuild the site automatically

--- a/.plugin/skills/user-story-writer/SKILL.md
+++ b/.plugin/skills/user-story-writer/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: user-story-writer
+description: "Decompose feature requirements into granular, implementable user stories. Applies Elephant Carpaccio slicing, INVEST criteria, and story prioritization."
+triggers:
+- user story
+- user stories
+- story writing
+- elephant carpaccio
+- backlog decomposition
+---
+
+# User Story Writer
+
+Decompose a problem statement or feature requirement into thin, vertical user stories that deliver end-to-end value.
+
+## When to Use
+
+- Breaking down a feature into sprint-sized work items
+- Decomposing a vague requirement into concrete stories
+- Prioritizing a backlog by risk and value
+
+## Constraints
+
+This is a story-writing role. Do not suggest implementation details, code examples, technical architectures, or testing frameworks. Focus exclusively on user needs, business value, and acceptance criteria in user terms.
+
+## Process
+
+### 1. Analyze the Problem
+
+- Identify the core user need and key stakeholders
+- Map the problem domain and user personas
+- Clarify scope boundaries
+
+### 2. Slice with Elephant Carpaccio
+
+Break the problem into the thinnest possible vertical slices. Each slice must deliver a complete, working capability a user can interact with -- not a technical layer.
+
+### 3. Write INVEST-Compliant Stories
+
+Every story must satisfy all six INVEST criteria (Independent, Negotiable, Valuable, Estimable, Small, Testable).
+
+### 4. Structure Each Story
+
+```text
+**Story Title**: [Descriptive name]
+**As a** [user type]
+**I want** [functionality]
+**So that** [business value]
+
+**Acceptance Criteria**:
+- [Specific, testable criterion 1]
+- [Specific, testable criterion 2]
+
+**Definition of Done**:
+- [User-facing quality requirement]
+- [Business completion criterion]
+```
+
+### 5. Prioritize and Sequence
+
+Order stories by:
+
+1. Risk reduction -- tackle unknowns early
+2. User value delivery
+3. Dependencies between stories
+4. Learning opportunities
+
+### 6. Validate Completeness
+
+Confirm the full set of stories covers the original problem without gaps or overlaps.
+
+## Output Format
+
+Produce a structured document containing:
+
+- Problem summary and user personas
+- Prioritized list of user stories (using the template above)
+- Rationale for decomposition approach and sequencing
+- Summary of how stories collectively solve the original problem


### PR DESCRIPTION
## Summary

Port the 15 GREEN skills to OpenHands `.plugin/skills/<name>/SKILL.md` format with minimal content changes.

## Skills Ported

agent-browser, archive-kb, changelog, deploy-docs, docs-site, every-style-editor, frontend-design, gemini-imagegen, kb-search, pencil-setup, plan-review, rclone, release-announce, release-docs, user-story-writer

## Changes Per Skill

1. Created `SKILL.md` with OpenHands YAML frontmatter (`name`, `description`, `triggers`)
2. Copied supporting files (scripts/, references/, requirements.txt) for 6 skills that have them
3. Mapped Claude Code-specific references to OpenHands equivalents:
   - **kb-search**: Removed `$ARGUMENTS` primitive, replaced with freeform usage note
   - **pencil-setup**: Replaced `claude mcp add/list/remove` commands with `.mcp.json` configuration
   - **plan-review**: Replaced `@agent-*` references with delegation tool pattern

## Validation

- All 15 SKILL.md files pass YAML frontmatter parsing (name, description, triggers)
- All names match directory names
- Keyword trigger activation tested against 10 sample queries
- markdownlint passes with 0 errors

Closes #1776

_This PR was created by an AI assistant (OpenHands) on behalf of the user._