### PR TITLE
sec: switch CodeQL threat model from remote_and_local to remote

### DIFF
--- a/knowledge-base/project/plans/2026-04-16-sec-switch-codeql-threat-model-remote-only-plan.md
+++ b/knowledge-base/project/plans/2026-04-16-sec-switch-codeql-threat-model-remote-only-plan.md
@@ -140,11 +140,11 @@ sources to network requests only.
 
 ## Acceptance Criteria
 
-- [ ] CodeQL default setup `threat_model` field reads `remote` (not `remote_and_local`)
-- [ ] Language list preserved after PATCH (all 5 entries: actions, javascript,
+- [x] CodeQL default setup `threat_model` field reads `remote` (not `remote_and_local`)
+- [x] Language list preserved after PATCH (all 5 entries: actions, javascript,
   javascript-typescript, python, typescript)
-- [ ] CodeQL re-analysis completes successfully after the config change
-- [ ] Previously dismissed alerts remain dismissed (not re-opened by the config change)
+- [x] CodeQL re-analysis completes successfully after the config change
+- [x] Previously dismissed alerts remain dismissed (not re-opened by the config change)
 - [x] Spec documentation updated to reflect the new threat model
 
 ## Test Scenarios

--- a/knowledge-base/project/plans/2026-04-16-sec-switch-codeql-threat-model-remote-only-plan.md
+++ b/knowledge-base/project/plans/2026-04-16-sec-switch-codeql-threat-model-remote-only-plan.md
@@ -145,7 +145,7 @@ sources to network requests only.
   javascript-typescript, python, typescript)
 - [ ] CodeQL re-analysis completes successfully after the config change
 - [ ] Previously dismissed alerts remain dismissed (not re-opened by the config change)
-- [ ] Spec documentation updated to reflect the new threat model
+- [x] Spec documentation updated to reflect the new threat model
 
 ## Test Scenarios
 

