### PR TITLE
test(runtime): TR9 PR-6 — vitest harness against real gray-matter + repo frontmatter shapes

### DIFF
--- a/apps/web-platform/server/inngest/functions/cron-strategy-review.ts
+++ b/apps/web-platform/server/inngest/functions/cron-strategy-review.ts
@@ -317,7 +317,9 @@ async function listExistingReviewIssueTitles(
 }
 
 // Script: find <dir> -maxdepth 1 -name '*.md' -type f
-async function collectStrategyFiles(repoRoot: string): Promise<string[]> {
+export async function collectStrategyFiles(
+  repoRoot: string,
+): Promise<string[]> {
   const files: string[] = [];
   for (const rel of STRATEGY_DIRS) {
     const abs = join(repoRoot, rel);
@@ -350,7 +352,7 @@ async function collectStrategyFiles(repoRoot: string): Promise<string[]> {
 // date, treat as malformed (script's "invalid last_reviewed" branch).
 // Use Date.parse for the strict shape since YYYY-MM-DD parses
 // unambiguously as UTC midnight.
-function parseISODate(s: string): number | null {
+export function parseISODate(s: string): number | null {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return null;
   const t = Date.parse(`${s}T00:00:00Z`);
   return Number.isNaN(t) ? null : t;
@@ -364,7 +366,7 @@ function parseISODate(s: string): number | null {
 // for missing/null and the literal raw string for unrecognized shapes (which
 // will then fail parseISODate and route into the "invalid last_reviewed"
 // errors++ branch — matching bash's `date -d` failure path).
-function coerceFrontmatterDate(raw: unknown): string | undefined {
+export function coerceFrontmatterDate(raw: unknown): string | undefined {
   if (raw === undefined || raw === null) return undefined;
   if (raw instanceof Date) {
     if (Number.isNaN(raw.getTime())) return undefined;

--- a/apps/web-platform/test/server/cron-strategy-review-graymatter.test.ts
+++ b/apps/web-platform/test/server/cron-strategy-review-graymatter.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+
+// vi.hoisted runs BEFORE all ES-module imports below, including the chain
+// `cron-strategy-review` → `client` → startup throw. The client checks
+// NEXT_PHASE === "phase-production-build" to short-circuit the env checks
+// (same path Next.js's `next build` uses).
+vi.hoisted(() => {
+  process.env.NEXT_PHASE = "phase-production-build";
+});
+
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import matter from "gray-matter";
+import {
+  coerceFrontmatterDate,
+  collectStrategyFiles,
+  parseISODate,
+} from "@/server/inngest/functions/cron-strategy-review";
+
+// Lock the contract that the multi-agent review caught:
+// gray-matter parses YAML 1.1, which coerces unquoted ISO dates
+// (`last_reviewed: 2026-05-25`) into JavaScript `Date` objects, NOT strings.
+// Hand-mocking `{ data: { last_reviewed: "2026-05-25" } }` masks the trap
+// because String(Date) is a no-op on a string. Every test below uses REAL
+// `matter()` against literal YAML so a regression to `String(rawDate)` would
+// re-fail. See `knowledge-base/project/learnings/2026-05-25-tr9-pr6-gray-matter-yaml11-date-coercion-trap.md`.
+
+describe("coerceFrontmatterDate — gray-matter YAML 1.1 contract", () => {
+  it("normalises unquoted YAML date (the production shape) to YYYY-MM-DD", () => {
+    const raw = "---\nlast_reviewed: 2026-05-25\nreview_cadence: weekly\n---\nbody";
+    const parsed = matter(raw);
+    // Assert the trap is real: gray-matter DOES coerce to Date.
+    expect(parsed.data.last_reviewed).toBeInstanceOf(Date);
+    // Assert the fix: coerceFrontmatterDate normalises back to ISO string.
+    expect(coerceFrontmatterDate(parsed.data.last_reviewed)).toBe("2026-05-25");
+  });
+
+  it("passes through quoted YAML strings unchanged", () => {
+    const raw = '---\nlast_reviewed: "2026-05-25"\n---\nbody';
+    const parsed = matter(raw);
+    expect(typeof parsed.data.last_reviewed).toBe("string");
+    expect(coerceFrontmatterDate(parsed.data.last_reviewed)).toBe("2026-05-25");
+  });
+
+  it("returns undefined for missing fields", () => {
+    const raw = "---\nreview_cadence: weekly\n---\nbody";
+    const parsed = matter(raw);
+    expect(coerceFrontmatterDate(parsed.data.last_reviewed)).toBeUndefined();
+  });
+
+  it("returns undefined for explicit null", () => {
+    const raw = "---\nlast_reviewed: null\n---\nbody";
+    const parsed = matter(raw);
+    expect(coerceFrontmatterDate(parsed.data.last_reviewed)).toBeUndefined();
+  });
+
+  it("returns undefined for an invalid Date object", () => {
+    expect(coerceFrontmatterDate(new Date("not-a-date"))).toBeUndefined();
+  });
+
+  it("returns the raw string for unrecognized non-Date shapes (so parseISODate routes them into the errors++ branch)", () => {
+    // Arbitrary non-date string in last_reviewed — bash's `date -d` would fail.
+    const result = coerceFrontmatterDate("definitely not a date");
+    expect(result).toBe("definitely not a date");
+    expect(parseISODate(result!)).toBeNull();
+  });
+
+  it("integration: full pipe from gray-matter Date through parseISODate yields a valid epoch", () => {
+    const raw = "---\nlast_reviewed: 2026-05-25\n---\nbody";
+    const parsed = matter(raw);
+    const normalized = coerceFrontmatterDate(parsed.data.last_reviewed);
+    expect(normalized).toBe("2026-05-25");
+    const epoch = parseISODate(normalized!);
+    expect(epoch).not.toBeNull();
+    // Sanity-check: 2026-05-25 UTC midnight in unix ms.
+    expect(new Date(epoch!).toISOString()).toBe("2026-05-25T00:00:00.000Z");
+  });
+});
+
+describe("collectStrategyFiles — file discovery contract", () => {
+  it("discovers .md files in STRATEGY_DIRS and skips symlinks (security hardening)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "cron-strategy-test-"));
+    try {
+      // Synthesize a minimal strategy tree.
+      const productDir = join(root, "knowledge-base", "product");
+      const marketingDir = join(root, "knowledge-base", "marketing");
+      await mkdir(productDir, { recursive: true });
+      await mkdir(marketingDir, { recursive: true });
+      const realFile = join(productDir, "roadmap.md");
+      await writeFile(
+        realFile,
+        "---\nreview_cadence: weekly\nlast_reviewed: 2026-05-25\n---\nbody\n",
+      );
+      const otherReal = join(marketingDir, "content-strategy.md");
+      await writeFile(otherReal, "---\nreview_cadence: weekly\n---\nbody\n");
+      // Plant a symlink pointing to /etc/passwd — handler must skip it
+      // (lstat + isSymbolicLink guard from the security-sentinel finding).
+      const malicious = join(productDir, "leak.md");
+      try {
+        await symlink("/etc/passwd", malicious);
+      } catch {
+        // Some test environments may not allow symlink creation; skip the
+        // assertion silently in that case.
+      }
+      // Plant a non-.md file — should be filtered.
+      await writeFile(join(productDir, "notes.txt"), "ignore me");
+
+      const found = await collectStrategyFiles(root);
+      const basenames = found.map((p) => p.split("/").slice(-2).join("/")).sort();
+      expect(basenames).toContain("product/roadmap.md");
+      expect(basenames).toContain("marketing/content-strategy.md");
+      // The symlink must NOT be discovered.
+      expect(basenames).not.toContain("product/leak.md");
+      // The .txt file must NOT be discovered.
+      expect(basenames.every((n) => n.endsWith(".md"))).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("silently skips missing strategy directories (matches bash `find ... 2>/dev/null` behavior)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "cron-strategy-test-empty-"));
+    try {
+      // No knowledge-base/ tree at all.
+      const found = await collectStrategyFiles(root);
+      expect(found).toEqual([]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("parseISODate — strict-YYYY-MM-DD contract (matches bash `date -d` failure path for non-strict)", () => {
+  it("accepts canonical YYYY-MM-DD", () => {
+    expect(parseISODate("2026-05-25")).toBe(Date.UTC(2026, 4, 25));
+  });
+
+  it("rejects ISO with timezone", () => {
+    expect(parseISODate("2026-05-25T00:00:00Z")).toBeNull();
+  });
+
+  it("rejects forward-slash forms", () => {
+    expect(parseISODate("2026/05/25")).toBeNull();
+  });
+
+  it("rejects two-digit-year shorthand", () => {
+    expect(parseISODate("26-05-25")).toBeNull();
+  });
+
+  it("rejects empty string", () => {
+    expect(parseISODate("")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the test that would have caught PR #4412's P1 at PR-CI rather than at multi-agent review. Validates `coerceFrontmatterDate`, `parseISODate`, and `collectStrategyFiles` against **real** `gray-matter` + **real**-shape YAML — not hand-crafted `{ data: { ... } }` mocks (which were the reason the trap survived TS unit testing in the original PR).

Refs #4416 (the umbrella child for TR9 PR-6).

## Why this matters

`data-integrity-guardian` (multi-agent review on #4412) caught a P1 silent-data-loss bug: `gray-matter` delegates YAML parsing to `js-yaml` (YAML 1.1), which auto-coerces unquoted `last_reviewed: 2026-05-25` into a JavaScript `Date` object — NOT a string. The original `String(rawDate)` cast produced `"Mon May 25 2026 02:00:00 GMT+0200 (CEST)"`, which failed `parseISODate`'s strict `^\d{4}-\d{2}-\d{2}$` regex, routing every overdue doc into the `errors++ → continue` branch. Result without the fix: zero issues created on every cron fire.

The bug was invisible to:
- TypeScript (`parsed.data` is typed `{ [k: string]: any }`, `String(Date)` typechecks)
- Hand-crafted mocks (`vi.mock(matter, () => ({ data: { last_reviewed: "2026-05-25" } }))` makes `String()` a no-op string-to-string)
- The bash predecessor's test approach (the bash script uses `sed` to extract literal bytes, never round-tripping through gray-matter)

Only invoking REAL `matter("---\nlast_reviewed: 2026-05-25\n---\n")` against the helper surfaces the trap.

## Changelog

### Web Platform
- **NEW** `apps/web-platform/test/server/cron-strategy-review-graymatter.test.ts` — 14 tests covering the three helpers PR #4412 added.
- **MODIFIED** `apps/web-platform/server/inngest/functions/cron-strategy-review.ts` — exported `coerceFrontmatterDate`, `parseISODate`, `collectStrategyFiles` (3-line behavior-preserving change). No runtime impact.

## Beyond PR-6

Every remaining TR9 child (#3948 children: `scheduled-roadmap-review`, `scheduled-community-monitor`, `scheduled-compound-promote`, etc.) that ports a shell script reading frontmatter dates will hit the same trap-class. The harness convention this PR establishes (`vi.hoisted(() => { process.env.NEXT_PHASE = ... })` to bypass the Inngest client's startup check, + real `matter()` against literal YAML) is now reusable for every future TR9 migration.

A future improvement: add a `gray-matter`-real-parse pre-commit lint that flags any `parsed.data.<*_at|*_date|last_*>` read without a `coerceFrontmatterDate`-equivalent wrapper.

## Test plan

- [x] `cd apps/web-platform && ./node_modules/.bin/vitest run test/server/cron-strategy-review-graymatter.test.ts` — 14/14 pass
- [x] `cd apps/web-platform && npm run typecheck` — clean (export-only change to source)
- [x] `cd apps/web-platform && ./node_modules/.bin/vitest run test/server/cron-no-byok-lease-sweep.test.ts test/server/byok-audit-writer-sweep.test.ts` — 36/36 unchanged (no substrate regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
