### PR TITLE
fix(sw): bump CACHE_NAME v2→v3 + preflight Check 8 for regression-fix gate

### DIFF
--- a/apps/web-platform/public/sw.js
+++ b/apps/web-platform/public/sw.js
@@ -1,7 +1,7 @@
 // Bumping the suffix triggers the activate handler's cache cleanup, which
 // purges _next/static/** chunks cached against an old project ref. Keep
 // push-notification subscriptions intact (registration is unchanged).
-const CACHE_NAME = "soleur-app-shell-v2";
+const CACHE_NAME = "soleur-app-shell-v3";
 
 // Static shell assets cached on install (non-hashed assets only).
 // _next/static/** are cached on fetch via cache-first strategy.

--- a/knowledge-base/project/learnings/runtime-errors/2026-04-29-sw-cache-survives-regression-fix-without-cache-name-bump.md
+++ b/knowledge-base/project/learnings/runtime-errors/2026-04-29-sw-cache-survives-regression-fix-without-cache-name-bump.md
@@ -1,0 +1,109 @@
+---
+title: Service worker cache-first survives regression fix unless CACHE_NAME is bumped
+date: 2026-04-29
+category: runtime-errors
+related_pr: TBD
+related_commits:
+  - b2fed080  # PR #3014 — module-load throw observability + canary fix
+---
+
+# SW cache-first masks the regression fix until `CACHE_NAME` is bumped
+
+## Symptom
+
+PR #3014 deployed v0.58.0 with a corrected `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+inlined into the client bundle. Server health reported
+`version=0.58.0, supabase=connected`. Direct inspection of the deployed
+`/_next/static/chunks/8237-*.js` confirmed the inlined JWT decoded to
+canonical claims (`iss=supabase, ref=ifsccnjhymdmidffkzhl, role=anon`).
+
+The PR author's browser **continued to render the dashboard error.tsx** on
+post-auth landings, despite the deploy. Server-side state was good; the
+client bundle running in the browser was not the new one.
+
+## Mechanism
+
+`apps/web-platform/public/sw.js` registers a service worker with a
+cache-first strategy for `/_next/static/**` under a single `CACHE_NAME`:
+
+```js
+const CACHE_NAME = "soleur-app-shell-v2";
+// ...
+event.respondWith(
+  caches.match(event.request).then(
+    (cached) => cached || fetch(event.request).then(/* ... cache.put */)
+  )
+);
+```
+
+Two stale-cache vectors compound:
+
+1. **Stale chunk under unchanged filename.** If a chunk's content-hashed
+   filename happens to be unchanged across builds (rare but possible for
+   utility chunks whose content is deterministic), the SW serves the
+   cached copy indefinitely.
+2. **Stale HTML in a tab the user never reloaded.** If the user has an
+   open tab that loaded the OLD HTML referencing OLD chunk filenames,
+   client-side navigations within that tab continue to fetch those OLD
+   filenames — and they're cached. Only a hard reload re-requests fresh
+   HTML.
+
+The activate handler IS designed to purge old caches:
+
+```js
+self.addEventListener("activate", (event) => {
+  event.waitUntil(caches.keys().then((names) =>
+    Promise.all(names.filter((n) => n !== CACHE_NAME).map((n) => caches.delete(n)))
+  ));
+  self.clients.claim();
+});
+```
+
+But it only purges caches whose name does NOT match `CACHE_NAME`. If
+`CACHE_NAME` did not change between the broken build and the fix, the
+single cache survives — broken chunks intact.
+
+## Why a regression fix is special
+
+For an additive feature, the SW behavior is acceptable: users get the
+new chunks on next navigation, old ones idle in cache and eventually
+get evicted. For a **regression fix on the auth surface**, that is not
+acceptable — the user's browser is the source of truth for their
+session, and stale code in their bundle keeps them broken until they
+manually clear site data. PR #3014 did not bump `CACHE_NAME` because
+the regression-fix-needs-cache-bump rule was not codified anywhere.
+
+## Detection rule (preflight Check 8)
+
+`plugins/soleur/skills/preflight/SKILL.md` Check 8 now fires when:
+
+1. Branch contains a commit subject matching `^(fix\(|fix:|hotfix)` AND
+2. The diff touches any of:
+   - `apps/web-platform/lib/supabase/**`
+   - `apps/web-platform/sentry.client.config.ts`
+   - `apps/web-platform/lib/auth/**`
+   - `apps/web-platform/lib/byok/**`
+   - `apps/web-platform/components/error-boundary-view.tsx`
+
+It compares `CACHE_NAME` in `apps/web-platform/public/sw.js` against
+`origin/main`. Byte-equal → FAIL. Different (suffix bumped) → PASS.
+
+## Mitigations (in order of preference)
+
+1. **Bump `CACHE_NAME` whenever a regression fix touches the inlined
+   client bundle.** One-line change; activate handler does the rest.
+2. **Don't cache-first chunks at all.** A network-first or stale-while-
+   revalidate strategy avoids this class entirely, at the cost of
+   first-paint latency on offline / poor connections. Tradeoff is
+   non-trivial — current cache-first is intentional.
+3. **Bundle a content hash in `CACHE_NAME` itself** (e.g.,
+   `soleur-app-shell-${BUILD_VERSION}`) so it bumps automatically per
+   build. Useful but produces cache churn on every deploy — discuss
+   before adopting.
+
+## See also
+
+- `apps/web-platform/public/sw.js` — `CACHE_NAME` declaration site
+- `plugins/soleur/skills/preflight/SKILL.md` Check 8 — detection rule
+- PR #3014 — the regression fix that exposed the gap
+- `knowledge-base/project/learnings/runtime-errors/2026-04-28-module-load-throw-collapses-auth-surface.md` — root incident

