### PR TITLE
fix(billing): address review findings from #2036

### DIFF
--- a/apps/web-platform/components/settings/billing-section.tsx
+++ b/apps/web-platform/components/settings/billing-section.tsx
@@ -36,14 +36,14 @@ export function BillingSection({
       })
     : null;
 
-  async function handlePortalRedirect() {
+  async function redirectTo(endpoint: string, fallbackError: string) {
     setLoading(true);
     setError("");
     try {
-      const res = await fetch("/api/billing/portal", { method: "POST" });
+      const res = await fetch(endpoint, { method: "POST" });
       const data = await res.json();
       if (!res.ok) {
-        setError(data.error || "Failed to open billing portal");
+        setError(data.error || fallbackError);
         return;
       }
       if (data.url) {
@@ -56,25 +56,10 @@ export function BillingSection({
     }
   }
 
-  async function handleSubscribe() {
-    setLoading(true);
-    setError("");
-    try {
-      const res = await fetch("/api/checkout", { method: "POST" });
-      const data = await res.json();
-      if (!res.ok) {
-        setError(data.error || "Failed to create checkout session");
-        return;
-      }
-      if (data.url) {
-        window.location.href = data.url;
-      }
-    } catch {
-      setError("Something went wrong. Please try again.");
-    } finally {
-      setLoading(false);
-    }
-  }
+  const handlePortalRedirect = () =>
+    redirectTo("/api/billing/portal", "Failed to open billing portal");
+  const handleSubscribe = () =>
+    redirectTo("/api/checkout", "Failed to create checkout session");
 
   return (
     <section>

--- a/apps/web-platform/components/settings/cancel-retention-modal.tsx
+++ b/apps/web-platform/components/settings/cancel-retention-modal.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useRef } from "react";
+
 interface CancelRetentionModalProps {
   open: boolean;
   onClose: () => void;
@@ -17,6 +19,49 @@ export function CancelRetentionModal({
   serviceTokenCount,
   createdAt,
 }: CancelRetentionModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
+
+  useEffect(() => {
+    if (!open) return;
+
+    triggerRef.current = document.activeElement as HTMLElement;
+    dialogRef.current?.focus();
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onCloseRef.current();
+        return;
+      }
+
+      if (e.key === "Tab" && dialogRef.current) {
+        const focusable = dialogRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last?.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first?.focus();
+        }
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      triggerRef.current?.focus();
+    };
+  }, [open]);
+
   if (!open) return null;
 
   const daysSinceSignup = Math.floor(
@@ -38,8 +83,18 @@ export function CancelRetentionModal({
         onClick={onClose}
         role="presentation"
       />
-      <div className="relative w-full max-w-md rounded-xl border border-neutral-800 bg-neutral-900 p-8">
-        <h3 className="mb-2 text-xl font-semibold text-white">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="retention-heading"
+        tabIndex={-1}
+        className="relative w-full max-w-md rounded-xl border border-neutral-800 bg-neutral-900 p-8"
+      >
+        <h3
+          id="retention-heading"
+          className="mb-2 text-xl font-semibold text-white"
+        >
           Before you go...
         </h3>
         <p className="mb-6 text-sm text-neutral-400">

--- a/apps/web-platform/supabase/migrations/021_unique_stripe_subscription.sql
+++ b/apps/web-platform/supabase/migrations/021_unique_stripe_subscription.sql
@@ -1,0 +1,7 @@
+-- Prevent duplicate subscription records from concurrent checkout race.
+-- Partial index: only enforces uniqueness on non-null values, so rows
+-- where stripe_subscription_id IS NULL are unaffected.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_stripe_subscription_id_unique
+  ON public.users (stripe_subscription_id)
+  WHERE stripe_subscription_id IS NOT NULL;

--- a/apps/web-platform/test/cancel-retention-modal.test.tsx
+++ b/apps/web-platform/test/cancel-retention-modal.test.tsx
@@ -79,4 +79,19 @@ describe("CancelRetentionModal", () => {
       screen.getByRole("button", { name: /continue to cancel/i }),
     ).toBeInTheDocument();
   });
+
+  it("has role=dialog and aria-modal=true", () => {
+    render(<CancelRetentionModal {...BASE_PROPS} />);
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-labelledby", "retention-heading");
+  });
+
+  it("calls onClose when Escape key is pressed", () => {
+    render(<CancelRetentionModal {...BASE_PROPS} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(BASE_PROPS.onClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/knowledge-base/project/learnings/2026-04-13-billing-review-findings-batch-fix.md
+++ b/knowledge-base/project/learnings/2026-04-13-billing-review-findings-batch-fix.md
@@ -1,0 +1,49 @@
+# Learning: Billing code-review fixes — race condition, accessibility, duplication
+
+## Problem
+
+PR #2036 code review surfaced four issues in the billing/settings area:
+
+1. **#2046 — Checkout race window**: The checkout route reads `subscription_status` then creates a Stripe session — not atomic. Two rapid requests can both read `null` and create duplicate sessions.
+2. **#2047 — Modal accessibility**: `CancelRetentionModal` used `role="presentation"` on the backdrop but lacked `role="dialog"`, `aria-modal`, focus trapping, Escape key handling, and focus restoration.
+3. **#2048 — Duplicated fetch-redirect**: `handlePortalRedirect` and `handleSubscribe` in `billing-section.tsx` were near-identical, differing only in URL and error message.
+4. **#2065 — Unapplied migration**: Migration 020 (subscription billing columns) needed production verification.
+
+## Solution
+
+1. **Race condition**: Added migration 021 with a partial unique index: `CREATE UNIQUE INDEX idx_users_stripe_subscription_id_unique ON public.users (stripe_subscription_id) WHERE stripe_subscription_id IS NOT NULL`. This makes the webhook handler's write fail-safe at the DB level.
+2. **Accessibility**: Added `role="dialog"`, `aria-modal="true"`, `aria-labelledby="retention-heading"` to the dialog container. Added `useEffect` with focus trapping (Tab cycle), Escape key handler via `onCloseRef` pattern, and focus restoration to trigger element on close.
+3. **Duplication**: Extracted `redirectTo(endpoint, fallbackError)` helper. `handlePortalRedirect` and `handleSubscribe` now delegate to it.
+4. **Migration**: Verified via Supabase REST API — columns exist, 200 response. Closed #2065.
+
+All three code fixes shipped in one PR to minimize review overhead.
+
+## Key Insight
+
+Partial unique indexes (`WHERE col IS NOT NULL`) are ideal for optional foreign keys like `stripe_subscription_id` — they prevent duplicates on populated rows without blocking the default NULL state. This is the right level for race condition defense: DB constraints survive concurrent requests that application-level checks cannot.
+
+Modal accessibility requires five things working together: `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, focus trapping, and Escape-to-close with focus restoration. Missing any one breaks the experience for screen reader and keyboard users.
+
+## Prevention
+
+- **Race conditions on payment endpoints**: Ask "does this endpoint handle concurrent requests safely?" during review. Enforce partial unique indexes or idempotency keys for payment-related writes.
+- **Modal accessibility**: Consider a shared `<Modal>` base component with accessibility built in, or add `eslint-plugin-jsx-a11y` rules requiring `role="dialog"` and `aria-modal` on modal patterns.
+- **Code duplication**: When review spots two instances of the same pattern, extraction should be mandatory before merge.
+- **Unapplied migrations**: The existing workflow gate (verify via REST API post-merge) caught this. Continue enforcing.
+
+## Session Errors
+
+1. **Stale local main in worktree creation** — The `worktree-manager.sh create` reported "Could not fast-forward local main — using origin/main" but the worktree was created at the old local main commit (`613169a5`), missing all PR #2036 files. Required manual `git rebase origin/main`. **Prevention:** The worktree manager's origin/main fallback may not be working as intended — investigate whether the script actually checks out from origin/main when local fast-forward fails.
+
+## Cross-References
+
+- `knowledge-base/project/learnings/2026-03-20-websocket-first-message-auth-toctou-race.md` — analogous TOCTOU race pattern
+- `knowledge-base/project/learnings/2026-03-21-kb-migration-verification-pitfalls.md` — migration verification approach
+- `knowledge-base/project/learnings/2026-03-20-csrf-three-layer-defense-nextjs-api-routes.md` — `validateOrigin` pattern used in billing routes
+
+## Tags
+
+category: code-review
+module: apps/web-platform/billing
+issues: #2046, #2047, #2048, #2065
+pr: #2036


### PR DESCRIPTION
## Summary

- Add partial unique index on `stripe_subscription_id` to prevent duplicate subscriptions from concurrent checkout race (#2046)
- Add `role="dialog"`, `aria-modal`, focus trapping, Escape key handling, and focus restoration to CancelRetentionModal (#2047)
- Extract shared `redirectTo` helper to replace duplicate fetch-redirect functions in billing section (#2048)

Closes #2046, Closes #2047, Closes #2048

## Changelog

- **Billing API**: New migration (021) adds partial unique index on `stripe_subscription_id` — prevents duplicate subscriptions at DB level even under concurrent checkout requests
- **Settings UI**: CancelRetentionModal now meets WCAG accessibility requirements — dialog role, focus trap, keyboard navigation, focus restoration
- **Settings UI**: Billing section uses single `redirectTo(endpoint, error)` helper instead of two near-identical functions

## Test plan

- [x] All 15 billing/settings tests pass (api-checkout, billing-section, cancel-retention-modal)
- [x] Full suite: 108 passed, 0 failed
- [x] New tests: dialog role/aria-modal assertion, Escape key closes modal
- [x] Migration 020 verified applied to production (Closes #2065)

🤖 Generated with [Claude Code](https://claude.com/claude-code)