### PR TITLE
feat: port PreToolUse and lifecycle hooks to OpenHands

### DIFF
--- a/.claude/hooks/worktree-write-guard.sh
+++ b/.claude/hooks/worktree-write-guard.sh
@@ -27,9 +27,10 @@ GIT_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | s
 # If file path is inside a worktree, allow it (correct behavior)
 [[ "$FILE_PATH" == *"/.worktrees/"* ]] && exit 0
 
-# Allow writes to .claude/ directory (settings, hooks, memory)
+# Allow writes to .claude/ and .openhands/ directories (settings, hooks, memory)
 RELATIVE_PATH="${FILE_PATH#"$GIT_ROOT"/}"
 [[ "$RELATIVE_PATH" == .claude/* ]] && exit 0
+[[ "$RELATIVE_PATH" == .openhands/* ]] && exit 0
 
 # Check if any worktrees exist
 WORKTREE_DIR="$GIT_ROOT/.worktrees"

--- a/.openhands/hooks.json
+++ b/.openhands/hooks.json
@@ -1,0 +1,53 @@
+{
+  "pre_tool_use": [
+    {
+      "matcher": "terminal",
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".openhands/hooks/guardrails.sh",
+          "timeout": 10
+        },
+        {
+          "type": "command",
+          "command": ".openhands/hooks/pre-merge-rebase.sh",
+          "timeout": 30
+        }
+      ]
+    },
+    {
+      "matcher": "file_editor",
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".openhands/hooks/worktree-write-guard.sh",
+          "timeout": 5
+        }
+      ]
+    }
+  ],
+  "session_start": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".openhands/hooks/welcome-hook.sh",
+          "timeout": 5
+        }
+      ]
+    }
+  ],
+  "stop": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".openhands/hooks/stop-hook.sh",
+          "timeout": 30
+        }
+      ]
+    }
+  ]
+}

--- a/.openhands/hooks/guardrails.sh
+++ b/.openhands/hooks/guardrails.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# PreToolUse guardrail hook for terminal commands (OpenHands port).
+# Blocks: commits on main, rm -rf on worktrees, --delete-branch with active worktrees,
+# commits with conflict markers in staged content, gh issue create without --milestone,
+# git stash in worktrees.
+#
+# OpenHands protocol: exit 2 + JSON {"decision":"deny","reason":"..."} to block.
+# Input: HookEvent JSON on stdin with tool_input.command and working_dir.
+#
+# Corresponding prose rules: see .claude/hooks/guardrails.sh
+
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+HOOK_CWD=$(echo "$INPUT" | jq -r '.working_dir // ""')
+
+deny() {
+  jq -n --arg reason "$1" '{"decision":"deny","reason":$reason}'
+  exit 2
+}
+
+# guardrails:block-commit-on-main — Block git commit on main branch
+if echo "$COMMAND" | grep -qE '(^|&&|\|\||;)\s*git\s+commit'; then
+  GIT_DIR=""
+  if echo "$COMMAND" | grep -qE '^\s*cd\s+'; then
+    GIT_DIR=$(echo "$COMMAND" | sed -nE 's/^\s*cd\s+"?([^"&;]+)"?.*/\1/p' | xargs)
+  elif echo "$COMMAND" | grep -qoE 'git\s+-C\s+\S+'; then
+    GIT_DIR=$(echo "$COMMAND" | grep -oE 'git\s+-C\s+\S+' | head -1 | sed -nE 's/git\s+-C\s+(\S+)/\1/p')
+  fi
+  if [ -n "$GIT_DIR" ] && [ -d "$GIT_DIR" ]; then
+    BRANCH=$(git -C "$GIT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  elif [ -n "$HOOK_CWD" ] && [ -d "$HOOK_CWD" ]; then
+    BRANCH=$(git -C "$HOOK_CWD" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  else
+    BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  fi
+  if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+    deny "BLOCKED: Committing directly to main/master is not allowed. Create a feature branch first."
+  fi
+fi
+
+# guardrails:block-rm-rf-worktrees — Block rm -rf on worktree paths
+if echo "$COMMAND" | grep -qE 'rm\s+(-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*|-[a-zA-Z]*f[a-zA-Z]*r[a-zA-Z]*)\s+\S*\.worktrees/'; then
+  deny "BLOCKED: rm -rf on worktree paths is not allowed. Use git worktree remove or worktree-manager.sh cleanup-merged instead."
+fi
+
+# guardrails:block-delete-branch — Block gh pr merge --delete-branch when worktrees exist
+if echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge.*--delete-branch'; then
+  WORKTREE_COUNT=$(git worktree list 2>/dev/null | wc -l)
+  if [ "$WORKTREE_COUNT" -gt 1 ]; then
+    deny "BLOCKED: --delete-branch with active worktrees will orphan them. Remove worktrees first, then merge."
+  fi
+fi
+
+# guardrails:block-conflict-markers — Block commits with conflict markers in staged content
+if echo "$COMMAND" | grep -qE '(^|&&|\|\||;)\s*git\s+(-C\s+\S+\s+)?(commit|merge\s+--continue)'; then
+  CONFLICT_MARKERS_DIR=""
+  if echo "$COMMAND" | grep -qE '^\s*cd\s+'; then
+    CONFLICT_MARKERS_DIR=$(echo "$COMMAND" | sed -nE 's/^\s*cd\s+"?([^"&;]+)"?.*/\1/p' | xargs)
+  elif echo "$COMMAND" | grep -qoE 'git\s+-C\s+\S+'; then
+    CONFLICT_MARKERS_DIR=$(echo "$COMMAND" | grep -oE 'git\s+-C\s+\S+' | head -1 | sed -nE 's/git\s+-C\s+(\S+)/\1/p')
+  fi
+  if [ -z "$CONFLICT_MARKERS_DIR" ] || [ ! -d "$CONFLICT_MARKERS_DIR" ]; then
+    if [ -n "$HOOK_CWD" ] && [ -d "$HOOK_CWD" ]; then
+      CONFLICT_MARKERS_DIR="$HOOK_CWD"
+    fi
+  fi
+  if [ -n "$CONFLICT_MARKERS_DIR" ] && [ -d "$CONFLICT_MARKERS_DIR" ]; then
+    STAGED_DIFF=$(git -C "$CONFLICT_MARKERS_DIR" diff --cached 2>/dev/null || true)
+  else
+    STAGED_DIFF=$(git diff --cached 2>/dev/null || true)
+  fi
+  if echo "$STAGED_DIFF" | grep -qE '^\+(<{7}|={7}|>{7})'; then
+    deny "BLOCKED: Staged content contains conflict markers (<<<<<<<, =======, or >>>>>>>). Resolve all conflicts before committing."
+  fi
+fi
+
+# guardrails:require-milestone — Block gh issue create without --milestone
+if echo "$COMMAND" | grep -qE '(^|&&|\|\||;)\s*gh\s+issue\s+create'; then
+  if ! echo "$COMMAND" | grep -qF -- '--milestone'; then
+    deny "BLOCKED: gh issue create must include --milestone. Default to 'Post-MVP / Later' for operational issues. Read knowledge-base/product/roadmap.md for feature issues."
+  fi
+fi
+
+# guardrails:block-stash-in-worktrees — Block git stash in worktrees
+if echo "$COMMAND" | grep -qE '(^|&&|\|\||;)\s*git\s+stash'; then
+  STASH_GUARD_DIR=""
+  if echo "$COMMAND" | grep -qE '^\s*cd\s+'; then
+    STASH_GUARD_DIR=$(echo "$COMMAND" | sed -nE 's/^\s*cd\s+"?([^"&;]+)"?.*/\1/p' | xargs)
+  elif echo "$COMMAND" | grep -qoE 'git\s+-C\s+\S+'; then
+    STASH_GUARD_DIR=$(echo "$COMMAND" | grep -oE 'git\s+-C\s+\S+' | head -1 | sed -nE 's/git\s+-C\s+(\S+)/\1/p')
+  fi
+  if [ -z "$STASH_GUARD_DIR" ] || [ ! -d "$STASH_GUARD_DIR" ]; then
+    if [ -n "$HOOK_CWD" ] && [ -d "$HOOK_CWD" ]; then
+      STASH_GUARD_DIR="$HOOK_CWD"
+    fi
+  fi
+  RESOLVE_DIR="${STASH_GUARD_DIR:-.}"
+  if echo "$(cd "$RESOLVE_DIR" 2>/dev/null && pwd)" | grep -qF '.worktrees'; then
+    deny "BLOCKED: git stash in worktrees is not allowed. Use git show <commit>:<path> to inspect old code, or commit WIP first."
+  fi
+fi
+
+# All checks passed
+exit 0

--- a/.openhands/hooks/pre-merge-rebase.sh
+++ b/.openhands/hooks/pre-merge-rebase.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# PreToolUse hook: review evidence gate + auto-sync against origin/main before gh pr merge.
+# OpenHands port of .claude/hooks/pre-merge-rebase.sh.
+#
+# OpenHands protocol: exit 2 + JSON {"decision":"deny","reason":"..."} to block.
+# Exit 0 + JSON {"additionalContext":"..."} to inject context.
+# Input: HookEvent JSON on stdin with tool_input.command and working_dir.
+#
+# Corresponding prose rules: see .claude/hooks/pre-merge-rebase.sh
+
+set -eo pipefail
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+# Early exit: only intercept gh pr merge commands.
+if ! echo "$CMD" | grep -qE '(^|&&|\|\||;)\s*gh\s+pr\s+merge(\s|$)'; then
+  exit 0
+fi
+
+# Determine working directory from hook input.
+WORK_DIR=$(echo "$INPUT" | jq -r '.working_dir // ""')
+if [[ -z "$WORK_DIR" ]] || [[ ! -d "$WORK_DIR" ]]; then
+  exit 0
+fi
+
+if ! git -C "$WORK_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+deny() {
+  jq -n --arg reason "$1" '{"decision":"deny","reason":$reason}'
+  exit 2
+}
+
+CURRENT_BRANCH=$(git -C "$WORK_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+if [[ "$CURRENT_BRANCH" == "main" ]] || [[ "$CURRENT_BRANCH" == "master" ]]; then
+  exit 0
+fi
+
+# pre-merge:review-evidence-gate
+REVIEW_TODOS=$(grep -rl "code-review" "$WORK_DIR/todos/" 2>/dev/null | head -1 || true)
+REVIEW_COMMIT=$(git -C "$WORK_DIR" log origin/main..HEAD --oneline 2>/dev/null \
+  | grep "refactor: add code review findings" || true)
+
+REVIEW_ISSUES=""
+if [[ -z "$REVIEW_TODOS" ]] && [[ -z "$REVIEW_COMMIT" ]]; then
+  PR_NUMBER=$(echo "$CMD" | grep -oE 'gh\s+pr\s+merge\s+([0-9]+)' | grep -oE '[0-9]+' || true)
+  if [[ -z "$PR_NUMBER" ]]; then
+    PR_NUMBER=$(gh pr list --repo "$(git -C "$WORK_DIR" remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||')" \
+      --head "$CURRENT_BRANCH" --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)
+  fi
+  if [[ -n "$PR_NUMBER" ]]; then
+    REVIEW_ISSUES=$(gh issue list --label code-review --search "PR #${PR_NUMBER}" \
+      --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)
+  fi
+fi
+
+if [[ -z "$REVIEW_TODOS" ]] && [[ -z "$REVIEW_COMMIT" ]] && [[ -z "$REVIEW_ISSUES" ]]; then
+  deny "BLOCKED: No review evidence found on this branch. Run /review before merging."
+fi
+
+# Check for detached HEAD
+if [[ "$CURRENT_BRANCH" == "HEAD" ]]; then
+  echo "Warning: Detached HEAD state. Skipping auto-sync." >&2
+  exit 0
+fi
+
+# Check for uncommitted changes
+if [[ "$(git -C "$WORK_DIR" rev-parse --is-inside-work-tree 2>/dev/null)" == "true" ]]; then
+  if ! git -C "$WORK_DIR" diff --quiet HEAD 2>/dev/null || \
+     ! git -C "$WORK_DIR" diff --cached --quiet 2>/dev/null; then
+    deny "BLOCKED: Uncommitted changes detected. Commit before merging."
+  fi
+fi
+
+# Fetch latest main
+if ! git -C "$WORK_DIR" fetch origin main >/dev/null 2>&1; then
+  echo "Warning: Could not fetch origin/main (network error). Proceeding with merge." >&2
+  exit 0
+fi
+
+MERGE_BASE=$(git -C "$WORK_DIR" merge-base HEAD origin/main 2>/dev/null) || true
+REMOTE_MAIN=$(git -C "$WORK_DIR" rev-parse origin/main 2>/dev/null) || true
+
+if [[ -z "$MERGE_BASE" ]] || [[ -z "$REMOTE_MAIN" ]]; then
+  echo "Warning: Could not determine branch relationship with main. Proceeding with merge." >&2
+  exit 0
+fi
+
+if [[ "$MERGE_BASE" == "$REMOTE_MAIN" ]]; then
+  echo "[ok] Branch already up-to-date with origin/main." >&2
+  exit 0
+fi
+
+# Attempt merge
+if ! git -C "$WORK_DIR" merge origin/main >/dev/null 2>&1; then
+  CONFLICT_FILES=$(git -C "$WORK_DIR" diff --name-only --diff-filter=U 2>/dev/null \
+    | head -5 | tr '\n' ', ' | sed 's/,$//')
+  git -C "$WORK_DIR" merge --abort 2>/dev/null || true
+  deny "BLOCKED: Merge of origin/main failed. Conflicting files: ${CONFLICT_FILES:-unknown}. Resolve conflicts manually before merging."
+fi
+
+# Push the merged result
+if ! PUSH_OUTPUT=$(git -C "$WORK_DIR" push origin HEAD 2>&1); then
+  deny "BLOCKED: Merge succeeded but push failed. Push manually before merging. Error: $PUSH_OUTPUT"
+fi
+
+# Success with context
+jq -n --arg branch "$CURRENT_BRANCH" \
+  '{"additionalContext":("Pre-merge hook: merged origin/main into " + $branch + " and pushed. Branch is now current.")}'
+exit 0

--- a/.openhands/hooks/stop-hook.sh
+++ b/.openhands/hooks/stop-hook.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# Ralph Loop Stop Hook (OpenHands port).
+# Prevents session exit when a ralph-loop is active.
+# OpenHands port of plugins/soleur/hooks/stop-hook.sh.
+#
+# OpenHands protocol: exit 2 + JSON {"decision":"deny","reason":"..."} to block stop.
+# Input: HookEvent JSON on stdin with working_dir and metadata.reason.
+#
+# Key difference from Claude Code version:
+# - Claude Code passes last_assistant_message in stdin JSON.
+# - OpenHands passes metadata.reason (the agent's stop reason).
+# - Stuck/repetition/similarity detection operates on metadata.reason content.
+
+set -euo pipefail
+
+# Source shared helper for repo root resolution
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_HELPER="${SCRIPT_DIR}/../../plugins/soleur/scripts/resolve-git-root.sh"
+if [[ -f "$RESOLVE_HELPER" ]]; then
+  source "$RESOLVE_HELPER" || { exit 0; }
+  PROJECT_ROOT="$GIT_COMMON_ROOT"
+else
+  # Fallback: use OPENHANDS_PROJECT_DIR or working_dir from input
+  PROJECT_ROOT="${OPENHANDS_PROJECT_DIR:-$(pwd)}"
+fi
+
+_RALPH_LOOP_PID="${RALPH_LOOP_PID:-$PPID}"
+RALPH_STATE_FILE="${PROJECT_ROOT}/.claude/ralph-loop.${_RALPH_LOOP_PID}.local.md"
+
+# --- Legacy Cleanup ---
+LEGACY_FILE="${PROJECT_ROOT}/.claude/ralph-loop.local.md"
+if [[ -f "$LEGACY_FILE" ]]; then
+  echo "Ralph loop: removing legacy state file (no session isolation)." >&2
+  rm -f "$LEGACY_FILE"
+fi
+
+# --- TTL Check: Auto-remove stale state files ---
+TTL_HOURS=1
+NOW_EPOCH=$(date +%s)
+for state_file in "${PROJECT_ROOT}/.claude"/ralph-loop.*.local.md; do
+  [[ -f "$state_file" ]] || continue
+  OWNER_PID=$(basename "$state_file" | sed 's/^ralph-loop\.\([0-9]*\)\.local\.md$/\1/')
+  if [[ "$OWNER_PID" =~ ^[0-9]+$ ]] && ! kill -0 "$OWNER_PID" 2>/dev/null; then
+    echo "Ralph loop: owner process $OWNER_PID is dead ($(basename "$state_file")). Auto-removing." >&2
+    rm -f "$state_file"
+    continue
+  fi
+  STARTED_AT=$(awk '/^---$/{c++; next} c==1' "$state_file" 2>/dev/null | grep '^started_at:' | sed 's/started_at: *//' | sed 's/^"\(.*\)"$/\1/' || true)
+  if [[ -n "$STARTED_AT" ]]; then
+    STARTED_EPOCH=$(date -d "$STARTED_AT" +%s 2>/dev/null || true)
+    if [[ -n "$STARTED_EPOCH" ]] && [[ $((NOW_EPOCH - STARTED_EPOCH)) -gt $((TTL_HOURS * 3600)) ]]; then
+      AGE_MINS=$(( (NOW_EPOCH - STARTED_EPOCH) / 60 ))
+      echo "Ralph loop: stale state file detected ($(basename "$state_file"), started ${AGE_MINS}m ago). Auto-removing." >&2
+      rm -f "$state_file"
+    fi
+  fi
+done
+
+# Check if ralph-loop is active for THIS session
+if [[ ! -f "$RALPH_STATE_FILE" ]]; then
+  exit 0
+fi
+
+# Read hook input from stdin
+HOOK_INPUT=$(cat)
+
+[[ -f "$RALPH_STATE_FILE" ]] || exit 0
+
+# Parse markdown frontmatter
+FRONTMATTER=$(awk '/^---$/{c++; next} c==1' "$RALPH_STATE_FILE" 2>/dev/null)
+if [[ -z "$FRONTMATTER" ]]; then
+  exit 0
+fi
+
+ITERATION=$(echo "$FRONTMATTER" | grep '^iteration:' | sed 's/iteration: *//' || true)
+MAX_ITERATIONS=$(echo "$FRONTMATTER" | grep '^max_iterations:' | sed 's/max_iterations: *//' || true)
+COMPLETION_PROMISE=$(echo "$FRONTMATTER" | grep '^completion_promise:' | sed 's/completion_promise: *//' | sed 's/^"\(.*\)"$/\1/' || true)
+
+STUCK_COUNT=$(echo "$FRONTMATTER" | grep '^stuck_count:' | sed 's/stuck_count: *//' || true)
+STUCK_THRESHOLD=$(echo "$FRONTMATTER" | grep '^stuck_threshold:' | sed 's/stuck_threshold: *//' || true)
+LAST_RESPONSE_HASH=$(echo "$FRONTMATTER" | grep '^last_response_hash:' | sed 's/last_response_hash: *//' || true)
+REPEAT_COUNT=$(echo "$FRONTMATTER" | grep '^repeat_count:' | sed 's/repeat_count: *//' || true)
+SIMILARITY_COUNT=$(echo "$FRONTMATTER" | grep '^similarity_count:' | sed 's/similarity_count: *//' || true)
+LAST_RESPONSE_WORDS=$(echo "$FRONTMATTER" | grep '^last_response_words:' | sed 's/last_response_words: *//' || true)
+
+# Defaults for backward compatibility
+[[ "$STUCK_COUNT" =~ ^[0-9]+$ ]] || STUCK_COUNT=0
+[[ "$STUCK_THRESHOLD" =~ ^[0-9]+$ ]] || STUCK_THRESHOLD=3
+[[ "$REPEAT_COUNT" =~ ^[0-9]+$ ]] || REPEAT_COUNT=0
+[[ "$SIMILARITY_COUNT" =~ ^[0-9]+$ ]] || SIMILARITY_COUNT=0
+
+if [[ ! "$ITERATION" =~ ^[0-9]+$ ]]; then
+  echo "Warning: Ralph loop state file corrupted (iteration: '$ITERATION'). Stopping." >&2
+  rm -f "$RALPH_STATE_FILE"
+  exit 0
+fi
+if [[ ! "$MAX_ITERATIONS" =~ ^[0-9]+$ ]]; then
+  echo "Warning: Ralph loop state file corrupted (max_iterations: '$MAX_ITERATIONS'). Stopping." >&2
+  rm -f "$RALPH_STATE_FILE"
+  exit 0
+fi
+
+if [[ $MAX_ITERATIONS -gt 0 ]] && [[ $ITERATION -ge $MAX_ITERATIONS ]]; then
+  echo "Ralph loop: Max iterations ($MAX_ITERATIONS) reached." >&2
+  rm -f "$RALPH_STATE_FILE"
+  exit 0
+fi
+
+HARD_CAP=50
+if [[ $ITERATION -ge $HARD_CAP ]]; then
+  echo "Ralph loop: Hard safety cap ($HARD_CAP iterations) reached. Auto-removing." >&2
+  rm -f "$RALPH_STATE_FILE"
+  exit 0
+fi
+
+# OpenHands passes metadata.reason instead of last_assistant_message.
+# Try last_assistant_message first (forward-compat), then metadata.reason.
+LAST_OUTPUT=$(echo "$HOOK_INPUT" | jq -r '.last_assistant_message // .metadata.reason // ""' 2>/dev/null || true)
+
+# Completion promise check
+if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
+  PROMISE_TEXT=$(echo "$LAST_OUTPUT" | perl -0777 -pe 's/.*?<promise>(.*?)<\/promise>.*/$1/s; s/^\s+|\s+$//g; s/\s+/ /g' 2>/dev/null || echo "")
+  if [[ -n "$PROMISE_TEXT" ]] && [[ "$PROMISE_TEXT" = "$COMPLETION_PROMISE" ]]; then
+    echo "Ralph loop: Detected <promise>$COMPLETION_PROMISE</promise>" >&2
+    rm -f "$RALPH_STATE_FILE"
+    exit 0
+  fi
+fi
+
+# --- Stuck Detection ---
+STRIPPED_OUTPUT=$(echo "$LAST_OUTPUT" | tr -d '[:space:]')
+RESPONSE_LENGTH=${#STRIPPED_OUTPUT}
+
+IS_IDLE=false
+if [[ $RESPONSE_LENGTH -lt 200 ]]; then
+  NORMALIZED_OUTPUT=$(echo "$LAST_OUTPUT" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' ' | sed 's/^ *//;s/ *$//')
+  if echo "$NORMALIZED_OUTPUT" | grep -iqE '(all (done|complete|finished)|all (slash )?commands? (are |have been )?(done|complete|finished|already)|nothing (left|pending|remaining|to do|to complete)|no (active|running|pending) (commands?|tasks?|slash commands?)|session (complete|finished|done|already)|already (done|complete|finished))'; then
+    IS_IDLE=true
+  fi
+fi
+
+# Repetition detection
+CURRENT_HASH=""
+if [[ -n "$STRIPPED_OUTPUT" ]]; then
+  CURRENT_HASH=$(echo "$STRIPPED_OUTPUT" | tr '[:upper:]' '[:lower:]' | md5sum | cut -d' ' -f1)
+fi
+if [[ -n "$CURRENT_HASH" ]] && [[ "$CURRENT_HASH" == "$LAST_RESPONSE_HASH" ]]; then
+  REPEAT_COUNT=$((REPEAT_COUNT + 1))
+else
+  REPEAT_COUNT=0
+fi
+LAST_RESPONSE_HASH="$CURRENT_HASH"
+
+if [[ "$IS_IDLE" == "true" ]] || [[ $RESPONSE_LENGTH -lt 150 ]]; then
+  STUCK_COUNT=$((STUCK_COUNT + 1))
+else
+  STUCK_COUNT=0
+fi
+
+if [[ $STUCK_THRESHOLD -gt 0 ]] && [[ $STUCK_COUNT -ge $STUCK_THRESHOLD ]]; then
+  echo "Ralph loop: terminated after $STUCK_COUNT consecutive empty/idle responses (stuck detection)" >&2
+  rm -f "$RALPH_STATE_FILE"
+  exit 0
+fi
+
+REPEAT_THRESHOLD=3
+if [[ $REPEAT_COUNT -ge $REPEAT_THRESHOLD ]]; then
+  echo "Ralph loop: terminated after $((REPEAT_COUNT + 1)) consecutive identical responses (repetition detection)" >&2
+  rm -f "$RALPH_STATE_FILE"
+  exit 0
+fi
+
+# Similarity detection
+CURRENT_WORDS=$(echo "$LAST_OUTPUT" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '\n' | sort -u | tr '\n' ' ' | sed 's/ $//')
+if [[ -n "$LAST_RESPONSE_WORDS" ]] && [[ -n "$CURRENT_WORDS" ]]; then
+  PREV_LINES=$(echo "$LAST_RESPONSE_WORDS" | tr ' ' '\n')
+  CURR_LINES=$(echo "$CURRENT_WORDS" | tr ' ' '\n')
+  PREV_N=$(echo "$PREV_LINES" | wc -l)
+  CURR_N=$(echo "$CURR_LINES" | wc -l)
+  COMMON=$(comm -12 <(echo "$PREV_LINES") <(echo "$CURR_LINES") | wc -l)
+  UNION=$(( PREV_N + CURR_N - COMMON ))
+  if [[ $UNION -gt 0 ]]; then
+    SIMILARITY=$((COMMON * 100 / UNION))
+  else
+    SIMILARITY=0
+  fi
+  if [[ $SIMILARITY -ge 80 ]]; then
+    SIMILARITY_COUNT=$((SIMILARITY_COUNT + 1))
+  else
+    SIMILARITY_COUNT=0
+  fi
+else
+  SIMILARITY_COUNT=0
+fi
+LAST_RESPONSE_WORDS="$CURRENT_WORDS"
+
+SIMILARITY_THRESHOLD=3
+if [[ $SIMILARITY_COUNT -ge $SIMILARITY_THRESHOLD ]]; then
+  echo "Ralph loop: terminated after $((SIMILARITY_COUNT + 1)) consecutive similar responses (similarity detection)" >&2
+  rm -f "$RALPH_STATE_FILE"
+  exit 0
+fi
+
+# Continue loop
+NEXT_ITERATION=$((ITERATION + 1))
+[[ -f "$RALPH_STATE_FILE" ]] || exit 0
+
+PROMPT_TEXT=$(awk '/^---$/{i++; next} i>=2' "$RALPH_STATE_FILE" 2>/dev/null)
+if [[ -z "$PROMPT_TEXT" ]]; then
+  echo "Warning: No prompt text in state file. Stopping." >&2
+  rm -f "$RALPH_STATE_FILE"
+  exit 0
+fi
+
+# Update state file
+TEMP_FILE="${RALPH_STATE_FILE}.tmp.$$"
+awk -v iter="$NEXT_ITERATION" -v sc="$STUCK_COUNT" -v lrh="$LAST_RESPONSE_HASH" -v rc="$REPEAT_COUNT" -v simc="$SIMILARITY_COUNT" -v lrw="$LAST_RESPONSE_WORDS" '
+  /^---$/ { c++; print; next }
+  c==1 && /^iteration:/ { print "iteration: " iter; next }
+  c==1 && /^stuck_count:/ { print "stuck_count: " sc; next }
+  c==1 && /^last_response_hash:/ { print "last_response_hash: " lrh; next }
+  c==1 && /^repeat_count:/ { print "repeat_count: " rc; next }
+  c==1 && /^similarity_count:/ { print "similarity_count: " simc; next }
+  c==1 && /^last_response_words:/ { print "last_response_words: " lrw; next }
+  { print }
+' "$RALPH_STATE_FILE" > "$TEMP_FILE" 2>/dev/null || true
+if [[ -s "$TEMP_FILE" ]]; then
+  mv "$TEMP_FILE" "$RALPH_STATE_FILE"
+else
+  rm -f "$TEMP_FILE"
+  exit 0
+fi
+
+# Build block response with prompt injection
+if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
+  SYSTEM_MSG="Ralph iteration $NEXT_ITERATION | To stop: output <promise>$COMPLETION_PROMISE</promise> (ONLY when statement is TRUE - do not lie to exit!)"
+else
+  SYSTEM_MSG="Ralph iteration $NEXT_ITERATION | No completion promise set - loop runs infinitely"
+fi
+
+# Block the stop and feed prompt back via reason field
+jq -n \
+  --arg reason "$PROMPT_TEXT" \
+  --arg msg "$SYSTEM_MSG" \
+  '{"decision":"deny","reason":($msg + "\n\n" + $reason)}'
+exit 2

--- a/.openhands/hooks/welcome-hook.sh
+++ b/.openhands/hooks/welcome-hook.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SessionStart hook: first-time Soleur welcome message.
+# OpenHands port of plugins/soleur/hooks/welcome-hook.sh.
+#
+# OpenHands protocol: exit 0 + JSON {"additionalContext":"..."} to inject context.
+# Input: HookEvent JSON on stdin with working_dir.
+
+set -euo pipefail
+
+INPUT=$(cat)
+PROJECT_DIR=$(echo "$INPUT" | jq -r '.working_dir // ""')
+[[ -z "$PROJECT_DIR" ]] && PROJECT_DIR="${OPENHANDS_PROJECT_DIR:-$(pwd)}"
+
+# Only run in projects that have the Soleur plugin installed locally.
+[[ -d "${PROJECT_DIR}/plugins/soleur" ]] || exit 0
+
+SENTINEL_FILE="${PROJECT_DIR}/.claude/soleur-welcomed.local"
+[[ -f "$SENTINEL_FILE" ]] && exit 0
+
+mkdir -p "${PROJECT_DIR}/.claude" 2>/dev/null || true
+touch "$SENTINEL_FILE" 2>/dev/null || true
+
+jq -n '{"additionalContext":"Welcome to Soleur! This appears to be the first session with Soleur installed. Suggest the user run /soleur:sync to analyze their project, or /soleur:help to see all available commands."}'
+exit 0

--- a/.openhands/hooks/worktree-write-guard.sh
+++ b/.openhands/hooks/worktree-write-guard.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# PreToolUse hook for file_editor tool.
+# Blocks file writes to the main repo checkout when worktrees exist.
+# OpenHands port of .claude/hooks/worktree-write-guard.sh.
+#
+# OpenHands protocol: exit 2 + JSON {"decision":"deny","reason":"..."} to block.
+# Input: HookEvent JSON on stdin with tool_input.path and working_dir.
+# OpenHands file_editor uses "path" (not "file_path" like Claude Code).
+#
+# Corresponding prose rules: see .claude/hooks/worktree-write-guard.sh
+
+set -euo pipefail
+
+INPUT=$(cat)
+# OpenHands file_editor uses "path"; fall back to "file_path" for compatibility
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.path // .tool_input.file_path // ""')
+
+[[ -z "$FILE_PATH" ]] && exit 0
+
+# Get the main repo root (not the worktree root).
+GIT_ROOT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||' || exit 0)
+
+# If file path is not under the repo root, allow it
+[[ "$FILE_PATH" != "$GIT_ROOT"* ]] && exit 0
+
+# If file path is inside a worktree, allow it
+[[ "$FILE_PATH" == *"/.worktrees/"* ]] && exit 0
+
+# Allow writes to .claude/ and .openhands/ directories
+RELATIVE_PATH="${FILE_PATH#"$GIT_ROOT"/}"
+[[ "$RELATIVE_PATH" == .claude/* ]] && exit 0
+[[ "$RELATIVE_PATH" == .openhands/* ]] && exit 0
+
+# Check if any worktrees exist
+WORKTREE_DIR="$GIT_ROOT/.worktrees"
+if [[ -d "$WORKTREE_DIR" ]] && [[ -n "$(ls -A "$WORKTREE_DIR" 2>/dev/null)" ]]; then
+  WORKTREE_NAMES=$(ls "$WORKTREE_DIR" 2>/dev/null | head -3 | tr '\n' ', ' | sed 's/,$//')
+  jq -n --arg names "$WORKTREE_NAMES" --arg path "$GIT_ROOT/.worktrees/<name>/$RELATIVE_PATH" \
+    '{"decision":"deny","reason":("BLOCKED: Writing to main repo checkout while worktrees exist (" + $names + "). Write to the worktree path instead: " + $path)}'
+  exit 2
+fi
+
+exit 0

--- a/knowledge-base/project/learnings/workflow-patterns/2026-04-09-openhands-hook-protocol-differences.md
+++ b/knowledge-base/project/learnings/workflow-patterns/2026-04-09-openhands-hook-protocol-differences.md
@@ -1,0 +1,51 @@
+---
+title: "OpenHands hook protocol differences from Claude Code"
+date: 2026-04-09
+issue: 1778
+category: workflow-patterns
+tags: [openhands, hooks, porting, protocol]
+---
+
+# OpenHands Hook Protocol Differences
+
+## Context
+
+Ported 5 Claude Code hooks to OpenHands `.openhands/hooks.json` format for #1778.
+
+## Key Protocol Differences
+
+### Blocking mechanism
+
+- **Claude Code:** Output JSON with `hookSpecificOutput.permissionDecision: "deny"`, exit 0.
+- **OpenHands:** Output JSON with `{"decision":"deny","reason":"..."}`, exit 2. Either exit code 2 OR `decision: "deny"` triggers blocking.
+
+### Input format
+
+- **Claude Code:** `tool_input.command` for Bash, `tool_input.file_path` for Write/Edit, `.cwd` for working directory.
+- **OpenHands:** `tool_input.command` for terminal (same), `tool_input.path` for file_editor (not `file_path`), `working_dir` top-level field.
+
+### Tool names
+
+| Claude Code | OpenHands |
+|---|---|
+| Bash | terminal |
+| Write\|Edit | file_editor |
+| TodoWrite | task_tracker |
+
+### Stop hook differences
+
+- Claude Code passes `last_assistant_message` in stdin JSON for stuck/repetition detection.
+- OpenHands passes `metadata.reason` (the agent's stop reason). Content is shorter and less suitable for similarity analysis but sufficient for basic idle detection.
+
+### Environment variables
+
+OpenHands injects `OPENHANDS_PROJECT_DIR`, `OPENHANDS_SESSION_ID`, `OPENHANDS_EVENT_TYPE`, `OPENHANDS_TOOL_NAME` into hook environment.
+
+### Config format
+
+- Claude Code: `.claude/settings.json` → `hooks.PreToolUse[].matcher` with PascalCase event types.
+- OpenHands: `.openhands/hooks.json` → `pre_tool_use[].matcher` with snake_case keys. PascalCase is also accepted via `_normalize_hooks_input`.
+
+## Gotcha
+
+The worktree-write-guard must allow writes to `.openhands/` in addition to `.claude/` — otherwise the OpenHands hooks directory itself gets blocked by the guard.


### PR DESCRIPTION
## Summary

Port all 5 Claude Code hooks to OpenHands `.openhands/hooks.json` format.

## Changes

### New files (`.openhands/`)

- **`.openhands/hooks.json`** — Hook config with `pre_tool_use` (terminal + file_editor matchers), `session_start`, and `stop` definitions
- **`.openhands/hooks/guardrails.sh`** — Blocks commits on main, rm -rf worktrees, stash in worktrees, gh issue without milestone, delete-branch with active worktrees, conflict markers
- **`.openhands/hooks/pre-merge-rebase.sh`** — Review evidence gate + auto-sync origin/main before `gh pr merge`
- **`.openhands/hooks/worktree-write-guard.sh`** — Blocks writes to main checkout when worktrees exist
- **`.openhands/hooks/welcome-hook.sh`** — First-time Soleur welcome via `additionalContext`
- **`.openhands/hooks/stop-hook.sh`** — Ralph loop stop prevention with stuck/repetition/similarity detection

### Modified files

- **`.claude/hooks/worktree-write-guard.sh`** — Added `.openhands/*` to the allowlist

## Protocol Translation

| Aspect | Claude Code | OpenHands |
|---|---|---|
| Block signal | `hookSpecificOutput.permissionDecision: deny` + exit 0 | `decision: deny` + exit 2 |
| Tool names | `Bash`, `Write\|Edit` | `terminal`, `file_editor` |
| File path field | `tool_input.file_path` | `tool_input.path` |
| Working dir | `.cwd` | `working_dir` top-level |
| Stop content | `last_assistant_message` | `metadata.reason` |

## Testing

All hooks tested with simulated OpenHands `HookEvent` JSON:
- ✅ guardrails: 6 guards tested
- ✅ worktree-write-guard: block/allow/allowlist
- ✅ welcome-hook: trigger + sentinel
- ✅ stop-hook: allow exit / block with ralph loop
- ✅ pre-merge-rebase: passthrough / sync
- ✅ hooks.json schema validation

Closes #1778

_This PR was created by an AI assistant (OpenHands) on behalf of the user._