### PR TITLE
chore(sentry-iac): rename SENTRY_AUTH_TOKEN → SENTRY_IAC_AUTH_TOKEN

### DIFF
--- a/.github/workflows/apply-sentry-infra.yml
+++ b/.github/workflows/apply-sentry-infra.yml
@@ -15,7 +15,13 @@
 # transient failure or for ad-hoc applies (still scoped to cron monitors).
 #
 # Authentication divergence from apps/web-platform/infra/ root:
-#   - SENTRY_AUTH_TOKEN comes from a GitHub repo secret (NOT Doppler) per
+#   - SENTRY_IAC_AUTH_TOKEN (the GitHub repo secret) is dedicated to this
+#     IaC pipeline. It maps to the Internal Integration `iac-terraform-prd`
+#     on `jikigai-eu` (see ADR-031 §Authentication). The env var passed to
+#     terraform/audit scripts is still named `SENTRY_AUTH_TOKEN` because that
+#     is the canonical env var the Sentry terraform provider and audit
+#     tooling expect.
+#   - SENTRY_IAC_AUTH_TOKEN comes from a GitHub repo secret (NOT Doppler) per
 #     ADR-031 secret-store-divergence.
 #   - R2 backend creds (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY) come from
 #     Doppler `prd_terraform` via `doppler secrets get --plain`.
@@ -98,11 +104,11 @@ jobs:
 
       - name: Verify required secrets present
         env:
-          SENTRY_TOKEN_CHECK: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_TOKEN_CHECK: ${{ secrets.SENTRY_IAC_AUTH_TOKEN }}
           DOPPLER_TOKEN_CHECK: ${{ secrets.DOPPLER_TOKEN }}
         run: |
           if [[ -z "$SENTRY_TOKEN_CHECK" ]]; then
-            echo "::error::SENTRY_AUTH_TOKEN secret is not configured."
+            echo "::error::SENTRY_IAC_AUTH_TOKEN secret is not configured."
             exit 1
           fi
           if [[ -z "$DOPPLER_TOKEN_CHECK" ]]; then
@@ -141,7 +147,7 @@ jobs:
         # operator-triggered apply traverses the 4-gate check. Fail-closed
         # — non-zero exit halts the workflow before any state mutation.
         env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_IAC_AUTH_TOKEN }}
           SENTRY_API_HOST: ${{ secrets.SENTRY_API_HOST }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
@@ -155,7 +161,7 @@ jobs:
         id: plan
         working-directory: ${{ env.INFRA_DIR }}
         env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_IAC_AUTH_TOKEN }}
           HEAD_MSG: ${{ github.event.head_commit.message }}
         run: |
           set -uo pipefail
@@ -201,7 +207,7 @@ jobs:
       - name: Terraform apply (cron monitors only)
         working-directory: ${{ env.INFRA_DIR }}
         env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_IAC_AUTH_TOKEN }}
         run: |
           set -euo pipefail
           terraform apply -auto-approve -input=false tfplan

--- a/knowledge-base/engineering/architecture/decisions/ADR-031-sentry-as-iac.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-031-sentry-as-iac.md
@@ -121,7 +121,12 @@ of S3 conditional writes — same posture as the main root.
 
 Sentry secrets stay in **GitHub repository secrets**, not Doppler:
 
-- `SENTRY_AUTH_TOKEN` — provider auth, used by `terraform plan|apply`.
+- `SENTRY_IAC_AUTH_TOKEN` — provider auth, used by `terraform plan|apply` in
+  `.github/workflows/apply-sentry-infra.yml`. The env var exposed to the
+  terraform provider inside the workflow step is still named `SENTRY_AUTH_TOKEN`
+  (the canonical Sentry provider env var); only the GitHub-secret-name has
+  changed to make the IaC-specific role explicit and to permit independent
+  rotation from the runtime `web-platform-ci` integration.
 - `SENTRY_INGEST_DOMAIN`, `SENTRY_PROJECT_ID`, `SENTRY_PUBLIC_KEY` —
   DSN-derived (see plan Phase 0.8), consumed by the per-workflow check-in
   steps. Not read by Terraform.
@@ -132,13 +137,42 @@ runtime where the workflows execute reduces moving parts. R2 backend creds
 remain in Doppler `prd_terraform` per the existing pattern in
 `scheduled-terraform-drift.yml:54-65`.
 
