### PR TITLE
fix(release): make Sentry migration audit non-blocking (post-#3811 hotfix)

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -274,10 +274,22 @@ jobs:
       # Re-runs the audit after each release and uploads the dated Markdown
       # report as a release asset. Provides an evergreen Article 30 §5(2)
       # accountability evidence trail co-located with release notes.
+      #
+      # NON-BLOCKING: this step is telemetry and MUST NOT fail the release
+      # pipeline. `continue-on-error: true` + an inner non-set-e shell with
+      # explicit exit-0 conversion ensures a Sentry-side transient (token
+      # scope mismatch, region-probe failure, API outage) cannot block the
+      # Docker build/push that follows. Initial #3811 ship hit this failure
+      # mode: the CI SENTRY_AUTH_TOKEN lacked the `/users/me/` scope the
+      # region probe requires, the audit script exited 1, and BOTH the
+      # plugin release AND the web-platform release skipped Docker push
+      # while the GitHub Release tags landed — production stayed stale.
+      #
       # Skips silently when SENTRY_AUTH_TOKEN is unavailable (e.g. component
       # release where the secret isn't required).
       - name: Sentry Monitors/Alerts migration audit
         if: steps.create_release.outputs.released == 'true'
+        continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -285,7 +297,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
-          set -euo pipefail
+          # No `set -e` — every audit failure path must exit 0 so the
+          # release pipeline continues. The `continue-on-error: true`
+          # marker above is belt; this is suspenders.
+          set -uo pipefail
           if [[ -z "${SENTRY_AUTH_TOKEN:-}" ]]; then
             echo "::notice::SENTRY_AUTH_TOKEN unavailable; skipping migration audit (no Article 30 evidence uploaded for this release)."
             exit 0
@@ -294,8 +309,15 @@ jobs:
             echo "::notice::Audit script not present in this checkout; skipping."
             exit 0
           fi
+          set +e
           AUDIT_OUT_DIR="${RUNNER_TEMP}/sentry-audit" \
             bash apps/web-platform/scripts/sentry-monitors-audit.sh
+          script_rc=$?
+          set -e
+          if [[ "$script_rc" -ne 0 ]]; then
+            echo "::warning::Sentry migration audit script exited ${script_rc} — no Article 30 evidence uploaded for this release. Operator should re-run with a SENTRY_AUTH_TOKEN that has org:read scope for /users/me/ region probe."
+            exit 0
+          fi
           report=$(ls "${RUNNER_TEMP}/sentry-audit"/sentry-migration-audit-*.md 2>/dev/null | head -1 || true)
           if [[ -z "$report" ]]; then
             echo "::warning::Audit produced no report file."


### PR DESCRIPTION
## Summary

Hotfix for PR #3811's post-merge release failure. The Sentry migration audit step added to `reusable-release.yml` exited 1 in CI (the auth token lacked the `/users/me/` region-probe scope), which failed the job **after** `Create GitHub Release` succeeded but **before** Docker push ran. Result: tags `v0.95.0` and `web-v0.87.0` landed but **production stayed on the old Docker image**.

Both runs that failed:

- `25920579695` — Version Bump and Release (plugin)
- `25920579708` — Web Platform Release

This PR makes the audit step non-blocking. Telemetry must never gate production deployment.

## Changes

- Add `continue-on-error: true` to the "Sentry Monitors/Alerts migration audit" step.
- Switch the step's shell to `set -uo pipefail` (drop `-e`) and wrap the audit-script invocation in explicit `set +e / set -e` with non-zero → `::warning::` + `exit 0`. Belt and suspenders.
- Update the step's header comment with the failure-mode context.

## Test plan

- [x] `actionlint .github/workflows/reusable-release.yml` — zero new findings on the changed lines.
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — parses.
- [ ] ⏳ CI merge + re-trigger of the plugin / web-platform release workflows confirms Docker push lands.

Ref #3811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
