### PR TITLE
ops(expenses): record 2x Claude Code Max 20x subscriptions

### DIFF
--- a/knowledge-base/operations/expenses.md
+++ b/knowledge-base/operations/expenses.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-04-15
+last_updated: 2026-04-19
 ---
 
 # Expenses
@@ -25,6 +25,8 @@ last_updated: 2026-04-15
 | Bluesky | Bluesky | social | 0.00 | active | - | @soleur.ai account for content distribution. AT Protocol API (free, no tier limits) |
 | Resend | Resend | email | 0.00 | free-tier | - | Transactional email API. Free tier: 100 emails/day, 3K emails/mo. Upgrade trigger: volume exceeds free tier ($20/mo for 50K emails) |
 | Anthropic API (ux-audit) | Anthropic | api | 15.00 | active | - | Event-driven + monthly cron via `.github/workflows/scheduled-ux-audit.yml`. ~$3-$12/run × ≤3 runs/month. Threshold warning at $15/run in workflow output. Budget: $15/mo estimate; COO target ≤$12/run. |
+| Claude Code Max 20x (seat 1) | Anthropic | dev-tools | 200.00 | active | 2026-05-01 | Max 20x tier ($200/mo/seat). Engineering tooling for Soleur development. Started 2026-02-01; seat 1 of 2 |
+| Claude Code Max 20x (seat 2) | Anthropic | dev-tools | 200.00 | active | 2026-05-01 | Max 20x tier ($200/mo/seat). Engineering tooling for Soleur development. Started 2026-02-01; seat 2 of 2 |
 
 ## One-Time
 


### PR DESCRIPTION
## Summary

- Records two Anthropic Claude Code Max 20x subscriptions ($200/mo per seat, $400/mo combined) in the operations expense ledger.
- Both seats are used as engineering tooling for Soleur development.
- Subscriptions started 2026-02-01; first tracked renewal 2026-05-01.

## Changelog

### Operations
- Added two rows to the Recurring expenses table in `knowledge-base/operations/expenses.md` grouped with the existing Anthropic entries.
- Bumped `last_updated` to 2026-04-19.

## Test plan

- [x] `npx markdownlint-cli2 --fix knowledge-base/operations/expenses.md` passes.
- [x] Diff confirmed — two additive rows, no reflow of existing entries.

Generated with [Claude Code](https://claude.com/claude-code)