### PR TITLE
fix(kb): bind share links to content hash to prevent token resurrection

### DIFF
--- a/apps/web-platform/app/api/kb/share/route.ts
+++ b/apps/web-platform/app/api/kb/share/route.ts
@@ -49,33 +49,15 @@ export async function POST(request: Request) {
   }
 
   // Validate the document exists in the user's workspace and is a regular
-  // file (not a directory, not a symlink) within the size limit. Symlink +
-  // size checks are point-of-use per the service-role-idor learning: every
-  // operation re-validates, even on owner-supplied paths.
+  // file. Symlink + size + type checks are done via O_NOFOLLOW + fstat on
+  // the fd we hash from — no pre-lstat, since the pre-lstat only opens a
+  // TOCTOU window the fd path already closes (CodeQL js/file-system-race).
   const kbRoot = path.join(userData.workspace_path, "knowledge-base");
   const fullPath = path.join(kbRoot, body.documentPath);
   if (!isPathInWorkspace(fullPath, kbRoot)) {
     return NextResponse.json({ error: "Invalid document path" }, { status: 400 });
   }
-  let lstat: fs.Stats;
-  try {
-    lstat = await fs.promises.lstat(fullPath);
-  } catch {
-    return NextResponse.json({ error: "File not found" }, { status: 404 });
-  }
-  if (lstat.isSymbolicLink() || !lstat.isFile()) {
-    return NextResponse.json({ error: "Invalid document path" }, { status: 400 });
-  }
-  if (lstat.size > MAX_BINARY_SIZE) {
-    return NextResponse.json(
-      { error: "File exceeds maximum size limit" },
-      { status: 413 },
-    );
-  }
 
-  // Hash the file through an O_NOFOLLOW fd. Stream-hashing avoids a second
-  // 50 MB buffer allocation and the fd-level fstat re-validates the type/size
-  // post-lstat, closing any symlink-swap window between lstat and open.
   let contentHash: string;
   let handle: fs.promises.FileHandle;
   try {

--- a/apps/web-platform/app/api/kb/share/route.ts
+++ b/apps/web-platform/app/api/kb/share/route.ts
@@ -6,6 +6,7 @@ import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 import { isPathInWorkspace } from "@/server/sandbox";
 import { MAX_BINARY_SIZE } from "@/server/kb-binary-response";
+import { hashStream } from "@/server/kb-content-hash";
 import logger from "@/server/logger";
 
 /** POST — generate a share link for a KB document. */
@@ -72,20 +73,72 @@ export async function POST(request: Request) {
     );
   }
 
+  // Hash the file through an O_NOFOLLOW fd. Stream-hashing avoids a second
+  // 50 MB buffer allocation and the fd-level fstat re-validates the type/size
+  // post-lstat, closing any symlink-swap window between lstat and open.
+  let contentHash: string;
+  let handle: fs.promises.FileHandle;
+  try {
+    handle = await fs.promises.open(
+      fullPath,
+      fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW,
+    );
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ELOOP" || code === "EMLINK") {
+      return NextResponse.json({ error: "Invalid document path" }, { status: 400 });
+    }
+    return NextResponse.json({ error: "File not found" }, { status: 404 });
+  }
+  try {
+    const fdStat = await handle.stat();
+    if (!fdStat.isFile()) {
+      return NextResponse.json({ error: "Invalid document path" }, { status: 400 });
+    }
+    if (fdStat.size > MAX_BINARY_SIZE) {
+      return NextResponse.json(
+        { error: "File exceeds maximum size limit" },
+        { status: 413 },
+      );
+    }
+    contentHash = await hashStream(handle.createReadStream({ autoClose: false }));
+  } finally {
+    await handle.close().catch(() => {});
+  }
+
   // Check if an active (non-revoked) share already exists for this document.
+  // If the stored hash still matches the current file, return the existing
+  // token (idempotent happy path). If the hash differs, the user is re-sharing
+  // a modified file — revoke the stale row and fall through to issue a fresh
+  // token. This keeps creation user-friendly after legitimate edits without
+  // coupling it to the view-time 410 branch.
   const { data: existing } = await serviceClient
     .from("kb_share_links")
-    .select("token")
+    .select("id, token, content_sha256")
     .eq("user_id", user.id)
     .eq("document_path", body.documentPath)
     .eq("revoked", false)
     .maybeSingle();
 
   if (existing) {
-    return NextResponse.json({
-      token: existing.token,
-      url: `/shared/${existing.token}`,
-    });
+    if (existing.content_sha256 === contentHash) {
+      return NextResponse.json({
+        token: existing.token,
+        url: `/shared/${existing.token}`,
+      });
+    }
+    await serviceClient
+      .from("kb_share_links")
+      .update({ revoked: true })
+      .eq("id", existing.id);
+    logger.info(
+      {
+        event: "share_reissued_on_content_drift",
+        userId: user.id,
+        documentPath: body.documentPath,
+      },
+      "kb/share: revoked stale share and issuing new token (content changed)",
+    );
   }
 
   // Generate a new cryptographically random token.
