### PR TITLE
fix(infra): vector.toml uses include_matches.PRIORITY (not bogus include_priorities)

### DIFF
--- a/apps/web-platform/infra/vector.toml
+++ b/apps/web-platform/infra/vector.toml
@@ -20,8 +20,17 @@ data_dir = "/var/lib/vector"
 # anti-pattern.
 [sources.inngest_journald]
 type = "journald"
-units = ["inngest-server.service"]
-include_priorities = ["emerg", "alert", "crit", "err", "warning"]
+# Vector's documented field is `include_units`, not `units` (alias accepted
+# but undocumented in newer versions); naming aligned for forward-compat.
+include_units = ["inngest-server.service"]
+# Vector's priority filter uses `include_matches.PRIORITY` (object of
+# journal-field → allowed values per
+# https://vector.dev/docs/reference/configuration/sources/journald/).
+# `include_priorities` (my v1.1.0 typo) is NOT a real Vector field;
+# the misconfigured unit fail-loops with `unknown field` until fixed
+# (caught at v1.1.1 deploy via cat-deploy-state's vector_journal_tail).
+# PRIORITY values: 0=EMERG, 1=ALERT, 2=CRIT, 3=ERR, 4=WARNING.
+include_matches.PRIORITY = ["0", "1", "2", "3", "4"]
 journal_directory = "/var/log/journal"
 batch_size = 16
 
@@ -32,7 +41,9 @@ batch_size = 16
 [sources.system_journald]
 type = "journald"
 exclude_units = ["inngest-server.service", "vector.service"]
-include_priorities = ["emerg", "alert", "crit"]
+# CRIT-or-worse only at the host level (see source 1 comment for field
+# naming rationale). PRIORITY: 0=EMERG, 1=ALERT, 2=CRIT.
+include_matches.PRIORITY = ["0", "1", "2"]
 journal_directory = "/var/log/journal"
 batch_size = 16
 


### PR DESCRIPTION
## Summary

Diagnosed via cat-deploy-state's new `vector_journal_tail` field (shipped in #4266):

```
ERROR vector::cli: Configuration error.
error=unknown field `include_priorities`, expected one of `since_now`,
`current_boot_only`, `include_units`, `exclude_units`, `include_matches`, ...
in `sources.inngest_journald`
```

`include_priorities` was my mistake in v1.1.0 — the actual Vector journald-source priority filter is `include_matches.PRIORITY = ["0", "1", "2", "3", "4"]`. The misconfigured `vector.service` fail-loops every 10s (Restart=on-failure / RestartSec=10) until fixed.

## Fix

- `inngest_journald` source: `include_matches.PRIORITY = ["0", "1", "2", "3", "4"]` (EMERG..WARNING)
- `system_journald` source: `include_matches.PRIORITY = ["0", "1", "2"]` (EMERG..CRIT)
- Bonus: rename `units` → `include_units` for forward-compat (the older alias still parses but isn't documented in current Vector docs)

## Next

Once merged → push `vinngest-v1.1.2` tag → OCI build runs → deploy `v1.1.2` via webhook → `vector.service` starts cleanly → first `host_metrics` scrape ships to Sentry within ~30s.

Ref #4250 (TR9 PR-5), #4266 (the diagnostic that surfaced this)
