### PR TITLE
fix(one-shot,review): add continuation gate after review + suppress verbose summary in pipeline mode

### DIFF
--- a/knowledge-base/project/learnings/2026-05-07-one-shot-stops-on-review-summary-as-pseudo-handoff.md
+++ b/knowledge-base/project/learnings/2026-05-07-one-shot-stops-on-review-summary-as-pseudo-handoff.md
@@ -1,0 +1,105 @@
+---
+module: one-shot
+date: 2026-05-07
+problem_type: workflow_issue
+component: skill_orchestration
+symptoms:
+  - "one-shot pipeline runs review then stops mid-task"
+  - "agent treats review's '## Code Review Complete' summary as a turn-ending deliverable"
+root_cause: missing_continuation_gate_after_review
+severity: medium
+tags: [one-shot, review, continuation-gate, workflow]
+---
+
+# Learning: one-shot stops after review because the summary block reads like a deliverable
+
+## Problem
+
+During PR #3399's one-shot run, the agent completed step 4 (`skill: soleur:review`),
+emitted the prescribed `## Code Review Complete` block + `### Next Steps`
+section, then ended the turn — leaving steps 5–8 (resolve findings, QA,
+compound, ship) un-executed until the user nudged with "btw, why did you stop
+mid task?"
+
+The pipeline didn't crash. There was no error. The agent simply mistook the
+review skill's verbose summary for a turn boundary, in violation of AGENTS.md
+`hr-when-a-workflow-concludes-with-an-actionable-next-step`.
+
+## Root cause
+
+Two structural gaps in the SKILL definitions:
+
+1. **`one-shot/SKILL.md`** had a `> CONTINUATION GATE` between work (step 3)
+   and review (step 4) but **none** between review (step 4) and the resolve
+   step (step 5). Work outputs `## Work Phase Complete` and the gate says
+   "this is a status marker, not a stopping point — proceed in the same
+   response." Review outputs `## Code Review Complete` with a `### Next Steps`
+   block — and there was no equivalent gate, so the model defaulted to its
+   built-in "summarize and yield" instinct.
+
+2. **`review/SKILL.md`** Step 3 (Summary Report) emitted the same verbose
+   `## Code Review Complete` template **regardless** of invocation mode.
+   Pipeline detection lived in Phase 6 (Exit Gate) and only said "skip the
+   exit gate" — too late: by then the agent had already written the
+   terminal-shaped summary and was preparing to return. The framing
+   (heading + Next Steps + advice on what `/ship` does next) reads exactly
+   like an end-of-task handoff to a human reviewer, even though the calling
+   orchestrator was waiting on a tight progress marker.
+
+The two gaps compounded: review emitted a turn-ending-shaped block, and
+one-shot had no rail to recognize it as a checkpoint.
+
+## Solution
+
+Two SKILL.md edits — both small, both reinforce the same invariant from
+opposite sides.
+
+**`plugins/soleur/skills/one-shot/SKILL.md`:** Added a `> CONTINUATION GATE`
+between step 4 (review) and step 5 with the same shape as the work→review
+gate. Names the failure modes explicitly ("`## Code Review Complete`",
+"Findings Summary", "Next Steps") and extends the rule to every subsequent
+hand-off (5 → 5.5 → 6 → 7 → 8) so each skill's exit summary is treated as a
+checkpoint, not a stopping point.
+
+**`plugins/soleur/skills/review/SKILL.md`:** Step 3 now runs **pipeline
+detection FIRST**, before any heading is emitted. In pipeline mode the
+review skill emits a compact `## Review Phase Complete` marker (analogous
+to work's `## Work Phase Complete`) with no `### Next Steps` block —
+removing the framing that triggers the stop. Phase 6's pipeline-detection
+paragraph explicitly says "do not output the verbose `## Code Review
+Complete` block" so the two sections agree.
+
+The compact marker is the first-class signal; the verbose block is reserved
+for direct interactive invocations where a human reader is the audience.
+
+## Key insight
+
+When a skill's exit summary uses the same heading-and-Next-Steps shape that
+the model has been trained to use as a "task complete, return control to the
+user" handoff, no amount of "skip the exit gate" instruction downstream can
+prevent the stop — the agent has already framed the response as terminal.
+The fix is to suppress the terminal-shaped output **at the source** for
+orchestrator callers, AND add an explicit continuation rail in the
+orchestrator that names the visual pattern the agent will encounter.
+
+This generalizes: any skill in the `plan → work → review → qa → compound →
+ship` chain that emits a verbose summary block needs the same two-sided
+defense — a compact pipeline-mode marker on the producer side, plus a
+continuation gate on the orchestrator side that names the marker and the
+forbidden alternatives. Work and review are now consistent; the same
+audit should apply to QA, compound, and ship summaries the next time one
+of them produces a stop-on-summary regression.
+
+## Session errors
+
+None new for this session — the fix WAS the response to the last
+session's stop-on-review-summary error.
+
+## Cross-references
+
+- AGENTS.md `hr-when-a-workflow-concludes-with-an-actionable-next-step` —
+  the load-bearing rule the stop violated.
+- `plugins/soleur/skills/work/SKILL.md` — `## Work Phase Complete` marker
+  pattern that this fix mirrors for review.
+- PR #3399 — the run where the stop was observed and the user nudge was
+  required to resume.

--- a/plugins/soleur/skills/one-shot/SKILL.md
+++ b/plugins/soleur/skills/one-shot/SKILL.md
@@ -100,6 +100,9 @@ After the subagent returns, check for a `## Session Summary` heading in the outp
 > **CONTINUATION GATE**: When work outputs `## Work Phase Complete`, that is your signal to continue. Do NOT end your turn. Do NOT treat "Implementation complete" or similar phrases as a stopping point. Immediately proceed to step 4 in the same response.
 
 4. Use the **Skill tool**: `skill: soleur:review`
+
+> **CONTINUATION GATE**: When review outputs `## Code Review Complete` (or any review-summary heading, "Findings Summary", "Next Steps", etc.), that is a **status marker**, not a turn boundary. Do NOT end your turn. Do NOT treat the review summary as a deliverable — your deliverable is the merged PR at step 8. After the summary, immediately proceed to step 5 in the same response. If you find yourself wanting to write a wrap-up sentence, hand off to the user, or wait for confirmation, stop — that is the failure mode this gate exists to block. The same anti-stop rule applies between every subsequent step (5 → 5.5 → 6 → 7 → 8): each skill's exit summary is a checkpoint, never a stopping point.
+
 5. **Resolve ALL review findings (P1, P2, and P3).** Technical debt compounds — fix everything now, not later. List open GitHub issues from this review session:
 
    ```bash

--- a/plugins/soleur/skills/review/SKILL.md
+++ b/plugins/soleur/skills/review/SKILL.md
@@ -503,7 +503,24 @@ this really cross-cutting?") for findings the PR itself introduced.
 
 #### Step 3: Summary Report
 
-After creating all GitHub issues, present comprehensive summary:
+**Pipeline detection (run BEFORE writing the summary):** Scan the conversation for `skill: soleur:work` or `skill: soleur:one-shot` output. If either is present, you are in **pipeline mode** — the calling orchestrator owns the lifecycle and is waiting on you to return so it can run step 5 / Phase 4. Emit the **compact progress marker** below instead of the verbose summary, then return immediately. Do NOT use the heading `## Code Review Complete`, do NOT include a `### Next Steps` section, and do NOT write a wrap-up sentence — those framings cause one-shot to mistake the summary for a turn boundary and stop mid-pipeline.
+
+**Compact progress marker (pipeline mode):**
+
+```markdown
+## Review Phase Complete
+
+- **Findings:** N total — N1 P1 / N2 P2 / N3 P3
+- **Fixed inline:** N (commits: <sha>, <sha>, …)
+- **Filed as scope-out:** N (#NNN, #NNN — criteria listed below)
+- **Agents run:** <comma-separated list>
+
+[Optional 1-line table of scope-out issues with criteria, if any.]
+```
+
+After emitting the marker, the calling skill's continuation gate takes over — control returns to one-shot step 5 / work Phase 4 in the SAME response.
+
+**Direct invocation summary (interactive mode only — no `soleur:work` or `soleur:one-shot` in conversation):** Use the verbose summary template below.
 
 ````markdown
 ## Code Review Complete
@@ -595,7 +612,7 @@ After creating all GitHub issues, present comprehensive summary:
 
 ### 6. Exit Gate
 
-**Pipeline detection:** If the conversation contains `skill: soleur:work` output earlier (indicating review was invoked by work's Phase 4 chain) or `soleur:one-shot` output (indicating review was invoked by one-shot step 4), skip the exit gate. The calling pipeline handles compound, commit, and lifecycle progression. When review is invoked by work or one-shot, do not duplicate these steps.
+**Pipeline detection:** If the conversation contains `skill: soleur:work` output earlier (indicating review was invoked by work's Phase 4 chain) or `soleur:one-shot` output (indicating review was invoked by one-shot step 4), skip the exit gate. The calling pipeline handles compound, commit, and lifecycle progression. When review is invoked by work or one-shot, do not duplicate these steps **and do not output the verbose `## Code Review Complete` block from Step 3** — the compact `## Review Phase Complete` marker (Step 3, pipeline mode) is the only output and the orchestrator's continuation gate handles progression. The verbose summary's `### Next Steps` block is the failure mode that causes orchestrators to mistake the report for a turn-ending deliverable.
 
 **If invoked directly by the user** (no work or one-shot orchestrator in the conversation):
 


### PR DESCRIPTION
## Summary

In PR #3399's one-shot run the agent stopped after step 4 (review). Root cause: the review skill emitted `## Code Review Complete` + `### Next Steps`, which reads as a terminal deliverable, and one-shot had no continuation rail between step 4 and step 5.

Two-sided fix:

- `one-shot/SKILL.md` gets a `> CONTINUATION GATE` between step 4 and step 5, mirroring the existing work→review gate. Names the visual pattern (`## Code Review Complete`, "Next Steps") so the agent recognizes it as a checkpoint, not a stop. Extends the rule to every subsequent hand-off in steps 5–8.
- `review/SKILL.md` runs pipeline detection at the start of Step 3 (Summary Report), before any heading is emitted. Pipeline mode emits a compact `## Review Phase Complete` marker (analogous to work's `## Work Phase Complete`) — no `### Next Steps`, no terminal framing. Direct invocations still get the verbose summary. Phase 6's pipeline detection paragraph reinforces the same rule.

The compact marker is the first-class signal; the verbose block is reserved for direct interactive invocations where a human reader is the audience.

## Changelog

### Plugin

- `skills/one-shot/SKILL.md`: continuation gate after step 4 (review)
- `skills/review/SKILL.md`: Step 3 pipeline-mode compact marker; Phase 6 reinforced

### Knowledge Base

- New learning: `2026-05-07-one-shot-stops-on-review-summary-as-pseudo-handoff.md`

## Test plan

- [x] 25/25 plugin test suites pass (`bash scripts/test-all.sh`)
- [x] Both SKILL.md edits diff-checked for placement gate compliance (domain-scoped, not AGENTS.md)
- [ ] ⏳ Verified next time `/soleur:one-shot` runs end-to-end without an explicit user nudge after the review step

Generated with [Claude Code](https://claude.com/claude-code)