### PR TITLE
fix(ship): widen DPF_REGEX to canary-bundle-claim-check.sh + self-healing parity test (#3068)

### DIFF
--- a/knowledge-base/project/learnings/test-failures/2026-05-04-hcl-multi-block-regex-must-scope-to-resource.md
+++ b/knowledge-base/project/learnings/test-failures/2026-05-04-hcl-multi-block-regex-must-scope-to-resource.md
@@ -1,0 +1,148 @@
+---
+module: System
+date: 2026-05-04
+problem_type: test_failure
+component: testing_framework
+symptoms:
+  - "Self-healing parity test extracted basenames from the wrong triggers_replace block in server.tf"
+  - "Test asserted [\"disk-monitor.sh\"] but expected the 5-element deploy_pipeline_fix list"
+root_cause: incorrect_scope
+resolution_type: test_fix
+severity: low
+tags: [regex, terraform, hcl, parity-tests, self-healing-tests, ship-gate, dpf]
+related_pr: "#3068 fix"
+related_learnings:
+  - 2026-04-29-cross-language-regex-and-terraform-indirect-reference.md
+---
+
+# HCL Multi-Block Regex Must Scope to the Owning Resource
+
+## Problem
+
+Closing #3068 required adding a self-healing test that derives the trigger-file
+list from `apps/web-platform/infra/server.tf` itself, so future additions to
+`terraform_data.deploy_pipeline_fix.triggers_replace` automatically fail the
+suite until `TRIGGER_FILES` (and therefore the gate's bash array + `DPF_REGEX`)
+catch up.
+
+First implementation matched the wrong block:
+
+```ts
+const blockMatch = serverTf.match(
+  /triggers_replace\s*=\s*sha256\(join\(",", \[([\s\S]*?)\]\)\)/,
+);
+```
+
+Test failed with:
+
+```
+Expected: ["canary-bundle-claim-check.sh", "cat-deploy-state.sh",
+           "ci-deploy.sh", "hooks.json.tmpl", "webhook.service"]
+Received: ["disk-monitor.sh"]
+```
+
+## Root Cause
+
+`apps/web-platform/infra/server.tf` declares **7** `triggers_replace`
+assignments across distinct resources:
+
+```text
+line  62: terraform_data.disk_monitor_install         (sha256(join(",", [...])))
+line 100: terraform_data.fail2ban_install             (sha256(join(",", [...])))
+line 140: terraform_data.fail2ban_sshd_local          (sha256(file(...)))
+line 219: terraform_data.deploy_pipeline_fix          (sha256(join(",", [...])))
+line 287: terraform_data.seccomp_bwrap                (sha256(file(...)))
+line 323: terraform_data.apparmor_bwrap_profile       (sha256(file(...)))
+line 350: terraform_data.orphan_reaper                (sha256(file(...)))
+```
+
+A non-greedy regex run against the full file matches the **first** block — the
+disk-monitor list — not the deploy_pipeline_fix list at line 219. The test
+extracted basenames from the wrong resource and reported a single-element
+result that had nothing to do with the gate under test.
+
+## Solution
+
+Locate the resource block first by string indexing, then run the
+`triggers_replace` regex against that slice:
+
+```ts
+const resourceStart = serverTf.indexOf(
+  'resource "terraform_data" "deploy_pipeline_fix"',
+);
+expect(resourceStart).toBeGreaterThanOrEqual(0);
+// Slice to the next `\nresource ` heading (or EOF if it's the last resource).
+const nextResource = serverTf.indexOf("\nresource ", resourceStart + 1);
+const resourceBlock = serverTf.slice(
+  resourceStart,
+  nextResource === -1 ? undefined : nextResource,
+);
+
+const blockMatch = resourceBlock.match(
+  /triggers_replace\s*=\s*sha256\(join\(\s*",\s*"\s*,\s*\[([\s\S]*?)\]\s*\)\s*\)/,
+);
+```
+
+The `\nresource ` upper bound (with the leading newline) is load-bearing — bare
+`resource ` would also match `resource_block` etc. inside comments or strings.
+Slicing to `undefined` when no following resource exists handles the
+last-resource-in-file case.
+
+## Key Insight
+
+**HCL is a block-structured language; regex parsers must scope to a block
+before attribute extraction.** Any attribute name that can repeat across
+resources (`triggers_replace`, `lifecycle`, `provisioner`, `connection`,
+`tags`, `labels`) is a multi-match risk. A non-greedy regex over the whole
+file silently selects the first occurrence, and the failure mode is
+"test extracts plausible-looking but wrong data," not "test errors out" —
+which is the worst kind of test bug because it reads as a correctness signal.
+
+The fix has two ingredients:
+
+1. **Resource-block scoping**: `serverTf.indexOf('resource "<type>" "<name>"')`
+   bounds the search before any attribute regex runs.
+2. **Resource-end heuristic**: `\nresource ` (newline-anchored) reliably bounds
+   the upper edge in the typical HCL convention where each resource starts at
+   column 0.
+
+For the `deploy_pipeline_fix` case, this also matters because `local.hooks_json`
+is referenced inside `triggers_replace` and resolved against a top-of-file
+`locals { hooks_json = templatefile(...) }` block — the block-scoped extraction
+yields the `local.<name>` token, then a separate file-level lookup resolves it
+to the `templatefile()` filename. Two-pass: scope locally for the trigger list,
+then resolve indirections globally.
+
+## Prevention
+
+When asserting infrastructure-as-code structure from tests, enforce the
+two-step pattern:
+
+1. Locate the owning resource by exact match (`'resource "<type>" "<name>"'`).
+2. Bound to the next `\nresource ` heading or EOF.
+3. Apply attribute-level regexes to the slice, not the file.
+
+The test file at `plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts`
+now demonstrates this pattern in the "every basename hashed by triggers_replace
+appears in TRIGGER_FILES" case — copy it for any future
+multi-block parser test.
+
+## Session Errors
+
+- **Self-healing test regex grabbed the wrong `triggers_replace` block.**
+  Recovery: scope to `resource "terraform_data" "deploy_pipeline_fix"`
+  via `indexOf` + `\nresource ` upper bound before applying the attribute
+  regex. Prevention: this learning + the inline pattern in
+  `ship-deploy-pipeline-fix-gate.test.ts`. No AGENTS.md rule needed —
+  bun:test surfaces the mismatch with a diff that names the wrong basename
+  in seconds (discoverability exit per `wg-every-session-error-must-produce-either`).
+
+## Cross-References
+
+- PR #3038 — original gate landing (4 triggers)
+- Issue #3068 — gate omitted `canary-bundle-claim-check.sh` (5th trigger)
+- Issue #3061 — 10th drift; resolved 2026-04-30
+- `knowledge-base/project/learnings/test-failures/2026-04-29-cross-language-regex-and-terraform-indirect-reference.md`
+  — sibling learning on cross-language regex equality + indirect locals reference
+- `apps/web-platform/infra/server.tf` line 219 — `terraform_data.deploy_pipeline_fix`
+- `plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts` — pattern reference

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -427,25 +427,27 @@ Domain leaders are consulted at brainstorm time but not at ship time. The actual
 
 ### Deploy Pipeline Fix Drift Gate
 
-**Trigger:** PR touches any of the 4 `terraform_data.deploy_pipeline_fix` trigger files:
+**Trigger:** PR touches any of the 5 `terraform_data.deploy_pipeline_fix` trigger files:
 
 - `apps/web-platform/infra/ci-deploy.sh`
 - `apps/web-platform/infra/webhook.service`
 - `apps/web-platform/infra/cat-deploy-state.sh`
+- `apps/web-platform/infra/canary-bundle-claim-check.sh`
 - `apps/web-platform/infra/hooks.json.tmpl`
 
 **Detection:**
 
-The four trigger files are enumerated as a single bash array. The regex below MUST be derived from this array — keep the gate's reject criteria, documentation block, and test fixtures in sync (per `cq-when-a-plan-prescribes-a-validator-guard-or` — guard-surface coupling). If `apps/web-platform/infra/server.tf`'s `triggers_replace` `sha256(join(",",...))` block is changed (file added, removed, renamed), update the array, the regex, and `plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts` in the same PR.
+The five trigger files are enumerated as a single bash array. The regex below MUST be derived from this array — keep the gate's reject criteria, documentation block, and test fixtures in sync (per `cq-when-a-plan-prescribes-a-validator-guard-or` — guard-surface coupling). If `apps/web-platform/infra/server.tf`'s `triggers_replace` `sha256(join(",",...))` block is changed (file added, removed, renamed), update the array, the regex, and `plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts` in the same PR.
 
 ```bash
 DEPLOY_PIPELINE_FIX_TRIGGERS=(
   "apps/web-platform/infra/ci-deploy.sh"
   "apps/web-platform/infra/webhook.service"
   "apps/web-platform/infra/cat-deploy-state.sh"
+  "apps/web-platform/infra/canary-bundle-claim-check.sh"
   "apps/web-platform/infra/hooks.json.tmpl"
 )
-DPF_REGEX='^apps/web-platform/infra/(ci-deploy\.sh|webhook\.service|cat-deploy-state\.sh|hooks\.json\.tmpl)$'
+DPF_REGEX='^apps/web-platform/infra/(ci-deploy\.sh|webhook\.service|cat-deploy-state\.sh|canary-bundle-claim-check\.sh|hooks\.json\.tmpl)$'
 
 git diff --name-only origin/main...HEAD | grep -E "$DPF_REGEX"
 ```
@@ -478,12 +480,14 @@ the output name is `server_ip`, not `server_ipv4`):
   LOCAL_HASHES=$(sha256sum \
     apps/web-platform/infra/ci-deploy.sh \
     apps/web-platform/infra/webhook.service \
-    apps/web-platform/infra/cat-deploy-state.sh)
+    apps/web-platform/infra/cat-deploy-state.sh \
+    apps/web-platform/infra/canary-bundle-claim-check.sh)
   echo "$LOCAL_HASHES"
   ssh -o ConnectTimeout=5 root@"$SERVER_IP" \
     "sha256sum /usr/local/bin/ci-deploy.sh \
               /etc/systemd/system/webhook.service \
-              /usr/local/bin/cat-deploy-state.sh && \
+              /usr/local/bin/cat-deploy-state.sh \
+              /usr/local/bin/canary-bundle-claim-check.sh && \
      systemctl is-active webhook"
 
 Each server-side hash must match the corresponding local hash AND

