### PR TITLE
feat(docs): redesign C4 architecture diagrams (SOL-40)

### DIFF
--- a/knowledge-base/engineering/architecture/diagrams/component-plugin.md
+++ b/knowledge-base/engineering/architecture/diagrams/component-plugin.md
@@ -1,59 +1,66 @@
 # Soleur Plugin — Component Diagram (C4 Level 3)
 
-Generated: 2026-03-27
+Generated: 2026-05-13 (visual redesign per SOL-40, was 2026-03-27)
 
 ```mermaid
 C4Component
 title Component diagram for Soleur Plugin
 
+UpdateLayoutConfig($c4ShapeInRow="1", $c4BoundaryInRow="1")
+
 Container(claude, "Agent Runtime", "Claude Code", "Executes agent workflows")
 Container(hooks, "Hook Engine", "PreToolUse Guards", "Syntactic enforcement")
-ContainerDb(kb, "Knowledge Base", "Markdown", "Conventions, learnings, ADRs")
 
 Container_Boundary(plugin, "Soleur Plugin (plugins/soleur/)") {
 
-    Component(go, "go command", "Entry Point", "Classifies intent and routes to workflow skills")
-    Component(sync, "sync command", "Entry Point", "Populates knowledge-base from existing codebase")
-    Component(help, "help command", "Entry Point", "Lists all available commands, skills, and agents")
-
-    Component(brainstorm, "brainstorm skill", "Workflow", "Explores requirements with domain leader assessment")
-    Component(plan, "plan skill", "Workflow", "Creates implementation plans with research and domain review")
-    Component(work, "work skill", "Workflow", "Executes plans with incremental commits and test-first")
-    Component(review, "review skill", "Workflow", "Multi-agent code review with 8 parallel reviewers")
-    Component(compound, "compound skill", "Workflow", "Captures learnings and promotes to constitution")
-    Component(ship, "ship skill", "Workflow", "Validates artifacts, creates PR, manages merge lifecycle")
-    Component(oneshot, "one-shot skill", "Orchestrator", "Full autonomous pipeline: plan, work, review, compound, ship")
-    Component(architecture, "architecture skill", "Documentation", "ADR lifecycle and C4 diagram generation")
-
-    Component(cto, "CTO agent", "Domain Leader", "Engineering assessment, architecture decision detection")
-    Component(cmo, "CMO agent", "Domain Leader", "Marketing assessment, content opportunities")
-    Component(cpo, "CPO agent", "Domain Leader", "Product strategy, UX flow analysis")
-    Component(archstrat, "architecture-strategist", "Review Agent", "Architectural compliance and ADR coverage check")
-
-    Rel(go, brainstorm, "Routes explore/generate")
-    Rel(go, oneshot, "Routes build")
-    Rel(oneshot, plan, "Step 1")
-    Rel(oneshot, work, "Step 2")
-    Rel(oneshot, review, "Step 3")
-    Rel(oneshot, compound, "Step 4")
-    Rel(oneshot, ship, "Step 5")
-    Rel(brainstorm, cto, "Phase 0.5 assessment")
-    Rel(brainstorm, cmo, "Phase 0.5 assessment")
-    Rel(brainstorm, cpo, "Phase 0.5 assessment")
-    Rel(plan, cto, "Phase 2.5 domain review")
-    Rel(review, archstrat, "Parallel review agent")
-    Rel(cto, architecture, "Recommends ADR creation")
-    Rel(archstrat, architecture, "Checks ADR coverage")
+    Component(entry, "Entry-Point Commands", "Markdown", "go, sync, help — see Details")
+    Component(workflows, "Workflow Skills", "Markdown", "brainstorm, plan, work, review, compound, ship, one-shot, architecture — see Details")
+    Component(leaders, "Domain Leaders & Reviewers", "Markdown", "cto, cmo, cpo, architecture-strategist — see Details (others folded)")
 }
 
-Rel(claude, go, "User invokes /soleur:go")
+ContainerDb(kb, "Knowledge Base", "Markdown", "Conventions, learnings, ADRs")
+
+Rel(claude, entry, "User invokes /soleur:<cmd>")
 Rel(hooks, claude, "Guards tool calls")
-Rel(brainstorm, kb, "Writes brainstorms")
-Rel(plan, kb, "Writes plans and specs")
-Rel(work, kb, "Reads plans, writes code")
-Rel(compound, kb, "Writes learnings, promotes to constitution")
-Rel(architecture, kb, "Writes ADRs and diagrams")
+Rel(workflows, leaders, "Phase 0.5 / 2.5 / review assessments", "Task spawn")
+Rel(leaders, workflows, "Recommend ADR / coverage check", "Task spawn")
+Rel(workflows, kb, "Reads + writes")
+Rel(leaders, kb, "Reads")
 ```
+
+## Details
+
+**`entry` (Entry-Point Commands)** — `plugins/soleur/commands/`:
+
+- `go` — classifies intent and routes to workflow skills
+- `sync` — populates knowledge-base from existing codebase
+- `help` — lists all available commands, skills, and agents
+
+**`workflows` (Workflow Skills)** — `plugins/soleur/skills/`:
+
+- `brainstorm` — explores requirements with domain leader assessment (Phase 0.5 → spawns leaders)
+- `plan` — creates implementation plans with research and domain review (Phase 2.5 → spawns leaders)
+- `work` — executes plans with incremental commits and test-first
+- `review` — multi-agent code review (8 parallel review agents, including `architecture-strategist`)
+- `compound` — captures learnings and promotes to constitution
+- `ship` — validates artifacts, creates PR, manages merge lifecycle
+- `one-shot` — full autonomous pipeline orchestrating `plan` → `work` → `review` → `compound` → `ship` as Steps 1–5
+- `architecture` — ADR lifecycle and C4 diagram generation (target of `cto` and `architecture-strategist` recommendations)
+
+**`leaders` (Domain Leaders & Reviewers)** — `plugins/soleur/agents/`:
+
+- `cto` — engineering assessment, architecture decision detection
+- `cmo` — marketing assessment, content opportunities
+- `cpo` — product strategy, UX flow analysis
+- `architecture-strategist` — architectural compliance and ADR coverage check at review time
+
+Other domain leaders exist (`clo` legal, `coo` operations, `cfo` finance, `cro` sales, `cco` support) — folded out of this diagram for visual budget. See #3714 for content refresh that may restore them when budget permits.
+
+**External containers shown for context** (defined at L2 `container.md`):
+
+- `claude` (Agent Runtime, Claude Code) — invokes plugin entry-points via slash commands
+- `hooks` (Hook Engine) — intercepts tool calls before they reach the runtime
+- `kb` (Knowledge Base) — read+write target for skills' artifacts and read target for leaders' assessments
 
 ## Notes
 
@@ -62,4 +69,4 @@ Rel(architecture, kb, "Writes ADRs and diagrams")
 - Domain leaders (CTO, CMO, CPO) participate in brainstorm Phase 0.5 and plan Phase 2.5 (ADR-013)
 - CTO agent detects architectural decisions and recommends `/soleur:architecture create`
 - Architecture-strategist checks ADR coverage during review as advisory finding
-- 8 review agents run in parallel during `/soleur:review` — only architecture-strategist shown here
+- 8 review agents run in parallel during `/soleur:review` — only `architecture-strategist` shown here

--- a/knowledge-base/engineering/architecture/diagrams/container.md
+++ b/knowledge-base/engineering/architecture/diagrams/container.md
@@ -1,66 +1,85 @@
 # Soleur Platform — Container Diagram (C4 Level 2)
 