--- a/knowledge-base/project/plans/2026-04-16-sec-switch-codeql-threat-model-remote-only-plan.md
+++ b/knowledge-base/project/plans/2026-04-16-sec-switch-codeql-threat-model-remote-only-plan.md
@@ -1,0 +1,130 @@
+---
+title: "sec: Switch CodeQL threat model from remote_and_local to remote only"
+type: fix
+date: 2026-04-16
+---
+
+# sec: Switch CodeQL threat model from remote_and_local to remote only
+
+## Overview
+
+Switch the CodeQL default setup threat model from `remote_and_local` to `remote` to reduce
+false positive volume. The current configuration flags server-side code that uses environment
+variables, CLI arguments, and file system paths as taint sources -- patterns with no
+user-controlled input reaching the sink. Switching to `remote` restricts taint sources to
+network requests only, which is the appropriate model for a web application where local inputs
+(env vars, file paths) are server-controlled and not adversary-reachable.
+
+## Problem Statement
+
+The `remote_and_local` threat model was enabled in PR #1894 (2026-04-10) because the repo
+contains shell scripts and GitHub Actions workflows that process environment variables and CLI
+arguments. In practice, this produced 100 false positives (now dismissed) -- 64 `path-injection`
+alerts and 9 `request-forgery` alerts driven primarily by the `local` taint sources. These
+alerts flag hardcoded env-var URLs as SSRF and server-controlled file paths as traversal, which
+are structurally false positives in this codebase.
+
+After the bulk dismissal in PR #2416, zero open alerts remain. However, future PRs will
+continue to trigger false positives for the same patterns, creating ongoing triage friction.
+
+### Current state
+
+- **Threat model:** `remote_and_local`
+- **Query suite:** `extended`
+- **Open alerts:** 0
+- **Dismissed alerts:** 100 (68 "false positive", 31 "used in tests", 1 "won't fix")
+- **Top dismissed rules:** `js/path-injection` (39), `py/path-injection` (25),
+  `js/request-forgery` (9)
+
+## Proposed Solution
+
+A single GitHub API call to update the CodeQL default setup configuration:
+
+```bash
+gh api -X PATCH repos/jikig-ai/soleur/code-scanning/default-setup \
+  --field state=configured \
+  --field query_suite=extended \
+  --field 'languages=["actions","javascript-typescript","python"]' \
+  --field threat_model=remote
+```
+
+This preserves the `extended` query suite and explicitly includes the language list (the PATCH
+endpoint may reset omitted fields) while restricting taint sources to network requests only.
+
+### Why this is safe
+
+1. **All 100 dismissed alerts were false positives** -- no genuine vulnerability was found among
+   them. The `local` taint sources added noise without catching real issues.
+2. **`remote` still covers the actual attack surface** -- user-controlled input arrives via HTTP
+   requests. Server-side env vars and file paths are not adversary-reachable.
+3. **Reversible** -- switching back to `remote_and_local` is a single API call with no code
+   changes required.
+4. **No impact on other security tools** -- secret scanning, push protection, and Dependabot
+   are unaffected.
+
+## Implementation Phases
+
+### Phase 1: Switch threat model and verify
+
+1. Run the PATCH API call to update `threat_model` from `remote_and_local` to `remote`.
+   Include `languages` in the PATCH to prevent the API from resetting the language list to
+   defaults (the GitHub default setup PATCH may reset omitted fields):
+
+   ```bash
+   gh api -X PATCH repos/jikig-ai/soleur/code-scanning/default-setup \
+     --field state=configured \
+     --field query_suite=extended \
+     --field 'languages=["actions","javascript-typescript","python"]' \
+     --field threat_model=remote
+   ```
+
+2. Verify the change via GET: `gh api repos/jikig-ai/soleur/code-scanning/default-setup`
+   -- confirm `threat_model` is `remote` and `languages` are preserved
+3. Poll for re-analysis completion via the analyses endpoint:
+   `gh api repos/jikig-ai/soleur/code-scanning/analyses?tool_name=CodeQL --jq '.[0] | {created_at, results_count}'`
+   -- wait for a new analysis with `created_at` after the config change timestamp
+4. Check open alerts: `gh api repos/jikig-ai/soleur/code-scanning/alerts?state=open --jq 'length'`
+   -- confirm zero open alerts
+
+### Phase 2: Update documentation
+
+1. Add a note to `knowledge-base/project/specs/feat-enable-github-security-quality/tasks.md`
+   recording the threat model change: `[Updated 2026-04-16] threat model switched to remote
+   (see #2418)`
+2. Update `knowledge-base/project/specs/feat-enable-github-security-quality/session-state.md`
+   with the same note
+
+## Acceptance Criteria
+
+- [ ] CodeQL default setup `threat_model` field reads `remote` (not `remote_and_local`)
+- [ ] Language list preserved after PATCH (actions, javascript-typescript, python)
+- [ ] CodeQL re-analysis completes successfully after the config change
+- [ ] Previously dismissed alerts remain dismissed (not re-opened by the config change)
+- [ ] Spec documentation updated to reflect the new threat model
+
+## Test Scenarios
+
+- Given the CodeQL default setup is configured with `remote_and_local`, when the PATCH API
+  sets `threat_model=remote`, then GET returns `threat_model: "remote"` and `languages`
+  includes `actions`, `javascript-typescript`, and `python`
+- Given the config change triggers a re-analysis, when the analysis completes, then
+  `gh api repos/.../code-scanning/alerts?state=open --jq 'length'` returns `0`
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected -- infrastructure/tooling change.
+
+## Context
+
+- Parent issue: #2417 (closed, merged as PR #2416)
+- Deferred from brainstorm: `knowledge-base/project/brainstorms/2026-04-16-security-scanning-alerts-brainstorm.md`
+- Original enablement plan: `knowledge-base/project/plans/2026-04-10-feat-enable-github-security-quality-plan.md`
+- CodeQL API format learning: `knowledge-base/project/learnings/2026-04-10-codeql-api-dismissal-format.md`
+- AGENTS.md rule: `[id: hr-github-api-endpoints-with-enum]`
+
+## References
+
+- [GitHub CodeQL default setup API](https://docs.github.com/en/rest/code-scanning/code-scanning#update-a-code-scanning-default-setup-configuration)
+- Issue: #2418

--- a/knowledge-base/project/plans/2026-04-16-sec-switch-codeql-threat-model-remote-only-plan.md
+++ b/knowledge-base/project/plans/2026-04-16-sec-switch-codeql-threat-model-remote-only-plan.md
@@ -6,6 +6,34 @@ date: 2026-04-16
 
 # sec: Switch CodeQL threat model from remote_and_local to remote only
 
+## Enhancement Summary
+
+**Deepened on:** 2026-04-16
+**Sections enhanced:** 2 (Proposed Solution, Implementation Phase 1)
+**Research sources:** Context7 GitHub REST API docs, institutional learnings (3 files),
+live API verification
+
+### Key Improvements
+
+1. **Fixed broken API call format** -- replaced `--field` with `--input -` heredoc for array
+   parameters, preventing HTTP 422 (institutional learning
+   `2026-04-10-github-security-enablement-api-patterns.md`)
+2. **Corrected language list expectation** -- current config has 5 language entries (GitHub
+   auto-expands `javascript-typescript`), not 3. Verification step now checks for all 5.
+3. **Added post-PATCH verification for silent failures** -- GitHub API can return 200 OK
+   without applying changes (learning from secret scanning enablement); plan now includes
+   immediate GET verification after PATCH.
+
+### Relevant Institutional Learnings Applied
+
+- `2026-04-10-github-security-enablement-api-patterns.md` -- `--field` wraps arrays as
+  strings; use `--input -` with heredoc. After any settings PATCH, immediately re-read to
+  verify the change was applied.
+- `2026-04-10-codeql-api-dismissal-format.md` -- GitHub API enum format uses space-separated
+  strings, not snake_case. (Not directly applicable here but context for the API surface.)
+- `2026-04-13-codeql-to-issues-invalid-workflow-trigger.md` -- CodeQL alert polling pattern
+  context; confirms the daily cron + deduplication approach for alert-to-issue tracking.
+
 ## Overview
 
 Switch the CodeQL default setup threat model from `remote_and_local` to `remote` to reduce
@@ -38,18 +66,30 @@ continue to trigger false positives for the same patterns, creating ongoing tria
 
 ## Proposed Solution
 
-A single GitHub API call to update the CodeQL default setup configuration:
+A single GitHub API call to update the CodeQL default setup configuration. Use `--input -`
+with a heredoc JSON body, not `--field`, because `--field` wraps arrays as strings causing
+HTTP 422 (documented in learning `2026-04-10-github-security-enablement-api-patterns.md`):
 
 ```bash
 gh api -X PATCH repos/jikig-ai/soleur/code-scanning/default-setup \
-  --field state=configured \
-  --field query_suite=extended \
-  --field 'languages=["actions","javascript-typescript","python"]' \
-  --field threat_model=remote
+  --input - <<'JSONEOF'
+{
+  "state": "configured",
+  "query_suite": "extended",
+  "languages": ["actions", "javascript-typescript", "python"],
+  "threat_model": "remote"
+}
+JSONEOF
 ```
 
-This preserves the `extended` query suite and explicitly includes the language list (the PATCH
-endpoint may reset omitted fields) while restricting taint sources to network requests only.
+**Note on languages:** The current GET response shows 5 language entries (`actions`,
+`javascript`, `javascript-typescript`, `python`, `typescript`) because GitHub auto-expands
+`javascript-typescript` into separate entries. Sending `["actions", "javascript-typescript",
+"python"]` in the PATCH is correct -- GitHub re-derives the expanded set. Verify via GET after
+PATCH that all 5 entries are still present.
+
+This preserves the `extended` query suite and all language coverage while restricting taint
+sources to network requests only.
 
 ### Why this is safe
 
@@ -67,19 +107,23 @@ endpoint may reset omitted fields) while restricting taint sources to network re
 ### Phase 1: Switch threat model and verify
 
 1. Run the PATCH API call to update `threat_model` from `remote_and_local` to `remote`.
