### PR TITLE
chore(sentry-iac): add scheduled_follow_through to apply-sentry-infra -target list

### DIFF
--- a/.github/workflows/apply-sentry-infra.yml
+++ b/.github/workflows/apply-sentry-infra.yml
@@ -175,6 +175,7 @@ jobs:
             -target=sentry_cron_monitor.scheduled_content_vendor_drift \
             -target=sentry_cron_monitor.scheduled_community_monitor \
             -target=sentry_cron_monitor.scheduled_gh_pages_cert_state \
+            -target=sentry_cron_monitor.scheduled_follow_through \
             -no-color -input=false -out=tfplan
           rc=$?
           if [[ $rc -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Adds the missing `-target=sentry_cron_monitor.scheduled_follow_through \` line to the workflow's `terraform plan` invocation. The monitor was introduced in PR #4062 (TR9 PR-2 — migrate scheduled-follow-through to Inngest cron) and was applied out-of-band today (`2026-05-19T20:25:44Z`, via local `terraform apply -target=...`).

## Why

Without this PR, future push-to-main runs that touch `cron-monitors.tf` would not reconcile drift on this monitor — the workflow's explicit `-target` list excluded it, so terraform would skip it during plan/apply. The other 9 cron monitors stay listed; this is purely additive.

## Verification

- Monitor already active in Sentry: `GET /api/0/organizations/jikigai-eu/monitors/scheduled-follow-through/` → 200, `status=active`, `schedule="0 9 * * 1-5"`, `max_runtime=15`.
- Local `terraform plan -target=sentry_cron_monitor.scheduled_follow_through` shows 0 changes (state matches reality).

## Test plan

- [ ] Reviewer confirms diff is one line, additive.
- [ ] After merge, next push-triggered run of `apply-sentry-infra.yml` includes scheduled_follow_through in the plan/apply (visible in the workflow logs).

Refs #3849.
Refs #4062.

🤖 Generated with [Claude Code](https://claude.com/claude-code)