### PR TITLE
fix(tests): add template_id to 5 more message-insert sites (follow-up to #4281)

### DIFF
--- a/apps/web-platform/test/cc-dispatcher-cross-tenant.integration.test.ts
+++ b/apps/web-platform/test/cc-dispatcher-cross-tenant.integration.test.ts
@@ -460,6 +460,9 @@ describe.skipIf(!INTEGRATION_ENABLED)(
         tool_calls: null,
         leader_id: "cc_router",
         usage: { cost_usd: 0.005 },
+        // PR-I (#4078, migration 053_template_authorizations.sql) added
+        // messages.template_id NOT NULL with CHECK ^[a-z][a-z0-9_]*$.
+        template_id: "default_legacy",
       });
       expect(seedErr).toBeNull();
 

--- a/apps/web-platform/test/dsar-export-cross-tenant.integration.test.ts
+++ b/apps/web-platform/test/dsar-export-cross-tenant.integration.test.ts
@@ -120,6 +120,9 @@ describe.skipIf(!INTEGRATION_ENABLED)(
           conversation_id: conv.id,
           role: "user",
           content: `Hello ${u.phrase}`,
+          // PR-I (#4078, migration 053_template_authorizations.sql) added
+          // messages.template_id NOT NULL with CHECK ^[a-z][a-z0-9_]*$.
+          template_id: "default_legacy",
         });
 
         // KB share link with the distinctive phrase in the document_path.

--- a/apps/web-platform/test/server/agent-runner.tenant-isolation.test.ts
+++ b/apps/web-platform/test/server/agent-runner.tenant-isolation.test.ts
@@ -122,6 +122,9 @@ describe.skipIf(!INTEGRATION_ENABLED)(
           conversation_id: convRow!.id,
           role: "user",
           content: `synthesized message for ${user.email}`,
+          // PR-I (#4078, migration 053_template_authorizations.sql) added
+          // messages.template_id NOT NULL with CHECK ^[a-z][a-z0-9_]*$.
+          template_id: "default_legacy",
         });
         expect(msgError, `seed messages for ${user.email}`).toBeNull();
 

--- a/apps/web-platform/test/server/api-messages.tenant-isolation.test.ts
+++ b/apps/web-platform/test/server/api-messages.tenant-isolation.test.ts
@@ -110,6 +110,9 @@ describe.skipIf(!INTEGRATION_ENABLED)(
             conversation_id: convRow!.id,
             role: "user",
             content: `synthesized message for ${user.email}`,
+            // PR-I (#4078, migration 053_template_authorizations.sql) added
+            // messages.template_id NOT NULL with CHECK ^[a-z][a-z0-9_]*$.
+            template_id: "default_legacy",
           })
           .select("id")
           .single();

--- a/apps/web-platform/test/server/attachment-pipeline.tenant-isolation.test.ts
+++ b/apps/web-platform/test/server/attachment-pipeline.tenant-isolation.test.ts
@@ -131,6 +131,9 @@ describe.skipIf(!INTEGRATION_ENABLED)(
         content: "tenant-isolation attachment seed",
         tool_calls: null,
         leader_id: null,
+        // PR-I (#4078, migration 053_template_authorizations.sql) added
+        // messages.template_id NOT NULL with CHECK ^[a-z][a-z0-9_]*$.
+        template_id: "default_legacy",
       });
       expect(msgErr).toBeNull();
 


### PR DESCRIPTION
## Summary

Follow-up to #4281. The manual `tenant-integration` dispatch run (26252187371) after #4281 merged revealed my original `template_id` fix only covered `action-sends-worm.test.ts`. Five other test files have their own direct `messages.insert()` calls hitting the same `NOT NULL` violation from PR-I #4078's migration:

- `test/server/agent-runner.tenant-isolation.test.ts:121`
- `test/server/api-messages.tenant-isolation.test.ts:107`
- `test/server/attachment-pipeline.tenant-isolation.test.ts:127`
- `test/dsar-export-cross-tenant.integration.test.ts:119`
- `test/cc-dispatcher-cross-tenant.integration.test.ts:455`

All five now include `template_id: "default_legacy"` (matches the migration backfill value + the `CHECK (template_id ~ '^[a-z][a-z0-9_]*$')` shape).

The PGRST205 soft-skip from #4281 worked as designed — all 3 workspace-tests cleanly skipped on the cache-stale run. This PR only addresses the parallel `template_id` class.

Verification:

```
grep -rln '\.from("messages")\.insert' apps/web-platform/test/ \
  | xargs grep -L 'template_id'
→ empty (all 6 insert sites now carry template_id)
```

## User-Brand Impact

- **Artifact at risk:** CI signal integrity (same as #4281)
- **Brand-survival threshold:** `aggregate pattern` — the systemic cost is the red baseline; this fix completes the cleanup started by #4281.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] All edits are `TENANT_INTEGRATION_TEST=1`-gated; default vitest unaffected
- [ ] ⏳ Post-merge: manual dispatch of tenant-integration should now show only PGRST205 soft-skips (no template_id failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
