### PR TITLE
sec: restrict origin firewall to CF IPs and upgrade DMARC to reject

### DIFF
--- a/apps/web-platform/infra/dns.tf
+++ b/apps/web-platform/infra/dns.tf
@@ -74,7 +74,7 @@ resource "cloudflare_record" "mx_send_send" {
 resource "cloudflare_record" "dmarc" {
   zone_id = var.cf_zone_id
   name    = "_dmarc"
-  content = "v=DMARC1; p=quarantine; rua=mailto:dmarc-reports@soleur.ai; pct=100"
+  content = "v=DMARC1; p=reject; rua=mailto:dmarc-reports@soleur.ai; pct=100"
   type    = "TXT"
   ttl     = 1
 }

--- a/apps/web-platform/infra/firewall.tf
+++ b/apps/web-platform/infra/firewall.tf
@@ -14,20 +14,70 @@ resource "hcloud_firewall" "web" {
 
   # CI deploy SSH rule removed -- deploys now use webhook via Cloudflare Tunnel (#749).
 
-  # HTTP (app traffic via Cloudflare proxy)
+  # HTTP (app traffic via Cloudflare proxy -- restricted to CF edge IPs only, #1836)
   rule {
-    direction  = "in"
-    protocol   = "tcp"
-    port       = "80"
-    source_ips = ["0.0.0.0/0", "::/0"]
+    direction = "in"
+    protocol  = "tcp"
+    port      = "80"
+    source_ips = [
+      # Cloudflare IPv4 — https://www.cloudflare.com/ips-v4/
+      "173.245.48.0/20",
+      "103.21.244.0/22",
+      "103.22.200.0/22",
+      "103.31.4.0/22",
+      "141.101.64.0/18",
+      "108.162.192.0/18",
+      "190.93.240.0/20",
+      "188.114.96.0/20",
+      "197.234.240.0/22",
+      "198.41.128.0/17",
+      "162.158.0.0/15",
+      "104.16.0.0/13",
+      "104.24.0.0/14",
+      "172.64.0.0/13",
+      "131.0.72.0/22",
+      # Cloudflare IPv6 — https://www.cloudflare.com/ips-v6/
+      "2400:cb00::/32",
+      "2606:4700::/32",
+      "2803:f800::/32",
+      "2405:b500::/32",
+      "2405:8100::/32",
+      "2a06:98c0::/29",
+      "2c0f:f248::/32",
+    ]
   }
 
-  # HTTPS
+  # HTTPS (restricted to CF edge IPs only, #1836)
   rule {
-    direction  = "in"
-    protocol   = "tcp"
-    port       = "443"
-    source_ips = ["0.0.0.0/0", "::/0"]
+    direction = "in"
+    protocol  = "tcp"
+    port      = "443"
+    source_ips = [
+      # Cloudflare IPv4 — https://www.cloudflare.com/ips-v4/
+      "173.245.48.0/20",
+      "103.21.244.0/22",
+      "103.22.200.0/22",
+      "103.31.4.0/22",
+      "141.101.64.0/18",
+      "108.162.192.0/18",
+      "190.93.240.0/20",
+      "188.114.96.0/20",
+      "197.234.240.0/22",
+      "198.41.128.0/17",
+      "162.158.0.0/15",
+      "104.16.0.0/13",
+      "104.24.0.0/14",
+      "172.64.0.0/13",
+      "131.0.72.0/22",
+      # Cloudflare IPv6 — https://www.cloudflare.com/ips-v6/
+      "2400:cb00::/32",
+      "2606:4700::/32",
+      "2803:f800::/32",
+      "2405:b500::/32",
+      "2405:8100::/32",
+      "2a06:98c0::/29",
+      "2c0f:f248::/32",
+    ]
   }
 
   # ICMP (ping) from anywhere


### PR DESCRIPTION
## Summary

- **Firewall (#1836):** Replace `0.0.0.0/0` and `::/0` source IPs on HTTP (80) and HTTPS (443) firewall rules with the 22 Cloudflare edge IP ranges (15 IPv4 + 7 IPv6). Direct origin access now blocked -- all web traffic must flow through Cloudflare proxy, enforcing WAF/DDoS protection. SSH and ICMP rules unchanged.
- **DMARC (#1838):** Upgrade DMARC policy from `p=quarantine` to `p=reject`. SPF is already `v=spf1 -all` (hard fail), so no legitimate email originates from `@soleur.ai` -- reject is the correct enforcement level.

Closes #1836, Closes #1838

## Changelog

### Security
- Restrict origin server HTTP/HTTPS firewall to Cloudflare IP ranges only, preventing direct-to-origin bypasses
- Upgrade DMARC policy from quarantine to reject for `@soleur.ai`

## Test plan

- [ ] `terraform validate` passes (verified locally)
- [ ] `terraform fmt -check` passes (verified locally)
- [ ] `terraform plan` in CI shows expected firewall rule and DNS record changes
- [ ] After apply: confirm `curl -H "Host: app.soleur.ai" http://135.181.45.178` is refused from non-CF IPs
- [ ] After apply: verify DMARC record via `dig TXT _dmarc.soleur.ai` shows `p=reject`

🤖 Generated with [Claude Code](https://claude.com/claude-code)