### PR TITLE
fix(dashboard): unify sidebar collapse toggle position

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/kb/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/kb/layout.tsx
@@ -255,6 +255,7 @@ export default function KbLayout({ children }: { children: ReactNode }) {
                 <button
                   onClick={toggleKbCollapsed}
                   aria-label="Collapse file tree"
+                  title="Collapse file tree (⌘B)"
                   className="hidden md:flex h-6 w-6 items-center justify-center rounded text-neutral-400 hover:bg-neutral-800 hover:text-white"
                 >
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
@@ -281,6 +282,7 @@ export default function KbLayout({ children }: { children: ReactNode }) {
               <button
                 onClick={toggleKbCollapsed}
                 aria-label="Expand file tree"
+                title="Expand file tree (⌘B)"
                 className="hidden md:flex m-2 h-8 w-8 items-center justify-center rounded-lg border border-neutral-800 text-neutral-400 hover:bg-neutral-800 hover:text-white"
               >
                 <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>

--- a/apps/web-platform/app/(dashboard)/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/layout.tsx
@@ -227,7 +227,7 @@ export default function DashboardLayout({
           ${collapsed ? "md:w-14" : "md:w-56"}
         `}
       >
-        {/* Brand + close button */}
+        {/* Brand + close/collapse buttons */}
         <div className={`flex items-center justify-between safe-top ${collapsed ? "px-2 py-5" : "px-5 py-5"}`}>
           <span className={`text-lg font-semibold tracking-tight text-white overflow-hidden whitespace-nowrap ${collapsed ? "md:hidden" : ""}`}>
             Soleur
@@ -238,6 +238,19 @@ export default function DashboardLayout({
             className="flex h-10 w-10 items-center justify-center rounded-lg text-neutral-400 hover:bg-neutral-800 hover:text-white md:hidden"
           >
             <XIcon className="h-5 w-5" />
+          </button>
+          {/* Collapse toggle — hidden on mobile, visible on md+ */}
+          <button
+            onClick={toggleCollapsed}
+            aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+            title={collapsed ? "Expand sidebar (⌘B)" : "Collapse sidebar (⌘B)"}
+            className="hidden md:flex h-6 w-6 items-center justify-center rounded text-neutral-400 hover:bg-neutral-800 hover:text-white"
+          >
+            {collapsed ? (
+              <ChevronRightIcon className="h-4 w-4" />
+            ) : (
+              <ChevronLeftIcon className="h-4 w-4" />
+            )}
           </button>
         </div>
 
@@ -296,19 +309,6 @@ export default function DashboardLayout({
           >
             <LogOutIcon className="h-4 w-4 shrink-0" />
             <span className={`overflow-hidden whitespace-nowrap ${collapsed ? "md:hidden" : ""}`}>Sign out</span>
-          </button>
-          {/* Collapse toggle — hidden on mobile, visible on md+ */}
-          <button
-            onClick={toggleCollapsed}
-            aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-            className={`hidden md:flex min-h-[44px] w-full items-center gap-3 rounded-lg px-3 py-2 text-sm text-neutral-400 transition-colors hover:bg-neutral-800/50 hover:text-neutral-200 ${collapsed ? "md:justify-center md:gap-0 md:px-0" : ""}`}
-          >
-            {collapsed ? (
-              <ChevronRightIcon className="h-4 w-4 shrink-0" />
-            ) : (
-              <ChevronLeftIcon className="h-4 w-4 shrink-0" />
-            )}
-            <span className={`overflow-hidden whitespace-nowrap ${collapsed ? "md:hidden" : ""}`}>Collapse</span>
           </button>
         </div>
       </aside>

--- a/apps/web-platform/components/settings/settings-shell.tsx
+++ b/apps/web-platform/components/settings/settings-shell.tsx
@@ -38,9 +38,21 @@ export function SettingsShell({ children }: { children: React.ReactNode }) {
         className={`hidden shrink-0 border-r border-neutral-800 md:block
         md:transition-[width] md:duration-200 md:ease-out
         ${settingsCollapsed ? "md:w-0 md:overflow-hidden md:border-r-0" : "w-48 px-4 py-10"}`}>
-        <h2 className="mb-4 text-xs font-medium uppercase tracking-wider text-neutral-500">
-          Settings
-        </h2>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-xs font-medium uppercase tracking-wider text-neutral-500">
+            Settings
+          </h2>
+          <button
+            onClick={toggleSettingsCollapsed}
+            aria-label="Collapse settings nav"
+            title="Collapse settings nav (⌘B)"
+            className="flex h-6 w-6 items-center justify-center rounded text-neutral-400 hover:bg-neutral-800 hover:text-white"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+            </svg>
+          </button>
+        </div>
         <ul className="space-y-1">
           {SETTINGS_TABS.map((tab) => {
             const active =
@@ -64,16 +76,6 @@ export function SettingsShell({ children }: { children: React.ReactNode }) {
             );
           })}
         </ul>
-        <button
-          onClick={toggleSettingsCollapsed}
-          aria-label="Collapse settings nav"
-          className="mt-6 flex w-full items-center gap-2 rounded-lg px-3 py-2 text-xs text-neutral-500 transition-colors hover:bg-neutral-800/50 hover:text-neutral-200"
-        >
-          <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
-          </svg>
-          Collapse
-        </button>
       </nav>
 
       {/* Mobile tab bar */}
@@ -104,6 +106,7 @@ export function SettingsShell({ children }: { children: React.ReactNode }) {
           <button
             onClick={toggleSettingsCollapsed}
             aria-label="Expand settings nav"
+            title="Expand settings nav (⌘B)"
             className="hidden md:flex mb-4 h-8 w-8 items-center justify-center rounded-lg border border-neutral-800 text-neutral-400 hover:bg-neutral-800 hover:text-white"
           >
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>


### PR DESCRIPTION
## Summary

- Move main sidebar collapse toggle from footer to header (next to "Soleur" text)
- Move settings sidebar collapse toggle from mid-nav to header (next to "Settings" title)
- KB sidebar toggle already in header — no position change
- Add `⌘B` keyboard shortcut hint in tooltip on all toggle buttons
- Remove "Collapse" text labels — icon-only toggles throughout

All three sidebars now have a consistent affordance: icon-only chevron toggle in the header top-right corner.

Ref #2342

## Changelog

- Unified collapse toggle position to header top-right across main, KB, and settings sidebars
- Added `title` tooltip with keyboard shortcut hint (`⌘B`) to all toggle buttons

## Test plan

- [x] 40 sidebar tests pass (hook + main + KB + settings)
- [x] Full suite: 1527 passed, 0 failed
- [ ] Browser verification: check toggle position on all three sidebar surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)