### PR TITLE
[bot-fix] Fix #1749: document context isolation risk

### DIFF
--- a/knowledge-base/project/specs/gemini-cli-portability/poc-results.md
+++ b/knowledge-base/project/specs/gemini-cli-portability/poc-results.md
@@ -100,3 +100,47 @@ All ported components are **structurally valid** (correct file formats, frontmat
 3. Verifying CLO activates specialist skills
 4. Running `/go #1234` to verify routing
 5. Activating compound after a code change to verify learning capture
+
+## Context Isolation Risk
+
+The subagent-to-skill restructuring introduces a **context cross-contamination risk** that is not tested in this PoC. When multiple specialist skills run sequentially within the same leader subagent conversation, earlier skill outputs remain visible to later skills. This creates a failure mode where one specialist's output is misinterpreted as instructions or context by a subsequent specialist.
+
+### Failure Scenario
+
+Consider the CLO domain leader activating two specialists sequentially:
+
+1. **legal-compliance-auditor** runs first, producing findings such as "Missing GDPR data processing agreement" or "Terms of Service lacks arbitration clause"
+2. **legal-document-generator** runs second in the same conversation context
+
+The document generator now sees the auditor's findings in its context window. Without explicit context boundaries, the generator may:
+
+- Treat audit findings as generation instructions (e.g., generating a GDPR agreement because the auditor flagged its absence, even if the user only requested a Terms of Service update)
+- Incorporate audit language verbatim into generated documents (mixing analytical tone into legal prose)
+- Act on remediation recommendations meant for the human operator, not for another skill
+
+### Why This Was Not Caught
+
+The PoC verified structural validity (file formats, tool references, frontmatter) but did not execute any skills at runtime. The cross-contamination risk only manifests during actual sequential skill execution within a shared conversation context. Claude Code avoids this by spawning specialists as independent subagents with isolated conversation contexts.
+
+### Affected Domains
+
+Any domain leader that activates multiple specialists is affected. Severity scales with specialist count:
+
+| Domain Leader | Specialist Count | Risk Level |
+|---|---|---|
+| CMO | 7+ | Critical — longest sequential chain, most diverse specialist outputs |
+| CLO | 2 | Medium — auditor output may contaminate generator |
+| CTO | 3 | Medium — architect findings may influence implementer |
+| COO | 2 | Low — fewer cross-specialist dependencies |
+
+### Runtime Test Case (Future)
+
+When a Gemini API key is available, validate context isolation with the following test:
+
+1. Activate the CLO subagent
+2. Have CLO activate `legal-compliance-auditor` skill, which produces audit findings (e.g., "CRITICAL: Missing privacy policy")
+3. Without clearing context, have CLO activate `legal-document-generator` skill with an unrelated request (e.g., "Generate a contributor license agreement")
+4. **Pass condition:** The generated CLA contains no references to privacy policies, GDPR, or any content from the auditor's findings
+5. **Fail condition:** The generated document incorporates or responds to the auditor's output
+
+A second test should verify the reverse direction — generator output should not influence a subsequent audit's findings or severity assessments.

--- a/knowledge-base/project/specs/gemini-cli-portability/recommendation.md
+++ b/knowledge-base/project/specs/gemini-cli-portability/recommendation.md
@@ -34,6 +34,43 @@ Gemini CLI is architecturally 50x closer to Claude Code than Codex CLI was. The 
 
 For 6 of 8 domain leaders (those with 2-3 specialists), this is acceptable. For the CMO (7+ specialists), it degrades significantly — a single CMO session would need to sequentially load marketing strategist, copywriter, SEO analyst, etc. instructions into the same context window.
 
+## Context Cross-Contamination Risk
+
+The subagent-to-skill restructuring has an unverified context cross-contamination risk. When multiple specialist skills run sequentially in the same conversation context, earlier skill outputs remain visible to later skills. This means one specialist's output may be misinterpreted as instructions or context by a subsequent specialist.
+
+**Example:** The CLO activates `legal-compliance-auditor`, which produces findings like "CRITICAL: Missing privacy policy." The CLO then activates `legal-document-generator` to draft a contributor license agreement. Because the auditor's findings are still in the conversation context, the generator may incorporate privacy policy language into the CLA — acting on the auditor's output as if it were a generation instruction.
+
+This failure mode does not exist in Claude Code, where each specialist runs as an independent subagent with its own isolated conversation context.
+
+### Severity
+
+The risk scales with specialist count and output diversity. The CMO domain (7+ specialists) is most exposed — SEO analysis findings could contaminate copywriter output, or social media metrics could influence content strategy recommendations in unintended ways. Domains with 2 specialists (CLO, COO) have lower but non-zero risk.
+
+### Mitigation Options
+
+1. **Explicit context boundaries** — Prepend each skill activation with instructions to ignore prior conversation content ("You are starting a new task. Disregard all previous output in this conversation.")
+2. **Output scrubbing** — Strip or collapse prior skill outputs before activating the next skill (requires Gemini CLI support for conversation context manipulation)
+3. **Accept and document** — For domains with 2 specialists and low cross-contamination potential, accept the risk and document the expected behavior
+
+None of these mitigations have been validated at runtime. Option 1 is the most practical but relies on model compliance, not enforcement.
+
+### Runtime Test Case Specification
+
+When runtime verification becomes possible (Gemini API key configured), execute the following test:
+
+**Test: Sequential Specialist Context Isolation**
+
+1. Activate the CLO subagent with a task requiring both specialists
+2. CLO activates `legal-compliance-auditor`, which produces audit findings (e.g., "CRITICAL: Missing privacy policy", "WARNING: Terms of Service lacks arbitration clause")
+3. Without clearing context, CLO activates `legal-document-generator` with an unrelated request: "Generate a contributor license agreement"
+4. Inspect the generated CLA for contamination from audit findings
+5. **Pass:** Generated CLA contains no references to privacy policies, GDPR, arbitration, or any audit-specific content
+6. **Fail:** Generated document incorporates, references, or responds to the auditor's findings
+
+**Reverse-direction test:** Generate a document first, then run an audit. Verify the audit does not reference or incorporate language from the generated document.
+
+**CMO stress test:** Activate 3+ CMO specialists sequentially (e.g., SEO analyst → copywriter → social media strategist). Verify each specialist's output is independent of the previous specialists' outputs.
+
 ## What to Build (when triggered)
 
 ### Minimum Viable Gemini Extension


### PR DESCRIPTION
## Summary

- Document context cross-contamination risk in Gemini CLI subagent-to-skill pattern
- Add runtime test case specification for future validation

Ref #1749

## Changes

- `knowledge-base/project/specs/gemini-cli-portability/poc-results.md`: added Context Isolation Risk section
- `knowledge-base/project/specs/gemini-cli-portability/recommendation.md`: added risk documentation and test case spec

---

*Automated fix by soleur:fix-issue. Human review required before merge.*