### PR TITLE
fix(workflow): guard close-orphans grep against pipefail kill

### DIFF
--- a/.github/workflows/codeql-to-issues.yml
+++ b/.github/workflows/codeql-to-issues.yml
@@ -135,9 +135,16 @@ jobs:
             # exhaust the authenticated rate limit (5000/hr); the cap bounds
             # the per-issue API cost to 50 calls × 200 issues = 10k worst
             # case, well inside one rate-limit window across daily runs.
+            # `|| true` swallows the inner `grep` exit-1 on no-match. Without
+            # it, the `pipefail` set above propagates the failure out of
+            # `$(...)` and `bash -e` (GitHub Actions default) kills the whole
+            # job on the first issue whose title/body has no `alert #N` token.
+            # Both grep calls in the pipe need guarding (the second `grep -oE`
+            # also exits 1 if the first emits nothing).
             ALERTS=$(echo "$issue" | jq -r '.title + "\n" + (.body // "")' \
-              | grep -oiE 'alert[[:space:]]*#?[0-9]+' \
-              | grep -oE '[0-9]+' | sort -un | head -n 50)
+              | { grep -oiE 'alert[[:space:]]*#?[0-9]+' || true; } \
+              | { grep -oE '[0-9]+' || true; } \
+              | sort -un | head -n 50)
 
             if [ -z "$ALERTS" ]; then
               SKIPPED=$((SKIPPED + 1))


### PR DESCRIPTION
## Summary

Hotfix for the `close-orphans` job introduced in #2631 — its first post-merge run failed immediately because `set -uo pipefail` + `grep`'s exit-1 on no-match killed the whole job inside the `ALERTS=$(... | grep ... | grep ...)` capture.

Wrapping each grep in `{ grep ... || true; }` lets the pipe exit cleanly when the issue body has no `alert #N` reference, so the existing `if [ -z "$ALERTS" ]; then SKIPPED++; continue; fi` can correctly skip to the next issue.

## Changelog

### Plugin (Soleur)
- **Workflow fix:** `.github/workflows/codeql-to-issues.yml` `close-orphans` job — both grep stages in the alert-extraction pipe now suppress no-match exit-1 so `pipefail` does not kill the job on issues that don't reference any `alert #N`.

## Test plan

- [x] Verified locally: empty-input pipe exits 0 with empty result; populated input yields newline-separated alert numbers
- [x] \`actionlint\` clean
- [ ] ⏳ Post-merge: \`gh workflow run codeql-to-issues.yml\` and verify \`close-orphans\` job completes successfully

Generated with [Claude Code](https://claude.com/claude-code)