### PR TITLE
feat(followthrough): scheduled sweeper for label:follow-through trackers

### DIFF
--- a/.github/workflows/scheduled-followthrough-sweeper.yml
+++ b/.github/workflows/scheduled-followthrough-sweeper.yml
@@ -1,0 +1,65 @@
+# Daily sweep of `follow-through` labeled issues. Parses the
+# `<!-- soleur:followthrough script=... earliest=... secrets=... -->`
+# directive in each open issue body and runs the referenced script with
+# only the secrets it declared. Closes with PASS comment on exit 0,
+# comments FAIL on exit 1, comments TRANSIENT on any other exit.
+#
+# Convention: knowledge-base/engineering/ops/runbooks/followthrough-convention.md
+#
+# Cron `0 18 * * *` (daily 18:00 UTC) — aligns with the issue-body
+# convention to express `earliest` in UTC and gives one sweep per
+# wall-clock day.
+#
+# Security model:
+#   - Verification scripts MUST live under scripts/followthroughs/ in the
+#     repo. The sweeper rejects any other path before exec. This means
+#     issue body editors cannot point the runner at arbitrary files.
+#   - The sweeper exports ONLY the secrets listed in the directive's
+#     `secrets=` clause. Add new secrets here as new follow-throughs
+#     declare them.
+#   - Issue body content is parsed via awk on stdin (never shell
+#     interpolation), then passed to bash as parameter values. Issue
+#     creators cannot inject shell commands via body content.
+#
+# To test manually: gh workflow run scheduled-followthrough-sweeper.yml
+
+name: "Scheduled: Follow-Through Sweeper"
+
+on:
+  schedule:
+    - cron: '0 18 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'If true, parse + report but do not comment or close'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: schedule-followthrough-sweeper
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sweep:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Run sweeper
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
+          # Secrets that one or more verification scripts may declare via
+          # the `secrets=` directive clause. Add new ones here when a new
+          # follow-through ships needing them.
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          bash scripts/sweep-followthroughs.sh

