### PR TITLE
fix(web-platform): populate /mnt/data/plugins/soleur via image-baked seed (#3045)

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -35,6 +35,10 @@ on:
         description: "Skip path change detection (for workflow_dispatch)"
         type: boolean
         default: false
+      vendor_plugin:
+        description: "Vendor plugins/soleur into <docker_context>/_plugin-vendored before docker build (#3045)"
+        type: boolean
+        default: false
     outputs:
       version:
         description: "Computed version without prefix (e.g., 0.1.1)"
@@ -389,6 +393,19 @@ jobs:
             exit 1
           fi
           echo "::notice::NEXT_PUBLIC_SUPABASE_ANON_KEY passes JWT-claims validation (ref=$ref_safe)"
+
+      - name: Vendor plugin into build context
+        if: steps.version.outputs.next != '' && inputs.docker_image != '' && inputs.vendor_plugin
+        env:
+          DOCKER_CONTEXT: ${{ inputs.docker_context }}
+        run: |
+          set -euo pipefail
+          DEST="${DOCKER_CONTEXT}/_plugin-vendored"
+          rm -rf "$DEST"
+          cp -r plugins/soleur "$DEST"
+          # Drop test/docs trees that aren't needed at runtime — keeps image small.
+          rm -rf "$DEST/test" "$DEST/docs/_site"
+          echo "Vendored $(find "$DEST" -type f | wc -l) plugin files into $DEST"
 
       - name: Build and push Docker image
         id: docker_build

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -400,11 +400,32 @@ jobs:
           DOCKER_CONTEXT: ${{ inputs.docker_context }}
         run: |
           set -euo pipefail
+          # Defense-in-depth: bound DOCKER_CONTEXT to the apps/* prefix so a
+          # future caller passing untrusted input cannot rm -rf an arbitrary
+          # path under "$DOCKER_CONTEXT/_plugin-vendored".
+          if [[ ! "$DOCKER_CONTEXT" =~ ^apps/[a-z0-9-]+$ ]]; then
+            echo "::error::vendor_plugin: DOCKER_CONTEXT='$DOCKER_CONTEXT' must match ^apps/[a-z0-9-]+$"
+            exit 1
+          fi
           DEST="${DOCKER_CONTEXT}/_plugin-vendored"
           rm -rf "$DEST"
-          cp -r plugins/soleur "$DEST"
-          # Drop test/docs trees that aren't needed at runtime — keeps image small.
-          rm -rf "$DEST/test" "$DEST/docs/_site"
+          # `cp -a --no-dereference` preserves symlinks AS symlinks rather than
+          # following them. Without it, an absolute or escaping symlink under
+          # plugins/soleur (e.g. -> /etc/passwd) would land its target's
+          # CONTENT in the build context and be baked into the image.
+          cp -a --no-dereference plugins/soleur "$DEST"
+          # Reject any symlink whose resolved target escapes the vendor tree.
+          # readlink -f resolves transitively; the resolved absolute path is
+          # compared against the absolute DEST. Symlinks that stay inside
+          # _plugin-vendored (e.g. test fixtures) pass.
+          DEST_ABS="$(readlink -f "$DEST")"
+          while IFS= read -r link; do
+            target="$(readlink -f "$link" || true)"
+            if [[ -z "$target" ]] || [[ "$target" != "$DEST_ABS"* ]]; then
+              echo "::error::vendor_plugin: symlink escapes vendor tree: $link -> $target"
+              exit 1
+            fi
+          done < <(find "$DEST" -type l)
           echo "Vendored $(find "$DEST" -type f | wc -l) plugin files into $DEST"
 
       - name: Build and push Docker image

--- a/.github/workflows/web-platform-release.yml
+++ b/.github/workflows/web-platform-release.yml
@@ -34,6 +34,7 @@ jobs:
       tag_prefix: "web-v"
       docker_image: "ghcr.io/jikig-ai/soleur-web-platform"
       docker_context: "apps/web-platform"
+      vendor_plugin: true
       bump_type: ${{ inputs.bump_type || '' }}
       force_run: ${{ github.event_name == 'workflow_dispatch' }}
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,8 @@ artifacts/
 # Stage 0 spike throwaway workspace + raw-run artifacts
 .spike-workspace/
 knowledge-base/project/plans/spike-raw-*.json
+
+# CI-vendored plugin tree (#3045) — populated by reusable-release.yml's
+# "Vendor plugin into build context" step before docker build. Local devs
+# building the image manually run the same `cp -r` command; never commit.
+apps/web-platform/_plugin-vendored/

--- a/apps/web-platform/.dockerignore
+++ b/apps/web-platform/.dockerignore
@@ -24,3 +24,8 @@ next-env.d.ts
 Dockerfile
 .dockerignore
 docker-compose*.yml
+
+# Vendored plugin tree (#3045) — must ship with all .md content (SKILL.md,
+# agent prompts) so re-include after the *.md rule above strips them.
+!_plugin-vendored
+!_plugin-vendored/**

--- a/apps/web-platform/.dockerignore
+++ b/apps/web-platform/.dockerignore
@@ -25,7 +25,18 @@ Dockerfile
 .dockerignore
 docker-compose*.yml
 
-# Vendored plugin tree (#3045) — must ship with all .md content (SKILL.md,
-# agent prompts) so re-include after the *.md rule above strips them.
-!_plugin-vendored
-!_plugin-vendored/**
+# Vendored plugin tree (#3045) — must ship with the file types listed below
+# (skill markdown, manifests, templates, scripts). Last-match-wins
+# semantics mean a blanket `!_plugin-vendored/**` would also re-include the
+# `.env*`, `*.pem`, `node_modules/`, and `.git/` excludes from earlier in
+# this file. Use a positive allowlist instead so a stray credential or
+# dependency tree under plugins/soleur cannot be baked into the image.
+!_plugin-vendored/
+!_plugin-vendored/**/*.md
+!_plugin-vendored/**/*.json
+!_plugin-vendored/**/*.njk
+!_plugin-vendored/**/*.yml
+!_plugin-vendored/**/*.yaml
+!_plugin-vendored/**/*.sh
+!_plugin-vendored/**/*.txt
+!_plugin-vendored/**/.claude-plugin/**

--- a/apps/web-platform/Dockerfile
+++ b/apps/web-platform/Dockerfile
@@ -70,6 +70,14 @@ COPY --from=builder /app/dist/server ./dist/server
 # Config file (compiled from .ts to .mjs to avoid TypeScript dep at runtime)
 COPY --from=builder /app/next.config.mjs ./next.config.mjs
 
+# Plugin baked at build time from the vendored copy in the build context (#3045).
+# Source tree is plugins/soleur, vendored to apps/web-platform/_plugin-vendored
+# by reusable-release.yml's "Vendor plugin into build context" step before docker build.
+# The bind-mount /mnt/data/plugins/soleur is seeded from this path by ci-deploy.sh
+# via `docker cp <ephemeral>:/opt/soleur/plugin/. /mnt/data/plugins/soleur/`.
+COPY _plugin-vendored /opt/soleur/plugin
+RUN chown -R 1001:1001 /opt/soleur
+
 # Non-root user (UID 1001 avoids collision with node:22-slim's built-in node user at UID 1000)
 RUN useradd --no-log-init --uid 1001 -m soleur \
     && chown -R soleur:soleur .next

--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -244,20 +244,29 @@ case "$COMPONENT" in
     # Uses an ephemeral container (`docker create` + `docker cp` + `docker rm`)
     # so we never run a second instance of the new image during the canary phase.
     # `docker cp src/. dst/` copies *contents* of src into dst (NOT src as a
-    # child of dst); the brace-glob removes prior-version content including
-    # dotfiles like `.claude-plugin/` (load-bearing — `*` alone leaves them).
+    # child of dst); `find -mindepth 1 -delete` is a single POSIX-portable
+    # cleanup form shared with cloud-init.yml — handles dotfiles like
+    # `.claude-plugin/` correctly.
     echo "Seeding plugin mount from image..."
+    # Pre-flight: a prior SIGKILLed deploy may have left this container behind.
+    # `docker create --name` would otherwise fail with "container already exists".
+    docker rm -f soleur-plugin-seed >/dev/null 2>&1 || true
     if ! docker create --name soleur-plugin-seed "$IMAGE:$TAG" >/dev/null; then
       final_write_state 1 "plugin_seed_create_failed"
       exit 1
     fi
-    rm -rf /mnt/data/plugins/soleur/{*,.[!.]*,..?*} 2>/dev/null || true
+    find /mnt/data/plugins/soleur -mindepth 1 -delete 2>/dev/null || true
     if ! docker cp soleur-plugin-seed:/opt/soleur/plugin/. /mnt/data/plugins/soleur/; then
       docker rm soleur-plugin-seed >/dev/null 2>&1 || true
       final_write_state 1 "plugin_seed_copy_failed"
       exit 1
     fi
     docker rm soleur-plugin-seed >/dev/null
+    # Sentinel marker — written LAST so a SIGKILL mid-cp leaves the marker
+    # absent. `verifyPluginMountOnce` checks for it to distinguish "manifest
+    # extracted early but partial copy" from a healthy mount.
+    printf '%s\n' "seeded $(date -u +%Y-%m-%dT%H:%M:%SZ) tag=$TAG" \
+      > /mnt/data/plugins/soleur/.seed-complete
 
     # Prepare environment (shared between canary and production)
     sudo chown 1001:1001 /mnt/data/workspaces

--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -237,6 +237,28 @@ case "$COMPONENT" in
     { docker stop soleur-web-platform-canary 2>/dev/null || true; }
     { docker rm soleur-web-platform-canary 2>/dev/null || true; }
 
+    # Seed the read-only plugin bind-mount from the new image (#3045).
+    # Source of truth: /opt/soleur/plugin in the image (vendored at build time).
+    # Must run BEFORE the canary docker run so the canary itself sees populated
+    # content on first read — the Layer 3 probe script lives in the same mount.
+    # Uses an ephemeral container (`docker create` + `docker cp` + `docker rm`)
+    # so we never run a second instance of the new image during the canary phase.
+    # `docker cp src/. dst/` copies *contents* of src into dst (NOT src as a
+    # child of dst); the brace-glob removes prior-version content including
+    # dotfiles like `.claude-plugin/` (load-bearing — `*` alone leaves them).
+    echo "Seeding plugin mount from image..."
+    if ! docker create --name soleur-plugin-seed "$IMAGE:$TAG" >/dev/null; then
+      final_write_state 1 "plugin_seed_create_failed"
+      exit 1
+    fi
+    rm -rf /mnt/data/plugins/soleur/{*,.[!.]*,..?*} 2>/dev/null || true
+    if ! docker cp soleur-plugin-seed:/opt/soleur/plugin/. /mnt/data/plugins/soleur/; then
+      docker rm soleur-plugin-seed >/dev/null 2>&1 || true
+      final_write_state 1 "plugin_seed_copy_failed"
+      exit 1
+    fi
+    docker rm soleur-plugin-seed >/dev/null
+
     # Prepare environment (shared between canary and production)
     sudo chown 1001:1001 /mnt/data/workspaces
     ENV_FILE=$(resolve_env_file)

--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -27,6 +27,10 @@ readonly EXIT_NO_PRIOR=-2
 # extraction headroom). 5GB expressed in KB to match `df --output=avail`.
 readonly MIN_DISK_KB=$((5 * 1024 * 1024))  # 5GB for image pull + extraction
 
+# Plugin bind-mount target. Test harness overrides via env so the seed block
+# writes under a tmpdir instead of /mnt/data (which the GH runner cannot create).
+PLUGIN_MOUNT_DIR="${PLUGIN_MOUNT_DIR:-/mnt/data/plugins/soleur}"
+
 # -----------------------------------------------------------------------------
 # Deploy state observability (#2185)
 # -----------------------------------------------------------------------------
@@ -255,8 +259,16 @@ case "$COMPONENT" in
       final_write_state 1 "plugin_seed_create_failed"
       exit 1
     fi
-    find /mnt/data/plugins/soleur -mindepth 1 -delete 2>/dev/null || true
-    if ! docker cp soleur-plugin-seed:/opt/soleur/plugin/. /mnt/data/plugins/soleur/; then
+    # Pre-create the mount dir so the sentinel write below cannot fail with
+    # ENOENT in test harnesses that run with PLUGIN_MOUNT_DIR pointed at a
+    # tmpdir. In production cloud-init.yml already creates /mnt/data/plugins/
+    # soleur, so this is a no-op there.
+    mkdir -p "$PLUGIN_MOUNT_DIR"
+    find "$PLUGIN_MOUNT_DIR" -mindepth 1 -delete 2>/dev/null || true
+    # Redirect cp stdout so it stays out of the docker-trace assertion stream
+    # used by ci-deploy.test.sh (which greps DOCKER_TRACE:* from script stdout).
+    # Stderr is preserved for journalctl debugging on real failures.
+    if ! docker cp soleur-plugin-seed:/opt/soleur/plugin/. "$PLUGIN_MOUNT_DIR/" >/dev/null; then
       docker rm soleur-plugin-seed >/dev/null 2>&1 || true
       final_write_state 1 "plugin_seed_copy_failed"
       exit 1
@@ -266,7 +278,7 @@ case "$COMPONENT" in
     # absent. `verifyPluginMountOnce` checks for it to distinguish "manifest
     # extracted early but partial copy" from a healthy mount.
     printf '%s\n' "seeded $(date -u +%Y-%m-%dT%H:%M:%SZ) tag=$TAG" \
-      > /mnt/data/plugins/soleur/.seed-complete
+      > "$PLUGIN_MOUNT_DIR/.seed-complete"
 
     # Prepare environment (shared between canary and production)
     sudo chown 1001:1001 /mnt/data/workspaces

--- a/apps/web-platform/infra/ci-deploy.test.sh
+++ b/apps/web-platform/infra/ci-deploy.test.sh
@@ -328,6 +328,9 @@ run_deploy() {
     export SSH_ORIGINAL_COMMAND="$cmd"
     MOCK_DIR=$(mktemp -d)
     trap 'rm -rf "$MOCK_DIR"' EXIT
+    # Redirect the plugin-seed bind-mount under MOCK_DIR so the seed block can
+    # mkdir/find/cp/sentinel-write without needing /mnt/data on the runner.
+    export PLUGIN_MOUNT_DIR="$MOCK_DIR/plugin-mount"
 
     export CI_DEPLOY_LOCK="$MOCK_DIR/ci-deploy.lock"
     # CI_DEPLOY_STATE defaults to a per-run temp path unless the caller already set one.
@@ -396,6 +399,9 @@ run_deploy_traced() {
     export SSH_ORIGINAL_COMMAND="$cmd"
     MOCK_DIR=$(mktemp -d)
     trap 'rm -rf "$MOCK_DIR"' EXIT
+    # Redirect the plugin-seed bind-mount under MOCK_DIR so the seed block can
+    # mkdir/find/cp/sentinel-write without needing /mnt/data on the runner.
+    export PLUGIN_MOUNT_DIR="$MOCK_DIR/plugin-mount"
 
     export CI_DEPLOY_LOCK="$MOCK_DIR/ci-deploy.lock"
     if [[ -z "${CI_DEPLOY_STATE:-}" ]]; then
@@ -785,6 +791,9 @@ run_deploy_doppler() {
     export SSH_ORIGINAL_COMMAND="$cmd"
     MOCK_DIR=$(mktemp -d)
     trap 'rm -rf "$MOCK_DIR"' EXIT
+    # Redirect the plugin-seed bind-mount under MOCK_DIR so the seed block can
+    # mkdir/find/cp/sentinel-write without needing /mnt/data on the runner.
+    export PLUGIN_MOUNT_DIR="$MOCK_DIR/plugin-mount"
 
     export CI_DEPLOY_LOCK="$MOCK_DIR/ci-deploy.lock"
     create_base_mocks "$MOCK_DIR"
@@ -1117,6 +1126,9 @@ assert_env_file_cleanup() {
     export SSH_ORIGINAL_COMMAND="deploy web-platform ghcr.io/jikig-ai/soleur-web-platform v1.0.0"
     MOCK_DIR=$(mktemp -d)
     trap 'rm -rf "$MOCK_DIR"' EXIT
+    # Redirect the plugin-seed bind-mount under MOCK_DIR so the seed block can
+    # mkdir/find/cp/sentinel-write without needing /mnt/data on the runner.
+    export PLUGIN_MOUNT_DIR="$MOCK_DIR/plugin-mount"
     export CI_DEPLOY_LOCK="$MOCK_DIR/ci-deploy.lock"
     export ENV_FILE_TRACKER="$tracker_dir/env_file_path"
     create_base_mocks "$MOCK_DIR"
@@ -1419,6 +1431,9 @@ assert_initial_running_has_tag() {
     export SSH_ORIGINAL_COMMAND="deploy web-platform ghcr.io/jikig-ai/soleur-web-platform v1.0.0"
     MOCK_DIR=$(mktemp -d)
     trap 'rm -rf "$MOCK_DIR"' EXIT
+    # Redirect the plugin-seed bind-mount under MOCK_DIR so the seed block can
+    # mkdir/find/cp/sentinel-write without needing /mnt/data on the runner.
+    export PLUGIN_MOUNT_DIR="$MOCK_DIR/plugin-mount"
     export CI_DEPLOY_LOCK="$MOCK_DIR/ci-deploy.lock"
     export CI_DEPLOY_STATE="$state_file"
     export RUNNING_SNAPSHOT="$snapshot"

--- a/apps/web-platform/infra/cloud-init-plugin-seed.test.sh
+++ b/apps/web-platform/infra/cloud-init-plugin-seed.test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tests the seed sequence used by ci-deploy.sh and cloud-init.yml to populate
+# /mnt/data/plugins/soleur from the image's baked plugin tree (#3045).
+#
+# Asserts:
+#   - manifest (.claude-plugin/plugin.json) lands at the mount root, not nested
+#     one extra level (the `src/.` trailing-dot is load-bearing per Sharp Edges)
+#   - skill stub markdown survives the docker cp (plugin .md content is the
+#     plugin's behavior — it MUST ship)
+#   - prior-version dotfiles and regular files are removed by the cleanup glob
+#     (otherwise stale `.claude-plugin/` from a previous deploy would persist)
+#
+# Skip cleanly if Docker is unavailable (CI runner without docker-in-docker).
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "SKIP: docker not available"
+  exit 0
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "SKIP: docker daemon not reachable"
+  exit 0
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"; docker rm -f soleur-plugin-seed-test >/dev/null 2>&1 || true; docker rmi -f soleur-plugin-seed-test:fixture >/dev/null 2>&1 || true' EXIT
+
+# Build a tiny fixture image with a synthetic plugin tree.
+cat > "$TMP/Dockerfile" <<'EOF'
+FROM busybox
+RUN mkdir -p /opt/soleur/plugin/.claude-plugin && \
+    echo '{"name":"soleur-test"}' > /opt/soleur/plugin/.claude-plugin/plugin.json && \
+    mkdir -p /opt/soleur/plugin/skills/test && \
+    echo "stub" > /opt/soleur/plugin/skills/test/SKILL.md
+EOF
+docker build -t soleur-plugin-seed-test:fixture "$TMP" >/dev/null
+
+# Pre-populate the bind-mount target with stale content (regular file + dotfile +
+# stale dotdir) to verify cleanup removes both visible and hidden entries.
+TARGET="$TMP/mnt/data/plugins/soleur"
+mkdir -p "$TARGET"
+echo "stale" > "$TARGET/stale-file.txt"
+mkdir -p "$TARGET/.stale-dir"
+touch "$TARGET/.stale-dir/keep"
+
+# Run the seed sequence verbatim (matches ci-deploy.sh — bash brace-glob).
+docker create --name soleur-plugin-seed-test soleur-plugin-seed-test:fixture >/dev/null
+rm -rf "$TARGET"/{*,.[!.]*,..?*} 2>/dev/null || true
+docker cp soleur-plugin-seed-test:/opt/soleur/plugin/. "$TARGET/"
+docker rm soleur-plugin-seed-test >/dev/null
+
+# Assertions — fail loudly with concrete reason on each.
+fail() { echo "FAIL: $1"; exit 1; }
+
+[[ -f "$TARGET/.claude-plugin/plugin.json" ]] \
+  || fail "manifest missing at $TARGET/.claude-plugin/plugin.json (docker cp src/. dst/ contract broken?)"
+[[ -f "$TARGET/skills/test/SKILL.md" ]] \
+  || fail "skill stub missing at $TARGET/skills/test/SKILL.md (.md content stripped by image build?)"
+[[ ! -e "$TARGET/stale-file.txt" ]] \
+  || fail "stale regular file remained at $TARGET/stale-file.txt (cleanup glob did not match *)"
+[[ ! -e "$TARGET/.stale-dir" ]] \
+  || fail "stale dotdir remained at $TARGET/.stale-dir (cleanup glob did not match .[!.]*)"
+
+# Negative-space: the manifest must NOT land at $TARGET/plugin/.claude-plugin
+# (which would happen if the trailing /. was dropped from `docker cp src dst`).
+[[ ! -e "$TARGET/plugin" ]] \
+  || fail "docker cp produced nested $TARGET/plugin/... — the trailing /. on the source argument was dropped"
+
+echo "PASS: cloud-init-plugin-seed"

--- a/apps/web-platform/infra/cloud-init-plugin-seed.test.sh
+++ b/apps/web-platform/infra/cloud-init-plugin-seed.test.sh
@@ -45,11 +45,18 @@ echo "stale" > "$TARGET/stale-file.txt"
 mkdir -p "$TARGET/.stale-dir"
 touch "$TARGET/.stale-dir/keep"
 
-# Run the seed sequence verbatim (matches ci-deploy.sh — bash brace-glob).
+# Run the seed sequence verbatim. `find -mindepth 1 -delete` is the single
+# POSIX-portable cleanup form used by both ci-deploy.sh (bash) and
+# cloud-init.yml (dash) so this test exercises the production form on both
+# paths. Sentinel `.seed-complete` is written LAST so partial-copy detection
+# in `verifyPluginMountOnce` works; the test asserts both are present.
+docker rm -f soleur-plugin-seed-test >/dev/null 2>&1 || true
 docker create --name soleur-plugin-seed-test soleur-plugin-seed-test:fixture >/dev/null
-rm -rf "$TARGET"/{*,.[!.]*,..?*} 2>/dev/null || true
+find "$TARGET" -mindepth 1 -delete 2>/dev/null || true
 docker cp soleur-plugin-seed-test:/opt/soleur/plugin/. "$TARGET/"
 docker rm soleur-plugin-seed-test >/dev/null
+printf '%s\n' "seeded $(date -u +%Y-%m-%dT%H:%M:%SZ) tag=test-fixture" \
+  > "$TARGET/.seed-complete"
 
 # Assertions — fail loudly with concrete reason on each.
 fail() { echo "FAIL: $1"; exit 1; }
@@ -58,14 +65,37 @@ fail() { echo "FAIL: $1"; exit 1; }
   || fail "manifest missing at $TARGET/.claude-plugin/plugin.json (docker cp src/. dst/ contract broken?)"
 [[ -f "$TARGET/skills/test/SKILL.md" ]] \
   || fail "skill stub missing at $TARGET/skills/test/SKILL.md (.md content stripped by image build?)"
+[[ -f "$TARGET/.seed-complete" ]] \
+  || fail "sentinel missing at $TARGET/.seed-complete (post-cp marker not written)"
 [[ ! -e "$TARGET/stale-file.txt" ]] \
-  || fail "stale regular file remained at $TARGET/stale-file.txt (cleanup glob did not match *)"
+  || fail "stale regular file remained at $TARGET/stale-file.txt (find -mindepth 1 -delete did not run?)"
 [[ ! -e "$TARGET/.stale-dir" ]] \
-  || fail "stale dotdir remained at $TARGET/.stale-dir (cleanup glob did not match .[!.]*)"
+  || fail "stale dotdir remained at $TARGET/.stale-dir (find -mindepth 1 -delete did not match dotfiles?)"
 
 # Negative-space: the manifest must NOT land at $TARGET/plugin/.claude-plugin
 # (which would happen if the trailing /. was dropped from `docker cp src dst`).
 [[ ! -e "$TARGET/plugin" ]] \
   || fail "docker cp produced nested $TARGET/plugin/... — the trailing /. on the source argument was dropped"
+
+# Mode-bit gate: container reads as UID 1001 over a `:ro` bind-mount, so the
+# seeded files MUST retain world-read. A future hardening pass that strips
+# o+r from /mnt/data/plugins/soleur silently breaks runtime; this assertion
+# fails the test BEFORE that change ships. Octal mode's last digit is the
+# "other" class — must be in {4,5,6,7} (read bit set).
+manifest_mode=$(stat -c '%a' "$TARGET/.claude-plugin/plugin.json")
+[[ "${manifest_mode: -1}" =~ ^[4567]$ ]] \
+  || fail "manifest mode $manifest_mode lacks world-read (container UID 1001 cannot read :ro mount)"
+
+# Container-readability gate: actually run a UID-1001 container against the
+# seeded :ro mount and read the manifest + skill stub. This catches the prod
+# failure mode (image perms stripped, host ACL deny, SELinux relabel) that
+# pure mode-bit checks miss. Requires nothing beyond busybox + Docker which
+# we already have.
+if ! docker run --rm --user 1001:1001 \
+       -v "$TARGET":/p:ro \
+       busybox sh -c 'cat /p/.claude-plugin/plugin.json >/dev/null && cat /p/skills/test/SKILL.md >/dev/null' \
+       2>/dev/null; then
+  fail ":ro mount unreadable to UID 1001 — container would silently load no plugin content"
+fi
 
 echo "PASS: cloud-init-plugin-seed"

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -345,6 +345,20 @@ runcmd:
 
   # Pull and run container (secrets from Doppler -- no .env fallback)
   - docker pull ${image_name}
+
+  # Seed /mnt/data/plugins/soleur from the image's baked plugin tree (#3045).
+  # Ephemeral container so we don't depend on a long-running container.
+  # `docker cp src/.` copies *contents* (not the src dir itself) into dst.
+  # `find -mindepth 1 -delete` is POSIX-portable: cloud-init `- |` blocks run
+  # under /bin/sh (= dash on Ubuntu), which has no bash brace-expansion. The
+  # bash brace-glob form is reserved for ci-deploy.sh (bash shebang).
+  - |
+    set -e
+    docker create --name soleur-plugin-seed ${image_name}
+    find /mnt/data/plugins/soleur -mindepth 1 -delete 2>/dev/null || true
+    docker cp soleur-plugin-seed:/opt/soleur/plugin/. /mnt/data/plugins/soleur/
+    docker rm soleur-plugin-seed
+
   - |
     set -e
     # Source token from the restricted env file (avoids exposing it in /proc/<pid>/cmdline)

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -351,13 +351,23 @@ runcmd:
   # `docker cp src/.` copies *contents* (not the src dir itself) into dst.
   # `find -mindepth 1 -delete` is POSIX-portable: cloud-init `- |` blocks run
   # under /bin/sh (= dash on Ubuntu), which has no bash brace-expansion. The
-  # bash brace-glob form is reserved for ci-deploy.sh (bash shebang).
+  # same form is also used in ci-deploy.sh so both paths share one cleanup
+  # expression and the bash test exercises the production form.
+  # The .seed-complete sentinel is written LAST and checked by
+  # verifyPluginMountOnce so a partial copy (manifest present but skill files
+  # missing) is detected at startup instead of silently degrading.
   - |
     set -e
+    docker rm -f soleur-plugin-seed >/dev/null 2>&1 || true
+    cleanup() { docker rm -f soleur-plugin-seed >/dev/null 2>&1 || true; }
+    trap cleanup EXIT
     docker create --name soleur-plugin-seed ${image_name}
     find /mnt/data/plugins/soleur -mindepth 1 -delete 2>/dev/null || true
     docker cp soleur-plugin-seed:/opt/soleur/plugin/. /mnt/data/plugins/soleur/
     docker rm soleur-plugin-seed
+    trap - EXIT
+    printf '%s\n' "seeded $(date -u +%Y-%m-%dT%H:%M:%SZ) tag=cloud-init" \
+      > /mnt/data/plugins/soleur/.seed-complete
 
   - |
     set -e

--- a/apps/web-platform/server/agent-runner.ts
+++ b/apps/web-platform/server/agent-runner.ts
@@ -52,9 +52,6 @@ const log = createChildLogger("agent");
 let _supabase: ReturnType<typeof createServiceClient>;
 function supabase() { return _supabase ??= createServiceClient(); }
 
-const PLUGIN_PATH =
-  process.env.SOLEUR_PLUGIN_PATH || "/app/shared/plugins/soleur";
-
 import { buildToolLabel } from "./tool-labels";
 
 // ---------------------------------------------------------------------------

--- a/apps/web-platform/server/index.ts
+++ b/apps/web-platform/server/index.ts
@@ -12,6 +12,7 @@ import { WS_CLOSE_CODES } from "@/lib/types";
 import { abortAllSessions, cleanupOrphanedConversations, startInactivityTimer } from "./agent-runner";
 import { handleConversationMessages } from "./api-messages";
 import { createChildLogger } from "./logger";
+import { verifyPluginMountOnce } from "./plugin-mount-check";
 import {
   buildHealthResponse,
   buildInternalMetricsResponse,
@@ -38,6 +39,8 @@ const app = next({ dev });
 const handle = app.getRequestHandler();
 
 app.prepare().then(() => {
+  verifyPluginMountOnce();
+
   const server = createServer(async (req, res) => {
     const parsedUrl = parse(req.url!, true);
 

--- a/apps/web-platform/server/observability.ts
+++ b/apps/web-platform/server/observability.ts
@@ -91,14 +91,26 @@ export function reportSilentFallback(
   // stdout, Better Stack) also get the same tag vocabulary.
   logger.error({ err, feature, op, ...extra }, message ?? `${feature} silent fallback`);
 
-  if (err instanceof Error) {
-    Sentry.captureException(err, { tags, extra });
-  } else {
-    Sentry.captureMessage(message ?? `${feature} silent fallback`, {
-      level: "error",
-      tags,
-      extra: { err, ...extra },
-    });
+  // Sentry's namespace shape varies across the dev-server bundle (where
+  // captureMessage may be tree-shaken when DSN is unset) and the prod build.
+  // Guard so an uninitialized Sentry never throws a TypeError into a caller
+  // that fires on server boot (see #3045 plugin-mount-check) — the pino mirror
+  // above is the durable signal regardless.
+  try {
+    if (err instanceof Error) {
+      if (typeof Sentry.captureException === "function") {
+        Sentry.captureException(err, { tags, extra });
+      }
+    } else if (typeof Sentry.captureMessage === "function") {
+      Sentry.captureMessage(message ?? `${feature} silent fallback`, {
+        level: "error",
+        tags,
+        extra: { err, ...extra },
+      });
+    }
+  } catch {
+    // Sentry call failures must never propagate — they would convert a
+    // diagnostic mirror into a service-killing exception.
   }
 }
 
@@ -118,13 +130,20 @@ export function warnSilentFallback(
 
   logger.warn({ err, feature, op, ...extra }, message ?? `${feature} silent fallback`);
 
-  if (err instanceof Error) {
-    Sentry.captureException(err, { level: "warning", tags, extra });
-  } else {
-    Sentry.captureMessage(message ?? `${feature} silent fallback`, {
-      level: "warning",
-      tags,
-      extra: { err, ...extra },
-    });
+  try {
+    if (err instanceof Error) {
+      if (typeof Sentry.captureException === "function") {
+        Sentry.captureException(err, { level: "warning", tags, extra });
+      }
+    } else if (typeof Sentry.captureMessage === "function") {
+      Sentry.captureMessage(message ?? `${feature} silent fallback`, {
+        level: "warning",
+        tags,
+        extra: { err, ...extra },
+      });
+    }
+  } catch {
+    // See reportSilentFallback — Sentry namespace may be partially shimmed
+    // in non-prod bundles; pino is the durable signal.
   }
 }

--- a/apps/web-platform/server/plugin-mount-check.ts
+++ b/apps/web-platform/server/plugin-mount-check.ts
@@ -2,26 +2,28 @@ import { existsSync, readdirSync } from "fs";
 import { join } from "path";
 import { reportSilentFallback } from "./observability";
 import { createChildLogger } from "./logger";
+import { getPluginPath } from "./plugin-path";
 
 const log = createChildLogger("plugin-mount");
 
-function getPluginPath(): string {
-  return process.env.SOLEUR_PLUGIN_PATH || "/app/shared/plugins/soleur";
-}
-
+// Latched once per process so the boot-time signal does not flap on repeat
+// calls. Test isolation uses `vi.resetModules()` rather than a public reset
+// hook so the reset path is not exposed on the production module surface.
 let _checked = false;
 
 /**
  * One-shot startup verification that the plugin bind-mount source has been
- * populated by the deploy seed step. Mirrors the empty-mount degraded
- * condition to Sentry via reportSilentFallback so a regression in the deploy
+ * populated by the deploy seed step. Mirrors empty/partial/missing-mount
+ * conditions to Sentry via reportSilentFallback so a regression in the deploy
  * seed step is visible in dashboards instead of being a silent feature drop.
  * See #3045.
  *
- * Three differentiated messages let dashboards distinguish:
+ * Four differentiated messages let dashboards distinguish:
  * - "plugin-mount path missing": Hetzner volume failed to attach
  * - "plugin-mount empty": deploy seed step skipped or failed
  * - "plugin-mount manifest missing": image shipped without .claude-plugin/
+ * - "plugin-mount partial seed": docker cp interrupted (manifest extracted
+ *   early but `.seed-complete` sentinel never written)
  */
 export function verifyPluginMountOnce(): void {
   if (_checked) return;
@@ -76,10 +78,21 @@ export function verifyPluginMountOnce(): void {
     return;
   }
 
-  log.info({ path: pluginPath, entries: entries.length }, "Plugin mount OK");
-}
+  // The seed sentinel is written by ci-deploy.sh and cloud-init.yml AFTER
+  // `docker cp` returns 0. A SIGKILLed cp leaves the manifest (which extracts
+  // early in tar order) but no sentinel — without this check, the mount looks
+  // healthy and downstream skill loading silently misses files.
+  const sentinel = join(pluginPath, ".seed-complete");
+  if (!existsSync(sentinel)) {
+    reportSilentFallback(null, {
+      feature: "plugin-mount",
+      op: "discovery",
+      message: "plugin-mount partial seed",
+      extra: { path: pluginPath, sentinel },
+    });
+    log.error({ sentinel }, "Plugin mount missing .seed-complete sentinel");
+    return;
+  }
 
-/** Test-only memoization reset. Not exported from server entry. */
-export function _resetForTesting(): void {
-  _checked = false;
+  log.info({ path: pluginPath, entries: entries.length }, "Plugin mount OK");
 }

--- a/apps/web-platform/server/plugin-mount-check.ts
+++ b/apps/web-platform/server/plugin-mount-check.ts
@@ -1,0 +1,85 @@
+import { existsSync, readdirSync } from "fs";
+import { join } from "path";
+import { reportSilentFallback } from "./observability";
+import { createChildLogger } from "./logger";
+
+const log = createChildLogger("plugin-mount");
+
+function getPluginPath(): string {
+  return process.env.SOLEUR_PLUGIN_PATH || "/app/shared/plugins/soleur";
+}
+
+let _checked = false;
+
+/**
+ * One-shot startup verification that the plugin bind-mount source has been
+ * populated by the deploy seed step. Mirrors the empty-mount degraded
+ * condition to Sentry via reportSilentFallback so a regression in the deploy
+ * seed step is visible in dashboards instead of being a silent feature drop.
+ * See #3045.
+ *
+ * Three differentiated messages let dashboards distinguish:
+ * - "plugin-mount path missing": Hetzner volume failed to attach
+ * - "plugin-mount empty": deploy seed step skipped or failed
+ * - "plugin-mount manifest missing": image shipped without .claude-plugin/
+ */
+export function verifyPluginMountOnce(): void {
+  if (_checked) return;
+  _checked = true;
+
+  const pluginPath = getPluginPath();
+
+  if (!existsSync(pluginPath)) {
+    reportSilentFallback(null, {
+      feature: "plugin-mount",
+      op: "discovery",
+      message: "plugin-mount path missing",
+      extra: { path: pluginPath },
+    });
+    log.error({ path: pluginPath }, "Plugin mount path does not exist");
+    return;
+  }
+
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(pluginPath);
+  } catch (err) {
+    reportSilentFallback(err, {
+      feature: "plugin-mount",
+      op: "discovery",
+      extra: { path: pluginPath },
+    });
+    log.error({ err, path: pluginPath }, "Plugin mount unreadable");
+    return;
+  }
+
+  if (entries.length === 0) {
+    reportSilentFallback(null, {
+      feature: "plugin-mount",
+      op: "discovery",
+      message: "plugin-mount empty",
+      extra: { path: pluginPath },
+    });
+    log.error({ path: pluginPath }, "Plugin mount is empty");
+    return;
+  }
+
+  const manifest = join(pluginPath, ".claude-plugin", "plugin.json");
+  if (!existsSync(manifest)) {
+    reportSilentFallback(null, {
+      feature: "plugin-mount",
+      op: "discovery",
+      message: "plugin-mount manifest missing",
+      extra: { path: pluginPath, manifest },
+    });
+    log.error({ manifest }, "Plugin mount missing .claude-plugin/plugin.json");
+    return;
+  }
+
+  log.info({ path: pluginPath, entries: entries.length }, "Plugin mount OK");
+}
+
+/** Test-only memoization reset. Not exported from server entry. */
+export function _resetForTesting(): void {
+  _checked = false;
+}

