### PR TITLE
refactor: rename validateBranchName and document worktree helper parameter

### DIFF
--- a/apps/web-platform/server/push-branch.ts
+++ b/apps/web-platform/server/push-branch.ts
@@ -52,10 +52,10 @@ export interface PushResult {
 // ---------------------------------------------------------------------------
 
 /**
- * Validate that a branch name is not protected.
+ * Reject pushes to protected branches.
  * Throws if the branch matches main, master, or the stored default branch.
  */
-export function validateBranchName(
+export function rejectProtectedBranch(
   branch: string,
   defaultBranch?: string,
 ): void {
@@ -94,8 +94,8 @@ export async function pushBranch(options: PushBranchOptions): Promise<PushResult
   // 2. Validate branch name format (all 10 git ref format rules)
   validateBranchFormat(branch);
 
-  // 3. Validate branch is not protected (main, master, default)
-  validateBranchName(branch, defaultBranch);
+  // 3. Reject pushes to protected branches (main, master, default)
+  rejectProtectedBranch(branch, defaultBranch);
 
   // 4. Set git author to Soleur Agent identity
   try {

--- a/apps/web-platform/test/push-branch.test.ts
+++ b/apps/web-platform/test/push-branch.test.ts
@@ -40,30 +40,30 @@ vi.mock("../server/logger", () => ({
 }));
 
 import {
-  validateBranchName,
+  rejectProtectedBranch,
   PROTECTED_BRANCHES,
   pushBranch,
 } from "../server/push-branch";
 
-describe("validateBranchName", () => {
+describe("rejectProtectedBranch", () => {
   test("rejects 'main'", () => {
-    expect(() => validateBranchName("main")).toThrow(/protected/i);
+    expect(() => rejectProtectedBranch("main")).toThrow(/protected/i);
   });
 
   test("rejects 'master'", () => {
-    expect(() => validateBranchName("master")).toThrow(/protected/i);
+    expect(() => rejectProtectedBranch("master")).toThrow(/protected/i);
   });
 
   test("rejects custom default branch", () => {
-    expect(() => validateBranchName("develop", "develop")).toThrow(/protected/i);
+    expect(() => rejectProtectedBranch("develop", "develop")).toThrow(/protected/i);
   });
 
   test("allows feature branches", () => {
-    expect(() => validateBranchName("feat-ci-cd")).not.toThrow();
+    expect(() => rejectProtectedBranch("feat-ci-cd")).not.toThrow();
   });
 
   test("allows branches with slashes", () => {
-    expect(() => validateBranchName("fix/bug-123")).not.toThrow();
+    expect(() => rejectProtectedBranch("fix/bug-123")).not.toThrow();
   });
 
   test("PROTECTED_BRANCHES includes main and master", () => {

--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -131,6 +131,9 @@ ensure_bare_config() {
 verify_worktree_created() {
   local worktree_path="$1"
   local branch_name="$2"
+  # $from_branch is used only in diagnostic hint messages below, but kept as a
+  # parameter because all callers already have it in scope and the hint aids
+  # debugging when worktree creation fails.
   local from_branch="$3"
 
   # Check 0: Fast-fail if directory was not created at all


### PR DESCRIPTION
## Summary

- Rename `validateBranchName` to `rejectProtectedBranch` in `apps/web-platform/server/push-branch.ts` and its test file for clarity — this function only rejects protected branches (main/master/default), while the similarly-named `validateBranchFormat` validates git ref format
- Document the `from_branch` parameter purpose in `verify_worktree_created()` in `plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh` — parameter is used only for diagnostic hint messages but kept because callers have it in scope and the hint aids debugging

## Test plan

- [x] All 9 push-branch tests pass with renamed function
- [x] No remaining references to old `validateBranchName` name in codebase
- [x] `worktree-manager.sh` passes bash syntax check

## Changelog

- Rename `validateBranchName` → `rejectProtectedBranch` (#1968)
- Document `from_branch` parameter in `verify_worktree_created` (#1938)

Closes #1968, Closes #1938

🤖 Generated with [Claude Code](https://claude.com/claude-code)