### PR TITLE
feat(cc-soleur-go): Stage 6 PR-B — routing/cost/UX smoke + FR2.4/2.8 client wires (#2939)

### DIFF
--- a/apps/web-platform/components/chat/chat-surface.tsx
+++ b/apps/web-platform/components/chat/chat-surface.tsx
@@ -533,9 +533,21 @@ export function ChatSurface({
 
       {/* Review F15: WorkflowLifecycleBar is sticky context above the
           scroll region — moving it OUTSIDE the `overflow-y-auto` container
-          keeps it pinned regardless of message-list scroll position. */}
+          keeps it pinned regardless of message-list scroll position.
+
+          #3774: thread the accumulated cost from `usageData` (driven by the
+          legacy `usage_update` setState at `ws-client.ts:791-806`) into the
+          active lifecycle slice so the bar can render the running total.
+          The reducer's `cumulativeCostUsd` field exists on the type but is
+          never written by any arm — this prop-time merge is the minimum
+          fix to expose the existing data without introducing a second
+          source of truth. */}
       <WorkflowLifecycleBar
-        lifecycle={workflow}
+        lifecycle={
+          workflow.state === "active" && usageData
+            ? { ...workflow, cumulativeCostUsd: usageData.totalCostUsd }
+            : workflow
+        }
         onStartNewConversation={() => router.push("/dashboard")}
       />
 

--- a/apps/web-platform/components/chat/workflow-lifecycle-bar.tsx
+++ b/apps/web-platform/components/chat/workflow-lifecycle-bar.tsx
@@ -68,6 +68,7 @@ export function WorkflowLifecycleBar({
       return (
         <div
           data-lifecycle-state="ended"
+          data-lifecycle-status={lifecycle.status}
           className="flex flex-col gap-2 border-b border-soleur-border-default bg-soleur-bg-surface-1/40 px-4 py-3"
         >
           <div className="flex items-center gap-2">

--- a/apps/web-platform/e2e/cc-soleur-go-routing.e2e.ts
+++ b/apps/web-platform/e2e/cc-soleur-go-routing.e2e.ts
@@ -18,17 +18,24 @@
 //     one-shot, brainstorm, plan, work, review, drain-labeled-backlog). cc-
 //     router is the dispatcher itself; what it routes INTO is the WorkflowName.
 //     Tests pick `"brainstorm"` as the routed workflow.
-//   - FR2.4 cost circuit-breaker — `usage_update` is in ws-zod-schemas.ts:300
-//     but NOT in the reducer StreamEvent union (chat-state-machine.ts:244-258)
-//     and `WorkflowLifecycleBar` has no `circuit_breaker` state. Ships as
-//     `test.fixme` + scope-out #3774.
-//   - FR2.8 subprocess reuse — `subagent_spawn` reducer
-//     (chat-state-machine.ts:596-665) appends without spawnId dedup; reuse
-//     is a server-runner invariant. Ships as `test.fixme` + scope-out #3775.
-//   - FR2.10 container-restart pendingPrompts drop — neither `context_reset`
-//     (chat-state-machine.ts:783) nor the `session_started` control frame
-//     clears resident `interactive_prompt` cards. Ships as `test.fixme` +
-//     scope-out #3776.
+//   - FR2.4 cost circuit-breaker — closed inline (#3774). Threaded the
+//     existing `usageData.totalCostUsd` (driven by ws-client.ts:791-806's
+//     out-of-reducer setState) into `WorkflowLifecycleBar` via a chat-
+//     surface prop-merge. Added `data-lifecycle-status` attribute on the
+//     bar's ended branch so the existing `cost_ceiling` terminal status
+//     (lib/types.ts:WORKFLOW_END_STATUSES) is DOM-distinguishable from a
+//     `completed` termination. The server-side threshold + emission of
+//     `workflow_ended(status="cost_ceiling")` already existed; the client
+//     just had no way to surface either signal.
+//   - FR2.8 subprocess reuse — closed inline (#3775). `subagent_spawn`
+//     reducer now dedupes via `priorSpawnIndex.has(event.spawnId)` at the
+//     top of the arm, mirroring the F7 shape on `interactive_prompt`
+//     (chat-state-machine.ts:751-770).
+//   - FR2.10 container-restart pendingPrompts drop — remains `test.fixme` +
+//     scope-out #3776 (contested-design — extending `context_reset` vs.
+//     promoting `session_started` to a reducer event flips the WS control-
+//     frame boundary the WsInjector explicitly draws). Deferred to its own
+//     design-locked PR.
 
 import { test, expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
@@ -217,22 +224,73 @@ test.describe("cc-soleur-go routing: FR2.3 @CTO mid-workflow", () => {
 });
 
 // ---------------------------------------------------------------------------
-// FR2.4 — Cost circuit-breaker. SCOPE-OUT.
+// FR2.4 — Cost circuit-breaker (lifted to live test).
 //
-// `usage_update` is wired at the WS schema layer (ws-zod-schemas.ts:300-314)
-// but NOT consumed by the chat-state-machine reducer; no `circuit_breaker`
-// lifecycle state exists on WorkflowLifecycleBar. The threshold and refusal
-// live server-side. Scope-out #3774 — when the client reducer learns to
-// consume `usage_update` and `WorkflowLifecycleState` gains a circuit-breaker
-// variant, flip this back to a live `test()`.
+// Originally scoped out as #3774; flipped inline per code-simplicity DISSENT
+// at review time. The minimal client wire added in this PR:
+//   - `usage_update` (handled out-of-reducer at `ws-client.ts:791-806` as
+//     today, via setUsageData) is now threaded into `WorkflowLifecycleBar`
+//     via a chat-surface prop-merge — when `workflow.state === "active"`,
+//     `cumulativeCostUsd` is overridden with `usageData.totalCostUsd` so
+//     the bar can render the running total without introducing a second
+//     handler.
+//   - `data-lifecycle-status` attribute added to `WorkflowLifecycleBar`'s
+//     ended branch (workflow-lifecycle-bar.tsx) so the existing
+//     `cost_ceiling` terminal status (lib/types.ts:WORKFLOW_END_STATUSES)
+//     is DOM-distinguishable from a `completed` termination.
+// Server-side threshold + emission of `workflow_ended(status="cost_ceiling")`
+// already existed; the client just had no way to surface the distinction.
 // ---------------------------------------------------------------------------
 
-test.fixme(
-  "cc-soleur-go routing: FR2.4 cost circuit-breaker — no client reducer wire (scope-out)",
-  async () => {
-    // intentionally empty — scope-out documented in file header + PR body.
-  },
-);
+test.describe("cc-soleur-go routing: FR2.4 cost circuit-breaker", () => {
+  test("usage_update updates cost AND workflow_ended(cost_ceiling) exposes lifecycle-status", async ({
+    page,
+  }) => {
+    const injector = await bootChat(page);
+
+    injector.send({
+      type: "workflow_started",
+      workflow: "brainstorm",
+      conversationId: CONV_ID,
+    } satisfies StreamEvent);
+    await expect(page.locator('[data-lifecycle-state="active"]')).toBeVisible();
+
+    // Synthesized cumulative cost — `usage_update` is handled by an out-of-
+    // reducer setState (`ws-client.ts:791-806`) and threaded into the
+    // lifecycle bar via a chat-surface prop merge (#3774). Therefore it goes
+    // through the typed `sendControl` channel, not `send`.
+    injector.sendControl({
+      type: "usage_update",
+      conversationId: CONV_ID,
+      totalCostUsd: 1.2345,
+      inputTokens: 1000,
+      outputTokens: 2000,
+    });
+    await expect(page.locator('[data-lifecycle-state="active"]')).toContainText("$1.2345");
+
+    // Server-side breaker trips → emit `workflow_ended` with the existing
+    // `cost_ceiling` status (lib/types.ts:WORKFLOW_END_STATUSES). The
+    // existing reducer arm transitions lifecycle to `ended`; the new
+    // `data-lifecycle-status` attribute on the bar lets the test distinguish
+    // it from a `completed` termination without coupling to copy.
+    injector.send({
+      type: "workflow_ended",
+      workflow: "brainstorm",
+      status: "cost_ceiling",
+      summary: "Per-conversation cost ceiling reached",
+    } satisfies StreamEvent);
+
+    const endedBar = page.locator(
+      '[data-lifecycle-state="ended"][data-lifecycle-status="cost_ceiling"]',
+    );
+    await expect(endedBar).toBeVisible();
+    // Refusal-of-further-turns proven by the ChatInput's disabled+placeholder
+    // hook (same path FR2.9 exercises for `completed`).
+    await expect(
+      page.getByPlaceholder("This conversation has ended"),
+    ).toBeDisabled();
+  });
+});
 
 // ---------------------------------------------------------------------------
 // FR2.5 — CFO gate spawn renders.
@@ -360,23 +418,50 @@ test.describe("cc-soleur-go routing: FR2.7 narration before Skill", () => {
 });
 
 // ---------------------------------------------------------------------------
-// FR2.8 — Subprocess reuse. SCOPE-OUT.
+// FR2.8 — Subprocess reuse (lifted to live test).
 //
-// `subagent_spawn` reducer (chat-state-machine.ts:596-665) finds an existing
-// group by `parentId` and APPENDS the new child — no `spawnId` dedup. A
-// second back-to-back skill call with the same `spawnId` produces a duplicate
-// child row rather than reusing the existing one. The "shared spawn"
-// invariant is enforced on the server-runner side. Scope-out #3775 — flip
-// back to a live `test()` once the reducer learns to detect and merge
-// duplicate spawnIds.
+// Originally scoped out as #3775; flipped inline per code-simplicity DISSENT
+// at review time. The `subagent_spawn` reducer now dedupes on `spawnId` via
+// `priorSpawnIndex.has(event.spawnId)` at the top of the arm
+// (chat-state-machine.ts), mirroring the F7 shape on `interactive_prompt`
+// (line 751-770). Two consecutive Skill calls that share a spawnId now
+// produce exactly one child row — the client-side regression net for what
+// the server-runner already guarantees.
 // ---------------------------------------------------------------------------
 
-test.fixme(
-  "cc-soleur-go routing: FR2.8 subprocess reuse — no spawnId dedup in reducer (scope-out)",
-  async () => {
-    // intentionally empty — scope-out documented in file header + PR body.
-  },
-);
+test.describe("cc-soleur-go routing: FR2.8 subprocess reuse", () => {
+  test("duplicate subagent_spawn with same spawnId produces exactly one child row", async ({
+    page,
+  }) => {
+    const injector = await bootChat(page);
+    const parentId = "parent-reuse";
+    const spawnId = `${parentId}-skill-shared`;
+
+    // First spawn — establishes the group + child.
+    injector.send({
+      type: "subagent_spawn",
+      parentId,
+      leaderId: "cto",
+      spawnId,
+      task: "First skill invocation",
+    } satisfies StreamEvent);
+
+    // Second spawn with the SAME spawnId — reducer idempotent path; should
+    // NOT produce a duplicate child row.
+    injector.send({
+      type: "subagent_spawn",
+      parentId,
+      leaderId: "cto",
+      spawnId,
+      task: "Second skill invocation (reuse)",
+    } satisfies StreamEvent);
+
+    const group = page.locator(`[data-parent-spawn-id="${parentId}"]`);
+    await expect(group).toHaveAttribute("data-expanded", "true");
+    await expect(group.locator(`[data-child-spawn-id="${spawnId}"]`)).toHaveCount(1);
+    await expect(group.locator("[data-child-spawn-id]")).toHaveCount(1);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // FR2.9 — Ended-state UX.

--- a/apps/web-platform/e2e/cc-soleur-go-routing.e2e.ts
+++ b/apps/web-platform/e2e/cc-soleur-go-routing.e2e.ts
@@ -1,0 +1,400 @@
+// PR-B (#2939) Stage 6 — cc-soleur-go routing/cost/UX smoke regression net.
+//
+// Sibling to e2e/cc-soleur-go-bubbles.e2e.ts (PR-A FR1.x bubble assertions).
+// Ten Playwright assertions covering plan §369-386 tasks 6.1-6.7 + 6.5.1-6.5.4
+// (spec FR2.1-FR2.10). Same hermetic surface as PR-A: mocked Supabase HTTP +
+// intercepted `**/ws` via attachWsInjector. NO real Anthropic SDK (Spec NG2),
+// NO screenshot baselines (Spec NG1), NO denied MCP tool names (TR9 / NG4).
+//
+// Research Reconciliation — spec FR text vs production code at /work-time
+// (mirrors the PR-A pattern; same hazard class as
+// `2026-05-14-plan-prescribed-runtime-shapes-must-be-grepped-against-installed-version.md`):
+//
+//   - FR2.1 / FR2.2 selector `[data-active-workflow]` — does NOT exist. The
+//     production signal for "routed" is the WorkflowLifecycleBar going
+//     active after `workflow_started` (workflow-lifecycle-bar.tsx:40).
+//   - FR2.1 / FR2.2 / FR2.9 use `workflow: "cc-router"` — `cc-router` is NOT
+//     a `WorkflowName` literal (conversation-routing.ts:26 enumerates
+//     one-shot, brainstorm, plan, work, review, drain-labeled-backlog). cc-
+//     router is the dispatcher itself; what it routes INTO is the WorkflowName.
+//     Tests pick `"brainstorm"` as the routed workflow.
+//   - FR2.4 cost circuit-breaker — `usage_update` is in ws-zod-schemas.ts:300
+//     but NOT in the reducer StreamEvent union (chat-state-machine.ts:244-258)
+//     and `WorkflowLifecycleBar` has no `circuit_breaker` state. Ships as
+//     `test.fixme` + scope-out #3774.
+//   - FR2.8 subprocess reuse — `subagent_spawn` reducer
+//     (chat-state-machine.ts:596-665) appends without spawnId dedup; reuse
+//     is a server-runner invariant. Ships as `test.fixme` + scope-out #3775.
+//   - FR2.10 container-restart pendingPrompts drop — neither `context_reset`
+//     (chat-state-machine.ts:783) nor the `session_started` control frame
+//     clears resident `interactive_prompt` cards. Ships as `test.fixme` +
+//     scope-out #3776.
+
+import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { attachWsInjector, type WsInjector } from "./cc-soleur-go-ws-injector";
+import { MOCK_USER } from "./mock-supabase";
+import {
+  injectFakeSupabaseSession,
+  mockSupabaseAuth,
+} from "./helpers/supabase-mocks";
+import type { StreamEvent } from "@/lib/chat-state-machine";
+
+const CONV_ID = "conv-stage-6-routing";
+
+const MOCK_CONVERSATION = {
+  id: CONV_ID,
+  user_id: MOCK_USER.id,
+  title: "Stage 6 routing smoke",
+  active_workflow: "cc-router",
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+/** Mirror of bootChat in cc-soleur-go-bubbles.e2e.ts. PR-B keeps a sibling
+ *  copy rather than extracting a third helper file — the two e2e specs share
+ *  no per-test state and a premature extraction would force a config-globals
+ *  dance for very little payoff. Fold when a third spec lands.
+ */
+async function bootChat(page: Page): Promise<WsInjector> {
+  await injectFakeSupabaseSession(page);
+  await mockSupabaseAuth(page);
+
+  await page.route("**/rest/v1/conversations*", (route) => {
+    const accept = route.request().headers().accept ?? "";
+    const single = accept.includes("application/vnd.pgrst.object+json");
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(single ? MOCK_CONVERSATION : [MOCK_CONVERSATION]),
+    });
+  });
+
+  await page.route("**/rest/v1/messages*", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+
+  await page.route("**/rest/v1/users*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          onboarding_completed_at: "2024-01-01T00:00:00Z",
+          pwa_banner_dismissed_at: "2024-01-01T00:00:00Z",
+        },
+      ]),
+    }),
+  );
+
+  const injector = await attachWsInjector(page);
+
+  const response = await page.goto(`/dashboard/chat/${CONV_ID}`);
+  if (response && response.status() >= 500) {
+    test.skip(true, "Dev server compile error — skipped in worktree, passes in CI");
+  }
+
+  await injector.ready;
+  injector.sendControl({ type: "session_started", conversationId: CONV_ID });
+  return injector;
+}
+
+// ---------------------------------------------------------------------------
+// FR2.1 — Fresh conversation routes through cc-router into a workflow.
+//
+// The router's output is a `workflow_started` event; the lifecycle bar then
+// reports the dispatched workflow. `cc-router` is the dispatcher, not a
+// WorkflowName — so the assertion is on the routed workflow ("brainstorm"
+// for this fixture) appearing in the bar.
+// ---------------------------------------------------------------------------
+
+test.describe("cc-soleur-go routing: FR2.1 fresh conv routes into a workflow", () => {
+  test("workflow_started activates the lifecycle bar with the routed workflow name", async ({
+    page,
+  }) => {
+    const injector = await bootChat(page);
+
+    injector.send({
+      type: "workflow_started",
+      workflow: "brainstorm",
+      conversationId: CONV_ID,
+    } satisfies StreamEvent);
+
+    const bar = page.locator('[data-lifecycle-state="active"]');
+    await expect(bar).toBeVisible();
+    await expect(bar).toContainText("brainstorm");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FR2.2 — Sticky workflow on subsequent turns.
+//
+// Every reducer arm except `workflow_started` / `workflow_ended` passes
+// `priorWorkflow` through unchanged (chat-state-machine.ts:336/386/422/etc).
+// Stream events on a peer leader must not clear the active lifecycle bar.
+// ---------------------------------------------------------------------------
+
+test.describe("cc-soleur-go routing: FR2.2 sticky workflow on subsequent turns", () => {
+  test("active lifecycle survives a peer-leader stream cycle", async ({ page }) => {
+    const injector = await bootChat(page);
+
+    injector.send({
+      type: "workflow_started",
+      workflow: "brainstorm",
+      conversationId: CONV_ID,
+    } satisfies StreamEvent);
+    await expect(page.locator('[data-lifecycle-state="active"]')).toBeVisible();
+
+    injector.send({
+      type: "stream_start",
+      leaderId: "cmo",
+    } satisfies StreamEvent);
+    injector.send({
+      type: "stream",
+      content: "follow-up turn body",
+      partial: false,
+      leaderId: "cmo",
+    } satisfies StreamEvent);
+    injector.send({
+      type: "stream_end",
+      leaderId: "cmo",
+    } satisfies StreamEvent);
+
+    const bar = page.locator('[data-lifecycle-state="active"]');
+    await expect(bar).toBeVisible();
+    await expect(bar).toContainText("brainstorm");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FR2.3 — Mid-workflow @CTO produces a subagent_spawn threaded into the
+// transcript. Reducer arm at chat-state-machine.ts:596 creates a
+// ChatSubagentGroupMessage on first spawn for a parentId; DOM exposes
+// `[data-parent-spawn-id]` and `[data-child-spawn-id]` per subagent-group.tsx.
+// ---------------------------------------------------------------------------
+
+test.describe("cc-soleur-go routing: FR2.3 @CTO mid-workflow", () => {
+  test("subagent_spawn leaderId=cto threads into the parent group", async ({
+    page,
+  }) => {
+    const injector = await bootChat(page);
+    const parentId = "parent-cto-mid";
+
+    injector.send({
+      type: "subagent_spawn",
+      parentId,
+      leaderId: "cto",
+      spawnId: `${parentId}-cto-1`,
+      task: "Engineering deep-dive",
+    } satisfies StreamEvent);
+
+    const group = page.locator(`[data-parent-spawn-id="${parentId}"]`);
+    await expect(group).toHaveCount(1);
+    await expect(
+      group.locator(`[data-child-spawn-id="${parentId}-cto-1"]`),
+    ).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FR2.4 — Cost circuit-breaker. SCOPE-OUT.
+//
+// `usage_update` is wired at the WS schema layer (ws-zod-schemas.ts:300-314)
+// but NOT consumed by the chat-state-machine reducer; no `circuit_breaker`
+// lifecycle state exists on WorkflowLifecycleBar. The threshold and refusal
+// live server-side. Scope-out #3774 — when the client reducer learns to
+// consume `usage_update` and `WorkflowLifecycleState` gains a circuit-breaker
+// variant, flip this back to a live `test()`.
+// ---------------------------------------------------------------------------
+
+test.fixme(
+  "cc-soleur-go routing: FR2.4 cost circuit-breaker — no client reducer wire (scope-out)",
+  async () => {
+    // intentionally empty — scope-out documented in file header + PR body.
+  },
+);
+
+// ---------------------------------------------------------------------------
+// FR2.5 — CFO gate spawn renders.
+//
+// The threshold logic that fires the CFO spawn is server-side (covered by
+// the FR2.4 scope-out). The receiving side — rendering the CFO child in the
+// subagent group — IS client wire and worth pinning so that when FR2.4 lands
+// the visual path is already a pass.
+// ---------------------------------------------------------------------------
+
+test.describe("cc-soleur-go routing: FR2.5 CFO gate spawn renders", () => {
+  test("subagent_spawn leaderId=cfo renders a child row in the group", async ({
+    page,
+  }) => {
+    const injector = await bootChat(page);
+    const parentId = "parent-cfo-gate";
+
+    injector.send({
+      type: "subagent_spawn",
+      parentId,
+      leaderId: "cfo",
+      spawnId: `${parentId}-cfo-1`,
+      task: "Cost review",
+    } satisfies StreamEvent);
+
+    await expect(
+      page.locator(
+        `[data-parent-spawn-id="${parentId}"] [data-child-spawn-id="${parentId}-cfo-1"]`,
+      ),
+    ).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FR2.6 — Chip render < 8s.
+//
+// `tool_use` for cc_router with no active stream is a pure sync reducer hop +
+// immediate React render. 8s is a generous ceiling — its purpose is to catch
+// a dev-server cold-start regression, not a sub-100ms one.
+// ---------------------------------------------------------------------------
+
+test.describe("cc-soleur-go routing: FR2.6 chip render under 8s", () => {
+  test("[data-tool-chip-id] mounts within 8s of tool_use injection", async ({
+    page,
+  }) => {
+    const injector = await bootChat(page);
+
+    injector.send({
+      type: "tool_use",
+      leaderId: "cc_router",
+      label: "Routing handoff",
+    } satisfies StreamEvent);
+
+    await expect(
+      page.locator('[data-tool-chip-id^="cc_router-Routing handoff-"]'),
+    ).toHaveCount(1, { timeout: 8_000 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FR2.7 — Narration text precedes any tool_use(skill_*).
+//
+// Server-side directive (soleur-go-runner.ts) emits a `stream` block before
+// any `tool_use(skill_*)`. Client-side, the ordering is proven by sequential
+// assertion: narration is visible AT THE MOMENT the test sends it (proves
+// the reducer received and rendered it), then the skill tool_use is sent
+// and asserted. Once `stream_start` fires, subsequent `tool_use` on the
+// same leader falls through to the per-leader path
+// (chat-state-machine.ts:347-353) and swaps the bubble's visible body
+// from `content` to `toolLabel` — so the narration text is no longer
+// queryable after tool_use lands. That swap is the per-leader bubble's
+// designed UX (one bubble per leader; tool label replaces the in-flight
+// content) and is not in PR-B scope to challenge.
+// ---------------------------------------------------------------------------
+
+test.describe("cc-soleur-go routing: FR2.7 narration before Skill", () => {
+  test("stream content before tool_use(skill_*) lands narration first, then skill toolLabel", async ({
+    page,
+  }) => {
+    const injector = await bootChat(page);
+    const narration = "Routing your request to the brainstorm specialist.";
+
+    injector.send({
+      type: "stream_start",
+      leaderId: "cc_router",
+    } satisfies StreamEvent);
+    injector.send({
+      type: "stream",
+      content: narration,
+      partial: false,
+      leaderId: "cc_router",
+    } satisfies StreamEvent);
+
+    // Order proof — narration must be observable BEFORE tool_use is injected.
+    await expect(page.getByText(narration)).toBeVisible();
+
+    injector.send({
+      type: "tool_use",
+      leaderId: "cc_router",
+      label: "skill_brainstorm",
+    } satisfies StreamEvent);
+
+    await expect(page.getByText(/skill_brainstorm/)).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FR2.8 — Subprocess reuse. SCOPE-OUT.
+//
+// `subagent_spawn` reducer (chat-state-machine.ts:596-665) finds an existing
+// group by `parentId` and APPENDS the new child — no `spawnId` dedup. A
+// second back-to-back skill call with the same `spawnId` produces a duplicate
+// child row rather than reusing the existing one. The "shared spawn"
+// invariant is enforced on the server-runner side. Scope-out #3775 — flip
+// back to a live `test()` once the reducer learns to detect and merge
+// duplicate spawnIds.
+// ---------------------------------------------------------------------------
+
+test.fixme(
+  "cc-soleur-go routing: FR2.8 subprocess reuse — no spawnId dedup in reducer (scope-out)",
+  async () => {
+    // intentionally empty — scope-out documented in file header + PR body.
+  },
+);
+
+// ---------------------------------------------------------------------------
+// FR2.9 — Ended-state UX.
+//
+// `workflow_ended` reducer (chat-state-machine.ts:728) sets
+// `workflow.state="ended"`; WorkflowLifecycleBar then renders the
+// "Start new conversation" button (workflow-lifecycle-bar.tsx:91-97).
+// ChatSurface flips `workflowEnded={true}` on ChatInput, which forces
+// `disabled = rawDisabled || workflowEnded` (chat-input.tsx:99) and swaps
+// the placeholder to "This conversation has ended" (chat-input.tsx:100-102).
+// The placeholder is the file-documented structural test hook.
+// ---------------------------------------------------------------------------
+
+test.describe("cc-soleur-go routing: FR2.9 ended-state UX", () => {
+  test("workflow_ended shows Start new conversation and disables the input", async ({
+    page,
+  }) => {
+    const injector = await bootChat(page);
+
+    injector.send({
+      type: "workflow_started",
+      workflow: "brainstorm",
+      conversationId: CONV_ID,
+    } satisfies StreamEvent);
+    injector.send({
+      type: "workflow_ended",
+      workflow: "brainstorm",
+      status: "completed",
+    } satisfies StreamEvent);
+
+    const endedBar = page.locator('[data-lifecycle-state="ended"]');
+    await expect(endedBar).toBeVisible();
+    await expect(
+      endedBar.getByRole("button", { name: "Start new conversation" }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByPlaceholder("This conversation has ended"),
+    ).toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FR2.10 — Container-restart `pendingPrompts` drop. SCOPE-OUT.
+//
+// `pendingPrompts` lives in the server-side soleur-go runner; the client
+// reducer dedupes `interactive_prompt` events on (promptId, conversationId)
+// (chat-state-machine.ts:751-770) but neither `context_reset` (line 783)
+// nor the `session_started` control frame clears resident prompt cards. A
+// stale card from before a container restart persists on reconnect if the
+// server re-emits the prompt with a different promptId. Scope-out #3776 —
+// flip back to a live `test()` once the client gains a reducer arm that
+// clears `interactive_prompt` cards on session reboot.
+// ---------------------------------------------------------------------------
+
+test.fixme(
+  "cc-soleur-go routing: FR2.10 container-restart pendingPrompts drop — no client clear wire (scope-out)",
+  async () => {
+    // intentionally empty — scope-out documented in file header + PR body.
+  },
+);

--- a/apps/web-platform/e2e/cc-soleur-go-routing.e2e.ts
+++ b/apps/web-platform/e2e/cc-soleur-go-routing.e2e.ts
@@ -51,15 +51,22 @@ const MOCK_CONVERSATION = {
   updated_at: "2024-01-01T00:00:00Z",
 };
 
-/** Mirror of bootChat in cc-soleur-go-bubbles.e2e.ts. PR-B keeps a sibling
- *  copy rather than extracting a third helper file — the two e2e specs share
- *  no per-test state and a premature extraction would force a config-globals
- *  dance for very little payoff. Fold when a third spec lands.
+/**
+ * Mirror of bootChat in cc-soleur-go-bubbles.e2e.ts. PR-B keeps a sibling
+ * copy rather than extracting a third helper file — the two e2e specs share
+ * no per-test state and a premature extraction would force a config-globals
+ * dance for very little payoff. Fold when a third spec lands.
+ *
+ * NOTE: order matters — `addInitScript` runs before any page script, then
+ * `page.route` registers HTTP intercepts, then `attachWsInjector` claims
+ * `**\/ws`. Finally `page.goto` boots the chat surface which opens the WS.
  */
 async function bootChat(page: Page): Promise<WsInjector> {
   await injectFakeSupabaseSession(page);
   await mockSupabaseAuth(page);
 
+  // PostgREST .single() expects an object, not an array — match the existing
+  // mock-supabase behavior (see e2e/mock-supabase.ts:wantsSingle).
   await page.route("**/rest/v1/conversations*", (route) => {
     const accept = route.request().headers().accept ?? "";
     const single = accept.includes("application/vnd.pgrst.object+json");
@@ -95,6 +102,12 @@ async function bootChat(page: Page): Promise<WsInjector> {
   }
 
   await injector.ready;
+
+  // Server-side confirmation frame. The reducer enters its happy path only
+  // after `session_started`; without it `useWebSocket` won't accept follow-up
+  // events on the resolved conversation id. `session_started` is a control
+  // frame outside the reducer-visible `StreamEvent` subset, so it goes
+  // through the typed `sendControl` channel rather than `send`.
   injector.sendControl({ type: "session_started", conversationId: CONV_ID });
   return injector;
 }
@@ -188,8 +201,15 @@ test.describe("cc-soleur-go routing: FR2.3 @CTO mid-workflow", () => {
       task: "Engineering deep-dive",
     } satisfies StreamEvent);
 
+    // Pin the auto-expand contract: child rows are conditionally rendered
+    // inside `{expanded ? (…) : null}` (subagent-group.tsx:157). N=1 ≤
+    // SUBAGENT_GROUP_AUTO_EXPAND_MAX (=2, subagent-group.tsx:36) so the
+    // group defaults to expanded. Asserting `data-expanded="true"` here
+    // names the contract — a regression that lowers the boundary fails
+    // explicitly rather than producing a misleading "child not visible".
     const group = page.locator(`[data-parent-spawn-id="${parentId}"]`);
     await expect(group).toHaveCount(1);
+    await expect(group).toHaveAttribute("data-expanded", "true");
     await expect(
       group.locator(`[data-child-spawn-id="${parentId}-cto-1"]`),
     ).toBeVisible();
@@ -238,24 +258,33 @@ test.describe("cc-soleur-go routing: FR2.5 CFO gate spawn renders", () => {
       task: "Cost review",
     } satisfies StreamEvent);
 
+    // Same auto-expand contract pin as FR2.3 — N=1 ≤ 2 so the group
+    // defaults to expanded; the child row only renders inside the
+    // expanded branch of subagent-group.tsx:157.
+    const group = page.locator(`[data-parent-spawn-id="${parentId}"]`);
+    await expect(group).toHaveAttribute("data-expanded", "true");
     await expect(
-      page.locator(
-        `[data-parent-spawn-id="${parentId}"] [data-child-spawn-id="${parentId}-cfo-1"]`,
-      ),
+      group.locator(`[data-child-spawn-id="${parentId}-cfo-1"]`),
     ).toBeVisible();
   });
 });
 
 // ---------------------------------------------------------------------------
-// FR2.6 — Chip render < 8s.
+// FR2.6 — Chip render under spec ceiling.
 //
-// `tool_use` for cc_router with no active stream is a pure sync reducer hop +
-// immediate React render. 8s is a generous ceiling — its purpose is to catch
-// a dev-server cold-start regression, not a sub-100ms one.
+// The spec sets an 8s budget. The actual codepath is a pure-sync reducer arm
+// (chat-state-machine.ts:344-389) + immediate React render — no debounce, no
+// async hop. Tightened the assertion to a 2s ceiling so a regression that
+// adds a 5s async hop (e.g., misplaced `await`, hydration race, sentry-
+// instrumented wrapper) fails AT THIS ASSERTION rather than passing within
+// the 8s slack. The 8s spec budget lives in the FR text; the test enforces
+// the order-of-magnitude that actually matters. Also wires a pageerror
+// listener so a render-throw fails loud rather than producing an unmounted-
+// chip false-pass.
 // ---------------------------------------------------------------------------
 
-test.describe("cc-soleur-go routing: FR2.6 chip render under 8s", () => {
-  test("[data-tool-chip-id] mounts within 8s of tool_use injection", async ({
+test.describe("cc-soleur-go routing: FR2.6 chip render under spec ceiling", () => {
+  test("[data-tool-chip-id] mounts within 2s of tool_use and no render-throw", async ({
     page,
   }) => {
     const injector = await bootChat(page);
@@ -266,9 +295,13 @@ test.describe("cc-soleur-go routing: FR2.6 chip render under 8s", () => {
       label: "Routing handoff",
     } satisfies StreamEvent);
 
-    await expect(
-      page.locator('[data-tool-chip-id^="cc_router-Routing handoff-"]'),
-    ).toHaveCount(1, { timeout: 8_000 });
+    const chip = page.locator('[data-tool-chip-id^="cc_router-Routing handoff-"]');
+    await expect(chip).toBeVisible({ timeout: 2_000 });
+    await expect(chip).toHaveCount(1);
+    expect(
+      injector.pageErrors,
+      `page errors during chip render: ${injector.pageErrors.map((e) => e.message).join("; ")}`,
+    ).toHaveLength(0);
   });
 });
 
@@ -289,7 +322,7 @@ test.describe("cc-soleur-go routing: FR2.6 chip render under 8s", () => {
 // ---------------------------------------------------------------------------
 
 test.describe("cc-soleur-go routing: FR2.7 narration before Skill", () => {
-  test("stream content before tool_use(skill_*) lands narration first, then skill toolLabel", async ({
+  test("narration is visible AND skill toolLabel is absent before tool_use is injected", async ({
     page,
   }) => {
     const injector = await bootChat(page);
@@ -306,8 +339,15 @@ test.describe("cc-soleur-go routing: FR2.7 narration before Skill", () => {
       leaderId: "cc_router",
     } satisfies StreamEvent);
 
-    // Order proof — narration must be observable BEFORE tool_use is injected.
+    // Order proof, half 1 — narration visible at this point in time.
     await expect(page.getByText(narration)).toBeVisible();
+    // Order proof, half 2 — at the same point in time, the skill toolLabel
+    // is NOT yet observable. Without this, the test only proves the test
+    // author's send-order; with it, a reducer that ever flipped the order
+    // (`tool_use` racing ahead of `stream`) would produce a visible skill
+    // chip here and fail the test — that's the actual invariant the FR
+    // claims to pin.
+    await expect(page.getByText("skill_brainstorm")).toHaveCount(0);
 
     injector.send({
       type: "tool_use",

--- a/apps/web-platform/e2e/cc-soleur-go-ws-injector.ts
+++ b/apps/web-platform/e2e/cc-soleur-go-ws-injector.ts
@@ -14,13 +14,26 @@ import type { StreamEvent } from "@/lib/chat-state-machine";
 
 /** Control frames the page expects from the server but that live outside the
  *  reducer-visible `StreamEvent` subset (`chat-state-machine.ts:244`).
- *  `session_started` is the only one PR-A tests need; widen this if PR-B/PR-C
- *  inject more control frames. */
-export type WsControlEvent = {
-  type: "session_started";
-  conversationId: string;
-  capabilities?: { promptKinds: readonly string[]; incomingTypes?: readonly string[] };
-};
+ *  `session_started` (PR-A) lets the WS hook resolve a session before the
+ *  reducer accepts follow-up events. `usage_update` (PR-B #3774) is handled
+ *  by an out-of-reducer `setUsageData` setState in `ws-client.ts:791-806`;
+ *  threaded into the lifecycle bar via a chat-surface prop merge. Widen
+ *  this union when a future test needs another out-of-reducer frame. */
+export type WsControlEvent =
+  | {
+      type: "session_started";
+      conversationId: string;
+      capabilities?: { promptKinds: readonly string[]; incomingTypes?: readonly string[] };
+    }
+  | {
+      type: "usage_update";
+      conversationId: string;
+      totalCostUsd: number;
+      inputTokens: number;
+      outputTokens: number;
+      cacheReadInputTokens?: number;
+      cacheCreationInputTokens?: number;
+    };
 
 export interface WsInjector {
   /** Resolves once the page has opened the intercepted `/ws` connection. */

--- a/apps/web-platform/lib/chat-state-machine.ts
+++ b/apps/web-platform/lib/chat-state-machine.ts
@@ -594,6 +594,20 @@ export function applyStreamEvent(
     // -----------------------------------------------------------------
 
     case "subagent_spawn": {
+      // #3775 — idempotent on `spawnId`. The wire protocol guarantees spawnId
+      // uniqueness server-side, but a WS reconnect / supabase realtime retry
+      // / regressed runner could re-emit. Duplicate-key state would corrupt
+      // `spawnIndex` (the second insert overwrites the first, breaking the
+      // subsequent `subagent_complete` lookup at line 668). Mirror the
+      // `interactive_prompt` arm's dedup shape (line 751-770).
+      if (priorSpawnIndex.has(event.spawnId)) {
+        return {
+          messages: prev,
+          activeStreams,
+          workflow: priorWorkflow,
+          spawnIndex: priorSpawnIndex,
+        };
+      }
       // Find an existing subagent_group in `prev` matching `parentId`.
       let groupIdx = -1;
       for (let i = prev.length - 1; i >= 0; i--) {

--- a/apps/web-platform/test/chat-state-machine.test.ts
+++ b/apps/web-platform/test/chat-state-machine.test.ts
@@ -744,3 +744,57 @@ describe("Stage 4 — new ChatMessage variants from /soleur:go events", () => {
     expect(result.activeStreams.has("cmo" as DomainLeaderId)).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #3775 — subagent_spawn idempotency on duplicate spawnId
+// ---------------------------------------------------------------------------
+
+describe("subagent_spawn idempotency (#3775)", () => {
+  test("duplicate spawnId returns prev unchanged (no second child appended)", () => {
+    const r1 = applyStreamEvent([], new Map(), {
+      type: "subagent_spawn",
+      parentId: "p-dup",
+      leaderId: "cto" as DomainLeaderId,
+      spawnId: "s-dup-1",
+      task: "first",
+    } as any);
+    // Second call with the same spawnId — should be idempotent.
+    const r2 = applyStreamEvent(r1.messages, r1.activeStreams, {
+      type: "subagent_spawn",
+      parentId: "p-dup",
+      leaderId: "cto" as DomainLeaderId,
+      spawnId: "s-dup-1",
+      task: "second",
+    } as any, r1.spawnIndex);
+    expect(r2.messages).toBe(r1.messages);
+    expect(r2.spawnIndex).toBe(r1.spawnIndex);
+    const group = r2.messages[r2.messages.length - 1];
+    expect(group.type).toBe("subagent_group");
+    if (group.type === "subagent_group") {
+      expect(group.children.length).toBe(1);
+      // First-write-wins: original task preserved.
+      expect(group.children[0].task).toBe("first");
+    }
+  });
+
+  test("different spawnIds still append normally (regression guard)", () => {
+    const r1 = applyStreamEvent([], new Map(), {
+      type: "subagent_spawn",
+      parentId: "p-multi",
+      leaderId: "cto" as DomainLeaderId,
+      spawnId: "s-multi-1",
+    } as any);
+    const r2 = applyStreamEvent(r1.messages, r1.activeStreams, {
+      type: "subagent_spawn",
+      parentId: "p-multi",
+      leaderId: "cmo" as DomainLeaderId,
+      spawnId: "s-multi-2",
+    } as any, r1.spawnIndex);
+    const group = r2.messages[r2.messages.length - 1];
+    expect(group.type).toBe("subagent_group");
+    if (group.type === "subagent_group") {
+      expect(group.children.length).toBe(2);
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary

Stage 6 PR-B of 3 for #2939 (cc-soleur-go regression net). Adds 10 Playwright tests covering spec FR2.1-FR2.10 (plan §369-386 tasks 6.1-6.7 + 6.5.1-6.5.4), plus the minimal client wires needed to make FR2.4 and FR2.8 live tests (closed during /work per code-simplicity DISSENT after operator approval).

- **9 live tests** pass on the `authenticated` Playwright project; **1 `test.fixme`** remains for FR2.10 (contested-design, scope-out #3776).
- **3 production-side changes** (all additive): chat-surface prop-merge for cost display in the lifecycle bar; `data-lifecycle-status` attribute on the bar's ended branch; `spawnId` dedup on the `subagent_spawn` reducer arm.

Plan: `knowledge-base/project/plans/2026-05-13-feat-cc-soleur-go-smoke-2939-pr-a-plan.md`
Spec: `knowledge-base/project/specs/feat-cc-soleur-go-smoke-2939/spec.md`

Ref #2939 (Stage 6 umbrella — PR-C still pending; auto-close at PR-B merge would orphan the last slice)
Closes #3774 (FR2.4 cost circuit-breaker client wire)
Closes #3775 (FR2.8 subagent_spawn spawnId dedup)
Ref #3776 (FR2.10 pendingPrompts drop — remains scope-out, CONCUR from code-simplicity-reviewer)

## Changelog

### Web Platform

- E2E regression net for cc-soleur-go routing/cost/UX (FR2.1-FR2.10) at `apps/web-platform/e2e/cc-soleur-go-routing.e2e.ts`
- Cost-display wire in workflow-lifecycle-bar via chat-surface prop-merge (closes #3774)
- `data-lifecycle-status` attribute on `WorkflowLifecycleBar`'s ended branch — `cost_ceiling` terminations are now DOM-distinguishable from `completed`
- `subagent_spawn` reducer dedupes on duplicate `spawnId`, mirroring the F7 `interactive_prompt` dedup (closes #3775)

## Test plan

- [x] `bun playwright test --project=authenticated cc-soleur-go-routing.e2e.ts` → 9 passed, 1 skipped (FR2.10 fixme), 47s wall
- [x] `bun tsc --noEmit` → clean
- [x] `bun vitest run test/chat-state-machine.test.ts` → 40/40 passed (+2 new for subagent_spawn idempotency)
- [x] Guard greps clean: no `mcp__soleur_platform__plausible_*`, no `ANTHROPIC_API_KEY`/`claude-agent-sdk`, no `toHaveScreenshot`
- [ ] ⏳ CI green (full suite)

## Review evidence

Ran 4 review agents (pattern-recognition, security-sentinel, code-simplicity, test-design):

- 5 P2/P3 findings fixed inline in commit `c0474b5` (FR2.7 ordering proof; FR2.6 budget tightening + `pageErrors` guard; FR2.3/2.5 auto-expand `data-expanded` pin; bootChat comment recovery).
- `code-simplicity-reviewer` DISSENTed on the FR2.4 and FR2.8 scope-outs — operator approved flipping both inline in commit `4e26387`. FR2.10 stays scope-out (CONCUR — genuine contested-design between extending `context_reset` vs. promoting `session_started` to a reducer event).
- `security-sentinel`: 0 findings across all 8 checks. Ship-ready.
- `test-design-reviewer`: 6.75/10 baseline; the inline fixes raise the score on Authentic, Specific, Trustworthy.

Generated with [Claude Code](https://claude.com/claude-code)
