### PR TITLE
refactor(marketing): drain 2026-04-21 SEO/AEO audit backlog

### DIFF
--- a/apps/web-platform/app/layout.tsx
+++ b/apps/web-platform/app/layout.tsx
@@ -4,9 +4,16 @@ import { SwRegister } from "./sw-register";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Soleur — One Command Center, 8 Departments",
+  // Scoped to the dashboard surface so the Next.js app (served under
+  // /dashboard/*) and the Eleventy marketing site (served at /) never present
+  // conflicting brand claims to crawlers or preview tools. The marketing brand
+  // line lives in plugins/soleur/docs/index.njk seoTitle. See #2708.
+  title: {
+    template: "%s — Soleur Dashboard",
+    default: "Soleur Dashboard — Your Command Center",
+  },
   description:
-    "One command center for your entire business. AI agents across 8 departments plan, execute, and compound knowledge — so you can focus on the decisions only you can make.",
+    "Your Soleur command center — manage subscriptions, review agent output, and configure your AI organization.",
   icons: {
     apple: "/icons/apple-touch-icon.png",
   },

--- a/apps/web-platform/app/manifest.ts
+++ b/apps/web-platform/app/manifest.ts
@@ -2,10 +2,10 @@ import type { MetadataRoute } from "next";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "Soleur — One Command Center, 8 Departments",
+    name: "Soleur Dashboard — Your Command Center",
     short_name: "Soleur",
     description:
-      "One command center for your entire business. AI agents across 8 departments plan, execute, and compound knowledge.",
+      "Your Soleur command center — manage subscriptions, review agent output, and configure your AI organization.",
     start_url: "/",
     display: "standalone",
     background_color: "#0a0a0a",

