### PR TITLE
fix(workflow): validate-csp.sh detects inline event-handler attributes; wire into pre-merge ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,12 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: npx @11ty/eleventy
 
+      - name: Validate CSP (hashes + inline event-handler attributes)
+        run: bash plugins/soleur/skills/seo-aeo/scripts/validate-csp.sh _site
+
+      - name: Validate SEO
+        run: bash plugins/soleur/skills/seo-aeo/scripts/validate-seo.sh _site
+
       - name: Static critical-CSS coverage check
         run: node plugins/soleur/docs/scripts/check-critical-css-coverage.mjs
 

--- a/knowledge-base/project/learnings/best-practices/2026-04-27-inline-event-handlers-silently-blocked-by-csp.md
+++ b/knowledge-base/project/learnings/best-practices/2026-04-27-inline-event-handlers-silently-blocked-by-csp.md
@@ -1,0 +1,139 @@
+---
+module: docs-site
+date: 2026-04-27
+problem_type: integration_issue
+component: csp_inline_event_handler
+symptoms:
+  - "Production docs site rendered the entire below-the-fold area in default browser styles for ~9 hours"
+  - "<link rel=preload onload=this.rel=stylesheet> async-swap pattern silently failed in browsers with JS enabled"
+  - "validate-csp.sh PASSED on every commit while the bug was live; eleventy build PASSED; SEO validator PASSED"
+  - "Compound failure: PR #2904 introduced the bug, PR #2960 fixed only the above-the-fold symptom (inline-CSS coverage), PR #2966 fixed the actual root cause (CSP-blocked swap), PR #2967 closed the workflow gap"
+root_cause: csp_script_src_blocks_inline_event_handlers_without_unsafe_inline_or_unsafe_hashes
+severity: critical
+tags:
+  - csp
+  - inline-event-handler
+  - silent-failure
+  - workflow-gate
+  - validate-csp
+  - eleventy
+synced_to: []
+---
+
+# Inline event-handler attributes are silently blocked by CSP — and no static gate caught it
+
+## Problem
+
+PR #2904 introduced an async-stylesheet-swap pattern in `_includes/base.njk`:
+
+```html
+<link rel="preload" href="css/style.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<noscript><link rel="stylesheet" href="css/style.css"></noscript>
+```
+
+The docs site CSP allows only:
+
+```
+script-src 'self' https://plausible.io 'sha256-<plausible>' 'sha256-<signup-handler>'
+```
+
+No `'unsafe-inline'`, no `'unsafe-hashes'`. The HTML5 spec treats `onload=` (and every `on*=` attribute) as an inline event handler that requires either `'unsafe-inline'` or `'unsafe-hashes'` + a matching SHA-256 hash. Neither was present, so every browser with JavaScript enabled silently refused to execute the handler. The `<link rel="preload">` fetched `css/style.css` correctly, but the `rel='stylesheet'` swap never fired. Below-the-fold elements stayed in default browser styles indefinitely.
+
+The bug shipped to production at PR #2904 merge and stayed live for ~9 hours through PR #2960 (which "fixed" FOUC by inlining more above-the-fold CSS but left the swap broken) until PR #2966 replaced the inline `onload=` with a hashed `<script>` block.
+
+## Why the existing gates didn't catch it
+
+| Gate | Why it missed |
+|---|---|
+| `eleventy build` | Pure templating — no semantic awareness of CSP behavior. |
+| `validate-csp.sh` (pre-PR #2967) | Only checked `<script>` block hashes. Did not scan for inline event-handler attributes. CSP enforcement against attributes is a different surface. |
+| `validate-seo.sh` | Markup correctness, not runtime behavior. |
+| `screenshot-gate.mjs` (added PR #2960) | Intentionally blocks `**/*.css` to test inline-only state. By design cannot detect "swap doesn't fire." |
+| `check-critical-css-coverage.mjs` (added PR #2960) | Static selector enumeration. Does not exercise the swap mechanism. |
+| Multi-agent code review (PR #2960) | None of 8 reviewers traced the real-browser-with-CSP load path. security-sentinel reviewed CSP for the workflow YAML, not for inline handlers in the rendered HTML. |
+| Local Playwright check (PR #2960 author) | Used `waitUntil: 'networkidle'` which masks the bug — `networkidle` does not care whether the swap script ran, only whether the browser finished loading the preload. |
+| Production curl probe (PR #2960 author) | Verified the inline `<style>` block contained the new selectors. Did not verify post-load DOM state. |
+
+The compound failure mode: every layer was looking at one specific facet (markup, hashes, FOUC, networking) and none was checking the *post-load DOM state in the actual CSP-enforced runtime*.
+
+## Root cause
+
+CSP `script-src` controls four execution surfaces:
+
+1. `<script>` blocks (with `src=` or inline body)
+2. Inline event handlers (`on*=` attributes)
+3. `javascript:` URIs (in `href=`, `src=`, `action=`)
+4. `eval`-class APIs (`eval`, `Function`, `setTimeout("string", ...)`)
+
+`'unsafe-inline'` allows (1) and (2). `'unsafe-hashes'` plus a matching SHA-256 hash allows (2) for the specific handler content. Neither was present, so (2) was blocked.
+
+Browsers do not produce a console error visible to static gates. They emit a CSP violation event (visible to a Playwright `console` listener observing `error`-level messages, or a CSP `report-uri` endpoint), but neither surface was being read. The user-visible symptom was "below-the-fold renders unstyled forever," reported by a human ~9 hours later.
+
+## Solution
+
+### Layer 1 — fix the immediate bug (PR #2966)
+
+Replace the inline `onload=` attribute with a separate inline `<script>` block whose SHA-256 is allowlisted in CSP `script-src`:
+
+```html
+<link id="soleur-css-preload" rel="preload" href="css/style.css" as="style">
+<noscript><link rel="stylesheet" href="css/style.css"></noscript>
+<script>(function(){var l=document.getElementById('soleur-css-preload');if(!l)return;function sw(){l.rel='stylesheet';}if(l.sheet){sw();}else{l.addEventListener('load',sw);}})();</script>
+```
+
+CSP gains `'sha256-9o2LMPU0pCC0i/83pWDPlO90JiCMiJbUjQWPhLF+W0Y='`.
+
+### Layer 2 — runtime regression gate (PR #2966)
+
+`plugins/soleur/docs/scripts/check-stylesheet-swap.mjs` — navigates without blocking CSS, waits for `'load'`, asserts (a) preload link's `rel` swapped to `stylesheet`, (b) a below-the-fold style applied (`.site-footer` padding-top from `var(--space-8)`), (c) zero CSP violations in the console log. Wired into both `deploy-docs.yml` (post-merge) and `ci.yml` (pre-merge).
+
+### Layer 3 — static gate that would have caught PR #2904 (PR #2967, this learning)
+
+Extended `plugins/soleur/skills/seo-aeo/scripts/validate-csp.sh` to detect inline event-handler attributes when CSP `script-src` lacks `'unsafe-inline'` and `'unsafe-hashes'`. The detection uses Python's `html.parser` (avoids regex false-positives in `<script>` content and HTML comments). Each `<tag on*="...">` becomes a `FAIL: page: inline event-handler attribute 'line:tag:attr=value' is silently blocked by script-src...` line.
+
+Verified by reintroducing the PR #2904 pattern in a test build — produces 41 FAIL lines (one per built page) with file:line and the offending attribute. Restoring the fix returns to PASS.
+
+`validate-csp.sh` also added to the pre-merge `ci.yml critical-css-gate` job (it was previously deploy-time only).
+
+### Layer 4 — pre-merge defense in depth
+
+`ci.yml critical-css-gate` now runs all six docs validators before merge:
+
+1. `npx @11ty/eleventy` (build)
+2. `validate-csp.sh` (hashes + NEW inline-handler check)
+3. `validate-seo.sh` (markup)
+4. `check-critical-css-coverage.mjs` (selectors inlined)
+5. `screenshot-gate.mjs` (FOUC behavior)
+6. `check-stylesheet-swap.mjs` (swap fires + no CSP violations)
+
+A PR that introduces an inline handler now fails `validate-csp.sh` mechanically before the more expensive Playwright gates run.
+
+## Key insight
+
+**CSP-enforcement bugs are a class of silent failure that no markup-level static check can detect without modeling the runtime behavior of the policy.** Three durable principles:
+
+1. **Static gates must scan all four script-execution surfaces, not just `<script>` blocks.** Event handlers, `javascript:` URIs, and `eval`-class APIs are equally constrained by `script-src`. Hash validation alone is incomplete.
+2. **Runtime gates must include "no CSP violations in console" as a first-class assertion.** Any test that boots a real browser is a candidate. A page that loads with violations is a page that's silently degraded.
+3. **`waitUntil` semantics in Playwright are subtle.** `networkidle` does NOT mean "scripts ran successfully" — it means "no network requests for 500ms." If a script is CSP-blocked, the network looks idle and the test passes. Use post-load DOM-state assertions, not network-state assertions.
+
+## Prevention strategies
+
+- **Any inline event handler attribute (`on*=`) in `plugins/soleur/docs/**` HTML/Nunjucks templates is rejected by `validate-csp.sh` if CSP `script-src` lacks `'unsafe-inline'` or `'unsafe-hashes'`.** This is a deterministic mechanical safeguard that runs in <1s on every PR. No agent vigilance required.
+- **When introducing or modifying a CSP-enforced page, run a real-browser load probe that captures `console.error` messages for CSP violations.** `check-stylesheet-swap.mjs` is the existing example.
+- **Treat `<link rel="preload">` swap mechanisms as security-policy-coupled.** The browser-default `onload=` attribute is the simplest pattern, but it requires CSP buy-in. A hashed `<script>` block is the CSP-compliant alternative for sites that don't allow `'unsafe-inline'`.
+- **When `validate-csp.sh` is the gate, remember it scans the BUILT HTML (`_site/`), not the source templates.** This is correct — Nunjucks expansion can introduce attributes the source template doesn't show. Always run after `npx @11ty/eleventy`.
+
+## Session Errors
+
+- **PR #2960 author (me) verified the fix locally with `waitUntil: 'networkidle'` Playwright loads, which silently masked the CSP-blocked swap.** Recovery: in PR #2966, the new `check-stylesheet-swap.mjs` uses `waitUntil: 'load'` AND asserts on post-load DOM state (`link.rel === 'stylesheet'`). **Prevention:** when verifying script-side-effects in Playwright, never use `networkidle` alone — it doesn't care whether scripts executed. Assert on the script's observable side effect.
+- **Multi-agent review on PR #2960 didn't trace the CSP-vs-inline-handler interaction across the 8 spawned reviewers.** security-sentinel reviewed CSP for the new workflow YAML, not for inline handlers in the rendered HTML. **Prevention:** when prompting a security agent for a CSP review, explicitly enumerate ALL four script-execution surfaces (script blocks, on* attributes, javascript: URIs, eval) and ask whether the policy covers each. The reviewer prompt template should include this checklist.
+- **Production curl-probe in PR #2960's session checked inline `<style>` content but not post-load DOM state.** Recovery: PR #2966 added the runtime gate. **Prevention:** any "is the fix live?" check must include a real-browser-load assertion, not just markup-content grep.
+
+## Cross-references
+
+- **PR #2904** — introduced the bug. Async stylesheet swap with inline `onload=`.
+- **PR #2960** — partial fix: inlined more critical CSS for above-the-fold. Swap still broken.
+- **PR #2966** — root-cause fix: hashed inline `<script>` block. Added `check-stylesheet-swap.mjs` runtime gate.
+- **PR #2967** — workflow gap fix: `validate-csp.sh` now scans for inline event-handler attributes. Added `validate-csp.sh` + `validate-seo.sh` to pre-merge `ci.yml`.
+- `knowledge-base/project/learnings/best-practices/2026-04-27-critical-css-fouc-prevention-via-static-and-playwright-gates.md` — sibling learning covering the FOUC class. This learning extends the same compound failure with the CSP-blocked-swap class.
+- `knowledge-base/project/learnings/best-practices/2026-04-27-hand-extracted-critical-css-misses-globally-rendered-selectors.md` — original PR #2904 learning. Names the FOUC class but did not address the swap-mechanism class.

--- a/plugins/soleur/skills/seo-aeo/scripts/validate-csp.sh
+++ b/plugins/soleur/skills/seo-aeo/scripts/validate-csp.sh
@@ -49,10 +49,14 @@ for html_file in "${html_files[@]}"; do
     continue
   fi
 
-  # Use Python for all HTML parsing: extract CSP hashes and inline script hashes.
+  # Use Python for all HTML parsing: extract CSP hashes, inline script hashes, AND
+  # detect inline event-handler attributes (`onload=`, `onclick=`, etc.) that the
+  # CSP would block but no static gate previously caught — see PR #2966 / learning
+  # at knowledge-base/project/learnings/best-practices/ for the silent-failure class.
   # Passing the file path via sys.argv[1] avoids shell injection.
   RESULT=$(python3 -c "
 import hashlib, base64, re, sys
+from html.parser import HTMLParser
 
 with open(sys.argv[1], 'r') as f:
     content = f.read()
@@ -74,8 +78,14 @@ if not src_match:
     print('NO_SCRIPT_SRC')
     sys.exit(0)
 
+script_src = src_match.group(1)
+
 # Extract sha256 hashes from CSP
-csp_hashes = set(re.findall(r\"'(sha256-[A-Za-z0-9+/=]+)'\", src_match.group(1)))
+csp_hashes = set(re.findall(r\"'(sha256-[A-Za-z0-9+/=]+)'\", script_src))
+
+# Detect whether the CSP allows inline event handlers.
+allows_unsafe_inline = bool(re.search(r\"'unsafe-inline'\", script_src))
+allows_unsafe_hashes = bool(re.search(r\"'unsafe-hashes'\", script_src))
 
 # Extract inline scripts (excluding ld+json and src= scripts)
 scripts = re.findall(
@@ -99,6 +109,31 @@ prohibited = ['strict-dynamic', 'report-uri', 'report-to', 'frame-ancestors', 's
 found_prohibited = [d for d in prohibited if re.search(r'(^|;\s*)' + d + r'(\s|;|$)', csp_content)]
 if found_prohibited:
     print('PROHIBITED:' + ','.join(found_prohibited))
+
+# Inline event-handler scan. Use html.parser so we naturally skip <script>
+# content and HTML comments — both contained false-positives in earlier regex
+# attempts (e.g., 'window.onload =' inside a <script>, or 'onload=' inside a
+# <!-- comment -->).
+class EventHandlerFinder(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.violations = []
+    def handle_starttag(self, tag, attrs):
+        for name, value in attrs:
+            if name and name.lower().startswith('on') and len(name) > 2 and name[2:].isalpha():
+                line, col = self.getpos()
+                self.violations.append((line, tag, name, (value or '')[:80]))
+    handle_startendtag = handle_starttag
+
+if not (allows_unsafe_inline or allows_unsafe_hashes):
+    finder = EventHandlerFinder()
+    try:
+        finder.feed(content)
+    except Exception as e:
+        print(f'INLINE_HANDLER_PARSE_ERROR:{e}')
+    for line, tag, attr, value in finder.violations:
+        # One violation per line. Bash splits on newlines.
+        print(f'INLINE_HANDLER:{line}:{tag}:{attr}={value}')
 " "$html_file" || true)
 
   # Skip pages without CSP
@@ -123,6 +158,20 @@ if found_prohibited:
   if [[ -n "$PROHIBITED_LINE" ]]; then
     directives="${PROHIBITED_LINE#PROHIBITED:}"
     fail "$page: CSP contains unsupported meta tag directive(s): $directives"
+  fi
+
+  # Check for inline event-handler attributes that CSP would silently block.
+  # See PR #2966 — `<link onload="...">` was blocked by `script-src` lacking
+  # `'unsafe-inline'`/`'unsafe-hashes'`, and the swap never fired in production.
+  while IFS= read -r handler_line; do
+    [[ -z "$handler_line" ]] && continue
+    detail="${handler_line#INLINE_HANDLER:}"
+    fail "$page: inline event-handler attribute '$detail' is silently blocked by script-src (no 'unsafe-inline'/'unsafe-hashes'). Move the handler into a hashed <script> block, or add 'unsafe-hashes' + a hash."
+  done < <(echo "$RESULT" | grep '^INLINE_HANDLER:' || true)
+
+  PARSE_ERR=$(echo "$RESULT" | grep '^INLINE_HANDLER_PARSE_ERROR:' || true)
+  if [[ -n "$PARSE_ERR" ]]; then
+    fail "$page: inline-handler parse error: ${PARSE_ERR#INLINE_HANDLER_PARSE_ERROR:}"
   fi
 
   # Convert to arrays


### PR DESCRIPTION
## Summary

Closes the workflow gap that allowed PR #2904's `<link onload=...>` to ship to production undetected. Fixes the question "can we improve the workflow so this never happens again?"

CSP `script-src` controls four execution surfaces — `<script>` blocks, inline event handlers (`on*=`), `javascript:` URIs, and `eval`-class APIs. `validate-csp.sh` previously only validated surface (1). Surface (2) was unguarded — and that's exactly where #2904 broke.

## Changelog

- **fix:** `validate-csp.sh` now scans every built HTML page for `on*=` attributes using Python `html.parser` (avoids regex false-positives in `<script>` content and HTML comments). When CSP `script-src` lacks `'unsafe-inline'` and `'unsafe-hashes'`, each violation fails the gate with `file:line:tag:attr=value`.
- **chore:** added `validate-csp.sh` and `validate-seo.sh` to the pre-merge `critical-css-gate` job in `ci.yml`. Previously only ran in `deploy-docs.yml` (post-merge).
- **docs:** new learning at `knowledge-base/project/learnings/best-practices/2026-04-27-inline-event-handlers-silently-blocked-by-csp.md` documenting the full chain (PR #2904 → 2960 → 2966 → this PR), why each layer of gates missed it, and three durable principles for CSP-coupled gates.

## Verification (RED → GREEN)

- **GREEN on clean main:** `bash plugins/soleur/skills/seo-aeo/scripts/validate-csp.sh _site` → `All CSP checks passed.`
- **RED on regression:** `sed`-injecting the PR #2904 pattern into `base.njk` and rebuilding → 41 FAIL lines (one per built page) like:
  `FAIL: legal/privacy-policy/index.html: inline event-handler attribute '149:link:onload=this.rel='stylesheet'' is silently blocked by script-src...`
- **Restored:** PASS again, deterministic.

## Pre-merge gate stack (now 6 layers)

PRs touching the docs site now run all six validators **before merge**:

1. `npx @11ty/eleventy` (build)
2. `validate-csp.sh` (hashes + **NEW** inline-handler check)
3. `validate-seo.sh` (markup)
4. `check-critical-css-coverage.mjs` (selectors inlined)
5. `screenshot-gate.mjs` (FOUC behavior)
6. `check-stylesheet-swap.mjs` (swap fires + no CSP violations)

## Test plan

- [x] validate-csp passes on clean build
- [x] validate-csp FAILS with file:line precision when `onload=` reintroduced
- [x] No false-positives on existing `<script>` content (the new check uses html.parser, not regex)
- [x] validate-seo passes on clean build
- [x] All other docs gates still green
- [ ] ⏳ Post-merge: `ci.yml critical-css-gate` runs all six validators on the next PR that touches `plugins/soleur/docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)