### PR TITLE
fix(compound): drop cross-skill trigger from route-to-definition gate

### DIFF
--- a/plugins/soleur/skills/compound/SKILL.md
+++ b/plugins/soleur/skills/compound/SKILL.md
@@ -362,17 +362,25 @@ Routing mechanics:
    `BASENAME=$(basename "$TARGET" | tr -cd '[:alnum:]._-')` — or pass the
    message via a heredoc (`git commit -m "$(cat <<EOF\nskill: route ...\nEOF\n)"`)
    so backticks or `$(...)` in a learning-file-derived basename cannot
-   command-substitute. The edit surface is BOUNDED: a single bullet-point
-   append, a single Sharp Edges entry, or a ≤3-line instruction clarification.
-   Edits that change existing bullet semantics, span multiple files, or modify
-   AGENTS.md rule wording are OUT OF SCOPE for direct edit — file an issue
-   instead.
+   command-substitute. The edit surface is BOUNDED **per file**: each
+   affected file gets a single bullet-point append, a single Sharp Edges
+   entry, or a ≤3-line instruction clarification. Multi-file edits are
+   allowed when the insight is **convergent** — one rule with parallel
+   per-skill bullets (e.g., "when an enum-gate exists, plan must enumerate
+   AND review must verify"). Each file's surface still has to satisfy the
+   bounded-surface budget on its own. Edits that change existing bullet
+   semantics or modify AGENTS.md rule wording remain OUT OF SCOPE for
+   direct edit — file an issue instead.
 
 4. **File-issue exception:** File a GitHub issue when the edit meets one of:
-   cross-skill (touches 2+ skill/agent files), contested-design (competing
-   valid approaches), agents-md-semantic-change (modifies existing rule text),
-   tier-ambiguous (insight straddles Tier 2 and Tier 3 and a reviewer's
-   judgment is load-bearing).
+   contested-design (competing valid approaches), agents-md-semantic-change
+   (modifies existing rule text), tier-ambiguous (insight straddles Tier 2
+   and Tier 3 and a reviewer's judgment is load-bearing), **divergent
+   multi-file** (two or more unrelated edits across skills that don't share
+   a single insight — these warrant separate scrutiny), or any single file's
+   edit exceeds the bounded-surface budget (>1 bullet, >1 Sharp Edges entry,
+   or >3 instruction lines). "Cross-skill" alone is NOT a trigger — a
+   convergent insight with parallel per-skill bullets applies inline.
    Title: `compound: route-to-definition proposal for <target-basename>`.
    Body: proposed edit text + target path + source learning path + `## Scope-Out
    Justification` naming the criterion. Flags: `--label deferred-scope-out


### PR DESCRIPTION
## Summary

The compound skill's route-to-definition file-issue gate fires on "touches 2+ skill/agent files," which conflates two cases:

- **Convergent**: one insight, parallel per-skill bullets (e.g., "when an enum-gate exists, plan must enumerate AND review must verify"). Naturally bounded, low risk.
- **Divergent**: unrelated edits across skills. Deserves its own scrutiny.

This change narrows the file-issue triggers so convergent multi-file insights apply inline. Surfaced today: PR #3653's compound filed #3667 as exactly this class — one insight (enum-gate enumeration), two parallel bullets, deferred because the gate didn't distinguish convergent from divergent.

Ref #3667

## Changelog

### Plugin
- fix(compound): bounded-surface budget is now per-file. Multi-file convergent insights apply inline. "Cross-skill" alone is no longer a file-issue trigger. File-issue retained for: contested-design, agents-md-semantic-change, tier-ambiguous, divergent-multi-file, and any single-file edit exceeding the bounded-surface budget.

## Test plan

- [x] `bun test plugins/soleur/test/components.test.ts` — 1045 pass / 0 fail. Description-budget unchanged (edit lives in the body, not in `description:`).
- [x] `bash scripts/test-all.sh` — full plugin test suite.

## User-Brand Impact

- **Artifact:** compound skill instruction surface; affects how route-to-definition edits land in future PRs.
- **Vector:** workflow-only change — no production code, no migration, no user-facing surface.
- **Brand-survival threshold:** `none` — threshold: none, reason: skill instruction change is reversible by a single follow-up PR; affected population is the operator running compound; no Art. 33 surface; current cross-skill issues (#3667) can be absorbed inline retroactively or left as-is.

Generated with [Claude Code](https://claude.com/claude-code)
