### PR TITLE
perf(kb): stream binary responses with hash-verdict cache

### DIFF
--- a/apps/web-platform/app/api/kb/content/[...path]/route.ts
+++ b/apps/web-platform/app/api/kb/content/[...path]/route.ts
@@ -8,7 +8,11 @@ import {
   KbAccessDeniedError,
   KbValidationError,
 } from "@/server/kb-reader";
-import { readBinaryFile, buildBinaryResponse } from "@/server/kb-binary-response";
+import {
+  validateBinaryFile,
+  buildBinaryResponse,
+  BinaryOpenError,
+} from "@/server/kb-binary-response";
 
 export async function GET(
   request: Request,
@@ -74,9 +78,20 @@ export async function GET(
   // Binary file serving — owner route streams unconditionally (no hash
   // gate). The share route adds a content-hash verdict cache on top of
   // the same helpers.
-  const result = await readBinaryFile(kbRoot, relativePath);
+  const result = await validateBinaryFile(kbRoot, relativePath);
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: result.status });
   }
-  return await buildBinaryResponse(result, request);
+  try {
+    return await buildBinaryResponse(result, request);
+  } catch (err) {
+    if (err instanceof BinaryOpenError) {
+      logger.warn(
+        { err: err.message, code: err.code, path: relativePath },
+        "kb/content: open failed on serve",
+      );
+      return NextResponse.json({ error: err.message }, { status: err.status });
+    }
+    throw err;
+  }
 }

--- a/apps/web-platform/app/api/kb/content/[...path]/route.ts
+++ b/apps/web-platform/app/api/kb/content/[...path]/route.ts
@@ -71,11 +71,12 @@ export async function GET(
     }
   }
 
-  // Binary file serving — delegate to shared helper so owner and public
-  // (/api/shared/[token]) routes share one hardened implementation.
+  // Binary file serving — owner route streams unconditionally (no hash
+  // gate). The share route adds a content-hash verdict cache on top of
+  // the same helpers.
   const result = await readBinaryFile(kbRoot, relativePath);
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: result.status });
   }
-  return buildBinaryResponse(result, request);
+  return await buildBinaryResponse(result, request);
 }

--- a/apps/web-platform/app/api/shared/[token]/route.ts
+++ b/apps/web-platform/app/api/shared/[token]/route.ts
@@ -8,9 +8,10 @@ import {
   KbAccessDeniedError,
 } from "@/server/kb-reader";
 import {
-  readBinaryFile,
+  validateBinaryFile,
   buildBinaryResponse,
   openBinaryStream,
+  BinaryOpenError,
 } from "@/server/kb-binary-response";
 import { hashBytes, hashStream } from "@/server/kb-content-hash";
 import { shareHashVerdictCache } from "@/server/share-hash-verdict-cache";
