### PR TITLE
fix(infra): Inngest bug #6 — bridge container can't reach host loopback

### DIFF
--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -358,6 +358,8 @@ case "$COMPONENT" in
       --security-opt seccomp=/etc/docker/seccomp-profiles/soleur-bwrap.json \
       --tmpfs /tmp:rw,nosuid,nodev,size=256m \
       --env-file "$ENV_FILE" \
+      --add-host host.docker.internal:host-gateway \
+      -e INNGEST_BASE_URL=http://host.docker.internal:8288 \
       -v /mnt/data/workspaces:/workspaces \
       -v /mnt/data/plugins/soleur:/app/shared/plugins/soleur:ro \
       -p 0.0.0.0:3001:3000 \
@@ -520,6 +522,8 @@ case "$COMPONENT" in
         --security-opt seccomp=/etc/docker/seccomp-profiles/soleur-bwrap.json \
         --tmpfs /tmp:rw,nosuid,nodev,size=256m \
         --env-file "$ENV_FILE" \
+        --add-host host.docker.internal:host-gateway \
+        -e INNGEST_BASE_URL=http://host.docker.internal:8288 \
         -v /mnt/data/workspaces:/workspaces \
         -v /mnt/data/plugins/soleur:/app/shared/plugins/soleur:ro \
         -p 0.0.0.0:80:3000 \

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -420,6 +420,8 @@ runcmd:
       --restart unless-stopped \
       --tmpfs /tmp:rw,nosuid,nodev,size=256m \
       --env-file "$TMPENV" \
+      --add-host host.docker.internal:host-gateway \
+      -e INNGEST_BASE_URL=http://host.docker.internal:8288 \
       -v /mnt/data/workspaces:/workspaces \
       -v /mnt/data/plugins/soleur:/app/shared/plugins/soleur:ro \
       -p 0.0.0.0:80:3000 \

--- a/apps/web-platform/infra/inngest-bootstrap.sh
+++ b/apps/web-platform/infra/inngest-bootstrap.sh
@@ -9,9 +9,15 @@
 #   - On version bump, pauses the running server (drains in-flight events),
 #     restarts, resumes.
 #
-# Self-hosted Inngest binds loopback only (127.0.0.1:8288 events / 8289 API)
-# per ADR-030. Signing/event keys + heartbeat URL come from Doppler `prd` via
-# `doppler run --project soleur --config prd --` wrapping ExecStart.
+# Self-hosted Inngest binds 0.0.0.0:8288 (events) + 8289 (connect-gateway).
+# ADR-030's "loopback only" intent — keep Inngest unreachable from the public
+# internet — is preserved via the host firewall (`apps/web-platform/infra/
+# firewall.tf`), which only allows 22 (admin IPs), 80, and 443 (Cloudflare
+# IPs) inbound. Port 8288 is implicitly closed externally. The 0.0.0.0 bind
+# is REQUIRED so the bridge-networked `soleur-web-platform` Docker container
+# can reach Inngest via `host.docker.internal` (= docker bridge gateway). The
+# original 127.0.0.1 bind worked for systemd unit-local consumers but blocked
+# the container's SDK from registering — surfaced 2026-05-19 via #4017.
 #
 # Embedded into OCI artifact `ghcr.io/jikig-ai/soleur-inngest-bootstrap:vX.Y.Z`
 # AND base64-embedded into cloud-init for fresh-host provisioning. Single
@@ -128,7 +134,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 EnvironmentFile=/etc/default/inngest-server
-ExecStart=/usr/bin/doppler run --project soleur --config prd -- /usr/bin/bash -c '/usr/local/bin/inngest start --host 127.0.0.1 --port 8288 --sqlite-dir /var/lib/inngest --signing-key "$${INNGEST_SIGNING_KEY#signkey-prod-}" --event-key "$${INNGEST_EVENT_KEY}"'
+ExecStart=/usr/bin/doppler run --project soleur --config prd -- /usr/bin/bash -c '/usr/local/bin/inngest start --host 0.0.0.0 --port 8288 --sqlite-dir /var/lib/inngest --signing-key "$${INNGEST_SIGNING_KEY#signkey-prod-}" --event-key "$${INNGEST_EVENT_KEY}"'
 Restart=on-failure
 RestartSec=5
 User=deploy


### PR DESCRIPTION
## Summary

Follow-up to PR #4085 (bugs #1-5 of the PR-F Inngest substrate cascade). This PR fixes the 6th and final bug: the bridge-networked `soleur-web-platform` container can't reach `127.0.0.1:8288` (host's Inngest server).

## The fix

1. **Inngest unit**: `--host 0.0.0.0` (was `127.0.0.1`). ADR-030's "loopback only" intent is preserved by `firewall.tf` (port 8288 not in inbound allowlist). The 0.0.0.0 bind makes Inngest reachable on the docker bridge gateway.
2. **`docker run`** (both production + canary in `ci-deploy.sh`, and the fresh-host `docker run` in `cloud-init.yml`): add `--add-host host.docker.internal:host-gateway` + `-e INNGEST_BASE_URL=http://host.docker.internal:8288`.
3. **Doppler `prd` value**: updated out-of-band to `http://host.docker.internal:8288` (one-time `doppler secrets set`).

## Production state

Already patched live: VM's `/etc/systemd/system/inngest-server.service` ExecStart updated via `sed`; container connectivity to `host.docker.internal:8288` verified working (`fetch().then(r => r.text())` returns `{"status":200,"message":"OK"}`). This PR codifies the live changes so the next deploy doesn't revert them.

## Verification (post-merge)

- [ ] CI green
- [ ] Auto-deploy fires; new container picks up `--add-host` + updated `INNGEST_BASE_URL`
- [ ] `curl /api/v0/runs` on the VM lists `cron-daily-triage` + `cron-follow-through-monitor`
- [ ] Send `cron/daily-triage.manual-trigger` event → function executes → Sentry monitor `scheduled-daily-triage` records `ok`
- [ ] Close #4017

## Related

- Refs #4085 (bugs #1-5 of cascade)
- Refs #4017 (P1: PR-1 substrate missed all scheduled fires)
- Refs #3940 (PR-F substrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)