### PR TITLE
fix(inngest): add -- separator before claude prompt (bug #8/8)

### DIFF
--- a/apps/web-platform/server/inngest/functions/cron-daily-triage.ts
+++ b/apps/web-platform/server/inngest/functions/cron-daily-triage.ts
@@ -153,12 +153,21 @@ DOMAIN (pick one — aligned with Soleur department leaders):
 // arbitrary shell — the agent is mechanically constrained to its triage
 // role. Syntax: `Bash(<cmd-prefix>:*)` per claude-code's per-Bash-command
 // allowlist (sibling-convention in .claude/settings.json).
+// The trailing `--` is load-bearing: claude 2.x's CLI declares
+// `--allowedTools <tools...>` as VARIADIC, so without an explicit end-of-
+// options marker it consumes ALL subsequent positional args as additional
+// tool names — including the prompt. Result: `Error: Input must be
+// provided either through stdin or as a prompt argument when using
+// --print` and exitCode=1 in ~1.5s. Surfaced 2026-05-19 via #4017
+// substrate audit (bug 8/8). The `--` MUST be the last flag-array entry;
+// the spawn argv is `[...CLAUDE_CODE_FLAGS, DAILY_TRIAGE_PROMPT]`.
 const CLAUDE_CODE_FLAGS = [
   "--print",
   "--model", "claude-sonnet-4-6",
   "--max-turns", "80",
   "--allowedTools",
   "Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Read,Glob,Grep",
+  "--",
 ];
 
 // 60 min — matches old GHA timeout; preserves 0.75 min/turn peer ratio for

--- a/apps/web-platform/server/inngest/functions/cron-follow-through-monitor.ts
+++ b/apps/web-platform/server/inngest/functions/cron-follow-through-monitor.ts
@@ -239,12 +239,16 @@ predicates and SLA status.
 // constrained to its monitor role. Network verbs (`curl`, `dig`) widen
 // the surface vs PR-1; the in-prompt HTTPS-and-non-RFC1918 guard at step
 // 3c above is the load-bearing SSRF mitigation (Layer 1 of dual defense).
+// The trailing `--` is load-bearing — see cron-daily-triage.ts:CLAUDE_CODE_FLAGS
+// for the explanation. claude 2.x's --allowedTools is variadic and consumes
+// the prompt as a tool name without the end-of-options marker. #4017 bug 8/8.
 const CLAUDE_CODE_FLAGS = [
   "--print",
   "--model", "claude-sonnet-4-6",
   "--max-turns", "30",
   "--allowedTools",
   "Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh issue close:*),Bash(gh label create:*),Bash(curl:*),Bash(dig:*),Read,Glob,Grep",
+  "--",
 ];
 
 // 15 min — see file-header MAX_TURN_DURATION_MS rationale. Exported for

--- a/apps/web-platform/test/server/inngest/cron-daily-triage.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-daily-triage.test.ts
@@ -118,6 +118,15 @@ describe("cron-daily-triage — T1 happy path", () => {
     expect(result.exitCode).toBe(0);
     expect(result.abortedByTimeout).toBe(false);
 
+    // Regression guard for #4017 bug 8/8: --allowedTools is variadic in
+    // claude 2.x and consumes the prompt as a tool name without the `--`
+    // end-of-options marker. The spawn argv MUST contain `--` IMMEDIATELY
+    // BEFORE the prompt (the last argument).
+    const spawnArgs = spawnSpy.mock.calls[0][1] as string[];
+    const lastIdx = spawnArgs.length - 1;
+    expect(spawnArgs[lastIdx - 1]).toBe("--");
+    expect(spawnArgs[lastIdx]).toMatch(/triage/i); // prompt body sanity check
+
     const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const url = fetchMock.mock.calls[0][0] as string;

--- a/apps/web-platform/test/server/inngest/cron-follow-through-monitor.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-follow-through-monitor.test.ts
@@ -150,6 +150,14 @@ describe("cron-follow-through-monitor — T1 happy path", () => {
     expect(result.exitCode).toBe(0);
     expect(result.abortedByTimeout).toBe(false);
 
+    // Regression guard for #4017 bug 8/8: --allowedTools is variadic in
+    // claude 2.x; without `--` end-of-options marker the prompt is parsed
+    // as another tool name and claude errors `Input must be provided`.
+    const claudeArgs = claudeCalls[0][1] as string[];
+    const lastIdx = claudeArgs.length - 1;
+    expect(claudeArgs[lastIdx - 1]).toBe("--");
+    expect(claudeArgs[lastIdx]).toMatch(/follow-through/i); // prompt sanity check
+
     const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const url = fetchMock.mock.calls[0][0] as string;


### PR DESCRIPTION
## Summary

8th and final bug in the PR-F substrate cascade. Surfaced post-bug-#7 fix (#4104), when the function finally executed end-to-end but `claude` exited 1 in ~1.5s.

## Root cause

claude 2.x CLI declares `--allowedTools <tools...>` as **variadic**. Without an explicit `--` end-of-options marker, claude consumes ALL following positional args as tool names — including the prompt. Result:

```
Error: Input must be provided either through stdin or as a prompt argument when using --print
```

And exitCode=1 in ~1.5s — which is exactly what produced the `status: error` Sentry check-in at `2026-05-19T20:43:08Z`.

## Fix

Add `--` as the final element of `CLAUDE_CODE_FLAGS` in both cron-daily-triage.ts and cron-follow-through-monitor.ts. With `--` present, claude treats it as end-of-options and the next positional arg becomes the prompt.

Tested live against `/app/node_modules/.bin/claude` in the production container — the `--` form returns the expected output; the no-`--` form errors.

## Regression guards

Both T1 happy-path tests now assert:
- `spawnArgs[length-2] === "--"`
- `spawnArgs[length-1]` matches the prompt body sanity check

Catches accidental flag-array reordering or `--` removal.

## Related

- Closes the #4017 substrate cascade (bug 8/8)
- Refs #3985 (TR9 PR-1 — introduced the broken flag set)
- Refs #4062 (TR9 PR-2 — copied it verbatim)
- Refs #4085 (substrate bugs 1-5)
- Refs #4093 (substrate bug 6)
- Refs #4104 (substrate bug 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)