### PR TITLE
fix(ci): remove push trigger and replace --only-secrets in ux-audit workflow

### DIFF
--- a/.github/workflows/scheduled-ux-audit.yml
+++ b/.github/workflows/scheduled-ux-audit.yml
@@ -4,9 +4,13 @@
 # findings as a workflow artifact.
 #
 # Triggers:
-#   push (main)   — auto-run on merges that touch web-platform UI
 #   cron monthly  — safety net for quiet UI-change months
 #   manual        — founder-triggered (no inputs; always dry-run)
+#
+# The push trigger was removed because claude-code-action does not support
+# push events (throws "Unsupported event type: push"). If dry-run mode is
+# ever disabled, re-add push via the workflow_run pattern — see plan
+# 2026-04-16-fix-ux-audit-workflow-crashes-plan.md. Ref: #2376.
 #
 # Security: no untrusted event inputs are interpolated in run: blocks. Agent
 # output is written to files inside the action and referenced via env vars.
@@ -25,11 +29,6 @@
 name: "Scheduled: UX Audit"
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'apps/web-platform/app/**'
-      - 'apps/web-platform/components/**'
   schedule:
     - cron: '0 9 1 * *'
   workflow_dispatch: {}
@@ -89,8 +88,10 @@ jobs:
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_PRD }}
         run: |
+          allowed="SUPABASE_URL|SUPABASE_SERVICE_ROLE_KEY|NEXT_PUBLIC_SUPABASE_ANON_KEY|NEXT_PUBLIC_SITE_URL"
           doppler secrets download --project soleur --config prd --no-file --format env-no-quotes \
-            --only-secrets SUPABASE_URL,SUPABASE_SERVICE_ROLE_KEY,NEXT_PUBLIC_SUPABASE_ANON_KEY,NEXT_PUBLIC_SITE_URL | while IFS= read -r line; do
+            | grep -E "^($allowed)=" \
+            | while IFS= read -r line; do
             key="${line%%=*}"
             value="${line#*=}"
             [ -z "$key" ] && continue

