### PR TITLE
fix(ci): replace invalid codeql-to-issues trigger with schedule polling

### DIFF
--- a/.github/workflows/codeql-to-issues.yml
+++ b/.github/workflows/codeql-to-issues.yml
@@ -1,51 +1,70 @@
-# Create a GitHub issue when CodeQL finds a new code scanning alert.
+# Poll CodeQL code scanning alerts and create GitHub issues for new findings.
 # Integrates with auto-label-security.yml via "sec:" title prefix.
 # Deduplicates by checking for existing open issues with the alert number.
+#
+# Note: code_scanning_alert is NOT a valid GitHub Actions trigger event.
+# This workflow uses schedule + workflow_dispatch instead.
 
 name: CodeQL Alert to Issue
 
 on:
-  code_scanning_alert:
-    types: [created]
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
 
 permissions:
   issues: write
   security-events: read
 
 jobs:
-  create-issue:
+  check-alerts:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
-      - name: Create issue from alert
+      - name: Process open CodeQL alerts
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          ALERT_NUMBER: ${{ github.event.alert.number }}
-          ALERT_RULE_ID: ${{ github.event.alert.rule.id }}
-          ALERT_RULE_DESC: ${{ github.event.alert.rule.description }}
-          ALERT_SEVERITY: ${{ github.event.alert.rule.security_severity_level }}
-          ALERT_TOOL: ${{ github.event.alert.tool.name }}
-          ALERT_FILE: ${{ github.event.alert.most_recent_instance.location.path }}
-          ALERT_START_LINE: ${{ github.event.alert.most_recent_instance.location.start_line }}
-          ALERT_MESSAGE: ${{ github.event.alert.most_recent_instance.message.text }}
-          ALERT_HTML_URL: ${{ github.event.alert.html_url }}
-          ALERT_REF: ${{ github.event.alert.most_recent_instance.ref }}
         run: |
-          SEARCH_QUERY="sec: CodeQL alert #${ALERT_NUMBER} repo:${GH_REPO} is:issue is:open"
-          EXISTING=$(gh search issues "$SEARCH_QUERY" --json number --jq 'length')
-          if [ "$EXISTING" -gt 0 ]; then
-            echo "Issue already exists for CodeQL alert #${ALERT_NUMBER} — skipping"
+          echo "Fetching open code scanning alerts..."
+          ALERTS=$(gh api repos/${GH_REPO}/code-scanning/alerts?state=open --jq '.[] | select(.rule.security_severity_level == "critical" or .rule.security_severity_level == "high") | {number, rule_id: .rule.id, rule_desc: .rule.description, severity: .rule.security_severity_level, tool: .tool.name, file: .most_recent_instance.location.path, line: .most_recent_instance.location.start_line, message: .most_recent_instance.message.text, html_url: .html_url, ref: .most_recent_instance.ref}' 2>&1) || true
+
+          if [ -z "$ALERTS" ]; then
+            echo "No open critical/high severity alerts found."
             exit 0
           fi
 
-          TITLE="sec: CodeQL alert #${ALERT_NUMBER} — ${ALERT_RULE_DESC}"
+          CREATED=0
+          SKIPPED=0
 
-          { echo "## CodeQL Alert #${ALERT_NUMBER}"; echo ""; echo "**Rule:** \`${ALERT_RULE_ID}\` — ${ALERT_RULE_DESC}"; echo "**Severity:** ${ALERT_SEVERITY}"; echo "**Tool:** ${ALERT_TOOL}"; echo "**File:** \`${ALERT_FILE}:${ALERT_START_LINE}\`"; echo "**Ref:** \`${ALERT_REF}\`"; echo ""; echo "### Message"; echo ""; echo "${ALERT_MESSAGE}"; echo ""; echo "### Links"; echo ""; echo "- [View alert](${ALERT_HTML_URL})"; echo ""; echo "---"; echo "*Auto-created by codeql-to-issues.yml*"; } > "${RUNNER_TEMP}/issue-body.md"
+          echo "$ALERTS" | jq -c '.' | while IFS= read -r alert; do
+            ALERT_NUMBER=$(echo "$alert" | jq -r '.number')
+            ALERT_RULE_ID=$(echo "$alert" | jq -r '.rule_id')
+            ALERT_RULE_DESC=$(echo "$alert" | jq -r '.rule_desc')
+            ALERT_SEVERITY=$(echo "$alert" | jq -r '.severity')
+            ALERT_TOOL=$(echo "$alert" | jq -r '.tool')
+            ALERT_FILE=$(echo "$alert" | jq -r '.file')
+            ALERT_LINE=$(echo "$alert" | jq -r '.line')
+            ALERT_MESSAGE=$(echo "$alert" | jq -r '.message')
+            ALERT_HTML_URL=$(echo "$alert" | jq -r '.html_url')
+            ALERT_REF=$(echo "$alert" | jq -r '.ref')
 
-          gh issue create \
-            --title "$TITLE" \
-            --body-file "${RUNNER_TEMP}/issue-body.md" \
-            --label "type/security"
+            SEARCH_QUERY="sec: CodeQL alert #${ALERT_NUMBER} repo:${GH_REPO} is:issue is:open"
+            EXISTING=$(gh search issues "$SEARCH_QUERY" --json number --jq 'length' 2>/dev/null || echo "0")
 
