### PR TITLE
fix(dashboard): domain names in filter dropdown

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/page.tsx
@@ -87,7 +87,7 @@ const STATUS_OPTIONS: { value: ConversationStatus | ""; label: string }[] = [
 const DOMAIN_OPTIONS: { value: string; label: string }[] = [
   { value: "", label: "All domains" },
   { value: "general", label: "General" },
-  ...ROUTABLE_DOMAIN_LEADERS.map((l) => ({ value: l.id, label: l.name })),
+  ...ROUTABLE_DOMAIN_LEADERS.map((l) => ({ value: l.id, label: l.domain })),
 ];
 
 export default function DashboardPage() {

--- a/apps/web-platform/server/domain-leaders.ts
+++ b/apps/web-platform/server/domain-leaders.ts
@@ -2,6 +2,7 @@ export const DOMAIN_LEADERS = [
   {
     id: "cmo",
     name: "CMO",
+    domain: "Marketing",
     title: "Chief Marketing Officer",
     description:
       "Marketing strategy, content, SEO, brand, social media, and growth.",
@@ -10,6 +11,7 @@ export const DOMAIN_LEADERS = [
   {
     id: "cto",
     name: "CTO",
+    domain: "Engineering",
     title: "Chief Technology Officer",
     description:
       "Technical architecture, code review, engineering practices, and infrastructure.",
@@ -18,6 +20,7 @@ export const DOMAIN_LEADERS = [
   {
     id: "cfo",
     name: "CFO",
+    domain: "Finance",
     title: "Chief Financial Officer",
     description:
       "Budget planning, revenue analysis, financial reporting, and forecasting.",
@@ -26,6 +29,7 @@ export const DOMAIN_LEADERS = [
   {
     id: "cpo",
     name: "CPO",
+    domain: "Product",
     title: "Chief Product Officer",
     description:
       "Product strategy, specs, user research, competitive analysis, and UX.",
@@ -34,6 +38,7 @@ export const DOMAIN_LEADERS = [
   {
     id: "cro",
     name: "CRO",
+    domain: "Sales",
     title: "Chief Revenue Officer",
     description:
       "Sales strategy, pipeline analysis, outbound, deal architecture, and pricing.",
@@ -42,6 +47,7 @@ export const DOMAIN_LEADERS = [
   {
     id: "coo",
     name: "COO",
+    domain: "Operations",
     title: "Chief Operations Officer",
     description:
       "Operations, tooling, vendor management, expense tracking, and provisioning.",
@@ -50,6 +56,7 @@ export const DOMAIN_LEADERS = [
   {
     id: "clo",
     name: "CLO",
+    domain: "Legal",
     title: "Chief Legal Officer",
     description:
       "Legal documents, compliance audits, privacy policies, and terms of service.",
@@ -58,6 +65,7 @@ export const DOMAIN_LEADERS = [
   {
     id: "cco",
     name: "CCO",
+    domain: "Support",
     title: "Chief Communications Officer",
     description:
       "Community management, support strategy, customer engagement, and communications.",
@@ -66,6 +74,7 @@ export const DOMAIN_LEADERS = [
   {
     id: "system",
     name: "System",
+    domain: "System",
     title: "System Process",
     description:
       "Internal system processes such as automated sync and health checks.",

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -167,6 +167,8 @@ Search for unarchived artifacts matching the feature name (excluding `archive/` 
 - **Yes** -> Use `skill: soleur:compound`
 - **Skip** -> Continue without documenting
 
+After compound completes (or is skipped), continue to Phase 3 immediately. Do NOT stop or wait for user input — the ship pipeline is not complete until Phase 7 finishes.
+
 ## Phase 3: Verify Documentation
 
 Check if new commands, skills, or agents were added in this branch.
@@ -261,7 +263,7 @@ Invoke the preflight skill via the **Skill tool**:
 
 **If preflight reports any FAIL:** Abort the ship pipeline. Display the preflight results table and stop. Do not proceed to Phase 5.5 or Phase 6.
 
-**If preflight reports all PASS or SKIP:** Continue to Phase 5.5.
+**If preflight reports all PASS or SKIP:** Continue to Phase 5.5 immediately. Do NOT stop or wait for user input after preflight passes — the ship pipeline is not complete until Phase 7 finishes. Nested skill invocations (preflight, compound) return control here; losing track of the pipeline state after a nested skill is a known failure mode.
 
 ## Phase 5.5: Pre-Ship Review Gates
 


### PR DESCRIPTION
## Summary
- Dashboard domain filter dropdown showed C-suite acronyms (CMO, CTO, CFO...) instead of user-friendly domain names
- Added `domain` field to each leader in `domain-leaders.ts` (Marketing, Engineering, Finance, Product, Sales, Operations, Legal, Support)
- Updated dropdown mapping to use `l.domain` instead of `l.name`
- Added continuity guards in ship SKILL.md after nested skill invocations (preflight, compound) to prevent pipeline stalls

## Changelog
- Dashboard filter dropdown now shows "Marketing" instead of "CMO", "Engineering" instead of "CTO", etc.
- Other uses of `l.name` (at-mention dropdown, leader badges) unchanged
- Ship skill now explicitly instructs to continue after nested skill returns

## Test plan
- [x] TypeScript compiles clean
- [x] All 1156 tests pass
- [ ] Visual verification: domain filter shows full names

Generated with [Claude Code](https://claude.com/claude-code)