### PR TITLE
chore(infra): reconcile github-app-manifest with live App state post-#4226

### DIFF
--- a/apps/web-platform/infra/github-app-manifest.json
+++ b/apps/web-platform/infra/github-app-manifest.json
@@ -20,10 +20,20 @@
     "administration": "write",
     "checks": "read",
     "contents": "write",
+    "issues": "read",
     "members": "read",
     "metadata": "read",
     "pull_requests": "write",
+    "repository_advisories": "read",
+    "secret_scanning_alerts": "read",
     "secrets": "write"
   },
-  "default_events": []
+  "default_events": [
+    "issues",
+    "pull_request",
+    "push",
+    "repository_advisory",
+    "secret_scanning_alert",
+    "workflow_run"
+  ]
 }

--- a/apps/web-platform/test/github-app-manifest-parity.test.ts
+++ b/apps/web-platform/test/github-app-manifest-parity.test.ts
@@ -42,18 +42,23 @@ const EXPECTED_TF_SECRETS = [
 
 // Exact set of permissions in the committed manifest. Reconciled to the live
 // App state at #4169 post-merge attestation (added `secrets: write` which the
-// live App already had but #4115 plan-time snapshot missed). The drift-guard
-// cron is the runtime signal for divergence; this test catches an in-band
-// manifest mutation that adds an unexpected permission via a malicious or
-// sloppy PR.
+// live App already had but #4115 plan-time snapshot missed). Extended again
+// after PR #4226 AC9 enablement granted `issues`, `repository_advisories`,
+// and `secret_scanning_alerts` at `read` so PR-H #3244's `triage.p0p1_issue`
+// and `security.cve_alert` event routes can deliver. The drift-guard cron is
+// the runtime signal for divergence; this test catches an in-band manifest
+// mutation that adds an unexpected permission via a malicious or sloppy PR.
 const EXPECTED_PERMISSION_KEYS = [
   "actions",
   "administration",
   "checks",
   "contents",
+  "issues",
   "members",
   "metadata",
   "pull_requests",
+  "repository_advisories",
+  "secret_scanning_alerts",
   "secrets",
 ];
 


### PR DESCRIPTION
## Summary

Reconciles `apps/web-platform/infra/github-app-manifest.json` with the live Soleur AI GitHub App state established during PR #4226's AC9 enablement.

Before this PR the manifest declared:
- `default_events: []`
- `default_permissions` lacking `issues`, `repository_advisories`, `secret_scanning_alerts`

…which would have re-introduced the operationally-inert state (zero webhook deliveries) on the next App provisioning — a latent regression of all 6 multi-source ingress event routes (PR-H #3244 + #4226).

## Changelog

### Web Platform

- `chore`: extend `default_permissions` with `issues: read`, `repository_advisories: read`, `secret_scanning_alerts: read` (matching the live App's current state).
- `chore`: extend `default_events` with the 6 events the live App now subscribes to: `issues`, `pull_request`, `push`, `repository_advisory`, `secret_scanning_alert`, `workflow_run`.
- `test`: extend `EXPECTED_PERMISSION_KEYS` in `github-app-manifest-parity.test.ts` to match.

## Test plan

- [x] `vitest run test/github-app-manifest-parity.test.ts` — all 11 parity tests pass with the new key set.
- [x] `jq` validates the JSON.
- [x] No live App changes — this only reconciles the source-of-truth artifact.

The drift-guard cron (`scheduled-github-app-drift-guard.yml`) will now see manifest == live state and stop emitting `permission_unexpected_grant`-class signals (which would have started firing the next time it ran against the live App's expanded permission set).

Ref #4226
Ref #4255

🤖 Generated with [Claude Code](https://claude.com/claude-code)
