### PR TITLE
fix: dynamic import agent-runner to fix Docker build

### DIFF
--- a/apps/web-platform/app/api/repo/setup/route.ts
+++ b/apps/web-platform/app/api/repo/setup/route.ts
@@ -4,7 +4,6 @@ import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 import { provisionWorkspaceWithRepo } from "@/server/workspace";
 import { scanProjectHealth } from "@/server/project-scanner";
-import { startAgentSession } from "@/server/agent-runner";
 import logger from "@/server/logger";
 
 /**
@@ -159,12 +158,16 @@ export async function POST(request: Request) {
         return;
       }
 
-      startAgentSession(
-        user.id,
-        conversationId,
-        undefined,
-        undefined,
-        "/soleur:sync --headless",
+      // Dynamic import: agent-runner.ts pulls in @anthropic-ai/claude-agent-sdk
+      // which breaks Next.js build-time route validation when statically imported.
+      import("@/server/agent-runner").then(({ startAgentSession }) =>
+        startAgentSession(
+          user.id,
+          conversationId,
+          undefined,
+          undefined,
+          "/soleur:sync --headless",
+        ),
       ).catch((syncErr) => {
         logger.error(
           { err: syncErr, userId: user.id },


### PR DESCRIPTION
## Summary

Static import of `agent-runner.ts` in `setup/route.ts` (from #1771) changed webpack chunking, causing `supabaseKey is required` errors during `next build` in Docker. The `@anthropic-ai/claude-agent-sdk` import tree is heavy and alters bundle composition when pulled into route handlers.

Fix: use `import()" dynamic import so agent-runner is loaded at runtime only.

## Changelog

### Web Platform
- Fixed: Docker build failure caused by static import of agent-runner in route handler

## Test plan

- [x] Type check passes (`tsc --noEmit`)
- [x] All 681 tests pass
- [ ] Docker build succeeds in release workflow

Generated with [Claude Code](https://claude.com/claude-code)