### PR TITLE
fix(kb): dynamic-import PdfPreview in shared viewer to avoid SSR crash

### DIFF
--- a/apps/web-platform/app/shared/[token]/page.tsx
+++ b/apps/web-platform/app/shared/[token]/page.tsx
@@ -2,9 +2,23 @@
 
 import { useState, useEffect, use } from "react";
 import Link from "next/link";
+import dynamic from "next/dynamic";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
 import { CtaBanner } from "@/components/shared/cta-banner";
-import { PdfPreview } from "@/components/kb/pdf-preview";
+
+// Dynamic import with ssr: false — pdf-preview touches `import.meta.url` and
+// pdfjs worker globals at module load, which fail during server render.
+const PdfPreview = dynamic(
+  () => import("@/components/kb/pdf-preview").then((mod) => mod.PdfPreview),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex items-center justify-center p-8">
+        <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-600 border-t-amber-400" />
+      </div>
+    ),
+  },
+);
 
 type SharedData =
   | { kind: "markdown"; content: string; path: string }


### PR DESCRIPTION
## Summary
- Production hotfix. `/shared/<token>` returned 500 on every request after web-v0.35.19 shipped because the page imported `PdfPreview` statically; `pdf-preview.tsx` touches `new URL(..., import.meta.url)` and pdfjs worker globals at module load and throws during Next.js SSR.
- Wrap in `next/dynamic({ ssr: false })` mirroring the working pattern in `components/kb/file-preview.tsx`.
- Discovered post-merge of #2282 while verifying the release.

Ref #2232

## Changelog

### Web Platform

- **fix(kb):** Restore `/shared/<token>` — PDFs now render inline again, markdown/image/download branches unblocked.

## Test plan

- [x] Regression tests pass: kb-share-allowed-paths, shared-page-binary, shared-page-ui, kb-page-routing, kb-content-binary (38/38)
- [x] Mirrors existing working pattern in `components/kb/file-preview.tsx`
- [ ] ⏳ Post-merge: `curl -I https://app.soleur.ai/shared/nonexistent` returns 200 (or 404 JSON from error state) — not 500

Generated with [Claude Code](https://claude.com/claude-code)