### PR TITLE
fix(kb): extract shared KB constants and Supabase mock helper

### DIFF
--- a/apps/web-platform/lib/kb-constants.ts
+++ b/apps/web-platform/lib/kb-constants.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared KB reading constants.
+ *
+ * Used by kb-reader.ts (file reading) and context-validation.ts (context
+ * content validation).  Keeping a single source of truth prevents drift.
+ */
+
+export const KB_MAX_FILE_SIZE = 1024 * 1024; // 1MB

--- a/apps/web-platform/server/context-validation.ts
+++ b/apps/web-platform/server/context-validation.ts
@@ -1,11 +1,10 @@
 import type { ConversationContext } from "@/lib/types";
+import { KB_MAX_FILE_SIZE } from "@/lib/kb-constants";
 
 /** Safe path pattern: alphanumeric, hyphens, underscores, slashes, ending in .md */
 const SAFE_PATH_RE = /^[a-zA-Z0-9_\-/]+\.md$/;
 /** Allowed context types */
 const ALLOWED_CONTEXT_TYPES = new Set(["kb-viewer"]);
-/** Max context content length (matches kb-reader MAX_FILE_SIZE) */
-const MAX_CONTEXT_CONTENT_LENGTH = 1024 * 1024; // 1MB
 
 /**
  * Validate a ConversationContext payload from the client.
@@ -38,7 +37,7 @@ export function validateConversationContext(
     if (typeof obj.content !== "string") {
       throw new Error("Invalid context: content must be a string");
     }
-    if (obj.content.length > MAX_CONTEXT_CONTENT_LENGTH) {
+    if (obj.content.length > KB_MAX_FILE_SIZE) {
       throw new Error("Invalid context: content exceeds 1MB limit");
     }
   }

--- a/apps/web-platform/server/kb-reader.ts
+++ b/apps/web-platform/server/kb-reader.ts
@@ -2,8 +2,7 @@ import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
 import { isPathInWorkspace } from "./sandbox";
-
-const MAX_FILE_SIZE = 1024 * 1024; // 1MB
+import { KB_MAX_FILE_SIZE } from "@/lib/kb-constants";
 const MAX_QUERY_LENGTH = 200;
 const MAX_SEARCH_RESULTS = 100;
 
@@ -210,7 +209,7 @@ export async function readContent(
     throw new KbNotFoundError();
   }
 
-  if (stat.size > MAX_FILE_SIZE) {
+  if (stat.size > KB_MAX_FILE_SIZE) {
     throw new KbValidationError("File exceeds maximum size limit");
   }
 
@@ -246,7 +245,7 @@ export async function searchKb(
       let raw: string;
       try {
         const stat = await fs.promises.stat(fullPath);
-        if (stat.size > MAX_FILE_SIZE) return null;
+        if (stat.size > KB_MAX_FILE_SIZE) return null;
         raw = await fs.promises.readFile(fullPath, "utf-8");
       } catch {
         return null;

--- a/apps/web-platform/test/disconnect-route.test.ts
+++ b/apps/web-platform/test/disconnect-route.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
+import { mockQueryChain } from "./helpers/mock-supabase";
 
 // ---------------------------------------------------------------------------
 // Mocks — vi.hoisted ensures these are available when vi.mock factories run
@@ -75,19 +76,17 @@ function setupUserMocks(opts: {
 }) {
   const { repoStatus = "ready", selectError = null, updateError = null } = opts;
 
-  const mockSelectSingle = vi.fn().mockResolvedValue({
-    data: selectError ? null : { repo_status: repoStatus },
-    error: selectError,
-  });
-  const mockSelectEq = vi.fn(() => ({ single: mockSelectSingle }));
-  const mockSelect = vi.fn(() => ({ eq: mockSelectEq }));
+  const selectChain = mockQueryChain(
+    selectError ? null : { repo_status: repoStatus },
+    selectError,
+  );
 
   const mockUpdateEq = vi.fn().mockResolvedValue({ error: updateError });
   const mockUpdate = vi.fn(() => ({ eq: mockUpdateEq }));
 
   mockFrom.mockImplementation((table: string) => {
     if (table === "users") {
-      return { select: mockSelect, update: mockUpdate };
+      return { select: selectChain.select, update: mockUpdate };
     }
     return {};
   });

--- a/apps/web-platform/test/helpers/mock-supabase.test.ts
+++ b/apps/web-platform/test/helpers/mock-supabase.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { mockQueryChain } from "./mock-supabase";
+
+describe("mockQueryChain", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves to { data, error } when awaited without terminal (thenable)", async () => {
+    const chain = mockQueryChain({ id: "123" });
+    const result = await chain.select("*").eq("id", "123");
+    expect(result).toEqual({ data: { id: "123" }, error: null });
+  });
+
+  it("resolves to { data, error } when awaited with .single() terminal", async () => {
+    const chain = mockQueryChain({ id: "123" });
+    const result = await chain.select().eq("id", "123").single();
+    expect(result).toEqual({ data: { id: "123" }, error: null });
+  });
+
+  it("resolves with error when error is provided", async () => {
+    const chain = mockQueryChain(null, { message: "not found" });
+    const result = await chain.select().eq("id", "missing");
+    expect(result).toEqual({ data: null, error: { message: "not found" } });
+  });
+
+  it("supports variable-depth chaining", async () => {
+    const chain = mockQueryChain([{ id: "1" }, { id: "2" }]);
+    const result = await chain.select("*").eq("org_id", "org1").order("created_at").limit(10);
+    expect(result).toEqual({
+      data: [{ id: "1" }, { id: "2" }],
+      error: null,
+    });
+  });
+
+  it("resets vi.fn() call counts on clearAllMocks", async () => {
+    const chain = mockQueryChain({ id: "1" });
+    await chain.select().eq("id", "1");
+    expect(chain.select).toHaveBeenCalledTimes(1);
+
+    vi.clearAllMocks();
+    expect(chain.select).toHaveBeenCalledTimes(0);
+  });
+
+  it("supports insert/update/delete mutations", async () => {
+    const chain = mockQueryChain({ id: "new" });
+    const result = await chain.insert({ name: "test" }).select();
+    expect(result).toEqual({ data: { id: "new" }, error: null });
+  });
+});

--- a/apps/web-platform/test/helpers/mock-supabase.ts
+++ b/apps/web-platform/test/helpers/mock-supabase.ts
@@ -1,4 +1,23 @@
+import type { Mock } from "vitest";
 import { vi } from "vitest";
+
+/** Return type of mockQueryChain — provides type safety at call sites. */
+export interface MockQueryChain {
+  select: Mock;
+  eq: Mock;
+  neq: Mock;
+  in: Mock;
+  is: Mock;
+  order: Mock;
+  limit: Mock;
+  range: Mock;
+  insert: Mock;
+  update: Mock;
+  upsert: Mock;
+  delete: Mock;
+  single: Mock;
+  then: (onfulfilled?: (v: unknown) => unknown) => Promise<unknown>;
+}
 
 /**
  * Create a thenable query chain mock matching Supabase JS v2 query builder.
@@ -29,12 +48,12 @@ import { vi } from "vitest";
 export function mockQueryChain<T>(
   data: T,
   error: { message: string } | null = null,
-) {
+): MockQueryChain {
   const result = { data, error };
 
-  const chain: Record<string, unknown> = {};
+  const chain = {} as MockQueryChain;
 
-  const chainingMethods = [
+  const chainingMethods: (keyof MockQueryChain)[] = [
     "select",
     "eq",
     "neq",
@@ -50,7 +69,7 @@ export function mockQueryChain<T>(
   ];
 
   for (const method of chainingMethods) {
-    chain[method] = vi.fn(() => chain);
+    (chain[method] as Mock) = vi.fn(() => chain);
   }
 
   // PromiseLike: allows `await chain.select().eq()`

--- a/apps/web-platform/test/helpers/mock-supabase.ts
+++ b/apps/web-platform/test/helpers/mock-supabase.ts
@@ -1,0 +1,67 @@
+import { vi } from "vitest";
+
+/**
+ * Create a thenable query chain mock matching Supabase JS v2 query builder.
+ *
+ * All chaining methods (.select, .eq, .in, .order, etc.) return `this`.
+ * The chain is PromiseLike — `await chain.select().eq()` resolves to { data, error }.
+ * `.single()` returns a separate thenable resolving to { data, error }.
+ *
+ * **Usage with vi.hoisted():**
+ * The helper exports a utility function, not a pre-built vi.mock() factory.
+ * Test files must declare their own vi.hoisted() + vi.mock() blocks.
+ *
+ * ```ts
+ * import { mockQueryChain } from "./helpers/mock-supabase";
+ *
+ * const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+ * vi.mock("@/lib/supabase/server", () => ({
+ *   createServiceClient: vi.fn(() => ({ from: mockFrom })),
+ * }));
+ *
+ * // In tests:
+ * mockFrom.mockReturnValue(mockQueryChain({ id: "123" }));
+ * ```
+ *
+ * **Caveat:** Some modules call createClient() at module scope (e.g., agent-runner.ts).
+ * For those, mockFrom must be wired inside the vi.mock() factory, not in beforeEach.
+ */
+export function mockQueryChain<T>(
+  data: T,
+  error: { message: string } | null = null,
+) {
+  const result = { data, error };
+
+  const chain: Record<string, unknown> = {};
+
+  const chainingMethods = [
+    "select",
+    "eq",
+    "neq",
+    "in",
+    "is",
+    "order",
+    "limit",
+    "range",
+    "insert",
+    "update",
+    "upsert",
+    "delete",
+  ];
+
+  for (const method of chainingMethods) {
+    chain[method] = vi.fn(() => chain);
+  }
+
+  // PromiseLike: allows `await chain.select().eq()`
+  chain.then = (onfulfilled?: (v: unknown) => unknown) =>
+    Promise.resolve(result).then(onfulfilled);
+
+  // Terminal: `.single()` returns a separate thenable
+  chain.single = vi.fn(() => ({
+    then: (onfulfilled?: (v: unknown) => unknown) =>
+      Promise.resolve(result).then(onfulfilled),
+  }));
+
+  return chain;
+}