-   Include `languages` in the PATCH to prevent the API from resetting the language list to
-   defaults (the GitHub default setup PATCH may reset omitted fields):
+   Use `--input -` with heredoc (not `--field` -- `--field` wraps arrays as strings, HTTP 422):
 
    ```bash
    gh api -X PATCH repos/jikig-ai/soleur/code-scanning/default-setup \
-     --field state=configured \
-     --field query_suite=extended \
-     --field 'languages=["actions","javascript-typescript","python"]' \
-     --field threat_model=remote
+     --input - <<'JSONEOF'
+   {
+     "state": "configured",
+     "query_suite": "extended",
+     "languages": ["actions", "javascript-typescript", "python"],
+     "threat_model": "remote"
+   }
+   JSONEOF
    ```
 
 2. Verify the change via GET: `gh api repos/jikig-ai/soleur/code-scanning/default-setup`
-   -- confirm `threat_model` is `remote` and `languages` are preserved
+   -- confirm `threat_model` is `remote` and all 5 language entries are preserved
+   (`actions`, `javascript`, `javascript-typescript`, `python`, `typescript`)
 3. Poll for re-analysis completion via the analyses endpoint:
    `gh api repos/jikig-ai/soleur/code-scanning/analyses?tool_name=CodeQL --jq '.[0] | {created_at, results_count}'`
    -- wait for a new analysis with `created_at` after the config change timestamp
