### PR TITLE
fix(sentry-iac): correct sentry_project default to actual prod slug

### DIFF
--- a/apps/web-platform/infra/sentry/variables.tf
+++ b/apps/web-platform/infra/sentry/variables.tf
@@ -6,8 +6,8 @@ variable "sentry_org" {
 
 variable "sentry_project" {
   type        = string
-  description = "Sentry project slug for the Web Platform (e.g. web-platform)."
-  default     = "web-platform"
+  description = "Sentry project slug for the Web Platform (e.g. soleur-web-platform — the production slug as of #3849)."
+  default     = "soleur-web-platform"
 }
 
 variable "sentry_region" {


### PR DESCRIPTION
## Summary

- `apps/web-platform/infra/sentry/variables.tf` default for `sentry_project` was `web-platform`; the real Sentry project slug is `soleur-web-platform`.
- Latent bug since #3811 merged. Was masked by the previous `SENTRY_AUTH_TOKEN` being so under-scoped it 403'd before reaching the project-lookup step.
- Surfaced today after rotating to a scoped token per #3849. The next apply-sentry-infra run failed with `Unable to read, got status code 404: {"detail":"Project does not exist"}` on `data.sentry_project.web_platform`.

## Evidence

- `doppler secrets get SENTRY_PROJECT -p soleur -c prd --plain` → `soleur-web-platform`
- `curl /api/0/organizations/jikigai/projects/` returns one project, slug `soleur-web-platform`
- Failed run: https://github.com/jikig-ai/soleur/actions/runs/25936657748

## Test plan

- [x] Diff is a 2-line default value change in one file
- [x] No other references to the literal string `"web-platform"` as a Sentry project slug exist in `apps/web-platform/infra/sentry/`, `.github/workflows/`, or `apps/web-platform/scripts/`
- [ ] After merge, re-trigger apply-sentry-infra.yml — expect plan + apply to succeed, creating 8 cron monitors
- [ ] Re-verify via `curl /api/0/organizations/jikigai/monitors/ | jq length` = 8

## Follow-up (out of scope)

A cleaner fix would remove the default entirely and require the workflow to pass `TF_VAR_sentry_project` from Doppler's `SENTRY_PROJECT`, matching how `AWS_*` credentials are wired. Filing as a separate scope-out concern.

Refs: #3849, #3811, ADR-031

🤖 Generated with [Claude Code](https://claude.com/claude-code)