--- a/apps/web-platform/test/kb-constants.test.ts
+++ b/apps/web-platform/test/kb-constants.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { KB_MAX_FILE_SIZE } from "@/lib/kb-constants";
+
+describe("kb-constants", () => {
+  it("exports KB_MAX_FILE_SIZE as 1MB", () => {
+    expect(KB_MAX_FILE_SIZE).toBe(1024 * 1024);
+  });
+});

--- a/apps/web-platform/test/kb-constants.test.ts
+++ b/apps/web-platform/test/kb-constants.test.ts
@@ -1,8 +1,0 @@
-import { describe, expect, it } from "vitest";
-import { KB_MAX_FILE_SIZE } from "@/lib/kb-constants";
-
-describe("kb-constants", () => {
-  it("exports KB_MAX_FILE_SIZE as 1MB", () => {
-    expect(KB_MAX_FILE_SIZE).toBe(1024 * 1024);
-  });
-});

--- a/apps/web-platform/test/presign-route.test.ts
+++ b/apps/web-platform/test/presign-route.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
+import { mockQueryChain } from "./helpers/mock-supabase";
 
 // ---------------------------------------------------------------------------
 // Mocks — vi.hoisted ensures these are available when vi.mock factories run
@@ -74,17 +75,9 @@ function setupAuthenticatedUser() {
 }
 
 function setupConversationOwnership(owned: boolean) {
-  const mockSingle = vi.fn().mockResolvedValue({
-    data: owned ? { id: TEST_CONVERSATION_ID } : null,
-    error: owned ? null : null,
-  });
-  const mockEq2 = vi.fn(() => ({ single: mockSingle }));
-  const mockEq1 = vi.fn(() => ({ eq: mockEq2 }));
-  const mockSelect = vi.fn(() => ({ eq: mockEq1 }));
-
   mockFrom.mockImplementation((table: string) => {
     if (table === "conversations") {
-      return { select: mockSelect };
+      return mockQueryChain(owned ? { id: TEST_CONVERSATION_ID } : null);
     }
     return {};
   });

--- a/apps/web-platform/test/vision-route.test.ts
+++ b/apps/web-platform/test/vision-route.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
+import { mockQueryChain } from "./helpers/mock-supabase";
 
 // ---------------------------------------------------------------------------
 // Mocks — vi.hoisted ensures these are available when vi.mock factories run
@@ -58,16 +59,6 @@ function buildRequest(body: unknown): Request {
   });
 }
 
-function mockQueryBuilder(data: unknown) {
-  return {
-    select: vi.fn().mockReturnThis(),
-    eq: vi.fn().mockReturnThis(),
-    single: vi.fn().mockReturnValue({
-      then: (fn: (v: unknown) => unknown) =>
-        Promise.resolve({ data, error: null }).then(fn),
-    }),
-  };
-}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -85,7 +76,7 @@ describe("POST /api/vision", () => {
       error: null,
     });
     mockFrom.mockReturnValue(
-      mockQueryBuilder({ workspace_path: "/workspaces/user-1" }),
+      mockQueryChain({ workspace_path: "/workspaces/user-1" }),
     );
     mockTryCreateVision.mockResolvedValue(undefined);
 
