### PR TITLE
test(4384): probe ack-destroy destroy-guard — DO NOT MERGE

### DIFF
--- a/infra/github/ruleset-ci-required.tf
+++ b/infra/github/ruleset-ci-required.tf
@@ -112,20 +112,6 @@ resource "github_repository_ruleset" "ci_required" {
         context        = "tc-document-sha-guard"
         integration_id = var.actions_integration_id
       }
-
-      # --- Tier 3: legal-doc cross-document lockstep gate (#4384, closes the
-      # advisory-bypass-via-auto-merge gap that produced #4333). Context
-      # string is the JOB name (`enforce`) at
-      # .github/workflows/legal-doc-cross-document-gate.yml:36, NOT the
-      # workflow display name — per ADR-032 job-name contract. Workflow
-      # `paths:` filter removed in the same PR (#4384) so the job posts on
-      # every PR; the existing `surface_hit=false` short-circuit (lines
-      # 82-85) keeps non-DSAR PRs at O(seconds). See learning
-      # 2026-03-20-github-required-checks-skip-ci-synthetic-status.md.
-      required_check {
-        context        = "enforce"
-        integration_id = var.actions_integration_id
-      }
     }
   }
 }


### PR DESCRIPTION
Synthetic probe per #4392 AC20 / closes #3915.

Removes the Tier 3 `enforce` required_check block from `infra/github/ruleset-ci-required.tf` (without `[ack-destroy]` in the commit). The PR-time `infra-validation.yml` plan job should post a plan comment showing the destroy operation (proxy for the apply-time destroy-guard at `apply-github-infra.yml:243-251`).

The apply-time destroy-guard fires only on `push: branches: [main]` (verified via code-read of `apply-github-infra.yml`), so end-to-end validation would require merging to main. Proxy verification via the PR plan comment was chosen instead per /soleur:go user direction (2026-05-25) to avoid temporarily drifting the live ruleset.

Closing after plan-output confirmation.