### PR TITLE
feat(settings): move billing to dedicated page and remove connected services

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/settings/billing/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/settings/billing/page.tsx
@@ -1,0 +1,49 @@
+import { redirect } from "next/navigation";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { BillingSection } from "@/components/settings/billing-section";
+import { SettingsShell } from "@/components/settings/settings-shell";
+
+export default async function BillingPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const service = createServiceClient();
+
+  const [{ data: userData }, { count: conversationCount }, { count: serviceTokenCount }] =
+    await Promise.all([
+      service
+        .from("users")
+        .select(
+          "subscription_status, current_period_end, cancel_at_period_end, created_at",
+        )
+        .eq("id", user.id)
+        .single(),
+      service
+        .from("conversations")
+        .select("*", { count: "exact", head: true })
+        .eq("user_id", user.id),
+      service
+        .from("service_tokens")
+        .select("*", { count: "exact", head: true })
+        .eq("user_id", user.id),
+    ]);
+
+  return (
+    <SettingsShell>
+      <BillingSection
+        subscriptionStatus={userData?.subscription_status ?? null}
+        currentPeriodEnd={userData?.current_period_end ?? null}
+        cancelAtPeriodEnd={userData?.cancel_at_period_end ?? false}
+        conversationCount={conversationCount ?? 0}
+        serviceTokenCount={serviceTokenCount ?? 0}
+        createdAt={userData?.created_at ?? new Date().toISOString()}
+      />
+    </SettingsShell>
+  );
+}

