### PR TITLE
fix(worktree): force-update local main when fast-forward fails

### DIFF
--- a/knowledge-base/project/learnings/2026-04-13-worktree-manager-origin-main-fallback-stale-ref.md
+++ b/knowledge-base/project/learnings/2026-04-13-worktree-manager-origin-main-fallback-stale-ref.md
@@ -1,0 +1,45 @@
+# Learning: worktree-manager.sh origin/main fallback leaves local main stale
+
+## Problem
+
+When `git fetch origin main:main` fails in a bare repo (e.g., because `main` is checked
+out in another worktree), the `update_branch_ref()` fallback ran `git fetch origin main`
+which only updates `origin/main` and `FETCH_HEAD` — the local `main` ref stayed stale.
+Worktrees created afterward were based on the stale commit, missing recently merged PRs.
+
+## Solution
+
+Added `git update-ref refs/heads/$branch origin/$branch` in the `elif` fallback path.
+This force-syncs the local ref to match the remote. Safe because direct commits to main
+are prohibited (hook-enforced). Applied to both `update_branch_ref()` and
+`cleanup_merged_worktrees()` for consistency. Added error guards on the `update-ref`
+calls to surface failures instead of printing misleading success messages.
+
+## Key Insight
+
+In bare repos with multiple worktrees, `git fetch origin branch:branch` fails when the
+target branch is checked out in any worktree — git refuses to update a ref that has a
+working tree attached. The fallback `git fetch origin branch` only updates the
+remote-tracking ref (`origin/branch`), not the local ref (`refs/heads/branch`). The
+`git update-ref` command bypasses the checkout check because it operates on refs directly
+without touching any working tree.
+
+## Session Errors
+
+1. **Worktree creation with long branch name silently failed** — Script reported success
+   but the worktree did not appear in `git worktree list`. **Prevention:** Validate
+   worktree exists after creation by checking `git worktree list` output.
+
+2. **cd to non-existent worktree path** — Attempted to cd into a path the script printed
+   but the directory did not exist. **Prevention:** Always verify worktree path via
+   `git worktree list` before cd.
+
+3. **Bare repo CWD drift** — Shell CWD silently reverted to bare repo root between Bash
+   calls, causing `git branch --show-current` to return `main` unexpectedly.
+   **Prevention:** Use absolute paths or re-cd at the start of each Bash call when
+   working in worktrees.
+
+## Tags
+
+category: integration-issues
+module: git-worktree

--- a/knowledge-base/project/plans/2026-04-13-fix-worktree-manager-origin-main-fallback-plan.md
+++ b/knowledge-base/project/plans/2026-04-13-fix-worktree-manager-origin-main-fallback-plan.md
@@ -4,6 +4,25 @@ type: fix
 date: 2026-04-13
 ---
 
+## Enhancement Summary
+
+**Deepened on:** 2026-04-13
+**Sections enhanced:** 3 (Proposed Solution, Test Scenarios, Context)
+**Research sources:** git-scm docs, codebase learnings, git update-ref edge case analysis
+
+### Key Improvements
+
+1. Added `git update-ref` safety analysis confirming atomicity and correctness
+2. Added edge case for failed fetch (both paths fail) -- no update-ref attempted
+3. Confirmed `cleanup_merged_worktrees()` needs identical fix for consistency
+4. Added verification step to test scenarios
+
+### New Considerations Discovered
+
+- `git update-ref` uses lockfiles internally -- safe for parallel sessions
+- The `elif` guard guarantees `origin/$branch` exists before `update-ref` runs
+- No `--no-deref` flag needed -- `refs/heads/main` is always a direct ref
+
 # fix: worktree-manager.sh origin/main fallback sets correct base commit
 
 ## Overview
