### PR TITLE
fix(cc): archive must release the concurrent-conversation slot via Postgres trigger

### DIFF
--- a/apps/web-platform/hooks/use-conversations.ts
+++ b/apps/web-platform/hooks/use-conversations.ts
@@ -323,6 +323,10 @@ export function useConversations(
   }, [userId, fetchConversations]);
 
   const archiveConversation = useCallback(async (id: string) => {
+    // Slot release on archive: handled by AFTER UPDATE OF archived_at
+    // trigger in supabase/migrations/036_release_slot_on_archive.sql.
+    // Do NOT add an explicit release_conversation_slot RPC call here —
+    // it would double-release.
     const supabase = createClient();
     const { error: updateError } = await supabase
       .from("conversations")

--- a/apps/web-platform/lib/ws-client.ts
+++ b/apps/web-platform/lib/ws-client.ts
@@ -107,7 +107,14 @@ export const NON_TRANSIENT_CLOSE_CODES: Record<number, { target?: string; reason
   [WS_CLOSE_CODES.INTERNAL_ERROR]: { reason: "Server error" },
   [WS_CLOSE_CODES.RATE_LIMITED]: { reason: "Too many requests. Please try again later." },
   [WS_CLOSE_CODES.IDLE_TIMEOUT]: { reason: "Session expired due to inactivity" },
-  [WS_CLOSE_CODES.CONCURRENCY_CAP]: { reason: "Concurrent-conversation limit reached" },
+  // Recovery hint: archive (not just complete) frees a slot — the
+  // AFTER UPDATE OF archived_at trigger in migration 036 fires
+  // release_conversation_slot only on archive, NOT on status='completed'.
+  // (Plan Risk #5: resume_session does not call acquireSlot, so releasing
+  // on completed alone would let resumes bypass the cap.)
+  [WS_CLOSE_CODES.CONCURRENCY_CAP]: {
+    reason: "Concurrent-conversation limit reached. Archive a completed conversation to free a slot.",
+  },
 };
 
 /** Combined chat state: messages and activeStreams update atomically via useReducer

--- a/apps/web-platform/server/conversations-tools.ts
+++ b/apps/web-platform/server/conversations-tools.ts
@@ -203,7 +203,11 @@ export function buildConversationsTools(opts: BuildConversationsToolsOpts) {
 
         const supabase = createServiceClient();
         const nowIso = new Date().toISOString();
-        // allow-direct-conversation-update: stronger 3-column composite key (id, user_id, repo_url) + select for not_found semantics — beyond updateConversationFor's R8 contract
+        // allow-direct-conversation-update: stronger 3-column composite key (id, user_id, repo_url) + select for not_found semantics — beyond updateConversationFor's R8 contract.
+        // Slot release on archive: handled by AFTER UPDATE OF archived_at trigger
+        // in supabase/migrations/036_release_slot_on_archive.sql (NULL → non-NULL
+        // transition fires public.release_conversation_slot). Do NOT add an
+        // explicit releaseSlot call here — it would double-release.
         const { data, error } = await supabase
           .from("conversations")
           .update({ archived_at: nowIso })

--- a/apps/web-platform/server/conversations-tools.ts
+++ b/apps/web-platform/server/conversations-tools.ts
@@ -203,11 +203,10 @@ export function buildConversationsTools(opts: BuildConversationsToolsOpts) {
 
         const supabase = createServiceClient();
         const nowIso = new Date().toISOString();
-        // allow-direct-conversation-update: stronger 3-column composite key (id, user_id, repo_url) + select for not_found semantics — beyond updateConversationFor's R8 contract.
-        // Slot release on archive: handled by AFTER UPDATE OF archived_at trigger
-        // in supabase/migrations/036_release_slot_on_archive.sql (NULL → non-NULL
-        // transition fires public.release_conversation_slot). Do NOT add an
-        // explicit releaseSlot call here — it would double-release.
+        // Slot release on archive is handled by the AFTER UPDATE OF archived_at trigger in
+        // supabase/migrations/036_release_slot_on_archive.sql (fires public.release_conversation_slot).
+        // Do NOT add an explicit releaseSlot call here — it would double-release.
+        // allow-direct-conversation-update: stronger 3-column composite key (id, user_id, repo_url) + select for not_found semantics — beyond updateConversationFor's R8 contract
         const { data, error } = await supabase
           .from("conversations")
           .update({ archived_at: nowIso })

--- a/apps/web-platform/supabase/migrations/036_release_slot_on_archive.sql
+++ b/apps/web-platform/supabase/migrations/036_release_slot_on_archive.sql
@@ -2,50 +2,63 @@
 --
 -- Bug: archiving a conversation in the Command Center (or via the
 -- conversation_archive MCP tool) updates `conversations.archived_at` directly
--- without calling `public.release_conversation_slot`. The WebSocket session
--- continues heartbeating other live conversations, so the lazy 120s sweep in
--- `acquire_conversation_slot` never fires either. The slot leaks until pg_cron
--- reclaims it on the next 1-minute tick, which only happens after the user
--- fully disconnects every WS. Result: a free-tier user (cap=1) who archives
--- their only conversation hits "Concurrent-conversation limit reached" on the
--- next "+ New conversation" click, with no in-product recovery path.
+-- without calling `public.release_conversation_slot`. The WS session keeps
+-- heartbeating other live conversations, so the 120s lazy sweep in
+-- `acquire_conversation_slot` never fires either. The slot leaks until
+-- pg_cron's 1-minute tick after full WS disconnect. Result: a free-tier
+-- user (cap=1) who archives their only conversation hits
+-- "Concurrent-conversation limit reached" on the next new-conversation click.
 --
--- Fix: AFTER UPDATE trigger on public.conversations that calls the existing
--- SECURITY DEFINER `public.release_conversation_slot` RPC whenever
--- `archived_at` transitions from NULL to non-NULL. Closes the slot-release
--- gap for every current and future writer (hook, MCP tool, future API
--- endpoint, manual DB write) without coupling each writer to slot lifecycle.
+-- Fix: AFTER UPDATE OF archived_at trigger on public.conversations that
+-- calls the existing SECURITY DEFINER `public.release_conversation_slot`
+-- RPC whenever `archived_at` transitions NULL → non-NULL. Closes the gap
+-- for every writer (hook, MCP tool, future API endpoint, manual DB write).
 --
 -- Trigger semantics (see plan Risk #5 + Sharp Edges):
 --
--- 1. Fires on `archived_at` transitions ONLY, NOT on `status='completed'`.
---    Reason: `resume_session` in ws-handler.ts does NOT call `acquireSlot`,
---    so releasing on completed-only would let a resumed conversation run
---    outside the slot ledger and effectively bypass the cap.
+-- 1. Archive-only. Does NOT fire on `status='completed'` because
+--    `resume_session` (ws-handler.ts:812) does not call `acquireSlot`.
+--    Releasing on completed-only would let a resumed conversation bypass
+--    the cap.
 --
--- 2. `AFTER UPDATE OF archived_at` keeps the trigger no-op for unrelated
---    column updates — Postgres skips trigger evaluation entirely when the
---    named column wasn't in the UPDATE's SET list.
+-- 2. Slot identity is read from OLD (`OLD.user_id`, `OLD.id`) — the
+--    pre-image is the auth-checked, immutable identity. The conversations
+--    RLS policy uses `FOR ALL USING (auth.uid() = user_id)` with no
+--    `WITH CHECK` clause (001_initial_schema.sql:60-62), so a malicious
+--    UPDATE could change `NEW.user_id` to any value the attacker chose.
+--    Using OLD pins the slot lookup to the auth-checked owner.
 --
 -- 3. WHEN clause uses `IS DISTINCT FROM` (not `=`) because
---    `NULL = NULL` returns NULL (not true), which `WHEN` treats as false →
---    the trigger would silently miss the NULL → non-NULL transition.
+--    `NULL = NULL` returns NULL (not true) — `WHEN` would treat that as
+--    false and silently miss the NULL → non-NULL transition.
 --
--- 4. The body invokes `public.release_conversation_slot(NEW.user_id, NEW.id)`,
---    which is a plain keyed DELETE in migration 029. Idempotent: a second
---    invocation (e.g., when `close_conversation` already released the slot
---    before the row was archived) is a safe no-op.
+-- 4. `public.release_conversation_slot` is a plain keyed DELETE in
+--    migration 029. Idempotent: a second invocation (e.g., when
+--    `close_conversation` already released the slot before the archive
+--    UPDATE landed) is a safe no-op.
+--
+-- 5. Chat-on-archived-conv is safe (AC12). After archive, the WS session's
+--    in-memory `session.conversationId` may still point at the archived row
+--    until the next start_session/resume. `updateConversationFor` writes
+--    `last_active`/`status` regardless of `archived_at` — defensible because
+--    the user can unarchive and resume. The Command Center sidebar filters
+--    archived rows; the explicit resume_session path is unreachable from the
+--    UI for archived conversations.
 --
 -- search_path is pinned to `public, pg_temp` per
 -- cq-pg-security-definer-search-path-pin-pg-temp; relations are qualified
 -- as `public.<table>` in the body.
 --
--- CONCURRENTLY is NOT used — Supabase wraps each migration in a txn and
--- CREATE INDEX CONCURRENTLY fails with SQLSTATE 25001. (Not relevant here
--- since the migration declares no indexes — kept in the header for
--- consistency with 025/027/029/032 which the cq lint scans.)
+-- Bulk-archive operators: an UPDATE that flips `archived_at` on N rows
+-- fires the trigger N times (one keyed DELETE each). For multi-thousand-row
+-- batch archives (data retention sweeps, backfills), bypass with
+-- `SET LOCAL session_replication_role = replica;` for the txn.
 --
--- FORWARD-ONLY: rollback requires a new migration that DROPs the trigger.
+-- FORWARD-ONLY. Rollback ordering: it is safe to drop this trigger any
+-- time (pre-existing leaked slots reclaim via 120s heartbeat-lapse + the
+-- 1-minute pg_cron sweep in migration 029 line 219). Reverting the code
+-- PR is not required, unlike 029. To reintroduce, a new migration must
+-- recreate the trigger; do NOT rely on `supabase db reset` in prod.
 
 create or replace function public.release_slot_on_archive()
 returns trigger
@@ -54,7 +67,10 @@ security definer
 set search_path = public, pg_temp
 as $$
 begin
-  perform public.release_conversation_slot(NEW.user_id, NEW.id);
+  -- OLD.user_id is the auth-checked owner from the pre-image.
+  -- See header §2 — NEW.user_id is client-controlled because the
+  -- conversations RLS policy lacks a WITH CHECK clause.
+  perform public.release_conversation_slot(OLD.user_id, OLD.id);
   return NEW;
 end;
 $$;

--- a/apps/web-platform/supabase/migrations/036_release_slot_on_archive.sql
+++ b/apps/web-platform/supabase/migrations/036_release_slot_on_archive.sql
@@ -1,0 +1,73 @@
+-- Release the user_concurrency_slots row when a conversation is archived.
+--
+-- Bug: archiving a conversation in the Command Center (or via the
+-- conversation_archive MCP tool) updates `conversations.archived_at` directly
+-- without calling `public.release_conversation_slot`. The WebSocket session
+-- continues heartbeating other live conversations, so the lazy 120s sweep in
+-- `acquire_conversation_slot` never fires either. The slot leaks until pg_cron
+-- reclaims it on the next 1-minute tick, which only happens after the user
+-- fully disconnects every WS. Result: a free-tier user (cap=1) who archives
+-- their only conversation hits "Concurrent-conversation limit reached" on the
+-- next "+ New conversation" click, with no in-product recovery path.
+--
+-- Fix: AFTER UPDATE trigger on public.conversations that calls the existing
+-- SECURITY DEFINER `public.release_conversation_slot` RPC whenever
+-- `archived_at` transitions from NULL to non-NULL. Closes the slot-release
+-- gap for every current and future writer (hook, MCP tool, future API
+-- endpoint, manual DB write) without coupling each writer to slot lifecycle.
+--
+-- Trigger semantics (see plan Risk #5 + Sharp Edges):
+--
+-- 1. Fires on `archived_at` transitions ONLY, NOT on `status='completed'`.
+--    Reason: `resume_session` in ws-handler.ts does NOT call `acquireSlot`,
+--    so releasing on completed-only would let a resumed conversation run
+--    outside the slot ledger and effectively bypass the cap.
+--
+-- 2. `AFTER UPDATE OF archived_at` keeps the trigger no-op for unrelated
+--    column updates — Postgres skips trigger evaluation entirely when the
+--    named column wasn't in the UPDATE's SET list.
+--
+-- 3. WHEN clause uses `IS DISTINCT FROM` (not `=`) because
+--    `NULL = NULL` returns NULL (not true), which `WHEN` treats as false →
+--    the trigger would silently miss the NULL → non-NULL transition.
+--
+-- 4. The body invokes `public.release_conversation_slot(NEW.user_id, NEW.id)`,
+--    which is a plain keyed DELETE in migration 029. Idempotent: a second
+--    invocation (e.g., when `close_conversation` already released the slot
+--    before the row was archived) is a safe no-op.
+--
+-- search_path is pinned to `public, pg_temp` per
+-- cq-pg-security-definer-search-path-pin-pg-temp; relations are qualified
+-- as `public.<table>` in the body.
+--
+-- CONCURRENTLY is NOT used — Supabase wraps each migration in a txn and
+-- CREATE INDEX CONCURRENTLY fails with SQLSTATE 25001. (Not relevant here
+-- since the migration declares no indexes — kept in the header for
+-- consistency with 025/027/029/032 which the cq lint scans.)
+--
+-- FORWARD-ONLY: rollback requires a new migration that DROPs the trigger.
+
+create or replace function public.release_slot_on_archive()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  perform public.release_conversation_slot(NEW.user_id, NEW.id);
+  return NEW;
+end;
+$$;
+
+revoke all on function public.release_slot_on_archive() from public;
+
+drop trigger if exists conversations_release_slot_on_archive on public.conversations;
+
+create trigger conversations_release_slot_on_archive
+  after update of archived_at on public.conversations
+  for each row
+  when (
+    OLD.archived_at IS DISTINCT FROM NEW.archived_at
+    AND NEW.archived_at IS NOT NULL
+  )
+  execute function public.release_slot_on_archive();

--- a/apps/web-platform/test/conversation-archive-release-slot.integration.test.ts
+++ b/apps/web-platform/test/conversation-archive-release-slot.integration.test.ts
@@ -18,7 +18,7 @@
  * assert the slot row is gone.
  */
 
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { randomBytes, randomUUID } from "crypto";
 
@@ -74,10 +74,25 @@ describe.skipIf(!INTEGRATION_ENABLED)(
         password: user.password,
         email_confirm: true,
       });
-      if (data.user?.id) user.id = data.user.id;
+      // Assign id BEFORE asserting so afterAll cleanup runs even if a flaky
+      // post-create assertion below trips. Same pattern as byok.integration.
+      user.id = data.user?.id ?? "";
       expect(error, `createUser(${user.email}) failed`).toBeNull();
       expect(user.id).toBeTruthy();
     }, 30_000);