@@ -158,7 +159,7 @@ export async function GET(
   // Binary branch — validate metadata without reading bytes, then either
   // trust the verdict cache (fast path) or hash via a fresh stream before
   // serving (slow path: first view OR file mutated since last verify).
-  const binary = await readBinaryFile(kbRoot, shareLink.document_path);
+  const binary = await validateBinaryFile(kbRoot, shareLink.document_path);
   if (!binary.ok) {
     if (binary.status === 403) {
       logger.warn(
@@ -171,32 +172,47 @@ export async function GET(
 
   const cachedVerdict = shareHashVerdictCache.get(
     token,
+    binary.ino,
     binary.mtimeMs,
     binary.size,
   );
 
   if (cachedVerdict !== true) {
     // Cache miss — drain a fresh stream through SHA-256 and compare
-    // before shipping any bytes. buildBinaryResponse opens another
-    // stream for the response body (fd lifetime is tied to each
-    // stream via autoClose: true).
-    let hashStreamObj;
-    try {
-      hashStreamObj = await openBinaryStream(binary.filePath);
-    } catch (err) {
-      logger.error(
-        { err, token, path: shareLink.document_path },
-        "shared: failed to open hash stream",
-      );
-      return NextResponse.json(
-        { error: "Document no longer available" },
-        { status: 404 },
-      );
-    }
+    // before shipping any bytes. The expected { ino, size } tuple on
+    // openBinaryStream rejects any rename/link swap between validate and
+    // hash — if the inode drifted, BinaryOpenError("content-changed") is
+    // thrown and surfaces as 410.
     let currentHash: string;
     try {
+      const hashStreamObj = await openBinaryStream(binary.filePath, {
+        expected: { ino: binary.ino, size: binary.size },
+      });
       currentHash = await hashStream(hashStreamObj);
     } catch (err) {
+      if (err instanceof BinaryOpenError) {
+        if (err.code === "content-changed") {
+          logger.info(
+            {
+              event: "shared_content_mismatch",
+              token,
+              documentPath: shareLink.document_path,
+              kind: "binary",
+              reason: "inode-drift",
+            },
+            "shared: inode drift between validate and hash",
+          );
+          return contentChangedResponse();
+        }
+        logger.warn(
+          { err: err.message, code: err.code, token, path: shareLink.document_path },
+          "shared: open failed on hash pass",
+        );
+        return NextResponse.json(
+          { error: err.message },
+          { status: err.status },
+        );
+      }
       logger.error(
         { err, token, path: shareLink.document_path },
         "shared: hash stream drain failed",
@@ -218,7 +234,7 @@ export async function GET(
       );
       return contentChangedResponse();
     }
-    shareHashVerdictCache.set(token, binary.mtimeMs, binary.size);
+    shareHashVerdictCache.set(token, binary.ino, binary.mtimeMs, binary.size);
   }
 
   logger.info(
@@ -231,5 +247,25 @@ export async function GET(
     },
     "shared: document viewed",
   );
-  return await buildBinaryResponse(binary, request);
+  try {
+    return await buildBinaryResponse(binary, request);
+  } catch (err) {
+    if (err instanceof BinaryOpenError && err.code === "content-changed") {
+      logger.info(
+        {
+          event: "shared_content_mismatch",
+          token,
+          documentPath: shareLink.document_path,
+          kind: "binary",
+          reason: "inode-drift-serve",
+        },
+        "shared: inode drift between hash and serve",
+      );
+      return contentChangedResponse();
+    }
+    if (err instanceof BinaryOpenError) {
+      return NextResponse.json({ error: err.message }, { status: err.status });
+    }
+    throw err;
+  }
 }

--- a/apps/web-platform/app/api/shared/[token]/route.ts
+++ b/apps/web-platform/app/api/shared/[token]/route.ts
@@ -10,8 +10,10 @@ import {
 import {
   readBinaryFile,
   buildBinaryResponse,
+  openBinaryStream,
 } from "@/server/kb-binary-response";
-import { hashBytes } from "@/server/kb-content-hash";
+import { hashBytes, hashStream } from "@/server/kb-content-hash";
+import { shareHashVerdictCache } from "@/server/share-hash-verdict-cache";
 import {
   shareEndpointThrottle,
   extractClientIpFromHeaders,
@@ -153,7 +155,9 @@ export async function GET(
     }
   }
 
-  // Binary branch.
+  // Binary branch — validate metadata without reading bytes, then either
+  // trust the verdict cache (fast path) or hash via a fresh stream before
+  // serving (slow path: first view OR file mutated since last verify).
   const binary = await readBinaryFile(kbRoot, shareLink.document_path);
   if (!binary.ok) {
     if (binary.status === 403) {
@@ -165,18 +169,56 @@ export async function GET(
     return NextResponse.json({ error: binary.error }, { status: binary.status });
   }
 
-  const currentHash = hashBytes(binary.buffer);
-  if (currentHash !== shareLink.content_sha256) {
-    logger.info(
-      {
-        event: "shared_content_mismatch",
-        token,
-        documentPath: shareLink.document_path,
-        kind: "binary",
-      },
-      "shared: content hash mismatch",
-    );
-    return contentChangedResponse();
+  const cachedVerdict = shareHashVerdictCache.get(
+    token,
+    binary.mtimeMs,
+    binary.size,
+  );
+
+  if (cachedVerdict !== true) {
+    // Cache miss — drain a fresh stream through SHA-256 and compare
+    // before shipping any bytes. buildBinaryResponse opens another
+    // stream for the response body (fd lifetime is tied to each
+    // stream via autoClose: true).
+    let hashStreamObj;
+    try {
+      hashStreamObj = await openBinaryStream(binary.filePath);
+    } catch (err) {
+      logger.error(
+        { err, token, path: shareLink.document_path },
+        "shared: failed to open hash stream",
+      );
+      return NextResponse.json(
+        { error: "Document no longer available" },
+        { status: 404 },
+      );
+    }
+    let currentHash: string;
+    try {
+      currentHash = await hashStream(hashStreamObj);
+    } catch (err) {
+      logger.error(
+        { err, token, path: shareLink.document_path },
+        "shared: hash stream drain failed",
+      );
+      return NextResponse.json(
+        { error: "An unexpected error occurred" },
+        { status: 500 },
+      );
+    }
+    if (currentHash !== shareLink.content_sha256) {
+      logger.info(
+        {
+          event: "shared_content_mismatch",
+          token,
+          documentPath: shareLink.document_path,
+          kind: "binary",
+        },
+        "shared: content hash mismatch",
+      );
+      return contentChangedResponse();
+    }
+    shareHashVerdictCache.set(token, binary.mtimeMs, binary.size);
   }
 
   logger.info(
@@ -185,8 +227,9 @@ export async function GET(
       token,
       documentPath: shareLink.document_path,
       contentType: binary.contentType,
+      cached: cachedVerdict === true,
     },
     "shared: document viewed",
   );
-  return buildBinaryResponse(binary, request);
+  return await buildBinaryResponse(binary, request);
 }

--- a/apps/web-platform/server/kb-binary-response.ts
+++ b/apps/web-platform/server/kb-binary-response.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { Readable } from "node:stream";
 import { isPathInWorkspace } from "@/server/sandbox";
 import { KB_BINARY_RESPONSE_CSP } from "@/lib/kb-csp";
 
@@ -21,44 +22,58 @@ export const CONTENT_TYPE_MAP: Record<string, string> = {
 
 export const ATTACHMENT_EXTENSIONS = new Set([".docx"]);
 
+/**
+ * Successful result of readBinaryFile. Holds validated metadata; does NOT
+ * hold the file bytes in memory. Response bodies open a fresh stream via
+ * openBinaryStream(filePath, …) so peak RSS per request stays ~64 KB
+ * (default createReadStream chunk size) instead of ~size bytes.
+ */
+export interface BinaryFileMetadata {
+  ok: true;
+  filePath: string;
+  size: number;
+  mtimeMs: number;
+  contentType: string;
+  disposition: "inline" | "attachment";
+  rawName: string;
+}
+
 export type BinaryReadResult =
-  | {
-      ok: true;
-      buffer: Buffer;
-      contentType: string;
-      disposition: "inline" | "attachment";
-      rawName: string;
-    }
+  | BinaryFileMetadata
   | {
       ok: false;
       status: 403 | 404 | 413;
       error: string;
     };
 
-/**
- * Build an RFC 6266 Content-Disposition header value with both an ASCII
- * fallback (`filename="..."`) and a UTF-8 RFC 5987 encoded form
- * (`filename*=UTF-8''...`). Strips control characters from the fallback to
- * keep the header parseable across browsers and proxies.
- */
 export function formatContentDisposition(
   disposition: "inline" | "attachment",
   rawName: string,
 ): string {
   const asciiFallback = rawName.replace(/[^\x20-\x7e]/g, "_").replace(/["\r\n\\]/g, "_");
   const utf8Encoded = encodeURIComponent(rawName)
-    // RFC 5987 reserves * ' ( ) ; , / ? : @ & = + $ -- encodeURIComponent
-    // already escapes most; leave * untouched per RFC 5987 examples.
     .replace(/['()]/g, escape);
   return `${disposition}; filename="${asciiFallback}"; filename*=UTF-8''${utf8Encoded}`;
 }
 
+/**
+ * Validate a KB-relative path + collect metadata. Opens with O_NOFOLLOW,
+ * fstats against the fd to close the symlink-swap window, then closes the
+ * fd and returns metadata only. Callers stream bytes separately via
+ * openBinaryStream(result.filePath, …), which opens another O_NOFOLLOW fd.
+ *
+ * This decouples validation from byte transfer. The trade-off: there is a
+ * small TOCTOU window between this function returning and openBinaryStream
+ * opening — the file could be swapped. isPathInWorkspace and O_NOFOLLOW
+ * still apply to the second open, so symlink replacement is rejected, and
+ * the verdict cache in share-hash-verdict-cache.ts keys on (token,
+ * mtimeMs, size) so a mutation between validate and stream will not be
+ * served from a stale verdict.
+ */
 export async function readBinaryFile(
   kbRoot: string,
   relativePath: string,
 ): Promise<BinaryReadResult> {
-  // Reject null bytes — `path.join`/`open` would throw `ERR_INVALID_ARG_VALUE`
-  // and bubble up as an unhandled 500. Mirrors `readContent`'s guard.
   if (relativePath.includes("\0")) {
     return { ok: false, status: 403, error: "Access denied" };
   }
@@ -66,20 +81,16 @@ export async function readBinaryFile(
   if (!isPathInWorkspace(fullPath, kbRoot)) {
     return { ok: false, status: 403, error: "Access denied" };
   }
-  // Open with O_NOFOLLOW to refuse symlinks at open time, then fstat the fd
-  // and read from the fd. This closes the lstat→readFile TOCTOU window: a
-  // file replaced between lstat and readFile would still be served from the
-  // fd we already hold. A symlink swapped in is rejected by O_NOFOLLOW.
   let handle: fs.promises.FileHandle;
   try {
-    handle = await fs.promises.open(fullPath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    handle = await fs.promises.open(
+      fullPath,
+      fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW,
+    );
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === "ELOOP" || code === "EMLINK") {
       return { ok: false, status: 403, error: "Access denied" };
-    }
-    if (code === "ENOENT") {
-      return { ok: false, status: 404, error: "File not found" };
     }
     return { ok: false, status: 404, error: "File not found" };
   }
@@ -95,8 +106,15 @@ export async function readBinaryFile(
     const contentType = CONTENT_TYPE_MAP[ext] || "application/octet-stream";
     const disposition = ATTACHMENT_EXTENSIONS.has(ext) ? "attachment" : "inline";
     const rawName = path.basename(relativePath);
-    const buffer = await handle.readFile();
-    return { ok: true, buffer, contentType, disposition, rawName };
+    return {
+      ok: true,
+      filePath: fullPath,
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+      contentType,
+      disposition,
+      rawName,
+    };
   } catch {
     return { ok: false, status: 404, error: "File not found" };
   } finally {
@@ -104,27 +122,45 @@ export async function readBinaryFile(
   }
 }
 
-export function buildBinaryResponse(
-  r: {
-    buffer: Buffer;
-    contentType: string;
-    disposition: "inline" | "attachment";
-    rawName: string;
-  },
+/**
+ * Open a fresh O_NOFOLLOW read stream for an already-validated filePath.
+ * The returned Node Readable is backed by the opened FileHandle with
+ * autoClose: true, so fd lifetime is tied to the stream. Pass start/end
+ * for Range requests; omit for full-file reads.
+ *
+ * Returns a Node Readable (not a web ReadableStream) so callers can either:
+ *   - wrap via Readable.toWeb(stream) for Response bodies, or
+ *   - pipe directly into hashStream() from kb-content-hash.ts.
+ */
+export async function openBinaryStream(
+  filePath: string,
+  opts?: { start?: number; end?: number },
+): Promise<Readable> {
+  const handle = await fs.promises.open(
+    filePath,
+    fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW,
+  );
+  return handle.createReadStream({
+    autoClose: true,
+    ...(opts?.start !== undefined ? { start: opts.start } : {}),
+    ...(opts?.end !== undefined ? { end: opts.end } : {}),
+  });
+}
+
+export async function buildBinaryResponse(
+  meta: BinaryFileMetadata,
   request?: Request,
-): Response {
-  const size = r.buffer.length;
+): Promise<Response> {
+  const size = meta.size;
   const commonHeaders: Record<string, string> = {
-    "Content-Type": r.contentType,
-    "Content-Disposition": formatContentDisposition(r.disposition, r.rawName),
+    "Content-Type": meta.contentType,
+    "Content-Disposition": formatContentDisposition(meta.disposition, meta.rawName),
     "X-Content-Type-Options": "nosniff",
     "Cache-Control": "private, max-age=60",
     "Content-Security-Policy": KB_BINARY_RESPONSE_CSP,
     "Accept-Ranges": "bytes",
   };
 
-  // Range request: respond with 206 Partial Content so PDF.js (and other
-  // clients) can stream in chunks and render progressively.
   const rangeHeader = request?.headers.get("range");
   if (rangeHeader) {
     const match = rangeHeader.trim().match(/^bytes=(\d+)-(\d*)$/);
@@ -144,23 +180,31 @@ export function buildBinaryResponse(
           headers: { "Content-Range": `bytes */${size}` },
         });
       }
-      const chunk = r.buffer.subarray(start, end + 1);
-      return new Response(new Uint8Array(chunk), {
-        status: 206,
-        headers: {
-          ...commonHeaders,
-          "Content-Range": `bytes ${start}-${end}/${size}`,
-          "Content-Length": chunk.length.toString(),
+      const chunkLength = end - start + 1;
+      const nodeStream = await openBinaryStream(meta.filePath, { start, end });
+      return new Response(
+        Readable.toWeb(nodeStream) as ReadableStream<Uint8Array>,
+        {
+          status: 206,
+          headers: {
+            ...commonHeaders,
+            "Content-Range": `bytes ${start}-${end}/${size}`,
+            "Content-Length": chunkLength.toString(),
+          },
         },
-      });
+      );
     }
     // Malformed Range header: fall through to full response.
   }
 
-  return new Response(new Uint8Array(r.buffer), {
-    headers: {
-      ...commonHeaders,
-      "Content-Length": size.toString(),
+  const nodeStream = await openBinaryStream(meta.filePath);
+  return new Response(
+    Readable.toWeb(nodeStream) as ReadableStream<Uint8Array>,
+    {
+      headers: {
+        ...commonHeaders,
+        "Content-Length": size.toString(),
+      },
     },
-  });
+  );
 }

--- a/apps/web-platform/server/kb-binary-response.ts
+++ b/apps/web-platform/server/kb-binary-response.ts
@@ -23,14 +23,16 @@ export const CONTENT_TYPE_MAP: Record<string, string> = {
 export const ATTACHMENT_EXTENSIONS = new Set([".docx"]);
 
 /**
- * Successful result of readBinaryFile. Holds validated metadata; does NOT
- * hold the file bytes in memory. Response bodies open a fresh stream via
- * openBinaryStream(filePath, …) so peak RSS per request stays ~64 KB
- * (default createReadStream chunk size) instead of ~size bytes.
+ * Validated metadata from validateBinaryFile. Carries (ino, mtimeMs, size)
+ * so callers of openBinaryStream can pass `expected` and reject a second
+ * open if the underlying inode drifted between validation and serve. This
+ * closes the TOCTOU window that would otherwise open between two separate
+ * fds on the same path.
  */
 export interface BinaryFileMetadata {
   ok: true;
   filePath: string;
+  ino: number;
   size: number;
   mtimeMs: number;
   contentType: string;
@@ -46,6 +48,17 @@ export type BinaryReadResult =
       error: string;
     };
 
+export class BinaryOpenError extends Error {
+  constructor(
+    public readonly status: 403 | 404 | 500 | 503,
+    message: string,
+    public readonly code?: string,
+  ) {
+    super(message);
+    this.name = "BinaryOpenError";
+  }
+}
+
 export function formatContentDisposition(
   disposition: "inline" | "attachment",
   rawName: string,
@@ -57,20 +70,19 @@ export function formatContentDisposition(
 }
 
 /**
- * Validate a KB-relative path + collect metadata. Opens with O_NOFOLLOW,
- * fstats against the fd to close the symlink-swap window, then closes the
- * fd and returns metadata only. Callers stream bytes separately via
- * openBinaryStream(result.filePath, …), which opens another O_NOFOLLOW fd.
+ * Validate a KB-relative path and collect metadata. Opens with O_NOFOLLOW
+ * to refuse symlinks, fstats against the held fd to capture ino/size/mtimeMs,
+ * then closes the fd and returns metadata only — no bytes in memory.
  *
- * This decouples validation from byte transfer. The trade-off: there is a
- * small TOCTOU window between this function returning and openBinaryStream
- * opening — the file could be swapped. isPathInWorkspace and O_NOFOLLOW
- * still apply to the second open, so symlink replacement is rejected, and
- * the verdict cache in share-hash-verdict-cache.ts keys on (token,
- * mtimeMs, size) so a mutation between validate and stream will not be
- * served from a stale verdict.
+ * Response bodies are opened separately via `openBinaryStream(filePath,
+ * { expected: { ino, size } })`. The `expected` tuple guards against a
+ * rename-swap TOCTOU between validate and serve: if the second fd points
+ * at a different inode or size, openBinaryStream throws BinaryOpenError.
+ *
+ * Name note: called "validate" (not "read") because it no longer reads
+ * file bytes — pre-#2316 it did; the rename avoids perpetuating the lie.
  */
-export async function readBinaryFile(
+export async function validateBinaryFile(
   kbRoot: string,
   relativePath: string,
 ): Promise<BinaryReadResult> {
@@ -109,6 +121,7 @@ export async function readBinaryFile(
     return {
       ok: true,
       filePath: fullPath,
+      ino: stat.ino,
       size: stat.size,
       mtimeMs: stat.mtimeMs,
       contentType,
@@ -123,27 +136,71 @@ export async function readBinaryFile(
 }
 
 /**
- * Open a fresh O_NOFOLLOW read stream for an already-validated filePath.
- * The returned Node Readable is backed by the opened FileHandle with
- * autoClose: true, so fd lifetime is tied to the stream. Pass start/end
- * for Range requests; omit for full-file reads.
+ * Deprecated alias preserved for backward compatibility during the rename
+ * landing. Will be removed once all callers migrate to validateBinaryFile.
  *
- * Returns a Node Readable (not a web ReadableStream) so callers can either:
- *   - wrap via Readable.toWeb(stream) for Response bodies, or
- *   - pipe directly into hashStream() from kb-content-hash.ts.
+ * @deprecated Use validateBinaryFile.
+ */
+export const readBinaryFile = validateBinaryFile;
+
+/**
+ * Open a fresh O_NOFOLLOW read stream for a filePath previously validated
+ * by validateBinaryFile. The returned Node Readable is backed by the
+ * opened FileHandle with autoClose: true — fd lifetime is tied to the
+ * stream.
+ *
+ * Pass `expected: { ino, size }` to close the TOCTOU window: if the
+ * freshly opened fd points at a different inode or the size changed, the
+ * stream is closed and a BinaryOpenError("content-changed") is thrown.
+ * Callers that know the expected inode (from a prior validateBinaryFile)
+ * SHOULD pass it; callers that do not (e.g., a path the caller just
+ * validated inline) MAY omit it.
+ *
+ * Caller remains responsible for running path containment checks
+ * (isPathInWorkspace) BEFORE invoking this helper — openBinaryStream
+ * trusts filePath and only enforces O_NOFOLLOW + optional inode identity.
  */
 export async function openBinaryStream(
   filePath: string,
-  opts?: { start?: number; end?: number },
+  opts?: { start?: number; end?: number; expected?: { ino: number; size: number } },
 ): Promise<Readable> {
-  const handle = await fs.promises.open(
-    filePath,
-    fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW,
-  );
+  let handle: fs.promises.FileHandle;
+  try {
+    handle = await fs.promises.open(
+      filePath,
+      fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW,
+    );
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      throw new BinaryOpenError(404, "File not found", code);
+    }
+    if (code === "ELOOP" || code === "EMLINK") {
+      throw new BinaryOpenError(403, "Access denied", code);
+    }
+    if (code === "EACCES" || code === "EPERM") {
+      throw new BinaryOpenError(403, "Access denied", code);
+    }
+    if (code === "EMFILE" || code === "ENFILE") {
+      throw new BinaryOpenError(503, "Server is out of file descriptors", code);
+    }
+    throw new BinaryOpenError(500, "Failed to open file", code);
+  }
+  if (opts?.expected) {
+    const stat = await handle.stat().catch(() => null);
+    if (!stat || stat.ino !== opts.expected.ino || stat.size !== opts.expected.size) {
+      await handle.close().catch(() => {});
+      throw new BinaryOpenError(
+        404,
+        "File changed between validation and read",
+        "content-changed",
+      );
+    }
+  }
   return handle.createReadStream({
     autoClose: true,
-    ...(opts?.start !== undefined ? { start: opts.start } : {}),
-    ...(opts?.end !== undefined ? { end: opts.end } : {}),
+    start: opts?.start,
+    end: opts?.end,
   });
 }
 
@@ -152,6 +209,7 @@ export async function buildBinaryResponse(
   request?: Request,
 ): Promise<Response> {
   const size = meta.size;
+  const expected = { ino: meta.ino, size: meta.size };
   const commonHeaders: Record<string, string> = {
     "Content-Type": meta.contentType,
     "Content-Disposition": formatContentDisposition(meta.disposition, meta.rawName),
@@ -181,7 +239,7 @@ export async function buildBinaryResponse(
         });
       }
       const chunkLength = end - start + 1;
-      const nodeStream = await openBinaryStream(meta.filePath, { start, end });
+      const nodeStream = await openBinaryStream(meta.filePath, { start, end, expected });
       return new Response(
         Readable.toWeb(nodeStream) as ReadableStream<Uint8Array>,
         {
@@ -197,7 +255,7 @@ export async function buildBinaryResponse(
     // Malformed Range header: fall through to full response.
   }
 
-  const nodeStream = await openBinaryStream(meta.filePath);
+  const nodeStream = await openBinaryStream(meta.filePath, { expected });
   return new Response(
     Readable.toWeb(nodeStream) as ReadableStream<Uint8Array>,
     {

--- a/apps/web-platform/server/share-hash-verdict-cache.ts
+++ b/apps/web-platform/server/share-hash-verdict-cache.ts
@@ -1,0 +1,95 @@
+// In-process verdict cache for /api/shared/[token] content-hash gate.
+//
+// Keyed on share token; the stored entry carries (mtimeMs, size) so file
+// mutations silently invalidate (a subsequent request with a different
+// mtime tuple is treated as a miss). Bounded to MAX_ENTRIES with
+// insertion-order eviction; entries expire after TTL_MS matching the
+// Cache-Control: private, max-age=60 header on view responses.
+//
+// Lives in a sibling module — NOT in route.ts — to stay inside the
+// Next.js App Router route-file export allowlist (cq-nextjs-route-files-
+// http-only-exports). PR #2401 shipped a hotfix for exactly this class of
+// bug after the analytics-track route file leaked a non-HTTP singleton.
+
+const TTL_MS = 60_000;
+const MAX_ENTRIES = 500;
+
+interface Entry {
+  mtimeMs: number;
+  size: number;
+  expiresAt: number;
+}
+
+const cache = new Map<string, Entry>();
+
+interface Stats {
+  hits: number;
+  misses: number;
+  evictions: number;
+  expirations: number;
+}
+const stats: Stats = { hits: 0, misses: 0, evictions: 0, expirations: 0 };
+
+export const shareHashVerdictCache = {
+  /**
+   * Returns true if (token, mtimeMs, size) has a fresh "verified" entry.
+   * Returns null on miss (absent, expired, or tuple mismatch — each
+   * counts as a cache miss for the purposes of forcing a re-hash).
+   */
+  get(token: string, mtimeMs: number, size: number): true | null {
+    const entry = cache.get(token);
+    if (!entry) {
+      stats.misses += 1;
+      return null;
+    }
+    if (entry.expiresAt <= Date.now()) {
+      cache.delete(token);
+      stats.expirations += 1;
+      stats.misses += 1;
+      return null;
+    }
+    if (entry.mtimeMs !== mtimeMs || entry.size !== size) {
+      // File changed since verification — treat as miss; caller will
+      // re-hash and overwrite via set().
+      stats.misses += 1;
+      return null;
+    }
+    // Refresh LRU position (Map preserves insertion order).
+    cache.delete(token);
+    cache.set(token, entry);
+    stats.hits += 1;
+    return true;
+  },
+
+  set(token: string, mtimeMs: number, size: number): void {
+    if (cache.size >= MAX_ENTRIES && !cache.has(token)) {
+      const oldest = cache.keys().next().value;
+      if (oldest !== undefined) {
+        cache.delete(oldest);
+        stats.evictions += 1;
+      }
+    }
+    cache.set(token, {
+      mtimeMs,
+      size,
+      expiresAt: Date.now() + TTL_MS,
+    });
+  },
+
+  stats(): Readonly<Stats> {
+    return { ...stats };
+  },
+};
+
+/**
+ * Test-only helper. Must never be imported from a route.ts file — keep
+ * the route-file export surface limited to HTTP method handlers +
+ * Next.js config exports per cq-nextjs-route-files-http-only-exports.
+ */
+export function __resetShareHashVerdictCacheForTest(): void {
+  cache.clear();
+  stats.hits = 0;
+  stats.misses = 0;
+  stats.evictions = 0;
+  stats.expirations = 0;
+}

--- a/apps/web-platform/server/share-hash-verdict-cache.ts
+++ b/apps/web-platform/server/share-hash-verdict-cache.ts
@@ -1,10 +1,19 @@
 // In-process verdict cache for /api/shared/[token] content-hash gate.
 //
-// Keyed on share token; the stored entry carries (mtimeMs, size) so file
-// mutations silently invalidate (a subsequent request with a different
-// mtime tuple is treated as a miss). Bounded to MAX_ENTRIES with
-// insertion-order eviction; entries expire after TTL_MS matching the
-// Cache-Control: private, max-age=60 header on view responses.
+// Keyed on share token; the stored entry carries (ino, mtimeMs, size) so
+// file mutations silently invalidate — a subsequent request with a
+// different tuple is treated as a miss. Including `ino` on top of
+// `mtimeMs + size` defends against same-second same-size swaps on
+// filesystems with coarse mtime resolution (NFS, overlayfs on older
+// kernels) that would otherwise let a malicious rename slip past the
+// verdict gate.
+//
+// Per-worker, self-healing: each Next.js worker has its own Map. Cross-
+// worker cache-miss just means one extra hash per worker per file per
+// 60 s window — acceptable for share traffic volume. Do NOT promote to a
+// shared Redis layer without measuring hit rate first; the correctness
+// story depends on the per-request validateBinaryFile fstat rebuilding
+// the tuple on every view.
 //
 // Lives in a sibling module — NOT in route.ts — to stay inside the
 // Next.js App Router route-file export allowlist (cq-nextjs-route-files-
@@ -15,6 +24,7 @@ const TTL_MS = 60_000;
 const MAX_ENTRIES = 500;
 
 interface Entry {
+  ino: number;
   mtimeMs: number;
   size: number;
   expiresAt: number;
@@ -32,11 +42,11 @@ const stats: Stats = { hits: 0, misses: 0, evictions: 0, expirations: 0 };
 
 export const shareHashVerdictCache = {
   /**
-   * Returns true if (token, mtimeMs, size) has a fresh "verified" entry.
-   * Returns null on miss (absent, expired, or tuple mismatch — each
-   * counts as a cache miss for the purposes of forcing a re-hash).
+   * Returns true if (token, ino, mtimeMs, size) has a fresh "verified"
+   * entry. Returns null on miss (absent, expired, or tuple mismatch —
+   * each counts as a cache miss for the purposes of forcing a re-hash).
    */
-  get(token: string, mtimeMs: number, size: number): true | null {
+  get(token: string, ino: number, mtimeMs: number, size: number): true | null {
     const entry = cache.get(token);
     if (!entry) {
       stats.misses += 1;
@@ -48,9 +58,13 @@ export const shareHashVerdictCache = {
       stats.misses += 1;
       return null;
     }
-    if (entry.mtimeMs !== mtimeMs || entry.size !== size) {
-      // File changed since verification — treat as miss; caller will
-      // re-hash and overwrite via set().
+    if (
+      entry.ino !== ino ||
+      entry.mtimeMs !== mtimeMs ||
+      entry.size !== size
+    ) {
+      // File swapped or mutated since verification — treat as miss;
+      // caller will re-hash and overwrite via set().
       stats.misses += 1;
       return null;
     }
@@ -61,7 +75,7 @@ export const shareHashVerdictCache = {
     return true;
   },
 
-  set(token: string, mtimeMs: number, size: number): void {
+  set(token: string, ino: number, mtimeMs: number, size: number): void {
     if (cache.size >= MAX_ENTRIES && !cache.has(token)) {
       const oldest = cache.keys().next().value;
       if (oldest !== undefined) {
@@ -70,6 +84,7 @@ export const shareHashVerdictCache = {
       }
     }
     cache.set(token, {
+      ino,
       mtimeMs,
       size,
       expiresAt: Date.now() + TTL_MS,

--- a/apps/web-platform/test/share-hash-verdict-cache.test.ts
+++ b/apps/web-platform/test/share-hash-verdict-cache.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+import {
+  shareHashVerdictCache,
+  __resetShareHashVerdictCacheForTest,
+} from "@/server/share-hash-verdict-cache";
+
+describe("shareHashVerdictCache", () => {
+  beforeEach(() => {
+    __resetShareHashVerdictCacheForTest();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns null on miss", () => {
+    expect(shareHashVerdictCache.get("token-a", 1, 10)).toBeNull();
+  });
+
+  it("returns true after set with matching tuple", () => {
+    shareHashVerdictCache.set("token-a", 123, 50);
+    expect(shareHashVerdictCache.get("token-a", 123, 50)).toBe(true);
+  });
+
+  it("returns null when mtimeMs differs", () => {
+    shareHashVerdictCache.set("token-a", 123, 50);
+    expect(shareHashVerdictCache.get("token-a", 124, 50)).toBeNull();
+  });
+
+  it("returns null when size differs", () => {
+    shareHashVerdictCache.set("token-a", 123, 50);
+    expect(shareHashVerdictCache.get("token-a", 123, 51)).toBeNull();
+  });
+
+  it("returns null after TTL expires", () => {
+    vi.useFakeTimers();
+    const baseTime = new Date("2026-04-17T12:00:00Z").getTime();
+    vi.setSystemTime(baseTime);
+    shareHashVerdictCache.set("token-a", 1, 10);
+    expect(shareHashVerdictCache.get("token-a", 1, 10)).toBe(true);
+    vi.setSystemTime(baseTime + 60_001);
+    expect(shareHashVerdictCache.get("token-a", 1, 10)).toBeNull();
+  });
+
+  it("evicts oldest entry when MAX_ENTRIES exceeded", () => {
+    const MAX_ENTRIES = 500;
+    for (let i = 0; i < MAX_ENTRIES; i++) {
+      shareHashVerdictCache.set(`token-${i}`, i, i);
+    }
+    // All 500 entries should still be present.
+    expect(shareHashVerdictCache.get("token-0", 0, 0)).toBe(true);
+    // Insert one more → oldest (token-0) evicted (we accessed it above
+    // which refreshed LRU position; insert after that means token-1 is now oldest).
+    shareHashVerdictCache.set("token-new", 9999, 9999);
+    expect(shareHashVerdictCache.get("token-1", 1, 1)).toBeNull();
+    expect(shareHashVerdictCache.get("token-new", 9999, 9999)).toBe(true);
+  });
+
+  it("tracks hit/miss stats", () => {
+    shareHashVerdictCache.set("token-a", 1, 10);
+    shareHashVerdictCache.get("token-a", 1, 10); // hit
+    shareHashVerdictCache.get("token-b", 1, 10); // miss
+    shareHashVerdictCache.get("token-a", 2, 10); // miss (mtime diff)
+    const stats = shareHashVerdictCache.stats();
+    expect(stats.hits).toBe(1);
+    expect(stats.misses).toBe(2);
+  });
+
+  it("re-setting the same token updates tuple + TTL", () => {
+    vi.useFakeTimers();
+    const baseTime = new Date("2026-04-17T12:00:00Z").getTime();
+    vi.setSystemTime(baseTime);
+    shareHashVerdictCache.set("token-a", 1, 10);
+    vi.setSystemTime(baseTime + 59_000);
+    shareHashVerdictCache.set("token-a", 2, 20);
+    vi.setSystemTime(baseTime + 60_500);
+    // Original tuple would be expired by now; new one should hit.
+    expect(shareHashVerdictCache.get("token-a", 1, 10)).toBeNull();
+    expect(shareHashVerdictCache.get("token-a", 2, 20)).toBe(true);
+  });
+});

--- a/apps/web-platform/test/share-hash-verdict-cache.test.ts
+++ b/apps/web-platform/test/share-hash-verdict-cache.test.ts
@@ -5,63 +5,74 @@ import {
   __resetShareHashVerdictCacheForTest,
 } from "@/server/share-hash-verdict-cache";
 
+const INO = 999;
+
 describe("shareHashVerdictCache", () => {
   beforeEach(() => {
     __resetShareHashVerdictCacheForTest();
   });
 
   afterEach(() => {
+    __resetShareHashVerdictCacheForTest();
     vi.useRealTimers();
   });
 
   it("returns null on miss", () => {
-    expect(shareHashVerdictCache.get("token-a", 1, 10)).toBeNull();
+    expect(shareHashVerdictCache.get("token-a", INO, 1, 10)).toBeNull();
   });
 
   it("returns true after set with matching tuple", () => {
-    shareHashVerdictCache.set("token-a", 123, 50);
-    expect(shareHashVerdictCache.get("token-a", 123, 50)).toBe(true);
+    shareHashVerdictCache.set("token-a", INO, 123, 50);
+    expect(shareHashVerdictCache.get("token-a", INO, 123, 50)).toBe(true);
+  });
+
+  it("returns null when ino differs", () => {
+    shareHashVerdictCache.set("token-a", INO, 123, 50);
+    expect(shareHashVerdictCache.get("token-a", INO + 1, 123, 50)).toBeNull();
   });
 
   it("returns null when mtimeMs differs", () => {
-    shareHashVerdictCache.set("token-a", 123, 50);
-    expect(shareHashVerdictCache.get("token-a", 124, 50)).toBeNull();
+    shareHashVerdictCache.set("token-a", INO, 123, 50);
+    expect(shareHashVerdictCache.get("token-a", INO, 124, 50)).toBeNull();
   });
 
   it("returns null when size differs", () => {
-    shareHashVerdictCache.set("token-a", 123, 50);
-    expect(shareHashVerdictCache.get("token-a", 123, 51)).toBeNull();
+    shareHashVerdictCache.set("token-a", INO, 123, 50);
+    expect(shareHashVerdictCache.get("token-a", INO, 123, 51)).toBeNull();
   });
 
   it("returns null after TTL expires", () => {
     vi.useFakeTimers();
     const baseTime = new Date("2026-04-17T12:00:00Z").getTime();
     vi.setSystemTime(baseTime);
-    shareHashVerdictCache.set("token-a", 1, 10);
-    expect(shareHashVerdictCache.get("token-a", 1, 10)).toBe(true);
+    shareHashVerdictCache.set("token-a", INO, 1, 10);
+    expect(shareHashVerdictCache.get("token-a", INO, 1, 10)).toBe(true);
     vi.setSystemTime(baseTime + 60_001);
-    expect(shareHashVerdictCache.get("token-a", 1, 10)).toBeNull();
+    expect(shareHashVerdictCache.get("token-a", INO, 1, 10)).toBeNull();
   });
 
   it("evicts oldest entry when MAX_ENTRIES exceeded", () => {
     const MAX_ENTRIES = 500;
     for (let i = 0; i < MAX_ENTRIES; i++) {
-      shareHashVerdictCache.set(`token-${i}`, i, i);
+      shareHashVerdictCache.set(`token-${i}`, INO + i, i, i);
     }
     // All 500 entries should still be present.
-    expect(shareHashVerdictCache.get("token-0", 0, 0)).toBe(true);
+    expect(shareHashVerdictCache.get("token-0", INO, 0, 0)).toBe(true);
     // Insert one more → oldest (token-0) evicted (we accessed it above
-    // which refreshed LRU position; insert after that means token-1 is now oldest).
-    shareHashVerdictCache.set("token-new", 9999, 9999);
-    expect(shareHashVerdictCache.get("token-1", 1, 1)).toBeNull();
-    expect(shareHashVerdictCache.get("token-new", 9999, 9999)).toBe(true);
+    // which refreshed LRU position; insert after that means token-1 is
+    // now oldest).
+    shareHashVerdictCache.set("token-new", INO + 9999, 9999, 9999);
+    expect(shareHashVerdictCache.get("token-1", INO + 1, 1, 1)).toBeNull();
+    expect(
+      shareHashVerdictCache.get("token-new", INO + 9999, 9999, 9999),
+    ).toBe(true);
   });
 
   it("tracks hit/miss stats", () => {
-    shareHashVerdictCache.set("token-a", 1, 10);
-    shareHashVerdictCache.get("token-a", 1, 10); // hit
-    shareHashVerdictCache.get("token-b", 1, 10); // miss
-    shareHashVerdictCache.get("token-a", 2, 10); // miss (mtime diff)
+    shareHashVerdictCache.set("token-a", INO, 1, 10);
+    shareHashVerdictCache.get("token-a", INO, 1, 10); // hit
+    shareHashVerdictCache.get("token-b", INO, 1, 10); // miss
+    shareHashVerdictCache.get("token-a", INO, 2, 10); // miss (mtime diff)
     const stats = shareHashVerdictCache.stats();
     expect(stats.hits).toBe(1);
     expect(stats.misses).toBe(2);
@@ -71,12 +82,22 @@ describe("shareHashVerdictCache", () => {
     vi.useFakeTimers();
     const baseTime = new Date("2026-04-17T12:00:00Z").getTime();
     vi.setSystemTime(baseTime);
-    shareHashVerdictCache.set("token-a", 1, 10);
+    shareHashVerdictCache.set("token-a", INO, 1, 10);
     vi.setSystemTime(baseTime + 59_000);
-    shareHashVerdictCache.set("token-a", 2, 20);
+    shareHashVerdictCache.set("token-a", INO + 7, 2, 20);
     vi.setSystemTime(baseTime + 60_500);
-    // Original tuple would be expired by now; new one should hit.
-    expect(shareHashVerdictCache.get("token-a", 1, 10)).toBeNull();
-    expect(shareHashVerdictCache.get("token-a", 2, 20)).toBe(true);
+    // Original tuple would be expired by now; new tuple should hit.
+    expect(shareHashVerdictCache.get("token-a", INO, 1, 10)).toBeNull();
+    expect(shareHashVerdictCache.get("token-a", INO + 7, 2, 20)).toBe(true);
+  });
+
+  it("same-size same-mtime but different ino is a miss (guards rename-swap)", () => {
+    // The scenario security-sentinel F2 flagged: on filesystems with
+    // coarse mtime, an attacker could swap a same-size file within the
+    // same mtime-second. ino is the defense in depth.
+    shareHashVerdictCache.set("token-a", 1000, 123_456, 2048);
+    expect(
+      shareHashVerdictCache.get("token-a", 2000, 123_456, 2048),
+    ).toBeNull();
   });
 });

--- a/apps/web-platform/test/shared-token-verdict-cache.test.ts
+++ b/apps/web-platform/test/shared-token-verdict-cache.test.ts
@@ -110,6 +110,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  __resetShareHashVerdictCacheForTest();
   fs.rmSync(tmpWorkspace, { recursive: true, force: true });
 });
 
@@ -173,7 +174,15 @@ describe("GET /api/shared/[token] — verdict cache (streaming)", () => {
     const second = await callGET(buildRequest("tok-mtime"), "tok-mtime");
     expect(second.status).toBe(410); // content-changed
     expect(hashStreamSpy).toHaveBeenCalledTimes(2);
-    expect(shareHashVerdictCache.get("tok-mtime", future.getTime(), newBytes.length)).toBeNull();
+    const stat = fs.statSync(filePath);
+    expect(
+      shareHashVerdictCache.get(
+        "tok-mtime",
+        stat.ino,
+        stat.mtimeMs,
+        stat.size,
+      ),
+    ).toBeNull();
   });
 
   it("streaming response body contains the full file bytes", async () => {
@@ -186,5 +195,48 @@ describe("GET /api/shared/[token] — verdict cache (streaming)", () => {
     expect(res.status).toBe(200);
     const body = await res.arrayBuffer();
     expect(Buffer.from(body).equals(bytes)).toBe(true);
+  });
+
+  it("hash mismatch on first view returns 410 and does NOT cache the verdict", async () => {
+    const actualBytes = Buffer.from("these are the real file bytes");
+    const storedHash = hashBytes(Buffer.from("something else was stored"));
+    const filePath = path.join(kbRoot, "doc.pdf");
+    fs.writeFileSync(filePath, actualBytes);
+    mockShareAndOwner("doc.pdf", { contentHash: storedHash });
+
+    const res = await callGET(buildRequest("tok-mismatch"), "tok-mismatch");
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.code).toBe("content-changed");
+
+    const stat = fs.statSync(filePath);
+    expect(
+      shareHashVerdictCache.get(
+        "tok-mismatch",
+        stat.ino,
+        stat.mtimeMs,
+        stat.size,
+      ),
+    ).toBeNull();
+  });
+
+  it("stores the exact validated tuple on cache set (ino, mtimeMs, size)", async () => {
+    const bytes = Buffer.from("payload to hash");
+    const filePath = path.join(kbRoot, "doc.pdf");
+    fs.writeFileSync(filePath, bytes);
+    const hash = hashBytes(bytes);
+    mockShareAndOwner("doc.pdf", { contentHash: hash });
+
+    const res = await callGET(buildRequest("tok-tuple"), "tok-tuple");
+    expect(res.status).toBe(200);
+    const stat = fs.statSync(filePath);
+    expect(
+      shareHashVerdictCache.get(
+        "tok-tuple",
+        stat.ino,
+        stat.mtimeMs,
+        stat.size,
+      ),
+    ).toBe(true);
   });
 });

--- a/apps/web-platform/test/shared-token-verdict-cache.test.ts
+++ b/apps/web-platform/test/shared-token-verdict-cache.test.ts
@@ -1,0 +1,190 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { hashBytes } from "@/server/kb-content-hash";
+import {
+  shareHashVerdictCache,
+  __resetShareHashVerdictCacheForTest,
+} from "@/server/share-hash-verdict-cache";
+
+const mocks = vi.hoisted(() => ({
+  mockServiceFrom: vi.fn(),
+  mockIsAllowed: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServiceClient: vi.fn(() => ({
+    from: mocks.mockServiceFrom,
+  })),
+}));
+
+vi.mock("@/server/rate-limiter", () => ({
+  shareEndpointThrottle: { isAllowed: mocks.mockIsAllowed },
+  extractClientIpFromHeaders: vi.fn(() => "1.2.3.4"),
+  logRateLimitRejection: vi.fn(),
+}));
+
+vi.mock("@/server/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+// Spy on hashStream to count invocations. The route calls hashStream
+// only on cache miss; this spy is the core assertion of this file.
+const hashStreamSpy = vi.fn();
+vi.mock("@/server/kb-content-hash", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/server/kb-content-hash")>(
+      "@/server/kb-content-hash",
+    );
+  return {
+    ...actual,
+    hashStream: async (...args: unknown[]) => {
+      hashStreamSpy();
+      // @ts-expect-error -- forwarded args match actual signature.
+      return actual.hashStream(...args);
+    },
+  };
+});
+
+import { GET } from "@/app/api/shared/[token]/route";
+
+let tmpWorkspace: string;
+let kbRoot: string;
+
+function buildRequest(token: string, headers?: Record<string, string>): Request {
+  return new Request(`http://localhost:3000/api/shared/${token}`, { headers });
+}
+function callGET(req: Request, token: string) {
+  return GET(req, { params: Promise.resolve({ token }) });
+}
+
+function mockShareAndOwner(
+  documentPath: string,
+  opts: { contentHash: string },
+) {
+  let fromCalls = 0;
+  mocks.mockServiceFrom.mockImplementation(() => {
+    fromCalls++;
+    if (fromCalls % 2 === 1) {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: {
+                document_path: documentPath,
+                user_id: "user-1",
+                revoked: false,
+                content_sha256: opts.contentHash,
+              },
+              error: null,
+            }),
+          }),
+        }),
+      };
+    }
+    return {
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: {
+              workspace_path: tmpWorkspace,
+              workspace_status: "ready",
+            },
+            error: null,
+          }),
+        }),
+      }),
+    };
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hashStreamSpy.mockClear();
+  __resetShareHashVerdictCacheForTest();
+  tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), "shared-cache-"));
+  kbRoot = path.join(tmpWorkspace, "knowledge-base");
+  fs.mkdirSync(kbRoot, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpWorkspace, { recursive: true, force: true });
+});
+
+describe("GET /api/shared/[token] — verdict cache (streaming)", () => {
+  it("first view hashes, second view skips hash on same file", async () => {
+    const pdfBytes = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a, 0xff]);
+    fs.writeFileSync(path.join(kbRoot, "doc.pdf"), pdfBytes);
+    const hash = hashBytes(pdfBytes);
+    mockShareAndOwner("doc.pdf", { contentHash: hash });
+
+    const first = await callGET(buildRequest("tok-a"), "tok-a");
+    expect(first.status).toBe(200);
+    expect(hashStreamSpy).toHaveBeenCalledTimes(1);
+
+    const second = await callGET(buildRequest("tok-a"), "tok-a");
+    expect(second.status).toBe(200);
+    expect(hashStreamSpy).toHaveBeenCalledTimes(1); // not called again
+  });
+
+  it("Range request on cached token returns 206 without re-hashing", async () => {
+    const pdfBytes = Buffer.alloc(1024, 0x42);
+    fs.writeFileSync(path.join(kbRoot, "doc.pdf"), pdfBytes);
+    const hash = hashBytes(pdfBytes);
+    mockShareAndOwner("doc.pdf", { contentHash: hash });
+
+    // Prime the cache.
+    const first = await callGET(buildRequest("tok-range"), "tok-range");
+    expect(first.status).toBe(200);
+    const hashCallsAfterPrime = hashStreamSpy.mock.calls.length;
+
+    // Mock must remain valid across invocations (reset call count).
+    mockShareAndOwner("doc.pdf", { contentHash: hash });
+
+    const rangeReq = buildRequest("tok-range", { Range: "bytes=0-99" });
+    const ranged = await callGET(rangeReq, "tok-range");
+    expect(ranged.status).toBe(206);
+    expect(ranged.headers.get("Content-Length")).toBe("100");
+    expect(ranged.headers.get("Content-Range")).toBe("bytes 0-99/1024");
+    expect(hashStreamSpy.mock.calls.length).toBe(hashCallsAfterPrime);
+  });
+
+  it("mtime change invalidates cache and re-hashes", async () => {
+    const origBytes = Buffer.from("original content padding padding");
+    const filePath = path.join(kbRoot, "doc.pdf");
+    fs.writeFileSync(filePath, origBytes);
+    const origHash = hashBytes(origBytes);
+    mockShareAndOwner("doc.pdf", { contentHash: origHash });
+
+    const first = await callGET(buildRequest("tok-mtime"), "tok-mtime");
+    expect(first.status).toBe(200);
+    expect(hashStreamSpy).toHaveBeenCalledTimes(1);
+
+    // Modify file. Advance mtime by writing with a future timestamp so
+    // the fs layer reports a different mtimeMs reliably.
+    const newBytes = Buffer.from("different content different length");
+    fs.writeFileSync(filePath, newBytes);
+    const future = new Date(Date.now() + 10_000);
+    fs.utimesSync(filePath, future, future);
+
+    mockShareAndOwner("doc.pdf", { contentHash: origHash });
+    const second = await callGET(buildRequest("tok-mtime"), "tok-mtime");
+    expect(second.status).toBe(410); // content-changed
+    expect(hashStreamSpy).toHaveBeenCalledTimes(2);
+    expect(shareHashVerdictCache.get("tok-mtime", future.getTime(), newBytes.length)).toBeNull();
+  });
+
+  it("streaming response body contains the full file bytes", async () => {
+    const bytes = Buffer.from("streamable content bytes ABCDEFG");
+    fs.writeFileSync(path.join(kbRoot, "doc.pdf"), bytes);
+    const hash = hashBytes(bytes);
+    mockShareAndOwner("doc.pdf", { contentHash: hash });
+
+    const res = await callGET(buildRequest("tok-body"), "tok-body");
+    expect(res.status).toBe(200);
+    const body = await res.arrayBuffer();
+    expect(Buffer.from(body).equals(bytes)).toBe(true);
+  });
+});

--- a/knowledge-base/project/learnings/2026-04-17-stream-response-toctou-across-fd-boundary.md
+++ b/knowledge-base/project/learnings/2026-04-17-stream-response-toctou-across-fd-boundary.md
@@ -1,0 +1,126 @@
+---
+module: "KB binary response + hash gate"
+date: 2026-04-17
+problem_type: security_issue
+component: nextjs_route
+symptoms:
+  - "Hash-then-serve refactor opened a rename/link TOCTOU window"
+  - "Verdict cache keyed only on (mtimeMs, size) could be fooled by same-second same-size swaps"
+  - "openBinaryStream errors mapped EVERY failure to 404 (incl. EMFILE)"
+root_cause: buffer-to-stream_refactor_split_the_hash_and_serve_fds
+severity: high
+tags:
+  - toctou
+  - fd-lifetime
+  - streaming
+  - nextjs
+  - inode-identity
+  - code-review
+synced_to: []
+---
+
+# Streaming refactor split the fd used for hashing from the fd used for serving — inode identity must be pinned across the gap
+
+## Problem
+
+PR #2477 converted `readBinaryFile` from a buffered read (`handle.readFile()` — bytes live in memory) to a metadata-only validator (`validateBinaryFile`) plus `openBinaryStream(filePath)` called fresh per response. This is the right perf fix (peak RSS drops from O(size) to O(64 KB)) but it split what had been a single-fd operation into **three separate `open()` calls** on the same path:
+
+1. `validateBinaryFile` opens fd A, fstats, closes — to get `(ino, mtimeMs, size)` and content-type metadata.
+2. `openBinaryStream(filePath)` opens fd B for the hash pass (cache miss), drains through SHA-256, closes.
+3. `buildBinaryResponse` opens fd C for the response body stream.
+
+The pre-refactor version used a single held fd for both the hash and the serve — bytes hashed and bytes served were bit-identical by fd identity. Post-refactor, an attacker with write access to the workspace can `rename(2)` a different regular file over the path between step 2 and step 3 and serve mismatched bytes that passed the hash gate.
+
+`O_NOFOLLOW` does NOT protect against this — it only refuses symlinks at the terminal component. A rename of a regular file on top of a regular file is not a symlink operation and slips past.
+
+Additionally: the verdict cache was initially keyed on `(token, mtimeMs, size)` only. On filesystems with coarse mtime resolution (NFS, overlayfs on older kernels, older tmpfs), a same-size file swap within the same mtime-second would hit the cache and serve the swapped bytes for up to 60 s without re-hashing.
+
+## Investigation / How It Surfaced
+
+Multi-agent review. `security-sentinel` F1 flagged the fd-split TOCTOU symbolically by reading the refactor's code path. `security-sentinel` F2 flagged the coarse-mtime cache-coherence edge case. `code-quality-analyst` P2-2 independently flagged that `openBinaryStream` errors mapped to 404 regardless of cause, swallowing fd-exhaustion (`EMFILE`/`ENFILE`) as "document no longer available" — which is a different failure mode of the same refactor (error classification drift when the I/O path grew an extra error source).
+
+None of these were caught by vitest (tests used `fs.writeFileSync` + small real files; no attempt to simulate a rename during the request), `tsc --noEmit` (no type signal), or semgrep (no rule covers cross-fd inode drift). Full Next.js build passed clean. This is the same class as `2026-04-15-multi-agent-review-catches-bugs-tests-miss.md` — the review agents catch bugs that green CI does not.
+
+## Solution
+
+### 1. Pin inode identity across fds
+
+```ts
+// In validateBinaryFile, capture stat.ino along with size/mtimeMs:
+return {
+  ok: true,
+  filePath: fullPath,
+  ino: stat.ino,
+  size: stat.size,
+  mtimeMs: stat.mtimeMs,
+  // ...
+};
+
+// In openBinaryStream, accept `expected` and fstat-verify:
+export async function openBinaryStream(
+  filePath: string,
+  opts?: { start?: number; end?: number; expected?: { ino: number; size: number } },
+): Promise<Readable> {
+  const handle = await fs.promises.open(filePath, O_RDONLY | O_NOFOLLOW);
+  if (opts?.expected) {
+    const stat = await handle.stat();
+    if (stat.ino !== opts.expected.ino || stat.size !== opts.expected.size) {
+      await handle.close();
+      throw new BinaryOpenError(404, "File changed between validation and read", "content-changed");
+    }
+  }
+  return handle.createReadStream({ autoClose: true, start: opts?.start, end: opts?.end });
+}
+```
+
+Callers that already have metadata (`validateBinaryFile` result) MUST pass `expected` on every subsequent `openBinaryStream` call. Missing the pass on any call silently reopens the TOCTOU window.
+
+### 2. Add `ino` to the verdict cache tuple
+
+```ts
+shareHashVerdictCache.get(token, ino, mtimeMs, size)  // was: (token, mtimeMs, size)
+shareHashVerdictCache.set(token, ino, mtimeMs, size)
+```
+
+`ino` is the defense-in-depth against coarse-mtime swap attacks. Even on a filesystem that truncates mtime to 1-second resolution, inode reuse within a 60 s window is extremely unlikely in practice and would require an orchestrated `rm` + `creat` cycle timed against the cache TTL.
+
+### 3. Classify `openBinaryStream` errors
+
+Introduce `BinaryOpenError` with a status field; map Node error codes:
+
+- `ENOENT` → 404
+- `ELOOP`, `EMLINK`, `EACCES`, `EPERM` → 403
+- `EMFILE`, `ENFILE` → 503 (server-side fd exhaustion, not client error)
+- anything else → 500
+
+The route handler catches `BinaryOpenError`, passes through `.status`, and logs `.code` for observability. The `"content-changed"` code is the sentinel thrown on inode/size drift so routes can map it to 410 without reading the error message string.
+
+### 4. Rename `readBinaryFile` → `validateBinaryFile`
+
+The old name is a lie post-refactor — it doesn't read the file. Keep a transitional `export const readBinaryFile = validateBinaryFile` alias so the rename lands in one commit without a big-bang callsite migration.
+
+## Key Insights
+
+- **Any refactor that splits a single-fd operation into multiple fds opens a TOCTOU window.** The pre-refactor safety was implicit in fd identity. Post-refactor, identity must become explicit via `ino` + fstat-verify on every subsequent open. Don't assume `O_NOFOLLOW` covers this — it doesn't.
+- **Verdict caches that key on filesystem-derived tuples should include `ino`.** `mtimeMs + size` is enough on a correctness-strict ext4, but wrong on NFS, tmpfs (older kernels), overlayfs, and anything behind a 1-second mtime rounding layer. `ino` is free (the fstat that produces mtime also produces ino) and closes an ugly edge case.
+- **When an error classifier exists in one helper (validateBinaryFile), it must also exist in every sibling helper that does the same I/O.** `openBinaryStream` initially swallowed all errors as 404; the fix introduces a shared `BinaryOpenError` with proper status mapping so the classification is load-bearing in both places.
+
+## Session Errors
+
+**Error 1 — Initial implementation shipped the 3-fd split without the `expected` tuple guard.** The plan document explicitly called out the TOCTOU window and documented acceptance of it, and I followed the plan verbatim without pushing back. On second-pass review, security-sentinel flagged it as P2 and the fix was small (~30 LOC across 3 files). **Prevention:** When a plan document says "accepted trade-off" for a TOCTOU or security-boundary change, treat that as a flag for extra scrutiny during implementation, not a rubber stamp. Ask: is there a cheap way to close the window even if the plan accepts leaving it open? In this case, threading `ino` through metadata was ~30 LOC — the plan's "acceptance" was premature.
+
+**Error 2 — Cache-key expansion required a coordinated signature change across module, singleton exports, tests, and route call sites.** Four files, one breaking signature. **Prevention:** Already covered by rule `cq-nextjs-route-files-http-only-exports` (cache in its own module) and the usual TDD-first gate. Adding `ino` to a cache key is cheap; omitting `ino` from one call site in a future edit would silently downgrade the security story. A test that asserts the exact cached tuple (ino included) guards against regression — now added at `test/shared-token-verdict-cache.test.ts`.
+
+## Prevention
+
+- In review checklists for any buffer → stream refactor on hot security paths, explicitly ask: "Does the refactor split what was a single fd into multiple fds? If so, is inode identity preserved across the gap?"
+- In verdict-cache design: prefer `(ino, mtimeMs, size)` over `(mtimeMs, size)`. The extra field is free from fstat and closes a real edge case.
+- Error classification: if a helper can throw, define a typed error (class with status+code) and let callers discriminate. Don't let callers map-all-errors-to-one-status because "it probably means X."
+
+## Related
+
+- `2026-04-17-migration-not-null-without-backfill-and-partial-unique-index-pattern.md` — earlier in this session, also a multi-agent-review P2 catch on a pattern that passed all local checks.
+- `2026-04-15-multi-agent-review-catches-bugs-tests-miss.md` — pattern catalogue.
+- PR #2463 — introduced the content-hash gate this PR had to preserve.
+- PR #2477 — this PR (streaming + verdict cache + TOCTOU fix).
+- Scope-outs filed: #2483 (serveBinaryWithHashGate helper, contested-design).

--- a/knowledge-base/project/plans/2026-04-17-perf-stream-binary-responses-with-verdict-cache-plan.md
+++ b/knowledge-base/project/plans/2026-04-17-perf-stream-binary-responses-with-verdict-cache-plan.md
@@ -1,0 +1,359 @@
+# perf(kb): stream binary responses with hash-verdict cache
+
+**Date:** 2026-04-17
+**Branch:** `feat-fix-2316-stream-binary-responses`
+**Worktree:** `.worktrees/feat-fix-2316-stream-binary-responses/`
+**Issues:** Closes #2316 (P1 perf) and Closes #2466 (deferred-scope-out — Range-request hash regression)
+**Milestone:** Phase 3: Make it Sticky
+**Type:** perf (refactor + new internal cache)
+
+## Enhancement Summary
+
+**Deepened on:** 2026-04-17
+**Sources queried:** Node.js stream/fs API docs via Context7 (`/nodejs/node`), Next.js App Router streaming patterns (`/vercel/next.js`), lru-cache ergonomics (`/isaacs/node-lru-cache`), codebase inspection of `server/rate-limiter.ts` for existing in-process cache patterns.
+
+### Key changes from the initial plan
+
+1. **Stream primitive switched: use `filehandle.readableWebStream({ autoClose: true })`, not `Readable.toWeb(handle.createReadStream())`.** This is the canonical Next.js pattern straight from the official docs; it is byte-oriented (web `ReadableStream` with `type: 'bytes'`, so Range support downstream is native) and ships an explicit `autoClose: true` flag that closes the fd when the stream ends. The `handedOff` flag gymnastics in Phase 2 of the initial plan are eliminated.
+2. **Range branch uses `fs.createReadStream(filePath, { start, end, flags: 'r', autoClose: true })` wrapped via `Readable.toWeb`.** `filehandle.readableWebStream` does not accept `start`/`end`, so a second primitive is needed for ranged responses. The `autoClose: true` default on `fs.createReadStream` covers fd cleanup.
+3. **No `lru-cache` dependency.** The repo pattern (see `apps/web-platform/server/rate-limiter.ts` — `SlidingWindowCounter` is ~40 LOC of hand-rolled `Map`) is hand-rolled bounded structures. A 500-entry verdict cache with insertion-order eviction and per-entry expiry is ~60 LOC in one file. Pulling in `lru-cache` for 500 entries is overkill and inflates bundle.
+4. **Cloudflare / proxy buffering verified non-blocking.** The repo has no `X-Accel-Buffering` header. Deploy path is Cloudflare Tunnel → Next.js Node runtime; Cloudflare proxy-streams by default for `Content-Length`-present responses. No infra change needed for streaming to work in prod.
+5. **TOCTOU window for Range re-open explicitly flagged and accepted.** Range requests open a second fd without `O_NOFOLLOW` (Node's `createReadStream` does not expose it). The acceptance reasoning is documented below in "Sharp Edges".
+
+## Overview
+
+`readBinaryFile` currently allocates a full `Buffer` (up to 50 MB) plus a second `Uint8Array` copy before shipping the first byte. Under concurrent load this OOMs the process and starves the libuv threadpool (which also serves markdown I/O). This plan replaces the buffered path with a streaming path where possible, while preserving the SHA-256 content-integrity gate shipped in PR #2463 for `/api/shared/[token]`.
+
+Naive streaming breaks the gate: the share-view route hashes the in-memory buffer and returns 410 on mismatch. If `readBinaryFile` returns only a stream, the buffer is gone and hashing must happen before or during response shipping. The two sibling concerns are deeply coupled, so #2316 and #2466 are shipped together:
+
+- **#2316 (streaming):** Return a web `ReadableStream` from `readBinaryFile` so `new Response(stream, …)` emits bytes with O(64 KB) RSS instead of O(file size) RSS.
+- **#2466 (verdict cache):** After the first hash succeeds for a given `(token, mtimeMs, size)` tuple, subsequent views skip the hash and stream directly. Without this, every Range request (PDF.js issues 8–20 per document open) re-hashes 50 MB, which was the regression #2466 called out.
+
+**Out of scope:** #2309 agent-user parity, `/api/kb/share` POST (creation-side hash already uses `hashStream`), any refactor of `readContentRaw` for markdown. This PR closes 2 of the 27 Phase-3 code-review issues (#2326 shipped as PR #2463).
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Spec claim (from #2316 / #2466) | Codebase reality (verified 2026-04-17) | Plan response |
+| --- | --- | --- |
+| `readBinaryFile` currently reads the full file into a `Buffer` via `handle.readFile()` then wraps in `new Uint8Array(buffer)` (~2× memory). | Confirmed at `apps/web-platform/server/kb-binary-response.ts:98` and `:148`/`:160`. | Streaming path must also drop the `Uint8Array` wrap — `Response(stream)` needs no copy. |
+| `/api/shared/[token]` hashes on every view including Range requests. | Confirmed at `apps/web-platform/app/api/shared/[token]/route.ts:168`. | Introduce verdict cache keyed on `(token, mtimeMs, size)`. |
+| `/api/kb/content/[...path]` has no hash check. | Confirmed at `apps/web-platform/app/api/kb/content/[...path]/route.ts:76–80`. | Owner path streams unconditionally, no cache needed. |
+| `hashStream` exists and is used at share creation. | Confirmed at `apps/web-platform/server/kb-content-hash.ts:28`. | Reuse — no new hashing primitives. |
+| `buildBinaryResponse` already supports 206 Range via `buffer.subarray`. | Confirmed at `apps/web-platform/server/kb-binary-response.ts:127–156`. Depends on in-memory buffer. | Re-implement Range as `createReadStream(path, { start, end })` so range slicing never requires the full buffer. Cache verdict keeps Range viable on the share-view path. |
+| Node 22 + Next.js 15 run the App Router. `Readable.toWeb` is GA. | Confirmed in `apps/web-platform/package.json` (target node22, next 15.5). | Use `filehandle.readableWebStream({ autoClose: true })` as the primary primitive (canonical Next.js streaming idiom per official docs); use `Readable.toWeb(fs.createReadStream(path, { start, end }))` for the Range branch. |
+
+## Chosen Approach
+
+**Option (a): Hash-then-stream with per-token LRU verdict cache.**
+
+The two alternatives were rejected:
+
+- **Option (b) — stream-and-hash concurrently with abort:** Already-shipped bytes can't be unsent. A client that receives mismatched PDF bytes followed by an aborted connection has a corrupt file with no clear error signal. For a gate whose purpose is "if content changed, show 410 instead of stale content," shipping 1 KB of the new content before aborting is worse than buffering.
+- **Option (c) — pre-hash by reading, then serve via second stream:** 2× disk I/O on every view, plus the fstat→read→hash→open→read window is a TOCTOU reopening of the bug class PR #2463's `O_NOFOLLOW`+fd pattern was written to close.
+
+### Data flow
+
+1. `readBinaryFile(kbRoot, relativePath)` returns a discriminated union with two success shapes:
+   - `{ ok: true, stream: ReadableStream, size, mtimeMs, contentType, disposition, rawName, filePath }` — default stream path, no buffer allocated.
+   - For Range requests, `buildBinaryResponse` opens a second stream with `createReadStream(filePath, { start, end })`. This keeps the bounded-range fast path without requiring the full buffer.
+2. `/api/kb/content/[...path]` calls `readBinaryFile` → `buildBinaryResponse` directly. No hash, no cache.
+3. `/api/shared/[token]` calls `readBinaryFile`, then:
+   - Computes the cache key `(token, mtimeMs, size)`.
+   - On cache hit (`verified: true` within TTL): skip hashing, call `buildBinaryResponse` directly. Fast path.
+   - On cache miss: consume the stream into a hash (`hashStream`), compare to `shareLink.content_sha256`. On mismatch → 410. On match → store `{ verified: true, expiresAt: Date.now()+60_000 }` in cache, then re-issue the response by opening a **new** stream on the held fd path. The first-view hash pass is unavoidable for the first byte of a newly-cached entry; subsequent views are hash-free.
+4. LRU cache bounds: 500 entries, 60 s TTL (matching `Cache-Control: private, max-age=60`). Tuple-keyed on `mtimeMs+size` so any file mutation invalidates naturally.
+
+### Why `mtimeMs + size` (not just `mtimeMs`)
+
+`mtimeMs` resolution on Linux ext4 is nanosecond; on NFS and some container overlay FS it's second-level. A same-second rewrite with identical size is vanishingly unlikely in practice but the size guard is free insurance. The fstat already happens inside `readBinaryFile`, so we piggy-back on it.
+
+### fd-ownership and TOCTOU preservation
+
+PR #2463's `O_NOFOLLOW`+fstat-on-fd pattern must survive. The streaming path opens the fd once, stats it on the fd (existing `handle.stat()`), then derives the `ReadStream` from the held fd via `handle.createReadStream()`. This keeps the bytes served identical to the bytes stat'd and hashed — the same TOCTOU closure the buffered path had.
+
+For Range requests (second stream), we re-open by path using `fs.createReadStream(fullPath, { start, end })` under the same `O_NOFOLLOW` flag. The verdict cache ensures we don't hash on the Range path, so the Range request doesn't need the same fd-lifetime guarantee as the hash check (which ran on the first view's fd).
+
+## Implementation Phases
+
+### Phase 1 — Refactor `readBinaryFile` to return a stream (RED)
+
+Files:
+
+- `apps/web-platform/server/kb-binary-response.ts` (modify)
+- `apps/web-platform/test/kb-binary-response.test.ts` (new — RED tests first)
+
+Tasks:
+
+1. Add a failing test `test/kb-binary-response.test.ts` asserting:
+   - `readBinaryFile` returns `{ ok: true, stream, size, mtimeMs, contentType, disposition, rawName, filePath }` (new shape).
+   - The stream is a web `ReadableStream`.
+   - `size` equals the byte length on disk.
+   - `mtimeMs` matches `fs.statSync(path).mtimeMs`.
+   - All existing error paths (403 traversal, 403 symlink, 403 null-byte, 404 ENOENT, 413 oversize) still return the same status shape.
+2. Modify `readBinaryFile`:
+   - Keep the `O_RDONLY | O_NOFOLLOW` open, keep `handle.stat()`, keep all size/type/path guards.
+   - Replace `handle.readFile()` with `handle.readableWebStream({ autoClose: true })` — the canonical Next.js streaming primitive. `autoClose: true` closes the `FileHandle` when the stream ends or errors, so we do NOT need a `try/finally handle.close()` on the success path.
+   - Return the new shape `{ ok: true, stream, size, mtimeMs, contentType, disposition, rawName, filePath }`. Return `filePath` (absolute) so `buildBinaryResponse` can re-open on Range.
+   - Keep `handle.close()` on ERROR paths only (stat-failed, oversize, non-file). Once `readableWebStream` is called with `autoClose: true`, the fd lifetime is tied to the stream — calling `handle.close()` after handoff would double-close.
+
+Reference (Next.js docs):
+
+```ts
+// Canonical pattern for streaming file responses from App Router:
+import { open } from "node:fs/promises";
+const file = await open(absolutePath);
+return new Response(file.readableWebStream({ autoClose: true }), {
+  headers: { "Content-Type": "...", "Content-Length": String(size) },
+});
+```
+
+### Phase 2 — Teach `buildBinaryResponse` to stream (GREEN)
+
+Files:
+
+- `apps/web-platform/server/kb-binary-response.ts` (modify)
+- `apps/web-platform/test/kb-binary-response.test.ts` (extend)
+
+Tasks:
+
+1. Change `buildBinaryResponse`'s input type from `{ buffer, … }` to `{ stream, size, contentType, disposition, rawName, filePath }`.
+2. Full response branch: `new Response(stream, { headers: { …, "Content-Length": size.toString() } })`. The `stream` came from `readableWebStream({ autoClose: true })` upstream; no further lifecycle work.
+3. Range branch: parse the Range header as before, then open a fresh stream with `fs.createReadStream(filePath, { start, end, flags: "r", autoClose: true })` and wrap via `Readable.toWeb(nodeStream)`. `autoClose: true` is the default but pass explicitly for clarity. Return 206 with `Content-Length: chunk.length` and `Content-Range: bytes start-end/size`.
+
+Why the asymmetry (two stream primitives): `filehandle.readableWebStream` is byte-oriented and has the best fd-lifetime ergonomics for full responses, but it does NOT accept `start`/`end`. `fs.createReadStream` accepts the offsets we need for Range but returns a Node `Readable`, so we adapt via `Readable.toWeb`. Both are GA in Node 22 and documented by Next.js as the App Router streaming idioms.
+4. Extend tests:
+
+- Full GET returns stream with `Content-Length` matching file size.
+- Range `bytes=0-99` returns 206 with `Content-Length: 100` and `Content-Range: bytes 0-99/<size>`.
+- Malformed Range falls through to 200 full response.
+- Out-of-range (start ≥ size) returns 416 with `Content-Range: bytes */<size>`.
+
+### Phase 3 — Introduce the verdict cache module (RED + GREEN)
+
+Files:
+
+- `apps/web-platform/server/share-hash-verdict-cache.ts` (new)
+- `apps/web-platform/test/share-hash-verdict-cache.test.ts` (new)
+
+> **Route-file hygiene note (rule `cq-nextjs-route-files-http-only-exports`):** the verdict-cache singleton, `__resetShareHashVerdictCacheForTest`, and cache-metric helpers must live in `share-hash-verdict-cache.ts`. Never export them from `app/api/shared/[token]/route.ts`. The post-merge Next.js route validator only allows HTTP method handlers + config exports in `route.ts`; exporting the cache singleton from the route file would reproduce the PR #2347/#2401 outage pattern.
+
+Tasks:
+
+1. Write failing tests covering:
+   - `get(token, mtimeMs, size)` returns `null` on miss.
+   - `set(token, mtimeMs, size, verified)` stores and subsequent `get` returns the verdict within TTL.
+   - `get` returns `null` after TTL expires (use `vi.useFakeTimers` and advance 60 001 ms).
+   - Different `mtimeMs` on same token misses.
+   - Different `size` on same token and `mtimeMs` misses.
+   - LRU eviction: insert 501 entries, first key returns null, last 500 hit.
+   - `__resetShareHashVerdictCacheForTest()` clears state (for test isolation).
+2. Implement with a simple `Map<string, { verified: boolean; expiresAt: number; mtimeMs: number; size: number }>` plus insertion-order eviction. Pattern matches `apps/web-platform/server/rate-limiter.ts` `SlidingWindowCounter` (hand-rolled `Map`-based, ~40 LOC). Key on `token` alone and include `mtimeMs`/`size` in the value; treat mismatches as cache misses. This simplifies invalidation: a new tuple silently overwrites the old entry, so stale mtimes never accumulate.
+
+   ```ts
+   // Sketch — final form in share-hash-verdict-cache.ts
+   const TTL_MS = 60_000; // matches Cache-Control: max-age=60
+   const MAX_ENTRIES = 500;
+
+   type Entry = { verified: true; mtimeMs: number; size: number; expiresAt: number };
+   const cache = new Map<string, Entry>();
+
+   export const shareHashVerdictCache = {
+     get(token: string, mtimeMs: number, size: number): true | null {
+       const entry = cache.get(token);
+       if (!entry) return null;
+       if (entry.expiresAt <= Date.now()) { cache.delete(token); return null; }
+       if (entry.mtimeMs !== mtimeMs || entry.size !== size) return null;
+       // Refresh LRU position.
+       cache.delete(token);
+       cache.set(token, entry);
+       return true;
+     },
+     set(token: string, mtimeMs: number, size: number) {
+       if (cache.size >= MAX_ENTRIES && !cache.has(token)) {
+         // Evict oldest (Map preserves insertion order).
+         const oldest = cache.keys().next().value;
+         if (oldest !== undefined) cache.delete(oldest);
+       }
+       cache.set(token, { verified: true, mtimeMs, size, expiresAt: Date.now() + TTL_MS });
+     },
+     // Test-only helper — never export from route.ts (rule cq-nextjs-route-files-http-only-exports).
+   };
+   export function __resetShareHashVerdictCacheForTest() { cache.clear(); }
+   ```
+
+**Why not `lru-cache`:** The `lru-cache` package is excellent (and present transitively) but adds a direct dep, a bundle-surface change, and 46+ config options for a use case where our total state is 500 entries × ~40 bytes. The hand-rolled version above matches the repo's existing rate-limiter style and is trivially reviewable. If eviction patterns ever get more complex (size-weighted, async fetch-on-miss), revisit.
+3. Export a singleton `shareHashVerdictCache` and `__resetShareHashVerdictCacheForTest` helper.
+4. Optional counters for observability: `hits`, `misses`, `evictions` — expose via a `stats()` method. Deferred to follow-up if the basic cache is working; do not block ship on metrics.
+
+### Phase 4 — Wire the cache into `/api/shared/[token]` (GREEN)
+
+Files:
+
+- `apps/web-platform/app/api/shared/[token]/route.ts` (modify)
+- `apps/web-platform/test/shared-page-binary.test.ts` (update mocks for new shape)
+- `apps/web-platform/test/shared-token-content-hash.test.ts` (extend with cache-hit test)
+
+Tasks:
+
+1. In the binary branch, after `readBinaryFile` returns:
+
+   ```ts
+   const cached = shareHashVerdictCache.get(token, binary.mtimeMs, binary.size);
+   if (cached === true) {
+     // Fast path: known-good, skip hash.
+     logger.info({ event: "shared_page_viewed_cached", token }, "…");
+     return buildBinaryResponse(binary, request);
+   }
+   // Slow path: consume stream through hash, compare, then re-stream.
+   const hashResult = await hashStreamThenTee(binary.stream);
+   if (hashResult.hash !== shareLink.content_sha256) {
+     return contentChangedResponse();
+   }
+   shareHashVerdictCache.set(token, binary.mtimeMs, binary.size, true);
+   // binary.stream is consumed; re-open via filePath for the response body.
+   const streamForResponse = Readable.toWeb(fs.createReadStream(binary.filePath));
+   return buildBinaryResponse({ ...binary, stream: streamForResponse }, request);
+   ```
+
+2. For markdown (`.md` / extensionless) branch: unchanged. `readContentRaw` already returns a buffer at ~1 MB ceiling; streaming it is not worth the complexity. The hash-on-view behavior stays identical. Optional follow-up: the markdown path could use a similar verdict cache keyed on the markdown hash, but it's deferred because markdown is already O(1 MB) not O(50 MB).
+
+3. Add a `hashStreamThenTee` helper in `server/kb-content-hash.ts`: takes a `ReadableStream`, drains it through `createHash("sha256")`, returns `{ hash, bytesRead }`. (Note: does NOT tee — we discard the consumed stream and re-open below. The name reflects intent that the caller will need a fresh stream.) Add a failing test first.
+
+4. Update `shared-page-binary.test.ts`:
+   - Existing test helpers need to accept the new `{ stream, size, mtimeMs, filePath, … }` shape from `readBinaryFile`, or re-stub by just writing the file to disk and letting the real reader run (simpler — most tests already do this).
+   - Add one cache-hit test: issue two GETs for the same token, assert the second one does NOT invoke `hashStream` (spy on the exported function) and returns 200.
+   - Add one Range-request test: issue a GET with `Range: bytes=0-99` on a share with a known-good cached verdict, assert 206 and that the byte body length is 100.
+   - Add one cache-miss-after-edit test: issue GET, mutate the file (changes `mtimeMs`), issue second GET — verify hash runs again and 410 is returned (mismatch).
+
+### Phase 5 — Wire `/api/kb/content/[...path]` to the streaming API (GREEN)
+
+Files:
+
+- `apps/web-platform/app/api/kb/content/[...path]/route.ts` (modify)
+- `apps/web-platform/test/kb-content-route.test.ts` (new or extend existing)
+
+Tasks:
+
+1. Update the call site to use the new shape. No cache, no hash — owner route streams unconditionally.
+2. Test: owner GET of a PDF returns 200 with `Content-Type: application/pdf`, `Accept-Ranges: bytes`, `Content-Length` matching size.
+3. Test: owner Range GET returns 206 with the correct slice length.
+
+### Phase 6 — Remove the buffer type from the public helper surface
+
+Files:
+
+- `apps/web-platform/server/kb-binary-response.ts` (cleanup)
+
+Tasks:
+
+1. Remove the `buffer: Buffer` field from `BinaryReadResult`'s success shape. Any test that still destructures `binary.buffer` fails loudly — grep confirms only `test/shared-page-binary.test.ts` and the share-route files touch it, and both are updated in Phase 4.
+2. Ensure the only exports from `kb-binary-response.ts` remain: the types, `MAX_BINARY_SIZE`, `CONTENT_TYPE_MAP`, `ATTACHMENT_EXTENSIONS`, `formatContentDisposition`, `readBinaryFile`, `buildBinaryResponse`. No route-file exports leak.
+
+### Phase 7 — Manual benchmark (optional, local verification)
+
+Defer to post-merge if the local Doppler env isn't handy. Ship steps:
+
+1. Create a 50 MB dummy PDF in the dev workspace.
+2. Issue `autocannon -c 10 -d 30 https://soleur.ai/api/shared/<token>`, capture p99 and peak RSS.
+3. Compare against pre-merge baseline (main). Expected: RSS flat; p99 unchanged or lower.
+
+Non-blocking for the PR. If the numbers regress, open a follow-up.
+
+## Acceptance Criteria
+
+- `readBinaryFile` returns a web `ReadableStream`, `size`, `mtimeMs`, `filePath`, plus existing type/disposition fields. Type check passes.
+- `buildBinaryResponse` accepts the new shape for both full (200) and Range (206) paths; no `Buffer` in the hot path.
+- `/api/kb/content/[...path]` streams binaries with no hash check.
+- `/api/shared/[token]` preserves hash-on-first-view gate, returns 410 on mismatch, returns 200 streaming body on match, caches verdict for 60 s.
+- Second view of the same `(token, mtimeMs, size)` skips the hash (verified via spy).
+- Range request on a cached token returns 206 without a hash pass.
+- File mutation (`mtimeMs` change) invalidates the cache; next view re-hashes.
+- All existing security tests still pass (`shared-page-binary.test.ts`, `shared-token-content-hash.test.ts`, `kb-share-content-hash.test.ts`, `kb-content-hash.test.ts`).
+- `tsc --noEmit` passes. `next build` passes. `vitest run` passes.
+- No new exports added to `app/api/shared/[token]/route.ts` (rule `cq-nextjs-route-files-http-only-exports`).
+
+## Test Scenarios
+
+| Scenario | Expected |
+| --- | --- |
+| Owner GET /api/kb/content/file.pdf (full) | 200, streaming body, Content-Length matches |
+| Owner GET /api/kb/content/file.pdf with Range: bytes=0-99 | 206, Content-Length=100, Content-Range: bytes 0-99/size |
+| Shared GET first view, hash matches | 200, streaming body, cache entry set |
+| Shared GET second view, same mtime | 200, streaming body, hash NOT invoked (spy asserts) |
+| Shared GET Range, cache hit | 206, streaming body, hash NOT invoked |
+| Shared GET after file edit (new mtime) | 410, hash invoked, cache rewrites verdict for new tuple |
+| Shared GET mismatched hash (file changed post-share) | 410, no cache entry stored for mismatched hash |
+| Shared GET on revoked share | 410 (unchanged from #2463) |
+| Shared GET on legacy null-hash share | 410 (unchanged) |
+| Shared GET on symlink at stored path | 403 (O_NOFOLLOW preserved) |
+| Shared GET on null-byte path | 403 (unchanged) |
+| Shared GET on oversize file (>50 MB) | 413 (unchanged) |
+| Cache TTL expiry (advance 60 001 ms) | Next GET re-hashes |
+| Cache LRU eviction (>500 entries) | Oldest entry evicted, re-hashes on next view |
+
+## Domain Review
+
+**Domains relevant:** engineering (performance, security-adjacent).
+
+### Engineering (CTO)
+
+**Status:** reviewed
+**Assessment:** This is a performance+correctness refactor of server-side code that participates in the share-link security boundary. The fd-lifetime and O_NOFOLLOW invariants from PR #2463 must survive. The cache is in-process, bounded, with clear invalidation on file change — no new persistence surface, no cross-request state leakage across users (keyed on per-share token). No domain leaders beyond CTO apply: no UI, no copy, no marketing surface, no legal commitments, no expense.
+
+No cross-domain implications detected — internal engineering/performance change.
+
+## Non-Goals / Out of Scope
+
+- **#2309 agent-user parity:** explicitly deferred by user. Separate issue.
+- **Markdown streaming:** markdown responses stay buffered via `readContentRaw` (1 MB ceiling). A verdict cache for markdown would be a ~10 LOC addition but adds API surface; deferred unless benchmarks show hot contention.
+- **Cross-instance cache coherence:** in-process cache is fine because share-view traffic is low-cardinality and the only correctness risk (stale `verified: true` after file mutation) is eliminated by `mtimeMs+size` keying. When we scale to multi-instance, the cache is still correct per-instance; worst case is each instance re-hashes once per 60 s window.
+- **Observability dashboard for cache hit rate:** optional `stats()` method is included for a future Grafana panel; not required for this PR.
+- **Rate-limit tuning:** the `shareEndpointThrottle` gate already precedes all hash/filesystem work. No changes.
+
+## Sharp Edges / Known Gotchas
+
+- **fd lifetime with `filehandle.readableWebStream({ autoClose: true })`:** with `autoClose: true`, the fd closes automatically when the stream ends or errors. Do NOT call `handle.close()` in `finally` on the success path — that would double-close. Keep `handle.close()` only on error branches *before* `readableWebStream` is called (stat failure, oversize, non-file).
+- **Range path TOCTOU (explicitly accepted):** the Range branch opens a second fd via `fs.createReadStream(filePath, { start, end })` WITHOUT `O_NOFOLLOW`. Node's `createReadStream` does not expose that flag. This reopens a symlink-swap window between the first open (which passed `O_NOFOLLOW` + size/type guards) and the Range-branch re-open. Mitigating factors: (a) `isPathInWorkspace(fullPath, kbRoot)` is re-verified at request entry, (b) the verdict-cache path means Range requests don't require a new hash pass, (c) the same window exists on any subsequent request for the same path — this is not a new regression. If a reviewer pushes back, the alternative is opening a second `FileHandle` with `O_NOFOLLOW`, stat-on-fd, then `handle.createReadStream({ start, end })`. That's more code and the win is marginal since we still re-verify the path. Document the trade-off in the PR body.
+- **Full response + cache-miss = two disk reads.** On cache miss, we drain the first stream through `hashStream`, discard, then re-open via `fs.createReadStream(filePath)` for the actual response body. 2× I/O on miss is acceptable because misses are rare (first view of a token OR file-change events). Cache hits are 1× I/O (streaming only). This is the cost of not shipping bytes until hash verification completes, which is the correctness requirement #2463 established.
+- **Cache-miss + Range request:** rare edge case. We must hash the full file before serving any Range (otherwise a Range client could receive mismatched bytes before the hash gate runs). Implementation: on cache miss, always hash the full file first, store verdict, *then* handle the Range header. No shortcut.
+- **Test file conflict with PR #2401 learning:** keep cache singleton in `server/share-hash-verdict-cache.ts`, never co-located with `route.ts`. Phase 3 enforces this.
+- **Node stream support:** `filehandle.readableWebStream` GA in Node 20+; `Readable.toWeb` GA since Node 17. Repo targets Node 22. No flag needed.
+- **Next.js 15 + stream on Response body:** supported and documented. `new Response(readableStream, …)` on App Router Node runtime is the canonical idiom (see Next.js streaming guide — `file.readableWebStream()` example is verbatim the pattern we're using).
+- **Cloudflare / proxy buffering:** no `X-Accel-Buffering` configuration in this repo. Deploy path is Cloudflare Tunnel → Next.js Node runtime; Cloudflare proxies stream responses with `Content-Length` by default. Not a blocker; if streaming stalls on the edge, add `X-Accel-Buffering: no` to `buildBinaryResponse` headers as a follow-up.
+- **Hash-stream consumption state:** after draining through `hashStream`, the `ReadableStream` is consumed and locked. The response MUST re-open via `filePath`; do not try to re-use the locked stream.
+- **`Content-Length` still required:** `PdfPreview` progress indicator and many clients expect `Content-Length`. Already on the fstat from before the stream opens, so no extra syscall. Keep it in `buildBinaryResponse`.
+
+## References
+
+- Issue #2316 — perf(kb): stream binary responses (P1)
+- Issue #2466 — review: cache hash verdict on /api/shared/[token] for Range requests (deferred-scope-out, now scoped in)
+- PR #2463 — content-hash gate for share links (shipped earlier this session)
+- PR #2451 — added `Accept-Ranges: bytes` to `buildBinaryResponse`
+- PR #2401 — learning: Next.js route files must export only HTTP handlers + config
+- `apps/web-platform/server/kb-binary-response.ts:56–105` — `readBinaryFile` current implementation
+- `apps/web-platform/server/kb-binary-response.ts:107–166` — `buildBinaryResponse` current implementation
+- `apps/web-platform/server/kb-content-hash.ts:14–37` — `hashBytes` / `hashStream`
+- `apps/web-platform/app/api/shared/[token]/route.ts:157–191` — share-view binary branch
+- `apps/web-platform/app/api/kb/content/[...path]/route.ts:75–81` — owner binary branch
+- `knowledge-base/project/learnings/2026-04-15-kb-share-binary-files-lifecycle.md` — origin of the shared helper pattern
+- `knowledge-base/project/learnings/runtime-errors/2026-04-15-nextjs-15-route-file-non-http-exports.md` — why cache goes in its own module
+
+## Files to Modify
+
+- `apps/web-platform/server/kb-binary-response.ts` — return stream, accept stream shape
+- `apps/web-platform/server/kb-content-hash.ts` — add `hashStreamThenDiscard` (or reuse `hashStream` directly)
+- `apps/web-platform/app/api/shared/[token]/route.ts` — wire cache + stream
+- `apps/web-platform/app/api/kb/content/[...path]/route.ts` — wire stream (no cache)
+- `apps/web-platform/test/shared-page-binary.test.ts` — update for new shape, add cache tests
+- `apps/web-platform/test/shared-token-content-hash.test.ts` — extend with cache-hit/miss cases
+
+## Files to Create
+
+- `apps/web-platform/server/share-hash-verdict-cache.ts` — LRU+TTL verdict cache (singleton)
+- `apps/web-platform/test/share-hash-verdict-cache.test.ts` — unit tests for the cache
+- `apps/web-platform/test/kb-binary-response.test.ts` — unit tests for the refactored helper
+- `apps/web-platform/test/kb-content-route.test.ts` — (if not already covered) streaming + Range for owner route
+
+## Resume Prompt
+
+Run `/soleur:work knowledge-base/project/plans/2026-04-17-perf-stream-binary-responses-with-verdict-cache-plan.md`. Branch: `feat-fix-2316-stream-binary-responses`. Worktree: `.worktrees/feat-fix-2316-stream-binary-responses/`. Issues: Closes #2316, Closes #2466. Plan written and deepened — implementation starts with Phase 1 RED tests on `readBinaryFile` stream shape.

--- a/knowledge-base/project/specs/feat-fix-2316-stream-binary-responses/session-state.md
+++ b/knowledge-base/project/specs/feat-fix-2316-stream-binary-responses/session-state.md
@@ -1,0 +1,26 @@
+# Session State
+
+## Plan Phase
+
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-fix-2316-stream-binary-responses/knowledge-base/project/plans/2026-04-17-perf-stream-binary-responses-with-verdict-cache-plan.md
+- Status: complete
+
+### Errors
+
+None
+
+### Decisions
+
+- **Stream primitive:** `filehandle.readableWebStream({ autoClose: true })` as primary path (Next.js canonical). Range branch uses `Readable.toWeb(fs.createReadStream(path, { start, end }))` because `readableWebStream` doesn't accept offsets.
+- **Verdict cache:** hand-rolled `Map`-based bounded cache (~60 LOC, 500 entries, 60s TTL) matching existing `SlidingWindowCounter` pattern — no new `lru-cache` dependency.
+- **Cache singleton location:** `apps/web-platform/server/share-hash-verdict-cache.ts` — NOT in `route.ts` (avoids PR #2347/#2401 Next.js route-file-exports outage class).
+- **Owner vs share asymmetry:** `/api/kb/content/[...path]` streams unconditionally (no hash gate); only `/api/shared/[token]` hash-gates + caches.
+- **Trade-offs flagged:** Range branch re-opens fd without `O_NOFOLLOW` (Node's `createReadStream` doesn't expose it) — TOCTOU window documented; cache-miss = 2× disk I/O; cache-miss + Range still requires full-file hash before serving any Range slice.
+
+### Components Invoked
+
+- Skill: soleur:plan, soleur:deepen-plan
+- Context7 MCP: /nodejs/node, /vercel/next.js, /isaacs/node-lru-cache (evaluated, rejected)
+- Codebase inspection: kb-binary-response.ts, kb-reader.ts, kb-content-hash.ts, shared/[token]/route.ts, kb/content/[...path]/route.ts, rate-limiter.ts, shared-page-binary.test.ts
+- gh issue view: #2316, #2466
+- markdownlint-cli2

--- a/knowledge-base/project/specs/feat-fix-2316-stream-binary-responses/tasks.md
+++ b/knowledge-base/project/specs/feat-fix-2316-stream-binary-responses/tasks.md
@@ -1,0 +1,57 @@
+# Tasks — feat-fix-2316-stream-binary-responses
+
+Plan: `knowledge-base/project/plans/2026-04-17-perf-stream-binary-responses-with-verdict-cache-plan.md`
+Issues: Closes #2316, Closes #2466
+
+## Phase 1: Stream shape for readBinaryFile (RED)
+
+- [ ] 1.1 Write failing tests in `apps/web-platform/test/kb-binary-response.test.ts` for the new `{ stream, size, mtimeMs, filePath, contentType, disposition, rawName }` success shape
+- [ ] 1.2 Assert all existing error paths still return identical status codes (403/404/413)
+- [ ] 1.3 Confirm tests fail against current `buffer`-returning implementation
+
+## Phase 2: Implement stream + range (GREEN)
+
+- [ ] 2.1 Rewrite `readBinaryFile` to return `Readable.toWeb(handle.createReadStream())`
+- [ ] 2.2 Guard fd close with `handedOff` flag so the stream owns the fd after handoff
+- [ ] 2.3 Rewrite `buildBinaryResponse` to accept stream shape
+- [ ] 2.4 Full-response branch: `new Response(stream, headers)`
+- [ ] 2.5 Range branch: open a fresh `createReadStream(filePath, { start, end })`
+- [ ] 2.6 Extend tests: full 200, Range 206, malformed Range fallback to 200, out-of-range 416
+
+## Phase 3: Verdict cache module
+
+- [ ] 3.1 Write failing tests in `apps/web-platform/test/share-hash-verdict-cache.test.ts` (TTL, mtime mismatch, size mismatch, LRU eviction)
+- [ ] 3.2 Implement `server/share-hash-verdict-cache.ts` — Map-backed LRU + TTL, 500-entry bound, 60s TTL
+- [ ] 3.3 Export singleton `shareHashVerdictCache` and `__resetShareHashVerdictCacheForTest`
+- [ ] 3.4 Verify tests pass
+
+## Phase 4: Wire /api/shared/[token] to cache + stream
+
+- [ ] 4.1 Add cache lookup before hashing in share-view binary branch
+- [ ] 4.2 On cache miss: drain stream through `hashStream`, compare hash, on match write cache entry and re-open stream for response
+- [ ] 4.3 On cache hit: skip hash, call `buildBinaryResponse` directly
+- [ ] 4.4 Update `shared-page-binary.test.ts` for new shape
+- [ ] 4.5 Add cache-hit test (spy asserts hash NOT called on 2nd view)
+- [ ] 4.6 Add Range-request-on-cached-token test (206, no hash)
+- [ ] 4.7 Add post-edit invalidation test (new mtime triggers re-hash, returns 410 on mismatch)
+
+## Phase 5: Wire /api/kb/content/[...path] to stream
+
+- [ ] 5.1 Update owner route call site for new shape — no hash, no cache
+- [ ] 5.2 Add/extend test: owner full GET returns 200 streaming body with correct Content-Length
+- [ ] 5.3 Add/extend test: owner Range GET returns 206 with correct slice
+
+## Phase 6: Clean up helper surface
+
+- [ ] 6.1 Remove `buffer: Buffer` from `BinaryReadResult` success shape
+- [ ] 6.2 Grep-verify no remaining consumers
+- [ ] 6.3 Confirm `route.ts` files export only HTTP handlers (rule `cq-nextjs-route-files-http-only-exports`)
+
+## Phase 7: Verify + ship
+
+- [ ] 7.1 `tsc --noEmit` passes
+- [ ] 7.2 `vitest run` passes in `apps/web-platform`
+- [ ] 7.3 `next build` passes (validates route-file export restriction)
+- [ ] 7.4 Optional: local `autocannon` benchmark comparing RSS on main vs branch
+- [ ] 7.5 Run `/soleur:compound` to capture learnings
+- [ ] 7.6 Run `/soleur:ship` to create PR with `Closes #2316` and `Closes #2466` in body


### PR DESCRIPTION
## Summary

- Closes #2316 (P1 perf): binary responses stream via `fs.promises.open` + `handle.createReadStream` + `Readable.toWeb` instead of buffering up to 50 MB. Peak per-request RSS drops from O(file size) to O(64 KB chunk).
- Closes #2466 (deferred-scope-out): in-process hash-verdict cache for `/api/shared/[token]` keyed on `(token, ino, mtimeMs, size)` with 60s TTL + 500-entry LRU. PDF.js Range bursts no longer re-hash the full 50 MB on every request.
- Preserves the PR #2463 content-hash gate: first view hashes, subsequent views (until TTL or file mutation) stream immediately.
- Closes a TOCTOU window the naive streaming refactor would have opened: `openBinaryStream` accepts an `expected: { ino, size }` tuple and rejects rename/link swaps between validate and serve with a 410.

Closes #2316
Closes #2466

## Changelog

### Web Platform

- **Performance (KB binary):** Binary responses stream end-to-end. `readBinaryFile` was renamed to `validateBinaryFile` (it stopped reading bytes in this PR; the old name was a lie) and now returns metadata only — `{ ino, size, mtimeMs, filePath, contentType, disposition, rawName }`.
- **API (`openBinaryStream`, new):** Opens a fresh `O_NOFOLLOW` FileHandle with `autoClose: true`, optionally verifies `{ ino, size }` against the validated metadata, returns a Node `Readable`. Used by `buildBinaryResponse` for both full and Range responses.
- **API (`buildBinaryResponse`):** Now async. Opens a fresh stream per response; wraps via `Readable.toWeb` for the `Response` body. Range requests preserve the 206 / `Content-Range` / partial-length contract.
- **Security (`/api/shared/[token]`):** Hash-verdict cache in `server/share-hash-verdict-cache.ts`. First view reads the file via a fresh stream, drains through SHA-256, compares to `kb_share_links.content_sha256`, and — on match — caches the verified `(ino, mtimeMs, size)` tuple for 60 s. Subsequent views skip the hash. Cache invalidates on any tuple change (file edited, renamed, or inode-swapped). Cache is **not** promoted across workers.
- **Error handling (`BinaryOpenError`, new):** Typed error with `status` + `code`. Classifies `ENOENT → 404`, `ELOOP/EMLINK/EACCES/EPERM → 403`, `EMFILE/ENFILE → 503`, `content-changed → 404` (thrown when the `expected` tuple drifts). Route handlers map the status through directly — no more "document no longer available" for fd exhaustion.
- **Observability:** `shareHashVerdictCache.stats()` exposes `hits/misses/evictions/expirations` for future Grafana integration. Log events now include `cached: boolean` on `shared_page_viewed` so hit rate is derivable from logs today.

## Test plan

- [x] vitest: full suite green (1688 tests, +29 new for streaming + cache + TOCTOU).
- [x] typecheck clean (`tsc --noEmit`).
- [x] Next.js production build clean (`next build`).
- [x] semgrep with repo + public rule packs: 0 findings across modified files.
- [ ] ⏳ Post-merge: observe `/api/shared/[token]` p99 and peak RSS on a 50 MB PDF view session. Expect p99 flat or lower, peak RSS flat.
- [ ] ⏳ Post-merge: confirm `shareHashVerdictCache.stats()` is callable via an admin/debug endpoint (follow-up for Grafana).

## Review

Multi-agent review (security-sentinel, performance-oracle, code-quality-analyst, architecture-strategist, test-design-reviewer + semgrep) flagged a TOCTOU regression the naive refactor introduced: splitting the single held fd of the pre-PR buffered path into separate hash-open and serve-open fds opens a rename-swap window even with `O_NOFOLLOW` on both opens. Fixed inline via `ino` identity propagation. See commit `review: close TOCTOU window between validate and serve opens (P2)` for details.

Scoped out:
- **#2483** (`Refactor: extract serveBinaryWithHashGate helper after #2309 lands`) — contested-design. Only one caller today; #2309 may introduce a second. Wait for the third caller before abstracting.
- **#2468** (already open) — `Refactor: shared Supabase mock fixture for KB share tests`. PR adds one more copy of `mockShareAndOwner`; #2468 will consolidate.

## Learning

New: `knowledge-base/project/learnings/2026-04-17-stream-response-toctou-across-fd-boundary.md` — "any refactor that splits a single-fd operation into multiple fds opens a TOCTOU window; inode identity must become explicit via a pinned tuple."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
