### PR TITLE
fix(ci): recover lost #3624 fix commits — actual workflow + cache-key change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,10 @@ jobs:
   # detect-changes: drives the if:-gate on critical-css-gate. Mirrors the
   # infra-validation.yml pattern (single boolean output instead of matrix).
   # Cheap (one checkout + one git diff). See #3624.
-  # BASE_REF is the PR target branch (controlled enum, not user content) and
-  # is passed via env: + quoted "$BASE_REF" per workflow-injection guidance.
+  # BASE_REF is only set on pull_request events; we short-circuit on other
+  # events (push / workflow_dispatch) before referencing it. It is passed
+  # via env: + quoted "$BASE_REF" per workflow-injection guidance — see
+  # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions.
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
@@ -40,6 +42,12 @@ jobs:
             printf 'docs=true\n' >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # Path anchors mirror .github/workflows/deploy-docs.yml's on.push.paths
+          # (docs/skills/agents/commands/eleventy.config.js). The ci|deploy-docs
+          # workflow self-trigger is an intentional addition NOT in deploy-docs:
+          # edits to the gate workflow itself must run the gate to prevent
+          # silent gate-bypass on gate-logic changes. Keep this list in sync
+          # with deploy-docs.yml's paths: when adding new docs source trees.
           CHANGED=$(git diff --name-only "origin/${BASE_REF}...HEAD")
           if printf '%s\n' "$CHANGED" | grep -qE '^(plugins/soleur/(docs|skills|agents|commands)/|eleventy\.config\.js$|\.github/workflows/(ci|deploy-docs)\.yml$)'; then
             printf 'docs=true\n' >> "$GITHUB_OUTPUT"
@@ -264,6 +272,11 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
+          # Cache key MUST track the Playwright npm version (lives in
+          # package-lock.json), NOT the consumer script. The cache-hit branch
+          # runs only `npx playwright install-deps chromium` (OS deps), not
+          # the binary — keying on screenshot-gate.mjs let stale browser
+          # binaries persist across Playwright bumps. See #3624.
           key: playwright-critical-css-gate-${{ hashFiles('package-lock.json') }}
 
       - name: Install Playwright + http-server (cache miss)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,36 @@ jobs:
       - name: Verify README component counts match filesystem
         run: bash scripts/sync-readme-counts.sh --check
 
+  # detect-changes: drives the if:-gate on critical-css-gate. Mirrors the
+  # infra-validation.yml pattern (single boolean output instead of matrix).
+  # Cheap (one checkout + one git diff). See #3624.
+  # BASE_REF is the PR target branch (controlled enum, not user content) and
+  # is passed via env: + quoted "$BASE_REF" per workflow-injection guidance.
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            # push to main / workflow_dispatch: always run (main is source of truth).
+            printf 'docs=true\n' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CHANGED=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+          if printf '%s\n' "$CHANGED" | grep -qE '^(plugins/soleur/(docs|skills|agents|commands)/|eleventy\.config\.js$|\.github/workflows/(ci|deploy-docs)\.yml$)'; then
+            printf 'docs=true\n' >> "$GITHUB_OUTPUT"
+          else
+            printf 'docs=false\n' >> "$GITHUB_OUTPUT"
+          fi
+
   lint-bot-statuses:
     runs-on: ubuntu-latest
     steps:
@@ -198,7 +228,10 @@ jobs:
 
   # Pre-merge variant of the deploy-docs critical-CSS gate. Catches FOUC-class
   # regressions before merge, not after — see AGENTS.md cq-eleventy-critical-css-screenshot-gate.
+  # Scoped to docs-touching PRs via detect-changes (see #3624).
   critical-css-gate:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -231,7 +264,7 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-critical-css-gate-${{ hashFiles('plugins/soleur/docs/scripts/screenshot-gate.mjs') }}
+          key: playwright-critical-css-gate-${{ hashFiles('package-lock.json') }}
 
       - name: Install Playwright + http-server (cache miss)
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,6 +3,10 @@ name: Deploy Documentation to GitHub Pages
 on:
   push:
     branches: [main]