-          echo "Created issue for CodeQL alert #${ALERT_NUMBER}"
+            if [ "$EXISTING" -gt 0 ]; then
+              echo "Issue already exists for CodeQL alert #${ALERT_NUMBER} — skipping"
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            TITLE="sec: CodeQL alert #${ALERT_NUMBER} — ${ALERT_RULE_DESC}"
+
+            { echo "## CodeQL Alert #${ALERT_NUMBER}"; echo ""; echo "**Rule:** \`${ALERT_RULE_ID}\` — ${ALERT_RULE_DESC}"; echo "**Severity:** ${ALERT_SEVERITY}"; echo "**Tool:** ${ALERT_TOOL}"; echo "**File:** \`${ALERT_FILE}:${ALERT_LINE}\`"; echo "**Ref:** \`${ALERT_REF}\`"; echo ""; echo "### Message"; echo ""; echo "${ALERT_MESSAGE}"; echo ""; echo "### Links"; echo ""; echo "- [View alert](${ALERT_HTML_URL})"; echo ""; echo "---"; echo "*Auto-created by codeql-to-issues.yml*"; } > "${RUNNER_TEMP}/issue-body-${ALERT_NUMBER}.md"
+
+            gh issue create --title "$TITLE" --body-file "${RUNNER_TEMP}/issue-body-${ALERT_NUMBER}.md" --label "type/security"
+            echo "Created issue for CodeQL alert #${ALERT_NUMBER} (severity: ${ALERT_SEVERITY})"
+            CREATED=$((CREATED + 1))
+          done
+
+          echo "Done. Created: ${CREATED}, Skipped (existing): ${SKIPPED}"

--- a/knowledge-base/project/learnings/2026-04-13-codeql-to-issues-invalid-workflow-trigger.md
+++ b/knowledge-base/project/learnings/2026-04-13-codeql-to-issues-invalid-workflow-trigger.md
@@ -1,0 +1,73 @@
+---
+title: "CodeQL to Issues: Invalid Workflow Trigger and Polling Alternative"
+date: 2026-04-13
+category: integration-issues
+tags: [github-actions, codeql, code-scanning, workflow-triggers, ci]
+---
+
+# Learning: CodeQL to Issues — Invalid Workflow Trigger and Polling Alternative
+
+## Problem
+
+The `codeql-to-issues.yml` workflow was failing on every push with "This run likely failed
+because of a workflow file issue" and zero jobs executed. The failure was pre-existing (7/8
+workflows passing) and affected all branches. The workflow used `on: code_scanning_alert:
+types: [created]` as its trigger.
+
+## Root Cause
+
+`code_scanning_alert` is **not** a valid GitHub Actions workflow trigger. It is a webhook-only
+event. GitHub Actions supports approximately 33 valid `on:` event triggers (documented at
+<https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs>).
+`code_scanning_alert` does not appear in that list.
+
+When an `on:` block references an unknown event, GitHub Actions cannot parse the workflow file
+and creates a failed run entry with zero jobs on every push. This was introduced in PR #2029
+without validating the event name against the official trigger list.
+
+## Solution
+
+Replace the invalid `on: code_scanning_alert` trigger with a polling approach:
+
+```yaml
+on:
+  schedule:
+    - cron: '0 6 * * *'   # daily at 06:00 UTC
+  workflow_dispatch:       # manual trigger
+```
+
+Change the implementation from event-driven (react to each alert as it fires) to polling-based
+(query the code scanning API for all currently open alerts). Apply false-positive filtering:
+
+- Only process alerts with `critical` or `high` severity — skip `medium` and `low`.
+- Only process `open` state alerts — skip `dismissed` and `fixed`.
+- Deduplicate by searching existing GitHub issues before creating a new one.
+
+## Session Errors
+
+1. **`git fetch origin main:main` failed** — local `main` was checked out in another worktree,
+   making the ref locked for fast-forward.
+   **Prevention:** Use `origin/main` directly (`git show origin/main:<path>`) when local `main`
+   may be locked in a parallel worktree.
+
+2. **`git show main:<path>` returned stale data** — the local `main` ref was behind `origin`
+   because the fetch had failed.
+   **Prevention:** After any fetch failure, always use the `origin/main` ref rather than the
+   local `main` ref to read files.
+
+3. **First worktree was created from stale local `main`** — worktree-manager used the locked
+   local `main`, so the worktree started from an outdated base. It was auto-cleaned.
+   **Prevention:** worktree-manager should fall back to `origin/main` when local `main`
+   fast-forward fails.
+
+4. **`gh pr view --json merged` failed** — `merged` is not a valid JSON field for `gh pr view`.
+   **Prevention:** Use `mergedAt` (returns a timestamp or null) instead of `merged`. Verify
+   field names with `gh pr view --help` before scripting.
+
+## Key Insight
+
+Not all GitHub webhook events are valid GitHub Actions workflow triggers. Always verify an
+event name against the official Actions trigger list before adding it to an `on:` block. When
+a webhook event has no corresponding Actions trigger, schedule-based polling (`cron`) plus
+`workflow_dispatch` is a robust alternative: it trades real-time response for simplicity and
+debuggability, and deduplication logic in the job body prevents duplicate issues.


### PR DESCRIPTION
## Summary
- `code_scanning_alert` is not a valid GitHub Actions workflow trigger (webhook-only event)
- Every push to any branch created a zero-job failed run with 'workflow file issue'
- Replaced with `schedule` (daily 06:00 UTC) + `workflow_dispatch` that polls the code scanning API
- Added false-positive filtering: only `critical`/`high` severity, only `open` state alerts

## Changelog
- Replace invalid `on: code_scanning_alert` trigger with `schedule` + `workflow_dispatch`
- Add API-based polling of code scanning alerts via `gh api`
- Filter alerts by severity (critical/high only) and state (open only)
- Deduplicate via GitHub issue search before creating

## Test plan
- [x] YAML validated with Python yaml parser
- [x] No heredocs or left-aligned content (AGENTS.md compliance)
- [x] Verified 0 open critical/high alerts currently (no spam on first run)
- [ ] Trigger manual run after merge (`gh workflow run codeql-to-issues.yml`)

Generated with [Claude Code](https://claude.com/claude-code)