### PR TITLE
fix(infra): pin integrations/github provider in web-platform lockfile

### DIFF
--- a/apps/web-platform/infra/.terraform.lock.hcl
+++ b/apps/web-platform/infra/.terraform.lock.hcl
@@ -112,3 +112,25 @@ provider "registry.terraform.io/hetznercloud/hcloud" {
     "zh:f9c3fb21c9f64e82841811e7ef51e3a102c1af801153a670bffd005d89476f0e",
   ]
 }
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.12.1"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:bGz4LIep/7PVrqy6P8cTYbAJpdxXGrupUJjkCczlzIs=",
+    "zh:3e1a4081ecb9518fdf0074db83c16ad00dc81ffe8249a6e3cf1894e947e28df6",
+    "zh:4cb8224b7f530795b674ac044675f6b22a7c9154f55eb9f76c5af6c7534056a4",
+    "zh:560bc08637926191f6871a89e986022ca67c70afda5bebca34b5216e6fac69c9",
+    "zh:5a70b5d2ac650c5c9819a1875411ebda229d0fcc6c9f57f9d751852ca3cd77ac",
+    "zh:8668d93bd4dc2ffa2545e1473af600a925d479b16033a71a4498a16f3b683c0c",
+    "zh:86eacc6059fd057948e178b665ba5cce74bd5488a9e1035734e60ff5ef1b6f8f",
+    "zh:a329fac98881d8dfc211a9bdc0ec6f2948f0b0c2704d1b6cbe5307403c7ad1b2",
+    "zh:dadd44abab3c52b9d572955afaef1658790e17ea355ee22b58996d81d28e02d8",
+    "zh:de9f455ef342cc38fb76bce844bfcd376fb81a4b9f9bc2fae023ff99efdf1338",
+    "zh:f8c6d2e8351b334491790358574e0a30a7c6d7f5b80f7daf32a7c0f3e9b1ab19",
+    "zh:fab41971a3edee04ab6eceaeab4eeb9a2b2f38a2af3b06eda93e2117b64994be",
+    "zh:fb1279b566dd9c8c117b2e4e0cc8344413b8fc8f2a3e24be22a9b2610551777b",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+    "zh:fe79d2a861fb9af420fa5bd7f02c031b2a0a3edf5dbc46022c8ecc7a33cf2b6d",
+  ]
+}


### PR DESCRIPTION
## Summary

- Pins `integrations/github` v6.12.1 in `apps/web-platform/infra/.terraform.lock.hcl`.
- Resolves the `apply-web-platform-infra.yml` first-run failure where `terraform init -lockfile=readonly` (from PR #4122) rejected the unrecorded provider.
- The provider was transitively pulled in by PR #4066's `kb-drift.tf` (`github_actions_secret.doppler_token_kb_drift`) without a corresponding `terraform init -upgrade` to update the lockfile.

## How the lockfile was regenerated

```bash
cd apps/web-platform/infra
doppler run -p soleur -c prd_terraform --name-transformer tf-var -- \
  terraform init -upgrade -backend=false
```

`-backend=false` was used to skip S3 backend init (which requires AWS SSO refresh and is unrelated to provider/lockfile state). Provider download and lockfile recording are independent of backend configuration.

## Diff scope

```
apps/web-platform/infra/.terraform.lock.hcl | 22 ++++++++++++++++++++++
1 file changed, 22 insertions(+)
```

Pure additive — new `provider "registry.terraform.io/integrations/github"` block with `version = "6.12.1"`, `constraints = "~> 6.0"`, and 13 zh: hashes + h1: hash. No existing provider blocks touched.

## User-Brand Impact

- **Brand-survival threshold:** `none` — lockfile-only diff with no production-state semantics.
- threshold: none, reason: provider hashes are cryptographically verified by terraform on every init; this PR unblocks the `apply-web-platform-infra.yml` CI workflow (gated on `-lockfile=readonly`) but introduces zero behavioral change to running infrastructure. No user-owned resource is touched; no credentials, auth flow, or data path is altered. The next workflow run is the load-bearing verification — a fresh `terraform plan` will surface any provider-resolution drift before any `apply` runs.

## Verification

- [x] `terraform init -upgrade -backend=false` exits 0
- [x] `grep -c 'integrations/github' apps/web-platform/infra/.terraform.lock.hcl` returns 1
- [x] Net +22 lines, no other lockfile providers altered

## Out of scope (follow-up)

The issue body notes that Phase 4 of the original rollout (creating the `web-platform-infra-apply` GitHub environment with @deruelle as required reviewer) is operator-only and must happen before end-to-end apply can succeed. Track separately.

## Changelog

### Fixed

- `apps/web-platform/infra/.terraform.lock.hcl` now pins `integrations/github` v6.12.1, unblocking `apply-web-platform-infra.yml`.

## Test plan

- [x] Manual: `terraform init -upgrade -backend=false` succeeded locally with `doppler run -p soleur -c prd_terraform`
- [ ] Re-run `apply-web-platform-infra.yml` via `workflow_dispatch` after merge and confirm `Terraform init` exits 0

Closes #4134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
