### PR TITLE
fix(kb): breadcrumb overlap + chat textarea default size

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/kb/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/kb/layout.tsx
@@ -315,7 +315,7 @@ export default function KbLayout({ children }: { children: ReactNode }) {
           </svg>
         </button>
       )}
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className={`min-h-0 flex-1 overflow-y-auto ${kbCollapsed ? "pl-10" : ""}`}>
         <KbErrorBoundary>
           {isContentView ? children : <DesktopPlaceholder />}
         </KbErrorBoundary>

--- a/apps/web-platform/components/chat/chat-input.tsx
+++ b/apps/web-platform/components/chat/chat-input.tsx
@@ -99,14 +99,14 @@ export function ChatInput({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const activeXhrs = useRef<Map<string, XMLHttpRequest>>(new Map());
 
-  // Auto-resize textarea height based on content (capped at ~5 lines / 100px).
+  // Auto-resize textarea height based on content (default ~2 lines, capped at ~6 lines / 140px).
   // useIsomorphicLayoutEffect prevents flicker on the client while avoiding
   // SSR warnings; keying on `value` covers typing, paste, programmatic changes.
   useIsomorphicLayoutEffect(() => {
     const el = textareaRef.current;
     if (!el) return;
     el.style.height = "auto"; // Reset to measure true scrollHeight
-    el.style.height = `${Math.min(el.scrollHeight, 100)}px`;
+    el.style.height = `${Math.min(el.scrollHeight, 140)}px`;
   }, [value]);
 
   // Clear error after 3 seconds
@@ -509,7 +509,7 @@ export function ChatInput({
             disabled={disabled || isUploading}
             rows={1}
             className={
-              "w-full resize-none rounded-xl border border-neutral-700 bg-neutral-900 px-4 py-2.5 pr-12 text-sm text-white placeholder:text-neutral-500 focus:border-neutral-500 focus:outline-none disabled:opacity-50 min-h-[44px] max-h-[100px] overflow-y-auto transition-shadow" +
+              "w-full resize-none rounded-xl border border-neutral-700 bg-neutral-900 px-4 py-2.5 pr-12 text-sm text-white placeholder:text-neutral-500 focus:border-neutral-500 focus:outline-none disabled:opacity-50 min-h-[72px] max-h-[140px] overflow-y-auto transition-shadow" +
               (flashQuote ? " ring-2 ring-amber-400" : "")
             }
           />

--- a/apps/web-platform/test/chat-input-auto-grow.test.tsx
+++ b/apps/web-platform/test/chat-input-auto-grow.test.tsx
@@ -40,11 +40,11 @@ describe("ChatInput auto-grow", () => {
   it("textarea has min-height and max-height constraints instead of fixed height", () => {
     setup();
     const textarea = screen.getByRole("textbox");
-    // Should NOT have the fixed h-[44px] class (but min-h-[44px] is ok)
-    expect(textarea.className).not.toMatch(/(?<![-\w])h-\[44px\]/);
+    // Should NOT have any fixed h-[*px] class (min-h-/max-h- are ok)
+    expect(textarea.className).not.toMatch(/(?<![-\w])h-\[\d+px\]/);
     // Should have min-h and max-h constraints
-    expect(textarea.className).toMatch(/min-h-\[44px\]/);
-    expect(textarea.className).toMatch(/max-h-\[100px\]/);
+    expect(textarea.className).toMatch(/min-h-\[72px\]/);
+    expect(textarea.className).toMatch(/max-h-\[140px\]/);
   });
 
   it("textarea has overflow-y auto for internal scrolling", () => {
@@ -69,20 +69,20 @@ describe("ChatInput auto-grow", () => {
     expect(textarea.style.height).toBeTruthy();
   });
 
-  it("caps height at 100px even when content is taller", async () => {
+  it("caps height at 140px even when content is taller", async () => {
     setup();
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
 
     // Simulate scrollHeight exceeding max
     Object.defineProperty(textarea, "scrollHeight", {
-      get: () => 200,
+      get: () => 300,
       configurable: true,
     });
 
     await userEvent.type(textarea, "a\nb\nc\nd\ne\nf\ng\nh");
 
-    // Height should be capped at 100px
-    expect(textarea.style.height).toBe("100px");
+    // Height should be capped at 140px
+    expect(textarea.style.height).toBe("140px");
   });
 
   it("resets height on submit (value cleared)", async () => {

--- a/apps/web-platform/test/chat-input.test.tsx
+++ b/apps/web-platform/test/chat-input.test.tsx
@@ -133,7 +133,7 @@ describe("ChatInput", () => {
   it("textarea has auto-growing height constraints", () => {
     setup();
     const textarea = screen.getByRole("textbox");
-    expect(textarea.className).toContain("min-h-[44px]");
-    expect(textarea.className).toContain("max-h-[100px]");
+    expect(textarea.className).toContain("min-h-[72px]");
+    expect(textarea.className).toContain("max-h-[140px]");
   });
 });


### PR DESCRIPTION
## Summary

Two small UX fixes on top of PR #2443:

1. **Breadcrumb no longer overlaps the KB expand button** when the tree is collapsed. Added conditional `pl-10` (40px) to the doc panel scroll wrapper so breadcrumb text starts at x=56 with comfortable spacing from the button (x=8-32).
2. **Chat textarea default size increased** from 1 line (`min-h-[44px]`) to 2 lines (`min-h-[72px]`). The placeholder "Ask about this document — ⌘⇧L to quote selection" wraps to 2 lines at the chat panel width; previous size clipped the second line. Max also raised from 100px to 140px (~6 lines).

## Changelog

- **fix:** Breadcrumb no longer overlaps KB expand button when tree is collapsed
- **fix:** Chat textarea shows 2 lines by default so the full placeholder is visible

Ref #2434

Generated with [Claude Code](https://claude.com/claude-code)