### PR TITLE
docs(feature-flags): fill PR #4469 reference in dev-signin stay-ENV comment

### DIFF
--- a/apps/web-platform/lib/feature-flags/server.ts
+++ b/apps/web-platform/lib/feature-flags/server.ts
@@ -22,7 +22,7 @@ const CACHE_TTL_MS = 30_000;
 // literals are what SWC/Terser need to eliminate the panel.
 //
 // team-workspace-invite and byok-delegations were historically ENV (per-org
-// allowlist gate) and migrated to RUNTIME_FLAGS in PR #TBD (umbrella #4456)
+// allowlist gate) and migrated to RUNTIME_FLAGS in PR #4469 (umbrella #4456)
 // under dual-control (Flagsmith boolean + env-allowlist as defense-in-depth).
 //
 // New flags: if the call-site needs DCE elimination → ENV. Otherwise → RUNTIME.


### PR DESCRIPTION
## Summary

- Replace `PR #TBD` placeholder with `PR #4469` in the dev-signin stay-ENV comment block
- Final PR (3/3) of umbrella #4456: both flags migrated, WORM audit shipped, comment finalized

Closes #4456

## Changelog

- **docs:** Fill PR reference in feature-flags server.ts comment

## Test plan

- [x] Comment-only change — no behavior change
- [x] `tsc --noEmit` unaffected (comment, not code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)