### PR TITLE
fix(theme): persist toggle position across reload + apply mock pill styling

### DIFF
--- a/apps/web-platform/components/theme/theme-provider.tsx
+++ b/apps/web-platform/components/theme/theme-provider.tsx
@@ -37,6 +37,41 @@ function readStoredTheme(): Theme {
 }
 
 /**
+ * Resolve the canonical post-bootstrap theme on the client.
+ *
+ * The inline `NoFoucScript` runs synchronously in `<head>` before React mounts
+ * and writes `documentElement.dataset.theme` from `localStorage["soleur:theme"]`.
+ * That attribute is the canonical, post-bootstrap theme — by the time React's
+ * lazy `useState` initializer runs on the client, the DOM is already correct.
+ *
+ * Reading from `dataset.theme` first (rather than re-reading `localStorage`)
+ * makes the initial React state match the painted palette without an
+ * effect-driven swap. The effect at line ~174 stays as a defense-in-depth
+ * fallback for environments where the inline script never ran (tests, dev
+ * preview that scrubbed the attribute, very old browsers).
+ *
+ * No-op on the server (`document` is undefined).
+ *
+ * **Why this matters:** prior to this helper, the lazy initializer called
+ * `readStoredTheme()` directly. The SSR snapshot returned `"system"` (window
+ * undefined). React 18 hydration reuses the server-rendered state and does
+ * NOT re-call lazy initializers — so the client's first paint rendered the
+ * `aria-pressed` indicator on the System segment even when the page palette
+ * (resolved via `dataset.theme`) was already Dark or Light. The first-mount
+ * useEffect re-synced state, but the wrong-segment paint persisted long
+ * enough for users to perceive it as "stuck on System after reload"
+ * (#3312 attempted to fix this; this is the structural fix).
+ */
+function resolveClientInitialTheme(): Theme {
+  if (typeof document === "undefined") return "system";
+  const fromDom = document.documentElement.dataset.theme;
+  if (isTheme(fromDom)) return fromDom;
+  // Fallback: dataset.theme not set (test fixture scrubbed it, or the
+  // inline script failed to run). Read localStorage directly.
+  return readStoredTheme();
+}
+
+/**
  * Suppress CSS transitions and keyframe animations for one paint frame.
  *
  * Theme switches re-resolve every `var(--soleur-*)` token that surfaces
@@ -125,21 +160,29 @@ type ThemeContextValue = {
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  // Lazy initializers read localStorage / matchMedia on first client render
-  // so the post-hydration paint already matches the persisted choice — no
-  // extra effect-driven swap, no flicker. SSR (where window is undefined)
-  // falls back to "system" + dark; the hydration mismatch on <html
-  // data-theme> set by the no-FOUC inline script is silenced via
-  // suppressHydrationWarning in app/layout.tsx.
-  // INVARIANT: the inline <NoFoucScript> in app/layout.tsx <head> has already
-  // written document.documentElement.dataset.theme before React mounts. This
-  // provider's first paint and that script must agree on the value or the
-  // user sees a one-frame flash.
+  // Lazy initializers read documentElement.dataset.theme on first client
+  // render so the initial paint matches the inline <NoFoucScript>'s value
+  // (which it already wrote synchronously in <head> from localStorage). No
+  // effect-driven swap, no flicker, no "stuck on System" first paint.
+  //
+  // SSR (where document is undefined) falls back to "system" + dark; the
+  // hydration mismatch on <html data-theme> set by the inline script is
+  // silenced via suppressHydrationWarning in app/layout.tsx.
+  //
+  // INVARIANT: the inline <NoFoucScript> in app/layout.tsx <head> has
+  // already written document.documentElement.dataset.theme before React
+  // mounts. This provider's first paint and that script MUST agree on the
+  // value or the user sees a one-frame flash. The first-mount useEffect
+  // below stays as a defense-in-depth fallback for environments where the
+  // inline script never ran (test fixtures that scrubbed the attribute,
+  // very old browsers, CSP-blocked inline scripts).
   const [theme, setThemeState] = useState<Theme>(() =>
-    typeof window === "undefined" ? "system" : readStoredTheme(),
+    typeof window === "undefined" ? "system" : resolveClientInitialTheme(),
   );
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() =>
-    typeof window === "undefined" ? "dark" : resolveInitial(readStoredTheme()),
+    typeof window === "undefined"
+      ? "dark"
+      : resolveInitial(resolveClientInitialTheme()),
   );
 
   // Apply data-theme on the html element whenever theme changes.

--- a/apps/web-platform/components/theme/theme-toggle.tsx
+++ b/apps/web-platform/components/theme/theme-toggle.tsx
@@ -81,7 +81,11 @@ export function ThemeToggle({ collapsed }: { collapsed: boolean }) {
       role="group"
       aria-label="Theme"
       onKeyDown={handleKeyDown}
-      className="flex h-8 w-full items-stretch border border-soleur-border-default"
+      className={[
+        "flex h-8 w-full items-stretch p-[3px]",
+        "rounded-full border border-soleur-border-default",
+        "bg-soleur-bg-surface-2",
+      ].join(" ")}
     >
       {SEGMENTS.map((seg, index) => {
         const active = theme === seg.value;
@@ -97,10 +101,10 @@ export function ThemeToggle({ collapsed }: { collapsed: boolean }) {
             aria-label={seg.ariaLabel}
             title={seg.label}
             className={[
-              "flex flex-1 items-center justify-center transition-colors",
-              "border-r border-soleur-border-default last:border-r-0",
+              "flex flex-1 items-center justify-center rounded-full",
+              "transition-colors",
               active
-                ? "bg-soleur-bg-surface-2 text-soleur-accent-gold-fg ring-1 ring-inset ring-soleur-border-emphasized"
+                ? "bg-soleur-bg-surface-1 text-soleur-accent-gold-fg ring-1 ring-inset ring-soleur-border-emphasized"
                 : "text-soleur-text-muted hover:text-soleur-text-secondary",
             ].join(" ")}
           >


### PR DESCRIPTION
## Summary

Two related follow-up fixes to PR #3315 (theme toggle redesign).

Closes #3317

### 1. Persist button position across reload

**Symptom (user report):** click Dark or Light, button updates correctly, page repaints. **On reload, the button reverts to the System position** even though the page palette is correct.

**Root cause:** `ThemeProvider`'s `useState` lazy initializer called `readStoredTheme()` which returns `"system"` on the server (`typeof window === "undefined"`). React 18 hydration reuses the server-rendered state and does NOT re-call lazy initializers on the client — so the first paint always rendered `aria-pressed` on System even when `dataset.theme` was already Dark or Light. The first-mount `useEffect` added in #3312 ran AFTER the first paint, but was insufficient under production timing.

**Fix:** New `resolveClientInitialTheme()` helper reads `document.documentElement.dataset.theme` first — the canonical post-bootstrap value the inline `NoFoucScript` writes synchronously in `<head>` from localStorage — falling back to `readStoredTheme()` only if `dataset.theme` is unset. The first-mount `useEffect` stays as defense-in-depth.

### 2. Apply approved mock styling to expanded pill

PR #3315 shipped the relocation but kept the **old hard-square segmented strip** JSX. The mock approved before that integration (and the design intent of the redesign) used a rounded pill. This commit applies it:

| | Before | After |
|---|---|---|
| Track | hard-square `border` | `rounded-full` + `bg-soleur-bg-surface-2` + `p-[3px]` padding |
| Active segment | hard-square + right-border separator + `bg-surface-2` | `rounded-full` + `bg-soleur-bg-surface-1` + gold ring |
| Inactive | hard-square + right-border + text-muted | transparent + text-muted, hover only |

Cycle button (collapsed mode) was already styled to mock; no change.

## Changelog

### Web Platform

- `ThemeProvider`: lazy initializer now reads `documentElement.dataset.theme` on the client (canonical post-bootstrap value) before falling back to `localStorage`. Fixes "toggle stuck on System after reload" symptom that re-emerged after PR #3315.
- `ThemeToggle`: expanded pill restyled to match the approved mock — rounded-full track + segments, gold ring on active.

## Test plan

- [x] All 5 affected test files pass: theme-toggle (15), theme-provider (13), theme-csp-regression (3), dashboard-sidebar-collapse (11), dashboard-layout-drawer-rail (2) = 44/44
- [x] `tsc --noEmit` clean
- [x] No changes to `--soleur-*` token values, `globals.css`, or `no-fouc-script.tsx`
- [ ] Post-merge: load `/dashboard`, click Dark, reload, verify button stays on Dark; repeat with Light

## Related

- Builds on PR #3315 (relocation + collapsed cycle button)
- Closes #3317 (the bug filed during PR #3315 work-phase)
- Mock reference: `knowledge-base/product/design/web-platform/theme-toggle-mock.html`

Generated with [Claude Code](https://claude.com/claude-code)