@@ -69,6 +88,58 @@ elif git fetch origin "$branch" 2>/dev/null; then
 fi
 ```
 
+### Changes to `cleanup_merged_worktrees()`
+
+Apply the same fix to the fallback at lines 820-824:
+
+```bash
+# Current (broken):
+if git fetch origin main:main 2>/dev/null; then
+  echo -e "${GREEN}Updated main to latest${NC}"
+elif git fetch origin main 2>/dev/null; then
+  # Fallback: non-fast-forward (e.g., force-push) -- at least update origin/main
+  echo -e "${YELLOW}Warning: Could not fast-forward local main -- fetched origin/main only${NC}"
+fi
+
+# Fixed:
+if git fetch origin main:main 2>/dev/null; then
+  echo -e "${GREEN}Updated main to latest${NC}"
+elif git fetch origin main 2>/dev/null; then
+  # Fast-forward failed but fetch succeeded -- force-update local ref to match remote.
+  # Safe because direct commits to main are prohibited (hook-enforced).
+  git update-ref refs/heads/main origin/main
+  echo -e "${YELLOW}Warning: Could not fast-forward local main -- force-updated to origin/main${NC}"
+fi
+```
+
+### Research Insights
+
+**Safety of `git update-ref` in this context:**
+
+- `git update-ref` is atomic -- it uses a lockfile (`refs/heads/main.lock`)
+  internally, so parallel sessions cannot corrupt the ref
+- The `elif` guard guarantees `origin/$branch` exists before `update-ref` runs
+  (the fetch that populated it succeeded)
+- No `--no-deref` flag is needed because `refs/heads/main` is always a direct
+  ref (not a symbolic ref like HEAD)
+- `git update-ref` does NOT verify ancestry -- it unconditionally moves the ref.
+  This is intentional here: direct commits to main are prohibited, so local main
+  should always be an ancestor of (or equal to) origin/main. If it somehow isn't,
+  force-updating is the correct recovery
+
+**Edge case: both fetch paths fail:**
+
+If `git fetch origin "$branch:$branch"` AND `git fetch origin "$branch"` both
+fail (network down, remote unreachable), neither branch executes and
+`update_branch_ref` returns silently. The worktree will be created from whatever
+local main currently points to. This is acceptable -- network failure is
+unrecoverable and the existing behavior is preserved
+
+**References:**
+
+- [git-update-ref documentation](https://git-scm.com/docs/git-update-ref)
+- [git update-ref best practices](https://copyprogramming.com/howto/git-update-ref-appears-to-do-nothing)
+
 ### File
 
 `plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh`
@@ -95,6 +166,33 @@ fi
 - Given a bare repo where local `main` is already at `origin/main`, when
   `worktree-manager.sh create <name>` runs, then the fast-forward path succeeds and
   no force-update is needed
+- Given a bare repo where both fetch paths fail (network down), when
+  `update_branch_ref` completes, then no `update-ref` is attempted and the function
+  returns silently (existing behavior preserved)
+- Given `cleanup_merged_worktrees()` runs in a bare repo where `git fetch origin
+  main:main` fails, when the cleanup completes, then `git rev-parse main` should
+  equal `git rev-parse origin/main` (same fix applied to cleanup path)
+
+### Verification commands
+
+After applying the fix, verify in a bare repo where local main is stale:
+
+```bash
+# Record stale state
+git rev-parse main          # Should show old commit
+git rev-parse origin/main   # Should show newer commit
+
+# Run worktree creation
+bash ./plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh --yes create test-branch
+
+# Verify fix
+git rev-parse main          # Should now equal origin/main
+git -C .worktrees/test-branch log --oneline -1  # Should show latest commit
+
+# Cleanup
+git worktree remove .worktrees/test-branch
+git branch -D test-branch
+```
 
 ## Domain Review
 

--- a/knowledge-base/project/plans/2026-04-13-fix-worktree-manager-origin-main-fallback-plan.md
+++ b/knowledge-base/project/plans/2026-04-13-fix-worktree-manager-origin-main-fallback-plan.md
@@ -1,0 +1,126 @@
+---
+title: "fix: worktree-manager.sh origin/main fallback doesn't set correct base commit"
+type: fix
+date: 2026-04-13
+---
+
+# fix: worktree-manager.sh origin/main fallback sets correct base commit
+
+## Overview
+
+When `worktree-manager.sh create` cannot fast-forward local main, it warns "Could
+not fast-forward local main -- using origin/main" but the worktree is still created
+from the stale local `main` ref. This causes worktrees to miss recently merged PRs.
+
+## Problem Statement
+
+The `update_branch_ref()` function has a fallback path that is misleading and
+incomplete. When `git fetch origin main:main` fails (non-fast-forward), it falls
+back to `git fetch origin main`, which only updates `origin/main` and `FETCH_HEAD`
+-- the local `main` ref stays stale. The warning message says "using origin/main"
+but the subsequent `git worktree add -b <branch> <path> main` still uses the
+stale local `main`.
+
+**Observed in:** Session fixing #2046/#2047/#2048 -- worktree was at `613169a5`
+(old main) instead of `932a7a1c` (origin/main with PR #2036 merged). Required
+manual `git rebase origin/main`.
+
+**Root cause trace:**
+
+1. `update_branch_ref("main")` runs `git fetch origin main:main` (line 188)
+2. Fast-forward fails (e.g., local main diverged due to a prior update-ref or
+   interrupted fetch)
+3. Falls back to `git fetch origin main` (line 190) -- updates `origin/main` only
+4. Returns without updating local `main`
+5. `create_worktree()` runs `git worktree add -b <branch> <path> main` (line 364)
+6. `main` still points to the stale commit
+
+The same pattern exists in `create_for_feature()` (line 424).
+
+## Proposed Solution
+
+When `git fetch origin main:main` fails, force-update the local `main` ref to
+match `origin/main` using `git update-ref`. This is safe because:
+
+- Direct commits to main are prohibited (hook-enforced)
+- The only valid state for local `main` is tracking `origin/main`
+- The warning already says "using origin/main" -- the behavior should match
+
+### Changes to `update_branch_ref()`
+
+In the bare repo fallback branch (lines 188-192 of `worktree-manager.sh`):
+
+```bash
+# Current (broken):
+if git fetch origin "$branch:$branch" 2>/dev/null; then
+  echo -e "${GREEN}Updated $branch to latest (via fetch)${NC}"
+elif git fetch origin "$branch" 2>/dev/null; then
+  echo -e "${YELLOW}Warning: Could not fast-forward local $branch -- using origin/$branch${NC}"
+fi
+
+# Fixed:
+if git fetch origin "$branch:$branch" 2>/dev/null; then
+  echo -e "${GREEN}Updated $branch to latest (via fetch)${NC}"
+elif git fetch origin "$branch" 2>/dev/null; then
+  # Fast-forward failed but fetch succeeded -- force-update local ref to match remote.
+  # Safe because direct commits to main are prohibited (hook-enforced).
+  git update-ref "refs/heads/$branch" "origin/$branch"
+  echo -e "${YELLOW}Warning: Could not fast-forward local $branch -- force-updated to origin/$branch${NC}"
+fi
+```
+
+### File
+
+`plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh`
+
+## Acceptance Criteria
+
+- [ ] When `git fetch origin main:main` fails (non-fast-forward), `update_branch_ref`
+  force-updates the local `main` ref to `origin/main` via `git update-ref`
+- [ ] Worktrees created after a failed fast-forward are based on `origin/main`,
+  not the stale local `main`
+- [ ] The warning message is updated to say "force-updated" instead of just "using"
+- [ ] The same fix applies to both `create_worktree()` and `create_for_feature()` paths
+  (both call `update_branch_ref`, so fixing the function fixes both)
+- [ ] The `cleanup_merged_worktrees()` fallback path (lines 820-824) receives the same
+  fix for consistency
+
+## Test Scenarios
+
+- Given a bare repo where local `main` is behind `origin/main` (non-fast-forwardable),
+  when `worktree-manager.sh create <name>` runs, then the new worktree should contain
+  files from the latest `origin/main` commit
+- Given a bare repo where `git fetch origin main:main` fails, when `update_branch_ref`
+  completes, then `git rev-parse main` should equal `git rev-parse origin/main`
+- Given a bare repo where local `main` is already at `origin/main`, when
+  `worktree-manager.sh create <name>` runs, then the fast-forward path succeeds and
+  no force-update is needed
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected -- infrastructure/tooling change.
+
+## Context
+
+### Related Learnings
+
+- `2026-04-12-stale-main-ref-breaks-multi-issue-worktree-creation.md` -- Documents
+  the exact symptom. Workaround was manual `git update-ref refs/heads/main origin/main`.
+  This plan makes the workaround automatic.
+- `2026-03-18-bare-repo-cleanup-stale-script-and-fetch-refspec.md` -- Documents why
+  `git fetch origin main` != `git fetch origin main:main`. The refspec form was added
+  to `cleanup_merged_worktrees` but the `update_branch_ref` fallback was not fixed.
+
+### Related Issues
+
+- Ref #2078
+
+## References
+
+- File: `plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh`
+- `update_branch_ref()`: lines 180-197
+- `create_worktree()`: lines 310-383
+- `create_for_feature()`: lines 386-452
+- `cleanup_merged_worktrees()`: lines 679-863 (fallback at lines 820-824)

--- a/knowledge-base/project/plans/2026-04-13-fix-worktree-manager-origin-main-fallback-plan.md
+++ b/knowledge-base/project/plans/2026-04-13-fix-worktree-manager-origin-main-fallback-plan.md
@@ -146,14 +146,14 @@ unrecoverable and the existing behavior is preserved
 
 ## Acceptance Criteria
 
-- [ ] When `git fetch origin main:main` fails (non-fast-forward), `update_branch_ref`
+- [x] When `git fetch origin main:main` fails (non-fast-forward), `update_branch_ref`
   force-updates the local `main` ref to `origin/main` via `git update-ref`
-- [ ] Worktrees created after a failed fast-forward are based on `origin/main`,
+- [x] Worktrees created after a failed fast-forward are based on `origin/main`,
   not the stale local `main`
-- [ ] The warning message is updated to say "force-updated" instead of just "using"
-- [ ] The same fix applies to both `create_worktree()` and `create_for_feature()` paths
+- [x] The warning message is updated to say "force-updated" instead of just "using"
+- [x] The same fix applies to both `create_worktree()` and `create_for_feature()` paths
   (both call `update_branch_ref`, so fixing the function fixes both)
-- [ ] The `cleanup_merged_worktrees()` fallback path (lines 820-824) receives the same
+- [x] The `cleanup_merged_worktrees()` fallback path (lines 820-824) receives the same
   fix for consistency
 
 ## Test Scenarios

--- a/knowledge-base/project/specs/fix-2078-worktree-fallback/session-state.md
+++ b/knowledge-base/project/specs/fix-2078-worktree-fallback/session-state.md
@@ -1,0 +1,26 @@
+# Session State
+
+## Plan Phase
+
+- Plan file: knowledge-base/project/plans/2026-04-13-fix-worktree-manager-origin-main-fallback-plan.md
+- Status: complete
+
+### Errors
+
+None
+
+### Decisions
+
+- Selected MINIMAL template -- focused shell script bug fix, not architectural change
+- Chose `git update-ref` over passing `origin/main` to `git worktree add` -- fixes root cause (stale local ref) rather than working around it
+- Identified `cleanup_merged_worktrees()` as having the same bug -- included in scope for consistency
+- No domain review needed -- pure infrastructure/tooling change
+- Skipped external research beyond git-scm docs -- fix pattern already documented in codebase learnings
+
+### Components Invoked
+
+- `soleur:plan` -- created initial plan from issue #2078
+- `soleur:deepen-plan` -- enhanced with git update-ref safety analysis, edge cases, and verification commands
+- `markdownlint-cli2` -- validated markdown formatting
+- `WebSearch` -- researched git update-ref edge cases in bare repositories
+- `Grep` -- searched codebase learnings for update-ref usage patterns

--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -188,7 +188,10 @@ update_branch_ref() {
     if git fetch origin "$branch:$branch" 2>/dev/null; then
       echo -e "${GREEN}Updated $branch to latest (via fetch)${NC}"
     elif git fetch origin "$branch" 2>/dev/null; then
-      echo -e "${YELLOW}Warning: Could not fast-forward local $branch -- using origin/$branch${NC}"
+      # Fast-forward failed but fetch succeeded -- force-update local ref to match remote.
+      # Safe because direct commits to main are prohibited (hook-enforced).
+      git update-ref "refs/heads/$branch" "origin/$branch"
+      echo -e "${YELLOW}Warning: Could not fast-forward local $branch -- force-updated to origin/$branch${NC}"
     fi
   else
     git checkout "$branch"
@@ -820,8 +823,10 @@ cleanup_merged_worktrees() {
       if git fetch origin main:main 2>/dev/null; then
         echo -e "${GREEN}Updated main to latest${NC}"
       elif git fetch origin main 2>/dev/null; then
-        # Fallback: non-fast-forward (e.g., force-push) -- at least update origin/main
-        echo -e "${YELLOW}Warning: Could not fast-forward local main -- fetched origin/main only${NC}"
+        # Fast-forward failed but fetch succeeded -- force-update local ref to match remote.
+        # Safe because direct commits to main are prohibited (hook-enforced).
+        git update-ref refs/heads/main origin/main
+        echo -e "${YELLOW}Warning: Could not fast-forward local main -- force-updated to origin/main${NC}"
       fi
       # Auto-sync stale on-disk files so the next session reads current versions
       sync_bare_files

--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -190,8 +190,11 @@ update_branch_ref() {
     elif git fetch origin "$branch" 2>/dev/null; then
       # Fast-forward failed but fetch succeeded -- force-update local ref to match remote.
       # Safe because direct commits to main are prohibited (hook-enforced).
-      git update-ref "refs/heads/$branch" "origin/$branch"
-      echo -e "${YELLOW}Warning: Could not fast-forward local $branch -- force-updated to origin/$branch${NC}"
+      if git update-ref "refs/heads/$branch" "origin/$branch"; then
+        echo -e "${YELLOW}Warning: Could not fast-forward local $branch -- force-updated to origin/$branch${NC}"
+      else
+        echo -e "${RED}Error: could not force-update refs/heads/$branch${NC}"
+      fi
     fi
   else
     git checkout "$branch"
@@ -825,8 +828,11 @@ cleanup_merged_worktrees() {
       elif git fetch origin main 2>/dev/null; then
         # Fast-forward failed but fetch succeeded -- force-update local ref to match remote.
         # Safe because direct commits to main are prohibited (hook-enforced).
-        git update-ref refs/heads/main origin/main
-        echo -e "${YELLOW}Warning: Could not fast-forward local main -- force-updated to origin/main${NC}"
+        if git update-ref "refs/heads/main" "origin/main"; then
+          echo -e "${YELLOW}Warning: Could not fast-forward local main -- force-updated to origin/main${NC}"
+        else
+          echo -e "${RED}Error: could not force-update refs/heads/main${NC}"
+        fi
       fi
       # Auto-sync stale on-disk files so the next session reads current versions
       sync_bare_files


### PR DESCRIPTION
## Summary

- When `git fetch origin main:main` fails (e.g., main checked out in another worktree), the fallback now uses `git update-ref` to sync the local ref with `origin/main`
- Previously the warning said "using origin/main" but worktrees were still created from stale local main
- Fix applied to both `update_branch_ref()` and `cleanup_merged_worktrees()` for consistency
- Added error guards on `update-ref` calls and consistent quoting

Closes #2078

## Changelog

### Plugin
- **fix:** worktree-manager.sh origin/main fallback now force-updates local ref via `git update-ref` instead of leaving it stale

## Test plan

- [x] Verified worktree created at origin/main commit (not stale local main) after failed fast-forward
- [x] Verified `git rev-parse main` equals `git rev-parse origin/main` after update-ref
- [x] Verified script syntax valid (`bash -n`)
- [x] Verified error guard prints failure message when update-ref fails
- [x] 8/9 test suites pass (web-platform failures are pre-existing, tracked in #2086)

Generated with [Claude Code](https://claude.com/claude-code)