### PR TITLE
fix(settings): keep nav padding constant so inner content doesn't flash to top on collapse

### DIFF
--- a/apps/web-platform/components/settings/settings-shell.tsx
+++ b/apps/web-platform/components/settings/settings-shell.tsx
@@ -35,9 +35,9 @@ export function SettingsShell({ children }: { children: React.ReactNode }) {
       {/* Settings sidebar — hidden on mobile, shown on md+ */}
       <nav
         inert={settingsCollapsed || undefined}
-        className={`hidden shrink-0 border-r border-soleur-border-default md:block
+        className={`hidden shrink-0 border-r border-soleur-border-default px-4 py-5 md:block
         md:transition-[width] md:duration-200 md:ease-out
-        ${settingsCollapsed ? "md:w-0 md:overflow-hidden md:border-r-0" : "w-48 px-4 py-5"}`}>
+        ${settingsCollapsed ? "md:w-0 md:overflow-hidden md:border-r-0" : "w-48"}`}>
         <div className="mb-4 flex min-h-7 items-center justify-between">
           <h2 className="text-xs font-medium uppercase tracking-wider text-soleur-text-muted">
             Settings

--- a/apps/web-platform/test/settings-sidebar-collapse.test.tsx
+++ b/apps/web-platform/test/settings-sidebar-collapse.test.tsx
@@ -152,7 +152,21 @@ describe("Settings sidebar collapse", () => {
       expect(navEl?.className).toMatch(/\bmd:w-0\b/);
       expect(navEl?.className).toMatch(/\bmd:overflow-hidden\b/);
       expect(navEl?.className).toMatch(/\bmd:border-r-0\b/);
-      expect(navEl?.className).not.toMatch(/\bpx-4\b/);
+    });
+
+    it("nav padding is constant across open/collapsed so inner content doesn't jump to (0, 0) when collapsing", async () => {
+      const { rerender } = render(<SettingsShell><div>content</div></SettingsShell>);
+      const navEl = document.querySelector("nav");
+      expect(navEl?.className).toMatch(/\bpx-4\b/);
+      expect(navEl?.className).toMatch(/\bpy-5\b/);
+      await userEvent.click(screen.getByLabelText("Collapse settings nav"));
+      rerender(<SettingsShell><div>content</div></SettingsShell>);
+      const navCollapsed = document.querySelector("nav");
+      // Padding MUST remain across the toggle — width animates while overflow-hidden
+      // clips the still-padded inner content. Removing the padding on collapse causes
+      // the SETTINGS label + nav items to flash to (0, 0) at the start of the transition.
+      expect(navCollapsed?.className).toMatch(/\bpx-4\b/);
+      expect(navCollapsed?.className).toMatch(/\bpy-5\b/);
     });
 
     it("collapsed content area pl matches sidebar-width + open-padding to keep centered text stationary", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #3557, #3573, #3579. With each prior fix, the user reported the content was still "flashing to the top." The previous fixes addressed the main content area (centered text staying anchored). This one fixes the **sidebar's own internal content** (SETTINGS header + General/Team/Integrations/Billing list).

The `<nav>` conditional swapped `w-48 px-4 py-5` (open) with `md:w-0 md:overflow-hidden md:border-r-0` (collapsed). Only `md:transition-[width]` was set, so the `px-4`/`py-5` padding was yanked instantly while width eased — the SETTINGS label and nav items snapped from (16, 20) to (0, 0) at the first frame before the eased width collapse caught up.

Move `px-4 py-5` to the always-on base classes. Width still animates 192→0 with `overflow-hidden`, but the inner content stays at (16, 20) and gets cleanly clipped right-to-left as the nav shrinks.

## Changelog

### Web Platform

- Fix: SETTINGS header and nav items no longer flash to the top-left of the sidebar at the start of the collapse animation — they stay in place and get clipped as the sidebar slides closed.

## Test plan

- [x] Unit tests: `apps/web-platform/test/settings-sidebar-collapse.test.tsx` → 19/19 green. New assert: padding is present in both open and collapsed states (the previous `not.toMatch(px-4)` assertion was locking in the bug).
- [x] `tsc --noEmit` clean on `apps/web-platform/`.
- [ ] ⏳ Visual verification deferred behind #3562. Same blocker as #3565.

Ref #3557, ref #3573, ref #3579

Generated with [Claude Code](https://claude.com/claude-code)
