### PR TITLE
fix(infra): escape templatefile interpolation in cloud-init.yml comment

### DIFF
--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -440,8 +440,10 @@ runcmd:
     INNGEST_CLI_SHA256=$(printf '%s\n' "$image_env" | grep '^INNGEST_CLI_SHA256=' | head -1 | cut -d= -f2-)
     # `|| true` for symmetry with ci-deploy.sh's hotfix (which runs under
     # `set -o pipefail` — this block doesn't, but defense-in-depth costs
-    # nothing). Bootstrap script's `${VECTOR_CLI_VERSION:-}` guard skips
-    # Vector install gracefully on empty values.
+    # nothing). Bootstrap script's bash `:-`-default guard on VECTOR_CLI_VERSION
+    # skips Vector install gracefully on empty values. (Comment intentionally
+    # avoids the literal $${ } shell-expansion syntax — this YAML is rendered
+    # by terraform `templatefile()` which would interpret it as TF interpolation.)
     VECTOR_CLI_VERSION=$(printf '%s\n' "$image_env" | grep '^VECTOR_CLI_VERSION=' | head -1 | cut -d= -f2- || true)
     VECTOR_CLI_SHA256=$(printf '%s\n' "$image_env" | grep '^VECTOR_CLI_SHA256=' | head -1 | cut -d= -f2- || true)
     env "INNGEST_CLI_VERSION=$INNGEST_CLI_VERSION" "INNGEST_CLI_SHA256=$INNGEST_CLI_SHA256" \


### PR DESCRIPTION
## Summary

Follow-up to #4252 (just merged). My hotfix comment in `cloud-init.yml` contained `${VECTOR_CLI_VERSION:-}` as a literal — but Terraform's `templatefile()` processes this YAML and interprets `${...}` as TF interpolation. The `:-` is invalid TF syntax, breaking `terraform plan/apply`.

Surfaced via `apply-deploy-pipeline-fix.yml` run `26235709975` (failure on the #4252 merge SHA).

## Fix

Reword the comment to avoid `${...}` entirely.

## Test plan

- [x] `terraform validate` on `apps/web-platform/infra/` — passes after fix
- [ ] Once merged, `apply-deploy-pipeline-fix` should succeed → ci-deploy.sh + sudoers + cloud-init re-upload to Hetzner → v1.0.3 rollback test should clear `reason=unhandled`

Ref #4252 #4250
