### PR TITLE
fix(test): regenerate package-lock.json after #3391 engines add

### DIFF
--- a/apps/web-platform/package-lock.json
+++ b/apps/web-platform/package-lock.json
@@ -54,6 +54,9 @@
         "tsx": "^4.19.0",
         "typescript": "^5.7.0",
         "vitest": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -10464,7 +10467,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [


### PR DESCRIPTION
## Summary

PR #3391 added `engines` to `apps/web-platform/package.json` but did not regenerate `package-lock.json`. CI's `lockfile-sync` job failed on the merge commit and the v0.66.10 release deploy timed out — prod stayed on v0.66.9.

Per AGENTS.md `cq-before-pushing-package-json-changes`: both `bun.lock` and `package-lock.json` must be regenerated when `package.json` changes. `bun.lock` was already current (`bun install --frozen-lockfile` no-op); `npm install` in `apps/web-platform/` now syncs `package-lock.json` with the new engines block.

Ref #3391

## Changelog

### Web Platform

- Fixed: regenerated `package-lock.json` so it includes the `engines` block from #3391, restoring CI `lockfile-sync` green and unblocking the v0.66.10 release deploy.

## Test plan

- [x] `git diff` shows minimal change: 3 insertions (engines block) + 1 deletion (fsevents `dev: true` flip from npm's solver)
- [ ] CI `lockfile-sync` job passes
- [ ] Web Platform Release succeeds and prod advances past v0.66.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)