### PR TITLE
[bot-fix] Fix #1750: Gemini CLI hook enforcement audit

### DIFF
--- a/knowledge-base/project/specs/gemini-cli-portability/recommendation.md
+++ b/knowledge-base/project/specs/gemini-cli-portability/recommendation.md
@@ -108,6 +108,48 @@ Invest in the Gemini CLI extension when ANY of:
 | Full extension (agents + 5 core pipeline skills) | 1-2 weeks | Degraded but functional workflow pipeline |
 | Dual-harness abstraction layer | 4+ weeks | Full parity — not recommended |
 
+## Hook-to-Policy Enforcement Mapping
+
+The portability inventory identifies `hookSpecificOutput` as the sole RED blocker (no Gemini CLI equivalent). However, this understates the impact: Claude Code's `.claude/hooks/` scripts enforce 9 distinct guardrails via `hookSpecificOutput`. On Gemini CLI, enforcement must map to one of three mechanisms:
+
+1. **Gemini CLI Policy Engine** (`.toml` tool-blocking rules) -- can block tools entirely or by pattern, but cannot inspect tool arguments
+2. **Gemini CLI hooks** (stdin/stdout JSON) -- exist but use a different protocol than `hookSpecificOutput`; scripts would need rewriting but the enforcement mechanism is present
+3. **Model compliance** (GEMINI.md instructions) -- advisory only, the model can ignore the instruction
+
+### Enforcement Tiers
+
+| # | Guard | Hook Script | Tool | Enforcement | Gemini CLI Mechanism | Classification | Notes |
+|---|---|---|---|---|---|---|---|
+| 1 | block-commit-on-main | guardrails.sh | Bash | Blocks `git commit` when branch is main/master | Gemini CLI hooks (rewrite) | **Degraded** | Requires rewriting to Gemini CLI hook protocol. Policy Engine cannot inspect shell command arguments to detect `git commit` specifically. Hook exists but must parse stdin JSON differently and return stdout JSON in Gemini's format, not `hookSpecificOutput`. |
+| 2 | block-rm-rf-worktrees | guardrails.sh | Bash | Blocks `rm -rf` on `.worktrees/` paths | Gemini CLI hooks (rewrite) | **Degraded** | Same as above -- command argument inspection requires hook rewrite. Policy Engine's tool-blocking is too coarse (would block all shell commands). |
+| 3 | block-delete-branch | guardrails.sh | Bash | Blocks `gh pr merge --delete-branch` with active worktrees | Gemini CLI hooks (rewrite) | **Degraded** | Requires hook rewrite. Needs both command parsing and worktree state inspection -- only achievable via a hook script, not policy rules. |
+| 4 | block-conflict-markers | guardrails.sh | Bash | Blocks commits when staged content contains `<<<<<<<`/`=======`/`>>>>>>>` | Gemini CLI hooks (rewrite) | **Degraded** | Requires hook rewrite. Inspects `git diff --cached` output -- stateful check that cannot be expressed as a static policy rule. |
+| 5 | require-milestone | guardrails.sh | Bash | Blocks `gh issue create` without `--milestone` | Gemini CLI hooks (rewrite) | **Degraded** | Requires hook rewrite. Inspects command arguments for presence of `--milestone` flag. |
+| 6 | block-stash-in-worktrees | guardrails.sh | Bash | Blocks `git stash` when CWD is inside `.worktrees/` | Gemini CLI hooks (rewrite) | **Degraded** | Requires hook rewrite. Needs both command detection and filesystem path inspection. |
+| 7 | worktree-write-guard | worktree-write-guard.sh | Write, Edit | Blocks file writes to main repo checkout when worktrees exist | GEMINI.md instruction | **Lost** | Gemini CLI hooks fire on shell tool usage. Write/Edit are separate tools in Claude Code but map to `write_file`/`edit_file` in Gemini CLI. Gemini CLI does not support PreToolUse hooks on file-write tools -- only shell commands. The guard must rely on model compliance via GEMINI.md instructions. |
+| 8 | review-evidence-gate | pre-merge-rebase.sh | Bash | Blocks `gh pr merge` without review evidence (code-review todos, commits, or GitHub issues) | Gemini CLI hooks (rewrite) | **Degraded** | Requires hook rewrite. Complex multi-signal check (local files, git log, GitHub API) but all logic is shell-based and portable. The hook protocol change is the only barrier. |
+| 9 | auto-sync-before-merge | pre-merge-rebase.sh | Bash | Merges origin/main into feature branch before `gh pr merge` | Gemini CLI hooks (rewrite) | **Degraded** | Requires hook rewrite. Performs `git fetch` + `git merge` + `git push` -- all portable shell operations. The enforcement mechanism (intercepting `gh pr merge`) needs the Gemini CLI hook protocol. |
+
+### Classification Summary
+
+| Classification | Count | Description |
+|---|---|---|
+| **Recoverable** | 0 | Policy Engine can replicate enforcement without code changes |
+| **Degraded** | 8 | Gemini CLI hooks can enforce, but scripts require rewriting to the different hook protocol (stdin/stdout JSON format differs from `hookSpecificOutput`) |
+| **Lost** | 1 | No hook mechanism exists for file-write tool interception; enforcement relies on model compliance only |
+
+### Analysis
+
+The assessment is more favorable than the inventory's RED classification implied. The Gemini CLI does have a hook system -- it is not `hookSpecificOutput`, but it serves the same purpose (intercept tool calls, inspect arguments, allow/deny). Of the 9 guardrails:
+
+- **8 of 9 guards are degraded, not lost.** They require rewriting the hook scripts to use Gemini CLI's hook protocol (different JSON schema on stdin/stdout), but the enforcement mechanism exists. The shell logic (branch detection, conflict marker scanning, worktree inspection) is fully portable -- only the I/O wrapper changes.
+- **1 of 9 guards is lost.** The worktree-write-guard intercepts Write/Edit tool calls (file operations), not shell commands. Gemini CLI's hook system appears limited to shell command interception. File-write guardrails would need to rely on model compliance via GEMINI.md instructions, which is advisory-only.
+- **0 of 9 guards are recoverable via the Policy Engine.** The Policy Engine's `.toml` tool-blocking operates at the tool level (block `run_shell_command` entirely), not at the argument level (block `run_shell_command` only when the command contains `git commit` on `main`). None of Soleur's guardrails are simple tool blocks -- they all require argument or state inspection.
+
+### Effort Impact
+
+The 8 degraded hooks add ~1 day to the Gemini CLI extension effort (rewriting the I/O wrapper while keeping shell logic). This should be added to the "Full extension" row in the estimated effort table. The 1 lost hook (worktree-write-guard) is a known-accepted risk -- agents writing to the wrong path is a workflow inconvenience, not a data loss vector.
+
 ## Follow-up Issues
 
 If proceeding to build:


### PR DESCRIPTION
## Summary

- Add hook-to-policy mapping table to Gemini CLI portability recommendation
- Classify each of the 9 hook guardrails as recoverable/degraded/lost for Gemini CLI Policy Engine
- Finding: 8 of 9 are degraded (hook rewrite needed), 1 is lost (file-write interception), 0 are recoverable via Policy Engine

Ref #1750

## Changes

- `knowledge-base/project/specs/gemini-cli-portability/recommendation.md`: added enforcement tier mapping table with per-guard classification, summary, analysis, and effort impact

---

*Automated fix by soleur:fix-issue. Human review required before merge.*