### PR TITLE
fix(build): move KB_BINARY_RESPONSE_CSP out of route.ts to unblock release

### DIFF
--- a/apps/web-platform/app/api/kb/content/[...path]/route.ts
+++ b/apps/web-platform/app/api/kb/content/[...path]/route.ts
@@ -10,6 +10,7 @@ import {
   KbValidationError,
 } from "@/server/kb-reader";
 import { isPathInWorkspace } from "@/server/sandbox";
+import { KB_BINARY_RESPONSE_CSP } from "@/lib/kb-csp";
 
 const CONTENT_TYPE_MAP: Record<string, string> = {
   ".png": "image/png",
@@ -28,9 +29,6 @@ const CONTENT_TYPE_MAP: Record<string, string> = {
 const ATTACHMENT_EXTENSIONS = new Set([".docx"]);
 
 const MAX_BINARY_SIZE = 50 * 1024 * 1024; // 50 MB
-
-export const KB_BINARY_RESPONSE_CSP =
-  "default-src 'none'; style-src 'unsafe-inline'; frame-ancestors 'none'";
 
 export async function GET(
   _request: Request,

--- a/apps/web-platform/lib/kb-csp.ts
+++ b/apps/web-platform/lib/kb-csp.ts
@@ -1,0 +1,10 @@
+/**
+ * CSP applied to binary content responses from /api/kb/content/[...path].
+ *
+ * Lives in `lib/` (not in the route handler file) because Next.js App Router
+ * rejects non-standard exports from `route.ts` -- only HTTP method handlers
+ * and a small allow-list (`runtime`, `dynamic`, `revalidate`, etc.) are
+ * permitted. Exporting this constant from route.ts breaks `next build`.
+ */
+export const KB_BINARY_RESPONSE_CSP =
+  "default-src 'none'; style-src 'unsafe-inline'; frame-ancestors 'none'";

--- a/apps/web-platform/test/kb-content-csp.test.ts
+++ b/apps/web-platform/test/kb-content-csp.test.ts
@@ -5,7 +5,7 @@
  * cosmetic reformatting of the literal string.
  */
 import { describe, it, expect } from "vitest";
-import { KB_BINARY_RESPONSE_CSP } from "@/app/api/kb/content/[...path]/route";
+import { KB_BINARY_RESPONSE_CSP } from "@/lib/kb-csp";
 
 function parseCsp(policy: string): Map<string, string[]> {
   const directives = new Map<string, string[]>();


### PR DESCRIPTION
## Summary
PR #2265 broke the production build by exporting `KB_BINARY_RESPONSE_CSP` directly from `app/api/kb/content/[...path]/route.ts`. Next.js App Router rejects non-standard exports from `route.ts` -- only HTTP method handlers and a small allow-list (`runtime`, `dynamic`, `revalidate`, etc.) are permitted.

```
Type error: Route "app/api/kb/content/[...path]/route.ts" does not match the required types of a Next.js Route.
  "KB_BINARY_RESPONSE_CSP" is not a valid Route export field.
```

Result: 5 consecutive Web Platform Release runs failed since #2265 merged at 10:02 UTC; production has been running stale code.

This PR moves the constant to `apps/web-platform/lib/kb-csp.ts` and updates the route + test to import from there. Verified locally with `next build` (passes) and the behavioral CSP test (4/4 pass).

## Changelog
### Web Platform
- Move `KB_BINARY_RESPONSE_CSP` from `route.ts` to `lib/kb-csp.ts` so the Next.js App Router build accepts it.

## Test plan
- [x] `next build` passes locally
- [x] `vitest run test/kb-content-csp.test.ts` -- 4/4 pass
- [ ] ⏳ Web Platform Release workflow succeeds after merge

Generated with [Claude Code](https://claude.com/claude-code)