### PR TITLE
chore(aeo): pin dual-rubric scorecard template and reconcile #2615

### DIFF
--- a/.github/workflows/scheduled-growth-audit.yml
+++ b/.github/workflows/scheduled-growth-audit.yml
@@ -71,6 +71,11 @@ jobs:
           plugin_marketplaces: 'https://github.com/jikig-ai/soleur.git'
           plugins: 'soleur@soleur'
           claude_args: '--model claude-opus-4-7 --max-turns 70 --allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,Task'
+          # Template-sync sentinel: weights, row labels, and grading scale inside Step 2
+          # below are duplicated across plugins/soleur/agents/marketing/growth-strategist.md
+          # (GEO/AEO Content Audit section) and the runbook parser at
+          # knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md
+          # Phase 2. Change one, change all three.
           prompt: |
             IMPORTANT: This is an automated CI workflow. The AGENTS.md rule
             Do NOT push directly to main.

--- a/.github/workflows/scheduled-growth-audit.yml
+++ b/.github/workflows/scheduled-growth-audit.yml
@@ -102,8 +102,31 @@ jobs:
             Task growth-strategist: "Audit the content at https://soleur.ai for GEO/AEO
             optimization: source citations, statistics, conversational readiness, FAQ
             structure, citation quality. If knowledge-base/overview/brand-guide.md exists,
-            read it. Produce a structured scoring table and detailed analysis. Use WebFetch
-            to retrieve pages."
+            read it. Use WebFetch to retrieve pages.
+
+            Produce BOTH scorecards below. Both tables are mandatory; do not omit either,
+            do not reorder dimensions, and do not rename row labels (downstream scripts
+            anchor on exact row names).
+
+            Table 1 - SAP Scorecard (headline, required):
+            Column headers: | Dimension | Weight | Score | Weighted | Notes |
+            Rows (in order): **Structure** (weight 40), **Authority** (weight 35),
+            **Presence** (weight 25), **Total** (weight 100).
+            Score cells use the form <n>/<weight> (e.g. 20/25). Weighted is the
+            absolute contribution to the overall total out of 100. Final row reports
+            the letter grade using the scale: A >= 90, B 80-89, B+ 75-79, C 60-74,
+            D < 60. Include the grading scale inline so readers can audit the grade.
+
+            Table 2 - 8-component AEO diagnostic (required):
+            Column headers: | Component | Weight | Score | Notes |
+            Rows (in order): FAQ structure & FAQPage schema (20), Answer density /
+            extractability (15), Statistics & specificity (15), Source citations (15),
+            Conversational readiness (10), Entity clarity (10), Authority / E-E-A-T (10),
+            Citation-friendly structure (5), **Total** (100).
+            Score cells use the form <n>/<weight>. Final row reports the total out of 100.
+
+            Follow the GEO/AEO Content Audit rubric in the growth-strategist agent
+            definition for what each dimension measures."
 
             Save the report to:
             knowledge-base/marketing/audits/soleur-ai/$(date +%Y-%m-%d)-aeo-audit.md

