### PR TITLE
perf(messages): add partial index on user_id for cascade + DSAR queries (#4453)

### DIFF
--- a/apps/web-platform/supabase/migrations/071_messages_user_id_partial_idx.sql
+++ b/apps/web-platform/supabase/migrations/071_messages_user_id_partial_idx.sql
@@ -1,0 +1,16 @@
+-- Partial index on messages(user_id) for the active (non-anonymised) row set.
+-- Covers: dsar-export participation probe, account-delete cascade RPC,
+-- mig 068 anonymise_departed_user_across_workspaces.
+-- Partial WHERE keeps the index compact: post-cascade rows (user_id IS NULL)
+-- are excluded since no query path filters on a NULL user_id.
+--
+-- Ref: #4453 (PR #4417 review P1 — performance-oracle finding)
+
+CREATE INDEX IF NOT EXISTS idx_messages_user_id
+  ON public.messages (user_id)
+  WHERE user_id IS NOT NULL;
+
+COMMENT ON INDEX public.idx_messages_user_id IS
+  'Partial index covering non-anonymised messages for user-scoped queries '
+  '(DSAR participation probe, account-delete cascade, storage purge). '
+  'Ref: #4453.';

--- a/apps/web-platform/supabase/verify/071_messages_user_id_partial_idx.sql
+++ b/apps/web-platform/supabase/verify/071_messages_user_id_partial_idx.sql
@@ -1,0 +1,23 @@
+-- Verify sentinel: assert idx_messages_user_id exists and is partial.
+-- CI runs this via verify-migrations job; failure blocks deploy.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND tablename = 'messages'
+      AND indexname = 'idx_messages_user_id'
+  ) THEN
+    RAISE EXCEPTION 'idx_messages_user_id does not exist on public.messages';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    WHERE c.relname = 'idx_messages_user_id'
+      AND i.indpred IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'idx_messages_user_id exists but is not a partial index';
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

- Add `CREATE INDEX idx_messages_user_id ON messages(user_id) WHERE user_id IS NOT NULL` migration (071)
- Covers three user_id-scoped query paths: DSAR participation probe, mig 068 cascade RPC, account-delete storage purge
- Partial WHERE excludes post-anonymisation rows (user_id NULL), keeping index compact
- Verify sentinel asserts index exists and is partial (CI enforcement)

Closes #4453

Ref #4417

## Changelog

- Added migration `071_messages_user_id_partial_idx.sql` with partial index on `messages(user_id)`
- Added verify sentinel `071_messages_user_id_partial_idx.sql` for CI enforcement

## Test plan

- [x] Migration SQL is valid (IF NOT EXISTS = idempotent)
- [x] Verify sentinel checks both existence AND partial predicate
- [ ] Post-merge: EXPLAIN ANALYZE on dsar-export participation probe confirms index scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)