+**Why a dedicated Internal Integration, not the runtime `web-platform-ci`
+token, and not an Org Auth Token (revised 2026-05-19):**
+
+- The runtime `web-platform-ci` token covers `org:read`, `project:read`,
+  `project:write`, `project:releases`, `org:ci` — wider than read-only but
+  narrower than IaC needs. It lacks `alerts:write` for `sentry_issue_alert`
+  rules, and reusing it for IaC would couple two distinct lifecycles
+  (runtime check-ins + ad-hoc IaC applies) onto a single auth secret,
+  defeating independent rotation.
+- Sentry **Org Auth Tokens** have been narrowed to a single available scope
+  (`org:ci` — source-map upload + release creation + code mappings); they
+  no longer carry sufficient permission for project/alert/monitor
+  resources. Path (c) in the 2026-05-19 triad re-spawn is empirically
+  dead. Falsified at `knowledge-base/legal/audits/2026-05-19-sentry-token-scope-probe-divergence.md`
+  Appendix B.
+- Therefore the IaC token is provisioned as a **dedicated Internal
+  Integration** named `iac-terraform-prd` on `jikigai-eu`, with permission
+  set: Project=Admin, Issue & Event=Read, Organization=Read,
+  Alerts=Read & Write, CI=checked, everything else No Access. This yields
+  `auth.scopes = [alerts:read, alerts:write, event:read, org:read,
+  project:admin, project:read, project:write]` — least-privilege for IaC
+  while keeping `monitor:*` derivable via the `project:write` umbrella.
+- Integration creation logs to the Organization Audit Log
+  (`sentry-app.add`), providing §5(2) evidence of who provisioned the IaC
+  identity — a property Personal Tokens do not have.
+
 ### Local-token source for operator runs
 
 GitHub Actions exposes secret VALUES only inside workflow steps. For local
-execution (Phase 2.1 audit, Phase 5 import), the operator uses a personal
-**Sentry user token** from `https://eu.sentry.io/settings/account/api/auth-tokens/`
-with scope `project:read` + `monitor:read` (audit) and `project:write` (import).
-The token is never persisted to Doppler or committed.
+execution (Phase 2.1 audit, Phase 5 import), the operator can fetch the
+same `SENTRY_IAC_AUTH_TOKEN` value from Doppler `soleur/prd` (where it is
+mirrored for runtime introspection convenience), or mint a separate
+personal token from
+`https://jikigai-eu.sentry.io/settings/account/api/auth-tokens/` with
+scope `project:read` + `monitor:read` (audit) and `project:write`
+(import). Operator-personal tokens are never committed.
 
 ### DE region support
 


### PR DESCRIPTION
## Summary

- Renames `secrets.SENTRY_AUTH_TOKEN` → `secrets.SENTRY_IAC_AUTH_TOKEN` in `.github/workflows/apply-sentry-infra.yml` (3 env refs + 1 verify-check + 1 error message + 3 comment lines). The env var exposed to terraform/audit scripts stays `SENTRY_AUTH_TOKEN` (Sentry's canonical name); only the secret name on the right side of `${{ secrets.X }}` changes.
- ADR-031 §Authentication updated to document the new dedicated Internal Integration `iac-terraform-prd` on `jikigai-eu`, why we chose it over reusing `web-platform-ci` and over an Org Auth Token (the latter now narrowed by Sentry to `org:ci` only — falsified at divergence-note Appendix B).
- GitHub repo secret `SENTRY_IAC_AUTH_TOKEN` already populated (set via Doppler `soleur/prd` pipe on `2026-05-19T19:50:38Z`). The old `SENTRY_AUTH_TOKEN` is left in place during transition — a follow-up will remove it once `apply-sentry-infra.yml` runs cleanly with the new name.

## What this unblocks

#3849 AC14–AC16. The next `workflow_dispatch` run of `apply-sentry-infra.yml` should:
- Create the 8 `sentry_cron_monitor` resources on first apply (AC14).
- Allow `terraform import` of the 4 `sentry_issue_alert` rules (AC13's last leg).
- Make `reusable-release.yml`'s `sentry-monitors-audit.sh` step exit 0 instead of the chronic `::warning::` (AC16).
- AC15 (check-in receipts) follows naturally once monitors exist + 48h of wall-clock pass.

## Provenance

- Integration `iac-terraform-prd-814bdd` minted via UI form + API token-mint (the latter as a workaround for Playwright-MCP context-death across the multi-step modal flow). Mint chronicle + leak post-mortem in PR jikig-ai/soleur#TODO (pr1b branch).
- Token verified: `GET /api/0/` → 200; `user.email = iac-terraform-prd-814bdd-...@proxy-user.sentry.io`; `auth.scopes = [alerts:read, alerts:write, event:read, org:read, project:admin, project:read, project:write]`.
- Audit-log §5(2) evidence: `sentry-app.add` by `jean.deruelle@jikigai.com` at `2026-05-19T19:08:06.848644Z` in jikigai-eu audit log.

## Test plan

- [ ] Reviewer dry-checks the workflow diff — env vars inside `run:` blocks remain `SENTRY_AUTH_TOKEN` (provider expects this), only the secret reference changes.
- [ ] Operator manually triggers `apply-sentry-infra.yml` post-merge with `reason="AC14 unblock: SENTRY_IAC_AUTH_TOKEN cutover"` and approves the `sentry-infra-apply` env gate.
- [ ] Confirm the workflow's `Verify required secrets present` step does not fail with "SENTRY_IAC_AUTH_TOKEN secret is not configured" (secret was set on `2026-05-19T19:50:38Z` so it should be there).
- [ ] Confirm `terraform plan` reports the 8 cron monitors as new + 0 destroy + run completes.
- [ ] After ≥48h, check-in receipts query against the 8 monitors per #3859.

Refs #3849.
Refs #3861.

🤖 Generated with [Claude Code](https://claude.com/claude-code)