### PR TITLE
fix(ci): preserve trailing '=' in Doppler env-no-quotes parse

### DIFF
--- a/.github/workflows/scheduled-community-monitor.yml
+++ b/.github/workflows/scheduled-community-monitor.yml
@@ -53,7 +53,12 @@ jobs:
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_SCHEDULED }}
         run: |
-          doppler secrets download --project soleur --config prd_scheduled --no-file --format env-no-quotes | while IFS='=' read -r key value; do
+          # Use parameter expansion so values ending in '=' (e.g. base64-padded
+          # secrets) keep their trailing char; IFS='=' read strips trailing
+          # delimiters from the last field.
+          doppler secrets download --project soleur --config prd_scheduled --no-file --format env-no-quotes | while IFS= read -r line; do
+            key="${line%%=*}"
+            value="${line#*=}"
             [ -z "$key" ] && continue
             printf '::add-mask::%s\n' "$value"
             printf '%s=%s\n' "$key" "$value" >> "$GITHUB_ENV"

--- a/.github/workflows/scheduled-ux-audit.yml
+++ b/.github/workflows/scheduled-ux-audit.yml
@@ -71,7 +71,13 @@ jobs:
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_SCHEDULED }}
         run: |
-          doppler secrets download --project soleur --config prd_scheduled --no-file --format env-no-quotes | while IFS='=' read -r key value; do
+          # Use parameter expansion (not IFS='=' read) so values ending in '='
+          # — e.g. base64-padded passwords from `openssl rand -base64 N` — keep
+          # their trailing char. IFS='=' strips trailing delimiters from the
+          # last field on `read`.
+          doppler secrets download --project soleur --config prd_scheduled --no-file --format env-no-quotes | while IFS= read -r line; do
+            key="${line%%=*}"
+            value="${line#*=}"
             [ -z "$key" ] && continue
             printf '::add-mask::%s\n' "$value"
             printf '%s=%s\n' "$key" "$value" >> "$GITHUB_ENV"
@@ -82,7 +88,9 @@ jobs:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_PRD }}
         run: |
           doppler secrets download --project soleur --config prd --no-file --format env-no-quotes \
-            --only-secrets SUPABASE_URL,SUPABASE_SERVICE_ROLE_KEY,NEXT_PUBLIC_SUPABASE_ANON_KEY,NEXT_PUBLIC_SITE_URL | while IFS='=' read -r key value; do
+            --only-secrets SUPABASE_URL,SUPABASE_SERVICE_ROLE_KEY,NEXT_PUBLIC_SUPABASE_ANON_KEY,NEXT_PUBLIC_SITE_URL | while IFS= read -r line; do
+            key="${line%%=*}"
+            value="${line#*=}"
             [ -z "$key" ] && continue
             printf '::add-mask::%s\n' "$value"
             printf '%s=%s\n' "$key" "$value" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

The Doppler-secrets injection pattern shared by `scheduled-ux-audit.yml` and `scheduled-community-monitor.yml` used `IFS='=' read -r key value`. That pattern strips trailing IFS chars from the last field, so a base64-padded secret ending in `=` (produced by `openssl rand -base64 N`) was losing its final `=`.

Symptom: `scheduled-ux-audit.yml` post-merge validation run (24468782597) failed at `Sign in as bot` with "Invalid login credentials" — Supabase received the password missing its last char.

Fix: replace `IFS='=' read -r key value` with parameter expansion (`\${line%%=*}` / `\${line#*=}`), which preserves the trailing `=`. Same fix applied to `scheduled-community-monitor.yml` (same bug, had not been observed because that workflow's secrets happen not to end in `=`).

Verified locally: the old parse returns 43 chars for the 44-char `UX_AUDIT_BOT_PASSWORD`; the new parse returns all 44 with the trailing `=` intact.

Ref #2346, #2369

## Changelog

### CI / Governance

- Fix Doppler env-no-quotes line parser to preserve trailing `=` in base64-padded secrets

## Test plan

- [x] actionlint clean on both modified workflows
- [x] Local verification: parameter-expansion parse preserves full 44-char password; `IFS='=' read` strips 1 char
- [ ] ⏳ Post-merge: re-trigger `scheduled-ux-audit.yml --field dry_run=true` and verify `Sign in as bot` succeeds