### PR TITLE
fix(seo): use 10 explicit redirect rules (regex_replace not Free-tier)

### DIFF
--- a/apps/web-platform/infra/seo-rulesets.tf
+++ b/apps/web-platform/infra/seo-rulesets.tf
@@ -37,15 +37,25 @@
 # the 301 is served whether GitHub Pages still emits the legacy HTML files or
 # not. Source-template deletion is tracked in follow-up issue #3328.
 #
-# Free-tier Cloudflare zones cap dynamic-redirect rules at 10 per phase. The
-# initial 19-rule rollout (one rule per source path) hit that limit on first
-# apply — see `knowledge-base/project/learnings/2026-05-06-cf-free-tier-rule-limits.md`.
-# This ruleset consolidates the 19 source paths into 4 rules using
-# `regex_replace()` in `target_url.expression`. Rule ORDER matters: the
-# dynamic-redirect phase short-circuits on first match, so the
-# `terms-of-service` rename rule must precede the generic `/pages/legal/*`
-# regex rule (otherwise the regex would route /pages/legal/terms-of-service.html
-# to /legal/terms-of-service/, a 404 — the slug was renamed to terms-and-conditions).
+# Cloudflare Free-tier zones cap dynamic-redirect rules at 10 per phase,
+# and `regex_replace()` in `target_url.expression` requires Business or WAF
+# Advanced (cannot be used to consolidate). Both constraints discovered
+# post-merge during PR #3296 apply.
+#
+# This ruleset declares 10 explicit rules (the Free-tier cap), prioritized:
+#   - 8 top-level `/pages/<slug>.html → /<slug>/` redirects (high-traffic pages)
+#   - 1 `terms-of-service → terms-and-conditions` slug rename (load-bearing —
+#     the only entry with a confirmed GSC 404 bucket entry pre-fix)
+#   - 1 `/blog/what-is-company-as-a-service/index.html → /company-as-a-service/` reslug
+#
+# Deferred to follow-up: 9 individual `/pages/legal/<slug>.html → /legal/<slug>/`
+# redirects (privacy, cookie, gdpr, AUP, data-protection, individual-cla,
+# corporate-cla, disclaimer, terms-and-conditions). These paths return 404
+# until a Bulk Redirects refactor lands (account-scoped `cloudflare_list` of
+# type "redirect" + `cloudflare_ruleset` with phase `http_request_redirect`).
+# Google will recrawl from the sitemap and drop them from the redirect-bucket
+# cluster — acceptable transitional state since the canonical `/legal/<slug>/`
+# paths ARE in the sitemap and indexed.
 resource "cloudflare_ruleset" "seo_page_redirects" {
   provider    = cloudflare.rulesets
   zone_id     = var.cf_zone_id
@@ -54,10 +64,136 @@ resource "cloudflare_ruleset" "seo_page_redirects" {
   kind        = "zone"
   phase       = "http_request_dynamic_redirect"
 
-  # Rule 1: terms-of-service slug rename — MUST come before Rule 3 below.
-  # The legacy slug terms-of-service was renamed to terms-and-conditions; if
-  # the generic /pages/legal/* regex (Rule 3) matched first, it would 301 to
-  # /legal/terms-of-service/ which is a 404.
+  rules {
+    action      = "redirect"
+    description = "Redirect /pages/agents.html → /agents/"
+    enabled     = true
+    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/agents.html\")"
+    action_parameters {
+      from_value {
+        status_code           = 301
+        preserve_query_string = false
+        target_url {
+          value = "https://www.soleur.ai/agents/"
+        }
+      }
+    }
+  }
+
+  rules {
+    action      = "redirect"
+    description = "Redirect /pages/skills.html → /skills/"
+    enabled     = true
+    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/skills.html\")"
+    action_parameters {
+      from_value {
+        status_code           = 301
+        preserve_query_string = false
+        target_url {
+          value = "https://www.soleur.ai/skills/"
+        }
+      }
+    }
+  }
+
+  rules {
+    action      = "redirect"
+    description = "Redirect /pages/vision.html → /vision/"
+    enabled     = true
+    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/vision.html\")"
+    action_parameters {
+      from_value {
+        status_code           = 301
+        preserve_query_string = false
+        target_url {
+          value = "https://www.soleur.ai/vision/"
+        }
+      }
+    }
+  }
+
+  rules {
+    action      = "redirect"
+    description = "Redirect /pages/community.html → /community/"
+    enabled     = true
+    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/community.html\")"
+    action_parameters {
+      from_value {
+        status_code           = 301
+        preserve_query_string = false
+        target_url {
+          value = "https://www.soleur.ai/community/"
+        }
+      }
+    }
+  }
+
+  rules {
+    action      = "redirect"
+    description = "Redirect /pages/getting-started.html → /getting-started/"
+    enabled     = true
+    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/getting-started.html\")"
+    action_parameters {
+      from_value {
+        status_code           = 301
+        preserve_query_string = false
+        target_url {
+          value = "https://www.soleur.ai/getting-started/"
+        }
+      }
+    }
+  }
+
+  rules {
+    action      = "redirect"
+    description = "Redirect /pages/legal.html → /legal/"
+    enabled     = true
+    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/legal.html\")"
+    action_parameters {
+      from_value {
+        status_code           = 301
+        preserve_query_string = false
+        target_url {
+          value = "https://www.soleur.ai/legal/"
+        }
+      }
+    }
+  }
+
+  rules {
+    action      = "redirect"
+    description = "Redirect /pages/pricing.html → /pricing/"
+    enabled     = true
+    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/pricing.html\")"
+    action_parameters {
+      from_value {
+        status_code           = 301
+        preserve_query_string = false
+        target_url {
+          value = "https://www.soleur.ai/pricing/"
+        }
+      }
+    }
+  }
+
+  rules {
+    action      = "redirect"
+    description = "Redirect /pages/changelog.html → /changelog/"
+    enabled     = true
+    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/changelog.html\")"
+    action_parameters {
+      from_value {
+        status_code           = 301
+        preserve_query_string = false
+        target_url {
+          value = "https://www.soleur.ai/changelog/"
+        }
+      }
+    }
+  }
+
+  # NEW: missing entry in legacy _data/pageRedirects.js — caused the 1× 404
+  # in the GSC report (legal slug renamed but redirect not added).
   rules {
     action      = "redirect"
     description = "Redirect /pages/legal/terms-of-service.html → /legal/terms-and-conditions/ (renamed slug)"
@@ -74,52 +210,6 @@ resource "cloudflare_ruleset" "seo_page_redirects" {
     }
   }
 
-  # Rule 2: top-level /pages/<slug>.html → /<slug>/.
-  # Match anchors are `^/pages/[^/]+\.html$` so single-segment paths only —
-  # /pages/legal/cookie-policy.html (depth 2) is intentionally NOT matched
-  # here; Rule 3 handles it. /pages/legal.html (depth 1) IS matched here and
-  # correctly routes to /legal/.
-  # Covers: agents, skills, vision, community, getting-started, legal,
-  #         pricing, changelog (8 source paths).
-  rules {
-    action      = "redirect"
-    description = "Redirect /pages/<slug>.html → /<slug>/ (regex-consolidated, 8 source paths)"
-    enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path matches \"^/pages/[^/]+\\.html$\")"
-    action_parameters {
-      from_value {
-        status_code           = 301
-        preserve_query_string = false
-        target_url {
-          expression = "concat(\"https://www.soleur.ai\", regex_replace(http.request.uri.path, \"^/pages/([^/]+)\\.html$\", \"/$${1}/\"))"
-        }
-      }
-    }
-  }
-
-  # Rule 3: /pages/legal/<slug>.html → /legal/<slug>/ (depth 2, regex).
-  # The terms-of-service rename is excluded by Rule 1 firing first.
-  # Covers: privacy-policy, terms-and-conditions, cookie-policy, gdpr-policy,
-  #         acceptable-use-policy, data-protection-disclosure, individual-cla,
-  #         corporate-cla, disclaimer (9 source paths).
-  rules {
-    action      = "redirect"
-    description = "Redirect /pages/legal/<slug>.html → /legal/<slug>/ (regex-consolidated, 9 source paths)"
-    enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path matches \"^/pages/legal/[^/]+\\.html$\")"
-    action_parameters {
-      from_value {
-        status_code           = 301
-        preserve_query_string = false
-        target_url {
-          expression = "concat(\"https://www.soleur.ai/legal\", regex_replace(http.request.uri.path, \"^/pages/legal/([^/]+)\\.html$\", \"/$${1}/\"))"
-        }
-      }
-    }
-  }
-
-  # Rule 4: blog content reslug.
-  # Specific path; not part of the /pages/* pattern.
   rules {
     action      = "redirect"
     description = "Redirect /blog/what-is-company-as-a-service/index.html → /company-as-a-service/"

--- a/apps/web-platform/infra/seo-rulesets.tf
+++ b/apps/web-platform/infra/seo-rulesets.tf
@@ -37,14 +37,15 @@
 # the 301 is served whether GitHub Pages still emits the legacy HTML files or
 # not. Source-template deletion is tracked in follow-up issue #3328.
 #
-# Verbose `rules { ... }` blocks (one per redirect) are deliberate over
-# `dynamic { for_each = local.page_redirects ... }` for first-apply review:
-# `terraform plan` shows each rule as its own diff entry, which makes
-# operator review of the initial 22-rule rollout straightforward. A future
-# PR (after the deploy is verified live) can collapse to a `dynamic` block;
-# changing the iteration shape on a settled ruleset triggers in-place
-# updates across all entries (CF rule ordering matters), so the refactor
-# is cleaner as a separate Terraform change.
+# Free-tier Cloudflare zones cap dynamic-redirect rules at 10 per phase. The
+# initial 19-rule rollout (one rule per source path) hit that limit on first
+# apply — see `knowledge-base/project/learnings/2026-05-06-cf-free-tier-rule-limits.md`.
+# This ruleset consolidates the 19 source paths into 4 rules using
+# `regex_replace()` in `target_url.expression`. Rule ORDER matters: the
+# dynamic-redirect phase short-circuits on first match, so the
+# `terms-of-service` rename rule must precede the generic `/pages/legal/*`
+# regex rule (otherwise the regex would route /pages/legal/terms-of-service.html
+# to /legal/terms-of-service/, a 404 — the slug was renamed to terms-and-conditions).
 resource "cloudflare_ruleset" "seo_page_redirects" {
   provider    = cloudflare.rulesets
   zone_id     = var.cf_zone_id
@@ -53,168 +54,10 @@ resource "cloudflare_ruleset" "seo_page_redirects" {
   kind        = "zone"
   phase       = "http_request_dynamic_redirect"
 
-  rules {
-    action      = "redirect"
-    description = "Redirect /pages/agents.html → /agents/"
-    enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/agents.html\")"
-    action_parameters {
-      from_value {
-        status_code           = 301
-        preserve_query_string = false
-        target_url {
-          value = "https://www.soleur.ai/agents/"
-        }
-      }
-    }
-  }
-
-  rules {
-    action      = "redirect"
-    description = "Redirect /pages/skills.html → /skills/"
-    enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/skills.html\")"
-    action_parameters {
-      from_value {
-        status_code           = 301
-        preserve_query_string = false
-        target_url {
-          value = "https://www.soleur.ai/skills/"
-        }
-      }
-    }
-  }
-
-  rules {
-    action      = "redirect"
-    description = "Redirect /pages/vision.html → /vision/"
-    enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/vision.html\")"
-    action_parameters {
-      from_value {
-        status_code           = 301
-        preserve_query_string = false
-        target_url {
-          value = "https://www.soleur.ai/vision/"
-        }
-      }
-    }
-  }
-
-  rules {
-    action      = "redirect"
-    description = "Redirect /pages/community.html → /community/"
-    enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/community.html\")"
-    action_parameters {
-      from_value {
-        status_code           = 301
-        preserve_query_string = false
-        target_url {
-          value = "https://www.soleur.ai/community/"
-        }
-      }
-    }
-  }
-
-  rules {
-    action      = "redirect"
-    description = "Redirect /pages/getting-started.html → /getting-started/"
-    enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/getting-started.html\")"
-    action_parameters {
-      from_value {
-        status_code           = 301
-        preserve_query_string = false
-        target_url {
-          value = "https://www.soleur.ai/getting-started/"
-        }
-      }
-    }
-  }
-
-  rules {
-    action      = "redirect"
-    description = "Redirect /pages/legal.html → /legal/"
-    enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/legal.html\")"
-    action_parameters {
-      from_value {
-        status_code           = 301
-        preserve_query_string = false
-        target_url {
-          value = "https://www.soleur.ai/legal/"
-        }
-      }
-    }
-  }
-
-  rules {
-    action      = "redirect"
-    description = "Redirect /pages/pricing.html → /pricing/"
-    enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/pricing.html\")"
-    action_parameters {
-      from_value {
-        status_code           = 301
-        preserve_query_string = false
-        target_url {
-          value = "https://www.soleur.ai/pricing/"
-        }
-      }
-    }
-  }
-
-  rules {
-    action      = "redirect"
-    description = "Redirect /pages/changelog.html → /changelog/"
-    enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/changelog.html\")"
-    action_parameters {
-      from_value {
-        status_code           = 301
-        preserve_query_string = false
-        target_url {
-          value = "https://www.soleur.ai/changelog/"
-        }
-      }
-    }
-  }
-
-  rules {
-    action      = "redirect"
-    description = "Redirect /pages/legal/privacy-policy.html → /legal/privacy-policy/"
-    enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/legal/privacy-policy.html\")"
-    action_parameters {
-      from_value {
-        status_code           = 301
-        preserve_query_string = false
-        target_url {
-          value = "https://www.soleur.ai/legal/privacy-policy/"
-        }
-      }
-    }
-  }
-
-  rules {
-    action      = "redirect"
-    description = "Redirect /pages/legal/terms-and-conditions.html → /legal/terms-and-conditions/"
-    enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/legal/terms-and-conditions.html\")"
-    action_parameters {
-      from_value {
-        status_code           = 301
-        preserve_query_string = false
-        target_url {
-          value = "https://www.soleur.ai/legal/terms-and-conditions/"
-        }
-      }
-    }
-  }
-
-  # NEW: missing entry in legacy _data/pageRedirects.js — caused the 1× 404
-  # in the GSC report (legal slug renamed but redirect not added).
+  # Rule 1: terms-of-service slug rename — MUST come before Rule 3 below.
+  # The legacy slug terms-of-service was renamed to terms-and-conditions; if
+  # the generic /pages/legal/* regex (Rule 3) matched first, it would 301 to
+  # /legal/terms-of-service/ which is a 404.
   rules {
     action      = "redirect"
     description = "Redirect /pages/legal/terms-of-service.html → /legal/terms-and-conditions/ (renamed slug)"
@@ -231,118 +74,52 @@ resource "cloudflare_ruleset" "seo_page_redirects" {
     }
   }
 
+  # Rule 2: top-level /pages/<slug>.html → /<slug>/.
+  # Match anchors are `^/pages/[^/]+\.html$` so single-segment paths only —
+  # /pages/legal/cookie-policy.html (depth 2) is intentionally NOT matched
+  # here; Rule 3 handles it. /pages/legal.html (depth 1) IS matched here and
+  # correctly routes to /legal/.
+  # Covers: agents, skills, vision, community, getting-started, legal,
+  #         pricing, changelog (8 source paths).
   rules {
     action      = "redirect"
-    description = "Redirect /pages/legal/cookie-policy.html → /legal/cookie-policy/"
+    description = "Redirect /pages/<slug>.html → /<slug>/ (regex-consolidated, 8 source paths)"
     enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/legal/cookie-policy.html\")"
+    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path matches \"^/pages/[^/]+\\.html$\")"
     action_parameters {
       from_value {
         status_code           = 301
         preserve_query_string = false
         target_url {
-          value = "https://www.soleur.ai/legal/cookie-policy/"
+          expression = "concat(\"https://www.soleur.ai\", regex_replace(http.request.uri.path, \"^/pages/([^/]+)\\.html$\", \"/$${1}/\"))"
         }
       }
     }
   }
 
+  # Rule 3: /pages/legal/<slug>.html → /legal/<slug>/ (depth 2, regex).
+  # The terms-of-service rename is excluded by Rule 1 firing first.
+  # Covers: privacy-policy, terms-and-conditions, cookie-policy, gdpr-policy,
+  #         acceptable-use-policy, data-protection-disclosure, individual-cla,
+  #         corporate-cla, disclaimer (9 source paths).
   rules {
     action      = "redirect"
-    description = "Redirect /pages/legal/gdpr-policy.html → /legal/gdpr-policy/"
+    description = "Redirect /pages/legal/<slug>.html → /legal/<slug>/ (regex-consolidated, 9 source paths)"
     enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/legal/gdpr-policy.html\")"
+    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path matches \"^/pages/legal/[^/]+\\.html$\")"
     action_parameters {
       from_value {
         status_code           = 301
         preserve_query_string = false
         target_url {
-          value = "https://www.soleur.ai/legal/gdpr-policy/"
+          expression = "concat(\"https://www.soleur.ai/legal\", regex_replace(http.request.uri.path, \"^/pages/legal/([^/]+)\\.html$\", \"/$${1}/\"))"
         }
       }
     }
   }
 
-  rules {
-    action      = "redirect"
-    description = "Redirect /pages/legal/acceptable-use-policy.html → /legal/acceptable-use-policy/"
-    enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/legal/acceptable-use-policy.html\")"
-    action_parameters {
-      from_value {
-        status_code           = 301
-        preserve_query_string = false
-        target_url {
-          value = "https://www.soleur.ai/legal/acceptable-use-policy/"
-        }
-      }
-    }
-  }
-
-  rules {
-    action      = "redirect"
-    description = "Redirect /pages/legal/data-protection-disclosure.html → /legal/data-protection-disclosure/"
-    enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/legal/data-protection-disclosure.html\")"
-    action_parameters {
-      from_value {
-        status_code           = 301
-        preserve_query_string = false
-        target_url {
-          value = "https://www.soleur.ai/legal/data-protection-disclosure/"
-        }
-      }
-    }
-  }
-
-  rules {
-    action      = "redirect"
-    description = "Redirect /pages/legal/individual-cla.html → /legal/individual-cla/"
-    enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/legal/individual-cla.html\")"
-    action_parameters {
-      from_value {
-        status_code           = 301
-        preserve_query_string = false
-        target_url {
-          value = "https://www.soleur.ai/legal/individual-cla/"
-        }
-      }
-    }
-  }
-
-  rules {
-    action      = "redirect"
-    description = "Redirect /pages/legal/corporate-cla.html → /legal/corporate-cla/"
-    enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/legal/corporate-cla.html\")"
-    action_parameters {
-      from_value {
-        status_code           = 301
-        preserve_query_string = false
-        target_url {
-          value = "https://www.soleur.ai/legal/corporate-cla/"
-        }
-      }
-    }
-  }
-
-  rules {
-    action      = "redirect"
-    description = "Redirect /pages/legal/disclaimer.html → /legal/disclaimer/"
-    enabled     = true
-    expression  = "(http.host eq \"www.soleur.ai\" and http.request.uri.path eq \"/pages/legal/disclaimer.html\")"
-    action_parameters {
-      from_value {
-        status_code           = 301
-        preserve_query_string = false
-        target_url {
-          value = "https://www.soleur.ai/legal/disclaimer/"
-        }
-      }
-    }
-  }
-
+  # Rule 4: blog content reslug.
+  # Specific path; not part of the /pages/* pattern.
   rules {
     action      = "redirect"
     description = "Redirect /blog/what-is-company-as-a-service/index.html → /company-as-a-service/"


### PR DESCRIPTION
**Hotfix #2 for PR #3296.** PR #3357 consolidated 19 explicit rules to 4 regex-based rules. The apply failed on a different Free-tier constraint:

```
Error: '...regex_replace(...)' is not allowed for target_url because not entitled:
the use of function regex_replace is not allowed,
a Business plan or a WAF Advanced plan is required
```

Free tier blocks BOTH `>10 rules` (the original failure that motivated #3357) AND `regex_replace` in target_url expressions (the consolidation failure here). No combination of regex consolidation works on Free tier; only path is explicit static targets, capped at 10.

## Summary

10 explicit rules, prioritized by GSC bucket impact:

- **8 top-level pages** (`/pages/<slug>.html → /<slug>/`): agents, skills, vision, community, getting-started, legal, pricing, changelog
- **1 slug rename**: `/pages/legal/terms-of-service.html → /legal/terms-and-conditions/` — the only entry with a confirmed GSC 404 bucket pre-fix
- **1 blog reslug**: `/blog/what-is-company-as-a-service/index.html → /company-as-a-service/`

**Deferred to #3367** (Bulk Redirects refactor): 9 individual `/pages/legal/<slug>.html` redirects. These paths return 404 until #3367 lands; Google will recrawl from sitemap and drop them — acceptable since the canonical `/legal/<slug>/` paths are in the sitemap and indexed.

## Verification

- `terraform validate` ✓
- `terraform fmt -check` ✓

## Test plan

- [x] Local validate + fmt
- [ ] Post-merge `terraform plan` shows `1 to add, 0 to change, 0 to destroy`
- [ ] Post-merge `terraform apply` succeeds (10 rules ≤ Free-tier cap; no regex_replace)
- [ ] Curl verification on each of the 10 source paths returns HTTP 301 to the correct canonical
- [ ] GSC `Validate fix` clicked on redirect bucket once URLs propagate

## Changelog

semver:patch — infra hygiene; no end-user behavior change beyond what PR #3296 already promised. Subset of redirects deferred to #3367 Bulk Redirects refactor.

Ref #3297
Ref #3367

🤖 Generated with [Claude Code](https://claude.com/claude-code)