### PR TITLE
fix: reject unrendered Liquid markers in distribution content

### DIFF
--- a/knowledge-base/marketing/distribution-content/2026-04-17-repo-connection-launch.md
+++ b/knowledge-base/marketing/distribution-content/2026-04-17-repo-connection-launch.md
@@ -24,7 +24,7 @@ What this changes:
 
 Three onboarding paths: connect an existing repo, create a new one, or skip for later.
 
-Blog post with full details: <{{ site.url }}blog/your-ai-team-works-from-your-actual-codebase/>
+Blog post with full details: <https://soleur.ai/blog/your-ai-team-works-from-your-actual-codebase/?utm_source=discord&utm_medium=community&utm_campaign=your-ai-team-works-from-your-actual-codebase>
 
 ---
 
@@ -55,7 +55,7 @@ You brief it from scratch. Every. Single. Session.
 
 Designed for founders who may not be technical. Plain language throughout.
 
-Full details: <{{ site.url }}blog/your-ai-team-works-from-your-actual-codebase/>
+Full details: <https://soleur.ai/blog/your-ai-team-works-from-your-actual-codebase/?utm_source=x&utm_medium=social&utm_campaign=your-ai-team-works-from-your-actual-codebase>
 
 <!-- markdownlint-disable-next-line MD018 -->
 #solofounder #buildinpublic
@@ -84,7 +84,7 @@ For founders without a repo yet: the onboarding flow creates one for you with a 
 
 This is the feature that makes compound knowledge practical. Without it, institutional memory was per-session. With it, every decision persists, every session builds on the last, and the AI team gets better the longer you use it.
 
-Full writeup on the engineering and the design decisions: <{{ site.url }}blog/your-ai-team-works-from-your-actual-codebase/>
+Full writeup on the engineering and the design decisions: <https://soleur.ai/blog/your-ai-team-works-from-your-actual-codebase/?utm_source=linkedin-personal&utm_medium=social&utm_campaign=your-ai-team-works-from-your-actual-codebase>
 
 <!-- markdownlint-disable-next-line MD018 -->
 #solofounder #buildinpublic
@@ -106,7 +106,7 @@ Key details:
 
 This is the infrastructure that makes Soleur's compound knowledge architecture practical. Every session builds on the last.
 
-Full details: <{{ site.url }}blog/your-ai-team-works-from-your-actual-codebase/>
+Full details: <https://soleur.ai/blog/your-ai-team-works-from-your-actual-codebase/?utm_source=linkedin-company&utm_medium=social&utm_campaign=your-ai-team-works-from-your-actual-codebase>
 
 ---
 
@@ -165,7 +165,7 @@ The pattern: write a shell script to `/tmp/git-cred-<UUID>` that echoes x-access
 
 Security hardening: randomized UUID paths prevent symlink attacks, userId UUID validation prevents path traversal, and the tokens auto-expire regardless.
 
-Full technical writeup: <{{ site.url }}blog/credential-helper-isolation-sandboxed-environments/>
+Full technical writeup: <https://soleur.ai/blog/credential-helper-isolation-sandboxed-environments/?utm_source=hackernews&utm_medium=community&utm_campaign=your-ai-team-works-from-your-actual-codebase>
 
 Context: this is part of Soleur, an open-source AI team platform. The repo connection feature lets agents operate on a founder's actual GitHub codebase with best-effort sync (pull on session start, push on session end).
 

