### PR TITLE
fix(kb): sync chat trigger label with current document

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/kb/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/kb/layout.tsx
@@ -235,6 +235,31 @@ export default function KbLayout({ children }: { children: ReactNode }) {
     closeSidebar();
   }, [contextPath, closeSidebar]);
 
+  // Prefetch message count for the current document so the toolbar trigger
+  // shows "Continue thread" vs "Ask about this document" accurately even
+  // while the chat panel is closed. Without this, messageCount stays stale
+  // from the previously-mounted ChatSurface.
+  useEffect(() => {
+    if (!kbChatFlag) return;
+    if (!contextPath) {
+      setMessageCount(0);
+      return;
+    }
+    setMessageCount(0);
+    const controller = new AbortController();
+    fetch(`/api/chat/thread-info?contextPath=${encodeURIComponent(contextPath)}`, {
+      signal: controller.signal,
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: { messageCount?: number } | null) => {
+        if (data && typeof data.messageCount === "number") {
+          setMessageCount(data.messageCount);
+        }
+      })
+      .catch(() => { /* abort or network error — label stays at default */ });
+    return () => controller.abort();
+  }, [contextPath, kbChatFlag]);
+
   const registerQuoteHandler = useCallback(
     (handler: ((text: string) => void) | null) => {
       quoteHandlerRef.current = handler;

--- a/apps/web-platform/app/api/chat/thread-info/route.ts
+++ b/apps/web-platform/app/api/chat/thread-info/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { reportSilentFallback } from "@/server/observability";
+
+const CONTEXT_PATH_MAX_LEN = 512;
+const CONTEXT_PATH_PREFIX = "knowledge-base/";
+
+function validateContextPath(v: string | null): string | null {
+  if (!v || v.length === 0 || v.length > CONTEXT_PATH_MAX_LEN) return null;
+  if (!v.startsWith(CONTEXT_PATH_PREFIX)) return null;
+  if (v.includes("..") || v.includes("\0")) return null;
+  const filename = v.split("/").pop() ?? "";
+  if (filename.lastIndexOf(".") <= 0) return null;
+  return v;
+}
+
+export async function GET(req: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const contextPath = validateContextPath(url.searchParams.get("contextPath"));
+  if (!contextPath) {
+    return NextResponse.json({ error: "Invalid contextPath" }, { status: 400 });
+  }
+
+  const service = createServiceClient();
+  const { data: existing, error: lookupErr } = await service
+    .from("conversations")
+    .select("id")
+    .eq("user_id", user.id)
+    .eq("context_path", contextPath)
+    .is("archived_at", null)
+    .order("last_active", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (lookupErr) {
+    reportSilentFallback(lookupErr, {
+      feature: "kb-chat",
+      op: "thread-info-lookup",
+      extra: { contextPath },
+    });
+    return NextResponse.json({ messageCount: 0 });
+  }
+  if (!existing) {
+    return NextResponse.json({ messageCount: 0 });
+  }
+
+  const { count, error: countErr } = await service
+    .from("messages")
+    .select("id", { count: "exact", head: true })
+    .eq("conversation_id", existing.id);
+
+  if (countErr) {
+    reportSilentFallback(countErr, {
+      feature: "kb-chat",
+      op: "thread-info-count",
+      extra: { conversationId: existing.id },
+    });
+    return NextResponse.json({ messageCount: 0 });
+  }
+
+  return NextResponse.json({ messageCount: count ?? 0 });
+}

--- a/apps/web-platform/test/kb-layout-thread-info-prefetch.test.tsx
+++ b/apps/web-platform/test/kb-layout-thread-info-prefetch.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render, waitFor } from "@testing-library/react";
+
+const mockPush = vi.fn();
+let mockPathname = "/dashboard/kb/knowledge-base/product/roadmap.md";
+const stableRouter = {
+  push: mockPush,
+  back: vi.fn(),
+  forward: vi.fn(),
+  refresh: vi.fn(),
+  replace: vi.fn(),
+  prefetch: vi.fn(),
+};
+const mockSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => mockPathname,
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock("@/hooks/use-media-query", () => ({ useMediaQuery: () => true }));
+
+const { React: MockReact } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return { React: require("react") };
+});
+
+vi.mock("react-resizable-panels", () => ({
+  Group: MockReact.forwardRef(function G(p: Record<string, unknown>, r: unknown) {
+    return MockReact.createElement("div", { "data-testid": "panel-group", ref: r }, p.children);
+  }),
+  Panel: MockReact.forwardRef(function P(p: Record<string, unknown>, r: unknown) {
+    return MockReact.createElement("div", { "data-testid": "panel", ref: r }, p.children);
+  }),
+  Separator: () => MockReact.createElement("div", { "data-testid": "panel-separator" }),
+  usePanelRef: () => ({ current: { collapse: vi.fn(), expand: vi.fn(), isCollapsed: () => false } }),
+  useGroupRef: () => ({ current: null }),
+  useDefaultLayout: () => ({ defaultLayout: undefined, onLayoutChanged: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-team-names", () => ({
+  useTeamNames: () => ({ names: {}, getDisplayName: (id: string) => id, getIconPath: () => null, loading: false }),
+  TeamNamesProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("@/lib/ws-client", () => ({
+  useWebSocket: () => ({
+    messages: [], startSession: vi.fn(), resumeSession: vi.fn(), sendMessage: vi.fn(),
+    sendReviewGateResponse: vi.fn(), status: "connected", disconnectReason: undefined,
+    lastError: null, reconnect: vi.fn(), routeSource: null, activeLeaderIds: [],
+    sessionConfirmed: true, usageData: null, realConversationId: null, resumedFrom: null,
+  }),
+}));
+
+vi.mock("@/lib/analytics-client", () => ({ track: vi.fn() }));
+
+// Capture thread-info fetch calls separately from tree/flags fetches.
+const threadInfoCalls: string[] = [];
+const threadInfoResponses = new Map<string, number>();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPathname = "/dashboard/kb/knowledge-base/product/roadmap.md";
+  threadInfoCalls.length = 0;
+  threadInfoResponses.clear();
+  sessionStorage.clear();
+  global.fetch = vi.fn().mockImplementation((url: string) => {
+    if (url === "/api/flags") {
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ "kb-chat-sidebar": true }) });
+    }
+    if (url.startsWith("/api/chat/thread-info")) {
+      threadInfoCalls.push(url);
+      const cp = new URL(url, "http://localhost").searchParams.get("contextPath") ?? "";
+      const mc = threadInfoResponses.get(cp) ?? 0;
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ messageCount: mc }) });
+    }
+    return Promise.resolve({
+      ok: true, status: 200, json: () => Promise.resolve({
+        tree: { name: "root", type: "directory", path: "", children: [
+          { name: "roadmap.md", type: "file", path: "knowledge-base/product/roadmap.md" },
+          { name: "vision.md", type: "file", path: "knowledge-base/product/vision.md" },
+        ]},
+      }),
+    });
+  });
+});
+
+describe("KbLayout — thread-info prefetch", () => {
+  async function loadLayout() {
+    const mod = await import("@/app/(dashboard)/dashboard/kb/layout");
+    return mod.default;
+  }
+
+  it("fetches thread-info for the initial contextPath", async () => {
+    threadInfoResponses.set("knowledge-base/product/roadmap.md", 7);
+    const KbLayout = await loadLayout();
+    render(<KbLayout><div>c</div></KbLayout>);
+    await waitFor(() => {
+      expect(threadInfoCalls.some((u) => u.includes("knowledge-base%2Fproduct%2Froadmap.md"))).toBe(true);
+    });
+  });
+
+  it("re-fetches thread-info when the document changes", async () => {
+    threadInfoResponses.set("knowledge-base/product/roadmap.md", 5);
+    threadInfoResponses.set("knowledge-base/product/vision.md", 0);
+    const KbLayout = await loadLayout();
+    const { rerender } = render(<KbLayout><div>c</div></KbLayout>);
+    await waitFor(() => {
+      expect(threadInfoCalls.some((u) => u.includes("roadmap.md"))).toBe(true);
+    });
+
+    await act(async () => {
+      mockPathname = "/dashboard/kb/knowledge-base/product/vision.md";
+      rerender(<KbLayout><div>c</div></KbLayout>);
+    });
+
+    await waitFor(() => {
+      expect(threadInfoCalls.some((u) => u.includes("vision.md"))).toBe(true);
+    });
+  });
+
+  it("does not fetch thread-info when contextPath is null (KB root)", async () => {
+    mockPathname = "/dashboard/kb";
+    const KbLayout = await loadLayout();
+    render(<KbLayout><div>c</div></KbLayout>);
+    // Give effects a chance to run.
+    await waitFor(() => {
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
+    });
+    expect(threadInfoCalls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- After #2493 closed the KB chat panel on document switch, the "Continue thread" / "Ask about this document" button kept reading `ctx.messageCount`, which only updates when `ChatSurface` is mounted. Navigating between documents (panel closed) left the count frozen from the previously mounted document.
- Add `GET /api/chat/thread-info?contextPath=...` — a lightweight read-only endpoint that returns `{ messageCount }` using the same SQL the WebSocket `start_session` path uses (`conversations` lookup + `messages` count).
- Layout calls it whenever `contextPath` changes. Count resets to 0 first so the label never leaks stale state while the fetch is in flight.

## Changelog

### Web Platform

- Fix: KB toolbar chat button now correctly shows "Continue thread" only when the current document has an existing conversation — no more stale labels after document switches.
- New endpoint `GET /api/chat/thread-info` (auth-required, read-only) for prefetching thread existence per KB document.

## Test plan

- [x] New vitest file `kb-layout-thread-info-prefetch.test.tsx` (3 cases): initial fetch on mount, refetch on document switch, no fetch at KB root.
- [x] Regression: all 4 `kb-layout-chat-close-on-switch` cases still pass.
- [x] Full `apps/web-platform` suite: 1748 passed, 1 skipped.
- [x] `tsc --noEmit` clean.

Generated with [Claude Code](https://claude.com/claude-code)