### PR TITLE
debug(infra): vector.toml adds envelope_debug console sink

### DIFF
--- a/apps/web-platform/infra/vector.toml
+++ b/apps/web-platform/infra/vector.toml
@@ -221,3 +221,19 @@ type = "console"
 inputs = ["vector_internal"]
 encoding.codec = "json"
 target = "stdout"
+
+# Diagnostic console sink — temporary, to surface the EXACT envelope
+# bytes Vector is producing. Vector's sentry sink is getting HTTP 400
+# from every POST (v1.1.4 deploy diagnosis); the envelope format is
+# proven valid via manual curl, so the issue must be HOW Vector
+# serializes/encodes the .message field. Mirror the same inputs +
+# raw_message codec the sentry sink uses, but to stdout instead of
+# https://. Read via cat-deploy-state's vector_journal_tail — strip the
+# JSON wrapper to see the actual bytes. To revert: delete this entire
+# sinks block in the next vector.toml bump.
+[sinks.envelope_debug]
+type = "console"
+inputs = ["envelope_events", "envelope_metrics"]
+encoding.codec = "raw_message"
+framing.method = "newline_delimited"
+target = "stdout"


### PR DESCRIPTION
## Summary

Vector v1.1.4 is making 30K+ POST requests to Sentry; all return 400. Manual curl probe with hand-crafted envelope returns 200 → envelope format is valid → the problem must be HOW Vector serializes the `.message` field through `raw_message` codec + `newline_delimited` framing.

## Fix (diagnostic)

Add `[sinks.envelope_debug]` console sink with IDENTICAL inputs/codec/framing as the sentry sink. Stdout → journald → `cat-deploy-state.services.vector_journal_tail`. Next deploy surfaces the exact bytes Vector produces; I can diff against the known-good curl shape and pinpoint the divergence.

Temporary — revert in next vector.toml bump after Vector ships successfully.

Ref #4250 (TR9 PR-5), #4269 (prior .message rename that didn't unblock the 400s)
