### PR TITLE
fix(signup): conditional-render tc-hint to remove visible gap when ticked

### DIFF
--- a/apps/web-platform/app/(auth)/signup/page.tsx
+++ b/apps/web-platform/app/(auth)/signup/page.tsx
@@ -224,19 +224,24 @@ function SignupForm() {
         </div>
 
         {/*
-          Live-region pre-exists invariant: render the role=status element
-          unconditionally and swap its text content when tcAccepted flips.
-          Conditionally rendering the live region itself does not reliably
-          announce on first state change — see plan ARIA22 / MDN refs.
+          Hint is rendered only while the gating checkbox is unchecked.
+          - Sighted users: text is read in normal page flow on initial render
+            (checkbox is unchecked at mount, so the hint is present).
+          - Screen-reader users: the hint sits in the document at first paint
+            and is read in flow; the checkbox itself announces its toggled
+            state, which is the load-bearing signal for the disabled OAuth
+            buttons. Conditional render avoids the visual "ghost" gap that
+            a persistent empty live-region with min-h reservation creates
+            once the user accepts the terms.
         */}
-        <p
-          data-testid="tc-hint"
-          aria-live="polite"
-          aria-atomic="true"
-          className="min-h-[1rem] text-center text-xs text-neutral-500"
-        >
-          {!tcAccepted ? "Accept the terms above to continue." : ""}
-        </p>
+        {!tcAccepted && (
+          <p
+            data-testid="tc-hint"
+            className="text-center text-xs text-neutral-500"
+          >
+            Accept the terms above to continue.
+          </p>
+        )}
 
         <OAuthButtons disabled={!tcAccepted} />
 

--- a/apps/web-platform/test/signup-helper-hint.test.tsx
+++ b/apps/web-platform/test/signup-helper-hint.test.tsx
@@ -23,48 +23,42 @@ import SignupPage from "@/app/(auth)/signup/page";
 const HINT_COPY = "Accept the terms above to continue.";
 const OAUTH_PROVIDERS = ["Google", "Apple", "GitHub", "Microsoft"] as const;
 
-// The signup page also renders a separate role=status banner when the user
-// arrives via /login redirect with `?reason=no-account`. The default test
-// setup uses an empty URLSearchParams so that banner does NOT render — but
-// the unique selector below uses data-testid for stability against a future
-// refactor that adds another live region above the divider.
 describe("SignupPage helper hint (T&C-gated OAuth)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("renders the live-region hint at first render with the gating copy", () => {
+  it("renders the gating-copy hint while the checkbox is unchecked", () => {
     render(<SignupPage />);
 
     const hint = screen.getByTestId("tc-hint");
     expect(hint).toBeInTheDocument();
-    // No `role="status"` here on purpose: the /signup page already renders a
-    // separate role=status banner ("No Soleur account found...") when the user
-    // arrives via /login redirect. Two role=status regions would collide with
-    // single-role locators in e2e (otp-login.e2e.ts uses page.getByRole("status")
-    // expecting exactly one match). aria-live + aria-atomic preserves the
-    // announce-as-whole semantics without the role-collision.
-    expect(hint).not.toHaveAttribute("role", "status");
-    expect(hint).toHaveAttribute("aria-live", "polite");
-    expect(hint).toHaveAttribute("aria-atomic", "true");
     expect(hint).toHaveTextContent(HINT_COPY);
   });
 
-  it("empties the hint text when the T&C checkbox is ticked (live region persists)", () => {
+  it("removes the hint from the DOM when the T&C checkbox is ticked", () => {
     render(<SignupPage />);
 
-    const hint = screen.getByTestId("tc-hint");
-    expect(hint).toHaveTextContent(HINT_COPY);
+    expect(screen.getByTestId("tc-hint")).toHaveTextContent(HINT_COPY);
 
     fireEvent.click(screen.getByRole("checkbox"));
 
-    // Live-region pre-exists invariant: element stays in DOM, text empties.
-    const afterTick = screen.getByTestId("tc-hint");
-    expect(afterTick).toBeInTheDocument();
-    expect(afterTick).toHaveTextContent("");
-    // aria-live MUST persist across the text swap so the announcement
-    // pipeline keeps observing this region for future content changes.
-    expect(afterTick).toHaveAttribute("aria-live", "polite");
+    // Conditional render: the hint is fully unmounted post-tick so the
+    // parent's space-y stacking collapses cleanly between the "or" divider
+    // and the OAuth buttons. A persistent empty live-region with min-h
+    // reservation produced a visible ~64px ghost gap (see PR #3199 follow-up).
+    expect(screen.queryByTestId("tc-hint")).not.toBeInTheDocument();
+  });
+
+  it("re-renders the hint when the user un-ticks the checkbox", () => {
+    render(<SignupPage />);
+
+    const checkbox = screen.getByRole("checkbox");
+    fireEvent.click(checkbox);
+    expect(screen.queryByTestId("tc-hint")).not.toBeInTheDocument();
+
+    fireEvent.click(checkbox);
+    expect(screen.getByTestId("tc-hint")).toHaveTextContent(HINT_COPY);
   });
 
   it("keeps every OAuth provider button disabled before the checkbox is ticked", () => {
@@ -94,10 +88,9 @@ describe("SignupPage helper hint (T&C-gated OAuth)", () => {
   });
 
   it("does NOT render the hint in the OTP-sent step (form has unmounted)", async () => {
-    // Regression guard: the live region lives in the pre-OTP form branch
-    // only. If a future refactor lifts the live region above the otpSent
-    // conditional, the announce-on-mount bug returns. Drive the page into
-    // the OTP step and assert the hint is gone.
+    // Regression guard: the hint lives in the pre-OTP form branch only.
+    // If a future refactor lifts the conditional above the otpSent branch,
+    // the empty-DOM contract for the OTP step would silently break.
     signInWithOtpMock.mockResolvedValueOnce({ error: null });
     render(<SignupPage />);
 


### PR DESCRIPTION
## Summary

Follow-up to PR #3199. The T&C-gating helper hint was rendered as a persistent `<p>` with `min-h-[1rem]` and an `aria-live` region, intending to pre-exist for screen-reader announcements. The parent wrapper uses `space-y-6` (24px between siblings); when the user accepts the terms and the `<p>` empties, the layout still reserves `1.5rem + 16px + 1.5rem` = ~64px of visible empty space between the "or" divider and the OAuth buttons. Users read the gap as a broken page.

Switch to a plain conditional render gated by `!tcAccepted`:
- On mount the hint is in document flow (read by SR as part of normal page consumption).
- On tick the hint unmounts and adjacent siblings collapse to `space-y-6`'s standard 1.5rem stacking gap.
- On un-tick the hint remounts.

The live-region complexity was overkill here: the checkbox toggle is user-initiated, so the screen reader already announces the checkbox state change — the hint did not need its own `aria-live` channel.

## Test plan

- [x] Component tests updated: 6/6 pass. New cases assert (a) hint mounts pre-tick, (b) hint unmounts post-tick, (c) hint re-renders on un-tick.
- [x] Visual layout: parent `space-y-6` collapses cleanly between divider and OAuth buttons post-tick.
- [x] Existing `otp-login.e2e.ts` still passes: tc-hint no longer carries `role=status`, so `getByRole("status")` collisions are already gone (PR #3199 follow-up commit `621da735` had set the stage).

## Changelog

- fix(signup): conditional-render T&C-gating helper hint to remove visible gap when checkbox is ticked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
