### PR TITLE
feat(kb): add file rename to KB Tree

### DIFF
--- a/apps/web-platform/app/api/kb/file/[...path]/route.ts
+++ b/apps/web-platform/app/api/kb/file/[...path]/route.ts
@@ -404,8 +404,12 @@ export async function PATCH(
       // 404 is expected — destination doesn't exist, proceed
     }
 
-    // 3. GET current branch ref
-    const defaultBranch = userData.repo_url.includes("github.com") ? "main" : "main";
+    // 3. GET current branch ref (fetch actual default branch from repo metadata)
+    const repoMeta = await githubApiGet<{ default_branch: string }>(
+      userData.github_installation_id,
+      `/repos/${owner}/${repo}`,
+    );
+    const defaultBranch = repoMeta.default_branch;
     const refData = await githubApiGet<{ object: { sha: string } }>(
       userData.github_installation_id,
       `/repos/${owner}/${repo}/git/ref/heads/${defaultBranch}`,
@@ -432,22 +436,30 @@ export async function PATCH(
       },
     );
 
+    if (!treeData?.sha) {
+      throw new Error("GitHub API: tree creation returned no data");
+    }
+
     // 6. POST /git/commits
     const newCommit = await githubApiPost<{ sha: string }>(
       userData.github_installation_id,
       `/repos/${owner}/${repo}/git/commits`,
       {
         message: `Rename ${oldName} to ${sanitizedNewName} via Soleur`,
-        tree: treeData!.sha,
+        tree: treeData.sha,
         parents: [currentCommitSha],
       },
     );
+
+    if (!newCommit?.sha) {
+      throw new Error("GitHub API: commit creation returned no data");
+    }
 
     // 7. PATCH /git/refs to update branch pointer
     await githubApiPost(
       userData.github_installation_id,
       `/repos/${owner}/${repo}/git/refs/heads/${defaultBranch}`,
-      { sha: newCommit!.sha },
+      { sha: newCommit.sha },
       "PATCH",
     );
 

--- a/apps/web-platform/app/api/kb/file/[...path]/route.ts
+++ b/apps/web-platform/app/api/kb/file/[...path]/route.ts
@@ -2,8 +2,9 @@ import { NextResponse } from "next/server";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 import { isPathInWorkspace } from "@/server/sandbox";
-import { githubApiGet, githubApiDelete } from "@/server/github-api";
+import { githubApiGet, githubApiPost, githubApiDelete } from "@/server/github-api";
 import { generateInstallationToken, randomCredentialPath } from "@/server/github-app";
+import { sanitizeFilename } from "@/server/kb-validation";
 import { execFile } from "node:child_process";
 import { writeFileSync, unlinkSync, promises as fs } from "node:fs";
 import { promisify } from "node:util";
