### PR TITLE
feat(ci): auto-verify + auto-close data-migration follow-throughs

### DIFF
--- a/.github/workflows/web-platform-release.yml
+++ b/.github/workflows/web-platform-release.yml
@@ -104,9 +104,20 @@ jobs:
             exit 0
           fi
 
+          # Build a list of (full_filename, stem) pairs. Match on either:
+          # - full filename (e.g. "031_normalize_repo_url.sql") — precise
+          # - stem (e.g. "031_normalize_repo_url") — catches issue bodies that
+          #   omit the extension. Stem is long and distinctive (NNN_ prefix +
+          #   snake_case name), so false-positive risk across unrelated issues
+          #   is effectively zero.
+          # Bare "NNN" / "031" is NOT matched — too ambiguous (collides with
+          # issue numbers, dates, etc.).
           verified_names=()
+          verified_stems=()
           for f in "${verify_files[@]}"; do
-            verified_names+=("$(basename "$f")")
+            full="$(basename "$f")"
+            verified_names+=("$full")
+            verified_stems+=("${full%.sql}")
           done
           echo "Verified migrations: ${verified_names[*]}"
 
@@ -125,8 +136,11 @@ jobs:
             [[ -z "$body" ]] && continue
 
             matched=""
-            for name in "${verified_names[@]}"; do
-              if printf '%s' "$body" | grep -qF -- "$name"; then
+            for i in "${!verified_names[@]}"; do
+              name="${verified_names[$i]}"
+              stem="${verified_stems[$i]}"
+              if printf '%s' "$body" | grep -qF -- "$name" \
+                 || printf '%s' "$body" | grep -qF -- "$stem"; then
                 matched="$name"
                 break
               fi

--- a/.github/workflows/web-platform-release.yml
+++ b/.github/workflows/web-platform-release.yml
@@ -55,6 +55,103 @@ jobs:
         run: |
           doppler run -c prd -- bash apps/web-platform/scripts/run-migrations.sh
 
+  verify-migrations:
+    # Runs supabase/verify/*.sql sentinels post-apply, then closes any open
+    # `follow-through` issue whose body references a verified migration. Keeps
+    # migration verification out of the human follow-through loop. See runbook
+    # knowledge-base/engineering/ops/runbooks/supabase-migrations.md §3.
+    needs: migrate
+    if: needs.migrate.result == 'success'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: verify-migrations-web-platform
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@014df23b1329b615816a38eb5f473bb9000700b1 # v3
+      - name: Install psql
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends postgresql-client
+      - name: Run verify files
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_PRD }}
+        run: |
+          doppler run -c prd -- bash apps/web-platform/scripts/run-verify.sh
+
+      - name: Close follow-through issues for verified migrations
+        # Scans open issues labeled `follow-through` for migration filenames
+        # that (a) appear in the body AND (b) have a sibling
+        # supabase/verify/<filename> committed. Body content is fetched via
+        # `gh issue view` into a bash variable and only used as a grep -qF
+        # argument (fixed-string, no regex, never eval'd) — safe per
+        # workflow-injection guidance.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          verify_files=(apps/web-platform/supabase/verify/*.sql)
+          shopt -u nullglob
+          if [[ "${#verify_files[@]}" -eq 0 ]]; then
+            echo "No verify files — nothing to auto-close."
+            exit 0
+          fi
+
+          verified_names=()
+          for f in "${verify_files[@]}"; do
+            verified_names+=("$(basename "$f")")
+          done
+          echo "Verified migrations: ${verified_names[*]}"
+
+          issue_numbers=$(gh issue list \
+            --label follow-through --state open \
+            --limit 200 --json number --jq '.[].number')
+          if [[ -z "$issue_numbers" ]]; then
+            echo "No open follow-through issues."
+            exit 0
+          fi
+
+          closed=0
+          while IFS= read -r issue_number; do
+            [[ -z "$issue_number" ]] && continue
+            body=$(gh issue view "$issue_number" --json body --jq .body 2>/dev/null || echo "")
+            [[ -z "$body" ]] && continue
+
+            matched=""
+            for name in "${verified_names[@]}"; do
+              if printf '%s' "$body" | grep -qF -- "$name"; then
+                matched="$name"
+                break
+              fi
+            done
+            [[ -z "$matched" ]] && continue
+
+            echo "Issue #$issue_number references verified migration $matched — closing."
+            short_sha="${COMMIT_SHA:0:12}"
+            {
+              echo "## Verified by CI"
+              echo
+              echo "Migration \`$matched\` passed the sentinel + idempotence probes defined in \`apps/web-platform/supabase/verify/$matched\`."
+              echo
+              echo "- **Run:** $RUN_URL"
+              echo "- **Commit:** $short_sha"
+              echo
+              echo "Closed automatically by the \`verify-migrations\` job."
+            } > /tmp/auto-close-body.md
+            gh issue comment "$issue_number" --body-file /tmp/auto-close-body.md
+            gh issue close "$issue_number"
+            closed=$((closed + 1))
+          done <<< "$issue_numbers"
+
+          echo "Auto-closed $closed follow-through issue(s)."
+
   verify-doppler-secrets:
     # Pre-deploy guard: asserts the hand-maintained list of required NEXT_PUBLIC_*
     # secrets is present in Doppler prd. Closes #2769 (silent Doppler drift that
