### PR TITLE
fix(kb-chat): reset timeout on tool_use, pass context on resume (#2430)

### DIFF
--- a/apps/web-platform/lib/chat-state-machine.ts
+++ b/apps/web-platform/lib/chat-state-machine.ts
@@ -116,7 +116,11 @@ export function applyStreamEvent(
       return {
         messages: updated,
         activeStreams,
-        timerAction: undefined,
+        // Reset the stuck-state timer on each tool_use — long-running tools
+        // (Read on large files, Bash commands, web searches) can exceed the
+        // 45s timeout. Each new tool_use proves the agent is still active.
+        // See #2430.
+        timerAction: { type: "reset", leaderId: event.leaderId },
       };
     }
 

--- a/apps/web-platform/server/agent-runner.ts
+++ b/apps/web-platform/server/agent-runner.ts
@@ -1510,6 +1510,7 @@ export async function sendUserMessage(
       (conv.domain_leader as DomainLeaderId) ?? undefined,
       resumeSessionId,
       augmentedContent,
+      conversationContext, // Pass context so system prompt includes document (#2430)
     ).catch(async (err) => {
       log.warn({ err }, "SDK resume failed, falling back to message replay");
       // Clear stale session_id
@@ -1531,6 +1532,7 @@ export async function sendUserMessage(
         (conv.domain_leader as DomainLeaderId) ?? undefined,
         undefined,
         replayPrompt,
+        conversationContext, // Pass context so system prompt includes document (#2430)
       ).catch(handleSessionError);
     });
   } else {
@@ -1546,6 +1548,7 @@ export async function sendUserMessage(
       (conv.domain_leader as DomainLeaderId) ?? undefined,
       undefined,
       prompt,
+      conversationContext, // Pass context so system prompt includes document (#2430)
     ).catch(handleSessionError);
   }
 }

--- a/apps/web-platform/test/chat-state-machine.test.ts
+++ b/apps/web-platform/test/chat-state-machine.test.ts
@@ -23,7 +23,7 @@ function thinkingMessage(leaderId: string): ChatMessage {
 // ---------------------------------------------------------------------------
 
 describe("chat-state-machine timeout behavior", () => {
-  test("tool_use event does NOT reset the timer (timerAction is null)", () => {
+  test("tool_use event resets the timer (#2430)", () => {
     const prev: ChatMessage[] = [thinkingMessage("cpo")];
     const streams = new Map([["cpo", 0]]);
 
@@ -33,8 +33,9 @@ describe("chat-state-machine timeout behavior", () => {
       label: "Read",
     } as any);
 
-    // timerAction must be undefined (no-op) — not a reset
-    expect(result.timerAction).toBeUndefined();
+    // tool_use resets the timer — long-running tools should not trigger
+    // "Agent stopped responding" while the agent is actively working.
+    expect(result.timerAction).toEqual({ type: "reset", leaderId: "cpo" });
   });
 
   test("stream event resets the timer", () => {

--- a/apps/web-platform/test/ws-streaming-state.test.ts
+++ b/apps/web-platform/test/ws-streaming-state.test.ts
@@ -288,3 +288,47 @@ describe("timeout guard (#2136)", () => {
     expect(timedOut.messages[0].state).toBe("error");
   });
 });
+
+describe("tool_use timer reset (#2430)", () => {
+  test("tool_use event returns timerAction 'reset' to restart stuck-state timer", () => {
+    const s1 = applyStreamEvent(
+      [],
+      new Map(),
+      { type: "stream_start", leaderId: "cmo" } as StreamEvent,
+    );
+
+    const s2 = applyStreamEvent(
+      s1.messages,
+      s1.activeStreams,
+      { type: "tool_use", leaderId: "cmo", label: "Reading file..." } as StreamEvent,
+    );
+
+    expect(s2.timerAction).toEqual({ type: "reset", leaderId: "cmo" });
+  });
+
+  test("each successive tool_use resets the timer", () => {
+    let messages: ChatMessage[] = [];
+    let activeStreams = new Map<string, number>();
+
+    const s1 = applyStreamEvent(messages, activeStreams, {
+      type: "stream_start",
+      leaderId: "cto",
+    } as StreamEvent);
+    messages = s1.messages;
+    activeStreams = s1.activeStreams;
+
+    const s2 = applyStreamEvent(messages, activeStreams, {
+      type: "tool_use",
+      leaderId: "cto",
+      label: "Reading file...",
+    } as StreamEvent);
+    expect(s2.timerAction).toEqual({ type: "reset", leaderId: "cto" });
+
+    const s3 = applyStreamEvent(s2.messages, s2.activeStreams, {
+      type: "tool_use",
+      leaderId: "cto",
+      label: "Searching code...",
+    } as StreamEvent);
+    expect(s3.timerAction).toEqual({ type: "reset", leaderId: "cto" });
+  });
+});


### PR DESCRIPTION
## Summary

- Fix tool_use events not resetting the 45s stuck-state timeout — agents no longer show "Agent stopped responding" while actively using tools
- Pass conversation context to all startAgentSession call sites in sendUserMessage — resumed single-leader conversations now get document context injection

Ref #2428

## Changelog

### Web Platform
- fix: tool_use events now reset the stuck-state timer (timerAction: reset instead of undefined)
- fix: pass conversationContext to all 3 startAgentSession calls in sendUserMessage (resume, replay fallback, first-turn)

## Test plan
- [x] 2 new tests for tool_use timer reset behavior
- [x] Updated existing test that asserted old behavior (tool_use NOT resetting timer)
- [x] Full test suite passes (1580 tests, 0 failures)

Generated with [Claude Code](https://claude.com/claude-code)