### PR TITLE
fix(community): add anomaly detection for X API public_metrics

### DIFF
--- a/knowledge-base/project/learnings/2026-04-13-x-api-metrics-anomaly-detection.md
+++ b/knowledge-base/project/learnings/2026-04-13-x-api-metrics-anomaly-detection.md
@@ -1,0 +1,56 @@
+---
+title: "X API metrics anomaly detection: verify data before assuming API fault"
+date: 2026-04-13
+category: integration-issues
+tags: [x-api, community-monitor, anomaly-detection, shell-scripting]
+module: plugins/soleur/skills/community
+---
+
+# Learning: X API metrics anomaly detection
+
+## Problem
+
+The community monitor daily digest reported 0 X/Twitter followers starting
+April 11, 2026. The initial assumption was that the X API was returning
+incorrect data, possibly due to the February 2026 pay-per-use migration.
+
+## Investigation
+
+Three independent verification paths were tested:
+
+1. X API v2 (authenticated via Doppler `prd_scheduled` credentials)
+2. X GraphQL guest token endpoint (`UserByScreenName`)
+3. Playwright visual snapshot of the X profile page
+
+All three confirmed `followers_count: 0`. The API was accurate — the account
+genuinely lost its followers (likely spam cleanup on a 3-follower account).
+
+## Solution
+
+Instead of "fixing" correct data, added anomaly detection to
+`x-community.sh`:
+
+- `_has_metrics_anomaly` function detects suspicious patterns (active account
+  with 0 followers, all-zeros degradation) and emits stderr warnings
+- Integrated into `cmd_fetch_metrics` without changing the stdout JSON schema
+- Updated `community-manager.md` to instruct the agent to surface warnings
+
+## Key Insight
+
+When monitoring data looks wrong, verify the data source independently before
+assuming the API is at fault. Three verification paths (API, GraphQL, visual)
+cost 5 minutes but prevented building a web scraping fallback that would not
+have helped. The correct fix was diagnostics, not data correction.
+
+## Review Findings Applied
+
+- Added numeric guard for non-numeric jq output (defensive arithmetic)
+- Renamed from `_check_metrics_anomaly` to `_has_metrics_anomaly` (shell
+  boolean convention: 0=true)
+- Consolidated 5 jq subshells to 2 (single `@tsv` extraction)
+- Added `listed_count` edge-case test documenting its exclusion from detection
+
+## Tags
+
+category: integration-issues
+module: plugins/soleur/skills/community

--- a/knowledge-base/project/plans/2026-04-13-fix-x-followers-count-zero-plan.md
+++ b/knowledge-base/project/plans/2026-04-13-fix-x-followers-count-zero-plan.md
@@ -2,6 +2,7 @@
 title: "fix: X followers count showing 0 in community monitor"
 type: fix
 date: 2026-04-13
+deepened: 2026-04-13
 ---
 
 # fix: X followers count showing 0 in community monitor
@@ -9,80 +10,136 @@ date: 2026-04-13
 The community monitor daily digest has been reporting 0 X/Twitter followers since
 April 11, 2026. Previous digests showed 3 followers (April 6-9), then 1 (April 10),
 then 0 (April 11 onward). The Bluesky follower count (5) is correct and growing
-normally, confirming the issue is X-specific.
+normally.
+
+## Enhancement Summary
+
+**Deepened on:** 2026-04-13
+**Sections enhanced:** Root cause, proposed fix, acceptance criteria, test scenarios
+**Research agents used:** WebSearch, WebFetch, Playwright MCP, X API live testing, GraphQL endpoint testing
+
+### Key Improvements
+
+1. Root cause corrected from "API returning bad data" to "account genuinely has 0 followers" -- verified via 3 independent sources (API v2, GraphQL, Playwright page snapshot)
+2. Proposed fix changed from web scraping fallback (would not help) to detection heuristic with warning annotation in digest output
+3. Added staleness detection for all zeroed-out metrics to catch silent API degradation in the future
+
+### New Considerations Discovered
+
+- X profile page shows "0 Followers" visually (verified via Playwright snapshot)
+- X GraphQL endpoint (guest token, UserByScreenName) also returns `followers_count: 0`
+- The profile page shows `@soleur_ai hasn't posted` despite `statuses_count: 67` in API -- posts exist but are not visible to unauthenticated viewers, which is normal X behavior for logged-out page views
+- X migrated to pay-per-use pricing in Feb 2026 -- free-tier apps were migrated with a $10 voucher; this may or may not be related to the follower loss
+- Web scraping cannot solve this since the web page itself shows 0
 
 ## Root Cause Analysis
 
-The X API v2 endpoint `GET /2/users/me?user.fields=public_metrics` is returning
-`followers_count: 0` in its response. This was verified by calling the live API
-directly with the production Doppler credentials (`prd_scheduled` config). The API
-authenticates correctly and returns a valid JSON response with the correct username,
-description, and tweet count -- but `followers_count` is 0.
+### Investigation Method
+
+Three independent verification paths were tested:
+
+1. **X API v2 (authenticated):** `GET /2/users/me?user.fields=public_metrics` via
+   production Doppler credentials (`prd_scheduled` config) -- returns `followers_count: 0`
+2. **X GraphQL (guest token):** `UserByScreenName` endpoint with guest bearer token --
+   returns `followers_count: 0` and `normal_followers_count: 0`
+3. **X profile page (Playwright):** Navigated to `https://x.com/soleur_ai` and captured
+   accessibility snapshot -- page displays "0 Followers" in the profile section
+
+All three sources agree: the account has 0 followers. The API is returning accurate data.
+
+### Conclusion
+
+The community monitor is **correctly** reporting 0 followers. The account genuinely
+lost its followers between April 9-11. Possible causes:
+
+- **Spam account cleanup:** X periodically removes spam/bot accounts, which can reduce
+  follower counts for small accounts disproportionately
+- **Pay-per-use migration side effect:** X migrated free-tier API users to pay-per-use
+  in February 2026. Unclear if this affects follower visibility
+- **Organic unfollows:** With only 3 followers previously, all 3 unfollowing is plausible
 
 **Timeline of the decline:**
 
 | Date | X Followers | Bluesky Followers | Notes |
 |------|-------------|-------------------|-------|
 | Apr 6-9 | 3 | 3-4 | Normal |
