### PR TITLE
fix(kb): chat X button closes panel + reduce expand button padding

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/kb/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/kb/layout.tsx
@@ -255,7 +255,9 @@ export default function KbLayout({ children }: { children: ReactNode }) {
   }), [sidebarOpen, openSidebar, closeSidebar, contextPath, kbChatFlag, submitQuote, registerQuoteHandler, messageCount]);
 
   // Whether to show the chat panel as a resizable column on desktop.
-  const showChat = kbChatFlag && !!contextPath;
+  // sidebarOpen is user-controlled: clicking X (`closeSidebar`) sets it false
+  // and unmounts the chat Panel; "Continue thread" (`openSidebar`) re-opens it.
+  const showChat = kbChatFlag && !!contextPath && sidebarOpen;
 
   // Full-width states: loading, errors, or empty KB (no sidebar needed)
   if (loading || error || (!loading && !hasTreeContent)) {
@@ -302,7 +304,7 @@ export default function KbLayout({ children }: { children: ReactNode }) {
   const docContent = (
     <>
       {kbCollapsed && (
-        <div className="flex shrink-0 items-center px-2 py-5">
+        <div className="flex shrink-0 items-center px-2 py-2">
           <button
             onClick={toggleKbCollapsed}
             aria-label="Expand file tree"

--- a/apps/web-platform/test/kb-layout-panels.test.tsx
+++ b/apps/web-platform/test/kb-layout-panels.test.tsx
@@ -89,6 +89,9 @@ beforeEach(() => {
   mockPathname = "/dashboard/kb/knowledge-base/product/roadmap.md";
   mockIsDesktop = true;
   sessionStorage.clear();
+  // Simulate user having opened the chat sidebar — showChat now depends on
+  // sidebarOpen so tests asserting 3-panel layout must set this flag.
+  sessionStorage.setItem("kb.chat.sidebarOpen", "1");
   global.fetch = vi.fn().mockImplementation((url: string) => {
     if (url === "/api/flags") {
       return Promise.resolve({


### PR DESCRIPTION
## Summary

Two small fixes on top of the resizable panels feature:

1. **Chat X button now closes the panel on desktop.** Previously `showChat` only checked `kbChatFlag && !!contextPath`, so clicking X (which sets `sidebarOpen=false`) had no effect on desktop. Now `showChat` also requires `sidebarOpen`, matching the mobile Sheet semantics.

2. **Reduce vertical padding above the document viewer when the KB tree is collapsed.** The expand button container was `py-5` (40px top + 40px bottom), pushing the breadcrumb and action buttons too far down. Reduced to `py-2` (16px total).

## Changelog

- **fix:** Chat X button now correctly closes the chat panel on desktop (sidebarOpen state)
- **fix:** Reduce unused vertical space above breadcrumb when KB tree is collapsed

## Test plan

- [x] 1602 tests pass, 0 failures
- [x] TypeScript clean
- [ ] Browser QA: click X on chat panel, verify panel disappears and resize fills freed space

Ref #2434

Generated with [Claude Code](https://claude.com/claude-code)