### PR TITLE
docs: add Ollama instructions to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ claude plugin install soleur
 claude plugin install --url https://github.com/jikig-ai/soleur/tree/main/plugins/soleur
 ```
 
+**Running with Ollama?** Use `ollama launch claude --model gemma4:31b-cloud` to start Soleur with your preferred local model.
+
 **For existing codebases:** Run `/soleur:sync` first to populate your knowledge-base with conventions and patterns.
 
 ## The Workflow

--- a/plugins/soleur/README.md
+++ b/plugins/soleur/README.md
@@ -10,6 +10,8 @@ Install the plugin:
 claude plugin install soleur
 ```
 
+**Running with Ollama?** Use `ollama launch claude --model gemma4:31b-cloud` to start Soleur with your preferred local model.
+
 ## The Soleur Workflow
 
 The recommended way to use Soleur is through the unified entry point:


### PR DESCRIPTION
## Summary
- Add Ollama launch command to root README and plugin README installation sections
- Mirrors the instructions already added to the docs site in #1810

## Changelog
- Added Ollama instructions to root README.md (Installation section)
- Added Ollama instructions to plugins/soleur/README.md (Quick Start section)

## Test plan
- [x] All test suites pass (9/9)
- [x] README counts in sync
- [x] Markdown lint passes

Generated with [Claude Code](https://claude.com/claude-code)