### PR TITLE
fix(learnings): scrub real operator email to pass secret-scan lint

### DIFF
--- a/knowledge-base/project/learnings/2026-05-21-follow-through-template-host-drift-and-qa-spawned-feature.md
+++ b/knowledge-base/project/learnings/2026-05-21-follow-through-template-host-drift-and-qa-spawned-feature.md
@@ -51,7 +51,7 @@ rather than spawning leaders.
 
 **For #4067 specifically:** verified inline via Playwright + DOM
 MutationObserver on `app.soleur.ai/dashboard/settings/scope-grants` (operator
-already authenticated as ops@jikigai.com — no OTP handoff needed). Both
+already authenticated as the operator — no OTP handoff needed). Both
 assertions passed; issue closed with measured latencies in the comment.
 
 **For the template:** the wrong-host class affects every future


### PR DESCRIPTION
## Summary

Replace `ops@jikigai.com` with `the operator` in `knowledge-base/project/learnings/2026-05-21-follow-through-template-host-drift-and-qa-spawned-feature.md` (line 54). The `lint-fixture-content` script in the `secret-scan` workflow rejects real-looking emails outside `@example.com` / `@test.local` / `@fixtures.local` even in docs/learnings, and PR #4214 merged with a stray operator email in the captured learning.

Currently main fails the post-merge `secret-scan` workflow ([run 26215454858](https://github.com/jikig-ai/soleur/actions/runs/26215454858)). One-line scrub clears it.

Ref #4214

## Changelog

- Replace real operator email in learning file with generic phrasing.

## Test plan

- [x] Verify the change is the only diff against main.
- [ ] ⏳ Secret-scan workflow on this PR's HEAD passes.

Generated with [Claude Code](https://claude.com/claude-code)