### PR TITLE
fix(cla-evidence): capture R2 response body in fast-fail annotations

### DIFF
--- a/apps/cla-evidence/scripts/r2-conditional-put.sh
+++ b/apps/cla-evidence/scripts/r2-conditional-put.sh
@@ -46,11 +46,20 @@ bucket="${R2_CLA_EVIDENCE_BUCKET:-soleur-cla-evidence}"
 endpoint="${R2_CLA_EVIDENCE_ENDPOINT:?R2_CLA_EVIDENCE_ENDPOINT must be set}"
 url="${endpoint%/}/${bucket}/${key}"
 
+# Response-body capture: R2 returns XML error bodies (<Code>…</Code>) on 4xx/5xx.
+# We pipe them to a tempfile so the failure annotation can echo the real reason
+# (e.g., InvalidRequest vs ObjectLockedRetention vs SignatureDoesNotMatch) rather
+# than the prior generic "stale token or missing perms" guess. Without this the
+# operator has to bisect blind every time R2 returns a new 4xx code.
+body_tmp=$(mktemp)
+trap 'rm -f "$body_tmp"' EXIT
+
 put_once() {
   # Stub-friendly: in tests, $(which curl) is the PATH-stub that emits a numeric
-  # HTTP code on stdout. In production, curl is invoked with full SigV4 via
-  # --aws-sigv4 (curl 7.75+) and emits the code via -w "%{http_code}".
-  curl -sS -o /dev/null -w "%{http_code}\n" --max-time 30 \
+  # HTTP code on stdout and ignores -o (so $body_tmp stays empty, which the
+  # error-emit path tolerates). In production, curl is invoked with full SigV4
+  # via --aws-sigv4 (curl 7.75+) and emits the code via -w "%{http_code}".
+  curl -sS -o "$body_tmp" -w "%{http_code}\n" --max-time 30 \
     -X PUT \
     -H "If-None-Match: *" \
     -H "Content-Type: application/json" \
@@ -58,6 +67,18 @@ put_once() {
     --user "${R2_CLA_EVIDENCE_ACCESS_KEY_ID}:${R2_CLA_EVIDENCE_SECRET}" \
     --data-binary "$payload" \
     "$url" 2>/dev/null || echo "000"
+}
+
+# Single-line body excerpt for inclusion in `::error::` annotations (GH Actions
+# annotations are one-line; multi-line XML would be truncated mid-tag). Caps at
+# 512 chars so a future malicious-bucket-redirect dumping HTML can't blow up
+# the log line.
+body_excerpt() {
+  if [[ ! -s "$body_tmp" ]]; then
+    printf '(empty body)'
+    return
+  fi
+  tr '\n' ' ' < "$body_tmp" | head -c 512
 }
 
 attempt_max=3
@@ -93,18 +114,21 @@ while [[ "$attempt" -le "$attempt_max" ]]; do
       attempt=$(( attempt + 1 ))
       continue
     fi
-    echo "::error::${label}: ${attempt_max} consecutive 5xx/429; last status=$code key=$key" >&2
+    echo "::error::${label}: ${attempt_max} consecutive 5xx/429; last status=$code key=$key body=$(body_excerpt)" >&2
     exit 2
   fi
 
   if (( code >= 400 && code < 500 )); then
     # 4xx ≠ 412 → fast-fail per Kieran F5 (e.g., 403 from stale token is a
-    # config bug, not transient).
-    echo "::error::${label}: fatal-4xx status=$code key=$key (config bug; stale token or missing perms)" >&2
+    # config bug, not transient). The R2 response body (now captured to
+    # $body_tmp) carries the actual S3 ErrorCode — surface it so the operator
+    # does not have to guess between SignatureDoesNotMatch / InvalidRequest /
+    # ObjectLockedRetention / etc.
+    echo "::error::${label}: fatal-4xx status=$code key=$key body=$(body_excerpt)" >&2
     exit 2
   fi
 
-  echo "::error::${label}: unexpected status=$code key=$key" >&2
+  echo "::error::${label}: unexpected status=$code key=$key body=$(body_excerpt)" >&2
   exit 2
 done
 

--- a/apps/cla-evidence/scripts/upload-bypass.test.sh
+++ b/apps/cla-evidence/scripts/upload-bypass.test.sh
@@ -26,6 +26,9 @@ trap 'rm -rf "$work"' EXIT
 # Stub curl: emit the next HTTP code from $work/codes.txt and consume it.
 # Also append the request URL to $work/urls.txt so tests can assert key
 # derivation (the URL is the only side-effect visible to the harness).
+# If $work/body_fixture exists, honor curl's `-o <file>` arg and copy the
+# fixture there so body-echo tests can assert the error annotation
+# surfaces the R2 ErrorCode.
 mk_curl_stub() {
   local codes="$1"
   cat > "$work/curl" <<EOF
@@ -33,6 +36,16 @@ mk_curl_stub() {
 codes_file="$codes"
 read -r code < "\$codes_file"
 sed -i '1d' "\$codes_file"
+# Parse \`-o <file>\` and copy the body fixture there if present.
+prev=""
+out_path=""
+for arg in "\$@"; do
+  if [[ "\$prev" == "-o" ]]; then out_path="\$arg"; fi
+  prev="\$arg"
+done
+if [[ -n "\$out_path" && -f "$work/body_fixture" ]]; then
+  cp "$work/body_fixture" "\$out_path"
+fi
 # The URL is the last positional arg.
 for arg in "\$@"; do url="\$arg"; done
 echo "\$url" >> "$work/urls.txt"
@@ -126,6 +139,22 @@ if run_sut "$payload_evil" >/dev/null 2>&1; then
   fi
 else
   red "FAIL: Bypass.e expected exit 0 on 200 with adversarial payload"
+  fail=1
+fi
+
+# Bypass.g: 4xx error surfaces the captured R2 response body in the annotation.
+# This is the diagnostic-PR contract — without it the operator has no way to
+# distinguish e.g. SignatureDoesNotMatch from ObjectLockedRetention.
+printf "400\n" > "$work/codes.txt"
+printf '<Error><Code>ObjectLockConfigurationNotFoundError</Code><Message>example</Message></Error>' > "$work/body_fixture"
+mk_curl_stub "$work/codes.txt"
+out=$(run_sut "$payload" 2>&1) && rc=0 || rc=$?
+rm -f "$work/body_fixture"
+if [[ "$rc" -ne 0 ]] && grep -q 'ObjectLockConfigurationNotFoundError' <<<"$out"; then
+  green "PASS: Bypass.g 400 → fast-fail annotation includes R2 response body"
+else
+  red "FAIL: Bypass.g expected error annotation to include 'ObjectLockConfigurationNotFoundError'"
+  red "$out"
   fail=1
 fi
 


### PR DESCRIPTION
## Summary

- Every `pull_request_target` event on the `cla-evidence` workflow has been failing the `Record allowlist-bypass` step since the 2026-05-16 bootstrap with `fatal-4xx status=400`, spamming operator notifications.
- Root cause is *unclear* because the curl call in `r2-conditional-put.sh` discards the response body (`-o /dev/null`); the prior `(config bug; stale token or missing perms)` suffix is a guess.
- This is the minimum diagnostic step: capture the R2 response body to a tempfile and surface a single-line excerpt (capped at 512 chars) in the `::error::` annotation on 4xx/5xx-exhausted/unexpected paths.
- The next failed PR run will reveal the real S3 ErrorCode (`SignatureDoesNotMatch` / `InvalidRequest` / `ObjectLockedRetention` / ...), which a follow-up commit can then act on.

## What is NOT in this PR

- The actual fix to make bypass writes succeed. Without the response body we are guessing; once this lands and the next PR's run emits the real ErrorCode, the corrective change is single-targeted.

## Test plan

- [x] `bash apps/cla-evidence/scripts/upload-bypass.test.sh` — all 7 pass (added Bypass.g for body-echo behavior).
- [x] `bash apps/cla-evidence/scripts/upload-evidence.test.sh` — all 5 pass unchanged.
- [ ] After merge: next `pull_request_target` event surfaces the real S3 ErrorCode in the `Record allowlist-bypass` step log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)