### PR TITLE
fix: web-platform code review findings (fail-closed tiers, test helpers, coverage)

### DIFF
--- a/apps/web-platform/server/tool-tiers.ts
+++ b/apps/web-platform/server/tool-tiers.ts
@@ -14,8 +14,8 @@ export type ToolTier = "auto-approve" | "gated" | "blocked";
 
 /**
  * Canonical tier assignments for all platform MCP tools.
- * Tools not in this map default to "auto-approve" in getToolTier()
- * because they are already validated by platformToolNames inclusion.
+ * Tools not in this map default to "gated" in getToolTier()
+ * (fail-closed: new tools require explicit tier assignment).
  */
 export const TOOL_TIER_MAP: Record<string, ToolTier> = {
   // Phase 2: Read CI status (auto-approve — read-only)
@@ -32,11 +32,11 @@ export const TOOL_TIER_MAP: Record<string, ToolTier> = {
 
 /**
  * Look up the tier for a platform MCP tool.
- * Returns "auto-approve" for tools not in the map (safe default for
- * platform tools already validated by platformToolNames inclusion).
+ * Returns "gated" for tools not in the map (fail-closed: new tools
+ * require explicit tier assignment before they can auto-approve).
  */
 export function getToolTier(toolName: string): ToolTier {
-  return TOOL_TIER_MAP[toolName] ?? "auto-approve";
+  return TOOL_TIER_MAP[toolName] ?? "gated";
 }
 
 /**

--- a/apps/web-platform/test/canusertool-tiered-gating.test.ts
+++ b/apps/web-platform/test/canusertool-tiered-gating.test.ts
@@ -207,6 +207,34 @@ async function getCanUseTool() {
   ) => Promise<{ behavior: string; message?: string; updatedInput?: Record<string, unknown> }>;
 }
 
+/**
+ * Find a structured audit log call matching the given filter.
+ * Throws a descriptive error listing all actual audit calls if no match found.
+ */
+function findAuditLog(
+  mock: ReturnType<typeof vi.fn>,
+  filter: (obj: Record<string, unknown>) => boolean,
+): Record<string, unknown> {
+  const allAuditCalls = mock.mock.calls.filter(
+    (args: unknown[]) => {
+      const obj = args[0] as Record<string, unknown>;
+      return obj?.tool && obj?.tier;
+    },
+  );
+  const match = allAuditCalls.find((args: unknown[]) =>
+    filter(args[0] as Record<string, unknown>),
+  );
+  if (!match) {
+    const summaries = allAuditCalls.map(
+      (args: unknown[]) => JSON.stringify(args[0]),
+    );
+    throw new Error(
+      `No audit log matched filter. Actual audit calls (${allAuditCalls.length}):\n${summaries.join("\n")}`,
+    );
+  }
+  return match[0] as Record<string, unknown>;
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -295,14 +323,9 @@ describe("canUseTool tiered gating (#1926)", () => {
       );
 
       // Logger.info should have been called with audit data
-      const auditCall = mockLogInfo.mock.calls.find(
-        (args: unknown[]) => {
-          const obj = args[0] as Record<string, unknown>;
-          return obj?.tool && obj?.tier && obj?.decision;
-        },
+      const auditData = findAuditLog(mockLogInfo, (obj) =>
+        obj.tool === "mcp__soleur_platform__create_pull_request" && obj.decision === "approved",
       );
-      expect(auditCall).toBeDefined();
-      const auditData = auditCall![0] as Record<string, unknown>;
       expect(auditData.tool).toBe("mcp__soleur_platform__create_pull_request");
       expect(auditData.tier).toBe("gated");
       expect(auditData.decision).toBe("approved");
@@ -319,13 +342,31 @@ describe("canUseTool tiered gating (#1926)", () => {
         { signal: new AbortController().signal },
       );
 
-      const auditCall = mockLogInfo.mock.calls.find(
-        (args: unknown[]) => {
-          const obj = args[0] as Record<string, unknown>;
-          return obj?.decision === "rejected";
-        },
+      const auditData = findAuditLog(mockLogInfo, (obj) =>
+        obj.decision === "rejected",
       );
-      expect(auditCall).toBeDefined();
+      expect(auditData.decision).toBe("rejected");
+    });
+  });
+
+  describe("auto-approve tier", () => {
+    test("structured audit log emitted for auto-approved tool", async () => {
+      const canUseTool = await getCanUseTool();
+
+      await canUseTool(
+        "mcp__soleur_platform__github_read_ci_status",
+        { owner: "alice", repo: "my-repo", ref: "main" },
+        { signal: new AbortController().signal },
+      );
+
+      const auditData = findAuditLog(mockLogInfo, (obj) =>
+        obj.tool === "mcp__soleur_platform__github_read_ci_status" && obj.tier === "auto-approve",
+      );
+      expect(auditData.tool).toBe("mcp__soleur_platform__github_read_ci_status");
+      expect(auditData.tier).toBe("auto-approve");
+      expect(auditData.decision).toBe("auto-approved");
+      // Review gate should NOT have been called for auto-approve tools
+      expect(mockAbortableReviewGate).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web-platform/test/service-tools.test.ts
+++ b/apps/web-platform/test/service-tools.test.ts
@@ -161,6 +161,31 @@ describe("plausibleAddGoal", () => {
     expect(result.error).toContain("goal_type");
   });
 
+  test("page goal produces page_path not event_name in fetch body", async () => {
+    const responseBody = { goal_type: "page", page_path: "/signup" };
+    globalThis.fetch = mockFetchResponse(200, responseBody);
+
+    const result = await plausibleAddGoal("test-api-key", "example.com", "page", "/signup");
+
+    expect(result.success).toBe(true);
+
+    const [, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(opts.body);
+    expect(body.page_path).toBe("/signup");
+    expect(body.event_name).toBeUndefined();
+    expect(body.goal_type).toBe("page");
+    expect(body.site_id).toBe("example.com");
+  });
+
+  test("non-timeout network error returns Network error", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+
+    const result = await plausibleAddGoal("test-api-key", "example.com", "event", "Signup");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Network error");
+  });
+
   test("handles PUT upsert idempotency (success on repeated call)", async () => {
     const responseBody = { goal_type: "event", event_name: "Signup" };
     globalThis.fetch = mockFetchResponse(200, responseBody);

--- a/apps/web-platform/test/tool-tiers.test.ts
+++ b/apps/web-platform/test/tool-tiers.test.ts
@@ -46,11 +46,11 @@ describe("getToolTier", () => {
     );
   });
 
-  test("returns auto-approve for unregistered platform tools (safe default)", () => {
-    // Platform tools not in the tier map default to auto-approve
-    // because they are already validated by platformToolNames inclusion
+  test("returns gated for unregistered platform tools (fail-closed default)", () => {
+    // Platform tools not in the tier map default to gated
+    // so new tools require explicit tier assignment before auto-approve
     expect(getToolTier("mcp__soleur_platform__unknown_future_tool")).toBe(
-      "auto-approve",
+      "gated",
     );
   });
 


### PR DESCRIPTION
## Summary

- **#1966 — Fail-closed default tier:** Changed `getToolTier()` default from `"auto-approve"` to `"gated"` so new platform tools require explicit tier assignment. Updated unit test to assert the new default.
- **#1967 — Extract findAuditLog helper:** Replaced duplicated `mockLogInfo.mock.calls.find()` pattern with a reusable `findAuditLog(mock, filter)` helper that throws descriptive errors on mismatch. Used in both gated and new auto-approve tier audit tests.
- **#1941 — Missing test coverage:** Added page goal body shape test (verifies `page_path` not `event_name` in fetch body) and network error test (non-timeout `TypeError` returns `"Network error"`).

Closes #1966, Closes #1967, Closes #1941

## Test plan

- [x] `npx vitest run` — all 33 tests pass across tool-tiers, canusertool-tiered-gating, and service-tools test files
- [x] New `findAuditLog` helper correctly throws with audit call listing when no match found
- [x] Default tier change verified: unmapped tool returns `"gated"` not `"auto-approve"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)