### PR TITLE
fix(cla-evidence): diagnose + repair allowlist-bypass R2 write

### DIFF
--- a/apps/cla-evidence/scripts/r2-conditional-put.sh
+++ b/apps/cla-evidence/scripts/r2-conditional-put.sh
@@ -10,7 +10,10 @@
 #   - 412              → dup-label, exit 0 (idempotent first-writer-wins).
 #   - 5xx / 429        → retry up to 3 with 250ms / 500ms / 1000ms backoff.
 #   - 4xx ≠ 412        → fast-fail (Kieran F5; e.g., 403 from stale token is a
-#                        config bug, not transient).
+#                        config bug, not transient). The R2 response body is
+#                        captured and surfaced in the `::error::` annotation so
+#                        operators read the actual S3 ErrorCode instead of
+#                        bisecting blind.
 #
 # Status classification uses explicit integer comparisons rather than shell
 # globs (`5*` would match "5" or "50"; the prior `case` was ordering-coupled —

--- a/apps/cla-evidence/scripts/r2-conditional-put.sh
+++ b/apps/cla-evidence/scripts/r2-conditional-put.sh
@@ -49,6 +49,27 @@ bucket="${R2_CLA_EVIDENCE_BUCKET:-soleur-cla-evidence}"
 endpoint="${R2_CLA_EVIDENCE_ENDPOINT:?R2_CLA_EVIDENCE_ENDPOINT must be set}"
 url="${endpoint%/}/${bucket}/${key}"
 
+# Credential-shape preflight. R2's S3-compat SigV4 hard-fails with
+# `<Code>InvalidArgument</Code> <Message>Credential access key has length N,
+# should be 32</Message>` when the access key id is not exactly 32 chars.
+# Catching this at the script entry — before the doomed curl — turns a
+# generic 4xx body into an operator-actionable instruction. The most common
+# cause is Doppler `prd_cla` still holding the pre-2026-05-bootstrap
+# bearer-token value (~53 chars) instead of the corrected token-id-as-HMAC
+# derivation (32 chars). Re-running bootstrap.sh with a fresh admin token
+# pushes the corrected creds. See `apps/cla-evidence/infra/bootstrap.sh`
+# header for the 32-char/64-char derivation from the TF outputs.
+access_key="${R2_CLA_EVIDENCE_ACCESS_KEY_ID:?R2_CLA_EVIDENCE_ACCESS_KEY_ID must be set}"
+if [[ "${#access_key}" -ne 32 ]]; then
+  echo "::error::${label}: R2_CLA_EVIDENCE_ACCESS_KEY_ID length=${#access_key}, expected 32. Doppler prd_cla likely holds a Cloudflare API Token (bearer value) instead of an R2 S3-compat access key id. Operator action: re-run \`bash apps/cla-evidence/infra/bootstrap.sh\` with a fresh CF_ADMIN_TOKEN_BOOTSTRAP to push the corrected 32-char access-key-id + 64-char sha256(secret) pair to Doppler." >&2
+  exit 2
+fi
+secret="${R2_CLA_EVIDENCE_SECRET:?R2_CLA_EVIDENCE_SECRET must be set}"
+if [[ "${#secret}" -ne 64 ]]; then
+  echo "::error::${label}: R2_CLA_EVIDENCE_SECRET length=${#secret}, expected 64 (sha256 hex). Same operator action as above — re-run bootstrap.sh." >&2
+  exit 2
+fi
+
 # Response-body capture: R2 returns XML error bodies (<Code>…</Code>) on 4xx/5xx.
 # We pipe them to a tempfile so the failure annotation can echo the real reason
 # (e.g., InvalidRequest vs ObjectLockedRetention vs SignatureDoesNotMatch) rather

