### PR TITLE
refactor(kb): shared serve-binary + dispatch + isMarkdownExt helpers

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/kb/[...path]/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/kb/[...path]/page.tsx
@@ -11,6 +11,7 @@ import { KbChatTrigger } from "@/components/kb/kb-chat-trigger";
 import { KbChatContext } from "@/components/kb/kb-chat-context";
 import { KbChatQuoteBridgeContext } from "@/components/kb/kb-chat-quote-bridge";
 import { SelectionToolbar } from "@/components/kb/selection-toolbar";
+import { isMarkdownKbPath } from "@/lib/kb-extensions";
 import type { ContentResult } from "@/server/kb-reader";
 
 export default function KbContentPage({
@@ -22,7 +23,7 @@ export default function KbContentPage({
   const router = useRouter();
   const joinedPath = pathSegments.join("/");
   const extension = joinedPath.includes(".") ? `.${joinedPath.split(".").pop()}` : "";
-  const isMarkdown = extension === ".md" || extension === "";
+  const isMarkdown = isMarkdownKbPath(joinedPath);
   const [content, setContent] = useState<ContentResult | null>(null);
   const [loading, setLoading] = useState(isMarkdown);
   const [error, setError] = useState<"not-found" | "unknown" | null>(null);

--- a/apps/web-platform/app/(dashboard)/dashboard/kb/[...path]/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/kb/[...path]/page.tsx
@@ -11,7 +11,7 @@ import { KbChatTrigger } from "@/components/kb/kb-chat-trigger";
 import { KbChatContext } from "@/components/kb/kb-chat-context";
 import { KbChatQuoteBridgeContext } from "@/components/kb/kb-chat-quote-bridge";
 import { SelectionToolbar } from "@/components/kb/selection-toolbar";
-import { isMarkdownKbPath } from "@/lib/kb-extensions";
+import { getKbExtension, isMarkdownKbPath } from "@/lib/kb-extensions";
 import type { ContentResult } from "@/server/kb-reader";
 
 export default function KbContentPage({
@@ -22,7 +22,7 @@ export default function KbContentPage({
   const { path: pathSegments } = use(params);
   const router = useRouter();
   const joinedPath = pathSegments.join("/");
-  const extension = joinedPath.includes(".") ? `.${joinedPath.split(".").pop()}` : "";
+  const extension = getKbExtension(joinedPath);
   const isMarkdown = isMarkdownKbPath(joinedPath);
   const [content, setContent] = useState<ContentResult | null>(null);
   const [loading, setLoading] = useState(isMarkdown);

--- a/apps/web-platform/app/api/kb/content/[...path]/route.ts
+++ b/apps/web-platform/app/api/kb/content/[...path]/route.ts
@@ -6,7 +6,6 @@ import {
   readContent,
   KbNotFoundError,
   KbAccessDeniedError,
-  KbFileTooLargeError,
   KbValidationError,
 } from "@/server/kb-reader";
 import { serveKbFile, serveBinary } from "@/server/kb-serve";
@@ -70,47 +69,17 @@ export async function GET(
           { status: 500 },
         );
       }
-      if (err instanceof KbNotFoundError) {
-        return NextResponse.json({ error: "File not found" }, { status: 404 });
-      }
-      if (err instanceof KbValidationError) {
-        return NextResponse.json({ error: err.message }, { status: 400 });
-      }
-      logger.error({ err }, "kb/content: unexpected error");
-      return NextResponse.json(
-        { error: "An unexpected error occurred" },
-        { status: 500 },
-      );
-    }
-  }
-
-  // Binary file serving — owner route streams unconditionally (no hash
-  // gate). The share route adds a content-hash verdict cache on top of
-  // the same helpers.
-  try {
-    const meta = await validateBinaryFile(kbRoot, relativePath);
-    return await buildBinaryResponse(meta, request);
-  } catch (err) {
-    if (err instanceof KbAccessDeniedError) {
-      return NextResponse.json({ error: "Access denied" }, { status: 403 });
-    }
-    if (err instanceof KbNotFoundError) {
-      return NextResponse.json({ error: "File not found" }, { status: 404 });
-    }
-    if (err instanceof KbFileTooLargeError) {
-      return NextResponse.json({ error: err.message }, { status: 413 });
-    }
-    if (err instanceof BinaryOpenError) {
-      logger.warn(
-        { err: err.message, code: err.code, path: relativePath },
-        "kb/content: open failed on serve",
-      );
-      return NextResponse.json({ error: err.message }, { status: err.status });
-    }
-    logger.error({ err, path: relativePath }, "kb/content: unexpected error");
-    return NextResponse.json(
-      { error: "An unexpected error occurred" },
-      { status: 500 },
-    );
-  }
+    },
+    onBinary: (root, rel) =>
+      serveBinary(root, rel, {
+        request,
+        onError: (status, message, code) => {
+          if (status !== 404 && status !== 403) return;
+          logger.warn(
+            { err: message, code, path: rel },
+            "kb/content: open failed on serve",
+          );
+        },
+      }),
+  });
 }

--- a/apps/web-platform/app/api/kb/content/[...path]/route.ts
+++ b/apps/web-platform/app/api/kb/content/[...path]/route.ts
@@ -8,11 +8,7 @@ import {
   KbAccessDeniedError,
   KbValidationError,
 } from "@/server/kb-reader";
-import {
-  validateBinaryFile,
-  buildBinaryResponse,
-  BinaryOpenError,
-} from "@/server/kb-binary-response";
+import { serveKbFile, serveBinary } from "@/server/kb-serve";
 
 export async function GET(
   request: Request,
@@ -50,48 +46,40 @@ export async function GET(
   }
 
   const kbRoot = path.join(userData.workspace_path, "knowledge-base");
-  const ext = path.extname(relativePath).toLowerCase();
 
-  // Fork: .md (or no extension) → readContent, non-.md → binary serving
-  if (ext === ".md" || ext === "") {
-    try {
-      const result = await readContent(kbRoot, relativePath);
-      return NextResponse.json(result);
-    } catch (err) {
-      if (err instanceof KbAccessDeniedError) {
-        return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  return serveKbFile(kbRoot, relativePath, {
+    request,
+    onMarkdown: async (root, rel) => {
+      try {
+        const result = await readContent(root, rel);
+        return NextResponse.json(result);
+      } catch (err) {
+        if (err instanceof KbAccessDeniedError) {
+          return NextResponse.json({ error: "Access denied" }, { status: 403 });
+        }
+        if (err instanceof KbNotFoundError) {
+          return NextResponse.json({ error: "File not found" }, { status: 404 });
+        }
+        if (err instanceof KbValidationError) {
+          return NextResponse.json({ error: err.message }, { status: 400 });
+        }
+        logger.error({ err }, "kb/content: unexpected error");
+        return NextResponse.json(
+          { error: "An unexpected error occurred" },
+          { status: 500 },
+        );
       }
-      if (err instanceof KbNotFoundError) {
-        return NextResponse.json({ error: "File not found" }, { status: 404 });
-      }
-      if (err instanceof KbValidationError) {
-        return NextResponse.json({ error: err.message }, { status: 400 });
-      }
-      logger.error({ err }, "kb/content: unexpected error");
-      return NextResponse.json(
-        { error: "An unexpected error occurred" },
-        { status: 500 },
-      );
-    }
-  }
-
-  // Binary file serving — owner route streams unconditionally (no hash
-  // gate). The share route adds a content-hash verdict cache on top of
-  // the same helpers.
-  const result = await validateBinaryFile(kbRoot, relativePath);
-  if (!result.ok) {
-    return NextResponse.json({ error: result.error }, { status: result.status });
-  }
-  try {
-    return await buildBinaryResponse(result, request);
-  } catch (err) {
-    if (err instanceof BinaryOpenError) {
-      logger.warn(
-        { err: err.message, code: err.code, path: relativePath },
-        "kb/content: open failed on serve",
-      );
-      return NextResponse.json({ error: err.message }, { status: err.status });
-    }
-    throw err;
-  }
+    },
+    onBinary: (root, rel) =>
+      serveBinary(root, rel, {
+        request,
+        onError: (status, message, code) => {
+          if (status !== 404 && status !== 403) return;
+          logger.warn(
+            { err: message, code, path: rel },
+            "kb/content: open failed on serve",
+          );
+        },
+      }),
+  });
 }

--- a/apps/web-platform/app/api/shared/[token]/route.ts
+++ b/apps/web-platform/app/api/shared/[token]/route.ts
@@ -7,14 +7,13 @@ import {
   KbNotFoundError,
   KbAccessDeniedError,
 } from "@/server/kb-reader";
+import { validateBinaryFile } from "@/server/kb-binary-response";
+import { hashBytes } from "@/server/kb-content-hash";
 import {
-  validateBinaryFile,
-  buildBinaryResponse,
-  openBinaryStream,
-  BinaryOpenError,
-} from "@/server/kb-binary-response";
-import { hashBytes, hashStream } from "@/server/kb-content-hash";
-import { shareHashVerdictCache } from "@/server/share-hash-verdict-cache";
+  contentChangedResponse,
+  serveKbFile,
+  serveBinaryWithHashGate,
+} from "@/server/kb-serve";
 import {
   shareEndpointThrottle,
   extractClientIpFromHeaders,
@@ -22,16 +21,6 @@ import {
 } from "@/server/rate-limiter";
 import logger from "@/server/logger";
 import * as Sentry from "@sentry/nextjs";
-
-function contentChangedResponse() {
-  return NextResponse.json(
-    {
-      error: "The shared file has been modified since it was shared.",
-      code: "content-changed",
-    },
-    { status: 410 },
-  );
-}
 
 function legacyNullHashResponse() {
   return NextResponse.json(
@@ -80,8 +69,6 @@ export async function GET(
   }
 
   if (!shareLink.content_sha256) {
-    // Legacy row from before content-hash binding. Treat as invalid — the
-    // migration should have revoked these, but belt-and-suspenders.
     logger.warn(
       { event: "shared_legacy_null_hash", token, documentPath: shareLink.document_path },
       "shared: legacy row without content hash",
@@ -104,177 +91,81 @@ export async function GET(
   }
 
   const kbRoot = path.join(owner.workspace_path, "knowledge-base");
-  const ext = path.extname(shareLink.document_path).toLowerCase();
 
-  // Markdown / extensionless branch.
-  if (ext === ".md" || ext === "") {
-    try {
-      const { buffer, raw } = await readContentRaw(
-        kbRoot,
-        shareLink.document_path,
-      );
-      const currentHash = hashBytes(buffer);
-      if (currentHash !== shareLink.content_sha256) {
-        logger.info(
-          {
-            event: "shared_content_mismatch",
-            token,
-            documentPath: shareLink.document_path,
-            kind: "markdown",
-          },
-          "shared: content hash mismatch",
-        );
-        return contentChangedResponse();
-      }
-      const { content } = parseFrontmatter(raw);
-      logger.info(
-        { event: "shared_page_viewed", token, documentPath: shareLink.document_path },
-        "shared: document viewed",
-      );
-      return NextResponse.json({
-        content,
-        path: shareLink.document_path,
-      });
-    } catch (err) {
-      if (err instanceof KbAccessDeniedError) {
-        logger.warn(
-          { token, path: shareLink.document_path },
-          "shared: path traversal attempt blocked",
-        );
-        return NextResponse.json({ error: "Access denied" }, { status: 403 });
-      }
-      if (err instanceof KbNotFoundError) {
-        return NextResponse.json(
-          { error: "Document no longer available" },
-          { status: 404 },
-        );
-      }
-      logger.error({ err, token }, "shared: unexpected error");
-      Sentry.captureException(err, {
-        tags: { feature: "shared-token" },
-        extra: { token },
-      });
-      return NextResponse.json(
-        { error: "An unexpected error occurred" },
-        { status: 500 },
-      );
-    }
-  }
-
-  // Binary branch — validate metadata without reading bytes, then either
-  // trust the verdict cache (fast path) or hash via a fresh stream before
-  // serving (slow path: first view OR file mutated since last verify).
-  const binary = await validateBinaryFile(kbRoot, shareLink.document_path);
-  if (!binary.ok) {
-    if (binary.status === 403) {
-      logger.warn(
-        { token, path: shareLink.document_path },
-        "shared: binary access denied (symlink / outside root)",
-      );
-    }
-    return NextResponse.json({ error: binary.error }, { status: binary.status });
-  }
-
-  const cachedVerdict = shareHashVerdictCache.get(
-    token,
-    binary.ino,
-    binary.mtimeMs,
-    binary.size,
-  );
-
-  if (cachedVerdict !== true) {
-    // Cache miss — drain a fresh stream through SHA-256 and compare
-    // before shipping any bytes. The expected { ino, size } tuple on
-    // openBinaryStream rejects any rename/link swap between validate and
-    // hash — if the inode drifted, BinaryOpenError("content-changed") is
-    // thrown and surfaces as 410.
-    let currentHash: string;
-    try {
-      const hashStreamObj = await openBinaryStream(binary.filePath, {
-        expected: { ino: binary.ino, size: binary.size },
-      });
-      currentHash = await hashStream(hashStreamObj);
-    } catch (err) {
-      if (err instanceof BinaryOpenError) {
-        if (err.code === "content-changed") {
+  return serveKbFile(kbRoot, shareLink.document_path, {
+    request,
+    onMarkdown: async (root, rel) => {
+      try {
+        const { buffer, raw } = await readContentRaw(root, rel);
+        const currentHash = hashBytes(buffer);
+        if (currentHash !== shareLink.content_sha256) {
           logger.info(
             {
               event: "shared_content_mismatch",
               token,
-              documentPath: shareLink.document_path,
-              kind: "binary",
-              reason: "inode-drift",
+              documentPath: rel,
+              kind: "markdown",
             },
-            "shared: inode drift between validate and hash",
+            "shared: content hash mismatch",
           );
           return contentChangedResponse();
         }
-        logger.warn(
-          { err: err.message, code: err.code, token, path: shareLink.document_path },
-          "shared: open failed on hash pass",
+        const { content } = parseFrontmatter(raw);
+        logger.info(
+          { event: "shared_page_viewed", token, documentPath: rel },
+          "shared: document viewed",
         );
+        return NextResponse.json({
+          content,
+          path: rel,
+        });
+      } catch (err) {
+        if (err instanceof KbAccessDeniedError) {
+          logger.warn(
+            { token, path: rel },
+            "shared: path traversal attempt blocked",
+          );
+          return NextResponse.json({ error: "Access denied" }, { status: 403 });
+        }
+        if (err instanceof KbNotFoundError) {
+          return NextResponse.json(
+            { error: "Document no longer available" },
+            { status: 404 },
+          );
+        }
+        logger.error({ err, token }, "shared: unexpected error");
+        Sentry.captureException(err, {
+          tags: { feature: "shared-token" },
+          extra: { token },
+        });
         return NextResponse.json(
-          { error: err.message },
-          { status: err.status },
+          { error: "An unexpected error occurred" },
+          { status: 500 },
         );
       }
-      logger.error(
-        { err, token, path: shareLink.document_path },
-        "shared: hash stream drain failed",
-      );
-      return NextResponse.json(
-        { error: "An unexpected error occurred" },
-        { status: 500 },
-      );
-    }
-    if (currentHash !== shareLink.content_sha256) {
-      logger.info(
-        {
-          event: "shared_content_mismatch",
-          token,
-          documentPath: shareLink.document_path,
-          kind: "binary",
-        },
-        "shared: content hash mismatch",
-      );
-      return contentChangedResponse();
-    }
-    shareHashVerdictCache.set(token, binary.ino, binary.mtimeMs, binary.size);
-  }
-
-  logger.info(
-    {
-      event: "shared_page_viewed",
-      token,
-      documentPath: shareLink.document_path,
-      contentType: binary.contentType,
-      cached: cachedVerdict === true,
     },
-    "shared: document viewed",
-  );
-  try {
-    return await buildBinaryResponse(binary, request, {
-      // Strong ETag from the stored content hash: a repeat view with a
-      // matching If-None-Match returns 304 without re-opening the fd.
-      strongETag: shareLink.content_sha256,
-    });
-  } catch (err) {
-    if (err instanceof BinaryOpenError && err.code === "content-changed") {
-      logger.info(
-        {
-          event: "shared_content_mismatch",
-          token,
-          documentPath: shareLink.document_path,
-          kind: "binary",
-          reason: "inode-drift-serve",
-        },
-        "shared: inode drift between hash and serve",
-      );
-      return contentChangedResponse();
-    }
-    if (err instanceof BinaryOpenError) {
-      return NextResponse.json({ error: err.message }, { status: err.status });
-    }
-    throw err;
-  }
+    onBinary: async (root, rel) => {
+      const binary = await validateBinaryFile(root, rel);
+      if (!binary.ok) {
+        if (binary.status === 403) {
+          logger.warn(
+            { token, path: rel },
+            "shared: binary access denied (symlink / outside root)",
+          );
+        }
+        return NextResponse.json(
+          { error: binary.error },
+          { status: binary.status },
+        );
+      }
+      return serveBinaryWithHashGate({
+        token,
+        expectedHash: shareLink.content_sha256,
+        meta: binary,
+        request,
+        logger,
+        logContext: { token, documentPath: rel },
+      });
+    },
+  });
 }

--- a/apps/web-platform/app/api/shared/[token]/route.ts
+++ b/apps/web-platform/app/api/shared/[token]/route.ts
@@ -12,7 +12,7 @@ import { hashBytes } from "@/server/kb-content-hash";
 import {
   contentChangedResponse,
   serveKbFile,
-  serveBinaryWithHashGate,
+  serveSharedBinaryWithHashGate,
 } from "@/server/kb-serve";
 import {
   shareEndpointThrottle,
@@ -22,6 +22,10 @@ import {
 import logger from "@/server/logger";
 import * as Sentry from "@sentry/nextjs";
 
+// Kept route-private (not in kb-serve.ts) because "legacy-null-hash" is a
+// share-specific migration artifact: only pre-#2326 share rows can carry a
+// null content_sha256. contentChangedResponse, by contrast, serves any
+// future hash-gated flow and therefore lives in the shared module.
 function legacyNullHashResponse() {
   return NextResponse.json(
     {
@@ -158,8 +162,7 @@ export async function GET(
           { status: binary.status },
         );
       }
-      return serveBinaryWithHashGate({
-        token,
+      return serveSharedBinaryWithHashGate({
         expectedHash: shareLink.content_sha256,
         meta: binary,
         request,

--- a/apps/web-platform/app/api/shared/[token]/route.ts
+++ b/apps/web-platform/app/api/shared/[token]/route.ts
@@ -8,19 +8,17 @@ import {
   KbAccessDeniedError,
   KbFileTooLargeError,
 } from "@/server/kb-reader";
-import { validateBinaryFile } from "@/server/kb-binary-response";
-import { hashBytes } from "@/server/kb-content-hash";
 import {
   validateBinaryFile,
-  buildBinaryResponse,
-  openBinaryStream,
-  deriveBinaryKind,
-  SHARED_CONTENT_KIND_HEADER,
   BinaryOpenError,
-  type BinaryFileMetadata,
 } from "@/server/kb-binary-response";
-import { hashBytes, hashStream } from "@/server/kb-content-hash";
-import { shareHashVerdictCache } from "@/server/share-hash-verdict-cache";
+import { hashBytes } from "@/server/kb-content-hash";
+import {
+  contentChangedResponse,
+  serveKbFile,
+  serveSharedBinaryWithHashGate,
+  SHARED_CONTENT_KIND_HEADER,
+} from "@/server/kb-serve";
 import {
   shareEndpointThrottle,
   extractClientIpFromHeaders,
@@ -86,9 +84,6 @@ export async function GET(
       document_path: string;
       revoked: boolean;
       content_sha256: string | null;
-      // PostgREST embedded many-to-one returns a single object; some
-      // client/server-type combinations surface it as an array. Normalize
-      // below so the route is robust to both shapes.
       users:
         | { workspace_path: string | null; workspace_status: string | null }
         | { workspace_path: string | null; workspace_status: string | null }[]
@@ -126,121 +121,60 @@ export async function GET(
   }
 
   const kbRoot = path.join(owner.workspace_path, "knowledge-base");
-  const ext = path.extname(shareLink.document_path).toLowerCase();
   const contentSha256 = shareLink.content_sha256;
   const documentPath = shareLink.document_path;
 
-  // Markdown / extensionless branch.
-  if (ext === ".md" || ext === "") {
-    try {
-      const { buffer, raw } = await readContentRaw(kbRoot, documentPath);
-      const currentHash = hashBytes(buffer);
-      if (currentHash !== contentSha256) {
+  return serveKbFile(kbRoot, documentPath, {
+    request,
+    onMarkdown: async (root, rel) => {
+      try {
+        const { buffer, raw } = await readContentRaw(root, rel);
+        const currentHash = hashBytes(buffer);
+        if (currentHash !== contentSha256) {
+          logger.info(
+            {
+              event: "shared_content_mismatch",
+              token,
+              documentPath: rel,
+              kind: "markdown",
+            },
+            "shared: content hash mismatch",
+          );
+          return contentChangedResponse();
+        }
+        const { content } = parseFrontmatter(raw);
         logger.info(
           {
-            event: "shared_content_mismatch",
+            event: "shared_page_viewed",
             token,
-            documentPath,
+            documentPath: rel,
             kind: "markdown",
           },
-          "shared: content hash mismatch",
+          "shared: document viewed",
         );
-        return contentChangedResponse();
-      }
-      const { content } = parseFrontmatter(raw);
-      logger.info(
-        {
-          event: "shared_page_viewed",
-          token,
-          documentPath,
-          kind: "markdown",
-        },
-        "shared: document viewed",
-      );
-      return NextResponse.json(
-        { content, path: documentPath },
-        { headers: { [SHARED_CONTENT_KIND_HEADER]: "markdown" } },
-      );
-    } catch (err) {
-      return mapSharedError(err, token, documentPath);
-    }
-  }
-
-  // Binary branch — validate metadata without reading bytes, then either
-  // trust the verdict cache (fast path) or hash via a fresh stream before
-  // serving (slow path: first view OR file mutated since last verify).
-  try {
-    const binary = await validateBinaryFile(kbRoot, documentPath);
-
-    const cachedVerdict = shareHashVerdictCache.get(
-      token,
-      binary.ino,
-      binary.mtimeMs,
-      binary.size,
-    );
-
-    if (cachedVerdict !== true) {
-      const hashResult = await hashAndVerify(binary, contentSha256);
-      if (hashResult !== "match") {
-        logger.info(
-          {
-            event: "shared_content_mismatch",
-            token,
-            documentPath,
-            kind: "binary",
-            reason: hashResult,
-          },
-          "shared: content hash mismatch",
+        return NextResponse.json(
+          { content, path: rel },
+          { headers: { [SHARED_CONTENT_KIND_HEADER]: "markdown" } },
         );
-        return contentChangedResponse();
+      } catch (err) {
+        return mapSharedError(err, token, rel);
       }
-      shareHashVerdictCache.set(token, binary.ino, binary.mtimeMs, binary.size);
-    }
-
-    logger.info(
-      {
-        event: "shared_page_viewed",
-        token,
-        documentPath,
-        kind: deriveBinaryKind(binary),
-        contentType: binary.contentType,
-        cached: cachedVerdict === true,
-      },
-      "shared: document viewed",
-    );
-    return await buildBinaryResponse(binary, request, {
-      // Strong ETag from the stored content hash: a repeat view with a
-      // matching If-None-Match returns 304 without re-opening the fd.
-      strongETag: contentSha256,
-    });
-  } catch (err) {
-    return mapSharedError(err, token, documentPath);
-  }
-}
-
-/**
- * Hash the currently-on-disk bytes and compare to the stored hash. Returns
- * "match" on success, a reason string on mismatch (surfaces in the
- * shared_content_mismatch log), and re-throws `BinaryOpenError` /
- * KB errors so the route-level catch can map them to HTTP responses.
- */
-async function hashAndVerify(
-  meta: BinaryFileMetadata,
-  expectedHash: string,
-): Promise<"match" | "inode-drift" | "hash-mismatch"> {
-  let currentHash: string;
-  try {
-    const hashStreamObj = await openBinaryStream(meta.filePath, {
-      expected: { ino: meta.ino, size: meta.size },
-    });
-    currentHash = await hashStream(hashStreamObj);
-  } catch (err) {
-    if (err instanceof BinaryOpenError && err.code === "content-changed") {
-      return "inode-drift";
-    }
-    throw err;
-  }
-  return currentHash === expectedHash ? "match" : "hash-mismatch";
+    },
+    onBinary: async (root, rel) => {
+      try {
+        const binary = await validateBinaryFile(root, rel);
+        return await serveSharedBinaryWithHashGate({
+          expectedHash: contentSha256,
+          meta: binary,
+          request,
+          logger,
+          logContext: { token, documentPath: rel },
+        });
+      } catch (err) {
+        return mapSharedError(err, token, rel);
+      }
+    },
+  });
 }
 
 function mapSharedError(
@@ -288,7 +222,6 @@ function mapSharedError(
     logSharedFailed(token, documentPath, `binary-open:${err.code ?? "unknown"}`);
     return NextResponse.json({ error: err.message }, { status: err.status });
   }
-  // Unknown error — mirror to Sentry so the silent-fallback rule is honored.
   reportSilentFallback(err, {
     feature: "shared-token",
     op: "serve",

--- a/apps/web-platform/lib/kb-extensions.ts
+++ b/apps/web-platform/lib/kb-extensions.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared KB file-extension classifier. Pure string helpers with zero Node
+ * dependencies so both client (React) and server (Next route handlers) can
+ * import from one authority.
+ *
+ * The markdown dispatch fork in both `/api/kb/content/[...path]` and
+ * `/api/shared/[token]` keys off `isMarkdownKbPath`; the dashboard viewer
+ * page keys off the same helper so `NOTES.MD` classifies identically on
+ * client and server.
+ */
+
+export function getKbExtension(relPath: string): string {
+  const lastSlash = relPath.lastIndexOf("/");
+  const basename = lastSlash === -1 ? relPath : relPath.slice(lastSlash + 1);
+  const lastDot = basename.lastIndexOf(".");
+  if (lastDot <= 0) return "";
+  return basename.slice(lastDot).toLowerCase();
+}
+
+export function isMarkdownKbPath(relPath: string): boolean {
+  const ext = getKbExtension(relPath);
+  return ext === ".md" || ext === "";
+}

--- a/apps/web-platform/server/kb-binary-response.ts
+++ b/apps/web-platform/server/kb-binary-response.ts
@@ -137,14 +137,6 @@ export async function validateBinaryFile(
 }
 
 /**
- * Deprecated alias preserved for backward compatibility during the rename
- * landing. Will be removed once all callers migrate to validateBinaryFile.
- *
- * @deprecated Use validateBinaryFile.
- */
-export const readBinaryFile = validateBinaryFile;
-
-/**
  * Open a fresh O_NOFOLLOW read stream for a filePath previously validated
  * by validateBinaryFile. The returned Node Readable is backed by the
  * opened FileHandle with autoClose: true — fd lifetime is tied to the

--- a/apps/web-platform/server/kb-binary-response.ts
+++ b/apps/web-platform/server/kb-binary-response.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { Readable } from "node:stream";
 import { isPathInWorkspace } from "@/server/sandbox";
 import { KB_BINARY_RESPONSE_CSP } from "@/lib/kb-csp";
+import { getKbExtension } from "@/lib/kb-extensions";
 
 export const MAX_BINARY_SIZE = 50 * 1024 * 1024; // 50 MB
 
@@ -114,7 +115,7 @@ export async function validateBinaryFile(
     if (stat.size > MAX_BINARY_SIZE) {
       return { ok: false, status: 413, error: "File exceeds maximum size limit" };
     }
-    const ext = path.extname(relativePath).toLowerCase();
+    const ext = getKbExtension(relativePath);
     const contentType = CONTENT_TYPE_MAP[ext] || "application/octet-stream";
     const disposition = ATTACHMENT_EXTENSIONS.has(ext) ? "attachment" : "inline";
     const rawName = path.basename(relativePath);

--- a/apps/web-platform/server/kb-binary-response.ts
+++ b/apps/web-platform/server/kb-binary-response.ts
@@ -12,6 +12,7 @@ import {
   SHARED_CONTENT_KIND_HEADER,
   type SharedContentKind,
 } from "@/lib/shared-kind";
+import { getKbExtension } from "@/lib/kb-extensions";
 
 export { SHARED_CONTENT_KIND_HEADER };
 export type { SharedContentKind };

--- a/apps/web-platform/server/kb-content-hash.ts
+++ b/apps/web-platform/server/kb-content-hash.ts
@@ -9,7 +9,7 @@ import { pipeline } from "node:stream/promises";
 
 /**
  * SHA-256 of a byte buffer, lowercase hex. Use when the caller already
- * holds the full buffer (e.g. readBinaryFile returns buffer).
+ * holds the full buffer (e.g. markdown files read via readContentRaw).
  */
 export function hashBytes(buf: Buffer): string {
   return createHash("sha256").update(buf).digest("hex");

--- a/apps/web-platform/server/kb-reader.ts
+++ b/apps/web-platform/server/kb-reader.ts
@@ -256,8 +256,9 @@ export async function buildTree(
  * Safe for markdown only — size is bounded by `KB_MAX_FILE_SIZE` (~1 MB).
  * Do NOT reuse this helper for the binary path; the size ceiling there
  * (`MAX_BINARY_SIZE`, 50 MB) would double-allocate as `buffer + utf-8 raw`.
- * Binary hashing should use `hashBytes` over the buffer returned by
- * `readBinaryFile`, or `hashStream` with a fd-owned ReadStream.
+ * Binary hashing should use `hashStream` with a fd-owned ReadStream
+ * (see `openBinaryStream` + `hashStream`) — binary bytes are never held
+ * entirely in memory.
  */
 export async function readContentRaw(
   kbRoot: string,

--- a/apps/web-platform/server/kb-serve.ts
+++ b/apps/web-platform/server/kb-serve.ts
@@ -1,0 +1,197 @@
+import type { Logger } from "pino";
+import { NextResponse } from "next/server";
+import { isMarkdownKbPath } from "@/lib/kb-extensions";
+import {
+  validateBinaryFile,
+  buildBinaryResponse,
+  openBinaryStream,
+  BinaryOpenError,
+  type BinaryFileMetadata,
+} from "@/server/kb-binary-response";
+import { hashStream } from "@/server/kb-content-hash";
+import { shareHashVerdictCache } from "@/server/share-hash-verdict-cache";
+
+// 410 response shared between the markdown and binary branches of the share
+// route. Extracted here so serveBinaryWithHashGate can use it without the
+// route re-exporting a helper (Next.js route-file export validator allows
+// only HTTP method handlers from app/**/route.ts).
+export function contentChangedResponse(): Response {
+  return NextResponse.json(
+    {
+      error: "The shared file has been modified since it was shared.",
+      code: "content-changed",
+    },
+    { status: 410 },
+  );
+}
+
+export async function serveBinary(
+  kbRoot: string,
+  relativePath: string,
+  opts: {
+    request: Request;
+    onError?: (status: number, reason: string, code?: string) => void;
+  },
+): Promise<Response> {
+  const result = await validateBinaryFile(kbRoot, relativePath);
+  if (!result.ok) {
+    opts.onError?.(result.status, result.error);
+    return NextResponse.json(
+      { error: result.error },
+      { status: result.status },
+    );
+  }
+  try {
+    return await buildBinaryResponse(result, opts.request);
+  } catch (err) {
+    if (err instanceof BinaryOpenError) {
+      opts.onError?.(err.status, err.message, err.code);
+      return NextResponse.json(
+        { error: err.message },
+        { status: err.status },
+      );
+    }
+    throw err;
+  }
+}
+
+export async function serveKbFile(
+  kbRoot: string,
+  relativePath: string,
+  opts: {
+    request: Request;
+    onMarkdown: (kbRoot: string, relativePath: string) => Promise<Response>;
+    onBinary?: (kbRoot: string, relativePath: string) => Promise<Response>;
+  },
+): Promise<Response> {
+  if (isMarkdownKbPath(relativePath)) {
+    return opts.onMarkdown(kbRoot, relativePath);
+  }
+  const onBinary =
+    opts.onBinary ??
+    ((root, rel) => serveBinary(root, rel, { request: opts.request }));
+  return onBinary(kbRoot, relativePath);
+}
+
+export interface HashGateLogContext {
+  token: string;
+  documentPath: string;
+}
+
+// Verdict-cache + hash-stream + serve orchestration for shared binary files.
+// Returns ONLY a Response — no side-channel fields. Log emission happens
+// inside the helper using the caller's logger so field names, events, and
+// codes stay exact.
+export async function serveBinaryWithHashGate(args: {
+  token: string;
+  expectedHash: string;
+  meta: BinaryFileMetadata;
+  request: Request;
+  logger: Logger;
+  logContext: HashGateLogContext;
+}): Promise<Response> {
+  const { token, expectedHash, meta, request, logger, logContext } = args;
+  const cachedVerdict = shareHashVerdictCache.get(
+    token,
+    meta.ino,
+    meta.mtimeMs,
+    meta.size,
+  );
+
+  if (cachedVerdict !== true) {
+    let currentHash: string;
+    try {
+      const stream = await openBinaryStream(meta.filePath, {
+        expected: { ino: meta.ino, size: meta.size },
+      });
+      currentHash = await hashStream(stream);
+    } catch (err) {
+      if (err instanceof BinaryOpenError) {
+        if (err.code === "content-changed") {
+          logger.info(
+            {
+              event: "shared_content_mismatch",
+              token,
+              documentPath: logContext.documentPath,
+              kind: "binary",
+              reason: "inode-drift",
+            },
+            "shared: inode drift between validate and hash",
+          );
+          return contentChangedResponse();
+        }
+        logger.warn(
+          {
+            err: err.message,
+            code: err.code,
+            token,
+            path: logContext.documentPath,
+          },
+          "shared: open failed on hash pass",
+        );
+        return NextResponse.json(
+          { error: err.message },
+          { status: err.status },
+        );
+      }
+      logger.error(
+        { err, token, path: logContext.documentPath },
+        "shared: hash stream drain failed",
+      );
+      return NextResponse.json(
+        { error: "An unexpected error occurred" },
+        { status: 500 },
+      );
+    }
+    if (currentHash !== expectedHash) {
+      logger.info(
+        {
+          event: "shared_content_mismatch",
+          token,
+          documentPath: logContext.documentPath,
+          kind: "binary",
+        },
+        "shared: content hash mismatch",
+      );
+      return contentChangedResponse();
+    }
+    shareHashVerdictCache.set(token, meta.ino, meta.mtimeMs, meta.size);
+  }
+
+  logger.info(
+    {
+      event: "shared_page_viewed",
+      token,
+      documentPath: logContext.documentPath,
+      contentType: meta.contentType,
+      cached: cachedVerdict === true,
+    },
+    "shared: document viewed",
+  );
+  try {
+    return await buildBinaryResponse(meta, request, {
+      strongETag: expectedHash,
+    });
+  } catch (err) {
+    if (err instanceof BinaryOpenError && err.code === "content-changed") {
+      logger.info(
+        {
+          event: "shared_content_mismatch",
+          token,
+          documentPath: logContext.documentPath,
+          kind: "binary",
+          reason: "inode-drift-serve",
+        },
+        "shared: inode drift between hash and serve",
+      );
+      return contentChangedResponse();
+    }
+    if (err instanceof BinaryOpenError) {
+      return NextResponse.json(
+        { error: err.message },
+        { status: err.status },
+      );
+    }
+    throw err;
+  }
+}

--- a/apps/web-platform/server/kb-serve.ts
+++ b/apps/web-platform/server/kb-serve.ts
@@ -10,10 +10,11 @@ import {
 } from "@/server/kb-binary-response";
 import { hashStream } from "@/server/kb-content-hash";
 import { shareHashVerdictCache } from "@/server/share-hash-verdict-cache";
+import { reportSilentFallback } from "@/server/observability";
 
 // 410 response shared between the markdown and binary branches of the share
-// route. Extracted here so serveBinaryWithHashGate can use it without the
-// route re-exporting a helper (Next.js route-file export validator allows
+// route. Extracted here so serveSharedBinaryWithHashGate can use it without
+// the route re-exporting a helper (Next.js route-file export validator allows
 // only HTTP method handlers from app/**/route.ts).
 export function contentChangedResponse(): Response {
   return NextResponse.json(
@@ -25,6 +26,13 @@ export function contentChangedResponse(): Response {
   );
 }
 
+/**
+ * Serve a binary KB file with default owner-route semantics: validate
+ * metadata, stream bytes with weak ETag / Range / 304 support. onError is
+ * invoked on every non-ok branch so callers can emit their own structured
+ * log lines; it is NOT a short-circuit (the caller's log is a side effect,
+ * the helper still returns the standard JSON error Response).
+ */
 export async function serveBinary(
   kbRoot: string,
   relativePath: string,
@@ -55,22 +63,24 @@ export async function serveBinary(
   }
 }
 
+/**
+ * Dispatch a KB request to markdown or binary handler by extension. Both
+ * handlers are required — callers decide their own error-logging and
+ * response-shaping, so the dispatcher has nothing sensible to default to.
+ */
 export async function serveKbFile(
   kbRoot: string,
   relativePath: string,
   opts: {
     request: Request;
     onMarkdown: (kbRoot: string, relativePath: string) => Promise<Response>;
-    onBinary?: (kbRoot: string, relativePath: string) => Promise<Response>;
+    onBinary: (kbRoot: string, relativePath: string) => Promise<Response>;
   },
 ): Promise<Response> {
   if (isMarkdownKbPath(relativePath)) {
     return opts.onMarkdown(kbRoot, relativePath);
   }
-  const onBinary =
-    opts.onBinary ??
-    ((root, rel) => serveBinary(root, rel, { request: opts.request }));
-  return onBinary(kbRoot, relativePath);
+  return opts.onBinary(kbRoot, relativePath);
 }
 
 export interface HashGateLogContext {
@@ -78,19 +88,20 @@ export interface HashGateLogContext {
   documentPath: string;
 }
 
-// Verdict-cache + hash-stream + serve orchestration for shared binary files.
-// Returns ONLY a Response — no side-channel fields. Log emission happens
-// inside the helper using the caller's logger so field names, events, and
-// codes stay exact.
-export async function serveBinaryWithHashGate(args: {
-  token: string;
+// Verdict-cache + hash-stream + serve orchestration for SHARED binary files
+// (i.e., accessed via /api/shared/[token], not the owner route). Returns ONLY
+// a Response — no side-channel fields. Log emission happens inside the helper
+// using the caller's logger so field names, events, and codes stay exact
+// (observability dashboards and SIEM filters key off these strings).
+export async function serveSharedBinaryWithHashGate(args: {
   expectedHash: string;
   meta: BinaryFileMetadata;
   request: Request;
   logger: Logger;
   logContext: HashGateLogContext;
 }): Promise<Response> {
-  const { token, expectedHash, meta, request, logger, logContext } = args;
+  const { expectedHash, meta, request, logger, logContext } = args;
+  const { token, documentPath } = logContext;
   const cachedVerdict = shareHashVerdictCache.get(
     token,
     meta.ino,
@@ -112,7 +123,7 @@ export async function serveBinaryWithHashGate(args: {
             {
               event: "shared_content_mismatch",
               token,
-              documentPath: logContext.documentPath,
+              documentPath,
               kind: "binary",
               reason: "inode-drift",
             },
@@ -125,19 +136,29 @@ export async function serveBinaryWithHashGate(args: {
             err: err.message,
             code: err.code,
             token,
-            path: logContext.documentPath,
+            path: documentPath,
           },
           "shared: open failed on hash pass",
         );
+        reportSilentFallback(err, {
+          feature: "shared-token",
+          op: "hash-gate",
+          extra: { token, documentPath },
+        });
         return NextResponse.json(
           { error: err.message },
           { status: err.status },
         );
       }
       logger.error(
-        { err, token, path: logContext.documentPath },
+        { err, token, path: documentPath },
         "shared: hash stream drain failed",
       );
+      reportSilentFallback(err, {
+        feature: "shared-token",
+        op: "hash-gate",
+        extra: { token, documentPath },
+      });
       return NextResponse.json(
         { error: "An unexpected error occurred" },
         { status: 500 },
@@ -148,7 +169,7 @@ export async function serveBinaryWithHashGate(args: {
         {
           event: "shared_content_mismatch",
           token,
-          documentPath: logContext.documentPath,
+          documentPath,
           kind: "binary",
         },
         "shared: content hash mismatch",
@@ -162,7 +183,7 @@ export async function serveBinaryWithHashGate(args: {
     {
       event: "shared_page_viewed",
       token,
-      documentPath: logContext.documentPath,
+      documentPath,
       contentType: meta.contentType,
       cached: cachedVerdict === true,
     },
@@ -178,7 +199,7 @@ export async function serveBinaryWithHashGate(args: {
         {
           event: "shared_content_mismatch",
           token,
-          documentPath: logContext.documentPath,
+          documentPath,
           kind: "binary",
           reason: "inode-drift-serve",
         },
@@ -187,6 +208,15 @@ export async function serveBinaryWithHashGate(args: {
       return contentChangedResponse();
     }
     if (err instanceof BinaryOpenError) {
+      logger.warn(
+        { err: err.message, code: err.code, token, path: documentPath },
+        "shared: open failed on serve",
+      );
+      reportSilentFallback(err, {
+        feature: "shared-token",
+        op: "serve",
+        extra: { token, documentPath },
+      });
       return NextResponse.json(
         { error: err.message },
         { status: err.status },

--- a/apps/web-platform/server/kb-serve.ts
+++ b/apps/web-platform/server/kb-serve.ts
@@ -2,9 +2,16 @@ import type { Logger } from "pino";
 import { NextResponse } from "next/server";
 import { isMarkdownKbPath } from "@/lib/kb-extensions";
 import {
+  KbAccessDeniedError,
+  KbFileTooLargeError,
+  KbNotFoundError,
+} from "@/server/kb-reader";
+import {
   validateBinaryFile,
   buildBinaryResponse,
   openBinaryStream,
+  deriveBinaryKind,
+  SHARED_CONTENT_KIND_HEADER,
   BinaryOpenError,
   type BinaryFileMetadata,
 } from "@/server/kb-binary-response";
@@ -41,16 +48,26 @@ export async function serveBinary(
     onError?: (status: number, reason: string, code?: string) => void;
   },
 ): Promise<Response> {
-  const result = await validateBinaryFile(kbRoot, relativePath);
-  if (!result.ok) {
-    opts.onError?.(result.status, result.error);
-    return NextResponse.json(
-      { error: result.error },
-      { status: result.status },
-    );
+  let meta: BinaryFileMetadata;
+  try {
+    meta = await validateBinaryFile(kbRoot, relativePath);
+  } catch (err) {
+    if (err instanceof KbAccessDeniedError) {
+      opts.onError?.(403, "Access denied");
+      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+    if (err instanceof KbNotFoundError) {
+      opts.onError?.(404, "File not found");
+      return NextResponse.json({ error: "File not found" }, { status: 404 });
+    }
+    if (err instanceof KbFileTooLargeError) {
+      opts.onError?.(413, err.message);
+      return NextResponse.json({ error: err.message }, { status: 413 });
+    }
+    throw err;
   }
   try {
-    return await buildBinaryResponse(result, opts.request);
+    return await buildBinaryResponse(meta, opts.request);
   } catch (err) {
     if (err instanceof BinaryOpenError) {
       opts.onError?.(err.status, err.message, err.code);
@@ -93,6 +110,10 @@ export interface HashGateLogContext {
 // a Response — no side-channel fields. Log emission happens inside the helper
 // using the caller's logger so field names, events, and codes stay exact
 // (observability dashboards and SIEM filters key off these strings).
+//
+// Caller has already run validateBinaryFile to obtain meta. Throws from the
+// validate step are the caller's responsibility so KB error mapping stays
+// consistent across markdown and binary branches.
 export async function serveSharedBinaryWithHashGate(args: {
   expectedHash: string;
   meta: BinaryFileMetadata;
@@ -110,67 +131,15 @@ export async function serveSharedBinaryWithHashGate(args: {
   );
 
   if (cachedVerdict !== true) {
-    let currentHash: string;
-    try {
-      const stream = await openBinaryStream(meta.filePath, {
-        expected: { ino: meta.ino, size: meta.size },
-      });
-      currentHash = await hashStream(stream);
-    } catch (err) {
-      if (err instanceof BinaryOpenError) {
-        if (err.code === "content-changed") {
-          logger.info(
-            {
-              event: "shared_content_mismatch",
-              token,
-              documentPath,
-              kind: "binary",
-              reason: "inode-drift",
-            },
-            "shared: inode drift between validate and hash",
-          );
-          return contentChangedResponse();
-        }
-        logger.warn(
-          {
-            err: err.message,
-            code: err.code,
-            token,
-            path: documentPath,
-          },
-          "shared: open failed on hash pass",
-        );
-        reportSilentFallback(err, {
-          feature: "shared-token",
-          op: "hash-gate",
-          extra: { token, documentPath },
-        });
-        return NextResponse.json(
-          { error: err.message },
-          { status: err.status },
-        );
-      }
-      logger.error(
-        { err, token, path: documentPath },
-        "shared: hash stream drain failed",
-      );
-      reportSilentFallback(err, {
-        feature: "shared-token",
-        op: "hash-gate",
-        extra: { token, documentPath },
-      });
-      return NextResponse.json(
-        { error: "An unexpected error occurred" },
-        { status: 500 },
-      );
-    }
-    if (currentHash !== expectedHash) {
+    const hashResult = await hashAndVerify(meta, expectedHash);
+    if (hashResult !== "match") {
       logger.info(
         {
           event: "shared_content_mismatch",
           token,
           documentPath,
           kind: "binary",
+          reason: hashResult,
         },
         "shared: content hash mismatch",
       );
@@ -184,6 +153,7 @@ export async function serveSharedBinaryWithHashGate(args: {
       event: "shared_page_viewed",
       token,
       documentPath,
+      kind: deriveBinaryKind(meta),
       contentType: meta.contentType,
       cached: cachedVerdict === true,
     },
@@ -210,7 +180,7 @@ export async function serveSharedBinaryWithHashGate(args: {
     if (err instanceof BinaryOpenError) {
       logger.warn(
         { err: err.message, code: err.code, token, path: documentPath },
-        "shared: open failed on serve",
+        "shared: binary open failed",
       );
       reportSilentFallback(err, {
         feature: "shared-token",
@@ -225,3 +195,31 @@ export async function serveSharedBinaryWithHashGate(args: {
     throw err;
   }
 }
+
+// Hash the currently-on-disk bytes and compare to the stored hash. Returns
+// "match" on success, a reason string on mismatch (surfaces in the
+// shared_content_mismatch log). Re-throws unexpected errors so the route-
+// level mapSharedError catch can map them to HTTP responses.
+async function hashAndVerify(
+  meta: BinaryFileMetadata,
+  expectedHash: string,
+): Promise<"match" | "inode-drift" | "hash-mismatch"> {
+  let currentHash: string;
+  try {
+    const stream = await openBinaryStream(meta.filePath, {
+      expected: { ino: meta.ino, size: meta.size },
+    });
+    currentHash = await hashStream(stream);
+  } catch (err) {
+    if (err instanceof BinaryOpenError && err.code === "content-changed") {
+      return "inode-drift";
+    }
+    throw err;
+  }
+  return currentHash === expectedHash ? "match" : "hash-mismatch";
+}
+
+// Re-export for caller convenience (share route uses the header on markdown
+// responses too, so keeping kb-serve.ts as the single import site for all
+// KB-serving primitives shrinks the route's import block).
+export { SHARED_CONTENT_KIND_HEADER };

--- a/apps/web-platform/test/kb-extensions.test.ts
+++ b/apps/web-platform/test/kb-extensions.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { getKbExtension, isMarkdownKbPath } from "@/lib/kb-extensions";
+
+describe("getKbExtension", () => {
+  it("returns lowercased extension with leading dot", () => {
+    expect(getKbExtension("foo.md")).toBe(".md");
+  });
+
+  it("case-folds uppercase extensions", () => {
+    expect(getKbExtension("FOO.MD")).toBe(".md");
+  });
+
+  it("handles nested paths", () => {
+    expect(getKbExtension("notes/doc.PDF")).toBe(".pdf");
+  });
+
+  it("returns empty for extensionless paths", () => {
+    expect(getKbExtension("noext")).toBe("");
+    expect(getKbExtension("notes/readme")).toBe("");
+  });
+
+  it("treats leading-dot-only filenames as no extension (unix hidden files)", () => {
+    expect(getKbExtension(".hidden")).toBe("");
+    expect(getKbExtension("dir/.config")).toBe("");
+  });
+
+  it("returns only the last segment for multi-dot filenames", () => {
+    expect(getKbExtension("a/b/c.tar.gz")).toBe(".gz");
+    expect(getKbExtension("archive.tar.bz2")).toBe(".bz2");
+  });
+
+  it("returns empty for empty string", () => {
+    expect(getKbExtension("")).toBe("");
+  });
+
+  it("ignores dots in directory segments", () => {
+    expect(getKbExtension("v1.2/readme")).toBe("");
+  });
+});
+
+describe("isMarkdownKbPath", () => {
+  it("treats .md as markdown", () => {
+    expect(isMarkdownKbPath("foo.md")).toBe(true);
+  });
+
+  it("treats uppercase .MD as markdown (regression for #2317)", () => {
+    expect(isMarkdownKbPath("NOTES.MD")).toBe(true);
+    expect(isMarkdownKbPath("dir/NOTES.Md")).toBe(true);
+  });
+
+  it("treats extensionless paths as markdown", () => {
+    expect(isMarkdownKbPath("foo")).toBe(true);
+    expect(isMarkdownKbPath("notes/readme")).toBe(true);
+    expect(isMarkdownKbPath("")).toBe(true);
+  });
+
+  it("treats binary extensions as non-markdown", () => {
+    expect(isMarkdownKbPath("foo.pdf")).toBe(false);
+    expect(isMarkdownKbPath("foo.PDF")).toBe(false);
+    expect(isMarkdownKbPath("images/logo.png")).toBe(false);
+    expect(isMarkdownKbPath("data.csv")).toBe(false);
+  });
+
+  it("treats hidden files (leading dot only) as markdown (no extension)", () => {
+    expect(isMarkdownKbPath(".gitignore")).toBe(true);
+  });
+});

--- a/apps/web-platform/test/kb-extensions.test.ts
+++ b/apps/web-platform/test/kb-extensions.test.ts
@@ -36,6 +36,24 @@ describe("getKbExtension", () => {
   it("ignores dots in directory segments", () => {
     expect(getKbExtension("v1.2/readme")).toBe("");
   });
+
+  it("returns trailing-dot as the extension (matches path.extname)", () => {
+    expect(getKbExtension("foo.")).toBe(".");
+  });
+
+  it("handles double-leading-dot filenames", () => {
+    // Diverges intentionally from path.extname("..bashrc") === "":
+    // getKbExtension treats the second dot as the extension marker.
+    // Safe because ".bashrc" is not in CONTENT_TYPE_MAP — falls through
+    // to application/octet-stream on both code paths.
+    expect(getKbExtension("..bashrc")).toBe(".bashrc");
+  });
+
+  it("treats backslash as a filename character on POSIX (not a separator)", () => {
+    // Windows-style paths on a POSIX server: the entire string is the
+    // basename, extension is computed from the last '.'.
+    expect(getKbExtension("dir\\file.md")).toBe(".md");
+  });
 });
 
 describe("isMarkdownKbPath", () => {

--- a/apps/web-platform/test/kb-serve-hash-gate.test.ts
+++ b/apps/web-platform/test/kb-serve-hash-gate.test.ts
@@ -5,7 +5,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { hashBytes } from "@/server/kb-content-hash";
 import { validateBinaryFile } from "@/server/kb-binary-response";
 import { __resetShareHashVerdictCacheForTest } from "@/server/share-hash-verdict-cache";
-import { serveBinaryWithHashGate } from "@/server/kb-serve";
+import { serveSharedBinaryWithHashGate } from "@/server/kb-serve";
+
+// A 64-char hex string that will never match a real content_sha256.
+const WRONG_HASH = "0".repeat(64);
 
 const loggerStub = {
   info: vi.fn(),
@@ -19,8 +22,11 @@ const loggerStub = {
   level: "info",
 };
 
+vi.mock("@/server/observability", () => ({
+  reportSilentFallback: vi.fn(),
+}));
+
 function logger() {
-  // Cast to any for test purposes — the helper only uses info/warn/error.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return loggerStub as any;
 }
@@ -44,7 +50,7 @@ afterEach(() => {
   fs.rmSync(tmpWorkspace, { recursive: true, force: true });
 });
 
-describe("serveBinaryWithHashGate", () => {
+describe("serveSharedBinaryWithHashGate", () => {
   it("cache miss + hash match: serves 200 with strong ETag", async () => {
     const bytes = Buffer.from("fake-png-content");
     const expectedHash = hashBytes(bytes);
@@ -53,8 +59,7 @@ describe("serveBinaryWithHashGate", () => {
     const meta = await validateBinaryFile(kbRoot, "logo.png");
     if (!meta.ok) throw new Error("meta not ok");
 
-    const res = await serveBinaryWithHashGate({
-      token: "tok",
+    const res = await serveSharedBinaryWithHashGate({
       expectedHash,
       meta,
       request: buildRequest(),
@@ -81,8 +86,7 @@ describe("serveBinaryWithHashGate", () => {
     if (!meta.ok) throw new Error("meta not ok");
 
     // Prime the cache
-    await serveBinaryWithHashGate({
-      token: "tok",
+    await serveSharedBinaryWithHashGate({
       expectedHash,
       meta,
       request: buildRequest(),
@@ -91,8 +95,7 @@ describe("serveBinaryWithHashGate", () => {
     });
     loggerStub.info.mockClear();
 
-    const res = await serveBinaryWithHashGate({
-      token: "tok",
+    const res = await serveSharedBinaryWithHashGate({
       expectedHash,
       meta,
       request: buildRequest(),
@@ -116,9 +119,8 @@ describe("serveBinaryWithHashGate", () => {
     const meta = await validateBinaryFile(kbRoot, "mismatch.png");
     if (!meta.ok) throw new Error("meta not ok");
 
-    const res = await serveBinaryWithHashGate({
-      token: "tok",
-      expectedHash: "deadbeef-wrong-hash",
+    const res = await serveSharedBinaryWithHashGate({
+      expectedHash: WRONG_HASH,
       meta,
       request: buildRequest(),
       logger: logger(),
@@ -149,8 +151,7 @@ describe("serveBinaryWithHashGate", () => {
     fs.rmSync(filePath);
     fs.writeFileSync(filePath, Buffer.from("different-size-bytes"));
 
-    const res = await serveBinaryWithHashGate({
-      token: "tok",
+    const res = await serveSharedBinaryWithHashGate({
       expectedHash,
       meta,
       request: buildRequest(),
@@ -170,6 +171,49 @@ describe("serveBinaryWithHashGate", () => {
     );
   });
 
+  it("inode drift between hash and serve: returns 410 with reason=inode-drift-serve", async () => {
+    const bytes = Buffer.from("serve-drift-bytes");
+    const expectedHash = hashBytes(bytes);
+    const filePath = path.join(kbRoot, "serve-drift.png");
+    fs.writeFileSync(filePath, bytes);
+    const meta = await validateBinaryFile(kbRoot, "serve-drift.png");
+    if (!meta.ok) throw new Error("meta not ok");
+
+    // Prime the cache so the helper skips the hash pass and goes straight
+    // to buildBinaryResponse — where we want the TOCTOU drift to trigger.
+    await serveSharedBinaryWithHashGate({
+      expectedHash,
+      meta,
+      request: buildRequest(),
+      logger: logger(),
+      logContext: { token: "tok", documentPath: "serve-drift.png" },
+    });
+    loggerStub.info.mockClear();
+
+    // Swap inode+size between the cached verdict and the serve-stream open.
+    fs.rmSync(filePath);
+    fs.writeFileSync(filePath, Buffer.from("different-size-bytes-now-serving"));
+
+    const res = await serveSharedBinaryWithHashGate({
+      expectedHash,
+      meta,
+      request: buildRequest(),
+      logger: logger(),
+      logContext: { token: "tok", documentPath: "serve-drift.png" },
+    });
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body).toMatchObject({ code: "content-changed" });
+    expect(loggerStub.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "shared_content_mismatch",
+        kind: "binary",
+        reason: "inode-drift-serve",
+      }),
+      expect.any(String),
+    );
+  });
+
   it("BinaryOpenError (non content-changed) during hash: returns helper status", async () => {
     const bytes = Buffer.from("hash-fail-bytes");
     const expectedHash = hashBytes(bytes);
@@ -182,8 +226,7 @@ describe("serveBinaryWithHashGate", () => {
     // BinaryOpenError(404) with no code.
     fs.rmSync(filePath);
 
-    const res = await serveBinaryWithHashGate({
-      token: "tok",
+    const res = await serveSharedBinaryWithHashGate({
       expectedHash,
       meta,
       request: buildRequest(),

--- a/apps/web-platform/test/kb-serve-hash-gate.test.ts
+++ b/apps/web-platform/test/kb-serve-hash-gate.test.ts
@@ -57,7 +57,6 @@ describe("serveSharedBinaryWithHashGate", () => {
     const filePath = path.join(kbRoot, "logo.png");
     fs.writeFileSync(filePath, bytes);
     const meta = await validateBinaryFile(kbRoot, "logo.png");
-    if (!meta.ok) throw new Error("meta not ok");
 
     const res = await serveSharedBinaryWithHashGate({
       expectedHash,
@@ -83,7 +82,6 @@ describe("serveSharedBinaryWithHashGate", () => {
     const filePath = path.join(kbRoot, "cached.png");
     fs.writeFileSync(filePath, bytes);
     const meta = await validateBinaryFile(kbRoot, "cached.png");
-    if (!meta.ok) throw new Error("meta not ok");
 
     // Prime the cache
     await serveSharedBinaryWithHashGate({
@@ -117,7 +115,6 @@ describe("serveSharedBinaryWithHashGate", () => {
     const filePath = path.join(kbRoot, "mismatch.png");
     fs.writeFileSync(filePath, bytes);
     const meta = await validateBinaryFile(kbRoot, "mismatch.png");
-    if (!meta.ok) throw new Error("meta not ok");
 
     const res = await serveSharedBinaryWithHashGate({
       expectedHash: WRONG_HASH,
@@ -144,7 +141,6 @@ describe("serveSharedBinaryWithHashGate", () => {
     const filePath = path.join(kbRoot, "drift.png");
     fs.writeFileSync(filePath, bytes);
     const meta = await validateBinaryFile(kbRoot, "drift.png");
-    if (!meta.ok) throw new Error("meta not ok");
 
     // Simulate inode drift: remove and recreate with different size between
     // validateBinaryFile and the hash pass inside the helper.
@@ -177,7 +173,6 @@ describe("serveSharedBinaryWithHashGate", () => {
     const filePath = path.join(kbRoot, "serve-drift.png");
     fs.writeFileSync(filePath, bytes);
     const meta = await validateBinaryFile(kbRoot, "serve-drift.png");
-    if (!meta.ok) throw new Error("meta not ok");
 
     // Prime the cache so the helper skips the hash pass and goes straight
     // to buildBinaryResponse — where we want the TOCTOU drift to trigger.
@@ -214,29 +209,27 @@ describe("serveSharedBinaryWithHashGate", () => {
     );
   });
 
-  it("BinaryOpenError (non content-changed) during hash: returns helper status", async () => {
+  it("BinaryOpenError (non content-changed) during hash: re-throws for caller to map", async () => {
     const bytes = Buffer.from("hash-fail-bytes");
     const expectedHash = hashBytes(bytes);
     const filePath = path.join(kbRoot, "gone.png");
     fs.writeFileSync(filePath, bytes);
     const meta = await validateBinaryFile(kbRoot, "gone.png");
-    if (!meta.ok) throw new Error("meta not ok");
 
     // Remove the file entirely — openBinaryStream will throw
-    // BinaryOpenError(404) with no code.
+    // BinaryOpenError(404) with no code. The helper re-throws so the
+    // route-level mapSharedError catch owns the HTTP mapping and
+    // shared_page_failed log.
     fs.rmSync(filePath);
 
-    const res = await serveSharedBinaryWithHashGate({
-      expectedHash,
-      meta,
-      request: buildRequest(),
-      logger: logger(),
-      logContext: { token: "tok", documentPath: "gone.png" },
-    });
-    expect(res.status).toBe(404);
-    expect(loggerStub.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ token: "tok", path: "gone.png" }),
-      expect.stringContaining("open failed on hash pass"),
-    );
+    await expect(
+      serveSharedBinaryWithHashGate({
+        expectedHash,
+        meta,
+        request: buildRequest(),
+        logger: logger(),
+        logContext: { token: "tok", documentPath: "gone.png" },
+      }),
+    ).rejects.toMatchObject({ name: "BinaryOpenError", status: 404 });
   });
 });

--- a/apps/web-platform/test/kb-serve-hash-gate.test.ts
+++ b/apps/web-platform/test/kb-serve-hash-gate.test.ts
@@ -1,0 +1,199 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { hashBytes } from "@/server/kb-content-hash";
+import { validateBinaryFile } from "@/server/kb-binary-response";
+import { __resetShareHashVerdictCacheForTest } from "@/server/share-hash-verdict-cache";
+import { serveBinaryWithHashGate } from "@/server/kb-serve";
+
+const loggerStub = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  fatal: vi.fn(),
+  silent: vi.fn(),
+  child: vi.fn(() => loggerStub),
+  level: "info",
+};
+
+function logger() {
+  // Cast to any for test purposes — the helper only uses info/warn/error.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return loggerStub as any;
+}
+
+function buildRequest(headers?: Record<string, string>): Request {
+  return new Request("http://localhost:3000/api/shared/tok", { headers });
+}
+
+let tmpWorkspace: string;
+let kbRoot: string;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetShareHashVerdictCacheForTest();
+  tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), "kb-hash-gate-test-"));
+  kbRoot = path.join(tmpWorkspace, "knowledge-base");
+  fs.mkdirSync(kbRoot, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpWorkspace, { recursive: true, force: true });
+});
+
+describe("serveBinaryWithHashGate", () => {
+  it("cache miss + hash match: serves 200 with strong ETag", async () => {
+    const bytes = Buffer.from("fake-png-content");
+    const expectedHash = hashBytes(bytes);
+    const filePath = path.join(kbRoot, "logo.png");
+    fs.writeFileSync(filePath, bytes);
+    const meta = await validateBinaryFile(kbRoot, "logo.png");
+    if (!meta.ok) throw new Error("meta not ok");
+
+    const res = await serveBinaryWithHashGate({
+      token: "tok",
+      expectedHash,
+      meta,
+      request: buildRequest(),
+      logger: logger(),
+      logContext: { token: "tok", documentPath: "logo.png" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("ETag")).toBe(`"${expectedHash}"`);
+    expect(loggerStub.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "shared_page_viewed",
+        cached: false,
+      }),
+      expect.any(String),
+    );
+  });
+
+  it("cache hit: serves 200 without logging mismatch, cached=true", async () => {
+    const bytes = Buffer.from("cache-hit-content");
+    const expectedHash = hashBytes(bytes);
+    const filePath = path.join(kbRoot, "cached.png");
+    fs.writeFileSync(filePath, bytes);
+    const meta = await validateBinaryFile(kbRoot, "cached.png");
+    if (!meta.ok) throw new Error("meta not ok");
+
+    // Prime the cache
+    await serveBinaryWithHashGate({
+      token: "tok",
+      expectedHash,
+      meta,
+      request: buildRequest(),
+      logger: logger(),
+      logContext: { token: "tok", documentPath: "cached.png" },
+    });
+    loggerStub.info.mockClear();
+
+    const res = await serveBinaryWithHashGate({
+      token: "tok",
+      expectedHash,
+      meta,
+      request: buildRequest(),
+      logger: logger(),
+      logContext: { token: "tok", documentPath: "cached.png" },
+    });
+    expect(res.status).toBe(200);
+    expect(loggerStub.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "shared_page_viewed",
+        cached: true,
+      }),
+      expect.any(String),
+    );
+  });
+
+  it("cache miss + hash mismatch: returns 410 content-changed", async () => {
+    const bytes = Buffer.from("actual-bytes");
+    const filePath = path.join(kbRoot, "mismatch.png");
+    fs.writeFileSync(filePath, bytes);
+    const meta = await validateBinaryFile(kbRoot, "mismatch.png");
+    if (!meta.ok) throw new Error("meta not ok");
+
+    const res = await serveBinaryWithHashGate({
+      token: "tok",
+      expectedHash: "deadbeef-wrong-hash",
+      meta,
+      request: buildRequest(),
+      logger: logger(),
+      logContext: { token: "tok", documentPath: "mismatch.png" },
+    });
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body).toMatchObject({ code: "content-changed" });
+    expect(loggerStub.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "shared_content_mismatch",
+        kind: "binary",
+      }),
+      expect.any(String),
+    );
+  });
+
+  it("inode drift between validate and hash: returns 410 with reason=inode-drift", async () => {
+    const bytes = Buffer.from("original-bytes");
+    const expectedHash = hashBytes(bytes);
+    const filePath = path.join(kbRoot, "drift.png");
+    fs.writeFileSync(filePath, bytes);
+    const meta = await validateBinaryFile(kbRoot, "drift.png");
+    if (!meta.ok) throw new Error("meta not ok");
+
+    // Simulate inode drift: remove and recreate with different size between
+    // validateBinaryFile and the hash pass inside the helper.
+    fs.rmSync(filePath);
+    fs.writeFileSync(filePath, Buffer.from("different-size-bytes"));
+
+    const res = await serveBinaryWithHashGate({
+      token: "tok",
+      expectedHash,
+      meta,
+      request: buildRequest(),
+      logger: logger(),
+      logContext: { token: "tok", documentPath: "drift.png" },
+    });
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body).toMatchObject({ code: "content-changed" });
+    expect(loggerStub.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "shared_content_mismatch",
+        kind: "binary",
+        reason: "inode-drift",
+      }),
+      expect.any(String),
+    );
+  });
+
+  it("BinaryOpenError (non content-changed) during hash: returns helper status", async () => {
+    const bytes = Buffer.from("hash-fail-bytes");
+    const expectedHash = hashBytes(bytes);
+    const filePath = path.join(kbRoot, "gone.png");
+    fs.writeFileSync(filePath, bytes);
+    const meta = await validateBinaryFile(kbRoot, "gone.png");
+    if (!meta.ok) throw new Error("meta not ok");
+
+    // Remove the file entirely — openBinaryStream will throw
+    // BinaryOpenError(404) with no code.
+    fs.rmSync(filePath);
+
+    const res = await serveBinaryWithHashGate({
+      token: "tok",
+      expectedHash,
+      meta,
+      request: buildRequest(),
+      logger: logger(),
+      logContext: { token: "tok", documentPath: "gone.png" },
+    });
+    expect(res.status).toBe(404);
+    expect(loggerStub.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ token: "tok", path: "gone.png" }),
+      expect.stringContaining("open failed on hash pass"),
+    );
+  });
+});

--- a/apps/web-platform/test/kb-serve.test.ts
+++ b/apps/web-platform/test/kb-serve.test.ts
@@ -57,7 +57,8 @@ describe("serveBinary", () => {
 
     const res = await serveBinary(kbRoot, "huge.pdf", { request: buildRequest() });
     expect(res.status).toBe(413);
-    expect(await res.json()).toEqual({ error: "File exceeds maximum size limit" });
+    const body = await res.json();
+    expect(body.error).toContain("exceed");
   });
 
   test("valid PNG returns 200 with expected headers", async () => {

--- a/apps/web-platform/test/kb-serve.test.ts
+++ b/apps/web-platform/test/kb-serve.test.ts
@@ -1,0 +1,144 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { serveBinary, serveKbFile } from "@/server/kb-serve";
+
+let tmpWorkspace: string;
+let kbRoot: string;
+
+function buildRequest(): Request {
+  return new Request("http://localhost:3000/anything");
+}
+
+beforeEach(() => {
+  tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), "kb-serve-test-"));
+  kbRoot = path.join(tmpWorkspace, "knowledge-base");
+  fs.mkdirSync(kbRoot, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpWorkspace, { recursive: true, force: true });
+});
+
+describe("serveBinary", () => {
+  test("path traversal returns 403 with { error: 'Access denied' }", async () => {
+    const res = await serveBinary(kbRoot, "../../etc/passwd.png", {
+      request: buildRequest(),
+    });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Access denied" });
+  });
+
+  test("symlink returns 403", async () => {
+    const outside = path.join(tmpWorkspace, "secret.txt");
+    fs.writeFileSync(outside, "secret");
+    fs.symlinkSync(outside, path.join(kbRoot, "link.png"));
+
+    const res = await serveBinary(kbRoot, "link.png", { request: buildRequest() });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Access denied" });
+  });
+
+  test("missing file returns 404", async () => {
+    const res = await serveBinary(kbRoot, "missing.png", {
+      request: buildRequest(),
+    });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "File not found" });
+  });
+
+  test("file exceeding MAX_BINARY_SIZE returns 413", async () => {
+    const big = path.join(kbRoot, "huge.pdf");
+    const fd = fs.openSync(big, "w");
+    fs.ftruncateSync(fd, 51 * 1024 * 1024);
+    fs.closeSync(fd);
+
+    const res = await serveBinary(kbRoot, "huge.pdf", { request: buildRequest() });
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({ error: "File exceeds maximum size limit" });
+  });
+
+  test("valid PNG returns 200 with expected headers", async () => {
+    fs.writeFileSync(path.join(kbRoot, "logo.png"), Buffer.from("fake-png"));
+
+    const res = await serveBinary(kbRoot, "logo.png", { request: buildRequest() });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/png");
+    expect(res.headers.get("Accept-Ranges")).toBe("bytes");
+    expect(res.headers.get("ETag")).toBeTruthy();
+  });
+
+  test("invokes onError with (status, message) on validate rejection", async () => {
+    const onError = vi.fn();
+    const res = await serveBinary(kbRoot, "missing.png", {
+      request: buildRequest(),
+      onError,
+    });
+    expect(res.status).toBe(404);
+    expect(onError).toHaveBeenCalledWith(404, "File not found");
+  });
+});
+
+describe("serveKbFile dispatcher", () => {
+  test(".md path routes to onMarkdown", async () => {
+    const onMarkdown = vi.fn(async () => new Response("md", { status: 200 }));
+    await serveKbFile(kbRoot, "foo.md", {
+      request: buildRequest(),
+      onMarkdown,
+    });
+    expect(onMarkdown).toHaveBeenCalledWith(kbRoot, "foo.md");
+  });
+
+  test("extensionless path routes to onMarkdown", async () => {
+    const onMarkdown = vi.fn(async () => new Response("md", { status: 200 }));
+    await serveKbFile(kbRoot, "notes", {
+      request: buildRequest(),
+      onMarkdown,
+    });
+    expect(onMarkdown).toHaveBeenCalledWith(kbRoot, "notes");
+  });
+
+  test("uppercase .MD routes to onMarkdown (case-fold regression)", async () => {
+    const onMarkdown = vi.fn(async () => new Response("md", { status: 200 }));
+    await serveKbFile(kbRoot, "NOTES.MD", {
+      request: buildRequest(),
+      onMarkdown,
+    });
+    expect(onMarkdown).toHaveBeenCalledWith(kbRoot, "NOTES.MD");
+  });
+
+  test("binary path routes to onBinary override when provided", async () => {
+    const onMarkdown = vi.fn();
+    const onBinary = vi.fn(async () => new Response("bin", { status: 200 }));
+    await serveKbFile(kbRoot, "foo.pdf", {
+      request: buildRequest(),
+      onMarkdown,
+      onBinary,
+    });
+    expect(onMarkdown).not.toHaveBeenCalled();
+    expect(onBinary).toHaveBeenCalledWith(kbRoot, "foo.pdf");
+  });
+
+  test("uppercase .PDF routes to binary (case-fold regression)", async () => {
+    const onMarkdown = vi.fn();
+    const onBinary = vi.fn(async () => new Response("bin", { status: 200 }));
+    await serveKbFile(kbRoot, "foo.PDF", {
+      request: buildRequest(),
+      onMarkdown,
+      onBinary,
+    });
+    expect(onMarkdown).not.toHaveBeenCalled();
+    expect(onBinary).toHaveBeenCalledWith(kbRoot, "foo.PDF");
+  });
+
+  test("binary path without onBinary falls through to serveBinary default", async () => {
+    fs.writeFileSync(path.join(kbRoot, "logo.png"), Buffer.from("data"));
+    const res = await serveKbFile(kbRoot, "logo.png", {
+      request: buildRequest(),
+      onMarkdown: vi.fn(),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/png");
+  });
+});

--- a/apps/web-platform/test/kb-serve.test.ts
+++ b/apps/web-platform/test/kb-serve.test.ts
@@ -3,6 +3,7 @@ import os from "os";
 import path from "path";
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 import { serveBinary, serveKbFile } from "@/server/kb-serve";
+import { MAX_BINARY_SIZE } from "@/server/kb-binary-response";
 
 let tmpWorkspace: string;
 let kbRoot: string;
@@ -51,7 +52,7 @@ describe("serveBinary", () => {
   test("file exceeding MAX_BINARY_SIZE returns 413", async () => {
     const big = path.join(kbRoot, "huge.pdf");
     const fd = fs.openSync(big, "w");
-    fs.ftruncateSync(fd, 51 * 1024 * 1024);
+    fs.ftruncateSync(fd, MAX_BINARY_SIZE + 1);
     fs.closeSync(fd);
 
     const res = await serveBinary(kbRoot, "huge.pdf", { request: buildRequest() });
@@ -81,36 +82,50 @@ describe("serveBinary", () => {
 });
 
 describe("serveKbFile dispatcher", () => {
+  const okMarkdown = () =>
+    vi.fn(async () => new Response("md", { status: 200 }));
+  const okBinary = () =>
+    vi.fn(async () => new Response("bin", { status: 200 }));
+
   test(".md path routes to onMarkdown", async () => {
-    const onMarkdown = vi.fn(async () => new Response("md", { status: 200 }));
+    const onMarkdown = okMarkdown();
+    const onBinary = okBinary();
     await serveKbFile(kbRoot, "foo.md", {
       request: buildRequest(),
       onMarkdown,
+      onBinary,
     });
     expect(onMarkdown).toHaveBeenCalledWith(kbRoot, "foo.md");
+    expect(onBinary).not.toHaveBeenCalled();
   });
 
   test("extensionless path routes to onMarkdown", async () => {
-    const onMarkdown = vi.fn(async () => new Response("md", { status: 200 }));
+    const onMarkdown = okMarkdown();
+    const onBinary = okBinary();
     await serveKbFile(kbRoot, "notes", {
       request: buildRequest(),
       onMarkdown,
+      onBinary,
     });
     expect(onMarkdown).toHaveBeenCalledWith(kbRoot, "notes");
+    expect(onBinary).not.toHaveBeenCalled();
   });
 
   test("uppercase .MD routes to onMarkdown (case-fold regression)", async () => {
-    const onMarkdown = vi.fn(async () => new Response("md", { status: 200 }));
+    const onMarkdown = okMarkdown();
+    const onBinary = okBinary();
     await serveKbFile(kbRoot, "NOTES.MD", {
       request: buildRequest(),
       onMarkdown,
+      onBinary,
     });
     expect(onMarkdown).toHaveBeenCalledWith(kbRoot, "NOTES.MD");
+    expect(onBinary).not.toHaveBeenCalled();
   });
 
-  test("binary path routes to onBinary override when provided", async () => {
-    const onMarkdown = vi.fn();
-    const onBinary = vi.fn(async () => new Response("bin", { status: 200 }));
+  test("binary path routes to onBinary", async () => {
+    const onMarkdown = okMarkdown();
+    const onBinary = okBinary();
     await serveKbFile(kbRoot, "foo.pdf", {
       request: buildRequest(),
       onMarkdown,
@@ -121,8 +136,8 @@ describe("serveKbFile dispatcher", () => {
   });
 
   test("uppercase .PDF routes to binary (case-fold regression)", async () => {
-    const onMarkdown = vi.fn();
-    const onBinary = vi.fn(async () => new Response("bin", { status: 200 }));
+    const onMarkdown = okMarkdown();
+    const onBinary = okBinary();
     await serveKbFile(kbRoot, "foo.PDF", {
       request: buildRequest(),
       onMarkdown,
@@ -130,15 +145,5 @@ describe("serveKbFile dispatcher", () => {
     });
     expect(onMarkdown).not.toHaveBeenCalled();
     expect(onBinary).toHaveBeenCalledWith(kbRoot, "foo.PDF");
-  });
-
-  test("binary path without onBinary falls through to serveBinary default", async () => {
-    fs.writeFileSync(path.join(kbRoot, "logo.png"), Buffer.from("data"));
-    const res = await serveKbFile(kbRoot, "logo.png", {
-      request: buildRequest(),
-      onMarkdown: vi.fn(),
-    });
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Content-Type")).toBe("image/png");
   });
 });

--- a/knowledge-base/project/learnings/2026-04-17-esbuild-backtick-in-jsdoc-block-comment.md
+++ b/knowledge-base/project/learnings/2026-04-17-esbuild-backtick-in-jsdoc-block-comment.md
@@ -1,0 +1,96 @@
+---
+date: 2026-04-17
+category: build-errors
+module: apps/web-platform
+tags: [esbuild, vitest, jsdoc, typescript]
+related_pr: 2517
+---
+
+# Learning: esbuild transform rejects backtick-containing JSDoc block comments
+
+## Problem
+
+In PR #2517 (kb-serve refactor), vitest failed at transform with:
+
+```
+ERROR: Expected ";" but found "cachedVerdict"
+85 |   * Verdict-cache + hash-stream + serve orchestration for shared binary
+86 |   * files. Returns ONLY a Response — no side-channel fields like
+87 |   * `cachedVerdict` or `logEmitted`. Log emission happens inside the helper
+     |      ^
+88 |   * using the caller's logger so field names, events, and codes stay exact.
+```
+
+The JSDoc block had legitimate markdown:
+
+```ts
+/**
+ * Verdict-cache + hash-stream + serve orchestration for shared binary
+ * files. Returns ONLY a Response — no side-channel fields like
+ * `cachedVerdict` or `logEmitted`. Log emission happens inside the helper
+ */
+export async function serveBinaryWithHashGate(...)
+```
+
+Vitest's esbuild transform pass parsed the backtick inside the block comment
+as the start of a template literal, then demanded a `;` before `cachedVerdict`.
+`tsc --noEmit` was happy; only the esbuild-based vitest transform failed.
+
+## Solution
+
+Replace `/** ... */` blocks containing backtick-wrapped identifiers or
+em-dashes (`—`) with `//` line comments, or strip the backticks:
+
+```ts
+// Verdict-cache + hash-stream + serve orchestration for shared binary files.
+// Returns ONLY a Response — no side-channel fields. Log emission happens
+// inside the helper using the caller's logger so field names stay exact.
+export async function serveBinaryWithHashGate(...)
+```
+
+Line comments survive because esbuild treats them as opaque whitespace.
+
+## Key Insight
+
+The difference between `/** ... */` and `// ...` for esbuild is that the
+block-comment variant still gets a limited intra-token scan (for JSDoc tag
+extraction). Backticks can trip that scanner even when the comment is not
+position-sensitive code. Standard TS/Node parsers are lenient here; vitest
++ esbuild is not.
+
+**Prevention:** When writing JSDoc that quotes identifiers or uses markdown
+inline code (``` ` ```), either use line comments or escape the backtick.
+Smoke-test by running the single affected test file immediately after the
+edit: `./node_modules/.bin/vitest run test/<file>.test.ts` surfaces the
+transform error in <1s.
+
+## Session Errors
+
+1. **Worktree created with long name silently disappeared.**
+   `worktree-manager.sh --yes create feat-one-shot-kb-serve-binary-helpers`
+   reported success but the directory was not present when the next Bash
+   call tried to `cd` into it. Recreating with the shorter name
+   `feat-kb-serve-binary-helpers` succeeded.
+   Recovery: re-run the create command with a shorter branch name.
+   Prevention: constrain worktree branch names to ≤40 chars, or have
+   `worktree-manager.sh create` validate the directory exists before
+   printing the success banner.
+
+2. **`draft-pr` command failed from bare repo root.**
+   `bash ./plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh draft-pr`
+   errored with "Cannot run from bare repo root (no working tree available)."
+   Recovery: cd into the worktree dir and re-run. Safe because the script
+   already errors loudly — this is working as intended.
+   Prevention: one-shot's step 0c could emit the `cd` in the same Bash call:
+   `cd <worktree-path> && bash .../worktree-manager.sh draft-pr`. The skill
+   currently assumes the shell's CWD persists across Bash tool calls, which
+   it does NOT.
+
+3. **esbuild/vitest transform rejected backtick-in-JSDoc-block.**
+   Recovery: switched block comments to line comments.
+   Prevention: see above section.
+
+## Tags
+
+category: build-errors
+module: apps/web-platform/server

--- a/knowledge-base/project/plans/2026-04-17-refactor-kb-serve-binary-helpers-plan.md
+++ b/knowledge-base/project/plans/2026-04-17-refactor-kb-serve-binary-helpers-plan.md
@@ -1,0 +1,520 @@
+# Refactor: shared KB serving helpers (serveBinary + dispatch + isMarkdownExt + serveBinaryWithHashGate)
+
+**Branch:** `feat-kb-serve-binary-helpers`
+**Worktree:** `.worktrees/feat-kb-serve-binary-helpers/`
+**PR:** #2517 (draft)
+**Issues closed:** #2299, #2313, #2317, #2483
+**Pattern reference:** PR #2486 (close-more-than-open refactor: 3 scope-outs, 13 files, no new deferrals)
+
+## Enhancement Summary
+
+**Deepened on:** 2026-04-17
+**Sections enhanced:** Risks, Test Strategy, Phases 3/6/9, new Phase 11 (negative-space test migration)
+**Research sources:** 4 directly-relevant project learnings + `kb-security.test.ts` inspection
+
+### Key Improvements from deepen pass
+
+1. **Negative-space test gate surfaced** — `test/kb-security.test.ts` already carries structural-regex assertions that scan KB route files for delegation patterns (`authenticateAndResolveKbPath` / `resolveUserKbRoot` / `readContent`). After the refactor, the content route's markdown branch still invokes `readContent` inside the `onMarkdown` callback, so the existing `logger.error` delegation regex continues to match — **no test migration needed for the content route**. The share route continues to carry inline `logger.error` calls (multiple) — the test passes via that branch. Call this out explicitly in Phase 11 to prevent a future refactor from accidentally loosening.
+2. **Half-extraction risk flagged (from 2026-04-14 learning)** — `serveBinaryWithHashGate` accepts `logger` + `logContext` as parameters. If the helper accrues a return contract (e.g., `{ cachedVerdict, logContext }`) that the route ignores, that's exactly the purity-drift shape that burned #2209. Decision: helper returns ONLY `Promise<Response>`. No side-channel return fields. Any log emission happens inside the helper using the caller's logger; the route does not post-process.
+3. **"Trim to negative-space only" applied (from 2026-04-17 learning)** — the plan does NOT add positive regex-on-source tests like "content route imports `serveKbFile`" or "share route invokes `serveBinaryWithHashGate`". End-to-end tests (`kb-content-binary.test.ts`, `shared-page-binary.test.ts`, `shared-token-verdict-cache.test.ts`) transitively prove delegation. Only the existing negative-space gate in `kb-security.test.ts` remains; no new regex-on-source tests are added.
+4. **Companion state (from 2026-04-14 learning)** — audit the helper's inputs: `shareHashVerdictCache` is a module-level singleton. The helper reads AND writes it. Single source of truth — no ref/state split. Safe. No companion-state migration required.
+5. **Plan-preflight CLI-form verification (from 2026-04-17 learning)** — the plan prescribes no CLI flag combinations that require version-aware verification. The build/test commands (`vitest`, `tsc --noEmit`, `npm run build`) are already convention in this repo. N/A.
+
+### New Considerations Discovered
+
+- The `contentChangedResponse` helper is used by BOTH the markdown and binary branches of the share route. Moving it into `server/kb-serve.ts` requires the route to re-import it. Verified: this is cleaner than duplicating (both branches want the same wire shape).
+- `legacyNullHashResponse` is only called from the markdown-path's guard before dispatching. It stays in the route.
+- The dashboard page's `extension` variable (still used for `<FilePreview extension={extension} />`) needs a secondary pass: its current computation lacks `.toLowerCase()`. Adding it is a behavior change for FilePreview consumers of `.PDF`, `.PNG`, etc. Audit: check whether `FilePreview` normalizes the extension prop internally before concluding this is safe.
+
+## Overview
+
+Four open code-review findings from the PR #2282 / #2477 sweep describe different shards of the same duplication: `/api/kb/content/[...path]` (owner) and `/api/shared/[token]` (recipient) both run an identical pattern:
+
+1. Pick fork by extension (`.md` / `""` → markdown JSON; else binary).
+2. `validateBinaryFile` → propagate typed result / Response.
+3. `buildBinaryResponse` → propagate `BinaryOpenError` → Response.
+
+The share route wraps step 2–3 with a verdict-cache + hash-gate dance. The dashboard page (`app/(dashboard)/dashboard/kb/[...path]/page.tsx`) carries its own slightly-divergent copy of the extension classifier.
+
+This PR introduces one consolidated server-side helper module plus one client/server-shared primitive, and migrates all four call sites (two route handlers, one dashboard page, server-internal `validateBinaryFile`) to delegate. Net intent: close 4 issues in a single focused refactor with zero behavior change visible to clients.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim in issues | Reality in branch `feat-kb-serve-binary-helpers` | Plan response |
+|---|---|---|
+| #2299: "`readBinaryFile` + `buildBinaryResponse` two-step API" | `readBinaryFile` was renamed to `validateBinaryFile` in PR #2316 and is now a deprecated alias. Current two-step is `validateBinaryFile` + `buildBinaryResponse`. | Plan targets current names; `serveBinary` wraps `validateBinaryFile` + `buildBinaryResponse`. Deprecated `readBinaryFile` export stays (removal is out of scope). |
+| #2313: "`/api/kb/content` lines 49–80; `/api/shared/[token]` lines 70–129" | Current content route: lines 48–96. Current share route: lines 107–162 (markdown branch) and 164–280 (binary+hash branch). | Line numbers are illustrative only; plan references the semantic branches, not byte offsets. |
+| #2483: "extract after #2309 lands" | #2309 merged via PR #2497 on 2026-04-17 (confirmed in args). `content_sha256` always-required path now stable. | Precondition met; safe to extract `serveBinaryWithHashGate` now. |
+| #2317: "client uses `joinedPath.includes('.')` + `split('.').pop()` without `.toLowerCase()`" | Confirmed at `app/(dashboard)/dashboard/kb/[...path]/page.tsx:24`. `NOTES.MD` would classify as non-markdown on client, markdown on server. | Plan extracts `lib/kb-extensions.ts`, migrates both sides, adds case-sensitivity regression test. |
+| PR #2486 "net-negative pattern" | Confirmed merged. Closed #2467/#2468/#2469 in one PR with 13 files touched. | Mirror the approach: single-PR drain, no new scope-out issues filed from this PR. |
+
+## Goals / Non-goals
+
+**Goals:**
+
+1. One server module (`server/kb-serve.ts`) exporting `serveKbFile`, `serveBinary`, `serveBinaryWithHashGate`.
+2. One shared primitive (`lib/kb-extensions.ts`) exporting `getKbExtension` + `isMarkdownKbPath`.
+3. `/api/kb/content/[...path]/route.ts` delegates to `serveKbFile` (owner variant, no hash gate).
+4. `/api/shared/[token]/route.ts` delegates to `serveKbFile` with `serveBinaryWithHashGate`.
+5. `app/(dashboard)/dashboard/kb/[...path]/page.tsx` uses `isMarkdownKbPath` instead of the inline expression.
+6. Behavior-preserving: status codes, headers, log events, error-code strings (`content-changed`, `revoked`, `legacy-null-hash`) all unchanged.
+7. No new dependencies. No migration.
+
+**Non-goals (out of scope — do NOT chase these):**
+
+- Collapsing share-link + owner Supabase queries into one (tracked in #2328).
+- Eliminating the double-GET for PDFs/images (tracked in #2324).
+- Error-shape convention unification (tracked in #2308).
+- Removing deprecated `readBinaryFile` alias (should be a separate cleanup PR once no callers remain).
+- Extracting `KbContentHeader`, `LoadingSkeleton`, or `classifyResponse` (tracked in #2312, #2318, #2321).
+- `BinaryFilePayload` parameter object (#2311) — deliberately not bundled to keep this PR small.
+- File-kind classification unification for the viewer page (#2297) — dashboard page uses the extracted `isMarkdownKbPath`, but the shared viewer page's Content-Type inference (`#2304`) is a different concern and remains.
+
+## Open Code-Review Overlap
+
+These open scope-outs touch files this PR will modify:
+
+- **#2299** (`serveBinary` extraction) — **Fold in.** This IS the first helper extracted. Closes.
+- **#2313** (markdown/binary dispatch extraction) — **Fold in.** This IS `serveKbFile`. Closes.
+- **#2317** (`isMarkdownExt` helper) — **Fold in.** This IS `lib/kb-extensions.ts`. Closes.
+- **#2483** (`serveBinaryWithHashGate` after #2309 lands) — **Fold in.** #2309 confirmed merged via PR #2497. Closes.
+- **#2303** (contract test: owner + shared return identical bytes/headers) — **Acknowledge.** Different concern (new contract test, not a refactor). After `serveBinary` lands, writing this test becomes easier — but filing it as part of this PR would balloon scope. Leave open; reference this PR in a follow-up.
+- **#2308** (mixed error-shape conventions) — **Acknowledge.** Semantic decision (typed errors vs tagged-union). This PR preserves both shapes at their current sites; unifying them is a separate design call. Leave open.
+- **#2301** (symlink-reject message parity) — **Acknowledge.** Different concern (status-code parity, not helper extraction). The `serveBinary` helper returns `{ error: 'Access denied' }` uniformly, which happens to improve parity, but a full fix requires touching the JSON envelope shapes on the share route. Leave open; this PR may reduce its surface incidentally.
+- **#2305** (error-handling symmetry between markdown and binary branches of share route) — **Acknowledge.** After `serveKbFile` extraction, markdown and binary both flow through the same try/catch shape in the route — partially addresses the smell, but the markdown branch's inline `hashBytes` comparison stays in-route. Leave open.
+- **#2297** (unify file-kind classification across owner and shared viewer pages) — **Acknowledge.** Dashboard page gets `isMarkdownKbPath` here, but the shared viewer page's kind inference happens client-side on Content-Type and is a separate refactor. Leave open.
+- **#2321** (`classifyResponse` from shared page useEffect) — **Acknowledge.** Client-side concern; orthogonal to server helpers. Leave open.
+- **#2311** (`BinaryFilePayload` parameter object) — **Defer.** DHH-style "don't abstract until there's a third caller". Leave open; re-evaluate if a third caller appears.
+- **#2325** (inline `ATTACHMENT_EXTENSIONS`) — **Defer.** Cleanup on `kb-binary-response.ts` internals; orthogonal. Leave open.
+- **#2300** (move `MAX_BINARY_SIZE` to `kb-limits.ts`) — **Defer.** Pure file-move; orthogonal. Leave open.
+- **#2322** (agent preview of shared recipient view) — **Defer.** Feature work, not refactor. Leave open.
+- **#2304** (shared page infers kind from Content-Type) — **Defer.** Client-side refactor in a different file. Leave open.
+- **#2306** (a11y: image viewer alt text) — **Defer.** Orthogonal. Leave open.
+- **#2312** (duplicate `LoadingSkeleton`) — **Defer.** Component extraction, orthogonal. Leave open.
+- **#2318** (`KbContentHeader` extraction) — **Defer.** Component extraction, orthogonal. Leave open.
+- **#2328** / **#2324** / **#2329** — **Defer.** All performance/DB concerns, not helper extraction. Leave open.
+- **#2348** (vitest mock-factory export drift) — **Acknowledge.** If `serveKbFile` extraction causes any test file to need an updated mock factory, the fix will be made in that same test file. If the tests pass unchanged, leave the issue open.
+
+Net: +0 new scope-out issues. 4 closures (#2299, #2313, #2317, #2483). 13+ items acknowledged or deferred with rationale.
+
+## Files to create
+
+1. `apps/web-platform/lib/kb-extensions.ts` — shared client/server extension classifier.
+    - `getKbExtension(relPath: string): string` — lastIndexOf('.') based, returns lowercased ext or `""`.
+    - `isMarkdownKbPath(relPath: string): boolean` — `ext === ".md" || ext === ""`.
+2. `apps/web-platform/server/kb-serve.ts` — server-side dispatch + binary serve helpers.
+    - `serveBinary(kbRoot, relativePath, { request, onError? }): Promise<Response>` — wraps `validateBinaryFile` + `buildBinaryResponse` + `BinaryOpenError` → error Response.
+    - `serveBinaryWithHashGate({ token, expectedHash, meta, request, logger, logContext }): Promise<Response>` — verdict-cache + hash-stream + serve with strong ETag.
+    - `serveKbFile(kbRoot, relativePath, { request, onMarkdown, onBinary? }): Promise<Response>` — dispatches by `isMarkdownKbPath`; markdown callback produces the JSON envelope; binary defaults to `serveBinary`, or caller overrides with `serveBinaryWithHashGate` wrapper.
+3. `apps/web-platform/test/kb-extensions.test.ts` — unit tests for the two helpers (Windows-style separators, case folding, multiple dots, hidden files, empty strings).
+4. `apps/web-platform/test/kb-serve.test.ts` — unit tests for `serveBinary` and `serveKbFile` behavior (404/403/413 paths, markdown callback invocation, binary callback override).
+5. `apps/web-platform/test/kb-serve-hash-gate.test.ts` — unit tests for `serveBinaryWithHashGate` (cache hit, cache miss + match, cache miss + mismatch → 410, inode drift → 410, BinaryOpenError → error response, strong ETag echoed).
+
+## Files to edit
+
+1. `apps/web-platform/app/api/kb/content/[...path]/route.ts` — delegate to `serveKbFile` with `onMarkdown` returning `NextResponse.json(result)`.
+2. `apps/web-platform/app/api/shared/[token]/route.ts` — delegate to `serveKbFile`; markdown branch still does `hashBytes` against `shareLink.content_sha256` before returning the JSON envelope; binary branch calls `serveBinaryWithHashGate`.
+3. `apps/web-platform/app/(dashboard)/dashboard/kb/[...path]/page.tsx` — import `isMarkdownKbPath`, replace the inline expression.
+4. `apps/web-platform/server/kb-binary-response.ts` — internal: use `getKbExtension` from `lib/kb-extensions.ts` in `validateBinaryFile` so the server has one authoritative classifier.
+5. `apps/web-platform/test/kb-content-binary.test.ts` — no behavior change expected; if any mock-factory drift occurs (c.f. #2348), update in place.
+6. `apps/web-platform/test/shared-page-binary.test.ts` — same. No behavior change expected.
+7. `apps/web-platform/test/shared-token-content-hash.test.ts` — same.
+8. `apps/web-platform/test/shared-token-verdict-cache.test.ts` — same.
+9. `apps/web-platform/test/kb-share-content-hash.test.ts` — same.
+
+## Implementation Phases
+
+### Phase 1 — Shared extension primitive (`lib/kb-extensions.ts`)
+
+**TDD gate:** Write `test/kb-extensions.test.ts` FIRST. Assert:
+
+- `getKbExtension("foo.md") === ".md"`
+- `getKbExtension("FOO.MD") === ".md"` (case folds)
+- `getKbExtension("notes/doc.PDF") === ".pdf"`
+- `getKbExtension("noext") === ""`
+- `getKbExtension(".hidden") === ""` (lastIndexOf is 0 → returns `".hidden"`.lowerCased — **document intended behavior:** leading dot with no further dot → treat as no extension per bash/unix convention; return `""`). Verify chosen semantics in the test.
+- `getKbExtension("a/b/c.tar.gz") === ".gz"` (last dot only)
+- `getKbExtension("") === ""`
+- `isMarkdownKbPath("NOTES.MD") === true` (regression for the #2317 bug)
+- `isMarkdownKbPath("foo") === true` (extensionless)
+- `isMarkdownKbPath("foo.pdf") === false`
+
+Then implement the two functions. Keep them pure — no Node APIs (`path`/`fs`), no Next APIs. They must be importable from both client (React component) and server (Next route handler).
+
+### Phase 2 — `serveBinary` helper (closes #2299)
+
+**TDD gate:** Extend `test/kb-serve.test.ts`. Cover:
+
+- validate returns 403 (path traversal / symlink) → Response with status 403 JSON body `{ error: "Access denied" }`.
+- validate returns 404 (missing / non-file) → 404 JSON.
+- validate returns 413 (size exceeds max) → 413 JSON.
+- `validateBinaryFile` ok → `buildBinaryResponse` succeeds → 200 stream with expected headers (`Content-Type`, `ETag`, `Accept-Ranges`).
+- `buildBinaryResponse` throws `BinaryOpenError(404)` → 404 JSON, `onError` callback invoked with `(404, "File not found")` if passed.
+- `buildBinaryResponse` throws non-`BinaryOpenError` → error rethrows (caller's outer try/catch handles it).
+
+Implement in `server/kb-serve.ts`:
+
+```ts
+import { NextResponse } from "next/server";
+import {
+  validateBinaryFile,
+  buildBinaryResponse,
+  BinaryOpenError,
+} from "@/server/kb-binary-response";
+
+export async function serveBinary(
+  kbRoot: string,
+  relativePath: string,
+  opts: {
+    request: Request;
+    onError?: (status: number, reason: string, code?: string) => void;
+  },
+): Promise<Response> {
+  const result = await validateBinaryFile(kbRoot, relativePath);
+  if (!result.ok) {
+    opts.onError?.(result.status, result.error);
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+  try {
+    return await buildBinaryResponse(result, opts.request);
+  } catch (err) {
+    if (err instanceof BinaryOpenError) {
+      opts.onError?.(err.status, err.message, err.code);
+      return NextResponse.json({ error: err.message }, { status: err.status });
+    }
+    throw err;
+  }
+}
+```
+
+The `onError` hook preserves the owner route's existing `logger.warn` on `BinaryOpenError` and the share route's 403 `logger.warn` on traversal — both route-specific log events stay where they are instead of being centralized (DHH: "the helper shouldn't know the caller's log namespace").
+
+### Phase 3 — `serveBinaryWithHashGate` helper (closes #2483)
+
+**TDD gate:** Write `test/kb-serve-hash-gate.test.ts` BEFORE editing. Cover:
+
+- **Cache hit path.** `shareHashVerdictCache.get` returns `true` → no `openBinaryStream` for hashing, serves with strong ETag.
+- **Cache miss + hash match.** Drains stream via `hashStream`, compares, calls `shareHashVerdictCache.set`, serves with strong ETag.
+- **Cache miss + hash mismatch.** Logs `shared_content_mismatch` with `kind: "binary"`, returns 410 `{ error, code: "content-changed" }`.
+- **Inode drift during hash stream.** `openBinaryStream` throws `BinaryOpenError("content-changed")` → logs `inode-drift`, returns 410.
+- **Inode drift during serve.** `buildBinaryResponse` throws `BinaryOpenError("content-changed")` → logs `inode-drift-serve`, returns 410.
+- **Generic `BinaryOpenError` during hash** → logs warn, returns helper's status.
+- **Non-error throw during hash** → logs error, returns 500.
+
+Signature in `server/kb-serve.ts`:
+
+```ts
+import type { Logger } from "pino";
+import {
+  BinaryFileMetadata,
+  BinaryOpenError,
+  buildBinaryResponse,
+  openBinaryStream,
+} from "@/server/kb-binary-response";
+import { hashStream } from "@/server/kb-content-hash";
+import { shareHashVerdictCache } from "@/server/share-hash-verdict-cache";
+
+export interface HashGateLogContext {
+  event?: string;
+  token: string;
+  documentPath: string;
+}
+
+export async function serveBinaryWithHashGate(args: {
+  token: string;
+  expectedHash: string;
+  meta: BinaryFileMetadata;
+  request: Request;
+  logger: Logger;
+  logContext: HashGateLogContext;
+}): Promise<Response>;
+```
+
+**Return-type discipline (from learning `2026-04-14-pure-reducer-extraction-requires-companion-state-migration.md`):** The helper returns ONLY `Promise<Response>`. No side-channel fields like `{ response, cachedVerdict, logEmitted }`. If a future caller needs the verdict-cache hit rate for metrics, that caller adds its own instrumentation — do NOT bolt a return-tuple onto the helper "for observability" and then let the route ignore most of its fields. "Never ship a contract the consumer ignores" is the specific anti-pattern that burned PR #2209.
+
+**Companion-state audit.** Helper state surface:
+
+- Reads: `shareHashVerdictCache` (module-level singleton, imported from `@/server/share-hash-verdict-cache`).
+- Writes: `shareHashVerdictCache.set(...)` on hash match.
+- No ref/state split. No reducer-and-ref hybrid. Single authority. Safe.
+
+Move the cache-miss + hash-pass + mismatch-response + serve orchestration from the current `/api/shared/[token]/route.ts:178-279` into this helper verbatim. Preserve:
+
+- All `logger.info` / `logger.warn` / `logger.error` call sites. Pass `logger` in; helper does not take its own child logger.
+- Exact log field names (`event`, `token`, `documentPath`, `kind`, `reason`).
+- Exact response-builder functions for 410s (`contentChangedResponse`) — move helper into `server/kb-serve.ts` as a module-private function; the route's one remaining caller of it (markdown branch) imports from the new module.
+- Strong ETag passed via `buildBinaryResponse(meta, request, { strongETag: expectedHash })`.
+
+### Phase 4 — `serveKbFile` dispatcher (closes #2313)
+
+**TDD gate:** Add dispatch tests to `test/kb-serve.test.ts`:
+
+- Path `foo.md` → `onMarkdown` callback invoked with `(kbRoot, "foo.md")`. Return value of callback returned.
+- Path `notes/` (extensionless) → `onMarkdown` invoked.
+- Path `NOTES.MD` → `onMarkdown` invoked (case-fold regression).
+- Path `foo.pdf` → `serveBinary` (or overridden `onBinary`) invoked.
+- Path `foo.PDF` → binary branch (case-fold regression).
+
+Signature:
+
+```ts
+export async function serveKbFile(
+  kbRoot: string,
+  relativePath: string,
+  opts: {
+    request: Request;
+    onMarkdown: (kbRoot: string, relativePath: string) => Promise<Response>;
+    onBinary?: (kbRoot: string, relativePath: string) => Promise<Response>;
+  },
+): Promise<Response> {
+  if (isMarkdownKbPath(relativePath)) {
+    return opts.onMarkdown(kbRoot, relativePath);
+  }
+  return (opts.onBinary ?? ((root, p) => serveBinary(root, p, { request: opts.request })))(
+    kbRoot,
+    relativePath,
+  );
+}
+```
+
+### Phase 5 — Migrate owner route
+
+Edit `app/api/kb/content/[...path]/route.ts`. After the workspace lookup and `relativePath` validation, dispatch:
+
+```ts
+return serveKbFile(kbRoot, relativePath, {
+  request,
+  onMarkdown: async (root, rel) => {
+    try {
+      const result = await readContent(root, rel);
+      return NextResponse.json(result);
+    } catch (err) {
+      // existing KbAccessDeniedError / KbNotFoundError / KbValidationError mapping
+    }
+  },
+  onBinary: (root, rel) =>
+    serveBinary(root, rel, {
+      request,
+      onError: (status, message, code) => {
+        if (status !== 404 && status !== 403) return;
+        logger.warn(
+          { err: message, code, path: rel },
+          "kb/content: open failed on serve",
+        );
+      },
+    }),
+});
+```
+
+Run `kb-content-binary.test.ts` + `kb-content-csp.test.ts` after the edit. Every test must pass unchanged. If any test fails, the helper has drifted from the original behavior — fix the helper, not the test.
+
+### Phase 6 — Migrate share route
+
+Edit `app/api/shared/[token]/route.ts`. Structure after refactor:
+
+```ts
+// ... rate-limit, shareLink fetch, revoked/legacy checks unchanged ...
+// ... owner workspace fetch unchanged ...
+const kbRoot = path.join(owner.workspace_path, "knowledge-base");
+
+return serveKbFile(kbRoot, shareLink.document_path, {
+  request,
+  onMarkdown: async (root, rel) => {
+    try {
+      const { buffer, raw } = await readContentRaw(root, rel);
+      const currentHash = hashBytes(buffer);
+      if (currentHash !== shareLink.content_sha256) {
+        logger.info(
+          { event: "shared_content_mismatch", token, documentPath: rel, kind: "markdown" },
+          "shared: content hash mismatch",
+        );
+        return contentChangedResponse();
+      }
+      const { content } = parseFrontmatter(raw);
+      logger.info(
+        { event: "shared_page_viewed", token, documentPath: rel },
+        "shared: document viewed",
+      );
+      return NextResponse.json({ content, path: rel });
+    } catch (err) {
+      // existing error mapping unchanged
+    }
+  },
+  onBinary: async (root, rel) => {
+    const binary = await validateBinaryFile(root, rel);
+    if (!binary.ok) {
+      if (binary.status === 403) {
+        logger.warn({ token, path: rel }, "shared: binary access denied (symlink / outside root)");
+      }
+      return NextResponse.json({ error: binary.error }, { status: binary.status });
+    }
+    return serveBinaryWithHashGate({
+      token,
+      expectedHash: shareLink.content_sha256,
+      meta: binary,
+      request,
+      logger,
+      logContext: { token, documentPath: rel },
+    });
+  },
+});
+```
+
+Run `shared-page-binary.test.ts`, `shared-token-content-hash.test.ts`, `shared-token-verdict-cache.test.ts`, `kb-share-content-hash.test.ts`, `kb-share-allowed-paths.test.ts`. All must pass unchanged.
+
+### Phase 7 — Migrate dashboard page (closes #2317)
+
+Edit `app/(dashboard)/dashboard/kb/[...path]/page.tsx`:
+
+```ts
+import { isMarkdownKbPath } from "@/lib/kb-extensions";
+
+// ...
+const joinedPath = pathSegments.join("/");
+const isMarkdown = isMarkdownKbPath(joinedPath);
+const extension = joinedPath.includes(".") ? `.${joinedPath.split(".").pop()?.toLowerCase()}` : "";
+```
+
+Note: The `extension` variable is still used for `<FilePreview extension={extension} />`. Verified at `components/kb/file-preview.tsx:33`: `FilePreview` internally lowercases the prop before switching on it (`const ext = extension.toLowerCase();`). So the page-level `extension` variable does NOT need `.toLowerCase()` — leave it as-is to keep the diff minimal. The only behavior change from this phase is the `isMarkdown` branch: `NOTES.MD` now correctly routes to the markdown fetch path (was: non-markdown → FilePreview with `.MD` extension → DownloadPreview fallback).
+
+### Phase 8 — Internal: unify `kb-binary-response` classifier
+
+In `server/kb-binary-response.ts:117`:
+
+```ts
+const ext = path.extname(relativePath).toLowerCase();
+```
+
+Change to:
+
+```ts
+import { getKbExtension } from "@/lib/kb-extensions";
+// ...
+const ext = getKbExtension(relativePath);
+```
+
+This completes the "one classifier everywhere" property. `path.extname` and `getKbExtension` return the same string for paths without edge cases, but `getKbExtension` is also available client-side where `node:path` is not. Single source of truth.
+
+### Phase 9 — Route-file export audit (AGENTS.md `cq-nextjs-route-files-http-only-exports`)
+
+Verify: `app/api/kb/content/[...path]/route.ts` and `app/api/shared/[token]/route.ts` export ONLY the `GET` HTTP handler. No helpers, no constants, no test resets. The `contentChangedResponse` and `legacyNullHashResponse` helpers currently defined in the share route at lines 26–44: move `contentChangedResponse` into `server/kb-serve.ts` (the hash-gate helper needs it); keep `legacyNullHashResponse` in the route since it's only called from the route. **Verification:** run `npm run build` in `apps/web-platform/` — if Next.js route-file validator rejects any export, fix before commit. `tsc --noEmit` does not catch this.
+
+### Phase 10 — Run the full test + build pipeline
+
+```bash
+cd apps/web-platform
+./node_modules/.bin/vitest run
+./node_modules/.bin/tsc --noEmit
+npm run build
+```
+
+All three must pass. The `next build` step is non-negotiable per AGENTS.md `cq-nextjs-route-files-http-only-exports`.
+
+### Phase 11 — Verify negative-space test gate still holds
+
+`test/kb-security.test.ts` runs structural-regex assertions on every KB route file. Specifically:
+
+- Line 22: `expect(content).toContain("readContent")` — content route. Preserved: `readContent` now lives inside the `onMarkdown` callback, which is inline in the route source. Passes.
+- Line 23: `expect(content).toContain("KbAccessDeniedError")` — content route. Preserved: still referenced in the callback's catch block. Passes.
+- Lines 72–98: all KB route handlers must have either inline auth OR proven delegation to `authenticateAndResolveKbPath`. The content route keeps its inline `supabase.auth.getUser` call (workspace lookup is NOT delegated). Passes.
+- Lines 101–125: all KB route handlers must have either inline `workspace_status` OR proven helper delegation. The content route keeps its inline `.select("workspace_path, workspace_status")` check. Passes.
+- Lines 143–168: all KB route handlers must have inline `logger.error` OR proven tagged-union delegation. The content route's `onMarkdown` callback still includes `logger.error({ err }, "kb/content: unexpected error")`. Passes.
+
+**Verification step:** after Phase 5 (content route migration) and Phase 6 (share route migration), run `./node_modules/.bin/vitest run test/kb-security.test.ts` explicitly. If any assertion fails, the refactor has drifted past a negative-space gate — fix the callback / route shape to preserve the pattern, do NOT weaken the test. Per learning `2026-04-15-negative-space-tests-must-follow-extracted-logic.md`, loosening the substring match on `readContent` to something like `onMarkdown` would accept dead imports, comment-only references, and callbacks that never fire.
+
+**Do not add new regex-on-source tests.** Per learning `2026-04-17-regex-on-source-delegation-tests-trim-to-negative-space.md`, do NOT add assertions like "content route imports `serveKbFile`" or "share route invokes `serveBinaryWithHashGate`". The existing end-to-end tests (`kb-content-binary.test.ts`, `shared-token-verdict-cache.test.ts`, etc.) transitively prove delegation via mocked `validateBinaryFile` / `hashStream` / `shareHashVerdictCache`. Positive regex assertions duplicate coverage and break on harmless edits (alias imports, barrel re-exports, whitespace around `await`).
+
+## Test Strategy
+
+- **Unit tests (new):**
+  - `test/kb-extensions.test.ts` — 10+ cases covering case fold, multi-dot, hidden files, extensionless.
+  - `test/kb-serve.test.ts` — dispatch routing + `serveBinary` error paths (validate/buildBinaryResponse/BinaryOpenError).
+  - `test/kb-serve-hash-gate.test.ts` — cache hit/miss, hash match/mismatch, inode drift pre-serve and mid-serve, generic `BinaryOpenError`.
+- **Existing tests (regression):** All 7 existing tests listed in Files to edit #5–#9 MUST pass unchanged. Any change to their expectations indicates a behavior drift; fix the helper, not the test.
+- **Contract test (#2303, out of scope):** After this PR lands, authoring "owner and shared return identical bytes + headers for same file" becomes trivial — both sides invoke the same `serveBinary`. Do NOT add this test to this PR; leave #2303 open.
+
+## Acceptance Criteria
+
+1. `serveBinary`, `serveKbFile`, `serveBinaryWithHashGate` exist in `server/kb-serve.ts`.
+2. `getKbExtension`, `isMarkdownKbPath` exist in `lib/kb-extensions.ts`.
+3. `/api/kb/content/[...path]/route.ts` GET handler is ≤ ~40 lines (workspace lookup + one `serveKbFile` call). Currently ~97 lines.
+4. `/api/shared/[token]/route.ts` GET handler is shorter: the ~100 line binary+hash orchestration is reduced to a `serveBinaryWithHashGate` call; the markdown branch stays inline (hash-compare + JSON envelope is route-specific).
+5. `app/(dashboard)/dashboard/kb/[...path]/page.tsx` imports `isMarkdownKbPath` instead of computing extension inline.
+6. `server/kb-binary-response.ts` `validateBinaryFile` uses `getKbExtension`.
+7. Full vitest suite passes (`./node_modules/.bin/vitest run`).
+8. TypeScript clean (`./node_modules/.bin/tsc --noEmit`).
+9. Next.js build clean (`npm run build`) — verifies route-file export validator.
+10. No new dependencies in `package.json`.
+11. PR body contains `Closes #2299`, `Closes #2313`, `Closes #2317`, `Closes #2483`.
+
+## Risks
+
+- **Log-field drift.** The share route has highly specific log field names (`event: "shared_content_mismatch"`, `kind: "binary"`, `reason: "inode-drift-serve"`). Moving the hash-gate into a helper risks a typo. **Mitigation:** tests assert the logger-mock call args exactly; reviewer visually diffs the log fields line by line.
+- **Error-code drift.** `code: "content-changed"`, `code: "revoked"`, `code: "legacy-null-hash"` are contract strings the client keys on. **Mitigation:** `contentChangedResponse` / `legacyNullHashResponse` are copied verbatim with matching body shape; existing `shared-token-content-hash.test.ts` assertions cover this.
+- **`BinaryOpenError` pass-through regression.** The share route's outer try/catch around `buildBinaryResponse` catches both `content-changed` (maps to 410) and generic errors (maps to err.status). If `serveBinaryWithHashGate` swallows these incorrectly, a 404 could become a 500. **Mitigation:** dedicated test cases `test/kb-serve-hash-gate.test.ts` lines 30–60.
+- **Client-server import boundary.** `lib/kb-extensions.ts` must not import any server-only module. **Mitigation:** file uses only JavaScript strings; no imports needed. CI would reject a server import via Next.js build, but catch it at review time.
+- **Route-file export validator.** Per AGENTS.md `cq-nextjs-route-files-http-only-exports`, only HTTP methods can be exported from route files. The current share route exports only `GET` but defines `contentChangedResponse` / `legacyNullHashResponse` as module-private functions — that's fine. **Do not** export either helper from a route file during migration. Move `contentChangedResponse` to `server/kb-serve.ts` (the only remaining share-route consumer is the markdown branch, which imports it from the new module). `legacyNullHashResponse` stays module-private in the route.
+- **#2348 mock-factory drift.** If adding new named exports to `server/kb-reader` or `server/kb-binary-response` causes vitest mocks to miss a factory entry, existing tests will fail with "is not a function". **Mitigation:** run the full suite after Phase 8; if any test fails with this class of error, fix the mock factory in the test file in the same commit.
+
+- **Negative-space test gate silent-break.** The existing `test/kb-security.test.ts` scans route files for `readContent` substring presence (line 22). If Phase 5's `onMarkdown` callback is extracted further (e.g., into `handleMarkdownContent(kbRoot, relativePath)` inside the route file), the literal `readContent` may stop appearing in route source. **Mitigation:** do NOT extract the markdown callback into a named local function; keep the `readContent(root, rel)` call inline inside the arrow-function callback. If a future maintainer wants a named callback, they must add a companion assertion on the helper file per the 2026-04-15 learning pattern. Documented in Phase 11.
+
+- **Half-extraction / purity drift in `serveBinaryWithHashGate`.** Helper accepts `logger` + `logContext` for log emission. Risk: if a future change adds a return field like `{ response, cachedVerdict: boolean }` for observability, the route may ignore the boolean, producing the same "contract the consumer ignores" pattern that PR #2209 burned. **Mitigation:** helper-signature review during implementation — return type is strictly `Promise<Response>`. If a caller needs verdict-hit metrics, instrumentation goes in the helper, not the return type. Documented in Phase 3.
+
+- **Positive regex-on-source test temptation.** Reviewers commonly ask for "test that confirms the route imports and calls the helper" after an extraction. These assertions duplicate behavioral-test coverage and break on aliased imports, barrel re-exports, or whitespace changes. **Mitigation:** do not add them. Phase 11 explicitly calls this out with a reference to the 2026-04-17 learning.
+
+## Domain Review
+
+**Domains relevant:** engineering only — pure refactor, no product/UX/marketing/legal/finance/security surface change.
+
+No cross-domain implications detected — infrastructure/tooling change behind a stable API. The refactor is behavior-preserving; user-facing surfaces (dashboard KB viewer, shared-link recipient page) render identical output before and after.
+
+## Research Insights
+
+**Applied learnings:**
+
+- `2026-04-14-pure-reducer-extraction-requires-companion-state-migration.md` — helper returns only `Response`, no side-channel fields; companion-state audit confirms `shareHashVerdictCache` has a single authority.
+- `2026-04-15-negative-space-tests-must-follow-extracted-logic.md` — existing `test/kb-security.test.ts` gate verified to still pass without modification; `onMarkdown` callback keeps `readContent` inline in route source.
+- `2026-04-17-regex-on-source-delegation-tests-trim-to-negative-space.md` — no new positive regex-on-source tests added. End-to-end tests transitively prove delegation.
+- `2026-04-17-review-backlog-net-positive-filing.md` — mirror #2486 pattern: net-negative scope-out ledger. 4 closes, 0 new filings, all acknowledgments recorded in `## Open Code-Review Overlap`.
+
+**Deliberately NOT applied:**
+
+- External research (Context7 / WebSearch) — this is a pure behavior-preserving refactor in first-party TypeScript. No new library APIs, no framework migrations. External doc lookup adds zero signal.
+- Product/UX specialists — engineering-only refactor, no surface change. Per `## Domain Review` section.
+- `BinaryFilePayload` parameter object (#2311) — deliberately out of scope. Wait for a third caller before further abstraction (Fowler's rule of three). Helper signatures stay positional + options-object as established in current `validateBinaryFile` / `buildBinaryResponse`.
+
+**Edge cases captured:**
+
+- `getKbExtension(".hidden")` — leading-dot-only files (unix hidden files) return `""`. Tested.
+- `getKbExtension("a.tar.gz")` — only last segment returned (`.gz`). Tested.
+- `NOTES.MD` (case fold) — now correctly classified as markdown on client, matching server. Tested with dedicated assertion (regression for #2317).
+- Path with no slashes (`foo.pdf`) vs path with slashes (`notes/foo.pdf`) — helper strips via `split("/").pop()`. Tested.
+
+## PR Body (reminder for ship phase)
+
+The PR body MUST include the following Closes lines (AGENTS.md `wg-use-closes-n-in-pr-body-not-title-to`):
+
+```text
+Closes #2299
+Closes #2313
+Closes #2317
+Closes #2483
+```
+
+Title suggestion: `refactor(kb): shared serve-binary + dispatch + isMarkdownExt helpers`
+
+Summary bullets:
+
+- `serveBinary` / `serveKbFile` / `serveBinaryWithHashGate` in `server/kb-serve.ts`.
+- `isMarkdownKbPath` + `getKbExtension` in `lib/kb-extensions.ts`, used by dashboard page + server.
+- Owner route (`/api/kb/content`) reduced to a single `serveKbFile` call.
+- Share route (`/api/shared/[token]`) delegates binary+hash orchestration to `serveBinaryWithHashGate`.
+- Case-sensitivity regression closed: `NOTES.MD` now classified as markdown on client (was: non-markdown).
+- Net backlog impact: 4 closures, 0 new scope-out issues. Mirrors the #2486 pattern.
+
+Test plan:
+
+- [ ] `./node_modules/.bin/vitest run` clean
+- [ ] `./node_modules/.bin/tsc --noEmit` clean
+- [ ] `npm run build` clean (route-file export validator)
+- [ ] Manual smoke: owner KB page opens a PDF; shared link opens same PDF; `NOTES.MD` renders as markdown on dashboard.

--- a/knowledge-base/project/specs/feat-kb-serve-binary-helpers/session-state.md
+++ b/knowledge-base/project/specs/feat-kb-serve-binary-helpers/session-state.md
@@ -1,0 +1,22 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-kb-serve-binary-helpers/knowledge-base/project/plans/2026-04-17-refactor-kb-serve-binary-helpers-plan.md
+- Branch: feat-kb-serve-binary-helpers
+- PR: #2517 (draft)
+- Status: complete
+
+### Errors
+None.
+
+### Decisions
+- One module `server/kb-serve.ts` exports `serveBinary`, `serveKbFile`, `serveBinaryWithHashGate`; `lib/kb-extensions.ts` exports `getKbExtension` + `isMarkdownKbPath` (shared client/server, zero Node deps).
+- `serveBinaryWithHashGate` returns only `Promise<Response>` — no side-channel tuple fields (applies learning `2026-04-14-pure-reducer-extraction-requires-companion-state-migration`).
+- No new positive regex-on-source tests; existing `kb-security.test.ts` negative-space gate still holds.
+- Net-negative scope-out ledger: 4 closes (#2299/#2313/#2317/#2483), 0 new filings.
+- Route-file export validator compliance: `contentChangedResponse` moves into `server/kb-serve.ts`; `npm run build` is final gate per AGENTS.md `cq-nextjs-route-files-http-only-exports`.
+
+### Components Invoked
+- skill: soleur:plan
+- skill: soleur:deepen-plan
+- `gh issue view` for #2299/#2313/#2317/#2483 + `gh pr view 2486`

--- a/plugins/soleur/skills/one-shot/SKILL.md
+++ b/plugins/soleur/skills/one-shot/SKILL.md
@@ -13,10 +13,10 @@ bash ./plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh --yes crea
 
 Then `cd` into the worktree path printed by the script. Parallel agents on the same repo cause silent merge conflicts when both work on main.
 
-**Step 0c: Create draft PR.** After creating the feature branch, create a draft PR:
+**Step 0c: Create draft PR.** After creating the feature branch, create a draft PR from inside the worktree (the script errors with "Cannot run from bare repo root" otherwise, and the Bash tool does NOT persist CWD across calls — use a single `cd && bash` to be explicit):
 
 ```bash
-bash ./plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh draft-pr
+cd <worktree-path> && bash ./plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh draft-pr
 ```
 
 If this fails (no network, or "No commits between main and <branch>"), print a warning but continue. The branch exists locally and the `/ship` phase will create the PR after implementation commits exist.


### PR DESCRIPTION
## Summary

- New `server/kb-serve.ts` exports `serveBinary`, `serveKbFile`, `serveSharedBinaryWithHashGate`, and `contentChangedResponse`.
- New `lib/kb-extensions.ts` exports `getKbExtension` + `isMarkdownKbPath` — one shared classifier for client (dashboard page) and server (routes).
- Owner route (`/api/kb/content/[...path]`) reduced to a single `serveKbFile` call.
- Share route (`/api/shared/[token]`) delegates binary hash-gate orchestration to `serveSharedBinaryWithHashGate`.
- Case-sensitivity regression closed: `NOTES.MD` now classifies as markdown on client (was: non-markdown, served via FilePreview fallback).
- `kb-binary-response.validateBinaryFile` uses `getKbExtension` for classifier parity.
- Deprecated `readBinaryFile` alias removed (no remaining callers).
- Silent-fallback 5xx/4xx branches in `serveSharedBinaryWithHashGate` now mirror to Sentry via `reportSilentFallback` (`cq-silent-fallback-must-mirror-to-sentry`).

Closes #2299
Closes #2313
Closes #2317
Closes #2483

## Changelog

### Web Platform
- Refactor: shared KB file-serving helpers consolidate duplicate markdown/binary dispatch and hash-gate orchestration across owner and shared-link routes.
- Bug fix (`#2317`): `NOTES.MD` and other uppercase-extension markdown files now render correctly on the dashboard KB viewer.
- Observability: shared-link binary 5xx fallbacks now reach Sentry (previously pino-only).

### Plugin
- `one-shot` skill: Step 0c `draft-pr` invocation now chains `cd <worktree> && bash ...` as a single Bash call (CWD does not persist across tool invocations).

## Test plan

- [x] `./node_modules/.bin/vitest run` — 1898 passed / 1 skipped
- [x] `./node_modules/.bin/tsc --noEmit` — clean
- [x] `npm run build` — clean (validates Next.js route-file export rule)
- [x] `/preflight` — PASS (security headers, no migrations, no lockfile drift)
- [x] `/review` — 9 agents spawned (1 P1, 6 P2, 12 P3); all findings fixed inline; zero scope-out issues filed

🤖 Generated with [Claude Code](https://claude.com/claude-code)