### PR TITLE
fix(release): pass SENTRY_API_HOST to audit step (unblocks AC16)

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -285,6 +285,17 @@ jobs:
       # plugin release AND the web-platform release skipped Docker push
       # while the GitHub Release tags landed — production stayed stale.
       #
+      # SENTRY_API_HOST bypasses the audit script's `/users/me/` region
+      # probe (which requires `member:read` scope — a scope that personal
+      # tokens minted for CI commonly lack even after the post-#3849 token
+      # rotation). Mirrors the escape hatch added to
+      # `configure-sentry-alerts.sh` in #3858. Falls back to `sentry.io`
+      # (US ingest — the empirically-verified host the operator's
+      # 2026-05-15 baseline audit ran against per the committed artifact
+      # at `knowledge-base/legal/audits/sentry-migration-audit-2026-05-15.md`).
+      # Override via the `SENTRY_API_HOST` repo secret if Sentry residency
+      # changes (e.g., migration to `de.sentry.io`).
+      #
       # Skips silently when SENTRY_AUTH_TOKEN is unavailable (e.g. component
       # release where the secret isn't required).
       - name: Sentry Monitors/Alerts migration audit
@@ -294,6 +305,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_API_HOST: ${{ secrets.SENTRY_API_HOST || 'sentry.io' }}
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
@@ -315,7 +327,7 @@ jobs:
           script_rc=$?
           set -e
           if [[ "$script_rc" -ne 0 ]]; then
-            echo "::warning::Sentry migration audit script exited ${script_rc} — no Article 30 evidence uploaded for this release. Operator should re-run with a SENTRY_AUTH_TOKEN that has org:read scope for /users/me/ region probe."
+            echo "::warning::Sentry migration audit script exited ${script_rc} — no Article 30 evidence uploaded for this release. If the script output reads 'Sentry token not valid against either US or EU ingest', verify SENTRY_API_HOST is reaching the script (defaults to 'sentry.io'; override via repo secret if residency changed). If the token is rejected past the probe, rotate per ADR-031 §Authentication."
             exit 0
           fi
           report=$(ls "${RUNNER_TEMP}/sentry-audit"/sentry-migration-audit-*.md 2>/dev/null | head -1 || true)


### PR DESCRIPTION
## Summary

PR #3858 added a `SENTRY_API_HOST` escape hatch to `configure-sentry-alerts.sh` to bypass the audit script's `/users/me/` region probe — required because personal Sentry tokens minted for CI commonly lack the `member:read` scope the probe needs, even after the post-#3849 token rotation that widened scopes for `org:read`, `project:read`, `project:write`.

**The same escape hatch was NOT propagated to the audit step in `.github/workflows/reusable-release.yml`.** Verified empirically:

- Post-#3858 release `web-v0.87.8` at 2026-05-15T20:45:04Z still emitted: `::warning::Sentry migration audit script exited 1 — Operator should re-run with a SENTRY_AUTH_TOKEN that has org:read scope for /users/me/ region probe.`
- 10 releases since #3811 merged; **0 have the audit asset** uploaded.

The audit artifact eventually committed manually in #3858 satisfies the "have the artifact" intent, but NOT the AC16 obligation that `reusable-release.yml` auto-uploads it per release cycle. Without this fix, future releases continue producing no Article 30 evidence trail.

## Fix

Pass `SENTRY_API_HOST` to the audit step env, with a fallback default of `sentry.io` (the empirically-verified host the operator's local 2026-05-15 baseline audit ran against per `knowledge-base/legal/audits/sentry-migration-audit-2026-05-15.md` frontmatter). Override via the `SENTRY_API_HOST` repo secret if Sentry residency changes in the future.

```yaml
SENTRY_API_HOST: ${{ secrets.SENTRY_API_HOST || 'sentry.io' }}
```

Also tightened the failure-mode `::warning::` message to point at the new escape hatch first (`SENTRY_API_HOST`) and the token-rotation path second.

## Operator action required

**None for the immediate AC16 unblock** — the `sentry.io` fallback default matches the validated current config. The optional `SENTRY_API_HOST` repo secret only needs setting if Sentry residency changes (or if you want to force `de.sentry.io` for the EU-residency posture the Article 30 register claims).

## Latent observation (out of scope for this PR)

The Article 30 register PA8 §(e) says Soleur's Sentry org is **DE-region**, but the committed baseline audit ran against `sentry.io` (**US**). The 8 cron monitors are live on `sentry.io`. That contradiction is a separate compliance discussion — flagging for the legal corpus sweep, not blocking this AC16 fix.

## Test plan

- [x] `actionlint .github/workflows/reusable-release.yml` — clean (pre-existing SC2012 info-level finding is outside the diff).
- [ ] Post-merge: next release triggers the workflow; audit step writes the report; `gh release view <tag>` shows `sentry-migration-audit-<date>.md` as an asset.

Ref #3849 (AC16). Closes the AC16 operator-action item in #3849's resolution steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)