### PR TITLE
fix(content-publisher): extract_tweets supports numbered thread format

### DIFF
--- a/knowledge-base/project/learnings/bug-fixes/2026-04-17-extract-tweets-numbered-format.md
+++ b/knowledge-base/project/learnings/bug-fixes/2026-04-17-extract-tweets-numbered-format.md
@@ -1,0 +1,50 @@
+---
+date: 2026-04-17
+category: bug-fixes
+module: content-publisher
+problem_type: authoring_parser_contract
+severity: P2
+pr_reference: "#2496"
+---
+
+# extract_tweets silently collapsed a 5-tweet thread to 1 tweet (2026-04-17)
+
+## Problem
+
+The 2026-04-17 repo-connection launch produced a distribution content file whose `## X/Twitter Thread` section used the numbered authoring convention (hook, then `2/ ...`, `3/ ...`, `4/ ...`, `5/ ...`). `content-publisher.sh` at cron time logged `[ok] X thread posted successfully (1 tweets)` and went green — silently posting only the hook. Tweets 2-5 were concatenated into the hook's buffer and dropped when it exceeded 280 chars (the last-tweet path truncated or X rejected silently).
+
+## Root Cause
+
+`social-distribute` Phase 5.2 prescribes two authoring formats:
+- Labeled: `**Tweet N (label) -- N chars:**` preceding each tweet (dropped at extraction).
+- Numbered: hook + subsequent tweets prefixed `N/ ` on a fresh line (prefix preserved).
+
+`extract_tweets` only split on `^\*\*Tweet [0-9]` — the labeled convention. When the skill emitted the numbered convention (which it's allowed to), no split points existed; the entire section became a single blob. The publisher's success branch then reported "posted successfully (1 tweets)" because the buffer contained exactly one record.
+
+Two classes of contract bug in one:
+1. **Parser didn't match the skill's documented output.** Two documented authoring formats, one parser branch.
+2. **No assertion on tweet count vs. section structure.** If `extract_tweets` produces 1 record but the section contains `2/`, `3/` markers, that's a tell — the parser silently accepts it.
+
+## Solution
+
+Two-mode extractor:
+
+1. **Mode detection** scans the section for `^[[:space:]]*\*\*Tweet[[:space:]]+[0-9]`. Present → labeled mode (original behavior, regression-guarded). Absent → numbered mode.
+2. **Numbered mode** tracks an expected sequence number (starts at 2). Only lines matching `^N/ ` where `N == expected` trigger a split; the prefix is preserved. Sequence guard prevents prose like `1/3 of devs` or `4/5 users say` from being sliced mid-tweet.
+3. **Leading-whitespace tolerance** in the labeled regex defends against indented labels inside lists.
+
+Tests: 4 happy-path + 1 labeled-format regression + 4 edge cases (single-tweet, prose fraction guard, hook-as-`1/`, labeled-with-`N/`-in-body). All pass.
+
+## Key Insight
+
+**When a producer has two valid output formats, the consumer must accept both OR the producer must be forced to one.** This extractor trusted that the producer would always label — the skill's own docs explicitly allowed both. The publisher should also emit a *warning-with-Sentry* (per `cq-silent-fallback-must-mirror-to-sentry`) if `extract_tweets` returns 1 record but the section has 2+ `N/` or `**Tweet N` markers: a mismatch between parsed structure and raw signal is a legit silent-fallback and deserves mirroring. Out of scope for this PR; good candidate for follow-up.
+
+## Session Errors
+
+- **Markdownlint corrupted hashtags in the test fixture.** `#solofounder #buildinpublic` was rewritten to `# solofounder #buildinpublic` (space after first `#`, which semantically converts it to a heading). Recovery: added `<!-- markdownlint-disable-next-line MD018 -->` pragma (same pattern used in live distribution content files). **Prevention:** When writing new distribution-content test fixtures, copy the pragma pattern from an existing live file rather than relying on markdownlint's fix output.
+
+## Cross-references
+
+- PR #2491 — the Liquid-marker leak that first exposed the broken announcement; surfaced this bug during retroactive remediation.
+- `knowledge-base/project/learnings/bug-fixes/2026-04-17-distribution-content-liquid-marker-leak.md` — sibling learning.
+- `plugins/soleur/skills/social-distribute/SKILL.md` Phase 5.2 — the authoring spec that was already correct; the parser just didn't match it.

--- a/scripts/content-publisher.sh
+++ b/scripts/content-publisher.sh
@@ -222,17 +222,18 @@ extract_tweets() {
   #  (b) Numbered format: no label; tweets 2+ begin with `N/ ` on a fresh line. The hook
   #      is the blob before the first `N/` marker. The `N/ ` prefix is preserved so the
   #      posted tweet keeps its thread-position cue.
-  # Detect mode so `N/ ` lines inside a labeled tweet body (present in labeled fixtures)
-  # are not mistakenly treated as tweet boundaries.
+  # Detect mode so `N/ ` lines inside a labeled tweet body (which are legitimate
+  # tweet content in the labeled convention) are not mistakenly treated as tweet
+  # boundaries. Label detection tolerates leading whitespace (`  **Tweet 1 ...`).
   mode="labeled"
-  if ! echo "$x_section" | grep -qE '^\*\*Tweet [0-9]'; then
+  if ! echo "$x_section" | grep -qE '^[[:space:]]*\*\*Tweet[[:space:]]+[0-9]'; then
     mode="numbered"
   fi
 
   # Output RS-separated (\x1e) for safe multi-line handling. mawk silently drops \0.
   if [[ "$mode" == "labeled" ]]; then
     echo "$x_section" | awk '
-      /^\*\*Tweet [0-9]/ { if (buf != "") { printf "%s\x1e", buf }; buf=""; next }
+      /^[[:space:]]*\*\*Tweet[[:space:]]+[0-9]/ { if (buf != "") { printf "%s\x1e", buf }; buf=""; next }
       {
         line = $0
         gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
@@ -242,17 +243,33 @@ extract_tweets() {
       END { if (buf != "") printf "%s\x1e", buf }
     '
   else
+    # Numbered mode: only split when the line starts with `<expected>/ ` where
+    # `expected` begins at 2 (hook is tweet 1, un-prefixed) and increments after
+    # each match. This prevents prose like `3/5 users` or `1/3 of devs` from
+    # being miscounted as a tweet boundary.
     echo "$x_section" | awk '
-      /^[0-9]+\/ / {
-        if (buf != "") { printf "%s\x1e", buf }
-        line = $0
-        gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
-        buf = line
-        next
-      }
+      BEGIN { expected = 2 }
       {
         line = $0
         gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+      }
+      # Boundary detected: line starts with the expected sequence number + "/ ".
+      # Use substr/match to parse rather than regex interpolation.
+      {
+        is_boundary = 0
+        if (match(line, /^[0-9]+\/ /)) {
+          prefix = substr(line, RSTART, RLENGTH)
+          n = substr(prefix, 1, length(prefix) - 2) + 0
+          if (n == expected) { is_boundary = 1 }
+        }
+      }
+      is_boundary {
+        if (buf != "") { printf "%s\x1e", buf }
+        buf = line
+        expected++
+        next
+      }
+      {
         if (buf != "") buf = buf "\n" line
         else buf = line
       }

--- a/scripts/content-publisher.sh
+++ b/scripts/content-publisher.sh
@@ -209,7 +209,7 @@ extract_section() {
 
 extract_tweets() {
   local file="$1"
-  local x_section
+  local x_section mode
 
   x_section=$(extract_section "$file" "X/Twitter Thread")
   if [[ -z "$x_section" ]]; then
@@ -217,19 +217,48 @@ extract_tweets() {
     return 1
   fi
 
-  # Split on **Tweet N pattern, output RS-separated (\x1e) for safe multi-line handling.
-  # Uses \x1e (ASCII Record Separator) because mawk silently drops \0.
-  # Strips the label line (e.g., "**Tweet 1 (Hook) -- 272 chars:**").
-  echo "$x_section" | awk '
-    /^\*\*Tweet [0-9]/ { if (buf != "") { printf "%s\x1e", buf }; buf=""; next }
-    {
-      line = $0
-      gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
-      if (buf != "") buf = buf "\n" line
-      else buf = line
-    }
-    END { if (buf != "") printf "%s\x1e", buf }
-  '
+  # Two authoring formats are supported:
+  #  (a) Labeled format: each tweet preceded by `**Tweet N (...) -- N chars:**` (label dropped).
+  #  (b) Numbered format: no label; tweets 2+ begin with `N/ ` on a fresh line. The hook
+  #      is the blob before the first `N/` marker. The `N/ ` prefix is preserved so the
+  #      posted tweet keeps its thread-position cue.
+  # Detect mode so `N/ ` lines inside a labeled tweet body (present in labeled fixtures)
+  # are not mistakenly treated as tweet boundaries.
+  mode="labeled"
+  if ! echo "$x_section" | grep -qE '^\*\*Tweet [0-9]'; then
+    mode="numbered"
+  fi
+
+  # Output RS-separated (\x1e) for safe multi-line handling. mawk silently drops \0.
+  if [[ "$mode" == "labeled" ]]; then
+    echo "$x_section" | awk '
+      /^\*\*Tweet [0-9]/ { if (buf != "") { printf "%s\x1e", buf }; buf=""; next }
+      {
+        line = $0
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+        if (buf != "") buf = buf "\n" line
+        else buf = line
+      }
+      END { if (buf != "") printf "%s\x1e", buf }
+    '
+  else
+    echo "$x_section" | awk '
+      /^[0-9]+\/ / {
+        if (buf != "") { printf "%s\x1e", buf }
+        line = $0
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+        buf = line
+        next
+      }
+      {
+        line = $0
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+        if (buf != "") buf = buf "\n" line
+        else buf = line
+      }
+      END { if (buf != "") printf "%s\x1e", buf }
+    '
+  fi
 }
 
 # --- Discord Posting ---

--- a/test/content-publisher.test.ts
+++ b/test/content-publisher.test.ts
@@ -309,6 +309,147 @@ describe("extract_tweets", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe("4");
   });
+
+  // --- Edge cases for numbered-mode robustness ---
+
+  test("numbered format: single-tweet (hook only, no N/ lines) yields 1 tweet", () => {
+    const RS = "\\x1e";
+    const result = Bun.spawnSync(["bash", "-c", `
+      set -euo pipefail
+      source '${SCRIPT_PATH}'
+      tmpfile=$(mktemp)
+      cat > "$tmpfile" <<'EOF'
+---
+title: "Hook Only"
+---
+
+## X/Twitter Thread
+
+A single-tweet hook with no thread. https://example.com/x
+EOF
+      count=0
+      while IFS= read -r -d $'\\x1e' tweet; do
+        [[ -n "$tweet" ]] && count=$((count + 1))
+      done < <(extract_tweets "$tmpfile")
+      echo "$count"
+      rm -f "$tmpfile"
+    `], { env: BASE_ENV });
+    expect(result.exitCode).toBe(0);
+    expect(decode(result.stdout).trim()).toBe("1");
+  });
+
+  test("numbered format: prose `1/3 of devs` in hook does NOT split (sequence guard)", () => {
+    const RS = "\\x1e";
+    const result = Bun.spawnSync(["bash", "-c", `
+      set -euo pipefail
+      source '${SCRIPT_PATH}'
+      tmpfile=$(mktemp)
+      cat > "$tmpfile" <<'EOF'
+---
+title: "Prose Guard"
+---
+
+## X/Twitter Thread
+
+Hook with a fraction at the start of a line.
+1/3 of devs say this.
+
+2/ Real body tweet. https://example.com/x
+EOF
+      count=0
+      first=""
+      i=0
+      while IFS= read -r -d $'\\x1e' tweet; do
+        [[ -n "$tweet" ]] || continue
+        count=$((count + 1))
+        i=$((i + 1))
+        if [[ $i -eq 1 ]]; then first="$tweet"; fi
+      done < <(extract_tweets "$tmpfile")
+      echo "count=$count"
+      echo "first-contains-fraction=$(echo "$first" | grep -c '1/3 of devs')"
+      rm -f "$tmpfile"
+    `], { env: BASE_ENV });
+    expect(result.exitCode).toBe(0);
+    const out = decode(result.stdout);
+    // The fraction line must stay in the hook; total tweet count is 2.
+    expect(out).toContain("count=2");
+    expect(out).toContain("first-contains-fraction=1");
+  });
+
+  test("numbered format: first content line is `1/ ...` — kept in the hook blob", () => {
+    // Documents the current contract: tweet 1 has no leading `N/ ` by
+    // convention. If an author writes `1/ ...` as the hook, it is treated as
+    // hook content (not a boundary — the sequence starts at expected=2).
+    const RS = "\\x1e";
+    const result = Bun.spawnSync(["bash", "-c", `
+      set -euo pipefail
+      source '${SCRIPT_PATH}'
+      tmpfile=$(mktemp)
+      cat > "$tmpfile" <<'EOF'
+---
+title: "Hook with 1/"
+---
+
+## X/Twitter Thread
+
+1/ Hook written with an explicit 1/ prefix.
+
+2/ Body tweet.
+EOF
+      count=0
+      first=""
+      i=0
+      while IFS= read -r -d $'\\x1e' tweet; do
+        [[ -n "$tweet" ]] || continue
+        count=$((count + 1))
+        i=$((i + 1))
+        if [[ $i -eq 1 ]]; then first="$tweet"; fi
+      done < <(extract_tweets "$tmpfile")
+      echo "count=$count"
+      echo "first-starts=$(echo "$first" | head -1)"
+      rm -f "$tmpfile"
+    `], { env: BASE_ENV });
+    expect(result.exitCode).toBe(0);
+    const out = decode(result.stdout);
+    expect(out).toContain("count=2");
+    expect(out).toContain("first-starts=1/ Hook written with an explicit 1/ prefix.");
+  });
+
+  test("labeled format: `N/ ` inside a tweet body is NOT treated as a boundary", () => {
+    // The labeled convention uses **Tweet N labels as the only boundaries;
+    // body content can include `2/ ` on its own line without being sliced.
+    const RS = "\\x1e";
+    const result = Bun.spawnSync(["bash", "-c", `
+      set -euo pipefail
+      source '${SCRIPT_PATH}'
+      tmpfile=$(mktemp)
+      cat > "$tmpfile" <<'EOF'
+---
+title: "Labeled With Internal Slash"
+---
+
+## X/Twitter Thread
+
+**Tweet 1 (Hook) -- 100 chars:**
+Hook tweet content.
+
+**Tweet 2 (Body) -- 120 chars:**
+2/ Body tweet that starts with a slash prefix.
+3/ A second slash-prefixed line inside the same body (intentional).
+
+**Tweet 3 (Final) -- 80 chars:**
+Final tweet. https://example.com/x
+EOF
+      count=0
+      while IFS= read -r -d $'\\x1e' tweet; do
+        [[ -n "$tweet" ]] && count=$((count + 1))
+      done < <(extract_tweets "$tmpfile")
+      echo "$count"
+      rm -f "$tmpfile"
+    `], { env: BASE_ENV });
+    expect(result.exitCode).toBe(0);
+    expect(decode(result.stdout).trim()).toBe("3");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/content-publisher.test.ts
+++ b/test/content-publisher.test.ts
@@ -5,6 +5,7 @@ const SCRIPT_PATH = join(import.meta.dirname, "..", "scripts", "content-publishe
 const SAMPLE_CONTENT = join(import.meta.dirname, "helpers", "sample-content.md");
 const SAMPLE_NO_MANUAL = join(import.meta.dirname, "helpers", "sample-content-no-manual.md");
 const SAMPLE_FRONTMATTER = join(import.meta.dirname, "helpers", "sample-frontmatter.md");
+const SAMPLE_NUMBERED_THREAD = join(import.meta.dirname, "helpers", "sample-content-numbered-thread.md");
 
 const BASE_ENV: Record<string, string> = {
   PATH: process.env.PATH ?? "/usr/bin:/bin:/usr/local/bin",
@@ -230,6 +231,83 @@ describe("extract_tweets", () => {
     `);
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe("3");
+  });
+
+  test("numbered format (no **Tweet N labels): extracts all 5 tweets", () => {
+    const RS = "\\x1e";
+    const result = runFunction(`
+      count=0
+      while IFS= read -r -d $'${RS}' tweet; do
+        [[ -n "$tweet" ]] && count=$((count + 1))
+      done < <(extract_tweets "${SAMPLE_NUMBERED_THREAD}")
+      echo "$count"
+    `);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("5");
+  });
+
+  test("numbered format: hook is the blob before the first N/ marker", () => {
+    const RS = "\\x1e";
+    const result = runFunction(`
+      while IFS= read -r -d $'${RS}' tweet; do
+        echo "$tweet"
+        break
+      done < <(extract_tweets "${SAMPLE_NUMBERED_THREAD}")
+    `);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Your AI team now operates on your actual codebase");
+    expect(result.stdout).toContain("Every agent conversation starts with real project context");
+    // Must NOT include content from tweet 2
+    expect(result.stdout).not.toContain("The problem with every AI development workflow");
+  });
+
+  test("numbered format: tweet 2 preserves the 2/ prefix", () => {
+    const RS = "\\x1e";
+    const result = runFunction(`
+      i=0
+      while IFS= read -r -d $'${RS}' tweet; do
+        i=$((i + 1))
+        if [[ $i -eq 2 ]]; then
+          echo "$tweet"
+          break
+        fi
+      done < <(extract_tweets "${SAMPLE_NUMBERED_THREAD}")
+    `);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/^2\/ /);
+    expect(result.stdout).toContain("The problem with every AI development workflow");
+    // Must NOT bleed into tweet 3
+    expect(result.stdout).not.toContain("Now: connect your GitHub repo");
+  });
+
+  test("numbered format: last tweet keeps its trailer (URL, hashtags)", () => {
+    const RS = "\\x1e";
+    const result = runFunction(`
+      last=""
+      while IFS= read -r -d $'${RS}' tweet; do
+        [[ -n "$tweet" ]] && last="$tweet"
+      done < <(extract_tweets "${SAMPLE_NUMBERED_THREAD}")
+      echo "$last"
+    `);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/^5\/ /);
+    expect(result.stdout).toContain("Three paths during onboarding");
+    expect(result.stdout).toContain("https://example.com/blog/numbered/");
+    expect(result.stdout).toContain("#solofounder");
+  });
+
+  test("labeled format unchanged: SAMPLE_CONTENT still yields 4 tweets", () => {
+    // Regression guard for the original behavior.
+    const RS = "\\x1e";
+    const result = runFunction(`
+      count=0
+      while IFS= read -r -d $'${RS}' tweet; do
+        [[ -n "$tweet" ]] && count=$((count + 1))
+      done < <(extract_tweets "${SAMPLE_CONTENT}")
+      echo "$count"
+    `);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("4");
   });
 });
 

--- a/test/helpers/sample-content-numbered-thread.md
+++ b/test/helpers/sample-content-numbered-thread.md
@@ -1,0 +1,79 @@
+---
+title: "Numbered Thread Fixture"
+type: feature-launch
+publish_date: "2026-04-17"
+channels: x
+status: draft
+---
+
+## Discord
+
+Placeholder discord content.
+
+---
+
+## X/Twitter Thread
+
+Your AI team now operates on your actual codebase -- not a blank workspace.
+
+Connect your GitHub repo during onboarding. Every agent conversation starts with real project context.
+
+2/ The problem with every AI development workflow: the agent starts from zero. It does not know your architecture, your brand voice, your legal constraints, or what you shipped last week.
+
+You brief it from scratch. Every. Single. Session.
+
+3/ Now: connect your GitHub repo, and agents across departments read your knowledge base, brand guide, specs, and learnings. Context carries forward. Knowledge compounds.
+
+4/ How it works behind the scenes:
+
+- Session start: workspace pulls latest from your repo
+- Session end: changes push back
+- Sync is best-effort -- a failed sync never blocks your session
+- Auth uses GitHub App tokens that expire in 1 hour
+
+5/ Three paths during onboarding:
+
+- Connect an existing project
+- Start fresh (we create the repo for you)
+- Skip for now
+
+Full details: <https://example.com/blog/numbered/?utm_source=x&utm_medium=social&utm_campaign=numbered>
+
+<!-- markdownlint-disable-next-line MD018 -->
+#solofounder #buildinpublic
+
+---
+
+## Bluesky
+
+Not scheduled for Bluesky distribution.
+
+---
+
+## IndieHackers
+
+Not scheduled.
+
+---
+
+## Reddit
+
+Not scheduled.
+
+---
+
+## Hacker News
+
+Not scheduled.
+
+---
+
+## LinkedIn Personal
+
+Not scheduled.
+
+---
+
+## LinkedIn Company Page
+
+Not scheduled.


### PR DESCRIPTION
## Summary

- Fix `extract_tweets` to handle both documented X-thread authoring formats (labeled `**Tweet N` and numbered `N/ ` prefixes).
- Prevents the silent 5-tweet → 1-tweet collapse that happened on the 2026-04-17 repo-connection launch.

## Why

`social-distribute` SKILL.md Phase 5.2 documents two authoring formats for X threads: labeled (`**Tweet N (...) -- N chars:**`) and numbered (`N/ ` prefix). The publisher's `extract_tweets` only split on labeled boundaries. When the skill emitted numbered format, the entire thread collapsed into the hook buffer and the publisher logged `[ok] X thread posted successfully (1 tweets)` — a silent authoring/parser contract bug that shipped a broken launch to X.

## Changelog

### Scripts

- `scripts/content-publisher.sh` — `extract_tweets` now detects the authoring format and dispatches to a matching awk branch:
  - **Labeled mode**: unchanged split on `^[[:space:]]*\*\*Tweet[[:space:]]+[0-9]` (now tolerant of leading whitespace).
  - **Numbered mode**: sequence-guarded split — only lines matching `^N/ ` where `N` equals the expected next tweet number (starting at 2) trigger a boundary. Prose fractions like `1/3 of devs` or `4/5 users` are NOT sliced.

### Tests

- `test/content-publisher.test.ts` — 8 new cases (4 numbered-format happy path, 1 labeled regression guard, 3 edge cases: single-tweet section, prose-fraction guard, labeled-format-with-slashes-in-body).
- `test/helpers/sample-content-numbered-thread.md` — new fixture mirroring the 2026-04-17 authoring format.

### Learning

- `knowledge-base/project/learnings/bug-fixes/2026-04-17-extract-tweets-numbered-format.md` — root cause, insight (silent count-mismatch warrants Sentry mirror), follow-up candidate.

## Test plan

- [x] 71 bun tests pass (8 new, 63 pre-existing).
- [x] `bash scripts/test-all.sh` → 17/17 suites pass.
- [x] Regression guard: labeled-format `SAMPLE_CONTENT` still extracts 4 tweets.
- [x] Sequence guard: hook prose `1/3 of devs` stays in the hook, only `2/ `, `3/ `, etc. at expected positions trigger splits.
- [x] Inline review: 2 P2 (indented-label tolerance, numbered-prose false-positive) + 3 P3 (test coverage) resolved before push.

Generated with [Claude Code](https://claude.com/claude-code)