### PR TITLE
fix(theme): tokenize remaining web-platform surfaces for light mode

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/admin/analytics/loading.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/admin/analytics/loading.tsx
@@ -1,16 +1,16 @@
 export default function AnalyticsLoading() {
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold text-white">Analytics</h1>
-      <div className="rounded-xl border border-neutral-800 bg-neutral-900/50 overflow-hidden">
+      <h1 className="text-2xl font-semibold text-soleur-text-primary">Analytics</h1>
+      <div className="rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1/50 overflow-hidden">
         <table className="w-full">
           <thead>
-            <tr className="border-b border-neutral-800">
+            <tr className="border-b border-soleur-border-default">
               {["User", "Domains", "Sessions", "Multi-Domain", "KB Growth", "TTFV", "Error Rate", "Status"].map(
                 (header) => (
                   <th
                     key={header}
-                    className="px-4 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider"
+                    className="px-4 py-3 text-left text-xs font-medium text-soleur-text-muted uppercase tracking-wider"
                   >
                     {header}
                   </th>
@@ -20,10 +20,10 @@ export default function AnalyticsLoading() {
           </thead>
           <tbody>
             {Array.from({ length: 5 }).map((_, i) => (
-              <tr key={i} className="border-b border-neutral-800/50">
+              <tr key={i} className="border-b border-soleur-border-default/50">
                 {Array.from({ length: 8 }).map((_, j) => (
                   <td key={j} className="px-4 py-3">
-                    <div className="h-4 rounded bg-neutral-800 animate-pulse" />
+                    <div className="h-4 rounded bg-soleur-bg-surface-2 animate-pulse" />
                   </td>
                 ))}
               </tr>

--- a/apps/web-platform/app/(dashboard)/dashboard/chat/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/chat/layout.tsx
@@ -6,7 +6,7 @@ export default function ChatLayout({ children }: { children: ReactNode }) {
     <div className="flex h-full min-h-0 flex-1">
       <aside
         data-testid="conversations-rail"
-        className="hidden md:block md:w-72 md:shrink-0 md:border-r md:border-neutral-800 md:bg-neutral-950"
+        className="hidden md:block md:w-72 md:shrink-0 md:border-r md:border-soleur-border-default md:bg-soleur-bg-base"
       >
         <ConversationsRail />
       </aside>

--- a/apps/web-platform/app/(dashboard)/dashboard/kb/[...path]/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/kb/[...path]/page.tsx
@@ -75,7 +75,7 @@ export default function KbContentPage({
     return (
       <div className="p-6 md:p-8">
         <div className="mx-auto max-w-3xl space-y-4">
-          <div className="h-4 w-48 animate-pulse rounded bg-neutral-800" />
+          <div className="h-4 w-48 animate-pulse rounded bg-soleur-bg-surface-2" />
           <KbContentSkeleton
             widths={["85%", "70%", "90%", "65%", "80%", "75%"]}
           />
@@ -88,12 +88,12 @@ export default function KbContentPage({
     return (
       <div className="flex h-full items-center justify-center p-6">
         <div className="text-center">
-          <p className="mb-2 text-sm text-neutral-400">
+          <p className="mb-2 text-sm text-soleur-text-secondary">
             File not found. This file may have been renamed or removed.
           </p>
           <Link
             href="/dashboard/kb"
-            className="text-sm text-amber-400 underline hover:text-amber-300"
+            className="text-sm text-soleur-accent-gold-fg underline hover:text-soleur-accent-gold-text"
           >
             Back to file tree
           </Link>
@@ -106,7 +106,7 @@ export default function KbContentPage({
     return (
       <div className="flex h-full items-center justify-center p-6">
         <div className="text-center">
-          <p className="text-sm text-neutral-400">
+          <p className="text-sm text-soleur-text-secondary">
             Unable to load this file. Please try again later.
           </p>
         </div>

--- a/apps/web-platform/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/page.tsx
@@ -337,9 +337,9 @@ export default function DashboardPage() {
     return (
       <div className="mx-auto flex min-h-[calc(100dvh-4rem)] max-w-3xl flex-col items-center justify-center px-4 py-10">
         <div className="mb-6 h-12 w-12 animate-pulse rounded-lg bg-amber-600/50" />
-        <div className="mb-3 h-4 w-48 animate-pulse rounded bg-neutral-800" />
-        <div className="mb-8 h-3 w-64 animate-pulse rounded bg-neutral-800" />
-        <div className="h-[44px] w-full max-w-xl animate-pulse rounded-xl bg-neutral-800/50" />
+        <div className="mb-3 h-4 w-48 animate-pulse rounded bg-soleur-bg-surface-2" />
+        <div className="mb-8 h-3 w-64 animate-pulse rounded bg-soleur-bg-surface-2" />
+        <div className="h-[44px] w-full max-w-xl animate-pulse rounded-xl bg-soleur-bg-surface-2/50" />
       </div>
     );
   }
@@ -352,7 +352,7 @@ export default function DashboardPage() {
     return (
       <div className="mx-auto flex min-h-[calc(100dvh-4rem)] max-w-3xl flex-col items-center justify-center px-4 py-10">
         <div className="mb-6 h-12 w-12 animate-pulse rounded-lg bg-amber-600/50" />
-        <p className="text-sm text-neutral-400">Setting up your workspace...</p>
+        <p className="text-sm text-soleur-text-secondary">Setting up your workspace...</p>
       </div>
     );
   }
@@ -364,19 +364,19 @@ export default function DashboardPage() {
   if (!kbError && !visionExists && conversations.length === 0 && !hasActiveFilter) {
     return (
       <div className="mx-auto flex min-h-[calc(100dvh-4rem)] max-w-3xl flex-col items-center justify-center px-4 py-10">
-        <p className="mb-3 text-xs font-medium tracking-widest text-amber-500">
+        <p className="mb-3 text-xs font-medium tracking-widest text-soleur-accent-gold-fg">
           DASHBOARD
         </p>
-        <h1 className="mb-3 text-center text-3xl font-semibold text-white md:text-4xl">
+        <h1 className="mb-3 text-center text-3xl font-semibold text-soleur-text-primary md:text-4xl">
           Tell your organization what you&apos;re building.
         </h1>
-        <p className="mb-10 max-w-md text-center text-sm text-neutral-400">
+        <p className="mb-10 max-w-md text-center text-sm text-soleur-text-secondary">
           Describe your startup idea and your AI organization will get to work.
         </p>
         {repoDisconnected && orphanedCount > 0 && (
           <p
             data-testid="disconnected-orphans-hint"
-            className="mb-6 max-w-md text-center text-xs text-neutral-500"
+            className="mb-6 max-w-md text-center text-xs text-soleur-text-muted"
           >
             {orphanedCount === 1
               ? "Your previous conversation is tied to your disconnected repository. Reconnect that repository to view it."
@@ -401,7 +401,7 @@ export default function DashboardPage() {
               {firstRunAttachments.map((att) => (
                 <div
                   key={att.id}
-                  className="flex items-center gap-1.5 rounded-lg border border-neutral-700 bg-neutral-800 px-2 py-1.5"
+                  className="flex items-center gap-1.5 rounded-lg border border-soleur-border-default bg-soleur-bg-surface-2 px-2 py-1.5"
                 >
                   {att.preview ? (
                     <img
@@ -414,11 +414,11 @@ export default function DashboardPage() {
                       <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
                     </svg>
                   )}
-                  <span className="max-w-[120px] truncate text-xs text-neutral-300">{att.file.name}</span>
+                  <span className="max-w-[120px] truncate text-xs text-soleur-text-secondary">{att.file.name}</span>
                   <button
                     type="button"
                     onClick={() => removeFirstRunAttachment(att.id)}
-                    className="ml-1 text-neutral-500 hover:text-white"
+                    className="ml-1 text-soleur-text-muted hover:text-soleur-text-primary"
                     aria-label={`Remove ${att.file.name}`}
                   >
                     <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -440,7 +440,7 @@ export default function DashboardPage() {
             <button
               type="button"
               onClick={() => fileInputRef.current?.click()}
-              className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-xl border border-neutral-700 text-neutral-400 transition-colors hover:border-neutral-500 hover:text-white"
+              className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-xl border border-soleur-border-default text-soleur-text-secondary transition-colors hover:border-soleur-border-default hover:text-soleur-text-primary"
               aria-label="Attach files"
             >
               <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -464,7 +464,7 @@ export default function DashboardPage() {
               type="text"
               placeholder="What are you building?"
               autoFocus
-              className="min-h-[44px] flex-1 rounded-xl border border-neutral-700 bg-neutral-900 px-4 py-3 text-sm text-white placeholder:text-neutral-500 focus:border-neutral-500 focus:outline-none"
+              className="min-h-[44px] flex-1 rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1 px-4 py-3 text-sm text-soleur-text-primary placeholder:text-soleur-text-muted focus:border-soleur-border-default focus:outline-none"
               onPaste={(e) => {
                 const files = Array.from(e.clipboardData.files);
                 if (files.length > 0) {
@@ -475,7 +475,7 @@ export default function DashboardPage() {
             />
             <button
               type="submit"
-              className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-xl bg-amber-600 text-white transition-colors hover:bg-amber-500"
+              className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-xl bg-amber-600 text-soleur-text-on-accent transition-colors hover:bg-amber-500"
               aria-label="Send message"
             >
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -508,22 +508,22 @@ export default function DashboardPage() {
           />
         )}
 
-        <p className="mb-3 text-xs font-medium tracking-widest text-amber-500">
+        <p className="mb-3 text-xs font-medium tracking-widest text-soleur-accent-gold-fg">
           DASHBOARD
         </p>
-        <h1 className="mb-3 text-center text-3xl font-semibold text-white md:text-4xl">
+        <h1 className="mb-3 text-center text-3xl font-semibold text-soleur-text-primary md:text-4xl">
           {allTasksComplete
             ? "Your organization is ready."
             : "No conversations yet."}
         </h1>
-        <p className="mb-8 text-center text-sm text-neutral-400">
+        <p className="mb-8 text-center text-sm text-soleur-text-secondary">
           Start a conversation to put your agents to work.
         </p>
 
         <button
           type="button"
           onClick={() => router.push("/dashboard/chat/new")}
-          className="mb-10 rounded-lg bg-gradient-to-r from-[#D4B36A] to-[#B8923E] px-6 py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+          className="mb-10 rounded-lg bg-gradient-to-r from-[#D4B36A] to-[#B8923E] px-6 py-3 text-sm font-semibold text-soleur-text-on-accent transition-opacity hover:opacity-90"
         >
           New conversation
         </button>
@@ -541,7 +541,7 @@ export default function DashboardPage() {
     <div className="mx-auto max-w-4xl px-4 py-6 md:py-8">
       {/* Header */}
       <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-xl font-semibold text-white md:text-2xl">
+        <h1 className="text-xl font-semibold text-soleur-text-primary md:text-2xl">
           Dashboard
         </h1>
       </div>
@@ -558,14 +558,14 @@ export default function DashboardPage() {
       {/* Filter bar */}
       <div className="mb-4 flex flex-wrap items-center gap-2">
         {/* Archive toggle */}
-        <div className="flex rounded-lg border border-neutral-700 overflow-hidden">
+        <div className="flex rounded-lg border border-soleur-border-default overflow-hidden">
           <button
             type="button"
             onClick={() => setArchiveFilter("active")}
             className={`min-h-[44px] px-3 py-2 text-sm font-medium transition-colors ${
               archiveFilter === "active"
-                ? "bg-neutral-700 text-white"
-                : "bg-neutral-900 text-neutral-400 hover:text-neutral-300"
+                ? "bg-soleur-bg-surface-2 text-soleur-text-primary"
+                : "bg-soleur-bg-surface-1 text-soleur-text-secondary hover:text-soleur-text-secondary"
             }`}
           >
             Active
@@ -575,8 +575,8 @@ export default function DashboardPage() {
             onClick={() => setArchiveFilter("archived")}
             className={`min-h-[44px] px-3 py-2 text-sm font-medium transition-colors ${
               archiveFilter === "archived"
-                ? "bg-neutral-700 text-white"
-                : "bg-neutral-900 text-neutral-400 hover:text-neutral-300"
+                ? "bg-soleur-bg-surface-2 text-soleur-text-primary"
+                : "bg-soleur-bg-surface-1 text-soleur-text-secondary hover:text-soleur-text-secondary"
             }`}
           >
             Archived
@@ -588,8 +588,8 @@ export default function DashboardPage() {
           onChange={handleStatusChange}
           className={`min-h-[44px] rounded-lg border px-3 py-2 text-sm transition-colors ${
             statusFilter
-              ? "border-amber-500/50 bg-neutral-900 text-amber-500"
-              : "border-neutral-700 bg-neutral-900 text-neutral-300"
+              ? "border-soleur-border-emphasized bg-soleur-bg-surface-1 text-soleur-accent-gold-fg"
+              : "border-soleur-border-default bg-soleur-bg-surface-1 text-soleur-text-secondary"
           }`}
         >
           {STATUS_OPTIONS.map((opt) => (
@@ -604,8 +604,8 @@ export default function DashboardPage() {
           onChange={handleDomainChange}
           className={`min-h-[44px] rounded-lg border px-3 py-2 text-sm transition-colors ${
             domainFilter
-              ? "border-amber-500/50 bg-neutral-900 text-amber-500"
-              : "border-neutral-700 bg-neutral-900 text-neutral-300"
+              ? "border-soleur-border-emphasized bg-soleur-bg-surface-1 text-soleur-accent-gold-fg"
+              : "border-soleur-border-default bg-soleur-bg-surface-1 text-soleur-text-secondary"
           }`}
         >
           {DOMAIN_OPTIONS.map((opt) => (
@@ -620,7 +620,7 @@ export default function DashboardPage() {
         <button
           type="button"
           onClick={() => router.push("/dashboard/chat/new")}
-          className="min-h-[44px] rounded-lg bg-gradient-to-r from-[#D4B36A] to-[#B8923E] px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+          className="min-h-[44px] rounded-lg bg-gradient-to-r from-[#D4B36A] to-[#B8923E] px-4 py-2 text-sm font-semibold text-soleur-text-on-accent transition-opacity hover:opacity-90"
         >
           + New conversation
         </button>
@@ -632,14 +632,14 @@ export default function DashboardPage() {
           {[1, 2, 3, 4].map((i) => (
             <div
               key={i}
-              className="animate-pulse rounded-lg border border-neutral-800 bg-neutral-900/50 p-4"
+              className="animate-pulse rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1/50 p-4"
             >
               <div className="flex items-center gap-4">
-                <div className="h-5 w-28 rounded-full bg-neutral-800" />
-                <div className="h-4 w-48 rounded bg-neutral-800" />
+                <div className="h-5 w-28 rounded-full bg-soleur-bg-surface-2" />
+                <div className="h-4 w-48 rounded bg-soleur-bg-surface-2" />
                 <div className="flex-1" />
-                <div className="h-7 w-7 rounded-md bg-neutral-800" />
-                <div className="h-4 w-16 rounded bg-neutral-800" />
+                <div className="h-7 w-7 rounded-md bg-soleur-bg-surface-2" />
+                <div className="h-4 w-16 rounded bg-soleur-bg-surface-2" />
               </div>
             </div>
           ))}
@@ -658,13 +658,13 @@ export default function DashboardPage() {
       {/* Filtered empty state */}
       {!loading && !error && conversations.length === 0 && hasActiveFilter && (
         <div className="flex flex-col items-center justify-center py-20">
-          <p className="mb-4 text-sm text-neutral-400">
+          <p className="mb-4 text-sm text-soleur-text-secondary">
             No conversations match your filters.
           </p>
           <button
             type="button"
             onClick={clearFilters}
-            className="rounded-lg border border-neutral-700 px-4 py-2 text-sm text-neutral-300 transition-colors hover:bg-neutral-800"
+            className="rounded-lg border border-soleur-border-default px-4 py-2 text-sm text-soleur-text-secondary transition-colors hover:bg-soleur-bg-surface-2"
           >
             Clear filters
           </button>
@@ -692,7 +692,7 @@ export default function DashboardPage() {
 function LeaderStrip({ onLeaderClick, getIconPath }: { onLeaderClick: (leaderId: string) => void; getIconPath: (id: DomainLeaderId) => string | null }) {
   return (
     <>
-      <p className="mb-4 text-xs font-medium tracking-widest text-neutral-400">
+      <p className="mb-4 text-xs font-medium tracking-widest text-soleur-text-secondary">
         YOUR ORGANIZATION
       </p>
       <div className="flex flex-wrap justify-center gap-3">
@@ -701,10 +701,10 @@ function LeaderStrip({ onLeaderClick, getIconPath }: { onLeaderClick: (leaderId:
             key={leader.id}
             type="button"
             onClick={() => onLeaderClick(leader.id)}
-            className="group flex items-center gap-1.5 rounded-lg px-2 py-1 transition-colors hover:bg-neutral-800/50"
+            className="group flex items-center gap-1.5 rounded-lg px-2 py-1 transition-colors hover:bg-soleur-bg-surface-2/50"
           >
             <LeaderAvatar leaderId={leader.id} size="sm" customIconPath={getIconPath(leader.id as DomainLeaderId)} />
-            <span className="text-xs text-neutral-500 group-hover:text-neutral-300">
+            <span className="text-xs text-soleur-text-muted group-hover:text-soleur-text-secondary">
               {leader.name}
             </span>
           </button>

--- a/apps/web-platform/app/(dashboard)/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/layout.tsx
@@ -58,21 +58,21 @@ export function PaymentWarningBanner({
   return (
     <div className="border-b border-orange-800/50 bg-orange-950/30 px-4 py-3">
       <div className="mx-auto flex max-w-4xl items-center justify-between gap-3">
-        <p className="text-sm text-neutral-200">
+        <p className="text-sm text-soleur-text-primary">
           <span className="font-medium text-orange-400">Your last payment failed.</span>{" "}
           Update your payment method to avoid service interruption.
         </p>
         <div className="flex shrink-0 items-center gap-2">
           <a
             href="/dashboard/settings"
-            className="rounded-lg bg-orange-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-orange-500"
+            className="rounded-lg bg-orange-600 px-3 py-1.5 text-xs font-medium text-soleur-text-on-accent hover:bg-orange-500"
           >
             Update Payment
           </a>
           <button
             onClick={dismissBanner}
             aria-label="Dismiss payment warning"
-            className="rounded p-1 text-neutral-400 hover:text-neutral-200"
+            className="rounded p-1 text-soleur-text-secondary hover:text-soleur-text-primary"
           >
             <XIcon className="h-4 w-4" />
           </button>
@@ -372,13 +372,13 @@ export default function DashboardLayout({
         {subscriptionStatus === "unpaid" && (
           <div className="border-b border-red-800/50 bg-red-950/30 px-4 py-3">
             <div className="mx-auto flex max-w-4xl items-center justify-between gap-3">
-              <p className="text-sm text-neutral-200">
+              <p className="text-sm text-soleur-text-primary">
                 <span className="font-medium text-red-400">Your subscription is unpaid.</span>{" "}
                 Your account is in read-only mode.
               </p>
               <a
                 href="/dashboard/settings"
-                className="shrink-0 rounded-lg bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-500"
+                className="shrink-0 rounded-lg bg-red-600 px-3 py-1.5 text-xs font-medium text-soleur-text-on-accent hover:bg-red-500"
               >
                 Resolve Payment
               </a>

--- a/apps/web-platform/app/global-error.tsx
+++ b/apps/web-platform/app/global-error.tsx
@@ -15,15 +15,16 @@ export default function GlobalError({
 
   return (
     <html lang="en">
-      <body className="bg-neutral-950 text-white">
+      {/* global-error has no data-theme attribute (no-FOUC script lives in failed root layout); :root:not([data-theme]) defaults to OS preference. */}
+      <body className="bg-soleur-bg-base text-soleur-text-primary">
         <div className="flex min-h-screen flex-col items-center justify-center gap-4">
           <h2 className="text-xl font-semibold">Something went wrong</h2>
-          <p className="text-sm text-neutral-400">
+          <p className="text-sm text-soleur-text-secondary">
             A critical error occurred. Please try refreshing the page.
           </p>
           <button
             onClick={reset}
-            className="rounded-lg border border-neutral-700 px-4 py-2 text-sm text-neutral-300 hover:border-neutral-500"
+            className="rounded-lg border border-soleur-border-default px-4 py-2 text-sm text-soleur-text-secondary hover:border-soleur-border-default"
           >
             Try again
           </button>

--- a/apps/web-platform/app/shared/[token]/page.tsx
+++ b/apps/web-platform/app/shared/[token]/page.tsx
@@ -22,7 +22,7 @@ const PdfPreview = dynamic(
     ssr: false,
     loading: () => (
       <div className="flex items-center justify-center p-8">
-        <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-600 border-t-amber-400" />
+        <div className="h-5 w-5 animate-spin rounded-full border-2 border-soleur-text-muted border-t-amber-400" />
       </div>
     ),
   },
@@ -82,14 +82,14 @@ export default function SharedDocumentPage({
       <head>
         <meta name="robots" content="noindex" />
       </head>
-      <div className="min-h-screen bg-neutral-950 text-neutral-200">
+      <div className="min-h-screen bg-soleur-bg-base text-soleur-text-primary">
         {/* Soleur branded header */}
-        <header className="border-b border-neutral-800 px-4 py-3">
+        <header className="border-b border-soleur-border-default px-4 py-3">
           <div className="mx-auto flex max-w-3xl items-center justify-between">
-            <Link href="https://soleur.ai" className="text-lg font-semibold text-white">
+            <Link href="https://soleur.ai" className="text-lg font-semibold text-soleur-text-primary">
               Soleur
             </Link>
-            <span className="text-xs text-neutral-500">Shared document</span>
+            <span className="text-xs text-soleur-text-muted">Shared document</span>
           </div>
         </header>
 
@@ -160,7 +160,7 @@ function renderSharedContent(data: SharedData) {
             src={data.src}
             alt="Shared image"
             title={data.filename ?? undefined}
-            className="max-h-[80vh] max-w-full rounded-lg border border-neutral-800"
+            className="max-h-[80vh] max-w-full rounded-lg border border-soleur-border-default"
           />
         </div>
       );
@@ -169,13 +169,13 @@ function renderSharedContent(data: SharedData) {
     case "download":
       return (
         <div className="flex flex-col items-center justify-center py-20 text-center">
-          <h1 className="mb-2 text-lg font-semibold text-white">{data.filename}</h1>
-          <p className="mb-6 text-sm text-neutral-400">Download to view this file.</p>
+          <h1 className="mb-2 text-lg font-semibold text-soleur-text-primary">{data.filename}</h1>
+          <p className="mb-6 text-sm text-soleur-text-secondary">Download to view this file.</p>
           <a
             data-testid="shared-download"
             href={data.src}
             download={data.filename}
-            className="inline-flex items-center gap-2 rounded-lg border border-amber-500/50 px-4 py-2 text-sm font-medium text-amber-400 transition-colors hover:border-amber-400 hover:text-amber-300"
+            className="inline-flex items-center gap-2 rounded-lg border border-soleur-border-emphasized px-4 py-2 text-sm font-medium text-soleur-accent-gold-fg transition-colors hover:border-amber-400 hover:text-soleur-accent-gold-text"
           >
             Download {data.filename}
           </a>
@@ -194,11 +194,11 @@ function renderSharedContent(data: SharedData) {
 function ErrorMessage({ title, message }: { title: string; message: string }) {
   return (
     <div className="flex flex-col items-center justify-center py-20 text-center">
-      <h1 className="mb-2 text-lg font-semibold text-white">{title}</h1>
-      <p className="mb-6 text-sm text-neutral-400">{message}</p>
+      <h1 className="mb-2 text-lg font-semibold text-soleur-text-primary">{title}</h1>
+      <p className="mb-6 text-sm text-soleur-text-secondary">{message}</p>
       <Link
         href="https://soleur.ai"
-        className="text-sm text-amber-400 underline hover:text-amber-300"
+        className="text-sm text-soleur-accent-gold-fg underline hover:text-soleur-accent-gold-text"
       >
         Learn about Soleur
       </Link>

--- a/apps/web-platform/components/analytics/analytics-dashboard.tsx
+++ b/apps/web-platform/components/analytics/analytics-dashboard.tsx
@@ -16,7 +16,7 @@ function Sparkline({
   color?: string;
 }) {
   if (data.length === 0) {
-    return <span className="text-neutral-600">—</span>;
+    return <span className="text-soleur-text-muted">—</span>;
   }
 
   if (data.length === 1) {
@@ -113,9 +113,9 @@ export function AnalyticsDashboard({
   if (metrics.length === 0) {
     return (
       <div className="space-y-6">
-        <h1 className="text-2xl font-semibold text-white">Analytics</h1>
-        <div className="flex flex-col items-center justify-center min-h-[300px] rounded-xl border border-neutral-800 bg-neutral-900/50">
-          <p className="text-neutral-400">No users registered yet.</p>
+        <h1 className="text-2xl font-semibold text-soleur-text-primary">Analytics</h1>
+        <div className="flex flex-col items-center justify-center min-h-[300px] rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1/50">
+          <p className="text-soleur-text-secondary">No users registered yet.</p>
         </div>
       </div>
     );
@@ -123,37 +123,37 @@ export function AnalyticsDashboard({
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold text-white">Analytics</h1>
-      <p className="text-sm text-neutral-500">
+      <h1 className="text-2xl font-semibold text-soleur-text-primary">Analytics</h1>
+      <p className="text-sm text-soleur-text-muted">
         P4 validation metrics — {metrics.length} user{metrics.length !== 1 ? "s" : ""}
       </p>
 
-      <div className="rounded-xl border border-neutral-800 bg-neutral-900/50 overflow-x-auto">
+      <div className="rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1/50 overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-neutral-800">
-              <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
+            <tr className="border-b border-soleur-border-default">
+              <th className="px-4 py-3 text-left text-xs font-medium text-soleur-text-muted uppercase tracking-wider">
                 User
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
+              <th className="px-4 py-3 text-left text-xs font-medium text-soleur-text-muted uppercase tracking-wider">
                 Domains
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
+              <th className="px-4 py-3 text-left text-xs font-medium text-soleur-text-muted uppercase tracking-wider">
                 Sessions
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
+              <th className="px-4 py-3 text-left text-xs font-medium text-soleur-text-muted uppercase tracking-wider">
                 Multi-Domain
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
+              <th className="px-4 py-3 text-left text-xs font-medium text-soleur-text-muted uppercase tracking-wider">
                 KB Growth
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
+              <th className="px-4 py-3 text-left text-xs font-medium text-soleur-text-muted uppercase tracking-wider">
                 TTFV
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
+              <th className="px-4 py-3 text-left text-xs font-medium text-soleur-text-muted uppercase tracking-wider">
                 Error Rate
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
+              <th className="px-4 py-3 text-left text-xs font-medium text-soleur-text-muted uppercase tracking-wider">
                 Status
               </th>
             </tr>
@@ -162,37 +162,37 @@ export function AnalyticsDashboard({
             {metrics.map((m) => (
               <tr
                 key={m.userId}
-                className="border-b border-neutral-800/50 hover:bg-neutral-800/30"
+                className="border-b border-soleur-border-default/50 hover:bg-soleur-bg-surface-2/30"
               >
-                <td className="px-4 py-3 text-neutral-300 font-mono text-xs">
+                <td className="px-4 py-3 text-soleur-text-secondary font-mono text-xs">
                   {m.email}
                 </td>
-                <td className="px-4 py-3 text-neutral-400">
+                <td className="px-4 py-3 text-soleur-text-secondary">
                   {m.totalSessions > 0 ? (
                     <span title={Object.entries(m.domainCounts).map(([k, v]) => `${k}: ${v}`).join(", ")}>
                       {Object.entries(m.domainCounts).map(([leader, count]) => (
                         <span key={leader} className="inline-block mr-1.5 text-xs">
-                          <span className="text-amber-500">{leader}</span>
-                          <span className="text-neutral-500 ml-0.5">{count}</span>
+                          <span className="text-soleur-accent-gold-fg">{leader}</span>
+                          <span className="text-soleur-text-muted ml-0.5">{count}</span>
                         </span>
                       ))}
                     </span>
                   ) : (
-                    <span className="text-neutral-600">—</span>
+                    <span className="text-soleur-text-muted">—</span>
                   )}
                 </td>
                 <td className="px-4 py-3">
                   <div className="flex items-center gap-2">
-                    <span className="text-neutral-300">{m.totalSessions}</span>
+                    <span className="text-soleur-text-secondary">{m.totalSessions}</span>
                     <Sparkline data={sessionSparklineData(m.sessionsByDay)} />
                   </div>
                 </td>
-                <td className="px-4 py-3 text-neutral-300">
-                  {m.domainCount > 0 ? m.domainCount : <span className="text-neutral-600">—</span>}
+                <td className="px-4 py-3 text-soleur-text-secondary">
+                  {m.domainCount > 0 ? m.domainCount : <span className="text-soleur-text-muted">—</span>}
                 </td>
                 <td className="px-4 py-3">
                   <div className="flex items-center gap-2">
-                    <span className="text-neutral-300 text-xs">
+                    <span className="text-soleur-text-secondary text-xs">
                       {kbGrowthLabel(m.kbHistory)}
                     </span>
                     <Sparkline
@@ -201,7 +201,7 @@ export function AnalyticsDashboard({
                     />
                   </div>
                 </td>
-                <td className="px-4 py-3 text-neutral-400">
+                <td className="px-4 py-3 text-soleur-text-secondary">
                   {formatDays(m.ttfvDays)}
                 </td>
                 <td className="px-4 py-3">
@@ -211,7 +211,7 @@ export function AnalyticsDashboard({
                         ? "text-red-400"
                         : m.errorRate > 0
                           ? "text-amber-400"
-                          : "text-neutral-400"
+                          : "text-soleur-text-secondary"
                     }
                   >
                     {formatPercent(m.errorRate)}
@@ -224,7 +224,7 @@ export function AnalyticsDashboard({
                         m.churning ? "bg-red-500" : "bg-green-500"
                       }`}
                     />
-                    <span className="text-xs text-neutral-500">
+                    <span className="text-xs text-soleur-text-muted">
                       {m.churning
                         ? m.daysSinceLastSession !== null
                           ? `${m.daysSinceLastSession}d ago`

--- a/apps/web-platform/components/auth/oauth-buttons.tsx
+++ b/apps/web-platform/components/auth/oauth-buttons.tsx
@@ -105,7 +105,7 @@ export function OAuthButtons({ disabled = false }: { disabled?: boolean }) {
           type="button"
           onClick={() => handleOAuth(provider)}
           disabled={loading !== null || disabled}
-          className="flex w-full items-center justify-center gap-3 rounded-lg border border-neutral-700 bg-neutral-900 px-4 py-3 text-sm font-medium text-white hover:bg-neutral-800 disabled:opacity-50"
+          className="flex w-full items-center justify-center gap-3 rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1 px-4 py-3 text-sm font-medium text-soleur-text-primary hover:bg-soleur-bg-surface-2 disabled:opacity-50"
         >
           {provider.icon}
           Continue with {provider.label}

--- a/apps/web-platform/components/chat/at-mention-dropdown.tsx
+++ b/apps/web-platform/components/chat/at-mention-dropdown.tsx
@@ -84,13 +84,13 @@ export function AtMentionDropdown({
     <div
       role="listbox"
       aria-label="Leaders"
-      className="absolute bottom-full left-0 z-50 mb-2 w-full max-w-md rounded-xl border border-neutral-700 bg-neutral-900 shadow-xl"
+      className="absolute bottom-full left-0 z-50 mb-2 w-full max-w-md rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1 shadow-xl"
     >
-      <div className="px-3 py-2 text-xs font-medium uppercase tracking-wider text-neutral-500">
+      <div className="px-3 py-2 text-xs font-medium uppercase tracking-wider text-soleur-text-muted">
         Leaders
       </div>
       {filtered.length === 0 ? (
-        <div className="px-3 py-3 text-sm text-neutral-500">
+        <div className="px-3 py-3 text-sm text-soleur-text-muted">
           {loading && query ? "Loading team..." : "No matches"}
         </div>
       ) : (
@@ -105,19 +105,19 @@ export function AtMentionDropdown({
                 onClick={() => onSelect(leader.id)}
                 onMouseEnter={() => setActiveIndex(index)}
                 className={`flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors ${
-                  index === activeIndex ? "bg-neutral-800" : ""
+                  index === activeIndex ? "bg-soleur-bg-surface-2" : ""
                 }`}
               >
                 <LeaderAvatar leaderId={leader.id} size="md" />
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
-                    <span className="text-sm font-semibold text-white">
+                    <span className="text-sm font-semibold text-soleur-text-primary">
                       {customName
                         ? `${customName} (${leader.name})`
                         : leader.name}
                     </span>
                   </div>
-                  <p className="truncate text-xs text-neutral-400">
+                  <p className="truncate text-xs text-soleur-text-secondary">
                     {leader.title} &mdash; {leader.description.split(",").slice(0, 3).join(",")}
                   </p>
                 </div>
@@ -126,11 +126,11 @@ export function AtMentionDropdown({
           })}
         </ul>
       )}
-      <div className="flex items-center gap-3 border-t border-neutral-800 px-3 py-1.5 text-xs text-neutral-400">
+      <div className="flex items-center gap-3 border-t border-soleur-border-default px-3 py-1.5 text-xs text-soleur-text-secondary">
         <span>{filtered.length} {filtered.length === 1 ? "match" : "matches"}</span>
         <span className="ml-auto flex items-center gap-1">
-          <kbd className="rounded border border-neutral-700 px-1">↑</kbd>
-          <kbd className="rounded border border-neutral-700 px-1">↓</kbd>
+          <kbd className="rounded border border-soleur-border-default px-1">↑</kbd>
+          <kbd className="rounded border border-soleur-border-default px-1">↓</kbd>
           to navigate
         </span>
       </div>

--- a/apps/web-platform/components/chat/attachment-display.tsx
+++ b/apps/web-platform/components/chat/attachment-display.tsx
@@ -77,7 +77,7 @@ function ImageAttachment({ attachment }: { attachment: AttachmentRef }) {
 
   if (!url) {
     return (
-      <div className="h-32 w-32 animate-pulse rounded-lg bg-neutral-800" />
+      <div className="h-32 w-32 animate-pulse rounded-lg bg-soleur-bg-surface-2" />
     );
   }
 
@@ -86,7 +86,7 @@ function ImageAttachment({ attachment }: { attachment: AttachmentRef }) {
       <button
         type="button"
         onClick={() => setExpanded(true)}
-        className="overflow-hidden rounded-lg border border-neutral-700 transition-opacity hover:opacity-80"
+        className="overflow-hidden rounded-lg border border-soleur-border-default transition-opacity hover:opacity-80"
       >
         <img
           src={url}
@@ -124,7 +124,7 @@ function FileAttachment({ attachment }: { attachment: AttachmentRef }) {
       href={url ?? "#"}
       target="_blank"
       rel="noopener noreferrer"
-      className={`flex items-center gap-2 rounded-lg border border-neutral-700 bg-neutral-800/50 px-3 py-2 text-sm transition-colors hover:border-neutral-500 ${!url ? "pointer-events-none opacity-60" : ""}`}
+      className={`flex items-center gap-2 rounded-lg border border-soleur-border-default bg-soleur-bg-surface-2/50 px-3 py-2 text-sm transition-colors hover:border-soleur-border-emphasized ${!url ? "pointer-events-none opacity-60" : ""}`}
     >
       <svg
         width="20"
@@ -143,8 +143,8 @@ function FileAttachment({ attachment }: { attachment: AttachmentRef }) {
         <line x1="16" y1="17" x2="8" y2="17" />
       </svg>
       <div className="flex flex-col">
-        <span className="max-w-[200px] truncate text-neutral-200">{attachment.filename}</span>
-        <span className="text-xs text-neutral-500">{sizeKb} KB</span>
+        <span className="max-w-[200px] truncate text-soleur-text-primary">{attachment.filename}</span>
+        <span className="text-xs text-soleur-text-muted">{sizeKb} KB</span>
       </div>
     </a>
   );

--- a/apps/web-platform/components/chat/chat-input.tsx
+++ b/apps/web-platform/components/chat/chat-input.tsx
@@ -499,7 +499,7 @@ export function ChatInput({
             <div
               key={att.id}
               data-testid="attachment-preview"
-              className="relative flex items-center gap-2 rounded-lg border border-neutral-700 bg-neutral-800 px-2 py-1.5"
+              className="relative flex items-center gap-2 rounded-lg border border-soleur-border-default bg-soleur-bg-surface-2 px-2 py-1.5"
             >
               {att.preview ? (
                 <img
@@ -508,19 +508,19 @@ export function ChatInput({
                   className="h-8 w-8 rounded object-cover"
                 />
               ) : (
-                <div className="flex h-8 w-8 items-center justify-center rounded bg-neutral-700 text-xs text-neutral-400">
+                <div className="flex h-8 w-8 items-center justify-center rounded bg-soleur-bg-surface-2 text-xs text-soleur-text-secondary">
                   PDF
                 </div>
               )}
               <div className="flex flex-col">
-                <span className="max-w-[120px] truncate text-xs text-neutral-300">
+                <span className="max-w-[120px] truncate text-xs text-soleur-text-secondary">
                   {att.file.name}
                 </span>
                 {att.error ? (
                   <span className="text-xs text-red-400">{att.error}</span>
                 ) : att.progress > 0 && att.progress < 100 ? (
                   <div className="mt-0.5 flex items-center gap-1.5">
-                    <div className="h-1 w-16 overflow-hidden rounded-full bg-neutral-700">
+                    <div className="h-1 w-16 overflow-hidden rounded-full bg-soleur-bg-surface-2">
                       <div
                         className="h-full bg-amber-500"
                         style={{
@@ -529,7 +529,7 @@ export function ChatInput({
                         }}
                       />
                     </div>
-                    <span className="text-[10px] tabular-nums text-neutral-400">
+                    <span className="text-[10px] tabular-nums text-soleur-text-secondary">
                       {att.progress}%
                     </span>
                   </div>
@@ -540,7 +540,7 @@ export function ChatInput({
               <button
                 type="button"
                 onClick={() => removeAttachment(att.id)}
-                className="ml-1 rounded p-0.5 text-neutral-500 hover:text-neutral-300"
+                className="ml-1 rounded p-0.5 text-soleur-text-muted hover:text-soleur-text-secondary"
                 aria-label={`Remove ${att.file.name}`}
               >
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -566,7 +566,7 @@ export function ChatInput({
           type="button"
           onClick={() => fileInputRef.current?.click()}
           disabled={disabled || isUploading}
-          className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-xl border border-neutral-700 text-neutral-400 transition-colors hover:border-neutral-500 hover:text-white disabled:opacity-50"
+          className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-xl border border-soleur-border-default text-soleur-text-secondary transition-colors hover:border-soleur-border-emphasized hover:text-soleur-text-primary disabled:opacity-50"
           aria-label="Attach file"
         >
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -598,7 +598,7 @@ export function ChatInput({
             rows={1}
             data-quote-flashing={flashQuote ? "true" : undefined}
             className={
-              "w-full resize-none rounded-xl border border-neutral-700 bg-neutral-900 px-4 py-2.5 pr-12 text-sm text-white placeholder:text-neutral-500 focus:border-neutral-500 focus:outline-none disabled:opacity-50 min-h-[72px] max-h-[140px] overflow-y-auto transition-shadow" +
+              "w-full resize-none rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1 px-4 py-2.5 pr-12 text-sm text-soleur-text-primary placeholder:text-soleur-text-muted focus:border-soleur-border-emphasized focus:outline-none disabled:opacity-50 min-h-[72px] max-h-[140px] overflow-y-auto transition-shadow" +
               (flashQuote ? " ring-2 ring-amber-400" : "")
             }
           />
@@ -607,7 +607,7 @@ export function ChatInput({
             type="button"
             onClick={handleAtButtonClick}
             disabled={disabled}
-            className="absolute bottom-2.5 right-2 rounded-md p-1 text-neutral-500 transition-colors hover:text-neutral-300 disabled:opacity-50 md:hidden"
+            className="absolute bottom-2.5 right-2 rounded-md p-1 text-soleur-text-muted transition-colors hover:text-soleur-text-secondary disabled:opacity-50 md:hidden"
             aria-label="Mention a leader"
           >
             <span className="text-sm font-medium">@</span>
@@ -617,7 +617,7 @@ export function ChatInput({
           type="button"
           onClick={handleSubmit}
           disabled={disabled || isUploading || (!value.trim() && attachments.length === 0)}
-          className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-xl bg-amber-600 text-white transition-colors hover:bg-amber-500 disabled:opacity-50 disabled:hover:bg-amber-600"
+          className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-xl bg-amber-600 text-soleur-text-on-accent transition-colors hover:bg-amber-500 disabled:opacity-50 disabled:hover:bg-amber-600"
           aria-label="Send message"
         >
           {isUploading ? (

--- a/apps/web-platform/components/chat/chat-surface.tsx
+++ b/apps/web-platform/components/chat/chat-surface.tsx
@@ -402,12 +402,12 @@ export function ChatSurface({
   return (
     <div className={rootClass}>
       {isFull && (
-        <header className="flex shrink-0 items-center justify-between border-b border-neutral-800 px-4 py-3 md:px-6">
+        <header className="flex shrink-0 items-center justify-between border-b border-soleur-border-default px-4 py-3 md:px-6">
           <div className="flex items-center gap-3">
             <a
               href="/dashboard"
               aria-label="Back to dashboard"
-              className="flex items-center text-neutral-400 hover:text-white md:hidden"
+              className="flex items-center text-soleur-text-secondary hover:text-soleur-text-primary md:hidden"
             >
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <polyline points="15 18 9 12 15 6" />
@@ -415,12 +415,12 @@ export function ChatSurface({
             </a>
 
             {activeLeaderIds.length > 0 && (
-              <span className="text-sm text-neutral-400 md:hidden">
+              <span className="text-sm text-soleur-text-secondary md:hidden">
                 {activeLeaderIds.map((id) => getDisplayName(id)).join(", ")} responding
               </span>
             )}
 
-            <span className="hidden text-sm font-semibold text-white md:inline">
+            <span className="hidden text-sm font-semibold text-soleur-text-primary md:inline">
               Dashboard
             </span>
           </div>
@@ -485,7 +485,7 @@ export function ChatSurface({
 
         {messages.length === 0 && !isClassifying && !lastError && !historyLoading && (
           <div className="flex h-full items-center justify-center">
-            <p className="text-sm text-neutral-400">
+            <p className="text-sm text-soleur-text-secondary">
               Send a message to get started
             </p>
           </div>
@@ -564,9 +564,9 @@ export function ChatSurface({
                   body = (
                     <div
                       data-message-type="workflow_ended"
-                      className="rounded-xl border border-neutral-800 bg-neutral-900/40 px-4 py-3"
+                      className="rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1/40 px-4 py-3"
                     >
-                      <p className="text-sm text-neutral-200">
+                      <p className="text-sm text-soleur-text-primary">
                         Workflow{" "}
                         <span className="font-semibold">{msg.workflow}</span>{" "}
                         ended:{" "}
@@ -581,7 +581,7 @@ export function ChatSurface({
                         </span>
                       </p>
                       {msg.summary ? (
-                        <p className="mt-1 text-xs text-neutral-400">{msg.summary}</p>
+                        <p className="mt-1 text-xs text-soleur-text-secondary">{msg.summary}</p>
                       ) : null}
                     </div>
                   );
@@ -614,10 +614,10 @@ export function ChatSurface({
 
           {isClassifying && (
             <div className="flex justify-start" data-testid="routing-chip">
-              <div className="flex items-center gap-2 rounded-xl border border-neutral-800 bg-neutral-900 px-4 py-3">
+              <div className="flex items-center gap-2 rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1 px-4 py-3">
                 <LeaderAvatar leaderId={CC_ROUTER_LEADER_ID} size="sm" />
                 <span className="h-2 w-2 animate-pulse rounded-full bg-amber-500" />
-                <span className="text-sm text-neutral-400">
+                <span className="text-sm text-soleur-text-secondary">
                   Soleur Concierge is routing to the right experts...
                 </span>
               </div>
@@ -630,23 +630,23 @@ export function ChatSurface({
       </div>
 
       {isFull && (activeLeaderIds.length > 0 || (usageData && usageData.totalCostUsd > 0)) && (
-        <div className="hidden border-t border-neutral-800/50 px-4 py-1.5 md:block md:px-6">
-          <p className="text-xs text-neutral-500">
+        <div className="hidden border-t border-soleur-border-default/50 px-4 py-1.5 md:block md:px-6">
+          <p className="text-xs text-soleur-text-muted">
             {activeLeaderIds.length > 0 && (
               <>{activeLeaderIds.length} leaders responding</>
             )}
             {usageData && usageData.totalCostUsd > 0 && (
-              <span className="text-neutral-400">
+              <span className="text-soleur-text-secondary">
                 {activeLeaderIds.length > 0 && " · "}
                 ~${usageData.totalCostUsd.toFixed(4)}
-                <span className="text-neutral-500 ml-1">estimated</span>
+                <span className="text-soleur-text-muted ml-1">estimated</span>
               </span>
             )}
           </p>
         </div>
       )}
 
-      <div className={`shrink-0 border-t border-neutral-800 bg-neutral-950 py-3 ${inputPadX} ${isFull ? "safe-bottom md:px-6" : ""}`}>
+      <div className={`shrink-0 border-t border-soleur-border-default bg-soleur-bg-base py-3 ${inputPadX} ${isFull ? "safe-bottom md:px-6" : ""}`}>
         <div className={`relative min-w-0 ${widthWrapper}`}>
           <AtMentionDropdown
             query={atQuery}
@@ -686,18 +686,18 @@ export function ChatSurface({
           />
         </div>
         {!isFull && usageData && usageData.totalCostUsd > 0 && (
-          <div className="mt-1 px-1 text-xs text-neutral-500">
+          <div className="mt-1 px-1 text-xs text-soleur-text-muted">
             ~${usageData.totalCostUsd.toFixed(4)} estimated
           </div>
         )}
         {isFull && (
-          <div className="mx-auto mt-1 flex max-w-3xl items-center justify-between text-xs text-neutral-400">
+          <div className="mx-auto mt-1 flex max-w-3xl items-center justify-between text-xs text-soleur-text-secondary">
             <span className="md:hidden">
               {activeLeaderIds.length > 0 && (
                 <>{activeLeaderIds.length} leaders responding</>
               )}
               {usageData && usageData.totalCostUsd > 0 && (
-                <span className="text-neutral-400">
+                <span className="text-soleur-text-secondary">
                   {activeLeaderIds.length > 0 && " · "}
                   ~${usageData.totalCostUsd.toFixed(4)} est.
                 </span>

--- a/apps/web-platform/components/chat/interactive-prompt-card.tsx
+++ b/apps/web-platform/components/chat/interactive-prompt-card.tsx
@@ -45,7 +45,7 @@ type InteractivePromptCardProps = InteractivePromptCardPropsBase &
 
 export function InteractivePromptCard(props: InteractivePromptCardProps) {
   const baseClass =
-    "rounded-xl border border-neutral-800 bg-neutral-900/60 px-4 py-3";
+    "rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1/60 px-4 py-3";
   const disabled = props.resolved === true;
 
   switch (props.kind) {
@@ -132,7 +132,7 @@ const ResolvedCardRow = React.memo(function ResolvedCardRow({
 }) {
   return (
     <div data-prompt-kind={kind} data-prompt-id={promptId}>
-      <div className="flex items-center gap-2 rounded-lg border border-neutral-800 bg-neutral-900/50 px-4 py-2 text-sm text-neutral-400 transition-all duration-300">
+      <div className="flex items-center gap-2 rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1/50 px-4 py-2 text-sm text-soleur-text-secondary transition-all duration-300">
         <svg
           className="h-4 w-4 text-green-500"
           viewBox="0 0 24 24"
@@ -149,7 +149,7 @@ const ResolvedCardRow = React.memo(function ResolvedCardRow({
           {target ? (
             <>
               :{" "}
-              <strong className="text-neutral-200">{target}</strong>
+              <strong className="text-soleur-text-primary">{target}</strong>
             </>
           ) : null}
         </span>
@@ -202,10 +202,10 @@ function AskUserCard({
     return (
       <CardShell promptId={promptId} kind="ask_user">
         <div className={baseClass}>
-          <p className="mb-2 text-sm text-neutral-200">{payload.question}</p>
+          <p className="mb-2 text-sm text-soleur-text-primary">{payload.question}</p>
           <div className="flex flex-col gap-1.5">
             {payload.options.map((opt) => (
-              <label key={opt} className="flex items-center gap-2 text-sm text-neutral-300">
+              <label key={opt} className="flex items-center gap-2 text-sm text-soleur-text-secondary">
                 <input
                   type="checkbox"
                   aria-label={opt}
@@ -223,7 +223,7 @@ function AskUserCard({
             onClick={() =>
               onRespond({ kind: "ask_user", response: picked })
             }
-            className="mt-3 rounded-md bg-amber-600 px-3 py-1 text-sm text-white disabled:opacity-50"
+            className="mt-3 rounded-md bg-amber-600 px-3 py-1 text-sm text-soleur-text-on-accent disabled:opacity-50"
           >
             Submit
           </button>
@@ -236,7 +236,7 @@ function AskUserCard({
   return (
     <CardShell promptId={promptId} kind="ask_user">
       <div className={baseClass}>
-        <p className="mb-2 text-sm text-neutral-200">{payload.question}</p>
+        <p className="mb-2 text-sm text-soleur-text-primary">{payload.question}</p>
         <div className="flex flex-wrap gap-2">
           {payload.options.map((opt) => (
             <button
@@ -244,7 +244,7 @@ function AskUserCard({
               type="button"
               disabled={disabled}
               onClick={() => onRespond({ kind: "ask_user", response: opt })}
-              className="rounded-full border border-neutral-700 px-3 py-1 text-xs text-neutral-200 hover:border-amber-500 disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-full border border-soleur-border-default px-3 py-1 text-xs text-soleur-text-primary hover:border-amber-500 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {opt}
             </button>
@@ -280,7 +280,7 @@ function PlanPreviewCard({
   return (
     <CardShell promptId={promptId} kind="plan_preview">
       <div className={baseClass}>
-        <pre className="mb-3 max-h-64 overflow-auto whitespace-pre-wrap text-sm text-neutral-200">
+        <pre className="mb-3 max-h-64 overflow-auto whitespace-pre-wrap text-sm text-soleur-text-primary">
           {text}
         </pre>
         <div className="flex gap-2">
@@ -288,7 +288,7 @@ function PlanPreviewCard({
             type="button"
             disabled={disabled}
             onClick={() => onRespond({ kind: "plan_preview", response: "accept" })}
-            className="rounded-md bg-amber-600 px-3 py-1 text-sm text-white disabled:opacity-50"
+            className="rounded-md bg-amber-600 px-3 py-1 text-sm text-soleur-text-on-accent disabled:opacity-50"
           >
             Accept
           </button>
@@ -296,7 +296,7 @@ function PlanPreviewCard({
             type="button"
             disabled={disabled}
             onClick={() => onRespond({ kind: "plan_preview", response: "iterate" })}
-            className="rounded-md border border-neutral-700 px-3 py-1 text-sm text-neutral-200 disabled:opacity-50"
+            className="rounded-md border border-soleur-border-default px-3 py-1 text-sm text-soleur-text-primary disabled:opacity-50"
           >
             Iterate
           </button>
@@ -333,8 +333,8 @@ function DiffCard({
   return (
     <CardShell promptId={promptId} kind="diff">
       <div className={baseClass}>
-        <p className="mb-2 text-sm text-neutral-200">
-          Edited file <code className="rounded bg-neutral-800 px-1 py-0.5 text-xs">{payload.path}</code>{" "}
+        <p className="mb-2 text-sm text-soleur-text-primary">
+          Edited file <code className="rounded bg-soleur-bg-surface-2 px-1 py-0.5 text-xs">{payload.path}</code>{" "}
           <span className="text-emerald-400">+{payload.additions}</span>{" "}
           <span className="text-red-400">-{payload.deletions}</span>
         </p>
@@ -342,7 +342,7 @@ function DiffCard({
           type="button"
           disabled={disabled}
           onClick={() => onRespond({ kind: "diff", response: "ack" })}
-          className="rounded-md border border-neutral-700 px-3 py-1 text-sm text-neutral-200 disabled:opacity-50"
+          className="rounded-md border border-soleur-border-default px-3 py-1 text-sm text-soleur-text-primary disabled:opacity-50"
         >
           Acknowledge
         </button>
@@ -380,19 +380,19 @@ function BashApprovalCard({
   return (
     <CardShell promptId={promptId} kind="bash_approval">
       <div className={baseClass}>
-        <pre className="mb-2 overflow-auto rounded bg-neutral-950 p-2 text-xs text-neutral-200">
+        <pre className="mb-2 overflow-auto rounded bg-soleur-bg-base p-2 text-xs text-soleur-text-primary">
           {/* Default React text-node escaping handles HTML-special chars in
               attacker-influenced `payload.command`. NO escape-hatch render APIs. */}
           {payload.command}
         </pre>
-        <p className="mb-3 text-xs text-neutral-500">cwd: {payload.cwd}</p>
+        <p className="mb-3 text-xs text-soleur-text-muted">cwd: {payload.cwd}</p>
         {payload.gated ? (
           <div className="flex gap-2">
             <button
               type="button"
               disabled={disabled}
               onClick={() => onRespond({ kind: "bash_approval", response: "approve" })}
-              className="rounded-md bg-amber-600 px-3 py-1 text-sm text-white disabled:opacity-50"
+              className="rounded-md bg-amber-600 px-3 py-1 text-sm text-soleur-text-on-accent disabled:opacity-50"
             >
               Approve
             </button>
@@ -439,11 +439,11 @@ function TodoWriteCard({
   return (
     <CardShell promptId={promptId} kind="todo_write">
       <div className={baseClass}>
-        <p className="mb-2 text-sm text-neutral-200">{payload.items.length} todos</p>
+        <p className="mb-2 text-sm text-soleur-text-primary">{payload.items.length} todos</p>
         <ul className="mb-3 space-y-1">
           {payload.items.map((it) => (
-            <li key={it.id} className="flex items-center gap-2 text-xs text-neutral-300">
-              <span className="rounded bg-neutral-800 px-1.5 py-0.5 text-[10px] text-neutral-400">
+            <li key={it.id} className="flex items-center gap-2 text-xs text-soleur-text-secondary">
+              <span className="rounded bg-soleur-bg-surface-2 px-1.5 py-0.5 text-[10px] text-soleur-text-secondary">
                 {it.status}
               </span>
               <span className="truncate">{it.content}</span>
@@ -454,7 +454,7 @@ function TodoWriteCard({
           type="button"
           disabled={disabled}
           onClick={() => onRespond({ kind: "todo_write", response: "ack" })}
-          className="rounded-md border border-neutral-700 px-3 py-1 text-sm text-neutral-200 disabled:opacity-50"
+          className="rounded-md border border-soleur-border-default px-3 py-1 text-sm text-soleur-text-primary disabled:opacity-50"
         >
           Acknowledge
         </button>
@@ -490,12 +490,12 @@ function NotebookEditCard({
   return (
     <CardShell promptId={promptId} kind="notebook_edit">
       <div className={baseClass}>
-        <p className="mb-2 text-sm text-neutral-200">
-          {payload.cellIds.length} cells in <code className="rounded bg-neutral-800 px-1 py-0.5 text-xs">{payload.notebookPath}</code>
+        <p className="mb-2 text-sm text-soleur-text-primary">
+          {payload.cellIds.length} cells in <code className="rounded bg-soleur-bg-surface-2 px-1 py-0.5 text-xs">{payload.notebookPath}</code>
         </p>
         <div className="mb-3 flex flex-wrap gap-1">
           {payload.cellIds.map((cid) => (
-            <span key={cid} className="rounded-full bg-neutral-800 px-2 py-0.5 text-[10px] text-neutral-300">
+            <span key={cid} className="rounded-full bg-soleur-bg-surface-2 px-2 py-0.5 text-[10px] text-soleur-text-secondary">
               {cid}
             </span>
           ))}
@@ -504,7 +504,7 @@ function NotebookEditCard({
           type="button"
           disabled={disabled}
           onClick={() => onRespond({ kind: "notebook_edit", response: "ack" })}
-          className="rounded-md border border-neutral-700 px-3 py-1 text-sm text-neutral-200 disabled:opacity-50"
+          className="rounded-md border border-soleur-border-default px-3 py-1 text-sm text-soleur-text-primary disabled:opacity-50"
         >
           Acknowledge
         </button>

--- a/apps/web-platform/components/chat/kb-chat-content.tsx
+++ b/apps/web-platform/components/chat/kb-chat-content.tsx
@@ -146,10 +146,10 @@ export function KbChatContent({ contextPath, onClose, visible }: KbChatContentPr
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col" data-kb-chat>
-      <header className="flex shrink-0 items-center justify-between border-b border-neutral-800 px-3 py-2">
+      <header className="flex shrink-0 items-center justify-between border-b border-soleur-border-default px-3 py-2">
         <div className="min-w-0 flex-1 truncate">
           <span
-            className="truncate font-mono text-xs text-neutral-300"
+            className="truncate font-mono text-xs text-soleur-text-secondary"
             title={filename}
           >
             {filename}
@@ -159,7 +159,7 @@ export function KbChatContent({ contextPath, onClose, visible }: KbChatContentPr
           type="button"
           aria-label="Close panel"
           onClick={onClose}
-          className="ml-2 shrink-0 rounded p-1 text-neutral-400 hover:bg-neutral-800 hover:text-white"
+          className="ml-2 shrink-0 rounded p-1 text-soleur-text-secondary hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary"
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <line x1="18" y1="6" x2="6" y2="18" />
@@ -168,7 +168,7 @@ export function KbChatContent({ contextPath, onClose, visible }: KbChatContentPr
         </button>
       </header>
       {resumedBanner && (
-        <div className="shrink-0 border-b border-neutral-800 bg-neutral-900/60 px-3 py-1.5 text-xs text-neutral-400">
+        <div className="shrink-0 border-b border-soleur-border-default bg-soleur-bg-surface-1/60 px-3 py-1.5 text-xs text-soleur-text-secondary">
           Continuing from {new Date(resumedBanner.timestamp).toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" })}
         </div>
       )}

--- a/apps/web-platform/components/chat/message-bubble.tsx
+++ b/apps/web-platform/components/chat/message-bubble.tsx
@@ -14,9 +14,9 @@ import { reportSilentFallback } from "@/lib/client-observability";
 export function ThinkingDots() {
   return (
     <div className="flex items-center gap-1.5 py-1" data-testid="thinking-dots">
-      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-neutral-400" style={{ animationDelay: "0ms" }} />
-      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-neutral-400" style={{ animationDelay: "150ms" }} />
-      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-neutral-400" style={{ animationDelay: "300ms" }} />
+      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-soleur-text-secondary" style={{ animationDelay: "0ms" }} />
+      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-soleur-text-secondary" style={{ animationDelay: "150ms" }} />
+      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-soleur-text-secondary" style={{ animationDelay: "300ms" }} />
     </div>
   );
 }
@@ -25,7 +25,7 @@ export function ToolStatusChip({ label }: { label: string }) {
   return (
     <div className="flex items-center gap-2 py-0.5">
       <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-amber-500" />
-      <span className="text-sm text-neutral-400">{label}</span>
+      <span className="text-sm text-soleur-text-secondary">{label}</span>
     </div>
   );
 }
@@ -49,7 +49,7 @@ export function RetryingChip({ label }: { label: string | undefined }) {
         <span className="text-sm font-medium text-amber-400">Retrying…</span>
       </div>
       {label ? (
-        <span className="text-xs text-neutral-500">{label}</span>
+        <span className="text-xs text-soleur-text-muted">{label}</span>
       ) : null}
     </div>
   );
@@ -114,8 +114,8 @@ export const MessageBubble = memo(function MessageBubble({
     : isActive
       ? "message-bubble-active border-2 border-amber-600/70"
       : isDone
-        ? "border border-neutral-800/60"
-        : "border border-neutral-800";
+        ? "border border-soleur-border-default/60"
+        : "border border-soleur-border-default";
 
   return (
     <div
@@ -129,19 +129,19 @@ export const MessageBubble = memo(function MessageBubble({
         <div
           className={`relative min-w-0 rounded-xl px-4 py-3 text-sm leading-relaxed ${
             isUser
-              ? "bg-neutral-800 text-neutral-100"
-              : `bg-neutral-900 text-neutral-200 ${borderStyle} ${leader && !isActive && !isError ? `border-l-2 ${colorClass}` : ""}`
+              ? "bg-soleur-bg-surface-2 text-soleur-text-primary"
+              : `bg-soleur-bg-surface-1 text-soleur-text-primary ${borderStyle} ${leader && !isActive && !isError ? `border-l-2 ${colorClass}` : ""}`
           }`}
         >
           {(messageState === "tool_use" || messageState === "streaming") && (
-            <span className="absolute -top-2.5 right-3 rounded-full border border-amber-700/50 bg-neutral-900 px-2 py-0.5 text-[10px] font-medium text-amber-500">
+            <span className="absolute -top-2.5 right-3 rounded-full border border-amber-700/50 bg-soleur-bg-surface-1 px-2 py-0.5 text-[10px] font-medium text-amber-500">
               {messageState === "tool_use" ? "Working" : "Streaming"}
             </span>
           )}
 
           {isDone && role === "assistant" && (
             <span
-              className="absolute -top-2.5 right-3 flex h-5 w-5 items-center justify-center rounded-full bg-neutral-900 text-amber-600"
+              className="absolute -top-2.5 right-3 flex h-5 w-5 items-center justify-center rounded-full bg-soleur-bg-surface-1 text-amber-600"
               aria-label="Response complete"
             >
               <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
@@ -155,11 +155,11 @@ export const MessageBubble = memo(function MessageBubble({
               className="mb-1 flex items-center gap-2"
               data-testid="message-bubble-header"
             >
-              <span className="text-xs font-semibold text-neutral-300">
+              <span className="text-xs font-semibold text-soleur-text-secondary">
                 {headerPrimary}
               </span>
               {showFullTitle && !titleContainsName && (
-                <span className="text-xs text-neutral-500">{leader.title}</span>
+                <span className="text-xs text-soleur-text-muted">{leader.title}</span>
               )}
             </div>
           )}
@@ -251,7 +251,7 @@ function renderBubbleContent({
             href="https://github.com/jikigai/soleur/issues/new?labels=type%2Fbug&template=bug_report.md"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-xs text-neutral-500 underline hover:text-neutral-300"
+            className="text-xs text-soleur-text-muted underline hover:text-soleur-text-secondary"
             data-testid="file-issue-link"
           >
             File an issue
@@ -261,10 +261,10 @@ function renderBubbleContent({
     case "done":
       if (content === "" && toolsUsed && toolsUsed.length > 0) {
         return (
-          <div className="flex items-center gap-1.5 text-xs text-neutral-500">
+          <div className="flex items-center gap-1.5 text-xs text-soleur-text-muted">
             <span>Used:</span>
             {toolsUsed.map((t, i) => (
-              <span key={i} className="rounded bg-neutral-800 px-1.5 py-0.5">
+              <span key={i} className="rounded bg-soleur-bg-surface-2 px-1.5 py-0.5">
                 {t}
               </span>
             ))}

--- a/apps/web-platform/components/chat/naming-nudge.tsx
+++ b/apps/web-platform/components/chat/naming-nudge.tsx
@@ -43,7 +43,7 @@ export function NamingNudge({
         <p className="text-sm font-medium text-amber-200">
           You just worked with your {roleName}.
         </p>
-        <p className="text-xs text-neutral-400">
+        <p className="text-xs text-soleur-text-secondary">
           Want to give them a name? It will display as &quot;Name ({roleName})&quot; in conversations.
         </p>
         {error && (
@@ -59,19 +59,19 @@ export function NamingNudge({
         placeholder={`Name your ${roleName}...`}
         maxLength={30}
         disabled={saving}
-        className="w-32 rounded-lg border border-neutral-700 bg-neutral-800/50 px-3 py-1.5 text-sm text-white placeholder-neutral-500 outline-none focus:border-amber-600 disabled:opacity-50"
+        className="w-32 rounded-lg border border-soleur-border-default bg-soleur-bg-surface-2/50 px-3 py-1.5 text-sm text-soleur-text-primary placeholder:text-soleur-text-muted outline-none focus:border-amber-600 disabled:opacity-50"
       />
       <button
         onClick={handleSave}
         disabled={saving}
-        className="rounded-lg bg-amber-500 px-3 py-1.5 text-sm font-semibold text-neutral-900 transition-colors hover:bg-amber-400 disabled:cursor-not-allowed disabled:opacity-60"
+        className="rounded-lg bg-soleur-accent-gold-fill px-3 py-1.5 text-sm font-semibold text-soleur-text-on-accent transition-colors hover:bg-amber-400 disabled:cursor-not-allowed disabled:opacity-60"
       >
         {saving ? "Saving..." : "Save"}
       </button>
       <button
         onClick={() => onDismiss(leaderId)}
         disabled={saving}
-        className="text-sm text-neutral-400 transition-colors hover:text-neutral-200 disabled:opacity-50"
+        className="text-sm text-soleur-text-secondary transition-colors hover:text-soleur-text-primary disabled:opacity-50"
       >
         Dismiss
       </button>

--- a/apps/web-platform/components/chat/notification-prompt.tsx
+++ b/apps/web-platform/components/chat/notification-prompt.tsx
@@ -85,10 +85,10 @@ export function NotificationPrompt({ visible }: NotificationPromptProps) {
       <div className="mt-3 flex w-full items-start gap-3 rounded-xl border border-blue-800/40 bg-blue-950/30 p-4">
         <BellIcon />
         <div className="flex-1">
-          <p className="text-sm font-semibold text-white">
+          <p className="text-sm font-semibold text-soleur-text-primary">
             Install Soleur for push notifications
           </p>
-          <p className="mt-1 text-sm text-neutral-400">
+          <p className="mt-1 text-sm text-soleur-text-secondary">
             Add Soleur to your home screen to receive notifications when agents
             need your input.
           </p>
@@ -114,7 +114,7 @@ export function NotificationPrompt({ visible }: NotificationPromptProps) {
       <div className="mt-3 flex w-full items-start gap-3 rounded-xl border border-blue-800/40 bg-blue-950/30 p-4">
         <BellIcon />
         <div className="flex-1">
-          <p className="text-sm text-neutral-400">
+          <p className="text-sm text-soleur-text-secondary">
             No problem — we&apos;ll email you instead when agents need your input.
           </p>
         </div>
@@ -128,24 +128,24 @@ export function NotificationPrompt({ visible }: NotificationPromptProps) {
     <div className="mt-3 flex w-full items-start gap-3 rounded-xl border border-blue-800/40 bg-blue-950/30 p-4">
       <BellIcon />
       <div className="flex-1">
-        <p className="text-sm font-semibold text-white">
+        <p className="text-sm font-semibold text-soleur-text-primary">
           Agents need you even when you&apos;re away.
         </p>
-        <p className="mt-1 text-sm text-neutral-400">
+        <p className="mt-1 text-sm text-soleur-text-secondary">
           Enable notifications so you never miss a decision that blocks progress.
         </p>
         <div className="mt-3 flex items-center gap-3">
           <button
             type="button"
             onClick={handleEnable}
-            className="rounded-lg bg-blue-600 px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-500"
+            className="rounded-lg bg-blue-600 px-4 py-1.5 text-sm font-medium text-soleur-text-on-accent transition-colors hover:bg-blue-500"
           >
             Enable notifications
           </button>
           <button
             type="button"
             onClick={handleDismiss}
-            className="text-sm text-neutral-500 transition-colors hover:text-neutral-300"
+            className="text-sm text-soleur-text-muted transition-colors hover:text-soleur-text-secondary"
           >
             Not now
           </button>
@@ -161,7 +161,7 @@ function DismissButton({ onClick }: { onClick: () => void }) {
     <button
       type="button"
       onClick={onClick}
-      className="shrink-0 rounded p-1 text-neutral-500 transition-colors hover:text-neutral-300"
+      className="shrink-0 rounded p-1 text-soleur-text-muted transition-colors hover:text-soleur-text-secondary"
       aria-label="Dismiss notification prompt"
     >
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/apps/web-platform/components/chat/pwa-install-banner.tsx
+++ b/apps/web-platform/components/chat/pwa-install-banner.tsx
@@ -16,15 +16,15 @@ export function PwaInstallBanner({ dismissed, onDismiss }: PwaInstallBannerProps
   if (dismissed || !isIosSafari()) return null;
 
   return (
-    <div className="mb-4 flex w-full items-start gap-3 rounded-xl border border-neutral-800 bg-neutral-900/80 p-4">
-      <span className="mt-0.5 text-lg text-neutral-400">
+    <div className="mb-4 flex w-full items-start gap-3 rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1/80 p-4">
+      <span className="mt-0.5 text-lg text-soleur-text-secondary">
         <ShareIcon />
       </span>
       <div className="flex-1">
-        <p className="text-sm font-semibold text-white">
+        <p className="text-sm font-semibold text-soleur-text-primary">
           Add Soleur to Your Home Screen
         </p>
-        <p className="mt-1 text-sm text-neutral-400">
+        <p className="mt-1 text-sm text-soleur-text-secondary">
           Open on any device, no app store needed. Tap the Share icon, then
           &ldquo;Add to Home Screen.&rdquo;
         </p>
@@ -32,7 +32,7 @@ export function PwaInstallBanner({ dismissed, onDismiss }: PwaInstallBannerProps
       <button
         type="button"
         onClick={onDismiss}
-        className="shrink-0 rounded p-1 text-neutral-500 transition-colors hover:text-neutral-300"
+        className="shrink-0 rounded p-1 text-soleur-text-muted transition-colors hover:text-soleur-text-secondary"
         aria-label="Dismiss PWA install banner"
       >
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/apps/web-platform/components/chat/review-gate-card.tsx
+++ b/apps/web-platform/components/chat/review-gate-card.tsx
@@ -39,11 +39,11 @@ export function ReviewGateCard({
 
   if (resolved && selectedOption) {
     return (
-      <div className="flex items-center gap-2 rounded-lg border border-neutral-800 bg-neutral-900/50 px-4 py-2 text-sm text-neutral-400 transition-all duration-300">
+      <div className="flex items-center gap-2 rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1/50 px-4 py-2 text-sm text-soleur-text-secondary transition-all duration-300">
         <svg className="h-4 w-4 text-green-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <polyline points="20 6 9 17 4 12" />
         </svg>
-        <span>Selected: <strong className="text-neutral-200">{selectedOption}</strong></span>
+        <span>Selected: <strong className="text-soleur-text-primary">{selectedOption}</strong></span>
       </div>
     );
   }
@@ -90,13 +90,13 @@ export function ReviewGateCard({
               pending === option
                 ? "border-amber-500 bg-amber-900/50 text-amber-100"
                 : pending !== null
-                  ? "border-neutral-700 text-neutral-500 opacity-50"
-                  : "border-neutral-700 text-neutral-300 hover:border-amber-600 hover:text-amber-200"
+                  ? "border-soleur-border-default text-soleur-text-muted opacity-50"
+                  : "border-soleur-border-default text-soleur-text-secondary hover:border-amber-600 hover:text-amber-200"
             }`}
           >
             <span>{option}</span>
             {descriptions?.[option] && (
-              <span className="mt-0.5 text-xs text-neutral-400">{descriptions[option]}</span>
+              <span className="mt-0.5 text-xs text-soleur-text-secondary">{descriptions[option]}</span>
             )}
           </button>
         ))}

--- a/apps/web-platform/components/chat/routed-leaders-strip.tsx
+++ b/apps/web-platform/components/chat/routed-leaders-strip.tsx
@@ -35,15 +35,15 @@ export function RoutedLeadersStrip({
   return (
     <div
       data-testid="routed-leaders-strip"
-      className={`border-b border-neutral-800/50 px-4 py-2 ${isFull ? "md:px-6" : ""}`}
+      className={`border-b border-soleur-border-default/50 px-4 py-2 ${isFull ? "md:px-6" : ""}`}
     >
       <span
-        className="inline-flex items-center gap-1.5 rounded-full bg-neutral-800/50 px-3 py-1 text-xs text-neutral-400"
+        className="inline-flex items-center gap-1.5 rounded-full bg-soleur-bg-surface-2/50 px-3 py-1 text-xs text-soleur-text-secondary"
         aria-label={`${CONCIERGE_TITLE} ${verb} ${visibleJoin}`}
       >
         <LeaderAvatar leaderId={CC_ROUTER_LEADER_ID} size="sm" />
         <span>{CONCIERGE_TITLE}</span>
-        <span className="text-neutral-600">·</span>
+        <span className="text-soleur-text-muted">·</span>
         {verb} {visibleJoin}
       </span>
     </div>

--- a/apps/web-platform/components/chat/subagent-group.tsx
+++ b/apps/web-platform/components/chat/subagent-group.tsx
@@ -127,19 +127,19 @@ export function SubagentGroup({
     <div
       data-parent-spawn-id={parentSpawnId}
       data-expanded={expanded ? "true" : "false"}
-      className={`rounded-xl border border-neutral-800 bg-neutral-900/40 px-4 py-3 ${parentColor} border-l-2`}
+      className={`rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1/40 px-4 py-3 ${parentColor} border-l-2`}
     >
       <div className="flex items-center gap-3">
         <LeaderAvatar leaderId={parentLeaderId} size="md" customIconPath={parentIcon} />
         <div className="flex min-w-0 flex-1 flex-col">
           <div className="flex items-center gap-2">
-            <span className="text-xs font-semibold text-neutral-200">{parentName}</span>
-            <span className="rounded-full bg-neutral-800 px-2 py-0.5 text-[10px] text-neutral-300">
+            <span className="text-xs font-semibold text-soleur-text-primary">{parentName}</span>
+            <span className="rounded-full bg-soleur-bg-surface-2 px-2 py-0.5 text-[10px] text-soleur-text-secondary">
               {subagents.length} subagents spawned
             </span>
           </div>
           {parentTask ? (
-            <span className="mt-0.5 text-xs text-neutral-500">{parentTask}</span>
+            <span className="mt-0.5 text-xs text-soleur-text-muted">{parentTask}</span>
           ) : null}
         </div>
         {subagents.length > SUBAGENT_GROUP_AUTO_EXPAND_MAX ? (
@@ -147,7 +147,7 @@ export function SubagentGroup({
             type="button"
             data-testid="subagent-group-toggle"
             onClick={() => setExpanded((v) => !v)}
-            className="rounded-md border border-neutral-700 px-2 py-0.5 text-xs text-neutral-300 hover:border-neutral-500"
+            className="rounded-md border border-soleur-border-default px-2 py-0.5 text-xs text-soleur-text-secondary hover:border-soleur-border-emphasized"
           >
             {expanded ? "Collapse" : `Show ${subagents.length}`}
           </button>
@@ -166,16 +166,16 @@ export function SubagentGroup({
                 key={c.spawnId}
                 data-child-spawn-id={c.spawnId}
                 data-child-status={statusKey(c.status)}
-                className={`${SUBAGENT_CHILD_INDENT_CLASS} flex items-center gap-2 rounded-lg border border-neutral-800/60 bg-neutral-900/40 px-3 py-2`}
+                className={`${SUBAGENT_CHILD_INDENT_CLASS} flex items-center gap-2 rounded-lg border border-soleur-border-default/60 bg-soleur-bg-surface-1/40 px-3 py-2`}
                 /* Review F21 (#2886): the redundant `data-parent-id` attribute
                    was removed — the wrapping group already exposes
                    `data-parent-spawn-id`, which is the canonical hook. */
               >
                 <LeaderAvatar leaderId={c.leaderId} size="sm" customIconPath={childIcon} />
                 <div className="flex min-w-0 flex-1 flex-col">
-                  <span className="text-xs font-semibold text-neutral-200">{childName}</span>
+                  <span className="text-xs font-semibold text-soleur-text-primary">{childName}</span>
                   {c.task ? (
-                    <span className="truncate text-xs text-neutral-500">{c.task}</span>
+                    <span className="truncate text-xs text-soleur-text-muted">{c.task}</span>
                   ) : null}
                 </div>
                 <StatusBadge status={c.status} />

--- a/apps/web-platform/components/chat/tool-use-chip.tsx
+++ b/apps/web-platform/components/chat/tool-use-chip.tsx
@@ -35,18 +35,18 @@ export function ToolUseChip({ toolName, toolLabel, leaderId }: ToolUseChipProps)
   const colorClass =
     leaderId === "cc_router"
       ? `border border-yellow-700/60 ${LEADER_COLORS.cc_router}`
-      : `border border-neutral-700 ${LEADER_COLORS.system}`;
+      : `border border-soleur-border-default ${LEADER_COLORS.system}`;
 
   return (
     <div
       data-tool-chip-id={`${leaderId}-${toolName}-${toolLabel}`}
-      className={`inline-flex items-center gap-2 rounded-full bg-neutral-900/60 px-3 py-1 ${colorClass}`}
+      className={`inline-flex items-center gap-2 rounded-full bg-soleur-bg-surface-1/60 px-3 py-1 ${colorClass}`}
     >
       <span
         className="h-1.5 w-1.5 animate-pulse rounded-full bg-amber-500"
         aria-hidden="true"
       />
-      <span className="text-xs text-neutral-300">{toolLabel}</span>
+      <span className="text-xs text-soleur-text-secondary">{toolLabel}</span>
     </div>
   );
 }

--- a/apps/web-platform/components/chat/welcome-card.tsx
+++ b/apps/web-platform/components/chat/welcome-card.tsx
@@ -1,17 +1,17 @@
 export function WelcomeCard() {
   return (
-    <div className="mb-4 flex items-start gap-3 rounded-xl border border-neutral-800 bg-neutral-900/80 p-4">
+    <div className="mb-4 flex items-start gap-3 rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1/80 p-4">
       <span
         data-testid="welcome-icon"
-        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-amber-600 text-sm font-bold text-white"
+        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-amber-600 text-sm font-bold text-soleur-text-on-accent"
       >
         S
       </span>
       <div>
-        <p className="text-sm font-semibold text-white">
+        <p className="text-sm font-semibold text-soleur-text-primary">
           Your Organization Is Ready
         </p>
-        <p className="mt-1 text-sm text-neutral-400">
+        <p className="mt-1 text-sm text-soleur-text-secondary">
           Eight department leaders are standing by. Type @ to put one to work.
         </p>
       </div>

--- a/apps/web-platform/components/chat/workflow-lifecycle-bar.tsx
+++ b/apps/web-platform/components/chat/workflow-lifecycle-bar.tsx
@@ -38,16 +38,16 @@ export function WorkflowLifecycleBar({
       return (
         <div
           data-lifecycle-state="active"
-          className="flex items-center gap-3 border-b border-neutral-800 bg-neutral-900/40 px-4 py-2"
+          className="flex items-center gap-3 border-b border-soleur-border-default bg-soleur-bg-surface-1/40 px-4 py-2"
         >
           <span className="rounded-full bg-amber-900/30 px-2 py-0.5 text-[10px] font-semibold text-amber-300">
             {lifecycle.workflow}
           </span>
           {lifecycle.phase ? (
-            <span className="text-xs text-neutral-400">{lifecycle.phase}</span>
+            <span className="text-xs text-soleur-text-secondary">{lifecycle.phase}</span>
           ) : null}
           {typeof lifecycle.cumulativeCostUsd === "number" ? (
-            <span className="text-xs text-neutral-500">
+            <span className="text-xs text-soleur-text-muted">
               ~${lifecycle.cumulativeCostUsd.toFixed(4)}
             </span>
           ) : null}
@@ -56,7 +56,7 @@ export function WorkflowLifecycleBar({
               <button
                 type="button"
                 onClick={onSwitchWorkflow}
-                className="rounded-md border border-neutral-700 px-2 py-1 text-xs text-neutral-300 hover:border-neutral-500"
+                className="rounded-md border border-soleur-border-default px-2 py-1 text-xs text-soleur-text-secondary hover:border-soleur-border-emphasized"
               >
                 Switch workflow
               </button>
@@ -68,10 +68,10 @@ export function WorkflowLifecycleBar({
       return (
         <div
           data-lifecycle-state="ended"
-          className="flex flex-col gap-2 border-b border-neutral-800 bg-neutral-900/40 px-4 py-3"
+          className="flex flex-col gap-2 border-b border-soleur-border-default bg-soleur-bg-surface-1/40 px-4 py-3"
         >
           <div className="flex items-center gap-2">
-            <span className="rounded-full bg-neutral-800 px-2 py-0.5 text-[10px] font-semibold text-neutral-200">
+            <span className="rounded-full bg-soleur-bg-surface-2 px-2 py-0.5 text-[10px] font-semibold text-soleur-text-primary">
               {lifecycle.workflow}
             </span>
             <span
@@ -84,14 +84,14 @@ export function WorkflowLifecycleBar({
               {lifecycle.status}
             </span>
             {lifecycle.summary ? (
-              <span className="truncate text-xs text-neutral-400">{lifecycle.summary}</span>
+              <span className="truncate text-xs text-soleur-text-secondary">{lifecycle.summary}</span>
             ) : null}
           </div>
           <div>
             <button
               type="button"
               onClick={onStartNewConversation}
-              className="rounded-md bg-amber-600 px-3 py-1 text-xs text-white hover:bg-amber-500"
+              className="rounded-md bg-amber-600 px-3 py-1 text-xs text-soleur-text-on-accent hover:bg-amber-500"
             >
               Start new conversation
             </button>

--- a/apps/web-platform/components/concurrency/account-state-banner.tsx
+++ b/apps/web-platform/components/concurrency/account-state-banner.tsx
@@ -28,14 +28,14 @@ export function AccountStateBanner({
 
   return (
     <div
-      className="flex items-center justify-between gap-4 border-b border-neutral-800 bg-neutral-900/60 px-4 py-2 text-sm text-neutral-300"
+      className="flex items-center justify-between gap-4 border-b border-soleur-border-default bg-soleur-bg-surface-1/60 px-4 py-2 text-sm text-soleur-text-secondary"
       data-variant={variant}
       role="status"
     >
       <p>{copy.message}</p>
       <div className="flex items-center gap-3">
         {copy.cta ? (
-          <Link href={copy.cta.href} className="font-medium text-amber-400 hover:text-amber-300">
+          <Link href={copy.cta.href} className="font-medium text-soleur-accent-gold-fg hover:text-soleur-accent-gold-text">
             {copy.cta.label}
           </Link>
         ) : null}
@@ -43,7 +43,7 @@ export function AccountStateBanner({
           <button
             type="button"
             onClick={onDismiss}
-            className="text-neutral-500 hover:text-neutral-300"
+            className="text-soleur-text-muted hover:text-soleur-text-secondary"
             aria-label="Dismiss"
           >
             ×

--- a/apps/web-platform/components/connect-repo/choose-state.tsx
+++ b/apps/web-platform/components/connect-repo/choose-state.tsx
@@ -21,12 +21,12 @@ export function ChooseState({ onCreateNew, onConnectExisting, onSkip }: ChooseSt
         <h1 className={`${serif.className} text-4xl font-semibold`}>
           Give Your AI Team the Full Picture
         </h1>
-        <p className="mx-auto max-w-lg text-base text-neutral-400">
+        <p className="mx-auto max-w-lg text-base text-soleur-text-secondary">
           Your AI team works best when it understands your actual business — your
           decisions, your patterns, what you have built so far. Connect a project
           so your team starts with real context, not a blank slate.
         </p>
-        <p className="text-sm text-neutral-500">
+        <p className="text-sm text-soleur-text-muted">
           You stay in control — your AI team proposes changes, you decide what ships.
         </p>
       </div>
@@ -35,11 +35,11 @@ export function ChooseState({ onCreateNew, onConnectExisting, onSkip }: ChooseSt
         {/* Card A: Start Fresh */}
         <Card className="flex flex-col justify-between">
           <div className="space-y-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-neutral-700 bg-neutral-800">
-              <PlusIcon className="h-5 w-5 text-neutral-300" />
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-soleur-border-default bg-soleur-bg-surface-2">
+              <PlusIcon className="h-5 w-5 text-soleur-text-secondary" />
             </div>
             <h2 className={`${serif.className} text-xl font-semibold`}>Start Fresh</h2>
-            <p className="text-sm text-neutral-400">
+            <p className="text-sm text-soleur-text-secondary">
               Starting from scratch? We create a project workspace on GitHub
               (owned by Microsoft) under your own account — you keep full
               ownership of your code and data. Your AI team gets a home base
@@ -54,13 +54,13 @@ export function ChooseState({ onCreateNew, onConnectExisting, onSkip }: ChooseSt
         {/* Card B: Connect Existing Project */}
         <Card className="flex flex-col justify-between">
           <div className="space-y-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-neutral-700 bg-neutral-800">
-              <LinkIcon className="h-5 w-5 text-neutral-300" />
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-soleur-border-default bg-soleur-bg-surface-2">
+              <LinkIcon className="h-5 w-5 text-soleur-text-secondary" />
             </div>
             <h2 className={`${serif.className} text-xl font-semibold`}>
               Connect Existing Project
             </h2>
-            <p className="text-sm text-neutral-400">
+            <p className="text-sm text-soleur-text-secondary">
               Already have code on GitHub? Connect it and your AI team starts
               with full context — your architecture, your patterns, your
               decisions.
@@ -72,11 +72,11 @@ export function ChooseState({ onCreateNew, onConnectExisting, onSkip }: ChooseSt
         </Card>
       </div>
 
-      <p className="text-center text-sm text-neutral-500">
+      <p className="text-center text-sm text-soleur-text-muted">
         <button
           type="button"
           onClick={onSkip}
-          className="underline decoration-neutral-600 underline-offset-2 transition-colors hover:text-neutral-300"
+          className="underline decoration-soleur-border-default underline-offset-2 transition-colors hover:text-soleur-text-secondary"
         >
           Skip this step
         </button>{" "}

--- a/apps/web-platform/components/connect-repo/create-project-state.tsx
+++ b/apps/web-platform/components/connect-repo/create-project-state.tsx
@@ -45,14 +45,14 @@ export function CreateProjectState({ onBack, onSubmit }: CreateProjectStateProps
         <h1 className={`${serif.className} text-4xl font-semibold`}>
           Name Your Project
         </h1>
-        <p className="text-base text-neutral-400">
+        <p className="text-base text-soleur-text-secondary">
           Give your project a name. This will be used to create your workspace on GitHub.
         </p>
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-6">
         <div className="space-y-2">
-          <label htmlFor="project-name" className="block text-sm font-medium text-neutral-200">
+          <label htmlFor="project-name" className="block text-sm font-medium text-soleur-text-primary">
             Project Name
           </label>
           <input
@@ -62,32 +62,32 @@ export function CreateProjectState({ onBack, onSubmit }: CreateProjectStateProps
             value={projectName}
             onChange={(e) => setProjectName(e.target.value)}
             placeholder="my-startup"
-            className="w-full rounded-lg border border-neutral-700 bg-neutral-900 px-4 py-3 text-sm placeholder:text-neutral-500 focus:border-neutral-500 focus:outline-none"
+            className="w-full rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1 px-4 py-3 text-sm placeholder:text-soleur-text-muted focus:border-soleur-text-muted focus:outline-none"
           />
           {slug && (
-            <p className="text-xs text-neutral-500">
+            <p className="text-xs text-soleur-text-muted">
               This becomes your project address on GitHub (e.g. github.com/you/{slug}).
             </p>
           )}
           {!slug && (
-            <p className="text-xs text-neutral-500">
+            <p className="text-xs text-soleur-text-muted">
               This becomes your project address on GitHub (e.g. github.com/you/my-startup).
             </p>
           )}
         </div>
 
         <div className="space-y-2">
-          <label className="block text-sm font-medium text-neutral-200">
+          <label className="block text-sm font-medium text-soleur-text-primary">
             Visibility
           </label>
-          <div className="flex overflow-hidden rounded-lg border border-neutral-700">
+          <div className="flex overflow-hidden rounded-lg border border-soleur-border-default">
             <button
               type="button"
               onClick={() => setIsPrivate(true)}
               className={`flex flex-1 items-center justify-center gap-2 px-4 py-2.5 text-sm transition-colors ${
                 isPrivate
-                  ? "bg-neutral-800 text-neutral-100"
-                  : "bg-transparent text-neutral-400 hover:text-neutral-200"
+                  ? "bg-soleur-bg-surface-2 text-soleur-text-primary"
+                  : "bg-transparent text-soleur-text-secondary hover:text-soleur-text-primary"
               }`}
             >
               <LockIcon className="h-4 w-4" />
@@ -96,10 +96,10 @@ export function CreateProjectState({ onBack, onSubmit }: CreateProjectStateProps
             <button
               type="button"
               onClick={() => setIsPrivate(false)}
-              className={`flex flex-1 items-center justify-center gap-2 border-l border-neutral-700 px-4 py-2.5 text-sm transition-colors ${
+              className={`flex flex-1 items-center justify-center gap-2 border-l border-soleur-border-default px-4 py-2.5 text-sm transition-colors ${
                 !isPrivate
-                  ? "bg-neutral-800 text-neutral-100"
-                  : "bg-transparent text-neutral-400 hover:text-neutral-200"
+                  ? "bg-soleur-bg-surface-2 text-soleur-text-primary"
+                  : "bg-transparent text-soleur-text-secondary hover:text-soleur-text-primary"
               }`}
             >
               <GlobeIcon className="h-4 w-4" />

--- a/apps/web-platform/components/connect-repo/failed-state.tsx
+++ b/apps/web-platform/components/connect-repo/failed-state.tsx
@@ -101,7 +101,7 @@ export function FailedState({ onRetry, errorMessage, errorCode }: FailedStatePro
         <h1 className={`${serif.className} text-4xl font-semibold`}>
           {copy?.headline ?? "Project Setup Failed"}
         </h1>
-        <p className="text-base text-neutral-400">
+        <p className="text-base text-soleur-text-secondary">
           {copy?.body ??
             "Something went wrong while setting up your project. This is usually a temporary issue."}
         </p>
@@ -110,10 +110,10 @@ export function FailedState({ onRetry, errorMessage, errorCode }: FailedStatePro
       {errorMessage && (
         <Card className="text-left">
           <details>
-            <summary className="cursor-pointer text-sm font-medium text-neutral-200">
+            <summary className="cursor-pointer text-sm font-medium text-soleur-text-primary">
               Error details (for support)
             </summary>
-            <p className="mt-2 text-sm text-neutral-400 font-mono break-all">
+            <p className="mt-2 text-sm text-soleur-text-secondary font-mono break-all">
               {errorMessage}
             </p>
           </details>
@@ -121,7 +121,7 @@ export function FailedState({ onRetry, errorMessage, errorCode }: FailedStatePro
       )}
 
       <Card className="text-left">
-        <h3 className="mb-3 text-sm font-medium text-neutral-200">What you can do</h3>
+        <h3 className="mb-3 text-sm font-medium text-soleur-text-primary">What you can do</h3>
         <ol className="space-y-3">
           {(copy?.steps ?? [
             "Try again — most issues resolve on a second attempt.",
@@ -129,10 +129,10 @@ export function FailedState({ onRetry, errorMessage, errorCode }: FailedStatePro
             "If the problem persists, contact support with the time of the error.",
           ]).map((step, i) => (
             <li key={i} className="flex items-start gap-3">
-              <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-neutral-700 text-xs font-medium text-neutral-300">
+              <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-soleur-border-default text-xs font-medium text-soleur-text-secondary">
                 {i + 1}
               </span>
-              <span className="text-sm text-neutral-400">{step}</span>
+              <span className="text-sm text-soleur-text-secondary">{step}</span>
             </li>
           ))}
         </ol>

--- a/apps/web-platform/components/connect-repo/github-redirect-state.tsx
+++ b/apps/web-platform/components/connect-repo/github-redirect-state.tsx
@@ -20,48 +20,48 @@ export function GitHubRedirectState({ onContinue, onBack }: GitHubRedirectStateP
         <h1 className={`${serif.className} text-4xl font-semibold`}>
           Connecting to GitHub
         </h1>
-        <p className="text-base text-neutral-400">
+        <p className="text-base text-soleur-text-secondary">
           GitHub is a trusted platform used by millions of developers and
           businesses to manage their projects securely.
         </p>
       </div>
 
       <Card>
-        <h3 className="mb-4 text-sm font-medium text-neutral-200">What happens next</h3>
+        <h3 className="mb-4 text-sm font-medium text-soleur-text-primary">What happens next</h3>
         <ol className="space-y-4">
           <li className="flex items-start gap-3">
-            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-neutral-700 text-xs font-medium text-neutral-300">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-soleur-border-default text-xs font-medium text-soleur-text-secondary">
               1
             </span>
-            <span className="text-sm text-neutral-300">Sign in to GitHub</span>
+            <span className="text-sm text-soleur-text-secondary">Sign in to GitHub</span>
           </li>
           <li className="flex items-start gap-3">
-            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-neutral-700 text-xs font-medium text-neutral-300">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-soleur-border-default text-xs font-medium text-soleur-text-secondary">
               2
             </span>
             <div>
-              <span className="text-sm text-neutral-300">Grant project access</span>
-              <p className="mt-0.5 text-xs text-neutral-500">
+              <span className="text-sm text-soleur-text-secondary">Grant project access</span>
+              <p className="mt-0.5 text-xs text-soleur-text-muted">
                 We only request permission to read and manage your project files — nothing else.
               </p>
             </div>
           </li>
           <li className="flex items-start gap-3">
-            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-neutral-700 text-xs font-medium text-neutral-300">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-soleur-border-default text-xs font-medium text-soleur-text-secondary">
               3
             </span>
-            <span className="text-sm text-neutral-300">Return here automatically</span>
+            <span className="text-sm text-soleur-text-secondary">Return here automatically</span>
           </li>
         </ol>
       </Card>
 
       <Card className="flex items-start gap-3">
-        <ShieldIcon className="mt-0.5 h-5 w-5 shrink-0 text-amber-500/70" />
+        <ShieldIcon className="mt-0.5 h-5 w-5 shrink-0 text-soleur-accent-gold-fg/70" />
         <div>
-          <h3 className="text-sm font-medium text-neutral-200">
+          <h3 className="text-sm font-medium text-soleur-text-primary">
             Why your own GitHub account?
           </h3>
-          <p className="mt-1 text-xs text-neutral-500">
+          <p className="mt-1 text-xs text-soleur-text-muted">
             Your project stays in your GitHub account, under your control. Your
             AI team accesses it through a secure GitHub App installation — you
             can revoke access at any time from your GitHub settings.

--- a/apps/web-platform/components/connect-repo/github-resolve-state.tsx
+++ b/apps/web-platform/components/connect-repo/github-resolve-state.tsx
@@ -19,7 +19,7 @@ export function GitHubResolveState({ onContinue, onBack }: GitHubResolveStatePro
         <h1 className={`${serif.className} text-4xl font-semibold`}>
           Connect to GitHub
         </h1>
-        <p className="text-base text-neutral-400">
+        <p className="text-base text-soleur-text-secondary">
           Your Soleur account was created with email. A quick GitHub sign-in
           lets us find the app installation on your account and connect your
           project.
@@ -27,19 +27,19 @@ export function GitHubResolveState({ onContinue, onBack }: GitHubResolveStatePro
       </div>
 
       <Card>
-        <h3 className="mb-4 text-sm font-medium text-neutral-200">What happens next</h3>
+        <h3 className="mb-4 text-sm font-medium text-soleur-text-primary">What happens next</h3>
         <ol className="space-y-4">
           <li className="flex items-start gap-3">
-            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-neutral-700 text-xs font-medium text-neutral-300">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-soleur-border-default text-xs font-medium text-soleur-text-secondary">
               1
             </span>
-            <span className="text-sm text-neutral-300">Sign in to GitHub (quick authorization)</span>
+            <span className="text-sm text-soleur-text-secondary">Sign in to GitHub (quick authorization)</span>
           </li>
           <li className="flex items-start gap-3">
-            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-neutral-700 text-xs font-medium text-neutral-300">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-soleur-border-default text-xs font-medium text-soleur-text-secondary">
               2
             </span>
-            <span className="text-sm text-neutral-300">Return here to connect your project</span>
+            <span className="text-sm text-soleur-text-secondary">Return here to connect your project</span>
           </li>
         </ol>
       </Card>

--- a/apps/web-platform/components/connect-repo/interrupted-state.tsx
+++ b/apps/web-platform/components/connect-repo/interrupted-state.tsx
@@ -22,14 +22,14 @@ export function InterruptedState({ onResume, onStartOver }: InterruptedStateProp
         <h1 className={`${serif.className} text-4xl font-semibold`}>
           Setup Was Interrupted
         </h1>
-        <p className="text-base text-neutral-400">
+        <p className="text-base text-soleur-text-secondary">
           It looks like the GitHub authorization process was not completed. This
           can happen if the browser was closed or the connection was lost.
         </p>
       </div>
 
       <Card className="text-left">
-        <p className="text-sm text-neutral-400">
+        <p className="text-sm text-soleur-text-secondary">
           No changes were made to your GitHub account. You can resume the
           connection process right where you left off, or start over from the
           beginning.

--- a/apps/web-platform/components/connect-repo/no-projects-state.tsx
+++ b/apps/web-platform/components/connect-repo/no-projects-state.tsx
@@ -27,9 +27,9 @@ export function NoProjectsState({ onUpdateAccess, onBack, onRefresh }: NoProject
       </div>
 
       <Card className="flex flex-col items-center py-12 text-center">
-        <FolderIcon className="mb-4 h-12 w-12 text-neutral-600" />
-        <h3 className="text-lg font-medium text-neutral-200">No projects found</h3>
-        <p className="mt-2 max-w-sm text-sm text-neutral-500">
+        <FolderIcon className="mb-4 h-12 w-12 text-soleur-text-muted" />
+        <h3 className="text-lg font-medium text-soleur-text-primary">No projects found</h3>
+        <p className="mt-2 max-w-sm text-sm text-soleur-text-muted">
           We could not find any repositories you have granted access to. You may
           need to update the GitHub App permissions to include the repositories
           you want to connect.

--- a/apps/web-platform/components/connect-repo/ready-state.tsx
+++ b/apps/web-platform/components/connect-repo/ready-state.tsx
@@ -46,7 +46,7 @@ export function ReadyState({
           <h1 className={`${serif.className} text-4xl font-semibold`}>
             Your AI Team Is Ready.
           </h1>
-          <p className="text-base text-neutral-400">
+          <p className="text-base text-soleur-text-secondary">
             Your AI team. Your project. Full context from the first
             conversation.
           </p>
@@ -55,13 +55,13 @@ export function ReadyState({
         <Card className="mx-auto inline-block text-left">
           <div className="space-y-3">
             <div className="flex items-center justify-between gap-8">
-              <span className="text-sm text-neutral-500">Project</span>
-              <span className="text-sm font-medium text-neutral-100">
+              <span className="text-sm text-soleur-text-muted">Project</span>
+              <span className="text-sm font-medium text-soleur-text-primary">
                 {repoName}
               </span>
             </div>
             <div className="flex items-center justify-between gap-8">
-              <span className="text-sm text-neutral-500">Agents</span>
+              <span className="text-sm text-soleur-text-muted">Agents</span>
               <span className="text-sm font-medium text-green-400">
                 {process.env.NEXT_PUBLIC_AGENT_COUNT || "60+"} ready
               </span>
@@ -69,7 +69,7 @@ export function ReadyState({
           </div>
         </Card>
 
-        <p className="text-sm text-neutral-500">
+        <p className="text-sm text-soleur-text-muted">
           You are always the decision-maker. Your AI team proposes — you
           approve.
         </p>
@@ -79,7 +79,7 @@ export function ReadyState({
           <button
             type="button"
             onClick={onViewKb}
-            className="rounded-lg border border-neutral-700 px-6 py-3 text-sm font-medium text-neutral-300 transition-colors hover:border-neutral-500 hover:text-neutral-100"
+            className="rounded-lg border border-soleur-border-default px-6 py-3 text-sm font-medium text-soleur-text-secondary transition-colors hover:border-soleur-text-muted hover:text-soleur-text-primary"
           >
             Review Knowledge Base
           </button>
@@ -112,7 +112,7 @@ export function ReadyState({
         <div className="space-y-4">
           {/* Detected signals */}
           <div data-testid="detected-signals">
-            <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-neutral-500">
+            <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-soleur-text-muted">
               Detected
             </h3>
             <div className="flex flex-wrap gap-2">
@@ -133,7 +133,7 @@ export function ReadyState({
           {/* Missing signals */}
           {healthSnapshot.signals.missing.length > 0 && (
             <div data-testid="missing-signals">
-              <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-neutral-500">
+              <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-soleur-text-muted">
                 Missing
               </h3>
               <div className="flex flex-wrap gap-2">
@@ -155,7 +155,7 @@ export function ReadyState({
 
           {/* Recommendations */}
           <div>
-            <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-neutral-500">
+            <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-soleur-text-muted">
               Next Steps
             </h3>
             <ol className="space-y-2">
@@ -163,9 +163,9 @@ export function ReadyState({
                 <li
                   key={i}
                   data-testid="recommendation-item"
-                  className="flex gap-2 text-xs text-neutral-300"
+                  className="flex gap-2 text-xs text-soleur-text-secondary"
                 >
-                  <span className="flex-shrink-0 font-medium text-neutral-500">
+                  <span className="flex-shrink-0 font-medium text-soleur-text-muted">
                     {i + 1}.
                   </span>
                   {rec}
@@ -178,17 +178,17 @@ export function ReadyState({
 
       {/* Deep analysis status — only shown when a sync conversation exists (#1816) */}
       {syncConversationId ? (
-        <p className="text-xs text-neutral-500">
+        <p className="text-xs text-soleur-text-muted">
           Deep analysis in progress —{" "}
           <Link
             href="/dashboard"
-            className="text-amber-400 underline underline-offset-2 hover:text-amber-300"
+            className="text-soleur-accent-gold-fg underline underline-offset-2 hover:text-soleur-accent-gold-text"
           >
             View in Dashboard
           </Link>
         </p>
       ) : (
-        <p className="text-xs text-neutral-500">
+        <p className="text-xs text-soleur-text-muted">
           Your project is ready. Start a conversation to begin working with your AI team.
         </p>
       )}
@@ -199,7 +199,7 @@ export function ReadyState({
         <button
           type="button"
           onClick={onViewKb}
-          className="rounded-lg border border-neutral-700 px-6 py-3 text-sm font-medium text-neutral-300 transition-colors hover:border-neutral-500 hover:text-neutral-100"
+          className="rounded-lg border border-soleur-border-default px-6 py-3 text-sm font-medium text-soleur-text-secondary transition-colors hover:border-soleur-text-muted hover:text-soleur-text-primary"
         >
           Review Knowledge Base
         </button>

--- a/apps/web-platform/components/connect-repo/select-project-state.tsx
+++ b/apps/web-platform/components/connect-repo/select-project-state.tsx
@@ -43,7 +43,7 @@ export function SelectProjectState({ repos, loading, onSelect, onBack, onRefresh
         <button
           type="button"
           onClick={onBack}
-          className="flex h-8 w-8 items-center justify-center rounded-lg border border-neutral-700 text-neutral-400 transition-colors hover:bg-neutral-800 hover:text-neutral-200"
+          className="flex h-8 w-8 items-center justify-center rounded-lg border border-soleur-border-default text-soleur-text-secondary transition-colors hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary"
         >
           <ArrowLeftIcon className="h-4 w-4" />
         </button>
@@ -52,7 +52,7 @@ export function SelectProjectState({ repos, loading, onSelect, onBack, onRefresh
           <button
             type="button"
             onClick={onRefresh}
-            className="flex h-8 w-8 items-center justify-center rounded-lg border border-neutral-700 text-neutral-400 transition-colors hover:bg-neutral-800 hover:text-neutral-200"
+            className="flex h-8 w-8 items-center justify-center rounded-lg border border-soleur-border-default text-soleur-text-secondary transition-colors hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary"
             aria-label="Refresh"
           >
             <RefreshIcon className="h-4 w-4" />
@@ -64,7 +64,7 @@ export function SelectProjectState({ repos, loading, onSelect, onBack, onRefresh
         <h1 className={`${serif.className} text-3xl font-semibold`}>
           Select a Project
         </h1>
-        <p className="text-sm text-neutral-400">
+        <p className="text-sm text-soleur-text-secondary">
           Choose which project your AI team should work on. You can change this
           later from Settings.
         </p>
@@ -72,7 +72,7 @@ export function SelectProjectState({ repos, loading, onSelect, onBack, onRefresh
 
       {/* Search */}
       <div className="relative">
-        <SearchIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-neutral-500" />
+        <SearchIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-soleur-text-muted" />
         <input
           type="text"
           value={search}
@@ -81,14 +81,14 @@ export function SelectProjectState({ repos, loading, onSelect, onBack, onRefresh
             setPage(1);
           }}
           placeholder="Search projects..."
-          className="w-full rounded-lg border border-neutral-700 bg-neutral-900 py-2.5 pl-10 pr-4 text-sm placeholder:text-neutral-500 focus:border-neutral-500 focus:outline-none"
+          className="w-full rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1 py-2.5 pl-10 pr-4 text-sm placeholder:text-soleur-text-muted focus:border-soleur-text-muted focus:outline-none"
         />
       </div>
 
       {/* Repo list */}
       {loading ? (
         <div className="flex items-center justify-center py-12">
-          <SpinnerIcon className="h-6 w-6 text-amber-500/70" />
+          <SpinnerIcon className="h-6 w-6 text-soleur-accent-gold-fg/70" />
         </div>
       ) : (
         <div className="space-y-1">
@@ -99,19 +99,19 @@ export function SelectProjectState({ repos, loading, onSelect, onBack, onRefresh
               onClick={() => setSelected(repo.fullName)}
               className={`flex w-full items-center justify-between rounded-lg border px-4 py-3 text-left transition-colors ${
                 selected === repo.fullName
-                  ? "border-amber-500/40 bg-amber-500/5"
-                  : "border-neutral-800 bg-neutral-900/30 hover:bg-neutral-900/60"
+                  ? "border-soleur-border-emphasized/40 bg-soleur-accent-gold-fg/5"
+                  : "border-soleur-border-default bg-soleur-bg-surface-1/30 hover:bg-soleur-bg-surface-1/60"
               }`}
             >
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium text-neutral-100">
+                  <span className="text-sm font-medium text-soleur-text-primary">
                     {repo.name}
                   </span>
                   <span
                     className={`rounded px-1.5 py-0.5 text-[10px] font-medium uppercase ${
                       repo.private
-                        ? "bg-neutral-800 text-neutral-400"
+                        ? "bg-soleur-bg-surface-2 text-soleur-text-secondary"
                         : "bg-emerald-950 text-emerald-400"
                     }`}
                   >
@@ -119,12 +119,12 @@ export function SelectProjectState({ repos, loading, onSelect, onBack, onRefresh
                   </span>
                 </div>
                 {repo.description && (
-                  <p className="mt-0.5 truncate text-xs text-neutral-500">
+                  <p className="mt-0.5 truncate text-xs text-soleur-text-muted">
                     {repo.description}
                   </p>
                 )}
               </div>
-              <span className="shrink-0 text-xs text-neutral-400">
+              <span className="shrink-0 text-xs text-soleur-text-secondary">
                 Updated {relativeTime(repo.updatedAt)}
               </span>
             </button>
@@ -134,12 +134,12 @@ export function SelectProjectState({ repos, loading, onSelect, onBack, onRefresh
 
       {/* Pagination */}
       {!loading && totalPages > 1 && (
-        <div className="flex items-center justify-between text-xs text-neutral-500">
+        <div className="flex items-center justify-between text-xs text-soleur-text-muted">
           <button
             type="button"
             onClick={() => setPage((p) => Math.max(1, p - 1))}
             disabled={page === 1}
-            className="rounded px-2 py-1 hover:bg-neutral-800 disabled:opacity-30"
+            className="rounded px-2 py-1 hover:bg-soleur-bg-surface-2 disabled:opacity-30"
           >
             Previous
           </button>
@@ -150,7 +150,7 @@ export function SelectProjectState({ repos, loading, onSelect, onBack, onRefresh
             type="button"
             onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
             disabled={page === totalPages}
-            className="rounded px-2 py-1 hover:bg-neutral-800 disabled:opacity-30"
+            className="rounded px-2 py-1 hover:bg-soleur-bg-surface-2 disabled:opacity-30"
           >
             Next
           </button>
@@ -165,11 +165,11 @@ export function SelectProjectState({ repos, loading, onSelect, onBack, onRefresh
       </div>
 
       {/* Expandable: access info */}
-      <div className="border-t border-neutral-800 pt-4">
+      <div className="border-t border-soleur-border-default pt-4">
         <button
           type="button"
           onClick={() => setShowAccess((v) => !v)}
-          className="flex items-center gap-2 text-sm text-neutral-400 transition-colors hover:text-neutral-200"
+          className="flex items-center gap-2 text-sm text-soleur-text-secondary transition-colors hover:text-soleur-text-primary"
         >
           <ChevronDownIcon
             className={`h-4 w-4 transition-transform ${showAccess ? "rotate-180" : ""}`}
@@ -177,7 +177,7 @@ export function SelectProjectState({ repos, loading, onSelect, onBack, onRefresh
           What can the GitHub App access?
         </button>
         {showAccess && (
-          <div className="mt-3 rounded-lg border border-neutral-800 bg-neutral-900/50 p-4 text-xs text-neutral-500">
+          <div className="mt-3 rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1/50 p-4 text-xs text-soleur-text-muted">
             <p>
               The Soleur GitHub App can read and write code in repositories you
               explicitly grant access to. It cannot access other repositories,

--- a/apps/web-platform/components/connect-repo/setting-up-state.tsx
+++ b/apps/web-platform/components/connect-repo/setting-up-state.tsx
@@ -19,13 +19,13 @@ export function SettingUpState({ steps }: SettingUpStateProps) {
         <h1 className={`${serif.className} text-4xl font-semibold`}>
           Setting up your AI team...
         </h1>
-        <p className="text-base text-neutral-400">
+        <p className="text-base text-soleur-text-secondary">
           This usually takes less than a minute.
         </p>
       </div>
 
       {/* Progress bar */}
-      <div className="h-1 overflow-hidden rounded-full bg-neutral-800">
+      <div className="h-1 overflow-hidden rounded-full bg-soleur-bg-surface-2">
         <div
           className="h-full rounded-full transition-all duration-700 ease-out"
           style={{
@@ -48,18 +48,18 @@ export function SettingUpState({ steps }: SettingUpStateProps) {
               <CheckCircleIcon className="h-5 w-5 shrink-0 text-green-400" />
             )}
             {step.status === "active" && (
-              <SpinnerIcon className="h-5 w-5 shrink-0 text-amber-500/70" />
+              <SpinnerIcon className="h-5 w-5 shrink-0 text-soleur-accent-gold-fg/70" />
             )}
             {step.status === "pending" && (
-              <div className="h-5 w-5 shrink-0 rounded-full border-2 border-neutral-600" />
+              <div className="h-5 w-5 shrink-0 rounded-full border-2 border-soleur-border-default" />
             )}
             <span
               className={`text-sm ${
                 step.status === "done"
-                  ? "text-neutral-300"
+                  ? "text-soleur-text-secondary"
                   : step.status === "active"
-                    ? "text-neutral-100"
-                    : "text-neutral-400"
+                    ? "text-soleur-text-primary"
+                    : "text-soleur-text-secondary"
               }`}
             >
               {step.label}
@@ -70,14 +70,14 @@ export function SettingUpState({ steps }: SettingUpStateProps) {
 
       {/* What happens next */}
       <Card>
-        <h3 className="mb-2 text-sm font-medium text-neutral-200">What happens next</h3>
-        <p className="text-xs text-neutral-500">
+        <h3 className="mb-2 text-sm font-medium text-soleur-text-primary">What happens next</h3>
+        <p className="text-xs text-soleur-text-muted">
           Your AI team — marketing, engineering, legal, finance, and more —
           will have full context on your project from the first conversation.
         </p>
       </Card>
 
-      <p className="text-center text-xs text-neutral-500">
+      <p className="text-center text-xs text-soleur-text-muted">
         Your code stays in your GitHub account. Your AI team reads it —
         you decide what changes get made.
       </p>

--- a/apps/web-platform/components/dashboard/foundation-cards.tsx
+++ b/apps/web-platform/components/dashboard/foundation-cards.tsx
@@ -46,7 +46,7 @@ export function FoundationCards({
             <a
               key={card.id}
               href={`/dashboard/kb/${card.kbPath}`}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-neutral-800/50 bg-neutral-900/30 px-3 py-1.5 text-sm text-neutral-400 transition-colors hover:border-neutral-700 hover:text-neutral-300"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-soleur-border-default/50 bg-soleur-bg-surface-1/30 px-3 py-1.5 text-sm text-soleur-text-secondary transition-colors hover:border-soleur-border-default hover:text-soleur-text-secondary"
             >
               <svg className="h-3.5 w-3.5 text-green-500" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                 <path d="M20 6 9 17l-5-5" />
@@ -65,17 +65,17 @@ export function FoundationCards({
               key={card.id}
               type="button"
               onClick={() => onIncompleteClick(card.promptText)}
-              className="flex flex-col gap-2 rounded-xl border border-neutral-800 bg-neutral-900/50 p-4 text-left transition-colors hover:border-neutral-600"
+              className="flex flex-col gap-2 rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1/50 p-4 text-left transition-colors hover:border-soleur-border-default"
             >
               <LeaderAvatar
                 leaderId={card.leaderId}
                 size="sm"
                 customIconPath={getIconPath(card.leaderId)}
               />
-              <span className="text-sm font-medium text-white">
+              <span className="text-sm font-medium text-soleur-text-primary">
                 {card.title}
               </span>
-              <span className="text-xs text-neutral-500">
+              <span className="text-xs text-soleur-text-muted">
                 {card.promptText}
               </span>
             </button>

--- a/apps/web-platform/components/dashboard/foundation-section.tsx
+++ b/apps/web-platform/components/dashboard/foundation-section.tsx
@@ -27,10 +27,10 @@ export function FoundationSection({
 }: FoundationSectionProps) {
   return (
     <div className={className}>
-      <p className="mb-2 text-xs font-medium tracking-widest text-amber-500">
+      <p className="mb-2 text-xs font-medium tracking-widest text-soleur-accent-gold-fg">
         FOUNDATIONS
       </p>
-      <p className="mb-4 text-sm text-neutral-400">
+      <p className="mb-4 text-sm text-soleur-text-secondary">
         Complete these to brief your department leaders.
       </p>
       <FoundationCards

--- a/apps/web-platform/components/error-boundary-view.tsx
+++ b/apps/web-platform/components/error-boundary-view.tsx
@@ -37,15 +37,15 @@ export function ErrorBoundaryView({
       data-error-boundary={segment ?? "root"}
       className="flex min-h-[50vh] flex-col items-center justify-center gap-4"
     >
-      <h2 className="text-xl font-semibold text-white">Something went wrong</h2>
-      <p className="text-sm text-neutral-400">
+      <h2 className="text-xl font-semibold text-soleur-text-primary">Something went wrong</h2>
+      <p className="text-sm text-soleur-text-secondary">
         {error.digest
           ? `Error ID: ${error.digest}`
           : "An unexpected error occurred."}
       </p>
       <button
         onClick={reset}
-        className="rounded-lg border border-neutral-700 px-4 py-2 text-sm text-neutral-300 transition-colors hover:border-neutral-500 hover:text-white"
+        className="rounded-lg border border-soleur-border-default px-4 py-2 text-sm text-soleur-text-secondary transition-colors hover:border-soleur-border-default hover:text-soleur-text-primary"
       >
         Try again
       </button>

--- a/apps/web-platform/components/inbox/conversation-row.tsx
+++ b/apps/web-platform/components/inbox/conversation-row.tsx
@@ -74,24 +74,24 @@ function StatusBadge({
       {open && (
         <div
           role="menu"
-          className="absolute left-0 top-full z-50 mt-1 min-w-[160px] rounded-lg border border-neutral-700 bg-neutral-900 py-1 shadow-lg"
+          className="absolute left-0 top-full z-50 mt-1 min-w-[160px] rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1 py-1 shadow-lg"
         >
           <button
             type="button"
             role="menuitem"
-            className="flex w-full min-h-[44px] items-center gap-2 px-3 py-2 text-left text-sm text-neutral-200 hover:bg-neutral-800"
+            className="flex w-full min-h-[44px] items-center gap-2 px-3 py-2 text-left text-sm text-soleur-text-primary hover:bg-soleur-bg-surface-2"
             onClick={(e) => {
               e.stopPropagation();
               onAction!(action!.target);
               setOpen(false);
             }}
           >
-            <span className="flex h-4 w-4 items-center justify-center rounded-full border border-neutral-500 text-[10px] text-neutral-400">
+            <span className="flex h-4 w-4 items-center justify-center rounded-full border border-soleur-border-default text-[10px] text-soleur-text-secondary">
               &#x2298;
             </span>
             <div>
               <div>{action!.label}</div>
-              <div className="text-xs text-neutral-500">Move to completed</div>
+              <div className="text-xs text-soleur-text-muted">Move to completed</div>
             </div>
           </button>
         </div>
@@ -118,7 +118,7 @@ function ArchiveButton({
         e.stopPropagation();
         isArchived ? onUnarchive() : onArchive();
       }}
-      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-neutral-500 transition-colors hover:bg-neutral-700 hover:text-neutral-300"
+      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-soleur-text-muted transition-colors hover:bg-soleur-bg-surface-2 hover:text-soleur-text-secondary"
     >
       {isArchived ? (
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
@@ -161,7 +161,7 @@ export function ConversationRow({ conversation, onArchive, onUnarchive, onStatus
       className={`flex w-full min-h-[44px] cursor-pointer items-start gap-3 rounded-lg border p-3 text-left transition-colors md:items-center md:gap-4 md:p-4 ${
         isDecision
           ? "border-amber-500/20 bg-amber-500/[0.06] hover:bg-amber-500/[0.1]"
-          : "border-neutral-800 bg-neutral-900/50 hover:bg-neutral-800/50"
+          : "border-soleur-border-default bg-soleur-bg-surface-1/50 hover:bg-soleur-bg-surface-2/50"
       } ${isArchived ? "opacity-60" : ""}`}
     >
       {/* Mobile: vertical stack */}
@@ -175,20 +175,20 @@ export function ConversationRow({ conversation, onArchive, onUnarchive, onStatus
               </span>
             )}
             {isArchived && (
-              <span className="inline-flex items-center rounded-full bg-neutral-800 px-2 py-0.5 text-[10px] font-medium text-neutral-400">
+              <span className="inline-flex items-center rounded-full bg-soleur-bg-surface-2 px-2 py-0.5 text-[10px] font-medium text-soleur-text-secondary">
                 Archived
               </span>
             )}
           </div>
-          <span className="text-xs text-neutral-500">
+          <span className="text-xs text-soleur-text-muted">
             {relativeTime(conversation.last_active)}
           </span>
         </div>
-        <p className={`text-sm font-medium ${isCompleted || isArchived ? "text-neutral-400" : "text-white"}`}>
+        <p className={`text-sm font-medium ${isCompleted || isArchived ? "text-soleur-text-secondary" : "text-soleur-text-primary"}`}>
           {conversation.title}
         </p>
         {conversation.preview && (
-          <p className={`text-xs ${isCompleted || isArchived ? "text-neutral-600" : "text-neutral-400"}`}>
+          <p className={`text-xs ${isCompleted || isArchived ? "text-soleur-text-muted" : "text-soleur-text-secondary"}`}>
             {conversation.preview}
           </p>
         )}
@@ -217,16 +217,16 @@ export function ConversationRow({ conversation, onArchive, onUnarchive, onStatus
           </span>
         )}
         {isArchived && (
-          <span className="inline-flex items-center rounded-full bg-neutral-800 px-2 py-0.5 text-[10px] font-medium text-neutral-400">
+          <span className="inline-flex items-center rounded-full bg-soleur-bg-surface-2 px-2 py-0.5 text-[10px] font-medium text-soleur-text-secondary">
             Archived
           </span>
         )}
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <p className={`truncate text-sm font-medium ${isCompleted || isArchived ? "text-neutral-400" : "text-white"}`}>
+          <p className={`truncate text-sm font-medium ${isCompleted || isArchived ? "text-soleur-text-secondary" : "text-soleur-text-primary"}`}>
             {conversation.title}
           </p>
           {conversation.preview && (
-            <p className={`truncate text-xs ${isCompleted || isArchived ? "text-neutral-600" : "text-neutral-400"}`}>
+            <p className={`truncate text-xs ${isCompleted || isArchived ? "text-soleur-text-muted" : "text-soleur-text-secondary"}`}>
               {conversation.preview}
             </p>
           )}
@@ -234,7 +234,7 @@ export function ConversationRow({ conversation, onArchive, onUnarchive, onStatus
         {conversation.domain_leader && (
           <LeaderAvatar leaderId={conversation.domain_leader} size="md" customIconPath={getIconPath(conversation.domain_leader as DomainLeaderId)} />
         )}
-        <span className="w-16 shrink-0 truncate text-right text-xs tabular-nums text-neutral-500">
+        <span className="w-16 shrink-0 truncate text-right text-xs tabular-nums text-soleur-text-muted">
           {relativeTime(conversation.last_active)}
         </span>
         {(onArchive || onUnarchive) && (

--- a/apps/web-platform/components/kb/desktop-placeholder.tsx
+++ b/apps/web-platform/components/kb/desktop-placeholder.tsx
@@ -9,13 +9,13 @@ export function DesktopPlaceholder() {
           fill="none"
           stroke="currentColor"
           strokeWidth="1"
-          className="mx-auto mb-3 text-neutral-600"
+          className="mx-auto mb-3 text-soleur-text-muted"
         >
           <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z" strokeLinecap="round" strokeLinejoin="round" />
           <path d="M14 2v6h6" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
-        <p className="text-sm text-neutral-500">Select a file to view</p>
-        <p className="mt-1 text-xs text-neutral-600">
+        <p className="text-sm text-soleur-text-muted">Select a file to view</p>
+        <p className="mt-1 text-xs text-soleur-text-muted">
           Choose a file from the sidebar to preview its contents
         </p>
       </div>

--- a/apps/web-platform/components/kb/download-preview.tsx
+++ b/apps/web-platform/components/kb/download-preview.tsx
@@ -14,20 +14,20 @@ export function DownloadPreview({ src, filename }: { src: string; filename: stri
   return (
     <div className="flex h-full items-center justify-center p-8">
       <div className="flex flex-col items-center gap-4 text-center">
-        <div className="rounded-lg border border-neutral-800 bg-neutral-900/50 p-6">
-          <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-neutral-500">
+        <div className="rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1/50 p-6">
+          <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-soleur-text-muted">
             <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z" strokeLinecap="round" strokeLinejoin="round" />
             <path d="M14 2v6h6" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
         </div>
         <div>
-          <p className="mb-1 text-sm font-medium text-neutral-300">{filename}</p>
-          <p className="text-xs text-neutral-500">{ext} file</p>
+          <p className="mb-1 text-sm font-medium text-soleur-text-secondary">{filename}</p>
+          <p className="text-xs text-soleur-text-muted">{ext} file</p>
         </div>
         <a
           href={src}
           download={filename}
-          className="inline-flex items-center gap-2 rounded-lg border border-amber-500/50 px-4 py-2 text-sm font-medium text-amber-400 transition-colors hover:border-amber-400 hover:text-amber-300"
+          className="inline-flex items-center gap-2 rounded-lg border border-soleur-border-emphasized px-4 py-2 text-sm font-medium text-soleur-accent-gold-fg transition-colors hover:border-amber-400 hover:text-soleur-accent-gold-text"
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" strokeLinecap="round" strokeLinejoin="round" />

--- a/apps/web-platform/components/kb/empty-state.tsx
+++ b/apps/web-platform/components/kb/empty-state.tsx
@@ -7,18 +7,18 @@ export function EmptyState() {
         <p className="mb-4 text-xs font-semibold uppercase tracking-widest text-amber-500/80">
           Knowledge Base
         </p>
-        <h1 className="mb-3 font-serif text-2xl font-medium text-white">
+        <h1 className="mb-3 font-serif text-2xl font-medium text-soleur-text-primary">
           Nothing Here Yet.{" "}
-          <span className="text-neutral-400">One Message Changes That.</span>
+          <span className="text-soleur-text-secondary">One Message Changes That.</span>
         </h1>
-        <p className="mb-6 text-sm leading-relaxed text-neutral-400">
+        <p className="mb-6 text-sm leading-relaxed text-soleur-text-secondary">
           Start a conversation and your AI organization gets to work — producing
           plans, specs, brand guides, and competitive analyses that appear here
           automatically.
         </p>
         <Link
           href="/dashboard/chat/new"
-          className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-amber-600 to-amber-500 px-5 py-2.5 text-sm font-medium text-neutral-950 transition-opacity hover:opacity-90"
+          className="inline-flex items-center gap-2 rounded-lg bg-soleur-accent-gold-fill px-5 py-2.5 text-sm font-medium text-soleur-text-on-accent transition-opacity hover:opacity-90"
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="shrink-0">
             <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2Z" strokeLinecap="round" strokeLinejoin="round" />

--- a/apps/web-platform/components/kb/file-preview.tsx
+++ b/apps/web-platform/components/kb/file-preview.tsx
@@ -12,7 +12,7 @@ const PdfPreview = dynamic(
     ssr: false,
     loading: () => (
       <div className="flex items-center justify-center p-8">
-        <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-600 border-t-amber-400" />
+        <div className="h-5 w-5 animate-spin rounded-full border-2 border-soleur-border-default border-t-amber-400" />
       </div>
     ),
   },
@@ -64,7 +64,7 @@ function ImagePreview({ src, filename }: { src: string; filename: string }) {
     <div className="flex flex-col items-center gap-4 p-6">
       <button
         onClick={() => setLightbox(true)}
-        className="cursor-zoom-in overflow-hidden rounded-lg border border-neutral-800 bg-neutral-900/50"
+        className="cursor-zoom-in overflow-hidden rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1/50"
       >
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
@@ -74,7 +74,7 @@ function ImagePreview({ src, filename }: { src: string; filename: string }) {
           loading="lazy"
         />
       </button>
-      <p className="text-xs text-neutral-500">Click to enlarge</p>
+      <p className="text-xs text-soleur-text-muted">Click to enlarge</p>
 
       {lightbox && (
         <div
@@ -85,7 +85,7 @@ function ImagePreview({ src, filename }: { src: string; filename: string }) {
         >
           <button
             onClick={() => setLightbox(false)}
-            className="absolute right-4 top-4 rounded-full p-2 text-neutral-400 hover:text-white"
+            className="absolute right-4 top-4 rounded-full p-2 text-soleur-text-secondary hover:text-soleur-text-primary"
             aria-label="Close lightbox"
           >
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/apps/web-platform/components/kb/file-tree.tsx
+++ b/apps/web-platform/components/kb/file-tree.tsx
@@ -193,7 +193,7 @@ function TreeItem({
       <div className="group relative">
         <button
           onClick={() => onToggle(dirKey)}
-          className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-neutral-300 hover:bg-neutral-800/50 ${
+          className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-soleur-text-secondary hover:bg-soleur-bg-surface-2/50 ${
             isBusy ? "bg-amber-500/10" : ""
           }`}
           style={{ paddingLeft }}
@@ -219,7 +219,7 @@ function TreeItem({
           <FolderIcon />
           <span className="truncate font-medium">{node.name}</span>
           {node.modifiedAt && !isBusy && (
-            <span className="ml-auto shrink-0 text-xs text-neutral-600 group-hover:opacity-0 transition-opacity">
+            <span className="ml-auto shrink-0 text-xs text-soleur-text-muted group-hover:opacity-0 transition-opacity">
               {formatRelativeTime(node.modifiedAt)}
             </span>
           )}
@@ -230,7 +230,7 @@ function TreeItem({
               e.stopPropagation();
               fileInputRef.current?.click();
             }}
-            className="absolute right-1 top-1/2 -translate-y-1/2 rounded p-1 text-neutral-500 opacity-0 transition-opacity hover:bg-neutral-700 hover:text-neutral-300 group-hover:opacity-100"
+            className="absolute right-1 top-1/2 -translate-y-1/2 rounded p-1 text-soleur-text-muted opacity-0 transition-opacity hover:bg-soleur-bg-surface-2 hover:text-soleur-text-secondary group-hover:opacity-100"
             title="Upload file"
             aria-label={`Upload file to ${node.name}`}
           >
@@ -267,7 +267,7 @@ function TreeItem({
             </button>
             <button
               onClick={() => setUploadState({ status: "idle" })}
-              className="rounded px-2 py-0.5 text-neutral-400 hover:text-neutral-300"
+              className="rounded px-2 py-0.5 text-soleur-text-secondary hover:text-soleur-text-primary"
             >
               Cancel
             </button>
@@ -398,7 +398,7 @@ function FileNode({
       <div className="group relative">
         {isEditing ? (
           <div
-            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-neutral-300"
+            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-soleur-text-secondary"
             style={{ paddingLeft }}
           >
             <FileTypeIcon extension={node.extension} />
@@ -408,34 +408,34 @@ function FileNode({
               defaultValue={baseName}
               onKeyDown={handleRenameKeyDown}
               onBlur={(e) => handleRenameConfirm(e.target.value)}
-              className="min-w-0 flex-1 rounded border border-neutral-600 bg-neutral-800 px-1.5 py-0.5 text-sm text-neutral-200 outline-none focus:border-amber-500"
+              className="min-w-0 flex-1 rounded border border-soleur-border-default bg-soleur-bg-surface-2 px-1.5 py-0.5 text-sm text-soleur-text-primary outline-none focus:border-soleur-border-emphasized"
             />
-            <span className="shrink-0 text-sm text-neutral-500">{ext}</span>
+            <span className="shrink-0 text-sm text-soleur-text-muted">{ext}</span>
           </div>
         ) : (
           <Link
             href={filePath}
             className={`flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
               isActive
-                ? "bg-neutral-800 text-amber-400"
-                : "text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-200"
+                ? "bg-soleur-bg-surface-2 text-soleur-accent-gold-fg"
+                : "text-soleur-text-secondary hover:bg-soleur-bg-surface-2/50 hover:text-soleur-text-primary"
             } ${isDeleting || isRenaming ? "opacity-50" : ""}`}
             style={{ paddingLeft }}
           >
             <FileTypeIcon extension={node.extension} />
             <span className="truncate">{node.name}</span>
             {node.modifiedAt && !isDeleting && !isRenaming && (
-              <span className={`ml-auto shrink-0 text-xs text-neutral-600${isAttachment ? " group-hover:opacity-0 transition-opacity" : ""}`}>
+              <span className={`ml-auto shrink-0 text-xs text-soleur-text-muted${isAttachment ? " group-hover:opacity-0 transition-opacity" : ""}`}>
                 {formatRelativeTime(node.modifiedAt)}
               </span>
             )}
             {isDeleting && (
-              <span className="ml-auto shrink-0 text-xs text-neutral-500">
+              <span className="ml-auto shrink-0 text-xs text-soleur-text-muted">
                 Deleting...
               </span>
             )}
             {isRenaming && (
-              <span className="ml-auto shrink-0 text-xs text-neutral-500">
+              <span className="ml-auto shrink-0 text-xs text-soleur-text-muted">
                 Renaming...
               </span>
             )}
@@ -450,7 +450,7 @@ function FileNode({
                 renameSubmittedRef.current = false;
                 setRenameState({ status: "editing" });
               }}
-              className="rounded p-1 text-neutral-500 hover:bg-neutral-700 hover:text-neutral-300"
+              className="rounded p-1 text-soleur-text-muted hover:bg-soleur-bg-surface-2 hover:text-soleur-text-secondary"
               title="Rename file"
               aria-label={`Rename ${node.name}`}
             >
@@ -462,7 +462,7 @@ function FileNode({
                 e.stopPropagation();
                 setDeleteState({ status: "confirming" });
               }}
-              className="rounded p-1 text-neutral-500 hover:bg-neutral-700 hover:text-red-400"
+              className="rounded p-1 text-soleur-text-muted hover:bg-soleur-bg-surface-2 hover:text-red-400"
               title="Delete file"
               aria-label={`Delete ${node.name}`}
             >
@@ -483,7 +483,7 @@ function FileNode({
             </button>
             <button
               onClick={() => setDeleteState({ status: "idle" })}
-              className="rounded px-2 py-0.5 text-neutral-400 hover:text-neutral-300"
+              className="rounded px-2 py-0.5 text-soleur-text-secondary hover:text-soleur-text-primary"
             >
               Cancel
             </button>
@@ -577,7 +577,7 @@ function FileTypeIcon({ extension }: { extension?: string }) {
 
   // Default file icon (including .md)
   return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="shrink-0 text-neutral-500">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="shrink-0 text-soleur-text-muted">
       <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z" strokeLinecap="round" strokeLinejoin="round" />
       <path d="M14 2v6h6" strokeLinecap="round" strokeLinejoin="round" />
     </svg>

--- a/apps/web-platform/components/kb/kb-breadcrumb.tsx
+++ b/apps/web-platform/components/kb/kb-breadcrumb.tsx
@@ -12,7 +12,7 @@ export function KbBreadcrumb({ path }: { path: string }) {
   const segments = path.split("/");
 
   return (
-    <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-xs text-neutral-500">
+    <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-xs text-soleur-text-muted">
       {segments.map((segment, i) => {
         const isCurrent = i === segments.length - 1;
         return (
@@ -23,7 +23,7 @@ export function KbBreadcrumb({ path }: { path: string }) {
                 "data-testid": "kb-breadcrumb-current",
                 "aria-current": "page",
               })}
-              className={isCurrent ? "text-neutral-300" : ""}
+              className={isCurrent ? "text-soleur-text-secondary" : ""}
             >
               {safeDecode(segment)}
             </span>

--- a/apps/web-platform/components/kb/kb-content-header.tsx
+++ b/apps/web-platform/components/kb/kb-content-header.tsx
@@ -13,12 +13,12 @@ export type KbContentHeaderProps = {
 
 export function KbContentHeader({ joinedPath, chatUrl, download }: KbContentHeaderProps) {
   return (
-    <header className="flex shrink-0 items-center justify-between border-b border-neutral-800 px-4 py-3 md:px-6">
+    <header className="flex shrink-0 items-center justify-between border-b border-soleur-border-default px-4 py-3 md:px-6">
       <div className="flex items-center gap-2">
         <Link
           href="/dashboard/kb"
           aria-label="Back to file tree"
-          className="flex items-center text-neutral-400 hover:text-white md:hidden"
+          className="flex items-center text-soleur-text-secondary hover:text-soleur-text-primary md:hidden"
         >
           <svg
             width="20"
@@ -42,7 +42,7 @@ export function KbContentHeader({ joinedPath, chatUrl, download }: KbContentHead
             href={download.href}
             download={download.filename}
             aria-label={`Download ${download.filename}`}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-neutral-700 px-3 py-1.5 text-xs font-medium text-neutral-300 transition-colors hover:border-neutral-500 hover:text-white"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-soleur-border-default px-3 py-1.5 text-xs font-medium text-soleur-text-secondary transition-colors hover:border-soleur-border-emphasized hover:text-soleur-text-primary"
           >
             <svg
               width="14"

--- a/apps/web-platform/components/kb/kb-content-skeleton.tsx
+++ b/apps/web-platform/components/kb/kb-content-skeleton.tsx
@@ -3,13 +3,13 @@ const DEFAULT_WIDTHS = ["85%", "70%", "90%", "65%", "80%"];
 export function KbContentSkeleton({ widths = DEFAULT_WIDTHS }: { widths?: string[] }) {
   return (
     <div className="space-y-4">
-      <div className="h-8 w-64 animate-pulse rounded bg-neutral-800" />
+      <div className="h-8 w-64 animate-pulse rounded bg-soleur-bg-surface-2" />
       <div className="space-y-2">
         {widths.map((w, i) => (
           <div
             key={i}
             data-testid="kb-content-skeleton-row"
-            className="h-4 animate-pulse rounded bg-neutral-800"
+            className="h-4 animate-pulse rounded bg-soleur-bg-surface-2"
             style={{ width: w }}
           />
         ))}

--- a/apps/web-platform/components/kb/kb-desktop-layout.tsx
+++ b/apps/web-platform/components/kb/kb-desktop-layout.tsx
@@ -16,13 +16,13 @@ const KbChatContent = dynamic(
 function ResizeHandle(props: { style?: React.CSSProperties }) {
   return (
     <Separator
-      className="group relative w-1 bg-transparent transition-colors duration-150 hover:bg-neutral-400/50 active:bg-amber-500/50 data-[resize-handle-active]:bg-amber-500/50"
+      className="group relative w-1 bg-transparent transition-colors duration-150 hover:bg-soleur-text-secondary/50 active:bg-amber-500/50 data-[resize-handle-active]:bg-amber-500/50"
       style={props.style}
     >
       <div className="absolute inset-y-0 left-1/2 flex -translate-x-1/2 flex-col items-center justify-center gap-0.5">
-        <span className="h-0.5 w-0.5 rounded-full bg-neutral-600 group-hover:bg-neutral-400" />
-        <span className="h-0.5 w-0.5 rounded-full bg-neutral-600 group-hover:bg-neutral-400" />
-        <span className="h-0.5 w-0.5 rounded-full bg-neutral-600 group-hover:bg-neutral-400" />
+        <span className="h-0.5 w-0.5 rounded-full bg-soleur-text-muted group-hover:bg-soleur-text-secondary" />
+        <span className="h-0.5 w-0.5 rounded-full bg-soleur-text-muted group-hover:bg-soleur-text-secondary" />
+        <span className="h-0.5 w-0.5 rounded-full bg-soleur-text-muted group-hover:bg-soleur-text-secondary" />
       </div>
     </Separator>
   );
@@ -60,7 +60,7 @@ export function KbDesktopLayout({ children, state }: KbDesktopLayoutProps) {
           setKbCollapsed(size.asPercentage < 1);
         }}
       >
-        <div className="min-w-0 h-full overflow-y-auto border-r border-neutral-800">
+        <div className="min-w-0 h-full overflow-y-auto border-r border-soleur-border-default">
           <KbSidebarShell onCollapse={toggleKbCollapsed} />
         </div>
       </Panel>
@@ -90,7 +90,7 @@ export function KbDesktopLayout({ children, state }: KbDesktopLayoutProps) {
             minSize="20%"
             maxSize="40%"
           >
-            <div className="min-w-0 h-full border-l border-neutral-800">
+            <div className="min-w-0 h-full border-l border-soleur-border-default">
               <KbChatContent
                 contextPath={contextPath}
                 onClose={closeSidebar}

--- a/apps/web-platform/components/kb/kb-doc-shell.tsx
+++ b/apps/web-platform/components/kb/kb-doc-shell.tsx
@@ -29,7 +29,7 @@ export function KbDocShell({
           onClick={onExpand}
           aria-label="Expand file tree"
           title="Expand file tree (⌘B)"
-          className="absolute left-2 top-5 z-10 flex h-6 w-6 items-center justify-center rounded text-neutral-400 hover:bg-neutral-800 hover:text-white"
+          className="absolute left-2 top-5 z-10 flex h-6 w-6 items-center justify-center rounded text-soleur-text-secondary hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary"
         >
           <svg
             className="h-4 w-4"

--- a/apps/web-platform/components/kb/kb-error-boundary.tsx
+++ b/apps/web-platform/components/kb/kb-error-boundary.tsx
@@ -19,12 +19,12 @@ export class KbErrorBoundary extends Component<
       return (
         <div className="flex h-full items-center justify-center">
           <div className="text-center">
-            <p className="text-sm text-neutral-400">
+            <p className="text-sm text-soleur-text-secondary">
               Something went wrong loading this content.
             </p>
             <button
               onClick={() => this.setState({ hasError: false })}
-              className="mt-2 text-sm text-amber-400 underline hover:text-amber-300"
+              className="mt-2 text-sm text-soleur-accent-gold-fg underline hover:text-soleur-accent-gold-text"
             >
               Try again
             </button>

--- a/apps/web-platform/components/kb/kb-mobile-layout.tsx
+++ b/apps/web-platform/components/kb/kb-mobile-layout.tsx
@@ -31,7 +31,7 @@ export function KbMobileLayout({ children, state }: KbMobileLayoutProps) {
     <div className="flex h-full">
       <aside
         inert={kbCollapsed || undefined}
-        className={`w-full shrink-0 overflow-y-auto border-r border-neutral-800
+        className={`w-full shrink-0 overflow-y-auto border-r border-soleur-border-default
           ${isContentView ? "hidden" : "block"}`}
       >
         <KbSidebarShell onCollapse={toggleKbCollapsed} />

--- a/apps/web-platform/components/kb/kb-sidebar-shell.tsx
+++ b/apps/web-platform/components/kb/kb-sidebar-shell.tsx
@@ -15,14 +15,14 @@ export function KbSidebarShell({ onCollapse }: KbSidebarShellProps) {
   return (
     <div className="flex h-full flex-col">
       <header className="flex shrink-0 items-center justify-between px-4 pb-3 pt-4">
-        <h1 className="font-serif text-lg font-medium tracking-tight text-white">
+        <h1 className="font-serif text-lg font-medium tracking-tight text-soleur-text-primary">
           Knowledge Base
         </h1>
         <button
           onClick={onCollapse}
           aria-label="Collapse file tree"
           title="Collapse file tree (⌘B)"
-          className="hidden md:flex h-6 w-6 items-center justify-center rounded text-neutral-400 hover:bg-neutral-800 hover:text-white"
+          className="hidden md:flex h-6 w-6 items-center justify-center rounded text-soleur-text-secondary hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary"
         >
           <svg
             className="h-4 w-4"

--- a/apps/web-platform/components/kb/loading-skeleton.tsx
+++ b/apps/web-platform/components/kb/loading-skeleton.tsx
@@ -2,13 +2,13 @@ export function LoadingSkeleton() {
   const widths = [140, 120, 160, 100, 130];
   return (
     <div className="flex h-full flex-col p-4">
-      <div className="mb-4 h-6 w-32 animate-pulse rounded bg-neutral-800" />
+      <div className="mb-4 h-6 w-32 animate-pulse rounded bg-soleur-bg-surface-2" />
       <div className="space-y-2">
         {widths.map((w, i) => (
           <div key={i} className="flex items-center gap-2">
-            <div className="h-4 w-4 animate-pulse rounded bg-neutral-800" />
+            <div className="h-4 w-4 animate-pulse rounded bg-soleur-bg-surface-2" />
             <div
-              className="h-4 animate-pulse rounded bg-neutral-800"
+              className="h-4 animate-pulse rounded bg-soleur-bg-surface-2"
               style={{ width: `${w}px` }}
             />
           </div>

--- a/apps/web-platform/components/kb/no-project-state.tsx
+++ b/apps/web-platform/components/kb/no-project-state.tsx
@@ -4,21 +4,21 @@ export function NoProjectState() {
   return (
     <div className="flex h-full items-center justify-center p-6">
       <div className="max-w-sm text-center">
-        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-neutral-800">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-amber-500">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-soleur-bg-surface-2">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-soleur-accent-gold-fg">
             <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2Z" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
         </div>
-        <h1 className="mb-2 font-serif text-lg font-medium text-white">
+        <h1 className="mb-2 font-serif text-lg font-medium text-soleur-text-primary">
           No Project Connected
         </h1>
-        <p className="mb-6 text-sm leading-relaxed text-neutral-400">
+        <p className="mb-6 text-sm leading-relaxed text-soleur-text-secondary">
           Connect a GitHub project so your AI team can build your knowledge
           base with plans, specs, and analyses.
         </p>
         <Link
           href="/connect-repo?return_to=/dashboard/kb"
-          className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-amber-600 to-amber-500 px-5 py-2.5 text-sm font-medium text-neutral-950 transition-opacity hover:opacity-90"
+          className="inline-flex items-center gap-2 rounded-lg bg-soleur-accent-gold-fill px-5 py-2.5 text-sm font-medium text-soleur-text-on-accent transition-opacity hover:opacity-90"
         >
           Set Up Project
         </Link>

--- a/apps/web-platform/components/kb/pdf-preview.tsx
+++ b/apps/web-platform/components/kb/pdf-preview.tsx
@@ -96,11 +96,11 @@ export function PdfPreview({ src, filename, showDownload = true }: PdfPreviewPro
   if (error) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center">
-        <p className="text-sm text-neutral-400">Unable to preview this PDF</p>
+        <p className="text-sm text-soleur-text-secondary">Unable to preview this PDF</p>
         <a
           href={src}
           download={filename}
-          className="inline-flex items-center gap-2 rounded-lg border border-amber-500/50 px-4 py-2 text-sm font-medium text-amber-400 transition-colors hover:border-amber-400 hover:text-amber-300"
+          className="inline-flex items-center gap-2 rounded-lg border border-soleur-border-emphasized px-4 py-2 text-sm font-medium text-soleur-accent-gold-fg transition-colors hover:border-amber-400 hover:text-soleur-accent-gold-text"
         >
           Download {filename}
         </a>
@@ -112,18 +112,18 @@ export function PdfPreview({ src, filename, showDownload = true }: PdfPreviewPro
     <div className="flex min-h-0 h-full flex-col gap-3 p-4">
       {showDownload && (
         <div className="flex items-center justify-between">
-          <span className="text-sm text-neutral-400">{filename}</span>
+          <span className="text-sm text-soleur-text-secondary">{filename}</span>
           <a
             href={src}
             download={filename}
-            className="rounded-md border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:bg-neutral-800"
+            className="rounded-md border border-soleur-border-default px-3 py-1 text-xs text-soleur-text-secondary hover:bg-soleur-bg-surface-2"
           >
             Download
           </a>
         </div>
       )}
 
-      <div ref={containerRef} className="min-h-0 flex-1 flex items-center justify-center overflow-auto rounded-lg border border-neutral-800 bg-neutral-900/50">
+      <div ref={containerRef} className="min-h-0 flex-1 flex items-center justify-center overflow-auto rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1/50">
         <Document
           file={src}
           options={PDF_DOCUMENT_OPTIONS}
@@ -138,16 +138,16 @@ export function PdfPreview({ src, filename, showDownload = true }: PdfPreviewPro
           className="flex items-center justify-center"
           loading={
             <div className="flex flex-col items-center justify-center gap-3 p-8">
-              <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-600 border-t-amber-400" />
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-soleur-border-default border-t-amber-400" />
               {loadProgress && loadProgress.total > 0 && (
                 <div className="w-48 text-center">
-                  <div className="h-1 w-full overflow-hidden rounded-full bg-neutral-800">
+                  <div className="h-1 w-full overflow-hidden rounded-full bg-soleur-bg-surface-2">
                     <div
                       className="h-full bg-amber-400 transition-[width] duration-150"
                       style={{ width: `${Math.min(100, (loadProgress.loaded / loadProgress.total) * 100)}%` }}
                     />
                   </div>
-                  <p className="mt-2 text-xs text-neutral-500">
+                  <p className="mt-2 text-xs text-soleur-text-muted">
                     Loading {Math.round(loadProgress.loaded / 1024)}KB / {Math.round(loadProgress.total / 1024)}KB
                   </p>
                 </div>
@@ -173,17 +173,17 @@ export function PdfPreview({ src, filename, showDownload = true }: PdfPreviewPro
           <button
             onClick={() => setPageNumber((p) => Math.max(p - 1, 1))}
             disabled={pageNumber <= 1}
-            className="rounded-md border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-40"
+            className="rounded-md border border-soleur-border-default px-3 py-1 text-xs text-soleur-text-secondary hover:bg-soleur-bg-surface-2 disabled:cursor-not-allowed disabled:opacity-40"
           >
             Previous
           </button>
-          <span className="text-xs text-neutral-400">
+          <span className="text-xs text-soleur-text-secondary">
             Page {pageNumber} of {numPages}
           </span>
           <button
             onClick={() => setPageNumber((p) => Math.min(p + 1, numPages))}
             disabled={pageNumber >= numPages}
-            className="rounded-md border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-40"
+            className="rounded-md border border-soleur-border-default px-3 py-1 text-xs text-soleur-text-secondary hover:bg-soleur-bg-surface-2 disabled:cursor-not-allowed disabled:opacity-40"
           >
             Next
           </button>

--- a/apps/web-platform/components/kb/search-overlay.tsx
+++ b/apps/web-platform/components/kb/search-overlay.tsx
@@ -57,7 +57,7 @@ export function SearchOverlay() {
           fill="none"
           stroke="currentColor"
           strokeWidth="2"
-          className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-500"
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-soleur-text-muted"
         >
           <circle cx="11" cy="11" r="8" />
           <path d="m21 21-4.3-4.3" strokeLinecap="round" />
@@ -67,19 +67,19 @@ export function SearchOverlay() {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search files..."
-          className="w-full rounded-lg border border-neutral-700 bg-neutral-900 py-2 pl-9 pr-3 text-sm text-neutral-200 placeholder-neutral-500 outline-none transition-colors focus:border-amber-500/50"
+          className="w-full rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1 py-2 pl-9 pr-3 text-sm text-soleur-text-primary placeholder:text-soleur-text-muted outline-none transition-colors focus:border-soleur-border-emphasized"
         />
       </div>
 
       {/* Search results */}
       {searched && query.trim() && (
         <div className="mt-3">
-          <p className="mb-2 text-xs text-neutral-500">
+          <p className="mb-2 text-xs text-soleur-text-muted">
             {results.length} result{results.length !== 1 ? "s" : ""} for &ldquo;{query}&rdquo;
           </p>
 
           {results.length === 0 ? (
-            <p className="py-4 text-center text-sm text-neutral-500">
+            <p className="py-4 text-center text-sm text-soleur-text-muted">
               No results for &ldquo;{query}&rdquo;
             </p>
           ) : (
@@ -94,7 +94,7 @@ export function SearchOverlay() {
 
       {loading && query.trim() && (
         <div className="mt-3 flex justify-center py-4">
-          <span className="h-4 w-4 animate-spin rounded-full border-2 border-neutral-600 border-t-amber-500" />
+          <span className="h-4 w-4 animate-spin rounded-full border-2 border-soleur-border-default border-t-amber-500" />
         </div>
       )}
     </div>
@@ -107,14 +107,14 @@ function SearchResultCard({ result }: { result: SearchResult }) {
   return (
     <Link
       href={`/dashboard/kb/${result.path}`}
-      className="block rounded-lg border border-neutral-800 p-3 transition-colors hover:border-neutral-700 hover:bg-neutral-900/50"
+      className="block rounded-lg border border-soleur-border-default p-3 transition-colors hover:border-soleur-border-emphasized hover:bg-soleur-bg-surface-1/50"
     >
       <div className="mb-1 flex items-center gap-1.5">
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="shrink-0 text-amber-500/70">
           <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z" strokeLinecap="round" strokeLinejoin="round" />
           <path d="M14 2v6h6" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
-        <span className="text-sm font-medium text-amber-400">{result.path}</span>
+        <span className="text-sm font-medium text-soleur-accent-gold-fg">{result.path}</span>
       </div>
       <div className="space-y-1">
         {snippets.map((match, i) => (
@@ -139,10 +139,10 @@ function SnippetLine({
 
   return (
     <div className="flex items-start gap-2 text-xs">
-      <span className="shrink-0 text-neutral-600">
+      <span className="shrink-0 text-soleur-text-muted">
         {kind === "filename" ? "Filename" : `Line ${match.line}`}
       </span>
-      <p className="truncate text-neutral-400">
+      <p className="truncate text-soleur-text-secondary">
         {before}
         <mark className="rounded bg-amber-500/20 px-0.5 text-amber-300">{highlighted}</mark>
         {after}

--- a/apps/web-platform/components/kb/selection-toolbar.tsx
+++ b/apps/web-platform/components/kb/selection-toolbar.tsx
@@ -220,8 +220,8 @@ export function SelectionToolbar({
       className={
         "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium shadow-lg transition-colors " +
         (disabled
-          ? "cursor-not-allowed border-neutral-700 bg-neutral-900 text-neutral-500"
-          : "border-amber-500/60 bg-neutral-900 text-amber-300 hover:border-amber-400 hover:text-amber-200")
+          ? "cursor-not-allowed border-soleur-border-default bg-soleur-bg-surface-1 text-soleur-text-muted"
+          : "border-soleur-border-emphasized bg-soleur-bg-surface-1 text-soleur-accent-gold-fg hover:border-amber-400 hover:text-soleur-accent-gold-text")
       }
     >
       <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -231,7 +231,7 @@ export function SelectionToolbar({
       Quote in chat
       <span
         aria-hidden="true"
-        className="ml-1 rounded border border-neutral-700 bg-neutral-800 px-1 py-0.5 text-[10px] text-neutral-400"
+        className="ml-1 rounded border border-soleur-border-default bg-soleur-bg-surface-2 px-1 py-0.5 text-[10px] text-soleur-text-secondary"
       >
         ⌘⇧L
       </span>

--- a/apps/web-platform/components/kb/share-popover.tsx
+++ b/apps/web-platform/components/kb/share-popover.tsx
@@ -128,7 +128,7 @@ export function SharePopover({ documentPath }: SharePopoverProps) {
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        className="inline-flex items-center gap-1.5 rounded-lg border border-neutral-700 px-3 py-1.5 text-xs font-medium text-neutral-300 transition-colors hover:border-neutral-500 hover:text-white"
+        className="inline-flex items-center gap-1.5 rounded-lg border border-soleur-border-default px-3 py-1.5 text-xs font-medium text-soleur-text-secondary transition-colors hover:border-soleur-border-emphasized hover:text-soleur-text-primary"
       >
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="shrink-0">
           <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" strokeLinecap="round" strokeLinejoin="round" />
@@ -139,20 +139,20 @@ export function SharePopover({ documentPath }: SharePopoverProps) {
       </button>
 
       {open && (
-        <div className="absolute right-0 top-full z-50 mt-2 w-80 rounded-lg border border-neutral-700 bg-neutral-900 p-4 shadow-xl">
+        <div className="absolute right-0 top-full z-50 mt-2 w-80 rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1 p-4 shadow-xl">
           {state.status === "loading" && (
-            <p className="text-sm text-neutral-400">Loading...</p>
+            <p className="text-sm text-soleur-text-secondary">Loading...</p>
           )}
 
           {state.status === "idle" && (
             <div>
-              <p className="mb-3 text-sm text-neutral-300">
+              <p className="mb-3 text-sm text-soleur-text-secondary">
                 Generate a public link to share this document with anyone.
               </p>
               <button
                 type="button"
                 onClick={generateLink}
-                className="w-full rounded-lg bg-amber-500 px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-amber-400"
+                className="w-full rounded-lg bg-soleur-accent-gold-fill px-4 py-2 text-sm font-medium text-soleur-text-on-accent transition-colors hover:bg-amber-400"
               >
                 Generate link
               </button>
@@ -161,18 +161,18 @@ export function SharePopover({ documentPath }: SharePopoverProps) {
 
           {state.status === "active" && state.url && (
             <div>
-              <p className="mb-2 text-xs text-neutral-400">Share link</p>
+              <p className="mb-2 text-xs text-soleur-text-secondary">Share link</p>
               <div className="mb-3 flex items-center gap-2">
                 <input
                   type="text"
                   readOnly
                   value={state.url}
-                  className="flex-1 truncate rounded border border-neutral-700 bg-neutral-800 px-2 py-1.5 text-xs text-neutral-200"
+                  className="flex-1 truncate rounded border border-soleur-border-default bg-soleur-bg-surface-2 px-2 py-1.5 text-xs text-soleur-text-primary"
                 />
                 <button
                   type="button"
                   onClick={copyLink}
-                  className="shrink-0 rounded border border-neutral-600 px-3 py-1.5 text-xs text-neutral-300 transition-colors hover:border-neutral-400 hover:text-white"
+                  className="shrink-0 rounded border border-soleur-border-default px-3 py-1.5 text-xs text-soleur-text-secondary transition-colors hover:border-soleur-border-emphasized hover:text-soleur-text-primary"
                 >
                   {state.copied ? "Copied!" : "Copy"}
                 </button>
@@ -194,14 +194,14 @@ export function SharePopover({ documentPath }: SharePopoverProps) {
                     <button
                       type="button"
                       onClick={revokeLink}
-                      className="rounded bg-red-600 px-3 py-1 text-xs text-white hover:bg-red-500"
+                      className="rounded bg-red-600 px-3 py-1 text-xs text-soleur-text-on-accent hover:bg-red-500"
                     >
                       Revoke
                     </button>
                     <button
                       type="button"
                       onClick={() => setState((s) => ({ ...s, confirmRevoke: false }))}
-                      className="rounded border border-neutral-600 px-3 py-1 text-xs text-neutral-300 hover:border-neutral-400"
+                      className="rounded border border-soleur-border-default px-3 py-1 text-xs text-soleur-text-secondary hover:border-soleur-border-emphasized"
                     >
                       Cancel
                     </button>

--- a/apps/web-platform/components/kb/text-preview.tsx
+++ b/apps/web-platform/components/kb/text-preview.tsx
@@ -72,7 +72,7 @@ export function TextPreview({
   if (loading) {
     return (
       <div className="flex items-center justify-center p-8">
-        <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-600 border-t-amber-400" />
+        <div className="h-5 w-5 animate-spin rounded-full border-2 border-soleur-border-default border-t-amber-400" />
       </div>
     );
   }
@@ -85,17 +85,17 @@ export function TextPreview({
     <div className="flex flex-col gap-3 p-4">
       {showDownload && (
         <div className="flex items-center justify-between">
-          <span className="text-sm text-neutral-400">{filename}</span>
+          <span className="text-sm text-soleur-text-secondary">{filename}</span>
           <a
             href={src}
             download={filename}
-            className="rounded-md border border-neutral-700 px-3 py-1 text-xs text-neutral-300 hover:bg-neutral-800"
+            className="rounded-md border border-soleur-border-default px-3 py-1 text-xs text-soleur-text-secondary hover:bg-soleur-bg-surface-2"
           >
             Download
           </a>
         </div>
       )}
-      <pre className="max-h-[70vh] overflow-auto rounded-lg border border-neutral-800 bg-neutral-900/50 p-4 text-sm text-neutral-300">
+      <pre className="max-h-[70vh] overflow-auto rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1/50 p-4 text-sm text-soleur-text-secondary">
         {text}
       </pre>
     </div>

--- a/apps/web-platform/components/kb/unknown-error.tsx
+++ b/apps/web-platform/components/kb/unknown-error.tsx
@@ -2,7 +2,7 @@ export function UnknownError() {
   return (
     <div className="flex h-full items-center justify-center p-6">
       <div className="text-center">
-        <p className="text-sm text-neutral-400">
+        <p className="text-sm text-soleur-text-secondary">
           Unable to load your knowledge base. Please try again later.
         </p>
       </div>

--- a/apps/web-platform/components/kb/workspace-not-ready.tsx
+++ b/apps/web-platform/components/kb/workspace-not-ready.tsx
@@ -2,16 +2,16 @@ export function WorkspaceNotReady() {
   return (
     <div className="flex h-full items-center justify-center p-6">
       <div className="text-center">
-        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-neutral-800">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="animate-pulse text-amber-500">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-soleur-bg-surface-2">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="animate-pulse text-soleur-accent-gold-fg">
             <path d="M12 6v6l4 2" strokeLinecap="round" strokeLinejoin="round" />
             <circle cx="12" cy="12" r="10" />
           </svg>
         </div>
-        <h1 className="mb-2 font-serif text-lg font-medium text-white">
+        <h1 className="mb-2 font-serif text-lg font-medium text-soleur-text-primary">
           Setting Up Your Workspace
         </h1>
-        <p className="text-sm text-neutral-400">
+        <p className="text-sm text-soleur-text-secondary">
           Your workspace is being prepared. This usually takes a moment.
         </p>
       </div>

--- a/apps/web-platform/components/onboarding/naming-modal.tsx
+++ b/apps/web-platform/components/onboarding/naming-modal.tsx
@@ -28,15 +28,15 @@ export function NamingOnboardingModal({
   }
 
   return (
-    <div className="flex min-h-[100dvh] items-center justify-center bg-neutral-950 px-4">
+    <div className="flex min-h-[100dvh] items-center justify-center bg-soleur-bg-base px-4">
       <div className="w-full max-w-lg">
-        <div className="mb-2 text-center text-xs font-medium uppercase tracking-wider text-amber-500">
+        <div className="mb-2 text-center text-xs font-medium uppercase tracking-wider text-soleur-accent-gold-fg">
           Meet Your Team
         </div>
-        <h1 className="mb-2 text-center text-2xl font-semibold text-white">
+        <h1 className="mb-2 text-center text-2xl font-semibold text-soleur-text-primary">
           Want to Name Your Leaders?
         </h1>
-        <p className="mb-8 text-center text-sm text-neutral-400">
+        <p className="mb-8 text-center text-sm text-soleur-text-secondary">
           Give each domain leader a name that feels right to you. You can always
           change these later in Settings.
         </p>
@@ -45,7 +45,7 @@ export function NamingOnboardingModal({
           {ROUTABLE_DOMAIN_LEADERS.map((leader) => (
             <div key={leader.id} className="flex items-center gap-4">
               <LeaderAvatar leaderId={leader.id} size="lg" />
-              <span className="min-w-0 flex-1 text-sm text-neutral-300">
+              <span className="min-w-0 flex-1 text-sm text-soleur-text-secondary">
                 {leader.title}
               </span>
               <input
@@ -54,7 +54,7 @@ export function NamingOnboardingModal({
                 onChange={(e) => handleChange(leader.id, e.target.value)}
                 placeholder="Enter a name..."
                 maxLength={30}
-                className="w-40 rounded-lg border border-neutral-700 bg-neutral-800/50 px-3 py-2 text-sm text-white placeholder-neutral-500 outline-none transition-colors focus:border-amber-600"
+                className="w-40 rounded-lg border border-soleur-border-default bg-soleur-bg-surface-2/50 px-3 py-2 text-sm text-soleur-text-primary placeholder-soleur-text-muted outline-none transition-colors focus:border-soleur-border-emphasized"
               />
             </div>
           ))}
@@ -63,13 +63,13 @@ export function NamingOnboardingModal({
         <div className="mt-8 flex items-center justify-center gap-6">
           <button
             onClick={onSkip}
-            className="text-sm text-neutral-400 transition-colors hover:text-neutral-200"
+            className="text-sm text-soleur-text-secondary transition-colors hover:text-soleur-text-primary"
           >
             Skip for now
           </button>
           <button
             onClick={handleSave}
-            className="rounded-lg bg-amber-500 px-6 py-2.5 text-sm font-semibold text-neutral-900 transition-colors hover:bg-amber-400"
+            className="rounded-lg bg-soleur-accent-gold-fill px-6 py-2.5 text-sm font-semibold text-soleur-text-on-accent transition-colors hover:bg-soleur-accent-gold-text"
           >
             Save Names
           </button>

--- a/apps/web-platform/components/settings/connected-services-content.tsx
+++ b/apps/web-platform/components/settings/connected-services-content.tsx
@@ -83,20 +83,20 @@ function ProviderCard({
           ? error
             ? "border-red-900/50"
             : "border-amber-600/50"
-          : "border-neutral-800"
+          : "border-soleur-border-default"
       }`}
     >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <div
             className={`h-2 w-2 rounded-full ${
-              connected ? "bg-green-400" : "bg-neutral-600"
+              connected ? "bg-green-400" : "bg-soleur-bg-surface-2"
             }`}
           />
           <div>
-            <span className="text-sm font-medium text-white">{config.label}</span>
+            <span className="text-sm font-medium text-soleur-text-primary">{config.label}</span>
             {connected && validatedAt && (
-              <span className="ml-2 text-xs text-neutral-500">
+              <span className="ml-2 text-xs text-soleur-text-muted">
                 Connected {formatDate(validatedAt)}
               </span>
             )}
@@ -107,7 +107,7 @@ function ProviderCard({
             <>
               <button
                 onClick={() => setExpanded(!expanded)}
-                className="rounded-lg border border-neutral-700 px-3 py-1.5 text-xs font-medium text-neutral-300 transition-colors hover:border-neutral-600 hover:text-white"
+                className="rounded-lg border border-soleur-border-default px-3 py-1.5 text-xs font-medium text-soleur-text-secondary transition-colors hover:border-soleur-border-default hover:text-soleur-text-primary"
               >
                 Rotate
               </button>
@@ -122,7 +122,7 @@ function ProviderCard({
           ) : (
             <button
               onClick={() => setExpanded(!expanded)}
-              className="rounded-lg bg-amber-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-amber-500"
+              className="rounded-lg bg-soleur-accent-gold-fill px-3 py-1.5 text-xs font-medium text-soleur-text-on-accent transition-colors hover:opacity-90"
             >
               {expanded ? "Cancel" : "Connect"}
             </button>
@@ -135,7 +135,7 @@ function ProviderCard({
           <div>
             <label
               htmlFor={`token-${provider}`}
-              className="mb-1 block text-xs font-medium text-neutral-400"
+              className="mb-1 block text-xs font-medium text-soleur-text-secondary"
             >
               API Token
             </label>
@@ -148,10 +148,10 @@ function ProviderCard({
                 if (e.key === "Enter") handleSubmit();
               }}
               placeholder={`Paste your ${config.label} API token`}
-              className={`w-full rounded-lg border bg-neutral-900 px-3 py-2 text-sm text-white placeholder:text-neutral-600 focus:ring-1 ${
+              className={`w-full rounded-lg border bg-soleur-bg-surface-1 px-3 py-2 text-sm text-soleur-text-primary placeholder:text-soleur-text-muted focus:ring-1 ${
                 error
                   ? "border-red-800 focus:border-red-600 focus:ring-red-600"
-                  : "border-neutral-700 focus:border-amber-600 focus:ring-amber-600"
+                  : "border-soleur-border-default focus:border-soleur-border-emphasized focus:ring-soleur-border-emphasized"
               }`}
             />
           </div>
@@ -161,13 +161,13 @@ function ProviderCard({
             </p>
           )}
           <div className="flex items-center justify-between">
-            <p className="text-xs text-neutral-500">
+            <p className="text-xs text-soleur-text-muted">
               Token will be encrypted at rest and validated before saving.
             </p>
             <button
               onClick={handleSubmit}
               disabled={loading || !token.trim()}
-              className="rounded-lg bg-amber-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-amber-500 disabled:opacity-50"
+              className="rounded-lg bg-soleur-accent-gold-fill px-4 py-2 text-sm font-medium text-soleur-text-on-accent transition-colors hover:opacity-90 disabled:opacity-50"
             >
               {loading ? "Validating..." : "Save"}
             </button>
@@ -230,8 +230,8 @@ export function ConnectedServicesContent({ initialServices }: Props) {
   return (
     <div className="space-y-10">
       <div>
-        <h1 className="text-2xl font-bold text-white">Connected Services</h1>
-        <p className="mt-1 text-sm text-neutral-400">
+        <h1 className="text-2xl font-bold text-soleur-text-primary">Connected Services</h1>
+        <p className="mt-1 text-sm text-soleur-text-secondary">
           Manage API tokens for third-party services. Tokens are encrypted with
           AES-256-GCM and automatically available to your agent sessions.
         </p>
@@ -244,9 +244,9 @@ export function ConnectedServicesContent({ initialServices }: Props) {
         return (
           <section
             key={category}
-            className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-6"
+            className="rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1/50 p-6"
           >
-            <h2 className="mb-4 text-lg font-semibold text-white">
+            <h2 className="mb-4 text-lg font-semibold text-soleur-text-primary">
               {CATEGORY_LABELS[category]}
             </h2>
             <div className="space-y-3">

--- a/apps/web-platform/components/settings/delete-account-dialog.tsx
+++ b/apps/web-platform/components/settings/delete-account-dialog.tsx
@@ -62,13 +62,13 @@ export function DeleteAccountDialog({ userEmail }: DeleteAccountDialogProps) {
       <h3 className="mb-2 text-lg font-semibold text-red-400">
         Permanently delete your account
       </h3>
-      <p className="mb-4 text-sm text-neutral-400">
+      <p className="mb-4 text-sm text-soleur-text-secondary">
         This action cannot be undone. All your data, API keys, conversations,
         and workspace files will be permanently deleted.
       </p>
 
-      <label className="mb-2 block text-sm text-neutral-300">
-        Type <span className="font-mono text-white">{userEmail}</span> to
+      <label className="mb-2 block text-sm text-soleur-text-secondary">
+        Type <span className="font-mono text-soleur-text-primary">{userEmail}</span> to
         confirm:
       </label>
       <input
@@ -76,7 +76,7 @@ export function DeleteAccountDialog({ userEmail }: DeleteAccountDialogProps) {
         value={confirmEmail}
         onChange={(e) => setConfirmEmail(e.target.value)}
         placeholder={userEmail}
-        className="mb-4 w-full rounded-lg border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-white placeholder:text-neutral-400 focus:border-red-700 focus:outline-none focus:ring-1 focus:ring-red-700"
+        className="mb-4 w-full rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1 px-3 py-2 text-sm text-soleur-text-primary placeholder:text-soleur-text-muted focus:border-red-700 focus:outline-none focus:ring-1 focus:ring-red-700"
         autoComplete="off"
         spellCheck={false}
       />
@@ -90,7 +90,7 @@ export function DeleteAccountDialog({ userEmail }: DeleteAccountDialogProps) {
           type="button"
           onClick={handleDelete}
           disabled={!emailMatches || isDeleting}
-          className="rounded-lg bg-red-700 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-600 disabled:cursor-not-allowed disabled:opacity-50"
+          className="rounded-lg bg-red-700 px-4 py-2 text-sm font-medium text-soleur-text-on-accent transition-colors hover:bg-red-600 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {isDeleting ? "Deleting..." : "Confirm Deletion"}
         </button>
@@ -101,7 +101,7 @@ export function DeleteAccountDialog({ userEmail }: DeleteAccountDialogProps) {
             setConfirmEmail("");
             setError(null);
           }}
-          className="rounded-lg border border-neutral-700 px-4 py-2 text-sm text-neutral-400 transition-colors hover:bg-neutral-800 hover:text-white"
+          className="rounded-lg border border-soleur-border-default px-4 py-2 text-sm text-soleur-text-secondary transition-colors hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary"
         >
           Cancel
         </button>

--- a/apps/web-platform/components/settings/disconnect-repo-dialog.tsx
+++ b/apps/web-platform/components/settings/disconnect-repo-dialog.tsx
@@ -42,7 +42,7 @@ export function DisconnectRepoDialog({ repoName }: DisconnectRepoDialogProps) {
       <button
         type="button"
         onClick={() => setIsOpen(true)}
-        className="rounded-lg border border-neutral-700 px-4 py-2 text-sm font-medium text-neutral-400 transition-colors hover:bg-neutral-800 hover:text-white"
+        className="rounded-lg border border-soleur-border-default px-4 py-2 text-sm font-medium text-soleur-text-secondary transition-colors hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary"
       >
         Disconnect
       </button>
@@ -50,12 +50,12 @@ export function DisconnectRepoDialog({ repoName }: DisconnectRepoDialogProps) {
   }
 
   return (
-    <div className="rounded-xl border border-neutral-700/50 bg-neutral-900/50 p-6">
-      <h3 className="mb-2 text-lg font-semibold text-white">
+    <div className="rounded-xl border border-soleur-border-default/50 bg-soleur-bg-surface-1/50 p-6">
+      <h3 className="mb-2 text-lg font-semibold text-soleur-text-primary">
         Disconnect repository
       </h3>
-      <p className="mb-4 text-sm text-neutral-400">
-        This will unlink <span className="font-mono text-white">{repoName}</span>{" "}
+      <p className="mb-4 text-sm text-soleur-text-secondary">
+        This will unlink <span className="font-mono text-soleur-text-primary">{repoName}</span>{" "}
         from your account. Your workspace files will be removed. You can reconnect
         a repository at any time.
       </p>
@@ -69,7 +69,7 @@ export function DisconnectRepoDialog({ repoName }: DisconnectRepoDialogProps) {
           type="button"
           onClick={handleDisconnect}
           disabled={isDisconnecting}
-          className="rounded-lg border border-neutral-700 bg-neutral-800 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-neutral-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="rounded-lg border border-soleur-border-default bg-soleur-bg-surface-2 px-4 py-2 text-sm font-medium text-soleur-text-primary transition-colors hover:bg-soleur-bg-surface-2 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {isDisconnecting ? "Disconnecting..." : "Confirm Disconnect"}
         </button>
@@ -79,7 +79,7 @@ export function DisconnectRepoDialog({ repoName }: DisconnectRepoDialogProps) {
             setIsOpen(false);
             setError(null);
           }}
-          className="rounded-lg border border-neutral-700 px-4 py-2 text-sm text-neutral-400 transition-colors hover:bg-neutral-800 hover:text-white"
+          className="rounded-lg border border-soleur-border-default px-4 py-2 text-sm text-soleur-text-secondary transition-colors hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary"
         >
           Cancel
         </button>

--- a/apps/web-platform/components/settings/project-setup-card.tsx
+++ b/apps/web-platform/components/settings/project-setup-card.tsx
@@ -26,17 +26,17 @@ export function ProjectSetupCard({
 }: ProjectSetupCardProps) {
   return (
     <section>
-      <h2 className="mb-4 text-lg font-semibold text-white">Project</h2>
-      <div className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-6">
+      <h2 className="mb-4 text-lg font-semibold text-soleur-text-primary">Project</h2>
+      <div className="rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1/50 p-6">
         {repoStatus === "not_connected" && (
           <div>
-            <p className="mb-4 text-sm text-neutral-400">
+            <p className="mb-4 text-sm text-soleur-text-secondary">
               Connect a GitHub project so your AI team has full context on your
               codebase.
             </p>
             <a
               href="/connect-repo?return_to=/dashboard/settings"
-              className="inline-block rounded-lg bg-white px-4 py-2 text-sm font-medium text-neutral-900 transition-colors hover:bg-neutral-200"
+              className="inline-block rounded-lg bg-soleur-accent-gold-fill px-4 py-2 text-sm font-medium text-soleur-text-on-accent transition-colors hover:opacity-90"
             >
               Set Up Project
             </a>
@@ -47,7 +47,7 @@ export function ProjectSetupCard({
           <div className="space-y-4">
             <div className="space-y-1">
               <div className="flex items-center gap-2">
-                <p className="text-sm font-medium text-white">
+                <p className="text-sm font-medium text-soleur-text-primary">
                   {extractRepoName(repoUrl)}
                 </p>
                 <span className="rounded-full bg-green-900/50 px-2 py-0.5 text-xs font-medium text-green-400">
@@ -55,7 +55,7 @@ export function ProjectSetupCard({
                 </span>
               </div>
               {repoLastSyncedAt && (
-                <p className="text-sm text-neutral-400">
+                <p className="text-sm text-soleur-text-secondary">
                   Last synced:{" "}
                   {new Date(repoLastSyncedAt).toLocaleDateString()}
                 </p>
@@ -81,8 +81,8 @@ export function ProjectSetupCard({
 
         {repoStatus === "cloning" && (
           <div className="flex items-center gap-2">
-            <div className="h-4 w-4 animate-spin rounded-full border-2 border-neutral-600 border-t-white" />
-            <p className="text-sm text-neutral-400">Setting up your project...</p>
+            <div className="h-4 w-4 animate-spin rounded-full border-2 border-soleur-border-default border-t-soleur-text-primary" />
+            <p className="text-sm text-soleur-text-secondary">Setting up your project...</p>
           </div>
         )}
       </div>

--- a/apps/web-platform/components/settings/settings-content.tsx
+++ b/apps/web-platform/components/settings/settings-content.tsx
@@ -23,15 +23,15 @@ export function SettingsContent({
 }: SettingsContentProps) {
   return (
     <div className="space-y-10">
-      <h1 className="mb-8 text-2xl font-semibold text-white">Settings</h1>
+      <h1 className="mb-8 text-2xl font-semibold text-soleur-text-primary">Settings</h1>
 
       {/* Account Section */}
       <section>
-        <h2 className="mb-4 text-lg font-semibold text-white">Account</h2>
-        <div className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-6">
+        <h2 className="mb-4 text-lg font-semibold text-soleur-text-primary">Account</h2>
+        <div className="rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1/50 p-6">
           <div className="space-y-1">
-            <p className="text-sm text-neutral-400">Email</p>
-            <p className="text-sm font-medium text-white">{userEmail}</p>
+            <p className="text-sm text-soleur-text-secondary">Email</p>
+            <p className="text-sm font-medium text-soleur-text-primary">{userEmail}</p>
           </div>
         </div>
       </section>
@@ -45,27 +45,27 @@ export function SettingsContent({
 
       {/* API Key Section */}
       <section>
-        <h2 className="mb-4 text-lg font-semibold text-white">API Key</h2>
-        <div className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-6">
+        <h2 className="mb-4 text-lg font-semibold text-soleur-text-primary">API Key</h2>
+        <div className="rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1/50 p-6">
           {/* Key status */}
           <div className="mb-6">
             {hasApiKey ? (
               <div className="space-y-1">
-                <p className="text-sm text-neutral-300">
+                <p className="text-sm text-soleur-text-secondary">
                   Provider:{" "}
-                  <span className="font-medium text-white capitalize">
+                  <span className="font-medium text-soleur-text-primary capitalize">
                     {apiKeyProvider}
                   </span>
                 </p>
                 {apiKeyLastValidated && (
-                  <p className="text-sm text-neutral-400">
+                  <p className="text-sm text-soleur-text-secondary">
                     Last validated:{" "}
                     {new Date(apiKeyLastValidated).toLocaleDateString()}
                   </p>
                 )}
               </div>
             ) : (
-              <p className="text-sm text-neutral-400">No key configured</p>
+              <p className="text-sm text-soleur-text-secondary">No key configured</p>
             )}
           </div>
 
@@ -76,8 +76,8 @@ export function SettingsContent({
       {/* Danger Zone Section */}
       <section>
         <h2 className="mb-4 text-lg font-semibold text-red-400">Danger Zone</h2>
-        <div className="rounded-xl border border-red-900/30 bg-neutral-900/50 p-6">
-          <p className="mb-4 text-sm text-neutral-400">
+        <div className="rounded-xl border border-red-900/30 bg-soleur-bg-surface-1/50 p-6">
+          <p className="mb-4 text-sm text-soleur-text-secondary">
             Permanently delete your account and all associated data. This action
             is irreversible and complies with GDPR Article 17 (Right to Erasure).
           </p>

--- a/apps/web-platform/components/settings/settings-shell.tsx
+++ b/apps/web-platform/components/settings/settings-shell.tsx
@@ -35,18 +35,18 @@ export function SettingsShell({ children }: { children: React.ReactNode }) {
       {/* Settings sidebar — hidden on mobile, shown on md+ */}
       <nav
         inert={settingsCollapsed || undefined}
-        className={`hidden shrink-0 border-r border-neutral-800 md:block
+        className={`hidden shrink-0 border-r border-soleur-border-default md:block
         md:transition-[width] md:duration-200 md:ease-out
         ${settingsCollapsed ? "md:w-0 md:overflow-hidden md:border-r-0" : "w-48 px-4 py-5"}`}>
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-xs font-medium uppercase tracking-wider text-neutral-500">
+          <h2 className="text-xs font-medium uppercase tracking-wider text-soleur-text-muted">
             Settings
           </h2>
           <button
             onClick={toggleSettingsCollapsed}
             aria-label="Collapse settings nav"
             title="Collapse settings nav (⌘B)"
-            className="flex h-6 w-6 items-center justify-center rounded text-neutral-400 hover:bg-neutral-800 hover:text-white"
+            className="flex h-6 w-6 items-center justify-center rounded text-soleur-text-secondary hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary"
           >
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
@@ -66,8 +66,8 @@ export function SettingsShell({ children }: { children: React.ReactNode }) {
                   href={tab.href}
                   className={`block rounded-lg px-3 py-2 text-sm transition-colors ${
                     active
-                      ? "bg-neutral-800 text-white font-medium"
-                      : "text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-200"
+                      ? "bg-soleur-bg-surface-2 text-soleur-text-primary font-medium"
+                      : "text-soleur-text-secondary hover:bg-soleur-bg-surface-2/50 hover:text-soleur-text-primary"
                   }`}
                 >
                   {tab.label}
@@ -79,7 +79,7 @@ export function SettingsShell({ children }: { children: React.ReactNode }) {
       </nav>
 
       {/* Mobile tab bar */}
-      <div className="fixed bottom-0 left-0 right-0 z-40 flex border-t border-neutral-800 bg-neutral-900 safe-bottom md:hidden">
+      <div className="fixed bottom-0 left-0 right-0 z-40 flex border-t border-soleur-border-default bg-soleur-bg-surface-1 safe-bottom md:hidden">
         {SETTINGS_TABS.map((tab) => {
           const active =
             tab.href === "/dashboard/settings"
@@ -91,7 +91,7 @@ export function SettingsShell({ children }: { children: React.ReactNode }) {
               key={tab.href}
               href={tab.href}
               className={`flex-1 py-3 text-center text-xs font-medium transition-colors ${
-                active ? "text-white" : "text-neutral-500"
+                active ? "text-soleur-text-primary" : "text-soleur-text-muted"
               }`}
             >
               {tab.label}
@@ -107,7 +107,7 @@ export function SettingsShell({ children }: { children: React.ReactNode }) {
             onClick={toggleSettingsCollapsed}
             aria-label="Expand settings nav"
             title="Expand settings nav (⌘B)"
-            className="absolute left-2 top-5 z-10 hidden md:flex h-6 w-6 items-center justify-center rounded text-neutral-400 hover:bg-neutral-800 hover:text-white"
+            className="absolute left-2 top-5 z-10 hidden md:flex h-6 w-6 items-center justify-center rounded text-soleur-text-secondary hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary"
           >
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
               <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />

--- a/apps/web-platform/components/settings/team-settings.tsx
+++ b/apps/web-platform/components/settings/team-settings.tsx
@@ -17,18 +17,18 @@ export function TeamSettingsContent() {
   if (loading) {
     return (
       <div className="flex h-64 items-center justify-center">
-        <span className="text-sm text-neutral-400">Loading team...</span>
+        <span className="text-sm text-soleur-text-secondary">Loading team...</span>
       </div>
     );
   }
 
   return (
     <div>
-      <div className="mb-1 text-xs font-medium uppercase tracking-wider text-amber-500">
+      <div className="mb-1 text-xs font-medium uppercase tracking-wider text-soleur-accent-gold-fg">
         Your Team
       </div>
-      <h1 className="mb-2 text-2xl font-semibold text-white">Domain Leaders</h1>
-      <p className="mb-8 text-sm text-neutral-400">
+      <h1 className="mb-2 text-2xl font-semibold text-soleur-text-primary">Domain Leaders</h1>
+      <p className="mb-8 text-sm text-soleur-text-secondary">
         Give your leaders custom names and icons. Names display as &quot;Name (Role)&quot; across conversations and mentions.
       </p>
 
@@ -47,7 +47,7 @@ export function TeamSettingsContent() {
         ))}
       </div>
 
-      <p className="mt-6 text-xs text-neutral-500">Changes save automatically</p>
+      <p className="mt-6 text-xs text-soleur-text-muted">Changes save automatically</p>
     </div>
   );
 }
@@ -171,7 +171,7 @@ function LeaderRow({
       <button
         type="button"
         onClick={handleAvatarClick}
-        className="relative shrink-0 cursor-pointer rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500"
+        className="relative shrink-0 cursor-pointer rounded-lg focus:outline-none focus:ring-2 focus:ring-soleur-border-emphasized"
         aria-label={`${name} avatar — click to upload custom icon`}
       >
         <LeaderAvatar leaderId={leaderId} size="lg" customIconPath={customIconPath} />
@@ -192,13 +192,13 @@ function LeaderRow({
         <button
           type="button"
           onClick={handleReset}
-          className="shrink-0 text-xs text-neutral-500 hover:text-neutral-300"
+          className="shrink-0 text-xs text-soleur-text-muted hover:text-soleur-text-secondary"
           aria-label={`Reset ${name} icon to default`}
         >
           Reset
         </button>
       )}
-      <span className="min-w-0 flex-1 text-sm text-neutral-300">{title}</span>
+      <span className="min-w-0 flex-1 text-sm text-soleur-text-secondary">{title}</span>
       <div className="w-48">
         <input
           type="text"
@@ -206,8 +206,8 @@ function LeaderRow({
           onChange={handleChange}
           placeholder="Enter a name..."
           maxLength={30}
-          className={`w-full rounded-lg border bg-neutral-800/50 px-3 py-2 text-sm text-white placeholder-neutral-500 outline-none transition-colors focus:border-amber-600 ${
-            error ? "border-red-500" : "border-neutral-700"
+          className={`w-full rounded-lg border bg-soleur-bg-surface-2/50 px-3 py-2 text-sm text-soleur-text-primary placeholder:text-soleur-text-muted outline-none transition-colors focus:border-soleur-border-emphasized ${
+            error ? "border-red-500" : "border-soleur-border-default"
           }`}
         />
         {error && <p className="mt-1 text-xs text-red-400">{error}</p>}

--- a/apps/web-platform/components/shared/cta-banner.tsx
+++ b/apps/web-platform/components/shared/cta-banner.tsx
@@ -19,24 +19,24 @@ export function CtaBanner() {
   }
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-40 border-t border-neutral-800 bg-neutral-900/95 px-4 py-3 backdrop-blur-sm">
+    <div className="fixed bottom-0 left-0 right-0 z-40 border-t border-soleur-border-default bg-soleur-bg-surface-1/95 px-4 py-3 backdrop-blur-sm">
       <div className="mx-auto flex max-w-3xl items-center justify-between gap-4">
-        <p className="text-sm text-neutral-300">
+        <p className="text-sm text-soleur-text-secondary">
           This document was created with{" "}
-          <span className="font-medium text-amber-400">Soleur</span> — AI
+          <span className="font-medium text-soleur-accent-gold-fg">Soleur</span> — AI
           agents for every department of your startup.
         </p>
         <div className="flex shrink-0 items-center gap-2">
           <Link
             href="/signup"
-            className="rounded-lg bg-amber-500 px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-amber-400"
+            className="rounded-lg bg-soleur-accent-gold-fill px-4 py-2 text-sm font-medium text-soleur-text-on-accent transition-colors hover:bg-amber-400"
           >
             Create your account
           </Link>
           <button
             type="button"
             onClick={handleDismiss}
-            className="rounded p-1 text-neutral-500 transition-colors hover:text-neutral-300"
+            className="rounded p-1 text-soleur-text-muted transition-colors hover:text-soleur-text-secondary"
             aria-label="Dismiss signup banner"
             data-testid="cta-banner-dismiss"
           >

--- a/apps/web-platform/components/ui/card.tsx
+++ b/apps/web-platform/components/ui/card.tsx
@@ -1,6 +1,6 @@
 export function Card({ children, className }: { children: React.ReactNode; className?: string }) {
   return (
-    <div className={`rounded-xl border border-neutral-800 bg-neutral-900/50 p-6 ${className ?? ""}`}>
+    <div className={`rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1/50 p-6 ${className ?? ""}`}>
       {children}
     </div>
   );

--- a/apps/web-platform/components/ui/error-card.tsx
+++ b/apps/web-platform/components/ui/error-card.tsx
@@ -12,12 +12,12 @@ export function ErrorCard({ title, message, onRetry, retryLabel = "Try again", a
   return (
     <div role="alert" className="rounded-xl border border-red-900/50 bg-red-950/20 p-5">
       <h3 className="mb-1 text-sm font-semibold text-red-300">{title}</h3>
-      <p className="text-sm text-neutral-400">{message}</p>
+      <p className="text-sm text-soleur-text-secondary">{message}</p>
       <div className="mt-3 flex gap-2">
         {onRetry && (
           <button
             onClick={onRetry}
-            className="rounded-lg border border-neutral-700 px-3 py-1.5 text-sm text-neutral-300 transition-colors hover:border-neutral-500 hover:text-white"
+            className="rounded-lg border border-soleur-border-default px-3 py-1.5 text-sm text-soleur-text-secondary transition-colors hover:border-soleur-border-default hover:text-soleur-text-primary"
           >
             {retryLabel}
           </button>
@@ -25,7 +25,7 @@ export function ErrorCard({ title, message, onRetry, retryLabel = "Try again", a
         {action && (
           <a
             href={action.href}
-            className="rounded-lg border border-neutral-700 px-3 py-1.5 text-sm text-neutral-300 transition-colors hover:border-neutral-500 hover:text-white"
+            className="rounded-lg border border-soleur-border-default px-3 py-1.5 text-sm text-soleur-text-secondary transition-colors hover:border-soleur-border-default hover:text-soleur-text-primary"
           >
             {action.label}
           </a>

--- a/apps/web-platform/components/ui/markdown-renderer.tsx
+++ b/apps/web-platform/components/ui/markdown-renderer.tsx
@@ -19,13 +19,13 @@ interface BuildOptions {
 function buildComponents({ linkRel, preWrap }: BuildOptions): Components {
   return {
     h1: ({ children }) => (
-      <h1 className="mb-3 mt-4 text-lg font-semibold text-white">{children}</h1>
+      <h1 className="mb-3 mt-4 text-lg font-semibold text-soleur-text-primary">{children}</h1>
     ),
     h2: ({ children }) => (
-      <h2 className="mb-2 mt-3 text-base font-semibold text-white">{children}</h2>
+      <h2 className="mb-2 mt-3 text-base font-semibold text-soleur-text-primary">{children}</h2>
     ),
     h3: ({ children }) => (
-      <h3 className="mb-2 mt-3 text-sm font-semibold text-neutral-200">{children}</h3>
+      <h3 className="mb-2 mt-3 text-sm font-semibold text-soleur-text-primary">{children}</h3>
     ),
     p: ({ children }) => (
       <p className="mb-2 leading-relaxed">{children}</p>
@@ -37,7 +37,7 @@ function buildComponents({ linkRel, preWrap }: BuildOptions): Components {
       <ol className="mb-2 ml-4 list-decimal space-y-1">{children}</ol>
     ),
     li: ({ children }) => (
-      <li className="text-neutral-200">{children}</li>
+      <li className="text-soleur-text-secondary">{children}</li>
     ),
     table: ({ children }) => (
       <div className="mb-3 overflow-x-auto">
@@ -45,7 +45,7 @@ function buildComponents({ linkRel, preWrap }: BuildOptions): Components {
       </div>
     ),
     th: ({ children }) => (
-      <th className="whitespace-nowrap border border-neutral-700 bg-neutral-800/50 px-3 py-1.5 text-left font-semibold text-neutral-200">
+      <th className="whitespace-nowrap border border-soleur-border-default bg-soleur-bg-surface-2/50 px-3 py-1.5 text-left font-semibold text-soleur-text-primary">
         {children}
       </th>
     ),
@@ -53,14 +53,14 @@ function buildComponents({ linkRel, preWrap }: BuildOptions): Components {
     // readable line so a single long-paragraph cell doesn't blow out the table.
     // Header may exceed 40ch (whitespace-nowrap on th wins) by design.
     td: ({ children }) => (
-      <td className="min-w-[8ch] max-w-[40ch] border border-neutral-700 px-3 py-1.5 align-top text-neutral-300">{children}</td>
+      <td className="min-w-[8ch] max-w-[40ch] border border-soleur-border-default px-3 py-1.5 align-top text-soleur-text-secondary">{children}</td>
     ),
     pre: ({ children }) => (
       <pre
         className={
           preWrap
-            ? "mb-3 min-w-0 whitespace-pre-wrap break-words rounded-lg bg-neutral-950 p-3 text-xs text-neutral-300 [overflow-wrap:anywhere]"
-            : "mb-3 overflow-x-auto rounded-lg bg-neutral-950 p-3 text-xs text-neutral-300"
+            ? "mb-3 min-w-0 whitespace-pre-wrap break-words rounded-lg bg-soleur-bg-base p-3 text-xs text-soleur-text-secondary [overflow-wrap:anywhere]"
+            : "mb-3 overflow-x-auto rounded-lg bg-soleur-bg-base p-3 text-xs text-soleur-text-secondary"
         }
       >
         {children}
@@ -71,18 +71,18 @@ function buildComponents({ linkRel, preWrap }: BuildOptions): Components {
       return isBlock ? (
         <code className={className}>{children}</code>
       ) : (
-        <code className="rounded bg-neutral-800 px-1.5 py-0.5 text-xs text-amber-300">{children}</code>
+        <code className="rounded bg-soleur-bg-surface-2 px-1.5 py-0.5 text-xs text-soleur-accent-gold-fg">{children}</code>
       );
     },
     strong: ({ children }) => (
-      <strong className="font-semibold text-white">{children}</strong>
+      <strong className="font-semibold text-soleur-text-primary">{children}</strong>
     ),
     a: ({ href, children }) => (
       <a href={href} target="_blank" rel={linkRel}
-        className="text-amber-400 underline hover:text-amber-300">{children}</a>
+        className="text-soleur-accent-gold-fg underline hover:text-soleur-accent-gold-text">{children}</a>
     ),
     blockquote: ({ children }) => (
-      <blockquote className="mb-2 border-l-2 border-neutral-600 pl-3 italic text-neutral-400">
+      <blockquote className="mb-2 border-l-2 border-soleur-border-default pl-3 italic text-soleur-text-muted">
         {children}
       </blockquote>
     ),

--- a/apps/web-platform/components/ui/outlined-button.tsx
+++ b/apps/web-platform/components/ui/outlined-button.tsx
@@ -11,7 +11,7 @@ export function OutlinedButton({
     <button
       type="button"
       onClick={onClick}
-      className="rounded-lg border border-neutral-700 bg-transparent px-6 py-3 text-sm font-medium text-neutral-200 transition-colors hover:bg-neutral-800"
+      className="rounded-lg border border-soleur-border-default bg-transparent px-6 py-3 text-sm font-medium text-soleur-text-primary transition-colors hover:bg-soleur-bg-surface-2"
     >
       {children}
     </button>

--- a/apps/web-platform/components/ui/sheet.tsx
+++ b/apps/web-platform/components/ui/sheet.tsx
@@ -51,13 +51,13 @@ export function Sheet({
   const vh = typeof window !== "undefined" ? window.innerHeight : 800;
 
   const desktopClasses =
-    "z-40 flex h-full w-[380px] shrink-0 flex-col border-l border-neutral-800 bg-neutral-950 shadow-2xl";
+    "z-40 flex h-full w-[380px] shrink-0 flex-col border-l border-soleur-border-default bg-soleur-bg-base shadow-2xl";
 
   const mobileHeight =
     dragHeight !== null ? dragHeight : Math.round(vh * MOBILE_HEIGHT_VH);
 
   const mobileClasses =
-    "fixed bottom-0 left-0 right-0 z-40 flex flex-col rounded-t-2xl border-t border-neutral-800 bg-neutral-950 shadow-2xl";
+    "fixed bottom-0 left-0 right-0 z-40 flex flex-col rounded-t-2xl border-t border-soleur-border-default bg-soleur-bg-base shadow-2xl";
 
   function onPointerDown(e: React.PointerEvent<HTMLButtonElement>) {
     if (isDesktop) return;
@@ -105,7 +105,7 @@ export function Sheet({
           type="button"
           aria-label="Resize panel"
           title="Drag to close"
-          className="mx-auto mt-2 h-1.5 w-10 shrink-0 rounded-full bg-neutral-700 touch-none"
+          className="mx-auto mt-2 h-1.5 w-10 shrink-0 rounded-full bg-soleur-bg-surface-2 touch-none"
           onPointerDown={onPointerDown}
           onPointerMove={onPointerMove}
           onPointerUp={onPointerUp}

--- a/apps/web-platform/public/sw.js
+++ b/apps/web-platform/public/sw.js
@@ -1,7 +1,7 @@
 // Bumping the suffix triggers the activate handler's cache cleanup, which
 // purges _next/static/** chunks cached against an old project ref. Keep
 // push-notification subscriptions intact (registration is unchanged).
-const CACHE_NAME = "soleur-app-shell-v5";
+const CACHE_NAME = "soleur-app-shell-v6";
 
 // Static shell assets cached on install (non-hashed assets only).
 // _next/static/** are cached on fetch via cache-first strategy.

--- a/apps/web-platform/test/light-theme-tokenization.test.tsx
+++ b/apps/web-platform/test/light-theme-tokenization.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = resolve(__dirname, "..");
+
+// Files that legitimately retain literal Tailwind grays/colors.
+// Each entry MUST cite a one-line reason — reviewer reviews each entry.
+const ALLOWLIST = new Set<string>([
+  "components/chat/leader-colors.ts", // Domain-leader identity palette (cross-theme).
+  "components/chat/status-indicator.tsx", // Status semantics (red/orange/green).
+]);
+
+// Surfaces that must consume Soleur tokens after the light-theme migration.
+// Representative sampling across Group A–F (chat, KB, settings, connect-repo, dashboard, UI primitives).
+const SURFACE_GROUPS: readonly string[] = [
+  // Group A — Chat
+  "components/chat/chat-surface.tsx",
+  "components/chat/interactive-prompt-card.tsx",
+  "components/chat/message-bubble.tsx",
+  "components/chat/chat-input.tsx",
+  "components/chat/at-mention-dropdown.tsx",
+  "components/chat/workflow-lifecycle-bar.tsx",
+  "components/chat/subagent-group.tsx",
+  "components/chat/notification-prompt.tsx",
+  "components/chat/review-gate-card.tsx",
+  "components/chat/pwa-install-banner.tsx",
+  "components/chat/attachment-display.tsx",
+  "components/chat/welcome-card.tsx",
+  "components/chat/naming-nudge.tsx",
+  "components/chat/kb-chat-content.tsx",
+  "components/chat/tool-use-chip.tsx",
+  "components/chat/routed-leaders-strip.tsx",
+
+  // Group B — KB
+  "components/kb/file-tree.tsx",
+  "components/kb/pdf-preview.tsx",
+  "components/kb/share-popover.tsx",
+  "components/kb/search-overlay.tsx",
+  "components/kb/kb-desktop-layout.tsx",
+  "components/kb/text-preview.tsx",
+  "components/kb/no-project-state.tsx",
+  "components/kb/file-preview.tsx",
+  "components/kb/empty-state.tsx",
+  "components/kb/download-preview.tsx",
+  "components/kb/workspace-not-ready.tsx",
+  "components/kb/selection-toolbar.tsx",
+  "components/kb/loading-skeleton.tsx",
+  "components/kb/kb-content-header.tsx",
+  "components/kb/desktop-placeholder.tsx",
+
+  // Group C — Settings
+  "components/settings/connected-services-content.tsx",
+  "components/settings/settings-content.tsx",
+  "components/settings/team-settings.tsx",
+  "components/settings/settings-shell.tsx",
+  "components/settings/project-setup-card.tsx",
+  "components/settings/disconnect-repo-dialog.tsx",
+  "components/settings/delete-account-dialog.tsx",
+
+  // Group D — Connect-repo / onboarding
+  "components/connect-repo/select-project-state.tsx",
+  "components/connect-repo/ready-state.tsx",
+  "components/connect-repo/create-project-state.tsx",
+  "components/connect-repo/github-redirect-state.tsx",
+  "components/connect-repo/choose-state.tsx",
+  "components/connect-repo/setting-up-state.tsx",
+  "components/connect-repo/github-resolve-state.tsx",
+  "components/connect-repo/failed-state.tsx",
+  "components/connect-repo/no-projects-state.tsx",
+  "components/connect-repo/interrupted-state.tsx",
+  "components/onboarding/naming-modal.tsx",
+
+  // Group E — Dashboard / analytics / inbox / share
+  "app/(dashboard)/dashboard/page.tsx",
+  "components/analytics/analytics-dashboard.tsx",
+  "components/inbox/conversation-row.tsx",
+  "components/dashboard/foundation-cards.tsx",
+  "app/shared/[token]/page.tsx",
+
+  // Group F — UI primitives + global-error
+  "components/ui/markdown-renderer.tsx",
+  "components/ui/sheet.tsx",
+  "components/ui/error-card.tsx",
+  "components/ui/outlined-button.tsx",
+  "components/ui/card.tsx",
+  "components/error-boundary-view.tsx",
+  "app/global-error.tsx",
+];
+
+// Hardcoded Tailwind gray/text-white classes that should not appear on tokenized surfaces.
+// `\b(bg|text|border)-` deliberately scoped so it doesn't false-match `border-l-pink-500`
+// (leader-colors palette) or status colors (`bg-red-600`, `text-orange-400`).
+const HARDCODED =
+  /\b(?:bg|text|border)-(?:zinc|slate|neutral|stone|gray)-\d+|\btext-white\b/;
+
+// Soleur token namespace — at least one occurrence required per migrated file.
+const TOKENIZED = /\bsoleur-(?:bg|text|border|accent)-/;
+
+describe("light-theme tokenization regression", () => {
+  for (const rel of SURFACE_GROUPS) {
+    if (ALLOWLIST.has(rel)) continue;
+
+    it(`${rel} contains no hardcoded gray classes`, () => {
+      const src = readFileSync(resolve(ROOT, rel), "utf8");
+      expect(src).not.toMatch(HARDCODED);
+    });
+
+    it(`${rel} consumes Soleur tokens`, () => {
+      const src = readFileSync(resolve(ROOT, rel), "utf8");
+      expect(src).toMatch(TOKENIZED);
+    });
+  }
+});

--- a/apps/web-platform/test/tool-use-chip.test.tsx
+++ b/apps/web-platform/test/tool-use-chip.test.tsx
@@ -31,7 +31,7 @@ describe("ToolUseChip", () => {
       <ToolUseChip toolName="Bash" toolLabel="Bootstrap" leaderId="system" />,
     );
     const chip = container.querySelector("[data-tool-chip-id]");
-    expect(chip?.className ?? "").toMatch(/border-neutral/);
+    expect(chip?.className ?? "").toMatch(/border-l-neutral/);
   });
 
   test("multiple chips coexist when rendered together", () => {

--- a/knowledge-base/project/learnings/2026-05-06-token-on-accent-vs-text-primary-on-status-backgrounds.md
+++ b/knowledge-base/project/learnings/2026-05-06-token-on-accent-vs-text-primary-on-status-backgrounds.md
@@ -1,0 +1,88 @@
+---
+title: text-soleur-text-on-accent vs text-soleur-text-primary on status backgrounds
+date: 2026-05-06
+category: best-practices
+tags: [tokenization, light-theme, contrast, parallel-agents, migration]
+related_pr: "#3308"
+related_pr_parent: "#3271"
+---
+
+# text-soleur-text-on-accent vs text-soleur-text-primary on status backgrounds
+
+## Problem
+
+When migrating Tailwind hardcoded grays to Soleur design tokens, three of six parallel migration agents (Groups A, B, C of PR #3308) independently produced the same wrong mapping for `text-white` on status/brand-color backgrounds:
+
+```tsx
+// Wrong (low contrast in light theme)
+className="rounded-lg bg-amber-600 ... text-soleur-text-primary"
+className="rounded bg-red-700 ... text-soleur-text-primary"
+className="rounded-lg bg-blue-600 ... text-soleur-text-primary"
+```
+
+`text-soleur-text-primary` resolves to **dark text in light theme** (intended for body content on light surfaces). Pairing it with a saturated status background produces dark-on-color, which fails the original `text-white` contrast intent.
+
+Six sites across four files needed post-hoc fixing:
+
+- `components/chat/welcome-card.tsx` (avatar)
+- `components/chat/workflow-lifecycle-bar.tsx` (Start new conversation CTA)
+- `components/chat/interactive-prompt-card.tsx` (×3 CTAs)
+- `components/chat/chat-input.tsx` (send button)
+- `components/kb/share-popover.tsx` (Revoke destructive)
+- `components/settings/delete-account-dialog.tsx` (Confirm Deletion destructive)
+- `components/chat/notification-prompt.tsx` (Allow CTA)
+
+## Solution
+
+Use `text-soleur-text-on-accent` — it resolves to **white in both Forge and Radiance** by design, exactly preserving the original `text-white` contrast pairing across themes.
+
+```tsx
+// Correct
+className="rounded-lg bg-amber-600 ... text-soleur-text-on-accent"
+className="rounded bg-red-700 ... text-soleur-text-on-accent"
+```
+
+## Root Cause
+
+The token-migration prompt enumerated:
+
+> `text-white`, `text-zinc-50`, `text-zinc-100`, `text-zinc-200`, `text-neutral-100`, `text-neutral-200` → `text-soleur-text-primary`
+
+This is correct for `text-white` over neutral surfaces (body text on dark cards in Forge, or what *should* be dark body text in Radiance). It is wrong for `text-white` paired with `bg-<status>-NNN` or `bg-amber-NNN`, where the original intent is "white text on a saturated fill" — a contrast pairing the `text-soleur-text-on-accent` token exists to preserve.
+
+The CTA-fill section of the prompt did mention:
+> `bg-amber-500 text-black`, `bg-yellow-500 text-zinc-900` → `bg-soleur-accent-gold-fill text-soleur-text-on-accent`
+
+But three agents handled the case where the literal `bg-amber-600` (not `bg-amber-500`) and the literal `bg-red-700`, `bg-blue-600` were kept literal as status colors per the "DO NOT CHANGE: status colors" rule, while `text-white` was migrated standalone.
+
+## Key Insight
+
+When a migration prompt has TWO rules:
+
+1. "Status backgrounds stay literal"
+2. "Map `text-white` → `text-soleur-text-primary`"
+
+…rule (2) silently shadows the contrast intent that rule (1) preserves. The fix is a third rule that takes precedence:
+
+> **If the same className contains both a literal status/brand background (`bg-<color>-NNN`) and `text-white`, map `text-white` to `text-soleur-text-on-accent`** (white in both themes by design — same contrast as the original).
+
+This rule must appear *before* the generic `text-white` mapping in the prompt, and the agent must check both directions: the substring `text-white` in a className with any literal `bg-<status>-NNN` adjacent.
+
+## Prevention
+
+For future token migrations:
+
+1. **Add a precedence-ordered mapping section** to migration prompts: contrast-pair rules (status bg + text-white) come BEFORE generic substring mappings. Order matters because the agent applies the first matching rule.
+2. **Add a verification grep** to the migration agent's contract: before reporting "Group N complete," run `rg 'bg-(amber|red|orange|blue|green|emerald|cyan|pink|violet|sky|indigo|rose|fuchsia|teal|yellow)-[0-9]+[^"]*text-soleur-text-primary'` and assert zero hits.
+3. **Add a post-merge regression assertion** to `light-theme-tokenization.test.tsx` (or a sibling test file): grep the tokenized surfaces for the same anti-pattern and fail if any are present. This catches future contrast regressions even if the migration prompt is forgotten.
+
+## Session Errors
+
+1. **Three migration agents made the same wrong mapping independently.** Recovery: orchestrator post-implementation sweep with a single `sed` invocation across the affected files. Prevention: token-mapping prompts must enumerate contrast-pair precedence before generic mappings.
+2. **Group A migration missed `app/(dashboard)/dashboard/chat/layout.tsx`** — file was outside the explicit hand-listed scope but contained tokenizable classes; only caught by code-quality reviewer post-implementation. Recovery: P2 fix-inline (commit `99bbcc4f`). Prevention: migration-group prompts should accept a glob pattern (`app/(dashboard)/**/*.tsx`) and let the agent expand to the actual file list, rather than hand-enumerating files which can miss layout/template siblings.
+3. **Plan subagent did not create the spec directory.** `knowledge-base/project/specs/feat-one-shot-fix-light-theme-incomplete-styling/` was missing when the orchestrator tried to write `session-state.md`. Recovery: orchestrator `mkdir -p` before writing. Prevention: plan skill should create the spec dir during plan generation (Phase 0 of the plan skill).
+
+## Tags
+
+category: best-practices
+module: apps/web-platform/design-tokens

--- a/knowledge-base/project/plans/2026-05-06-fix-light-theme-incomplete-styling-plan.md
+++ b/knowledge-base/project/plans/2026-05-06-fix-light-theme-incomplete-styling-plan.md
@@ -1,0 +1,518 @@
+---
+type: bug-fix
+status: draft
+created: 2026-05-06
+deepened: 2026-05-06
+branch: feat-one-shot-fix-light-theme-incomplete-styling
+related_pr: "#3271"
+related_issue: "#3232 (parent), follow-up TBD"
+requires_cpo_signoff: false
+---
+
+# Fix Light Theme Incomplete Styling — Tokenize Remaining Web-Platform Surfaces
+
+## Enhancement Summary
+
+**Deepened on:** 2026-05-06
+**Sections enhanced:** Overview, Phase 1 (Mapping table), Phase 2 (Group F markdown-renderer + global-error guidance), Phase 3 (regression test design), Phase 4 (visual QA precedent), Risks (3 new), Sharp Edges (4 new), Research Insights (new section).
+
+### Key Improvements
+
+1. **Markdown-renderer is the highest-risk single file in the migration** — it controls every rendered chat message + KB doc, embeds amber link colors that need brand-token mapping (`text-soleur-accent-gold-fg`), and has 11 distinct color classes across `<h1>/<h2>/<h3>/<th>/<td>/<pre>/<code>/<blockquote>/<a>`. Promoted from Group F to its own dedicated review sub-step with both-themes manual verification on a long markdown reply.
+2. **`app/global-error.tsx` rendering invariant pinned**: Next.js 15 mounts global-error inside its own `<html>` shell — `globals.css` IS imported on this route (it lives under `app/`), but the inline no-FOUC script is NOT, so `data-theme` is unset and `:root:not([data-theme])` resolves via `prefers-color-scheme`. Mapping to tokens is therefore **safe** but the section uses `:root:not([data-theme])` defaults, which means a dark-OS user sees Forge and a light-OS user sees Radiance — verify this rendering matches expectation.
+3. **Tailwind v4 opacity-modifier compatibility verified**: `bg-soleur-bg-surface-2/60` and `border-soleur-border-default/50` are valid in Tailwind v4 — the `@theme` declaration shipped in PR #3271 wires CSS-variable-backed colors through the slash-modifier opacity pipeline (`color-mix(in oklch, var(--color-soleur-bg-surface-2) 60%, transparent)`). No need to add opacity-paired token variants.
+4. **Brand-workshop UX-mockup-gate learning applies inversely**: PR #3271's predecessor session (`knowledge-base/project/learnings/best-practices/2026-05-05-brand-workshop-needs-ux-mockup-gate.md`) shipped the Radiance palette through brand-architect without rendering it on real surfaces. PR #3271 then validated the palette on credential surfaces only. **This PR is the missing surface validation** for chat / KB / dashboard / settings / connect-repo / share. The ux-design-lead Pencil iteration is NOT re-required — palette is locked; only application widens.
+5. **Selected/emphasis state mapping needed**: dashboard page and chat-input use `border-amber-500/50` + `text-amber-500` for the selected pill state. Map to `border-soleur-border-emphasized` + `text-soleur-accent-gold-fg`; the gold-emphasis tokens are already in `globals.css` and shipped by PR #3271. Without this mapping, "selected" reads as muted gold on Radiance.
+
+### New Considerations Discovered
+
+- The migration covers 64 files / ~536 raw color lines. A multi-commit strategy (one commit per Group A–F) is preferable to a single mega-commit — each Group is independently reviewable, each commit can ship a screenshot pair, and `bisect` retains usefulness.
+- The new regression-grep test (`light-theme-tokenization.test.tsx`) supersedes manual review for future drift. It is the load-bearing follow-up gate — without it, the next contributor adds a `bg-zinc-900` and Light mode silently regresses.
+- `chat/leader-colors.ts` is OUT-OF-SCOPE but its consumers (`message-bubble.tsx`, `tool-use-chip.tsx`, `routed-leaders-strip.tsx`, `subagent-group.tsx`, `leader-avatar.tsx`) ARE in scope. The leader pink/blue/etc. literal classes in those consumer files must be left untouched while surrounding gray classes are tokenized — drift class: a careless rename touches `border-l-pink-500`.
+
+## Overview
+
+PR #3271 ("Light/Dark/System theme toggle + Light-mode tokenization for credential surfaces") shipped the theme toggle UI plus a CSS-variable-backed token system in `apps/web-platform/app/globals.css`, then tokenized only the credential / billing / concurrency / chat-rail surfaces (auth pages, billing, BYOK rotation, API-usage panel, upgrade-at-capacity, conversations rail). The user reports light mode "looks like you only did the background" — every other surface still ships hardcoded `bg-zinc-*` / `text-white` / `border-zinc-*` classes that do not respond to `data-theme="light"`.
+
+Audit numbers (run 2026-05-06 against the current branch):
+
+- **80 files** in `apps/web-platform/{app,components}` contain hardcoded gray/zinc/slate/neutral/stone backgrounds, text, or borders.
+- **536 raw lines** of hardcoded color classes across those files.
+- **Only 16 files** currently consume the `soleur-*` token namespace — those are the PR #3271 scope plus the new theme components.
+
+This plan tokenizes the remaining 64 user-visible files using the same pattern PR #3271 established: drop hardcoded gray scales in favor of `bg-soleur-bg-*` / `text-soleur-text-*` / `border-soleur-border-*` Tailwind utilities, which resolve via CSS variables in `globals.css` and switch automatically on `<html data-theme="light">`.
+
+**Goal:** Light mode renders all in-app surfaces (chat, KB browser, dashboard, settings, connect-repo, onboarding modals, share/error pages) with intentional Radiance-palette colors that match the brand-guide direction shipped in PR #3271, not just an inverted base background.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim from prompt / PR #3271 description | Codebase reality (2026-05-06) | Plan response |
+|---|---|---|
+| "PR #3271 only themed the background" | PR #3271 themed background **plus** 9 specific surfaces (auth × 4, billing, BYOK rotation, api-usage × 3, cancel-retention, upgrade-at-capacity, conversations-rail). Background-only was the *user-visible perception* — not literally what shipped. | Plan must scope to the **remaining** ~64 user-visible files, not re-tokenize what already shipped. Don't double-touch billing-section, conversations-rail, etc. |
+| "Hardcoded `bg-zinc-*`, `bg-slate-*`, `text-white`" | Confirmed: 80 files, 536 lines. Includes `gray-`, `neutral-`, `stone-` variants too. The project uses all five Tailwind gray scales interchangeably. | Migration grep MUST cover all five (`zinc\|slate\|neutral\|gray\|stone`), not just the three named in the prompt. |
+| "Apply the same semantic-token pattern from PR #3271" | Pattern is Tailwind v4 `@theme { --color-soleur-bg-*: var(--soleur-bg-*) }` declarations + `@custom-variant dark` pinned to `[data-theme="dark"]`. Migration is a class rename (`bg-zinc-900` → `bg-soleur-bg-base`), not a `dark:`-prefix retrofit. PR #3271 deliberately removed `dark:*` pairs in favor of the pinned variant. | Plan adopts the tokenized-class approach. Avoid introducing new `dark:bg-*` pairs — that contradicts the architecture. The single `dark:*` user (api-usage-section.tsx) is intentional and out of scope. |
+| "Status colors (red/orange/green/blue) need theming" | Status colors are used for semantic purposes (errors, warnings, success). PR #3271 left these as-is (e.g., `bg-red-600`, `bg-orange-600`). | Out of scope for v1. Status colors are visually legible on both backgrounds; theming them adds risk without clear win. Track as deferred follow-up if visual QA flags contrast. |
+| "Leader-color constants" (`apps/web-platform/components/chat/leader-colors.ts`) | Border/badge palette per domain leader (cmo→pink, cto→blue, etc.). Designed to be brand-recognizable across themes. | Out of scope. Domain identification > theme harmony. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** Light mode toggle appears non-functional or chaotic — switching to Light flips the base background to ivory but leaves dark cards, dark sidebars, dark chat bubbles, and white-on-dark text floating on the new light surface. Multiple high-contrast inversions per screen. Reads as "the Light option is broken; the team didn't finish."
+**If this leaks, the user's [data / workflow / money] is exposed via:** Not applicable — this is a pure visual/styling change. No new code paths handle credentials, payments, or user data.
+**Brand-survival threshold:** none
+
+This change carries no data-exposure or single-user-incident risk. It is a visual quality bar enforcement against a feature already shipped publicly.
+
+## Research Insights
+
+### Tailwind v4 + CSS-variable token mechanics (verified against repo state)
+
+The token system established in `apps/web-platform/app/globals.css` (PR #3271) uses two layered mechanisms:
+
+1. **`@theme` registration** turns `--color-soleur-*` CSS variables into Tailwind utility classes at compile time:
+   ```css
+   @theme {
+     --color-soleur-bg-base: var(--soleur-bg-base);
+     --color-soleur-text-primary: var(--soleur-text-primary);
+     /* ...etc */
+   }
+   ```
+   Result: `bg-soleur-bg-base`, `text-soleur-text-primary`, `border-soleur-border-default`, etc. resolve as standard Tailwind utilities.
+2. **`@custom-variant dark`** is pinned to `[data-theme="dark"]` and `[data-theme="system"] @media (prefers-color-scheme: dark)`, so any `dark:*` class still works but is **not the migration target**. PR #3271 explicitly drops `dark:*` pairs in favor of single tokenized classes that respond automatically to the `data-theme` attribute change.
+
+**Implication for this PR:** the migration is a 1:1 className rename, not a `light:`-prefix add. Reviewers expecting `dark:bg-zinc-950 light:bg-amber-50`-style pairs are wrong about the architecture; point them at `globals.css` and PR #3271's diff.
+
+**Opacity modifier interaction:** Tailwind v4 implements `bg-color/N` via `color-mix(in oklch, <token> N%, transparent)`. CSS-variable-backed colors work natively — `bg-soleur-bg-surface-2/60` produces `color-mix(in oklch, var(--color-soleur-bg-surface-2) 60%, transparent)` and recomposes when the underlying variable changes on theme switch. No opacity-paired token additions required.
+
+### Class-rename mapping (canonical reference)
+
+Drop-in replacements for every hardcoded gray scale found in the audit. Two helpful sub-rules:
+
+- **Page chrome / app shell backgrounds** (the biggest, outermost surface — modal overlay, dashboard outer, sheet desktop panel): `bg-zinc-950`, `bg-neutral-950` → `bg-soleur-bg-base`. Examples: `app/(dashboard)/layout.tsx`'s outer flex, `app/global-error.tsx`'s `<body>`.
+- **Card / modal body / sidebar / topbar** (one elevation up): `bg-zinc-900`, `bg-neutral-900`, `bg-zinc-800` → `bg-soleur-bg-surface-1`. Examples: `billing-section.tsx` card, `conversations-rail.tsx`, sheet panels.
+- **Hover / pressed / input field / chip / kbd** (two elevations up): `bg-zinc-800`, `bg-zinc-700`, `bg-neutral-700` → `bg-soleur-bg-surface-2`. Examples: `hover:bg-soleur-bg-surface-2`, `<kbd className="bg-soleur-bg-surface-2 ...">`.
+
+Text:
+
+- **Body emphasis / heading / value-text:** `text-white`, `text-zinc-50`, `text-zinc-100`, `text-zinc-200`, `text-neutral-100` → `text-soleur-text-primary`.
+- **Body prose / labels:** `text-zinc-300`, `text-zinc-400`, `text-neutral-300`, `text-neutral-400`, `text-slate-300`, `text-slate-400` → `text-soleur-text-secondary`.
+- **Muted / metadata / placeholder:** `text-zinc-500`, `text-zinc-600`, `text-neutral-500`, `text-stone-500`, `placeholder:text-zinc-500` → `text-soleur-text-muted` (and `placeholder:text-soleur-text-muted`).
+
+Borders:
+
+- **Default border:** `border-zinc-800`, `border-zinc-700`, `border-neutral-800`, `border-neutral-700`, `border-slate-700` → `border-soleur-border-default`.
+- **Emphasis (selected / focused / brand-accent):** `border-amber-500`, `border-amber-500/50` → `border-soleur-border-emphasized` (drop the `/50` only if visual QA shows the new emphasized border is too strong; the Radiance emphasis token is `#9b8857`, similar visual weight to amber-500/50 on Forge).
+
+Brand accents:
+
+- **CTA fill button:** `bg-amber-500 text-black`, `bg-yellow-500 text-zinc-900` → `bg-soleur-accent-gold-fill text-soleur-text-on-accent`.
+- **Gold link / accent label:** `text-amber-400`, `text-amber-500` → `text-soleur-accent-gold-fg`.
+- **Gold link hover:** `hover:text-amber-300` → `hover:text-soleur-accent-gold-text`.
+
+### Markdown-renderer color audit (`components/ui/markdown-renderer.tsx`)
+
+This is the single highest-leverage file. It controls the rendered color of every chat message and every KB doc preview. The 11 color decisions in the current build:
+
+| Element | Current class | Proposed mapping |
+|---|---|---|
+| `<h1>` | `text-white` | `text-soleur-text-primary` |
+| `<h2>` | `text-white` | `text-soleur-text-primary` |
+| `<h3>` | `text-neutral-200` | `text-soleur-text-primary` (heading hierarchy reads as primary on both themes; secondary makes h3 fade) |
+| `<li>` | `text-neutral-200` | `text-soleur-text-secondary` |
+| `<th>` | `border-neutral-700 bg-neutral-800/50 text-neutral-200` | `border-soleur-border-default bg-soleur-bg-surface-2/50 text-soleur-text-primary` |
+| `<td>` | `border-neutral-700 text-neutral-300` | `border-soleur-border-default text-soleur-text-secondary` |
+| `<pre>` (preWrap + non-wrap) | `bg-neutral-950 text-neutral-300` | `bg-soleur-bg-base text-soleur-text-secondary` (`pre` is intentionally darker than card surface — Forge stays dark, Radiance ivory base reads as a code-block recess) |
+| `<code>` inline | `bg-neutral-800 text-amber-300` | `bg-soleur-bg-surface-2 text-soleur-accent-gold-fg` |
+| `<a>` | `text-amber-400 hover:text-amber-300` | `text-soleur-accent-gold-fg hover:text-soleur-accent-gold-text` |
+| `<strong>` | `text-white` | `text-soleur-text-primary` |
+| `<blockquote>` | `border-neutral-600 text-neutral-400` | `border-soleur-border-default text-soleur-text-muted` |
+
+Validation: render an existing chat conversation with at least one of every element above, screenshot Forge + Radiance, confirm contrast and visual hierarchy survive.
+
+### Selected / emphasis state mapping (from dashboard + chat-input audit)
+
+`apps/web-platform/app/(dashboard)/dashboard/page.tsx` and `chat-input.tsx` use a "pill-selected" pattern for prompt-mode toggle and routed-leader pills:
+
+```tsx
+// Before
+className={isSelected
+  ? "border-amber-500/50 bg-neutral-900 text-amber-500"
+  : "border-neutral-700 bg-neutral-900 text-neutral-300"}
+
+// After
+className={isSelected
+  ? "border-soleur-border-emphasized bg-soleur-bg-surface-1 text-soleur-accent-gold-fg"
+  : "border-soleur-border-default bg-soleur-bg-surface-1 text-soleur-text-secondary"}
+```
+
+The `bg-neutral-900` background in BOTH selected and unselected branches is the same surface — it should map to the **same** token in both branches (`bg-soleur-bg-surface-1`). Only the border + text differ. Drift class: mapping selected to `surface-2` and unselected to `surface-1` would make the selected pill subtly raise off the row, which the original design did not do.
+
+### `app/global-error.tsx` — Next.js 15 root-error rendering invariant
+
+Next.js 15 docs (`next/app-router/error-handling`) confirm:
+
+- `app/global-error.tsx` mounts when the root layout itself throws. It owns its own `<html>` and `<body>` because the root layout is unavailable.
+- `app/globals.css` IS still loaded — the file is imported by `app/layout.tsx`'s static import chain that PostCSS/Tailwind compiles regardless of which route renders.
+- The **inline `<NoFoucScript>` is NOT loaded** because it lives inside the failed root layout. `<html>` therefore has no `data-theme` attribute.
+- Resolution: `:root:not([data-theme])` block in `globals.css` matches → `prefers-color-scheme` decides → dark-OS users see Forge, light-OS users see Radiance.
+
+**Plan adjustment:** map `global-error.tsx` to `bg-soleur-bg-base text-soleur-text-primary` etc. — it WILL respond to OS preference correctly. Do NOT skip global-error in the migration. The previous draft's risk note ("if `globals.css` is unavailable") is mitigated.
+
+### Vitest regression-test pattern (verified against repo precedent)
+
+Repo precedent for grep-style tests:
+
+- `apps/web-platform/test/theme-csp-regression.test.tsx` (PR #3271) — reads `app/layout.tsx`, asserts CSP/no-FOUC invariants via string match.
+- `plugins/soleur/docs/scripts/screenshot-gate.mjs` — Eleventy critical-CSS screenshot gate (`cq-eleventy-critical-css-screenshot-gate`).
+
+Implementation sketch for `apps/web-platform/test/light-theme-tokenization.test.tsx`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = resolve(__dirname, "..");
+
+// Files that legitimately retain literal grays (status, leader identity, etc.).
+// Each entry MUST cite a one-line reason in code comments.
+const ALLOWLIST = new Set<string>([
+  "components/chat/leader-colors.ts",       // Domain-leader identity palette (cross-theme).
+  "components/chat/status-indicator.tsx",   // Status semantics (red/orange/green).
+  // ...add as discovered during migration; reviewer reviews each entry.
+]);
+
+const SURFACE_GROUPS = [
+  "app/(dashboard)/layout.tsx",
+  "app/(dashboard)/dashboard/page.tsx",
+  "app/global-error.tsx",
+  "app/shared/[token]/page.tsx",
+  "components/ui/markdown-renderer.tsx",
+  "components/ui/sheet.tsx",
+  "components/chat/chat-surface.tsx",
+  "components/chat/message-bubble.tsx",
+  "components/chat/interactive-prompt-card.tsx",
+  "components/kb/file-tree.tsx",
+  "components/settings/connected-services-content.tsx",
+  "components/connect-repo/select-project-state.tsx",
+  "components/dashboard/foundation-cards.tsx",
+  "components/inbox/conversation-row.tsx",
+  // Representative sampling — full list in the test.
+];
+
+const HARDCODED = /\b(?:bg|text|border)-(?:zinc|slate|neutral|stone|gray)-\d+|text-white\b/;
+const TOKENIZED = /\bsoleur-(?:bg|text|border|accent)-/;
+
+describe("light-theme tokenization", () => {
+  for (const rel of SURFACE_GROUPS) {
+    it(`${rel} contains no hardcoded gray classes`, () => {
+      if (ALLOWLIST.has(rel)) return;
+      const src = readFileSync(resolve(ROOT, rel), "utf8");
+      expect(src).not.toMatch(HARDCODED);
+    });
+    it(`${rel} consumes Soleur tokens`, () => {
+      const src = readFileSync(resolve(ROOT, rel), "utf8");
+      expect(src).toMatch(TOKENIZED);
+    });
+  }
+});
+```
+
+The test must run in `vitest` (not `vitest run --browser`), uses `node:fs`, and pins absolute paths via `path.resolve(__dirname, "..")` per the brittleness note.
+
+### Visual QA cadence
+
+PR #3271 captured 4 reference screenshots under `knowledge-base/product/design/theme-toggle/screenshots/` and the brand workshop UX-mockup-gate learning is the canonical reason this is required. This PR widens the same screenshot capture to 12 (6 groups × 2 themes) with the file-naming convention proposed in Phase 4.4.
+
+If a Pencil MCP session is available at work-time, those screenshots can be taken inside Pencil for easier annotation; otherwise plain `--screenshot` Playwright captures suffice. Skipping screenshots would be a workflow regression.
+
+## Implementation Phases
+
+### Phase 1 — Migration Scaffolding
+
+**Files to read (no edits):**
+
+- `apps/web-platform/app/globals.css` — confirm token list, no schema changes needed.
+- `apps/web-platform/components/settings/billing-section.tsx` — exemplar for surface-1 + accent CTA mapping.
+- `apps/web-platform/components/chat/conversations-rail.tsx` — exemplar for navigation/list mapping.
+
+**Deliverable:** A short mapping reference (kept in the PR description, not committed as a doc) that fixes the migration grammar:
+
+| Tailwind class (deprecated in app surfaces) | Replace with |
+|---|---|
+| `bg-zinc-950`, `bg-neutral-950`, `bg-zinc-900` (page chrome) | `bg-soleur-bg-base` |
+| `bg-zinc-900`, `bg-neutral-900`, `bg-zinc-800` (cards, modals, headers) | `bg-soleur-bg-surface-1` |
+| `bg-zinc-800`, `bg-zinc-700` (elevated rows, hover, input, kbd) | `bg-soleur-bg-surface-2` |
+| `bg-zinc-700/50`, `bg-zinc-800/60` opacity variants | `bg-soleur-bg-surface-2/60` (numeric opacity preserved) |
+| `text-white`, `text-zinc-50`, `text-zinc-100`, `text-zinc-200` | `text-soleur-text-primary` |
+| `text-zinc-300`, `text-zinc-400`, `text-slate-300`, `text-slate-400`, `text-neutral-400` | `text-soleur-text-secondary` |
+| `text-zinc-500`, `text-zinc-600`, `text-neutral-500`, `text-stone-500` | `text-soleur-text-muted` |
+| `border-zinc-800`, `border-zinc-700`, `border-neutral-800`, `border-slate-700` | `border-soleur-border-default` |
+| `border-zinc-600`, `border-amber-500`-as-emphasis | `border-soleur-border-emphasized` (only for selected/focused emphasis) |
+| `bg-amber-500` / `bg-yellow-500` (CTAs only) | `bg-soleur-accent-gold-fill` paired with `text-soleur-text-on-accent` |
+| `text-amber-400`, `text-amber-500` (gold accent text/link) | `text-soleur-accent-gold-fg` (default), `hover:text-soleur-accent-gold-text` |
+
+Status colors (`red-`, `orange-`, `green-`, `blue-`, `cyan-`, `pink-`, `violet-`, `emerald-`) remain literal — out of scope for this PR.
+
+**Tasks:**
+
+- [ ] 1.1 Re-read `globals.css` to confirm the token list (no schema additions in v1).
+- [ ] 1.2 Confirm exemplar consistency (`billing-section.tsx` and `conversations-rail.tsx`) — note any drift from the mapping table above.
+- [ ] 1.3 Run the audit grep one more time at start-of-work to confirm scope hasn't changed:
+  ```bash
+  rg -c '\b(bg|text|border)-(zinc|slate|neutral|stone|gray)-|text-white\b' apps/web-platform/{app,components}
+  ```
+  Record the file count as a baseline for the post-implementation check.
+
+### Phase 2 — Surface-by-Surface Tokenization (parallel-ready)
+
+Six surface groups. Each group is independent and can be migrated in any order. Within a group, files share visual context, so reviewing diffs together catches inconsistencies (a card uses `surface-1`, its hover row should use `surface-2`).
+
+**Group A — Chat surface** (16 files; ~125 hardcoded color lines)
+
+- [ ] `apps/web-platform/components/chat/chat-surface.tsx` (18 lines)
+- [ ] `apps/web-platform/components/chat/interactive-prompt-card.tsx` (25 lines — heaviest in chat; many surface levels)
+- [ ] `apps/web-platform/components/chat/message-bubble.tsx` (16 lines — verify `border-l-*` leader colors are NOT touched)
+- [ ] `apps/web-platform/components/chat/chat-input.tsx` (10 lines)
+- [ ] `apps/web-platform/components/chat/at-mention-dropdown.tsx` (9 lines)
+- [ ] `apps/web-platform/components/chat/workflow-lifecycle-bar.tsx` (8 lines)
+- [ ] `apps/web-platform/components/chat/subagent-group.tsx` (8 lines)
+- [ ] `apps/web-platform/components/chat/notification-prompt.tsx` (8 lines)
+- [ ] `apps/web-platform/components/chat/review-gate-card.tsx` (5 lines)
+- [ ] `apps/web-platform/components/chat/pwa-install-banner.tsx` (5 lines)
+- [ ] `apps/web-platform/components/chat/attachment-display.tsx` (5 lines)
+- [ ] `apps/web-platform/components/chat/welcome-card.tsx` (4 lines)
+- [ ] `apps/web-platform/components/chat/naming-nudge.tsx` (4 lines)
+- [ ] `apps/web-platform/components/chat/kb-chat-content.tsx` (4 lines)
+- [ ] `apps/web-platform/components/chat/tool-use-chip.tsx` (3 lines)
+- [ ] `apps/web-platform/components/chat/routed-leaders-strip.tsx` (3 lines)
+- [ ] **NOT touched (intentional):** `chat/leader-colors.ts` (domain identity palette), `chat/conversations-rail.tsx` (already tokenized), `chat/status-indicator.tsx` (status semantics), `chat/kb-chat-sidebar.tsx` (verify; if hardcoded, add to list).
+
+**Group B — Knowledge-base browser** (17 files; ~74 hardcoded color lines)
+
+- [ ] `apps/web-platform/components/kb/file-tree.tsx` (16)
+- [ ] `apps/web-platform/components/kb/pdf-preview.tsx` (10)
+- [ ] `apps/web-platform/components/kb/share-popover.tsx` (9)
+- [ ] `apps/web-platform/components/kb/search-overlay.tsx` (8)
+- [ ] `apps/web-platform/components/kb/kb-desktop-layout.tsx` (6)
+- [ ] `apps/web-platform/components/kb/text-preview.tsx` (4)
+- [ ] `apps/web-platform/components/kb/no-project-state.tsx` (4)
+- [ ] `apps/web-platform/components/kb/file-preview.tsx` (4)
+- [ ] `apps/web-platform/components/kb/empty-state.tsx` (4)
+- [ ] `apps/web-platform/components/kb/download-preview.tsx` (4)
+- [ ] `apps/web-platform/components/kb/workspace-not-ready.tsx` (3)
+- [ ] `apps/web-platform/components/kb/selection-toolbar.tsx` (3)
+- [ ] `apps/web-platform/components/kb/loading-skeleton.tsx` (3)
+- [ ] `apps/web-platform/components/kb/kb-content-header.tsx` (3)
+- [ ] `apps/web-platform/components/kb/desktop-placeholder.tsx` (3)
+- [ ] `apps/web-platform/components/kb/kb-sidebar-shell.tsx` (2)
+- [ ] `apps/web-platform/components/kb/kb-content-skeleton.tsx` (2)
+- [ ] `apps/web-platform/components/kb/kb-breadcrumb.tsx` (2)
+- [ ] `apps/web-platform/components/kb/unknown-error.tsx` (1)
+- [ ] `apps/web-platform/components/kb/kb-mobile-layout.tsx` (1)
+- [ ] `apps/web-platform/components/kb/kb-error-boundary.tsx` (1)
+- [ ] `apps/web-platform/components/kb/kb-doc-shell.tsx` (verify count; appears in audit but not in top counts)
+- [ ] `apps/web-platform/app/(dashboard)/dashboard/kb/[...path]/page.tsx` (3) — App Router page; also touch the layout sibling if it has hardcoded grays.
+
+**Group C — Settings & account surfaces** (11 files; ~74 hardcoded color lines)
+
+- [ ] `apps/web-platform/components/settings/connected-services-content.tsx` (15)
+- [ ] `apps/web-platform/components/settings/settings-content.tsx` (13)
+- [ ] `apps/web-platform/components/settings/team-settings.tsx` (8)
+- [ ] `apps/web-platform/components/settings/settings-shell.tsx` (8)
+- [ ] `apps/web-platform/components/settings/project-setup-card.tsx` (8)
+- [ ] `apps/web-platform/components/settings/disconnect-repo-dialog.tsx` (7)
+- [ ] `apps/web-platform/components/settings/delete-account-dialog.tsx` (6)
+- [ ] **NOT touched:** `settings/billing-section.tsx`, `settings/api-usage-*.tsx`, `settings/cancel-retention-modal.tsx`, `settings/key-rotation-form.tsx` (already tokenized in PR #3271 — do not double-edit).
+
+**Group D — Connect-repo / onboarding flow** (10 files; ~85 hardcoded color lines)
+
+- [ ] `apps/web-platform/components/connect-repo/select-project-state.tsx` (16)
+- [ ] `apps/web-platform/components/connect-repo/ready-state.tsx` (14)
+- [ ] `apps/web-platform/components/connect-repo/create-project-state.tsx` (12)
+- [ ] `apps/web-platform/components/connect-repo/github-redirect-state.tsx` (11)
+- [ ] `apps/web-platform/components/connect-repo/choose-state.tsx` (10)
+- [ ] `apps/web-platform/components/connect-repo/setting-up-state.tsx` (9)
+- [ ] `apps/web-platform/components/connect-repo/github-resolve-state.tsx` (6)
+- [ ] `apps/web-platform/components/connect-repo/failed-state.tsx` (6)
+- [ ] `apps/web-platform/components/connect-repo/no-projects-state.tsx` (3)
+- [ ] `apps/web-platform/components/connect-repo/interrupted-state.tsx` (2)
+- [ ] `apps/web-platform/components/onboarding/naming-modal.tsx` (7)
+
+**Group E — Dashboard, analytics, inbox, shared** (9 files; ~104 hardcoded color lines)
+
+- [ ] `apps/web-platform/app/(dashboard)/dashboard/page.tsx` (37 — heaviest single file in the audit)
+- [ ] `apps/web-platform/components/analytics/analytics-dashboard.tsx` (28)
+- [ ] `apps/web-platform/components/inbox/conversation-row.tsx` (14)
+- [ ] `apps/web-platform/components/dashboard/foundation-cards.tsx` (4)
+- [ ] `apps/web-platform/components/dashboard/foundation-section.tsx` (verify)
+- [ ] `apps/web-platform/app/shared/[token]/page.tsx` (10) — public share page; visible to recipients without an account; light theme correctness matters most here.
+- [ ] `apps/web-platform/app/(dashboard)/dashboard/admin/analytics/loading.tsx` (6)
+- [ ] `apps/web-platform/app/(dashboard)/layout.tsx` (5 — already partially tokenized, audit residual hardcoded classes; re-verify CTA buttons that still use `bg-orange-600 text-white` and `bg-red-600 text-white`)
+- [ ] `apps/web-platform/components/concurrency/account-state-banner.tsx` (2)
+- [ ] `apps/web-platform/components/shared/cta-banner.tsx` (3)
+
+**Group F — UI primitives, error pages, auth helpers** (8 files; ~24 hardcoded color lines)
+
+- [ ] `apps/web-platform/components/ui/markdown-renderer.tsx` (11) — **highest-leverage single file in this PR.** Prose colors render every chat message + KB doc preview. Use the Markdown-renderer color audit table in Research Insights as the canonical mapping. After migration: render an existing chat conversation containing all of `<h1>/<h2>/<h3>/<p>/<ul>/<table>/<pre>/<code>/<a>/<strong>/<blockquote>` and capture both-themes screenshots BEFORE moving on. Drift here is site-wide.
+- [ ] `apps/web-platform/components/ui/sheet.tsx` (3) — modal/drawer overlay primitive.
+- [ ] `apps/web-platform/components/ui/error-card.tsx` (3)
+- [ ] `apps/web-platform/components/ui/outlined-button.tsx` (1)
+- [ ] `apps/web-platform/components/ui/card.tsx` (1)
+- [ ] `apps/web-platform/components/error-boundary-view.tsx` (3)
+- [ ] `apps/web-platform/app/global-error.tsx` (3) — Next.js root error page. Verified in Research Insights: `globals.css` IS loaded; the no-FOUC inline script is NOT. `<html>` therefore has no `data-theme` and falls through to `:root:not([data-theme])` (OS-preference). Map to `bg-soleur-bg-base text-soleur-text-primary` and add an inline comment explaining the OS-follow behavior. Validate by force-throwing in the root layout and screenshotting in both Forge and Radiance OS modes.
+- [ ] `apps/web-platform/components/leader-avatar.tsx` (1)
+- [ ] `apps/web-platform/components/auth/oauth-buttons.tsx` (verify count) — auth pages already tokenized; if oauth buttons still ship raw classes, fold in.
+
+### Phase 3 — Tests
+
+PR #3271 added `theme-provider.test.tsx`, `theme-toggle.test.tsx`, `theme-csp-regression.test.tsx`, and `dynamic-theme-color.test.tsx`. The existing tests cover the toggle behavior + hydration but do not assert that surface components consume tokens.
+
+**Test additions (new file):**
+
+- [ ] `apps/web-platform/test/light-theme-tokenization.test.tsx` — a single-file regression harness that:
+  1. Reads a representative file from each Group (A–F) via `fs.readFileSync` against absolute paths.
+  2. Asserts each file contains zero matches of the deprecated grep:
+     ```ts
+     /\b(bg|text|border)-(zinc|slate|neutral|stone|gray)-\d+|text-white\b/
+     ```
+     except for an explicit allowlist (status-colored helpers, leader-colors.ts, chat/status-indicator.tsx, components that intentionally retain literal grays for status semantics).
+  3. Asserts each file contains at least one `soleur-(bg|text|border|accent)-` token.
+
+  Why a regression-grep test: TypeScript and Tailwind v4 don't catch hardcoded color drift; the only signal today is "looks wrong in Light mode," which requires manual visual QA. A grep test pins the pattern as a build-time invariant.
+
+- [ ] No new tests are required for the Group A–F files individually — the regression-grep test covers them collectively. Existing component tests should not need updates because tokenized classes are still valid Tailwind utilities; rendered HTML changes only the className strings.
+
+**Test invariants:**
+
+- The test file must import absolute paths via `path.resolve(__dirname, '../components/...')` — relative `../../` traversal is brittle.
+- The allowlist constant (status-color exempt files) lives at the top of the test file with an inline comment per entry explaining why.
+
+### Phase 4 — Visual QA
+
+Visual QA runs after the diff is staged but before merge. Two passes per group, one per theme.
+
+- [ ] 4.1 `bun run dev` (or whichever script `apps/web-platform/package.json` exposes), open `http://localhost:3000`, log in.
+- [ ] 4.2 For each Group A–F, navigate to a representative page in **Dark theme**, screenshot, then toggle to **Light theme**, screenshot. Compare:
+  - Surface colors switch (no leftover dark cards on light backgrounds, no leftover light cards on dark backgrounds).
+  - Text contrast holds (no `text-soleur-text-primary` rendering as off-white-on-ivory or near-black-on-near-black).
+  - Borders are visible in both themes (no `border-soleur-border-default` becoming invisible).
+  - Hover states (`hover:bg-soleur-bg-surface-2`) are visible.
+- [ ] 4.3 Save screenshots under `knowledge-base/product/design/light-theme-completion/screenshots/{group-letter}-{theme}.png`.
+- [ ] 4.4 If any contrast or hover issue surfaces, fix inline before merge.
+
+**Out-of-band visual checks:**
+
+- [ ] 4.5 The `app/global-error.tsx` route is hard to trigger naturally; verify by temporarily throwing in `app/layout.tsx`, screenshotting, then reverting. If global-error renders without `globals.css`, document why hardcoded colors are correct and add a Sharp Edges note.
+- [ ] 4.6 The `app/shared/[token]/page.tsx` route is logged-out / shareable. Capture screenshots in both themes (default unauthenticated browser, no theme cookie set → renders System theme).
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] Audit grep `rg -c '\b(bg|text|border)-(zinc|slate|neutral|stone|gray)-|text-white\b' apps/web-platform/{app,components}` returns ≤ N files where N is the count of the documented allowlist (status-color carriers + leader-colors.ts + components with intentional literal grays). Allowlist enumerated in the new test file.
+- [ ] Existing 16 already-tokenized files (PR #3271 scope) appear in `git diff main...HEAD --name-only` ONLY if they had residual hardcoded classes the audit caught — never as a refactor of correct code.
+- [ ] `bun test apps/web-platform/test/` passes including the new `light-theme-tokenization.test.tsx`.
+- [ ] `tsc --noEmit` clean.
+- [ ] Visual QA screenshots committed under `knowledge-base/product/design/light-theme-completion/screenshots/` for all 6 groups × 2 themes (12 screenshots minimum).
+- [ ] PR body uses `Closes #3232` only if the original issue specifically called for full-app tokenization; otherwise `Ref #3232` and link the new follow-up issue.
+- [ ] No new `dark:*` Tailwind prefixes introduced (per PR #3271 architecture; `@custom-variant dark` does the work via tokens).
+
+### Post-merge (operator)
+
+- [ ] None. This is a CSS-class change with no migrations, deploys, or external service mutations.
+
+## Risks
+
+- **Token namespace gaps for status colors.** The current token system has no `--soleur-status-*` (red/orange/green/blue) variables. Components using semantic colors (`bg-red-600`, `text-orange-400`) keep the literal Tailwind classes. In Light mode these colors are slightly under-saturated against the ivory background. If visual QA flags low contrast, file a follow-up to add `--soleur-status-{danger,warning,success,info}` tokens — do NOT widen this PR.
+- **Markdown renderer prose color drift.** `components/ui/markdown-renderer.tsx` controls the rendered color of every chat message and every KB doc. A sloppy mapping (e.g., body text → `text-soleur-text-muted` instead of `-secondary`) will fade content site-wide. Validate against an existing chat conversation with a long markdown reply.
+- **Sheet / modal overlay opacity.** `components/ui/sheet.tsx` uses `bg-zinc-900/80` for the backdrop. The token system has no opacity-paired variant; mapping to `bg-soleur-bg-base/80` works but rendered alpha differs between themes (light alpha tint vs dark alpha tint). Visual QA must confirm modals still feel modal in Light mode (backdrop visibly recedes).
+- **`global-error.tsx` follows OS preference, not user choice.** Verified via Next.js 15 docs: `globals.css` IS loaded on this route, but the no-FOUC inline script is NOT (it lives in the failed root layout). The `<html>` therefore has no `data-theme`, and `:root:not([data-theme])` resolves via `prefers-color-scheme`. Result: a Light-mode user with a dark OS sees the error page render in Forge — technically a divergence from the user's chosen theme. Acceptable for an error path that already represents a degraded state. Document inline as a comment.
+- **Reviewer false-positive on test allowlist.** The regression-grep test allowlist will look like "we're suppressing the rule for some files." Document the per-file rationale in test comments so reviewers don't suspect drift suppression.
+- **Selected-pill mapping inconsistency.** Two files (`dashboard/page.tsx`, `chat/chat-input.tsx`) use the `bg-neutral-900` shared-background pill pattern. If reviewer A maps both branches to `surface-1` and reviewer B maps the selected branch to `surface-2`, the pill rises subtly out of the row. Pin to `surface-1` for both branches, only border + text change.
+- **Leader-colors consumer drift class.** `chat/leader-colors.ts` is out of scope (domain-identity palette), but its consumers (`message-bubble.tsx`, `tool-use-chip.tsx`, `routed-leaders-strip.tsx`, `subagent-group.tsx`, `leader-avatar.tsx`) ARE in scope. A grep-and-replace using a too-broad pattern (e.g., regex `border-l-(pink|blue|emerald|violet|orange|amber|slate|cyan|neutral)-`) would tokenize the leader pink/blue/etc. literal classes — defeating the cross-theme identity guarantee. Use surgical edits, not regex sweep.
+- **Markdown-renderer `<pre>` darker-than-card invariant.** PR #3271 + Forge convention sets code blocks to `bg-neutral-950` — visibly darker than the surrounding `<div>` card. On Radiance, `bg-soleur-bg-base` (ivory `#fbf7ee`) is lighter than `bg-soleur-bg-surface-1` (`#f4eedf`), inverting the recess effect — code blocks "stick out" instead of "recess in." Visual QA must confirm this reads as intentional; if not, `<pre>` may need its own `--soleur-bg-code` token. Track as deferred follow-up.
+
+## Sharp Edges
+
+- The single existing `dark:*`-prefix consumer (`api-usage-section.tsx`) is intentional per PR #3271's architecture; do not retro-tokenize it in this PR.
+- `chat/leader-colors.ts` exports literal `border-l-pink-500` etc. — these are domain-identity colors, not theme colors. Adding the file to this PR's diff is a workflow violation (out of scope, brand-recognizable across themes).
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder text, or omits the threshold will fail `deepen-plan` Phase 4.6. Section is filled (threshold: none) per the impact analysis above.
+- When migrating opacity-modifier classes (`bg-zinc-800/60`), preserve the `/60` suffix on the new token (`bg-soleur-bg-surface-2/60`). Tailwind v4 handles opacity modifiers on CSS-variable-backed colors natively.
+- The audit grep deliberately uses `\b(bg|text|border)-` rather than just `bg-`; subagents that "simplify" the regex will miss `text-zinc-400` (the most common offender, ~18 occurrences in `interactive-prompt-card.tsx` alone).
+- Do NOT migrate marketing pages or the docs site (`plugins/soleur/docs/**`). Those have their own theming context and are out of scope for the web-platform light-theme fix.
+- `app/shared/[token]/page.tsx` is the public share-link surface; its theme defaults to System. Confirm no logged-in-only assumptions (e.g., reading a theme cookie that requires auth) — if found, document expected unauth behavior in code comments.
+- Per AGENTS.md `cq-write-failing-tests-before` (TDD), `light-theme-tokenization.test.tsx` MUST land in a commit BEFORE the surface migrations land — write the test first against the current state (which will fail on every Group A–F file), then migrate group-by-group, watching the failure list shrink.
+- Per AGENTS.md `hr-when-a-plan-specifies-relative-paths-e-g`, every Phase 2 file path was verified against `git ls-files apps/web-platform/components | grep` at plan time. `dashboard/foundation-section.tsx` and `auth/oauth-buttons.tsx` are listed as "verify count" and may have zero hardcoded grays — verify and remove from the diff if so, do not no-op edit.
+- Tailwind v4 opacity modifiers (`/60`) on CSS-variable-backed tokens use `color-mix(in oklch, ...)` under the hood. Browsers without `color-mix` support (Safari < 16.2) fall back to fully-opaque. Soleur's browser support floor (Next 15 + React 19 implicit baseline) excludes this concern, but a dependency bump that adds an older-browser target needs a rebaseline.
+- The migration is a 1:1 className rename, not a `light:`-prefix add. Reviewers expecting `dark:bg-zinc-950 light:bg-amber-50`-style pairs are wrong about the architecture; point them at `globals.css` and PR #3271's diff.
+- Do NOT introduce new `dark:*` Tailwind prefixes during the migration. PR #3271 chose tokens + `@custom-variant dark`; new `dark:*` consumers contradict the architecture. The single existing consumer (`api-usage-section.tsx`) is intentional and OUT OF SCOPE.
+
+## Domain Review
+
+**Domains relevant:** Product/UX (advisory)
+
+### Product/UX Gate
+
+**Tier:** advisory
+**Decision:** auto-accepted (pipeline)
+**Agents invoked:** none (auto-accepted in pipeline)
+**Skipped specialists:** ux-design-lead (auto-accepted in pipeline; visual QA in Phase 4 covers screenshot validation)
+**Pencil available:** N/A
+
+#### Findings
+
+This plan modifies **existing** UI surfaces (no new pages, no new modals, no new flows). It tokenizes color classes against the design system PR #3271 already validated (with ux-design-lead and screenshot iterations under `knowledge-base/product/design/theme-toggle/`). The visual contract is the Radiance palette already chosen and shipped. Phase 4 visual QA validates that the migration preserves brand-aligned color behavior — no new design surface to review.
+
+Per the plan skill's pipeline-mode rule for ADVISORY tier, the gate auto-accepts and proceeds with documented visual-QA gating in Phase 4 instead of a fresh ux-design-lead Pencil session.
+
+## Open Code-Review Overlap
+
+None — this plan touches presentational `className` strings only. No open `code-review`-labeled issues match the planned file paths (would need to re-run `gh issue list --label code-review` if the audit window slips, but as of plan time there are no overlaps with chat/, kb/, settings/, connect-repo/, dashboard/, ui/ surface files).
+
+## Test Scenarios
+
+1. **Tokenization grep regression**: A file under `apps/web-platform/components/chat/` containing `bg-zinc-900` causes `light-theme-tokenization.test.tsx` to fail. (Add a temporary file in the test, assert the grep matches, then remove.)
+2. **Theme toggle integration**: Existing `theme-provider.test.tsx` + `theme-toggle.test.tsx` continue to pass — the migration changes class names but not the toggle's stateful logic.
+3. **Cold-render Light mode**: With `<html data-theme="light">` set by the no-FOUC script before React hydrates, every Group A–F surface renders ivory-base + Radiance accents (manual, captured as screenshots in Phase 4).
+4. **Cold-render System mode → OS dark**: Default user (no theme cookie, OS in dark) renders Forge palette across all surfaces (no leftover light surfaces).
+5. **Cold-render System mode → OS light**: Default user (no theme cookie, OS in light) renders Radiance palette across all surfaces.
+6. **Live theme switch**: Toggle Forge → Radiance → System on the dashboard; every Group A–F surface visible at the time of toggle re-renders with the new palette without reload.
+
+## Commit Strategy
+
+Recommended: 8 commits on the feature branch.
+
+1. `test: add light-theme tokenization regression harness` — `apps/web-platform/test/light-theme-tokenization.test.tsx` only. Test fails on current state (every Group A–F file). RED commit.
+2. `fix(light-theme): tokenize chat surface` — Group A (16 files).
+3. `fix(light-theme): tokenize KB browser surface` — Group B (~22 files).
+4. `fix(light-theme): tokenize settings + onboarding surfaces` — Group C (7 files).
+5. `fix(light-theme): tokenize connect-repo flow` — Group D (11 files).
+6. `fix(light-theme): tokenize dashboard, analytics, inbox, share` — Group E (~9 files).
+7. `fix(light-theme): tokenize UI primitives + global-error` — Group F (~8 files, includes the markdown-renderer dedicated review).
+8. `docs: light-theme completion screenshots` — `knowledge-base/product/design/light-theme-completion/screenshots/*.png` (12 PNGs).
+
+After commit 7, the regression test goes GREEN. Each Group commit can be independently reviewed and reverted; bisect retains usefulness.
+
+## Files to Edit
+
+See Phase 2 enumeration. Approximate count: 64 files modified, 1 test file created. Net diff is largely class-rename churn.
+
+## Files to Create
+
+- `apps/web-platform/test/light-theme-tokenization.test.tsx` — regression-grep harness with documented allowlist.
+- `knowledge-base/product/design/light-theme-completion/screenshots/{a-chat,b-kb,c-settings,d-connect,e-dashboard,f-ui}-{forge,radiance}.png` — 12 screenshots captured during Phase 4 visual QA.
+
+## Out of Scope (deferred)
+
+- Status-color tokenization (`--soleur-status-{danger,warning,success,info}`). Track via follow-up issue if Phase 4 visual QA flags contrast.
+- `chat/leader-colors.ts` palette refactor. Domain-identity colors are deliberately theme-stable; no action.
+- Marketing site / Eleventy docs theming.
+- Re-tokenizing the 16 files PR #3271 already shipped.
+- Adding `dark:*` prefix-based variants. PR #3271 chose `@custom-variant dark` + tokens; do not contradict.
+
+## Resume Prompt
+
+```text
+Resume prompt (copy-paste after /clear):
+/soleur:work knowledge-base/project/plans/2026-05-06-fix-light-theme-incomplete-styling-plan.md. Branch: feat-one-shot-fix-light-theme-incomplete-styling. Worktree: .worktrees/feat-one-shot-fix-light-theme-incomplete-styling/. Issue: TBD (follow-up to #3232/#3271). Plan reviewed, implementation next.
+```

--- a/knowledge-base/project/specs/feat-one-shot-fix-light-theme-incomplete-styling/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-light-theme-incomplete-styling/session-state.md
@@ -1,0 +1,23 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/harry/Documents/Stage/Soleur/soleur/.worktrees/feat-one-shot-fix-light-theme-incomplete-styling/knowledge-base/project/plans/2026-05-06-fix-light-theme-incomplete-styling-plan.md
+- Status: complete
+
+### Errors
+None. User-Brand Impact halt gate passed (threshold `none`, no sensitive-path diffs — `apps/web-platform/{app,components}/*.tsx` className changes only).
+
+### Decisions
+- Scope = 64 files / ~536 hardcoded color lines to migrate, organized into 6 surface groups (A: chat 16 / B: KB 22 / C: settings 7 / D: connect-repo 11 / E: dashboard+share+analytics 9 / F: UI primitives + global-error 8). The 16 files PR #3271 already tokenized are explicitly excluded.
+- Migration is a 1:1 className rename, not a `light:`-prefix retrofit. Drop hardcoded gray scales for `bg-soleur-bg-*`, `text-soleur-text-*`, `border-soleur-border-*` Tailwind utilities that PR #3271 wired through `@theme` + `@custom-variant dark`.
+- `markdown-renderer.tsx` is the highest-leverage single file (renders every chat message + KB doc). Promoted to a dedicated review sub-step with an 11-element color-mapping table in Research Insights.
+- Regression-grep test (`light-theme-tokenization.test.tsx`) is the load-bearing follow-up gate — written first (RED commit), forces tokenization to GREEN. Allowlist scoped to `chat/leader-colors.ts` + `chat/status-indicator.tsx` (status semantics, not theme).
+- 8-commit strategy: 1 RED test commit + 6 group migration commits + 1 screenshot commit. Bisect-friendly; each group is independently reviewable.
+- Out of scope: status-color tokenization, leader-colors palette, marketing/docs site, re-tokenizing PR #3271 surfaces, new `dark:*` prefix consumers.
+
+### Components Invoked
+- soleur:plan
+- soleur:deepen-plan
+- gh CLI (PR #3271 inspection)
+- ripgrep + bash (audit greps)
+- Read tool (globals.css token system, billing-section.tsx, conversations-rail.tsx, markdown-renderer.tsx, dashboard/page.tsx, sheet.tsx, global-error.tsx, brand-guide.md)


### PR DESCRIPTION
## Summary

Light-mode UI now feels intentional everywhere instead of just the background. Migrates 75 files from hardcoded Tailwind grays (`bg-zinc-*`, `bg-neutral-*`, `text-white`, `border-zinc-*`) to the Soleur design tokens shipped in PR #3271 (`bg-soleur-bg-*`, `text-soleur-text-*`, `border-soleur-border-*`, `*-accent-gold-*`).

PR #3271 themed the toggle plus credential surfaces. This PR widens to chat, KB browser, settings, connect-repo, dashboard, analytics, inbox, share, UI primitives + global-error.

Ref #3232

## Changelog

### Web Platform
- **fix(theme):** Light mode now renders Radiance palette across all in-app surfaces — chat (16 files), KB browser (22 files), settings (7 files), connect-repo + onboarding (11 files), dashboard / analytics / inbox / share (10 files), UI primitives + global-error (8 files).
- **fix(theme):** Markdown-renderer (every chat message + KB doc preview) tokenized end-to-end — h1/h2/h3, lists, tables, code blocks, blockquotes, links all switch palette on theme change.
- **fix(theme):** Status/destructive CTA buttons (`bg-red-*`, `bg-amber-*`, `bg-blue-*` paired with white text) now use `text-soleur-text-on-accent` for correct contrast in both themes.
- **chore(sw):** Bump service-worker `CACHE_NAME` to v6 to invalidate cached chunks for users on the prior bundle.
- **test:** New regression-grep harness `light-theme-tokenization.test.tsx` (122 assertions) blocks future hardcoded-gray drift.

## Test plan

- [x] All 6 surface groups tokenized (75 files modified)
- [x] Regression test (`light-theme-tokenization.test.tsx`) passes 122/122
- [x] Full vitest suite passes 3581/3581
- [x] `tsc --noEmit` clean
- [x] Code review pass: 3 reviewers, 1 P2 fixed inline (`chat/layout.tsx` aside missed in Group A sweep), zero P1
- [ ] ⏳ Visual QA in production: dev server has a pre-existing Sentry instrumentation hook ESM crash that prevents local browser verification (unrelated to this PR). Recommended post-deploy: visit dashboard, chat, KB browser, settings in both Forge and Radiance, confirm no leftover dark cards on light backgrounds and vice versa.

## Out of scope

- Status-color tokenization (`text-red-400`, `text-amber-400`, etc. as light-tone status text) — pre-existing 40-site concern, deferred to a separate PR.
- Marketing/docs site theming.
- `chat/leader-colors.ts` palette refactor (intentional cross-theme identity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)