### PR TITLE
fix(tenant-jwt): bounded retry on GoTrue 'over_request_rate_limit' 429

### DIFF
--- a/apps/web-platform/lib/supabase/tenant.ts
+++ b/apps/web-platform/lib/supabase/tenant.ts
@@ -134,6 +134,22 @@ const DEFAULT_TTL_SEC = 600;
  */
 export const JWT_AUDIENCE = "soleur-runtime";
 
+/**
+ * `verifyOtp` retry config for GoTrue's `over_request_rate_limit` 429
+ * response. Distinct from the precheck-ceiling `mint_rate_exceeded` raise
+ * (cause:rotation, no retry — the per-founder ceiling won't clear in
+ * seconds) and from generic verifyOtp errors (cause:jwt_mint, no retry —
+ * network/malformed-response symptoms don't get better with backoff).
+ *
+ * Bounded retries smooth transient bursts (concurrent CI runs, prior-hour
+ * residue against the dev project's per-instance ceiling). They do NOT
+ * fix steady-state ceiling exhaustion — see
+ * `knowledge-base/engineering/ops/runbooks/supabase-magiclink-rate-limit.md`
+ * for the operational fix.
+ */
+const DEFAULT_VERIFY_OTP_MAX_RETRIES = 3;
+const DEFAULT_VERIFY_OTP_BASE_DELAY_MS = 500;
+
 function getAnonKey(): string {
   const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   if (!key) {
@@ -280,11 +296,34 @@ export async function mintFounderJwt(
   // `42501 permission denied for function is_jti_denied`. Use a
   // throw-away client for the OTP exchange so the singleton's auth
   // state stays pristine.
+  // Bounded retry on GoTrue's structured `over_request_rate_limit` 429
+  // code only. The precheck-ceiling raise (`mint_rate_exceeded` in
+  // `message`, no `code`) is NOT retried — that's a per-founder ceiling
+  // that won't clear in seconds. Generic errors (network, malformed) are
+  // NOT retried either — backoff doesn't recover them. See retry config
+  // block above + runbook for the steady-state-ceiling caveat.
   const otpClient = createServiceClient();
-  const verified = await otpClient.auth.verifyOtp({
-    token_hash: link.data.properties.hashed_token,
-    type: "email",
-  });
+  const retryConfig = getVerifyOtpRetryConfig();
+  let verified: Awaited<ReturnType<typeof otpClient.auth.verifyOtp>>;
+  for (let attempt = 0; ; attempt++) {
+    verified = await otpClient.auth.verifyOtp({
+      token_hash: link.data.properties.hashed_token,
+      type: "email",
+    });
+    const errCode = (verified.error as { code?: string } | null | undefined)
+      ?.code;
+    if (
+      errCode !== "over_request_rate_limit" ||
+      attempt >= retryConfig.maxRetries
+    ) {
+      break;
+    }
+    // Jittered exponential backoff: base * 2^attempt ± 25%. Random jitter
+    // prevents concurrent callers from re-bursting in lockstep.
+    const baseDelay = retryConfig.baseDelayMs * Math.pow(2, attempt);
+    const jitter = baseDelay * 0.25 * (Math.random() * 2 - 1);
+    await sleepMs(Math.max(0, baseDelay + jitter));
+  }
   if (verified.error || !verified.data?.session?.access_token) {
     const msg = verified.error?.message ?? "";
     // The hook bubbled the precheck ceiling raise (SQLSTATE 45001,
@@ -296,9 +335,9 @@ export async function mintFounderJwt(
         "Authentication unavailable; retry shortly",
       );
     }
-    // GoTrue rate-limit, network failure, malformed response — all
-    // collapse to jwt_mint (distinct from the precheck-ceiling rotation
-    // cause). The catch site logs via mirrorWithDebounce.
+    // GoTrue rate-limit (after retries exhausted), network failure,
+    // malformed response — all collapse to jwt_mint. The catch site logs
+    // via mirrorWithDebounce.
     throw new RuntimeAuthError(
       "jwt_mint",
       "Authentication unavailable; retry shortly",
@@ -403,6 +442,41 @@ export function _setMintFnForTest(
     );
   }
   __mintFnForTest = fn;
+}
+
+/**
+ * Test-only seam — overrides the verifyOtp 429-retry config. Pass `null`
+ * to restore defaults. Tests use a tiny `baseDelayMs` (e.g. 1ms) so the
+ * retry path is exercised without dilating test runtime. Production
+ * callers MUST NOT use this.
+ */
+interface VerifyOtpRetryConfig {
+  maxRetries: number;
+  baseDelayMs: number;
+}
+let __verifyOtpRetryConfigForTest: VerifyOtpRetryConfig | null = null;
+export function _setVerifyOtpRetryConfigForTest(
+  config: VerifyOtpRetryConfig | null,
+): void {
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      "_setVerifyOtpRetryConfigForTest is a test-only seam and must not be called in production",
+    );
+  }
+  __verifyOtpRetryConfigForTest = config;
+}
+
+function getVerifyOtpRetryConfig(): VerifyOtpRetryConfig {
+  return (
+    __verifyOtpRetryConfigForTest ?? {
+      maxRetries: DEFAULT_VERIFY_OTP_MAX_RETRIES,
+      baseDelayMs: DEFAULT_VERIFY_OTP_BASE_DELAY_MS,
+    }
+  );
+}
+
+function sleepMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function callMint(userId: UserId): Promise<MintedJwt> {

--- a/apps/web-platform/test/server/tenant-jwt-asymmetric.test.ts
+++ b/apps/web-platform/test/server/tenant-jwt-asymmetric.test.ts
@@ -55,7 +55,7 @@ const mocks = vi.hoisted(() => {
 
   let nextVerifyOtpResult: {
     data: unknown;
-    error: { message: string } | null;
+    error: { message: string; code?: string } | null;
   } = { data: null, error: null };
 
   let nextAdminGetUserResult: {
@@ -180,6 +180,7 @@ import {
   JWT_AUDIENCE,
   RuntimeAuthError,
   _resetTenantCache,
+  _setVerifyOtpRetryConfigForTest,
 } from "@/lib/supabase/tenant";
 
 const FOUNDER_A = "00000000-0000-0000-0000-00000000aaaa";
@@ -270,6 +271,9 @@ function synthesizeHookInjectedJwt(opts: {
 beforeEach(() => {
   mocks.reset();
   _resetTenantCache();
+  // Reset the verifyOtp retry config so individual tests can override
+  // without leaking state across `it` blocks.
+  _setVerifyOtpRetryConfigForTest(null);
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "test-anon-key";
   // Set adminGetUser default so the mint path can look up the founder email.
   mocks.setAdminGetUserResult({
@@ -472,6 +476,63 @@ describe("mintFounderJwt — asymmetric substrate (Resolution C, #3363)", () => 
       name: "RuntimeAuthError",
       cause: "jwt_mint",
     });
+  });
+
+  // 429 retry — structured `over_request_rate_limit` code triggers
+  // bounded retry-with-backoff. Distinguished from the AC6 message-only
+  // mock above (no `code`) which still throws immediately. See
+  // `lib/supabase/tenant.ts` retry-config block + runbook
+  // `supabase-magiclink-rate-limit.md`.
+  it("retries verifyOtp on error.code='over_request_rate_limit' and exhausts to jwt_mint after maxRetries+1 attempts", async () => {
+    _setVerifyOtpRetryConfigForTest({ maxRetries: 3, baseDelayMs: 1 });
+    mocks.setVerifyOtpResult({
+      data: null,
+      error: {
+        message: "Request rate limit reached",
+        code: "over_request_rate_limit",
+      },
+    });
+
+    await expect(mintFounderJwt(FOUNDER_A)).rejects.toMatchObject({
+      name: "RuntimeAuthError",
+      cause: "jwt_mint",
+    });
+
+    // Initial call + 3 retries = 4 verifyOtp invocations.
+    expect(mocks.verifyOtpCalls).toHaveLength(4);
+  });
+
+  it("does NOT retry verifyOtp when error has no over_request_rate_limit code (network/malformed/etc.)", async () => {
+    _setVerifyOtpRetryConfigForTest({ maxRetries: 3, baseDelayMs: 1 });
+    mocks.setVerifyOtpResult({
+      data: null,
+      error: { message: "network unreachable" },
+    });
+
+    await expect(mintFounderJwt(FOUNDER_A)).rejects.toMatchObject({
+      name: "RuntimeAuthError",
+      cause: "jwt_mint",
+    });
+
+    // No code → no retry → single call.
+    expect(mocks.verifyOtpCalls).toHaveLength(1);
+  });
+
+  it("does NOT retry verifyOtp on precheck-ceiling raise (mint_rate_exceeded in message, no code)", async () => {
+    _setVerifyOtpRetryConfigForTest({ maxRetries: 3, baseDelayMs: 1 });
+    mocks.setVerifyOtpResult({
+      data: null,
+      error: { message: "mint_rate_exceeded" },
+    });
+
+    await expect(mintFounderJwt(FOUNDER_A)).rejects.toMatchObject({
+      name: "RuntimeAuthError",
+      cause: "rotation",
+    });
+
+    // Precheck-ceiling raise resolves immediately to cause:rotation —
+    // no retry budget is spent on the per-founder ceiling.
+    expect(mocks.verifyOtpCalls).toHaveLength(1);
   });
 
   // AC7 / plan §1.1: jti coupling — denied_jti indexes the same value.


### PR DESCRIPTION
## Summary

- Wrap `verifyOtp` in `mintFounderJwt` with bounded retry-with-jittered-exponential-backoff, gated on the structured `code: \"over_request_rate_limit\"` error code.
- Default: 3 retries with 500 / 1000 / 2000 ms ± 25% jitter (≤4s end-to-end on full exhaustion).
- Test-only seam `_setVerifyOtpRetryConfigForTest` (production-guarded, mirrors `_setMintFnForTest`).
- 3 new unit tests covering retry-then-exhaust, no-retry on non-429 errors, no-retry on precheck-ceiling raise.

## Why

Companion PR to #4037 (runbook + mint-once pointer). The operational bump in the runbook addresses steady-state ceiling exhaustion; this PR addresses transient bursts (concurrent CI runs, prior-hour residue) that an operational change alone cannot help with.

Retry is **specifically** gated on the GoTrue structured code, not the message text or HTTP status. This keeps existing behavior for:

- **Precheck-ceiling raise** (\`mint_rate_exceeded\` in message, no code) → still `cause:rotation`, immediate throw. The per-founder ceiling won't clear in seconds.
- **Generic verifyOtp errors** (network, malformed response, etc.) → still `cause:jwt_mint`, immediate throw. Backoff doesn't recover them.
- **Message-only 429 strings** (\`\"rate_limit exceeded (429)\"\`) → still immediate throw. The structured code is the contract; legacy message-only paths stay untouched (preserved by existing AC6 test).

## Test plan

- [x] `npx vitest run test/server/tenant-jwt-asymmetric.test.ts` — 15 tests pass (12 existing + 3 new)
- [x] `npx vitest run test/server/tenant-jwt-refresh.test.ts` — 12 tests pass (no regression in the cache/refresh path)
- [x] `npx tsc --noEmit` — clean
- [ ] CI green on this PR

## Related

- PR #4037 — operational runbook + mint-once pointer (companion)
- PR #4036 — pino bundling fix (separate, also unblocks PR #3984's required check)
- PR #3984 — PR-G cohort onboarding (consumes all three when rebased)

🤖 Generated with [Claude Code](https://claude.com/claude-code)