### PR TITLE
fix(dashboard): require minimum file size for foundation card completion

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/page.tsx
@@ -8,6 +8,7 @@ import { useOnboarding } from "@/hooks/use-onboarding";
 import { ConversationRow } from "@/components/inbox/conversation-row";
 import { ErrorCard } from "@/components/ui/error-card";
 import { STATUS_LABELS } from "@/lib/types";
+import { FOUNDATION_MIN_CONTENT_BYTES } from "@/lib/kb-constants";
 import type { ConversationStatus } from "@/lib/types";
 import type { DomainLeaderId } from "@/server/domain-leaders";
 import { DOMAIN_LEADERS, ROUTABLE_DOMAIN_LEADERS } from "@/server/domain-leaders";
@@ -40,13 +41,23 @@ interface TreeNode {
   name: string;
   type: "file" | "directory";
   path?: string;
+  size?: number;
   children?: TreeNode[];
 }
 
-function flattenTree(node: TreeNode, paths = new Set<string>()): Set<string> {
-  if (node.type === "file" && node.path) paths.add(node.path);
-  for (const child of node.children ?? []) flattenTree(child, paths);
-  return paths;
+interface FileInfo {
+  size?: number;
+}
+
+function flattenTree(
+  node: TreeNode,
+  files = new Map<string, FileInfo>(),
+): Map<string, FileInfo> {
+  if (node.type === "file" && node.path) {
+    files.set(node.path, { size: node.size });
+  }
+  for (const child of node.children ?? []) flattenTree(child, files);
+  return files;
 }
 
 // ---------------------------------------------------------------------------
@@ -108,7 +119,7 @@ export default function DashboardPage() {
   // ---------------------------------------------------------------------------
 
   const [kbLoading, setKbLoading] = useState(true);
-  const [kbPaths, setKbPaths] = useState<Set<string>>(new Set());
+  const [kbFiles, setKbFiles] = useState<Map<string, FileInfo>>(new Map());
   const [kbError, setKbError] = useState<"provisioning" | "error" | null>(null);
 
   useEffect(() => {
@@ -134,7 +145,7 @@ export default function DashboardPage() {
       .then((data) => {
         if (cancelled) return;
         if (data?.tree) {
-          setKbPaths(flattenTree(data.tree));
+          setKbFiles(flattenTree(data.tree));
         }
         setKbLoading(false);
       })
@@ -150,10 +161,12 @@ export default function DashboardPage() {
     };
   }, [router]);
 
-  const visionExists = kbPaths.has("overview/vision.md");
+  const visionExists = kbFiles.has("overview/vision.md");
   const foundationCards: FoundationCard[] = FOUNDATION_PATHS.map((f) => ({
     ...f,
-    done: kbPaths.has(f.kbPath),
+    done:
+      kbFiles.has(f.kbPath) &&
+      (kbFiles.get(f.kbPath)?.size ?? 0) >= FOUNDATION_MIN_CONTENT_BYTES,
   }));
   const allFoundationsComplete = foundationCards.every((c) => c.done);
 

--- a/apps/web-platform/e2e/start-fresh-onboarding.e2e.ts
+++ b/apps/web-platform/e2e/start-fresh-onboarding.e2e.ts
@@ -9,6 +9,7 @@ interface TreeNode {
   name: string;
   type: "file" | "directory";
   path?: string;
+  size?: number;
   children?: TreeNode[];
 }
 
@@ -23,7 +24,7 @@ function kbTree(...files: string[]): { tree: TreeNode } {
       pathSoFar = pathSoFar ? `${pathSoFar}/${part}` : part;
       if (i === parts.length - 1) {
         current.children ??= [];
-        current.children.push({ name: part, type: "file", path: pathSoFar });
+        current.children.push({ name: part, type: "file", path: pathSoFar, size: 1000 });
       } else {
         current.children ??= [];
         let child = current.children.find((c) => c.name === part && c.type === "directory");

--- a/apps/web-platform/lib/kb-constants.ts
+++ b/apps/web-platform/lib/kb-constants.ts
@@ -6,3 +6,14 @@
  */
 
 export const KB_MAX_FILE_SIZE = 1024 * 1024; // 1MB
+
+/**
+ * Minimum file size (bytes) to consider a foundation document "complete".
+ * Used by:
+ * - dashboard/page.tsx: Foundation card completion check
+ * - vision-helpers.ts: buildVisionEnhancementPrompt threshold
+ *
+ * A typical stub (# Title + placeholder) is ~100-300 bytes.
+ * Real authored content (multiple sections) exceeds 500 bytes.
+ */
+export const FOUNDATION_MIN_CONTENT_BYTES = 500;

--- a/apps/web-platform/server/kb-reader.ts
+++ b/apps/web-platform/server/kb-reader.ts
@@ -14,6 +14,7 @@ export interface TreeNode {
   type: "file" | "directory";
   path?: string;
   modifiedAt?: string;
+  size?: number;
   extension?: string; // e.g., ".md", ".png", ".pdf"
   children?: TreeNode[];
 }
@@ -180,15 +181,13 @@ export async function buildTree(
       MAX_CONCURRENT_STAT,
       async ({ entry, fullPath }): Promise<TreeNode> => {
         const ext = path.extname(entry.name);
-        const modifiedAt = await fs.promises
-          .stat(fullPath)
-          .then((stat) => stat.mtime.toISOString())
-          .catch(() => undefined);
+        const stat = await fs.promises.stat(fullPath).catch(() => null);
         return {
           name: entry.name,
           type: "file" as const,
           path: path.relative(effectiveTopRoot, fullPath),
-          modifiedAt,
+          modifiedAt: stat?.mtime.toISOString(),
+          size: stat?.size,
           extension: ext || undefined,
         };
       },

--- a/apps/web-platform/server/vision-helpers.ts
+++ b/apps/web-platform/server/vision-helpers.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import { FOUNDATION_MIN_CONTENT_BYTES } from "@/lib/kb-constants";
 
 const MAX_VISION_CONTENT = 5000;
 
@@ -64,7 +65,7 @@ export async function buildVisionEnhancementPrompt(
 
   try {
     const stat = await fs.promises.stat(visionPath);
-    if (stat.size >= 500) return null;
+    if (stat.size >= FOUNDATION_MIN_CONTENT_BYTES) return null;
   } catch {
     return null;
   }

--- a/apps/web-platform/test/command-center.test.tsx
+++ b/apps/web-platform/test/command-center.test.tsx
@@ -145,10 +145,10 @@ describe("Command Center", () => {
             name: "knowledge-base",
             type: "directory",
             children: [
-              { name: "overview", type: "directory", children: [{ name: "vision.md", type: "file", path: "overview/vision.md" }] },
-              { name: "marketing", type: "directory", children: [{ name: "brand-guide.md", type: "file", path: "marketing/brand-guide.md" }] },
-              { name: "product", type: "directory", children: [{ name: "business-validation.md", type: "file", path: "product/business-validation.md" }] },
-              { name: "legal", type: "directory", children: [{ name: "privacy-policy.md", type: "file", path: "legal/privacy-policy.md" }] },
+              { name: "overview", type: "directory", children: [{ name: "vision.md", type: "file", path: "overview/vision.md", size: 1000 }] },
+              { name: "marketing", type: "directory", children: [{ name: "brand-guide.md", type: "file", path: "marketing/brand-guide.md", size: 1000 }] },
+              { name: "product", type: "directory", children: [{ name: "business-validation.md", type: "file", path: "product/business-validation.md", size: 1000 }] },
+              { name: "legal", type: "directory", children: [{ name: "privacy-policy.md", type: "file", path: "legal/privacy-policy.md", size: 1000 }] },
             ],
           },
         }),
@@ -299,6 +299,43 @@ describe("Command Center", () => {
     await waitFor(() => {
       expect(conversationBuilder.not).toHaveBeenCalledWith("archived_at", "is", null);
     });
+  });
+
+  it("shows foundation cards with Vision incomplete when vision.md is a stub", async () => {
+    conversationBuilder = createQueryBuilder([]);
+    messageBuilder = createQueryBuilder([]);
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          tree: {
+            name: "knowledge-base",
+            type: "directory",
+            children: [
+              { name: "overview", type: "directory", children: [{ name: "vision.md", type: "file", path: "overview/vision.md", size: 200 }] },
+              { name: "marketing", type: "directory", children: [{ name: "brand-guide.md", type: "file", path: "marketing/brand-guide.md", size: 1000 }] },
+              { name: "product", type: "directory", children: [{ name: "business-validation.md", type: "file", path: "product/business-validation.md", size: 1000 }] },
+              { name: "legal", type: "directory", children: [{ name: "privacy-policy.md", type: "file", path: "legal/privacy-policy.md", size: 1000 }] },
+            ],
+          },
+        }),
+    });
+
+    const { default: DashboardPage } = await import(
+      "@/app/(dashboard)/dashboard/page"
+    );
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/no conversations yet/i)).toBeInTheDocument();
+    });
+
+    // Vision is a stub — should NOT have green checkmark
+    // Only 3 of 4 foundations complete (brand, validation, legal)
+    const completeLabels = screen.getAllByLabelText("Complete");
+    expect(completeLabels).toHaveLength(3);
   });
 
   it("navigates to new conversation when button is clicked", async () => {

--- a/apps/web-platform/test/start-fresh-onboarding.test.tsx
+++ b/apps/web-platform/test/start-fresh-onboarding.test.tsx
@@ -55,7 +55,10 @@ vi.mock("@/lib/supabase/client", () => ({
 }));
 
 // Helper: build a KB tree structure matching the API response
-function buildMockTree(filePaths: string[]) {
+function buildMockTree(
+  filePaths: string[],
+  sizes?: Record<string, number>,
+) {
   // Build a nested TreeNode from flat paths
   const root: Record<string, unknown> = {
     name: "knowledge-base",
@@ -78,6 +81,7 @@ function buildMockTree(filePaths: string[]) {
           type: "file",
           path: p,
           modifiedAt: new Date().toISOString(),
+          size: sizes?.[p] ?? 1000,
         });
       } else {
         let dir = children.find(
@@ -272,6 +276,65 @@ describe("Start Fresh Onboarding - KB State Derivation", () => {
     // Foundation card titles
     expect(screen.getByText("Brand Identity")).toBeInTheDocument();
     expect(screen.getByText("Legal Foundations")).toBeInTheDocument();
+  });
+
+  it("stub vision.md does not count as foundation complete", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          tree: buildMockTree(
+            ["overview/vision.md"],
+            { "overview/vision.md": 200 },
+          ),
+        }),
+    });
+
+    const { default: DashboardPage } = await import(
+      "@/app/(dashboard)/dashboard/page"
+    );
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      // Vision exists but is stub — should show foundation cards
+      expect(screen.getByText(/no conversations yet/i)).toBeInTheDocument();
+    });
+
+    // No green checkmarks — vision is a stub (< 500 bytes)
+    expect(screen.queryByLabelText("Complete")).not.toBeInTheDocument();
+  });
+
+  it("shows all foundations complete only when all files >= 500 bytes", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          tree: buildMockTree(
+            [
+              "overview/vision.md",
+              "marketing/brand-guide.md",
+              "product/business-validation.md",
+              "legal/privacy-policy.md",
+            ],
+            { "overview/vision.md": 300 },
+          ),
+        }),
+    });
+
+    const { default: DashboardPage } = await import(
+      "@/app/(dashboard)/dashboard/page"
+    );
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      // Vision is a stub so not all foundations complete — shows foundations view
+      expect(screen.getByText(/complete these to brief your department leaders/i)).toBeInTheDocument();
+    });
+
+    // Should NOT show "Your organization is ready"
+    expect(screen.queryByText(/your organization is ready/i)).not.toBeInTheDocument();
   });
 
   it("falls through to Command Center on API error", async () => {

--- a/knowledge-base/project/learnings/2026-04-13-foundation-card-completion-requires-file-size-not-existence.md
+++ b/knowledge-base/project/learnings/2026-04-13-foundation-card-completion-requires-file-size-not-existence.md
@@ -1,0 +1,57 @@
+# Learning: Foundation card completion requires file size, not just existence
+
+## Problem
+
+The Command Center dashboard showed a green checkmark (complete) for foundation
+cards when the underlying file merely existed, even if it was a stub containing
+only a title and a placeholder instruction (~100-200 bytes). This false-positive
+completion gave users the impression their vision document was done when it had
+no real content.
+
+## Solution
+
+Added `size` to the KB tree API response (already available from the existing
+`fs.stat()` call in `buildTree`) and changed the dashboard completion check from
+pure file-existence (`Set.has(path)`) to existence + minimum size
+(`Map.get(path)?.size >= FOUNDATION_MIN_CONTENT_BYTES`).
+
+Key decisions:
+
+- Extracted the 500-byte threshold into `FOUNDATION_MIN_CONTENT_BYTES` in
+  `lib/kb-constants.ts` to prevent drift between `vision-helpers.ts` and the
+  dashboard
+- Changed `flattenTree` from `Set<string>` to `Map<string, FileInfo>` to carry
+  size metadata to the consumption site
+- Kept `visionExists` as file-existence-only for the first-run gate (a stub
+  means the user already submitted their idea)
+
+## Key Insight
+
+When a tree API already calls `stat()` on every file, piggybacking additional
+metadata (size, permissions) costs zero additional I/O. The stat result was being
+destructured to extract only `mtime` and the rest discarded. Capturing the full
+result object and extracting multiple fields is both simpler and more useful.
+
+Shared constants (`FOUNDATION_MIN_CONTENT_BYTES`) between server and client code
+prevent threshold drift -- the 500-byte magic number existed in two places before
+this fix.
+
+## Session Errors
+
+1. **E2e test `kbTree()` helper missing `size` field** — The plan's task list
+   covered unit test updates but missed the e2e test file
+   (`e2e/start-fresh-onboarding.e2e.ts`), which has its own `TreeNode` interface
+   copy. Three review agents independently flagged this. Recovery: Fixed in a
+   follow-up commit. Prevention: When adding a field to a shared interface,
+   grep for all copies of the interface across the codebase (including test and
+   e2e directories) before considering the task complete.
+
+2. **Dev server startup failure during QA** — Supabase env vars missing from
+   Doppler `dev` config prevented browser-based QA. Recovery: Skipped browser
+   QA (unit tests covered all scenarios). Prevention: Pre-existing environment
+   issue; tracked separately.
+
+## Tags
+
+category: ui-bugs
+module: dashboard, kb-reader

--- a/knowledge-base/project/plans/2026-04-13-fix-vision-completion-check-plan.md
+++ b/knowledge-base/project/plans/2026-04-13-fix-vision-completion-check-plan.md
@@ -4,6 +4,28 @@ type: fix
 date: 2026-04-13
 ---
 
+## Enhancement Summary
+
+**Deepened on:** 2026-04-13
+**Sections enhanced:** 5 (Implementation, Architecture, Tests, Edge Cases, Learnings)
+**Research sources:** Local codebase analysis, 6 institutional learnings, kb-reader concurrency patterns
+
+### Key Improvements
+
+1. Precise `buildTree` refactoring that preserves bounded concurrency (`mapWithConcurrency` pattern from learning 2026-04-12)
+2. Complete `buildMockTree` helper update with size parameter and default value strategy
+3. Edge case analysis: threshold boundary, YAML frontmatter overhead, binary files, concurrent writes
+4. Identified 4 existing tests that need mock updates (with exact line changes)
+
+### New Considerations Discovered
+
+- The `buildTree` stat call pattern uses `.then().catch()` chaining, not `await` -- refactoring must preserve this to avoid changing error handling semantics
+- The `buildMockTree` helper in `start-fresh-onboarding.test.tsx` is shared across 12+ tests -- default size must be >= 500 to avoid breaking existing passing tests
+- `visionExists` (first-run gate) must remain file-existence-only to preserve the UX of "user already submitted idea but agent hasn't enhanced yet"
+- The 500-byte threshold aligns with `buildVisionEnhancementPrompt` but should be exported as a shared constant to prevent drift
+
+---
+
 # fix: Vision foundation card shows green checkmark for stub files
 
 ## Overview
@@ -79,21 +101,29 @@ stubs from real content. This approach:
 
 **File:** `apps/web-platform/server/kb-reader.ts`
 
-- Add `size?: number` to the `TreeNode` interface
-- In the `mapWithConcurrency` callback (line ~181-193), the `stat` is already
-  being called. Add `size: stat.size` to the returned `TreeNode`
+- Add `size?: number` to the `TreeNode` interface (line 12-19)
+- In the `mapWithConcurrency` callback (lines 181-194), refactor the stat
+  call to capture the full stat result instead of chaining `.then()`
+
+### Research Insights
+
+**Concurrency preservation (learning: 2026-04-12-buildtree-bounded-concurrency-emfile):**
+The current `mapWithConcurrency` pattern bounds stat calls to 50 concurrent.
+The refactoring must stay inside this callback -- do NOT move the stat call
+outside or add additional parallel operations.
+
+**Current stat pattern (lines 183-186):** Uses `.then().catch()` chaining:
 
 ```typescript
-// Current:
-return {
-  name: entry.name,
-  type: "file" as const,
-  path: path.relative(effectiveTopRoot, fullPath),
-  modifiedAt,
-  extension: ext || undefined,
-};
+const modifiedAt = await fs.promises
+  .stat(fullPath)
+  .then((stat) => stat.mtime.toISOString())
+  .catch(() => undefined);
+```
 
-// Updated:
+**Refactored pattern:** Capture full stat result, extract both fields:
+
+```typescript
 const stat = await fs.promises.stat(fullPath).catch(() => null);
 return {
   name: entry.name,
@@ -105,6 +135,17 @@ return {
 };
 ```
 
+**Why `.catch(() => null)` instead of try/catch:** Preserves the existing
+functional chaining style and keeps the same error semantics -- a failed stat
+produces `undefined` for both `modifiedAt` and `size` instead of throwing.
+
+**TreeNode interface change:**
+
+```typescript
+// Add after line 17 (modifiedAt):
+size?: number;
+```
+
 #### 2. Add size to `flattenTree` output on the dashboard
 
 **File:** `apps/web-platform/app/(dashboard)/dashboard/page.tsx`
@@ -113,8 +154,39 @@ Change `kbPaths` from `Set<string>` to `Map<string, { size?: number }>` so
 the dashboard knows both existence and size. Update `flattenTree` to populate
 the map.
 
+### Research Insights
+
+**`Map.has()` is a drop-in for `Set.has()`:** Both return boolean for key
+existence. The only API difference is `Map.get()` for size retrieval. All
+existing `kbPaths.has(...)` call sites work unchanged after renaming.
+
+**TreeNode interface on the client side:** The dashboard already declares a
+local `TreeNode` interface (lines 39-44) that mirrors the server type. Add
+`size?: number` there too.
+
+**State type change (lines 111, 137):** `useState<Set<string>>(new Set())`
+becomes `useState<Map<string, FileInfo>>(new Map())`. The `new Map()`
+default matches `new Set()` semantics (empty collection).
+
 ```typescript
-// Current:
+// Current (line 39-44):
+interface TreeNode {
+  name: string;
+  type: "file" | "directory";
+  path?: string;
+  children?: TreeNode[];
+}
+
+// Updated:
+interface TreeNode {
+  name: string;
+  type: "file" | "directory";
+  path?: string;
+  size?: number;
+  children?: TreeNode[];
+}
+
+// Current flattenTree (lines 46-50):
 function flattenTree(node: TreeNode, paths = new Set<string>()): Set<string> {
   if (node.type === "file" && node.path) paths.add(node.path);
   for (const child of node.children ?? []) flattenTree(child, paths);
@@ -139,18 +211,44 @@ function flattenTree(
 
 **File:** `apps/web-platform/app/(dashboard)/dashboard/page.tsx`
 
-Add a minimum content size constant and update the `done` derivation:
+Add a minimum content size constant and update the `done` derivation.
+
+### Research Insights
+
+**Shared constant to prevent drift:** The 500-byte threshold already exists
+in `server/vision-helpers.ts` (line 67: `if (stat.size >= 500) return null`).
+To prevent future drift, extract to the shared constants file:
+
+**File:** `apps/web-platform/lib/kb-constants.ts` (already exists with `KB_MAX_FILE_SIZE`)
 
 ```typescript
+// Add to existing file:
 /**
  * Minimum file size (bytes) to consider a foundation document "complete".
- * Aligned with buildVisionEnhancementPrompt threshold in vision-helpers.ts.
- * A typical stub (title + placeholder) is ~100-300 bytes.
- * Real authored content (Mission, Target Audience, etc.) exceeds 500 bytes.
+ * Used by:
+ * - dashboard/page.tsx: Foundation card completion check
+ * - vision-helpers.ts: buildVisionEnhancementPrompt threshold
+ *
+ * A typical stub (# Title + placeholder) is ~100-300 bytes.
+ * Real authored content (multiple sections) exceeds 500 bytes.
  */
-const FOUNDATION_MIN_CONTENT_BYTES = 500;
+export const FOUNDATION_MIN_CONTENT_BYTES = 500;
+```
 
-// Updated completion check:
+**File:** `apps/web-platform/server/vision-helpers.ts` -- Update to use shared constant:
+
+```typescript
+import { FOUNDATION_MIN_CONTENT_BYTES } from "@/lib/kb-constants";
+// ...
+if (stat.size >= FOUNDATION_MIN_CONTENT_BYTES) return null;
+```
+
+**File:** `apps/web-platform/app/(dashboard)/dashboard/page.tsx`:
+
+```typescript
+import { FOUNDATION_MIN_CONTENT_BYTES } from "@/lib/kb-constants";
+
+// Updated completion check (replaces lines 154-157):
 const foundationCards: FoundationCard[] = FOUNDATION_PATHS.map((f) => ({
   ...f,
   done:
@@ -159,11 +257,14 @@ const foundationCards: FoundationCard[] = FOUNDATION_PATHS.map((f) => ({
 }));
 ```
 
-Also update `visionExists` (used for first-run detection) to retain
-file-existence behavior (Vision existing but being a stub should NOT show the
-first-run input -- the user already submitted their idea):
+**`visionExists` must remain file-existence-only (learning: start-fresh-shows-import-screen):**
+The first-run gate (`!visionExists && conversations.length === 0`) controls
+whether to show the "What are you building?" input. A stub vision means the
+user already submitted their idea -- the agent just hasn't enhanced it yet.
+Showing the input again would be confusing.
 
 ```typescript
+// Unchanged -- file existence only, NOT size-gated:
 const visionExists = kbFiles.has("overview/vision.md");
 ```
 
@@ -174,16 +275,180 @@ type (`Map<string, FileInfo>` instead of `Set<string>`).
 
 #### 5. Update tests
 
+### Research Insights
+
+**Mock stability (learning: 2026-04-07-userouter-mock-instability):** The
+existing tests already use stable mock references. Do not change the
+`useRouter` mock pattern.
+
+**`buildMockTree` helper strategy:** The `buildMockTree` helper in
+`start-fresh-onboarding.test.tsx` (lines 58-96) builds tree nodes from flat
+path strings. It needs a way to specify per-file size. Two options:
+
+- **Option A (recommended):** Default size to 1000 (above threshold) so all
+  existing tests pass without changes. Add optional `sizes` map parameter for
+  tests that need specific sizes.
+- **Option B:** Change each `filePaths` call to include size. Requires
+  updating 12+ test call sites.
+
+Option A is safer -- existing tests implicitly expect files to be "complete".
+
+```typescript
+// Updated buildMockTree signature:
+function buildMockTree(
+  filePaths: string[],
+  sizes?: Record<string, number>,
+) {
+  // ... existing logic ...
+  if (isFile) {
+    children.push({
+      name: part,
+      type: "file",
+      path: p,
+      modifiedAt: new Date().toISOString(),
+      size: sizes?.[p] ?? 1000, // Default above threshold
+    });
+  }
+  // ...
+}
+```
+
 **File:** `apps/web-platform/test/command-center.test.tsx`
 
-Update the mock KB tree to include `size` fields. Add a test case where
-`vision.md` exists but is below the threshold (should NOT show green
-checkmark).
+The inline KB tree mock (lines 139-155) uses direct object literals, not
+`buildMockTree`. Add `size: 1000` to each file node to preserve existing
+behavior:
+
+```typescript
+// Add size to each file node in the mock:
+{ name: "vision.md", type: "file", path: "overview/vision.md", size: 1000 },
+{ name: "brand-guide.md", type: "file", path: "marketing/brand-guide.md", size: 1000 },
+// etc.
+```
+
+Add new test case for stub detection:
+
+```typescript
+it("shows foundation cards with Vision incomplete when vision.md is a stub", async () => {
+  conversationBuilder = createQueryBuilder([]);
+  messageBuilder = createQueryBuilder([]);
+
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () =>
+      Promise.resolve({
+        tree: {
+          name: "knowledge-base",
+          type: "directory",
+          children: [
+            {
+              name: "overview",
+              type: "directory",
+              children: [
+                { name: "vision.md", type: "file", path: "overview/vision.md", size: 200 },
+              ],
+            },
+          ],
+        },
+      }),
+  });
+
+  const { default: DashboardPage } = await import(
+    "@/app/(dashboard)/dashboard/page"
+  );
+  render(<DashboardPage />);
+
+  await waitFor(() => {
+    // Vision exists (no first-run), but stub -- should show foundations
+    expect(screen.getByText(/no conversations yet/i)).toBeInTheDocument();
+  });
+
+  // Vision should NOT have the green checkmark (Complete label)
+  expect(screen.queryByLabelText("Complete")).not.toBeInTheDocument();
+});
+```
 
 **File:** `apps/web-platform/test/start-fresh-onboarding.test.tsx`
 
-Update mock tree builders to include `size` fields. Verify that stub vision
-files do not trigger the "all foundations complete" state.
+Update `buildMockTree` as described above. Add new test:
+
+```typescript
+it("stub vision.md does not count as foundation complete", async () => {
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: () =>
+      Promise.resolve({
+        tree: buildMockTree(
+          ["overview/vision.md"],
+          { "overview/vision.md": 200 },
+        ),
+      }),
+  });
+
+  const { default: DashboardPage } = await import(
+    "@/app/(dashboard)/dashboard/page"
+  );
+  render(<DashboardPage />);
+
+  await waitFor(() => {
+    // Vision exists but is stub -- should show foundation cards
+    expect(screen.getByText(/no conversations yet/i)).toBeInTheDocument();
+  });
+
+  // No green checkmarks -- all 4 foundations are incomplete
+  expect(screen.queryByLabelText("Complete")).not.toBeInTheDocument();
+});
+```
+
+### Edge Cases
+
+1. **Threshold boundary (exactly 500 bytes):** A file of exactly 500 bytes
+   should show as complete (`>=` not `>`). This matches `vision-helpers.ts`
+   which uses `stat.size >= 500`.
+
+2. **YAML frontmatter inflation:** A file with `---\ntitle: Vision\n---\n`
+   frontmatter (30 bytes) plus minimal content could appear larger than the
+   raw content warrants. However, since we measure raw file size (not parsed
+   content size), this is acceptable -- frontmatter-only files are still well
+   under 500 bytes. A file that has enough frontmatter to reach 500 bytes
+   also has enough structure to be considered "started."
+
+3. **Binary/non-markdown files:** Foundation paths are all `.md` files.
+   Binary files (images, PDFs) in the KB tree get `size` too, but
+   foundation card logic only checks the specific `.md` paths, so binary
+   files are irrelevant.
+
+4. **Concurrent agent writes:** If the CPO agent is actively writing
+   `vision.md` and the user reloads the dashboard mid-write, the file
+   might be under 500 bytes. This is correct behavior -- the card will
+   update to "complete" on the next dashboard load after the agent finishes.
+
+5. **stat failure (file deleted between readdir and stat):** The existing
+   `.catch(() => null)` pattern handles this gracefully -- `size` will be
+   `undefined`, which the `?? 0` fallback handles correctly (shows as
+   incomplete).
+
+6. **KB tree cache:** The `/api/kb/tree` endpoint has no server-side cache.
+   Each dashboard load fetches fresh tree data, so size changes are
+   reflected immediately.
+
+### Applicable Institutional Learnings
+
+- **2026-04-12-buildtree-bounded-concurrency-emfile:** The `mapWithConcurrency`
+  pattern must be preserved. Do not refactor stat calls outside the callback.
+- **2026-04-10-dashboard-onboarding-state-independent-of-conversation-loading:**
+  The onboarding state (first-run/foundations/command center) is determined by
+  KB tree state, not conversation loading. This fix aligns with that principle.
+- **2026-04-07-userouter-mock-instability:** Test mocks use stable references.
+  Do not change mock patterns when updating tests.
+- **start-fresh-shows-import-screen-and-vision-sync-content-20260410:**
+  `tryCreateVision` content validation is already in place. The size-based
+  completion check is a separate concern from content validation.
+- **2026-04-07-promise-all-parallel-fs-io-patterns:** The stat call runs inside
+  the bounded `mapWithConcurrency` worker pool, not inside unbounded
+  `Promise.all`. No concurrency risk from the refactoring.
 
 ## Acceptance Criteria
 

--- a/knowledge-base/project/plans/2026-04-13-fix-vision-completion-check-plan.md
+++ b/knowledge-base/project/plans/2026-04-13-fix-vision-completion-check-plan.md
@@ -452,15 +452,15 @@ it("stub vision.md does not count as foundation complete", async () => {
 
 ## Acceptance Criteria
 
-- [ ] KB tree API response includes `size` (number, bytes) for each file node
-- [ ] Foundation cards show green checkmark only when file exists AND size >= 500 bytes
-- [ ] Stub vision.md (< 500 bytes) shows as incomplete (clickable card with prompt)
-- [ ] Substantial vision.md (>= 500 bytes) shows as complete (green checkmark, link to KB)
-- [ ] First-run state (no vision.md at all) still shows the "What are you building?" input
-- [ ] Vision exists but is stub: shows foundation cards with Vision as incomplete
-- [ ] All four foundation cards use the same size-based completion check
-- [ ] Existing tests pass with updated mocks
-- [ ] New test: stub vision.md (size < 500) does not show green checkmark
+- [x] KB tree API response includes `size` (number, bytes) for each file node
+- [x] Foundation cards show green checkmark only when file exists AND size >= 500 bytes
+- [x] Stub vision.md (< 500 bytes) shows as incomplete (clickable card with prompt)
+- [x] Substantial vision.md (>= 500 bytes) shows as complete (green checkmark, link to KB)
+- [x] First-run state (no vision.md at all) still shows the "What are you building?" input
+- [x] Vision exists but is stub: shows foundation cards with Vision as incomplete
+- [x] All four foundation cards use the same size-based completion check
+- [x] Existing tests pass with updated mocks
+- [x] New test: stub vision.md (size < 500) does not show green checkmark
 
 ## Test Scenarios
 

--- a/knowledge-base/project/plans/2026-04-13-fix-vision-completion-check-plan.md
+++ b/knowledge-base/project/plans/2026-04-13-fix-vision-completion-check-plan.md
@@ -1,0 +1,234 @@
+---
+title: "fix: Vision foundation card shows green checkmark for stub files"
+type: fix
+date: 2026-04-13
+---
+
+# fix: Vision foundation card shows green checkmark for stub files
+
+## Overview
+
+The Command Center dashboard marks the Vision foundation card as completed
+(green checkmark) when `overview/vision.md` merely *exists*, even if the file
+contains only a title, a placeholder instruction, and/or a PDF reference. The
+completion detection must validate that the document has meaningful content
+before showing the green checkmark.
+
+## Problem Statement
+
+The dashboard page (`apps/web-platform/app/(dashboard)/dashboard/page.tsx`)
+derives foundation-card completion from a pure file-existence check:
+
+```typescript
+// Line 153-157
+const foundationCards: FoundationCard[] = FOUNDATION_PATHS.map((f) => ({
+    ...f,
+    done: kbPaths.has(f.kbPath),
+}));
+```
+
+`kbPaths` is a `Set<string>` of relative paths returned by the
+`/api/kb/tree` endpoint. The `buildTree` function in `server/kb-reader.ts`
+already calls `fs.promises.stat()` on every file (to populate `modifiedAt`)
+but does not include `size` in the response.
+
+Meanwhile, `server/vision-helpers.ts` already defines a 500-byte threshold
+for "minimal" vision documents in `buildVisionEnhancementPrompt`. The
+dashboard UI has no access to this signal.
+
+### Scenarios that produce false-positive completions
+
+1. **Start Fresh onboarding:** `tryCreateVision` writes `# Vision\n\n{short
+   idea}\n`. A 30-word idea produces ~200 bytes -- well below meaningful
+   content.
+2. **Existing repo with stub:** User connects a repo that has a template
+   `vision.md` with a title, placeholder instruction, and an attached PDF
+   link. File exists, so it shows as complete.
+3. **Agent partially writes:** CPO agent starts writing but the conversation
+   is interrupted. A partial file under 500 bytes is misleadingly shown as
+   done.
+
+This same bug can affect **all four foundation cards** (Vision, Brand
+Identity, Business Validation, Legal Foundations), though Vision is the most
+commonly hit because `tryCreateVision` creates the stub automatically.
+
+## Proposed Solution
+
+Extend the KB tree API to include `size` (already available from the existing
+`stat()` call) and apply a minimum-size threshold on the client to distinguish
+stubs from real content. This approach:
+
+- Requires minimal server changes (one field addition to `TreeNode`)
+- Requires no additional API calls or endpoints
+- Aligns with the existing 500-byte threshold in `buildVisionEnhancementPrompt`
+- Is generalizable to all foundation cards
+
+### Architecture
+
+```
+/api/kb/tree  -->  buildTree() adds `size` field to TreeNode
+                         |
+                    Dashboard page reads size from tree response
+                         |
+                    Foundation card `done` = file exists AND size >= threshold
+```
+
+### Implementation
+
+#### 1. Add `size` to `TreeNode` interface and `buildTree` output
+
+**File:** `apps/web-platform/server/kb-reader.ts`
+
+- Add `size?: number` to the `TreeNode` interface
+- In the `mapWithConcurrency` callback (line ~181-193), the `stat` is already
+  being called. Add `size: stat.size` to the returned `TreeNode`
+
+```typescript
+// Current:
+return {
+  name: entry.name,
+  type: "file" as const,
+  path: path.relative(effectiveTopRoot, fullPath),
+  modifiedAt,
+  extension: ext || undefined,
+};
+
+// Updated:
+const stat = await fs.promises.stat(fullPath).catch(() => null);
+return {
+  name: entry.name,
+  type: "file" as const,
+  path: path.relative(effectiveTopRoot, fullPath),
+  modifiedAt: stat?.mtime.toISOString(),
+  size: stat?.size,
+  extension: ext || undefined,
+};
+```
+
+#### 2. Add size to `flattenTree` output on the dashboard
+
+**File:** `apps/web-platform/app/(dashboard)/dashboard/page.tsx`
+
+Change `kbPaths` from `Set<string>` to `Map<string, { size?: number }>` so
+the dashboard knows both existence and size. Update `flattenTree` to populate
+the map.
+
+```typescript
+// Current:
+function flattenTree(node: TreeNode, paths = new Set<string>()): Set<string> {
+  if (node.type === "file" && node.path) paths.add(node.path);
+  for (const child of node.children ?? []) flattenTree(child, paths);
+  return paths;
+}
+
+// Updated:
+interface FileInfo { size?: number }
+function flattenTree(
+  node: TreeNode,
+  files = new Map<string, FileInfo>(),
+): Map<string, FileInfo> {
+  if (node.type === "file" && node.path) {
+    files.set(node.path, { size: node.size });
+  }
+  for (const child of node.children ?? []) flattenTree(child, files);
+  return files;
+}
+```
+
+#### 3. Update foundation card completion logic
+
+**File:** `apps/web-platform/app/(dashboard)/dashboard/page.tsx`
+
+Add a minimum content size constant and update the `done` derivation:
+
+```typescript
+/**
+ * Minimum file size (bytes) to consider a foundation document "complete".
+ * Aligned with buildVisionEnhancementPrompt threshold in vision-helpers.ts.
+ * A typical stub (title + placeholder) is ~100-300 bytes.
+ * Real authored content (Mission, Target Audience, etc.) exceeds 500 bytes.
+ */
+const FOUNDATION_MIN_CONTENT_BYTES = 500;
+
+// Updated completion check:
+const foundationCards: FoundationCard[] = FOUNDATION_PATHS.map((f) => ({
+  ...f,
+  done:
+    kbFiles.has(f.kbPath) &&
+    (kbFiles.get(f.kbPath)?.size ?? 0) >= FOUNDATION_MIN_CONTENT_BYTES,
+}));
+```
+
+Also update `visionExists` (used for first-run detection) to retain
+file-existence behavior (Vision existing but being a stub should NOT show the
+first-run input -- the user already submitted their idea):
+
+```typescript
+const visionExists = kbFiles.has("overview/vision.md");
+```
+
+#### 4. Update state variable naming
+
+Rename `kbPaths`/`setKbPaths` to `kbFiles`/`setKbFiles` to reflect the richer
+type (`Map<string, FileInfo>` instead of `Set<string>`).
+
+#### 5. Update tests
+
+**File:** `apps/web-platform/test/command-center.test.tsx`
+
+Update the mock KB tree to include `size` fields. Add a test case where
+`vision.md` exists but is below the threshold (should NOT show green
+checkmark).
+
+**File:** `apps/web-platform/test/start-fresh-onboarding.test.tsx`
+
+Update mock tree builders to include `size` fields. Verify that stub vision
+files do not trigger the "all foundations complete" state.
+
+## Acceptance Criteria
+
+- [ ] KB tree API response includes `size` (number, bytes) for each file node
+- [ ] Foundation cards show green checkmark only when file exists AND size >= 500 bytes
+- [ ] Stub vision.md (< 500 bytes) shows as incomplete (clickable card with prompt)
+- [ ] Substantial vision.md (>= 500 bytes) shows as complete (green checkmark, link to KB)
+- [ ] First-run state (no vision.md at all) still shows the "What are you building?" input
+- [ ] Vision exists but is stub: shows foundation cards with Vision as incomplete
+- [ ] All four foundation cards use the same size-based completion check
+- [ ] Existing tests pass with updated mocks
+- [ ] New test: stub vision.md (size < 500) does not show green checkmark
+
+## Test Scenarios
+
+- Given a KB tree with `overview/vision.md` at 200 bytes, when the dashboard loads, then the Vision card shows as incomplete (no green checkmark)
+- Given a KB tree with `overview/vision.md` at 800 bytes, when the dashboard loads, then the Vision card shows as complete (green checkmark)
+- Given a KB tree with no `overview/vision.md`, when the dashboard loads with no conversations, then the first-run "What are you building?" input is shown
+- Given a KB tree with `overview/vision.md` at 100 bytes and no other foundation files, when the dashboard loads, then foundation cards are shown with Vision marked incomplete
+- Given all four foundation files exist at >= 500 bytes each, when the dashboard loads with no conversations, then "Your organization is ready." is shown with suggested prompts
+- Given all four foundation files exist but Vision is only 300 bytes, when the dashboard loads, then foundations section is shown (not "Your organization is ready.")
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected -- bug fix to internal completion detection logic.
+
+## Context
+
+### Related code
+
+- `apps/web-platform/app/(dashboard)/dashboard/page.tsx` -- Dashboard page with foundation cards (lines 28-33, 153-158)
+- `apps/web-platform/server/kb-reader.ts` -- `buildTree` function that generates the tree (lines 144-204)
+- `apps/web-platform/server/vision-helpers.ts` -- `buildVisionEnhancementPrompt` with 500-byte threshold (lines 55-77)
+- `apps/web-platform/test/command-center.test.tsx` -- Dashboard test with KB tree mock
+- `apps/web-platform/test/start-fresh-onboarding.test.tsx` -- Onboarding tests with foundation card assertions
+
+### Existing threshold precedent
+
+`vision-helpers.ts:buildVisionEnhancementPrompt` uses `stat.size >= 500` as
+the threshold for "substantial" content. The dashboard should align with this.
+
+## References
+
+- `buildVisionEnhancementPrompt` in `server/vision-helpers.ts:55-77`
+- `TreeNode` interface in `server/kb-reader.ts:12-19`
+- Foundation card definitions in `dashboard/page.tsx:28-33`

--- a/knowledge-base/project/specs/feat-one-shot-fix-vision-completion-check/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-vision-completion-check/session-state.md
@@ -1,0 +1,23 @@
+# Session State
+
+## Plan Phase
+
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-one-shot-fix-vision-completion-check/knowledge-base/project/plans/2026-04-13-fix-vision-completion-check-plan.md
+- Status: complete
+
+### Errors
+
+None
+
+### Decisions
+
+- Use file size from the existing `stat()` call in `buildTree` rather than adding a new API endpoint or reading file content -- minimal change, zero additional I/O
+- Extract the 500-byte threshold into a shared constant in `lib/kb-constants.ts` to prevent drift between `vision-helpers.ts` and the dashboard
+- Default `buildMockTree` helper size to 1000 (above threshold) so all 12+ existing tests pass without individual updates
+- Keep `visionExists` as file-existence-only for first-run gate -- a stub vision means the user already submitted their idea
+- Refactor the stat call from `.then().catch()` chaining to `.catch(() => null)` with property access to extract both `mtime` and `size`
+
+### Components Invoked
+
+- `soleur:plan` -- Created initial plan with research, domain review, and test scenarios
+- `soleur:deepen-plan` -- Enhanced plan with 6 institutional learnings, precise code diffs, edge case analysis, and updated task breakdown

--- a/knowledge-base/project/specs/feat-one-shot-fix-vision-completion-check/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-vision-completion-check/tasks.md
@@ -2,30 +2,30 @@
 
 ## Phase 1: Server — Add size to KB tree
 
-- [ ] 1.1 Add `size?: number` to `TreeNode` interface in `apps/web-platform/server/kb-reader.ts` (after line 17)
-- [ ] 1.2 Refactor stat call in `buildTree`'s `mapWithConcurrency` callback (lines 183-186): change `.then(stat => stat.mtime.toISOString()).catch(() => undefined)` to `.catch(() => null)`, then extract `stat?.mtime.toISOString()` and `stat?.size`
-- [ ] 1.3 Add `size` field to returned `TreeNode` object (line 187-193)
+- [x] 1.1 Add `size?: number` to `TreeNode` interface in `apps/web-platform/server/kb-reader.ts` (after line 17)
+- [x] 1.2 Refactor stat call in `buildTree`'s `mapWithConcurrency` callback (lines 183-186): change `.then(stat => stat.mtime.toISOString()).catch(() => undefined)` to `.catch(() => null)`, then extract `stat?.mtime.toISOString()` and `stat?.size`
+- [x] 1.3 Add `size` field to returned `TreeNode` object (line 187-193)
 
 ## Phase 2: Shared constant
 
-- [ ] 2.1 Add `FOUNDATION_MIN_CONTENT_BYTES = 500` to `apps/web-platform/lib/kb-constants.ts`
-- [ ] 2.2 Update `apps/web-platform/server/vision-helpers.ts` line 67 to use `FOUNDATION_MIN_CONTENT_BYTES` instead of hardcoded `500`
+- [x] 2.1 Add `FOUNDATION_MIN_CONTENT_BYTES = 500` to `apps/web-platform/lib/kb-constants.ts`
+- [x] 2.2 Update `apps/web-platform/server/vision-helpers.ts` line 67 to use `FOUNDATION_MIN_CONTENT_BYTES` instead of hardcoded `500`
 
 ## Phase 3: Client — Size-aware completion check
 
-- [ ] 3.1 Add `size?: number` to client-side `TreeNode` interface in `apps/web-platform/app/(dashboard)/dashboard/page.tsx` (line 39-44)
-- [ ] 3.2 Add `FileInfo` interface and update `flattenTree` to return `Map<string, FileInfo>` instead of `Set<string>` (lines 46-50)
-- [ ] 3.3 Rename `kbPaths`/`setKbPaths` state to `kbFiles`/`setKbFiles` (lines 111, 137)
-- [ ] 3.4 Update `useState` type from `Set<string>` to `Map<string, FileInfo>` with `new Map()` default
-- [ ] 3.5 Import `FOUNDATION_MIN_CONTENT_BYTES` and update `done` derivation (lines 154-157): check both existence AND `size >= FOUNDATION_MIN_CONTENT_BYTES`
-- [ ] 3.6 Keep `visionExists` as `kbFiles.has("overview/vision.md")` (file-existence-only, first-run gate unchanged)
+- [x] 3.1 Add `size?: number` to client-side `TreeNode` interface in `apps/web-platform/app/(dashboard)/dashboard/page.tsx` (line 39-44)
+- [x] 3.2 Add `FileInfo` interface and update `flattenTree` to return `Map<string, FileInfo>` instead of `Set<string>` (lines 46-50)
+- [x] 3.3 Rename `kbPaths`/`setKbPaths` state to `kbFiles`/`setKbFiles` (lines 111, 137)
+- [x] 3.4 Update `useState` type from `Set<string>` to `Map<string, FileInfo>` with `new Map()` default
+- [x] 3.5 Import `FOUNDATION_MIN_CONTENT_BYTES` and update `done` derivation (lines 154-157): check both existence AND `size >= FOUNDATION_MIN_CONTENT_BYTES`
+- [x] 3.6 Keep `visionExists` as `kbFiles.has("overview/vision.md")` (file-existence-only, first-run gate unchanged)
 
 ## Phase 4: Tests
 
-- [ ] 4.1 Update `apps/web-platform/test/command-center.test.tsx` inline KB tree mock (lines 139-155): add `size: 1000` to each file node
-- [ ] 4.2 Add test in `command-center.test.tsx`: stub vision.md (size 200) does NOT show green checkmark
-- [ ] 4.3 Update `buildMockTree` helper in `apps/web-platform/test/start-fresh-onboarding.test.tsx` (lines 58-96): add optional `sizes` parameter, default file size to 1000
-- [ ] 4.4 Add test in `start-fresh-onboarding.test.tsx`: stub vision.md with size 200 does not count as complete
-- [ ] 4.5 Add test: all four foundation files at >= 500 bytes shows "Your organization is ready", but with one at 300 bytes shows foundations section
-- [ ] 4.6 Verify all existing tests pass with updated mocks
-- [ ] 4.7 Run full test suite: `cd apps/web-platform && ./node_modules/.bin/vitest run`
+- [x] 4.1 Update `apps/web-platform/test/command-center.test.tsx` inline KB tree mock (lines 139-155): add `size: 1000` to each file node
+- [x] 4.2 Add test in `command-center.test.tsx`: stub vision.md (size 200) does NOT show green checkmark
+- [x] 4.3 Update `buildMockTree` helper in `apps/web-platform/test/start-fresh-onboarding.test.tsx` (lines 58-96): add optional `sizes` parameter, default file size to 1000
+- [x] 4.4 Add test in `start-fresh-onboarding.test.tsx`: stub vision.md with size 200 does not count as complete
+- [x] 4.5 Add test: all four foundation files at >= 500 bytes shows "Your organization is ready", but with one at 300 bytes shows foundations section
+- [x] 4.6 Verify all existing tests pass with updated mocks
+- [x] 4.7 Run full test suite: `cd apps/web-platform && ./node_modules/.bin/vitest run`

--- a/knowledge-base/project/specs/feat-one-shot-fix-vision-completion-check/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-vision-completion-check/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: fix Vision completion check
+
+## Phase 1: Server — Add size to KB tree
+
+- [ ] 1.1 Add `size?: number` to `TreeNode` interface in `apps/web-platform/server/kb-reader.ts`
+- [ ] 1.2 Populate `size` from the existing `stat()` call in `buildTree`'s `mapWithConcurrency` callback
+- [ ] 1.3 Verify `/api/kb/tree` response includes `size` for file nodes
+
+## Phase 2: Client — Size-aware completion check
+
+- [ ] 2.1 Update `flattenTree` in `apps/web-platform/app/(dashboard)/dashboard/page.tsx` to return `Map<string, FileInfo>` instead of `Set<string>`
+- [ ] 2.2 Rename `kbPaths`/`setKbPaths` state to `kbFiles`/`setKbFiles`
+- [ ] 2.3 Add `FOUNDATION_MIN_CONTENT_BYTES = 500` constant
+- [ ] 2.4 Update `done` derivation to check both existence and size >= threshold
+- [ ] 2.5 Keep `visionExists` as file-existence-only (first-run detection unchanged)
+
+## Phase 3: Tests
+
+- [ ] 3.1 Update `apps/web-platform/test/command-center.test.tsx` mock KB tree to include `size` fields
+- [ ] 3.2 Add test: stub vision.md (size 200) does NOT show green checkmark
+- [ ] 3.3 Add test: substantial vision.md (size 800) shows green checkmark
+- [ ] 3.4 Update `apps/web-platform/test/start-fresh-onboarding.test.tsx` mock tree builders to include `size` fields
+- [ ] 3.5 Verify existing tests pass with updated mocks
+- [ ] 3.6 Run full test suite: `cd apps/web-platform && npx vitest run`

--- a/knowledge-base/project/specs/feat-one-shot-fix-vision-completion-check/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-vision-completion-check/tasks.md
@@ -2,23 +2,30 @@
 
 ## Phase 1: Server — Add size to KB tree
 
-- [ ] 1.1 Add `size?: number` to `TreeNode` interface in `apps/web-platform/server/kb-reader.ts`
-- [ ] 1.2 Populate `size` from the existing `stat()` call in `buildTree`'s `mapWithConcurrency` callback
-- [ ] 1.3 Verify `/api/kb/tree` response includes `size` for file nodes
+- [ ] 1.1 Add `size?: number` to `TreeNode` interface in `apps/web-platform/server/kb-reader.ts` (after line 17)
+- [ ] 1.2 Refactor stat call in `buildTree`'s `mapWithConcurrency` callback (lines 183-186): change `.then(stat => stat.mtime.toISOString()).catch(() => undefined)` to `.catch(() => null)`, then extract `stat?.mtime.toISOString()` and `stat?.size`
+- [ ] 1.3 Add `size` field to returned `TreeNode` object (line 187-193)
 
-## Phase 2: Client — Size-aware completion check
+## Phase 2: Shared constant
 
-- [ ] 2.1 Update `flattenTree` in `apps/web-platform/app/(dashboard)/dashboard/page.tsx` to return `Map<string, FileInfo>` instead of `Set<string>`
-- [ ] 2.2 Rename `kbPaths`/`setKbPaths` state to `kbFiles`/`setKbFiles`
-- [ ] 2.3 Add `FOUNDATION_MIN_CONTENT_BYTES = 500` constant
-- [ ] 2.4 Update `done` derivation to check both existence and size >= threshold
-- [ ] 2.5 Keep `visionExists` as file-existence-only (first-run detection unchanged)
+- [ ] 2.1 Add `FOUNDATION_MIN_CONTENT_BYTES = 500` to `apps/web-platform/lib/kb-constants.ts`
+- [ ] 2.2 Update `apps/web-platform/server/vision-helpers.ts` line 67 to use `FOUNDATION_MIN_CONTENT_BYTES` instead of hardcoded `500`
 
-## Phase 3: Tests
+## Phase 3: Client — Size-aware completion check
 
-- [ ] 3.1 Update `apps/web-platform/test/command-center.test.tsx` mock KB tree to include `size` fields
-- [ ] 3.2 Add test: stub vision.md (size 200) does NOT show green checkmark
-- [ ] 3.3 Add test: substantial vision.md (size 800) shows green checkmark
-- [ ] 3.4 Update `apps/web-platform/test/start-fresh-onboarding.test.tsx` mock tree builders to include `size` fields
-- [ ] 3.5 Verify existing tests pass with updated mocks
-- [ ] 3.6 Run full test suite: `cd apps/web-platform && npx vitest run`
+- [ ] 3.1 Add `size?: number` to client-side `TreeNode` interface in `apps/web-platform/app/(dashboard)/dashboard/page.tsx` (line 39-44)
+- [ ] 3.2 Add `FileInfo` interface and update `flattenTree` to return `Map<string, FileInfo>` instead of `Set<string>` (lines 46-50)
+- [ ] 3.3 Rename `kbPaths`/`setKbPaths` state to `kbFiles`/`setKbFiles` (lines 111, 137)
+- [ ] 3.4 Update `useState` type from `Set<string>` to `Map<string, FileInfo>` with `new Map()` default
+- [ ] 3.5 Import `FOUNDATION_MIN_CONTENT_BYTES` and update `done` derivation (lines 154-157): check both existence AND `size >= FOUNDATION_MIN_CONTENT_BYTES`
+- [ ] 3.6 Keep `visionExists` as `kbFiles.has("overview/vision.md")` (file-existence-only, first-run gate unchanged)
+
+## Phase 4: Tests
+
+- [ ] 4.1 Update `apps/web-platform/test/command-center.test.tsx` inline KB tree mock (lines 139-155): add `size: 1000` to each file node
+- [ ] 4.2 Add test in `command-center.test.tsx`: stub vision.md (size 200) does NOT show green checkmark
+- [ ] 4.3 Update `buildMockTree` helper in `apps/web-platform/test/start-fresh-onboarding.test.tsx` (lines 58-96): add optional `sizes` parameter, default file size to 1000
+- [ ] 4.4 Add test in `start-fresh-onboarding.test.tsx`: stub vision.md with size 200 does not count as complete
+- [ ] 4.5 Add test: all four foundation files at >= 500 bytes shows "Your organization is ready", but with one at 300 bytes shows foundations section
+- [ ] 4.6 Verify all existing tests pass with updated mocks
+- [ ] 4.7 Run full test suite: `cd apps/web-platform && ./node_modules/.bin/vitest run`


### PR DESCRIPTION
## Summary
- Foundation cards showed green checkmarks for stub files (< 500 bytes). Now checks both file existence AND size >= FOUNDATION_MIN_CONTENT_BYTES
- Added `size` field to KB tree API response (piggybacked on existing `fs.stat()` call -- zero additional I/O)
- Extracted 500-byte threshold into shared constant `FOUNDATION_MIN_CONTENT_BYTES` in `lib/kb-constants.ts`
- Updated `vision-helpers.ts` to use the shared constant instead of hardcoded `500`
- Changed `flattenTree` from `Set<string>` to `Map<string, FileInfo>` to carry size metadata

## Changelog
- **fix:** Foundation cards no longer show as complete for stub files under 500 bytes
- **feat:** KB tree API now includes file size in response
- **refactor:** Shared `FOUNDATION_MIN_CONTENT_BYTES` constant prevents threshold drift between dashboard and vision-helpers

## Test plan
- [x] Stub vision.md (200 bytes) does NOT show green checkmark
- [x] Large vision.md (1000 bytes) shows green checkmark
- [x] First-run state (no vision.md) still shows 'What are you building?' input
- [x] Mixed sizes: one stub among complete files shows foundations section
- [x] All four foundations at >= 500 bytes shows 'Your organization is ready'
- [x] Existing 22 tests pass with updated mocks
- [x] 3 new stub detection tests added
- [x] E2e test helper updated with size field
- [x] Full test suite: 110 files, 1159 tests passing

Generated with [Claude Code](https://claude.com/claude-code)