### PR TITLE
[bot-fix] Fix #1781: P3 improvements from code review

### DIFF
--- a/apps/web-platform/app/api/auth/github-resolve/callback/route.ts
+++ b/apps/web-platform/app/api/auth/github-resolve/callback/route.ts
@@ -115,6 +115,23 @@ export async function GET(request: Request) {
     return redirectWithDeletedCookie(ERROR_REDIRECT, request);
   }
 
+  // --- Revoke the access token (fire-and-forget) ---
+  // The token has no scopes but revoking it limits the window for misuse.
+  // Uses DELETE /applications/{client_id}/token with Basic auth.
+  try {
+    await fetch(`https://api.github.com/applications/${clientId}/token`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        Accept: "application/vnd.github+json",
+      },
+      body: JSON.stringify({ access_token: accessToken }),
+    });
+  } catch {
+    // Best-effort — don't fail the flow if revocation fails
+    logger.warn("GitHub resolve callback: token revocation failed (non-fatal)");
+  }
+
   // --- Get authenticated user ---
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/apps/web-platform/test/detect-installation-fallback.test.ts
+++ b/apps/web-platform/test/detect-installation-fallback.test.ts
@@ -50,6 +50,39 @@ function makeRequest() {
 }
 
 // ---------------------------------------------------------------------------
+// Table-routing helpers for mockServiceFrom
+// ---------------------------------------------------------------------------
+type TableOperation = "select" | "update";
+type TableMockConfig = Record<string, Partial<Record<TableOperation, unknown>>>;
+
+/**
+ * Configure mockServiceFrom to route by table name + operation instead of
+ * relying on positional mockReturnValueOnce chains.
+ */
+function setupTableRoutes(config: TableMockConfig) {
+  mockServiceFrom.mockImplementation((table: string) => {
+    const tableConfig = config[table];
+    if (!tableConfig) {
+      throw new Error(`Unexpected .from("${table}") call — add it to setupTableRoutes`);
+    }
+    const mock: Record<string, unknown> = {};
+    if (tableConfig.select !== undefined) {
+      mock.select = vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: tableConfig.select }),
+        }),
+      });
+    }
+    if (tableConfig.update !== undefined) {
+      mock.update = vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: tableConfig.update }),
+      });
+    }
+    return mock;
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Tests: github_username fallback
 // ---------------------------------------------------------------------------
 