@@ -127,7 +118,7 @@ describe("POST /api/vision", () => {
       data: { user: { id: "user-1" } },
       error: null,
     });
-    mockFrom.mockReturnValue(mockQueryBuilder(null));
+    mockFrom.mockReturnValue(mockQueryChain(null));
 
     const res = await POST(buildRequest({ content: "A valid startup idea" }));
 

--- a/knowledge-base/project/plans/2026-04-12-fix-kb-constants-and-mock-helper-plan.md
+++ b/knowledge-base/project/plans/2026-04-12-fix-kb-constants-and-mock-helper-plan.md
@@ -1,0 +1,192 @@
+---
+title: "fix: extract shared KB constants and Supabase mock helper"
+type: fix
+date: 2026-04-12
+---
+
+# Extract shared KB constants and Supabase mock helper
+
+## Overview
+
+Two small refactors from PR #2002 code review findings:
+
+1. **#2014 -- KB constants drift:** `MAX_FILE_SIZE` (1MB) is defined independently in
+   `server/kb-reader.ts` and `server/context-validation.ts` (as `MAX_CONTEXT_CONTENT_LENGTH`
+   with a comment "matches kb-reader MAX_FILE_SIZE"). A separate pair of duplicated attachment
+   constants (`MAX_FILE_SIZE` = 20MB, `ALLOWED_CONTENT_TYPES`/`ALLOWED_TYPES`) exists in
+   `app/api/attachments/presign/route.ts` and `components/chat/chat-input.tsx`.
+
+2. **#2016 -- Supabase mock repetition:** 17 test files independently reconstruct Supabase's
+   fluent query API (`from().select().eq().single()`) with nested `vi.fn().mockReturnValue`
+   chains. A Supabase SDK upgrade or query refactor cascades across all test files.
+
+**Note:** The original issue #2014 references `ALLOWED_EXTENSIONS` in `file-tree.tsx` --
+that code no longer exists. The codebase has evolved since the issue was filed. The current
+duplication is between the file pairs listed above.
+
+## Problem Statement
+
+### KB Constants (#2014)
+
+Four files define overlapping size/type constants:
+
+| Constant | Value | File | Domain |
+|----------|-------|------|--------|
+| `MAX_FILE_SIZE` | 1MB | `server/kb-reader.ts:6` | KB reading |
+| `MAX_CONTEXT_CONTENT_LENGTH` | 1MB | `server/context-validation.ts:8` | Context validation |
+| `MAX_FILE_SIZE` | 20MB | `app/api/attachments/presign/route.ts:15` | Attachment upload |
+| `MAX_FILE_SIZE` | 20MB | `components/chat/chat-input.tsx:14` | Client attachment validation |
+| `ALLOWED_CONTENT_TYPES` | 5 MIME types | `app/api/attachments/presign/route.ts:7` | Attachment upload |
+| `ALLOWED_TYPES` | 5 MIME types | `components/chat/chat-input.tsx:6` | Client attachment validation |
+| `MAX_FILES_PER_MESSAGE` | 5 | `app/api/attachments/presign/route.ts:16` | Attachment upload |
+| `MAX_FILES` | 5 | `components/chat/chat-input.tsx:15` | Client attachment validation |
+
+If someone changes the KB file size limit in `kb-reader.ts`, they must remember to update
+`context-validation.ts`. If someone changes the attachment MIME types in the presign route,
+they must remember to update `chat-input.tsx`.
+
+### Supabase Mock Helper (#2016)
+
+17 test files mock `@/lib/supabase/server`, `@/lib/supabase/service`, or `@supabase/supabase-js`
+with bespoke `vi.fn()` chains. Common patterns that are repeated:
+
+- `createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } }))`
+- `createServiceClient: vi.fn(() => ({ from: mockFrom }))`
+- `mockFrom.mockImplementation((table) => ({ select: ..., eq: ..., single: ... }))`
+- Chain builders like `mockQueryBuilder(data)` (defined inline in `vision-route.test.ts:61-70`)
+
+The original issue referenced `kb-upload.test.ts`, `kb-share-md-only.test.ts`, and
+`kb-content-binary.test.ts` -- those files no longer exist. The problem is now broader:
+17 files, not 3.
+
+## Proposed Solution
+
+### Part 1: KB Constants (`lib/kb-constants.ts`)
+
+Create `apps/web-platform/lib/kb-constants.ts` exporting two constant groups:
+
+```ts
+// KB reading constants
+export const KB_MAX_FILE_SIZE = 1024 * 1024; // 1MB
+
+// Attachment constants (shared between server presign route and client validation)
+export const ATTACHMENT_ALLOWED_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+]);
+export const ATTACHMENT_MAX_FILE_SIZE = 20 * 1024 * 1024; // 20MB
+export const ATTACHMENT_MAX_FILES = 5;
+```
+
+Then update the four consumer files to import from `@/lib/kb-constants`.
+
+**Scope decision:** The `getExtension()` map in `presign/route.ts` is not duplicated
+elsewhere, so it stays in the route file.
+
+### Part 2: Supabase Mock Helper (`test/helpers/mock-supabase.ts`)
+
+Create `apps/web-platform/test/helpers/mock-supabase.ts` exporting reusable helpers for the
+two most common patterns:
+
+1. **`createMockSupabaseClient(overrides?)`** -- returns a mock client with `auth.getUser`
+   and `from` pre-wired to `vi.fn()` instances. Returns the mock functions for per-test
+   configuration.
+
+2. **`mockQueryChain(data, error?)`** -- returns a fluent chain mock
+   (`select().eq().eq().single()`) resolving to `{ data, error }`. Handles variable chain
+   depth.
+
+**Scope decision -- incremental migration:** Do NOT rewrite all 17 test files in this PR.
+Instead:
+
+- Create the helper with the two functions above
+- Migrate 3-4 representative test files to prove the helper works
+- Leave remaining files for incremental adoption (each future PR that touches a test file
+  can migrate it)
+
+The 3-4 files to migrate are:
+
+- `test/presign-route.test.ts` -- has `setupConversationOwnership` with explicit chain (lines 77-91)
+- `test/vision-route.test.ts` -- has inline `mockQueryBuilder` (lines 61-70)
+- `test/disconnect-route.test.ts` -- duplicates the `createClient`/`createServiceClient` pattern
+- `test/account-delete.test.ts` -- has `setupSupabaseMocks` helper with chain
+
+## Acceptance Criteria
+
+- [ ] `lib/kb-constants.ts` exists with `KB_MAX_FILE_SIZE`, `ATTACHMENT_ALLOWED_TYPES`,
+      `ATTACHMENT_MAX_FILE_SIZE`, and `ATTACHMENT_MAX_FILES` exports
+- [ ] `server/kb-reader.ts` imports `KB_MAX_FILE_SIZE` from `@/lib/kb-constants`
+- [ ] `server/context-validation.ts` imports `KB_MAX_FILE_SIZE` from `@/lib/kb-constants`
+- [ ] `app/api/attachments/presign/route.ts` imports attachment constants from `@/lib/kb-constants`
+- [ ] `components/chat/chat-input.tsx` imports attachment constants from `@/lib/kb-constants`
+- [ ] No duplicate constant definitions remain in any of the four consumer files
+- [ ] `test/helpers/mock-supabase.ts` exists with `createMockSupabaseClient` and `mockQueryChain`
+- [ ] 3-4 test files migrated to use the shared helper
+- [ ] All existing tests pass without changes to assertions
+- [ ] `getExtension()` map stays in `presign/route.ts` (not extracted -- no duplication)
+
+## Test Scenarios
+
+- Given kb-reader uses `KB_MAX_FILE_SIZE` from the shared module, when a file exceeds 1MB,
+  then `readContent` throws `KbValidationError`
+- Given context-validation uses `KB_MAX_FILE_SIZE` from the shared module, when content
+  exceeds 1MB, then `validateConversationContext` throws
+- Given presign route uses `ATTACHMENT_MAX_FILE_SIZE` from shared module, when file exceeds
+  20MB, then route returns 400 `file_too_large`
+- Given chat-input uses `ATTACHMENT_ALLOWED_TYPES` from shared module, when user attaches
+  an unsupported type, then error is shown
+- Given `mockQueryChain({ id: "123" })` returns a fluent chain, when test calls
+  `.select().eq().single()`, then it resolves to `{ data: { id: "123" }, error: null }`
+- Given a migrated test file uses `createMockSupabaseClient`, when `vi.clearAllMocks()` runs
+  in `beforeEach`, then all mock functions are reset correctly
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected -- infrastructure/tooling change.
+
+## Context
+
+### Related Issues and PRs
+
+- Issue #2014: extract shared KB constants to prevent drift
+- Issue #2016: extract shared Supabase mock helper for tests
+- PR #2002: source code review that identified both issues
+
+### Learning Reference
+
+- `knowledge-base/project/learnings/2026-03-18-shared-test-helpers-extraction.md` -- same
+  pattern for bash test helpers. Key insight: "When two test files duplicate helper functions,
+  implementation drift is inevitable. Extract shared helpers early."
+
+### Files to Modify
+
+**New files:**
+
+- `apps/web-platform/lib/kb-constants.ts`
+- `apps/web-platform/test/helpers/mock-supabase.ts`
+
+**Modified files (constants):**
+
+- `apps/web-platform/server/kb-reader.ts` -- replace local `MAX_FILE_SIZE` with import
+- `apps/web-platform/server/context-validation.ts` -- replace local `MAX_CONTEXT_CONTENT_LENGTH`
+  with import
+- `apps/web-platform/app/api/attachments/presign/route.ts` -- replace local constants with imports
+- `apps/web-platform/components/chat/chat-input.tsx` -- replace local constants with imports
+
+**Modified files (mock helper migration):**
+
+- `apps/web-platform/test/presign-route.test.ts`
+- `apps/web-platform/test/vision-route.test.ts`
+- `apps/web-platform/test/disconnect-route.test.ts`
+- `apps/web-platform/test/account-delete.test.ts`
+
+## References
+
+- #2014 -- extract shared KB constants to prevent drift
+- #2016 -- extract shared Supabase mock helper for tests
+- `knowledge-base/project/learnings/2026-03-18-shared-test-helpers-extraction.md`

