### PR TITLE
fix(ci): sync deploy-pipeline-fix trigger arrays with new infra-config files

### DIFF
--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -594,8 +594,10 @@ DEPLOY_PIPELINE_FIX_TRIGGERS=(
   "apps/web-platform/infra/canary-bundle-claim-check.sh"
   "apps/web-platform/infra/hooks.json.tmpl"
   "apps/web-platform/infra/deploy-inngest-bootstrap.sudoers"
+  "apps/web-platform/infra/infra-config-apply.sh"
+  "apps/web-platform/infra/push-infra-config.sh"
 )
-DPF_REGEX='^apps/web-platform/infra/(ci-deploy\.sh|ci-deploy-wrapper\.sh|webhook\.service|cat-deploy-state\.sh|canary-bundle-claim-check\.sh|hooks\.json\.tmpl|deploy-inngest-bootstrap\.sudoers)$'
+DPF_REGEX='^apps/web-platform/infra/(ci-deploy\.sh|ci-deploy-wrapper\.sh|webhook\.service|cat-deploy-state\.sh|canary-bundle-claim-check\.sh|hooks\.json\.tmpl|deploy-inngest-bootstrap\.sudoers|infra-config-apply\.sh|push-infra-config\.sh)$'
 
 git diff --name-only origin/main...HEAD | grep -E "$DPF_REGEX"
 ```

--- a/plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts
+++ b/plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts
@@ -37,6 +37,8 @@ const TRIGGER_FILES = [
   "apps/web-platform/infra/canary-bundle-claim-check.sh",
   "apps/web-platform/infra/hooks.json.tmpl",
   "apps/web-platform/infra/deploy-inngest-bootstrap.sudoers",
+  "apps/web-platform/infra/infra-config-apply.sh",
+  "apps/web-platform/infra/push-infra-config.sh",
 ];
 
 function buildTriggerRegex(files: string[]): RegExp {


### PR DESCRIPTION
## Summary

- Adds `infra-config-apply.sh` and `push-infra-config.sh` to the `TRIGGER_FILES` array in `ship-deploy-pipeline-fix-gate.test.ts` and the `DEPLOY_PIPELINE_FIX_TRIGGERS` + `DPF_REGEX` in `ship/SKILL.md`
- These files were added to `server.tf` `triggers_replace` and the workflow `paths:` filter in #4492 but the drift guard test and skill arrays were not updated

Fixes CI `test-bun` failure on main post-#4492 merge.

## Changelog

- Synced drift guard test and ship skill trigger arrays with new infra-config webhook files from #4492

## Test plan

- [x] `bun test plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts` — 51 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)