### PR TITLE
fix(web-platform): move analytics throttle out of route.ts (Next.js 15 constraint)

### DIFF
--- a/apps/web-platform/app/api/analytics/track/route.ts
+++ b/apps/web-platform/app/api/analytics/track/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
-import { SlidingWindowCounter } from "@/server/rate-limiter";
 import { createChildLogger } from "@/server/logger";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
+import { analyticsTrackThrottle } from "./throttle";
 
 // Phase 5.2: same-origin-checked, per-IP rate-limited analytics forwarder.
 //
@@ -11,18 +11,11 @@ import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 // rate cap. We strip any `user_id`/`userId` from forwarded props so a stable
 // identifier never reaches a third-party tool without a documented salt
 // rotation strategy (see plan 5.2 + learning 2026-03-30-plausible-http-402).
+//
+// Non-HTTP-method exports are forbidden in Next.js 15 App Router route files.
+// The throttle + test reset helper live in ./throttle.ts.
 
 const log = createChildLogger("analytics-track");
-
-const RATE_PER_MIN = parseInt(
-  process.env.ANALYTICS_TRACK_RATE_PER_MIN ?? "120",
-  10,
-);
-
-export const analyticsTrackThrottle = new SlidingWindowCounter({
-  windowMs: 60_000,
-  maxRequests: RATE_PER_MIN,
-});
 
 function clientIp(req: Request): string {
   const xff = req.headers.get("x-forwarded-for");
@@ -134,9 +127,4 @@ export async function POST(req: Request): Promise<Response> {
 
 export async function GET(): Promise<Response> {
   return NextResponse.json({ error: "method_not_allowed" }, { status: 405 });
-}
-
-/** Test-only helper: clear the in-memory throttle between tests. */
-export function __resetAnalyticsTrackThrottleForTest(): void {
-  analyticsTrackThrottle.reset();
 }

--- a/apps/web-platform/app/api/analytics/track/throttle.ts
+++ b/apps/web-platform/app/api/analytics/track/throttle.ts
@@ -1,0 +1,22 @@
+// Sliding-window throttle for the /api/analytics/track route.
+//
+// Lives in a sibling module (not the route file) because Next.js 15's
+// App Router rejects any non-HTTP-method export from a route file with
+// "Type error: Route ... does not match the required types of a Next.js
+// Route." See review fix for PR #2347 post-merge Docker build failure.
+import { SlidingWindowCounter } from "@/server/rate-limiter";
+
+const RATE_PER_MIN = parseInt(
+  process.env.ANALYTICS_TRACK_RATE_PER_MIN ?? "120",
+  10,
+);
+
+export const analyticsTrackThrottle = new SlidingWindowCounter({
+  windowMs: 60_000,
+  maxRequests: RATE_PER_MIN,
+});
+
+/** Test-only helper: clear the in-memory throttle between tests. */
+export function __resetAnalyticsTrackThrottleForTest(): void {
+  analyticsTrackThrottle.reset();
+}


### PR DESCRIPTION
## Summary

Hotfix for a production release failure introduced by PR #2347 (KB chat sidebar). \`next build\` rejects non-HTTP-method exports from App Router route files, so the \`analyticsTrackThrottle\` (stateful SlidingWindowCounter instance) and \`__resetAnalyticsTrackThrottleForTest\` helper move from \`route.ts\` to a sibling \`throttle.ts\` module.

## Root cause

Next.js 15's route-file validator allows only framework-recognized exports (\`GET\`/\`POST\`/etc.). Vitest passed because it loads the module as a plain ES import without running the route validator. Only \`next build\` (or \`next lint\`) catches this.

Production outage window: ~1 minute (merge of #2347 at 20:55 UTC, Web Platform Release failed at 20:57 UTC on run [24477947581](https://github.com/jikig-ai/soleur/actions/runs/24477947581)).

## Changelog

### Web Platform

- Moved \`analyticsTrackThrottle\` and \`__resetAnalyticsTrackThrottleForTest\` from \`app/api/analytics/track/route.ts\` to a new sibling module \`app/api/analytics/track/throttle.ts\`. The route imports from there. No behavior change.

## Test plan

- [x] \`npx next build\` → Compiled successfully in 55s
- [x] \`test/api-analytics-track.test.ts\` → 10/10 pass (tests already isolated the stateful counter via \`vi.resetModules()\` + env-var reset, no direct import of the helper)
- [x] \`tsc --noEmit\` → clean
- [ ] Web Platform Release workflow succeeds on this merge

## Follow-up

Filing a separate issue to add a pre-push check that catches non-HTTP-method exports from App Router route files — the class of bug should never reach main again.

Generated with [Claude Code](https://claude.com/claude-code)