### PR TITLE
fix(kb-chat): relax resumeByContextPath validation for spaces and unicode

### DIFF
--- a/apps/web-platform/server/ws-handler.ts
+++ b/apps/web-platform/server/ws-handler.ts
@@ -37,14 +37,15 @@ const log = createChildLogger("ws");
 
 const CONTEXT_PATH_MAX_LEN = 512;
 const CONTEXT_PATH_PREFIX = "knowledge-base/";
-// Conservative KB-path alphabet: letters, digits, `_`, `-`, `.`, `/`.
-// Matches what the client's `deriveContextPathFromPathname` can produce
-// from KB route segments.
-const CONTEXT_PATH_ALLOWED = /^[\w\-./]+$/;
 
 /**
  * Validate an untrusted `context_path` string from the client before using
  * it in DB equality filters. Returns the trimmed path when valid, else null.
+ *
+ * Uses a blocklist approach (reject dangerous patterns) rather than an
+ * allowlist regex, so spaces, unicode filenames, and non-.md extensions
+ * all pass — matching isSafePath in context-validation.ts.
+ *
  * See review #2381 — the field previously went straight into `.eq()` with no
  * typeof/length/prefix guard.
  */
@@ -52,7 +53,11 @@ function validateContextPath(v: unknown): string | null {
   if (typeof v !== "string") return null;
   if (v.length === 0 || v.length > CONTEXT_PATH_MAX_LEN) return null;
   if (!v.startsWith(CONTEXT_PATH_PREFIX)) return null;
-  if (!CONTEXT_PATH_ALLOWED.test(v)) return null;
+  // Block traversal, null bytes, and dotfiles
+  if (v.includes("..") || v.includes("\0")) return null;
+  // Must have a file extension (dot in filename that is not the first char)
+  const filename = v.split("/").pop() ?? "";
+  if (filename.lastIndexOf(".") <= 0) return null;
   return v;
 }
 

--- a/apps/web-platform/test/ws-resume-by-context-path.test.ts
+++ b/apps/web-platform/test/ws-resume-by-context-path.test.ts
@@ -220,6 +220,57 @@ describe("start_session resumeByContextPath", () => {
     expect(mockMaybeSingle).not.toHaveBeenCalled();
   });
 
+  it("accepts resumeByContextPath with spaces and unicode (review #2412)", async () => {
+    const { session, sent } = createMockSession();
+    sessions.set("user-1", session);
+
+    await handleMessage(
+      "user-1",
+      JSON.stringify({
+        type: "start_session",
+        resumeByContextPath: "knowledge-base/overview/Au Chat Pôtan - Pitch Projet.pdf",
+      }),
+    );
+
+    // Should NOT get an error — path is valid
+    const err = sent.find((m) => m.type === "error" && /invalid resumeByContextPath/i.test(m.message));
+    expect(err).toBeUndefined();
+  });
+
+  it("rejects resumeByContextPath with path traversal (review #2412)", async () => {
+    const { session, sent } = createMockSession();
+    sessions.set("user-1", session);
+
+    await handleMessage(
+      "user-1",
+      JSON.stringify({
+        type: "start_session",
+        resumeByContextPath: "knowledge-base/../../../etc/passwd",
+      }),
+    );
+
+    const err = sent.find((m) => m.type === "error");
+    expect(err).toBeTruthy();
+    expect(mockMaybeSingle).not.toHaveBeenCalled();
+  });
+
+  it("rejects resumeByContextPath with dotfile (review #2412)", async () => {
+    const { session, sent } = createMockSession();
+    sessions.set("user-1", session);
+
+    await handleMessage(
+      "user-1",
+      JSON.stringify({
+        type: "start_session",
+        resumeByContextPath: "knowledge-base/.env",
+      }),
+    );
+
+    const err = sent.find((m) => m.type === "error");
+    expect(err).toBeTruthy();
+    expect(mockMaybeSingle).not.toHaveBeenCalled();
+  });
+
   it("start_session without resumeByContextPath behaves as before (pending)", async () => {
     const { session, sent } = createMockSession();
     sessions.set("user-1", session);


### PR DESCRIPTION
## Summary

- Replace strict ASCII-only allowlist regex (`/^[\w\-./]+$/`) in `ws-handler.ts:validateContextPath()` with blocklist approach matching `isSafePath` in `context-validation.ts`
- Paths with spaces (`Au Chat Pôtan - Pitch Projet.pdf`) and unicode characters now pass validation
- Still blocks: path traversal (`..`), null bytes, dotfiles (`.env`), paths >512 chars, missing `knowledge-base/` prefix, missing file extension

This is a companion fix to PR #2412 which fixed the same class of bug in `context-validation.ts`. The `validateContextPath` function in `ws-handler.ts` had the same overly-strict validation but was missed because it's a separate code path (WebSocket session resumption vs HTTP context validation).

## Changelog

- `validateContextPath` now uses blocklist (reject `..`, `\0`, dotfiles, missing extension) instead of allowlist regex
- Added 3 tests: spaces+unicode acceptance, path traversal rejection, dotfile rejection

## Test plan

- [x] 10 resume-by-context-path tests pass (including 3 new)
- [x] Full suite: 1488 tests pass, 0 failures
- [x] Manually verified: `"knowledge-base/overview/Au Chat Pôtan - Pitch Projet.pdf"` passes validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)