### PR TITLE
fix(web-platform): replace Bun-specific import.meta.path in bot-fixture.ts

### DIFF
--- a/plugins/soleur/skills/ux-audit/scripts/bot-fixture.ts
+++ b/plugins/soleur/skills/ux-audit/scripts/bot-fixture.ts
@@ -260,7 +260,7 @@ if (import.meta.main) {
   } else if (cmd === "reset") {
     await reset();
   } else {
-    console.error(`Usage: bun ${import.meta.path} <seed|reset>`);
+    console.error("Usage: bun bot-fixture.ts <seed|reset>");
     process.exit(2);
   }
 }


### PR DESCRIPTION
## Summary

- Web Platform Release has been failing on every commit since PR #3045 merged because `plugins/soleur/skills/ux-audit/scripts/bot-fixture.ts:263` used Bun-specific `import.meta.path`, which is not part of the standard `ImportMeta` type. PR #3045 baked `plugins/soleur/` into the web-platform Docker image, putting this script under `next build`'s strict TS check.
- Replaced the dynamic `${import.meta.path}` interpolation with a static `"bun bot-fixture.ts"` literal — the value is just an error/usage message, not load-bearing runtime data.
- `bunx tsc --noEmit` clean from `apps/web-platform/` (the web-platform tsconfig is what `next build` uses to typecheck the vendored plugin tree). `import.meta.main` is allowed; only `.path` was the offender.

Closes #3055

## Test plan

- [x] `bunx tsc --noEmit` from `apps/web-platform/` passes (was failing on `bot-fixture.ts:263`)
- [ ] CI: web-platform tests + Web Platform Release build pass on the PR
- [ ] Post-merge: Web Platform Release run on the merge commit succeeds (first green prod build since `1edf7a62`)

## Changelog

- **PATCH**: Fix Bun-specific `import.meta.path` usage that was breaking the Docker build for the web-platform release pipeline since PR #3045.

🤖 Generated with [Claude Code](https://claude.com/claude-code)