--- a/knowledge-base/project/learnings/2026-04-22-multi-agent-review-catches-aeo-semantic-drift.md
+++ b/knowledge-base/project/learnings/2026-04-22-multi-agent-review-catches-aeo-semantic-drift.md
@@ -1,0 +1,63 @@
+# Learning: multi-agent review catches AEO semantic drift that drift-guard tests accept
+
+## Problem
+
+PR #2794 shipped the 2026-04-21 AEO audit drain (closed #2707+#2708+#2709+#2711). The initial implementation:
+
+1. Added `https://www.linkedin.com/company/jikigai/` to `site.author.sameAs` — a Company URL under a Person's sameAs graph claim.
+2. Wrote drift-guard assertions `expect(author.sameAs.length).toBeGreaterThanOrEqual(2)` against a 3-element array — tautologically passes if anyone deletes an entry.
+3. Regex-matched `<img src="/images/jean-deruelle.(jpg|png|svg)"` without asserting the file exists in `_site/images/` — a deleted image ships a broken `<img>` and the test still passes.
+4. Dropped sentences from FAQ JSON-LD `acceptedAnswer.text` (Q1/Q3/Q5 on /pricing/) that appeared in visible `<details>` — positioning content only humans could read.
+5. JSON-LD Person node had `image` + `sameAs` but not `description` or `knowsAbout`, while the visible author card rendered bio and credentials — audience split.
+6. New `@id: /about/#jean-deruelle` referenced an anchor that did not exist on `about.njk`.
+
+The 26/26 unit test suite (`plugins/soleur/test/seo-aeo-drift-guard.test.ts`) was GREEN with all six defects present.
+
+## Solution
+
+Ran `/soleur:review` with 10 parallel review agents (8 core + test-design-reviewer + semgrep-sast). Each found a different slice:
+
+- **data-integrity-guardian** — caught the LinkedIn Company URL misuse and both weak-assertion classes.
+- **agent-native-reviewer** — character-compared visible vs JSON-LD answer text across 7 FAQ entries and found 3 with dropped sentences.
+- **architecture-strategist** — flagged missing `/about/` anchor for the `@id` reference and the unused `%s` title-template slot.
+- **pattern-recognition-specialist** — caught BEM `__` convention drift (first uses in a 1594-line flat-hyphen file).
+- **performance-oracle** — flagged `existsSync`-only build-skip in test `beforeAll` causing stale `_site/` false-passes.
+
+All six defects fixed inline in 3 commits (`c5eb3f45`, `0719f38e`, `f0f0e1ec`). Drift-guard tightened to assert `sameAs` deep-equality against `site.json` (per `cq-mutation-assertions-pin-exact-post-state`) and to `existsSync` the image file. Test `beforeAll` switched to always-rebuild. Extended drift-guard to cover `apps/web-platform/app/layout.tsx` strings (prevents #2708 regression).
+
+## Key Insight
+
+**Unit tests written from the same mental model as the implementation inherit its blind spots.** The drift-guard test was drafted RED then made GREEN against the same author-written assertions — but semantic errors (Company URL ≠ Person sameAs; visible-vs-JSON-LD sentence parity; dangling `@id`) were invisible to the author at both write-times.
+
+Multi-agent review catches these because each agent comes with a *different* prior:
+
+- `data-integrity-guardian` reads schema.org semantics, not code behavior.
+- `agent-native-reviewer` does character-by-character parity checks humans skim past.
+- `architecture-strategist` asks "does this ID resolve?" not "does this compile?"
+
+For any PR touching structured data that crawlers consume (JSON-LD, OpenGraph, Microdata, RSS, sitemaps, meta tags), the invariant tests must be complemented by multi-agent review — and the drift-guard assertions themselves must be reviewed for exact-value pinning, not just existence/shape checks.
+
+## Prevention
+
+- **Assertion rigor:** when a test verifies a known-count collection or fixed string, assert the exact value from the config/data source (read `site.json` in the test, diff against it). Existence, `>=`, and `toContain` are traps. Rule `cq-mutation-assertions-pin-exact-post-state` already covers this; the PR drafted two violations in fresh code anyway.
+- **Multi-agent review is mandatory for structured-data PRs.** Skipping to QA or ship without `/soleur:review` on a PR that modifies JSON-LD, sitemap generation, or meta tags is a workflow regression. Add to ship Phase 5.5 pre-merge detection if not already gated.
+- **Extend drift-guard scope to both surfaces in cross-surface PRs.** The initial test covered Eleventy `_site/` only, missing the Next.js `apps/web-platform/app/layout.tsx` string regression surface. When a PR reconciles two surfaces, the drift-guard must assert against both.
+- **SVG asset provenance:** synthesizing a real person's likeness via image models is inappropriate regardless of tool availability. Monogram SVG is the correct automated fallback; hand off real-photo procurement to the owner (#2799 filed).
+
+## Session Errors
+
+Session error inventory: **none detected**. No failed commands, no path confusion, no forwarded errors from plan phase. Clean pipeline execution.
+
+## Tags
+
+category: integration-issues
+module: marketing-aeo
+prs:
+  - "2794"
+closes:
+  - "2707"
+  - "2708"
+  - "2709"
+  - "2711"
+follow-up:
+  - "2799"

--- a/knowledge-base/project/plans/2026-04-22-refactor-drain-seo-aeo-2026-04-21-plan.md
+++ b/knowledge-base/project/plans/2026-04-22-refactor-drain-seo-aeo-2026-04-21-plan.md
@@ -1,0 +1,364 @@
+---
+title: "refactor(marketing): drain 2026-04-21 SEO/AEO audit backlog"
+date: 2026-04-22
+type: refactor
+domain: marketing
+branch: feat-one-shot-drain-seo-aeo-2026-04-21
+closes:
+  - "2707"  # P0 — FAQ + FAQPage JSON-LD on /pricing/
+  - "2708"  # P0 — homepage <title> conflict Eleventy vs Next.js
+  - "2709"  # P1 — bare single-word <title> on /pricing/, /community/, /blog/
+  - "2711"  # P1 — inline author card + Person JSON-LD on blog posts
+references:
+  - "2706"  # 2026-04-21 growth audit summary issue
+  - "2486"  # drain-pattern reference PR (one PR, multiple closures)
+  - "2609"  # jsonLdSafe filter requirement
+audit_inputs:
+  - knowledge-base/marketing/audits/soleur-ai/2026-04-21-aeo-audit.md
+  - knowledge-base/marketing/audits/soleur-ai/2026-04-21-content-audit.md
+  - knowledge-base/marketing/audits/soleur-ai/2026-04-21-content-plan.md
+  - knowledge-base/marketing/audits/soleur-ai/2026-04-21-seo-audit.md
+brand_guide: knowledge-base/marketing/brand-guide.md
+---
+
+## Enhancement Summary
+
+**Deepened on:** 2026-04-22
+**Sections enhanced:** Files-to-Edit (output dir correction), Research Reconciliation, Implementation Phases 2/5/6, Acceptance Criteria, Risks, Test Strategy, Research Insights
+**Research sources:** Live codebase reads (`eleventy.config.js`, `blog/blog.json`, `apps/web-platform/package.json`, `test/community-stats-data.test.ts`, `docs/_includes/base.njk`), Next.js 15 metadata docs (verified via context match: app has `next@^15.5.15`), Schema.org FAQPage + Person spec, Google Search Central rich-results rules.
+
+### Key Improvements (delta from initial plan)
+
+1. **CRITICAL: Eleventy output directory corrected from `_site/` to `_site/`.** Verified via `grep "output:" eleventy.config.js` → line 64: `output: "_site"`. Every Acceptance Criterion, drift-guard assertion, and build-validation command that referenced `_site/` has been corrected. A wrong build-path in the plan would have burned the first 20 minutes of the work phase with empty `fs.readFile` failures.
+2. **CRITICAL: Blog post permalink structure verified.** `plugins/soleur/docs/blog/blog.json` sets `permalink: "blog/{{ page.fileSlug }}/index.html"` and `layout: "blog-post.njk"` — the directory-data-cascade. Every `.md` file in `docs/blog/` auto-inherits the layout. Rendered paths are `_site/blog/<slug>/index.html`. Drift-guard test 4 glob corrected from `_site/blog/*/index.html` to `_site/blog/*/index.html`.
+3. **Next.js 15 title-template verified.** App pins `next@^15.5.15` in `apps/web-platform/package.json`. Next.js 15 supports the `{ template, default, absolute }` Metadata title object (documented since 13.2, stable through 15.x). `tsc --noEmit` gate in Phase 3 will catch any type drift.
+4. **Next.js `title` sites-of-use swept.** `grep -rn "title:" apps/web-platform/app/ | grep -v "page.tsx,pricing,line"` returned: only `app/layout.tsx` exports `metadata.title`. No descendant `/dashboard/*` route overrides `metadata.title` — all route titles defined inside `dashboard/page.tsx` are component prop `title:` fields (unrelated to Next.js metadata). The title-template `%s` placeholder will fall through to `default` on every route. Safe to proceed.
+5. **`jsonLdSafe` filter implementation verified.** `eleventy.config.js:30-35`: `JSON.stringify(value).replace(/<\//g, "<\\/").replace(/ /g, "\\u2028").replace(/ /g, "\\u2029")`. This is the three-hazard-class filter (HTML breakout + JS runtime termination + JSON parse safety). Arrays and objects pass through `JSON.stringify` cleanly — `site.author.sameAs` as an array is safe to pass directly to `jsonLdSafe`. No per-element map needed. Risk #7 in the initial plan is eliminated.
+6. **`foundingDate` confirmed "2026" in base.njk (not 2025).** `grep "foundingDate" base.njk` → `"foundingDate": "2026"`. Any future author-object `foundingDate` (not added in this PR) must match.
+7. **Test runner path verified.** Sibling test (`plugins/soleur/test/community-stats-data.test.ts`) imports `from "bun:test"` and uses `resolve(import.meta.dir, "../docs/_data/...")` to locate docs artifacts. Drift-guard test will follow the same pattern — paths relative to `plugins/soleur/test/` via `import.meta.dir`, resolved against `../docs/...` for source and `../../../../_site/...` for built artifacts (repo root is 4 levels up from `plugins/soleur/test/`).
+8. **Eleventy input path caveat surfaced.** `eleventy.config.js:3` sets `INPUT = "plugins/soleur/docs"` and the build must run from repo root. The `docs:build` npm script already handles this (`cd ../../../ && npx @11ty/eleventy`). Do NOT run `npx @11ty/eleventy` from `plugins/soleur/docs/` — it will fail with "no input directory" per learning `2026-03-15-eleventy-build-must-run-from-repo-root.md`.
+
+### New Considerations Discovered
+
+- **`blog.njk` listing title-prefix semantics change.** Current template interpolates `(title + " - " + site.name)` into CollectionPage JSON-LD `name`. Adding `seoTitle: "Blog — Soleur"` does NOT automatically fix the JSON-LD — the JSON-LD still references `title` (which stays "Blog"). Phase 4 step 4 MUST also update the JSON-LD interpolation to use `seoTitle or (title + " — " + site.name)` with Nunjucks `or` fallback to avoid the "Blog - Soleur" double-dash vs seoTitle "Blog — Soleur" split-signal.
+- **`base.njk` title fallback logic needs re-reading before edit.** The logic at line 125 is: `{% if seoTitle %}{{ seoTitle }}{% elif title == site.name %}{{ site.name }} - {{ site.tagline }}{% else %}{{ title }} - {{ site.name }}{% endif %}`. Setting `seoTitle` overrides everything — the `title` + dash + `site.name` branch is bypassed. Safe.
+- **`<img>` asset passthrough already wired.** `eleventy.config.js:54` has `addPassthroughCopy({ [${INPUT}/images]: "images" })`. Dropping `jean-deruelle.jpg` into `plugins/soleur/docs/images/` auto-copies to `_site/images/jean-deruelle.jpg` with no config change. Risk #4 ("photo missing breaks build") further reduced — Eleventy ignores missing image paths; only the drift-guard test enforces presence.
+- **Existing BlogPosting author JSON-LD already has Person shape.** `_includes/blog-post.njk:27-32` renders `author: { @type: "Person", name, url, jobTitle }`. The plan only EXTENDS this node (adds `image`, `sameAs`) — does NOT create from scratch. Much lower risk of JSON-LD structural drift.
+- **`site.author.sameAs` serialization path confirmed safe.** Nunjucks `{{ site.author.sameAs | jsonLdSafe | safe }}` → `jsonLdSafe` runs `JSON.stringify(array)` → produces a valid JSON array literal like `["https://github.com/deruelle","https://x.com/jeandev_"]`. Direct drop-in works; no per-element map needed.
+- **CSP `img-src` re-verified for external `sameAs` linked resources.** The `<img>` in the author card is same-origin (`/images/`) — `'self'` covers. Any external profile photo (e.g., linking directly to GitHub avatar URL) would require CSP edit. Plan pins same-origin asset; no CSP change.
+- **AEO content-plan suggests additional FAQ items that should NOT be smuggled in.** The 2026-04-21 content-plan lists 5 suggested new pricing FAQ items. This PR adds only the 2 strictly required for the aggregate-cost-breakdown citation claim in #2707's audit finding. Additional items are a marketing content task, not a drain. Explicit in Non-Goals.
+
+# refactor(marketing): drain 2026-04-21 SEO/AEO audit backlog
+
+## Overview
+
+One focused PR that closes four open issues (two P0, two P1) filed by the 2026-04-21 weekly growth audit (#2706). All four are narrow on-page markup edits to the Eleventy docs site at `plugins/soleur/docs/`, plus a single targeted edit to the Next.js root layout at `apps/web-platform/app/layout.tsx` to eliminate the homepage `<title>` split signal.
+
+PR #2486 is the explicit drain pattern: one PR, multiple `Closes #N` lines in the body, zero new scope-outs. This PR follows the same pattern.
+
+Every fix is additive or rewrites a single metadata field. No new infrastructure, no new build steps, no new dependencies, no new pages, no new top-level routes. The PR adds one new image asset (founder photo) and wires it into the blog post layout as an inline author card.
+
+The PR body MUST include, verbatim:
+
+```text
+Closes #2707
+Closes #2708
+Closes #2709
+Closes #2711
+```
+
+One per line, in the PR body (not the title) per AGENTS.md rule `wg-use-closes-n-in-pr-body-not-title-to`.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Issue claim | Codebase reality | Plan response |
+|---|---|---|
+| `#2711` says blog-post layout is at `_includes/layouts/` (`post.njk` or equivalent). | No `_includes/layouts/` directory exists. The only blog-post layout file is `plugins/soleur/docs/_includes/blog-post.njk` (verified by `find _includes -type f`). All blog posts in `docs/blog/*.md` use this layout via front-matter or collection tag. | Edit `plugins/soleur/docs/_includes/blog-post.njk` directly. Do NOT create `_includes/layouts/`. |
+| `#2711` says "photo asset path under `plugins/soleur/docs/assets/`". | `docs/assets/` does NOT exist. Static images live at `plugins/soleur/docs/images/` (see `/images/og-image.png`, `/images/logo-mark-512.png` already referenced in `base.njk`). `docs/screenshots/` and `docs/images/blog/` exist. | Place founder photo at `plugins/soleur/docs/images/jean-deruelle.jpg` (or `.png`), serve at `/images/jean-deruelle.jpg`. Update issue language accordingly in the PR body. |
+| `#2709` and `#2708` reference "homepage `<title>`" in `plugins/soleur/docs/pages/index.njk`. | Homepage file is actually `plugins/soleur/docs/index.njk` (at `docs/` root, NOT under `pages/`). Verified by `find docs -maxdepth 2 -name "index.njk"`. Front-matter already has `seoTitle: "Soleur — AI Agents for Solo Founders | Every Department, One Platform"` — the conflict is with Next.js `apps/web-platform/app/layout.tsx`. | Edit `plugins/soleur/docs/index.njk` (root) and `apps/web-platform/app/layout.tsx`. Do NOT touch `pages/index.njk` (does not exist). |
+| `#2708` claims Next.js layout currently shows `"Soleur — One Command Center, 8 Departments"`. | Verified by `head apps/web-platform/app/layout.tsx`: exact match on line 7. `app/page.tsx` redirects `/` → `/dashboard`, so on soleur.ai production this Next.js title only renders behind `/dashboard/*` (the Eleventy index.html serves at `soleur.ai/`). | The split is theoretical on prod (Next.js `/` redirects before paint) but real for any crawler or preview tool that fetches the redirect target. Plan: scope the Next.js title to dashboard-surface language so the two surfaces never present conflicting claims about what "Soleur" is. |
+| `#2711` says blog posts lack "consistent byline rendering". | `_includes/blog-post.njk` already renders a byline via `<span class="blog-post-author">by <a href="{{ site.author.url }}" rel="author">{{ site.author.name }}</a>, {{ site.author.role }} of {{ site.name }}</span>` (line 58). BlogPosting JSON-LD already has `author: { @type: "Person", name, url, jobTitle }` (lines 27–32). | The byline is NOT missing — the _inline author card_ (photo + bio + credentials + sameAs links) is. Plan scope narrows to: (1) add inline author card block below blog post content, (2) extend site.json author metadata with `bio`, `credentials`, `sameAs`, `image`, (3) extend the existing BlogPosting `author` JSON-LD node with `image` and `sameAs`. |
+| Issue body says "model after existing FAQ blocks on home/getting-started/agents/skills/vision". | FAQPage JSON-LD confirmed on `/agents/` (verified — 5 Q&A, lines 110–153 of `pages/agents.njk`). Pattern uses `<details class="faq-item"><summary class="faq-question">` visible markup + separate `<script type="application/ld+json">` FAQPage. | Replicate `agents.njk` pattern verbatim on `pricing.njk`. Pricing already has a trailing FAQPage JSON-LD block at the bottom (lines 300-ish) but NO visible FAQ markup — verify and reconcile in Phase 2. |
+
+**Key correction discovered during research:** `pricing.njk` actually **already has a FAQPage JSON-LD block** at the bottom (5 Q&A pairs: "Why $49/mo", "concurrent conversations", "Claude separately", "free option", "when do paid plans launch"). The gap reported by #2707 is **NOT missing JSON-LD** — it is **missing the visible `<details>`/`<summary>` FAQ section** that corresponds to the schema. AEO audit's "#1 gap" is: Google's rich-result eligibility requires the visible FAQ to match the JSON-LD answers verbatim; an orphaned JSON-LD block with no visible counterpart can be treated as schema spam and dropped from rich-results. Plan: add the visible `<details class="faq-item">` block that mirrors the existing JSON-LD (or extend both together with additional Q&A pairs from the 2026-04-21 content-plan).
+
+## Files to Edit
+
+| Path | Change | Issue |
+|---|---|---|
+| `plugins/soleur/docs/pages/pricing.njk` | 1) Add visible `<section class="landing-section">` FAQ block with `<details class="faq-item">` items matching the existing JSON-LD; 2) Extend JSON-LD with 2 added Q&A: an aggregate-cost claim ("How does $95K/mo replacement stack break down?") with inline BLS / Robert Half / Levels.fyi citations, and a methodology footnote; 3) Update `title` front-matter from `Pricing` to `"Pricing — AI Agents for Solo Founders"`. | #2707, #2709 |
+| `plugins/soleur/docs/pages/community.njk` | Update `title` front-matter from `Community` to `"Community — Soleur"`. | #2709 |
+| `plugins/soleur/docs/pages/blog.njk` | Update `title` front-matter from `Blog` to `"Blog — Soleur"`. Verify the existing CollectionPage JSON-LD `name` field still interpolates correctly with the new title (current: `"{{ (title + " - " + site.name) }}"` → would become "Blog — Soleur - Soleur"; reconcile to a single-pass `seoTitle` override pattern mirroring `docs/index.njk`). | #2709 |
+| `plugins/soleur/docs/index.njk` | No title change required (already has `seoTitle: "Soleur — AI Agents for Solo Founders \| Every Department, One Platform"`). Verify nothing else references the conflicting Next.js string. | #2708 (confirmation only) |
+| `apps/web-platform/app/layout.tsx` | Change `metadata.title` from `"Soleur — One Command Center, 8 Departments"` to something scoped to the dashboard surface so the two surfaces never present conflicting brand claims. Proposed: `{ template: "%s — Soleur Dashboard", default: "Soleur Dashboard — Your Command Center" }` (Next.js title-template pattern). This ensures `/dashboard`, `/dashboard/billing`, etc. inherit a scoped title; no descendant route can accidentally render the marketing brand line. | #2708 |
+| `plugins/soleur/docs/_includes/blog-post.njk` | 1) Add inline author-card block in `{% block content %}` after the prose content, before `</section>`. Renders: photo (`<img src="{{ site.author.image }}" width=96 height=96 alt="Jean Deruelle — Founder of Soleur" loading="lazy">`), name, role, one-line bio, credentials list, sameAs links. 2) Extend JSON-LD `author` Person node with `"image"` and `"sameAs"` fields (uses `\| jsonLdSafe \| safe` per rule `cq-prose-issue-ref-line-start` companion pattern from #2609). | #2711 |
+| `plugins/soleur/docs/_data/site.json` | Extend `author` object with `image: "/images/jean-deruelle.jpg"`, `bio: "Founder of Soleur. 15+ years building distributed systems and developer tools. Creator of the Company-as-a-Service platform."` (one sentence, mirrors `about.njk` language), `credentials: ["Founder, Soleur", "15+ years in distributed systems"]`, `sameAs: ["https://github.com/deruelle", "https://x.com/jeandev_", <LinkedIn URL if available>]`. | #2711 |
+| `plugins/soleur/docs/pages/blog.njk` (author card on listing) | Add a compact `<div class="blog-listing-author">` block above the first category section rendering `site.author.name` + `site.author.role` as the blog's canonical author. Models the "By Jean Deruelle — Founder of Soleur" pattern from the brand guide. | #2711 |
+| `plugins/soleur/docs/css/style.css` | Add minimal CSS for `.author-card`, `.author-card__photo`, `.author-card__body`, `.author-card__credentials`, `.author-card__links` (neutral layout — photo 96px left, text right, monochrome). Do NOT introduce new tokens; reuse existing `--color-*` / `--space-*` CSS vars. | #2711 |
+
+## Files to Create
+
+| Path | Purpose |
+|---|---|
+| `plugins/soleur/docs/images/jean-deruelle.jpg` | Founder headshot for inline author card. Square 512×512 JPEG (under 80 KB). Sourced from existing brand/social assets — do not generate. If no existing asset is usable, invoke `soleur:gemini-imagegen` (per AGENTS.md `hr-when-triaging-a-batch-of-issues-never`) with a "professional headshot, neutral background, 512×512, editorial portrait style" prompt ONLY if no real photo is available; otherwise the founder (user) provides the photo and this plan stops at the point of asset insertion. |
+| `plugins/soleur/test/seo-aeo-drift-guard.test.ts` | New `bun:test` drift-guard that asserts: (1) `_site/pricing/index.html` contains `"@type":"FAQPage"` AND at least one `<details class="faq-item">` visible element AND the JSON-LD Q&A count matches the visible `<details>` count; (2) `_site/pricing/index.html`, `_site/community/index.html`, `_site/blog/index.html` all have `<title>` containing `"Soleur"` AND at least one em-dash/hyphen/pipe separator (not a single bare word); (3) `_site/index.html` `<title>` is the seoTitle string (exact); (4) every rendered blog-post HTML under `_site/blog/*/index.html` contains both an inline author-card DOM block (class `author-card`) AND a Person JSON-LD with `image` + `sameAs`; (5) all FAQPage and BlogPosting JSON-LD blocks parse as valid JSON via `JSON.parse`. |
+
+## Open Code-Review Overlap
+
+None. Ran `gh issue list --label code-review --state open --json number,title,body --limit 200` — zero open code-review issues reference any of the six file paths in the `Files to Edit` table. Check performed 2026-04-22.
+
+## Implementation Phases
+
+### Phase 1 — RED tests (drift-guard)
+
+1. Create `plugins/soleur/test/seo-aeo-drift-guard.test.ts` with five failing assertions as enumerated in "Files to Create" above.
+2. Run: `bun test plugins/soleur/test/seo-aeo-drift-guard.test.ts` — confirm 5 failures.
+3. Do NOT touch any source file yet.
+
+### Phase 2 — #2707 (FAQ + visible block + extended JSON-LD on /pricing/)
+
+1. Add visible FAQ section (`<section class="landing-section">` with `<details class="faq-item">` items) mirroring the existing JSON-LD's 5 Q&A pairs.
+2. Extend JSON-LD with 2 new Q&A pairs from 2026-04-21 content-plan (aggregate-cost breakdown + methodology). Both must also appear in the visible `<details>` block (Google rich-result parity requirement).
+3. Inline citations for the $95K/mo claim: link to Robert Half salary guide (200 OK for curl — verified in prior drain pattern per PR #2486 research), Payscale C-suite, and Levels.fyi engineering salaries. Do NOT cite `bls.gov` (returns 403 to curl per PR #2486 research — breaks pre-merge link-rot guard).
+4. All string interpolations in new JSON-LD use `\| jsonLdSafe \| safe` (per rule `#2609` pattern already used in the file).
+5. Run drift-guard test 1 → PASS.
+
+### Phase 3 — #2708 (homepage `<title>` reconciliation)
+
+1. Verify `plugins/soleur/docs/index.njk` `seoTitle` is unchanged and correct.
+2. In `apps/web-platform/app/layout.tsx`, replace `metadata.title` with Next.js title-template pattern:
+
+   ```ts
+   export const metadata: Metadata = {
+     title: {
+       template: "%s — Soleur Dashboard",
+       default: "Soleur Dashboard — Your Command Center",
+     },
+     // description unchanged or updated to dashboard-scoped copy
+     // ...
+   };
+   ```
+
+3. Update the `description` if it overlaps with the marketing-site description (avoid the exact tagline split).
+4. Run `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` to verify Metadata type still compiles.
+5. Run drift-guard test 3 → PASS.
+
+### Phase 4 — #2709 (bare single-word titles)
+
+1. Update `pages/pricing.njk` front-matter `title: Pricing` → `title: "Pricing — AI Agents for Solo Founders"`.
+   - Verify this does NOT double-append "- Soleur" in `base.njk:125`: the branch `{% elif title == site.name %}{{ site.name }} - {{ site.tagline }}{% else %}{{ title }} - {{ site.name }}{% endif %}` would produce `"Pricing — AI Agents for Solo Founders - Soleur"` (double dash-separated). Acceptable for SERP (two separators: em-dash for product anchor, hyphen for brand) but re-check against brand-guide voice rules before freezing the exact string. Alternative: set `seoTitle: "Pricing — AI Agents for Solo Founders | Soleur"` and keep `title: Pricing` for in-page H1 — this is the pattern `index.njk` already uses.
+   - **Chosen pattern:** use `seoTitle` override (mirrors `index.njk`) to keep the in-page `<h1>Every department.<br>One price.</h1>` unchanged while fixing the crawler-visible `<title>`. Applies to all three pages below.
+2. `pages/pricing.njk`: add `seoTitle: "Pricing — AI Agents for Solo Founders | Soleur"` to front-matter.
+3. `pages/community.njk`: add `seoTitle: "Community — Soleur"` to front-matter.
+4. `pages/blog.njk`: add `seoTitle: "Blog — Soleur"` to front-matter AND update the CollectionPage JSON-LD `name` field from `{{ (title + " - " + site.name) | jsonLdSafe | safe }}` to `{{ (seoTitle or (title + " — " + site.name)) | jsonLdSafe | safe }}`. Without this change, `<title>` becomes "Blog — Soleur" but the JSON-LD `name` stays "Blog - Soleur" — Google Structured-Data Testing flags this as inconsistent name/title and may demote the page.
+5. Run drift-guard test 2 → PASS.
+
+### Phase 5 — #2711 (inline author card + Person JSON-LD)
+
+1. Place founder photo at `plugins/soleur/docs/images/jean-deruelle.jpg` (512×512, ≤80 KB). If no asset is available, stop and hand off to the user at this exact point (per AGENTS.md `hr-when-a-workflow-concludes-with-an` — only genuinely manual step in this plan).
+2. Extend `_data/site.json` `author` object with `image`, `bio`, `credentials`, `sameAs` fields per spec above.
+3. Edit `_includes/blog-post.njk`:
+   - In the `{% block content %}` section, append a new `<section class="author-card-section">` block below the prose, containing the compact author card.
+   - In the `{% block extraHead %}` JSON-LD, extend the `author` Person node with:
+     - `"@id": {{ (site.url + "/about/#jean-deruelle") | jsonLdSafe | safe }}` (stable entity ID for graph-stitching across posts)
+     - `"image": {{ (site.url + site.author.image) | jsonLdSafe | safe }}` (absolute URL required by Google Rich Results)
+     - `"sameAs": {{ site.author.sameAs | jsonLdSafe | safe }}` (direct array interpolation — verified safe because `jsonLdSafe` uses `JSON.stringify` which serializes arrays natively; do NOT use `dump` which is redundant and drops the three-hazard escapes)
+     - Keep existing `"@type": "Person"`, `"name"`, `"url"`, `"jobTitle"` unchanged.
+4. Edit `pages/blog.njk` to add the compact byline banner above the first category section.
+5. Add minimal CSS to `docs/css/style.css` for `.author-card*` classes.
+6. Run drift-guard test 4 and 5 → PASS.
+
+### Phase 6 — Build validation
+
+1. Build from repo root (not from `docs/`). Either `cd plugins/soleur/docs && npm run docs:build` (which chains `cd ../../../ && npx @11ty/eleventy`) OR run `npx @11ty/eleventy` directly from repo root. Output lands at `_site/` (repo-root-relative), per `eleventy.config.js:64`. Per learning `2026-03-15-eleventy-build-must-run-from-repo-root.md`, running eleventy from `plugins/soleur/docs/` fails with no-input-directory.
+2. Validate JSON-LD on every modified page:
+
+   ```bash
+   for p in _site/index.html _site/pricing/index.html _site/community/index.html _site/blog/index.html _site/blog/*/index.html; do
+     echo "=== $p ==="
+     python3 -c "
+   import re, sys, json
+   html = open('$p').read()
+   for m in re.finditer(r'<script type=\"application/ld\+json\">(.*?)</script>', html, re.DOTALL):
+     try: json.loads(m.group(1))
+     except Exception as e: print(f'INVALID JSON-LD: {e}'); sys.exit(1)
+   print('OK')
+   "
+   done
+   ```
+
+3. Visually verify with `curl -s file://$(pwd)/_site/pricing/index.html | grep -E '<title>|FAQPage|faq-item'`.
+4. Run `bun test plugins/soleur/test/seo-aeo-drift-guard.test.ts` — all 5 assertions PASS.
+
+### Phase 7 — Commit / review / ship
+
+1. Run `skill: soleur:compound` per AGENTS.md `wg-before-every-commit-run-compound-skill`.
+2. `git add` only the touched files explicitly (never `-A`).
+3. Commit with message: `refactor(marketing): drain 2026-04-21 SEO/AEO audit backlog`.
+4. Push and open PR via `skill: soleur:ship`. PR body MUST contain the four verbatim `Closes #N` lines AND a `## Net impact on backlog` table per PR #2486 style (4 closures vs 0 new scope-outs).
+5. Mark PR ready; queue auto-merge per AGENTS.md `wg-after-marking-a-pr-ready-run-gh-pr-merge`.
+
+## Acceptance Criteria
+
+### Pre-merge (PR branch)
+
+- [ ] `plugins/soleur/docs/pages/pricing.njk` has a visible `<details class="faq-item">` block with ≥5 Q&A pairs AND a matching `FAQPage` JSON-LD block (visible count == JSON-LD count).
+- [ ] `_site/pricing/index.html` contains `<script type="application/ld+json">` with `"@type":"FAQPage"` and visible `<details>` markup in the same file (verified via `curl file://.../_site/pricing/index.html`).
+- [ ] `_site/index.html`, `_site/pricing/index.html`, `_site/community/index.html`, `_site/blog/index.html` all have `<title>` tags that: (a) contain the word `Soleur`, (b) contain at least one separator character (`—`, `|`, or ` - `), (c) are NOT a single bare word.
+- [ ] `apps/web-platform/app/layout.tsx` `metadata.title` is a Next.js title-template object (NOT the literal string `"Soleur — One Command Center, 8 Departments"`).
+- [ ] No grep hit for the old Next.js brand string: `grep -rn "One Command Center, 8 Departments" apps/ plugins/ knowledge-base/marketing/ 2>/dev/null` returns zero matches (aside from this plan file and audit files, which are research artifacts).
+- [ ] At least one rendered blog post at `_site/blog/*/index.html` contains: (a) a `class="author-card"` (or equivalent) DOM block with an `<img>` referencing `/images/jean-deruelle.jpg`, (b) a BlogPosting JSON-LD with a `Person` author node containing both `image` and `sameAs`.
+- [ ] Every new JSON-LD block parses as valid JSON (no trailing commas, no unescaped `</script>`) — verified by the drift-guard test's JSON.parse pass and by the `python3 -c ...` script in Phase 6.
+- [ ] `bun test plugins/soleur/test/seo-aeo-drift-guard.test.ts` — all 5 assertions PASS.
+- [ ] `npm run docs:build` succeeds with zero Eleventy errors or warnings.
+- [ ] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` succeeds.
+- [ ] `npx markdownlint-cli2 --fix knowledge-base/project/plans/2026-04-22-refactor-drain-seo-aeo-2026-04-21-plan.md` produces no changes on re-run.
+- [ ] PR body includes the four `Closes #N` lines verbatim, one per line.
+- [ ] PR body includes `## Net impact on backlog` table modeled on #2486: 4 closures, 0 new scope-outs.
+
+### Post-merge (operator)
+
+- [ ] Verify production `soleur.ai/pricing/` renders the visible FAQ section (view-source check).
+- [ ] Verify `soleur.ai` HTML `<title>` on the homepage matches the seoTitle string (not the Next.js string).
+- [ ] Run Google's Rich Results Test against `https://soleur.ai/pricing/` — expect `FAQPage` valid with ≥5 questions detected.
+- [ ] Run Rich Results Test against one blog-post URL — expect `BlogPosting` valid with `author.image` and `author.sameAs` populated.
+- [ ] Close the four issues automatically via the merged PR's `Closes` lines; verify state via `gh issue view <N> --json state`.
+- [ ] Re-run weekly growth audit next week and confirm all four M33–M36 roadmap rows flip from "Not started" to "Done".
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| `pages/blog.njk` JSON-LD `name` field double-appends "Soleur" after adding `seoTitle`. | Medium | Phase 4 step 4 explicitly calls out reconciling the `name` interpolation to use `seoTitle` (or pre-computed string) so the rendered name is exactly `"Blog — Soleur"`, not `"Blog — Soleur - Soleur"`. Drift-guard test 2 asserts no triple-brand string (regex: no `Soleur.*Soleur.*Soleur`). |
+| Next.js title-template object is incompatible with the `apps/web-platform` metadata type in the installed Next.js version. | Low | Plan prescribes `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` as a gate in Phase 3. Next.js 13+ has supported `{ template, default }` titles since 13.2 (official docs). Verify via `cat apps/web-platform/package.json | grep '"next"'` before implementing. |
+| FAQ question/answer mismatch between visible `<details>` block and JSON-LD triggers Google's schema-spam penalty. | Medium | Drift-guard test 1 asserts that the JSON-LD `mainEntity` count equals the `<details class="faq-item">` count AND that each JSON-LD `name` appears verbatim as the text content of some `<summary>` element. This is a structural assertion, not a byte-level hash, so whitespace is tolerated but semantic drift fails. |
+| Founder photo asset does not exist and cannot be produced automatically. | Medium | Phase 5 step 1 explicitly hands off to the user at this point. The drift-guard test asserts the `<img src="/images/jean-deruelle.jpg">` reference; if the file is missing, Eleventy build still passes (it doesn't fetch image paths) but the test fails because `_site/blog/*/index.html` lacks the expected `<img>` tag. This is the only genuinely manual step and it is scoped to a single asset drop. Alternative: if the user cannot provide the photo, the implementation can generate a vector monogram SVG (`J`/`D` glyph at 96×96, neutral colors) as a placeholder and the `sameAs`/`bio`/`credentials` fields still satisfy the E-E-A-T structural requirement. |
+| CSP meta tag in `base.njk` blocks the new `<img>` from loading. | Very low | The CSP `img-src` directive already allows `'self'` and `data:` (verified in `base.njk:30`). The founder photo is served from `/images/`, which is same-origin, so `'self'` covers it. No CSP change needed. |
+| `site.author.sameAs` array serialization through Nunjucks `\| dump` does not pass through `jsonLdSafe` escapes. | Medium | Phase 5 step 3 includes a fallback: if `dump` produces unsafe output, switch to a per-element map using `jsonLdSafe` on each URL. Verify by reading the rendered HTML before committing — look for raw `</` or ` ` sequences in the JSON-LD. |
+| The aggregate-cost Q&A on /pricing/ cites a source URL that returns 4xx/5xx to the pre-merge link-rot guard. | Low (if BLS avoided) | Plan Phase 2 step 3 explicitly names the three verified-200 citation targets (Robert Half, Payscale, Levels.fyi). BLS is explicitly excluded per PR #2486 research. If a new URL is introduced in the Q&A, add a `curl -fsIL "$URL"` step to Phase 6 before commit. |
+| `/dashboard` routes in the Next.js app gain a double-branded title (`"Soleur Dashboard — Your Command Center — Soleur Dashboard"`) due to the template pattern. | Low | The Next.js title-template `%s` placeholder only applies when a child route's `metadata.title` is a string. Routes that do NOT override title inherit the `default`. Verify no existing `/dashboard/*` page exports a `metadata.title` that already contains "Soleur" (grep `apps/web-platform/app/**/*.tsx` for `title:`). |
+
+## Non-Goals
+
+- **#2679 (rubric reconciliation):** requires a CMO decision on 8-component AEO vs SAP rubric. Not a code change. Out of scope — remains open.
+- **Off-site AEO work (#2599–#2604):** G2, AlternativeTo, Product Hunt, TopAIProduct, case study, press strip. Off-site, not an on-page markup fix. Tracked separately.
+- **#2712 (billion-dollar pillar):** listed in the 2026-04-21 audit roadmap as M37 but not in this drain's scope per the user's task brief. Remains open.
+- **New blog posts or author profiles:** this PR adds structural metadata (photo, bio, sameAs, Person JSON-LD) but does NOT add new content or a full author profile page.
+- **Eleventy layout refactor:** do NOT introduce `_includes/layouts/` directory or migrate the existing layouts there. The plan works within the current structure.
+- **FAQ content expansion beyond 2 new pairs:** the content-plan document may suggest 5–10 new FAQ items for pricing; this drain adds only the 2 required for the aggregate-cost claim. Additional content is a marketing writing task, not a markup drain.
+
+## Domain Review
+
+**Domains relevant:** marketing (CMO)
+
+### Marketing (CMO)
+
+**Status:** reviewed (carry-forward)
+**Assessment:** The four issues closed by this PR were all filed by the 2026-04-21 weekly growth audit workflow, which invokes the `seo-aeo-analyst` specialist under the CMO domain leader. The audit + content-plan pipeline constitutes the CMO sign-off for in-scope on-page markup fixes. The plan's content decisions (title patterns, FAQ expansion, citation sources) are drawn verbatim from the 2026-04-21 content-plan.md and aeo-audit.md. No fresh CMO invocation is required pre-implementation per the carry-forward pattern documented in PR #2486's drain plan.
+
+No new user-facing page is created (only metadata, a visible FAQ section on an existing page, and an inline author card block on an existing layout). Product/UX Gate tier is **ADVISORY** (existing page modifications), not BLOCKING. In pipeline context (plan invoked from `soleur:one-shot`), auto-accepted per skill Phase 2.5.
+
+### Product/UX Gate
+
+**Tier:** advisory
+**Decision:** auto-accepted (pipeline)
+**Agents invoked:** none (CMO carry-forward satisfies advisory tier per #2486 pattern)
+**Skipped specialists:** none
+**Pencil available:** N/A
+
+No new user-facing pages, flows, or components are created. The author-card block is a neutral metadata component rendered below existing content — no new interaction surfaces, no decision points, no emotional or persuasive copy. The visible FAQ block on `/pricing/` mirrors the pattern already on five sibling pages (home, getting-started, agents, skills, vision) and introduces no new UX convention.
+
+## Test Strategy
+
+**Runner:** `bun:test` (verified via `head -1 plugins/soleur/test/community-stats-data.test.ts` → imports from `"bun:test"`). Do NOT use `vitest` — the Eleventy docs test harness is bun-native per plugins/soleur/AGENTS.md.
+
+**Invocation:** `bun test plugins/soleur/test/seo-aeo-drift-guard.test.ts`.
+
+**What the drift-guard asserts (RED-then-GREEN order):**
+
+1. `_site/pricing/index.html` contains `"@type":"FAQPage"` in a `<script type="application/ld+json">` block; `<details class="faq-item">` count ≥5; every JSON-LD `mainEntity[*].name` appears verbatim in some `<summary>` element.
+2. For each of `_site/index.html`, `_site/pricing/index.html`, `_site/community/index.html`, `_site/blog/index.html`: the parsed `<title>` contains "Soleur" AND contains at least one of `—`, `|`, ` - `; AND is NOT a single word from the set `{"Pricing", "Community", "Blog"}`.
+3. `_site/index.html` `<title>` matches the exact seoTitle string from `docs/index.njk` front-matter.
+4. For each file matching `_site/blog/*/index.html`: contains a DOM element with class `author-card`; contains `<img src="/images/jean-deruelle.jpg"` (or serving equivalent from `site.author.image`); contains a BlogPosting JSON-LD block whose `author` Person node has both `image` and `sameAs` keys, and the `sameAs` array has ≥2 entries.
+5. Every `<script type="application/ld+json">` block in every `_site/**/*.html` file parses as valid JSON via `JSON.parse`. (Generalization of #2609's jsonLdSafe guard.)
+
+**Fixture strategy:** sibling tests in `plugins/soleur/test/*.ts` all target source artifacts (`_data/*.js`), NOT built `_site/` output. The drift-guard is a new class — built-output assertions. Recommended pattern:
+
+```ts
+// plugins/soleur/test/seo-aeo-drift-guard.test.ts
+import { describe, test, expect, beforeAll } from "bun:test";
+import { resolve } from "path";
+import { existsSync, readFileSync, readdirSync } from "fs";
+import { spawnSync } from "child_process";
+
+const REPO_ROOT = resolve(import.meta.dir, "../../..");
+const SITE = resolve(REPO_ROOT, "_site");
+
+beforeAll(() => {
+  if (!existsSync(SITE)) {
+    // Build once for the whole suite. Eleventy must run from repo root.
+    const res = spawnSync("npx", ["@11ty/eleventy"], { cwd: REPO_ROOT, stdio: "inherit" });
+    if (res.status !== 0) throw new Error("Eleventy build failed in test setup");
+  }
+});
+
+test("pricing has visible FAQ matching JSON-LD", () => {
+  const html = readFileSync(resolve(SITE, "pricing/index.html"), "utf8");
+  const ld = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+    .map((m) => JSON.parse(m[1]))
+    .find((o) => o["@type"] === "FAQPage");
+  expect(ld).toBeDefined();
+  const summaries = [...html.matchAll(/<summary class="faq-question">([^<]+)<\/summary>/g)].map((m) => m[1].trim());
+  const names = ld.mainEntity.map((q: any) => q.name.trim());
+  expect(summaries.length).toBe(names.length);
+  for (const name of names) expect(summaries).toContain(name);
+});
+// ... further tests follow the same readFileSync + regex/JSON.parse pattern
+```
+
+Path math: `plugins/soleur/test/` → `../../..` = repo root. `_site/` is at repo root. All built artifacts resolvable as `resolve(REPO_ROOT, "_site/<permalink>/index.html")`.
+
+**No existing tests are disabled or loosened.** The drift-guard is additive and does not touch any sibling assertion.
+
+## Research Insights
+
+**Prior-art references:**
+
+- **PR #2486** — drain pattern (one PR, multiple closures, net-impact table format). Pre-merge BLS link-rot finding: bls.gov returns 403 to curl; use Robert Half / Payscale / Levels.fyi instead.
+- **Issue #2609** — `jsonLdSafe` filter requirement. All new JSON-LD string interpolations in `docs/_includes/*.njk` and `docs/pages/*.njk` MUST use `\| jsonLdSafe \| safe`.
+- **Learning `2026-03-17-faq-section-nesting-consistency.md`** — existing guidance on FAQ section DOM structure.
+- **Learning `2026-03-15-eleventy-build-must-run-from-repo-root.md`** — `docs:build` script CDs to repo root before invoking `@11ty/eleventy`. Do NOT run eleventy from `docs/` directly.
+
+**CLI verification (per rule `cq-docs-cli-verification`):**
+
+- `bun test` — verified (installed, runs in repo).
+- `npx @11ty/eleventy` — verified (pinned in `docs/package.json` via transitive — confirm before build).
+- `curl -fsIL "$URL"` — standard POSIX; no plan-time verification needed.
+- No fabricated CLI invocations land in any `.njk`, `.md`, or `.tsx` file produced by this plan. (The plan itself prescribes CLI only in internal build/test steps.)
+
+**Next.js metadata title-template pattern** — verified via [Next.js metadata docs](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#title) — `{ template: string, default: string }` supported since Next.js 13.2. Applies at page-metadata merge time. <!-- verified: 2026-04-22 source: https://nextjs.org/docs/app/api-reference/functions/generate-metadata -->
+
+**Schema.org FAQPage rich-result eligibility** — Google requires the visible FAQ text on the page to match the JSON-LD answers; an orphaned JSON-LD block with no visible FAQ is schema spam (per Google Search Central docs on FAQPage markup). This is why #2707's "add JSON-LD" framing was re-scoped in this plan to "add visible FAQ + extend existing JSON-LD to match".
+
+**Schema.org Person best practices for E-E-A-T (Geneo, Schema Pilot, Search Engine Journal 2025–2026):**
+
+- Person node should have stable `@id` (e.g., `https://soleur.ai/about/#jean-deruelle`) so multiple pages can reference the same entity via `@id`.
+- `sameAs` array strongly preferred with ≥3 authoritative profile URLs (GitHub, LinkedIn, X/Twitter at minimum). More is better for graph-stitching by AI engines.
+- `image` should be a square photo ≥160×160 (preferably 512×512) and must be same-origin for Google's Rich Results Test to fetch successfully.
+- `jobTitle`, `worksFor` (with Organization link), and `description` (short bio) all contribute to E-E-A-T scoring.
+- **Implication for this PR:** the extended Person node should include `@id`, `image`, `sameAs` (≥2 URLs from `site.author.sameAs`), plus the existing `name`, `url`, `jobTitle`. `description` can be added but is optional for the drain's scope — flagged for follow-up.
+
+**`_site/` output-dir verified** — `grep "output:" eleventy.config.js` → `output: "_site"` (line 64). No `dist/` directory. Any plan-prescribed path hitting `dist/` is an error.
+
+**Blog post permalink verified** — `plugins/soleur/docs/blog/blog.json` → `{"layout": "blog-post.njk", "permalink": "blog/{{ page.fileSlug }}/index.html"}`. Every `.md` in `docs/blog/` renders to `_site/blog/<slug>/index.html` and uses `_includes/blog-post.njk` via directory-data-cascade. Drift-guard glob: `_site/blog/*/index.html`.
+
+**Next.js 15 metadata title-template** — verified via `apps/web-platform/package.json` `"next": "^15.5.15"`. Object form `{ template: string, default: string, absolute?: string }` supported since 13.2, stable in 15. Child routes that export `metadata.title` as a string substitute for `%s`; child routes that omit `title` inherit `default`. <!-- verified: 2026-04-22 source: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#title -->
+
+**`jsonLdSafe` filter implementation verified** — `eleventy.config.js:30-35`. Applies three escapes: `</` → `<\/` (HTML breakout), `U+2028` → ` ` (JS runtime string termination), `U+2029` → ` ` (same). `JSON.stringify` handles arrays/objects cleanly. Arrays pass through directly; no per-element mapping needed for `site.author.sameAs`.
+
+## Success Criteria
+
+- 4 open P0/P1 issues closed in a single PR.
+- 0 new scope-outs filed against any file in `Files to Edit`.
+- AEO audit score (next weekly audit) improves from 78/100 → ≥82/100 on the Structure dimension (FAQ visible + matching JSON-LD on pricing) and ≥4 points on Authority (named author + sameAs + credentials rendered as Person JSON-LD).
+- SERP CTR uplift on `/pricing/`, `/community/`, `/blog/` observable in Plausible (tracked but not blocking merge).

--- a/knowledge-base/project/specs/feat-one-shot-drain-seo-aeo-2026-04-21/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-drain-seo-aeo-2026-04-21/session-state.md
@@ -1,0 +1,22 @@
+# Session State
+
+## Plan Phase
+- Plan file: `/home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-one-shot-drain-seo-aeo-2026-04-21/knowledge-base/project/plans/2026-04-22-refactor-drain-seo-aeo-2026-04-21-plan.md`
+- Status: complete
+- Draft PR: https://github.com/jikig-ai/soleur/pull/2794
+
+### Errors
+None
+
+### Decisions
+- Eleventy output is `_site/` not `dist/` — corrected across all acceptance criteria and drift-guard assertions.
+- Reconciled #2711 path drift: layout is `docs/_includes/blog-post.njk`; photo asset is `docs/images/jean-deruelle.jpg` (passthrough-copied).
+- #2707 re-scoped from "add JSON-LD" to "add visible FAQ matching existing JSON-LD". Pricing already has FAQPage JSON-LD; audit gap is the missing visible `<details>` section. Drift-guard test asserts visible-count == JSON-LD-count.
+- #2708 reconciled via Next.js 15 title-template: `{ template: "%s — Soleur Dashboard", default: "Soleur Dashboard — Your Command Center" }` in `apps/web-platform/app/layout.tsx`. Eleventy homepage `seoTitle` already correct.
+- #2709 uses `seoTitle` override pattern (mirrors `docs/index.njk`) to fix `<title>` without touching visible `<h1>`. Includes Blog JSON-LD `name` reconciliation.
+- #2711 extends existing Person node in `blog-post.njk` JSON-LD with `@id`, `image`, `sameAs`; adds inline author-card DOM, site.json metadata, CSS.
+- Drift-guard test is additive: `plugins/soleur/test/seo-aeo-drift-guard.test.ts` with `bun:test`, `beforeAll` Eleventy build, `_site/` assertions.
+
+### Components Invoked
+- `skill: soleur:plan` (9-section plan, 7 files-to-edit, 2 files-to-create, 7 implementation phases)
+- `skill: soleur:deepen-plan` (8 enhancements — `_site/` correction, Next.js 15 verification, Person schema E-E-A-T shape, test-runner path verification)

--- a/plugins/soleur/docs/_data/site.json
+++ b/plugins/soleur/docs/_data/site.json
@@ -40,8 +40,7 @@
     ],
     "sameAs": [
       "https://github.com/deruelle",
-      "https://x.com/jeandev_",
-      "https://www.linkedin.com/company/jikigai/"
+      "https://x.com/jeandev_"
     ]
   },
   "footerColumns": [

--- a/plugins/soleur/docs/_data/site.json
+++ b/plugins/soleur/docs/_data/site.json
@@ -31,7 +31,18 @@
     "name": "Jean Deruelle",
     "url": "https://soleur.ai/about/",
     "role": "Founder",
-    "company": "Soleur"
+    "company": "Soleur",
+    "image": "/images/jean-deruelle.svg",
+    "bio": "Founder of Soleur. 15+ years building distributed systems and developer tools. Creator of the Company-as-a-Service platform.",
+    "credentials": [
+      "Founder, Soleur",
+      "15+ years in distributed systems"
+    ],
+    "sameAs": [
+      "https://github.com/deruelle",
+      "https://x.com/jeandev_",
+      "https://www.linkedin.com/company/jikigai/"
+    ]
   },
   "footerColumns": [
     {

--- a/plugins/soleur/docs/_includes/blog-post.njk
+++ b/plugins/soleur/docs/_includes/blog-post.njk
@@ -30,8 +30,10 @@ layout: base.njk
     "name": {{ site.author.name | jsonLdSafe | safe }},
     "url": {{ site.author.url | jsonLdSafe | safe }},
     "jobTitle": {{ (site.author.role + " of " + site.name) | jsonLdSafe | safe }},
+    "description": {{ site.author.bio | jsonLdSafe | safe }},
     "image": {{ (site.url + site.author.image) | jsonLdSafe | safe }},
-    "sameAs": {{ site.author.sameAs | jsonLdSafe | safe }}
+    "sameAs": {{ site.author.sameAs | jsonLdSafe | safe }},
+    "knowsAbout": {{ site.author.credentials | jsonLdSafe | safe }}
   },
   "publisher": {
     "@type": "Organization",

--- a/plugins/soleur/docs/_includes/blog-post.njk
+++ b/plugins/soleur/docs/_includes/blog-post.njk
@@ -83,28 +83,28 @@ layout: base.njk
 <section class="author-card-section" aria-label="About the author">
   <div class="container">
     <div class="author-card">
-      <img class="author-card__photo"
+      <img class="author-card-photo"
            src="{{ site.author.image }}"
            width="96"
            height="96"
            alt="{{ site.author.name }} — {{ site.author.role }} of {{ site.name }}"
            loading="lazy"
            decoding="async">
-      <div class="author-card__body">
-        <p class="author-card__name">{{ site.author.name }}</p>
-        <p class="author-card__role">{{ site.author.role }} of {{ site.name }}</p>
-        <p class="author-card__bio">{{ site.author.bio }}</p>
+      <div class="author-card-body">
+        <p class="author-card-name">{{ site.author.name }}</p>
+        <p class="author-card-role">{{ site.author.role }} of {{ site.name }}</p>
+        <p class="author-card-bio">{{ site.author.bio }}</p>
         {% if site.author.credentials %}
-        <ul class="author-card__credentials">
+        <ul class="author-card-credentials">
           {% for credential in site.author.credentials %}
           <li>{{ credential }}</li>
           {% endfor %}
         </ul>
         {% endif %}
         {% if site.author.sameAs %}
-        <ul class="author-card__links">
+        <ul class="author-card-links">
           {% for link in site.author.sameAs %}
-          <li><a href="{{ link }}" rel="noopener me" target="_blank">{{ link | replace("https://", "") | replace("www.", "") }}</a></li>
+          <li><a href="{{ link }}" rel="noopener noreferrer me" target="_blank">{{ link | replace("https://", "") | replace("www.", "") }}</a></li>
           {% endfor %}
         </ul>
         {% endif %}

--- a/plugins/soleur/docs/_includes/blog-post.njk
+++ b/plugins/soleur/docs/_includes/blog-post.njk
@@ -26,9 +26,12 @@ layout: base.njk
   "image": {{ (site.url + "/images/og-image.png") | jsonLdSafe | safe }},
   "author": {
     "@type": "Person",
+    "@id": {{ (site.url + "/about/#jean-deruelle") | jsonLdSafe | safe }},
     "name": {{ site.author.name | jsonLdSafe | safe }},
     "url": {{ site.author.url | jsonLdSafe | safe }},
-    "jobTitle": {{ (site.author.role + " of " + site.name) | jsonLdSafe | safe }}
+    "jobTitle": {{ (site.author.role + " of " + site.name) | jsonLdSafe | safe }},
+    "image": {{ (site.url + site.author.image) | jsonLdSafe | safe }},
+    "sameAs": {{ site.author.sameAs | jsonLdSafe | safe }}
   },
   "publisher": {
     "@type": "Organization",
@@ -71,6 +74,39 @@ layout: base.njk
   <div class="container">
     <div class="prose">
       {{ content | safe }}
+    </div>
+  </div>
+</section>
+
+<section class="author-card-section" aria-label="About the author">
+  <div class="container">
+    <div class="author-card">
+      <img class="author-card__photo"
+           src="{{ site.author.image }}"
+           width="96"
+           height="96"
+           alt="{{ site.author.name }} — {{ site.author.role }} of {{ site.name }}"
+           loading="lazy"
+           decoding="async">
+      <div class="author-card__body">
+        <p class="author-card__name">{{ site.author.name }}</p>
+        <p class="author-card__role">{{ site.author.role }} of {{ site.name }}</p>
+        <p class="author-card__bio">{{ site.author.bio }}</p>
+        {% if site.author.credentials %}
+        <ul class="author-card__credentials">
+          {% for credential in site.author.credentials %}
+          <li>{{ credential }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+        {% if site.author.sameAs %}
+        <ul class="author-card__links">
+          {% for link in site.author.sameAs %}
+          <li><a href="{{ link }}" rel="noopener me" target="_blank">{{ link | replace("https://", "") | replace("www.", "") }}</a></li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+      </div>
     </div>
   </div>
 </section>

--- a/plugins/soleur/docs/css/style.css
+++ b/plugins/soleur/docs/css/style.css
@@ -1612,7 +1612,7 @@
   max-width: 720px;
   margin: 0 auto;
 }
-.author-card__photo {
+.author-card-photo {
   width: 96px;
   height: 96px;
   border-radius: 50%;
@@ -1620,27 +1620,27 @@
   border: 1px solid var(--color-border);
   background: var(--color-bg-tertiary);
 }
-.author-card__body {
+.author-card-body {
   min-width: 0;
 }
-.author-card__name {
+.author-card-name {
   font-size: 1.125rem;
   font-weight: 600;
   color: var(--color-text);
   margin: 0 0 var(--space-1) 0;
 }
-.author-card__role {
+.author-card-role {
   font-size: 0.875rem;
   color: var(--color-text-secondary);
   margin: 0 0 var(--space-3) 0;
 }
-.author-card__bio {
+.author-card-bio {
   font-size: 0.9375rem;
   color: var(--color-text-secondary);
   line-height: 1.6;
   margin: 0 0 var(--space-3) 0;
 }
-.author-card__credentials {
+.author-card-credentials {
   list-style: none;
   padding: 0;
   margin: 0 0 var(--space-3) 0;
@@ -1648,7 +1648,7 @@
   flex-wrap: wrap;
   gap: var(--space-2);
 }
-.author-card__credentials li {
+.author-card-credentials li {
   font-size: 0.8125rem;
   color: var(--color-text-tertiary);
   padding: var(--space-1) var(--space-3);
@@ -1656,7 +1656,7 @@
   border-radius: 999px;
   background: var(--color-bg-tertiary);
 }
-.author-card__links {
+.author-card-links {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -1664,7 +1664,7 @@
   flex-wrap: wrap;
   gap: var(--space-4);
 }
-.author-card__links a {
+.author-card-links a {
   font-size: 0.8125rem;
   color: var(--color-text-secondary);
   text-decoration: none;
@@ -1672,8 +1672,8 @@
   padding-bottom: 2px;
   transition: color 0.15s, border-color 0.15s;
 }
-.author-card__links a:hover,
-.author-card__links a:focus {
+.author-card-links a:hover,
+.author-card-links a:focus {
   color: var(--color-accent);
   border-bottom-color: var(--color-accent);
 }
@@ -1682,7 +1682,7 @@
     grid-template-columns: 1fr;
     text-align: left;
   }
-  .author-card__photo {
+  .author-card-photo {
     width: 72px;
     height: 72px;
   }
@@ -1700,20 +1700,20 @@
   border-bottom: 1px solid var(--color-border);
   margin-bottom: var(--space-6);
 }
-.blog-listing-author__label {
+.blog-listing-author-label {
   color: var(--color-text-tertiary);
 }
-.blog-listing-author__name {
+.blog-listing-author-name {
   color: var(--color-text);
   font-weight: 500;
   text-decoration: none;
   border-bottom: 1px solid transparent;
 }
-.blog-listing-author__name:hover,
-.blog-listing-author__name:focus {
+.blog-listing-author-name:hover,
+.blog-listing-author-name:focus {
   color: var(--color-accent);
   border-bottom-color: var(--color-accent);
 }
-.blog-listing-author__role {
+.blog-listing-author-role {
   color: var(--color-text-tertiary);
 }

--- a/plugins/soleur/docs/css/style.css
+++ b/plugins/soleur/docs/css/style.css
@@ -1595,3 +1595,125 @@
   .site-header, .category-nav, .site-footer, .nav-toggle-label { display: none !important; }
   .page-hero, .landing-hero { margin-top: 0; }
 }
+
+/* --- Blog author card (inline, below post prose) ------------------------ */
+/* Rendered by _includes/blog-post.njk after the prose <section>. Mirrors
+   the structure referenced in the extended BlogPosting Person JSON-LD. */
+.author-card-section {
+  padding: var(--space-8, 3rem) 0;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
+}
+.author-card {
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  gap: var(--space-6);
+  align-items: start;
+  max-width: 720px;
+  margin: 0 auto;
+}
+.author-card__photo {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-tertiary);
+}
+.author-card__body {
+  min-width: 0;
+}
+.author-card__name {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 0 0 var(--space-1) 0;
+}
+.author-card__role {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--space-3) 0;
+}
+.author-card__bio {
+  font-size: 0.9375rem;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+  margin: 0 0 var(--space-3) 0;
+}
+.author-card__credentials {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 var(--space-3) 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+.author-card__credentials li {
+  font-size: 0.8125rem;
+  color: var(--color-text-tertiary);
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-bg-tertiary);
+}
+.author-card__links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+}
+.author-card__links a {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 2px;
+  transition: color 0.15s, border-color 0.15s;
+}
+.author-card__links a:hover,
+.author-card__links a:focus {
+  color: var(--color-accent);
+  border-bottom-color: var(--color-accent);
+}
+@media (max-width: 480px) {
+  .author-card {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
+  .author-card__photo {
+    width: 72px;
+    height: 72px;
+  }
+}
+
+/* --- Blog listing author banner (blog/ index only) ---------------------- */
+.blog-listing-author {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: var(--space-4) 0 var(--space-6);
+  font-size: 0.9375rem;
+  color: var(--color-text-secondary);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--space-6);
+}
+.blog-listing-author__label {
+  color: var(--color-text-tertiary);
+}
+.blog-listing-author__name {
+  color: var(--color-text);
+  font-weight: 500;
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+.blog-listing-author__name:hover,
+.blog-listing-author__name:focus {
+  color: var(--color-accent);
+  border-bottom-color: var(--color-accent);
+}
+.blog-listing-author__role {
+  color: var(--color-text-tertiary);
+}

--- a/plugins/soleur/docs/images/jean-deruelle.svg
+++ b/plugins/soleur/docs/images/jean-deruelle.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Placeholder author monogram for Jean Deruelle.
+  512×512, neutral monochrome. Used by the blog-post author card and
+  the extended Person JSON-LD (site.author.image). Replace with a real
+  editorial headshot when one is available — drop the JPG/PNG at the
+  same basename and update site.author.image accordingly.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" role="img" aria-label="Jean Deruelle — Founder of Soleur">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1a1a1a"/>
+      <stop offset="1" stop-color="#0a0a0a"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="256" ry="256" fill="url(#bg)"/>
+  <circle cx="256" cy="256" r="252" fill="none" stroke="#2a2a2a" stroke-width="2"/>
+  <g font-family="Georgia, 'Times New Roman', serif" font-weight="400" fill="#f5f5f5" text-anchor="middle">
+    <text x="256" y="300" font-size="200" letter-spacing="-8">JD</text>
+  </g>
+  <g font-family="system-ui, -apple-system, sans-serif" font-size="20" fill="#888" text-anchor="middle" letter-spacing="4">
+    <text x="256" y="420">JEAN DERUELLE</text>
+  </g>
+</svg>

--- a/plugins/soleur/docs/pages/about.njk
+++ b/plugins/soleur/docs/pages/about.njk
@@ -32,9 +32,9 @@ permalink: about/index.html
             Jean writes about agentic engineering, solo founding, and the mechanics of the billion-dollar one-person company on the <a href="/blog/">Soleur blog</a>. His thesis: the combination of AI agent orchestration and compounding institutional knowledge will enable <a href="https://www.inc.com/ben-sherry/anthropic-ceo-dario-amodei-predicts-the-first-billion-dollar-solopreneur-by-2026/91193609" rel="noopener noreferrer">the first single-person billion-dollar company</a>.
           </p>
           <ul>
-            <li><a href="{{ site.x }}" target="_blank" rel="noopener">@soleur_ai on X / Twitter</a></li>
-            <li><a href="{{ site.linkedin }}" target="_blank" rel="noopener">LinkedIn</a></li>
-            <li><a href="{{ site.github }}" target="_blank" rel="noopener">GitHub</a></li>
+            <li><a href="{{ site.x }}" target="_blank" rel="noopener noreferrer">@soleur_ai on X / Twitter</a></li>
+            <li><a href="{{ site.linkedin }}" target="_blank" rel="noopener noreferrer">LinkedIn</a></li>
+            <li><a href="{{ site.github }}" target="_blank" rel="noopener noreferrer">GitHub</a></li>
           </ul>
         </div>
       </section>

--- a/plugins/soleur/docs/pages/about.njk
+++ b/plugins/soleur/docs/pages/about.njk
@@ -13,7 +13,7 @@ permalink: about/index.html
     </section>
 
     <div class="container">
-      <section class="category-section">
+      <section id="jean-deruelle" class="category-section">
         <div class="category-header">
           <h2 class="category-title">Jean Deruelle</h2>
           <span class="category-count">Founder</span>
@@ -140,6 +140,7 @@ permalink: about/index.html
       "url": {{ (site.url + "/about/") | jsonLdSafe | safe }},
       "mainEntity": {
         "@type": "Person",
+        "@id": {{ (site.url + "/about/#jean-deruelle") | jsonLdSafe | safe }},
         "name": "Jean Deruelle",
         "url": {{ (site.url + "/about/") | jsonLdSafe | safe }},
         "jobTitle": "Founder",

--- a/plugins/soleur/docs/pages/blog.njk
+++ b/plugins/soleur/docs/pages/blog.njk
@@ -31,9 +31,9 @@ permalink: blog/index.html
 
 <div class="container">
   <div class="blog-listing-author" aria-label="Blog author">
-    <span class="blog-listing-author__label">By</span>
-    <a class="blog-listing-author__name" href="{{ site.author.url }}" rel="author">{{ site.author.name }}</a>
-    <span class="blog-listing-author__role">{{ site.author.role }} of {{ site.name }}</span>
+    <span class="blog-listing-author-label">By</span>
+    <a class="blog-listing-author-name" href="{{ site.author.url }}" rel="author">{{ site.author.name }}</a>
+    <span class="blog-listing-author-role">{{ site.author.role }} of {{ site.name }}</span>
   </div>
 
   {% if collections.blog and collections.blog.length > 0 %}

--- a/plugins/soleur/docs/pages/blog.njk
+++ b/plugins/soleur/docs/pages/blog.njk
@@ -1,5 +1,6 @@
 ---
 title: Blog
+seoTitle: "Blog — Soleur"
 description: "Insights on agentic engineering, company-as-a-service, and building at scale with AI teams."
 layout: base.njk
 permalink: blog/index.html
@@ -17,7 +18,7 @@ permalink: blog/index.html
 {
   "@context": "https://schema.org",
   "@type": "CollectionPage",
-  "name": {{ (title + " - " + site.name) | jsonLdSafe | safe }},
+  "name": {{ (seoTitle or (title + " — " + site.name)) | jsonLdSafe | safe }},
   "description": {{ description | jsonLdSafe | safe }},
   "url": {{ (site.url + "/blog/") | jsonLdSafe | safe }},
   "publisher": {

--- a/plugins/soleur/docs/pages/blog.njk
+++ b/plugins/soleur/docs/pages/blog.njk
@@ -30,6 +30,12 @@ permalink: blog/index.html
 </script>
 
 <div class="container">
+  <div class="blog-listing-author" aria-label="Blog author">
+    <span class="blog-listing-author__label">By</span>
+    <a class="blog-listing-author__name" href="{{ site.author.url }}" rel="author">{{ site.author.name }}</a>
+    <span class="blog-listing-author__role">{{ site.author.role }} of {{ site.name }}</span>
+  </div>
+
   {% if collections.blog and collections.blog.length > 0 %}
 
   <nav class="category-nav" aria-label="Blog categories">

--- a/plugins/soleur/docs/pages/community.njk
+++ b/plugins/soleur/docs/pages/community.njk
@@ -1,5 +1,6 @@
 ---
 title: Community
+seoTitle: "Community — Soleur"
 description: "Join the Soleur community. Connect on Discord, contribute on GitHub, get help, and learn about our community guidelines."
 layout: base.njk
 permalink: community/

--- a/plugins/soleur/docs/pages/pricing.njk
+++ b/plugins/soleur/docs/pages/pricing.njk
@@ -323,7 +323,7 @@ ogImageAlt: "Soleur Pricing — Every department. One price."
           "name": "Why should I pay $49/mo when AI coding tools cost $20?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Coding tools handle code. Soleur handles the other 70% of running a company -- marketing, legal, finance, operations, product, sales, and support. One writes functions. The other runs departments. The replacement stack for what Soleur covers costs $95,000/mo in people."
+            "text": "Coding tools handle code. Soleur handles the other 70% of running a company — marketing, legal, finance, operations, product, sales, and support. A $20 coding tool and Soleur are not in the same category. One writes functions. The other runs departments. The replacement stack for what Soleur covers costs $95,000/mo in people."
           }
         },
         {
@@ -331,7 +331,7 @@ ogImageAlt: "Soleur Pricing — Every department. One price."
           "name": "What are concurrent conversations?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Concurrent conversations are how many chats can run work at the same time. On the Solo plan, two conversations run in parallel -- your CTO reviews a pull request while your CMO drafts a blog post. Inside one conversation, you can @mention multiple specialists and they work together on that thread. Every plan includes every agent. Concurrency determines parallelism, not access."
+            "text": "Concurrent conversations are how many chats can run work at the same time. On the Solo plan, two conversations run in parallel — your CTO reviews a pull request while your CMO drafts a blog post. Inside one conversation, you can @mention multiple specialists and they work together on that single thread. Every plan includes every agent. Concurrency determines parallelism, not access."
           }
         },
         {
@@ -339,7 +339,7 @@ ogImageAlt: "Soleur Pricing — Every department. One price."
           "name": "Do I pay for Claude separately?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Yes. Soleur is the organization layer -- the agents, knowledge base, and cross-domain orchestration. Claude provides the intelligence. Self-hosted users bring their own API key. Hosted plan users pay their Soleur subscription plus their own Claude Pro, Max, or API costs."
+            "text": "Yes. Soleur is the organization layer — the agents, knowledge base, and cross-domain orchestration. Claude provides the intelligence. Self-hosted users bring their own API key. Hosted plan users pay their Soleur subscription plus their own Claude Pro, Max, or API costs. You choose the Claude plan that fits your usage."
           }
         },
         {
@@ -347,7 +347,7 @@ ogImageAlt: "Soleur Pricing — Every department. One price."
           "name": "Is there a free option?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Yes. The self-hosted version is free, open-source, and Apache-2.0 licensed. You get the full platform -- every agent, every skill, every department. You provide the infrastructure and the Claude API key. The paid plans add managed hosting, cloud-synced knowledge, priority execution, and team features."
+            "text": "Yes. The self-hosted version is free, open-source, and Apache-2.0 licensed. You get the full platform — every agent, every skill, every department. You provide the infrastructure and the Claude API key. The paid plans add managed hosting, cloud-synced knowledge, priority execution, and team features."
           }
         },
         {
@@ -355,7 +355,7 @@ ogImageAlt: "Soleur Pricing — Every department. One price."
           "name": "When do paid plans launch?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "We are building the hosted platform now. Join the waitlist to get early access and founder pricing. The self-hosted version is available today."
+            "text": "We are building the hosted platform now. Join the waitlist to get early access and founder pricing when we launch. The self-hosted version is available today."
           }
         },
         {
@@ -371,7 +371,7 @@ ogImageAlt: "Soleur Pricing — Every department. One price."
           "name": "What is the methodology behind the $95K/mo number?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Fully-loaded compensation assumes US market median base salary plus approximately 30-40% overhead for benefits, payroll tax, and equity -- the standard total-comp methodology used by Levels.fyi. The eight roles represent the minimum viable leadership headcount for a typical early-stage SaaS company. Figures are 2025-2026 medians and will be refreshed each salary-guide cycle. Comparisons are illustrative, not a guarantee of hiring cost; regional variance, equity mix, and seniority tier all move the number."
+            "text": "Fully-loaded compensation assumes US market median base salary plus approximately 30–40% overhead for benefits, payroll tax, and equity — the standard total-comp methodology used by Levels.fyi. The eight roles represent the minimum viable leadership headcount for a typical early-stage SaaS company. Figures are 2025–2026 medians and will be refreshed each salary-guide cycle. Comparisons are illustrative, not a guarantee of hiring cost; regional variance, equity mix, and seniority tier all move the number."
           }
         }
       ]

--- a/plugins/soleur/docs/pages/pricing.njk
+++ b/plugins/soleur/docs/pages/pricing.njk
@@ -1,5 +1,6 @@
 ---
 title: Pricing
+seoTitle: "Pricing — AI Agents for Solo Founders | Soleur"
 description: "All 8 departments -- engineering, marketing, legal, finance, sales, operations, product, and support -- from $49/month. Less than a single contractor."
 layout: base.njk
 permalink: pricing/
@@ -300,6 +301,14 @@ ogImageAlt: "Soleur Pricing — Every department. One price."
             <summary class="faq-question">When do paid plans launch?</summary>
             <p class="faq-answer">We are building the hosted platform now. Join the waitlist to get early access and founder pricing when we launch. The self-hosted version is available today.</p>
           </details>
+          <details class="faq-item">
+            <summary class="faq-question">How does the $95,000/mo replacement stack break down?</summary>
+            <p class="faq-answer">The eight-role comparison stack at the top of this page sums to $95,000/mo of fully-loaded US median compensation: CTO/VP Engineering $18K, General Counsel $15K, CFO $15K, Sales Director $12K, Marketing Director $10K, Product Manager $10K, Operations Manager $8K, Support Lead $7K. Per-role salary medians are cross-checked against the <a href="https://www.roberthalf.com/us/en/insights/salary-guide" rel="noopener noreferrer" target="_blank">Robert Half 2026 Salary Guide</a> and the <a href="https://www.payscale.com/research/US/Country=United_States/Salary" rel="noopener noreferrer" target="_blank">Payscale US compensation database</a>. Engineering total-comp uses <a href="https://www.levels.fyi/" rel="noopener noreferrer" target="_blank">Levels.fyi</a> for base plus equity plus bonus.</p>
+          </details>
+          <details class="faq-item">
+            <summary class="faq-question">What is the methodology behind the $95K/mo number?</summary>
+            <p class="faq-answer">Fully-loaded compensation assumes US market median base salary plus approximately 30&ndash;40% overhead for benefits, payroll tax, and equity &mdash; the standard total-comp methodology used by <a href="https://www.levels.fyi/" rel="noopener noreferrer" target="_blank">Levels.fyi</a>. The eight roles represent the minimum viable leadership headcount for a typical early-stage SaaS company. Figures are 2025&ndash;2026 medians and will be refreshed each salary-guide cycle. Comparisons are illustrative, not a guarantee of hiring cost; regional variance, equity mix, and seniority tier all move the number.</p>
+          </details>
         </div>
       </div>
     </section>
@@ -347,6 +356,22 @@ ogImageAlt: "Soleur Pricing — Every department. One price."
           "acceptedAnswer": {
             "@type": "Answer",
             "text": "We are building the hosted platform now. Join the waitlist to get early access and founder pricing. The self-hosted version is available today."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How does the $95,000/mo replacement stack break down?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "The eight-role comparison stack sums to $95,000/mo of fully-loaded US median compensation: CTO/VP Engineering $18K, General Counsel $15K, CFO $15K, Sales Director $12K, Marketing Director $10K, Product Manager $10K, Operations Manager $8K, Support Lead $7K. Per-role salary medians are cross-checked against the Robert Half 2026 Salary Guide and the Payscale US compensation database. Engineering total-comp uses Levels.fyi for base plus equity plus bonus."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What is the methodology behind the $95K/mo number?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Fully-loaded compensation assumes US market median base salary plus approximately 30-40% overhead for benefits, payroll tax, and equity -- the standard total-comp methodology used by Levels.fyi. The eight roles represent the minimum viable leadership headcount for a typical early-stage SaaS company. Figures are 2025-2026 medians and will be refreshed each salary-guide cycle. Comparisons are illustrative, not a guarantee of hiring cost; regional variance, equity mix, and seniority tier all move the number."
           }
         }
       ]

--- a/plugins/soleur/test/fixtures/jsonld-escaping/_data/site.json
+++ b/plugins/soleur/test/fixtures/jsonld-escaping/_data/site.json
@@ -15,7 +15,11 @@
     "name": "Fixture Author",
     "url": "https://example.test/about/",
     "role": "Fixture Role",
-    "company": "Fixture Co"
+    "company": "Fixture Co",
+    "image": "/images/fixture-author.svg",
+    "bio": "Fixture bio with \"quotes\" and </script><script>alert(1)</script> breakout.",
+    "credentials": ["Credential with \"quotes\"", "Credential with & ampersand"],
+    "sameAs": ["https://github.com/fixture", "https://x.com/fixture"]
   },
   "footerColumns": [],
   "footerLegal": []

--- a/plugins/soleur/test/seo-aeo-drift-guard.test.ts
+++ b/plugins/soleur/test/seo-aeo-drift-guard.test.ts
@@ -1,0 +1,235 @@
+// SEO/AEO drift-guard — enforces the on-page markup invariants closed by
+// #2707 (visible FAQ matches FAQPage JSON-LD on /pricing/),
+// #2708 (homepage <title> scoped to marketing brand, not Next.js dashboard),
+// #2709 (brand-anchored <title> on pricing/community/blog — no bare single words),
+// #2711 (inline author card + extended Person JSON-LD on every blog post).
+//
+// Test harness: bun:test (matches sibling tests in plugins/soleur/test/*.ts).
+// Build gating: if _site/ is absent, runs `npx @11ty/eleventy` from the repo
+// root (see eleventy.config.js INPUT constant — build MUST run from repo root
+// per learning 2026-03-15-eleventy-build-must-run-from-repo-root.md).
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { resolve, join } from "path";
+import { existsSync, readFileSync, readdirSync, statSync } from "fs";
+import { spawnSync } from "child_process";
+
+// plugins/soleur/test/ → ../../.. is the worktree (repo) root
+const REPO_ROOT = resolve(import.meta.dir, "../../..");
+const SITE = resolve(REPO_ROOT, "_site");
+const INDEX_NJK = resolve(REPO_ROOT, "plugins/soleur/docs/index.njk");
+
+beforeAll(() => {
+  if (!existsSync(SITE)) {
+    const res = spawnSync("npx", ["@11ty/eleventy"], {
+      cwd: REPO_ROOT,
+      stdio: "inherit",
+    });
+    if (res.status !== 0) {
+      throw new Error(
+        `Eleventy build failed in test setup (exit ${res.status}). Run 'npx @11ty/eleventy' from repo root to reproduce.`,
+      );
+    }
+  }
+});
+
+// -- helpers ---------------------------------------------------------------
+
+function readSite(relPath: string): string {
+  const abs = resolve(SITE, relPath);
+  if (!existsSync(abs)) {
+    throw new Error(
+      `Expected built file missing: ${abs}. Did Eleventy build succeed?`,
+    );
+  }
+  return readFileSync(abs, "utf8");
+}
+
+function jsonLdBlocks(html: string): unknown[] {
+  const re = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
+  const out: unknown[] = [];
+  for (const m of html.matchAll(re)) {
+    out.push(JSON.parse(m[1]));
+  }
+  return out;
+}
+
+function extractTitle(html: string): string {
+  const m = html.match(/<title>([\s\S]*?)<\/title>/);
+  if (!m) throw new Error("no <title> in HTML");
+  return m[1].trim();
+}
+
+function extractFrontMatterSeoTitle(njkPath: string): string | null {
+  const src = readFileSync(njkPath, "utf8");
+  const m = src.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return null;
+  const fm = m[1];
+  // seoTitle can be bare or quoted (single, double). Capture the raw value.
+  const line = fm.match(/^seoTitle:\s*(.+)$/m);
+  if (!line) return null;
+  let v = line[1].trim();
+  if (
+    (v.startsWith('"') && v.endsWith('"')) ||
+    (v.startsWith("'") && v.endsWith("'"))
+  ) {
+    v = v.slice(1, -1);
+  }
+  return v;
+}
+
+function walkHtmlFiles(dir: string): string[] {
+  const out: string[] = [];
+  if (!existsSync(dir)) return out;
+  for (const ent of readdirSync(dir)) {
+    const full = join(dir, ent);
+    const st = statSync(full);
+    if (st.isDirectory()) out.push(...walkHtmlFiles(full));
+    else if (st.isFile() && full.endsWith(".html")) out.push(full);
+  }
+  return out;
+}
+
+// -- Test 1: pricing FAQ parity -------------------------------------------
+
+describe("#2707 pricing FAQ — visible <details> matches FAQPage JSON-LD", () => {
+  test("JSON-LD mainEntity count equals visible <details class=\"faq-item\"> count and every name has a <summary>", () => {
+    const html = readSite("pricing/index.html");
+    const blocks = jsonLdBlocks(html);
+    const faq = blocks.find(
+      (b): b is { "@type": string; mainEntity: { name: string }[] } =>
+        typeof b === "object" &&
+        b !== null &&
+        (b as { "@type"?: string })["@type"] === "FAQPage",
+    );
+    expect(faq).toBeDefined();
+    const summaries = [
+      ...html.matchAll(
+        /<summary class="faq-question">([\s\S]*?)<\/summary>/g,
+      ),
+    ].map((m) => m[1].replace(/<[^>]+>/g, "").trim());
+    const detailsCount = [
+      ...html.matchAll(/<details class="faq-item">/g),
+    ].length;
+    const names = faq!.mainEntity.map((q) => q.name.trim());
+    expect(detailsCount).toBe(names.length);
+    expect(summaries.length).toBe(names.length);
+    for (const name of names) {
+      expect(summaries).toContain(name);
+    }
+  });
+});
+
+// -- Test 2: brand-anchored <title> --------------------------------------
+
+describe("#2709 <title> is brand-anchored on pricing/community/blog + index", () => {
+  const pages = [
+    "index.html",
+    "pricing/index.html",
+    "community/index.html",
+    "blog/index.html",
+  ];
+  const bareBanned = new Set(["Pricing", "Community", "Blog"]);
+
+  for (const p of pages) {
+    test(`${p} <title> contains "Soleur" and a separator, not a bare single word`, () => {
+      const html = readSite(p);
+      const t = extractTitle(html);
+      expect(t).toContain("Soleur");
+      expect(t.includes("—") || t.includes("|") || t.includes(" - ")).toBe(
+        true,
+      );
+      expect(bareBanned.has(t)).toBe(false);
+    });
+  }
+});
+
+// -- Test 3: homepage <title> equals seoTitle string exactly --------------
+
+describe("#2708 homepage <title> matches docs/index.njk seoTitle exactly", () => {
+  test("exact string match", () => {
+    const html = readSite("index.html");
+    const t = extractTitle(html);
+    const expected = extractFrontMatterSeoTitle(INDEX_NJK);
+    expect(expected).toBeTruthy();
+    expect(t).toBe(expected!);
+  });
+});
+
+// -- Test 4: inline author card + extended Person JSON-LD on blog posts ---
+
+describe("#2711 blog posts render author card + extended Person JSON-LD", () => {
+  const blogDir = resolve(SITE, "blog");
+  const entries = existsSync(blogDir)
+    ? readdirSync(blogDir).filter((e) => {
+        const p = join(blogDir, e);
+        return statSync(p).isDirectory() && existsSync(join(p, "index.html"));
+      })
+    : [];
+
+  test("at least one blog post rendered", () => {
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  for (const slug of entries) {
+    test(`${slug}: author-card DOM + Person JSON-LD with image+sameAs`, () => {
+      const html = readSite(`blog/${slug}/index.html`);
+      // Author card DOM
+      expect(html).toContain('class="author-card"');
+      expect(html).toMatch(/<img[^>]+src="\/images\/jean-deruelle\.(jpg|png|svg)"/);
+      // BlogPosting JSON-LD with Person author extended with image + sameAs
+      const blocks = jsonLdBlocks(html);
+      const post = blocks.find(
+        (b): b is {
+          "@type": string;
+          author: {
+            "@type": string;
+            image?: string;
+            sameAs?: string[];
+          };
+        } =>
+          typeof b === "object" &&
+          b !== null &&
+          (b as { "@type"?: string })["@type"] === "BlogPosting",
+      );
+      expect(post).toBeDefined();
+      expect(post!.author["@type"]).toBe("Person");
+      expect(typeof post!.author.image).toBe("string");
+      expect(post!.author.image!.length).toBeGreaterThan(0);
+      expect(Array.isArray(post!.author.sameAs)).toBe(true);
+      expect(post!.author.sameAs!.length).toBeGreaterThanOrEqual(2);
+    });
+  }
+});
+
+// -- Test 5: every JSON-LD block parses as valid JSON --------------------
+
+describe("all <script type=\"application/ld+json\"> blocks parse as valid JSON", () => {
+  test("no malformed JSON-LD anywhere in _site", () => {
+    const files = walkHtmlFiles(SITE);
+    expect(files.length).toBeGreaterThan(0);
+    const failures: { file: string; err: string; snippet: string }[] = [];
+    for (const f of files) {
+      const html = readFileSync(f, "utf8");
+      const re =
+        /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
+      for (const m of html.matchAll(re)) {
+        try {
+          JSON.parse(m[1]);
+        } catch (e) {
+          failures.push({
+            file: f,
+            err: (e as Error).message,
+            snippet: m[1].slice(0, 200),
+          });
+        }
+      }
+    }
+    if (failures.length > 0) {
+      const msg = failures
+        .map((f) => `${f.file}: ${f.err}\n  ${f.snippet}`)
+        .join("\n");
+      throw new Error(`Invalid JSON-LD in ${failures.length} block(s):\n${msg}`);
+    }
+  });
+});

--- a/plugins/soleur/test/seo-aeo-drift-guard.test.ts
+++ b/plugins/soleur/test/seo-aeo-drift-guard.test.ts
@@ -160,10 +160,19 @@ describe("#2708 homepage <title> matches docs/index.njk seoTitle exactly", () =>
 
 describe("#2711 blog posts render author card + extended Person JSON-LD", () => {
   const blogDir = resolve(SITE, "blog");
+  // Filter out redirect stubs built from `blog/redirects.njk` — those are
+  // meta-refresh pages (no layout, no content), not real posts. Detected by
+  // a short (<800 bytes) HTML body containing `<meta http-equiv="refresh"`.
   const entries = existsSync(blogDir)
     ? readdirSync(blogDir).filter((e) => {
         const p = join(blogDir, e);
-        return statSync(p).isDirectory() && existsSync(join(p, "index.html"));
+        const idx = join(p, "index.html");
+        if (!statSync(p).isDirectory() || !existsSync(idx)) return false;
+        const body = readFileSync(idx, "utf8");
+        if (body.length < 2000 && /<meta\s+http-equiv="refresh"/i.test(body)) {
+          return false;
+        }
+        return true;
       })
     : [];
 

--- a/plugins/soleur/test/seo-aeo-drift-guard.test.ts
+++ b/plugins/soleur/test/seo-aeo-drift-guard.test.ts
@@ -68,6 +68,9 @@ afterAll(() => {
 
 // -- helpers ---------------------------------------------------------------
 
+const JSONLD_BLOCK_RE =
+  /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
+
 function readSite(relPath: string): string {
   const abs = resolve(SITE, relPath);
   if (!existsSync(abs)) {
@@ -78,13 +81,13 @@ function readSite(relPath: string): string {
   return readFileSync(abs, "utf8");
 }
 
+function jsonLdBlockBodies(html: string): string[] {
+  // Reset regex lastIndex because the global flag shares state across calls.
+  return [...html.matchAll(JSONLD_BLOCK_RE)].map((m) => m[1]);
+}
+
 function jsonLdBlocks(html: string): unknown[] {
-  const re = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
-  const out: unknown[] = [];
-  for (const m of html.matchAll(re)) {
-    out.push(JSON.parse(m[1]));
-  }
-  return out;
+  return jsonLdBlockBodies(html).map((body) => JSON.parse(body));
 }
 
 function extractTitle(html: string): string {
@@ -287,32 +290,17 @@ describe("all <script type=\"application/ld+json\"> blocks parse as valid JSON",
     const failures: { file: string; err: string; snippet: string }[] = [];
     for (const f of files) {
       const html = readFileSync(f, "utf8");
-      try {
-        // jsonLdBlocks throws on the first invalid block — wrap per-file so
-        // we accumulate failures across files instead of aborting on the first.
-        jsonLdBlocks(html);
-      } catch (e) {
-        // Re-scan this file block-by-block to report which snippet failed.
-        const re =
-          /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
-        for (const m of html.matchAll(re)) {
-          try {
-            JSON.parse(m[1]);
-          } catch (inner) {
-            failures.push({
-              file: f,
-              err: (inner as Error).message,
-              snippet: m[1].slice(0, 200),
-            });
-          }
-        }
-        // Defensive: if the top-level catch fired but no block failed inner
-        // JSON.parse (shouldn't happen), surface the original error.
-        if (failures.length === 0) {
+      // Reuse the shared extractor (jsonLdBlockBodies) + try/catch per-block
+      // so failures accumulate across the whole site rather than aborting on
+      // the first bad block.
+      for (const body of jsonLdBlockBodies(html)) {
+        try {
+          JSON.parse(body);
+        } catch (e) {
           failures.push({
             file: f,
             err: (e as Error).message,
-            snippet: "<no-extractable-block>",
+            snippet: body.slice(0, 200),
           });
         }
       }

--- a/plugins/soleur/test/seo-aeo-drift-guard.test.ts
+++ b/plugins/soleur/test/seo-aeo-drift-guard.test.ts
@@ -5,31 +5,64 @@
 // #2711 (inline author card + extended Person JSON-LD on every blog post).
 //
 // Test harness: bun:test (matches sibling tests in plugins/soleur/test/*.ts).
-// Build gating: if _site/ is absent, runs `npx @11ty/eleventy` from the repo
-// root (see eleventy.config.js INPUT constant — build MUST run from repo root
-// per learning 2026-03-15-eleventy-build-must-run-from-repo-root.md).
+// Build: runs `npx @11ty/eleventy` into a tmp output dir so each test invocation
+// produces a fresh build (mirrors plugins/soleur/test/jsonld-escaping.test.ts).
+// Set SEO_AEO_SKIP_BUILD=1 to reuse an existing _site/ at repo root (rare —
+// only useful for iterative local debugging of the drift-guard itself).
 
-import { describe, test, expect, beforeAll } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { resolve, join } from "path";
-import { existsSync, readFileSync, readdirSync, statSync } from "fs";
-import { spawnSync } from "child_process";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  mkdtempSync,
+  rmSync,
+} from "fs";
+import { tmpdir } from "os";
 
 // plugins/soleur/test/ → ../../.. is the worktree (repo) root
 const REPO_ROOT = resolve(import.meta.dir, "../../..");
-const SITE = resolve(REPO_ROOT, "_site");
+const SITE_JSON = resolve(
+  REPO_ROOT,
+  "plugins/soleur/docs/_data/site.json",
+);
 const INDEX_NJK = resolve(REPO_ROOT, "plugins/soleur/docs/index.njk");
+const LAYOUT_TSX = resolve(
+  REPO_ROOT,
+  "apps/web-platform/app/layout.tsx",
+);
+
+let SITE: string;
+let tmpSite: string | null = null;
 
 beforeAll(() => {
-  if (!existsSync(SITE)) {
-    const res = spawnSync("npx", ["@11ty/eleventy"], {
-      cwd: REPO_ROOT,
-      stdio: "inherit",
-    });
-    if (res.status !== 0) {
+  if (process.env.SEO_AEO_SKIP_BUILD === "1") {
+    SITE = resolve(REPO_ROOT, "_site");
+    if (!existsSync(SITE)) {
       throw new Error(
-        `Eleventy build failed in test setup (exit ${res.status}). Run 'npx @11ty/eleventy' from repo root to reproduce.`,
+        "SEO_AEO_SKIP_BUILD=1 set but _site/ not found. Run `npx @11ty/eleventy` first.",
       );
     }
+    return;
+  }
+  tmpSite = mkdtempSync(join(tmpdir(), "seo-aeo-drift-"));
+  SITE = tmpSite;
+  const proc = Bun.spawnSync(
+    ["npx", "@11ty/eleventy", `--output=${tmpSite}`],
+    { cwd: REPO_ROOT, stdout: "inherit", stderr: "inherit" },
+  );
+  if (proc.exitCode !== 0) {
+    throw new Error(
+      `Eleventy build failed in test setup (exit ${proc.exitCode}). Run 'npx @11ty/eleventy' from repo root to reproduce.`,
+    );
+  }
+});
+
+afterAll(() => {
+  if (tmpSite) {
+    rmSync(tmpSite, { recursive: true, force: true });
   }
 });
 
@@ -159,33 +192,67 @@ describe("#2708 homepage <title> matches docs/index.njk seoTitle exactly", () =>
 // -- Test 4: inline author card + extended Person JSON-LD on blog posts ---
 
 describe("#2711 blog posts render author card + extended Person JSON-LD", () => {
-  const blogDir = resolve(SITE, "blog");
-  // Filter out redirect stubs built from `blog/redirects.njk` — those are
-  // meta-refresh pages (no layout, no content), not real posts. Detected by
-  // a short (<800 bytes) HTML body containing `<meta http-equiv="refresh"`.
-  const entries = existsSync(blogDir)
-    ? readdirSync(blogDir).filter((e) => {
-        const p = join(blogDir, e);
-        const idx = join(p, "index.html");
-        if (!statSync(p).isDirectory() || !existsSync(idx)) return false;
-        const body = readFileSync(idx, "utf8");
-        if (body.length < 2000 && /<meta\s+http-equiv="refresh"/i.test(body)) {
-          return false;
-        }
-        return true;
-      })
-    : [];
+  // Load the canonical sameAs array from site.json so the drift-guard
+  // pins the exact post-state (cq-mutation-assertions-pin-exact-post-state).
+  // Evaluated lazily inside each test to avoid running before beforeAll.
+  const site = () =>
+    JSON.parse(readFileSync(SITE_JSON, "utf8")) as {
+      author: { sameAs: string[] };
+    };
 
   test("at least one blog post rendered", () => {
+    const blogDir = resolve(SITE, "blog");
+    const entries = existsSync(blogDir)
+      ? readdirSync(blogDir).filter((e) => {
+          const p = join(blogDir, e);
+          const idx = join(p, "index.html");
+          if (!statSync(p).isDirectory() || !existsSync(idx)) return false;
+          const body = readFileSync(idx, "utf8");
+          if (body.length < 2000 && /<meta\s+http-equiv="refresh"/i.test(body)) {
+            return false;
+          }
+          return true;
+        })
+      : [];
     expect(entries.length).toBeGreaterThan(0);
   });
 
-  for (const slug of entries) {
-    test(`${slug}: author-card DOM + Person JSON-LD with image+sameAs`, () => {
+  test("every blog post: author-card DOM + Person JSON-LD image exists on disk + sameAs pins site.json exactly", () => {
+    const blogDir = resolve(SITE, "blog");
+    const entries = existsSync(blogDir)
+      ? readdirSync(blogDir).filter((e) => {
+          const p = join(blogDir, e);
+          const idx = join(p, "index.html");
+          if (!statSync(p).isDirectory() || !existsSync(idx)) return false;
+          const body = readFileSync(idx, "utf8");
+          if (body.length < 2000 && /<meta\s+http-equiv="refresh"/i.test(body)) {
+            return false;
+          }
+          return true;
+        })
+      : [];
+    const expectedSameAs = site().author.sameAs;
+
+    for (const slug of entries) {
       const html = readSite(`blog/${slug}/index.html`);
-      // Author card DOM
-      expect(html).toContain('class="author-card"');
-      expect(html).toMatch(/<img[^>]+src="\/images\/jean-deruelle\.(jpg|png|svg)"/);
+
+      // Author card DOM (flat-hyphen convention — see commit 3)
+      expect(html, `${slug}: author-card class`).toContain(
+        'class="author-card"',
+      );
+      const imgMatch = html.match(
+        /<img[^>]+src="(\/images\/jean-deruelle\.(?:jpg|png|svg))"/,
+      );
+      expect(imgMatch, `${slug}: author-card img src`).not.toBeNull();
+      // Pinned existence of the referenced asset on disk — catches the
+      // case where site.json references an image whose file was deleted.
+      const imgPath = imgMatch![1].replace(/^\//, "");
+      const absImg = resolve(SITE, imgPath);
+      expect(
+        existsSync(absImg),
+        `${slug}: author-card asset ${imgMatch![1]} missing from _site/`,
+      ).toBe(true);
+
       // BlogPosting JSON-LD with Person author extended with image + sameAs
       const blocks = jsonLdBlocks(html);
       const post = blocks.find(
@@ -201,14 +268,14 @@ describe("#2711 blog posts render author card + extended Person JSON-LD", () => 
           b !== null &&
           (b as { "@type"?: string })["@type"] === "BlogPosting",
       );
-      expect(post).toBeDefined();
+      expect(post, `${slug}: BlogPosting JSON-LD block`).toBeDefined();
       expect(post!.author["@type"]).toBe("Person");
       expect(typeof post!.author.image).toBe("string");
       expect(post!.author.image!.length).toBeGreaterThan(0);
-      expect(Array.isArray(post!.author.sameAs)).toBe(true);
-      expect(post!.author.sameAs!.length).toBeGreaterThanOrEqual(2);
-    });
-  }
+      // Deep equality in order — prevents silent shrinkage or reordering.
+      expect(post!.author.sameAs).toEqual(expectedSameAs);
+    }
+  });
 });
 
 // -- Test 5: every JSON-LD block parses as valid JSON --------------------
@@ -220,16 +287,32 @@ describe("all <script type=\"application/ld+json\"> blocks parse as valid JSON",
     const failures: { file: string; err: string; snippet: string }[] = [];
     for (const f of files) {
       const html = readFileSync(f, "utf8");
-      const re =
-        /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
-      for (const m of html.matchAll(re)) {
-        try {
-          JSON.parse(m[1]);
-        } catch (e) {
+      try {
+        // jsonLdBlocks throws on the first invalid block — wrap per-file so
+        // we accumulate failures across files instead of aborting on the first.
+        jsonLdBlocks(html);
+      } catch (e) {
+        // Re-scan this file block-by-block to report which snippet failed.
+        const re =
+          /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
+        for (const m of html.matchAll(re)) {
+          try {
+            JSON.parse(m[1]);
+          } catch (inner) {
+            failures.push({
+              file: f,
+              err: (inner as Error).message,
+              snippet: m[1].slice(0, 200),
+            });
+          }
+        }
+        // Defensive: if the top-level catch fired but no block failed inner
+        // JSON.parse (shouldn't happen), surface the original error.
+        if (failures.length === 0) {
           failures.push({
             file: f,
             err: (e as Error).message,
-            snippet: m[1].slice(0, 200),
+            snippet: "<no-extractable-block>",
           });
         }
       }
@@ -240,5 +323,19 @@ describe("all <script type=\"application/ld+json\"> blocks parse as valid JSON",
         .join("\n");
       throw new Error(`Invalid JSON-LD in ${failures.length} block(s):\n${msg}`);
     }
+  });
+});
+
+// -- Test 6: Next.js layout title is dashboard-scoped (prevent #2708) -----
+
+describe("#2708 — Next.js layout title is dashboard-scoped", () => {
+  test("apps/web-platform/app/layout.tsx uses dashboard template + default, not marketing brand", () => {
+    const src = readFileSync(LAYOUT_TSX, "utf8");
+    // Must NOT contain the old brand string that leaked onto marketing routes.
+    expect(src).not.toContain("One Command Center, 8 Departments");
+    // Must use the dashboard-scoped template.
+    expect(src).toContain("%s — Soleur Dashboard");
+    // Must use the dashboard default title.
+    expect(src).toContain("Soleur Dashboard — Your Command Center");
   });
 });

--- a/plugins/soleur/test/seo-aeo-drift-guard.test.ts
+++ b/plugins/soleur/test/seo-aeo-drift-guard.test.ts
@@ -58,7 +58,7 @@ beforeAll(() => {
       `Eleventy build failed in test setup (exit ${proc.exitCode}). Run 'npx @11ty/eleventy' from repo root to reproduce.`,
     );
   }
-});
+}, 60_000);
 
 afterAll(() => {
   if (tmpSite) {


### PR DESCRIPTION
## Summary

Drains the 2026-04-21 weekly growth-audit backlog in a single focused docs-site refactor (pattern from PR #2486).

- **#2707** (P0): Added visible FAQ section to `/pricing/` that mirrors the existing FAQPage JSON-LD (5 existing Q&A pairs + 2 new: aggregate-cost breakdown + methodology). Visible/JSON-LD parity is now drift-guard-enforced.
- **#2708** (P0): Resolved homepage `<title>` conflict between Eleventy (`soleur.ai/`) and Next.js (`app.soleur.ai`). Next.js root layout now uses `{ template: "%s — Soleur Dashboard", default: "Soleur Dashboard — Your Command Center" }` — marketing brand string lives only on Eleventy.
- **#2709** (P1): Brand-anchored bare single-word `<title>` on `/pricing/`, `/community/`, `/blog/`. Uses `seoTitle` override pattern (mirrors `docs/index.njk`); also reconciled Blog CollectionPage JSON-LD `name` to prefer seoTitle.
- **#2711** (P1): Inline author card on blog posts with photo + bio + credentials + sameAs; extended Person JSON-LD with `@id`, `image`, `description`, `knowsAbout`, `sameAs`. Added matching `id="jean-deruelle"` anchor on `/about/`. Blog listing gets compact byline.

Closes #2707
Closes #2708
Closes #2709
Closes #2711

## Changelog

### Docs site (plugins/soleur/docs)

- Visible FAQ section on `/pricing/` with 7 Q&A pairs (up from 0 visible / 5 JSON-LD); inline citations to Robert Half / Payscale / Levels.fyi salary data for the $95K/mo replacement-stack claim.
- Brand-anchored `<title>` on `/pricing/`, `/community/`, `/blog/` via `seoTitle` front-matter.
- Inline author card block on blog posts (photo, bio, credentials, sameAs links) + extended BlogPosting Person JSON-LD (@id, image, description, knowsAbout, sameAs).
- `/about/` gains matching `id="jean-deruelle"` anchor and ProfilePage Person @id for entity-graph stitching.
- Blog listing page renders compact "By Jean Deruelle, Founder of Soleur" byline.
- Added `docs/images/jean-deruelle.svg` monogram placeholder (follow-up #2799 tracks replacement with editorial headshot).
- `_data/site.json` author object extended with image, bio, credentials, sameAs.

### Web platform (apps/web-platform)

- Root layout `metadata.title` scoped to dashboard surface using Next.js 15 `{ template, default }` pattern.
- PWA manifest `name`/`description` aligned to dashboard scope.

### Test infrastructure

- New `plugins/soleur/test/seo-aeo-drift-guard.test.ts` (bun:test, 10 tests / 173 assertions) enforcing cross-page invariants: visible/JSON-LD FAQ parity, brand-anchored `<title>`, homepage exact-seoTitle, blog-post author card + Person JSON-LD completeness, universal JSON-LD parse-validity, Next.js layout title scoping.

## Review + fixes inline

`/soleur:review` ran 10 parallel agents and surfaced 6 semantic defects that the initial drift-guard accepted. All fixed inline on the branch:

- LinkedIn company URL misused as Person.sameAs (data-integrity)
- Weak `>=2` assertion on a 3-element sameAs array; no existsSync on image path
- `existsSync` build-skip caused stale `_site/` false-passes
- FAQ JSON-LD dropped sentences visible to humans (audience split)
- Person JSON-LD missing description and knowsAbout despite visible bio/credentials
- Dangling `@id` to `/about/#jean-deruelle` with no anchor
- BEM `__` convention drift (first uses in a 1594-line flat-hyphen file)
- Missing `noreferrer` on `target="_blank"` social links

Learning captured: `knowledge-base/project/learnings/2026-04-22-multi-agent-review-catches-aeo-semantic-drift.md`.

## Out of scope

- #2679 (rubric reconciliation) — CMO decision task, not a code fix. Remains open.
- Off-site AEO work (#2599–#2604) — tracked separately.
- Editorial headshot swap — filed as #2799.

## Test plan

- [x] Eleventy build succeeds zero warnings (`npx @11ty/eleventy`)
- [x] Drift-guard test passes 10/10 (`bun test plugins/soleur/test/seo-aeo-drift-guard.test.ts`)
- [x] `tsc --noEmit` clean in `apps/web-platform/`
- [x] Review findings resolved inline (8 commits on branch)
- [x] Preflight: security headers + migrations + lockfiles all PASS/SKIP
- [ ] ⏳ Post-merge: Google Rich Results Test against `/pricing/` confirms FAQPage valid with 7 questions
- [ ] ⏳ Post-merge: Rich Results Test on a blog post confirms BlogPosting with `author.image` + `author.sameAs` populated
- [ ] ⏳ Post-merge: next weekly growth audit shows M33–M36 roadmap rows flipping to Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)