### PR TITLE
fix(supabase): browser-safe JWT decode + preflight Check 9 (Node-only-encoding ban)

### DIFF
--- a/apps/web-platform/lib/supabase/validate-anon-key.ts
+++ b/apps/web-platform/lib/supabase/validate-anon-key.ts
@@ -60,10 +60,17 @@ function decodeJwtPayload(raw: string): JwtPayload {
       "NEXT_PUBLIC_SUPABASE_ANON_KEY payload segment is not valid base64url",
     );
   }
-  // `Buffer.from(s, "base64url")` does not throw on malformed input — it returns
-  // a partial/empty buffer. Validity is enforced by the base64url-charset regex
-  // above, so no try/catch is needed here.
-  const json = Buffer.from(middle, "base64url").toString("utf8");
+  // Decode base64url manually — `Buffer.from(s, "base64url")` is Node 16+ only
+  // and throws `Unknown encoding: base64url` in browser Buffer polyfills. This
+  // module is imported by `lib/supabase/client.ts` which runs at module load in
+  // the client bundle, so the decode MUST be browser-safe. Validity is enforced
+  // by the base64url-charset regex above, so this conversion is total.
+  const base64 = middle.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "=");
+  const json =
+    typeof atob === "function"
+      ? atob(padded)
+      : Buffer.from(padded, "base64").toString("utf8");
   let parsed: unknown;
   try {
     parsed = JSON.parse(json);

--- a/apps/web-platform/test/lib/supabase/validate-anon-key-browser-decode.test.ts
+++ b/apps/web-platform/test/lib/supabase/validate-anon-key-browser-decode.test.ts
@@ -1,0 +1,101 @@
+// Reproduces the production browser-bundle environment by patching
+// `Buffer.from(s, "base64url")` to throw `TypeError: Unknown encoding:
+// base64url` — matching the older `buffer` npm polyfill webpack ships in
+// client bundles. `atob` is native in Node 16+ and in browsers, so the
+// validator's atob branch is exercised directly here.
+//
+// PR #3007 introduced `Buffer.from(middle, "base64url")` in
+// `validate-anon-key.ts`. Vitest's default Node env hid the regression — Node
+// 16+ has native base64url. Production browsers throw at module load, so every
+// authenticated visitor saw the dashboard error.tsx until this test was added.
+//
+// The test is the GREEN gate for the browser-safe decoder. Removing the test
+// would re-open the regression class.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
+
+const realBufferFrom = Buffer.from.bind(Buffer);
+let originalBufferFrom: typeof Buffer.from;
+
+beforeAll(() => {
+  originalBufferFrom = Buffer.from;
+  // Replace Buffer.from so calls with "base64url" throw, but other encodings still work.
+  // Mirrors the `buffer@5.x` polyfill behavior that webpack ships for client bundles.
+  Buffer.from = ((value: unknown, encoding?: BufferEncoding) => {
+    if (encoding === ("base64url" as BufferEncoding)) {
+      throw new TypeError("Unknown encoding: base64url");
+    }
+    return realBufferFrom(value as string, encoding);
+  }) as typeof Buffer.from;
+});
+
+afterAll(() => {
+  Buffer.from = originalBufferFrom;
+});
+
+const CANONICAL_URL = "https://ifsccnjhymdmidffkzhl.supabase.co";
+const CANONICAL_REF = "ifsccnjhymdmidffkzhl";
+
+// Hand-construct a JWT WITHOUT calling Buffer.from(_, "base64url") — that
+// helper is what we just patched to throw.
+function browserSafeBase64UrlEncode(str: string): string {
+  return Buffer.from(str, "utf8")
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function fakeJwt(payload: Record<string, unknown>): string {
+  const header = browserSafeBase64UrlEncode('{"alg":"HS256","typ":"JWT"}');
+  const body = browserSafeBase64UrlEncode(JSON.stringify(payload));
+  return `${header}.${body}.fake-signature`;
+}
+
+describe("validate-anon-key under browser-polyfill Buffer", () => {
+  beforeEach(() => {
+    vi.stubEnv("NODE_ENV", "production");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("decodes a canonical anon JWT without calling Buffer.from(_, 'base64url')", async () => {
+    const { assertProdSupabaseAnonKey } = await import(
+      "@/lib/supabase/validate-anon-key"
+    );
+    const jwt = fakeJwt({
+      iss: "supabase",
+      role: "anon",
+      ref: CANONICAL_REF,
+      iat: 1700000000,
+      exp: 2000000000,
+    });
+    expect(() => assertProdSupabaseAnonKey(jwt, CANONICAL_URL)).not.toThrow();
+  });
+
+  it("rejects a service_role JWT (claim-check still runs after browser-safe decode)", async () => {
+    const { assertProdSupabaseAnonKey } = await import(
+      "@/lib/supabase/validate-anon-key"
+    );
+    const jwt = fakeJwt({
+      iss: "supabase",
+      role: "service_role",
+      ref: CANONICAL_REF,
+      iat: 1700000000,
+      exp: 2000000000,
+    });
+    expect(() =>
+      assertProdSupabaseAnonKey(jwt, CANONICAL_URL),
+    ).toThrow(/role="service_role"/);
+  });
+
+  it("Buffer.from(_, 'base64url') is genuinely patched (sentinel — guards against accidental mock removal)", () => {
+    expect(() => Buffer.from("dGVzdA", "base64url" as BufferEncoding)).toThrow(
+      /Unknown encoding: base64url/,
+    );
+    // Other encodings still work.
+    expect(Buffer.from("dGVzdA==", "base64").toString("utf8")).toBe("test");
+  });
+});

--- a/knowledge-base/engineering/ops/runbooks/canary-probe-set.md
+++ b/knowledge-base/engineering/ops/runbooks/canary-probe-set.md
@@ -36,13 +36,17 @@ spot.
 | 1a | `curl http://localhost:3001/health` returns 200 | container is alive | enforced |
 | 1b | `curl http://localhost:3001/login` returns 200 with non-empty body | public route renders | enforced |
 | 1c | `curl http://localhost:3001/dashboard --max-redirs 0` returns 200/302/307, body does NOT contain `data-error-boundary=` | middleware redirect or successful render; rejects SSR-rendered error.tsx | enforced |
-| 2 | Headless chromium hydrates `/dashboard` and observes no console errors | client-only throws (e.g. validator at module load) | **deferred — D1** |
+| 2 | Headless chromium hydrates `/login` AND `/dashboard`; rejects on any `pageerror`, console.error, or `Unhandled error` event during hydration | client-only throws at module load (validators, polyfill incompatibilities, encoding mismatches) | **required — was D1, promoted post-#3014** |
 | 3 | `apps/web-platform/infra/canary-bundle-claim-check.sh` fetches the deployed login chunk and asserts the inlined Supabase JWT has canonical claims (`iss=supabase`, `role=anon`, ref shape) | inlined build-arg corruption (the #3007 regression class) — runs without a browser, catches what Layer 1 cannot see | enforced |
 
-Layer 1 is the cheapest broad-coverage gate. Layer 2 is the only thing
-that catches the exact PR #3007 regression class. Layer 3 is a
-build-arg integrity check — if Doppler / GitHub secret / build-arg
-plumbing drifts, Layer 3 detects it without needing a browser.
+Layer 1 is the cheapest broad-coverage gate. Layer 2 is the ONLY layer
+that exercises the production browser environment — including webpack's
+`buffer@5.x` polyfill, which was the missing gate for the
+`Buffer.from(_, "base64url")` regression class. Layer 3 covers
+build-arg integrity (claim shape) but cannot detect runtime polyfill
+incompatibilities. The post-#3014 incident (validator throws
+`Unknown encoding: base64url` in the browser despite a canonical JWT)
+forced Layer 2 from deferred to required.
 
 ## Body-content sentinel — structured marker
 

--- a/knowledge-base/project/learnings/runtime-errors/2026-04-29-buffer-base64url-throws-in-client-bundle.md
+++ b/knowledge-base/project/learnings/runtime-errors/2026-04-29-buffer-base64url-throws-in-client-bundle.md
@@ -1,0 +1,114 @@
+---
+title: Buffer.from(_, "base64url") throws in client-bundle webpack polyfill
+date: 2026-04-29
+category: runtime-errors
+related_pr: TBD
+related_commits:
+  - 7d556531  # PR #3007 — JWT-claims guardrails (introduced the bug)
+  - b2fed080  # PR #3014 — observability/canary fix (added Sentry mirror but not the source-level gate)
+---
+
+# `Buffer.from(_, "base64url")` is Node-only and throws in browser bundles
+
+## Symptom
+
+After PR #3014 deployed v0.58.1 with a verified-canonical inlined JWT
+(`iss=supabase, ref=ifsccnjhymdmidffkzhl, role=anon`), users continued to see
+the `Something went wrong` error.tsx — on `/login` AND `/dashboard`. Hard
+refresh, cleared cookies, cleared cache: no change. Diagnostic via Playwright
+console capture surfaced:
+
+```
+TypeError: Unknown encoding: base64url
+    at s (5376-3155e54cb192971f.js:1:2438)
+    at u.from (5376-3155e54cb192971f.js:1:5109)
+    at 8237-9ee97fc0757ef8e6.js:1:2622   ← supabase init module
+```
+
+## Mechanism
+
+`apps/web-platform/lib/supabase/validate-anon-key.ts` (added in PR #3007)
+contained:
+
+```ts
+const json = Buffer.from(middle, "base64url").toString("utf8");
+```
+
+`"base64url"` is a Node 16+ encoding token. **In Node, this works.** In the
+browser, webpack's `buffer@5.x` polyfill ships in the client bundle —
+`buffer@5.x` does NOT support the `"base64url"` encoding token, so
+`Buffer.from(_, "base64url")` throws `TypeError: Unknown encoding: base64url`
+at module evaluation time. The surrounding try/catch in `client.ts` (added
+in PR #3014) caught the throw, mirrored to Sentry as
+`feature: supabase-validator-throw`, then re-threw — so the React render
+path bailed out and `error.tsx` rendered.
+
+## Why every existing gate missed it
+
+| Gate | What it ran | Why it missed |
+|---|---|---|
+| Vitest unit tests (PR #3007) | Node env (default) | Node has native `base64url`; tests passed |
+| Vitest unit tests (PR #3014) | Node env | Same — tests covered claim shapes, not encoding compatibility |
+| `tsc --noEmit` | TypeScript types only | `BufferEncoding` includes `"base64url"`; types are wrong about runtime |
+| Layer 1 canary (curl /login + /dashboard) | SSR HTML over HTTP | The throw is client-only; SSR HTML renders fine |
+| Layer 3 canary (bash JWT decode) | bash `base64 -d` | Tests claim shape, doesn't exercise `Buffer.from` polyfill |
+| Sentry alert | Real browser at runtime | Alert fires AFTER users hit the bug — too late |
+
+The single shared assumption was that **vitest's Node env is a faithful
+proxy for the browser bundle**. It is not. `Buffer.from`, `crypto.subtle`,
+`fetch`, `URL`, `process.versions` — these all behave differently in the
+browser-polyfilled runtime than in Node, and any of them in client-bundle
+code at module load is a regression vector.
+
+## The fix
+
+Decode base64url manually using browser-safe primitives (`atob` is native
+since Node 16 AND in all browsers):
+
+```ts
+const base64 = middle.replace(/-/g, "+").replace(/_/g, "/");
+const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "=");
+const json =
+  typeof atob === "function"
+    ? atob(padded)
+    : Buffer.from(padded, "base64").toString("utf8");
+```
+
+The conditional preserves SSR/Node fallback for environments without `atob`
+(Node ≤15 — currently unreachable in this repo, but cheap).
+
+## The systemic gate (preflight Check 9)
+
+`plugins/soleur/skills/preflight/SKILL.md` Check 9 ("Node-Only Encodings
+Banned in Client-Bundle Paths") greps the canonical client-bundle path list
+for `Buffer\.from\([^)]*"base64url"`. Match → FAIL with file/line. The
+ban-list is extensible; future Node-only-API regressions add an entry plus
+a `**Why:**` pointer to the discovery learning file.
+
+## The systemic safety net (Layer 2 canary, promoted from deferred)
+
+`knowledge-base/engineering/ops/runbooks/canary-probe-set.md` Layer 2
+(headless chromium hydrating `/login` + `/dashboard` and rejecting on any
+`pageerror` / console.error) was deferred as D1 in PR #3014. Post-incident
+it is **required** — the only gate that exercises the production browser
+runtime including webpack's polyfill chain. Implementation (Playwright in
+the canary container) is tracked separately; until it lands, Check 9 + the
+jsdom test pattern are the load-bearing gates.
+
+## Test pattern
+
+`apps/web-platform/test/lib/supabase/validate-anon-key-browser-decode.test.ts`
+patches `Buffer.from` to throw on `"base64url"`, then exercises the
+validator. This is the GREEN gate for the browser-safe decoder. The
+sentinel test (`Buffer.from(_, "base64url") is genuinely patched`) locks in
+the patching so future regressions cannot bypass the test by accidentally
+removing the mock.
+
+## See also
+
+- `apps/web-platform/lib/supabase/validate-anon-key.ts` — fix site
+- `apps/web-platform/test/lib/supabase/validate-anon-key-browser-decode.test.ts` — regression-class test
+- `plugins/soleur/skills/preflight/SKILL.md` Check 9 — source-level gate
+- `knowledge-base/engineering/ops/runbooks/canary-probe-set.md` — Layer 2 promotion to required
+- `knowledge-base/project/learnings/runtime-errors/2026-04-28-module-load-throw-collapses-auth-surface.md` — root incident
+- `knowledge-base/project/learnings/runtime-errors/2026-04-29-sw-cache-survives-regression-fix-without-cache-name-bump.md` — adjacent miss

--- a/plugins/soleur/skills/preflight/SKILL.md
+++ b/plugins/soleur/skills/preflight/SKILL.md
@@ -474,6 +474,54 @@ If the values differ (suffix bumped), **PASS**.
 - **FAIL** — client-bundle regression fix on branch with unchanged `CACHE_NAME`. Bump the suffix to force-purge the stale-cache class.
 - **SKIP** — no `fix(...)` commit, OR no client-bundle surface in the diff.
 
+### Check 9: Node-Only Encodings Banned in Client-Bundle Paths
+
+**Always runs (no path-pattern gate).** Enforces the rule that any module imported into the Next.js client bundle must use browser-safe APIs at module load. Node's `Buffer.from(s, "base64url")` (added in Node 16) is the canonical example: it works in vitest's default Node env AND in SSR, but the `buffer@5.x` polyfill webpack ships throws `TypeError: Unknown encoding: base64url` in browsers. A test that runs the validator only in Node passes; production hydration crashes on the first authenticated visit.
+
+**Rationale:** PR #3007's `assertProdSupabaseAnonKey` introduced `Buffer.from(middle, "base64url")` inside `validate-anon-key.ts`, which `lib/supabase/client.ts` imports at module load. PR #3014's added tests also ran in Node env and missed it. The deployed bundle threw on every page load — dashboard AND login. Layer 1 canary missed it (HTML-only). Layer 3 missed it (bash `base64 -d` is unrelated to webpack's Buffer polyfill). The only true source-level gate is to ban the encoding token.
+
+**Step 9.1: Build the candidate file list.**
+
+```bash
+git ls-files \
+  'apps/web-platform/lib/**/*.ts' \
+  'apps/web-platform/lib/**/*.tsx' \
+  'apps/web-platform/components/**/*.ts' \
+  'apps/web-platform/components/**/*.tsx' \
+  'apps/web-platform/app/**/*.ts' \
+  'apps/web-platform/app/**/*.tsx' \
+  'apps/web-platform/hooks/**/*.ts' \
+  'apps/web-platform/hooks/**/*.tsx' \
+  | grep -v -E '/(server|api)/' \
+  | grep -v -E '\.test\.(ts|tsx)$' \
+  | grep -v -E '\.spec\.(ts|tsx)$'
+```
+
+**Step 9.2: Grep candidates for banned tokens (excluding comment lines).**
+
+```bash
+grep -nE 'Buffer\.from\([^)]*"base64url"' <files> \
+  | grep -vE ':[[:space:]]*(//|\*)' \
+  | grep -vE '`[^`]*Buffer\.from\([^`]*"base64url"[^`]*`'
+```
+
+The first filter drops single-line `// ...` comments and JSDoc `* ...` lines. The second drops backtick-quoted references inside markdown-style code spans (which can occur in TSDoc/JSDoc bodies that don't start with `* `). The remaining matches are real call sites.
+
+If output is non-empty, **FAIL** with a per-file listing: "Node-only encoding `base64url` in client-bundle path `<file>:<line>`. Replace with browser-safe `atob` + `base64.padEnd(...)` per `apps/web-platform/lib/supabase/validate-anon-key.ts` post-fix pattern, OR move the file behind a `lib/server/` boundary if it does not need the client bundle."
+
+**Step 9.3: Ban-list extension policy.**
+
+The current ban-list (extend as new classes are discovered):
+
+- `Buffer.from(_, "base64url")` — covered above
+- Future additions go here with a **Why:** pointer to the learning file
+
+**Result:**
+
+- **PASS** — no banned token found in any client-bundle path.
+- **FAIL** — at least one banned token found (file + line listed).
+- **SKIP** — never; this check has no path gate (it always scans the canonical candidate list).
+
 ### Check 7: Canary Probe Set Covers Authenticated Surface
 
 **Path-gated:** only runs when `git diff --name-only origin/main...HEAD` contains `apps/web-platform/infra/ci-deploy.sh`. Otherwise return **SKIP** with note: "ci-deploy.sh untouched."
@@ -528,6 +576,7 @@ After all checks complete, aggregate results into a structured report:
 | Brand-Survival Self-Review | PASS/FAIL/SKIP | <details> |
 | Canary Probe Set Covers Auth Surface | PASS/FAIL/SKIP | <details> |
 | SW Cache Bump on Client-Bundle Fix | PASS/FAIL/SKIP | <details> |
+| Node-Only Encodings Banned in Client-Bundle | PASS/FAIL | <details> |
 
 **Overall: PASS / FAIL**
 ```


### PR DESCRIPTION
## Summary

This is the actual root cause of the production /dashboard outage that PR #3014 only partially closed. PR #3014's observability layer worked correctly — Sentry received the `feature: supabase-validator-throw` event — but the validator THROW was caused by the validator code itself, not by a broken inlined JWT.

`apps/web-platform/lib/supabase/validate-anon-key.ts` calls `Buffer.from(middle, "base64url")`. `"base64url"` is a Node 16+ encoding. The `buffer@5.x` polyfill webpack ships in client bundles throws `TypeError: Unknown encoding: base64url`. Every authenticated /dashboard load AND every /login render threw at module evaluation time. Vitest's default Node env hid the regression because Node has native base64url support.

Verified via Playwright console capture against prod: `TypeError: Unknown encoding: base64url at chunk 8237 (supabase init)`.

## User-Brand Impact

**Surfaces touched:** `lib/supabase/validate-anon-key.ts` (auth — module-load validator).

**If this lands broken, the user experiences:** continued dashboard error.tsx on every authenticated visit; users cannot reach Command Center, Knowledge Base, Chat, Settings, Teams. Sign-in completes; every post-auth route fails. Same symptom as the original PR #3014 outage.

**If this leaks, the user's workflow is exposed via:** none — this is a decoder pure function with no exfiltration vector.

- **Brand-survival threshold:** `single-user incident` — every authenticated visitor sees the broken page.

CPO + user-impact-reviewer signed off per AGENTS.md `hr-weigh-every-decision-against-target-user-impact`.

## Changelog

### Web Platform
- Fix: `lib/supabase/validate-anon-key.ts` decodes JWT payload via `atob` (native in Node 16+ and all browsers) instead of `Buffer.from(_, "base64url")` (Node-only)
- Test: `test/lib/supabase/validate-anon-key-browser-decode.test.ts` patches `Buffer.from` to throw on `"base64url"`, verifying the decoder works without Node-only encoding support; sentinel test locks in the patching

### Plugin
- New preflight check: `Check 9: Node-Only Encodings Banned in Client-Bundle Paths` — source-level grep gate that would have caught PR #3007 before merge

### Knowledge Base
- New learning: `2026-04-29-buffer-base64url-throws-in-client-bundle.md`
- Promote Layer 2 canary (chromium-in-canary) from deferred (D1) to required in `canary-probe-set.md` — only Layer 2 exercises webpack's polyfill chain in the production browser environment

## Test plan

- [x] All 58 existing supabase validator tests pass
- [x] New test reproduces the regression: patches Buffer.from to throw on `"base64url"`, validator still works via atob path
- [x] Sentinel test confirms Buffer.from patching is genuine (would catch accidental mock removal)
- [x] Check 9 returns exit 1 (PASS) on this branch
- [x] Check 9 returns exit 0 (FAIL) on `origin/main` (verified) — would have rejected PR #3007
- [ ] ⏳ Post-merge: verify prod /login + /dashboard hydrate clean (Playwright console — zero pageerror)

Generated with [Claude Code](https://claude.com/claude-code)
