### PR TITLE
fix(lockfile): mark playwright/fsevents@2.3.2 as dev (post-merge CI fix)

### DIFF
--- a/apps/web-platform/package-lock.json
+++ b/apps/web-platform/package-lock.json
@@ -10464,6 +10464,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [


### PR DESCRIPTION
## Summary

Single-line lockfile metadata drift caught by CI's `lockfile-sync` job post-merge of #3338. CI's `npm install --package-lock-only` regenerated `apps/web-platform/package-lock.json` from a clean state and added `"dev": true` to the `playwright/node_modules/fsevents@2.3.2` entry. My local `npm install` (with existing node_modules) reused the existing marker, so the diff didn't surface pre-merge.

Web Platform Release ran successfully — `npm ci` in Docker doesn't validate this metadata, so prod is healthy. This PR only restores CI's lockfile-sync gate.

## Changelog

### Web Platform
- Lockfile metadata fix: mark transitive `playwright/fsevents` as `dev: true` (matches CI's expected output)

## Test plan

- [x] Diff is exactly 1 line, matching the CI failure output verbatim
- [ ] Lockfile-sync CI check turns green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)