--- a/knowledge-base/project/learnings/integration-issues/claude-code-action-unsupported-push-event-and-doppler-only-secrets-20260416.md
+++ b/knowledge-base/project/learnings/integration-issues/claude-code-action-unsupported-push-event-and-doppler-only-secrets-20260416.md
@@ -1,0 +1,107 @@
+---
+module: System
+date: 2026-04-16
+problem_type: integration_issue
+component: development_workflow
+symptoms:
+  - "claude-code-action throws 'Unsupported event type: push' on push-triggered workflow runs"
+  - "Doppler CLI prints error for invalid --only-secrets flag but exits 0, leaking all prd secrets into GITHUB_ENV"
+  - "Issue #2376 misdiagnosed the error as an SDK/Ajv crash when it was minified source context around a credit balance error"
+root_cause: config_error
+resolution_type: config_change
+severity: high
+tags: [claude-code-action, github-actions, doppler, workflow, misdiagnosis]
+---
+
+# Troubleshooting: claude-code-action unsupported push event and Doppler --only-secrets flag
+
+## Problem
+
+The `Scheduled: UX Audit` workflow failed on all push-triggered runs with two root causes, both in the workflow YAML. The issue report (#2376) misdiagnosed the primary failure as an SDK/Ajv crash, when in reality the minified Ajv code was source context around a "Credit balance is too low" error -- not the error itself.
+
+## Environment
+
+- Module: System (CI/CD)
+- Affected Component: `.github/workflows/scheduled-ux-audit.yml`
+- Date: 2026-04-16
+- claude-code-action versions tested: v1.0.75 (pinned), v1.0.97 (latest)
+- Doppler CLI version: v3.75.3
+
+## Symptoms
+
+- Push-triggered workflow runs fail with `Unsupported event type: push` before SDK/schema validation runs
+- Doppler step prints `Error: unknown flag: --only-secrets` but exits 0 (non-blocking)
+- All prd secrets leak into `$GITHUB_ENV` instead of just the 4 intended ones
+- Issue report described "SDK/Ajv crash" that was actually minified source context
+
+## What Didn't Work
+
+**Attempted Solution 1:** PR #2371 fixed an invalid setup-bun SHA
+
+- **Why it failed:** Addressed a different problem; the push event and --only-secrets issues remained
+
+**Attempted Solution 2:** PR #2373 fixed Doppler `IFS='='` trailing-`=` loss
+
+- **Why it failed:** Fixed a real parsing bug but did not address the unsupported event type or invalid flag
+
+**Attempted Solution 3:** Investigating Ajv schema validation (as described in issue #2376)
+
+- **Why it failed:** Misdiagnosis. Two successful `workflow_dispatch` runs (24472727054, 24469469972) proved the SDK, plugin schemas, and Ajv validation work correctly. The "Ajv crash" was minified source context around line 19 of `sdk.mjs`.
+
+## Solution
+
+Two changes to `.github/workflows/scheduled-ux-audit.yml`:
+
+**Fix 1: Remove push trigger**
+
+```yaml
+# Before (broken):
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/web-platform/app/**'
+      - 'apps/web-platform/components/**'
+  schedule:
+    - cron: '0 9 1 * *'
+  workflow_dispatch: {}
+
+# After (fixed):
+on:
+  schedule:
+    - cron: '0 9 1 * *'
+  workflow_dispatch: {}
+```
+
+**Fix 2: Replace --only-secrets with grep filter**
+
+```yaml
+# Before (broken):
+doppler secrets download --project soleur --config prd --no-file --format env-no-quotes \
+  --only-secrets SUPABASE_URL,SUPABASE_SERVICE_ROLE_KEY,NEXT_PUBLIC_SUPABASE_ANON_KEY,NEXT_PUBLIC_SITE_URL | while IFS= read -r line; do
+
+# After (fixed):
+allowed="SUPABASE_URL|SUPABASE_SERVICE_ROLE_KEY|NEXT_PUBLIC_SUPABASE_ANON_KEY|NEXT_PUBLIC_SITE_URL"
+doppler secrets download --project soleur --config prd --no-file --format env-no-quotes \
+  | grep -E "^($allowed)=" \
+  | while IFS= read -r line; do
+```
+
+## Why This Works
+
+1. **Push event unsupported:** `claude-code-action`'s `parseGitHubContext()` only handles: `issues`, `issue_comment`, `pull_request`, `pull_request_target`, `pull_request_review`, `pull_request_review_comment`, `workflow_dispatch`, `repository_dispatch`, `schedule`, `workflow_run`. Push events hit the `default` case and throw. Removing the push trigger eliminates the unsupported event entirely. Monthly cron + manual dispatch are sufficient while dry-run mode is permanent.
+
+2. **--only-secrets does not exist:** The flag was never part of the Doppler CLI (v3.75+). The `grep -E "^($allowed)="` filter restricts secrets to the 4 intended keys. The `^` anchor + `=` delimiter prevent substring matches (e.g., `SUPABASE_URL_BACKUP` cannot match `SUPABASE_URL`). Under GitHub Actions' `bash -e` (no `pipefail`), `grep` exit 1 on no matches does not fail the step because `while read` (exit 0) is the pipeline's last command.
+
+## Prevention
+
+- Before using a CLI flag in a workflow, verify it exists in the tool's `--help` output or documentation -- don't assume flags from memory or other tools
+- Check `claude-code-action`'s supported event list before adding new trigger types to workflows that use it
+- When debugging minified error output, look for the actual error message in surrounding lines rather than focusing on the minified code fragment that happens to be displayed
+
+## Related Issues
+
+- See also: [claude-code-action-token-revocation](../2026-03-02-claude-code-action-token-revocation-breaks-persist-step.md) -- another claude-code-action integration issue
+- See also: [doppler-service-token-config-scope-mismatch](../2026-03-29-doppler-service-token-config-scope-mismatch.md) -- Doppler service token scoping
+- See also: [ux-audit-calibration-miss-path](../2026-04-15-ux-audit-calibration-miss-path.md) -- why dry-run mode is permanent
+- Ref: #2376 (this fix), #2346 (original workflow), #2371, #2373, #2392 (prior fix attempts)

--- a/knowledge-base/project/plans/2026-04-16-fix-ux-audit-workflow-crashes-plan.md
+++ b/knowledge-base/project/plans/2026-04-16-fix-ux-audit-workflow-crashes-plan.md
@@ -1,0 +1,121 @@
+---
+title: "fix: resolve scheduled-ux-audit.yml failures (push event, Doppler flag)"
+type: fix
+date: 2026-04-16
+issue: 2376
+related: [2341, 2342, 2346, 2371, 2373, 2392]
+branch: feat-fix-ux-audit-sdk-crash
+worktree: .worktrees/feat-fix-ux-audit-sdk-crash/
+---
+
+# fix: resolve scheduled-ux-audit.yml failures (push event, Doppler flag)
+
+## Overview
+
+The `Scheduled: UX Audit` workflow (`.github/workflows/scheduled-ux-audit.yml`) is failing on all `push`-triggered runs and has an invalid Doppler CLI flag. Two root causes, both in the workflow YAML:
+
+1. **Primary**: `claude-code-action` does not support `push` events. The action's `parseGitHubContext()` only handles: `issues`, `issue_comment`, `pull_request`, `pull_request_target`, `pull_request_review`, `pull_request_review_comment`, `workflow_dispatch`, `repository_dispatch`, `schedule`, `workflow_run`. Push events hit the `default` case and throw `Unsupported event type: push`. This is confirmed in both the pinned version (v1.0.75) and the latest (v1.0.97).
+
+2. **Secondary**: `--only-secrets` flag on line 93 does not exist in Doppler CLI v3.75+. The command prints an error but exits 0, so downstream steps still receive all secrets (not just the filtered set).
+
+## Research Reconciliation -- Issue Description vs. Codebase
+
+| Issue claim | Reality | Plan response |
+|---|---|---|
+| SDK/Ajv crash during claude-code-action startup is the primary blocker | The Ajv `dependencies` code in the error output is minified source context around line 19 of `sdk.mjs`, not the actual error. Run 24469143935 shows the real error: "Credit balance is too low". Two successful `workflow_dispatch` runs (24472727054, 24469469972) prove the SDK, plugin schemas (`.mcp.json`, `plugin.json`), and Ajv validation work correctly. | Drop the Ajv/schema investigation entirely. The "SDK crash" is a misread of the error output format. |
+| Push-triggered runs fail with SDK crash | They fail with `Unsupported event type: push` before any SDK/schema validation runs. | Fix the `push` trigger by converting it to a supported event type. |
+| `--only-secrets` flag is secondary/non-blocking | Confirmed: Doppler prints error but exits 0. All secrets leak into `$GITHUB_ENV` instead of just the 4 intended ones. | Fix with grep filter approach (as described in issue). |
+
+## Proposed Solution
+
+### Fix 1: Convert `push` trigger to `workflow_run` (or remove it)
+
+`claude-code-action` supports `schedule`, `workflow_dispatch`, `repository_dispatch`, and `workflow_run` as automation events. Two options:
+
+**Option A (recommended): Remove the `push` trigger entirely.**
+
+The workflow already has a monthly cron (`0 9 1 * *`) and manual `workflow_dispatch`. The `push` trigger was intended to catch UI changes on merge, but `UX_AUDIT_DRY_RUN` is permanently `true` (per #2392 calibration MISS outcome). Running the full audit on every push that touches `apps/web-platform/app/**` or `components/**` is expensive ($3.55/run per run 24474065455) and produces artifacts that require manual founder review. The monthly cron and manual dispatch are sufficient for the dry-run-only mode.
+
+**Option B: Convert `push` to `workflow_run` trigger.**
+
+Create a lightweight "trigger" workflow that runs on `push` to `main` with the same path filters, and have `scheduled-ux-audit.yml` trigger via `workflow_run` on that workflow. This preserves the event-driven path but adds complexity. Only worth doing if/when `UX_AUDIT_DRY_RUN` is flipped to `false`.
+
+**Decision: Option A.** Remove the `push` trigger. Add a comment documenting why (link to this plan and the `Unsupported event type: push` error). When dry-run mode is disabled in the future (requires calibration pass per #2392), the `push` trigger can be re-added via the `workflow_run` pattern.
+
+### Fix 2: Replace `--only-secrets` with grep filter
+
+Replace the invalid `--only-secrets` flag in the "Inject Doppler secrets (prd)" step with a `grep -E` filter that restricts which secrets are injected into `$GITHUB_ENV`.
+
+**Before (line 92-99):**
+
+```yaml
+doppler secrets download --project soleur --config prd --no-file --format env-no-quotes \
+  --only-secrets SUPABASE_URL,SUPABASE_SERVICE_ROLE_KEY,NEXT_PUBLIC_SUPABASE_ANON_KEY,NEXT_PUBLIC_SITE_URL | while IFS= read -r line; do
+```
+
+**After:**
+
+```yaml
+allowed="SUPABASE_URL|SUPABASE_SERVICE_ROLE_KEY|NEXT_PUBLIC_SUPABASE_ANON_KEY|NEXT_PUBLIC_SITE_URL"
+doppler secrets download --project soleur --config prd --no-file --format env-no-quotes \
+  | grep -E "^($allowed)=" \
+  | while IFS= read -r line; do
+```
+
+## Implementation Phases
+
+### Phase 1: Fix the workflow file (single commit)
+
+Both fixes are in `.github/workflows/scheduled-ux-audit.yml`:
+
+1. **Remove `push` trigger block** (lines 28-31). Keep `schedule` and `workflow_dispatch`.
+2. **Replace `--only-secrets` with grep filter** (lines 92-93). Use the `allowed` variable + `grep -E` pattern.
+3. **Update workflow header comment** to document the removal of the `push` trigger and the reason.
+
+Files to modify:
+
+- `.github/workflows/scheduled-ux-audit.yml`
+
+### Phase 2: Verify
+
+1. Push the branch and trigger a manual workflow run: `gh workflow run scheduled-ux-audit.yml`.
+2. Verify the Doppler step no longer prints the `--only-secrets` error.
+3. Verify the `claude-code-action` step runs (no `Unsupported event type` error).
+4. Confirm the workflow completes (success or expected `error_max_turns`/dry-run behavior).
+
+## Acceptance Criteria
+
+- [ ] `push` trigger is removed from `scheduled-ux-audit.yml`
+- [ ] `--only-secrets` flag is replaced with `grep -E` filter restricting to 4 named secrets
+- [ ] Workflow header comment documents the `push` trigger removal with rationale
+- [ ] Manual `workflow_dispatch` run succeeds past the Doppler and `claude-code-action` steps
+
+## Test Scenarios
+
+- Given a `workflow_dispatch` trigger, when the workflow runs, then the Doppler step outputs no `Error: unknown flag` and the `claude-code-action` step does not throw `Unsupported event type`.
+- Given the grep filter in the prd Doppler step, when secrets are downloaded, then only `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and `NEXT_PUBLIC_SITE_URL` are injected into `$GITHUB_ENV`.
+- Given a push to main touching `apps/web-platform/app/**`, when the push event fires, then the `scheduled-ux-audit.yml` workflow does NOT trigger (push trigger removed).
+
+## Alternative Approaches Considered
+
+| Approach | Why not |
+|---|---|
+| Fix `claude-code-action` upstream to support `push` events | Not in our control. Even if a PR were accepted, we'd be blocked until it ships. The `push` trigger is also expensive in dry-run-only mode. |
+| Use `repository_dispatch` with a separate trigger workflow | Adds complexity for no benefit while dry-run is permanent. Reconsider when calibration passes. |
+| Investigate Ajv schema validation | Misdiagnosis. The SDK works fine -- two successful runs prove it. The "Ajv crash" was minified source context around a "Credit balance is too low" error. |
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected -- CI workflow bug fix.
+
+## References
+
+- Issue: #2376
+- Successful runs (workflow_dispatch): 24472727054, 24469469972
+- Failed runs (push): 24478421961, 24477947551
+- Failed run (credit balance): 24469143935
+- `claude-code-action` supported events: `src/github/context.ts` in `anthropics/claude-code-action`
+- Prior fix PRs: #2346, #2371, #2373, #2392
+- Calibration MISS learning: `knowledge-base/project/learnings/2026-04-15-ux-audit-calibration-miss-path.md`

--- a/knowledge-base/project/plans/2026-04-16-fix-ux-audit-workflow-crashes-plan.md
+++ b/knowledge-base/project/plans/2026-04-16-fix-ux-audit-workflow-crashes-plan.md
@@ -8,6 +8,25 @@ branch: feat-fix-ux-audit-sdk-crash
 worktree: .worktrees/feat-fix-ux-audit-sdk-crash/
 ---
 
+## Enhancement Summary
+
+**Deepened on:** 2026-04-16
+**Sections enhanced:** 3 (Fix 2 edge cases, Implementation verification, Test Scenarios)
+**Research sources:** Workflow run logs (5 runs analyzed), `claude-code-action` source (v1.0.75 + v1.0.97), Doppler learnings, CI shell behavior analysis
+
+### Key Improvements
+
+1. Confirmed `grep -E` filter is safe under `bash -e` without `pipefail` (GitHub Actions default for user `run:` blocks) -- `while read` is the last pipeline command and exits 0 even when grep finds no matches
+2. Added edge case: if Doppler `prd` config loses any of the 4 expected secrets, grep silently produces no output -- added diagnostic `echo` to surface this
+3. Identified that `claude-code-action` v1.0.97 (latest) still does not support `push` events, confirming removal is the only viable path without an upstream PR
+
+### Relevant Institutional Learnings Applied
+
+- `2026-03-29-doppler-service-token-config-scope-mismatch.md`: Confirms the workflow correctly uses `DOPPLER_TOKEN_PRD` (config-specific secret name) -- no scope mismatch risk
+- `2026-02-21-github-actions-workflow-security-patterns.md`: All actions in the workflow are already SHA-pinned -- no changes needed
+- `knowledge-base/project/learnings/bug-fixes/2026-04-15-signed-get-verify-step-tolerate-non-json-bodies.md`: Pattern of pre-validating command output before parsing applies to the grep filter (though less critical here since grep output is plain text, not JSON)
+- Constitution `set -euo pipefail` audit vector: `grep` in pipelines returns exit 1 on no match, which `-o pipefail` would propagate -- but user `run:` blocks use `bash -e` only (no `pipefail`), so the `while read` command's exit code (0) governs the pipeline
+
 # fix: resolve scheduled-ux-audit.yml failures (push event, Doppler flag)
 
 ## Overview
@@ -62,6 +81,36 @@ doppler secrets download --project soleur --config prd --no-file --format env-no
   | while IFS= read -r line; do
 ```
 
+### Research Insights (Fix 2)
+
+**Shell pipeline behavior under `bash -e`:**
+
+GitHub Actions user `run:` blocks use `bash -e` without `-o pipefail` (confirmed from run logs: `shell: /usr/bin/bash -e {0}`). In a `cmd1 | cmd2` pipeline under `bash -e`:
+
+- Only the **last** command's exit code determines step success/failure
+- `grep -E` returning exit 1 (no matches) does NOT fail the step because `while read` (exit 0) is the pipeline's last command
+- If `pipefail` were enabled, `grep` exit 1 would propagate -- but it is not
+
+**Edge case -- missing secrets in Doppler `prd` config:**
+
+If any of the 4 expected secrets (`SUPABASE_URL`, etc.) are missing from the Doppler `prd` config, `grep` silently produces no output for that key. The downstream steps (`bot-fixture.ts seed`, `bot-signin.ts`) would then fail with missing env vars, but the error message would be opaque ("Missing SUPABASE_URL" at runtime, not at the Doppler injection step).
+
+**Mitigation (optional, low priority):** Add a diagnostic count after the `while` loop:
+
+```bash
+count=$(doppler secrets download --project soleur --config prd --no-file --format env-no-quotes \
+  | grep -cE "^($allowed)=" || true)
+if [ "$count" -lt 4 ]; then
+  echo "::warning::Expected 4 Doppler prd secrets, got $count"
+fi
+```
+
+This is optional because the 4 secrets have been stable in `prd` since the workflow was created (#2346), and a missing secret would surface clearly in the seed/signin steps. Adding the diagnostic is a defense-in-depth improvement, not a required fix.
+
+**Pattern: `grep -E "^(A|B|C)="` prevents substring matches.**
+
+The `^` anchor + `=` delimiter ensure `SUPABASE_URL_BACKUP=...` does NOT match `SUPABASE_URL` -- the regex requires the key to start at the beginning of the line and end with `=` immediately after the key name.
+
 ## Implementation Phases
 
 ### Phase 1: Fix the workflow file (single commit)
@@ -83,6 +132,14 @@ Files to modify:
 3. Verify the `claude-code-action` step runs (no `Unsupported event type` error).
 4. Confirm the workflow completes (success or expected `error_max_turns`/dry-run behavior).
 
+### Research Insights (Verification)
+
+**Verification must happen post-merge, not on the feature branch.** The `claude-code-action` step installs the plugin from `https://github.com/jikig-ai/soleur.git` (the default branch). Running `gh workflow run scheduled-ux-audit.yml --ref feat-fix-ux-audit-sdk-crash` would use the feature branch's workflow YAML (fixing the `push` trigger and `--only-secrets` issues) but the claude-code-action would install the plugin from `main`. Since the fixes are workflow-level only (not plugin code), this is fine -- the feature branch YAML is what gets tested.
+
+**Expected run outcome:** The two successful `workflow_dispatch` runs (24472727054: success, 24469469972: success) prove that once the `push` event and `--only-secrets` errors are eliminated, the workflow runs to completion. The expected outcome for verification is either `success` or `error_max_turns` (the agent hitting 60-turn limit, which is acceptable in dry-run mode -- the findings artifact is still uploaded).
+
+**Cost awareness:** Each successful run costs approximately $3.55 in Anthropic API usage (from run 24474065455). The verification run is necessary but should be limited to one dispatch.
+
 ## Acceptance Criteria
 
 - [ ] `push` trigger is removed from `scheduled-ux-audit.yml`
@@ -95,6 +152,32 @@ Files to modify:
 - Given a `workflow_dispatch` trigger, when the workflow runs, then the Doppler step outputs no `Error: unknown flag` and the `claude-code-action` step does not throw `Unsupported event type`.
 - Given the grep filter in the prd Doppler step, when secrets are downloaded, then only `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and `NEXT_PUBLIC_SITE_URL` are injected into `$GITHUB_ENV`.
 - Given a push to main touching `apps/web-platform/app/**`, when the push event fires, then the `scheduled-ux-audit.yml` workflow does NOT trigger (push trigger removed).
+
+### Research Insights (Test Scenarios)
+
+**Verification command sequence (post-merge):**
+
+```bash
+# 1. Trigger a manual run
+gh workflow run scheduled-ux-audit.yml
+
+# 2. Get the run ID (wait a few seconds for it to appear)
+RUN_ID=$(gh run list --workflow=scheduled-ux-audit.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+
+# 3. Check the Doppler step output for the --only-secrets error
+gh run view "$RUN_ID" --log 2>&1 | grep -c "unknown flag: --only-secrets"
+# Expected: 0 (no matches)
+
+# 4. Check for the Unsupported event type error
+gh run view "$RUN_ID" --log 2>&1 | grep -c "Unsupported event type"
+# Expected: 0 (no matches)
+
+# 5. Verify the claude-code-action step reached SDK execution
+gh run view "$RUN_ID" --log 2>&1 | grep "Running Claude Code via SDK"
+# Expected: match found (SDK started)
+```
+
+**Negative test -- push trigger removal:** After merging, push a trivial change to `apps/web-platform/app/` (e.g., whitespace in a comment). Verify via `gh run list --workflow=scheduled-ux-audit.yml --limit 3` that no new run was triggered by the push event.
 
 ## Alternative Approaches Considered
 

--- a/knowledge-base/project/plans/2026-04-16-fix-ux-audit-workflow-crashes-plan.md
+++ b/knowledge-base/project/plans/2026-04-16-fix-ux-audit-workflow-crashes-plan.md
@@ -142,9 +142,9 @@ Files to modify:
 
 ## Acceptance Criteria
 
-- [ ] `push` trigger is removed from `scheduled-ux-audit.yml`
-- [ ] `--only-secrets` flag is replaced with `grep -E` filter restricting to 4 named secrets
-- [ ] Workflow header comment documents the `push` trigger removal with rationale
+- [x] `push` trigger is removed from `scheduled-ux-audit.yml`
+- [x] `--only-secrets` flag is replaced with `grep -E` filter restricting to 4 named secrets
+- [x] Workflow header comment documents the `push` trigger removal with rationale
 - [ ] Manual `workflow_dispatch` run succeeds past the Doppler and `claude-code-action` steps
 
 ## Test Scenarios

--- a/knowledge-base/project/specs/feat-fix-ux-audit-sdk-crash/session-state.md
+++ b/knowledge-base/project/specs/feat-fix-ux-audit-sdk-crash/session-state.md
@@ -1,0 +1,26 @@
+# Session State
+
+## Plan Phase
+
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-fix-ux-audit-sdk-crash/knowledge-base/project/plans/2026-04-16-fix-ux-audit-workflow-crashes-plan.md
+- Status: complete
+
+### Errors
+
+None
+
+### Decisions
+
+- The "SDK/Ajv crash" described in issue #2376 was a misdiagnosis -- the Ajv code was minified source context around a "Credit balance is too low" error. Two successful workflow_dispatch runs prove the SDK and plugin schemas work correctly. Dropped the Ajv investigation entirely.
+- Chose to remove the `push` trigger from the workflow rather than converting to `workflow_run`, because dry-run mode is permanent (per #2392 calibration MISS) and each run costs ~$3.55. Monthly cron + manual dispatch are sufficient.
+- Chose `grep -E "^($allowed)="` filter approach for Doppler `--only-secrets` replacement, with analysis confirming it is safe under GitHub Actions' `bash -e` shell (no `pipefail` means `grep` exit 1 does not propagate).
+- Identified the actual two root causes: (1) `push` event not in `claude-code-action`'s supported event list, (2) `--only-secrets` flag does not exist in Doppler CLI v3.75+.
+- Optional diagnostic `echo` for missing secrets is documented but not required -- the 4 secrets are stable and failures would surface clearly in downstream steps.
+
+### Components Invoked
+
+- soleur:plan (planning skill)
+- soleur:plan-review (three parallel reviewers)
+- soleur:deepen-plan (research enhancement)
+- GitHub API: 5 workflow runs analyzed, claude-code-action source code inspected
+- Institutional learnings: 4 relevant learnings cross-referenced

--- a/knowledge-base/project/specs/feat-fix-ux-audit-sdk-crash/tasks.md
+++ b/knowledge-base/project/specs/feat-fix-ux-audit-sdk-crash/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: fix scheduled-ux-audit.yml failures
+
+## Phase 1: Fix workflow file
+
+- [ ] 1.1 Remove `push` trigger block from `.github/workflows/scheduled-ux-audit.yml` (lines 28-31)
+- [ ] 1.2 Update workflow header comment to document push trigger removal with rationale
+- [ ] 1.3 Replace `--only-secrets` flag with grep filter in "Inject Doppler secrets (prd)" step (lines 92-93)
+  - [ ] 1.3.1 Add `allowed` variable with pipe-separated secret names
+  - [ ] 1.3.2 Pipe `doppler secrets download` output through `grep -E "^($allowed)="`
+
+## Phase 2: Verify
+
+- [ ] 2.1 Push branch to remote
+- [ ] 2.2 Trigger manual workflow run via `gh workflow run scheduled-ux-audit.yml`
+- [ ] 2.3 Verify Doppler step has no `Error: unknown flag` output
+- [ ] 2.4 Verify `claude-code-action` step runs without `Unsupported event type` error
+- [ ] 2.5 Confirm workflow completes past both fixed steps


### PR DESCRIPTION
## Summary
- Remove unsupported `push` event trigger from `scheduled-ux-audit.yml` — `claude-code-action` does not support push events (throws `Unsupported event type: push`)
- Replace invalid `--only-secrets` Doppler CLI flag with `grep -E` filter restricting prd secrets to the 4 needed Supabase keys
- The issue's reported SDK/Ajv crash was a misdiagnosis — the Ajv code was minified source context around a credit balance error, not the error itself

Closes #2376

## Changelog
- fix: remove push trigger from scheduled-ux-audit.yml (claude-code-action unsupported event)
- fix: replace invalid --only-secrets Doppler flag with grep filter (fixes secret over-exposure)

## Test plan
- [ ] Manual `workflow_dispatch` run succeeds past Doppler and claude-code-action steps (post-merge)
- [ ] Doppler step outputs no `Error: unknown flag` (post-merge)
- [ ] Push to main touching `apps/web-platform/app/**` does NOT trigger ux-audit workflow (post-merge)

Generated with [Claude Code](https://claude.com/claude-code)