### PR TITLE
fix(settings): anchor centered content during sidebar collapse

### DIFF
--- a/apps/web-platform/components/settings/settings-shell.tsx
+++ b/apps/web-platform/components/settings/settings-shell.tsx
@@ -101,7 +101,7 @@ export function SettingsShell({ children }: { children: React.ReactNode }) {
       </div>
 
       {/* Content area */}
-      <div className={`relative flex-1 px-4 py-10 pb-20 md:pb-10 md:transition-[padding] md:duration-200 md:ease-out ${settingsCollapsed ? "md:pl-8 md:pr-10" : "md:px-10"}`}>
+      <div className={`relative flex-1 px-4 py-10 pb-20 md:pb-10 md:transition-[padding] md:duration-200 md:ease-out ${settingsCollapsed ? "md:pl-[14.5rem] md:pr-10" : "md:px-10"}`}>
         {settingsCollapsed && (
           <button
             onClick={toggleSettingsCollapsed}

--- a/apps/web-platform/test/settings-sidebar-collapse.test.tsx
+++ b/apps/web-platform/test/settings-sidebar-collapse.test.tsx
@@ -155,13 +155,15 @@ describe("Settings sidebar collapse", () => {
       expect(navEl?.className).not.toMatch(/\bpx-4\b/);
     });
 
-    it("content area uses a reduced left padding when sidebar is collapsed", async () => {
+    it("collapsed content area pl matches sidebar-width + open-padding to keep centered text stationary", async () => {
       render(<SettingsShell><div>content</div></SettingsShell>);
       await userEvent.click(screen.getByLabelText("Collapse settings nav"));
       const expandBtn = screen.getByLabelText("Expand settings nav");
       const contentArea = expandBtn.parentElement;
       expect(contentArea).not.toBeNull();
-      expect(contentArea?.className).toMatch(/\bmd:pl-(?:6|8)\b/);
+      // Sidebar = w-48 (12rem) + open pad = md:px-10 (2.5rem) → collapsed pl must equal 14.5rem
+      // so the `mx-auto max-w-2xl` inner content's screen-x position is identical in both states.
+      expect(contentArea?.className).toMatch(/(?:^|\s)md:pl-\[14\.5rem\](?:\s|$)/);
     });
 
     it("content area transitions padding in sync with sidebar width (200ms ease-out)", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #3557 + #3573. The sidebar now slides smoothly and the content-area padding eases, but the centered inner content (`<div class="mx-auto max-w-2xl">` in `apps/web-platform/components/settings/settings-shell.tsx`) was still drifting ~100px leftward over the 200ms collapse — `mx-auto` re-centers continuously as the parent flex-1 grows. The user perceived this as the text "flashing to where the sidebar was."

Make collapsed-state left padding equal `sidebar_width + open_padding` (12rem + 2.5rem = 14.5rem). With matching container width math in both states, the `mx-auto` content's screen-x position is identical when open and when collapsed → text stays anchored, sidebar slides away, an empty "ghost slot" eases in to take the sidebar's place.

## Changelog

### Web Platform

- Fix: settings sidebar content text now stays visually stationary while the sidebar slides closed; only the surrounding empty space animates.

## Test plan

- [x] Unit tests: `apps/web-platform/test/settings-sidebar-collapse.test.tsx` → 18/18 green (the previous "reduced padding" assertion is now the 14.5rem anchor contract).
- [x] `tsc --noEmit` clean on `apps/web-platform/`.
- [x] Geometry math verified at multiple viewport widths (768px and 1400px): text-left identical in open and collapsed states.
- [ ] ⏳ Visual verification deferred behind #3562 (dev-server bug). Same blocker as #3565.

Ref #3557, ref #3573

Generated with [Claude Code](https://claude.com/claude-code)