@@ -214,6 +215,304 @@ export async function DELETE(
     logger.error(
       { err: error, userId: user.id },
       "kb/delete: unexpected error",
+    );
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  // CSRF validation
+  const { valid: originValid, origin } = validateOrigin(request);
+  if (!originValid) return rejectCsrf("api/kb/file", origin);
+
+  // Authentication
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Fetch workspace data
+  const serviceClient = createServiceClient();
+  const { data: userData } = await serviceClient
+    .from("users")
+    .select("workspace_path, workspace_status, repo_url, github_installation_id")
+    .eq("id", user.id)
+    .single();
+
+  if (!userData?.workspace_path || userData.workspace_status !== "ready") {
+    return NextResponse.json({ error: "Workspace not ready" }, { status: 503 });
+  }
+
+  if (!userData.repo_url || !userData.github_installation_id) {
+    return NextResponse.json({ error: "No repository connected" }, { status: 400 });
+  }
+
+  // Extract and validate path
+  const { path: pathSegments } = await params;
+  const relativePath = pathSegments.join("/");
+
+  if (!relativePath) {
+    return NextResponse.json({ error: "File path required" }, { status: 400 });
+  }
+
+  // Null byte check
+  if (relativePath.includes("\0")) {
+    return NextResponse.json({ error: "Invalid path: null byte detected" }, { status: 400 });
+  }
+
+  // Extension check — only attachments can be renamed, not markdown
+  const oldExt = path.extname(relativePath).toLowerCase();
+  if (oldExt === ".md") {
+    return NextResponse.json(
+      { error: "Markdown files cannot be renamed through this endpoint" },
+      { status: 400 },
+    );
+  }
+
+  // Path traversal check
+  const kbRoot = path.join(userData.workspace_path, "knowledge-base");
+  const fullPath = path.join(kbRoot, relativePath);
+  if (!isPathInWorkspace(fullPath, kbRoot)) {
+    return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+  }
+
+  // Symlink check — skip if file doesn't exist locally (ENOENT)
+  try {
+    const stat = await fs.lstat(fullPath);
+    if (stat.isSymbolicLink()) {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+  }
+
+  // Parse newName from JSON body
+  let newName: string;
+  try {
+    const body = await request.json();
+    newName = body.newName;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!newName || typeof newName !== "string") {
+    return NextResponse.json({ error: "newName is required" }, { status: 400 });
+  }
+
+  // Sanitize newName
+  const { valid: nameValid, sanitized: sanitizedNewName, error: nameError } =
+    sanitizeFilename(newName);
+  if (!nameValid) {
+    return NextResponse.json(
+      { error: nameError || "Invalid filename" },
+      { status: 400 },
+    );
+  }
+
+  // Extension preservation check
+  const newExt = path.extname(sanitizedNewName).toLowerCase();
+  if (newExt !== oldExt) {
+    return NextResponse.json(
+      { error: "Cannot change file extension" },
+      { status: 400 },
+    );
+  }
+
+  // Same-name check
+  const oldName = path.basename(relativePath);
+  if (sanitizedNewName === oldName) {
+    return NextResponse.json(
+      { error: "New name is the same as current name" },
+      { status: 400 },
+    );
+  }
+
+  // Path traversal check on new path
+  const dirPath = path.dirname(relativePath);
+  const newRelativePath = dirPath === "." ? sanitizedNewName : `${dirPath}/${sanitizedNewName}`;
+  const newFullPath = path.join(kbRoot, newRelativePath);
+  if (!isPathInWorkspace(newFullPath, kbRoot)) {
+    return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+  }
+
+  // Parse owner/repo from repo_url
+  const repoUrlParts = userData.repo_url.replace(/\.git$/, "").split("/");
+  const repo = repoUrlParts.pop()!;
+  const owner = repoUrlParts.pop()!;
+
+  if (!owner || !repo) {
+    return NextResponse.json({ error: "Invalid repository URL" }, { status: 500 });
+  }
+
+  const oldFilePath = `knowledge-base/${relativePath}`;
+  const newFilePath = `knowledge-base/${newRelativePath}`;
+
+  try {
+    // 1. GET file blob SHA from Contents API
+    let blobSha: string;
+    try {
+      const fileData = await githubApiGet<
+        { sha: string; type: string } | Array<{ sha: string; type: string }>
+      >(
+        userData.github_installation_id,
+        `/repos/${owner}/${repo}/contents/${oldFilePath}`,
+      );
+
+      if (Array.isArray(fileData)) {
+        return NextResponse.json(
+          { error: "Cannot rename a directory" },
+          { status: 400 },
+        );
+      }
+
+      blobSha = fileData.sha;
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : "";
+      if (errMsg.includes("404")) {
+        return NextResponse.json({ error: "File not found" }, { status: 404 });
+      }
+      throw err;
+    }
+
+    // 2. Check if destination already exists
+    try {
+      await githubApiGet(
+        userData.github_installation_id,
+        `/repos/${owner}/${repo}/contents/${newFilePath}`,
+      );
+      return NextResponse.json(
+        { error: "A file with that name already exists" },
+        { status: 409 },
+      );
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : "";
+      if (!errMsg.includes("404")) {
+        throw err;
+      }
+      // 404 is expected — destination doesn't exist, proceed
+    }
+
+    // 3. GET current branch ref
+    const defaultBranch = userData.repo_url.includes("github.com") ? "main" : "main";
+    const refData = await githubApiGet<{ object: { sha: string } }>(
+      userData.github_installation_id,
+      `/repos/${owner}/${repo}/git/ref/heads/${defaultBranch}`,
+    );
+    const currentCommitSha = refData.object.sha;
+
+    // 4. GET commit to get tree SHA
+    const commitData = await githubApiGet<{ tree: { sha: string } }>(
+      userData.github_installation_id,
+      `/repos/${owner}/${repo}/git/commits/${currentCommitSha}`,
+    );
+    const baseTreeSha = commitData.tree.sha;
+
+    // 5. POST /git/trees — atomic rename (delete old + create new in one tree)
+    const treeData = await githubApiPost<{ sha: string }>(
+      userData.github_installation_id,
+      `/repos/${owner}/${repo}/git/trees`,
+      {
+        base_tree: baseTreeSha,
+        tree: [
+          { path: oldFilePath, mode: "100644", type: "blob", sha: null },
+          { path: newFilePath, mode: "100644", type: "blob", sha: blobSha },
+        ],
+      },
+    );
+
+    // 6. POST /git/commits
+    const newCommit = await githubApiPost<{ sha: string }>(
+      userData.github_installation_id,
+      `/repos/${owner}/${repo}/git/commits`,
+      {
+        message: `Rename ${oldName} to ${sanitizedNewName} via Soleur`,
+        tree: treeData!.sha,
+        parents: [currentCommitSha],
+      },
+    );
+
+    // 7. PATCH /git/refs to update branch pointer
+    await githubApiPost(
+      userData.github_installation_id,
+      `/repos/${owner}/${repo}/git/refs/heads/${defaultBranch}`,
+      { sha: newCommit!.sha },
+      "PATCH",
+    );
+
+    // 8. Workspace sync
+    let helperPath: string | null = null;
+    try {
+      const token = await generateInstallationToken(userData.github_installation_id);
+      helperPath = randomCredentialPath();
+      writeFileSync(
+        helperPath,
+        `#!/bin/sh\necho "username=x-access-token"\necho "password=${token}"`,
+        { mode: 0o700 },
+      );
+
+      await execFileAsync(
+        "git",
+        ["-c", `credential.helper=!${helperPath}`, "pull", "--ff-only"],
+        { cwd: userData.workspace_path, timeout: 30_000 },
+      );
+    } catch (syncError) {
+      logger.error(
+        { err: syncError, userId: user.id },
+        "kb/rename: workspace sync failed after successful rename",
+      );
+      Sentry.captureException(syncError);
+      return NextResponse.json(
+        {
+          error: "File renamed on GitHub but workspace sync failed. Try refreshing.",
+          code: "SYNC_FAILED",
+          commitSha: newCommit!.sha,
+        },
+        { status: 500 },
+      );
+    } finally {
+      if (helperPath) {
+        try { unlinkSync(helperPath); } catch { /* best-effort cleanup */ }
+      }
+    }
+
+    logger.info(
+      { event: "kb_rename", userId: user.id, oldPath: oldFilePath, newPath: newFilePath },
+      "kb/rename: file renamed successfully",
+    );
+
+    return NextResponse.json(
+      { oldPath: oldFilePath, newPath: newFilePath, commitSha: newCommit!.sha },
+      { status: 200 },
+    );
+  } catch (error) {
+    Sentry.captureException(error);
+
+    if (error instanceof Error && error.message.includes("GitHub API")) {
+      logger.error(
+        { err: error, userId: user.id, oldPath: oldFilePath, newPath: newFilePath },
+        "kb/rename: GitHub API error",
+      );
+      return NextResponse.json(
+        { error: error.message, code: "GITHUB_API_ERROR" },
+        { status: 502 },
+      );
+    }
+
+    logger.error(
+      { err: error, userId: user.id },
+      "kb/rename: unexpected error",
     );
     return NextResponse.json(
       { error: "Internal server error" },

--- a/apps/web-platform/app/api/kb/upload/route.ts
+++ b/apps/web-platform/app/api/kb/upload/route.ts
@@ -4,6 +4,7 @@ import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 import { isPathInWorkspace } from "@/server/sandbox";
 import { githubApiGet, githubApiPost } from "@/server/github-api";
 import { generateInstallationToken, randomCredentialPath } from "@/server/github-app";
+import { sanitizeFilename } from "@/server/kb-validation";
 import { execFile } from "node:child_process";
 import { writeFileSync, unlinkSync } from "node:fs";
 import { promisify } from "node:util";
@@ -20,43 +21,7 @@ const execFileAsync = promisify(execFile);
 const ALLOWED_EXTENSIONS = new Set([
   "png", "jpg", "jpeg", "gif", "webp", "pdf", "csv", "txt", "docx",
 ]);
-const WINDOWS_RESERVED = new Set([
-  "con", "prn", "aux", "nul",
-  "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9",
-  "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
-]);
-const MAX_FILENAME_BYTES = 255;
 const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20 MB
-
-// ---------------------------------------------------------------------------
-// Filename sanitization
-// ---------------------------------------------------------------------------
-
-function sanitizeFilename(
-  filename: string,
-): { valid: boolean; sanitized: string; error?: string } {
-  // Strip control chars (0x00-0x1F, 0x7F)
-  const sanitized = filename.replace(/[\x00-\x1f\x7f]/g, "");
-
-  if (!sanitized || sanitized.trim() === "") {
-    return { valid: false, sanitized, error: "Empty filename" };
-  }
-
-  if (sanitized.startsWith(".")) {
-    return { valid: false, sanitized, error: "Filename cannot start with a dot" };
-  }
-
-  if (new TextEncoder().encode(sanitized).length > MAX_FILENAME_BYTES) {
-    return { valid: false, sanitized, error: "Filename too long" };
-  }
-
-  const nameWithoutExt = sanitized.replace(/\.[^.]+$/, "").toLowerCase();
-  if (WINDOWS_RESERVED.has(nameWithoutExt)) {
-    return { valid: false, sanitized, error: "Reserved filename" };
-  }
-
-  return { valid: true, sanitized };
-}
 
 // ---------------------------------------------------------------------------
 // Route handler

--- a/apps/web-platform/components/kb/file-tree.tsx
+++ b/apps/web-platform/components/kb/file-tree.tsx
@@ -110,6 +110,7 @@ function TreeItem({
   const [deleteState, setDeleteState] = useState<DeleteState>({ status: "idle" });
   const [renameState, setRenameState] = useState<RenameState>({ status: "idle" });
   const renameInputRef = useRef<HTMLInputElement>(null);
+  const renameSubmittedRef = useRef(false);
 
   const renameFile = useCallback(async (filePath: string, newName: string) => {
     setRenameState({ status: "renaming" });
@@ -338,11 +339,13 @@ function TreeItem({
   const baseName = ext ? node.name.slice(0, -ext.length) : node.name;
 
   const handleRenameConfirm = useCallback((inputValue: string) => {
+    if (renameSubmittedRef.current) return;
     const trimmed = inputValue.trim();
     if (!trimmed || trimmed === baseName) {
       setRenameState({ status: "idle" });
       return;
     }
+    renameSubmittedRef.current = true;
     if (node.path) {
       renameFile(node.path, trimmed + ext);
     }
@@ -420,6 +423,7 @@ function TreeItem({
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
+                renameSubmittedRef.current = false;
                 setRenameState({ status: "editing", currentName: node.name });
               }}
               className="rounded p-1 text-neutral-500 hover:bg-neutral-700 hover:text-neutral-300"

--- a/apps/web-platform/components/kb/file-tree.tsx
+++ b/apps/web-platform/components/kb/file-tree.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useCallback } from "react";
+import { useRef, useState, useCallback, useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useKb } from "./kb-context";
@@ -84,6 +84,12 @@ type DeleteState =
   | { status: "deleting" }
   | { status: "error"; message: string };
 
+type RenameState =
+  | { status: "idle" }
+  | { status: "editing"; currentName: string }
+  | { status: "renaming" }
+  | { status: "error"; message: string };
+
 function TreeItem({
   node,
   depth,
@@ -102,6 +108,28 @@ function TreeItem({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploadState, setUploadState] = useState<UploadState>({ status: "idle" });
   const [deleteState, setDeleteState] = useState<DeleteState>({ status: "idle" });
+  const [renameState, setRenameState] = useState<RenameState>({ status: "idle" });
+  const renameInputRef = useRef<HTMLInputElement>(null);
+
+  const renameFile = useCallback(async (filePath: string, newName: string) => {
+    setRenameState({ status: "renaming" });
+    try {
+      const res = await fetch(`/api/kb/file/${filePath}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ newName }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: "Rename failed" }));
+        setRenameState({ status: "error", message: body.error || "Rename failed" });
+        return;
+      }
+      setRenameState({ status: "idle" });
+      await refreshTree();
+    } catch {
+      setRenameState({ status: "error", message: "Network error. Please try again." });
+    }
+  }, [refreshTree]);
 
   const deleteFile = useCallback(async (filePath: string) => {
     setDeleteState({ status: "deleting" });
@@ -302,45 +330,117 @@ function TreeItem({
   const isActive = pathname === filePath;
   const isAttachment = node.extension !== ".md";
   const isDeleting = deleteState.status === "deleting";
+  const isRenaming = renameState.status === "renaming";
+  const isEditing = renameState.status === "editing";
+
+  // Extract basename without extension for the rename input
+  const ext = node.extension || "";
+  const baseName = ext ? node.name.slice(0, -ext.length) : node.name;
+
+  const handleRenameConfirm = useCallback((inputValue: string) => {
+    const trimmed = inputValue.trim();
+    if (!trimmed || trimmed === baseName) {
+      setRenameState({ status: "idle" });
+      return;
+    }
+    if (node.path) {
+      renameFile(node.path, trimmed + ext);
+    }
+  }, [baseName, ext, node.path, renameFile]);
+
+  const handleRenameKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleRenameConfirm((e.target as HTMLInputElement).value);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setRenameState({ status: "idle" });
+    }
+  }, [handleRenameConfirm]);
+
+  // Auto-focus and select input text when entering edit mode
+  useEffect(() => {
+    if (isEditing && renameInputRef.current) {
+      renameInputRef.current.focus();
+      renameInputRef.current.select();
+    }
+  }, [isEditing]);
 
   return (
     <li>
       <div className="group relative">
-        <Link
-          href={filePath}
-          className={`flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
-            isActive
-              ? "bg-neutral-800 text-amber-400"
-              : "text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-200"
-          } ${isDeleting ? "opacity-50" : ""}`}
-          style={{ paddingLeft }}
-        >
-          <FileTypeIcon extension={node.extension} />
-          <span className="truncate">{node.name}</span>
-          {node.modifiedAt && !isDeleting && (
-            <span className="ml-auto shrink-0 text-xs text-neutral-600">
-              {formatRelativeTime(node.modifiedAt)}
-            </span>
-          )}
-          {isDeleting && (
-            <span className="ml-auto shrink-0 text-xs text-neutral-500">
-              Deleting...
-            </span>
-          )}
-        </Link>
-        {isAttachment && deleteState.status === "idle" && (
-          <button
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              setDeleteState({ status: "confirming" });
-            }}
-            className="absolute right-1 top-1/2 -translate-y-1/2 rounded p-1 text-neutral-500 opacity-0 transition-opacity hover:bg-neutral-700 hover:text-red-400 group-hover:opacity-100"
-            title="Delete file"
-            aria-label={`Delete ${node.name}`}
+        {isEditing ? (
+          <div
+            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-neutral-300"
+            style={{ paddingLeft }}
           >
-            <TrashIcon />
-          </button>
+            <FileTypeIcon extension={node.extension} />
+            <input
+              ref={renameInputRef}
+              type="text"
+              defaultValue={baseName}
+              onKeyDown={handleRenameKeyDown}
+              onBlur={(e) => handleRenameConfirm(e.target.value)}
+              className="min-w-0 flex-1 rounded border border-neutral-600 bg-neutral-800 px-1.5 py-0.5 text-sm text-neutral-200 outline-none focus:border-amber-500"
+            />
+            <span className="shrink-0 text-sm text-neutral-500">{ext}</span>
+          </div>
+        ) : (
+          <Link
+            href={filePath}
+            className={`flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
+              isActive
+                ? "bg-neutral-800 text-amber-400"
+                : "text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-200"
+            } ${isDeleting || isRenaming ? "opacity-50" : ""}`}
+            style={{ paddingLeft }}
+          >
+            <FileTypeIcon extension={node.extension} />
+            <span className="truncate">{node.name}</span>
+            {node.modifiedAt && !isDeleting && !isRenaming && (
+              <span className="ml-auto shrink-0 text-xs text-neutral-600">
+                {formatRelativeTime(node.modifiedAt)}
+              </span>
+            )}
+            {isDeleting && (
+              <span className="ml-auto shrink-0 text-xs text-neutral-500">
+                Deleting...
+              </span>
+            )}
+            {isRenaming && (
+              <span className="ml-auto shrink-0 text-xs text-neutral-500">
+                Renaming...
+              </span>
+            )}
+          </Link>
+        )}
+        {isAttachment && deleteState.status === "idle" && renameState.status === "idle" && (
+          <div className="absolute right-1 top-1/2 flex -translate-y-1/2 gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setRenameState({ status: "editing", currentName: node.name });
+              }}
+              className="rounded p-1 text-neutral-500 hover:bg-neutral-700 hover:text-neutral-300"
+              title="Rename file"
+              aria-label={`Rename ${node.name}`}
+            >
+              <PencilIcon />
+            </button>
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setDeleteState({ status: "confirming" });
+              }}
+              className="rounded p-1 text-neutral-500 hover:bg-neutral-700 hover:text-red-400"
+              title="Delete file"
+              aria-label={`Delete ${node.name}`}
+            >
+              <TrashIcon />
+            </button>
+          </div>
         )}
       </div>
       {deleteState.status === "confirming" && (
@@ -366,6 +466,12 @@ function TreeItem({
         <div className="mx-2 mt-1 flex items-center gap-1.5 rounded bg-red-500/10 px-2 py-1 text-xs text-red-400" style={{ marginLeft: paddingLeft }}>
           <span className="flex-1">{deleteState.message}</span>
           <button onClick={() => setDeleteState({ status: "idle" })} className="shrink-0 hover:text-red-300" aria-label="Dismiss error">&times;</button>
+        </div>
+      )}
+      {renameState.status === "error" && (
+        <div className="mx-2 mt-1 flex items-center gap-1.5 rounded bg-red-500/10 px-2 py-1 text-xs text-red-400" style={{ marginLeft: paddingLeft }}>
+          <span className="flex-1">{renameState.message}</span>
+          <button onClick={() => setRenameState({ status: "idle" })} className="shrink-0 hover:text-red-300" aria-label="Dismiss error">&times;</button>
         </div>
       )}
     </li>
@@ -458,6 +564,15 @@ function UploadIcon() {
       <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" strokeLinecap="round" strokeLinejoin="round" />
       <polyline points="17 8 12 3 7 8" strokeLinecap="round" strokeLinejoin="round" />
       <line x1="12" y1="3" x2="12" y2="15" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function PencilIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="m15 5 4 4" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 }

--- a/apps/web-platform/server/kb-validation.ts
+++ b/apps/web-platform/server/kb-validation.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared KB filename validation utilities.
+ *
+ * Used by upload and rename routes to enforce consistent filename rules.
+ */
+
+export const WINDOWS_RESERVED = new Set([
+  "con", "prn", "aux", "nul",
+  "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9",
+  "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
+]);
+
+export const MAX_FILENAME_BYTES = 255;
+
+export function sanitizeFilename(
+  filename: string,
+): { valid: boolean; sanitized: string; error?: string } {
+  // Strip control chars (0x00-0x1F, 0x7F)
+  const sanitized = filename.replace(/[\x00-\x1f\x7f]/g, "");
+
+  if (!sanitized || sanitized.trim() === "") {
+    return { valid: false, sanitized, error: "Empty filename" };
+  }
+
+  if (sanitized.startsWith(".")) {
+    return { valid: false, sanitized, error: "Filename cannot start with a dot" };
+  }
+
+  if (new TextEncoder().encode(sanitized).length > MAX_FILENAME_BYTES) {
+    return { valid: false, sanitized, error: "Filename too long" };
+  }
+
+  const nameWithoutExt = sanitized.replace(/\.[^.]+$/, "").toLowerCase();
+  if (WINDOWS_RESERVED.has(nameWithoutExt)) {
+    return { valid: false, sanitized, error: "Reserved filename" };
+  }
+
+  return { valid: true, sanitized };
+}

--- a/apps/web-platform/server/kb-validation.ts
+++ b/apps/web-platform/server/kb-validation.ts
@@ -22,6 +22,10 @@ export function sanitizeFilename(
     return { valid: false, sanitized, error: "Empty filename" };
   }
 
+  if (sanitized.includes("/") || sanitized.includes("\\")) {
+    return { valid: false, sanitized, error: "Filename cannot contain path separators" };
+  }
+
   if (sanitized.startsWith(".")) {
     return { valid: false, sanitized, error: "Filename cannot start with a dot" };
   }

--- a/apps/web-platform/test/file-tree-rename.test.tsx
+++ b/apps/web-platform/test/file-tree-rename.test.tsx
@@ -184,6 +184,8 @@ describe("FileTree rename UI", () => {
   });
 
   it("cancels edit mode on Escape without making API call", () => {
+    const fetchSpy = vi.spyOn(global, "fetch");
+
     setupKbMock(makeTree([overviewDir]));
     render(<FileTree />);
 
@@ -200,7 +202,7 @@ describe("FileTree rename UI", () => {
     // Input should be gone
     expect(fileItem.querySelector("input[type='text']")).toBeNull();
     // No fetch call
-    expect(global.fetch).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("confirms rename on blur", async () => {

--- a/apps/web-platform/test/file-tree-rename.test.tsx
+++ b/apps/web-platform/test/file-tree-rename.test.tsx
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { TreeNode } from "@/server/kb-reader";
+
+// ---------------------------------------------------------------------------
+// Mocks — vi.hoisted for use in vi.mock factories
+// ---------------------------------------------------------------------------
+
+const { mockRefreshTree, mockUseKb } = vi.hoisted(() => ({
+  mockRefreshTree: vi.fn(),
+  mockUseKb: vi.fn(),
+}));
+
+let mockPathname = "/dashboard/kb";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), forward: vi.fn(), refresh: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => mockPathname,
+}));
+
+vi.mock("@/components/kb/kb-context", () => ({
+  useKb: mockUseKb,
+}));
+
+vi.mock("@/server/kb-reader", () => ({
+  readContent: vi.fn(),
+  KbNotFoundError: class extends Error {},
+  KbAccessDeniedError: class extends Error {},
+  KbValidationError: class extends Error {},
+}));
+
+import { FileTree } from "@/components/kb/file-tree";
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const pngFile: TreeNode = {
+  name: "screenshot.png",
+  type: "file",
+  path: "overview/screenshot.png",
+  extension: ".png",
+  modifiedAt: new Date().toISOString(),
+};
+
+const mdFile: TreeNode = {
+  name: "readme.md",
+  type: "file",
+  path: "overview/readme.md",
+  extension: ".md",
+  modifiedAt: new Date().toISOString(),
+};
+
+const overviewDir: TreeNode = {
+  name: "overview",
+  type: "directory",
+  path: "overview",
+  children: [pngFile, mdFile],
+};
+
+function makeTree(children: TreeNode[]): TreeNode {
+  return {
+    name: "root",
+    type: "directory",
+    path: "",
+    children,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setupKbMock(tree: TreeNode) {
+  mockUseKb.mockReturnValue({
+    tree,
+    loading: false,
+    error: null,
+    expanded: new Set(["overview"]),
+    toggleExpanded: vi.fn(),
+    refreshTree: mockRefreshTree,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("FileTree rename UI", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPathname = "/dashboard/kb";
+    mockRefreshTree.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows rename (pencil) button on hover for attachment files", () => {
+    setupKbMock(makeTree([overviewDir]));
+    render(<FileTree />);
+
+    const fileLink = screen.getByText("screenshot.png");
+    const fileItem = fileLink.closest("li")!;
+
+    const renameBtn = fileItem.querySelector('[aria-label*="ename"]') as HTMLElement;
+    expect(renameBtn).toBeTruthy();
+  });
+
+  it("does NOT show rename button for .md files", () => {
+    setupKbMock(makeTree([overviewDir]));
+    render(<FileTree />);
+
+    const mdLink = screen.getByText("readme.md");
+    const mdItem = mdLink.closest("li")!;
+
+    const renameBtn = mdItem.querySelector('[aria-label*="ename"]');
+    expect(renameBtn).toBeNull();
+  });
+
+  it("enters edit mode when pencil icon is clicked, showing input with basename", () => {
+    setupKbMock(makeTree([overviewDir]));
+    render(<FileTree />);
+
+    const fileLink = screen.getByText("screenshot.png");
+    const fileItem = fileLink.closest("li")!;
+    const renameBtn = fileItem.querySelector('[aria-label*="ename"]') as HTMLElement;
+
+    fireEvent.click(renameBtn);
+
+    const input = fileItem.querySelector("input[type='text']") as HTMLInputElement;
+    expect(input).toBeTruthy();
+    expect(input.value).toBe("screenshot");
+  });
+
+  it("displays extension as static suffix next to input in edit mode", () => {
+    setupKbMock(makeTree([overviewDir]));
+    render(<FileTree />);
+
+    const fileLink = screen.getByText("screenshot.png");
+    const fileItem = fileLink.closest("li")!;
+    const renameBtn = fileItem.querySelector('[aria-label*="ename"]') as HTMLElement;
+
+    fireEvent.click(renameBtn);
+
+    // Extension should be visible as text after the input
+    expect(fileItem.textContent).toContain(".png");
+  });
+
+  it("calls PATCH with new name on Enter and refreshes tree", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ oldPath: "knowledge-base/overview/screenshot.png", newPath: "knowledge-base/overview/renamed.png", commitSha: "abc123" }),
+    } as unknown as Response);
+
+    setupKbMock(makeTree([overviewDir]));
+    render(<FileTree />);
+
+    const fileLink = screen.getByText("screenshot.png");
+    const fileItem = fileLink.closest("li")!;
+    const renameBtn = fileItem.querySelector('[aria-label*="ename"]') as HTMLElement;
+
+    fireEvent.click(renameBtn);
+
+    const input = fileItem.querySelector("input[type='text']") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "renamed" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/kb/file/overview/screenshot.png",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ newName: "renamed.png" }),
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockRefreshTree).toHaveBeenCalled();
+    });
+  });
+
+  it("cancels edit mode on Escape without making API call", () => {
+    setupKbMock(makeTree([overviewDir]));
+    render(<FileTree />);
+
+    const fileLink = screen.getByText("screenshot.png");
+    const fileItem = fileLink.closest("li")!;
+    const renameBtn = fileItem.querySelector('[aria-label*="ename"]') as HTMLElement;
+
+    fireEvent.click(renameBtn);
+
+    const input = fileItem.querySelector("input[type='text']") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "something-else" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    // Input should be gone
+    expect(fileItem.querySelector("input[type='text']")).toBeNull();
+    // No fetch call
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("confirms rename on blur", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ oldPath: "a", newPath: "b", commitSha: "c" }),
+    } as unknown as Response);
+
+    setupKbMock(makeTree([overviewDir]));
+    render(<FileTree />);
+
+    const fileLink = screen.getByText("screenshot.png");
+    const fileItem = fileLink.closest("li")!;
+    const renameBtn = fileItem.querySelector('[aria-label*="ename"]') as HTMLElement;
+
+    fireEvent.click(renameBtn);
+
+    const input = fileItem.querySelector("input[type='text']") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "blurred" } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/kb/file/overview/screenshot.png",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ newName: "blurred.png" }),
+        }),
+      );
+    });
+  });
+
+  it("shows inline error on API failure", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: () => Promise.resolve({ error: "A file with that name already exists" }),
+    } as unknown as Response);
+
+    setupKbMock(makeTree([overviewDir]));
+    render(<FileTree />);
+
+    const fileLink = screen.getByText("screenshot.png");
+    const fileItem = fileLink.closest("li")!;
+    const renameBtn = fileItem.querySelector('[aria-label*="ename"]') as HTMLElement;
+
+    fireEvent.click(renameBtn);
+
+    const input = fileItem.querySelector("input[type='text']") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "duplicate" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      const dismissBtn = screen.getByLabelText(/dismiss/i);
+      expect(dismissBtn).toBeTruthy();
+    });
+  });
+
+  it("shows 'Renaming...' loading state during API call", async () => {
+    // Never-resolving fetch to keep loading state
+    vi.spyOn(global, "fetch").mockReturnValue(new Promise(() => {}));
+
+    setupKbMock(makeTree([overviewDir]));
+    render(<FileTree />);
+
+    const fileLink = screen.getByText("screenshot.png");
+    const fileItem = fileLink.closest("li")!;
+    const renameBtn = fileItem.querySelector('[aria-label*="ename"]') as HTMLElement;
+
+    fireEvent.click(renameBtn);
+
+    const input = fileItem.querySelector("input[type='text']") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "pending" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(fileItem.textContent).toContain("Renaming");
+    });
+  });
+});

--- a/apps/web-platform/test/kb-rename.test.ts
+++ b/apps/web-platform/test/kb-rename.test.ts
@@ -1,0 +1,599 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — vi.hoisted ensures these are available when vi.mock factories run
+// ---------------------------------------------------------------------------
+
+const {
+  mockGetUser,
+  mockFrom,
+  mockGithubApiGet,
+  mockGithubApiPost,
+  mockGenerateInstallationToken,
+  mockRandomCredentialPath,
+  mockIsPathInWorkspace,
+  mockExecFile,
+  mockWriteFileSync,
+  mockUnlinkSync,
+  mockLstat,
+} = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+  mockGithubApiGet: vi.fn(),
+  mockGithubApiPost: vi.fn(),
+  mockGenerateInstallationToken: vi.fn(),
+  mockRandomCredentialPath: vi.fn(),
+  mockIsPathInWorkspace: vi.fn(),
+  mockExecFile: vi.fn(),
+  mockWriteFileSync: vi.fn(),
+  mockUnlinkSync: vi.fn(),
+  mockLstat: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+  })),
+  createServiceClient: vi.fn(() => ({
+    from: mockFrom,
+  })),
+}));
+
+vi.mock("@/lib/auth/validate-origin", () => ({
+  validateOrigin: vi.fn(() => ({ valid: true, origin: "https://app.soleur.ai" })),
+  rejectCsrf: vi.fn(
+    (_route: string, _origin: string | null) =>
+      new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 }),
+  ),
+}));
+
+vi.mock("@/server/github-api", () => ({
+  githubApiGet: mockGithubApiGet,
+  githubApiPost: mockGithubApiPost,
+}));
+
+vi.mock("@/server/github-app", () => ({
+  generateInstallationToken: mockGenerateInstallationToken,
+  randomCredentialPath: mockRandomCredentialPath,
+}));
+
+vi.mock("@/server/sandbox", () => ({
+  isPathInWorkspace: mockIsPathInWorkspace,
+}));
+
+vi.mock("@/server/logger", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: mockExecFile,
+}));
+
+vi.mock("node:util", () => ({
+  promisify: vi.fn((fn: unknown) => fn),
+}));
+
+vi.mock("node:fs", () => ({
+  writeFileSync: mockWriteFileSync,
+  unlinkSync: mockUnlinkSync,
+  promises: { lstat: mockLstat },
+}));
+
+// ---------------------------------------------------------------------------
+// Import route handler AFTER mocks
+// ---------------------------------------------------------------------------
+
+import { PATCH } from "@/app/api/kb/file/[...path]/route";
+import { validateOrigin } from "@/lib/auth/validate-origin";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_USER_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const TEST_INSTALLATION_ID = 12345;
+const TEST_WORKSPACE_PATH = "/workspaces/test-user";
+const TEST_REPO_URL = "https://github.com/test-owner/test-repo";
+
+function createRequest(pathSegments: string[], body: Record<string, unknown>): Request {
+  const url = `http://localhost:3000/api/kb/file/${pathSegments.join("/")}`;
+  return new Request(url, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      Origin: "https://app.soleur.ai",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function createParams(pathSegments: string[]): Promise<{ path: string[] }> {
+  return Promise.resolve({ path: pathSegments });
+}
+
+function setupAuthenticatedUser() {
+  mockGetUser.mockResolvedValue({
+    data: { user: { id: TEST_USER_ID } },
+  });
+}
+
+function setupUserData(overrides: Record<string, unknown> = {}) {
+  const mockSingle = vi.fn().mockResolvedValue({
+    data: {
+      workspace_path: TEST_WORKSPACE_PATH,
+      workspace_status: "ready",
+      repo_url: TEST_REPO_URL,
+      github_installation_id: TEST_INSTALLATION_ID,
+      ...overrides,
+    },
+    error: null,
+  });
+  const mockEq = vi.fn(() => ({ single: mockSingle }));
+  const mockSelect = vi.fn(() => ({ eq: mockEq }));
+
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "users") {
+      return { select: mockSelect };
+    }
+    return {};
+  });
+}
+
+function setupFullMocks() {
+  setupAuthenticatedUser();
+  setupUserData();
+  mockIsPathInWorkspace.mockReturnValue(true);
+  mockGenerateInstallationToken.mockResolvedValue("test-token");
+  mockRandomCredentialPath.mockReturnValue("/tmp/git-cred-test-uuid");
+  // File is not a symlink
+  mockLstat.mockResolvedValue({
+    isSymbolicLink: () => false,
+    isFile: () => true,
+    isDirectory: () => false,
+  });
+  // File exists on GitHub with a blob SHA
+  mockGithubApiGet.mockImplementation((_id: number, path: string) => {
+    // Contents API — returns file metadata
+    if (path.includes("/contents/")) {
+      return Promise.resolve({
+        sha: "blobsha123",
+        name: "test.png",
+        path: "knowledge-base/overview/test.png",
+        type: "file",
+      });
+    }
+    // Git Refs API — returns current ref
+    if (path.includes("/git/ref/")) {
+      return Promise.resolve({
+        object: { sha: "commitsha000", type: "commit" },
+      });
+    }
+    // Git Commits API — returns commit with tree SHA
+    if (path.includes("/git/commits/")) {
+      return Promise.resolve({
+        sha: "commitsha000",
+        tree: { sha: "treesha000" },
+      });
+    }
+    return Promise.reject(new Error(`Unexpected GET: ${path}`));
+  });
+  // POST /git/trees — returns new tree
+  // POST /git/commits — returns new commit
+  // PATCH /git/refs — returns updated ref
+  mockGithubApiPost.mockImplementation((_id: number, path: string) => {
+    if (path.includes("/git/trees")) {
+      return Promise.resolve({ sha: "newtreesha111" });
+    }
+    if (path.includes("/git/commits")) {
+      return Promise.resolve({ sha: "newcommitsha222" });
+    }
+    if (path.includes("/git/refs/")) {
+      return Promise.resolve({
+        object: { sha: "newcommitsha222" },
+      });
+    }
+    return Promise.reject(new Error(`Unexpected POST: ${path}`));
+  });
+  // Successful git pull
+  mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PATCH /api/kb/file/[...path] (rename)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // 1. CSRF validation
+  test("returns 403 when CSRF validation fails", async () => {
+    vi.mocked(validateOrigin).mockReturnValueOnce({
+      valid: false,
+      origin: "https://evil.com",
+    });
+
+    const req = createRequest(["overview", "test.png"], { newName: "renamed.png" });
+    const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
+    expect(res.status).toBe(403);
+  });
+
+  // 2. Auth
+  test("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const req = createRequest(["overview", "test.png"], { newName: "renamed.png" });
+    const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body.error).toMatch(/unauthorized/i);
+  });
+
+  // 3. Workspace not ready
+  test("returns 503 when workspace is not ready", async () => {
+    setupAuthenticatedUser();
+    setupUserData({ workspace_status: "provisioning" });
+
+    const req = createRequest(["overview", "test.png"], { newName: "renamed.png" });
+    const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
+    expect(res.status).toBe(503);
+  });
+
+  // 4. Null byte in path
+  test("returns 400 for null byte in path", async () => {
+    setupFullMocks();
+
+    const req = createRequest(["overview", "test\0evil.png"], { newName: "renamed.png" });
+    const res = await PATCH(req, { params: createParams(["overview", "test\0evil.png"]) });
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toMatch(/null byte/i);
+  });
+
+  // 5. .md file rejection
+  test("returns 400 for .md file rename attempt", async () => {
+    setupFullMocks();
+
+    const req = createRequest(["overview", "readme.md"], { newName: "notes.md" });
+    const res = await PATCH(req, { params: createParams(["overview", "readme.md"]) });
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toMatch(/markdown/i);
+  });
+
+  // 6. Path traversal
+  test("returns 400 for path traversal", async () => {
+    setupFullMocks();
+    mockIsPathInWorkspace.mockReturnValue(false);
+
+    const req = createRequest(["..", "..", "etc", "passwd"], { newName: "evil.png" });
+    const res = await PATCH(req, { params: createParams(["..", "..", "etc", "passwd"]) });
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid path/i);
+  });
+
+  // 7. Symlink target
+  test("returns 403 for symlink target", async () => {
+    setupFullMocks();
+    mockLstat.mockResolvedValue({
+      isSymbolicLink: () => true,
+      isFile: () => false,
+      isDirectory: () => false,
+    });
+
+    const req = createRequest(["overview", "link.png"], { newName: "renamed.png" });
+    const res = await PATCH(req, { params: createParams(["overview", "link.png"]) });
+    expect(res.status).toBe(403);
+  });
+
+  // 8. Empty newName
+  test("returns 400 for empty newName", async () => {
+    setupFullMocks();
+
+    const req = createRequest(["overview", "test.png"], { newName: "" });
+    const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
+    expect(res.status).toBe(400);
+  });
+
+  // 9. Missing newName
+  test("returns 400 when newName is missing", async () => {
+    setupFullMocks();
+
+    const req = createRequest(["overview", "test.png"], {});
+    const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
+    expect(res.status).toBe(400);
+  });
+
+  // 10. Extension change
+  test("returns 400 when extension changes (png to jpg)", async () => {
+    setupFullMocks();
+
+    const req = createRequest(["overview", "test.png"], { newName: "test.jpg" });
+    const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toMatch(/extension/i);
+  });
+
+  // 11. Extension change to .md
+  test("returns 400 when renaming to .md extension", async () => {
+    setupFullMocks();
+
+    const req = createRequest(["overview", "test.png"], { newName: "exploit.md" });
+    const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
+    expect(res.status).toBe(400);
+  });
+
+  // 12. Same name
+  test("returns 400 when newName is same as current name", async () => {
+    setupFullMocks();
+
+    const req = createRequest(["overview", "test.png"], { newName: "test.png" });
+    const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toMatch(/same/i);
+  });
+
+  // 13. File not found on GitHub
+  test("returns 404 when file not found on GitHub", async () => {
+    setupFullMocks();
+    mockGithubApiGet.mockRejectedValue(
+      new Error("GitHub API request failed: 404 /repos/test-owner/test-repo/contents/knowledge-base/overview/missing.png"),
+    );
+
+    const req = createRequest(["overview", "missing.png"], { newName: "renamed.png" });
+    const res = await PATCH(req, { params: createParams(["overview", "missing.png"]) });
+    expect(res.status).toBe(404);
+  });
+
+  // 14. Destination already exists
+  test("returns 409 when destination file already exists", async () => {
+    setupFullMocks();
+    // First call: GET old file (exists) — second call: GET new file (also exists)
+    mockGithubApiGet
+      .mockResolvedValueOnce({
+        sha: "blobsha123",
+        name: "test.png",
+        path: "knowledge-base/overview/test.png",
+        type: "file",
+      })
+      .mockResolvedValueOnce({
+        sha: "existingsha456",
+        name: "renamed.png",
+        path: "knowledge-base/overview/renamed.png",
+        type: "file",
+      });
+
+    const req = createRequest(["overview", "test.png"], { newName: "renamed.png" });
+    const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
+    expect(res.status).toBe(409);
+
+    const body = await res.json();
+    expect(body.error).toMatch(/already exists/i);
+  });
+
+  // 15. Directory path
+  test("returns 400 when path points to a directory", async () => {
+    setupFullMocks();
+    mockGithubApiGet.mockResolvedValueOnce([
+      { name: "file1.png", type: "file" },
+      { name: "file2.png", type: "file" },
+    ]);
+
+    const req = createRequest(["overview"], { newName: "renamed-dir" });
+    const res = await PATCH(req, { params: createParams(["overview"]) });
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toMatch(/directory/i);
+  });
+
+  // 16. Happy path — atomic rename via Git Trees API
+  test("returns 200 with oldPath, newPath, commitSha on successful rename", async () => {
+    setupFullMocks();
+    // First GET: old file exists
+    // Second GET: new path returns 404 (doesn't exist)
+    mockGithubApiGet
+      .mockResolvedValueOnce({
+        sha: "blobsha123",
+        name: "test.png",
+        path: "knowledge-base/overview/test.png",
+        type: "file",
+      })
+      .mockRejectedValueOnce(
+        new Error("GitHub API request failed: 404 /repos/test-owner/test-repo/contents/knowledge-base/overview/renamed.png"),
+      )
+      .mockResolvedValueOnce({
+        object: { sha: "commitsha000", type: "commit" },
+      })
+      .mockResolvedValueOnce({
+        sha: "commitsha000",
+        tree: { sha: "treesha000" },
+      });
+
+    const req = createRequest(["overview", "test.png"], { newName: "renamed.png" });
+    const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.oldPath).toBe("knowledge-base/overview/test.png");
+    expect(body.newPath).toBe("knowledge-base/overview/renamed.png");
+    expect(body.commitSha).toBe("newcommitsha222");
+
+    // Verify Git Trees API call
+    expect(mockGithubApiPost).toHaveBeenCalledWith(
+      TEST_INSTALLATION_ID,
+      "/repos/test-owner/test-repo/git/trees",
+      expect.objectContaining({
+        base_tree: "treesha000",
+        tree: expect.arrayContaining([
+          expect.objectContaining({ path: "knowledge-base/overview/test.png", sha: null }),
+          expect.objectContaining({ path: "knowledge-base/overview/renamed.png", sha: "blobsha123" }),
+        ]),
+      }),
+    );
+  });
+
+  // 17. Workspace sync failure
+  test("returns 500 with SYNC_FAILED when git pull fails after rename", async () => {
+    setupFullMocks();
+    mockGithubApiGet
+      .mockResolvedValueOnce({
+        sha: "blobsha123",
+        name: "test.png",
+        path: "knowledge-base/overview/test.png",
+        type: "file",
+      })
+      .mockRejectedValueOnce(
+        new Error("GitHub API request failed: 404 /repos/test-owner/test-repo/contents/knowledge-base/overview/renamed.png"),
+      )
+      .mockResolvedValueOnce({
+        object: { sha: "commitsha000", type: "commit" },
+      })
+      .mockResolvedValueOnce({
+        sha: "commitsha000",
+        tree: { sha: "treesha000" },
+      });
+    mockExecFile.mockRejectedValue(new Error("git pull failed: merge conflict"));
+
+    const req = createRequest(["overview", "test.png"], { newName: "renamed.png" });
+    const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
+    expect(res.status).toBe(500);
+
+    const body = await res.json();
+    expect(body.code).toBe("SYNC_FAILED");
+  });
+
+  // 18. GitHub API error during tree creation
+  test("returns 502 when GitHub API fails during tree creation", async () => {
+    setupFullMocks();
+    mockGithubApiGet
+      .mockResolvedValueOnce({
+        sha: "blobsha123",
+        name: "test.png",
+        path: "knowledge-base/overview/test.png",
+        type: "file",
+      })
+      .mockRejectedValueOnce(
+        new Error("GitHub API request failed: 404 /repos/test-owner/test-repo/contents/knowledge-base/overview/renamed.png"),
+      )
+      .mockResolvedValueOnce({
+        object: { sha: "commitsha000", type: "commit" },
+      })
+      .mockResolvedValueOnce({
+        sha: "commitsha000",
+        tree: { sha: "treesha000" },
+      });
+    mockGithubApiPost.mockRejectedValue(
+      new Error("GitHub API request failed: 500 /repos/test-owner/test-repo/git/trees"),
+    );
+
+    const req = createRequest(["overview", "test.png"], { newName: "renamed.png" });
+    const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
+    expect(res.status).toBe(502);
+  });
+
+  // 19. Invalid characters in newName
+  test("returns 400 for invalid newName with control characters", async () => {
+    setupFullMocks();
+
+    const req = createRequest(["overview", "test.png"], { newName: "bad\x01name.png" });
+    const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
+    expect(res.status).toBe(400);
+  });
+
+  // 20. newName starting with dot
+  test("returns 400 for newName starting with dot", async () => {
+    setupFullMocks();
+
+    const req = createRequest(["overview", "test.png"], { newName: ".hidden.png" });
+    const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
+    expect(res.status).toBe(400);
+  });
+
+  // 21. File not on disk (ENOENT) — skip symlink check
+  test("skips symlink check when file does not exist locally", async () => {
+    setupFullMocks();
+    const enoent = new Error("ENOENT: no such file or directory") as NodeJS.ErrnoException;
+    enoent.code = "ENOENT";
+    mockLstat.mockRejectedValue(enoent);
+
+    mockGithubApiGet
+      .mockResolvedValueOnce({
+        sha: "blobsha123",
+        name: "remote-only.png",
+        path: "knowledge-base/overview/remote-only.png",
+        type: "file",
+      })
+      .mockRejectedValueOnce(
+        new Error("GitHub API request failed: 404 /repos/test-owner/test-repo/contents/knowledge-base/overview/renamed.png"),
+      )
+      .mockResolvedValueOnce({
+        object: { sha: "commitsha000", type: "commit" },
+      })
+      .mockResolvedValueOnce({
+        sha: "commitsha000",
+        tree: { sha: "treesha000" },
+      });
+
+    const req = createRequest(["overview", "remote-only.png"], { newName: "renamed.png" });
+    const res = await PATCH(req, { params: createParams(["overview", "remote-only.png"]) });
+    expect(res.status).toBe(200);
+  });
+
+  // 22. No repo connected
+  test("returns 400 when no repository is connected", async () => {
+    setupAuthenticatedUser();
+    setupUserData({ repo_url: null, github_installation_id: null });
+
+    const req = createRequest(["overview", "test.png"], { newName: "renamed.png" });
+    const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
+    expect(res.status).toBe(400);
+  });
+
+  // 23. Credential helper cleanup
+  test("credential helper is cleaned up after successful rename", async () => {
+    setupFullMocks();
+    mockGithubApiGet
+      .mockResolvedValueOnce({
+        sha: "blobsha123",
+        name: "test.png",
+        path: "knowledge-base/overview/test.png",
+        type: "file",
+      })
+      .mockRejectedValueOnce(
+        new Error("GitHub API request failed: 404 /repos/test-owner/test-repo/contents/knowledge-base/overview/renamed.png"),
+      )
+      .mockResolvedValueOnce({
+        object: { sha: "commitsha000", type: "commit" },
+      })
+      .mockResolvedValueOnce({
+        sha: "commitsha000",
+        tree: { sha: "treesha000" },
+      });
+
+    const req = createRequest(["overview", "test.png"], { newName: "renamed.png" });
+    const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
+    expect(res.status).toBe(200);
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      "/tmp/git-cred-test-uuid",
+      expect.stringContaining("x-access-token"),
+      expect.objectContaining({ mode: 0o700 }),
+    );
+    expect(mockUnlinkSync).toHaveBeenCalledWith("/tmp/git-cred-test-uuid");
+  });
+});

--- a/apps/web-platform/test/kb-rename.test.ts
+++ b/apps/web-platform/test/kb-rename.test.ts
@@ -506,11 +506,11 @@ describe("PATCH /api/kb/file/[...path] (rename)", () => {
     expect(res.status).toBe(502);
   });
 
-  // 19. Invalid characters in newName
-  test("returns 400 for invalid newName with control characters", async () => {
+  // 19. newName that becomes empty after control char stripping
+  test("returns 400 for newName that is only control characters", async () => {
     setupFullMocks();
 
-    const req = createRequest(["overview", "test.png"], { newName: "bad\x01name.png" });
+    const req = createRequest(["overview", "test.png"], { newName: "\x01\x02.png" });
     const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
     expect(res.status).toBe(400);
   });

--- a/apps/web-platform/test/kb-rename.test.ts
+++ b/apps/web-platform/test/kb-rename.test.ts
@@ -157,6 +157,12 @@ function setupFullMocks() {
   });
   // File exists on GitHub with a blob SHA
   mockGithubApiGet.mockImplementation((_id: number, path: string) => {
+    // Repo metadata API — returns default branch
+    if (path.match(/\/repos\/[^/]+\/[^/]+$/) && !path.includes("/contents/")) {
+      return Promise.resolve({
+        default_branch: "main",
+      });
+    }
     // Contents API — returns file metadata
     if (path.includes("/contents/")) {
       return Promise.resolve({
@@ -416,6 +422,7 @@ describe("PATCH /api/kb/file/[...path] (rename)", () => {
       .mockRejectedValueOnce(
         new Error("GitHub API request failed: 404 /repos/test-owner/test-repo/contents/knowledge-base/overview/renamed.png"),
       )
+      .mockResolvedValueOnce({ default_branch: "main" })
       .mockResolvedValueOnce({
         object: { sha: "commitsha000", type: "commit" },
       })
@@ -460,6 +467,7 @@ describe("PATCH /api/kb/file/[...path] (rename)", () => {
       .mockRejectedValueOnce(
         new Error("GitHub API request failed: 404 /repos/test-owner/test-repo/contents/knowledge-base/overview/renamed.png"),
       )
+      .mockResolvedValueOnce({ default_branch: "main" })
       .mockResolvedValueOnce({
         object: { sha: "commitsha000", type: "commit" },
       })
@@ -490,6 +498,7 @@ describe("PATCH /api/kb/file/[...path] (rename)", () => {
       .mockRejectedValueOnce(
         new Error("GitHub API request failed: 404 /repos/test-owner/test-repo/contents/knowledge-base/overview/renamed.png"),
       )
+      .mockResolvedValueOnce({ default_branch: "main" })
       .mockResolvedValueOnce({
         object: { sha: "commitsha000", type: "commit" },
       })
@@ -541,6 +550,7 @@ describe("PATCH /api/kb/file/[...path] (rename)", () => {
       .mockRejectedValueOnce(
         new Error("GitHub API request failed: 404 /repos/test-owner/test-repo/contents/knowledge-base/overview/renamed.png"),
       )
+      .mockResolvedValueOnce({ default_branch: "main" })
       .mockResolvedValueOnce({
         object: { sha: "commitsha000", type: "commit" },
       })
@@ -577,6 +587,7 @@ describe("PATCH /api/kb/file/[...path] (rename)", () => {
       .mockRejectedValueOnce(
         new Error("GitHub API request failed: 404 /repos/test-owner/test-repo/contents/knowledge-base/overview/renamed.png"),
       )
+      .mockResolvedValueOnce({ default_branch: "main" })
       .mockResolvedValueOnce({
         object: { sha: "commitsha000", type: "commit" },
       })

--- a/knowledge-base/project/plans/2026-04-14-feat-kb-file-rename-plan.md
+++ b/knowledge-base/project/plans/2026-04-14-feat-kb-file-rename-plan.md
@@ -203,17 +203,17 @@ type RenameState =
 
 ## Acceptance Criteria
 
-- [ ] PATCH `/api/kb/file/[...path]` renames a file on GitHub atomically (single commit via Git Trees API) and syncs workspace
-- [ ] Security validations match DELETE route parity (CSRF, auth, path traversal, null bytes, symlinks, .md rejection)
-- [ ] Extension preservation enforced -- cannot change file extension during rename
-- [ ] Rename button (pencil icon) appears on hover for attachment files only
-- [ ] Clicking pencil enters inline edit mode with input pre-filled with current basename (without extension)
-- [ ] Extension displayed as static suffix next to input
-- [ ] Enter confirms rename, Escape cancels, blur confirms
-- [ ] Duplicate filename at destination returns 409
-- [ ] Error states display inline (same pattern as delete errors)
-- [ ] Tree refreshes after successful rename
-- [ ] `sanitizeFilename` extracted to shared module, upload route updated to import from it
+- [x] PATCH `/api/kb/file/[...path]` renames a file on GitHub atomically (single commit via Git Trees API) and syncs workspace
+- [x] Security validations match DELETE route parity (CSRF, auth, path traversal, null bytes, symlinks, .md rejection)
+- [x] Extension preservation enforced -- cannot change file extension during rename
+- [x] Rename button (pencil icon) appears on hover for attachment files only
+- [x] Clicking pencil enters inline edit mode with input pre-filled with current basename (without extension)
+- [x] Extension displayed as static suffix next to input
+- [x] Enter confirms rename, Escape cancels, blur confirms
+- [x] Duplicate filename at destination returns 409
+- [x] Error states display inline (same pattern as delete errors)
+- [x] Tree refreshes after successful rename
+- [x] `sanitizeFilename` extracted to shared module, upload route updated to import from it
 
 ## Domain Review
 

--- a/knowledge-base/project/plans/2026-04-14-feat-kb-file-rename-plan.md
+++ b/knowledge-base/project/plans/2026-04-14-feat-kb-file-rename-plan.md
@@ -1,0 +1,203 @@
+---
+title: "feat: add file rename to KB Tree"
+type: feat
+date: 2026-04-14
+---
+
+# feat: Add File Rename to KB Tree
+
+## Overview
+
+Add the ability to rename files and folders in the knowledge base tree UI. The KB Tree already supports file deletion (merged in #2143) and file upload. This adds an inline rename interaction that lets users rename attachment files and folders directly from the sidebar tree.
+
+## Problem Statement / Motivation
+
+Users who upload files to the KB cannot rename them without deleting and re-uploading. Folder names cannot be changed at all through the UI. This forces users to either use git directly or live with the original names, which degrades the KB as an organizational tool.
+
+## Proposed Solution
+
+Add a PATCH endpoint at `/api/kb/file/[...path]` that performs a rename via the GitHub Contents API (get content at old path, create at new path, delete old). Add an inline rename UI in the file tree triggered by a pencil/edit icon button (similar to the existing delete trash icon).
+
+### Approach: GitHub Contents API (Two-Step)
+
+The GitHub Contents API has no native rename endpoint. A rename is implemented as:
+
+1. **GET** the file content and SHA from the old path
+2. **PUT** (create) the file at the new path with the base64 content
+3. **DELETE** the old file using its SHA
+
+This is the same API surface already used by upload (PUT) and delete (DELETE). For folders, each file in the folder must be moved individually (recursive rename).
+
+**Why not the Git Trees API?** The Git Trees API can move files in a single commit, but it requires a more complex flow (create tree, create commit, update ref) and the existing codebase uses the Contents API exclusively. Consistency with existing patterns is preferred.
+
+## Technical Approach
+
+### API Route: PATCH `/api/kb/file/[...path]`
+
+Add a PATCH handler to the existing `apps/web-platform/app/api/kb/file/[...path]/route.ts`. This file already exports DELETE.
+
+**Request body:**
+
+```json
+{
+  "newName": "renamed-file.png"
+}
+```
+
+**Validation (security parity with DELETE route):**
+
+- CSRF validation (validateOrigin/rejectCsrf)
+- Authentication (supabase auth.getUser)
+- Workspace status check (workspace_path, workspace_status === "ready")
+- Path segment extraction and validation
+- Null byte check on both old path and new name
+- Extension check: `.md` files cannot be renamed through this endpoint (consistency with delete)
+- Path traversal check on both old and new resolved paths (isPathInWorkspace)
+- Symlink check on old path (skip on ENOENT like delete does)
+- Filename sanitization on newName (reuse sanitizeFilename from upload route -- extract to shared utility)
+
+**Rename logic:**
+
+1. Parse `newName` from request body (JSON, not FormData)
+2. Validate newName (sanitizeFilename, extension check, not `.md`)
+3. Compute old GitHub path and new GitHub path (same directory, different filename)
+4. GET file from GitHub Contents API at old path (get SHA + content)
+5. PUT file at new path with the base64 content
+6. DELETE old file using its SHA
+7. Workspace sync (git pull --ff-only, same pattern as delete)
+8. Return `{ oldPath, newPath, commitSha }`
+
+**Error handling:**
+
+- 404: Old file not found
+- 409: Old file was modified since last read (SHA mismatch on delete step)
+- 400: Invalid newName, empty name, `.md` file, path traversal, null bytes
+- 409: New path already exists (check before PUT)
+- 502: GitHub API errors
+- 500: Unexpected errors, sync failures
+
+**Folder rename:**
+
+For the initial implementation, restrict rename to files only. Folder rename requires recursively moving all files, which involves multiple GitHub API calls per file and complex error recovery (partial rename if one file fails). Folder rename can be added as a follow-up.
+
+### Shared Utility: `sanitizeFilename`
+
+Extract `sanitizeFilename` from `apps/web-platform/app/api/kb/upload/route.ts` into a shared module (e.g., `apps/web-platform/server/kb-validation.ts`). Both upload and rename need the same validation. The constants `WINDOWS_RESERVED` and `MAX_FILENAME_BYTES` move with it.
+
+### UI: Inline Rename in FileTree
+
+Add a rename interaction to `apps/web-platform/components/kb/file-tree.tsx`:
+
+**New state type:**
+
+```typescript
+type RenameState =
+  | { status: "idle" }
+  | { status: "editing"; currentName: string }
+  | { status: "renaming" }
+  | { status: "error"; message: string };
+```
+
+**Interaction flow:**
+
+1. Pencil icon appears on hover next to the delete (trash) icon for attachment files (non-`.md`)
+2. Clicking the pencil icon enters edit mode: the filename text becomes an inline `<input>` pre-filled with the current name (without extension)
+3. User edits the name. Press Enter or blur to confirm. Press Escape to cancel.
+4. On confirm: call `PATCH /api/kb/file/{path}` with `{ newName: "edited-name.ext" }`
+5. On success: refresh tree, return to idle
+6. On error: show inline error message (same pattern as delete error)
+
+**Keyboard accessibility:**
+
+- Enter: confirm rename
+- Escape: cancel rename
+- The input should auto-focus and select the filename (without extension) on enter
+
+**Icon:** Use a pencil/edit SVG icon (PencilIcon component) matching the existing icon style (14x14, stroke-based).
+
+### Files to Create
+
+- `apps/web-platform/server/kb-validation.ts` -- shared sanitizeFilename + constants
+
+### Files to Modify
+
+- `apps/web-platform/app/api/kb/file/[...path]/route.ts` -- add PATCH handler
+- `apps/web-platform/app/api/kb/upload/route.ts` -- import sanitizeFilename from shared module (remove local copy)
+- `apps/web-platform/components/kb/file-tree.tsx` -- add rename UI, PencilIcon, RenameState
+- `apps/web-platform/server/github-api.ts` -- no changes needed (uses existing githubApiGet, githubApiPost with PUT, githubApiDelete)
+
+### Files to Create (Tests)
+
+- `apps/web-platform/test/kb-rename.test.ts` -- API route unit tests
+- `apps/web-platform/test/file-tree-rename.test.tsx` -- component tests
+
+## Non-Goals
+
+- Folder rename (recursive multi-file move) -- deferred to follow-up issue
+- Renaming `.md` files (consistency with delete restriction)
+- Drag-and-drop to move files between folders
+- Batch rename (multiple files at once)
+
+## Acceptance Criteria
+
+- [ ] PATCH `/api/kb/file/[...path]` renames a file on GitHub and syncs workspace
+- [ ] Security validations match DELETE route parity (CSRF, auth, path traversal, null bytes, symlinks, .md rejection)
+- [ ] Rename button (pencil icon) appears on hover for attachment files only
+- [ ] Clicking pencil enters inline edit mode with input pre-filled with current name
+- [ ] Enter confirms rename, Escape cancels, blur confirms
+- [ ] Duplicate filename at destination returns 409
+- [ ] Error states display inline (same pattern as delete errors)
+- [ ] Tree refreshes after successful rename
+- [ ] `sanitizeFilename` extracted to shared module, upload route updated to import from it
+
+## Domain Review
+
+**Domains relevant:** Product
+
+### Product/UX Gate
+
+**Tier:** advisory
+**Decision:** auto-accepted (pipeline)
+**Agents invoked:** none
+**Skipped specialists:** none
+**Pencil available:** N/A
+
+The rename interaction follows established UI patterns (inline editing on hover, confirmation via Enter/Escape, error display). No new pages or flows are introduced.
+
+## Test Scenarios
+
+### API Route Tests (kb-rename.test.ts)
+
+- Given an unauthenticated request, when PATCH is called, then return 401
+- Given a valid user with workspace not ready, when PATCH is called, then return 503
+- Given a path with null bytes, when PATCH is called, then return 400
+- Given a `.md` file path, when PATCH is called, then return 400 "Markdown files cannot be renamed"
+- Given a path traversal attempt (e.g., `../../etc/passwd`), when PATCH is called, then return 400
+- Given a symlink path, when PATCH is called, then return 403
+- Given a valid path but file not found on GitHub, when PATCH is called, then return 404
+- Given a valid file but newName already exists at destination, when PATCH is called, then return 409
+- Given an empty newName, when PATCH is called, then return 400
+- Given a newName with invalid characters, when PATCH is called, then return 400
+- Given a newName that is a `.md` extension, when PATCH is called, then return 400
+- Given a valid file and valid newName, when PATCH is called, then file is created at new path, old file is deleted, workspace syncs, and return 200 with paths
+- Given a successful GitHub create but failed delete, when PATCH is called, then return 500 with rollback info
+- Given a workspace sync failure after successful rename, when PATCH is called, then return 500 with SYNC_FAILED code
+- Given a directory path (GitHub returns array), when PATCH is called, then return 400 "Cannot rename a directory"
+
+### Component Tests (file-tree-rename.test.tsx)
+
+- Given a file tree with an attachment file, when hovering, then pencil icon is visible
+- Given a `.md` file, when hovering, then no pencil icon is shown
+- Given idle state, when pencil icon is clicked, then input appears with current filename
+- Given edit mode, when Enter is pressed with a new name, then PATCH is called and tree refreshes
+- Given edit mode, when Escape is pressed, then edit mode is cancelled without API call
+- Given a rename API error, when rename fails, then error message displays inline
+
+## References
+
+- File deletion PR: #2143 (pattern reference for API route structure, security checks, and UI)
+- Upload route: `apps/web-platform/app/api/kb/upload/route.ts` (sanitizeFilename source, GitHub Contents API PUT pattern)
+- Delete route: `apps/web-platform/app/api/kb/file/[...path]/route.ts` (security validation pattern, workspace sync pattern)
+- GitHub Contents API: `GET /repos/{owner}/{repo}/contents/{path}`, `PUT` (create/update), `DELETE`
+- Issue: #2152
+- Semver: `semver:patch` (enhancement to existing KB feature)

--- a/knowledge-base/project/plans/2026-04-14-feat-kb-file-rename-plan.md
+++ b/knowledge-base/project/plans/2026-04-14-feat-kb-file-rename-plan.md
@@ -6,29 +6,58 @@ date: 2026-04-14
 
 # feat: Add File Rename to KB Tree
 
+## Enhancement Summary
+
+**Deepened on:** 2026-04-14
+**Sections enhanced:** 5 (Technical Approach, API Route, UI, Error Handling, Test Scenarios)
+**Research sources:** GitHub REST API docs (Context7), existing codebase patterns (#2143), institutional learnings
+
+### Key Improvements
+
+1. Atomic rename via Git Trees API instead of two-step Contents API -- single commit, no orphaned files on failure
+2. Extension preservation enforcement -- prevent users from changing file extensions during rename (security: blocks `.png` to `.md` bypass)
+3. Optimistic UI update pattern -- show renamed file immediately, revert on error for responsive UX
+
+### New Considerations Discovered
+
+- GitHub Contents API docs explicitly warn: PUT and DELETE "must use these endpoints serially" and "concurrent requests will conflict" -- validates the need for careful ordering if using Contents API
+- Git Trees API enables single-commit atomic rename (create tree with old path `sha: null` + new path with blob SHA, create commit, update ref) -- eliminates the partial-failure window entirely
+- Extension change during rename could bypass the `.md` restriction -- must validate that the new extension matches the old extension
+
 ## Overview
 
-Add the ability to rename files and folders in the knowledge base tree UI. The KB Tree already supports file deletion (merged in #2143) and file upload. This adds an inline rename interaction that lets users rename attachment files and folders directly from the sidebar tree.
+Add the ability to rename files and folders in the knowledge base tree UI. The KB Tree already supports file deletion (merged in #2143) and file upload. This adds an inline rename interaction that lets users rename attachment files directly from the sidebar tree.
 
 ## Problem Statement / Motivation
 
-Users who upload files to the KB cannot rename them without deleting and re-uploading. Folder names cannot be changed at all through the UI. This forces users to either use git directly or live with the original names, which degrades the KB as an organizational tool.
+Users who upload files to the KB cannot rename them without deleting and re-uploading. This forces users to either use git directly or live with the original names, which degrades the KB as an organizational tool.
 
 ## Proposed Solution
 
-Add a PATCH endpoint at `/api/kb/file/[...path]` that performs a rename via the GitHub Contents API (get content at old path, create at new path, delete old). Add an inline rename UI in the file tree triggered by a pencil/edit icon button (similar to the existing delete trash icon).
+Add a PATCH endpoint at `/api/kb/file/[...path]` that performs an atomic rename via the GitHub Git Trees API (single commit). Add an inline rename UI in the file tree triggered by a pencil/edit icon button (similar to the existing delete trash icon).
 
-### Approach: GitHub Contents API (Two-Step)
+### Approach: Git Trees API (Atomic Single-Commit)
 
-The GitHub Contents API has no native rename endpoint. A rename is implemented as:
+The GitHub Contents API has no native rename endpoint and requires two commits (PUT + DELETE) which creates a partial-failure window. Instead, use the Git Trees API for an atomic single-commit rename:
 
-1. **GET** the file content and SHA from the old path
-2. **PUT** (create) the file at the new path with the base64 content
-3. **DELETE** the old file using its SHA
+1. **GET** the file blob SHA from the old path via Contents API
+2. **POST** `/git/trees` with `base_tree` set to current tree, two entries: old path with `sha: null` (delete) and new path with the existing blob SHA (create)
+3. **POST** `/git/commits` with the new tree SHA and current commit as parent
+4. **PATCH** `/git/refs/heads/{branch}` to update the branch ref to the new commit
 
-This is the same API surface already used by upload (PUT) and delete (DELETE). For folders, each file in the folder must be moved individually (recursive rename).
+This produces a single atomic commit. If any step fails, no changes are persisted.
 
-**Why not the Git Trees API?** The Git Trees API can move files in a single commit, but it requires a more complex flow (create tree, create commit, update ref) and the existing codebase uses the Contents API exclusively. Consistency with existing patterns is preferred.
+### Research Insights
+
+**Why Git Trees API over Contents API:**
+
+- Contents API PUT + DELETE creates two separate commits, leaving a window where the file exists at both paths (after PUT but before DELETE)
+- GitHub docs explicitly state PUT and DELETE "must use these endpoints serially" and "concurrent requests will conflict"
+- If DELETE fails after PUT succeeds, the file is duplicated with no automatic rollback
+- Git Trees API produces one atomic commit -- either the rename happens completely or not at all
+- The existing `githubApiPost` helper already supports arbitrary methods and can be used for the Git Trees API endpoints
+
+**Trade-off acknowledged:** The Git Trees API flow requires 4 serial API calls (GET content, POST tree, POST commit, PATCH ref) vs. Contents API's 3 (GET, PUT, DELETE). But atomicity eliminates the need for rollback logic, making the implementation simpler overall despite the extra call.
 
 ## Technical Approach
 
@@ -52,37 +81,52 @@ Add a PATCH handler to the existing `apps/web-platform/app/api/kb/file/[...path]
 - Path segment extraction and validation
 - Null byte check on both old path and new name
 - Extension check: `.md` files cannot be renamed through this endpoint (consistency with delete)
+- **Extension preservation check:** newName must have the same extension as the original file (prevents `.png` to `.md` bypass of the markdown restriction)
 - Path traversal check on both old and new resolved paths (isPathInWorkspace)
 - Symlink check on old path (skip on ENOENT like delete does)
 - Filename sanitization on newName (reuse sanitizeFilename from upload route -- extract to shared utility)
+- **Same-name check:** if newName equals current name, return 400 "New name is the same as current name"
 
-**Rename logic:**
+### Research Insights -- Validation
+
+**Extension preservation is a security boundary.** Without it, a user could rename `exploit.png` to `exploit.md`, bypassing the `.md` restriction that both the delete and upload routes enforce. The extension check should compare `path.extname(oldName).toLowerCase()` with `path.extname(newName).toLowerCase()`.
+
+**Rename logic (Git Trees API -- atomic):**
 
 1. Parse `newName` from request body (JSON, not FormData)
-2. Validate newName (sanitizeFilename, extension check, not `.md`)
-3. Compute old GitHub path and new GitHub path (same directory, different filename)
-4. GET file from GitHub Contents API at old path (get SHA + content)
-5. PUT file at new path with the base64 content
-6. DELETE old file using its SHA
-7. Workspace sync (git pull --ff-only, same pattern as delete)
-8. Return `{ oldPath, newPath, commitSha }`
+2. Validate newName (sanitizeFilename, extension preservation, not `.md`, not same name)
+3. Compute old and new GitHub paths (same directory, different filename)
+4. **GET** file metadata from Contents API at old path -- extract `sha` (blob SHA)
+5. **Check** if new path already exists via Contents API GET (return 409 if so)
+6. **GET** the current branch ref to get the latest commit SHA
+7. **GET** the commit to get the tree SHA
+8. **POST** `/git/trees` with `base_tree` and two entries:
+   - `{ path: oldFilePath, mode: "100644", type: "blob", sha: null }` (delete old)
+   - `{ path: newFilePath, mode: "100644", type: "blob", sha: blobSha }` (create new)
+9. **POST** `/git/commits` with new tree SHA, parent = current commit SHA, message = "Rename {oldName} to {newName} via Soleur"
+10. **PATCH** `/git/refs/heads/{branch}` with new commit SHA
+11. Workspace sync (git pull --ff-only, same pattern as delete)
+12. Return `{ oldPath, newPath, commitSha }`
 
 **Error handling:**
 
 - 404: Old file not found
-- 409: Old file was modified since last read (SHA mismatch on delete step)
-- 400: Invalid newName, empty name, `.md` file, path traversal, null bytes
-- 409: New path already exists (check before PUT)
-- 502: GitHub API errors
+- 400: Invalid newName, empty name, `.md` file, path traversal, null bytes, extension change, same name
+- 409: New path already exists (check before tree creation)
+- 502: GitHub API errors (any step in the Git Trees flow)
 - 500: Unexpected errors, sync failures
+
+### Research Insights -- Error Handling
+
+**Atomicity simplifies error handling.** With the Git Trees API, if any step fails before the ref update (step 10), no changes are persisted. The only partial-failure scenario is if the ref update succeeds but workspace sync fails -- which is the same scenario the existing delete route already handles with `SYNC_FAILED`.
 
 **Folder rename:**
 
-For the initial implementation, restrict rename to files only. Folder rename requires recursively moving all files, which involves multiple GitHub API calls per file and complex error recovery (partial rename if one file fails). Folder rename can be added as a follow-up.
+For the initial implementation, restrict rename to files only. Folder rename requires enumerating all files in the tree and creating entries for each -- add as a follow-up.
 
 ### Shared Utility: `sanitizeFilename`
 
-Extract `sanitizeFilename` from `apps/web-platform/app/api/kb/upload/route.ts` into a shared module (e.g., `apps/web-platform/server/kb-validation.ts`). Both upload and rename need the same validation. The constants `WINDOWS_RESERVED` and `MAX_FILENAME_BYTES` move with it.
+Extract `sanitizeFilename` from `apps/web-platform/app/api/kb/upload/route.ts` into a shared module `apps/web-platform/server/kb-validation.ts`. Both upload and rename need the same validation. The constants `WINDOWS_RESERVED` and `MAX_FILENAME_BYTES` move with it.
 
 ### UI: Inline Rename in FileTree
 
@@ -103,17 +147,35 @@ type RenameState =
 1. Pencil icon appears on hover next to the delete (trash) icon for attachment files (non-`.md`)
 2. Clicking the pencil icon enters edit mode: the filename text becomes an inline `<input>` pre-filled with the current name (without extension)
 3. User edits the name. Press Enter or blur to confirm. Press Escape to cancel.
-4. On confirm: call `PATCH /api/kb/file/{path}` with `{ newName: "edited-name.ext" }`
+4. On confirm: call `PATCH /api/kb/file/{path}` with `{ newName: "edited-name.ext" }` (extension appended automatically)
 5. On success: refresh tree, return to idle
 6. On error: show inline error message (same pattern as delete error)
+
+### Research Insights -- UI Patterns
+
+**Extension handling in the input field:**
+
+- The input should show only the basename without extension (e.g., "screenshot" not "screenshot.png")
+- The extension is displayed as a static suffix after the input: `[input: screenshot][.png]`
+- On submit, the extension is re-appended automatically: `newName = inputValue + originalExtension`
+- This prevents accidental extension changes and makes the interaction cleaner
+
+**Optimistic UI update:**
+
+- When the user confirms a rename, immediately update the tree node's `name` property in local state
+- If the PATCH fails, revert to the old name and show the error
+- This provides instant visual feedback instead of waiting for the API round-trip + tree refresh
 
 **Keyboard accessibility:**
 
 - Enter: confirm rename
 - Escape: cancel rename
-- The input should auto-focus and select the filename (without extension) on enter
+- The input should auto-focus and select all text on enter (the basename portion)
+- Tab should also confirm (consistent with other inline edit patterns)
 
-**Icon:** Use a pencil/edit SVG icon (PencilIcon component) matching the existing icon style (14x14, stroke-based).
+**Icon placement:** The pencil icon sits to the left of the trash icon in the hover action area. Order: `[pencil] [trash]`. Both share the same opacity/hover transition.
+
+**Icon:** Use a pencil/edit SVG icon (PencilIcon component) matching the existing icon style (14x14, stroke-based, `currentColor`).
 
 ### Files to Create
 
@@ -124,7 +186,7 @@ type RenameState =
 - `apps/web-platform/app/api/kb/file/[...path]/route.ts` -- add PATCH handler
 - `apps/web-platform/app/api/kb/upload/route.ts` -- import sanitizeFilename from shared module (remove local copy)
 - `apps/web-platform/components/kb/file-tree.tsx` -- add rename UI, PencilIcon, RenameState
-- `apps/web-platform/server/github-api.ts` -- no changes needed (uses existing githubApiGet, githubApiPost with PUT, githubApiDelete)
+- `apps/web-platform/server/github-api.ts` -- no changes needed (uses existing githubApiGet, githubApiPost)
 
 ### Files to Create (Tests)
 
@@ -137,13 +199,16 @@ type RenameState =
 - Renaming `.md` files (consistency with delete restriction)
 - Drag-and-drop to move files between folders
 - Batch rename (multiple files at once)
+- Changing file extensions during rename (security boundary)
 
 ## Acceptance Criteria
 
-- [ ] PATCH `/api/kb/file/[...path]` renames a file on GitHub and syncs workspace
+- [ ] PATCH `/api/kb/file/[...path]` renames a file on GitHub atomically (single commit via Git Trees API) and syncs workspace
 - [ ] Security validations match DELETE route parity (CSRF, auth, path traversal, null bytes, symlinks, .md rejection)
+- [ ] Extension preservation enforced -- cannot change file extension during rename
 - [ ] Rename button (pencil icon) appears on hover for attachment files only
-- [ ] Clicking pencil enters inline edit mode with input pre-filled with current name
+- [ ] Clicking pencil enters inline edit mode with input pre-filled with current basename (without extension)
+- [ ] Extension displayed as static suffix next to input
 - [ ] Enter confirms rename, Escape cancels, blur confirms
 - [ ] Duplicate filename at destination returns 409
 - [ ] Error states display inline (same pattern as delete errors)
@@ -178,26 +243,40 @@ The rename interaction follows established UI patterns (inline editing on hover,
 - Given a valid file but newName already exists at destination, when PATCH is called, then return 409
 - Given an empty newName, when PATCH is called, then return 400
 - Given a newName with invalid characters, when PATCH is called, then return 400
+- Given a newName that changes the extension (e.g., `.png` to `.jpg`), when PATCH is called, then return 400 "Cannot change file extension"
+- Given a newName that is the same as the current name, when PATCH is called, then return 400 "New name is the same as current name"
 - Given a newName that is a `.md` extension, when PATCH is called, then return 400
-- Given a valid file and valid newName, when PATCH is called, then file is created at new path, old file is deleted, workspace syncs, and return 200 with paths
-- Given a successful GitHub create but failed delete, when PATCH is called, then return 500 with rollback info
+- Given a valid file and valid newName, when PATCH is called, then a single atomic commit is created via Git Trees API, workspace syncs, and return 200 with `{ oldPath, newPath, commitSha }`
 - Given a workspace sync failure after successful rename, when PATCH is called, then return 500 with SYNC_FAILED code
 - Given a directory path (GitHub returns array), when PATCH is called, then return 400 "Cannot rename a directory"
+- Given a GitHub API error during tree creation, when PATCH is called, then return 502
 
 ### Component Tests (file-tree-rename.test.tsx)
 
 - Given a file tree with an attachment file, when hovering, then pencil icon is visible
 - Given a `.md` file, when hovering, then no pencil icon is shown
-- Given idle state, when pencil icon is clicked, then input appears with current filename
-- Given edit mode, when Enter is pressed with a new name, then PATCH is called and tree refreshes
+- Given idle state, when pencil icon is clicked, then input appears with current basename (without extension)
+- Given edit mode, then extension is displayed as static text after the input
+- Given edit mode, when Enter is pressed with a new name, then PATCH is called with newName including extension and tree refreshes
 - Given edit mode, when Escape is pressed, then edit mode is cancelled without API call
+- Given edit mode, when blur occurs, then rename is confirmed (same as Enter)
 - Given a rename API error, when rename fails, then error message displays inline
+- Given a rename in progress, then "Renaming..." loading state is shown
+
+### Research Insights -- Test Edge Cases
+
+- **Race condition test:** Given two rename requests for the same file, verify the second receives a conflict error (the ref update uses non-force mode which fails if the ref changed)
+- **Large filename test:** Given a newName at MAX_FILENAME_BYTES boundary, verify it is accepted; at MAX_FILENAME_BYTES + 1, verify it is rejected
+- **Unicode filename test:** Given a newName with Unicode characters (e.g., emoji, CJK), verify sanitizeFilename handles byte-length correctly (UTF-8 multi-byte)
 
 ## References
 
 - File deletion PR: #2143 (pattern reference for API route structure, security checks, and UI)
 - Upload route: `apps/web-platform/app/api/kb/upload/route.ts` (sanitizeFilename source, GitHub Contents API PUT pattern)
 - Delete route: `apps/web-platform/app/api/kb/file/[...path]/route.ts` (security validation pattern, workspace sync pattern)
-- GitHub Contents API: `GET /repos/{owner}/{repo}/contents/{path}`, `PUT` (create/update), `DELETE`
+- GitHub Contents API docs: PUT and DELETE "must use these endpoints serially" -- validates serial approach
+- GitHub Git Trees API: `POST /repos/{owner}/{repo}/git/trees` -- enables atomic rename in single commit
+- GitHub Git Commits API: `POST /repos/{owner}/{repo}/git/commits` -- creates commit from tree
+- GitHub Git Refs API: `PATCH /repos/{owner}/{repo}/git/refs/{ref}` -- updates branch pointer
 - Issue: #2152
 - Semver: `semver:patch` (enhancement to existing KB feature)

--- a/knowledge-base/project/specs/feat-kb-file-rename/session-state.md
+++ b/knowledge-base/project/specs/feat-kb-file-rename/session-state.md
@@ -1,0 +1,23 @@
+# Session State
+
+## Plan Phase
+
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-kb-file-rename/knowledge-base/project/plans/2026-04-14-feat-kb-file-rename-plan.md
+- Status: complete
+
+### Errors
+
+None
+
+### Decisions
+
+- Git Trees API over Contents API for atomic single-commit rename -- eliminates partial-failure window
+- Extension preservation enforcement -- prevent users from changing file extensions during rename
+- File-only rename for v1 -- folder rename deferred to follow-up issue
+- Inline edit UI with static extension suffix -- input shows only basename
+- Shared sanitizeFilename extraction -- move validation into server/kb-validation.ts for reuse
+
+### Components Invoked
+
+- soleur:plan -- created initial plan and tasks
+- soleur:deepen-plan -- enhanced plan with GitHub REST API research, atomicity analysis, security edge cases, UI patterns

--- a/knowledge-base/project/specs/feat-kb-file-rename/tasks.md
+++ b/knowledge-base/project/specs/feat-kb-file-rename/tasks.md
@@ -10,39 +10,46 @@
 
 - [ ] 2.1 Write failing tests for PATCH `/api/kb/file/[...path]` in `apps/web-platform/test/kb-rename.test.ts`
   - [ ] 2.1.1 Auth tests (unauthenticated, workspace not ready, no repo connected)
-  - [ ] 2.1.2 Validation tests (null bytes, `.md` rejection, path traversal, symlinks, empty newName, invalid newName, directory path)
+  - [ ] 2.1.2 Validation tests (null bytes, `.md` rejection, path traversal, symlinks, empty newName, invalid newName, directory path, extension change, same name)
   - [ ] 2.1.3 Conflict tests (newName already exists at destination)
-  - [ ] 2.1.4 Happy path test (GET content + PUT at new path + DELETE old path + sync)
-  - [ ] 2.1.5 Error recovery tests (GitHub API errors, sync failures)
+  - [ ] 2.1.4 Happy path test (atomic Git Trees API flow: GET blob SHA, POST tree, POST commit, PATCH ref, sync)
+  - [ ] 2.1.5 Error recovery tests (GitHub API errors at each step, sync failures)
+  - [ ] 2.1.6 Edge case tests (Unicode filenames, MAX_FILENAME_BYTES boundary)
 - [ ] 2.2 Implement PATCH handler in `apps/web-platform/app/api/kb/file/[...path]/route.ts`
   - [ ] 2.2.1 CSRF + auth + workspace validation (same pattern as DELETE)
   - [ ] 2.2.2 Path extraction and validation (null bytes, `.md`, path traversal, symlinks)
-  - [ ] 2.2.3 Parse and validate newName from JSON body
-  - [ ] 2.2.4 Check if destination path already exists (409 if so)
-  - [ ] 2.2.5 GET file content from old path (SHA + base64)
-  - [ ] 2.2.6 PUT file at new path
-  - [ ] 2.2.7 DELETE old file
-  - [ ] 2.2.8 Workspace sync (git pull --ff-only)
-  - [ ] 2.2.9 Error handling and logging
+  - [ ] 2.2.3 Parse and validate newName from JSON body (sanitizeFilename, extension preservation, same-name check)
+  - [ ] 2.2.4 GET file blob SHA from Contents API at old path
+  - [ ] 2.2.5 Check if destination path already exists via Contents API GET (409 if so)
+  - [ ] 2.2.6 GET current branch ref and commit tree SHA
+  - [ ] 2.2.7 POST `/git/trees` with base_tree, old path `sha: null`, new path with blob SHA
+  - [ ] 2.2.8 POST `/git/commits` with new tree SHA and parent commit
+  - [ ] 2.2.9 PATCH `/git/refs/heads/{branch}` to update branch pointer
+  - [ ] 2.2.10 Workspace sync (git pull --ff-only)
+  - [ ] 2.2.11 Error handling, logging, and Sentry capture
 - [ ] 2.3 Run tests -- all should pass (GREEN)
 
 ## Phase 3: Core Implementation -- UI
 
 - [ ] 3.1 Write failing component tests in `apps/web-platform/test/file-tree-rename.test.tsx`
   - [ ] 3.1.1 Pencil icon visibility (attachment files only, not .md)
-  - [ ] 3.1.2 Edit mode entry (click pencil, input appears)
-  - [ ] 3.1.3 Confirm rename (Enter key triggers PATCH call)
-  - [ ] 3.1.4 Cancel rename (Escape key, no API call)
-  - [ ] 3.1.5 Error display (inline error on API failure)
+  - [ ] 3.1.2 Edit mode entry (click pencil, input appears with basename without extension)
+  - [ ] 3.1.3 Extension displayed as static suffix after input
+  - [ ] 3.1.4 Confirm rename (Enter key triggers PATCH call with extension appended)
+  - [ ] 3.1.5 Confirm rename on blur
+  - [ ] 3.1.6 Cancel rename (Escape key, no API call)
+  - [ ] 3.1.7 Error display (inline error on API failure)
+  - [ ] 3.1.8 Loading state ("Renaming..." shown during API call)
 - [ ] 3.2 Add RenameState type and rename UI to `apps/web-platform/components/kb/file-tree.tsx`
   - [ ] 3.2.1 Add PencilIcon SVG component
   - [ ] 3.2.2 Add RenameState type
-  - [ ] 3.2.3 Add pencil button (hover, attachment files only, next to delete icon)
-  - [ ] 3.2.4 Add inline input for edit mode (pre-filled with current name, auto-focus, select text)
-  - [ ] 3.2.5 Add keyboard handlers (Enter to confirm, Escape to cancel)
-  - [ ] 3.2.6 Add rename fetch call (PATCH) and tree refresh on success
-  - [ ] 3.2.7 Add error display (inline, dismissable)
-  - [ ] 3.2.8 Add "Renaming..." loading state
+  - [ ] 3.2.3 Add pencil button (hover, attachment files only, left of delete icon)
+  - [ ] 3.2.4 Add inline input for edit mode (pre-filled with basename, static extension suffix)
+  - [ ] 3.2.5 Add auto-focus and select-all on input mount
+  - [ ] 3.2.6 Add keyboard handlers (Enter to confirm, Escape to cancel, blur to confirm)
+  - [ ] 3.2.7 Add rename fetch call (PATCH) with extension auto-append, tree refresh on success
+  - [ ] 3.2.8 Add error display (inline, dismissable, same pattern as delete)
+  - [ ] 3.2.9 Add "Renaming..." loading state with opacity reduction
 - [ ] 3.3 Run component tests -- all should pass (GREEN)
 
 ## Phase 4: Testing and Polish

--- a/knowledge-base/project/specs/feat-kb-file-rename/tasks.md
+++ b/knowledge-base/project/specs/feat-kb-file-rename/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: feat-kb-file-rename
+
+## Phase 1: Setup
+
+- [ ] 1.1 Extract `sanitizeFilename` and constants (`WINDOWS_RESERVED`, `MAX_FILENAME_BYTES`) from `apps/web-platform/app/api/kb/upload/route.ts` into `apps/web-platform/server/kb-validation.ts`
+- [ ] 1.2 Update `apps/web-platform/app/api/kb/upload/route.ts` to import `sanitizeFilename` from the shared module
+- [ ] 1.3 Verify existing upload tests still pass after extraction
+
+## Phase 2: Core Implementation -- API
+
+- [ ] 2.1 Write failing tests for PATCH `/api/kb/file/[...path]` in `apps/web-platform/test/kb-rename.test.ts`
+  - [ ] 2.1.1 Auth tests (unauthenticated, workspace not ready, no repo connected)
+  - [ ] 2.1.2 Validation tests (null bytes, `.md` rejection, path traversal, symlinks, empty newName, invalid newName, directory path)
+  - [ ] 2.1.3 Conflict tests (newName already exists at destination)
+  - [ ] 2.1.4 Happy path test (GET content + PUT at new path + DELETE old path + sync)
+  - [ ] 2.1.5 Error recovery tests (GitHub API errors, sync failures)
+- [ ] 2.2 Implement PATCH handler in `apps/web-platform/app/api/kb/file/[...path]/route.ts`
+  - [ ] 2.2.1 CSRF + auth + workspace validation (same pattern as DELETE)
+  - [ ] 2.2.2 Path extraction and validation (null bytes, `.md`, path traversal, symlinks)
+  - [ ] 2.2.3 Parse and validate newName from JSON body
+  - [ ] 2.2.4 Check if destination path already exists (409 if so)
+  - [ ] 2.2.5 GET file content from old path (SHA + base64)
+  - [ ] 2.2.6 PUT file at new path
+  - [ ] 2.2.7 DELETE old file
+  - [ ] 2.2.8 Workspace sync (git pull --ff-only)
+  - [ ] 2.2.9 Error handling and logging
+- [ ] 2.3 Run tests -- all should pass (GREEN)
+
+## Phase 3: Core Implementation -- UI
+
+- [ ] 3.1 Write failing component tests in `apps/web-platform/test/file-tree-rename.test.tsx`
+  - [ ] 3.1.1 Pencil icon visibility (attachment files only, not .md)
+  - [ ] 3.1.2 Edit mode entry (click pencil, input appears)
+  - [ ] 3.1.3 Confirm rename (Enter key triggers PATCH call)
+  - [ ] 3.1.4 Cancel rename (Escape key, no API call)
+  - [ ] 3.1.5 Error display (inline error on API failure)
+- [ ] 3.2 Add RenameState type and rename UI to `apps/web-platform/components/kb/file-tree.tsx`
+  - [ ] 3.2.1 Add PencilIcon SVG component
+  - [ ] 3.2.2 Add RenameState type
+  - [ ] 3.2.3 Add pencil button (hover, attachment files only, next to delete icon)
+  - [ ] 3.2.4 Add inline input for edit mode (pre-filled with current name, auto-focus, select text)
+  - [ ] 3.2.5 Add keyboard handlers (Enter to confirm, Escape to cancel)
+  - [ ] 3.2.6 Add rename fetch call (PATCH) and tree refresh on success
+  - [ ] 3.2.7 Add error display (inline, dismissable)
+  - [ ] 3.2.8 Add "Renaming..." loading state
+- [ ] 3.3 Run component tests -- all should pass (GREEN)
+
+## Phase 4: Testing and Polish
+
+- [ ] 4.1 Run full test suite to verify no regressions
+- [ ] 4.2 Run markdownlint on changed `.md` files
+- [ ] 4.3 Verify TypeScript compilation passes

--- a/knowledge-base/project/specs/feat-kb-file-rename/tasks.md
+++ b/knowledge-base/project/specs/feat-kb-file-rename/tasks.md
@@ -2,58 +2,58 @@
 
 ## Phase 1: Setup
 
-- [ ] 1.1 Extract `sanitizeFilename` and constants (`WINDOWS_RESERVED`, `MAX_FILENAME_BYTES`) from `apps/web-platform/app/api/kb/upload/route.ts` into `apps/web-platform/server/kb-validation.ts`
-- [ ] 1.2 Update `apps/web-platform/app/api/kb/upload/route.ts` to import `sanitizeFilename` from the shared module
-- [ ] 1.3 Verify existing upload tests still pass after extraction
+- [x] 1.1 Extract `sanitizeFilename` and constants (`WINDOWS_RESERVED`, `MAX_FILENAME_BYTES`) from `apps/web-platform/app/api/kb/upload/route.ts` into `apps/web-platform/server/kb-validation.ts`
+- [x] 1.2 Update `apps/web-platform/app/api/kb/upload/route.ts` to import `sanitizeFilename` from the shared module
+- [x] 1.3 Verify existing upload tests still pass after extraction
 
 ## Phase 2: Core Implementation -- API
 
-- [ ] 2.1 Write failing tests for PATCH `/api/kb/file/[...path]` in `apps/web-platform/test/kb-rename.test.ts`
-  - [ ] 2.1.1 Auth tests (unauthenticated, workspace not ready, no repo connected)
-  - [ ] 2.1.2 Validation tests (null bytes, `.md` rejection, path traversal, symlinks, empty newName, invalid newName, directory path, extension change, same name)
-  - [ ] 2.1.3 Conflict tests (newName already exists at destination)
-  - [ ] 2.1.4 Happy path test (atomic Git Trees API flow: GET blob SHA, POST tree, POST commit, PATCH ref, sync)
-  - [ ] 2.1.5 Error recovery tests (GitHub API errors at each step, sync failures)
-  - [ ] 2.1.6 Edge case tests (Unicode filenames, MAX_FILENAME_BYTES boundary)
-- [ ] 2.2 Implement PATCH handler in `apps/web-platform/app/api/kb/file/[...path]/route.ts`
-  - [ ] 2.2.1 CSRF + auth + workspace validation (same pattern as DELETE)
-  - [ ] 2.2.2 Path extraction and validation (null bytes, `.md`, path traversal, symlinks)
-  - [ ] 2.2.3 Parse and validate newName from JSON body (sanitizeFilename, extension preservation, same-name check)
-  - [ ] 2.2.4 GET file blob SHA from Contents API at old path
-  - [ ] 2.2.5 Check if destination path already exists via Contents API GET (409 if so)
-  - [ ] 2.2.6 GET current branch ref and commit tree SHA
-  - [ ] 2.2.7 POST `/git/trees` with base_tree, old path `sha: null`, new path with blob SHA
-  - [ ] 2.2.8 POST `/git/commits` with new tree SHA and parent commit
-  - [ ] 2.2.9 PATCH `/git/refs/heads/{branch}` to update branch pointer
-  - [ ] 2.2.10 Workspace sync (git pull --ff-only)
-  - [ ] 2.2.11 Error handling, logging, and Sentry capture
-- [ ] 2.3 Run tests -- all should pass (GREEN)
+- [x] 2.1 Write failing tests for PATCH `/api/kb/file/[...path]` in `apps/web-platform/test/kb-rename.test.ts`
+  - [x] 2.1.1 Auth tests (unauthenticated, workspace not ready, no repo connected)
+  - [x] 2.1.2 Validation tests (null bytes, `.md` rejection, path traversal, symlinks, empty newName, invalid newName, directory path, extension change, same name)
+  - [x] 2.1.3 Conflict tests (newName already exists at destination)
+  - [x] 2.1.4 Happy path test (atomic Git Trees API flow: GET blob SHA, POST tree, POST commit, PATCH ref, sync)
+  - [x] 2.1.5 Error recovery tests (GitHub API errors at each step, sync failures)
+  - [x] 2.1.6 Edge case tests (Unicode filenames, MAX_FILENAME_BYTES boundary)
+- [x] 2.2 Implement PATCH handler in `apps/web-platform/app/api/kb/file/[...path]/route.ts`
+  - [x] 2.2.1 CSRF + auth + workspace validation (same pattern as DELETE)
+  - [x] 2.2.2 Path extraction and validation (null bytes, `.md`, path traversal, symlinks)
+  - [x] 2.2.3 Parse and validate newName from JSON body (sanitizeFilename, extension preservation, same-name check)
+  - [x] 2.2.4 GET file blob SHA from Contents API at old path
+  - [x] 2.2.5 Check if destination path already exists via Contents API GET (409 if so)
+  - [x] 2.2.6 GET current branch ref and commit tree SHA
+  - [x] 2.2.7 POST `/git/trees` with base_tree, old path `sha: null`, new path with blob SHA
+  - [x] 2.2.8 POST `/git/commits` with new tree SHA and parent commit
+  - [x] 2.2.9 PATCH `/git/refs/heads/{branch}` to update branch pointer
+  - [x] 2.2.10 Workspace sync (git pull --ff-only)
+  - [x] 2.2.11 Error handling, logging, and Sentry capture
+- [x] 2.3 Run tests -- all should pass (GREEN)
 
 ## Phase 3: Core Implementation -- UI
 
-- [ ] 3.1 Write failing component tests in `apps/web-platform/test/file-tree-rename.test.tsx`
-  - [ ] 3.1.1 Pencil icon visibility (attachment files only, not .md)
-  - [ ] 3.1.2 Edit mode entry (click pencil, input appears with basename without extension)
-  - [ ] 3.1.3 Extension displayed as static suffix after input
-  - [ ] 3.1.4 Confirm rename (Enter key triggers PATCH call with extension appended)
-  - [ ] 3.1.5 Confirm rename on blur
-  - [ ] 3.1.6 Cancel rename (Escape key, no API call)
-  - [ ] 3.1.7 Error display (inline error on API failure)
-  - [ ] 3.1.8 Loading state ("Renaming..." shown during API call)
-- [ ] 3.2 Add RenameState type and rename UI to `apps/web-platform/components/kb/file-tree.tsx`
-  - [ ] 3.2.1 Add PencilIcon SVG component
-  - [ ] 3.2.2 Add RenameState type
-  - [ ] 3.2.3 Add pencil button (hover, attachment files only, left of delete icon)
-  - [ ] 3.2.4 Add inline input for edit mode (pre-filled with basename, static extension suffix)
-  - [ ] 3.2.5 Add auto-focus and select-all on input mount
-  - [ ] 3.2.6 Add keyboard handlers (Enter to confirm, Escape to cancel, blur to confirm)
-  - [ ] 3.2.7 Add rename fetch call (PATCH) with extension auto-append, tree refresh on success
-  - [ ] 3.2.8 Add error display (inline, dismissable, same pattern as delete)
-  - [ ] 3.2.9 Add "Renaming..." loading state with opacity reduction
-- [ ] 3.3 Run component tests -- all should pass (GREEN)
+- [x] 3.1 Write failing component tests in `apps/web-platform/test/file-tree-rename.test.tsx`
+  - [x] 3.1.1 Pencil icon visibility (attachment files only, not .md)
+  - [x] 3.1.2 Edit mode entry (click pencil, input appears with basename without extension)
+  - [x] 3.1.3 Extension displayed as static suffix after input
+  - [x] 3.1.4 Confirm rename (Enter key triggers PATCH call with extension appended)
+  - [x] 3.1.5 Confirm rename on blur
+  - [x] 3.1.6 Cancel rename (Escape key, no API call)
+  - [x] 3.1.7 Error display (inline error on API failure)
+  - [x] 3.1.8 Loading state ("Renaming..." shown during API call)
+- [x] 3.2 Add RenameState type and rename UI to `apps/web-platform/components/kb/file-tree.tsx`
+  - [x] 3.2.1 Add PencilIcon SVG component
+  - [x] 3.2.2 Add RenameState type
+  - [x] 3.2.3 Add pencil button (hover, attachment files only, left of delete icon)
+  - [x] 3.2.4 Add inline input for edit mode (pre-filled with basename, static extension suffix)
+  - [x] 3.2.5 Add auto-focus and select-all on input mount
+  - [x] 3.2.6 Add keyboard handlers (Enter to confirm, Escape to cancel, blur to confirm)
+  - [x] 3.2.7 Add rename fetch call (PATCH) with extension auto-append, tree refresh on success
+  - [x] 3.2.8 Add error display (inline, dismissable, same pattern as delete)
+  - [x] 3.2.9 Add "Renaming..." loading state with opacity reduction
+- [x] 3.3 Run component tests -- all should pass (GREEN)
 
 ## Phase 4: Testing and Polish
 
-- [ ] 4.1 Run full test suite to verify no regressions
-- [ ] 4.2 Run markdownlint on changed `.md` files
-- [ ] 4.3 Verify TypeScript compilation passes
+- [x] 4.1 Run full test suite to verify no regressions
+- [x] 4.2 Run markdownlint on changed `.md` files
+- [x] 4.3 Verify TypeScript compilation passes


### PR DESCRIPTION
## Summary

- Add PATCH `/api/kb/file/[...path]` endpoint for atomic file rename via GitHub Git Trees API (single commit, no partial-failure window)
- Add inline rename UI with pencil icon, keyboard handling (Enter/Escape/blur), and error display
- Extract shared `sanitizeFilename` to `server/kb-validation.ts` for reuse across upload and rename routes
- Enforce extension preservation during rename (prevents `.png` to `.md` bypass)
- Fetch actual default branch from GitHub API instead of hardcoding

Closes #2152

## Changelog

- Add file rename support to KB Tree sidebar (pencil icon on hover for attachment files)
- Atomic rename via Git Trees API eliminates partial-failure window from Contents API approach
- Extension preservation enforced during rename (security boundary)
- `sanitizeFilename` extracted to shared module with path separator rejection
- Dynamic default branch detection (supports repos using `master` or custom branches)

## Test plan

- [x] 23 API route tests (auth, validation, happy path, error recovery, edge cases)
- [x] 9 component tests (pencil visibility, edit mode, keyboard handlers, error display, loading state)
- [x] 1288 total tests passing, 0 regressions
- [x] TypeScript clean, markdownlint clean

Generated with [Claude Code](https://claude.com/claude-code)