### PR TITLE
fix(ci): re-enable growth audit cron schedule

### DIFF
--- a/.github/workflows/scheduled-growth-audit.yml
+++ b/.github/workflows/scheduled-growth-audit.yml
@@ -15,10 +15,8 @@
 name: "Scheduled: Growth Audit"
 
 on:
-  # MIGRATED TO CLOUD SCHEDULED TASK — 2026-03-25
-  # Uncomment schedule to revert to GHA execution
-  # schedule:
-  #   - cron: '0 9 * * 1'   # Every Monday at 09:00 UTC
+  schedule:
+    - cron: '0 9 * * 1'   # Every Monday at 09:00 UTC
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Re-enables the weekly Monday cron schedule (`0 9 * * 1`) for the Growth Audit GHA workflow
- The schedule was commented out on 2026-03-25 when migrated to a Cloud Remote Trigger, but the trigger silently failed every week because it cannot load Soleur plugin skills (`Unknown skill: soleur:growth audit`)
- The Cloud Remote Trigger has been disabled — GHA is the correct execution environment since `claude-code-action` has full plugin support via `plugin_marketplaces`

Closes #2049

## Test plan
- [ ] After merge, trigger a manual run: `gh workflow run scheduled-growth-audit.yml`
- [ ] Verify the workflow completes successfully and creates a GitHub issue with audit findings
- [ ] Confirm next Monday's scheduled run fires automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)