### PR TITLE
fix(ship): increase merge poll interval from 10s to 60s

### DIFF
--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -568,20 +568,20 @@ Do NOT use `gh pr checks --watch` -- it exits immediately with "no checks report
 
 After auto-merge is queued, poll until the PR is merged. Do NOT ask "merge now or later?" -- auto-merge handles it. Do NOT use foreground `sleep` — Claude Code blocks `sleep` >= 2s in foreground Bash calls.
 
-Use the **Monitor tool** with this shell loop (max 60 iterations = 10 minutes):
+Use the **Monitor tool** with this shell loop (max 15 iterations = 15 minutes):
 
 ```bash
 i=0
 while true; do
   state=$(gh pr view <number> --json state --jq .state)
-  echo "$(date +%H:%M:%S) state=$state (iteration $((i+1))/60)"
+  echo "$(date +%H:%M:%S) state=$state (iteration $((i+1))/15)"
   [ "$state" = "MERGED" ] || [ "$state" = "CLOSED" ] && break
   i=$((i+1))
-  if [ "$i" -ge 60 ]; then
-    echo "Merge poll timed out after 10 minutes. PR state: $state"
+  if [ "$i" -ge 15 ]; then
+    echo "Merge poll timed out after 15 minutes. PR state: $state"
     break
   fi
-  sleep 10
+  sleep 60
 done
 ```
 


### PR DESCRIPTION
## Summary

- Change merge poll interval in ship Phase 7 from `sleep 10` (60 iterations / 10 min) to `sleep 60` (15 iterations / 15 min)
- Reduces token consumption during merge wait by 6x
- CI typically takes 3-5 minutes — polling every 10s wastes context on ~20 identical status updates

## Changelog

### Plugin
- **Fixed:** Ship skill merge polling interval reduced from 10s to 60s to cut token waste

## Test plan

- [x] No code changes — skill instruction update only
- [x] Verified timeout math: 15 iterations x 60s = 15 min (sufficient for CI)

Generated with [Claude Code](https://claude.com/claude-code)