### PR TITLE
fix(kb-chat): render sidebar inline on desktop and relax path validation

### DIFF
--- a/apps/web-platform/components/ui/sheet.tsx
+++ b/apps/web-platform/components/ui/sheet.tsx
@@ -70,7 +70,7 @@ export function Sheet({
   const vh = typeof window !== "undefined" ? window.innerHeight : 800;
 
   const desktopClasses =
-    "fixed right-0 top-0 z-40 flex h-[100dvh] w-[380px] flex-col border-l border-neutral-800 bg-neutral-950 shadow-2xl";
+    "z-40 flex h-full w-[380px] shrink-0 flex-col border-l border-neutral-800 bg-neutral-950 shadow-2xl";
 
   const mobileHeight =
     dragHeight !== null ? dragHeight : Math.round(vh * SNAP_VH[snap]);
@@ -146,5 +146,8 @@ export function Sheet({
     </div>
   );
 
+  // Desktop: render inline as a flex child so the content area shrinks.
+  // Mobile: portal to body for bottom-sheet overlay behavior.
+  if (resolvedSide === "right") return panel;
   return createPortal(panel, document.body);
 }

--- a/apps/web-platform/server/context-validation.ts
+++ b/apps/web-platform/server/context-validation.ts
@@ -7,12 +7,12 @@ import { KB_MAX_FILE_SIZE } from "@/lib/kb-constants";
  * Rejects: "..", leading "/", null bytes.
  */
 function isSafePath(path: string): boolean {
-  if (!path || path.includes("..") || path.startsWith("/") || path.includes("\0")) {
+  if (!path || path.length > 512 || path.includes("..") || path.startsWith("/") || path.includes("\0")) {
     return false;
   }
-  // Must have a file extension (contains at least one dot after the last slash)
+  // Must have a real file extension (dot that is not the first character)
   const filename = path.split("/").pop() ?? "";
-  return filename.includes(".");
+  return filename.lastIndexOf(".") > 0;
 }
 /** Allowed context types */
 const ALLOWED_CONTEXT_TYPES = new Set(["kb-viewer"]);

--- a/apps/web-platform/server/context-validation.ts
+++ b/apps/web-platform/server/context-validation.ts
@@ -1,8 +1,19 @@
 import type { ConversationContext } from "@/lib/types";
 import { KB_MAX_FILE_SIZE } from "@/lib/kb-constants";
 
-/** Safe path pattern: alphanumeric, hyphens, underscores, slashes, ending in .md */
-const SAFE_PATH_RE = /^[a-zA-Z0-9_\-/]+\.md$/;
+/**
+ * Safe path pattern: any characters except path traversal sequences.
+ * Must start with a word character and contain at least one dot (file extension).
+ * Rejects: "..", leading "/", null bytes.
+ */
+function isSafePath(path: string): boolean {
+  if (!path || path.includes("..") || path.startsWith("/") || path.includes("\0")) {
+    return false;
+  }
+  // Must have a file extension (contains at least one dot after the last slash)
+  const filename = path.split("/").pop() ?? "";
+  return filename.includes(".");
+}
 /** Allowed context types */
 const ALLOWED_CONTEXT_TYPES = new Set(["kb-viewer"]);
 
@@ -22,9 +33,9 @@ export function validateConversationContext(
 
   const obj = raw as Record<string, unknown>;
 
-  // path: required, must match safe pattern (no traversal sequences)
-  if (typeof obj.path !== "string" || !SAFE_PATH_RE.test(obj.path)) {
-    throw new Error("Invalid context: path must match [a-zA-Z0-9_-/]+.md");
+  // path: required, must be a safe file path (no traversal)
+  if (typeof obj.path !== "string" || !isSafePath(obj.path)) {
+    throw new Error("Invalid context: path must be a valid file path (no '..' or leading '/')");
   }
 
   // type: required, must be from allowed set

--- a/apps/web-platform/test/sheet.test.tsx
+++ b/apps/web-platform/test/sheet.test.tsx
@@ -54,15 +54,23 @@ describe("Sheet", () => {
     expect(screen.getByText("visible content")).toBeInTheDocument();
   });
 
-  it("renders with right-side classes on desktop", () => {
+  it("renders desktop sheet inline (not portaled to body, not fixed)", () => {
     installMatchMedia(true);
-    render(
-      <Sheet open={true} onClose={() => {}} aria-label="Desktop sheet">
-        <p>x</p>
-      </Sheet>,
+    const { container } = render(
+      <div data-testid="parent-container">
+        <Sheet open={true} onClose={() => {}} aria-label="Desktop sheet">
+          <p>x</p>
+        </Sheet>
+      </div>,
     );
     const panel = screen.getByRole("dialog", { name: "Desktop sheet" });
-    expect(panel.className).toMatch(/right-0/);
+    // Should render inside the parent container, not portaled to document.body
+    const parent = container.querySelector("[data-testid='parent-container']");
+    expect(parent?.contains(panel)).toBe(true);
+    // Should NOT have fixed positioning
+    expect(panel.className).not.toMatch(/\bfixed\b/);
+    // Should have shrink-0 for flex layout
+    expect(panel.className).toMatch(/shrink-0/);
     // Desktop has no drag handle
     expect(screen.queryByLabelText(/resize panel/i)).toBeNull();
   });

--- a/apps/web-platform/test/ws-context-validation.test.ts
+++ b/apps/web-platform/test/ws-context-validation.test.ts
@@ -46,7 +46,7 @@ describe("validateConversationContext", () => {
         path: "../../../etc/passwd",
         type: "kb-viewer",
       }),
-    ).toThrow("path must match");
+    ).toThrow("path must be a valid file path");
   });
 
   it("rejects path with dot-dot segments", () => {
@@ -55,16 +55,19 @@ describe("validateConversationContext", () => {
         path: "knowledge-base/../../secret.md",
         type: "kb-viewer",
       }),
-    ).toThrow("path must match");
+    ).toThrow("path must be a valid file path");
   });
 
-  it("rejects non-.md path extensions", () => {
-    expect(() =>
-      validateConversationContext({
-        path: "file.js",
-        type: "kb-viewer",
-      }),
-    ).toThrow("path must match");
+  it("accepts non-.md path extensions", () => {
+    const result = validateConversationContext({
+      path: "file.js",
+      type: "kb-viewer",
+    });
+    expect(result).toEqual({
+      path: "file.js",
+      type: "kb-viewer",
+      content: undefined,
+    });
   });
 
   it("rejects path with null bytes", () => {
@@ -73,16 +76,61 @@ describe("validateConversationContext", () => {
         path: "file\0.md",
         type: "kb-viewer",
       }),
-    ).toThrow("path must match");
+    ).toThrow("path must be a valid file path");
   });
 
-  it("rejects path with spaces", () => {
+  it("accepts path with spaces", () => {
+    const result = validateConversationContext({
+      path: "my file.md",
+      type: "kb-viewer",
+    });
+    expect(result).toEqual({
+      path: "my file.md",
+      type: "kb-viewer",
+      content: undefined,
+    });
+  });
+
+  it("accepts .pdf paths", () => {
+    const result = validateConversationContext({
+      path: "docs/report.pdf",
+      type: "kb-viewer",
+    });
+    expect(result).toEqual({
+      path: "docs/report.pdf",
+      type: "kb-viewer",
+      content: undefined,
+    });
+  });
+
+  it("accepts unicode filenames", () => {
+    const result = validateConversationContext({
+      path: "docs/café-menu.md",
+      type: "kb-viewer",
+    });
+    expect(result).toEqual({
+      path: "docs/café-menu.md",
+      type: "kb-viewer",
+      content: undefined,
+    });
+  });
+
+  it("rejects empty string path", () => {
     expect(() =>
       validateConversationContext({
-        path: "my file.md",
+        path: "",
         type: "kb-viewer",
       }),
-    ).toThrow("path must match");
+    ).toThrow("path must be a valid file path");
+  });
+
+  it("rejects path with no extension", () => {
+    expect(() =>
+      validateConversationContext({
+        path: "README",
+        type: "kb-viewer",
+      }),
+    ).toThrow("path must be a valid file path");
   });
 
   it("rejects unknown context type", () => {

--- a/apps/web-platform/test/ws-context-validation.test.ts
+++ b/apps/web-platform/test/ws-context-validation.test.ts
@@ -133,6 +133,25 @@ describe("validateConversationContext", () => {
     ).toThrow("path must be a valid file path");
   });
 
+  it("rejects dotfiles (leading dot, no real extension)", () => {
+    expect(() =>
+      validateConversationContext({
+        path: ".env",
+        type: "kb-viewer",
+      }),
+    ).toThrow("path must be a valid file path");
+  });
+
+  it("rejects paths exceeding 512 characters", () => {
+    const longPath = "a/".repeat(255) + "file.md";
+    expect(() =>
+      validateConversationContext({
+        path: longPath,
+        type: "kb-viewer",
+      }),
+    ).toThrow("path must be a valid file path");
+  });
+
   it("rejects unknown context type", () => {
     expect(() =>
       validateConversationContext({

--- a/knowledge-base/project/plans/2026-04-16-fix-kb-chat-sidebar-overlay-and-path-validation-tests-plan.md
+++ b/knowledge-base/project/plans/2026-04-16-fix-kb-chat-sidebar-overlay-and-path-validation-tests-plan.md
@@ -1,0 +1,133 @@
+---
+title: "fix: KB chat sidebar overlays PDF content instead of pushing it aside; update path validation tests"
+type: fix
+date: 2026-04-16
+---
+
+# fix: KB chat sidebar overlays PDF content instead of pushing it aside; update path validation tests
+
+## Overview
+
+Two related fixes for the KB chat feature:
+
+1. **Layout fix**: The chat sidebar overlays the PDF/document content instead of sitting beside it. The `Sheet` component (`components/ui/sheet.tsx`) uses `createPortal(panel, document.body)` with `position: fixed`, which renders the sidebar on top of the content area. On desktop, the sidebar should render inline within the flex layout so the content area narrows when the sidebar opens.
+
+2. **Test fix**: The path validation tests in `test/ws-context-validation.test.ts` still assert against the old regex-based error messages and old behavior (rejecting spaces, non-`.md` extensions). Commit `c912d554` relaxed validation to accept spaces, unicode, `.pdf`, and any valid file path, but the tests were not updated.
+
+## Proposed Solution
+
+### Layout fix
+
+Modify `Sheet` to render inline (no portal, no `fixed` positioning) on desktop, while preserving the portal-based bottom-sheet on mobile. Sheet is only consumed by `KbChatSidebar`, and `KbChatSidebar` is already rendered inside the flex container in `KbLayout` (line 257). This means removing the portal and fixed positioning on desktop makes the Sheet an inline flex child -- the content area shrinks automatically.
+
+Implementation in `components/ui/sheet.tsx`:
+
+- When `resolvedSide === "right"` (desktop), return `panel` directly instead of `createPortal(panel, document.body)`
+- Remove `fixed right-0 top-0` from `desktopClasses`, replace with flex-compatible classes (e.g., `shrink-0` to prevent the sidebar from shrinking)
+- Keep `w-[380px]`, `h-[100dvh]`, `border-l`, `bg-neutral-950`, `shadow-2xl`, `z-40` in desktop classes
+- Mobile bottom-sheet continues to use `createPortal` (it must overlay, not participate in flex layout)
+
+**Verification point**: The Escape-to-close handler in Sheet's `useEffect` does not depend on portal rendering -- it listens on `document` and checks `panelRef.current.contains(document.activeElement)`. This works identically whether the panel is portaled or inline. No change needed, but verify in testing.
+
+### Test fix
+
+Update `test/ws-context-validation.test.ts`:
+
+- Change error message assertions from `"path must match"` to `"path must be a valid file path"` (lines 49, 58, 63, 72, 85)
+- Change `"rejects non-.md path extensions"` to `"accepts non-.md path extensions"` -- replace `expect(() => ...).toThrow(...)` with `expect(validateConversationContext({path: "file.js", type: "kb-viewer"})).toEqual({path: "file.js", type: "kb-viewer", content: undefined})`
+- Change `"rejects path with spaces"` to `"accepts path with spaces"` -- same pattern, expect valid result
+- Add new test cases:
+  - `"accepts .pdf paths"`: `validateConversationContext({path: "docs/report.pdf", type: "kb-viewer"})` returns valid
+  - `"accepts unicode filenames"`: `validateConversationContext({path: "docs/cafe-menu.md", type: "kb-viewer"})` returns valid
+  - `"rejects empty string path"`: `validateConversationContext({path: "", type: "kb-viewer"})` throws
+  - `"rejects path with no extension"`: `validateConversationContext({path: "README", type: "kb-viewer"})` throws (isSafePath requires a dot in filename)
+- Keep the existing tests that should still pass: `..` traversal rejection, null byte rejection, leading `/` rejection
+
+## Acceptance Criteria
+
+- [x] On desktop (>=768px), when the KB chat sidebar is open, the PDF/document content area shrinks to accommodate the sidebar -- no overlay, no content hidden behind the sidebar
+- [x] On mobile (<768px), the chat sidebar continues to render as a bottom sheet (existing behavior preserved)
+- [x] The sidebar width on desktop is 380px (matching current Sheet desktop width)
+- [x] Opening/closing the sidebar does not cause layout jumps or content reflow glitches
+- [x] All path validation tests pass with updated assertions matching the new `isSafePath` behavior
+- [x] Path validation still rejects `..` traversal, leading `/`, and null bytes
+- [x] Path validation accepts: `.pdf` files, files with spaces, unicode filenames
+- [x] Path validation rejects: empty string paths, paths with no file extension
+- [x] Escape-to-close works on the inline desktop sidebar (no regression from portal removal)
+
+## Test Scenarios
+
+### Layout
+
+- Given a desktop viewport (>=768px) and a PDF file open in the KB viewer, when the user opens the chat sidebar, then the PDF content area width decreases by ~380px and the sidebar appears to its right
+- Given a desktop viewport with the sidebar open, when the user closes the sidebar, then the content area expands back to full width
+- Given a mobile viewport (<768px) and a file open, when the user opens the chat sidebar, then a bottom sheet appears (overlay behavior preserved)
+
+### Path validation
+
+- Given `context-validation.ts` with `isSafePath`, when validating `"document.pdf"`, then it returns valid
+- Given `isSafePath`, when validating `"my file with spaces.pdf"`, then it returns valid
+- Given `isSafePath`, when validating `"docs/accents-cafe.md"`, then it returns valid
+- Given `isSafePath`, when validating `"../etc/passwd"`, then it throws (path traversal blocked)
+- Given `isSafePath`, when validating `"/absolute/path.md"`, then it throws (leading slash blocked)
+- Given `isSafePath`, when validating a path with null byte, then it throws
+- Given `isSafePath`, when validating `""` (empty string), then it throws
+- Given `isSafePath`, when validating `"README"` (no extension), then it throws
+
+## Implementation Phases
+
+### Phase 1: Update path validation tests (`test/ws-context-validation.test.ts`)
+
+**Files to modify:**
+
+- `apps/web-platform/test/ws-context-validation.test.ts` -- update error message assertions, invert tests for spaces and non-`.md` extensions, add new acceptance test cases
+
+### Phase 2: Fix sidebar layout
+
+**Files to modify:**
+
+- `apps/web-platform/components/ui/sheet.tsx` -- remove portal and fixed positioning on desktop; keep portal for mobile bottom-sheet
+
+**Files to update tests:**
+
+- `apps/web-platform/test/sheet.test.tsx` -- update desktop class assertions (no longer `fixed right-0`), verify inline rendering on desktop
+- `apps/web-platform/test/kb-layout.test.tsx` -- add test verifying sidebar renders within the flex container, not as a portal
+
+**Files NOT modified (no changes needed):**
+
+- `apps/web-platform/app/(dashboard)/dashboard/kb/layout.tsx` -- KbChatSidebar is already inside the flex container
+- `apps/web-platform/components/chat/kb-chat-sidebar.tsx` -- no API changes
+
+### Phase 3: Ship
+
+- Run all tests
+- Review, compound, PR, merge
+
+## Context
+
+- Path validation fix: commit `c912d554`
+- KB chat sidebar feature: PR #2347 (`e3a2acc3`)
+- Branch: `feat-fix-kb-chat-path-and-layout`
+- Worktree: `.worktrees/feat-fix-kb-chat-path-and-layout/`
+
+## Domain Review
+
+**Domains relevant:** Product
+
+### Product/UX Gate
+
+**Tier:** advisory
+**Decision:** auto-accepted (pipeline)
+**Agents invoked:** none
+**Skipped specialists:** none
+**Pencil available:** N/A
+
+Layout fix restores intended behavior (sidebar beside content, not overlaying it). No new UI surfaces created -- this corrects an existing component's positioning.
+
+## References
+
+- `apps/web-platform/components/ui/sheet.tsx` -- Sheet component using `createPortal`
+- `apps/web-platform/app/(dashboard)/dashboard/kb/layout.tsx` -- KbLayout flex container
+- `apps/web-platform/components/chat/kb-chat-sidebar.tsx` -- KbChatSidebar wrapping Sheet
+- `apps/web-platform/server/context-validation.ts` -- updated validation (commit `c912d554`)
+- `apps/web-platform/test/ws-context-validation.test.ts` -- tests needing update


### PR DESCRIPTION
## Summary

- Fix KB chat sidebar layout: render Sheet inline on desktop (flex child with `shrink-0`) instead of portal overlay, so the PDF content area shrinks when the sidebar opens
- Relax path validation: replace strict `.md`-only regex with `isSafePath` function that accepts spaces, unicode, `.pdf`, and any valid file extension while still blocking `..` traversal, leading `/`, null bytes, dotfiles, and paths >512 chars
- Update all path validation tests (19→21) and sheet tests (7) to match new behavior

## Changelog

- Sheet component renders inline on desktop (no portal, no `fixed` positioning) so content area narrows when sidebar opens; mobile bottom-sheet behavior preserved via portal
- Path validation accepts `.pdf`, unicode filenames, and spaces; rejects dotfiles (`.env`) and paths exceeding 512 characters
- Added tests for dotfile rejection, path length limit, `.pdf` acceptance, unicode filenames, and inline desktop rendering

## Test plan

- [x] 21 path validation tests pass (traversal, null bytes, dotfiles, length, .pdf, unicode, spaces)
- [x] 7 sheet tests pass (inline desktop rendering, mobile portal, escape-to-close, drag close/snap)
- [x] Full test suite: 1483 tests pass, 0 failures
- [x] 5-agent code review completed, findings fixed inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)