### PR TITLE
fix(rule-prune): skip rules with null first_seen instead of treating as stale

### DIFF
--- a/scripts/rule-prune.sh
+++ b/scripts/rule-prune.sh
@@ -64,14 +64,30 @@ jq -e --argjson v "$SCHEMA_VERSION" '.schema == $v' "$METRICS" >/dev/null 2>&1 \
 cutoff_epoch=$(( $(date -u +%s) - WEEKS * 7 * 86400 ))
 
 # Emit candidate tuples: id\tsection\tfirst_seen\trule_text_prefix.
-# try/catch on fromdateiso8601 mirrors the aggregator: malformed timestamps
-# get treated as "seen long ago" (epoch 0 < any finite cutoff).
+# Selection invariants:
+#   - fire_count == 0 (no deny/bypass/applied/warn events)
+#   - first_seen is set AND parseable AND older than cutoff
+#
+# `first_seen == null` means the aggregator hasn't recorded a first observation
+# yet (rule added since last aggregator run, or rule pre-dates v1 schema).
+# Treating null as "long ago" was the original intent (defensive fallback)
+# but the failure mode is severe: on first quarterly run after a rule-metrics
+# initialization, every never-fired rule with null first_seen is wrongly
+# flagged as stale. Surfaced post-merge by PR #3123's workflow_dispatch
+# validation, which proposed retiring 41 healthy rules including
+# `cq-rule-ids-are-immutable`. Rules without a first_seen timestamp are
+# unobservable, not stale — skip them and let the aggregator's next run
+# populate the timestamp.
+#
+# try/catch on fromdateiso8601 still treats malformed timestamps as
+# epoch 0 < cutoff (i.e., stale) — this is correct because a malformed
+# timestamp is corrupted state, not "not yet observed."
 candidates=$(jq -r \
   --argjson cutoff "$cutoff_epoch" \
   '.rules
    | map(select(.fire_count == 0
-        and (.first_seen == null
-             or (try (.first_seen | fromdateiso8601) catch 0) < $cutoff)))
+        and .first_seen != null
+        and (try (.first_seen | fromdateiso8601) catch 0) < $cutoff))
    | .[]
    | [.id, .section, (.first_seen // "unknown"), .rule_text_prefix]
    | @tsv' \

--- a/tests/commands/test-sync-rule-prune.sh
+++ b/tests/commands/test-sync-rule-prune.sh
@@ -451,6 +451,40 @@ tp11_dry_run_honored() {
   rm -rf "$root"
 }
 
+# tp12: rule with first_seen=null is NOT a retirement candidate.
+# Regression guard for the post-merge bug surfaced by #3123's workflow_dispatch:
+# the prior jq filter treated `first_seen == null` as "long ago," wrongly
+# proposing retirement of healthy never-fired rules whose timestamps the
+# aggregator hadn't populated yet (66 rules in rule-metrics.json on
+# 2026-05-04, 41 of which were proposed by PR #3154 before being closed).
+# Null first_seen means "not yet observed," not "stale" — it must skip.
+tp12_null_first_seen_skipped() {
+  local root; root=$(mktemp -d)
+  mkdir -p "$root/knowledge-base/project" "$root/scripts"
+  jq -n '{
+    schema:1, generated_at:"2026-05-04T00:00:00Z",
+    rules:[
+      {id:"wg-no-timestamp", section:"Workflow Gates", hit_count:0, bypass_count:0, applied_count:0, warn_count:0, fire_count:0, prevented_errors:0, last_hit:null, first_seen:null, rule_text_prefix:"never observed yet"}
+    ],
+    summary:{total_rules_tagged:1, rules_unused_over_8w:0, rules_bypassed_over_baseline:0, orphan_rule_ids:[]}
+  }' > "$root/knowledge-base/project/rule-metrics.json"
+  : > "$root/scripts/retired-rule-ids.txt"
+  local rc; rc=$(_run_pr "$root")
+  # Expectation: identical to tp1 (no candidates) — the null-first_seen rule
+  # must be filtered out at the candidates-jq stage, before any
+  # propose-retirement-mode logic runs. So we exit via the shared
+  # "No prune candidates" path.
+  if [[ "$rc" == "0" ]] \
+     && grep -qE 'No (prune|retirement) candidates' "$root/out.txt" \
+     && ! grep -qE '::rule-prune-pr-(title|body)::' "$root/out.txt" \
+     && ! grep -qE '^wg-no-timestamp \|' "$root/scripts/retired-rule-ids.txt"; then
+    _report "tp12: first_seen=null → not a candidate" ok
+  else
+    _report "tp12: first_seen=null → not a candidate" fail "rc=$rc; out=$(cat "$root/out.txt"); file=$(cat "$root/scripts/retired-rule-ids.txt")"
+  fi
+  rm -rf "$root"
+}
+
 if [[ ! -f "$SCRIPT" ]]; then
   echo "ERROR: $SCRIPT does not exist — RED phase expected this." >&2
   exit 1
@@ -474,6 +508,7 @@ tp8_schema_mismatch
 tp9_rerun_idempotent
 tp10_duplicate_candidate
 tp11_dry_run_honored
+tp12_null_first_seen_skipped
 
 echo "=== $pass passed, $fail failed ==="
 [[ "$fail" -eq 0 ]]


### PR DESCRIPTION
## Summary

Surfaced post-merge by PR #3123's `gh workflow run scheduled-rule-prune.yml` validation (per `wg-after-merging-a-pr-that-adds-or-modifies`). The first scheduled-rule-prune dispatch proposed retiring **41 healthy rules** including `cq-rule-ids-are-immutable`, `cq-write-failing-tests-before`, `wg-before-every-commit-run-compound-skill`, and `rf-review-finding-default-fix-inline` — closed as PR #3154 before auto-merge fired.

## Root cause

`scripts/rule-prune.sh`'s candidate jq filter has a permissive null branch:

```jq
| map(select(.fire_count == 0
     AND (.first_seen == null OR fromdateiso8601(.first_seen) < cutoff)))
```

The `first_seen == null` branch treats absence-of-timestamp as "older than cutoff," intended as a defensive "long-ago" fallback. But 66 of ~280 rules in `knowledge-base/project/rule-metrics.json` have `first_seen=null` because the aggregator hasn't yet recorded a first observation — either the rule was added since the last weekly run, or it pre-dates the v1 schema. Null first_seen means **"not yet observed enough to judge,"** not "stale."

## Fix

Change the null branch from `OR` to `AND first_seen != null`. Rules without timestamps are skipped; the aggregator's next weekly run populates the field naturally. Malformed timestamps still fall to epoch 0 < cutoff (corrupted state IS stale), preserving that defensive path.

```jq
| map(select(.fire_count == 0
     AND .first_seen != null
     AND (try (.first_seen | fromdateiso8601) catch 0) < ))
```

## Test

`tp12_null_first_seen_skipped` — fixture with a single null-first_seen rule asserts no append, no sentinels, exit 0 via the shared empty-candidates path. 18/18 tests pass.

Sanity check against the real production `rule-metrics.json` (with the same 66 null-first_seen rules): now produces `No prune candidates (fire_count=0 for >=26w)` — the correct zero-result on schedule until aggregator runs populate first_seen for never-fired rules.

## Changelog

### Plugin

- `scripts/rule-prune.sh`: rules with `first_seen=null` are no longer falsely flagged as stale retirement candidates. Both default (issue-filing) and `--propose-retirement` modes are corrected — they share the candidate filter.

## Test plan

- [x] `tests/commands/test-sync-rule-prune.sh` (18/18 pass — tp12 added)
- [x] Live `rule-metrics.json` sanity check produces zero candidates (was 41)
- [ ] ⏳ After merge, re-run `gh workflow run scheduled-rule-prune.yml` and verify it logs `No prune candidates` instead of opening a PR

This closes the loop opened by #3123 → workflow_dispatch → #3154 (closed). The post-merge gate caught a real bug; this is exactly the value the gate provides.

Generated with [Claude Code](https://claude.com/claude-code)