### PR TITLE
fix(billing): align tooltip ? icons on API Usage section

### DIFF
--- a/apps/web-platform/components/settings/api-usage-info-tooltip.tsx
+++ b/apps/web-platform/components/settings/api-usage-info-tooltip.tsx
@@ -17,7 +17,7 @@ export function ApiUsageInfoTooltip({
   return (
     <details className="group relative inline-block">
       <summary
-        className="inline-flex cursor-pointer list-none items-center gap-1 rounded text-xs text-zinc-500 hover:text-zinc-700 focus:outline-none focus:ring-1 focus:ring-zinc-400 dark:text-zinc-400 dark:hover:text-zinc-200 [&::-webkit-details-marker]:hidden"
+        className="inline-flex cursor-pointer list-none items-center gap-1 whitespace-nowrap rounded text-xs text-zinc-500 hover:text-zinc-700 focus:outline-none focus:ring-1 focus:ring-zinc-400 dark:text-zinc-400 dark:hover:text-zinc-200 [&::-webkit-details-marker]:hidden"
       >
         <span
           aria-hidden="true"


### PR DESCRIPTION
## Summary

Nit reported on production after #2464 merged: the \`?\` icons beside the "What is a token?" and "Why does cost vary?" tooltip triggers don't align vertically because "Why does cost vary?" wraps to two lines in the right column of the section header, centering its \`?\` against the wrapping text.

Fix: add \`whitespace-nowrap\` to the \`<summary>\` so labels stay on one line. Both \`?\` icons now sit at the same vertical position.

## Changelog

### Web Platform

- **fix**: BYOK usage section tooltip triggers now align on one line.

## Test plan

- [x] Vitest suite pass (8/8 component tests for section).
- [ ] ⏳ Visual verification on prod after deploy.

Generated with [Claude Code](https://claude.com/claude-code)