### PR TITLE
fix(workflow): operator-step gate on gh pr ready + NEXT_PUBLIC fallback in oauth-probe handler

### DIFF
--- a/.claude/hooks/ship-operator-step-gate.sh
+++ b/.claude/hooks/ship-operator-step-gate.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) hook: blocks `gh pr ready` and `gh pr merge --auto` when the
+# PR body contains undeferred operator-step accretions.
+#
+# Enforces hard rule `hr-never-label-any-step-as-manual-without` and workflow
+# gate `wg-block-pr-ready-on-undeferred-operator-steps` at the
+# `gh pr ready` / `gh pr merge --auto` boundary — closing the bypass class
+# where the agent skips /ship Phase 5.5 (where the gate is documented) and
+# goes straight to `gh pr ready`.
+#
+# Pattern source: ship/SKILL.md §Undeferred Operator-Step Gate, with broader
+# detection regex covering phrasings observed in real PRs that slipped the
+# narrower /ship version (PR #4227, 2026-05-21):
+#   - `Operator: <noun>` (capitalised, with colon — bullet headings)
+#   - `Operator (verify|confirm|set|file|check|...)`  (extended verb set)
+#   - `T+<N><units>` verification bullets ("T+90 min", "T+24h")
+#   - `Within <N>h of merge: (file|run|verify)`
+#   - `**Post-merge**:` blocks with action verbs
+#
+# Contract-inherited PreToolUse(Bash) input shape (sibling-hook parity):
+#   .tool_input.command  (string) — the bash command string
+#   .cwd                 (string) — absolute path to working directory
+#
+# Fail-open conditions (exit 0 silently):
+#   - input lacks .cwd or path is not an absolute existing directory
+#   - command is not `gh pr ready` / `gh pr merge --auto`
+#   - cannot read PR body (no PR exists yet, gh not authenticated, etc.)
+#
+# Fail-closed conditions (deny + emit_incident):
+#   - PR body contains operator-step accretions without OPEN
+#     `deferred-automation` / `automation gap` companion issues
+
+set -eo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib/incidents.sh" 2>/dev/null || true
+
+INPUT=$(cat)
+eval "$(echo "$INPUT" | jq -r '@sh "CMD=\(.tool_input.command // "") WORK_DIR=\(.cwd // "")"' 2>/dev/null || echo 'CMD="" WORK_DIR=""')"
+: "${CMD:=}"
+: "${WORK_DIR:=}"
+
+# Match either `gh pr ready` or `gh pr merge` with --auto flag. The chained-
+# operator clause catches `gh pr ready && gh pr merge --squash --auto` and
+# similar. Word-boundary-anchored to avoid false positives on quoted strings.
+if ! echo "$CMD" | grep -qE '(^|&&|\|\||;)\s*gh\s+pr\s+(ready|merge\s+.*--auto)(\s|$|&&|\|\||;)'; then
+  exit 0
+fi
+
+# Validate WORK_DIR
+if [[ "$WORK_DIR" != /* ]] || [[ ! -d "$WORK_DIR" ]]; then
+  exit 0
+fi
+cd "$WORK_DIR" 2>/dev/null || exit 0
+
+# Allow override via env var (CI workflows, ultrareview, etc.)
+if [[ "${SOLEUR_SKIP_OPERATOR_STEP_GATE:-}" == "1" ]]; then
+  exit 0
+fi
+
+# Resolve the PR number. Try the command first (e.g., `gh pr ready 4227`),
+# then fall back to the current branch's PR.
+PR_NUM=$(echo "$CMD" | grep -oE 'gh\s+pr\s+(ready|merge[^|;&]*)\s+([0-9]+)' | grep -oE '[0-9]+$' | head -1 || true)
+if [[ -z "$PR_NUM" ]]; then
+  PR_NUM=$(gh pr view --json number --jq .number 2>/dev/null || true)
+fi
+[[ -n "$PR_NUM" ]] || exit 0
+
+PR_BODY=$(gh pr view "$PR_NUM" --json body --jq .body 2>/dev/null || true)
+[[ -n "$PR_BODY" ]] || exit 0
+
+PR_BODY_FILE=$(mktemp)
+trap 'rm -f "$PR_BODY_FILE"' EXIT INT TERM
+
+# Strip fenced code blocks — quotations of the gate's own regex inside
+# ```...``` MUST NOT count as undeferred declarations. Fail-closed on
+# unbalanced fence per /ship parity.
+printf '%s' "$PR_BODY" | awk '
+  /^```/ { in_fence = !in_fence; next }
+  !in_fence { print }
+  END { if (in_fence) exit 2 }
+' > "$PR_BODY_FILE" || printf '%s' "$PR_BODY" > "$PR_BODY_FILE"
+
+# Strip HTML-comment override blocks (operator attestation per /ship §687)
+sed -i 's|<!--[^>]*-->||g' "$PR_BODY_FILE"
+
+# Broader regex than ship/SKILL.md §Detection — covers the phrasings PR #4227
+# slipped past. Anchored to list/bullet markers (no prose false-positives).
+#
+# Group A: explicit operator/manual declarations
+#   - `Operator:` / `Operator <verb>` / `manual gate` / `post-merge operator`
+#   - Extended verb set: run/create/provision/configure/paste/cop(y/ies)
+#     PLUS verify/confirm/check/file/set/install/upload/audit/click
+# Group B: time-anchored verification bullets
+#   - `T+<N><units>` (e.g., T+90 min, T+24h, T+2 weeks)
+# Group C: post-merge-clock bullets
+#   - `Within <N><units> of merge: <verb>`
+# Group D: AC-PM<N> tokens (legacy from ship gate)
+GROUP_A='[Oo]perator\s*:|[Oo]perator\s+(run|create|provision|configure|paste|cop(y|ies)|verif(y|ies)|confirm|check|file|set|install|upload|audit|click)s?|manual\s+gate|post-merge\s+operator'
+GROUP_B='T\+[0-9]+\s*(min|m|h|hour|d|day|wk|week)s?\b.*(verif|check|confirm|file|run)'
+GROUP_C='[Ww]ithin\s+[0-9]+\s*(min|m|h|hour|d|day|wk|week)s?(\s+of\s+merge)?\s*:.*(file|run|verif|check|confirm|create|provision|set)'
+GROUP_D='AC-PM[0-9]+'
+
+DETECT_RE="^[[:space:]]*([-*]|[0-9]+\.)[[:space:]]+(\[[[:space:]xX]\][[:space:]]+)?(\*\*)?(${GROUP_A}|${GROUP_B}|${GROUP_C}|${GROUP_D})"
+
+MATCHES=$(grep -niE "$DETECT_RE" "$PR_BODY_FILE" 2>/dev/null || true)
+
+if [[ -z "$MATCHES" ]]; then
+  exit 0
+fi
+
+# For each match, verify a `(Tracks|Refs) #NNNN` companion exists on the same,
+# previous, or next line AND points to an OPEN issue whose body contains the
+# `deferred-automation` or `automation gap` sentinel.
+UNDEFERRED=()
+while IFS= read -r match_line; do
+  line_no=$(echo "$match_line" | awk -F: '{print $1}')
+  [[ "$line_no" =~ ^[0-9]+$ ]] || continue
+  prev=$((line_no > 1 ? line_no - 1 : 1))
+  ctx=$(sed -n "${prev}p;${line_no}p;$((line_no+1))p" "$PR_BODY_FILE")
+  refs=$(printf '%s' "$ctx" | grep -oE '(Tracks|Refs)[[:space:]]+#[0-9]+' || true)
+  if [[ -z "$refs" ]]; then
+    UNDEFERRED+=("$match_line"); continue
+  fi
+  ok=0
+  for n in $(printf '%s' "$refs" | grep -oE '[0-9]+'); do
+    state=$(gh issue view "$n" --json state --jq .state 2>/dev/null || echo "")
+    [[ "$state" == "OPEN" ]] || continue
+    body=$(gh issue view "$n" --json body --jq .body 2>/dev/null || echo "")
+    if printf '%s' "$body" | grep -qiE 'deferred-automation|automation gap'; then
+      ok=1; break
+    fi
+  done
+  [[ "$ok" == 1 ]] || UNDEFERRED+=("$match_line")
+done <<< "$MATCHES"
+
+if [[ ${#UNDEFERRED[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+# Fail-closed: deny the tool call with a structured message.
+declare -f emit_incident >/dev/null && \
+  emit_incident wg-block-pr-ready-on-undeferred-operator-steps applied \
+    "PreToolUse gate blocked gh pr ready/merge --auto for PR #${PR_NUM}" 2>/dev/null || true
+
+REASON_LINES=()
+REASON_LINES+=("PR #${PR_NUM} body contains ${#UNDEFERRED[@]} undeferred operator-step accretion(s) (see hr-never-label-any-step-as-manual-without).")
+REASON_LINES+=("")
+REASON_LINES+=("Matching lines:")
+for m in "${UNDEFERRED[@]}"; do
+  REASON_LINES+=("  $m")
+done
+REASON_LINES+=("")
+REASON_LINES+=("Resolve via one of:")
+REASON_LINES+=("  (a) Inline-execute each step now (Doppler/gh/Playwright/MCP — see hr-exhaust-all-automated-options-before).")
+REASON_LINES+=("  (b) File a 'deferred-automation' tracked issue per match: gh issue create --label type/chore --title '...' --body 'deferred-automation backlog item; re-evaluate when: <criterion>' then add 'Tracks #N' next to each match in the PR body.")
+REASON_LINES+=("  (c) Emergency override: SOLEUR_SKIP_OPERATOR_STEP_GATE=1 <cmd> (use sparingly; logged as gate-override).")
+
+REASON=$(printf '%s\n' "${REASON_LINES[@]}")
+
+jq -nc --arg r "$REASON" '{decision: "deny", reason: $r}'
+exit 0

--- a/.claude/hooks/ship-operator-step-gate.test.sh
+++ b/.claude/hooks/ship-operator-step-gate.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Pattern-only tests for ship-operator-step-gate.sh. Asserts the gate's
+# expanded detection regex catches every phrasing that slipped past the
+# narrower /ship Phase 5.5 regex in PR #4227, and that the command-trigger
+# regex catches `gh pr ready` + `gh pr merge --auto` (and chained forms).
+#
+# Does NOT exercise the gh-API path (no network in tests); the gate's
+# fail-open behaviour on missing PR is exercised separately.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/ship-operator-step-gate.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+GROUP_A='[Oo]perator\s*:|[Oo]perator\s+(run|create|provision|configure|paste|cop(y|ies)|verif(y|ies)|confirm|check|file|set|install|upload|audit|click)s?|manual\s+gate|post-merge\s+operator'
+GROUP_B='T\+[0-9]+\s*(min|m|h|hour|d|day|wk|week)s?\b.*(verif|check|confirm|file|run)'
+GROUP_C='[Ww]ithin\s+[0-9]+\s*(min|m|h|hour|d|day|wk|week)s?(\s+of\s+merge)?\s*:.*(file|run|verif|check|confirm|create|provision|set)'
+GROUP_D='AC-PM[0-9]+'
+DETECT_RE="^[[:space:]]*([-*]|[0-9]+\.)[[:space:]]+(\[[[:space:]xX]\][[:space:]]+)?(\*\*)?(${GROUP_A}|${GROUP_B}|${GROUP_C}|${GROUP_D})"
+CMD_RE='(^|&&|\|\||;)\s*gh\s+pr\s+(ready|merge\s+.*--auto)(\s|$|&&|\|\||;)'
+
+t() {
+  TOTAL=$((TOTAL + 1))
+  local label="$1" pattern="$2" input="$3" expected="$4"  # expected: match|no-match
+  local got="no-match"
+  if echo "$input" | grep -qE "$pattern"; then got="match"; fi
+  if [[ "$got" == "$expected" ]]; then
+    PASS=$((PASS + 1))
+    echo "PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label  (expected $expected, got $got)"
+    echo "  input: $input"
+  fi
+}
+
+# --- DETECT_RE tests (PR-body line patterns) -------------------------------
+
+t "Operator-colon bullet (PR #4227 phrasing #1)" "$DETECT_RE" \
+  "- **Operator: Doppler prd secrets** — verify OAUTH_PROBE_GITHUB_CLIENT_ID is set" match
+t "Operator-verify (PR #4227 #2)" "$DETECT_RE" \
+  "- Operator verifies pre-deploy" match
+t "T+90 min verification bullet" "$DETECT_RE" \
+  "- T+90 min: confirm Sentry ok check-in" match
+t "T+24h verification bullet" "$DETECT_RE" \
+  "- T+24h: confirm Sentry issue auto-resolves" match
+t "Within Nh of merge: file bullet" "$DETECT_RE" \
+  "- Within 48h: file TR9 PR-4 follow-up issue per AC25" match
+t "AC-PM3 token (legacy)" "$DETECT_RE" \
+  "- [ ] **AC-PM3** Operator creates the foo bucket" match
+t "Operator run (original gate keyword)" "$DETECT_RE" \
+  "- Operator runs the bootstrap script" match
+t "Operator file (extended verb)" "$DETECT_RE" \
+  "- Operator files the tracking issue" match
+t "Operator check (extended verb)" "$DETECT_RE" \
+  "- Operator checks the dashboard" match
+
+# Negatives: prose mentions in body text should not fire.
+t "Prose: 'the operator's choice' (no list marker)" "$DETECT_RE" \
+  "  This document mentions the operator's choice in mid-paragraph." no-match
+t "Prose without bullet" "$DETECT_RE" \
+  "The operator runs the script ONCE post-merge." no-match
+t "AC25 (not AC-PM25) — non-PM AC stays prose-noise" "$DETECT_RE" \
+  "- AC25 is satisfied by inline-execution" no-match
+
+# --- CMD_RE tests (which bash commands the gate triggers on) ---------------
+
+t "gh pr ready 4227" "$CMD_RE" "gh pr ready 4227" match
+t "gh pr merge --squash --auto" "$CMD_RE" "gh pr merge --squash --auto" match
+t "chained: gh pr ready 1 && gh pr merge --auto" "$CMD_RE" \
+  "gh pr ready 1 && gh pr merge --auto" match
+t "gh pr merge (no --auto) — direct merge, NOT this gate's scope" "$CMD_RE" \
+  "gh pr merge 4227 --squash" no-match
+t "gh pr view — read-only, not gated" "$CMD_RE" \
+  "gh pr view 4227" no-match
+t "echo containing 'gh pr ready' substring — word-bounded safe" "$CMD_RE" \
+  "echo 'remember to gh pr ready when done'" no-match
+
+# --- Hook script syntax check (no real invocation; lacks gh + PR context) --
+
+if bash -n "$HOOK"; then
+  PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1))
+  echo "PASS: hook script syntax OK"
+else
+  FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1))
+  echo "FAIL: hook script syntax error"
+fi
+
+echo ""
+echo "=== $PASS/$TOTAL pass ($FAIL fail) ==="
+[[ $FAIL -eq 0 ]]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -58,6 +58,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/ship-operator-step-gate.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prod-write-defer-gate.sh"
           }
         ]

--- a/apps/web-platform/server/inngest/functions/cron-oauth-probe.ts
+++ b/apps/web-platform/server/inngest/functions/cron-oauth-probe.ts
@@ -296,7 +296,12 @@ async function resolveSupabaseRefFromCname(apiHost: string): Promise<string | nu
 async function probeOauth(): Promise<ProbeResult> {
   const appHost = process.env.APP_HOST || DEFAULT_APP_HOST;
   const apiHost = process.env.API_HOST || DEFAULT_API_HOST;
-  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+  // The GHA workflow mapped `secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY` → env
+  // `SUPABASE_ANON_KEY`. Doppler prd carries it under its canonical name
+  // (`NEXT_PUBLIC_SUPABASE_ANON_KEY`); accept either to avoid creating a
+  // redundant secret.
+  const supabaseAnonKey =
+    process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   const githubClientId = process.env.OAUTH_PROBE_GITHUB_CLIENT_ID;
   const supabaseProjectRef = process.env.SUPABASE_PROJECT_REF;
 

--- a/knowledge-base/project/learnings/best-practices/2026-05-21-post-merge-section-self-audit.md
+++ b/knowledge-base/project/learnings/best-practices/2026-05-21-post-merge-section-self-audit.md
@@ -1,0 +1,57 @@
+---
+title: "PR-body Post-merge sections accrete operator handoffs that hard rules already forbid; gate them at gh pr ready"
+date: 2026-05-21
+tags: [workflow, ship, operator-handoff, hr-never-label-any-step-as-manual-without, wg-block-pr-ready-on-undeferred-operator-steps]
+related_prs: [4227]
+related_issues: [4211]
+related_rules:
+  - hr-exhaust-all-automated-options-before
+  - hr-never-label-any-step-as-manual-without
+  - wg-block-pr-ready-on-undeferred-operator-steps
+  - hr-when-a-workflow-concludes-with-an
+  - hr-no-dashboard-eyeball-pull-data-yourself
+---
+
+# Post-merge sections accrete operator handoffs that hard rules already forbid
+
+## Symptom
+
+`/soleur:work` repeatedly produces PR bodies whose `## Post-merge` (or `## Operator follow-ups`) section lists 3-5 items the agent could have done inline. Recurring example (PR #4227, TR9 PR-3 oauth-probe Inngest migration):
+
+1. "Verify Doppler prd has `OAUTH_PROBE_GITHUB_CLIENT_ID` + `SUPABASE_PROJECT_REF` set before merge"
+2. "T+90 min: confirm Sentry `?status=ok` check-in"
+3. "T+24h: confirm Sentry issue auto-resolves"
+4. "Within 48h: file TR9 PR-4 follow-up issue per AC25"
+
+All four are inline-automatable:
+
+- (1) `doppler secrets get … --plain` to probe; `doppler secrets set` to remediate when source values exist elsewhere in Doppler.
+- (2)/(3) The Sentry monitor already has `failure_issue_threshold = 1` + `recovery_threshold = 1` — the monitor IS the verification (`hr-no-dashboard-eyeball-pull-data-yourself`); the operator-eyeball bullet was duplicate of an already-automated alert path.
+- (4) `gh issue create` with the template the bullet itself described.
+
+The user surfaced this with "why do you keep adding operator follow ups? please modify the workflow so those things are entirely automatically driven by Soleur from now on. It's been happening over and over again this week."
+
+## Root cause
+
+Three hard rules forbid this pattern (`hr-exhaust-all-automated-options-before`, `hr-never-label-any-step-as-manual-without`, `wg-block-pr-ready-on-undeferred-operator-steps`) and a gate existed at `/ship` Phase 5.5 — but:
+
+1. **The gate fired at `/ship`, not at `gh pr ready`.** When the agent skipped `/ship` (or invoked `gh pr ready` directly during `/work`'s post-implementation pipeline), the gate never ran.
+2. **The detection regex was too narrow.** It matched `operator (run|create|provision|configure|paste|copy)` but missed `Operator:` (with colon, bullet-heading shape), `Operator verify/confirm/check/file/set/...`, `T+<N><units>` verification bullets, `Within <N>h of merge: file/run/verify`, and the legacy `AC<N>:` form (only `AC-PM<N>` was caught).
+3. **The agent had no Phase 4 self-audit step.** The work skill's Phase 4 (handoff) had a Playwright-first audit + entry-guard but no symmetric audit on the PR-body itself; the agent's only forcing function was at the gate.
+
+## Fix
+
+1. **New PreToolUse hook**: `.claude/hooks/ship-operator-step-gate.sh`. Intercepts `gh pr ready` / `gh pr merge --auto` (and chained forms via `&&`/`;`/`||`); reads the PR body via `gh pr view`; runs an expanded regex (4 groups: explicit operator/manual declarations with extended verb set, `T+<N><units>` verification bullets, `Within <N>h of merge: <verb>` bullets, legacy `AC-PM<N>`); for each match requires a `(Tracks|Refs) #<N>` companion to an OPEN issue whose body carries the `deferred-automation` / `automation gap` sentinel. Override: `SOLEUR_SKIP_OPERATOR_STEP_GATE=1` (rare attestation case).
+2. **Work skill §Post-Merge Section Self-Audit (HARD GATE)**: after drafting the PR body and BEFORE `gh pr ready`, scan every line under `^##\s+(Post-?merge|Operator|Follow-?ups?)` headings; classify each bullet against a 6-row pattern→action table (Doppler verify → `doppler secrets get`; `Within Nh: file <issue>` → `gh issue create` NOW; Sentry/monitor verify → the monitor IS the gate; genuine operator-only → file `type/chore deferred-automation` tracked issue; default → inline-execute).
+
+The hook closes the bypass; the skill text gives the agent the active resolution playbook so the hook rarely needs to deny.
+
+## How to apply
+
+- Touched a PR body's `## Post-merge` / `## Operator` section? Run the self-audit table before `gh pr ready`. Inline-execute the resolvable items; for the residual genuine handoffs, file `type/chore deferred-automation` issues and add `Tracks #N` next to each.
+- New gate written? Wire it as a PreToolUse(Bash) hook so it fires regardless of which skill the agent invokes — gating via skill-internal prose alone has reliably bypass-prone failure modes.
+- When the agent surfaces a "T+<N> dashboard verify" bullet, ask: does the monitor already alert on the bad path? If yes, the bullet duplicates an automated signal and should be deleted (`hr-no-dashboard-eyeball-pull-data-yourself`).
+
+## Verification
+
+After this PR lands, the next `gh pr ready` invocation on a PR whose body contains an undeferred `Operator:` / `T+<N>h verify` / `Within Nh of merge: file` bullet will be DENIED at the PreToolUse hook, with a structured message listing every match and the three resolution paths (inline, file deferred-automation issue, override).

--- a/plugins/soleur/skills/work/SKILL.md
+++ b/plugins/soleur/skills/work/SKILL.md
@@ -655,6 +655,23 @@ Before emitting `## Work Phase Complete` (one-shot mode) or chaining into the po
 
 **Form rationale.** `git rev-parse --abbrev-ref HEAD` matches `ship/SKILL.md:619` precedent and returns the literal `HEAD` on detached state (vs. `git branch --show-current` which returns empty), so the detached-HEAD guard catches both shapes. `git rev-list ... --count` returns a clean integer ready for `[[ "$N" == "0" ]]`; the `wc -l` shape requires a `tr -d` strip and is whitespace-padded. Precedent: `plugins/soleur/skills/ship/SKILL.md:619`, `.claude/hooks/ship-unpushed-commits-gate.sh`. **Distinct exit codes** (`2 = pause-and-commit`, `1 = halt-and-investigate`) let one-shot orchestrators distinguish the two recovery paths rather than treating both as opaque non-zero failures.
 
+#### Post-Merge Section Self-Audit (HARD GATE)
+
+After drafting the PR body and BEFORE `gh pr ready` / `gh pr merge --auto`, scan every line under headings matching `^##\s+(Post-?merge|Operator|Follow-?ups?)` (case-insensitive). For each bullet, classify and resolve **before** marking ready:
+
+| Pattern | Action |
+|---|---|
+| Doppler/env-var verification | Inline-execute via `doppler secrets get <KEY> -p soleur -c <env> --plain`; if missing, set from a known source via `doppler secrets set` or update the handler to read the existing canonical name. |
+| `Within Nh of merge: file <issue>` | File the issue NOW via `gh issue create` using the template the bullet describes; replace the bullet with `Done: #<num>`. |
+| `gh issue close` / `gh issue comment` on existing issues | Run NOW via `gh` CLI. |
+| Sentry / Better Stack / monitor verification | Replace with the monitor's own auto-page mechanism (`failure_issue_threshold = 1` is the verification — no operator gaze required per `hr-no-dashboard-eyeball-pull-data-yourself`). If active verification is still wanted, create a one-time scheduled workflow via `/soleur:schedule create --once --at <date>` with a self-disabling `verify-and-close-or-file-issue` body. |
+| Genuinely operator-only (CAPTCHA, SSO consent, payment-card entry, hardware MFA, K-bis-style first-onboarding) | File a `type/chore` issue carrying the literal `deferred-automation` sentinel via `gh issue create --label type/chore --body "deferred-automation backlog item; re-evaluate when: <criterion>" ...`, then add `Tracks #N` to the bullet in the PR body. |
+| Anything else | Inline-execute. Default-deny on "operator should later …" phrasing. |
+
+After resolution, re-scan; the section MUST contain zero unaccompanied operator/manual bullets. The `ship-operator-step-gate.sh` PreToolUse hook enforces this mechanically at `gh pr ready` / `gh pr merge --auto` — the gate's deny message lists each undeferred match. Override via `SOLEUR_SKIP_OPERATOR_STEP_GATE=1` is reserved for the rare attestation case.
+
+**Why:** PR #4227 (TR9 PR-3) shipped with a "Post-merge" section listing four operator items (Doppler secrets check, T+90 min Sentry verify, T+24h auto-resolve verify, file follow-up issue within 48h) — all four were inline-automatable; the agent had hard rules forbidding the deferral (`hr-exhaust-all-automated-options-before`, `hr-never-label-any-step-as-manual-without`, `wg-block-pr-ready-on-undeferred-operator-steps`) and still wrote the bullets. The gate existed at `/ship` Phase 5.5 but the agent reached `gh pr ready` directly. This self-audit + the hook close both halves of that bypass. See `knowledge-base/project/learnings/best-practices/2026-05-21-post-merge-section-self-audit.md`.
+
 #### Invocation Mode
 
 **If invoked by one-shot** (the conversation contains `soleur:one-shot` skill output earlier): Output exactly `## Work Phase Complete` and then **immediately invoke** `skill: soleur:review` (step 4 of the one-shot sequence). Do NOT end your turn after outputting the marker — you ARE the orchestrator, so you must continue executing one-shot steps 4 through 10 in order. The marker is a progress signal, not a stopping point.


### PR DESCRIPTION
## Summary

Two follow-ups that didn't make the #4227 auto-merge cutoff:

1. **`apps/web-platform/server/inngest/functions/cron-oauth-probe.ts`** — reads `NEXT_PUBLIC_SUPABASE_ANON_KEY` as a fallback for `SUPABASE_ANON_KEY`. Without this, the first probe fire on prod returns `settings_misconfigured` because Doppler `prd` carries the secret under its canonical `NEXT_PUBLIC_*` name (the GHA workflow re-mapped via `env:`; Inngest reads `process.env.*` directly).
2. **`.claude/hooks/ship-operator-step-gate.sh`** + test + work-skill self-audit section + learning — PreToolUse(Bash) hook that intercepts `gh pr ready` / `gh pr merge --auto` and denies when the PR body contains undeferred operator-step accretions lacking a `(Tracks|Refs) #N` companion to an OPEN `deferred-automation` issue. Closes the bypass class where the agent skips `/ship` Phase 5.5 (where the gate's narrower form is documented) and goes straight to `gh pr ready`.

Auto-merge on #4227 fired on commit `abd2cf63` before the workflow-gate commit `75a704c9` reached origin, so both fixes need a fresh PR. Squash `1b8bf50f` (TR9 PR-3) is on main and shipped fine — this PR is the residual.

Ref #4211 (umbrella; merged via #4227).

## Test plan

- [x] `.claude/hooks/ship-operator-step-gate.test.sh` — 19/19 pass (covers all four phrasings PR #4227 v1 slipped past + 6 command-trigger fixtures + syntax check).
- [x] `cd apps/web-platform && tsc --noEmit` — passes (handler change is a one-line `||` fallback).
- [x] Hook executable bit set; wired in `.claude/settings.json` after `ship-unpushed-commits-gate.sh` per sibling-hook ordering convention.

## What this changes for the agent from now on

When `/soleur:work` drafts a PR body with `Operator:` / `T+Nh verify` / `Within Nh: file` bullets, the PreToolUse hook at `gh pr ready` denies until they're either inlined or tracked via a `deferred-automation` issue. The work skill's new §Post-Merge Section Self-Audit gives the agent an active 6-row pattern→action playbook so the gate rarely needs to fire.

Per the operator's request ("modify the workflow so those things are entirely automatically driven by Soleur from now on").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
