### PR TITLE
docs: add Ollama instructions to getting started page

### DIFF
--- a/knowledge-base/project/specs/feat-docs-ollama-instructions/session-state.md
+++ b/knowledge-base/project/specs/feat-docs-ollama-instructions/session-state.md
@@ -1,0 +1,23 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/knowledge-base/project/plans/2026-04-10-docs-add-ollama-instructions-plan.md
+- Status: complete
+
+### Errors
+None
+
+### Decisions
+- Target File: Identified `plugins/soleur/docs/pages/getting-started.njk` as the primary location for adding Ollama instructions.
+- Content: Focused on adding the specific command `ollama launch claude --model gemma4:31b-cloud`.
+- Scope: Update existing "Getting Started" page.
+- Domain: Purely technical documentation update.
+
+### Components Invoked
+- soleur:plan
+- soleur:deepen-plan
+- Bash
+- Read
+- Grep
+- Glob
+- Write

--- a/plugins/soleur/docs/pages/getting-started.njk
+++ b/plugins/soleur/docs/pages/getting-started.njk
@@ -63,8 +63,8 @@ claude plugin install soleur</code></pre>
           <strong>Starting fresh?</strong> Run <code>/soleur:go</code> and describe what you need.
         </div>
 
-        <div class="callout" style="margin-top: var(--space-4); border-color: var(--color-purple-400); background-color: var(--color-purple-50);">
-          <strong>Running with Ollama?</strong> Use the command <code class="inline-code">ollama launch claude --model gemma4:31b-cloud</code> to start Soleur with your preferred local model.
+        <div class="callout">
+          <strong>Running with Ollama?</strong> Use the command <code>ollama launch claude --model gemma4:31b-cloud</code> to start Soleur with your preferred local model.
         </div>
 
         <h3 class="section-subtitle" style="margin-top: var(--space-8);">The Workflow</h3>
@@ -170,7 +170,7 @@ claude plugin install soleur</code></pre>
         <div class="faq-list">
           <details class="faq-item">
             <summary class="faq-question">What do I need to run Soleur?</summary>
-            <p class="faq-answer">For the self-hosted version, you need the Claude Code CLI with an Anthropic API key or a Claude subscription. Alternatively, you can run Soleur using Ollama via the <code class="inline-code">ollama launch</code> command. First, add the Soleur marketplace with <code>claude plugin marketplace add jikig-ai/soleur</code>, then install with <code>claude plugin install soleur</code> and run <code>/soleur:go</code> to start. No additional dependencies or server setup needed. The cloud platform (coming soon) requires only a browser and a Soleur subscription.</p>
+            <p class="faq-answer">For the self-hosted version, you need the Claude Code CLI with an Anthropic API key or a Claude subscription. Alternatively, you can run Soleur using Ollama via the <code>ollama launch</code> command. First, add the Soleur marketplace with <code>claude plugin marketplace add jikig-ai/soleur</code>, then install with <code>claude plugin install soleur</code> and run <code>/soleur:go</code> to start. No additional dependencies or server setup needed. The cloud platform (coming soon) requires only a browser and a Soleur subscription.</p>
           </details>
           <details class="faq-item">
             <summary class="faq-question">Does Soleur work on Windows, Linux, and macOS?</summary>
@@ -206,7 +206,7 @@ claude plugin install soleur</code></pre>
           "name": "What do I need to run Soleur?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "For the self-hosted version, you need the Claude Code CLI with an Anthropic API key or a Claude subscription. First, add the Soleur marketplace with claude plugin marketplace add jikig-ai/soleur, then install with claude plugin install soleur and run /soleur:go to start. The cloud platform (coming soon) requires only a browser and a Soleur subscription."
+            "text": "For the self-hosted version, you need the Claude Code CLI with an Anthropic API key or a Claude subscription. Alternatively, you can run Soleur using Ollama via the ollama launch command. First, add the Soleur marketplace with claude plugin marketplace add jikig-ai/soleur, then install with claude plugin install soleur and run /soleur:go to start. No additional dependencies or server setup needed. The cloud platform (coming soon) requires only a browser and a Soleur subscription."
           }
         },
         {

--- a/plugins/soleur/docs/pages/getting-started.njk
+++ b/plugins/soleur/docs/pages/getting-started.njk
@@ -63,6 +63,10 @@ claude plugin install soleur</code></pre>
           <strong>Starting fresh?</strong> Run <code>/soleur:go</code> and describe what you need.
         </div>
 
+        <div class="callout" style="margin-top: var(--space-4); border-color: var(--color-purple-400); background-color: var(--color-purple-50);">
+          <strong>Running with Ollama?</strong> Use the command <code class="inline-code">ollama launch claude --model gemma4:31b-cloud</code> to start Soleur with your preferred local model.
+        </div>
+
         <h3 class="section-subtitle" style="margin-top: var(--space-8);">The Workflow</h3>
         <p>Soleur follows a structured 5-step workflow for software development:</p>
 
@@ -166,7 +170,7 @@ claude plugin install soleur</code></pre>
         <div class="faq-list">
           <details class="faq-item">
             <summary class="faq-question">What do I need to run Soleur?</summary>
-            <p class="faq-answer">For the self-hosted version, you need the Claude Code CLI with an Anthropic API key or a Claude subscription. First, add the Soleur marketplace with <code>claude plugin marketplace add jikig-ai/soleur</code>, then install with <code>claude plugin install soleur</code> and run <code>/soleur:go</code> to start. No additional dependencies or server setup needed. The cloud platform (coming soon) requires only a browser and a Soleur subscription.</p>
+            <p class="faq-answer">For the self-hosted version, you need the Claude Code CLI with an Anthropic API key or a Claude subscription. Alternatively, you can run Soleur using Ollama via the <code class="inline-code">ollama launch</code> command. First, add the Soleur marketplace with <code>claude plugin marketplace add jikig-ai/soleur</code>, then install with <code>claude plugin install soleur</code> and run <code>/soleur:go</code> to start. No additional dependencies or server setup needed. The cloud platform (coming soon) requires only a browser and a Soleur subscription.</p>
           </details>
           <details class="faq-item">
             <summary class="faq-question">Does Soleur work on Windows, Linux, and macOS?</summary>


### PR DESCRIPTION
## Summary
- Add Ollama callout to the getting started page with the `ollama launch claude --model gemma4:31b-cloud` command
- Update FAQ answer for "What do I need to run Soleur?" to mention Ollama as an alternative
- Sync JSON-LD structured data to match the updated FAQ text

## Changelog
- Added Ollama instructions callout to the self-hosted installation section
- Updated FAQ text and structured data to mention Ollama as an alternative runtime

## Test plan
- [x] All test suites pass (9/9)
- [x] README counts in sync
- [x] Code review completed (#1811, #1812, #1813 — all resolved)
- [x] No inline styles or nonexistent CSS classes in the template
- [x] JSON-LD structured data matches visible FAQ content

Generated with [Claude Code](https://claude.com/claude-code)