### PR TITLE
fix: parallelize uploads, deduplicate URL hook, share attachment constants

### DIFF
--- a/apps/web-platform/app/api/attachments/presign/route.ts
+++ b/apps/web-platform/app/api/attachments/presign/route.ts
@@ -3,17 +3,10 @@ import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 import logger from "@/server/logger";
 import { randomUUID } from "crypto";
-
-const ALLOWED_CONTENT_TYPES = new Set([
-  "image/png",
-  "image/jpeg",
-  "image/gif",
-  "image/webp",
-  "application/pdf",
-]);
-
-const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20 MB
-const MAX_FILES_PER_MESSAGE = 5;
+import {
+  ALLOWED_ATTACHMENT_TYPES,
+  MAX_ATTACHMENT_SIZE,
+} from "@/lib/attachment-constants";
 
 function getExtension(contentType: string): string {
   const map: Record<string, string> = {
@@ -55,12 +48,12 @@ export async function POST(request: Request) {
   const { filename, contentType, sizeBytes, conversationId } = body;
 
   // Validate file type
-  if (!ALLOWED_CONTENT_TYPES.has(contentType)) {
+  if (!ALLOWED_ATTACHMENT_TYPES.has(contentType)) {
     return NextResponse.json({ error: "unsupported_file_type" }, { status: 400 });
   }
 
   // Validate file size
-  if (sizeBytes <= 0 || sizeBytes > MAX_FILE_SIZE) {
+  if (sizeBytes <= 0 || sizeBytes > MAX_ATTACHMENT_SIZE) {
     return NextResponse.json({ error: "file_too_large" }, { status: 400 });
   }
 

--- a/apps/web-platform/components/chat/attachment-display.tsx
+++ b/apps/web-platform/components/chat/attachment-display.tsx
@@ -3,6 +3,54 @@
 import { useState, useEffect } from "react";
 import type { AttachmentRef } from "@/lib/types";
 
+// ── Signed-URL cache with 50-minute TTL ──────────────────────────────
+// Signed URLs expire after 1 hour; we cache for 50 minutes to avoid
+// serving an expired URL while still minimising redundant fetches.
+const URL_TTL_MS = 50 * 60 * 1_000; // 50 minutes
+const urlCache = new Map<string, { url: string; expiresAt: number }>();
+
+function useAttachmentUrl(storagePath: string): string | null {
+  const [url, setUrl] = useState<string | null>(() => {
+    const cached = urlCache.get(storagePath);
+    if (cached && cached.expiresAt > Date.now()) return cached.url;
+    return null;
+  });
+
+  useEffect(() => {
+    // Return early if we already have a valid cached URL
+    const cached = urlCache.get(storagePath);
+    if (cached && cached.expiresAt > Date.now()) {
+      setUrl(cached.url);
+      return;
+    }
+
+    let cancelled = false;
+    fetch("/api/attachments/url", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ storagePath }),
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        if (!cancelled && data.url) {
+          urlCache.set(storagePath, {
+            url: data.url,
+            expiresAt: Date.now() + URL_TTL_MS,
+          });
+          setUrl(data.url);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [storagePath]);
+
+  return url;
+}
+
+// ── Components ───────────────────────────────────────────────────────
+
 interface AttachmentDisplayProps {
   attachments: AttachmentRef[];
 }
@@ -24,23 +72,8 @@ export function AttachmentDisplay({ attachments }: AttachmentDisplayProps) {
 }
 
 function ImageAttachment({ attachment }: { attachment: AttachmentRef }) {
-  const [url, setUrl] = useState<string | null>(null);
+  const url = useAttachmentUrl(attachment.storagePath);
   const [expanded, setExpanded] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    fetch("/api/attachments/url", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ storagePath: attachment.storagePath }),
-    })
-      .then((r) => r.json())
-      .then((data) => {
-        if (!cancelled && data.url) setUrl(data.url);
-      })
-      .catch(() => {});
-    return () => { cancelled = true; };
-  }, [attachment.storagePath]);
 
   if (!url) {
     return (
@@ -82,22 +115,7 @@ function ImageAttachment({ attachment }: { attachment: AttachmentRef }) {
 }
 
 function FileAttachment({ attachment }: { attachment: AttachmentRef }) {
-  const [url, setUrl] = useState<string | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    fetch("/api/attachments/url", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ storagePath: attachment.storagePath }),
-    })
-      .then((r) => r.json())
-      .then((data) => {
-        if (!cancelled && data.url) setUrl(data.url);
-      })
-      .catch(() => {});
-    return () => { cancelled = true; };
-  }, [attachment.storagePath]);
+  const url = useAttachmentUrl(attachment.storagePath);
 
   const sizeKb = Math.round(attachment.sizeBytes / 1_024);
 