-| Apr 10 | 1 | 5 | Degradation begins |
-| Apr 11-13 | 0 | 5 | Fully zeroed out |
-
-**Likely cause:** X migrated free-tier API users to a pay-per-use credit model
-(announced February 2026, rolled out progressively). Existing free-tier users
-received a one-time $10 voucher. After credits are exhausted or during migration,
-the API still returns HTTP 200 with valid JSON but zeroes out `public_metrics`
-fields. This is a "soft degradation" -- no error, just silently inaccurate data.
+| Apr 10 | 1 | 5 | Two unfollows in one day |
+| Apr 11-13 | 0 | 5 | Last follower gone |
 
 The script `plugins/soleur/skills/community/scripts/x-community.sh` function
-`cmd_fetch_metrics` (lines 369-379) correctly requests `user.fields=public_metrics`
-and extracts `.data.public_metrics`. The script is not at fault -- the upstream API
-is returning bad data.
+`cmd_fetch_metrics` (lines 369-379) is working correctly.
 
 ## Proposed Fix
 
-Add a web scraping fallback to `x-community.sh` that detects when the API returns
-suspect metrics and falls back to scraping the public profile page for accurate
-follower counts.
+Since the API data is accurate, the fix is not about correcting the data but about
+making the community monitor resilient to suspect metrics and providing better
+diagnostics when metrics look anomalous.
 
-### Approach: Detect-and-Fallback in `cmd_fetch_metrics`
+### Approach: Anomaly Detection + Warning Annotation
 
-1. **Detection heuristic:** After the API call, if `followers_count` is 0 AND
-   `tweet_count` is > 0, the data is suspect (an account with 67 tweets is
-   extremely unlikely to have exactly 0 followers). This heuristic avoids
-   false-triggering on genuinely new accounts.
+1. **Anomaly detection in `cmd_fetch_metrics`:** After the API call, check if
+   `followers_count` is 0 AND `tweet_count` is > 0 AND `following_count` is > 0.
+   This combination (active account with zero followers) is unusual and worth flagging.
+   When detected, emit a warning to stderr so the community monitor agent can
+   include a diagnostic note in the digest.
 
-2. **Web scraping fallback:** When suspect data is detected, fetch the public
-   profile page at `https://x.com/<username>` and extract the follower count
-   from the HTML. The profile page displays the real count regardless of API
-   tier.
+2. **Add `_check_metrics_anomaly` function:** A pure detection function that takes
+   the metrics JSON and returns 0 (anomaly detected) or 1 (normal). The function
+   writes the anomaly description to stderr when triggered.
 
-3. **Implementation in `x-community.sh`:**
-   - Add a new function `_scrape_followers_count` that uses `curl` + HTML
-     parsing to extract the follower count from the public profile page
-   - Modify `cmd_fetch_metrics` to check the detection heuristic and call
-     the scrape function when triggered
-   - Merge the scraped value back into the JSON output
-   - Print a diagnostic to stderr: "Warning: API returned 0 followers for
-     account with N tweets. Using web scrape fallback."
+3. **Existing behavior preserved:** The `cmd_fetch_metrics` JSON output schema
+   remains unchanged. The anomaly check is informational only (stderr) and does
+   not modify stdout. This ensures the community monitor agent receives the data
+   and can decide how to present it.
 
-4. **Graceful degradation:** If the scrape also fails (rate limiting, page
-   structure change), keep the API value and warn on stderr. The monitor
-   should not fail entirely because of a metrics accuracy issue.
+4. **Future-proofing:** The anomaly check also detects if ALL `public_metrics`
+   values are 0 (which would indicate a genuine API degradation rather than
+   organic unfollows). This catches the "soft degradation" scenario where X
+   silently zeroes out metrics.
+
+### Research Insights
+
+**Best Practices (from learnings):**
+
+- **Truncate API error responses** (`2026-03-26-truncate-api-error-responses`):
+  Any warning or diagnostic output to stderr should truncate variable data to
+  avoid leaking large responses in CI logs. Use `head -c 200` for safety.
+- **Shell script defensive patterns** (`2026-03-13-shell-script-defensive-patterns`):
+  The anomaly check function should follow the single-responsibility pattern
+  and fail loudly on unknown conditions.
+
+**X API Platform Context:**
+
+- X migrated to pay-per-use pricing in February 2026, progressively rolling
+  out to free-tier users. The `GET /2/users/me` endpoint with `public_metrics`
+  works on both the legacy free tier and pay-per-use.
+- The X syndication API (`cdn.syndication.twimg.com`) returns empty responses
+  for profile data (tested live, returns 200 with 0 bytes).
+- X.com is a React SPA; follower counts are not in static HTML but loaded
+  via GraphQL. The GraphQL guest token approach confirms the count.
+
+**Edge Cases:**
+
+- Genuinely new account with 0 tweets and 0 followers: should not trigger warning
+- Account suspended or restricted: API may return different error codes (401/403)
+  rather than zeroed metrics
+- All metrics zeroed out simultaneously: stronger signal of API degradation vs
+  organic decline
 
 ### Alternative Approaches Considered
 
 | Approach | Pros | Cons | Decision |
 |----------|------|------|----------|
-| Purchase X API credits | Clean API fix, no scraping | Ongoing cost ($0.01/call), requires billing setup | Deferred -- existing issue #497 tracks this |
-| Hardcode known follower count | Zero-cost | Immediately stale, defeats purpose of monitoring | Rejected |
-| Use third-party API (Apify, etc.) | Reliable data | New vendor dependency, cost | Rejected |
-| Web scrape fallback | Zero cost, uses public data | Fragile if page structure changes | **Selected** |
+| Purchase X API credits | May resolve if API-tier related | Ongoing cost, unlikely to fix since web page also shows 0 | Deferred -- issue #497 |
+| Web scraping fallback | Zero cost | Web page also shows 0; would not help | **Rejected** (verified) |
+| Anomaly detection + warning | Zero cost, informational, future-proof | Does not "fix" the count | **Selected** |
+| Hardcode known follower count | Immediate visual fix | Defeats monitoring purpose | Rejected |
 | Skip X metrics when suspect | Simple | Hides the problem | Rejected |
 
 ## Files to Modify
 
-- `plugins/soleur/skills/community/scripts/x-community.sh` -- Add `_scrape_followers_count`
-  function and detection logic in `cmd_fetch_metrics`
+- `plugins/soleur/skills/community/scripts/x-community.sh` -- Add
+  `_check_metrics_anomaly` function and call it from `cmd_fetch_metrics`
 
 ## Files to Create
 
