### PR TITLE
feat(infra): auto-apply deploy_pipeline_fix on merge (zero-touch)

### DIFF
--- a/.github/workflows/apply-deploy-pipeline-fix.yml
+++ b/.github/workflows/apply-deploy-pipeline-fix.yml
@@ -1,35 +1,48 @@
-# Apply `terraform_data.deploy_pipeline_fix` from a one-click GitHub Actions
-# button so changes to host-resident deploy-pipeline files (ci-deploy.sh,
-# webhook.service, cat-deploy-state.sh, canary-bundle-claim-check.sh,
-# hooks.json.tmpl) can be propagated to the production VPS without a
-# terminal-typed `yes` prompt.
+# Auto-apply `terraform_data.deploy_pipeline_fix` whenever a PR that touches
+# the host-resident deploy-pipeline trigger files merges to main. This
+# eliminates the "edit script → drift on next 12h cron → manually apply"
+# cycle documented in:
+#   knowledge-base/project/learnings/bug-fixes/2026-04-24-recurring-deploy-pipeline-fix-drift-as-feature.md
 #
-# Authorization model: workflow_dispatch + `environment: production`. Once
-# protection rules are added to the `production` environment (Settings →
-# Environments → production → Required reviewers), the reviewer-click is the
-# human-typed authorization that replaces the TTY `yes`.
+# Authorization model: the PR merge IS the human authorization. Same model as
+# `web-platform-release.yml` — the reviewer's approval click on the merge
+# button is the load-bearing `yes`, replacing the in-terminal Terraform
+# prompt. Restricted to the 5 trigger files via the `paths:` filter so
+# unrelated merges (app code, docs, plugin changes) never write prod.
 #
-# Initial run-blocking setup (one-time, performed via Doppler web UI):
-#   1. Doppler `soleur / prd_terraform` config must have a secret named
-#      `TERRAFORM_SSH_PRIVATE_KEY` containing the prod root SSH private key
-#      that authorizes connections to `hcloud_server.web`.
-#   2. The first workflow run with the secret missing will FAIL with a clear
-#      diagnostic at the "Verify Terraform SSH key" step. Add the secret and
-#      re-run.
+# Kill switch: include `[skip-deploy-fix-apply]` anywhere in a commit message
+# on the PR to skip auto-apply for that merge (e.g., when the change is
+# intentionally not meant to land on prod yet).
 #
-# All workflow_dispatch inputs are routed through env vars before being
-# interpolated into shell — never directly into `run:` blocks. This matches
-# the project's CI workflow injection-prevention conventions.
+# Manual escape hatch: `workflow_dispatch` is kept for re-runs after a
+# transient failure or for ad-hoc applies.
 #
-# All action references are SHA-pinned.
+# Doppler `prd_terraform` config provides:
+#   - HCLOUD_TOKEN          (via doppler run --name-transformer tf-var)
+#   - AWS_ACCESS_KEY_ID     (R2 backend)
+#   - AWS_SECRET_ACCESS_KEY (R2 backend)
+#   - DEPLOY_SSH_PRIVATE_KEY (auth for remote-exec; matches DEPLOY_SSH_PUBLIC_KEY
+#                             already registered with the server via cloud-init)
+#
+# All untrusted inputs (commit messages, workflow_dispatch inputs) are routed
+# through env vars before reaching any `run:` block — CI workflow
+# injection-prevention convention. All action references are SHA-pinned.
 
 name: Apply deploy-pipeline-fix
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/web-platform/infra/ci-deploy.sh"
+      - "apps/web-platform/infra/webhook.service"
+      - "apps/web-platform/infra/cat-deploy-state.sh"
+      - "apps/web-platform/infra/canary-bundle-claim-check.sh"
+      - "apps/web-platform/infra/hooks.json.tmpl"
   workflow_dispatch:
     inputs:
       reason:
-        description: "Why are you applying? (e.g., 'PR #3601 ci-deploy.sh assertion')"
+        description: "Why are you applying? (manual re-run only)"
         required: true
         type: string
 
@@ -46,10 +59,28 @@ env:
   INFRA_DIR: apps/web-platform/infra
 
 jobs:
