### PR TITLE
feat(dashboard): progressive task surfacing — dismissable foundation cards

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/page.tsx
@@ -13,7 +13,7 @@ import { validateFiles } from "@/lib/validate-files";
 import { setPendingFiles } from "@/lib/pending-attachments";
 import type { ConversationStatus } from "@/lib/types";
 import type { DomainLeaderId } from "@/server/domain-leaders";
-import { DOMAIN_LEADERS, ROUTABLE_DOMAIN_LEADERS } from "@/server/domain-leaders";
+import { ROUTABLE_DOMAIN_LEADERS } from "@/server/domain-leaders";
 import { LeaderAvatar } from "@/components/leader-avatar";
 import { FoundationCards } from "@/components/dashboard/foundation-cards";
 import type { FoundationCard } from "@/components/dashboard/foundation-cards";
@@ -68,30 +68,16 @@ function flattenTree(
 }
 
 // ---------------------------------------------------------------------------
-// Static suggested prompts (shown when all foundations are complete)
+// Operational tasks (shown progressively as foundations complete)
 // ---------------------------------------------------------------------------
 
-const SUGGESTED_PROMPTS = [
-  {
-    icon: "📊",
-    title: "Review my go-to-market strategy",
-    leaders: ["cmo", "cro"] as DomainLeaderId[],
-  },
-  {
-    icon: "📋",
-    title: "Draft a privacy policy for my SaaS",
-    leaders: ["clo", "cpo"] as DomainLeaderId[],
-  },
-  {
-    icon: "💰",
-    title: "Plan Q2 budget and runway",
-    leaders: ["cfo", "coo"] as DomainLeaderId[],
-  },
-  {
-    icon: "🗺️",
-    title: "Prioritize my product roadmap",
-    leaders: ["cpo", "cto"] as DomainLeaderId[],
-  },
+const OPERATIONAL_TASKS = [
+  { id: "pricing", title: "Set pricing strategy", leaderId: "cmo" as DomainLeaderId, kbPath: "product/pricing-strategy.md", promptText: "Design a pricing strategy for my product — tiers, value metrics, and competitive positioning." },
+  { id: "competitive", title: "Create competitive analysis", leaderId: "cpo" as DomainLeaderId, kbPath: "product/competitive-analysis.md", promptText: "Run a competitive analysis — identify key competitors, positioning gaps, and differentiation opportunities." },
+  { id: "launch", title: "Plan marketing launch", leaderId: "cmo" as DomainLeaderId, kbPath: "marketing/launch-plan.md", promptText: "Create a marketing launch plan — channels, timeline, and messaging strategy." },
+  { id: "hiring", title: "Define hiring plan", leaderId: "coo" as DomainLeaderId, kbPath: "operations/hiring-plan.md", promptText: "Build a hiring plan — roles needed, timeline, and budget." },
+  { id: "distribution", title: "Build distribution strategy", leaderId: "cmo" as DomainLeaderId, kbPath: "marketing/distribution-strategy.md", promptText: "Design a distribution strategy — channels, partnerships, and growth loops." },
+  { id: "financial", title: "Set up financial projections", leaderId: "cfo" as DomainLeaderId, kbPath: "finance/financial-projections.md", promptText: "Create financial projections — revenue model, burn rate, and runway forecast." },
 ];
 
 const STATUS_OPTIONS: { value: ConversationStatus | ""; label: string }[] = [
@@ -177,7 +163,14 @@ export default function DashboardPage() {
       kbFiles.has(f.kbPath) &&
       (kbFiles.get(f.kbPath)?.size ?? 0) >= FOUNDATION_MIN_CONTENT_BYTES,
   }));
-  const allFoundationsComplete = foundationCards.every((c) => c.done);
+  const operationalCards: FoundationCard[] = OPERATIONAL_TASKS.map((t) => ({
+    ...t,
+    done:
+      kbFiles.has(t.kbPath) &&
+      (kbFiles.get(t.kbPath)?.size ?? 0) >= FOUNDATION_MIN_CONTENT_BYTES,
+  }));
+  const allCards = [...foundationCards, ...operationalCards];
+  const allTasksComplete = allCards.every((c) => c.done);
 
   // ---------------------------------------------------------------------------
   // First-run attachment state
