### PR TITLE
fix(kb-chat): load message history on resumed conversations

### DIFF
--- a/apps/web-platform/components/chat/kb-chat-sidebar.tsx
+++ b/apps/web-platform/components/chat/kb-chat-sidebar.tsx
@@ -141,7 +141,7 @@ export function KbChatSidebar({ open, onClose, contextPath }: KbChatSidebarProps
         </header>
         {resumedBanner && (
           <div className="shrink-0 border-b border-neutral-800 bg-neutral-900/60 px-3 py-1.5 text-xs text-neutral-400">
-            Continuing from {new Date(resumedBanner.timestamp).toLocaleDateString()}
+            Continuing from {new Date(resumedBanner.timestamp).toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" })}
           </div>
         )}
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">

--- a/apps/web-platform/components/chat/kb-chat-sidebar.tsx
+++ b/apps/web-platform/components/chat/kb-chat-sidebar.tsx
@@ -21,6 +21,7 @@ export function KbChatSidebar({ open, onClose, contextPath }: KbChatSidebarProps
   const { setMessageCount, registerQuoteHandler } = useKbChat();
   const [resumedBanner, setResumedBanner] = useState<{ timestamp: string } | null>(null);
   const [openedEmitted, setOpenedEmitted] = useState<string | null>(null);
+  const historicalCountRef = useRef<number>(0);
   const quoteRef = useRef<ChatInputQuoteHandle | null>(null);
 
   // Register an insertQuote handler with KbChatContext while mounted.
@@ -63,6 +64,7 @@ export function KbChatSidebar({ open, onClose, contextPath }: KbChatSidebarProps
   useEffect(() => {
     setResumedBanner(null);
     setOpenedEmitted(null);
+    historicalCountRef.current = 0;
   }, [contextPath]);
 
   // Derive a file name from the context path for the header display.
@@ -76,6 +78,7 @@ export function KbChatSidebar({ open, onClose, contextPath }: KbChatSidebarProps
   const handleThreadResumed = useCallback(
     (_conversationId: string, timestamp: string, messageCount: number) => {
       setResumedBanner({ timestamp });
+      historicalCountRef.current = messageCount;
       setMessageCount(messageCount);
       if (openedEmitted !== contextPath) {
         void track("kb.chat.opened", { path: contextPath });
@@ -99,11 +102,11 @@ export function KbChatSidebar({ open, onClose, contextPath }: KbChatSidebarProps
   const handleMessageCountChange = useCallback(
     (count: number) => {
       setMessageCount(count);
-      // AC2: auto-dismiss the "Continuing from …" banner once the user has
-      // sent a new message in this session. `messages` on a resumed thread
-      // starts empty (the server doesn't replay history) — so any count > 0
-      // means fresh activity in the current session.
-      if (count > 0) {
+      // AC2+AC7: auto-dismiss the "Continuing from …" banner once the user
+      // sends a NEW message — i.e. count exceeds the historical message count.
+      // History loading (count going from 0 → historicalCount) must NOT dismiss
+      // the banner; only fresh user activity beyond the historical count does.
+      if (count > historicalCountRef.current) {
         setResumedBanner(null);
       }
     },

--- a/apps/web-platform/lib/ws-client.ts
+++ b/apps/web-platform/lib/ws-client.ts
@@ -429,6 +429,60 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
     return () => controller.abort();
   }, [conversationId]);
 
+  // Fetch history for resumed sessions where conversationId="new" (sidebar resume path).
+  // The existing effect above skips "new" IDs. When the server responds with
+  // session_resumed, realConversationId transitions from null → UUID. This effect
+  // catches that transition and fetches history for the resolved conversation. #2425
+  useEffect(() => {
+    if (!realConversationId) return;
+    if (realConversationId === conversationId) return; // existing effect handles this
+    if (conversationId !== "new") return; // only the sidebar resume path
+
+    const controller = new AbortController();
+
+    (async () => {
+      try {
+        const supabase = createClient();
+        const { data: { session } } = await supabase.auth.getSession();
+        if (!session?.access_token) return;
+
+        const res = await fetch(
+          `/api/conversations/${realConversationId}/messages`,
+          {
+            headers: { Authorization: `Bearer ${session.access_token}` },
+            signal: controller.signal,
+          },
+        );
+        if (!res.ok) return;
+
+        const { messages: history } = await res.json();
+        const mapped: ChatMessage[] = history.map((m: { id: string; role: string; content: string; leader_id: string | null }) => ({
+          id: m.id,
+          role: m.role as "user" | "assistant",
+          content: m.content,
+          type: "text" as const,
+          leaderId: m.leader_id ?? undefined,
+          state: m.role === "assistant" ? ("done" as const) : undefined,
+        }));
+
+        // Deduplicate: filter out any messages already present from stream events
+        // that arrived while the fetch was in-flight (AC4). More robust than the
+        // activeStreamsRef.size === 0 guard: handles the window where a stream
+        // event arrives and completes before the fetch resolves.
+        setMessages(prev => {
+          const existingIds = new Set(prev.map(m => m.id));
+          const unique = mapped.filter(m => !existingIds.has(m.id));
+          return [...unique, ...prev];
+        });
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        console.error("Failed to load resume history:", err);
+      }
+    })();
+
+    return () => controller.abort();
+  }, [realConversationId, conversationId]);
+
   useEffect(() => {
     mountedRef.current = true;
     setLastError(null);

--- a/apps/web-platform/lib/ws-client.ts
+++ b/apps/web-platform/lib/ws-client.ts
@@ -389,6 +389,11 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
     targetId: string,
     signal: AbortSignal,
   ): Promise<ChatMessage[] | null> {
+    // Validate targetId is a safe path segment to satisfy CodeQL's
+    // request-forgery check. Allows UUIDs and alphanumeric IDs only.
+    // The server enforces ownership via user_id.
+    if (!/^[0-9a-zA-Z-]+$/.test(targetId)) return null;
+
     const supabase = createClient();
     const { data: { session } } = await supabase.auth.getSession();
     if (!session?.access_token) return null;

--- a/apps/web-platform/lib/ws-client.ts
+++ b/apps/web-platform/lib/ws-client.ts
@@ -383,6 +383,41 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
     };
   }, [getWsUrlAndToken, teardown]);
 
+  /** Fetch and map conversation history from the messages API. Shared by
+   *  the mount-time effect (non-"new" IDs) and the resume effect ("new" → UUID). */
+  async function fetchConversationHistory(
+    targetId: string,
+    signal: AbortSignal,
+  ): Promise<ChatMessage[] | null> {
+    const supabase = createClient();
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session?.access_token) return null;
+
+    const res = await fetch(
+      `/api/conversations/${targetId}/messages`,
+      {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+        signal,
+      },
+    );
+    if (!res.ok) {
+      console.warn(`History fetch failed for ${targetId}: ${res.status}`);
+      return null;
+    }
+
+    const { messages: history } = await res.json();
+    return history.map((m: { id: string; role: string; content: string; leader_id: string | null }) => ({
+      id: m.id,
+      role: m.role as "user" | "assistant",
+      content: m.content,
+      type: "text" as const,
+      leaderId: m.leader_id ?? undefined,
+      // Assistant messages loaded from DB are persisted from stream_end —
+      // they are complete by definition. See #2139.
+      state: m.role === "assistant" ? ("done" as const) : undefined,
+    }));
+  }
+
   // Fetch conversation history on mount (once per conversationId)
   useEffect(() => {
     if (conversationId === "new") return;
@@ -390,32 +425,8 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
 
     (async () => {
       try {
-        const supabase = createClient();
-        const { data: { session } } = await supabase.auth.getSession();
-        if (!session?.access_token) return;
-
-        const res = await fetch(
-          `/api/conversations/${conversationId}/messages`,
-          {
-            headers: { Authorization: `Bearer ${session.access_token}` },
-            signal: controller.signal,
-          },
-        );
-        if (!res.ok) return;
-
-        const { messages: history } = await res.json();
-        const mapped: ChatMessage[] = history.map((m: { id: string; role: string; content: string; leader_id: string | null }) => ({
-          id: m.id,
-          role: m.role as "user" | "assistant",
-          content: m.content,
-          type: "text" as const,
-          leaderId: m.leader_id ?? undefined,
-          // Assistant messages loaded from DB are persisted from stream_end —
-          // they are complete by definition. Assigning state: "done" up-front
-          // eliminates the fallback heuristic that the rendering chain used
-          // to infer completion from `!messageState && content !== ""`. See #2139.
-          state: m.role === "assistant" ? ("done" as const) : undefined,
-        }));
+        const mapped = await fetchConversationHistory(conversationId, controller.signal);
+        if (!mapped || !mountedRef.current) return;
 
         if (activeStreamsRef.current.size === 0) {
           setMessages(prev => [...mapped, ...prev]);
@@ -442,31 +453,11 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
 
     (async () => {
       try {
-        const supabase = createClient();
-        const { data: { session } } = await supabase.auth.getSession();
-        if (!session?.access_token) return;
-
-        const res = await fetch(
-          `/api/conversations/${realConversationId}/messages`,
-          {
-            headers: { Authorization: `Bearer ${session.access_token}` },
-            signal: controller.signal,
-          },
-        );
-        if (!res.ok) return;
-
-        const { messages: history } = await res.json();
-        const mapped: ChatMessage[] = history.map((m: { id: string; role: string; content: string; leader_id: string | null }) => ({
-          id: m.id,
-          role: m.role as "user" | "assistant",
-          content: m.content,
-          type: "text" as const,
-          leaderId: m.leader_id ?? undefined,
-          state: m.role === "assistant" ? ("done" as const) : undefined,
-        }));
+        const mapped = await fetchConversationHistory(realConversationId, controller.signal);
+        if (!mapped || !mountedRef.current) return;
 
         // Deduplicate: filter out any messages already present from stream events
-        // that arrived while the fetch was in-flight (AC4). More robust than the
+        // that arrived while the fetch was in-flight. More robust than the
         // activeStreamsRef.size === 0 guard: handles the window where a stream
         // event arrives and completes before the fetch resolves.
         setMessages(prev => {

--- a/apps/web-platform/test/kb-chat-sidebar-banner-dismiss.test.tsx
+++ b/apps/web-platform/test/kb-chat-sidebar-banner-dismiss.test.tsx
@@ -95,10 +95,13 @@ describe("KbChatSidebar — resumed banner auto-dismiss (AC2)", () => {
     const { rerender } = await renderSidebar();
     expect(screen.getByText(/continuing from/i)).toBeTruthy();
 
-    // Simulate: user sends a new message. The WS client's `messages` state
-    // goes from [] to [user], triggering ChatSurface's onMessageCountChange
-    // with count=1.
+    // Simulate: history loads first (3 historical messages), then user sends
+    // a new message (count goes from 3 → 4). The banner should dismiss only
+    // when count exceeds the historical message count (3).
     wsReturn.messages = [
+      { id: "hist-1", role: "user", content: "old question", type: "text" },
+      { id: "hist-2", role: "assistant", content: "old answer", type: "text" },
+      { id: "hist-3", role: "user", content: "follow-up", type: "text" },
       { id: "u1", role: "user", content: "new question", type: "text" },
     ];
     const { KbChatSidebar } = await import("@/components/chat/kb-chat-sidebar");
@@ -126,6 +129,96 @@ describe("KbChatSidebar — resumed banner auto-dismiss (AC2)", () => {
       );
     });
 
+    expect(screen.queryByText(/continuing from/i)).toBeNull();
+  });
+
+  it("does NOT dismiss the banner when history messages load (AC7)", async () => {
+    // Simulate: history loads, populating messages from 0 → 3.
+    // The banner must persist because these are historical messages, not
+    // fresh user activity. The old guard (count > 0) would dismiss here.
+    wsReturn.messages = [
+      { id: "hist-1", role: "user", content: "old question", type: "text" },
+      { id: "hist-2", role: "assistant", content: "old answer", type: "text" },
+      { id: "hist-3", role: "user", content: "follow-up", type: "text" },
+    ];
+    const { KbChatSidebar } = await import("@/components/chat/kb-chat-sidebar");
+    const { KbChatContext } = await import("@/components/kb/kb-chat-context");
+    const ctx = {
+      open: true,
+      openSidebar: vi.fn(),
+      closeSidebar: vi.fn(),
+      contextPath: "knowledge-base/x.md",
+      enabled: true,
+      submitQuote: vi.fn(),
+      registerQuoteHandler: vi.fn(),
+      messageCount: 3,
+      setMessageCount: vi.fn(),
+    };
+    const { rerender } = await renderSidebar();
+    expect(screen.getByText(/continuing from/i)).toBeTruthy();
+
+    act(() => {
+      rerender(
+        <KbChatContext value={ctx}>
+          <KbChatSidebar
+            open={true}
+            onClose={vi.fn()}
+            contextPath="knowledge-base/x.md"
+          />
+        </KbChatContext>,
+      );
+    });
+
+    // Banner should STILL be visible — history load is not a dismiss trigger
+    expect(screen.getByText(/continuing from/i)).toBeTruthy();
+  });
+
+  it("dismisses banner when user sends AFTER history loads (AC7)", async () => {
+    // First: history loads (3 messages)
+    wsReturn.messages = [
+      { id: "hist-1", role: "user", content: "old question", type: "text" },
+      { id: "hist-2", role: "assistant", content: "old answer", type: "text" },
+      { id: "hist-3", role: "user", content: "follow-up", type: "text" },
+    ];
+    const { KbChatSidebar } = await import("@/components/chat/kb-chat-sidebar");
+    const { KbChatContext } = await import("@/components/kb/kb-chat-context");
+    const makeCtx = (count: number) => ({
+      open: true,
+      openSidebar: vi.fn(),
+      closeSidebar: vi.fn(),
+      contextPath: "knowledge-base/x.md",
+      enabled: true,
+      submitQuote: vi.fn(),
+      registerQuoteHandler: vi.fn(),
+      messageCount: count,
+      setMessageCount: vi.fn(),
+    });
+    const { rerender } = await renderSidebar();
+
+    // History loads — banner persists
+    act(() => {
+      rerender(
+        <KbChatContext value={makeCtx(3)}>
+          <KbChatSidebar open={true} onClose={vi.fn()} contextPath="knowledge-base/x.md" />
+        </KbChatContext>,
+      );
+    });
+    expect(screen.getByText(/continuing from/i)).toBeTruthy();
+
+    // User sends a NEW message — count goes from 3 → 4
+    wsReturn.messages = [
+      ...wsReturn.messages,
+      { id: "u1", role: "user", content: "new question", type: "text" },
+    ];
+    act(() => {
+      rerender(
+        <KbChatContext value={makeCtx(4)}>
+          <KbChatSidebar open={true} onClose={vi.fn()} contextPath="knowledge-base/x.md" />
+        </KbChatContext>,
+      );
+    });
+
+    // NOW the banner should be dismissed
     expect(screen.queryByText(/continuing from/i)).toBeNull();
   });
 });

--- a/apps/web-platform/test/kb-chat-sidebar.test.tsx
+++ b/apps/web-platform/test/kb-chat-sidebar.test.tsx
@@ -157,4 +157,20 @@ describe("KbChatSidebar", () => {
     await renderSidebar(false);
     expect(screen.queryByLabelText("Close panel")).toBeNull();
   });
+
+  it("includes time in the resumed banner, not just date (AC2)", async () => {
+    wsReturn.resumedFrom = {
+      conversationId: "existing-xyz",
+      timestamp: "2026-04-16T14:15:00Z",
+      messageCount: 5,
+    };
+    wsReturn.realConversationId = "existing-xyz";
+    await renderSidebar(true);
+    const banner = screen.getByText(/Continuing from/);
+    const text = banner.textContent ?? "";
+    // The banner must include a time component (colon-separated hours:minutes),
+    // not just a date. toLocaleDateString() produces "4/16/2026" without time;
+    // toLocaleString() with timeStyle produces something like "2:15 PM".
+    expect(text).toMatch(/\d{1,2}:\d{2}/);
+  });
 });

--- a/apps/web-platform/test/ws-client-resume-history.test.tsx
+++ b/apps/web-platform/test/ws-client-resume-history.test.tsx
@@ -214,16 +214,15 @@ describe("useWebSocket — resume history fetch (AC1, AC3, AC4)", () => {
     // Clear the fetch spy calls from the existing effect
     fetchSpy.mockClear();
 
-    // Give effects time to run
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 50));
+    // Wait for any pending effects to settle deterministically
+    await waitFor(() => {
+      // No additional fetch calls from the resume effect — the guard
+      // (realConversationId === conversationId) prevents the resume
+      // effect from firing when both IDs match.
+      const resumeFetchCalls = fetchSpy.mock.calls.filter(
+        (call) => typeof call[0] === "string" && call[0].includes("conv-known-456"),
+      );
+      expect(resumeFetchCalls.length).toBe(0);
     });
-
-    // No additional fetch calls from the resume effect
-    const resumeFetchCalls = fetchSpy.mock.calls.filter(
-      (call) => typeof call[0] === "string" && call[0].includes("conv-known-456"),
-    );
-    // May be 0 or 1 (from the existing effect), but NOT from the new resume effect
-    expect(resumeFetchCalls.length).toBeLessThanOrEqual(1);
   });
 });

--- a/apps/web-platform/test/ws-client-resume-history.test.tsx
+++ b/apps/web-platform/test/ws-client-resume-history.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, type MockInstance, beforeEach, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 
 // --- Mocks ---
@@ -54,7 +54,7 @@ const historyMessages = [
 
 describe("useWebSocket — resume history fetch (AC1, AC3, AC4)", () => {
   let originalWebSocket: typeof globalThis.WebSocket;
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let fetchSpy: MockInstance;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web-platform/test/ws-client-resume-history.test.tsx
+++ b/apps/web-platform/test/ws-client-resume-history.test.tsx
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+// --- Mocks ---
+
+const mockGetSession = vi.fn().mockResolvedValue({
+  data: { session: { access_token: "test-token" } },
+});
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: { getSession: mockGetSession },
+  }),
+}));
+
+// Capture the WebSocket instance so tests can simulate server messages
+let wsInstance: {
+  onopen: ((ev: Event) => void) | null;
+  onmessage: ((ev: MessageEvent) => void) | null;
+  onclose: ((ev: CloseEvent) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  readyState: number;
+} | null = null;
+
+class MockWebSocket {
+  static OPEN = 1;
+  static CONNECTING = 0;
+  onopen: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  onclose: ((ev: CloseEvent) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  send = vi.fn();
+  close = vi.fn();
+  readyState = MockWebSocket.OPEN;
+  constructor() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    wsInstance = this;
+    // Simulate connection opening asynchronously
+    queueMicrotask(() => {
+      this.readyState = MockWebSocket.OPEN;
+      this.onopen?.(new Event("open"));
+    });
+  }
+}
+
+// History messages returned by the fetch mock
+const historyMessages = [
+  { id: "hist-1", role: "user", content: "Hello", leader_id: null },
+  { id: "hist-2", role: "assistant", content: "Hi there!", leader_id: "cto" },
+  { id: "hist-3", role: "user", content: "How are you?", leader_id: null },
+];
+
+describe("useWebSocket — resume history fetch (AC1, AC3, AC4)", () => {
+  let originalWebSocket: typeof globalThis.WebSocket;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wsInstance = null;
+
+    originalWebSocket = globalThis.WebSocket;
+    // @ts-expect-error — mock constructor shape
+    globalThis.WebSocket = MockWebSocket;
+
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ messages: historyMessages }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket;
+    fetchSpy.mockRestore();
+  });
+
+  /** Helper: simulate server sending a WS message to the client */
+  function serverSend(data: Record<string, unknown>) {
+    act(() => {
+      wsInstance?.onmessage?.(new MessageEvent("message", {
+        data: JSON.stringify(data),
+      }));
+    });
+  }
+
+  /** Helper: bring the hook to "connected + session confirmed" state */
+  async function connectAndAuth(result: { current: ReturnType<typeof import("@/lib/ws-client").useWebSocket> }) {
+    // Wait for WebSocket onopen + auth send
+    await waitFor(() => {
+      expect(wsInstance).not.toBeNull();
+      expect(wsInstance?.send).toHaveBeenCalled();
+    });
+
+    // Server confirms auth
+    serverSend({ type: "auth_ok" });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("connected");
+    });
+  }
+
+  it("fetches history when realConversationId is set from session_resumed", async () => {
+    const { useWebSocket } = await import("@/lib/ws-client");
+    const { result } = renderHook(() => useWebSocket("new"));
+
+    await connectAndAuth(result);
+
+    // Server sends session_resumed (the sidebar resume path)
+    serverSend({
+      type: "session_resumed",
+      conversationId: "conv-existing-123",
+      resumedFromTimestamp: "2026-04-16T14:15:00Z",
+      messageCount: 3,
+    });
+
+    // The new effect should fire and fetch history
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/conversations/conv-existing-123/messages",
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: "Bearer test-token" }),
+        }),
+      );
+    });
+
+    // Messages should contain the fetched history
+    await waitFor(() => {
+      expect(result.current.messages.length).toBe(3);
+      expect(result.current.messages[0].id).toBe("hist-1");
+      expect(result.current.messages[1].id).toBe("hist-2");
+      expect(result.current.messages[2].id).toBe("hist-3");
+    });
+  });
+
+  it("preserves chronological order (oldest first)", async () => {
+    const { useWebSocket } = await import("@/lib/ws-client");
+    const { result } = renderHook(() => useWebSocket("new"));
+
+    await connectAndAuth(result);
+
+    serverSend({
+      type: "session_resumed",
+      conversationId: "conv-existing-123",
+      resumedFromTimestamp: "2026-04-16T14:15:00Z",
+      messageCount: 3,
+    });
+
+    await waitFor(() => {
+      expect(result.current.messages.length).toBe(3);
+    });
+
+    // Verify order: user, assistant, user (oldest first)
+    expect(result.current.messages[0].role).toBe("user");
+    expect(result.current.messages[0].content).toBe("Hello");
+    expect(result.current.messages[1].role).toBe("assistant");
+    expect(result.current.messages[1].content).toBe("Hi there!");
+    expect(result.current.messages[2].role).toBe("user");
+    expect(result.current.messages[2].content).toBe("How are you?");
+  });
+
+  it("deduplicates messages if a stream event arrives during fetch", async () => {
+    const { useWebSocket } = await import("@/lib/ws-client");
+    const { result } = renderHook(() => useWebSocket("new"));
+
+    await connectAndAuth(result);
+
+    // Simulate a stream_start that creates a message with ID "hist-2"
+    // BEFORE the resume event fires (simulates race condition)
+    serverSend({
+      type: "stream_start",
+      leaderId: "cto",
+      messageId: "hist-2",
+    });
+
+    // Now server sends session_resumed — the history fetch should
+    // deduplicate "hist-2" which already exists from the stream
+    serverSend({
+      type: "session_resumed",
+      conversationId: "conv-existing-123",
+      resumedFromTimestamp: "2026-04-16T14:15:00Z",
+      messageCount: 3,
+    });
+
+    // Wait for history to load
+    await waitFor(() => {
+      // Should have history messages PLUS the stream message, but
+      // "hist-2" should appear only once (deduplication)
+      const hist2Count = result.current.messages.filter((m) => m.id === "hist-2").length;
+      expect(hist2Count).toBe(1);
+      // Total should be 3 (hist-1, hist-2 deduplicated, hist-3) + 0 extra
+      // The stream_start created a bubble for "hist-2" which history also contains
+      expect(result.current.messages.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  it("does NOT fetch history when conversationId is not 'new'", async () => {
+    const { useWebSocket } = await import("@/lib/ws-client");
+    // Using a real conversation ID (not "new") — the existing effect handles this
+    const { result } = renderHook(() => useWebSocket("conv-known-456"));
+
+    await connectAndAuth(result);
+
+    serverSend({
+      type: "session_started",
+      conversationId: "conv-known-456",
+    });
+
+    // The existing effect already fetches for non-"new" IDs.
+    // The new resume-specific effect should NOT fire because
+    // realConversationId matches the prop conversationId.
+    // Clear the fetch spy calls from the existing effect
+    fetchSpy.mockClear();
+
+    // Give effects time to run
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    // No additional fetch calls from the resume effect
+    const resumeFetchCalls = fetchSpy.mock.calls.filter(
+      (call) => typeof call[0] === "string" && call[0].includes("conv-known-456"),
+    );
+    // May be 0 or 1 (from the existing effect), but NOT from the new resume effect
+    expect(resumeFetchCalls.length).toBeLessThanOrEqual(1);
+  });
+});

--- a/knowledge-base/project/learnings/ui-bugs/2026-04-16-kb-chat-resume-empty-messages.md
+++ b/knowledge-base/project/learnings/ui-bugs/2026-04-16-kb-chat-resume-empty-messages.md
@@ -1,0 +1,63 @@
+---
+module: KB Chat
+date: 2026-04-16
+problem_type: ui_bug
+component: frontend_stimulus
+symptoms:
+  - "Resumed KB Chat sidebar shows 'Continuing from' header but chat area is empty"
+  - "'Send a message to get started' placeholder contradicts 'Continuing from' banner"
+  - "Banner dismisses immediately when history loads instead of persisting"
+  - "Resume banner date lacks time component for same-day disambiguation"
+root_cause: async_timing
+resolution_type: code_fix
+severity: high
+tags: [useeffect, react-hooks, prop-vs-state, history-fetch, deduplication, kb-chat]
+---
+
+# Learning: useEffect dependency on prop vs state causes missed history fetch on resume
+
+## Problem
+
+When resuming a KB Chat sidebar conversation, the "Continuing from" header appeared
+(server metadata loaded) but the chat area was empty. The history-fetching `useEffect`
+in `ws-client.ts` guards on `conversationId` (a prop), which stays `"new"` for the
+sidebar resume path. When the server responds with `session_resumed`, it sets
+`realConversationId` (state) to the actual UUID, but no effect watches that state
+transition to trigger the history fetch.
+
+Secondary issue: `handleMessageCountChange` dismissed the banner when `count > 0`,
+which fires immediately when history loads -- before the user sees the banner.
+
+## Solution
+
+1. **Added a second `useEffect`** watching `[realConversationId, conversationId]` that
+   fetches `/api/conversations/${realConversationId}/messages` when `realConversationId`
+   transitions from null to UUID and `conversationId === "new"`.
+
+2. **Extracted `fetchConversationHistory` helper** shared by both effects to eliminate
+   ~30 lines of duplication (auth, fetch, mapping, error handling).
+
+3. **Used Set-based deduplication** when prepending history: `existingIds = new Set(prev.map(m => m.id))`
+   to handle the race where a stream event arrives during the fetch.
+
+4. **Tracked `historicalCountRef`** from `onThreadResumed` callback. Banner only dismisses
+   when `count > historicalCountRef.current` (user sent a new message), not when history loads.
+
+5. **Changed `toLocaleDateString()` to `toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" })`**
+   for same-day conversation disambiguation.
+
+## Key Insight
+
+When a React hook uses a prop as an ID but the real ID is resolved asynchronously into
+state, effects keyed on the prop will never re-fire for the resolved ID. The fix is a
+second effect watching the state, with guards to avoid double-fetching when both IDs
+are the same. This is a general pattern for "deferred ID resolution" -- any hook that
+accepts a placeholder ID and later resolves the real one needs effects on both.
+
+When extracting shared fetch logic, different merge strategies (guard-based vs dedup-based)
+should be parameterized in the caller, not duplicated in the helper.
+
+## Tags
+
+category: ui-bugs
+module: KB Chat

--- a/knowledge-base/project/plans/2026-04-16-fix-kb-chat-resume-empty-messages-plan.md
+++ b/knowledge-base/project/plans/2026-04-16-fix-kb-chat-resume-empty-messages-plan.md
@@ -2,11 +2,30 @@
 title: "fix(kb-chat): resumed conversation shows empty chat -- messages not loaded"
 type: fix
 date: 2026-04-16
+deepened: 2026-04-16
 ---
 
 # fix(kb-chat): resumed conversation shows empty chat -- messages not loaded
 
 Closes #2425
+
+## Enhancement Summary
+
+**Deepened on:** 2026-04-16
+**Sections enhanced:** 4 (Implementation Phases, Test Scenarios, Acceptance Criteria, Root Cause Analysis)
+**Research sources:** Codebase analysis, institutional learnings, edge case discovery
+
+### Key Improvements
+
+1. Discovered a **banner premature dismissal bug** that would be introduced by Phase 1: `handleMessageCountChange` in `kb-chat-sidebar.tsx` dismisses the "Continuing from" banner when `messages.length > 0`, which will fire immediately when history loads -- before the user sees the banner
+2. Added explicit guidance on `useEffect` dependency arrays and cleanup patterns based on institutional learning `2026-04-16-module-scope-to-async-state-deps-mismatch.md`
+3. Added a `setMessages` deduplication guard using message IDs to prevent history/stream overlap (strengthens AC4)
+4. Added SSR/hydration consideration for `toLocaleString` -- test must pin locale to avoid flaky assertions across environments
+
+### New Considerations Discovered
+
+- The `handleMessageCountChange` callback comment explicitly documents the assumption that "messages on a resumed thread starts empty" -- fixing the bug invalidates this assumption and creates a cascading banner dismissal bug
+- The `connect` callback clears `setSessionConfirmed(false)` on reconnect, which resets `sessionStarted` in chat-surface.tsx via the status effect at line 177 -- this means a reconnect after resume would re-trigger `startSession`, potentially creating a duplicate session. The existing code handles this via `abortActiveSession` on the server side, but the client may briefly show stale messages from the aborted session
 
 ## Overview
 
@@ -48,6 +67,7 @@ This produces "4/16/2026" with no time. The fix: use `toLocaleString()` with opt
 - [ ] **AC4:** History messages do not duplicate if a new message arrives from a live stream while history is loading
 - [ ] **AC5:** The "Send a message to get started" placeholder does NOT appear when history messages are present
 - [ ] **AC6:** Auto-scroll to the bottom of the chat after history is loaded
+- [ ] **AC7:** The "Continuing from" banner remains visible after history messages load (not dismissed prematurely by the message count change handler)
 
 ## Implementation Phases
 
@@ -73,7 +93,41 @@ apps/web-platform/lib/ws-client.ts
   - Map and prepend to messages state using shared helper
 ```
 
-### Phase 2: Fix date format in resume banner
+#### Research Insights
+
+**Deduplication guard (strengthens AC4):** When prepending history to `messages`, use a Set of existing message IDs to filter out any messages that arrived via stream while the fetch was in-flight:
+
+```typescript
+setMessages(prev => {
+  const existingIds = new Set(prev.map(m => m.id));
+  const unique = mapped.filter(m => !existingIds.has(m.id));
+  return [...unique, ...prev];
+});
+```
+
+This is more robust than the `activeStreamsRef.current.size === 0` guard alone: it handles the window where a stream event arrives and completes (setting `size` back to 0) before the fetch resolves.
+
+**Dependency array audit (from learning `2026-04-16-module-scope-to-async-state-deps-mismatch.md`):** The new `useEffect` reads `realConversationId` (state) and `conversationId` (prop). Both must appear in the dependency array. Since `realConversationId` starts as `null` and transitions to a UUID, the effect naturally fires only once per resume. No additional guard needed beyond the null check.
+
+**Effect cleanup on `conversationId` change:** If `conversationId` changes (unlikely in sidebar but possible in full chat), the existing effect at line 432 resets the connection via `connect()`. The new effect's `AbortController` will abort any in-flight fetch, preventing stale history from landing in a new session's message list.
+
+### Phase 2: Fix banner premature dismissal
+
+**File:** `apps/web-platform/components/chat/kb-chat-sidebar.tsx`
+
+**Critical edge case discovered during deepening:** The `handleMessageCountChange` callback (line 99-111) has an explicit assumption in its comment: "messages on a resumed thread starts empty (the server doesn't replay history) -- so any count > 0 means fresh activity in the current session." Phase 1 invalidates this assumption. Once history loads, `messages.length` will immediately become > 0, triggering `setResumedBanner(null)` and dismissing the banner before the user sees it.
+
+**Fix:** Change the `count > 0` guard to track whether the count increase is from history vs. new user activity. The simplest approach: check if `resumedFrom` is set (meaning we just loaded history) and only dismiss the banner when the count exceeds the historical message count:
+
+```text
+apps/web-platform/components/chat/kb-chat-sidebar.tsx
+  - Track the initial history count from onThreadResumed's messageCount parameter
+  - In handleMessageCountChange, only dismiss banner when count > historicalMessageCount
+```
+
+Alternatively, remove the auto-dismiss from `handleMessageCountChange` entirely and rely on a separate "first user message sent" signal. The current approach conflates "messages exist" with "user sent a message."
+
+### Phase 3: Fix date format in resume banner
 
 **File:** `apps/web-platform/components/chat/kb-chat-sidebar.tsx`
 
@@ -84,15 +138,29 @@ apps/web-platform/components/chat/kb-chat-sidebar.tsx
   - Update toLocaleDateString() → toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" })
 ```
 
+#### Research Insights
+
+**SSR/hydration safety:** `toLocaleString` output depends on the runtime locale. In SSR (Node.js) vs. client (browser), the locale may differ, causing a hydration mismatch. This is safe here because the banner is client-only (it renders from `resumedBanner` state, which is set by an effect after mount -- never during SSR). However, tests must pin the locale to avoid flaky assertions:
+
+```typescript
+// In test: use a fixed locale for deterministic output
+const formatted = new Date("2026-04-16T14:15:00Z")
+  .toLocaleString("en-US", { dateStyle: "short", timeStyle: "short" });
+// -> "4/16/26, 2:15 PM"
+```
+
 **Verification note (AC5):** The empty-state placeholder in `chat-surface.tsx` (line 359-365) checks `messages.length === 0`. Phase 1 populates `messages` with history, so the placeholder hides naturally. No code change needed -- covered by test scenarios.
 
 ## Test Scenarios
 
 - Given a KB Chat sidebar with an existing conversation for a document, when the sidebar opens and `session_resumed` fires, then prior messages appear in the chat area
 - Given a resumed session with 5 historical messages, when the history loads, then messages appear in chronological order (oldest first, newest last)
-- Given a resumed session where a live stream event arrives during history fetch, when both complete, then no duplicate messages appear
+- Given a resumed session where a live stream event arrives during history fetch, when both complete, then no duplicate messages appear (deduplication by message ID)
 - Given a resumed session, when the "Continuing from" banner is visible, then it shows both date and time (e.g., "4/16/2026, 2:15 PM")
 - Given a resumed session with loaded history, then the "Send a message to get started" placeholder is NOT visible
+- Given a resumed session with loaded history (e.g., 5 messages), then the "Continuing from" banner is still visible (not dismissed by the message count change)
+- Given a resumed session with loaded history, when the user sends a NEW message (count goes from 5 to 6), then the "Continuing from" banner is dismissed
+- Given a resumed session, when `toLocaleString` is called in tests, the assertion pins the locale to avoid environment-dependent flakiness
 
 ## Context
 
@@ -100,8 +168,8 @@ apps/web-platform/components/chat/kb-chat-sidebar.tsx
 
 | File | Change |
 |------|--------|
-| `apps/web-platform/lib/ws-client.ts` | Add `useEffect` to fetch history when `realConversationId` is set from resume |
-| `apps/web-platform/components/chat/kb-chat-sidebar.tsx` | Change `toLocaleDateString()` to include time |
+| `apps/web-platform/lib/ws-client.ts` | Add `useEffect` to fetch history when `realConversationId` is set from resume; extract shared message mapper |
+| `apps/web-platform/components/chat/kb-chat-sidebar.tsx` | Fix banner premature dismissal (Phase 2); change `toLocaleDateString()` to include time (Phase 3) |
 
 ### Files to add tests
 

--- a/knowledge-base/project/plans/2026-04-16-fix-kb-chat-resume-empty-messages-plan.md
+++ b/knowledge-base/project/plans/2026-04-16-fix-kb-chat-resume-empty-messages-plan.md
@@ -1,0 +1,137 @@
+---
+title: "fix(kb-chat): resumed conversation shows empty chat -- messages not loaded"
+type: fix
+date: 2026-04-16
+---
+
+# fix(kb-chat): resumed conversation shows empty chat -- messages not loaded
+
+Closes #2425
+
+## Overview
+
+When resuming a previous KB Chat sidebar conversation, the header shows "Continuing from 4/16/2026" but the chat area is empty. The root cause is a missed history fetch: the sidebar always mounts `ChatSurface` with `conversationId="new"`, and the history-loading effect in `ws-client.ts` has a guard that exits early for `"new"` conversations. When the server responds with `session_resumed`, it sets `realConversationId` but the history fetch is keyed on the prop `conversationId`, not `realConversationId`, so history is never loaded.
+
+Additionally, the "Continuing from" banner date uses `toLocaleDateString()` which omits the time, making same-day conversations ambiguous.
+
+## Root Cause Analysis
+
+### Bug 1: Empty messages on resume
+
+The flow:
+
+1. `kb-chat-sidebar.tsx` mounts `ChatSurface` with `conversationId="new"` (line 146)
+2. `chat-surface.tsx` calls `useWebSocket("new")` which initializes `ws-client.ts`
+3. The history-fetching `useEffect` in `ws-client.ts` (line 387) checks `if (conversationId === "new") return;` -- this early-return skips the history fetch
+4. `chat-surface.tsx` calls `startSession({ resumeByContextPath })` (line 144-149)
+5. Server finds existing thread, sends `session_resumed` with the real conversation ID
+6. `ws-client.ts` handles `session_resumed` (line 320-328): sets `realConversationId` and `resumedFrom`
+7. **No history fetch occurs** because the effect at line 387 only depends on `conversationId` (the prop, which is still `"new"`)
+
+The fix: add a second `useEffect` in `ws-client.ts` that watches `realConversationId`. When `realConversationId` transitions from null to a value AND differs from the prop `conversationId`, fetch history from `/api/conversations/${realConversationId}/messages`.
+
+### Bug 2: Ambiguous date format
+
+In `kb-chat-sidebar.tsx` line 141:
+
+```tsx
+Continuing from {new Date(resumedBanner.timestamp).toLocaleDateString()}
+```
+
+This produces "4/16/2026" with no time. The fix: use `toLocaleString()` with options that include date and time (e.g., `toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" })`) to produce output like "4/16/2026, 2:15 PM".
+
+## Acceptance Criteria
+
+- [ ] **AC1:** When resuming a KB Chat sidebar conversation, prior messages are visible in the chat area
+- [ ] **AC2:** The "Continuing from" banner includes both date and time (e.g., "Continuing from 4/16/2026, 2:15 PM")
+- [ ] **AC3:** Messages loaded from history display in chronological order (oldest first)
+- [ ] **AC4:** History messages do not duplicate if a new message arrives from a live stream while history is loading
+- [ ] **AC5:** The "Send a message to get started" placeholder does NOT appear when history messages are present
+- [ ] **AC6:** Auto-scroll to the bottom of the chat after history is loaded
+
+## Implementation Phases
+
+### Phase 1: Fix history fetch for resumed sessions
+
+**File:** `apps/web-platform/lib/ws-client.ts`
+
+Add a new `useEffect` that triggers on `realConversationId` changes. When `realConversationId` is set and the `conversationId` prop is `"new"` (sidebar resume path), fetch message history from the API and prepend to `messages` state.
+
+Extract the duplicated message-mapping logic (DB row to `ChatMessage`) into a shared helper function `mapDbMessageToChatMessage` rather than copy-pasting the mapping from the existing history effect. Both effects use the same shape.
+
+Key considerations:
+
+- Guard against race conditions: only prepend if `activeStreamsRef.current.size === 0` (same pattern as the existing history fetch on line 420). If a stream starts DURING the fetch (the `await fetch()` yields), the prepend guard prevents stale history from overwriting live data. The `AbortController` handles component unmount but the `activeStreamsRef` guard handles the mid-fetch stream arrival case.
+- Use `AbortController` for cleanup (same pattern as existing effect)
+- Return early if `realConversationId` is null or matches the prop `conversationId` (the existing effect already covers non-"new" IDs)
+
+```text
+apps/web-platform/lib/ws-client.ts
+  - Extract mapDbMessageToChatMessage helper (shared by both history effects)
+  - Add useEffect watching [realConversationId, conversationId]
+  - Fetch /api/conversations/${realConversationId}/messages
+  - Map and prepend to messages state using shared helper
+```
+
+### Phase 2: Fix date format in resume banner
+
+**File:** `apps/web-platform/components/chat/kb-chat-sidebar.tsx`
+
+Change line 141 from `toLocaleDateString()` to `toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" })`.
+
+```text
+apps/web-platform/components/chat/kb-chat-sidebar.tsx
+  - Update toLocaleDateString() → toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" })
+```
+
+**Verification note (AC5):** The empty-state placeholder in `chat-surface.tsx` (line 359-365) checks `messages.length === 0`. Phase 1 populates `messages` with history, so the placeholder hides naturally. No code change needed -- covered by test scenarios.
+
+## Test Scenarios
+
+- Given a KB Chat sidebar with an existing conversation for a document, when the sidebar opens and `session_resumed` fires, then prior messages appear in the chat area
+- Given a resumed session with 5 historical messages, when the history loads, then messages appear in chronological order (oldest first, newest last)
+- Given a resumed session where a live stream event arrives during history fetch, when both complete, then no duplicate messages appear
+- Given a resumed session, when the "Continuing from" banner is visible, then it shows both date and time (e.g., "4/16/2026, 2:15 PM")
+- Given a resumed session with loaded history, then the "Send a message to get started" placeholder is NOT visible
+
+## Context
+
+### Files to modify
+
+| File | Change |
+|------|--------|
+| `apps/web-platform/lib/ws-client.ts` | Add `useEffect` to fetch history when `realConversationId` is set from resume |
+| `apps/web-platform/components/chat/kb-chat-sidebar.tsx` | Change `toLocaleDateString()` to include time |
+
+### Files to add tests
+
+| File | Tests |
+|------|-------|
+| `apps/web-platform/test/kb-chat-sidebar.test.tsx` | Add test for timestamp format in resume banner |
+| `apps/web-platform/test/ws-client-resume-history.test.ts` (new) | Test that history fetch fires on `realConversationId` change for `conversationId="new"` |
+
+### Related files (read-only)
+
+| File | Relevance |
+|------|-----------|
+| `apps/web-platform/server/ws-handler.ts` | Server-side session resume handling (no changes needed) |
+| `apps/web-platform/server/api-messages.ts` | Messages API endpoint (no changes needed) |
+| `apps/web-platform/lib/chat-state-machine.ts` | Pure state machine for message rendering (no changes needed) |
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected -- bug fix for existing KB Chat feature with no new user-facing surfaces, no cost changes, no legal implications.
+
+## MVP
+
+This is already minimal. Two code changes (one new effect, one date format tweak) fix both reported bugs.
+
+## Alternative Approaches Considered
+
+| Approach | Pros | Cons | Decision |
+|----------|------|------|----------|
+| Modify existing history `useEffect` to also watch `realConversationId` | Single effect | Conflates two trigger paths; harder to reason about cleanup | Rejected -- separate effects are cleaner |
+| Have the server replay messages in the `session_resumed` event | No extra HTTP call | Changes WS protocol; large payloads over WS; breaks existing clients | Rejected -- too invasive for a bug fix |
+| Use `conversationId` state instead of prop for history fetch | Works with current architecture | Requires significant refactor of `useWebSocket` hook signature | Rejected -- overkill |

--- a/knowledge-base/project/plans/archive/20260416-151846-2026-04-16-fix-kb-chat-resume-empty-messages-plan.md
+++ b/knowledge-base/project/plans/archive/20260416-151846-2026-04-16-fix-kb-chat-resume-empty-messages-plan.md
@@ -61,13 +61,13 @@ This produces "4/16/2026" with no time. The fix: use `toLocaleString()` with opt
 
 ## Acceptance Criteria
 
-- [ ] **AC1:** When resuming a KB Chat sidebar conversation, prior messages are visible in the chat area
-- [ ] **AC2:** The "Continuing from" banner includes both date and time (e.g., "Continuing from 4/16/2026, 2:15 PM")
-- [ ] **AC3:** Messages loaded from history display in chronological order (oldest first)
-- [ ] **AC4:** History messages do not duplicate if a new message arrives from a live stream while history is loading
-- [ ] **AC5:** The "Send a message to get started" placeholder does NOT appear when history messages are present
-- [ ] **AC6:** Auto-scroll to the bottom of the chat after history is loaded
-- [ ] **AC7:** The "Continuing from" banner remains visible after history messages load (not dismissed prematurely by the message count change handler)
+- [x] **AC1:** When resuming a KB Chat sidebar conversation, prior messages are visible in the chat area
+- [x] **AC2:** The "Continuing from" banner includes both date and time (e.g., "Continuing from 4/16/2026, 2:15 PM")
+- [x] **AC3:** Messages loaded from history display in chronological order (oldest first)
+- [x] **AC4:** History messages do not duplicate if a new message arrives from a live stream while history is loading
+- [x] **AC5:** The "Send a message to get started" placeholder does NOT appear when history messages are present
+- [x] **AC6:** Auto-scroll to the bottom of the chat after history is loaded
+- [x] **AC7:** The "Continuing from" banner remains visible after history messages load (not dismissed prematurely by the message count change handler)
 
 ## Implementation Phases
 

--- a/knowledge-base/project/specs/feat-fix-kb-chat-resume-empty/session-state.md
+++ b/knowledge-base/project/specs/feat-fix-kb-chat-resume-empty/session-state.md
@@ -1,0 +1,23 @@
+# Session State
+
+## Plan Phase
+
+- Plan file: knowledge-base/project/plans/2026-04-16-fix-kb-chat-resume-empty-messages-plan.md
+- Status: complete
+
+### Errors
+
+None
+
+### Decisions
+
+- Server-side ws-handler must emit stored messages on resume (not just metadata)
+- Client-side chat-surface must hydrate messages from resume response before accepting new ones
+- Banner premature dismissal bug identified: handleMessageCountChange dismisses "Continuing from" banner when messages.length > 0, which fires immediately on history load — needs separate fix
+- Timestamp added to "Continuing from" header for same-day disambiguation
+- Message ID deduplication guard needed to prevent duplicates during resume + active stream overlap
+
+### Components Invoked
+
+- soleur:plan
+- soleur:deepen-plan (3 parallel research agents)

--- a/knowledge-base/project/specs/feat-fix-kb-chat-resume-empty/tasks.md
+++ b/knowledge-base/project/specs/feat-fix-kb-chat-resume-empty/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: fix(kb-chat) resumed conversation shows empty chat
+
+Ref: [Plan](../../plans/2026-04-16-fix-kb-chat-resume-empty-messages-plan.md)
+Issue: #2425
+
+## Phase 1: Fix history fetch for resumed sessions
+
+- [ ] 1.1 Extract `mapDbMessageToChatMessage` helper in `apps/web-platform/lib/ws-client.ts`
+  - [ ] 1.1.1 Create a function that maps `{ id, role, content, leader_id }` to `ChatMessage`
+  - [ ] 1.1.2 Refactor existing history `useEffect` (line 407-418) to use the helper
+- [ ] 1.2 Add new `useEffect` for `realConversationId` history fetch in `apps/web-platform/lib/ws-client.ts`
+  - [ ] 1.2.1 Guard: return early if `realConversationId` is null
+  - [ ] 1.2.2 Guard: return early if `realConversationId === conversationId` (existing effect handles this)
+  - [ ] 1.2.3 Guard: return early if `conversationId !== "new"` (only sidebar resume path needs this)
+  - [ ] 1.2.4 Fetch `/api/conversations/${realConversationId}/messages` with auth header
+  - [ ] 1.2.5 Map response with `mapDbMessageToChatMessage`
+  - [ ] 1.2.6 Prepend to messages only if `activeStreamsRef.current.size === 0`
+  - [ ] 1.2.7 Use `AbortController` for cleanup on unmount
+- [ ] 1.3 Write tests in `apps/web-platform/test/ws-client-resume-history.test.ts`
+  - [ ] 1.3.1 Test: history fetch fires when `realConversationId` set with `conversationId="new"`
+  - [ ] 1.3.2 Test: history fetch does NOT fire when `conversationId` is a real UUID
+  - [ ] 1.3.3 Test: history fetch does NOT fire when `realConversationId` is null
+  - [ ] 1.3.4 Test: messages from history appear in chronological order
+  - [ ] 1.3.5 Test: "Send a message to get started" placeholder hides after history loads
+
+## Phase 2: Fix date format in resume banner
+
+- [ ] 2.1 Update `toLocaleDateString()` to `toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" })` in `apps/web-platform/components/chat/kb-chat-sidebar.tsx`
+- [ ] 2.2 Add test in `apps/web-platform/test/kb-chat-sidebar.test.tsx`
+  - [ ] 2.2.1 Test: resumed banner includes time portion (not just date)
+
+## Verification
+
+- [ ] 3.1 Run existing test suite to confirm no regressions
+- [ ] 3.2 Verify AC1-AC6 pass via test scenarios

--- a/knowledge-base/project/specs/feat-fix-kb-chat-resume-empty/tasks.md
+++ b/knowledge-base/project/specs/feat-fix-kb-chat-resume-empty/tasks.md
@@ -14,22 +14,32 @@ Issue: #2425
   - [ ] 1.2.3 Guard: return early if `conversationId !== "new"` (only sidebar resume path needs this)
   - [ ] 1.2.4 Fetch `/api/conversations/${realConversationId}/messages` with auth header
   - [ ] 1.2.5 Map response with `mapDbMessageToChatMessage`
-  - [ ] 1.2.6 Prepend to messages only if `activeStreamsRef.current.size === 0`
+  - [ ] 1.2.6 Deduplicate by message ID when prepending to messages state
   - [ ] 1.2.7 Use `AbortController` for cleanup on unmount
 - [ ] 1.3 Write tests in `apps/web-platform/test/ws-client-resume-history.test.ts`
   - [ ] 1.3.1 Test: history fetch fires when `realConversationId` set with `conversationId="new"`
   - [ ] 1.3.2 Test: history fetch does NOT fire when `conversationId` is a real UUID
   - [ ] 1.3.3 Test: history fetch does NOT fire when `realConversationId` is null
   - [ ] 1.3.4 Test: messages from history appear in chronological order
-  - [ ] 1.3.5 Test: "Send a message to get started" placeholder hides after history loads
+  - [ ] 1.3.5 Test: duplicate messages from stream are filtered out by ID
+  - [ ] 1.3.6 Test: "Send a message to get started" placeholder hides after history loads
 
-## Phase 2: Fix date format in resume banner
+## Phase 2: Fix banner premature dismissal
 
-- [ ] 2.1 Update `toLocaleDateString()` to `toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" })` in `apps/web-platform/components/chat/kb-chat-sidebar.tsx`
+- [ ] 2.1 Update `handleMessageCountChange` in `apps/web-platform/components/chat/kb-chat-sidebar.tsx`
+  - [ ] 2.1.1 Track initial history count from `onThreadResumed` messageCount parameter
+  - [ ] 2.1.2 Only dismiss banner when message count exceeds historical message count (user sent new message)
 - [ ] 2.2 Add test in `apps/web-platform/test/kb-chat-sidebar.test.tsx`
-  - [ ] 2.2.1 Test: resumed banner includes time portion (not just date)
+  - [ ] 2.2.1 Test: banner stays visible when message count matches historical count (history loaded)
+  - [ ] 2.2.2 Test: banner dismisses when message count exceeds historical count (user sent new message)
+
+## Phase 3: Fix date format in resume banner
+
+- [ ] 3.1 Update `toLocaleDateString()` to `toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" })` in `apps/web-platform/components/chat/kb-chat-sidebar.tsx`
+- [ ] 3.2 Add test in `apps/web-platform/test/kb-chat-sidebar.test.tsx`
+  - [ ] 3.2.1 Test: resumed banner includes time portion (not just date); pin locale for determinism
 
 ## Verification
 
-- [ ] 3.1 Run existing test suite to confirm no regressions
-- [ ] 3.2 Verify AC1-AC6 pass via test scenarios
+- [ ] 4.1 Run existing test suite to confirm no regressions
+- [ ] 4.2 Verify AC1-AC7 pass via test scenarios


### PR DESCRIPTION
## Summary

- Fix empty chat on resume: add `useEffect` watching `realConversationId` to fetch history when sidebar resumes a conversation (`conversationId='new'`)
- Fix banner premature dismissal: track historical message count via `historicalCountRef` so the 'Continuing from' banner persists through history load and only dismisses on new user messages
- Fix timestamp format: change `toLocaleDateString()` to `toLocaleString()` with `dateStyle:'short', timeStyle:'short'` for same-day disambiguation
- Extract shared `fetchConversationHistory` helper to eliminate ~30-line duplication between effects

Closes #2425

## Changelog

### Web Platform
- **fix:** Resumed KB Chat conversations now load prior message history instead of showing empty chat
- **fix:** 'Continuing from' banner no longer dismisses prematurely when history loads
- **fix:** Resume banner includes time alongside date for same-day conversation disambiguation
- **refactor:** Extract shared `fetchConversationHistory` helper, add `mountedRef` guard

## Test plan

- [x] `ws-client-resume-history.test.tsx`: 4 tests — history fetch on resume, chronological order, deduplication, guard for non-'new' IDs
- [x] `kb-chat-sidebar-banner-dismiss.test.tsx`: 4 tests — banner render, dismiss on new message, persist on history load, dismiss after history+new message
- [x] `kb-chat-sidebar.test.tsx`: 1 test — timestamp includes time component
- [x] Full test suite: 156/157 passed (1 pre-existing flaky test unrelated to this PR)

Generated with [Claude Code](https://claude.com/claude-code)