### PR TITLE
fix(inngest): run heartbeat unit as User=deploy to provide HOME (#4116)

### DIFF
--- a/apps/web-platform/infra/inngest-bootstrap.sh
+++ b/apps/web-platform/infra/inngest-bootstrap.sh
@@ -207,6 +207,13 @@ After=network-online.target
 
 [Service]
 Type=oneshot
+User=deploy
+Group=deploy
+# Doppler CLI calls os.UserHomeDir() during init even when DOPPLER_CONFIG_DIR
+# is set in the env file. Running as root with no HOME triggers
+# "Doppler Error: \$HOME is not defined". User=deploy gets HOME=/home/deploy
+# automatically, matching inngest-server.service's hardening pattern.
+# Surfaced 2026-05-20 once #4204's reconcile gate exposed the new unit shape.
 EnvironmentFile=/etc/default/inngest-server
 ExecStart=${DOPPLER_BIN} run --project soleur --config prd -- ${HEARTBEAT_SCRIPT}
 HEARTBEATEOF


### PR DESCRIPTION
## Summary

- Add `User=deploy` + `Group=deploy` to the `inngest-heartbeat.service` template in `inngest-bootstrap.sh`.

## Why

After #4204 (v1.0.2) finally let the new doppler-wrapped heartbeat unit shape land on prd, the unit failed with `Doppler Error: $HOME is not defined`. The unit had no `User=` directive so systemd ran it as root with `HOME` unset; Doppler CLI calls `os.UserHomeDir()` during init even when `DOPPLER_CONFIG_DIR` is set in the EnvironmentFile.

Setting `User=deploy` mirrors `inngest-server.service`'s pattern. `deploy` can read the `0640 root:deploy` env file and exec the `0755` heartbeat script. systemd auto-exports `HOME=/home/deploy`.

## Test plan

- [ ] Tag `vinngest-v1.0.3` after merge, GHA publishes `ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.0.3`
- [ ] Fire `deploy inngest ... v1.0.3` webhook
- [ ] `cat /etc/systemd/system/inngest-heartbeat.service` shows `User=deploy`
- [ ] `systemctl is-active inngest-heartbeat.service` → `active`, `ExecMainStatus=0`
- [ ] AC18 (BetterStack `460830` unpause) follows once AC17 is green

Resumes the #4144 cascade. Follow-up to #4204. Refs #4116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)