@@ -96,6 +149,7 @@ export async function POST(request: Request) {
       user_id: user.id,
       token,
       document_path: body.documentPath,
+      content_sha256: contentHash,
     });
 
   if (insertError) {

--- a/apps/web-platform/app/api/kb/share/route.ts
+++ b/apps/web-platform/app/api/kb/share/route.ts
@@ -153,6 +153,30 @@ export async function POST(request: Request) {
     });
 
   if (insertError) {
+    // 23505 = unique_violation. The partial unique index
+    // kb_share_links_one_active_per_doc guarantees one active share per
+    // (user_id, document_path), so a concurrent POST won that race. Read
+    // the winner's row and return its token if hashes match; otherwise
+    // surface the conflict as 409 (user can retry).
+    if ((insertError as { code?: string }).code === "23505") {
+      const { data: winner } = await serviceClient
+        .from("kb_share_links")
+        .select("token, content_sha256")
+        .eq("user_id", user.id)
+        .eq("document_path", body.documentPath)
+        .eq("revoked", false)
+        .maybeSingle();
+      if (winner && winner.content_sha256 === contentHash) {
+        return NextResponse.json({
+          token: winner.token,
+          url: `/shared/${winner.token}`,
+        });
+      }
+      return NextResponse.json(
+        { error: "Concurrent share creation — retry" },
+        { status: 409 },
+      );
+    }
     logger.error({ err: insertError }, "kb/share: failed to create share link");
     return NextResponse.json(
       { error: "Failed to create share link" },

--- a/apps/web-platform/app/api/shared/[token]/route.ts
+++ b/apps/web-platform/app/api/shared/[token]/route.ts
@@ -2,14 +2,16 @@ import { NextResponse } from "next/server";
 import path from "node:path";
 import { createServiceClient } from "@/lib/supabase/server";
 import {
-  readContent,
+  readContentRaw,
   KbNotFoundError,
   KbAccessDeniedError,
 } from "@/server/kb-reader";
+import matter from "gray-matter";
 import {
   readBinaryFile,
   buildBinaryResponse,
 } from "@/server/kb-binary-response";
+import { hashBytes } from "@/server/kb-content-hash";
 import {
   shareEndpointThrottle,
   extractClientIpFromHeaders,
@@ -17,11 +19,32 @@ import {
 } from "@/server/rate-limiter";
 import logger from "@/server/logger";
 
+function contentChangedResponse() {
+  return NextResponse.json(
+    {
+      error: "The shared file has been modified since it was shared.",
+      code: "content-changed",
+    },
+    { status: 410 },
+  );
+}
+
+function legacyNullHashResponse() {
+  return NextResponse.json(
+    {
+      error: "This link is from an older share system and is no longer valid.",
+      code: "legacy-null-hash",
+    },
+    { status: 410 },
+  );
+}
+
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ token: string }> },
 ) {
-  // Rate limiting.
+  // Rate limiting — must precede any filesystem / hash work to avoid DoS via
+  // repeated 50 MB hashing requests.
   const clientIp = extractClientIpFromHeaders(request.headers);
   if (!shareEndpointThrottle.isAllowed(clientIp)) {
     logRateLimitRejection("share-endpoint", clientIp);
@@ -37,7 +60,7 @@ export async function GET(
   // Look up share link.
   const { data: shareLink, error: fetchError } = await serviceClient
     .from("kb_share_links")
-    .select("document_path, user_id, revoked")
+    .select("document_path, user_id, revoked, content_sha256")
     .eq("token", token)
     .single();
 
@@ -47,9 +70,19 @@ export async function GET(
 
   if (shareLink.revoked) {
     return NextResponse.json(
-      { error: "This link has been disabled" },
+      { error: "This link has been disabled", code: "revoked" },
       { status: 410 },
     );
+  }
+
+  if (!shareLink.content_sha256) {
+    // Legacy row from before content-hash binding. Treat as invalid — the
+    // migration should have revoked these, but belt-and-suspenders.
+    logger.warn(
+      { event: "shared_legacy_null_hash", token, documentPath: shareLink.document_path },
+      "shared: legacy row without content hash",
+    );
+    return legacyNullHashResponse();
   }
 
   // Resolve owner's workspace.
@@ -69,20 +102,34 @@ export async function GET(
   const kbRoot = path.join(owner.workspace_path, "knowledge-base");
   const ext = path.extname(shareLink.document_path).toLowerCase();
 
-  // Fork on extension. Markdown (or extensionless) uses readContent and
-  // returns JSON as before; everything else streams the binary via the
-  // shared helper. Point-of-use path containment + symlink + size guards
-  // are re-validated inside readBinaryFile, per the service-role-idor
-  // learning — don't trust that the owner's stored document_path is safe.
+  // Markdown / extensionless branch.
   if (ext === ".md" || ext === "") {
     try {
-      const result = await readContent(kbRoot, shareLink.document_path);
+      const { buffer, raw } = await readContentRaw(
+        kbRoot,
+        shareLink.document_path,
+      );
+      const currentHash = hashBytes(buffer);
+      if (currentHash !== shareLink.content_sha256) {
+        logger.info(
+          {
+            event: "shared_content_mismatch",
+            token,
+            documentPath: shareLink.document_path,
+            kind: "markdown",
+          },
+          "shared: content hash mismatch",
+        );
+        return contentChangedResponse();
+      }
+      // engines: {} disables custom YAML engines per kb-reader convention.
+      const parsed = matter(raw, { engines: {} });
       logger.info(
         { event: "shared_page_viewed", token, documentPath: shareLink.document_path },
         "shared: document viewed",
       );
       return NextResponse.json({
-        content: result.content,
+        content: parsed.content.trim(),
         path: shareLink.document_path,
       });
     } catch (err) {
@@ -107,6 +154,7 @@ export async function GET(
     }
   }
 
+  // Binary branch.
   const binary = await readBinaryFile(kbRoot, shareLink.document_path);
   if (!binary.ok) {
     if (binary.status === 403) {
@@ -117,6 +165,21 @@ export async function GET(
     }
     return NextResponse.json({ error: binary.error }, { status: binary.status });
   }
+
+  const currentHash = hashBytes(binary.buffer);
+  if (currentHash !== shareLink.content_sha256) {
+    logger.info(
+      {
+        event: "shared_content_mismatch",
+        token,
+        documentPath: shareLink.document_path,
+        kind: "binary",
+      },
+      "shared: content hash mismatch",
+    );
+    return contentChangedResponse();
+  }
+
   logger.info(
     {
       event: "shared_page_viewed",

--- a/apps/web-platform/app/api/shared/[token]/route.ts
+++ b/apps/web-platform/app/api/shared/[token]/route.ts
@@ -3,10 +3,10 @@ import path from "node:path";
 import { createServiceClient } from "@/lib/supabase/server";
 import {
   readContentRaw,
+  parseFrontmatter,
   KbNotFoundError,
   KbAccessDeniedError,
 } from "@/server/kb-reader";
-import matter from "gray-matter";
 import {
   readBinaryFile,
   buildBinaryResponse,
@@ -122,14 +122,13 @@ export async function GET(
         );
         return contentChangedResponse();
       }
-      // engines: {} disables custom YAML engines per kb-reader convention.
-      const parsed = matter(raw, { engines: {} });
+      const { content } = parseFrontmatter(raw);
       logger.info(
         { event: "shared_page_viewed", token, documentPath: shareLink.document_path },
         "shared: document viewed",
       );
       return NextResponse.json({
-        content: parsed.content.trim(),
+        content,
         path: shareLink.document_path,
       });
     } catch (err) {

--- a/apps/web-platform/app/shared/[token]/page.tsx
+++ b/apps/web-platform/app/shared/[token]/page.tsx
@@ -26,7 +26,7 @@ type SharedData =
   | { kind: "image"; src: string; alt: string }
   | { kind: "download"; src: string; filename: string };
 
-type PageError = "not-found" | "revoked" | "unknown";
+type PageError = "not-found" | "revoked" | "content-changed" | "unknown";
 
 function extractFilename(contentDisposition: string | null): string {
   if (!contentDisposition) return "file";
@@ -56,7 +56,16 @@ export default function SharedDocumentPage({
           return;
         }
         if (res.status === 410) {
-          setError("revoked");
+          // Discriminate via response body `code` so we can show tailored
+          // copy for content-changed without disturbing the existing revoked
+          // path. Fall back to "revoked" copy if the body is missing/unparseable.
+          const body = await res.json().catch(() => null);
+          const code = body && typeof body === "object" ? body.code : null;
+          if (code === "content-changed" || code === "legacy-null-hash") {
+            setError("content-changed");
+          } else {
+            setError("revoked");
+          }
           setLoading(false);
           return;
         }
@@ -127,6 +136,13 @@ export default function SharedDocumentPage({
               <ErrorMessage
                 title="This link has been disabled"
                 message="The owner has revoked access to this document."
+              />
+            )}
+
+            {error === "content-changed" && (
+              <ErrorMessage
+                title="The shared file was modified"
+                message="The file has been edited or replaced since this link was created. Ask the owner to share again."
               />
             )}
 

--- a/apps/web-platform/server/kb-content-hash.ts
+++ b/apps/web-platform/server/kb-content-hash.ts
@@ -1,0 +1,25 @@
+import { createHash } from "node:crypto";
+import type { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+/**
+ * SHA-256 of a byte buffer, lowercase hex. Use when the caller already
+ * holds the full buffer (e.g. readBinaryFile returns buffer).
+ */
+export function hashBytes(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+/**
+ * SHA-256 of a Readable stream, lowercase hex. Use at share creation to
+ * avoid allocating a second 50 MB buffer for hashing — stream the file
+ * through the hasher and let GC reclaim chunks.
+ *
+ * Callers supply the stream; this helper does NOT close the underlying fd.
+ * That is the caller's responsibility (it owns the fd lifecycle).
+ */
+export async function hashStream(source: Readable): Promise<string> {
+  const hasher = createHash("sha256");
+  await pipeline(source, hasher);
+  return hasher.digest("hex");
+}

--- a/apps/web-platform/server/kb-content-hash.ts
+++ b/apps/web-platform/server/kb-content-hash.ts
@@ -1,3 +1,8 @@
+// Content-integrity hashing for KB share links. Two entry points by caller
+// shape: hashBytes for post-read verification where the buffer is already
+// in hand (view path), hashStream for share creation where streaming avoids
+// a second 50 MB buffer allocation on top of the fd read.
+
 import { createHash } from "node:crypto";
 import type { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -16,10 +21,17 @@ export function hashBytes(buf: Buffer): string {
  * through the hasher and let GC reclaim chunks.
  *
  * Callers supply the stream; this helper does NOT close the underlying fd.
- * That is the caller's responsibility (it owns the fd lifecycle).
+ * That is the caller's responsibility (it owns the fd lifecycle). On
+ * pipeline error the source is explicitly destroyed so a subsequent close
+ * on the caller's fd does not race with a still-draining stream.
  */
 export async function hashStream(source: Readable): Promise<string> {
   const hasher = createHash("sha256");
-  await pipeline(source, hasher);
+  try {
+    await pipeline(source, hasher);
+  } catch (err) {
+    source.destroy();
+    throw err;
+  }
   return hasher.digest("hex");
 }

--- a/apps/web-platform/server/kb-reader.ts
+++ b/apps/web-platform/server/kb-reader.ts
@@ -99,7 +99,7 @@ async function mapWithConcurrency<T, R>(
   return results;
 }
 
-function parseFrontmatter(raw: string): {
+export function parseFrontmatter(raw: string): {
   frontmatter: Record<string, unknown>;
   content: string;
 } {
@@ -252,6 +252,12 @@ export async function buildTree(
  * The `buffer` is the un-parsed, un-trimmed file content — callers that need
  * an integrity hash MUST hash the buffer, not the post-frontmatter `content`
  * string, otherwise frontmatter-only edits silently pass verification.
+ *
+ * Safe for markdown only — size is bounded by `KB_MAX_FILE_SIZE` (~1 MB).
+ * Do NOT reuse this helper for the binary path; the size ceiling there
+ * (`MAX_BINARY_SIZE`, 50 MB) would double-allocate as `buffer + utf-8 raw`.
+ * Binary hashing should use `hashBytes` over the buffer returned by
+ * `readBinaryFile`, or `hashStream` with a fd-owned ReadStream.
  */
 export async function readContentRaw(
   kbRoot: string,

--- a/apps/web-platform/server/kb-reader.ts
+++ b/apps/web-platform/server/kb-reader.ts
@@ -247,10 +247,16 @@ export async function buildTree(
   return root;
 }
 
-export async function readContent(
+/**
+ * Read a markdown file's raw bytes AND UTF-8 text in a single disk pass.
+ * The `buffer` is the un-parsed, un-trimmed file content — callers that need
+ * an integrity hash MUST hash the buffer, not the post-frontmatter `content`
+ * string, otherwise frontmatter-only edits silently pass verification.
+ */
+export async function readContentRaw(
   kbRoot: string,
   relativePath: string,
-): Promise<ContentResult> {
+): Promise<{ buffer: Buffer; raw: string; path: string }> {
   // Null byte check (CWE-158)
   if (relativePath.includes("\0")) {
     throw new KbAccessDeniedError();
@@ -268,7 +274,6 @@ export async function readContent(
     throw new KbAccessDeniedError();
   }
 
-  // File size guard
   let stat: fs.Stats;
   try {
     stat = await fs.promises.stat(fullPath);
@@ -284,9 +289,17 @@ export async function readContent(
     throw new KbValidationError("File exceeds maximum size limit");
   }
 
-  const raw = await fs.promises.readFile(fullPath, "utf-8");
-  const { frontmatter, content } = parseFrontmatter(raw);
+  const buffer = await fs.promises.readFile(fullPath);
+  const raw = buffer.toString("utf-8");
+  return { buffer, raw, path: relativePath };
+}
 
+export async function readContent(
+  kbRoot: string,
+  relativePath: string,
+): Promise<ContentResult> {
+  const { raw } = await readContentRaw(kbRoot, relativePath);
+  const { frontmatter, content } = parseFrontmatter(raw);
   return { path: relativePath, frontmatter, content };
 }
 

--- a/apps/web-platform/server/kb-reader.ts
+++ b/apps/web-platform/server/kb-reader.ts
@@ -280,24 +280,36 @@ export async function readContentRaw(
     throw new KbAccessDeniedError();
   }
 
-  let stat: fs.Stats;
+  // O_NOFOLLOW refuses symlinks at open time; fstat + read run against the
+  // fd so the bytes we return came from the inode we stat'd. Closes the
+  // stat→readFile TOCTOU window (CodeQL js/file-system-race).
+  let handle: fs.promises.FileHandle;
   try {
-    stat = await fs.promises.stat(fullPath);
-  } catch {
+    handle = await fs.promises.open(
+      fullPath,
+      fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW,
+    );
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ELOOP" || code === "EMLINK") {
+      throw new KbAccessDeniedError();
+    }
     throw new KbNotFoundError();
   }
-
-  if (!stat.isFile()) {
-    throw new KbNotFoundError();
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) {
+      throw new KbNotFoundError();
+    }
+    if (stat.size > KB_MAX_FILE_SIZE) {
+      throw new KbValidationError("File exceeds maximum size limit");
+    }
+    const buffer = await handle.readFile();
+    const raw = buffer.toString("utf-8");
+    return { buffer, raw, path: relativePath };
+  } finally {
+    await handle.close().catch(() => {});
   }
-
-  if (stat.size > KB_MAX_FILE_SIZE) {
-    throw new KbValidationError("File exceeds maximum size limit");
-  }
-
-  const buffer = await fs.promises.readFile(fullPath);
-  const raw = buffer.toString("utf-8");
-  return { buffer, raw, path: relativePath };
 }
 
 export async function readContent(

--- a/apps/web-platform/supabase/migrations/026_kb_share_links_content_sha256.sql
+++ b/apps/web-platform/supabase/migrations/026_kb_share_links_content_sha256.sql
@@ -6,23 +6,40 @@
 -- (knowledge-base/engineering/ops/runbooks/supabase-migrations.md) to count
 -- existing rows. If 0 rows, the defensive revoke below is a no-op. If >10
 -- rows, pause and switch to a soft-legacy path (keep nullable, backfill job).
+--
+-- NOT NULL is deliberately NOT applied: we want revoked legacy rows to
+-- retain audit metadata (token, user_id, document_path) with NULL hash.
+-- Active (revoked = false) rows are still required to have a valid hash
+-- via the CHECK constraint below, which is what actually prevents
+-- resurrection. Do NOT backfill from current file bytes — that would
+-- re-enable the very resurrection attack this migration prevents.
 
 alter table public.kb_share_links
   add column content_sha256 text;
 
--- Existing rows have no hash. Mark them revoked so they cannot be
--- resurrected by a new file at the same path — users must re-create any
--- links they still want.
+-- Revoke pre-existing rows. They predate the hash binding, so we cannot
+-- trust their document_path → content mapping.
 update public.kb_share_links
    set revoked = true
  where content_sha256 is null
    and revoked = false;
 
--- New rows MUST carry a hash.
+-- Active rows must carry a valid lowercase-hex SHA-256. Revoked rows may
+-- retain NULL (no active view path can reach them — the route returns
+-- 410 on revoked before any hash check).
 alter table public.kb_share_links
-  alter column content_sha256 set not null,
   add constraint kb_share_links_content_sha256_format
-    check (content_sha256 ~ '^[a-f0-9]{64}$');
+    check (revoked = true or content_sha256 ~ '^[a-f0-9]{64}$');
+
+-- One active share per (user_id, document_path). Without this, two
+-- concurrent POSTs for the same (user, path) with a modified file can
+-- both pass the existing-share check and both insert new rows, leaving
+-- the older token as a dangling authorized link the user cannot see or
+-- revoke via the UI — exactly the resurrection class this migration
+-- closes. The POST handler catches the 23505 conflict and re-reads.
+create unique index kb_share_links_one_active_per_doc
+  on public.kb_share_links(user_id, document_path)
+  where revoked = false;
 
 -- Small index for future auditability (e.g. "how many share links point
 -- at identical content?"). Not required for correctness.

--- a/apps/web-platform/supabase/migrations/026_kb_share_links_content_sha256.sql
+++ b/apps/web-platform/supabase/migrations/026_kb_share_links_content_sha256.sql
@@ -1,0 +1,30 @@
+-- 026_kb_share_links_content_sha256.sql
+-- Bind KB share links to content, not path, to prevent token resurrection
+-- after file delete/rename/overwrite. See issue #2326.
+--
+-- Pre-apply: run the REST probe documented in the runbook
+-- (knowledge-base/engineering/ops/runbooks/supabase-migrations.md) to count
+-- existing rows. If 0 rows, the defensive revoke below is a no-op. If >10
+-- rows, pause and switch to a soft-legacy path (keep nullable, backfill job).
+
+alter table public.kb_share_links
+  add column content_sha256 text;
+
+-- Existing rows have no hash. Mark them revoked so they cannot be
+-- resurrected by a new file at the same path — users must re-create any
+-- links they still want.
+update public.kb_share_links
+   set revoked = true
+ where content_sha256 is null
+   and revoked = false;
+
+-- New rows MUST carry a hash.
+alter table public.kb_share_links
+  alter column content_sha256 set not null,
+  add constraint kb_share_links_content_sha256_format
+    check (content_sha256 ~ '^[a-f0-9]{64}$');
+
+-- Small index for future auditability (e.g. "how many share links point
+-- at identical content?"). Not required for correctness.
+create index idx_kb_share_links_content_sha256
+  on public.kb_share_links(content_sha256);

--- a/apps/web-platform/test/kb-content-hash.test.ts
+++ b/apps/web-platform/test/kb-content-hash.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+
+import { hashBytes, hashStream } from "@/server/kb-content-hash";
+
+const EMPTY_SHA256 =
+  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+describe("kb-content-hash", () => {
+  describe("hashBytes", () => {
+    it("returns lowercase-hex SHA-256 of an empty buffer (known vector)", () => {
+      expect(hashBytes(Buffer.from(""))).toBe(EMPTY_SHA256);
+    });
+
+    it("returns a 64-char lowercase hex digest for arbitrary bytes", () => {
+      const hash = hashBytes(Buffer.from("hello world"));
+      expect(hash).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it("returns a stable hash across invocations for the same input", () => {
+      const buf = Buffer.from("deterministic-content");
+      expect(hashBytes(buf)).toBe(hashBytes(buf));
+    });
+  });
+
+  describe("hashStream", () => {
+    it("returns the SHA-256 of an empty readable (known vector)", async () => {
+      const empty = Readable.from(Buffer.alloc(0));
+      await expect(hashStream(empty)).resolves.toBe(EMPTY_SHA256);
+    });
+
+    it("matches hashBytes for the same small buffer", async () => {
+      const buf = Buffer.from("small-content");
+      const streamed = await hashStream(Readable.from(buf));
+      expect(streamed).toBe(hashBytes(buf));
+    });
+
+    it("matches hashBytes on a ≥1 MB file via fs.createReadStream", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hash-stream-"));
+      const filePath = path.join(tmpDir, "blob.bin");
+      // 1.5 MB of repeated pattern — exercises chunk boundaries.
+      const content = Buffer.alloc(1_500_000, "ab");
+      fs.writeFileSync(filePath, content);
+      try {
+        const streamed = await hashStream(fs.createReadStream(filePath));
+        const buffered = hashBytes(content);
+        expect(streamed).toBe(buffered);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("rejects with the underlying error if the stream errors", async () => {
+      const broken = new Readable({
+        read() {
+          this.destroy(new Error("stream boom"));
+        },
+      });
+      await expect(hashStream(broken)).rejects.toThrow(/stream boom/);
+    });
+  });
+});

--- a/apps/web-platform/test/kb-share-content-hash.test.ts
+++ b/apps/web-platform/test/kb-share-content-hash.test.ts
@@ -1,0 +1,192 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockServiceFrom: vi.fn(),
+  mockValidateOrigin: vi.fn(),
+  mockRejectCsrf: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({
+      auth: { getUser: mocks.mockGetUser },
+    }),
+  ),
+  createServiceClient: vi.fn(() => ({
+    from: mocks.mockServiceFrom,
+  })),
+}));
+
+vi.mock("@/lib/auth/validate-origin", () => ({
+  validateOrigin: mocks.mockValidateOrigin,
+  rejectCsrf: mocks.mockRejectCsrf,
+}));
+
+vi.mock("@/server/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from "@/app/api/kb/share/route";
+
+function hex(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+let tmpWorkspace: string;
+let kbRoot: string;
+let insertSpy: ReturnType<typeof vi.fn>;
+let updateSpy: ReturnType<typeof vi.fn>;
+let existingShare: { id: string; token: string; content_sha256: string | null } | null;
+
+function createShareRequest(documentPath: string): Request {
+  return new Request("http://localhost:3000/api/kb/share", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Origin: "http://localhost:3000",
+    },
+    body: JSON.stringify({ documentPath }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), "kb-share-hash-"));
+  kbRoot = path.join(tmpWorkspace, "knowledge-base");
+  fs.mkdirSync(kbRoot, { recursive: true });
+
+  insertSpy = vi.fn().mockResolvedValue({ error: null });
+  updateSpy = vi.fn().mockResolvedValue({ error: null });
+  existingShare = null;
+
+  mocks.mockValidateOrigin.mockReturnValue({
+    valid: true,
+    origin: "http://localhost:3000",
+  });
+  mocks.mockGetUser.mockResolvedValue({
+    data: { user: { id: "user-1" } },
+  });
+
+  const makeChain = (terminal: Record<string, unknown>) => {
+    const chain: Record<string, unknown> = { ...terminal };
+    chain.eq = vi.fn().mockReturnValue(chain);
+    return chain;
+  };
+
+  let fromCallCount = 0;
+  mocks.mockServiceFrom.mockImplementation(() => {
+    fromCallCount++;
+    if (fromCallCount === 1) {
+      // users lookup
+      return {
+        select: vi.fn().mockReturnValue(
+          makeChain({
+            single: vi.fn().mockResolvedValue({
+              data: {
+                workspace_path: tmpWorkspace,
+                workspace_status: "ready",
+              },
+              error: null,
+            }),
+          }),
+        ),
+      };
+    }
+    // kb_share_links — select for existing share, then insert, plus update for revoke.
+    return {
+      select: vi.fn().mockReturnValue(
+        makeChain({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: existingShare,
+            error: null,
+          }),
+        }),
+      ),
+      insert: insertSpy,
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue(updateSpy()),
+      }),
+    };
+  });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpWorkspace, { recursive: true, force: true });
+});
+
+describe("KB share — content hash", () => {
+  it("persists SHA-256 of file bytes in the insert payload", async () => {
+    const bytes = Buffer.from("hash-me plz");
+    fs.writeFileSync(path.join(kbRoot, "note.md"), bytes);
+    const expected = hex(bytes);
+
+    const res = await POST(createShareRequest("note.md"));
+    expect(res.status).toBe(201);
+    expect(insertSpy).toHaveBeenCalledTimes(1);
+    const payload = insertSpy.mock.calls[0][0];
+    expect(payload.content_sha256).toBe(expected);
+    expect(payload.content_sha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("hashes a PDF (binary) identically to hashBytes on its raw bytes", async () => {
+    const bytes = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x00, 0xff, 0xfe]);
+    fs.writeFileSync(path.join(kbRoot, "doc.pdf"), bytes);
+    const expected = hex(bytes);
+
+    const res = await POST(createShareRequest("doc.pdf"));
+    expect(res.status).toBe(201);
+    const payload = insertSpy.mock.calls[0][0];
+    expect(payload.content_sha256).toBe(expected);
+  });
+
+  it("returns the existing token (no new insert) when the file bytes match the stored hash", async () => {
+    const bytes = Buffer.from("same content");
+    fs.writeFileSync(path.join(kbRoot, "doc.md"), bytes);
+    existingShare = {
+      id: "share-1",
+      token: "existing-token",
+      content_sha256: hex(bytes),
+    };
+
+    const res = await POST(createShareRequest("doc.md"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toBe("existing-token");
+    expect(insertSpy).not.toHaveBeenCalled();
+  });
+
+  it("revokes the stale row and issues a new token when content changed since the original share", async () => {
+    const newBytes = Buffer.from("version 2");
+    fs.writeFileSync(path.join(kbRoot, "doc.md"), newBytes);
+    existingShare = {
+      id: "share-1",
+      token: "stale-token",
+      content_sha256: hex(Buffer.from("version 1")),
+    };
+
+    const res = await POST(createShareRequest("doc.md"));
+    expect(res.status).toBe(201);
+    expect(updateSpy).toHaveBeenCalled();
+    expect(insertSpy).toHaveBeenCalledTimes(1);
+    const payload = insertSpy.mock.calls[0][0];
+    expect(payload.content_sha256).toBe(hex(newBytes));
+    const body = await res.json();
+    expect(body.token).not.toBe("stale-token");
+  });
+
+  it("rejects a symlink even if the target is a regular file (O_NOFOLLOW guard)", async () => {
+    const outside = path.join(tmpWorkspace, "real.md");
+    fs.writeFileSync(outside, "x");
+    fs.symlinkSync(outside, path.join(kbRoot, "link.md"));
+
+    const res = await POST(createShareRequest("link.md"));
+    // lstat already rejects symlinks with 400 — confirm the post-hash path never runs.
+    expect(res.status).toBe(400);
+    expect(insertSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-platform/test/shared-page-binary.test.ts
+++ b/apps/web-platform/test/shared-page-binary.test.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { createHash } from "node:crypto";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { hashBytes } from "@/server/kb-content-hash";
 
 const mocks = vi.hoisted(() => ({
   mockServiceFrom: vi.fn(),
@@ -42,8 +43,7 @@ function callGET(request: Request, token: string) {
 
 function hashFile(absPath: string): string | null {
   try {
-    const buf = fs.readFileSync(absPath);
-    return createHash("sha256").update(buf).digest("hex");
+    return hashBytes(fs.readFileSync(absPath));
   } catch {
     return null;
   }

--- a/apps/web-platform/test/shared-page-binary.test.ts
+++ b/apps/web-platform/test/shared-page-binary.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { createHash } from "node:crypto";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -39,10 +40,23 @@ function callGET(request: Request, token: string) {
   return GET(request, { params: Promise.resolve({ token }) });
 }
 
+function hashFile(absPath: string): string | null {
+  try {
+    const buf = fs.readFileSync(absPath);
+    return createHash("sha256").update(buf).digest("hex");
+  } catch {
+    return null;
+  }
+}
+
 function mockShareAndOwner(
   documentPath: string,
-  opts: { revoked?: boolean } = {},
+  opts: { revoked?: boolean; contentHash?: string | null } = {},
 ) {
+  const resolvedHash =
+    opts.contentHash === undefined
+      ? hashFile(path.join(kbRoot, documentPath)) ?? "0".repeat(64)
+      : opts.contentHash;
   let fromCallCount = 0;
   mocks.mockServiceFrom.mockImplementation(() => {
     fromCallCount++;
@@ -55,6 +69,7 @@ function mockShareAndOwner(
                 document_path: documentPath,
                 user_id: "user-1",
                 revoked: Boolean(opts.revoked),
+                content_sha256: resolvedHash,
               },
               error: null,
             }),

--- a/apps/web-platform/test/shared-token-content-changed-ui.test.tsx
+++ b/apps/web-platform/test/shared-token-content-changed-ui.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor, act } from "@testing-library/react";
+import { Suspense } from "react";
+
+vi.mock("@/components/ui/markdown-renderer", () => ({
+  MarkdownRenderer: ({ content }: { content: string }) => (
+    <div data-testid="markdown">{content}</div>
+  ),
+}));
+
+vi.mock("@/components/shared/cta-banner", () => ({
+  CtaBanner: () => <div data-testid="cta-banner" />,
+}));
+
+vi.mock("@/components/kb/pdf-preview", () => ({
+  PdfPreview: () => <div data-testid="pdf-preview" />,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function renderWithSuspense(ui: React.ReactNode) {
+  return render(<Suspense fallback={<div>Loading...</div>}>{ui}</Suspense>);
+}
+
+function mock410(body: unknown) {
+  const headers = new Map([["content-type", "application/json"]]);
+  global.fetch = vi.fn(() =>
+    Promise.resolve({
+      ok: false,
+      status: 410,
+      headers: {
+        get: (name: string) => headers.get(name.toLowerCase()) ?? null,
+      },
+      json: () =>
+        body === "INVALID"
+          ? Promise.reject(new Error("bad json"))
+          : Promise.resolve(body),
+    }),
+  ) as unknown as typeof fetch;
+}
+
+describe("SharedDocumentPage — 410 content-changed variant", () => {
+  it("renders the content-changed copy when body code is content-changed", async () => {
+    mock410({ error: "...", code: "content-changed" });
+
+    const { default: SharedDocumentPage } = await import(
+      "@/app/shared/[token]/page"
+    );
+
+    const { container } = await act(() =>
+      renderWithSuspense(
+        <SharedDocumentPage params={Promise.resolve({ token: "t-cc" })} />,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("The shared file was modified");
+    });
+    expect(container.textContent).not.toContain("This link has been disabled");
+  });
+
+  it("renders legacy-null-hash as the content-changed copy (same user-facing state)", async () => {
+    mock410({ error: "...", code: "legacy-null-hash" });
+
+    const { default: SharedDocumentPage } = await import(
+      "@/app/shared/[token]/page"
+    );
+
+    const { container } = await act(() =>
+      renderWithSuspense(
+        <SharedDocumentPage params={Promise.resolve({ token: "t-legacy" })} />,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("The shared file was modified");
+    });
+  });
+
+  it("falls back to the revoked copy when the 410 body lacks a code field", async () => {
+    mock410({ error: "This link has been disabled" });
+
+    const { default: SharedDocumentPage } = await import(
+      "@/app/shared/[token]/page"
+    );
+
+    const { container } = await act(() =>
+      renderWithSuspense(
+        <SharedDocumentPage params={Promise.resolve({ token: "t-old" })} />,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("This link has been disabled");
+    });
+  });
+
+  it("falls back to the revoked copy when the 410 body is not parseable JSON", async () => {
+    mock410("INVALID");
+
+    const { default: SharedDocumentPage } = await import(
+      "@/app/shared/[token]/page"
+    );
+
+    const { container } = await act(() =>
+      renderWithSuspense(
+        <SharedDocumentPage params={Promise.resolve({ token: "t-bad" })} />,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("This link has been disabled");
+    });
+  });
+});

--- a/apps/web-platform/test/shared-token-content-hash.test.ts
+++ b/apps/web-platform/test/shared-token-content-hash.test.ts
@@ -7,6 +7,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const mocks = vi.hoisted(() => ({
   mockServiceFrom: vi.fn(),
   mockIsAllowed: vi.fn(),
+  mockLoggerInfo: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+  mockLoggerError: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/server", () => ({
@@ -22,7 +25,12 @@ vi.mock("@/server/rate-limiter", () => ({
 }));
 
 vi.mock("@/server/logger", () => ({
-  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  default: {
+    info: mocks.mockLoggerInfo,
+    error: mocks.mockLoggerError,
+    warn: mocks.mockLoggerWarn,
+    debug: vi.fn(),
+  },
 }));
 
 import { GET } from "@/app/api/shared/[token]/route";
@@ -112,6 +120,10 @@ describe("GET /api/shared/[token] — content hash verification", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.content).toContain("Body text.");
+    expect(mocks.mockLoggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "shared_page_viewed" }),
+      expect.any(String),
+    );
   });
 
   it("returns 410 with code content-changed when markdown body drifts", async () => {

--- a/apps/web-platform/test/shared-token-content-hash.test.ts
+++ b/apps/web-platform/test/shared-token-content-hash.test.ts
@@ -1,0 +1,229 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  mockServiceFrom: vi.fn(),
+  mockIsAllowed: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServiceClient: vi.fn(() => ({
+    from: mocks.mockServiceFrom,
+  })),
+}));
+
+vi.mock("@/server/rate-limiter", () => ({
+  shareEndpointThrottle: { isAllowed: mocks.mockIsAllowed },
+  extractClientIpFromHeaders: vi.fn(() => "127.0.0.1"),
+  logRateLimitRejection: vi.fn(),
+}));
+
+vi.mock("@/server/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from "@/app/api/shared/[token]/route";
+
+function hex(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+let tmpWorkspace: string;
+let kbRoot: string;
+let shareRow: Record<string, unknown> | null;
+
+function mockShareLookup() {
+  const makeChain = (terminal: Record<string, unknown>) => {
+    const chain: Record<string, unknown> = { ...terminal };
+    chain.eq = vi.fn().mockReturnValue(chain);
+    return chain;
+  };
+
+  let fromCalls = 0;
+  mocks.mockServiceFrom.mockImplementation(() => {
+    fromCalls++;
+    if (fromCalls === 1) {
+      // kb_share_links lookup by token
+      return {
+        select: vi.fn().mockReturnValue(
+          makeChain({
+            single: vi.fn().mockResolvedValue({
+              data: shareRow,
+              error: shareRow ? null : new Error("not found"),
+            }),
+          }),
+        ),
+      };
+    }
+    // users lookup for owner workspace
+    return {
+      select: vi.fn().mockReturnValue(
+        makeChain({
+          single: vi.fn().mockResolvedValue({
+            data: {
+              workspace_path: tmpWorkspace,
+              workspace_status: "ready",
+            },
+            error: null,
+          }),
+        }),
+      ),
+    };
+  });
+}
+
+function getReq(): Request {
+  return new Request("http://localhost:3000/api/shared/token-123");
+}
+
+async function callGET() {
+  return GET(getReq(), { params: Promise.resolve({ token: "token-123" }) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), "shared-hash-"));
+  kbRoot = path.join(tmpWorkspace, "knowledge-base");
+  fs.mkdirSync(kbRoot, { recursive: true });
+  mocks.mockIsAllowed.mockReturnValue(true);
+  shareRow = null;
+  mockShareLookup();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpWorkspace, { recursive: true, force: true });
+});
+
+describe("GET /api/shared/[token] — content hash verification", () => {
+  it("serves markdown when the stored hash matches current bytes", async () => {
+    const raw = "---\ntitle: Hi\n---\nBody text.";
+    fs.writeFileSync(path.join(kbRoot, "note.md"), raw);
+    shareRow = {
+      document_path: "note.md",
+      user_id: "owner-1",
+      revoked: false,
+      content_sha256: hex(Buffer.from(raw)),
+    };
+
+    const res = await callGET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.content).toContain("Body text.");
+  });
+
+  it("returns 410 with code content-changed when markdown body drifts", async () => {
+    fs.writeFileSync(path.join(kbRoot, "note.md"), "new body");
+    shareRow = {
+      document_path: "note.md",
+      user_id: "owner-1",
+      revoked: false,
+      content_sha256: hex(Buffer.from("old body")),
+    };
+
+    const res = await callGET();
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.code).toBe("content-changed");
+  });
+
+  it("returns 410 when ONLY the markdown frontmatter changes (raw bytes hashed)", async () => {
+    const originalRaw = "---\ntitle: Old\n---\nSame body.";
+    const editedRaw = "---\ntitle: New\n---\nSame body.";
+    fs.writeFileSync(path.join(kbRoot, "note.md"), editedRaw);
+    shareRow = {
+      document_path: "note.md",
+      user_id: "owner-1",
+      revoked: false,
+      content_sha256: hex(Buffer.from(originalRaw)),
+    };
+
+    const res = await callGET();
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.code).toBe("content-changed");
+  });
+
+  it("serves a PDF when the stored hash matches current bytes", async () => {
+    const pdfBytes = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x01, 0x02]);
+    fs.writeFileSync(path.join(kbRoot, "doc.pdf"), pdfBytes);
+    shareRow = {
+      document_path: "doc.pdf",
+      user_id: "owner-1",
+      revoked: false,
+      content_sha256: hex(pdfBytes),
+    };
+
+    const res = await callGET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/pdf");
+  });
+
+  it("returns 410 with code content-changed when PDF bytes drift", async () => {
+    fs.writeFileSync(path.join(kbRoot, "doc.pdf"), Buffer.from("new pdf bytes"));
+    shareRow = {
+      document_path: "doc.pdf",
+      user_id: "owner-1",
+      revoked: false,
+      content_sha256: hex(Buffer.from("old pdf bytes")),
+    };
+
+    const res = await callGET();
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.code).toBe("content-changed");
+  });
+
+  it("returns 404 unchanged when the file is missing (resurrection not relevant)", async () => {
+    shareRow = {
+      document_path: "gone.pdf",
+      user_id: "owner-1",
+      revoked: false,
+      content_sha256: hex(Buffer.from("whatever")),
+    };
+
+    const res = await callGET();
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 410 with code legacy-null-hash when content_sha256 is null", async () => {
+    fs.writeFileSync(path.join(kbRoot, "note.md"), "body");
+    shareRow = {
+      document_path: "note.md",
+      user_id: "owner-1",
+      revoked: false,
+      content_sha256: null,
+    };
+
+    const res = await callGET();
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.code).toBe("legacy-null-hash");
+  });
+
+  it("keeps the revoked 410 path intact (distinct from content-changed)", async () => {
+    shareRow = {
+      document_path: "doc.pdf",
+      user_id: "owner-1",
+      revoked: true,
+      content_sha256: hex(Buffer.from("x")),
+    };
+
+    const res = await callGET();
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    // Must NOT claim content-changed when the row is explicitly revoked.
+    expect(body.code).not.toBe("content-changed");
+  });
+
+  it("rate-limits before hashing (no fs work on 429)", async () => {
+    mocks.mockIsAllowed.mockReturnValue(false);
+    const fsReadSpy = vi.spyOn(fs.promises, "open");
+    const res = await callGET();
+    expect(res.status).toBe(429);
+    expect(fsReadSpy).not.toHaveBeenCalled();
+    fsReadSpy.mockRestore();
+  });
+});

--- a/knowledge-base/project/learnings/2026-04-17-migration-not-null-without-backfill-and-partial-unique-index-pattern.md
+++ b/knowledge-base/project/learnings/2026-04-17-migration-not-null-without-backfill-and-partial-unique-index-pattern.md
@@ -1,0 +1,131 @@
+---
+module: "KB share links"
+date: 2026-04-17
+problem_type: security_issue
+component: supabase_migration
+symptoms:
+  - "Share link token resurrection after file delete/rename/overwrite"
+  - "Concurrent POST /api/kb/share can create duplicate active rows for the same (user_id, document_path)"
+  - "Migration alter column set not null fails when prior UPDATE did not populate the new column"
+root_cause: missing_backfill_and_missing_unique_constraint
+severity: high
+tags:
+  - migration
+  - supabase
+  - sha256
+  - content-integrity
+  - partial-unique-index
+  - concurrency
+  - code-review
+synced_to: [data-integrity-guardian]
+---
+
+# Migration NOT NULL trap + partial unique index pattern for revoke-and-reissue flows
+
+## Problem
+
+Three related defects in one PR (#2463, closing #2326):
+
+1. **Token resurrection.** `kb_share_links` rows persisted `revoked = false` after the underlying KB file was deleted, renamed, or overwritten. A new file materialising at the same `document_path` would be served through the old token.
+
+2. **Migration NOT NULL trap.** First draft of the migration added `content_sha256 text NOT NULL` after an `UPDATE ... SET revoked = true` that did **not** populate the new column. Any pre-existing row would fail the NOT NULL transition at `alter column ... set not null`. Locally the migration ran against an empty table, so vitest (mocked Supabase) and `tsc --noEmit` never exercised the failure path. Would have failed on first apply if prod had any rows.
+
+3. **Concurrent-POST race.** Two concurrent POSTs for the same `(user_id, document_path)` with a modified file could both pass the existing-share lookup (SELECT-then-INSERT) and both insert new rows. Result: multiple active shares per (user, path), one of them invisible to the UI — exactly the dangling-row class the migration is meant to prevent.
+
+## Investigation / How It Surfaced
+
+Written tests + typecheck all green. The failure modes were caught by parallel review agents:
+
+- **data-integrity-guardian** read the migration SQL symbolically against the insert path and noticed the `UPDATE ... SET revoked = true` leaves `content_sha256 IS NULL`, so the subsequent `set not null` fails on any existing row. Reinforces `2026-04-15-multi-agent-review-catches-bugs-tests-miss.md`.
+- **security-sentinel + data-integrity-guardian** both flagged the SELECT-then-INSERT race. The missing partial unique index is the exact mechanism by which the bug the migration tries to close can still occur under concurrent load.
+- **performance-oracle** separately flagged a Range-request performance regression (scope-out #2466).
+
+## Solution
+
+### 1. Migration: scope the CHECK to active rows instead of NOT NULL
+
+Instead of requiring `content_sha256 IS NOT NULL` for all rows (which forces backfill or revoke of legacy rows — awkward for audit), keep the column nullable and enforce the invariant only on rows that can be viewed:
+
+```sql
+alter table public.kb_share_links
+  add column content_sha256 text;
+
+update public.kb_share_links
+   set revoked = true
+ where content_sha256 is null
+   and revoked = false;
+
+alter table public.kb_share_links
+  add constraint kb_share_links_content_sha256_format
+    check (revoked = true or content_sha256 ~ '^[a-f0-9]{64}$');
+```
+
+The CHECK reads: "either this row is revoked, or it carries a valid lowercase-hex SHA-256." Revoked legacy rows retain audit metadata (token, user_id, document_path); active rows are invariant-enforced at the DB layer.
+
+### 2. Partial unique index for "one active X per Y"
+
+The resurrection class needs a DB-level guarantee that no two rows can be active for the same natural key:
+
+```sql
+create unique index kb_share_links_one_active_per_doc
+  on public.kb_share_links(user_id, document_path)
+  where revoked = false;
+```
+
+The partial `where revoked = false` is critical: a user can have many historical revoked shares for the same path, but only one active one. The unique constraint only applies to the active subset.
+
+### 3. Handle the resulting 23505 conflict in the POST handler
+
+```ts
+const { error: insertError } = await serviceClient
+  .from("kb_share_links")
+  .insert({ user_id, token, document_path, content_sha256 });
+
+if (insertError) {
+  if ((insertError as { code?: string }).code === "23505") {
+    // Concurrent POST won the race. Read the winner's row; return its
+    // token if hashes match, else 409.
+    const { data: winner } = await serviceClient
+      .from("kb_share_links")
+      .select("token, content_sha256")
+      .eq("user_id", user.id)
+      .eq("document_path", body.documentPath)
+      .eq("revoked", false)
+      .maybeSingle();
+    if (winner && winner.content_sha256 === contentHash) {
+      return NextResponse.json({ token: winner.token, url: `/shared/${winner.token}` });
+    }
+    return NextResponse.json({ error: "Concurrent share creation — retry" }, { status: 409 });
+  }
+  // ...
+}
+```
+
+### 4. Hash raw bytes, not parsed content
+
+For integrity binding to catch frontmatter-only edits, hash the **raw file bytes** (pre-frontmatter-parse). `gray-matter` returns `content` with frontmatter stripped; hashing that lets `title:` / `tags:` edits silently pass verification. Added `readContentRaw` to `server/kb-reader.ts` returning `{ buffer, raw, path }`, and refactored `readContent` as a thin wrapper around it.
+
+## Key Insights
+
+- **Migration "set not null" trap:** Any `alter column X set not null` that runs after an `UPDATE` which does not populate X will fail at apply time if prior rows exist. Vitest with mocked Supabase will pass; `tsc --noEmit` sees no type involvement. Only a prod apply (or integration test against a real DB) catches it. **Prefer scoped CHECK constraints (`revoked = true or X ~ ...`) over blanket NOT NULL** when pre-existing rows can stay in a "tombstone" state.
+- **Partial unique indexes are the mechanical guarantee for "one active X per Y":** SELECT-then-INSERT is a race. A partial unique `where revoked = false` cannot race — the DB rejects the second insert. Handle 23505 in app code by re-reading the winner.
+- **Hash raw bytes for integrity binding:** `gray-matter`, `parse5`, any content-transforming reader strips metadata. Hash the buffer *before* the parser touches it. Ship a `readContentRaw` sibling to the parsing helper and have the parser call it.
+
+## Session Errors
+
+**Error 1 — Lost CWD between Bash calls.** First `./node_modules/.bin/vitest` attempt after an Edit failed with "No such file or directory" because shell state does not persist between Bash tool invocations. Recovered by prefixing `cd <abs-path> &&`. **Prevention:** Already covered by rule `cq-for-local-verification-of-apps-doppler` in AGENTS.md.
+
+**Error 2 — Migration NOT NULL trap not caught by tests.** Initial migration had `alter column content_sha256 set not null` after an UPDATE that only populated `revoked`. Would have failed on first prod apply. Tests didn't catch it because Supabase was mocked; typecheck didn't see it because there's no type involvement; the failure only surfaces at DB apply time. **Prevention:** When writing a migration that adds NOT NULL on a new column, verify the backfill path explicitly. If pre-existing rows cannot be backfilled with a valid value, use a scoped CHECK (`revoked = true or X ~ ...`) instead of NOT NULL and keep the column nullable. Also: run the migration against a real prod-shaped Supabase instance (or at minimum a local `supabase start`) in any migration PR.
+
+## Prevention
+
+- In migration review checklists, explicitly ask: "Does this migration add NOT NULL to a new column? If yes, does the backfill populate it for all existing rows?"
+- When modelling a "one active X per Y" invariant, reach for `CREATE UNIQUE INDEX ... WHERE <active-predicate>` instead of application-level SELECT-then-INSERT.
+- When binding a token/signature to file content, hash the raw bytes from the fs read — never hash the output of a content-transforming reader.
+
+## Related
+
+- `2026-04-15-multi-agent-review-catches-bugs-tests-miss.md` — Same pattern: review agents catch defects that unit tests + typecheck miss.
+- `plugins/soleur/agents/engineering/review/data-integrity-guardian.md` — This agent reads migration SQL symbolically against app insert code and flags backfill gaps.
+- PR #2463 / issue #2326 — Scope.
+- Deferred scope-outs filed: #2466 (Range-request hash cache), #2467 (POST handler extraction), #2468 (shared mock fixture), #2469 (ETag emission).

--- a/knowledge-base/project/plans/2026-04-17-fix-kb-share-dangling-rows-plan.md
+++ b/knowledge-base/project/plans/2026-04-17-fix-kb-share-dangling-rows-plan.md
@@ -323,7 +323,7 @@ Record all four screenshots in the PR body.
 
 ## Acceptance Criteria
 
-- [ ] Migration `026_kb_share_links_content_sha256.sql` applied on prod via the Supabase runbook; REST probe confirms column presence AND check constraint AND NOT NULL.
+- [ ] (post-merge) Migration `026_kb_share_links_content_sha256.sql` applied on prod via the Supabase runbook; REST probe confirms column presence AND check constraint AND NOT NULL.
 - [ ] Pre-apply row count audit documented in PR body (actual number from prod REST probe).
 - [ ] Pre-existing rows marked `revoked = true` (or explicit operator override path documented) so no legacy token can view anything post-deploy.
 - [ ] `POST /api/kb/share` computes SHA-256 via `hashStream` (not `hashBytes` over `readFile`) and stores in `content_sha256` on every new row. Insert payload covered by vitest.

--- a/knowledge-base/project/plans/2026-04-17-fix-kb-share-dangling-rows-plan.md
+++ b/knowledge-base/project/plans/2026-04-17-fix-kb-share-dangling-rows-plan.md
@@ -1,0 +1,440 @@
+# fix(kb): bind KB share links to content hash to prevent token resurrection
+
+## Enhancement Summary
+
+**Deepened on:** 2026-04-17
+**Sections enhanced:** 6 (Phase 2-4, Phase 4 UI integration, Security, Acceptance)
+**Research targeted:** Node.js `crypto` streaming hash benchmarks, existing codebase patterns for `readContent` vs `readBinaryFile`, UI error-variant handling in `/shared/[token]/page.tsx`.
+
+### Key Improvements
+
+1. **Hash raw file bytes, not post-parse content.** `readContent` strips frontmatter via `gray-matter` before returning `content`. Hashing the return value would mean frontmatter edits silently pass verification. Switch to hashing the raw read buffer before frontmatter parsing.
+2. **Stream the hash, don't buffer twice.** Use `crypto.createHash('sha256')` as a `Transform` stream fed by `handle.createReadStream()` so we never hold two 50 MB buffers in memory. Creation path becomes O(1) extra memory, not O(file size).
+3. **UI needs a third error state.** The existing page maps 410 → "This link has been disabled" (revoked copy). Content-changed is semantically distinct — introduce `error === "content-changed"` with tailored copy ("The shared file has been modified"). Discriminate via response body tag, not status code.
+4. **`readContent` lacks O_NOFOLLOW.** Unlike `readBinaryFile`, markdown reads don't use the fd-safe pattern. The plan calls out this asymmetry but does not fix it here (scope creep); we hash the buffer `readContent` already produces.
+5. **Migration: defensive revoke AFTER prod-row audit.** The blanket `update ... set revoked = true` is correct *only* if prod has near-zero share links. Added a mandatory pre-apply REST probe with a documented fork: 0 rows → proceed as-is; >0 rows → operator decision documented in PR.
+6. **ETag header alignment.** `Content-SHA256` makes a natural `ETag`. Emit `ETag: "<sha256>"` on binary view responses so conditional GETs (`If-None-Match`) short-circuit with 304. Free latency win, no extra compute.
+
+### New Considerations Discovered
+
+- `readBinaryFile` already returns the full buffer (L98) — view-time hash costs nothing beyond one pass over that buffer (~200-400 ms for 50 MB).
+- Node's stdlib `createHash` in native C++ runs at ~1.5-2 GB/s on modern x86 — a 50 MB hash is **25-35 ms**, not 200-400 ms. View-time latency cost is negligible.
+- `kb_share_links.document_path` has no unique constraint today. A user could technically have two active shares for the same `document_path` with different tokens if the existing-share lookup raced — not a regression introduced by this PR, worth noting for a future hardening issue (not filed in this PR scope).
+
+---
+
+**Issue:** [#2326](https://github.com/jikigai-ai/soleur/issues/2326)
+**Labels:** `priority/p1-high`, `type/security`, `domain/engineering`, `code-review`
+**Milestone:** Phase 3: Make it Sticky
+**Worktree:** `.worktrees/feat-fix-2326-kb-share-dangling-rows/`
+**Branch:** `feat-fix-2326-kb-share-dangling-rows`
+
+## Overview
+
+`kb_share_links` rows persist with `revoked = false` even after the underlying KB file is deleted, renamed, or replaced. Today the shared-view endpoint returns 404 ("Document no longer available") when the file is missing, which makes links *look* dead, but the row is still live. If a new file materialises at the same relative path — whether by re-upload of an unrelated file named `invoice.pdf`, or a rename that vacates `secret.pdf` so a different `secret.pdf` can be created — the old token silently starts serving the new bytes.
+
+This is a **referential integrity** problem: `document_path` is a string, not a foreign key, and the filesystem has no stable identifier Supabase can refer to. The fix is to bind each share to **content**, not to a path: add `content_sha256` to `kb_share_links`, populate it at share-creation time, and re-hash the current file at view time. Any mismatch → `410 Gone` with a user-visible "content changed" message. Resurrection becomes cryptographically impossible because a new file at the same path has a different hash.
+
+This is the first of 27 code-review issues in Phase 3. Scope is intentionally tight: fix this bug only. Follow-ups (#2316 stream binary responses, #2309 agent-user parity for KB share) are tracked separately and called out in Non-Goals.
+
+### Why Option A (content_sha256) over B/C
+
+The issue body enumerates three options:
+
+| Option | Mechanism | Resurrection coverage | Complexity | Cross-host safety |
+|---|---|---|---|---|
+| **A: content_sha256** | Hash content at create, re-hash at view, compare | Full (delete→re-upload, rename→recreate, overwrite) | 1 migration + `~40 LOC` | Yes |
+| B: inode + mtime | stat-based fingerprint | Full on same host | Low | Breaks on workspace host migration |
+| C: cron cleanup | Mark revoked when path missing | Partial — doesn't cover rename→recreate | Medium (new job + scheduler) | Yes |
+
+Option A wins because (a) it closes the loophole completely, (b) SHA-256 of the 50 MB upper bound is sub-second on modern CPUs and runs **once** at share creation, (c) re-hash at view time adds ~300 ms for a 50 MB file which is trivial next to the network transfer, and (d) no cross-host assumptions. We pay one migration and one file-hash per share creation, and we gain a strong content binding. The issue author explicitly recommends Option A; we agree.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Spec claim | Reality in codebase | Plan response |
+|---|---|---|
+| `kb_share_links.document_path` is a path string with no FS-backed referential integrity | Confirmed. `supabase/migrations/017_kb_share_links.sql` L5-12: columns are `id, user_id, token, document_path, created_at, revoked`. No content-binding column exists. | Add `content_sha256 text` in a new migration (`026_kb_share_links_content_sha256.sql`). |
+| View endpoint returns 404 when the file is missing but row is still live | Confirmed. `app/api/shared/[token]/route.ts` L96-101: `KbNotFoundError` → 404 with no row mutation. `DELETE /api/kb/share/[token]` is the only path that sets `revoked = true`. | No row-state mutation needed on hash mismatch — a `410` response is sufficient and matches the existing revoke-semantics pattern. |
+| Creation endpoint already lstats the file and enforces size ≤ 50 MB | Confirmed. `app/api/kb/share/route.ts` L59-73 opens lstat, rejects symlinks/non-files, rejects > `MAX_BINARY_SIZE`. | Compute SHA-256 *after* these guards pass, using the same fd-safe pattern as `readBinaryFile` to avoid a TOCTOU swap between lstat and hash. |
+| View endpoint already re-reads binary via `readBinaryFile` with O_NOFOLLOW and fd-based fstat | Confirmed. `server/kb-binary-response.ts` L73-80 uses `fs.promises.open(..., O_RDONLY | O_NOFOLLOW)` and fstat on the fd. | Hash at view time from the *same* fd so the hash and the served bytes are guaranteed to match, closing any hash-then-serve TOCTOU window. |
+| Markdown files use `readContent` instead of `readBinaryFile` | Confirmed. `app/api/shared/[token]/route.ts` L77-108 forks on extension. | Hash both markdown and binary content paths at view time. Markdown needs a parallel hash computation since `readContent` currently returns a string, not a buffer. Preferred implementation: hash the buffer in a helper that both paths call (`server/kb-content-hash.ts`), fed by the existing fs read. |
+
+## Implementation Phases
+
+Tight, linear phases — no cross-cutting refactor.
+
+### Phase 1: Database migration (30 min)
+
+**Goal:** Add `content_sha256` column to `kb_share_links` and populate existing rows with a safe sentinel.
+
+Files:
+
+- `apps/web-platform/supabase/migrations/026_kb_share_links_content_sha256.sql` (new)
+
+Migration content:
+
+```sql
+-- 026_kb_share_links_content_sha256.sql
+-- Bind KB share links to content, not path, to prevent token resurrection
+-- after file delete/rename. See issue #2326.
+
+alter table public.kb_share_links
+  add column content_sha256 text;
+
+-- Existing rows have no hash. Mark them revoked so they cannot be
+-- resurrected — users must re-create any links they still want.
+-- (Prod currently has 0 production share links per Supabase REST check;
+-- confirm before applying. See Pre-apply checklist below.)
+update public.kb_share_links
+   set revoked = true
+ where content_sha256 is null
+   and revoked = false;
+
+-- New rows MUST carry a hash.
+alter table public.kb_share_links
+  alter column content_sha256 set not null,
+  add constraint kb_share_links_content_sha256_format
+    check (content_sha256 ~ '^[a-f0-9]{64}$');
+
+-- Small index for future auditability (e.g., "how many share links point
+-- at identical content?"). Not required for correctness.
+create index idx_kb_share_links_content_sha256
+  on public.kb_share_links(content_sha256);
+```
+
+**Pre-apply check (runbook reference: `knowledge-base/engineering/ops/runbooks/supabase-migrations.md`):**
+
+1. **Count audit** — REST probe (under Doppler `prd` creds):
+
+   ```bash
+   curl -s -H "apikey: $SUPABASE_SERVICE_KEY" \
+     -H "Authorization: Bearer $SUPABASE_SERVICE_KEY" \
+     "$SUPABASE_URL/rest/v1/kb_share_links?select=id,user_id,revoked&limit=1000" | jq 'length'
+   ```
+
+   - **0 rows** → apply the migration as written. Defensive revoke is a no-op.
+   - **≤10 rows (non-zero)** → apply as written; the defensive revoke is acceptable collateral and operators can notify affected users individually. Document the pre-state row count in the PR body.
+   - **>10 rows** → PAUSE. Switch migration to the "soft legacy" form (drop the `update ... set revoked = true` and keep `content_sha256` nullable until a backfill job populates hashes from current files). File a follow-up issue for the backfill. This path needs explicit operator sign-off — do not auto-apply.
+2. Apply via the runbook's canonical path (`supabase db push` from `apps/web-platform/` or the CI migrate job).
+3. Post-apply verification:
+
+   ```sql
+   -- Column exists with correct type + constraints
+   select column_name, data_type, is_nullable
+     from information_schema.columns
+    where table_name = 'kb_share_links'
+      and column_name = 'content_sha256';
+   -- Expect: text, NO
+
+   -- Constraint is present
+   select conname from pg_constraint
+    where conrelid = 'public.kb_share_links'::regclass
+      and conname = 'kb_share_links_content_sha256_format';
+   ```
+
+4. Rollback contract: column stays (dropping loses data on re-roll-forward); only the NOT NULL + check are reversible. See Rollback Plan below.
+
+Tests:
+
+- No test file for migrations directly — verified via post-apply REST probe.
+
+### Phase 2: Shared hash helper (30 min)
+
+**Goal:** Central module that both creation and view paths use, with two entry points: buffer-based (when a buffer is already in hand) and stream-based (when we haven't read yet, to avoid buffering twice).
+
+Files:
+
+- `apps/web-platform/server/kb-content-hash.ts` (new)
+- `apps/web-platform/test/kb-content-hash.test.ts` (new — RED first)
+
+Module:
+
+```ts
+// server/kb-content-hash.ts
+import { createHash } from "node:crypto";
+import type { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+/**
+ * SHA-256 of a byte buffer, lowercase hex. Use when the caller already
+ * holds the full buffer (e.g., readBinaryFile returns buffer).
+ */
+export function hashBytes(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+/**
+ * SHA-256 of a Readable stream, lowercase hex. Use at share creation to
+ * avoid allocating a second 50 MB buffer just for hashing — we stream
+ * the file through the hasher and let the GC reclaim chunks as they go.
+ * The hasher is a Transform-compatible Writable for stream.pipeline.
+ *
+ * Callers supply the stream; this helper does NOT close the underlying
+ * fd — that's the caller's responsibility (it should own the fd lifecycle).
+ */
+export async function hashStream(source: Readable): Promise<string> {
+  const hasher = createHash("sha256");
+  await pipeline(source, hasher);
+  return hasher.digest("hex");
+}
+```
+
+Test (RED → GREEN):
+
+- `hashBytes(Buffer.from(""))` returns the known SHA-256 of empty string (`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`).
+- `hashBytes` of a 1 KB known-content fixture matches a precomputed hex value.
+- `hashStream` of a `Readable.from(Buffer)` equals `hashBytes` on the same buffer (parity check).
+- `hashStream` of a `fs.createReadStream(path)` equals `hashBytes(await fs.promises.readFile(path))` on a ≥1 MB fixture (stream correctness at chunk boundaries).
+- `hashStream` rejects with the underlying error if the stream errors mid-read.
+
+**Performance reference:** Node's `crypto.createHash('sha256')` uses OpenSSL's native C++ SHA-256 implementation (AVX2/SHA-NI accelerated on modern x86). Typical throughput: **1.5-2 GB/s**. A 50 MB file hashes in **25-35 ms** on AWS t3 or Hetzner CX class hardware. No measurable p99 impact on the share-create or share-view paths.
+
+### Phase 3: Hash on share creation (45 min)
+
+**Goal:** `POST /api/kb/share` computes the hash after existing lstat/size/symlink guards and persists it with the row.
+
+Files:
+
+- `apps/web-platform/app/api/kb/share/route.ts` (edit)
+- `apps/web-platform/test/kb-share-allowed-paths.test.ts` (extend)
+- `apps/web-platform/test/kb-share-content-hash.test.ts` (new)
+
+Edits to `route.ts` (between current L73 size guard and L76 existing-share lookup):
+
+1. After size guard passes, open the file with `O_RDONLY | O_NOFOLLOW` and `fstat` the fd (mirrors `readBinaryFile`'s pattern at `kb-binary-response.ts:73-80`). **Do not call `fs.promises.readFile(fullPath)`** — that re-opens the path and is vulnerable to a symlink swap between lstat and readFile. If fstat disagrees with the earlier lstat (size, type, non-file), close fd and reject.
+2. Create a `handle.createReadStream()` and pass it to `hashStream(stream)` from Phase 2. This avoids a second 50 MB allocation just to hash — we stream bytes through the hasher and never hold the file contents in memory on the creation path.
+3. `await handle.close()` (in a `finally`) after hashing completes.
+4. Pass `content_sha256: contentHash` in the `insert()` payload.
+5. Existing-share lookup: keep as-is (it matches on `user_id + document_path + revoked=false`). A caller asking for a share of the same path **and** same current bytes (hash matches) gets the same token back. If the file *changed* since the original share, the old row's `content_sha256` no longer matches current bytes — view time returns 410. Creation side deliberately does **not** auto-revoke or replace; the user must explicitly re-share. This is simpler than coupling creation to view-time semantics and avoids a write amplification on the happy path.
+6. Stale-share awareness: after the existing-share lookup returns a row, *before* returning it, compare `existing.content_sha256` against the newly-computed hash. If they match → return the existing token (happy path, same content). If they differ → the user is re-sharing a modified file; revoke the stale row (`update revoked = true` by `id`) and fall through to insert a new row. This keeps the API idempotent in a user-friendly way: re-sharing after a legitimate edit transparently issues a fresh token. Test covers both branches.
+
+**Why (6) is in scope:** without it, a user who uploads a new version of `report.pdf` and clicks Share gets the *existing* (now-stale) token back. That token returns 410 at view time per Phase 4 — a confusing "share created but broken" UX. Revoke-and-reissue on content drift makes the creation endpoint a clean "ensure a working share exists" primitive.
+
+Open question resolved: should creation auto-revoke a stale row when it detects the file changed? **No.** That would couple creation to view-time semantics and add an extra write on a happy-path. Let view time return 410 and let the user explicitly re-share if needed. Documented in code comment.
+
+Tests (RED → GREEN):
+
+- `kb-share-allowed-paths.test.ts`: extend existing happy-path assertions to also verify `content_sha256` is present in the insert payload (test already spies `mockServiceFrom`).
+- `kb-share-content-hash.test.ts` (new):
+  - Creation stores the hash of the file bytes (match against `hashBytes` output for a fixture).
+  - Same file → second POST returns the existing token without a second insert (idempotent happy path).
+  - File bytes change between two POSTs → second POST revokes the stale row and issues a NEW token (covers the re-share-after-edit flow from step 6).
+  - Binary file (PDF, PNG) and text file (markdown) both produce 64-char hex hashes.
+  - Symlink swap between lstat and hash-read is rejected by O_NOFOLLOW (vitest fixture: create a file, symlink it post-lstat; fstat guard catches the type mismatch and returns 400/403).
+
+### Phase 4: Hash verification on view (75 min)
+
+**Goal:** `GET /api/shared/[token]` re-hashes current file bytes and responds `410 Gone` with a `content-changed` error tag if the hash diverges from the stored `content_sha256`.
+
+Files:
+
+- `apps/web-platform/app/api/shared/[token]/route.ts` (edit)
+- `apps/web-platform/server/kb-reader.ts` (add a `readContentRaw` sibling that returns the raw file buffer *without* frontmatter parsing — critical finding, see below)
+- `apps/web-platform/server/kb-binary-response.ts` (already returns `buffer` — optionally add `ETag` to `buildBinaryResponse`)
+- `apps/web-platform/app/shared/[token]/page.tsx` (add `"content-changed"` to `PageError` union)
+- `apps/web-platform/test/shared-token-content-hash.test.ts` (new)
+
+**Critical finding — hash raw bytes, not parsed content:** `readContent` (`kb-reader.ts:250-291`) calls `parseFrontmatter(raw)` and returns `{ content }` which is the *post-frontmatter* body. If we hash `result.content`, frontmatter edits silently pass verification — a user who updates `title:` or `tags:` in a share thinks they re-authored the doc, but the old token still serves the new title. **Always hash the raw file bytes.**
+
+Add to `server/kb-reader.ts`:
+
+```ts
+export async function readContentRaw(
+  kbRoot: string,
+  relativePath: string,
+): Promise<{ buffer: Buffer; content: string; path: string }> {
+  // Same guards as readContent (null byte, .md requirement, traversal,
+  // file-size). Returns raw buffer (for hashing) and decoded UTF-8 string
+  // (for frontmatter parsing). Single disk read, not two.
+  // ... implementation mirrors readContent's guards ...
+  const buffer = await fs.promises.readFile(fullPath);
+  const raw = buffer.toString("utf-8");
+  return { buffer, content: raw, path: relativePath };
+}
+```
+
+Then `readContent` becomes a thin wrapper that calls `readContentRaw` and runs `parseFrontmatter(content)` on its output. This avoids code duplication and guarantees the raw-byte path and the parsed path see the same file read (no double-read race window).
+
+Edits to `app/api/shared/[token]/route.ts`:
+
+1. After the revoked check (current L48-53), also select `content_sha256` from `kb_share_links`.
+2. If `shareLink.content_sha256` is `null` (legacy defensive) → return `410` with body `{ error: "This link is from an older share system and is no longer valid.", code: "legacy-null-hash" }` and log `shared_legacy_null_hash`. Migration should have revoked these; this is belt-and-suspenders.
+3. For the **markdown** branch: call `readContentRaw(kbRoot, shareLink.document_path)`. `hashBytes(result.buffer)`. Compare to `shareLink.content_sha256`. Mismatch → 410 with body `{ error: "The shared file has been modified since it was shared.", code: "content-changed" }`. Log `shared_content_mismatch`. Match → parse frontmatter and return JSON as today.
+4. For the **binary** branch: `readBinaryFile` returns `ok: true` with `buffer`. `hashBytes(buffer)`. Compare. Mismatch → 410 with `content-changed` body. Match → `buildBinaryResponse(binary, request)` as today. Optionally: `buildBinaryResponse` emits `ETag: "\"${hash}\""` (weak-quoted per RFC 7232) so conditional GET can 304.
+5. 410 response contentType is `application/json` for both branches (the client-side page branches on response `content-type`; today markdown is `application/json` and binaries are `application/pdf`/`image/*`/etc. A 410 is always JSON, which is what the client already expects in the `res.status === 410` early return).
+6. Do not log the hash value (see Security & Privacy Notes). Log the *existence* of a mismatch, the token, and the document path.
+7. **Hash-work-after-rate-limit order:** the existing rate-limit check (L25-32) must remain the first thing in the handler. Do not compute the hash before the rate check — that would invite DoS via repeated 50 MB hashing requests.
+
+Edits to `app/shared/[token]/page.tsx`:
+
+1. Extend `PageError` union: `"not-found" | "revoked" | "content-changed" | "unknown"`.
+2. In the 410 branch (L58-62), read the JSON body to discriminate: `revoked` → `"revoked"`, `content-changed` → `"content-changed"`, `legacy-null-hash` → `"content-changed"` (same user-facing copy — "the link is no longer valid"), default → `"revoked"` for backwards-compat with the existing delete flow.
+3. Add an `ErrorMessage` block for `error === "content-changed"` with title "The shared file was modified" and message "The file has been edited or replaced since this link was created. Ask the owner to share again."
+4. Do not block the page render on the JSON parse failing — fall back to `"revoked"` copy so an older client that ignores the `code` field still degrades gracefully.
+
+Tests (RED → GREEN):
+
+- `shared-token-content-hash.test.ts` (server):
+  - **Markdown, hash matches** → 200 with `{ content, path }`.
+  - **Markdown, file bytes differ from stored hash** → 410 with `code: "content-changed"`.
+  - **Markdown, frontmatter change only** → 410 (this is the key test for the "hash raw bytes not parsed content" correction — changing `title:` in the frontmatter must invalidate).
+  - **Binary, hash matches** → 200 with `buildBinaryResponse` headers intact (Content-Type, Content-Disposition, optional ETag).
+  - **Binary, file bytes differ** → 410 with `code: "content-changed"`.
+  - **File deleted after share creation** → 404 (unchanged — we only 410 on *mismatch*, not on *missing*; 404 stays because the read itself fails before we can hash).
+  - **Null `content_sha256`** (legacy defense) → 410 with `code: "legacy-null-hash"`.
+  - **Rate-limit path** unchanged — test 429 still returns before any hash work.
+  - **ETag round-trip** (if implemented): conditional GET with matching `If-None-Match: "<hash>"` returns `304 Not Modified`.
+- Extend `kb-share-allowed-paths.test.ts` to confirm the creation path's hash *matches* the view path's hash for a round-trip fixture (markdown + PDF).
+- UI test `shared-token-content-changed-ui.test.tsx` (vitest + React Testing Library):
+  - Given a mocked fetch returning `410 { code: "content-changed" }`, the page renders "The shared file was modified" heading (not "This link has been disabled").
+  - Given `410 { code: "legacy-null-hash" }`, same copy (or dedicated legacy copy if copy team prefers).
+  - Given `410` with no JSON body, falls back to existing "revoked" copy.
+
+### Phase 5: Manual resurrection-scenario QA (20 min)
+
+**Goal:** Walk the two attack scenarios from the issue body end-to-end in a local dev workspace.
+
+Files: none (manual QA step, logged in PR body).
+
+Scenarios:
+
+1. **Delete → re-upload resurrection:**
+   - Create share for `dev/fixtures/invoice-v1.pdf` → save URL.
+   - Delete the file from workspace.
+   - Create `invoice-v1.pdf` at the same path with different bytes (unrelated content).
+   - Open the saved URL. Expect 410 "content has changed", NOT the new file.
+2. **Rename → recreate resurrection:**
+   - Create share for `dev/fixtures/secret.pdf` → save URL.
+   - Rename `secret.pdf` → `report.pdf` in the workspace.
+   - Create a new `secret.pdf` at the now-vacant path with different bytes.
+   - Open the saved URL. Expect 410.
+3. **Frontmatter-only edit invalidation (markdown):**
+   - Create share for `dev/fixtures/note.md` with frontmatter `title: "Old"` → save URL.
+   - Edit `note.md` to `title: "New"` without touching the body.
+   - Open saved URL. Expect 410 (validates the "hash raw bytes not parsed content" correction).
+4. **Legitimate re-share after edit:**
+   - Create share for `report.pdf` → save URL-A.
+   - Overwrite `report.pdf` with new bytes.
+   - Open URL-A → expect 410.
+   - Re-click Share in the UI → expect a **new** URL-B (revoke-and-reissue flow).
+   - Open URL-B → expect 200 with new content.
+
+Record all four screenshots in the PR body.
+
+## Acceptance Criteria
+
+- [ ] Migration `026_kb_share_links_content_sha256.sql` applied on prod via the Supabase runbook; REST probe confirms column presence AND check constraint AND NOT NULL.
+- [ ] Pre-apply row count audit documented in PR body (actual number from prod REST probe).
+- [ ] Pre-existing rows marked `revoked = true` (or explicit operator override path documented) so no legacy token can view anything post-deploy.
+- [ ] `POST /api/kb/share` computes SHA-256 via `hashStream` (not `hashBytes` over `readFile`) and stores in `content_sha256` on every new row. Insert payload covered by vitest.
+- [ ] `POST /api/kb/share` revokes-and-reissues when the existing row's hash no longer matches current file bytes (covers re-share-after-edit flow).
+- [ ] `GET /api/shared/[token]` re-hashes current file bytes and returns `410` + `{ code: "content-changed" }` when the hash differs. Covered by vitest for markdown, binary, and frontmatter-only-change scenarios.
+- [ ] Markdown branch hashes **raw file bytes** (pre-frontmatter-parse) so frontmatter edits invalidate the share. Covered by a dedicated test.
+- [ ] `app/shared/[token]/page.tsx` renders a dedicated "The shared file was modified" message for `code: "content-changed"` (distinct from the revoked copy).
+- [ ] Manual QA screenshots for all three scenarios (delete→re-upload, rename→recreate, frontmatter edit) attached to the PR.
+- [ ] No regression: app-level `npm test` passes; `kb-share-allowed-paths.test.ts` still green; new tests green.
+- [ ] TypeScript build passes (`npm run build` under Doppler in `apps/web-platform/`).
+- [ ] No hash values appear in any log line (grep PR diff for `content_sha256` and confirm only presence/mismatch events are logged, never the hash itself).
+
+## Test Scenarios
+
+Covered above per phase. Summary table:
+
+| Scenario | File | RED test |
+|---|---|---|
+| Hash helper correctness | `test/kb-content-hash.test.ts` | Phase 2 |
+| Creation writes hash (happy path) | `test/kb-share-allowed-paths.test.ts` (extended) | Phase 3 |
+| Creation hash matches arbitrary content | `test/kb-share-content-hash.test.ts` | Phase 3 |
+| View returns 410 on markdown content drift | `test/shared-token-content-hash.test.ts` | Phase 4 |
+| View returns 410 on binary content drift | `test/shared-token-content-hash.test.ts` | Phase 4 |
+| View returns 404 on missing file (unchanged) | `test/shared-token-content-hash.test.ts` | Phase 4 |
+| View returns 410 on legacy `null` hash | `test/shared-token-content-hash.test.ts` | Phase 4 |
+| Rate-limit still precedes hash work | `test/shared-token-content-hash.test.ts` | Phase 4 |
+
+## Domain Review
+
+**Domains relevant:** Engineering (primary), Security (sub-domain of Engineering per `type/security` label).
+
+### Engineering
+
+**Status:** reviewed (inline — fix is scoped within existing engineering conventions)
+
+**Assessment:**
+
+- Single-module change bounded to KB share surface. Follows existing patterns: shared server module (`kb-binary-response.ts`, `kb-reader.ts`) consumed by route handlers; vitest-colocated tests under `apps/web-platform/test/`.
+- Migration numbering: next free index is `026_` (last applied: `025_context_path_archived_predicate.sql`). No naming conflict.
+- No new dependencies. `node:crypto` is stdlib.
+- Security posture: closes the token-resurrection class of bug entirely. Trades an off-by-default auto-revoke (cron) for a cryptographic guarantee at view time — simpler, no scheduler to maintain.
+- Risk: hash at view time adds latency on the happy path (50 MB SHA-256 ≈ 200-400 ms on prod hardware). Measured against network transfer of the same 50 MB (seconds), this is a rounding error. No need to cache hashes — files change rarely.
+
+No cross-domain implications (no UI copy changes requiring copywriter, no flow-level UX changes requiring ux-design-lead, no billing/legal/marketing impact). The 410 error message is a one-line copy change that fits within existing SharePopover/shared page error-display conventions — noted in Acceptance Criteria as a verification step rather than a new design artifact.
+
+### Product/UX Gate
+
+Tier: **ADVISORY** (re-assessed during deepen). The plan now adds a new `ErrorMessage` variant ("The shared file was modified") to `app/shared/[token]/page.tsx`. This is an existing user-facing surface receiving a new state branch — ADVISORY per the tier definition ("modifies existing user-facing pages or components without adding new interactive surfaces").
+
+**Decision:** auto-accepted (pipeline). The copy is a two-line error-state message that sits inside the existing `ErrorMessage` component pattern used by the page (revoked/not-found/unknown variants). Not a new flow; not a new screen; not a decision surface. Copywriter review is **not** required per the AGENTS.md `wg-for-user-facing-pages-with-a-product-ux` gate since no domain leader recommended a copywriter and the change is a single error string. If the ship/QA reviewer flags the copy on PR, we iterate inline.
+
+**Agents invoked:** none (ADVISORY auto-accept in pipeline).
+**Skipped specialists:** copywriter (no domain-leader recommendation; single error string in an existing pattern), ux-design-lead (no new flow or surface).
+
+## Security & Privacy Notes
+
+- **Do not log the hash value.** The hash is a content fingerprint. Logging it per-view lets an attacker who gets log access enumerate which shares correspond to which content (e.g., correlating with a known-document hash). Log only the presence of a mismatch and the token, which is already logged elsewhere.
+- **Hash is not a secret.** It's stored alongside the path and token. Anyone with DB access already has the token. No extra threat surface.
+- **Timing-safe comparison not required.** Hashes are compared against a stored value on the same server; the attacker cannot iterate. `===` on 64-char strings is fine. If this assumption ever changes (e.g., hash compared against user-supplied input), switch to `crypto.timingSafeEqual`.
+- **GDPR posture improves.** Today, a user who deletes a file to "revoke" access has not actually revoked anything because the row is live. After this fix, a deletion breaks the hash binding at the next view, producing a 410 and a logged `shared_content_mismatch` event. Explicit revoke via the DELETE endpoint remains the supported path; this is defense in depth.
+
+## Non-Goals / Deferred
+
+Explicitly out of scope for this PR — tracked separately:
+
+- **#2316** — stream binary responses instead of buffering 50 MB (P1). Separate PR, next in the Phase-3 review-finding queue.
+- **#2309** — agent-user parity for KB share (P1). Separate PR after #2316.
+- **Background cleanup** of revoked rows older than N days. Minor hygiene; no issue yet — deferred to housekeeping batch later in Phase 3.
+- **Pre-signed URL TTL.** The issue body mentions "no TTL on the share row" as an observation but the recommended fix does not address it; TTL is a separate policy decision. Not tracked in this plan.
+
+## Rollback Plan
+
+The migration adds a column and a constraint. Rollback, if required:
+
+```sql
+-- rollback.sql
+alter table public.kb_share_links
+  drop constraint kb_share_links_content_sha256_format;
+alter table public.kb_share_links
+  alter column content_sha256 drop not null;
+-- Column retained (dropping would lose data if we re-roll forward).
+-- No app code depends on the column being absent.
+```
+
+App-level rollback is `git revert` of the PR. Revoked rows stay revoked — operators must explicitly unrevoke if the migration's defensive revoke sweep is regretted.
+
+## Files Changed Summary
+
+| File | Action | Purpose |
+|---|---|---|
+| `apps/web-platform/supabase/migrations/026_kb_share_links_content_sha256.sql` | new | Add `content_sha256 text not null` with format check + defensive revoke |
+| `apps/web-platform/server/kb-content-hash.ts` | new | `hashBytes(buf)` + `hashStream(readable)` helpers |
+| `apps/web-platform/app/api/kb/share/route.ts` | edit | Stream-hash on POST, revoke-and-reissue on content drift |
+| `apps/web-platform/app/api/shared/[token]/route.ts` | edit | Verify hash on GET, 410 + `code: content-changed` on mismatch |
+| `apps/web-platform/server/kb-reader.ts` | edit | Extract `readContentRaw` so markdown hash sees raw bytes (not post-frontmatter) |
+| `apps/web-platform/server/kb-binary-response.ts` | edit (optional) | Emit `ETag: "<hash>"` header so conditional GETs 304 |
+| `apps/web-platform/app/shared/[token]/page.tsx` | edit | Add `"content-changed"` error variant with dedicated copy |
+| `apps/web-platform/test/kb-content-hash.test.ts` | new | Unit tests for `hashBytes` + `hashStream` (incl. stream/buffer parity) |
+| `apps/web-platform/test/kb-share-content-hash.test.ts` | new | Creation-side hash persistence + revoke-and-reissue tests |
+| `apps/web-platform/test/shared-token-content-hash.test.ts` | new | View-side hash verification tests (incl. frontmatter-only change = 410) |
+| `apps/web-platform/test/shared-token-content-changed-ui.test.tsx` | new | UI error-variant rendering tests |
+| `apps/web-platform/test/kb-share-allowed-paths.test.ts` | edit | Assert hash appears in insert payload |
+
+## Post-merge Verification
+
+Per AGENTS.md (`wg-when-a-pr-includes-database-migrations`): after merge, run the Supabase migration runbook against prod, verify via REST probe, and include the probe output in the PR close comment. The ship/postmerge skills handle this if invoked.
+
+## References
+
+- Issue #2326 (root cause, option analysis, recommendation)
+- PR #2282 (feat-kb-share-btn-pdf-attachments) — where this finding originated
+- `knowledge-base/engineering/ops/runbooks/supabase-migrations.md` — migration apply procedure
+- `knowledge-base/project/learnings/` — service-role-idor learning (already followed by current code; we maintain the pattern)
+- AGENTS.md `cq-progressive-rendering-for-large-assets` — acknowledged but orthogonal; streaming is #2316's scope

--- a/knowledge-base/project/specs/feat-fix-2326-kb-share-dangling-rows/session-state.md
+++ b/knowledge-base/project/specs/feat-fix-2326-kb-share-dangling-rows/session-state.md
@@ -1,0 +1,27 @@
+# Session State
+
+## Plan Phase
+
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-fix-2326-kb-share-dangling-rows/knowledge-base/project/plans/2026-04-17-fix-kb-share-dangling-rows-plan.md
+- Status: complete
+
+### Errors
+
+None
+
+### Decisions
+
+- **Option A (content_sha256 binding)** chosen over inode+mtime or cron-cleanup — closes delete→re-upload, rename→recreate, and overwrite resurrection completely; SHA-256 of 50 MB is ~25-35 ms on native OpenSSL so view-time cost is negligible.
+- **Hash raw file bytes, not post-parse content.** `readContent` strips frontmatter before returning `content` — hashing that would silently pass frontmatter-only edits. Added `readContentRaw` helper and a dedicated test scenario.
+- **Stream-hash on creation, buffer-hash on view.** Creation uses `hashStream(handle.createReadStream())` so we don't hold two 50 MB buffers; view uses `hashBytes` over the buffer `readBinaryFile` already produces — no double-read.
+- **Revoke-and-reissue on content drift at creation time.** If a user re-shares a modified file, the stale row is revoked and a fresh token issued — keeps endpoint idempotent and user-friendly.
+- **New UI error variant (`content-changed`).** Discriminated via response body `code`, not status code, so the existing 410→revoked mapping stays intact. Tier re-assessed NONE→ADVISORY during deepen.
+- **Pre-apply migration audit fork.** Row-count probe with three branches (0, 1-10, >10) so the defensive `update ... set revoked = true` doesn't surprise operators at scale.
+
+### Components Invoked
+
+- Skill: soleur:plan
+- Skill: soleur:deepen-plan
+- Bash, Read, Grep, Edit, Write, Glob
+- gh CLI (issue #2326, #2316, #2309 metadata)
+- markdownlint-cli2 (plan + tasks lint pass, 0 errors)

--- a/knowledge-base/project/specs/feat-fix-2326-kb-share-dangling-rows/tasks.md
+++ b/knowledge-base/project/specs/feat-fix-2326-kb-share-dangling-rows/tasks.md
@@ -1,0 +1,70 @@
+# Tasks — fix(kb): bind KB share links to content hash
+
+Derived from: `knowledge-base/project/plans/2026-04-17-fix-kb-share-dangling-rows-plan.md`
+Issue: #2326 · Branch: `feat-fix-2326-kb-share-dangling-rows`
+
+## 1. Setup
+
+- 1.1 Verify worktree state: `git status --short` clean, branch `feat-fix-2326-kb-share-dangling-rows` checked out.
+- 1.2 Run prod `kb_share_links` row-count audit (REST probe under Doppler `prd`). Record count in PR body.
+  - 1.2.1 If 0 rows → proceed with migration as written.
+  - 1.2.2 If 1-10 rows → proceed as written; document pre-state in PR.
+  - 1.2.3 If >10 rows → PAUSE; switch to soft-legacy migration path; file backfill follow-up.
+- 1.3 Confirm app-level test runner works: `cd apps/web-platform && ./node_modules/.bin/vitest run --reporter=verbose test/kb-share-allowed-paths.test.ts`.
+
+## 2. Core Implementation (RED → GREEN)
+
+### 2.1 Phase 1 — Migration
+
+- 2.1.1 Write `apps/web-platform/supabase/migrations/026_kb_share_links_content_sha256.sql` with: add column, defensive revoke, set NOT NULL, add check constraint, add index.
+- 2.1.2 Lint migration with `supabase db lint` if available locally.
+
+### 2.2 Phase 2 — Hash helper (TDD)
+
+- 2.2.1 RED: write `apps/web-platform/test/kb-content-hash.test.ts` with failing assertions for `hashBytes`, `hashStream`, stream/buffer parity, empty-buffer known-hash.
+- 2.2.2 GREEN: write `apps/web-platform/server/kb-content-hash.ts` exporting `hashBytes` and `hashStream`.
+- 2.2.3 Verify tests green: `./node_modules/.bin/vitest run test/kb-content-hash.test.ts`.
+
+### 2.3 Phase 3 — Creation endpoint (TDD)
+
+- 2.3.1 RED: write `apps/web-platform/test/kb-share-content-hash.test.ts` covering:
+  - Hash persisted in insert payload.
+  - Same content → existing token returned (no second insert).
+  - Different content for same path → stale row revoked AND new token issued.
+  - Symlink swap rejected by O_NOFOLLOW.
+- 2.3.2 RED: extend `apps/web-platform/test/kb-share-allowed-paths.test.ts` to assert `content_sha256` present in insert payload.
+- 2.3.3 GREEN: edit `apps/web-platform/app/api/kb/share/route.ts` — open with O_NOFOLLOW, fstat-validate, `hashStream(createReadStream)`, existing-share-with-hash-check, revoke-and-reissue on mismatch.
+- 2.3.4 Verify tests green.
+
+### 2.4 Phase 4 — View endpoint + kb-reader extraction (TDD)
+
+- 2.4.1 RED: write `apps/web-platform/test/shared-token-content-hash.test.ts` covering all eight view scenarios in the plan (markdown match/mismatch, binary match/mismatch, frontmatter-only edit, deletion, null hash, rate-limit precedence).
+- 2.4.2 GREEN: add `readContentRaw` to `apps/web-platform/server/kb-reader.ts`; refactor `readContent` to call it.
+- 2.4.3 GREEN: edit `apps/web-platform/app/api/shared/[token]/route.ts` — select `content_sha256`, verify on both branches, 410 with `code: content-changed` on mismatch, 410 with `code: legacy-null-hash` on null hash.
+- 2.4.4 Optional: add `ETag` emission to `buildBinaryResponse` in `apps/web-platform/server/kb-binary-response.ts` and handle `If-None-Match` short-circuit.
+- 2.4.5 Verify server tests green.
+
+### 2.5 Phase 4b — UI error variant (TDD)
+
+- 2.5.1 RED: write `apps/web-platform/test/shared-token-content-changed-ui.test.tsx` covering content-changed copy, legacy-null-hash copy, and 410-without-body fallback.
+- 2.5.2 GREEN: edit `apps/web-platform/app/shared/[token]/page.tsx` — extend `PageError` union, read JSON body in the 410 branch, add `ErrorMessage` for `content-changed`.
+- 2.5.3 Verify UI tests green.
+
+## 3. Integration & QA
+
+- 3.1 Run full app-level suite: `cd apps/web-platform && ./node_modules/.bin/vitest run`.
+- 3.2 `npm run build` under Doppler in `apps/web-platform/` to catch Next route-file validator errors.
+- 3.3 Manual QA against `./scripts/dev.sh` (Doppler-wrapped dev server):
+  - 3.3.1 Scenario 1 — delete → re-upload → 410. Screenshot.
+  - 3.3.2 Scenario 2 — rename → recreate → 410. Screenshot.
+  - 3.3.3 Scenario 3 — frontmatter-only edit → 410. Screenshot.
+  - 3.3.4 Scenario 4 — legitimate re-share after edit → new token works. Screenshot.
+- 3.4 Verify no hash values appear in any log line (grep diff for `content_sha256` and review context).
+
+## 4. Ship
+
+- 4.1 `/soleur:compound` to capture learnings.
+- 4.2 `/soleur:ship` with labels `priority/p1-high`, `type/security`, `domain/engineering`.
+- 4.3 PR body: include pre-apply row count, all four QA screenshots, `Closes #2326`.
+- 4.4 Post-merge: verify migration applied on prod via the Supabase runbook REST probe.
+- 4.5 Post-merge: proceed to #2316 (stream binary responses) as the next Phase-3 review finding.


### PR DESCRIPTION
## Summary

- Adds `content_sha256` binding to `kb_share_links` so a deleted/renamed/overwritten file can no longer be resurrected by a new file at the same path.
- Creation path stream-hashes through an `O_NOFOLLOW` fd; view path re-hashes current bytes on every request and returns `410` with `code: content-changed` on mismatch.
- Markdown path hashes raw bytes (pre-frontmatter-parse) via new `readContentRaw`, so title/tags edits also invalidate the share.
- Partial unique index `(user_id, document_path) where revoked = false` closes the concurrent-POST duplicate-active-row race.

Closes #2326

## Changelog

### Web Platform

- **Security (KB share):** Share links now bind to content hash. Any edit to the shared file invalidates the token; re-sharing issues a fresh token. Legacy rows without a hash are defensively revoked at migration time.
- **API (`GET /api/shared/[token]`):** Returns `410 { code: "content-changed" }` when current bytes diverge from the stored hash. Legacy rows return `410 { code: "legacy-null-hash" }`. Existing `revoked` branch now returns `code: "revoked"`.
- **API (`POST /api/kb/share`):** Stream-hashes file content through an `O_NOFOLLOW` fd (no second 50 MB buffer). If an existing share's stored hash diverges from current bytes, the stale row is revoked and a fresh token is issued. 23505 conflicts from the new partial unique index are handled by re-reading the winner.
- **UI (`/shared/[token]`):** New error variant "The shared file was modified" renders for `code: "content-changed"`; revoked copy preserved for compatibility.
- **Internals:** New `server/kb-content-hash.ts` (`hashBytes` + `hashStream`). `readContent` refactored as a thin wrapper around `readContentRaw`, which returns `{ buffer, raw, path }` in a single disk pass. `parseFrontmatter` exported from `kb-reader.ts` to avoid duplicating the `engines: {}` CVE hardening in route handlers.

### Migration 026

Adds `content_sha256 text` column, defensively revokes pre-existing rows, adds CHECK scoped to active rows (`revoked or content_sha256 ~ '^[a-f0-9]{64}$'`), and adds a partial unique index for one-active-share-per-(user, path).

## Test plan

- [x] vitest: full suite green (1659 tests)
- [x] typecheck clean (`tsc --noEmit`)
- [x] 4 new test files + 1 updated covering hash helpers, creation path, view path, UI variant, binary share regression
- [ ] ⏳ Post-merge: apply migration 026 via Supabase runbook; verify `content_sha256` column + CHECK + partial unique index present; confirm `active` row count is 0
- [ ] ⏳ Post-merge: smoke test shared-link flow end-to-end on prod (create share → 200, delete file → 410 `content-changed`, re-share edited file → new token 200)

## Review

Multi-agent review caught two P1 issues unit tests + typecheck missed:
1. Migration `set not null` would have failed on any pre-existing row (initial draft had this). Fixed by scoping CHECK to active rows.
2. Concurrent POSTs could create duplicate active shares. Fixed by partial unique index + 23505 re-read.

Review findings filed as deferred-scope-out: #2466 (Range-request hash cache — contested-design), #2467 (POST handler extraction — cross-cutting-refactor), #2468 (shared test mock fixture — cross-cutting-refactor), #2469 (ETag emission — architectural-pivot).

Follow-up issues in the Phase-3 code-review queue: #2316 (stream binary responses, P1), #2309 (agent-user parity for KB share, P1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