+    # Keep this list in sync with the path-filter regex in
+    # .github/workflows/ci.yml's detect-changes job — both gate the same
+    # docs/Eleventy surface (critical-css-gate pre-merge, this workflow
+    # post-merge). See #3624.
     paths:
       - 'plugins/soleur/docs/**'
       - 'plugins/soleur/agents/**'

--- a/knowledge-base/project/learnings/best-practices/2026-05-12-ci-playwright-cache-key-must-track-npm-version-not-script-hash.md
+++ b/knowledge-base/project/learnings/best-practices/2026-05-12-ci-playwright-cache-key-must-track-npm-version-not-script-hash.md
@@ -1,0 +1,67 @@
+---
+module: System
+date: 2026-05-12
+problem_type: best_practice
+component: ci
+symptoms:
+  - "critical-css-gate fails on PRs that do not touch docs (Playwright chromium binary missing)"
+  - "browserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium_headless_shell-1223/chrome-headless-shell-linux64/chrome-headless-shell"
+  - "actions/cache restores a stale Playwright browser tree across Playwright version bumps"
+root_cause: config_error
+resolution_type: config_change
+severity: medium
+tags: [ci, playwright, cache-key, workflow-conditional, paths-filter, github-actions]
+---
+
+# CI Playwright Cache Key Must Track npm Version, Not Consumer Script Hash
+
+## Problem
+
+Two independent bugs in `.github/workflows/ci.yml`'s `critical-css-gate` combined to fail PRs that had no business running the gate at all:
+
+1. **No path filter on the job.** The gate ran on every PR — including server-only or test-only diffs — paying ~50 s of CI time per irrelevant run and (on staleness) failing them outright.
+2. **Cache key invariant to Playwright version.** The cache key hashed `screenshot-gate.mjs` (the consumer script), which never references the Playwright version. The cache-hit branch ran only `npx playwright install-deps chromium` (OS deps, not the binary), so when upstream Playwright shipped a new chromium revision (`chromium_headless_shell-1223` → next), the cached binary went stale and every cache-hit run failed with `Executable doesn't exist at /home/runner/.cache/ms-playwright/...`. No one would notice until the next time someone edited `screenshot-gate.mjs` (which busted the cache and forced a fresh install).
+
+PR #3602 (a server-only diff to `apps/web-platform/server/cc-dispatcher.ts`) hit both failures simultaneously: the gate had no business running, but it ran, and it failed on the stale binary. `/soleur:ship` Phase 7 correctly refused to bypass the failure, blocking auto-merge.
+
+## Two Lessons
+
+### Lesson 1 — Workflow-level `paths:` gates ALL jobs; use a per-job conditional when one workflow houses unrelated jobs
+
+`ci.yml` houses 11+ jobs (`test`, `e2e`, `lint-*`, `web-platform-build`, `critical-css-gate`, …). A workflow-level `on.pull_request.paths` filter would orphan required checks (`test`, `e2e`, `CodeQL`, `skill-security-scan PR gate`) on non-docs PRs. The correct shape is a small `detect-changes` job emitting a boolean output, then `needs: detect-changes` + `if: needs.detect-changes.outputs.docs == 'true'` on the single job that should be conditional.
+
+The in-repo precedent is `.github/workflows/infra-validation.yml:24-52`, which uses the same hand-rolled `actions/checkout@<pin>` + `fetch-depth: 0` + `git diff --name-only "origin/${BASE_REF}...HEAD"` shape (with a matrix-shaped output instead of a single boolean). Adopting `dorny/paths-filter@v3` was considered but rejected: it would have been the first usage of that action in the repo, triggering a vendor-pin obligation, when the hand-rolled pattern already works.
+
+**`fetch-depth: 0` is mandatory.** Default `fetch-depth: 1` (shallow clone) makes `git diff --name-only "origin/${BASE_REF}...HEAD"` return nothing — the filter would silently always-skip on PRs.
+
+### Lesson 2 — Playwright cache key must include something that advances with the Playwright version
+
+Playwright's browser binaries are versioned by chromium revision (`chromium_headless_shell-1223`), not by npm package version directly. But the npm package version IS the source of truth — bump `playwright@1.X.Y` → npm install pulls a new binary; lockfile hash changes. So the cache key must include the lockfile (or any file whose hash advances on a Playwright bump).
+
+| Pattern | Cache key behavior | Verdict |
+|---|---|---|
+| `hashFiles('screenshot-gate.mjs')` | Invariant to Playwright version | **Wrong** — went stale silently |
+| `hashFiles('package-lock.json')` | Advances on every Playwright bump | **Right** — caches refresh on bump |
+| `hashFiles('apps/web-platform/bun.lock')` | Right for the `e2e` job (bun-mediated install) | Wrong here — the critical-CSS gate installs via `npm install --no-save playwright@1` against the root `package-lock.json` |
+| Drop cache entirely (match `deploy-docs.yml`) | Zero invariant drift risk; +30-40 s per run | Acceptable fallback if cache-key realignment shows residual failures |
+
+**Cache-hit vs cache-miss install diverge by design** (`ci.yml:236-246`): cache-miss runs `npx playwright install --with-deps chromium` (binary + OS deps); cache-hit runs only `npx playwright install-deps chromium` (OS deps only). When the cache key advances on a Playwright bump, the cache-miss branch fires on first hit and reinstalls the new binary. When the key is invariant, the cache-hit branch reuses a stale binary forever.
+
+## Resolution
+
+Single PR (#3624 fix) edits `.github/workflows/ci.yml` only:
+
+1. Insert a `detect-changes` job (mirrors `infra-validation.yml:24-52`) that emits `outputs.docs` as `'true'` or `'false'` based on a regex anchor list mirroring `deploy-docs.yml`'s `paths:`. Push events to `main` and `workflow_dispatch` always run the gate.
+2. Add `needs: detect-changes` and `if: needs.detect-changes.outputs.docs == 'true'` to `critical-css-gate`.
+3. Realign the cache key: `hashFiles('plugins/soleur/docs/scripts/screenshot-gate.mjs')` → `hashFiles('package-lock.json')`.
+
+The static `check-critical-css-coverage.mjs` step continues to run unconditionally whenever the job runs (the path filter governs whether the job runs at all, not which steps within it run). `deploy-docs.yml` continues to run the same gate post-merge without caching as the load-bearing safeguard.
+
+## Generalizable Pattern
+
+When wiring a cache for an external tool that ships native binaries (Playwright browsers, bun, deno, foundry forge, etc.) in a workflow that already installs via a package manager:
+
+- **Cache key = `hashFiles('<lockfile>')`** — the lockfile is the canonical version-anchor.
+- **Never** key on a downstream consumer script unless that script directly encodes the tool version.
+- **Cache-hit branches must not bypass binary install** — only OS-level setup. Anything that touches the cached path itself must run on cache miss too.
+- **When one workflow houses required + non-required jobs**, scope conditionals per-job via a `detect-changes` upstream, not workflow-level `paths:`. Workflow-level `paths:` orphans every required check on non-matching diffs.

--- a/knowledge-base/project/specs/feat-one-shot-3624-critical-css-gate/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-3624-critical-css-gate/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-one-shot-3624-critical-css-gate/knowledge-base/project/plans/2026-05-12-fix-critical-css-gate-path-filter-and-cache-key-plan.md
+- Status: complete
+
+### Errors
+None
+
+### Decisions
+- Dual root cause confirmed: (a) no path filter on `critical-css-gate`, (b) cache key `hashFiles('screenshot-gate.mjs')` is invariant to Playwright version, so the cache-hit branch reuses a stale chromium binary. Both fixes go in the same PR.
+- Deepen-pass flip: chosen approach moved from `dorny/paths-filter@v3` (would be a first-time vendor pin) to a hand-rolled `git diff --name-only` + `if:` filter that mirrors the in-repo precedent at `infra-validation.yml:24-52`. Zero new dependencies; `dorny/paths-filter` kept as Alternatives row with live-resolved SHA `d1c1ffe0248fe513906c8e24db8ea791d46f8590` (v3.0.3 peeled).
+- Cache key realignment: swap `hashFiles('plugins/soleur/docs/scripts/screenshot-gate.mjs')` → `hashFiles('package-lock.json')` so Playwright version bumps invalidate the cache and trigger the `npx playwright install --with-deps chromium` branch.
+- Required-status-checks independence verified live (`gh api repos/jikig-ai/soleur/rulesets/14145388`): required = `test`, `dependency-review`, `e2e`, `CodeQL`, `skill-security-scan PR gate`. `critical-css-gate` is NOT required, so path-filtering does not orphan any required check; the block on PR #3602 came from `/soleur:ship` Phase 7 (all-checks-pass safety), not branch protection.
+- User-Brand Impact threshold = `none` with explicit one-sentence reason. The path `.github/workflows/ci.yml` does NOT match preflight Check 6's sensitive-path regex (no doppler/secret/token/deploy/etc. tokens), so no scope-out bullet required. Phase 4.6 PASSED.
+
+### Components Invoked
+- soleur:plan (Phase 0 KB load, Phase 1 local research, Phase 1.7 reconciliation, Phase 1.7.5 code-review overlap check → #2965 acknowledged, Phase 2 issue structure, Phase 2.5 domain review = engineering-only, Phase 2.6 user-brand impact, Phase 2.7 GDPR gate = skip, Phase 4 detail level, Phase 5 formatting)
+- soleur:deepen-plan (Phase 4.6 halt gate = PASS, in-repo precedent discovery via `grep`/`find`, live SHA resolution via `gh api repos/dorny/paths-filter/git/tags/...`, branch-protection ruleset verification via `gh api repos/jikig-ai/soleur/rulesets/14145388`, failure-run log inspection via `gh run view 25718834192 --log`)
+- Bash, Read, Edit, Write tools throughout

--- a/knowledge-base/project/specs/feat-one-shot-3624-critical-css-gate/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-3624-critical-css-gate/tasks.md
@@ -4,37 +4,37 @@ Derived from `knowledge-base/project/plans/2026-05-12-fix-critical-css-gate-path
 
 ## 1. Setup
 
-- [ ] 1.1 Read the failing run logs once more (`gh run view 25718834192 --log | grep critical-css-gate`) to confirm error string.
-- [ ] 1.2 Read `.github/workflows/ci.yml` (full file) — note all jobs, the canonical action-pin format, and any pre-existing `needs:` dependencies.
-- [ ] 1.3 Read `.github/workflows/deploy-docs.yml` lines 6-11 — capture the `paths:` prefix list verbatim (will be re-used in the per-job filter).
-- [ ] 1.4 Read `.github/workflows/infra-validation.yml:24-52` — confirm the `detect-changes` + `outputs.directories` + `if:` pattern that this plan mirrors (single boolean output instead of matrix).
+- [x] 1.1 Read the failing run logs once more (`gh run view 25718834192 --log | grep critical-css-gate`) to confirm error string.
+- [x] 1.2 Read `.github/workflows/ci.yml` (full file) — note all jobs, the canonical action-pin format, and any pre-existing `needs:` dependencies.
+- [x] 1.3 Read `.github/workflows/deploy-docs.yml` lines 6-11 — capture the `paths:` prefix list verbatim (will be re-used in the per-job filter).
+- [x] 1.4 Read `.github/workflows/infra-validation.yml:24-52` — confirm the `detect-changes` + `outputs.directories` + `if:` pattern that this plan mirrors (single boolean output instead of matrix).
 
 ## 2. Core Implementation
 
 ### 2.1 Add `detect-changes` job (hand-rolled, mirrors `infra-validation.yml:24-52`)
 
-- [ ] 2.1.1 Insert a new `detect-changes` job at the top of the `jobs:` block in `.github/workflows/ci.yml` (immediately after `readme-counts`).
-- [ ] 2.1.2 Use `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1` with `fetch-depth: 0` (REQUIRED — shallow clone breaks the `origin/${BASE_REF}...HEAD` diff).
-- [ ] 2.1.3 Add a `filter` step that runs `git diff --name-only "origin/${BASE_REF}...HEAD" | grep -qE '<regex>'` against the regex anchor list from Phase 1 of the plan. Short-circuit `push` events to `docs=true` unconditionally.
-- [ ] 2.1.4 Emit `outputs.docs` as `'true'` or `'false'` via `$GITHUB_OUTPUT`.
-- [ ] 2.1.5 Run the three-shape fixture test from the plan against the regex BEFORE committing (deep-nested, root, negative).
+- [x] 2.1.1 Insert a new `detect-changes` job at the top of the `jobs:` block in `.github/workflows/ci.yml` (immediately after `readme-counts`).
+- [x] 2.1.2 Use `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1` with `fetch-depth: 0` (REQUIRED — shallow clone breaks the `origin/${BASE_REF}...HEAD` diff).
+- [x] 2.1.3 Add a `filter` step that runs `git diff --name-only "origin/${BASE_REF}...HEAD" | grep -qE '<regex>'` against the regex anchor list from Phase 1 of the plan. Short-circuit `push` events to `docs=true` unconditionally.
+- [x] 2.1.4 Emit `outputs.docs` as `'true'` or `'false'` via `$GITHUB_OUTPUT`.
+- [x] 2.1.5 Run the three-shape fixture test from the plan against the regex BEFORE committing (deep-nested, root, negative).
 
 ### 2.2 Gate `critical-css-gate` with the conditional
 
-- [ ] 2.2.1 Add `needs: detect-changes` to the `critical-css-gate` job.
-- [ ] 2.2.2 Add `if: needs.detect-changes.outputs.docs == 'true'` to the job.
-- [ ] 2.2.3 Confirm no other job in the workflow has `needs: critical-css-gate` (grep verifies — none today).
-- [ ] 2.2.4 Run `actionlint` against the modified workflow file. Do NOT use `bash -n` (Sharp Edge — YAML parses as bash and fails on header).
+- [x] 2.2.1 Add `needs: detect-changes` to the `critical-css-gate` job.
+- [x] 2.2.2 Add `if: needs.detect-changes.outputs.docs == 'true'` to the job.
+- [x] 2.2.3 Confirm no other job in the workflow has `needs: critical-css-gate` (grep verifies — none today).
+- [x] 2.2.4 Run `actionlint` against the modified workflow file. Do NOT use `bash -n` (Sharp Edge — YAML parses as bash and fails on header).
 
 ### 2.3 Realign cache key
 
-- [ ] 2.3.1 Change line 234 of `.github/workflows/ci.yml`: `key: playwright-critical-css-gate-${{ hashFiles('plugins/soleur/docs/scripts/screenshot-gate.mjs') }}` → `key: playwright-critical-css-gate-${{ hashFiles('package-lock.json') }}`.
-- [ ] 2.3.2 No other edits needed — the install-on-cache-miss branch already runs `npx playwright install --with-deps chromium` and will fire on first lockfile-keyed cache miss.
+- [x] 2.3.1 Change line 234 of `.github/workflows/ci.yml`: `key: playwright-critical-css-gate-${{ hashFiles('plugins/soleur/docs/scripts/screenshot-gate.mjs') }}` → `key: playwright-critical-css-gate-${{ hashFiles('package-lock.json') }}`.
+- [x] 2.3.2 No other edits needed — the install-on-cache-miss branch already runs `npx playwright install --with-deps chromium` and will fire on first lockfile-keyed cache miss.
 
 ### 2.4 Capture learning
 
-- [ ] 2.4.1 Create `knowledge-base/project/learnings/best-practices/<date>-ci-playwright-cache-key-must-track-npm-version-not-script-hash.md` (author picks date at write-time per `2026-04-15-plan-skill-reconcile-spec-vs-codebase.md` convention).
-- [ ] 2.4.2 Cover two lessons: per-job conditional vs workflow-level `paths`, and Playwright cache-key invariants must advance with binary version.
+- [x] 2.4.1 Create `knowledge-base/project/learnings/best-practices/<date>-ci-playwright-cache-key-must-track-npm-version-not-script-hash.md` (author picks date at write-time per `2026-04-15-plan-skill-reconcile-spec-vs-codebase.md` convention).
+- [x] 2.4.2 Cover two lessons: per-job conditional vs workflow-level `paths`, and Playwright cache-key invariants must advance with binary version.
 
 ## 3. Verification
 


### PR DESCRIPTION
## Summary

Recovery PR for #3624. The original PR #3627 squash-merged only the planning and tasks markdown files — the actual fix commits (`6f1a808e` ci.yml + cache key, `ec380c58` review fixes) were committed locally but **never pushed before merge**. Cherry-picked from the local-only commits to land the real fix on main.

This PR contains the actual two-bug fix from the plan:

1. **Scope `critical-css-gate` to docs-touching PRs** via a new `detect-changes` job (mirrors `infra-validation.yml:24-52`).
2. **Realign Playwright cache key** from `screenshot-gate.mjs` hash to `package-lock.json` hash so Playwright version bumps invalidate the cache.

Plus the review-pass clarifications: BASE_REF comment accuracy, reciprocal "keep in sync" comments tying `ci.yml`'s regex to `deploy-docs.yml`'s `paths:`, and a one-line rationale on the cache key.

## Background — what went wrong on #3627

- Draft PR #3627 was created from the initial worktree commit.
- The plan/deepen-plan subagents pushed their commits to the branch.
- The fix commits (made later in this session) were **committed but never pushed**.
- `gh pr merge --squash --auto` merged the PR with only the planning files on it.
- The post-merge CI ran the OLD (un-patched) `critical-css-gate` against a stale cache and failed (cache-key collision: the old key on `screenshot-gate.mjs` happened to hash-collide with today's `package-lock.json` hash).
- Hotfix: stale cache `playwright-critical-css-gate-4873fdec…` (created 2026-04-27, cache id 3999168382) was deleted.
- Workflow-dispatch verification run succeeded against the (still-unpatched) workflow with a fresh cache — proving the cache deletion was the right hotfix while this recovery PR lands the actual logic fix.

## User-Brand Impact

- **Artifact:** N/A — CI orchestration change, no user-facing surface or regulated data touched.
- **Vector:** N/A — no production traffic depends on `critical-css-gate`; `deploy-docs.yml` continues to run the same screenshot-gate flow post-merge as the load-bearing FOUC defense.
- **Brand-survival threshold:** `none` — failure mode is "the gate stops gating on relevant PRs", which the static coverage check + post-merge deploy-docs gate continue to cover.

threshold: none, reason: CI orchestration change with no user-facing surface; deploy-docs.yml post-merge gate is the load-bearing FOUC defense and is unchanged.

## Changelog

### Plugin (CI)

- Scope `critical-css-gate` to docs-touching PRs via a new `detect-changes` job.
- Realign Playwright cache key to `package-lock.json` so version bumps invalidate the cache.
- Document path-list parity between `ci.yml`'s filter regex and `deploy-docs.yml`'s `on.push.paths`.

## Test plan

- [x] Local regex fixture: 10/10 scenarios match the plan's spec.
- [x] `actionlint` clean on both edited workflows.
- [x] `bash scripts/test-all.sh` — 36/36 suites passed.
- [x] Workflow_dispatch run on main after cache deletion: `critical-css-gate` succeeded.
- [ ] Post-merge: this PR is itself a docs/workflow-touching PR per the new regex (it edits `.github/workflows/ci.yml`), so the gate should self-trigger and run green on this PR's pre-merge CI.
- [ ] Post-merge: confirm `critical-css-gate` is skipped on the next non-docs PR.

Generated with [Claude Code](https://claude.com/claude-code)