@@ -74,13 +171,17 @@ jobs:
           doppler run -c prd -- bash apps/web-platform/scripts/verify-required-secrets.sh
 
   deploy:
-    needs: [release, migrate, verify-doppler-secrets]
+    needs: [release, migrate, verify-migrations, verify-doppler-secrets]
     # verify-doppler-secrets must succeed — skipped/failed blocks deploy (unlike
     # migrate which tolerates 'skipped' when no migrations changed).
+    # verify-migrations tolerates 'skipped' because it only runs on
+    # migrate.result==success; when migrate is itself skipped, verify is
+    # skipped too, and deploy should still proceed.
     if: >-
       always() &&
       needs.release.outputs.docker_pushed == 'true' &&
       (needs.migrate.result == 'success' || needs.migrate.result == 'skipped') &&
+      (needs.verify-migrations.result == 'success' || needs.verify-migrations.result == 'skipped') &&
       needs.verify-doppler-secrets.result == 'success' &&
       (github.event_name != 'workflow_dispatch' || !inputs.skip_deploy)
     runs-on: ubuntu-latest

--- a/apps/web-platform/scripts/run-verify.sh
+++ b/apps/web-platform/scripts/run-verify.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs every SQL file under apps/web-platform/supabase/verify/ against prod
+# and fails if any check reports a non-zero `bad` count.
+#
+# Contract (enforced by this script): each verify file's SELECTs must emit
+# two columns — `check_name TEXT` and `bad INT`. UNION ALL multiple checks
+# into one file to bundle sentinels + idempotence probes per migration.
+#
+# Usage: doppler run -c prd -- bash run-verify.sh
+# Requires: DATABASE_URL or DATABASE_URL_POOLER. Prefers DATABASE_URL_POOLER
+#           for parity with run-migrations.sh (IPv4 path).
+#
+# Exit codes:
+#   0  every verify file passed (or no verify files exist)
+#   1  at least one check returned bad > 0, or psql failed
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERIFY_DIR="$SCRIPT_DIR/../supabase/verify"
+
+command -v psql >/dev/null 2>&1 || { echo "::error::psql not found on PATH"; exit 1; }
+
+DATABASE_URL="${DATABASE_URL_POOLER:-${DATABASE_URL:-}}"
+
+if [[ -z "$DATABASE_URL" ]]; then
+  echo "::error::Neither DATABASE_URL_POOLER nor DATABASE_URL is set. Ensure Doppler injects them."
+  exit 1
+fi
+
+if [[ ! -d "$VERIFY_DIR" ]]; then
+  echo "::notice::No verify directory at $VERIFY_DIR — nothing to check."
+  exit 0
+fi
+
+shopt -s nullglob
+verify_files=("$VERIFY_DIR"/*.sql)
+shopt -u nullglob
+
+if [[ "${#verify_files[@]}" -eq 0 ]]; then
+  echo "::notice::No verify files present — nothing to check."
+  exit 0
+fi
+
+failures=0
+passed=0
+
+for verify_file in "${verify_files[@]}"; do
+  filename="$(basename "$verify_file")"
+  echo "::group::verify $filename"
+
+  # -F $'\t' emits tab-separated rows; -A strips aligned-table padding;
+  # -t drops header/footer so we only see data rows; ON_ERROR_STOP=1 turns
+  # SQL errors into psql exit 1 (tripping `set -e`).
+  if ! output=$(psql "$DATABASE_URL" --no-psqlrc \
+    --set ON_ERROR_STOP=1 \
+    -tAF $'\t' \
+    -f "$verify_file" 2>&1); then
+    echo "::error::verify file failed to execute: $filename"
+    echo "$output"
+    failures=$((failures + 1))
+    echo "::endgroup::"
+    continue
+  fi
+
+  if [[ -z "$output" ]]; then
+    echo "::error::$filename returned no rows — verify files must emit at least one (check_name, bad) row."
+    failures=$((failures + 1))
+    echo "::endgroup::"
+    continue
+  fi
+
+  file_failed=0
+  while IFS=$'\t' read -r check_name bad rest; do
+    [[ -z "$check_name" ]] && continue
+    if [[ -n "$rest" ]]; then
+      echo "::error::$filename/$check_name: extra columns in row — contract is (check_name, bad) only."
+      file_failed=1
+      continue
+    fi
+    if ! [[ "$bad" =~ ^-?[0-9]+$ ]]; then
+      echo "::error::$filename/$check_name: bad column is not an integer ('$bad')."
+      file_failed=1
+      continue
+    fi
+    if [[ "$bad" -gt 0 ]]; then
+      echo "::error::$filename/$check_name: FAIL (bad=$bad)"
+      file_failed=1
+    else
+      echo "ok $filename/$check_name (bad=$bad)"
+    fi
+  done <<< "$output"
+
+  if [[ "$file_failed" -eq 1 ]]; then
+    failures=$((failures + 1))
+  else
+    passed=$((passed + 1))
+  fi
+  echo "::endgroup::"
+done
+
+echo "Verify summary: $passed passed, $failures failed"
+
+if [[ "$failures" -gt 0 ]]; then
+  exit 1
+fi

--- a/apps/web-platform/supabase/verify/031_normalize_repo_url.sql
+++ b/apps/web-platform/supabase/verify/031_normalize_repo_url.sql
@@ -1,0 +1,48 @@
+-- Verify 031_normalize_repo_url.sql.
+--
+-- Contract (see run-verify.sh): every row returns `check_name` + `bad`.
+-- Any row with `bad > 0` fails the CI verify-migrations job.
+--
+-- Sentinels reject any repo_url that still carries a form 031 was meant
+-- to strip: `.git`/`.GIT` suffix, trailing slash, or uppercase scheme/host.
+-- Idempotence probes replay the migration's WHERE clause as a SELECT — a
+-- second run would UPDATE zero rows when the data is canonical.
+
+SELECT 'users_sentinel' AS check_name,
+       count(*)::int AS bad
+  FROM public.users
+ WHERE repo_url IS NOT NULL
+   AND (repo_url ~ '\.git$' OR repo_url ~ '\.GIT$'
+        OR repo_url ~ '/$' OR repo_url ~ '^https://[^/]*[A-Z]')
+UNION ALL
+SELECT 'conversations_sentinel', count(*)::int
+  FROM public.conversations
+ WHERE repo_url IS NOT NULL
+   AND (repo_url ~ '\.git$' OR repo_url ~ '\.GIT$'
+        OR repo_url ~ '/$' OR repo_url ~ '^https://[^/]*[A-Z]')
+UNION ALL
+SELECT 'users_idempotence', count(*)::int
+  FROM public.users u
+ WHERE u.repo_url IS NOT NULL
+   AND substring(trim(u.repo_url) from '^([^/]*//[^/]+)') IS NOT NULL
+   AND u.repo_url <> regexp_replace(
+     regexp_replace(
+       regexp_replace(
+         LOWER(substring(trim(u.repo_url) from '^([^/]*//[^/]+)'))
+         || COALESCE(substring(trim(u.repo_url) from '^[^/]*//[^/]+(/.*)$'), ''),
+         '/+$', '', 'g'),
+       '(\.git)+$', '', 'i'),
+     '/+$', '', 'g')
+UNION ALL
+SELECT 'conversations_idempotence', count(*)::int
+  FROM public.conversations c
+ WHERE c.repo_url IS NOT NULL
+   AND substring(trim(c.repo_url) from '^([^/]*//[^/]+)') IS NOT NULL
+   AND c.repo_url <> regexp_replace(
+     regexp_replace(
+       regexp_replace(
+         LOWER(substring(trim(c.repo_url) from '^([^/]*//[^/]+)'))
+         || COALESCE(substring(trim(c.repo_url) from '^[^/]*//[^/]+(/.*)$'), ''),
+         '/+$', '', 'g'),
+       '(\.git)+$', '', 'i'),
+     '/+$', '', 'g');