--- a/knowledge-base/project/plans/2026-04-12-fix-kb-constants-and-mock-helper-plan.md
+++ b/knowledge-base/project/plans/2026-04-12-fix-kb-constants-and-mock-helper-plan.md
@@ -213,20 +213,20 @@ The 3-4 files to migrate are:
 
 ## Acceptance Criteria
 
-- [ ] `lib/kb-constants.ts` exists with `KB_MAX_FILE_SIZE`, `ATTACHMENT_ALLOWED_TYPES`,
-      `ATTACHMENT_MAX_FILE_SIZE`, and `ATTACHMENT_MAX_FILES` exports
-- [ ] `server/kb-reader.ts` imports `KB_MAX_FILE_SIZE` from `@/lib/kb-constants`
-- [ ] `server/context-validation.ts` imports `KB_MAX_FILE_SIZE` from `@/lib/kb-constants`
-- [ ] `app/api/attachments/presign/route.ts` imports attachment constants from `@/lib/kb-constants`
-- [ ] `components/chat/chat-input.tsx` imports attachment constants from `@/lib/kb-constants`
-- [ ] No duplicate constant definitions remain in any of the four consumer files
-- [ ] `test/helpers/mock-supabase.ts` exists with `mockQueryChain` helper
-- [ ] `mockQueryChain` implements `.then()` for PromiseLike compatibility (thenable)
-- [ ] `mockQueryChain` supports `.single()` as a terminal that returns a separate thenable
-- [ ] 3-4 test files migrated to use the shared helper
-- [ ] All existing tests pass without changes to assertions
-- [ ] `lib/kb-constants.ts` does NOT include `"use client"` directive
-- [ ] `getExtension()` map stays in `presign/route.ts` (not extracted -- no duplication)
+- [x] `lib/kb-constants.ts` exists with `KB_MAX_FILE_SIZE` export
+      (attachment constants already extracted to `lib/attachment-constants.ts` on main)
+- [x] `server/kb-reader.ts` imports `KB_MAX_FILE_SIZE` from `@/lib/kb-constants`
+- [x] `server/context-validation.ts` imports `KB_MAX_FILE_SIZE` from `@/lib/kb-constants`
+- [x] `app/api/attachments/presign/route.ts` imports attachment constants from `@/lib/attachment-constants` (already done on main)
+- [x] `components/chat/chat-input.tsx` imports attachment constants from `@/lib/attachment-constants` (already done on main)
+- [x] No duplicate constant definitions remain in any of the four consumer files
+- [x] `test/helpers/mock-supabase.ts` exists with `mockQueryChain` helper
+- [x] `mockQueryChain` implements `.then()` for PromiseLike compatibility (thenable)
+- [x] `mockQueryChain` supports `.single()` as a terminal that returns a separate thenable
+- [x] 3 test files migrated to use the shared helper (vision-route, presign-route, disconnect-route)
+- [x] All existing tests pass without changes to assertions (1085 passed, 0 failed)
+- [x] `lib/kb-constants.ts` does NOT include `"use client"` directive
+- [x] `getExtension()` map stays in `presign/route.ts` (not extracted -- no duplication)
 
 ## Test Scenarios
 