@@ -90,31 +147,35 @@ None.
 
 ## Acceptance Criteria
 
-- [ ] When the X API returns `followers_count: 0` and `tweet_count > 0`, the
-  script falls back to web scraping and returns the actual follower count
-- [ ] When the X API returns a non-zero `followers_count`, the script uses
-  the API value without fallback (no behavior change)
-- [ ] When the web scrape fallback fails, the script returns the API value
-  and emits a warning to stderr
+- [ ] When the X API returns `followers_count: 0` and `tweet_count > 0` and
+  `following_count > 0`, a warning is emitted to stderr describing the anomaly
+- [ ] When the X API returns non-zero `followers_count`, no warning is emitted
+- [ ] When the X API returns all-zero `public_metrics`, a stronger warning is
+  emitted to stderr indicating possible API degradation
 - [ ] The diagnostic warning is printed to stderr (not stdout) so it does
   not corrupt JSON output
 - [ ] The `cmd_fetch_metrics` output JSON schema is unchanged (same keys,
   same structure)
+- [ ] An account with `followers_count: 0`, `tweet_count: 0`, `following_count: 0`
+  does not trigger a warning (genuinely new account)
 
 ## Test Scenarios
 
-- Given an X API response with `followers_count: 0` and `tweet_count: 67`,
-  when `cmd_fetch_metrics` runs, then the scrape fallback is triggered and
-  a non-zero follower count is returned
+- Given an X API response with `followers_count: 0`, `tweet_count: 67`, and
+  `following_count: 18`, when `cmd_fetch_metrics` runs, then a warning is
+  emitted to stderr: "Warning: X API returned 0 followers for active account
+  (67 tweets, 18 following). This may indicate unfollows, spam cleanup, or
+  API degradation."
 - Given an X API response with `followers_count: 5` and `tweet_count: 67`,
-  when `cmd_fetch_metrics` runs, then the API value is used directly (no
-  scrape attempt)
-- Given an X API response with `followers_count: 0` and `tweet_count: 0`,
-  when `cmd_fetch_metrics` runs, then the API value is used (genuinely new
-  account, no scrape needed)
-- Given the scrape fallback fails (curl error or parse failure), when
-  `cmd_fetch_metrics` runs, then the API value is returned with a warning
-  on stderr
+  when `cmd_fetch_metrics` runs, then no anomaly warning is emitted
+- Given an X API response with `followers_count: 0`, `tweet_count: 0`, and
+  `following_count: 0`, when `cmd_fetch_metrics` runs, then no warning is
+  emitted (genuinely new/empty account)
+- Given an X API response where all `public_metrics` values are 0 except
+  `tweet_count: 67`, when `cmd_fetch_metrics` runs, then a warning is emitted
+  mentioning possible API degradation
+- Given `cmd_fetch_metrics` produces a warning on stderr, when the output is
+  captured, then stdout contains valid JSON and stderr contains the warning text
 
 ## Domain Review
 

--- a/knowledge-base/project/plans/2026-04-13-fix-x-followers-count-zero-plan.md
+++ b/knowledge-base/project/plans/2026-04-13-fix-x-followers-count-zero-plan.md
@@ -147,16 +147,16 @@ None.
 
 ## Acceptance Criteria
 
-- [ ] When the X API returns `followers_count: 0` and `tweet_count > 0` and
+- [x] When the X API returns `followers_count: 0` and `tweet_count > 0` and
   `following_count > 0`, a warning is emitted to stderr describing the anomaly
-- [ ] When the X API returns non-zero `followers_count`, no warning is emitted
-- [ ] When the X API returns all-zero `public_metrics`, a stronger warning is
+- [x] When the X API returns non-zero `followers_count`, no warning is emitted
+- [x] When the X API returns all-zero `public_metrics`, a stronger warning is
   emitted to stderr indicating possible API degradation
-- [ ] The diagnostic warning is printed to stderr (not stdout) so it does
+- [x] The diagnostic warning is printed to stderr (not stdout) so it does
   not corrupt JSON output
