### PR TITLE
fix(drift-guard): tripwire pre-filter ^:: lines (always-fires on green run)

### DIFF
--- a/.github/workflows/scheduled-github-app-drift-guard.yml
+++ b/.github/workflows/scheduled-github-app-drift-guard.yml
@@ -312,6 +312,19 @@ jobs:
             exit 0
           fi
 
+          # Strip runner-directive lines before scanning. The drift step
+          # registers `::add-mask::<line>` for each PEM line and for the
+          # minted JWT, plus the workflow may emit `::warning::`/`::error::`
+          # directives. `tee -a` captures these to step-output.log BEFORE
+          # the runner consumes them, so the file contains
+          # `::add-mask::-----BEGIN RSA PRIVATE KEY-----` and
+          # `::add-mask::eyJ...JWT...`. These are mask REGISTRATIONS, not
+          # leaks — the runner replaces matched values in the displayed
+          # log. Filtering `^::` lines before grepping is correct: a real
+          # leak via plain `echo` would still match (it would appear on a
+          # non-`::`-prefixed line). The filter only hides values that we
+          # already explicitly registered for masking.
+          #
           # Three alternations:
           #   PEM block header (covers RSA, PKCS#8, EC, OPENSSH; rejects PUBLIC KEY)
           #   base64-of-PEM ("LS0tLS1CRUdJTi…" — what PRIVATE_KEY_B64 itself looks like)
@@ -320,7 +333,7 @@ jobs:
           # someone echoes $PRIVATE_KEY_B64 directly without decoding (the
           # decoded PEM would be masked, but the un-decoded base64 form
           # bypasses the line-by-line ::add-mask:: registration).
-          if grep -E "BEGIN [A-Z ]*PRIVATE KEY|LS0tLS1CRUdJTi[A-Za-z0-9+/]|eyJ[A-Za-z0-9_-]{20,}" "$LOG" >/dev/null; then
+          if grep -v '^::' "$LOG" | grep -E "BEGIN [A-Z ]*PRIVATE KEY|LS0tLS1CRUdJTi[A-Za-z0-9+/]|eyJ[A-Za-z0-9_-]{20,}" >/dev/null; then
             echo "::error::Leak tripwire fired."
 
             BODY_FILE=$(mktemp)

--- a/apps/web-platform/test/github-app-drift-guard-contract.test.ts
+++ b/apps/web-platform/test/github-app-drift-guard-contract.test.ts
@@ -207,6 +207,24 @@ describe("scheduled-github-app-drift-guard.yml — leak tripwire", () => {
     // grepping the GitHub-rendered log post-hoc is impossible mid-run.
     expect(yaml).toContain("step-output.log");
   });
+
+  test("leak tripwire filters runner-directive lines (^::) before scanning", () => {
+    const yaml = readFileSync(workflowPath, "utf-8");
+    // The drift step's `tee -a step-output.log` captures
+    // `::add-mask::<line>` registrations BEFORE the runner consumes them.
+    // Without a `^::` pre-filter, the tripwire matches its own mask
+    // registrations (PEM lines + minted JWT) and always fires on a
+    // green run — the "guard-itself-dark" failure mode the workflow was
+    // supposed to detect. The pre-filter must be a literal `grep -v '^::'`
+    // piped INTO the tripwire grep (not after; that would let the leak
+    // grep run against unfiltered input).
+    //
+    // A real leak via plain `echo` still fires because the leaked value
+    // appears on a non-`::`-prefixed line.
+    expect(yaml).toMatch(
+      /grep\s+-v\s+'\^::'\s+"\$LOG"\s*\|\s*grep\s+-E\s+"BEGIN \[A-Z \]\*PRIVATE KEY/,
+    );
+  });
 });
 
 // =============================================================================

--- a/knowledge-base/engineering/ops/runbooks/github-app-drift.md
+++ b/knowledge-base/engineering/ops/runbooks/github-app-drift.md
@@ -206,9 +206,18 @@ anchored patterns is near-zero in practice.
    - JWT segment: the `JWT=$(mint_jwt)` capture or the curl auth header
      bypassed the mask. Less common; usually means a future PR added
      `echo "$JWT"` somewhere.
