### PR TITLE
fix: optimize share popover query and allow originless API requests

### DIFF
--- a/apps/web-platform/app/api/kb/share/route.ts
+++ b/apps/web-platform/app/api/kb/share/route.ts
@@ -87,8 +87,8 @@ export async function POST(request: Request) {
   return NextResponse.json({ token, url: `/shared/${token}` }, { status: 201 });
 }
 
-/** GET — list all share links for the authenticated user. */
-export async function GET() {
+/** GET — list share links for the authenticated user, optionally filtered by documentPath. */
+export async function GET(request: Request) {
   const supabase = await createClient();
   const {
     data: { user },
@@ -98,11 +98,20 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const { searchParams } = new URL(request.url);
+  const documentPath = searchParams.get("documentPath");
+
   const serviceClient = createServiceClient();
-  const { data: shares, error } = await serviceClient
+  let query = serviceClient
     .from("kb_share_links")
     .select("token, document_path, created_at, revoked")
-    .eq("user_id", user.id)
+    .eq("user_id", user.id);
+
+  if (documentPath) {
+    query = query.eq("document_path", documentPath);
+  }
+
+  const { data: shares, error } = await query
     .order("created_at", { ascending: false });
 
   if (error) {

--- a/apps/web-platform/components/kb/share-popover.tsx
+++ b/apps/web-platform/components/kb/share-popover.tsx
@@ -45,15 +45,14 @@ export function SharePopover({ documentPath }: SharePopoverProps) {
     async function checkShare() {
       setState((s) => ({ ...s, status: "loading" }));
       try {
-        const res = await fetch("/api/kb/share");
+        const res = await fetch(`/api/kb/share?documentPath=${encodeURIComponent(documentPath)}`);
         if (!res.ok) {
           setState((s) => ({ ...s, status: "idle" }));
           return;
         }
         const data = await res.json();
         const existing = data.shares?.find(
-          (s: { document_path: string; revoked: boolean }) =>
-            s.document_path === documentPath && !s.revoked,
+          (s: { revoked: boolean }) => !s.revoked,
         );
         if (!cancelled && existing) {
           setState({

--- a/apps/web-platform/lib/auth/validate-origin.test.ts
+++ b/apps/web-platform/lib/auth/validate-origin.test.ts
@@ -61,10 +61,10 @@ describe("validateOrigin", () => {
     expect(result.origin).toBe("not-a-valid-url");
   });
 
-  it("rejects when neither Origin nor Referer is present (fail-closed)", () => {
+  it("allows requests without Origin or Referer (non-browser clients)", () => {
     const req = makeRequest({});
     const result = validateOrigin(req);
-    expect(result.valid).toBe(false);
+    expect(result.valid).toBe(true);
     expect(result.origin).toBeNull();
   });
 

--- a/apps/web-platform/lib/auth/validate-origin.ts
+++ b/apps/web-platform/lib/auth/validate-origin.ts
@@ -28,7 +28,10 @@ export function validateOrigin(request: Request): {
     }
   }
 
-  return { valid: false, origin: null };
+  // No Origin or Referer header — this is a non-browser client (curl,
+  // server-to-server, mobile app).  CSRF is a browser-only attack vector,
+  // so allow the request through.  Authentication still gates access.
+  return { valid: true, origin: null };
 }
 
 export function rejectCsrf(route: string, origin: string | null): Response {


### PR DESCRIPTION
## Summary

- **Share popover** (`share-popover.tsx`): passes `documentPath` as a query parameter to `GET /api/kb/share`, so the API filters server-side instead of returning all shares for client-side filtering. Eliminates unnecessary data transfer.
- **Share API** (`api/kb/share/route.ts`): accepts optional `documentPath` query param to scope the database query. Backward compatible -- omitting the param returns all shares as before.
- **Origin validation** (`validate-origin.ts`): requests with no `Origin` or `Referer` header are now allowed through. CSRF is a browser-only attack; non-browser clients (curl, server-to-server, mobile apps) never send Origin. Authentication still gates access.
- Updated test to reflect the new behavior for originless requests.

## Changelog

- fix: share popover now fetches only shares for the current document path instead of all shares (#1861)
- fix: validateOrigin allows requests without Origin header, unblocking API clients like curl and mobile apps (#1862)

## Test plan

- [x] `vitest run lib/auth/validate-origin.test.ts` -- 15/15 pass
- [ ] Verify share popover still works end-to-end (open popover, generate link, copy, revoke)
- [ ] Verify curl requests to API routes no longer get 403

Closes #1861, Closes #1862

🤖 Generated with [Claude Code](https://claude.com/claude-code)