-Generated: 2026-03-27
+Generated: 2026-05-13 (visual redesign per SOL-40, was 2026-03-27)
 
 ```mermaid
 C4Container
 title Container diagram for Soleur Platform
 
+UpdateLayoutConfig($c4ShapeInRow="2", $c4BoundaryInRow="2")
+
 Person(founder, "Founder", "Solo founder using Soleur")
 
-System_Ext(anthropic, "Anthropic API", "Claude LLM")
-System_Ext(github, "GitHub", "Source control and CI/CD")
-System_Ext(cloudflare, "Cloudflare", "DNS, CDN, Tunnel, R2")
-System_Ext(doppler, "Doppler", "Secrets management")
-System_Ext(stripe, "Stripe", "Payment processing")
-System_Ext(plausible, "Plausible", "Privacy-focused analytics")
 Enterprise_Boundary(b0, "Soleur Platform") {
 
     Container_Boundary(web, "Web Application") {
-        Container(dashboard, "Dashboard", "React, Next.js", "Conversation UI, knowledge base viewer, session management")
-        Container(api, "API Routes", "Next.js API", "REST endpoints for auth, sessions, and agent control")
-        Container(auth, "Auth Module", "Supabase Auth", "JWT authentication, OAuth providers, session tokens")
+        Container(webapp, "Web Application", "Next.js PWA", "Dashboard UI + API routes + Supabase Auth — see Details")
     }
 
     Container_Boundary(cli, "Cloud CLI Engine") {
-        Container(claude, "Agent Runtime", "Claude Code", "Executes agent workflows with full orchestration tools")
-        Container(skillloader, "Skill Loader", "Plugin Discovery", "Discovers and loads skills, agents, commands from plugin directory")
-        Container(hooks, "Hook Engine", "PreToolUse Guards", "Enforces syntactic rules — blocks commits to main, rm -rf, etc.")
+        Container(engine, "Cloud CLI Engine", "Claude Code", "Agent runtime + plugin discovery + hook engine — see Details")
     }
 
     Container_Boundary(plugin, "Soleur Plugin") {
-        Container(skills, "Skills", "Markdown SKILL.md", "61 workflow skills — brainstorm, plan, work, review, compound, etc.")
-        Container(agents, "Agents", "Markdown Agent Defs", "65 domain agents across 8 departments")
-        Container(kb, "Knowledge Base", "Markdown + YAML", "Conventions, learnings, ADRs, specs, plans, brainstorms")
+        Container(plugin_box, "Soleur Plugin", "Markdown", "Skills + Agents + Knowledge Base — see L3 component-plugin.md")
     }
 
     Container_Boundary(infra, "Infrastructure") {
         ContainerDb(supabase, "Supabase PostgreSQL", "PostgreSQL", "Users, BYOK-encrypted API keys, conversation sessions")
-        Container(tunnel, "Cloudflare Tunnel", "cloudflared", "Zero-trust inbound access — no exposed ports")
-        Container(hetzner, "Compute", "Hetzner Cloud", "Docker containers running web app and CLI engine")
+        Container(compute, "Compute & Tunnel", "Hetzner Cloud + Cloudflare Tunnel", "Docker containers behind zero-trust tunnel")
     }
 }
 
-Rel(founder, dashboard, "Browses and converses", "HTTPS")
-Rel(dashboard, api, "Calls", "HTTPS")
-Rel(api, claude, "Spawns agent sessions", "WebSocket")
-Rel(claude, skillloader, "Loads plugin", "File I/O")
-Rel(skillloader, skills, "Discovers", "Directory scan")
-Rel(skillloader, agents, "Discovers", "Recursive scan")
-Rel(hooks, claude, "Guards tool calls", "Event hook")
-Rel(skills, kb, "Reads/writes", "File I/O")
-Rel(agents, kb, "Reads", "File I/O")
-Rel(api, supabase, "Auth and data", "HTTPS")
-Rel(claude, supabase, "Sessions and keys", "HTTPS")
-Rel(claude, anthropic, "LLM calls", "HTTPS")
-Rel(claude, github, "Git operations", "HTTPS/SSH")
-Rel(tunnel, api, "Routes traffic", "HTTPS")
-Rel(hetzner, claude, "Hosts", "Docker")
-Rel(doppler, claude, "Injects secrets", "CLI")
-Rel(auth, supabase, "Validates tokens", "HTTPS")
-Rel(api, stripe, "Checkout and webhooks", "HTTPS")
-Rel(dashboard, plausible, "Page view events", "JS snippet")
+System_Ext(cloudflare, "Cloudflare", "DNS, CDN, Tunnel, R2")
+System_Ext(doppler, "Doppler", "Secrets management")
+System_Ext(anthropic, "Anthropic API", "Claude LLM")
+System_Ext(github, "GitHub", "Source control and CI/CD")
+System_Ext(thirdparty, "Third-Party Services", "Discord + Stripe + Plausible — see Details")
+
+Rel(founder, webapp, "Browses and converses", "HTTPS")
+Rel(webapp, engine, "Spawns agent sessions", "WebSocket")
+Rel(engine, plugin_box, "Loads + guards", "File I/O + event hook")
+Rel(webapp, supabase, "Auth and data", "HTTPS")
+Rel(engine, supabase, "Sessions and keys", "HTTPS")
+Rel(engine, anthropic, "LLM calls", "HTTPS")
+Rel(engine, github, "Git operations", "HTTPS/SSH")
+Rel(compute, engine, "Hosts + tunnel", "Docker + cloudflared")
+Rel(doppler, engine, "Injects secrets", "CLI")
+Rel(cloudflare, webapp, "DNS / CDN / Tunnel", "HTTPS")
+BiRel(webapp, thirdparty, "Checkout / webhooks / page events", "HTTPS")
+Rel(engine, thirdparty, "Notifications", "Webhook")
 ```
+
+## Details
+
+**`webapp` (Web Application) — folded from L2 source for visual budget; original Mermaid aliases preserved:**
+
+- `dashboard` (React, Next.js) — conversation UI, knowledge base viewer, session management
+- `api` (Next.js API) — REST endpoints for auth, sessions, and agent control
+- `auth` (Supabase Auth) — JWT authentication, OAuth providers, session tokens
+
+**`engine` (Cloud CLI Engine) — folded from L2 source:**
+
+- `claude` (Claude Code) — executes agent workflows with full orchestration tools
+- `skillloader` (Plugin Discovery) — discovers and loads skills, agents, commands from the plugin directory
+- `hooks` (PreToolUse Guards) — enforces syntactic rules; blocks commits to main, `rm -rf`, etc.
+
+**`plugin_box` (Soleur Plugin) — see L3 `component-plugin.md` for full decomposition:**
+
+- `skills` — workflow skills (brainstorm, plan, work, review, compound, ship, one-shot, …) under `plugins/soleur/skills/`
+- `agents` — domain agents across 8 departments under `plugins/soleur/agents/`
+- `kb` — Markdown + YAML conventions, learnings, ADRs, specs, plans, brainstorms under `knowledge-base/`
+
+**`compute` (Compute & Tunnel) — folded from L2 source:**
+
+- `tunnel` (cloudflared) — zero-trust inbound access; no exposed ports (ADR-008)
+- `hetzner` (Hetzner Cloud) — Docker containers running web app and CLI engine (ADR-006)
+
+**`thirdparty` (Third-Party Services) — same fold as L1 `system-context.md`:**
+
+- `stripe` — payment processing and subscription checkout + webhooks (test mode)
+- `discord` — community notifications and release announcements via webhook
+- `plausible` — privacy-focused page-view analytics (no cookies, GDPR-compliant)
 
 ## Notes
 

--- a/knowledge-base/engineering/architecture/diagrams/system-context.md
+++ b/knowledge-base/engineering/architecture/diagrams/system-context.md
@@ -1,10 +1,12 @@
 # Soleur Platform — System Context (C4 Level 1)
 
-Generated: 2026-03-27
+Generated: 2026-05-13 (visual redesign per SOL-40, was 2026-03-27)
 
 ```mermaid
 C4Context
 title System Context diagram for Soleur Platform
+
+UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
 
 Person(founder, "Founder", "Solo founder using Soleur as their AI organization")
 
@@ -14,27 +16,33 @@ Enterprise_Boundary(b0, "Soleur Platform") {
     SystemDb(supabase, "Supabase", "Auth, PostgreSQL database, and file storage")
 }
 
-System_Ext(anthropic, "Anthropic API", "Claude LLM for agent reasoning and tool use")
-System_Ext(github, "GitHub", "Source control, CI/CD, issue tracking, and releases")
 System_Ext(cloudflare, "Cloudflare", "DNS, CDN, R2 storage, and zero-trust tunnel")
 System_Ext(doppler, "Doppler", "Centralized secrets management with runtime injection")
-System_Ext(discord, "Discord", "Community notifications and release announcements")
-System_Ext(stripe, "Stripe", "Payment processing and subscription billing")
-System_Ext(plausible, "Plausible Analytics", "Privacy-focused website analytics")
+System_Ext(anthropic, "Anthropic API", "Claude LLM for agent reasoning and tool use")
+System_Ext(github, "GitHub", "Source control, CI/CD, issue tracking, and releases")
+System_Ext(thirdparty, "Third-Party Services", "Discord + Stripe + Plausible — see Details")
 
 Rel(founder, webapp, "Interacts via browser", "HTTPS")
 Rel(webapp, engine, "Thin view/control layer", "WebSocket")
 Rel(webapp, supabase, "Auth and data", "HTTPS")
-Rel(webapp, stripe, "Checkout and billing", "HTTPS")
-Rel(webapp, plausible, "Page view events", "JS snippet")
-Rel(engine, anthropic, "LLM calls with BYOK keys", "HTTPS")
-Rel(engine, github, "Git operations and CI", "HTTPS/SSH")
 Rel(engine, supabase, "Sessions and encrypted keys", "HTTPS")
-Rel(engine, discord, "Notifications", "Webhook")
 Rel(cloudflare, webapp, "Tunnel, DNS, CDN", "HTTPS")
 Rel(doppler, engine, "Runtime secrets", "CLI")
-Rel(stripe, webapp, "Payment webhooks", "HTTPS")
+Rel(engine, anthropic, "LLM calls with BYOK keys", "HTTPS")
+Rel(engine, github, "Git operations and CI", "HTTPS/SSH")
+BiRel(webapp, thirdparty, "Checkout / webhooks / page events", "HTTPS")
+Rel(engine, thirdparty, "Notifications", "Webhook")
 ```
+
+## Details
+
+**`thirdparty` group contains** (original Mermaid aliases preserved for grep-ability):
+
+- `discord` — Discord — community notifications and release announcements
+- `stripe` — Stripe — payment processing and subscription billing (test mode)
+- `plausible` — Plausible Analytics — privacy-focused page-view tracking
+
+All three are external SaaS systems with low individual visual signal at the system-context level. The `BiRel(webapp, thirdparty)` covers Stripe checkout + Stripe webhooks + Plausible JS events. The `Rel(engine, thirdparty)` covers Discord webhook notifications.
 
 ## Notes
 

