### PR TITLE
fix(test-all): discover .claude/hooks/*.test.sh + pre-merge-rebase CI fix

### DIFF
--- a/.claude/hooks/pre-merge-rebase.test.sh
+++ b/.claude/hooks/pre-merge-rebase.test.sh
@@ -122,7 +122,7 @@ t3_merge_conflict() {
   local tmp; tmp=$(mktemp -d)
   local work="$tmp/work" origin="$tmp/origin.git" incidents="$tmp/incidents"
   mkdir -p "$work" "$incidents"
-  git init -q --bare "$origin"
+  git init -q --bare -b main "$origin"
 
   init_git_repo "$work"
   echo "base" > "$work/file.txt"
@@ -162,7 +162,7 @@ t4_push_failure() {
   local tmp; tmp=$(mktemp -d)
   local work="$tmp/work" origin="$tmp/origin.git" incidents="$tmp/incidents"
   mkdir -p "$work" "$incidents"
-  git init -q --bare "$origin"
+  git init -q --bare -b main "$origin"
 
   init_git_repo "$work"
   echo "base" > "$work/file.txt"

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -116,7 +116,6 @@ if want_scripts; then
   run_suite "tests/hooks/emissions" bash tests/hooks/test_hook_emissions.sh
   run_suite "tests/scripts/lint-rule-ids" python3 -m unittest tests.scripts.test_lint_rule_ids
   run_suite "scripts/lint-rule-ids-live" python3 scripts/lint-rule-ids.py --retired-file scripts/retired-rule-ids.txt --index-file AGENTS.md AGENTS.md AGENTS.core.md AGENTS.docs.md AGENTS.rest.md
-  run_suite ".claude/hooks/session-rules-loader" bash .claude/hooks/session-rules-loader.test.sh
   run_suite "tests/scripts/classifier-regex-parity" bash tests/scripts/test_classifier_regex_parity.sh
   run_suite "tests/scripts/rule-id-regex-parity" python3 -m unittest tests.scripts.test_rule_id_regex_parity
   run_suite "tests/scripts/rule-metrics-aggregate" bash tests/scripts/test-rule-metrics-aggregate.sh
@@ -159,8 +158,10 @@ if want_bun; then
 fi
 
 # Bash *.test.sh glob — scripts shard. (ci-deploy.test.sh runs in infra-validation.yml.)
+# .claude/hooks/*.test.sh added 2026-05-15 (#3799 prereq to #3789); covers the
+# 8 hook tests that previously only the session-rules-loader entry pulled in.
 if want_scripts; then
-  for f in plugins/soleur/test/*.test.sh plugins/soleur/skills/*/test/*.test.sh; do
+  for f in plugins/soleur/test/*.test.sh plugins/soleur/skills/*/test/*.test.sh .claude/hooks/*.test.sh; do
     [[ -f "$f" ]] || continue
     run_suite "$f" bash "$f"
   done


### PR DESCRIPTION
## Summary

One-line scope expansion: `scripts/test-all.sh` glob now covers `.claude/hooks/*.test.sh`. 8 previously-uncovered hook tests now run as part of the `scripts` shard.

Removes the redundant explicit `session-rules-loader` entry (the glob now covers it).

Also includes a CI-portability fix to `.claude/hooks/pre-merge-rebase.test.sh` — T3/T4 now pass `-b main` to `git init --bare` so the test works on runners where `init.defaultBranch=master` (e.g., GitHub Actions Ubuntu).

## Verification

```
TEST_GROUP=scripts bash scripts/test-all.sh
=== 47/47 suites passed ===
```

Zero newly-discovered failures after the test fix.

## Why this is a prereq to #3789

Per plan-review (Kieran P1 #7): folding this fix into #3789 (deterministic permissions) was rejected because discovery may surface previously-broken hook tests that would then block #3789's merge. Shipping standalone here keeps the bigger PR clean. The one newly-surfaced failure (pre-merge-rebase T3/T4 on master-default CI) is fixed inline.

Closes #3799
Refs #3789

🤖 Generated with [Claude Code](https://claude.com/claude-code)