--- a/apps/web-platform/server/plugin-path.ts
+++ b/apps/web-platform/server/plugin-path.ts
@@ -1,0 +1,12 @@
+/**
+ * Canonical plugin-mount path resolution. Single source of truth for the
+ * `SOLEUR_PLUGIN_PATH || /app/shared/plugins/soleur` default — consumed by
+ * `workspace.ts` (symlink target for new user workspaces) and
+ * `plugin-mount-check.ts` (boot-time integrity probe). See #3045.
+ */
+
+export const SOLEUR_PLUGIN_PATH_DEFAULT = "/app/shared/plugins/soleur";
+
+export function getPluginPath(): string {
+  return process.env.SOLEUR_PLUGIN_PATH || SOLEUR_PLUGIN_PATH_DEFAULT;
+}

--- a/apps/web-platform/server/workspace.ts
+++ b/apps/web-platform/server/workspace.ts
@@ -15,6 +15,7 @@ import {
   GitOperationError,
 } from "./git-auth";
 import { generateInstallationToken, checkRepoAccess } from "./github-app";
+import { getPluginPath } from "./plugin-path";
 
 const GITHUB_URL_RE =
   /^https:\/\/github\.com\/([a-zA-Z0-9._-]+)\/([a-zA-Z0-9._-]+?)(?:\.git)?\/?$/;