--- a/knowledge-base/engineering/ops/runbooks/supabase-migrations.md
+++ b/knowledge-base/engineering/ops/runbooks/supabase-migrations.md
@@ -65,28 +65,32 @@ SELECT indexname, indexdef
 
 ### CI path (default)
 
-Migrations are applied by the deploy workflow via the Supabase Management
-API. The migration file's presence on `main` triggers application during
-the next release run; no manual step is required.
+Migrations are applied by the `migrate` job in
+`.github/workflows/web-platform-release.yml`, which invokes
+`apps/web-platform/scripts/run-migrations.sh` under
+`doppler run -c prd`. The runner tracks applied migrations in the
+`public._schema_migrations` table and applies any new file whose
+filename is not already recorded. The migration file's presence on
+`main` triggers application during the next release run; no manual
+step is required.
 
 ### Manual path (when CI is unavailable)
 
-```bash
-# Fetch the access token from Doppler prd config.
-export SUPABASE_ACCESS_TOKEN=$(doppler secrets get SUPABASE_ACCESS_TOKEN \
-  -p soleur -c prd --plain)
-export SUPABASE_PROJECT_REF=$(doppler secrets get SUPABASE_PROJECT_REF \
-  -p soleur -c prd --plain)
+The runner is portable — run it locally against prod with the same
+Doppler injection CI uses:
 
+```bash
 cd apps/web-platform
