### PR TITLE
fix(infra): include github-app-manifest.json in Docker context (#4115 hotfix)

### DIFF
--- a/apps/web-platform/.dockerignore
+++ b/apps/web-platform/.dockerignore
@@ -3,6 +3,14 @@ node_modules
 
 # Terraform configs, not needed at runtime
 infra/
+# Re-include the GitHub App manifest (#4115) — page.tsx at
+# /internal/github-app-init statically imports it at build time via
+# `import manifest from "@/infra/github-app-manifest.json"`. The drift-guard
+# cron is the runtime source of truth for divergence; the build-time inline
+# guarantees the page always renders the committed manifest, not a runtime
+# FS read. Excluding the JSON file shrinks the build context by 28 lines —
+# leaving it in is harmless to the runtime image.
+!infra/github-app-manifest.json
 scripts/
 # Allow the post-build dev-signin grep gate (R3 / feat-dev-signin-bypass).
 # The Dockerfile builder stage runs `bash scripts/assert-dev-signin-eliminated.sh`


### PR DESCRIPTION
## Summary

Hotfix for PR #4121 (#4115). Production Docker build has been failing since #4121 merged: webpack cannot resolve `@/infra/github-app-manifest.json` from `app/internal/github-app-init/page.tsx` because `.dockerignore` excludes `infra/`. Re-include only the single manifest JSON file via `!infra/github-app-manifest.json`.

Web Platform Release run failed at 13:20 UTC; production has been running stale code since. This hotfix restores deploys.

Ref #4115

## User-Brand Impact

- **Artifact:** Production deployment of every Soleur change merged after #4121 (until this hotfix lands)
- **Vector:** Silent outage — Web Platform Release fails at Docker build, so new commits to main don't roll out
- **Brand-survival threshold:** `single-user incident`

## Changelog

- `apps/web-platform/.dockerignore`: re-include `!infra/github-app-manifest.json` so the static import in the init page resolves at build time

## Test plan

- [x] `git diff` confirms 8-line addition, no other changes
- [ ] ⏳ Verify post-merge Web Platform Release run succeeds (Docker build + push to GHCR + deploy probe pass)

Generated with [Claude Code](https://claude.com/claude-code)