--- a/apps/cla-evidence/scripts/upload-bypass.test.sh
+++ b/apps/cla-evidence/scripts/upload-bypass.test.sh
@@ -58,9 +58,11 @@ EOF
 run_sut() {
   local payload="$1"
   : > "$work/urls.txt"
+  # 32-char access key + 64-char secret to satisfy the r2-conditional-put.sh
+  # credential-shape preflight (catches Doppler-still-holds-bearer-token regressions).
   PATH="$work:$PATH" \
-  R2_CLA_EVIDENCE_ACCESS_KEY_ID=stub-key \
-  R2_CLA_EVIDENCE_SECRET=stub-secret \
+  R2_CLA_EVIDENCE_ACCESS_KEY_ID=00000000000000000000000000000000 \
+  R2_CLA_EVIDENCE_SECRET=0000000000000000000000000000000000000000000000000000000000000000 \
   R2_CLA_EVIDENCE_BUCKET=soleur-cla-evidence \
   R2_CLA_EVIDENCE_ENDPOINT=https://example.invalid \
     bash "$SUT" "$payload"
@@ -154,6 +156,26 @@ if [[ "$rc" -ne 0 ]] && grep -q 'ObjectLockConfigurationNotFoundError' <<<"$out"
   green "PASS: Bypass.g 400 → fast-fail annotation includes R2 response body"
 else
   red "FAIL: Bypass.g expected error annotation to include 'ObjectLockConfigurationNotFoundError'"
+  red "$out"
+  fail=1
+fi
+
+# Bypass.h: 53-char bearer-token-shaped access key → preflight fast-fail with
+# operator-actionable bootstrap.sh instruction. Reproduces the 2026-05-16
+# Doppler misconfig that caused every pull_request_target run to fail.
+prime_200
+out=$(
+  PATH="$work:$PATH" \
+  R2_CLA_EVIDENCE_ACCESS_KEY_ID=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA \
+  R2_CLA_EVIDENCE_SECRET=0000000000000000000000000000000000000000000000000000000000000000 \
+  R2_CLA_EVIDENCE_BUCKET=soleur-cla-evidence \
+  R2_CLA_EVIDENCE_ENDPOINT=https://example.invalid \
+    bash "$SUT" "$payload" 2>&1
+) && rc=0 || rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q 'length=53, expected 32' <<<"$out" && grep -q 'bootstrap.sh' <<<"$out"; then
+  green "PASS: Bypass.h 53-char bearer token → preflight fast-fail with bootstrap.sh instruction"
+else
+  red "FAIL: Bypass.h expected preflight error pointing at bootstrap.sh; got rc=$rc"
   red "$out"
   fail=1
 fi

--- a/apps/cla-evidence/scripts/upload-evidence.test.sh
+++ b/apps/cla-evidence/scripts/upload-evidence.test.sh
@@ -40,9 +40,11 @@ EOF
 
 run_sut() {
   local payload="$1"
+  # 32-char access key + 64-char secret to satisfy the r2-conditional-put.sh
+  # credential-shape preflight (catches Doppler-still-holds-bearer-token regressions).
   PATH="$work:$PATH" \
-  R2_CLA_EVIDENCE_ACCESS_KEY_ID=stub-key \
-  R2_CLA_EVIDENCE_SECRET=stub-secret \
+  R2_CLA_EVIDENCE_ACCESS_KEY_ID=00000000000000000000000000000000 \
+  R2_CLA_EVIDENCE_SECRET=0000000000000000000000000000000000000000000000000000000000000000 \
   R2_CLA_EVIDENCE_BUCKET=soleur-cla-evidence \
   R2_CLA_EVIDENCE_ENDPOINT=https://example.invalid \
     bash "$SUT" "$payload"


### PR DESCRIPTION
## Summary

Root cause of every `pull_request_target` `Record allowlist-bypass` failure since the 2026-05-16 bootstrap: Doppler `prd_cla` holds a **Cloudflare API Token** (53-char bearer value) in `R2_CLA_EVIDENCE_ACCESS_KEY_ID` instead of the **R2 S3-compat access key id** (32-char hex). R2's SigV4 surface enforces the 32-char invariant and rejects with:

```
<Code>InvalidArgument</Code>
<Message>Credential access key has length 53, should be 32</Message>
```

The diagnostic body-capture from merged PR #3965 surfaced this directly. The bootstrap script (`apps/cla-evidence/infra/bootstrap.sh`) already contains the correct derivation:

```bash
R2_ACCESS_KEY="$OBJECT_WRITE_TOKEN_ID"
R2_SECRET=$(printf '%s' "$OBJECT_WRITE_TOKEN_VALUE" | openssl dgst -sha256 -hex | awk '{print $NF}')
```

and even asserts both lengths — but Doppler `prd_cla` was last populated by a pre-fix bootstrap revision that pushed the bearer-token value to both halves.

## What this PR changes

- Adds credential-shape preflight to `r2-conditional-put.sh` that fast-fails with an **operator-actionable** error pointing at `bootstrap.sh` when `R2_CLA_EVIDENCE_ACCESS_KEY_ID` is not 32 chars (or secret is not 64 chars).
- Updates test fixtures from `stub-key` / `stub-secret` to synthesized 32/64-char zero-fixtures.
- Adds `Bypass.h` test reproducing the exact 53-char regression to lock the contract.

## What this PR does NOT change

- The actual Doppler secret values. That requires an operator to re-run `bash apps/cla-evidence/infra/bootstrap.sh` with a fresh one-time `CF_ADMIN_TOKEN_BOOTSTRAP`. After that, the workflow goes green on its own.

## Operator action required (single command)

```bash
# Mint a 1-hour CF admin token at https://dash.cloudflare.com/profile/api-tokens
# with scopes: Account → Cloudflare R2 → Edit + User → API Tokens → Edit
CF_ADMIN_TOKEN_BOOTSTRAP=<paste> bash apps/cla-evidence/infra/bootstrap.sh
```

The script self-revokes the admin token at the end.

## Test plan

- [x] `bash apps/cla-evidence/scripts/upload-bypass.test.sh` — all 8 pass (Bypass.h is new).
- [x] `bash apps/cla-evidence/scripts/upload-evidence.test.sh` — all 5 pass with updated 32/64-char fixtures.
- [ ] Workflow run on this PR (with merged PR #3965 diagnostic) shows the preflight emitting the bootstrap.sh pointer instead of `Credential access key has length 53` XML.
- [ ] After operator runs bootstrap.sh, next PR's `cla-evidence` step reports `ok status=200` or `duplicate status=412`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)