-npx supabase db push \
-  --project-ref "$SUPABASE_PROJECT_REF" \
-  --include-all
+doppler run -p soleur -c prd -- bash scripts/run-migrations.sh
 ```
 
-`--include-all` sends every un-applied migration since the last pushed
-version; `db push` is idempotent as long as the migration file itself
-uses `IF NOT EXISTS` guards.
+The runner requires `DATABASE_URL_POOLER` or `DATABASE_URL` in the
+environment — both live in Doppler `prd`. The `-c prd` injection
+supplies them.
+
+Do not reach for `npx supabase db push` — the repo does not use the
+Supabase migration CLI. The psql runner above is the single source of
+truth for production application.
 
 ## Verify
 
@@ -125,11 +129,14 @@ This is the exact failure pattern captured in
 ### 2. Management API (detailed)
 
 Use when the probe passes but you need to confirm constraints or index
-predicates.
+predicates. Doppler `prd` stores `SUPABASE_URL`
+(`https://<ref>.supabase.co`) but not the bare project ref — derive it
+from the URL.
 
 ```bash
 export SUPABASE_ACCESS_TOKEN=$(doppler secrets get SUPABASE_ACCESS_TOKEN -p soleur -c prd --plain)
-export SUPABASE_PROJECT_REF=$(doppler secrets get SUPABASE_PROJECT_REF -p soleur -c prd --plain)
+SUPABASE_URL=$(doppler secrets get SUPABASE_URL -p soleur -c prd --plain)
+SUPABASE_PROJECT_REF=$(echo "$SUPABASE_URL" | sed -E 's|https://([^.]+)\.supabase\.co.*|\1|')
 
 # Confirm column definition (nullability, data type, default).
 curl -sS "https://api.supabase.com/v1/projects/$SUPABASE_PROJECT_REF/database/query" \
@@ -144,17 +151,50 @@ curl -sS "https://api.supabase.com/v1/projects/$SUPABASE_PROJECT_REF/database/qu
   -d '{"query": "SELECT indexname, indexdef FROM pg_indexes WHERE schemaname = '\''public'\'' AND tablename = '\''<table>'\'';"}'
 ```
 