@@ -97,7 +141,8 @@ endpoint may reset omitted fields) while restricting taint sources to network re
 ## Acceptance Criteria
 
 - [ ] CodeQL default setup `threat_model` field reads `remote` (not `remote_and_local`)
-- [ ] Language list preserved after PATCH (actions, javascript-typescript, python)
+- [ ] Language list preserved after PATCH (all 5 entries: actions, javascript,
+  javascript-typescript, python, typescript)
 - [ ] CodeQL re-analysis completes successfully after the config change
 - [ ] Previously dismissed alerts remain dismissed (not re-opened by the config change)
 - [ ] Spec documentation updated to reflect the new threat model

--- a/knowledge-base/project/specs/feat-enable-github-security-quality/session-state.md
+++ b/knowledge-base/project/specs/feat-enable-github-security-quality/session-state.md
@@ -21,3 +21,12 @@ None
 
 - soleur:plan -- created initial plan with local research, domain review, API verification, and learnings integration
 - soleur:deepen-plan -- enhanced plan with external research, learnings integration, live API queries
+
+## Threat Model Update (2026-04-16)
+
+- **Change:** Switched CodeQL threat model from `remote_and_local` to `remote`
+- **Issue:** #2418
+- **Reason:** 100 false positives from `local` taint sources (env vars, file paths)
+  dismissed in PR #2416. Switching to `remote` prevents recurrence on future PRs.
+- **API:** `gh api -X PATCH repos/jikig-ai/soleur/code-scanning/default-setup`
+  with `"threat_model": "remote"`

--- a/knowledge-base/project/specs/feat-enable-github-security-quality/session-state.md
+++ b/knowledge-base/project/specs/feat-enable-github-security-quality/session-state.md
@@ -13,7 +13,7 @@ None
 
 - Use CodeQL default setup (managed by GitHub) over advanced setup (custom workflow YAML) since the repository has no compiled languages requiring custom build steps
 - Use the extended query suite to cover both security vulnerabilities AND code quality findings
-- Use remote_and_local threat model instead of default remote because the repo's shell scripts and GitHub Actions workflows heavily use environment variables and CLI arguments as data sources
+- Use remote_and_local threat model instead of default remote because the repo's shell scripts and GitHub Actions workflows heavily use environment variables and CLI arguments as data sources *(Superseded 2026-04-16: switched to `remote` — see Threat Model Update below)*
 - Include actions, javascript-typescript, python languages; exclude ruby (only template assets, not runtime code)
 - Keep CodeQL advisory-only (not added to CI Required ruleset) for initial rollout to avoid disrupting existing workflows
 

--- a/knowledge-base/project/specs/feat-enable-github-security-quality/tasks.md
+++ b/knowledge-base/project/specs/feat-enable-github-security-quality/tasks.md
@@ -27,6 +27,13 @@ date: 2026-04-10
 - [x] 2.4 Triage any initial code scanning alerts
   - 84 alerts (63 error, 21 warning) across 11 rules. Tracking issue #1894 created
 