--- a/knowledge-base/project/brainstorms/2026-05-13-c4-diagram-visual-redesign-brainstorm.md
+++ b/knowledge-base/project/brainstorms/2026-05-13-c4-diagram-visual-redesign-brainstorm.md
@@ -1,0 +1,75 @@
+---
+title: C4 Architecture Diagram Visual Redesign
+date: 2026-05-13
+linear_issue: SOL-40
+related_pr: https://github.com/jikig-ai/soleur/pull/3713
+worktree: .worktrees/feat-sol-40-redesign-c4-model/
+spec: knowledge-base/project/specs/feat-sol-40-redesign-c4-model/spec.md
+lane: cross-domain
+brand_survival_threshold: none (internal architecture documentation)
+status: complete
+---
+
+# C4 Architecture Diagram Visual Redesign — Brainstorm
+
+## What We're Building
+
+A visual redesign of the three existing C4 architecture diagrams so they render legibly on GitHub markdown preview. Source format stays Mermaid. Filenames stay unchanged. Each file keeps one rendered diagram, restructured to fit within Mermaid's auto-layout ceiling.
+
+Files in scope:
+
+- `knowledge-base/engineering/architecture/diagrams/system-context.md` (C4 Level 1)
+- `knowledge-base/engineering/architecture/diagrams/container.md` (C4 Level 2)
+- `knowledge-base/engineering/architecture/diagrams/component-plugin.md` (C4 Level 3)
+
+## Why This Approach
+
+Mermaid's `C4Context` / `C4Container` / `C4Component` renderer is the layout ceiling — it does not honor `Container_Boundary` grouping reliably, and arrows are routed point-to-point with no avoidance heuristic. The CTO assessment confirms this is a renderer ceiling, not a source defect. Restructuring the source helps only by reducing the load (fewer nodes, fewer edges, controlled boundary ordering).
+
+The CTO also confirms switching renderers is technically low-risk (the Eleventy docs site does not render these files — `knowledge-base/**` is excluded from `deploy-docs.yml`; only GitHub markdown preview and IDE consume them). However, the operator preferred to **stay on Mermaid** to preserve GitHub-native inline rendering without committing parallel SVG artifacts. The COO recommendation (Likec4) and the prior deferred decision from `2026-03-27-architecture-as-code-brainstorm.md` (open question #5 — "Start with Mermaid-only and add Structurizr later?") remain available as a follow-up.
+
+A deferred-issue path captures the architectural debt the agents surfaced — staleness, missing views, hand-authored drift — so SOL-40 stays tight.
+
+## Key Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | **Scope = visual fix only.** Out of scope: content staleness updates, new C4 views (Deployment, additional L3s), and auto-generation from code manifests. | Keeps SOL-40 shippable. Each deferred concern becomes its own GitHub issue (see Deferred Items below). |
+| D2 | **Stay on Mermaid.** No renderer swap. | GitHub markdown preview must keep working without committing parallel SVGs. The 19+ ADRs referencing existing filenames stay intact. Operator preference. |
+| D3 | **Same 3 files, same filenames, one Mermaid block per file.** No splitting into per-subsystem files. | Preserves ~12 cross-references from ADRs, plans, specs (see Cross-references in repo research). |
+| D4 | **Slim-down tactic = Approach C** — relation bundling on L1, aggressive node trim on L2/L3, with a `## Details` prose section below each diagram listing what was folded. | L1 (8 nodes) is small enough that bundling alone fixes it. L2/L3 are above Mermaid's auto-layout ceiling and need node count reduction. The Details section keeps the folded information grep-able without polluting the diagram. |
+| D5 | **Node-count budget per diagram: L1 ≤ 8, L2 ≤ 10, L3 ≤ 8.** Anything beyond moves into the `## Details` section. | Empirically the threshold where Mermaid's C4 renderer keeps arrows un-crossed. |
+| D6 | **Bundle related `Rel()` edges into single labeled edges.** | Three separate "Reads / Writes / Discovers" rels become one "Loads plugin [File I/O]" rel. Cuts edge count without losing the semantic story. |
+| D7 | **Reorder boundary declaration top-to-bottom by data flow** (Founder → Web → CLI → Plugin → Infra). Set `UpdateLayoutConfig($c4ShapeInRow=3, $c4BoundaryInRow=2)`. | Aligns Mermaid's row-wrap with the architectural flow direction, reducing arrow crossings. |
+| D8 | **Mermaid retained as the standard diagram format.** Likec4 / D2 / Structurizr DSL remain deferred per `2026-03-27-architecture-as-code-brainstorm.md` open question #5. | No ADR formally locks Mermaid (the locking is in the as-code plan / spec, not an ADR). No new ADR required for D2; renderer swap, if revisited, will need one. |
+
+## Open Questions
+
+- After restructure renders, does L3 still have residual arrow overlap? If yes, the deferred renderer-swap follow-up gets prioritized rather than waiting indefinitely.
+- Should the `architecture` skill's `c4-reference.md` reference be updated to teach the slim-down conventions (node budget, edge bundling, boundary order)? Tracked as a possible follow-up.
+
+## Domain Assessments
+
+**Assessed:** Marketing, Engineering, Operations, Product, Legal, Sales, Finance, Support
+
+### Engineering
+
+**Summary:** Root cause is Mermaid's experimental C4 renderer hitting its auto-layout ceiling on medium-to-large diagrams, not a source defect. Source restructure reduces density but cannot fully fix L3 (14 components). Renderer-swap is technically low-risk (zero docs-site coupling) but adds a second toolchain. Diagrams are LLM-hand-authored and will drift from code regardless of renderer — flagged as a separate concern.
+
+### Operations
+
+**Summary:** Likec4 is the lowest-friction renderer alternative (Node devDep, zero spend, free auto-layout). IcePanel rejected at $40/editor/mo and loss of diff-friendly source. Stay-on-Mermaid is the zero-cost zero-procurement baseline. Recommendation respected operator's stay-on-Mermaid choice; full Likec4 evaluation captured as a deferred follow-up rather than discarded.
+
+## Capability Gaps
+
+No new capability gaps. The `architecture` skill already exists and handles ADR lifecycle and C4 diagram scaffolding (LLM-authored). No new skills, agents, or commands are required. Auto-generation from a plugin manifest is a *latent* gap but explicitly out-of-scope for SOL-40.
+
+## Deferred Items
+
+Tracked as separate GitHub issues at Phase 3.6:
+
+1. **Content refresh** — `container.md` reports "61 skills, 65 agents" but actual count is 71/66; missing skills include ship, qa, merge-pr, linear-fetch, agent-native-audit; missing domain leaders include CLO, COO, CFO, CRO, CCO. Re-evaluation criterion: at any point the diagrams' counts mismatch the live `find` count by more than 10%.
+2. **Add L3 views for non-plugin containers** — Web App (Dashboard / API / Auth), Agent Runtime internals, Hook Engine. Re-evaluation criterion: when a contributor cannot answer "how does the web app spawn an agent session?" from existing diagrams.
+3. **Add a C4Deployment view** — given ADR-006 (Terraform/R2), ADR-007 (Doppler), ADR-008 (Cloudflare Tunnel), ADR-019 (infra layout), a deployment view would carry real signal. Re-evaluation criterion: when next onboarding a contractor or audit team to the infra.
+4. **Code-introspected diagram generation** — replace the LLM-authored scaffold in `plugins/soleur/skills/architecture/SKILL.md` with a manifest scanner that emits Mermaid (or whichever renderer is chosen) from `plugins/soleur/{commands,skills,agents}/` discovery. Re-evaluation criterion: when manual content refreshes (item 1) happen more than once per quarter.
+5. **Renderer evaluation (Likec4 / D2 / Structurizr DSL)** — revisits open question #5 of `2026-03-27-architecture-as-code-brainstorm.md`. Re-evaluation criterion: when item 1's content refresh or this brainstorm's L3 restructure leaves residual layout problems that source restructuring cannot fix.

--- a/knowledge-base/project/plans/2026-05-13-feat-sol-40-redesign-c4-diagrams-plan.md
+++ b/knowledge-base/project/plans/2026-05-13-feat-sol-40-redesign-c4-diagrams-plan.md
@@ -1,0 +1,323 @@
+---
+title: SOL-40 — Redesign C4 Architecture Diagrams
+type: feat
+date: 2026-05-13
+linear_issue: SOL-40
+related_pr: https://github.com/jikig-ai/soleur/pull/3713
+brainstorm: knowledge-base/project/brainstorms/2026-05-13-c4-diagram-visual-redesign-brainstorm.md
+spec: knowledge-base/project/specs/feat-sol-40-redesign-c4-model/spec.md
+worktree: .worktrees/feat-sol-40-redesign-c4-model/
+branch: feat-sol-40-redesign-c4-model
+deferred_followups: ["#3714", "#3715", "#3716", "#3717", "#3718"]
+lane: cross-domain
+brand_survival_threshold: none (internal architecture documentation)
+requires_cpo_signoff: false
+status: ready
+---
+
+# SOL-40 — Redesign C4 Architecture Diagrams
+
+## Overview
+
+Restructure the source of three Mermaid C4 diagrams in `knowledge-base/engineering/architecture/diagrams/` so each rendered block lands within Mermaid's auto-layout ceiling. Source format, filenames, and rendering surface stay unchanged. Folded detail moves into a prose `## Details` section per file so semantic content stays grep-able.
+
+Three deeper concerns (content staleness, missing views, hand-author drift) are out of scope and filed as deferred issues #3714 / #3715 / #3716 / #3717 / #3718.
+
+## Problem Statement
+
+The three diagrams render with overlapping arrows, label collisions, and boundary frames that visually do not contain their declared components. L3 Component is functionally illegible at 18 visible nodes. CTO assessment (brainstorm): Mermaid's C4 renderer is the auto-layout ceiling — not a source defect. Source restructure can land each rendered block under the ceiling; renderer swap (deferred #3718) is the alternative if restructure proves insufficient.
+
+## Research Reconciliation — Spec vs. Codebase
+
+Plan-time recount via `grep -cE '^[[:space:]]*(Person|Container|Component|System_Ext|System|SystemDb|ContainerDb)\(' <file>` exposed gaps in the spec's node-count assumption. The spec is amended in this PR to align with reality.
+
+| Diagram | Spec v1 budget | Actual nodes | Spec v2 budget | Folds applied | Final visible |
+|---|---|---|---|---|---|
+| L1 system-context | ≤ 8 | 11 | **≤ 9** | discord+stripe+plausible → `thirdparty` (saves 2) | **9** |
+| L2 container | ≤ 10 | 19 | **≤ 11** | 4 per-boundary collapses + thirdparty external fold (saves 8) | **11** |
+| L3 component-plugin | ≤ 8 | 18 | ≤ 8 (unchanged) | entry-points (3→1) + workflow-skills (8→1) + leaders (4→1) (saves 12) | **6** |
+
+L1 keeps `doppler` distinct (ADR-007 architectural significance). L2 keeps `doppler` distinct for the same reason — spec G2 amended to ≤ 11 rather than fold doppler. Spec FR1/FR2 also amended to quote `UpdateLayoutConfig` values (per `c4-reference.md:77` — unquoted values fail silently) and to enumerate the additional L2 folds.
+
+**Verified cross-reference counts** (post-plan-write grep, excluding this plan/spec/brainstorm from the count):
+
+- `system-context.md`: **4 consumers** — `INDEX.md`, 2 plans, 1 spec tasks.md
+- `container.md`: **12 consumers** — `INDEX.md`, `nfr-register.md`, `nfr-reference.md`, 6 plans, 1 archived plan, 2 learnings, 1 spec tasks.md, 1 archived spec tasks.md
+- `component-plugin.md`: **1 consumer** — `INDEX.md`
+
+Filenames stay stable so no sweep is required. The verification re-runs at AC4.
+
+## User-Brand Impact
+
+- **If this lands broken, the user experiences:** architecture diagrams render with overlap → contributor confusion during onboarding. No live user surface.
+- **If this leaks, the user's data is exposed via:** N/A — diagrams describe public architecture already documented in ADRs.
+- **Brand-survival threshold:** `none` (internal architecture documentation, no end-user touch point)
+
+Sensitive-path check: diff touches `knowledge-base/engineering/architecture/diagrams/*.md` + `knowledge-base/project/specs/feat-sol-40-redesign-c4-model/spec.md`. Neither matches preflight Check 6 patterns. No scope-out bullet required.
+
+## Domain Review
+
+**Domains relevant:** Engineering, Operations (both carried forward from brainstorm)
+
+### Engineering
+
+**Status:** reviewed (brainstorm carry-forward)
+**Assessment:** Mermaid C4 is the layout ceiling; source restructure reduces density but cannot fully fix L3. Renderer swap is technically low-risk (zero docs-site coupling) but adds a second toolchain. Diagrams are LLM-hand-authored and will drift from code — tracked as #3717.
+
+### Operations
+
+**Status:** reviewed (brainstorm carry-forward)
+**Assessment:** Likec4 is the lowest-friction alternative if swap is later adopted. Stay-on-Mermaid is the zero-cost baseline this plan executes. Renderer evaluation captured as #3718.
+
+### Product/UX Gate
+
+Not invoked — Product domain was NONE in brainstorm (no user-facing surfaces, no UI, no copy changes).
+
+## Open Code-Review Overlap
+
+**None.** Queried 75 open `code-review`-labeled issues against the three planned-edit diagram files + the spec. Zero matches.
+
+## Files to Edit
+
+| File | Purpose |
+|---|---|
+| `knowledge-base/engineering/architecture/diagrams/system-context.md` | L1 restructure + Details section + stamp |
+| `knowledge-base/engineering/architecture/diagrams/container.md` | L2 restructure + Details section + stamp |
+| `knowledge-base/engineering/architecture/diagrams/component-plugin.md` | L3 restructure + Details section + stamp |
+| `knowledge-base/project/specs/feat-sol-40-redesign-c4-model/spec.md` | Amend G2 budgets to ≤9/≤11/≤8; quote UpdateLayoutConfig values; enumerate L2 boundary folds in FR2 |
+
+## Files to Create
+
+None.
+
+## Technical Considerations
+
+- **Architecture impact:** none. No new components, no behavior change.
+- **NFR impact:** none. Diagrams are descriptive artifacts.
+- **Cross-references preserved:** filenames stable; no consumer-file sweep needed.
+- **Mermaid `UpdateLayoutConfig` semantics:** `$c4ShapeInRow="N"` / `$c4BoundaryInRow="M"` — values are **quoted strings** per `c4-reference.md:77`. Unquoted values fail silently (keep defaults).
+
+## Implementation Phases
+
+### Phase 0: Amend spec.md
+
+Update `knowledge-base/project/specs/feat-sol-40-redesign-c4-model/spec.md`:
+
+- G2: `L1 ≤ 8` → `L1 ≤ 9`; `L2 ≤ 10` → `L2 ≤ 11`. Add note: "Amended 2026-05-13 after plan-time recount; ADR-007 importance keeps doppler distinct."
+- FR1: change `UpdateLayoutConfig($c4ShapeInRow=3, $c4BoundaryInRow=2)` → `UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")`. Note the quoting rationale inline.
+- FR1: replace "if exceeds 8, fold plausible+discord into Analytics & Notifications" with "fold discord+stripe+plausible into single `thirdparty` external for visual budget; preserve semantic detail in `## Details`".
+- FR2: change `UpdateLayoutConfig` values to quoted strings (`"2"`, `"2"`).
+- FR2: enumerate the four additional boundary-level folds (Web App / CLI Engine / Plugin Resources / Compute & Tunnel) beyond just `Plugin Resources`.
+- FR3: change `UpdateLayoutConfig` values to quoted strings (`"1"`, `"1"`).
+
+These amendments make spec and plan agree before Phases 1-3 execute. Commit at end of Phase 0; subsequent phases share the same PR commit chain.
+
+### Phase 1: Restructure L1 — `system-context.md`
+
+**Target:** 9 visible nodes, ≤ 10 Rel edges, top-to-bottom flow.
+
+**Fold map (folds only; everything else stays):**
+
+| Current | Action |
+|---|---|
+| `System_Ext(discord)` + `System_Ext(stripe)` + `System_Ext(plausible)` | **Fold to one:** `System_Ext(thirdparty, "Third-Party Services", "Discord + Stripe + Plausible")` |
+
+Visible after: founder, webapp, engine, supabase, anthropic, github, cloudflare, doppler, thirdparty = **9**.
+
+**Relation bundling:** combine `Rel(webapp, stripe, ...)` + `Rel(stripe, webapp, ...)` + `Rel(webapp, plausible, ...)` into one `BiRel(webapp, thirdparty, "Checkout / webhooks / page events", "HTTPS")`. Bundle `Rel(engine, discord, ...)` into the same `thirdparty` target.
+
+**Boundary-flow ordering:** Person → Enterprise_Boundary → cloudflare → doppler → anthropic → github → thirdparty.
+
+**Layout:** `UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")`.
+
+**`## Details` section** (alias-preserving, with source paths for #3714's future audit):
+
+```markdown
+## Details
+
+**`thirdparty` group contains** (original Mermaid aliases preserved):
+
+- `discord` — Discord — community notifications and release announcements
+- `stripe` — Stripe — payment processing and subscription billing (test mode)
+- `plausible` — Plausible Analytics — privacy-focused page-view tracking
+```
+
+**Stamp:** `Generated: 2026-05-13 (visual redesign per SOL-40, was 2026-03-27)`.
+
+**Visual gate:** push, view `https://github.com/jikig-ai/soleur/pull/3713/files`, confirm no crossing arrows and no label collisions on GitHub's rendered Mermaid view at desktop viewport. If pass, advance.
+
+### Phase 2: Restructure L2 — `container.md`
+
+**Target:** 11 visible nodes, ≤ 12 Rel edges, top-to-bottom flow.
+
+**Fold map (folds only):**
+
+| Boundary | Action |
+|---|---|
+| Web Application (dashboard + api + auth) | **Fold to 1:** `Container(webapp, "Web Application", "Next.js PWA", "Dashboard UI + API routes + Supabase Auth")` |
+| Cloud CLI Engine (claude + skillloader + hooks) | **Fold to 1:** `Container(engine, "Cloud CLI Engine", "Claude Code", "Agent runtime + plugin discovery + hook engine")` |
+| Soleur Plugin (skills + agents + kb) | **Fold to 1:** `Container(plugin, "Soleur Plugin", "Markdown", "Skills + Agents + Knowledge Base — see L3")` |
+| Infrastructure (tunnel + hetzner) | **Fold to 1:** `Container(compute, "Compute & Tunnel", "Hetzner Cloud + Cloudflare Tunnel", "Docker containers behind zero-trust tunnel")`. Keep `ContainerDb(supabase, ...)` separate. |
+| Externals: discord + stripe + plausible | **Fold to 1:** `System_Ext(thirdparty, ...)` (matches Phase 1 fold) |
+
+Visible after: founder, webapp, engine, plugin, supabase, compute, anthropic, github, cloudflare, doppler, thirdparty = **11**.
+
+**Relation bundling:** dashboard→api→auth chain disappears with the fold. `api→claude` becomes `webapp→engine`. `claude→skillloader→skills/agents` + `hooks→claude` collapse to `Rel(engine, plugin, "Loads + guards", "File I/O + event hook")`. Externals bundle into `thirdparty` per Phase 1.
+
+**Boundary-flow ordering:** Person → Web App → CLI Engine → Plugin → Infrastructure (supabase + compute) → externals.
+
+**Layout:** `UpdateLayoutConfig($c4ShapeInRow="2", $c4BoundaryInRow="2")`.
+
+**`## Details`** enumerates per-folded-boundary contents with original aliases:
+
+```markdown
+## Details
+
+**`webapp` (Web Application) — folded from L2 source:**
+
+- `dashboard` (React, Next.js) — conversation UI, KB viewer, session management
+- `api` (Next.js API) — REST endpoints for auth, sessions, agent control
+- `auth` (Supabase Auth) — JWT, OAuth providers, session tokens
+
+**`engine` (Cloud CLI Engine) — folded from L2 source:**
+
+- `claude` (Claude Code) — executes agent workflows
+- `skillloader` (Plugin Discovery) — loads skills, agents, commands
+- `hooks` (PreToolUse Guards) — enforces syntactic rules, blocks dangerous tool calls
+
+**`plugin` (Soleur Plugin) — see L3 `component-plugin.md` for decomposition:**
+
+- `skills` — workflow skills (brainstorm, plan, work, review, compound, ship, one-shot, …)
+- `agents` — domain agents across 8 departments
+- `kb` — Markdown + YAML conventions, learnings, ADRs, specs, plans, brainstorms
+
+**`compute` (Compute & Tunnel) — folded from L2 source:**
+
+- `tunnel` (cloudflared) — zero-trust inbound access (ADR-008)
+- `hetzner` (Hetzner Cloud) — Docker containers running web app + CLI engine (ADR-006)
+
+**`thirdparty` (Third-Party Services) — see L1 Details** (same fold).
+```
+
+**Stamp:** updated per Phase 1 convention.
+
+**Visual gate:** same as Phase 1.
+
+### Phase 3: Restructure L3 — `component-plugin.md`
+
+**Target:** 6 visible nodes, ≤ 8 Rel edges.
+
+**Fold map (folds only):**
+
+| Current | Action |
+|---|---|
+| `Component(go)` + `Component(sync)` + `Component(help)` | **Fold to 1:** `Component(entry, "Entry-Point Commands", "Markdown", "go, sync, help")` |
+| `Component(brainstorm)` + `Component(plan)` + `Component(work)` + `Component(review)` + `Component(compound)` + `Component(ship)` + `Component(oneshot)` + `Component(architecture)` | **Fold to 1:** `Component(workflows, "Workflow Skills", "Markdown", "8 skills — see Details")` |
+| `Component(cto)` + `Component(cmo)` + `Component(cpo)` + `Component(archstrat)` | **Fold to 1:** `Component(leaders, "Domain Leaders & Reviewers", "Markdown", "4 visible; see Details")` |
+
+External `claude`, `hooks`, `kb` containers kept as-is. Visible: 3 inside boundary + 3 external = **6**.
+
+**Relation bundling:** all `Rel(go|sync|help, *)` collapse under `entry`. `Rel(oneshot, plan|work|review|compound|ship)` (5 edges) drop — orchestration is documented in `## Details`, not the diagram. `Rel(brainstorm|plan|review, cto|cmo|cpo|archstrat)` (6 edges) collapse to `Rel(workflows, leaders, "Phase 0.5 / 2.5 / review assessments", "Task spawn")`. `Rel(cto|archstrat, architecture)` collapse to `Rel(leaders, workflows, "Recommend ADR / coverage check", "Task spawn")`. `Rel(claude, entry, "User invokes /soleur:<cmd>")`. `Rel(hooks, claude, "Guards tool calls")`. `Rel(workflows, kb, "Reads + writes")`. `Rel(leaders, kb, "Reads")`.
+
+Final Rel count: 6.
+
+**Boundary-flow ordering:** external `claude` + `hooks` at top → `Container_Boundary(plugin)` containing entry → workflows → leaders → `kb` at bottom.
+
+**Layout:** `UpdateLayoutConfig($c4ShapeInRow="1", $c4BoundaryInRow="1")`.
+
+**`## Details`** is the most substantive of the three files — full list with aliases:
+
+```markdown
+## Details
+
+**`entry` (Entry-Point Commands)** — `plugins/soleur/commands/`:
+
+- `go` — classifies intent and routes to workflow skills
+- `sync` — populates knowledge-base from existing codebase
+- `help` — lists all commands, skills, and agents
+
+**`workflows` (Workflow Skills)** — `plugins/soleur/skills/`:
+
+- `brainstorm` — explores requirements with domain leader assessment
+- `plan` — creates implementation plans with research and domain review
+- `work` — executes plans with incremental commits and test-first
+- `review` — multi-agent code review
+- `compound` — captures learnings and promotes to constitution
+- `ship` — validates artifacts, creates PR, manages merge lifecycle
+- `one-shot` — full autonomous pipeline (orchestrates plan → work → review → compound → ship as Steps 1-5)
+- `architecture` — ADR lifecycle and C4 diagram generation
+
+**`leaders` (Domain Leaders & Reviewers)** — `plugins/soleur/agents/`:
+
+- `cto` — engineering assessment, architecture decision detection
+- `cmo` — marketing assessment, content opportunities
+- `cpo` — product strategy, UX flow analysis
+- `architecture-strategist` — architectural compliance and ADR coverage check at review time
+
+Other domain leaders exist (`clo`, `coo`, `cfo`, `cro`, `cco`) — folded out for visual budget; tracked in #3714.
+
+**External containers:** `claude` (Agent Runtime), `hooks` (Hook Engine), `kb` (Knowledge Base) — defined at L2.
+```
+
+**Stamp:** same convention.
+
+**Visual gate:** push, view on PR. **If L3 still has overlap after the trim:**
+
+1. Drop the `Rel(leaders, workflows, "Recommend ADR / coverage check")` edge (lowest signal — the relationship is captured in Details).
+2. Reverse boundary declaration order to place `kb` first and externals last; Mermaid C4 places earlier declarations higher in the layout grid.
+3. **Fallback (≥ 30 min hand-tweak):** file a delta-issue on #3718 (renderer evaluation) and prepend a one-line known-limitation note to `component-plugin.md` directly under the title. Mark AC3 partially-met in PR body, ship L1+L2. Drafting the banner takes ~2 minutes if/when it fires; not pre-specified here.
+
+Spec NG4 ("renderer evaluation out of scope") does NOT forbid filing the deferred-issue delta — it forbids running the evaluation in this PR.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] **AC1 — L1 visual gate.** `system-context.md` renders on GitHub PR diff view at desktop viewport with no crossing arrows and no label-on-label or label-on-box collisions; visible node count = 9. `## Details` section enumerates every folded node by its **original Mermaid alias** verbatim. `Generated:` stamp updated.
+- [ ] **AC2 — L2 visual gate.** `container.md` same gate; visible node count ≤ 11; `## Details` present with original aliases; stamp updated.
+- [ ] **AC3 — L3 visual gate.** `component-plugin.md` same gate; visible node count ≤ 8; `## Details` present with original aliases; stamp updated. **Fallback branch:** if AC3 fails the visual gate after Phase 3's escalation sequence + 30-min cap, AC3 is partially-met IF (a) a delta-issue against #3718 is filed with L3 evidence, (b) a known-limitation note is prepended to `component-plugin.md`, (c) the PR body documents the partial-success.
+- [ ] **AC4 — Cross-references intact.** Re-run the verification grep and confirm the same counts as plan-time (4 / 12 / 1). Command (note: three separate `:!` excludes — git pathspec does not support brace expansion):
+
+  ```bash
+  git grep -l "system-context\.md" \
+    -- ':!knowledge-base/engineering/architecture/diagrams/' \
+       ':!knowledge-base/project/brainstorms/2026-05-13-c4-diagram-visual-redesign-brainstorm.md' \
+       ':!knowledge-base/project/specs/feat-sol-40-redesign-c4-model/spec.md' \
+       ':!knowledge-base/project/plans/2026-05-13-feat-sol-40-redesign-c4-diagrams-plan.md' \
+    | sort -u | wc -l   # expect 4
+  ```
+
+  Repeat for `container\.md` (expect 12) and `component-plugin\.md` (expect 1). Drift requires investigation before merge.
+
+### Post-merge
+
+None — docs-only change.
+
+## Test Scenarios
+
+- Given the redesigned `system-context.md` on the PR's diff view, when viewed at desktop viewport, then 9 nodes appear with zero crossing arrows and zero label collisions.
+- Given the redesigned `container.md` on the PR's diff view, when viewed at desktop viewport, then ≤ 11 nodes appear grouped into 4 boundaries that visually contain their declared containers.
+- Given the redesigned `component-plugin.md` on the PR's diff view, when viewed at desktop viewport, then ≤ 8 nodes appear and the Soleur Plugin boundary visibly contains entry, workflows, and leaders.
+- Given any of the three files, when scrolled below the Mermaid block, then `## Details` enumerates every folded element with its **original Mermaid alias**.
+- Given Phase 3's escalation cap is hit, when the fallback fires, then a delta-issue on #3718 is filed, the known-limitation note is added, and AC3 is marked partially-met in the PR body.
+
+## Dependencies & Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| L3 still illegible after the fold map | Medium | Phase 3 escalation sequence + 30-min cap + fallback to delta-issue on #3718. |
+| Visual gate is subjective | Low | AFTER screenshots in PR body are the tiebreaker; PR diff view at desktop viewport is the source of truth. |
+
+## References
+
+**Internal:** brainstorm, spec, `c4-reference.md`, `architecture` skill, prior decision `2026-03-27-architecture-as-code-brainstorm.md` open question #5 (deferred Structurizr DSL).
+
+**External:** https://c4model.com, https://mermaid.js.org/syntax/c4.html
+
+**Related:** PR #3713 (draft) | Linear SOL-40 | Deferred follow-ups #3714 / #3715 / #3716 / #3717 / #3718
+
+## Sharp Edges
+
+- `UpdateLayoutConfig` values must be **quoted strings** (`"3"`, not `3`) per `c4-reference.md:77`. Unquoted values fail silently — Mermaid keeps defaults.
+- `BiRel()` does not always reduce arrow count — renderer may emit two arrows depending on Mermaid version. If the visual gate shows two arrows where one was expected, fall back to separate `Rel()` calls.
+- Git pathspec exclude (`:!path`) does NOT support brace expansion. AC4's verification grep lists each excluded path on its own `:!` line. Compact forms like `':!a/{x,y}'` are silently ineffective — both `x` and `y` leak back into results.

--- a/knowledge-base/project/specs/feat-sol-40-redesign-c4-model/spec.md
+++ b/knowledge-base/project/specs/feat-sol-40-redesign-c4-model/spec.md
@@ -20,7 +20,7 @@ The three existing C4 architecture diagrams in `knowledge-base/engineering/archi
 ## Goals
 
 - G1 — `system-context.md`, `container.md`, and `component-plugin.md` render with zero overlapping arrows and zero label collisions on GitHub markdown preview.
-- G2 — Each rendered Mermaid block stays within the node-count budget: L1 ≤ 8, L2 ≤ 10, L3 ≤ 8.
+- G2 — Each rendered Mermaid block stays within the node-count budget: **L1 ≤ 9, L2 ≤ 11, L3 ≤ 8**. (Amended 2026-05-13 from initial draft `L1 ≤ 8 / L2 ≤ 10` after plan-time recount; ADR-007 architectural significance keeps `doppler` distinct at both levels rather than fold it.)
 - G3 — All semantic content currently represented in the three diagrams remains discoverable in the same file (either inside the Mermaid block or in a new `## Details` prose section).
 - G4 — Filenames `system-context.md`, `container.md`, `component-plugin.md` remain unchanged so the 19+ ADR / plan / spec cross-references stay valid.
 - G5 — No new tooling, no new runtime dependency, no new CI step. Source format stays Mermaid.
@@ -41,18 +41,24 @@ Apply relation bundling to `system-context.md`:
 
 - Combine related `Rel()` edges that share source and target into a single labeled bundle (e.g., today's separate "Auth and data" + "Sessions and encrypted keys" become bundled per source-target pair).
 - Reorder boundary and system_ext declaration top-to-bottom by data flow direction: Founder → Web App → Cloud CLI Engine → Supabase → External systems.
-- Apply `UpdateLayoutConfig($c4ShapeInRow=3, $c4BoundaryInRow=2)`.
-- Maintain the existing 8 systems (founder, webapp, engine, supabase, anthropic, github, cloudflare, doppler, discord, stripe, plausible) **subject to G2** — if node count exceeds 8, fold the lowest-signal external systems (e.g., plausible, discord) into a single `Analytics & Notifications` system_ext with the folded detail in the `## Details` section.
+- Apply `UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")`. **Values are quoted strings** per `plugins/soleur/skills/architecture/references/c4-reference.md:77` — unquoted values fail silently (Mermaid keeps defaults).
+- Fold `discord` + `stripe` + `plausible` into a single `System_Ext(thirdparty, "Third-Party Services", "Discord + Stripe + Plausible")`. Preserve original Mermaid aliases (`discord`, `stripe`, `plausible`) and per-system role descriptions in the new `## Details` section below the Mermaid block. Final visible node count: 9 (founder + 3 internal + cloudflare + doppler + anthropic + github + thirdparty).
 
 ### FR2: Container (L2) restructure
 
-Apply aggressive node trim to `container.md`:
+Apply aggressive node trim to `container.md` — fold each boundary's internal containers to a single representative container plus the same `thirdparty` external fold from FR1:
 
-- Inside the `Soleur Plugin` boundary, collapse `Skills` + `Agents` + `Knowledge Base` into a single `Plugin Resources` container (their detail belongs at L3 anyway).
-- Reorder boundary declarations top-to-bottom by data flow: Web Application → Cloud CLI Engine → Soleur Plugin → Infrastructure.
+- Web Application boundary: collapse `dashboard` + `api` + `auth` into a single `Container(webapp, "Web Application", "Next.js PWA", "Dashboard UI + API routes + Supabase Auth")`.
+- Cloud CLI Engine boundary: collapse `claude` + `skillloader` + `hooks` into a single `Container(engine, "Cloud CLI Engine", "Claude Code", "Agent runtime + plugin discovery + hook engine")`.
+- Soleur Plugin boundary: collapse `skills` + `agents` + `kb` into a single `Container(plugin, "Soleur Plugin", "Markdown", "Skills + Agents + Knowledge Base — see L3")`.
+- Infrastructure boundary: collapse `tunnel` + `hetzner` into a single `Container(compute, "Compute & Tunnel", "Hetzner Cloud + Cloudflare Tunnel", "Docker containers behind zero-trust tunnel")`. Keep `ContainerDb(supabase, ...)` separate (data store visibility).
+- Externals: fold `discord` + `stripe` + `plausible` into single `System_Ext(thirdparty, ...)` (same fold as FR1).
+- Reorder boundary declarations top-to-bottom by data flow: Web Application → Cloud CLI Engine → Soleur Plugin → Infrastructure (supabase + compute) → externals.
 - Bundle redundant cross-boundary `Rel()` edges where source-target pairs share semantics.
-- Apply `UpdateLayoutConfig($c4ShapeInRow=2, $c4BoundaryInRow=2)`.
-- Add a `## Details` prose section listing every folded element and its origin (e.g., "`Plugin Resources` contains: Skills (markdown SKILL.md), Agents (markdown Agent Defs), Knowledge Base (Markdown + YAML)").
+- Apply `UpdateLayoutConfig($c4ShapeInRow="2", $c4BoundaryInRow="2")` (quoted strings per `c4-reference.md:77`).
+- Add a `## Details` prose section listing every folded element by **original Mermaid alias** with role description (e.g., "`webapp` contains: `dashboard` (React, Next.js), `api` (Next.js API), `auth` (Supabase Auth)").
+
+Final visible node count: 11 (founder + 5 internal + 5 externals).
 
 ### FR3: Component plugin (L3) restructure
 
@@ -61,8 +67,8 @@ Apply aggressive node trim to `component-plugin.md`:
 - Collapse entry-point commands (`go`, `sync`, `help`) into one `Entry Points` component.
 - Collapse workflow skills (`brainstorm`, `plan`, `work`, `review`, `compound`, `ship`, `one-shot`, `architecture`) into one `Workflow Skills` component.
 - Keep `CTO agent`, `CMO agent`, `CPO agent`, `architecture-strategist` visible only if total node count remains ≤ 8 — otherwise fold the four domain leaders + architecture-strategist into a single `Domain Leaders & Reviewers` component.
-- Bundle the seven `Rel(oneshot, *)` edges into one labeled bundle (`one-shot → Workflow Skills [orchestrates steps 1-5]`).
-- Apply `UpdateLayoutConfig($c4ShapeInRow=2, $c4BoundaryInRow=1)`.
+- Bundle the seven `Rel(oneshot, *)` edges into one labeled bundle (`one-shot → Workflow Skills [orchestrates steps 1-5]`), OR drop the intra-workflow orchestration edges and document the Step 1-5 sequence in `## Details` (preferred — the relationships are textual sequencing, not architectural couplings).
+- Apply `UpdateLayoutConfig($c4ShapeInRow="1", $c4BoundaryInRow="1")` (quoted strings per `c4-reference.md:77`).
 - Add a `## Details` prose section listing every folded element (component name + role) so the information stays grep-able and reviewable.
 
 ### FR4: Visual acceptance check

--- a/knowledge-base/project/specs/feat-sol-40-redesign-c4-model/spec.md
+++ b/knowledge-base/project/specs/feat-sol-40-redesign-c4-model/spec.md
@@ -1,0 +1,108 @@
+---
+title: C4 Architecture Diagram Visual Redesign
+status: draft
+date: 2026-05-13
+linear_issue: SOL-40
+related_pr: https://github.com/jikig-ai/soleur/pull/3713
+brainstorm: knowledge-base/project/brainstorms/2026-05-13-c4-diagram-visual-redesign-brainstorm.md
+worktree: .worktrees/feat-sol-40-redesign-c4-model/
+branch: feat-sol-40-redesign-c4-model
+lane: cross-domain
+brand_survival_threshold: none (internal architecture documentation)
+---
+
+# Feature: C4 Architecture Diagram Visual Redesign
+
+## Problem Statement
+
+The three existing C4 architecture diagrams in `knowledge-base/engineering/architecture/diagrams/` (`system-context.md`, `container.md`, `component-plugin.md`) render unreadable on GitHub markdown preview: arrows overlap, labels collide, boundaries do not group their contained components, and the L3 Component diagram is functionally illegible. Cause: Mermaid's experimental `C4Context` / `C4Container` / `C4Component` renderer hits its auto-layout ceiling on diagrams above ~10 nodes. The information is structurally correct in source; only the visual output fails.
+
+## Goals
+
+- G1 — `system-context.md`, `container.md`, and `component-plugin.md` render with zero overlapping arrows and zero label collisions on GitHub markdown preview.
+- G2 — Each rendered Mermaid block stays within the node-count budget: L1 ≤ 8, L2 ≤ 10, L3 ≤ 8.
+- G3 — All semantic content currently represented in the three diagrams remains discoverable in the same file (either inside the Mermaid block or in a new `## Details` prose section).
+- G4 — Filenames `system-context.md`, `container.md`, `component-plugin.md` remain unchanged so the 19+ ADR / plan / spec cross-references stay valid.
+- G5 — No new tooling, no new runtime dependency, no new CI step. Source format stays Mermaid.
+
+## Non-Goals
+
+- NG1 — Refreshing diagram content to reflect today's counts (71 skills, 66 agents) is **out of scope**. The diagrams stay structurally faithful to their 2026-03-27 stamp; content drift is tracked as a separate deferred issue.
+- NG2 — Adding new C4 views (Deployment, additional L3s for Web App / Agent Runtime / Hook Engine) is **out of scope** and tracked as a separate deferred issue.
+- NG3 — Code-introspected diagram generation (replacing the LLM scaffold in the `architecture` skill) is **out of scope** and tracked as a separate deferred issue.
+- NG4 — Renderer evaluation (Likec4 / D2 / Structurizr DSL) is **out of scope** and tracked as a separate deferred issue.
+- NG5 — Editing or amending any existing ADR. The redesign carries no architectural decision warranting an ADR.
+
+## Functional Requirements
+
+### FR1: System Context (L1) restructure
+
+Apply relation bundling to `system-context.md`:
+
+- Combine related `Rel()` edges that share source and target into a single labeled bundle (e.g., today's separate "Auth and data" + "Sessions and encrypted keys" become bundled per source-target pair).
+- Reorder boundary and system_ext declaration top-to-bottom by data flow direction: Founder → Web App → Cloud CLI Engine → Supabase → External systems.
+- Apply `UpdateLayoutConfig($c4ShapeInRow=3, $c4BoundaryInRow=2)`.
+- Maintain the existing 8 systems (founder, webapp, engine, supabase, anthropic, github, cloudflare, doppler, discord, stripe, plausible) **subject to G2** — if node count exceeds 8, fold the lowest-signal external systems (e.g., plausible, discord) into a single `Analytics & Notifications` system_ext with the folded detail in the `## Details` section.
+
+### FR2: Container (L2) restructure
+
+Apply aggressive node trim to `container.md`:
+
+- Inside the `Soleur Plugin` boundary, collapse `Skills` + `Agents` + `Knowledge Base` into a single `Plugin Resources` container (their detail belongs at L3 anyway).
+- Reorder boundary declarations top-to-bottom by data flow: Web Application → Cloud CLI Engine → Soleur Plugin → Infrastructure.
+- Bundle redundant cross-boundary `Rel()` edges where source-target pairs share semantics.
+- Apply `UpdateLayoutConfig($c4ShapeInRow=2, $c4BoundaryInRow=2)`.
+- Add a `## Details` prose section listing every folded element and its origin (e.g., "`Plugin Resources` contains: Skills (markdown SKILL.md), Agents (markdown Agent Defs), Knowledge Base (Markdown + YAML)").
+
+### FR3: Component plugin (L3) restructure
+
+Apply aggressive node trim to `component-plugin.md`:
+
+- Collapse entry-point commands (`go`, `sync`, `help`) into one `Entry Points` component.
+- Collapse workflow skills (`brainstorm`, `plan`, `work`, `review`, `compound`, `ship`, `one-shot`, `architecture`) into one `Workflow Skills` component.
+- Keep `CTO agent`, `CMO agent`, `CPO agent`, `architecture-strategist` visible only if total node count remains ≤ 8 — otherwise fold the four domain leaders + architecture-strategist into a single `Domain Leaders & Reviewers` component.
+- Bundle the seven `Rel(oneshot, *)` edges into one labeled bundle (`one-shot → Workflow Skills [orchestrates steps 1-5]`).
+- Apply `UpdateLayoutConfig($c4ShapeInRow=2, $c4BoundaryInRow=1)`.
+- Add a `## Details` prose section listing every folded element (component name + role) so the information stays grep-able and reviewable.
+
+### FR4: Visual acceptance check
+
+After implementation, the three diagrams MUST render on GitHub (open the PR, view each file's rendered Mermaid) with:
+
+- Zero arrows crossing other arrows.
+- Zero arrow labels overlapping other arrow labels or component boxes.
+- Every Container_Boundary visually contains its declared components.
+
+Acceptance is verified by viewing the three files at the PR commit (link from the PR description) — not by local Mermaid CLI render. GitHub's renderer is the only consumer surface that matters here.
+
+## Technical Requirements
+
+### TR1: No new dependencies or CI changes
+
+No new runtime dependencies. No new CI jobs. No edits to `eleventy.config.js` or `.github/workflows/*`. The change set is markdown-only edits to three files plus the optional `architecture/SKILL.md` reference update from TR3.
+
+### TR2: Preserve cross-references
+
+The filenames `system-context.md`, `container.md`, `component-plugin.md` MUST NOT change. The 12+ files cross-referencing them (`knowledge-base/INDEX.md`, `2026-03-27-feat-architecture-as-code-plan.md`, `feat-architecture-decision-records/tasks.md`, and others — see brainstorm "Cross-references" section) stay valid without sweep.
+
+### TR3: Optional — update `c4-reference.md`
+
+`plugins/soleur/skills/architecture/references/c4-reference.md` MAY be updated to teach the slim-down conventions used here: node-count budget, edge bundling pattern, boundary-order convention, `UpdateLayoutConfig` defaults. If included in this PR, the change is documentation-only and adds no execution semantics. If deferred, file as a follow-up so the next `/soleur:architecture diagram` invocation produces a similarly slim scaffold.
+
+### TR4: No ADR amendment
+
+No ADR amendment is required. No ADR formally locks Mermaid as the diagram renderer — the locking lives in `2026-03-27-feat-architecture-as-code-plan.md` and `feat-architecture-decision-records/spec.md`. Neither needs amendment for this redesign (FR4 visual fix is consistent with both).
+
+### TR5: Generated-stamp update
+
+Each redesigned file's "Generated: 2026-03-27" line MUST be updated to "Generated: 2026-05-13 (visual redesign per SOL-40)" so reviewers can distinguish a redesign pass from a content refresh. This sets a precedent for future content refreshes (deferred-item #1) to update the stamp similarly.
+
+## Deferred Items
+
+The following are explicitly out of scope for this spec and MUST be filed as separate GitHub issues at brainstorm Phase 3.6 step 7:
+
+1. **Content refresh** — sync diagrams to 71 skills / 66 agents / current domain leaders. Re-eval: when count drift > 10%.
+2. **Add missing L3 views** — Web App, Agent Runtime, Hook Engine. Re-eval: when contributor cannot answer architectural question from existing diagrams.
+3. **Add C4Deployment view** — covers ADR-006/007/008/019 infra surface. Re-eval: next contractor/audit onboarding.
+4. **Code-introspected diagram generation** — replace LLM scaffold with manifest scanner. Re-eval: when manual refresh happens > 1×/quarter.
+5. **Renderer evaluation** — revisits `2026-03-27-architecture-as-code-brainstorm.md` open question #5 (Likec4 / D2 / Structurizr DSL). Re-eval: when source restructuring leaves residual layout problems FR4 cannot satisfy.

--- a/knowledge-base/project/specs/feat-sol-40-redesign-c4-model/tasks.md
+++ b/knowledge-base/project/specs/feat-sol-40-redesign-c4-model/tasks.md
@@ -1,0 +1,71 @@
+# Tasks: SOL-40 — Redesign C4 Architecture Diagrams
+
+Source plan: `knowledge-base/project/plans/2026-05-13-feat-sol-40-redesign-c4-diagrams-plan.md`
+
+## Phase 0: Amend spec.md
+
+- [ ] 0.1 Edit `knowledge-base/project/specs/feat-sol-40-redesign-c4-model/spec.md`:
+  - [ ] 0.1.1 G2: change `L1 ≤ 8` → `L1 ≤ 9`; `L2 ≤ 10` → `L2 ≤ 11`. Add inline note: "Amended 2026-05-13 after plan-time recount; ADR-007 importance keeps doppler distinct at both levels."
+  - [ ] 0.1.2 FR1: change `UpdateLayoutConfig($c4ShapeInRow=3, $c4BoundaryInRow=2)` → `UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")`. Annotate the quoting rationale (per `c4-reference.md:77`, unquoted values fail silently).
+  - [ ] 0.1.3 FR1: rewrite the conditional-fold prose to: "fold `discord` + `stripe` + `plausible` into a single `thirdparty` external; preserve semantic detail in `## Details` section below the Mermaid block."
+  - [ ] 0.1.4 FR2: change `UpdateLayoutConfig` values to quoted strings (`"2"`, `"2"`).
+  - [ ] 0.1.5 FR2: extend the fold list beyond `Plugin Resources` to enumerate the four boundary-level folds — Web App (`webapp`), CLI Engine (`engine`), Plugin (`plugin`), Compute & Tunnel (`compute`) — plus the `thirdparty` external fold.
+  - [ ] 0.1.6 FR3: change `UpdateLayoutConfig` values to quoted strings (`"1"`, `"1"`).
+- [ ] 0.2 `git commit -m "spec: amend node budgets and UpdateLayoutConfig quoting for SOL-40"`
+
+## Phase 1: Restructure L1 (`system-context.md`)
+
+- [ ] 1.1 Replace the existing `System_Ext(discord, ...)` + `System_Ext(stripe, ...)` + `System_Ext(plausible, ...)` triplet with a single `System_Ext(thirdparty, "Third-Party Services", "Discord + Stripe + Plausible")`.
+- [ ] 1.2 Replace `Rel(webapp, stripe, "Checkout and billing", "HTTPS")` + `Rel(stripe, webapp, "Payment webhooks", "HTTPS")` + `Rel(webapp, plausible, "Page view events", "JS snippet")` with single `BiRel(webapp, thirdparty, "Checkout / webhooks / page events", "HTTPS")`.
+- [ ] 1.3 Replace `Rel(engine, discord, "Notifications", "Webhook")` with `Rel(engine, thirdparty, "Notifications", "Webhook")`.
+- [ ] 1.4 Reorder declaration top-to-bottom: Person → Enterprise_Boundary block → `cloudflare` → `doppler` → `anthropic` → `github` → `thirdparty`.
+- [ ] 1.5 Add `UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")` directly after the `title` line in the Mermaid block.
+- [ ] 1.6 Append `## Details` section below the Mermaid block listing original aliases `discord`, `stripe`, `plausible` with role descriptions (template in plan Phase 1).
+- [ ] 1.7 Update first-line stamp: `Generated: 2026-05-13 (visual redesign per SOL-40, was 2026-03-27)`.
+- [ ] 1.8 Commit + push: `git commit -m "diagrams: restructure L1 system-context for Mermaid layout ceiling"` then `git push`.
+- [ ] 1.9 **Visual gate:** open `https://github.com/jikig-ai/soleur/pull/3713/files`, locate the new `system-context.md` render, confirm 9 visible nodes with no crossing arrows and no label collisions at desktop viewport (≥1200 px, 100% zoom). If pass, advance to Phase 2. If fail, hand-tweak boundary order / `UpdateLayoutConfig` values until pass.
+
+## Phase 2: Restructure L2 (`container.md`)
+
+- [ ] 2.1 Inside `Container_Boundary(web, ...)` collapse `dashboard` + `api` + `auth` into a single `Container(webapp, "Web Application", "Next.js PWA", "Dashboard UI + API routes + Supabase Auth")`. Delete the now-unused boundary or rename to enclose just `webapp`.
+- [ ] 2.2 Inside `Container_Boundary(cli, ...)` collapse `claude` + `skillloader` + `hooks` into a single `Container(engine, "Cloud CLI Engine", "Claude Code", "Agent runtime + plugin discovery + hook engine")`.
+- [ ] 2.3 Inside `Container_Boundary(plugin, ...)` collapse `skills` + `agents` + `kb` into a single `Container(plugin, "Soleur Plugin", "Markdown", "Skills + Agents + Knowledge Base — see L3")`.
+- [ ] 2.4 Inside `Container_Boundary(infra, ...)` collapse `tunnel` + `hetzner` into a single `Container(compute, "Compute & Tunnel", "Hetzner Cloud + Cloudflare Tunnel", "Docker containers behind zero-trust tunnel")`. Keep `ContainerDb(supabase, ...)` separate.
+- [ ] 2.5 Externals: replace `System_Ext(discord)` + `System_Ext(stripe)` + `System_Ext(plausible)` with single `System_Ext(thirdparty, ...)` (matches Phase 1).
+- [ ] 2.6 Rewrite the `Rel(...)` block: drop the internal `dashboard→api→auth` chain (covered by `webapp` fold); change `Rel(api, claude, ...)` → `Rel(webapp, engine, "Spawns agent sessions", "WebSocket")`; collapse the four `claude→skillloader→skills/agents` + `hooks→claude` edges into `Rel(engine, plugin, "Loads + guards", "File I/O + event hook")`; bundle the three externals into `thirdparty`.
+- [ ] 2.7 Reorder boundaries top-to-bottom: Person → Web App → CLI Engine → Plugin → Infrastructure (supabase + compute) → externals.
+- [ ] 2.8 Add `UpdateLayoutConfig($c4ShapeInRow="2", $c4BoundaryInRow="2")` after the `title` line.
+- [ ] 2.9 Append `## Details` section per plan Phase 2 template (preserves original aliases `dashboard`, `api`, `auth`, `claude`, `skillloader`, `hooks`, `skills`, `agents`, `kb`, `tunnel`, `hetzner`).
+- [ ] 2.10 Update first-line stamp.
+- [ ] 2.11 Commit + push: `git commit -m "diagrams: restructure L2 container for Mermaid layout ceiling"` then `git push`.
+- [ ] 2.12 **Visual gate:** confirm ≤ 11 visible nodes, no crossing arrows, no label collisions, boundaries visually contain their containers. If pass, advance. If fail, hand-tweak.
+
+## Phase 3: Restructure L3 (`component-plugin.md`)
+
+- [ ] 3.1 Inside `Container_Boundary(plugin, ...)` collapse `Component(go)` + `Component(sync)` + `Component(help)` into `Component(entry, "Entry-Point Commands", "Markdown", "go, sync, help")`.
+- [ ] 3.2 Collapse the eight workflow-skill components (`brainstorm`, `plan`, `work`, `review`, `compound`, `ship`, `oneshot`, `architecture`) into `Component(workflows, "Workflow Skills", "Markdown", "8 skills — see Details")`.
+- [ ] 3.3 Collapse the four leader/reviewer components (`cto`, `cmo`, `cpo`, `archstrat`) into `Component(leaders, "Domain Leaders & Reviewers", "Markdown", "4 visible; see Details")`.
+- [ ] 3.4 Keep `Container(claude)`, `Container(hooks)`, `ContainerDb(kb)` as external context outside the boundary.
+- [ ] 3.5 Rewrite the `Rel(...)` block:
+  - [ ] 3.5.1 Drop all `Rel(go|sync|help, *)` and `Rel(oneshot, plan|work|review|compound|ship)` — orchestration is documented in `## Details`.
+  - [ ] 3.5.2 Collapse `Rel(brainstorm|plan|review, cto|cmo|cpo|archstrat)` into single `Rel(workflows, leaders, "Phase 0.5 / 2.5 / review assessments", "Task spawn")`.
+  - [ ] 3.5.3 Collapse `Rel(cto|archstrat, architecture)` into single `Rel(leaders, workflows, "Recommend ADR / coverage check", "Task spawn")`.
+  - [ ] 3.5.4 Add: `Rel(claude, entry, "User invokes /soleur:<cmd>")`, `Rel(hooks, claude, "Guards tool calls")`, `Rel(workflows, kb, "Reads + writes")`, `Rel(leaders, kb, "Reads")`.
+  - [ ] 3.5.5 Final Rel count: 6.
+- [ ] 3.6 Reorder declaration: external `claude` + `hooks` at top → `Container_Boundary(plugin)` containing `entry` → `workflows` → `leaders` → external `kb` at bottom.
+- [ ] 3.7 Add `UpdateLayoutConfig($c4ShapeInRow="1", $c4BoundaryInRow="1")` after the `title` line.
+- [ ] 3.8 Append `## Details` section per plan Phase 3 template — preserve original aliases `go`, `sync`, `help`, `brainstorm`, `plan`, `work`, `review`, `compound`, `ship`, `oneshot`, `architecture`, `cto`, `cmo`, `cpo`, `archstrat`; include explicit mention that `clo`, `coo`, `cfo`, `cro`, `cco` exist but are folded for visual budget (link to #3714).
+- [ ] 3.9 Update first-line stamp.
+- [ ] 3.10 Commit + push: `git commit -m "diagrams: restructure L3 component-plugin for Mermaid layout ceiling"` then `git push`.
+- [ ] 3.11 **Visual gate:** confirm 6 visible nodes, no crossing arrows, no label collisions. If pass, advance to Phase 4 (finalize PR). **If fail and escalation sequence (drop low-signal edge, reverse declaration order) does not resolve within 30 minutes:**
+  - [ ] 3.11.1 Open delta-issue on #3718 with L3 evidence (screenshot of overlap).
+  - [ ] 3.11.2 Prepend a one-line known-limitation note to `component-plugin.md` directly under the title.
+  - [ ] 3.11.3 Mark AC3 partially-met in PR body; link the delta-issue.
+  - [ ] 3.11.4 Commit + push; advance to Phase 4.
+
+## Phase 4: Finalize PR
+
+- [ ] 4.1 Re-run the cross-reference verification grep (AC4); confirm 4 / 12 / 1 counts unchanged. Investigate any drift.
+- [ ] 4.2 Capture rendered Mermaid screenshots from the PR diff view (one per diagram, AFTER state). Linear SOL-40 already holds the BEFORE state.
+- [ ] 4.3 Update PR #3713 body's `## Test plan` checklist with AC1 / AC2 / AC3 / AC4 status, attach Before/After screenshots.
+- [ ] 4.4 Mark PR ready for review: `gh pr ready 3713`.


### PR DESCRIPTION
## Summary

Visual redesign of the three C4 architecture diagrams in `knowledge-base/engineering/architecture/diagrams/` so they render legibly on GitHub markdown preview. Mermaid stays as the renderer; sources are restructured (relation bundling, aggressive node trim, boundary-flow reordering) to fit within Mermaid's auto-layout ceiling.

Linear: [SOL-40](https://linear.app/jikigai/issue/SOL-40/visual-redesign-architecture-diagrams)

## Brainstorm + Spec + Plan

- Brainstorm: [`knowledge-base/project/brainstorms/2026-05-13-c4-diagram-visual-redesign-brainstorm.md`](./knowledge-base/project/brainstorms/2026-05-13-c4-diagram-visual-redesign-brainstorm.md)
- Spec: [`knowledge-base/project/specs/feat-sol-40-redesign-c4-model/spec.md`](./knowledge-base/project/specs/feat-sol-40-redesign-c4-model/spec.md)
- Plan: [`knowledge-base/project/plans/2026-05-13-feat-sol-40-redesign-c4-diagrams-plan.md`](./knowledge-base/project/plans/2026-05-13-feat-sol-40-redesign-c4-diagrams-plan.md)
- Tasks: [`knowledge-base/project/specs/feat-sol-40-redesign-c4-model/tasks.md`](./knowledge-base/project/specs/feat-sol-40-redesign-c4-model/tasks.md)

## Implementation Result (source-level verification)

All four implementation phases complete:

| Diagram | Before (nodes / edges) | After (nodes / edges) | Budget | Pass |
|---|---|---|---|---|
| L1 system-context | 11 / 12 | **9 / 10** | ≤ 9 nodes | yes |
| L2 container | 19 / 19 | **11 / 12** | ≤ 11 nodes | yes |
| L3 component-plugin | 18 / 21 | **6 / 6** | ≤ 8 nodes | yes |

**AC4 — cross-references preserved:** 4 (system-context) / 12 (container) / 1 (component-plugin) consumer files outside the spec dir — identical to plan-time counts. No external drift.

## Visual verification — needs human review

This is a docs-only PR whose acceptance gate (AC1/AC2/AC3) is the rendered Mermaid view on GitHub. The implementation environment cannot run a headless Chromium to capture the rendered output (Playwright system deps require sudo, unavailable in this sandbox).

**Please view each file at the merge commit and confirm:**

- [ ] [`system-context.md` rendered Mermaid](./knowledge-base/engineering/architecture/diagrams/system-context.md) — no crossing arrows, no label collisions at desktop viewport
- [ ] [`container.md` rendered Mermaid](./knowledge-base/engineering/architecture/diagrams/container.md) — same gate
- [ ] [`component-plugin.md` rendered Mermaid](./knowledge-base/engineering/architecture/diagrams/component-plugin.md) — same gate

If any diagram still shows overlap, the fallback path is documented in the plan's Phase 3 escalation sequence: drop low-signal edge → reverse boundary declaration order → file a delta-issue against #3718 (renderer evaluation) and prepend a known-limitation note to that file.

Linear SOL-40 already holds the BEFORE state (3 attached screenshots showing the overlap problem on the 2026-03-27 stamp).

## Key Decisions

- Scope = visual fix only. Out-of-scope concerns filed as deferred issues (below).
- Stay on Mermaid. No renderer change.
- Same 3 files, same filenames (preserves 17 ADR/plan/spec/learning cross-references).
- Per-diagram fold maps in plan + spec + each file's `## Details` section (original Mermaid aliases preserved for grep-ability).

## Deferred Follow-Ups

- #3714 — Refresh diagram content to current skill/agent counts
- #3715 — Add missing L3 C4 views (Web App, Agent Runtime, Hook Engine)
- #3716 — Add C4Deployment view covering infra ADRs
- #3717 — Code-introspected C4 diagram generation (replace LLM scaffold)
- #3718 — Evaluate renderer alternatives (Likec4 / D2 / Structurizr DSL)

## Changelog

- docs(arch): redesign C4 diagrams (L1/L2/L3) by source restructure; amend spec budgets and UpdateLayoutConfig quoting; no behavior change

## Test plan

- [x] Source-level: each diagram's node count within amended budget (L1 ≤ 9 / L2 ≤ 11 / L3 ≤ 8); verified via `grep -cE '^[[:space:]]*(Person|Container|Component|System_Ext|System|SystemDb|ContainerDb)\('`
- [x] Source-level: each diagram has a `## Details` section enumerating original Mermaid aliases verbatim
- [x] Filenames unchanged (same 3 paths under `knowledge-base/engineering/architecture/diagrams/`)
- [x] Each diagram's `Generated:` stamp updated to `2026-05-13 (visual redesign per SOL-40, was 2026-03-27)`
- [x] Cross-references intact (4 / 12 / 1, identical to plan-time)
- [x] `UpdateLayoutConfig` values are quoted strings (per `c4-reference.md:77`)
- [ ] **Visual gate (reviewer):** L1 renders with no crossing arrows, no label collisions on GitHub at desktop viewport
- [ ] **Visual gate (reviewer):** L2 same
- [ ] **Visual gate (reviewer):** L3 same (or fallback path applied per Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)