+### 3. Data backfill verification (automated in CI)
+
+Schema-only migrations (`ADD COLUMN`, `CREATE TABLE`) are fully
+verified by the REST probe above. Data migrations — backfills, value
+normalizations, constraint-preparation rewrites — need a deeper check:
+that the target data now satisfies the invariant the migration
+promises.
+
+Declare those checks in a sibling file under
+`apps/web-platform/supabase/verify/`, using the same basename as the
+migration:
+
+```text
+apps/web-platform/supabase/
+├── migrations/
+│   └── 031_normalize_repo_url.sql   # the backfill
+└── verify/
+    └── 031_normalize_repo_url.sql   # the check
+```
+
+The verify file must emit exactly two columns per row:
+
+- `check_name TEXT` — a human-readable label
+- `bad INT`          — count of rows violating the invariant (expected 0)
+
+Any row where `bad > 0` fails the run. `UNION ALL` multiple SELECTs
+into one file to bundle sentinels with idempotence probes (see 031 for
+the pattern).
+
+CI executes every verify file via the `verify-migrations` job in
+`web-platform-release.yml` after `migrate` succeeds. A verify failure
+blocks `deploy` the same way a failed migrate does.
+
 ## Rollback
 
 Rollbacks are destructive. Before running any `DROP COLUMN` or `DROP
-INDEX`, capture the affected rows for recovery:
+INDEX`, capture the affected rows for recovery. Derive `PROJECT_REF`
+from `SUPABASE_URL` as in the Management API section above, then use
+`pg_dump` against `DATABASE_URL_POOLER`:
 
 ```bash
