### PR TITLE
fix(ux-audit): use valid setup-bun SHA in scheduled-ux-audit.yml

### DIFF
--- a/.github/workflows/scheduled-ux-audit.yml
+++ b/.github/workflows/scheduled-ux-audit.yml
@@ -89,7 +89,7 @@ jobs:
           done
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a829280e9b607f # v2.0.2
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
         with:
           bun-version-file: .bun-version
 


### PR DESCRIPTION
## Summary

The `oven-sh/setup-bun@4bc047ad...` SHA pinned in #2346 does not exist. Post-merge validation run for `scheduled-ux-audit.yml` failed at `Set up job` with:
```
Unable to resolve action `oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a829280e9b607f`, unable to find version
```

Replacing with `3d267786b128fe76c2f16a390aa2448b815359f3` (v2.1.2), the SHA already used by `ci.yml`, `scheduled-ship-merge.yml`, and `main-health-monitor.yml`. Verified via `gh api /repos/oven-sh/setup-bun/commits/<sha>`.

Ref #2346 follow-up #2369

## Changelog

### CI / Governance

- Fix invalid setup-bun pinned SHA in `scheduled-ux-audit.yml`

## Test plan

- [x] actionlint clean
- [x] SHA verified real via GitHub API
- [ ] ⏳ Post-merge: `gh workflow run scheduled-ux-audit.yml --ref main --field dry_run=true` succeeds past Set up job