--- a/knowledge-base/project/plans/2026-04-12-fix-kb-constants-and-mock-helper-plan.md
+++ b/knowledge-base/project/plans/2026-04-12-fix-kb-constants-and-mock-helper-plan.md
@@ -2,9 +2,26 @@
 title: "fix: extract shared KB constants and Supabase mock helper"
 type: fix
 date: 2026-04-12
+deepened: 2026-04-12
 ---
 
 # Extract shared KB constants and Supabase mock helper
+
+## Enhancement Summary
+
+**Deepened on:** 2026-04-12
+**Sections enhanced:** 3 (Proposed Solution Part 2, Test Scenarios, new Sharp Edges)
+**Research sources:** 4 institutional learnings, codebase analysis of 17 test files
+
+### Key Improvements
+
+1. Mock helper must implement `.then()` for PromiseLike compatibility (Supabase v2 query
+   builder is thenable -- documented in project learning `supabase-query-builder-mock-thenable-20260407`)
+2. All mock functions shared with `vi.mock()` factories must use `vi.hoisted()` -- the helper
+   must be designed to work with hoisted references, not export pre-built mocks
+3. Added concrete `mockQueryChain` implementation with variable-depth chaining and `.single()`
+   terminal support
+4. Added sharp edges section documenting three pitfalls from institutional learnings
 
 ## Overview
 
@@ -91,18 +108,98 @@ elsewhere, so it stays in the route file.
 Create `apps/web-platform/test/helpers/mock-supabase.ts` exporting reusable helpers for the
 two most common patterns:
 
-1. **`createMockSupabaseClient(overrides?)`** -- returns a mock client with `auth.getUser`
-   and `from` pre-wired to `vi.fn()` instances. Returns the mock functions for per-test
-   configuration.
+1. **`mockQueryChain(data, error?)`** -- returns a fluent chain mock that is **thenable**
+   (implements `.then()`) so `await chain.select().eq()` works. All chaining methods return
+   `this`; `.single()` returns a thenable resolving to `{ data, error }`.
 
-2. **`mockQueryChain(data, error?)`** -- returns a fluent chain mock
-   (`select().eq().eq().single()`) resolving to `{ data, error }`. Handles variable chain
-   depth.
+2. **`createMockSupabaseClient(overrides?)`** -- not a pre-built mock. Instead, a factory
+   that returns `{ mockGetUser, mockFrom }` vi.fn instances that test files wire into their
+   own `vi.hoisted()` + `vi.mock()` blocks. The helper cannot export a ready-made `vi.mock()`
+   factory because `vi.mock()` must be called at the top level of each test file.
+
+#### Research Insights: mockQueryChain Implementation
+
+The Supabase JS v2 query builder is a `PromiseLike` -- it implements `.then()` so queries
+can be `await`ed directly. Mocks that only make terminal methods (`.single()`, `.limit()`)
+return Promises break when queries are `await`ed without a terminal.
+
+**Concrete implementation pattern (from institutional learning):**
+
+```ts
+import { vi } from "vitest";
+
+/**
+ * Create a thenable query chain mock that supports variable-depth chaining.
+ * All chaining methods (.select, .eq, .in, .is, .order, .limit) return `this`.
+ * The chain is PromiseLike: `await chain.select().eq()` resolves to { data, error }.
+ * `.single()` returns a separate thenable resolving to { data, error }.
+ */
+export function mockQueryChain<T>(data: T, error: { message: string } | null = null) {
+  const result = { data, error };
+  const chain: Record<string, unknown> = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    neq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    range: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    upsert: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    // PromiseLike: allows `await chain.select().eq()`
+    then: (onfulfilled?: (v: unknown) => unknown) =>
+      Promise.resolve(result).then(onfulfilled),
+    // Terminal: `.single()` returns a separate thenable
+    single: vi.fn(() => ({
+      then: (onfulfilled?: (v: unknown) => unknown) =>
+        Promise.resolve(result).then(onfulfilled),
+    })),
+  };
+  // Make all chaining methods return `chain` (mockReturnThis needs the reference)
+  for (const key of ["select", "eq", "neq", "in", "is", "order", "limit", "range",
+                      "insert", "update", "upsert", "delete"]) {
+    (chain[key] as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+  }
+  return chain;
+}
+```
+
+#### Design Constraint: vi.hoisted() Compatibility
+
+The helper CANNOT export a `vi.mock()` factory because vitest hoists `vi.mock()` calls to
+the file top. Test files must still declare their own `vi.hoisted()` block and `vi.mock()`
+call. The helper provides building blocks, not a complete mock setup.
+
+**Usage pattern in test files:**
+
+```ts
+import { mockQueryChain } from "./helpers/mock-supabase";
+
+const { mockGetUser, mockFrom } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+  })),
+  createServiceClient: vi.fn(() => ({
+    from: mockFrom,
+  })),
+}));
+
+// In tests:
+mockFrom.mockReturnValue(mockQueryChain({ id: "123", name: "test" }));
+```
 
 **Scope decision -- incremental migration:** Do NOT rewrite all 17 test files in this PR.
 Instead:
 
-- Create the helper with the two functions above
+- Create the helper with `mockQueryChain` (primary value -- eliminates the chain boilerplate)
 - Migrate 3-4 representative test files to prove the helper works
 - Leave remaining files for incremental adoption (each future PR that touches a test file
   can migrate it)
@@ -123,12 +220,17 @@ The 3-4 files to migrate are:
 - [ ] `app/api/attachments/presign/route.ts` imports attachment constants from `@/lib/kb-constants`
 - [ ] `components/chat/chat-input.tsx` imports attachment constants from `@/lib/kb-constants`
 - [ ] No duplicate constant definitions remain in any of the four consumer files
-- [ ] `test/helpers/mock-supabase.ts` exists with `createMockSupabaseClient` and `mockQueryChain`
+- [ ] `test/helpers/mock-supabase.ts` exists with `mockQueryChain` helper
+- [ ] `mockQueryChain` implements `.then()` for PromiseLike compatibility (thenable)
+- [ ] `mockQueryChain` supports `.single()` as a terminal that returns a separate thenable
 - [ ] 3-4 test files migrated to use the shared helper
 - [ ] All existing tests pass without changes to assertions