-npx supabase db dump \
-  --project-ref "$SUPABASE_PROJECT_REF" \
-  --data-only \
-  --schema public \
-  --table <table> \
+DATABASE_URL=$(doppler secrets get DATABASE_URL_POOLER -p soleur -c prd --plain)
+pg_dump "$DATABASE_URL" \
+  --data-only --schema=public --table=public.<table> \
   > backup-pre-rollback-$(date +%Y%m%d-%H%M%S).sql
 ```
 
@@ -183,14 +223,21 @@ the rollback succeeded.
 ## Post-merge Verification
 
 Per `wg-when-a-pr-includes-database-migrations`, a PR is not done until
-the migration is confirmed applied to production:
+the migration is confirmed applied to production. The
+`web-platform-release.yml` workflow automates this:
 
-1. Watch the deploy workflow for completion on `main`.
-2. Run the REST API probe (above) against production.
-3. If 200, close the issue referencing the migration with a short note
-   pointing at this runbook and the SHA that applied.
-4. If 400, the migration did not apply — open an incident issue and
-   follow the manual apply path.
+1. `migrate` applies unapplied migrations via `run-migrations.sh`.
+2. `verify-migrations` runs every `supabase/verify/*.sql`, failing on
+   any `bad > 0`.
+3. `verify-migrations` scans open GitHub issues with the
+   `follow-through` label for migration filenames in their body and
+   closes any whose verify passed, commenting with the run URL.
+
+If both jobs succeed, no human action is required. If either fails,
+`deploy` is blocked and the workflow run reports the failing check.
+
+For migrations without a sibling verify file (schema-only), fall back
+to the REST API probe in §1 above.
 
 ## Cross-references
 

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -828,6 +828,8 @@ Each meaningful event (first iteration, every state change, heartbeat every 3rd 
 
    If an issue with a matching title prefix already exists, skip creation and note "Dedup: skipped [title] -- existing issue found."
 
+   **CI-verified migration skip.** Before creating the issue, grep the item description for a migration filename (`NNN_*.sql`). If one is matched AND a sibling verify file exists at `apps/web-platform/supabase/verify/<filename>`, skip creating the follow-through — the `verify-migrations` job in `web-platform-release.yml` will run the sentinels and auto-close any existing issue referencing that filename. Log: "Skip: [item] — CI verify covers <filename>". This prevents the #2826/#2827 pattern (one apply issue + one sentinel issue per data-backfill migration) from regenerating on future PRs.
+
    For each item, write the issue body to a temp file (do NOT use heredocs in this step — write with `{ echo "..."; } > /tmp/follow-through-body.md`), then create the issue:
 
    ```bash
@@ -879,9 +881,12 @@ Each meaningful event (first iteration, every state change, heartbeat every 3rd 
 
    If no migration files found, skip to Step 4.
 
-   **Step 2:** For each new migration file, extract the column additions or table changes. Read the SQL file and identify `ADD COLUMN`, `CREATE TABLE`, or other schema changes.
+   **Step 2:** Classify each new migration.
 
-   **Step 3:** Verify each schema change is live in production by querying the Supabase REST API:
+- **Schema-addition** (`ADD COLUMN`, `CREATE TABLE`, `CREATE INDEX`): verify via the REST probe in Step 3 below.
+- **Data migration** (backfill, value normalization, constraint-preparation rewrite): require a sibling verify file at `apps/web-platform/supabase/verify/<same-filename>.sql`. If absent, block the session and prompt the author to add one — see `knowledge-base/engineering/ops/runbooks/supabase-migrations.md` §3 ("Data backfill verification"). Once present, CI's `verify-migrations` job runs the sentinels on every deploy and auto-closes any matching `follow-through` issues; no additional manual step here.
+
+   **Step 3:** Verify each schema-addition migration is live in production by querying the Supabase REST API:
 
    ```bash
    SUPABASE_URL=$(doppler secrets get NEXT_PUBLIC_SUPABASE_URL -p soleur -c prd --plain)

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -830,6 +830,8 @@ Each meaningful event (first iteration, every state change, heartbeat every 3rd 
 
    **CI-verified migration skip.** Before creating the issue, grep the item description for a migration filename (`NNN_*.sql`). If one is matched AND a sibling verify file exists at `apps/web-platform/supabase/verify/<filename>`, skip creating the follow-through — the `verify-migrations` job in `web-platform-release.yml` will run the sentinels and auto-close any existing issue referencing that filename. Log: "Skip: [item] — CI verify covers <filename>". This prevents the #2826/#2827 pattern (one apply issue + one sentinel issue per data-backfill migration) from regenerating on future PRs.
 
+   **Migration filename anchor.** If the item description mentions any migration filename OR a bare migration number (e.g. "migration 031") AND no sibling verify file exists yet (so we're still creating the issue), prepend a `**Migration file:** \`NNN_full_stem.sql\`` line to the body below the `<ITEM_DESCRIPTION>` paragraph. The `verify-migrations` auto-close job matches on both the full filename AND the stem (`NNN_full_stem`) — having either in the body ensures auto-close works once a verify file is later added. Bare `NNN` alone is not enough to match.
+
    For each item, write the issue body to a temp file (do NOT use heredocs in this step — write with `{ echo "..."; } > /tmp/follow-through-body.md`), then create the issue:
 
    ```bash
@@ -844,6 +846,10 @@ Each meaningful event (first iteration, every state change, heartbeat every 3rd 
    ## Follow-Through Item
 
    <ITEM_DESCRIPTION>
+
+   <!-- When this item is about a migration, include either of:
+   **Migration file:** `NNN_full_stem.sql`
+   See "Migration filename anchor" rule above. -->
 
    **Source PR:** #<PR_NUMBER>
    **Created by:** /ship Phase 7 Step 3.5


### PR DESCRIPTION
## Summary

- Adds a sibling-file convention for data-migration sentinels: `apps/web-platform/supabase/verify/NNN_*.sql` returning `(check_name, bad)` rows; any `bad > 0` fails CI.
- New `verify-migrations` job runs every verify file post-`migrate` via `psql` + Doppler `prd`, then auto-closes any open `follow-through` issue whose body references a verified migration filename with a run-link comment. `deploy` now gates on it.
- `/ship` Phase 7 Step 3.5 skips creating manual follow-through issues for migration ⏳ items when a sibling verify file exists (CI owns it). Step 3.6 splits schema-addition vs data migrations.
- Migration runbook: drops the non-existent `SUPABASE_PROJECT_REF` secret assumption (derive from `SUPABASE_URL`), corrects the apply path (it is `psql` via `run-migrations.sh`, not Management API), documents the verify convention.
- First verify file: `031_normalize_repo_url.sql` — sentinels + idempotence probes validated read-only against prod during this session (resolved #2826, #2827).

## Why

PR #2817 merged a data-backfill migration (031). `/ship` Phase 7 Step 3.5 generated two follow-through issues (apply + verify) that both required manual resolution, even though CI's `migrate` job had already applied the migration automatically. This closes the loop: data migrations ship with their own invariant checks, CI runs them every deploy, and follow-through issues close themselves when the invariant holds.

## Changelog

- **Added** `apps/web-platform/supabase/verify/` convention + `031_normalize_repo_url.sql`
- **Added** `apps/web-platform/scripts/run-verify.sh` (psql-based runner)
- **Added** `verify-migrations` job in `web-platform-release.yml`
- **Changed** `/ship` SKILL.md Phase 7 Step 3.5/3.6 (skip CI-verified migrations, classify schema vs data)
- **Changed** `supabase-migrations.md` runbook (correct apply path, new §3 verify convention, fix SUPABASE_URL derivation)

## Test plan

- [x] `run-verify.sh` smoke-tested against 8 mock-`psql` cases (all-pass, failing row, non-int column, extra columns, empty output, psql error, no verify files, no `DATABASE_URL`) — all rc match expectations
- [x] 031 verify SQL validated read-only against prod Supabase in this session (both sentinels = 0, both idempotence probes = 0, 2 users + 30 conversations populated)
- [x] YAML parses cleanly (`python3 -c 'yaml.safe_load(...)'`)
- [x] Bash syntax check passes (`bash -n`)
- [ ] ⏳ First post-merge deploy: verify the `verify-migrations` job runs, passes, and produces a clean "Auto-closed 0 follow-through issue(s)" log (no open issues currently reference migration filenames; #2826/#2827 already closed manually in this session)
- [ ] ⏳ Next data-backfill PR: confirm `/ship` skips follow-through creation and CI auto-closes any it does create

🤖 Generated with [Claude Code](https://claude.com/claude-code)