--- a/knowledge-base/engineering/ops/runbooks/followthrough-convention.md
+++ b/knowledge-base/engineering/ops/runbooks/followthrough-convention.md
@@ -1,0 +1,66 @@
+# Follow-Through Convention
+
+A `follow-through` is a tracker issue whose closure depends on wall-clock
+time passing AND a verifiable condition being true (e.g. "wait 48 hours
+then check that Sentry monitors received check-ins"). The
+follow-through sweeper closes them automatically when both gates pass.
+
+## Why
+
+Without automation, the engineer who filed the tracker has to remember
+to come back and check. Sessions close, calendar reminders get lost,
+and the issue rots open. With the sweeper, the issue closes the day the
+verification passes — no human revisit required.
+
+## Author workflow
+
+1. **File the tracker** with label `follow-through` and a clear close-criteria description in the body.
+2. **Write the verification script** under `scripts/followthroughs/<short-name>-<issue-num>.sh`. Conventions:
+   - Exit 0 = PASS (close-criteria met → sweeper closes the issue)
+   - Exit 1 = FAIL (criteria not met → sweeper comments, leaves open)
+   - Any other exit = TRANSIENT (network failure, timeout → sweeper retries next sweep)
+   - The script may print human-readable output to stdout/stderr; the sweeper captures the last 4 KB and posts it as a comment.
+   - The script must be deterministic in its exit semantics: do not exit 0 on partial success.
+3. **Declare needed secrets** via the directive's `secrets=` clause. Only the named secrets get exported into the script's environment. Add the secret to `.github/workflows/scheduled-followthrough-sweeper.yml` `env:` block if it isn't already wired.
+4. **Add the directive** to the issue body:
+
+   ```html
+   <!-- soleur:followthrough
+     script=scripts/followthroughs/sentry-checkins-3859.sh
+     earliest=2026-05-17T18:00:00Z
+     secrets=SENTRY_AUTH_TOKEN
+   -->
+   ```
+
+   Place it inline anywhere in the body. Multiple directives in one body: only the first is honored.
+
+5. **Open a PR** that lands the script + (optionally) any new secrets in the workflow env. CI on the PR includes the workflow file's syntax check.
+
+## Directive fields
+
+| Field | Required | Notes |
+|---|---|---|
+| `script` | yes | Path MUST start with `scripts/followthroughs/`. Other paths are refused (defense against tampered issue bodies pointing at arbitrary files). |
+| `earliest` | yes | ISO-8601 UTC timestamp. The sweeper skips the issue until `now >= earliest`. |
+| `secrets` | optional | Comma-separated GitHub secret names. Only these are exported into the script's environment. Omit if the script needs no secrets. |
+
+## Security guarantees
+
+- Verification scripts are code-reviewed at PR time and live committed in the repo. Issue body editors cannot inline-execute code, only reference an existing path.
+- The sweeper exports a narrow allowlist of secrets (declared per-script), not the full workflow env.
+- Issue body content reaches the sweeper via `awk` on stdin (no shell interpolation). Directive values are passed to the verification script as environment values and command-line args, never via shell-evaluated strings.
+- The sweeper uses `gh` CLI for issue close/comment, not raw token interpolation.
+
+## What the sweeper does NOT cover
+
+- **One-shot scheduling**: every sweep checks every open follow-through. If you want a script to run exactly once at a specific timestamp, that's a regular scheduled workflow, not a follow-through.
+- **Inline scripts**: scripts must be committed. We considered allowing inline shell in directives and rejected it for security.
+- **Multi-step verification**: each script is one binary pass/fail. For verifications that span multiple days with different criteria, file multiple follow-through issues that block each other.
+
+## Operator reference
+
+- **Workflow**: `.github/workflows/scheduled-followthrough-sweeper.yml`
+- **Driver script**: `scripts/sweep-followthroughs.sh`
+- **Manual run**: `gh workflow run scheduled-followthrough-sweeper.yml`
+- **Dry run**: `gh workflow run scheduled-followthrough-sweeper.yml -f dry_run=true`
+- **First user**: #3859 (Sentry cron monitor check-in receipts after #3849 rotation)

--- a/scripts/followthroughs/sentry-checkins-3859.sh
+++ b/scripts/followthroughs/sentry-checkins-3859.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Follow-through verification for #3859 (AC15 of #3849).
+#
+# Verifies that each of the 8 Sentry cron monitors created by the 2026-05-15
+# rotation has either accumulated check-ins OR has a low-frequency schedule
+# (monthly) that may still have zero. Returns:
+#   0 = PASS (close-criteria met → sweeper auto-closes #3859)
+#   1 = FAIL (criteria not met → sweeper leaves open, comments)
+#   * = TRANSIENT (e.g. network error → sweeper leaves open, retries next day)
+#
+# Required env: SENTRY_AUTH_TOKEN
+#
+# Close criteria (from #3859 body):
+#   - Every slug returns 200 on the checkins API
+#   - At least 6/8 monitors have ≥1 checkin recorded (allowing 2 for
+#     low-frequency / once-a-month schedules that may have no fire yet)
+
+set -uo pipefail
+
+: "${SENTRY_AUTH_TOKEN:?SENTRY_AUTH_TOKEN must be set}"
+
+ORG="jikigai"
+API="https://sentry.io/api/0"
+SLUGS=(
+  scheduled-terraform-drift
+  scheduled-oauth-probe
+  scheduled-github-app-drift-guard
+  scheduled-daily-triage
+  scheduled-realtime-probe
+  scheduled-skill-freshness
+  scheduled-content-vendor-drift
+  scheduled-community-monitor
+)
+
+have_count=0
+total_count=0
+errors=0
+
+for slug in "${SLUGS[@]}"; do
+  total_count=$((total_count + 1))
+  http_code=$(curl -sS -o /tmp/ck.json -w '%{http_code}' \
+    --max-time 30 \
+    -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
+    "${API}/organizations/${ORG}/monitors/${slug}/checkins/?limit=5" || echo "000")
+
+  if [[ "$http_code" != "200" ]]; then
+    echo "FAIL: ${slug} — HTTP ${http_code}"
+    errors=$((errors + 1))
+    continue
+  fi
+
+  n=$(jq 'if type=="array" then length else 0 end' /tmp/ck.json 2>/dev/null || echo 0)
+  if [[ "$n" -gt 0 ]]; then
+    have_count=$((have_count + 1))
+    echo "ok:   ${slug} — ${n} check-in(s)"
+  else
+    echo "warn: ${slug} — 0 check-ins (acceptable for low-frequency monitors)"
+  fi
+done
+
+echo ""
+echo "Summary: ${have_count}/${total_count} monitors with ≥1 check-in; ${errors} HTTP errors"
+
+# TRANSIENT: network/HTTP errors → leave open, retry next day
+if [[ "$errors" -gt 0 ]]; then
+  echo "exit: TRANSIENT (HTTP errors)"
+  exit 2
+fi
+
+# PASS: ≥6/8 (close-criteria met, monthly-schedule slack accepted)
+if [[ "$have_count" -ge 6 ]]; then
+  echo "exit: PASS"
+  exit 0
+fi
+
+# FAIL: <6/8 monitors have any check-ins after the earliest gate
+echo "exit: FAIL (only ${have_count} of 8 have check-ins; threshold is 6)"
+exit 1

--- a/scripts/sweep-followthroughs.sh
+++ b/scripts/sweep-followthroughs.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Sweep open `follow-through` issues, parse the soleur:followthrough
+# directive in their bodies, and run the referenced verification script
+# when the earliest-check timestamp has passed. Close the issue with a
+# PASS comment on script exit 0; comment FAIL and leave open on exit 1;
+# comment TRANSIENT and leave open on any other exit.
+#
+# Convention: knowledge-base/engineering/ops/runbooks/followthrough-convention.md
+#
+# Required env:
+#   GH_TOKEN  — GitHub token with issues:write
+#
+# Optional env:
+#   GH_REPO   — repo (defaults to current)
+#   DRY_RUN   — set to 1 to skip close/comment, only print actions
+#
+# All other env vars listed in the directive's `secrets=` clause are
+# expected to be present in the calling environment (the workflow YAML
+# is responsible for selectively exposing them).
+
+set -euo pipefail
+
+REPO="${GH_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+DRY_RUN="${DRY_RUN:-0}"
+SCRIPTS_ROOT="scripts/followthroughs"
+
+now_epoch=$(date -u +%s)
+
+log()  { printf '[%s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+fail() { printf '[%s] ERROR: %s\n' "$(date -u +%H:%M:%S)" "$*" >&2; }
+
+# Parse a single directive from an issue body. Stdin = body text.
+# Writes lines: `KEY VALUE` for script/earliest/secrets, or nothing if no
+# directive is present. Multiple directives in one body → only the first
+# is honored (log a warning).
+parse_directive() {
+  awk '
+    /<!-- *soleur:followthrough/, /-->/ {
+      gsub(/^<!-- *soleur:followthrough/, "")
+      gsub(/-->/, "")
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^script=/)   { sub(/^script=/, "", $i);   print "script "   $i }
+        if ($i ~ /^earliest=/) { sub(/^earliest=/, "", $i); print "earliest " $i }
+        if ($i ~ /^secrets=/)  { sub(/^secrets=/, "", $i);  print "secrets "  $i }
+      }
+    }
+  '
+}
+
+iso_to_epoch() {
+  # GNU date; portable enough for ubuntu-latest runner. Empty stdin → 0.
+  local iso="$1"
+  [[ -z "$iso" ]] && { echo 0; return; }
+  date -u -d "$iso" +%s 2>/dev/null || echo 0
+}
+
+run_one() {
+  local issue_num="$1"
+  local body="$2"
+
+  local script earliest secrets
+  while read -r key val; do
+    case "$key" in
+      script)   script="$val" ;;
+      earliest) earliest="$val" ;;
+      secrets)  secrets="$val" ;;
+    esac
+  done < <(printf '%s' "$body" | parse_directive)
+
+  if [[ -z "${script:-}" ]]; then
+    log "issue #$issue_num: no directive — skipping"
+    return 0
+  fi
+
+  log "issue #$issue_num: directive found (script=$script earliest=${earliest:-now} secrets=${secrets:-none})"
+
+  # Path safety: script MUST live under scripts/followthroughs/. Reject
+  # anything else so a tampered issue body can't point at /etc/passwd.
+  case "$script" in
+    "$SCRIPTS_ROOT"/*) : ok ;;
+    *)
+      fail "issue #$issue_num: script path '$script' not under $SCRIPTS_ROOT/ — refusing to run"
+      return 2
+      ;;
+  esac
+
+  if [[ ! -f "$script" ]]; then
+    fail "issue #$issue_num: script '$script' missing in repo HEAD — leaving issue open"
+    return 0
+  fi
+  if [[ ! -x "$script" ]]; then
+    fail "issue #$issue_num: script '$script' not executable — leaving issue open"
+    return 0
+  fi
+
+  # Earliest gate
+  local earliest_epoch
+  earliest_epoch=$(iso_to_epoch "${earliest:-}")
+  if (( now_epoch < earliest_epoch )); then
+    log "issue #$issue_num: earliest=$earliest not yet reached (now=$(date -u +%FT%TZ)) — skipping"
+    return 0
+  fi
+
+  # Build the env allowlist. Default = nothing. Only vars named in
+  # `secrets=` are passed through to the script.
+  local -a env_args=("env" "-i" "PATH=$PATH" "HOME=$HOME")
+  if [[ -n "${secrets:-}" ]]; then
+    IFS=',' read -r -a secret_names <<<"$secrets"
+    for name in "${secret_names[@]}"; do
+      name="${name// /}"
+      [[ -z "$name" ]] && continue
+      # Only pass through if the var is set in our environment.
+      if [[ -n "${!name+x}" ]]; then
+        env_args+=("$name=${!name}")
+      else
+        fail "issue #$issue_num: required secret '$name' not set in workflow env — leaving issue open"
+        return 0
+      fi
+    done
+  fi
+
+  log "issue #$issue_num: running $script"
+  local rc=0
+  local out
+  out=$("${env_args[@]}" "$script" 2>&1) || rc=$?
+  log "issue #$issue_num: $script exit=$rc"
+
+  local trimmed_out
+  trimmed_out=$(printf '%s' "$out" | tail -c 4000)
+
+  local verdict body_msg action
+  case "$rc" in
+    0)
+      verdict="PASS"
+      body_msg="### Sweeper run: PASS ($(date -u +%FT%TZ))
+Script: \`$script\` exited 0. Auto-closing per follow-through convention.
+
+<details><summary>Output (last 4 KB)</summary>
+
+\`\`\`
+$trimmed_out
+\`\`\`
+
+</details>"
+      action="close"
+      ;;
+    1)
+      verdict="FAIL"
+      body_msg="### Sweeper run: FAIL ($(date -u +%FT%TZ))
+Script: \`$script\` exited 1. Leaving issue open; the close criteria are not met.
+
+<details><summary>Output (last 4 KB)</summary>
+
+\`\`\`
+$trimmed_out
+\`\`\`
+
+</details>"
+      action="comment"
+      ;;
+    *)
+      verdict="TRANSIENT"
+      body_msg="### Sweeper run: TRANSIENT (exit $rc, $(date -u +%FT%TZ))
+Script: \`$script\` exited $rc. Treating as transient; leaving issue open for next sweep.
+
+<details><summary>Output (last 4 KB)</summary>
+
+\`\`\`
+$trimmed_out
+\`\`\`
+
+</details>"
+      action="comment"
+      ;;
+  esac
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log "issue #$issue_num: DRY_RUN — would $action with verdict=$verdict"
+    return 0
+  fi
+
+  printf '%s' "$body_msg" | gh issue comment "$issue_num" --repo "$REPO" --body-file -
+  if [[ "$action" == "close" ]]; then
+    gh issue close "$issue_num" --repo "$REPO"
+  fi
+
+  log "issue #$issue_num: verdict=$verdict action=$action"
+}
+
+main() {
+  log "sweep start (repo=$REPO dry_run=$DRY_RUN)"
+
+  local issues_json
+  issues_json=$(gh issue list --repo "$REPO" --label follow-through --state open --limit 50 --json number,body)
+  local count
+  count=$(printf '%s' "$issues_json" | jq 'length')
+  log "found $count open follow-through issues"
+
+  local i
+  for i in $(seq 0 $((count - 1))); do
+    local num body
+    num=$(printf '%s' "$issues_json" | jq -r ".[$i].number")
+    body=$(printf '%s' "$issues_json" | jq -r ".[$i].body")
+    run_one "$num" "$body" || fail "issue #$num: run_one returned non-zero (continuing)"
+  done
+
+  log "sweep done"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds a daily cron workflow + driver that auto-closes `follow-through` labeled issues once their declared earliest-check timestamp passes AND a referenced verification script exits 0. Removes the human-revisit-after-N-days burden that this class of tracker requires today.

First user: **#3859** (Sentry cron-monitor check-in receipts after the 2026-05-15 token rotation in #3849). After 2026-05-17 18:00 UTC, the sweeper runs `scripts/followthroughs/sentry-checkins-3859.sh`, posts a PASS comment, and closes the issue. No human revisit needed.

## How it works

Each follow-through issue body carries an HTML comment directive:

```html
<!-- soleur:followthrough
  script=scripts/followthroughs/<name>-<issue#>.sh
  earliest=YYYY-MM-DDTHH:MM:SSZ
  secrets=COMMA,SEPARATED,NAMES
-->
```

The cron-scheduled workflow:
1. Lists `label:follow-through state:open`
2. Parses each body for the directive (skips silently if absent)
3. If `now < earliest`, skips
4. Runs the referenced script with only the declared secrets exposed
5. Exit 0 → close + PASS comment; Exit 1 → FAIL comment; Other → TRANSIENT comment (retry next sweep)

## Security posture

- Verification scripts MUST live under `scripts/followthroughs/`. The driver rejects other paths before exec — a tampered issue body cannot point at arbitrary files.
- Only secrets declared in the directive get exported into the script's env. Default = none.
- Issue body content is parsed via `awk` on stdin, not shell interpolation. Directive values flow to scripts as env vars and command args, never via shell-evaluated strings.
- All issue close/comment goes through `gh` CLI.

## Files

| File | Purpose |
|---|---|
| `.github/workflows/scheduled-followthrough-sweeper.yml` | Daily cron + workflow_dispatch |
| `scripts/sweep-followthroughs.sh` | Driver (parse + run + close/comment) |
| `scripts/followthroughs/sentry-checkins-3859.sh` | Concrete verification for #3859 |
| `knowledge-base/engineering/ops/runbooks/followthrough-convention.md` | Operator-facing docs of the convention |
| #3859 body | Updated in this commit to include the directive |

## Test plan

- [x] Dry-run executed locally against live repo: 50 open follow-through issues enumerated; #3859 correctly identified as the only one with a directive; correctly skipped because earliest=2026-05-17 not yet reached.
- [x] All scripts marked executable (`scripts/sweep-followthroughs.sh`, `scripts/followthroughs/sentry-checkins-3859.sh`)
- [ ] CI green
- [ ] After merge, `gh workflow run scheduled-followthrough-sweeper.yml -f dry_run=true` exercises the wired-up path end-to-end without side effects
- [ ] On 2026-05-17 ≥18:00 UTC, the scheduled run closes #3859 (verifiable from #3859's close timestamp + the workflow run log)

## Why now

`follow-through` trackers historically rotted open because there was no place that knew when their wall-clock gate passed. The repo has **50 open** today — most of which could be auto-resolved once each gets a verification script. This PR builds the substrate; future PRs can opt-in any existing tracker by adding a directive + writing a script.

Refs #3849, #3859.

🤖 Generated with [Claude Code](https://claude.com/claude-code)