--- a/knowledge-base/project/brainstorms/2026-04-22-aeo-rubric-reconcile-2679-brainstorm.md
+++ b/knowledge-base/project/brainstorms/2026-04-22-aeo-rubric-reconcile-2679-brainstorm.md
@@ -1,0 +1,66 @@
+---
+date: 2026-04-22
+topic: AEO audit rubric reconciliation (#2679, #2615)
+issue: 2679
+related_issues: [2615, 2596, 2647, 2678]
+status: complete
+---
+
+# Brainstorm: AEO Audit Rubric Reconciliation
+
+## What We're Building
+
+Pin a **dual-rubric AEO audit template** (SAP headline + 8-component AEO diagnostic) so future runs of `scheduled-growth-audit.yml` produce deterministic, comparable scorecards. Close #2615 citing the 2026-04-21 audit where Presence scored 20/25 (80%), well above the ≥55/D threshold. Update the re-audit runbook to match.
+
+## Why This Approach
+
+The 04-18 → 04-19 → 04-21 rubric flip is drift, not a migration:
+
+| Date | Rubric | Presence | Overall |
+|---|---|---|---|
+| 2026-04-18 | SAP | 40/F | 72 |
+| 2026-04-19 | 8-component AEO | — (row absent) | 81/B |
+| 2026-04-21 | SAP | **20/25 (80%)** | 78/B+ |
+
+**Root cause:** Neither `.github/workflows/scheduled-growth-audit.yml` nor `plugins/soleur/agents/marketing/growth-strategist.md` prescribes a specific scorecard template. The workflow says "produce a structured scoring table"; the agent describes SAP dimensions qualitatively without pinning weights or grading scale. Each run freelances a table shape.
+
+The 8-component rubric that appeared on 04-19 is actually richer (source citations, authority, entity clarity, FAQ schema are split out), but it drops the cross-audit Presence comparison #2615 depends on. A dual-rubric template keeps SAP as the stable year-over-year headline while surfacing the richer diagnostic detail.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Rubric strategy | Dual: SAP headline + 8-component AEO diagnostic | Preserves cross-audit comparability for #2615 while capturing richer diagnostic signal |
+| #2615 verification | Close using 2026-04-21 audit (Presence 20/25 = 80%) | Evidence already exists; no need to wait another cron cycle |
+| Pin location | Workflow prompt **and** agent doc | Belt-and-suspenders: covers both cron and ad-hoc `/soleur:growth aeo` invocations |
+| Runbook update | Same PR | Atomic change: workflow + agent + runbook + #2615 closure land together |
+| Rubric weights (SAP) | Structure 40, Authority 35, Presence 25 (per 04-21 audit) | Matches the existing documented SAP framework; grading scale reused verbatim |
+| Rubric weights (AEO diagnostic) | FAQ 20, Answer density 15, Statistics 15, Source citations 15, Conversational 10, Entity clarity 10, Authority/E-E-A-T 10, Citation-friendly 5 | Matches the 04-19 run's weights; preserves the richer signal for trend-line analysis |
+
+## Non-Goals
+
+- Creating a separate audit workflow for AEO-only runs (the dual template folds into the existing scheduled-growth-audit cron).
+- Re-scoring past audits retroactively. The 04-19 audit stays as-is; the 04-21 audit is the verification baseline.
+- Touching `seo-aeo-analyst.md` — it owns technical SEO (JSON-LD, meta tags, sitemaps), not the content-level AEO scorecard.
+- Adding new audit outputs (dashboards, trend charts, alerting). YAGNI — two tables in one markdown file suffices.
+
+## Acceptance Criteria
+
+1. `.github/workflows/scheduled-growth-audit.yml` Step 2 prompt prescribes the exact SAP + AEO template (dimensions, weights, grading scale) by reference to the agent doc or inline.
+2. `plugins/soleur/agents/marketing/growth-strategist.md` GEO/AEO Content Audit section includes both scorecard templates with weights and grading scale.
+3. `knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md` Phase 2 anchor logic handles both rubrics (or points to the pinned template).
+4. #2615 closed referencing the 2026-04-21 audit (Presence 20/25 = 80% ≥ 55/D threshold).
+5. #2679 closed by the PR.
+
+## Open Questions
+
+- Does the agent need an explicit instruction to produce BOTH tables, or is prescribing the headline SAP template + secondary "Detailed AEO Diagnostic" section enough? (Leaning toward explicit "produce both" instruction to prevent single-table freelancing.)
+- Should the runbook move to `knowledge-base/engineering/ops/runbooks/` for better discoverability? (Out of scope for this PR; worth a separate cleanup.)
+
+## Domain Assessments
+
+**Assessed:** Marketing
+
+### Marketing
+
+**Summary:** Rubric pinning is a CMO operational concern (content audit determinism). SAP remains the canonical public-facing framework per `plugins/soleur/agents/marketing/growth-strategist.md`; the 8-component rubric is the diagnostic layer. Dual-template matches how the auditor already produced both framings across the three audits. No brand-guide implications.

--- a/knowledge-base/project/learnings/2026-04-22-agent-scorecard-determinism-requires-pinned-template.md
+++ b/knowledge-base/project/learnings/2026-04-22-agent-scorecard-determinism-requires-pinned-template.md
@@ -1,0 +1,68 @@
+---
+date: 2026-04-22
+category: integration-issues
+tags: [agents, scheduled-audits, determinism, prompt-engineering, aeo, growth-strategist]
+issue: 2679
+related_issues: [2615, 2596]
+module: growth-strategist
+---
+
+# Learning: Agent-produced scorecards drift when the template isn't pinned
+
+## Problem
+
+Three consecutive runs of `scheduled-growth-audit.yml` (2026-04-18, 04-19, 04-21) produced three different AEO scorecard shapes:
+
+- **04-18:** SAP framework (Structure/Authority/Presence), weights 40/35/25, Presence row present (40/F).
+- **04-19:** 8-component AEO rubric (FAQ structure, answer density, statistics, source citations, conversational readiness, entity clarity, authority, citation-friendly structure). No Presence row.
+- **04-21:** Back to SAP, Presence 20/25 (80%).
+
+The 04-19 drift broke #2615's exit criteria (Presence lift from 40/F → ≥55/D) because the Presence row was gone. Triage landed in #2679.
+
+## Root Cause
+
+Neither the workflow prompt nor the agent doc prescribed a deterministic scorecard template:
+
+- `.github/workflows/scheduled-growth-audit.yml` Step 2 prompt: *"Produce a structured scoring table and detailed analysis."* — no format specified.
+- `plugins/soleur/agents/marketing/growth-strategist.md` GEO/AEO Content Audit section: describes SAP dimensions qualitatively, lists sub-signals under each, but does not pin weights, grading scale, or the table column structure.
+
+With qualitative guidance and no pinned template, the agent freelanced a new table shape each run based on which signals felt most diagnostic at the moment.
+
+## Solution (Planned)
+
+Pin a **dual-rubric template** in BOTH the workflow prompt and the agent doc:
+
+1. **SAP headline scorecard** (weights Structure=40, Authority=35, Presence=25; grading A≥90, B 80-89, B+ 75-79, C 60-74, D <60). This preserves cross-audit Presence comparability that #2615 depends on.
+2. **8-component AEO diagnostic** (weights FAQ=20, Answer density=15, Statistics=15, Source citations=15, Conversational=10, Entity clarity=10, Authority/E-E-A-T=10, Citation-friendly=5). This surfaces richer diagnostic detail without replacing the headline.
+
+Pinning in both surfaces (workflow inline + agent doc) is belt-and-suspenders: cron runs and ad-hoc `/soleur:growth aeo` invocations both get the deterministic template.
+
+## Key Insight
+
+**Agents with qualitative scoring instructions produce non-deterministic scorecards.** When the output is a comparison artifact (something consumed across multiple runs for trend analysis or threshold verification), the prompt MUST pin:
+
+1. **Exact dimensions** (named rows).
+2. **Weights** (numeric, summing to 100 or 1.0).
+3. **Grading scale** (numeric thresholds → letter grades).
+4. **Column structure** (Dimension, Weight, Score, Weighted, Notes).
+
+Qualitative "score each category" plus a list of sub-signals is not enough. If you want comparable outputs across runs, prescribe the table verbatim.
+
+## Prevention
+
+- For any agent that produces a scorecard consumed by workflows or threshold gates, audit the prompt for the four pinning requirements above.
+- When creating a follow-through issue with score-based exit criteria (e.g., "Presence ≥ 55/D"), verify the producing agent's template is pinned BEFORE the issue is filed. An exit criterion against a free-form agent output is a latent rubric-drift bug.
+- When drift is detected (scorecard shape differs from prior runs), check the workflow prompt and agent doc in the same diagnostic pass — drift usually lives in one of those two surfaces, not in the agent's reasoning.
+
+## Session Errors
+
+1. **Spec directory created at bare-repo path, invisible from worktree** — `worktree-manager.sh feature <name>` echoed `Created spec directory: <bare-repo-path>/knowledge-base/project/specs/<feat>/` but that directory was not accessible from the worktree working tree. `ls` from inside the worktree returned exit code 2. Recovery: `mkdir -p` inside the worktree before `Write` could save `spec.md`. **Prevention:** The brainstorm skill already prescribes writing inside the worktree, so this is a UX papercut in the worktree script's echo rather than a workflow violation. Worth tracking but not blocking.
+
+## References
+
+- Source PR: #2596 (on-site Presence surface)
+- Follow-through: #2615
+- Triage: #2679
+- Audits: `knowledge-base/marketing/audits/soleur-ai/{2026-04-18-seo-audit.md, 2026-04-19-aeo-audit.md, 2026-04-21-aeo-audit.md}`
+- Agent doc: `plugins/soleur/agents/marketing/growth-strategist.md`
+- Workflow: `.github/workflows/scheduled-growth-audit.yml`

--- a/knowledge-base/project/learnings/2026-04-22-markdown-table-parser-papercuts-and-review-diff-direction.md
+++ b/knowledge-base/project/learnings/2026-04-22-markdown-table-parser-papercuts-and-review-diff-direction.md
@@ -1,0 +1,83 @@
+---
+date: 2026-04-22
+category: best-practices
+tags: [bash-parsing, markdown-tables, github-actions-yaml, multi-agent-review, git-diff]
+issue: 2679
+related_issues: [2615, 2795]
+module: review + runbook-parser
+---
+
+# Learning: Markdown-table parser papercuts and review-agent diff-direction false-positives
+
+## Problem
+
+During implementation of PR #2795 (AEO rubric reconciliation) and its multi-agent review, four small-but-transferable papercuts surfaced. Individually trivial; together they represent a pattern worth documenting so future similar work skips these cycles.
+
+## Four papercuts
+
+### 1. `#` comment placed inside `prompt: |` literal block scalar
+
+Workflow edit added a sync-sentinel `# Template-sync: ...` comment at the 12-space indent of `## Step 2: AEO Audit` — which is INSIDE the `prompt: |` multi-line scalar. The `#` became part of the prompt text sent to the agent rather than being treated as a YAML comment.
+
+`python3 -c "import yaml; yaml.safe_load(...)"` passed (YAML syntax was valid; the file loaded fine) — the content was just in the wrong place semantically. Caught only by self-review before commit.
+
+**Fix:** Moved the comment to YAML structural level — above `prompt: |` at the same indent as `prompt:` itself (the `with:` key level).
+
+**Prevention:** When adding a `#` comment inside a GitHub Actions workflow, verify the line is at YAML structural indent (between keys), NOT indented inside a `|` or `>` scalar. YAML validators catch syntax errors, not semantic misplacement.
+
+### 2. Parser stripped whitespace but not bold markdown
+
+The `2026-04-19` re-audit runbook parser stripped only whitespace from table score cells (`"${SCORE_CELL// /}"`). Old-format audits bold the Overall row's Score cell (`| **Overall** | **72** | ...`); after whitespace-strip, `**72**` still didn't match `^[0-9]+$`, so the extractor fell through to an unsafe fallback that stripped non-digits from the *Weighted* column value `**72.0**` → `720`.
+
+Caught only by dry-running the parser against both the 04-18 and 04-21 audit fixtures.
+
+**Fix:** Added `${VAR//\*/}` to strip bold markers alongside the whitespace strip.
+
+**Prevention:** When parsing markdown table cells with regex, strip inline formatting markers (`**`, `*`, backticks) in addition to whitespace before matching numeric values. The "matches valid format" check in the parser is worthless if the format can include formatting noise the strip doesn't remove.
+
+### 3. Fallback `grep -oE '\b[0-9]{1,3}\b' | head -n 1` over full line
+
+On new SAP Total rows with an empty Score cell (`| **Total** | 100 | | 78 | B+ |`), the fallback grabbed the first integer on the line — `100` (Weight), not `78` (Weighted).
+
+**Fix:** Added a Weighted-column header lookup (parallel to the existing Score-column lookup) and read that column explicitly when Score is empty.
+
+**Prevention:** When a markdown table has multiple adjacent numeric columns, anchor value extraction on header-name lookup, NOT on line-wide regex. The pattern `find column index by header name` scales; `first integer in line` does not.
+
+### 4. Review-agent P0 false positive from Git diff-direction misuse
+
+The `code-quality-analyst` reported a P0 "stale branch silently reverts #2796" citing files (`scripts/content-publisher.sh`, etc.) that the PR's actual diff does not touch. Root cause: the agent ran `git diff main..HEAD` (two-dot — shows commits on `main` since the fork point, NOT commits on the branch). Correct form: `git diff origin/main...HEAD` (three-dot — commits on HEAD since the merge base).
+
+Verified by re-running with three-dot diff: 8 files, none in content-publisher. The agent's "reverts #2796" claim was an artifact of reading #2796's merge commit as if it were a branch change.
+
+**Fix:** Reject the P0, cite the correct `origin/main...HEAD` diff.
+
+**Prevention:** When a review agent reports unexpected large-scope regressions (claims N files changed where N is much larger than the PR's actual scope), verify immediately with `git diff origin/main...HEAD --name-only` before accepting the finding. Diff-direction is an easy mistake for agents trained on mixed Git docs — and `main..HEAD` vs `main...HEAD` produces wildly different file lists when the branch is behind main. This failure mode is NOT caught by agent rate-limiting, retries, or multi-agent consensus — only by a direct cross-check.
+
+## Key Insight
+
+**Bold markers, empty cells, wrong-direction diffs, and misplaced YAML comments are all the same class of bug: tools that "look valid" but apply their valid logic to the wrong data.** The signal is that the tool doesn't error — it just produces wrong output.
+
+Defenses:
+
+- Test parsers against fixtures from EVERY format version the parser claims to support. Don't trust mental models of "the old format should still work" — run it.
+- Validate semantic placement of config/comments (is this comment at the right YAML level?), not just syntactic validity.
+- Cross-check review-agent claims on Git state with the exact three-dot form before accepting large-scope findings.
+
+## Session Errors
+
+1. **YAML comment misplacement** — Recovery: moved above `prompt: |`. Prevention: check comment is at YAML structural indent, not inside a `|` block scalar.
+2. **Bold-markdown not stripped** — Recovery: added `${VAR//\*/}`. Prevention: strip formatting markers alongside whitespace in markdown parsers.
+3. **First-integer fallback grabbed Weight, not Weighted** — Recovery: Weighted-column header lookup. Prevention: header-name column index for every numeric column, never line-wide grep.
+4. **Two-dot vs three-dot diff confusion** — Recovery: verified with `origin/main...HEAD`. Prevention: always use three-dot when measuring "what this PR contains"; reserve two-dot for "what changed on base since fork".
+5. **Security-reminder hook false-positive on workflow Edit** — Recovery: retried identical edit, which succeeded. Prevention: the hook is advisory; first-edit-prompts-second-edit-passes is expected.
+6. **`actionlint`/`npx actionlint` fabrication in initial plan** — Recovery: dropped from AC, use `yamllint` or `python3 -c "import yaml"`. Prevention: already covered by rule `cq-docs-cli-verification`.
+7. **`#2615's` at line start mangled by `markdownlint --fix` into `# 2615's`** — Recovery: reworded to `The \`#2615\` exit criterion ...`. Prevention: already covered by rule`cq-prose-issue-ref-line-start`.
+
+## References
+
+- PR: #2795
+- Issues: #2679, #2615
+- Audit fixtures used for parser verification:
+  - `knowledge-base/marketing/audits/soleur-ai/2026-04-21-aeo-audit.md` (new SAP format)
+  - `knowledge-base/marketing/audits/soleur-ai/2026-04-18-aeo-audit.md` (old SAP format)
+- Prior learning: `knowledge-base/project/learnings/2026-04-22-agent-scorecard-determinism-requires-pinned-template.md` (captured the WHY; this one captures implementation HOW-not-to).

--- a/knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md
+++ b/knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md
@@ -204,10 +204,26 @@ Monday or if the Monday cron failed (check via
 ### Phase 2 — Extract the Presence score
 
 Once `<date>-aeo-audit.md` exists, use a **column-name lookup** rather than
-fixed positional `awk` because the audit table column count has already
-drifted once (5 cols on 2026-04-13 → 6 cols on 2026-04-18 with added "Delta"
-column). The script below locates the `Score` column by reading the header
-row, then reads the same column in the `Presence` row.
+fixed positional `awk` because the audit table has drifted multiple times
+(5 cols on 2026-04-13, 6 cols on 2026-04-18, new SAP shape on 2026-04-21
+after the rubric was pinned per PR reconciling #2679). The script locates
+the `Score` column by reading the header row, then reads the same column
+in the `Presence` row.
+
+**Threshold translation (worked example — cross-rubric):**
+
+The issue's `≥55` threshold normalizes to percentage-of-Presence-category
+across both rubric eras:
+
+- **Old format** (`| Presence & Third-Party Mentions | 40 | F | 5% | 2.0 |`):
+  Score column is a bare 0–100 integer. `PRESENCE_SCORE=40` → `40 < 55` → FAIL.
+- **New SAP format** (`| **Presence** | 25 | 20/25 | 20 | ... |`): Score column
+  is `<n>/<weight>`. Normalize: `PRESENCE_SCORE = round(n/weight * 100) = 80`.
+  `80 ≥ 55` → PASS. The 2026-04-21 audit proved #2615 under this format.
+
+Both interpretations measure the same thing — what fraction of the rubric's
+Presence-category maximum the audit awarded — so the downstream branching
+(PASS/PARTIAL/FAIL) and the re-run band (52–58) apply uniformly.
 
 ```bash
 set -euo pipefail
@@ -223,10 +239,11 @@ if grep -qiE "(SEO|AEO) audit failed.*see CI logs" "$LATEST"; then
   exit 2
 fi
 
-# Locate the Scoring Table header row, find the column index of "Score"
-HEADER=$(awk '/^\| Category \|/{print; exit}' "$LATEST")
+# Locate the Scoring Table header row. Accept either the old "| Category |"
+# (pre-2026-04-21) or the new SAP "| Dimension |" header.
+HEADER=$(awk '/^\| (Category|Dimension) \|/{print; exit}' "$LATEST")
 if [[ -z "$HEADER" ]]; then
-  echo "ERROR: no Scoring Table header (expected '| Category |...| Score |...')" >&2
+  echo "ERROR: no Scoring Table header (expected '| Category |...' or '| Dimension |...')" >&2
   exit 3
 fi
 # Split the header on '|', strip whitespace, find index of "Score"
@@ -242,40 +259,85 @@ if [[ -z "$SCORE_COL" ]]; then
 fi
 echo "Score is in column $SCORE_COL"
 
-# Extract the Presence row (anchor on the stable label, not column position)
-PRESENCE_LINE=$(grep -E "^\| Presence & Third-Party Mentions" "$LATEST" | head -n 1)
+# Extract the Presence row. Match both the old "Presence & Third-Party Mentions"
+# label and the new "**Presence**" bold label. Require NF >= 5 so a legend/footer
+# row that happens to mention "Presence" does not match.
+PRESENCE_LINE=$(awk -F'|' '
+  NF >= 5 && $2 ~ /^ *(\*\*)?Presence(\*\*)?( & Third-Party Mentions)? *$/ { print; exit }
+' "$LATEST")
 if [[ -z "$PRESENCE_LINE" ]]; then
-  echo "ERROR: no row matches '| Presence & Third-Party Mentions ...'" >&2
+  echo "ERROR: no table row matches a Presence label (old or new)" >&2
   exit 5
 fi
-PRESENCE_SCORE=$(echo "$PRESENCE_LINE" | awk -F'|' -v c="$SCORE_COL" '{
-  gsub(/^[ \t]+|[ \t]+$/, "", $c); gsub(/[^0-9]/, "", $c); print $c
+
+# Extract the Score cell. Accept both formats:
+#   - bare integer (old rubric, e.g. "40")
+#   - <n>/<weight> fraction (new SAP rubric, e.g. "20/25", tolerant of
+#     "20 / 25" that markdownlint reflow can introduce).
+SCORE_CELL=$(echo "$PRESENCE_LINE" | awk -F'|' -v c="$SCORE_COL" '{
+  gsub(/^[ \t]+|[ \t]+$/, "", $c); print $c
 }')
-if ! [[ "$PRESENCE_SCORE" =~ ^[0-9]+$ ]] || [[ "$PRESENCE_SCORE" -gt 100 ]]; then
-  echo "ERROR: extracted Presence score is not a valid integer 0-100: '$PRESENCE_SCORE'" >&2
+SCORE_CELL_TRIMMED="${SCORE_CELL// /}"  # strip inline spaces ("20 / 25" -> "20/25")
+if [[ "$SCORE_CELL_TRIMMED" =~ ^([0-9]+)/([0-9]+)$ ]]; then
+  NUM="${BASH_REMATCH[1]}"; DEN="${BASH_REMATCH[2]}"
+  if [[ "$DEN" -eq 0 ]]; then
+    echo "ERROR: Presence score denominator is zero in '$SCORE_CELL' (line: $PRESENCE_LINE)" >&2
+    exit 6
+  fi
+  PRESENCE_SCORE=$(awk "BEGIN { printf \"%.0f\", ($NUM / $DEN) * 100 }")
+elif [[ "$SCORE_CELL_TRIMMED" =~ ^[0-9]+$ ]]; then
+  PRESENCE_SCORE="$SCORE_CELL_TRIMMED"  # old rubric: already 0-100 on category
+else
+  echo "ERROR: unrecognized Presence score format: '$SCORE_CELL' in line: $PRESENCE_LINE" >&2
   exit 6
 fi
-echo "Presence score: $PRESENCE_SCORE"
+if [[ "$PRESENCE_SCORE" -gt 100 ]]; then
+  echo "ERROR: normalized Presence score > 100 ('$PRESENCE_SCORE' from '$SCORE_CELL')" >&2
+  exit 6
+fi
+echo "Presence score (percentage-of-category, 0-100): $PRESENCE_SCORE"
 
-# Extract the Presence grade (column after Score, defensively).
-# Regex keeps A-Z plus +/- modifiers; current rubric uses bare letters (F, D, C, B, A)
-# but the regex tolerates D+/D- etc. should the rubric add modifiers in future audits.
-PRESENCE_GRADE=$(echo "$PRESENCE_LINE" | awk -F'|' -v c=$((SCORE_COL+1)) '{
-  gsub(/^[ \t]+|[ \t]+$/, "", $c); gsub(/[^A-Z+\-]/, "", $c); print $c
-}')
-echo "Presence grade: $PRESENCE_GRADE"
+# Derive a letter grade from PRESENCE_SCORE using the pinned SAP grading scale
+# (A >=90, B 80-89, B+ 75-79, C 60-74, D 55-59, F <55). The old rubric included
+# a separate Grade column per row; the new SAP rubric only grades the Total row.
+# Deriving keeps PRESENCE_GRADE populated across both eras so downstream
+# comment formatting ("${PRESENCE_SCORE}/${PRESENCE_GRADE}") stays clean.
+if   [[ "$PRESENCE_SCORE" -ge 90 ]]; then PRESENCE_GRADE="A"
+elif [[ "$PRESENCE_SCORE" -ge 80 ]]; then PRESENCE_GRADE="B"
+elif [[ "$PRESENCE_SCORE" -ge 75 ]]; then PRESENCE_GRADE="B+"
+elif [[ "$PRESENCE_SCORE" -ge 60 ]]; then PRESENCE_GRADE="C"
+elif [[ "$PRESENCE_SCORE" -ge 55 ]]; then PRESENCE_GRADE="D"
+else                                      PRESENCE_GRADE="F"
+fi
+echo "Presence grade (derived): $PRESENCE_GRADE"
 
-# Extract the overall score from the | **Overall** | row (parallel guard with PRESENCE_LINE)
-OVERALL_LINE=$(grep -E "^\| \*\*Overall\*\*" "$LATEST" | head -n 1)
+# Extract the overall score. The old rubric used "**Overall**"; the new SAP
+# rubric uses "**Total**". Match either.
+OVERALL_LINE=$(awk -F'|' '
+  NF >= 5 && $2 ~ /^ *\*\*(Overall|Total)\*\* *$/ { print; exit }
+' "$LATEST")
 if [[ -z "$OVERALL_LINE" ]]; then
-  echo "ERROR: no row matches '| **Overall** ...'" >&2
+  echo "ERROR: no row matches '| **Overall** ...' or '| **Total** ...'" >&2
   exit 7
 fi
-OVERALL_SCORE=$(echo "$OVERALL_LINE" | awk -F'|' -v c="$SCORE_COL" '{
-  gsub(/^[ \t]+|[ \t]+$/, "", $c); gsub(/[^0-9]/, "", $c); print $c
+OVERALL_CELL=$(echo "$OVERALL_LINE" | awk -F'|' -v c="$SCORE_COL" '{
+  gsub(/^[ \t]+|[ \t]+$/, "", $c); print $c
 }')
+OVERALL_CELL_TRIMMED="${OVERALL_CELL// /}"
+# The new SAP Total row leaves the Score cell empty and puts the total in the
+# Weighted column; fall back to extracting the first 0-100 integer from the
+# whole line if the Score cell is blank.
+if [[ "$OVERALL_CELL_TRIMMED" =~ ^[0-9]+$ ]]; then
+  OVERALL_SCORE="$OVERALL_CELL_TRIMMED"
+elif [[ "$OVERALL_CELL_TRIMMED" =~ ^([0-9]+)/([0-9]+)$ ]]; then
+  NUM="${BASH_REMATCH[1]}"; DEN="${BASH_REMATCH[2]}"
+  [[ "$DEN" -eq 0 ]] && { echo "ERROR: Overall denominator zero (line: $OVERALL_LINE)" >&2; exit 8; }
+  OVERALL_SCORE=$(awk "BEGIN { printf \"%.0f\", ($NUM / $DEN) * 100 }")
+else
+  OVERALL_SCORE=$(echo "$OVERALL_LINE" | grep -oE '\b[0-9]{1,3}\b' | head -n 1)
+fi
 if ! [[ "$OVERALL_SCORE" =~ ^[0-9]+$ ]] || [[ "$OVERALL_SCORE" -gt 100 ]]; then
-  echo "ERROR: extracted Overall score is not a valid integer 0-100: '$OVERALL_SCORE'" >&2
+  echo "ERROR: extracted Overall score is not a valid integer 0-100: '$OVERALL_SCORE' (line: $OVERALL_LINE)" >&2
   exit 8
 fi
 echo "Overall AEO score: $OVERALL_SCORE"
@@ -486,6 +548,9 @@ gh issue comment 2615 --body "AEO Presence audit at ${AUDIT_DATE} reported ${PRE
 | Audit file missing on Monday >12:00 UTC | Operator runs `gh workflow run scheduled-growth-audit.yml`; waits for PR auto-merge | New `<date>-aeo-audit.md` exists; Phase 2 proceeds |
 | Audit step 3 returned the stub fallback ("SEO audit failed — see CI logs.") | Skip the score extraction; do not infer a Presence number from a missing AEO report | File P1 tracker referencing the failed cron run; #2615 needs-attention |
 | Table format changed (e.g., column reorder) | Re-read the latest audit, locate column by header name, abort if anchor missing | No silent default; operator notified to update Phase 2 anchors |
+| New SAP rubric with fraction score (e.g., `20/25`) | Phase 2 parser normalizes fraction → percentage-of-category | `PRESENCE_SCORE=80`, `PRESENCE_GRADE=B`, PASS branch (threshold ≥55) |
+| Old rubric with bare integer score (e.g., `40`) | Phase 2 parser treats bare integer as already-normalized | `PRESENCE_SCORE=40`, `PRESENCE_GRADE=F`, FAIL branch (below ≥55) |
+| Score cell reflowed with whitespace (e.g., `20 / 25`) | Parser strips inline whitespace before matching | Parsed identically to `20/25` |
 
 ## Risks
 

--- a/knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md
+++ b/knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md
@@ -277,7 +277,8 @@ fi
 SCORE_CELL=$(echo "$PRESENCE_LINE" | awk -F'|' -v c="$SCORE_COL" '{
   gsub(/^[ \t]+|[ \t]+$/, "", $c); print $c
 }')
-SCORE_CELL_TRIMMED="${SCORE_CELL// /}"  # strip inline spaces ("20 / 25" -> "20/25")
+SCORE_CELL_TRIMMED="${SCORE_CELL// /}"    # strip inline spaces ("20 / 25" -> "20/25")
+SCORE_CELL_TRIMMED="${SCORE_CELL_TRIMMED//\*/}"  # strip bold markdown markers ("**72**" -> "72")
 if [[ "$SCORE_CELL_TRIMMED" =~ ^([0-9]+)/([0-9]+)$ ]]; then
   NUM="${BASH_REMATCH[1]}"; DEN="${BASH_REMATCH[2]}"
   if [[ "$DEN" -eq 0 ]]; then
@@ -297,19 +298,26 @@ if [[ "$PRESENCE_SCORE" -gt 100 ]]; then
 fi
 echo "Presence score (percentage-of-category, 0-100): $PRESENCE_SCORE"
 
-# Derive a letter grade from PRESENCE_SCORE using the pinned SAP grading scale
-# (A >=90, B 80-89, B+ 75-79, C 60-74, D 55-59, F <55). The old rubric included
-# a separate Grade column per row; the new SAP rubric only grades the Total row.
-# Deriving keeps PRESENCE_GRADE populated across both eras so downstream
-# comment formatting ("${PRESENCE_SCORE}/${PRESENCE_GRADE}") stays clean.
+# Alias to PRESENCE_PCT for downstream code that prefers the semantic name
+# (the plan contract uses "percentage-of-category"). Both names reference
+# the same value.
+PRESENCE_PCT="$PRESENCE_SCORE"
+
+# Derive a letter grade from PRESENCE_SCORE using the pinned SAP grading
+# scale exactly as defined in growth-strategist.md and scheduled-growth-
+# audit.yml Step 2 (A >= 90, B 80-89, B+ 75-79, C 60-74, D < 60). The old
+# rubric included a separate Grade column per row; the new SAP rubric only
+# grades the Total row. Deriving keeps PRESENCE_GRADE populated across
+# both eras so downstream comment formatting stays clean. Do NOT introduce
+# letters not in the pinned scale — agents produce audits against the
+# pinned five-tier scale, and a runbook-internal sixth tier would desync.
 if   [[ "$PRESENCE_SCORE" -ge 90 ]]; then PRESENCE_GRADE="A"
 elif [[ "$PRESENCE_SCORE" -ge 80 ]]; then PRESENCE_GRADE="B"
 elif [[ "$PRESENCE_SCORE" -ge 75 ]]; then PRESENCE_GRADE="B+"
 elif [[ "$PRESENCE_SCORE" -ge 60 ]]; then PRESENCE_GRADE="C"
-elif [[ "$PRESENCE_SCORE" -ge 55 ]]; then PRESENCE_GRADE="D"
-else                                      PRESENCE_GRADE="F"
+else                                      PRESENCE_GRADE="D"
 fi
-echo "Presence grade (derived): $PRESENCE_GRADE"
+echo "Presence grade (derived from pinned scale): $PRESENCE_GRADE"
 
 # Extract the overall score. The old rubric used "**Overall**"; the new SAP
 # rubric uses "**Total**". Match either.
@@ -320,21 +328,41 @@ if [[ -z "$OVERALL_LINE" ]]; then
   echo "ERROR: no row matches '| **Overall** ...' or '| **Total** ...'" >&2
   exit 7
 fi
+
+# Look up the Weighted column index by name (parallel with SCORE_COL lookup).
+# The new SAP Total row leaves the Score cell empty and puts the overall total
+# in the Weighted column; old rubrics put the overall in Score directly. A
+# first-integer-in-line fallback is unsafe because "Weight" (e.g. 100) precedes
+# "Weighted" in new SAP column order and would be grabbed first.
+WEIGHTED_COL=$(echo "$HEADER" | awk -F'|' '{
+  for (i=2; i<=NF; i++) {
+    gsub(/^[ \t]+|[ \t]+$/, "", $i)
+    if ($i == "Weighted") { print i; exit }
+  }
+}')
+
 OVERALL_CELL=$(echo "$OVERALL_LINE" | awk -F'|' -v c="$SCORE_COL" '{
   gsub(/^[ \t]+|[ \t]+$/, "", $c); print $c
 }')
 OVERALL_CELL_TRIMMED="${OVERALL_CELL// /}"
-# The new SAP Total row leaves the Score cell empty and puts the total in the
-# Weighted column; fall back to extracting the first 0-100 integer from the
-# whole line if the Score cell is blank.
+OVERALL_CELL_TRIMMED="${OVERALL_CELL_TRIMMED//\*/}"  # strip bold markers (old audits bold the Overall Score cell)
 if [[ "$OVERALL_CELL_TRIMMED" =~ ^[0-9]+$ ]]; then
   OVERALL_SCORE="$OVERALL_CELL_TRIMMED"
 elif [[ "$OVERALL_CELL_TRIMMED" =~ ^([0-9]+)/([0-9]+)$ ]]; then
   NUM="${BASH_REMATCH[1]}"; DEN="${BASH_REMATCH[2]}"
-  [[ "$DEN" -eq 0 ]] && { echo "ERROR: Overall denominator zero (line: $OVERALL_LINE)" >&2; exit 8; }
+  if [[ "$DEN" -eq 0 ]]; then
+    echo "ERROR: Overall denominator zero in '$OVERALL_CELL' (line: $OVERALL_LINE)" >&2
+    exit 8
+  fi
   OVERALL_SCORE=$(awk "BEGIN { printf \"%.0f\", ($NUM / $DEN) * 100 }")
+elif [[ -n "$WEIGHTED_COL" ]]; then
+  # New SAP Total row fallback: read the Weighted column explicitly.
+  OVERALL_SCORE=$(echo "$OVERALL_LINE" | awk -F'|' -v c="$WEIGHTED_COL" '{
+    gsub(/^[ \t]+|[ \t]+$/, "", $c); gsub(/[^0-9]/, "", $c); print $c
+  }')
 else
-  OVERALL_SCORE=$(echo "$OVERALL_LINE" | grep -oE '\b[0-9]{1,3}\b' | head -n 1)
+  echo "ERROR: cannot extract Overall score (Score cell empty, no Weighted column in header) (line: $OVERALL_LINE)" >&2
+  exit 8
 fi
 if ! [[ "$OVERALL_SCORE" =~ ^[0-9]+$ ]] || [[ "$OVERALL_SCORE" -gt 100 ]]; then
   echo "ERROR: extracted Overall score is not a valid integer 0-100: '$OVERALL_SCORE' (line: $OVERALL_LINE)" >&2
@@ -549,8 +577,9 @@ gh issue comment 2615 --body "AEO Presence audit at ${AUDIT_DATE} reported ${PRE
 | Audit step 3 returned the stub fallback ("SEO audit failed — see CI logs.") | Skip the score extraction; do not infer a Presence number from a missing AEO report | File P1 tracker referencing the failed cron run; #2615 needs-attention |
 | Table format changed (e.g., column reorder) | Re-read the latest audit, locate column by header name, abort if anchor missing | No silent default; operator notified to update Phase 2 anchors |
 | New SAP rubric with fraction score (e.g., `20/25`) | Phase 2 parser normalizes fraction → percentage-of-category | `PRESENCE_SCORE=80`, `PRESENCE_GRADE=B`, PASS branch (threshold ≥55) |
-| Old rubric with bare integer score (e.g., `40`) | Phase 2 parser treats bare integer as already-normalized | `PRESENCE_SCORE=40`, `PRESENCE_GRADE=F`, FAIL branch (below ≥55) |
+| Old rubric with bare integer score (e.g., `40`) | Phase 2 parser treats bare integer as already-normalized | `PRESENCE_SCORE=40`, `PRESENCE_GRADE=D` (below 60 per pinned scale), FAIL branch (below ≥55) |
 | Score cell reflowed with whitespace (e.g., `20 / 25`) | Parser strips inline whitespace before matching | Parsed identically to `20/25` |
+| New SAP Total row with empty Score cell (e.g., `\| **Total** \| 100 \| \| 78 \| B+ \|`) | Parser reads Weighted column via header lookup | `OVERALL_SCORE=78` (not 100, the Weight) |
 
 ## Risks
 

--- a/knowledge-base/project/plans/2026-04-22-chore-aeo-rubric-reconcile-plan.md
+++ b/knowledge-base/project/plans/2026-04-22-chore-aeo-rubric-reconcile-plan.md
@@ -1,0 +1,249 @@
+---
+title: "AEO audit rubric reconciliation (#2679) and #2615 closure"
+issue: 2679
+closes_issues: [2679, 2615]
+source_brainstorm: knowledge-base/project/brainstorms/2026-04-22-aeo-rubric-reconcile-2679-brainstorm.md
+source_spec: knowledge-base/project/specs/feat-aeo-rubric-reconcile-2679/spec.md
+type: chore
+priority: P1
+domain: marketing
+created: 2026-04-22
+status: planned
+---
+
+# AEO audit rubric reconciliation plan
+
+## Overview
+
+Pin a **dual-rubric AEO audit template** (SAP headline + 8-component AEO diagnostic) in BOTH `.github/workflows/scheduled-growth-audit.yml` Step 2 prompt AND `plugins/soleur/agents/marketing/growth-strategist.md` GEO/AEO Content Audit section. Update the re-audit runbook (`knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md`) Phase 2 bash parser to handle the new score format. Close #2615 by citing the 2026-04-21 audit (Presence `20/25` = 80%, above the ≥55% threshold).
+
+## Context
+
+### Why the plan exists
+
+Three consecutive AEO audits used three different scorecard shapes:
+
+| Date | Rubric | Presence row | Overall |
+|---|---|---|---|
+| 2026-04-18 | SAP, 5% weight, bare 0–100 score | `40/F` | 72 |
+| 2026-04-19 | 8-component AEO (no Presence row) | *absent* | 81/B |
+| 2026-04-21 | SAP, 25% weight, `<n>/<weight>` score | `20/25 (80%)` | 78/B+ |
+
+Neither the workflow Step 2 prompt (*"produce a structured scoring table"*) nor the `growth-strategist.md` GEO/AEO Content Audit section pins weights, grading scale, or column format. The agent freelances a different table shape each run.
+
+### Threshold translation (worked example)
+
+The `#2615` exit criterion `≥55` normalizes cleanly to percentage-of-category across both rubric eras:
+
+- **Old format** (`PRESENCE_LINE = "| Presence & Third-Party Mentions | 40 | F | 5% | 2.0 |"`): Score column is already a bare 0–100 integer. `PRESENCE_PCT = 40`. `40 < 55` → FAIL (historical; the pre-PR-#2596 baseline).
+- **New format** (`PRESENCE_LINE = "| **Presence** | 25 | 20/25 | 20 | ... |"`): Score column is `<n>/<weight>`. `PRESENCE_PCT = (20 / 25) * 100 = 80`. `80 ≥ 55` → PASS. This is the 2026-04-21 audit that verifies #2615.
+
+Both interpretations measure the same thing: *what fraction of the rubric's Presence-category maximum did the audit award?* The issue's literal `≥55` threshold applies without reinterpretation.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim | Reality (verified) | Plan response |
+|---|---|---|
+| Runbook grep anchors on `"^\| Presence & Third-Party Mentions"` | Confirmed at `knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md:246`. 2026-04-21 audit uses `"**Presence**"`. | Update grep to match both labels; require `NF >= 5` to exclude legend/footer rows. |
+| Score cell format changed | Confirmed: old `40`, new `20/25`. Whitespace can land as `20 / 25` after markdownlint reflow. | Parser accepts both; trims whitespace before matching. |
+| Weight changed from 5% to 25% | Confirmed (04-18 vs 04-21 audit). | Pin weight=25 in new template. |
+| 2026-04-21 audit proves #2615 exit criterion | Confirmed: Presence `20/25 (80%)` ≥ 55. | Close #2615 by citing this audit; no new audit run required. |
+
+## Open Code-Review Overlap
+
+Ran at plan-write time (2026-04-22) against the three target files — **no open code-review issues match**.
+
+```bash
+gh issue list --label code-review --state open --json number,title,body --limit 200 > /tmp/open-review-issues.json
+for path in ".github/workflows/scheduled-growth-audit.yml" \
+            "plugins/soleur/agents/marketing/growth-strategist.md" \
+            "knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md"; do
+  jq -r --arg path "$path" '.[] | select(.body // "" | contains($path)) | "#\(.number): \(.title)"' /tmp/open-review-issues.json
+done
+```
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] `growth-strategist.md` GEO/AEO Content Audit section contains BOTH template skeletons (SAP with weights 40/35/25 + grading scale; 8-component AEO diagnostic with weights summing to 100). Narrative sub-signal guidance under each SAP dimension is preserved below the table skeleton.
+- [ ] `scheduled-growth-audit.yml` Step 2 prompt inlines the identical templates, indented inside the `prompt: |` block (no column-0 lines, no heredocs — `hr-in-github-actions-run-blocks-never-use`).
+- [ ] Re-audit runbook Phase 2 bash parser: (a) grep matches both `"Presence & Third-Party Mentions"` and `"**Presence**"` labels and requires `NF >= 5` to exclude legend rows; (b) score parser trims whitespace and accepts both `40` (bare integer) and `20/25` (fraction); (c) error messages include `$PRESENCE_LINE` when parsing fails. A worked-example comment block documents the threshold translation for both rubric eras.
+- [ ] PR body includes `Closes #2679` and `Closes #2615` on their own lines (`wg-use-closes-n-in-pr-body-not-title-to`), with a short verification paragraph for #2615 that backtick-wraps all `#NNNN` references to avoid `cq-prose-issue-ref-line-start`.
+
+### Post-merge (operator)
+
+- [ ] `gh workflow run scheduled-growth-audit.yml` triggered (`wg-after-merging-a-pr-that-adds-or-modifies`); poll to completion.
+- [ ] Deterministic validator passes against the new audit file:
+
+  ```bash
+  AUDIT=$(ls -1 knowledge-base/marketing/audits/soleur-ai/*-aeo-audit.md | sort | tail -n 1)
+  grep -qE "^\| \*\*Structure\*\* +\| 40 +\|" "$AUDIT" || { echo "FAIL: Structure row missing"; exit 1; }
+  grep -qE "^\| \*\*Authority\*\* +\| 35 +\|" "$AUDIT" || { echo "FAIL: Authority row missing"; exit 1; }
+  grep -qE "^\| \*\*Presence\*\*  +\| 25 +\|" "$AUDIT" || { echo "FAIL: Presence row missing"; exit 1; }
+  n=$(grep -cE "^\| (FAQ structure|Answer density|Statistics|Source citations|Conversational|Entity clarity|Authority / E-E-A-T|Citation-friendly)" "$AUDIT")
+  [[ "$n" == "8" ]] || { echo "FAIL: 8-component diagnostic has $n/8 rows"; exit 1; }
+  echo "OK: pinned template held"
+  ```
+
+- [ ] If the validator fails: file a P1 follow-up (`priority/p1-high`, `type/chore`, `domain/marketing`) titled `chore(aeo): pinned prompt dropped — investigate agent compliance`. Do NOT silently accept the drift.
+- [ ] `#2679` and `#2615` are both CLOSED.
+
+## Implementation Phases
+
+### Phase 1 — Agent doc update
+
+Edit `plugins/soleur/agents/marketing/growth-strategist.md` GEO/AEO Content Audit section (lines ~45-120). Add a preamble mandating both tables, then embed the two skeletons below. Keep the existing narrative sub-signal guidance for each SAP dimension as rubric commentary beneath the skeletons.
+
+**SAP scorecard template:**
+
+```markdown
+| Dimension       | Weight | Score   | Weighted | Notes |
+|-----------------|--------|---------|----------|-------|
+| **Structure**   | 40     | <n>/40  | <n>      | ...   |
+| **Authority**   | 35     | <n>/35  | <n>      | ...   |
+| **Presence**    | 25     | <n>/25  | <n>      | ...   |
+| **Total**       | 100    |         | <n>      | <letter grade> |
+```
+
+Grading scale: `A ≥90, B 80-89, B+ 75-79, C 60-74, D <60`.
+
+**8-component AEO diagnostic template:**
+
+```markdown
+| Component                       | Weight | Score  | Notes |
+|---------------------------------|--------|--------|-------|
+| FAQ structure & FAQPage schema  | 20     | <n>/20 | ...   |
+| Answer density / extractability | 15     | <n>/15 | ...   |
+| Statistics & specificity        | 15     | <n>/15 | ...   |
+| Source citations                | 15     | <n>/15 | ...   |
+| Conversational readiness        | 10     | <n>/10 | ...   |
+| Entity clarity                  | 10     | <n>/10 | ...   |
+| Authority / E-E-A-T             | 10     | <n>/10 | ...   |
+| Citation-friendly structure     | 5      | <n>/5  | ...   |
+| **Total**                       | 100    |        | <n>/100 |
+```
+
+**Why pin in the agent doc:** manual `/soleur:growth aeo` invocations use the agent doc, not the workflow prompt. Workflow-only pinning leaves ad-hoc runs free to drift.
+
+### Phase 2 — Workflow prompt update
+
+Edit `.github/workflows/scheduled-growth-audit.yml` Step 2 (lines ~98-109). Stay inside `prompt: |` with 12-space base indentation. Replace the open-ended `"produce a structured scoring table"` with explicit template text enumerating both tables, weights, the grading scale, and a directive that both tables are mandatory. Prompt text may mirror the tables in Phase 1 but expressed as natural-language requirements (avoid embedding raw markdown skeletons; the workflow prompt is Task input, not a table to copy).
+
+Constraint: the prompt is YAML text, not a shell `run:` block. `hr-in-github-actions-run-blocks-never-use` addresses heredocs in `run:` blocks; a YAML `prompt: |` scalar with consistent indentation is fine.
+
+### Phase 3 — Runbook parser update
+
+Edit `knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md` Phase 2 extraction block.
+
+1. **Label match:** replace single-pattern grep with alternation that also requires `NF >= 5` columns (excludes legend rows):
+
+   ```bash
+   PRESENCE_LINE=$(awk -F'|' 'NF >= 5 && $2 ~ /^ *(\*\*)?Presence(\*\*)?( & Third-Party Mentions)? *$/ { print; exit }' "$LATEST")
+   ```
+
+2. **Score parsing:** trim whitespace, accept both bare and fraction forms, include line in error:
+
+   ```bash
+   SCORE_CELL=$(echo "$PRESENCE_LINE" | awk -F'|' -v c="$SCORE_COL" '{ gsub(/^[ \t]+|[ \t]+$/, "", $c); print $c }')
+   SCORE_CELL="${SCORE_CELL// /}"  # strip inline whitespace (handles "20 / 25" after markdownlint reflow)
+   if [[ "$SCORE_CELL" =~ ^([0-9]+)/([0-9]+)$ ]]; then
+     NUM="${BASH_REMATCH[1]}"; DEN="${BASH_REMATCH[2]}"
+     PRESENCE_PCT=$(awk "BEGIN { printf \"%.0f\", ($NUM / $DEN) * 100 }")
+   elif [[ "$SCORE_CELL" =~ ^[0-9]+$ ]]; then
+     PRESENCE_PCT="$SCORE_CELL"  # old rubric: bare 0-100
+   else
+     echo "ERROR: unrecognized Presence score format: '$SCORE_CELL' in line: $PRESENCE_LINE" >&2
+     exit 6
+   fi
+   ```
+
+3. **Threshold check:** PASS/PARTIAL/FAIL branching compares `PRESENCE_PCT` (not `PRESENCE_SCORE`) against 55; re-run band is `52 <= PRESENCE_PCT <= 58`.
+
+4. **Documentation header** at top of Phase 2:
+
+   > Score extraction normalizes to percentage-of-category across rubric eras. Old format: bare `40` → `PRESENCE_PCT=40`. New format: `20/25` → `PRESENCE_PCT=80`. The issue's `≥55` threshold applies uniformly.
+
+5. **Test Scenarios row:** *"Historical audit with `20/25` format → `PRESENCE_PCT=80` → PASS."*
+
+### Phase 4 — Post-merge verification (single step)
+
+After merge, run:
+
+```bash
+gh workflow run scheduled-growth-audit.yml
+# Poll until the audit PR merges, then run the Acceptance Criteria validator above.
+```
+
+If the validator passes, done. If it fails, file the P1 follow-up per Acceptance Criteria.
+
+## Files to edit
+
+- `plugins/soleur/agents/marketing/growth-strategist.md` — GEO/AEO Content Audit section.
+- `.github/workflows/scheduled-growth-audit.yml` — Step 2 prompt block.
+- `knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md` — Phase 2 extraction and Test Scenarios.
+
+## Files to create
+
+None.
+
+## Test Scenarios
+
+Infrastructure-only change (prompt engineering + markdown). `cq-write-failing-tests-before` is exempt. Verification is the post-merge deterministic validator (see Acceptance Criteria post-merge block).
+
+| Scenario | Expected |
+|---|---|
+| Post-merge audit run produces both tables | Validator passes |
+| Post-merge audit drops a table | Validator fails; P1 follow-up filed |
+| Runbook parser against 2026-04-21 audit | `PRESENCE_PCT=80`, PASS branch |
+| Runbook parser against 2026-04-18 audit | `PRESENCE_PCT=40`, FAIL branch (historical) |
+
+## Risks
+
+- **Agent non-compliance.** LLMs aren't fully deterministic; the pinned prompt may still be dropped. Mitigation: deterministic validator in Phase 4 surfaces drift immediately. Two failures within two runs → escalate to moving audit generation out of agent-prose (future work).
+- **Threshold interpretation is load-bearing.** The `≥55` translation assumes both rubric eras measure percentage-of-category. Documented with worked example (Context section) so the comparison survives future audit-format changes. If a future rubric abandons per-category scoring entirely, this plan's verification approach no longer applies and the runbook needs a wider rewrite.
+
+## Non-Goals
+
+- New audit workflow or sub-command.
+- Retroactive re-scoring of audits before 2026-04-22.
+- Changes to `seo-aeo-analyst.md` (separate agent, out of scope).
+- Off-site Presence work (tracked in #2599, #2600, #2601, #2602, #2603, #2604).
+- Changing SAP weights or grading scale cutoffs.
+- Moving audit generation out of agent-prose into a deterministic template-filler (future work if drift recurs).
+
+## Domain Review
+
+**Domains relevant:** Marketing (CMO — carried forward from brainstorm)
+
+### Marketing (CMO)
+
+**Status:** carried forward from `knowledge-base/project/brainstorms/2026-04-22-aeo-rubric-reconcile-2679-brainstorm.md` Domain Assessments.
+
+**Assessment:** Rubric pinning is a CMO operational concern (content audit determinism). SAP remains the canonical public-facing framework; the 8-component rubric is the diagnostic layer. Dual-template matches how the auditor already produced both framings. No brand-guide implications. No user-facing copy.
+
+**Specialists:** none recommended in brainstorm.
+
+**No Product/UX Gate:** no new user-facing pages, no new components, no new flows. Agent-facing prompt engineering only.
+
+## Out of Scope
+
+- Code changes (no production paths touched).
+- Database migrations, Terraform, infrastructure.
+- New automated tests.
+- Non-Marketing domain agents.
+
+## Definition of Done
+
+- Three files edited per specification.
+- PR is open, CI green, review signed off.
+- PR body includes `Closes #2679` + `Closes #2615` + verification paragraph citing `knowledge-base/marketing/audits/soleur-ai/2026-04-21-aeo-audit.md` and the Presence `20/25 (80%)` numerical proof.
+- Post-merge validator (Acceptance Criteria block) passes against the next scheduled-growth-audit run; otherwise P1 follow-up filed.
+- `#2679` and `#2615` both CLOSED.
+
+## How to resume / hand off
+
+1. Read this plan top-to-bottom.
+2. Read the brainstorm at `knowledge-base/project/brainstorms/2026-04-22-aeo-rubric-reconcile-2679-brainstorm.md`.
+3. Run `skill: soleur:work knowledge-base/project/plans/2026-04-22-chore-aeo-rubric-reconcile-plan.md` to execute Phases 1–3.
+4. Run `skill: soleur:ship` to open/mark-ready the PR and execute Phase 4 post-merge.

--- a/knowledge-base/project/plans/2026-04-22-chore-aeo-rubric-reconcile-plan.md
+++ b/knowledge-base/project/plans/2026-04-22-chore-aeo-rubric-reconcile-plan.md
@@ -66,9 +66,9 @@ done
 
 ### Pre-merge (PR)
 
-- [ ] `growth-strategist.md` GEO/AEO Content Audit section contains BOTH template skeletons (SAP with weights 40/35/25 + grading scale; 8-component AEO diagnostic with weights summing to 100). Narrative sub-signal guidance under each SAP dimension is preserved below the table skeleton.
-- [ ] `scheduled-growth-audit.yml` Step 2 prompt inlines the identical templates, indented inside the `prompt: |` block (no column-0 lines, no heredocs — `hr-in-github-actions-run-blocks-never-use`).
-- [ ] Re-audit runbook Phase 2 bash parser: (a) grep matches both `"Presence & Third-Party Mentions"` and `"**Presence**"` labels and requires `NF >= 5` to exclude legend rows; (b) score parser trims whitespace and accepts both `40` (bare integer) and `20/25` (fraction); (c) error messages include `$PRESENCE_LINE` when parsing fails. A worked-example comment block documents the threshold translation for both rubric eras.
+- [x] `growth-strategist.md` GEO/AEO Content Audit section contains BOTH template skeletons (SAP with weights 40/35/25 + grading scale; 8-component AEO diagnostic with weights summing to 100). Narrative sub-signal guidance under each SAP dimension is preserved below the table skeleton.
+- [x] `scheduled-growth-audit.yml` Step 2 prompt inlines the identical templates, indented inside the `prompt: |` block (no column-0 lines, no heredocs — `hr-in-github-actions-run-blocks-never-use`).
+- [x] Re-audit runbook Phase 2 bash parser: (a) grep matches both `"Presence & Third-Party Mentions"` and `"**Presence**"` labels and requires `NF >= 5` to exclude legend rows; (b) score parser trims whitespace and accepts both `40` (bare integer) and `20/25` (fraction); (c) error messages include `$PRESENCE_LINE` when parsing fails. A worked-example comment block documents the threshold translation for both rubric eras.
 - [ ] PR body includes `Closes #2679` and `Closes #2615` on their own lines (`wg-use-closes-n-in-pr-body-not-title-to`), with a short verification paragraph for #2615 that backtick-wraps all `#NNNN` references to avoid `cq-prose-issue-ref-line-start`.
 
 ### Post-merge (operator)

--- a/knowledge-base/project/specs/feat-aeo-rubric-reconcile-2679/spec.md
+++ b/knowledge-base/project/specs/feat-aeo-rubric-reconcile-2679/spec.md
@@ -1,0 +1,59 @@
+---
+feature: aeo-rubric-reconcile-2679
+issue: 2679
+related_issues: [2615, 2596, 2647]
+status: draft
+created: 2026-04-22
+owner: CMO
+---
+
+# Spec: AEO Audit Rubric Reconciliation
+
+## Problem Statement
+
+The `scheduled-growth-audit.yml` cron produces non-deterministic AEO scorecards. Between 2026-04-18 and 2026-04-21, three consecutive audits used three different scorecard shapes (SAP → 8-component AEO → SAP), preventing cross-audit comparison. #2615's exit criteria (Presence score lift from 40/F → ≥55/D) could not be evaluated against the 04-19 audit because that run dropped the Presence row entirely. Neither the workflow prompt nor the `growth-strategist` agent doc prescribes a deterministic scorecard template.
+
+## Goals
+
+- **G1.** Pin a dual-rubric audit template (SAP headline + 8-component AEO diagnostic) so every future run produces both tables.
+- **G2.** Close #2615 by citing the 2026-04-21 audit where Presence scored 20/25 (80%), well above the ≥55/D threshold.
+- **G3.** Update the re-audit runbook (`knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md`) Phase 2 anchor logic to match the pinned template.
+
+## Non-Goals
+
+- **NG1.** Creating a separate AEO-only audit workflow. The dual template folds into the existing growth-audit cron.
+- **NG2.** Retroactively re-scoring past audits. 04-19 stays as-is; 04-21 is the verification baseline.
+- **NG3.** Modifying `seo-aeo-analyst.md` — it owns technical SEO, not content-level AEO scorecards.
+- **NG4.** Adding dashboards, trend charts, or alerting. Two tables in one markdown file suffices.
+- **NG5.** Moving the runbook to `knowledge-base/engineering/ops/runbooks/`. Worth a separate cleanup.
+
+## Functional Requirements
+
+- **FR1.** The growth-strategist agent, when invoked with an AEO audit prompt, MUST produce both the SAP scorecard and the 8-component AEO diagnostic table in the same audit report.
+- **FR2.** The SAP scorecard MUST use weights Structure=40, Authority=35, Presence=25 and the grading scale defined in the 2026-04-21 audit (A ≥90, B 80-89, B+ 75-79, C 60-74, D <60).
+- **FR3.** The 8-component AEO diagnostic MUST use weights FAQ=20, Answer density=15, Statistics=15, Source citations=15, Conversational=10, Entity clarity=10, Authority/E-E-A-T=10, Citation-friendly=5.
+- **FR4.** `scheduled-growth-audit.yml` Step 2 prompt MUST reference or inline the pinned template so cron runs produce deterministic output.
+- **FR5.** The re-audit runbook Phase 2 MUST document how to extract Presence score from the pinned SAP table.
+- **FR6.** #2615 MUST be closed by the merge commit, referencing the 04-21 audit as verification.
+
+## Technical Requirements
+
+- **TR1.** Template pinning MUST live in both `.github/workflows/scheduled-growth-audit.yml` (inline prompt) AND `plugins/soleur/agents/marketing/growth-strategist.md` (agent spec). Workflow-only pinning would leave ad-hoc `/soleur:growth aeo` invocations unpinned; agent-only pinning repeats the 04-19 failure mode (agent freelanced despite SAP mention).
+- **TR2.** The PR body MUST include `Closes #2679` and `Closes #2615`.
+- **TR3.** No code changes to `growth-strategist.md` Execution section or `seo-aeo-analyst.md` — scope is limited to the GEO/AEO Content Audit section's scorecard specification.
+- **TR4.** The pinned template MUST preserve backward compatibility: the SAP table column names (Dimension, Weight, Score, Weighted, Notes) must match the 04-21 audit so historical SAP audits remain comparable.
+
+## Acceptance Criteria
+
+1. `gh issue view 2679 --json state` returns `CLOSED`.
+2. `gh issue view 2615 --json state` returns `CLOSED`.
+3. `scheduled-growth-audit.yml` Step 2 prompt contains the SAP and AEO scorecard templates (or a reference to the agent doc section that does).
+4. `growth-strategist.md` GEO/AEO Content Audit section contains both scorecard templates with weights and grading scale.
+5. The re-audit runbook Phase 2 extracts Presence from the SAP table anchor.
+6. A manual `gh workflow run scheduled-growth-audit.yml` trigger (post-merge verification) produces an audit file with both tables.
+
+## Out of Scope (Tracked Separately)
+
+- Off-site Presence work: #2599, #2600, #2601, #2602, #2603, #2604 remain open and will further lift the Presence score.
+- Moving runbook to engineering/ops/runbooks/ directory.
+- Adding rubric-comparison or trend-line tooling.

--- a/knowledge-base/project/specs/feat-aeo-rubric-reconcile-2679/tasks.md
+++ b/knowledge-base/project/specs/feat-aeo-rubric-reconcile-2679/tasks.md
@@ -8,29 +8,29 @@ status: ready
 
 ## Phase 1 — Agent doc update
 
-- [ ] 1.1 Read `plugins/soleur/agents/marketing/growth-strategist.md` GEO/AEO Content Audit section (lines ~45-120)
-- [ ] 1.2 Add preamble mandating both tables in every AEO audit
-- [ ] 1.3 Embed SAP scorecard template skeleton (Dimension / Weight / Score / Weighted / Notes; weights 40/35/25; grading scale A/B/B+/C/D)
-- [ ] 1.4 Embed 8-component AEO diagnostic template skeleton (weights sum to 100: FAQ=20, Answer density=15, Statistics=15, Source citations=15, Conversational=10, Entity clarity=10, Authority/E-E-A-T=10, Citation-friendly=5)
-- [ ] 1.5 Preserve existing narrative sub-signal guidance under each SAP dimension as rubric commentary beneath the skeletons
-- [ ] 1.6 Run `npx markdownlint-cli2 --fix plugins/soleur/agents/marketing/growth-strategist.md`; re-read after fix to catch any `cq-prose-issue-ref-line-start` issues
+- [x] 1.1 Read `plugins/soleur/agents/marketing/growth-strategist.md` GEO/AEO Content Audit section (lines ~45-120)
+- [x] 1.2 Add preamble mandating both tables in every AEO audit
+- [x] 1.3 Embed SAP scorecard template skeleton (Dimension / Weight / Score / Weighted / Notes; weights 40/35/25; grading scale A/B/B+/C/D)
+- [x] 1.4 Embed 8-component AEO diagnostic template skeleton (weights sum to 100: FAQ=20, Answer density=15, Statistics=15, Source citations=15, Conversational=10, Entity clarity=10, Authority/E-E-A-T=10, Citation-friendly=5)
+- [x] 1.5 Preserve existing narrative sub-signal guidance under each SAP dimension as rubric commentary beneath the skeletons
+- [x] 1.6 Run `npx markdownlint-cli2 --fix plugins/soleur/agents/marketing/growth-strategist.md`; re-read after fix to catch any `cq-prose-issue-ref-line-start` issues
 
 ## Phase 2 — Workflow prompt update
 
-- [ ] 2.1 Read `.github/workflows/scheduled-growth-audit.yml` Step 2 block (lines ~98-109)
-- [ ] 2.2 Replace the open-ended "produce a structured scoring table" with natural-language prompt enumerating both tables, weights, grading scale, and mandatory-both-tables directive
-- [ ] 2.3 Verify 12-space base indentation stays inside the `prompt: |` block (no column-0 lines, no heredocs)
-- [ ] 2.4 Validate YAML: run `yamllint .github/workflows/scheduled-growth-audit.yml` (or `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/scheduled-growth-audit.yml'))"`)
+- [x] 2.1 Read `.github/workflows/scheduled-growth-audit.yml` Step 2 block (lines ~98-109)
+- [x] 2.2 Replace the open-ended "produce a structured scoring table" with natural-language prompt enumerating both tables, weights, grading scale, and mandatory-both-tables directive
+- [x] 2.3 Verify 12-space base indentation stays inside the `prompt: |` block (no column-0 lines, no heredocs)
+- [x] 2.4 Validate YAML: run `yamllint .github/workflows/scheduled-growth-audit.yml` (or `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/scheduled-growth-audit.yml'))"`)
 
 ## Phase 3 — Runbook parser update
 
-- [ ] 3.1 Read `knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md` Phase 2 extraction block
-- [ ] 3.2 Add Phase 2 header note documenting threshold-translation worked example (old `40` → `PRESENCE_PCT=40`, new `20/25` → `PRESENCE_PCT=80`)
-- [ ] 3.3 Replace single-pattern grep with `awk -F'|' 'NF >= 5 && $2 ~ /^ *(\*\*)?Presence(\*\*)?( & Third-Party Mentions)? *$/'`
-- [ ] 3.4 Update score parser: trim whitespace (`SCORE_CELL="${SCORE_CELL// /}"`), accept both `40` and `20/25`; include `$PRESENCE_LINE` in error message
-- [ ] 3.5 Rename `PRESENCE_SCORE` → `PRESENCE_PCT` (or set both) at the Phase 3 branch-selection site so comparison is uniform
-- [ ] 3.6 Update Test Scenarios table: add row for `20/25` format → `PRESENCE_PCT=80` → PASS, and preserve the historical `40` row → FAIL
-- [ ] 3.7 Run `npx markdownlint-cli2 --fix knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md`; re-read after
+- [x] 3.1 Read `knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md` Phase 2 extraction block
+- [x] 3.2 Add Phase 2 header note documenting threshold-translation worked example (old `40` → `PRESENCE_PCT=40`, new `20/25` → `PRESENCE_PCT=80`)
+- [x] 3.3 Replace single-pattern grep with `awk -F'|' 'NF >= 5 && $2 ~ /^ *(\*\*)?Presence(\*\*)?( & Third-Party Mentions)? *$/'`
+- [x] 3.4 Update score parser: trim whitespace (`SCORE_CELL="${SCORE_CELL// /}"`), accept both `40` and `20/25`; include `$PRESENCE_LINE` in error message
+- [x] 3.5 Rename `PRESENCE_SCORE` → `PRESENCE_PCT` (or set both) at the Phase 3 branch-selection site so comparison is uniform
+- [x] 3.6 Update Test Scenarios table: add row for `20/25` format → `PRESENCE_PCT=80` → PASS, and preserve the historical `40` row → FAIL
+- [x] 3.7 Run `npx markdownlint-cli2 --fix knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md`; re-read after
 
 ## Phase 4 — Ship and post-merge verification
 

--- a/knowledge-base/project/specs/feat-aeo-rubric-reconcile-2679/tasks.md
+++ b/knowledge-base/project/specs/feat-aeo-rubric-reconcile-2679/tasks.md
@@ -1,0 +1,42 @@
+---
+feature: aeo-rubric-reconcile-2679
+plan: knowledge-base/project/plans/2026-04-22-chore-aeo-rubric-reconcile-plan.md
+status: ready
+---
+
+# Tasks: AEO audit rubric reconciliation
+
+## Phase 1 — Agent doc update
+
+- [ ] 1.1 Read `plugins/soleur/agents/marketing/growth-strategist.md` GEO/AEO Content Audit section (lines ~45-120)
+- [ ] 1.2 Add preamble mandating both tables in every AEO audit
+- [ ] 1.3 Embed SAP scorecard template skeleton (Dimension / Weight / Score / Weighted / Notes; weights 40/35/25; grading scale A/B/B+/C/D)
+- [ ] 1.4 Embed 8-component AEO diagnostic template skeleton (weights sum to 100: FAQ=20, Answer density=15, Statistics=15, Source citations=15, Conversational=10, Entity clarity=10, Authority/E-E-A-T=10, Citation-friendly=5)
+- [ ] 1.5 Preserve existing narrative sub-signal guidance under each SAP dimension as rubric commentary beneath the skeletons
+- [ ] 1.6 Run `npx markdownlint-cli2 --fix plugins/soleur/agents/marketing/growth-strategist.md`; re-read after fix to catch any `cq-prose-issue-ref-line-start` issues
+
+## Phase 2 — Workflow prompt update
+
+- [ ] 2.1 Read `.github/workflows/scheduled-growth-audit.yml` Step 2 block (lines ~98-109)
+- [ ] 2.2 Replace the open-ended "produce a structured scoring table" with natural-language prompt enumerating both tables, weights, grading scale, and mandatory-both-tables directive
+- [ ] 2.3 Verify 12-space base indentation stays inside the `prompt: |` block (no column-0 lines, no heredocs)
+- [ ] 2.4 Validate YAML: run `yamllint .github/workflows/scheduled-growth-audit.yml` (or `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/scheduled-growth-audit.yml'))"`)
+
+## Phase 3 — Runbook parser update
+
+- [ ] 3.1 Read `knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md` Phase 2 extraction block
+- [ ] 3.2 Add Phase 2 header note documenting threshold-translation worked example (old `40` → `PRESENCE_PCT=40`, new `20/25` → `PRESENCE_PCT=80`)
+- [ ] 3.3 Replace single-pattern grep with `awk -F'|' 'NF >= 5 && $2 ~ /^ *(\*\*)?Presence(\*\*)?( & Third-Party Mentions)? *$/'`
+- [ ] 3.4 Update score parser: trim whitespace (`SCORE_CELL="${SCORE_CELL// /}"`), accept both `40` and `20/25`; include `$PRESENCE_LINE` in error message
+- [ ] 3.5 Rename `PRESENCE_SCORE` → `PRESENCE_PCT` (or set both) at the Phase 3 branch-selection site so comparison is uniform
+- [ ] 3.6 Update Test Scenarios table: add row for `20/25` format → `PRESENCE_PCT=80` → PASS, and preserve the historical `40` row → FAIL
+- [ ] 3.7 Run `npx markdownlint-cli2 --fix knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md`; re-read after
+
+## Phase 4 — Ship and post-merge verification
+
+- [ ] 4.1 Run `skill: soleur:compound` before commit (per `wg-before-every-commit-run-compound-skill`)
+- [ ] 4.2 Run `skill: soleur:ship` to commit + push + mark PR ready. PR body must include `Closes #2679` and `Closes #2615` on their own lines, plus a verification paragraph citing `knowledge-base/marketing/audits/soleur-ai/2026-04-21-aeo-audit.md` with Presence `20/25 (80%)` ≥ 55. Backtick-wrap all issue references to avoid `cq-prose-issue-ref-line-start`.
+- [ ] 4.3 After merge: `gh workflow run scheduled-growth-audit.yml`; poll `gh run list --workflow=scheduled-growth-audit.yml --limit 1 --json status,conclusion,url`
+- [ ] 4.4 Run deterministic validator (from Acceptance Criteria) against the post-merge audit file — must pass on Structure/Authority/Presence rows + 8-component rows
+- [ ] 4.5 If validator fails: file P1 follow-up (`priority/p1-high`, `type/chore`, `domain/marketing`) titled `chore(aeo): pinned prompt dropped — investigate agent compliance`
+- [ ] 4.6 Confirm `#2679` and `#2615` are both CLOSED by the merge

--- a/plugins/soleur/agents/marketing/growth-strategist.md
+++ b/plugins/soleur/agents/marketing/growth-strategist.md
@@ -46,6 +46,41 @@ Audit content for AI agent consumability and generative engine optimization usin
 
 Prioritize findings by GEO impact: source citations > statistics/numbers > quotations > definitions > readability. Keyword density is counterproductive for AI visibility -- flag keyword-stuffed content as a negative signal.
 
+**Output contract (MANDATORY — both tables in every AEO audit):**
+
+Every AEO audit must produce BOTH scorecards below. The SAP scorecard is the headline (used for cross-audit trend comparison and exit-criteria thresholds such as #2615's `Presence >= 55/D`). The 8-component AEO diagnostic surfaces per-signal detail. Do not omit either table, do not reorder the dimensions, and do not rename the labels — downstream scripts anchor on the exact row names.
+
+**Table 1 — SAP Scorecard (headline):**
+
+```markdown
+| Dimension       | Weight | Score   | Weighted | Notes |
+|-----------------|--------|---------|----------|-------|
+| **Structure**   | 40     | <n>/40  | <n>      | ...   |
+| **Authority**   | 35     | <n>/35  | <n>      | ...   |
+| **Presence**    | 25     | <n>/25  | <n>      | ...   |
+| **Total**       | 100    |         | <n>      | <letter grade> |
+```
+
+Grading scale (apply to the Total weighted score): `A >= 90, B 80-89, B+ 75-79, C 60-74, D < 60`.
+
+**Table 2 — 8-component AEO diagnostic:**
+
+```markdown
+| Component                       | Weight | Score  | Notes |
+|---------------------------------|--------|--------|-------|
+| FAQ structure & FAQPage schema  | 20     | <n>/20 | ...   |
+| Answer density / extractability | 15     | <n>/15 | ...   |
+| Statistics & specificity        | 15     | <n>/15 | ...   |
+| Source citations                | 15     | <n>/15 | ...   |
+| Conversational readiness        | 10     | <n>/10 | ...   |
+| Entity clarity                  | 10     | <n>/10 | ...   |
+| Authority / E-E-A-T             | 10     | <n>/10 | ...   |
+| Citation-friendly structure     | 5      | <n>/5  | ...   |
+| **Total**                       | 100    |        | <n>/100 |
+```
+
+The narrative rubric below explains what each SAP dimension measures; use it to decide the numerator in each `<n>/<weight>` cell.
+
 **Structure** -- Is content machine-extractable?
 
 - **Source citations:** Do pages cite authoritative external sources inline? Are claims backed by data, studies, or official documentation? Uncited claims reduce AI citation probability.

--- a/plugins/soleur/agents/marketing/growth-strategist.md
+++ b/plugins/soleur/agents/marketing/growth-strategist.md
@@ -50,6 +50,8 @@ Prioritize findings by GEO impact: source citations > statistics/numbers > quota
 
 Every AEO audit must produce BOTH scorecards below. The SAP scorecard is the headline (used for cross-audit trend comparison and exit-criteria thresholds such as #2615's `Presence >= 55/D`). The 8-component AEO diagnostic surfaces per-signal detail. Do not omit either table, do not reorder the dimensions, and do not rename the labels — downstream scripts anchor on the exact row names.
 
+<!-- sync: keep in sync with .github/workflows/scheduled-growth-audit.yml Step 2 prompt and knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md Phase 2 parser. Weights, row labels, and grading scale are duplicated across these three surfaces. -->
+
 **Table 1 — SAP Scorecard (headline):**
 
 ```markdown

--- a/plugins/soleur/skills/review/SKILL.md
+++ b/plugins/soleur/skills/review/SKILL.md
@@ -589,6 +589,8 @@ When reviewing a Nunjucks/Eleventy page that pairs a visible HTML answer with a 
 
 When flagging a skill description word-budget overrun, the tokenizer MUST match the CI gate. `plugins/soleur/test/components.test.ts` uses `desc.split(/\s+/).filter(Boolean).length` against the YAML value only (1800-word skill budget); the `grep -h 'description:' | wc -w` pattern in AGENTS.md belongs to the agent 2500-word budget and includes YAML framing, inflating counts by ~5 words per skill. Run `bun test plugins/soleur/test/components.test.ts` before reporting — if it passes, the budget is satisfied. See `knowledge-base/project/learnings/2026-04-19-skill-description-word-budget-tokenizer.md`.
 
+When a review agent reports branch-scope regressions (claims the PR reverts merged commits, touches files outside the PR's linked issue/directory, or shows a file list materially larger than expected), verify with `git diff origin/main...HEAD --name-only` (three-dot) before accepting. Two-dot variants like `git diff main..HEAD` show commits on `main` since the fork point (NOT commits on HEAD) and produce wildly different file lists when the branch is behind main — a common agent failure mode that surfaces as a false-positive P0. See `knowledge-base/project/learnings/2026-04-22-markdown-table-parser-papercuts-and-review-diff-direction.md`.
+
 ### Important: P1 Findings Block Merge
 
 Any **P1 (CRITICAL)** findings must be addressed before merging the PR. Present these prominently and ensure they're resolved before accepting the PR.


### PR DESCRIPTION
## Summary

- Pin a **dual-rubric AEO audit template** (SAP headline scorecard + 8-component AEO diagnostic) in BOTH `.github/workflows/scheduled-growth-audit.yml` Step 2 prompt AND `plugins/soleur/agents/marketing/growth-strategist.md` GEO/AEO Content Audit section. Cron runs and ad-hoc `/soleur:growth aeo` invocations now produce deterministic, comparable scorecards across runs.
- Update the re-audit runbook (`knowledge-base/project/plans/2026-04-19-chore-aeo-presence-reaudit-after-pr-2596-plan.md`) Phase 2 bash parser to accept both old-format (`40`) and new SAP-format (`20/25`) score cells. Parser normalizes to percentage-of-category so the `>=55` threshold applies uniformly across rubric eras. Strips bold markdown (`**72**`) and inline whitespace (`20 / 25`) before regex matching.
- Address multi-agent review findings inline: OVERALL_SCORE Weighted-column header lookup (was grabbing Weight column `100`), pinned-scale grade derivation (drop out-of-scale `F` tier), sync-sentinel comments linking all three duplicated surfaces.

Closes #2679
Closes #2615

## Changelog

### Plugin

- **Agents:** `growth-strategist.md` GEO/AEO Content Audit section now defines an explicit output contract with two mandatory table skeletons (SAP + 8-component AEO diagnostic) plus a pinned grading scale. Agents that inherit from this doc (manual `/soleur:growth aeo` invocations) produce comparable scorecards automatically.
- **Skills:** `review/SKILL.md` gains a Sharp Edge directing reviewers to verify branch-scope claims with `git diff origin/main...HEAD --name-only` (three-dot) before accepting — two-dot variants produce wildly different file lists when the branch is behind main and surface as false-positive P0s.
- **Workflows:** `scheduled-growth-audit.yml` Step 2 pins the SAP + AEO dual-rubric template inline, preserving determinism across cron runs. A YAML-level sync-sentinel comment links the workflow to the agent doc and runbook.
- **Knowledge base:**
  - Re-audit runbook Phase 2 parser handles dual-format audits with bold-stripping, Weighted-column fallback, and threshold-translation worked example.
  - Two new learnings: agent-scorecard determinism pinning; markdown-parser papercuts + review-agent diff-direction false-positives.
  - Brainstorm, spec, and plan for `feat-aeo-rubric-reconcile-2679`.

### Verification for #2615

`#2615` is closed citing the 2026-04-21 AEO audit (`knowledge-base/marketing/audits/soleur-ai/2026-04-21-aeo-audit.md`), where Presence scored `20/25 (80%)` under the new SAP rubric — well above the issue's `>=55` threshold. The threshold is interpreted as "percentage-of-category" to reconcile the old (5% weight, bare 0-100 score) and new (25% weight, `<n>/<weight>` score) rubric forms; both formats normalize identically. Off-site follow-ups #2599, #2600, #2601, #2602, #2603, #2604 remain OPEN and will further lift the Presence score; this closure is for the on-site half only (PR #2596 deliverables).

### Parser verification against fixtures

- `2026-04-21-aeo-audit.md` (new SAP, `20/25`): `PRESENCE_SCORE=80`, `PRESENCE_GRADE=B`, `OVERALL_SCORE=78` — PASS branch (>=55).
- `2026-04-18-aeo-audit.md` (old SAP, bare `40`, bold `**72**` on Overall): `PRESENCE_SCORE=40`, `PRESENCE_GRADE=D`, `OVERALL_SCORE=72` — FAIL branch (below 55, historical baseline).
- `2026-04-19-aeo-audit.md` (8-component only, no SAP header): correctly aborts with exit 3 "no header".

## Test plan

- [x] Full test suite passes locally (`bash scripts/test-all.sh` — 22/22 suites pass).
- [x] Parser dry-run against all three audit fixtures produces expected output.
- [x] `python3 yaml.safe_load` on the modified workflow file — YAML valid.
- [x] `markdownlint-cli2 --fix` on all modified markdown files — 0 errors.
- [x] Multi-agent review run; 2 P1 findings fixed inline (commit `e87e3209`), 1 P0 rejected as agent diff-direction false-positive.
- [ ] ⏳ Post-merge: trigger `gh workflow run scheduled-growth-audit.yml` and verify the produced audit contains both the SAP Scorecard and the 8-component AEO diagnostic tables. If either is missing, file a P1 follow-up per the plan's Acceptance Criteria.

Generated with [Claude Code](https://claude.com/claude-code)