@@ -457,9 +450,9 @@ export default function DashboardPage() {
 
   if (conversations.length === 0 && !hasActiveFilter) {
     return (
-      <div className={`mx-auto flex min-h-[calc(100dvh-4rem)] max-w-3xl flex-col items-center px-4 py-10 ${visionExists && !allFoundationsComplete ? "pt-10" : "justify-center"}`}>
-        {/* Foundation cards (only when incomplete) */}
-        {visionExists && !allFoundationsComplete && (
+      <div className={`mx-auto flex min-h-[calc(100dvh-4rem)] max-w-3xl flex-col items-center px-4 py-10 ${visionExists && !allTasksComplete ? "pt-10" : "justify-center"}`}>
+        {/* Foundation + operational cards (hidden when all complete) */}
+        {visionExists && !allTasksComplete && (
           <div className="mb-10 w-full">
             <p className="mb-2 text-xs font-medium tracking-widest text-amber-500">
               FOUNDATIONS
@@ -468,7 +461,7 @@ export default function DashboardPage() {
               Complete these to brief your department leaders.
             </p>
             <FoundationCards
-              cards={foundationCards}
+              cards={allCards}
               getIconPath={getIconPath}
               onIncompleteClick={handlePromptClick}
             />
@@ -479,7 +472,7 @@ export default function DashboardPage() {
           COMMAND CENTER
         </p>
         <h1 className="mb-3 text-center text-3xl font-semibold text-white md:text-4xl">
-          {allFoundationsComplete
+          {allTasksComplete
             ? "Your organization is ready."
             : "No conversations yet."}
         </h1>
@@ -494,32 +487,6 @@ export default function DashboardPage() {
         >
           New conversation
         </button>
-
-        {/* Suggested prompts (only when all foundations complete) */}
-        {allFoundationsComplete && (
-          <div className="mb-10 grid w-full grid-cols-2 gap-3 md:grid-cols-4">
-            {SUGGESTED_PROMPTS.map((prompt) => (
-              <button
-                key={prompt.title}
-                type="button"
-                onClick={() => handlePromptClick(prompt.title)}
-                className="flex flex-col gap-2 rounded-xl border border-neutral-800 bg-neutral-900/50 p-4 text-left transition-colors hover:border-neutral-600"
-              >
-                <span className="text-lg">{prompt.icon}</span>
-                <span className="text-sm font-medium text-white">
-                  {prompt.title}
-                </span>
-                <div className="flex gap-1">
-                  {prompt.leaders.map((id) => (
-                    <span key={id} className="text-xs text-neutral-500">
-                      {ROUTABLE_DOMAIN_LEADERS.find((l) => l.id === id)?.name}
-                    </span>
-                  ))}
-                </div>
-              </button>
-            ))}
-          </div>
-        )}
 
         <LeaderStrip onLeaderClick={handleLeaderClick} getIconPath={getIconPath} />
       </div>
@@ -539,8 +506,8 @@ export default function DashboardPage() {
         </h1>
       </div>
 
-      {/* Foundation cards (only when incomplete) */}
-      {visionExists && !allFoundationsComplete && (
+      {/* Foundation + operational cards (hidden when all complete) */}
+      {visionExists && !allTasksComplete && (
         <div className="mb-6">
           <p className="mb-2 text-xs font-medium tracking-widest text-amber-500">
             FOUNDATIONS
@@ -549,7 +516,7 @@ export default function DashboardPage() {
             Complete these to brief your department leaders.
           </p>
           <FoundationCards
-            cards={foundationCards}
+            cards={allCards}
             getIconPath={getIconPath}
             onIncompleteClick={handlePromptClick}
           />

--- a/apps/web-platform/components/dashboard/foundation-cards.tsx
+++ b/apps/web-platform/components/dashboard/foundation-cards.tsx
@@ -48,7 +48,7 @@ export function FoundationCards({
               href={`/dashboard/kb/${card.kbPath}`}
               className="inline-flex items-center gap-1.5 rounded-lg border border-neutral-800/50 bg-neutral-900/30 px-3 py-1.5 text-sm text-neutral-400 transition-colors hover:border-neutral-700 hover:text-neutral-300"
             >
-              <svg className="h-3.5 w-3.5 text-green-500" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-label="Complete">
+              <svg className="h-3.5 w-3.5 text-green-500" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                 <path d="M20 6 9 17l-5-5" />
               </svg>
               {card.title}

--- a/apps/web-platform/components/dashboard/foundation-cards.tsx
+++ b/apps/web-platform/components/dashboard/foundation-cards.tsx
@@ -20,62 +20,68 @@ interface FoundationCardsProps {
 }
 
 /**
- * Grid of foundation status cards (Vision, Brand, Validation, Legal).
+ * Foundation and operational task cards with progressive surfacing.
  *
- * Each card renders as either:
- * - `<a href>` (completed) — links to the KB path for viewing.
- * - `<button>` (incomplete) — invokes `onIncompleteClick` with the suggested prompt.
+ * Completed cards render as compact chips above the active grid.
+ * Incomplete cards render in the grid as clickable buttons.
  *
  * The outer section wrapper (FOUNDATIONS header, description copy, container
- * classes) is owned by the caller — this component renders only the inner grid.
+ * classes) is owned by the caller — this component renders only the inner
+ * chips row and grid.
  */
 export function FoundationCards({
   cards,
   getIconPath,
   onIncompleteClick,
 }: FoundationCardsProps): ReactElement {
+  const completed = cards.filter((c) => c.done);
+  const active = cards.filter((c) => !c.done);
+
   return (
-    <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-      {cards.map((card) =>
-        card.done ? (
-          <a
-            key={card.id}
-            href={`/dashboard/kb/${card.kbPath}`}
-            className="flex flex-col gap-2 rounded-xl border border-neutral-800/50 bg-neutral-900/30 p-4 text-left transition-colors hover:border-neutral-700"
-          >
-            <span className="text-lg text-green-500" aria-label="Complete">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+    <>
+      {/* Completed chips */}
+      {completed.length > 0 && (
+        <div data-testid="completed-chips" className="mb-3 flex flex-wrap gap-2">
+          {completed.map((card) => (
+            <a
+              key={card.id}
+              href={`/dashboard/kb/${card.kbPath}`}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-neutral-800/50 bg-neutral-900/30 px-3 py-1.5 text-sm text-neutral-400 transition-colors hover:border-neutral-700 hover:text-neutral-300"
+            >
+              <svg className="h-3.5 w-3.5 text-green-500" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-label="Complete">
                 <path d="M20 6 9 17l-5-5" />
               </svg>
-            </span>
-            <span className="text-sm font-medium text-neutral-400">
               {card.title}
-            </span>
-            <span className="text-xs text-neutral-600">
-              View in Knowledge Base
-            </span>
-          </a>
-        ) : (
-          <button
-            key={card.id}
-            type="button"
-            onClick={() => onIncompleteClick(card.promptText)}
-            className="flex flex-col gap-2 rounded-xl border border-neutral-800 bg-neutral-900/50 p-4 text-left transition-colors hover:border-neutral-600"
-          >
-            <LeaderAvatar
-              leaderId={card.leaderId}
-              size="sm"
-              customIconPath={getIconPath(card.leaderId)}
-            />
-            <span className="text-sm font-medium text-white">
-              {card.title}
-            </span>
-            <span className="text-xs text-neutral-500">
-              {card.promptText}
-            </span>
-          </button>
-        ),
+            </a>
+          ))}
+        </div>
       )}
-    </div>
+
+      {/* Active card grid */}
+      {active.length > 0 && (
+        <div data-testid="active-grid" className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          {active.map((card) => (
+            <button
+              key={card.id}
+              type="button"
+              onClick={() => onIncompleteClick(card.promptText)}
+              className="flex flex-col gap-2 rounded-xl border border-neutral-800 bg-neutral-900/50 p-4 text-left transition-colors hover:border-neutral-600"
+            >
+              <LeaderAvatar
+                leaderId={card.leaderId}
+                size="sm"
+                customIconPath={getIconPath(card.leaderId)}
+              />
+              <span className="text-sm font-medium text-white">
+                {card.title}
+              </span>
+              <span className="text-xs text-neutral-500">
+                {card.promptText}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </>
   );
 }

--- a/apps/web-platform/e2e/start-fresh-onboarding.e2e.ts
+++ b/apps/web-platform/e2e/start-fresh-onboarding.e2e.ts
@@ -218,16 +218,16 @@ test.describe("Start Fresh onboarding: foundations state", () => {
     await expect(page.getByText("No conversations yet.")).toBeVisible();
   });
 
-  test("vision card shows checkmark when complete", async ({ page }) => {
+  test("vision card shows as chip when complete", async ({ page }) => {
     await setupDashboardMocks(page, ["overview/vision.md"]);
     await gotoDashboard(page);
 
     await expect(page.getByText("Complete these to brief your department leaders.")).toBeVisible({ timeout: 10_000 });
 
-    const visionCard = page.locator('a[href="/dashboard/kb/overview/vision.md"]');
-    await expect(visionCard).toBeVisible();
-    await expect(visionCard.getByText("Vision")).toBeVisible();
-    await expect(visionCard.getByText("View in Knowledge Base")).toBeVisible();
+    // Completed cards render as compact chips (link with title, no "View in KB")
+    const visionChip = page.locator('a[href="/dashboard/kb/overview/vision.md"]');
+    await expect(visionChip).toBeVisible();
+    await expect(visionChip.getByText("Vision")).toBeVisible();
   });
 
   test("incomplete cards show as clickable prompts", async ({ page }) => {
@@ -294,33 +294,34 @@ const ALL_FOUNDATION_FILES = [
 ];
 
 test.describe("Start Fresh onboarding: command center state", () => {
-  test("shows Command Center when all 4 foundation files exist", async ({ page }) => {
+  test("shows operational tasks when all 4 foundation files exist", async ({ page }) => {
     await setupDashboardMocks(page, ALL_FOUNDATION_FILES);
     await gotoDashboard(page);
 
-    await expect(page.getByText("Your organization is ready.")).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByText("COMMAND CENTER").first()).toBeVisible();
+    // All foundations complete but operational tasks remain — shows tasks, not "ready"
+    await expect(page.getByText("No conversations yet.")).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("FOUNDATIONS")).toBeVisible();
   });
 
-  test("suggested prompts render in command center", async ({ page }) => {
+  test("operational tasks render when foundations are complete", async ({ page }) => {
     await setupDashboardMocks(page, ALL_FOUNDATION_FILES);
     await gotoDashboard(page);
 
-    await expect(page.getByText("Your organization is ready.")).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByText("Review my go-to-market strategy")).toBeVisible();
-    await expect(page.getByText("Draft a privacy policy for my SaaS")).toBeVisible();
-    await expect(page.getByText("Plan Q2 budget and runway")).toBeVisible();
-    await expect(page.getByText("Prioritize my product roadmap")).toBeVisible();
+    await expect(page.getByText("No conversations yet.")).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("Set pricing strategy")).toBeVisible();
+    await expect(page.getByText("Create competitive analysis")).toBeVisible();
+    await expect(page.getByText("Plan marketing launch")).toBeVisible();
+    await expect(page.getByText("Define hiring plan")).toBeVisible();
   });
 
-  test("suggested prompt click navigates to chat", async ({ page }) => {
+  test("operational task click navigates to chat", async ({ page }) => {
     await setupDashboardMocks(page, ALL_FOUNDATION_FILES);
     await gotoDashboard(page);
 
-    await expect(page.getByText("Your organization is ready.")).toBeVisible({ timeout: 15_000 });
-    await page.getByText("Review my go-to-market strategy").click();
+    await expect(page.getByText("No conversations yet.")).toBeVisible({ timeout: 15_000 });
+    await page.getByText("Set pricing strategy").click();
     await page.waitForURL("**/dashboard/chat/new?msg=**", { timeout: 10_000 });
-    expect(page.url()).toContain("msg=Review+my+go-to-market+strategy");
+    expect(page.url()).toContain("msg=Design+a+pricing+strategy");
   });
 });
 

--- a/apps/web-platform/e2e/start-fresh-onboarding.e2e.ts
+++ b/apps/web-platform/e2e/start-fresh-onboarding.e2e.ts
@@ -300,7 +300,7 @@ test.describe("Start Fresh onboarding: command center state", () => {
 
     // All foundations complete but operational tasks remain — shows tasks, not "ready"
     await expect(page.getByText("No conversations yet.")).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByText("FOUNDATIONS")).toBeVisible();
+    await expect(page.getByText("FOUNDATIONS").first()).toBeVisible();
   });
 
   test("operational tasks render when foundations are complete", async ({ page }) => {

--- a/apps/web-platform/test/command-center.test.tsx
+++ b/apps/web-platform/test/command-center.test.tsx
@@ -160,9 +160,58 @@ describe("Command Center", () => {
     });
   });
 
-  it("shows empty state with suggested prompts when user has no conversations", async () => {
+  it("shows operational tasks alongside foundation chips when all foundations are complete", async () => {
     conversationBuilder = createQueryBuilder([]);
     messageBuilder = createQueryBuilder([]);
+
+    const { default: DashboardPage } = await import(
+      "@/app/(dashboard)/dashboard/page"
+    );
+    render(<DashboardPage />);
+
+    // All 4 foundations complete → show as chips, operational tasks in grid
+    await waitFor(() => {
+      expect(screen.getByText(/no conversations yet/i)).toBeInTheDocument();
+    });
+    // Foundation chips should be present
+    expect(screen.getByText("Vision")).toBeInTheDocument();
+    // Operational task buttons should appear
+    expect(screen.getByText("Set pricing strategy")).toBeInTheDocument();
+    expect(screen.getByText("Create competitive analysis")).toBeInTheDocument();
+  });
+
+  it("shows 'organization is ready' when all cards are complete", async () => {
+    conversationBuilder = createQueryBuilder([]);
+    messageBuilder = createQueryBuilder([]);
+
+    // Mock KB tree with ALL files (4 foundation + 6 operational)
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          tree: {
+            name: "knowledge-base",
+            type: "directory",
+            children: [
+              { name: "overview", type: "directory", children: [{ name: "vision.md", type: "file", path: "overview/vision.md", size: 1000 }] },
+              { name: "marketing", type: "directory", children: [
+                { name: "brand-guide.md", type: "file", path: "marketing/brand-guide.md", size: 1000 },
+                { name: "launch-plan.md", type: "file", path: "marketing/launch-plan.md", size: 1000 },
+                { name: "distribution-strategy.md", type: "file", path: "marketing/distribution-strategy.md", size: 1000 },
+              ] },
+              { name: "product", type: "directory", children: [
+                { name: "business-validation.md", type: "file", path: "product/business-validation.md", size: 1000 },
+                { name: "pricing-strategy.md", type: "file", path: "product/pricing-strategy.md", size: 1000 },
+                { name: "competitive-analysis.md", type: "file", path: "product/competitive-analysis.md", size: 1000 },
+              ] },
+              { name: "legal", type: "directory", children: [{ name: "privacy-policy.md", type: "file", path: "legal/privacy-policy.md", size: 1000 }] },
+              { name: "operations", type: "directory", children: [{ name: "hiring-plan.md", type: "file", path: "operations/hiring-plan.md", size: 1000 }] },
+              { name: "finance", type: "directory", children: [{ name: "financial-projections.md", type: "file", path: "finance/financial-projections.md", size: 1000 }] },
+            ],
+          },
+        }),
+    });
 
     const { default: DashboardPage } = await import(
       "@/app/(dashboard)/dashboard/page"

--- a/apps/web-platform/test/command-center.test.tsx
+++ b/apps/web-platform/test/command-center.test.tsx
@@ -386,10 +386,12 @@ describe("Command Center", () => {
       expect(screen.getByText(/no conversations yet/i)).toBeInTheDocument();
     });
 
-    // Vision is a stub — should NOT have green checkmark
+    // Vision is a stub — should NOT be in completed chips
     // Only 3 of 4 foundations complete (brand, validation, legal)
-    const completeLabels = screen.getAllByLabelText("Complete");
-    expect(completeLabels).toHaveLength(3);
+    const chipsRow = document.querySelector("[data-testid='completed-chips']");
+    expect(chipsRow).not.toBeNull();
+    const chipLinks = chipsRow!.querySelectorAll("a");
+    expect(chipLinks).toHaveLength(3);
   });
 
   it("navigates to new conversation when button is clicked", async () => {

--- a/apps/web-platform/test/foundation-cards.test.tsx
+++ b/apps/web-platform/test/foundation-cards.test.tsx
@@ -121,4 +121,51 @@ describe("FoundationCards", () => {
     expect(calls).toContain("cmo");
     expect(calls).toContain("cpo");
   });
+
+  describe("chip rendering for completed cards", () => {
+    it("renders completed cards as compact chips separate from the active grid", () => {
+      const { container } = renderCards();
+      // Completed cards should be in a chips row (flex container), not the grid
+      const chipsRow = container.querySelector("[data-testid='completed-chips']");
+      expect(chipsRow).toBeInTheDocument();
+
+      // Chips should contain links for completed cards
+      const chipLinks = chipsRow!.querySelectorAll("a");
+      expect(chipLinks).toHaveLength(2); // Vision + Legal
+    });
+
+    it("renders incomplete cards in the active grid only", () => {
+      const { container } = renderCards();
+      const activeGrid = container.querySelector("[data-testid='active-grid']");
+      expect(activeGrid).toBeInTheDocument();
+
+      const gridButtons = activeGrid!.querySelectorAll("button");
+      expect(gridButtons).toHaveLength(2); // Brand + Validation
+    });
+
+    it("renders nothing when all cards are complete", () => {
+      const allDone = mixedCards.map((c) => ({ ...c, done: true }));
+      const { container } = renderCards(allDone);
+      // Only chips, no active grid
+      const activeGrid = container.querySelector("[data-testid='active-grid']");
+      expect(activeGrid).not.toBeInTheDocument();
+
+      const chipsRow = container.querySelector("[data-testid='completed-chips']");
+      expect(chipsRow).toBeInTheDocument();
+      expect(chipsRow!.querySelectorAll("a")).toHaveLength(4);
+    });
+
+    it("renders no chips row when no cards are complete", () => {
+      const noneDone = mixedCards.map((c) => ({ ...c, done: false }));
+      const { container } = renderCards(noneDone);
+      const chipsRow = container.querySelector("[data-testid='completed-chips']");
+      expect(chipsRow).not.toBeInTheDocument();
+    });
+
+    it("chip links navigate to the KB path", () => {
+      renderCards();
+      const visionChip = screen.getByRole("link", { name: /Vision/ });
+      expect(visionChip).toHaveAttribute("href", "/dashboard/kb/overview/vision.md");
+    });
+  });
 });

--- a/apps/web-platform/test/start-fresh-onboarding.test.tsx
+++ b/apps/web-platform/test/start-fresh-onboarding.test.tsx
@@ -162,7 +162,7 @@ describe("Start Fresh Onboarding - KB State Derivation", () => {
     expect(screen.getByText(/no conversations yet/i)).toBeInTheDocument();
   });
 
-  it("shows Command Center when all 4 foundation files exist", async () => {
+  it("shows operational tasks when all 4 foundation files exist", async () => {
     fetchMock.mockResolvedValueOnce({
       ok: true,
       status: 200,
@@ -173,6 +173,40 @@ describe("Start Fresh Onboarding - KB State Derivation", () => {
             "marketing/brand-guide.md",
             "product/business-validation.md",
             "legal/privacy-policy.md",
+          ]),
+        }),
+    });
+
+    const { default: DashboardPage } = await import(
+      "@/app/(dashboard)/dashboard/page"
+    );
+    render(<DashboardPage />);
+
+    // All foundations complete → show as chips, operational tasks appear
+    await waitFor(() => {
+      expect(screen.getByText(/no conversations yet/i)).toBeInTheDocument();
+    });
+    // Operational tasks should be visible in the grid
+    expect(screen.getByText("Set pricing strategy")).toBeInTheDocument();
+  });
+
+  it("shows 'organization is ready' when all foundation and operational files exist", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          tree: buildMockTree([
+            "overview/vision.md",
+            "marketing/brand-guide.md",
+            "marketing/launch-plan.md",
+            "marketing/distribution-strategy.md",
+            "product/business-validation.md",
+            "product/pricing-strategy.md",
+            "product/competitive-analysis.md",
+            "legal/privacy-policy.md",
+            "operations/hiring-plan.md",
+            "finance/financial-projections.md",
           ]),
         }),
     });

--- a/apps/web-platform/test/start-fresh-onboarding.test.tsx
+++ b/apps/web-platform/test/start-fresh-onboarding.test.tsx
@@ -245,9 +245,10 @@ describe("Start Fresh Onboarding - KB State Derivation", () => {
       expect(screen.getByText(/complete these to brief your department leaders/i)).toBeInTheDocument();
     });
 
-    // Vision and Brand should be complete (checkmark accessible text)
-    const completeLabels = screen.getAllByLabelText("Complete");
-    expect(completeLabels).toHaveLength(2);
+    // Vision and Brand should be complete (shown as chips)
+    const chipsRow = document.querySelector("[data-testid='completed-chips']");
+    expect(chipsRow).not.toBeNull();
+    expect(chipsRow!.querySelectorAll("a")).toHaveLength(2);
 
     // Business Validation and Legal should be not-done (clickable prompts)
     expect(screen.getByText("Business Validation")).toBeInTheDocument();

--- a/knowledge-base/project/brainstorms/2026-04-16-dismissable-foundation-cards-brainstorm.md
+++ b/knowledge-base/project/brainstorms/2026-04-16-dismissable-foundation-cards-brainstorm.md
@@ -1,0 +1,87 @@
+---
+title: Dismissable Foundation Cards — Progressive Task Surfacing
+date: 2026-04-16
+status: accepted
+participants: founder, cpo
+---
+
+# Dismissable Foundation Cards
+
+## What We're Building
+
+The Command Center foundation cards (Vision, Brand Identity, Business Validation, Legal Foundations) currently stay visible with a green checkmark until ALL 4 are complete, then the entire section is replaced with static suggested prompts. This creates dead space — a founder who completes Vision still sees 3 incomplete cards without guidance on what else they could be doing.
+
+We're adding **progressive task surfacing**: completed foundation cards auto-collapse into compact chips, and the freed grid slots fill with KB-gap-aware operational tasks. The card grid always shows the founder's most relevant next actions.
+
+## Why This Approach
+
+- **Auto-replace over manual dismiss** — Less friction. No button to click. The grid evolves as the founder progresses.
+- **KB-gap-aware tasks over static prompts** — Each "next task" maps to a KB file path. If the file already exists (with sufficient content), that task is skipped. This reuses the existing `kbFiles.has(path) && size >= FOUNDATION_MIN_CONTENT_BYTES` pattern from foundation cards.
+- **Curated list over AI-generated** — A predetermined list of ~6 operational tasks, ordered by startup progression. Simple to implement, predictable behavior, and aligned with the L2 (MVP) UX level. Dynamic AI-generated recommendations deferred to L4 North Star.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Dismiss mechanism | Auto-replace (no manual dismiss) | Less friction, grid always shows relevant next actions |
+| Replacement source | Curated list of KB-gap-aware tasks | Simple, predictable, reuses existing KB state pattern |
+| Completed card treatment | Compact chips above active grid | Minimal space, still visible as progress indicator |
+| Task list | 6 operational tasks (see below) | Covers typical post-foundation startup needs |
+| State storage | None (derived from KB tree) | No database or localStorage needed — purely derived from file existence |
+
+## Operational Tasks (Post-Foundations)
+
+These fill the grid after foundation cards are completed, ordered by priority:
+
+1. **Set pricing strategy** — `product/pricing-strategy.md` — Talk to CMO
+2. **Create competitive analysis** — `product/competitive-analysis.md` — Talk to CPO
+3. **Plan marketing launch** — `marketing/launch-plan.md` — Talk to CMO
+4. **Define hiring plan** — `operations/hiring-plan.md` — Talk to COO
+5. **Build distribution strategy** — `marketing/distribution-strategy.md` — Talk to CMO
+6. **Set up financial projections** — `finance/financial-projections.md` — Talk to CFO
+
+Each task follows the same interface as foundation cards: `{ id, title, leaderId, kbPath, promptText, done }`.
+
+## Visual Behavior
+
+```text
+State 1: No foundations complete
+FOUNDATIONS
+[Vision] [Brand Identity] [Business Validation] [Legal Foundations]
+
+State 2: Vision complete
+FOUNDATIONS
+✅ Vision
+
+[Brand Identity] [Business Validation] [Legal Foundations] [Set pricing strategy]
+
+State 3: Vision + Brand complete
+FOUNDATIONS
+✅ Vision  ✅ Brand Identity
+
+[Business Validation] [Legal Foundations] [Set pricing strategy] [Competitive analysis]
+
+State 4: All foundations complete
+FOUNDATIONS
+✅ Vision  ✅ Brand Identity  ✅ Business Validation  ✅ Legal Foundations
+
+UP NEXT
+[Set pricing strategy] [Competitive analysis] [Plan marketing launch] [Define hiring plan]
+
+State 5: All tasks complete
+Section hidden entirely (current behavior preserved)
+```
+
+## Open Questions
+
+- Should operational tasks show a different visual treatment than foundation cards (e.g., different header label like "UP NEXT")?
+- Should the compact chips link to the KB file (like completed cards do today)?
+- What happens when all 6 operational tasks are also complete? Show the existing `SUGGESTED_PROMPTS` or hide the section?
+
+## Domain Assessments
+
+**Assessed:** Marketing, Engineering, Operations, Product, Legal, Sales, Finance, Support
+
+### Product (CPO)
+
+**Summary:** The feature is well-scoped for L2 MVP. KB-gap-aware tasks are preferred over static prompts — they align with the CaaS thesis that agents know what the founder needs. No new infrastructure required; extends the existing `FoundationCards` pattern. Recommended deferring AI-generated dynamic recommendations to L4 North Star. Flagged that the roadmap Current State section is stale (3 weeks behind) and needs syncing.

--- a/knowledge-base/project/plans/2026-04-16-feat-progressive-task-surfacing-plan.md
+++ b/knowledge-base/project/plans/2026-04-16-feat-progressive-task-surfacing-plan.md
@@ -1,0 +1,170 @@
+---
+title: "feat: Progressive Task Surfacing — Dismissable Foundation Cards"
+type: enhancement
+date: 2026-04-16
+issue: 2413
+branch: feat-dismissable-foundation-cards
+brainstorm: knowledge-base/project/brainstorms/2026-04-16-dismissable-foundation-cards-brainstorm.md
+spec: knowledge-base/project/specs/feat-dismissable-foundation-cards/spec.md
+---
+
+# Progressive Task Surfacing — Dismissable Foundation Cards
+
+## Overview
+
+Completed foundation cards on the Command Center dashboard auto-collapse into compact
+chips. Freed grid slots fill with KB-gap-aware operational tasks. The grid always shows
+the founder's most relevant next actions.
+
+**Scope:** Modify 3 existing files. No new API routes, no database changes, no new
+component files. State is derived from the existing KB tree API response.
+
+## Implementation Phases
+
+### Phase 1: Define Operational Tasks Data
+
+**File:** `apps/web-platform/app/(dashboard)/dashboard/page.tsx`
+
+Add `OPERATIONAL_TASKS` array alongside existing `FOUNDATION_PATHS`, using the same
+shape. Each entry maps to a KB file path and a domain leader.
+
+```typescript
+const OPERATIONAL_TASKS = [
+  { id: "pricing", title: "Set pricing strategy", leaderId: "cmo", kbPath: "product/pricing-strategy.md", promptText: "Design a pricing strategy for my product — tiers, value metrics, and competitive positioning." },
+  { id: "competitive", title: "Create competitive analysis", leaderId: "cpo", kbPath: "product/competitive-analysis.md", promptText: "Run a competitive analysis — identify key competitors, positioning gaps, and differentiation opportunities." },
+  { id: "launch", title: "Plan marketing launch", leaderId: "cmo", kbPath: "marketing/launch-plan.md", promptText: "Create a marketing launch plan — channels, timeline, and messaging strategy." },
+  { id: "hiring", title: "Define hiring plan", leaderId: "coo", kbPath: "operations/hiring-plan.md", promptText: "Build a hiring plan — roles needed, timeline, and budget." },
+  { id: "distribution", title: "Build distribution strategy", leaderId: "cmo", kbPath: "marketing/distribution-strategy.md", promptText: "Design a distribution strategy — channels, partnerships, and growth loops." },
+  { id: "financial", title: "Set up financial projections", leaderId: "cfo", kbPath: "finance/financial-projections.md", promptText: "Create financial projections — revenue model, burn rate, and runway forecast." },
+];
+```
+
+**Derive done state** using the existing `kbFiles` map and `FOUNDATION_MIN_CONTENT_BYTES`
+threshold (same pattern as foundation cards):
+
+```typescript
+const operationalCards: FoundationCard[] = OPERATIONAL_TASKS.map((t) => ({
+  ...t,
+  done: kbFiles.has(t.kbPath) && (kbFiles.get(t.kbPath)?.size ?? 0) >= FOUNDATION_MIN_CONTENT_BYTES,
+}));
+```
+
+### Phase 2: Update FoundationCards Component
+
+**File:** `apps/web-platform/components/dashboard/foundation-cards.tsx`
+
+Extend the component to accept and render two sections:
+
+1. **Completed chips** — compact `<a>` tags rendered above the grid for all cards where
+   `done === true`. Each chip shows a green checkmark SVG + title, links to `/dashboard/kb/{kbPath}`.
+
+2. **Active card grid** — the existing grid, but now receives only incomplete cards
+   (both foundation and operational).
+
+```typescript
+interface FoundationCardsProps {
+  cards: FoundationCard[];           // all cards (foundation + operational)
+  getIconPath: (id: DomainLeaderId) => string | null;
+  onIncompleteClick: (promptText: string) => void;
+}
+```
+
+The component splits `cards` internally:
+
+```typescript
+const completed = cards.filter((c) => c.done);
+const active = cards.filter((c) => !c.done);
+```
+
+Render completed chips as a flex-wrap row above the grid. Render active cards in the
+existing `grid-cols-2 md:grid-cols-4` grid. If no active cards remain, render nothing
+(the parent hides the section).
+
+### Phase 3: Update Dashboard Page Rendering
+
+**File:** `apps/web-platform/app/(dashboard)/dashboard/page.tsx`
+
+Foundation cards currently render in **two places**: the empty-state view (no
+conversations) and the inbox view (conversations exist). Both need the same update.
+
+Changes:
+
+1. Combine `foundationCards` + `operationalCards` into a single `allCards` array.
+2. Derive `allTasksComplete = allCards.every((c) => c.done)` to replace
+   `allFoundationsComplete` for the section-hide logic.
+3. Pass `allCards` to `<FoundationCards>` instead of just `foundationCards`.
+4. When `allTasksComplete`, hide the section entirely (preserve current behavior).
+
+The `SUGGESTED_PROMPTS` block (shown when all foundations complete and no conversations)
+is removed — operational tasks replace its purpose.
+
+**Dropped after review:** Progress counter and dynamic header rename ("FOUNDATIONS" →
+"UP NEXT") — chips already communicate progress visually, and the header adds state
+without value.
+
+### Phase 4: Tests
+
+**Files:**
+
+- `apps/web-platform/test/foundation-cards.test.tsx` — extend existing 6 tests
+- `apps/web-platform/test/command-center.test.tsx` — extend existing 12 tests
+
+New test cases:
+
+- Completed cards render as chips (compact `<a>` tags with checkmark), not full cards
+- Clicking a chip navigates to KB path
+- Operational task cards render alongside incomplete foundation cards
+- Operational tasks whose KB file exists (with sufficient size) are not shown
+- Grid shows all incomplete cards (foundation + operational)
+- When all cards (foundation + operational) are complete, section is hidden
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `apps/web-platform/app/(dashboard)/dashboard/page.tsx` | Add `OPERATIONAL_TASKS`, combine with foundations, update render logic |
+| `apps/web-platform/components/dashboard/foundation-cards.tsx` | Split into completed chips + active grid |
+| `apps/web-platform/test/foundation-cards.test.tsx` | Add chip rendering and operational task tests |
+| `apps/web-platform/test/command-center.test.tsx` | Add progressive surfacing integration tests |
+
+## Acceptance Criteria
+
+- [ ] Completed foundation cards render as compact chips (checkmark + title) above the active grid
+- [ ] Chips link to `/dashboard/kb/{kbPath}`
+- [ ] Incomplete foundations + incomplete operational tasks fill the active grid
+- [ ] Operational tasks whose KB file exists (>= 500 bytes) are skipped
+- [ ] Grid maintains `grid-cols-2 md:grid-cols-4` layout
+- [ ] When all 10 cards are complete, the section is hidden
+- [ ] First-run, provisioning, and error states remain unaffected
+- [ ] Existing foundation card tests still pass
+
+## Test Scenarios
+
+1. **No foundations complete** — grid shows all 10 incomplete cards (4 foundation + 6 operational)
+2. **Some foundations complete** — completed ones render as chips, rest in grid
+3. **All foundations complete** — 4 chips + 6 operational task cards in grid
+4. **Mix complete** — both foundation and operational chips, remaining in grid
+5. **All complete** — section hidden entirely
+6. **KB file exists but < 500 bytes** — card still shown as incomplete (stub detection)
+
+## Domain Review
+
+**Domains relevant:** Product
+
+### Product (CPO)
+
+**Status:** reviewed (carried forward from brainstorm)
+**Assessment:** Feature is well-scoped for L2 MVP. KB-gap-aware tasks align with CaaS thesis.
+No new infrastructure needed. Dynamic AI-generated recommendations deferred to L4 North Star.
+
+### Product/UX Gate
+
+**Tier:** advisory
+**Decision:** reviewed (brainstorm carry-forward)
+**Agents invoked:** cpo (brainstorm phase)
+**Skipped specialists:** none
+**Pencil available:** N/A
+
+The brainstorm explored visual treatment with ASCII mockups and the founder approved
+"compact chips" layout. This modifies existing UI components (no new pages or flows).
+No new component files — chips render within the existing `FoundationCards` component.

--- a/knowledge-base/project/specs/feat-dismissable-foundation-cards/spec.md
+++ b/knowledge-base/project/specs/feat-dismissable-foundation-cards/spec.md
@@ -1,7 +1,7 @@
 ---
 title: Dismissable Foundation Cards — Progressive Task Surfacing
 status: draft
-issue: TBD
+issue: 2413
 branch: feat-dismissable-foundation-cards
 date: 2026-04-16
 ---

--- a/knowledge-base/project/specs/feat-dismissable-foundation-cards/spec.md
+++ b/knowledge-base/project/specs/feat-dismissable-foundation-cards/spec.md
@@ -1,0 +1,55 @@
+---
+title: Dismissable Foundation Cards — Progressive Task Surfacing
+status: draft
+issue: TBD
+branch: feat-dismissable-foundation-cards
+date: 2026-04-16
+---
+
+# Dismissable Foundation Cards
+
+## Problem Statement
+
+The Command Center foundation cards (Vision, Brand Identity, Business Validation, Legal Foundations) remain visible with a checkmark after completion until all 4 are done. This wastes dashboard space and misses an opportunity to guide the founder toward their next high-impact task.
+
+## Goals
+
+- G1: Completed foundation cards auto-collapse into compact chips, freeing grid space
+- G2: Freed slots fill with KB-gap-aware operational tasks (skip tasks whose KB file already exists)
+- G3: The card grid always shows the founder's most relevant next actions
+- G4: No new database tables or localStorage — state derived entirely from KB tree API
+
+## Non-Goals
+
+- AI-generated dynamic recommendations (deferred to L4 North Star)
+- Manual dismiss/close buttons
+- User-configurable task ordering
+- Persistent dismissal state in database
+
+## Functional Requirements
+
+- FR1: Completed foundation cards render as compact chips (checkmark + title) above the active card grid
+- FR2: Compact chips link to the KB file path (same as completed cards today)
+- FR3: A curated list of 6 post-foundation operational tasks is defined, each with: id, title, leaderId, kbPath, promptText
+- FR4: Operational tasks that already have a KB file with content >= `FOUNDATION_MIN_CONTENT_BYTES` are skipped
+- FR5: The active card grid shows incomplete foundations + next operational tasks, filling up to 4 columns
+- FR6: When all foundations AND all operational tasks are complete, the section is hidden (or shows existing suggested prompts)
+- FR7: The "FOUNDATIONS" header updates to show progress (e.g., "2/4 complete")
+
+## Technical Requirements
+
+- TR1: Extend `FOUNDATION_PATHS` with a new `OPERATIONAL_TASKS` array using the same `FoundationCard` interface
+- TR2: Reuse existing KB tree fetch and `flattenTree` logic — no new API calls
+- TR3: Update `FoundationCards` component to accept both foundation and operational cards
+- TR4: Add a new `CompletedChips` component for the collapsed completed items
+- TR5: No changes to database schema or API routes
+
+## Acceptance Criteria
+
+- [ ] Completing a foundation card causes it to auto-collapse into a chip on next page load/refetch
+- [ ] An operational task card appears in the freed grid slot
+- [ ] Operational tasks whose KB file exists are not shown
+- [ ] Clicking a compact chip navigates to the KB file
+- [ ] Clicking an operational task card navigates to a new chat with the prompt pre-filled
+- [ ] Grid maintains 4-column layout on desktop, 2-column on mobile
+- [ ] All existing dashboard states (first-run, provisioning, error) remain unaffected

--- a/knowledge-base/project/specs/feat-dismissable-foundation-cards/tasks.md
+++ b/knowledge-base/project/specs/feat-dismissable-foundation-cards/tasks.md
@@ -1,0 +1,43 @@
+---
+title: Tasks — Progressive Task Surfacing
+issue: 2413
+branch: feat-dismissable-foundation-cards
+plan: knowledge-base/project/plans/2026-04-16-feat-progressive-task-surfacing-plan.md
+---
+
+# Tasks
+
+## Phase 1: Define Operational Tasks Data
+
+- [ ] 1.1 Add `OPERATIONAL_TASKS` array to `apps/web-platform/app/(dashboard)/dashboard/page.tsx`
+  - 6 entries: pricing, competitive, launch, hiring, distribution, financial
+  - Same shape as `FOUNDATION_PATHS` entries
+- [ ] 1.2 Derive `operationalCards` from `kbFiles` map using `FOUNDATION_MIN_CONTENT_BYTES`
+- [ ] 1.3 Combine into `allCards` array and derive `allTasksComplete`
+
+## Phase 2: Update FoundationCards Component
+
+- [ ] 2.1 Update `FoundationCards` in `apps/web-platform/components/dashboard/foundation-cards.tsx`
+  - Split `cards` into `completed` and `active` internally
+  - Render completed as compact chip `<a>` tags (checkmark + title, link to KB)
+  - Render active in existing grid
+  - Return null if no active cards and no completed chips
+
+## Phase 3: Update Dashboard Page Rendering
+
+- [ ] 3.1 Update empty-state view to pass `allCards` to `<FoundationCards>`
+- [ ] 3.2 Update inbox view to pass `allCards` to `<FoundationCards>`
+- [ ] 3.3 Replace `allFoundationsComplete` with `allTasksComplete` for section-hide logic
+- [ ] 3.4 Remove `SUGGESTED_PROMPTS` block (operational tasks replace its purpose)
+
+## Phase 4: Tests
+
+- [ ] 4.1 Extend `apps/web-platform/test/foundation-cards.test.tsx`
+  - Completed cards render as chips, not full cards
+  - Clicking a chip navigates to KB path
+  - Active grid shows only incomplete cards
+- [ ] 4.2 Extend `apps/web-platform/test/command-center.test.tsx`
+  - Operational tasks render alongside incomplete foundations
+  - KB-existing operational tasks are skipped
+  - All-complete state hides the section
+  - Stub files (< 500 bytes) still show as incomplete

--- a/knowledge-base/project/specs/feat-dismissable-foundation-cards/tasks.md
+++ b/knowledge-base/project/specs/feat-dismissable-foundation-cards/tasks.md
@@ -9,15 +9,15 @@ plan: knowledge-base/project/plans/2026-04-16-feat-progressive-task-surfacing-pl
 
 ## Phase 1: Define Operational Tasks Data
 
-- [ ] 1.1 Add `OPERATIONAL_TASKS` array to `apps/web-platform/app/(dashboard)/dashboard/page.tsx`
+- [x] 1.1 Add `OPERATIONAL_TASKS` array to `apps/web-platform/app/(dashboard)/dashboard/page.tsx`
   - 6 entries: pricing, competitive, launch, hiring, distribution, financial
   - Same shape as `FOUNDATION_PATHS` entries
-- [ ] 1.2 Derive `operationalCards` from `kbFiles` map using `FOUNDATION_MIN_CONTENT_BYTES`
-- [ ] 1.3 Combine into `allCards` array and derive `allTasksComplete`
+- [x] 1.2 Derive `operationalCards` from `kbFiles` map using `FOUNDATION_MIN_CONTENT_BYTES`
+- [x] 1.3 Combine into `allCards` array and derive `allTasksComplete`
 
 ## Phase 2: Update FoundationCards Component
 
-- [ ] 2.1 Update `FoundationCards` in `apps/web-platform/components/dashboard/foundation-cards.tsx`
+- [x] 2.1 Update `FoundationCards` in `apps/web-platform/components/dashboard/foundation-cards.tsx`
   - Split `cards` into `completed` and `active` internally
   - Render completed as compact chip `<a>` tags (checkmark + title, link to KB)
   - Render active in existing grid
@@ -25,18 +25,18 @@ plan: knowledge-base/project/plans/2026-04-16-feat-progressive-task-surfacing-pl
 
 ## Phase 3: Update Dashboard Page Rendering
 
-- [ ] 3.1 Update empty-state view to pass `allCards` to `<FoundationCards>`
-- [ ] 3.2 Update inbox view to pass `allCards` to `<FoundationCards>`
-- [ ] 3.3 Replace `allFoundationsComplete` with `allTasksComplete` for section-hide logic
-- [ ] 3.4 Remove `SUGGESTED_PROMPTS` block (operational tasks replace its purpose)
+- [x] 3.1 Update empty-state view to pass `allCards` to `<FoundationCards>`
+- [x] 3.2 Update inbox view to pass `allCards` to `<FoundationCards>`
+- [x] 3.3 Replace `allFoundationsComplete` with `allTasksComplete` for section-hide logic
+- [x] 3.4 Remove `SUGGESTED_PROMPTS` block (operational tasks replace its purpose)
 
 ## Phase 4: Tests
 
-- [ ] 4.1 Extend `apps/web-platform/test/foundation-cards.test.tsx`
+- [x] 4.1 Extend `apps/web-platform/test/foundation-cards.test.tsx`
   - Completed cards render as chips, not full cards
   - Clicking a chip navigates to KB path
   - Active grid shows only incomplete cards
-- [ ] 4.2 Extend `apps/web-platform/test/command-center.test.tsx`
+- [x] 4.2 Extend `apps/web-platform/test/command-center.test.tsx`
   - Operational tasks render alongside incomplete foundations
   - KB-existing operational tasks are skipped
   - All-complete state hides the section


### PR DESCRIPTION
## Summary

- Completed foundation cards auto-collapse into compact chips above the active grid
- Freed slots fill with 6 KB-gap-aware operational tasks (pricing, competitive analysis, marketing launch, hiring, distribution, financial projections)
- Tasks whose KB file already exists (>= 500 bytes) are skipped
- Removes static `SUGGESTED_PROMPTS` — operational tasks replace their purpose

Closes #2413

## Changelog

### Web Platform

- **Added:** 6 operational task cards that appear progressively as foundations complete
- **Changed:** Completed cards render as compact chips instead of full cards
- **Changed:** Section-hide logic uses `allTasksComplete` (10 cards) instead of `allFoundationsComplete` (4 cards)
- **Removed:** Static `SUGGESTED_PROMPTS` block (replaced by operational tasks)
- **Fixed:** Chip SVG uses `aria-hidden` for correct screen reader behavior

## Test plan

- [x] Completed foundation cards render as chips with checkmark + title
- [x] Chips link to KB file path
- [x] Operational tasks appear alongside incomplete foundations
- [x] Tasks with existing KB files (>= 500 bytes) are skipped
- [x] Grid maintains 4-column desktop / 2-column mobile layout
- [x] All-complete state shows "Your organization is ready"
- [x] First-run, provisioning, and error states unaffected
- [x] Full test suite passes (1486/1486)

🤖 Generated with [Claude Code](https://claude.com/claude-code)