### PR TITLE
fix(runtime): skip inngest env-throws during next build (PR-F follow-up)

### DIFF
--- a/apps/web-platform/app/api/inngest/route.ts
+++ b/apps/web-platform/app/api/inngest/route.ts
@@ -20,12 +20,17 @@ import { inngest } from "@/server/inngest/client";
 import { cfoOnPaymentFailed } from "@/server/inngest/functions/cfo-on-payment-failed";
 
 const SIGNING_KEY = process.env.INNGEST_SIGNING_KEY;
-if (!SIGNING_KEY) {
+// next build page-data collection loads this module without runtime env.
+// Skip the throw during build; runtime process restart on Hetzner re-fires
+// the validation against Doppler-injected env. Mirrors the bypass in
+// server/inngest/client.ts.
+const IS_BUILD_PHASE = process.env.NEXT_PHASE === "phase-production-build";
+if (!IS_BUILD_PHASE && !SIGNING_KEY) {
   throw new Error("INNGEST_SIGNING_KEY missing at /api/inngest load");
 }
 
 export const { GET, POST, PUT } = serve({
   client: inngest,
   functions: [cfoOnPaymentFailed],
-  signingKey: SIGNING_KEY,
+  signingKey: SIGNING_KEY ?? "build-phase-placeholder",
 });

--- a/apps/web-platform/server/inngest/client.ts
+++ b/apps/web-platform/server/inngest/client.ts
@@ -18,24 +18,33 @@ const SIGNING_KEY = process.env.INNGEST_SIGNING_KEY;
 const EVENT_KEY = process.env.INNGEST_EVENT_KEY;
 const BASE_URL = process.env.INNGEST_BASE_URL;
 
-if (!SIGNING_KEY) {
-  throw new Error("INNGEST_SIGNING_KEY missing at startup");
-}
-if (!EVENT_KEY) {
-  throw new Error("INNGEST_EVENT_KEY missing at startup");
-}
-// Review P2-1 (security-sentinel): in cloud mode the Inngest SDK
-// validates signatures; in dev mode it short-circuits validateSignature
-// to success (per node_modules/inngest/components/InngestCommHandler.js).
-// A Doppler prd misconfiguration setting INNGEST_DEV=1 would silently
-// disable I4 — refuse to load.
-if (
-  process.env.NODE_ENV === "production" &&
-  process.env.INNGEST_DEV === "1"
-) {
-  throw new Error(
-    "INNGEST_DEV=1 in production refuses to load: signature verification would be bypassed (ADR-030 I4)",
-  );
+// Next.js sets NEXT_PHASE during `next build` page-data collection, which
+// loads route modules (including /api/inngest) without runtime env vars.
+// Skip the load-time guards during build so the bundle compiles; they
+// re-fire at first request via process-restart on Hetzner (the production
+// node process starts with the Doppler-injected env vars).
+const IS_BUILD_PHASE = process.env.NEXT_PHASE === "phase-production-build";
+
+if (!IS_BUILD_PHASE) {
+  if (!SIGNING_KEY) {
+    throw new Error("INNGEST_SIGNING_KEY missing at startup");
+  }
+  if (!EVENT_KEY) {
+    throw new Error("INNGEST_EVENT_KEY missing at startup");
+  }
+  // Review P2-1 (security-sentinel): in cloud mode the Inngest SDK
+  // validates signatures; in dev mode it short-circuits validateSignature
+  // to success (per node_modules/inngest/components/InngestCommHandler.js).
+  // A Doppler prd misconfiguration setting INNGEST_DEV=1 would silently
+  // disable I4 — refuse to load.
+  if (
+    process.env.NODE_ENV === "production" &&
+    process.env.INNGEST_DEV === "1"
+  ) {
+    throw new Error(
+      "INNGEST_DEV=1 in production refuses to load: signature verification would be bypassed (ADR-030 I4)",
+    );
+  }
 }
 if (BASE_URL) {
   try {
@@ -47,6 +56,6 @@ if (BASE_URL) {
 
 export const inngest = new Inngest({
   id: "soleur-runtime",
-  eventKey: EVENT_KEY,
+  eventKey: EVENT_KEY ?? "build-phase-placeholder",
   ...(BASE_URL ? { baseUrl: BASE_URL } : {}),
 });

--- a/apps/web-platform/test/server/inngest/client-startup.test.ts
+++ b/apps/web-platform/test/server/inngest/client-startup.test.ts
@@ -21,6 +21,7 @@ const ORIGINAL_ENV = {
   INNGEST_BASE_URL: process.env.INNGEST_BASE_URL,
   INNGEST_DEV: process.env.INNGEST_DEV,
   NODE_ENV: process.env.NODE_ENV,
+  NEXT_PHASE: process.env.NEXT_PHASE,
 };
 
 function restoreEnv(key: keyof typeof ORIGINAL_ENV) {
@@ -48,6 +49,7 @@ afterEach(() => {
   restoreEnv("INNGEST_BASE_URL");
   restoreEnv("INNGEST_DEV");
   restoreEnv("NODE_ENV");
+  restoreEnv("NEXT_PHASE");
 });
 
 describe("server/inngest/client.ts — module-load env validation", () => {
@@ -124,6 +126,19 @@ describe("server/inngest/client.ts — module-load env validation", () => {
     // @ts-expect-error see above.
     process.env.NODE_ENV = "test";
     process.env.INNGEST_DEV = "1";
+    const mod = await import("@/server/inngest/client");
+    expect(mod.inngest).toBeDefined();
+  });
+
+  // PR-F follow-up: Next.js page-data collection during `next build` loads
+  // route modules without runtime env vars. If the module throws at import
+  // when env is missing, build fails. The NEXT_PHASE=phase-production-build
+  // bypass lets the module load with placeholder env; runtime restart on
+  // Hetzner re-fires the validation with the Doppler-injected env.
+  it("does NOT throw at import during NEXT_PHASE=phase-production-build (build-phase bypass)", async () => {
+    delete process.env.INNGEST_SIGNING_KEY;
+    delete process.env.INNGEST_EVENT_KEY;
+    process.env.NEXT_PHASE = "phase-production-build";
     const mod = await import("@/server/inngest/client");
     expect(mod.inngest).toBeDefined();
   });


### PR DESCRIPTION
## Summary

- PR #3940 merged with `next build` page-data collection failing: `app/api/inngest/route.ts` imports `server/inngest/client.ts`, whose load-time `INNGEST_SIGNING_KEY` / `INNGEST_EVENT_KEY` throws fire during page-data collection (CI env has no Doppler secrets).
- Adds the Next-canonical `NEXT_PHASE === "phase-production-build"` bypass so the module compiles; the runtime restart on Hetzner re-fires validation with Doppler-injected env.
- New unit test asserts import does NOT throw under `NEXT_PHASE=phase-production-build` even with both keys deleted.

## Why this didn't fire on PR #3940

The `web-platform-build` job is NOT in the branch protection ruleset (`test`, `dependency-review`, `e2e`, `CodeQL`, `skill-security-scan PR gate` are required; build is observational). PR #3940's auto-merge fired on the required-checks set while `web-platform-build` was still failing. The post-merge release deploy (`web-platform-release.yml`) was already in progress at merge time; this hotfix lands before it gets to the build step.

## Test plan

- [x] `npx vitest run test/server/inngest/client-startup.test.ts` → 11 passed (including the new build-phase bypass test)
- [ ] `web-platform-build` CI job passes on this branch
- [ ] post-merge release deploy reaches build step and succeeds

Ref #3244 #3940

🤖 Generated with [Claude Code](https://claude.com/claude-code)