### PR TITLE
feat(infra): surface bootstrap stderr via deploy-state + trace Vector block

### DIFF
--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -647,11 +647,25 @@ case "$COMPONENT" in
     # /etc/sudoers.d/deploy-inngest-bootstrap (provisioned by Terraform)
     # pins the exact command and env_keep's the four version vars (#4144 + TR9 PR-5).
     export INNGEST_CLI_VERSION INNGEST_CLI_SHA256 VECTOR_CLI_VERSION VECTOR_CLI_SHA256
+    # Capture stderr to a file so a non-zero exit's last lines are surfaced
+    # via cat-deploy-state (no-SSH debugging per hr-no-ssh-fallback-in-runbooks
+    # and the TR9 PR-5 observability stack). The bootstrap script logs to
+    # journald + stdout; stderr captures bash's own diagnostics (set -x,
+    # syntax errors, unbound var traps) which journald wouldn't show.
+    BOOTSTRAP_STDERR=/tmp/inngest-bootstrap-stderr.log
+    rm -f "$BOOTSTRAP_STDERR"
     if ! sudo --preserve-env=INNGEST_CLI_VERSION,INNGEST_CLI_SHA256,VECTOR_CLI_VERSION,VECTOR_CLI_SHA256 \
-        /usr/bin/bash /tmp/inngest-extract/inngest-bootstrap.sh; then
-      logger -t "$LOG_TAG" "FAILED: inngest-bootstrap.sh non-zero exit"
+        /usr/bin/bash /tmp/inngest-extract/inngest-bootstrap.sh 2> "$BOOTSTRAP_STDERR"; then
+      # Extract a SHORT (≤400 char) reason suffix from the stderr tail so
+      # cat-deploy-state's JSON reason field carries actionable detail.
+      # Strip control bytes that would break JSON encoding.
+      stderr_tail=$(tail -c 600 "$BOOTSTRAP_STDERR" 2>/dev/null \
+        | tr -d '\r' | tr '\n' '|' | tr -dc '[:print:]|' | tail -c 400)
+      logger -t "$LOG_TAG" "FAILED: inngest-bootstrap.sh non-zero exit; stderr_tail=${stderr_tail}"
       rm -rf "$INNGEST_EXTRACT_DIR"
-      final_write_state 1 "inngest_bootstrap_failed"
+      # Reason field carries the stderr tail so cat-deploy-state surfaces it
+      # via /hooks/deploy-status without requiring SSH to journalctl.
+      final_write_state 1 "inngest_bootstrap_failed:${stderr_tail}"
       exit 1
     fi
 

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -440,8 +440,10 @@ runcmd:
     INNGEST_CLI_SHA256=$(printf '%s\n' "$image_env" | grep '^INNGEST_CLI_SHA256=' | head -1 | cut -d= -f2-)
     # `|| true` for symmetry with ci-deploy.sh's hotfix (which runs under
     # `set -o pipefail` — this block doesn't, but defense-in-depth costs
-    # nothing). Bootstrap script's `${VECTOR_CLI_VERSION:-}` guard skips
-    # Vector install gracefully on empty values.
+    # nothing). Bootstrap script's bash `:-`-default guard on VECTOR_CLI_VERSION
+    # skips Vector install gracefully on empty values. (Comment intentionally
+    # avoids the literal $${ } shell-expansion syntax — this YAML is rendered
+    # by terraform `templatefile()` which would interpret it as TF interpolation.)
     VECTOR_CLI_VERSION=$(printf '%s\n' "$image_env" | grep '^VECTOR_CLI_VERSION=' | head -1 | cut -d= -f2- || true)
     VECTOR_CLI_SHA256=$(printf '%s\n' "$image_env" | grep '^VECTOR_CLI_SHA256=' | head -1 | cut -d= -f2- || true)
     env "INNGEST_CLI_VERSION=$INNGEST_CLI_VERSION" "INNGEST_CLI_SHA256=$INNGEST_CLI_SHA256" \

--- a/apps/web-platform/infra/inngest-bootstrap.sh
+++ b/apps/web-platform/infra/inngest-bootstrap.sh
@@ -293,6 +293,15 @@ fi
 log "bootstrap complete: inngest-server $INNGEST_CLI_VERSION active on 127.0.0.1:8288"
 
 # ----------------------------------------------------------------------
+# Vector block diagnostic: bash trace enabled for the entire Vector
+# install/config/start section. The trace lines write to stderr which
+# ci-deploy.sh captures into /tmp/inngest-bootstrap-stderr.log; the
+# `final_write_state` failure path surfaces the last ~400 chars via the
+# /hooks/deploy-status endpoint (no SSH needed). Will be reverted to
+# `set +x` only after Vector v1.1.x is verified live on prd.
+set -x
+
+# ----------------------------------------------------------------------
 # Vector observability shipper (TR9 PR-5 / observability stack).
 #
 # Streams ERROR+ journald lines AND host_metrics from this VM to Sentry's


### PR DESCRIPTION
## Summary

Two complementary diagnostic additions to enable no-SSH debugging of the v1.1.0 inngest-bootstrap deploy failure (the OCI image bump that introduced Vector but exits non-zero in ~9s with no surfacable log).

## Changes

1. **`ci-deploy.sh`** — captures bootstrap stderr to `/tmp/inngest-bootstrap-stderr.log`; on non-zero exit, extracts a 400-char printable tail and appends it to `final_write_state`'s `reason` field. `cat-deploy-state`'s `/hooks/deploy-status` endpoint already surfaces `reason` in its JSON response — so the next deploy failure is fully diagnoseable via `curl deploy-status`. **Permanent improvement** (benefits every future deploy, not just inngest).
2. **`inngest-bootstrap.sh`** — `set -x` at the start of the Vector block, so the trace lines reach stderr which ci-deploy.sh now captures. **Temporary diagnostic** (comment notes the revert path once v1.1.x is verified live).

Together: the next `vinngest-v1.1.1` deploy that fails will write its last bash trace + the failed command + the exit status into the deploy-state JSON. Visible via the existing webhook signed-GET endpoint — no SSH, no `docker exec`.

## Why not just SSH

`hr-no-ssh-fallback-in-runbooks` (added in #4250) explicitly forbids SSH/docker-exec as primary debug path. This PR is the discipline of making the diagnostic accessible the right way.

Ref #4250 (TR9 PR-5)
