### PR TITLE
chore(cc-dispatcher): D-pr-a1-cosmetics — renames + microtask flushes + AssistantPersistMode union — #3603

### DIFF
--- a/apps/web-platform/server/cc-dispatcher.ts
+++ b/apps/web-platform/server/cc-dispatcher.ts
@@ -1133,12 +1133,12 @@ export async function dispatchSoleurGo(
   // and live UI. Invariant: the value at the instant `onTextTurnEnd`
   // fires (or `onWorkflowEnded` flushes for the abort path) is what
   // persists. No reordering, no merge.
-  let accumulatedAssistantText = "";
+  let latestAssistantText = "";
   // #3603 W2 — flushed by `onWorkflowEnded` for non-`completed` statuses
   // so a late `onTextTurnEnd` (in-flight SDK callback after abort fires)
   // cannot double-write or overwrite the abort row. Closure-scoped per
   // dispatch invocation; fresh `false` for each `dispatchSoleurGo` call.
-  let workflowEnded = false;
+  let assistantTurnPersisted = false;
   // #3603 W4 — per-turn cost telemetry captured pre-`onTextTurnEnd`.
   // `currentTurnIndex` is the closure-scoped turn counter; `pendingTurnUsage`
   // holds the cost captured by `onResult` tagged with the turnIndex active at
@@ -1154,12 +1154,13 @@ export async function dispatchSoleurGo(
   // legacy agent-runner path emits the full `UsageSnapshot` (input_tokens,
   // output_tokens, cost_usd, completed_actions[]) on `'aborted'` turns —
   // see `Message.usage` doc-comment in `lib/types.ts`.
-  type AssistantPersistMode = {
-    status?: "aborted";
+  type AssistantPersistMode = "complete" | "aborted";
+  interface AssistantPersistOpts {
+    mode: AssistantPersistMode;
     usage?: { costUsd: number } | null;
-  };
+  }
 
-  async function saveAssistantMessage(opts?: AssistantPersistMode): Promise<void> {
+  async function saveAssistantMessage(opts: AssistantPersistOpts): Promise<void> {
     // #3603 W1 — Cross-tenant write-boundary sentinel. cc-path uses
     // service-role for INSERT (RLS-bypass on writes). RLS catches reads;
     // this guard catches writes. Returns `false` only via the test seam
@@ -1171,8 +1172,8 @@ export async function dispatchSoleurGo(
     // Snapshot-then-reset must precede `await` so a turn N+1 `onText` cannot
     // mutate `fullText` while this insert is in flight (single async loop
     // serializes onText/onTextTurnEnd, but the await yields the microtask).
-    const fullText = accumulatedAssistantText;
-    accumulatedAssistantText = "";
+    const fullText = latestAssistantText;
+    latestAssistantText = "";
     if (!fullText) return;
 
     // #3603 W4 — gated single-read site for `CC_PERSIST_USAGE`. The hot-path
@@ -1188,7 +1189,7 @@ export async function dispatchSoleurGo(
     // ensures we mirror once, not on every persist call.
     if (flagOn) _observeCcPersistUsageFirstTrue();
     const usageColumn =
-      flagOn && opts?.usage ? { cost_usd: opts.usage.costUsd } : null;
+      flagOn && opts.usage ? { cost_usd: opts.usage.costUsd } : null;
 
     const row: Record<string, unknown> = {
       id: randomUUID(),
@@ -1202,14 +1203,14 @@ export async function dispatchSoleurGo(
     // Omit `status` for the normal completion path — migration 040's
     // DEFAULT of `'complete'` applies. Only the abort branch writes
     // `status: "aborted"` explicitly.
-    if (opts?.status === "aborted") {
+    if (opts.mode === "aborted") {
       row.status = "aborted";
     }
 
     // Hoisted op slug so `mirrorWithDebounce` receives the same value for
     // both `op` and `errorClass` (the dedupe key) — drift between them
     // would silently split the Sentry dedupe stream.
-    const opSlug = opts?.status === "aborted"
+    const opSlug = opts.mode === "aborted"
       ? "save-assistant-message-aborted-failed"
       : "save-assistant-message-failed";
 
@@ -1237,7 +1238,7 @@ export async function dispatchSoleurGo(
       // #3603 W8 — replace, not append. Mirrors chat-state-machine REPLACE
       // semantic so persisted content matches the UI's live render.
       // See accumulator declaration comment above for invariant + AC11 source.
-      accumulatedAssistantText = text;
+      latestAssistantText = text;
       sendToClient(userId, {
         type: "stream",
         content: text,
@@ -1265,7 +1266,7 @@ export async function dispatchSoleurGo(
       // flushed an abort row would double-write or, worse, overwrite the
       // "aborted" status row with a "complete" one. Silent no-op:
       // user already saw the partial text (rendered live; abort row hydrates).
-      if (workflowEnded) {
+      if (assistantTurnPersisted) {
         // silent: turn was already persisted via the abort path
         return;
       }
@@ -1280,6 +1281,7 @@ export async function dispatchSoleurGo(
       currentTurnIndex = turnSnapshot + 1;
       // Fire-and-forget — user already saw the streamed text; helper mirrors on failure.
       void saveAssistantMessage({
+        mode: "complete",
         usage: turnUsage ? { costUsd: turnUsage.costUsd } : null,
       });
       // Per-turn boundary → terminal stream event for the cc_router bubble.
@@ -1305,27 +1307,27 @@ export async function dispatchSoleurGo(
       // BEFORE the existing user-visible routing below. Mirrors the legacy
       // abort contract at `agent-runner.ts:2044-2055`. Skips on
       // `status: "completed"` because the normal `onTextTurnEnd` path
-      // already wrote (or will write) the row. The `workflowEnded` flag
+      // already wrote (or will write) the row. The `assistantTurnPersisted` flag
       // suppresses a late `onTextTurnEnd` arriving after this flush.
       // Use the typed `ABORT_FLUSH_STATUSES` set (exhaustively type-checked
       // via `_abortFlushExhaustive`) rather than a bare `!== "completed"` so
       // a future `WorkflowEnd` variant cannot silently route through abort
       // without a deliberate listing here.
       if (ABORT_FLUSH_STATUSES.has(end.status)) {
-        if (accumulatedAssistantText.length > 0) {
+        if (latestAssistantText.length > 0) {
           // #3603 W4 — text-present abort: capture the per-turn usage tagged
           // to the active turn index, then clear pendingTurnUsage so a late
           // onTextTurnEnd cannot re-attach the stale value. Set
-          // `workflowEnded = true` SYNCHRONOUSLY so the late onTextTurnEnd
+          // `assistantTurnPersisted = true` SYNCHRONOUSLY so the late onTextTurnEnd
           // cannot race the await microtask.
           const turnUsage =
             pendingTurnUsage?.turnIndex === currentTurnIndex
               ? pendingTurnUsage
               : null;
           pendingTurnUsage = null;
-          workflowEnded = true;
+          assistantTurnPersisted = true;
           void saveAssistantMessage({
-            status: "aborted",
+            mode: "aborted",
             usage: turnUsage ? { costUsd: turnUsage.costUsd } : null,
           });
         } else if (pendingTurnUsage) {

--- a/apps/web-platform/test/cc-dispatcher.test.ts
+++ b/apps/web-platform/test/cc-dispatcher.test.ts
@@ -139,6 +139,16 @@ type InteractivePromptResponse = Extract<WSMessage, { type: "interactive_prompt_
 // singleton init, rate-limit config, and interactive_prompt_response
 // WS-error mapping.
 
+// Drains the microtask queue twice so a `void saveAssistantMessage()`
+// kicked off in a synchronous SDK callback (and any chained `.then`s the
+// insert spawns) gets to run before the assertion. Replaces the
+// `setTimeout(_, 10)` settle wait pattern — microtask flushes are
+// deterministic and don't carry the 10ms wall-clock cost per assertion.
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 describe("cc-dispatcher singletons + orchestration", () => {
   beforeEach(() => {
     __resetDispatcherForTests();
@@ -1115,7 +1125,7 @@ describe("cc-dispatcher singletons + orchestration", () => {
 
     // No assistant row should ever be inserted — flush microtasks and assert
     // the count stays at 0.
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await flushMicrotasks();
     expect(assistantInsertCalls(mockMessagesInsert)).toHaveLength(0);
   });
 
@@ -1130,7 +1140,7 @@ describe("cc-dispatcher singletons + orchestration", () => {
   // hidden routing preamble with the visible answer; user only saw the
   // answer).
   //
-  // Invariant: the value of `accumulatedAssistantText` at the instant
+  // Invariant: the value of `latestAssistantText` at the instant
   // `onTextTurnEnd` fires is what persists. No reordering, no merge.
   // ---------------------------------------------------------------------------
 
@@ -1223,7 +1233,7 @@ describe("cc-dispatcher singletons + orchestration", () => {
   //
   // Mirrors the legacy abort contract at `agent-runner.ts:2044-2055` so the
   // user's partially-streamed text survives a runner abort. A closure-scoped
-  // `workflowEnded` flag suppresses a late `onTextTurnEnd` so it cannot
+  // `assistantTurnPersisted` flag suppresses a late `onTextTurnEnd` so it cannot
   // double-write or overwrite the abort row.
   //
   // Scope: 6 non-`completed` `WorkflowEnd` statuses (cost_ceiling,
@@ -1234,15 +1244,16 @@ describe("cc-dispatcher singletons + orchestration", () => {
   // reaper/closeConversation paths (cc-dispatcher.ts:738).
   // ---------------------------------------------------------------------------
 
-  for (const statusFixture of [
+  it.each([
     { status: "runner_runaway", elapsedMs: 5000, lastBlockKind: "text", lastBlockToolName: null, reason: "idle_window" },
     { status: "idle_timeout" },
     { status: "internal_error", error: "boom" },
     { status: "user_aborted" },
     { status: "plugin_load_failure", error: "plugin missing" },
     { status: "cost_ceiling", totalCostUsd: 5, cap: 4, workflow: null },
-  ]) {
-    it(`T-W2-${statusFixture.status}: flushes accumulated text as status:"aborted" row on non-completed workflow end`, async () => {
+  ])(
+    'T-W2-$status: flushes accumulated text as status:"aborted" row on non-completed workflow end',
+    async (statusFixture) => {
       const { __setCcRunnerForTests } = await import("@/server/cc-dispatcher");
 
       __setCcRunnerForTests(
@@ -1278,8 +1289,8 @@ describe("cc-dispatcher singletons + orchestration", () => {
           status: "aborted",
         }),
       );
-    });
-  }
+    },
+  );
 
   it("T-W2-empty: does NOT write an aborted row when accumulator is empty (tool-only turn that aborts)", async () => {
     const { __setCcRunnerForTests } = await import("@/server/cc-dispatcher");
@@ -1304,7 +1315,7 @@ describe("cc-dispatcher singletons + orchestration", () => {
     });
 
     // Flush microtasks; no assistant insert should land.
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await flushMicrotasks();
     expect(assistantInsertCalls(mockMessagesInsert)).toHaveLength(0);
   });
 
@@ -1343,7 +1354,7 @@ describe("cc-dispatcher singletons + orchestration", () => {
     expect(row.content).toBe("normal reply");
   });
 
-  it("T-W2-late-text-async: workflowEnded flag survives a real microtask boundary between onWorkflowEnded and onTextTurnEnd", async () => {
+  it("T-W2-late-text-async: assistantTurnPersisted flag survives a real microtask boundary between onWorkflowEnded and onTextTurnEnd", async () => {
     // Per GDPR work-phase-2-exit R2 (2026-05-12): T-W2-late-text fires both
     // callbacks synchronously; in production the SDK iterator may interleave
     // them across actual microtasks. The synchronous flag set is correct
@@ -1382,7 +1393,7 @@ describe("cc-dispatcher singletons + orchestration", () => {
     await vi.waitFor(() =>
       expect(assistantInsertCalls(mockMessagesInsert)).toHaveLength(1),
     );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await flushMicrotasks();
     expect(assistantInsertCalls(mockMessagesInsert)).toHaveLength(1);
 
     const [row] = assistantInsertCalls(mockMessagesInsert);
@@ -1399,7 +1410,7 @@ describe("cc-dispatcher singletons + orchestration", () => {
           events.onText("text before abort");
           events.onWorkflowEnded?.({ status: "runner_runaway", elapsedMs: 5000, lastBlockKind: "text", lastBlockToolName: null, reason: "idle_window" });
           // Simulate the in-flight SDK callback that arrives after the abort
-          // has already flushed. The workflowEnded flag must suppress this.
+          // has already flushed. The assistantTurnPersisted flag must suppress this.
           events.onTextTurnEnd?.();
         },
       }),
@@ -1420,7 +1431,7 @@ describe("cc-dispatcher singletons + orchestration", () => {
     await vi.waitFor(() =>
       expect(assistantInsertCalls(mockMessagesInsert)).toHaveLength(1),
     );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await flushMicrotasks();
     expect(assistantInsertCalls(mockMessagesInsert)).toHaveLength(1);
 
     const [row] = assistantInsertCalls(mockMessagesInsert);
@@ -1652,7 +1663,7 @@ describe("cc-dispatcher singletons + orchestration", () => {
     });
 
     // Settle: no assistant insert.
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await flushMicrotasks();
     expect(assistantInsertCalls(mockMessagesInsert)).toHaveLength(0);
 
     // Exactly ONE P0 mirror with the literal op slug.
@@ -1734,7 +1745,7 @@ describe("cc-dispatcher singletons + orchestration", () => {
     );
     // Settle further — confirm the late onTextTurnEnd does NOT produce a
     // second insert.
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await flushMicrotasks();
     expect(assistantInsertCalls(mockMessagesInsert)).toHaveLength(1);
 
     const [row] = assistantInsertCalls(mockMessagesInsert);
@@ -1812,7 +1823,7 @@ describe("cc-dispatcher singletons + orchestration", () => {
       });
 
       // Settle the assistant call sites' microtasks.
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await flushMicrotasks();
 
       // Exactly ONE user-INSERT (call 1 passed), ZERO assistant rows (calls
       // 2 + 3 halted by sentinel).


### PR DESCRIPTION
## Summary

Applies the 5 deferred cosmetic refactors from PR-A1's multi-reviewer pass (per plan rev-2 §5.5, captured in #3623). Pure cosmetics — no behavioral changes to production code paths.

1. **Rename `accumulatedAssistantText` → `latestAssistantText`** — post-W8 (PR-A1) the value holds the LATEST SDK emission, not an accumulation. The old name was a vestige of the pre-W8 `+=` semantics.
2. **Rename `workflowEnded` → `assistantTurnPersisted`** — closer to the contract this flag actually encodes. Parity with legacy `messagePersisted` in `agent-runner.ts`.
3. **`AssistantPersistMode` reshape** — was an optional-fields type `{ status?: \"aborted\"; usage?: ... }` that encoded implicit invariants in optionality. Now a string literal union `\"complete\" | \"aborted\"` paired with `AssistantPersistOpts` that requires `mode` explicitly. Both call sites pass `mode: \"complete\"` / `mode: \"aborted\"` so the contract is visible at the call site.
4. **Replace `setTimeout(resolve, 10)` settle waits with `flushMicrotasks()`** (double `Promise.resolve()`). Deterministic, no wall-clock cost. Test runtime dropped from ~113ms to ~49ms.
5. **Convert W2 6-status `for` loop to `it.each(...)`** — each status gets its own properly-named test case in vitest's output (was one synthesized name per iteration).

## Out of scope

- **`dispatchWithDefaults` test boilerplate helper** (item 6 of D-pr-a1-cosmetics): the 31 existing `dispatchSoleurGo({...})` call sites would require mass conversion for partial value; the helper alone would be unused dead code. Re-evaluate when a new test author lands a 32nd call site.

## Changelog

### Web Platform
- Renamed closure-scoped locals in `cc-dispatcher.ts` for clearer naming post-PR-A1.
- Refactored `AssistantPersistMode` to a discriminated union so the complete/abort contract is visible at every call site.
- Cleaner microtask flushes in cc-dispatcher unit tests (deterministic + faster).
- Converted W2 status-loop to `it.each` for properly-named test output.

## Test plan

- [x] 43/43 cc-dispatcher unit tests pass
- [x] 6/6 observability tests pass
- [x] 5/5 api-messages tests pass
- [x] tsc --noEmit clean
- [x] No production behavioral changes (pure rename + type-level + test-organization)

Refs #3603, #3623.

Generated with [Claude Code](https://claude.com/claude-code)