### PR TITLE
fix(infra): strip .sudoers suffix in apply-deploy-pipeline-fix verify step

### DIFF
--- a/.github/workflows/apply-deploy-pipeline-fix.yml
+++ b/.github/workflows/apply-deploy-pipeline-fix.yml
@@ -338,6 +338,11 @@ jobs:
           echo "Server-side state:"
           echo "$REMOTE_OUT"
 
+          # Basename mapping note: `deploy-inngest-bootstrap.sudoers` (source
+          # filename in apps/web-platform/infra/) installs to
+          # `/etc/sudoers.d/deploy-inngest-bootstrap` (no extension, per
+          # sudoers.d convention). Strip the `.sudoers` suffix on the local
+          # side so the basename key matches the remote install path.
           declare -A REMOTE
           while read -r hash path; do
             base=$(basename "$path")
@@ -347,6 +352,7 @@ jobs:
           MISMATCH=0
           while read -r hash path; do
             base=$(basename "$path")
+            base="${base%.sudoers}"
             r="${REMOTE[$base]:-}"
             if [[ -z "$r" ]]; then
               echo "::error::No remote hash recorded for $base"


### PR DESCRIPTION
## Summary

Pre-existing verify-step bug exposed by PR #4201's L7 auth fix. The local hash list keys by source basename (`deploy-inngest-bootstrap.sudoers`); the remote sha256sum keys by install basename (`deploy-inngest-bootstrap` under `/etc/sudoers.d/`). Once PR #4201 landed and the workflow finally reached the verify step (run [26188932828](https://github.com/jikig-ai/soleur/actions/runs/26188932828)), the basename mismatch surfaced as `No remote hash recorded for deploy-inngest-bootstrap.sudoers`.

This bug has been latent since PR #4144 (which added the sudoers file) — every prior workflow run failed before reaching the verify step due to the L7 SSH auth failure.

## Changelog

- Strip the `.sudoers` suffix on the local-side basename via bash parameter expansion (`base="${base%.sudoers}"`) so the associative-array lookup matches the remote install basename.
- All other 5 trigger files have basenames identical between source and install — they were already matching correctly.

## Test plan

- [x] `actionlint .github/workflows/apply-deploy-pipeline-fix.yml` exits 0
- [ ] ⏳ Operator dispatches `apply-deploy-pipeline-fix.yml` post-merge; verify step now passes (Tracks #4202)

Ref #4177 (the L7 follow-on cascade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)