### PR TITLE
fix(theme): selector gap, transition mismatch, and light-mode FOUC

### DIFF
--- a/apps/web-platform/app/(dashboard)/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/layout.tsx
@@ -324,7 +324,7 @@ export default function DashboardLayout({
             room for the 3-segment control). Anchored under a "THEME"
             ALL-CAPS label per brand-guide.md section-label convention. */}
         {!collapsed && (
-          <div className="border-t border-soleur-border-default px-3 pt-3">
+          <div className="border-t border-soleur-border-default p-3">
             <p className="px-1 pb-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-soleur-accent-gold-fg">
               Theme
             </p>

--- a/apps/web-platform/components/theme/no-fouc-script.tsx
+++ b/apps/web-platform/components/theme/no-fouc-script.tsx
@@ -1,3 +1,8 @@
+import {
+  NO_TRANSITION_CSS_TEXT,
+  NO_TRANSITION_STYLE_ID,
+} from "@/components/theme/no-transition-contract";
+
 /**
  * No-FOUC theme bootstrap. Runs synchronously in <head> BEFORE the React
  * tree mounts so the first paint matches the user's persisted theme. Reads
@@ -8,13 +13,18 @@
  *      pre-paint hints. These bypass stylesheet load timing entirely —
  *      even if globals.css is still loading, the very first paint matches
  *      the resolved palette and the user does not see a dark-to-light
- *      flash on Light-mode reload.
+ *      flash on Light-mode reload. `style.colorScheme` is left set after
+ *      cleanup; the runtime <ThemeProvider> re-asserts it on every theme
+ *      change so UA-rendered widgets (scrollbars, form controls) follow
+ *      the active palette.
  *   3. Injects a transient <style id="__soleur-no-transition"> with
  *      `transition: none` and `animation-duration: 0s`, removed on the
  *      next frame via double-rAF. Prevents first-paint transitions when
  *      React hydrates and consumer components compute their own initial
  *      colors against `transition-colors` utilities. Mirrors the runtime
- *      `disableTransitionsForOneFrame` helper in theme-provider.tsx.
+ *      `disableTransitionsForOneFrame` helper in theme-provider.tsx; both
+ *      sides import the id and CSS text from no-transition-contract.ts so
+ *      the contract has a single source of truth.
  *
  * Server-rendered as an inline <script>; Next.js 15 will attach the
  * per-request CSP nonce automatically because we render this from a Server
@@ -22,6 +32,12 @@
  *
  * The script is intentionally tiny and dependency-free — anything heavy
  * here delays Time-To-First-Contentful-Paint.
+ *
+ * Agent-DX: external introspection of the resolved theme should read
+ * `documentElement.dataset.theme` (stable, persisted) or
+ * `documentElement.style.colorScheme` (re-asserted on every theme change).
+ * Do NOT read `documentElement.style.backgroundColor` — it is a transient
+ * pre-paint hint cleared on the first cleanup frame.
  *
  * IMPORTANT: the hex literals below MUST match `--soleur-bg-base` for each
  * palette in app/globals.css. The drift-guard test in
@@ -52,38 +68,36 @@ const SCRIPT = `(function () {
     // Pre-paint inline-style hint. colorScheme governs system colors for
     // form controls, scrollbars, and the default <body> background;
     // backgroundColor on <html> ensures the very first paint matches the
-    // resolved palette even if the stylesheet is still loading. The hex
-    // literals duplicate --soleur-bg-base from globals.css; drift is
-    // caught by the drift-guard test.
+    // resolved palette even if the stylesheet is still loading.
     html.style.colorScheme = effective === "light" ? "light" : "dark";
     html.style.backgroundColor = effective === "light" ? "#fbf7ee" : "#0a0a0a";
 
     // Inject a transient transition-disable override so React's hydration
     // and any first-paint transition-colors consumer doesn't animate from
     // its initial computed value. Removed via double-rAF after first paint.
-    var STYLE_ID = "__soleur-no-transition";
-    if (!document.getElementById(STYLE_ID)) {
-      var s = document.createElement("style");
-      s.id = STYLE_ID;
-      s.textContent = "* { transition: none !important; animation-duration: 0s !important; }";
-      document.head.appendChild(s);
+    // No existence guard — this script is the very first thing to run in
+    // <head>; nothing earlier could have injected the same id.
+    var s = document.createElement("style");
+    s.id = ${JSON.stringify(NO_TRANSITION_STYLE_ID)};
+    s.textContent = ${JSON.stringify(NO_TRANSITION_CSS_TEXT)};
+    document.head.appendChild(s);
 
-      var cleanup = function () {
-        var existing = document.getElementById(STYLE_ID);
-        if (existing) existing.remove();
-        // Clear the inline backgroundColor so subsequent CSS-only theme
-        // changes (data-theme writes that update --soleur-bg-base) take
-        // effect normally. colorScheme stays — browser system colors
-        // benefit from the persistent hint, and it is harmlessly
-        // re-asserted on every theme change by the runtime helper.
-        html.style.backgroundColor = "";
-      };
-      var raf = window.requestAnimationFrame;
-      if (typeof raf === "function") {
-        raf(function () { raf(cleanup); });
-      } else {
-        setTimeout(cleanup, 0);
-      }
+    var cleanup = function () {
+      var existing = document.getElementById(${JSON.stringify(NO_TRANSITION_STYLE_ID)});
+      if (existing) existing.remove();
+      // Clear the inline backgroundColor so subsequent CSS-only theme
+      // changes (data-theme writes that update --soleur-bg-base) take
+      // effect normally. colorScheme stays — the runtime <ThemeProvider>
+      // re-asserts it on every theme change, and the persistent inline
+      // hint keeps UA-rendered widgets aligned with the active palette
+      // even before React hydrates.
+      html.style.backgroundColor = "";
+    };
+    var raf = window.requestAnimationFrame;
+    if (typeof raf === "function") {
+      raf(function () { raf(cleanup); });
+    } else {
+      setTimeout(cleanup, 0);
     }
   } catch (_e) {
     document.documentElement.dataset.theme = "system";

--- a/apps/web-platform/components/theme/no-fouc-script.tsx
+++ b/apps/web-platform/components/theme/no-fouc-script.tsx
@@ -1,7 +1,20 @@
 /**
  * No-FOUC theme bootstrap. Runs synchronously in <head> BEFORE the React
  * tree mounts so the first paint matches the user's persisted theme. Reads
- * localStorage["soleur:theme"] and sets <html data-theme=...>.
+ * localStorage["soleur:theme"] and:
+ *
+ *   1. Sets <html data-theme=...> so CSS variables resolve correctly.
+ *   2. Writes documentElement.style.colorScheme + style.backgroundColor as
+ *      pre-paint hints. These bypass stylesheet load timing entirely —
+ *      even if globals.css is still loading, the very first paint matches
+ *      the resolved palette and the user does not see a dark-to-light
+ *      flash on Light-mode reload.
+ *   3. Injects a transient <style id="__soleur-no-transition"> with
+ *      `transition: none` and `animation-duration: 0s`, removed on the
+ *      next frame via double-rAF. Prevents first-paint transitions when
+ *      React hydrates and consumer components compute their own initial
+ *      colors against `transition-colors` utilities. Mirrors the runtime
+ *      `disableTransitionsForOneFrame` helper in theme-provider.tsx.
  *
  * Server-rendered as an inline <script>; Next.js 15 will attach the
  * per-request CSP nonce automatically because we render this from a Server
@@ -9,6 +22,12 @@
  *
  * The script is intentionally tiny and dependency-free — anything heavy
  * here delays Time-To-First-Contentful-Paint.
+ *
+ * IMPORTANT: the hex literals below MUST match `--soleur-bg-base` for each
+ * palette in app/globals.css. The drift-guard test in
+ * test/components/theme-no-fouc-script.test.tsx asserts parity at CI time;
+ * a brand-guide palette refresh that updates globals.css without updating
+ * this file will fail the drift-guard before merge.
  */
 const SCRIPT = `(function () {
   try {
@@ -16,7 +35,56 @@ const SCRIPT = `(function () {
     if (v !== "dark" && v !== "light" && v !== "system") {
       v = "system";
     }
-    document.documentElement.dataset.theme = v;
+    var html = document.documentElement;
+    html.dataset.theme = v;
+
+    // Resolve the effective palette for the inline pre-paint hint. For
+    // "system", read prefers-color-scheme; matchMedia is synchronous and
+    // safe in a head script. Defaults to dark on any failure to mirror the
+    // CSS cascade fallback.
+    var effective = v;
+    if (v === "system") {
+      effective = (window.matchMedia &&
+        window.matchMedia("(prefers-color-scheme: light)").matches)
+        ? "light" : "dark";
+    }
+
+    // Pre-paint inline-style hint. colorScheme governs system colors for
+    // form controls, scrollbars, and the default <body> background;
+    // backgroundColor on <html> ensures the very first paint matches the
+    // resolved palette even if the stylesheet is still loading. The hex
+    // literals duplicate --soleur-bg-base from globals.css; drift is
+    // caught by the drift-guard test.
+    html.style.colorScheme = effective === "light" ? "light" : "dark";
+    html.style.backgroundColor = effective === "light" ? "#fbf7ee" : "#0a0a0a";
+
+    // Inject a transient transition-disable override so React's hydration
+    // and any first-paint transition-colors consumer doesn't animate from
+    // its initial computed value. Removed via double-rAF after first paint.
+    var STYLE_ID = "__soleur-no-transition";
+    if (!document.getElementById(STYLE_ID)) {
+      var s = document.createElement("style");
+      s.id = STYLE_ID;
+      s.textContent = "* { transition: none !important; animation-duration: 0s !important; }";
+      document.head.appendChild(s);
+
+      var cleanup = function () {
+        var existing = document.getElementById(STYLE_ID);
+        if (existing) existing.remove();
+        // Clear the inline backgroundColor so subsequent CSS-only theme
+        // changes (data-theme writes that update --soleur-bg-base) take
+        // effect normally. colorScheme stays — browser system colors
+        // benefit from the persistent hint, and it is harmlessly
+        // re-asserted on every theme change by the runtime helper.
+        html.style.backgroundColor = "";
+      };
+      var raf = window.requestAnimationFrame;
+      if (typeof raf === "function") {
+        raf(function () { raf(cleanup); });
+      } else {
+        setTimeout(cleanup, 0);
+      }
+    }
   } catch (_e) {
     document.documentElement.dataset.theme = "system";
   }

--- a/apps/web-platform/components/theme/no-transition-contract.ts
+++ b/apps/web-platform/components/theme/no-transition-contract.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared contract between the inline boot script (`no-fouc-script.tsx`) and
+ * the runtime provider (`theme-provider.tsx`). Both managers inject and
+ * remove a transient `<style id="__soleur-no-transition">` to suppress CSS
+ * transitions and keyframe animations for one paint frame around a theme
+ * change. They MUST agree on the id and the CSS text or one side's bail
+ * guard will not match the other side's element.
+ *
+ * The boot script cannot import at runtime — it is rendered as an inline
+ * `<script dangerouslySetInnerHTML>` whose body must be self-contained
+ * before the bundle loads. It interpolates these constants at build time
+ * via a JS template literal, so any drift between the two files is caught
+ * by the build step (TypeScript compile-time identity).
+ */
+
+export const NO_TRANSITION_STYLE_ID = "__soleur-no-transition";
+
+export const NO_TRANSITION_CSS_TEXT =
+  "* { transition: none !important; animation-duration: 0s !important; }";

--- a/apps/web-platform/components/theme/theme-provider.tsx
+++ b/apps/web-platform/components/theme/theme-provider.tsx
@@ -4,11 +4,16 @@ import {
   createContext,
   useContext,
   useEffect,
+  useRef,
   useState,
   useCallback,
   useMemo,
 } from "react";
 import { reportSilentFallback } from "@/lib/client-observability";
+import {
+  NO_TRANSITION_CSS_TEXT,
+  NO_TRANSITION_STYLE_ID,
+} from "@/components/theme/no-transition-contract";
 
 export type Theme = "dark" | "light" | "system";
 export type ResolvedTheme = "dark" | "light";
@@ -55,8 +60,6 @@ function readStoredTheme(): Theme {
  *
  * No-op on the server.
  */
-const NO_TRANSITION_STYLE_ID = "__soleur-no-transition";
-
 function disableTransitionsForOneFrame(): void {
   if (typeof document === "undefined") return;
   // Bail if a previous call (e.g., the inline boot script's transient
@@ -67,8 +70,7 @@ function disableTransitionsForOneFrame(): void {
 
   const style = document.createElement("style");
   style.id = NO_TRANSITION_STYLE_ID;
-  style.textContent =
-    "* { transition: none !important; animation-duration: 0s !important; }";
+  style.textContent = NO_TRANSITION_CSS_TEXT;
   document.head.appendChild(style);
 
   // Force a synchronous style recalc so the override is committed BEFORE
@@ -140,14 +142,35 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     typeof window === "undefined" ? "dark" : resolveInitial(readStoredTheme()),
   );
 
-  // Apply data-theme on the html element whenever theme changes. Runs once
-  // post-mount to harmonise with the lazy initializer above (covers the
-  // narrow window where the inline script wrote a stale value before the
-  // user changed their preference in another tab).
+  // Apply data-theme on the html element whenever theme changes. The first
+  // run on mount writes the attribute (covers the narrow window where the
+  // inline script wrote a stale value vs. another tab) but intentionally
+  // skips disableTransitionsForOneFrame: the inline <NoFoucScript> already
+  // owns the boot-frame transition-disable cleanup, and the helper would
+  // no-op anyway via its bail guard while the boot-script's <style> is
+  // still alive. Skipping the call avoids an unnecessary createElement +
+  // reflow round on first mount.
+  const prevThemeRef = useRef<Theme | null>(null);
   useEffect(() => {
-    disableTransitionsForOneFrame();
+    if (prevThemeRef.current === theme) return;
+    if (prevThemeRef.current !== null) {
+      disableTransitionsForOneFrame();
+    }
     document.documentElement.dataset.theme = theme;
+    prevThemeRef.current = theme;
   }, [theme]);
+
+  // Re-assert html.style.colorScheme whenever the resolved palette flips.
+  // The inline boot script seeds colorScheme once at first paint; without
+  // re-assertion here, a user who boots Dark and toggles Light keeps
+  // `style.colorScheme = "dark"` permanently because nothing in the CSS
+  // cascade declares `color-scheme` for our data-theme blocks. Inline
+  // style beats stylesheet, so this assignment is the only path that
+  // updates UA-rendered widgets (scrollbars, form controls, default <body>
+  // background) after the boot frame.
+  useEffect(() => {
+    document.documentElement.style.colorScheme = resolvedTheme;
+  }, [resolvedTheme]);
 
   // Live OS-change listener: only matters when theme === "system". The CSS
   // @media (prefers-color-scheme) block in globals.css already handles the
@@ -191,6 +214,8 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       }
       const next = isTheme(event.newValue) ? event.newValue : "system";
       disableTransitionsForOneFrame();
+      // No localStorage.setItem here by design — the originating tab
+      // already persisted; mirroring the write would cause an event loop.
       setThemeState(next);
     }
     window.addEventListener("storage", onStorage);
@@ -198,8 +223,14 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const setTheme = useCallback((next: Theme) => {
+    let changed = false;
+    setThemeState((cur) => {
+      if (cur === next) return cur;
+      changed = true;
+      return next;
+    });
+    if (!changed) return;
     disableTransitionsForOneFrame();
-    setThemeState(next);
     try {
       localStorage.setItem(STORAGE_KEY, next);
     } catch (err) {

--- a/apps/web-platform/components/theme/theme-provider.tsx
+++ b/apps/web-platform/components/theme/theme-provider.tsx
@@ -31,6 +31,77 @@ function readStoredTheme(): Theme {
   return "system";
 }
 
+/**
+ * Suppress CSS transitions and keyframe animations for one paint frame.
+ *
+ * Theme switches re-resolve every `var(--soleur-*)` token that surfaces
+ * consume; surfaces with `transition-colors` (theme-toggle squares, active
+ * nav indicator, conversations-rail rows, chat bubbles) animate the change
+ * over Tailwind's default 150ms while the body and non-transitioning
+ * surfaces snap instantly. The user perceives this as different parts of
+ * the page changing theme at different speeds.
+ *
+ * Mirrors `next-themes`' `disableTransitionOnChange` pattern: inject a
+ * transient `<style>` with `transition: none !important;` BEFORE the
+ * `data-theme` attribute flips, force a synchronous style recalc so the
+ * override is committed, then remove the style on the next paint via
+ * double-rAF. Browsers commit the theme change as a single paint with no
+ * transition cascade.
+ *
+ * Also forces `animation-duration: 0s !important;` because `globals.css`
+ * declares a `pulse-border` keyframe used by `.message-bubble-active` —
+ * without this rule, an in-progress pulse would mid-animate during a
+ * theme switch.
+ *
+ * No-op on the server.
+ */
+const NO_TRANSITION_STYLE_ID = "__soleur-no-transition";
+
+function disableTransitionsForOneFrame(): void {
+  if (typeof document === "undefined") return;
+  // Bail if a previous call (e.g., the inline boot script's transient
+  // style, or a fast user toggle within the same frame) already injected
+  // the override. The existing element is on its own rAF cleanup
+  // schedule — we do not extend it here.
+  if (document.getElementById(NO_TRANSITION_STYLE_ID)) return;
+
+  const style = document.createElement("style");
+  style.id = NO_TRANSITION_STYLE_ID;
+  style.textContent =
+    "* { transition: none !important; animation-duration: 0s !important; }";
+  document.head.appendChild(style);
+
+  // Force a synchronous style recalc so the override is committed BEFORE
+  // the data-theme attribute change. Reading getComputedStyle on a
+  // non-pseudo element is the standard reflow-forcing trick; opacity is
+  // cheap to read and defends against dead-code-elimination.
+  if (typeof window !== "undefined" && document.body) {
+    void window.getComputedStyle(document.body).opacity;
+  }
+
+  // Double-rAF cleanup: gives the browser one full frame to commit the
+  // theme change without animation, then removes the override on the
+  // following frame. Resolve via globalThis so test stubs (vi.stubGlobal)
+  // override the lookup; a bare `requestAnimationFrame` reference may bind
+  // to the host's native function past property writes on globalThis.
+  function schedule(cb: FrameRequestCallback): void {
+    const g = globalThis as unknown as {
+      requestAnimationFrame?: (cb: FrameRequestCallback) => number;
+    };
+    if (typeof g.requestAnimationFrame === "function") {
+      g.requestAnimationFrame(cb);
+      return;
+    }
+    setTimeout(() => cb(0), 0);
+  }
+  schedule(() => {
+    schedule(() => {
+      const existing = document.getElementById(NO_TRANSITION_STYLE_ID);
+      if (existing) existing.remove();
+    });
+  });
+}
+
 function getSystemPreference(): ResolvedTheme {
   if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
     return "dark";
@@ -74,6 +145,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   // narrow window where the inline script wrote a stale value before the
   // user changed their preference in another tab).
   useEffect(() => {
+    disableTransitionsForOneFrame();
     document.documentElement.dataset.theme = theme;
   }, [theme]);
 
@@ -92,6 +164,8 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
     setResolvedTheme(mq.matches ? "dark" : "light");
     const handler = (e: { matches: boolean }) => {
+      // OS flipped under "system" — same instant-switch invariant.
+      disableTransitionsForOneFrame();
       setResolvedTheme(e.matches ? "dark" : "light");
     };
     mq.addEventListener("change", handler);
@@ -116,6 +190,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
         });
       }
       const next = isTheme(event.newValue) ? event.newValue : "system";
+      disableTransitionsForOneFrame();
       setThemeState(next);
     }
     window.addEventListener("storage", onStorage);
@@ -123,6 +198,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const setTheme = useCallback((next: Theme) => {
+    disableTransitionsForOneFrame();
     setThemeState(next);
     try {
       localStorage.setItem(STORAGE_KEY, next);

--- a/apps/web-platform/test/components/theme-no-fouc-script.test.tsx
+++ b/apps/web-platform/test/components/theme-no-fouc-script.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Unit + drift-guard tests for the inline <NoFoucScript> bootstrap. The
+ * SCRIPT constant is a static string rendered via dangerouslySetInnerHTML,
+ * so we assert on its source rather than executing it under JSDOM.
+ *
+ * The drift-guard test reads globals.css and confirms the inline script's
+ * hex literals match the canonical --soleur-bg-base values declared for
+ * each palette. A brand-guide palette refresh that updates globals.css
+ * without updating the script will fail this test at CI time.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const SCRIPT_FILE = resolve(__dirname, "../../components/theme/no-fouc-script.tsx");
+const CSS_FILE = resolve(__dirname, "../../app/globals.css");
+
+function readScriptSource(): string {
+  return readFileSync(SCRIPT_FILE, "utf8");
+}
+
+describe("NoFoucScript SCRIPT contents", () => {
+  it("writes documentElement.style.colorScheme synchronously", () => {
+    const src = readScriptSource();
+    expect(src).toMatch(/\.style\.colorScheme\s*=/);
+  });
+
+  it("writes documentElement.style.backgroundColor synchronously", () => {
+    const src = readScriptSource();
+    expect(src).toMatch(/\.style\.backgroundColor\s*=/);
+  });
+
+  it("contains the light palette base hex literal (#fbf7ee)", () => {
+    const src = readScriptSource();
+    expect(src.toLowerCase()).toContain("#fbf7ee");
+  });
+
+  it("contains the dark palette base hex literal (#0a0a0a)", () => {
+    const src = readScriptSource();
+    expect(src.toLowerCase()).toContain("#0a0a0a");
+  });
+
+  it("injects a transient style element with the __soleur-no-transition id", () => {
+    const src = readScriptSource();
+    expect(src).toContain("__soleur-no-transition");
+  });
+
+  it("calls localStorage.getItem('soleur:theme') exactly once", () => {
+    const src = readScriptSource();
+    const matches = src.match(/localStorage\.getItem\(["']soleur:theme["']\)/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+
+  it("falls back to 'system' on invalid stored values", () => {
+    const src = readScriptSource();
+    // Two fallback paths: invalid value normalisation + try/catch fallback.
+    // Both must coerce to "system".
+    const systemFallbacks = src.match(/=\s*["']system["']/g) ?? [];
+    expect(systemFallbacks.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("queries prefers-color-scheme to resolve 'system' to a concrete palette", () => {
+    const src = readScriptSource();
+    expect(src).toContain("prefers-color-scheme");
+  });
+});
+
+describe("no-fouc-script hex literal drift-guard", () => {
+  it("script literals match globals.css --soleur-bg-base values", () => {
+    const script = readScriptSource();
+    const css = readFileSync(CSS_FILE, "utf8");
+
+    // Extract --soleur-bg-base from :root[data-theme="light"] and "dark" blocks.
+    // The CSS declares the dark variables under both `:root` and
+    // `:root[data-theme="dark"]`; either qualifier is acceptable.
+    const lightMatch = css.match(
+      /\[data-theme="light"\][^}]*--soleur-bg-base:\s*([^;]+);/,
+    );
+    const darkMatch = css.match(
+      /\[data-theme="dark"\][^}]*--soleur-bg-base:\s*([^;]+);/,
+    );
+
+    expect(lightMatch?.[1]?.trim()).toBeTruthy();
+    expect(darkMatch?.[1]?.trim()).toBeTruthy();
+    expect(script.toLowerCase()).toContain(lightMatch![1].trim().toLowerCase());
+    expect(script.toLowerCase()).toContain(darkMatch![1].trim().toLowerCase());
+  });
+});

--- a/apps/web-platform/test/components/theme-no-fouc-script.test.tsx
+++ b/apps/web-platform/test/components/theme-no-fouc-script.test.tsx
@@ -11,6 +11,10 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import {
+  NO_TRANSITION_CSS_TEXT,
+  NO_TRANSITION_STYLE_ID,
+} from "@/components/theme/no-transition-contract";
 
 const SCRIPT_FILE = resolve(__dirname, "../../components/theme/no-fouc-script.tsx");
 const CSS_FILE = resolve(__dirname, "../../app/globals.css");
@@ -40,9 +44,25 @@ describe("NoFoucScript SCRIPT contents", () => {
     expect(src.toLowerCase()).toContain("#0a0a0a");
   });
 
-  it("injects a transient style element with the __soleur-no-transition id", () => {
+  it("imports the shared NO_TRANSITION_STYLE_ID + NO_TRANSITION_CSS_TEXT contract", () => {
     const src = readScriptSource();
-    expect(src).toContain("__soleur-no-transition");
+    // Both the runtime helper (theme-provider.tsx) and this boot script
+    // import these constants from no-transition-contract.ts. TypeScript's
+    // compile-time identity is the load-bearing drift-guard between the
+    // two files; this test just confirms the import edge survives any
+    // future refactor that might inline the literals back into either
+    // file. The constants themselves ARE used (referenced via
+    // ${"$"}{JSON.stringify(NO_TRANSITION_STYLE_ID)} interpolation in the
+    // SCRIPT template), so an unused-import lint would flag a regression.
+    expect(src).toMatch(
+      /from\s+["']@\/components\/theme\/no-transition-contract["']/,
+    );
+    expect(src).toContain("NO_TRANSITION_STYLE_ID");
+    expect(src).toContain("NO_TRANSITION_CSS_TEXT");
+    // Sanity: confirm the constants resolve to non-empty values at test
+    // time so the contract module isn't accidentally exporting empty strings.
+    expect(NO_TRANSITION_STYLE_ID.length).toBeGreaterThan(0);
+    expect(NO_TRANSITION_CSS_TEXT).toMatch(/transition:\s*none/);
   });
 
   it("calls localStorage.getItem('soleur:theme') exactly once", () => {
@@ -66,23 +86,40 @@ describe("NoFoucScript SCRIPT contents", () => {
 });
 
 describe("no-fouc-script hex literal drift-guard", () => {
-  it("script literals match globals.css --soleur-bg-base values", () => {
+  // Anchor to `:root[data-theme="..."]` (canonical block in globals.css)
+  // rather than `[data-theme="..."]`; the @custom-variant declaration at
+  // the top of globals.css also contains `[data-theme="dark"]` but no
+  // `--soleur-bg-base`, and a permissive regex would silently fall through
+  // to a later match on a CSS reorder. Anchoring removes that ambiguity.
+  function extractBgBase(css: string, palette: "light" | "dark"): string {
+    const re = new RegExp(
+      `:root\\[data-theme="${palette}"\\]\\s*\\{[^}]*?--soleur-bg-base:\\s*([^;]+);`,
+    );
+    const match = css.match(re);
+    return match?.[1]?.trim() ?? "";
+  }
+
+  it("script literal matches globals.css :root[data-theme=light] --soleur-bg-base", () => {
     const script = readScriptSource();
     const css = readFileSync(CSS_FILE, "utf8");
+    const lightHex = extractBgBase(css, "light");
 
-    // Extract --soleur-bg-base from :root[data-theme="light"] and "dark" blocks.
-    // The CSS declares the dark variables under both `:root` and
-    // `:root[data-theme="dark"]`; either qualifier is acceptable.
-    const lightMatch = css.match(
-      /\[data-theme="light"\][^}]*--soleur-bg-base:\s*([^;]+);/,
-    );
-    const darkMatch = css.match(
-      /\[data-theme="dark"\][^}]*--soleur-bg-base:\s*([^;]+);/,
-    );
+    expect(lightHex, "light --soleur-bg-base not found in globals.css").toBeTruthy();
+    expect(
+      script.toLowerCase(),
+      `script missing light hex literal '${lightHex}'`,
+    ).toContain(lightHex.toLowerCase());
+  });
 
-    expect(lightMatch?.[1]?.trim()).toBeTruthy();
-    expect(darkMatch?.[1]?.trim()).toBeTruthy();
-    expect(script.toLowerCase()).toContain(lightMatch![1].trim().toLowerCase());
-    expect(script.toLowerCase()).toContain(darkMatch![1].trim().toLowerCase());
+  it("script literal matches globals.css :root[data-theme=dark] --soleur-bg-base", () => {
+    const script = readScriptSource();
+    const css = readFileSync(CSS_FILE, "utf8");
+    const darkHex = extractBgBase(css, "dark");
+
+    expect(darkHex, "dark --soleur-bg-base not found in globals.css").toBeTruthy();
+    expect(
+      script.toLowerCase(),
+      `script missing dark hex literal '${darkHex}'`,
+    ).toContain(darkHex.toLowerCase());
   });
 });

--- a/apps/web-platform/test/theme-provider.test.tsx
+++ b/apps/web-platform/test/theme-provider.test.tsx
@@ -254,6 +254,47 @@ describe("ThemeProvider", () => {
     consoleSpy.mockRestore();
   });
 
+  it("setTheme injects __soleur-no-transition style and removes it on next frames", async () => {
+    const { matchMedia } = makeMatchMedia(true);
+    vi.stubGlobal("matchMedia", matchMedia);
+
+    // Polyfill rAF on JSDOM/happy-dom — the transition-disable helper relies
+    // on a double-rAF cleanup. setTimeout(0) is a faithful enough stand-in
+    // for our purposes (we want to assert the cleanup eventually runs, not
+    // verify exact frame timing).
+    const rafs: Array<() => void> = [];
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      rafs.push(() => cb(0));
+      return rafs.length;
+    });
+
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+
+    act(() => {
+      screen.getByText("set-light").click();
+    });
+
+    // The helper should have appended a style element with the agreed id.
+    const styleEl = document.head.querySelector("style#__soleur-no-transition");
+    expect(styleEl).not.toBeNull();
+    expect(styleEl!.textContent).toMatch(/transition\s*:\s*none/);
+
+    // Drain the queued rAF callbacks (double-rAF cleanup); the style should
+    // be removed after both fire.
+    act(() => {
+      while (rafs.length) {
+        const next = rafs.shift()!;
+        next();
+      }
+    });
+
+    expect(document.head.querySelector("style#__soleur-no-transition")).toBeNull();
+  });
+
   it("setTheme survives localStorage.setItem quota errors (state still updates)", () => {
     const { matchMedia } = makeMatchMedia(true);
     vi.stubGlobal("matchMedia", matchMedia);

--- a/apps/web-platform/test/theme-provider.test.tsx
+++ b/apps/web-platform/test/theme-provider.test.tsx
@@ -58,6 +58,12 @@ describe("ThemeProvider", () => {
   beforeEach(() => {
     localStorage.clear();
     document.documentElement.removeAttribute("data-theme");
+    // Scrub any stale transition-disable style left by an undrained rAF in
+    // the previous test on this happy-dom worker. Tests that do not stub
+    // rAF rely on happy-dom's native rAF, which may not fire before the
+    // test ends — cleanup callbacks (and their <style> elements) leak.
+    const stale = document.head.querySelector("style#__soleur-no-transition");
+    if (stale) stale.remove();
   });
 
   afterEach(() => {
@@ -254,17 +260,16 @@ describe("ThemeProvider", () => {
     consoleSpy.mockRestore();
   });
 
-  it("setTheme injects __soleur-no-transition style and removes it on next frames", async () => {
+  it("setTheme injects __soleur-no-transition style and removes it on next frames", () => {
     const { matchMedia } = makeMatchMedia(true);
     vi.stubGlobal("matchMedia", matchMedia);
 
-    // Polyfill rAF on JSDOM/happy-dom — the transition-disable helper relies
-    // on a double-rAF cleanup. setTimeout(0) is a faithful enough stand-in
-    // for our purposes (we want to assert the cleanup eventually runs, not
-    // verify exact frame timing).
-    const rafs: Array<() => void> = [];
+    // Defer the queued rAF callbacks so the test can observe the style
+    // BEFORE the cleanup runs, then explicitly drain. Two-deep recursion is
+    // expected (double-rAF cleanup); the loop drains both.
+    const rafs: Array<FrameRequestCallback> = [];
     vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
-      rafs.push(() => cb(0));
+      rafs.push(cb);
       return rafs.length;
     });
 
@@ -274,23 +279,30 @@ describe("ThemeProvider", () => {
       </ThemeProvider>,
     );
 
+    // Initial mount queued one rAF. Drain only the cleanup pair from the
+    // mount BEFORE the click so the click's helper invocation can re-inject
+    // (won't bail) and we observe a fresh style element.
+    while (rafs.length) {
+      const next = rafs.shift()!;
+      next(0);
+    }
+    expect(document.head.querySelector("style#__soleur-no-transition")).toBeNull();
+
     act(() => {
       screen.getByText("set-light").click();
     });
 
-    // The helper should have appended a style element with the agreed id.
+    // setTheme injected the style synchronously.
     const styleEl = document.head.querySelector("style#__soleur-no-transition");
     expect(styleEl).not.toBeNull();
     expect(styleEl!.textContent).toMatch(/transition\s*:\s*none/);
 
-    // Drain the queued rAF callbacks (double-rAF cleanup); the style should
-    // be removed after both fire.
-    act(() => {
-      while (rafs.length) {
-        const next = rafs.shift()!;
-        next();
-      }
-    });
+    // Drain queued rAFs; each invocation may schedule another (double-rAF
+    // cleanup). After the queue empties, the override style is removed.
+    while (rafs.length) {
+      const next = rafs.shift()!;
+      next(0);
+    }
 
     expect(document.head.querySelector("style#__soleur-no-transition")).toBeNull();
   });

--- a/knowledge-base/project/learnings/2026-05-06-source-grep-drift-guards-break-after-buildtime-interpolation.md
+++ b/knowledge-base/project/learnings/2026-05-06-source-grep-drift-guards-break-after-buildtime-interpolation.md
@@ -1,0 +1,110 @@
+---
+title: Source-grep drift-guards break after build-time interpolation; switch to compile-time identity
+date: 2026-05-06
+category: test-failures
+tags: [drift-guard, build-time-interpolation, typescript-identity, no-fouc-script, theme-system]
+problem_type: test_failure
+component: theme/no-fouc-script
+related_pr: "#3309"
+related_learnings:
+  - 2026-04-27-critical-css-fouc-prevention-via-static-and-playwright-gates.md
+  - 2026-04-22-ts-sql-normalizer-parity-when-shipping-backfill-migration.md
+---
+
+# Source-grep Drift-Guards Break After Build-Time Interpolation
+
+## Problem
+
+PR #3309 introduced a runtime helper `disableTransitionsForOneFrame` in `theme-provider.tsx` and a parallel inline boot-script in `no-fouc-script.tsx`. Both injected a transient `<style id="__soleur-no-transition">` with the same CSS text. The original test asserted on the SCRIPT source via `readFileSync`:
+
+```ts
+expect(src).toContain("__soleur-no-transition");
+expect(src).toContain("* { transition: none !important; ...");
+```
+
+This caught lexical drift between the two files but provided no real guarantee — the `STYLE_ID` was a string literal in both files, so a typo in either would silently desync.
+
+A reviewer (`pattern-recognition-specialist` and `code-quality-analyst`) recommended extracting the contract to a shared TS module:
+
+```ts
+// no-transition-contract.ts
+export const NO_TRANSITION_STYLE_ID = "__soleur-no-transition";
+export const NO_TRANSITION_CSS_TEXT = "* { transition: none !important; ...";
+```
+
+Both files now import these. The boot script — which is a `const SCRIPT = \`...\`` template literal rendered as a runtime string — interpolates them at build time:
+
+```ts
+s.id = ${JSON.stringify(NO_TRANSITION_STYLE_ID)};
+s.textContent = ${JSON.stringify(NO_TRANSITION_CSS_TEXT)};
+```
+
+After the refactor, the source-grep test broke:
+
+```
+expected 'import { NO_TRANSITION_CSS_TEXT, ... } from "...";\nconst SCRIPT = `...${JSON.stringify(NO_TRANSITION_CSS_TEXT)}...`'
+to contain '"* { transition: none !important; animation-duration: 0s !important; }"'
+```
+
+`readFileSync` returns the *un-interpolated source* — the `${JSON.stringify(NO_TRANSITION_CSS_TEXT)}` placeholder, not the resolved string. The drift-guard regex was looking for content that no longer exists in the file.
+
+## Root Cause
+
+A source-grep test asserts on **what the editor sees**, not **what the program runs with**. When a build-time mechanism (template-literal interpolation, code generation, macro expansion, `defineConfig({ define: { ... } })`) substitutes values *before* runtime, the source diverges from the runtime string and any source-grep assertion against the post-substitution value silently breaks — even though the runtime behavior is correct.
+
+The class:
+- Source-grep tests work when the value lives inline in the file as a string literal.
+- Source-grep tests break when the value is referenced by name and resolved at build time.
+- The fix is not to revert to inline literals — it is to recognize that the **drift-guard moved from runtime to compile-time**.
+
+## Solution
+
+When refactoring duplicated string literals to shared TS constants:
+
+1. **Drop source-grep tests that assert the literal content.** TypeScript's compile-time identity (`import { X } from "./contract"`) is now the load-bearing drift-guard between files. A typo, rename, or removal of the constant in `no-transition-contract.ts` produces a TS compile error in BOTH consumer files — strictly stronger than a runtime regex.
+
+2. **Replace with edge-asserting tests.** Confirm the import edge survives refactors (so a future inline-literal regression flips back to a real drift surface):
+
+   ```ts
+   it("imports the shared contract", () => {
+     const src = readScriptSource();
+     expect(src).toMatch(/from\s+["']@\/components\/theme\/no-transition-contract["']/);
+     expect(src).toContain("NO_TRANSITION_STYLE_ID");
+     expect(src).toContain("NO_TRANSITION_CSS_TEXT");
+     // Sanity: constants resolve to non-empty values at test time.
+     expect(NO_TRANSITION_STYLE_ID.length).toBeGreaterThan(0);
+     expect(NO_TRANSITION_CSS_TEXT).toMatch(/transition:\s*none/);
+   });
+   ```
+
+3. **Keep source-grep tests for content that genuinely cannot live in TS.** Hex literals duplicated from `globals.css` (e.g., `#fbf7ee` for `--soleur-bg-base`) fall in this category — the boot script needs JS strings before stylesheets load, but the canonical source is CSS. The test reads `globals.css`, extracts the value via regex anchored to `:root[data-theme="..."]`, and asserts the script contains it. This is a runtime check that survives refactors because the canonical-source file is the regex target, not the consuming file.
+
+## Key Insight
+
+Drift-guards have two failure modes:
+- **Brittleness** — they break on refactors that preserve behavior.
+- **Vacuity** — they pass when the actual contract has drifted (the matcher is too permissive).
+
+The fix for brittleness is rarely "revert the refactor." It is to recognize **where the drift surface moved** and route the guard to the new surface. When duplication collapses to shared imports, the drift surface moves from runtime strings to compile-time identifiers; the test should assert on the import edge or rely on the compiler.
+
+## Sharp Edges
+
+- A `${expr}` interpolation in a template-literal SCRIPT does NOT make the resolved value visible to `readFileSync(file)`. The placeholder text is what the file contains.
+- TypeScript compile-time identity protects two files from drifting against each other ONLY when both files import from the same source. If one file copies the value (`const X = "literal"`) instead of importing, the contract has degraded to runtime-only and source-grep is the only available guard. Code review should flag any inline copy of a shared-contract constant.
+- Hex literals in inline boot scripts are a special case: the script runs before stylesheets load, so it cannot import from CSS at runtime. The drift-guard must read the canonical CSS source and string-match the consumer — the inverse of the import-edge pattern.
+
+## Session Errors
+
+1. **CWD non-persistence on `cd apps/web-platform && vitest run`** — Recovery: switched to absolute-path commands. Prevention: AGENTS.md already documents Bash CWD non-persistence; one-off slip.
+2. **Stale `__soleur-no-transition` style leaked across happy-dom tests on the same worker** — Recovery: added `beforeEach` scrub. Prevention: any test file that adds module-level DOM mutators (style-injection, listener-attachment) must clean up in `beforeEach`/`afterEach`. Considered a learning candidate but already covered by the existing `cq-ref-removal-sweep-cleanup-closures` rule's spirit.
+3. **`vi.stubGlobal` indirection misdiagnosis** — initially attributed test failure to stub-coverage; real cause was Error #2. Recovery: routed the helper through `globalThis.requestAnimationFrame` defensively (not strictly required but improves test isolation) AND added the leak-scrub. Prevention: when a test failure points at a stubbing mechanism, verify the stub IS receiving calls (e.g., add a counter) before redesigning the helper.
+4. **Review-fix regression: 3 tests broke after applying P2 corrections** — Recovery: re-ran the full theme test suite after each fix, identified the two root causes (mount-skip dropped a load-bearing dataset write; source-grep broke on JSON.stringify interpolation), corrected the helper to write data-theme always while skipping the transition-disable on first run, replaced source-grep with import-edge assertion. Prevention: when applying review fixes, re-run not just the failed tests but the full file's suite and the broader-domain suite to catch regressions. Documented in this learning.
+5. **Semgrep auto-install failed (no brew/pipx/pip3)** — Recovery: announced the skip explicitly per skill rule; CI gate intact. Prevention: skill rule already covers ("Do NOT silently skip"); the explicit announcement was the correct response. Could update the review skill to allow continuation when the diff has no I/O/auth/network surfaces — but this is contested-design territory; leave as-is for now.
+6. **Dev server instrumentation ES-module mismatch** — pre-existing in `apps/web-platform`, blocked automated visual QA. Recovery: documented in QA report; visual scenarios deferred to Phase 5 manual. Prevention: file as a separate issue (out of scope for this PR).
+
+## Prevention
+
+When extracting shared TS constants for build-time interpolation:
+- **Audit every existing source-grep test** for the constants being centralized. Each one is a candidate for replacement with an import-edge assertion.
+- **Confirm the import edge is actually used** via a complementary assertion that the constant resolves at test time — guards against a refactor that imports without using.
+- **Keep the canonical-source-file pattern** for content that genuinely cannot live in TS (CSS variables read by inline JS before stylesheets load).

--- a/knowledge-base/project/plans/2026-05-06-fix-theme-selector-gap-and-fouc-plan.md
+++ b/knowledge-base/project/plans/2026-05-06-fix-theme-selector-gap-and-fouc-plan.md
@@ -153,8 +153,8 @@ This means the inline script grows from ~10 lines to ~25 lines and includes a tr
 
 **File:** `apps/web-platform/app/(dashboard)/layout.tsx`
 
-- [ ] 1.1 Change line 327 from `className="border-t border-soleur-border-default px-3 pt-3"` to `className="border-t border-soleur-border-default p-3"` (or `px-3 py-3` for consistency with the footer's pattern).
-- [ ] 1.2 Verify the THEME label's `pb-2` still produces the intended 8px below the label before the toggle (no change needed).
+- [x] 1.1 Change line 327 from `className="border-t border-soleur-border-default px-3 pt-3"` to `className="border-t border-soleur-border-default p-3"` (or `px-3 py-3` for consistency with the footer's pattern).
+- [x] 1.2 Verify the THEME label's `pb-2` still produces the intended 8px below the label before the toggle (no change needed).
 - [ ] 1.3 Visual confirm: above-toggle gap (border-t → label) and below-toggle gap (toggle → border-t) are now 12px each.
 
 ### Phase 2 — Transition Disable on Theme Change

--- a/knowledge-base/project/plans/2026-05-06-fix-theme-selector-gap-and-fouc-plan.md
+++ b/knowledge-base/project/plans/2026-05-06-fix-theme-selector-gap-and-fouc-plan.md
@@ -201,15 +201,15 @@ This means the inline script grows from ~10 lines to ~25 lines and includes a tr
 
 **File:** `apps/web-platform/components/theme/no-fouc-script.tsx`
 
-- [ ] 3.1 Replace the `SCRIPT` constant with the augmented version (see Research Insights → Issue 3). It must:
+- [x] 3.1 Replace the `SCRIPT` constant with the augmented version (see Research Insights → Issue 3). It must:
   - Resolve `effective` palette (light/dark) by reading `prefers-color-scheme` for "system".
   - Set `documentElement.style.colorScheme`.
   - Set `documentElement.style.backgroundColor` to the literal hex of `--soleur-bg-base` for the resolved palette.
   - Inject a transient `<style id="__soleur-no-transition">* { transition: none !important; animation-duration: 0s !important; }</style>` into `<head>` and remove it via double-rAF, mirroring the runtime helper. This prevents first-paint transitions on hydration when React mounts and consumers compute their own initial colors.
 
-- [ ] 3.2 Add an inline comment naming `--soleur-bg-base` value drift as a Sharp Edge — the hex literals in this script duplicate `globals.css` and must move together.
+- [x] 3.2 Add an inline comment naming `--soleur-bg-base` value drift as a Sharp Edge — the hex literals in this script duplicate `globals.css` and must move together.
 
-- [ ] 3.3 Confirm the inline-style hint clears once React's hydration runs OR at the moment the `<style id="__soleur-no-transition">` is removed. Ideally the inline `style.backgroundColor` is removed as part of the post-rAF cleanup, OR set on a `<html data-theme-bootstrapping>` attribute that's removed in a `useEffect` after first paint. **Prefer: remove `style.backgroundColor` and `style.colorScheme` after the first rAF as well, so future CSS-only theming (e.g., a future `:root[data-theme="dim"]`) is not pinned by an inline override.**
+- [x] 3.3 Confirm the inline-style hint clears once React's hydration runs OR at the moment the `<style id="__soleur-no-transition">` is removed. Ideally the inline `style.backgroundColor` is removed as part of the post-rAF cleanup, OR set on a `<html data-theme-bootstrapping>` attribute that's removed in a `useEffect` after first paint. **Prefer: remove `style.backgroundColor` and `style.colorScheme` after the first rAF as well, so future CSS-only theming (e.g., a future `:root[data-theme="dim"]`) is not pinned by an inline override.**
 
   Implementation choice: keep `style.colorScheme` (browser defaults benefit from this — scrollbars, autofill) but clear `style.backgroundColor` after first rAF; the body/`html` will then resolve via the now-correct CSS cascade.
 
@@ -217,7 +217,7 @@ This means the inline script grows from ~10 lines to ~25 lines and includes a tr
 
 **File (new):** `apps/web-platform/test/components/theme-no-fouc-script.test.tsx`
 
-- [ ] 4.1 Unit-test the augmented `<NoFoucScript>` script string for:
+- [x] 4.1 Unit-test the augmented `<NoFoucScript>` script string for:
   - Contains `style.colorScheme` write.
   - Contains `style.backgroundColor` write.
   - Contains both light hex (`#fbf7ee`) and dark hex (`#0a0a0a`) literals (drift-guard).
@@ -227,7 +227,7 @@ This means the inline script grows from ~10 lines to ~25 lines and includes a tr
 
   These are string-match assertions on the SCRIPT constant; no JSDOM execution required because the script is rendered via `dangerouslySetInnerHTML` as a static string.
 
-- [ ] 4.2 Add a "hex literal parity" assertion that reads `apps/web-platform/app/globals.css` and confirms the `--soleur-bg-base` declarations for `:root[data-theme="light"]` and `:root[data-theme="dark"]` match the script's literal strings. This is the drift-guard for the Sharp Edge in Phase 3.2.
+- [x] 4.2 Add a "hex literal parity" assertion that reads `apps/web-platform/app/globals.css` and confirms the `--soleur-bg-base` declarations for `:root[data-theme="light"]` and `:root[data-theme="dark"]` match the script's literal strings. This is the drift-guard for the Sharp Edge in Phase 3.2.
 
   ```ts
   import { describe, expect, it } from "vitest";
@@ -256,7 +256,7 @@ This means the inline script grows from ~10 lines to ~25 lines and includes a tr
 
 **File (extend):** `apps/web-platform/test/theme-provider.test.tsx`
 
-- [ ] 4.3 Add a unit test that calling `setTheme("light")` from `useTheme()` injects a `<style>` element with `transition: none` into `document.head`, and that the style is removed after two animation frames. Use JSDOM's `document.head.querySelectorAll("style")` to inspect, and a `requestAnimationFrame` polyfill (existing test file may already have one — verify in Phase 1 of /work).
+- [x] 4.3 Add a unit test that calling `setTheme("light")` from `useTheme()` injects a `<style>` element with `transition: none` into `document.head`, and that the style is removed after two animation frames. Use JSDOM's `document.head.querySelectorAll("style")` to inspect, and a `requestAnimationFrame` polyfill (existing test file may already have one — verify in Phase 1 of /work).
 
 ### Phase 5 — Visual QA
 

--- a/knowledge-base/project/plans/2026-05-06-fix-theme-selector-gap-and-fouc-plan.md
+++ b/knowledge-base/project/plans/2026-05-06-fix-theme-selector-gap-and-fouc-plan.md
@@ -1,0 +1,387 @@
+---
+type: bug-fix
+status: draft
+created: 2026-05-06
+deepened: 2026-05-06
+branch: feat-one-shot-theme-selector-gap-and-fouc-fixes
+related_pr: "#3271, #3308"
+related_issue: TBD
+requires_cpo_signoff: false
+---
+
+# Fix Theme Selector Gap, Theme-Switch Animation Mismatch, and Light-Mode FOUC
+
+## Enhancement Summary
+
+**Deepened on:** 2026-05-06
+**Sections enhanced:** Research Insights (Issue 2 + Issue 3 cross-validated against external sources), Risks (Chromium-specific note added), Sharp Edges (next-themes parity note added).
+
+### Key Improvements
+
+1. **Issue 2 root cause is industry-validated, not just locally diagnosed.** Tailwind GitHub Discussion #15598 ("Colors not updating synchronously when applying transition-colors property to all elements on Chromium") documents the exact symptom the user reported — Chromium's `transition-colors` repaints elements in DOM-walk order rather than in a single composite frame, producing visible per-element lag against non-transitioning surfaces. The plan's transition-disable approach is the canonical fix; Chromium developers have not committed to changing the rendering behavior. Source: [tailwindlabs/tailwindcss#15598](https://github.com/tailwindlabs/tailwindcss/discussions/15598).
+2. **Issue 2 fix matches next-themes' shipping pattern verbatim.** Context7 query against `/pacocoursey/next-themes` confirms `disableTransitionOnChange` is implemented as a transient `<style>* { transition: none !important; }</style>` injection + reflow-forcing `getComputedStyle` call + double-rAF cleanup. The plan's `disableTransitionsForOneFrame` helper mirrors this, with one deliberate difference: it adds `animation-duration: 0s !important;` because Soleur has a `pulse-border` keyframe animation declared in `globals.css:165-172` that next-themes does not have to defend against. Reference: [pacocoursey/next-themes README — Disable transitions on theme change](https://github.com/pacocoursey/next-themes/blob/main/README.md).
+3. **Issue 3 fix grounded in Tailwind v4 + CSS-variable interaction semantics.** Tailwind v4's `@theme` directive (used at `globals.css:122-138`) compiles `--color-soleur-*` variables into `var(--soleur-*)` references at every utility class. CSS variables resolve **per-element-at-paint-time**, not at parse-time — so a script-driven `data-theme` attribute change on `<html>` should produce a single repaint with the new var values. The flash window only opens when the script executes AFTER the browser has committed a "first frame." The inline-style hint (`html.style.colorScheme` + `html.style.backgroundColor`) makes the first frame correct regardless of script-vs-stylesheet load timing.
+4. **Tailwind v4-specific constraint pinned.** Tailwind v4's `transition-colors` utility does NOT itself emit CSS variables (per Tailwind issue #16639 — `transition-property` theme variables are not yet wired through). This means the plan's helper that injects `* { transition: none !important; }` cannot be replaced with a "set `--tw-transition-property: none` via inline style" alternative — direct CSS override is the only working pattern in v4. Source: [tailwindlabs/tailwindcss#16639](https://github.com/tailwindlabs/tailwindcss/issues/16639).
+
+### New Considerations Discovered
+
+- The existing FOUC-prevention learning (`knowledge-base/project/learnings/best-practices/2026-04-27-critical-css-fouc-prevention-via-static-and-playwright-gates.md`) addresses a **different** FOUC class — Eleventy `<link rel="preload" onload="this.rel='stylesheet'">` async-swap timing — and prescribes static + Playwright screenshot gates. It is adjacent but not directly applicable here. The Next.js theme-FOUC class is mitigated by inline-style hints, not by widening a critical-CSS subset.
+- The drift-guard test (Phase 4.2 in this plan) is the analog of that learning's "Layer 2 — static selector-coverage gate" — different mechanism, same intent: prevent the inline `<style>` from drifting silently from the source-of-truth CSS file.
+
+## Overview
+
+Three small theme-system polish bugs surfaced after PRs #3271 (theme toggle + tokens) and #3308 (web-platform tokenization):
+
+1. **Visual gap asymmetry under the theme selector.** In `apps/web-platform/app/(dashboard)/layout.tsx`, the wrapper around the THEME label + `<ThemeToggle />` uses `px-3 pt-3` (12px top padding, **0px bottom padding**) — the toggle's bottom edge butts directly against the next sibling's `border-t`. The "line above the selector" sits 12px from the THEME label; the "line below the selector" sits flush against the toggle. Result: visibly asymmetric vertical rhythm in the sidebar.
+2. **Theme-switch animation mismatch.** Surfaces with `transition-colors` (theme-toggle squares, active-page nav indicator, footer links, conversations-rail rows, many chat surfaces) animate their background/border/text from the old palette to the new over Tailwind's default 150ms `transition-duration`. The `<body>` background and most non-transitioning surfaces snap instantly because they consume `var(--soleur-bg-*)` directly with no `transition` declaration. The user perceives this as "some elements switch theme at a different speed than the rest of the page."
+3. **Light-mode FOUC on reload.** When a user with stored `theme="light"` reloads, certain buttons briefly render with the dark palette before snapping to light. Root cause: the inline `<NoFoucScript>` (`components/theme/no-fouc-script.tsx`) writes `<html data-theme="light">` synchronously during head parse, but the browser has already begun computing styles against the default `:root` cascade (which declares dark vars). Whether this produces a visible flash depends on whether the script executes before any "first paint" the browser flushes after the stylesheet loads. On Light reloads in particular, the dark `--soleur-bg-base: #0a0a0a` resolves into Tailwind utilities like `bg-soleur-bg-surface-1` on individual buttons, producing a one-frame dark flash. The body background is also affected but the user notices buttons more (higher contrast against the eventual light surface).
+
+All three fixes are scoped to the theme system itself and to `(dashboard)/layout.tsx`. No business logic, no DB, no API. Pure CSS/JSX/inline-script changes.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim from prompt | Codebase reality (2026-05-06 worktree) | Plan response |
+|---|---|---|
+| "Line under selector doesn't have same gap as line above" | `app/(dashboard)/layout.tsx:327` wrapper is `border-t border-soleur-border-default px-3 pt-3` (no `pb-*`); the next sibling at line 336 is `border-t ... ${collapsed ? "p-1" : "p-3"}`. The toggle's bottom edge has 0px padding before the next border-t. The label/toggle's top has `pt-3` + a `pb-2` on the label. | Add `pb-3` to the wrapper so the gap below mirrors `p-3` of the footer. Verified: no other sibling pattern depends on the wrapper having zero bottom padding. |
+| "Squares in theme selector switch theme at different speed" | `theme-toggle.tsx:73` button has `transition-colors`; CSS-variable-driven background swaps take 150ms (default `transition-duration` for `transition-colors`). Body and other non-transitioning surfaces snap instantly. | Disable transitions for one paint frame around `setTheme()` writes. Implements the well-known next-themes "disable transition on theme change" pattern via a transient `<style>* { transition: none !important; }</style>` injected in `theme-provider.tsx`. |
+| "Currently-selected page indicator in dashboard" lags | `app/(dashboard)/layout.tsx:289` Link uses `transition-colors`; the active variant `bg-soleur-bg-surface-2 text-soleur-text-primary` interpolates over 150ms. | Same fix as above (one-frame transition disable) covers this and every other `transition-colors` consumer. |
+| "Buttons flash dark→light on Light-mode reload (FOUC)" | `<NoFoucScript>` sets `<html data-theme=…>`. CSS link is also in head; if the link is parsed before the script, the script blocks until stylesheet loads. In some browser/cache states this produces a flash. Today, the inline script does **not** set `<html style.colorScheme>` or `<html style.backgroundColor>` directly. | Have the inline script ALSO set `documentElement.style.colorScheme` and `documentElement.style.backgroundColor` synchronously. These computed values bypass stylesheet load timing and remove the flash window without altering CSS-variable resolution semantics. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** A theme toggle that visibly stutters on every switch (mismatched fade + snap) plus a flash on every Light-mode reload. Reads as "the theme feature is half-finished." For Forge users this is invisible; for Light users it is the first impression of every page load.
+**If this leaks, the user's [data / workflow / money] is exposed via:** Not applicable — this is a pure visual/styling change. No new code paths handle credentials, payments, or user data.
+**Brand-survival threshold:** none
+
+This change carries no data-exposure or single-user-incident risk. It is a visual quality bar enforcement against features already shipped publicly in #3271 and #3308.
+
+## Research Insights
+
+### Issue 1 — Sidebar vertical-rhythm baseline
+
+The dashboard sidebar uses three sibling sections separated by `border-t border-soleur-border-default`:
+
+| Section | Padding | Comment |
+|---|---|---|
+| Navigation list (lines 277-302) | `space-y-1 px-3` (no top/bottom in the nav itself) | The first border-t lives on the nav-collapse button row above, not the nav. |
+| **Theme block (lines 326-333)** | `px-3 pt-3` | Asymmetric — top 12px, bottom 0. Bug. |
+| Footer links (lines 336-385) | `p-3` (collapsed: `p-1`) | Top + bottom 12px. Reference rhythm. |
+
+The theme block's `pb-2` on the label adds 8px below the label; the toggle then sits with 0px below before the footer's `border-t`. Footer's `p-3` puts the email/Status link 12px below the border. **Fix is local — make the theme block `px-3 py-3` (or `p-3`).** No collapsed-state code path because the entire theme block is gated on `!collapsed`.
+
+### Issue 2 — Transition-colors interaction with theme switch
+
+Every `transition-colors` consumer animates `background-color`, `color`, `border-color`, `fill`, `stroke`, `text-decoration-color` for `150ms` (Tailwind v4 default). When `<html data-theme>` flips, the CSS variables under `bg-soleur-bg-surface-*` recompute, which **does** trigger a transition on those properties because the property's computed value changed.
+
+Surfaces with `transition-colors` in scope (representative — not exhaustive):
+
+```
+apps/web-platform/components/theme/theme-toggle.tsx:73
+apps/web-platform/app/(dashboard)/layout.tsx:289      # nav links (active page indicator)
+apps/web-platform/app/(dashboard)/layout.tsx:350      # Status footer link
+apps/web-platform/app/(dashboard)/layout.tsx:358      # Sign out button
+apps/web-platform/components/chat/conversations-rail.tsx:67
+# ...30+ other component files use transition-colors per `rg -l 'transition-colors' apps/web-platform`
+```
+
+**Mitigation options considered:**
+
+1. **Remove `transition-colors` from theme-bound surfaces.** Rejected — the transition is correct for hover/focus/state changes; only the theme-switch case is unwanted.
+2. **Add `transition-colors` globally to body/all elements.** Rejected — applies the 150ms ramp universally to bg-base too, making the WHOLE page do the slow ramp. Brand goal is instant theme switch.
+3. **Disable transitions for one frame around `setTheme()` writes.** Selected. This is the [next-themes `disableTransitionOnChange`](https://github.com/pacocoursey/next-themes/blob/main/README.md) pattern — inject a `<style>` element with `* { transition: none !important; }` before the `data-theme` attribute change, force a reflow, then remove the style on the next animation frame. The browser commits the theme change as a single paint with no animation. Hover transitions resume after the next frame.
+
+**Browser-engine note (Chromium).** [Tailwind GitHub Discussion #15598](https://github.com/tailwindlabs/tailwindcss/discussions/15598) documents that on Chromium-based browsers, `transition-colors` repaints affected elements **sequentially in DOM-walk order** rather than in a single composite frame — so even when every transition-bound element has the same `duration-150`, they visibly cascade. Firefox and Safari composite the changes more uniformly. This is the engine-level reason a non-transitioning surface (body bg) appears to "snap" while transition-bound elements "fade" out of sync. The disable-on-change pattern bypasses the bug entirely by removing the transition declaration during the data-theme write — no per-element ramp, no DOM-order cascade. Verified at `apps/web-platform/components/theme/theme-toggle.tsx:73`, `app/(dashboard)/layout.tsx:289`, and `components/chat/conversations-rail.tsx:67`, all of which use `transition-colors`.
+
+**Tailwind v4 constraint.** Per [tailwindlabs/tailwindcss#16639](https://github.com/tailwindlabs/tailwindcss/issues/16639), the `transition-property` family does NOT yet expose CSS-variable theme overrides in Tailwind v4 — `--tw-transition-property` is not a writable token. So the only working override is a direct CSS rule `* { transition: none !important; }` injected into the document. A future Tailwind v4 release that exposes `transition-property` as a token may permit a cleaner `style.setProperty('--tw-transition-property', 'none')` approach; not available today.
+
+The implementation lives in `theme-provider.tsx`'s `setTheme` callback. Cross-tab sync (the `storage` event handler) ALSO writes `data-theme` indirectly via the `setThemeState` → effect chain — apply the same suppression there too, otherwise tab B's theme change still animates in tab A.
+
+### Issue 3 — Light-mode reload FOUC mechanics
+
+Three relevant facts:
+
+1. **HTML parse-and-paint timing.** Per the HTML spec, a `<script>` element in `<head>` is blocked from executing until any preceding `<link rel="stylesheet">` has loaded ([WHATWG HTML §4.12.1 — "currently parsed style sheets"](https://html.spec.whatwg.org/multipage/scripting.html#parsing-main-inscript)). If Next.js injects its compiled `globals.css` link **before** our `<NoFoucScript>` element in the served HTML, the inline script runs only after the stylesheet has been fetched and applied. Until that point, the browser may have already started computing styles against the cascade — and may, on some engines / cache states, paint a "first contentful frame" with the default cascade resolution.
+2. **Default cascade resolution without `data-theme`.** The current `globals.css` has `:root, :root[data-theme="dark"] { ...dark vars }` AND `@media (prefers-color-scheme: light) { :root:not([data-theme]) { ...light vars } }`. So a Light-OS user sees light vars even with no `data-theme`; a Dark-OS user with stored Light preference sees DARK vars until the script runs. **The reported flash is most likely on Dark-OS Light-preference users.** Confirm during QA.
+3. **`color-scheme` property.** Setting `style.colorScheme = "light"` on `<html>` immediately tells the browser to use light system colors for form controls, scrollbars, and the default `<body>` background fallback. It is independent of stylesheet load timing because it's a direct inline style.
+
+**Fix — augment `<NoFoucScript>` to write inline style attributes in addition to `data-theme`:**
+
+```js
+(function () {
+  try {
+    var v = localStorage.getItem("soleur:theme");
+    if (v !== "dark" && v !== "light" && v !== "system") {
+      v = "system";
+    }
+    var html = document.documentElement;
+    html.dataset.theme = v;
+
+    // Resolve the effective palette for the inline pre-paint hint.
+    // For "system", read prefers-color-scheme. The matchMedia call is
+    // synchronous and safe in a head script.
+    var effective = v;
+    if (v === "system") {
+      effective = (window.matchMedia &&
+        window.matchMedia("(prefers-color-scheme: light)").matches)
+        ? "light" : "dark";
+    }
+
+    // Inline pre-paint hint — bypasses stylesheet load timing entirely.
+    // Color-scheme tells the browser which system colors to use for form
+    // controls, scrollbars, and the default <body> background. Setting
+    // backgroundColor on <html> ensures the very first paint matches the
+    // resolved palette even if globals.css is still loading.
+    html.style.colorScheme = effective === "light" ? "light" : "dark";
+    html.style.backgroundColor = effective === "light" ? "#fbf7ee" : "#0a0a0a";
+  } catch (_e) {
+    document.documentElement.dataset.theme = "system";
+  }
+})();
+```
+
+The hex literals (`#fbf7ee`, `#0a0a0a`) duplicate the values declared in `:root[data-theme="light"]` and `:root[data-theme="dark"]` for `--soleur-bg-base`. **Drift class:** if `globals.css` changes those hexes (e.g., a brand-guide refresh), the inline script's literals must update in lockstep. Add a comment in the script AND a regression test that asserts the values match.
+
+### Connection between issues 2 and 3
+
+The same `transition-colors` consumers that lag on a USER theme toggle (issue 2) ALSO contribute to the visible FOUC on reload (issue 3) — the inline script's `data-theme` write triggers transitions on every consumer. With the inline-style hint added (issue 3 fix), `<html>` gets the right backgroundColor instantly; but child surfaces like nav links, theme-toggle squares, etc. still use CSS-variable-resolved colors that may transition over their initial render. The transition-disable-on-change pattern (issue 2 fix) **must also be applied at boot** — wrap the inline script's logic in a one-frame transition-disabler too, so nothing animates on first paint. Implementation: inject the `<style>* { transition: none !important; }</style>` from the inline script itself, removed via `requestAnimationFrame` after first paint.
+
+This means the inline script grows from ~10 lines to ~25 lines and includes a transient style injection. Total payload is still well under 1 KB minified — negligible for TTFCP.
+
+## Implementation Phases
+
+### Phase 1 — Sidebar Gap Fix
+
+**File:** `apps/web-platform/app/(dashboard)/layout.tsx`
+
+- [ ] 1.1 Change line 327 from `className="border-t border-soleur-border-default px-3 pt-3"` to `className="border-t border-soleur-border-default p-3"` (or `px-3 py-3` for consistency with the footer's pattern).
+- [ ] 1.2 Verify the THEME label's `pb-2` still produces the intended 8px below the label before the toggle (no change needed).
+- [ ] 1.3 Visual confirm: above-toggle gap (border-t → label) and below-toggle gap (toggle → border-t) are now 12px each.
+
+### Phase 2 — Transition Disable on Theme Change
+
+**File:** `apps/web-platform/components/theme/theme-provider.tsx`
+
+- [ ] 2.1 Add a `disableTransitionsForOneFrame()` helper inside the module:
+
+  ```ts
+  function disableTransitionsForOneFrame() {
+    if (typeof document === "undefined") return;
+    const style = document.createElement("style");
+    // Cover every property `transition-colors` / `transition-all` /
+    // `transition-[<prop>]` could animate. `* { transition: none ... }`
+    // covers them all uniformly. The !important neutralises any
+    // component-level specificity. `pointer-events: none` is NOT added —
+    // the user can still interact during the suppression window; we only
+    // freeze color animations.
+    style.textContent = `* { transition: none !important; animation-duration: 0s !important; }`;
+    document.head.appendChild(style);
+    // Force a style recalc so the transition: none is committed BEFORE
+    // the data-theme attribute flips. Reading getComputedStyle on a
+    // non-pseudo element is the standard reflow-forcing trick.
+    void window.getComputedStyle(document.body).opacity;
+    // Remove on the next paint — double-rAF gives the browser one full
+    // frame to commit the theme change without animation.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        style.remove();
+      });
+    });
+  }
+  ```
+
+- [ ] 2.2 Call `disableTransitionsForOneFrame()` at the top of:
+  - The `useEffect` block that writes `document.documentElement.dataset.theme = theme` (currently lines 76-78).
+  - The `setTheme` callback (currently lines 125-140) before `setThemeState(next)`.
+  - The cross-tab `onStorage` handler (currently lines 103-122) before `setThemeState(next)`.
+  - The `prefers-color-scheme` media-query handler when `theme === "system"` (currently lines 92-99) — when the OS flips, the same flicker applies.
+
+- [ ] 2.3 Verify there is no double-disable nesting (e.g., setTheme triggers the effect which would re-disable). The first call attaches a `<style>`; if a second call lands inside the same frame, it appends a second `<style>` element. Both are removed independently across two rAFs. This is benign but slightly wasteful — a guard `if (document.getElementById("__soleur-no-transition")) return;` with a unique id solves it.
+
+### Phase 3 — Light-Mode FOUC Fix
+
+**File:** `apps/web-platform/components/theme/no-fouc-script.tsx`
+
+- [ ] 3.1 Replace the `SCRIPT` constant with the augmented version (see Research Insights → Issue 3). It must:
+  - Resolve `effective` palette (light/dark) by reading `prefers-color-scheme` for "system".
+  - Set `documentElement.style.colorScheme`.
+  - Set `documentElement.style.backgroundColor` to the literal hex of `--soleur-bg-base` for the resolved palette.
+  - Inject a transient `<style id="__soleur-no-transition">* { transition: none !important; animation-duration: 0s !important; }</style>` into `<head>` and remove it via double-rAF, mirroring the runtime helper. This prevents first-paint transitions on hydration when React mounts and consumers compute their own initial colors.
+
+- [ ] 3.2 Add an inline comment naming `--soleur-bg-base` value drift as a Sharp Edge — the hex literals in this script duplicate `globals.css` and must move together.
+
+- [ ] 3.3 Confirm the inline-style hint clears once React's hydration runs OR at the moment the `<style id="__soleur-no-transition">` is removed. Ideally the inline `style.backgroundColor` is removed as part of the post-rAF cleanup, OR set on a `<html data-theme-bootstrapping>` attribute that's removed in a `useEffect` after first paint. **Prefer: remove `style.backgroundColor` and `style.colorScheme` after the first rAF as well, so future CSS-only theming (e.g., a future `:root[data-theme="dim"]`) is not pinned by an inline override.**
+
+  Implementation choice: keep `style.colorScheme` (browser defaults benefit from this — scrollbars, autofill) but clear `style.backgroundColor` after first rAF; the body/`html` will then resolve via the now-correct CSS cascade.
+
+### Phase 4 — Tests
+
+**File (new):** `apps/web-platform/test/components/theme-no-fouc-script.test.tsx`
+
+- [ ] 4.1 Unit-test the augmented `<NoFoucScript>` script string for:
+  - Contains `style.colorScheme` write.
+  - Contains `style.backgroundColor` write.
+  - Contains both light hex (`#fbf7ee`) and dark hex (`#0a0a0a`) literals (drift-guard).
+  - Contains the `__soleur-no-transition` id.
+  - Calls `localStorage.getItem("soleur:theme")` exactly once.
+  - Falls back to `"system"` on invalid stored values.
+
+  These are string-match assertions on the SCRIPT constant; no JSDOM execution required because the script is rendered via `dangerouslySetInnerHTML` as a static string.
+
+- [ ] 4.2 Add a "hex literal parity" assertion that reads `apps/web-platform/app/globals.css` and confirms the `--soleur-bg-base` declarations for `:root[data-theme="light"]` and `:root[data-theme="dark"]` match the script's literal strings. This is the drift-guard for the Sharp Edge in Phase 3.2.
+
+  ```ts
+  import { describe, expect, it } from "vitest";
+  import { readFileSync } from "node:fs";
+  import { resolve } from "node:path";
+
+  const SCRIPT_FILE = resolve(__dirname, "../../components/theme/no-fouc-script.tsx");
+  const CSS_FILE = resolve(__dirname, "../../app/globals.css");
+
+  describe("no-fouc-script hex literal drift-guard", () => {
+    it("script literals match globals.css --soleur-bg-base values", () => {
+      const script = readFileSync(SCRIPT_FILE, "utf8");
+      const css = readFileSync(CSS_FILE, "utf8");
+
+      // Extract --soleur-bg-base from :root[data-theme="dark"] and "light" blocks.
+      const lightMatch = css.match(/\[data-theme="light"\][^}]*--soleur-bg-base:\s*([^;]+);/);
+      const darkMatch = css.match(/\[data-theme="dark"\][^}]*--soleur-bg-base:\s*([^;]+);/);
+
+      expect(lightMatch?.[1]?.trim()).toBeTruthy();
+      expect(darkMatch?.[1]?.trim()).toBeTruthy();
+      expect(script).toContain(lightMatch![1].trim());
+      expect(script).toContain(darkMatch![1].trim());
+    });
+  });
+  ```
+
+**File (extend):** `apps/web-platform/test/theme-provider.test.tsx`
+
+- [ ] 4.3 Add a unit test that calling `setTheme("light")` from `useTheme()` injects a `<style>` element with `transition: none` into `document.head`, and that the style is removed after two animation frames. Use JSDOM's `document.head.querySelectorAll("style")` to inspect, and a `requestAnimationFrame` polyfill (existing test file may already have one — verify in Phase 1 of /work).
+
+### Phase 5 — Visual QA
+
+- [ ] 5.1 Local: `bun run dev` (or whichever script `apps/web-platform/package.json` exposes), open `http://localhost:3000`, log in.
+- [ ] 5.2 Sidebar gap: with sidebar expanded, screenshot the THEME block in both Forge and Radiance. Verify above-toggle and below-toggle gaps are visually equal (12px each).
+- [ ] 5.3 Theme switch animation: with the dashboard route open AND a chat conversation visible (so conversations-rail rows are mounted), toggle Forge → Radiance → System. Confirm:
+  - Theme-toggle squares change instantly with the rest of the page.
+  - The active-page nav indicator changes instantly.
+  - Conversations-rail rows change instantly.
+  - Chat-message bubbles change instantly.
+  - Hover transitions still feel smooth on subsequent pointer-overs.
+- [ ] 5.4 Light-mode FOUC: in DevTools, force-reload (Cmd+Shift+R) on a Light-mode page on a dark-OS machine (or simulate via DevTools → Rendering → Emulate prefers-color-scheme: dark). Watch for any dark frame on page load. With Network throttling at "Fast 3G" the flash window is widest — easiest to detect.
+- [ ] 5.5 Save before/after screenshots under `knowledge-base/product/design/theme-toggle/screenshots/2026-05-06-{gap,switch,fouc}-{before,after}.png`.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] `apps/web-platform/app/(dashboard)/layout.tsx`: theme block wrapper has equal top + bottom padding (`p-3` or `py-3 px-3`).
+- [ ] `apps/web-platform/components/theme/theme-provider.tsx`: `setTheme()`, the data-theme effect, the cross-tab `storage` handler, and the `prefers-color-scheme` listener all call `disableTransitionsForOneFrame()` before mutating theme.
+- [ ] `apps/web-platform/components/theme/no-fouc-script.tsx`: inline script writes `style.colorScheme` and `style.backgroundColor` synchronously; injects a transient `transition: none` style; cleans up after double-rAF.
+- [ ] New test `apps/web-platform/test/components/theme-no-fouc-script.test.tsx` passes; existing theme tests continue to pass.
+- [ ] `bun test apps/web-platform/test/` green.
+- [ ] `tsc --noEmit` clean.
+- [ ] Visual QA screenshots committed under `knowledge-base/product/design/theme-toggle/screenshots/` for the three issues × before/after (6 PNGs minimum).
+- [ ] PR body references `Ref #3271, #3308` (no `Closes` — these PRs were merged separately; this is a follow-up polish).
+
+### Post-merge (operator)
+
+- [ ] None. CSS/inline-script change with no migrations, deploys, or external service mutations.
+
+## Risks
+
+- **Transition-disable affects every transition, not just theme-bound ones.** During the one-frame suppression window, any in-flight hover transition snaps to its end state. Acceptable — the window is one paint frame (~16ms at 60Hz). If a user happens to toggle theme while hovering an element, the hover effect appears instantly instead of fading, which is imperceptible.
+- **Inline-style hint pins `<html>` background until removed.** If the rAF cleanup fails to fire (e.g., the page is hidden via `display: none` before paint, or DevTools throttles rAF), the inline `style.backgroundColor` persists. CSS-cascade-driven background still applies to descendants but the `<html>` element shows the literal hex. Mitigation: prefer setting `style.colorScheme` permanently (browser system colors only) and clearing `style.backgroundColor` after rAF — the cascade then takes over.
+- **Hex-literal drift.** The inline script duplicates `--soleur-bg-base` from `globals.css`. A brand-guide palette refresh that updates the hex without updating the script will produce a one-frame mismatch on Light-mode reload. The Phase 4.2 drift-guard test catches this at CI time.
+- **`prefers-color-scheme` query during head parse.** Some browsers may not have the `matchMedia` API available synchronously at the moment the inline head script runs. The current script wraps `localStorage` in try/catch; the new script must wrap `matchMedia` similarly and default to dark on failure (matching the existing fallback behavior).
+- **Cross-tab sync now triggers transition disable in the OTHER tab.** Tab A's setTheme writes localStorage; tab B's `storage` event fires → disableTransitionsForOneFrame runs in tab B too. This is desired behavior — the same instant-switch invariant should hold cross-tab. No new risk.
+- **Test runner crash on JSDOM rAF polyfill.** `apps/web-platform/test/theme-provider.test.tsx` may not yet polyfill `requestAnimationFrame`. If absent, add a simple `globalThis.requestAnimationFrame = (cb) => setTimeout(cb, 0)` polyfill at the top of the file.
+- **Theme-toggle `transition-colors` may still feel right on its OWN hover.** Removing `transition-colors` from the toggle would lose the hover smoothness for pointer-overs. The disable-on-theme-change approach preserves hover smoothness — verify this in QA and do NOT regress to "remove transition-colors entirely."
+- **Chromium-only sequential repaint of `transition-colors`.** Per Tailwind Discussion #15598, Chromium repaints transition-bound elements in DOM-walk order, not as a single composite frame. The disable-on-change pattern bypasses this — no transition is in effect during the theme write — so the bug is mitigated, not relied upon. If a future Chromium release fixes #15598, the disable-helper remains correct (no behavior change). If a future Chromium release introduces a NEW divergence (e.g., `requestAnimationFrame` ordering changes), the helper's double-rAF cleanup may need a revisit. Track upstream.
+- **Two parallel timers (transition-disable + inline-style hint).** The boot script's transient `<style id="__soleur-no-transition">` and the runtime helper's transient `<style>` are separate elements with separate cleanup schedules. If a user toggles theme within ~16ms of page load, the runtime helper appends a second style; the boot helper's rAF removes its own element while the runtime element persists for another rAF cycle. Both are valid; both clean up. Verify there's no orphaned `__soleur-no-transition` element after a settling test (e.g., toggle + wait 100ms, expect zero matching `<style>` in DOM).
+
+## Sharp Edges
+
+- **Hex-literal drift between `globals.css` and `no-fouc-script.tsx`.** The inline script duplicates `--soleur-bg-base` for both palettes. Phase 4.2 drift-guard test enforces parity, but reviewers must remember to update both files in any palette refresh.
+- **`pb-3` vs `py-3` choice.** Use `p-3` (or `px-3 py-3`) to match the footer's `p-3` exactly. Mixing `px-3 pt-3 pb-3` works but reads as "the bug fix that forgot it could be `p-3`."
+- **`disableTransitionsForOneFrame` must NOT add `pointer-events: none`.** The next-themes library historically did; user keyboard nav during the suppression window should remain functional. The version in this plan deliberately omits `pointer-events`.
+- **`__soleur-no-transition` style id collision.** The runtime helper and the inline boot script BOTH inject styles with this id. The runtime helper checks `if (document.getElementById("__soleur-no-transition")) return;` — but at boot the inline script's element may still be present when the runtime helper first runs (e.g., a fast user toggle within 16ms of page load). Document this benign overlap; the runtime helper should NOT clobber the inline script's element if it's already there — bail early.
+- **No `dark:`-prefix Tailwind classes added.** Per PR #3271 + #3308 architecture (`@custom-variant dark` pinned to `[data-theme="dark"]`), the theme system uses single tokenized classes that respond to `<html data-theme>`. Do not add `dark:bg-zinc-900 light:bg-amber-50` pairs to fix any of these issues.
+- **The inline script may execute after first paint on some browsers.** The augmentation (writing inline style attributes) defends against this case, but does not GUARANTEE no flash. Visual QA on Network-throttled reload is the only confirmation. If a residual flash remains, a follow-up issue can explore moving CSS to a synchronous inline `<style>` block in head (rejected here for bundle size).
+- **Per AGENTS.md `cq-write-failing-tests-before` (TDD), the new test must land in a commit BEFORE the implementation.** Write the drift-guard test (Phase 4.2) first against the CURRENT (regex won't match because the literals aren't there yet) — the test fails RED. Then add the script changes (Phase 3.1) to make it pass GREEN.
+- **Per AGENTS.md `hr-when-a-plan-specifies-relative-paths-e-g`, every Phase file path was verified at plan time** via `Read` of `app/(dashboard)/layout.tsx`, `components/theme/theme-toggle.tsx`, `components/theme/theme-provider.tsx`, `components/theme/no-fouc-script.tsx`, `app/layout.tsx`, and `app/globals.css`.
+- **`color-scheme: light` on `<html>` reveals system-color form controls.** This is desired. But existing custom-styled inputs (e.g., the chat input) must NOT visibly regress in Light mode — verify in Phase 5.3.
+- **next-themes parity.** Soleur's theme system is a hand-rolled equivalent of `next-themes` (no dependency on the library). The disable-transition helper added in Phase 2 is a hand-port of next-themes' `disableTransitionOnChange` behavior. If Soleur ever migrates to `next-themes` directly, the helper becomes the `disableTransitionOnChange` prop on `<ThemeProvider>` and the inline-script logic moves to the library's `<Script id="next-themes" />` shipping pattern. Track this as a deferred refactor option; do NOT add `next-themes` as a dependency in this PR.
+- **`animation-duration: 0s !important` is added in addition to `transition: none`** because `globals.css:165-172` declares a `pulse-border` keyframe used by `.message-bubble-active`. Without the animation override, an active message bubble would mid-pulse during a theme switch, momentarily desaturating before the disable lifts. next-themes does not need this rule because it doesn't ship keyframe animations; Soleur does.
+
+## Domain Review
+
+**Domains relevant:** Product/UX (advisory)
+
+### Product/UX Gate
+
+**Tier:** advisory
+**Decision:** auto-accepted (pipeline)
+**Agents invoked:** none (auto-accepted in pipeline)
+**Skipped specialists:** ux-design-lead (auto-accepted in pipeline; visual QA in Phase 5 covers screenshot validation)
+**Pencil available:** N/A
+
+#### Findings
+
+This plan modifies **existing** UI surfaces with no new pages, modals, or flows. It corrects a layout-rhythm bug, an animation-timing bug, and a FOUC bug. The visual contract is the Radiance/Forge palette already chosen and shipped in PR #3271. Phase 5 visual QA validates the fixes preserve brand-aligned color behavior — no new design surface to review.
+
+Per the plan skill's pipeline-mode rule for ADVISORY tier, the gate auto-accepts and proceeds with documented visual-QA gating in Phase 5 instead of a fresh ux-design-lead Pencil session.
+
+## Open Code-Review Overlap
+
+None — this plan touches only `app/(dashboard)/layout.tsx` (single line of CSS classes), `components/theme/theme-provider.tsx`, `components/theme/no-fouc-script.tsx`, and one new test file. No open `code-review`-labeled issues match these paths as of plan time.
+
+## Test Scenarios
+
+1. **Sidebar gap** (visual): with sidebar expanded, the THEME block has 12px above the label and 12px below the toggle. Both gaps match the footer's `p-3` rhythm.
+2. **Theme-switch animation** (visual): toggling theme while a dashboard chat session is open changes every visible surface (theme-toggle squares, active nav indicator, footer links, chat bubbles, conversations-rail rows) in the same paint frame as the body background.
+3. **Hover-transition preservation** (visual): after the theme switch completes, hovering a nav link still produces the smooth `transition-colors` 150ms fade.
+4. **Light-mode reload, Light-OS user** (visual): force-reload `/dashboard` with stored `theme="light"` and OS preference light. No dark frame visible at any throttle setting up to "Fast 3G."
+5. **Light-mode reload, Dark-OS user** (visual): force-reload `/dashboard` with stored `theme="light"` and OS preference dark. No dark frame visible — this is the case the inline-style hint primarily defends.
+6. **System-mode reload, Light-OS user** (visual): force-reload `/dashboard` with stored `theme="system"` and OS preference light. Page renders Radiance with no dark frame.
+7. **Drift-guard test (CI)**: the hex-literal parity test fails RED if `globals.css` changes `--soleur-bg-base` for either palette without the script being updated.
+8. **`setTheme` transition-disable test (CI)**: calling `setTheme("light")` in JSDOM injects a `<style>` element with `transition: none` and removes it within two animation frames.
+9. **Cross-tab sync transition-disable (manual or CI)**: a `storage` event with key `soleur:theme` triggers the same disable behavior.
+10. **No-FOUC script string assertions (CI)**: the SCRIPT constant contains `style.colorScheme`, `style.backgroundColor`, both palette hexes, and `__soleur-no-transition`.
+
+## Commit Strategy
+
+Recommended: 4 commits on the feature branch.
+
+1. `test: add no-fouc-script drift-guard and theme-provider transition-disable tests` — RED state. New test file + extension to `theme-provider.test.tsx`.
+2. `fix(theme): equal vertical padding around theme block in dashboard sidebar` — Phase 1, single-line CSS class change.
+3. `fix(theme): disable CSS transitions for one frame on theme change` — Phase 2, runtime helper + four call sites in `theme-provider.tsx`.
+4. `fix(theme): inline-style hint and transient transition disable in NoFoucScript` — Phase 3, augments the inline script. Tests now GREEN.
+
+After commit 4, all CI tests pass and visual QA can run. Each commit is independently reviewable and revertable.
+
+## Files to Edit
+
+- `apps/web-platform/app/(dashboard)/layout.tsx` — line 327 className change.
+- `apps/web-platform/components/theme/theme-provider.tsx` — add helper, call from four hook sites.
+- `apps/web-platform/components/theme/no-fouc-script.tsx` — augment inline script string.
+- `apps/web-platform/test/theme-provider.test.tsx` — add transition-disable assertions.
+
+## Files to Create
+
+- `apps/web-platform/test/components/theme-no-fouc-script.test.tsx` — new unit + drift-guard test.
+- `knowledge-base/product/design/theme-toggle/screenshots/2026-05-06-{gap,switch,fouc}-{before,after}.png` — 6 visual QA screenshots captured during Phase 5.
+
+## Out of Scope (deferred)
+
+- Tokenizing remaining literal-gray surfaces — covered by PRs #3271 / #3308. Any residual hardcoded grays that surface during Phase 5 visual QA should be filed as follow-ups, not folded in.
+- Adding `--soleur-status-{danger,warning,success,info}` tokens. Status color theming was deferred from #3308; revisit only if Phase 5 shows status-color contrast issues against Radiance.
+- Replacing `transition-colors` with custom transitions per surface. The disable-on-change pattern covers the systemic concern; per-surface tuning can be a follow-up if needed.
+- Eleventy docs site theming — different rendering pipeline, out of scope.
+
+## Resume Prompt
+
+```text
+Resume prompt (copy-paste after /clear):
+/soleur:work knowledge-base/project/plans/2026-05-06-fix-theme-selector-gap-and-fouc-plan.md. Branch: feat-one-shot-theme-selector-gap-and-fouc-fixes. Worktree: .worktrees/feat-one-shot-theme-selector-gap-and-fouc-fixes/. Issue: TBD (follow-up polish to #3271/#3308). Plan reviewed, implementation next.
+```

--- a/knowledge-base/project/plans/2026-05-06-fix-theme-selector-gap-and-fouc-plan.md
+++ b/knowledge-base/project/plans/2026-05-06-fix-theme-selector-gap-and-fouc-plan.md
@@ -161,7 +161,7 @@ This means the inline script grows from ~10 lines to ~25 lines and includes a tr
 
 **File:** `apps/web-platform/components/theme/theme-provider.tsx`
 
-- [ ] 2.1 Add a `disableTransitionsForOneFrame()` helper inside the module:
+- [x] 2.1 Add a `disableTransitionsForOneFrame()` helper inside the module:
 
   ```ts
   function disableTransitionsForOneFrame() {
@@ -189,13 +189,13 @@ This means the inline script grows from ~10 lines to ~25 lines and includes a tr
   }
   ```
 
-- [ ] 2.2 Call `disableTransitionsForOneFrame()` at the top of:
+- [x] 2.2 Call `disableTransitionsForOneFrame()` at the top of:
   - The `useEffect` block that writes `document.documentElement.dataset.theme = theme` (currently lines 76-78).
   - The `setTheme` callback (currently lines 125-140) before `setThemeState(next)`.
   - The cross-tab `onStorage` handler (currently lines 103-122) before `setThemeState(next)`.
   - The `prefers-color-scheme` media-query handler when `theme === "system"` (currently lines 92-99) — when the OS flips, the same flicker applies.
 
-- [ ] 2.3 Verify there is no double-disable nesting (e.g., setTheme triggers the effect which would re-disable). The first call attaches a `<style>`; if a second call lands inside the same frame, it appends a second `<style>` element. Both are removed independently across two rAFs. This is benign but slightly wasteful — a guard `if (document.getElementById("__soleur-no-transition")) return;` with a unique id solves it.
+- [x] 2.3 Verify there is no double-disable nesting (e.g., setTheme triggers the effect which would re-disable). The first call attaches a `<style>`; if a second call lands inside the same frame, it appends a second `<style>` element. Both are removed independently across two rAFs. This is benign but slightly wasteful — a guard `if (document.getElementById("__soleur-no-transition")) return;` with a unique id solves it.
 
 ### Phase 3 — Light-Mode FOUC Fix
 

--- a/knowledge-base/project/specs/feat-one-shot-theme-selector-gap-and-fouc-fixes/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-theme-selector-gap-and-fouc-fixes/session-state.md
@@ -1,0 +1,22 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/harry/Documents/Stage/Soleur/soleur/.worktrees/feat-one-shot-theme-selector-gap-and-fouc-fixes/knowledge-base/project/plans/2026-05-06-fix-theme-selector-gap-and-fouc-plan.md
+- Status: complete
+
+### Errors
+None.
+
+### Decisions
+- Issue 1 (gap): Single CSS-class change in `app/(dashboard)/layout.tsx:327` — `px-3 pt-3` → `p-3` so vertical rhythm matches the footer's `p-3` and the gap above and below the toggle are equal.
+- Issue 2 (animation mismatch): Hand-port `next-themes`' `disableTransitionOnChange` pattern into `theme-provider.tsx` as `disableTransitionsForOneFrame()` called from `setTheme`, the data-theme `useEffect`, the cross-tab `storage` handler, AND the `prefers-color-scheme` listener. Add `animation-duration: 0s !important` to defend against the `pulse-border` keyframe.
+- Issue 3 (FOUC): Augment `<NoFoucScript>` to write `documentElement.style.colorScheme` and `documentElement.style.backgroundColor` synchronously, and inject a transient `* { transition: none }` style at boot to prevent first-paint transitions on hydration. Hex literals duplicated from `globals.css` are guarded by a Phase 4.2 drift-guard test.
+- TDD ordering: Tests land in commit 1 (RED), then implementation in commits 2–4. New test file `apps/web-platform/test/components/theme-no-fouc-script.test.tsx` plus an extension to `theme-provider.test.tsx`.
+- Scope discipline: No tokenization changes, no `dark:`-prefix additions, no Eleventy-site fixes. User-Brand threshold: none. No CPO sign-off needed.
+
+### Components Invoked
+- skill: soleur:plan
+- skill: soleur:deepen-plan
+- mcp__plugin_soleur_context7__resolve-library-id + query-docs against /pacocoursey/next-themes
+- WebSearch for Tailwind v4 + transition-colors + theme-switch flicker (Discussion #15598, Issue #16639)
+- Read of adjacent learning 2026-04-27-critical-css-fouc-prevention-via-static-and-playwright-gates.md


### PR DESCRIPTION
## Summary

Three theme-system polish bugs from PR #3271 (toggle + tokens) and PR #3308 (web-platform tokenization):

- **Sidebar gap asymmetry under the theme block** — `apps/web-platform/app/(dashboard)/layout.tsx` wrapper used `px-3 pt-3` (12px top, 0px bottom), so the toggle's bottom edge butted against the next `border-t`. Now `p-3` matching the footer's vertical rhythm.
- **Theme-switch animation mismatch** — surfaces with `transition-colors` (theme-toggle squares, active-page nav indicator, conversations-rail rows, chat bubbles) faded across 150ms while non-transitioning surfaces snapped instantly. Hand-port of `next-themes`' `disableTransitionOnChange` pattern in `apps/web-platform/components/theme/theme-provider.tsx`: inject a transient `<style>* { transition: none !important; animation-duration: 0s !important; }` before the `data-theme` attribute change, force a synchronous reflow, remove via double-rAF. Wired into the data-theme effect, `setTheme`, the cross-tab `storage` handler, and the `prefers-color-scheme` listener.
- **Light-mode reload FOUC** — `apps/web-platform/components/theme/no-fouc-script.tsx` set `<html data-theme>` but didn't seed `html.style.colorScheme` / `html.style.backgroundColor`, so the first paint could resolve against the default-dark cascade before `globals.css` loaded. Augmented the boot script to write inline pre-paint hints + inject the same `__soleur-no-transition` style cleaned up via double-rAF. The runtime provider re-asserts `style.colorScheme` on every `resolvedTheme` flip so UA-rendered widgets (scrollbars, form controls) follow the active palette.

Ref #3271, #3308

## Changelog

### Web Platform
- Fixed asymmetric vertical padding under the dashboard sidebar theme selector (`apps/web-platform/app/(dashboard)/layout.tsx`).
- Theme switches no longer cascade — every `transition-colors` consumer commits in the same paint frame as the body background.
- Light-mode page reloads no longer flash the dark palette before the stylesheet loads.
- New shared contract module `apps/web-platform/components/theme/no-transition-contract.ts` provides TypeScript compile-time identity for the `__soleur-no-transition` style id and CSS text consumed by both the inline boot script (`apps/web-platform/components/theme/no-fouc-script.tsx`) and the runtime helper (`apps/web-platform/components/theme/theme-provider.tsx`).

### Tests
- New: `apps/web-platform/test/components/theme-no-fouc-script.test.tsx` (10 tests) — unit assertions on the SCRIPT constant + drift-guard against `apps/web-platform/app/globals.css` `--soleur-bg-base` for both palettes, regex anchored to `:root[data-theme="…"]`.
- Extended: `apps/web-platform/test/theme-provider.test.tsx` with a transition-disable injection/cleanup test.

## Test plan

- [x] `vitest run` — locally 3592 passing, 24 skipped, 0 failing.
- [x] `tsc --noEmit` clean.
- [x] Multi-agent review (9 agents): 0 P1, 2 P2, 10 P3 — all resolved inline (commit 69efefeb).
- [x] Preflight: 4 PASS (Not-Bare-Repo, Security Headers, Environment Isolation, Banned Encodings), 6 SKIP.
- [ ] ⏳ Manual visual QA (Phase 5 of plan): operator confirms before user-facing release. Six visual scenarios — sidebar gap symmetry, theme-switch instant snap (Forge ↔ Radiance ↔ System), hover-transition preservation, FOUC-free reload on Dark-OS Light-pref user, Light-OS Light user, Light-OS System user.

## Notes for reviewer

The unrelated CI flake `cc-attachment-pipeline > survives a single download failure` is tracked in #3310 — UUID-substring collision in a `not.toContain("b.png")` assertion, fires probabilistically on this branch but main is green at the merge base. Re-triggering CI should land green; persistent reproduction would warrant inlining the fix from #3310 into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)