@@ -64,15 +97,12 @@ describe("POST /api/repo/detect-installation — github_username fallback", () =
   });
 
   test("uses stored github_username when no Supabase GitHub identity exists", async () => {
-    // No github_installation_id but github_username stored from prior OAuth resolve
-    mockServiceFrom.mockReturnValueOnce({
-      select: vi.fn().mockReturnValue({
-        eq: vi.fn().mockReturnValue({
-          single: vi.fn().mockResolvedValue({
-            data: { github_installation_id: null, github_username: "deruelle" },
-          }),
-        }),
-      }),
+    // Route .from("users") to return select data and accept updates
+    setupTableRoutes({
+      users: {
+        select: { github_installation_id: null, github_username: "deruelle" },
+        update: null, // no error
+      },
     });
 
     // No GitHub identity in Supabase
@@ -85,13 +115,6 @@ describe("POST /api/repo/detect-installation — github_username fallback", () =
     mockVerifyInstallationOwnership.mockResolvedValue({ verified: true });
     mockListInstallationRepos.mockResolvedValue([{ name: "my-repo", fullName: "deruelle/my-repo" }]);
 
-    // Update call to store installation_id
-    mockServiceFrom.mockReturnValueOnce({
-      update: vi.fn().mockReturnValue({
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      }),
-    });
-
     const response = await POST(makeRequest());
     const data = await response.json();
 
@@ -101,15 +124,11 @@ describe("POST /api/repo/detect-installation — github_username fallback", () =
   });
 
   test("returns no_github_identity when neither Supabase identity nor github_username exists", async () => {
-    // No github_installation_id and no github_username
-    mockServiceFrom.mockReturnValueOnce({
-      select: vi.fn().mockReturnValue({
-        eq: vi.fn().mockReturnValue({
-          single: vi.fn().mockResolvedValue({
-            data: { github_installation_id: null, github_username: null },
-          }),
-        }),
-      }),
+    // Route .from("users") — no installation ID or username
+    setupTableRoutes({
+      users: {
+        select: { github_installation_id: null, github_username: null },
+      },
     });
 
     // No GitHub identity in Supabase
@@ -125,13 +144,12 @@ describe("POST /api/repo/detect-installation — github_username fallback", () =
   });
 
   test("prefers Supabase GitHub identity over stored github_username", async () => {
-    // No github_installation_id stored
-    mockServiceFrom.mockReturnValueOnce({
-      select: vi.fn().mockReturnValue({
-        eq: vi.fn().mockReturnValue({
-          single: vi.fn().mockResolvedValue({ data: { github_installation_id: null } }),
-        }),
-      }),
+    // Route .from("users") — no installation ID, accept updates
+    setupTableRoutes({
+      users: {
+        select: { github_installation_id: null },
+        update: null, // no error
+      },
     });
 
     // Has GitHub identity in Supabase
@@ -150,13 +168,6 @@ describe("POST /api/repo/detect-installation — github_username fallback", () =
     mockFindInstallationForLogin.mockResolvedValue(99999);
     mockVerifyInstallationOwnership.mockResolvedValue({ verified: true });
     mockListInstallationRepos.mockResolvedValue([{ name: "repo", fullName: "supabase-user/repo" }]);
-
-    // Update call
-    mockServiceFrom.mockReturnValueOnce({
-      update: vi.fn().mockReturnValue({
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      }),
-    });
 
     const response = await POST(makeRequest());
     const data = await response.json();

--- a/apps/web-platform/test/github-resolve.test.ts
+++ b/apps/web-platform/test/github-resolve.test.ts
@@ -26,9 +26,47 @@ vi.mock("@/server/logger", () => ({
   default: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
 
-// Mock global fetch for GitHub API calls
-const mockFetch = vi.fn();
+// ---------------------------------------------------------------------------
+// URL-routing mock for global fetch (GitHub API calls)
+// ---------------------------------------------------------------------------
+
+type MockRoute = {
+  test: (url: string, init?: RequestInit) => boolean;
+  response: () => Promise<Partial<Response>>;
+};
+
+const fetchRoutes: MockRoute[] = [];
 const originalFetch = globalThis.fetch;
+
+/** Register a URL-matching mock response. Routes are checked in order. */
+function mockFetchRoute(
+  match: string | ((url: string, init?: RequestInit) => boolean),
+  response: Partial<Response> | (() => Promise<Partial<Response>>),
+) {
+  const test = typeof match === "string"
+    ? (url: string) => url.includes(match)
+    : match;
+  const responseFn = typeof response === "function"
+    ? response
+    : () => Promise.resolve(response);
+  fetchRoutes.push({ test, response: responseFn });
+}
+
+/** Clear all registered routes. */
+function clearFetchRoutes() {
+  fetchRoutes.length = 0;
+}
+
+/** The routing fetch mock — matches registered routes by URL. */
+const routingFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+  const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+  for (const route of fetchRoutes) {
+    if (route.test(url, init)) {
+      return route.response();
+    }
+  }
+  throw new Error(`Unmatched fetch URL: ${url}`);
+}) as unknown as typeof fetch;
 
 // ---------------------------------------------------------------------------
 // Import route handlers
@@ -131,7 +169,8 @@ describe("GET /api/auth/github-resolve (initiate)", () => {
 describe("GET /api/auth/github-resolve/callback", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    globalThis.fetch = mockFetch as unknown as typeof fetch;
+    clearFetchRoutes();
+    globalThis.fetch = routingFetch;
 
     // Default: authenticated user
     mockGetUser.mockResolvedValue({
@@ -144,22 +183,26 @@ describe("GET /api/auth/github-resolve/callback", () => {
         eq: vi.fn().mockResolvedValue({ error: null }),
       }),
     });
+
+    // Default: token revocation succeeds (fire-and-forget, matched by URL)
+    mockFetchRoute("/applications/", { ok: true, status: 204 });
   });
 
   afterEach(() => {
+    clearFetchRoutes();
     globalThis.fetch = originalFetch;
   });
 
   test("stores github_username and redirects on valid code+state", async () => {
     const stateNonce = "test-state-123";
 
-    // Mock GitHub token exchange
-    mockFetch.mockResolvedValueOnce({
+    // Mock GitHub token exchange (matched by URL)
+    mockFetchRoute("login/oauth/access_token", {
       ok: true,
       json: async () => ({ access_token: "ghu_test_token", token_type: "bearer" }),
     });
-    // Mock GET /user
-    mockFetch.mockResolvedValueOnce({
+    // Mock GET /user (matched by URL)
+    mockFetchRoute((url, init) => url.includes("api.github.com/user") && init?.method !== "DELETE", {
       ok: true,
       json: async () => ({ login: "deruelle" }),
     });
@@ -215,7 +258,7 @@ describe("GET /api/auth/github-resolve/callback", () => {
   test("redirects with resolve_error=1 when token exchange fails", async () => {
     const stateNonce = "test-state-456";
 
-    mockFetch.mockResolvedValueOnce({
+    mockFetchRoute("login/oauth/access_token", {
       ok: false,
       status: 400,
       json: async () => ({ error: "bad_verification_code" }),
@@ -235,11 +278,11 @@ describe("GET /api/auth/github-resolve/callback", () => {
   test("redirects with resolve_error=1 when GET /user returns empty login", async () => {
     const stateNonce = "test-state-789";
 
-    mockFetch.mockResolvedValueOnce({
+    mockFetchRoute("login/oauth/access_token", {
       ok: true,
       json: async () => ({ access_token: "ghu_test_token", token_type: "bearer" }),
     });
-    mockFetch.mockResolvedValueOnce({
+    mockFetchRoute((url, init) => url.includes("api.github.com/user") && init?.method !== "DELETE", {
       ok: true,
       json: async () => ({ login: "" }),
     });
@@ -258,11 +301,11 @@ describe("GET /api/auth/github-resolve/callback", () => {
   test("deletes state cookie on successful callback", async () => {
     const stateNonce = "test-state-cleanup";
 
-    mockFetch.mockResolvedValueOnce({
+    mockFetchRoute("login/oauth/access_token", {
       ok: true,
       json: async () => ({ access_token: "ghu_test_token", token_type: "bearer" }),
     });
-    mockFetch.mockResolvedValueOnce({
+    mockFetchRoute((url, init) => url.includes("api.github.com/user") && init?.method !== "DELETE", {
       ok: true,
       json: async () => ({ login: "deruelle" }),
     });


### PR DESCRIPTION
## Summary

- Add GitHub OAuth token revocation after username extraction (security P3)
- Refactor test mocks from positional `mockReturnValueOnce` chains to URL-routing pattern (test quality P3)

Ref #1781

## Changes

- `apps/web-platform/app/api/auth/github-resolve/callback/route.ts`: added fire-and-forget token revocation via `DELETE /applications/{client_id}/token` after extracting the GitHub username
- `apps/web-platform/test/github-resolve.test.ts`: replaced positional `mockFetch.mockResolvedValueOnce` chains with a URL-routing mock that matches fetch calls by URL pattern
- `apps/web-platform/test/detect-installation-fallback.test.ts`: replaced positional `mockServiceFrom.mockReturnValueOnce` chains with a table-routing `setupTableRoutes` helper that dispatches by table name and operation

## Test plan

- [x] All 14 tests in modified files pass
- [x] Full suite: 652 passed, 1 skipped, 0 failed

---

*Automated fix by soleur:fix-issue. Human review required before merge.*