### PR TITLE
fix(settings): collapse nav fully to 0 by moving padding to inner wrapper

### DIFF
--- a/apps/web-platform/components/settings/settings-shell.tsx
+++ b/apps/web-platform/components/settings/settings-shell.tsx
@@ -35,47 +35,49 @@ export function SettingsShell({ children }: { children: React.ReactNode }) {
       {/* Settings sidebar — hidden on mobile, shown on md+ */}
       <nav
         inert={settingsCollapsed || undefined}
-        className={`hidden shrink-0 border-r border-soleur-border-default px-4 py-5 md:block
+        className={`hidden shrink-0 border-r border-soleur-border-default md:block md:overflow-hidden
         md:transition-[width] md:duration-200 md:ease-out
-        ${settingsCollapsed ? "md:w-0 md:overflow-hidden md:border-r-0" : "w-48"}`}>
-        <div className="mb-4 flex min-h-7 items-center justify-between">
-          <h2 className="text-xs font-medium uppercase tracking-wider text-soleur-text-muted">
-            Settings
-          </h2>
-          <button
-            onClick={toggleSettingsCollapsed}
-            aria-label="Collapse settings nav"
-            title="Collapse settings nav (⌘B)"
-            className="flex h-6 w-6 items-center justify-center rounded text-soleur-text-secondary hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary"
-          >
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
-            </svg>
-          </button>
-        </div>
-        <ul className="space-y-1">
-          {SETTINGS_TABS.map((tab) => {
-            const active =
-              tab.href === "/dashboard/settings"
-                ? pathname === "/dashboard/settings"
-                : pathname.startsWith(tab.href);
+        ${settingsCollapsed ? "md:w-0 md:border-r-0" : "w-48"}`}>
+        <div className="w-48 px-4 py-5">
+          <div className="mb-4 flex min-h-7 items-center justify-between">
+            <h2 className="text-xs font-medium uppercase tracking-wider text-soleur-text-muted">
+              Settings
+            </h2>
+            <button
+              onClick={toggleSettingsCollapsed}
+              aria-label="Collapse settings nav"
+              title="Collapse settings nav (⌘B)"
+              className="flex h-6 w-6 items-center justify-center rounded text-soleur-text-secondary hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+              </svg>
+            </button>
+          </div>
+          <ul className="space-y-1">
+            {SETTINGS_TABS.map((tab) => {
+              const active =
+                tab.href === "/dashboard/settings"
+                  ? pathname === "/dashboard/settings"
+                  : pathname.startsWith(tab.href);
 
-            return (
-              <li key={tab.href}>
-                <Link
-                  href={tab.href}
-                  className={`block rounded-lg px-3 py-2 text-sm transition-colors ${
-                    active
-                      ? "bg-soleur-bg-surface-2 text-soleur-text-primary font-medium"
-                      : "text-soleur-text-secondary hover:bg-soleur-bg-surface-2/50 hover:text-soleur-text-primary"
-                  }`}
-                >
-                  {tab.label}
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
+              return (
+                <li key={tab.href}>
+                  <Link
+                    href={tab.href}
+                    className={`block rounded-lg px-3 py-2 text-sm transition-colors ${
+                      active
+                        ? "bg-soleur-bg-surface-2 text-soleur-text-primary font-medium"
+                        : "text-soleur-text-secondary hover:bg-soleur-bg-surface-2/50 hover:text-soleur-text-primary"
+                    }`}
+                  >
+                    {tab.label}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
       </nav>
 
       {/* Mobile tab bar */}

--- a/apps/web-platform/test/settings-sidebar-collapse.test.tsx
+++ b/apps/web-platform/test/settings-sidebar-collapse.test.tsx
@@ -115,13 +115,16 @@ describe("Settings sidebar collapse", () => {
   // Main nav header at apps/web-platform/app/(dashboard)/layout.tsx uses py-5;
   // the settings <nav> must match so both <` chevrons land on the same y-row.
   describe("collapse button alignment with main nav chevron (expanded state)", () => {
-    it("nav wrapper uses py-5 to align chevron y-origin with main nav header", () => {
+    it("inner wrapper uses py-5 to align chevron y-origin with main nav header", () => {
       render(<SettingsShell><div>content</div></SettingsShell>);
       const collapseBtn = screen.getByLabelText("Collapse settings nav");
-      const navEl = collapseBtn.closest("nav");
-      expect(navEl).not.toBeNull();
-      expect(navEl).toHaveClass("py-5");
-      expect(navEl?.className).not.toMatch(/\bpy-10\b/);
+      // The padding lives on the inner fixed-width wrapper, NOT the <nav> itself,
+      // so the nav can collapse to md:w-0 without the padding forcing a 32px sliver.
+      // The wrapper is `collapseBtn.parentElement.parentElement` (button → header div → wrapper).
+      const wrapperEl = collapseBtn.parentElement?.parentElement;
+      expect(wrapperEl).not.toBeNull();
+      expect(wrapperEl).toHaveClass("py-5");
+      expect(wrapperEl?.className).not.toMatch(/\bpy-10\b/);
     });
 
     it("collapse button keeps h-6 w-6 geometry matching main nav toggle", () => {
@@ -154,19 +157,20 @@ describe("Settings sidebar collapse", () => {
       expect(navEl?.className).toMatch(/\bmd:border-r-0\b/);
     });
 
-    it("nav padding is constant across open/collapsed so inner content doesn't jump to (0, 0) when collapsing", async () => {
-      const { rerender } = render(<SettingsShell><div>content</div></SettingsShell>);
+    it("nav has NO padding (so md:w-0 collapses fully) and inner wrapper has fixed w-48 px-4 py-5 so content position is stable", async () => {
+      render(<SettingsShell><div>content</div></SettingsShell>);
       const navEl = document.querySelector("nav");
-      expect(navEl?.className).toMatch(/\bpx-4\b/);
-      expect(navEl?.className).toMatch(/\bpy-5\b/);
-      await userEvent.click(screen.getByLabelText("Collapse settings nav"));
-      rerender(<SettingsShell><div>content</div></SettingsShell>);
-      const navCollapsed = document.querySelector("nav");
-      // Padding MUST remain across the toggle — width animates while overflow-hidden
-      // clips the still-padded inner content. Removing the padding on collapse causes
-      // the SETTINGS label + nav items to flash to (0, 0) at the start of the transition.
-      expect(navCollapsed?.className).toMatch(/\bpx-4\b/);
-      expect(navCollapsed?.className).toMatch(/\bpy-5\b/);
+      expect(navEl).not.toBeNull();
+      // Nav itself MUST NOT carry px-4/py-5 — with box-border + md:w-0, padding would
+      // force the box to a min visible width of 32px (a sliver of letters showing).
+      expect(navEl?.className).not.toMatch(/\bpx-4\b/);
+      expect(navEl?.className).not.toMatch(/\bpy-5\b/);
+      // The inner content wrapper holds the padding AND a fixed w-48 so the SETTINGS
+      // header + nav items stay at (16, 20) the whole transition; overflow-hidden on
+      // the nav clips the wrapper right-to-left as the nav width animates to 0.
+      const wrapperEl = navEl?.firstElementChild as HTMLElement | null;
+      expect(wrapperEl).not.toBeNull();
+      expect(wrapperEl).toHaveClass("w-48", "px-4", "py-5");
     });
 
     it("collapsed content area pl matches sidebar-width + open-padding to keep centered text stationary", async () => {


### PR DESCRIPTION
## Summary

PR #3584 fixed the "flash to top" by moving `px-4 py-5` to the nav's always-on base, but introduced a 32px sliver: with `box-sizing: border-box`, padding can't be negative, so `width: 0` + `padding-left/right: 16px` forces the box-border width to `max(0, 32) = 32px`. User saw the first letter of each nav item at the screen's left edge.

Structural fix in `apps/web-platform/components/settings/settings-shell.tsx`: nav itself has NO padding (so `md:w-0 md:overflow-hidden` fully collapses to 0). Padding moves to a new inner `<div className="w-48 px-4 py-5">` wrapper that's always 192px wide. The wrapper never resizes — SETTINGS header and nav items stay at (16, 20) the entire 200ms — and `overflow-hidden` on the nav clips the still-positioned wrapper right-to-left as the nav width animates from 192 to 0.

Per the flexbox spec, `overflow: hidden` nullifies the `min-width: auto` default, so the nav can reach 0 width without min-content forcing a minimum.

## Changelog

### Web Platform

- Fix: settings sidebar now collapses fully to 0 width with no residual sliver, while the SETTINGS header and nav items still stay anchored at their open-state position during the transition.

## Test plan

- [x] Unit tests: `apps/web-platform/test/settings-sidebar-collapse.test.tsx` → 19/19 green. Tests updated to reflect that padding lives on the inner wrapper, not the nav.
- [x] `tsc --noEmit` clean on `apps/web-platform/`.
- [ ] ⏳ Visual verification deferred behind #3562.

Ref #3557, ref #3573, ref #3579, ref #3584

Generated with [Claude Code](https://claude.com/claude-code)