--- a/plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts
+++ b/plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts
@@ -217,13 +217,18 @@ describe("Trigger array and server.tf are in sync (path-glob verification)", () 
       'resource "terraform_data" "deploy_pipeline_fix"',
     );
     expect(resourceStart).toBeGreaterThanOrEqual(0);
-    // The next `resource ` heading bounds the block. The very last resource in
-    // the file has no following marker — slice to EOF in that case.
-    const nextResource = serverTf.indexOf("\nresource ", resourceStart + 1);
-    const resourceBlock = serverTf.slice(
-      resourceStart,
-      nextResource === -1 ? undefined : nextResource,
-    );
+    // Bound by the next top-level HCL block — `resource`, `data`, `module`,
+    // `output`, `locals`, `variable`, `provider`, `terraform`. Bare `\nresource `
+    // would absorb downstream non-resource blocks if `deploy_pipeline_fix`
+    // ever became the last `resource` in the file (P2 review finding).
+    const TOP_LEVEL_BLOCK_RE =
+      /\n(resource|data|module|output|locals|variable|provider|terraform)\b/;
+    const tail = serverTf.slice(resourceStart + 1);
+    const tailMatch = tail.match(TOP_LEVEL_BLOCK_RE);
+    const resourceBlock =
+      tailMatch && tailMatch.index !== undefined
+        ? serverTf.slice(resourceStart, resourceStart + 1 + tailMatch.index)
+        : serverTf.slice(resourceStart);
 
     const blockMatch = resourceBlock.match(
       /triggers_replace\s*=\s*sha256\(join\(\s*",\s*"\s*,\s*\[([\s\S]*?)\]\s*\)\s*\)/,
@@ -236,13 +241,28 @@ describe("Trigger array and server.tf are in sync (path-glob verification)", () 
       inner.matchAll(/file\(\s*"\$\{path\.module\}\/([^"]+)"\s*\)/g),
     ).map((m) => m[1]);
 
-    // local.<name> references → resolved via top-of-file `locals { <name> = templatefile("${path.module}/<file>", ...) }`.
+    // local.<name> references → resolved against the file-level `locals { ... }`
+    // block. Scoping the lookup (rather than searching the whole file) keeps the
+    // resolver from accidentally matching same-named identifiers in unrelated
+    // contexts (P2 review finding).
+    // `^locals` (file start) or `\nlocals` (subsequent line). Closing brace on
+    // its own line at column 0 (`\n}`) bounds the body — the templatefile()'s
+    // nested `})` is column-2 indented and won't match.
+    const localsBlockMatch = serverTf.match(/(?:^|\n)locals\s*\{([\s\S]*?)\n\}/);
+    if (!localsBlockMatch) {
+      throw new Error(
+        "server.tf has no top-level `locals { ... }` block but " +
+          "triggers_replace references `local.*` — refactor required.",
+      );
+    }
+    const localsBody = localsBlockMatch[1];
+
     const localNames = Array.from(inner.matchAll(/\blocal\.([A-Za-z0-9_]+)\b/g)).map(
       (m) => m[1],
     );
     const templatefileBasenames = localNames.map((name) => {
       const escaped = name.replace(/[.+*?^$(){}|[\]\\]/g, "\\$&");
-      const localMatch = serverTf.match(
+      const localMatch = localsBody.match(
         new RegExp(
           `\\b${escaped}\\s*=\\s*templatefile\\(\\s*"\\$\\{path\\.module\\}/([^"]+)"`,
         ),
@@ -250,13 +270,18 @@ describe("Trigger array and server.tf are in sync (path-glob verification)", () 
       if (!localMatch) {
         throw new Error(
           `triggers_replace references local.${name} but no matching ` +
-            `\`${name} = templatefile("\${path.module}/...")\` was found in server.tf. ` +
-            `Either add the local definition, or replace the local with a direct file()/templatefile() reference.`,
+            `\`${name} = templatefile("\${path.module}/...")\` was found in the ` +
+            `top-level locals { ... } block. Either add the local definition, or ` +
+            `replace the local with a direct file()/templatefile() reference.`,
         );
       }
       return localMatch[1];
     });
 
+    // Order-insensitive comparison: regex alternation is commutative, so the
+    // physical order in server.tf vs. TRIGGER_FILES is irrelevant for gate
+    // semantics. The token-for-token bash-array test above (line ~125) is
+    // where editorial ordering between SKILL.md and TRIGGER_FILES is enforced.
     const triggerBasenames = [...fileBasenames, ...templatefileBasenames].sort();
     const fixtureBasenames = TRIGGER_FILES.map((p) => p.split("/").pop()!).sort();
 

--- a/plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts
+++ b/plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts
@@ -23,14 +23,17 @@ const SERVER_TF = resolve(REPO_ROOT, "apps/web-platform/infra/server.tf");
 const GATE_HEADING = "### Deploy Pipeline Fix Drift Gate";
 const NEXT_HEADING = "### Retroactive Gate Application";
 
-// The 4 trigger files MUST match apps/web-platform/infra/server.tf
+// The 5 trigger files MUST match apps/web-platform/infra/server.tf
 // `terraform_data.deploy_pipeline_fix.triggers_replace.sha256(join(",",...))`.
 // If a future infra refactor changes the basenames, this fixture, the gate's
-// bash array, and the gate's regex must update together.
+// bash array, and the gate's regex must update together. The
+// "server.tf is in sync with TRIGGER_FILES" describe block below auto-detects
+// drift between server.tf and this fixture (#3068).
 const TRIGGER_FILES = [
   "apps/web-platform/infra/ci-deploy.sh",
   "apps/web-platform/infra/webhook.service",
   "apps/web-platform/infra/cat-deploy-state.sh",
+  "apps/web-platform/infra/canary-bundle-claim-check.sh",
   "apps/web-platform/infra/hooks.json.tmpl",
 ];
 
@@ -188,9 +191,9 @@ describe("Trigger array and server.tf are in sync (path-glob verification)", () 
     "server.tf references basename via file()/templatefile(): %s",
     (path) => {
       const basename = path.split("/").pop()!;
-      // Three direct triggers are referenced via file("${path.module}/<basename>")
-      // inside the triggers_replace block. The fourth (hooks.json.tmpl) is rendered
-      // by templatefile("${path.module}/hooks.json.tmpl", ...) in a locals block
+      // Direct triggers are referenced via file("${path.module}/<basename>")
+      // inside the triggers_replace block. hooks.json.tmpl is rendered by
+      // templatefile("${path.module}/hooks.json.tmpl", ...) in a locals block
       // and folded into triggers_replace via local.hooks_json. Either form proves
       // terraform tracks the file's contents.
       const escaped = basename.replace(/[.+*?^$(){}|[\]\\]/g, "\\$&");
@@ -200,6 +203,65 @@ describe("Trigger array and server.tf are in sync (path-glob verification)", () 
       expect(referenced).toBe(true);
     },
   );
+
+  // Self-healing direction (#3068): if server.tf grows a new file in
+  // triggers_replace, this test fails until TRIGGER_FILES (and therefore the
+  // gate's array + regex via the "matches token-for-token" tests above) is
+  // updated. Closes the gap that caused PR #3042 to slip past the gate and
+  // file drift issue #3061.
+  test("every basename hashed by triggers_replace appears in TRIGGER_FILES", () => {
+    // Locate the deploy_pipeline_fix resource block (server.tf has several
+    // `triggers_replace = sha256(join(",", [ ... ]))` blocks; we want only the
+    // one under `terraform_data "deploy_pipeline_fix"`).
+    const resourceStart = serverTf.indexOf(
+      'resource "terraform_data" "deploy_pipeline_fix"',
+    );
+    expect(resourceStart).toBeGreaterThanOrEqual(0);
+    // The next `resource ` heading bounds the block. The very last resource in
+    // the file has no following marker — slice to EOF in that case.
+    const nextResource = serverTf.indexOf("\nresource ", resourceStart + 1);
+    const resourceBlock = serverTf.slice(
+      resourceStart,
+      nextResource === -1 ? undefined : nextResource,
+    );
+
+    const blockMatch = resourceBlock.match(
+      /triggers_replace\s*=\s*sha256\(join\(\s*",\s*"\s*,\s*\[([\s\S]*?)\]\s*\)\s*\)/,
+    );
+    expect(blockMatch).not.toBeNull();
+    const inner = blockMatch![1];
+
+    // Direct file() references.
+    const fileBasenames = Array.from(
+      inner.matchAll(/file\(\s*"\$\{path\.module\}\/([^"]+)"\s*\)/g),
+    ).map((m) => m[1]);
+
+    // local.<name> references → resolved via top-of-file `locals { <name> = templatefile("${path.module}/<file>", ...) }`.
+    const localNames = Array.from(inner.matchAll(/\blocal\.([A-Za-z0-9_]+)\b/g)).map(
+      (m) => m[1],
+    );
+    const templatefileBasenames = localNames.map((name) => {
+      const escaped = name.replace(/[.+*?^$(){}|[\]\\]/g, "\\$&");
+      const localMatch = serverTf.match(
+        new RegExp(
+          `\\b${escaped}\\s*=\\s*templatefile\\(\\s*"\\$\\{path\\.module\\}/([^"]+)"`,
+        ),
+      );
+      if (!localMatch) {
+        throw new Error(
+          `triggers_replace references local.${name} but no matching ` +
+            `\`${name} = templatefile("\${path.module}/...")\` was found in server.tf. ` +
+            `Either add the local definition, or replace the local with a direct file()/templatefile() reference.`,
+        );
+      }
+      return localMatch[1];
+    });
+
+    const triggerBasenames = [...fileBasenames, ...templatefileBasenames].sort();
+    const fixtureBasenames = TRIGGER_FILES.map((p) => p.split("/").pop()!).sort();
+
+    expect(triggerBasenames).toEqual(fixtureBasenames);
+  });
 });
 
 describe("postmerge runbook updates (#3034)", () => {


### PR DESCRIPTION
## Summary

- `/ship` Phase 5.5 \"Deploy Pipeline Fix Drift Gate\" had `DPF_REGEX` omitting `canary-bundle-claim-check.sh`. PR #3042 only edited that file, the gate didn't fire, and the 12h drift cron filed #3061 — the 10th occurrence in this resource class.
- This PR widens the regex + bash array + verification block to include the 5th trigger, and adds a self-healing parser test that derives the truth from `apps/web-platform/infra/server.tf` so any future trigger-list growth auto-fails the suite until SKILL.md and the test fixture catch up.
- Retroactive remediation per `wg-when-fixing-a-workflow-gates-detection`: the case that exposed the gap (#3061) was already resolved 2026-04-30 via `terraform apply -target=terraform_data.deploy_pipeline_fix`. Rule satisfied.

Closes #3068

## Changelog

### Plugin

- `/ship` Phase 5.5 Deploy Pipeline Fix Drift Gate now matches all 5 trigger files (`ci-deploy.sh`, `webhook.service`, `cat-deploy-state.sh`, `canary-bundle-claim-check.sh`, `hooks.json.tmpl`) — not just the original 4. Verification block also runs `sha256sum` against the new file.
- New self-healing parity test in `plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts` parses the `terraform_data \"deploy_pipeline_fix\"` block in server.tf, extracts every `file()` and `local.<name>`-via-`templatefile()` basename, and asserts it equals `TRIGGER_FILES`.
- Captured the multi-block HCL scoping gotcha in `knowledge-base/project/learnings/test-failures/2026-05-04-hcl-multi-block-regex-must-scope-to-resource.md` (server.tf has 8 `triggers_replace` blocks; un-scoped regex matches the first one).

## Review

Code-quality + architecture review run before push. Two P2 findings fixed inline (resource-block boundary widened to all top-level HCL keywords; `local.<name>` resolver scoped to file-level `locals { }` body). Two architectural follow-ups filed as separate issues (#3214 generate-from-server.tf, #3215 helper extraction). Tracking issue: #3216.

## Test plan

- [x] `bun test plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts` — 39/39 green
- [x] `echo 'apps/web-platform/infra/canary-bundle-claim-check.sh' | grep -E '\$DPF_REGEX'` matches
- [x] `echo 'apps/web-platform/infra/canary-bundle-claim-check.test.sh' | grep -E '\$DPF_REGEX'` does NOT match (\$ anchor + literal `.sh`)
- [x] Retroactive: #3061 closed via apply on 2026-04-30
- [ ] ⏳ Next PR touching any of the 5 trigger files fires the gate (tracked by follow-through #3043)

🤖 Generated with [Claude Code](https://claude.com/claude-code)