### PR TITLE
fix(incident): defang JWT fixture — clear post-merge secret-scan failure

### DIFF
--- a/plugins/soleur/skills/incident/test/fixtures/positive-corpus.md
+++ b/plugins/soleur/skills/incident/test/fixtures/positive-corpus.md
@@ -10,7 +10,7 @@ This keeps the fixture safe to commit while still exercising every regex class.
 
 ## JWT three-segment
 
-eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzeW50aGV0aWMtZml4dHVyZS1ub3QtcmVhbCJ9.SyNtHeTiC0SiGnAtUrE_DoNoTuSe_XXXXXX
+eyJaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaa
 
 ## Email
 


### PR DESCRIPTION
## Summary

Hot-fix for post-merge `secret-scan` failure on PR #3721 (`/soleur:incident` skill). The merged `positive-corpus.md` fixture contained a high-entropy synthesized JWT that triggered gitleaks default-pack `jwt` rule.

Pre-merge review caught this and proposed the defang, but the fixup commit landed AFTER auto-merge had already squashed — a race condition between auto-merge and the gitleaks check on the merge-ref commit.

Ref #2725

## Changelog

- Replace `eyJhbGciOiJIUzI1NiJ9.eyJzdW...` (entropy 5.2) with low-entropy `eyJ<17 a's>.<17 a's>.<17 a's>` form in `plugins/soleur/skills/incident/test/fixtures/positive-corpus.md`. Still triggers the sentinel's JWT regex (`eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`) but bypasses gitleaks default-pack `jwt` regex (`ey[A-Za-z0-9_-]{17,}\.ey[A-Za-z0-9_-]{17,}...` — segment 2 starts with `a` not `ey` now).

## Test plan

- [x] `bash plugins/soleur/skills/incident/test/redact-sentinel.test.sh` → 19/19 pass (JWT class still triggers)
- [x] `gitleaks dir plugins/soleur/skills/incident/test/fixtures/` → clean
- [ ] Post-merge `secret-scan` on main passes

Generated with [Claude Code](https://claude.com/claude-code)
