### PR TITLE
fix(secret-scan): use .test hosts in synthesized fixtures (post-merge lint-fixture-content regression from #3886)

### DIFF
--- a/apps/web-platform/test/__synthesized__/secret-scan-database-url-fixtures.md
+++ b/apps/web-platform/test/__synthesized__/secret-scan-database-url-fixtures.md
@@ -14,13 +14,13 @@ learnings tree, closes #3874).
 These shapes match the placeholder-allowlist regex and would be silenced even
 outside the path allowlist:
 
-- `postgres://USER:PASSWORD@host.example.com:5432/db`
-- `postgres://user:password@host.example.com:5432/db`
-- `postgres://postgres:secret@host.example.com:5432/db`
-- `postgres://<user>:<password>@host.example.com:5432/db`
+- `postgres://USER:PASSWORD@db.test:5432/db`
+- `postgres://user:password@db.test:5432/db`
+- `postgres://postgres:secret@db.test:5432/db`
+- `postgres://<user>:<password>@db.test:5432/db`
 - `postgres://user:***@aws-0-eu-west-1.pooler.supabase.com:6543/postgres`
-- `postgres://user:**@host.example.com:5432/db`
-- `postgresql://postgres:*****************@host.example.com:5432/db`
+- `postgres://user:**@db.test:5432/db`
+- `postgresql://postgres:*****************@db.test:5432/db`
 
 ## Negative — real-shape passwords that still fire (caught by path-allowlist here)
 
@@ -28,8 +28,8 @@ These are NOT silenced by the regex allowlist — they would fire on any path NO
 listed in the per-rule `paths` allowlist. They are silenced HERE only because
 the path matches `apps/web-platform/test/__synthesized__/.*`:
 
-- `postgres://user:realpw_AAAA1111@host.example.com:5432/db`
-- `postgres://admin:s3cret_pAssw0rd@host.example.com:5432/db`
+- `postgres://user:realpw_AAAA1111@db.test:5432/db`
+- `postgres://admin:s3cret_pAssw0rd@db.test:5432/db`
 
 ## How to re-verify
 

--- a/knowledge-base/project/learnings/2026-05-16-git-trailer-parser-requires-contiguous-key-value-block.md
+++ b/knowledge-base/project/learnings/2026-05-16-git-trailer-parser-requires-contiguous-key-value-block.md
@@ -36,7 +36,7 @@ Two distinct shapes triggered the silent drop:
 
 Allowlist-Widened-By: Jean Deruelle
 
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@example.com>
 ```
 
 Git's parser treats only the LAST contiguous paragraph of `Token: value` lines as the trailer block. Inserting a blank line between `Allowlist-Widened-By:` and `Co-Authored-By:` makes the former part of the body, not a trailer.
@@ -47,7 +47,7 @@ Git's parser treats only the LAST contiguous paragraph of `Token: value` lines a
 Closes #3877.
 Refs #3874 (path-allowlist precedent), #3888 (sibling parser refactor).
 Allowlist-Widened-By: Jean Deruelle
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@example.com>
 ```
 
 Git requires EVERY line in the final paragraph to be parseable as `Token: value` (or a continuation line starting with whitespace). The `Closes #3877.` and `Refs #3874 (...)` lines don't match — they have a number sign and a period, not `Closes: #3877`. The parser falls back to "no trailers detected" for the entire block; even valid `Allowlist-Widened-By:` and `Co-Authored-By:` lines below are dropped.
@@ -72,7 +72,7 @@ Closes #3877. Refs #3874 (motivating issue), #3875 (precedent PR),
 ...more prose, code block list, etc...
 
 Allowlist-Widened-By: Jean Deruelle
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@example.com>
 ```
 
 ## Verification


### PR DESCRIPTION
## Summary

Hotfix for the post-merge regression introduced by PR #3886. The `secret-scan` workflow on `main` is failing because `lint-fixture-content.mjs` flags `<user>@<host>` patterns whose host isn't in the allowed test-domain set (`example.com`, `example.org`, `*.test`, `fixtures.local`, `test.local`).

Two surfaces tripped:

- `apps/web-platform/test/__synthesized__/secret-scan-database-url-fixtures.md` — used `host.example.com` (subdomain, not exact `example.com` match). Lines like `postgres://USER:PASSWORD@host.example.com:5432/db` made the linter read `PASSWORD@host.example.com` as a real-looking email.
- `knowledge-base/project/learnings/2026-05-16-git-trailer-parser-requires-contiguous-key-value-block.md` — used `noreply@anthropic.com` literally in three commit-message code examples.

## Fix

- Fixture hosts: `host.example.com` → `db.test` (matches `.+\.test`, exact-allowed by the linter).
- Learning examples: `noreply@anthropic.com` → `noreply@example.com`.

Both edits verified locally:

- `node apps/web-platform/scripts/lint-fixture-content.mjs <both files>` → exit 0.
- `gitleaks detect --no-banner --no-git --redact -v -c .gitleaks.toml --source apps/web-platform/test/__synthesized__/secret-scan-database-url-fixtures.md` → `no leaks found`, exit 0.

## Why PR CI didn't gate this on #3886

`secret-scan` is not a required check on `main` branch protection. PR CI did fail it (8 attempts, all `secret-scan` runs `failure`) but auto-merge proceeded anyway. Filing follow-up to make secret-scan required, separately.

## Test plan

- [x] `lint-fixture-content.mjs` exits 0 on both files
- [x] `gitleaks detect` on the updated fixture finds no leaks
- [ ] Post-merge: `secret-scan` workflow on `main` returns green

Ref #3877. Fixes the post-merge regression introduced by PR #3886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)