### PR TITLE
docs(runbook): document cron-bug-fixer manual-trigger event + override semantics

### DIFF
--- a/knowledge-base/engineering/ops/runbooks/inngest-server.md
+++ b/knowledge-base/engineering/ops/runbooks/inngest-server.md
@@ -14,6 +14,7 @@ Per ADR-030 the Inngest server runs as a single-host SQLite-backed durable trigg
 | Inngest CLI version bump | [§ Version bump](#cli-version-bump) |
 | FR5 flag flip | [§ FR5 flip](#fr5-flag-flip) |
 | Unpause heartbeat after first ping | [§ Unpause heartbeat](#unpause-heartbeat) |
+| Cron bug-fixer manual trigger | [§ Cron bug-fixer](#cron-bug-fixer) |
 
 ## Fresh-host bootstrap
 
@@ -168,6 +169,65 @@ Stopping inngest-server before VACUUM is required (SQLite write lock). Downtime 
 
 - **One `terraform apply` at a time.** The R2 backend has `use_lockfile = false` (R2 does not support S3 conditional writes). Concurrent applies race silently. R7 in the plan documents this.
 - **`inngest-bootstrap.sh` is idempotent** — second invocation against the same version is a ~50ms no-op via `systemctl is-active` + version-file match. Safe to re-run.
+
+## Cron bug-fixer
+
+The cron-bug-fixer Inngest function (`apps/web-platform/server/inngest/functions/cron-bug-fixer.ts`) runs daily at `0 6 * * *` UTC, selecting a qualifying `type/bug` issue and spawning `claude-code` to fix it. It also accepts a manual-trigger event for operator-initiated runs.
+
+### Event name and payload
+
+- **Event:** `cron/bug-fixer.manual-trigger`
+- **Payload:** `{ "issue_number": <positive integer> }` (optional)
+- **Validation:** If `issue_number` is present, it must be a positive integer (`typeof === "number"`, `Number.isInteger()`, `> 0`). Invalid values are rejected with a Sentry fallback report and the function returns `ok: false` without selecting any issue.
+
+When `issue_number` is omitted, the function falls through to the priority cascade (see Override semantics).
+
+### Override semantics
+
+- **Without override:** The handler runs the priority cascade, selecting the first qualifying issue in order: `priority/p3-low` → `priority/p2-medium` → `priority/p1-high`. Issues matching the title skip-regex (`/^\[Content Publisher\]|flaky|flake|test-flake|test/i`) or carrying skip-labels (`bot-fix/attempted`, `ux-audit`, `synthetic-test`) are excluded.
+- **With override:** The `issue_number` bypasses the cascade entirely. The operator owns ensuring the target issue is fix-issue-compatible (has `type/bug` label, is open, is not in the skip-list). The handler does not re-validate these constraints on override.
+
+### Concurrency
+
+- **fn-scoped limit 1:** Only one `cron-bug-fixer` invocation runs at a time.
+- **account-scoped `cron-platform` limit 1:** Shared across all `cron-*` functions using the `cron-platform` key. A manual trigger queues behind any in-flight cron run (daily-triage, follow-through-monitor, etc.).
+- **Retries:** 1 (Inngest retries once on non-terminal failure).
+
+Manual triggers do NOT preempt scheduled runs — they queue behind them.
+
+### How to fire
+
+**CLI (preferred):**
+```bash
+inngest send '{"name":"cron/bug-fixer.manual-trigger","data":{"issue_number":4383}}'
+```
+
+Without `issue_number` (runs the default cascade):
+```bash
+inngest send '{"name":"cron/bug-fixer.manual-trigger","data":{}}'
+```
+
+**Inngest dashboard:** Navigate to the Events tab → Send Event → paste the JSON body above.
+
+### How to observe results
+
+1. **Sentry cron monitor:** `scheduled-bug-fixer` — shows `ok` / `error` heartbeat status per run.
+2. **GitHub PRs:** Filter by `bot-fix/*` branch prefix — `gh pr list --search "head:bot-fix/"`.
+3. **Inngest dashboard:** Run history for `cron-bug-fixer` shows step-by-step execution (mint-installation-token → precreate-labels → select-issue → setup-workspace → claude-eval → detect-pr → auto-merge-gate → sentry-heartbeat).
+
+### Common failure modes
+
+| Mode | Symptom | Resolution |
+|------|---------|------------|
+| Invalid override | Sentry fallback: "Manual-trigger issue_number must be a positive integer" | Re-send with a valid positive integer |
+| Empty cascade | Function returns `ok: true`, `selectedIssue: null` — no qualifying issue at any priority level | Expected when no open `type/bug` issues exist; no action needed |
+| claude-eval timeout | Sentry fallback: "claude-eval aborted by timeout (3000000ms budget exceeded)" | The 50-minute AbortController fired; check Anthropic usage for the aborted run |
+| Workspace setup failure | Sentry fallback: "Failed to scaffold ephemeral cron workspace" | Check GitHub App installation token minting, repo clone permissions |
+| No PR detected | Warning log: "No bot-fix PR detected after claude-eval" | The agent did not produce a PR — review the claude-eval step output in Inngest dashboard |
+| Auto-merge gate: non-bot author | Gate returns "author is not a recognized bot" | PR was opened by a human or unrecognized bot account |
+| Auto-merge gate: missing label | Gate returns "missing bot-fix/auto-merge-eligible label" | Agent did not add the eligibility label; review PR manually |
+| Auto-merge gate: multi-file diff | Gate strips eligibility label, adds `bot-fix/review-required` | PR touches >1 file; requires human review before merge |
+| Auto-merge gate: non-p3-low source | Gate strips eligibility label, adds `bot-fix/review-required` | Source issue priority is not `priority/p3-low`; requires human review |
 
 ## Plan deviations from `2026-05-18-feat-pr-f-inngest-iac-plan.md`
 

--- a/knowledge-base/engineering/ops/runbooks/inngest-server.md
+++ b/knowledge-base/engineering/ops/runbooks/inngest-server.md
@@ -178,13 +178,13 @@ The cron-bug-fixer Inngest function (`apps/web-platform/server/inngest/functions
 
 - **Event:** `cron/bug-fixer.manual-trigger`
 - **Payload:** `{ "issue_number": <positive integer> }` (optional)
-- **Validation:** If `issue_number` is present, it must be a positive integer (`typeof === "number"`, `Number.isInteger()`, `> 0`). Invalid values are rejected with a Sentry fallback report and the function returns `ok: false` without selecting any issue.
+- **Validation:** If `issue_number` is present, it must be a positive integer. Invalid values are rejected with a Sentry fallback report and the function returns `ok: false` without selecting any issue.
 
 When `issue_number` is omitted, the function falls through to the priority cascade (see Override semantics).
 
 ### Override semantics
 
-- **Without override:** The handler runs the priority cascade, selecting the first qualifying issue in order: `priority/p3-low` → `priority/p2-medium` → `priority/p1-high`. Issues matching the title skip-regex (`/^\[Content Publisher\]|flaky|flake|test-flake|test/i`) or carrying skip-labels (`bot-fix/attempted`, `ux-audit`, `synthetic-test`) are excluded.
+- **Without override:** The handler runs the priority cascade, selecting the first qualifying issue in order: `priority/p3-low` → `priority/p2-medium` → `priority/p1-high`. Issues matching the title skip-regex (`/^(\[Content Publisher\]|flaky|flake|test-flake|test)[: [(]/i`) or carrying skip-labels (`bot-fix/attempted`, `ux-audit`, `synthetic-test`) are excluded.
 - **With override:** The `issue_number` bypasses the cascade entirely. The operator owns ensuring the target issue is fix-issue-compatible (has `type/bug` label, is open, is not in the skip-list). The handler does not re-validate these constraints on override.
 
 ### Concurrency
@@ -213,7 +213,7 @@ inngest send '{"name":"cron/bug-fixer.manual-trigger","data":{}}'
 
 1. **Sentry cron monitor:** `scheduled-bug-fixer` — shows `ok` / `error` heartbeat status per run.
 2. **GitHub PRs:** Filter by `bot-fix/*` branch prefix — `gh pr list --search "head:bot-fix/"`.
-3. **Inngest dashboard:** Run history for `cron-bug-fixer` shows step-by-step execution (mint-installation-token → precreate-labels → select-issue → setup-workspace → claude-eval → detect-pr → auto-merge-gate → sentry-heartbeat).
+3. **Inngest dashboard:** Run history for `cron-bug-fixer` shows step-by-step execution (mint-installation-token → precreate-labels → select-issue → setup-workspace → claude-eval → detect-pr → auto-merge-gate → notify-ops-email → sentry-heartbeat).
 
 ### Common failure modes
 

--- a/knowledge-base/project/plans/2026-05-26-docs-cron-bug-fixer-runbook-plan.md
+++ b/knowledge-base/project/plans/2026-05-26-docs-cron-bug-fixer-runbook-plan.md
@@ -1,0 +1,118 @@
+---
+title: "docs: document cron-bug-fixer manual-trigger event + override semantics"
+type: fix
+date: 2026-05-26
+lane: single-domain
+---
+
+# docs(runbook): document cron-bug-fixer manual-trigger event + override semantics
+
+## Overview
+
+Add a "Cron bug-fixer" section to `knowledge-base/engineering/ops/runbooks/inngest-server.md` documenting the manual-trigger event, override semantics, concurrency behavior, how to fire, how to observe results, and common failure modes. Closes #4383.
+
+The cron-bug-fixer function (`apps/web-platform/server/inngest/functions/cron-bug-fixer.ts`) was migrated from the GHA `scheduled-bug-fixer.yml` workflow in TR9 PR-5 (#4377). Its manual-trigger semantics are currently documented only in the source header comment and the archived PR-5 plan. An agent or operator outside the original implementation context has no canonical runbook to consult.
+
+## Research Insights
+
+- **Existing runbook:** `knowledge-base/engineering/ops/runbooks/inngest-server.md` (326 lines) covers bootstrap, heartbeat triage, key rotation, CLI version bump, FR5 flag flip, unpause heartbeat, SQLite retention, concurrency conventions, and fresh-host provisioning. No mention of the bug-fixer function.
+- **Source of truth:** `cron-bug-fixer.ts` lines 582-839 define the handler, registration, event trigger, validation, and concurrency config.
+- **Event name:** `cron/bug-fixer.manual-trigger` (registered at line 837).
+- **Payload shape:** `{ issue_number?: number }` — optional positive integer (validated at lines 594-621).
+- **Concurrency:** Dual scope: `fn` limit 1 + `account` key `"cron-platform"` limit 1 (lines 831-835). Retries: 1.
+- **Scheduled trigger:** `0 6 * * *` UTC (line 837).
+- **Sentry monitor slug:** `scheduled-bug-fixer` (line 73).
+- **Event send precedent:** Sibling runbooks use two forms: `inngest send <event> --data '{...}'` (github-app-drift.md) and `inngest send '{"name":"...","data":{...}}'` (ship-merge-trigger.md). Both forms are valid.
+- **No external research needed.** All content derives from the implementation source code and existing runbook patterns. Strong local context.
+
+## User-Brand Impact
+
+- **If this lands broken, the user experiences:** stale or incorrect runbook instructions leading to a failed manual trigger attempt.
+- **If this leaks, the user's [data / workflow / money] is exposed via:** N/A — this is pure documentation with no secrets or code changes.
+- **Brand-survival threshold:** `none`
+
+## Proposed Solution
+
+Add a new `## Cron bug-fixer` section to `inngest-server.md` (between the existing "Concurrency conventions" section and "Plan deviations" section) containing subsections for:
+
+1. **Event name + payload shape + validation rules** — the event name, the optional `issue_number` field, type validation (positive integer), and rejection behavior.
+2. **Override semantics** — bypass of the priority cascade, operator responsibility for issue-compatibility.
+3. **Concurrency behavior** — fn-scoped limit 1 + account-scoped `cron-platform` limit 1 queuing.
+4. **How to fire** — both `inngest send` CLI form and the Inngest dashboard UI approach.
+5. **How to observe results** — Sentry monitor, `bot-fix/*` PR list on GitHub, Inngest dashboard run history.
+6. **Common failure modes** — override rejected, cascade returns no qualifying issue, claude-eval over-budget, workspace setup failure, no PR detected after eval, auto-merge gate rejection (non-bot author, missing label, multi-file diff, non-p3-low source issue).
+
+Also add a row to the Quick Reference table at the top of the file.
+
+## Acceptance Criteria
+
+- [ ] AC1 — `knowledge-base/engineering/ops/runbooks/inngest-server.md` contains a `## Cron bug-fixer` section with subsections for: event name/payload, override semantics, concurrency, how to fire, how to observe, common failure modes.
+- [ ] AC2 — Quick Reference table includes a row linking to the new section.
+- [ ] AC3 — Event name matches source: `cron/bug-fixer.manual-trigger`.
+- [ ] AC4 — Payload shape documented as `{ "issue_number": <positive integer> }` (optional).
+- [ ] AC5 — Override semantics document that override bypasses the priority cascade and operator owns ensuring issue compatibility.
+- [ ] AC6 — Concurrency section documents dual-scope (fn limit 1 + account `cron-platform` limit 1) and that manual triggers queue behind in-flight runs.
+- [ ] AC7 — "How to fire" section shows `inngest send` CLI invocation form.
+- [ ] AC8 — "How to observe" section references Sentry monitor `scheduled-bug-fixer` and `bot-fix/*` PR branch prefix.
+- [ ] AC9 — "Common failure modes" section lists at least 5 modes documented in the handler (override rejection, empty cascade, timeout, workspace failure, no PR detected, auto-merge gate rejection).
+- [ ] AC10 — No `ssh ` commands appear in the new section (per `hr-no-ssh-fallback-in-runbooks`).
+- [ ] AC11 — PR body uses `Closes #4383` to auto-close the issue on merge.
+
+## Test Scenarios
+
+- Given the updated runbook, when an operator searches for "bug-fixer" within `inngest-server.md`, then the section is findable.
+- Given the event name in the runbook, when an operator copies the `inngest send` command verbatim, then the Inngest server accepts the event.
+- Given the documented payload shape, when an operator sends `{"issue_number": "abc"}`, then the handler rejects with a Sentry fallback report (as documented in the failure modes section).
+
+## Implementation Phases
+
+### Phase 1: Add cron bug-fixer section to inngest-server.md
+
+1. Read `knowledge-base/engineering/ops/runbooks/inngest-server.md`.
+2. Add a row to the Quick Reference table: `| Cron bug-fixer manual trigger | [section link] |`.
+3. Insert a `## Cron bug-fixer` section between `## Concurrency conventions` and `## Plan deviations`. Content derived from `cron-bug-fixer.ts` lines 582-839.
+
+### Phase 2: Verification
+
+1. Verify the section heading exists: `grep -c '## Cron bug-fixer' knowledge-base/engineering/ops/runbooks/inngest-server.md` returns 1.
+2. Verify no SSH commands: `grep -c 'ssh ' <new-section-content>` returns 0.
+3. Verify event name: `grep -c 'cron/bug-fixer.manual-trigger' knowledge-base/engineering/ops/runbooks/inngest-server.md` returns >= 1.
+
+## Files to Edit
+
+- `knowledge-base/engineering/ops/runbooks/inngest-server.md` — add Quick Reference row + new `## Cron bug-fixer` section.
+
+## Files to Create
+
+None.
+
+## Open Code-Review Overlap
+
+#4383 itself is the code-review issue this plan closes. No other open code-review issues touch `inngest-server.md`.
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected — pure documentation addition to an existing engineering runbook.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Runbook content drifts from implementation | Event name, payload shape, and concurrency config are derived from source code with specific line references. Future refactors should update the runbook. |
+| Inngest CLI `send` invocation form changes between versions | Document the JSON-body form which is the most stable across Inngest CLI versions. |
+
+## Context
+
+- Source: PR #4377 (TR9 PR-5), 10-agent review. Agent-native-reviewer Observation 1.
+- Implementation: `apps/web-platform/server/inngest/functions/cron-bug-fixer.ts`
+- Umbrella: #3948
+- Existing runbook: `knowledge-base/engineering/ops/runbooks/inngest-server.md`
+
+## References
+
+- Issue: #4383
+- PR #4377 (TR9 PR-5 — cron-bug-fixer Inngest migration)
+- Plan: `knowledge-base/project/plans/2026-05-24-feat-tr9-pr5-bug-fixer-inngest-migration-plan.md`
+- ADR-030 (Inngest as durable trigger layer)

--- a/knowledge-base/project/plans/2026-05-26-docs-cron-bug-fixer-runbook-plan.md
+++ b/knowledge-base/project/plans/2026-05-26-docs-cron-bug-fixer-runbook-plan.md
@@ -46,17 +46,17 @@ Also add a row to the Quick Reference table at the top of the file.
 
 ## Acceptance Criteria
 
-- [ ] AC1 — `knowledge-base/engineering/ops/runbooks/inngest-server.md` contains a `## Cron bug-fixer` section with subsections for: event name/payload, override semantics, concurrency, how to fire, how to observe, common failure modes.
-- [ ] AC2 — Quick Reference table includes a row linking to the new section.
-- [ ] AC3 — Event name matches source: `cron/bug-fixer.manual-trigger`.
-- [ ] AC4 — Payload shape documented as `{ "issue_number": <positive integer> }` (optional).
-- [ ] AC5 — Override semantics document that override bypasses the priority cascade and operator owns ensuring issue compatibility.
-- [ ] AC6 — Concurrency section documents dual-scope (fn limit 1 + account `cron-platform` limit 1) and that manual triggers queue behind in-flight runs.
-- [ ] AC7 — "How to fire" section shows `inngest send` CLI invocation form.
-- [ ] AC8 — "How to observe" section references Sentry monitor `scheduled-bug-fixer` and `bot-fix/*` PR branch prefix.
-- [ ] AC9 — "Common failure modes" section lists at least 5 modes documented in the handler (override rejection, empty cascade, timeout, workspace failure, no PR detected, auto-merge gate rejection).
-- [ ] AC10 — No `ssh ` commands appear in the new section (per `hr-no-ssh-fallback-in-runbooks`).
-- [ ] AC11 — PR body uses `Closes #4383` to auto-close the issue on merge.
+- [x] AC1 — `knowledge-base/engineering/ops/runbooks/inngest-server.md` contains a `## Cron bug-fixer` section with subsections for: event name/payload, override semantics, concurrency, how to fire, how to observe, common failure modes.
+- [x] AC2 — Quick Reference table includes a row linking to the new section.
+- [x] AC3 — Event name matches source: `cron/bug-fixer.manual-trigger`.
+- [x] AC4 — Payload shape documented as `{ "issue_number": <positive integer> }` (optional).
+- [x] AC5 — Override semantics document that override bypasses the priority cascade and operator owns ensuring issue compatibility.
+- [x] AC6 — Concurrency section documents dual-scope (fn limit 1 + account `cron-platform` limit 1) and that manual triggers queue behind in-flight runs.
+- [x] AC7 — "How to fire" section shows `inngest send` CLI invocation form.
+- [x] AC8 — "How to observe" section references Sentry monitor `scheduled-bug-fixer` and `bot-fix/*` PR branch prefix.
+- [x] AC9 — "Common failure modes" section lists at least 5 modes documented in the handler (override rejection, empty cascade, timeout, workspace failure, no PR detected, auto-merge gate rejection).
+- [x] AC10 — No `ssh ` commands appear in the new section (per `hr-no-ssh-fallback-in-runbooks`).
+- [x] AC11 — PR body uses `Closes #4383` to auto-close the issue on merge.
 
 ## Test Scenarios
 

--- a/knowledge-base/project/specs/feat-one-shot-4383-cron-bug-fixer-runbook/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-4383-cron-bug-fixer-runbook/session-state.md
@@ -1,0 +1,19 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-05-26-docs-cron-bug-fixer-runbook-plan.md
+- Status: complete
+
+### Errors
+None
+
+### Decisions
+- Add bug-fixer runbook as a new section in existing inngest-server.md (not a separate file)
+- Document event name, payload shape, validation rules, override semantics, concurrency behavior
+- Include Inngest send command for manual triggering
+- Document auto-merge gate failure modes (from plan review P2)
+- 9 acceptance criteria covering all documented sections
+
+### Components Invoked
+- soleur:plan
+- soleur:deepen-plan (plan-review with DHH, Kieran, Code Simplicity reviewers)

--- a/knowledge-base/project/specs/feat-one-shot-4383-cron-bug-fixer-runbook/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-4383-cron-bug-fixer-runbook/tasks.md
@@ -1,0 +1,27 @@
+---
+title: "docs: document cron-bug-fixer manual-trigger event + override semantics"
+status: pending
+lane: single-domain
+---
+
+# Tasks: cron-bug-fixer runbook documentation
+
+## Phase 1: Add cron bug-fixer section to inngest-server.md
+
+- [ ] 1.1 Read `knowledge-base/engineering/ops/runbooks/inngest-server.md`
+- [ ] 1.2 Add Quick Reference table row: `| Cron bug-fixer manual trigger | [link] |`
+- [ ] 1.3 Insert `## Cron bug-fixer` section between `## Concurrency conventions` and `## Plan deviations`
+  - [ ] 1.3.1 Document event name: `cron/bug-fixer.manual-trigger`
+  - [ ] 1.3.2 Document payload shape: `{ "issue_number": <positive integer> }` (optional)
+  - [ ] 1.3.3 Document validation rules (positive integer, rejection with Sentry fallback)
+  - [ ] 1.3.4 Document override semantics (bypasses cascade, operator owns compatibility)
+  - [ ] 1.3.5 Document concurrency (fn limit 1 + account `cron-platform` limit 1, queuing)
+  - [ ] 1.3.6 Document how to fire (`inngest send` CLI + dashboard)
+  - [ ] 1.3.7 Document how to observe (Sentry `scheduled-bug-fixer`, `bot-fix/*` PRs, dashboard)
+  - [ ] 1.3.8 Document common failure modes (override rejection, empty cascade, timeout, workspace failure, no PR detected, auto-merge gate rejection)
+
+## Phase 2: Verification
+
+- [ ] 2.1 Verify section heading: `grep -c '## Cron bug-fixer' knowledge-base/engineering/ops/runbooks/inngest-server.md` returns 1
+- [ ] 2.2 Verify no SSH: `grep -c 'ssh ' <new-section>` returns 0
+- [ ] 2.3 Verify event name present: `grep -c 'cron/bug-fixer.manual-trigger' knowledge-base/engineering/ops/runbooks/inngest-server.md` >= 1


### PR DESCRIPTION
## Summary
- Add a "Cron bug-fixer" section to `knowledge-base/engineering/ops/runbooks/inngest-server.md`
- Document event name (`cron/bug-fixer.manual-trigger`), payload shape, validation rules
- Document override semantics, concurrency behavior, firing instructions, observability surface
- Document 9 common failure modes including auto-merge gate rejection criteria
- Add Quick Reference table row linking to the new section

Closes #4383

## Changelog
- Added cron-bug-fixer manual-trigger runbook section to inngest-server.md

## Test plan
- [x] Section heading exists: `grep -c '## Cron bug-fixer' inngest-server.md` returns 1
- [x] No SSH commands in new section (per `hr-no-ssh-fallback-in-runbooks`)
- [x] Event name matches source: `cron/bug-fixer.manual-trigger`
- [x] Skip-regex matches source verbatim
- [x] All 9 Inngest step names documented

Generated with [Claude Code](https://claude.com/claude-code)