@@ -33,10 +34,6 @@ const log = createChildLogger("workspace");
 
 function getWorkspacesRoot(): string {
   return process.env.WORKSPACES_ROOT || "/workspaces";
-}
-
-function getPluginPath(): string {
-  return process.env.SOLEUR_PLUGIN_PATH || "/app/shared/plugins/soleur";
 }
 
 const KNOWLEDGE_BASE_PROJECT_DIRS = [

--- a/apps/web-platform/test/plugin-mount-check.test.ts
+++ b/apps/web-platform/test/plugin-mount-check.test.ts
@@ -5,14 +5,7 @@ import { join } from "path";
 
 vi.mock("../server/observability", () => ({
   reportSilentFallback: vi.fn(),
-  warnSilentFallback: vi.fn(),
 }));
-
-import { reportSilentFallback } from "../server/observability";
-import {
-  verifyPluginMountOnce,
-  _resetForTesting,
-} from "../server/plugin-mount-check";
 
 const FEATURE = "plugin-mount";
 const OP = "discovery";
@@ -27,13 +20,28 @@ function seedManifest(dir: string): void {
   writeFileSync(join(inner, "plugin.json"), '{"name":"soleur"}', "utf8");
 }
 
+function writeSentinel(dir: string): void {
+  writeFileSync(join(dir, ".seed-complete"), "seeded test\n", "utf8");
+}
+
+// Re-imports the module after vi.resetModules() so the latched _checked flag
+// starts false for each test. This replaces a `_resetForTesting()` export from
+// the production module — keeping the prod surface free of test-only hooks.
+async function loadModule() {
+  vi.resetModules();
+  return await import("../server/plugin-mount-check");
+}
+
+async function loadObservability() {
+  return await import("../server/observability");
+}
+
 describe("verifyPluginMountOnce", () => {
   const originalEnv = process.env.SOLEUR_PLUGIN_PATH;
   let tmpDirs: string[] = [];
 
   beforeEach(() => {
     vi.clearAllMocks();
-    _resetForTesting();
     tmpDirs = [];
   });
 
@@ -49,8 +57,10 @@ describe("verifyPluginMountOnce", () => {
     }
   });
 
-  test("Scenario A: path missing fires reportSilentFallback with 'plugin-mount path missing'", () => {
+  test("Scenario A: path missing fires reportSilentFallback with 'plugin-mount path missing'", async () => {
     process.env.SOLEUR_PLUGIN_PATH = "/nonexistent-plugin-mount-test-path-3045";
+    const { verifyPluginMountOnce } = await loadModule();
+    const { reportSilentFallback } = await loadObservability();
 
     verifyPluginMountOnce();
 
@@ -64,33 +74,33 @@ describe("verifyPluginMountOnce", () => {
     });
   });
 
-  test("Scenario B: empty mount fires 'plugin-mount empty'", () => {
+  test("Scenario B: empty mount fires 'plugin-mount empty'", async () => {
     const dir = makeTempDir();
     tmpDirs.push(dir);
     process.env.SOLEUR_PLUGIN_PATH = dir;
+    const { verifyPluginMountOnce } = await loadModule();
+    const { reportSilentFallback } = await loadObservability();
 
     verifyPluginMountOnce();
 
     expect(reportSilentFallback).toHaveBeenCalledTimes(1);
     const [, opts] = vi.mocked(reportSilentFallback).mock.calls[0];
-    expect(opts.feature).toBe(FEATURE);
-    expect(opts.op).toBe(OP);
     expect(opts.message).toBe("plugin-mount empty");
     expect(opts.extra).toMatchObject({ path: dir });
   });
 
-  test("Scenario C: manifest missing fires 'plugin-mount manifest missing'", () => {
+  test("Scenario C: manifest missing fires 'plugin-mount manifest missing'", async () => {
     const dir = makeTempDir();
     tmpDirs.push(dir);
     writeFileSync(join(dir, "stray.txt"), "stub", "utf8");
     process.env.SOLEUR_PLUGIN_PATH = dir;
+    const { verifyPluginMountOnce } = await loadModule();
+    const { reportSilentFallback } = await loadObservability();
 
     verifyPluginMountOnce();
 
     expect(reportSilentFallback).toHaveBeenCalledTimes(1);
     const [, opts] = vi.mocked(reportSilentFallback).mock.calls[0];
-    expect(opts.feature).toBe(FEATURE);
-    expect(opts.op).toBe(OP);
     expect(opts.message).toBe("plugin-mount manifest missing");
     expect(opts.extra).toMatchObject({
       path: dir,
@@ -98,23 +108,65 @@ describe("verifyPluginMountOnce", () => {
     });
   });
 
-  test("Scenario D: populated mount is silent", () => {
+  test("Scenario D: manifest present but sentinel missing fires 'plugin-mount partial seed'", async () => {
     const dir = makeTempDir();
     tmpDirs.push(dir);
     seedManifest(dir);
+    // Intentionally NOT writing .seed-complete — simulates a docker cp that
+    // extracted .claude-plugin/ early in the tar but was SIGKILLed before
+    // the sentinel was written.
     process.env.SOLEUR_PLUGIN_PATH = dir;
+    const { verifyPluginMountOnce } = await loadModule();
+    const { reportSilentFallback } = await loadObservability();
+
+    verifyPluginMountOnce();
+
+    expect(reportSilentFallback).toHaveBeenCalledTimes(1);
+    const [, opts] = vi.mocked(reportSilentFallback).mock.calls[0];
+    expect(opts.message).toBe("plugin-mount partial seed");
+    expect(opts.extra).toMatchObject({
+      path: dir,
+      sentinel: join(dir, ".seed-complete"),
+    });
+  });
+
+  test("Scenario E: fully-seeded mount is silent", async () => {
+    const dir = makeTempDir();
+    tmpDirs.push(dir);
+    seedManifest(dir);
+    writeSentinel(dir);
+    process.env.SOLEUR_PLUGIN_PATH = dir;
+    const { verifyPluginMountOnce } = await loadModule();
+    const { reportSilentFallback } = await loadObservability();
 
     verifyPluginMountOnce();
 
     expect(reportSilentFallback).not.toHaveBeenCalled();
   });
 
-  test("Scenario E: memoization — second call is a no-op", () => {
+  test("Scenario F: memoization survives env-var change between calls", async () => {
     const dir = makeTempDir();
     tmpDirs.push(dir);
     process.env.SOLEUR_PLUGIN_PATH = dir;
+    const { verifyPluginMountOnce } = await loadModule();
+    const { reportSilentFallback } = await loadObservability();
 
+    // First call against an empty mount fires once.
     verifyPluginMountOnce();
+    expect(reportSilentFallback).toHaveBeenCalledTimes(1);
+
+    // Now seed the dir AND change env to a fully-populated path. A regression
+    // that re-evaluated state per call (instead of memoizing) would either
+    // re-fire (against the still-empty original path) or stay silent (against
+    // the new populated path) — both would diverge from "called exactly once".
+    seedManifest(dir);
+    writeSentinel(dir);
+    const populated = makeTempDir();
+    tmpDirs.push(populated);
+    seedManifest(populated);
+    writeSentinel(populated);
+    process.env.SOLEUR_PLUGIN_PATH = populated;
+
     verifyPluginMountOnce();
     verifyPluginMountOnce();
 

--- a/apps/web-platform/test/plugin-mount-check.test.ts
+++ b/apps/web-platform/test/plugin-mount-check.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+vi.mock("../server/observability", () => ({
+  reportSilentFallback: vi.fn(),
+  warnSilentFallback: vi.fn(),
+}));
+
+import { reportSilentFallback } from "../server/observability";
+import {
+  verifyPluginMountOnce,
+  _resetForTesting,
+} from "../server/plugin-mount-check";
+
+const FEATURE = "plugin-mount";
+const OP = "discovery";
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "plugin-mount-test-"));
+}
+
+function seedManifest(dir: string): void {
+  const inner = join(dir, ".claude-plugin");
+  mkdirSync(inner, { recursive: true });
+  writeFileSync(join(inner, "plugin.json"), '{"name":"soleur"}', "utf8");
+}
+
+describe("verifyPluginMountOnce", () => {
+  const originalEnv = process.env.SOLEUR_PLUGIN_PATH;
+  let tmpDirs: string[] = [];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetForTesting();
+    tmpDirs = [];
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.SOLEUR_PLUGIN_PATH;
+    else process.env.SOLEUR_PLUGIN_PATH = originalEnv;
+    for (const d of tmpDirs) {
+      try {
+        rmSync(d, { recursive: true, force: true });
+      } catch {
+        // Best effort cleanup; sweep on fixture-collision.
+      }
+    }
+  });
+
+  test("Scenario A: path missing fires reportSilentFallback with 'plugin-mount path missing'", () => {
+    process.env.SOLEUR_PLUGIN_PATH = "/nonexistent-plugin-mount-test-path-3045";
+
+    verifyPluginMountOnce();
+
+    expect(reportSilentFallback).toHaveBeenCalledTimes(1);
+    const [, opts] = vi.mocked(reportSilentFallback).mock.calls[0];
+    expect(opts.feature).toBe(FEATURE);
+    expect(opts.op).toBe(OP);
+    expect(opts.message).toBe("plugin-mount path missing");
+    expect(opts.extra).toMatchObject({
+      path: "/nonexistent-plugin-mount-test-path-3045",
+    });
+  });
+
+  test("Scenario B: empty mount fires 'plugin-mount empty'", () => {
+    const dir = makeTempDir();
+    tmpDirs.push(dir);
+    process.env.SOLEUR_PLUGIN_PATH = dir;
+
+    verifyPluginMountOnce();
+
+    expect(reportSilentFallback).toHaveBeenCalledTimes(1);
+    const [, opts] = vi.mocked(reportSilentFallback).mock.calls[0];
+    expect(opts.feature).toBe(FEATURE);
+    expect(opts.op).toBe(OP);
+    expect(opts.message).toBe("plugin-mount empty");
+    expect(opts.extra).toMatchObject({ path: dir });
+  });
+
+  test("Scenario C: manifest missing fires 'plugin-mount manifest missing'", () => {
+    const dir = makeTempDir();
+    tmpDirs.push(dir);
+    writeFileSync(join(dir, "stray.txt"), "stub", "utf8");
+    process.env.SOLEUR_PLUGIN_PATH = dir;
+
+    verifyPluginMountOnce();
+
+    expect(reportSilentFallback).toHaveBeenCalledTimes(1);
+    const [, opts] = vi.mocked(reportSilentFallback).mock.calls[0];
+    expect(opts.feature).toBe(FEATURE);
+    expect(opts.op).toBe(OP);
+    expect(opts.message).toBe("plugin-mount manifest missing");
+    expect(opts.extra).toMatchObject({
+      path: dir,
+      manifest: join(dir, ".claude-plugin", "plugin.json"),
+    });
+  });
+
+  test("Scenario D: populated mount is silent", () => {
+    const dir = makeTempDir();
+    tmpDirs.push(dir);
+    seedManifest(dir);
+    process.env.SOLEUR_PLUGIN_PATH = dir;
+
+    verifyPluginMountOnce();
+
+    expect(reportSilentFallback).not.toHaveBeenCalled();
+  });
+
+  test("Scenario E: memoization — second call is a no-op", () => {
+    const dir = makeTempDir();
+    tmpDirs.push(dir);
+    process.env.SOLEUR_PLUGIN_PATH = dir;
+
+    verifyPluginMountOnce();
+    verifyPluginMountOnce();
+    verifyPluginMountOnce();
+
+    expect(reportSilentFallback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/knowledge-base/project/learnings/2026-04-29-bind-mount-seed-detection-needs-late-sentinel.md
+++ b/knowledge-base/project/learnings/2026-04-29-bind-mount-seed-detection-needs-late-sentinel.md
@@ -1,0 +1,84 @@
+---
+date: 2026-04-29
+category: integration-issues
+module: web-platform/infra
+issue: 3045
+pr: 3046
+tags: [docker, bind-mount, deploy-pipeline, observability, partial-copy, sentinel]
+---
+
+# Bind-mount seed detection needs a late-written sentinel — manifest checks miss SIGKILL-mid-cp partial copies
+
+## Problem
+
+PR #3046 populates `/mnt/data/plugins/soleur` on prod hosts via `docker cp <ephemeral>:/opt/soleur/plugin/. /mnt/data/plugins/soleur/`. The first reviewer iteration of `verifyPluginMountOnce()` checked three states: path missing, directory empty, manifest missing. Multi-agent review surfaced a fourth: **manifest present but skill files missing**.
+
+`docker cp` ships a tar stream. tar entries extract in archive order, which is generally the producer's filesystem walk order — and `.claude-plugin/plugin.json` lives at the root and extracts very early. If the cp is interrupted mid-extraction (SIGKILL during deploy, OOM, disk full), the manifest can land while later directories (`skills/`, `agents/`, `commands/`) extract partially or not at all.
+
+Result: the boot probe sees populated dir + manifest exists + structure looks fine. Health check passes. SDK loads zero skills because most of `skills/*` is empty. Sentry is silent. Production silently degrades.
+
+## Solution
+
+Write a sentinel file (`.seed-complete`) AFTER `docker cp` returns 0 — i.e., as a separate post-cp filesystem write that only happens when cp succeeded as a whole. Then check the sentinel in the boot probe.
+
+```bash
+# In ci-deploy.sh AND cloud-init.yml:
+docker cp soleur-plugin-seed:/opt/soleur/plugin/. /mnt/data/plugins/soleur/
+docker rm soleur-plugin-seed
+# Sentinel — written LAST so SIGKILL during the cp leaves it absent.
+printf '%s\n' "seeded $(date -u +%Y-%m-%dT%H:%M:%SZ) tag=$TAG" \
+  > /mnt/data/plugins/soleur/.seed-complete
+```
+
+```ts
+// In server/plugin-mount-check.ts, after the manifest check:
+const sentinel = join(pluginPath, ".seed-complete");
+if (!existsSync(sentinel)) {
+  reportSilentFallback(null, {
+    feature: "plugin-mount",
+    op: "discovery",
+    message: "plugin-mount partial seed",
+    extra: { path: pluginPath, sentinel },
+  });
+  return;
+}
+```
+
+The sentinel is a **post-condition assertion** for the cp operation: its existence proves the cp returned 0 from the deploy script's perspective. tar extract order, filesystem ordering, and SIGKILL semantics become irrelevant — either the deploy script wrote the marker or it didn't.
+
+## Key Insight
+
+**Late-extracted file inside the payload is not equivalent to a sentinel written AFTER the operation.** They look similar in the happy path but diverge under failure.
+
+A "late-extracted" check (e.g., assert `skills/zzz-marker/SKILL.md` exists) is hostage to:
+- tar entry order (producer-defined, may shift across image rebuilds)
+- partial-extract semantics (SIGKILL truncates the in-flight file but leaves prior entries intact)
+- the marker file's own bytes inside the payload
+
+A sentinel **written by the deploy script after the cp** is hostage only to whether the deploy script reached its post-cp line. It is the canonical post-condition.
+
+This generalizes beyond docker cp: any compound operation where you need to attest "the whole thing succeeded" should write a small, separate post-success marker rather than relying on a property of the payload itself. The same pattern applies to: rsync mirrors, multi-file unzip extractions, image-build artifact bundles, multi-row DB seed scripts.
+
+## Cross-references
+
+- [Plan](../plans/2026-04-29-fix-plugins-soleur-mount-empty-plan.md)
+- Issue #3045 (the empty-mount investigation that surfaced the gap)
+- Issue #3053 (deferred: empty-mount window during deploy — design venue #2608)
+- Issue #2608 (plugin freshness rotation API — design parent for the durable fix)
+- `knowledge-base/project/learnings/2026-02-09-plugin-staleness-audit-patterns.md` (related: plugin staleness detection)
+- `knowledge-base/project/learnings/2026-03-20-docker-nonroot-user-with-volume-mounts.md` (related: three-file lockstep rule)
+
+## Session Errors
+
+- **PreToolUse security_reminder_hook.py silently rejected workflow edits.** Two `Edit` calls on `.github/workflows/*.yml` returned the hook's reminder text in the result without applying the change; identical retries succeeded. Recovery: grep-verify each workflow edit landed before continuing. **Prevention:** add a step to the work/review pipelines (or a hook) that auto-verifies a workflow edit's `old_string`→`new_string` substitution by post-edit grep, surfacing silent rejections.
+
+- **Bash CWD drift between calls.** A `cd apps/web-platform && <cmd>` call left subsequent calls anchored differently than expected; a follow-up `grep apps/web-platform/...` failed with ENOENT until I prepended `cd <worktree-root>`. Recovery: anchor every Bash call with an absolute path or a `cd <abs> && ...` chain. **Prevention:** treat every Bash call as starting from indeterminate CWD; chain `cd <abs-path> && <cmd>` in one call when CWD matters. Already documented in AGENTS.md as `wg-when-running-test-lint-budget-commands` for test runners — extend the discipline to grep/find/general invocations.
+
+- **session-state.md directory missing.** The work skill expected `knowledge-base/project/specs/<branch>/session-state.md` but the planning subagent wrote the plan to `knowledge-base/project/plans/`, leaving the specs dir uncreated. Had to `mkdir -p` manually. Recovery: created the dir before Write. **Prevention:** the plan skill should create `knowledge-base/project/specs/<branch>/` as part of its contract (even when only the plan is initially written), or the work skill's session-state writer should create-as-needed via Write's auto-mkdir behavior.
+
+- **Scope-out criterion mislabeled twice before reviewer CONCUR.** First pitch used `contested-design` (reviewer DISSENTed: approach (a) treated as trivial). Second pitch used `architectural-pivot` (reviewer DISSENTed: single-pipeline change, not codebase-wide). Third pitch (`contested-design` with corrected cost analysis) got CONCUR. Recovery: re-pitched with each round's substantive critique addressed. **Prevention:** before pitching a scope-out, walk the four criteria definitions explicitly and pre-empt the most likely reviewer objections — particularly cost analysis for any "trivial inline" claim.
+
+## Tags
+
+category: integration-issues
+module: web-platform/infra

--- a/knowledge-base/project/plans/2026-04-29-fix-plugins-soleur-mount-empty-plan.md
+++ b/knowledge-base/project/plans/2026-04-29-fix-plugins-soleur-mount-empty-plan.md
@@ -1,0 +1,555 @@
+---
+title: "Fix /mnt/data/plugins/soleur empty-mount: silent no-op SDK plugin discovery"
+issue: 3045
+type: bug
+classification: silent-fallback
+requires_cpo_signoff: false
+created: 2026-04-29
+deepened: 2026-04-29
+branch: feat-one-shot-3045-plugins-mount
+worktree: .worktrees/feat-one-shot-3045-plugins-mount
+---
+
+# fix: populate /mnt/data/plugins/soleur on prod hosts (or remove the mount cleanly)
+
+Closes #3045.
+
+## Enhancement Summary
+
+**Deepened on:** 2026-04-29
+**Sections enhanced:** 8 (Overview, Hypotheses, Files to Edit, Files to Create, Acceptance Criteria, Test Scenarios, Sharp Edges, Alternatives)
+**Research sources used:** repo grep (deploy/canary/sudoers semantics), institutional learning `2026-03-20-docker-nonroot-user-with-volume-mounts.md`, observability surface read (`reportSilentFallback`), server entry read (`server/index.ts`), open scope-out cross-check (#2608, #2955, #2962), code-grep verification (`PLUGIN_PATH` dead-code), the canary lifecycle in `ci-deploy.sh:255-394`.
+
+### Key Improvements
+
+1. **Sequencing fix surfaced.** The seed step MUST run *before* canary launch — not "before container start" generically. The canary launches at `ci-deploy.sh:255` with `-v /mnt/data/plugins/soleur:...:ro`; if seeded after canary launch, canary itself sees an empty mount and the Layer 3 verification (which itself depends on plugin-mount-shipped scripts per line 332) cannot fire. Plan now prescribes a `docker create` + `docker cp` + `docker rm` ephemeral-container pattern that runs **between `docker pull` and the canary `docker run`**.
+2. **No sudo required.** Webhook runs as `User=deploy` with `ReadWritePaths=/mnt/data /var/lock` and cloud-init `chown -R deploy:deploy /mnt/data` at line 303 — `docker cp` invoked by deploy writes to the bind-mount source directly. Sudoers (`/etc/sudoers.d/deploy-chown`) only grants `chown 1001:1001 /mnt/data/workspaces` — narrowly scoped, do NOT widen.
+3. **Use `docker create`, not `docker exec` on a running container.** During the canary deploy, the new image's container is the canary itself (port 3001). Spinning up an ephemeral copy-only container with `docker create --name soleur-plugin-seed "$IMAGE:$TAG"` avoids racing the canary's startup AND avoids needing the canary to be running before seeding. Tear-down via `docker rm soleur-plugin-seed`.
+4. **Idempotent seed semantics.** `docker cp src/. dst/` overwrites file-by-file. To guarantee removal of stale entries from prior plugin versions, prescribe `rm -rf /mnt/data/plugins/soleur/{*,.[!.]*,..?*} 2>/dev/null || true` before the `docker cp`. Bracket glob handles both visible and dotfile entries (e.g., `.claude-plugin/`).
+5. **Three-file lockstep matches prior learning.** `2026-03-20-docker-nonroot-user-with-volume-mounts.md` documented the Dockerfile + deploy-workflow + cloud-init three-file sync rule for non-root migrations. The same rule applies here for plugin seeding — and the plan already covers all three. Cite the learning directly so the reviewer recognizes the pattern.
+6. **Convergence with #3033.** PR #3042 fixes #3033 (`apps` mount Layer 3 path); this PR fixes #3045 (`plugins` mount empty). Both touch `ci-deploy.sh` and `cloud-init.yml`. Coordination guidance moved to a top-level Sequencing section (was Sharp Edges only).
+7. **`reportSilentFallback` signature and call site validated** against `apps/web-platform/server/observability.ts:82` — `feature` is required, `op` and `extra` are optional. Plan-prescribed call signature now matches exactly.
+8. **Server entry wiring concretized.** `apps/web-platform/server/index.ts` is the entry (compiled to `dist/server/index.cjs`). The startup check fires inside `app.prepare().then(...)` callback after Sentry init (`import "../sentry.server.config"` is the first import). Plan now names the precise insertion point.
+
+### New Considerations Discovered
+
+- **Docker build-context constraint (LOAD-BEARING).** The release workflow uses `docker_context: "apps/web-platform"` (verified at `.github/workflows/web-platform-release.yml:36`), so a naive `COPY plugins/soleur /opt/soleur/plugin` in the Dockerfile would FAIL — `plugins/` is at the repo root, outside the build context. The deepen pass discovered this constraint and pivoted to a vendor-into-context pattern via a new optional `vendor_plugin` input on `reusable-release.yml`. This is the main architectural change between the original plan and the deepened plan.
+- **`.dockerignore` allowlist gap.** `apps/web-platform/.dockerignore` excludes `*.md` to keep markdown out of the runtime image. But the plugin's `.md` files (skill SKILL.md, agent prompts) ARE the plugin behavior — they MUST ship. Plan now adds two `!_plugin-vendored/**` re-include lines so the vendored tree's markdown survives the existing exclusions.
+- **The Layer 3 canary script (`canary-bundle-claim-check.sh`) is also mounted from the plugin path** per the comment at `ci-deploy.sh:332` ("the script is shipped via the read-only plugin mount"). So #3045's empty-mount fix unblocks #3033's Layer 3 visibility *and* the original SDK plugin discovery. Once both PRs land, Layer 3 actually runs against fresh plugin content for the first time since the canary system was introduced.
+- **The bind-mount being `:ro` from the container's perspective does NOT prevent host-side writes** to the bind-mount source. Host writes propagate live to the container's view (this is a kernel bind-mount property, not Docker-specific). Re-seeding while a container holds `:ro` is safe; the running container will see new content on next `readFileSync`.
+- **Cloud-init runcmd entries run under `/bin/sh` (= `dash`)**, NOT bash. The brace-expansion form `{*,.[!.]*,..?*}` is bash-only — using it in cloud-init silently produces wrong cleanup (dotfiles like `.claude-plugin/` survive). Plan now uses `find -mindepth 1 -delete` in cloud-init's seed block (POSIX-portable) and reserves the bash brace form for `ci-deploy.sh` (which has `#!/usr/bin/env bash`).
+- **Sentry is already wired via `sentry.server.config`** as the first import in `server/index.ts`. The startup check can call `reportSilentFallback` immediately during `app.prepare().then(...)` without additional Sentry boot ordering.
+- **Webhook runs as `User=deploy` with `ReadWritePaths=/mnt/data /var/lock`** (cloud-init line 173, 179) and cloud-init recursively chowns `/mnt/data` to deploy:deploy at provision (line 303). `docker cp` invoked by the deploy user can write to the bind-mount source without sudo. Sudoers grants only the narrow `chown 1001:1001 /mnt/data/workspaces` privilege — do NOT widen.
+
+## Overview
+
+Issue #3045 surfaced during #3033 verification: the bind mount
+`/mnt/data/plugins/soleur:/app/shared/plugins/soleur:ro` exists on every
+prod host and is mounted into the canary + main containers, but **nothing
+ever populates the source directory**. Cloud-init's runcmd `mkdir -p`
+creates the directory empty; no terraform `provisioner`, no CI rsync, no
+post-deploy hook, no Dockerfile `COPY` writes the plugin into it. The
+runtime callers therefore see an empty directory on every read.
+
+The downstream blast radius is larger than the issue body implies:
+
+1. `apps/web-platform/server/workspace.ts:381` symlinks
+   `<workspace>/plugins/soleur` → `/app/shared/plugins/soleur` (empty).
+2. `apps/web-platform/server/agent-runner.ts:549` reads
+   `<workspace>/plugins/soleur/.claude-plugin/plugin.json`. The file is
+   missing because the mount is empty. The catch on line 554-566 treats
+   ENOENT as "no plugin installed" and silently sets
+   `pluginMcpServerNames = []`. ENOENT is **not** mirrored to Sentry
+   (line 559: `if ((err)?.code !== "ENOENT")` — the `cq-silent-fallback`
+   rule is intentionally skipped here because ENOENT was assumed to be
+   "expected when no plugin").
+3. `apps/web-platform/server/cc-dispatcher.ts:424` does the same lookup
+   for cc-soleur-go (`pluginPath = path.join(workspacePath, "plugins",
+   "soleur")`) and feeds the SDK an empty directory.
+4. The Agent SDK launches with `pluginPath` pointing at an empty dir →
+   **no Soleur skills, no Soleur agents, no Soleur MCP servers ever
+   load in user-facing web-platform sessions**, despite the entire
+   architecture being designed for that.
+
+Issue #2608 ("plugin freshness rotation for running workspaces")
+explicitly claims: *"'Latest' is tied to image deploy cadence — when
+the container image updates, all running workspaces see the new plugin
+on the next symlink dereference."* This is the documented design intent
+— but the Dockerfile (`apps/web-platform/Dockerfile`) does **not**
+COPY the plugin into the image. The intended mechanism was either never
+implemented or lost in a refactor. The mount has been empty since the
+web-platform MVP commit `5b8e2420` (PR closing #297) — months in
+production.
+
+This plan delivers the smallest, lowest-risk fix that closes the
+investigation: **bake the plugin into the runtime image at build time
+and populate the bind-mount source from the running container at deploy
+time, with explicit verification that the mount source is non-empty
+before the canary container launches.** Removing the mount is a viable
+alternative but more invasive (changes ci-deploy.sh, cloud-init.yml, and
+the canary flow simultaneously) — see Alternatives Considered.
+
+## Research Reconciliation — Spec vs. Codebase
+
+Issue #3045 paraphrases call-site line numbers and a callable surface.
+Three reconciliations against the live codebase:
+
+| Issue claim | Codebase reality | Plan response |
+|---|---|---|
+| `cc-dispatcher.ts:387` is a mount caller | Line 387 is `fetchUserWorkspacePath`'s `await supabase()...` call. The real caller is **line 424**: `const pluginPath = path.join(workspacePath, "plugins", "soleur")`. | Plan addresses line 424 (and the symmetric line 542 in `agent-runner.ts`). |
+| `agent-runner.ts:542` is the only caller in that file | Line 542 IS a real caller. But `agent-runner.ts:55-56` *also* declares `const PLUGIN_PATH = process.env.SOLEUR_PLUGIN_PATH || "/app/shared/plugins/soleur"` — and `grep -n "\bPLUGIN_PATH\b" apps/web-platform/server/agent-runner.ts` returns only the declaration site. The constant is **dead code**. | Phase 4 deletes the unused constant in the same PR (no behavior change; reduces code-grep noise for future investigations). |
+| `workspace.ts:381-384` warns on failure rather than throwing → "best-effort no-op" | The warn is on `symlinkSync` *failure* (e.g., EEXIST race). The symlink itself **succeeds** because the target directory exists (cloud-init created it). The "no-op" framing is misleading: the symlink is created successfully and points at an empty directory. The failure mode is silent-empty, not warn-and-skip. | Phase 1 ADD a startup-time mount-populated assertion in `workspace.ts` (or a new `plugin-mount-check.ts`) that mirrors to Sentry on empty mount. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a Command Center session
+that loads but where every Soleur skill (`/soleur:plan`, `/soleur:work`,
+`/soleur:brainstorm`, etc.) is missing — the assistant returns "skill
+not found" or silently degrades to a generic Claude session. This is
+the **current production behavior** for every web-platform user (months
+of empty mount); the fix restores the advertised feature surface.
+
+**If this leaks, the user's data/workflow is exposed via:** N/A —
+populating an empty read-only mount with public plugin content does
+not expose user data. The `:ro` flag on the mount means a compromised
+container cannot write back. The plugin source is the same content
+already published to the Claude Code marketplace at
+`marketplace.json` and `plugin.json` — no secrets are introduced.
+
+**Brand-survival threshold:** none — capability gap, not a privacy or
+data-loss surface. Threshold `none` justification: this PR populates
+read-only public plugin content that is already in the open repo;
+there is no auth/credentials/data/payments/user-resources surface
+crossed, so per `plugins/soleur/skills/preflight/SKILL.md` Check 6 the
+sensitive-path regex does not fire and no scope-out bullet is required.
+
+## Hypotheses
+
+(No SSH/network-connectivity trigger keywords matched in #3045 — Phase
+1.4 network-outage checklist not required.)
+
+The empty-mount root cause is a missing population step. Three plausible
+mechanisms, listed in cost-asc order:
+
+1. **Image-baked plugin (most aligned with #2608's documented intent).**
+   `apps/web-platform/Dockerfile` `COPY plugins/soleur /opt/soleur/plugin`
+   in the runner stage; cloud-init's first deploy seeds
+   `/mnt/data/plugins/soleur` from the running container
+   (`docker cp soleur-web-platform:/opt/soleur/plugin/. /mnt/data/plugins/soleur/`).
+   Subsequent deploys re-seed via the same mechanism in `ci-deploy.sh`
+   so plugin updates ride image deploys (matches the #2608 "latest is
+   tied to image deploy cadence" contract).
+2. **CI rsync from runner to host.** Add a deploy step that rsyncs
+   `plugins/soleur/` from the GitHub Actions runner over SSH into
+   `/mnt/data/plugins/soleur` before the container starts. Adds an
+   SSH-write surface and a second source of truth (runner workspace ≠
+   image content); rejected.
+3. **Runtime fetch.** Container starts; on first request, fetches the
+   plugin from R2 / GitHub. Adds a runtime network dependency and a
+   bootstrap race; rejected.
+
+**Chosen: Hypothesis 1.** It is the only one that honors #2608's
+already-documented contract and keeps the source of truth in the
+container image (single artifact, audited via the existing image SBOM).
+
+## Files to Edit
+
+- `.github/workflows/reusable-release.yml` — add a new optional input `vendor_plugin: bool` (default `false`) and a conditional step that runs BEFORE `docker/build-push-action` when `vendor_plugin == true`:
+
+  ```yaml
+  inputs:
+    # ... existing inputs ...
+    vendor_plugin:
+      description: "Vendor plugins/soleur into <docker_context>/_plugin-vendored before build"
+      required: false
+      type: boolean
+      default: false
+  ```
+
+  ```yaml
+  - name: Vendor plugin into build context
+    if: inputs.vendor_plugin == true && inputs.docker_image != ''
+    run: |
+      set -euo pipefail
+      DEST="${{ inputs.docker_context }}/_plugin-vendored"
+      rm -rf "$DEST"
+      cp -r plugins/soleur "$DEST"
+      # Drop test/docs trees that are not needed at runtime — keeps image small
+      rm -rf "$DEST/test" "$DEST/docs/_site"
+      echo "Vendored $(find "$DEST" -type f | wc -l) plugin files"
+  ```
+
+  Place between the existing `Validate NEXT_PUBLIC_SUPABASE_ANON_KEY` step and the `Build and push Docker image` step. Step is idempotent (cleans destination first).
+
+- `.github/workflows/web-platform-release.yml` (line 36 region) — pass `vendor_plugin: true` to the reusable workflow:
+
+  ```yaml
+  with:
+    component: web-platform
+    component_display: "Soleur Web Platform"
+    path_filter: "apps/web-platform/"
+    tag_prefix: "web-v"
+    docker_image: "ghcr.io/jikig-ai/soleur-web-platform"
+    docker_context: "apps/web-platform"
+    vendor_plugin: true       # NEW (#3045)
+    bump_type: ${{ inputs.bump_type || '' }}
+    force_run: ${{ github.event_name == 'workflow_dispatch' }}
+  ```
+
+- `apps/web-platform/Dockerfile` (runner stage, after line 49) — add:
+
+  ```dockerfile
+  # Plugin baked at build time from the vendored copy in the build context (#3045).
+  # Source tree is /workflow/plugins/soleur copied to apps/web-platform/_plugin-vendored
+  # by reusable-release.yml's "Vendor plugin into build context" step.
+  COPY _plugin-vendored /opt/soleur/plugin
+  RUN chown -R 1001:1001 /opt/soleur
+  ```
+
+  Place BEFORE `USER soleur` (line 76). Mode bits inherit from source (644/755); world-readable suffices since the container reads the bind-mount under UID 1001 and the host bind-mount writer is the deploy user (different UID, but world-readable mode resolves it).
+
+- `apps/web-platform/.dockerignore` — append two lines to ensure the vendored plugin tree is NOT excluded by the existing `*.md` rule:
+
+  ```
+  # Vendored plugin tree (#3045) — must ship with all .md content (SKILL.md, agent prompts)
+  !_plugin-vendored
+  !_plugin-vendored/**
+  ```
+
+  `.dockerignore` allowlist semantics: `!` re-includes paths that prior patterns excluded. Without these, the existing `*.md` line at the top would strip the plugin's skill/agent markdown content even though the directory is allowed.
+
+- `.gitignore` (root) — add `apps/web-platform/_plugin-vendored/` so a developer's local `docker build` (which they may run manually for debugging) doesn't bloat git diffs. The vendor step is CI-only in normal flows, but local-dev parity matters for repro.
+
+- Local-dev documentation (where the existing build commands live — likely `apps/web-platform/README.md`, `CONTRIBUTING.md`, or the project root README) — add a one-liner: "If building the web-platform image locally, first run `cp -r plugins/soleur apps/web-platform/_plugin-vendored` from the repo root." Defer to work-phase to locate the right doc anchor.
+
+- `apps/web-platform/infra/cloud-init.yml` — after `docker pull ${image_name}` at line 347 and before the production `docker run -d` at line 366, add a seed block:
+
+  ```yaml
+  # Seed /mnt/data/plugins/soleur from the image's baked plugin tree (#3045).
+  # Ephemeral container so we don't depend on a long-running container.
+  # `docker cp src/.` copies *contents* (not the src dir itself) into dst.
+  - |
+    set -e
+    docker create --name soleur-plugin-seed ${image_name}
+    rm -rf /mnt/data/plugins/soleur/{*,.[!.]*,..?*} 2>/dev/null || true
+    docker cp soleur-plugin-seed:/opt/soleur/plugin/. /mnt/data/plugins/soleur/
+    docker rm soleur-plugin-seed
+  ```
+
+  The `set -e` confines the failure scope to just this step (cloud-init runcmd entries are otherwise newline-separated and continue on failure). `mkdir -p /mnt/data/plugins/soleur` at line 299 already runs earlier in the same runcmd block — the dir exists by the time this block fires.
+
+- `apps/web-platform/infra/ci-deploy.sh` — after `docker pull` of the new image (insert between the existing pull step and `docker run -d --name soleur-web-platform-canary` at line 255). The deploy user owns `/mnt/data/plugins/soleur`, so no `sudo` is needed. The `set -e` at the script level (the existing `trap` at line 246 captures non-zero exits) means a failed seed step rolls the deploy back via `final_write_state 1 "plugin_seed_failed"`. New CI deploy path:
+
+  ```bash
+  echo "Seeding plugin mount from image..."
+  if ! docker create --name soleur-plugin-seed "$IMAGE:$TAG" >/dev/null; then
+    final_write_state 1 "plugin_seed_create_failed"
+    exit 1
+  fi
+  rm -rf /mnt/data/plugins/soleur/{*,.[!.]*,..?*} 2>/dev/null || true
+  if ! docker cp soleur-plugin-seed:/opt/soleur/plugin/. /mnt/data/plugins/soleur/; then
+    docker rm soleur-plugin-seed >/dev/null 2>&1 || true
+    final_write_state 1 "plugin_seed_copy_failed"
+    exit 1
+  fi
+  docker rm soleur-plugin-seed >/dev/null
+  ```
+
+  Sequencing constraint: this MUST run before the canary `docker run` (line 255) so the canary itself sees a populated mount on first read.
+
+- `apps/web-platform/server/agent-runner.ts` — delete lines 55-56 (`const PLUGIN_PATH = ...`). Verify with `grep -n '\bPLUGIN_PATH\b' apps/web-platform/` returns zero matches after the edit (the constant is unreferenced; deletion is mechanical dead-code removal). Do this in the same PR so future plan-grep on the symbol returns one obvious answer.
+
+- `apps/web-platform/server/index.ts` — inside the `app.prepare().then(() => { ... })` callback at the existing top-level (line ~42), call `verifyPluginMountOnce()` from the new module before `setupWebSocket(server)`. This places the check after Sentry init (the file's first import is `../sentry.server.config`) but before the WebSocket loop is accepting connections — we want the Sentry event to fire even if subsequent server boot fails. Single line: `verifyPluginMountOnce();` (sync, fast — `readdirSync` on a small directory).
+
+## Files to Create
+
+- `apps/web-platform/server/plugin-mount-check.ts` — new module:
+
+  ```ts
+  import { existsSync, readdirSync } from "fs";
+  import { join } from "path";
+  import { reportSilentFallback } from "./observability";
+  import { createChildLogger } from "./logger";
+
+  const log = createChildLogger("plugin-mount");
+
+  function getPluginPath(): string {
+    return process.env.SOLEUR_PLUGIN_PATH || "/app/shared/plugins/soleur";
+  }
+
+  let _checked = false;
+
+  /**
+   * One-shot startup verification that the plugin bind-mount source has
+   * been populated by the deploy script. Runs once per process; subsequent
+   * calls are no-ops. Mirrors the empty-mount degraded condition to Sentry
+   * via `reportSilentFallback` so a regression in the deploy seed step is
+   * visible in dashboards instead of being a silent feature drop. See #3045.
+   */
+  export function verifyPluginMountOnce(): void {
+    if (_checked) return;
+    _checked = true;
+
+    const pluginPath = getPluginPath();
+
+    if (!existsSync(pluginPath)) {
+      reportSilentFallback(null, {
+        feature: "plugin-mount",
+        op: "discovery",
+        message: "plugin-mount path missing",
+        extra: { path: pluginPath },
+      });
+      log.error({ path: pluginPath }, "Plugin mount path does not exist");
+      return;
+    }
+
+    let entries: string[] = [];
+    try {
+      entries = readdirSync(pluginPath);
+    } catch (err) {
+      reportSilentFallback(err, {
+        feature: "plugin-mount",
+        op: "discovery",
+        extra: { path: pluginPath },
+      });
+      log.error({ err, path: pluginPath }, "Plugin mount unreadable");
+      return;
+    }
+
+    if (entries.length === 0) {
+      reportSilentFallback(null, {
+        feature: "plugin-mount",
+        op: "discovery",
+        message: "plugin-mount empty",
+        extra: { path: pluginPath },
+      });
+      log.error({ path: pluginPath }, "Plugin mount is empty");
+      return;
+    }
+
+    const manifest = join(pluginPath, ".claude-plugin", "plugin.json");
+    if (!existsSync(manifest)) {
+      reportSilentFallback(null, {
+        feature: "plugin-mount",
+        op: "discovery",
+        message: "plugin-mount manifest missing",
+        extra: { path: pluginPath, manifest },
+      });
+      log.error({ manifest }, "Plugin mount missing .claude-plugin/plugin.json");
+      return;
+    }
+
+    log.info({ path: pluginPath, entries: entries.length }, "Plugin mount OK");
+  }
+
+  /** Test-only memoization reset. Not exported from server entry. */
+  export function _resetForTesting(): void {
+    _checked = false;
+  }
+  ```
+
+  Three-state Sentry signal (path-missing / empty / manifest-missing) lets dashboards distinguish "Hetzner volume failed to attach" from "deploy seed step skipped" from "deploy ran but image didn't COPY the plugin." All three produce `feature: "plugin-mount", op: "discovery"`; the `message` and `extra.path/manifest` fields differentiate. Verified `reportSilentFallback` signature against `apps/web-platform/server/observability.ts:82` — `feature` required, `op`/`extra`/`message` optional.
+
+- `apps/web-platform/test/plugin-mount-check.test.ts` — Vitest covering:
+  - **Scenario A (path missing):** `SOLEUR_PLUGIN_PATH=/nonexistent` → `reportSilentFallback` mock called once with `feature: "plugin-mount", op: "discovery"`, message `"plugin-mount path missing"`.
+  - **Scenario B (empty):** point at a temp dir created with `mkdirSync` and not populated → fires with message `"plugin-mount empty"`.
+  - **Scenario C (manifest missing):** point at a temp dir with one stray file but no `.claude-plugin/plugin.json` → fires with `"plugin-mount manifest missing"`.
+  - **Scenario D (populated):** create temp dir with `.claude-plugin/plugin.json` → no Sentry call, `log.info` fired.
+  - **Scenario E (memoization):** call `verifyPluginMountOnce()` twice with empty dir → mock called exactly once.
+
+  Use `vi.mock("./observability")` to spy on `reportSilentFallback`. Use `tmpdir()` + `randomUUID()` for fixture paths. Wire `_resetForTesting()` in `beforeEach`.
+
+- `apps/web-platform/infra/test/cloud-init-plugin-seed.test.sh` — bash test in the existing `*.test.sh` pattern (sibling of `ci-deploy.test.sh`):
+
+  ```bash
+  #!/usr/bin/env bash
+  set -euo pipefail
+  TMP=$(mktemp -d)
+  trap 'rm -rf "$TMP"; docker rm -f soleur-plugin-seed-test >/dev/null 2>&1 || true' EXIT
+
+  # Build a tiny image with a synthetic plugin tree
+  cat > "$TMP/Dockerfile" <<'EOF'
+  FROM busybox
+  RUN mkdir -p /opt/soleur/plugin/.claude-plugin && \
+      echo '{"name":"soleur-test"}' > /opt/soleur/plugin/.claude-plugin/plugin.json && \
+      mkdir -p /opt/soleur/plugin/skills/test && \
+      echo "stub" > /opt/soleur/plugin/skills/test/SKILL.md
+  EOF
+  docker build -t soleur-plugin-seed-test:fixture "$TMP" >/dev/null
+
+  # Pre-populate the bind-mount target with stale content to verify cleanup
+  TARGET="$TMP/mnt/data/plugins/soleur"
+  mkdir -p "$TARGET"
+  echo "stale" > "$TARGET/stale-file.txt"
+  mkdir -p "$TARGET/.stale-dir"
+
+  # Run the seed sequence (verbatim from ci-deploy.sh)
+  docker create --name soleur-plugin-seed-test soleur-plugin-seed-test:fixture >/dev/null
+  rm -rf "$TARGET"/{*,.[!.]*,..?*} 2>/dev/null || true
+  docker cp soleur-plugin-seed-test:/opt/soleur/plugin/. "$TARGET/"
+  docker rm soleur-plugin-seed-test >/dev/null
+
+  # Assertions
+  test -f "$TARGET/.claude-plugin/plugin.json" || { echo "FAIL: manifest missing"; exit 1; }
+  test -f "$TARGET/skills/test/SKILL.md" || { echo "FAIL: skill stub missing"; exit 1; }
+  test ! -e "$TARGET/stale-file.txt" || { echo "FAIL: stale file remained"; exit 1; }
+  test ! -e "$TARGET/.stale-dir" || { echo "FAIL: stale dotdir remained"; exit 1; }
+  echo "PASS: cloud-init-plugin-seed"
+  ```
+
+  Test must be runnable locally (Docker available) and via the `apps/web-platform/infra/ci-deploy.test.sh` harness. Skip if Docker is unavailable (CI runner without docker-in-docker) — emit `SKIP: docker not available` and exit 0.
+
+## Open Code-Review Overlap
+
+Two open scope-outs touch the modified files:
+
+- **#2962** — *review: extract memoized getServiceClient() shared lazy singleton* (touches `agent-runner.ts`, `cc-dispatcher.ts`). **Disposition: Acknowledge.** Different concern (Supabase service-client memoization vs. plugin mount); refactor scope is orthogonal and would unnecessarily inflate this PR. The scope-out remains open.
+- **#2955** — *arch: process-local state assumption needs ADR + startup guard* (touches `agent-runner.ts`, `cc-dispatcher.ts`). **Disposition: Acknowledge with reuse hint.** This plan adds a new process-local one-shot check (`verifyPluginMountOnce` memoization). When #2955's startup-guard architecture lands, the new check should be migrated to that pattern. Note in this PR's body so the reviewer of #2955 can fold it in.
+- **#2608** — *ops: plugin freshness rotation for running workspaces* (parent design issue). **Disposition: Fold reference; do not fold scope.** This PR delivers the prerequisite #2608 assumed (image-baked plugin) but does NOT implement the rotation API #2608 describes. After this lands, #2608's re-evaluation criterion ("first time a plugin hotfix needs to land faster than container deploy permits") becomes meaningful for the first time. Add a comment on #2608 noting this dependency was unmet and is now met.
+
+## Sequencing & Coordination
+
+This PR and PR #3042 (#3033 fix) both modify `ci-deploy.sh` and `cloud-init.yml`. They are independent corrections to the same deploy flow but textually adjacent. Recommended sequencing:
+
+1. **Land #3042 first** (#3033 Layer 3 mount fix) — adds an `apps` mount which is independent of plugin mount semantics.
+2. **Rebase this PR on `main` after #3042 merges** — should be a clean rebase since the two PRs touch different lines of `ci-deploy.sh` (the canary `docker run` block at line 255 vs. the new pre-canary seed block this PR adds).
+3. **If this PR lands first** instead, #3042 must rebase. Either order works; the earlier-merger does not need rebase.
+
+**Composite verification (post both merges):** with both `apps` and `plugins` mounts populated, the Layer 3 canary should run for the first time since the canary system was introduced. Expect the first deploy after both land to take an extra ~15 seconds for the new probe and to either pass or surface a real Layer 3 finding (which would then be worked as a separate issue).
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [x] `apps/web-platform/Dockerfile` runner stage COPYs `_plugin-vendored` to `/opt/soleur/plugin` with `chown -R 1001:1001 /opt/soleur` BEFORE the `USER soleur` line; image build succeeds locally via `cd apps/web-platform && cp -r ../../plugins/soleur _plugin-vendored && docker build .` (the manual vendor step replicates what CI does).
+- [x] `.github/workflows/reusable-release.yml` adds the `vendor_plugin` input (default false) and the conditional vendor step BEFORE `docker/build-push-action`; `web-platform-release.yml` passes `vendor_plugin: true`.
+- [x] `apps/web-platform/.dockerignore` re-includes `_plugin-vendored/**` so plugin markdown content is NOT excluded by the existing `*.md` rule.
+- [x] `.gitignore` includes `apps/web-platform/_plugin-vendored/` to prevent accidental commits of the vendored tree.
+- [x] `cloud-init.yml` and `ci-deploy.sh` contain the seed block (`docker create` + `rm -rf`/`find -mindepth 1 -delete` + `docker cp` + `docker rm`) BEFORE the canary `docker run` block; the seed step exits 0 against a synthetic container (per `cloud-init-plugin-seed.test.sh`).
+- [x] The `rm -rf /mnt/data/plugins/soleur/{*,.[!.]*,..?*}` glob is verified by `cloud-init-plugin-seed.test.sh` (test pre-populates target with both `.stale-dir` and `stale-file.txt`, asserts both are removed by the cleanup step).
+- [x] `agent-runner.ts:55-56` `PLUGIN_PATH` constant is removed; `grep -rn '\bPLUGIN_PATH\b' apps/web-platform/` returns zero matches outside vendored/`node_modules`/`.next`.
+- [x] `apps/web-platform/server/index.ts` calls `verifyPluginMountOnce()` inside `app.prepare().then(...)` before `setupWebSocket(server)`.
+- [x] `apps/web-platform/test/plugin-mount-check.test.ts` covers all five scenarios (path-missing / empty / manifest-missing / populated / memoization) and passes under `npx vitest run test/plugin-mount-check.test.ts` (5/5 ✓).
+- [x] `apps/web-platform/infra/cloud-init-plugin-seed.test.sh` passes against the synthetic-image fixture (PASS local; skips cleanly if Docker is unavailable). Note: located alongside the other `*.test.sh` files at `apps/web-platform/infra/`, not in a `test/` subdir, to match the existing convention (`ci-deploy.test.sh`, `disk-monitor.test.sh`).
+- [x] `npx vitest run` in `apps/web-platform/` is green: 3018 passed | 11 skipped (3029) — no regression in adjacent suites.
+- [x] `npx tsc --noEmit` clean (exit 0).
+- [x] No new dependencies added.
+- [x] Plan-derived globs verified at plan time: `git ls-files apps/web-platform/server | grep -E 'workspace\.ts$|agent-runner\.ts$|cc-dispatcher\.ts$|index\.ts$|observability\.ts$'` returns 5 matches.
+- [x] `git ls-files apps/web-platform/infra | grep -E 'cloud-init\.yml$|ci-deploy\.sh$'` returns 2 matches.
+- [x] PR body uses `Closes #3045` (population is automated end-to-end via image + ci-deploy — no operator-only step gates closure).
+- [x] PR body cross-references #3033/#3042 in the Sequencing section so reviewers can confirm rebase order.
+
+### Post-merge (operator)
+
+- [ ] First deploy after merge: monitor `journalctl -u webhook -f` on `app.soleur.ai` and confirm the seed step prints `Seeding plugin mount from image...` and exits 0.
+- [ ] SSH `app.soleur.ai` (deploy user) and run `ls /mnt/data/plugins/soleur/.claude-plugin/plugin.json` — must exist and be readable.
+- [ ] `docker exec soleur-web-platform ls /app/shared/plugins/soleur/.claude-plugin/plugin.json` — must exist and be readable as UID 1001 (canary readability check).
+- [ ] **Sentry:** in the 60 minutes following first post-merge deploy, confirm zero new `feature: "plugin-mount"` events. (Pre-merge baseline establishes the existing-empty-mount fire rate as the proof-of-fire signal — confirm at least one event was captured by the new code on a host that hasn't yet been re-deployed.)
+- [ ] Run a Command Center session against `app.soleur.ai` and execute `/soleur:help` — output MUST list non-zero commands/skills (current behavior: empty list / "skill not found"). This is the user-facing acceptance.
+- [ ] Comment on #2608 with: "PR #<this> delivered image-baked plugin (the prerequisite #2608 implicitly assumed). The 're-evaluation criterion' (plugin hotfix faster than container deploy) is now genuinely actionable since the bind-mount is populated and refresh is a single `docker cp` away."
+- [ ] If this is the first deploy where Layer 3 canary actually executes (PR #3042 also merged), document the Layer 3 outcome in the deploy postmortem — pass or surface a real finding to triage separately.
+
+## Test Scenarios
+
+### Scenario A — Empty mount fires Sentry on boot (the load-bearing regression guard)
+
+**Given** `/app/shared/plugins/soleur` is empty (mount source not seeded), **when** the server process starts, **then** `verifyPluginMountOnce` fires exactly one `reportSilentFallback` with `feature: "plugin-mount"`.
+
+### Scenario B — Populated mount is silent
+
+**Given** `/app/shared/plugins/soleur/.claude-plugin/plugin.json` exists and is readable, **when** the server starts, **then** `verifyPluginMountOnce` returns silently (no Sentry event, no error log).
+
+### Scenario C — Idempotent re-seed across deploys
+
+**Given** `/mnt/data/plugins/soleur` already contains stale plugin content from a prior deploy, **when** `ci-deploy.sh` runs the seed step against the new image, **then** the destination contains the new image's content and the operation exits 0 (no "destination not empty" failure).
+
+### Scenario D — Permission compatibility with `:ro` mount and UID 1001
+
+**Given** the mount is populated by `docker cp` (writes as deploy:deploy on host since the webhook runs `User=deploy`, NOT root), **when** the container starts with `-v /mnt/data/plugins/soleur:/app/shared/plugins/soleur:ro` and runs as soleur UID 1001, **then** `readFileSync` from inside the container succeeds because `docker cp` preserves the source mode bits (which are 644/755 from the Dockerfile `chown -R 1001:1001 /opt/soleur` step) and `:ro` does not strip read permission. Test via `cloud-init-plugin-seed.test.sh` extended assertion: after seed, `stat -c '%a %U %G' /mnt/data/plugins/soleur/.claude-plugin/plugin.json` returns mode bits with at least the `4` bit set in the world position.
+
+### Scenario E — Cloud-init shell portability
+
+**Given** `cloud-init.yml` uses `- |` block scalars (executed by Ubuntu's `/bin/sh` = `dash`, no brace expansion), **when** the seed block runs at first boot, **then** the `find /mnt/data/plugins/soleur -mindepth 1 -delete` cleanup executes correctly (POSIX-portable). Negative test: a fixture that uses `{*,.[!.]*,..?*}` under `dash` would silently leave dotfiles. Add a shellcheck assertion in CI that catches `bash`-only constructs in cloud-init `- |` blocks.
+
+### Scenario F — Sequencing under canary failure
+
+**Given** the seed step succeeds but the canary fails downstream (e.g., bwrap sandbox check fails), **when** rollback fires, **then** the plugin mount remains populated with the new content (no automatic rollback of the bind-mount). This is acceptable: the prior production container still serves on port 80 and reads from the same mount; if the new content is incompatible with the old code, this would surface as a separate runtime issue. Document in the deploy runbook: a rolled-back deploy leaves the plugin mount at the *attempted* version, not the prior version. Operator may choose to re-run a `docker cp` from a known-good prior image if needed (out of scope for this PR; tracked under #2608's rotation work).
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected — infrastructure/tooling change.
+The plugin content is already public, plugin distribution does not
+touch auth/credentials/data/payments. CTO is implicitly relevant
+(Dockerfile + ci-deploy + cloud-init touch architecture) but the
+change is a single-PR three-line fix to a documented design intent —
+no domain-leader Task spawn is justified per Phase 0.5 brainstorm
+gate (no new capability surface, no new vendor, no new data flow).
+
+## Sharp Edges
+
+- **Bash brace-glob with dotfiles.** `rm -rf /mnt/data/plugins/soleur/{*,.[!.]*,..?*}` is the canonical pattern to match all entries including dotfiles while excluding `.` and `..`. A naive `rm -rf /mnt/data/plugins/soleur/*` leaves `.claude-plugin/` (which is the plugin's load-bearing directory!) on the bind-mount source, producing stale-plus-fresh hybrid content. **Verify the glob matches before merging:** `bash -c 'set -- /tmp/test/{*,.[!.]*,..?*}; echo "$@"'` against a fixture with both `regular.txt` and `.dotfile`.
+
+- **`docker cp` and trailing slashes — load-bearing.** `docker cp src/. dst/` copies *contents* of `src` into `dst`. `docker cp src dst` (no trailing `/.`) copies `src` *as a child* of `dst`, producing `dst/plugin/.claude-plugin/...` instead of `dst/.claude-plugin/...`. The mount is bound at `/app/shared/plugins/soleur` so the manifest must be at `${mount}/.claude-plugin/plugin.json`, not `${mount}/plugin/.claude-plugin/plugin.json`. The `cloud-init-plugin-seed.test.sh` fixture asserts the correct destination layout.
+
+- **Read-only mount + host writes.** `:ro` flags apply to the container's view of the bind mount, NOT the host's view. Host-side writes to `/mnt/data/plugins/soleur` propagate live to the container's view (Linux kernel bind-mount property). Re-seeding while a container holds the mount `:ro` is safe and visible to the running container immediately. `existsSync` / `readFileSync` from inside the container will pick up new content on next call.
+
+- **`docker create` is not `docker run`.** `docker create` instantiates a container without starting it — it never executes `CMD`, never opens sockets, never claims ports. We use `docker create` precisely because we don't want a running second instance of the new image during the canary deploy. Cleanup is `docker rm` (no `--force` needed since the container was never running).
+
+- **Image-build context and `COPY plugins/soleur`.** The `Dockerfile` lives at `apps/web-platform/Dockerfile` but the build context is the **repo root** (per `web-platform-release.yml`). `COPY plugins/soleur /opt/soleur/plugin` therefore resolves correctly. Verify by checking the existing `web-platform-release.yml` build step uses `context: .` — if it uses `context: apps/web-platform/`, the COPY would fail and the plan must change to a multi-stage approach.
+
+- **Symlink-traversal vs. bind-mount in `verifyPluginMountOnce`.** `existsSync` and `readdirSync` follow symlinks transparently, which is what we want here — `<workspace>/plugins/soleur` is a symlink in user workspaces, but the startup check looks at the source-of-truth path (`SOLEUR_PLUGIN_PATH` or `/app/shared/plugins/soleur`) which is the bind-mount target itself, not a symlink. No `realpathSync` needed.
+
+- **`agent-runner.ts:559` ENOENT-skip is intentionally NOT promoted to Sentry.** The ENOENT path remains silent because per-user `plugin.json` reads happen on every session start; with the empty-mount fix in place, ENOENT is a transient condition (not steady-state). The new startup check (`verifyPluginMountOnce`) fires the Sentry signal exactly once per process boot — the right cardinality. Do NOT remove the catch in `agent-runner.ts`; do NOT add `reportSilentFallback` there. The two layers are complementary.
+
+- **`Closes #3045` is correct, NOT `Ref #3045`.** The ops-remediation rule (`closes-vs-ref` for ops PRs) applies when the fix executes post-merge and the AC is operator-only. Here the fix lands in the image at merge time AND ci-deploy.sh seeds the mount on the next deploy automatically — no operator action gates closure. Standard `Closes #N` semantics apply.
+
+- **`PLUGIN_PATH` dead-code removal pre-flight.** Before deleting `agent-runner.ts:55-56`, run `grep -rn '\bPLUGIN_PATH\b' apps/web-platform/server/` to re-verify zero usages (the symbol might be re-imported by a sibling change between plan-time and work-time). The grep is the load-bearing safety check, not the deletion itself.
+
+- **User-Brand Impact threshold gate.** Section is present, threshold is `none` with non-empty reason, sensitive-path regex (`apps/web-platform/(server|supabase|...)`) DOES match the modified server-path files — but the change populates a public read-only mount (no auth/credentials/data/payments) so the `threshold: none, reason: ...` scope-out bullet is justified per preflight Check 6. Verified `## User-Brand Impact` block contains the required `If this lands broken / If this leaks / Brand-survival threshold` lines and the scope-out bullet.
+
+- **Bash glob expansion under `set -e` in cloud-init.** Cloud-init runcmd entries are executed by `sh -c`, not `bash`. The brace expansion `{*,.[!.]*,..?*}` is a **bash extension**, NOT POSIX sh. The seed block uses an explicit `- |` multi-line entry which cloud-init runs as a single shell invocation under whatever shell is the entry's shebang (defaults to `/bin/sh`, which on Ubuntu is `dash` — no brace expansion). **Mitigation:** the seed block must start with `set -e` AND use `bash -c '...'` to wrap the brace-glob, OR use a shell-portable form: `find /mnt/data/plugins/soleur -mindepth 1 -delete`. The `find -delete` form is portable and equivalent. Plan-time choice: use `find -mindepth 1 -delete` in cloud-init's `- |` block; the bash-specific brace expansion stays only in `ci-deploy.sh` which is run as `bash` per its shebang.
+
+  **Update prescribed cloud-init seed block:**
+
+  ```yaml
+  - |
+    set -e
+    docker create --name soleur-plugin-seed ${image_name}
+    find /mnt/data/plugins/soleur -mindepth 1 -delete 2>/dev/null || true
+    docker cp soleur-plugin-seed:/opt/soleur/plugin/. /mnt/data/plugins/soleur/
+    docker rm soleur-plugin-seed
+  ```
+
+  **`ci-deploy.sh` keeps the bash brace-glob form** (its shebang is `#!/usr/bin/env bash` — verify before merging).
+
+- **Verbatim string literal: `feature: "plugin-mount"`, `op: "discovery"`.** Used in (a) `plugin-mount-check.ts` (5 sites: 4 `reportSilentFallback` calls + 1 future regression-baseline note), (b) `plugin-mount-check.test.ts` (5 assertions), (c) Acceptance Criteria post-merge step ("Sentry: confirm zero `feature: \"plugin-mount\"` events"). Grep-confirm one canonical pair across all sites before merging — drift between code and tests is the highest-risk class for this plan per the deepen-plan quality checklist.
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons | Verdict |
+|---|---|---|---|
+| Remove the mount entirely; rely on the image's `/opt/soleur/plugin` directly via a `SOLEUR_PLUGIN_PATH=/opt/soleur/plugin` env var; delete the bind-mount + symlink. | Simpler steady state; one source of truth (image only); honors #2608's "deploy cadence" contract trivially. | Breaks the rotation-without-redeploy story #2608 wants to preserve as a re-evaluation option. Larger blast radius (touches both apps and infra). Loses the per-host plugin-update surface that future hotfix automation may need. | Rejected. #2608 explicitly wants the bind-mount to remain so a future API endpoint can re-point/refresh it without a container redeploy. |
+| Run `git clone` of the soleur repo at cloud-init time into `/mnt/data/plugins/soleur`. | No image change; no docker cp dance. | Adds a runtime auth dependency (GitHub token at provision time); tight coupling between host-bootstrap and a private-vs-public repo decision; provision-time network dependency. | Rejected. |
+| GitHub Actions step rsyncs `plugins/soleur/` from the runner over SSH to the host before container start. | Decouples plugin version from image version (potential ops upside). | Adds an SSH-write surface; second source of truth (runner workspace ≠ image); `hr-all-infrastructure-provisioning-servers` rule prefers Terraform-style flows over SSH writes. | Rejected. Defer until #2608's rotation-API plan is written. |
+
+## Out of Scope (Deferred)
+
+- **Per-host plugin rotation API** — tracked by #2608. This PR is the
+  prerequisite (image-baked plugin); the rotation surface itself is
+  out-of-scope here. Re-evaluate per #2608's existing criterion.
+- **Plugin-version pinning per workspace** — not requested by #3045.
+  All workspaces continue to symlink to a single shared path.
+- **Cleaning up legacy stale `/mnt/data/plugins/soleur` content on
+  existing prod hosts** — `docker cp` overwrites in place; explicit
+  cleanup is unnecessary. Re-seed is idempotent.
+
+## Why this is filed separately from #3033
+
+Per `wg-when-an-audit-identifies-pre-existing` — pre-existing issues
+identified during investigation get tracked, not folded into the current
+PR. The #3033 fix is scoped to the `apps` mount (Layer 3 canary script
+visibility); the `plugins` mount is a separate (and possibly older)
+configuration drift. Both share `ci-deploy.sh` and may textually
+conflict at merge — see Sharp Edges.

--- a/knowledge-base/project/specs/feat-one-shot-3045-plugins-mount/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-3045-plugins-mount/session-state.md
@@ -1,0 +1,26 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-one-shot-3045-plugins-mount/knowledge-base/project/plans/2026-04-29-fix-plugins-soleur-mount-empty-plan.md
+- Status: complete
+
+### Errors
+None
+
+### Decisions
+- Root-cause framing: empty `/mnt/data/plugins/soleur` mount silently empty since web-platform MVP (commit `5b8e2420`). All real callers (`agent-runner.ts:542`, `cc-dispatcher.ts:424`) traverse a per-workspace symlink → empty dir → ENOENT silent-skip → zero Soleur skills/agents/MCP servers ever load in user sessions. Issue #2608 documents intended-but-never-implemented "image-baked plugin" contract.
+- Reconciliation against issue body: issue claimed `cc-dispatcher.ts:387` (actually line 424); claimed `agent-runner.ts:542` is the only caller in that file (line 55-56 also declares a dead `PLUGIN_PATH` constant — plan removes it).
+- Architectural pivot: Docker build context is `apps/web-platform/` per `.github/workflows/web-platform-release.yml:36`, so naive `COPY plugins/soleur` would fail. Plan adds a `vendor_plugin` opt-in input to `reusable-release.yml` that vendors `plugins/soleur` → `apps/web-platform/_plugin-vendored` before docker build. `.dockerignore` re-includes vendored tree to escape `*.md` exclusion. `.gitignore` covers local-dev parity.
+- Sequencing fix: seed step uses `docker create` + `docker cp` + `docker rm` against an ephemeral container (NOT a running canary) and runs BEFORE canary `docker run` at `ci-deploy.sh:255`, so canary sees populated mount on first read. Also unblocks #3033/#3042's Layer 3 verification.
+- Shell portability: cloud-init `- |` blocks run under `/bin/sh` (= `dash` on Ubuntu) — bash brace-expansion is bash-only. Plan uses `find -mindepth 1 -delete` in cloud-init and reserves bash glob for `ci-deploy.sh` (bash shebang).
+- Observability cardinality: new `verifyPluginMountOnce()` fires `reportSilentFallback({ feature: "plugin-mount", op: "discovery" })` exactly once per process boot with three differentiated messages. Existing `agent-runner.ts:559` ENOENT-skip stays silent (per-user, complementary cardinality).
+- Code-review overlap: #2608 (parent design, fold reference), #2955 (process-local state ADR, acknowledge with reuse hint), #2962 (memoized service-client extraction, orthogonal).
+- User-Brand Impact: threshold `none` — public read-only plugin content, no auth/credentials/data/payments surface. Phase 4.6 gate passed.
+
+### Components Invoked
+- skill: soleur:plan
+- skill: soleur:deepen-plan
+- Bash, Read, Write, Edit
+- Phase 4.6 User-Brand Impact gate: passed
+- Phase 4.5 network-outage trigger: did not match
+- Institutional learnings consulted: `2026-03-20-docker-nonroot-user-with-volume-mounts.md`, `2026-02-09-plugin-staleness-audit-patterns.md`


### PR DESCRIPTION
## Summary

Populates `/mnt/data/plugins/soleur` on prod hosts so the Soleur Agent SDK can
load skills/agents/MCP servers in user-facing web-platform sessions. The mount
has been silently empty since the web-platform MVP commit (`5b8e2420`) — every
session was returning "skill not found" or degrading to a generic Claude.

- Vendor plugin tree into `apps/web-platform/_plugin-vendored` at build time, `COPY` into image at `/opt/soleur/plugin`, then seed `/mnt/data/plugins/soleur` from an ephemeral container at deploy time (`docker create` + `docker cp src/.` + `docker rm`).
- Sentinel file `.seed-complete` written **after** `docker cp` returns 0 — distinguishes a SIGKILL-mid-cp partial copy from a healthy mount. Boot probe (`verifyPluginMountOnce`) fires `reportSilentFallback` to Sentry on missing path / empty / manifest-missing / partial-seed states.
- Three-file lockstep (Dockerfile, ci-deploy.sh, cloud-init.yml) unified on POSIX `find -mindepth 1 -delete` so bash + dash paths exercise the same cleanup form.

## User-Brand Impact

**Brand-survival threshold:** `none` — capability gap, not a privacy or
data-loss surface. The mount is `:ro` and contains the same public plugin
content already published to the marketplace; no auth/credentials/data/
payments/user-resources surface is crossed.

**If this lands broken:** session loads but every Soleur skill returns
"skill not found" — i.e., the current production behavior for every
web-platform user (months of empty mount). The fix restores the advertised
feature surface.

**If this leaks:** N/A — populating a read-only public-content mount does
not expose user data. The `:ro` flag prevents container write-back.

## Test plan

- [x] Unit: `apps/web-platform/test/plugin-mount-check.test.ts` — 6 vitest scenarios (path missing / empty / manifest missing / partial seed / fully-seeded / memoization) using `vi.resetModules()` + dynamic import (no test-only `_resetForTesting` export).
- [x] Integration: `apps/web-platform/infra/cloud-init-plugin-seed.test.sh` — builds a fixture image, runs the seed sequence verbatim, asserts manifest + skill stub + sentinel land, stale dotfiles removed, manifest mode bits include world-read, `:ro` UID-1001 readability via `docker run --user 1001:1001 -v target:/p:ro busybox`.
- [x] Multi-agent review (8 reviewers + semgrep + test-design + simplicity) — findings fixed inline; one finding (#3053, empty-mount window during deploy) scope-out as `contested-design` with reviewer CONCUR; durable fix deferred to #2608's plugin-rotation API.
- [x] Compound learning recorded: `knowledge-base/project/learnings/2026-04-29-bind-mount-seed-detection-needs-late-sentinel.md` (key insight: late-extracted payload file ≠ post-success sentinel).

Closes #3045
Ref #3053 (deferred: empty-mount window during deploy)
Ref #2608 (plugin freshness rotation API — durable design venue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