+- [ ] `lib/kb-constants.ts` does NOT include `"use client"` directive
 - [ ] `getExtension()` map stays in `presign/route.ts` (not extracted -- no duplication)
 
 ## Test Scenarios
+
+### KB Constants (existing tests should continue passing)
 
 - Given kb-reader uses `KB_MAX_FILE_SIZE` from the shared module, when a file exceeds 1MB,
   then `readContent` throws `KbValidationError`
@@ -138,10 +240,19 @@ The 3-4 files to migrate are:
   20MB, then route returns 400 `file_too_large`
 - Given chat-input uses `ATTACHMENT_ALLOWED_TYPES` from shared module, when user attaches
   an unsupported type, then error is shown
-- Given `mockQueryChain({ id: "123" })` returns a fluent chain, when test calls
-  `.select().eq().single()`, then it resolves to `{ data: { id: "123" }, error: null }`
-- Given a migrated test file uses `createMockSupabaseClient`, when `vi.clearAllMocks()` runs
-  in `beforeEach`, then all mock functions are reset correctly
+
+### Mock Helper (new unit tests in `test/helpers/mock-supabase.test.ts`)
+
+- Given `mockQueryChain({ id: "123" })`, when `await chain.select("*").eq("id", "123")`,
+  then resolves to `{ data: { id: "123" }, error: null }` (thenable without terminal)
+- Given `mockQueryChain({ id: "123" })`, when `await chain.select().eq().single()`,
+  then resolves to `{ data: { id: "123" }, error: null }` (with `.single()` terminal)
+- Given `mockQueryChain(null, { message: "not found" })`, when `await chain.select().eq()`,
+  then resolves to `{ data: null, error: { message: "not found" } }` (error case)
+- Given a migrated test file uses `mockQueryChain`, when `vi.clearAllMocks()` runs in
+  `beforeEach`, then the chain's `vi.fn()` call counts are reset correctly
+- Given `mockQueryChain`, when used inside a `vi.mock()` factory via `vi.hoisted()`,
+  then the import resolves correctly (not blocked by hoisting)
 
 ## Domain Review
 
@@ -185,8 +296,44 @@ No cross-domain implications detected -- infrastructure/tooling change.
 - `apps/web-platform/test/disconnect-route.test.ts`
 - `apps/web-platform/test/account-delete.test.ts`
 
+## Sharp Edges
+
+These pitfalls are documented in institutional learnings and directly apply to this work:
+
+1. **Thenable mock is mandatory.** Supabase JS v2 query builder implements `PromiseLike`.
+   A mock that only makes `.single()` or `.limit()` return Promises will silently resolve
+   to `undefined` when the query is `await`ed without a terminal method. The `mockQueryChain`
+   helper MUST implement `.then()` on the chain object itself.
+   (Source: `learnings/test-failures/supabase-query-builder-mock-thenable-20260407.md`)
+
+2. **`vi.hoisted()` is required for shared mock references.** Any `vi.fn()` referenced inside
+   a `vi.mock()` factory must be declared via `vi.hoisted()`. The helper file can export
+   utility functions (like `mockQueryChain`) but NOT pre-declared `vi.fn()` instances that
+   test files pass into `vi.mock()` -- those must be hoisted per-file.
+   (Source: `learnings/test-failures/2026-04-06-vitest-mock-hoisting-requires-vi-hoisted.md`)
+
+3. **Module-level Supabase client timing.** Some modules call `createClient()` at module
+   scope (e.g., `agent-runner.ts`). For those, `mockFrom` must be wired inside the `vi.mock()`
+   factory, not in a `beforeEach`. This PR's migration candidates (`presign-route`,
+   `vision-route`, `disconnect-route`, `account-delete`) all use route handlers that call
+   `createClient()`/`createServiceClient()` per-request, so this is not a blocker -- but the
+   helper's documentation should note this constraint for future adopters.
+   (Source: `learnings/2026-04-06-vitest-module-level-supabase-mock-timing.md`)
+
+4. **`"use client"` directive in shared constants.** `chat-input.tsx` is a client component.
+   The shared `lib/kb-constants.ts` must NOT include `"use client"` -- it exports plain
+   constants that are tree-shakeable. Next.js correctly handles importing a server-compatible
+   module from a client component as long as the module only exports serializable values.
+
+5. **Test runner: use `npx vitest`, not `bunx vitest`.** The project uses vitest via npm.
+   `bunx vitest` fetches the latest version which may have incompatible native bindings.
+   (Source: `learnings/test-failures/2026-04-06-vitest-mock-hoisting-requires-vi-hoisted.md`)
+
 ## References
 
 - #2014 -- extract shared KB constants to prevent drift
 - #2016 -- extract shared Supabase mock helper for tests
 - `knowledge-base/project/learnings/2026-03-18-shared-test-helpers-extraction.md`
+- `knowledge-base/project/learnings/test-failures/supabase-query-builder-mock-thenable-20260407.md`
+- `knowledge-base/project/learnings/test-failures/2026-04-06-vitest-mock-hoisting-requires-vi-hoisted.md`
+- `knowledge-base/project/learnings/2026-04-06-vitest-module-level-supabase-mock-timing.md`

--- a/knowledge-base/project/specs/feat-fix-2014-2016-kb-constants-and-mock-helper/session-state.md
+++ b/knowledge-base/project/specs/feat-fix-2014-2016-kb-constants-and-mock-helper/session-state.md
@@ -1,0 +1,22 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-fix-2014-2016-kb-constants-and-mock-helper/knowledge-base/project/plans/2026-04-12-fix-kb-constants-and-mock-helper-plan.md
+- Status: complete
+
+### Errors
+None
+
+### Decisions
+- **Issue #2014 scope adjusted:** The original issue referenced `ALLOWED_EXTENSIONS` in `file-tree.tsx` which no longer exists. Current duplication is between `kb-reader.ts`/`context-validation.ts` (1MB KB limit) and `presign/route.ts`/`chat-input.tsx` (20MB attachment constants). Plan addresses both groups.
+- **Incremental mock migration:** Only 3-4 of the 17 test files with Supabase mocks will be migrated in this PR. Remaining files adopt incrementally when touched by future PRs.
+- **mockQueryChain must be thenable:** Institutional learning (`supabase-query-builder-mock-thenable-20260407`) documents that Supabase v2 query builder is `PromiseLike`. The helper implements `.then()` on the chain itself, not just on terminal methods.
+- **Helper exports building blocks, not vi.mock factories:** Due to vitest hoisting constraints (`vi.hoisted()` requirement), the helper exports `mockQueryChain` as a utility function, not pre-built mock instances. Test files still declare their own `vi.hoisted()` + `vi.mock()` blocks.
+- **No cross-domain implications:** Both issues are pure engineering refactors with no product, marketing, legal, or operational impact.
+
+### Components Invoked
+- `soleur:plan` (skill)
+- `soleur:deepen-plan` (skill)
+- GitHub CLI (`gh issue view #2014`, `gh issue view #2016`)
+- Institutional learnings search (4 relevant learnings applied)
+- markdownlint-cli2 (validation)

