### PR TITLE
[bot-fix] Fix #1753: configurable Plausible site_id

### DIFF
--- a/apps/web-platform/server/token-validators.ts
+++ b/apps/web-platform/server/token-validators.ts
@@ -3,7 +3,7 @@ import type { Provider } from "@/lib/types";
 const VALIDATION_TIMEOUT_MS = 5_000;
 
 interface ValidatorConfig {
-  url: string;
+  url: string | (() => string);
   headers: (token: string) => Record<string, string>;
   method?: string;
 }
@@ -23,7 +23,7 @@ const VALIDATOR_CONFIGS: Partial<Record<Provider, ValidatorConfig>> = {
     headers: (token) => ({ Authorization: `Bearer ${token}` }),
   },
   plausible: {
-    url: "https://plausible.io/api/v1/stats/realtime/visitors?site_id=soleur.ai",
+    url: () => `https://plausible.io/api/v1/stats/realtime/visitors?site_id=${encodeURIComponent(process.env.PLAUSIBLE_SITE_ID ?? "soleur.ai")}`,
     headers: (token) => ({ Authorization: `Bearer ${token}` }),
   },
   hetzner: {
@@ -67,7 +67,8 @@ export async function validateToken(
   const config = VALIDATOR_CONFIGS[provider];
   if (!config) return false;
   try {
-    const res = await fetch(config.url, {
+    const url = typeof config.url === "function" ? config.url() : config.url;
+    const res = await fetch(url, {
       method: config.method,
       headers: config.headers(token),
       signal: AbortSignal.timeout(VALIDATION_TIMEOUT_MS),

--- a/apps/web-platform/test/token-validators.test.ts
+++ b/apps/web-platform/test/token-validators.test.ts
@@ -103,6 +103,21 @@ describe("validateToken", () => {
   test("returns true for plausible when stats endpoint responds 200", async () => {
     mockFetch.mockResolvedValue({ ok: true });
     expect(await validateToken("plausible", "pl-key")).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("site_id=soleur.ai"),
+      expect.any(Object),
+    );
+  });
+
+  test("plausible uses PLAUSIBLE_SITE_ID env var when set", async () => {
+    process.env.PLAUSIBLE_SITE_ID = "example.com";
+    mockFetch.mockResolvedValue({ ok: true });
+    expect(await validateToken("plausible", "pl-key")).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("site_id=example.com"),
+      expect.any(Object),
+    );
+    delete process.env.PLAUSIBLE_SITE_ID;
   });
 
   test("returns false when fetch throws (network error)", async () => {


### PR DESCRIPTION
## Summary

- Remove hardcoded `site_id=soleur.ai` from Plausible token validator
- Read `PLAUSIBLE_SITE_ID` from environment with `soleur.ai` fallback default
- URL-encode the site_id value for safety
- Add tests for both default and env-var-override behavior

Ref #1753

## Changes

- `apps/web-platform/server/token-validators.ts`: replace hardcoded `site_id=soleur.ai` with `process.env.PLAUSIBLE_SITE_ID ?? "soleur.ai"`, consistent with existing usage across shell scripts and CI workflows
- `apps/web-platform/test/token-validators.test.ts`: add assertions for default site_id URL and env var override

## Test plan

- [x] Existing plausible test updated to assert default `site_id=soleur.ai` in URL
- [x] New test verifies `PLAUSIBLE_SITE_ID` env var is used when set
- [x] Full test suite passes (653 tests, 59 files)

---

*Automated fix by soleur:fix-issue. Human review required before merge.*