### PR TITLE
fix(inngest): resolveClaudeBin webpack-broken in standalone bundle (bug #7)

### DIFF
--- a/apps/web-platform/server/inngest/functions/cron-daily-triage.ts
+++ b/apps/web-platform/server/inngest/functions/cron-daily-triage.ts
@@ -35,8 +35,8 @@
 // (deleted in the same commit).
 
 import { spawn } from "node:child_process";
-import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { inngest } from "@/server/inngest/client";
 import { reportSilentFallback } from "@/server/observability";
 
@@ -45,17 +45,37 @@ import { reportSilentFallback } from "@/server/observability";
 // at spawn time → reportSilentFallback → Sentry status=error, instead of
 // throwing at /api/inngest route registration which would silently disable
 // the entire Inngest worker with no operator-visible Sentry signal.
-// createRequire is the only ESM-friendly resolution shape that does not
-// depend on process.cwd() or PATH. The package's `bin` entry maps "claude"
-// → "bin/claude.exe" inside the package dir; node's npm-bin layout puts it
-// at node_modules/.bin/claude (a symlink that re-runs the platform-native
-// postinstall'd binary).
+//
+// The `claude` binary lives at `node_modules/.bin/claude` (npm bin shim →
+// `@anthropic-ai/claude-code/bin/claude.exe`). The original implementation
+// used `createRequire(import.meta.url) + require.resolve(...)` which works
+// in dev mode but produces `TypeError: path argument must be of type string
+// (received number 32798)` in the Next.js standalone bundle — webpack
+// statically replaces `require.resolve()` calls with module-id integers
+// (#4017 substrate audit, 2026-05-19). Switched to filesystem checks against
+// the two known install paths instead; webpack can't see these strings, so
+// they pass through verbatim. The CLAUDE_BIN env var is the override hatch
+// for fresh-host bootstraps that put the binary outside node_modules.
 function resolveClaudeBin(): string {
-  const require_ = createRequire(import.meta.url);
-  const pkgDir = dirname(
-    require_.resolve("@anthropic-ai/claude-code/package.json"),
+  const override = process.env.CLAUDE_BIN;
+  if (override && existsSync(override)) return override;
+
+  // Standalone Next.js bundle layout: /app/node_modules/.bin/claude.
+  // Dev/test layout: <repo>/apps/web-platform/node_modules/.bin/claude.
+  // The bin symlink is the canonical entry — npm regenerates it on every
+  // install, so it survives package version bumps.
+  const candidates = [
+    "/app/node_modules/.bin/claude",
+    join(process.cwd(), "node_modules/.bin/claude"),
+    join(process.cwd(), "apps/web-platform/node_modules/.bin/claude"),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  throw new Error(
+    `claude binary not found in any known location: ${candidates.join(", ")}. ` +
+      "Set CLAUDE_BIN env var to override.",
   );
-  return join(pkgDir, "..", "..", ".bin", "claude");
 }
 
 // Inlined verbatim from .github/workflows/scheduled-daily-triage.yml lines

--- a/apps/web-platform/server/inngest/functions/cron-follow-through-monitor.ts
+++ b/apps/web-platform/server/inngest/functions/cron-follow-through-monitor.ts
@@ -69,8 +69,8 @@
 // See ADR-033 [Refined 2026-05-19 post PR-2 plan review] for details.
 
 import { spawn } from "node:child_process";
-import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { inngest } from "@/server/inngest/client";
 import { reportSilentFallback } from "@/server/observability";
 
@@ -79,12 +79,28 @@ import { reportSilentFallback } from "@/server/observability";
 // at spawn time → reportSilentFallback → Sentry status=error, instead of
 // throwing at /api/inngest route registration which would silently disable
 // the entire Inngest worker with no operator-visible Sentry signal.
+//
+// IMPLEMENTATION NOTE (#4017): the original `createRequire(import.meta.url)
+// + require.resolve(...)` shape works in dev but produces `TypeError: path
+// argument must be of type string (received number 32798)` in the Next.js
+// standalone bundle — webpack rewrites `require.resolve()` to module-id
+// integers. Use filesystem `existsSync` checks against known paths instead.
 function resolveClaudeBin(): string {
-  const require_ = createRequire(import.meta.url);
-  const pkgDir = dirname(
-    require_.resolve("@anthropic-ai/claude-code/package.json"),
+  const override = process.env.CLAUDE_BIN;
+  if (override && existsSync(override)) return override;
+
+  const candidates = [
+    "/app/node_modules/.bin/claude",
+    join(process.cwd(), "node_modules/.bin/claude"),
+    join(process.cwd(), "apps/web-platform/node_modules/.bin/claude"),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  throw new Error(
+    `claude binary not found in any known location: ${candidates.join(", ")}. ` +
+      "Set CLAUDE_BIN env var to override.",
   );
-  return join(pkgDir, "..", "..", ".bin", "claude");
 }
 
 // Inlined verbatim from .github/workflows/scheduled-follow-through.yml lines


### PR DESCRIPTION
## Summary

7th and final bug in the PR-F substrate cascade. After PR #4085 (bugs 1-5) and PR #4093 (bug 6) fixed all the wiring, function runs themselves still failed within ~30s:

```
TypeError: The "path" argument must be of type string. Received type number (32798)
  at dirname (node:path:1457:5)
  at <bundled route>:60:371
```

Root cause: `createRequire(import.meta.url)` + `require_.resolve("@anthropic-ai/claude-code/package.json")` works in dev (raw ESM) but the Next.js standalone bundle's webpack step statically rewrites `require.resolve()` calls into **module-id integers** (32798 in this case). Then `path.dirname(32798)` throws.

## Fix

Replace dynamic resolve with `existsSync()` checks against three known install paths plus a `CLAUDE_BIN` env override. Webpack can't see these literal strings during static analysis, so they pass through verbatim.

Applied to BOTH `cron-daily-triage.ts` and `cron-follow-through-monitor.ts`.

## Verification

- [x] CI: existing 10 cron-*.test.ts tests pass unchanged (mock spawn factory doesn't care about the bin path)
- [x] typecheck clean
- [ ] Post-merge: container redeploys, send manual-trigger, function executes claude-eval to completion, Sentry monitor records `ok`

## Related

- Closes the #4017 substrate cascade (bug 7/7)
- Refs #3985 (TR9 PR-1 — introduced the broken `resolveClaudeBin`)
- Refs #4062 (TR9 PR-2 — copied it verbatim)
- Refs #4085 (substrate bugs #1-5)
- Refs #4093 (substrate bug #6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)