### PR TITLE
[bot-fix] Fix #1752: config-driven token validators

### DIFF
--- a/apps/web-platform/server/token-validators.ts
+++ b/apps/web-platform/server/token-validators.ts
@@ -2,135 +2,78 @@ import type { Provider } from "@/lib/types";
 
 const VALIDATION_TIMEOUT_MS = 5_000;
 
-async function fetchWithTimeout(
-  url: string,
-  init: RequestInit,
-): Promise<Response> {
-  return fetch(url, { ...init, signal: AbortSignal.timeout(VALIDATION_TIMEOUT_MS) });
+interface ValidatorConfig {
+  url: string;
+  headers: (token: string) => Record<string, string>;
+  method?: string;
 }
 
-// --- Per-provider validators ---
-
-async function validateAnthropic(token: string): Promise<boolean> {
-  const res = await fetchWithTimeout("https://api.anthropic.com/v1/models", {
+const VALIDATOR_CONFIGS: Partial<Record<Provider, ValidatorConfig>> = {
+  anthropic: {
+    url: "https://api.anthropic.com/v1/models",
+    headers: (token) => ({ "x-api-key": token, "anthropic-version": "2023-06-01" }),
     method: "GET",
-    headers: { "x-api-key": token, "anthropic-version": "2023-06-01" },
-  });
-  return res.ok;
-}
-
-async function validateCloudflare(token: string): Promise<boolean> {
-  const res = await fetchWithTimeout(
-    "https://api.cloudflare.com/client/v4/user/tokens/verify",
-    { headers: { Authorization: `Bearer ${token}` } },
-  );
-  return res.ok;
-}
-
-async function validateStripe(token: string): Promise<boolean> {
-  const res = await fetchWithTimeout("https://api.stripe.com/v1/balance", {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  return res.ok;
-}
-
-async function validatePlausible(token: string): Promise<boolean> {
-  const res = await fetchWithTimeout(
-    "https://plausible.io/api/v1/stats/realtime/visitors?site_id=soleur.ai",
-    { headers: { Authorization: `Bearer ${token}` } },
-  );
-  // 200 = valid token (may return 0 visitors), 401/403 = invalid
-  return res.ok;
-}
-
-async function validateHetzner(token: string): Promise<boolean> {
-  const res = await fetchWithTimeout(
-    "https://api.hetzner.cloud/v1/servers?per_page=1",
-    { headers: { Authorization: `Bearer ${token}` } },
-  );
-  return res.ok;
-}
-
-async function validateGithub(token: string): Promise<boolean> {
-  const res = await fetchWithTimeout("https://api.github.com/user", {
-    headers: { Authorization: `Bearer ${token}`, "User-Agent": "soleur" },
-  });
-  return res.ok;
-}
-
-async function validateDoppler(token: string): Promise<boolean> {
-  const res = await fetchWithTimeout("https://api.doppler.com/v3/me", {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  return res.ok;
-}
-
-async function validateResend(token: string): Promise<boolean> {
-  const res = await fetchWithTimeout("https://api.resend.com/api-keys", {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  return res.ok;
-}
-
-async function validateX(token: string): Promise<boolean> {
-  const res = await fetchWithTimeout("https://api.x.com/2/users/me", {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  return res.ok;
-}
-
-async function validateLinkedin(token: string): Promise<boolean> {
-  const res = await fetchWithTimeout("https://api.linkedin.com/v2/userinfo", {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  return res.ok;
-}
-
-async function validateBluesky(token: string): Promise<boolean> {
-  // Use describeServer to avoid createSession side effect.
-  // describeServer is unauthenticated, so we fall back to getProfile.
-  const res = await fetchWithTimeout(
-    "https://bsky.social/xrpc/app.bsky.actor.getProfile?actor=self",
-    { headers: { Authorization: `Bearer ${token}` } },
-  );
-  return res.ok;
-}
-
-async function validateButtondown(token: string): Promise<boolean> {
-  const res = await fetchWithTimeout(
-    "https://api.buttondown.com/v1/emails?page_size=1",
-    { headers: { Authorization: `Token ${token}` } },
-  );
-  return res.ok;
-}
-
-// --- Registry ---
-
-const VALIDATORS: Partial<Record<Provider, (token: string) => Promise<boolean>>> = {
-  anthropic: validateAnthropic,
-  cloudflare: validateCloudflare,
-  stripe: validateStripe,
-  plausible: validatePlausible,
-  hetzner: validateHetzner,
-  github: validateGithub,
-  doppler: validateDoppler,
-  resend: validateResend,
-  x: validateX,
-  linkedin: validateLinkedin,
-  bluesky: validateBluesky,
-  buttondown: validateButtondown,
+  },
+  cloudflare: {
+    url: "https://api.cloudflare.com/client/v4/user/tokens/verify",
+    headers: (token) => ({ Authorization: `Bearer ${token}` }),
+  },
+  stripe: {
+    url: "https://api.stripe.com/v1/balance",
+    headers: (token) => ({ Authorization: `Bearer ${token}` }),
+  },
+  plausible: {
+    url: "https://plausible.io/api/v1/stats/realtime/visitors?site_id=soleur.ai",
+    headers: (token) => ({ Authorization: `Bearer ${token}` }),
+  },
+  hetzner: {
+    url: "https://api.hetzner.cloud/v1/servers?per_page=1",
+    headers: (token) => ({ Authorization: `Bearer ${token}` }),
+  },
+  github: {
+    url: "https://api.github.com/user",
+    headers: (token) => ({ Authorization: `Bearer ${token}`, "User-Agent": "soleur" }),
+  },
+  doppler: {
+    url: "https://api.doppler.com/v3/me",
+    headers: (token) => ({ Authorization: `Bearer ${token}` }),
+  },
+  resend: {
+    url: "https://api.resend.com/api-keys",
+    headers: (token) => ({ Authorization: `Bearer ${token}` }),
+  },
+  x: {
+    url: "https://api.x.com/2/users/me",
+    headers: (token) => ({ Authorization: `Bearer ${token}` }),
+  },
+  linkedin: {
+    url: "https://api.linkedin.com/v2/userinfo",
+    headers: (token) => ({ Authorization: `Bearer ${token}` }),
+  },
+  bluesky: {
+    url: "https://bsky.social/xrpc/app.bsky.actor.getProfile?actor=self",
+    headers: (token) => ({ Authorization: `Bearer ${token}` }),
+  },
+  buttondown: {
+    url: "https://api.buttondown.com/v1/emails?page_size=1",
+    headers: (token) => ({ Authorization: `Token ${token}` }),
+  },
 };
 
 export async function validateToken(
   provider: Provider,
   token: string,
 ): Promise<boolean> {
-  const validator = VALIDATORS[provider];
-  if (!validator) return false;
+  const config = VALIDATOR_CONFIGS[provider];
+  if (!config) return false;
   try {
-    return await validator(token);
+    const res = await fetch(config.url, {
+      method: config.method,
+      headers: config.headers(token),
+      signal: AbortSignal.timeout(VALIDATION_TIMEOUT_MS),
+    });
+    return res.ok;
   } catch {
-    // Timeout, network error, etc.
     return false;
   }
 }


### PR DESCRIPTION
## Summary

- Collapse 12 near-identical token validator functions into a single config-driven generic validator
- Replace individual `validateX(token)` functions with a `VALIDATOR_CONFIGS` table mapping each provider to its URL, header builder, and optional HTTP method
- Single `validateToken` function reads from the config table, reducing ~130 lines to ~80 lines
- Same external interface (`validateToken(provider, token)`) -- all 17 existing tests pass without modification

Ref #1752

## Changes

- `apps/web-platform/server/token-validators.ts`: refactored to config-driven approach

## Test plan

- [x] All 17 token-validator tests pass (URL matching, header format, error handling, unsupported providers)
- [x] Full test suite passes (652 tests, 0 failures)

---

*Automated fix by soleur:fix-issue. Human review required before merge.*