### PR TITLE
fix(web-platform): exclude .ts from vendored plugin docker context (#3045)

### DIFF
--- a/apps/web-platform/.dockerignore
+++ b/apps/web-platform/.dockerignore
@@ -25,13 +25,22 @@ Dockerfile
 .dockerignore
 docker-compose*.yml
 
-# Vendored plugin tree (#3045) — must ship with the file types listed below
-# (skill markdown, manifests, templates, scripts). Last-match-wins
-# semantics mean a blanket `!_plugin-vendored/**` would also re-include the
-# `.env*`, `*.pem`, `node_modules/`, and `.git/` excludes from earlier in
-# this file. Use a positive allowlist instead so a stray credential or
-# dependency tree under plugins/soleur cannot be baked into the image.
+# Vendored plugin tree (#3045) — allowlist specific file types only.
+#
+# `!_plugin-vendored/` (bare directory bang) is a *recursive* re-include in
+# Docker .dockerignore semantics: it pulls in ALL children regardless of
+# extension, so the per-extension lines below it become no-ops. The Bun-
+# specific `import.meta.path` in plugins/soleur/skills/ux-audit/scripts/
+# bot-fixture.ts then trips Next.js's strict TS pass during `npm run build`
+# — the 1edf7a62 release failed for exactly this reason.
+#
+# Correct allowlist pattern: exclude everything inside the dir first, then
+# bang specific patterns we ship. Children of an excluded dir are reachable
+# only when the dir itself is also banged back in (`!_plugin-vendored/`).
+_plugin-vendored/**
 !_plugin-vendored/
+!_plugin-vendored/**/.claude-plugin/
+!_plugin-vendored/**/.claude-plugin/**
 !_plugin-vendored/**/*.md
 !_plugin-vendored/**/*.json
 !_plugin-vendored/**/*.njk
@@ -39,4 +48,3 @@ docker-compose*.yml
 !_plugin-vendored/**/*.yaml
 !_plugin-vendored/**/*.sh
 !_plugin-vendored/**/*.txt
-!_plugin-vendored/**/.claude-plugin/**


### PR DESCRIPTION
## Summary

Post-merge release hotfix for #3046 (1edf7a62). The `.dockerignore` allowlist
intent was correct but the `!_plugin-vendored/` line was a recursive directory
bang — it re-includes ALL children regardless of extension, so the per-
extension lines below it became no-ops. A Bun-specific `import.meta.path` in
one of the plugin's audit scripts then tripped Next.js's strict TS pass during
`npm run build`:

```
Type error: Property 'path' does not exist on type 'ImportMeta'.
```

Fix: invert the pattern in `apps/web-platform/.dockerignore` — exclude
`_plugin-vendored/**` first, then bang the directory entry back (so children
remain reachable) plus the specific file types we actually ship. `.ts` /
`.tsx` / `.js` files now stay out of the Docker build context.

## Test plan

- [x] Local: `.dockerignore` semantics validated by inspection — first-pattern excludes the dir contents, subsequent bangs re-include only allowlisted extensions.
- [ ] CI: Web Platform Release runs on merge to main.

Closes #3045 (post-merge release follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
