### PR TITLE
chore(legal): bump compliance-posture last_updated to gdpr-gate merge date

### DIFF
--- a/knowledge-base/legal/compliance-posture.md
+++ b/knowledge-base/legal/compliance-posture.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-05-05
+last_updated: 2026-05-10
 ---
 
 # Legal Compliance Posture

--- a/knowledge-base/project/plans/2026-05-11-chore-compliance-posture-last-updated-bump-plan.md
+++ b/knowledge-base/project/plans/2026-05-11-chore-compliance-posture-last-updated-bump-plan.md
@@ -1,0 +1,105 @@
+---
+type: chore
+issue: 3519
+source_pr: 3501
+priority: p3-low
+domain: legal
+created: 2026-05-11
+---
+
+# chore: bump compliance-posture.md last_updated for gdpr-gate handshake (#3519)
+
+## Overview
+
+One-line frontmatter bump on `knowledge-base/legal/compliance-posture.md`: change `last_updated: 2026-05-05` → `last_updated: 2026-05-10` (merge date of PR #3501, SHA `6d7e8ec18ff1331688a6285ea0a8000645183396`).
+
+This closes AC-PM-1 of the gdpr-gate skill plan: the `last_updated` field is the freshness signal domain leaders read when assessing whether to trust the Active Items table. PR #3501 added the gate-write contract surface (Active Items row schema for gdpr-gate critical-finding handshake) without bumping the date — this PR is the deferred bookkeeping fix.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** stale `last_updated` continues to claim 2026-05-05 — domain leaders (CLO, CPO) and the gdpr-gate skill's own reader path treat the Active Items table as ~6 days older than reality, slightly miscalibrating "is this row still authoritative?" judgments. No user-facing artifact regresses.
+
+**If this leaks, the user's [data / workflow / money] is exposed via:** N/A — this is documentation metadata, not credentials, schema, or runtime config.
+
+**Brand-survival threshold:** none
+
+**Reason for threshold none:** Edits only the `last_updated:` frontmatter line. No regulated-data surface, no auth flow, no API route, no schema. The compliance-posture.md file is regulated-data-adjacent (lists vendor DPA status) but this specific edit does not touch that table.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Spec claim (issue body) | Reality (verified) | Plan response |
+|---|---|---|
+| `last_updated` is currently `2026-05-05` | Confirmed at `knowledge-base/legal/compliance-posture.md:2` via `grep -n` | Bump to `2026-05-10` |
+| Source PR #3501 merge SHA `6d7e8ec18ff1331688a6285ea0a8000645183396` | Confirmed via `gh pr view 3501 --json mergedAt,mergeCommit` → `mergedAt: 2026-05-10T13:42:03Z`, sha matches | Use 2026-05-10 (merge date) per issue's first preference |
+
+## Files to Edit
+
+- `knowledge-base/legal/compliance-posture.md` — line 2: `last_updated: 2026-05-05` → `last_updated: 2026-05-10`
+
+## Files to Create
+
+None.
+
+## Open Code-Review Overlap
+
+None. (Verified via `gh issue list --label code-review --state open --json number,title,body` + `jq` substring search on `compliance-posture.md` and `knowledge-base/legal/compliance-posture.md`.)
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] `knowledge-base/legal/compliance-posture.md` line 2 reads `last_updated: 2026-05-10`
+- [ ] No other lines in `compliance-posture.md` modified (verify via `git diff --stat` showing exactly 1 file, exactly 1 insertion + 1 deletion)
+- [ ] PR body uses `Closes #3519` (issue auto-closes at merge — there is no post-merge step)
+- [ ] `/soleur:gdpr-gate` invocation skipped per AGENTS.md `hr-gdpr-gate-on-regulated-data-surfaces`: the canonical regex covers schemas, migrations, auth flows, API routes, `.sql` files — none match a frontmatter-only edit to a docs-tree markdown file. The compliance-posture.md file itself is the *output* of the gdpr-gate handshake, not a regulated-data surface.
+
+### Post-merge (operator)
+
+None. The bump is a string change; no apply, no deploy, no external service touch.
+
+## Test Scenarios
+
+None. This is a single-line metadata edit; there is no behavior to assert. The Pre-merge AC `git diff --stat` check is the only verification needed.
+
+**Why no test scaffolding:** Adding a test for "the date string equals `2026-05-10`" would be cosmetic — it would assert a literal that the next bump will immediately invalidate, and there is no consumer of the frontmatter value that could regress silently. The frontmatter is read by humans (domain leaders) and YAML-parsing tools that don't validate semantic freshness.
+
+## Hypotheses
+
+N/A — this is not an investigation. The bug is the missed bookkeeping step in PR #3501, identified verbatim in the issue body.
+
+## Domain Review
+
+**Domains relevant:** Legal (CLO advisory, low-confidence)
+
+### Legal
+
+**Status:** advisory carry-forward
+**Assessment:** This is the bookkeeping closure of the AC-PM-1 follow-through item the CLO would have surfaced on its own. The bump itself does not change any legal claim or vendor-DPA row; it only refreshes the freshness signal at the top of the document. CLO sign-off is not required for a metadata refresh that reflects an already-merged content change (#3501).
+
+No Product/UX, Engineering, Marketing, Operations, Finance, Security, or Compliance domains relevant — the change has no behavior surface.
+
+## Phases
+
+### Phase 1 — Apply the bump
+
+1. Read `knowledge-base/legal/compliance-posture.md` to confirm current state (already done at plan time; re-read at work time per AGENTS.md `hr-always-read-a-file-before-editing-it`).
+2. Use `Edit` tool: `old_string: "last_updated: 2026-05-05"` → `new_string: "last_updated: 2026-05-10"`.
+3. Verify `git diff --stat` shows exactly `knowledge-base/legal/compliance-posture.md | 2 +-`.
+4. Commit with message `chore(legal): bump compliance-posture.md last_updated to gdpr-gate merge date (#3519)`.
+5. Push, open PR with body `Closes #3519`, mark ready, queue `--squash --auto`, poll until MERGED, run `cleanup-merged`.
+
+## Risks
+
+- **None substantive.** The only failure mode is mistyping the date — caught by the Pre-merge `git diff --stat` AC.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder text, or omits the threshold will fail `deepen-plan` Phase 4.6. (This plan declares `threshold: none, reason: …` per the preflight Check 6 contract; the edit does not touch a sensitive path under the canonical regex, so the scope-out bullet is satisfied.)
+- Do not bump version files in feature branches (AGENTS.md `wg-never-bump-version-files-in-feature`) — this edit is metadata in a docs-tree file, not `plugin.json` or `marketplace.json`.
+- Do not run `/soleur:gdpr-gate` on this diff: the edit does not match the regulated-data-surfaces regex; running it would be a false positive.
+
+## Out of Scope
+
+- Updating any of the per-row `Last Updated` columns in the `## Legal Documents` table — those track when each linked document was last edited, not when compliance-posture.md was last touched. Those rows remain at `2026-03-20` because the underlying legal documents have not been modified.
+- Auditing whether other follow-through items from PR #3501 (AC-PM-2+) are open or closed — out of scope per the issue body's tight framing.
+- Any DPA refresh or Active Items table edit — also out of scope.

--- a/knowledge-base/project/plans/2026-05-11-chore-compliance-posture-last-updated-bump-plan.md
+++ b/knowledge-base/project/plans/2026-05-11-chore-compliance-posture-last-updated-bump-plan.md
@@ -126,10 +126,10 @@ None. (Verified via `gh issue list --label code-review --state open --json numbe
 
 ### Pre-merge (PR)
 
-- [ ] `knowledge-base/legal/compliance-posture.md` line 2 reads `last_updated: 2026-05-10`
-- [ ] No other lines in `compliance-posture.md` modified (verify via `git diff --stat` showing exactly 1 file, exactly 1 insertion + 1 deletion)
-- [ ] PR body uses `Closes #3519` (issue auto-closes at merge — there is no post-merge step)
-- [ ] `/soleur:gdpr-gate` invocation skipped per AGENTS.md `hr-gdpr-gate-on-regulated-data-surfaces`: the canonical regex covers schemas, migrations, auth flows, API routes, `.sql` files — none match a frontmatter-only edit to a docs-tree markdown file. The compliance-posture.md file itself is the *output* of the gdpr-gate handshake, not a regulated-data surface.
+- [x] `knowledge-base/legal/compliance-posture.md` line 2 reads `last_updated: 2026-05-10`
+- [x] No other lines in `compliance-posture.md` modified (verify via `git diff --stat` showing exactly 1 file, exactly 1 insertion + 1 deletion)
+- [x] PR body uses `Closes #3519` (issue auto-closes at merge — there is no post-merge step)
+- [x] `/soleur:gdpr-gate` invocation skipped per AGENTS.md `hr-gdpr-gate-on-regulated-data-surfaces`: the canonical regex covers schemas, migrations, auth flows, API routes, `.sql` files — none match a frontmatter-only edit to a docs-tree markdown file. The compliance-posture.md file itself is the *output* of the gdpr-gate handshake, not a regulated-data surface.
 
 ### Post-merge (operator)
 

--- a/knowledge-base/project/plans/2026-05-11-chore-compliance-posture-last-updated-bump-plan.md
+++ b/knowledge-base/project/plans/2026-05-11-chore-compliance-posture-last-updated-bump-plan.md
@@ -5,7 +5,12 @@ source_pr: 3501
 priority: p3-low
 domain: legal
 created: 2026-05-11
+date: 2026-05-11
 deepened: 2026-05-11
+branch: feat-one-shot-3519-compliance-posture-bump
+worktree: .worktrees/feat-one-shot-3519-compliance-posture-bump
+spec: knowledge-base/project/specs/feat-one-shot-3519-compliance-posture-bump/tasks.md
+requires_cpo_signoff: false
 ---
 
 # chore: bump compliance-posture.md last_updated for gdpr-gate handshake (#3519)

--- a/knowledge-base/project/plans/2026-05-11-chore-compliance-posture-last-updated-bump-plan.md
+++ b/knowledge-base/project/plans/2026-05-11-chore-compliance-posture-last-updated-bump-plan.md
@@ -5,9 +5,87 @@ source_pr: 3501
 priority: p3-low
 domain: legal
 created: 2026-05-11
+deepened: 2026-05-11
 ---
 
 # chore: bump compliance-posture.md last_updated for gdpr-gate handshake (#3519)
+
+## Enhancement Summary
+
+**Deepened on:** 2026-05-11
+**Sections enhanced:** 0 net additions; verification artifacts inlined
+**Approach:** Proportionate deepen. A 1-line YAML frontmatter date bump on a markdown docs file does not warrant a 40-agent fan-out — the deepen-plan quality checks (SHA verification, PR citation, AGENTS.md rule citations, sensitive-path regex match) are the load-bearing gates for this plan class, and they have been applied directly below.
+
+### Phase 9 Quality-Check Verification Block
+
+All verifications performed at deepen-pass time (2026-05-11). Outputs preserved verbatim per deepen-plan quality-check requirements.
+
+**SHA + PR citation (`6d7e8ec18ff1331688a6285ea0a8000645183396` / #3501):**
+
+```bash
+$ gh pr view 3501 --json state,title,mergedAt,mergeCommit
+{"mergeCommit":{"oid":"6d7e8ec18ff1331688a6285ea0a8000645183396"},"mergedAt":"2026-05-10T13:42:03Z","state":"MERGED","title":"feat(gdpr-gate): code-level GDPR/CCPA/HIPAA pre-generation advisory gate"}
+
+$ git log --oneline 6d7e8ec18ff1331688a6285ea0a8000645183396 -1
+6d7e8ec1 feat(gdpr-gate): code-level GDPR/CCPA/HIPAA pre-generation advisory gate (#3501)
+```
+
+**Issue state (#3519):**
+
+```bash
+$ gh issue view 3519 --json state,title
+{"state":"OPEN","title":"follow-through: bump compliance-posture.md last_updated for gdpr-gate handshake (AC-PM-1)"}
+```
+
+**AGENTS.md rule citations — all active, none retired or fabricated:**
+
+```bash
+$ for id in hr-gdpr-gate-on-regulated-data-surfaces hr-always-read-a-file-before-editing-it \
+           wg-never-bump-version-files-in-feature hr-weigh-every-decision-against-target-user-impact; do
+    grep -qE "\[id: $id\]" AGENTS.md && echo "ACTIVE: $id"
+  done
+ACTIVE: hr-gdpr-gate-on-regulated-data-surfaces
+ACTIVE: hr-always-read-a-file-before-editing-it
+ACTIVE: wg-never-bump-version-files-in-feature
+ACTIVE: hr-weigh-every-decision-against-target-user-impact
+
+$ # Cross-check against scripts/retired-rule-ids.txt → zero matches
+```
+
+**Sensitive-path regex (preflight Check 6 canonical, line 398 of `plugins/soleur/skills/preflight/SKILL.md`) against the only edited file:**
+
+```bash
+$ echo "knowledge-base/legal/compliance-posture.md" | grep -E "$SENSITIVE_PATH_RE" || echo "NOT_SENSITIVE"
+NOT_SENSITIVE
+```
+
+The `threshold: none` declaration in `## User-Brand Impact` is therefore valid without a scope-out bullet — the file is not under any of the canonical sensitive-path classes (no Doppler shell, no `apps/web-platform/server|app/api|middleware.ts`, no `apps/*/infra/`, no credential-handling workflow).
+
+**Phase 4.6 (User-Brand Impact halt gate):** PASSES. Heading present, body non-empty, threshold value is `none` (one of the three allowed values), file not in sensitive-path class. No telemetry emitted (gate only records on activation).
+
+### Phase 4.5 (Network-Outage Deep-Dive)
+
+Skipped. Plan body contains zero matches for the trigger patterns (`SSH`, `connection reset`, `kex`, `firewall`, `unreachable`, `timeout`, `502`, `503`, `504`, `handshake`, `EHOSTUNREACH`, `ECONNRESET`). No Terraform resource with `provisioner` or `connection { type = "ssh" }` blocks is referenced. No `terraform apply` is in scope.
+
+### Skills/Agents Considered and Skipped
+
+Skipped with explicit rationale (each would be ceremony, not signal, on a date-string change):
+
+- `soleur:gdpr-gate` — file edited is the *output* surface of the gate, not a regulated-data source; per `hr-gdpr-gate-on-regulated-data-surfaces` canonical regex, frontmatter-only edits to docs-tree markdown do not match.
+- `frontend-design`, `dhh-rails-style`, `andrew-kane-gem-writer`, `vercel-react-best-practices`, `supabase-postgres-best-practices`, `agent-native-architecture` — domain mismatch (no UI, Ruby, gem, React, Postgres, or agent surface).
+- `security-review`, `simplify`, all engineering review agents (architecture-strategist, security-sentinel, data-integrity-guardian, type-design-analyzer, code-quality-analyst, user-impact-reviewer, test-design-reviewer, agent-native-reviewer, git-history-analyzer, repo-research-analyst, framework-docs-researcher, best-practices-researcher, spec-flow-analyzer) — every agent operates on diff content or design surface; this PR's diff is `-last_updated: 2026-05-05` / `+last_updated: 2026-05-10`, with no behavior, schema, contract, type, test, security, or design surface to review. The Pre-merge `git diff --stat` AC (exactly 1 file, 1 insertion + 1 deletion) is the verification a reviewer would perform anyway.
+- `web-design-guidelines`, `claude-api` — no UI rendering, no Anthropic SDK calls.
+- Learnings under `knowledge-base/project/learnings/` — filtered: no learning category applies (no performance, debugging, integration, deployment, configuration, security, or best-practice class is engaged by a date bump). The closest semantic match is the plan-quality learnings (paraphrase-without-verification class), which this deepen pass has *applied* by verifying SHA, PR, issue state, and rule citations live above.
+
+### Key Improvements vs Plan-Skill Output
+
+1. Verification artifacts (SHA / PR / issue / rule citations) inlined in a fenced block, satisfying deepen-plan Phase 9 quality checks without forcing the reader to re-run the commands.
+2. Explicit Phase 4.5 / Phase 4.6 / sensitive-path regex pass-through documented so a future review agent can confirm the gates fired with the right answer.
+3. Explicit skill/agent skip rationale recorded so the next reader does not waste cycles wondering whether a 40-agent fan-out was overlooked.
+
+### New Considerations Discovered
+
+None. The plan is structurally minimal because the change is structurally minimal. No new risks, no new edge cases, no new sharp edges beyond those already enumerated in the plan body.
 
 ## Overview
 

--- a/knowledge-base/project/specs/feat-one-shot-3519-compliance-posture-bump/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-3519-compliance-posture-bump/session-state.md
@@ -1,0 +1,21 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-one-shot-3519-compliance-posture-bump/knowledge-base/project/plans/2026-05-11-chore-compliance-posture-last-updated-bump-plan.md
+- Status: complete
+
+### Errors
+None.
+
+### Decisions
+- Detail level: MINIMAL. 1-line YAML frontmatter date bump on knowledge-base/legal/compliance-posture.md (last_updated: 2026-05-05 → 2026-05-10).
+- Date chosen: 2026-05-10 (merge date of #3501, verified via `gh pr view 3501` mergedAt timestamp and merge SHA 6d7e8ec1).
+- User-Brand Impact threshold: none (file does not match preflight Check 6 sensitive-path regex).
+- GDPR-gate invocation skipped: compliance-posture.md is the output surface of the gate handshake, not a regulated-data source per the canonical regex.
+- Proportionate deepen-pass: load-bearing Phase 9 quality checks applied directly (SHA, PR, issue, AGENTS.md rule citations) rather than fanning out review/skill agents against a date-string change.
+
+### Components Invoked
+- soleur:plan
+- soleur:deepen-plan
+- Bash verifications: gh pr view 3501, gh issue view 3519, git log, grep against AGENTS.md + scripts/retired-rule-ids.txt
+- No subagents spawned (proportionate scope)

--- a/knowledge-base/project/specs/feat-one-shot-3519-compliance-posture-bump/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-3519-compliance-posture-bump/tasks.md
@@ -1,0 +1,19 @@
+---
+plan: knowledge-base/project/plans/2026-05-11-chore-compliance-posture-last-updated-bump-plan.md
+issue: 3519
+source_pr: 3501
+created: 2026-05-11
+---
+
+# Tasks — chore: bump compliance-posture.md last_updated (#3519)
+
+## Phase 1 — Apply the bump
+
+- [ ] 1.1 Read `knowledge-base/legal/compliance-posture.md` (re-read at work time per AGENTS.md `hr-always-read-a-file-before-editing-it`)
+- [ ] 1.2 Edit line 2: `last_updated: 2026-05-05` → `last_updated: 2026-05-10`
+- [ ] 1.3 Verify `git diff --stat` shows exactly 1 file changed, 1 insertion + 1 deletion
+- [ ] 1.4 Commit: `chore(legal): bump compliance-posture.md last_updated to gdpr-gate merge date (#3519)`
+- [ ] 1.5 Push to remote
+- [ ] 1.6 Open PR with body `Closes #3519`, mark ready
+- [ ] 1.7 Queue `gh pr merge <N> --squash --auto`, poll until MERGED
+- [ ] 1.8 Run `cleanup-merged` via worktree-manager

--- a/knowledge-base/project/specs/feat-one-shot-3519-compliance-posture-bump/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-3519-compliance-posture-bump/tasks.md
@@ -9,11 +9,11 @@ created: 2026-05-11
 
 ## Phase 1 — Apply the bump
 
-- [ ] 1.1 Read `knowledge-base/legal/compliance-posture.md` (re-read at work time per AGENTS.md `hr-always-read-a-file-before-editing-it`)
-- [ ] 1.2 Edit line 2: `last_updated: 2026-05-05` → `last_updated: 2026-05-10`
-- [ ] 1.3 Verify `git diff --stat` shows exactly 1 file changed, 1 insertion + 1 deletion
-- [ ] 1.4 Commit: `chore(legal): bump compliance-posture.md last_updated to gdpr-gate merge date (#3519)`
-- [ ] 1.5 Push to remote
+- [x] 1.1 Read `knowledge-base/legal/compliance-posture.md` (re-read at work time per AGENTS.md `hr-always-read-a-file-before-editing-it`)
+- [x] 1.2 Edit line 2: `last_updated: 2026-05-05` → `last_updated: 2026-05-10`
+- [x] 1.3 Verify `git diff --stat` shows exactly 1 file changed, 1 insertion + 1 deletion
+- [x] 1.4 Commit: `chore(legal): bump compliance-posture.md last_updated to gdpr-gate merge date (#3519)`
+- [x] 1.5 Push to remote
 - [ ] 1.6 Open PR with body `Closes #3519`, mark ready
 - [ ] 1.7 Queue `gh pr merge <N> --squash --auto`, poll until MERGED
 - [ ] 1.8 Run `cleanup-merged` via worktree-manager


### PR DESCRIPTION
## Summary
- Bumps `last_updated` frontmatter in `knowledge-base/legal/compliance-posture.md` from `2026-05-05` to `2026-05-10` (merge date of #3501)
- Closes AC-PM-1 follow-through from #3501 (gdpr-gate code-level pre-generation advisory gate)

Closes #3519

## Changelog
- docs(legal): refresh compliance-posture freshness signal to reflect #3501 merge date

## Test plan
- [x] `git diff --stat` shows exactly 1 file changed, 1 insertion + 1 deletion in `compliance-posture.md`
- [x] Review evidence on branch (commit `0012332f`)
- [x] Preflight passed
- [x] `bash scripts/test-all.sh` — 30/30 suites passed

Generated with [Claude Code](https://claude.com/claude-code)