--- a/knowledge-base/project/specs/feat-fix-2014-2016-kb-constants-and-mock-helper/tasks.md
+++ b/knowledge-base/project/specs/feat-fix-2014-2016-kb-constants-and-mock-helper/tasks.md
@@ -2,24 +2,28 @@
 
 ## Phase 1: KB Constants Extraction
 
-- [ ] 1.1 Create `apps/web-platform/lib/kb-constants.ts` with `KB_MAX_FILE_SIZE`, `ATTACHMENT_ALLOWED_TYPES`, `ATTACHMENT_MAX_FILE_SIZE`, `ATTACHMENT_MAX_FILES`
-- [ ] 1.2 Update `apps/web-platform/server/kb-reader.ts` to import `KB_MAX_FILE_SIZE` from `@/lib/kb-constants`, remove local constant
-- [ ] 1.3 Update `apps/web-platform/server/context-validation.ts` to import `KB_MAX_FILE_SIZE` from `@/lib/kb-constants`, remove local `MAX_CONTEXT_CONTENT_LENGTH`
-- [ ] 1.4 Update `apps/web-platform/app/api/attachments/presign/route.ts` to import `ATTACHMENT_ALLOWED_TYPES`, `ATTACHMENT_MAX_FILE_SIZE`, `ATTACHMENT_MAX_FILES` from `@/lib/kb-constants`, remove local constants
-- [ ] 1.5 Update `apps/web-platform/components/chat/chat-input.tsx` to import `ATTACHMENT_ALLOWED_TYPES`, `ATTACHMENT_MAX_FILE_SIZE`, `ATTACHMENT_MAX_FILES` from `@/lib/kb-constants`, remove local constants
-- [ ] 1.6 Run tests to verify no regressions: `cd apps/web-platform && npx vitest run`
+- [ ] 1.1 Create `apps/web-platform/lib/kb-constants.ts` with `KB_MAX_FILE_SIZE`, `ATTACHMENT_ALLOWED_TYPES`, `ATTACHMENT_MAX_FILE_SIZE`, `ATTACHMENT_MAX_FILES` (no `"use client"` directive)
+- [ ] 1.2 Update `apps/web-platform/server/kb-reader.ts` to import `KB_MAX_FILE_SIZE` from `@/lib/kb-constants`, remove local `MAX_FILE_SIZE` constant
+- [ ] 1.3 Update `apps/web-platform/server/context-validation.ts` to import `KB_MAX_FILE_SIZE` from `@/lib/kb-constants`, remove local `MAX_CONTEXT_CONTENT_LENGTH` and its comment
+- [ ] 1.4 Update `apps/web-platform/app/api/attachments/presign/route.ts` to import `ATTACHMENT_ALLOWED_TYPES`, `ATTACHMENT_MAX_FILE_SIZE`, `ATTACHMENT_MAX_FILES` from `@/lib/kb-constants`, remove local `ALLOWED_CONTENT_TYPES`, `MAX_FILE_SIZE`, `MAX_FILES_PER_MESSAGE`
+- [ ] 1.5 Update `apps/web-platform/components/chat/chat-input.tsx` to import `ATTACHMENT_ALLOWED_TYPES`, `ATTACHMENT_MAX_FILE_SIZE`, `ATTACHMENT_MAX_FILES` from `@/lib/kb-constants`, remove local `ALLOWED_TYPES`, `MAX_FILE_SIZE`, `MAX_FILES`
+- [ ] 1.6 Run tests: `cd apps/web-platform && npx vitest run`
 
 ## Phase 2: Supabase Mock Helper
 
-- [ ] 2.1 Create `apps/web-platform/test/helpers/mock-supabase.ts` with `createMockSupabaseClient` and `mockQueryChain` helpers
-- [ ] 2.2 Migrate `test/vision-route.test.ts` to use shared helper (replace inline `mockQueryBuilder`)
-- [ ] 2.3 Migrate `test/presign-route.test.ts` to use shared helper (replace `setupConversationOwnership` chain)
-- [ ] 2.4 Migrate `test/disconnect-route.test.ts` to use shared helper
-- [ ] 2.5 Migrate `test/account-delete.test.ts` to use shared helper
-- [ ] 2.6 Run tests to verify no regressions: `cd apps/web-platform && npx vitest run`
+- [ ] 2.1 Create `apps/web-platform/test/helpers/mock-supabase.ts` with `mockQueryChain` helper (must be thenable -- implement `.then()` for PromiseLike compatibility)
+- [ ] 2.1.1 Ensure `mockQueryChain` supports: `.select()`, `.eq()`, `.neq()`, `.in()`, `.is()`, `.order()`, `.limit()`, `.range()`, `.insert()`, `.update()`, `.upsert()`, `.delete()` as chaining methods (all return `this`)
+- [ ] 2.1.2 Ensure `.single()` returns a separate thenable resolving to `{ data, error }`
+- [ ] 2.1.3 Ensure `await chain.select().eq()` (no terminal) resolves via `.then()` on the chain itself
+- [ ] 2.2 Create `apps/web-platform/test/helpers/mock-supabase.test.ts` with unit tests for `mockQueryChain`
+- [ ] 2.3 Migrate `test/vision-route.test.ts` -- replace inline `mockQueryBuilder` (lines 61-70) with `mockQueryChain` import
+- [ ] 2.4 Migrate `test/presign-route.test.ts` -- replace `setupConversationOwnership` chain mock (lines 77-91) with `mockQueryChain`
+- [ ] 2.5 Migrate `test/disconnect-route.test.ts` -- use `mockQueryChain` for `mockFrom` implementation
+- [ ] 2.6 Migrate `test/account-delete.test.ts` -- use `mockQueryChain` where chain mocks are built inline
+- [ ] 2.7 Run tests: `cd apps/web-platform && npx vitest run`
 
 ## Phase 3: Verification and Cleanup
 
