### PR TITLE
hotfix(verify): rewrite 071 sentinel to (check_name, bad) contract

### DIFF
--- a/apps/web-platform/supabase/verify/071_messages_user_id_partial_idx.sql
+++ b/apps/web-platform/supabase/verify/071_messages_user_id_partial_idx.sql
@@ -1,23 +1,26 @@
--- Verify sentinel: assert idx_messages_user_id exists and is partial.
--- CI runs this via verify-migrations job; failure blocks deploy.
+-- Verify 071_messages_user_id_partial_idx.sql.
+--
+-- Contract: every row returns `check_name` + `bad`. Any `bad > 0` row
+-- fails CI verify-migrations.
+--
+-- Sentinels confirm post-apply state from migration 071:
+--   * idx_messages_user_id exists on public.messages
+--   * idx_messages_user_id is a partial index (has a WHERE predicate)
 
-DO $$
-BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_indexes
-    WHERE schemaname = 'public'
-      AND tablename = 'messages'
-      AND indexname = 'idx_messages_user_id'
-  ) THEN
-    RAISE EXCEPTION 'idx_messages_user_id does not exist on public.messages';
-  END IF;
-
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_index i
-    JOIN pg_class c ON c.oid = i.indexrelid
-    WHERE c.relname = 'idx_messages_user_id'
-      AND i.indpred IS NOT NULL
-  ) THEN
-    RAISE EXCEPTION 'idx_messages_user_id exists but is not a partial index';
-  END IF;
-END $$;
+-- (1) idx_messages_user_id exists
+SELECT 'idx_messages_user_id_exists' AS check_name,
+       CASE WHEN EXISTS (
+         SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'public'
+           AND tablename = 'messages'
+           AND indexname = 'idx_messages_user_id'
+       ) THEN 0 ELSE 1 END::int AS bad
+UNION ALL
+-- (2) idx_messages_user_id is a partial index (has predicate)
+SELECT 'idx_messages_user_id_is_partial',
+       CASE WHEN EXISTS (
+         SELECT 1 FROM pg_index i
+         JOIN pg_class c ON c.oid = i.indexrelid
+         WHERE c.relname = 'idx_messages_user_id'
+           AND i.indpred IS NOT NULL
+       ) THEN 0 ELSE 1 END::int;


### PR DESCRIPTION
## Summary

- Rewrites `071_messages_user_id_partial_idx.sql` verify sentinel from `DO $$` / `RAISE EXCEPTION` to the `(check_name, bad)` row contract required by `run-verify.sh`
- The `DO $$` pattern emits `DO` as a psql status message, which the runner parses as `check_name=DO, bad=''` — failing with "bad column is not an integer"
- This was blocking the Web Platform Release workflow on every merge to main

Closes #4453

## Changelog

- **Fix:** Verify sentinel 071 rewritten to SELECT-based `(check_name, bad)` rows matching all other verify files

## Test plan

- [x] Verify file follows the same pattern as `069_jti_deny_grant_restore.sql` (passing sentinel)
- [x] Two checks: index existence + partial predicate presence

Generated with [Claude Code](https://claude.com/claude-code)