### PR TITLE
fix(infra): vector.toml uses generic http sink (Vector 0.43.1 lacks better_stack_logs)

### DIFF
--- a/apps/web-platform/infra/vector.toml
+++ b/apps/web-platform/infra/vector.toml
@@ -82,14 +82,32 @@ if exists(.gauge.value) {
 }
 '''
 
-# ---------------- Sink: Better Stack Logs (native Vector integration) ----------------
-# Token from Doppler `prd.BETTERSTACK_LOGS_TOKEN`, injected at vector.service
-# ExecStart via `doppler run`. Better Stack's `https://in.logs.betterstack.com`
-# default endpoint is correct (sink uses it implicitly).
+# ---------------- Sink: Better Stack Logs via generic http sink ----------------
+# Vector 0.43.1 does NOT have a `better_stack_logs` sink (added in a
+# later release per its sink registry — confirmed via v1.1.7 deploy
+# diagnostic: the unknown-variant error listed every other sink type).
+# Use the generic `http` sink against Better Stack's `https://in.logs.
+# betterstack.com/` ingest endpoint with Bearer auth — same shape the
+# manual curl probe (HTTP 202) used. Each event posts as a JSON object;
+# Better Stack accepts arbitrary JSON shape.
+#
+# Bumping Vector to a version with the native sink is a separate
+# concern (#4273 substrate-version review).
 [sinks.betterstack]
-type = "better_stack_logs"
+type = "http"
 inputs = ["tag_journald", "tag_metrics"]
-source_token = "${BETTERSTACK_LOGS_TOKEN}"
+uri = "https://in.logs.betterstack.com/"
+method = "post"
+batch.max_events = 10
+encoding.codec = "json"
+[sinks.betterstack.request.headers]
+authorization = "Bearer ${BETTERSTACK_LOGS_TOKEN}"
+content-type = "application/json"
+[sinks.betterstack.request]
+timeout_secs = 10
+retry_attempts = 2
+retry_initial_backoff_secs = 1
+retry_max_duration_secs = 30
 
 # ---------------- Internal liveness sink (stdout → journald) ----------------
 # Vector emits its own internal_metrics every 60s so `cat-deploy-state.sh`'s


### PR DESCRIPTION
## Summary

v1.1.8 verified the propagation fix worked (`sentry_errors=0`, new config in use), but exposed another mismatch: **Vector 0.43.1 doesn't have a `better_stack_logs` sink type** — it was added in a later release.

```
ERROR vector::cli: Configuration error.
error=unknown variant `better_stack_logs`, expected one of `amqp`,
`appsignal`, ..., `datadog_logs`, `datadog_metrics`, `datadog_traces`,
`elasticsearch`, ...
in `sinks.betterstack`
```

## Fix

Switch from `type = "better_stack_logs"` to the generic `type = "http"` sink against `https://in.logs.betterstack.com/` with `Authorization: Bearer ${BETTERSTACK_LOGS_TOKEN}` and `encoding.codec = "json"`. This is the EXACT shape my manual curl probe used (HTTP 202 + Better Stack ingested cleanly).

Bumping Vector to a newer version with the native sink is deferred to the substrate-version review in #4273.

After merge → push `vinngest-v1.1.9` → OCI build → deploy → events flow.

Ref #4250 (TR9 PR-5), #4273 (consolidation), #4277 (BS pivot), #4278 (propagation fix)
