### PR TITLE
fix(docs): hashed inline-script for CSS swap (CSP was blocking onload= attribute)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
           npm install --no-save playwright@1 http-server@14
           npx playwright install-deps chromium
 
-      - name: Screenshot gate (critical-CSS FOUC detection)
+      - name: Screenshot + stylesheet-swap gates
         run: |
           npx http-server _site -p 8888 -a 127.0.0.1 -c-1 -s &
           SERVER_PID=$!
@@ -230,13 +230,17 @@ jobs:
             sleep 0.5
           done
           if [ "$UP" -ne 1 ]; then
-            echo "screenshot-gate: http-server failed to come up within 15s" >&2
+            echo "gates: http-server failed to come up within 15s" >&2
             kill $SERVER_PID 2>/dev/null || true
             exit 2
           fi
           set +e
           node plugins/soleur/docs/scripts/screenshot-gate.mjs
           GATE_EXIT=$?
+          if [ "$GATE_EXIT" -eq 0 ]; then
+            node plugins/soleur/docs/scripts/check-stylesheet-swap.mjs
+            GATE_EXIT=$?
+          fi
           set -e
           kill $SERVER_PID 2>/dev/null || true
           exit $GATE_EXIT

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -78,26 +78,27 @@ jobs:
           npm install --no-save playwright@1 http-server@14
           npx playwright install --with-deps chromium
 
-      - name: Screenshot gate (critical-CSS FOUC detection)
+      - name: Screenshot gate (FOUC) + stylesheet-swap regression gate
         run: |
           npx http-server _site -p 8888 -a 127.0.0.1 -c-1 -s &
           SERVER_PID=$!
-          # Poll for the static server to be ready (15s budget). Fail explicitly
-          # if it never comes up so the gate doesn't silently run against a dead
-          # server and report 11x "navigation failed" instead of a real cause.
           UP=0
           for i in $(seq 1 30); do
             if curl -sf -o /dev/null http://127.0.0.1:8888/; then UP=1; break; fi
             sleep 0.5
           done
           if [ "$UP" -ne 1 ]; then
-            echo "screenshot-gate: http-server failed to come up within 15s" >&2
+            echo "gates: http-server failed to come up within 15s" >&2
             kill $SERVER_PID 2>/dev/null || true
             exit 2
           fi
           set +e
           node plugins/soleur/docs/scripts/screenshot-gate.mjs
           GATE_EXIT=$?
+          if [ "$GATE_EXIT" -eq 0 ]; then
+            node plugins/soleur/docs/scripts/check-stylesheet-swap.mjs
+            GATE_EXIT=$?
+          fi
           set -e
           kill $SERVER_PID 2>/dev/null || true
           exit $GATE_EXIT