--- a/plugins/soleur/skills/preflight/SKILL.md
+++ b/plugins/soleur/skills/preflight/SKILL.md
@@ -430,6 +430,50 @@ If `RESULT=PASS_INCIDENT` or `RESULT=PASS_AGGREGATE`: **PASS**.
 - **FAIL** — Sensitive-path diff with missing or empty User-Brand Impact section; OR `none` threshold without scope-out; OR missing/invalid threshold line.
 - **SKIP** — No sensitive paths touched, OR no PR exists yet (defer to post-PR run).
 
+### Check 8: Service Worker Cache Bump on Client-Bundle Regression Fix
+
+**Path-gated:** only runs when `git diff --name-only origin/main...HEAD` includes BOTH a regression-fix marker (a commit subject starting with `fix(`, `fix:`, or `hotfix`) AND any file under `apps/web-platform/lib/supabase/`, `apps/web-platform/sentry.client.config.ts`, `apps/web-platform/lib/auth/`, `apps/web-platform/lib/byok/`, or `apps/web-platform/components/error-boundary-view.tsx`. Otherwise return **SKIP** with note: "No client-bundle regression-fix surface detected."
+
+**Rationale:** Content-hashed Next.js chunks normally invalidate cache automatically — new content → new filename → SW cache miss → fresh fetch. But the SW at `apps/web-platform/public/sw.js` uses a cache-first strategy under a single `CACHE_NAME` for `/_next/static/**`, and old broken chunks remain cached under their old filenames until either (a) browser eviction, or (b) the activate handler purges them via a `CACHE_NAME` bump. After PR #3014 deployed v0.58.0 with a corrected validator, users still saw the dashboard error.tsx because their SW was serving cached PR #3007 chunks. Without bumping `CACHE_NAME`, a regression fix to the inlined client bundle relies on every user manually clearing site data — unacceptable for an auth-tree outage.
+
+**Step 8.1: Detect regression-fix commit subject.**
+
+```bash
+git log origin/main..HEAD --pretty=%s | grep -iE '^(fix\(|fix:|hotfix)' | head -1
+```
+
+If empty, return **SKIP** with note: "No fix(...) commit on branch."
+
+**Step 8.2: Detect client-bundle surface in diff.**
+
+```bash
+git diff --name-only origin/main...HEAD | grep -E '^apps/web-platform/(lib/(supabase|auth|byok)/|sentry\.client\.config\.ts|components/error-boundary-view\.tsx)' | head -1
+```
+
+If empty, return **SKIP** with note: "No client-bundle surface touched."
+
+**Step 8.3: Compare `CACHE_NAME` against `origin/main`.**
+
+Run as separate Bash calls (no command substitution per skill convention):
+
+```bash
+git show origin/main:apps/web-platform/public/sw.js 2>/dev/null | grep -oE 'CACHE_NAME[[:space:]]*=[[:space:]]*"[^"]+"' | head -1
+```
+
+```bash
+grep -oE 'CACHE_NAME[[:space:]]*=[[:space:]]*"[^"]+"' apps/web-platform/public/sw.js | head -1
+```
+
+If the two values are byte-equal, **FAIL** with: "Client-bundle regression fix detected on branch but `CACHE_NAME` in `apps/web-platform/public/sw.js` was not bumped. Old chunks remain cached for users with an active SW registration. Bump the suffix (e.g., `v2` → `v3`) so the activate handler purges stale caches on next page load."
+
+If the values differ (suffix bumped), **PASS**.
+
+**Result:**
+
+- **PASS** — `CACHE_NAME` bumped relative to `origin/main`, OR no client-bundle regression-fix surface detected.
+- **FAIL** — client-bundle regression fix on branch with unchanged `CACHE_NAME`. Bump the suffix to force-purge the stale-cache class.
+- **SKIP** — no `fix(...)` commit, OR no client-bundle surface in the diff.
+
 ### Check 7: Canary Probe Set Covers Authenticated Surface
 
 **Path-gated:** only runs when `git diff --name-only origin/main...HEAD` contains `apps/web-platform/infra/ci-deploy.sh`. Otherwise return **SKIP** with note: "ci-deploy.sh untouched."
