### PR TITLE
fix(csp): allow form-action POST to github.com from /internal/github-app-init

### DIFF
--- a/apps/web-platform/lib/csp.ts
+++ b/apps/web-platform/lib/csp.ts
@@ -20,14 +20,42 @@ function parseSupabaseScheme(url: string): "http" | "https" {
   }
 }
 
+// Whitelist of origins that may be added to `form-action` via the
+// `formActionExtra` option. The committed manifest-POST flow
+// (`/internal/github-app-init`) requires `https://github.com` so the
+// operator can submit the manifest to GitHub's App-create form. Adding
+// other origins requires a whitelist update + reviewer scrutiny — every
+// extra origin widens the cross-origin form-POST surface and undoes the
+// default-deny posture of `form-action 'self'`.
+const FORM_ACTION_ALLOWLIST = new Set(["https://github.com"]);
+
+function buildFormAction(extras: string[] | undefined): string {
+  if (!extras || extras.length === 0) return "form-action 'self'";
+  const uniq = Array.from(new Set(extras));
+  for (const origin of uniq) {
+    if (!FORM_ACTION_ALLOWLIST.has(origin)) {
+      throw new Error(
+        `form-action override '${origin}' is not in the allowlist. ` +
+          `Add to FORM_ACTION_ALLOWLIST in apps/web-platform/lib/csp.ts ` +
+          `with a code-comment rationale before using.`,
+      );
+    }
+  }
+  return `form-action 'self' ${uniq.join(" ")}`;
+}
+
 export function buildCspHeader(options: {
   nonce: string;
   isDev: boolean;
   supabaseUrl: string;
   appHost: string;
   sentryReportUri?: string;
+  // Per-route additions to `form-action`. Each entry must be in
+  // FORM_ACTION_ALLOWLIST; unknown entries throw at build time so a typo
+  // or attacker-controlled value cannot silently widen CSP.
+  formActionExtra?: string[];
 }): string {
-  const { nonce, isDev, supabaseUrl, appHost, sentryReportUri } = options;
+  const { nonce, isDev, supabaseUrl, appHost, sentryReportUri, formActionExtra } = options;
   const supabaseHost = parseSupabaseHost(supabaseUrl);
   const supabaseScheme = parseSupabaseScheme(supabaseUrl);
   const supabaseWsScheme = supabaseScheme === "http" ? "ws" : "wss";
@@ -73,7 +101,7 @@ export function buildCspHeader(options: {
     "frame-src 'none'",
     "worker-src 'self' blob:", // blob: required by pdfjs-dist Web Worker (react-pdf)
     "base-uri 'self'",
-    "form-action 'self'",
+    buildFormAction(formActionExtra),
     "frame-ancestors 'none'",
     "upgrade-insecure-requests",
     ...(sentryReportUri ? [`report-uri ${sentryReportUri}`] : []),

--- a/apps/web-platform/middleware.ts
+++ b/apps/web-platform/middleware.ts
@@ -33,12 +33,22 @@ export async function middleware(request: NextRequest) {
     request.headers.get("host"),
   );
   const appHost = new URL(origin).host;
+  // `/internal/github-app-init` POSTs the committed manifest JSON to
+  // GitHub's App-create form (https://github.com/settings/apps/new) per
+  // the manifest-flow design in #4115. Default `form-action 'self'`
+  // CSP-blocks the POST. Narrow per-route extension keeps the
+  // default-deny posture for every other route.
+  const formActionExtra =
+    pathname === "/internal/github-app-init"
+      ? ["https://github.com"]
+      : undefined;
   const cspValue = buildCspHeader({
     nonce,
     isDev: process.env.NODE_ENV === "development",
     supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
     appHost,
     sentryReportUri: process.env.SENTRY_CSP_REPORT_URI,
+    formActionExtra,
   });
 
   // Set nonce and CSP on request headers for Next.js SSR nonce extraction.

--- a/apps/web-platform/test/csp.test.ts
+++ b/apps/web-platform/test/csp.test.ts
@@ -186,4 +186,81 @@ describe("buildCspHeader", () => {
       expect(prodCsp).toContain(directive);
     }
   });
+
+  describe("form-action override", () => {
+    test("defaults to 'self' when formActionExtra is not provided", () => {
+      const formAction = parseCspDirective(prodCsp, "form-action");
+      expect(formAction).toBe("'self'");
+    });
+
+    test("defaults to 'self' when formActionExtra is empty array", () => {
+      const csp = buildCspHeader({
+        nonce: TEST_NONCE,
+        isDev: false,
+        supabaseUrl: "https://abc.supabase.co",
+        appHost: "app.soleur.ai",
+        formActionExtra: [],
+      });
+      expect(parseCspDirective(csp, "form-action")).toBe("'self'");
+    });
+
+    test("extends form-action with whitelisted github.com origin", () => {
+      const csp = buildCspHeader({
+        nonce: TEST_NONCE,
+        isDev: false,
+        supabaseUrl: "https://abc.supabase.co",
+        appHost: "app.soleur.ai",
+        formActionExtra: ["https://github.com"],
+      });
+      expect(parseCspDirective(csp, "form-action")).toBe(
+        "'self' https://github.com",
+      );
+    });
+
+    test("deduplicates repeated origins in formActionExtra", () => {
+      const csp = buildCspHeader({
+        nonce: TEST_NONCE,
+        isDev: false,
+        supabaseUrl: "https://abc.supabase.co",
+        appHost: "app.soleur.ai",
+        formActionExtra: ["https://github.com", "https://github.com"],
+      });
+      expect(parseCspDirective(csp, "form-action")).toBe(
+        "'self' https://github.com",
+      );
+    });
+
+    test("throws when formActionExtra contains an origin not in the allowlist", () => {
+      expect(() =>
+        buildCspHeader({
+          nonce: TEST_NONCE,
+          isDev: false,
+          supabaseUrl: "https://abc.supabase.co",
+          appHost: "app.soleur.ai",
+          formActionExtra: ["https://evil.example"],
+        }),
+      ).toThrow(/not in the allowlist/);
+    });
+
+    test("throws when formActionExtra contains a subtly different github origin", () => {
+      // Defense-in-depth: github.io, raw.githubusercontent.com, codespaces,
+      // and case-variant Github.com must NOT be silently accepted.
+      for (const bad of [
+        "https://github.io",
+        "https://raw.githubusercontent.com",
+        "https://Github.com",
+        "http://github.com",
+      ]) {
+        expect(() =>
+          buildCspHeader({
+            nonce: TEST_NONCE,
+            isDev: false,
+            supabaseUrl: "https://abc.supabase.co",
+            appHost: "app.soleur.ai",
+            formActionExtra: [bad],
+          }),
+        ).toThrow(/not in the allowlist/);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fix the CSP `form-action` block that prevented `/internal/github-app-init` from POSTing the committed manifest to GitHub's App-create form. The feature has been non-functional in prd since #4121 merged.

Surfaced via PM3 (#4171) operator dogfood — pre-merge gates missed it because the page test stubs the env (so the route never exercised live CSP), and Layer 1 canary fetches HTML without exercising form-POST.

Closes #4171
Refs #4115

## Changelog

### Web Platform

- `lib/csp.ts`: Add optional `formActionExtra: string[]` to `buildCspHeader`. Defense-in-depth: extras must be in `FORM_ACTION_ALLOWLIST` (currently only `https://github.com`); unknown origins throw at build time. Default behavior unchanged (`form-action 'self'`).
- `middleware.ts`: Pass `['https://github.com']` as `formActionExtra` when `pathname === '/internal/github-app-init'`. Narrow per-route extension; every other route retains strict `form-action 'self'`.

### Tests

- 6 new tests in `csp.test.ts`: default behavior, empty array, allowlist accept, dedup, unknown-origin reject (4 subtle variants — github.io, raw.githubusercontent.com, case-variant Github.com, http scheme).

## Failure-mode notes

Two real bugs in #4121 that PM3 surfaced together:
1. **APP_DOMAIN env var missing in Doppler dev/prd** — fixed earlier in this session by setting both Doppler values + triggering web-platform redeploy. Page now renders correctly with target domain `app.soleur.ai`.
2. **CSP `form-action 'self'` blocked the manifest POST** — this PR.

Pre-merge dogfood (visiting `/internal/github-app-init` on dev) would have caught both. The plan referenced `process.env.APP_DOMAIN` (task 2.1.5) but never tracked "set APP_DOMAIN in Doppler" as a deliverable. The CSP block was invisible to HTML-only canary probes (they don't exercise form-POST).

## Brand-survival threshold

- **Brand-survival threshold:** none — `/internal/github-app-init` is operator-only (gated by `ADMIN_USER_IDS` + middleware auth). Cross-origin form-POST whitelist scoped narrowly (allowlist of 1 origin, single-route check). No user data, no PII, no credentials touch this path.
- `threshold: none, reason: cross-origin form-action extension is allowlisted at the source, narrowed per-route, gated by ADMIN_USER_IDS authentication — no user-facing surface affected.`

## Test plan

- [x] `bun test apps/web-platform/test/csp.test.ts` — 28 passed (was 22, +6 new tests)
- [x] `bun test apps/web-platform/test/middleware.test.ts` — 12 passed (unchanged)
- [x] `bun test apps/web-platform/test/github-app-init-page.test.ts` — 8 passed (unchanged)
- [x] `bun test apps/web-platform/test/theme-csp-regression.test.tsx` — 3 passed
- [x] `bun test apps/web-platform/test/kb-content-csp.test.ts` — 4 passed
- [x] `tsc --noEmit` — exit 0
- [ ] ⏳ Post-merge: re-run PM3 dogfood by clicking "Create GitHub App" button on `/internal/github-app-init`. Expected: GitHub's App-create form renders with all 11 manifest fields pre-filled.

Generated with [Claude Code](https://claude.com/claude-code)