--- a/plugins/soleur/docs/_includes/base.njk
+++ b/plugins/soleur/docs/_includes/base.njk
@@ -27,7 +27,7 @@
   <!-- CSP: Cloudflare Bot Fight Mode injects an inline script with per-request
        tokens. This script is intentionally blocked by script-src (its hash is
        unpredictable). The blocked script has no user-facing impact — see #1149. -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://plausible.io 'sha256-l56vLAULxECuIebP1+Hhz+75oNwhX8YnMpMJrN6HoPo=' 'sha256-SVJF5zPt5S9fNTROUuCTIHZpLN5Ht8ZoYfJXtx4ngtM='; connect-src 'self' https://buttondown.com https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; base-uri 'self'; form-action 'self' https://buttondown.com; object-src 'none'; upgrade-insecure-requests;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://plausible.io 'sha256-l56vLAULxECuIebP1+Hhz+75oNwhX8YnMpMJrN6HoPo=' 'sha256-SVJF5zPt5S9fNTROUuCTIHZpLN5Ht8ZoYfJXtx4ngtM=' 'sha256-9o2LMPU0pCC0i/83pWDPlO90JiCMiJbUjQWPhLF+W0Y='; connect-src 'self' https://buttondown.com https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; base-uri 'self'; form-action 'self' https://buttondown.com; object-src 'none'; upgrade-insecure-requests;">
   <script type="application/ld+json">
   {# All string interpolations in this JSON-LD block MUST use | jsonLdSafe | safe — see #2609 #}
   {
@@ -212,8 +212,13 @@
       .honeypot-trap{position:absolute;left:-9999px;height:0;overflow:hidden}
     }
   </style>
-  <link rel="preload" href="css/style.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <link id="soleur-css-preload" rel="preload" href="css/style.css" as="style">
   <noscript><link rel="stylesheet" href="css/style.css"></noscript>
+  <!-- CSP-compliant async stylesheet swap. Replaces an inline onload= attribute (blocked
+       by script-src without unsafe-inline / unsafe-hashes) with a hashed inline script.
+       Editing the swap below requires updating the sha256 hash in the CSP meta tag above.
+       Run validate-csp.sh to verify. -->
+  <script>(function(){var l=document.getElementById('soleur-css-preload');if(!l)return;function sw(){l.rel='stylesheet';}if(l.sheet){sw();}else{l.addEventListener('load',sw);}})();</script>
   <!-- Privacy-friendly analytics by Plausible -->
   <script async src="https://plausible.io/js/pa-unmpBTT7YXW_UsDCGRfHH.js"></script>
   <!-- CSP: editing this script requires updating the sha256 hash in the CSP meta tag above. Run validate-csp.sh to check. -->

--- a/plugins/soleur/docs/scripts/check-stylesheet-swap.mjs
+++ b/plugins/soleur/docs/scripts/check-stylesheet-swap.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// Regression gate for the post-load stylesheet swap on the Eleventy docs site.
+//
+// The site uses a `<link rel="preload">` + scripted `rel='stylesheet'` swap to
+// improve LCP. This gate verifies the swap actually fires and applies the full
+// stylesheet — catching a class of bug the screenshot gate (which blocks CSS)
+// cannot detect.
+//
+// Detected failure classes:
+//   1. CSP `script-src` blocks the swap script (no `'unsafe-inline'`,
+//      `'unsafe-hashes'`, or matching SHA-256 hash). The link's `rel` stays
+//      `preload` and style.css never applies. Original symptom in PR after
+//      #2960: every page below the inline-CSS region rendered unstyled in
+//      browsers with JavaScript enabled.
+//   2. The swap script throws (referenced ID missing, addEventListener
+//      unavailable, etc.) leaving rel as `preload`.
+//   3. `style.css` fails to load (404, MIME type, blocked by CSP `style-src`).
+//
+// Strategy: navigate without blocking external CSS, wait for `'load'`, then
+// assert (a) the link's `rel` is `stylesheet`, (b) a below-the-fold rule from
+// `style.css` is applied (e.g., `.site-footer` padding-top from `var(--space-8)`),
+// (c) no CSP violations in the console log.
+//
+// Exit codes:
+//   0  swap fires on every probed route
+//   1  one or more routes failed (rel not swapped, computed style missing, or CSP violation)
+//   2  bootstrap error (browser launch failed, server unreachable)
+
+import { chromium } from "playwright";
+
+const BASE_URL = process.env.SCREENSHOT_GATE_BASE_URL || "http://127.0.0.1:8888";
+
+// Probe routes. The swap mechanism is identical across all pages (defined in
+// `_includes/base.njk`), so probing 3 representative pages is sufficient.
+// The screenshot gate covers per-route inline-CSS regressions.
+const ROUTES = ["/", "/pricing/", "/blog/"];
+
+// var(--space-8) is `3rem`; the docs site uses the browser default 16px root
+// font size, so .site-footer padding-top is 48px when style.css is applied.
+// Default <footer> padding is 0.
+const FOOTER_PADDING_MIN_PX = 30;
+
+const NAV_TIMEOUT_MS = 15_000;
+
+let browser;
+try {
+  browser = await chromium.launch();
+} catch (err) {
+  console.error("check-stylesheet-swap: failed to launch chromium:", err.message);
+  process.exit(2);
+}
+
+try {
+  const probe = await fetch(`${BASE_URL}/`, { method: "HEAD" });
+  void probe;
+} catch (err) {
+  console.error(`check-stylesheet-swap: server unreachable at ${BASE_URL}: ${err.message}`);
+  await browser.close();
+  process.exit(2);
+}
+
+const failures = [];
+
+for (const path of ROUTES) {
+  const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const page = await ctx.newPage();
+  const cspViolations = [];
+
+  page.on("console", (msg) => {
+    if (msg.type() === "error" && msg.text().includes("Content-Security-Policy")) {
+      cspViolations.push(msg.text());
+    }
+  });
+
+  try {
+    await page.goto(`${BASE_URL}${path}`, { waitUntil: "load", timeout: NAV_TIMEOUT_MS });
+    const result = await page.evaluate(() => {
+      const link = document.getElementById("soleur-css-preload");
+      const footer = document.querySelector(".site-footer");
+      const footerCs = footer ? getComputedStyle(footer) : null;
+      return {
+        linkPresent: !!link,
+        linkRel: link ? link.rel : null,
+        footerPaddingTop: footerCs ? parseFloat(footerCs.paddingTop) : null,
+      };
+    });
+
+    const errs = [];
+    if (!result.linkPresent) {
+      errs.push("`#soleur-css-preload` link not in DOM — base.njk swap structure changed");
+    } else if (result.linkRel !== "stylesheet") {
+      errs.push(
+        `link rel is "${result.linkRel}" after load — swap script did not fire (CSP block? script error?)`,
+      );
+    }
+    if (result.footerPaddingTop !== null && result.footerPaddingTop < FOOTER_PADDING_MIN_PX) {
+      errs.push(
+        `.site-footer padding-top=${result.footerPaddingTop}px (<${FOOTER_PADDING_MIN_PX}px) — full stylesheet did not apply`,
+      );
+    }
+    if (cspViolations.length) {
+      errs.push(`CSP violations (${cspViolations.length}): ${cspViolations[0].slice(0, 120)}`);
+    }
+
+    if (errs.length) failures.push({ path, errs });
+  } catch (err) {
+    failures.push({ path, errs: [`navigation failed: ${err.message}`] });
+  } finally {
+    await ctx.close();
+  }
+}
+
+await browser.close();
+
+if (failures.length) {
+  console.error("check-stylesheet-swap: FAIL");
+  for (const f of failures) {
+    console.error(`  ${f.path}`);
+    for (const e of f.errs) console.error(`    - ${e}`);
+  }
+  process.exit(1);
+}
+
+console.log(`check-stylesheet-swap: PASS (${ROUTES.length} routes; swap fires, full stylesheet applies)`);


### PR DESCRIPTION
## Summary

Production showed entire pages (everything below the inline critical-CSS region) rendering in default browser styles — footers unstyled, blog catalog as plain links, code blocks without backgrounds. Despite PR #2960 inlining the page-hero region, the user kept seeing the broken state.

**Root cause** (older than #2960, since PR #2904): the async-stylesheet pattern uses an inline `onload="this.rel='stylesheet'"` attribute on the preload `<link>`. The docs-site CSP allows only:

```
script-src 'self' https://plausible.io 'sha256-...' 'sha256-...'
```

No `'unsafe-inline'`, no `'unsafe-hashes'` → inline event handlers are blocked. The browser fetches `css/style.css` (preload still works) but the rel-swap never fires. Below-the-fold elements stay in default styles forever. Fix has been live-broken since PR #2904 merged this morning.

## Changelog

- **fix:** replaced the inline `onload=` attribute on the CSS preload link with a separate inline `<script>` block whose SHA-256 is allowlisted in the CSP `script-src`. The script attaches a load listener (or swaps immediately if the stylesheet already loaded). The existing `<noscript>` fallback handles JS-disabled clients.
- **feat:** new regression gate `plugins/soleur/docs/scripts/check-stylesheet-swap.mjs` — navigates without blocking CSS, waits for `'load'`, asserts (a) preload link's `rel` swapped to `stylesheet`, (b) a below-the-fold rule (`.site-footer` padding-top from `var(--space-8)`) applied, (c) zero CSP violations in console. Catches a class the FOUC screenshot-gate cannot (it intentionally blocks CSS).
- **chore:** wired the new gate after the FOUC screenshot gate in both `deploy-docs.yml` (post-merge) and `ci.yml` (pre-merge).

## Verification

- **Pre-fix gate run against production** `https://www.soleur.ai/` returns `link not in DOM, .site-footer padding-top=0px` for /, /pricing/, /blog/ — confirms the bug class on prod.
- **Post-fix gate run against locally-served _site/** returns PASS for the same 3 routes — `link.rel='stylesheet'` after load, footer padding 48px, zero CSP violations.
- All 3 gates green: `check-critical-css-coverage` (static), `screenshot-gate` (FOUC), `check-stylesheet-swap` (new).
- `bash plugins/soleur/skills/seo-aeo/scripts/validate-csp.sh _site` PASS — new SHA-256 hash matches the inline script body.

## Test plan

- [x] CSP validation passes (new sha256 hash matches the swap script body)
- [x] FOUC screenshot gate still passes (inline CSS coverage unchanged)
- [x] New regression gate passes locally
- [x] New regression gate FAILS against current production (proves it would have caught the bug)
- [x] Local Playwright load: no CSP violations, link.rel === 'stylesheet' after load, .site-footer styled
- [ ] ⏳ Post-merge: production .site-footer renders styled (48px padding) on /, /pricing/, /blog/

🤖 Generated with [Claude Code](https://claude.com/claude-code)