### PR TITLE
feat(infra): one-click GitHub Action to apply deploy_pipeline_fix

### DIFF
--- a/.github/workflows/apply-deploy-pipeline-fix.yml
+++ b/.github/workflows/apply-deploy-pipeline-fix.yml
@@ -1,0 +1,234 @@
+# Apply `terraform_data.deploy_pipeline_fix` from a one-click GitHub Actions
+# button so changes to host-resident deploy-pipeline files (ci-deploy.sh,
+# webhook.service, cat-deploy-state.sh, canary-bundle-claim-check.sh,
+# hooks.json.tmpl) can be propagated to the production VPS without a
+# terminal-typed `yes` prompt.
+#
+# Authorization model: workflow_dispatch + `environment: production`. Once
+# protection rules are added to the `production` environment (Settings →
+# Environments → production → Required reviewers), the reviewer-click is the
+# human-typed authorization that replaces the TTY `yes`.
+#
+# Initial run-blocking setup (one-time, performed via Doppler web UI):
+#   1. Doppler `soleur / prd_terraform` config must have a secret named
+#      `TERRAFORM_SSH_PRIVATE_KEY` containing the prod root SSH private key
+#      that authorizes connections to `hcloud_server.web`.
+#   2. The first workflow run with the secret missing will FAIL with a clear
+#      diagnostic at the "Verify Terraform SSH key" step. Add the secret and
+#      re-run.
+#
+# All workflow_dispatch inputs are routed through env vars before being
+# interpolated into shell — never directly into `run:` blocks. This matches
+# the project's CI workflow injection-prevention conventions.
+#
+# All action references are SHA-pinned.
+
+name: Apply deploy-pipeline-fix
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why are you applying? (e.g., 'PR #3601 ci-deploy.sh assertion')"
+        required: true
+        type: string
+
+concurrency:
+  group: terraform-apply-deploy-pipeline-fix
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  TERRAFORM_VERSION: "1.10.5"
+  INFRA_DIR: apps/web-platform/infra
+
+jobs:
+  apply:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment: production
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+
+      - name: Install Doppler CLI
+        uses: DopplerHQ/cli-action@5351693ec144fc7f7a2d30025061acfc3c53c47c # v4
+
+      - name: Verify DOPPLER_TOKEN
+        env:
+          DOPPLER_TOKEN_CHECK: ${{ secrets.DOPPLER_TOKEN }}
+        run: |
+          if [[ -z "$DOPPLER_TOKEN_CHECK" ]]; then
+            echo "::error::DOPPLER_TOKEN secret is not configured."
+            exit 1
+          fi
+
+      - name: Verify Terraform SSH key
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          DOPPLER_PROJECT: soleur
+          DOPPLER_CONFIG: prd_terraform
+        run: |
+          set -euo pipefail
+          if ! TF_SSH_KEY=$(doppler secrets get TERRAFORM_SSH_PRIVATE_KEY --plain 2>/dev/null) || [[ -z "$TF_SSH_KEY" ]]; then
+            cat <<'MSG'
+          ::error::Doppler secret TERRAFORM_SSH_PRIVATE_KEY is missing or empty.
+
+          One-time setup (browser only — no terminal required):
+            1. Open https://dashboard.doppler.com → project `soleur` → config `prd_terraform`.
+            2. Add a secret named TERRAFORM_SSH_PRIVATE_KEY whose value is the
+               root@hcloud_server.web SSH private key.
+            3. Re-run this workflow.
+
+          The key never leaves Doppler → ssh-agent within this job; it is not
+          written to the filesystem and is masked in logs.
+          MSG
+            exit 1
+          fi
+
+      - name: Extract backend credentials
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          DOPPLER_PROJECT: soleur
+          DOPPLER_CONFIG: prd_terraform
+        run: |
+          set -euo pipefail
+          KEY_ID=$(doppler secrets get AWS_ACCESS_KEY_ID --plain)
+          SECRET=$(doppler secrets get AWS_SECRET_ACCESS_KEY --plain)
+          printf '::add-mask::%s\n' "$KEY_ID"
+          printf '::add-mask::%s\n' "$SECRET"
+          printf 'AWS_ACCESS_KEY_ID=%s\n' "$KEY_ID" >> "$GITHUB_ENV"
+          printf 'AWS_SECRET_ACCESS_KEY=%s\n' "$SECRET" >> "$GITHUB_ENV"
+
+      - name: Generate CI public SSH key for var.ssh_key_path
+        run: |
+          ssh-keygen -t ed25519 -f /tmp/ci_ssh_key -N "" -q
+          printf 'CI_SSH_PUB=%s\n' "/tmp/ci_ssh_key.pub" >> "$GITHUB_ENV"
+
+      - name: Start ssh-agent with prod key
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          DOPPLER_PROJECT: soleur
+          DOPPLER_CONFIG: prd_terraform
+        run: |
+          set -euo pipefail
+          eval "$(ssh-agent -s)"
+          printf 'SSH_AUTH_SOCK=%s\n' "$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
+          printf 'SSH_AGENT_PID=%s\n' "$SSH_AGENT_PID" >> "$GITHUB_ENV"
+          doppler secrets get TERRAFORM_SSH_PRIVATE_KEY --plain | ssh-add - >/dev/null 2>&1
+          ssh-add -l >/dev/null
+
+      - name: Capture local hashes (pre-apply)
+        run: |
+          set -euo pipefail
+          sha256sum \
+            "${INFRA_DIR}/ci-deploy.sh" \
+            "${INFRA_DIR}/webhook.service" \
+            "${INFRA_DIR}/cat-deploy-state.sh" \
+            "${INFRA_DIR}/canary-bundle-claim-check.sh" \
+            > /tmp/local-hashes.txt
+          cat /tmp/local-hashes.txt
+
+      - name: Terraform init
+        working-directory: ${{ env.INFRA_DIR }}
+        run: terraform init -input=false
+
+      - name: Terraform plan (visibility before apply)
+        working-directory: ${{ env.INFRA_DIR }}
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          DOPPLER_PROJECT: soleur
+          DOPPLER_CONFIG: prd_terraform
+          REASON: ${{ inputs.reason }}
+        run: |
+          set -euo pipefail
+          echo "Reason: ${REASON}"
+          doppler run --name-transformer tf-var -- \
+            terraform plan -target=terraform_data.deploy_pipeline_fix \
+            -var="ssh_key_path=${CI_SSH_PUB}" \
+            -no-color -input=false
+
+      - name: Terraform apply (deploy_pipeline_fix only)
+        working-directory: ${{ env.INFRA_DIR }}
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          DOPPLER_PROJECT: soleur
+          DOPPLER_CONFIG: prd_terraform
+        run: |
+          set -euo pipefail
+          doppler run --name-transformer tf-var -- \
+            terraform apply -target=terraform_data.deploy_pipeline_fix \
+            -var="ssh_key_path=${CI_SSH_PUB}" \
+            -auto-approve -input=false
+
+      - name: Verify server-side file hashes match local
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          DOPPLER_PROJECT: soleur
+          DOPPLER_CONFIG: prd_terraform
+        working-directory: ${{ env.INFRA_DIR }}
+        run: |
+          set -euo pipefail
+          SERVER_IP=$(terraform output -raw server_ip)
+          printf '::add-mask::%s\n' "$SERVER_IP"
+
+          REMOTE_OUT=$(ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 \
+            root@"$SERVER_IP" \
+            "sha256sum /usr/local/bin/ci-deploy.sh /etc/systemd/system/webhook.service /usr/local/bin/cat-deploy-state.sh /usr/local/bin/canary-bundle-claim-check.sh && systemctl is-active webhook")
+          echo "Server-side state:"
+          echo "$REMOTE_OUT"
+
+          declare -A REMOTE
+          while read -r hash path; do
+            base=$(basename "$path")
+            REMOTE["$base"]="$hash"
+          done < <(printf '%s\n' "$REMOTE_OUT" | grep -E '^[a-f0-9]{64}  ')
+
+          MISMATCH=0
+          while read -r hash path; do
+            base=$(basename "$path")
+            r="${REMOTE[$base]:-}"
+            if [[ -z "$r" ]]; then
+              echo "::error::No remote hash recorded for $base"
+              MISMATCH=1
+            elif [[ "$r" != "$hash" ]]; then
+              echo "::error::Hash mismatch for $base: local=$hash remote=$r"
+              MISMATCH=1
+            else
+              echo "OK: $base hash matches ($hash)"
+            fi
+          done < /tmp/local-hashes.txt
+
+          if [[ "$MISMATCH" -ne 0 ]]; then
+            echo "::error::One or more files diverged between local and server post-apply."
+            exit 1
+          fi
+
+          if ! printf '%s\n' "$REMOTE_OUT" | tail -n 1 | grep -qx 'active'; then
+            echo "::error::systemctl is-active webhook returned non-'active' on the server."
+            exit 1
+          fi
+
+          echo "All trigger-file hashes match and webhook is active."
+
+      - name: Post-apply summary
+        if: always()
+        env:
+          REASON: ${{ inputs.reason }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "## Apply deploy-pipeline-fix"
+            echo ""
+            echo "**Reason:** ${REASON}"
+            echo "**Run:** ${RUN_URL}"
+            echo "**Status:** ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -505,7 +505,11 @@ If the grep matches at least one path, the gate fires. Trigger condition is "≥
 
 The PR's diff will produce drift on `terraform_data.deploy_pipeline_fix` — by design, because `hcloud_server.web` has `lifecycle.ignore_changes = [user_data]` (per `#967`) so cloud-init can't re-apply. The drift workflow (`scheduled-terraform-drift.yml`, cron `0 6,18 * * *`) will detect this on its next tick and auto-file an issue. The cleaner path is to schedule the apply to happen *with* the merge.
 
-Display this exact block to the operator:
+**Preferred path: one-click workflow.** Run the [`apply-deploy-pipeline-fix.yml`](../../../../.github/workflows/apply-deploy-pipeline-fix.yml) workflow via the GitHub Actions UI (`Actions → Apply deploy-pipeline-fix → Run workflow`). The workflow runs the targeted `terraform apply` with the credentials sourced from Doppler `prd_terraform`, then verifies server-side hashes match local trigger files and `webhook` is `active`. No terminal, no local Doppler/SSH setup. The first run requires a one-time browser-only setup (paste the prod SSH private key into Doppler as `TERRAFORM_SSH_PRIVATE_KEY`) — the workflow's "Verify Terraform SSH key" step fails with explicit instructions when the secret is missing.
+
+The local-terminal flow below is preserved as a fallback for operators who cannot use the workflow (e.g., the workflow's environment-protection reviewer is unavailable, or the Doppler secret has not yet been seeded). Issue #3618 tracks the deeper refactor that eliminates this whole class of host-resident-script drift (containerized deploy-orchestrator).
+
+Display this exact block to the operator (fallback path):
 
 ```text
 This PR edits `terraform_data.deploy_pipeline_fix` trigger files. Drift will be
@@ -552,18 +556,19 @@ plugins/soleur/skills/postmerge/references/deploy-status-debugging.md
 
 **Interactive mode:**
 
-Ask via AskUserQuestion: "Apply now (recommended), defer to operator post-merge, or skip?"
+Ask via AskUserQuestion: "Apply now via one-click workflow (recommended), apply locally via terminal (fallback), defer to operator post-merge, or skip?"
 
-- **Apply now:** Pause the ship pipeline until the operator confirms the apply ran. Do NOT execute the apply from this skill — the operator runs it in their own terminal so the Terraform `yes` prompt is in their TTY. (TTY hand-off is intentional: prod blast radius warrants a human-typed `yes` rather than `-auto-approve` plus an in-conversation confirmation menu, even though `hr-menu-option-ack-not-prod-write-auth` would technically permit the latter.)
-- **Defer:** Add a `gh pr comment` on the PR (deferred until Phase 6 has the PR number) tagged `[deploy_pipeline_fix-drift-gate]` with the apply command embedded so the next operator (post-merge) sees it.
+- **Apply now via workflow:** Open the [`apply-deploy-pipeline-fix.yml`](../../../../.github/workflows/apply-deploy-pipeline-fix.yml) workflow in the GitHub Actions UI and click "Run workflow." The reviewer-click on the `production` environment is the human authorization. Pause the ship pipeline until the workflow reports success (visible in the Actions tab).
+- **Apply locally via terminal:** Pause the ship pipeline until the operator confirms the apply ran. Do NOT execute the apply from this skill — the operator runs it in their own terminal so the Terraform `yes` prompt is in their TTY. (TTY hand-off is intentional: prod blast radius warrants a human-typed `yes` rather than `-auto-approve` plus an in-conversation confirmation menu, even though `hr-menu-option-ack-not-prod-write-auth` would technically permit the latter.)
+- **Defer:** Add a `gh pr comment` on the PR (deferred until Phase 6 has the PR number) tagged `[deploy_pipeline_fix-drift-gate]` with both remediation paths embedded so the next operator (post-merge) sees them.
 - **Skip:** Same as Defer plus a "skip rationale" sentence; the next drift cron tick will still file an issue as the safety net.
 
 **Headless mode:**
 
-Auto-defer. Try `gh pr comment` first. If `gh pr comment` exits non-zero (the most common cause is the workflow's `GITHUB_TOKEN` lacks `pull-requests: write`; soleur shipping workflows typically grant `contents: read` + `issues: write` only), fall back to writing the tracking message into both stderr and `$GITHUB_STEP_SUMMARY` so it appears in the workflow's Summary tab. Do NOT abort the ship pipeline — the 12h drift cron remains the eventual safety net.
+Auto-defer. Try `gh pr comment` first. If `gh pr comment` exits non-zero (the most common cause is the workflow's `GITHUB_TOKEN` lacks `pull-requests: write`; soleur shipping workflows typically grant `contents: read` + `issues: write` only), fall back to writing the tracking message into both stderr and `$GITHUB_STEP_SUMMARY` so it appears in the workflow's Summary tab. Do NOT abort the ship pipeline — the 12h drift cron remains the eventual safety net. The tracking message names the one-click workflow first so a non-technical operator can click through without a terminal.
 
 ```bash
-TRACKING_MSG="[deploy_pipeline_fix-drift-gate] PR touches a trigger file. Run: doppler run -p soleur -c prd_terraform -- terraform apply -target=terraform_data.deploy_pipeline_fix -input=true"
+TRACKING_MSG="[deploy_pipeline_fix-drift-gate] PR touches a trigger file. Preferred: run the 'Apply deploy-pipeline-fix' workflow in the GitHub Actions UI (Actions tab → Apply deploy-pipeline-fix → Run workflow). Fallback: doppler run -p soleur -c prd_terraform -- terraform apply -target=terraform_data.deploy_pipeline_fix -input=true"
 if ! gh pr comment "$PR_NUMBER" --body "$TRACKING_MSG" 2>/dev/null; then
   echo "$TRACKING_MSG" >&2
   if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then


### PR DESCRIPTION
## Summary

Adds a one-click GitHub Action that applies `terraform_data.deploy_pipeline_fix` so changes to host-resident deploy-pipeline files (`ci-deploy.sh`, `webhook.service`, `cat-deploy-state.sh`, `canary-bundle-claim-check.sh`, `hooks.json.tmpl`) propagate to the production VPS without a terminal-typed `yes` prompt. The reviewer-click on the GitHub `production` environment is the human authorization that replaces the TTY hand-off.

Follow-up to PR #3601 (ADR-027 ci-deploy.sh assertion still needs to be applied to the VPS) and the recurring drift documented in `2026-04-24-recurring-deploy-pipeline-fix-drift-as-feature.md` (9 cycles in 6 weeks).

Ref #3618 (deeper architectural refactor — containerize deploy-orchestrator — tracked separately).

## User-Brand Impact

- **If this lands broken, the user experiences:** the workflow fails on first run; operator falls back to the existing terminal-based flow (which still works). No user-facing impact.
- **If this leaks, the user's data is exposed via:** the workflow handles the prod SSH private key in a `ssh-agent` loaded from a Doppler-injected pipe — never written to the filesystem. GitHub job logs are masked. The standard supply-chain risk for any workflow that holds prod creds applies; mitigated by SHA-pinned actions and `environment: production` for reviewer-gating once protection rules are added.
- **Brand-survival threshold:** `none`
- threshold: none, reason: a workflow file that fails closed when secrets are missing. Adds no new user-facing surface; the only runtime privilege expansion is loading an existing SSH key into a CI-side ssh-agent, with the action SHA-pinned and the key never persisted to disk. Failure mode = the operator falls back to the pre-existing terminal flow.

## Changelog

### Infrastructure

- New workflow `.github/workflows/apply-deploy-pipeline-fix.yml` — `workflow_dispatch` trigger, `environment: production`, runs `terraform apply -target=terraform_data.deploy_pipeline_fix -auto-approve` from Doppler `prd_terraform`, then verifies server-side hashes + `systemctl is-active webhook`. The reviewer-click on the `production` environment becomes the human authorization (TTY hand-off equivalent).
- Ship skill `Deploy Pipeline Fix Drift Gate` now surfaces the workflow as the preferred path, with the terminal command preserved as fallback for operators who cannot use the workflow.

## Setup required (one-time, browser only)

The first workflow run will fail with explicit instructions until the founder pastes the prod SSH private key into Doppler:

1. Open https://dashboard.doppler.com → project `soleur` → config `prd_terraform`.
2. Add a secret named `TERRAFORM_SSH_PRIVATE_KEY` whose value is the `root@hcloud_server.web` SSH private key.
3. (Optional but recommended) GitHub → Settings → Environments → `production` → Required reviewers — add yourself so the workflow blocks for a click before applying.

After step (1), every future ship of a deploy-pipeline trigger file becomes one click in the GitHub Actions UI. No terminal, no local Doppler/SSH setup.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/apply-deploy-pipeline-fix.yml'))"` — YAML parses.
- [x] `bash scripts/test-all.sh` — 36/36 suites pass.
- [x] All workflow uses of `${{ inputs.reason }}` are routed through `env:` before reaching shell — matches the project's CI injection-prevention conventions.
- [x] Workflow uses SHA-pinned actions (`actions/checkout`, `hashicorp/setup-terraform`, `DopplerHQ/cli-action`).
- [ ] ⏳ Post-merge: founder adds `TERRAFORM_SSH_PRIVATE_KEY` to Doppler `prd_terraform`, then runs the workflow once to apply PR #3601's pending ci-deploy.sh changes to the VPS. The `infra-drift` issue auto-filed by `scheduled-terraform-drift.yml` will close on next drift-check tick after the apply lands.

Generated with [Claude Code](https://claude.com/claude-code)
