### PR TITLE
chore(schedule): defer gdpr-gate preflight Check 10 evaluation to 2026-06-29 (#3516)

### DIFF
--- a/.github/workflows/scheduled-gdpr-gate-preflight-eval-50d.yml
+++ b/.github/workflows/scheduled-gdpr-gate-preflight-eval-50d.yml
@@ -1,0 +1,201 @@
+name: "Scheduled (once): gdpr-gate preflight Check 10 — 50d eval (#3516)"
+
+on:
+  schedule:
+    - cron: '0 9 29 6 *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+concurrency:
+  group: schedule-once-gdpr-gate-preflight-eval-50d
+  cancel-in-progress: false
+
+env:
+  ISSUE_NUMBER: "3516"
+  COMMENT_ID: "4415647777"
+  FIRE_DATE: "2026-06-29"
+  WORKFLOW_NAME: "scheduled-gdpr-gate-preflight-eval-50d.yml"
+  EXPECTED_AUTHOR: "deruelle"
+  EXPECTED_CREATED_AT: "2026-05-10T15:27:18Z"
+
+jobs:
+  run-once:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: One-time fire (with self-neutralization)
+        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          show_full_output: true
+          plugin_marketplaces: 'https://github.com/jikig-ai/soleur.git'
+          plugins: 'soleur@soleur'
+          claude_args: >-
+            --max-turns 25
+            --allowedTools Bash,Read,Write,Edit,Glob,Grep
+          prompt: |
+            ## Neutralization primitive (referenced by D3 abort, preflight-failure abort, and the Final step)
+
+            To **neutralize** the workflow (prevent any future cron fires), do
+            the following IN ORDER. The previous mechanism `gh workflow disable
+            "$WORKFLOW_NAME"` was removed in #3153 — `claude-code-action`'s App
+            installation token does not honor `actions: write`, so the disable
+            returns 403 regardless of the workflow's declared permissions.
+
+            1. **Idempotency precheck.** Read `.github/workflows/$WORKFLOW_NAME`.
+               If the `on:` block has already had `schedule:` removed (or only
+               contains `workflow_dispatch:`), the workflow is already
+               neutralized — skip to step 6 (success, no-op).
+            2. **Edit YAML.** Use the Read+Edit tools (NOT shell `sed`/`awk` —
+               shell-based YAML mutation has a long history of corrupting
+               workflow files in CI) to remove the `schedule:` key and its
+               child list under `on:`. Leave any other triggers
+               (`workflow_dispatch:`, etc.) intact. If `schedule:` is the ONLY
+               trigger, replace the entire `on:` block with `on:\n  workflow_dispatch:`
+               so the file remains a valid GHA workflow that can be manually
+               invoked for forensic purposes.
+            3. **Stage and guard against no-op commit.**
+               `git add .github/workflows/$WORKFLOW_NAME` then
+               `git diff --cached --quiet`. If the diff is empty (exit 0), the
+               file was already neutralized between step 1 and step 2 — skip
+               to step 6.
+            4. **Configure git identity, then commit.**
+               ```bash
+               git config user.name "github-actions[bot]"
+               git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+               git commit -m "chore(schedule): neutralize one-time workflow $WORKFLOW_NAME (post-fire cleanup, #$ISSUE_NUMBER)"
+               ```
+            5. **Push — direct first, PR fallback.**
+               - **5a.** Try direct push:
+                 `git push origin HEAD:$DEFAULT_BRANCH`.
+                 If exit 0, neutralization succeeded — go to step 6.
+               - **5b.** If direct push fails (branch protection / required
+                 status checks): first check whether a stale neutralization
+                 PR already exists for this workflow:
+                 `EXISTING=$(gh pr list --search "head:chore/neutralize-$WORKFLOW_NAME" --state open --json url --jq '.[0].url // empty')`.
+                 If `$EXISTING` is non-empty, treat as a successful handoff —
+                 go to step 6 without opening a duplicate. Otherwise create
+                 an ephemeral branch
+                 `chore/neutralize-$WORKFLOW_NAME-$(date -u +%Y%m%d%H%M%S)`,
+                 push it, then open a PR via
+                 `gh pr create --base "$DEFAULT_BRANCH" --head "$BRANCH" --title "chore(schedule): neutralize $WORKFLOW_NAME" --body "Auto-cleanup after one-time fire of #$ISSUE_NUMBER. Removes the schedule: trigger from the generated --once workflow file."`.
+                 Then attempt auto-merge:
+                 `gh pr merge --squash --auto "$PR_URL" 2>/tmp/merge.err`.
+                 If `merge.err` contains `auto-merge is not allowed`, the PR
+                 is open and waiting on a human reviewer; that is still a
+                 successful neutralization handoff (D3 catches any re-fire
+                 before the PR lands).
+            6. **Success.** No fallback comment posted; the task-result
+               comment from the main work suffices.
+            7. **Both legs failed.** If step 5a errored AND step 5b
+               PR-creation errored (NOT auto-merge — auto-merge unavailability
+               is acceptable), post the fallback comment to issue
+               #$ISSUE_NUMBER with this exact body:
+               "Workflow ran but auto-cleanup failed (direct push: <err>; PR
+               create: <err>). Operator action required: edit
+               `.github/workflows/$WORKFLOW_NAME` to remove the `schedule:`
+               trigger."
+
+            ## Pre-flight (abort with observation comment if any check fails)
+
+            1. **Date guard (PRIMARY cross-year defense, D3):**
+               First, refuse to run if `$FIRE_DATE` is empty or malformed:
+               `[[ "$FIRE_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || { echo "FIRE_DATE empty or malformed: '$FIRE_DATE'"; <invoke neutralization primitive>; exit 0; }`
+               Then assert the calendar match:
+               `[[ "$(date -u +%F)" == "$FIRE_DATE" ]]` must be true. If false,
+               invoke the Neutralization primitive above and exit 0. Take no
+               other action.
+            2. **Idempotency:** if the workflow's `on:` block no longer
+               contains `schedule:` (already neutralized), exit 0 immediately.
+            3. **Repo not archived:**
+               `[[ "$(gh repo view --json isArchived --jq .isArchived)" == "false" ]]`.
+            4. **Issue OPEN + same repo:** fetch
+               `gh issue view "$ISSUE_NUMBER" --json state,repository_url`. The state
+               must be OPEN, and `repository_url` must end in `$REPO`.
+            5. **Comment exists + matches issue:**
+               `gh api "repos/$REPO/issues/comments/$COMMENT_ID" --jq .issue_url`
+               must end in `/issues/$ISSUE_NUMBER`.
+            6. **Comment-author pin (D5, FIRST half):** the comment's author MUST equal `$EXPECTED_AUTHOR`.
+               `actual_author=$(gh api "repos/$REPO/issues/comments/$COMMENT_ID" --jq .user.login)`
+               then `[[ "$actual_author" == "$EXPECTED_AUTHOR" ]]`.
+            7. **Comment-immutability pin (D5, SECOND half):** the comment MUST NOT have been edited after authoring.
+               `meta=$(gh api "repos/$REPO/issues/comments/$COMMENT_ID" --jq '"\(.created_at)\t\(.updated_at)"')`
+               then verify `created_at == EXPECTED_CREATED_AT` AND `created_at == updated_at`.
+
+            If ANY pre-flight check fails: post a single observation comment to issue
+            #$ISSUE_NUMBER naming which check failed, then invoke the
+            Neutralization primitive above and exit 0.
+
+            ## Task
+
+            Fetch the documented task spec from the referenced comment:
+
+            `body=$(gh api "repos/$REPO/issues/comments/$COMMENT_ID" --jq .body)`
+
+            If `$body` is empty (`[[ -z "$body" ]]`), treat as a pre-flight failure: post observation comment "comment body is empty", invoke the Neutralization primitive, exit 0.
+
+            Otherwise execute the documented work as instructed by `$body`. When complete, post results as a follow-up comment on issue #$ISSUE_NUMBER (re-verify `gh issue view "$ISSUE_NUMBER" --json repository_url` matches `$REPO` immediately before posting).
+
+            ## Final step (mandatory, last)
+
+            Invoke the Neutralization primitive above. This is D4 — the
+            secondary self-cleanup. D3 (the date guard above) is the primary
+            cross-year defense.
+
+            ## Post-fire verification (in-prompt observation) — #3403
+
+            After the Neutralization primitive completes, also post an
+            observable signal into the issue thread. Read the workflow file
+            back from the default branch via the contents API:
+
+            ```bash
+            CONTENT=$(gh api "repos/$REPO/contents/.github/workflows/$WORKFLOW_NAME" --jq .content | base64 -d)
+            STILL_HAS_SCHEDULE=$(printf '%s' "$CONTENT" | grep -cE '^[[:space:]]*schedule:' || true)
+            HAS_DISPATCH=$(printf '%s' "$CONTENT" | grep -cE '^[[:space:]]*workflow_dispatch:' || true)
+            ```
+
+            Expected post-neutralization state: `STILL_HAS_SCHEDULE == 0` AND
+            `HAS_DISPATCH >= 1`. If verification FAILS, post a follow-up
+            comment to issue #$ISSUE_NUMBER:
+
+            "Workflow neutralization claimed success but post-fire
+            verification shows `schedule:` still present (or
+            `workflow_dispatch:` removed) on the default branch. Manual
+            intervention required: edit `.github/workflows/$WORKFLOW_NAME` to
+            remove the `schedule:` trigger."
+
+      - name: Post-fire verification (#3403)
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          STILL_HAS_SCHEDULE=99
+          HAS_DISPATCH=0
+          for attempt in 1 2 3; do
+            CONTENT=$(gh api "repos/$REPO/contents/.github/workflows/$WORKFLOW_NAME" --jq .content 2>/dev/null | base64 -d || true)
+            STILL_HAS_SCHEDULE=$(printf '%s' "$CONTENT" | grep -cE '^[[:space:]]*schedule:' || true)
+            HAS_DISPATCH=$(printf '%s' "$CONTENT" | grep -cE '^[[:space:]]*workflow_dispatch:' || true)
+            if [[ "$STILL_HAS_SCHEDULE" == "0" && "$HAS_DISPATCH" -ge "1" ]]; then
+              echo "::notice::Post-fire verification passed (attempt $attempt)."
+              exit 0
+            fi
+            echo "Attempt $attempt: schedule=$STILL_HAS_SCHEDULE dispatch=$HAS_DISPATCH — retrying after replication lag."
+            sleep 10
+          done
+          echo "::error::Post-fire verification failed: schedule=$STILL_HAS_SCHEDULE dispatch=$HAS_DISPATCH"
+          exit 1

--- a/knowledge-base/project/brainstorms/2026-05-10-gdpr-gate-preflight-check-10-eval-brainstorm.md
+++ b/knowledge-base/project/brainstorms/2026-05-10-gdpr-gate-preflight-check-10-eval-brainstorm.md
@@ -1,0 +1,90 @@
+---
+title: gdpr-gate as preflight Check 10 — Q1 re-evaluation
+date: 2026-05-10
+status: deferred-pending-data
+issue: 3516
+related_pr: 3501
+related_adr: ADR-026
+brand_survival_threshold: single-user incident
+---
+
+# gdpr-gate as preflight Check 10 — Q1 re-evaluation
+
+## What We're Deciding
+
+Whether to add `/soleur:gdpr-gate` as preflight Check 10 (third tier of enforcement, after `/soleur:plan` Phase 2.7 and `/soleur:work` Phase 2 exit).
+
+## Decision
+
+**Keep deferred. Do not implement preflight integration today.** Set a calendar-based
+re-evaluation on **2026-08-10** (90 days post-ship).
+
+## Why This Approach
+
+The Q1 deferral criterion in #3516 is data-dependent:
+
+> ≥3 Critical findings post-merge that escaped both `/soleur:plan` Phase 2.7 and `/soleur:work` Phase 2 exit gates.
+
+PR #3501 (which introduced gdpr-gate as a plan/work-phase skill) merged at
+**2026-05-10T13:42:03Z** — hours before this brainstorm. The criterion is
+literally unmeasurable today: there is no post-merge window in which Critical
+findings could have escaped, accumulated to 3, and been observed.
+
+Implementing preflight Check 10 now would:
+
+1. Bypass the criterion the spec deliberately set, treating the gate's
+   plan/work coverage as insufficient by assumption rather than evidence.
+2. Add a third tier of enforcement on top of two unproven tiers, increasing
+   token cost on every preflight run for unknown marginal coverage.
+3. Pre-commit context to a design (where in preflight, what trigger paths,
+   what failure UX) before we know what *kind* of Critical findings escape —
+   and the right Check 10 design depends on that distribution.
+
+## Alternative Considered: Calendar Re-Evaluation Without Count
+
+The criterion is "≥3 Critical findings". A purely count-based criterion can
+silently never fire if usage is low. We pair the count with a calendar
+checkpoint (90 days) so the question gets re-asked even if the count is 0.
+At 2026-08-10, three outcomes are possible:
+
+| Observed (90d) | Action |
+|----------------|--------|
+| ≥3 Critical findings escaped both gates | Implement Check 10. Brainstorm reopens with real failure data shaping the design. |
+| 1-2 Critical findings escaped | Keep deferred 90 more days; document the cases. |
+| 0 Critical findings escaped, OR plan/work gates caught everything | Close #3516 as "criterion settled — preflight tier not needed." |
+
+90 days is a balance: long enough that low-frequency PII surfaces (auth
+flows, schema changes, API routes) get hit by ordinary work; short enough
+that the issue doesn't drift indefinitely.
+
+## Key Decisions
+
+- **Defer:** No code changes today. Issue #3516 stays open; draft PR #3520 closes without merge.
+- **Re-eval mechanism:** One-time scheduled agent task on 2026-08-10 via `/soleur:schedule`, which posts to #3516 with the 90-day data and a recommendation.
+- **Data source for re-eval:** `incidents.sh` telemetry on the gdpr-gate Critical-finding rule (`cq-gdpr-gate-critical-finding`, planned at gate-implementation time per the spec's TR8) — plus a manual scan of merged PRs in the 90-day window for compliance regressions that escaped review.
+
+## Open Questions (deferred to re-eval)
+
+- Does the gdpr-gate Critical-finding telemetry actually exist by 2026-08-10? If TR8's `cq-gdpr-gate-critical-finding` rule was never wired up, we have no count and the re-eval falls back to a manual sweep.
+- If preflight Check 10 ships, is it a hard gate (block ship on Critical) or advisory (annotate ship message)? Plan/work tiers are advisory; a third advisory tier may be lower-value than a hard tier.
+
+## User-Brand Impact
+
+**Artifact:** Regulated user data (Art. 9 categories, PII, payment data) flowing through Soleur-generated code paths.
+
+**Vector:** A Critical-severity GDPR/CCPA/HIPAA violation slips past plan-time and work-time advisory gates and reaches production, exposing real user data to non-compliant processing or storage.
+
+**Threshold:** `single-user incident`. One user's regulated data leaked or mis-processed is a brand-survival event for an EU-targeting platform.
+
+**Mitigation premise of this brainstorm:** The two existing tiers (plan + work) cover the design-time and implementation-time generation paths. Preflight Check 10 would catch only the residual case where (a) a Critical finding appears in a diff and (b) both upstream tiers missed it. We cannot size that residual without operational data.
+
+## Domain Assessments
+
+**Assessed:** none — the decision is "wait for data," not a feature design. CPO/CLO/CTO will be re-engaged at the 2026-08-10 re-evaluation if the count threshold is reached or if calendar review surfaces a design choice.
+
+## Next Action
+
+1. Comment on #3516 with this decision and the 2026-08-10 re-eval date.
+2. Schedule a one-time agent task via `/soleur:schedule` to re-open this brainstorm on 2026-08-10.
+3. Close draft PR #3520 (no implementation needed in this branch).
+4. Leave #3516 OPEN with milestone unchanged so the scheduled task has something to comment on.


### PR DESCRIPTION
## Summary

Defers Q1 of `feat-compliance-skills-eval` (add `gdpr-gate` as preflight Check 10) until operational data exists. Schedules a one-time agent task on **2026-06-29** (50 days post-ship of #3501) to re-evaluate against the criterion.

**Why defer:** the re-evaluation criterion in #3516 is `≥3 Critical findings post-merge that escaped both /soleur:plan Phase 2.7 and /soleur:work Phase 2 exit gates`. PR #3501 merged at `2026-05-10T13:42:03Z` — hours before this evaluation. The criterion is literally unmeasurable today.

**Why 50 days, not 90:** the schedule skill caps `--at` at 50 days (GHA's 60-day inactivity timer leaves ~10d margin). The 2026-06-29 fire is a first checkpoint — if 0–2 Critical findings have escaped, the agent re-schedules a 90-day final checkpoint for 2026-08-10. If ≥3 have escaped, it labels #3516 `priority/p1` and recommends implementation.

## Files

- `knowledge-base/project/brainstorms/2026-05-10-gdpr-gate-preflight-check-10-eval-brainstorm.md` — decision record with the truncated outcome matrix.
- `.github/workflows/scheduled-gdpr-gate-preflight-eval-50d.yml` — one-time GHA cron with full D1–D5 defenses (runtime context fetch, stale-context preamble, date guard, self-neutralization, comment-author + immutability pin).

## Test plan

- [x] YAML validates (cron `0 9 29 6 *`, env block FIRE_DATE=2026-06-29, EXPECTED_AUTHOR=deruelle, EXPECTED_CREATED_AT=2026-05-10T15:27:18Z, permissions correct).
- [x] Comment 4415647777 (the task spec) is unedited (created_at == updated_at) at workflow create time.
- [x] Action SHAs pinned (actions/checkout@34e1148…, anthropics/claude-code-action@476e359…).
- [ ] After merge, `gh workflow list` shows `Scheduled (once): gdpr-gate preflight Check 10 — 50d eval (#3516)` as `active` on main.
- [ ] Manual `workflow_dispatch` smoke test post-merge would fire the D3 date guard and abort cleanly (today != 2026-06-29) — optional.

## Brand-survival

Tagged `single-user incident` in the brainstorm. The gdpr-gate's job is to catch PII / regulated-data violations before generation; the deferred preflight tier would be the third level of defense. Plan/work tiers are unproven but live; the deferral is *not* a removal of coverage — it's a wait-for-data on adding a third tier.

Refs: #3516, #3501, ADR-026, brainstorm doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)