### PR TITLE
refactor(kb): extract layout state components into separate files

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/kb/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/kb/layout.tsx
@@ -1,14 +1,22 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo, Component } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import type { ReactNode } from "react";
-import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { KbContext } from "@/components/kb/kb-context";
 import type { KbContextValue } from "@/components/kb/kb-context";
 import { FileTree } from "@/components/kb/file-tree";
 import { SearchOverlay } from "@/components/kb/search-overlay";
 import { getAncestorPaths } from "@/components/kb/get-ancestor-paths";
+import {
+  DesktopPlaceholder,
+  EmptyState,
+  KbErrorBoundary,
+  LoadingSkeleton,
+  NoProjectState,
+  UnknownError,
+  WorkspaceNotReady,
+} from "@/components/kb";
 import type { TreeNode } from "@/server/kb-reader";
 
 export default function KbLayout({ children }: { children: ReactNode }) {
@@ -155,174 +163,4 @@ export default function KbLayout({ children }: { children: ReactNode }) {
       </div>
     </KbContext>
   );
-}
-
-function DesktopPlaceholder() {
-  return (
-    <div className="hidden h-full items-center justify-center md:flex">
-      <div className="text-center">
-        <svg
-          width="48"
-          height="48"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1"
-          className="mx-auto mb-3 text-neutral-600"
-        >
-          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z" strokeLinecap="round" strokeLinejoin="round" />
-          <path d="M14 2v6h6" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-        <p className="text-sm text-neutral-500">Select a file to view</p>
-        <p className="mt-1 text-xs text-neutral-600">
-          Choose a file from the sidebar to preview its contents
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function LoadingSkeleton() {
-  const widths = [140, 120, 160, 100, 130];
-  return (
-    <div className="flex h-full flex-col p-4">
-      <div className="mb-4 h-6 w-32 animate-pulse rounded bg-neutral-800" />
-      <div className="space-y-2">
-        {widths.map((w, i) => (
-          <div key={i} className="flex items-center gap-2">
-            <div className="h-4 w-4 animate-pulse rounded bg-neutral-800" />
-            <div
-              className="h-4 animate-pulse rounded bg-neutral-800"
-              style={{ width: `${w}px` }}
-            />
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function WorkspaceNotReady() {
-  return (
-    <div className="flex h-full items-center justify-center p-6">
-      <div className="text-center">
-        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-neutral-800">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="animate-pulse text-amber-500">
-            <path d="M12 6v6l4 2" strokeLinecap="round" strokeLinejoin="round" />
-            <circle cx="12" cy="12" r="10" />
-          </svg>
-        </div>
-        <h1 className="mb-2 font-serif text-lg font-medium text-white">
-          Setting Up Your Workspace
-        </h1>
-        <p className="text-sm text-neutral-400">
-          Your workspace is being prepared. This usually takes a moment.
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function NoProjectState() {
-  return (
-    <div className="flex h-full items-center justify-center p-6">
-      <div className="max-w-sm text-center">
-        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-neutral-800">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-amber-500">
-            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2Z" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        </div>
-        <h1 className="mb-2 font-serif text-lg font-medium text-white">
-          No Project Connected
-        </h1>
-        <p className="mb-6 text-sm leading-relaxed text-neutral-400">
-          Connect a GitHub project so your AI team can build your knowledge
-          base with plans, specs, and analyses.
-        </p>
-        <Link
-          href="/connect-repo?return_to=/dashboard/kb"
-          className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-amber-600 to-amber-500 px-5 py-2.5 text-sm font-medium text-neutral-950 transition-opacity hover:opacity-90"
-        >
-          Set Up Project
-        </Link>
-      </div>
-    </div>
-  );
-}
-
-function UnknownError() {
-  return (
-    <div className="flex h-full items-center justify-center p-6">
-      <div className="text-center">
-        <p className="text-sm text-neutral-400">
-          Unable to load your knowledge base. Please try again later.
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function EmptyState() {
-  return (
-    <div className="flex h-full items-center justify-center p-6">
-      <div className="max-w-sm text-center">
-        <p className="mb-4 text-xs font-semibold uppercase tracking-widest text-amber-500/80">
-          Knowledge Base
-        </p>
-        <h1 className="mb-3 font-serif text-2xl font-medium text-white">
-          Nothing Here Yet.{" "}
-          <span className="text-neutral-400">One Message Changes That.</span>
-        </h1>
-        <p className="mb-6 text-sm leading-relaxed text-neutral-400">
-          Start a conversation and your AI organization gets to work — producing
-          plans, specs, brand guides, and competitive analyses that appear here
-          automatically.
-        </p>
-        <Link
-          href="/dashboard/chat/new"
-          className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-amber-600 to-amber-500 px-5 py-2.5 text-sm font-medium text-neutral-950 transition-opacity hover:opacity-90"
-        >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="shrink-0">
-            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2Z" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-          Open a Chat
-        </Link>
-      </div>
-    </div>
-  );
-}
-
-class KbErrorBoundary extends Component<
-  { children: ReactNode },
-  { hasError: boolean }
-> {
-  constructor(props: { children: ReactNode }) {
-    super(props);
-    this.state = { hasError: false };
-  }
-
-  static getDerivedStateFromError() {
-    return { hasError: true };
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return (
-        <div className="flex h-full items-center justify-center">
-          <div className="text-center">
-            <p className="text-sm text-neutral-400">
-              Something went wrong loading this content.
-            </p>
-            <button
-              onClick={() => this.setState({ hasError: false })}
-              className="mt-2 text-sm text-amber-400 underline hover:text-amber-300"
-            >
-              Try again
-            </button>
-          </div>
-        </div>
-      );
-    }
-    return this.props.children;
-  }
 }

--- a/apps/web-platform/components/kb/desktop-placeholder.tsx
+++ b/apps/web-platform/components/kb/desktop-placeholder.tsx
@@ -1,0 +1,24 @@
+export function DesktopPlaceholder() {
+  return (
+    <div className="hidden h-full items-center justify-center md:flex">
+      <div className="text-center">
+        <svg
+          width="48"
+          height="48"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1"
+          className="mx-auto mb-3 text-neutral-600"
+        >
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z" strokeLinecap="round" strokeLinejoin="round" />
+          <path d="M14 2v6h6" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+        <p className="text-sm text-neutral-500">Select a file to view</p>
+        <p className="mt-1 text-xs text-neutral-600">
+          Choose a file from the sidebar to preview its contents
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-platform/components/kb/empty-state.tsx
+++ b/apps/web-platform/components/kb/empty-state.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+
+export function EmptyState() {
+  return (
+    <div className="flex h-full items-center justify-center p-6">
+      <div className="max-w-sm text-center">
+        <p className="mb-4 text-xs font-semibold uppercase tracking-widest text-amber-500/80">
+          Knowledge Base
+        </p>
+        <h1 className="mb-3 font-serif text-2xl font-medium text-white">
+          Nothing Here Yet.{" "}
+          <span className="text-neutral-400">One Message Changes That.</span>
+        </h1>
+        <p className="mb-6 text-sm leading-relaxed text-neutral-400">
+          Start a conversation and your AI organization gets to work — producing
+          plans, specs, brand guides, and competitive analyses that appear here
+          automatically.
+        </p>
+        <Link
+          href="/dashboard/chat/new"
+          className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-amber-600 to-amber-500 px-5 py-2.5 text-sm font-medium text-neutral-950 transition-opacity hover:opacity-90"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="shrink-0">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2Z" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          Open a Chat
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-platform/components/kb/index.ts
+++ b/apps/web-platform/components/kb/index.ts
@@ -1,0 +1,7 @@
+export { DesktopPlaceholder } from "./desktop-placeholder";
+export { EmptyState } from "./empty-state";
+export { KbErrorBoundary } from "./kb-error-boundary";
+export { LoadingSkeleton } from "./loading-skeleton";
+export { NoProjectState } from "./no-project-state";
+export { UnknownError } from "./unknown-error";
+export { WorkspaceNotReady } from "./workspace-not-ready";

--- a/apps/web-platform/components/kb/kb-error-boundary.tsx
+++ b/apps/web-platform/components/kb/kb-error-boundary.tsx
@@ -1,0 +1,37 @@
+import { Component } from "react";
+import type { ReactNode } from "react";
+
+export class KbErrorBoundary extends Component<
+  { children: ReactNode },
+  { hasError: boolean }
+> {
+  constructor(props: { children: ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex h-full items-center justify-center">
+          <div className="text-center">
+            <p className="text-sm text-neutral-400">
+              Something went wrong loading this content.
+            </p>
+            <button
+              onClick={() => this.setState({ hasError: false })}
+              className="mt-2 text-sm text-amber-400 underline hover:text-amber-300"
+            >
+              Try again
+            </button>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/apps/web-platform/components/kb/loading-skeleton.tsx
+++ b/apps/web-platform/components/kb/loading-skeleton.tsx
@@ -1,0 +1,19 @@
+export function LoadingSkeleton() {
+  const widths = [140, 120, 160, 100, 130];
+  return (
+    <div className="flex h-full flex-col p-4">
+      <div className="mb-4 h-6 w-32 animate-pulse rounded bg-neutral-800" />
+      <div className="space-y-2">
+        {widths.map((w, i) => (
+          <div key={i} className="flex items-center gap-2">
+            <div className="h-4 w-4 animate-pulse rounded bg-neutral-800" />
+            <div
+              className="h-4 animate-pulse rounded bg-neutral-800"
+              style={{ width: `${w}px` }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-platform/components/kb/no-project-state.tsx
+++ b/apps/web-platform/components/kb/no-project-state.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+
+export function NoProjectState() {
+  return (
+    <div className="flex h-full items-center justify-center p-6">
+      <div className="max-w-sm text-center">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-neutral-800">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-amber-500">
+            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2Z" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </div>
+        <h1 className="mb-2 font-serif text-lg font-medium text-white">
+          No Project Connected
+        </h1>
+        <p className="mb-6 text-sm leading-relaxed text-neutral-400">
+          Connect a GitHub project so your AI team can build your knowledge
+          base with plans, specs, and analyses.
+        </p>
+        <Link
+          href="/connect-repo?return_to=/dashboard/kb"
+          className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-amber-600 to-amber-500 px-5 py-2.5 text-sm font-medium text-neutral-950 transition-opacity hover:opacity-90"
+        >
+          Set Up Project
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-platform/components/kb/unknown-error.tsx
+++ b/apps/web-platform/components/kb/unknown-error.tsx
@@ -1,0 +1,11 @@
+export function UnknownError() {
+  return (
+    <div className="flex h-full items-center justify-center p-6">
+      <div className="text-center">
+        <p className="text-sm text-neutral-400">
+          Unable to load your knowledge base. Please try again later.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-platform/components/kb/workspace-not-ready.tsx
+++ b/apps/web-platform/components/kb/workspace-not-ready.tsx
@@ -1,0 +1,20 @@
+export function WorkspaceNotReady() {
+  return (
+    <div className="flex h-full items-center justify-center p-6">
+      <div className="text-center">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-neutral-800">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="animate-pulse text-amber-500">
+            <path d="M12 6v6l4 2" strokeLinecap="round" strokeLinejoin="round" />
+            <circle cx="12" cy="12" r="10" />
+          </svg>
+        </div>
+        <h1 className="mb-2 font-serif text-lg font-medium text-white">
+          Setting Up Your Workspace
+        </h1>
+        <p className="text-sm text-neutral-400">
+          Your workspace is being prepared. This usually takes a moment.
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Extract 7 inline state components (LoadingSkeleton, WorkspaceNotReady, NoProjectState, UnknownError, EmptyState, DesktopPlaceholder, KbErrorBoundary) from `kb/layout.tsx` into individual files under `components/kb/`
- Add barrel `index.ts` re-exporting all extracted components for clean imports
- Layout reduced from ~330 lines to ~166 lines with no visual or behavioral changes

Closes #1828

## Test plan

- [x] All 3 KB layout tests pass (`vitest run test/kb-layout.test.tsx`)
- [x] All 38 KB reader/security tests pass
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)