-- [ ] The `cmd_fetch_metrics` output JSON schema is unchanged (same keys,
+- [x] The `cmd_fetch_metrics` output JSON schema is unchanged (same keys,
   same structure)
-- [ ] An account with `followers_count: 0`, `tweet_count: 0`, `following_count: 0`
+- [x] An account with `followers_count: 0`, `tweet_count: 0`, `following_count: 0`
   does not trigger a warning (genuinely new account)
 
 ## Test Scenarios

--- a/knowledge-base/project/plans/2026-04-13-fix-x-followers-count-zero-plan.md
+++ b/knowledge-base/project/plans/2026-04-13-fix-x-followers-count-zero-plan.md
@@ -1,0 +1,125 @@
+---
+title: "fix: X followers count showing 0 in community monitor"
+type: fix
+date: 2026-04-13
+---
+
+# fix: X followers count showing 0 in community monitor
+
+The community monitor daily digest has been reporting 0 X/Twitter followers since
+April 11, 2026. Previous digests showed 3 followers (April 6-9), then 1 (April 10),
+then 0 (April 11 onward). The Bluesky follower count (5) is correct and growing
+normally, confirming the issue is X-specific.
+
+## Root Cause Analysis
+
+The X API v2 endpoint `GET /2/users/me?user.fields=public_metrics` is returning
+`followers_count: 0` in its response. This was verified by calling the live API
+directly with the production Doppler credentials (`prd_scheduled` config). The API
+authenticates correctly and returns a valid JSON response with the correct username,
+description, and tweet count -- but `followers_count` is 0.
+
+**Timeline of the decline:**
+
+| Date | X Followers | Bluesky Followers | Notes |
+|------|-------------|-------------------|-------|
+| Apr 6-9 | 3 | 3-4 | Normal |
+| Apr 10 | 1 | 5 | Degradation begins |
+| Apr 11-13 | 0 | 5 | Fully zeroed out |
+
+**Likely cause:** X migrated free-tier API users to a pay-per-use credit model
+(announced February 2026, rolled out progressively). Existing free-tier users
+received a one-time $10 voucher. After credits are exhausted or during migration,
+the API still returns HTTP 200 with valid JSON but zeroes out `public_metrics`
+fields. This is a "soft degradation" -- no error, just silently inaccurate data.
+
+The script `plugins/soleur/skills/community/scripts/x-community.sh` function
+`cmd_fetch_metrics` (lines 369-379) correctly requests `user.fields=public_metrics`
+and extracts `.data.public_metrics`. The script is not at fault -- the upstream API
+is returning bad data.
+
+## Proposed Fix
+
+Add a web scraping fallback to `x-community.sh` that detects when the API returns
+suspect metrics and falls back to scraping the public profile page for accurate
+follower counts.
+
+### Approach: Detect-and-Fallback in `cmd_fetch_metrics`
+
+1. **Detection heuristic:** After the API call, if `followers_count` is 0 AND
+   `tweet_count` is > 0, the data is suspect (an account with 67 tweets is
+   extremely unlikely to have exactly 0 followers). This heuristic avoids
+   false-triggering on genuinely new accounts.
+
+2. **Web scraping fallback:** When suspect data is detected, fetch the public
+   profile page at `https://x.com/<username>` and extract the follower count
+   from the HTML. The profile page displays the real count regardless of API
+   tier.
+
+3. **Implementation in `x-community.sh`:**
+   - Add a new function `_scrape_followers_count` that uses `curl` + HTML
+     parsing to extract the follower count from the public profile page
+   - Modify `cmd_fetch_metrics` to check the detection heuristic and call
+     the scrape function when triggered
+   - Merge the scraped value back into the JSON output
+   - Print a diagnostic to stderr: "Warning: API returned 0 followers for
+     account with N tweets. Using web scrape fallback."
+
+4. **Graceful degradation:** If the scrape also fails (rate limiting, page
+   structure change), keep the API value and warn on stderr. The monitor
+   should not fail entirely because of a metrics accuracy issue.
+
+### Alternative Approaches Considered
+
+| Approach | Pros | Cons | Decision |
+|----------|------|------|----------|
+| Purchase X API credits | Clean API fix, no scraping | Ongoing cost ($0.01/call), requires billing setup | Deferred -- existing issue #497 tracks this |
+| Hardcode known follower count | Zero-cost | Immediately stale, defeats purpose of monitoring | Rejected |
+| Use third-party API (Apify, etc.) | Reliable data | New vendor dependency, cost | Rejected |
+| Web scrape fallback | Zero cost, uses public data | Fragile if page structure changes | **Selected** |
+| Skip X metrics when suspect | Simple | Hides the problem | Rejected |
+
+## Files to Modify
+
+- `plugins/soleur/skills/community/scripts/x-community.sh` -- Add `_scrape_followers_count`
+  function and detection logic in `cmd_fetch_metrics`
+
+## Files to Create
+
+None.
+
+## Acceptance Criteria
+
+- [ ] When the X API returns `followers_count: 0` and `tweet_count > 0`, the
+  script falls back to web scraping and returns the actual follower count
+- [ ] When the X API returns a non-zero `followers_count`, the script uses
+  the API value without fallback (no behavior change)
+- [ ] When the web scrape fallback fails, the script returns the API value
+  and emits a warning to stderr
+- [ ] The diagnostic warning is printed to stderr (not stdout) so it does
+  not corrupt JSON output
+- [ ] The `cmd_fetch_metrics` output JSON schema is unchanged (same keys,
+  same structure)
+
+## Test Scenarios
+
+- Given an X API response with `followers_count: 0` and `tweet_count: 67`,
+  when `cmd_fetch_metrics` runs, then the scrape fallback is triggered and
+  a non-zero follower count is returned
+- Given an X API response with `followers_count: 5` and `tweet_count: 67`,
+  when `cmd_fetch_metrics` runs, then the API value is used directly (no
+  scrape attempt)
+- Given an X API response with `followers_count: 0` and `tweet_count: 0`,
+  when `cmd_fetch_metrics` runs, then the API value is used (genuinely new
+  account, no scrape needed)
+- Given the scrape fallback fails (curl error or parse failure), when
+  `cmd_fetch_metrics` runs, then the API value is returned with a warning
+  on stderr
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected -- infrastructure/tooling bug fix with
+no user-facing, financial, or operational changes. The existing issue #497
+already tracks the X API tier upgrade decision.

--- a/knowledge-base/project/specs/feat-one-shot-fix-x-followers-count/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-x-followers-count/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: fix X followers count showing 0
+
+## Phase 1: Setup
+
+- [x] 1.1 Investigate root cause of 0 followers in community digest
+- [x] 1.2 Verify X API response returns 0 followers_count directly
+- [x] 1.3 Confirm issue is X API side (pay-per-use migration), not script parsing
+
+## Phase 2: Core Implementation
+
+- [ ] 2.1 Add `_scrape_followers_count` function to `x-community.sh`
+  - [ ] 2.1.1 Fetch public profile page at `https://x.com/<username>` using curl
+  - [ ] 2.1.2 Parse HTML to extract follower count (grep/sed pattern)
+  - [ ] 2.1.3 Validate extracted value is a positive integer
+  - [ ] 2.1.4 Return extracted count or empty string on failure
+- [ ] 2.2 Add detection heuristic to `cmd_fetch_metrics`
+  - [ ] 2.2.1 After API call, extract followers_count and tweet_count from response
+  - [ ] 2.2.2 If followers_count == 0 AND tweet_count > 0, trigger fallback
+  - [ ] 2.2.3 Call `_scrape_followers_count` with username from API response
+  - [ ] 2.2.4 If scrape succeeds, merge scraped value into JSON output
+  - [ ] 2.2.5 If scrape fails, keep API value and warn on stderr
+  - [ ] 2.2.6 Emit diagnostic warning to stderr when fallback triggers
+
+## Phase 3: Testing
+
+- [ ] 3.1 Run `cmd_fetch_metrics` with live API to verify fallback triggers
+- [ ] 3.2 Verify JSON output schema is unchanged
+- [ ] 3.3 Verify stderr diagnostic does not corrupt stdout JSON
+- [ ] 3.4 Test edge case: account with 0 tweets and 0 followers (no fallback)

--- a/knowledge-base/project/specs/feat-one-shot-fix-x-followers-count/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-x-followers-count/tasks.md
@@ -3,27 +3,28 @@
 ## Phase 1: Setup
 
 - [x] 1.1 Investigate root cause of 0 followers in community digest
-- [x] 1.2 Verify X API response returns 0 followers_count directly
-- [x] 1.3 Confirm issue is X API side (pay-per-use migration), not script parsing
+- [x] 1.2 Verify X API v2 response returns 0 followers_count directly
+- [x] 1.3 Verify X GraphQL endpoint returns 0 followers_count
+- [x] 1.4 Verify X profile page shows 0 followers (Playwright snapshot)
+- [x] 1.5 Conclude: API data is accurate, account genuinely has 0 followers
 
 ## Phase 2: Core Implementation
 
-- [ ] 2.1 Add `_scrape_followers_count` function to `x-community.sh`
-  - [ ] 2.1.1 Fetch public profile page at `https://x.com/<username>` using curl
-  - [ ] 2.1.2 Parse HTML to extract follower count (grep/sed pattern)
-  - [ ] 2.1.3 Validate extracted value is a positive integer
-  - [ ] 2.1.4 Return extracted count or empty string on failure
-- [ ] 2.2 Add detection heuristic to `cmd_fetch_metrics`
-  - [ ] 2.2.1 After API call, extract followers_count and tweet_count from response
-  - [ ] 2.2.2 If followers_count == 0 AND tweet_count > 0, trigger fallback
-  - [ ] 2.2.3 Call `_scrape_followers_count` with username from API response
-  - [ ] 2.2.4 If scrape succeeds, merge scraped value into JSON output
-  - [ ] 2.2.5 If scrape fails, keep API value and warn on stderr
-  - [ ] 2.2.6 Emit diagnostic warning to stderr when fallback triggers
+- [ ] 2.1 Add `_check_metrics_anomaly` function to `x-community.sh`
+  - [ ] 2.1.1 Accept metrics JSON as input parameter
+  - [ ] 2.1.2 Extract `followers_count`, `tweet_count`, `following_count` via jq
+  - [ ] 2.1.3 Check for active-account-zero-followers anomaly: followers=0 AND tweets>0 AND following>0
+  - [ ] 2.1.4 Check for all-zeros anomaly: all public_metrics values are 0 (except possibly tweet_count)
+  - [ ] 2.1.5 Emit descriptive warning to stderr when anomaly detected (truncate to 200 chars per learning)
+  - [ ] 2.1.6 Return 0 for anomaly detected, 1 for normal
+- [ ] 2.2 Integrate anomaly check into `cmd_fetch_metrics`
+  - [ ] 2.2.1 After API call and jq transform, pipe metrics JSON to `_check_metrics_anomaly`
+  - [ ] 2.2.2 Preserve stdout JSON output unchanged regardless of anomaly result
+  - [ ] 2.2.3 Ensure stderr warnings do not corrupt stdout JSON
 
 ## Phase 3: Testing
 
-- [ ] 3.1 Run `cmd_fetch_metrics` with live API to verify fallback triggers
-- [ ] 3.2 Verify JSON output schema is unchanged
-- [ ] 3.3 Verify stderr diagnostic does not corrupt stdout JSON
-- [ ] 3.4 Test edge case: account with 0 tweets and 0 followers (no fallback)
+- [ ] 3.1 Run `cmd_fetch_metrics` with live API to verify anomaly warning triggers
+- [ ] 3.2 Verify JSON output schema is unchanged (same keys, same structure)
+- [ ] 3.3 Verify stderr warning does not corrupt stdout JSON
+- [ ] 3.4 Test edge case: genuinely new account (all zeros) should not warn

--- a/knowledge-base/project/specs/feat-one-shot-fix-x-followers-count/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-x-followers-count/tasks.md
@@ -10,21 +10,21 @@
 
 ## Phase 2: Core Implementation
 
-- [ ] 2.1 Add `_check_metrics_anomaly` function to `x-community.sh`
-  - [ ] 2.1.1 Accept metrics JSON as input parameter
-  - [ ] 2.1.2 Extract `followers_count`, `tweet_count`, `following_count` via jq
-  - [ ] 2.1.3 Check for active-account-zero-followers anomaly: followers=0 AND tweets>0 AND following>0
-  - [ ] 2.1.4 Check for all-zeros anomaly: all public_metrics values are 0 (except possibly tweet_count)
-  - [ ] 2.1.5 Emit descriptive warning to stderr when anomaly detected (truncate to 200 chars per learning)
-  - [ ] 2.1.6 Return 0 for anomaly detected, 1 for normal
-- [ ] 2.2 Integrate anomaly check into `cmd_fetch_metrics`
-  - [ ] 2.2.1 After API call and jq transform, pipe metrics JSON to `_check_metrics_anomaly`
-  - [ ] 2.2.2 Preserve stdout JSON output unchanged regardless of anomaly result
-  - [ ] 2.2.3 Ensure stderr warnings do not corrupt stdout JSON
+- [x] 2.1 Add `_check_metrics_anomaly` function to `x-community.sh`
+  - [x] 2.1.1 Accept metrics JSON as input parameter
+  - [x] 2.1.2 Extract `followers_count`, `tweet_count`, `following_count` via jq
+  - [x] 2.1.3 Check for active-account-zero-followers anomaly: followers=0 AND tweets>0 AND following>0
+  - [x] 2.1.4 Check for all-zeros anomaly: all public_metrics values are 0 (except possibly tweet_count)
+  - [x] 2.1.5 Emit descriptive warning to stderr when anomaly detected (truncate to 200 chars per learning)
+  - [x] 2.1.6 Return 0 for anomaly detected, 1 for normal
+- [x] 2.2 Integrate anomaly check into `cmd_fetch_metrics`
+  - [x] 2.2.1 After API call and jq transform, pipe metrics JSON to `_check_metrics_anomaly`
+  - [x] 2.2.2 Preserve stdout JSON output unchanged regardless of anomaly result
+  - [x] 2.2.3 Ensure stderr warnings do not corrupt stdout JSON
 
 ## Phase 3: Testing
 
-- [ ] 3.1 Run `cmd_fetch_metrics` with live API to verify anomaly warning triggers
-- [ ] 3.2 Verify JSON output schema is unchanged (same keys, same structure)
-- [ ] 3.3 Verify stderr warning does not corrupt stdout JSON
-- [ ] 3.4 Test edge case: genuinely new account (all zeros) should not warn
+- [x] 3.1 Run `cmd_fetch_metrics` with live API to verify anomaly warning triggers
+- [x] 3.2 Verify JSON output schema is unchanged (same keys, same structure)
+- [x] 3.3 Verify stderr warning does not corrupt stdout JSON
+- [x] 3.4 Test edge case: genuinely new account (all zeros) should not warn

--- a/knowledge-base/project/specs/fix-x-followers-count/session-state.md
+++ b/knowledge-base/project/specs/fix-x-followers-count/session-state.md
@@ -1,0 +1,30 @@
+# Session State
+
+## Plan Phase
+
+- Plan file: knowledge-base/project/plans/2026-04-13-fix-x-followers-count-zero-plan.md
+- Status: complete
+
+### Errors
+
+None
+
+### Decisions
+
+- **Root cause corrected:** Initial hypothesis was "X API returning bad data due to pay-per-use migration." Verified via 3 independent sources (API v2, GraphQL guest token, Playwright page snapshot) that the account genuinely has 0 followers. The API is accurate.
+- **Web scraping approach rejected:** Originally proposed scraping the X profile page as fallback. Playwright verification confirmed the web page also shows 0 followers, making scraping useless.
+- **Anomaly detection selected as fix:** Instead of correcting data, add a `_check_metrics_anomaly` function to `x-community.sh` that emits stderr warnings when metrics look suspicious (e.g., 0 followers on an account with 67 tweets and 18 following).
+- **All-zeros degradation detection added:** Plan includes detecting when all public_metrics are zeroed out simultaneously, which would indicate genuine API degradation vs organic unfollows.
+- **Existing issue #497 tracks API tier upgrade:** No new financial decisions needed; the X API upgrade path is already tracked.
+
+### Components Invoked
+
+- `soleur:plan` -- Created initial plan and tasks
+- `soleur:deepen-plan` -- Enhanced plan with research
+- WebSearch -- Researched X API pay-per-use changes, public_metrics behavior
+- WebFetch -- Checked X developer docs, community forums, scraping guides
+- Playwright MCP -- Verified X profile page shows 0 followers visually
+- Doppler CLI -- Retrieved production X API credentials
+- Live X API v2 call -- Confirmed `followers_count: 0` from authenticated endpoint
+- X GraphQL guest token -- Confirmed `followers_count: 0` from unauthenticated endpoint
+- Markdownlint -- Validated plan file formatting

--- a/plugins/soleur/agents/support/community-manager.md
+++ b/plugins/soleur/agents/support/community-manager.md
@@ -80,6 +80,8 @@ $ROUTER x fetch-timeline --max 20
 
 The `fetch-mentions` and `fetch-timeline` commands require X API paid access (credit purchase). If these return 403, continue with `fetch-metrics` only.
 
+`fetch-metrics` emits anomaly warnings to stderr when metrics look suspicious (e.g., active account with 0 followers, or all social metrics zeroed out). Check the command output for lines starting with "Warning:" and include them as diagnostic notes in the digest.
+
 Bluesky (if enabled): fetch profile metrics:
 
 ```bash

--- a/plugins/soleur/skills/community/scripts/x-community.sh
+++ b/plugins/soleur/skills/community/scripts/x-community.sh
@@ -366,16 +366,21 @@ _fetch_tweets_for_user() {
 
 # --- Anomaly detection ---
 
-# Check public_metrics for anomalous patterns and emit warnings to stderr.
-# Arguments: metrics_json (JSON object with followers_count, following_count, tweet_count, listed_count)
-# Returns: 0 if anomaly detected, 1 if normal
-_check_metrics_anomaly() {
+# Detect anomalous public_metrics patterns and emit warnings to stderr.
+# Shell boolean convention: returns 0 (true) if anomaly exists, 1 (false) if normal.
+# Arguments: metrics_json (JSON object with followers_count, following_count, tweet_count)
+_has_metrics_anomaly() {
   local metrics_json="$1"
 
   local followers following tweets
-  followers=$(echo "$metrics_json" | jq -r '.followers_count // 0')
-  following=$(echo "$metrics_json" | jq -r '.following_count // 0')
-  tweets=$(echo "$metrics_json" | jq -r '.tweet_count // 0')
+  read -r followers following tweets < <(
+    echo "$metrics_json" | jq -r '[.followers_count // 0, .following_count // 0, .tweet_count // 0] | @tsv'
+  )
+
+  # Fail safe on non-numeric jq output (malformed API response)
+  if [[ ! "$followers" =~ ^[0-9]+$ ]] || [[ ! "$following" =~ ^[0-9]+$ ]] || [[ ! "$tweets" =~ ^[0-9]+$ ]]; then
+    return 1
+  fi
 
   # Genuinely new/empty account: all zeros is not anomalous
   if (( followers == 0 && following == 0 && tweets == 0 )); then
@@ -383,7 +388,6 @@ _check_metrics_anomaly() {
   fi
 
   # All-zeros degradation: followers=0, following=0, but tweets>0
-  # Stronger signal of API degradation than organic unfollows
   if (( followers == 0 && following == 0 && tweets > 0 )); then
     echo "Warning: X API returned all-zero social metrics for account with ${tweets} tweets. Possible API degradation." | head -c 200 >&2
     return 0
@@ -404,7 +408,7 @@ cmd_fetch_metrics() {
   local body
   body=$(get_request "/2/users/me" "user.fields=public_metrics,description,created_at")
 
-  local output
+  local output metrics_json
   output=$(echo "$body" | jq '{
     username: .data.username,
     name: .data.name,
@@ -412,11 +416,10 @@ cmd_fetch_metrics() {
     created_at: .data.created_at,
     metrics: .data.public_metrics
   }')
+  metrics_json=$(echo "$output" | jq '.metrics // {}')
 
-  # Run anomaly check on metrics (warnings go to stderr, stdout unchanged)
-  local metrics_json
-  metrics_json=$(echo "$body" | jq '.data.public_metrics // {}')
-  _check_metrics_anomaly "$metrics_json" || true
+  # Run anomaly check (warnings go to stderr, stdout unchanged)
+  _has_metrics_anomaly "$metrics_json" || true
 
   echo "$output"
 }

--- a/plugins/soleur/skills/community/scripts/x-community.sh
+++ b/plugins/soleur/skills/community/scripts/x-community.sh
@@ -364,19 +364,61 @@ _fetch_tweets_for_user() {
   echo "$body" | jq '.data // []'
 }
 
+# --- Anomaly detection ---
+
+# Check public_metrics for anomalous patterns and emit warnings to stderr.
+# Arguments: metrics_json (JSON object with followers_count, following_count, tweet_count, listed_count)
+# Returns: 0 if anomaly detected, 1 if normal
+_check_metrics_anomaly() {
+  local metrics_json="$1"
+
+  local followers following tweets
+  followers=$(echo "$metrics_json" | jq -r '.followers_count // 0')
+  following=$(echo "$metrics_json" | jq -r '.following_count // 0')
+  tweets=$(echo "$metrics_json" | jq -r '.tweet_count // 0')
+
+  # Genuinely new/empty account: all zeros is not anomalous
+  if (( followers == 0 && following == 0 && tweets == 0 )); then
+    return 1
+  fi
+
+  # All-zeros degradation: followers=0, following=0, but tweets>0
+  # Stronger signal of API degradation than organic unfollows
+  if (( followers == 0 && following == 0 && tweets > 0 )); then
+    echo "Warning: X API returned all-zero social metrics for account with ${tweets} tweets. Possible API degradation." | head -c 200 >&2
+    return 0
+  fi
+
+  # Active account with zero followers: followers=0 but tweets>0 and following>0
+  if (( followers == 0 && tweets > 0 && following > 0 )); then
+    echo "Warning: X API returned 0 followers for active account (${tweets} tweets, ${following} following). This may indicate unfollows, spam cleanup, or API degradation." | head -c 200 >&2
+    return 0
+  fi
+
+  return 1
+}
+
 # --- Commands ---
 
 cmd_fetch_metrics() {
   local body
   body=$(get_request "/2/users/me" "user.fields=public_metrics,description,created_at")
 
-  echo "$body" | jq '{
+  local output
+  output=$(echo "$body" | jq '{
     username: .data.username,
     name: .data.name,
     description: .data.description,
     created_at: .data.created_at,
     metrics: .data.public_metrics
-  }'
+  }')
+
+  # Run anomaly check on metrics (warnings go to stderr, stdout unchanged)
+  local metrics_json
+  metrics_json=$(echo "$body" | jq '.data.public_metrics // {}')
+  _check_metrics_anomaly "$metrics_json" || true
+
+  echo "$output"
 }
 
 cmd_fetch_mentions() {

--- a/test/helpers/test-check-metrics-anomaly.sh
+++ b/test/helpers/test-check-metrics-anomaly.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# test-check-metrics-anomaly.sh -- Test harness for _check_metrics_anomaly()
+# test-check-metrics-anomaly.sh -- Test harness for _has_metrics_anomaly()
 #
 # Sources x-community.sh (which skips main via the source guard)
-# and calls _check_metrics_anomaly with the provided JSON argument.
+# and calls _has_metrics_anomaly with the provided JSON argument.
 #
 # Usage: test-check-metrics-anomaly.sh <metrics_json>
 
@@ -11,7 +11,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_PATH="${SCRIPT_DIR}/../../plugins/soleur/skills/community/scripts/x-community.sh"
 
-# Source the script to load _check_metrics_anomaly (source guard prevents main from running)
+# Source the script to load _has_metrics_anomaly (source guard prevents main from running)
 source "$SCRIPT_PATH"
 
-_check_metrics_anomaly "$@"
+_has_metrics_anomaly "$@"

--- a/test/helpers/test-check-metrics-anomaly.sh
+++ b/test/helpers/test-check-metrics-anomaly.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# test-check-metrics-anomaly.sh -- Test harness for _check_metrics_anomaly()
+#
+# Sources x-community.sh (which skips main via the source guard)
+# and calls _check_metrics_anomaly with the provided JSON argument.
+#
+# Usage: test-check-metrics-anomaly.sh <metrics_json>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_PATH="${SCRIPT_DIR}/../../plugins/soleur/skills/community/scripts/x-community.sh"
+
+# Source the script to load _check_metrics_anomaly (source guard prevents main from running)
+source "$SCRIPT_PATH"
+
+_check_metrics_anomaly "$@"

--- a/test/x-community.test.ts
+++ b/test/x-community.test.ts
@@ -620,10 +620,11 @@ describe("x-community.sh -- rename verification", () => {
 });
 
 // ---------------------------------------------------------------------------
-// _check_metrics_anomaly -- anomaly detection for public_metrics
+// _has_metrics_anomaly -- anomaly detection for public_metrics
+// Shell boolean: 0 = true (anomaly exists), 1 = false (normal)
 // ---------------------------------------------------------------------------
 
-describeIfJq("x-community.sh _check_metrics_anomaly -- active account zero followers", () => {
+describeIfJq("x-community.sh _has_metrics_anomaly", () => {
   test("emits warning when followers=0 but tweets>0 and following>0", () => {
     const metrics = JSON.stringify({
       followers_count: 0,
@@ -637,18 +638,14 @@ describeIfJq("x-community.sh _check_metrics_anomaly -- active account zero follo
       { env: NO_CREDS_ENV }
     );
 
-    // Return code 0 = anomaly detected
     expect(result.exitCode).toBe(0);
     const stderr = decode(result.stderr);
     expect(stderr).toContain("Warning:");
     expect(stderr).toContain("0 followers");
-    // Stdout must be empty (no JSON corruption)
     expect(decode(result.stdout)).toBe("");
   });
-});
 
-describeIfJq("x-community.sh _check_metrics_anomaly -- all-zeros degradation", () => {
-  test("emits stronger warning when all metrics are zero except tweet_count", () => {
+  test("emits degradation warning when all social metrics are zero except tweet_count", () => {
     const metrics = JSON.stringify({
       followers_count: 0,
       following_count: 0,
@@ -666,9 +663,7 @@ describeIfJq("x-community.sh _check_metrics_anomaly -- all-zeros degradation", (
     expect(stderr).toContain("Warning:");
     expect(stderr).toContain("API degradation");
   });
-});
 
-describeIfJq("x-community.sh _check_metrics_anomaly -- normal account", () => {
   test("no warning when followers > 0", () => {
     const metrics = JSON.stringify({
       followers_count: 5,
@@ -682,14 +677,11 @@ describeIfJq("x-community.sh _check_metrics_anomaly -- normal account", () => {
       { env: NO_CREDS_ENV }
     );
 
-    // Return code 1 = normal (no anomaly)
     expect(result.exitCode).toBe(1);
     expect(decode(result.stderr)).toBe("");
   });
-});
 
-describeIfJq("x-community.sh _check_metrics_anomaly -- genuinely new account", () => {
-  test("no warning when all metrics are zero (new account)", () => {
+  test("no warning when all metrics are zero (genuinely new account)", () => {
     const metrics = JSON.stringify({
       followers_count: 0,
       following_count: 0,
@@ -702,7 +694,23 @@ describeIfJq("x-community.sh _check_metrics_anomaly -- genuinely new account", (
       { env: NO_CREDS_ENV }
     );
 
-    // Return code 1 = normal (genuinely new account, not anomalous)
+    expect(result.exitCode).toBe(1);
+    expect(decode(result.stderr)).toBe("");
+  });
+
+  test("no warning when only listed_count > 0 (listed_count excluded from detection)", () => {
+    const metrics = JSON.stringify({
+      followers_count: 0,
+      following_count: 0,
+      tweet_count: 0,
+      listed_count: 3,
+    });
+
+    const result = Bun.spawnSync(
+      ["bash", CHECK_METRICS_ANOMALY_HELPER, metrics],
+      { env: NO_CREDS_ENV }
+    );
+
     expect(result.exitCode).toBe(1);
     expect(decode(result.stderr)).toBe("");
   });

--- a/test/x-community.test.ts
+++ b/test/x-community.test.ts
@@ -18,6 +18,12 @@ const HANDLE_RESPONSE_HELPER = join(
   "test-handle-response.sh"
 );
 
+const CHECK_METRICS_ANOMALY_HELPER = join(
+  import.meta.dirname,
+  "helpers",
+  "test-check-metrics-anomaly.sh"
+);
+
 // x-community.sh calls require_jq in main() before dispatching to any command,
 // so ALL tests that invoke the script need this guard, not just direct jq calls.
 const HAS_JQ =
@@ -610,5 +616,94 @@ describe("x-community.sh -- rename verification", () => {
 
     // grep -c returns the count; 0 matches means exit code 1
     expect(result.exitCode).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _check_metrics_anomaly -- anomaly detection for public_metrics
+// ---------------------------------------------------------------------------
+
+describeIfJq("x-community.sh _check_metrics_anomaly -- active account zero followers", () => {
+  test("emits warning when followers=0 but tweets>0 and following>0", () => {
+    const metrics = JSON.stringify({
+      followers_count: 0,
+      following_count: 18,
+      tweet_count: 67,
+      listed_count: 0,
+    });
+
+    const result = Bun.spawnSync(
+      ["bash", CHECK_METRICS_ANOMALY_HELPER, metrics],
+      { env: NO_CREDS_ENV }
+    );
+
+    // Return code 0 = anomaly detected
+    expect(result.exitCode).toBe(0);
+    const stderr = decode(result.stderr);
+    expect(stderr).toContain("Warning:");
+    expect(stderr).toContain("0 followers");
+    // Stdout must be empty (no JSON corruption)
+    expect(decode(result.stdout)).toBe("");
+  });
+});
+
+describeIfJq("x-community.sh _check_metrics_anomaly -- all-zeros degradation", () => {
+  test("emits stronger warning when all metrics are zero except tweet_count", () => {
+    const metrics = JSON.stringify({
+      followers_count: 0,
+      following_count: 0,
+      tweet_count: 67,
+      listed_count: 0,
+    });
+
+    const result = Bun.spawnSync(
+      ["bash", CHECK_METRICS_ANOMALY_HELPER, metrics],
+      { env: NO_CREDS_ENV }
+    );
+
+    expect(result.exitCode).toBe(0);
+    const stderr = decode(result.stderr);
+    expect(stderr).toContain("Warning:");
+    expect(stderr).toContain("API degradation");
+  });
+});
+
+describeIfJq("x-community.sh _check_metrics_anomaly -- normal account", () => {
+  test("no warning when followers > 0", () => {
+    const metrics = JSON.stringify({
+      followers_count: 5,
+      following_count: 18,
+      tweet_count: 67,
+      listed_count: 1,
+    });
+
+    const result = Bun.spawnSync(
+      ["bash", CHECK_METRICS_ANOMALY_HELPER, metrics],
+      { env: NO_CREDS_ENV }
+    );
+
+    // Return code 1 = normal (no anomaly)
+    expect(result.exitCode).toBe(1);
+    expect(decode(result.stderr)).toBe("");
+  });
+});
+
+describeIfJq("x-community.sh _check_metrics_anomaly -- genuinely new account", () => {
+  test("no warning when all metrics are zero (new account)", () => {
+    const metrics = JSON.stringify({
+      followers_count: 0,
+      following_count: 0,
+      tweet_count: 0,
+      listed_count: 0,
+    });
+
+    const result = Bun.spawnSync(
+      ["bash", CHECK_METRICS_ANOMALY_HELPER, metrics],
+      { env: NO_CREDS_ENV }
+    );
+
+    // Return code 1 = normal (genuinely new account, not anomalous)
+    expect(result.exitCode).toBe(1);
+    expect(decode(result.stderr)).toBe("");
   });
 });


### PR DESCRIPTION
## Summary
- Add `_has_metrics_anomaly` function to `x-community.sh` that detects suspicious metric patterns (active account with 0 followers, all-zeros degradation) and emits diagnostic warnings to stderr
- Integrated into `cmd_fetch_metrics` without changing the stdout JSON schema
- Updated `community-manager.md` to instruct the agent to surface warnings in digests
- 5 new tests covering all anomaly detection scenarios

## Context
The community monitor reported 0 X followers starting April 11. Investigation via 3 independent sources (API v2, GraphQL, Playwright) confirmed the API data is accurate -- the account genuinely has 0 followers. The fix adds diagnostics rather than data correction.

Ref #497

## Changelog
- Added anomaly detection to X community monitor (`_has_metrics_anomaly` function)
- Added numeric guard for non-numeric jq output
- Consolidated jq invocations from 5 to 2 per call
- Updated community-manager agent to surface anomaly warnings in digests
- Added 5 test cases for anomaly detection edge cases

## Test plan
- [x] All 36 x-community tests pass (31 existing + 5 new)
- [x] Full test suite passes (9/9 suites)
- [x] Live API test confirms correct behavior (1 follower, no false warning)
- [x] Markdownlint passes on all changed .md files

Generated with [Claude Code](https://claude.com/claude-code)