### PR TITLE
feat(infra): cat-deploy-state surfaces vector.service status + journal tail

### DIFF
--- a/apps/web-platform/infra/cat-deploy-state.sh
+++ b/apps/web-platform/infra/cat-deploy-state.sh
@@ -14,16 +14,35 @@ set -euo pipefail
 # Best-effort: systemctl may be unavailable in non-systemd contexts (local
 # tests, containers). `systemctl is-active` prints a canonical state word to
 # stdout and exits non-zero for inactive/failed; the `|| true` swallows the
-# exit so the stdout value reaches HEARTBEAT_STATUS. Empty stdout only on
+# exit so the stdout value reaches the caller. Empty stdout only on
 # missing systemctl (covered by the `else` branch).
-heartbeat_status() {
+service_status() {
+  local unit="$1"
   if command -v systemctl >/dev/null 2>&1; then
-    systemctl is-active inngest-heartbeat.service 2>/dev/null || true
+    systemctl is-active "$unit" 2>/dev/null || true
   else
     echo "unknown"
   fi
 }
-HEARTBEAT_STATUS="$(heartbeat_status)"
+
+# Tail of recent journal entries for a unit. Read-only; returns at most 10
+# lines (capped to ~2000 chars total). Strips control bytes so the JSON
+# `vector_journal_tail` field round-trips cleanly. Empty on missing
+# journalctl OR non-existent unit. Used for no-SSH RCA of vector.service
+# startup failures (TR9 PR-5).
+service_journal_tail() {
+  local unit="$1"
+  if command -v journalctl >/dev/null 2>&1; then
+    journalctl -u "$unit" --no-pager --output=cat -n 10 2>/dev/null \
+      | tr -d '\r' | tr '\n' '|' | tr -dc '[:print:]|' | tail -c 2000 \
+      || true
+  fi
+}
+
+HEARTBEAT_STATUS="$(service_status inngest-heartbeat.service)"
+INNGEST_SERVER_STATUS="$(service_status inngest-server.service)"
+VECTOR_STATUS="$(service_status vector.service)"
+VECTOR_JOURNAL_TAIL="$(service_journal_tail vector.service)"
 
 STATE_FILE="${CI_DEPLOY_STATE:-/var/lock/ci-deploy.state}"
 
@@ -36,5 +55,15 @@ elif ! BASE="$(jq -c . "$STATE_FILE" 2>/dev/null)"; then
   BASE='{"exit_code":-3,"reason":"corrupt_state"}'
 fi
 
-jq -nc --argjson base "$BASE" --arg hb "$HEARTBEAT_STATUS" \
-  '$base + {services: (($base.services // {}) + {inngest_heartbeat: $hb})}'
+jq -nc \
+  --argjson base "$BASE" \
+  --arg hb "$HEARTBEAT_STATUS" \
+  --arg is "$INNGEST_SERVER_STATUS" \
+  --arg vs "$VECTOR_STATUS" \
+  --arg vj "$VECTOR_JOURNAL_TAIL" \
+  '$base + {services: (($base.services // {}) + {
+    inngest_heartbeat: $hb,
+    inngest_server: $is,
+    vector: $vs,
+    vector_journal_tail: $vj
+  })}'


### PR DESCRIPTION
## Summary

v1.1.1 inngest-bootstrap deploy reports `exit=0 reason=success` but Vector isn't shipping events to Sentry. No-SSH RCA needs visibility into `vector.service`'s runtime state, which `cat-deploy-state.sh` doesn't expose today (only `inngest-heartbeat` is checked).

## Fix

Three new fields in the `/hooks/deploy-status` JSON response:

- `services.inngest_server` — `systemctl is-active inngest-server.service`
- `services.vector` — `systemctl is-active vector.service`
- `services.vector_journal_tail` — last 10 journalctl lines for vector.service, stripped of control bytes, capped at 2000 chars

Read-only, defensive `|| true` pattern matches the existing `heartbeat_status()` function. Empty fields gracefully if journalctl/unit absent.

## Why

The TR9 PR-5 observability stack established the discipline that prd debugging must work without SSH/docker exec (`hr-no-ssh-fallback-in-runbooks`). Vector itself was supposed to make `journalctl -u inngest-server.service` accessible via Sentry — but Vector isn't running, so we have a chicken-and-egg: we need Vector to debug Vector. This script extension breaks the loop by exposing Vector's own state through the already-existing webhook diagnostic endpoint.

`apply-deploy-pipeline-fix.yml`'s path filter already includes `cat-deploy-state.sh`, so this auto-deploys on merge.

Ref #4250 (TR9 PR-5 observability stack)
