### PR TITLE
fix(infra): mark /var/lib/vector + /etc/vector optional with - prefix

### DIFF
--- a/apps/web-platform/infra/webhook.service
+++ b/apps/web-platform/infra/webhook.service
@@ -32,7 +32,12 @@ PrivateTmp=true
 # its config + state dirs need bootstrap-time write access from inside this
 # namespace. Surfaced via v1.1.1 deploy diagnostic capture
 # (reason="mkdir: cannot create directory /etc/vector: Read-only file system").
-ReadWritePaths=/mnt/data /var/lock /etc/systemd/system /etc/default /var/lib/inngest /var/lib/vector /etc/vector /usr/local/bin
+# `-` prefix on /var/lib/vector + /etc/vector marks them optional:
+# systemd silently ignores the path if absent, instead of refusing to set up
+# the mount namespace (which on prior PR #4257 took webhook.service down
+# entirely until the dirs were created). Once inngest-bootstrap.sh creates
+# them on first v1.1.x deploy, they become real ReadWritePaths.
+ReadWritePaths=/mnt/data /var/lock /etc/systemd/system /etc/default /var/lib/inngest -/var/lib/vector -/etc/vector /usr/local/bin
 ReadOnlyPaths=/etc/webhook /etc/default/webhook-deploy
 TimeoutStopSec=180
 


### PR DESCRIPTION
## Summary

#4257's apply-pipeline failed at the post-apply verify step. terraform_data uploaded the new `webhook.service` and ran `systemctl restart webhook`. systemd refuses to set up the unit's mount namespace when a `ReadWritePaths` entry doesn't exist on disk — and `/var/lib/vector` + `/etc/vector` don't get created until the FIRST successful inngest-bootstrap.sh run (which can never happen if webhook is down).

## Fix

Add the `-` prefix to both directories. systemd silently skips paths prefixed with `-` if they don't exist (documented in `systemd.exec(5)`). Once the first v1.1.x deploy creates the dirs (via the bootstrap's `mkdir -p $VECTOR_CONFIG_DIR /var/lib/vector`), subsequent webhook restarts pick them up as real allowlist entries.

Same shape as systemd's idiomatic `-/path/...` syntax for optional config/runtime directory references.

Ref #4250 (TR9 PR-5), #4257 (preceding attempt — should have been part of that PR but the failure mode only surfaced post-apply)
