### PR TITLE
[bot-fix] review: add Cache-Control headers to binary content responses

### DIFF
--- a/apps/web-platform/app/api/kb/content/[...path]/route.ts
+++ b/apps/web-platform/app/api/kb/content/[...path]/route.ts
@@ -122,6 +122,7 @@ export async function GET(
         "Content-Disposition": `${disposition}; filename="${safeName}"`,
         "Content-Length": buffer.length.toString(),
         "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "private, max-age=60",
       },
     });
   } catch {


### PR DESCRIPTION
## Summary

Add `Cache-Control: private, max-age=60` header to binary content responses from the KB content API, reducing redundant disk reads for cached assets.

Ref #2013

## Changes

- `apps/web-platform/app/api/kb/content/[...path]/route.ts`: Added `Cache-Control: private, max-age=60` header to the binary file serving response. The `private` directive ensures only the user's browser caches (not shared proxies), and `max-age=60` allows 60-second reuse before revalidation.

---

*Automated fix by soleur:fix-issue. Human review required before merge.*
*After verifying the fix resolves the issue, close #2013 manually.*