### PR TITLE
fix(infra): vector.toml propagation — clear /tmp before cp, restart service, log sha256

### DIFF
--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -611,6 +611,15 @@ case "$COMPONENT" in
     # built before this feature lands won't have /vector.toml; the script's
     # downstream `[[ -f /tmp/vector.toml ]]` guard skips Vector install
     # gracefully when missing.
+    #
+    # Clear /tmp/vector.toml FIRST so a prior deploy's content can't survive
+    # into this one if the docker cp silently fails. Without this rm, a
+    # silent cp failure (e.g., older OCI image missing /vector.toml) made
+    # the bootstrap re-install the stale prior config — surfaced 2026-05-21
+    # during the Better Stack pivot when v1.1.7 deploy left the old
+    # Sentry-sink config running because /tmp/vector.toml hadn't been
+    # replaced.
+    rm -f /tmp/vector.toml
     docker cp "$INNGEST_EXTRACT_CONTAINER:/vector.toml" /tmp/vector.toml 2>/dev/null || true
     # Read ENV vars baked into the image at build time (see
     # .github/workflows/build-inngest-bootstrap-image.yml — ENV

--- a/apps/web-platform/infra/inngest-bootstrap.sh
+++ b/apps/web-platform/infra/inngest-bootstrap.sh
@@ -356,19 +356,27 @@ else
       mkdir -p "$VECTOR_CONFIG_DIR" /var/lib/vector
       install -m 0644 /tmp/vector.toml "$VECTOR_CONFIG"
       chown -R deploy:deploy /var/lib/vector
+      # Log the sha256 of the installed config so cat-deploy-state's
+      # journal tail proves what content actually reached disk. Bitten
+      # 2026-05-21 by the stale `/tmp/vector.toml` reuse path; the hash
+      # comparison surfaces drift between the OCI-bundled config and
+      # what vector.service is actually reading.
+      log "vector config installed: sha256=$(sha256sum "$VECTOR_CONFIG" | awk '{print $1}')"
     fi
 
     if [[ -f "$VECTOR_CONFIG" ]]; then
       cat > "$VECTOR_UNIT" <<'VECTOREOF'
 [Unit]
-Description=Vector observability shipper (journald + host_metrics -> Sentry)
+Description=Vector observability shipper (journald + host_metrics -> Better Stack Logs)
 After=network-online.target inngest-server.service
 Wants=network-online.target
 
 [Service]
 Type=simple
 EnvironmentFile=/etc/default/inngest-server
-# Vector needs Doppler-injected SENTRY_INGEST_DOMAIN/PROJECT_ID/PUBLIC_KEY.
+# Vector needs Doppler-injected BETTERSTACK_LOGS_TOKEN (and any other
+# secrets the config references). doppler run resolves them at
+# ExecStart time.
 ExecStart=/usr/bin/doppler run --project soleur --config prd -- /usr/local/bin/vector --config /etc/vector/vector.toml
 Restart=on-failure
 RestartSec=10
@@ -389,8 +397,16 @@ WantedBy=multi-user.target
 VECTOREOF
 
       systemctl daemon-reload
-      systemctl enable --now vector.service || log "warn: vector.service failed to start (Sentry shipper deferred; check journalctl -u vector.service)"
-      log "vector observability shipper active"
+      # `enable --now` is a no-op when the unit is already running; the
+      # new config would never be picked up by an already-running vector
+      # process. Replace with explicit enable + restart so each deploy
+      # gives Vector a clean reload (it reads /etc/vector/vector.toml
+      # only at start, not on SIGHUP without explicit reload mapping).
+      # Surfaced 2026-05-21: v1.1.7 deploy reported "active" but kept
+      # running the v1.1.6 Sentry-sink config.
+      systemctl enable vector.service 2>/dev/null || true
+      systemctl restart vector.service || log "warn: vector.service failed to (re)start; check journalctl -u vector.service"
+      log "vector observability shipper restarted"
     else
       log "warn: $VECTOR_CONFIG missing — vector installed but not started"
     fi


### PR DESCRIPTION
## Summary

Three bugs combined to leave the OLD vector.toml in place after every deploy. Surfaced on the v1.1.7 Better Stack pivot (#4277): bootstrap reported `success` + `vector=active`, but the journal still showed `component_id=sentry` errors — proving the old Sentry-sink config was still in use, not the new Better Stack one.

## Fixes

1. **`ci-deploy.sh`** — `rm -f /tmp/vector.toml` BEFORE the `docker cp`. The `2>/dev/null || true` on the cp was silently masking failures, and a prior deploy's content was surviving. Now a silent cp failure leaves no file → bootstrap correctly skips.

2. **`inngest-bootstrap.sh`** — replace `systemctl enable --now vector.service` (no-op on running units) with `systemctl enable + systemctl restart`. Vector reads `/etc/vector/vector.toml` only at start, not on SIGHUP without explicit reload mapping — without a restart, a new config never takes effect.

3. **`inngest-bootstrap.sh`** — `log "vector config installed: sha256=$(sha256sum ...)"` after each install. cat-deploy-state's `vector_journal_tail` now exposes which config content is actually live, making the propagation drift class detectable without SSH.

## Next

After merge → push `vinngest-v1.1.8` → OCI build → deploy → Vector picks up the new Better Stack config → events ship within ~30s.

Ref #4250 (TR9 PR-5), #4273 (consolidation), #4277 (Better Stack pivot)
