### PR TITLE
fix(infra): pre-create /etc/vector + /var/lib/vector in terraform_data remote-exec

### DIFF
--- a/.github/workflows/apply-deploy-pipeline-fix.yml
+++ b/.github/workflows/apply-deploy-pipeline-fix.yml
@@ -49,6 +49,11 @@ on:
       - "apps/web-platform/infra/canary-bundle-claim-check.sh"
       - "apps/web-platform/infra/hooks.json.tmpl"
       - "apps/web-platform/infra/deploy-inngest-bootstrap.sudoers"
+      # TR9 PR-5: server.tf carries the terraform_data.deploy_pipeline_fix
+      # remote-exec; new mkdir steps (e.g., for /var/lib/vector + /etc/vector)
+      # must auto-trigger this workflow. Path-only paths filter; no untrusted
+      # input flows into any shell command.
+      - "apps/web-platform/infra/server.tf"
   workflow_dispatch:
     inputs:
       reason:

--- a/apps/web-platform/infra/server.tf
+++ b/apps/web-platform/infra/server.tf
@@ -221,6 +221,11 @@ resource "terraform_data" "deploy_pipeline_fix" {
   # to the existing server. This resource is the sole path for pushing ci-deploy.sh,
   # webhook.service, cat-deploy-state.sh, canary-bundle-claim-check.sh, and
   # hooks.json updates to production (#2185, #3033).
+  # Sentinel string at the end forces re-recreation when the inline
+  # remote-exec list itself changes (terraform_data doesn't auto-detect
+  # provisioner-block content drift; only triggers_replace is consulted).
+  # Bump the sentinel suffix in lockstep with any inline edit so the
+  # remote host re-receives + re-runs the updated commands.
   triggers_replace = sha256(join(",", [
     file("${path.module}/ci-deploy.sh"),
     file("${path.module}/ci-deploy-wrapper.sh"),
@@ -229,6 +234,7 @@ resource "terraform_data" "deploy_pipeline_fix" {
     file("${path.module}/canary-bundle-claim-check.sh"),
     file("${path.module}/deploy-inngest-bootstrap.sudoers"),
     local.hooks_json,
+    "v2-pre-create-vector-dirs", # bump on inline remote-exec change
   ]))
 
   connection {
@@ -302,6 +308,15 @@ resource "terraform_data" "deploy_pipeline_fix" {
       # Redirects Doppler CLI config to /tmp (writable under PrivateTmp) instead of ~/.doppler
       # (blocked by ProtectHome=read-only). grep guard makes this idempotent.
       "grep -q DOPPLER_CONFIG_DIR /etc/default/webhook-deploy || printf 'DOPPLER_CONFIG_DIR=/tmp/.doppler\\nDOPPLER_ENABLE_VERSION_CHECK=false\\n' >> /etc/default/webhook-deploy",
+      # TR9 PR-5 / Vector observability shipper: pre-create the Vector dirs
+      # BEFORE webhook starts so the `-/var/lib/vector` `-/etc/vector`
+      # entries in webhook.service's ReadWritePaths are recognized as
+      # writable mounts inside the unit's namespace (systemd's `-` prefix
+      # only suppresses fail-on-missing — it does NOT grant write access
+      # to a non-existent path inside ProtectSystem=strict). Idempotent.
+      # Surfaced 2026-05-21 via v1.1.1 deploy diagnostic capture.
+      "mkdir -p /etc/vector /var/lib/vector",
+      "chown deploy:deploy /var/lib/vector",
       "systemctl daemon-reload",
       "systemctl restart webhook",
       # One-time cleanup: delete stale .env so deploys fail loudly if Doppler is unavailable.

--- a/apps/web-platform/infra/webhook.service
+++ b/apps/web-platform/infra/webhook.service
@@ -32,7 +32,12 @@ PrivateTmp=true
 # its config + state dirs need bootstrap-time write access from inside this
 # namespace. Surfaced via v1.1.1 deploy diagnostic capture
 # (reason="mkdir: cannot create directory /etc/vector: Read-only file system").
-ReadWritePaths=/mnt/data /var/lock /etc/systemd/system /etc/default /var/lib/inngest /var/lib/vector /etc/vector /usr/local/bin
+# `-` prefix on /var/lib/vector + /etc/vector marks them optional:
+# systemd silently ignores the path if absent, instead of refusing to set up
+# the mount namespace (which on prior PR #4257 took webhook.service down
+# entirely until the dirs were created). Once inngest-bootstrap.sh creates
+# them on first v1.1.x deploy, they become real ReadWritePaths.
+ReadWritePaths=/mnt/data /var/lock /etc/systemd/system /etc/default /var/lib/inngest -/var/lib/vector -/etc/vector /usr/local/bin
 ReadOnlyPaths=/etc/webhook /etc/default/webhook-deploy
 TimeoutStopSec=180
 


### PR DESCRIPTION
## Summary

#4259's `-` prefix on `ReadWritePaths` only suppresses "fail on missing path" — it does NOT create the dirs or grant write access to them. v1.1.1's redeploy still failed with `mkdir: cannot create directory /etc/vector: Read-only file system`.

## Fix

Three coordinated changes:

1. **`server.tf` — `terraform_data.deploy_pipeline_fix` remote-exec**: gains `mkdir -p /etc/vector /var/lib/vector` + `chown deploy:deploy /var/lib/vector` BEFORE `systemctl restart webhook`. With real dirs in place at unit-start time, systemd grants writable mounts inside the namespace.
2. **`server.tf` — `triggers_replace`**: adds a sentinel string suffix (`v2-pre-create-vector-dirs`). terraform_data ignores inline provisioner content for drift; without the bump, terraform sees no change and skips re-apply.
3. **`apply-deploy-pipeline-fix.yml` — `paths`**: adds `apps/web-platform/infra/server.tf`. Future edits to this terraform_data's inline list auto-trigger the workflow.

Diagnostic capture from v1.1.1 attempt (deploy-state JSON, no SSH needed):

```
mkdir: cannot create directory /etc/vector: Read-only file system
mkdir: cannot create directory /var/lib/vector: Read-only file system
```

After merge → apply-pipeline runs → terraform_data re-creates → remote-exec creates dirs + restarts webhook → v1.1.1 redeploy succeeds past mkdir → Vector starts → first event to Sentry.

Ref #4250 (TR9 PR-5), #4257 + #4259 (preceding layered fixes)
