### PR TITLE
fix(infra): vector.toml VRL — use to_string ?? default + is_object guard

### DIFF
--- a/apps/web-platform/infra/vector.toml
+++ b/apps/web-platform/infra/vector.toml
@@ -62,16 +62,33 @@ collectors = ["cpu", "memory", "disk", "filesystem", "load", "network"]
 [transforms.envelope_events]
 type = "remap"
 inputs = ["inngest_journald", "system_journald"]
+# VRL note: use `to_string(...) ?? "default"` (fallible form) rather than
+# `string!(...) ?? "default"` (infallible form — VRL flags the `??` as
+# dead code because string!() aborts on bad input). Same for direct field
+# access (`.field ?? "x"` is also flagged); guard with explicit
+# `if exists(.field)` before assignment.
 source = '''
 event_id = uuid_v4()
 event_id = replace(event_id, "-", "")
 
-priority_str = string!(.PRIORITY) ?? "5"
+priority_str = "5"
+if exists(.PRIORITY) {
+    priority_str = to_string(.PRIORITY) ?? "5"
+}
 sentry_level = if priority_str == "0" || priority_str == "1" || priority_str == "2" { "fatal" } else if priority_str == "3" { "error" } else { "warning" }
 
-unit_safe = string!(._SYSTEMD_UNIT) ?? "system"
-host_safe = string!(.host) ?? "hetzner"
-message_safe = string!(.message) ?? ""
+unit_safe = "system"
+if exists(._SYSTEMD_UNIT) {
+    unit_safe = to_string(._SYSTEMD_UNIT) ?? "system"
+}
+host_safe = "hetzner"
+if exists(.host) {
+    host_safe = to_string(.host) ?? "hetzner"
+}
+message_safe = ""
+if exists(.message) {
+    message_safe = to_string(.message) ?? ""
+}
 
 # Sentry event payload (compact — one log line == one Sentry event).
 sentry_event = {
@@ -119,21 +136,30 @@ source = '''
 event_id = uuid_v4()
 event_id = replace(event_id, "-", "")
 
-metric_name = string!(.name) ?? "unknown"
+metric_name = "unknown"
+if exists(.name) {
+    metric_name = to_string(.name) ?? "unknown"
+}
 metric_value = if exists(.gauge.value) { .gauge.value } else if exists(.counter.value) { .counter.value } else { 0.0 }
-tag_struct = .tags ?? {}
+# VRL: `.tags ?? {}` is flagged because field access can't fail. Guard with
+# is_object() so the merge() call below sees a valid object.
+tag_struct = {}
+if is_object(.tags) {
+    tag_struct = object!(.tags)
+}
 
+value_str = to_string(metric_value) ?? "?"
 sentry_event = {
     "event_id": event_id,
     "timestamp": to_unix_timestamp(now()),
     "platform": "other",
     "level": "info",
     "logger": "vector.host_metrics",
-    "message": { "formatted": string!(metric_name) + "=" + to_string!(metric_value) },
+    "message": { "formatted": metric_name + "=" + value_str },
     "tags": merge({
         "metric_name": metric_name,
         "source": "vector-host-metrics"
-    }, object!(tag_struct)),
+    }, tag_struct),
     "extra": { "value": metric_value }
 }
 


### PR DESCRIPTION
## Summary

After #4267 fixed `include_priorities`, the next-layer VRL error surfaced via cat-deploy-state's diagnostic field:

```
remap_metrics:6:14
tag_struct = .tags ?? {}
            ^^^^^ -- -- this expression never resolves
                 remove this error coalescing operation
            this expression can't fail
```

Two VRL-idiomatic mistakes carried from my v1.1.0 draft:

1. **`.field ?? default`** on direct field access — VRL flags as dead code (field access can't fail; returns `null` at worst). Fix: `if exists(.field) { ... }` or `if is_object(.tags) { ... }` guard.
2. **`string!(...) ?? default`** — the `!` form aborts on coercion error, so `??` is dead code. Fix: use `to_string(...) ?? default` (fallible form).

Both `remap` transforms (`envelope_events` for journald, `envelope_metrics` for host_metrics) rewritten with correct VRL patterns. Same observable behavior; just compiles.

## Plan

1. Merge.
2. Push `vinngest-v1.1.3` tag at the merge SHA.
3. OCI build (auto on the tag).
4. Deploy `v1.1.3` via webhook.
5. `vector.service` starts cleanly → first event ships to Sentry within ~30s.

Ref #4250 (TR9 PR-5), #4266 (cat-deploy-state diagnostic), #4267 (prior include_priorities fix)