-- [ ] 3.1 Grep for remaining duplicate constant definitions to confirm none remain
+- [ ] 3.1 Grep for remaining duplicate KB constant definitions: `grep -rn 'const MAX_FILE_SIZE\|const ALLOWED_CONTENT_TYPES\|const ALLOWED_TYPES\|const MAX_FILES' apps/web-platform/` -- only `lib/kb-constants.ts` and unrelated `agent-runner.ts` (20MB attachment) should match
 - [ ] 3.2 Verify all modified test files pass individually
-- [ ] 3.3 Run full test suite one final time
+- [ ] 3.3 Run full test suite one final time: `cd apps/web-platform && npx vitest run`

--- a/knowledge-base/project/specs/feat-fix-2014-2016-kb-constants-and-mock-helper/tasks.md
+++ b/knowledge-base/project/specs/feat-fix-2014-2016-kb-constants-and-mock-helper/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: Extract shared KB constants and Supabase mock helper
+
+## Phase 1: KB Constants Extraction
+
+- [ ] 1.1 Create `apps/web-platform/lib/kb-constants.ts` with `KB_MAX_FILE_SIZE`, `ATTACHMENT_ALLOWED_TYPES`, `ATTACHMENT_MAX_FILE_SIZE`, `ATTACHMENT_MAX_FILES`
+- [ ] 1.2 Update `apps/web-platform/server/kb-reader.ts` to import `KB_MAX_FILE_SIZE` from `@/lib/kb-constants`, remove local constant
+- [ ] 1.3 Update `apps/web-platform/server/context-validation.ts` to import `KB_MAX_FILE_SIZE` from `@/lib/kb-constants`, remove local `MAX_CONTEXT_CONTENT_LENGTH`
+- [ ] 1.4 Update `apps/web-platform/app/api/attachments/presign/route.ts` to import `ATTACHMENT_ALLOWED_TYPES`, `ATTACHMENT_MAX_FILE_SIZE`, `ATTACHMENT_MAX_FILES` from `@/lib/kb-constants`, remove local constants
+- [ ] 1.5 Update `apps/web-platform/components/chat/chat-input.tsx` to import `ATTACHMENT_ALLOWED_TYPES`, `ATTACHMENT_MAX_FILE_SIZE`, `ATTACHMENT_MAX_FILES` from `@/lib/kb-constants`, remove local constants
+- [ ] 1.6 Run tests to verify no regressions: `cd apps/web-platform && npx vitest run`
+
+## Phase 2: Supabase Mock Helper
+
+- [ ] 2.1 Create `apps/web-platform/test/helpers/mock-supabase.ts` with `createMockSupabaseClient` and `mockQueryChain` helpers
+- [ ] 2.2 Migrate `test/vision-route.test.ts` to use shared helper (replace inline `mockQueryBuilder`)
+- [ ] 2.3 Migrate `test/presign-route.test.ts` to use shared helper (replace `setupConversationOwnership` chain)
+- [ ] 2.4 Migrate `test/disconnect-route.test.ts` to use shared helper
+- [ ] 2.5 Migrate `test/account-delete.test.ts` to use shared helper
+- [ ] 2.6 Run tests to verify no regressions: `cd apps/web-platform && npx vitest run`
+
+## Phase 3: Verification and Cleanup
+
+- [ ] 3.1 Grep for remaining duplicate constant definitions to confirm none remain
+- [ ] 3.2 Verify all modified test files pass individually
+- [ ] 3.3 Run full test suite one final time

--- a/plugins/soleur/skills/one-shot/SKILL.md
+++ b/plugins/soleur/skills/one-shot/SKILL.md
@@ -106,15 +106,15 @@ After the subagent returns, check for a `## Session Summary` heading in the outp
 > **CONTINUATION GATE**: When work outputs `## Work Phase Complete`, that is your signal to continue. Do NOT end your turn. Do NOT treat "Implementation complete" or similar phrases as a stopping point. Immediately proceed to step 4 in the same response.
 
 4. Use the **Skill tool**: `skill: soleur:review`
-5. **Resolve P1 review findings.** List open GitHub issues with `code-review` + `priority/p1-high` labels:
+5. **Resolve ALL review findings (P1, P2, and P3).** Technical debt compounds — fix everything now, not later. List open GitHub issues from this review session:
 
    ```bash
-   gh issue list --label code-review --label priority/p1-high --state open --search "PR #<current_pr_number>" --json number,title,body
+   gh issue list --label code-review --state open --search "PR #<current_pr_number>" --json number,title,body,labels
    ```
 
    The `--search` flag scopes results to issues from this review session (the review skill's issue template includes `PR #<number>` in the body). If zero issues match, proceed immediately to Step 5.5.
 
-   For each matching P1 issue, spawn a parallel `pr-comment-resolver` agent. Pass the issue body's `## Problem`, `## Proposed Fix`, and `Location:` fields as the agent's input. After all agents return, commit fixes and close each resolved issue:
+   For each matching issue (regardless of priority), spawn a parallel `pr-comment-resolver` agent. Pass the issue body's `## Problem`, `## Proposed Fix`, and `Location:` fields as the agent's input. After all agents return, commit fixes and close each resolved issue:
 
    ```bash
    gh issue close <number> --comment "Fixed in <commit-sha>"


### PR DESCRIPTION
## Summary

- Extract `KB_MAX_FILE_SIZE` from `kb-reader.ts` and `context-validation.ts` into shared `lib/kb-constants.ts`
- Create `test/helpers/mock-supabase.ts` with thenable `mockQueryChain` helper matching Supabase JS v2 query builder
- Migrate 3 test files (vision-route, presign-route, disconnect-route) to use the shared helper
- Add `MockQueryChain` interface for type-safe returns
- Update one-shot pipeline to resolve all review findings (P1-P3), not just P1

Closes #2014
Closes #2016

## Changelog

### Web Platform
- Extract `KB_MAX_FILE_SIZE` constant into `lib/kb-constants.ts` to prevent drift between `kb-reader.ts` and `context-validation.ts`
- Add `mockQueryChain` test helper with PromiseLike support for Supabase v2 query builder mocks
- Migrate 3 test files to shared mock helper, removing ~28 lines of duplicated chain boilerplate

### Plugin
- Update one-shot pipeline Step 5 to resolve P1, P2, and P3 review findings (prevents technical debt accumulation)

## Test plan

- [x] All 1084 tests pass (102 files, 0 failures)
- [x] All 9 test suites pass via test-all.sh
- [x] mockQueryChain helper has 6 dedicated tests covering thenable, terminal, error, variable-depth, reset, and mutation patterns
- [x] Migrated test files produce identical behavior with shared helper

Generated with [Claude Code](https://claude.com/claude-code)