+  preflight:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 1
+    outputs:
+      skip: ${{ steps.kill_switch.outputs.skip }}
+    steps:
+      - id: kill_switch
+        env:
+          HEAD_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          if [[ "$HEAD_MSG" == *"[skip-deploy-fix-apply]"* ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Kill switch detected in commit message — skipping apply."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
   apply:
+    needs: preflight
+    if: needs.preflight.outputs.skip != 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    environment: production
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -71,26 +102,15 @@ jobs:
             exit 1
           fi
 
-      - name: Verify Terraform SSH key
+      - name: Verify Deploy SSH key
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
           DOPPLER_PROJECT: soleur
           DOPPLER_CONFIG: prd_terraform
         run: |
           set -euo pipefail
-          if ! TF_SSH_KEY=$(doppler secrets get TERRAFORM_SSH_PRIVATE_KEY --plain 2>/dev/null) || [[ -z "$TF_SSH_KEY" ]]; then
-            cat <<'MSG'
-          ::error::Doppler secret TERRAFORM_SSH_PRIVATE_KEY is missing or empty.
-
-          One-time setup (browser only — no terminal required):
-            1. Open https://dashboard.doppler.com → project `soleur` → config `prd_terraform`.
-            2. Add a secret named TERRAFORM_SSH_PRIVATE_KEY whose value is the
-               root@hcloud_server.web SSH private key.
-            3. Re-run this workflow.
-
-          The key never leaves Doppler → ssh-agent within this job; it is not
-          written to the filesystem and is masked in logs.
-          MSG
+          if ! KEY=$(doppler secrets get DEPLOY_SSH_PRIVATE_KEY --plain 2>/dev/null) || [[ -z "$KEY" ]]; then
+            echo "::error::Doppler secret DEPLOY_SSH_PRIVATE_KEY is missing or empty. See workflow header for setup."
             exit 1
           fi
 
@@ -113,7 +133,7 @@ jobs:
           ssh-keygen -t ed25519 -f /tmp/ci_ssh_key -N "" -q
           printf 'CI_SSH_PUB=%s\n' "/tmp/ci_ssh_key.pub" >> "$GITHUB_ENV"
 
-      - name: Start ssh-agent with prod key
+      - name: Start ssh-agent with deploy key
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
           DOPPLER_PROJECT: soleur
@@ -123,7 +143,7 @@ jobs:
           eval "$(ssh-agent -s)"
           printf 'SSH_AUTH_SOCK=%s\n' "$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
           printf 'SSH_AGENT_PID=%s\n' "$SSH_AGENT_PID" >> "$GITHUB_ENV"
-          doppler secrets get TERRAFORM_SSH_PRIVATE_KEY --plain | ssh-add - >/dev/null 2>&1
+          doppler secrets get DEPLOY_SSH_PRIVATE_KEY --plain | ssh-add - >/dev/null 2>&1
           ssh-add -l >/dev/null
 
       - name: Capture local hashes (pre-apply)
@@ -141,22 +161,20 @@ jobs:
         working-directory: ${{ env.INFRA_DIR }}
         run: terraform init -input=false
 
-      - name: Terraform plan (visibility before apply)
+      - name: Terraform plan
         working-directory: ${{ env.INFRA_DIR }}
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
           DOPPLER_PROJECT: soleur
           DOPPLER_CONFIG: prd_terraform
-          REASON: ${{ inputs.reason }}
         run: |
           set -euo pipefail
-          echo "Reason: ${REASON}"
           doppler run --name-transformer tf-var -- \
             terraform plan -target=terraform_data.deploy_pipeline_fix \
             -var="ssh_key_path=${CI_SSH_PUB}" \
             -no-color -input=false
 
-      - name: Terraform apply (deploy_pipeline_fix only)
+      - name: Terraform apply
         working-directory: ${{ env.INFRA_DIR }}
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
@@ -219,16 +237,34 @@ jobs:
 
           echo "All trigger-file hashes match and webhook is active."
 
+      - name: Auto-close any open drift issues for this stack
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          issues=$(gh issue list --label "infra-drift" --state open \
+            --search "infra: drift detected in web-platform in:title" \
+            --json number --jq '.[].number')
+          for n in $issues; do
+            gh issue comment "$n" --body "Auto-closed by \`apply-deploy-pipeline-fix.yml\` after merge ${MERGE_SHA}. Server state was re-aligned with HEAD."
+            gh issue close "$n" --reason completed
+            echo "Closed #$n"
+          done
+
       - name: Post-apply summary
         if: always()
         env:
-          REASON: ${{ inputs.reason }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REASON: ${{ inputs.reason }}
         run: |
           {
             echo "## Apply deploy-pipeline-fix"
             echo ""
-            echo "**Reason:** ${REASON}"
-            echo "**Run:** ${RUN_URL}"
+            echo "**Trigger:** ${{ github.event_name }}"
+            echo "**Merge SHA:** ${{ github.sha }}"
+            echo "**Reason (manual only):** ${REASON:-n/a}"
             echo "**Status:** ${{ job.status }}"
+            echo "**Run:** ${RUN_URL}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -503,13 +503,13 @@ If the grep matches at least one path, the gate fires. Trigger condition is "≥
 
 **If triggered:**
 
-The PR's diff will produce drift on `terraform_data.deploy_pipeline_fix` — by design, because `hcloud_server.web` has `lifecycle.ignore_changes = [user_data]` (per `#967`) so cloud-init can't re-apply. The drift workflow (`scheduled-terraform-drift.yml`, cron `0 6,18 * * *`) will detect this on its next tick and auto-file an issue. The cleaner path is to schedule the apply to happen *with* the merge.
+The PR's diff will produce drift on `terraform_data.deploy_pipeline_fix` — by design, because `hcloud_server.web` has `lifecycle.ignore_changes = [user_data]` (per `#967`) so cloud-init can't re-apply.
 
-**Preferred path: one-click workflow.** Run the [`apply-deploy-pipeline-fix.yml`](../../../../.github/workflows/apply-deploy-pipeline-fix.yml) workflow via the GitHub Actions UI (`Actions → Apply deploy-pipeline-fix → Run workflow`). The workflow runs the targeted `terraform apply` with the credentials sourced from Doppler `prd_terraform`, then verifies server-side hashes match local trigger files and `webhook` is `active`. No terminal, no local Doppler/SSH setup. The first run requires a one-time browser-only setup (paste the prod SSH private key into Doppler as `TERRAFORM_SSH_PRIVATE_KEY`) — the workflow's "Verify Terraform SSH key" step fails with explicit instructions when the secret is missing.
+**Auto-apply on merge.** The [`apply-deploy-pipeline-fix.yml`](../../../../.github/workflows/apply-deploy-pipeline-fix.yml) workflow auto-fires on push to `main` when any of the 5 trigger files change. It runs the targeted `terraform apply` from Doppler `prd_terraform`, verifies server-side hashes match the merged tree, and auto-closes any open `infra: drift detected in web-platform` issue. **Zero operator action required** post-merge — the PR review is the human authorization. Kill switch: include `[skip-deploy-fix-apply]` in any commit message on the PR to suppress the apply for that merge.
 
-The local-terminal flow below is preserved as a fallback for operators who cannot use the workflow (e.g., the workflow's environment-protection reviewer is unavailable, or the Doppler secret has not yet been seeded). Issue #3618 tracks the deeper refactor that eliminates this whole class of host-resident-script drift (containerized deploy-orchestrator).
+This gate's role is now purely informational: surface that the PR will trigger the auto-apply, and confirm the operator has not used the kill-switch unintentionally. Issue #3618 tracks the deeper refactor that eliminates the `terraform_data.deploy_pipeline_fix` pattern entirely (containerized deploy-orchestrator).
 
-Display this exact block to the operator (fallback path):
+The local-terminal flow below is preserved as a documented fallback for the rare case where the auto-apply fails (transient network, Hetzner outage, terraform state lock). Display this block to the operator only when the auto-apply has actually failed:
 
 ```text
 This PR edits `terraform_data.deploy_pipeline_fix` trigger files. Drift will be
@@ -556,19 +556,14 @@ plugins/soleur/skills/postmerge/references/deploy-status-debugging.md
 
 **Interactive mode:**
 
-Ask via AskUserQuestion: "Apply now via one-click workflow (recommended), apply locally via terminal (fallback), defer to operator post-merge, or skip?"
-
-- **Apply now via workflow:** Open the [`apply-deploy-pipeline-fix.yml`](../../../../.github/workflows/apply-deploy-pipeline-fix.yml) workflow in the GitHub Actions UI and click "Run workflow." The reviewer-click on the `production` environment is the human authorization. Pause the ship pipeline until the workflow reports success (visible in the Actions tab).
-- **Apply locally via terminal:** Pause the ship pipeline until the operator confirms the apply ran. Do NOT execute the apply from this skill — the operator runs it in their own terminal so the Terraform `yes` prompt is in their TTY. (TTY hand-off is intentional: prod blast radius warrants a human-typed `yes` rather than `-auto-approve` plus an in-conversation confirmation menu, even though `hr-menu-option-ack-not-prod-write-auth` would technically permit the latter.)
-- **Defer:** Add a `gh pr comment` on the PR (deferred until Phase 6 has the PR number) tagged `[deploy_pipeline_fix-drift-gate]` with both remediation paths embedded so the next operator (post-merge) sees them.
-- **Skip:** Same as Defer plus a "skip rationale" sentence; the next drift cron tick will still file an issue as the safety net.
+Inform the operator: "PR touches `terraform_data.deploy_pipeline_fix` trigger file(s). The `apply-deploy-pipeline-fix.yml` workflow will auto-apply on merge — no action required. Kill switch: add `[skip-deploy-fix-apply]` to a commit message if you want to defer the apply." Proceed to Phase 6 without blocking on user input.
 
 **Headless mode:**
 
-Auto-defer. Try `gh pr comment` first. If `gh pr comment` exits non-zero (the most common cause is the workflow's `GITHUB_TOKEN` lacks `pull-requests: write`; soleur shipping workflows typically grant `contents: read` + `issues: write` only), fall back to writing the tracking message into both stderr and `$GITHUB_STEP_SUMMARY` so it appears in the workflow's Summary tab. Do NOT abort the ship pipeline — the 12h drift cron remains the eventual safety net. The tracking message names the one-click workflow first so a non-technical operator can click through without a terminal.
+Same as interactive — surface a tracking comment on the PR noting the auto-apply will fire on merge, then proceed. The comment also names the kill-switch and the fallback terminal command for the rare auto-apply failure case.
 
 ```bash
-TRACKING_MSG="[deploy_pipeline_fix-drift-gate] PR touches a trigger file. Preferred: run the 'Apply deploy-pipeline-fix' workflow in the GitHub Actions UI (Actions tab → Apply deploy-pipeline-fix → Run workflow). Fallback: doppler run -p soleur -c prd_terraform -- terraform apply -target=terraform_data.deploy_pipeline_fix -input=true"
+TRACKING_MSG=$'[deploy_pipeline_fix-drift-gate] This PR touches a trigger file. `apply-deploy-pipeline-fix.yml` will auto-apply on merge — no action required. To skip the auto-apply, add `[skip-deploy-fix-apply]` to a commit message. If the auto-apply fails (transient outage), run the workflow manually from the Actions tab, or as a last resort: `doppler run -p soleur -c prd_terraform -- terraform apply -target=terraform_data.deploy_pipeline_fix -input=true`.'
 if ! gh pr comment "$PR_NUMBER" --body "$TRACKING_MSG" 2>/dev/null; then
   echo "$TRACKING_MSG" >&2
   if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then


### PR DESCRIPTION
## Summary

Converts `apply-deploy-pipeline-fix.yml` from a one-click `workflow_dispatch` to a zero-click `on: push: branches: [main]` trigger with a paths filter restricted to the 5 host-resident deploy-pipeline files. The PR merge becomes the human authorization (same model as `web-platform-release.yml`). After this merges:

- **Editing `ci-deploy.sh` or sibling trigger files:** open PR → merge → done. No clicks, no terminal.
- **Suppressing the apply for a specific PR:** include `[skip-deploy-fix-apply]` in any commit message on the branch.
- **Failed auto-apply:** workflow_dispatch is kept as the manual escape hatch for re-runs.

Follow-up to PR #3619 (which I just merged with the one-click model). The user pushed back: a one-click setup that requires a terminal-y SSH-key paste + GitHub environment configuration is still N manual steps when the right answer is zero. This PR is the actual zero-touch path I should have shipped first.

Ref #3618 (deeper containerized-deploy-orchestrator refactor remains the long-term architectural goal).

## User-Brand Impact

- **If this lands broken, the user experiences:** auto-apply fails on a future merge; the existing 12h drift cron remains the safety net AND the manual workflow_dispatch escape hatch is preserved. No user-facing impact.
- **If this leaks, the user's data is exposed via:** the workflow uses the same Doppler-injected SSH key + R2 backend creds as PR #3619 — no new secrets surface. Removing the `environment: production` reviewer-click trades that explicit gate for the PR-merge gate (already trusted for app-container deploys via `web-platform-release.yml`). The `paths:` filter prevents unrelated merges from triggering prod writes.
- **Brand-survival threshold:** `none`
- threshold: none, reason: a workflow trigger change + secret-rename refactor. The five trigger files are unchanged in semantics; only the apply mechanism is automated. Failure modes are bounded by the same hash-verification and `systemctl is-active` checks that PR #3619 already shipped.

## Changelog

### Infrastructure

- `apply-deploy-pipeline-fix.yml` trigger flipped from `workflow_dispatch` to `push: branches: [main]` with paths filter on the 5 trigger files. `workflow_dispatch` kept as a manual escape hatch.
- New `preflight` job reads `[skip-deploy-fix-apply]` from `github.event.head_commit.message` (routed through env per CI injection-prevention convention) and short-circuits the `apply` job if present.
- New `Auto-close drift issues` step closes any open `infra: drift detected in web-platform` issue on successful apply — eliminates the "drift filed by cron / closed manually after apply" loop.
- Secret reference renamed `TERRAFORM_SSH_PRIVATE_KEY` → `DEPLOY_SSH_PRIVATE_KEY` to match the existing `DEPLOY_SSH_PUBLIC_KEY` naming in Doppler `prd_terraform`. Single key pair, one naming convention.
- `environment: production` removed — the PR merge is the human authorization, same model as `web-platform-release.yml`.
- `permissions: issues: write` retained (needed for the drift-issue auto-close step).

### Ship skill

- Deploy Pipeline Fix Drift Gate is now informational: surface that the merge will auto-apply, name the kill-switch, proceed to Phase 6 without blocking. Interactive and headless modes both leave a single tracking comment on the PR.

## Setup status

`DEPLOY_SSH_PRIVATE_KEY` was uploaded to Doppler `soleur / prd_terraform` earlier in this session. No additional setup required.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses.
- [x] `bash scripts/test-all.sh` — 36/36 suites pass.
- [x] All untrusted inputs (`github.event.head_commit.message`, `inputs.reason`) routed through `env:` before reaching `run:` blocks.
- [x] `Doppler has DEPLOY_SSH_PRIVATE_KEY = true` confirmed via `doppler secrets --json | jq has(...)` (value not displayed).
- [ ] ⏳ Post-merge: the workflow will fire on this PR's own merge (PR diff touches `apply-deploy-pipeline-fix.yml` and `plugins/soleur/skills/ship/SKILL.md` — neither matches the paths filter, so it will NOT fire on this merge). The first real test will be the next PR that touches `apps/web-platform/infra/ci-deploy.sh` or a sibling trigger file.
- [ ] ⏳ Post-merge: PR #3601's ADR-027 ci-deploy.sh change has been merged but not yet applied to the VPS. To apply it via the new model, run `gh workflow run apply-deploy-pipeline-fix.yml -f reason='PR #3601 ci-deploy.sh ADR-027 assertion'` once after this PR merges. (After this PR, the next ci-deploy.sh edit will auto-apply with no command needed.)

Generated with [Claude Code](https://claude.com/claude-code)
