### PR TITLE
fix(kb): disable PDF auto-fetch so page 1 renders before full download

### DIFF
--- a/apps/web-platform/components/kb/pdf-preview.tsx
+++ b/apps/web-platform/components/kb/pdf-preview.tsx
@@ -22,14 +22,18 @@ interface PdfPreviewProps {
 }
 
 // PDF.js document loading options.
-// - disableRange/Stream/AutoFetch must all be false for progressive rendering
-// - rangeChunkSize: 128KB chunks keep first render fast while avoiding too
-//   many round-trips on long documents
+// - disableRange/Stream: false so range requests are used (need Accept-Ranges)
+// - disableAutoFetch: true so PDF.js only fetches what's needed for the
+//   currently-rendered page. With `false` (default), PDF.js eagerly prefetches
+//   the entire document in the background even though `getDocument` resolves
+//   after the xref is parsed — this makes the progress bar fill to 100%
+//   before page 1 renders, defeating the point of streaming.
+// - rangeChunkSize: 128KB chunks keep first render fast
 // Memoized at module scope since these never change across renders.
 const PDF_DOCUMENT_OPTIONS = {
   disableRange: false,
   disableStream: false,
-  disableAutoFetch: false,
+  disableAutoFetch: true,
   rangeChunkSize: 131072,
 };
 


### PR DESCRIPTION
## Summary

The progress bar reaching 100% before page 1 rendered was caused by `disableAutoFetch: false`. With that default, PDF.js uses range requests (good) but also **eagerly prefetches the entire document** in the background. Since every range completes successfully, the progress bar fills to 100% before PDF.js finishes parsing enough to render page 1.

Setting `disableAutoFetch: true` tells PDF.js to only fetch the xref and data needed for the currently-rendered page. Page 1 renders as soon as its specific data arrives; subsequent pages fetch on demand when the user navigates.

**Caveat:** If a PDF isn't linearized ("Fast Web View" not enabled when saved), PDF.js still has to load significant structure before finding any page. This PR is necessary but not sufficient for non-linearized PDFs — for those, server-side linearization is a follow-up.

## Changelog

- **fix:** PDF.js now uses `disableAutoFetch: true` — page 1 renders as soon as its data arrives instead of waiting for full eager prefetch

## Test plan

- [x] TypeScript clean
- [x] File preview tests pass
- [ ] Browser QA: open a large PDF, verify page 1 appears BEFORE progress bar reaches 100%

Ref #2434

Generated with [Claude Code](https://claude.com/claude-code)