### PR TITLE
perf(docs): inline critical CSS + async stylesheet swap (#2831)

### DIFF
--- a/knowledge-base/project/learnings/best-practices/2026-04-27-hand-extracted-critical-css-misses-globally-rendered-selectors.md
+++ b/knowledge-base/project/learnings/best-practices/2026-04-27-hand-extracted-critical-css-misses-globally-rendered-selectors.md
@@ -1,0 +1,149 @@
+---
+name: hand-extracted-critical-css-misses-globally-rendered-selectors
+description: A hand-extracted critical-CSS inline block silently omits selectors for globally-rendered template fragments (e.g., a nav CTA driven by _data/site.json). Static markup checks pass; users see FOUC. The only fix that survives is enumerating every globally-rendered above-fold selector during extraction, not relying on a free-text regenerate comment.
+type: best-practice
+tags: [code-review, critical-css, eleventy, FOUC, drift, multi-agent-review]
+category: best-practices
+module: plugins/soleur/docs
+---
+
+# Hand-Extracted Critical CSS Misses Globally-Rendered Selectors
+
+## Problem
+
+PR #2904 (`fix-2831-lcp-clean`) inlined an above-the-fold critical CSS block
+into `plugins/soleur/docs/_includes/base.njk` and switched the linked
+stylesheet to a `preload`+`onload`-swap async pattern. The PR author hand-
+extracted the critical subset from `css/style.css` (1759 lines) into a 60-
+line `<style>` block and protected it with a free-text comment:
+
+> "Regenerate this block if style.css tokens, header, or hero sections change."
+
+The pre-merge mechanical gates all passed:
+
+- `npx @11ty/eleventy` → 78 files written, 0 errors
+- `grep onload _site/index.html` → swap markup present
+- Inline `<style>` block contains every selector the author thought was needed
+
+Yet the inline block omitted `.nav-cta-slot`, `.nav-cta`, and `.btn--sm`.
+Why this matters: `_data/site.json` sets `primaryCta` globally, so every
+page renders this fragment in its nav:
+
+```html
+<li class="nav-cta-slot">
+  <a class="btn btn-primary btn--sm nav-cta">Sign up</a>
+</li>
+```
+
+Without those rules in the inline block, the nav CTA flashes unstyled
+(oversized button, wrong color) until the async stylesheet swaps in. The
+exact bug the inline block was supposed to prevent — a Flash Of Unstyled
+Content — was preserved on the most prominent above-fold element on every
+page in the site.
+
+## Why Mechanical Checks Missed It
+
+- `tsc`, lint, build → no concept of "is this CSS sufficient for the page".
+- `grep "<style>" _site/*.html` → present, passes.
+- Author's manual visual check on `/` and `/blog/...` → the FOUC happens in
+  the first ~400ms before stylesheet swap; easy to miss on a fast local
+  network and a primed font cache.
+- Test plan checkbox "no FOUC" → unchecked at PR time, deferred to "manual
+  visual check post-merge".
+
+The bug is structural: it's about which selectors the page renders at first
+paint, which is information distributed across `_data/site.json`,
+`base.njk`, and `css/style.css`. No single file shows the gap.
+
+## Solution
+
+Multi-agent review caught it. The pattern-recognition specialist agent was
+given the diff and asked "what's missing for above-fold first paint?" and
+listed every selector consumed by the rendered nav. Cross-referencing
+against the inline block surfaced the gap immediately.
+
+Inline fix (commit `f96276db` on `fix-2831-lcp-clean`):
+
+```css
+.nav-links .nav-cta-slot { margin-left: auto; }
+.nav-links .nav-cta-slot .nav-cta { color: var(--color-text-inverse); }
+.nav-links .nav-cta-slot .nav-cta:hover { color: var(--color-text-inverse); border-bottom-color: transparent; }
+.nav-links .nav-cta-slot .nav-cta:focus-visible { outline: 2px solid var(--color-text-inverse); outline-offset: 3px; }
+.btn.btn--sm { padding: var(--space-2) var(--space-4); font-size: 0.875rem; }
+@media(max-width:768px){
+  .nav-links .nav-cta-slot { margin-left: 0; margin-top: var(--space-2); }
+  .nav-links .nav-cta-slot .nav-cta { display: inline-block; text-align: center; }
+}
+```
+
+Plus a tightened regenerate-comment with a grep-stable selector list (per
+rule `cq-code-comments-symbol-anchors-not-line-numbers`) so a future editor
+of `.nav-cta-slot` in `style.css` will hit the inline block via grep.
+
+## Key Insight
+
+Any time you hand-extract a "critical subset" from a larger source (CSS,
+schema, GraphQL fragment, type definition, config), the extraction is
+silently incomplete if you do not enumerate the consumer's input set.
+
+The consumer here was `base.njk`'s `<nav>` block, which renders fragments
+driven by `_data/site.json` — a data file separate from both the source
+CSS and the inline block. The author saw `style.css` and the page they
+were optimizing, but not the data file that wires them together.
+
+**Generalizable rule:** Before hand-extracting a critical subset, list
+every consumer the page renders at first paint by reading the template
+top-to-bottom, then the data files driving each `{% if %}` and
+`{{ ... }}` interpolation. Extract the subset to satisfy the union, not
+the visible-on-first-load subset of the union.
+
+The free-text comment ("regenerate when X changes") is the weakest
+possible enforcement — it depends on a future editor noticing the comment
+and reasoning correctly. Stronger options, in order:
+
+1. **Build-time extractor** (Eleventy `addTransform` reading source CSS
+   and emitting the inline block). Eliminates drift entirely. Cost:
+   ~50 LOC + dev-loop integration.
+2. **CI parity test** (a test that re-extracts on every build and diffs
+   against the committed inline block). Catches drift at PR time. Cost:
+   one test file.
+3. **Grep-stable comment with explicit selector enumeration** (this PR's
+   approach — a comment listing every selector mirrored). Catches an
+   editor mid-edit if they grep for the selector they're changing.
+4. **Free-text comment** (the original approach). Decorative.
+
+The rule of thumb: when the cost of (1) is small and the consequence of
+drift is user-visible (FOUC, broken layout, wrong colors), pay for (1).
+This PR shipped (3) because the docs site is small and weekly-cadence;
+(1) is a candidate follow-up if the inline block grows or drifts.
+
+## Related Learnings
+
+- `2026-04-15-multi-agent-review-catches-bugs-tests-miss.md` — parent
+  pattern: tests/tsc pass, structural review catches.
+- `2026-04-24-multi-agent-review-catches-feature-wiring-bugs.md` — same
+  shape (the bug lives in a downstream consumer the author didn't model).
+- `2026-04-22-binary-lcp-gate-vs-measurement-variance.md` — the issue
+  acceptance criterion this PR addresses; reminds reviewers that "build
+  passes" ≠ "performance budget met".
+
+## Session Errors
+
+- **Wrong CWD for Eleventy build verification.** Ran `npx @11ty/eleventy`
+  from `plugins/soleur/docs/` and got `filter not found: dateToShort`.
+  Recovery: ran from repo root (the `package.json` script in
+  `plugins/soleur/docs/` does `cd ../../../ && npx @11ty/eleventy`).
+  **Prevention:** existing project convention via the `docs:build` npm
+  script; no rule needed — discoverable via clear error.
+
+## References
+
+- PR: #2904 (`fix-2831-lcp-clean`)
+- Issue: #2831 (Eleventy LCP optimization)
+- Replaces abandoned attempts: #2857, #2859 (both bundled the fix with
+  destructive scope and were closed).
+- Touched file: `plugins/soleur/docs/_includes/base.njk:126-186`
+- Source CSS: `plugins/soleur/docs/css/style.css:771-781` (the missed
+  rules)
+- Globally-rendered consumer: `plugins/soleur/docs/_data/site.json:26`
+  (`primaryCta`) → `base.njk:206-208`

--- a/plugins/soleur/docs/_includes/base.njk
+++ b/plugins/soleur/docs/_includes/base.njk
@@ -123,8 +123,66 @@
   <base href="/">
   <link rel="icon" type="image/png" href="images/favicon.png">
   <title>{% if seoTitle %}{{ seoTitle }}{% elif title == site.name %}{{ site.name }} - {{ site.tagline }}{% else %}{{ title }} - {{ site.name }}{% endif %}</title>
-  <link rel="preload" href="css/style.css" as="style">
-  <link rel="stylesheet" href="css/style.css">
+  <!-- Critical CSS: above-the-fold styles for / and /blog/* inlined to unblock first paint.
+       The full stylesheet loads asynchronously via the onload-swap pattern below.
+       Regenerate this block if style.css tokens, header, or hero sections change. -->
+  <style>
+    @layer reset,tokens,base,layout,components,utilities;
+    @font-face{font-family:'Cormorant Garamond';src:url('fonts/cormorant-garamond-500.woff2') format('woff2');font-weight:500;font-style:normal;font-display:swap}
+    @font-face{font-family:'Inter';src:url('fonts/inter.woff2') format('woff2');font-weight:400 700;font-style:normal;font-display:swap}
+    @layer reset{*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}img{max-width:100%;display:block}input,button{font:inherit}}
+    @layer tokens{:root{--color-bg:#0A0A0A;--color-bg-secondary:#0E0E0E;--color-bg-tertiary:#141414;--color-bg-inverse:#FFFFFF;--color-text:#FFFFFF;--color-text-secondary:#848484;--color-text-tertiary:#737373;--color-text-inverse:#0A0A0A;--color-accent:#C9A962;--color-accent-hover:#D4B36A;--color-accent-dark:#B8923E;--color-border:#2A2A2A;--color-border-strong:#3A3A3A;--color-focus:#C9A962;--font-display:'Cormorant Garamond',Georgia,'Times New Roman',serif;--font-body:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif;--font-mono:'JetBrains Mono',ui-monospace,'Cascadia Code','Fira Code',monospace;--text-xs:0.75rem;--text-sm:0.875rem;--text-base:1rem;--text-lg:1.25rem;--text-xl:1.5rem;--text-2xl:1.875rem;--text-3xl:2.25rem;--text-4xl:3rem;--text-5xl:4.5rem;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.5rem;--space-6:2rem;--space-8:3rem;--space-10:5rem;--space-12:8rem;--header-h:3.5rem}}
+    @layer base{html{scroll-behavior:smooth}body{font-family:var(--font-body);font-size:var(--text-base);line-height:1.6;color:var(--color-text);background:var(--color-bg);-webkit-font-smoothing:antialiased}h1,h2,h3,h4{line-height:1.2;font-weight:700}h1{font-size:var(--text-3xl)}h2{font-size:var(--text-2xl)}h3{font-size:var(--text-lg)}a{color:var(--color-accent);text-decoration:none}a:hover{color:var(--color-accent-hover);text-decoration:underline}:focus-visible{outline:2px solid var(--color-focus);outline-offset:2px}::selection{background:rgba(201,169,98,0.25)}}
+    @layer layout{.container{max-width:1200px;margin-inline:auto;padding-inline:var(--space-5)}@media(min-width:768px){.container{padding-inline:var(--space-8)}}}
+    @layer components{
+      .site-header{position:fixed;top:0;left:0;right:0;z-index:100;height:var(--header-h);display:flex;align-items:center;justify-content:space-between;padding-inline:var(--space-6);background:rgba(10,10,10,0.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--color-border)}
+      .site-header .logo{text-decoration:none;display:flex;align-items:center;gap:var(--space-3)}
+      .site-header .logo:hover{text-decoration:none}
+      .header-mark{width:24px;height:24px;border-radius:6px;border:1px solid var(--color-accent);display:grid;place-items:center;font-family:var(--font-display);font-size:var(--text-sm);color:var(--color-accent)}
+      .header-name{font-size:var(--text-xs);font-weight:500;letter-spacing:3px;color:var(--color-text-secondary);text-transform:uppercase}
+      .nav-links{display:flex;align-items:center;gap:var(--space-4);list-style:none}
+      .nav-links a{font-size:var(--text-sm);color:var(--color-text-secondary);text-decoration:none;padding:var(--space-1) 0;border-bottom:2px solid transparent;transition:color 0.15s,border-color 0.15s}
+      .nav-links a:hover,.nav-links a[aria-current="page"]{color:var(--color-text);border-bottom-color:var(--color-accent);text-decoration:none}
+      .nav-toggle{display:none}
+      .nav-toggle-label{display:none;cursor:pointer;padding:var(--space-2);font-size:var(--text-lg);color:var(--color-text-secondary)}
+      @media(max-width:768px){.nav-toggle-label{display:block}.nav-links{position:fixed;top:var(--header-h);right:0;width:260px;height:calc(100vh - var(--header-h));flex-direction:column;align-items:stretch;gap:0;background:var(--color-bg);border-left:1px solid var(--color-border);padding:var(--space-4);transform:translateX(100%);transition:transform 0.2s ease;z-index:2}.nav-links a{padding:var(--space-3) var(--space-4);border-bottom:none}.nav-toggle:checked ~ .nav-links{transform:translateX(0)}.nav-toggle:checked ~ .nav-toggle-label::before{content:'';position:fixed;top:var(--header-h);left:0;width:100vw;height:calc(100vh - var(--header-h));background:rgba(0,0,0,0.5);z-index:1}}
+      .skip-link{position:absolute;top:-100%;left:var(--space-4);background:var(--color-accent);color:var(--color-text-inverse);padding:var(--space-2) var(--space-4);border-radius:0 0 4px 4px;z-index:200;font-weight:600}
+      .skip-link:focus{top:0}
+      /* Homepage above-fold */
+      .landing-hero{margin-top:var(--header-h);padding:var(--space-10) var(--space-5) var(--space-10);text-align:center}
+      .landing-hero h1{font-family:var(--font-display);font-size:var(--text-5xl);font-weight:500;letter-spacing:-0.02em;line-height:1.05;max-width:900px;margin-inline:auto;margin-bottom:var(--space-6)}
+      .landing-hero .hero-tagline{font-size:1.5rem;font-weight:500;color:var(--color-text-secondary);margin-bottom:var(--space-4)}
+      .landing-hero .hero-sub{font-size:1.125rem;color:var(--color-text-secondary);line-height:1.6;max-width:700px;margin-inline:auto;margin-bottom:var(--space-8)}
+      .hero-cta{display:inline-flex;align-items:center;gap:var(--space-4)}
+      .section-label{font-size:var(--text-xs);font-weight:600;letter-spacing:3px;color:var(--color-accent);text-transform:uppercase;text-align:center;margin-bottom:var(--space-4)}
+      .landing-stats{display:flex;justify-content:space-around;align-items:center;padding:var(--space-10) var(--space-5);background:var(--color-bg-secondary);border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border)}
+      .landing-stat{text-align:center}
+      a.landing-stat{color:inherit;text-decoration:none;display:block}
+      a.landing-stat:hover .landing-stat-label{text-decoration:underline}
+      .landing-stat-value{font-family:var(--font-display);font-size:2.5rem;font-weight:500;color:var(--color-accent);letter-spacing:-0.02em;line-height:1}
+      .landing-stat-label{font-size:var(--text-sm);color:var(--color-text-secondary);margin-top:var(--space-1)}
+      .btn{display:inline-block;padding:var(--space-3) var(--space-5);border-radius:4px;font-weight:600;text-decoration:none;transition:opacity 0.15s}
+      .btn:hover{text-decoration:none}
+      .btn-primary{background:linear-gradient(180deg,#D4B36A 0%,#B8923E 100%);color:var(--color-text-inverse);padding:var(--space-4) var(--space-6)}
+      .btn-primary:hover{opacity:0.9;color:var(--color-text-inverse)}
+      .newsletter-form{display:flex;flex-wrap:wrap;gap:var(--space-3);justify-content:center;align-items:flex-start;max-width:480px;margin:0 auto}
+      .newsletter-form input[type="email"]{flex:1 1 220px;padding:var(--space-3) var(--space-4);background:var(--color-bg);border:1px solid var(--color-border);border-radius:4px;color:var(--color-text);font-size:var(--text-base)}
+      .newsletter-form input[type="email"]:focus{outline:2px solid var(--color-focus);outline-offset:2px;border-color:var(--color-accent)}
+      .newsletter-form input[type="email"]::placeholder{color:var(--color-text-tertiary)}
+      .newsletter-form button[type="submit"]{cursor:pointer;border:none}
+      .hero-waitlist-form{max-width:560px;margin:var(--space-6) auto 0}
+      .hero-waitlist-form input[type="email"]{background:#111}
+      .hero-waitlist-form .btn-primary{flex-shrink:0}
+      @media(max-width:768px){.hero-waitlist-form{max-width:100%}.hero-waitlist-form input[type="email"],.hero-waitlist-form .btn-primary{flex:1 1 100%}}
+      /* Blog above-fold */
+      .hero{background:var(--color-bg);color:var(--color-text);padding:var(--space-10) 0 var(--space-8);margin-top:var(--header-h);position:relative;text-align:center;border-bottom:1px solid var(--color-border)}
+      .hero h1{font-size:var(--text-4xl);margin-bottom:var(--space-4);letter-spacing:-0.02em}
+      .hero p,.hero .hero-subtitle,.hero .subtitle{font-size:var(--text-lg);color:var(--color-text-secondary);max-width:600px;margin-inline:auto}
+      .blog-post-meta{display:flex;align-items:center;gap:var(--space-3);margin-top:var(--space-2);color:var(--color-text-secondary);font-size:var(--text-sm)}
+    }
+  </style>
+  <link rel="preload" href="css/style.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="css/style.css"></noscript>
   <!-- Privacy-friendly analytics by Plausible -->
   <script async src="https://plausible.io/js/pa-unmpBTT7YXW_UsDCGRfHH.js"></script>
   <!-- CSP: editing this script requires updating the sha256 hash in the CSP meta tag above. Run validate-csp.sh to check. -->

--- a/plugins/soleur/docs/_includes/base.njk
+++ b/plugins/soleur/docs/_includes/base.njk
@@ -125,7 +125,11 @@
   <title>{% if seoTitle %}{{ seoTitle }}{% elif title == site.name %}{{ site.name }} - {{ site.tagline }}{% else %}{{ title }} - {{ site.name }}{% endif %}</title>
   <!-- Critical CSS: above-the-fold styles for / and /blog/* inlined to unblock first paint.
        The full stylesheet loads asynchronously via the onload-swap pattern below.
-       Regenerate this block if style.css tokens, header, or hero sections change. -->
+       Regenerate from css/style.css when these change: @layer tokens (--color-*, --font-*,
+       --space-*, --header-h, --text-*); rules .site-header, .header-mark, .header-name,
+       .nav-links*, .nav-toggle*, .nav-cta-slot, .nav-cta, .skip-link, .landing-hero*,
+       .section-label, .landing-stats, .landing-stat*, .btn, .btn-primary, .btn--sm,
+       .newsletter-form*, .hero-waitlist-form*, .hero (blog), .blog-post-meta. -->
   <style>
     @layer reset,tokens,base,layout,components,utilities;
     @font-face{font-family:'Cormorant Garamond';src:url('fonts/cormorant-garamond-500.woff2') format('woff2');font-weight:500;font-style:normal;font-display:swap}
@@ -143,9 +147,13 @@
       .nav-links{display:flex;align-items:center;gap:var(--space-4);list-style:none}
       .nav-links a{font-size:var(--text-sm);color:var(--color-text-secondary);text-decoration:none;padding:var(--space-1) 0;border-bottom:2px solid transparent;transition:color 0.15s,border-color 0.15s}
       .nav-links a:hover,.nav-links a[aria-current="page"]{color:var(--color-text);border-bottom-color:var(--color-accent);text-decoration:none}
+      .nav-links .nav-cta-slot{margin-left:auto}
+      .nav-links .nav-cta-slot .nav-cta{color:var(--color-text-inverse)}
+      .nav-links .nav-cta-slot .nav-cta:hover{color:var(--color-text-inverse);border-bottom-color:transparent}
+      .nav-links .nav-cta-slot .nav-cta:focus-visible{outline:2px solid var(--color-text-inverse);outline-offset:3px}
       .nav-toggle{display:none}
       .nav-toggle-label{display:none;cursor:pointer;padding:var(--space-2);font-size:var(--text-lg);color:var(--color-text-secondary)}
-      @media(max-width:768px){.nav-toggle-label{display:block}.nav-links{position:fixed;top:var(--header-h);right:0;width:260px;height:calc(100vh - var(--header-h));flex-direction:column;align-items:stretch;gap:0;background:var(--color-bg);border-left:1px solid var(--color-border);padding:var(--space-4);transform:translateX(100%);transition:transform 0.2s ease;z-index:2}.nav-links a{padding:var(--space-3) var(--space-4);border-bottom:none}.nav-toggle:checked ~ .nav-links{transform:translateX(0)}.nav-toggle:checked ~ .nav-toggle-label::before{content:'';position:fixed;top:var(--header-h);left:0;width:100vw;height:calc(100vh - var(--header-h));background:rgba(0,0,0,0.5);z-index:1}}
+      @media(max-width:768px){.nav-toggle-label{display:block}.nav-links{position:fixed;top:var(--header-h);right:0;width:260px;height:calc(100vh - var(--header-h));flex-direction:column;align-items:stretch;gap:0;background:var(--color-bg);border-left:1px solid var(--color-border);padding:var(--space-4);transform:translateX(100%);transition:transform 0.2s ease;z-index:2}.nav-links a{padding:var(--space-3) var(--space-4);border-bottom:none}.nav-links .nav-cta-slot{margin-left:0;margin-top:var(--space-2)}.nav-links .nav-cta-slot .nav-cta{display:inline-block;text-align:center}.nav-toggle:checked ~ .nav-links{transform:translateX(0)}.nav-toggle:checked ~ .nav-toggle-label::before{content:'';position:fixed;top:var(--header-h);left:0;width:100vw;height:calc(100vh - var(--header-h));background:rgba(0,0,0,0.5);z-index:1}}
       .skip-link{position:absolute;top:-100%;left:var(--space-4);background:var(--color-accent);color:var(--color-text-inverse);padding:var(--space-2) var(--space-4);border-radius:0 0 4px 4px;z-index:200;font-weight:600}
       .skip-link:focus{top:0}
       /* Homepage above-fold */
@@ -163,6 +171,7 @@
       .landing-stat-label{font-size:var(--text-sm);color:var(--color-text-secondary);margin-top:var(--space-1)}
       .btn{display:inline-block;padding:var(--space-3) var(--space-5);border-radius:4px;font-weight:600;text-decoration:none;transition:opacity 0.15s}
       .btn:hover{text-decoration:none}
+      .btn.btn--sm{padding:var(--space-2) var(--space-4);font-size:0.875rem}
       .btn-primary{background:linear-gradient(180deg,#D4B36A 0%,#B8923E 100%);color:var(--color-text-inverse);padding:var(--space-4) var(--space-6)}
       .btn-primary:hover{opacity:0.9;color:var(--color-text-inverse)}
       .newsletter-form{display:flex;flex-wrap:wrap;gap:var(--space-3);justify-content:center;align-items:flex-start;max-width:480px;margin:0 auto}


### PR DESCRIPTION
## Summary

Fixes #2831. Replaces #2857 and #2859, which both bundled this fix with destructive unrelated changes (settings.json hooks wipe, stray gitlink, unrelated docs).

- Inlines above-the-fold critical CSS in `_includes/base.njk` as a `<style>` block (CSS layer order, tokens, reset, base typography, container, site-header + mobile nav, skip-link, `.landing-hero` + hero waitlist form, `.landing-stats`, `.btn`/`.btn-primary`, `.newsletter-form`, blog `.hero`, `.blog-post-meta`)
- Replaces the render-blocking `<link rel="stylesheet">` with the preload + onload-swap pattern; adds `<noscript>` fallback
- `@font-face` for Cormorant Garamond + Inter is included in the inline block so font fetch begins on first paint
- No CSP change: `style-src 'self' 'unsafe-inline'` already permits the inline `<style>` block (verified at `base.njk:30`)

## Changelog

### Plugin (docs site only — no plugin component changes)

- **perf(docs):** Inline critical above-the-fold CSS in `_includes/base.njk` and load the full stylesheet asynchronously via the `preload`+`onload`-swap pattern, with a `<noscript>` fallback. Targets the LCP regression tracked in #2831.
- **review fix:** Inline block now includes `.nav-cta-slot`, `.nav-cta`, and `.btn--sm` rules so the global navigation CTA (driven by `_data/site.json:primaryCta`) does not flash unstyled until the async stylesheet swaps in.
- **review fix:** Tightened the regenerate-comment in the inline block from free-text into a grep-stable selector list (per rule `cq-code-comments-symbol-anchors-not-line-numbers`).
- **learning:** Captured `2026-04-27-hand-extracted-critical-css-misses-globally-rendered-selectors.md` — generalized rule for hand-extracting any "critical subset" (CSS, schema, fragment, type) from a larger source.

## Provenance

The diff is the `plugins/soleur/docs/_includes/base.njk` hunk from #2859, cherry-picked clean into a fresh worktree. The destructive changes from #2857/#2859 (settings.json hooks deletion, `.claude/worktrees/agent-a8cf89db` gitlink, unrelated `vision.md`/`constitution.md` adds) are excluded.

Subsequent commits on this branch:
- `f96276db` — review fixes (nav-cta inlining + comment anchor)
- `b4db9c7e` — learning file capturing the bug class

## Test plan

- [x] `npx @11ty/eleventy` build completes without errors (verified locally — 78 files written)
- [x] Generated `/index.html` and `/blog/billion-dollar-solo-founder-stack/index.html` both contain the inlined `<style>` block, `onload="this.onload=null;this.rel='stylesheet'"`, and the new `nav-cta-slot`/`btn--sm` rules (verified via grep on built output)
- [x] Multi-agent review (security, pattern-recognition, code-quality, git-history) — see review summary below
- [ ] Visual check on `/` and `/blog/billion-dollar-solo-founder-stack/` post-deploy — no FOUC on hero, header, stats strip, CTA button, or nav CTA (manual)
- [ ] Mobile (≤768px) nav toggle functions; nav CTA renders correctly in mobile drawer (manual)
- [ ] Keyboard: skip-link appears on focus (manual)
- [ ] JS-disabled browser: `<noscript>` fallback serves the full stylesheet (manual)
- [ ] ⏳ 3× Lighthouse on `/` and `/blog/billion-dollar-solo-founder-stack/` — confirm median LCP ≤ 2500ms and CLS ≤ 0.1 per #2831 acceptance criteria (gate)

## Review Summary

`/soleur:review` ran four parallel agents (non-code classification — single `.njk` file). Findings:

- **0 P1**, **2 P2 fixed inline** (commit `f96276db`):
  1. Missing `.nav-cta-slot`/`.nav-cta`/`.btn--sm` inline → real FOUC on every page (`site.primaryCta` is set globally in `_data/site.json`).
  2. Vague regenerate-comment violated `cq-code-comments-symbol-anchors-not-line-numbers`.
- **0 unresolved review-origin issues** (Review-Findings Exit Gate passes).
- Token/layer parity verified bit-identical to `css/style.css` source.
- security-sentinel verified the CSP `script-src` doesn't have `'unsafe-inline'`/`'unsafe-hashes'` but the loadCSS `<link onload>` pattern is the documented browser-exempt case (every major engine since 2014). Runtime CSP probe is recommended belt-and-suspenders.

## Notes

If `style.css` tokens, header, or hero sections change in the future, the inline `<style>` block in `base.njk` must be updated to match. The regenerate-comment now lists every selector mirrored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
