### PR TITLE
review: defang positive-corpus JWT fixture (gitleaks entropy)

### DIFF
--- a/plugins/soleur/skills/incident/test/fixtures/positive-corpus.md
+++ b/plugins/soleur/skills/incident/test/fixtures/positive-corpus.md
@@ -10,7 +10,7 @@ This keeps the fixture safe to commit while still exercising every regex class.
 
 ## JWT three-segment
 
-eyJsynthesized_HEADER_placeholder.synthesized_PAYLOAD_placeholder.synthesized_SIGNATURE_placeholder
+eyJaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaa
 
 ## Email
 


### PR DESCRIPTION
## Summary

Salvages the P1 review-fix commit (`cde06342`) that didn't make it into the squash-merge of PR #3721 (`/soleur:incident` skill, merged 2026-05-14).

Replaces the JWT positive-corpus entry with a low-entropy variant (`eyJaaa...`) so it stays below gitleaks JWT regex/entropy thresholds if/when secret-scanning is wired into CI. The descriptive `eyJsynthesized_HEADER_placeholder...` form on main was a synthesis-readable placeholder, but it still leads with `eyJ` and exceeds the typical 16-char base64 segment length most JWT regexes look for. Defanging now is cheap insurance — no current CI gate fails on the main version, but future gitleaks adoption would.

## Changelog

- Defang JWT positive-corpus fixture (`plugins/soleur/skills/incident/test/fixtures/positive-corpus.md`) to a low-entropy form below typical gitleaks regex/entropy thresholds while preserving the redact-sentinel's JWT-class trigger.

## Test plan

- [x] `bash plugins/soleur/skills/incident/test/redact-sentinel.test.sh` — 19/19 pass (JWT pattern still triggers redact-sentinel as required)
- [ ] CI green on the synthetic-check sweep

## Provenance

Originally part of the `feat-incident-commander-2725` worktree post-merge cleanup. Verified: cherry-picked `cde06342` against current `main`, resolved the placeholder-vs-defang conflict in favor of the defanged form. Worktree `feat-incident-commander-2725` (PR #3721 merged) was removed after this PR was queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)