### PR TITLE
WIP: feat-app-url-hardening

### DIFF
--- a/apps/web-platform/app/api/auth/github-resolve/callback/route.ts
+++ b/apps/web-platform/app/api/auth/github-resolve/callback/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
-import { reportSilentFallback } from "@/server/observability";
+import { APP_URL_FALLBACK, reportSilentFallback } from "@/server/observability";
 import logger from "@/server/logger";
 
 const REDIRECT_BASE = "/connect-repo";
@@ -166,10 +166,10 @@ function redirectWithDeletedCookie(path: string, _request: Request): NextRespons
     reportSilentFallback(null, {
       feature: "github-resolve",
       op: "callback-redirect",
-      message: "NEXT_PUBLIC_APP_URL unset; github-resolve callback redirect fallback to https://app.soleur.ai",
+      message: `NEXT_PUBLIC_APP_URL unset; github-resolve callback redirect fallback to ${APP_URL_FALLBACK}`,
     });
   }
-  const appUrl = appUrlEnv ?? "https://app.soleur.ai";
+  const appUrl = appUrlEnv ?? APP_URL_FALLBACK;
   const response = NextResponse.redirect(new URL(path, appUrl), 302);
   response.cookies.set("soleur_github_resolve", "", {
     httpOnly: true,

--- a/apps/web-platform/app/api/auth/github-resolve/callback/route.ts
+++ b/apps/web-platform/app/api/auth/github-resolve/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { reportSilentFallback } from "@/server/observability";
 import logger from "@/server/logger";
 
 const REDIRECT_BASE = "/connect-repo";
@@ -160,8 +161,16 @@ export async function GET(request: Request) {
 
 /** Build a redirect response that also deletes the state cookie. */
 function redirectWithDeletedCookie(path: string, _request: Request): NextResponse {
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://app.soleur.ai";
-  const response = NextResponse.redirect(new URL(path, siteUrl), 302);
+  const appUrlEnv = process.env.NEXT_PUBLIC_APP_URL;
+  if (!appUrlEnv) {
+    reportSilentFallback(null, {
+      feature: "github-resolve",
+      op: "callback-redirect",
+      message: "NEXT_PUBLIC_APP_URL unset; github-resolve callback redirect fallback to https://app.soleur.ai",
+    });
+  }
+  const appUrl = appUrlEnv ?? "https://app.soleur.ai";
+  const response = NextResponse.redirect(new URL(path, appUrl), 302);
   response.cookies.set("soleur_github_resolve", "", {
     httpOnly: true,
     secure: true,

--- a/apps/web-platform/app/api/auth/github-resolve/route.ts
+++ b/apps/web-platform/app/api/auth/github-resolve/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { reportSilentFallback } from "@/server/observability";
 import logger from "@/server/logger";
 
 /**
@@ -12,22 +13,30 @@ import logger from "@/server/logger";
  * Sets a state nonce cookie for CSRF protection and redirects to GitHub.
  */
 export async function GET(_request: Request) {
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://app.soleur.ai";
+  const appUrlEnv = process.env.NEXT_PUBLIC_APP_URL;
+  if (!appUrlEnv) {
+    reportSilentFallback(null, {
+      feature: "github-resolve",
+      op: "initiate",
+      message: "NEXT_PUBLIC_APP_URL unset; github-resolve OAuth redirect_uri fallback to https://app.soleur.ai",
+    });
+  }
+  const appUrl = appUrlEnv ?? "https://app.soleur.ai";
 
   // Defense-in-depth: verify session even though middleware enforces auth
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
-    return NextResponse.redirect(new URL("/login", siteUrl));
+    return NextResponse.redirect(new URL("/login", appUrl));
   }
   const clientId = process.env.GITHUB_CLIENT_ID;
   if (!clientId) {
     logger.error("GITHUB_CLIENT_ID not configured");
-    return NextResponse.redirect(new URL("/connect-repo?resolve_error=1", siteUrl));
+    return NextResponse.redirect(new URL("/connect-repo?resolve_error=1", appUrl));
   }
 
   const state = crypto.randomUUID();
-  const callbackUrl = `${siteUrl}/api/auth/github-resolve/callback`;
+  const callbackUrl = `${appUrl}/api/auth/github-resolve/callback`;
 
   const authorizeUrl = new URL("https://github.com/login/oauth/authorize");
   authorizeUrl.searchParams.set("client_id", clientId);

--- a/apps/web-platform/app/api/auth/github-resolve/route.ts
+++ b/apps/web-platform/app/api/auth/github-resolve/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { reportSilentFallback } from "@/server/observability";
+import { APP_URL_FALLBACK, reportSilentFallback } from "@/server/observability";
 import logger from "@/server/logger";
 
 /**
@@ -13,19 +13,21 @@ import logger from "@/server/logger";
  * Sets a state nonce cookie for CSRF protection and redirects to GitHub.
  */
 export async function GET(_request: Request) {
+  // Defense-in-depth: verify session even though middleware enforces auth
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
   const appUrlEnv = process.env.NEXT_PUBLIC_APP_URL;
   if (!appUrlEnv) {
     reportSilentFallback(null, {
       feature: "github-resolve",
       op: "initiate",
-      message: "NEXT_PUBLIC_APP_URL unset; github-resolve OAuth redirect_uri fallback to https://app.soleur.ai",
+      message: `NEXT_PUBLIC_APP_URL unset; github-resolve OAuth redirect_uri fallback to ${APP_URL_FALLBACK}`,
+      extra: user ? { userId: user.id } : undefined,
     });
   }
-  const appUrl = appUrlEnv ?? "https://app.soleur.ai";
+  const appUrl = appUrlEnv ?? APP_URL_FALLBACK;
 
-  // Defense-in-depth: verify session even though middleware enforces auth
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
     return NextResponse.redirect(new URL("/login", appUrl));
   }

--- a/apps/web-platform/app/api/billing/portal/route.ts
+++ b/apps/web-platform/app/api/billing/portal/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getStripe } from "@/lib/stripe";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
-import { reportSilentFallback } from "@/server/observability";
+import { APP_URL_FALLBACK, reportSilentFallback } from "@/server/observability";
 
 export async function POST(request: Request) {
   const { valid, origin } = validateOrigin(request);
@@ -32,11 +32,11 @@ export async function POST(request: Request) {
     reportSilentFallback(null, {
       feature: "billing",
       op: "portal-session",
-      message: "NEXT_PUBLIC_APP_URL unset; billing portal return_url fallback to https://app.soleur.ai",
+      message: `NEXT_PUBLIC_APP_URL unset; billing portal return_url fallback to ${APP_URL_FALLBACK}`,
       extra: { userId: user.id },
     });
   }
-  const appOrigin = appUrl ?? "https://app.soleur.ai";
+  const appOrigin = appUrl ?? APP_URL_FALLBACK;
 
   const portalSession = await getStripe().billingPortal.sessions.create({
     customer: userData.stripe_customer_id,

--- a/apps/web-platform/app/api/billing/portal/route.ts
+++ b/apps/web-platform/app/api/billing/portal/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getStripe } from "@/lib/stripe";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
+import { reportSilentFallback } from "@/server/observability";
 
 export async function POST(request: Request) {
   const { valid, origin } = validateOrigin(request);
@@ -26,7 +27,16 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "No subscription" }, { status: 400 });
   }
 
-  const appOrigin = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.soleur.ai";
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+  if (!appUrl) {
+    reportSilentFallback(null, {
+      feature: "billing",
+      op: "portal-session",
+      message: "NEXT_PUBLIC_APP_URL unset; billing portal return_url fallback to https://app.soleur.ai",
+      extra: { userId: user.id },
+    });
+  }
+  const appOrigin = appUrl ?? "https://app.soleur.ai";
 
   const portalSession = await getStripe().billingPortal.sessions.create({
     customer: userData.stripe_customer_id,

--- a/apps/web-platform/app/api/checkout/route.ts
+++ b/apps/web-platform/app/api/checkout/route.ts
@@ -4,7 +4,7 @@ import { getStripe } from "@/lib/stripe";
 import { priceIdForTier } from "@/lib/stripe-price-tier-map";
 import type { PlanTier } from "@/lib/types";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
-import { reportSilentFallback } from "@/server/observability";
+import { APP_URL_FALLBACK, reportSilentFallback } from "@/server/observability";
 import logger from "@/server/logger";
 
 const VALID_TARGET_TIERS: PlanTier[] = ["solo", "startup", "scale", "enterprise"];
@@ -64,11 +64,11 @@ export async function POST(request: Request) {
     reportSilentFallback(null, {
       feature: "checkout",
       op: "create-session",
-      message: "NEXT_PUBLIC_APP_URL unset; checkout origin fallback to https://app.soleur.ai",
+      message: `NEXT_PUBLIC_APP_URL unset; checkout origin fallback to ${APP_URL_FALLBACK}`,
       extra: { userId: user.id },
     });
   }
-  const appOrigin = appUrl ?? "https://app.soleur.ai";
+  const appOrigin = appUrl ?? APP_URL_FALLBACK;
 
   const resolvedPriceId = targetTier
     ? priceIdForTier(targetTier)

--- a/apps/web-platform/app/api/checkout/route.ts
+++ b/apps/web-platform/app/api/checkout/route.ts
@@ -4,6 +4,7 @@ import { getStripe } from "@/lib/stripe";
 import { priceIdForTier } from "@/lib/stripe-price-tier-map";
 import type { PlanTier } from "@/lib/types";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
+import { reportSilentFallback } from "@/server/observability";
 import logger from "@/server/logger";
 
 const VALID_TARGET_TIERS: PlanTier[] = ["solo", "startup", "scale", "enterprise"];
@@ -58,7 +59,16 @@ export async function POST(request: Request) {
     );
   }
 
-  const appOrigin = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.soleur.ai";
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+  if (!appUrl) {
+    reportSilentFallback(null, {
+      feature: "checkout",
+      op: "create-session",
+      message: "NEXT_PUBLIC_APP_URL unset; checkout origin fallback to https://app.soleur.ai",
+      extra: { userId: user.id },
+    });
+  }
+  const appOrigin = appUrl ?? "https://app.soleur.ai";
 
   const resolvedPriceId = targetTier
     ? priceIdForTier(targetTier)

--- a/apps/web-platform/server/notifications.ts
+++ b/apps/web-platform/server/notifications.ts
@@ -9,7 +9,7 @@ import webpush from "web-push";
 import { Resend } from "resend";
 import { createServiceClient } from "@/lib/supabase/service";
 import { createChildLogger } from "@/server/logger";
-import { reportSilentFallback } from "@/server/observability";
+import { APP_URL_FALLBACK, reportSilentFallback } from "@/server/observability";
 
 const log = createChildLogger("notifications");
 
@@ -65,11 +65,11 @@ function appUrl(): string {
   if (!url) {
     reportSilentFallback(null, {
       feature: "notifications",
-      op: "appUrl",
-      message: "NEXT_PUBLIC_APP_URL unset; notification deep links fallback to https://app.soleur.ai",
+      op: "app-url",
+      message: `NEXT_PUBLIC_APP_URL unset; notification deep links fallback to ${APP_URL_FALLBACK}`,
     });
   }
-  return url ?? "https://app.soleur.ai";
+  return url ?? APP_URL_FALLBACK;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web-platform/server/notifications.ts
+++ b/apps/web-platform/server/notifications.ts
@@ -9,6 +9,7 @@ import webpush from "web-push";
 import { Resend } from "resend";
 import { createServiceClient } from "@/lib/supabase/service";
 import { createChildLogger } from "@/server/logger";
+import { reportSilentFallback } from "@/server/observability";
 
 const log = createChildLogger("notifications");
 
@@ -60,7 +61,15 @@ function getResend(): Resend {
 // App URL for deep links
 // ---------------------------------------------------------------------------
 function appUrl(): string {
-  return process.env.NEXT_PUBLIC_APP_URL || "https://app.soleur.ai";
+  const url = process.env.NEXT_PUBLIC_APP_URL;
+  if (!url) {
+    reportSilentFallback(null, {
+      feature: "notifications",
+      op: "appUrl",
+      message: "NEXT_PUBLIC_APP_URL unset; notification deep links fallback to https://app.soleur.ai",
+    });
+  }
+  return url ?? "https://app.soleur.ai";
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web-platform/server/observability.ts
+++ b/apps/web-platform/server/observability.ts
@@ -2,6 +2,15 @@ import * as Sentry from "@sentry/nextjs";
 import logger from "@/server/logger";
 
 /**
+ * Single source of truth for the literal app-origin used when
+ * `NEXT_PUBLIC_APP_URL` is unset. Matches prod; used by every
+ * `reportSilentFallback`-guarded fallback site so a future domain rename
+ * is a one-line change here (plus a Doppler update) rather than a repo-wide
+ * grep + 6-file edit.
+ */
+export const APP_URL_FALLBACK = "https://app.soleur.ai";
+
+/**
  * Options for a silent-fallback capture.
  *
  * - `feature`: required tag — used for Sentry search/filtering. Use the route

--- a/apps/web-platform/test/api-billing-portal.test.ts
+++ b/apps/web-platform/test/api-billing-portal.test.ts
@@ -4,16 +4,24 @@ import { describe, test, expect, vi, beforeEach } from "vitest";
 // Mocks — vi.hoisted ensures these are available when vi.mock factories run
 // ---------------------------------------------------------------------------
 
-const { mockGetUser, mockFrom, mockCreatePortalSession, mockValidateOrigin } =
-  vi.hoisted(() => ({
-    mockGetUser: vi.fn(),
-    mockFrom: vi.fn(),
-    mockCreatePortalSession: vi.fn(),
-    mockValidateOrigin: vi.fn(() => ({
-      valid: true,
-      origin: "https://app.soleur.ai",
-    })),
-  }));
+const {
+  mockGetUser,
+  mockFrom,
+  mockCreatePortalSession,
+  mockValidateOrigin,
+  mockCaptureException,
+  mockCaptureMessage,
+} = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+  mockCreatePortalSession: vi.fn(),
+  mockValidateOrigin: vi.fn(() => ({
+    valid: true,
+    origin: "https://app.soleur.ai",
+  })),
+  mockCaptureException: vi.fn(),
+  mockCaptureMessage: vi.fn(),
+}));
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({
@@ -37,6 +45,11 @@ vi.mock("@/lib/auth/validate-origin", () => ({
 
 vi.mock("@/server/logger", () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: mockCaptureException,
+  captureMessage: mockCaptureMessage,
 }));
 
 // ---------------------------------------------------------------------------
@@ -85,6 +98,7 @@ describe("POST /api/billing/portal", () => {
       origin: "https://app.soleur.ai",
     });
     mockCreatePortalSession.mockResolvedValue({ url: PORTAL_URL });
+    process.env.NEXT_PUBLIC_APP_URL = "https://test.example";
   });
 
   test("returns portal URL for authenticated user with stripe_customer_id", async () => {
@@ -130,5 +144,44 @@ describe("POST /api/billing/portal", () => {
 
     expect(res.status).toBe(403);
     expect(mockGetUser).not.toHaveBeenCalled();
+  });
+
+  test("degraded: NEXT_PUBLIC_APP_URL unset fires Sentry and uses literal fallback", async () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    setupAuthenticatedUser();
+    setupUserQuery({ stripe_customer_id: CUSTOMER_ID });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        level: "error",
+        tags: expect.objectContaining({ feature: "billing", op: "portal-session" }),
+      }),
+    );
+    expect(mockCreatePortalSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        return_url: "https://app.soleur.ai/dashboard/settings",
+      }),
+    );
+  });
+
+  test("happy: NEXT_PUBLIC_APP_URL set routes URL to Stripe and Sentry stays silent", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://test.example";
+    setupAuthenticatedUser();
+    setupUserQuery({ stripe_customer_id: CUSTOMER_ID });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+
+    expect(mockCaptureException).not.toHaveBeenCalled();
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+    expect(mockCreatePortalSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        return_url: "https://test.example/dashboard/settings",
+      }),
+    );
   });
 });

--- a/apps/web-platform/test/api-billing-portal.test.ts
+++ b/apps/web-platform/test/api-billing-portal.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach } from "vitest";
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Mocks — vi.hoisted ensures these are available when vi.mock factories run
@@ -98,7 +98,11 @@ describe("POST /api/billing/portal", () => {
       origin: "https://app.soleur.ai",
     });
     mockCreatePortalSession.mockResolvedValue({ url: PORTAL_URL });
-    process.env.NEXT_PUBLIC_APP_URL = "https://test.example";
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://test.example");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   test("returns portal URL for authenticated user with stripe_customer_id", async () => {
@@ -147,7 +151,7 @@ describe("POST /api/billing/portal", () => {
   });
 
   test("degraded: NEXT_PUBLIC_APP_URL unset fires Sentry and uses literal fallback", async () => {
-    delete process.env.NEXT_PUBLIC_APP_URL;
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", undefined);
     setupAuthenticatedUser();
     setupUserQuery({ stripe_customer_id: CUSTOMER_ID });
 
@@ -155,7 +159,7 @@ describe("POST /api/billing/portal", () => {
     expect(res.status).toBe(200);
 
     expect(mockCaptureMessage).toHaveBeenCalledWith(
-      expect.any(String),
+      expect.stringContaining("NEXT_PUBLIC_APP_URL unset"),
       expect.objectContaining({
         level: "error",
         tags: expect.objectContaining({ feature: "billing", op: "portal-session" }),
@@ -169,7 +173,7 @@ describe("POST /api/billing/portal", () => {
   });
 
   test("happy: NEXT_PUBLIC_APP_URL set routes URL to Stripe and Sentry stays silent", async () => {
-    process.env.NEXT_PUBLIC_APP_URL = "https://test.example";
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://test.example");
     setupAuthenticatedUser();
     setupUserQuery({ stripe_customer_id: CUSTOMER_ID });
 

--- a/apps/web-platform/test/api-checkout.test.ts
+++ b/apps/web-platform/test/api-checkout.test.ts
@@ -8,11 +8,14 @@ process.env.STRIPE_PRICE_ID = "price_legacy";
 // Mocks — vi.hoisted ensures these are available when vi.mock factories run
 // ---------------------------------------------------------------------------
 
-const { mockGetUser, mockFrom, mockCreateSession } = vi.hoisted(() => ({
-  mockGetUser: vi.fn(),
-  mockFrom: vi.fn(),
-  mockCreateSession: vi.fn(),
-}));
+const { mockGetUser, mockFrom, mockCreateSession, mockCaptureException, mockCaptureMessage } =
+  vi.hoisted(() => ({
+    mockGetUser: vi.fn(),
+    mockFrom: vi.fn(),
+    mockCreateSession: vi.fn(),
+    mockCaptureException: vi.fn(),
+    mockCaptureMessage: vi.fn(),
+  }));
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({
@@ -25,6 +28,11 @@ vi.mock("@/lib/stripe", () => ({
   getStripe: () => ({
     checkout: { sessions: { create: mockCreateSession } },
   }),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: mockCaptureException,
+  captureMessage: mockCaptureMessage,
 }));
 
 vi.mock("@/lib/auth/validate-origin", () => ({
@@ -76,6 +84,8 @@ describe("POST /api/checkout", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCreateSession.mockResolvedValue({ url: "https://checkout.stripe.com/session" });
+    // Default for existing tests — degraded-path test deletes below
+    process.env.NEXT_PUBLIC_APP_URL = "https://test.example";
   });
 
   test("reuses existing stripe_customer_id when available", async () => {
@@ -135,5 +145,44 @@ describe("POST /api/checkout", () => {
 
     expect(res.status).toBe(401);
     expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+
+  test("degraded: NEXT_PUBLIC_APP_URL unset fires Sentry and uses literal fallback", async () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    setupAuthenticatedUser();
+    setupUserQuery({ stripe_customer_id: CUSTOMER_ID, subscription_status: null });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        level: "error",
+        tags: expect.objectContaining({ feature: "checkout", op: "create-session" }),
+      }),
+    );
+    expect(mockCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        return_url: expect.stringMatching(/^https:\/\/app\.soleur\.ai\//),
+      }),
+    );
+  });
+
+  test("happy: NEXT_PUBLIC_APP_URL set routes URL to Stripe and Sentry stays silent", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://test.example";
+    setupAuthenticatedUser();
+    setupUserQuery({ stripe_customer_id: CUSTOMER_ID, subscription_status: null });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+
+    expect(mockCaptureException).not.toHaveBeenCalled();
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+    expect(mockCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        return_url: expect.stringMatching(/^https:\/\/test\.example\//),
+      }),
+    );
   });
 });

--- a/apps/web-platform/test/api-checkout.test.ts
+++ b/apps/web-platform/test/api-checkout.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach } from "vitest";
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Legacy STRIPE_PRICE_ID path is still exercised by these tests. Set the env
 // var before the route imports so priceIdForTier() fallback resolves cleanly.
@@ -84,8 +84,12 @@ describe("POST /api/checkout", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCreateSession.mockResolvedValue({ url: "https://checkout.stripe.com/session" });
-    // Default for existing tests — degraded-path test deletes below
-    process.env.NEXT_PUBLIC_APP_URL = "https://test.example";
+    // Default for existing tests — degraded-path test unsets below via vi.stubEnv(..., "")
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://test.example");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   test("reuses existing stripe_customer_id when available", async () => {
@@ -148,7 +152,7 @@ describe("POST /api/checkout", () => {
   });
 
   test("degraded: NEXT_PUBLIC_APP_URL unset fires Sentry and uses literal fallback", async () => {
-    delete process.env.NEXT_PUBLIC_APP_URL;
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", undefined);
     setupAuthenticatedUser();
     setupUserQuery({ stripe_customer_id: CUSTOMER_ID, subscription_status: null });
 
@@ -156,7 +160,7 @@ describe("POST /api/checkout", () => {
     expect(res.status).toBe(200);
 
     expect(mockCaptureMessage).toHaveBeenCalledWith(
-      expect.any(String),
+      expect.stringContaining("NEXT_PUBLIC_APP_URL unset"),
       expect.objectContaining({
         level: "error",
         tags: expect.objectContaining({ feature: "checkout", op: "create-session" }),
@@ -170,7 +174,7 @@ describe("POST /api/checkout", () => {
   });
 
   test("happy: NEXT_PUBLIC_APP_URL set routes URL to Stripe and Sentry stays silent", async () => {
-    process.env.NEXT_PUBLIC_APP_URL = "https://test.example";
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://test.example");
     setupAuthenticatedUser();
     setupUserQuery({ stripe_customer_id: CUSTOMER_ID, subscription_status: null });
 

--- a/apps/web-platform/test/github-resolve.test.ts
+++ b/apps/web-platform/test/github-resolve.test.ts
@@ -1,7 +1,10 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 
 // ---------------------------------------------------------------------------
-// Set env BEFORE any imports that read at load time
+// Set env BEFORE any imports that read at load time.
+// These are module-load defaults; per-test env is scoped via vi.stubEnv +
+// vi.unstubAllEnvs in the beforeEach/afterEach hooks below to prevent
+// cross-test pollution.
 // ---------------------------------------------------------------------------
 process.env.GITHUB_CLIENT_ID = "test-client-id";
 process.env.GITHUB_CLIENT_SECRET = "test-client-secret";
@@ -122,8 +125,12 @@ describe("GET /api/auth/github-resolve (initiate)", () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: "user-123" } } });
     // Guard against shell-leaked legacy env var; post-migration the route
     // reads NEXT_PUBLIC_APP_URL only.
-    delete process.env.NEXT_PUBLIC_SITE_URL;
-    delete process.env.NEXT_PUBLIC_APP_URL;
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", undefined);
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   test("returns 302 redirect to GitHub OAuth authorize URL", async () => {
@@ -171,8 +178,8 @@ describe("GET /api/auth/github-resolve (initiate)", () => {
   });
 
   test("reads NEXT_PUBLIC_APP_URL (not NEXT_PUBLIC_SITE_URL) for callback redirect_uri", async () => {
-    process.env.NEXT_PUBLIC_APP_URL = "https://test.example";
-    process.env.NEXT_PUBLIC_SITE_URL = "https://should-not-be-used.example";
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://test.example");
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://should-not-be-used.example");
 
     const response = await initiateHandler(makeInitiateRequest());
     const location = response.headers.get("Location")!;
@@ -195,8 +202,8 @@ describe("GET /api/auth/github-resolve/callback", () => {
 
     // Guard against shell-leaked legacy env var; post-migration the route
     // reads NEXT_PUBLIC_APP_URL only.
-    delete process.env.NEXT_PUBLIC_SITE_URL;
-    delete process.env.NEXT_PUBLIC_APP_URL;
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", undefined);
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", undefined);
 
     // Default: authenticated user
     mockGetUser.mockResolvedValue({
@@ -217,6 +224,7 @@ describe("GET /api/auth/github-resolve/callback", () => {
   afterEach(() => {
     clearFetchRoutes();
     globalThis.fetch = originalFetch;
+    vi.unstubAllEnvs();
   });
 
   test("stores github_username and redirects on valid code+state", async () => {

--- a/apps/web-platform/test/github-resolve.test.ts
+++ b/apps/web-platform/test/github-resolve.test.ts
@@ -26,6 +26,11 @@ vi.mock("@/server/logger", () => ({
   default: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
 
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
 // ---------------------------------------------------------------------------
 // URL-routing mock for global fetch (GitHub API calls)
 // ---------------------------------------------------------------------------
@@ -115,6 +120,10 @@ describe("GET /api/auth/github-resolve (initiate)", () => {
   beforeEach(() => {
     // Initiate route now checks auth (defense-in-depth)
     mockGetUser.mockResolvedValue({ data: { user: { id: "user-123" } } });
+    // Guard against shell-leaked legacy env var; post-migration the route
+    // reads NEXT_PUBLIC_APP_URL only.
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
   });
 
   test("returns 302 redirect to GitHub OAuth authorize URL", async () => {
@@ -160,6 +169,18 @@ describe("GET /api/auth/github-resolve (initiate)", () => {
     const location = response.headers.get("Location")!;
     expect(location).not.toContain("scope=");
   });
+
+  test("reads NEXT_PUBLIC_APP_URL (not NEXT_PUBLIC_SITE_URL) for callback redirect_uri", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://test.example";
+    process.env.NEXT_PUBLIC_SITE_URL = "https://should-not-be-used.example";
+
+    const response = await initiateHandler(makeInitiateRequest());
+    const location = response.headers.get("Location")!;
+    const redirectUri = new URL(location).searchParams.get("redirect_uri")!;
+
+    expect(redirectUri).toBe("https://test.example/api/auth/github-resolve/callback");
+    expect(redirectUri).not.toContain("should-not-be-used");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -171,6 +192,11 @@ describe("GET /api/auth/github-resolve/callback", () => {
     vi.clearAllMocks();
     clearFetchRoutes();
     globalThis.fetch = routingFetch;
+
+    // Guard against shell-leaked legacy env var; post-migration the route
+    // reads NEXT_PUBLIC_APP_URL only.
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
 
     // Default: authenticated user
     mockGetUser.mockResolvedValue({

--- a/apps/web-platform/test/notifications.test.ts
+++ b/apps/web-platform/test/notifications.test.ts
@@ -6,12 +6,16 @@ const {
   mockResendSend,
   mockFrom,
   mockAdminGetUserById,
+  mockCaptureException,
+  mockCaptureMessage,
 } = vi.hoisted(() => ({
   mockSendNotification: vi.fn(),
   mockSetVapidDetails: vi.fn(),
   mockResendSend: vi.fn(),
   mockFrom: vi.fn(),
   mockAdminGetUserById: vi.fn(),
+  mockCaptureException: vi.fn(),
+  mockCaptureMessage: vi.fn(),
 }));
 
 vi.mock("web-push", () => ({
@@ -38,12 +42,18 @@ vi.mock("@/lib/supabase/service", () => ({
 }));
 
 vi.mock("@/server/logger", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
   createChildLogger: () => ({
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
     debug: vi.fn(),
   }),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: mockCaptureException,
+  captureMessage: mockCaptureMessage,
 }));
 
 // Import after mocks
@@ -60,6 +70,8 @@ describe("notifications", () => {
     process.env.VAPID_PUBLIC_KEY = "test-public-key";
     process.env.VAPID_PRIVATE_KEY = "test-private-key";
     process.env.RESEND_API_KEY = "re_test_key";
+    // Default for existing tests — degraded-path test deletes below
+    process.env.NEXT_PUBLIC_APP_URL = "https://test.example";
   });
 
   describe("notifyOfflineUser", () => {
@@ -250,6 +262,45 @@ describe("notifications", () => {
 
       const call = mockResendSend.mock.calls[0][0];
       expect(call.html).toContain("/dashboard/chat/conv-123");
+    });
+
+    test("happy: NEXT_PUBLIC_APP_URL set appears in deep link and Sentry stays silent", async () => {
+      process.env.NEXT_PUBLIC_APP_URL = "https://test.example";
+      mockResendSend.mockResolvedValue({ data: { id: "msg-1" }, error: null });
+
+      await sendEmailNotification("test@example.com", {
+        type: "review_gate",
+        conversationId: "conv-happy",
+        agentName: "CEO",
+        question: "Approve budget?",
+      });
+
+      const call = mockResendSend.mock.calls[0][0];
+      expect(call.html).toContain("https://test.example/dashboard/chat/conv-happy");
+      expect(mockCaptureException).not.toHaveBeenCalled();
+      expect(mockCaptureMessage).not.toHaveBeenCalled();
+    });
+
+    test("degraded: NEXT_PUBLIC_APP_URL unset fires Sentry and uses literal fallback", async () => {
+      delete process.env.NEXT_PUBLIC_APP_URL;
+      mockResendSend.mockResolvedValue({ data: { id: "msg-1" }, error: null });
+
+      await sendEmailNotification("test@example.com", {
+        type: "review_gate",
+        conversationId: "conv-degraded",
+        agentName: "CEO",
+        question: "Approve budget?",
+      });
+
+      const call = mockResendSend.mock.calls[0][0];
+      expect(call.html).toContain("https://app.soleur.ai/dashboard/chat/conv-degraded");
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          level: "error",
+          tags: expect.objectContaining({ feature: "notifications", op: "appUrl" }),
+        }),
+      );
     });
   });
 });

--- a/apps/web-platform/test/notifications.test.ts
+++ b/apps/web-platform/test/notifications.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach } from "vitest";
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 
 const {
   mockSendNotification,
@@ -67,11 +67,15 @@ describe("notifications", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Reset env vars
-    process.env.VAPID_PUBLIC_KEY = "test-public-key";
-    process.env.VAPID_PRIVATE_KEY = "test-private-key";
-    process.env.RESEND_API_KEY = "re_test_key";
-    // Default for existing tests — degraded-path test deletes below
-    process.env.NEXT_PUBLIC_APP_URL = "https://test.example";
+    vi.stubEnv("VAPID_PUBLIC_KEY", "test-public-key");
+    vi.stubEnv("VAPID_PRIVATE_KEY", "test-private-key");
+    vi.stubEnv("RESEND_API_KEY", "re_test_key");
+    // Default for existing tests — degraded-path test unsets below
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://test.example");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   describe("notifyOfflineUser", () => {
@@ -265,7 +269,7 @@ describe("notifications", () => {
     });
 
     test("happy: NEXT_PUBLIC_APP_URL set appears in deep link and Sentry stays silent", async () => {
-      process.env.NEXT_PUBLIC_APP_URL = "https://test.example";
+      vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://test.example");
       mockResendSend.mockResolvedValue({ data: { id: "msg-1" }, error: null });
 
       await sendEmailNotification("test@example.com", {
@@ -282,7 +286,7 @@ describe("notifications", () => {
     });
 
     test("degraded: NEXT_PUBLIC_APP_URL unset fires Sentry and uses literal fallback", async () => {
-      delete process.env.NEXT_PUBLIC_APP_URL;
+      vi.stubEnv("NEXT_PUBLIC_APP_URL", undefined);
       mockResendSend.mockResolvedValue({ data: { id: "msg-1" }, error: null });
 
       await sendEmailNotification("test@example.com", {
@@ -295,10 +299,10 @@ describe("notifications", () => {
       const call = mockResendSend.mock.calls[0][0];
       expect(call.html).toContain("https://app.soleur.ai/dashboard/chat/conv-degraded");
       expect(mockCaptureMessage).toHaveBeenCalledWith(
-        expect.any(String),
+        expect.stringContaining("NEXT_PUBLIC_APP_URL unset"),
         expect.objectContaining({
           level: "error",
-          tags: expect.objectContaining({ feature: "notifications", op: "appUrl" }),
+          tags: expect.objectContaining({ feature: "notifications", op: "app-url" }),
         }),
       );
     });

--- a/knowledge-base/project/brainstorms/2026-04-22-app-url-hardening-brainstorm.md
+++ b/knowledge-base/project/brainstorms/2026-04-22-app-url-hardening-brainstorm.md
@@ -1,0 +1,96 @@
+---
+date: 2026-04-22
+topic: APP_URL hardening (PR #2767 follow-up bundle)
+status: complete
+---
+
+# Brainstorm: APP_URL Hardening
+
+Bundled scoping for the 3 deferrals and 2 follow-throughs that were filed during PR #2767 (the Doppler `prd` `NEXT_PUBLIC_APP_URL` missing-secret fix).
+
+## What We're Building
+
+A coherent cleanup of the `NEXT_PUBLIC_APP_URL` surface area:
+
+1. **Close verification follow-throughs** for PR #2767 (`#2773`, `#2774`) based on post-deploy Sentry silence.
+2. **Harden the two remaining silent `??` fallbacks** in billing and checkout routes so future misconfig fires to Sentry instead of degrading silently (`#2770`).
+3. **Consolidate `NEXT_PUBLIC_APP_URL` and `NEXT_PUBLIC_SITE_URL`** into a single canonical var; remove the duplicate from Doppler `prd` (`#2768`).
+4. **Add a pre-deploy CI guard** asserting every required `NEXT_PUBLIC_*` secret is present in Doppler `prd` (`#2769`).
+
+## Why This Approach
+
+PR #2767 fixed one symptom (one missing secret). These five issues together neutralise the **class of bug** — silent URL fallbacks that degrade payment-critical flows without a Sentry signal, and secrets missing from Doppler `prd` with no pre-deploy gate. The same configuration smell (two vars for one concept) is also what let the drift happen in the first place.
+
+Shipping this as two PRs keeps blast radius small while avoiding three separate deploy cycles:
+
+- **PR-A = `#2770` + `#2768`**: both touch URL env handling, coherent scope, one Doppler `prd` write (delete `NEXT_PUBLIC_SITE_URL`).
+- **PR-B = `#2769`**: workflow-level guard, orthogonal to app code, warrants isolated review.
+
+Verification issues `#2773` / `#2774` close immediately based on the passive Sentry result (see Pre-Work Findings below) — no code change needed.
+
+## Pre-Work Findings (Sentry passive verification)
+
+Sentry issue `114137538` (`SOLEUR-WEB-PLATFORM-H`) queried at `2026-04-22T17:01:54Z`, 8h38m post-deploy (`08:23Z`):
+
+- `count`: 1 (unchanged from pre-deploy baseline)
+- `firstSeen` == `lastSeen` == `2026-04-22T07:44:03Z` (pre-deploy firing, the one that motivated PR #2767)
+- `status`: unresolved
+
+Zero new events in ~9 hours with normal traffic. Passive signal is load-bearing. `#2773`'s "active trigger" step (login + start agent session) can ride on top of the next authenticated session an operator happens to run; if no event fires, close. `#2774` (docker exec printenv) is redundant per its own issue body ("if `#2773` confirms silence, this check is redundant and can be closed").
+
+## Key Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Split into two PRs: PR-A = `#2770`+`#2768`, PR-B = `#2769` | Blast-radius isolation — app code + Doppler write together, CI workflow separate |
+| 2 | Canonical var is `NEXT_PUBLIC_APP_URL`; migrate `github-resolve` away from `NEXT_PUBLIC_SITE_URL` | More consumers already on `APP_URL`; avoids a 2-step rename for the majority |
+| 3 | Deleting `NEXT_PUBLIC_SITE_URL` from Doppler `prd` requires explicit per-command ack | Per `hr-menu-option-ack-not-prod-write-auth`. No `--force` / menu-option shortcut. |
+| 4 | `#2770` Sentry mirror follows the `agent-runner.ts:675` pattern via `reportSilentFallback` | Matches `cq-silent-fallback-must-mirror-to-sentry`, consistent with 15 prior remediations (PR #2480/#2484) |
+| 5 | `#2769` required-secrets list is a **hand-maintained array** in the workflow, not auto-computed | YAGNI — auto-compute from Dockerfile ARGs + code grep is ~2x the code for zero detection-speed gain. The next missing secret still reveals the drift. |
+| 6 | `#2773` / `#2774` close on passive Sentry signal + opportunistic active trigger | Strong 9h zero-event baseline. Avoids burning a separate session on a login handoff for a redundant check. |
+| 7 | PR-A migration sequence: merge code → Doppler `secrets delete NEXT_PUBLIC_SITE_URL -c prd` as post-merge step, not pre-merge | Code must first stop reading the var, else the delete fires a 500. Runtime injection via `--env-file` rebuilds on deploy, so ordering is: ship code → wait for container restart → delete secret → verify env absent. |
+
+## Non-Goals
+
+- **No preview/per-branch URL handling.** `#2768`'s re-evaluation criterion explicitly calls out "when a preview env needs per-branch URLs" as the trigger to rethink. Not in scope.
+- **No migration away from `NEXT_PUBLIC_*` to runtime env.** Keep build-time injection; the Dockerfile `ARG` + runtime `--env-file` dual-path is intentional.
+- **No expansion of the CI guard to cover non-`NEXT_PUBLIC_*` secrets.** Scope is browser-exposed secrets only — the class that bit us in PR #2767.
+- **No auto-compute of required list for `#2769`.** Deferred indefinitely; re-evaluate only if the hand-maintained list drifts twice.
+
+## Open Questions
+
+None blocking. The following resolve during the plan phase:
+
+- Exact CI workflow to wire `#2769` into (candidate: new job in `.github/workflows/reusable-release.yml` gating the existing deploy job).
+- Whether to add a unit test for `#2770` that asserts `reportSilentFallback` is called when env is unset, or rely on the existing Sentry-mirror sweep tests.
+
+## Scope & Issue Map
+
+| Issue | Priority | Target PR | Closes via |
+|---|---|---|---|
+| `#2770` mirror `??` fallbacks to Sentry | p2 | PR-A | `Closes #2770` in PR-A body |
+| `#2768` consolidate `APP_URL`/`SITE_URL` | p3 | PR-A | `Closes #2768` in PR-A body |
+| `#2769` CI guard for required secrets | p2 | PR-B | `Closes #2769` in PR-B body |
+| `#2773` verify Sentry silence post-deploy | follow-through | none | Manual close with comment citing passive signal (this doc) |
+| `#2774` verify prod container env | follow-through | none | Manual close with comment citing redundancy per issue body |
+
+## Risks
+
+- **R1 — Doppler `prd` delete fires a 500 if any consumer still reads `NEXT_PUBLIC_SITE_URL`.** Mitigation: Decision #7 sequencing. Grep after merge to confirm zero remaining readers before the delete.
+- **R2 — The CI guard itself depends on a `DOPPLER_TOKEN_PRD` service token that must be scoped to `prd` config.** Per `cq-doppler-service-tokens-are-per-config`. The existing deploy job already has this wired; reuse it.
+- **R3 — The hand-maintained required-list in `#2769` will drift if a future PR adds a new `NEXT_PUBLIC_*` without updating the array.** Accepted — the first missing-secret firing is the drift signal, same detection speed as auto-compute.
+
+## Domain Assessments
+
+**Assessed:** Engineering (inline). No other domain consulted — this is a scoped infra/observability chore bundle, no user-facing capability, no marketing/product/legal/sales/finance/support implications (per `hr-new-skills-agents-or-user-facing`, CPO/CMO gates apply to user-facing capabilities, which this is not).
+
+### Engineering (inline assessment)
+
+**Summary:** Three well-scoped hardening changes with small code footprint and established patterns (`reportSilentFallback`, Doppler CI checks). Primary architectural risk is the Doppler `prd` delete ordering — addressed via Decision #7. No new dependencies, no schema changes, no migrations.
+
+## Artifacts
+
+- Brainstorm: this file
+- Spec: `knowledge-base/project/specs/feat-app-url-hardening/spec.md`
+- Prior session context: `knowledge-base/project/specs/feat-one-shot-next-public-app-url-unset/session-state.md` (PR #2767 deferrals)
+- Relevant rules: `cq-silent-fallback-must-mirror-to-sentry`, `hr-menu-option-ack-not-prod-write-auth`, `cq-doppler-service-tokens-are-per-config`, `hr-exhaust-all-automated-options-before`

--- a/knowledge-base/project/learnings/best-practices/2026-04-22-passive-sentry-signal-closes-followthrough-verification.md
+++ b/knowledge-base/project/learnings/best-practices/2026-04-22-passive-sentry-signal-closes-followthrough-verification.md
@@ -1,0 +1,59 @@
+---
+date: 2026-04-22
+category: best-practices
+module: observability
+tags: [sentry, verification, follow-through, post-deploy, brainstorm]
+triggered_by_pr: 2767
+related_issues: [2773, 2774]
+---
+
+# Passive Sentry signal closes follow-through verification issues
+
+## Problem
+
+`/ship` Phase 7 Step 3.5 files follow-through issues for post-deploy verification (e.g., `#2773` "verify Sentry issue count unchanged" and `#2774` "verify env var in prod container"). These issues prescribe an **active trigger** — authenticated user session + explicit `POST /api/repo/setup` + wait 10 min + re-query Sentry. Closing them requires an auth handoff to the operator, which frequently costs a separate session.
+
+In practice the active trigger is usually redundant when the passive signal is already overwhelmingly strong.
+
+## Solution
+
+Query Sentry passively first; if the signal is strong, close the follow-through with a comment citing the numeric evidence rather than scheduling an active-trigger session.
+
+**Passive signal is strong when all of:**
+
+- Time since deploy is materially larger than the issue's original firing cadence (e.g., ≥8× the pre-deploy `lastSeen → firstSeen` delta, or ≥4 hours for a low-frequency issue).
+- `count` is unchanged from pre-deploy baseline.
+- `firstSeen == lastSeen` and both predate the deploy timestamp (no new events have been grouped into the issue).
+- `status` is still `unresolved` (not auto-resolved by Sentry heuristics, which would mask a re-fire).
+
+**Example from PR #2767 follow-up (`#2773`, queried 8h38m post-deploy):**
+
+```text
+shortId:   SOLEUR-WEB-PLATFORM-H
+count:     1                    (unchanged)
+firstSeen: 2026-04-22T07:44:03Z (pre-deploy)
+lastSeen:  2026-04-22T07:44:03Z (pre-deploy, == firstSeen)
+status:    unresolved
+```
+
+All four criteria met → close `#2773` with a comment citing the four values. `#2774` (docker exec printenv) closes transitively per its own body ("if `#2773` confirms silence, this check is redundant").
+
+**Passive signal is NOT strong enough when:**
+
+- Any criterion above fails.
+- The fix targeted a low-traffic code path that may not fire without the active trigger (e.g., a specific user action gated by auth).
+- The issue category is something Sentry re-groups aggressively (rare; usually a separate problem).
+
+## Key Insight
+
+Follow-through verification issues default to prescribing an active trigger because the `/ship` phase-7 template doesn't know which signal will be strongest post-deploy. The operator reviewing the follow-through has more information (actual post-deploy traffic, actual Sentry state) and should bypass the active trigger when the passive signal makes it redundant.
+
+**Do not** close a follow-through "just because it's been a while" — anchor the close to the four numeric criteria above.
+
+**Do not** burn an auth-handoff session on the active trigger when passive is already conclusive. Auth handoffs cost a full operator context-switch; redundant ones are pure overhead.
+
+## Related
+
+- Rule: `cq-for-production-debugging-use` — Sentry API is the primary observability surface for prod debugging.
+- Rule: `hr-when-a-workflow-concludes-with-an-actionable-next-step` — bias toward executing the automatable step rather than listing it.
+- Prior follow-through pattern: `/ship` Phase 7 Step 3.5 creates these issues via the daily follow-through monitor.

--- a/knowledge-base/project/plans/2026-04-22-chore-app-url-hardening-pr-a-plan.md
+++ b/knowledge-base/project/plans/2026-04-22-chore-app-url-hardening-pr-a-plan.md
@@ -1,0 +1,202 @@
+---
+title: "chore: app-url hardening PR-A (Sentry-mirror silent fallbacks + consolidate NEXT_PUBLIC_APP_URL)"
+type: chore
+date: 2026-04-22
+bundle: feat-app-url-hardening
+closes: [2770, 2768]
+related: [2769, 2773, 2774]
+pr: 2793
+---
+
+# chore: app-url hardening PR-A
+
+Bundles `#2770` (Sentry-mirror silent `??` URL fallbacks) and `#2768` (consolidate `NEXT_PUBLIC_APP_URL` / `NEXT_PUBLIC_SITE_URL`) into one PR. `#2769` (CI guard) ships as PR-B. `#2773` / `#2774` close out of band with a Sentry passive-signal comment.
+
+## Overview
+
+Two coupled cleanups from PR #2767:
+
+1. **Silent-fallback mirroring.** Plan-time grep found **three** silent-fallback sites (issue #2770 names two). All three get `reportSilentFallback` mirroring per `cq-silent-fallback-must-mirror-to-sentry`.
+2. **Env var consolidation.** Migrate the two `NEXT_PUBLIC_SITE_URL` consumers in `github-resolve/*.ts` to `NEXT_PUBLIC_APP_URL`; delete the duplicate secret from Doppler `prd` post-merge via explicit per-command ack (`hr-menu-option-ack-not-prod-write-auth`).
+
+Pattern reference: the existing `reportSilentFallback` call in `apps/web-platform/server/agent-runner.ts` (around line 682, `feature: "kb-share"`, `op: "baseUrl"`).
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Spec claim | Reality (2026-04-22, verified) | Plan response |
+|---|---|---|
+| `checkout/route.ts:33` has the fallback | Actually at line **61** | Symbol anchor, not line number |
+| `billing/portal/route.ts:29` has the fallback | Confirmed line 29 | OK |
+| `agent-runner.ts:675` reference | Actually line **682** | Mirror the runtime call shape, not the line |
+| "Two API routes fall back silently" (#2770) | **Three** sites fall back silently — `checkout`, `billing/portal`, `server/notifications.ts` (the third uses `\|\|`, same literal, no Sentry mirror) | **Fold `notifications.ts` into PR-A** — same rule violation, same literal, trivial cost |
+| `NEXT_PUBLIC_SITE_URL` has two consumers | Confirmed: `github-resolve/route.ts:15`, `github-resolve/callback/route.ts:163`. No other prod consumers. | Post-migration sweep: `rg NEXT_PUBLIC_SITE_URL apps/ server/ lib/` → zero hits |
+| Tests will need creating | **All four test files already exist** (`test/api-checkout.test.ts`, `test/api-billing-portal.test.ts`, `test/notifications.test.ts`, `test/github-resolve.test.ts`); reference `observability.test.ts` from PR #2487 | Edit existing files, create zero new ones |
+| `@sentry/nextjs` mocked in route tests | **Not mocked** in any of the four files | First RED-phase task per file is the Sentry mock setup |
+
+## Scope Decisions
+
+### Folded in beyond issue #2770
+
+- **`apps/web-platform/server/notifications.ts`** — `|| "https://app.soleur.ai"` silent fallback. Plan-time grep found 3 sites when issue named 2; the sharp-edge advice is to widen to match the grep, not trust the enumerated list. Rule violation is identical (`cq-silent-fallback-must-mirror-to-sentry`).
+
+### Explicitly out of PR-A
+
+- `middleware.ts` `NEXT_PUBLIC_SUPABASE_URL ?? ""` — different feature; empty-string fail is loud, not silent.
+- `server/github-app.ts` / `connect-repo/page.tsx` `NEXT_PUBLIC_GITHUB_APP_SLUG ?? "soleur-ai"` — fallback literal is the correct prod slug; config sanity-check, not a silent degradation.
+- `#2769` CI guard — separate PR-B.
+- `#2773`/`#2774` follow-throughs — close out-of-band with Sentry passive-signal comment (see `knowledge-base/project/learnings/best-practices/2026-04-22-passive-sentry-signal-closes-followthrough-verification.md`).
+
+## Implementation Phases
+
+### Phase 1 — TDD RED (tests before implementation, per `cq-write-failing-tests-before`)
+
+**Sentry mock factory shape (apply to all four test files):**
+
+```ts
+vi.mock("@sentry/nextjs", async (orig) => ({
+  ...(await orig<object>()),
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+```
+
+Partial mock via `...(await orig())` preserves `init` / `withSentryConfig` at import time — a full replacement risks breaking the observability module's own import graph (Kieran plan-review finding).
+
+- [ ] 1.1 `test/api-checkout.test.ts`
+  - [ ] 1.1.1 Add the Sentry partial-mock above. Hoist captured mocks via `vi.hoisted` if the test file's existing mocks use that pattern.
+  - [ ] 1.1.2 **Degraded path (new RED):** `given NEXT_PUBLIC_APP_URL unset, when POST /api/checkout runs, then captureException/captureMessage fires with tags { feature: "checkout", op: "create-session" }` AND `then stripe.checkout.sessions.create was called with success_url matching /^https:\/\/app\.soleur\.ai\// (the fallback literal)`.
+  - [ ] 1.1.3 **Happy path (anti-tautology per `cq-mutation-assertions-pin-exact-post-state`):** `given NEXT_PUBLIC_APP_URL = "https://test.example", when POST /api/checkout runs, then captureException/captureMessage NOT called AND stripe.checkout.sessions.create.success_url starts with "https://test.example/"`. The positive URL assertion is load-bearing — a silent mutation that forgets to use env would otherwise pass the "not called" assertion.
+- [ ] 1.2 `test/api-billing-portal.test.ts` — symmetrical to 1.1: `feature: "billing"`, `op: "portal-session"`. Happy path asserts `billingPortal.sessions.create.return_url` uses env value.
+- [ ] 1.3 `test/notifications.test.ts`
+  - [ ] 1.3.1 Add Sentry partial-mock.
+  - [ ] 1.3.2 Read `server/notifications.ts` to determine the callsite's operation name. Name the op after the function containing the fallback (e.g., `op: "origin"` or `op: "webpush-base"` depending on the site). Decide at implementation-start by reading the file, not at plan time.
+  - [ ] 1.3.3 Degraded-path + happy-path pair, same anti-tautology shape as 1.1.2 / 1.1.3.
+- [ ] 1.4 `test/github-resolve.test.ts`
+  - [ ] 1.4.1 Every `describe`/`it` block must `beforeEach` clear `process.env.NEXT_PUBLIC_SITE_URL` (`delete process.env.NEXT_PUBLIC_SITE_URL`). Without this guard, a shell-leaked value would silently satisfy the legacy code path and hide the migration's RED state.
+  - [ ] 1.4.2 Switch every test that previously stubbed `NEXT_PUBLIC_SITE_URL` to stub `NEXT_PUBLIC_APP_URL` instead. These tests fail against current `main` until Phase 2 migration lands.
+- [ ] 1.5 From `apps/web-platform/`: `./node_modules/.bin/vitest run test/api-checkout.test.ts test/api-billing-portal.test.ts test/notifications.test.ts test/github-resolve.test.ts` — confirm every new/updated assertion **fails**. Per `cq-in-worktrees-run-vitest-via-node-node`, never `npx vitest run`.
+
+### Phase 2 — TDD GREEN (minimal implementation)
+
+Open `apps/web-platform/server/agent-runner.ts` once for reference (the `reportSilentFallback` call near the `kb-share baseUrl` guard). Mirror that call shape.
+
+- [ ] 2.1 `app/api/checkout/route.ts` — rewrite the `appOrigin` line as `if (!appUrl) reportSilentFallback(null, { feature: "checkout", op: "create-session", message: "NEXT_PUBLIC_APP_URL unset; checkout origin fallback to https://app.soleur.ai" })` followed by `const appOrigin = appUrl ?? "https://app.soleur.ai"`. Keep the call inline inside the handler (`cq-nextjs-route-files-http-only-exports`).
+- [ ] 2.2 `app/api/billing/portal/route.ts` — same pattern, `feature: "billing"`, `op: "portal-session"`.
+- [ ] 2.3 `server/notifications.ts` — same pattern using the op name decided in 1.3.2. **Rewrite the `||` to `??`** — `||` also falls back on `""` and `0`, but for a URL env var, `""` is semantically identical to unset; the stricter `??` matches the other two sites and keeps the class consistent.
+- [ ] 2.4 `app/api/auth/github-resolve/route.ts` — rename local `siteUrl` → `appUrl`; read `process.env.NEXT_PUBLIC_APP_URL`. Preserve the fallback literal.
+- [ ] 2.5 `app/api/auth/github-resolve/callback/route.ts` — same migration inside `redirectWithDeletedCookie`.
+- [ ] 2.6 Re-run the Phase 1.5 vitest command — all assertions green.
+
+### Phase 3 — Typecheck, build, completeness sweeps
+
+- [ ] 3.1 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit`.
+- [ ] 3.2 `cd apps/web-platform && ./node_modules/.bin/next build` — catches route-file export constraints `tsc` misses (`cq-nextjs-route-files-http-only-exports`).
+- [ ] 3.3 **SITE_URL sweep:** `rg NEXT_PUBLIC_SITE_URL apps/ server/ lib/` → zero hits in production code. Test-fixture hits asserting absence are OK.
+- [ ] 3.4 **Brute-force completeness sweep (Kieran finding):** `rg '"https://app\.soleur\.ai"' apps/ server/ lib/` → expect only five hits, each in one of the five files touched by this PR. This is the deterministic proof that no silent-fallback site was missed (covers single-quoted, backtick-quoted, destructured-default, and variable-indirection patterns that a narrower regex would miss).
+- [ ] 3.5 **Enumerated read-check:** For any remaining `rg 'process\.env\.NEXT_PUBLIC_APP_URL' apps/ server/ lib/` hit that reads the env var, open the file and verify a `reportSilentFallback` sits in the enclosing `if (!...)` branch, or the read is guaranteed-set (e.g., middleware with a hard failure). Regex cannot assert "same function/same block" — this is the manual final pass.
+- [ ] 3.6 Full `apps/web-platform` test suite: `./node_modules/.bin/vitest run` — zero regressions.
+
+### Phase 4 — Ship
+
+- [ ] 4.1 Run `/soleur:ship`. It handles: markdownlint-fix on changed files, commit, push, QA, multi-agent review, resolve findings inline, mark ready, `gh pr merge --squash --auto`, poll until MERGED, verify release workflow succeeds.
+- [ ] 4.2 Pre-ship, ensure PR #2793 body contains:
+  - `Closes #2770` and `Closes #2768` on separate lines (not in title, per `wg-use-closes-n-in-pr-body-not-title-to`)
+  - `## Changelog` section per plugin AGENTS.md
+  - Note that `#2769` ships as PR-B and `#2773`/`#2774` close out-of-band
+- [ ] 4.3 Pre-ship, set labels: `semver:patch` + `type/security` (inherit from #2770's labels; surfaces security-scan runners).
+
+### Phase 5 — Post-merge: Doppler `prd` delete + follow-through closure
+
+**Destructive prod write — per `hr-menu-option-ack-not-prod-write-auth`, show the exact command verbatim and wait for explicit per-command go-ahead. Never pass `--force`/`--yes`.**
+
+- [ ] 5.1 Confirm Web Platform Release run for PR-A's merge commit finished green end-to-end (deploy-webhook verify, not just build).
+- [ ] 5.2 **Deterministic "new code running" check:** SSH to prod host and run `docker inspect soleur-web-platform | jq -r '.[0].Config.Labels["org.opencontainers.image.revision"]'` — the commit SHA must match PR-A's merge commit. Then `docker exec soleur-web-platform printenv NEXT_PUBLIC_APP_URL` — expect `https://app.soleur.ai`. This is read-only diagnosis, allowed per `cq-for-production-debugging-use`.
+- [ ] 5.3 Present delete command for explicit per-command ack:
+
+  ```text
+  doppler secrets delete NEXT_PUBLIC_SITE_URL --project soleur --config prd
+  ```
+
+  Wait for operator go-ahead. Menu-option / plan-accept is NOT authorization. After ack, run the command — the Doppler CLI's native interactive confirmation will surface.
+- [ ] 5.4 Verify deletion: `doppler secrets get NEXT_PUBLIC_SITE_URL -p soleur -c prd --plain --silent` exits non-zero. The deletion is inert for the currently-running container (prod code no longer reads `NEXT_PUBLIC_SITE_URL` — verified by 3.3); no forced redeploy needed.
+- [ ] 5.5 Close `#2773` with a comment citing the Sentry passive-signal evidence from the brainstorm (`count`=1, `firstSeen`==`lastSeen`=`2026-04-22T07:44:03Z`, queried ≥8h post-deploy, zero new events). Link to learning `best-practices/2026-04-22-passive-sentry-signal-closes-followthrough-verification.md`. Close `#2774` with a one-line comment: "Redundant per issue body — #2773 confirmed Sentry silence and Phase 5.2 confirmed `NEXT_PUBLIC_APP_URL` in prod container env."
+
+## Files to Edit
+
+**Production code (5):**
+
+- `apps/web-platform/app/api/checkout/route.ts`
+- `apps/web-platform/app/api/billing/portal/route.ts`
+- `apps/web-platform/server/notifications.ts` (fold-in)
+- `apps/web-platform/app/api/auth/github-resolve/route.ts`
+- `apps/web-platform/app/api/auth/github-resolve/callback/route.ts`
+
+**Tests (4):**
+
+- `apps/web-platform/test/api-checkout.test.ts`
+- `apps/web-platform/test/api-billing-portal.test.ts`
+- `apps/web-platform/test/notifications.test.ts`
+- `apps/web-platform/test/github-resolve.test.ts`
+
+## Files to Create
+
+None. All test files already exist.
+
+## Open Code-Review Overlap
+
+**None.** Query against 27 open `code-review` issues returned zero hits on any planned file path.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] `rg NEXT_PUBLIC_SITE_URL apps/ server/ lib/` returns zero hits in production code.
+- [ ] `rg '"https://app\.soleur\.ai"' apps/ server/ lib/` returns exactly five hits — one per file touched by this PR (completeness guarantee).
+- [ ] `rg reportSilentFallback apps/web-platform/app/api/checkout/route.ts apps/web-platform/app/api/billing/portal/route.ts apps/web-platform/server/notifications.ts` returns ≥1 hit per file.
+- [ ] Degraded-path tests (1.1.2/1.2/1.3.3) assert BOTH (a) `captureException`/`captureMessage` fires with correct tags AND (b) downstream call uses the fallback URL.
+- [ ] Happy-path tests assert BOTH (a) `captureException`/`captureMessage` NOT called AND (b) downstream call uses the env-derived URL (anti-tautology per `cq-mutation-assertions-pin-exact-post-state`).
+- [ ] Full `apps/web-platform` vitest suite passes with zero regressions.
+- [ ] `tsc --noEmit` and `next build` both pass.
+- [ ] PR body contains `Closes #2770` and `Closes #2768`, a `## Changelog` section, and `semver:patch` + `type/security` labels.
+- [ ] Multi-agent review (`/soleur:review`) pass with findings resolved inline.
+
+### Post-merge (operator)
+
+- [ ] Web Platform Release workflow for merge commit succeeded end-to-end.
+- [ ] `docker inspect` image revision label matches PR-A merge commit SHA AND `docker exec … printenv NEXT_PUBLIC_APP_URL` returns `https://app.soleur.ai` (deterministic proof of new code running).
+- [ ] `doppler secrets delete NEXT_PUBLIC_SITE_URL --project soleur --config prd` executed with explicit per-command go-ahead.
+- [ ] `doppler secrets get NEXT_PUBLIC_SITE_URL -p soleur -c prd --plain` exits non-zero.
+- [ ] `#2773` closed with Sentry-passive-signal comment + learning link.
+- [ ] `#2774` closed as redundant with cross-reference to `#2773`.
+
+## Risks / Sharp Edges
+
+1. **Doppler `prd` delete ordering.** Deleting `NEXT_PUBLIC_SITE_URL` before the prod container restarts with migrated code would 500 `github-resolve`. Mitigated by Phase 5 sequencing (merge → release green → deterministic code-running check → ack → delete → verify absence). AC 5.2 is the gate.
+
+2. **Sentry mock import-graph drift.** Naive `vi.mock("@sentry/nextjs", { ... })` can break `init`/`withSentryConfig` at import time and cascade into every test file that transitively imports the observability module. Mitigation: the exact partial-mock factory spelled out in Phase 1 (`async (orig) => ({ ...(await orig()), captureException: vi.fn(), captureMessage: vi.fn() })`). Also verify `server/observability.ts` does not export constants consumed by the four test files (`cq-test-mocked-module-constant-import`) before shipping.
+
+3. **Completeness of the silent-fallback sweep.** Regex cannot prove absence of pathological patterns (backtick-quoted fallbacks, destructured defaults, variable-indirection, multi-line wrap). The brute-force `rg '"https://app\.soleur\.ai"'` in Phase 3.4 is the closest we get to deterministic — every hit of the literal must live in one of the five files. Any surprise hit = triage before ship.
+
+## Domain Review
+
+**Domains relevant:** none (carry-forward from brainstorm's `## Domain Assessments` — Engineering assessed inline).
+
+No cross-domain implications — observability + config hygiene chore with no user-facing UI, no schema, no pricing/legal/marketing signal. Mechanical escalation scan: Files to Create = 0, zero `components/**/*.tsx` / `app/**/page.tsx` / `app/**/layout.tsx` paths. **Product/UX Tier: NONE.** UX gate skipped.
+
+## Test Strategy
+
+- **Runner:** vitest via `apps/web-platform/node_modules/.bin/vitest run` (`cq-in-worktrees-run-vitest-via-node-node`).
+- **Pattern per test file:** degraded-path (env unset → Sentry fires AND fallback URL used) + happy-path (env set → Sentry silent AND env URL used). Both assertions are load-bearing — one without the other permits silent regressions (finding: Kieran #3).
+- **Sentry mock:** partial via `await orig()` spread, replacing only `captureException` / `captureMessage`.
+- **Build-time validation:** `next build` catches route-file export constraint violations.
+- **Framework:** vitest (existing convention — no new test dependencies).
+
+## References
+
+- Brainstorm: `knowledge-base/project/brainstorms/2026-04-22-app-url-hardening-brainstorm.md`
+- Spec: `knowledge-base/project/specs/feat-app-url-hardening/spec.md`
+- Prior PR: #2767 (original APP_URL missing-secret fix)
+- Prior sweeps: #2480, #2484, #2487 (`reportSilentFallback` rollout + `observability.test.ts`)
+- New learning (2026-04-22): `knowledge-base/project/learnings/best-practices/2026-04-22-passive-sentry-signal-closes-followthrough-verification.md`
+- Rules: `cq-silent-fallback-must-mirror-to-sentry`, `hr-menu-option-ack-not-prod-write-auth`, `cq-write-failing-tests-before`, `cq-in-worktrees-run-vitest-via-node-node`, `cq-nextjs-route-files-http-only-exports`, `cq-mutation-assertions-pin-exact-post-state`, `cq-test-mocked-module-constant-import`, `wg-use-closes-n-in-pr-body-not-title-to`, `cq-for-production-debugging-use`, `cq-code-comments-symbol-anchors-not-line-numbers`
+- Bundled issues: `#2770`, `#2768` (closed by this PR); `#2773`, `#2774` (closed out-of-band); `#2769` (PR-B).

--- a/knowledge-base/project/specs/feat-app-url-hardening/spec.md
+++ b/knowledge-base/project/specs/feat-app-url-hardening/spec.md
@@ -1,0 +1,127 @@
+# Feature: APP_URL Hardening
+
+Bundled cleanup of the five `NEXT_PUBLIC_APP_URL` follow-ups from PR #2767 (issues `#2768`, `#2769`, `#2770`, `#2773`, `#2774`).
+
+## Problem Statement
+
+PR #2767 fixed one symptom: `NEXT_PUBLIC_APP_URL` was missing from Doppler `prd`, causing a Sentry error. The underlying class of bug is still open:
+
+1. Two env vars (`NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_SITE_URL`) represent the same logical value and can drift independently.
+2. Two API routes (`checkout`, `billing/portal`) still degrade silently with `?? "https://app.soleur.ai"` — no Sentry signal when misconfig recurs.
+3. No pre-deploy CI gate asserts that required `NEXT_PUBLIC_*` secrets exist in Doppler `prd`.
+4. Post-deploy verification of PR #2767 (`#2773`, `#2774`) is outstanding.
+
+## Goals
+
+- Single canonical var for app origin; zero code reading `NEXT_PUBLIC_SITE_URL`; no `NEXT_PUBLIC_SITE_URL` secret in Doppler `prd`.
+- Every `NEXT_PUBLIC_APP_URL` read site either throws, returns an error, or calls `reportSilentFallback` — no undisguised `??` fallback.
+- CI fails before deploy when any required `NEXT_PUBLIC_*` secret is absent from Doppler `prd`.
+- `#2773` and `#2774` closed with cited passive Sentry evidence.
+
+## Non-Goals
+
+- Preview-env per-branch URLs (see `#2768` re-evaluation criterion).
+- Migrating away from build-time `NEXT_PUBLIC_*` injection.
+- Guard coverage for non-`NEXT_PUBLIC_*` secrets.
+- Auto-computing the required-secrets list from Dockerfile / code grep (YAGNI — deferred unless hand-maintained list drifts twice).
+
+## Functional Requirements
+
+### FR1: Sentry-mirror both silent URL fallbacks (`#2770`)
+
+`apps/web-platform/app/api/checkout/route.ts` and `apps/web-platform/app/api/billing/portal/route.ts` must, when `process.env.NEXT_PUBLIC_APP_URL` is unset:
+
+- Call `reportSilentFallback(null, { feature: "checkout" | "billing", op: "appOrigin", message: "NEXT_PUBLIC_APP_URL unset; origin fallback to https://app.soleur.ai" })` from `@/server/observability`.
+- Proceed with the literal fallback `"https://app.soleur.ai"` (unchanged behavior).
+
+Pattern reference: `apps/web-platform/server/agent-runner.ts` (look up the `reportSilentFallback` call there).
+
+### FR2: Consolidate `NEXT_PUBLIC_APP_URL` as canonical (`#2768`)
+
+- Migrate `apps/web-platform/app/api/auth/github-resolve/route.ts` and `apps/web-platform/app/api/auth/github-resolve/callback/route.ts` to read `NEXT_PUBLIC_APP_URL` instead of `NEXT_PUBLIC_SITE_URL`.
+- After the code change ships and the prod container restarts, delete `NEXT_PUBLIC_SITE_URL` from Doppler `prd` via explicit per-command ack (per `hr-menu-option-ack-not-prod-write-auth`).
+- No other consumers of `NEXT_PUBLIC_SITE_URL` may remain — verified via `rg NEXT_PUBLIC_SITE_URL` after the migration (zero hits in `apps/`, `server/`, `lib/`).
+
+### FR3: Pre-deploy required-secrets CI guard (`#2769`)
+
+A CI job that runs **before** the web-platform deploy step and fails the deploy if any secret in a hand-maintained required-list is absent from Doppler `prd`:
+
+```bash
+REQUIRED=(
+  NEXT_PUBLIC_APP_URL
+  NEXT_PUBLIC_SUPABASE_URL
+  NEXT_PUBLIC_SUPABASE_ANON_KEY
+  NEXT_PUBLIC_SENTRY_DSN
+  NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  NEXT_PUBLIC_GITHUB_APP_SLUG
+)
+```
+
+(The final list is determined at plan time after grepping current `process.env.NEXT_PUBLIC_*` usage; `NEXT_PUBLIC_SITE_URL` is omitted because FR2 removes it.)
+
+Failing the job must emit a `::error::` line naming the missing secret and exit non-zero.
+
+### FR4: Close `#2773` / `#2774` with passive evidence
+
+- `#2773`: Close with a comment citing the Sentry query result — `count` unchanged at 1, `firstSeen == lastSeen == 2026-04-22T07:44:03Z` (pre-deploy), queried ≥8h post-deploy.
+- `#2774`: Close with a comment noting redundancy per the issue's own body ("if `#2773` confirms silence, this check is redundant and can be closed").
+- If the plan opts to do an active trigger (authenticated session → `POST /api/repo/setup`) for extra assurance, the Sentry re-query must occur ≥10 minutes after the trigger before closing `#2773`.
+
+## Technical Requirements
+
+### TR1: PR split
+
+- **PR-A** implements FR1 + FR2. Closes `#2770`, `#2768`.
+- **PR-B** implements FR3. Closes `#2769`.
+- `#2773` / `#2774` close out of band with comment-only updates (FR4), not tied to either PR.
+
+### TR2: Doppler `prd` write ordering
+
+The `NEXT_PUBLIC_SITE_URL` deletion (FR2) must happen **after** PR-A merges and the prod container has restarted with the migrated code. Sequence:
+
+1. Merge PR-A.
+2. Wait for Web Platform Release workflow to succeed.
+3. Verify `docker exec soleur-web-platform printenv NEXT_PUBLIC_SITE_URL` still returns the current value (container running with old env injection but new code that doesn't read it).
+4. Run `doppler secrets delete NEXT_PUBLIC_SITE_URL --project soleur --config prd` — show verbatim, wait for per-command go-ahead (`hr-menu-option-ack-not-prod-write-auth`).
+5. Next deploy propagates the deletion; verify absence via a subsequent `printenv` check.
+
+### TR3: CI guard wiring
+
+- New job in `.github/workflows/reusable-release.yml` or a dedicated `verify-doppler-secrets.yml` called as a prerequisite. Exact location decided at plan time.
+- Uses `DOPPLER_TOKEN_PRD` (per-config service token — `cq-doppler-service-tokens-are-per-config`). Must not use bare `DOPPLER_TOKEN`.
+- Must block the deploy job via `needs:` dependency, not run in parallel.
+
+### TR4: Tests
+
+- FR1: Unit tests for `checkout/route.ts` and `billing/portal/route.ts` asserting `reportSilentFallback` is called when `NEXT_PUBLIC_APP_URL` is unset. Follow existing mirror-pattern tests from PR #2480/#2484.
+- FR2: Unit tests for the migrated `github-resolve` routes verifying they read from `NEXT_PUBLIC_APP_URL`.
+- FR3: A shell-level sanity test (local dry-run of the guard script with a known-present secret) is sufficient; the workflow itself is the acceptance test on the next deploy run.
+
+### TR5: Rules compliance
+
+- `cq-silent-fallback-must-mirror-to-sentry` — FR1 is the primary remediation.
+- `hr-menu-option-ack-not-prod-write-auth` — TR2 step 4.
+- `cq-doppler-service-tokens-are-per-config` — TR3.
+- `hr-exhaust-all-automated-options-before` — FR4 uses Sentry API (automated), not SSH.
+- `cq-for-production-debugging-use` — Sentry API is the primary verification surface for FR4.
+
+## Acceptance Criteria
+
+- [ ] PR-A merged; `rg NEXT_PUBLIC_SITE_URL apps/ server/ lib/` returns zero.
+- [ ] `reportSilentFallback` grep in `checkout/route.ts` and `billing/portal/route.ts` each return ≥1 hit.
+- [ ] `NEXT_PUBLIC_SITE_URL` absent from `doppler secrets --project soleur --config prd --only-names`.
+- [ ] PR-B merged; manually trigger the new workflow; `gh run view` shows the guard job passed.
+- [ ] `#2770`, `#2768`, `#2769` closed via PR body `Closes #N`.
+- [ ] `#2773`, `#2774` closed with comment citing Sentry passive evidence.
+
+## Risks
+
+- **Doppler delete fires before container restart** → 500s on `github-resolve` routes if old code is still running. Mitigated by TR2 step ordering.
+- **CI guard required-list drifts** (future `NEXT_PUBLIC_*` added without array update). Accepted: next missing-secret firing reveals the drift, same signal as auto-compute.
+
+## References
+
+- Brainstorm: `knowledge-base/project/brainstorms/2026-04-22-app-url-hardening-brainstorm.md`
+- Prior PR: #2767
+- Prior session-state: `knowledge-base/project/specs/feat-one-shot-next-public-app-url-unset/session-state.md`
+- Issues: `#2768`, `#2769`, `#2770`, `#2773`, `#2774`

--- a/knowledge-base/project/specs/feat-app-url-hardening/tasks.md
+++ b/knowledge-base/project/specs/feat-app-url-hardening/tasks.md
@@ -1,0 +1,63 @@
+# Tasks: feat-app-url-hardening PR-A
+
+Derived from `knowledge-base/project/plans/2026-04-22-chore-app-url-hardening-pr-a-plan.md`.
+
+Closes `#2770`, `#2768`. Out-of-band closes `#2773`, `#2774` post-merge. `#2769` ships as PR-B (separate plan).
+
+## Phase 1: TDD RED — failing tests first
+
+- [ ] 1.1 `test/api-checkout.test.ts`
+  - [ ] 1.1.1 Add `@sentry/nextjs` partial mock (`async (orig) => ({ ...(await orig()), captureException: vi.fn(), captureMessage: vi.fn() })`)
+  - [ ] 1.1.2 Degraded-path test: env unset → Sentry fires with `{feature: "checkout", op: "create-session"}` AND Stripe `success_url` uses `https://app.soleur.ai` fallback
+  - [ ] 1.1.3 Happy-path test: env set → Sentry NOT called AND Stripe `success_url` uses env-derived URL (anti-tautology)
+- [ ] 1.2 `test/api-billing-portal.test.ts` — symmetrical to 1.1, `feature: "billing"`, `op: "portal-session"`, assert `return_url`
+- [ ] 1.3 `test/notifications.test.ts`
+  - [ ] 1.3.1 Add Sentry partial mock
+  - [ ] 1.3.2 Read `server/notifications.ts` and decide op name (likely `"origin"` or `"webpush-base"`)
+  - [ ] 1.3.3 Degraded + happy-path pair with positive URL assertion
+- [ ] 1.4 `test/github-resolve.test.ts`
+  - [ ] 1.4.1 `beforeEach`: `delete process.env.NEXT_PUBLIC_SITE_URL` in every describe block (absence guard against shell leak)
+  - [ ] 1.4.2 Migrate all `NEXT_PUBLIC_SITE_URL` env stubs → `NEXT_PUBLIC_APP_URL`
+- [ ] 1.5 Run `cd apps/web-platform && ./node_modules/.bin/vitest run test/api-checkout.test.ts test/api-billing-portal.test.ts test/notifications.test.ts test/github-resolve.test.ts` — confirm RED
+
+## Phase 2: TDD GREEN — implementation
+
+- [ ] 2.1 `app/api/checkout/route.ts` — add `if (!appUrl) reportSilentFallback(null, {feature: "checkout", op: "create-session", message})` above the literal fallback
+- [ ] 2.2 `app/api/billing/portal/route.ts` — same pattern, `feature: "billing"`, `op: "portal-session"`
+- [ ] 2.3 `server/notifications.ts` — same pattern + rewrite `||` to `??`
+- [ ] 2.4 `app/api/auth/github-resolve/route.ts` — `NEXT_PUBLIC_SITE_URL` → `NEXT_PUBLIC_APP_URL`, rename local `siteUrl` → `appUrl`
+- [ ] 2.5 `app/api/auth/github-resolve/callback/route.ts` — same migration in `redirectWithDeletedCookie`
+- [ ] 2.6 Re-run 1.5 vitest command — confirm GREEN
+
+## Phase 3: Typecheck, build, completeness sweeps
+
+- [ ] 3.1 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit`
+- [ ] 3.2 `cd apps/web-platform && ./node_modules/.bin/next build` (catches route-file export violations)
+- [ ] 3.3 `rg NEXT_PUBLIC_SITE_URL apps/ server/ lib/` → zero hits in production code
+- [ ] 3.4 `rg '"https://app\.soleur\.ai"' apps/ server/ lib/` → exactly 5 hits (one per touched file) — brute-force completeness guarantee
+- [ ] 3.5 Enumerated read-check: each remaining `process.env.NEXT_PUBLIC_APP_URL` hit is either gated by `reportSilentFallback` in enclosing `if` OR guaranteed-set
+- [ ] 3.6 Full suite: `cd apps/web-platform && ./node_modules/.bin/vitest run` — zero regressions
+
+## Phase 4: Ship
+
+- [ ] 4.1 Ensure PR #2793 body contains `Closes #2770`, `Closes #2768` (separate lines), `## Changelog` section
+- [ ] 4.2 Set labels: `semver:patch`, `type/security`
+- [ ] 4.3 Run `/soleur:ship` (handles markdownlint-fix, commit, push, QA, review, resolve, mark-ready, auto-merge, release verify)
+
+## Phase 5: Post-merge operator actions (destructive prod writes)
+
+- [ ] 5.1 Confirm Web Platform Release workflow for PR-A merge commit succeeded end-to-end
+- [ ] 5.2 SSH diagnostic (deterministic code-running proof):
+  - [ ] 5.2.1 `docker inspect soleur-web-platform | jq -r '.[0].Config.Labels["org.opencontainers.image.revision"]'` matches PR-A merge commit SHA
+  - [ ] 5.2.2 `docker exec soleur-web-platform printenv NEXT_PUBLIC_APP_URL` returns `https://app.soleur.ai`
+- [ ] 5.3 Present delete command verbatim + wait for explicit per-command ack: `doppler secrets delete NEXT_PUBLIC_SITE_URL --project soleur --config prd`
+- [ ] 5.4 After ack, run the delete. Doppler CLI native confirmation will surface.
+- [ ] 5.5 Verify absence: `doppler secrets get NEXT_PUBLIC_SITE_URL -p soleur -c prd --plain --silent` exits non-zero
+- [ ] 5.6 Close `#2773` with Sentry passive-signal comment + link to learning `best-practices/2026-04-22-passive-sentry-signal-closes-followthrough-verification.md`
+- [ ] 5.7 Close `#2774` as redundant: "Closing per issue body — #2773 confirmed Sentry silence; Phase 5.2 confirmed env var in prod container"
+
+## Out of scope (tracked elsewhere)
+
+- `#2769` CI guard for required `NEXT_PUBLIC_*` secrets → PR-B, separate plan
+- `middleware.ts` `NEXT_PUBLIC_SUPABASE_URL ?? ""` — different feature, fails loud
+- `server/github-app.ts` + `connect-repo/page.tsx` `NEXT_PUBLIC_GITHUB_APP_SLUG ?? "soleur-ai"` — fallback is correct prod slug

--- a/knowledge-base/project/specs/feat-app-url-hardening/tasks.md
+++ b/knowledge-base/project/specs/feat-app-url-hardening/tasks.md
@@ -28,7 +28,8 @@ Closes `#2770`, `#2768`. Out-of-band closes `#2773`, `#2774` post-merge. `#2769`
 - [x] 2.4 `app/api/auth/github-resolve/route.ts` — `NEXT_PUBLIC_SITE_URL` → `NEXT_PUBLIC_APP_URL`, rename local `siteUrl` → `appUrl`
 - [x] 2.5 `app/api/auth/github-resolve/callback/route.ts` — same migration in `redirectWithDeletedCookie`
 - [x] 2.6 **Scope expansion surfaced by Phase 3.5 sweep:** add `reportSilentFallback` to both `github-resolve/route.ts` (feature: `"github-resolve"`, op: `"initiate"`) and `github-resolve/callback/route.ts` (op: `"callback-redirect"`) — the migration preserved an existing silent-fallback pattern; per `cq-silent-fallback-must-mirror-to-sentry` every `NEXT_PUBLIC_APP_URL` fallback site must mirror. Closes the class fully.
-- [x] 2.7 Re-run 1.5 vitest command — confirm GREEN
+- [x] 2.7 **Review-driven inline fixes (post-commit e009241f):** rename `notifications` op `"appUrl"` → `"app-url"` (kebab-case parity); add `extra: { userId }` to github-resolve initiate; tighten Sentry message assertions to `stringContaining("NEXT_PUBLIC_APP_URL unset")`; switch tests to `vi.stubEnv`/`vi.unstubAllEnvs` for env-restore; extract `APP_URL_FALLBACK` constant in `server/observability.ts` (simplicity-reviewer minimum — full helper extract deferred); migrate ux-audit tooling (`bot-signin.ts`, `route-list.yaml`, `ux-audit/SKILL.md`, `preflight/SKILL.md`) from `NEXT_PUBLIC_SITE_URL` → `NEXT_PUBLIC_APP_URL` so post-merge Doppler delete doesn't break tooling.
+- [x] 2.8 Re-run 1.5 vitest command — confirm GREEN
 
 ## Phase 3: Typecheck, build, completeness sweeps
 

--- a/knowledge-base/project/specs/feat-app-url-hardening/tasks.md
+++ b/knowledge-base/project/specs/feat-app-url-hardening/tasks.md
@@ -6,37 +6,38 @@ Closes `#2770`, `#2768`. Out-of-band closes `#2773`, `#2774` post-merge. `#2769`
 
 ## Phase 1: TDD RED — failing tests first
 
-- [ ] 1.1 `test/api-checkout.test.ts`
-  - [ ] 1.1.1 Add `@sentry/nextjs` partial mock (`async (orig) => ({ ...(await orig()), captureException: vi.fn(), captureMessage: vi.fn() })`)
-  - [ ] 1.1.2 Degraded-path test: env unset → Sentry fires with `{feature: "checkout", op: "create-session"}` AND Stripe `success_url` uses `https://app.soleur.ai` fallback
-  - [ ] 1.1.3 Happy-path test: env set → Sentry NOT called AND Stripe `success_url` uses env-derived URL (anti-tautology)
-- [ ] 1.2 `test/api-billing-portal.test.ts` — symmetrical to 1.1, `feature: "billing"`, `op: "portal-session"`, assert `return_url`
-- [ ] 1.3 `test/notifications.test.ts`
-  - [ ] 1.3.1 Add Sentry partial mock
-  - [ ] 1.3.2 Read `server/notifications.ts` and decide op name (likely `"origin"` or `"webpush-base"`)
-  - [ ] 1.3.3 Degraded + happy-path pair with positive URL assertion
-- [ ] 1.4 `test/github-resolve.test.ts`
-  - [ ] 1.4.1 `beforeEach`: `delete process.env.NEXT_PUBLIC_SITE_URL` in every describe block (absence guard against shell leak)
-  - [ ] 1.4.2 Migrate all `NEXT_PUBLIC_SITE_URL` env stubs → `NEXT_PUBLIC_APP_URL`
-- [ ] 1.5 Run `cd apps/web-platform && ./node_modules/.bin/vitest run test/api-checkout.test.ts test/api-billing-portal.test.ts test/notifications.test.ts test/github-resolve.test.ts` — confirm RED
+- [x] 1.1 `test/api-checkout.test.ts`
+  - [x] 1.1.1 Add `@sentry/nextjs` partial mock (`async (orig) => ({ ...(await orig()), captureException: vi.fn(), captureMessage: vi.fn() })`)
+  - [x] 1.1.2 Degraded-path test: env unset → Sentry fires with `{feature: "checkout", op: "create-session"}` AND Stripe `success_url` uses `https://app.soleur.ai` fallback
+  - [x] 1.1.3 Happy-path test: env set → Sentry NOT called AND Stripe `success_url` uses env-derived URL (anti-tautology)
+- [x] 1.2 `test/api-billing-portal.test.ts` — symmetrical to 1.1, `feature: "billing"`, `op: "portal-session"`, assert `return_url`
+- [x] 1.3 `test/notifications.test.ts`
+  - [x] 1.3.1 Add Sentry partial mock
+  - [x] 1.3.2 Read `server/notifications.ts` and decide op name (likely `"origin"` or `"webpush-base"`)
+  - [x] 1.3.3 Degraded + happy-path pair with positive URL assertion
+- [x] 1.4 `test/github-resolve.test.ts`
+  - [x] 1.4.1 `beforeEach`: `delete process.env.NEXT_PUBLIC_SITE_URL` in every describe block (absence guard against shell leak)
+  - [x] 1.4.2 Migrate all `NEXT_PUBLIC_SITE_URL` env stubs → `NEXT_PUBLIC_APP_URL`
+- [x] 1.5 Run `cd apps/web-platform && ./node_modules/.bin/vitest run test/api-checkout.test.ts test/api-billing-portal.test.ts test/notifications.test.ts test/github-resolve.test.ts` — confirm RED
 
 ## Phase 2: TDD GREEN — implementation
 
-- [ ] 2.1 `app/api/checkout/route.ts` — add `if (!appUrl) reportSilentFallback(null, {feature: "checkout", op: "create-session", message})` above the literal fallback
-- [ ] 2.2 `app/api/billing/portal/route.ts` — same pattern, `feature: "billing"`, `op: "portal-session"`
-- [ ] 2.3 `server/notifications.ts` — same pattern + rewrite `||` to `??`
-- [ ] 2.4 `app/api/auth/github-resolve/route.ts` — `NEXT_PUBLIC_SITE_URL` → `NEXT_PUBLIC_APP_URL`, rename local `siteUrl` → `appUrl`
-- [ ] 2.5 `app/api/auth/github-resolve/callback/route.ts` — same migration in `redirectWithDeletedCookie`
-- [ ] 2.6 Re-run 1.5 vitest command — confirm GREEN
+- [x] 2.1 `app/api/checkout/route.ts` — add `if (!appUrl) reportSilentFallback(null, {feature: "checkout", op: "create-session", message})` above the literal fallback
+- [x] 2.2 `app/api/billing/portal/route.ts` — same pattern, `feature: "billing"`, `op: "portal-session"`
+- [x] 2.3 `server/notifications.ts` — same pattern + rewrite `||` to `??`
+- [x] 2.4 `app/api/auth/github-resolve/route.ts` — `NEXT_PUBLIC_SITE_URL` → `NEXT_PUBLIC_APP_URL`, rename local `siteUrl` → `appUrl`
+- [x] 2.5 `app/api/auth/github-resolve/callback/route.ts` — same migration in `redirectWithDeletedCookie`
+- [x] 2.6 **Scope expansion surfaced by Phase 3.5 sweep:** add `reportSilentFallback` to both `github-resolve/route.ts` (feature: `"github-resolve"`, op: `"initiate"`) and `github-resolve/callback/route.ts` (op: `"callback-redirect"`) — the migration preserved an existing silent-fallback pattern; per `cq-silent-fallback-must-mirror-to-sentry` every `NEXT_PUBLIC_APP_URL` fallback site must mirror. Closes the class fully.
+- [x] 2.7 Re-run 1.5 vitest command — confirm GREEN
 
 ## Phase 3: Typecheck, build, completeness sweeps
 
-- [ ] 3.1 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit`
-- [ ] 3.2 `cd apps/web-platform && ./node_modules/.bin/next build` (catches route-file export violations)
-- [ ] 3.3 `rg NEXT_PUBLIC_SITE_URL apps/ server/ lib/` → zero hits in production code
-- [ ] 3.4 `rg '"https://app\.soleur\.ai"' apps/ server/ lib/` → exactly 5 hits (one per touched file) — brute-force completeness guarantee
-- [ ] 3.5 Enumerated read-check: each remaining `process.env.NEXT_PUBLIC_APP_URL` hit is either gated by `reportSilentFallback` in enclosing `if` OR guaranteed-set
-- [ ] 3.6 Full suite: `cd apps/web-platform && ./node_modules/.bin/vitest run` — zero regressions
+- [x] 3.1 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit`
+- [x] 3.2 `cd apps/web-platform && ./node_modules/.bin/next build` (catches route-file export violations)
+- [x] 3.3 `rg NEXT_PUBLIC_SITE_URL apps/ server/ lib/` → zero hits in production code
+- [x] 3.4 `rg '"https://app\.soleur\.ai"' apps/ server/ lib/` → exactly 5 hits (one per touched file) — brute-force completeness guarantee
+- [x] 3.5 Enumerated read-check: each remaining `process.env.NEXT_PUBLIC_APP_URL` hit is either gated by `reportSilentFallback` in enclosing `if` OR guaranteed-set
+- [x] 3.6 Full suite: `cd apps/web-platform && ./node_modules/.bin/vitest run` — zero regressions
 
 ## Phase 4: Ship
 

--- a/plugins/soleur/skills/brainstorm/SKILL.md
+++ b/plugins/soleur/skills/brainstorm/SKILL.md
@@ -248,12 +248,13 @@ Ensure the brainstorms directory exists before writing.
 
 1. **Check for existing issue reference in feature_description:**
 
-   Parse the feature description for `#N` patterns (e.g., `#42`). Extract the first issue number found.
+   Parse the feature description for `#N` patterns (e.g., `#42`). Extract **all** issue numbers found (not just the first — bundle brainstorms commonly reference 3-5 related issues).
 
-   **If issue reference found**, validate its state by running `gh issue view <number> --json state` and pipe to `jq .state`:
+   **If one or more issue references found**, validate each via `gh issue view <number> --json state` + `jq .state`:
 
-   - **If OPEN:** Use existing issue -- skip creation, proceed to step 3
-   - **If CLOSED:** Warn the user, then create a new issue with "Replaces closed #N" in the body (proceed to step 2)
+   - **Single OPEN issue:** Use it as the tracking issue -- skip creation, proceed to step 3 (link artifacts back to this issue).
+   - **Multiple OPEN issues (bundle):** Do not create a new umbrella issue. In step 3, append a "Bundled scoping" note linking brainstorm + spec + branch + draft PR to **each** of the referenced issues. The brainstorm/spec themselves serve as the bundle's single source of truth.
+   - **If CLOSED:** Warn the user, then create a new issue with "Replaces closed #N" in the body (proceed to step 2).
    - **If not found or error:** Use AskUserQuestion: "Issue #N not found. Create new issue anyway?" If yes, proceed to step 2. If no, abort.
 
 2. **Create GitHub issue** (only if no valid existing issue):
@@ -274,7 +275,7 @@ Ensure the brainstorms directory exists before writing.
 
 3. **Update existing issue with artifact links** (if using existing issue):
 
-   Fetch the existing issue body with `gh issue view <number> --json body` piped to `jq .body`. Append an Artifacts section with links to the brainstorm document, spec file, and branch name. Then update with `gh issue edit <number> --body "<updated body>"`.
+   Fetch the existing issue body with `gh issue view <number> --json body` piped to `jq .body`. Append an Artifacts (or "Bundled scoping") section with links to the brainstorm document, spec file, branch name, and draft PR. Then update with `gh issue edit <number> --body-file -` reading stdin. For bundles, loop over every referenced issue and append the same note to each.
 
 4. **Generate spec.md** using `spec-templates` skill template:
    - Fill in Problem Statement from brainstorm

--- a/plugins/soleur/skills/preflight/SKILL.md
+++ b/plugins/soleur/skills/preflight/SKILL.md
@@ -107,7 +107,7 @@ If no relevant files changed, return **SKIP**.
 **Step 2.2: Get production URL from Doppler.**
 
 ```bash
-doppler secrets get NEXT_PUBLIC_SITE_URL -p soleur -c prd --plain
+doppler secrets get NEXT_PUBLIC_APP_URL -p soleur -c prd --plain
 ```
 
 If no URL is available, return **SKIP** with note: "Production URL not available."

--- a/plugins/soleur/skills/ux-audit/SKILL.md
+++ b/plugins/soleur/skills/ux-audit/SKILL.md
@@ -38,7 +38,7 @@ Dry-run toggle: export `UX_AUDIT_DRY_RUN=true` before launching Claude Code. The
 
 Env vars required (loaded from Doppler `prd_scheduled`, falling back to `prd`):
 
-- `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `NEXT_PUBLIC_SITE_URL` — from `prd`
+- `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `NEXT_PUBLIC_APP_URL` — from `prd`
 - `UX_AUDIT_BOT_EMAIL`, `UX_AUDIT_BOT_PASSWORD` — from `prd_scheduled`
 - `UX_AUDIT_DRY_RUN` — `true` writes findings JSON to stdout + workflow artifact; `false` files issues
 - `GH_TOKEN` — for `gh issue create` / `gh issue list`

--- a/plugins/soleur/skills/ux-audit/references/route-list.yaml
+++ b/plugins/soleur/skills/ux-audit/references/route-list.yaml
@@ -4,7 +4,7 @@
 # ux-design-lead (audit mode) for 5-category rubric analysis.
 #
 # Fields:
-#   path             URL path, relative to NEXT_PUBLIC_SITE_URL
+#   path             URL path, relative to NEXT_PUBLIC_APP_URL
 #   auth             "anonymous" (no session) | "bot" (authenticated as ux-audit-bot@jikigai.com)
 #   fixture_prereqs  required state before navigating — if unmet, route is skipped with a logged reason
 #                    (bot-fixture.ts seed idempotently satisfies: tcs_accepted, billing_active, chat_conversations)

--- a/plugins/soleur/skills/ux-audit/scripts/bot-signin.ts
+++ b/plugins/soleur/skills/ux-audit/scripts/bot-signin.ts
@@ -8,7 +8,7 @@
  * Env:
  *   SUPABASE_URL                    prd
  *   NEXT_PUBLIC_SUPABASE_ANON_KEY   prd
- *   NEXT_PUBLIC_SITE_URL            prd                (domain for the cookie)
+ *   NEXT_PUBLIC_APP_URL             prd                (domain for the cookie)
  *   UX_AUDIT_BOT_EMAIL              prd_scheduled
  *   UX_AUDIT_BOT_PASSWORD           prd_scheduled
  *   UX_AUDIT_STORAGE_STATE          (optional)         output path override
@@ -97,7 +97,7 @@ async function main() {
   const session = await signIn();
 
   const ref = projectRef(env("SUPABASE_URL"));
-  const domain = cookieDomain(env("NEXT_PUBLIC_SITE_URL"));
+  const domain = cookieDomain(env("NEXT_PUBLIC_APP_URL"));
   const cookieName = `sb-${ref}-auth-token`;
 
   const storageState = {


### PR DESCRIPTION
## Summary

Bundled cleanup of the `NEXT_PUBLIC_APP_URL` observability + config-hygiene class exposed by PR #2767. Part of `feat-app-url-hardening`; PR-B (#2769 CI guard) ships separately.

- **Silent-fallback → Sentry mirroring** at 5 sites (issue #2770 named 2; plan-time grep + Phase 3.5 sweep found 3 more, all folded in per `cq-silent-fallback-must-mirror-to-sentry`):
  - `apps/web-platform/app/api/checkout/route.ts`
  - `apps/web-platform/app/api/billing/portal/route.ts`
  - `apps/web-platform/server/notifications.ts` (plan-time audit)
  - `apps/web-platform/app/api/auth/github-resolve/route.ts` (Phase 3.5 sweep)
  - `apps/web-platform/app/api/auth/github-resolve/callback/route.ts` (Phase 3.5 sweep)
- **Env-var consolidation:** two `github-resolve` routes migrated `NEXT_PUBLIC_SITE_URL` → `NEXT_PUBLIC_APP_URL`. `ux-audit` tooling + preflight skill migrated same direction so post-merge Doppler delete is safe.
- **Tests:** `@sentry/nextjs` mock + degraded/happy-path assertions in 4 existing test files; happy-path pins env-derived URL in Stripe/email/redirect calls (anti-tautology per `cq-mutation-assertions-pin-exact-post-state`).
- **Constant:** `APP_URL_FALLBACK` in `server/observability.ts` as single source of truth (simplicity-reviewer minimum; full helper extract declined — DISSENT on scope-out filing).

Follow-throughs `#2773` (Sentry passive-signal) and `#2774` (prod container env) close out-of-band post-merge with a comment citing the passive evidence (see `knowledge-base/project/learnings/best-practices/2026-04-22-passive-sentry-signal-closes-followthrough-verification.md`).

## Review

Plan reviewed by DHH / Kieran / Simplicity (plan-phase); code reviewed by 6 post-impl agents + semgrep (security-sentinel, architecture-strategist, pattern-recognition-specialist, code-quality-analyst, test-design-reviewer, semgrep-sast, code-simplicity-reviewer). **Zero P1 findings. Zero semgrep findings.** Consensus P2s fixed inline (commit 63cd2da7). One scope-out filed: #2800 (pre-existing-unrelated, CONCUR'd).

## Post-merge operator checklist

1. Confirm Web Platform Release for the merge commit succeeded.
2. SSH + `docker inspect` image SHA matches merge commit; `docker exec … printenv NEXT_PUBLIC_APP_URL` returns `https://app.soleur.ai`.
3. Present verbatim + wait for per-command ack (`hr-menu-option-ack-not-prod-write-auth`): `doppler secrets delete NEXT_PUBLIC_SITE_URL --project soleur --config prd`.
4. Verify: `doppler secrets get NEXT_PUBLIC_SITE_URL -p soleur -c prd --plain --silent` exits non-zero.
5. Close `#2773` with Sentry passive-signal comment + learning link.
6. Close `#2774` as redundant (cross-ref #2773).

## Quality gates

- vitest: 2254 tests passed, 11 skipped, 0 failed
- `tsc --noEmit`: clean
- `next build`: compiled in 23.7s
- semgrep (custom + p/typescript + p/owasp-top-ten): 0 findings
- `rg NEXT_PUBLIC_SITE_URL apps/ server/ lib/ plugins/`: zero prod hits (only test-fixture negative guards)

## Changelog

### Observability

- Silent `NEXT_PUBLIC_APP_URL` fallbacks in checkout, billing, notifications, and github-resolve now mirror to Sentry (tag: `feature=<route>`, `op=<action>`).

### Config

- `NEXT_PUBLIC_SITE_URL` retired in favour of the single canonical `NEXT_PUBLIC_APP_URL`. Post-merge operator action: delete `NEXT_PUBLIC_SITE_URL` from Doppler `prd`.

## Test plan

- [x] All new + existing tests pass locally
- [x] `tsc --noEmit` passes
- [x] `next build` compiles
- [x] Multi-agent review pass complete, findings resolved inline or scope-out filed
- [ ] Post-merge operator runs the Doppler delete (Phase 5 checklist above)

Closes #2770
Closes #2768

🤖 Generated with [Claude Code](https://claude.com/claude-code)
