### PR TITLE
fix(infra): vector.toml remap writes to .message (matches raw_message codec)

### DIFF
--- a/apps/web-platform/infra/vector.toml
+++ b/apps/web-platform/infra/vector.toml
@@ -118,8 +118,15 @@ item_body = encode_json(sentry_event)
 item_header = { "type": "event", "length": length(item_body) }
 
 . = {
-    "envelope_body": encode_json(envelope_header) + "\n" + encode_json(item_header) + "\n" + item_body + "\n",
-    "_routing": "sentry_envelope"
+    # Sentry envelope body MUST land under the `message` field name so the
+    # downstream http sink's `encoding.codec = "raw_message"` ships it as
+    # the request body. The codec serializes ONLY the `message` field of
+    # each event — any other field (like the prior `envelope_body`) is
+    # silently dropped and Sentry receives an empty POST body → HTTP 400.
+    # Caught via deploy-status `vector_journal_tail` + manual curl probe
+    # that confirmed the envelope format itself is valid (Sentry returned
+    # 200 on the exact bytes when sent directly).
+    "message": encode_json(envelope_header) + "\n" + encode_json(item_header) + "\n" + item_body + "\n"
 }
 '''
 
@@ -168,8 +175,15 @@ item_body = encode_json(sentry_event)
 item_header = { "type": "event", "length": length(item_body) }
 
 . = {
-    "envelope_body": encode_json(envelope_header) + "\n" + encode_json(item_header) + "\n" + item_body + "\n",
-    "_routing": "sentry_envelope"
+    # Sentry envelope body MUST land under the `message` field name so the
+    # downstream http sink's `encoding.codec = "raw_message"` ships it as
+    # the request body. The codec serializes ONLY the `message` field of
+    # each event — any other field (like the prior `envelope_body`) is
+    # silently dropped and Sentry receives an empty POST body → HTTP 400.
+    # Caught via deploy-status `vector_journal_tail` + manual curl probe
+    # that confirmed the envelope format itself is valid (Sentry returned
+    # 200 on the exact bytes when sent directly).
+    "message": encode_json(envelope_header) + "\n" + encode_json(item_header) + "\n" + item_body + "\n"
 }
 '''
 


### PR DESCRIPTION
## Summary

After #4268 cleared the VRL compile errors, Vector ran cleanly and posted envelopes — but every POST returned HTTP 400. Diagnosed by:

1. **cat-deploy-state `vector_journal_tail`** exposed the 400 errors in real-time, no SSH.
2. **Manual curl probe** to Sentry with the EXACT envelope shape Vector was supposed to be sending → HTTP 200 + valid event id. So envelope format itself is fine.
3. **Re-reading vector.toml**: `encoding.codec = "raw_message"` in the http sink serializes ONLY the `.message` field. My remap wrote the envelope to `.envelope_body` instead → silently dropped at sink encoding → empty body to Sentry → 400.

## Fix

Rename `.envelope_body` → `.message` in both remap transforms (`envelope_events` for journald, `envelope_metrics` for host_metrics). Sink config unchanged.

Final piece of the Vector chain. After this merges, build, deploy → events should flow to Sentry within ~30s.

Ref #4250 (TR9 PR-5), #4266 (cat-deploy-state diagnostic), #4267 + #4268 (prior layered fixes)
