### PR TITLE
fix(infra): include dev-signin gate script in Docker build context

### DIFF
--- a/apps/web-platform/.dockerignore
+++ b/apps/web-platform/.dockerignore
@@ -4,6 +4,13 @@ node_modules
 # Terraform configs, not needed at runtime
 infra/
 scripts/
+# Allow the post-build dev-signin grep gate (R3 / feat-dev-signin-bypass).
+# The Dockerfile builder stage runs `bash scripts/assert-dev-signin-eliminated.sh`
+# immediately after `npm run build`; without this re-include the script is
+# excluded from the build context and the RUN step exits 127 (file not
+# found), failing the prd image build. The runner stage is a separate
+# `FROM` so this re-include does NOT bloat the runtime image.
+!scripts/assert-dev-signin-eliminated.sh
 
 .git
 .gitignore


### PR DESCRIPTION
## Summary

Hotfix for #3455: the Dockerfile builder stage runs the post-build dev-signin grep gate immediately after `npm run build`, but the .dockerignore in this app excludes the entire scripts/ directory wholesale. The script was therefore absent inside the container and the RUN step exited 127 (file not found), failing every Web Platform Release run since merge of #3455.

Production is currently running the previous image (the merge of #3455 created tag `web-v0.69.0` but the Docker image push step failed; deploy was skipped).

## Changelog

### Web Platform — fix(infra)

- Re-include only the dev-signin grep gate's bash file via a `!` pattern in the .dockerignore. The runner stage is a separate `FROM` and does not inherit the script — the runtime image stays clean.

## Test plan

- [x] Local diff verified: only one file changed, single re-include line.
- [x] CI's Web Platform Release docker buildx step is the actual verifier — passing the build means the script is now in context AND the gate ran cleanly against the prd-mode `.next/` output (the gate itself was already verified locally pre-merge of #3455).

Refs #3455