--- a/knowledge-base/project/learnings/bug-fixes/2026-04-17-distribution-content-liquid-marker-leak.md
+++ b/knowledge-base/project/learnings/bug-fixes/2026-04-17-distribution-content-liquid-marker-leak.md
@@ -1,0 +1,72 @@
+---
+date: 2026-04-17
+category: bug-fixes
+module: content-publisher, social-distribute, lefthook
+problem_type: authoring_publishing_contract
+severity: P1
+pr_reference: "#2491"
+---
+
+# Distribution content Liquid markers leaked to Discord/X/LinkedIn (2026-04-17)
+
+## Problem
+
+The 2026-04-17 launch announcement for the repo-connection feature was posted to Discord (and X, Bluesky, LinkedIn Company) with the blog CTA showing a literal unrendered Liquid template:
+
+```text
+Blog post with full details: <{{ site.url }}blog/your-ai-team-works-from-your-actual-codebase/>
+```
+
+Instead of:
+
+```text
+Blog post with full details: https://soleur.ai/blog/your-ai-team-works-from-your-actual-codebase/
+```
+
+The same broken markup appeared in 5 section variants of `knowledge-base/marketing/distribution-content/2026-04-17-repo-connection-launch.md` and was posted verbatim to four third-party APIs on the daily cron run.
+
+## Root Cause
+
+**Authoring-to-publishing contract bug.** Three layers of trust, zero mechanical verification:
+
+1. `soleur:social-distribute` Phase 5 prompts the LLM to substitute `site.url` when assembling each platform variant. The LLM forgot / didn't, and left `{{ site.url }}` in the generated file.
+2. The cron-driven `scripts/content-publisher.sh` extracts sections verbatim and pipes them to Discord/X/LinkedIn/Bluesky webhooks. It had no sanity check that content was free of Liquid/Jinja markup.
+3. `lefthook` pre-commit had no guard on `knowledge-base/marketing/distribution-content/**/*.md` either, so a manually-authored file with markers would also slip through.
+
+Distribution content files are **NOT** Eleventy templates — they're raw third-party API payloads. There is no `site.url` render step in the pipeline between the file and the Discord webhook. `{{ site.url }}` is only valid in files under `plugins/soleur/docs/**`.
+
+## Solution
+
+**Three-layer defense-in-depth.** Matching the established pattern in `2026-03-27-skill-defense-in-depth-gate-pattern.md`:
+
+1. **Publishing-time gate (hard)** — `scripts/content-publisher.sh` now calls `validate_no_liquid_markers()` per file before channel dispatch. On any match it files a `create_liquid_marker_fallback_issue()` and leaves the file's `status: scheduled` so it retries on the next cron run once fixed. Body-only grep (post-frontmatter) via `awk '/^---$/{c++; next} c==2'`. File-relative line numbers reported via offset computed from second fence.
+
+2. **Pre-commit lint (manual authoring)** — `scripts/lint-distribution-content.sh` wired into `lefthook.yml` with glob `knowledge-base/marketing/distribution-content/*.md` (single-star; content files are flat and gobwas's `**` requires 1+ directory levels per `2026-03-21-lefthook-gobwas-glob-double-star.md`).
+
+3. **Authoring-time gate (skill-level)** — `plugins/soleur/skills/social-distribute/SKILL.md` Phase 5.5 and Phase 9 Step 5 now require the LLM to shell out to `scripts/lint-distribution-content.sh` against a temp-file copy of each variant before presenting to the user and before writing to disk. Explicit "do NOT rely on visual inspection" instruction.
+
+Both validators also strip C0/C1 control bytes and U+2028/U+2029 before echoing matched content (terminal escape injection defense) and redact `(token|secret|key|password|api_key)` patterns before embedding offender lines in a public GitHub issue body.
+
+**Remediation on the archive file:** the posted file was edited in-place to show resolved URLs with per-platform UTM tails per the social-distribute UTM mapping. The live Discord/X/LinkedIn messages were not retroactively edited (deferred — no `DISCORD_BOT_TOKEN` in Doppler; webhook edits require a message ID that `post_discord()` didn't capture because it POSTed without `?wait=true`).
+
+## Key Insight
+
+**Every pipeline seam between "LLM authored" and "third-party posted" must have mechanical validation.** The rule that covers this in general — `wg-when-a-workflow-gap-causes-a-mistake-fix` — was satisfied by fixing three definition files (skill, hook, publisher) in the same PR rather than just writing a learning. "LLM will remember" is not a control.
+
+Additional insight: persisting a **message ID sidecar** at post time (append `?wait=true` to the Discord webhook POST, capture `response.id`, write a `.posted.json` next to the `.md`) converts a future "we need to edit the broken post" incident from a Playwright scrape into a one-line `PATCH /webhooks/{id}/{token}/messages/{id}`. Not in scope for this PR; filed as a follow-up consideration.
+
+## Session Errors
+
+- **Lefthook `--files` (plural) CLI flag** — used `lefthook run pre-commit --files <path>` while verifying the new hook's glob fired. The flag is `--file` (singular, repeatable). Recovery: `lefthook run --help` revealed the correct flag. **Prevention:** Already covered by `hr-when-a-command-exits-non-zero-or-prints` (investigate before proceeding); no new rule needed — the failure was caught and resolved in under a minute.
+- **Shell redirect ordering bug in test harness** — wrote `2>&1 >/dev/null` in a bun test body intending to capture stderr only. Redirects are order-sensitive: `2>&1` points stderr to the *current* stdout (original), then `>/dev/null` points stdout to `/dev/null`. Intended capture silently produced no stderr. Recovery: removed the `>/dev/null` and captured `result.stderr` directly. **Prevention:** When capturing stderr-only in a bash snippet under a test runner, prefer `2>&1 | ...` with a single direction, or capture both streams and assert on `decode(result.stderr)` without cross-stream redirection.
+- **`sleep 5` in publisher main() blocked integration test** — bun test timed out because `main()` sleeps 5s between files (intentional rate-limit buffer). Recovery: stub `sleep() { :; }` in the test wrapper. **Prevention:** When integration-testing long-loop shell functions, stub `sleep` in the test harness alongside other mocks like `post_discord`. Added to the test file for future iterations.
+
+No workflow changes warranted: all three errors were (a) self-correcting within the session, (b) already covered by existing hard rules, or (c) specific to test-harness ergonomics that don't recur outside this file.
+
+## Cross-references
+
+- `knowledge-base/project/learnings/2026-03-27-skill-defense-in-depth-gate-pattern.md` — the canonical three-layer pattern.
+- `knowledge-base/project/learnings/2026-03-21-lefthook-gobwas-glob-double-star.md` — why the glob uses single-`*`.
+- `knowledge-base/project/learnings/2026-02-19-discord-bot-identity-and-webhook-behavior.md` — webhook edit semantics (indefinite for content, frozen identity).
+- `knowledge-base/project/learnings/2026-03-05-discord-allowed-mentions-for-webhook-sanitization.md` — `allowed_mentions` must be preserved on PATCH edits too.
+- PR #2491 — implementation.

--- a/knowledge-base/project/plans/2026-04-17-fix-discord-blog-url-template-plan.md
+++ b/knowledge-base/project/plans/2026-04-17-fix-discord-blog-url-template-plan.md
@@ -1,0 +1,427 @@
+# Fix: Discord Blog URL Rendered Liquid Template Instead of Site URL
+
+**Type:** bug
+**Severity:** P1 (community-visible broken link in published announcement)
+**Created:** 2026-04-17
+**Branch:** `feat-fix-discord-blog-url-template`
+**Worktree:** `.worktrees/feat-fix-discord-blog-url-template`
+
+## Enhancement Summary
+
+**Deepened on:** 2026-04-17
+**Sections enhanced:** Phases 1-6, Test Scenarios, Files Affected, Sharp Edges
+**Research inputs used:** institutional learnings (8 applicable), Doppler secret audit, lefthook glob semantics, Discord webhook API (v10), content-publisher code path review, existing test-convention probe
+
+### Key Improvements
+
+1. **Test convention confirmed**: `bats` is NOT installed — use `.test.sh` pattern under `plugins/soleur/test/` with shared `test-helpers.sh`. Plan now prescribes the correct path and file naming (matches learning `2026-04-14-plan-prescribed-test-framework-not-available.md`).
+2. **Discord message-edit path hardened**: confirmed no `DISCORD_BOT_TOKEN` exists in any Doppler config. The only credentials are webhook URLs. Webhook POSTs that did not use `?wait=true` return no body (message ID is not stored) — we CANNOT retrieve the already-posted message ID via API. Plan now correctly sequences: (a) future posts MUST use `?wait=true` and persist the message ID, (b) for THIS specific incident, find the ID via Playwright MCP on Discord web (keeps session open per AGENTS.md `hr-when-playwright-mcp-hits-an-auth-wall`).
+3. **Lefthook glob semantics corrected**: `gobwas` (Lefthook default) treats `**` as "1+ directories," not "0+". Content files sit flat directly in `distribution-content/` with no subdirectories — the glob MUST be `knowledge-base/marketing/distribution-content/*.md`, NOT `.../**/*.md` (otherwise the hook silently skips everything, per learning `2026-03-21-lefthook-gobwas-glob-double-star.md`).
+4. **Lefthook keyword false-positive risk acknowledged**: the existing `pre-merge-rebase.sh` PreToolUse hook broadly matches keyword strings; our new Liquid-marker linter must NOT be enforced via PreToolUse on Bash tool — it must be a standard `lefthook` command running against staged files (per learning `2026-03-19-pre-merge-hook-false-positive-on-string-content.md`).
+5. **`allowed_mentions: {parse: []}` must be preserved on edits**: confirmed in learning `2026-03-05-discord-allowed-mentions-for-webhook-sanitization.md` and already present in `post_discord()`. Phase 1.2 MUST include `allowed_mentions` in the PATCH payload too — otherwise an edit could retroactively trigger `@everyone` if the corrected content somehow contained it.
+6. **Content-publisher stderr/temp-file hardening already in place**: learning `2026-04-02-content-publisher-stderr-hardening.md` shows `_TMPFILES`/`trap EXIT`/`make_tmp()` exist (lines 45-56 of `content-publisher.sh`). Plan's new validator must use `make_tmp` for any temp files and not introduce new bare `mktemp` calls.
+7. **UTM parameter omission is an authoring-bug pattern, not just a markup bug**: learnings `2026-03-11-multi-platform-publisher-error-propagation.md` and `2026-03-14-content-publisher-channel-extension-pattern.md` both call out that authoring skills that skip steps create silent publisher failures. Phase 5.5 validation must catch BOTH Liquid markers AND missing UTMs (the latter via regex: `site\.url.*blog/.*[^&?]$` for links that have no UTM tail — TBD scope per phase 3.1 discussion).
+8. **Defense-in-depth is the right model for community-visible pipelines**: matches learning `2026-03-27-skill-defense-in-depth-gate-pattern.md` — authoring gate (Phase 3) + publishing gate (Phase 2) + pre-commit gate (Phase 4) is the canonical three-layer pattern for content that ships to third parties. Do NOT reduce to a single gate.
+
+### New Considerations Discovered
+
+- **Webhook message edit is time-bounded for identity** but NOT for content. Per learning `2026-02-19-discord-bot-identity-and-webhook-behavior.md`, `PATCH /webhooks/{id}/{token}/messages/{msg_id}` works indefinitely for content changes. Identity (username/avatar) is frozen at post time. Phase 1.2 can safely PATCH the content even days after the original post.
+- **Post-edit future incidents**: Phase 2 should ALSO modify `post_discord()` to POST with `?wait=true`, capture the response JSON, and persist `message.id` to a sidecar file (e.g., a new frontmatter field `post_message_ids:` or a parallel `.posted.json`) so future corrections do not require Playwright scraping. This is a small addition that pays for itself on the next incident.
+- **LinkedIn Company Page edit capability**: per learning `2026-04-09-linkedin-org-access-token-for-company-page-posts.md`, posting requires `LINKEDIN_ORG_ACCESS_TOKEN` (not personal). Edits via `POST /rest/posts/<urn>` with PUT semantics require the same org scope. If the existing token has `w_organization_social` but not `r_organization_social`, we may not be able to read back the post URN to PATCH it — falls back to a correction comment.
+- **Bluesky edit is impossible**: AT Protocol does not support post edits. For Bluesky, only delete-and-repost works (which loses engagement metrics). Phase 1.6 should verify the live post text before deciding; if broken, the cost/benefit of delete+repost is likely "accept the minor defect, learn forward."
+- **The already-published file status MUST stay `published`**: editing the distribution content file after cron has already consumed it does not re-trigger the publisher (because the status changed from `scheduled` to `published`). Safe to correct the archival copy without risk of duplicate posting.
+
+## Overview
+
+The 2026-04-17 repo-connection launch announcement was posted to Discord (and X, Bluesky, LinkedIn Company) with the blog CTA showing a literal unrendered Liquid template instead of a real URL:
+
+**Posted (broken):**
+
+```text
+Blog post with full details: <{{ site.url }}blog/your-ai-team-works-from-your-actual-codebase/>
+```
+
+**Expected:**
+
+```text
+Blog post with full details: https://soleur.ai/blog/your-ai-team-works-from-your-actual-codebase/
+```
+
+### Root cause
+
+`soleur:social-distribute` Phase 3 instructs the LLM to build an article URL from `site.url + path` and Phase 5 says *"Every variant must contain resolved numbers, not template syntax like `{{ stats.agents }}`"*. In this run, the LLM authored content that left `{{ site.url }}` **in the distribution content file itself** (`knowledge-base/marketing/distribution-content/2026-04-17-repo-connection-launch.md`) — 5 occurrences across Discord, X/Twitter, LinkedIn Personal, LinkedIn Company, and Hacker News sections.
+
+The cron-driven publisher (`scripts/content-publisher.sh`) then extracts those sections verbatim and posts them to Discord/X/LinkedIn/Bluesky via webhook/API. There is no intermediate template-rendering pass and no validation that content is free of Liquid/Jinja markup — so "LLM forgot to substitute" becomes "broken link in the community channel."
+
+This is a **content pipeline** bug, not an Eleventy bug. `{{ site.url }}` is valid **only** inside files processed by the Eleventy build (`plugins/soleur/docs/**`). Distribution content files are NOT Eleventy templates — they are raw posts piped to third-party APIs.
+
+### Scope of damage (already posted)
+
+The announcement has already been sent to:
+
+- **Discord #blog** (2026-04-17 cron run) — broken `{{ site.url }}` in message body
+- **X/Twitter thread** — final tweet has `<{{ site.url }}blog/...>` (thread is a chain, cannot be edited, can only be deleted or a correction replied)
+- **LinkedIn Company Page** — broken URL in body
+- **Bluesky** — section uses the bare blog URL without `{{ site.url }}` wrapper (inspection shows Bluesky section already in plain prose, may be unaffected — verify)
+- **LinkedIn Personal** and **Hacker News** sections are manual-posting-only per the skill design; check whether they were manually posted before correcting
+
+The file's status is `published` and `pr_reference: "#1257"` — the cron has already run successfully and rewritten `status: scheduled` → `status: published`.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Spec/Description claim | Codebase reality | Plan response |
+|---|---|---|
+| "Discord announcement is generated by `soleur:social-distribute`" | Confirmed: `plugins/soleur/skills/social-distribute/SKILL.md` Phase 5.1. LLM authors content at Phase 5; there is no deterministic template substitution. | Fix validation in BOTH the authoring skill (catch at generation time) and the posting pipeline (hard gate — catches stale files too). |
+| "The `{{ site.url }}` pattern is an Eleventy/11ty template variable" | Confirmed: `plugins/soleur/docs/_data/site.json` defines `url: "https://soleur.ai"`. Eleventy processes `plugins/soleur/docs/**` only. Distribution content in `knowledge-base/marketing/distribution-content/` is NOT Eleventy-processed. | The fix is not "add template rendering to the pipeline" — it is "reject Liquid markers as a bug." The content file must contain pre-resolved URLs. |
+| "CI workflow posts to Discord" | Confirmed: `.github/workflows/scheduled-content-publisher.yml` runs `scripts/content-publisher.sh` on daily 14:00 UTC cron. Discord posting is `post_discord()` in that script (lines 149-185). | Add a validation function in `content-publisher.sh` that runs before extracting sections — fail the file with a fallback issue if any section contains Liquid/Jinja markers. |
+| "retro-edit the already-posted Discord message if possible via bot/webhook" | Discord webhook messages CAN be edited via `PATCH /webhooks/{webhook.id}/{webhook.token}/messages/{message.id}` — but only if we captured the message ID. `post_discord()` does NOT capture/store message IDs (the `curl` call discards the response body in favor of the HTTP code). | Two-path remediation: (a) attempt to find the message ID via Discord API `GET /channels/{channel.id}/messages` using a bot token if available, then PATCH; (b) if no message ID path, post a brief correction reply in #blog with the working URL. Both paths are scripted, not manual. |
+
+## Goals
+
+1. **Fix the already-posted Discord message** — ideally via webhook edit (PATCH); fall back to a correction follow-up post.
+2. **Correct the archived distribution content file** so future re-reads of `knowledge-base/marketing/distribution-content/2026-04-17-repo-connection-launch.md` show the resolved URL (consistency with reality, not rewriting history).
+3. **Add a hard gate in `content-publisher.sh`** that rejects any section containing Liquid/Jinja markers (`{{`, `}}`, `{%`, `%}`) before posting — fallback issue is created, no post goes out.
+4. **Add a gate in `social-distribute` skill (Phase 5.5 — new)** that greps the generated content for the same markers and refuses to write the content file if found, forcing the LLM to regenerate with resolved values.
+5. **Add a pre-commit lint** (`lefthook` glob `knowledge-base/marketing/distribution-content/**/*.md`) that blocks commits of content files containing Liquid markers — defense in depth for manually-authored files.
+6. **Audit remaining distribution content** — one-time sweep for stale `{{`/`}}`/`{%`/`%}` in the other 14 files to prevent repeat incidents when older content is rescheduled.
+
+## Non-Goals
+
+- **Do NOT add a Liquid/Jinja rendering step to the content pipeline.** The content files are raw API payloads, not templates. Resolving `{{ site.url }}` automatically would hide the root-cause bug (LLM failed to resolve during authoring) and create a new class of failures (Liquid syntax errors, undefined variables, etc.).
+- Do NOT alter the posting behavior for non-Liquid issues (rate-limit retries, partial-thread fallback, etc.) — out of scope.
+- Do NOT delete the already-posted X thread. Thread chain cannot be restructured; a correction reply preserves social proof on the hook tweet.
+- Do NOT retro-edit the LinkedIn Company Page post if the LinkedIn API does not support edit-within-window without losing engagement metrics — a correction comment is the path. (Verify during implementation.)
+
+## Implementation Phases
+
+Phases are ordered so that remediation (urgent, community-visible) ships first, then prevention.
+
+### Phase 1 — Remediation of the posted announcement
+
+1.1 **Fix the archived distribution content file.** Hand-edit `knowledge-base/marketing/distribution-content/2026-04-17-repo-connection-launch.md`: replace every `{{ site.url }}` with the resolved `https://soleur.ai/` in the 5 occurrences (Discord, X/Twitter, LinkedIn Personal, LinkedIn Company, Hacker News sections). Keep the UTM suffixes (the current strings do not have them — verify against the UTM table in `social-distribute` SKILL.md Phase 3 and apply `?utm_source=discord&utm_medium=community&utm_campaign=your-ai-team-works-from-your-actual-codebase` etc. to each platform-specific URL).
+
+1.2 **Attempt Discord message edit.** Write a one-shot script `scripts/discord-edit-message.sh` that:
+
+- Loads `DISCORD_BLOG_WEBHOOK_URL` from Doppler (`doppler secrets get DISCORD_BLOG_WEBHOOK_URL -p soleur -c prd --plain`).
+- **No `DISCORD_BOT_TOKEN` is available** — verified via `doppler secrets --project soleur --config prd --only-names | grep -i discord`. Available: `DISCORD_OPS_WEBHOOK_URL`, `DISCORD_BLOG_WEBHOOK_URL`, `DISCORD_WEBHOOK_URL`. Without a bot token, the Discord REST API cannot list channel messages (webhooks alone cannot read a channel's message history).
+- The only automated path to retrieve the message ID is **Playwright MCP** — navigate to `https://discord.com/channels/<guild-id>/<blog-channel-id>`, wait for auth, scrape the DOM for the Sol bot message matching "Your AI team now operates on your actual codebase" and extract the `data-list-item-id` / `data-message-id` attribute. Per AGENTS.md `[id: hr-when-playwright-mcp-hits-an-auth-wall]`, keep the session open at the login wall and prompt the user to authenticate — do not close the browser and hand off a URL.
+- Given the message ID, PATCH the content: `PATCH https://discord.com/api/webhooks/{webhook.id}/{webhook.token}/messages/{message.id}` with JSON body `{"content": "<fixed content>", "allowed_mentions": {"parse": []}}`. The `allowed_mentions` field is MANDATORY on edits too — per learning `2026-03-05-discord-allowed-mentions-for-webhook-sanitization.md`, Discord re-parses mentions on PATCH, not just POST. Omitting it could retroactively ping @everyone if the corrected content contained such syntax (it doesn't in this case, but defense in depth).
+- If the PATCH succeeds (HTTP 200), print `[ok] Discord message edited`.
+- If the PATCH fails (404 = message too old or not owned by this webhook, 403 = webhook lacks permission, 429 = rate limit), fall back to Phase 1.3.
+
+### Research Insights (Phase 1.2)
+
+**Discord webhook API behavior:**
+
+- `POST /webhooks/{id}/{token}` with NO `?wait=true` query param returns HTTP 204 with an empty body. Our current `post_discord()` in `content-publisher.sh` does NOT use `?wait=true` (line 169-172 — just captures the status code). **This is why we have no message ID for the 2026-04-17 post** — it was discarded at post time.
+- `POST /webhooks/{id}/{token}?wait=true` returns HTTP 200 with the full message JSON including `id`. Phase 2 MUST change `post_discord()` to use `?wait=true` and persist the returned message ID alongside the content file. Sidecar format: write `.posted.json` next to the `.md` file with `{"discord": {"message_id": "...", "posted_at": "..."}}`.
+- `PATCH /webhooks/{id}/{token}/messages/{message.id}` works indefinitely for content. Identity (username/avatar) is frozen at original post time. Preservation confirmed in learning `2026-02-19-discord-bot-identity-and-webhook-behavior.md`.
+- **Rate limit:** Discord webhooks are limited to 30 requests per 60 seconds per channel; a single PATCH is well under. The `post_discord_warning` call on stale content (content-publisher.sh:580) shares the same bucket — avoid back-to-back corrections in rapid succession.
+- **Content length:** Edits are subject to the same 2000-char limit. The corrected content must fit. Original message was ~1100 chars; adding a UTM suffix (~60 chars) stays well under.
+
+**Playwright MCP for Discord scraping:**
+
+- The MCP `mcp__playwright__browser_navigate` works but Discord detects headless signatures on some paths. Using `--isolated` mode (per AGENTS.md `[id: cq-playwright-mcp-uses-isolated-mode-mcp]`) should bypass.
+- DOM selectors: message list items have `data-list-item-id` like `chat-messages___<message-id>` — parse with a regex after locating by text content.
+- Before calling `browser_close`, confirm the message ID was captured. Per `[id: cq-after-completing-a-playwright-task-call]`, close the session after extraction.
+
+**References:**
+
+- Discord Developer Docs — Execute Webhook: <https://discord.com/developers/docs/resources/webhook#execute-webhook>
+- Discord Developer Docs — Edit Webhook Message: <https://discord.com/developers/docs/resources/webhook#edit-webhook-message>
+
+1.3 **Fallback: post a brief correction.** If edit is not possible, post a short correction message via the same webhook:
+
+```text
+Small correction — the blog link in the prior message rendered as template syntax. Fixed link: https://soleur.ai/blog/your-ai-team-works-from-your-actual-codebase/?utm_source=discord&utm_medium=community&utm_campaign=your-ai-team-works-from-your-actual-codebase
+```
+
+1.4 **X/Twitter correction.** Reply to the last tweet in the 2026-04-17 thread (the one containing the broken URL) with a correction reply. Use the existing `plugins/soleur/skills/community/scripts/x-community.sh post-tweet --reply-to <thread-tail-id>` interface. Find the tail ID by reading the scheduled-content-publisher CI run logs from 2026-04-17 (workflow_run API); the log prints `[ok] Tweet N/M posted: https://x.com/soleur_ai/status/<id>` for each tweet. Pick the last one.
+
+1.5 **LinkedIn Company Page correction.** Invoke `plugins/soleur/skills/community/scripts/linkedin-community.sh` to either (a) delete + repost if within the edit window, or (b) post a short comment with the fixed URL. The skill may not currently expose edit/comment — if not, add a `post-comment` sub-command as part of this phase (small, scoped addition).
+
+1.6 **Bluesky inspection.** Verify Bluesky post does NOT contain `{{ site.url }}`. If it does, delete via AT Protocol `com.atproto.repo.deleteRecord` and repost. Inspection of the archived file shows the Bluesky section uses plain prose without the blog URL — likely unaffected — but verify the live post.
+
+### Phase 2 — Hard gate in content-publisher.sh (prevents future posts)
+
+2.1 **Add `validate_no_liquid_markers()` helper** in `scripts/content-publisher.sh` after `parse_frontmatter()`. Signature: accepts a file path, greps for `{{`, `}}`, `{%`, `%}` across the extracted content sections (not frontmatter — frontmatter may legitimately contain URL paths). Returns 0 if clean, 1 if any marker is found; when non-zero, prints the first 3 offending lines with context to stderr.
+
+2.2 **Call the validator in the main publish loop** before the `channel_to_section` dispatch (around line 605 of current `content-publisher.sh`): if validation fails for this file, create a `create_liquid_marker_fallback_issue()` (new helper), skip all channels for this file, treat as `file_failures++`. This gate intentionally refuses to post even if only one section is affected — all-or-nothing is safer than partial posts that the community has to reconcile.
+
+2.3 **Add a test fixture** `scripts/test/fixtures/content-publisher/liquid-markers.md` with a sample containing `{{ site.url }}` and a sibling "clean" fixture, and a new `scripts/test/content-publisher.test.sh` (bats-style or plain bash asserts, following the repo's existing convention — check whether `bats` is installed first; if not, use the `.test.sh` pattern used by other scripts/test/*.sh). Tests: (a) clean file passes validator; (b) dirty file triggers validator; (c) dirty file creates fallback issue and does NOT call `post_discord`.
+
+2.4 **Add the fallback issue creator**: `create_liquid_marker_fallback_issue()` follows the pattern of `create_discord_fallback_issue()`. Title: `[Content Publisher] Unrendered Liquid markers in <slug> — post blocked`. Body: lists offending lines with file path and line numbers, suggests fix (resolve templates in the authoring skill output), labels `action-required,content-publisher`. Milestone: default `Post-MVP / Later`.
+
+2.5 **Add `?wait=true` and persist message IDs in `post_discord()`**. Change the `curl` invocation to append `?wait=true` to the webhook URL, capture the JSON response body, extract `message.id` via `jq -r .id`, and write a sidecar file `<content-file>.posted.json` with `{"discord": {"message_id": "<id>", "posted_at": "<ISO8601>"}}`. If the sidecar exists, append (merge) rather than overwrite — the file may already have `x`, `linkedin`, etc. IDs from other publishers. This unlocks future corrections without Playwright scraping. **Cost:** ~12 lines of bash + a `jq` merge. **Benefit:** next Liquid-marker incident (or any content fix) is a one-line API call.
+
+### Research Insights (Phase 2)
+
+**Content-publisher existing patterns (must match):**
+
+- Per learning `2026-04-02-content-publisher-stderr-hardening.md`, the script uses `_TMPFILES` array + `trap EXIT` + `make_tmp()` helper. New temp files in the validator MUST use `make_tmp` — no bare `mktemp`.
+- Per learning `2026-03-26-truncate-api-error-responses-in-bash-scripts.md`, any stderr content embedded in fallback issues must be truncated (e.g., `head -c 1000` or `${var:0:1000}`) to avoid oversize issue bodies.
+- Per learning `2026-03-20-stale-content-publisher-duplicate-warnings.md`, the stale-content branch already marks files `status: stale` to prevent duplicate warnings — the new Liquid-marker branch should similarly mark the offending file (e.g., `status: blocked-liquid-markers`) so subsequent cron runs do not spam fallback issues. Alternatively, `create_dedup_issue()` already deduplicates by title — verify the dedup title includes the slug so repeated scans produce one issue, not N.
+
+**Awk/sed gotchas for frontmatter scoping:**
+
+- Per learning `2026-03-05-awk-scoping-yaml-frontmatter-shell.md`, the canonical pattern is `awk '/^---$/{c++; next} c==1'` for frontmatter and `awk '/^---$/{c++; next} c==2'` for body. Use the body-only pattern in `validate_no_liquid_markers()` to avoid false positives on frontmatter URLs (already accounted for in the plan — this insight confirms the approach).
+- Per learning `2026-03-31-awk-split-defaults-to-fs-not-whitespace.md`, if regex matching is used, anchor on literal `{{` with `index()` or `~/\\{\\{/` — do NOT use `split` for detection.
+
+**Test dependency guard:**
+
+- Per learning `2026-03-20-test-dependency-guard-pattern.md`, `scripts/test-all.sh` should gate-call the new `content-publisher.test.sh` only if `jq` is available (the validator also needs `jq`). `test-all.sh` already loops over `plugins/soleur/test/*.test.sh` — adding a file there wires it automatically.
+
+**References:**
+
+- Existing pattern in `content-publisher.sh` lines 501-523 (`create_dedup_issue`) — reuse, do not duplicate.
+- jq merge pattern for sidecar: `jq -n --slurpfile a file1 --slurpfile b file2 '$a[0] * $b[0]'` or `jq --argjson new "$NEW" '. + $new' existing.json`.
+
+### Phase 3 — Gate in social-distribute skill (catches at authoring time)
+
+3.1 **Amend `plugins/soleur/skills/social-distribute/SKILL.md`** with a new Phase 5.5 between Phase 5 (Generate All Variants) and Phase 6 (Present All Variants):
+
+```markdown
+### Phase 5.5: Marker Validation
+
+Before presenting variants (Phase 6), scan ALL generated sections for unresolved Liquid/Jinja markers:
+
+- `{{`, `}}`, `{%`, `%}`
+
+If any marker is found, do NOT proceed to Phase 6. Instead:
+
+1. Print the offending section name and the offending substring.
+2. Regenerate that section with explicit substitution of `site.url` (from `plugins/soleur/docs/_data/site.json`) and any `{{ stats.* }}` placeholders using the values from Phase 2.
+3. Re-run marker validation. If it still fails after one regeneration, STOP and surface to the user: "Auto-regeneration did not resolve Liquid markers — manual intervention required." This prevents infinite loops.
+
+The validation is mechanical — the LLM may not shortcut it. Template markers in distribution content files are always a bug: Eleventy is not in the pipeline between the content file and the Discord webhook.
+```
+
+3.2 **Amend SKILL.md Phase 9 Step 4** ("Write the content file") with a pre-write assertion: run the same marker scan on the fully-assembled file content one final time before writing to disk. Belt-and-suspenders — catches case where Phase 5.5 was somehow bypassed.
+
+3.3 **Document in SKILL.md Important Guidelines** the rationale: "Distribution content files are raw API payloads (Discord webhook content field, X tweet text, LinkedIn share text), NOT Eleventy templates. Liquid/Jinja markers in these files will be posted verbatim to third parties — a `{{ site.url }}` becomes a literal `{{ site.url }}` in the Discord message."
+
+### Research Insights (Phase 3)
+
+**Skill defense-in-depth gate pattern:**
+
+- Per learning `2026-03-27-skill-defense-in-depth-gate-pattern.md`, the established pattern for output-critical skills is: (a) inline validation before presentation, (b) re-validation at file-write, (c) pipeline-stage validation at the consumer. This plan implements all three (Phases 3.1, 3.2, 2.1).
+- Per learning `2026-03-16-linearize-multi-step-llm-prompts.md`, a single re-generation attempt (not a loop) is the correct balance. Phase 3.1 caps at one regeneration then escalates to the user — this prevents LLM-cost blow-up on pathological cases.
+
+**Template substitution — LLM vs deterministic:**
+
+- The skill currently relies on the LLM to substitute `{{ site.url }}`. A stronger design (scope-out for this plan, but file as follow-up issue) is DETERMINISTIC substitution: read `plugins/soleur/docs/_data/site.json` in Phase 2 (already being read for stats), pass the resolved URL as an explicit prompt variable, and instruct the LLM to use that string literal. This eliminates the class of bug entirely. Tracked issue: file post-merge with milestone "Post-MVP / Later", title "Deterministic URL substitution in social-distribute Phase 5".
+- Per learning `2026-03-12-llm-as-script-pattern-for-ci-file-generation.md`, LLM-authored files in CI pipelines need mechanical post-conditions, not just prompt instructions. Phase 3.1 IS that mechanical post-condition.
+
+**References:**
+
+- `plugins/soleur/skills/social-distribute/SKILL.md` Phase 3 (article URL construction — the LLM already has `site.url` in context, it just failed to substitute)
+- `plugins/soleur/docs/_data/site.json` — source of truth for `site.url` (`https://soleur.ai`)
+
+### Phase 4 — Pre-commit lint (defense in depth)
+
+4.1 **Add a `lefthook` pre-commit command** in `lefthook.yml`. CRITICAL: use a single `*` (not `**`) because the distribution content files are flat — no subdirectories. Per learning `2026-03-21-lefthook-gobwas-glob-double-star.md`, gobwas (Lefthook's default glob matcher) requires `**` to match 1+ directory levels, meaning `distribution-content/**/*.md` silently skips every file when they're flat. Verified the layout: `ls knowledge-base/marketing/distribution-content/` shows 15 flat `.md` files, no subdirectories.
+
+```yaml
+distribution-content-liquid-guard:
+  priority: 11
+  glob: "knowledge-base/marketing/distribution-content/*.md"
+  run: bash scripts/lint-distribution-content.sh {staged_files}
+```
+
+If the directory ever adds subdirectories, update to the array form: `glob: ["knowledge-base/marketing/distribution-content/*.md", "knowledge-base/marketing/distribution-content/**/*.md"]` (Lefthook 1.10.10+).
+
+4.2 **Create `scripts/lint-distribution-content.sh`** that:
+
+- Accepts one or more file paths as args.
+- For each file, reads everything between the frontmatter fences (skip the fences themselves). Use the canonical awk pattern from `content-publisher.sh`: `awk '/^---$/{c++; next} c==2' "$file"` selects body only.
+- If content contains `{{`, `}}`, `{%`, or `%}`, print `<path>:<line>: unrendered Liquid marker: <matching line>` and exit 1 at the end.
+- Frontmatter fields like `blog_url: "/blog/slug/"` are NOT Liquid and must NOT match — scope the grep to the body section only (lines after the second `---`).
+- Use `grep -nE` with a pattern anchored on literal `{{|}}|{%|%}` (escape the braces per `grep -E`) — do NOT use `awk` split, per learning `2026-03-31-awk-split-defaults-to-fs-not-whitespace.md`.
+- Exit codes: 0 = clean, 1 = found markers. NOT 2+ — lefthook treats any nonzero as failure, but tests assert 1 specifically.
+
+4.3 **Test the hook glob immediately after editing `lefthook.yml`**: run `lefthook run pre-commit --files knowledge-base/marketing/distribution-content/2026-04-17-repo-connection-launch.md` and verify the hook fires. Per learning `2026-03-21-lefthook-gobwas-glob-double-star.md`, silent "skip: no files for inspection" means the glob didn't match — catch it here, not in a PR review round-trip.
+
+4.4 **Validate against the existing corpus**: run the new lint against all 15 files in `knowledge-base/marketing/distribution-content/` before landing the hook — any pre-existing offenders must be fixed in Phase 5 (Audit).
+
+### Research Insights (Phase 4)
+
+**Lefthook gotchas (from institutional learnings):**
+
+- `2026-03-21-lefthook-gobwas-glob-double-star.md`: `**` ≠ `*` in gobwas. Always test the glob with a realistic file path BEFORE shipping the hook.
+- `2026-03-19-pre-merge-hook-false-positive-on-string-content.md`: PreToolUse hooks that do keyword matching on Bash command content produce false positives. Our linter is a pre-commit hook on FILES, not a PreToolUse hook — no risk of the same pattern. But be aware: if a linter's error message gets echoed inside a subsequent `git commit -m "..."` as a string containing `{{`, a naïve implementation could loop. The linter must only scan file contents, never commit messages.
+
+**Grep pattern robustness:**
+
+- Literal braces in `grep -E`: `{{|}}` requires escaping — use `grep -nE '\{\{|\}\}|\{%|%\}'` or the simpler `grep -nF` with multiple `-e` args: `grep -nF -e '{{' -e '}}' -e '{%' -e '%}'`. The `-F` form is safer (fixed strings, no regex surprises).
+- `grep` exits 1 if nothing matches, 0 if matches found — invert in the script: a match means FAIL, no match means PASS. Wrap with `if grep ... ; then exit 1; else exit 0; fi`.
+
+**References:**
+
+- `lefthook.yml` (existing commands for pattern — see `markdown-lint`, `kb-structure-guard`, `plugin-component-test`)
+- `scripts/lint-rule-ids.py` — existing per-file linter in the repo; mirror its CLI contract (multiple paths as positional args, exit 1 on any failure).
+
+### Phase 5 — One-time audit of remaining distribution content
+
+5.1 **Run** `bash scripts/lint-distribution-content.sh knowledge-base/marketing/distribution-content/*.md` locally (once the script is in place). Anything that fails is a latent bug — either it was posted with broken URLs and nobody noticed (check `status: published` files for Discord links) or it is still `draft`/`scheduled` and will break on the next cron run.
+
+5.2 **For each failure:**
+
+- If `status: published`: fix the file, decide whether remediation (a correction post) is warranted based on visibility. Add a note in the plan outcome if any other file had been posted broken.
+- If `status: draft` or `status: scheduled`: fix the file in place.
+- If `status: stale`: fix the file and leave it stale (not rescheduled unless the user wants it).
+
+5.3 **Commit all audit fixes in one commit** with message `fix(distribution-content): resolve unrendered Liquid markers in <N> files`.
+
+### Phase 6 — Close the loop
+
+6.1 **Open a GitHub issue** if the audit in Phase 5 finds additional posted-broken files, tracking correction posts or decisions to leave them.
+
+6.2 **Add a learning file** `knowledge-base/project/learnings/bug-fixes/2026-04-17-distribution-content-liquid-marker-leak.md` via `/soleur:compound`. Pattern: "Mechanical validation at every pipeline seam, not just authoring." This is a classic authoring-vs-publishing contract bug — the publisher trusts the author, and the author trusts the LLM.
+
+## Acceptance Criteria
+
+- [ ] The live Discord #blog message from 2026-04-17 is either edited to show the resolved URL (preferred) OR a correction reply is posted immediately after, linking to the blog post.
+- [ ] The X/Twitter thread has a correction reply appended with the resolved URL.
+- [ ] The LinkedIn Company Page post has a correction comment OR the post itself is edited, depending on API capability.
+- [ ] `knowledge-base/marketing/distribution-content/2026-04-17-repo-connection-launch.md` contains zero `{{`/`}}`/`{%`/`%}` markers in its body sections. UTM-tracked URLs are present on platform-specific sections per the social-distribute skill UTM mapping.
+- [ ] `scripts/content-publisher.sh` refuses to post any file containing Liquid markers and creates a fallback issue instead. Verified by unit test `scripts/test/content-publisher.test.sh`.
+- [ ] `plugins/soleur/skills/social-distribute/SKILL.md` has Phase 5.5 marker validation and a final-write assertion in Phase 9 Step 4.
+- [ ] `lefthook.yml` has a `distribution-content-liquid-guard` pre-commit command that blocks commits of content files containing Liquid markers. Verified by committing a test file with `{{ site.url }}` → commit is refused.
+- [ ] `scripts/lint-distribution-content.sh` exists, is executable, and has at least one test case.
+- [ ] One-time audit of all 15 existing distribution-content files is green under the new linter.
+- [ ] Learning file committed.
+
+## Test Scenarios
+
+### T1 — content-publisher.sh rejects Liquid markers (RED first)
+
+Given a fixture file `liquid-markers.md` in `plugins/soleur/test/fixtures/content-publisher/` with frontmatter `status: scheduled`, `publish_date: <today>`, `channels: discord` and a `## Discord` section containing `Blog post: <{{ site.url }}blog/test/>`,
+When the new test `plugins/soleur/test/content-publisher.test.sh` sources `content-publisher.sh` (guarded by `[[ "${BASH_SOURCE[0]}" == "${0}" ]]` — line 689), mocks `post_discord` with a recording shim, and invokes the validator,
+Then `validate_no_liquid_markers` MUST return 1 AND the recorded invocation list MUST NOT contain `post_discord` AND the fallback issue creator MUST be invoked once.
+
+**Convention:** Use `plugins/soleur/test/*.test.sh` (not `scripts/test/*.bats`) — confirmed via `command -v bats` (not installed) and `ls plugins/soleur/test/*.test.sh` (existing convention). Shared helpers at `plugins/soleur/test/test-helpers.sh`. Auto-wired into `scripts/test-all.sh`. Per learning `2026-04-14-plan-prescribed-test-framework-not-available.md`.
+
+### T2 — content-publisher.sh passes clean file
+
+Given a fixture `clean.md` with the same frontmatter and a `## Discord` section `Blog: https://soleur.ai/blog/clean/?utm_source=discord`,
+When the same invocation runs,
+Then the script MUST call `post_discord()` (or whichever channel was declared) AND MUST NOT call `create_liquid_marker_fallback_issue()`.
+
+### T3 — lint-distribution-content.sh blocks Liquid markers
+
+Given a staged file `knowledge-base/marketing/distribution-content/test-liquid.md` with `## Discord\n\nBlog: <{{ site.url }}blog/x/>`,
+When `bash scripts/lint-distribution-content.sh <that file>` is run,
+Then exit code MUST be 1 AND stderr MUST contain the file path and the offending line.
+
+### T4 — lint-distribution-content.sh allows frontmatter URL paths
+
+Given a file with frontmatter `blog_url: "/blog/x/"` and body `## Discord\n\nPlain prose, no URL`,
+When the linter runs,
+Then exit code MUST be 0 (frontmatter `blog_url` is a relative path, not a Liquid marker, and the linter must scope to body only).
+
+### T5 — social-distribute skill Phase 5.5 (manual verification)
+
+Given a manually-staged generation where the LLM produced a Discord variant containing `{{ site.url }}blog/foo/`,
+When Phase 5.5 runs,
+Then the skill MUST regenerate the offending section with a resolved URL AND MUST re-run validation before presenting variants. This is a prompt-level assertion verified by running `/soleur:social-distribute` against a crafted blog post and inspecting the generated content file.
+
+### T6 — Discord edit end-to-end
+
+Given the live #blog message from 2026-04-17 and the bot has message edit permission,
+When `scripts/discord-edit-message.sh <message-id>` is run,
+Then the message content MUST be replaced with the fixed content AND the Discord API MUST return 200 OK.
+
+### T7 — Audit pass
+
+Given all 15 distribution content files as they currently exist,
+When the linter runs against all of them,
+Then it MUST report zero failures after Phase 5 audit edits.
+
+## Domain Review
+
+**Domains relevant:** Marketing (CMO), Engineering (CTO)
+
+### Marketing (CMO)
+
+**Status:** reviewed (plan-author assessment in pipeline mode)
+**Assessment:** This is a visible-to-community defect in a launch announcement. The CMO's relevant concerns: (a) how quickly the correction reaches the same audience; (b) whether the correction preserves the value of the announcement or reads as noise. Recommendation: prefer in-place edit over a follow-up post wherever technically possible (Discord webhook edit, LinkedIn edit-window). For X/Twitter where the thread is immutable, a single concise correction reply is the minimum intrusion. Do NOT repost the full announcement — that signals greater disruption than the actual bug.
+
+### Engineering (CTO)
+
+**Status:** reviewed (plan-author assessment)
+**Assessment:** Classic pipeline-seam bug. The fix belongs at the seam — validation in `content-publisher.sh` is the hard gate (belts), validation in the authoring skill is suspenders, the pre-commit lint is defense in depth against manually-authored files. Resist the temptation to add Liquid rendering to the pipeline — it would hide future authoring bugs. Cost is ~50 lines of shell and a new lefthook entry; no architectural change.
+
+### Product/UX Gate
+
+**Tier:** NONE — no user-facing UI changes. Changes are: shell scripts, a skill instruction file, a lefthook entry, and a content file edit.
+
+## Files Affected
+
+### New files
+
+- `scripts/lint-distribution-content.sh` — pre-commit + manual linter
+- `scripts/discord-edit-message.sh` — one-shot remediation script (keep in repo for future incidents)
+- `plugins/soleur/test/content-publisher.test.sh` — publisher unit tests (CONFIRMED convention: `.test.sh` via shared `test-helpers.sh`, per learning `2026-04-14-plan-prescribed-test-framework-not-available.md` — bats not installed)
+- `plugins/soleur/test/lint-distribution-content.test.sh` — linter unit tests (same convention)
+- `plugins/soleur/test/fixtures/content-publisher/liquid-markers.md` — dirty fixture
+- `plugins/soleur/test/fixtures/content-publisher/clean.md` — clean fixture
+- `knowledge-base/project/learnings/bug-fixes/2026-04-17-distribution-content-liquid-marker-leak.md` — learning (Phase 6)
+
+### Modified files
+
+- `knowledge-base/marketing/distribution-content/2026-04-17-repo-connection-launch.md` — resolve 5 Liquid markers, add UTM parameters where the skill's UTM table prescribes them
+- `knowledge-base/marketing/distribution-content/*.md` — any additional files flagged by Phase 5 audit
+- `scripts/content-publisher.sh` — add `validate_no_liquid_markers()`, `create_liquid_marker_fallback_issue()`, invoke validator in main loop
+- `plugins/soleur/skills/social-distribute/SKILL.md` — add Phase 5.5 and Phase 9 assertion, update Important Guidelines
+- `lefthook.yml` — add `distribution-content-liquid-guard` pre-commit command
+- `plugins/soleur/skills/community/scripts/linkedin-community.sh` — add `post-comment` sub-command IF needed for Phase 1.5 (verify LinkedIn API capability first)
+
+## Alternative Approaches Considered
+
+| Approach | Pros | Cons | Decision |
+|---|---|---|---|
+| Add Liquid rendering step to `content-publisher.sh` (e.g., `sed 's|{{ site.url }}|https://soleur.ai|g'` or a minimal template engine) | Fixes the symptom for this specific variable | Hides the root cause (LLM authored broken content). New failure modes (undefined variables, escaping bugs). Doesn't cover `{% %}` tag forms. Encourages broken authoring. | Rejected. |
+| Only fix at authoring time (social-distribute skill), skip publisher gate | Smaller change | Doesn't cover manually-authored content files. Doesn't cover files authored before the fix shipped. No defense for cron-time regressions if the skill changes. | Rejected — belts AND suspenders is the right model for a published-to-community pipeline. |
+| Only add pre-commit lint, skip runtime gate | Simpler | Doesn't catch files authored via bot workflows (GitHub Actions may skip local hooks), doesn't catch LLM-generated files that bypass pre-commit (some flows write direct). | Rejected — the publisher is the last line of defense and MUST validate. |
+| Delete the Discord message and repost | Clean final state | Loses engagement (reactions, replies). Repost has a different message ID, breaks any external references. | Rejected — prefer edit, fall back to reply. |
+| Repost the entire announcement on X as a new thread | Canonical correction | Looks worse than a brief reply. Doubles the timeline noise. | Rejected — single correction reply. |
+
+## Sharp Edges and Gotchas
+
+- **Do not grep frontmatter for Liquid markers.** The frontmatter may contain `blog_url: "/blog/slug/"` which is a legitimate relative path, and future frontmatter keys may legitimately contain braces (e.g., a JSON-encoded value). Scope the grep to **content body only** — the bytes after the second `---` line.
+- **The `jq -n --arg content` payload build in `post_discord()` already JSON-escapes braces correctly.** The bug is not in Discord's rendering — it is in the source content. Discord faithfully rendered the literal string `{{ site.url }}`. Nothing about the webhook payload needs to change.
+- **X thread reply ID retrieval.** The GH Actions workflow run log from 2026-04-17 is the source of truth for the last tweet ID. Use `gh run view <run-id> --log` and grep for `Tweet N/N posted`. Do NOT attempt to use the X API to search for the thread by content — X's search index may not have it yet or may not surface it cleanly.
+- **LinkedIn edit window.** LinkedIn allows post editing for a short period after posting. If the 2026-04-17 post is outside the window, `post-comment` is the only option. Check the LinkedIn REST API before assuming edit works.
+- **Discord webhook `MESSAGES_HISTORY` permission.** Even with the webhook token, the webhook may not have permission to list channel messages. The reliable path to finding the message ID is via the Discord client with developer mode enabled (right-click → Copy Message ID). Use Playwright MCP to navigate Discord web and scrape the DOM, per `hr-when-playwright-mcp-hits-an-auth-wall` if auth is required keep the session open.
+- **Bluesky URL verification.** The live Bluesky post may differ from the file content if the content file was edited post-publish. Fetch the live AT Protocol record via `com.atproto.repo.listRecords` to confirm.
+- **UTM parameters were ALSO dropped.** The skill's Phase 3 specifies UTM tracking URLs per platform. The current content file has bare `{{ site.url }}blog/slug/` — no UTMs. Phase 1.1 must add UTMs, not just resolve the template. This is a secondary fix for the same incident.
+- **The skill currently relies on the LLM to substitute templates.** The new Phase 5.5 marker validation is necessary but not sufficient — consider whether a future improvement (out of scope here, file as issue) should have the skill DETERMINISTICALLY substitute `site.url` by reading `plugins/soleur/docs/_data/site.json` and injecting the resolved URL into the prompt context with explicit "use this value, not `{{ site.url }}`" instruction.
+
+## Rollout and Verification
+
+1. Implement phases in order 1 → 2 → 3 → 4 → 5 → 6.
+2. Phase 1 (remediation) SHOULD ship as a separate commit/PR from Phases 2-6 (prevention) — urgency differs. Acceptable to bundle if review is fast.
+3. After Phase 2 ships, verify in CI by triggering `scheduled-content-publisher.yml` manually (`gh workflow run scheduled-content-publisher.yml`) against a dry run — may require a `--dry-run` flag addition or a test fixture directory.
+4. After Phase 4 ships, verify the pre-commit hook by staging a dirty file locally and attempting to commit → expect rejection.
+5. After Phase 5 completes, run `gh workflow run scheduled-content-publisher.yml` once against main (no scheduled content for today → expect no-op) to confirm the new validator does not break clean runs.
+
+## Open Questions (resolved during deepen)
+
+- ~~Does the LinkedIn API (via `linkedin-community.sh`) support editing an existing post or commenting on one?~~ **Partially resolved:** the existing `linkedin-community.sh` only exposes `post-content` (no edit/comment sub-command). Adding `post-comment` is a Phase 1.5 sub-task if/when LinkedIn API supports it. Per learning `2026-04-09-linkedin-org-access-token-for-company-page-posts.md`, company-page operations require `LINKEDIN_ORG_ACCESS_TOKEN` with `w_organization_social` scope — verify the token has this scope before Phase 1.5. Fallback: accept the minor defect on LinkedIn (the broken URL is visible but the intent is clear).
+- ~~Does the repo use `bats` or `.test.sh`?~~ **Resolved: `.test.sh`**. `bats` is not installed (`command -v bats; echo $?` returns 1). Existing convention: `plugins/soleur/test/*.test.sh` + shared `test-helpers.sh`, auto-discovered by `scripts/test-all.sh`.
+- ~~Is there a `DISCORD_BOT_TOKEN` in Doppler?~~ **Resolved: NO.** Only `DISCORD_OPS_WEBHOOK_URL`, `DISCORD_BLOG_WEBHOOK_URL`, `DISCORD_WEBHOOK_URL` exist. Phase 1.2 must use Playwright MCP for message ID extraction. Phase 2.5 adds `?wait=true` to future posts so this is a one-time Playwright step.
+
+## Remaining Open Questions
+
+- Will the 2026-04-17 Discord message still be editable by the time this plan lands? Discord does NOT impose a time limit on webhook message edits (confirmed via API docs), but the message must still exist in the channel (not deleted by a moderator). Verify during Phase 1.2 by first fetching the message, not just assuming it's there.
+- Are the X thread tweets still visible? If the thread was deleted (accidentally or intentionally), the correction reply has no anchor. Verify before Phase 1.4.
+
+## References
+
+- `plugins/soleur/skills/social-distribute/SKILL.md` — authoring skill (Phases 3, 5, 9)
+- `scripts/content-publisher.sh` — runtime publisher (lines 149-185 for Discord, 58-69 for frontmatter parsing, 90-120 for section extraction)
+- `.github/workflows/scheduled-content-publisher.yml` — daily cron wiring
+- `knowledge-base/marketing/distribution-content/2026-04-17-repo-connection-launch.md` — the broken content file
+- `plugins/soleur/docs/_data/site.json` — `site.url` source of truth (`https://soleur.ai`)
+- `lefthook.yml` — pre-commit hook registry
+- AGENTS.md rule `[id: cq-silent-fallback-must-mirror-to-sentry]` — if the new fallback issue creator for Liquid markers ever catches an issue, consider also mirroring to Sentry since content publishers run in CI (pino → Sentry not applicable for bash scripts; Sentry CLI is optional)

--- a/knowledge-base/project/specs/feat-fix-discord-blog-url-template/session-state.md
+++ b/knowledge-base/project/specs/feat-fix-discord-blog-url-template/session-state.md
@@ -1,0 +1,22 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-fix-discord-blog-url-template/knowledge-base/project/plans/2026-04-17-fix-discord-blog-url-template-plan.md
+- Status: complete
+- Draft PR: https://github.com/jikig-ai/soleur/pull/2491
+
+### Errors
+None.
+
+### Decisions
+- Three-layer defense-in-depth: validation in `content-publisher.sh` (publishing-time hard gate) + validation in `social-distribute` SKILL.md Phase 5.5 + 9 (authoring-time gate) + pre-commit `lefthook` (manual-author gate).
+- Test framework: `.test.sh` under `plugins/soleur/test/` (repo convention), not `bats`.
+- Discord message-edit path: Playwright MCP only for the 2026-04-17 incident (no `DISCORD_BOT_TOKEN` in Doppler). Future posts mitigated by storing `message.id` via `?wait=true` so next incident is a one-line PATCH.
+- Lefthook glob must be single `*` (flat content dir), not `**` (gobwas's `**` requires dirs).
+- Remediation (fix live post) ships separately from prevention commits because urgency differs.
+
+### Components Invoked
+- skill: soleur:plan
+- skill: soleur:deepen-plan
+- 8 applicable learnings consulted
+- Doppler secret audit (prd config)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -57,6 +57,11 @@ pre-commit:
       priority: 10
       glob: "knowledge-base/**/*.md"
       run: bash scripts/generate-kb-index.sh && git add knowledge-base/INDEX.md
+    # priority 11: runs after generate-kb-index (priority 10) so the linter
+    # sees the final staged file. Single-star glob is intentional — content
+    # files are flat; gobwas's ** requires 1+ directory levels and would
+    # silently skip everything. See knowledge-base/project/learnings/
+    # 2026-03-21-lefthook-gobwas-glob-double-star.md.
     distribution-content-liquid-guard:
       priority: 11
       glob: "knowledge-base/marketing/distribution-content/*.md"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -57,3 +57,7 @@ pre-commit:
       priority: 10
       glob: "knowledge-base/**/*.md"
       run: bash scripts/generate-kb-index.sh && git add knowledge-base/INDEX.md
+    distribution-content-liquid-guard:
+      priority: 11
+      glob: "knowledge-base/marketing/distribution-content/*.md"
+      run: bash scripts/lint-distribution-content.sh {staged_files}

--- a/plugins/soleur/skills/social-distribute/SKILL.md
+++ b/plugins/soleur/skills/social-distribute/SKILL.md
@@ -215,18 +215,14 @@ Using the blog post content, stats values, article URL, and brand guide as conte
 
 Before presenting variants (Phase 6), scan every generated section for unresolved Liquid/Jinja template markers: `{{`, `}}`, `{%`, `%}`.
 
-This is a mechanical check, not an LLM judgment. Distribution content is piped to third-party APIs verbatim -- Discord webhooks, X/Twitter, LinkedIn, Bluesky. There is no Eleventy render pass between the content file and those APIs, so a literal `{{ site.url }}` becomes a literal `{{ site.url }}` in the posted message.
+You MUST run the committed linter on the assembled variant text (write it to a temp file with a minimal `---\n---\n` frontmatter preamble, then `bash scripts/lint-distribution-content.sh <tmpfile>`). Do NOT substitute an LLM visual inspection — the rule is "delegate to the deterministic tool that `lefthook` and `content-publisher.sh` both enforce against." Exit code 0 means clean; exit 1 means markers found.
 
 **Procedure:**
 
-1. For each variant section, `grep -F -e '{{' -e '}}' -e '{%' -e '%}'` across its content.
-2. If any marker is found, do NOT proceed to Phase 6. Instead:
-   - Print the offending section name and the offending substring.
-   - Regenerate that section once with explicit substitution of `site.url` (resolved value: `https://soleur.ai`) and any `{{ stats.* }}` placeholders using the values from Phase 2.
-   - Re-run marker validation.
-3. If the re-generation still produces markers, STOP and surface to the user: "Auto-regeneration did not resolve Liquid markers -- manual intervention required." Do not loop further (prevents runaway LLM cost).
-
-**Why the re-generation cap is 1:** if the LLM fails twice in a row to resolve a known-substitutable variable, the issue is in the prompt context, not randomness. Escalate to the user instead of looping.
+1. Assemble each generated variant into a `tmpfile` with a minimal frontmatter preamble.
+2. Run `bash scripts/lint-distribution-content.sh <tmpfile>`.
+3. If exit 1, do NOT proceed to Phase 6. Regenerate the offending section with explicit substitution of `site.url` (resolved value: `https://soleur.ai`) and any `{{ stats.* }}` placeholders using Phase 2 values. Re-run the linter against the new output.
+4. If the re-generation still produces markers, STOP and surface to the user: "Auto-regeneration did not resolve Liquid markers -- manual intervention required." Do not loop further.
 
 Template markers in distribution content files are always a bug.
 

--- a/plugins/soleur/skills/social-distribute/SKILL.md
+++ b/plugins/soleur/skills/social-distribute/SKILL.md
@@ -211,6 +211,25 @@ Using the blog post content, stats values, article URL, and brand guide as conte
 
 ## Approval Flow
 
+### Phase 5.5: Marker Validation (hard gate)
+
+Before presenting variants (Phase 6), scan every generated section for unresolved Liquid/Jinja template markers: `{{`, `}}`, `{%`, `%}`.
+
+This is a mechanical check, not an LLM judgment. Distribution content is piped to third-party APIs verbatim -- Discord webhooks, X/Twitter, LinkedIn, Bluesky. There is no Eleventy render pass between the content file and those APIs, so a literal `{{ site.url }}` becomes a literal `{{ site.url }}` in the posted message.
+
+**Procedure:**
+
+1. For each variant section, `grep -F -e '{{' -e '}}' -e '{%' -e '%}'` across its content.
+2. If any marker is found, do NOT proceed to Phase 6. Instead:
+   - Print the offending section name and the offending substring.
+   - Regenerate that section once with explicit substitution of `site.url` (resolved value: `https://soleur.ai`) and any `{{ stats.* }}` placeholders using the values from Phase 2.
+   - Re-run marker validation.
+3. If the re-generation still produces markers, STOP and surface to the user: "Auto-regeneration did not resolve Liquid markers -- manual intervention required." Do not loop further (prevents runaway LLM cost).
+
+**Why the re-generation cap is 1:** if the LLM fails twice in a row to resolve a known-substitutable variable, the issue is in the prompt context, not randomness. Escalate to the user instead of looping.
+
+Template markers in distribution content files are always a bug.
+
 ### Phase 6: Present All Variants
 
 Display all variants in a summary view with clear headers and character counts:
@@ -413,6 +432,12 @@ status: draft
 <bluesky content>
 ```
 
+**Step 5: Pre-write marker validation (belt-and-suspenders)**
+
+Before writing the assembled content to disk, scan the full content buffer one final time for `{{`, `}}`, `{%`, `%}`. This repeats the Phase 5.5 check against the fully assembled file (including headings, frontmatter, and inter-section transitions). If any marker is present, STOP and do not write the file. Regenerate the offending section or escalate to the user.
+
+Writing a content file that contains Liquid markers is a workflow violation -- `lefthook`'s `distribution-content-liquid-guard` will reject the commit, and if the file is somehow committed, `content-publisher.sh`'s runtime gate will refuse to post it. Catch it here so the skill does not produce a broken artifact in the first place.
+
 ### Phase 10: Summary & Next Steps
 
 Output the file path, channel status, and instructions:
@@ -448,6 +473,7 @@ Next steps:
 - If the brand guide's channel notes section is missing for a platform, generate content using only the `## Voice` section (no error)
 - If the user selects "Edit" for Discord, incorporate their feedback and regenerate -- do not present the same draft
 - Template variables in blog source (`{{ stats.agents }}` etc.) are resolved by passing current stats as LLM context -- the LLM substitutes actual values during generation
+- Distribution content files are raw API payloads (Discord webhook `content` field, X tweet text, LinkedIn share text), NOT Eleventy templates. Liquid/Jinja markers (`{{`, `}}`, `{%`, `%}`) in the body will be posted verbatim to third parties -- a `{{ site.url }}` becomes a literal `{{ site.url }}` in the Discord message. Phase 5.5 and Phase 9 Step 5 enforce this mechanically; do NOT weaken these gates
 - Markup artifacts (JSON-LD scripts, HTML details/summary tags, Nunjucks tags) in the blog source are ignored during generation -- they are meaningless in social posts
 - Missing `DISCORD_BLOG_WEBHOOK_URL` and `DISCORD_WEBHOOK_URL` does not block execution -- Discord is included in the content file's `channels` field for cron publishing
 - New content files use the blog post slug as filename. If an existing file with a numeric prefix matches the slug (e.g., `06-<slug>.md`), the existing filename is preserved

--- a/plugins/soleur/test/lint-distribution-content.test.sh
+++ b/plugins/soleur/test/lint-distribution-content.test.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+# Tests for scripts/lint-distribution-content.sh
+# Run: bash plugins/soleur/test/lint-distribution-content.test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/test-helpers.sh"
+
+REPO_ROOT="$SCRIPT_DIR/../../.."
+LINT_SCRIPT="$REPO_ROOT/scripts/lint-distribution-content.sh"
+
+echo "=== lint-distribution-content Tests ==="
+echo ""
+
+# --- Helpers ---
+TMPDIR_BASE=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+write_fixture() {
+  local name="$1"
+  local body="$2"
+  local path="$TMPDIR_BASE/$name.md"
+  {
+    echo "---"
+    echo "title: \"$name\""
+    echo "status: draft"
+    echo "---"
+    echo ""
+    echo "$body"
+  } > "$path"
+  echo "$path"
+}
+
+# --- Tests ---
+
+# Test 1: Clean file passes (exit 0)
+clean=$(write_fixture "clean" "## Discord
+
+Blog: https://soleur.ai/blog/x/?utm_source=discord")
+set +e
+bash "$LINT_SCRIPT" "$clean" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_eq "0" "$exit_code" "clean file exits 0"
+
+# Test 2: File with {{ in body fails (exit 1)
+dirty_braces=$(write_fixture "dirty-braces" "## Discord
+
+Blog: <{{ site.url }}blog/x/>")
+set +e
+stderr=$(bash "$LINT_SCRIPT" "$dirty_braces" 2>&1 >/dev/null)
+exit_code=$?
+set -e
+assert_eq "1" "$exit_code" "file with {{ exits 1"
+assert_contains "$stderr" "{{" "stderr reports offending marker"
+assert_contains "$stderr" "$dirty_braces" "stderr includes file path"
+
+# Test 3: File with {% tag %} in body fails
+dirty_tag=$(write_fixture "dirty-tag" "## Discord
+
+{% if foo %}bar{% endif %}")
+set +e
+bash "$LINT_SCRIPT" "$dirty_tag" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_eq "1" "$exit_code" "file with {% tag exits 1"
+
+# Test 4: File where Liquid-like braces appear only in frontmatter passes
+frontmatter_only="$TMPDIR_BASE/frontmatter-braces.md"
+{
+  echo "---"
+  echo "title: \"Frontmatter Braces\""
+  echo "note: \"{{ ignored }}\""
+  echo "---"
+  echo ""
+  echo "## Discord"
+  echo ""
+  echo "Clean body, no markers."
+} > "$frontmatter_only"
+set +e
+bash "$LINT_SCRIPT" "$frontmatter_only" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_eq "0" "$exit_code" "braces in frontmatter only exits 0 (body-scope)"
+
+# Test 5: Multiple files — exit 1 if any is dirty, reports all offenders
+set +e
+stderr=$(bash "$LINT_SCRIPT" "$clean" "$dirty_braces" 2>&1 >/dev/null)
+exit_code=$?
+set -e
+assert_eq "1" "$exit_code" "multi-file invocation with one dirty exits 1"
+assert_contains "$stderr" "dirty-braces" "stderr references dirty file"
+
+# Test 6: All clean files exit 0
+set +e
+bash "$LINT_SCRIPT" "$clean" "$frontmatter_only" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_eq "0" "$exit_code" "multi-file invocation all-clean exits 0"
+
+# Test 7: No arguments — exit 0 (nothing staged)
+set +e
+bash "$LINT_SCRIPT" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_eq "0" "$exit_code" "no args exits 0 (nothing to lint)"
+
+# Test 8: Missing file — error with non-zero exit
+set +e
+bash "$LINT_SCRIPT" "$TMPDIR_BASE/does-not-exist.md" >/dev/null 2>&1
+exit_code=$?
+set -e
+[[ "$exit_code" != "0" ]] && { echo "  PASS: missing file exits non-zero"; PASS=$((PASS + 1)); } \
+  || { echo "  FAIL: missing file should exit non-zero"; FAIL=$((FAIL + 1)); }
+
+print_results

--- a/plugins/soleur/test/lint-distribution-content.test.sh
+++ b/plugins/soleur/test/lint-distribution-content.test.sh
@@ -115,4 +115,72 @@ set -e
 [[ "$exit_code" != "0" ]] && { echo "  PASS: missing file exits non-zero"; PASS=$((PASS + 1)); } \
   || { echo "  FAIL: missing file should exit non-zero"; FAIL=$((FAIL + 1)); }
 
+# Test 9: Empty file (no frontmatter, no body) passes
+empty="$TMPDIR_BASE/empty.md"
+: > "$empty"
+set +e
+bash "$LINT_SCRIPT" "$empty" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_eq "0" "$exit_code" "empty file exits 0"
+
+# Test 10: File with no frontmatter fences passes when body has no markers
+no_fm="$TMPDIR_BASE/no-frontmatter.md"
+{
+  echo "# Heading only"
+  echo ""
+  echo "Prose with no braces."
+} > "$no_fm"
+set +e
+bash "$LINT_SCRIPT" "$no_fm" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_eq "0" "$exit_code" "file without frontmatter exits 0 when body is clean"
+
+# Test 11: File-relative line numbers are reported (not body-relative)
+line_test=$(write_fixture "line-test" "## Discord
+
+Blog: <{{ site.url }}blog/x/>")
+# The marker is on file line 8 (after 4-line frontmatter + blank + heading + blank),
+# not body line 3. Assert the emitted line number is file-relative.
+set +e
+stderr=$(bash "$LINT_SCRIPT" "$line_test" 2>&1 >/dev/null)
+set -e
+assert_contains "$stderr" ":8:" "file-relative line number is reported (line 8)"
+
+# Test 12: Multiple markers on separate lines — all reported
+multi=$(write_fixture "multi" "## Discord
+
+First: {{ a }}
+Second: {{ b }}")
+set +e
+stderr=$(bash "$LINT_SCRIPT" "$multi" 2>&1 >/dev/null)
+set -e
+assert_contains "$stderr" "{{ a }}" "first marker reported"
+assert_contains "$stderr" "{{ b }}" "second marker reported"
+
+# Test 13: Control bytes in offending line are stripped from stderr
+ctrl="$TMPDIR_BASE/ctrl.md"
+{
+  echo "---"
+  echo "title: \"Control\""
+  echo "---"
+  echo ""
+  echo "## Discord"
+  echo ""
+  # Write a literal ESC (0x1b) byte + OSC-like sequence alongside the marker
+  printf 'Blog: \x1b]0;hijack\x07{{ x }}\n'
+} > "$ctrl"
+set +e
+stderr=$(bash "$LINT_SCRIPT" "$ctrl" 2>&1 >/dev/null)
+set -e
+# The ESC byte (0x1b) must not appear in stderr after sanitization.
+if ! printf '%s' "$stderr" | grep -q $'\x1b'; then
+  echo "  PASS: control bytes stripped from stderr"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: stderr still contains ESC byte"
+  FAIL=$((FAIL + 1))
+fi
+
 print_results

--- a/scripts/content-publisher.sh
+++ b/scripts/content-publisher.sh
@@ -82,19 +82,33 @@ get_frontmatter_field() {
 # relative URL paths, etc.) and are never posted to third parties directly.
 #
 # Returns 0 if clean, 1 if any marker is found. Prints offending lines to
-# stderr in `<file>:<body-relative-line>: unrendered Liquid marker: <line>`
-# format.
+# stderr in `<file>:<file-relative-line>: unrendered Liquid marker: <content>`
+# format (matches scripts/lint-distribution-content.sh for operator grepability).
+
+# Strip C0/C1 control bytes and Unicode line separators (U+2028/U+2029).
+# Content bytes from third-party markdown flow into stderr and issue bodies;
+# escape sequences in those bytes can rewrite terminal titles, inject cursor
+# control in CI logs, or trigger OSC 52 clipboard hijack. echo (no -e) does
+# not interpret them, but many terminals do on raw output.
+_liquid_strip_controls() {
+  printf '%s' "$1" | LC_ALL=C tr -d '\000-\010\013\014\016-\037\177' | sed 's/\xe2\x80\xa8//g; s/\xe2\x80\xa9//g'
+}
+
 validate_no_liquid_markers() {
   local file="$1"
-  local body offenders
+  local body offenders offset
 
-  # Select body only (lines after the second `---`), then grep for any of the
-  # four Liquid/Jinja delimiters as fixed strings. `grep -n` prints line numbers
-  # that are body-relative, which is enough to locate the offender within the
-  # section the LLM authored.
   body=$(awk '/^---$/{c++; next} c==2' "$file")
   if [[ -z "$body" ]]; then
     return 0
+  fi
+
+  # Offset = line number of the second `---` in the source file. grep -n
+  # against the body gives body-relative numbers; adding offset yields
+  # file-relative numbers that a human can open directly in an editor.
+  offset=$(awk '/^---$/{c++; if (c==2) { print NR; exit } }' "$file")
+  if [[ -z "$offset" ]]; then
+    offset=0
   fi
 
   offenders=$(printf '%s\n' "$body" | grep -nF -e '{{' -e '}}' -e '{%' -e '%}' || true)
@@ -102,22 +116,39 @@ validate_no_liquid_markers() {
     return 0
   fi
 
-  while IFS= read -r line; do
-    echo "$file:$line: unrendered Liquid marker: ${line#*:}" >&2
+  local hit body_lineno content file_lineno safe_content
+  while IFS= read -r hit; do
+    body_lineno="${hit%%:*}"
+    content="${hit#*:}"
+    file_lineno=$((body_lineno + offset))
+    safe_content=$(_liquid_strip_controls "$content")
+    echo "$file:$file_lineno: unrendered Liquid marker: $safe_content" >&2
   done <<< "$offenders"
   return 1
+}
+
+# Redact token-like values before embedding offending lines in a public
+# GitHub issue body. Heuristic only — catches the common case of an
+# authoring mistake that embeds a secret via template syntax.
+_liquid_redact_secrets() {
+  sed -E 's/((token|secret|key|password|api[_-]?key)[[:space:]]*[:=][[:space:]]*)[^[:space:]"]+/\1[REDACTED]/gi'
 }
 
 create_liquid_marker_fallback_issue() {
   local file="$1"
   local offenders="${2:-}"
-  local base
+  local base safe_offenders
   base=$(basename "$file" .md)
+
+  # Sanitize offender content before embedding in a public issue body:
+  # strip control bytes, redact token-like values, escape triple-backticks
+  # that would terminate the fenced code block.
+  safe_offenders=$(_liquid_strip_controls "$offenders" | _liquid_redact_secrets | sed 's/```/`\xe2\x80\x8b``/g')
 
   local title="[Content Publisher] Unrendered Liquid markers in $base -- post blocked"
   local offender_section=""
-  if [[ -n "$offenders" ]]; then
-    offender_section=$(printf '\n\n**Offending lines:**\n```\n%s\n```' "${offenders:0:1500}")
+  if [[ -n "$safe_offenders" ]]; then
+    offender_section=$(printf '\n\n**Offending lines:**\n```\n%s\n```' "${safe_offenders:0:1500}")
   fi
   local body
   body=$(printf '## Unrendered Liquid Markers Detected\n\nThe content publisher refused to post **%s** because its body contains one or more Liquid/Jinja template markers (`{{`, `}}`, `{%%`, `%%}`).%s\n\nDistribution content is piped to third-party APIs verbatim — template markers are never resolved. Fix the source file, re-set `status: scheduled`, and the next cron run will publish.' \

--- a/scripts/content-publisher.sh
+++ b/scripts/content-publisher.sh
@@ -69,6 +69,63 @@ get_frontmatter_field() {
   parse_frontmatter "$file" | grep "^${field}:" | sed "s/^${field}: *//" | sed 's/^"\(.*\)"$/\1/' || true
 }
 
+# --- Liquid Marker Validation ---
+#
+# Distribution content files are raw API payloads (Discord webhook content,
+# X tweet text, LinkedIn share text) — NOT Eleventy templates. Any Liquid/Jinja
+# marker in a body section will be posted verbatim to third parties. This
+# validator rejects files containing such markers before the publish loop
+# dispatches to any channel.
+#
+# Scope: body only (bytes after the second `---`). Frontmatter fields are
+# exempt because they may legitimately contain braces (JSON-encoded values,
+# relative URL paths, etc.) and are never posted to third parties directly.
+#
+# Returns 0 if clean, 1 if any marker is found. Prints offending lines to
+# stderr in `<file>:<body-relative-line>: unrendered Liquid marker: <line>`
+# format.
+validate_no_liquid_markers() {
+  local file="$1"
+  local body offenders
+
+  # Select body only (lines after the second `---`), then grep for any of the
+  # four Liquid/Jinja delimiters as fixed strings. `grep -n` prints line numbers
+  # that are body-relative, which is enough to locate the offender within the
+  # section the LLM authored.
+  body=$(awk '/^---$/{c++; next} c==2' "$file")
+  if [[ -z "$body" ]]; then
+    return 0
+  fi
+
+  offenders=$(printf '%s\n' "$body" | grep -nF -e '{{' -e '}}' -e '{%' -e '%}' || true)
+  if [[ -z "$offenders" ]]; then
+    return 0
+  fi
+
+  while IFS= read -r line; do
+    echo "$file:$line: unrendered Liquid marker: ${line#*:}" >&2
+  done <<< "$offenders"
+  return 1
+}
+
+create_liquid_marker_fallback_issue() {
+  local file="$1"
+  local offenders="${2:-}"
+  local base
+  base=$(basename "$file" .md)
+
+  local title="[Content Publisher] Unrendered Liquid markers in $base -- post blocked"
+  local offender_section=""
+  if [[ -n "$offenders" ]]; then
+    offender_section=$(printf '\n\n**Offending lines:**\n```\n%s\n```' "${offenders:0:1500}")
+  fi
+  local body
+  body=$(printf '## Unrendered Liquid Markers Detected\n\nThe content publisher refused to post **%s** because its body contains one or more Liquid/Jinja template markers (`{{`, `}}`, `{%%`, `%%}`).%s\n\nDistribution content is piped to third-party APIs verbatim — template markers are never resolved. Fix the source file, re-set `status: scheduled`, and the next cron run will publish.' \
+    "$base" "$offender_section")
+
+  create_dedup_issue "$title" "$body" "action-required,content-publisher"
+}
+
 # --- Channel Mapping ---
 
 # Maps channel name from frontmatter to section heading in content file.
@@ -596,6 +653,19 @@ main() {
 
     echo "---"
     echo "Publishing: $CASE_NAME ($(basename "$file"))"
+
+    # Hard gate: reject any file whose body contains unrendered Liquid/Jinja
+    # markers. Distribution content is posted verbatim to third parties — a
+    # stray `{{ site.url }}` becomes a literal `{{ site.url }}` in the
+    # Discord message. Skip all channels for this file and file a fallback
+    # issue so the broken content is tracked, not lost.
+    local liquid_offenders
+    if ! liquid_offenders=$(validate_no_liquid_markers "$file" 2>&1 1>/dev/null); then
+      echo "Error: Unrendered Liquid markers detected. Skipping all channels for this file." >&2
+      create_liquid_marker_fallback_issue "$file" "$liquid_offenders" || true
+      failures=$((failures + 1))
+      continue
+    fi
 
     local file_failures=0
     local file_successes=0

--- a/scripts/lint-distribution-content.sh
+++ b/scripts/lint-distribution-content.sh
@@ -16,6 +16,14 @@
 
 set -euo pipefail
 
+# Strip C0/C1 control bytes and Unicode line separators (U+2028/U+2029) from
+# content bytes before echoing to stderr. Content files are third-party
+# markdown; escape sequences can rewrite terminal titles or inject cursor
+# control in CI logs on raw output.
+_strip_controls() {
+  printf '%s' "$1" | LC_ALL=C tr -d '\000-\010\013\014\016-\037\177' | sed 's/\xe2\x80\xa8//g; s/\xe2\x80\xa9//g'
+}
+
 if [[ $# -eq 0 ]]; then
   exit 0
 fi
@@ -29,6 +37,9 @@ for file in "$@"; do
     missing_file=1
     continue
   fi
+
+  # Declared here so ShellCheck doesn't flag them as unset below.
+  body="" offset="" offenders="" hit="" body_lineno="" content="" file_lineno="" safe_content=""
 
   # Body only: bytes after the second `---`. Frontmatter may legitimately
   # contain brace-like strings (JSON-encoded values, URL paths); never posted.
@@ -53,7 +64,8 @@ for file in "$@"; do
     body_lineno="${hit%%:*}"
     content="${hit#*:}"
     file_lineno=$((body_lineno + offset))
-    echo "$file:$file_lineno: unrendered Liquid marker: $content" >&2
+    safe_content=$(_strip_controls "$content")
+    echo "$file:$file_lineno: unrendered Liquid marker: $safe_content" >&2
   done <<< "$offenders"
   found_markers=1
 done

--- a/scripts/lint-distribution-content.sh
+++ b/scripts/lint-distribution-content.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# lint-distribution-content.sh -- reject distribution content files whose body
+# contains unrendered Liquid/Jinja template markers ({{, }}, {%, %}).
+#
+# Distribution content is piped to third-party APIs verbatim (Discord webhook,
+# X/Twitter, LinkedIn, Bluesky). Template markers in the body will be posted
+# as literal text. This linter runs both as a lefthook pre-commit guard on
+# knowledge-base/marketing/distribution-content/*.md and on-demand for audits.
+#
+# Usage: lint-distribution-content.sh <file> [<file> ...]
+#
+# Exit codes:
+#   0 - All files clean (or no files provided)
+#   1 - At least one file contains Liquid markers in body
+#   2 - A provided path does not exist or is not readable
+
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+  exit 0
+fi
+
+found_markers=0
+missing_file=0
+
+for file in "$@"; do
+  if [[ ! -f "$file" ]]; then
+    echo "lint-distribution-content: file not found: $file" >&2
+    missing_file=1
+    continue
+  fi
+
+  # Body only: bytes after the second `---`. Frontmatter may legitimately
+  # contain brace-like strings (JSON-encoded values, URL paths); never posted.
+  body=$(awk '/^---$/{c++; next} c==2' "$file")
+  if [[ -z "$body" ]]; then
+    continue
+  fi
+
+  # Count body lines consumed by awk so we can report file-relative numbers.
+  # We compute the offset = (number of lines up to and including the second `---`).
+  offset=$(awk '/^---$/{c++; if (c==2) { print NR; exit } }' "$file")
+  if [[ -z "$offset" ]]; then
+    offset=0
+  fi
+
+  offenders=$(printf '%s\n' "$body" | grep -nF -e '{{' -e '}}' -e '{%' -e '%}' || true)
+  if [[ -z "$offenders" ]]; then
+    continue
+  fi
+
+  while IFS= read -r hit; do
+    body_lineno="${hit%%:*}"
+    content="${hit#*:}"
+    file_lineno=$((body_lineno + offset))
+    echo "$file:$file_lineno: unrendered Liquid marker: $content" >&2
+  done <<< "$offenders"
+  found_markers=1
+done
+
+if [[ "$missing_file" -eq 1 && "$found_markers" -eq 0 ]]; then
+  exit 2
+fi
+if [[ "$found_markers" -eq 1 ]]; then
+  exit 1
+fi
+exit 0

--- a/test/content-publisher.test.ts
+++ b/test/content-publisher.test.ts
@@ -730,3 +730,240 @@ MOCK
     expect(decode(result.stderr)).toContain("Bluesky posting failed");
   });
 });
+
+// ---------------------------------------------------------------------------
+// validate_no_liquid_markers
+// ---------------------------------------------------------------------------
+
+describe("validate_no_liquid_markers", () => {
+  function writeFixture(frontmatter: string, body: string): string {
+    const path = `/tmp/liquid-fixture-${Math.random().toString(36).slice(2)}.md`;
+    const content = `---\n${frontmatter}\n---\n\n${body}\n`;
+    Bun.write(path, content);
+    return path;
+  }
+
+  test("returns 0 for file with clean body", () => {
+    const result = Bun.spawnSync(["bash", "-c", `
+      set -euo pipefail
+      source '${SCRIPT_PATH}'
+      tmpfile=$(mktemp)
+      cat > "$tmpfile" <<'EOF'
+---
+title: "Clean"
+status: scheduled
+---
+
+## Discord
+
+Blog post: https://soleur.ai/blog/x/?utm_source=discord
+EOF
+      validate_no_liquid_markers "$tmpfile"
+      exit_code=$?
+      rm -f "$tmpfile"
+      exit $exit_code
+    `], { env: BASE_ENV });
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("returns 1 for file with {{ in body", () => {
+    const result = Bun.spawnSync(["bash", "-c", `
+      set -euo pipefail
+      source '${SCRIPT_PATH}'
+      tmpfile=$(mktemp)
+      cat > "$tmpfile" <<'EOF'
+---
+title: "Dirty"
+status: scheduled
+---
+
+## Discord
+
+Blog post: <{{ site.url }}blog/x/>
+EOF
+      set +e
+      validate_no_liquid_markers "$tmpfile"
+      exit_code=$?
+      set -e
+      rm -f "$tmpfile"
+      exit $exit_code
+    `], { env: BASE_ENV });
+    expect(result.exitCode).toBe(1);
+    expect(decode(result.stderr)).toContain("unrendered Liquid marker");
+    expect(decode(result.stderr)).toContain("{{ site.url }}");
+  });
+
+  test("returns 1 for file with {% tag %} in body", () => {
+    const result = Bun.spawnSync(["bash", "-c", `
+      set -euo pipefail
+      source '${SCRIPT_PATH}'
+      tmpfile=$(mktemp)
+      cat > "$tmpfile" <<'EOF'
+---
+title: "Dirty Tag"
+---
+
+## Discord
+
+{% if foo %}bar{% endif %}
+EOF
+      set +e
+      validate_no_liquid_markers "$tmpfile"
+      exit_code=$?
+      set -e
+      rm -f "$tmpfile"
+      exit $exit_code
+    `], { env: BASE_ENV });
+    expect(result.exitCode).toBe(1);
+    expect(decode(result.stderr)).toContain("unrendered Liquid marker");
+  });
+
+  test("returns 0 when Liquid-like braces appear only in frontmatter keys", () => {
+    // Frontmatter may contain URL-like paths or JSON-encoded values with braces.
+    // The validator must scope to body-only to avoid false positives.
+    const result = Bun.spawnSync(["bash", "-c", `
+      set -euo pipefail
+      source '${SCRIPT_PATH}'
+      tmpfile=$(mktemp)
+      cat > "$tmpfile" <<'EOF'
+---
+title: "Frontmatter Braces"
+note: "{{ ignored }}"
+---
+
+## Discord
+
+Clean body content, no markers.
+EOF
+      validate_no_liquid_markers "$tmpfile"
+      exit_code=$?
+      rm -f "$tmpfile"
+      exit $exit_code
+    `], { env: BASE_ENV });
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("reports file path and line number in stderr", () => {
+    const result = Bun.spawnSync(["bash", "-c", `
+      set -euo pipefail
+      source '${SCRIPT_PATH}'
+      tmpfile=$(mktemp)
+      cat > "$tmpfile" <<'EOF'
+---
+title: "Line Test"
+---
+
+## Discord
+
+Line one clean.
+Line two: {{ bad }}
+EOF
+      set +e
+      validate_no_liquid_markers "$tmpfile"
+      set -e
+      rm -f "$tmpfile"
+    `], { env: BASE_ENV });
+    const stderr = decode(result.stderr);
+    expect(stderr).toContain("{{ bad }}");
+  });
+
+  // Use the sample-content-with-markers fixture (path reuse for sanity)
+  test("integration: existing SAMPLE_CONTENT (clean) passes validator", () => {
+    const result = runFunction(
+      `validate_no_liquid_markers "${SAMPLE_CONTENT}"`
+    );
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Main loop integration: Liquid-marker gate blocks posting
+// ---------------------------------------------------------------------------
+
+describe("main loop Liquid-marker gate", () => {
+  test("main() skips channel posting and calls create_liquid_marker_fallback_issue when body has markers", () => {
+    const result = Bun.spawnSync(["bash", "-c", `
+      set -euo pipefail
+
+      # Build an isolated content dir with a dirty file scheduled for today
+      tmpdir=$(mktemp -d)
+      today=$(date +%Y-%m-%d)
+      cat > "$tmpdir/dirty.md" <<EOF
+---
+title: "Dirty Fixture"
+type: feature-launch
+publish_date: "$today"
+channels: discord
+status: scheduled
+---
+
+## Discord
+
+Blog: <{{ site.url }}blog/x/>
+EOF
+
+      # Run the publisher with CONTENT_DIR pointed at our temp dir by sourcing
+      # and mocking the helpers that touch the outside world.
+      source '${SCRIPT_PATH}'
+      CONTENT_DIR="$tmpdir"
+
+      # Stubs — must be exported and defined AFTER sourcing so they override.
+      post_discord() { echo "[mock] post_discord called" ; return 0; }
+      create_liquid_marker_fallback_issue() { echo "[mock] fallback_issue: \$1" ; return 0; }
+      create_dedup_issue() { echo "[mock] dedup_issue: \$1" ; return 0; }
+      post_discord_warning() { return 0; }
+      sleep() { :; }
+
+      export DISCORD_BLOG_WEBHOOK_URL="https://example.invalid/webhook"
+
+      main 2>&1 || true
+      rm -rf "$tmpdir"
+    `], { env: BASE_ENV });
+
+    const combined = decode(result.stdout) + decode(result.stderr);
+    // Post MUST be blocked
+    expect(combined).not.toContain("[mock] post_discord called");
+    // Fallback issue MUST be created
+    expect(combined).toContain("[mock] fallback_issue:");
+  });
+
+  test("main() proceeds to post when body is clean", () => {
+    const result = Bun.spawnSync(["bash", "-c", `
+      set -euo pipefail
+
+      tmpdir=$(mktemp -d)
+      today=$(date +%Y-%m-%d)
+      cat > "$tmpdir/clean.md" <<EOF
+---
+title: "Clean Fixture"
+type: feature-launch
+publish_date: "$today"
+channels: discord
+status: scheduled
+---
+
+## Discord
+
+Blog: https://soleur.ai/blog/x/?utm_source=discord
+EOF
+
+      source '${SCRIPT_PATH}'
+      CONTENT_DIR="$tmpdir"
+
+      post_discord() { echo "[mock] post_discord called with: \$1" ; return 0; }
+      create_liquid_marker_fallback_issue() { echo "[mock] fallback_issue: should not be called" ; return 0; }
+      create_dedup_issue() { return 0; }
+      post_discord_warning() { return 0; }
+      sleep() { :; }
+
+      export DISCORD_BLOG_WEBHOOK_URL="https://example.invalid/webhook"
+
+      main 2>&1 || true
+      rm -rf "$tmpdir"
+    `], { env: BASE_ENV });
+
+    const combined = decode(result.stdout) + decode(result.stderr);
+    expect(combined).toContain("[mock] post_discord called");
+    expect(combined).not.toContain("[mock] fallback_issue:");
+  });
+});

--- a/test/content-publisher.test.ts
+++ b/test/content-publisher.test.ts
@@ -736,13 +736,6 @@ MOCK
 // ---------------------------------------------------------------------------
 
 describe("validate_no_liquid_markers", () => {
-  function writeFixture(frontmatter: string, body: string): string {
-    const path = `/tmp/liquid-fixture-${Math.random().toString(36).slice(2)}.md`;
-    const content = `---\n${frontmatter}\n---\n\n${body}\n`;
-    Bun.write(path, content);
-    return path;
-  }
-
   test("returns 0 for file with clean body", () => {
     const result = Bun.spawnSync(["bash", "-c", `
       set -euo pipefail
@@ -873,6 +866,89 @@ EOF
       `validate_no_liquid_markers "${SAMPLE_CONTENT}"`
     );
     expect(result.exitCode).toBe(0);
+  });
+
+  test("returns 0 for empty file (no frontmatter, no body)", () => {
+    const result = Bun.spawnSync(["bash", "-c", `
+      set -euo pipefail
+      source '${SCRIPT_PATH}'
+      tmpfile=$(mktemp)
+      : > "$tmpfile"
+      validate_no_liquid_markers "$tmpfile"
+      exit_code=$?
+      rm -f "$tmpfile"
+      exit $exit_code
+    `], { env: BASE_ENV });
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("returns 0 for file with no frontmatter (no `---` fences)", () => {
+    const result = Bun.spawnSync(["bash", "-c", `
+      set -euo pipefail
+      source '${SCRIPT_PATH}'
+      tmpfile=$(mktemp)
+      cat > "$tmpfile" <<'EOF'
+# Just a heading
+
+Prose with no braces.
+EOF
+      validate_no_liquid_markers "$tmpfile"
+      exit_code=$?
+      rm -f "$tmpfile"
+      exit $exit_code
+    `], { env: BASE_ENV });
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("reports file-relative line numbers, not body-relative", () => {
+    // Marker is on file line 8, body line 2 — validator must emit 8.
+    const result = Bun.spawnSync(["bash", "-c", `
+      set -euo pipefail
+      source '${SCRIPT_PATH}'
+      tmpfile=$(mktemp)
+      cat > "$tmpfile" <<'EOF'
+---
+title: "Line Number Test"
+status: scheduled
+---
+
+## Discord
+
+Blog: <{{ site.url }}blog/x/>
+EOF
+      set +e
+      validate_no_liquid_markers "$tmpfile" 2>&1 >/dev/null | head -1
+      set -e
+      rm -f "$tmpfile"
+    `], { env: BASE_ENV });
+    const stderr = decode(result.stderr) + decode(result.stdout);
+    // File-relative line 8 should appear, body-relative 2 alone should not.
+    expect(stderr).toMatch(/:8:/);
+  });
+
+  test("reports multiple markers on separate lines", () => {
+    const result = Bun.spawnSync(["bash", "-c", `
+      set -euo pipefail
+      source '${SCRIPT_PATH}'
+      tmpfile=$(mktemp)
+      cat > "$tmpfile" <<'EOF'
+---
+title: "Multi"
+---
+
+## Discord
+
+First marker: {{ a }}
+Second marker: {{ b }}
+EOF
+      set +e
+      validate_no_liquid_markers "$tmpfile"
+      set -e
+      rm -f "$tmpfile"
+    `], { env: BASE_ENV });
+    const stderr = decode(result.stderr);
+    expect(stderr).toContain("{{ a }}");
+    expect(stderr).toContain("{{ b }}");
   });
 });
 


### PR DESCRIPTION
## Summary

- Add three-layer defense-in-depth against Liquid/Jinja template markers leaking from distribution content into third-party API posts (Discord webhook, X, LinkedIn, Bluesky).
- Fix the 2026-04-17 launch announcement archive file where `{{ site.url }}` shipped as literal text to the community.
- Capture the authoring-to-publishing contract bug as a learning for future feature design.

## Why

On 2026-04-17 the repo-connection launch announcement was posted to Discord with the blog CTA rendered as literal Liquid template text: `<{{ site.url }}blog/your-ai-team-works-from-your-actual-codebase/>`. Root cause: `soleur:social-distribute` relies on the LLM to substitute `site.url` during authoring, `content-publisher.sh` trusts the authoring skill, and nothing in between mechanically verifies the bytes piped to webhook APIs. Distribution content files are NOT Eleventy templates — there is no render pass between the file and the third-party API.

## Changelog

### Plugin

- **social-distribute skill**: new Phase 5.5 marker validation (shell out to committed linter) and Phase 9 Step 5 pre-write assertion; rationale added to Important Guidelines.
- **new test**: `plugins/soleur/test/lint-distribution-content.test.sh` (17 cases) — auto-discovered by `scripts/test-all.sh`.
- **lefthook**: new `distribution-content-liquid-guard` pre-commit command with flat glob `knowledge-base/marketing/distribution-content/*.md` (gobwas single-star; see learning 2026-03-21).

### Scripts

- **content-publisher.sh**: new `validate_no_liquid_markers()` runs before channel dispatch in `main()`. On any match, creates a `create_liquid_marker_fallback_issue()` and skips the file, leaving `status: scheduled` so the next cron run retries after the fix. Offender content is control-byte-stripped and secret-redacted before embedding in the public GitHub issue body.
- **new**: `scripts/lint-distribution-content.sh` — pre-commit and on-demand linter; body-only grep, file-relative line numbers, exit 0/1/2 contract.

### Content

- **2026-04-17 launch announcement**: resolved 5 `{{ site.url }}` occurrences and added per-platform UTM tails (Discord/X/LinkedIn Personal/LinkedIn Company/Hacker News) per the social-distribute UTM mapping.

### Learning

- **`knowledge-base/project/learnings/bug-fixes/2026-04-17-distribution-content-liquid-marker-leak.md`**: captured root cause, three-layer fix, and session errors (lefthook CLI flag confusion, shell redirect ordering bug, `sleep` stub requirement for integration tests).

## Test plan

- [x] 62 bun tests pass (8 new for validator + main-loop gate, 4 additional edge cases for empty file / no frontmatter / file-relative line numbers / multiple markers).
- [x] 17 bash tests pass (11 original + 5 edge cases + 1 control-byte sanitization).
- [x] Full `bash scripts/test-all.sh` passes (16/16 suites).
- [x] Markdownlint clean on changed `.md` files.
- [x] Linter run against all 15 existing `knowledge-base/marketing/distribution-content/*.md` files → clean.
- [x] Lefthook glob fires: `lefthook run pre-commit --file knowledge-base/marketing/distribution-content/2026-04-17-repo-connection-launch.md --command distribution-content-liquid-guard` invokes the linter.
- [x] End-to-end: a dirty file with `{{ site.url }}` passed to the linter exits 1 with file:line:content stderr; content-publisher's main-loop gate (integration test with mocked channel dispatch) verifies post_discord is not called and a fallback issue is created.

Live Discord/X/LinkedIn posts are NOT retroactively edited — no `DISCORD_BOT_TOKEN` is in Doppler and `post_discord()` did not capture message IDs (no `?wait=true`). Adding `?wait=true` + sidecar persistence is filed as a follow-up consideration in the plan; not in scope for this PR.

Generated with [Claude Code](https://claude.com/claude-code)