### PR TITLE
fix(docs): sanitize apex-host URLs in changelog release bodies

### DIFF
--- a/plugins/soleur/docs/_data/github.js
+++ b/plugins/soleur/docs/_data/github.js
@@ -46,11 +46,13 @@ export default async function () {
 
   const version = releases[0]?.tag_name?.replace(/^v/, "") ?? null;
 
+  const APEX_RE = /https:\/\/soleur\.ai(?=$|[^a-zA-Z0-9.-])/g;
   const changelogMd = releases
     .map((r) => {
       const date = r.published_at?.slice(0, 10) ?? "";
       const tag = r.tag_name ?? "";
-      return `## ${tag} — ${date}\n\n${r.body ?? ""}`;
+      const body = (r.body ?? "").replace(APEX_RE, "https://www.soleur.ai");
+      return `## ${tag} — ${date}\n\n${body}`;
     })
     .join("\n\n");
 


### PR DESCRIPTION
## Summary

- Rewrite `https://soleur.ai` to `https://www.soleur.ai` in GitHub release bodies before Eleventy renders them to the changelog page
- Fixes the apex-host canonical gate failure caused by a release body describing the normalizer feature (`[https://soleur.ai]` → `[LINK_HOME_TEXT]`)

## Changelog

- **fix:** Docs deploy no longer fails when release bodies contain apex-host URLs

## Test plan

- [x] Regex matches the same pattern as the CI gate (`https://soleur.ai` followed by non-alnum or EOL)
- [x] Replacement uses `www.soleur.ai` which passes the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)