-3. **Rotate the GitHub App private key immediately.** Follow the
+3. **Rule out the self-leak class first.** The drift step's
+   `tee -a step-output.log` captures the workflow's own
+   `::add-mask::<line>` registrations BEFORE the runner consumes them.
+   The tripwire pre-filters lines starting with `::` (runner directives)
+   for exactly this reason — those are mask REGISTRATIONS, not leaks.
+   If the tripwire fires and the `LOG` matches are all
+   `::add-mask::…`-prefixed lines, the pre-filter has been removed or
+   broken. Re-add the `grep -v '^::' "$LOG"` pre-filter and re-run; do
+   NOT rotate the key for a self-leak.
+4. **Rotate the GitHub App private key immediately.** Follow the
    Rotation procedure below. Do not wait for IR triage.
-4. **Patch the leak vector.** Find the offending line in the workflow
+5. **Patch the leak vector.** Find the offending line in the workflow
    diff and add `::add-mask::` coverage or remove the echo. CODEOWNERS
    gates re-merge.
 5. **Postmortem.** Document the leak class in

--- a/knowledge-base/project/learnings/best-practices/2026-05-05-leak-tripwire-self-trips-on-mask-registrations.md
+++ b/knowledge-base/project/learnings/best-practices/2026-05-05-leak-tripwire-self-trips-on-mask-registrations.md
@@ -1,0 +1,180 @@
+---
+date: 2026-05-05
+category: best-practices
+problem_type: workflow_self_leak_false_positive
+component: github_actions_workflow + leak_tripwire
+related_issues: [3187]
+related_prs: [3224]
+tags: [github-actions, leak-detection, add-mask, tee, step-output, self-leak, guard-itself-dark]
+synced_to: []
+---
+
+# Leak Tripwires Must Filter Their Own Mask Registrations Before Scanning
+
+## Why this learning exists
+
+The GitHub App drift-guard workflow (`scheduled-github-app-drift-guard.yml`,
+shipped in PR #3224) included a leak tripwire as a blocking post-step:
+`exec > >(tee -a "$RUNNER_TEMP/step-output.log") 2>&1` captured the drift
+step's stdout/stderr, then a separate step grepped that file for PEM
+headers, base64-of-PEM, and JWT segments.
+
+When the workflow was first triggered manually post-merge against
+properly-bootstrapped Doppler/GH-Actions secrets, the drift step itself
+ran clean ("Drift-guard passed.") — but the tripwire fired and filed a
+`security/leak-suspected + ci/guard-broken + priority/p1-high` issue.
+This is the "guard-itself-dark" failure mode the workflow was designed
+to detect: a guard that ALWAYS-fails on a green run is worse than no
+guard, because operators learn to ignore it.
+
+## Root cause
+
+The drift step registers two kinds of `::add-mask::` directives BEFORE
+calling out to GitHub's API:
+
+```bash
+# Per-PEM-line mask (loop)
+while IFS= read -r line; do
+  [[ -n "$line" ]] && echo "::add-mask::$line"
+done < "$KEY_FILE"
+
+# Minted-JWT mask
+echo "::add-mask::$JWT"
+```
+
+These are runner-control directives — the runner consumes them and
+replaces matched values in the displayed log with `***`. They are NOT
+log content.
+
+But `tee -a step-output.log` runs BEFORE the runner consumes the
+directives. The runner sees `::add-mask::-----BEGIN RSA PRIVATE KEY-----`
+on stdout, registers the mask, and removes the line from displayed
+output. `tee` already wrote the raw bytes to the file. So
+`step-output.log` ends up containing:
+
+```text
+::add-mask::-----BEGIN RSA PRIVATE KEY-----
+::add-mask::MIIEowIBAAKCAQEA…
+…
+::add-mask::-----END RSA PRIVATE KEY-----
+::add-mask::eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiI…
+```
+
+The tripwire grep:
+
+```regex
+BEGIN [A-Z ]*PRIVATE KEY|LS0tLS1CRUdJTi[A-Za-z0-9+/]|eyJ[A-Za-z0-9_-]{20,}
+```
+
+matches:
+
+- `BEGIN RSA PRIVATE KEY` from PEM-line mask registrations →
+  PEM-header pattern
+- `eyJ…` from the JWT mask registration → JWT pattern
+
+Result: every green run trips the tripwire. False positive rate: 100%.
+
+## Fix
+
+Pre-filter runner-directive lines (`^::…`) before scanning:
+
+```bash
+if grep -v '^::' "$LOG" | grep -E "BEGIN [A-Z ]*PRIVATE KEY|LS0tLS1CRUdJTi[A-Za-z0-9+/]|eyJ[A-Za-z0-9_-]{20,}" >/dev/null; then
+  ...
+fi
+```
+
+The pre-filter is correct because:
+
+1. Lines starting with `::` are workflow commands consumed by the
+   runner (`::add-mask::`, `::warning::`, `::error::`,
+   `::group::`/`::endgroup::`, `::set-output::`, etc.). They are not
+   user-visible log content; the displayed log shows their *effect*
+   (mask applied, warning rendered) not the directive itself.
+2. A real leak via plain `echo "$JWT"` or `echo "$PRIVATE_KEY"` still
+   matches because the leaked bytes appear on a non-`::`-prefixed
+   line. The pre-filter only hides values that the workflow has
+   already explicitly registered for masking — masking and leaking
+   are mutually exclusive intents.
+3. An attacker-controlled value that happened to start with `::` cannot
+   bypass the filter, because the only inputs to step-output.log are
+   the workflow's own commands; there is no untrusted-input path that
+   feeds the log directly.
+
+## Generalization
+
+Any leak detector that reads a log captured *before* runner directives
+are consumed needs to filter those directives. This applies to:
+
+- `tee` capture inside a GHA step (this case)
+- A separate "audit" step that fetches the run's raw API log via
+  `gh api repos/.../actions/runs/.../logs` (the API returns the raw
+  stdout-as-uploaded form, which still contains directives)
+- Self-hosted runners that ship logs to an external SIEM before the
+  runner-directive consumer can rewrite them
+
+The general rule: **any log-derived leak detector must distinguish
+"workflow control plane" bytes from "data plane" bytes**. The control
+plane bytes are part of the channel between the script and the runner;
+they are not data the script has emitted to operators. Treating them as
+data produces false positives when those directives carry sensitive
+values *as their argument* — which is precisely the case for
+`::add-mask::`.
+
+## Where to apply this
+
+- Any new GHA workflow with a `tee`-captured step-output log AND a
+  post-step grep against that log.
+- Reviewing `scheduled-oauth-probe.yml` (precedent for this drift-guard
+  pattern) — it uses `tee step-output.log` too. The oauth-probe never
+  registers per-line `::add-mask::` for content matching its own grep
+  patterns, so the bug doesn't manifest there. But a future PR that
+  adds per-secret masking would re-introduce it. Add the same `^::`
+  pre-filter defensively.
+- The contract test pins the new pre-filter shape via a regex that
+  requires the literal `grep -v '^::' "$LOG" |` precede the tripwire
+  grep — not the other way around. Order matters: filtering AFTER the
+  detection grep would let the directive lines trip the detector.
+
+## Cross-references
+
+- `2026-05-05-extracted-bash-functions-need-self-contained-state.md` —
+  sibling learning from PR #3224, Pattern 3 ("co-sign FIRST, file
+  scope-out SECOND") and the "guard-itself-dark" framing.
+- `2026-05-05-workflow-jwt-mint-silent-failure-traps.md` — sibling
+  learning, covers the parent `tee | exec` capture decision and why
+  `set -uo pipefail` (no `-e`) is load-bearing.
+- `plugins/soleur/skills/review/SKILL.md` §5 — review-finding
+  fix-inline default; this learning was captured retroactively because
+  the bug only surfaced post-merge during AC21 manual verification.
+- `knowledge-base/engineering/ops/runbooks/github-app-drift.md` step 3
+  — runbook now instructs operators to rule out the self-leak class
+  BEFORE rotating the key.
+
+## Session Errors
+
+Errors enumerated during this session (continued from PR #3224's
+post-merge verification):
+
+1. **Drift-guard workflow always-fails on green run via self-leak.**
+   First post-merge run (#25374996338) failed on missing-secret bootstrap
+   (expected — Doppler had `GITHUB_APP_*` but workflow expected
+   `GH_APP_DRIFTGUARD_*`). Recovery: synced via Doppler write +
+   `gh secret set`. Second run (#25377012606) drift-checked clean but
+   tripwire fired on the workflow's own `::add-mask::` registrations.
+   **Prevention:** This learning + the contract test assertion that pins
+   the `^::` pre-filter.
+2. **Pre-merge contract test did not catch the self-trip.** The test
+   asserts the regex strings appear in the workflow body, but never
+   ran the tripwire against a synthetic step-output.log containing
+   `::add-mask::-----BEGIN…` lines. **Prevention:** add a synthetic
+   "tripwire-self-leak" test that constructs a fake log with the
+   directive lines and confirms the tripwire does NOT fire — this
+   catches the bug at write-time, not at first manual-trigger after
+   merge. (Filed as follow-up; not in this PR's scope to keep the fix
+   minimal.)
+3. **Phase 5.4 preflight passed despite the bug.** Preflight has no
+   check that exercises a workflow against a synthetic log. This is a
+   structural limit — preflight runs against the deployed prod surface,
+   not against newly-added workflow contracts. **Prevention:** none at
+   the preflight layer; the right layer is the contract test (item 2).


### PR DESCRIPTION
## Summary

Drift-guard tripwire fires on every green run because `tee -a step-output.log` captures the workflow's own `::add-mask::<line>` directives BEFORE the runner consumes them. The tripwire grep then matches its own mask registrations: `BEGIN RSA PRIVATE KEY` (PEM header pattern) and `eyJ…` (JWT pattern).

Surfaced post-merge during AC21 manual trigger of [run 25377012606](https://github.com/jikig-ai/soleur/actions/runs/25377012606): drift check reported \`Drift-guard passed.\` then the tripwire fired and filed \`security/leak-suspected + ci/guard-broken + priority/p1-high\`. False issue [#3258 closed-as-not-planned] (and [#3257 from the earlier missing-secret bootstrap run]).

This is exactly the \"guard-itself-dark\" failure mode the workflow was designed to detect.

## Fix

- **Workflow:** pre-filter \`^::\` lines (workflow control-plane bytes) before the detection grep — \`grep -v '^::' \"\$LOG\" | grep -E ...\`. Real leaks via plain \`echo \"\$JWT\"\` still fire because leaked bytes appear on a non-\`::\`-prefixed line; the filter only drops values the workflow already explicitly registered for masking.
- **Contract test:** new assertion pinning the literal pre-filter shape (must precede the tripwire grep, not follow it — order matters). 30/30 tests pass.
- **Runbook:** new step 3 instructing operators to rule out the self-leak class BEFORE rotating the key.
- **Learning:** \`knowledge-base/project/learnings/best-practices/2026-05-05-leak-tripwire-self-trips-on-mask-registrations.md\` generalizes to any leak detector reading a log captured before runner directives are consumed.

## User-Brand Impact

- **Artifact:** the same drift-guard sentinel that protects \`oauth_user.github_installation_id\` continuity for every authenticated user.
- **Vector:** alarm fatigue. A 100% false-positive rate on the highest-severity label (\`security/leak-suspected + priority/p1-high\`) trains operators to ignore the alert. When a real leak occurs, the issue gets dismissed by reflex. The drift-guard's protective value approaches zero.
- **Brand-survival threshold:** \`single-user incident\` — same threshold inherited from #3187. A real leak ignored is a real leak undisclosed within GDPR Article 33's 72-hour window.

## Test plan

- [x] 30/30 contract tests pass (\`npx vitest run test/github-app-drift-guard-contract.test.ts\`)
- [x] 25/25 test-all.sh suites pass
- [x] Pre-filter is literal-shape pinned by contract assertion (order matters: filter MUST precede detection grep)
- [ ] Post-merge: \`gh workflow run scheduled-github-app-drift-guard.yml\` and verify \`Drift-guard passed.\` + \`Leak tripwire passed.\` (no issue filed)
- [ ] Close false-positive issues #3257, #3258 (and any subsequent self-trip filings) as \`not planned\`

Ref #3187