### PR TITLE
fix(infra): ci-deploy.sh pipefail on missing VECTOR_CLI_* env breaks rollback

### DIFF
--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -620,8 +620,17 @@ case "$COMPONENT" in
     docker rm "$INNGEST_EXTRACT_CONTAINER" >/dev/null 2>&1 || true
     INNGEST_CLI_VERSION=$(printf '%s\n' "$image_env" | grep '^INNGEST_CLI_VERSION=' | cut -d= -f2-)
     INNGEST_CLI_SHA256=$(printf '%s\n' "$image_env" | grep '^INNGEST_CLI_SHA256=' | cut -d= -f2-)
-    VECTOR_CLI_VERSION=$(printf '%s\n' "$image_env" | grep '^VECTOR_CLI_VERSION=' | cut -d= -f2-)
-    VECTOR_CLI_SHA256=$(printf '%s\n' "$image_env" | grep '^VECTOR_CLI_SHA256=' | cut -d= -f2-)
+    # `|| true` is load-bearing: ci-deploy.sh runs under `set -euo pipefail`;
+    # grep-no-match returns 1, which `pipefail` propagates as the pipeline
+    # exit, which `$(...)` captures as the assignment exit. set -e then exits
+    # the script BEFORE final_write_state runs, and the EXIT trap writes
+    # reason=unhandled. Old inngest-bootstrap images (pre-TR9 PR-5) don't carry
+    # these env vars; rollback to such an image MUST stay functional. Missing
+    # values flow through to the bootstrap's `${VECTOR_CLI_VERSION:-}`
+    # warn-and-skip guard. Hotfix surfaced 2026-05-21 — v1.0.3 baseline rollback
+    # failed with reason=unhandled after TR9 PR-5 introduced this extraction.
+    VECTOR_CLI_VERSION=$(printf '%s\n' "$image_env" | grep '^VECTOR_CLI_VERSION=' | cut -d= -f2- || true)
+    VECTOR_CLI_SHA256=$(printf '%s\n' "$image_env" | grep '^VECTOR_CLI_SHA256=' | cut -d= -f2- || true)
     if [[ -z "$INNGEST_CLI_VERSION" || -z "$INNGEST_CLI_SHA256" ]]; then
       logger -t "$LOG_TAG" "FAILED: image missing INNGEST_CLI_{VERSION,SHA256} ENV"
       rm -rf "$INNGEST_EXTRACT_DIR"

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -438,8 +438,12 @@ runcmd:
     chmod +x "$EXTRACT_DIR/inngest-bootstrap.sh"
     INNGEST_CLI_VERSION=$(printf '%s\n' "$image_env" | grep '^INNGEST_CLI_VERSION=' | head -1 | cut -d= -f2-)
     INNGEST_CLI_SHA256=$(printf '%s\n' "$image_env" | grep '^INNGEST_CLI_SHA256=' | head -1 | cut -d= -f2-)
-    VECTOR_CLI_VERSION=$(printf '%s\n' "$image_env" | grep '^VECTOR_CLI_VERSION=' | head -1 | cut -d= -f2-)
-    VECTOR_CLI_SHA256=$(printf '%s\n' "$image_env" | grep '^VECTOR_CLI_SHA256=' | head -1 | cut -d= -f2-)
+    # `|| true` for symmetry with ci-deploy.sh's hotfix (which runs under
+    # `set -o pipefail` — this block doesn't, but defense-in-depth costs
+    # nothing). Bootstrap script's `${VECTOR_CLI_VERSION:-}` guard skips
+    # Vector install gracefully on empty values.
+    VECTOR_CLI_VERSION=$(printf '%s\n' "$image_env" | grep '^VECTOR_CLI_VERSION=' | head -1 | cut -d= -f2- || true)
+    VECTOR_CLI_SHA256=$(printf '%s\n' "$image_env" | grep '^VECTOR_CLI_SHA256=' | head -1 | cut -d= -f2- || true)
     env "INNGEST_CLI_VERSION=$INNGEST_CLI_VERSION" "INNGEST_CLI_SHA256=$INNGEST_CLI_SHA256" \
         "VECTOR_CLI_VERSION=$VECTOR_CLI_VERSION" "VECTOR_CLI_SHA256=$VECTOR_CLI_SHA256" \
       bash "$EXTRACT_DIR/inngest-bootstrap.sh"


### PR DESCRIPTION
## Summary

Hotfix for #4250 (TR9 PR-5 observability stack) — `ci-deploy.sh`'s new VECTOR_CLI_* env extraction breaks under `set -euo pipefail` when deploying an OLD inngest-bootstrap image (pre-TR9 PR-5) that doesn't carry those env vars. The grep returns 1 (no match) → pipefail → script exits before `final_write_state` → EXIT trap writes `reason=unhandled` → rollback path is blocked.

Surfaced live during TR9 PR-5 rollout this afternoon: `v1.1.0` deploy failed with `inngest_bootstrap_failed`; rollback to known-good `v1.0.3` then failed with `unhandled`, confirming the pipefail bug.

## Fix

Append `|| true` to both VECTOR_CLI_* extractions in `ci-deploy.sh`. Missing values flow through to the bootstrap script's existing `${VECTOR_CLI_VERSION:-}` warn-and-skip guard — rollback completes cleanly with Vector remaining un-installed (correct state on pre-TR9 images).

Same defensive treatment applied to `cloud-init.yml` for symmetry (its `| head -1 | cut` shape already masks grep's exit under `set -e` alone, but the `|| true` is harmless and prevents a future drift bug).

## Test plan

- [x] `bash -n` syntax check passes on both files
- [ ] Once merged + `apply-deploy-pipeline-fix` re-uploads ci-deploy.sh, rollback to `v1.0.3` should succeed (verifies the trap path is no longer broken)

Ref #4250
