### PR TITLE
chore(roadmap): add Phase 3 rows for #2004 and #1944

### DIFF
--- a/knowledge-base/product/roadmap.md
+++ b/knowledge-base/product/roadmap.md
@@ -200,6 +200,8 @@ This roadmap was reviewed by CTO, CLO, CFO, and CMO before finalization.
 | 3.18 | KB items, KB, and session sharing (read-only external access with signup CTAs, revocable) | P2 | [#1745](https://github.com/jikig-ai/soleur/issues/1745) | Done |
 | 3.19 | Chat attachments (images + PDFs via Supabase Storage, presigned URL upload, AI processing via filesystem write) | P2 | [#1961](https://github.com/jikig-ai/soleur/issues/1961) | Done |
 | 3.20 | KB file upload (images, PDFs, CSV, TXT, DOCX via GitHub Contents API, per-directory upload button, binary file preview) | P3 | [#1974](https://github.com/jikig-ai/soleur/issues/1974) | Done |
+| 3.21 | Agent work visualization in UX (show agent activity, progress, and outputs) | P2 | [#2004](https://github.com/jikig-ai/soleur/issues/2004) | Not started |
+| 3.22 | Service automation feature announcement (marketing content for launch) | P3 | [#1944](https://github.com/jikig-ai/soleur/issues/1944) | Not started |
 
 **Why 3.1-3.2 matter:** The knowledge base is the compounding moat. If founders cannot see plans, brainstorms, brand guides, and competitive analyses their agents produced, the value is invisible. The KB viewer closes the review loop.
 


### PR DESCRIPTION
## Summary
- Add row 3.21 for agent work visualization (#2004, P2 feature)
- Add row 3.22 for service automation announcement (#1944, P3 chore)
- Both issues are in the Phase 3 milestone but had no roadmap table entry (bidirectional gate violation)
- M12-M18 marketing gate rows were already added in #2084

Ref #2083

## Changelog
- Added 2 missing rows to Phase 3 table in roadmap.md to satisfy the bidirectional gate (every issue in a milestone must have a table row)

## Test plan
- [x] markdownlint passes with 0 errors
- [x] Table rows align with existing format
- [x] Issue numbers and statuses verified via `gh issue view`

Generated with [Claude Code](https://claude.com/claude-code)