--- a/apps/web-platform/components/chat/chat-input.tsx
+++ b/apps/web-platform/components/chat/chat-input.tsx
@@ -2,17 +2,11 @@
 
 import { useState, useRef, useCallback, useEffect } from "react";
 import type { AttachmentRef } from "@/lib/types";
-
-const ALLOWED_TYPES = new Set([
-  "image/png",
-  "image/jpeg",
-  "image/gif",
-  "image/webp",
-  "application/pdf",
-]);
-
-const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20 MB
-const MAX_FILES = 5;
+import {
+  ALLOWED_ATTACHMENT_TYPES,
+  MAX_ATTACHMENT_SIZE,
+  MAX_ATTACHMENTS_PER_MESSAGE,
+} from "@/lib/attachment-constants";
 
 interface PendingAttachment {
   id: string;
@@ -89,15 +83,15 @@ export function ChatInput({
       const validFiles: PendingAttachment[] = [];
 
       for (const file of fileArray) {
-        if (currentCount + validFiles.length >= MAX_FILES) {
-          setAttachError(`Maximum ${MAX_FILES} files per message.`);
+        if (currentCount + validFiles.length >= MAX_ATTACHMENTS_PER_MESSAGE) {
+          setAttachError(`Maximum ${MAX_ATTACHMENTS_PER_MESSAGE} files per message.`);
           break;
         }
-        if (!ALLOWED_TYPES.has(file.type)) {
+        if (!ALLOWED_ATTACHMENT_TYPES.has(file.type)) {
           setAttachError(`"${file.name}" is not a supported file type.`);
           continue;
         }
-        if (file.size > MAX_FILE_SIZE) {
+        if (file.size > MAX_ATTACHMENT_SIZE) {
           setAttachError(`"${file.name}" exceeds the 20 MB size limit.`);
           continue;
         }
@@ -130,14 +124,8 @@ export function ChatInput({
   }, []);
 
   const uploadAttachments = useCallback(async (): Promise<AttachmentRef[]> => {
-    const results: AttachmentRef[] = [];
-
-    for (let i = 0; i < attachments.length; i++) {
-      const att = attachments[i];
-      if (att.uploaded) {
-        results.push(att.uploaded);
-        continue;
-      }
+    const promises = attachments.map(async (att): Promise<AttachmentRef | null> => {
+      if (att.uploaded) return att.uploaded;
 
       try {
         // Step 1: Get presigned URL
@@ -187,7 +175,7 @@ export function ChatInput({
           ),
         );
 
-        results.push(ref);
+        return ref;
       } catch (err) {
         setAttachments((prev) =>
           prev.map((a) =>
@@ -196,10 +184,17 @@ export function ChatInput({
               : a,
           ),
         );
+        return null;
       }
-    }
+    });
 
-    return results;
+    const settled = await Promise.allSettled(promises);
+    return settled
+      .filter(
+        (r): r is PromiseFulfilledResult<AttachmentRef> =>
+          r.status === "fulfilled" && r.value !== null,
+      )
+      .map((r) => r.value);
   }, [attachments]);
 
   const handleSubmit = useCallback(async () => {

--- a/apps/web-platform/lib/attachment-constants.ts
+++ b/apps/web-platform/lib/attachment-constants.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared attachment validation constants.
+ *
+ * Used by both the client-side upload flow (chat-input.tsx) and the
+ * server-side presign route + agent runner validation.  Keeping a single
+ * source of truth prevents drift between front-end and back-end limits.
+ */
+
+export const ALLOWED_ATTACHMENT_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+]);
+
+export const MAX_ATTACHMENT_SIZE = 20 * 1024 * 1024; // 20 MB
+
+export const MAX_ATTACHMENTS_PER_MESSAGE = 5;

--- a/apps/web-platform/server/agent-runner.ts
+++ b/apps/web-platform/server/agent-runner.ts
@@ -8,6 +8,7 @@ import { createServiceClient } from "@/lib/supabase/service";
 import { ROUTABLE_DOMAIN_LEADERS, type DomainLeaderId } from "./domain-leaders";
 import { routeMessage } from "./domain-router";
 import { KeyInvalidError, type AttachmentRef } from "@/lib/types";
+import { ALLOWED_ATTACHMENT_TYPES } from "@/lib/attachment-constants";
 import { decryptKey, decryptKeyLegacy, encryptKey } from "./byok";
 import { sendToClient } from "./ws-handler";
 import * as Sentry from "@sentry/nextjs";
@@ -1240,7 +1241,6 @@ export async function sendUserMessage(
   let attachmentContext: string | undefined;
   if (attachments && attachments.length > 0) {
     // Validate and sanitize each attachment (defense-in-depth — client is untrusted)
-    const ALLOWED_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp", "application/pdf"]);
     const pathPrefix = `${userId}/${conversationId}/`;
 
     for (const att of attachments) {
@@ -1248,7 +1248,7 @@ export async function sendUserMessage(
       if (!att.storagePath.startsWith(pathPrefix) || att.storagePath.includes("..")) {
         throw new Error("Attachment not found");
       }
-      if (!ALLOWED_TYPES.has(att.contentType)) {
+      if (!ALLOWED_ATTACHMENT_TYPES.has(att.contentType)) {
         throw new Error("Unsupported file type");
       }
       // Sanitize filename: strip path separators

--- a/knowledge-base/project/learnings/2026-04-12-stale-main-ref-breaks-multi-issue-worktree-creation.md
+++ b/knowledge-base/project/learnings/2026-04-12-stale-main-ref-breaks-multi-issue-worktree-creation.md
@@ -1,0 +1,28 @@
+# Learning: stale local main ref breaks multi-issue worktree creation
+
+## Problem
+
+When batching 7 code review fixes (#1978-#1984) into 2 parallel PRs, worktrees created from local `main` were missing the files the issues referenced. `cleanup-merged` ran at session start and warned "Could not fast-forward local main -- fetched origin/main only", but this was treated as non-blocking. The 5 commits between local main and origin/main included PR #1975 (the PR that introduced the code being fixed).
+
+Symptoms: `Read` on `attachment-display.tsx` returned "File does not exist", issue line-number references didn't match, and initial analysis was wasted on the wrong file versions.
+
+## Solution
+
+Ran `git update-ref refs/heads/main origin/main` to manually advance the local ref, then recreated both worktrees. This is the same root cause documented in `2026-03-18-bare-repo-cleanup-stale-script-and-fetch-refspec.md` — the `cleanup-merged` fast-forward failed silently.
+
+## Session Errors
+
+1. **Stale local main ref** — `cleanup-merged` warned "Could not fast-forward local main" but the session proceeded to create worktrees from the stale ref. Recovery: `git update-ref refs/heads/main origin/main` + recreate worktrees. **Prevention:** After `cleanup-merged`, verify `git rev-parse main` equals `git rev-parse origin/main`. If they diverge, run `git update-ref refs/heads/main origin/main` before creating worktrees.
+
+2. **Worktree ghost creation** — First worktree creation reported success but worktrees vanished from `git worktree list` after main was updated. Likely caused by creating worktrees from a ref that was then updated. Recovery: Recreated worktrees from the updated main. **Prevention:** Always verify main is current before worktree creation.
+
+3. **Issue line-number mismatch** — Issue descriptions referenced code from PR #1975 which wasn't on local main. Wasted reads on wrong file versions. Recovery: Identified the gap via `gh pr view 1975` and fixed main ref. **Prevention:** Same as error #1 — ensure main is current.
+
+## Key Insight
+
+When `cleanup-merged` warns about fast-forward failure, treat it as blocking, not advisory. The warning means every subsequent worktree will branch from stale code. For multi-issue batch fixes, this compounds: each issue's file references become wrong.
+
+## Tags
+
+category: workflow
+module: worktree-manager


### PR DESCRIPTION
## Summary

- Replace sequential for-loop with `Promise.allSettled` in `uploadAttachments()` — files upload in parallel instead of sequentially (#1978)
- Extract `useAttachmentUrl` hook with 50-min TTL cache, deduplicating identical fetch logic in `ImageAttachment` and `FileAttachment` (#1980)
- Move `ALLOWED_TYPES`/`MAX_FILE_SIZE`/`MAX_FILES` to shared `lib/attachment-constants.ts` — single source of truth for client and server (#1981)

## Changelog

### Fixed
- Client-side file uploads now run in parallel via `Promise.allSettled` instead of sequential for-loop
- Attachment display URLs use shared hook with client-side caching (50-min TTL)
- Attachment validation constants extracted to single shared module

## Test plan

- [ ] Existing `chat-input-attachments.test.tsx` tests pass (8/8)
- [ ] Verify parallel uploads: attach 3+ files, confirm progress bars update independently
- [ ] Verify URL caching: navigate away from conversation and back, confirm no refetch within 50 min
- [ ] Verify shared constants: change MAX_FILE_SIZE in one place, confirm both client validation and server presign reject files above the limit

Closes #1978
Closes #1980
Closes #1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)