### PR TITLE
fix(conversations): scope Command Center + KB resume by repo_url

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
 import { useConversations } from "@/hooks/use-conversations";
 import type { ArchiveFilter } from "@/hooks/use-conversations";
 import { useOnboarding } from "@/hooks/use-onboarding";
@@ -155,6 +156,42 @@ export default function DashboardPage() {
       cancelled = true;
     };
   }, [router]);
+
+  // Disconnected-with-orphans hint: when a user has disconnected their repo
+  // but has pre-existing conversations tied to another repo_url, surface a
+  // one-line hint so the empty Command Center doesn't read as data loss.
+  // See plan 2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md
+  // Product/UX Gate findings.
+  const [orphanedCount, setOrphanedCount] = useState<number>(0);
+  const [repoDisconnected, setRepoDisconnected] = useState<boolean>(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const supabase = createClient();
+    (async () => {
+      const { data: auth } = await supabase.auth.getUser();
+      if (!auth.user) return;
+      const { data: userRow } = await supabase
+        .from("users")
+        .select("repo_url")
+        .eq("id", auth.user.id)
+        .maybeSingle();
+      const repoUrl = (userRow?.repo_url as string | null | undefined) ?? null;
+      if (repoUrl) return; // Connected — no hint needed.
+      // `count=exact head=true` — row-less query, just the total.
+      const { count } = await supabase
+        .from("conversations")
+        .select("id", { count: "exact", head: true })
+        .eq("user_id", auth.user.id)
+        .not("repo_url", "is", null);
+      if (cancelled) return;
+      setRepoDisconnected(true);
+      setOrphanedCount(count ?? 0);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const visionExists = kbFiles.has("overview/vision.md");
   const foundationCards: FoundationCard[] = FOUNDATION_PATHS.map((f) => ({
@@ -336,6 +373,16 @@ export default function DashboardPage() {
         <p className="mb-10 max-w-md text-center text-sm text-neutral-400">
           Describe your startup idea and your AI organization will get to work.
         </p>
+        {repoDisconnected && orphanedCount > 0 && (
+          <p
+            data-testid="disconnected-orphans-hint"
+            className="mb-6 max-w-md text-center text-xs text-neutral-500"
+          >
+            {orphanedCount === 1
+              ? "Your previous conversation is tied to your disconnected repository. Reconnect that repository to view it."
+              : `Your previous ${orphanedCount} conversations are tied to your disconnected repository. Reconnect that repository to view them.`}
+          </p>
+        )}
 
         <form
           onSubmit={handleFirstRunSend}

--- a/apps/web-platform/app/api/chat/thread-info/route.ts
+++ b/apps/web-platform/app/api/chat/thread-info/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import type { User } from "@supabase/supabase-js";
+import { createServiceClient } from "@/lib/supabase/service";
 import { lookupConversationForPath } from "@/server/lookup-conversation-for-path";
 import { validateContextPath } from "@/server/validate-context-path";
 import { withUserRateLimit } from "@/server/with-user-rate-limit";
@@ -11,7 +12,17 @@ async function getHandler(req: Request, user: User) {
     return NextResponse.json({ error: "Invalid contextPath" }, { status: 400 });
   }
 
-  const result = await lookupConversationForPath(user.id, contextPath);
+  // Scope the lookup to the user's CURRENT repo_url — see plan
+  // 2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md.
+  const service = createServiceClient();
+  const { data: userRow } = await service
+    .from("users")
+    .select("repo_url")
+    .eq("id", user.id)
+    .maybeSingle();
+  const repoUrl = (userRow?.repo_url as string | null | undefined) ?? null;
+
+  const result = await lookupConversationForPath(user.id, contextPath, repoUrl);
   if (!result.ok) {
     // Helper already mirrored to Sentry; thread-info's public contract
     // degrades to messageCount=0 rather than exposing the error.

--- a/apps/web-platform/app/api/chat/thread-info/route.ts
+++ b/apps/web-platform/app/api/chat/thread-info/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import type { User } from "@supabase/supabase-js";
-import { createServiceClient } from "@/lib/supabase/service";
+import { getCurrentRepoUrl } from "@/server/current-repo-url";
 import { lookupConversationForPath } from "@/server/lookup-conversation-for-path";
 import { validateContextPath } from "@/server/validate-context-path";
 import { withUserRateLimit } from "@/server/with-user-rate-limit";
@@ -12,16 +12,7 @@ async function getHandler(req: Request, user: User) {
     return NextResponse.json({ error: "Invalid contextPath" }, { status: 400 });
   }
 
-  // Scope the lookup to the user's CURRENT repo_url — see plan
-  // 2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md.
-  const service = createServiceClient();
-  const { data: userRow } = await service
-    .from("users")
-    .select("repo_url")
-    .eq("id", user.id)
-    .maybeSingle();
-  const repoUrl = (userRow?.repo_url as string | null | undefined) ?? null;
-
+  const repoUrl = await getCurrentRepoUrl(user.id);
   const result = await lookupConversationForPath(user.id, contextPath, repoUrl);
   if (!result.ok) {
     // Helper already mirrored to Sentry; thread-info's public contract

--- a/apps/web-platform/app/api/conversations/route.ts
+++ b/apps/web-platform/app/api/conversations/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import type { User } from "@supabase/supabase-js";
+import { createServiceClient } from "@/lib/supabase/service";
 import { lookupConversationForPath } from "@/server/lookup-conversation-for-path";
 import { validateContextPath } from "@/server/validate-context-path";
 import { withUserRateLimit } from "@/server/with-user-rate-limit";
@@ -32,7 +33,17 @@ async function getHandler(req: Request, user: User) {
     return NextResponse.json({ error: "Invalid contextPath" }, { status: 400 });
   }
 
-  const result = await lookupConversationForPath(user.id, contextPath);
+  // Scope the lookup to the user's CURRENT repo_url — see plan
+  // 2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md.
+  const service = createServiceClient();
+  const { data: userRow } = await service
+    .from("users")
+    .select("repo_url")
+    .eq("id", user.id)
+    .maybeSingle();
+  const repoUrl = (userRow?.repo_url as string | null | undefined) ?? null;
+
+  const result = await lookupConversationForPath(user.id, contextPath, repoUrl);
   if (!result.ok) {
     return NextResponse.json({ error: "Internal error" }, { status: 500 });
   }

--- a/apps/web-platform/app/api/conversations/route.ts
+++ b/apps/web-platform/app/api/conversations/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import type { User } from "@supabase/supabase-js";
-import { createServiceClient } from "@/lib/supabase/service";
+import { getCurrentRepoUrl } from "@/server/current-repo-url";
 import { lookupConversationForPath } from "@/server/lookup-conversation-for-path";
 import { validateContextPath } from "@/server/validate-context-path";
 import { withUserRateLimit } from "@/server/with-user-rate-limit";
@@ -33,16 +33,7 @@ async function getHandler(req: Request, user: User) {
     return NextResponse.json({ error: "Invalid contextPath" }, { status: 400 });
   }
 
-  // Scope the lookup to the user's CURRENT repo_url — see plan
-  // 2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md.
-  const service = createServiceClient();
-  const { data: userRow } = await service
-    .from("users")
-    .select("repo_url")
-    .eq("id", user.id)
-    .maybeSingle();
-  const repoUrl = (userRow?.repo_url as string | null | undefined) ?? null;
-
+  const repoUrl = await getCurrentRepoUrl(user.id);
   const result = await lookupConversationForPath(user.id, contextPath, repoUrl);
   if (!result.ok) {
     return NextResponse.json({ error: "Internal error" }, { status: 500 });

--- a/apps/web-platform/app/api/repo/setup/route.ts
+++ b/apps/web-platform/app/api/repo/setup/route.ts
@@ -146,12 +146,15 @@ export async function POST(request: Request) {
 
       // Auto-trigger headless sync — fire-and-forget with .catch()
       // BYOK check is handled internally by startAgentSession (rejects if no key)
+      // `repoUrl` is the freshly-set value from the request body — stamp it
+      // on the sync conversation so the Command Center scopes correctly.
       const conversationId = crypto.randomUUID();
       const { error: convError } = await serviceClient
         .from("conversations")
         .insert({
           id: conversationId,
           user_id: user.id,
+          repo_url: repoUrl,
           domain_leader: "system",
           status: "active",
           session_id: crypto.randomUUID(),

--- a/apps/web-platform/hooks/use-conversations.ts
+++ b/apps/web-platform/hooks/use-conversations.ts
@@ -84,6 +84,7 @@ export function useConversations(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [userId, setUserId] = useState<string | null>(null);
+  const [repoUrl, setRepoUrl] = useState<string | null>(null);
 
   const fetchConversations = useCallback(async () => {
     setLoading(true);
@@ -102,11 +103,32 @@ export function useConversations(
       const currentUserId = authData.user.id;
       setUserId(currentUserId);
 
-      // Query 1: Fetch conversations (explicit user_id filter for defence-in-depth)
+      // Scope the list to the user's CURRENT repo_url. Disconnected users
+      // (repo_url IS NULL) see an empty list — the old repo's conversations
+      // stay attached to their repo_url and are hidden until the user
+      // reconnects that exact URL. See plan
+      // 2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md.
+      const { data: userRow } = await supabase
+        .from("users")
+        .select("repo_url")
+        .eq("id", currentUserId)
+        .maybeSingle();
+      const currentRepoUrl =
+        (userRow?.repo_url as string | null | undefined) ?? null;
+      setRepoUrl(currentRepoUrl);
+
+      if (!currentRepoUrl) {
+        setConversations([]);
+        setLoading(false);
+        return;
+      }
+
+      // Query 1: Fetch conversations (explicit user_id + repo_url filter)
       let query = supabase
         .from("conversations")
         .select("*")
         .eq("user_id", currentUserId)
+        .eq("repo_url", currentRepoUrl)
         .order("last_active", { ascending: false })
         .order("created_at", { ascending: false });
 
@@ -181,8 +203,11 @@ export function useConversations(
     fetchConversations();
   }, [fetchConversations]);
 
-  // Supabase Realtime subscription for status updates
-  // Uses userId state (not ref) so effect re-runs when auth completes
+  // Supabase Realtime subscription for status updates.
+  // Uses userId state (not ref) so effect re-runs when auth completes.
+  // Realtime `filter` accepts only ONE equality predicate per realtime-js#97 —
+  // the `user_id` filter stays server-side; cross-repo payloads are dropped
+  // client-side in the callback below (same pattern as `archived_at`).
   useEffect(() => {
     if (!userId) return;
 
@@ -201,6 +226,10 @@ export function useConversations(
           const updated = payload.new as Conversation;
           // Client-side user_id check: Free tier ignores server-side filter
           if (updated.user_id !== userId) return;
+          // Client-side repo_url check: Realtime can't express the second
+          // equality, so drop payloads whose repo_url doesn't match the
+          // current scope.
+          if (repoUrl && updated.repo_url !== repoUrl) return;
 
           setConversations((prev) => {
             // Check if the conversation's archive state matches the current filter
@@ -226,7 +255,39 @@ export function useConversations(
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [userId, archiveFilter]);
+  }, [userId, archiveFilter, repoUrl]);
+
+  // Cross-tab disconnect/reconnect awareness (race R-C): another tab may
+  // swap the user's repo_url while this hook is mounted. Subscribe to
+  // users UPDATE events and refetch when repo_url changes — without this
+  // the Command Center keeps showing the pre-swap scope until a hard reload.
+  useEffect(() => {
+    if (!userId) return;
+    const supabase = createClient();
+    const channel = supabase
+      .channel("command-center-user")
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "users",
+          filter: `id=eq.${userId}`,
+        },
+        (payload) => {
+          const updated = payload.new as { repo_url?: string | null };
+          const nextRepoUrl = updated?.repo_url ?? null;
+          if (nextRepoUrl !== repoUrl) {
+            fetchConversations();
+          }
+        },
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [userId, repoUrl, fetchConversations]);
 
   const archiveConversation = useCallback(async (id: string) => {
     const supabase = createClient();

--- a/apps/web-platform/hooks/use-conversations.ts
+++ b/apps/web-platform/hooks/use-conversations.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { createClient } from "@/lib/supabase/client";
 import type { Conversation, Message, ConversationStatus } from "@/lib/types";
 import { DOMAIN_LEADERS, type DomainLeaderId } from "@/server/domain-leaders";
@@ -85,6 +85,13 @@ export function useConversations(
   const [error, setError] = useState<string | null>(null);
   const [userId, setUserId] = useState<string | null>(null);
   const [repoUrl, setRepoUrl] = useState<string | null>(null);
+  // Ref mirror of repoUrl so Realtime callbacks read the latest value
+  // without forcing the subscription effect to re-subscribe on every
+  // repo change (see review F1). Both channels read from this ref.
+  const repoUrlRef = useRef<string | null>(null);
+  useEffect(() => {
+    repoUrlRef.current = repoUrl;
+  }, [repoUrl]);
 
   const fetchConversations = useCallback(async () => {
     setLoading(true);
@@ -228,8 +235,14 @@ export function useConversations(
           if (updated.user_id !== userId) return;
           // Client-side repo_url check: Realtime can't express the second
           // equality, so drop payloads whose repo_url doesn't match the
-          // current scope.
-          if (repoUrl && updated.repo_url !== repoUrl) return;
+          // current scope. Strict equality catches the disconnected case
+          // (repoUrlRef=null, payload.repo_url=<something>) too — when
+          // disconnected, conversations list is empty so the update
+          // would find no matching row anyway, but this guards against
+          // rendering the first cross-repo row if a future refactor
+          // decouples list-empty from disconnect.
+          const currentRepoUrl = repoUrlRef.current;
+          if ((updated.repo_url ?? null) !== currentRepoUrl) return;
 
           setConversations((prev) => {
             // Check if the conversation's archive state matches the current filter
@@ -255,7 +268,7 @@ export function useConversations(
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [userId, archiveFilter, repoUrl]);
+  }, [userId, archiveFilter]);
 
   // Cross-tab disconnect/reconnect awareness (race R-C): another tab may
   // swap the user's repo_url while this hook is mounted. Subscribe to
@@ -277,7 +290,7 @@ export function useConversations(
         (payload) => {
           const updated = payload.new as { repo_url?: string | null };
           const nextRepoUrl = updated?.repo_url ?? null;
-          if (nextRepoUrl !== repoUrl) {
+          if (nextRepoUrl !== repoUrlRef.current) {
             fetchConversations();
           }
         },
@@ -287,7 +300,9 @@ export function useConversations(
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [userId, repoUrl, fetchConversations]);
+    // repoUrl intentionally not in deps (see F1) — the comparison reads
+    // repoUrlRef.current, which stays fresh without forcing resubscribe.
+  }, [userId, fetchConversations]);
 
   const archiveConversation = useCallback(async (id: string) => {
     const supabase = createClient();

--- a/apps/web-platform/lib/types.ts
+++ b/apps/web-platform/lib/types.ts
@@ -125,6 +125,7 @@ export interface Conversation {
   created_at: string;
   archived_at: string | null;
   context_path?: string | null;
+  repo_url?: string | null;
 }
 
 export type ConversationStatus = Conversation["status"];

--- a/apps/web-platform/server/conversations-tools.ts
+++ b/apps/web-platform/server/conversations-tools.ts
@@ -8,6 +8,7 @@
 
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod/v4";
+import { createServiceClient } from "@/lib/supabase/service";
 import {
   lookupConversationForPath,
   type LookupConversationResult,
@@ -17,6 +18,21 @@ import { validateContextPath } from "@/server/validate-context-path";
 interface BuildConversationsToolsOpts {
   /** Captured in closure — prevents cross-user lookups. */
   userId: string;
+}
+
+/**
+ * Read the user's CURRENT repo_url so the lookup is scoped to the repository
+ * they have connected right now — see plan
+ * 2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md.
+ */
+async function currentRepoUrl(userId: string): Promise<string | null> {
+  const service = createServiceClient();
+  const { data } = await service
+    .from("users")
+    .select("repo_url")
+    .eq("id", userId)
+    .maybeSingle();
+  return (data?.repo_url as string | null | undefined) ?? null;
 }
 
 type ToolTextResponse = {
@@ -58,8 +74,9 @@ export function buildConversationsTools(opts: BuildConversationsToolsOpts) {
           );
         }
 
+        const repoUrl = await currentRepoUrl(userId);
         const result: LookupConversationResult =
-          await lookupConversationForPath(userId, validated);
+          await lookupConversationForPath(userId, validated, repoUrl);
         if (!result.ok) {
           // Exhaustiveness check — adding a new error discriminant without
           // updating this wrapper fails tsc --noEmit. Mirrors the pattern

--- a/apps/web-platform/server/conversations-tools.ts
+++ b/apps/web-platform/server/conversations-tools.ts
@@ -8,7 +8,7 @@
 
 import { tool } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod/v4";
-import { createServiceClient } from "@/lib/supabase/service";
+import { getCurrentRepoUrl } from "@/server/current-repo-url";
 import {
   lookupConversationForPath,
   type LookupConversationResult,
@@ -18,21 +18,6 @@ import { validateContextPath } from "@/server/validate-context-path";
 interface BuildConversationsToolsOpts {
   /** Captured in closure — prevents cross-user lookups. */
   userId: string;
-}
-
-/**
- * Read the user's CURRENT repo_url so the lookup is scoped to the repository
- * they have connected right now — see plan
- * 2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md.
- */
-async function currentRepoUrl(userId: string): Promise<string | null> {
-  const service = createServiceClient();
-  const { data } = await service
-    .from("users")
-    .select("repo_url")
-    .eq("id", userId)
-    .maybeSingle();
-  return (data?.repo_url as string | null | undefined) ?? null;
 }
 
 type ToolTextResponse = {
@@ -60,6 +45,10 @@ export function buildConversationsTools(opts: BuildConversationsToolsOpts) {
         "'knowledge-base/product/roadmap.md'). " +
         "Returns { conversationId, contextPath, lastActive, messageCount } " +
         "when a thread exists, or null when no thread is bound to the path. " +
+        "Scoped to the user's currently connected repository: a null " +
+        "response on a disconnected workspace does NOT mean no prior thread " +
+        "exists for this path — orphaned threads from a previously " +
+        "connected repo reappear only after reconnecting that exact URL. " +
         "Does NOT return message bodies (threads are opaque from the agent's " +
         "perspective — use the UI to read them).",
       { contextPath: z.string() },
@@ -74,7 +63,7 @@ export function buildConversationsTools(opts: BuildConversationsToolsOpts) {
           );
         }
 
-        const repoUrl = await currentRepoUrl(userId);
+        const repoUrl = await getCurrentRepoUrl(userId);
         const result: LookupConversationResult =
           await lookupConversationForPath(userId, validated, repoUrl);
         if (!result.ok) {

--- a/apps/web-platform/server/current-repo-url.ts
+++ b/apps/web-platform/server/current-repo-url.ts
@@ -1,0 +1,41 @@
+import { createServiceClient } from "@/lib/supabase/service";
+import { reportSilentFallback } from "@/server/observability";
+
+/**
+ * Read the authenticated user's CURRENT `users.repo_url`.
+ *
+ * Collapses the pattern that otherwise repeats across every caller of
+ * `lookupConversationForPath` + `ws-handler.createConversation` +
+ * Command Center consumers. Centralizing the read keeps three things
+ * consistent:
+ *
+ *   - Error handling: transient DB errors are mirrored to Sentry via
+ *     `reportSilentFallback` (rule `cq-silent-fallback-must-mirror-to-sentry`)
+ *     rather than silently degrading to "disconnected".
+ *   - Coercion: Postgrest's nullable-row return is flattened to
+ *     `string | null` with no `as` casts at call sites.
+ *   - Single seam for future URL normalization or `projects.id` migration.
+ *
+ * Returns `null` when the user is disconnected OR on transient error —
+ * callers treat both identically (disconnect semantics fail-closed).
+ */
+export async function getCurrentRepoUrl(userId: string): Promise<string | null> {
+  const service = createServiceClient();
+  const { data, error } = await service
+    .from("users")
+    .select("repo_url")
+    .eq("id", userId)
+    .maybeSingle();
+
+  if (error) {
+    reportSilentFallback(error, {
+      feature: "repo-scope",
+      op: "read-current-repo-url",
+      extra: { userId },
+    });
+    return null;
+  }
+
+  const repoUrl = (data?.repo_url as string | null | undefined) ?? null;
+  return repoUrl && repoUrl.length > 0 ? repoUrl : null;
+}

--- a/apps/web-platform/server/lookup-conversation-for-path.ts
+++ b/apps/web-platform/server/lookup-conversation-for-path.ts
@@ -39,12 +39,19 @@ export type LookupConversationResult =
 export async function lookupConversationForPath(
   userId: string,
   contextPath: string,
+  repoUrl: string | null,
 ): Promise<LookupConversationResult> {
+  // Disconnected user (no connected repo) -> no resumable thread.
+  // Short-circuit before hitting the DB so orphaned rows from a prior
+  // repo cannot leak back into a freshly-connected project.
+  if (!repoUrl) return { ok: true, row: null };
+
   const service = createServiceClient();
   const { data, error } = await service
     .from("conversations")
     .select("id, context_path, last_active, messages(count)")
     .eq("user_id", userId)
+    .eq("repo_url", repoUrl)
     .eq("context_path", contextPath)
     .is("archived_at", null)
     .order("last_active", { ascending: false })

--- a/apps/web-platform/server/ws-handler.ts
+++ b/apps/web-platform/server/ws-handler.ts
@@ -7,6 +7,7 @@ import { KeyInvalidError, WS_CLOSE_CODES, type WSMessage, type Conversation } fr
 import type { ConversationContext } from "@/lib/types";
 import { validateConversationContext } from "./context-validation";
 import { createServiceClient } from "@/lib/supabase/service";
+import { getCurrentRepoUrl } from "@/server/current-repo-url";
 import type { DomainLeaderId } from "@/server/domain-leaders";
 import { TC_VERSION } from "@/lib/legal/tc-version";
 import { MAX_SELECTION_LENGTH } from "./review-gate";
@@ -285,15 +286,7 @@ async function createConversation(
   // mid-session have repo_url=null; we abort rather than orphan the row
   // (plan risk R-D). See
   // 2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md.
-  const { data: userRow, error: userErr } = await supabase
-    .from("users")
-    .select("repo_url")
-    .eq("id", userId)
-    .maybeSingle();
-  if (userErr) {
-    throw new Error(`Failed to read user repo_url: ${userErr.message}`);
-  }
-  const repoUrl = (userRow?.repo_url as string | null | undefined) ?? null;
+  const repoUrl = await getCurrentRepoUrl(userId);
   if (!repoUrl) {
     throw new Error(
       "No connected repository — conversation insert aborted (disconnect race).",
@@ -421,13 +414,21 @@ export async function handleMessage(userId: string, raw: string): Promise<void> 
         // review-backlog drain.
         //
         // If client asked to resume by context_path (KB sidebar), look up
-        // existing thread before deferring creation. UNIQUE partial index
-        // on (user_id, context_path) guarantees at most one match.
-        if (validResumePath) {
+        // existing thread before deferring creation. The UNIQUE partial
+        // index on (user_id, repo_url, context_path) now scopes by the
+        // connected repo — we must filter the lookup by repo_url too, or
+        // the same path in a previously-connected repo resumes a stale
+        // thread. If the user is disconnected, skip resume entirely and
+        // fall through to deferred creation (which aborts on null
+        // repo_url — see createConversation). See plan
+        // 2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md.
+        const currentRepoUrl = await getCurrentRepoUrl(userId);
+        if (validResumePath && currentRepoUrl) {
           const { data: existing, error: lookupErr } = await supabase
             .from("conversations")
             .select("id, last_active, context_path")
             .eq("user_id", userId)
+            .eq("repo_url", currentRepoUrl)
             .eq("context_path", validResumePath)
             .is("archived_at", null)
             .order("last_active", { ascending: false })
@@ -495,15 +496,29 @@ export async function handleMessage(userId: string, raw: string): Promise<void> 
         // Clear any pending deferred state — resuming an existing conversation
         session.pending = undefined;
 
-        // Verify conversation ownership
-        const { data: conv, error: convErr } = await supabase
+        // Verify conversation ownership AND repo scope. A cached id from a
+        // previously-connected repo must NOT resume across a repo swap —
+        // the Command Center hides it, the MCP lookup tool refuses to
+        // surface it, and this path is the last remaining backdoor. See
+        // plan 2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md.
+        const currentRepoUrl = await getCurrentRepoUrl(userId);
+        const convQuery = supabase
           .from("conversations")
-          .select("id, status")
+          .select("id, status, repo_url")
           .eq("id", msg.conversationId)
-          .eq("user_id", userId)
-          .single();
+          .eq("user_id", userId);
+        const { data: conv, error: convErr } = await convQuery.single();
 
         if (convErr || !conv) {
+          sendToClient(userId, { type: "error", message: "Conversation not found" });
+          return;
+        }
+
+        const convRepoUrl = (conv as { repo_url?: string | null }).repo_url ?? null;
+        if (convRepoUrl !== currentRepoUrl) {
+          // Could be cross-repo resume attempt OR a disconnected user. Keep
+          // the response indistinguishable from "not found" so callers
+          // can't probe for existence of cross-repo threads.
           sendToClient(userId, { type: "error", message: "Conversation not found" });
           return;
         }

--- a/apps/web-platform/server/ws-handler.ts
+++ b/apps/web-platform/server/ws-handler.ts
@@ -280,9 +280,30 @@ async function createConversation(
 ): Promise<string> {
   if (!id) id = randomUUID();
 
+  // Stamp the conversation with the user's CURRENT repo_url so Command
+  // Center + context_path resume can scope by it. Users who disconnected
+  // mid-session have repo_url=null; we abort rather than orphan the row
+  // (plan risk R-D). See
+  // 2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md.
+  const { data: userRow, error: userErr } = await supabase
+    .from("users")
+    .select("repo_url")
+    .eq("id", userId)
+    .maybeSingle();
+  if (userErr) {
+    throw new Error(`Failed to read user repo_url: ${userErr.message}`);
+  }
+  const repoUrl = (userRow?.repo_url as string | null | undefined) ?? null;
+  if (!repoUrl) {
+    throw new Error(
+      "No connected repository — conversation insert aborted (disconnect race).",
+    );
+  }
+
   const { error } = await supabase.from("conversations").insert({
     id,
     user_id: userId,
+    repo_url: repoUrl,
     domain_leader: leaderId ?? null,
     status: "active" as Conversation["status"],
     last_active: new Date().toISOString(),
@@ -291,15 +312,17 @@ async function createConversation(
 
   if (error) {
     // 23505 = unique_violation (postgres). When contextPath is set, this means
-    // another tab created the same (user_id, context_path) row — use it instead.
-    // We disambiguate on the index name (conversations_context_path_user_uniq)
-    // so an unrelated unique constraint (e.g., conversations_pkey id collision)
-    // does NOT fall through into the context_path lookup. See review #2390.
+    // another tab created the same (user_id, repo_url, context_path) row — use
+    // it instead. We disambiguate on the index name
+    // (conversations_context_path_user_uniq) so an unrelated unique constraint
+    // (e.g., conversations_pkey id collision) does NOT fall through into the
+    // context_path lookup. See review #2390.
     if (contextPath && isContextPathUniqueViolation(error)) {
       const { data: existing, error: lookupErr } = await supabase
         .from("conversations")
         .select("id")
         .eq("user_id", userId)
+        .eq("repo_url", repoUrl)
         .eq("context_path", contextPath)
         .is("archived_at", null)
         .order("last_active", { ascending: false })

--- a/apps/web-platform/supabase/migrations/029_conversations_repo_url.sql
+++ b/apps/web-platform/supabase/migrations/029_conversations_repo_url.sql
@@ -18,12 +18,39 @@
 ALTER TABLE public.conversations
   ADD COLUMN IF NOT EXISTS repo_url text;
 
+COMMENT ON COLUMN public.conversations.repo_url IS
+  'Snapshot of users.repo_url at conversation create time (free-text, '
+  'not a FK). Readers scope by (user_id, repo_url) to hide conversations '
+  'whose owning repo is no longer connected. Coupling invariant: any '
+  'future normalization of users.repo_url MUST also rewrite this column '
+  'in the same migration, or previously-connected conversations go dark.';
+
 -- Backfill pre-migration rows with the user's current repo_url.
--- For disconnected users (repo_url IS NULL), conversations.repo_url stays NULL.
+-- Caveats:
+--   1. Users currently disconnected (users.repo_url IS NULL) leave their
+--      conversations at repo_url = NULL — hidden from the Command Center
+--      until they reconnect. Marked archived below so they remain
+--      discoverable via the Archived filter.
+--   2. Users who already swapped repos before this migration cannot have
+--      historical rows recovered — we have no audit of past repo_url
+--      values. Those rows get stamped with the user's CURRENT repo_url
+--      (the known limitation documented in the plan). A future improvement
+--      could ship a per-user "tag all pre-migration rows as archived"
+--      batch if this becomes a complaint.
 UPDATE public.conversations c
    SET repo_url = u.repo_url
   FROM public.users u
  WHERE c.user_id = u.id
+   AND c.repo_url IS NULL;
+
+-- Caveat 1 (see above): archive pre-migration rows whose user is
+-- currently disconnected so the Archived filter can still surface them.
+-- Uses COALESCE so rows already archived keep their original timestamp.
+UPDATE public.conversations c
+   SET archived_at = COALESCE(c.archived_at, NOW())
+  FROM public.users u
+ WHERE c.user_id = u.id
+   AND u.repo_url IS NULL
    AND c.repo_url IS NULL;
 
 -- Partial index -- only populated rows are indexed (disconnected-user

--- a/apps/web-platform/supabase/migrations/029_conversations_repo_url.sql
+++ b/apps/web-platform/supabase/migrations/029_conversations_repo_url.sql
@@ -1,0 +1,42 @@
+-- 029_conversations_repo_url.sql
+-- Scope conversations to the repository they were created against.
+-- Fixes: command center + KB-context-path lookup leaking pre-disconnect
+-- conversations into a freshly-connected repo (see plan
+-- 2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md).
+--
+-- Nullable on purpose: pre-migration rows are backfilled with the user's
+-- CURRENT repo_url. If the user had already disconnected before this
+-- migration ran, users.repo_url is NULL and conversations.repo_url stays
+-- NULL -- those rows will be hidden by the new query filter (desired --
+-- matches disconnect semantics).
+--
+-- NOT using CONCURRENTLY: Supabase migration runner wraps each file in a
+-- transaction (see migrations 025, 027 comments). Column add + index are
+-- transaction-safe. If the table grows to a size where an index rebuild
+-- becomes disruptive, ship a second migration via direct psql.
+
+ALTER TABLE public.conversations
+  ADD COLUMN IF NOT EXISTS repo_url text;
+
+-- Backfill pre-migration rows with the user's current repo_url.
+-- For disconnected users (repo_url IS NULL), conversations.repo_url stays NULL.
+UPDATE public.conversations c
+   SET repo_url = u.repo_url
+  FROM public.users u
+ WHERE c.user_id = u.id
+   AND c.repo_url IS NULL;
+
+-- Partial index -- only populated rows are indexed (disconnected-user
+-- conversations don't need index coverage; they're never queried).
+CREATE INDEX IF NOT EXISTS idx_conversations_user_repo
+  ON public.conversations (user_id, repo_url)
+  WHERE repo_url IS NOT NULL;
+
+-- Update the existing context_path UNIQUE index to include repo_url so
+-- the same KB file path in two repos no longer collides. This drops and
+-- recreates the index (established pattern -- see migration 025).
+DROP INDEX IF EXISTS public.conversations_context_path_user_uniq;
+
+CREATE UNIQUE INDEX conversations_context_path_user_uniq
+  ON public.conversations (user_id, repo_url, context_path)
+  WHERE context_path IS NOT NULL AND archived_at IS NULL;

--- a/apps/web-platform/test/api-conversations.test.ts
+++ b/apps/web-platform/test/api-conversations.test.ts
@@ -16,16 +16,35 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // --- Mock infrastructure --------------------------------------------------
 
-const { mockGetUser, mockLookup } = vi.hoisted(() => ({
+const { mockGetUser, mockLookup, mockUserRepoUrl } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
   mockLookup: vi.fn(),
+  mockUserRepoUrl: vi.fn(),
 }));
+
+const buildServiceClient = () => ({
+  from: (_table: string) => {
+    const chain = {
+      select: vi.fn(() => chain),
+      eq: vi.fn(() => chain),
+      maybeSingle: vi.fn(async () => ({
+        data: { repo_url: mockUserRepoUrl() },
+        error: null,
+      })),
+    };
+    return chain;
+  },
+});
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({
     auth: { getUser: mockGetUser },
   })),
-  createServiceClient: vi.fn(() => ({})),
+  createServiceClient: vi.fn(buildServiceClient),
+}));
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: vi.fn(buildServiceClient),
 }));
 
 vi.mock("@/server/lookup-conversation-for-path", () => ({
@@ -43,6 +62,7 @@ function makeRequest(url: string): Request {
 describe("GET /api/conversations", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUserRepoUrl.mockReturnValue("https://github.com/acme/repo");
   });
 
   it("returns 401 when unauthenticated", async () => {
@@ -103,6 +123,7 @@ describe("GET /api/conversations", () => {
     expect(mockLookup).toHaveBeenCalledWith(
       "u1",
       "knowledge-base/product/roadmap.md",
+      "https://github.com/acme/repo",
     );
   });
 

--- a/apps/web-platform/test/api-conversations.test.ts
+++ b/apps/web-platform/test/api-conversations.test.ts
@@ -22,29 +22,20 @@ const { mockGetUser, mockLookup, mockUserRepoUrl } = vi.hoisted(() => ({
   mockUserRepoUrl: vi.fn(),
 }));
 
-const buildServiceClient = () => ({
-  from: (_table: string) => {
-    const chain = {
-      select: vi.fn(() => chain),
-      eq: vi.fn(() => chain),
-      maybeSingle: vi.fn(async () => ({
-        data: { repo_url: mockUserRepoUrl() },
-        error: null,
-      })),
-    };
-    return chain;
-  },
-});
-
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({
     auth: { getUser: mockGetUser },
   })),
-  createServiceClient: vi.fn(buildServiceClient),
+  createServiceClient: vi.fn(() => ({})),
 }));
 
-vi.mock("@/lib/supabase/service", () => ({
-  createServiceClient: vi.fn(buildServiceClient),
+// getCurrentRepoUrl is extracted; mock it directly so the route's scoping
+// test doesn't depend on the internal users-table query shape.
+vi.mock("@/server/current-repo-url", () => ({
+  getCurrentRepoUrl: (...args: unknown[]) => {
+    void args;
+    return Promise.resolve(mockUserRepoUrl());
+  },
 }));
 
 vi.mock("@/server/lookup-conversation-for-path", () => ({

--- a/apps/web-platform/test/command-center-repo-scope.test.tsx
+++ b/apps/web-platform/test/command-center-repo-scope.test.tsx
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+
+// RED phase for plan 2026-04-22-fix-command-center-stale-conversations-after-repo-swap.
+//
+// Contract:
+//   useConversations() must scope the list query to the user's CURRENT
+//   users.repo_url. Pre-swap conversations (different repo_url) must not
+//   render. When users.repo_url is null (disconnected), the hook returns
+//   an empty list without issuing the main list query.
+//
+//   The Realtime channel for conversations stays on user_id only (realtime-js
+//   single-column filter limitation); cross-repo payloads must be dropped in
+//   the callback by comparing payload.new.repo_url to currentRepoUrl.
+
+// --- Supabase mock plumbing -------------------------------------------------
+
+vi.mock("@/hooks/use-team-names", () => ({
+  useTeamNames: () => ({
+    names: {},
+    loading: false,
+    error: null,
+  }),
+}));
+
+type Row = Record<string, unknown>;
+
+interface MockState {
+  currentRepoUrl: string | null;
+  conversationsByRepo: Record<string, Row[]>;
+  messages: Row[];
+  capturedEq: Array<[string, unknown]>;
+}
+
+const state: MockState = {
+  currentRepoUrl: null,
+  conversationsByRepo: {},
+  messages: [],
+  capturedEq: [],
+};
+
+function resetState() {
+  state.currentRepoUrl = null;
+  state.conversationsByRepo = {};
+  state.messages = [];
+  state.capturedEq = [];
+}
+
+function buildConversationsBuilder() {
+  const predicates: Array<[string, unknown]> = [];
+  const builder: Record<string, unknown> = {
+    select: vi.fn(() => builder),
+    eq: vi.fn((col: string, val: unknown) => {
+      predicates.push([col, val]);
+      state.capturedEq.push([col, val]);
+      return builder;
+    }),
+    in: vi.fn(() => builder),
+    is: vi.fn(() => builder),
+    not: vi.fn(() => builder),
+    order: vi.fn(() => builder),
+    limit: vi.fn((_n: number) => {
+      const repoPred = predicates.find(([c]) => c === "repo_url");
+      // If no repo_url predicate was applied, the list is NOT scoped —
+      // return everything across repos (this is the bug we're fixing).
+      let rows: Row[];
+      if (!repoPred) {
+        rows = Object.values(state.conversationsByRepo).flat();
+      } else {
+        rows = state.conversationsByRepo[String(repoPred[1])] ?? [];
+      }
+      return Promise.resolve({ data: rows, error: null });
+    }),
+    then: (onfulfilled: (value: unknown) => unknown) =>
+      Promise.resolve({ data: [], error: null }).then(onfulfilled),
+  };
+  return builder;
+}
+
+function buildMessagesBuilder() {
+  const builder: Record<string, unknown> = {
+    select: vi.fn(() => builder),
+    in: vi.fn(() => builder),
+    order: vi.fn(() =>
+      Promise.resolve({ data: state.messages, error: null }),
+    ),
+    then: (onfulfilled: (value: unknown) => unknown) =>
+      Promise.resolve({ data: state.messages, error: null }).then(onfulfilled),
+  };
+  return builder;
+}
+
+function buildUsersBuilder() {
+  const builder: Record<string, unknown> = {
+    select: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    single: vi.fn(() =>
+      Promise.resolve({
+        data: { repo_url: state.currentRepoUrl },
+        error: null,
+      }),
+    ),
+    maybeSingle: vi.fn(() =>
+      Promise.resolve({
+        data: { repo_url: state.currentRepoUrl },
+        error: null,
+      }),
+    ),
+  };
+  return builder;
+}
+
+const mockChannel = vi.fn().mockReturnValue({
+  on: vi.fn().mockReturnThis(),
+  subscribe: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+});
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: { id: "user-1" } },
+        error: null,
+      }),
+    },
+    from: (table: string) => {
+      if (table === "conversations") return buildConversationsBuilder();
+      if (table === "messages") return buildMessagesBuilder();
+      if (table === "users") return buildUsersBuilder();
+      return buildConversationsBuilder();
+    },
+    channel: mockChannel,
+    removeChannel: vi.fn(),
+  }),
+}));
+
+// --- Tests ------------------------------------------------------------------
+
+describe("useConversations — repo_url scoping", () => {
+  beforeEach(() => {
+    resetState();
+    mockChannel.mockClear();
+  });
+
+  it("returns ONLY the conversations matching the user's current repo_url", async () => {
+    state.currentRepoUrl = "https://github.com/acme/new";
+    state.conversationsByRepo = {
+      "https://github.com/acme/old": [
+        {
+          id: "conv-old",
+          user_id: "user-1",
+          repo_url: "https://github.com/acme/old",
+          domain_leader: null,
+          session_id: null,
+          status: "completed",
+          total_cost_usd: 0,
+          input_tokens: 0,
+          output_tokens: 0,
+          last_active: new Date(Date.now() - 10_000).toISOString(),
+          created_at: new Date(Date.now() - 20_000).toISOString(),
+          archived_at: null,
+        },
+      ],
+      "https://github.com/acme/new": [
+        {
+          id: "conv-new",
+          user_id: "user-1",
+          repo_url: "https://github.com/acme/new",
+          domain_leader: null,
+          session_id: null,
+          status: "active",
+          total_cost_usd: 0,
+          input_tokens: 0,
+          output_tokens: 0,
+          last_active: new Date(Date.now() - 1_000).toISOString(),
+          created_at: new Date(Date.now() - 2_000).toISOString(),
+          archived_at: null,
+        },
+      ],
+    };
+
+    const { useConversations } = await import("@/hooks/use-conversations");
+    const { result } = renderHook(() => useConversations());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Pin exact post-state per cq-mutation-assertions-pin-exact-post-state.
+    expect(result.current.conversations.length).toBe(1);
+    expect(result.current.conversations[0]?.id).toBe("conv-new");
+
+    // The list query MUST have an .eq("repo_url", current) predicate —
+    // this is the load-bearing claim of the plan.
+    const repoEq = state.capturedEq.find(([c]) => c === "repo_url");
+    expect(repoEq?.[1]).toBe("https://github.com/acme/new");
+  });
+
+  it("returns an empty list when the user's repo_url is null (disconnected)", async () => {
+    state.currentRepoUrl = null;
+    state.conversationsByRepo = {
+      "https://github.com/acme/old": [
+        {
+          id: "conv-orphan",
+          user_id: "user-1",
+          repo_url: "https://github.com/acme/old",
+          domain_leader: null,
+          session_id: null,
+          status: "completed",
+          total_cost_usd: 0,
+          input_tokens: 0,
+          output_tokens: 0,
+          last_active: new Date(Date.now() - 10_000).toISOString(),
+          created_at: new Date(Date.now() - 20_000).toISOString(),
+          archived_at: null,
+        },
+      ],
+    };
+
+    const { useConversations } = await import("@/hooks/use-conversations");
+    const { result } = renderHook(() => useConversations());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.conversations.length).toBe(0);
+  });
+
+  it("refetches and re-scopes when users.repo_url changes in another tab (race R-C)", async () => {
+    state.currentRepoUrl = "https://github.com/acme/first";
+    state.conversationsByRepo = {
+      "https://github.com/acme/first": [
+        {
+          id: "conv-first",
+          user_id: "user-1",
+          repo_url: "https://github.com/acme/first",
+          domain_leader: null,
+          session_id: null,
+          status: "active",
+          total_cost_usd: 0,
+          input_tokens: 0,
+          output_tokens: 0,
+          last_active: new Date().toISOString(),
+          created_at: new Date(Date.now() - 2_000).toISOString(),
+          archived_at: null,
+        },
+      ],
+      "https://github.com/acme/second": [
+        {
+          id: "conv-second",
+          user_id: "user-1",
+          repo_url: "https://github.com/acme/second",
+          domain_leader: null,
+          session_id: null,
+          status: "active",
+          total_cost_usd: 0,
+          input_tokens: 0,
+          output_tokens: 0,
+          last_active: new Date().toISOString(),
+          created_at: new Date().toISOString(),
+          archived_at: null,
+        },
+      ],
+    };
+
+    // Capture the users-channel UPDATE callback so the test can fire it.
+    let usersCallback:
+      | ((payload: { new: { repo_url: string | null } }) => void)
+      | null = null;
+
+    mockChannel.mockImplementation((name: string) => {
+      const ch: Record<string, unknown> = {
+        on: vi.fn((event: string, cfg: { table: string }, cb: unknown) => {
+          if (cfg.table === "users") {
+            usersCallback = cb as (p: {
+              new: { repo_url: string | null };
+            }) => void;
+          }
+          return ch;
+        }),
+        subscribe: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+      };
+      return ch;
+    });
+
+    const { useConversations } = await import("@/hooks/use-conversations");
+    const { result } = renderHook(() => useConversations());
+
+    await waitFor(() => {
+      expect(result.current.conversations[0]?.id).toBe("conv-first");
+    });
+
+    // Another tab switched repos: users.repo_url changed.
+    state.currentRepoUrl = "https://github.com/acme/second";
+
+    await act(async () => {
+      usersCallback?.({ new: { repo_url: "https://github.com/acme/second" } });
+    });
+
+    await waitFor(() => {
+      expect(result.current.conversations[0]?.id).toBe("conv-second");
+    });
+  });
+});

--- a/apps/web-platform/test/command-center.test.tsx
+++ b/apps/web-platform/test/command-center.test.tsx
@@ -94,8 +94,8 @@ const mockOn = vi.fn().mockReturnValue({ subscribe: mockSubscribe });
 const mockChannel = vi.fn().mockReturnValue({ on: mockOn });
 
 // Supabase query builder mock — must be thenable like the real client
-function createQueryBuilder(data: unknown[]) {
-  const result = { data, error: null };
+function createQueryBuilder(data: unknown[], singleRow: unknown = null) {
+  const result = { data, error: null, count: data.length };
   const builder = {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
@@ -104,7 +104,8 @@ function createQueryBuilder(data: unknown[]) {
     not: vi.fn().mockReturnThis(),
     order: vi.fn().mockReturnThis(),
     limit: vi.fn().mockReturnThis(),
-    single: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: singleRow, error: null }),
+    maybeSingle: vi.fn().mockResolvedValue({ data: singleRow, error: null }),
     update: vi.fn().mockReturnThis(),
     then: (onfulfilled: (value: unknown) => unknown) =>
       Promise.resolve(result).then(onfulfilled),
@@ -114,6 +115,9 @@ function createQueryBuilder(data: unknown[]) {
 
 let conversationBuilder: ReturnType<typeof createQueryBuilder>;
 let messageBuilder: ReturnType<typeof createQueryBuilder>;
+// Default: simulate a connected repo so the new repo_url scoping + the
+// dashboard disconnected-hint effect both short-circuit sensibly.
+const DEFAULT_USERS_ROW = { repo_url: "https://github.com/acme/repo" };
 
 vi.mock("@/lib/supabase/client", () => ({
   createClient: () => ({
@@ -126,6 +130,7 @@ vi.mock("@/lib/supabase/client", () => ({
     from: (table: string) => {
       if (table === "conversations") return conversationBuilder;
       if (table === "messages") return messageBuilder;
+      if (table === "users") return createQueryBuilder([], DEFAULT_USERS_ROW);
       return createQueryBuilder([]);
     },
     channel: mockChannel,

--- a/apps/web-platform/test/conversations-tools.test.ts
+++ b/apps/web-platform/test/conversations-tools.test.ts
@@ -18,12 +18,29 @@ import { describe, test, expect, vi, beforeEach } from "vitest";
 //   userId captured in closure: two builders with different userIds must
 //   invoke the helper with their respective userIds (no cross-contamination).
 
-const { mockLookup } = vi.hoisted(() => ({
+const { mockLookup, mockUserRepoUrl } = vi.hoisted(() => ({
   mockLookup: vi.fn(),
+  mockUserRepoUrl: vi.fn(() => "https://github.com/acme/repo" as string | null),
 }));
 
 vi.mock("@/server/lookup-conversation-for-path", () => ({
   lookupConversationForPath: (...args: unknown[]) => mockLookup(...args),
+}));
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: () => ({
+    from: (_table: string) => {
+      const chain = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        maybeSingle: vi.fn(async () => ({
+          data: { repo_url: mockUserRepoUrl() },
+          error: null,
+        })),
+      };
+      return chain;
+    },
+  }),
 }));
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
@@ -148,11 +165,13 @@ describe("buildConversationsTools", () => {
       1,
       "user-a",
       "knowledge-base/x.md",
+      "https://github.com/acme/repo",
     );
     expect(mockLookup).toHaveBeenNthCalledWith(
       2,
       "user-b",
       "knowledge-base/x.md",
+      "https://github.com/acme/repo",
     );
   });
 

--- a/apps/web-platform/test/conversations-tools.test.ts
+++ b/apps/web-platform/test/conversations-tools.test.ts
@@ -27,20 +27,11 @@ vi.mock("@/server/lookup-conversation-for-path", () => ({
   lookupConversationForPath: (...args: unknown[]) => mockLookup(...args),
 }));
 
-vi.mock("@/lib/supabase/service", () => ({
-  createServiceClient: () => ({
-    from: (_table: string) => {
-      const chain = {
-        select: vi.fn(() => chain),
-        eq: vi.fn(() => chain),
-        maybeSingle: vi.fn(async () => ({
-          data: { repo_url: mockUserRepoUrl() },
-          error: null,
-        })),
-      };
-      return chain;
-    },
-  }),
+vi.mock("@/server/current-repo-url", () => ({
+  getCurrentRepoUrl: (...args: unknown[]) => {
+    void args;
+    return Promise.resolve(mockUserRepoUrl());
+  },
 }));
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({

--- a/apps/web-platform/test/disconnect-hides-conversations.test.ts
+++ b/apps/web-platform/test/disconnect-hides-conversations.test.ts
@@ -1,0 +1,140 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// RED phase for plan 2026-04-22-fix-command-center-stale-conversations-after-repo-swap
+// Phase 4.2.
+//
+// Contract:
+//   After a user disconnects their repo (users.repo_url = null), any call
+//   through the KB-chat resume path MUST return "no row" — no stale pre-
+//   disconnect conversation may be returned. This guards the exact failure
+//   mode the bug reproduces: opening overview/vision.md in a freshly-
+//   connected repo accidentally resumes the la-chatte thread.
+
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/server/observability", () => ({
+  reportSilentFallback: vi.fn(),
+  warnSilentFallback: vi.fn(),
+}));
+
+function mockDb(stored: {
+  repo_url: string;
+  row: {
+    id: string;
+    context_path: string;
+    last_active: string;
+    messages: Array<{ count: number }>;
+  };
+}) {
+  // Emulates: only rows whose repo_url matches the .eq("repo_url", ...)
+  // predicate pass through. Any other predicate short-circuits to miss.
+  const chain: Record<string, unknown> = {};
+  const predicates: Array<[string, unknown]> = [];
+
+  Object.assign(chain, {
+    select: vi.fn(() => chain),
+    eq: vi.fn((col: string, val: unknown) => {
+      predicates.push([col, val]);
+      return chain;
+    }),
+    is: vi.fn(() => chain),
+    order: vi.fn(() => chain),
+    limit: vi.fn(() => chain),
+    maybeSingle: vi.fn(async () => {
+      const repoPred = predicates.find(([c]) => c === "repo_url");
+      // Without a repo_url predicate, the pre-fix code would return the
+      // orphaned row — reproducing the bug. We represent that by returning
+      // the stored row when no repo_url filter was applied.
+      if (!repoPred) {
+        return { data: stored.row, error: null };
+      }
+      if (repoPred[1] === stored.repo_url) {
+        return { data: stored.row, error: null };
+      }
+      return { data: null, error: null };
+    }),
+  });
+  mockFrom.mockImplementation(() => chain);
+  return { predicates };
+}
+
+describe("lookupConversationForPath — disconnect hides conversations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("null repoUrl (disconnected) returns no row even if a matching path exists", async () => {
+    mockDb({
+      repo_url: "https://github.com/acme/la-chatte",
+      row: {
+        id: "conv-la-chatte-vision",
+        context_path: "overview/vision.md",
+        last_active: "2026-04-17T00:00:00Z",
+        messages: [{ count: 5 }],
+      },
+    });
+
+    const { lookupConversationForPath } = await import(
+      "@/server/lookup-conversation-for-path"
+    );
+    const result = await lookupConversationForPath(
+      "u1",
+      "overview/vision.md",
+      null,
+    );
+
+    expect(result).toEqual({ ok: true, row: null });
+  });
+
+  test("reconnecting to a DIFFERENT repo does not resume the disconnected repo's thread", async () => {
+    mockDb({
+      repo_url: "https://github.com/acme/la-chatte",
+      row: {
+        id: "conv-la-chatte-vision",
+        context_path: "overview/vision.md",
+        last_active: "2026-04-17T00:00:00Z",
+        messages: [{ count: 5 }],
+      },
+    });
+
+    const { lookupConversationForPath } = await import(
+      "@/server/lookup-conversation-for-path"
+    );
+    const result = await lookupConversationForPath(
+      "u1",
+      "overview/vision.md",
+      "https://github.com/acme/au-chat-chat",
+    );
+
+    expect(result).toEqual({ ok: true, row: null });
+  });
+
+  test("reconnecting to the SAME repo restores the original thread", async () => {
+    mockDb({
+      repo_url: "https://github.com/acme/la-chatte",
+      row: {
+        id: "conv-la-chatte-vision",
+        context_path: "overview/vision.md",
+        last_active: "2026-04-17T00:00:00Z",
+        messages: [{ count: 5 }],
+      },
+    });
+
+    const { lookupConversationForPath } = await import(
+      "@/server/lookup-conversation-for-path"
+    );
+    const result = await lookupConversationForPath(
+      "u1",
+      "overview/vision.md",
+      "https://github.com/acme/la-chatte",
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.row?.id).toBe("conv-la-chatte-vision");
+  });
+});

--- a/apps/web-platform/test/lookup-conversation-for-path-repo-scope.test.ts
+++ b/apps/web-platform/test/lookup-conversation-for-path-repo-scope.test.ts
@@ -72,18 +72,47 @@ describe("lookupConversationForPath — repo_url scoping", () => {
     expect(repoEq?.[1]).toBe("https://github.com/acme/new");
   });
 
-  test("returns the current-repo row when two rows share (user_id, context_path)", async () => {
-    // The mocked chain only returns what Supabase would return AFTER
-    // filtering by all .eq() predicates — here it's the new-repo row.
-    mockSingleChain({
-      data: {
+  test("returns ONLY the current-repo row when two rows share (user_id, context_path)", async () => {
+    // Predicate-aware mock: simulate two rows keyed by repo_url. Only
+    // the row whose stored repo_url matches the .eq("repo_url", ...)
+    // predicate may be returned — if the helper omits the predicate,
+    // the mock returns the OLD row and the assertion fails.
+    const storedByRepo: Record<string, Record<string, unknown>> = {
+      "https://github.com/acme/old": {
+        id: "conv-old-repo",
+        context_path: "overview/vision.md",
+        last_active: "2026-04-17T00:00:00Z",
+        messages: [{ count: 5 }],
+      },
+      "https://github.com/acme/new": {
         id: "conv-new-repo",
         context_path: "overview/vision.md",
         last_active: "2026-04-22T00:00:00Z",
         messages: [{ count: 1 }],
       },
-      error: null,
+    };
+    const predicates: Array<[string, unknown]> = [];
+    const chain: Record<string, unknown> = {};
+    Object.assign(chain, {
+      select: vi.fn(() => chain),
+      eq: vi.fn((col: string, val: unknown) => {
+        predicates.push([col, val]);
+        return chain;
+      }),
+      is: vi.fn(() => chain),
+      order: vi.fn(() => chain),
+      limit: vi.fn(() => chain),
+      maybeSingle: vi.fn(async () => {
+        const repoPred = predicates.find(([c]) => c === "repo_url");
+        if (!repoPred) {
+          // Helper omitted the repo_url predicate — return the OLD row
+          // so the test catches the regression.
+          return { data: storedByRepo["https://github.com/acme/old"], error: null };
+        }
+        return { data: storedByRepo[String(repoPred[1])] ?? null, error: null };
+      }),
     });
+    mockFrom.mockImplementation(() => chain);
 
     const { lookupConversationForPath } = await importHelper();
     const result = await lookupConversationForPath(

--- a/apps/web-platform/test/lookup-conversation-for-path-repo-scope.test.ts
+++ b/apps/web-platform/test/lookup-conversation-for-path-repo-scope.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// RED phase for plan 2026-04-22-fix-command-center-stale-conversations-after-repo-swap.
+//
+// Contract:
+//   lookupConversationForPath accepts a third `repoUrl` argument and adds
+//   .eq("repo_url", repoUrl) to the query. When repoUrl is null/empty the
+//   helper short-circuits to { ok: true, row: null } without issuing a query
+//   (no connected repo means no resumable thread).
+
+const { mockFrom, mockReportSilentFallback } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockReportSilentFallback: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/service", () => ({
+  createServiceClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/server/observability", () => ({
+  reportSilentFallback: mockReportSilentFallback,
+  warnSilentFallback: vi.fn(),
+}));
+
+async function importHelper() {
+  return await import("@/server/lookup-conversation-for-path");
+}
+
+function mockSingleChain(result: { data: unknown; error: unknown }) {
+  const calls = { eq: [] as Array<[string, unknown]> };
+  const chain = {
+    select: vi.fn(() => chain),
+    eq: vi.fn((col: string, val: unknown) => {
+      calls.eq.push([col, val]);
+      return chain;
+    }),
+    is: vi.fn(() => chain),
+    order: vi.fn(() => chain),
+    limit: vi.fn(() => chain),
+    maybeSingle: vi.fn(async () => result),
+  };
+  mockFrom.mockImplementation(() => chain);
+  return { chain, calls };
+}
+
+describe("lookupConversationForPath — repo_url scoping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("adds .eq('repo_url', repoUrl) to the query", async () => {
+    const { calls } = mockSingleChain({
+      data: {
+        id: "conv-new",
+        context_path: "overview/vision.md",
+        last_active: "2026-04-22T00:00:00Z",
+        messages: [{ count: 1 }],
+      },
+      error: null,
+    });
+
+    const { lookupConversationForPath } = await importHelper();
+    await lookupConversationForPath(
+      "u1",
+      "overview/vision.md",
+      "https://github.com/acme/new",
+    );
+
+    // Exact post-state pin per cq-mutation-assertions-pin-exact-post-state.
+    const repoEq = calls.eq.find(([col]) => col === "repo_url");
+    expect(repoEq).toBeDefined();
+    expect(repoEq?.[1]).toBe("https://github.com/acme/new");
+  });
+
+  test("returns the current-repo row when two rows share (user_id, context_path)", async () => {
+    // The mocked chain only returns what Supabase would return AFTER
+    // filtering by all .eq() predicates — here it's the new-repo row.
+    mockSingleChain({
+      data: {
+        id: "conv-new-repo",
+        context_path: "overview/vision.md",
+        last_active: "2026-04-22T00:00:00Z",
+        messages: [{ count: 1 }],
+      },
+      error: null,
+    });
+
+    const { lookupConversationForPath } = await importHelper();
+    const result = await lookupConversationForPath(
+      "u1",
+      "overview/vision.md",
+      "https://github.com/acme/new",
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.row?.id).toBe("conv-new-repo");
+  });
+
+  test("null repoUrl short-circuits to { ok: true, row: null } without querying", async () => {
+    mockSingleChain({ data: null, error: null });
+
+    const { lookupConversationForPath } = await importHelper();
+    const result = await lookupConversationForPath(
+      "u1",
+      "overview/vision.md",
+      null,
+    );
+
+    expect(result).toEqual({ ok: true, row: null });
+    // No connected repo → no Supabase round-trip at all.
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  test("empty-string repoUrl short-circuits to { ok: true, row: null } without querying", async () => {
+    mockSingleChain({ data: null, error: null });
+
+    const { lookupConversationForPath } = await importHelper();
+    const result = await lookupConversationForPath(
+      "u1",
+      "overview/vision.md",
+      "",
+    );
+
+    expect(result).toEqual({ ok: true, row: null });
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-platform/test/lookup-conversation-for-path.test.ts
+++ b/apps/web-platform/test/lookup-conversation-for-path.test.ts
@@ -70,7 +70,7 @@ describe("lookupConversationForPath — single-query collapse (#2511)", () => {
     });
 
     const { lookupConversationForPath } = await importHelper();
-    const result = await lookupConversationForPath("u1", "knowledge-base/x.md");
+    const result = await lookupConversationForPath("u1", "knowledge-base/x.md", "https://github.com/acme/repo");
 
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("unreachable");
@@ -93,7 +93,7 @@ describe("lookupConversationForPath — single-query collapse (#2511)", () => {
     });
 
     const { lookupConversationForPath } = await importHelper();
-    await lookupConversationForPath("u1", "knowledge-base/x.md");
+    await lookupConversationForPath("u1", "knowledge-base/x.md", "https://github.com/acme/repo");
 
     // `from("conversations")` must be called exactly once — the removed
     // second `from("messages")` call MUST NOT exist.
@@ -113,7 +113,7 @@ describe("lookupConversationForPath — single-query collapse (#2511)", () => {
     });
 
     const { lookupConversationForPath } = await importHelper();
-    await lookupConversationForPath("u1", "knowledge-base/x.md");
+    await lookupConversationForPath("u1", "knowledge-base/x.md", "https://github.com/acme/repo");
 
     // The embed syntax is the load-bearing claim of #2511. Regex-assert it.
     expect(calls.select).toHaveLength(1);
@@ -132,7 +132,7 @@ describe("lookupConversationForPath — single-query collapse (#2511)", () => {
     });
 
     const { lookupConversationForPath } = await importHelper();
-    const result = await lookupConversationForPath("u1", "knowledge-base/x.md");
+    const result = await lookupConversationForPath("u1", "knowledge-base/x.md", "https://github.com/acme/repo");
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("unreachable");
     // .toBe(0) — not .toBeFalsy(), not .toContain. Rule pin.
@@ -151,7 +151,7 @@ describe("lookupConversationForPath — single-query collapse (#2511)", () => {
     });
 
     const { lookupConversationForPath } = await importHelper();
-    const result = await lookupConversationForPath("u1", "knowledge-base/x.md");
+    const result = await lookupConversationForPath("u1", "knowledge-base/x.md", "https://github.com/acme/repo");
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("unreachable");
     expect(result.row?.message_count).toBe(0);
@@ -161,7 +161,7 @@ describe("lookupConversationForPath — single-query collapse (#2511)", () => {
     mockSingleChain({ data: null, error: null });
 
     const { lookupConversationForPath } = await importHelper();
-    const result = await lookupConversationForPath("u1", "knowledge-base/x.md");
+    const result = await lookupConversationForPath("u1", "knowledge-base/x.md", "https://github.com/acme/repo");
     expect(result).toEqual({ ok: true, row: null });
     expect(mockFrom).toHaveBeenCalledTimes(1);
   });
@@ -171,7 +171,7 @@ describe("lookupConversationForPath — single-query collapse (#2511)", () => {
     mockSingleChain({ data: null, error: err });
 
     const { lookupConversationForPath } = await importHelper();
-    const result = await lookupConversationForPath("u1", "knowledge-base/x.md");
+    const result = await lookupConversationForPath("u1", "knowledge-base/x.md", "https://github.com/acme/repo");
     expect(result).toEqual({ ok: false, error: "lookup_failed" });
     expect(mockReportSilentFallback).toHaveBeenCalledTimes(1);
     const [errArg, optsArg] = mockReportSilentFallback.mock.calls[0];

--- a/apps/web-platform/test/start-fresh-onboarding.test.tsx
+++ b/apps/web-platform/test/start-fresh-onboarding.test.tsx
@@ -15,16 +15,18 @@ vi.mock("@/hooks/use-team-names", () => ({
 }));
 
 // Supabase query builder mock (thenable, matches existing pattern)
-function createQueryBuilder(data: unknown[]) {
-  const result = { data, error: null };
+function createQueryBuilder(data: unknown[], singleRow: unknown = null) {
+  const result = { data, error: null, count: data.length };
   const builder = {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
     in: vi.fn().mockReturnThis(),
     is: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
     order: vi.fn().mockReturnThis(),
     limit: vi.fn().mockReturnThis(),
-    single: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: singleRow, error: null }),
+    maybeSingle: vi.fn().mockResolvedValue({ data: singleRow, error: null }),
     update: vi.fn().mockReturnThis(),
     then: (onfulfilled: (value: unknown) => unknown) =>
       Promise.resolve(result).then(onfulfilled),
@@ -112,9 +114,10 @@ beforeEach(() => {
   mockChannel.mockClear();
   conversationBuilder = createQueryBuilder([]);
   messageBuilder = createQueryBuilder([]);
-  userBuilder = createQueryBuilder([
-    { onboarding_completed_at: null, pwa_banner_dismissed_at: null },
-  ]);
+  userBuilder = createQueryBuilder(
+    [{ onboarding_completed_at: null, pwa_banner_dismissed_at: null }],
+    { repo_url: "https://github.com/acme/repo" },
+  );
   fetchMock = vi.fn();
   globalThis.fetch = fetchMock;
 });

--- a/apps/web-platform/test/update-status.test.tsx
+++ b/apps/web-platform/test/update-status.test.tsx
@@ -10,16 +10,22 @@ const mockChannel = vi.fn().mockReturnValue({ on: mockOn });
 // Track update calls
 const mockUpdate = vi.fn();
 
-function createQueryBuilder(data: unknown[], error: { message: string } | null = null) {
+function createQueryBuilder(
+  data: unknown[],
+  error: { message: string } | null = null,
+  singleRow: unknown = null,
+) {
   const result = { data, error };
   const builder = {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
     in: vi.fn().mockReturnThis(),
     is: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
     order: vi.fn().mockReturnThis(),
     limit: vi.fn().mockReturnThis(),
-    single: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: singleRow, error: null }),
+    maybeSingle: vi.fn().mockResolvedValue({ data: singleRow, error: null }),
     update: vi.fn((...args: unknown[]) => {
       mockUpdate(...args);
       return builder;
@@ -77,6 +83,10 @@ vi.mock("@/lib/supabase/client", () => ({
         return builder;
       }
       if (table === "messages") return messageBuilder;
+      if (table === "users")
+        return createQueryBuilder([], null, {
+          repo_url: "https://github.com/acme/repo",
+        });
       return createQueryBuilder([]);
     },
     channel: mockChannel,

--- a/apps/web-platform/test/ws-deferred-creation.test.ts
+++ b/apps/web-platform/test/ws-deferred-creation.test.ts
@@ -12,17 +12,32 @@ const mockSelectSingle = vi.fn().mockResolvedValue({
 
 vi.mock("@/lib/supabase/service", () => ({
   createServiceClient: () => ({
-    from: () => ({
-      insert: mockInsert,
-      update: mockUpdate,
-      select: vi.fn().mockReturnValue({
-        eq: vi.fn().mockReturnValue({
+    from: (table: string) => {
+      if (table === "users") {
+        // `users` reads go through .select().eq().maybeSingle() to fetch
+        // repo_url so conversation inserts can be scoped to the current repo.
+        const chain = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: { repo_url: "https://github.com/acme/repo" },
+            error: null,
+          }),
+        };
+        return chain;
+      }
+      return {
+        insert: mockInsert,
+        update: mockUpdate,
+        select: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
-            single: mockSelectSingle,
+            eq: vi.fn().mockReturnValue({
+              single: mockSelectSingle,
+            }),
           }),
         }),
-      }),
-    }),
+      };
+    },
     auth: {
       getUser: vi.fn().mockResolvedValue({
         data: { user: { id: "user-1" } },

--- a/apps/web-platform/test/ws-deferred-creation.test.ts
+++ b/apps/web-platform/test/ws-deferred-creation.test.ts
@@ -9,6 +9,9 @@ const mockSelectSingle = vi.fn().mockResolvedValue({
   data: { id: "conv-1", status: "active" },
   error: null,
 });
+// Lazy-evaluated `users.repo_url` lets individual tests simulate a
+// disconnected user (repo_url=null) to exercise the abort path.
+let mockUserRepoUrl: string | null = "https://github.com/acme/repo";
 
 vi.mock("@/lib/supabase/service", () => ({
   createServiceClient: () => ({
@@ -16,13 +19,15 @@ vi.mock("@/lib/supabase/service", () => ({
       if (table === "users") {
         // `users` reads go through .select().eq().maybeSingle() to fetch
         // repo_url so conversation inserts can be scoped to the current repo.
+        // Return shape is evaluated at call time so individual tests can
+        // simulate the disconnected state via `mockUserRepoUrl = null`.
         const chain = {
           select: vi.fn(() => chain),
           eq: vi.fn(() => chain),
-          maybeSingle: vi.fn().mockResolvedValue({
-            data: { repo_url: "https://github.com/acme/repo" },
+          maybeSingle: vi.fn(async () => ({
+            data: { repo_url: mockUserRepoUrl },
             error: null,
-          }),
+          })),
         };
         return chain;
       }
@@ -102,6 +107,7 @@ describe("deferred conversation creation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sessions.clear();
+    mockUserRepoUrl = "https://github.com/acme/repo";
   });
 
   it("start_session does not insert a conversation row", async () => {
@@ -163,6 +169,33 @@ describe("deferred conversation creation", () => {
     const errorMsg = sent.find((m: any) => m.type === "error") as any;
     expect(errorMsg).toBeTruthy();
     expect(errorMsg.message).toContain("@-mention");
+  });
+
+  it("chat after disconnect (users.repo_url=null) aborts without inserting", async () => {
+    // Plan risk R-D: user disconnects between start_session and their
+    // first real chat message. createConversation must abort rather than
+    // orphan a row stamped with a stale repo_url (or no repo_url at all).
+    const { session, sent } = createMockSession();
+    sessions.set("user-1", session);
+
+    // Connected for start_session; disconnected before the chat arrives.
+    mockUserRepoUrl = "https://github.com/acme/repo";
+    await handleMessage("user-1", JSON.stringify({ type: "start_session" }));
+
+    mockUserRepoUrl = null;
+    await handleMessage(
+      "user-1",
+      JSON.stringify({ type: "chat", content: "First message" }),
+    );
+
+    // No conversation row inserted.
+    expect(mockInsert).not.toHaveBeenCalled();
+    // An error was surfaced to the client.
+    const errorMsg = sent.find((m: any) => m.type === "error") as any;
+    expect(errorMsg).toBeTruthy();
+    // Pending state retained so a reconnect could retry (or the client
+    // can close cleanly).
+    expect(session.conversationId).toBeUndefined();
   });
 
   it("close_conversation with pending state cleans up without DB update", async () => {

--- a/apps/web-platform/test/ws-resume-by-context-path.test.ts
+++ b/apps/web-platform/test/ws-resume-by-context-path.test.ts
@@ -26,20 +26,32 @@ vi.mock("@/lib/supabase/service", () => ({
       return {
         insert: mockInsert,
         update: mockUpdate,
-        select: () => ({
-          eq: () => ({
-            eq: () => ({
-              is: () => ({
-                order: () => ({
-                  limit: () => ({
-                    maybeSingle: mockMaybeSingle,
-                  }),
+        select: () => {
+          // Recursive eq() chain so any length of predicates terminates at
+          // is().order().limit().maybeSingle(). The ws-handler lookup now
+          // uses 3 .eq() calls (user_id, repo_url, context_path).
+          const tail = {
+            is: () => ({
+              order: () => ({
+                limit: () => ({
+                  maybeSingle: mockMaybeSingle,
                 }),
               }),
             }),
-            single: vi.fn().mockResolvedValue({ data: { id: "conv-1", status: "active" }, error: null }),
-          }),
-        }),
+          };
+          const eqChain: Record<string, unknown> = {
+            eq: (...args: unknown[]) => {
+              void args;
+              return eqChain;
+            },
+            single: vi.fn().mockResolvedValue({
+              data: { id: "conv-1", status: "active", repo_url: mockUserRepoUrl },
+              error: null,
+            }),
+            ...tail,
+          };
+          return eqChain;
+        },
       };
     },
     auth: {
@@ -72,6 +84,14 @@ vi.mock("./rate-limiter", () => ({
 }));
 vi.mock("./context-validation", () => ({
   validateConversationContext: (ctx: unknown) => ctx,
+}));
+
+// getCurrentRepoUrl is read before the context_path lookup so the query
+// can scope by (user_id, repo_url, context_path). Tests default to a
+// connected repo; null simulates the disconnected state.
+let mockUserRepoUrl: string | null = "https://github.com/acme/repo";
+vi.mock("@/server/current-repo-url", () => ({
+  getCurrentRepoUrl: () => Promise.resolve(mockUserRepoUrl),
 }));
 
 import { handleMessage, sessions, type ClientSession } from "@/server/ws-handler";

--- a/knowledge-base/project/learnings/2026-04-22-scope-by-new-column-audit-every-query-not-just-the-helper.md
+++ b/knowledge-base/project/learnings/2026-04-22-scope-by-new-column-audit-every-query-not-just-the-helper.md
@@ -1,0 +1,181 @@
+---
+title: When Scoping by a New Column, Audit Every Query — Not Just the Helper
+date: 2026-04-22
+category: integration-issues
+tags:
+  - multi-tenant-scoping
+  - plan-gap
+  - code-review
+  - websocket-handler
+  - supabase
+  - repo-scoping
+  - test-mock-drift
+module: apps/web-platform/server
+problem_type: logic_error
+component: supabase_query
+severity: high
+symptoms:
+  - "Command Center lists conversations from previously-connected repo after disconnect/reconnect"
+  - "KB-path chat resume picks up thread from prior repo when same context_path exists in both"
+  - "WS cached conversationId resumes across repo swap"
+root_cause: missing_scope_column
+synced_to: [plan]
+---
+
+# Learning: When Scoping by a New Column, Audit Every Query — Not Just the Helper
+
+## Problem
+
+PR #2766 added `conversations.repo_url` scoping to fix a user-reported bug:
+after disconnecting repo `la-chatte` and connecting a new repo `au-chat-chat`,
+the Command Center still showed every conversation from `la-chatte`. The plan
+correctly identified the data-scoping gap and prescribed:
+
+- Add `repo_url` column to `conversations`.
+- Scope `hooks/use-conversations.ts` list query by `repo_url`.
+- Accept a `repoUrl` arg in `lookupConversationForPath` + short-circuit on null.
+- Thread `repoUrl` through 3 callers of that helper.
+- Stamp `repo_url` on 2 INSERT sites.
+
+The work-phase implementation followed the plan verbatim and all 2172 tests
+passed. Green CI, clean `tsc`, test file per acceptance criterion.
+
+**Multi-agent review then found two P1 plan gaps the plan author missed and
+no test caught:**
+
+1. **`start_session` inline resume-by-context_path lookup was unscoped.** The
+   handler at `server/ws-handler.ts:426-435` runs a direct Supabase query
+   against `conversations` (user_id + context_path + archived_at) BEFORE
+   reaching the `lookupConversationForPath` helper. The plan scoped the
+   helper and the 23505 fallback — it missed this third sibling query. A
+   user opening `overview/vision.md` in the new repo would silently resume
+   the la-chatte thread via this path.
+
+2. **`resume_session` lookup verified only `id` + `user_id`, not `repo_url`.**
+   A client holding a cached conversationId from the prior repo (browser
+   history, deep link, agent-memory of a prior `conversations_lookup` call,
+   mobile client) could resume across a repo swap. The Command Center hid
+   these ids, the MCP tool refused to surface them, but this WS path was
+   a backdoor.
+
+Both bugs would have shipped to production with green CI if multi-agent
+review hadn't caught them.
+
+## Solution
+
+Fixed both paths in a single review-response commit:
+
+1. Extracted `getCurrentRepoUrl(userId)` helper (`server/current-repo-url.ts`)
+   that reads `users.repo_url` with `reportSilentFallback` on DB error
+   (rule `cq-silent-fallback-must-mirror-to-sentry`).
+2. `start_session` reads `currentRepoUrl` once, short-circuits resume when
+   disconnected (falls through to deferred creation — which aborts when
+   still null), and adds `.eq("repo_url", currentRepoUrl)` to the inline
+   lookup.
+3. `resume_session` reads `currentRepoUrl`, SELECTs `conv.repo_url`
+   alongside `id, status`, and rejects with "Conversation not found" when
+   `conv.repo_url !== currentRepoUrl` — indistinguishable response from
+   a genuine miss to avoid existence-probe leakage.
+4. Collapsed 4 duplicated inline `users.repo_url` reads into the helper.
+5. Migration 029: added `COMMENT ON COLUMN` documenting coupling with
+   `users.repo_url`; added `archived_at` marker on pre-migration rows
+   whose user is currently disconnected so they remain discoverable via
+   the Archived filter.
+6. Test infra: rewrote `lookup-conversation-for-path-repo-scope.test.ts`
+   test 2 with a predicate-aware mock (was tautologically passing — fixed
+   return regardless of `.eq("repo_url", ...)`). Added RED test for the
+   `createConversation` disconnect-abort path.
+
+## Key Insight
+
+**When a plan prescribes scoping a helper function, grep the codebase for
+every other inline query that references the same table + columns before
+implementing.** Plan authors think in helpers; codebases have sibling
+inline queries. The helper-based scoping checklist is necessary but
+insufficient — any query that bypasses the helper (for performance, for
+historical reasons, or because the helper didn't exist when it was
+written) becomes a silent backdoor.
+
+**Concrete checklist when scoping by a new column:**
+
+- `rg '\.from\("<table>"\)' --type ts` — every site, not just the helper.
+- For each hit, ask: does this query need the new scope column? If it
+  handles user-identifiable data (including by id), the answer is
+  usually yes — an id can be cached across scope changes.
+- `rg '\.eq\("id"' --type ts` scoped to the table — id-based lookups are
+  the most common backdoor.
+- Diff the set of sites against the set the plan prescribes. Every
+  unexplained delta needs either a scope addition or a written
+  justification.
+
+## Session Errors
+
+- **Added `users.repo_url` reads broke 4 existing test-file mocks** —
+  `createQueryBuilder` helpers in `command-center.test.tsx`,
+  `update-status.test.tsx`, `start-fresh-onboarding.test.tsx`,
+  `ws-deferred-creation.test.ts` lacked `.maybeSingle()` (my new code
+  called it on the `users` table). Recovery: added `maybeSingle` + a
+  `singleRow` param to each helper. **Prevention:** when adding a new
+  fluent-chain call (`.maybeSingle`, `.single`, `.rpc`) to production
+  code, `rg 'createQueryBuilder'` and verify each test mock supports
+  the new call before committing.
+
+- **`ws-resume-by-context-path.test.ts` broke with 3 failures** when I
+  added a 3rd `.eq()` predicate to the `start_session` inline query. The
+  existing mock used a fixed-depth chain (`eq().eq().is()`) that silently
+  dropped the new predicate. Recovery: rewrote the mock's eq chain as
+  recursive (`eq: () => chain`) and mocked `@/server/current-repo-url`
+  directly. **Prevention:** when writing Supabase test mocks, use
+  recursive `eq: () => chain` + `is: () => chain` instead of fixed-depth
+  chains. A test mock that only supports N predicates silently drops
+  predicate N+1 when production code adds one.
+
+- **Doubled path segment** — called Read on
+  `apps/web-platform/apps/web-platform/server/ws-handler.ts` when I was
+  already `cd`'d into `apps/web-platform`. Recovery: corrected the path
+  on next attempt. **Prevention:** prefer worktree-absolute paths rooted
+  at the worktree directory, not compound-prefixed ones — the Bash tool
+  doesn't persist CWD across calls so "current directory" reasoning is
+  unreliable.
+
+- **Plan gap: `start_session` inline resumeByContextPath lookup missed
+  repo_url scoping.** The plan correctly scoped `lookupConversationForPath`
+  and the 23505 fallback but missed this third inline query. Caught by
+  architecture + agent-native review. Recovery: added
+  `.eq("repo_url", currentRepoUrl)` and null-short-circuit. **Prevention:**
+  when a plan prescribes scoping a helper, `rg` the codebase for every
+  other inline query on the same table+columns that bypass the helper —
+  they need the same scoping change (see "Key Insight" above).
+
+- **Plan gap: `resume_session` lookup was unscoped by repo_url.** Only
+  verified `id` + `user_id`, allowing cached-id cross-repo resumption.
+  Caught by agent-native review. Recovery: added `repo_url` match check
+  with deliberately indistinguishable "not found" response. **Prevention:**
+  when adding tenant/scope columns, audit every id-based query — ids can
+  be cached across scope swaps and bypass new column filters (see
+  `cq-ref-removal-sweep-cleanup-closures` for the general "sweep all
+  usages" class).
+
+- **Tautologically-passing test in
+  `lookup-conversation-for-path-repo-scope.test.ts` test 2.** Used
+  `mockSingleChain({ data: fixedRow })` — mock returned the fixed row
+  regardless of `.eq("repo_url", ...)` predicate. Test passed even if
+  the helper omitted the new predicate entirely. Caught by test-design
+  review. Recovery: rewrote with predicate-aware mock
+  (`eq: () => { predicates.push([col, val]); return chain }` + data
+  filtered by captured predicate). **Prevention:** when a test claims
+  "the filter is applied", the mock MUST inspect `.eq()` predicates.
+  A mock that returns the same data regardless of input can only
+  verify non-filtering contracts — per AGENTS.md TDD Gate:
+  "distinguish gate-absent from gate-present".
+
+## Related Learnings
+
+- [`2026-04-15-multi-agent-review-catches-bugs-tests-miss.md`](2026-04-15-multi-agent-review-catches-bugs-tests-miss.md) — same class: parallel review catches defects invisible to green-CI test suites. This session confirms the pattern for plan-level gaps (not just code-level smells).
+- [`2026-04-10-multi-agent-review-catches-info-disclosure.md`](2026-04-10-multi-agent-review-catches-info-disclosure.md) — related agent-native gap class.
+- [`2026-04-17-kb-chat-stale-context-on-doc-switch.md`](2026-04-17-kb-chat-stale-context-on-doc-switch.md) — same data-scoping problem at the UI layer (unmount-on-key-change). The current fix lands at the data layer; both are complementary.
+
+## Tags
+
+category: integration-issues
+module: apps/web-platform/server

--- a/knowledge-base/project/plans/2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md
+++ b/knowledge-base/project/plans/2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md
@@ -1,0 +1,310 @@
+# fix: Command Center shows stale conversations after repo swap
+
+**Type:** bug fix
+**Severity:** P1 — data-scoping / UX correctness (not security: all leaked rows belong to the same user)
+**Branch:** `feat-one-shot-command-center-stale-conversations-after-repo-swap`
+**Date:** 2026-04-22
+
+## Enhancement Summary
+
+**Deepened on:** 2026-04-22
+**Sections enhanced:** Migration safety, Realtime semantics, Race conditions, Related learnings, RLS alignment
+**Research sources:** Supabase Realtime docs + GitHub issue #97 (realtime-js multi-column filter limitation), PostgreSQL UPDATE FROM performance guidance, multi-tenant SaaS scoping patterns, sibling migrations 025/027/028, prior learnings (`2026-03-28-unapplied-migration-command-center-chat-failure.md`, `2026-04-17-kb-chat-stale-context-on-doc-switch.md`).
+
+### Key Improvements
+
+1. **Realtime-filter claim validated** — confirmed via Supabase docs and upstream [realtime-js#97](https://github.com/supabase/realtime-js/issues/97) that the `filter:` clause accepts only one `=` predicate. Client-side drop on `repo_url` mismatch is the only option. Plan text made explicit.
+2. **UPDATE-FROM backfill sized against prod** — migration 028 comment fixes conversations at ~1k prod rows; UPDATE-FROM with PK join is sub-second, no batching needed. Plan risk section narrowed accordingly.
+3. **Two new race conditions flagged** — (a) user disconnects mid-insert: a WS handler inserts a conversation stamped with the just-cleared `repo_url`; plan now prescribes reading `users.repo_url` inside the same transaction as the INSERT, and the WS handler must abort with a "no connected repo" close code if `repo_url` is null at insert time. (b) user reconnects to a different URL while a conversation page is open: the page's hook still has the old `repoUrl` in closure; plan adds a `repo_url`-change-aware effect that refetches (or hard-reloads) when `users.repo_url` changes server-side.
+4. **RLS scope clarified** — current RLS on `conversations` is `auth.uid() = user_id` only. This plan does NOT tighten RLS to include `repo_url` because (a) all leaked rows belong to the same user — no cross-tenant security failure, (b) RLS would force service-role clients (ws-handler, agent-runner) to bypass RLS or re-select `users.repo_url` on every write, adding latency for no security gain. Recorded as a defensible Non-Goal with a 1-line rationale.
+5. **Retroactive-gate check applied** (per AGENTS.md `wg-when-fixing-a-workflow-gates-detection`) — the KB-chat-stale-context learning (2026-04-17) fixed the same class of bug at the UI layer (unmount-on-key-change). This PR fixes it at the data layer. Both are now needed; plan adds an explicit cross-reference so neither regresses.
+
+### New Considerations Discovered
+
+- **Supabase Realtime cannot express multi-column AND filters** — [realtime-js#97](https://github.com/supabase/realtime-js/issues/97) has been open since 2023 with no movement. Client-side drop is the permanent pattern.
+- **`UPDATE FROM` with a joined subquery is ~92% faster than correlated subqueries** ([Dupple, 2026](https://dupple.com/blog/postgresql-update-join)) and is the idiomatic choice for this backfill.
+- **AGENTS.md cq-supabase-migration-concurrently-forbidden pattern is already respected** by sibling migrations 025, 027, 028 — our plan inherits their rationale verbatim so the pattern stays consistent.
+- **Multi-tenant SaaS guidance prefers tenant-level (here: project/repo) scoping over user-level scoping** — the repo_url approach aligns with this, but the deferred `projects` table is the long-term correct model. The deferral issue (task 10.1) now includes a link to the WorkOS and Flightcontrol multi-tenant guides for the future design.
+
+## Overview
+
+On account `jean.deruelle@jikigai.com`, a user disconnected repo `la-chatte`, then created a new public repo `au-chat-chat` through the Connect Repo flow. After the new project provisioned, the Command Center still displayed every conversation from the `la-chatte` era (e.g. "Shall we bundle Fablab and coworking together as activities?", "Tell me about the file at overview/vision.md"), with no relation to the newly-connected `au-chat-chat` repo.
+
+**Root cause:** the `conversations` table has no repo / project scoping column. The Command Center query (`hooks/use-conversations.ts`) filters on `user_id` only. `DELETE /api/repo/disconnect` clears `users.repo_url` and deletes the workspace on disk, but leaves every `conversations` row untouched. When the user connects a different repo, the query continues to return the pre-disconnect rows.
+
+**Fix, at a high level:** stamp each conversation with the `repo_url` it was created against (new `conversations.repo_url` column), and filter the Command Center query to only return conversations whose `repo_url` matches the user's current `users.repo_url`. Apply the same filter to the KB context-path lookup (`lookupConversationForPath`) so a shared path like `overview/vision.md` in the new repo does not silently resume a thread from the old repo. Leave old rows in place (hidden, recoverable if the user reconnects the same URL) — destructive cascade-delete is out of scope.
+
+**Not fixed in this PR (deferred):** a first-class `projects` table with a repo→project 1:N model; retroactive UX that surfaces "orphaned" conversations from disconnected repos; billing-page lifetime-conversation count (question for product: is billing per-user or per-repo).
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Bug-report claim | Codebase reality | Plan response |
+| --- | --- | --- |
+| "After swapping repos, Command Center should only show conversations scoped to the current repo" | No repo-scoping column exists on `conversations`; query filters on `user_id` only. | Add `conversations.repo_url` column; filter query by the user's current `users.repo_url`. |
+| "Disconnect should not leak to the new repo" | `/api/repo/disconnect/route.ts` clears `users.repo_url` but does **not** touch `conversations`. | Scoping via `repo_url` equality means disconnect automatically hides all conversations (current user `repo_url` becomes `NULL`; no row's `repo_url` equals `NULL` under `.eq()`). |
+| "New repo `au-chat-chat` showed conversations about the old repo's files (`overview/vision.md`, `overview/Au%20Chat%20…`)" | KB chat resumption via `lookupConversationForPath` matches on `(user_id, context_path)` only. Two repos with the same file path collide. | Add `repo_url` eq filter to that lookup too; without this, opening `overview/vision.md` in the new repo would resume the la-chatte thread. |
+
+## Hypotheses
+
+- **H1 (confirmed — primary):** `conversations` rows have no repo/project scoping. The Command Center query (`hooks/use-conversations.ts:107-124`) filters on `user_id` only, so any repo swap leaks.
+- **H2 (confirmed — secondary):** `lookupConversationForPath` (`server/lookup-conversation-for-path.ts:44-52`) has the same scoping gap on the `(user_id, context_path)` unique key. A file at the same path in the new repo resumes the old repo's thread.
+- **H3 (confirmed — cleanup):** `/api/repo/disconnect/route.ts` clears `users.repo_url` but never touches `conversations`. No deletion, no archival, no flag — the rows are simply orphaned.
+- **H4 (ruled out):** not an RLS leak. All returned rows belong to the same authenticated user. This is in-user tenancy (project-scope), not cross-user tenancy. Stamping `repo_url` and filtering in the query is sufficient; RLS can later be hardened but is not load-bearing.
+- **H5 (ruled out):** not a caching bug. The query re-runs on mount; the Supabase Realtime subscription still filters by `user_id` only. No stale state in hook memo / localStorage.
+
+## Files to Edit
+
+- `apps/web-platform/supabase/migrations/029_conversations_repo_url.sql` — **new migration** (create).
+- `apps/web-platform/hooks/use-conversations.ts` — load current user's `repo_url`, add `.eq("repo_url", repoUrl)` to the list query; gracefully handle `repo_url === null` (return empty list).
+- `apps/web-platform/server/lookup-conversation-for-path.ts` — accept `repoUrl` arg; add `.eq("repo_url", repoUrl)` to the context_path lookup.
+- `apps/web-platform/app/api/chat/thread-info/route.ts` — read `users.repo_url`, pass to `lookupConversationForPath`.
+- `apps/web-platform/app/api/conversations/route.ts` — same as above if it calls `lookupConversationForPath` (verify at work-time).
+- `apps/web-platform/server/conversations-tools.ts` — same as above (`conversations_lookup` MCP tool; verify at work-time).
+- `apps/web-platform/server/ws-handler.ts` — at conversation creation (line ~283 and the 23505 fallback path), stamp `repo_url` from current user row.
+- `apps/web-platform/app/api/repo/setup/route.ts` — at the auto-sync conversation insert (line ~151-158), stamp `repo_url`.
+- `apps/web-platform/lib/types.ts` — add `repo_url: string | null` to the `Conversation` type.
+
+## Files to Create
+
+- `apps/web-platform/supabase/migrations/029_conversations_repo_url.sql`
+- `apps/web-platform/test/command-center-repo-scope.test.tsx` — RED test: seed two conversations with different `repo_url` values against one user, assert only the current-repo one renders.
+- `apps/web-platform/test/lookup-conversation-for-path-repo-scope.test.ts` — RED test: two conversations with same `(user_id, context_path)` but different `repo_url`; assert only the current-repo one is returned.
+- `apps/web-platform/test/disconnect-hides-conversations.test.ts` — RED test (API-level or hook-level): after `users.repo_url` is nulled, the query returns `[]`.
+
+## Open Code-Review Overlap
+
+None. Queried the 20 most recent open `code-review` issues (#2594, #2592, #2591, #2590, #2349, #2348, #2246, #2244, #2231, #2225-#2217, #2197, #2196) — zero reference `hooks/use-conversations.ts`, `server/lookup-conversation-for-path.ts`, `app/api/repo/disconnect/`, `app/api/repo/setup/`, `app/api/conversations/`, or `supabase/migrations/`. No fold-in, no defer.
+
+## Implementation Phases
+
+### Phase 1 — Migration + type (DB contract first)
+
+**1.1** Write migration `029_conversations_repo_url.sql`:
+
+```sql
+-- 029_conversations_repo_url.sql
+-- Scope conversations to the repository they were created against.
+-- Fixes: command center + KB-context-path lookup leaking pre-disconnect
+-- conversations into a freshly-connected repo (see plan
+-- 2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md).
+--
+-- Nullable on purpose: pre-migration rows are backfilled with the user's
+-- CURRENT repo_url. If the user had already disconnected before this
+-- migration ran, users.repo_url is NULL and conversations.repo_url stays
+-- NULL — those rows will be hidden by the new query filter (desired —
+-- matches disconnect semantics).
+--
+-- NOT using CONCURRENTLY: Supabase migration runner wraps each file in a
+-- transaction (see migrations 025, 027 comments). Column add + index are
+-- transaction-safe. If the table grows to a size where an index rebuild
+-- becomes disruptive, ship a second migration via direct psql.
+
+ALTER TABLE public.conversations
+  ADD COLUMN IF NOT EXISTS repo_url text;
+
+-- Backfill pre-migration rows with the user's current repo_url.
+-- For disconnected users (repo_url IS NULL), conversations.repo_url stays NULL.
+UPDATE public.conversations c
+   SET repo_url = u.repo_url
+  FROM public.users u
+ WHERE c.user_id = u.id
+   AND c.repo_url IS NULL;
+
+-- Partial index — only populated rows are indexed (disconnected-user
+-- conversations don't need index coverage; they're never queried).
+CREATE INDEX IF NOT EXISTS idx_conversations_user_repo
+  ON public.conversations (user_id, repo_url)
+  WHERE repo_url IS NOT NULL;
+
+-- Update the existing context_path UNIQUE index to include repo_url so
+-- the same KB file path in two repos no longer collides. This drops and
+-- recreates the index (established pattern — see migration 025).
+DROP INDEX IF EXISTS public.conversations_context_path_user_uniq;
+
+CREATE UNIQUE INDEX conversations_context_path_user_uniq
+  ON public.conversations (user_id, repo_url, context_path)
+  WHERE context_path IS NOT NULL AND archived_at IS NULL;
+```
+
+**1.2** Update `apps/web-platform/lib/types.ts` — add `repo_url: string | null` to `Conversation`.
+
+**Deliverable of Phase 1:** migration applies cleanly on a populated dev DB; every pre-existing conversation has a non-null `repo_url` equal to the user's current `users.repo_url`.
+
+#### Research Insights (Phase 1)
+
+**Best Practices:**
+
+- `UPDATE ... FROM <table>` with an indexed PK join is ~92% faster than a correlated subquery (`UPDATE ... SET col = (SELECT ...)`) — the backfill uses the join form.
+- Supabase migrations run in a transaction per file — `CREATE INDEX CONCURRENTLY` is rejected (`SQLSTATE 25001`). Pattern established by migrations 025, 027, 028; this plan follows the same rationale verbatim.
+
+**Performance Considerations:**
+
+- Production `conversations` is ~1k rows (per migration 028's comment). UPDATE-FROM joined to `users` by PK completes in sub-second; no batching / timeout loop needed.
+- Lock scope during the backfill: UPDATE acquires `ROW EXCLUSIVE` on `conversations` and `ACCESS SHARE` on `users`. Blocks concurrent writes to `conversations` for the duration — sub-second window is acceptable; no concurrent-write traffic in the migration window is realistic for a single-instance deploy.
+
+**Edge Cases:**
+
+- Rows whose user has `users.repo_url IS NULL` at migration time stay `repo_url = NULL` and are hidden by the new query filter. Exactly what disconnect-without-reconnect semantics dictate.
+- Rows whose user row was deleted (impossible under `ON DELETE CASCADE` but worth stating) — the join simply misses them; they stay `NULL`. Hidden, consistent with H4.
+
+**References:**
+
+- [PostgreSQL UPDATE JOIN performance guide (Dupple, 2026)](https://dupple.com/blog/postgresql-update-join) — justifies the `UPDATE ... FROM` form.
+- [Supabase migration 028 comment (in-tree)](apps/web-platform/supabase/migrations/028_conversations_user_id_session_id_unique.sql) — prior-art transactional-runner rationale we mirror.
+
+### Phase 2 — Stamp `repo_url` on new conversations (producer side)
+
+**2.1** `server/ws-handler.ts` — at the conversation INSERT (~line 283) and the 23505 unique-violation fallback (~line 300), read the current user's `repo_url` and include it in the insert payload. On the fallback lookup, include `repo_url` in the `.eq()` chain.
+
+**2.2** `app/api/repo/setup/route.ts` — at the auto-sync conversation INSERT (~line 151-158), stamp `repo_url` from the freshly-set value (`repoUrl` is in scope from the request body).
+
+**2.3** Sweep `grep -rn "from(\"conversations\").insert" apps/web-platform` for any other INSERT sites and stamp them identically. Document each in this plan before implementing.
+
+**Deliverable of Phase 2:** conversations inserted after this phase carry a non-null `repo_url`. Manual verify: insert a test conversation, inspect the DB row.
+
+### Phase 3 — Scope the consumer queries (reader side)
+
+**3.1 RED test first — `test/command-center-repo-scope.test.tsx`:** seed two conversations for one mocked user — one with `repo_url = "https://github.com/acme/old"`, one with `"https://github.com/acme/new"`. Mock `users.repo_url = "https://github.com/acme/new"`. Render the dashboard. Assert only the "new" conversation renders. This test MUST fail against the current main.
+
+**3.2** Update `hooks/use-conversations.ts`:
+
+- After `getUser()`, fetch `users.repo_url` for the authenticated user.
+- If `repo_url` is `null`, short-circuit: `setConversations([])` and return — there is no connected repo, so the Command Center shows the empty state.
+- Otherwise add `.eq("repo_url", repoUrl)` to the list query.
+- The Supabase Realtime subscription filter stays on `user_id` — Realtime's `filter:` accepts only a single equality predicate per [realtime-js#97](https://github.com/supabase/realtime-js/issues/97); a two-column AND is not expressible at the wire protocol. We handle cross-repo rows client-side by dropping payloads whose `repo_url !== currentRepoUrl` in the listener callback — same defense-in-depth pattern as the existing `archived_at` handling.
+- Add a second effect that subscribes to `users` table UPDATE events on `id = currentUserId`. On payload with `new.repo_url !== currentRepoUrl`, update local `repoUrl` state and call `fetchConversations()` to re-scope the view in place. This closes race-condition **R-C** below (user reconnects to a different URL in another tab while this tab is open).
+
+**3.3 RED test — `test/lookup-conversation-for-path-repo-scope.test.ts`:** seed two rows with the same `(user_id, context_path)` but different `repo_url`. Call `lookupConversationForPath(userId, path, currentRepoUrl)`. Assert the returned row's `repo_url` matches `currentRepoUrl`. Also assert that the pre-migration UNIQUE index would have rejected this seed; the new index permits it.
+
+**3.4** Update `server/lookup-conversation-for-path.ts`:
+
+- Signature becomes `lookupConversationForPath(userId, contextPath, repoUrl)`.
+- Add `.eq("repo_url", repoUrl)` to the query.
+- If `repoUrl` is `null`/empty, return `{ ok: true, row: null }` — no connected repo means no resumable thread.
+
+**3.5** Update every caller of `lookupConversationForPath`:
+
+- `app/api/chat/thread-info/route.ts`
+- `app/api/conversations/route.ts` (verify — the file exists; inspect it at work-time)
+- `server/conversations-tools.ts` (MCP tool `conversations_lookup` — verify at work-time)
+- Each caller must fetch `users.repo_url` for the authenticated user and pass it through. If `repo_url` is null, return an empty / not-found response consistent with that route's contract.
+
+**3.6** Update the `ws-handler.ts` resume-by-context_path fallback (the 23505 branch, ~line 300) to include `repo_url` in its lookup, matching the new UNIQUE index predicate. Without this, a 23505 on insert would fall back to a lookup that finds nothing and throw the same "Failed to resolve existing context_path conversation" error migration 025 tried to eliminate.
+
+**Deliverable of Phase 3:** Command Center shows only current-repo conversations; KB context-path resume never crosses repo boundaries; tests from 3.1 and 3.3 pass.
+
+### Phase 4 — Disconnect path alignment (no code change expected)
+
+**4.1** Audit `/api/repo/disconnect/route.ts`. With the repo_url scoping in place, setting `users.repo_url = NULL` automatically hides all that user's conversations from the Command Center (because `.eq("repo_url", null)` matches nothing in PostgREST). **No code change is expected here** — but we must record this claim in the plan so a reviewer doesn't add speculative cleanup.
+
+**4.2 RED test — `test/disconnect-hides-conversations.test.ts`:** seed conversations with `repo_url = "https://github.com/acme/x"`, then null the user's `repo_url`. Assert the hook / route returns `[]`.
+
+**Deliverable of Phase 4:** verified-by-test that disconnect alone (no conversation mutation) hides all conversations.
+
+### Phase 5 — QA via Playwright MCP (ships with the PR)
+
+Reproduce the exact scenario from the bug report against the dev server:
+
+1. Log in as a test account with a pre-seeded repo + conversations.
+2. Navigate to Settings → Disconnect repository.
+3. Connect a new (different) repo via the Create Repo flow.
+4. Navigate to Command Center. Assert **zero** pre-swap conversations are visible (empty-state copy renders instead).
+5. Start a new conversation in the new repo. Verify it appears and the old ones are still hidden.
+6. Disconnect again. Navigate to Command Center. Assert empty state (no connected repo).
+7. Reconnect the SAME new repo (same URL). Assert the conversations from step 5 reappear (`repo_url` equality holds).
+
+Screenshots from steps 4, 5, 7 land in the PR description.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] Migration `029_conversations_repo_url.sql` adds `conversations.repo_url` column, backfills from `users.repo_url`, adds `(user_id, repo_url)` partial index, rotates the context_path UNIQUE index to include `repo_url`.
+- [ ] Every `conversations` INSERT site in `apps/web-platform/` stamps `repo_url` from the authenticated user's current `users.repo_url`.
+- [ ] `hooks/use-conversations.ts` filters by `(user_id, repo_url)`; returns empty list when `users.repo_url IS NULL`.
+- [ ] `lookupConversationForPath` requires a `repoUrl` argument and filters by it; all callers pass the current value.
+- [ ] Three new tests (Phase 3.1, 3.3, 4.2) pass; existing `test/command-center.test.tsx`, `test/chat-surface-sidebar.test.tsx`, and `test/dashboard-sidebar-collapse.test.tsx` still pass.
+- [ ] `tsc --noEmit` passes with the new `Conversation.repo_url` type.
+- [ ] `npm run test` passes in `apps/web-platform` (using `./node_modules/.bin/vitest run` per AGENTS.md `cq-in-worktrees-run-vitest-via-node-node`).
+- [ ] PR description includes Playwright screenshots for QA steps 4, 5, 7.
+
+### Post-merge (operator)
+
+- [ ] Migration applied to prod Supabase (verify via REST API per AGENTS.md `wg-when-a-pr-includes-database-migrations`; runbook `knowledge-base/engineering/ops/runbooks/supabase-migrations.md`).
+- [ ] Smoke-test on production: disconnect + reconnect cycle on a throwaway account does not leak conversations.
+
+## Test Scenarios
+
+| # | Scenario | Expected | Test file |
+| --- | --- | --- | --- |
+| 1 | Single connected repo, 3 conversations | All 3 show | existing `command-center.test.tsx` (must still pass) |
+| 2 | Disconnected (repo_url = null), 3 orphaned conversations | `conversations.length === 0`; empty-state renders | `disconnect-hides-conversations.test.ts` |
+| 3 | Swapped repos (old has 2 conversations, new has 1) | Only the 1 new conversation shows | `command-center-repo-scope.test.tsx` |
+| 4 | Two repos, same `overview/vision.md` path, different threads | `lookupConversationForPath` returns the current-repo row | `lookup-conversation-for-path-repo-scope.test.ts` |
+| 5 | User reconnects the exact same URL that was previously connected | Previously-hidden conversations re-appear | manual QA (step 7) |
+| 6 | Realtime UPDATE arrives for a conversation with a different `repo_url` than the user's current | Subscription callback drops the payload | unit test in `command-center-repo-scope.test.tsx` |
+| 7 | Realtime UPDATE on `users` changes `repo_url` (user reconnected to different URL in another tab) | Hook refetches; visible conversation set updates to new scope | unit test in `command-center-repo-scope.test.tsx` |
+
+## Risks & Edge Cases
+
+- **R-A: clone-in-progress disconnect.** The existing disconnect handler already rejects with 409 while `repo_status === "cloning"`. The stamping in Phase 2.2 relies on `users.repo_url` being set at insert time, which happens before the auto-sync conversation is created (setup route sets `repo_url` then inserts the conversation). Safe.
+- **R-B: user disconnects mid-stream.** A WebSocket session may insert messages into a conversation whose `repo_url` no longer matches the user's current `repo_url`. Those messages still persist under the conversation's original `repo_url`. The hook never shows them — correct behavior. No extra guard needed.
+- **R-C: user reconnects to a different URL in another tab while this tab is open.** Without mitigation, the hook keeps showing conversations scoped to the prior URL until the page reloads. **Mitigation:** Phase 3.2 second effect subscribes to `users` UPDATE events and refetches on `repo_url` change. Tested explicitly in `test/command-center-repo-scope.test.tsx` (add scenario: emit a `users` UPDATE with a new `repo_url`, assert the hook refetches and the conversation set changes).
+- **R-D: conversation INSERT races `users.repo_url` clear.** A WS handler reads `users.repo_url = X`, then the user's other tab disconnects (sets `repo_url = NULL`), then the WS handler INSERTs a conversation with `repo_url = X`. The row is then "orphaned" (user's current `repo_url` is NULL or a different value). Impact: one row in the DB that never surfaces in any query until the user re-connects `X`. Not a correctness failure — just a no-op row. **Mitigation:** accept as out-of-scope; disconnect is rare and the failure mode is benign. If it becomes a problem, wrap the INSERT in a single-statement `INSERT ... SELECT repo_url FROM users WHERE id = $1 AND repo_url IS NOT NULL` so the write short-circuits to zero rows when the user disconnected mid-insert.
+- **Per-request cost of reading `users.repo_url`.** Each conversation list query now adds one `users` row read. Negligible — single-row lookup by PK. Could be hoisted to a React context (alongside the existing `useOnboarding` / user-data context) if it shows in profiling, but not warranted at plan time.
+- **Null-`repo_url` Realtime filter.** Supabase Realtime's `filter` clause accepts only a single equality predicate ([realtime-js#97](https://github.com/supabase/realtime-js/issues/97)). Client-side drop in the callback is the idiomatic pattern (already used for `archived_at`).
+- **RLS not tightened.** Conversations' RLS is `auth.uid() = user_id`. This plan deliberately does NOT add `repo_url` to the RLS `USING` clause: (a) no cross-user leak exists, so RLS is not the defense layer, (b) ws-handler and agent-runner use the service role (RLS-bypassed) and would need their own checks anyway, (c) adding RLS would force every authenticated-client read to JOIN `users`, doubling the per-query row reads. Recorded as a Non-Goal; revisit if/when org-level sharing lands.
+- **`toContain` vs `toBe` in assertions (AGENTS.md `cq-mutation-assertions-pin-exact-post-state`).** All scenarios above assert exact post-state — scenario 2 asserts `conversations.length === 0`, scenario 3 asserts the specific surviving id, scenario 4 asserts the returned `repo_url` matches.
+- **jsdom layout traps (AGENTS.md `cq-jsdom-no-layout-gated-assertions`).** None of the new tests depend on layout values.
+- **Destructive-prod test allowlist (AGENTS.md `cq-destructive-prod-tests-allowlist`).** Not applicable — all new tests are unit-level with mocked Supabase; no prod writes.
+- **Union widening / exhaustive-switch (AGENTS.md `cq-union-widening-grep-three-patterns`).** Adding `repo_url` to the `Conversation` type is a field add, not a union widening — no consumer switch patterns to sweep.
+
+### Related Learnings (retroactive-gate check)
+
+- [`knowledge-base/project/learnings/2026-04-17-kb-chat-stale-context-on-doc-switch.md`](../learnings/2026-04-17-kb-chat-stale-context-on-doc-switch.md) — fixed a *UI-layer* variant of this bug class (chat panel carries state across URL-key change) by forcing unmount on key change. This PR fixes the *data-layer* variant (conversations are not scoped to the URL-equivalent `repo_url`). The UI fix and the data-layer fix are complementary — neither subsumes the other. The retroactive-gate check per AGENTS.md `wg-when-fixing-a-workflow-gates-detection` is satisfied: both fixes land, neither regresses.
+- [`knowledge-base/project/learnings/2026-03-28-unapplied-migration-command-center-chat-failure.md`](../learnings/2026-03-28-unapplied-migration-command-center-chat-failure.md) — documents the exact failure mode an unapplied `029_conversations_repo_url.sql` migration would produce (app code expects a column that doesn't exist → silent 500). Post-merge AC includes a REST-API verification probe per runbook to prevent recurrence.
+- [`knowledge-base/project/learnings/database-issues/disconnect-null-constraint-violation-20260406.md`](../learnings/database-issues/disconnect-null-constraint-violation-20260406.md) — prior disconnect-handler bug. This plan does NOT modify the disconnect handler's field-clear payload; no regression risk for that class.
+
+## Non-Goals / Out of Scope
+
+- A first-class `projects` table with `(user_id, repo_url) → project_id` FK. The repo_url-as-scope approach is sufficient for the current one-repo-per-user product model. When the product evolves to multi-repo-per-user, introduce `projects.id` and add a `project_id` column to `conversations`. Multi-tenant SaaS guidance favors tenant/project-level scoping over user-level scoping ([WorkOS guide](https://workos.com/blog/developers-guide-saas-multi-tenant-architecture), [Flightcontrol multi-tenant data modeling](https://www.flightcontrol.dev/blog/ultimate-guide-to-multi-tenant-saas-data-modeling)); the deferred design should follow that pattern. Deferral tracked as a follow-up issue (to be filed in Phase 6 of this plan if not already tracked).
+- RLS tightening on `conversations` to include `repo_url`. See R-D / "RLS not tightened" in Risks — deliberate no-op. Revisit only if org-level sharing lands.
+- Billing-page conversation count. The current query (`app/(dashboard)/dashboard/settings/billing/page.tsx:33`) counts lifetime conversations per `user_id`. **Open question for product:** should lifetime billing reflect all history, or only current-project? Not touched by this PR. File deferral issue.
+- UI for "orphaned" conversations (conversations whose `repo_url` no longer matches any current user's `repo_url`). Not needed today — hidden is sufficient.
+- Hard cascade delete on disconnect. Deliberate no-op — reconnecting the same URL should restore the view. Cascade-delete would make the disconnect button irreversible with zero upside.
+- Cross-user tenancy / RLS hardening. All leaked rows belong to the same user, so RLS is not load-bearing here. If future product decisions add org-level sharing, revisit.
+
+## Domain Review
+
+**Domains relevant:** Engineering (primary), Product (tier-assessment for UX impact).
+
+### Engineering (CTO scope)
+
+**Status:** inline review (no subagent spawn — plan phase handled by planner directly per plan step 2.5; full CTO review at /ship Phase 5.5 per AGENTS.md `hr-before-shipping-ship-phase-5-5-runs`).
+**Assessment:** Schema change is minimal and follows the migration 024/025 pattern (add column + rotate index + narrow partial-index predicate). No new tables. Query changes are additive. Three RED tests provide regression coverage. The one migration risk (backfill UPDATE on a possibly-large `conversations` table) is bounded by the dev DB size and acceptable within Supabase's transactional migration model — the query runs once, is idempotent, and only reads `users.repo_url`.
+
+### Product/UX Gate
+
+**Tier:** advisory (modifies the Command Center empty state & empty-filter states, no new pages/flows).
+**Decision:** auto-accepted (pipeline context — plan invoked by `/one-shot` subagent, not interactively).
+**Agents invoked:** none (advisory tier in pipeline context).
+**Skipped specialists:** none required.
+**Pencil available:** N/A (no wireframes needed; empty-state copy already exists at `app/(dashboard)/dashboard/page.tsx:329-443`).
+
+#### Findings
+
+- The existing first-run empty state (`!visionExists && conversations.length === 0 && !hasActiveFilter` → "Tell your organization what you're building.") is a good fallback when `users.repo_url IS NULL`. No new copy needed.
+- Risk: a user who had 50 conversations and disconnects will see the "No conversations yet" empty state, which can read like data loss. **Mitigation (in-scope for this PR):** if `users.repo_status === "not_connected"` and the user has pre-existing conversations stamped with other `repo_url` values, the dashboard should hint "Your previous conversations are tied to your disconnected repository. Reconnect that repository to view them." This is a one-line conditional render in `app/(dashboard)/dashboard/page.tsx`. Counts can come from a cheap `count=exact head=true` query. **Ship decision:** in-scope, lightweight, same PR.
+
+## Verification Commands (pre-flight)
+
+Before starting implementation, a work-skill agent MUST run:
+
+- `cd apps/web-platform && ls supabase/migrations/ | tail -5` — confirm the next migration number is 029 (currently 028 is the latest).
+- `cd apps/web-platform && grep -rn "from(\"conversations\").insert" . --include="*.ts" --include="*.tsx"` — enumerate every INSERT site.
+- `cd apps/web-platform && grep -rn "lookupConversationForPath" . --include="*.ts" --include="*.tsx"` — enumerate every caller.
+- `cd apps/web-platform && ./node_modules/.bin/vitest run test/command-center.test.tsx` — confirm the existing test suite is green against main before editing.
+
+Record each command's output under `## Preflight Output` when implementation begins — do not skip.
+
+<!-- verified: 2026-04-22 source: local inspection of apps/web-platform/supabase/migrations/ at commit HEAD of branch feat-one-shot-command-center-stale-conversations-after-repo-swap (latest migration 028_conversations_user_id_session_id_unique.sql) -->

--- a/knowledge-base/project/specs/feat-one-shot-command-center-stale-conversations-after-repo-swap/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-command-center-stale-conversations-after-repo-swap/session-state.md
@@ -1,0 +1,23 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-one-shot-command-center-stale-conversations-after-repo-swap/knowledge-base/project/plans/2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md
+- Status: complete
+
+### Errors
+None. Context7 MCP returned "Monthly quota exceeded" once; substituted with WebSearch + in-tree sibling migrations — no load-bearing gap.
+
+### Decisions
+- **Root cause:** `conversations` table has no repo/project scoping column. `hooks/use-conversations.ts` filters on `user_id` only; `/api/repo/disconnect` clears `users.repo_url` but never touches `conversations`. Swapping repos leaks every prior conversation into the new project's Command Center.
+- **Fix shape:** add `conversations.repo_url` column (nullable, backfilled from `users.repo_url`), stamp it at every INSERT site, filter Command Center + KB context-path lookup by `(user_id, repo_url)`. Old rows become hidden, recoverable if user reconnects the same URL — no cascade delete.
+- **Secondary fix:** rotate the `conversations_context_path_user_uniq` index to include `repo_url` so two repos with the same `overview/vision.md` path no longer collide (direct cause of the "Tell me about the file at overview/vision.md" rows leaking in the screenshot).
+- **Realtime limitation acknowledged:** Supabase Realtime `filter:` supports only single-column equality (realtime-js#97); client-side drop + a second `users` table subscription for cross-tab disconnect detection is the only viable design.
+- **RLS deliberately not tightened:** this is in-user tenancy (not cross-user), so RLS isn't the defense layer — recorded as a defensible Non-Goal with rationale. Future org-level sharing would revisit.
+- **Deferrals tracked in tasks.md:** (1) first-class `projects` table for future multi-repo-per-user model, (2) billing-page lifetime conversation count (product question: per-user vs per-project).
+
+### Components Invoked
+- soleur:plan (primary) — drafted the plan + tasks.md
+- soleur:deepen-plan (primary) — enhanced Migration safety, Realtime semantics, Race conditions, Related learnings sections
+- WebSearch × 4 — Supabase Realtime filter, PostgreSQL UPDATE-FROM perf, multi-tenant SaaS scoping, Supabase migration runner
+- mcp__plugin_soleur_context7__resolve-library-id — quota exceeded, fell through to WebSearch
+- Read / Bash / Edit — code & schema inspection

--- a/knowledge-base/project/specs/feat-one-shot-command-center-stale-conversations-after-repo-swap/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-command-center-stale-conversations-after-repo-swap/tasks.md
@@ -1,0 +1,69 @@
+# Tasks: fix Command Center stale conversations after repo swap
+
+**Plan:** `knowledge-base/project/plans/2026-04-22-fix-command-center-stale-conversations-after-repo-swap-plan.md`
+**Branch:** `feat-one-shot-command-center-stale-conversations-after-repo-swap`
+
+## 1. Preflight
+
+- [x] 1.1 Confirm next migration number is 029: `cd apps/web-platform && ls supabase/migrations/ | tail -5`.
+- [x] 1.2 Enumerate every `conversations` INSERT site: `cd apps/web-platform && grep -rn "from(\"conversations\").insert" . --include="*.ts" --include="*.tsx"`.
+- [x] 1.3 Enumerate every `lookupConversationForPath` caller: `cd apps/web-platform && grep -rn "lookupConversationForPath" . --include="*.ts" --include="*.tsx"`.
+- [x] 1.4 Baseline-green: `cd apps/web-platform && ./node_modules/.bin/vitest run test/command-center.test.tsx` passes against HEAD.
+
+## 2. RED tests (TDD gate — must fail first)
+
+- [x] 2.1 Create `apps/web-platform/test/command-center-repo-scope.test.tsx` — two conversations, two different `repo_url`; assert only the current one renders. Run, confirm fail.
+- [x] 2.2 Create `apps/web-platform/test/lookup-conversation-for-path-repo-scope.test.ts` — same context_path, different repo_url; assert current-repo row is returned. Run, confirm fail.
+- [x] 2.3 Create `apps/web-platform/test/disconnect-hides-conversations.test.ts` — user.repo_url = null returns empty. Run, confirm fail.
+
+## 3. Schema & type
+
+- [x] 3.1 Create `apps/web-platform/supabase/migrations/029_conversations_repo_url.sql` (content from plan Phase 1.1).
+- [ ] 3.2 Apply migration locally; verify every pre-existing row has non-null `repo_url` matching its user's `users.repo_url`; verify disconnected-user rows stay NULL.
+- [x] 3.3 Update `apps/web-platform/lib/types.ts` — add `repo_url: string | null` to `Conversation`.
+
+## 4. Producer side (stamp repo_url on insert)
+
+- [x] 4.1 `server/ws-handler.ts`: stamp `repo_url` on the conversation INSERT (~L283) and include in the 23505-fallback lookup (~L300).
+- [x] 4.2 `app/api/repo/setup/route.ts`: stamp `repo_url` on the auto-sync conversation INSERT (~L151-158) — `repoUrl` already in scope from request body.
+- [x] 4.3 Sweep every INSERT site from task 1.2 and stamp `repo_url` identically.
+
+## 5. Consumer side (scope queries)
+
+- [x] 5.1 `hooks/use-conversations.ts`: fetch `users.repo_url` after `getUser()`; short-circuit to `[]` when null; add `.eq("repo_url", repoUrl)` to the list query; drop Realtime payloads whose `repo_url !== currentRepoUrl` in the channel callback.
+- [x] 5.1b `hooks/use-conversations.ts`: add a second Realtime channel subscribed to `users` UPDATE on `id = currentUserId`. On payload, if `new.repo_url !== currentRepoUrl`, update local `repoUrl` state and call `fetchConversations()`. Covers race R-C (other tab switched repos). Add corresponding scenario 7 test to `test/command-center-repo-scope.test.tsx`.
+- [x] 5.2 `server/lookup-conversation-for-path.ts`: add `repoUrl` parameter; add `.eq("repo_url", repoUrl)` to the query; return `{ ok: true, row: null }` when repoUrl is null/empty.
+- [x] 5.3 Update every caller from task 1.3 (`app/api/chat/thread-info/route.ts`, `app/api/conversations/route.ts`, `server/conversations-tools.ts`, and the ws-handler 23505 fallback) to read `users.repo_url` and pass it.
+
+## 6. UX nuance — "previous conversations are tied to your disconnected repository"
+
+- [x] 6.1 `app/(dashboard)/dashboard/page.tsx`: when user.repo_status === "not_connected" AND a cheap `count=exact head=true` query on conversations shows pre-existing rows, render a hint line below the first-run CTA explaining that reconnecting the prior URL restores them.
+
+## 7. Verify GREEN
+
+- [x] 7.1 Tests from task 2 now pass.
+- [x] 7.2 Existing tests still pass: `test/command-center.test.tsx`, `test/chat-surface-sidebar.test.tsx`, `test/dashboard-sidebar-collapse.test.tsx`.
+- [x] 7.3 `./node_modules/.bin/tsc --noEmit` is clean in `apps/web-platform/`.
+- [x] 7.4 Full vitest run in `apps/web-platform/` is green.
+
+## 8. QA via Playwright MCP
+
+- [ ] 8.1 Log in as test account with pre-seeded conversations.
+- [ ] 8.2 Disconnect repo via Settings.
+- [ ] 8.3 Create + connect new (different) repo via Connect Repo flow.
+- [ ] 8.4 Command Center: assert zero pre-swap conversations visible; screenshot.
+- [ ] 8.5 Start a new conversation in the new repo; verify it appears; screenshot.
+- [ ] 8.6 Disconnect again → Command Center shows empty state.
+- [ ] 8.7 Reconnect the exact same URL from step 8.3 → new conversation from 8.5 reappears; screenshot.
+
+## 9. Ship artifacts
+
+- [ ] 9.1 Commit plan + tasks.md together with migration + test + code changes.
+- [ ] 9.2 Open PR with `Closes #<issue-number>` in the body.
+- [ ] 9.3 Post-merge operator: verify migration applied to prod Supabase per runbook `knowledge-base/engineering/ops/runbooks/supabase-migrations.md`.
+- [ ] 9.4 Post-merge operator: smoke-test the disconnect+reconnect cycle on a throwaway prod account.
+
+## 10. Deferral issues (file in same PR)
+
+- [ ] 10.1 Issue: `projects` table + project_id on conversations — future multi-repo-per-user model. Milestone: Post-MVP / Later.
+- [ ] 10.2 Issue: billing-page conversation count — product question: lifetime vs current-project. Milestone: Post-MVP / Later.

--- a/plugins/soleur/skills/plan/SKILL.md
+++ b/plugins/soleur/skills/plan/SKILL.md
@@ -240,6 +240,7 @@ Think like a product manager - what would make this issue clear and actionable? 
 - [ ] Gather supporting materials (error logs, screenshots, design mockups)
 - [ ] Prepare code examples or reproduction steps if applicable, name the mock filenames in the lists
 - [ ] When planning a directory rename, enumerate ALL files in the target directory as potential self-reference holders -- directory trees and conceptual prose derived from the directory name don't match path-pattern greps
+- [ ] When the plan prescribes scoping a helper function by a new column/predicate, `rg` the codebase for every other inline query on the same table that BYPASSES the helper (id-based lookups, pre-helper historical queries, WS-handler inline SELECTs) and list each as a `Files to Edit` entry -- sibling queries are the most common silent backdoor after a tenant-scope change. See learning `2026-04-22-scope-by-new-column-audit-every-query-not-just-the-helper.md`.
 
 ### 2.5. Domain Review Gate
 


### PR DESCRIPTION
## Summary

Fixes Command Center showing stale conversations from a disconnected repo.

A user on account `jean.deruelle@jikigai.com` disconnected `la-chatte` and created a new public repo `au-chat-chat`. The Command Center in the new project still listed every la-chatte conversation. Root cause: `conversations` had no repo/project scoping column — the list query filtered on `user_id` only; KB context-path resume matched on `(user_id, context_path)` only. Any repo swap leaked.

### What this PR does

- Adds `conversations.repo_url` (migration 029, nullable, backfilled, with rotated `(user_id, repo_url, context_path)` UNIQUE index).
- Stamps `repo_url` at every INSERT site (ws-handler `createConversation` + aborts on disconnect race per plan R-D; `/api/repo/setup` auto-sync conversation).
- Scopes every consumer query:
  - `hooks/use-conversations.ts` — `(user_id, repo_url)` filter + client-side repo-drop on the Realtime payload (realtime-js#97 single-filter limit).
  - `lookupConversationForPath` — takes `repoUrl` arg, short-circuits to `{ok: true, row: null}` when disconnected.
  - `start_session resumeByContextPath` inline lookup (ws-handler.ts) — review finding, P1.
  - `resume_session` lookup — review finding, P1 (id-only check allowed cross-repo resume).
  - `/api/chat/thread-info`, `/api/conversations`, `conversations_lookup` MCP tool.
- Cross-tab awareness: second Realtime channel on `users` UPDATE refetches when another tab swaps `repo_url`.
- UX: disconnected empty state hints that reconnecting the prior repo restores orphans.
- Agent-native: `conversations_lookup` description documents repo-scope semantics so agents don't misinterpret null as "no thread".

### Review fixes

Multi-agent review (10 agents) surfaced two P1 plan gaps — inline `start_session` resume-by-context_path was unscoped, and `resume_session` verified only id+user_id. Both fixed inline. P2s fixed: extracted `getCurrentRepoUrl` helper with `reportSilentFallback` (closed 4 silent-fallback sites), rewrote a tautologically-passing test with predicate-aware mock, added RED test for the disconnect-abort path, removed `repoUrl` from the users-channel effect deps (avoid resubscribe churn), strict equality on the Realtime cross-repo drop, and migration now carries `COMMENT ON COLUMN` + archives pre-migration disconnected-user rows for recoverability.

### Scope-outs filed

- #2775 — repo_url write-boundary normalization (cross-cutting-refactor)
- #2776 — `conversations_list` + `conversation_archive` MCP parity (pre-existing)
- #2777 — consolidate `createQueryBuilder` test mock (cross-cutting-refactor)
- #2778 — migrate to first-class `projects` table (architectural-pivot, plan Non-Goal)

## Changelog

### Web Platform

- **Fix:** Command Center + KB-path resume now scope by connected repo. Disconnecting a repo hides its conversations; reconnecting the same URL restores them.
- **New:** `conversations.repo_url` column (migration 029) stamped at INSERT, filtered on every SELECT.
- **New:** Cross-tab disconnect/reconnect awareness — hook refetches when another tab swaps `users.repo_url`.
- **New:** Disconnected empty-state hint pointing users to reconnect the prior repository.
- **Agent-native:** `conversations_lookup` tool documents repo-scope semantics.

## Test plan

- [x] Unit tests: 2172/2172 pass (10 new tests cover all 7 plan scenarios)
- [x] `tsc --noEmit` clean
- [x] Multi-agent review (10 agents: security, architecture, data-integrity, performance, pattern, code-quality, test-design, semgrep, git-history, agent-native) — all P1/P2 findings fixed inline
- [x] Dev server boots clean; login page renders (smoke probe)
- [ ] ⏳ Post-merge: verify migration 029 applied to prod Supabase per `knowledge-base/engineering/ops/runbooks/supabase-migrations.md`
- [ ] ⏳ Post-merge operator smoke test: disconnect → connect-new-repo → reconnect-same-URL cycle on a throwaway account

Generated with [Claude Code](https://claude.com/claude-code)
