### PR TITLE
chore(sentry-iac): rename remaining secrets.SENTRY_AUTH_TOKEN refs → SENTRY_IAC_AUTH_TOKEN

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -318,7 +318,7 @@ jobs:
         if: steps.create_release.outputs.released == 'true'
         continue-on-error: true
         env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_IAC_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           # Branch-C correction (2026-05-17): default is now the org-subdomain,
@@ -536,7 +536,7 @@ jobs:
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
             NEXT_PUBLIC_GITHUB_APP_SLUG=${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
             NEXT_PUBLIC_VAPID_PUBLIC_KEY=${{ secrets.NEXT_PUBLIC_VAPID_PUBLIC_KEY }}
-            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_IAC_AUTH_TOKEN }}
             SENTRY_ORG=${{ secrets.SENTRY_ORG }}
             SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}
             BUILD_VERSION=${{ steps.version.outputs.next }}

--- a/.github/workflows/scheduled-followthrough-sweeper.yml
+++ b/.github/workflows/scheduled-followthrough-sweeper.yml
@@ -59,7 +59,7 @@ jobs:
           # Secrets that one or more verification scripts may declare via
           # the `secrets=` directive clause. Add new ones here when a new
           # follow-through ships needing them.
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_IAC_AUTH_TOKEN }}
         run: |
           set -euo pipefail
           bash scripts/sweep-followthroughs.sh

--- a/.github/workflows/sentry-audit-gate.yml
+++ b/.github/workflows/sentry-audit-gate.yml
@@ -39,7 +39,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     env:
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_IAC_AUTH_TOKEN }}
       # Kieran P0-1 fail-loud: require SENTRY_API_HOST to be set explicitly.
       # No fallback default — `eu.sentry.io` would silently 401 for slugs
       # ending in `-eu` per the slug-rewrite finding (learning


### PR DESCRIPTION
## Summary

Follow-up to #4101 — that PR only updated `apply-sentry-infra.yml`. Three other workflows still consumed `secrets.SENTRY_AUTH_TOKEN`:

- `reusable-release.yml` (2 refs — release artifact source-map upload + Docker build args)
- `sentry-audit-gate.yml` (audit gate)
- `scheduled-followthrough-sweeper.yml` (follow-through verification env)

Env var inside `run:` blocks stays `SENTRY_AUTH_TOKEN` (Sentry's canonical env var that terraform-provider-sentry, sentry-cli, and the audit scripts expect); only the secret name on the right side of `${{ secrets.X }}` changes.

## After this merges

The legacy `SENTRY_AUTH_TOKEN` GitHub secret will have zero consumers and can be deleted (follow-up cleanup task in the #3849 thread).

## Scope-equivalence check

The new `SENTRY_IAC_AUTH_TOKEN` (set 2026-05-19T19:50:38Z) holds the `iac-terraform-prd-814bdd` Internal Integration token, with strictly equal-or-greater scopes:

| Scope | Old `SENTRY_AUTH_TOKEN` (Personal Token 2026-05-15) | New `SENTRY_IAC_AUTH_TOKEN` (Internal Integration) |
|---|---|---|
| `alerts:read` | ✓ | ✓ |
| `alerts:write` | ✓ | ✓ |
| `org:read` | ✓ | ✓ |
| `project:read` | ✓ | ✓ |
| `project:write` | ✓ | ✓ |
| `project:admin` | ✗ | ✓ (new — needed for `monitor:*` derivation per ADR-031) |
| `event:read` | ✗ | ✓ (new — needed for audit-script region probe) |

No scope regressions; the migration is safe across all four call sites.

## Test plan

- [ ] Reviewer confirms the diff is mechanical (4 lines, secret-name only).
- [ ] After merge, observe next `reusable-release.yml` run — confirm release source-map upload succeeds.
- [ ] After merge, observe next `scheduled-followthrough-sweeper.yml` cron — confirm Sentry follow-through scripts succeed.
- [ ] Once both ↑ are green, `gh secret delete SENTRY_AUTH_TOKEN --repo jikig-ai/soleur`.

Refs #3849.

🤖 Generated with [Claude Code](https://claude.com/claude-code)