+## Phase 2b: Threat Model Tuning
+
+- [x] 2b.1 Switch CodeQL threat model from `remote_and_local` to `remote`
+  - [Updated 2026-04-16] Threat model switched to `remote` only (see #2418).
+    100 false positives from `local` taint sources (env vars, file paths) were
+    dismissed in PR #2416. Switching to `remote` prevents recurrence on future PRs.
+
 ## Phase 3: Verification
 
 - [x] 3.1 Verify all features via API

--- a/knowledge-base/project/specs/feat-one-shot-codeql-threat-model/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-codeql-threat-model/session-state.md
@@ -1,0 +1,24 @@
+# Session State
+
+## Plan Phase
+
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-one-shot-codeql-threat-model/knowledge-base/project/plans/2026-04-16-sec-switch-codeql-threat-model-remote-only-plan.md
+- Status: complete
+
+### Errors
+
+None
+
+### Decisions
+
+- Used MINIMAL template -- this is a single API call config change, not a code feature
+- Fixed API call format from `--field` to `--input -` with heredoc JSON body, preventing HTTP 422 (caught by institutional learning)
+- Corrected language list expectation: current config has 5 entries (GitHub auto-expands `javascript-typescript`), not the 3 originally specified
+- Merged implementation phases 1 and 2 into a single phase per reviewer feedback
+- Kept Phase 2 (documentation update) per Kieran reviewer -- 30 seconds of effort prevents spec confusion
+
+### Components Invoked
+
+- soleur:plan
+- soleur:plan-review (DHH, Kieran, Code Simplicity reviewers)
+- soleur:deepen-plan (institutional learnings, Context7 API docs, live API verification)

--- a/knowledge-base/project/specs/feat-one-shot-codeql-threat-model/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-codeql-threat-model/tasks.md
@@ -1,6 +1,6 @@
 ---
 title: "Switch CodeQL threat model to remote only"
-status: pending
+status: complete
 date: 2026-04-16
 ---
 
@@ -8,12 +8,12 @@ date: 2026-04-16
 
 ## Phase 1: Switch threat model and verify
 
-- [ ] 1.1 Run PATCH API call to set `threat_model=remote` (include `languages` to prevent reset)
-- [ ] 1.2 Verify via GET that `threat_model` is `remote` and `languages` are preserved
-- [ ] 1.3 Poll analyses endpoint for re-analysis completion after config change
-- [ ] 1.4 Verify zero open alerts after re-analysis
+- [x] 1.1 Run PATCH API call to set `threat_model=remote` (include `languages` to prevent reset)
+- [x] 1.2 Verify via GET that `threat_model` is `remote` and `languages` are preserved
+- [x] 1.3 Poll analyses endpoint for re-analysis completion after config change
+- [x] 1.4 Verify zero open alerts after re-analysis
 
 ## Phase 2: Update documentation
 
-- [ ] 2.1 Add `[Updated 2026-04-16]` note to `knowledge-base/project/specs/feat-enable-github-security-quality/tasks.md` recording threat model switch
-- [ ] 2.2 Add `[Updated 2026-04-16]` note to `knowledge-base/project/specs/feat-enable-github-security-quality/session-state.md`
+- [x] 2.1 Add `[Updated 2026-04-16]` note to `knowledge-base/project/specs/feat-enable-github-security-quality/tasks.md` recording threat model switch
+- [x] 2.2 Add `[Updated 2026-04-16]` note to `knowledge-base/project/specs/feat-enable-github-security-quality/session-state.md`

--- a/knowledge-base/project/specs/feat-one-shot-codeql-threat-model/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-codeql-threat-model/tasks.md
@@ -1,0 +1,19 @@
+---
+title: "Switch CodeQL threat model to remote only"
+status: pending
+date: 2026-04-16
+---
+
+# Tasks: Switch CodeQL threat model to remote only
+
+## Phase 1: Switch threat model and verify
+
+- [ ] 1.1 Run PATCH API call to set `threat_model=remote` (include `languages` to prevent reset)
+- [ ] 1.2 Verify via GET that `threat_model` is `remote` and `languages` are preserved
+- [ ] 1.3 Poll analyses endpoint for re-analysis completion after config change
+- [ ] 1.4 Verify zero open alerts after re-analysis
+
+## Phase 2: Update documentation
+
+- [ ] 2.1 Add `[Updated 2026-04-16]` note to `knowledge-base/project/specs/feat-enable-github-security-quality/tasks.md` recording threat model switch
+- [ ] 2.2 Add `[Updated 2026-04-16]` note to `knowledge-base/project/specs/feat-enable-github-security-quality/session-state.md`


### PR DESCRIPTION
## Summary

- Switch CodeQL default setup threat model from `remote_and_local` to `remote` via GitHub API
- Reduces false positive volume from local taint sources (env vars, file paths) that produced 100 dismissed alerts
- All 5 language entries preserved, `extended` query suite unchanged
- Verified: zero open alerts after re-analysis, 100 dismissed alerts remain dismissed

Closes #2418

## Changelog

- Switched CodeQL threat model to `remote` only, eliminating false positives from `local` taint sources
- Updated spec documentation to record the threat model change

## Test plan

- [x] GET `/code-scanning/default-setup` returns `threat_model: "remote"`
- [x] Language list preserved (actions, javascript, javascript-typescript, python, typescript)
- [x] CodeQL re-analysis completed successfully (run 24507779760)
- [x] Zero open alerts after re-analysis
- [x] 100 dismissed alerts remain dismissed

Generated with [Claude Code](https://claude.com/claude-code)