### PR TITLE
fix(secret-scan): replace operator email literal in learning file

### DIFF
--- a/knowledge-base/project/learnings/2026-05-17-vendor-support-tickets-are-playwright-driveable.md
+++ b/knowledge-base/project/learnings/2026-05-17-vendor-support-tickets-are-playwright-driveable.md
@@ -27,7 +27,7 @@ The instinct to label vendor support submissions as "operator-only" comes from a
 
 PR #3946 retroactively drove both tickets via Playwright at `https://help.sentry.io/`:
 
-- **Ticket 1 (billing refund):** opened Intercom messenger, sent the body, AI returned standard non-refund policy reply, sent escalation follow-up explaining IaC-error context, AI requested email for routing, OTP (`<otp-redacted>` — 6-digit, single-session, consumed at submission time) sent to `jean.deruelle@jikigai.com` (operator pasted the code back into chat), conversation routed to Sentry Foundations team. Conversation auto-titled "Billing refund request" by Intercom.
+- **Ticket 1 (billing refund):** opened Intercom messenger, sent the body, AI returned standard non-refund policy reply, sent escalation follow-up explaining IaC-error context, AI requested email for routing, OTP (`<otp-redacted>` — 6-digit, single-session, consumed at submission time) sent to the operator email on file (operator pasted the code back into chat), conversation routed to Sentry Foundations team. Conversation auto-titled "Billing refund request" by Intercom.
 - **Ticket 2 (forensics):** opened a SEPARATE Intercom conversation (per brainstorm Decision #9 non-threading requirement), sent forensics body, AI returned substantive non-disclosure-policy statement citing Sentry help articles (which is itself the residual ceiling we needed for PIR Phase 8 Gate 3c), sent escalation follow-up requesting citable policy + escalation-path inquiry, routed to Foundations team without re-prompting OTP (cookie session already verified).
 
 Total operator interaction: paste one 6-digit OTP into chat. Zero "compose and submit a ticket" cognitive load.


### PR DESCRIPTION
## Summary

Hotfix for the post-merge `secret-scan` failure on PR #3946. The fixture-content linter at `apps/web-platform/scripts/lint-fixture-content.mjs` flagged the operator email literal `jean.deruelle@jikigai.com` in `knowledge-base/project/learnings/2026-05-17-vendor-support-tickets-are-playwright-driveable.md:30` as a "real-looking email" (learning files are explicitly in scope per `.github/workflows/secret-scan.yml` line 112's path regex).

The email value adds no semantic value to the learning narrative — the operator identity is documented in every commit's author trailer. Replaced with "the operator email on file".

## Changelog

### Operational artifacts

- `knowledge-base/project/learnings/2026-05-17-vendor-support-tickets-are-playwright-driveable.md`: replaced operator-email literal with generic placeholder to satisfy the fixture-content lint rule.

## Test plan

- [x] Local lint check: `node apps/web-platform/scripts/lint-fixture-content.mjs knowledge-base/project/learnings/2026-05-17-vendor-support-tickets-are-playwright-driveable.md` → exit 0.
- [ ] CI secret-scan green on merge.

Ref #3861
Ref #3946

🤖 Generated with [Claude Code](https://claude.com/claude-code)