### PR TITLE
fix(inngest): always reconcile heartbeat units on no-op redeploy (#4116)

### DIFF
--- a/apps/web-platform/infra/inngest-bootstrap.sh
+++ b/apps/web-platform/infra/inngest-bootstrap.sh
@@ -61,15 +61,25 @@ done
 
 log() { printf '[inngest-bootstrap] %s\n' "$*" >&2; }
 
-# Idempotency short-circuit: skip everything if the service is active AND
-# the recorded version matches the requested version. Second invocation of
-# the same vX.Y.Z is a no-op (~50ms).
+# Idempotency short-circuit: when the server is already active AND the recorded
+# version matches, skip the binary download/install + server unit write — but
+# ALWAYS fall through to reconcile heartbeat units, env file, and daemon-reload.
+# Without this, a bootstrap-script fix (e.g. PR #4123's doppler-run heartbeat
+# wrap) stays masked indefinitely: the version match short-circuits before the
+# unit writes, so the host runs the OLD unit shape even though the deployed
+# image embeds the new script. Surfaced 2026-05-20 during the #4144 cascade —
+# v1.0.1 image carried the heartbeat fix but every no-op redeploy skipped the
+# unit reconcile, leaving inngest-heartbeat.service in `failed` with
+# `curl: (3) URL rejected: Malformed input to a URL function`.
+SKIP_BINARY_INSTALL=
 if [[ -f "$VERSION_FILE" ]] && [[ "$(cat "$VERSION_FILE" 2>/dev/null || true)" == "$INNGEST_CLI_VERSION" ]]; then
   if systemctl is-active --quiet inngest-server.service 2>/dev/null; then
-    log "inngest-server.service already active at $INNGEST_CLI_VERSION — no-op"
-    exit 0
+    log "inngest-server.service already active at $INNGEST_CLI_VERSION — skipping binary install, reconciling units"
+    SKIP_BINARY_INSTALL=1
   fi
 fi
+
+if [[ -z "$SKIP_BINARY_INSTALL" ]]; then
 
 # Detect in-place version upgrade (existing service running an older version).
 # Pause the server so the in-memory queue drains to the SQLite store before
@@ -155,6 +165,8 @@ TimeoutStopSec=180
 [Install]
 WantedBy=multi-user.target
 UNITEOF
+
+fi  # end SKIP_BINARY_INSTALL guard — heartbeat reconcile below always runs
 
 # Heartbeat ping script + service + 60s timer.
 # The URL lives in $INNGEST_HEARTBEAT_URL — resolved at ExecStart time via
@@ -259,9 +271,13 @@ echo "$INNGEST_CLI_VERSION" > "$VERSION_FILE"
 systemctl daemon-reload
 systemctl enable --now inngest-server.service
 systemctl enable --now inngest-heartbeat.timer
+# Force one heartbeat tick now so a unit-shape change (e.g. ExecStart) takes
+# effect immediately rather than waiting up to 60s for the next timer fire.
+# Oneshot in `failed` state: restart re-runs ExecStart with the new unit.
+systemctl restart inngest-heartbeat.service || log "warn: heartbeat oneshot non-zero (timer will retry in 60s)"
 
 # Resume from upgrade pause (if any).
-if [[ -n "$UPGRADE_FROM" ]]; then
+if [[ -n "${UPGRADE_FROM:-}" ]]; then
   sleep 2  # let the new server bind loopback before resume
   "$INSTALL_PATH" resume >/dev/null 2>&1 || log "warn: resume command failed (server is still running)"
   log "upgrade complete: $UPGRADE_FROM → $INNGEST_CLI_VERSION"


### PR DESCRIPTION
## Summary

- Replace `inngest-bootstrap.sh`'s early `exit 0` short-circuit with a `SKIP_BINARY_INSTALL` flag — the heartbeat triplet, env file, daemon-reload, and timer enable now always run; only the binary download/install + server unit write are skipped when the version matches.
- Force `systemctl restart inngest-heartbeat.service` after daemon-reload so unit-shape changes apply immediately (no 60s wait for next timer tick).

## Why

PR #4123 wrapped `inngest-heartbeat.service` in `doppler run` so `INNGEST_HEARTBEAT_URL` is materialized at process start. v1.0.1 OCI image shipped that fix. But every v1.0.1 deploy against an already-active host took the no-op short-circuit before the unit writes, so the host stayed on the pre-#4123 unit shape and curl errored every 60s with `URL rejected: Malformed input to a URL function`.

Surfaced 2026-05-20 during the #4144 cascade — AC17 (`systemctl is-active inngest-heartbeat.service`) failed with `ExecMainStatus=3` despite v1.0.1 having the documented fix.

## Test plan

- [ ] Tag `vinngest-v1.0.2` after merge, GHA `build-inngest-bootstrap-image.yml` publishes `ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.0.2`
- [ ] Fire `deploy inngest ghcr.io/jikig-ai/soleur-inngest-bootstrap v1.0.2` webhook against prd
- [ ] Bootstrap takes the SKIP_BINARY_INSTALL path (v1.19.4 still pinned in `inngest.tf`)
- [ ] Heartbeat unit's `ExecStart` flips from `/usr/local/bin/inngest-heartbeat.sh` to `${DOPPLER_BIN} run --project soleur --config prd -- /usr/local/bin/inngest-heartbeat.sh`
- [ ] `systemctl is-active inngest-heartbeat.service` → `active`, `ExecMainStatus=0`
- [ ] AC18 (BetterStack `460830` unpause) follows once AC17 is green

Resumes the #4144 cascade at AC17. Refs #4116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)