### PR TITLE
feat(workflow): three-layer enforcement of soleur:followthrough directive

### DIFF
--- a/.claude/hooks/follow-through-directive-gate.sh
+++ b/.claude/hooks/follow-through-directive-gate.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) hook: blocks `gh issue create --label follow-through` when
+# the proposed body lacks a valid `<!-- soleur:followthrough -->` directive.
+#
+# Source rules: `/ship` Phase 7 Step 3.5.E (the parser self-test) +
+# `wg-pm-class-followthrough-for-operator-dogfood`. Converts the agent
+# honor-system rule into a mechanical gate at the `gh issue create` boundary.
+#
+# The hook rejects when ANY of:
+#   - body lacks the `<!-- soleur:followthrough` opening marker
+#   - body lacks the closing `-->`
+#   - parsed `script=` is empty OR doesn't resolve to an existing executable
+#     file under `scripts/followthroughs/` (path-traversal-safe via realpath)
+#   - parsed `earliest=` is empty OR doesn't parse via `date -u -d`
+#
+# Why it exists: PR #4226's ship Phase 7 Step 3.5 created three follow-through
+# issues (#4244, #4245, #4246) — NONE with a directive. The sweeper had nothing
+# to evaluate, and the issues would have rotted open. Surfaced at the workflow
+# audit immediately after merge. See knowledge-base learning
+# `2026-05-21-followthrough-directive-enforcement.md`.
+#
+# Contract-inherited PreToolUse(Bash) input shape:
+#   .tool_input.command  (string)
+#   .cwd                 (string)
+#
+# Fail-open conditions (exit 0 silently):
+#   - not a `gh issue create` call
+#   - command doesn't reference the `follow-through` label
+#   - input lacks .cwd or path is not an absolute existing directory
+#   - cannot extract body (no --body / --body-file / file unreadable)
+#
+# Fail-closed conditions (deny + emit_incident):
+#   - body lacks directive OR directive fails parser self-test
+
+set -eo pipefail
+
+# shellcheck source=lib/incidents.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/incidents.sh"
+
+INPUT=$(cat)
+eval "$(echo "$INPUT" | jq -r '@sh "CMD=\(.tool_input.command // "") WORK_DIR=\(.cwd // "")"' 2>/dev/null || echo 'CMD="" WORK_DIR=""')"
+: "${CMD:=}"
+: "${WORK_DIR:=}"
+
+# Match `gh issue create` (anchored at start of pipeline OR after &&/||/;).
+# The same word-boundary form used by ship-unpushed-commits-gate.sh.
+if ! echo "$CMD" | grep -qE '(^|&&|\|\||;)\s*gh\s+issue\s+create(\s|$)'; then
+  exit 0
+fi
+
+# Only fire when the create includes the `follow-through` label. We accept
+# either `--label follow-through` (single use) or `--label "follow-through"`
+# (quoted) — both shapes appear in /ship Phase 7 Step 3.5.
+if ! echo "$CMD" | grep -qE -- '--label[[:space:]]+["'"'"']?follow-through(["'"'"']|[[:space:]]|$)'; then
+  exit 0
+fi
+
+# Validate WORK_DIR: required for body-file resolution.
+if [[ "$WORK_DIR" != /* ]] || [[ ! -d "$WORK_DIR" ]]; then
+  exit 0
+fi
+
+# Extract the body. /ship's Phase 7 Step 3.5 always uses --body-file with a
+# /tmp path; older inline-call sites may use --body "<heredoc>". Handle both.
+BODY_FILE=$(echo "$CMD" | grep -oE -- '--body-file[[:space:]]+[^[:space:]]+' | head -1 | awk '{print $2}')
+BODY_INLINE=""
+if [[ -z "$BODY_FILE" ]]; then
+  # --body "<string>" or --body '<string>' or --body $'<string>'. Pull
+  # everything after --body that's quoted; bash's word-splitting in the
+  # caller's shell has already collapsed whitespace, so we work with the
+  # exact bytes the hook received from jq @sh.
+  # Use perl for greedy regex; sed -E can't do non-greedy across newlines.
+  BODY_INLINE=$(echo "$CMD" | perl -0777 -ne 'if (/--body[[:space:]]+(["'"'"'])(.+?)(?<!\\)\1/s) { print 2; }' || true)
+fi
+
+# Resolve to a real file we can read.
+PARSED_BODY=""
+if [[ -n "$BODY_FILE" ]]; then
+  # Resolve relative-to-WORK_DIR for safety.
+  if [[ "$BODY_FILE" != /* ]]; then
+    BODY_FILE="${WORK_DIR}/${BODY_FILE}"
+  fi
+  if [[ ! -f "$BODY_FILE" ]] || [[ ! -r "$BODY_FILE" ]]; then
+    # File doesn't exist at hook time → caller bug, not our class. Fail open.
+    exit 0
+  fi
+  PARSED_BODY=$(cat "$BODY_FILE")
+elif [[ -n "$BODY_INLINE" ]]; then
+  PARSED_BODY="$BODY_INLINE"
+else
+  # No --body or --body-file → no body to validate. `gh issue create` will
+  # prompt interactively, which won't happen under the Bash tool anyway.
+  exit 0
+fi
+
+# === Directive presence + parser self-test ===
+
+# Open marker. Mirrors scripts/sweep-followthroughs.sh's awk pattern at
+# the `^<!-- *soleur:followthrough` anchor.
+if ! printf '%s' "$PARSED_BODY" | grep -qE '^[[:space:]]*<!-- *soleur:followthrough'; then
+  emit_incident "wg-pm-class-followthrough-for-operator-dogfood" deny \
+    "Follow-through issues MUST embed the soleur:foll" "$CMD"
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "BLOCKED: `gh issue create --label follow-through` requires a `<!-- soleur:followthrough script=... earliest=... [secrets=...] -->` directive in the issue body. Without it the daily sweeper has nothing to evaluate against and the issue will rot open. See `/ship` Phase 7 Step 3.5.A-F and `plugins/soleur/skills/ship/references/followthrough-stub-template.sh` for the canonical pattern."
+    }
+  }'
+  exit 0
+fi
+
+# Closing marker on the same/subsequent line.
+if ! printf '%s' "$PARSED_BODY" | grep -qE -- '-->'; then
+  emit_incident "wg-pm-class-followthrough-for-operator-dogfood" deny \
+    "Follow-through directive MUST include closing -" "$CMD"
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "BLOCKED: `<!-- soleur:followthrough ...` directive is missing its closing `-->`. The awk parser at scripts/sweep-followthroughs.sh expects both markers."
+    }
+  }'
+  exit 0
+fi
+
+# Extract script= and earliest= using the same awk parser the sweeper uses.
+# Inlined here so the hook is self-contained (no source dependency on a
+# repo file that may move). If you change the parser, mirror BOTH places.
+PARSED=$(printf '%s' "$PARSED_BODY" | awk '
+  BEGIN { in_dir = 0; closing = 0; fence = 0 }
+  /^```/ { fence = !fence; next }
+  fence { next }
+  /^[[:space:]]*<!-- *soleur:followthrough/ { in_dir = 1 }
+  /-->/ && in_dir { closing = 1 }
+  in_dir {
+    gsub(/^[[:space:]]*<!-- *soleur:followthrough/, "")
+    gsub(/-->/, "")
+    for (i = 1; i <= NF; i++) {
+      if ($i ~ /^script=/)   { sub(/^script=/, "", $i);   print "script "   $i }
+      if ($i ~ /^earliest=/) { sub(/^earliest=/, "", $i); print "earliest " $i }
+    }
+  }
+  closing { in_dir = 0; closing = 0 }
+')
+
+SCRIPT_REL=$(printf '%s\n' "$PARSED" | awk '/^script /{print $2; exit}')
+EARLIEST=$(printf '%s\n' "$PARSED" | awk '/^earliest /{print $2; exit}')
+
+if [[ -z "$SCRIPT_REL" ]]; then
+  emit_incident "wg-pm-class-followthrough-for-operator-dogfood" deny \
+    "Follow-through directive MUST set script=<path>" "$CMD"
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "BLOCKED: directive parsed but `script=` is empty. Provide `script=scripts/followthroughs/<feature>-<issue>.sh` per /ship Phase 7 Step 3.5.A."
+    }
+  }'
+  exit 0
+fi
+
+if [[ -z "$EARLIEST" ]]; then
+  emit_incident "wg-pm-class-followthrough-for-operator-dogfood" deny \
+    "Follow-through directive MUST set earliest=<UTC>" "$CMD"
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "BLOCKED: directive parsed but `earliest=` is empty. Set `earliest=YYYY-MM-DDTHH:MM:SSZ` per /ship Phase 7 Step 3.5.D — the sweeper uses this to gate first evaluation."
+    }
+  }'
+  exit 0
+fi
+
+# Path-traversal guard: realpath under WORK_DIR/scripts/followthroughs/.
+# Same logic as /ship Phase 7 Step 3.5.E. A path using `..` traversal that
+# escapes the followthroughs root after canonicalization is rejected.
+SCRIPT_ABS=$(realpath -m "${WORK_DIR}/${SCRIPT_REL}" 2>/dev/null || echo "")
+SCRIPTS_ROOT_ABS=$(realpath -m "${WORK_DIR}/scripts/followthroughs" 2>/dev/null || echo "")
+if [[ -z "$SCRIPT_ABS" ]] || [[ -z "$SCRIPTS_ROOT_ABS" ]] || [[ "$SCRIPT_ABS" != "$SCRIPTS_ROOT_ABS"/* ]]; then
+  emit_incident "wg-pm-class-followthrough-for-operator-dogfood" deny \
+    "Follow-through script path must resolve under sc" "$CMD"
+  jq -n --arg s "$SCRIPT_REL" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: ("BLOCKED: directive `script=" + $s + "` does not resolve under `scripts/followthroughs/`. Use `script=scripts/followthroughs/<feature>-<issue>.sh` so the sweeper can locate the verification script.")
+    }
+  }'
+  exit 0
+fi
+
+# Script must exist + be executable. The script existence check catches
+# the most common failure: the agent composes the directive but forgets to
+# scaffold the stub. (PR #4178 was filed in this exact failure shape and
+# rotted open for 24h before retrofit.)
+if [[ ! -f "$SCRIPT_ABS" ]]; then
+  emit_incident "wg-pm-class-followthrough-for-operator-dogfood" deny \
+    "Follow-through script does not exist on disk; s" "$CMD"
+  jq -n --arg s "$SCRIPT_REL" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: ("BLOCKED: directive references `" + $s + "` but the file does not exist. Scaffold the stub via `cp plugins/soleur/skills/ship/references/followthrough-stub-template.sh " + $s + "` and customize before filing the issue.")
+    }
+  }'
+  exit 0
+fi
+if [[ ! -x "$SCRIPT_ABS" ]]; then
+  emit_incident "wg-pm-class-followthrough-for-operator-dogfood" deny \
+    "Follow-through script is not executable; chmod " "$CMD"
+  jq -n --arg s "$SCRIPT_REL" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: ("BLOCKED: script `" + $s + "` is not executable. Run `chmod +x " + $s + "` before filing.")
+    }
+  }'
+  exit 0
+fi
+
+# Validate `earliest` parses via `date -u -d`. The sweeper uses the same
+# command at iso_to_epoch — keeping the validator in sync.
+if ! date -u -d "$EARLIEST" +%s >/dev/null 2>&1; then
+  emit_incident "wg-pm-class-followthrough-for-operator-dogfood" deny \
+    "Follow-through earliest= must parse via date -u" "$CMD"
+  jq -n --arg e "$EARLIEST" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: ("BLOCKED: `earliest=" + $e + "` does not parse. Use ISO-8601 UTC, e.g. `earliest=2026-05-22T15:00:00Z`.")
+    }
+  }'
+  exit 0
+fi
+
+# All checks passed.
+exit 0

--- a/.claude/hooks/follow-through-directive-gate.test.sh
+++ b/.claude/hooks/follow-through-directive-gate.test.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# Fixture-based tests for follow-through-directive-gate.sh. Each test composes
+# a PreToolUse(Bash) input shape, pipes it to the hook, asserts the JSON
+# permissionDecision matches expectation.
+#
+# Isolation pattern matches ship-unpushed-commits-gate.test.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/follow-through-directive-gate.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq missing"; exit 0; }
+command -v realpath >/dev/null 2>&1 || { echo "SKIP: realpath missing"; exit 0; }
+
+# Build a tmp WORK_DIR with scripts/followthroughs/ + an existing executable
+# stub. Echoes the path.
+make_work_dir() {
+  local tmp="$1"
+  mkdir -p "$tmp/scripts/followthroughs"
+  cat > "$tmp/scripts/followthroughs/ok-1234.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$tmp/scripts/followthroughs/ok-1234.sh"
+
+  # Non-executable stub (chmod -x) to exercise the executable-bit gate
+  cat > "$tmp/scripts/followthroughs/not-executable-1235.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod 644 "$tmp/scripts/followthroughs/not-executable-1235.sh"
+
+  echo "$tmp"
+}
+
+# Compose the PreToolUse input as JSON. Args: <command> <cwd>
+make_input() {
+  jq -n --arg cmd "$1" --arg cwd "$2" '{
+    tool_name: "Bash",
+    tool_input: { command: $cmd },
+    cwd: $cwd,
+  }'
+}
+
+run() {
+  local label="$1" input="$2"
+  TOTAL=$((TOTAL + 1))
+  local out rc
+  out=$(printf '%s' "$input" | "$HOOK" 2>&1)
+  rc=$?
+  printf '[T%d] %s — rc=%d\n' "$TOTAL" "$label" "$rc"
+  if [[ -n "$out" ]]; then
+    printf '       output: %s\n' "$out" | head -c 300
+    printf '\n'
+  fi
+  HOOK_OUT="$out"
+  HOOK_RC="$rc"
+}
+
+assert_pass() {
+  if [[ "$HOOK_RC" -ne 0 ]]; then
+    echo "       FAIL: expected exit 0, got $HOOK_RC"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -n "$HOOK_OUT" ]]; then
+    # Hook fail-open path: silent exit 0
+    echo "       FAIL: expected silent fail-open, got output"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  PASS=$((PASS + 1))
+}
+
+assert_deny() {
+  local expected_substring="$1"
+  if [[ "$HOOK_RC" -ne 0 ]]; then
+    echo "       FAIL: expected exit 0 (deny JSON returned via stdout), got $HOOK_RC"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -z "$HOOK_OUT" ]]; then
+    echo "       FAIL: expected deny JSON, got empty output"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  local decision
+  decision=$(printf '%s' "$HOOK_OUT" | jq -r '.hookSpecificOutput.permissionDecision // ""' 2>/dev/null)
+  if [[ "$decision" != "deny" ]]; then
+    echo "       FAIL: expected permissionDecision=deny, got '$decision'"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if ! printf '%s' "$HOOK_OUT" | grep -q "$expected_substring"; then
+    echo "       FAIL: deny reason missing substring '$expected_substring'"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  PASS=$((PASS + 1))
+}
+
+# === T1: fail-open on non-issue-create commands ===
+TMP=$(mktemp -d)
+make_work_dir "$TMP" > /dev/null
+INPUT=$(make_input "git status" "$TMP")
+run "T1: git status is not gh issue create — fail open" "$INPUT"
+assert_pass
+rm -rf "$TMP"
+
+# === T2: fail-open on gh issue create WITHOUT follow-through label ===
+TMP=$(mktemp -d)
+make_work_dir "$TMP" > /dev/null
+INPUT=$(make_input 'gh issue create --title "test" --label bug --body "no directive needed"' "$TMP")
+run "T2: no follow-through label — fail open" "$INPUT"
+assert_pass
+rm -rf "$TMP"
+
+# === T3: deny when follow-through label + body lacks directive ===
+TMP=$(mktemp -d)
+make_work_dir "$TMP" > /dev/null
+cat > "$TMP/body.md" <<'EOF'
+## Follow-Through
+
+Some text. No directive.
+EOF
+INPUT=$(make_input "gh issue create --title 'test' --label follow-through --body-file $TMP/body.md" "$TMP")
+run "T3: directive missing — deny" "$INPUT"
+assert_deny "requires a"
+rm -rf "$TMP"
+
+# === T4: deny when directive open marker present but no closing --> ===
+TMP=$(mktemp -d)
+make_work_dir "$TMP" > /dev/null
+cat > "$TMP/body.md" <<'EOF'
+## Follow-Through
+
+<!-- soleur:followthrough script=scripts/followthroughs/ok-1234.sh earliest=2026-05-22T00:00:00Z
+
+(missing closing marker)
+EOF
+INPUT=$(make_input "gh issue create --title 'test' --label follow-through --body-file $TMP/body.md" "$TMP")
+run "T4: directive missing closing --> — deny" "$INPUT"
+assert_deny "closing"
+rm -rf "$TMP"
+
+# === T5: deny when script= empty ===
+TMP=$(mktemp -d)
+make_work_dir "$TMP" > /dev/null
+cat > "$TMP/body.md" <<'EOF'
+## Follow-Through
+
+<!-- soleur:followthrough earliest=2026-05-22T00:00:00Z -->
+EOF
+INPUT=$(make_input "gh issue create --title 'test' --label follow-through --body-file $TMP/body.md" "$TMP")
+run "T5: missing script= — deny" "$INPUT"
+assert_deny "script="
+rm -rf "$TMP"
+
+# === T6: deny when earliest= empty ===
+TMP=$(mktemp -d)
+make_work_dir "$TMP" > /dev/null
+cat > "$TMP/body.md" <<'EOF'
+## Follow-Through
+
+<!-- soleur:followthrough script=scripts/followthroughs/ok-1234.sh -->
+EOF
+INPUT=$(make_input "gh issue create --title 'test' --label follow-through --body-file $TMP/body.md" "$TMP")
+run "T6: missing earliest= — deny" "$INPUT"
+assert_deny "earliest="
+rm -rf "$TMP"
+
+# === T7: deny when script path escapes scripts/followthroughs/ via .. traversal ===
+TMP=$(mktemp -d)
+make_work_dir "$TMP" > /dev/null
+cat > "$TMP/body.md" <<'EOF'
+## Follow-Through
+
+<!-- soleur:followthrough script=scripts/followthroughs/../../etc/passwd earliest=2026-05-22T00:00:00Z -->
+EOF
+INPUT=$(make_input "gh issue create --title 'test' --label follow-through --body-file $TMP/body.md" "$TMP")
+run "T7: script path traversal escape — deny" "$INPUT"
+assert_deny "does not resolve under"
+rm -rf "$TMP"
+
+# === T8: deny when script does not exist on disk ===
+TMP=$(mktemp -d)
+make_work_dir "$TMP" > /dev/null
+cat > "$TMP/body.md" <<'EOF'
+## Follow-Through
+
+<!-- soleur:followthrough script=scripts/followthroughs/missing-9999.sh earliest=2026-05-22T00:00:00Z -->
+EOF
+INPUT=$(make_input "gh issue create --title 'test' --label follow-through --body-file $TMP/body.md" "$TMP")
+run "T8: script does not exist — deny" "$INPUT"
+assert_deny "does not exist"
+rm -rf "$TMP"
+
+# === T9: deny when script is not executable ===
+TMP=$(mktemp -d)
+make_work_dir "$TMP" > /dev/null
+cat > "$TMP/body.md" <<'EOF'
+## Follow-Through
+
+<!-- soleur:followthrough script=scripts/followthroughs/not-executable-1235.sh earliest=2026-05-22T00:00:00Z -->
+EOF
+INPUT=$(make_input "gh issue create --title 'test' --label follow-through --body-file $TMP/body.md" "$TMP")
+run "T9: script not executable — deny" "$INPUT"
+assert_deny "not executable"
+rm -rf "$TMP"
+
+# === T10: deny when earliest= does not parse ===
+TMP=$(mktemp -d)
+make_work_dir "$TMP" > /dev/null
+cat > "$TMP/body.md" <<'EOF'
+## Follow-Through
+
+<!-- soleur:followthrough script=scripts/followthroughs/ok-1234.sh earliest=not-a-date -->
+EOF
+INPUT=$(make_input "gh issue create --title 'test' --label follow-through --body-file $TMP/body.md" "$TMP")
+run "T10: earliest does not parse — deny" "$INPUT"
+assert_deny "does not parse"
+rm -rf "$TMP"
+
+# === T11: PASS — valid directive + script + earliest ===
+TMP=$(mktemp -d)
+make_work_dir "$TMP" > /dev/null
+cat > "$TMP/body.md" <<'EOF'
+## Follow-Through
+
+<!-- soleur:followthrough
+  script=scripts/followthroughs/ok-1234.sh
+  earliest=2026-05-22T15:00:00Z
+  secrets=SOME_SECRET
+-->
+
+Verification details here.
+EOF
+INPUT=$(make_input "gh issue create --title 'test' --label follow-through --body-file $TMP/body.md" "$TMP")
+run "T11: valid directive — pass" "$INPUT"
+assert_pass
+rm -rf "$TMP"
+
+# === T12: fail-open when WORK_DIR is not a directory ===
+INPUT=$(make_input "gh issue create --label follow-through --body 'no directive'" "/non/existent/path")
+run "T12: invalid WORK_DIR — fail open" "$INPUT"
+assert_pass
+
+# === T13: deny on quoted label (e.g. --label "follow-through") ===
+TMP=$(mktemp -d)
+make_work_dir "$TMP" > /dev/null
+cat > "$TMP/body.md" <<'EOF'
+no directive
+EOF
+INPUT=$(make_input "gh issue create --title 'test' --label \"follow-through\" --body-file $TMP/body.md" "$TMP")
+run "T13: quoted label — deny" "$INPUT"
+assert_deny "requires a"
+rm -rf "$TMP"
+
+# === T14: fail-open when label substring matches but does not exactly match
+# the follow-through label (e.g., 'follow-through-meta'). ===
+TMP=$(mktemp -d)
+make_work_dir "$TMP" > /dev/null
+cat > "$TMP/body.md" <<'EOF'
+no directive needed for follow-through-meta label
+EOF
+INPUT=$(make_input "gh issue create --title 'test' --label follow-through-meta --body-file $TMP/body.md" "$TMP")
+run "T14: label superset 'follow-through-meta' — fail open" "$INPUT"
+assert_pass
+rm -rf "$TMP"
+
+# === Summary ===
+printf '\n=== Results: %d/%d passed, %d failed ===\n' "$PASS" "$TOTAL" "$FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -67,6 +67,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/follow-through-directive-gate.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/ship-runbook-ssh-gate.sh"
           }
         ]

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -1352,6 +1352,27 @@ This complements the PreToolUse hook [`.claude/hooks/pre-merge-rebase.sh`](../..
    is the cheapest forward defense; the contract is asserted at PR time by
    `plugins/soleur/test/ship-followthrough-directive.test.sh`.
 
+   **Mechanical backstop** (defense-in-depth on top of this honor-system gate):
+   the PreToolUse hook [`.claude/hooks/follow-through-directive-gate.sh`](../../../../.claude/hooks/follow-through-directive-gate.sh)
+   intercepts every `gh issue create --label follow-through` call at the Bash-tool
+   boundary and re-runs the same awk parser against the resolved `--body-file` or
+   inline `--body`. The agent step above MUST still run — the hook is the second
+   net, not the first. The hook denies the tool call with a structured error if the
+   directive is absent, malformed, or references a missing/non-executable script.
+   See `.claude/hooks/follow-through-directive-gate.test.sh` for the cases the hook
+   enforces.
+
+   **Step 3.5.E.2 — Post-create re-validation.** After `gh issue create` succeeds,
+   re-fetch the just-created issue body via `gh issue view <N> --json body --jq .body`
+   and re-run the same awk parser against it. The on-create body MUST extract the
+   same `script`/`earliest` tokens as the proposed body. This catches the rare class
+   where GitHub's API silently truncates or mangles a body whose markdown collides
+   with one of GitHub's own template processors (the `<!-- ... -->` shape is
+   markdown-suppressed but mishandled by some legacy edit-path-validators). If the
+   post-create parse diverges from the proposed parse, fail the step: the issue
+   exists on GitHub but is sweeper-invisible — close it with a comment naming the
+   divergence and retry the create.
+
    **Step 3.5.F — Operator-only ack.** When the chosen pattern is operator-confirmed
    (Step 3.5.B), append a `## Operator instructions` block to the issue body explaining
    the `RESULT: PASS` / `RESULT: FAIL` comment sentinel the script greps for.

--- a/scripts/sweep-followthroughs.sh
+++ b/scripts/sweep-followthroughs.sh
@@ -115,6 +115,15 @@ run_one() {
 
   if [[ -z "${script:-}" ]]; then
     log "issue #$issue_num: no directive — skipping"
+    # Visibility: aggregate no-directive issues into the end-of-sweep
+    # summary. Without this, an issue filed without a directive (per the
+    # 2026-05-21 incident where #4244/#4245/#4246 all shipped directive-less)
+    # silently never gets evaluated. The summary surfaces the gap so the
+    # operator can either backfill the directive or close the issue as
+    # wontfix. Path: $NO_DIRECTIVE_FILE if set by main(), else no-op.
+    if [[ -n "${NO_DIRECTIVE_FILE:-}" ]]; then
+      printf '%s\n' "$issue_num" >> "$NO_DIRECTIVE_FILE"
+    fi
     return 0
   fi
 
@@ -269,6 +278,14 @@ $trimmed_out
 main() {
   log "sweep start (repo=$REPO dry_run=$DRY_RUN)"
 
+  # Tmpfile collects issue numbers that lack the soleur:followthrough
+  # directive. End-of-sweep summary surfaces them (closes #4244/#4245/#4246
+  # class — issues filed without a directive that the sweeper silently
+  # never evaluates).
+  NO_DIRECTIVE_FILE=$(mktemp -t followthrough-no-directive.XXXXXXXX.txt)
+  export NO_DIRECTIVE_FILE
+  trap 'rm -f "$NO_DIRECTIVE_FILE"' EXIT
+
   local issues_json
   issues_json=$(gh issue list --repo "$REPO" --label follow-through --state open --limit 50 --json number,body)
   local count
@@ -283,7 +300,32 @@ main() {
     run_one "$num" "$body" || fail "issue #$num: run_one returned non-zero (continuing)"
   done
 
-  log "sweep done"
+  # No-directive summary. If any issues lacked the directive, emit a
+  # structured warning section that bubbles to the workflow summary.
+  local no_dir_count=0
+  if [[ -s "$NO_DIRECTIVE_FILE" ]]; then
+    no_dir_count=$(wc -l < "$NO_DIRECTIVE_FILE" | tr -d '[:space:]')
+  fi
+  if [[ "$no_dir_count" -gt 0 ]]; then
+    log "WARN: $no_dir_count open follow-through issue(s) have no soleur:followthrough directive:"
+    while IFS= read -r issue_num; do
+      log "  - #$issue_num — needs directive or close as wontfix"
+    done < "$NO_DIRECTIVE_FILE"
+    # Emit to GITHUB_STEP_SUMMARY if running in CI so it appears in the
+    # workflow run page without forcing the operator to scroll the log.
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+      {
+        printf '### ⚠️ Follow-through issues missing directive (%d)\n\n' "$no_dir_count"
+        printf 'These issues carry the `follow-through` label but no `<!-- soleur:followthrough ... -->` block. The sweeper cannot evaluate them — they will rot open until manually addressed.\n\n'
+        while IFS= read -r issue_num; do
+          printf -- '- [#%s](https://github.com/%s/issues/%s)\n' "$issue_num" "$REPO" "$issue_num"
+        done < "$NO_DIRECTIVE_FILE"
+        printf '\nResolve each by either (a) adding the directive (see `plugins/soleur/skills/ship/SKILL.md` §Phase 7 Step 3.5.A-F), or (b) closing as wontfix with rationale.\n'
+      } >> "$GITHUB_STEP_SUMMARY"
+    fi
+  fi
+
+  log "sweep done (no_directive=$no_dir_count)"
 }
 
 # Allow tests to source this script without running main().


### PR DESCRIPTION
## Summary

Three independent enforcement layers for the `<!-- soleur:followthrough -->` directive on `follow-through`-labeled GitHub issues. Closes the workflow gap exposed by PR #4226: three follow-through issues (#4244, #4245, #4246) were filed without the directive — the sweeper had nothing to evaluate, and the issues would have rotted open. The `/ship` Phase 7 Step 3.5.E precondition gate is an honor-system rule that the agent rationalized around three times in the same session. Honor-system → mechanical, plus visibility + double-check.

**Layer 1 — PreToolUse hook (mechanical block).** New `.claude/hooks/follow-through-directive-gate.sh` intercepts `gh issue create --label follow-through` at the Bash-tool boundary, resolves `--body-file`/`--body`, re-runs the same awk parser the sweeper uses, and denies the create on any of: directive marker absent, closing `-->` missing, `script=` empty, `earliest=` unparseable, script path escapes `scripts/followthroughs/` (realpath traversal guard), referenced script doesn't exist or isn't executable. 14/14 test cases pass.

**Layer 2 — Sweeper visibility (catches what Layer 1 can't see).** `scripts/sweep-followthroughs.sh` now aggregates open follow-through issues that lack the directive into an end-of-sweep warning. When running under GitHub Actions, also writes the list to `$GITHUB_STEP_SUMMARY` so it surfaces in the workflow run page. Catches issues filed outside `/ship` (direct `gh` calls, GitHub UI).

**Layer 3 — Post-create re-validation in /ship.** `plugins/soleur/skills/ship/SKILL.md` Phase 7 Step 3.5.E.2 adds: after `gh issue create` succeeds, re-fetch the just-created body via `gh issue view <N> --json body` and re-run the same awk parser. Catches the rare class where GitHub's API silently truncates a markdown body.

All three layers share the **same awk parser** so the parsing contract stays single-source-of-truth across enforcement surfaces.

## Changelog

### Tooling

- `feat`: new `.claude/hooks/follow-through-directive-gate.sh` PreToolUse hook + companion `.test.sh` (14 cases — directive missing, closing marker missing, traversal escape, missing/non-executable scripts, unparseable earliest, fail-open paths).
- `feat`: wire the hook in `.claude/settings.json` after `ship-operator-step-gate.sh`.
- `feat`: extend `scripts/sweep-followthroughs.sh` to aggregate no-directive issues + emit end-of-sweep warning + write to `$GITHUB_STEP_SUMMARY` under CI.
- `docs`: `ship/SKILL.md` Phase 7 Step 3.5.E.2 — mandatory post-create re-validation step.

## Test plan

- [x] `bash .claude/hooks/follow-through-directive-gate.test.sh` — 14/14 pass.
- [x] `bash scripts/sweep-followthroughs.test.sh` — 21/21 pass (no regression on the directive parser core).
- [x] `bash scripts/test-all.sh` — 69/69 suites pass.

Ref #4226
Ref #4244 #4245 #4246 (the three issues that would have been blocked by Layer 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