--- a/apps/web-platform/app/(dashboard)/dashboard/settings/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/settings/page.tsx
@@ -17,12 +17,7 @@ export default async function SettingsPage() {
   const service = createServiceClient();
 
   // Parallelize all independent queries
-  const [
-    { data: apiKey },
-    { data: userData },
-    { count: conversationCount },
-    { count: serviceTokenCount },
-  ] = await Promise.all([
+  const [{ data: apiKey }, { data: userData }] = await Promise.all([
     service
       .from("api_keys")
       .select("provider, is_valid, updated_at")
@@ -32,19 +27,9 @@ export default async function SettingsPage() {
       .single(),
     service
       .from("users")
-      .select(
-        "repo_url, repo_status, repo_last_synced_at, subscription_status, current_period_end, cancel_at_period_end, created_at",
-      )
+      .select("repo_url, repo_status, repo_last_synced_at")
       .eq("id", user.id)
       .single(),
-    service
-      .from("conversations")
-      .select("*", { count: "exact", head: true })
-      .eq("user_id", user.id),
-    service
-      .from("service_tokens")
-      .select("*", { count: "exact", head: true })
-      .eq("user_id", user.id),
   ]);
 
   return (
@@ -57,12 +42,6 @@ export default async function SettingsPage() {
         repoUrl={userData?.repo_url ?? null}
         repoStatus={(userData?.repo_status as RepoStatus) ?? "not_connected"}
         repoLastSyncedAt={userData?.repo_last_synced_at ?? null}
-        subscriptionStatus={userData?.subscription_status ?? null}
-        currentPeriodEnd={userData?.current_period_end ?? null}
-        cancelAtPeriodEnd={userData?.cancel_at_period_end ?? false}
-        conversationCount={conversationCount ?? 0}
-        serviceTokenCount={serviceTokenCount ?? 0}
-        createdAt={userData?.created_at ?? new Date().toISOString()}
       />
     </SettingsShell>
   );

--- a/apps/web-platform/components/settings/settings-content.tsx
+++ b/apps/web-platform/components/settings/settings-content.tsx
@@ -1,8 +1,6 @@
-import Link from "next/link";
 import { KeyRotationForm } from "./key-rotation-form";
 import { DeleteAccountDialog } from "./delete-account-dialog";
 import { ProjectSetupCard, type RepoStatus } from "./project-setup-card";
-import { BillingSection } from "./billing-section";
 
 interface SettingsContentProps {
   userEmail: string;
@@ -12,12 +10,6 @@ interface SettingsContentProps {
   repoUrl: string | null;
   repoStatus: RepoStatus;
   repoLastSyncedAt: string | null;
-  subscriptionStatus: string | null;
-  currentPeriodEnd: string | null;
-  cancelAtPeriodEnd: boolean;
-  conversationCount: number;
-  serviceTokenCount: number;
-  createdAt: string;
 }
 
 export function SettingsContent({
@@ -28,12 +20,6 @@ export function SettingsContent({
   repoUrl,
   repoStatus,
   repoLastSyncedAt,
-  subscriptionStatus,
-  currentPeriodEnd,
-  cancelAtPeriodEnd,
-  conversationCount,
-  serviceTokenCount,
-  createdAt,
 }: SettingsContentProps) {
   return (
     <div className="space-y-10">
@@ -86,36 +72,6 @@ export function SettingsContent({
           <KeyRotationForm hasExistingKey={hasApiKey} />
         </div>
       </section>
-
-      {/* Connected Services Section */}
-      <section>
-        <h2 className="mb-4 text-lg font-semibold text-white">
-          Connected Services
-        </h2>
-        <div className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-6">
-          <p className="mb-4 text-sm text-neutral-400">
-            Manage API tokens for Cloudflare, Stripe, GitHub, and other
-            third-party services. Tokens are encrypted and available to your
-            agent sessions.
-          </p>
-          <Link
-            href="/dashboard/settings/services"
-            className="inline-flex items-center rounded-lg bg-amber-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-amber-500"
-          >
-            Manage Services
-          </Link>
-        </div>
-      </section>
-
-      {/* Billing Section */}
-      <BillingSection
-        subscriptionStatus={subscriptionStatus}
-        currentPeriodEnd={currentPeriodEnd}
-        cancelAtPeriodEnd={cancelAtPeriodEnd}
-        conversationCount={conversationCount}
-        serviceTokenCount={serviceTokenCount}
-        createdAt={createdAt}
-      />
 
       {/* Danger Zone Section */}
       <section>

--- a/apps/web-platform/components/settings/settings-shell.tsx
+++ b/apps/web-platform/components/settings/settings-shell.tsx
@@ -7,6 +7,7 @@ const SETTINGS_TABS = [
   { href: "/dashboard/settings", label: "General" },
   { href: "/dashboard/settings/team", label: "Team" },
   { href: "/dashboard/settings/services", label: "Integrations" },
+  { href: "/dashboard/settings/billing", label: "Billing" },
 ] as const;
 
 export function SettingsShell({ children }: { children: React.ReactNode }) {

--- a/apps/web-platform/test/settings-page.test.tsx
+++ b/apps/web-platform/test/settings-page.test.tsx
@@ -152,12 +152,6 @@ describe("Settings page sections", () => {
         repoUrl={null}
         repoStatus="not_connected"
         repoLastSyncedAt={null}
-        subscriptionStatus={null}
-        currentPeriodEnd={null}
-        cancelAtPeriodEnd={false}
-        conversationCount={0}
-        serviceTokenCount={0}
-        createdAt="2026-01-01T00:00:00.000Z"
       />,
     );
     expect(screen.getByText("API Key")).toBeInTheDocument();
@@ -176,12 +170,6 @@ describe("Settings page sections", () => {
         repoUrl={null}
         repoStatus="not_connected"
         repoLastSyncedAt={null}
-        subscriptionStatus={null}
-        currentPeriodEnd={null}
-        cancelAtPeriodEnd={false}
-        conversationCount={0}
-        serviceTokenCount={0}
-        createdAt="2026-01-01T00:00:00.000Z"
       />,
     );
     expect(screen.getByText("Account")).toBeInTheDocument();
@@ -201,12 +189,6 @@ describe("Settings page sections", () => {
         repoUrl={null}
         repoStatus="not_connected"
         repoLastSyncedAt={null}
-        subscriptionStatus={null}
-        currentPeriodEnd={null}
-        cancelAtPeriodEnd={false}
-        conversationCount={0}
-        serviceTokenCount={0}
-        createdAt="2026-01-01T00:00:00.000Z"
       />,
     );
     expect(screen.getByText("Danger Zone")).toBeInTheDocument();
@@ -225,12 +207,6 @@ describe("Settings page sections", () => {
         repoUrl={null}
         repoStatus="not_connected"
         repoLastSyncedAt={null}
-        subscriptionStatus={null}
-        currentPeriodEnd={null}
-        cancelAtPeriodEnd={false}
-        conversationCount={0}
-        serviceTokenCount={0}
-        createdAt="2026-01-01T00:00:00.000Z"
       />,
     );
     const headings = screen.getAllByRole("heading", { level: 2 });
@@ -253,12 +229,6 @@ describe("Settings page sections", () => {
         repoUrl={null}
         repoStatus="not_connected"
         repoLastSyncedAt={null}
-        subscriptionStatus={null}
-        currentPeriodEnd={null}
-        cancelAtPeriodEnd={false}
-        conversationCount={0}
-        serviceTokenCount={0}
-        createdAt="2026-01-01T00:00:00.000Z"
       />,
     );
     expect(screen.getByText(/no key configured/i)).toBeInTheDocument();
@@ -277,12 +247,6 @@ describe("Settings page sections", () => {
         repoUrl={null}
         repoStatus="not_connected"
         repoLastSyncedAt={null}
-        subscriptionStatus={null}
-        currentPeriodEnd={null}
-        cancelAtPeriodEnd={false}
-        conversationCount={0}
-        serviceTokenCount={0}
-        createdAt="2026-01-01T00:00:00.000Z"
       />,
     );
     expect(screen.getByText(/provider:/i)).toBeInTheDocument();
@@ -301,12 +265,6 @@ describe("Settings page sections", () => {
         repoUrl={null}
         repoStatus="not_connected"
         repoLastSyncedAt={null}
-        subscriptionStatus={null}
-        currentPeriodEnd={null}
-        cancelAtPeriodEnd={false}
-        conversationCount={0}
-        serviceTokenCount={0}
-        createdAt="2026-01-01T00:00:00.000Z"
       />,
     );
     // Project section should appear — look for heading rendered by ProjectSetupCard
@@ -326,12 +284,6 @@ describe("Settings page sections", () => {
         repoUrl={null}
         repoStatus="not_connected"
         repoLastSyncedAt={null}
-        subscriptionStatus={null}
-        currentPeriodEnd={null}
-        cancelAtPeriodEnd={false}
-        conversationCount={0}
-        serviceTokenCount={0}
-        createdAt="2026-01-01T00:00:00.000Z"
       />,
     );
     const headings = screen.getAllByRole("heading", { level: 2 });

--- a/knowledge-base/project/plans/2026-04-14-feat-team-settings-page-improvements-plan.md
+++ b/knowledge-base/project/plans/2026-04-14-feat-team-settings-page-improvements-plan.md
@@ -1,0 +1,134 @@
+---
+title: "feat: Team Settings Page improvements"
+type: feat
+date: 2026-04-14
+semver: patch
+---
+
+# feat: Team Settings Page improvements
+
+## Overview
+
+Reorganize the Settings page layout by removing redundant sections from the General page and creating a dedicated Billing page. The Connected Services section already has its own "Integrations" tab in the sidebar and should not also appear on the General page. The Billing section is substantial enough to warrant its own dedicated page accessible from the Settings sidebar.
+
+## Problem Statement
+
+The General settings page (`/dashboard/settings`) currently contains five sections: Account, Project, API Key, Connected Services, and Billing. Two of these are redundant or misplaced:
+
+1. **Connected Services** is duplicated -- it appears both as a link card on the General page AND as the "Integrations" sidebar tab (`/dashboard/settings/services`). The General page version is just a link to the Integrations page.
+2. **Billing** is a complex, self-contained section with subscription management, cancellation flows, and invoice history. It deserves its own dedicated page accessible from the sidebar rather than being buried at the bottom of the General page.
+
+## Proposed Solution
+
+### 1. Remove Connected Services from General Page
+
+Remove the "Connected Services" `<section>` from `settings-content.tsx` (lines 90-108). This is a simple deletion -- the section just contains a description and a "Manage Services" link that points to `/dashboard/settings/services`, which is already the "Integrations" sidebar tab.
+
+**Files to modify:**
+
+- `apps/web-platform/components/settings/settings-content.tsx` -- remove the Connected Services section JSX and its data dependencies
+- `apps/web-platform/app/(dashboard)/dashboard/settings/page.tsx` -- remove the `serviceTokenCount` query since it was only used by the Billing section on this page (Billing will move to its own page)
+
+### 2. Remove Billing from General Page
+
+Remove the `<BillingSection>` component and its `<CancelRetentionModal>` from `settings-content.tsx` (lines 110-118). Remove the associated imports and props (`subscriptionStatus`, `currentPeriodEnd`, `cancelAtPeriodEnd`, `conversationCount`, `serviceTokenCount`, `createdAt`).
+
+**Files to modify:**
+
+- `apps/web-platform/components/settings/settings-content.tsx` -- remove BillingSection import, remove billing-related props from interface and component, remove the JSX
+- `apps/web-platform/app/(dashboard)/dashboard/settings/page.tsx` -- remove billing-related queries (`userData` subscription fields, `conversationCount`, `serviceTokenCount`) and props from the `<SettingsContent>` component
+
+### 3. Create Dedicated Billing Page
+
+Create a new route at `/dashboard/settings/billing` that hosts the existing `BillingSection` component. This page will fetch the required billing data server-side and pass it as props, following the same pattern as the existing settings page.
+
+**Files to create:**
+
+- `apps/web-platform/app/(dashboard)/dashboard/settings/billing/page.tsx` -- new server component that fetches billing data and renders `BillingSection` wrapped in `SettingsShell`
+
+### 4. Add Billing to Settings Sidebar
+
+Add a "Billing" tab to the `SETTINGS_TABS` array in `settings-shell.tsx`.
+
+**Files to modify:**
+
+- `apps/web-platform/components/settings/settings-shell.tsx` -- add `{ href: "/dashboard/settings/billing", label: "Billing" }` to `SETTINGS_TABS`
+
+### Summary of Final Sidebar Tabs
+
+| Tab | Route | Status |
+|-----|-------|--------|
+| General | `/dashboard/settings` | Existing (slimmed down) |
+| Team | `/dashboard/settings/team` | Existing (unchanged) |
+| Integrations | `/dashboard/settings/services` | Existing (unchanged) |
+| Billing | `/dashboard/settings/billing` | New |
+
+### Summary of Files Changed
+
+| File | Action | Description |
+|------|--------|-------------|
+| `apps/web-platform/components/settings/settings-content.tsx` | Modify | Remove Connected Services section, BillingSection, and related props/imports |
+| `apps/web-platform/app/(dashboard)/dashboard/settings/page.tsx` | Modify | Remove billing/service queries and props no longer needed |
+| `apps/web-platform/components/settings/settings-shell.tsx` | Modify | Add Billing tab to sidebar |
+| `apps/web-platform/app/(dashboard)/dashboard/settings/billing/page.tsx` | Create | New billing page with server-side data fetching |
+
+## Acceptance Criteria
+
+- [ ] Connected Services section no longer appears on the General settings page
+- [ ] Billing section no longer appears on the General settings page
+- [ ] New Billing page exists at `/dashboard/settings/billing`
+- [ ] Billing page shows all existing billing functionality (subscription status, manage/cancel buttons, invoice list)
+- [ ] "Billing" tab appears in the Settings sidebar navigation (both desktop sidebar and mobile tab bar)
+- [ ] All existing billing API routes (`/api/billing/portal`, `/api/billing/invoices`, `/api/checkout`) continue to work
+- [ ] The `CancelRetentionModal` continues to function on the new Billing page
+- [ ] General settings page still shows Account, Project, API Key, and Danger Zone sections
+- [ ] No regressions in Team or Integrations pages
+
+## Domain Review
+
+**Domains relevant:** Product
+
+### Product/UX Gate
+
+**Tier:** advisory
+**Decision:** auto-accepted (pipeline)
+**Agents invoked:** none
+**Skipped specialists:** none
+**Pencil available:** N/A
+
+This is a straightforward UI reorganization that moves existing components to better navigation locations. The billing component is reused as-is with no modifications to its interface or behavior.
+
+## Test Scenarios
+
+- Given a user on the General settings page, when the page loads, then they should NOT see a "Connected Services" section
+- Given a user on the General settings page, when the page loads, then they should NOT see a "Billing" section
+- Given a user on the General settings page, when the page loads, then they should see Account, Project, API Key, and Danger Zone sections
+- Given a user navigating the Settings sidebar, when they view the sidebar tabs, then they should see General, Team, Integrations, and Billing tabs
+- Given a user clicking the Billing sidebar tab, when the page loads, then they should see subscription status, management buttons, and invoice history
+- Given a user on the Billing page with an active subscription, when they click "Cancel Subscription", then the retention modal should appear and function correctly
+- Given a user on the Billing page, when they click "Manage Subscription", then they should be redirected to the Stripe billing portal
+- Given a user on mobile, when they view the bottom tab bar, then they should see all four settings tabs including Billing
+
+## Non-Goals
+
+- Redesigning the Billing UI itself -- the existing `BillingSection` component is reused as-is
+- Changing the Integrations/Connected Services page behavior
+- Adding new billing features
+- Modifying billing API routes
+
+## Context
+
+- Issue: #2155
+- Milestone: Phase 3 (Make it Sticky)
+- The `BillingSection` component (`billing-section.tsx`) is a self-contained client component that fetches invoices client-side and handles all billing interactions
+- The `CancelRetentionModal` (`cancel-retention-modal.tsx`) is tightly coupled with `BillingSection` and moves with it
+- The `SettingsShell` component (`settings-shell.tsx`) provides both the desktop sidebar and mobile bottom tab bar navigation
+
+## References
+
+- `apps/web-platform/components/settings/settings-content.tsx` -- current General page content
+- `apps/web-platform/components/settings/settings-shell.tsx` -- settings sidebar/tab navigation
+- `apps/web-platform/components/settings/billing-section.tsx` -- billing component to move
+- `apps/web-platform/app/(dashboard)/dashboard/settings/page.tsx` -- current General page data fetching
+- `apps/web-platform/app/(dashboard)/dashboard/settings/team/page.tsx` -- pattern reference for new billing page
+- Learning: `knowledge-base/project/learnings/2026-04-13-billing-review-findings-batch-fix.md` -- recent billing area fixes

--- a/knowledge-base/project/plans/2026-04-14-feat-team-settings-page-improvements-plan.md
+++ b/knowledge-base/project/plans/2026-04-14-feat-team-settings-page-improvements-plan.md
@@ -145,14 +145,14 @@ Add a "Billing" tab to the `SETTINGS_TABS` array in `settings-shell.tsx`.
 
 ## Acceptance Criteria
 
-- [ ] Connected Services section no longer appears on the General settings page
-- [ ] Billing section no longer appears on the General settings page
-- [ ] New Billing page exists at `/dashboard/settings/billing`
-- [ ] Billing page shows all existing billing functionality (subscription status, manage/cancel buttons, invoice list)
-- [ ] "Billing" tab appears in the Settings sidebar navigation (both desktop sidebar and mobile tab bar)
-- [ ] All existing billing API routes (`/api/billing/portal`, `/api/billing/invoices`, `/api/checkout`) continue to work
-- [ ] The `CancelRetentionModal` continues to function on the new Billing page
-- [ ] General settings page still shows Account, Project, API Key, and Danger Zone sections
+- [x] Connected Services section no longer appears on the General settings page
+- [x] Billing section no longer appears on the General settings page
+- [x] New Billing page exists at `/dashboard/settings/billing`
+- [x] Billing page shows all existing billing functionality (subscription status, manage/cancel buttons, invoice list)
+- [x] "Billing" tab appears in the Settings sidebar navigation (both desktop sidebar and mobile tab bar)
+- [x] All existing billing API routes (`/api/billing/portal`, `/api/billing/invoices`, `/api/checkout`) continue to work
+- [x] The `CancelRetentionModal` continues to function on the new Billing page
+- [x] General settings page still shows Account, Project, API Key, and Danger Zone sections
 - [ ] No regressions in Team or Integrations pages
 
 ## Domain Review

--- a/knowledge-base/project/plans/2026-04-14-feat-team-settings-page-improvements-plan.md
+++ b/knowledge-base/project/plans/2026-04-14-feat-team-settings-page-improvements-plan.md
@@ -3,9 +3,22 @@ title: "feat: Team Settings Page improvements"
 type: feat
 date: 2026-04-14
 semver: patch
+deepened: 2026-04-14
 ---
 
 # feat: Team Settings Page improvements
+
+## Enhancement Summary
+
+**Deepened on:** 2026-04-14
+**Sections enhanced:** 2 (Proposed Solution, Test Scenarios)
+**Research sources:** Codebase patterns, billing learnings, Next.js App Router conventions
+
+### Key Improvements
+
+1. Added concrete billing page implementation template based on existing settings page pattern
+2. Added edge case for `settings-content.tsx` cleanup -- verify `Link` import can be removed after Connected Services section removal
+3. Added mobile tab bar width consideration for 4 tabs vs 3
 
 ## Overview
 
@@ -45,6 +58,64 @@ Create a new route at `/dashboard/settings/billing` that hosts the existing `Bil
 **Files to create:**
 
 - `apps/web-platform/app/(dashboard)/dashboard/settings/billing/page.tsx` -- new server component that fetches billing data and renders `BillingSection` wrapped in `SettingsShell`
+
+#### Implementation Template
+
+The billing page follows the same server component pattern as the General settings page. Key data fetching:
+
+```typescript
+// app/(dashboard)/dashboard/settings/billing/page.tsx
+import { redirect } from "next/navigation";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { BillingSection } from "@/components/settings/billing-section";
+import { SettingsShell } from "@/components/settings/settings-shell";
+
+export default async function BillingPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const service = createServiceClient();
+
+  const [
+    { data: userData },
+    { count: conversationCount },
+    { count: serviceTokenCount },
+  ] = await Promise.all([
+    service
+      .from("users")
+      .select("subscription_status, current_period_end, cancel_at_period_end, created_at")
+      .eq("id", user.id)
+      .single(),
+    service
+      .from("conversations")
+      .select("*", { count: "exact", head: true })
+      .eq("user_id", user.id),
+    service
+      .from("service_tokens")
+      .select("*", { count: "exact", head: true })
+      .eq("user_id", user.id),
+  ]);
+
+  return (
+    <SettingsShell>
+      <BillingSection
+        subscriptionStatus={userData?.subscription_status ?? null}
+        currentPeriodEnd={userData?.current_period_end ?? null}
+        cancelAtPeriodEnd={userData?.cancel_at_period_end ?? false}
+        conversationCount={conversationCount ?? 0}
+        serviceTokenCount={serviceTokenCount ?? 0}
+        createdAt={userData?.created_at ?? new Date().toISOString()}
+      />
+    </SettingsShell>
+  );
+}
+```
+
+Note: `conversationCount` and `serviceTokenCount` are needed by the `CancelRetentionModal` (rendered inside `BillingSection`) to show the user what they would lose by cancelling.
 
 ### 4. Add Billing to Settings Sidebar
 
@@ -108,6 +179,16 @@ This is a straightforward UI reorganization that moves existing components to be
 - Given a user on the Billing page with an active subscription, when they click "Cancel Subscription", then the retention modal should appear and function correctly
 - Given a user on the Billing page, when they click "Manage Subscription", then they should be redirected to the Stripe billing portal
 - Given a user on mobile, when they view the bottom tab bar, then they should see all four settings tabs including Billing
+
+## Edge Cases and Implementation Notes
+
+1. **`Link` import cleanup in settings-content.tsx**: After removing the Connected Services section, verify whether the `Link` import from `next/link` is still needed. The Connected Services section is the only place using `<Link>` in `settings-content.tsx`. If no other section uses it, remove the import to avoid unused import warnings.
+
+2. **Mobile tab bar with 4 tabs**: Adding a 4th tab to the mobile bottom tab bar (`flex-1` on each) changes the width from 33% to 25% per tab. At narrow viewport widths (320px), each tab gets 80px -- verify that "Integrations" text (longest label) does not overflow or get truncated. The current `text-xs font-medium` styling should accommodate this, but verify visually.
+
+3. **General page data fetching optimization**: After removing billing-related queries, the General settings page only needs `apiKey` and basic `userData` (repo fields). The `conversationCount` and `serviceTokenCount` queries can be removed entirely from the General page since they were only consumed by `BillingSection`. The `userData` select can be narrowed from including subscription fields to just `repo_url, repo_status, repo_last_synced_at`.
+
+4. **Active tab state for billing route**: The `settings-shell.tsx` active tab detection uses `pathname.startsWith(tab.href)` for non-root tabs. Since `/dashboard/settings/billing` does not share a prefix with any other tab, this works correctly without modification.
 
 ## Non-Goals
 

--- a/knowledge-base/project/specs/feat-team-settings-improvements/session-state.md
+++ b/knowledge-base/project/specs/feat-team-settings-improvements/session-state.md
@@ -1,0 +1,24 @@
+# Session State
+
+## Plan Phase
+
+- Plan file: knowledge-base/project/plans/2026-04-14-feat-team-settings-page-improvements-plan.md
+- Status: complete
+
+### Errors
+
+None
+
+### Decisions
+
+- Selected MINIMAL detail level -- straightforward UI reorganization with 4 files (3 modified, 1 created)
+- Product/UX Gate classified as ADVISORY tier, auto-accepted -- moves existing components without redesign
+- No other domains flagged as relevant
+- Included concrete billing page implementation template in deepened plan
+- Skipped heavy research agent fan-out since the plan is a simple component relocation
+
+### Components Invoked
+
+- soleur:plan
+- soleur:plan-review (DHH, Kieran, Code Simplicity reviewers)
+- soleur:deepen-plan

--- a/knowledge-base/project/specs/feat-team-settings-improvements/tasks.md
+++ b/knowledge-base/project/specs/feat-team-settings-improvements/tasks.md
@@ -1,0 +1,58 @@
+# Tasks: Team Settings Page Improvements
+
+Issue: #2155
+
+## Phase 1: Remove Redundant Sections from General Page
+
+### 1.1 Remove Connected Services section from settings-content.tsx
+
+- [ ] Remove the Connected Services `<section>` JSX (lines 90-108)
+- [ ] Remove the `serviceTokenCount` prop from the interface and component parameters
+- [ ] Verify no other code in this file references `serviceTokenCount` after billing removal
+
+### 1.2 Remove Billing section from settings-content.tsx
+
+- [ ] Remove `BillingSection` import
+- [ ] Remove billing-related props from `SettingsContentProps` interface: `subscriptionStatus`, `currentPeriodEnd`, `cancelAtPeriodEnd`, `conversationCount`, `serviceTokenCount`, `createdAt`
+- [ ] Remove the `<BillingSection>` JSX and its props
+- [ ] Verify the component still compiles with remaining sections (Account, Project, API Key, Danger Zone)
+
+### 1.3 Clean up General page data fetching
+
+- [ ] In `app/(dashboard)/dashboard/settings/page.tsx`, remove queries no longer needed: `conversationCount`, `serviceTokenCount`, and subscription fields from `userData` select
+- [ ] Remove corresponding props from `<SettingsContent>` component invocation
+- [ ] Verify the page still renders correctly with reduced data fetching
+
+## Phase 2: Create Billing Page
+
+### 2.1 Create billing page route
+
+- [ ] Create `app/(dashboard)/dashboard/settings/billing/page.tsx`
+- [ ] Implement as a server component following the pattern from the General settings page
+- [ ] Fetch billing-required data: `subscription_status`, `current_period_end`, `cancel_at_period_end`, `created_at` from users table
+- [ ] Fetch `conversationCount` and `serviceTokenCount` for the retention modal
+- [ ] Render `<SettingsShell>` wrapping `<BillingSection>` with all required props
+- [ ] Include auth check with redirect to `/login` if unauthenticated
+
+### 2.2 Add Billing tab to settings sidebar
+
+- [ ] In `settings-shell.tsx`, add `{ href: "/dashboard/settings/billing", label: "Billing" }` to `SETTINGS_TABS` array
+- [ ] Verify the tab appears in both desktop sidebar and mobile bottom tab bar
+- [ ] Verify active state highlighting works correctly for the billing route
+
+## Phase 3: Verification
+
+### 3.1 Visual verification
+
+- [ ] General page shows only Account, Project, API Key, and Danger Zone sections
+- [ ] Billing page loads at `/dashboard/settings/billing` with full billing UI
+- [ ] Settings sidebar shows 4 tabs: General, Team, Integrations, Billing
+- [ ] Mobile bottom tab bar shows all 4 tabs
+- [ ] Active tab highlighting works on all 4 routes
+
+### 3.2 Functional verification
+
+- [ ] Billing page subscription management buttons work (portal redirect)
+- [ ] Cancel subscription flow with retention modal works on billing page
+- [ ] Invoice list loads on billing page
+- [ ] No console errors on any settings page

--- a/knowledge-base/project/specs/feat-team-settings-improvements/tasks.md
+++ b/knowledge-base/project/specs/feat-team-settings-improvements/tasks.md
@@ -6,53 +6,53 @@ Issue: #2155
 
 ### 1.1 Remove Connected Services section from settings-content.tsx
 
-- [ ] Remove the Connected Services `<section>` JSX (lines 90-108)
-- [ ] Remove the `serviceTokenCount` prop from the interface and component parameters
-- [ ] Verify no other code in this file references `serviceTokenCount` after billing removal
+- [x] Remove the Connected Services `<section>` JSX (lines 90-108)
+- [x] Remove the `serviceTokenCount` prop from the interface and component parameters
+- [x] Verify no other code in this file references `serviceTokenCount` after billing removal
 
 ### 1.2 Remove Billing section from settings-content.tsx
 
-- [ ] Remove `BillingSection` import
-- [ ] Remove billing-related props from `SettingsContentProps` interface: `subscriptionStatus`, `currentPeriodEnd`, `cancelAtPeriodEnd`, `conversationCount`, `serviceTokenCount`, `createdAt`
-- [ ] Remove the `<BillingSection>` JSX and its props
-- [ ] Verify the component still compiles with remaining sections (Account, Project, API Key, Danger Zone)
+- [x] Remove `BillingSection` import
+- [x] Remove billing-related props from `SettingsContentProps` interface: `subscriptionStatus`, `currentPeriodEnd`, `cancelAtPeriodEnd`, `conversationCount`, `serviceTokenCount`, `createdAt`
+- [x] Remove the `<BillingSection>` JSX and its props
+- [x] Verify the component still compiles with remaining sections (Account, Project, API Key, Danger Zone)
 
 ### 1.3 Clean up General page data fetching
 
-- [ ] In `app/(dashboard)/dashboard/settings/page.tsx`, remove queries no longer needed: `conversationCount`, `serviceTokenCount`, and subscription fields from `userData` select
-- [ ] Remove corresponding props from `<SettingsContent>` component invocation
-- [ ] Verify the page still renders correctly with reduced data fetching
+- [x] In `app/(dashboard)/dashboard/settings/page.tsx`, remove queries no longer needed: `conversationCount`, `serviceTokenCount`, and subscription fields from `userData` select
+- [x] Remove corresponding props from `<SettingsContent>` component invocation
+- [x] Verify the page still renders correctly with reduced data fetching
 
 ## Phase 2: Create Billing Page
 
 ### 2.1 Create billing page route
 
-- [ ] Create `app/(dashboard)/dashboard/settings/billing/page.tsx`
-- [ ] Implement as a server component following the pattern from the General settings page
-- [ ] Fetch billing-required data: `subscription_status`, `current_period_end`, `cancel_at_period_end`, `created_at` from users table
-- [ ] Fetch `conversationCount` and `serviceTokenCount` for the retention modal
-- [ ] Render `<SettingsShell>` wrapping `<BillingSection>` with all required props
-- [ ] Include auth check with redirect to `/login` if unauthenticated
+- [x] Create `app/(dashboard)/dashboard/settings/billing/page.tsx`
+- [x] Implement as a server component following the pattern from the General settings page
+- [x] Fetch billing-required data: `subscription_status`, `current_period_end`, `cancel_at_period_end`, `created_at` from users table
+- [x] Fetch `conversationCount` and `serviceTokenCount` for the retention modal
+- [x] Render `<SettingsShell>` wrapping `<BillingSection>` with all required props
+- [x] Include auth check with redirect to `/login` if unauthenticated
 
 ### 2.2 Add Billing tab to settings sidebar
 
-- [ ] In `settings-shell.tsx`, add `{ href: "/dashboard/settings/billing", label: "Billing" }` to `SETTINGS_TABS` array
-- [ ] Verify the tab appears in both desktop sidebar and mobile bottom tab bar
-- [ ] Verify active state highlighting works correctly for the billing route
+- [x] In `settings-shell.tsx`, add `{ href: "/dashboard/settings/billing", label: "Billing" }` to `SETTINGS_TABS` array
+- [x] Verify the tab appears in both desktop sidebar and mobile bottom tab bar
+- [x] Verify active state highlighting works correctly for the billing route
 
 ## Phase 3: Verification
 
 ### 3.1 Visual verification
 
-- [ ] General page shows only Account, Project, API Key, and Danger Zone sections
-- [ ] Billing page loads at `/dashboard/settings/billing` with full billing UI
-- [ ] Settings sidebar shows 4 tabs: General, Team, Integrations, Billing
-- [ ] Mobile bottom tab bar shows all 4 tabs
-- [ ] Active tab highlighting works on all 4 routes
+- [x] General page shows only Account, Project, API Key, and Danger Zone sections
+- [x] Billing page loads at `/dashboard/settings/billing` with full billing UI
+- [x] Settings sidebar shows 4 tabs: General, Team, Integrations, Billing
+- [x] Mobile bottom tab bar shows all 4 tabs
+- [x] Active tab highlighting works on all 4 routes
 
 ### 3.2 Functional verification
 
-- [ ] Billing page subscription management buttons work (portal redirect)
-- [ ] Cancel subscription flow with retention modal works on billing page
-- [ ] Invoice list loads on billing page
-- [ ] No console errors on any settings page
+- [x] Billing page subscription management buttons work (portal redirect)
+- [x] Cancel subscription flow with retention modal works on billing page
+- [x] Invoice list loads on billing page
+- [x] No console errors on any settings page


### PR DESCRIPTION
## Summary
- Remove Connected Services section from General page (already accessible via Integrations tab)
- Remove Billing section from General page and create dedicated /dashboard/settings/billing route
- Add Billing tab to settings sidebar (both desktop and mobile)
- Clean up General page data fetching (4 queries reduced to 2)

Closes #2155

## Changelog
- Removed redundant Connected Services link card from General settings page
- Removed Billing section from General settings page
- Created new Billing page at /dashboard/settings/billing with full billing UI
- Added Billing tab to settings sidebar navigation
- Optimized General page queries (removed billing-related fetches)
- Updated tests to match slimmed-down SettingsContent props

## Test plan
- [x] 16/16 unit tests pass (settings-page.test.tsx)
- [x] TypeScript typecheck passes
- [x] 9/9 review agents found 0 issues
- [x] General page shows Account, Project, API Key, Danger Zone only
- [x] Billing page renders at /dashboard/settings/billing
- [x] Settings sidebar shows 4 tabs: General, Team, Integrations, Billing

Generated with [Claude Code](https://claude.com/claude-code)