### PR TITLE
fix(cc-dispatcher): route ownership-check through updateConversationFor (R8 wrapper)

### DIFF
--- a/apps/web-platform/server/cc-dispatcher.ts
+++ b/apps/web-platform/server/cc-dispatcher.ts
@@ -721,25 +721,22 @@ export async function dispatchSoleurGo(
   } = args;
 
   // Verify conversation ownership AND bump `last_active` in a single
-  // round-trip. The UPDATE/RETURNING form does both: rows that fail the
-  // user_id predicate return zero rows (treated as 404), rows that match
-  // record activity at the start of the turn so the conversation
-  // surfaces correctly in any "recent conversations" UI even if the
-  // runner errors before its own status callbacks fire. Mirrors the
-  // `user_id` defense-in-depth from `agent-runner.ts:sendUserMessage`.
-  const { data: ownership, error: ownershipErr } = await supabase()
-    .from("conversations")
-    .update({ last_active: new Date().toISOString() })
-    .eq("id", conversationId)
-    .eq("user_id", userId)
-    .select("id")
-    .single();
-  if (ownershipErr || !ownership) {
-    reportSilentFallback(ownershipErr, {
+  // round-trip. `updateConversationFor` with `expectMatch: true` runs the
+  // UPDATE scoped to (id, user_id) and returns `ok: false` when zero rows
+  // matched — that's our 404 signal. Sentry mirroring on failure happens
+  // inside the wrapper, so we only translate to the throw here. Routes
+  // through the canonical wrapper per the R8 lint rule.
+  const ownership = await updateConversationFor(
+    userId,
+    conversationId,
+    { last_active: new Date().toISOString() },
+    {
       feature: "cc-dispatcher",
       op: "verify-conversation-ownership",
-      extra: { userId, conversationId },
-    });
+      expectMatch: true,
+    },
+  );
+  if (!ownership.ok) {
     throw new Error("Conversation not found");
   }
 

--- a/apps/web-platform/test/cc-dispatcher.test.ts
+++ b/apps/web-platform/test/cc-dispatcher.test.ts
@@ -4,15 +4,23 @@ const {
   mockReportSilentFallback,
   mockFetchUserWorkspacePath,
   mockMessagesInsert,
-  mockConversationOwnership,
+  mockUpdateConversationFor,
 } = vi.hoisted(() => ({
   mockReportSilentFallback: vi.fn(),
   mockFetchUserWorkspacePath: vi.fn(),
   mockMessagesInsert: vi.fn().mockResolvedValue({ error: null }),
-  mockConversationOwnership: vi
-    .fn()
-    .mockResolvedValue({ data: { id: "stub-conv-id" }, error: null }),
+  mockUpdateConversationFor: vi.fn().mockResolvedValue({ ok: true }),
 }));
+
+vi.mock("@/server/conversation-writer", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/server/conversation-writer")
+  >("@/server/conversation-writer");
+  return {
+    ...actual,
+    updateConversationFor: mockUpdateConversationFor,
+  };
+});
 
 vi.mock("@/server/observability", () => ({
   reportSilentFallback: mockReportSilentFallback,
@@ -47,17 +55,8 @@ vi.mock("@/lib/supabase/service", () => ({
       if (table === "messages") {
         return { insert: mockMessagesInsert };
       }
-      if (table === "conversations") {
-        // dispatchSoleurGo's combined ownership-check + last_active bump:
-        // `from("conversations").update({...}).eq(...).eq(...).select("id").single()`
-        const chain = {
-          update: () => chain,
-          select: () => chain,
-          eq: () => chain,
-          single: mockConversationOwnership,
-        };
-        return chain;
-      }
+      // `conversations` writes go through `updateConversationFor` which is
+      // mocked above; service-client should never see a direct .from("conversations").
       throw new Error(`unexpected table in cc-dispatcher.test.ts: ${table}`);
     },
     storage: {
@@ -95,11 +94,8 @@ describe("cc-dispatcher singletons + orchestration", () => {
     // Default: every messages-insert succeeds; tests that need a failure
     // can override per-call.
     mockMessagesInsert.mockResolvedValue({ error: null });
-    mockConversationOwnership.mockClear();
-    mockConversationOwnership.mockResolvedValue({
-      data: { id: "stub-conv-id" },
-      error: null,
-    });
+    mockUpdateConversationFor.mockClear();
+    mockUpdateConversationFor.mockResolvedValue({ ok: true });
     // Default: a stable stub workspace path so existing tests that don't
     // care about the workspace-resolve path still get a deterministic value.
     mockFetchUserWorkspacePath.mockResolvedValue("/tmp/claude-XXXX/workspace");


### PR DESCRIPTION
## Summary

Post-merge red on `main` after PR #3254: `lint-conversations-update-callsites.sh` (R8 wrapper enforcement) flagged the new direct `.from(\"conversations\").update(...)` introduced during review fix-inline.

Routes the combined ownership-check + `last_active` bump through `updateConversationFor` with `expectMatch: true` — same UPDATE behavior, same 404 signal on zero-match, Sentry mirroring already handled inside the wrapper.

Web Platform Release deployed successfully — this is a CI-only red, not a runtime regression. Fast-fix to clear main.

## Changelog

### Web Platform

- `server/cc-dispatcher.ts` — ownership-check uses `updateConversationFor({ expectMatch: true })` instead of a raw supabase chain.
- `test/cc-dispatcher.test.ts` — mocks `@/server/conversation-writer` directly instead of the raw chain.

## Test plan

- [x] `npx vitest run test/cc-dispatcher.test.ts` — 19/19 pass
- [x] `bash scripts/lint-conversations-update-callsites.sh` — OK
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)