### PR TITLE
feat(web-platform): user-initiated Stop — client UI (PR2 of #3448)

### DIFF
--- a/apps/web-platform/components/chat/chat-input.tsx
+++ b/apps/web-platform/components/chat/chat-input.tsx
@@ -75,8 +75,27 @@ export function ChatInput({
   streamState = "idle",
   onStop,
 }: ChatInputProps) {
-  const isStopping = streamState === "stopping";
-  const showStop = streamState === "streaming" || isStopping;
+  // #3448 PR2 (review fix): exhaustive narrowing on the StreamState union
+  // per AGENTS.md `cq-union-widening-grep-three-patterns`. A future widening
+  // (e.g., adding `"queued"`) fails build here instead of silently flowing
+  // into the Send branch.
+  const buttonMode: "send" | "stop" | "stopping" = (() => {
+    switch (streamState) {
+      case "idle":
+        return "send";
+      case "streaming":
+        return "stop";
+      case "stopping":
+        return "stopping";
+      default: {
+        const _exhaustive: never = streamState;
+        void _exhaustive;
+        return "send";
+      }
+    }
+  })();
+  const showStop = buttonMode !== "send";
+  const isStopping = buttonMode === "stopping";
   const disabled = rawDisabled || workflowEnded;
   const placeholder = workflowEnded
     ? "This conversation has ended"

--- a/apps/web-platform/components/chat/chat-input.tsx
+++ b/apps/web-platform/components/chat/chat-input.tsx
@@ -5,6 +5,7 @@ import { useState, useRef, useCallback, useEffect, useLayoutEffect as reactUseLa
 const useIsomorphicLayoutEffect =
   typeof window !== "undefined" ? reactUseLayoutEffect : useEffect;
 import type { AttachmentRef } from "@/lib/types";
+import type { StreamState } from "@/lib/ws-client";
 import { validateFiles } from "@/lib/validate-files";
 import { uploadWithProgress } from "@/lib/upload-with-progress";
 import { safeSession } from "@/lib/safe-session";
@@ -45,6 +46,17 @@ interface ChatInputProps {
    *  Per `cq-jsdom-no-layout-gated-assertions`, the test hook is the
    *  textarea's `placeholder` attribute, which is structural. */
   workflowEnded?: boolean;
+  /** #3448 PR2: per-turn stream lifecycle. When `"streaming"` or
+   *  `"stopping"`, the Send button is replaced by a Stop button that
+   *  invokes `onStop`. While `"stopping"`, the Stop button is disabled and
+   *  labeled "Stopping…" until `session_ended` lands and the parent flips
+   *  this back to `"idle"`. Defaults to `"idle"` for callers that do not
+   *  yet thread the lifecycle (chat-input is reused outside the chat
+   *  surface — e.g. the KB sidebar passes the value directly). */
+  streamState?: StreamState;
+  /** #3448 PR2: invoked when the user clicks Stop. Wired to
+   *  `useWebSocket.abort()` by ChatSurface. */
+  onStop?: () => void;
 }
 
 export function ChatInput({
@@ -60,7 +72,11 @@ export function ChatInput({
   draftKey,
   atMentionVisible = false,
   workflowEnded = false,
+  streamState = "idle",
+  onStop,
 }: ChatInputProps) {
+  const isStopping = streamState === "stopping";
+  const showStop = streamState === "streaming" || isStopping;
   const disabled = rawDisabled || workflowEnded;
   const placeholder = workflowEnded
     ? "This conversation has ended"
@@ -613,25 +629,45 @@ export function ChatInput({
             <span className="text-sm font-medium">@</span>
           </button>
         </div>
-        <button
-          type="button"
-          onClick={handleSubmit}
-          disabled={disabled || isUploading || (!value.trim() && attachments.length === 0)}
-          className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-xl bg-amber-600 text-soleur-text-on-accent transition-colors hover:bg-amber-500 disabled:opacity-50 disabled:hover:bg-amber-600"
-          aria-label="Send message"
-        >
-          {isUploading ? (
-            <svg width="18" height="18" viewBox="0 0 24 24" className="animate-spin" fill="none" stroke="currentColor" strokeWidth="2">
-              <circle cx="12" cy="12" r="10" strokeOpacity="0.25" />
-              <path d="M12 2a10 10 0 0 1 10 10" strokeLinecap="round" />
-            </svg>
-          ) : (
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <line x1="12" y1="19" x2="12" y2="5" />
-              <polyline points="5 12 12 5 19 12" />
-            </svg>
-          )}
-        </button>
+        {showStop ? (
+          // #3448 PR2: Stop button replaces Send while a turn is in flight
+          // (`streaming`) and stays mounted but disabled while waiting for
+          // the server's `session_ended` ack (`stopping`). The accessible
+          // name + visible label both transition to "Stopping…" so the
+          // user has a single source of truth on the Stop affordance.
+          <button
+            type="button"
+            onClick={onStop}
+            disabled={isStopping || onStop === undefined}
+            className="flex h-[44px] min-w-[44px] shrink-0 items-center justify-center rounded-xl border border-amber-700/50 bg-soleur-bg-surface-2 px-3 text-soleur-text-primary transition-colors hover:border-amber-600 hover:bg-soleur-bg-surface-1 disabled:opacity-60"
+            aria-label={isStopping ? "Stopping" : "Stop"}
+            data-testid="chat-stop-button"
+          >
+            <span className="text-xs font-medium">
+              {isStopping ? "Stopping…" : "Stop"}
+            </span>
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={disabled || isUploading || (!value.trim() && attachments.length === 0)}
+            className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-xl bg-amber-600 text-soleur-text-on-accent transition-colors hover:bg-amber-500 disabled:opacity-50 disabled:hover:bg-amber-600"
+            aria-label="Send message"
+          >
+            {isUploading ? (
+              <svg width="18" height="18" viewBox="0 0 24 24" className="animate-spin" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="12" cy="12" r="10" strokeOpacity="0.25" />
+                <path d="M12 2a10 10 0 0 1 10 10" strokeLinecap="round" />
+              </svg>
+            ) : (
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="12" y1="19" x2="12" y2="5" />
+                <polyline points="5 12 12 5 19 12" />
+              </svg>
+            )}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/apps/web-platform/components/chat/chat-surface.tsx
+++ b/apps/web-platform/components/chat/chat-surface.tsx
@@ -205,6 +205,8 @@ export function ChatSurface({
     workflow,
     workflowEndedAt,
     historyLoading,
+    streamState,
+    abort,
   } = useWebSocket(conversationId);
 
   const { names: customNames, getDisplayName, getIconPath, loading: teamNamesLoading } = useTeamNames();
@@ -299,6 +301,39 @@ export function ChatSurface({
       setSessionStarted(false);
     }
   }, [status]);
+
+  // #3448 PR2 — Esc keyboard shortcut with focus guard.
+  //
+  // Mounts a `document`-level keydown listener only while a turn is in
+  // flight (`streaming`) or already aborting (`stopping`, so a quick second
+  // Esc is harmlessly ignored by `abort()`'s own no-op-while-stopping
+  // guard rather than racing the Stop button into a stale state).
+  //
+  // Esc-while-typing guard (plan §"Plan-time additions from SpecFlow"):
+  // when the user is mid-sentence in the chat textarea, Esc must NOT
+  // abort — the textarea's native Esc handling (clear autocomplete, blur)
+  // is the more frequent intent. We treat "focused on a textarea with
+  // content" as the suppressing condition; an empty textarea, an unfocused
+  // textarea, or focus on any other element falls through to abort.
+  //
+  // Per AGENTS.md `cq-ref-removal-sweep-cleanup-closures`, the effect's
+  // cleanup MUST return removeEventListener — orphaned listeners survive
+  // unmount and would re-fire abort on a freshly-mounted bubble's first
+  // Esc. The test `task 5.7` is the regression gate for this.
+  useEffect(() => {
+    if (streamState !== "streaming" && streamState !== "stopping") return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      const target = document.activeElement;
+      if (target instanceof HTMLTextAreaElement && target.value.length > 0) {
+        return;
+      }
+      e.preventDefault();
+      abort();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [streamState, abort]);
 
   useEffect(() => {
     if (sessionConfirmed && msgParam && !initialMsgSent) {
@@ -518,6 +553,8 @@ export function ChatSurface({
                       getIconPath={getIconPath}
                       attachments={msg.attachments}
                       variant={variant}
+                      status={msg.status}
+                      usage={msg.usage}
                     />
                   );
                   break;
@@ -706,6 +743,8 @@ export function ChatSurface({
             quoteRef={quoteRef}
             focusRef={focusRef}
             draftKey={draftKey}
+            streamState={streamState}
+            onStop={abort}
           />
         </div>
         {!isFull && usageData && usageData.totalCostUsd > 0 && (

--- a/apps/web-platform/components/chat/chat-surface.tsx
+++ b/apps/web-platform/components/chat/chat-surface.tsx
@@ -325,8 +325,27 @@ export function ChatSurface({
     const handler = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
       const target = document.activeElement;
-      if (target instanceof HTMLTextAreaElement && target.value.length > 0) {
-        return;
+      // Review fix (security): the original guard only suppressed Esc on
+      // a non-empty <textarea>. That left native UA Esc semantics (close
+      // autocomplete, clear, blur, dismiss dialog) shadowed for:
+      //   - <input type="text"> and friends (KB filename input, search box,
+      //     dialog text inputs),
+      //   - any [contenteditable] element (rich-text widgets),
+      //   - elements inside an open Radix/Headless `[role="dialog"]`
+      //     where Esc is the established close gesture.
+      // For all three, Esc-mid-stream now defers to the local handler:
+      // user closes the dialog / clears the input WITHOUT also burning
+      // their billable turn. Stop via the on-screen button still works.
+      if (target instanceof HTMLElement) {
+        if (target.closest('[role="dialog"]')) return;
+        if (target.isContentEditable) return;
+        const hasContent =
+          (target instanceof HTMLInputElement &&
+            target.type !== "checkbox" &&
+            target.type !== "radio" &&
+            target.value.length > 0) ||
+          (target instanceof HTMLTextAreaElement && target.value.length > 0);
+        if (hasContent) return;
       }
       e.preventDefault();
       abort();

--- a/apps/web-platform/components/chat/message-bubble.tsx
+++ b/apps/web-platform/components/chat/message-bubble.tsx
@@ -54,6 +54,20 @@ export function RetryingChip({ label }: { label: string | undefined }) {
   );
 }
 
+/** #3448 PR2 — abort-marker payload, mirrors the `usage` jsonb persisted on
+ *  `messages` rows whose `status === 'aborted'`. The shape is documented in
+ *  migration 040 and `lib/types.ts:Message.usage`. */
+export interface AbortMarkerUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd?: number | null;
+  completed_actions: Array<{
+    tool_name: string;
+    input_summary: string;
+    result_summary: string;
+  }>;
+}
+
 // Wrapped in React.memo so token streaming (10-50 Hz) doesn't re-render every
 // bubble in a long thread. `getDisplayName`/`getIconPath` are already
 // `useCallback`-stable in `use-team-names.tsx`; other props are primitives or
@@ -71,6 +85,8 @@ export const MessageBubble = memo(function MessageBubble({
   getIconPath,
   attachments,
   variant = "full",
+  status,
+  usage,
 }: {
   role: "user" | "assistant";
   content: string;
@@ -85,6 +101,14 @@ export const MessageBubble = memo(function MessageBubble({
   getIconPath?: (id: DomainLeaderId) => string | null;
   attachments?: AttachmentRef[];
   variant?: "full" | "sidebar";
+  /** #3448 PR2: persistence-tier discriminator for the abort marker.
+   *  `"aborted"` swaps the inner content for a marker block (partial text,
+   *  `[stopped by user]` chip, token cost, completed-actions chip-list).
+   *  `"complete"` / undefined uses the existing render path. */
+  status?: "complete" | "aborted";
+  /** #3448 PR2: aborted-turn snapshot. Required when `status === "aborted"`;
+   *  ignored otherwise. */
+  usage?: AbortMarkerUsage | null;
   // Review F5 (#2886): the `parentId` prop, the `ml-6` indentClass, and the
   // `data-parent-id` attribute were removed — they had no production caller.
   // SubagentGroup renders its child rows directly with their own indentation
@@ -163,7 +187,9 @@ export const MessageBubble = memo(function MessageBubble({
             </div>
           )}
 
-          {renderBubbleContent({ isUser, messageState, content, toolLabel, toolsUsed, retrying, isDone, variant })}
+          {status === "aborted" && role === "assistant"
+            ? renderAbortedAssistant({ content, usage, variant })
+            : renderBubbleContent({ isUser, messageState, content, toolLabel, toolsUsed, retrying, isDone, variant })}
 
           {attachments && attachments.length > 0 && (
             <AttachmentDisplay attachments={attachments} />
@@ -275,4 +301,82 @@ function renderBubbleContent({
       void isDone;
       return <MarkdownRenderer content={scrubbedContent} wrapCode={wrapCode} />;
   }
+}
+
+/**
+ * #3448 PR2 — abort-marker render path.
+ *
+ * Honest disclosure (G2 in the abort plan): partial text the user paid for,
+ * the `[stopped by user]` chip, the token cost, and the chip-list of
+ * tool calls that completed before Stop landed. The ToolUseChip component
+ * narrows `leaderId` to the routing leaders (`cc_router`/`system`), so we
+ * render the per-action chips inline rather than misusing that component
+ * with a different leader contract.
+ */
+function renderAbortedAssistant({
+  content,
+  usage,
+  variant,
+}: {
+  content: string;
+  usage: AbortMarkerUsage | null | undefined;
+  variant: "full" | "sidebar";
+}): React.ReactNode {
+  const wrapCode = variant === "sidebar";
+  const totalTokens = usage
+    ? usage.input_tokens + usage.output_tokens
+    : null;
+  const costLabel =
+    usage && typeof usage.cost_usd === "number"
+      ? `$${usage.cost_usd.toFixed(4)}`
+      : "included in your plan";
+  const actions = usage?.completed_actions ?? [];
+
+  return (
+    <div className="min-w-0" data-testid="abort-marker">
+      {content.length > 0 && (
+        <div className="min-w-0">
+          <MarkdownRenderer content={content} wrapCode={wrapCode} />
+        </div>
+      )}
+      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+        <span
+          className="inline-flex items-center rounded-full border border-amber-700/60 bg-soleur-bg-surface-2 px-2 py-0.5 text-amber-400"
+          data-testid="abort-marker-chip"
+        >
+          [stopped by user]
+        </span>
+        {totalTokens !== null && (
+          <span
+            className="inline-flex items-center gap-1 text-soleur-text-muted"
+            data-testid="abort-marker-cost"
+          >
+            <span className="tabular-nums">{totalTokens}</span>
+            <span>tokens · {costLabel}</span>
+          </span>
+        )}
+      </div>
+      {actions.length > 0 && (
+        <div
+          className="mt-2 flex flex-wrap gap-1.5"
+          data-testid="abort-marker-actions"
+        >
+          {actions.map((a, i) => (
+            <span
+              key={`${a.tool_name}-${i}`}
+              title={a.result_summary || a.input_summary}
+              className="inline-flex items-center rounded bg-soleur-bg-surface-2 px-1.5 py-0.5 text-xs text-soleur-text-secondary"
+            >
+              {a.tool_name}
+              {a.input_summary ? (
+                <span className="ml-1 max-w-[180px] truncate text-soleur-text-muted">
+                  · {a.input_summary}
+                </span>
+              ) : null}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/apps/web-platform/lib/chat-state-machine.ts
+++ b/apps/web-platform/lib/chat-state-machine.ts
@@ -49,6 +49,25 @@ interface ChatMessageBase {
 
 interface ChatTextMessage extends ChatMessageBase {
   type: "text";
+  /** #3448 PR2: persistence-tier discriminator surfaced by the history
+   *  fetch (`status` column added in migration 040). `"aborted"` rows
+   *  trigger the abort-marker render path in `message-bubble.tsx`.
+   *  Optional so live-stream bubbles (which have no DB row yet) and
+   *  legacy fixtures both type-check. */
+  status?: "complete" | "aborted";
+  /** #3448 PR2: aborted-turn snapshot. Present only for rows whose
+   *  `status === "aborted"`. Shape mirrors the `usage` jsonb column
+   *  documented in migration 040. */
+  usage?: {
+    input_tokens: number;
+    output_tokens: number;
+    cost_usd?: number | null;
+    completed_actions: Array<{
+      tool_name: string;
+      input_summary: string;
+      result_summary: string;
+    }>;
+  } | null;
 }
 
 interface ChatGateMessage extends ChatMessageBase {

--- a/apps/web-platform/lib/ws-client.ts
+++ b/apps/web-platform/lib/ws-client.ts
@@ -29,6 +29,23 @@ export { STUCK_TIMEOUT_MS } from "@/lib/ws-constants";
 
 type ConnectionStatus = "connecting" | "connected" | "reconnecting" | "disconnected";
 
+/**
+ * Per-turn stream lifecycle exposed on the hook return surface.
+ *
+ *   - `"idle"`     — no in-flight assistant turn for this conversation.
+ *   - `"streaming"` — at least one leader is mid-stream (entered on the first
+ *                    `stream_start` after auth).
+ *   - `"stopping"`  — user clicked Stop / pressed Esc; an `abort_turn` frame
+ *                    was sent. Stays here until `session_ended` arrives so the
+ *                    Stop button can disable + show "Stopping…" without a
+ *                    second client-side timer.
+ *
+ * Distinct from `activeLeaderIds`: a multi-leader dispatch may still have
+ * leaders responding while we are already in `"stopping"` — the UI binds the
+ * Stop button to `streamState`, not to the per-leader map.
+ */
+export type StreamState = "idle" | "streaming" | "stopping";
+
 export interface WebSocketError {
   code: string;
   message: string;
@@ -102,6 +119,16 @@ interface UseWebSocketReturn {
    *  would otherwise clobber `useKbLayoutState`'s prefetched messageCount
    *  (race H3 in the resume hydration plan). */
   historyLoading: boolean;
+  /** Per-turn stream lifecycle (#3448 PR2). See `StreamState` jsdoc. The
+   *  Stop button + Esc shortcut bind to this field, NOT to
+   *  `activeLeaderIds.length > 0` — a multi-leader dispatch may have
+   *  leaders responding while we are already `"stopping"`. */
+  streamState: StreamState;
+  /** User-initiated Stop. Sends `{ type: "abort_turn", conversationId }` and
+   *  optimistically transitions `streamState` to `"stopping"`. No-op when
+   *  `streamState !== "streaming"` (idempotent under double-click) or when
+   *  no conversationId is resolved yet (pre-`session_started`). */
+  abort: () => void;
 }
 
 const MAX_BACKOFF = 30_000;
@@ -312,6 +339,12 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
   // so the trigger button does not flip to "Ask about this document" between
   // the prefetch (`useKbLayoutState`) and the history fetch resolving.
   const [historyLoading, setHistoryLoading] = useState(false);
+  // Per-turn stream lifecycle (#3448 PR2). Driven inline in the WS message
+  // switch to keep the transitions next to the events that cause them.
+  const [streamState, setStreamState] = useState<StreamState>("idle");
+  // Mirror of `realConversationId` for the `abort()` callback so a stale
+  // closure cannot send the wrong conversationId on the wire.
+  const realConversationIdRef = useRef<string | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const backoffRef = useRef(INITIAL_BACKOFF);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -356,6 +389,15 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
     timeoutTimersRef.current.set(leaderId, timer);
   }, [clearLeaderTimeout]);
 
+  // Mirror realConversationId into a ref so `abort()` reads the latest value
+  // without re-binding on every WS frame that updates state. The Stop UX
+  // tolerates a one-tick stale read (the user has to click), but the abort
+  // payload's conversationId MUST be current — a stale closure here would
+  // route the abort to a prior conversation under multi-tab navigation.
+  useEffect(() => {
+    realConversationIdRef.current = realConversationId;
+  }, [realConversationId]);
+
   // Apply timer side-effects declared by the reducer after each stream event,
   // then clear the pending intent so unrelated subsequent dispatches (add_message,
   // filter_prepend, gate_error, resolve_gate) cannot carry stale timer state
@@ -379,6 +421,7 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
     clearAllTimeouts();
     setSessionConfirmed(false);
     setRealConversationId(null);
+    setStreamState("idle");
     if (wsRef.current) {
       wsRef.current.onclose = null;
       wsRef.current.close();
@@ -409,6 +452,7 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
     clearAllTimeouts();
     setSessionConfirmed(false);
     setUsageData(null);
+    setStreamState("idle");
 
     // Clean up any existing connection
     if (wsRef.current) {
@@ -531,6 +575,15 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
           if (msg.type === "stream_start" && msg.source) {
             setRouteSource(msg.source);
           }
+          // #3448 PR2: enter `"streaming"` on the first stream_start of a
+          // turn. If the user already pressed Stop and we're in `"stopping"`,
+          // stay there — the server will follow up with `session_ended` and
+          // we collapse to `"idle"` then. A stream_start that arrives during
+          // `"stopping"` would otherwise re-enable the Send button while the
+          // abort is still in flight.
+          if (msg.type === "stream_start") {
+            setStreamState((prev) => (prev === "stopping" ? prev : "streaming"));
+          }
           // Dispatch to the pure reducer — no ref mutations inside the updater.
           // activeStreams and messages update atomically; pendingTimerAction carries
           // the timer intent out of the pure reducer for the useEffect above. See #2217.
@@ -543,6 +596,7 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
         case "error": {
           dispatch({ type: "clear_streams" });
           clearAllTimeouts();
+          setStreamState("idle");
 
           // Key invalidation: set structured error instead of redirect
           if (msg.errorCode === "key_invalid") {
@@ -595,6 +649,16 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
         case "session_ended": {
           dispatch({ type: "clear_streams" });
           clearAllTimeouts();
+          // #3448 PR2: a turn ended (any reason). Reset streamState so the
+          // Send button comes back. Multi-tab disambiguation: the server
+          // forwards `conversationId` for `user_aborted` reasons; honour it
+          // when present. Frames without `conversationId` (existing emitters
+          // for `turn_complete` / `idle_timeout`) are treated as scoped to
+          // this socket's current conversation, matching today's semantics.
+          const targetConv = realConversationIdRef.current;
+          if (!msg.conversationId || msg.conversationId === targetConv) {
+            setStreamState("idle");
+          }
           // Don't display "turn_complete" as a visible message — it's a lifecycle signal
           if (msg.reason !== "turn_complete") {
             dispatch({
@@ -785,12 +849,24 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
       content_type: string;
       size_bytes: number;
     };
+    type RawUsage = {
+      input_tokens: number;
+      output_tokens: number;
+      cost_usd?: number | null;
+      completed_actions?: Array<{
+        tool_name: string;
+        input_summary: string;
+        result_summary: string;
+      }>;
+    };
     const mapped = json.messages.map((m: {
       id: string;
       role: string;
       content: string;
       leader_id: string | null;
       message_attachments?: RawAttachment[] | null;
+      status?: "complete" | "aborted" | null;
+      usage?: RawUsage | null;
     }) => ({
       id: m.id,
       role: m.role as "user" | "assistant",
@@ -810,6 +886,17 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
         contentType: a.content_type,
         sizeBytes: a.size_bytes,
       })),
+      // #3448 PR2: surface persistence-tier abort status + usage snapshot
+      // so MessageBubble can render the abort marker on history reload.
+      status: m.status ?? undefined,
+      usage: m.usage
+        ? {
+            input_tokens: m.usage.input_tokens,
+            output_tokens: m.usage.output_tokens,
+            cost_usd: m.usage.cost_usd ?? null,
+            completed_actions: m.usage.completed_actions ?? [],
+          }
+        : null,
     }));
 
     const costData: UsageData | null =
@@ -992,6 +1079,33 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
     [],
   );
 
+  /**
+   * #3448 PR2 — user-initiated Stop. The contract:
+   *
+   *   - No-op when streamState !== "streaming" — handles both the idle
+   *     "no turn to stop" case and the double-click-while-stopping case.
+   *   - No-op when the WebSocket is not OPEN.
+   *   - No-op when no conversationId is resolved yet (pre-`session_started`).
+   *
+   * Sends `{ type: "abort_turn", conversationId }` and transitions
+   * streamState to "stopping" optimistically. The hook stays in "stopping"
+   * until `session_ended` arrives (single source of truth for the turn
+   * boundary). The server resolves `userId` from the authenticated socket
+   * — `userId` is intentionally NOT in the wire payload (TR4 cross-user
+   * invariant; see plan §"User-Brand Impact").
+   */
+  const abort = useCallback(() => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    if (streamState !== "streaming") return;
+    const targetConv =
+      realConversationIdRef.current ??
+      (conversationId !== "new" ? conversationId : null);
+    if (!targetConv) return;
+    ws.send(JSON.stringify({ type: "abort_turn", conversationId: targetConv }));
+    setStreamState("stopping");
+  }, [streamState, conversationId]);
+
   const reconnect = useCallback(() => {
     setLastError(null);
     setDisconnectReason(undefined);
@@ -1021,5 +1135,7 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
     workflow: chatState.workflow,
     workflowEndedAt,
     historyLoading,
+    streamState,
+    abort,
   };
 }

--- a/apps/web-platform/lib/ws-client.ts
+++ b/apps/web-platform/lib/ws-client.ts
@@ -175,6 +175,19 @@ export interface ChatState {
   workflow: WorkflowLifecycleState;
   /** Stage 4 (#2886): reverse-lookup index for `subagent_complete`. */
   spawnIndex: SpawnIndex;
+  /**
+   * #3448 PR2 — per-turn stream lifecycle.
+   *
+   * Folded into `ChatState` (rather than a parallel `useState`) so transitions
+   * are atomic with the reducer-managed `activeStreams` and `messages` they
+   * track — a render cannot observe `activeStreams.size === 0` while
+   * `streamState === "streaming"` (or vice versa). Also keeps all five
+   * transition sites (`stream_start`/`stream`/`tool_use`/`tool_progress` →
+   * "streaming"; `enter_stopping` → "stopping"; `clear_streams` → "idle")
+   * inside the reducer's `: never` rail, where a future widening of
+   * `StreamState` fails build instead of silently flowing into a Send branch.
+   */
+  streamState: StreamState;
   pendingTimerAction?: StreamEventResult["timerAction"];
 }
 
@@ -189,6 +202,12 @@ export type ChatAction =
   | { type: "filter_prepend"; messages: ChatMessage[] }
   | { type: "gate_error"; gateId: string; message: string }
   | { type: "resolve_gate"; gateId: string; selection: string }
+  /** #3448 PR2 — user clicked Stop / pressed Esc. Transitions
+   *  `streamState` "streaming" → "stopping". No-op if already
+   *  "stopping" or "idle" (idempotent under double-click). The
+   *  `abort_turn` WS frame is sent imperatively from the hook, NOT
+   *  inside the reducer (the reducer is pure). */
+  | { type: "enter_stopping" }
   | {
       type: "resolve_interactive_prompt";
       promptId: string;
@@ -206,11 +225,26 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
         state.spawnIndex,
         state.workflow,
       );
+      // #3448 PR2: enter "streaming" on the first turn-active event of an
+      // idle hook. Any of `stream_start`/`stream`/`tool_use`/`tool_progress`
+      // qualifies — see the architectural rationale on `ChatState.streamState`.
+      // Stays in "stopping" if the user already aborted; otherwise stays
+      // in "streaming" through the rest of the turn.
+      const isTurnActive =
+        action.msg.type === "stream_start" ||
+        action.msg.type === "stream" ||
+        action.msg.type === "tool_use" ||
+        action.msg.type === "tool_progress";
+      const nextStreamState: StreamState =
+        state.streamState === "idle" && isTurnActive
+          ? "streaming"
+          : state.streamState;
       return {
         messages: result.messages,
         activeStreams: result.activeStreams,
         workflow: result.workflow,
         spawnIndex: result.spawnIndex,
+        streamState: nextStreamState,
         pendingTimerAction: result.timerAction,
       };
     }
@@ -232,13 +266,25 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
       // Otherwise after `key_invalid` / `session_ended` / socket remount
       // (`connect()`), the lifecycle bar still renders the old workflow's
       // `state: "active"` and stale spawnIndex entries linger.
+      // #3448 PR2: also resets streamState to "idle" — atomicity invariant
+      // for the per-turn lifecycle slice.
       return {
         ...state,
         activeStreams: new Map(),
         workflow: { state: "idle" },
         spawnIndex: new Map(),
+        streamState: "idle",
         pendingTimerAction: undefined,
       };
+    case "enter_stopping":
+      // #3448 PR2: idempotent under double-click — only "streaming" → "stopping".
+      // "idle" / "stopping" are no-ops. Send-of-`abort_turn` is performed
+      // by the caller (the hook's `abort()` callback) BEFORE dispatching
+      // this action, so a returning identity-equal state from the reducer
+      // signals nothing to the WS frame either way.
+      return state.streamState === "streaming"
+        ? { ...state, streamState: "stopping" }
+        : state;
     case "ack_timer_action":
       return state.pendingTimerAction === undefined ? state : { ...state, pendingTimerAction: undefined };
     case "add_message":
@@ -310,6 +356,7 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
     activeStreams: new Map<DomainLeaderId, number>(),
     workflow: { state: "idle" },
     spawnIndex: new Map(),
+    streamState: "idle",
   }));
 
   // Derive activeLeaderIds from reducer state. `applyStreamEvent` preserves the
@@ -339,9 +386,9 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
   // so the trigger button does not flip to "Ask about this document" between
   // the prefetch (`useKbLayoutState`) and the history fetch resolving.
   const [historyLoading, setHistoryLoading] = useState(false);
-  // Per-turn stream lifecycle (#3448 PR2). Driven inline in the WS message
-  // switch to keep the transitions next to the events that cause them.
-  const [streamState, setStreamState] = useState<StreamState>("idle");
+  // #3448 PR2: per-turn stream lifecycle now lives in `chatState.streamState`
+  // (folded into the reducer for atomicity with `activeStreams`/`messages`
+  // and a `: never` rail on the union — see ChatState jsdoc).
   // Mirror of `realConversationId` for the `abort()` callback so a stale
   // closure cannot send the wrong conversationId on the wire.
   const realConversationIdRef = useRef<string | null>(null);
@@ -421,7 +468,6 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
     clearAllTimeouts();
     setSessionConfirmed(false);
     setRealConversationId(null);
-    setStreamState("idle");
     if (wsRef.current) {
       wsRef.current.onclose = null;
       wsRef.current.close();
@@ -452,7 +498,6 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
     clearAllTimeouts();
     setSessionConfirmed(false);
     setUsageData(null);
-    setStreamState("idle");
 
     // Clean up any existing connection
     if (wsRef.current) {
@@ -575,15 +620,11 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
           if (msg.type === "stream_start" && msg.source) {
             setRouteSource(msg.source);
           }
-          // #3448 PR2: enter `"streaming"` on the first stream_start of a
-          // turn. If the user already pressed Stop and we're in `"stopping"`,
-          // stay there — the server will follow up with `session_ended` and
-          // we collapse to `"idle"` then. A stream_start that arrives during
-          // `"stopping"` would otherwise re-enable the Send button while the
-          // abort is still in flight.
-          if (msg.type === "stream_start") {
-            setStreamState((prev) => (prev === "stopping" ? prev : "streaming"));
-          }
+          // #3448 PR2: streamState transitions live inside the reducer
+          // (`stream_event` case in chatReducer). The reducer enters
+          // `"streaming"` on the first turn-active event of an idle hook
+          // and leaves all other transitions to `clear_streams` /
+          // `enter_stopping`. Atomic with the rest of ChatState.
           // Dispatch to the pure reducer — no ref mutations inside the updater.
           // activeStreams and messages update atomically; pendingTimerAction carries
           // the timer intent out of the pure reducer for the useEffect above. See #2217.
@@ -594,9 +635,9 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
         }
 
         case "error": {
+          // `clear_streams` resets streamState to "idle" atomically.
           dispatch({ type: "clear_streams" });
           clearAllTimeouts();
-          setStreamState("idle");
 
           // Key invalidation: set structured error instead of redirect
           if (msg.errorCode === "key_invalid") {
@@ -649,16 +690,42 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
         case "session_ended": {
           dispatch({ type: "clear_streams" });
           clearAllTimeouts();
-          // #3448 PR2: a turn ended (any reason). Reset streamState so the
-          // Send button comes back. Multi-tab disambiguation: the server
-          // forwards `conversationId` for `user_aborted` reasons; honour it
-          // when present. Frames without `conversationId` (existing emitters
-          // for `turn_complete` / `idle_timeout`) are treated as scoped to
-          // this socket's current conversation, matching today's semantics.
+          // #3448 PR2 (review fix): a turn ended — reset streamState so the
+          // Send button comes back. Initial implementation gated this on
+          // `msg.conversationId === realConversationIdRef.current` for
+          // multi-tab disambiguation, but that left two failure modes:
+          //   (a) stuck-stopping deadlock — if the server ever emits a
+          //       mismatched conversationId (server bug, race during a
+          //       `session_resumed` transition), the client would sit in
+          //       "stopping" forever with the Send button never returning.
+          //   (b) asymmetric scoping — `clear_streams` and
+          //       `clearAllTimeouts()` above this block run unconditionally,
+          //       so the gate only protected `streamState`, not the rest of
+          //       the lifecycle slice. Either we gate everything or nothing
+          //       (architecture-strategist + data-integrity findings).
+          // Resolution: reset unconditionally (mirror clear_streams behavior),
+          // emit a Sentry breadcrumb when conversationId mismatches the
+          // current realConversationId so the observability stays — if the
+          // server ever produces such a frame, the breadcrumb surfaces it
+          // for triage instead of leaving a silent Stop UI deadlock.
           const targetConv = realConversationIdRef.current;
-          if (!msg.conversationId || msg.conversationId === targetConv) {
-            setStreamState("idle");
+          if (
+            msg.conversationId &&
+            targetConv &&
+            msg.conversationId !== targetConv
+          ) {
+            Sentry.addBreadcrumb({
+              category: "abort-turn",
+              message: "session-ended-conversationid-mismatch",
+              level: "warning",
+              data: {
+                received: msg.conversationId,
+                current: targetConv,
+                reason: msg.reason,
+              },
+            });
           }
+          // streamState reset to "idle" handled by `clear_streams` above.
           // Don't display "turn_complete" as a visible message — it's a lifecycle signal
           if (msg.reason !== "turn_complete") {
             dispatch({
@@ -675,7 +742,18 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
         }
 
         case "session_started": {
-          if (msg.conversationId) setRealConversationId(msg.conversationId);
+          if (msg.conversationId) {
+            setRealConversationId(msg.conversationId);
+            // #3448 PR2 (review fix): mirror to ref synchronously so a
+            // first-turn Stop click that races the realConversationId
+            // useEffect mirror (line below the WS message handler block)
+            // still sees the resolved id. Without this, abort() at
+            // streamState="streaming" would no-op silently — the
+            // brand-survival worst case named in the plan ("Stop button
+            // click that silently does nothing") on the most common
+            // new-conversation path.
+            realConversationIdRef.current = msg.conversationId;
+          }
           setResumedFrom(null);
           setSessionConfirmed(true);
           break;
@@ -683,6 +761,10 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
 
         case "session_resumed": {
           setRealConversationId(msg.conversationId);
+          // Same synchronous-ref invariant as session_started — a fast
+          // Stop click after `session_resumed` lands but before the
+          // mirroring useEffect runs MUST find the resolved id.
+          realConversationIdRef.current = msg.conversationId;
           setResumedFrom({
             conversationId: msg.conversationId,
             timestamp: msg.resumedFromTimestamp,
@@ -888,15 +970,22 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
       })),
       // #3448 PR2: surface persistence-tier abort status + usage snapshot
       // so MessageBubble can render the abort marker on history reload.
+      // Review fix (perf): only attach the `usage` object when the row is
+      // actually aborted — otherwise every history-loaded `complete` row
+      // carries a fresh object literal that defeats <MessageBubble>'s
+      // React.memo (referential inequality on `usage` re-renders the
+      // bubble on every parent render, regressing the 10-50 Hz token-stream
+      // memo guarantee on long threads).
       status: m.status ?? undefined,
-      usage: m.usage
-        ? {
-            input_tokens: m.usage.input_tokens,
-            output_tokens: m.usage.output_tokens,
-            cost_usd: m.usage.cost_usd ?? null,
-            completed_actions: m.usage.completed_actions ?? [],
-          }
-        : null,
+      usage:
+        m.status === "aborted" && m.usage
+          ? {
+              input_tokens: m.usage.input_tokens,
+              output_tokens: m.usage.output_tokens,
+              cost_usd: m.usage.cost_usd ?? null,
+              completed_actions: m.usage.completed_actions ?? [],
+            }
+          : null,
     }));
 
     const costData: UsageData | null =
@@ -1097,14 +1186,33 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
   const abort = useCallback(() => {
     const ws = wsRef.current;
     if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    if (streamState !== "streaming") return;
+    if (chatState.streamState !== "streaming") return;
     const targetConv =
       realConversationIdRef.current ??
       (conversationId !== "new" ? conversationId : null);
     if (!targetConv) return;
-    ws.send(JSON.stringify({ type: "abort_turn", conversationId: targetConv }));
-    setStreamState("stopping");
-  }, [streamState, conversationId]);
+    // Review fix (security): readyState was OPEN above, but a server-
+    // initiated close (4011 tier-changed, 4010 cap, network drop) can flip
+    // the socket between the readyState read and `send`. Browsers throw
+    // `InvalidStateError` from `send()` on a non-OPEN socket — without
+    // this catch, the throw escapes the click handler, AND we still
+    // dispatched `enter_stopping` below, leaving the Stop button stuck on
+    // a closed socket (no `session_ended` will arrive). On throw, surface
+    // to Sentry and stay in "streaming" — the WS onclose path will reset
+    // to "idle" via clear_streams, and the standard reconnect/error UI
+    // covers the connection failure.
+    try {
+      ws.send(JSON.stringify({ type: "abort_turn", conversationId: targetConv }));
+    } catch (err) {
+      reportSilentFallback(err, {
+        feature: "abort-turn",
+        op: "send-abort-turn-throw",
+        extra: { conversationId: targetConv },
+      });
+      return;
+    }
+    dispatch({ type: "enter_stopping" });
+  }, [chatState.streamState, conversationId]);
 
   const reconnect = useCallback(() => {
     setLastError(null);
@@ -1135,7 +1243,7 @@ export function useWebSocket(conversationId: string): UseWebSocketReturn {
     workflow: chatState.workflow,
     workflowEndedAt,
     historyLoading,
-    streamState,
+    streamState: chatState.streamState,
     abort,
   };
 }

--- a/apps/web-platform/test/abort-marker.test.tsx
+++ b/apps/web-platform/test/abort-marker.test.tsx
@@ -1,0 +1,131 @@
+import { describe, test, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+vi.mock("@/lib/client-observability", () => ({
+  reportSilentFallback: vi.fn(),
+  warnSilentFallback: vi.fn(),
+}));
+
+import { MessageBubble } from "../components/chat/message-bubble";
+
+// Task 5.2 (RED) — abort marker rendering on MessageBubble.
+//
+// When a persisted assistant `Message` carries `status === "aborted"`, the
+// bubble renders four payload-driven elements in addition to the partial
+// `content` text:
+//   1. The accumulated partial text (already supplied via `content`).
+//   2. A `[stopped by user]` chip.
+//   3. Token cost: `usage.input_tokens + usage.output_tokens` and
+//      `usage.cost_usd` (or "included in your plan" when null/undefined).
+//   4. A chip-list, one chip per `usage.completed_actions[]` entry, that
+//      surfaces the tool name. Reuses `<ToolUseChip>` when the shape is
+//      compatible (per task 0.4).
+//
+// All assertions scope to the bubble container so unrelated chrome (the
+// "Response complete" checkmark for `state: "done"`, the streaming caret
+// for `state: "streaming"`, leader avatar/title) cannot drift counts.
+
+const baseUsage = {
+  input_tokens: 1200,
+  output_tokens: 340,
+  cost_usd: 0.0042,
+  completed_actions: [
+    { tool_name: "Bash", input_summary: "git status", result_summary: "clean" },
+    { tool_name: "Read", input_summary: "lib/foo.ts", result_summary: "ok" },
+  ],
+};
+
+describe("MessageBubble abort marker (task 5.2)", () => {
+  test("renders partial text + [stopped by user] chip when status='aborted'", () => {
+    const { container } = render(
+      <MessageBubble
+        role="assistant"
+        content="Here is the partial response that"
+        leaderId="cto"
+        status="aborted"
+        usage={baseUsage}
+      />,
+    );
+
+    // (1) partial text survives
+    expect(container.textContent).toContain("Here is the partial response that");
+    // (2) [stopped by user] chip
+    expect(container.textContent).toContain("[stopped by user]");
+  });
+
+  test("renders token count and USD cost from usage payload", () => {
+    const { container } = render(
+      <MessageBubble
+        role="assistant"
+        content="partial"
+        leaderId="cto"
+        status="aborted"
+        usage={baseUsage}
+      />,
+    );
+
+    // Total token count = input + output = 1540
+    expect(container.textContent).toContain("1540");
+    // USD cost rendered (4 decimals — same precision as the in-flight cost
+    // chrome in chat-surface.tsx)
+    expect(container.textContent).toContain("0.0042");
+  });
+
+  test("renders 'included in your plan' when usage.cost_usd is null", () => {
+    const { container } = render(
+      <MessageBubble
+        role="assistant"
+        content="partial"
+        leaderId="cto"
+        status="aborted"
+        usage={{ ...baseUsage, cost_usd: null }}
+      />,
+    );
+
+    expect(container.textContent).toContain("included in your plan");
+    expect(container.textContent).not.toContain("$");
+  });
+
+  test("renders a chip per completed_actions entry, surfacing the tool name", () => {
+    const { container } = render(
+      <MessageBubble
+        role="assistant"
+        content="partial"
+        leaderId="cto"
+        status="aborted"
+        usage={baseUsage}
+      />,
+    );
+
+    // Both tool_name values appear in the rendered marker.
+    expect(container.textContent).toContain("Bash");
+    expect(container.textContent).toContain("Read");
+  });
+
+  test("does NOT render the marker when status='complete'", () => {
+    const { container } = render(
+      <MessageBubble
+        role="assistant"
+        content="hello"
+        leaderId="cto"
+        status="complete"
+        messageState="done"
+      />,
+    );
+
+    expect(container.textContent).not.toContain("[stopped by user]");
+  });
+
+  test("does NOT render the marker when status is undefined (legacy bubbles)", () => {
+    const { container } = render(
+      <MessageBubble
+        role="assistant"
+        content="hello"
+        leaderId="cto"
+        messageState="done"
+      />,
+    );
+
+    expect(container.textContent).not.toContain("[stopped by user]");
+  });
+});

--- a/apps/web-platform/test/chat-reducer.test.ts
+++ b/apps/web-platform/test/chat-reducer.test.ts
@@ -8,6 +8,7 @@ function emptyState(): ChatState {
     activeStreams: new Map(),
     workflow: { state: "idle" },
     spawnIndex: new Map(),
+    streamState: "idle",
   };
 }
 
@@ -53,6 +54,7 @@ describe("chatReducer", () => {
       activeStreams: new Map([["cpo", 0]]),
       workflow: { state: "idle" },
       spawnIndex: new Map(),
+      streamState: "idle",
       pendingTimerAction: { type: "reset", leaderId: "cpo" },
     };
 
@@ -75,6 +77,7 @@ describe("chatReducer", () => {
       spawnIndex: new Map([
         ["s-1", { messageIdx: 0, childIdx: 0 }],
       ]),
+      streamState: "idle",
       pendingTimerAction: { type: "reset", leaderId: "cpo" },
     };
 
@@ -112,6 +115,7 @@ describe("chatReducer", () => {
       activeStreams: new Map([["cpo", 0]]),
       workflow: { state: "idle" },
       spawnIndex: new Map(),
+      streamState: "idle",
       pendingTimerAction: { type: "reset", leaderId: "cpo" },
     };
 

--- a/apps/web-platform/test/chat-stop-button.test.tsx
+++ b/apps/web-platform/test/chat-stop-button.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import { createUseTeamNamesMock } from "./mocks/use-team-names";
+import { createWebSocketMock } from "./mocks/use-websocket";
+
+// Tasks 5.3 – 5.7 (RED) — Stop button + Esc shortcut + cleanup.
+//
+// All five tests render the real ChatSurface with a mocked useWebSocket so
+// we can assert on the abort spy. ChatSurface is the binding site for both
+// (a) the Stop button replacing Send (delegated to ChatInput via props)
+// and (b) the document-level keydown listener with the focus guard.
+
+const mockAbort = vi.fn();
+const mockSend = vi.fn();
+let wsReturn: ReturnType<typeof createWebSocketMock> & {
+  abort: typeof mockAbort;
+  streamState: "idle" | "streaming" | "stopping";
+};
+
+vi.mock("@/lib/ws-client", () => ({ useWebSocket: () => wsReturn }));
+vi.mock("@/lib/analytics-client", () => ({ track: vi.fn() }));
+vi.mock("@/hooks/use-team-names", () => ({
+  useTeamNames: () => createUseTeamNamesMock(),
+  TeamNamesProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/dashboard/chat/cid-1",
+}));
+vi.mock("@/lib/client-observability", () => ({
+  reportSilentFallback: vi.fn(),
+  warnSilentFallback: vi.fn(),
+}));
+
+function makeWs(overrides: { streamState: "idle" | "streaming" | "stopping" }) {
+  const base = createWebSocketMock({
+    sendMessage: mockSend,
+    realConversationId: "cid-1",
+    activeLeaderIds: overrides.streamState === "idle" ? [] : ["cto"],
+  }) as ReturnType<typeof createWebSocketMock>;
+  return {
+    ...base,
+    abort: mockAbort,
+    streamState: overrides.streamState,
+  };
+}
+
+async function mount() {
+  const { ChatSurface } = await import("@/components/chat/chat-surface");
+  return render(<ChatSurface variant="full" conversationId="cid-1" />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAbort.mockClear();
+});
+
+describe("Stop button (task 5.3)", () => {
+  it("renders Stop in place of Send while streamState='streaming' and click invokes abort()", async () => {
+    wsReturn = makeWs({ streamState: "streaming" });
+    await mount();
+
+    // Send button is gone; Stop button is present.
+    expect(screen.queryByRole("button", { name: /send message/i })).toBeNull();
+    const stop = screen.getByRole("button", { name: /stop/i });
+
+    act(() => {
+      stop.click();
+    });
+
+    expect(mockAbort).toHaveBeenCalledTimes(1);
+  });
+
+  it("Stop button is disabled and labeled 'Stopping…' while streamState='stopping'", async () => {
+    wsReturn = makeWs({ streamState: "stopping" });
+    await mount();
+
+    const stop = screen.getByRole("button", { name: /stop/i });
+    expect((stop as HTMLButtonElement).disabled).toBe(true);
+    // Visible label transitions to "Stopping…" while waiting for session_ended
+    expect(stop.textContent).toMatch(/stopping/i);
+  });
+});
+
+describe("Esc keyboard shortcut (tasks 5.4 – 5.5)", () => {
+  it("invokes abort() when Esc is pressed and the textarea is empty (focus on chat surface)", async () => {
+    wsReturn = makeWs({ streamState: "streaming" });
+    await mount();
+
+    // Default focus state: textarea empty, no element explicitly focused.
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+
+    expect(mockAbort).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT invoke abort() when textarea has 10+ chars and is focused (Esc-while-typing guard)", async () => {
+    wsReturn = makeWs({ streamState: "streaming" });
+    await mount();
+
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "user is mid-sentence here" } });
+    textarea.focus();
+
+    act(() => {
+      // Dispatch on document so the chat-surface's document-level listener
+      // would fire if the focus guard is broken.
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+
+    expect(mockAbort).not.toHaveBeenCalled();
+  });
+
+  it("does NOT invoke abort() when streamState='idle' (no in-flight turn)", async () => {
+    wsReturn = makeWs({ streamState: "idle" });
+    await mount();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+
+    expect(mockAbort).not.toHaveBeenCalled();
+  });
+});
+
+describe("double-click safety (task 5.6)", () => {
+  it("a second Stop click while streamState='stopping' is a no-op (button disabled)", async () => {
+    wsReturn = makeWs({ streamState: "stopping" });
+    await mount();
+
+    const stop = screen.getByRole("button", { name: /stop/i });
+    act(() => {
+      stop.click();
+      stop.click();
+    });
+
+    // The disabled button must not fire abort even on programmatic .click().
+    expect(mockAbort).not.toHaveBeenCalled();
+  });
+});
+
+describe("useEffect cleanup (task 5.7)", () => {
+  it("removes the document keydown listener on unmount", async () => {
+    wsReturn = makeWs({ streamState: "streaming" });
+    const { unmount } = await mount();
+
+    unmount();
+
+    // After unmount, dispatching Esc must NOT reach the abort spy — the
+    // useEffect cleanup function returned by the effect must have called
+    // document.removeEventListener.
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+
+    expect(mockAbort).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-platform/test/chat-stop-button.test.tsx
+++ b/apps/web-platform/test/chat-stop-button.test.tsx
@@ -96,7 +96,7 @@ describe("Esc keyboard shortcut (tasks 5.4 – 5.5)", () => {
     expect(mockAbort).toHaveBeenCalledTimes(1);
   });
 
-  it("does NOT invoke abort() when textarea has 10+ chars and is focused (Esc-while-typing guard)", async () => {
+  it("does NOT invoke abort() when focused textarea has any content (Esc-while-typing guard; impl checks `value.length > 0`)", async () => {
     wsReturn = makeWs({ streamState: "streaming" });
     await mount();
 
@@ -111,6 +111,46 @@ describe("Esc keyboard shortcut (tasks 5.4 – 5.5)", () => {
     });
 
     expect(mockAbort).not.toHaveBeenCalled();
+  });
+
+  it("does NOT invoke abort() when focus is inside an [role='dialog'] (review fix — security P2)", async () => {
+    wsReturn = makeWs({ streamState: "streaming" });
+    await mount();
+
+    // Mount a dialog with a button inside, focus the button, then dispatch Esc.
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("data-state", "open");
+    const inner = document.createElement("button");
+    dialog.appendChild(inner);
+    document.body.appendChild(dialog);
+    inner.focus();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+
+    expect(mockAbort).not.toHaveBeenCalled();
+    document.body.removeChild(dialog);
+  });
+
+  it("does NOT invoke abort() when focus is on a [contenteditable] element with content (review fix — security P2)", async () => {
+    wsReturn = makeWs({ streamState: "streaming" });
+    await mount();
+
+    const editable = document.createElement("div");
+    editable.setAttribute("contenteditable", "true");
+    editable.textContent = "user typing in markdown widget";
+    editable.tabIndex = 0;
+    document.body.appendChild(editable);
+    editable.focus();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+
+    expect(mockAbort).not.toHaveBeenCalled();
+    document.body.removeChild(editable);
   });
 
   it("does NOT invoke abort() when streamState='idle' (no in-flight turn)", async () => {

--- a/apps/web-platform/test/mocks/use-websocket.ts
+++ b/apps/web-platform/test/mocks/use-websocket.ts
@@ -45,6 +45,8 @@ export function createWebSocketMock(
     workflow: { state: "idle" } as const,
     workflowEndedAt: null,
     historyLoading: false,
+    streamState: "idle" as const,
+    abort: vi.fn(),
   } satisfies WebSocketState;
   return { ...base, ...overrides };
 }

--- a/apps/web-platform/test/useWebSocket-abort.test.tsx
+++ b/apps/web-platform/test/useWebSocket-abort.test.tsx
@@ -196,6 +196,74 @@ describe("useWebSocket — abort() (task 5.8)", () => {
     });
   });
 
+  it("transitions to streamState='streaming' on first `stream` event without prior `stream_start` (review fix — Finding 2)", async () => {
+    // Brand-survival regression gate: if the server emits content directly
+    // via `stream` (sub-agent path or tool-only turn) without a leading
+    // `stream_start`, the Stop button must still appear. The original
+    // implementation only handled `stream_start`.
+    const { useWebSocket } = await import("@/lib/ws-client");
+    const { result } = renderHook(() => useWebSocket("cid-1"));
+
+    await connectAndAuth(result);
+    serverSend({ type: "session_started", conversationId: "cid-1" });
+    serverSend({
+      type: "stream",
+      content: "partial ",
+      partial: true,
+      leaderId: "cto",
+    });
+
+    await waitFor(() => {
+      expect(result.current.streamState).toBe("streaming");
+    });
+  });
+
+  it("transitions to streamState='streaming' on first `tool_use` event without prior `stream_start` (review fix — Finding 2)", async () => {
+    const { useWebSocket } = await import("@/lib/ws-client");
+    const { result } = renderHook(() => useWebSocket("cid-1"));
+
+    await connectAndAuth(result);
+    serverSend({ type: "session_started", conversationId: "cid-1" });
+    serverSend({ type: "tool_use", leaderId: "cto", label: "Bash" });
+
+    await waitFor(() => {
+      expect(result.current.streamState).toBe("streaming");
+    });
+  });
+
+  it("session_ended with mismatched conversationId still resets streamState to 'idle' (review fix — Finding 3)", async () => {
+    // The original disambiguator gate would have left streamState stuck in
+    // 'stopping' forever if the server emitted a mismatched conversationId.
+    // Resolution: always reset on session_ended (mirrors clear_streams);
+    // breadcrumb the mismatch for observability.
+    const { useWebSocket } = await import("@/lib/ws-client");
+    const { result } = renderHook(() => useWebSocket("cid-1"));
+
+    await connectAndAuth(result);
+    serverSend({ type: "session_started", conversationId: "cid-1" });
+    serverSend({ type: "stream_start", leaderId: "cto" });
+
+    await waitFor(() => {
+      expect(result.current.streamState).toBe("streaming");
+    });
+
+    act(() => {
+      result.current.abort();
+    });
+
+    expect(result.current.streamState).toBe("stopping");
+
+    serverSend({
+      type: "session_ended",
+      reason: "user_aborted",
+      conversationId: "cid-OTHER",
+    });
+
+    await waitFor(() => {
+      expect(result.current.streamState).toBe("idle");
+    });
+  });
+
   it("abort() while streamState='idle' is a no-op (no abort_turn sent)", async () => {
     const { useWebSocket } = await import("@/lib/ws-client");
     const { result } = renderHook(() => useWebSocket("cid-1"));

--- a/apps/web-platform/test/useWebSocket-abort.test.tsx
+++ b/apps/web-platform/test/useWebSocket-abort.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, type MockInstance, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+// Task 5.8 (RED) — useWebSocket.abort() contract.
+//
+// The hook return surface gains:
+//   - `streamState: "idle" | "streaming" | "stopping"`, driven by stream_start /
+//     stream_end / session_ended events.
+//   - `abort(): void`, which sends `{ type: "abort_turn", conversationId }`
+//     over the socket and transitions streamState to "stopping" optimistically.
+//
+// Mirrors the patterns in ws-client-resume-history.test.tsx for WebSocket /
+// supabase / fetch mocking.
+
+const mockGetSession = vi.fn().mockResolvedValue({
+  data: { session: { access_token: "test-token" } },
+});
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: { getSession: mockGetSession },
+  }),
+}));
+
+let wsInstance: {
+  onopen: ((ev: Event) => void) | null;
+  onmessage: ((ev: MessageEvent) => void) | null;
+  onclose: ((ev: CloseEvent) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  readyState: number;
+} | null = null;
+
+class MockWebSocket {
+  static OPEN = 1;
+  static CONNECTING = 0;
+  onopen: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  onclose: ((ev: CloseEvent) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  send = vi.fn();
+  close = vi.fn();
+  readyState = MockWebSocket.OPEN;
+  constructor() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    wsInstance = this;
+    queueMicrotask(() => {
+      this.readyState = MockWebSocket.OPEN;
+      this.onopen?.(new Event("open"));
+    });
+  }
+}
+
+function serverSend(data: Record<string, unknown>) {
+  act(() => {
+    wsInstance?.onmessage?.(new MessageEvent("message", { data: JSON.stringify(data) }));
+  });
+}
+
+async function connectAndAuth(result: {
+  current: ReturnType<typeof import("@/lib/ws-client").useWebSocket>;
+}) {
+  await waitFor(() => {
+    expect(wsInstance).not.toBeNull();
+    expect(wsInstance?.send).toHaveBeenCalled();
+  });
+  serverSend({ type: "auth_ok" });
+  await waitFor(() => {
+    expect(result.current.status).toBe("connected");
+  });
+}
+
+describe("useWebSocket — abort() (task 5.8)", () => {
+  let originalWebSocket: typeof globalThis.WebSocket;
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wsInstance = null;
+    originalWebSocket = globalThis.WebSocket;
+    // @ts-expect-error — mock constructor shape
+    globalThis.WebSocket = MockWebSocket;
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ messages: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket;
+    fetchSpy.mockRestore();
+  });
+
+  it("starts in streamState='idle'", async () => {
+    const { useWebSocket } = await import("@/lib/ws-client");
+    const { result } = renderHook(() => useWebSocket("cid-1"));
+
+    await connectAndAuth(result);
+
+    expect(result.current.streamState).toBe("idle");
+  });
+
+  it("transitions to streamState='streaming' on stream_start", async () => {
+    const { useWebSocket } = await import("@/lib/ws-client");
+    const { result } = renderHook(() => useWebSocket("cid-1"));
+
+    await connectAndAuth(result);
+    serverSend({ type: "session_started", conversationId: "cid-1" });
+    serverSend({ type: "stream_start", leaderId: "cto" });
+
+    await waitFor(() => {
+      expect(result.current.streamState).toBe("streaming");
+    });
+  });
+
+  it("abort() sends { type: 'abort_turn', conversationId } over the socket", async () => {
+    const { useWebSocket } = await import("@/lib/ws-client");
+    const { result } = renderHook(() => useWebSocket("cid-1"));
+
+    await connectAndAuth(result);
+    serverSend({ type: "session_started", conversationId: "cid-1" });
+    serverSend({ type: "stream_start", leaderId: "cto" });
+
+    await waitFor(() => {
+      expect(result.current.streamState).toBe("streaming");
+    });
+
+    const sendCallsBefore = wsInstance!.send.mock.calls.length;
+    act(() => {
+      result.current.abort();
+    });
+
+    // The latest send must be an abort_turn frame with the conversationId.
+    const newCalls = wsInstance!.send.mock.calls.slice(sendCallsBefore);
+    const aborts = newCalls
+      .map((c) => {
+        try {
+          return JSON.parse(c[0] as string);
+        } catch {
+          return null;
+        }
+      })
+      .filter((m) => m && m.type === "abort_turn");
+    expect(aborts.length).toBe(1);
+    expect(aborts[0].conversationId).toBe("cid-1");
+  });
+
+  it("abort() transitions streamState to 'stopping' optimistically", async () => {
+    const { useWebSocket } = await import("@/lib/ws-client");
+    const { result } = renderHook(() => useWebSocket("cid-1"));
+
+    await connectAndAuth(result);
+    serverSend({ type: "session_started", conversationId: "cid-1" });
+    serverSend({ type: "stream_start", leaderId: "cto" });
+
+    await waitFor(() => {
+      expect(result.current.streamState).toBe("streaming");
+    });
+
+    act(() => {
+      result.current.abort();
+    });
+
+    expect(result.current.streamState).toBe("stopping");
+  });
+
+  it("session_ended for the matching conversationId returns streamState to 'idle'", async () => {
+    const { useWebSocket } = await import("@/lib/ws-client");
+    const { result } = renderHook(() => useWebSocket("cid-1"));
+
+    await connectAndAuth(result);
+    serverSend({ type: "session_started", conversationId: "cid-1" });
+    serverSend({ type: "stream_start", leaderId: "cto" });
+
+    await waitFor(() => {
+      expect(result.current.streamState).toBe("streaming");
+    });
+
+    act(() => {
+      result.current.abort();
+    });
+
+    expect(result.current.streamState).toBe("stopping");
+
+    serverSend({
+      type: "session_ended",
+      reason: "user_aborted",
+      conversationId: "cid-1",
+    });
+
+    await waitFor(() => {
+      expect(result.current.streamState).toBe("idle");
+    });
+  });
+
+  it("abort() while streamState='idle' is a no-op (no abort_turn sent)", async () => {
+    const { useWebSocket } = await import("@/lib/ws-client");
+    const { result } = renderHook(() => useWebSocket("cid-1"));
+
+    await connectAndAuth(result);
+    serverSend({ type: "session_started", conversationId: "cid-1" });
+
+    const sendCallsBefore = wsInstance!.send.mock.calls.length;
+    act(() => {
+      result.current.abort();
+    });
+    const newCalls = wsInstance!.send.mock.calls.slice(sendCallsBefore);
+    const aborts = newCalls
+      .map((c) => {
+        try {
+          return JSON.parse(c[0] as string);
+        } catch {
+          return null;
+        }
+      })
+      .filter((m) => m && m.type === "abort_turn");
+    expect(aborts.length).toBe(0);
+  });
+});

--- a/knowledge-base/project/learnings/2026-05-07-tdd-ts-expect-error-sweep-and-reducer-fixture-sweep.md
+++ b/knowledge-base/project/learnings/2026-05-07-tdd-ts-expect-error-sweep-and-reducer-fixture-sweep.md
@@ -1,0 +1,192 @@
+---
+date: 2026-05-07
+title: "TDD GREEN sweep: @ts-expect-error directives and reducer-fixture seeding when ChatState shape changes"
+module: web-platform
+problem_type: build_errors
+component: tests
+severity: medium
+category: best-practices
+tags:
+  - tdd
+  - typescript
+  - vitest
+  - useReducer
+  - refactor-sweep
+  - "@ts-expect-error"
+related_prs:
+  - 3469
+related_issues:
+  - 3448
+synced_to: []
+---
+
+# TDD GREEN sweep: `@ts-expect-error` directives and reducer-fixture seeding when ChatState shape changes
+
+## Problem
+
+During PR2 of #3448 (`feat-abort-conversation-web-pr2`, PR #3469), two distinct
+`tsc --noEmit` regressions surfaced AFTER the implementation was working —
+both caused by stale type-system artifacts that survived the GREEN phase:
+
+1. **`TS2578: Unused '@ts-expect-error' directive`** — the RED-phase tests in
+   `apps/web-platform/test/useWebSocket-abort.test.tsx` placed
+   `// @ts-expect-error — streamState is added in this PR` directives above
+   each `result.current.streamState` access so the test file would compile
+   while the hook return type didn't yet have the field. Once the hook was
+   widened in GREEN, those directives became unused — `tsc --noEmit` emits
+   `TS2578` per directive. Eleven directives across the file failed
+   compilation simultaneously.
+
+2. **`TS2741: Property 'streamState' is missing` in pre-existing fixtures** —
+   PR2 folded `streamState` into the reducer-managed `ChatState` interface
+   (response to a 3-reviewer convergence on the atomicity invariant — see
+   PR #3469 review). Pre-existing test fixtures in
+   `apps/web-platform/test/chat-reducer.test.ts` build `ChatState` literals
+   directly via `emptyState()` and inline shape constructors (lines 5-12,
+   51-57, 71-79). All three fixture sites missed the new field. The
+   compile failure was four fixture sites at once, in a file that was not
+   touched by the feature edit.
+
+The shared root: a TypeScript-shape change at one site (the hook return type,
+the reducer state interface) had a sweep cost in unrelated locations
+(test directives, fixture constructors) that `tsc --noEmit` flagged
+deterministically — but only AFTER the implementation was done. Neither
+vitest nor the feature-specific tests caught these in the GREEN phase.
+
+## Solution
+
+For (1), the fix is mechanical: after GREEN, search the new test file for
+`@ts-expect-error` and remove every directive whose underlying error has
+been resolved. Vitest also surfaces this as a test failure with a clear
+error message (`TS2578: Unused '@ts-expect-error' directive`), but
+running `./node_modules/.bin/tsc --noEmit` is the deterministic gate.
+
+For (2), the fix is to grep for every constructor of the widened type and
+extend each one in the same edit cycle as the interface change:
+
+```bash
+# After widening ChatState with `streamState: StreamState`:
+grep -rn "messages: \[\].*activeStreams: new Map" apps/web-platform/test/
+# OR for any shape that builds ChatState directly:
+grep -rn "ChatState\b" apps/web-platform/test/ apps/web-platform/lib/
+```
+
+Then add `streamState: "idle"` (or the type's appropriate default) to each
+hit in the same commit that widens the interface.
+
+A third related issue surfaced separately: `MockInstance` from vitest must
+be imported explicitly when typing a `vi.spyOn` return — `ReturnType<typeof
+vi.spyOn>` is too loose and doesn't unify with vitest's typed mock signature.
+The existing `apps/web-platform/test/ws-client-resume-history.test.tsx`
+demonstrates the right pattern (`import { ..., type MockInstance } from
+"vitest"`); copying that import line at the start of any new spy-based test
+prevents the regression.
+
+## Key Insight
+
+**TDD's RED-phase tools (`@ts-expect-error`, type-asserting mocks, exhaustive
+fixtures) are scaffolding, not durable code.** Each tool's lifecycle ends at
+GREEN. If the GREEN sweep is informal ("I'll fix tsc errors as I go"), the
+sweep often lands AFTER the feature is "done" and surfaces as a flurry of
+mechanical TS errors that look like a regression but are actually
+unswept scaffolding.
+
+The reducer-fixture variant is a more general pattern: **any pre-existing
+type literal that builds an instance of an interface MUST be touched in the
+same edit cycle that widens the interface**. `tsc --noEmit` is the deterministic
+detector, but the sweep is a manual grep+edit pass — there's no "auto-fix"
+for missing required fields. The cheapest preventative is to grep for the
+type name (or a shape signature) before commit, AND to colocate
+fixture-builder helpers (`emptyState()`) so a single edit is the only sweep
+needed. The current `chat-reducer.test.ts` has both `emptyState()` and three
+inline shape constructors — splitting the fixture across four sites is what
+forced the four-site sweep.
+
+## Prevention
+
+1. **Run `./node_modules/.bin/tsc --noEmit` as part of the GREEN gate**, not
+   just at "ready to ship" time. The work-skill's TDD Gate already runs the
+   test suite after each RED→GREEN cycle; running `tsc --noEmit` in the same
+   cycle catches `TS2578` (directive sweep) and `TS2741` (fixture sweep)
+   immediately, before they accumulate across the whole feature.
+
+2. **Centralize fixture builders.** When a test file builds the same `ChatState`
+   shape in multiple places, extract a single `emptyState()` (or
+   `withStreamState({...})`) helper and use it everywhere. This ensures a
+   single-site sweep on interface changes. The `chat-reducer.test.ts` file
+   has the helper but three test cases still build the shape inline — those
+   three are the friction.
+
+3. **`@ts-expect-error` directives carry an explicit lifetime comment.** The
+   convention `// @ts-expect-error — <field> is added in this PR` makes the
+   GREEN sweep trivial: a regex pass for `@ts-expect-error.*added in this PR`
+   surfaces every directive ready for removal.
+
+4. **For new spy-based test files, copy the `MockInstance` import from a
+   sibling test file** rather than reaching for `ReturnType<typeof vi.spyOn>`.
+   The existing `ws-client-resume-history.test.tsx` is the precedent — start
+   from its template.
+
+## Session Errors
+
+These surfaced during the PR2 work session beyond the main implementation
+investigation:
+
+1. **Bare repo path resolution miss** — Initial `Read` on the spec file at
+   `/home/jean/git-repositories/jikig-ai/soleur/knowledge-base/project/specs/feat-abort-conversation-web/tasks.md`
+   returned "File does not exist" because that path is the bare-repo root,
+   which has no working tree. Recovered by switching to the worktree path
+   (`/home/jean/.../feat-abort-conversation-web-pr2/knowledge-base/...`).
+   **Prevention:** AGENTS.md `hr-when-in-a-worktree-never-read-from-bare`
+   already covers this; reinforce by always passing
+   `<worktree-root>/<rel-path>` for absolute reads when in a worktree.
+
+2. **Bash CWD non-persistence** — After
+   `cd apps/web-platform && ./node_modules/.bin/vitest`, a follow-up
+   `grep -rn` invoked from a separate `Bash` call returned "No such file or
+   directory" because CWD did not persist across calls. Recovered by chaining
+   with `&&` or absolute paths. **Prevention:** the work-skill already
+   documents this; the rule is "chain `cd <abs-path> && <cmd>` in a single
+   Bash call." Already enforced by skill instruction.
+
+3. **PR1 test path didn't match plan path** — Plan §1.9 specified
+   `apps/web-platform/server/__tests__/abort-turn.test.ts`; PR1 actually
+   shipped at `apps/web-platform/test/server/abort-turn.test.ts`. Recovered
+   via `git ls-tree -r HEAD --name-only | grep abort`. **Prevention:** when
+   a multi-PR feature has merged predecessor PRs, verify the actual file
+   locations of the merged PR's deliverables before honoring the plan's
+   prescribed paths. The plan was written before PR1 was implemented; PR1
+   diverged on test location; the plan was not retroactively edited. Adding
+   "verify merged-PR file locations from `git ls-tree HEAD` before starting
+   the next PR" to the work-skill's Phase 1 would close the gap.
+
+4. **`TS2578` unused `@ts-expect-error` directives** — Eleven directives
+   placed during RED became unused after GREEN; `tsc --noEmit` errored.
+   **Prevention:** see §Solution + §Prevention above. The work-skill could
+   add a Phase 2.5 step "after each RED→GREEN transition, grep the test file
+   for `@ts-expect-error` and remove resolved directives" — but this is a
+   skill-instruction-level fix that's small enough to leave as a Sharp Edge
+   note rather than a hook.
+
+5. **`TS2741` missing `streamState` in fixtures** — Pre-existing
+   `chat-reducer.test.ts` fixtures missed the new field after the reducer
+   state was widened. **Prevention:** see §Prevention above. The fix is a
+   workflow practice, not a hook — there's no static analysis path for
+   "field constructors that must be updated alongside an interface widening."
+
+6. **`fetchSpy` type mismatch** — `let fetchSpy: ReturnType<typeof vi.spyOn>`
+   is too loose and doesn't unify with vitest's typed mock signature.
+   **Prevention:** copy the import line from
+   `ws-client-resume-history.test.tsx` (which uses `import { ..., type
+   MockInstance } from "vitest"; let fetchSpy: MockInstance;`). See §Solution.
+
+## Related
+
+- AGENTS.md `cq-write-failing-tests-before` (the TDD Gate that surfaces these
+  scaffolding-sweep concerns when followed strictly).
+- AGENTS.md `cq-ref-removal-sweep-cleanup-closures` (the sibling pattern for
+  React `useRef` cleanups — same "sweep at the end" mechanic).
+- `knowledge-base/project/learnings/best-practices/2026-04-27-wrapper-extension-test-mock-chain-sweep.md`
+  (data-layer fluent-API extension sweep — same general class of "extend an
+  interface, sweep the test mocks in the same edit cycle").
+- PR #3469 (this PR; landed the streamState reducer fold + the fixture sweep).

--- a/knowledge-base/project/specs/feat-abort-conversation-web/tasks.md
+++ b/knowledge-base/project/specs/feat-abort-conversation-web/tasks.md
@@ -101,51 +101,53 @@ Two-PR sequence (Approach B). PR1 = server correctness + DB + legal. PR2 = clien
 
 ## Phase 5 — RED (PR2 client tests, failing first)
 
-- [ ] 5.1 — Create new feature branch `feat-abort-conversation-web-pr2` off updated main (after PR1 merge).
-- [ ] 5.2 — Create `apps/web-platform/components/chat/__tests__/abort-marker.test.tsx`. Failing test: rendering a message with `status='aborted'` shows partial text + `[stopped by user]` chip + token count + USD cost + completed-actions chip-list.
-- [ ] 5.3 — Failing test: Stop button replaces Send when `streamState === 'streaming' | 'stopping'`. Click invokes `useWebSocket.abort()`.
-- [ ] 5.4 — Failing test: `Esc` keystroke invokes abort when chat surface is focused AND (textarea is empty OR not focused).
-- [ ] 5.5 — Failing test: `Esc` does NOT invoke abort when textarea is focused AND has 10+ chars of content.
-- [ ] 5.6 — Failing test: double-click safety — second click while `stopping` is a no-op.
-- [ ] 5.7 — Failing test: `useEffect` cleanup removes the keydown listener on unmount.
-- [ ] 5.8 — Failing test: `useWebSocket.abort()` sends `{ type: "abort_turn", conversationId }` over the socket and transitions local `streamState` to `'stopping'`.
-- [ ] 5.9 — Run vitest → all RED.
+- [x] 5.1 — Create new feature branch `feat-abort-conversation-web-pr2` off updated main (after PR1 merge).
+- [x] 5.2 — Create `apps/web-platform/test/abort-marker.test.tsx` (repo convention `test/*.test.tsx`, vitest `include`). Failing test: rendering a message with `status='aborted'` shows partial text + `[stopped by user]` chip + token count + USD cost + completed-actions chip-list.
+- [x] 5.3 — Failing test: Stop button replaces Send when `streamState === 'streaming' | 'stopping'`. Click invokes `useWebSocket.abort()`.
+- [x] 5.4 — Failing test: `Esc` keystroke invokes abort when chat surface is focused AND (textarea is empty OR not focused).
+- [x] 5.5 — Failing test: `Esc` does NOT invoke abort when textarea is focused AND has 10+ chars of content.
+- [x] 5.6 — Failing test: double-click safety — second click while `stopping` is a no-op.
+- [x] 5.7 — Failing test: `useEffect` cleanup removes the keydown listener on unmount.
+- [x] 5.8 — Failing test: `useWebSocket.abort()` sends `{ type: "abort_turn", conversationId }` over the socket and transitions local `streamState` to `'stopping'`.
+- [x] 5.9 — Run vitest → all RED. (14 positive-case tests fail on initial run; 5 negative-space tests pass vacuously by design — they assert the marker / abort path is NOT triggered.)
 
 ## Phase 6 — GREEN: PR2 client implementation
 
 ### 6.1 — `useWebSocket.abort()`
 
-- [ ] 6.1.1 — `apps/web-platform/lib/ws-client.ts`: add `abort()` method to the hook's return surface. Sends `abort_turn`, transitions local state to `'stopping'`. Coordinate with #3280 (history-fetch reducer refactor).
-- [ ] 6.1.2 — Extend `streamState` type to include `'stopping'`. Update reducer / `_exhaustive: never` rails accordingly. Per AGENTS.md `cq-union-widening-grep-three-patterns`, run the 3-pattern grep on `streamState`.
+- [x] 6.1.1 — `apps/web-platform/lib/ws-client.ts`: add `abort()` method to the hook's return surface. Sends `abort_turn`, transitions local state to `'stopping'`. Coordinate with #3280 (history-fetch reducer refactor) — `abort` slots into the existing return surface as a callback; if #3280 lands first, the callback can move into the new reducer's action types in a follow-up.
+- [x] 6.1.2 — Add new `StreamState = 'idle' | 'streaming' | 'stopping'` type at the top of ws-client.ts. Three-pattern grep clean: zero `_exhaustive: never` consumers, two if-ladder hits both inside `chat-input.tsx` (`streamState === "stopping"`, `streamState === "streaming"`) which together cover the two non-idle states; `idle` is the implicit fall-through (Send button render).
 
 ### 6.2 — Stop button
 
-- [ ] 6.2.1 — `apps/web-platform/components/chat/chat-input.tsx`: when `streamState ∈ {'streaming', 'stopping'}`, render Stop button in place of Send. While `'stopping'`, disable the button + show "Stopping…" label.
-- [ ] 6.2.2 — Wire the click handler through to `useWebSocket.abort()` (via prop drilling from `page.tsx`).
+- [x] 6.2.1 — `apps/web-platform/components/chat/chat-input.tsx`: when `streamState ∈ {'streaming', 'stopping'}`, render Stop button in place of Send. While `'stopping'`, disable the button + show "Stopping…" label.
+- [x] 6.2.2 — Wire the click handler through to `useWebSocket.abort()` via `streamState` + `onStop` props passed from `<ChatSurface>` to `<ChatInput>`.
 
 ### 6.3 — Esc shortcut
 
-- [ ] 6.3.1 — `apps/web-platform/components/chat/chat-surface.tsx`: register a `keydown` listener (in `useEffect`) when `streamState ∈ {'streaming', 'stopping'}`.
-- [ ] 6.3.2 — Listener checks: `e.key === 'Escape'`, AND (focus is NOT a non-empty textarea), then `e.preventDefault()` + `abort()`.
-- [ ] 6.3.3 — `useEffect` cleanup returns `() => document.removeEventListener('keydown', handler)`.
+- [x] 6.3.1 — `apps/web-platform/components/chat/chat-surface.tsx`: register a `document` keydown listener (in `useEffect`) when `streamState ∈ {'streaming', 'stopping'}`.
+- [x] 6.3.2 — Listener checks: `e.key === 'Escape'`, AND focus is NOT a non-empty textarea, then `e.preventDefault()` + `abort()`.
+- [x] 6.3.3 — `useEffect` cleanup returns `() => document.removeEventListener('keydown', handler)` per AGENTS.md `cq-ref-removal-sweep-cleanup-closures`.
 
 ### 6.4 — Abort marker
 
-- [ ] 6.4.1 — `apps/web-platform/components/chat/message-bubble.tsx`: when `message.status === 'aborted'`, render the marker:
-  - The accumulated `content` text.
+- [x] 6.4.1 — `apps/web-platform/components/chat/message-bubble.tsx`: when `message.status === 'aborted'`, render the marker:
+  - The accumulated `content` text via MarkdownRenderer.
   - `[stopped by user]` chip.
-  - Token count: `usage.input_tokens + usage.output_tokens` and `usage.cost_usd` (or "included in your plan").
-  - Completed-actions chip-list (one chip per `usage.completed_actions[]` entry; reuse `tool-use-chip.tsx` if shape matches per 0.4).
-- [ ] 6.4.2 — If #3242 (raw tool name field) is merged before this PR, use the raw name. Otherwise use today's shape.
+  - Token count: `usage.input_tokens + usage.output_tokens` and `$<cost_usd>` (or "included in your plan" when `cost_usd` is null/undefined).
+  - Completed-actions chip-list (one inline chip per `usage.completed_actions[]` entry — `<ToolUseChip>` was NOT reused because its `leaderId` is narrowed to `cc_router | system`).
+- [x] 6.4.2 — Today's shape used (raw tool name on `completed_actions[].tool_name`). #3242 coordination noted; downstream cleanup if needed.
 
 ### 6.5 — Page wiring
 
-- [ ] 6.5.1 — `apps/web-platform/app/(dashboard)/dashboard/chat/[conversationId]/page.tsx`: pass `useWebSocket().abort` through to `ChatInput` and `ChatSurface` props.
+- [x] 6.5.1 — `apps/web-platform/components/chat/chat-surface.tsx` wires `streamState` + `abort` from `useWebSocket()` through to `<ChatInput>` (Stop button) and the document keydown effect (Esc). The `chat/[conversationId]/page.tsx` route delegates to `<ChatSurface>`, so no additional plumbing was needed there.
+- [x] 6.5.2 — `apps/web-platform/lib/ws-client.ts` `runHistoryFetch` mapper extended to surface `status` + `usage` from the API response (PR1's `api-messages.ts` already SELECTs these columns).
+- [x] 6.5.3 — `apps/web-platform/lib/chat-state-machine.ts` `ChatTextMessage` extended with optional `status` + `usage` fields so the persisted-row marker survives a page reload.
 
 ### 6.6 — Run tests
 
-- [ ] 6.6.1 — `vitest run components/chat/__tests__/abort-marker.test.tsx` → all GREEN.
-- [ ] 6.6.2 — `tsc --noEmit` from `apps/web-platform/` → clean.
+- [x] 6.6.1 — `vitest run test/abort-marker.test.tsx test/chat-stop-button.test.tsx test/useWebSocket-abort.test.tsx` → all GREEN (19 tests). Full suite: 3901 passed, 7 skipped, no regressions.
+- [x] 6.6.2 — `tsc --noEmit` from `apps/web-platform/` → clean.
 
 ## Phase 7 — PR2 verification + ship
 


### PR DESCRIPTION
## Summary

Closes the second half of the user-initiated Stop feature on top of PR1 (#3447, server + DB + protocol). PR2 lands the client UI: `useWebSocket.abort()` + `streamState` machine, Stop button replacing Send, `Esc` shortcut with focus guard, and the abort-marker render path on persisted partial assistant text.

PR1 already widened the abort reason union, wired `abortController` into the SDK `query()` call, landed migration 040, and made `api-messages.ts` SELECT the new `status` + `usage` columns.

## What this PR adds

- **`useWebSocket.abort()` and `streamState`** on the hook return surface (`lib/ws-client.ts`). Transitions: `stream_start → streaming` (unless already `stopping`), `session_ended → idle` with conversationId disambiguation, `error/teardown/connect → idle`. `abort()` is a no-op when `streamState !== "streaming"` (idempotent under double-click), sends `{ type: "abort_turn", conversationId }` using the server-resolved `realConversationId` ref, and optimistically transitions to `stopping`.
- **Stop button** in `components/chat/chat-input.tsx` while `streamState ∈ {streaming, stopping}`. Disabled + labeled "Stopping…" while `stopping` so a second click cannot fire a second `abort_turn`.
- **Esc keyboard shortcut** in `components/chat/chat-surface.tsx` with the Esc-while-typing focus guard (Esc only fires when focus is NOT on a non-empty textarea). `useEffect` cleanup returns `document.removeEventListener` per AGENTS.md `cq-ref-removal-sweep-cleanup-closures`.
- **Abort marker** in `components/chat/message-bubble.tsx` for rows with `status === "aborted"`: partial text + `[stopped by user]` chip + total tokens + cost (`$<usd>` or "included in your plan") + inline chip-list of `usage.completed_actions[]`. `<ToolUseChip>` was NOT reused — its `leaderId` is narrowed to `cc_router | system` (different contract).
- **History-fetch mapper** surfaces `status` + `usage` so the marker survives a page reload (G2 honest disclosure — without this the live-WS path would render once and a refresh would silently drop the marker).

## Constraints respected

- Client-bundle paths use `@/lib/client-observability`; no new `@/server/*` imports.
- `cq-union-widening-grep-three-patterns` swept for the new `StreamState` union — two if-ladder hits in `chat-input.tsx`, both inside this PR's diff, exhaustively covering the non-idle states.
- `cq-ref-removal-sweep-cleanup-closures` honored on the keydown listener; an unmount-then-Esc test is the regression gate.
- Test convention follows the repo's vitest config (`test/*.test.tsx`), not the path suggested verbatim in the plan.

## Coordination notes

- **#3242** (raw tool-use name): PR2 uses today's `completed_actions[].tool_name` shape. If #3242 lands first, PR2 inherits the cleaner shape automatically; if PR2 lands first, #3242 becomes a downstream cleanup.
- **#3280** (history-fetch reducer refactor): PR2 adds `abort` to the hook's return surface. If #3280 lands first, the callback can move into the new reducer's action types in a follow-up.

## Test plan

- [x] `vitest run test/abort-marker.test.tsx test/chat-stop-button.test.tsx test/useWebSocket-abort.test.tsx` — 19 tests pass.
- [x] Full vitest suite: 3901 passed, 7 skipped, no regressions.
- [x] `tsc --noEmit` from `apps/web-platform/` — clean.
- [ ] Playwright e2e (post-review): start turn → Stop → marker → follow-up; same via Esc; same for tab-close (verifies PR1+PR2 integration).
- [ ] 24h Sentry watch on `feature: "abort-turn"` after merge.
- [ ] Manual prd dogfood: long prompt → Stop → marker rendering with token count + completed-actions chip-list.

Closes #3448

🤖 Generated with [Claude Code](https://claude.com/claude-code)