+
+    afterEach(async () => {
+      if (!service || !user.id) return;
+      // Per-test cleanup so slot/conversation rows from one test do not
+      // skew the next test's slotCount() or trigger ordering coupling.
+      // Conversations: cascade through user_concurrency_slots is NOT
+      // present (slot FK is on users, not conversations) — clean both.
+      await service
+        .from("user_concurrency_slots")
+        .delete()
+        .eq("user_id", user.id);
+      await service.from("conversations").delete().eq("user_id", user.id);
+    });
 
     afterAll(async () => {
       if (!service || !user.id) return;
@@ -182,9 +197,13 @@ describe.skipIf(!INTEGRATION_ENABLED)(
       expect(acquireNew.active_count).toBe(1);
     }, 30_000);
 
-    test("unarchiving does NOT release a slot (NEW.archived_at IS NOT NULL guard)", async () => {
-      // Negative: a NULL → non-NULL → NULL transition must release the slot
-      // exactly once (on the first archive), not again on unarchive.
+    test("regression guard: trigger MUST NOT broaden to release on unarchive", async () => {
+      // Negative-space regression test. This test PASSES on the pre-fix
+      // branch too (no trigger means no release on unarchive either — the
+      // slot just leaks). It guards against a future broadening of the
+      // trigger's WHEN clause that would drop the `NEW.archived_at IS NOT
+      // NULL` filter and start releasing on unarchive (NULL → non-NULL →
+      // NULL). That broadening would silently break re-acquire-on-resume.
       const repoUrl = `https://github.com/synthetic/${randomBytes(4).toString("hex")}`;
       const convId = await insertConversation(repoUrl);
 
@@ -213,10 +232,12 @@ describe.skipIf(!INTEGRATION_ENABLED)(
       expect(await slotCount()).toBe(1);
     }, 30_000);
 
-    test("status='completed' alone does NOT release a slot (archive-only trigger)", async () => {
-      // Negative: the trigger uses AFTER UPDATE OF archived_at — a status-only
-      // UPDATE must not fire it. (See plan Risk #5: releasing on completed-only
-      // would let resume_session bypass the cap.)
+    test("regression guard: trigger MUST NOT broaden to release on status='completed'", async () => {
+      // Negative-space regression test. PASSES pre-fix too. Guards against
+      // a future widening of the AFTER UPDATE OF column list that would
+      // include `status` — see plan Risk #5: releasing on completed alone
+      // would let `resume_session` bypass the cap, because resume_session
+      // (ws-handler.ts:812) does not call acquireSlot.
       const repoUrl = `https://github.com/synthetic/${randomBytes(4).toString("hex")}`;
       const convId = await insertConversation(repoUrl);
 

--- a/apps/web-platform/test/conversation-archive-release-slot.integration.test.ts
+++ b/apps/web-platform/test/conversation-archive-release-slot.integration.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Trigger integration test — archive must release the concurrency slot.
+ *
+ * Opt-in via SLOT_TRIGGER_INTEGRATION_TEST=1. Runs against the real Supabase
+ * dev project; requires `doppler run -p soleur -c dev` to provide env vars.
+ *
+ *   cd apps/web-platform && \
+ *     doppler run -p soleur -c dev -- \
+ *     env SLOT_TRIGGER_INTEGRATION_TEST=1 \
+ *     ./node_modules/.bin/vitest run test/conversation-archive-release-slot.integration.test.ts
+ *
+ * Plan: 2026-05-04-fix-cc-conversation-limit-archive-plan.md AC6 / AC14.
+ *
+ * Vitest cannot exercise Postgres triggers natively — the migration-shape
+ * test (test/supabase-migrations/036-release-slot-on-archive.test.ts) pins
+ * the SQL contract, but only a real DB run can verify the trigger actually
+ * fires. This file closes that loop: insert a slot, archive the conversation,
+ * assert the slot row is gone.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { randomBytes, randomUUID } from "crypto";
+
+const INTEGRATION_ENABLED = process.env.SLOT_TRIGGER_INTEGRATION_TEST === "1";
+
+// Only synthetic emails matching this pattern may be created or deleted by
+// this test. Enforces hr-destructive-prod-tests-allowlist.
+const SYNTHETIC_EMAIL_PATTERN = /^slot-trigger-[a-f0-9]{16}@soleur\.test$/;
+
+function syntheticEmail(): string {
+  return `slot-trigger-${randomBytes(8).toString("hex")}@soleur.test`;
+}
+
+function assertSynthetic(email: string): void {
+  if (!SYNTHETIC_EMAIL_PATTERN.test(email)) {
+    throw new Error(
+      `Refusing to touch non-synthetic email "${email}" — this test only ` +
+        "manipulates slot-trigger-*@soleur.test accounts.",
+    );
+  }
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`[slot-trigger.integration] ${name} is required`);
+  }
+  return value;
+}
+
+describe.skipIf(!INTEGRATION_ENABLED)(
+  "release_slot_on_archive trigger (integration)",
+  () => {
+    let service: SupabaseClient;
+
+    const user = {
+      id: "",
+      email: syntheticEmail(),
+      password: randomBytes(16).toString("hex"),
+    };
+
+    beforeAll(async () => {
+      const supabaseUrl = requireEnv("NEXT_PUBLIC_SUPABASE_URL");
+      const serviceRoleKey = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
+
+      service = createClient(supabaseUrl, serviceRoleKey, {
+        auth: { persistSession: false, autoRefreshToken: false },
+      });
+
+      assertSynthetic(user.email);
+      const { data, error } = await service.auth.admin.createUser({
+        email: user.email,
+        password: user.password,
+        email_confirm: true,
+      });
+      if (data.user?.id) user.id = data.user.id;
+      expect(error, `createUser(${user.email}) failed`).toBeNull();
+      expect(user.id).toBeTruthy();
+    }, 30_000);
+
+    afterAll(async () => {
+      if (!service || !user.id) return;
+      assertSynthetic(user.email);
+      const { data: check } = await service.auth.admin.getUserById(user.id);
+      if (check?.user?.email && check.user.email !== user.email) {
+        throw new Error(
+          `afterAll: auth.users.email for ${user.id} (${check.user.email}) ` +
+            `does not match synthetic email ${user.email}`,
+        );
+      }
+      const { error } = await service.auth.admin.deleteUser(user.id);
+      if (error && !/not found/i.test(error.message)) {
+        throw new Error(
+          `afterAll: deleteUser(${user.email}) failed: ${error.message}`,
+        );
+      }
+    }, 30_000);
+
+    async function insertConversation(repoUrl: string): Promise<string> {
+      const id = randomUUID();
+      const sessionId = randomUUID();
+      const { error } = await service.from("conversations").insert({
+        id,
+        user_id: user.id,
+        session_id: sessionId,
+        repo_url: repoUrl,
+        status: "active",
+        title: "slot-trigger integration",
+      });
+      expect(error, `insert conversation failed: ${error?.message}`).toBeNull();
+      return id;
+    }
+
+    async function acquireSlot(
+      conversationId: string,
+      cap = 1,
+    ): Promise<{ status: string; active_count: number }> {
+      const { data, error } = await service.rpc("acquire_conversation_slot", {
+        p_user_id: user.id,
+        p_conversation_id: conversationId,
+        p_effective_cap: cap,
+      });
+      expect(
+        error,
+        `acquire_conversation_slot failed: ${error?.message}`,
+      ).toBeNull();
+      // RPC returns TABLE — supabase-js gives us an array.
+      const row = Array.isArray(data) ? data[0] : data;
+      return { status: row.status, active_count: row.active_count };
+    }
+
+    async function slotCount(): Promise<number> {
+      const { count, error } = await service
+        .from("user_concurrency_slots")
+        .select("*", { count: "exact", head: true })
+        .eq("user_id", user.id);
+      expect(error, `slot count query failed: ${error?.message}`).toBeNull();
+      return count ?? 0;
+    }
+
+    test("archiving a conversation releases its concurrency slot", async () => {
+      const repoUrl = `https://github.com/synthetic/${randomBytes(4).toString("hex")}`;
+      const convId = await insertConversation(repoUrl);
+
+      const acquireResult = await acquireSlot(convId, 1);
+      expect(acquireResult.status).toBe("ok");
+      expect(await slotCount()).toBe(1);
+
+      const { error: archiveError } = await service
+        .from("conversations")
+        .update({ archived_at: new Date().toISOString() })
+        .eq("id", convId);
+      expect(archiveError).toBeNull();
+
+      // The trigger fires AFTER UPDATE OF archived_at — synchronous; the
+      // slot row should be gone before the UPDATE returns.
+      expect(await slotCount()).toBe(0);
+    }, 30_000);
+
+    test("free-tier user can start a new conversation immediately after archiving", async () => {
+      // Reproduces the user's reported scenario: cap = 1, archive the
+      // current conversation, start a new one. Pre-fix: cap_hit. Post-fix: ok.
+      const repoUrl = `https://github.com/synthetic/${randomBytes(4).toString("hex")}`;
+      const oldConv = await insertConversation(repoUrl);
+
+      expect((await acquireSlot(oldConv, 1)).status).toBe("ok");
+
+      const { error: archiveError } = await service
+        .from("conversations")
+        .update({ archived_at: new Date().toISOString() })
+        .eq("id", oldConv);
+      expect(archiveError).toBeNull();
+
+      const newConv = await insertConversation(repoUrl);
+      const acquireNew = await acquireSlot(newConv, 1);
+
+      // Post-fix: the trigger released the old slot, so this acquire fits
+      // under cap = 1. Pre-fix would have returned cap_hit because the old
+      // slot was still in the ledger.
+      expect(acquireNew.status).toBe("ok");
+      expect(acquireNew.active_count).toBe(1);
+    }, 30_000);
+
+    test("unarchiving does NOT release a slot (NEW.archived_at IS NOT NULL guard)", async () => {
+      // Negative: a NULL → non-NULL → NULL transition must release the slot
+      // exactly once (on the first archive), not again on unarchive.
+      const repoUrl = `https://github.com/synthetic/${randomBytes(4).toString("hex")}`;
+      const convId = await insertConversation(repoUrl);
+
+      expect((await acquireSlot(convId, 1)).status).toBe("ok");
+      expect(await slotCount()).toBe(1);
+
+      // Archive — slot released.
+      await service
+        .from("conversations")
+        .update({ archived_at: new Date().toISOString() })
+        .eq("id", convId);
+      expect(await slotCount()).toBe(0);
+
+      // Re-acquire (simulating a "+ New conversation" after archive).
+      const newConv = await insertConversation(repoUrl);
+      expect((await acquireSlot(newConv, 1)).status).toBe("ok");
+      expect(await slotCount()).toBe(1);
+
+      // Unarchive the OLD row — trigger must NOT fire (NEW.archived_at
+      // IS NULL fails the WHEN clause). The new conversation's slot must
+      // remain.
+      await service
+        .from("conversations")
+        .update({ archived_at: null })
+        .eq("id", convId);
+      expect(await slotCount()).toBe(1);
+    }, 30_000);
+
+    test("status='completed' alone does NOT release a slot (archive-only trigger)", async () => {
+      // Negative: the trigger uses AFTER UPDATE OF archived_at — a status-only
+      // UPDATE must not fire it. (See plan Risk #5: releasing on completed-only
+      // would let resume_session bypass the cap.)
+      const repoUrl = `https://github.com/synthetic/${randomBytes(4).toString("hex")}`;
+      const convId = await insertConversation(repoUrl);
+
+      expect((await acquireSlot(convId, 1)).status).toBe("ok");
+      expect(await slotCount()).toBe(1);
+
+      const { error: statusError } = await service
+        .from("conversations")
+        .update({ status: "completed" })
+        .eq("id", convId);
+      expect(statusError).toBeNull();
+
+      // Slot still held.
+      expect(await slotCount()).toBe(1);
+    }, 30_000);
+  },
+);

--- a/apps/web-platform/test/supabase-migrations/036-release-slot-on-archive.test.ts
+++ b/apps/web-platform/test/supabase-migrations/036-release-slot-on-archive.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// Migration-shape test for 036_release_slot_on_archive.sql.
+//
+// File-parse test, not a live-DB test. It pins the SQL contract that fixes
+// the user-reported bug: archiving a conversation must release its
+// concurrency slot via the existing `public.release_conversation_slot` RPC.
+//
+// The trigger fires ONLY on `archived_at` NULL → non-NULL transitions
+// (NOT on `status = 'completed'` transitions) — see plan Risk #5: releasing
+// on completed-only would let a resumed conversation run outside the slot
+// ledger because `resume_session` does not call `acquireSlot`.
+//
+// Plan: 2026-05-04-fix-cc-conversation-limit-archive-plan.md.
+
+const MIGRATION_PATH = path.join(
+  __dirname,
+  "../../supabase/migrations/036_release_slot_on_archive.sql",
+);
+
+describe("migration 036_release_slot_on_archive", () => {
+  const sql = readFileSync(MIGRATION_PATH, "utf8");
+
+  // Strip line-comments before pattern checks so header prose can mention
+  // the same tokens without tripping the regex (mirrors 032 pattern).
+  const executable = sql.replace(/--[^\n]*/g, "");
+
+  it("declares a SECURITY DEFINER trigger function pinning search_path", () => {
+    // cq-pg-security-definer-search-path-pin-pg-temp: pin to public, pg_temp.
+    expect(executable).toMatch(/CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+public\.release_slot_on_archive\s*\(\s*\)/i);
+    expect(executable).toMatch(/SECURITY\s+DEFINER/i);
+    expect(executable).toMatch(/SET\s+search_path\s*=\s*public\s*,\s*pg_temp/i);
+  });
+
+  it("body invokes public.release_conversation_slot with NEW.user_id and NEW.id", () => {
+    // The function body must call the existing keyed-DELETE RPC with
+    // qualified relation names (cq-pg-security-definer-search-path-pin-pg-temp).
+    expect(executable).toMatch(
+      /public\.release_conversation_slot\s*\(\s*NEW\.user_id\s*,\s*NEW\.id\s*\)/i,
+    );
+  });
+
+  it("creates an AFTER UPDATE OF archived_at trigger on public.conversations", () => {
+    // `OF archived_at` keeps the trigger no-op for unrelated column updates
+    // (cheaper than WHEN-clause filtering alone — Postgres skips trigger
+    // evaluation entirely when the named column wasn't in the UPDATE's SET
+    // list).
+    expect(executable).toMatch(
+      /CREATE\s+TRIGGER\s+conversations_release_slot_on_archive[\s\S]*?AFTER\s+UPDATE\s+OF\s+archived_at[\s\S]*?ON\s+public\.conversations/i,
+    );
+  });
+
+  it("WHEN clause uses IS DISTINCT FROM for nullable archived_at comparison", () => {
+    // `OLD.archived_at = NEW.archived_at` returns NULL when both sides are
+    // NULL, which `WHEN` treats as false → trigger silently misses the
+    // NULL → non-NULL transition. IS DISTINCT FROM correctly compares
+    // nullable values (Postgres documented gotcha; see plan Sharp Edges).
+    expect(executable).toMatch(
+      /WHEN\s*\([^)]*OLD\.archived_at\s+IS\s+DISTINCT\s+FROM\s+NEW\.archived_at[^)]*\)/i,
+    );
+  });
+
+  it("WHEN clause filters to NULL → non-NULL transitions only (archive, not unarchive)", () => {
+    // Unarchive (archived_at non-NULL → NULL) must NOT release a slot — a
+    // re-acquire would happen on the next start_session/resume.
+    expect(executable).toMatch(
+      /WHEN\s*\([^)]*NEW\.archived_at\s+IS\s+NOT\s+NULL[^)]*\)/i,
+    );
+  });
+
+  it("trigger fires FOR EACH ROW (not statement-level)", () => {
+    // Per-row body needs NEW.user_id and NEW.id; FOR EACH STATEMENT cannot
+    // see them.
+    expect(executable).toMatch(/FOR\s+EACH\s+ROW/i);
+  });
+
+  it("does NOT fire on status transitions (archive-only by AFTER UPDATE OF clause)", () => {
+    // Trigger is `AFTER UPDATE OF archived_at` — the column list is the
+    // hard gate. Belt-and-suspenders: the create-trigger statement must NOT
+    // also list `status` in its OF clause.
+    const triggerStmt = executable.match(
+      /CREATE\s+TRIGGER\s+conversations_release_slot_on_archive[\s\S]*?(?=;)/i,
+    );
+    expect(triggerStmt, "must declare conversations_release_slot_on_archive trigger").not.toBeNull();
+    expect(triggerStmt![0]).not.toMatch(/UPDATE\s+OF\s+[^;]*\bstatus\b/i);
+  });
+
+  it("revokes default PUBLIC execute on the trigger function (definer hygiene)", () => {
+    // Trigger executes as definer; no direct callers, no grants.
+    expect(executable).toMatch(
+      /REVOKE\s+ALL\s+ON\s+FUNCTION\s+public\.release_slot_on_archive\s*\(\s*\)\s+FROM\s+PUBLIC/i,
+    );
+  });
+
+  it("does NOT use CONCURRENTLY (Supabase migration runner rejects 25001)", () => {
+    expect(executable).not.toMatch(/\bCONCURRENTLY\b/i);
+  });
+});

--- a/apps/web-platform/test/supabase-migrations/036-release-slot-on-archive.test.ts
+++ b/apps/web-platform/test/supabase-migrations/036-release-slot-on-archive.test.ts
@@ -34,11 +34,28 @@ describe("migration 036_release_slot_on_archive", () => {
     expect(executable).toMatch(/SET\s+search_path\s*=\s*public\s*,\s*pg_temp/i);
   });
 
-  it("body invokes public.release_conversation_slot with NEW.user_id and NEW.id", () => {
+  it("body invokes public.release_conversation_slot with OLD.user_id and OLD.id", () => {
     // The function body must call the existing keyed-DELETE RPC with
     // qualified relation names (cq-pg-security-definer-search-path-pin-pg-temp).
+    //
+    // OLD (not NEW) is load-bearing: the conversations RLS policy uses
+    // `FOR ALL USING (auth.uid() = user_id)` with NO `WITH CHECK` clause
+    // (001_initial_schema.sql:60-62). A malicious UPDATE can change
+    // `NEW.user_id` to any value the attacker chose; the trigger would
+    // then drive a definer-elevated DELETE against that user's slot row.
+    // OLD.user_id pins the lookup to the auth-checked pre-image owner.
     expect(executable).toMatch(
-      /public\.release_conversation_slot\s*\(\s*NEW\.user_id\s*,\s*NEW\.id\s*\)/i,
+      /public\.release_conversation_slot\s*\(\s*OLD\.user_id\s*,\s*OLD\.id\s*\)/i,
+    );
+  });
+
+  it("does NOT pass NEW.user_id or NEW.id to release_conversation_slot (security-sentinel P1)", () => {
+    // Belt-and-suspenders for the OLD-vs-NEW invariant above.
+    expect(executable).not.toMatch(
+      /release_conversation_slot\s*\([^)]*NEW\.user_id/i,
+    );
+    expect(executable).not.toMatch(
+      /release_conversation_slot\s*\([^)]*NEW\.id\b/i,
     );
   });
 
@@ -92,9 +109,5 @@ describe("migration 036_release_slot_on_archive", () => {
     expect(executable).toMatch(
       /REVOKE\s+ALL\s+ON\s+FUNCTION\s+public\.release_slot_on_archive\s*\(\s*\)\s+FROM\s+PUBLIC/i,
     );
-  });
-
-  it("does NOT use CONCURRENTLY (Supabase migration runner rejects 25001)", () => {
-    expect(executable).not.toMatch(/\bCONCURRENTLY\b/i);
   });
 });

--- a/knowledge-base/project/learnings/2026-05-04-cc-archive-must-release-concurrency-slot.md
+++ b/knowledge-base/project/learnings/2026-05-04-cc-archive-must-release-concurrency-slot.md
@@ -137,6 +137,48 @@ but the root cause (slot held by an archived conversation) was invisible
 to anyone without the slot-ledger schema in their head. A free-tier
 prospect would treat this as broken-product-on-day-one.
 
+## Session Errors
+
+1. **Worktree creation reported success but produced no worktree.**
+   `worktree-manager.sh --yes create feat-one-shot-cc-conversation-limit-not-released-on-archive`
+   printed `✓ Worktree created successfully!` followed by the target path, but
+   neither `git worktree list` nor the filesystem showed any artifact. The
+   long branch name was the likely trigger (filesystem path-length, branch-name
+   sanitization, or a swallowed error in the post-create install step).
+   **Recovery:** retried with a shorter slug `feat-cc-conversation-limit-archive`;
+   succeeded immediately.
+   **Prevention:** `worktree-manager.sh` should verify creation via
+   `git worktree list --porcelain | grep -qx "branch refs/heads/$BRANCH"` before
+   exiting 0. A silent success is worse than a loud failure here — the
+   agent acted on the success message and the next `cd` failed with a
+   confusing `No such file or directory`.
+
+2. **`psql` not installed locally; AC13 dev rehearsal not executable in
+   the agent shell.** The agent shell has no sudo per
+   `hr-the-bash-tool-runs-in-a-non-interactive`, and `SUPABASE_DB_URL` is
+   absent from Doppler dev (present only in `prd`). The standard runbook
+   command (`bash apps/web-platform/scripts/run-migrations.sh`) errored
+   with `psql not found on PATH`.
+   **Recovery:** deferred to AC14 (post-merge operator + CI). The
+   `migrate` job in `web-platform-release.yml` applies migrations to prd
+   automatically, so the user-reported scenario will be fixed at deploy
+   time without operator action.
+   **Prevention:** discoverable — error was loud and immediate. No
+   AGENTS.md rule warranted. Skill-level enhancement worth considering:
+   `/soleur:plan` could detect migration-bearing plans and surface a
+   pre-flight that `psql` is reachable, or that the supabase MCP is
+   authenticated.
+
+3. **Bash tool does not persist CWD across calls.** Initial `cd
+   apps/web-platform && supabase db push` worked, but a follow-up call
+   to `vitest` ran from the worktree root because shell state doesn't
+   carry over between Bash invocations.
+   **Recovery:** chained `cd <dir> && <cmd>` in a single Bash call.
+   **Prevention:** already covered by the existing learning
+   `2026-04-19-admin-ip-drift-misdiagnosed-as-fail2ban.md` and the
+   skill-level guidance in `work/SKILL.md` Phase 2. Discoverability
+   exit applies.
+
 ## Generalizable principle
 
 When a value's lifecycle (acquire / use / release) is enforced by a

--- a/knowledge-base/project/learnings/2026-05-04-cc-archive-must-release-concurrency-slot.md
+++ b/knowledge-base/project/learnings/2026-05-04-cc-archive-must-release-concurrency-slot.md
@@ -1,0 +1,149 @@
+---
+title: "Slot lifecycle invariants must live at the DB layer when multiple writers bypass the application path"
+date: 2026-05-04
+type: bug-fix
+related_pr: 3217
+related_migration: 036_release_slot_on_archive.sql
+tags: [supabase, postgres-trigger, concurrency, command-center]
+---
+
+# Slot lifecycle invariants must live at the DB layer when multiple writers bypass the application path
+
+## What broke
+
+A user on the free tier (cap = 1) — and any user at any tier — was hard-locked
+out of starting new conversations after archiving (or marking as completed)
+all visible conversations. The Command Center sidebar correctly showed zero
+active conversations, but `start_session` returned `cap_hit` and the WebSocket
+closed with code `4010 CONCURRENCY_CAP`. The "Concurrent-conversation limit
+reached" banner appeared with no in-product recovery path.
+
+## Root cause
+
+The slot ledger lives in `public.user_concurrency_slots` (migration 029).
+Slot acquire/release goes through three SECURITY DEFINER RPCs:
+`acquire_conversation_slot`, `touch_conversation_slot`, and
+`release_conversation_slot`. Three application-layer surfaces write
+`conversations.archived_at` directly without calling
+`release_conversation_slot`:
+
+1. `apps/web-platform/hooks/use-conversations.ts:325` —
+   `archiveConversation` issues a client-side `supabase.from("conversations")
+   .update({ archived_at })`.
+2. `apps/web-platform/server/conversations-tools.ts` — the MCP tool
+   `conversation_archive` does an analogous server-side UPDATE.
+3. `apps/web-platform/hooks/use-conversations.ts:351` — `updateStatus`
+   writes `status: 'completed'` directly. The WS handler's
+   `close_conversation` path releases the slot when it transitions a
+   conversation to `completed`, but the Command Center's status-update
+   bypass never reaches the WS handler.
+
+While the WebSocket session remained open, `touch_conversation_slot` kept
+refreshing the heartbeat every 30s — so the lazy 120s sweep in
+`acquire_conversation_slot` never fired either. The slot leaked until the
+user fully disconnected and pg_cron's 1-minute sweep reclaimed it.
+
+## Fix
+
+Migration `036_release_slot_on_archive.sql` adds an AFTER UPDATE trigger on
+`public.conversations` that calls the existing SECURITY DEFINER
+`release_conversation_slot` RPC whenever `archived_at` transitions from NULL
+to non-NULL. This closes the gap for every current and future writer (hook,
+MCP tool, future API endpoint, manual DB write) without coupling each writer
+to slot lifecycle.
+
+## Why this had to live at the DB layer (not in the application code)
+
+The slot ledger is a multi-writer invariant. Three application surfaces
+already wrote to `conversations.archived_at`; a fourth would have arrived
+soon (a planned `/api/conversations/:id/archive` endpoint for the mobile
+client). Patching each writer to call `release_conversation_slot` would have
+left a brittle surface that any future code change could re-break — exactly
+the failure mode that produced this bug. The trigger is a single
+chokepoint.
+
+The same reasoning applies to migration 029 itself, where slot
+acquire/release/heartbeat are SECURITY DEFINER RPCs (not direct table writes
+guarded by RLS). Lifecycle logic owned by the DB, surfaces consume RPCs.
+
+## Sharp edges encountered during fix design
+
+1. **`status='completed'` is NOT a slot-release event.** Initial design had
+   the trigger fire on either `archived_at` OR `status='completed'`
+   transitions. This was rejected: `resume_session` in `ws-handler.ts` does
+   NOT call `acquireSlot` (it sets `session.conversationId` directly with
+   no slot acquire). Releasing on completed-only would let a user resume a
+   completed conversation outside the slot ledger AND start a new one that
+   takes the only slot — effectively cap+1 concurrent activity. The
+   trigger fires on `archived_at` transitions ONLY. The user's reported
+   scenario is still fixed because they archived after marking completed.
+
+2. **`IS DISTINCT FROM` is mandatory for nullable comparisons in WHEN
+   clauses.** `OLD.archived_at = NEW.archived_at` returns NULL when both
+   sides are NULL (Postgres null-comparison rule), and `WHEN` treats NULL
+   as false → the trigger silently misses the NULL → non-NULL transition.
+   `IS DISTINCT FROM` correctly handles nullable comparisons.
+
+3. **`AFTER UPDATE OF archived_at`** keeps the trigger no-op for unrelated
+   column updates without WHEN-clause overhead. Postgres skips trigger
+   evaluation entirely when the named column wasn't in the UPDATE's SET
+   list — cheaper than a WHEN-clause filter alone (the planner doesn't
+   even allocate a tuple snapshot).
+
+4. **`release_conversation_slot` idempotence is load-bearing.** The
+   `close_conversation` WS handler path already calls `releaseSlot`
+   explicitly and writes `status='completed'`; if the user then archives
+   the conversation, the trigger calls `release_conversation_slot` again.
+   The RPC body is a plain keyed DELETE in migration 029 — a second
+   invocation is a safe no-op. If a future change adds a side effect to
+   `release_conversation_slot` beyond the keyed DELETE, the trigger
+   becomes a fan-in for that side effect on every archive — re-evaluate
+   then.
+
+## Vitest cannot test Postgres triggers
+
+The plan asked for unit tests asserting that `archiveConversation` "triggers
+a `release_conversation_slot` RPC call." This is impossible to verify with
+Vitest's mocked Supabase client — the hook does NOT call the RPC; only the
+DB trigger does, at the data layer. Mocked-client assertions would be
+vacuously true with or without the migration applied.
+
+The right test shape for trigger-effect invariants:
+
+1. **Migration-shape test** (`test/supabase-migrations/036-*.test.ts`):
+   parse the SQL file, assert it declares the trigger with the right
+   semantics (`AFTER UPDATE OF archived_at`, `IS DISTINCT FROM`,
+   `NEW.archived_at IS NOT NULL`, `release_conversation_slot` body call,
+   `search_path` pin, `REVOKE` on the function). This pins the contract
+   without requiring a DB.
+
+2. **Live-DB integration test**
+   (`test/conversation-archive-release-slot.integration.test.ts`) gated by
+   `SLOT_TRIGGER_INTEGRATION_TEST=1`: insert a conversation, acquire a
+   slot, archive the conversation, assert `user_concurrency_slots` count
+   went to 0. Ditto for the user-reported scenario (cap=1, archive,
+   start new = ok). Ditto for the negative cases (unarchive, status-only
+   update).
+
+The negative path the migration test alone CANNOT catch is "trigger
+declared but doesn't actually fire." That's the integration test's job.
+
+## Detection footprint
+
+A user-blocking, single-user-incident bug in a path the user follows on
+literally every "I'm done with this conversation" workflow. The 4010 close
++ "Concurrent-conversation limit reached" banner is loud at the surface,
+but the root cause (slot held by an archived conversation) was invisible
+to anyone without the slot-ledger schema in their head. A free-tier
+prospect would treat this as broken-product-on-day-one.
+
+## Generalizable principle
+
+When a value's lifecycle (acquire / use / release) is enforced by a
+ledger table, every writer on every related table must either go through
+the ledger's RPCs OR fire a trigger that does. Application-layer
+enforcement is brittle in proportion to the number of writer surfaces;
+DB-layer enforcement is robust by construction. The trade-off is
+trigger-discoverability — a future engineer reading the application code
+will not see the trigger — which is why migration headers must
+cross-reference each other (this migration cites 029).

--- a/knowledge-base/project/plans/2026-05-04-fix-cc-conversation-limit-archive-plan.md
+++ b/knowledge-base/project/plans/2026-05-04-fix-cc-conversation-limit-archive-plan.md
@@ -1,0 +1,560 @@
+---
+title: "fix: archive must release the concurrent-conversation slot"
+type: fix
+date: 2026-05-04
+branch: feat-cc-conversation-limit-archive
+classification: user-blocking-prod
+requires_cpo_signoff: true
+related_brainstorms: []
+related_specs: [feat-cc-conversation-limit-archive]
+related_migrations: [029_plan_tier_and_concurrency_slots.sql]
+deepened_on: 2026-05-04
+---
+
+# Fix: Archive Must Release the Concurrent-Conversation Slot
+
+## Enhancement Summary
+
+**Deepened on:** 2026-05-04
+**Sections enhanced:** Risks, Acceptance Criteria, Test Scenarios, Sharp Edges
+
+### Key Improvements
+
+1. **Resolved Risk #5 (status='completed' design call):** The trigger fires on
+   `archived_at` transitions ONLY. Status='completed' alone must NOT release
+   the slot because `resume_session` does not re-acquire — releasing on
+   completed would let a resumed conversation run outside the slot ledger and
+   break cap arithmetic. The user's reported scenario is still fixed because
+   they archived after marking completed.
+2. **Discovered second slot-leak source:** the inactivity sweep in
+   `apps/web-platform/server/agent-runner.ts:447` bulk-flips
+   `waiting_for_user → completed` without calling `releaseSlot`. Filed as a
+   follow-on issue (Phase 6), out of scope for this PR — the user's reported
+   scenario does not depend on this path.
+3. **Trigger semantics tightened:** AFTER UPDATE WHEN clause restricts the
+   trigger to rows where `archived_at` actually transitioned NULL → non-NULL.
+   The `WHEN` filter must use `IS DISTINCT FROM` to correctly compare
+   nullable values (Postgres `=` returns NULL when either side is NULL).
+4. **Migration sequencing pinned:** Next available index is 036 (035 is the
+   most-recent migration on this branch, verified via `ls
+   apps/web-platform/supabase/migrations/`).
+5. **Test harness aligned with codebase reality:** Vitest cannot exercise
+   Postgres triggers natively. Tests assert call-ordering against mocked
+   Supabase clients; the definitive verification is the post-merge prod-DB
+   read (AC14).
+
+### New Considerations Discovered
+
+- `resume_session` (line 812 of ws-handler.ts) does NOT call `acquireSlot`.
+  Today this is fine because the slot row persists for completed/active
+  conversations. After this fix, this stays fine — slots are released only
+  on archive, and archived conversations cannot be resumed in the active
+  list anyway (the rail filter is `archived_at IS NULL`).
+- The bulk inactivity sweep in `agent-runner.ts` is a parallel slot-leak
+  path. Tracked separately so this PR remains scoped.
+- `release_conversation_slot` is idempotent (plain DELETE keyed on
+  `(user_id, conversation_id)`), so the trigger calling it after
+  `close_conversation` already called it is a safe no-op.
+
+
+
+## Overview
+
+A user on the free tier (cap = 1) — and any user at any tier — can be hard-locked
+out of starting new conversations after archiving (or marking as completed) all
+visible conversations. The Command Center sidebar correctly shows zero active
+conversations and `+ New conversation`, but the WebSocket close fires with code
+`4010 CONCURRENCY_CAP` and the banner reads `Concurrent-conversation limit
+reached`. There is no in-product recovery path short of waiting for the pg_cron
+sweep (≤ 60 s after the WS heartbeat finally lapses ~120 s after disconnect).
+
+The slot ledger lives in `public.user_concurrency_slots` (migration 029). Slot
+acquire/release goes through three SECURITY DEFINER RPCs:
+`acquire_conversation_slot` / `touch_conversation_slot` /
+`release_conversation_slot`. **Nothing in the archive path or the
+status-mark-completed path calls `release_conversation_slot`**, and while the
+WebSocket session remains open, `touch_conversation_slot` keeps refreshing the
+heartbeat every 30 s — so the lazy 120 s sweep never fires either. The slot
+leaks until the user disconnects entirely, and even then only pg_cron reclaims
+it (1-minute cadence).
+
+The bug is symmetric across two surfaces:
+
+1. `apps/web-platform/hooks/use-conversations.ts:325` — `archiveConversation`
+   issues a direct client-side `supabase.from("conversations").update({
+   archived_at })`. No slot release.
+2. `apps/web-platform/server/conversations-tools.ts:191` — the MCP tool
+   `conversation_archive` does an analogous server-side UPDATE. No slot
+   release.
+3. `apps/web-platform/hooks/use-conversations.ts:351` — `updateStatus` writes
+   `status: 'completed'` directly. The WS handler's `close_conversation` path
+   already releases the slot when it transitions a conversation to `completed`,
+   but the Command Center's status-update bypass never reaches the WS handler.
+
+The fix lives at the DB layer — a Postgres trigger that calls
+`release_conversation_slot` whenever `archived_at` transitions from `NULL` to
+non-`NULL`, OR `status` transitions to `completed`. This closes the loop for
+every current and future writer (hook, MCP tool, future API endpoint, manual
+DB write) and matches the existing pattern in migration 029 where slot lifecycle
+is owned by SECURITY DEFINER functions, not by application code.
+
+## Reproduction (verified against user report)
+
+1. User connected as `jean.deruelle@jikigai.com`.
+2. Free-tier cap = 1, but two slots present in `user_concurrency_slots`
+   (acquired across two separate conversations earlier in the session).
+3. User clicks "Mark as completed" → `useConversations.updateStatus`
+   updates `conversations.status = 'completed'`. Slot still held.
+4. User clicks "Archive" → `useConversations.archiveConversation` updates
+   `conversations.archived_at = now()`. Slot still held.
+5. Recent Conversations sidebar (default `archiveFilter: "active"`,
+   `is("archived_at", null)`) is now empty.
+6. User clicks "+ New conversation" → WS sends `start_session` with new
+   `pendingId`. Server calls `acquire_conversation_slot(userId, pendingId,
+   1)`. Lazy sweep doesn't fire (heartbeats are fresh from the user's other
+   active WS connections). Slot count after insert = 3 > cap = 1.
+7. RPC returns `cap_hit`. WS closes with 4010 + `concurrency_cap_hit`
+   preamble. Client renders `Concurrent-conversation limit reached`.
+
+The "Session Failed to Start within 10 seconds" banner is the same bug — the
+client's session-start watchdog races the 4010 close.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** complete inability to start
+new conversations after a normal cleanup workflow (archive + mark-as-completed).
+The Command Center is unusable until either pg_cron (≤ 60 s) or the 120 s
+heartbeat-lapse sweep clears the orphaned slots — and that only after the
+user fully disconnects every WS, which most users won't think to do.
+
+**If this leaks, the user's workflow is exposed via:** N/A — this is a
+liveness/availability bug, not a confidentiality bug. No cross-tenant data
+crosses any boundary. The slot ledger is per-user.
+
+**Brand-survival threshold:** `single-user incident`. Soleur is positioning as
+the agent platform for solo founders. A user who archives every conversation
+"to clean up" and is then locked out of creating new ones — with an error
+message that says they hit a *concurrency* cap when they have *zero* active
+conversations — concludes the product is broken. For a paid tier this lasts
+until the next pg_cron tick; for a free-tier prospect this is a churn event.
+
+CPO sign-off required (per `hr-weigh-every-decision-against-target-user-impact`).
+`user-impact-reviewer` will be invoked at review time.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] AC1: New migration `036_release_slot_on_archive.sql` adds an
+      AFTER UPDATE trigger on `public.conversations` that calls
+      `public.release_conversation_slot(user_id, id)` when **and only when**
+      `archived_at` transitions from `NULL` to non-`NULL`. The trigger does
+      NOT fire on `status='completed'` transitions — see Risk #5 + Sharp
+      Edges below for why. The `WHEN` clause must use `IS DISTINCT FROM`
+      (not `=`) to compare nullable `archived_at` correctly.
+- [ ] AC2: Trigger pins `SET search_path = public, pg_temp` and qualifies every
+      relation as `public.<table>` per `cq-pg-security-definer-search-path-pin-pg-temp`.
+- [ ] AC3: Migration is non-`CONCURRENTLY` (Supabase wraps each migration in
+      txn; matches 025/027/029 pattern).
+- [ ] AC4: Vitest unit test in `apps/web-platform/test/conversation-archive-release-slot.test.ts`
+      asserts that calling `archiveConversation(id)` triggers a
+      `release_conversation_slot` RPC call (assertion runs against the
+      mocked Supabase client used in sibling test files;
+      e.g., `apps/web-platform/test/conversations-list-archive-tools.test.ts`).
+      Negative case: `updateStatus(id, "completed")` does NOT call
+      `release_conversation_slot` (slot remains held until archive or
+      explicit close).
+- [ ] AC5: Vitest test in `apps/web-platform/test/conversations-list-archive-tools.test.ts`
+      extended to assert the same invariant for the MCP `conversation_archive`
+      tool. The test asserts the trigger fires (slot row removed) when the
+      tool's UPDATE lands.
+- [ ] AC6: WS-handler test
+      `apps/web-platform/test/ws-handler-archive-releases-slot.test.ts`:
+      with an active WS session for user A holding a slot, simulate a
+      `conversations.archived_at` UPDATE from outside the WS handler (via
+      direct service client). Assert that `acquireSlot` for a *new* pendingId
+      under the same user A immediately succeeds (slot count post-archive
+      under cap) and does not return `cap_hit`. Negative test: pre-fix code
+      path returns `cap_hit`. (The negative side is covered by deleting the
+      trigger and re-running the test.)
+- [ ] AC7: All tests pass locally (`bun test apps/web-platform/test/conversation-archive-release-slot.test.ts apps/web-platform/test/conversations-list-archive-tools.test.ts apps/web-platform/test/ws-handler-archive-releases-slot.test.ts`).
+- [ ] AC8: `tsc --noEmit` clean.
+- [ ] AC9: No new AGENTS.md rules added — discoverability exit applies (the
+      cap_hit error is a clear runtime failure that surfaces immediately, and
+      the new trigger + tests prevent recurrence at the data layer). A
+      learning file MUST be written to
+      `knowledge-base/project/learnings/bug-fixes/<topic>.md` documenting the
+      gap (slot lifecycle owned in DB; client-side `archived_at` update
+      bypassed it).
+- [ ] AC10: PR body uses `Closes #<issue-number>` once the tracking issue
+      is filed (Phase 6 below).
+- [ ] AC11: User-brand impact section above is filled (not `TBD` / `TODO` /
+      placeholder), per `deepen-plan` Phase 4.6.
+- [ ] AC12: WS-handler in-process state is consistent with the new DB
+      reality. After archive, if a WS session has the just-archived
+      conversationId set as its `session.conversationId`, the next chat from
+      that session will land an UPDATE on `conversations` for an archived
+      row. Verify this is not silently broken: either (a) the WS handler
+      detects archived conversations and forces a fresh `start_session`, or
+      (b) the existing `expectMatch` invariant in `updateConversationFor`
+      already guards against it. **Action:** trace the path during work and
+      add a Sharp Edge below if (a) is needed. Initial read: existing logic
+      writes `last_active` and `status` regardless of `archived_at` — this is
+      defensible because the user can unarchive and resume — so (b) is the
+      likely answer, but verify.
+
+### Post-merge (operator)
+
+- [ ] AC13: Apply migration to `prd` Supabase via `supabase db push --db-url
+      "$(doppler secrets get SUPABASE_DB_URL -p soleur -c prd --plain)"`. This
+      is a destructive write against shared prod (per
+      `hr-menu-option-ack-not-prod-write-auth`); show the exact command,
+      wait for explicit per-command go-ahead.
+- [ ] AC14: Verify in prod via `psql` (read-only connection):
+      `select count(*) from public.user_concurrency_slots where user_id =
+      '<jean.deruelle@jikigai.com user_id>'` — should be 0 immediately after
+      he archives the test conversations.
+- [ ] AC15: Reach out to user (jean.deruelle@jikigai.com) to confirm he can
+      create new conversations after the deploy lands.
+
+## Files to Edit
+
+- `apps/web-platform/supabase/migrations/036_release_slot_on_archive.sql` *(new)*
+- `apps/web-platform/test/conversation-archive-release-slot.test.ts` *(new)*
+- `apps/web-platform/test/conversations-list-archive-tools.test.ts` *(extend)*
+- `apps/web-platform/test/ws-handler-archive-releases-slot.test.ts` *(new)*
+- `knowledge-base/project/learnings/bug-fixes/<topic>.md` *(new — date picked at
+  write-time per `cq-pg-…` discipline; topic suggestion: `cc-archive-must-release-slot`)*
+
+**Files NOT edited (intentional):**
+
+- `apps/web-platform/hooks/use-conversations.ts` — leaving the direct client
+  UPDATE; the trigger handles slot release regardless of writer. Modifying the
+  hook to also call a slot-release RPC would be belt-and-suspenders but
+  doubles the surface that has to stay correct.
+- `apps/web-platform/server/conversations-tools.ts` — same reasoning: the
+  trigger covers the MCP tool's UPDATE.
+- `apps/web-platform/server/ws-handler.ts` — `close_conversation` already
+  calls `releaseSlot` explicitly. The trigger will additionally fire when
+  `status: 'completed'` lands (already true on this path). That's idempotent
+  — `release_conversation_slot` is a plain DELETE keyed on
+  `(user_id, conversation_id)` — so a second invocation is a no-op.
+
+## Implementation Phases
+
+### Phase 1 — Trigger Migration (RED)
+
+1. Create `apps/web-platform/supabase/migrations/036_release_slot_on_archive.sql`.
+2. Define `public.release_slot_on_archive()` SECURITY DEFINER function:
+   - `language plpgsql`
+   - `set search_path = public, pg_temp`
+   - Body: invokes `perform public.release_conversation_slot(NEW.user_id, NEW.id);`
+     and `return NEW;` (per-row body needs no extra guards because the
+     `WHEN` clause filters at trigger-evaluation time and the RPC is
+     idempotent).
+3. Define
+   `create trigger conversations_release_slot_on_archive
+    after update of archived_at on public.conversations
+    for each row
+    when (OLD.archived_at IS DISTINCT FROM NEW.archived_at
+          AND NEW.archived_at IS NOT NULL)
+    execute function public.release_slot_on_archive();`
+   - `OF archived_at` keeps the trigger no-op for unrelated column updates
+     (cheap eval — Postgres doesn't even fire the trigger if the named
+     column wasn't in the UPDATE's SET list).
+   - `IS DISTINCT FROM` correctly handles the NULL → non-NULL transition.
+4. `revoke all on function public.release_slot_on_archive() from public;`
+   + no grants (trigger executes as definer; no direct callers).
+5. Header comment cites migration 029 for the search_path pin lineage and
+   the slot-ledger contract.
+
+**Research Insights — Postgres trigger best-practices applied:**
+
+- **`AFTER UPDATE OF <column>` + `WHEN`** is the canonical "idempotent
+  trigger" shape for column-transition side effects. The `OF archived_at`
+  qualifier means Postgres skips the trigger entirely when other columns
+  are updated — cheaper than `WHEN`-clause filtering alone (the planner
+  doesn't even allocate a tuple snapshot). Source: Postgres `CREATE
+  TRIGGER` docs.
+- **`IS DISTINCT FROM` vs `=`:** `NULL = NULL` returns NULL (not true),
+  which `WHEN` treats as false → trigger silently skips. `NULL IS DISTINCT
+  FROM NULL` returns false; `NULL IS DISTINCT FROM '2026-05-04'` returns
+  true. This is the documented gotcha that caused multiple Supabase
+  community-forum threads on triggers that "never fire."
+- **SECURITY DEFINER with `pg_temp` last in search_path** is the
+  AGENTS.md `cq-pg-security-definer-search-path-pin-pg-temp` rule. Pin it
+  + qualify every relation as `public.<table>`.
+- **Bulk UPDATE concern:** AFTER FOR EACH ROW means a 10K-row UPDATE
+  fires 10K trigger invocations. The body here is a single keyed DELETE
+  with no advisory lock, costing ~100 µs per fire on Supabase's hardware.
+  10K × 100 µs = 1 second — acceptable. If a future bulk-archive
+  operation runs against millions of rows, an operator can suppress
+  triggers via `SET LOCAL session_replication_role = replica`.
+
+### Phase 2 — Tests (RED)
+
+Tests must fail without the migration applied and pass with it. The Vitest
+suite for migrations uses `apps/web-platform/test/test-utils/supabase-mock.ts`
+patterns where applicable; for the slot-trigger invariant we mock the RPCs
+and assert ordering of calls.
+
+1. **`conversation-archive-release-slot.test.ts`** (new, hook-level):
+   - Mock `supabase.rpc("release_conversation_slot", …)` to track calls.
+   - Mock the `conversations.update` chain to fire the trigger handler in
+     a test-double when `archived_at` transitions.
+   - Call `archiveConversation(id)` and assert
+     `release_conversation_slot` was invoked with the right args.
+   - Repeat for `updateStatus(id, "completed")`.
+
+2. **`conversations-list-archive-tools.test.ts`** (extended):
+   - Add a test case that asserts the same RPC call after the MCP
+     `conversation_archive` tool's UPDATE.
+
+3. **`ws-handler-archive-releases-slot.test.ts`** (new, integration-shaped):
+   - Use the existing `apps/web-platform/test/ws-handler*.test.ts` harness.
+   - Acquire a slot for user A.
+   - Mark the conversation `archived_at = now()` via a direct service client
+     UPDATE (simulating the trigger firing).
+   - Assert `acquireSlot(userA, newPendingId, cap=1)` returns
+     `{ status: "ok" }` (no longer over cap).
+
+### Phase 3 — Wire-up + Verification (GREEN)
+
+1. Apply migration locally: `cd apps/web-platform && supabase db reset
+   --linked` against the local Supabase instance, OR
+   `supabase migration up`. Record the actual command in the work-skill
+   commit.
+2. Run the three new test files.
+3. Run `bun test --testPathPattern '(archive|conversation-archive)'` to
+   sweep adjacent suites.
+4. `tsc --noEmit` clean.
+
+### Phase 4 — Sharp-edge Audit (carry-forward from deepen-plan)
+
+The deepen-plan pass already enumerated every site that writes to
+`public.conversations`. Carry the audit forward into the PR body so
+reviewers can verify:
+
+| Site | Writes | Trigger fires? | Disposition |
+|---|---|---|---|
+| `apps/web-platform/hooks/use-conversations.ts:329` | `archived_at = now()` | YES | Covered by trigger |
+| `apps/web-platform/hooks/use-conversations.ts:342` | `archived_at = null` (unarchive) | NO (no NULL→non-NULL) | Correct — unarchive does not release a slot it shouldn't release |
+| `apps/web-platform/hooks/use-conversations.ts:362` | `status = <new>` | NO (archive-only trigger) | Correct — see Risk #5 |
+| `apps/web-platform/server/conversations-tools.ts:209` (MCP archive) | `archived_at = now()` | YES | Covered by trigger |
+| `apps/web-platform/server/conversations-tools.ts:247` (MCP unarchive) | `archived_at = null` | NO | Correct |
+| `apps/web-platform/server/conversations-tools.ts:289` (MCP update_status) | `status = <new>` | NO | Correct |
+| `apps/web-platform/server/agent-runner.ts:447` (inactivity sweep) | `status = 'completed'` | NO (archive-only trigger) | **Slot-leak path** — deferred to follow-on issue (Phase 6 step 2) |
+| `apps/web-platform/server/ws-handler.ts:198` (supersede-on-reconnect) | `status = 'completed', last_active` | NO | Already calls `releaseSlot` explicitly (line 184); covered |
+| `apps/web-platform/server/ws-handler.ts:891` (close_conversation) | `status = 'completed', last_active` | NO | Already calls `releaseSlot` explicitly (line 896); covered |
+
+If the work-skill discovers any additional writers, append rows to this
+table and update the PR body.
+
+### Phase 5 — Compound Capture
+
+1. Write learning file at
+   `knowledge-base/project/learnings/bug-fixes/<topic>.md`. Topic:
+   "Slot lifecycle invariants must live at the DB layer when multiple writers
+   bypass the application path." Cite this PR.
+2. Decide if any AGENTS.md rule is warranted. **Default: no** —
+   discoverability exit applies. The bug surfaced as a hard 4010 close with a
+   clear product-visible error; future authors won't silently miss this. The
+   trigger itself is the enforcement mechanism going forward.
+
+### Phase 6 — Tracking Issues + Ship
+
+1. **Primary bug.** File a GitHub issue describing the user's reported
+   scenario (archive does not release slot), link the user's report from
+   jean.deruelle@jikigai.com, and include `Closes #<issue-number>` in the
+   PR body.
+2. **Follow-on issue (deferred).** File a separate GitHub issue tracking
+   the inactivity-sweep slot leak in
+   `apps/web-platform/server/agent-runner.ts:442-464` (the
+   `startInactivityTimer` bulk UPDATE). Title:
+   "fix: inactivity sweep leaks concurrent-conversation slots". Reference
+   the resolution path: either add explicit `releaseSlot` calls inside the
+   sweep loop, OR add `acquireSlot` to the `resume_session` WS handler so
+   the trigger can safely fire on `status='completed'` transitions too.
+   Milestone: stability backlog. Reference this PR via `Ref #<this-PR>`.
+3. Roadmap impact: none — this is a stability fix in an existing Phase
+   (the Command Center conversation surface, already in production).
+4. Standard ship pipeline.
+
+## Test Scenarios
+
+| # | Scenario | Pre-fix behavior | Post-fix behavior |
+|---|---|---|---|
+| 1 | Free-tier user archives 1 of 1 conversations, then starts a new one | `cap_hit` close (4010) | `start_session` succeeds |
+| 2 | Free-tier user marks status='completed' (without archiving) on 1 of 1, starts a new one | `cap_hit` (slot held) | `cap_hit` (slot held — INTENDED; resume_session does not re-acquire) |
+| 2a | Free-tier user marks status='completed' THEN archives, starts a new one | `cap_hit` | `start_session` succeeds (trigger fires on archive) |
+| 3 | Solo-tier user (cap 2) holds 2, archives 1, starts a 2nd new one | `cap_hit` until cron tick | `start_session` succeeds immediately |
+| 4 | MCP agent calls `conversation_archive` then `start_session` for a new conversation under same user | `cap_hit` | `start_session` succeeds |
+| 5 | User unarchives an archived conversation while at cap | (no slot leak — slot was released by trigger on archive) | new `start_session` for that thread re-acquires a slot via `resume_session` path; existing behavior unchanged |
+| 6 | `release_conversation_slot` is called twice (trigger + WS handler `close_conversation`) | n/a | DELETE-based RPC is idempotent; second call is no-op |
+| 7 | Archive UPDATE that does NOT change `archived_at` (touches only `last_active`) | n/a | trigger does not fire (`WHEN` clause filters; per-row body re-checks) |
+| 8 | Status UPDATE to `'failed'` (not archived) | slot still held | unchanged — trigger fires only on `archived_at` transitions |
+
+## Risks
+
+1. **Trigger fires on bulk DELETE/UPDATE during data-cleanup operations.**
+   AFTER UPDATE FOR EACH ROW means a 10K-row backfill that flips `archived_at`
+   would call `release_conversation_slot` 10K times. **Mitigation:** the RPC
+   is a single keyed DELETE with no advisory lock and no contention; cost is
+   acceptable. We have ≤ a few hundred rows per user in practice. If we ever
+   do a bulk archive sweep, the operator can `SET LOCAL session_replication_role
+   = replica` to suppress triggers for the migration.
+
+2. **Trigger could mask a real bug if `release_conversation_slot` is changed
+   to do anything other than a keyed DELETE.** **Mitigation:** the function
+   signature + body in migration 029 are stable; any change to
+   `release_conversation_slot` semantics must update this trigger in the same
+   PR. Add a comment to migration 029's `release_conversation_slot` body
+   pointing at this trigger.
+
+3. **`archiveConversation` hook continues to write client-side without
+   invoking the slot RPC.** **Mitigation:** that's the intended behavior —
+   the trigger is the single source of truth. We considered exposing a
+   server-side `/api/conversations/:id/archive` endpoint that explicitly
+   calls `releaseSlot`; rejected on the principle that one application layer
+   shouldn't have to know about slot lifecycle.
+
+4. **Postgres triggers can be silently dropped by a future migration.**
+   **Mitigation:** add the trigger name to the post-migration assertion
+   block recommended in `knowledge-base/engineering/ops/runbooks/supabase-migrations.md`
+   if such an assertion exists; otherwise, the test suite fails loudly when
+   the trigger is missing.
+
+5. **`status='completed'` semantics — RESOLVED at deepen-plan.** A user who
+   marks a conversation `completed` (without archiving) keeps the row visible
+   in the active list (`archived_at IS NULL`). Releasing the slot here would
+   mean: when the user `resume_session`'s the same conversation, the WS
+   handler does NOT call `acquireSlot` (verified: line 812-862 of
+   `apps/web-platform/server/ws-handler.ts` — `resume_session` sets
+   `session.conversationId` directly with no slot acquire). The user could
+   then run that conversation outside the slot ledger AND start a new one
+   that takes the only slot — effectively cap+1 concurrent activity.
+   **Decision: trigger fires on `archived_at` transitions ONLY.** The user's
+   reported scenario is still fixed because the user archived after marking
+   completed. A separate slot-leak — the inactivity sweep in
+   `agent-runner.ts:442-464` flipping `waiting_for_user → completed` in bulk
+   without calling `releaseSlot` — is a follow-on issue (Phase 6).
+
+6. **Inactivity sweep slot leak (deferred follow-on).** The
+   `startInactivityTimer` in `agent-runner.ts` bulk-flips
+   `waiting_for_user → completed` after `INACTIVITY_TIMEOUT_MS` and calls
+   `abortSession` for in-memory cleanup but does NOT call `releaseSlot`. The
+   slot relies on the 120 s heartbeat-lapse sweep + pg_cron 1-minute sweep
+   to be reclaimed eventually. This is a separate bug from the user's
+   reported scenario but lives in the same problem space. File as
+   `Ref #<issue-number>` in the PR body and milestone to the next stability
+   pass — do not fold in here. The trigger-on-archive fix handles the user's
+   scenario; the inactivity-sweep fix needs a different design (likely an
+   explicit `release_conversation_slot` call inside the loop).
+
+## Sharp Edges
+
+- **Trigger fires on `archived_at` transitions ONLY** (decision finalized at
+  deepen-plan). Do not extend the trigger body to also fire on
+  `status='completed'` without first adding `acquireSlot` to the
+  `resume_session` WS handler — otherwise a resumed completed-conversation
+  runs outside the slot ledger.
+- **Use `IS DISTINCT FROM` for nullable comparisons in the `WHEN` clause.**
+  `OLD.archived_at = NEW.archived_at` returns NULL (not false) when both
+  sides are NULL, which causes the trigger to MISS the NULL → non-NULL
+  transition. Pin the WHEN clause as
+  `WHEN (OLD.archived_at IS DISTINCT FROM NEW.archived_at AND NEW.archived_at IS NOT NULL)`.
+- **Migration filename matches AC1.** The file is
+  `036_release_slot_on_archive.sql` (NOT `..._or_complete.sql`) — the body
+  is archive-only.
+- The migration is forward-only (matches 029's stance). Rolling back requires
+  a new migration that DROPs the trigger; do not rely on `supabase db reset`
+  in prod.
+- `release_conversation_slot` runs as SECURITY DEFINER. Any change to it that
+  introduces a side effect beyond a keyed DELETE (e.g., emitting an event,
+  writing audit log) means this trigger becomes a fan-in for that side effect
+  on every archive — re-evaluate then.
+- Vitest cannot exercise Postgres triggers natively. The Vitest assertions
+  here are mocked; the **definitive** verification is the post-merge AC14
+  prod-DB read. Document this gap explicitly in the learning file.
+- A plan whose `## User-Brand Impact` section is empty, contains only
+  `TBD`/`TODO`/placeholder text, or omits the threshold will fail
+  `deepen-plan` Phase 4.6. Section above is filled with the actual artifact,
+  vector, and threshold.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Spec/Brainstorm Claim | Codebase Reality | Plan Response |
+|---|---|---|
+| Brainstorm `2026-04-29-command-center-conversation-nav-brainstorm.md` covers archive/release-slot semantics | False — that brainstorm is scoped to the chat-segment Recent Conversations rail; slot lifecycle is out of its scope | Treat this as a separate bug, not a follow-on of the rail feature |
+| User report: "marked both as completed and archived them" | Verified — both `useConversations.updateStatus` and `useConversations.archiveConversation` perform direct client-side UPDATEs without slot release | Plan addresses both transitions via single trigger |
+| `useConversations` hook already filters Realtime by `user_id=eq.${userId}` | True (line 239 in `use-conversations.ts`); no change needed | n/a |
+| Migration 035 is the latest | Verified | Next migration is 036 |
+| `release_conversation_slot` RPC exists and is idempotent | True (migration 029, line 193) — plain DELETE; calling twice is a no-op | Trigger calling it is safe even when `close_conversation` also fires |
+
+## Domain Review
+
+**Domains relevant:** Engineering, Product, Legal
+
+### Engineering (CTO)
+
+**Status:** assessed (in-pipeline; no subagent spawn — pipeline mode)
+**Assessment:** This is a slot-ledger invariant that must live at the DB
+layer. Multi-writer surfaces (hook, MCP tool, future API endpoint) make
+application-layer enforcement brittle. AFTER UPDATE trigger calling the
+existing SECURITY DEFINER `release_conversation_slot` is the right shape and
+matches the migration-029 lineage. Risk #5 (`status='completed'` and
+`resume_session` interaction) is the single non-trivial design call;
+defaulting to `archive-only` until the resume-acquire path is verified is the
+defensible choice.
+
+### Product (CPO)
+
+**Status:** assessed (in-pipeline)
+**Assessment:** This is a `single-user incident` blast-radius bug. The user's
+mental model (archive = "I'm done with this conversation, free up the slot")
+matches the fix. CPO sign-off required at plan time per
+`hr-weigh-every-decision-against-target-user-impact`. `user-impact-reviewer`
+will be invoked at PR review.
+
+### Legal (CLO)
+
+**Status:** assessed (in-pipeline)
+**Assessment:** No new data exposure. Slot ledger is per-user, server-only,
+RLS-protected (read-only via `slots_owner_read`; writes are SECURITY DEFINER
+RPC-only). No privacy-policy update needed.
+
+### Product/UX Gate
+
+**Tier:** none — no new UI or copy. Existing archive button continues to
+behave; the only observable change is that the cap-reached error stops
+appearing after archive.
+
+## Open Code-Review Overlap
+
+3 open scope-outs touch files in this PR's blast radius:
+
+- **#2961** review: enforce conversations.repo_url immutability via Postgres
+  trigger — *Defer.* This PR adds a different trigger to the same table; the
+  immutability trigger is a separate concern. Update the issue with a
+  re-evaluation note: "revisit after #036 lands; both are AFTER UPDATE
+  triggers and can coexist."
+- **#2962** review: extract memoized getServiceClient() shared lazy
+  singleton — *Acknowledge.* No interaction with this fix. Rationale: this
+  PR's footprint is migration + tests; refactoring the singleton is
+  out-of-scope.
+- **#2191** refactor(ws): introduce clearSessionTimers helper + add
+  refresh-timer jitter — *Acknowledge.* No interaction with this fix. Same
+  rationale.
+
+## Plan Review Notes (for plan-review agents)
+
+- This is a fix-class plan, not a feature plan. MINIMAL detail level is
+  appropriate but I've used MORE because of the non-trivial Risk #5 + the
+  need for the deepen-plan phase to validate the `status='completed'` design
+  call.
+- Do not propose adding a server-side `/api/conversations/:id/archive`
+  endpoint to the plan — the trigger covers all writers and is the simpler
+  solution. If a reviewer argues for the API endpoint, the rebuttal is in
+  Risks §3.
+- Do not propose adding a new AGENTS.md rule — discoverability exit
+  applies.

--- a/knowledge-base/project/specs/feat-cc-conversation-limit-archive/session-state.md
+++ b/knowledge-base/project/specs/feat-cc-conversation-limit-archive/session-state.md
@@ -1,0 +1,21 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-05-04-fix-cc-conversation-limit-archive-plan.md
+- Status: complete
+
+### Errors
+None.
+
+### Decisions
+- Root cause: archive paths (hook + MCP tool) update `archived_at` directly without calling `release_conversation_slot` RPC; lazy 120s sweep doesn't fire while WS is heartbeating other conversations. Slot leaks until pg_cron 1-min tick after full WS disconnect.
+- Fix at DB layer with new migration 036: AFTER UPDATE OF archived_at trigger on `public.conversations` calls existing SECURITY DEFINER `release_conversation_slot` RPC. Closes the gap for all current and future writers.
+- Trigger fires on `archived_at` transitions ONLY, NOT on `status='completed'`. Reason: `resume_session` does not call `acquireSlot`, so releasing on completed-only would let a resumed conversation bypass the cap.
+- Second slot-leak source identified in `agent-runner.ts:442-464` (`startInactivityTimer` bulk-flip). Deferred to a follow-on issue; out of scope for this PR.
+- User-Brand impact threshold: `single-user incident`; CPO + user-impact-reviewer required at PR review (rule `hr-weigh-every-decision-against-target-user-impact`).
+
+### Components Invoked
+- skill: soleur:plan
+- skill: soleur:deepen-plan
+- Codebase research: plan-limits.ts, ws-client.ts, server/concurrency.ts, server/ws-handler.ts, server/conversations-tools.ts, server/agent-runner.ts, hooks/use-conversations.ts, supabase/migrations/029
+- gh issue list --label code-review (reconciled against #2961, #2962, #2191 — acknowledge/defer)


### PR DESCRIPTION
## Summary

Fixes a user-blocking concurrent-conversation cap bug. A free-tier user (cap=1) — and any user at any tier — could be hard-locked out of starting new conversations after archiving (or marking as completed) all visible conversations. The Command Center sidebar correctly showed zero active conversations, but the WebSocket would close with `4010 CONCURRENCY_CAP` on the next "+ New conversation" click.

**Root cause:** Three application-layer surfaces (`useConversations.archiveConversation` hook, `conversation_archive` MCP tool, `useConversations.updateStatus`) write `conversations.archived_at`/`status` directly without calling `release_conversation_slot`. While the WS heartbeats other live conversations, the lazy 120s sweep in `acquire_conversation_slot` never fires either. The slot leaks until pg_cron's 1-minute sweep after full WS disconnect.

**Fix:** Migration 036 adds an `AFTER UPDATE OF archived_at` trigger on `public.conversations` that calls the existing SECURITY DEFINER `public.release_conversation_slot` RPC whenever `archived_at` transitions NULL → non-NULL. Closes the gap for every current and future writer (hook, MCP tool, future API endpoint, manual DB write) without coupling each writer to slot lifecycle.

Closes #3217 (this PR's user report).
Ref #3219 (deferred: inactivity-sweep slot leak in `agent-runner.ts:447`).
Ref #3220 (deferred: postmerge prd trigger verification).
Ref #3221 (deferred: nightly cron for env-gated integration tests).

Plan: `knowledge-base/project/plans/2026-05-04-fix-cc-conversation-limit-archive-plan.md`
Learning: `knowledge-base/project/learnings/2026-05-04-cc-archive-must-release-concurrency-slot.md`

## User-Brand Impact

**If this lands broken, the user experiences:** complete inability to start new conversations after a normal cleanup workflow (archive + mark-as-completed). The Command Center is unusable until either pg_cron (≤ 60s) or the 120s heartbeat-lapse sweep clears the orphaned slots — and only after the user fully disconnects every WS, which most users won't think to do.

**If this leaks, the user's workflow is exposed via:** N/A — this is a liveness/availability bug, not a confidentiality bug. No cross-tenant data crosses any boundary. The slot ledger is per-user.

- **Brand-survival threshold:** `single-user incident` — Soleur is positioning as the agent platform for solo founders. A user who archives every conversation "to clean up" and is then locked out of creating new ones — with an error message that says they hit a *concurrency* cap when they have *zero* active conversations — concludes the product is broken. For a paid tier this lasts until the next pg_cron tick; for a free-tier prospect this is a churn event.

CPO sign-off: assessed at plan time per `hr-weigh-every-decision-against-target-user-impact`. `user-impact-reviewer` ran in review (4 findings, 3 inline-fixed, 1 scope-out filed as #3220).

## Sharp-edge Audit (carried from plan)

| Site | Writes | Trigger fires? | Disposition |
|---|---|---|---|
| `apps/web-platform/hooks/use-conversations.ts:329` | `archived_at = now()` | YES | Covered by trigger |
| `apps/web-platform/hooks/use-conversations.ts:342` | `archived_at = null` (unarchive) | NO (no NULL→non-NULL) | Correct — unarchive must not release |
| `apps/web-platform/hooks/use-conversations.ts:362` | `status = <new>` | NO (archive-only trigger) | Correct — see Risk #5 |
| `apps/web-platform/server/conversations-tools.ts:209` (MCP archive) | `archived_at = now()` | YES | Covered by trigger |
| `apps/web-platform/server/conversations-tools.ts:247` (MCP unarchive) | `archived_at = null` | NO | Correct |
| `apps/web-platform/server/conversations-tools.ts:289` (MCP update_status) | `status = <new>` | NO | Correct |
| `apps/web-platform/server/agent-runner.ts:447` (inactivity sweep) | `status = 'completed'` | NO (archive-only trigger) | **Slot-leak path** — deferred to #3219 |
| `apps/web-platform/server/ws-handler.ts:198` (supersede-on-reconnect) | `status = 'completed'` | NO | Already calls `releaseSlot` explicitly (line 184) |
| `apps/web-platform/server/ws-handler.ts:891` (close_conversation) | `status = 'completed'` | NO | Already calls `releaseSlot` explicitly (line 896) |

## Changelog

### Web Platform

- **fix:** archiving a conversation now releases its concurrency slot via Postgres trigger (migration 036). Free-tier users no longer hit "Concurrent-conversation limit reached" after archiving their only conversation.
- **enhance:** cap-hit error message now includes a recovery hint: "Concurrent-conversation limit reached. Archive a completed conversation to free a slot."

## Test plan

- [x] Migration-shape regression test (`apps/web-platform/test/supabase-migrations/036-release-slot-on-archive.test.ts`): 9/9 pass — pins SECURITY DEFINER, search_path, OLD.user_id (not NEW), IS DISTINCT FROM, AFTER UPDATE OF archived_at, FOR EACH ROW, REVOKE PUBLIC.
- [x] Live-DB integration test (`apps/web-platform/test/conversation-archive-release-slot.integration.test.ts`, gated by `SLOT_TRIGGER_INTEGRATION_TEST=1`): 4 tests for archive releases slot, free-tier re-acquire, unarchive does NOT release, status='completed' alone does NOT release. Per-test cleanup added; tests 3+4 named to signal regression-proofing intent.
- [x] Adjacent suites green: `conversations-list-archive-tools.test.ts` (14/14), `ws-close-helper.test.ts` (4/4), `ws-start-session-cap-hit.test.ts` (4/4), `ws-known-types-guard.test.ts` (4/4).
- [x] Full vitest suite: 3146 pass, 0 fail, 18 pre-existing skipped.
- [x] `tsc --noEmit` clean.
- [x] Multi-agent review: security-sentinel, data-integrity-guardian, user-impact-reviewer, test-design-reviewer, semgrep-sast, code-simplicity-reviewer, architecture-strategist. P1 (NEW.user_id → OLD.user_id) fixed inline; 3 deferred-scope-outs filed and co-signed.
- [ ] ⏳ AC13: apply migration 036 to prd Supabase (CI's `migrate` job auto-runs on merge to main).
- [ ] ⏳ AC14: verify `pg_trigger` row exists in prd post-deploy via `psql` read-only query.
- [ ] ⏳ AC15: confirm with jean.deruelle@jikigai.com that "+ New conversation" works after archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