@@ -483,6 +527,7 @@ After all checks complete, aggregate results into a structured report:
 | Production Bundle Supabase Host | PASS/FAIL/SKIP | <details> |
 | Brand-Survival Self-Review | PASS/FAIL/SKIP | <details> |
 | Canary Probe Set Covers Auth Surface | PASS/FAIL/SKIP | <details> |
+| SW Cache Bump on Client-Bundle Fix | PASS/FAIL/SKIP | <details> |
 
 **Overall: PASS / FAIL**
 ```


### PR DESCRIPTION
## Summary

Closes the second-order miss from PR #3014. The validator fix deployed correctly (v0.58.0 inlines a valid JWT for `ifsccnjhymdmidffkzhl`), but users with an active service worker registration continue to render the dashboard error.tsx because the cache-first SW under an unchanged `CACHE_NAME = "soleur-app-shell-v2"` keeps serving the broken PR #3007 chunks.

- Bumps `CACHE_NAME` to `"soleur-app-shell-v3"` so the activate handler purges stale `v2` caches on next page load
- Adds preflight Check 8 to detect this class on future regression fixes (fires on `fix(...)` commit subjects + diff touching `lib/supabase/**`, `sentry.client.config.ts`, `lib/auth/**`, `lib/byok/**`, or `components/error-boundary-view.tsx`); FAILs if `CACHE_NAME` is byte-equal to `origin/main`
- Records the rule and rationale in a learning file

## User-Brand Impact

**Surfaces touched:** `apps/web-platform/public/sw.js` (cache invalidation policy).

**If this lands broken, the user experiences:** users continue serving the broken PR #3007 chunks until they manually clear site data; the dashboard error.tsx persists post-deploy.

**If this leaks, the user's workflow is exposed via:** no exposure path — this is a cache-purge change, not a credential or data path.

- **Brand-survival threshold:** `single-user incident` — every authenticated visitor with an active SW registration sees the broken bundle until manual intervention.

## Changelog

### Web Platform
- Bump `apps/web-platform/public/sw.js` `CACHE_NAME` from `v2` to `v3` to force-purge stale caches

### Plugin
- New preflight check: `Check 8: Service Worker Cache Bump on Client-Bundle Regression Fix`

### Knowledge Base
- New learning: `2026-04-29-sw-cache-survives-regression-fix-without-cache-name-bump.md`

## Test plan

- [x] Health endpoint already reports `version=0.58.0, supabase=connected`
- [x] Inlined JWT verified canonical (`iss=supabase, ref=ifsccnjhymdmidffkzhl, role=anon`)
- [ ] After this PR merges and deploys, the activate handler will purge `v2` caches the next time each user loads the app — verify with one stale-state browser
- [ ] Future fix-on-client-bundle PRs will hit preflight Check 8 if they forget to bump `CACHE_NAME`

Generated with [Claude Code](https://claude.com/claude-code)
