### PR TITLE
feat(skills): widen frontend-anti-slop scope to include the Eleventy marketing site

### DIFF
--- a/plugins/soleur/skills/frontend-anti-slop/scripts/tier1-scan.ts
+++ b/plugins/soleur/skills/frontend-anti-slop/scripts/tier1-scan.ts
@@ -12,7 +12,8 @@
  *     [--paths <file-or-glob> ...] [--dry-run|--json] [--rule <id>]
  *
  * Default paths: `git diff --name-only --cached --diff-filter=AMR` filtered to
- * `apps/web-platform/(app|components)/**\*.(tsx|jsx|css)`.
+ * `apps/web-platform/(app|components)/**\*.(tsx|jsx|css)` AND
+ * `plugins/soleur/docs/**\*.(njk|css)`.
  *
  * Output:
  *   - `--dry-run` (default) — human-readable findings on stdout.
@@ -241,7 +242,9 @@ function defaultPaths(): string[] {
       .map((p) => p.trim())
       .filter(Boolean);
     return all.filter((p) =>
-      /^apps\/web-platform\/(app|components)\/.*\.(tsx|jsx|css)$/.test(p),
+      /^(apps\/web-platform\/(app|components)\/.*\.(tsx|jsx|css)|plugins\/soleur\/docs\/.*\.(njk|css))$/.test(
+        p,
+      ),
     );
   } catch {
     return [];
@@ -276,11 +279,11 @@ function expandPaths(inputs: string[]): string[] {
     if (ls.isSymbolicLink()) continue;
     const s = statSync(abs);
     if (s.isFile()) {
-      if (/\.(tsx|jsx|css)$/.test(abs)) out.push(abs);
+      if (/\.(tsx|jsx|css|njk)$/.test(abs)) out.push(abs);
     } else if (s.isDirectory()) {
       out.push(
         ...listFilesRecursive(abs).filter((f) =>
-          /\.(tsx|jsx|css)$/.test(f),
+          /\.(tsx|jsx|css|njk)$/.test(f),
         ),
       );
     }

--- a/plugins/soleur/skills/review/SKILL.md
+++ b/plugins/soleur/skills/review/SKILL.md
@@ -271,9 +271,9 @@ Use `gdpr-gate` for deterministic Art. 9 / RoPA / lawful-basis pattern checks; u
 
 ### Anti-slop Scanner Hook
 
-**If the diff touches `apps/web-platform/(app|components)/.*\.(tsx|jsx|css)$`:**
+**If the diff touches `apps/web-platform/(app|components)/.*\.(tsx|jsx|css)$` OR `plugins/soleur/docs/.*\.(njk|css)$`:**
 
-17. Run the `soleur:frontend-anti-slop` Tier 1 scanner inline (no separate agent spawn — v1 simplification per plan PR #4265):
+17. Run the `soleur:frontend-anti-slop` Tier 1 scanner inline (no separate agent spawn — v1 simplification per plan PR #4265). Scope covers both the Next.js platform and the Eleventy marketing site so AI-assisted edits to landing pages or blog posts get the same audit as React component changes.
 
     ```bash
     # NUL-delimited path collection + quoted argv expansion — prevents the
@@ -282,7 +282,7 @@ Use `gdpr-gate` for deterministic Art. 9 / RoPA / lawful-basis pattern checks; u
     # whitespace-free.
     mapfile -d '' -t CHANGED_FILES < <(
       git diff --name-only -z origin/main...HEAD |
-        grep -zE 'apps/web-platform/(app|components)/.*\.(tsx|jsx|css)$' || true
+        grep -zE '(apps/web-platform/(app|components)/.*\.(tsx|jsx|css)|plugins/soleur/docs/.*\.(njk|css))$' || true
     )
     if (( ${#CHANGED_FILES[@]} > 0 )); then
       bun run plugins/soleur/skills/frontend-anti-slop/scripts/tier1-scan.ts \

--- a/plugins/soleur/test/frontend-anti-slop/tier1-scan.test.ts
+++ b/plugins/soleur/test/frontend-anti-slop/tier1-scan.test.ts
@@ -295,3 +295,36 @@ describe("frontend-anti-slop tier1-scan: rule parsing", () => {
     }
   });
 });
+
+describe("frontend-anti-slop tier1-scan: file-filter scope", () => {
+  // Scope was widened to include `.njk` so the Eleventy marketing site
+  // (plugins/soleur/docs/) is audited alongside the Next.js platform.
+  // These tests lock the scope so a future refactor of `expandPaths` /
+  // `listFilesRecursive` can't silently drop `.njk` and break the docs-site
+  // audit path. See the SKILL.md "Scope" table and review/SKILL.md
+  // "Anti-slop Scanner Hook" trigger regex — both share this same file-
+  // extension set.
+
+  test("scanFile on a .njk fixture is well-defined (rule fires when pattern matches)", () => {
+    withFile(
+      "landing.njk",
+      `<a class="bg-clip-text text-transparent bg-gradient-to-r from-purple-500 to-blue-500">Try it</a>`,
+      (abs) => {
+        const findings = scanFile(abs, [ruleById("GRADIENT-TEXT")]);
+        expect(findings).toHaveLength(1);
+        expect(findings[0].selector).toMatch(/\.njk#GRADIENT-TEXT$/);
+      },
+    );
+  });
+
+  test("scanFile on a .njk fixture with no slop returns 0 (rule set tolerates non-Tailwind markup)", () => {
+    withFile(
+      "blog-post.njk",
+      `{% extends "base.njk" %}\n{% block content %}<article class="prose">{{ body | safe }}</article>{% endblock %}`,
+      (abs) => {
+        const findings = scanFile(abs, RULES);
+        expect(findings).toHaveLength(0);
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Widens `soleur:frontend-anti-slop` (shipped in #4265, tightened in #4274) to include the Eleventy marketing site (`plugins/soleur/docs/`). AI-assisted edits to landing pages, blog posts, and marketing copy now route through the same anti-slop audit as React component changes on the Next.js platform.

Ref #4270 (extends calibration surface; no new findings today, forward defense for future content).

## Changelog

### Plugin

- **Scanner file filter widened** (`tier1-scan.ts`): `expandPaths` and `listFilesRecursive` now accept `.njk` in addition to `.tsx|.jsx|.css`. Default-paths git-diff regex extended with `plugins/soleur/docs/.*\.(njk|css)$` alongside the existing Next.js platform pattern.
- **Review-hook trigger widened** (`review/SKILL.md` §"Anti-slop Scanner Hook"): conditional fires on either `apps/web-platform/(app|components)/.*\.(tsx|jsx|css)$` OR `plugins/soleur/docs/.*\.(njk|css)$`. Inline `grep -zE` regex updated to the union.

### Tests

- 2 new tests lock the `.njk` scope so a future refactor of `expandPaths`/`listFilesRecursive` can't silently drop the website-audit path. POSITIVE: Nunjucks template with a Tailwind gradient triad → 1 finding. NEGATIVE: real-shape Nunjucks blog-post template → 0 findings. Total: 21 (was 19 in #4274).

## Empirical baseline

- `bun run plugins/soleur/skills/frontend-anti-slop/scripts/tier1-scan.ts --paths plugins/soleur/docs --json` → `0` findings on 22 `.njk` + 1 `.css`. The marketing site is hand-crafted semantic CSS without Tailwind class shapes, so the rule set has nothing to flag today.
- Regression check on `apps/web-platform/components/connect-repo/setting-up-state.tsx` → still produces the canonical TRANSITION-ALL finding (calibration baseline preserved).

## Forward-defense rationale

Today's 0-finding result on the website is the desired state — the operator hand-designed the site. The scope widening exists for future modifications: any AI-assisted addition that pulls in a `next/font/google` font, Tailwind gradient classes, placeholder names ("Jane Doe", "Acme"), or other Hallmark-class anti-slop will trip the existing rule set without requiring a separate "docs-anti-slop" skill.

## Test plan

- [x] `bun test plugins/soleur/test/frontend-anti-slop/tier1-scan.test.ts` exits 0 (21/21).
- [x] Scanner on `plugins/soleur/docs/` → 0 findings.
- [x] Scanner on `apps/web-platform/.../setting-up-state.tsx` → 1 finding (TRANSITION-ALL).
- [x] Synthetic Nunjucks fixture with a Tailwind triad → 1 GRADIENT-TEXT finding (proves rules fire on `.njk` when patterns match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
