### PR TITLE
feat(ship,postmerge): CI auto-fix via test-fix-loop and Sentry cron monitor check

### DIFF
--- a/knowledge-base/project/brainstorms/2026-05-26-post-ship-autonomous-monitor-brainstorm.md
+++ b/knowledge-base/project/brainstorms/2026-05-26-post-ship-autonomous-monitor-brainstorm.md
@@ -1,0 +1,46 @@
+# Post-Ship Autonomous Monitor
+
+**Date:** 2026-05-26
+**Status:** Ready for planning
+**Lane:** single-domain
+
+## What We're Building
+
+End-to-end autonomous post-ship pipeline: from auto-merge queue through production health verification. Today the workflow stops at "auto-merge enabled" which leaves a gap — CI failures block merge silently, Sentry regressions go unnoticed until the next session, and postmerge is never chained automatically.
+
+Three changes close the gap:
+
+1. **CI failure auto-fix in ship Phase 7**: When a required check fails during the merge poll, attempt diagnosis and fix (run failing tests, commit fix, push, re-queue auto-merge). Cap at 2 attempts before escalating.
+2. **Auto-chain to postmerge**: After ship Phase 7 confirms merge + release workflows pass, invoke `/soleur:postmerge` automatically with the PR number.
+3. **Sentry regression check in postmerge**: New phase — (a) verify Sentry cron monitors report `ok` post-deploy, (b) compare error count 15-min post-deploy vs 15-min pre-deploy, flag >2x spike.
+
+## Why This Approach
+
+- Extends existing skills (ship + postmerge) rather than creating new ones
+- Ship Phase 7 already has the merge poll loop, release workflow verification, and follow-through detection — CI auto-fix is a natural addition to the failure branch
+- Postmerge already has health checks, browser verification, and issue updates — Sentry check is a natural new phase
+- Monitor tool replaces bash polling loops for reliability
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Where to add CI auto-fix | Ship Phase 7 failure branch | Already detects required-check failures; today it just reports |
+| Where to add Sentry check | Postmerge new Phase 3.5 | Postmerge owns production verification; Sentry is a production signal |
+| Polling mechanism | Monitor tool everywhere | Bash `while` + `sleep` loops are unreliable in Claude Code (sleep blocked, context consumed, no notifications). Monitor tool is purpose-built. |
+| Auto-chain trigger | Ship Phase 7, after release workflows pass | Natural handoff point — merge confirmed, deploy in progress |
+| Sentry check: window | 15 minutes post-deploy | Enough time for errors to surface without false positives from cold-start transients |
+| Sentry check: threshold | >2x error count vs pre-deploy baseline | Detects regressions without flagging normal background noise |
+| Sentry check: monitors | Also verify cron monitor heartbeats report `ok` | Covers scheduled function health, not just request-path errors |
+| CI auto-fix: attempt cap | 2 fix attempts before escalating | Prevents infinite fix-break loops while catching most transient issues |
+| CI auto-fix: scope | Only required checks, not optional/informational | Don't block merge on non-required checks |
+
+## Open Questions
+
+1. **Sentry API authentication**: Credentials are in Doppler `prd` as `SENTRY_API_TOKEN` — need to verify this is available in the operator's shell session or if we need `doppler run`
+2. **Sentry release naming**: Verify the release tag format matches what the web-platform release workflow publishes (likely `web-platform@X.Y.Z+<sha>`)
+3. **Monitor tool timeout**: The Monitor tool has per-line notifications — need to design the poll commands to emit state-change events efficiently
+
+## Inciting Incident
+
+PR #4498 was shipped during this session. After enabling auto-merge, the agent stopped. The PR needed a rebase (pre-merge hook handled it), but there was no autonomous monitoring of CI status, merge completion, or production health. Meanwhile, the very Sentry error that triggered this session (`cron-oauth-probe` JWT decode failure) demonstrated that production errors can surface immediately after deploy and need automated detection.

--- a/knowledge-base/project/brainstorms/2026-05-26-post-ship-autonomous-monitor-brainstorm.md
+++ b/knowledge-base/project/brainstorms/2026-05-26-post-ship-autonomous-monitor-brainstorm.md
@@ -10,9 +10,9 @@ End-to-end autonomous post-ship pipeline: from auto-merge queue through producti
 
 Three changes close the gap:
 
-1. **CI failure auto-fix in ship Phase 7**: When a required check fails during the merge poll, attempt diagnosis and fix (run failing tests, commit fix, push, re-queue auto-merge). Cap at 2 attempts before escalating.
+1. **CI failure auto-fix in ship Phase 7**: When a required check fails during the merge poll, attempt diagnosis and fix (run failing tests, commit fix, push, re-queue auto-merge). Cap at 1 attempt before escalating (reduced from 2 per plan review).
 2. **Auto-chain to postmerge**: After ship Phase 7 confirms merge + release workflows pass, invoke `/soleur:postmerge` automatically with the PR number.
-3. **Sentry regression check in postmerge**: New phase — (a) verify Sentry cron monitors report `ok` post-deploy, (b) compare error count 15-min post-deploy vs 15-min pre-deploy, flag >2x spike.
+3. **Sentry cron monitor check in postmerge**: New phase — verify Sentry cron monitors report `ok` or `active` post-deploy.
 
 ## Why This Approach
 

--- a/knowledge-base/project/plans/2026-05-26-feat-post-ship-autonomous-monitor-plan.md
+++ b/knowledge-base/project/plans/2026-05-26-feat-post-ship-autonomous-monitor-plan.md
@@ -180,13 +180,13 @@ None.
 
 ### Pre-merge (PR)
 
-- [ ] AC1: Ship SKILL.md Phase 7 CI failure handler delegates to `test-fix-loop` (1 attempt, then escalate)
-- [ ] AC2: Ship SKILL.md Phase 7 CI failure handler distinguishes required-check-failure exit (PR OPEN) from CLOSED exit — no `gh pr reopen` needed for the primary path
-- [ ] AC3: Ship SKILL.md Phase 7 contains `skill: soleur:postmerge` invocation after release workflow verification passes
-- [ ] AC4: Postmerge SKILL.md contains Phase 3.5 with Sentry cron monitor health check using `SENTRY_AUTH_TOKEN` (with `SENTRY_API_TOKEN` fallback)
-- [ ] AC5: Postmerge Phase 7 report and Phase 6 issue comment include Sentry monitor results
-- [ ] AC6: Phase 7 poll block mirror note (`merge-pr/SKILL.md §5.2`) is NOT affected (CI auto-fix is outside the poll block)
-- [ ] AC7: Sentry check is advisory (warn, don't block) with graceful degradation on API failure
+- [x] AC1: Ship SKILL.md Phase 7 CI failure handler delegates to `test-fix-loop` (1 attempt, then escalate)
+- [x] AC2: Ship SKILL.md Phase 7 CI failure handler distinguishes required-check-failure exit (PR OPEN) from CLOSED exit — no `gh pr reopen` needed for the primary path
+- [x] AC3: Ship SKILL.md Phase 7 contains `skill: soleur:postmerge` invocation after release workflow verification passes
+- [x] AC4: Postmerge SKILL.md contains Phase 3.5 with Sentry cron monitor health check using `SENTRY_AUTH_TOKEN` (with `SENTRY_API_TOKEN` fallback)
+- [x] AC5: Postmerge Phase 7 report and Phase 6 issue comment include Sentry monitor results
+- [x] AC6: Phase 7 poll block mirror note (`merge-pr/SKILL.md §5.2`) is NOT affected (CI auto-fix is outside the poll block)
+- [x] AC7: Sentry check is advisory (warn, don't block) with graceful degradation on API failure
 
 ### Post-merge (operator)
 

--- a/knowledge-base/project/plans/2026-05-26-feat-post-ship-autonomous-monitor-plan.md
+++ b/knowledge-base/project/plans/2026-05-26-feat-post-ship-autonomous-monitor-plan.md
@@ -1,0 +1,250 @@
+---
+title: "feat: post-ship autonomous monitor — CI auto-fix, postmerge chain, Sentry verification"
+type: feat
+date: 2026-05-26
+classification: ops-only-prod-write
+lane: single-domain
+brand_survival_threshold: none
+---
+
+# feat: post-ship autonomous monitor
+
+[Updated 2026-05-26] Applied 3-agent plan review findings: delegated CI auto-fix to `test-fix-loop`, dropped speculative error count comparison, dropped work/SKILL.md phase, fixed token naming, corrected exit-path handling.
+
+## Overview
+
+Close the gap between "auto-merge enabled" and "verified in production" by extending the ship and postmerge skills:
+
+1. **Ship Phase 7 CI auto-fix**: When a required check fails during the merge poll, delegate to `test-fix-loop` then push and re-queue auto-merge.
+2. **Ship → postmerge chain**: After merge + release workflows pass, automatically invoke `/soleur:postmerge`.
+3. **Postmerge Phase 3.5 Sentry check**: Query Sentry API for cron monitor health.
+
+All changes are SKILL.md edits — no application code, no infra changes. Two files: `ship/SKILL.md` and `postmerge/SKILL.md`.
+
+## User-Brand Impact
+
+- **If this lands broken, the user experiences:** no direct impact — this is operator-side CI/deploy tooling. A broken auto-fix loop could delay a bugfix delivery by one session.
+- **If this leaks, the user's data/workflow/money is exposed via:** N/A — reads Sentry API (read-only) and gh CLI (already authenticated). No new write surfaces.
+- **Brand-survival threshold:** `none`
+- `threshold: none, reason: operator-only workflow automation; no new code paths reach founders; Sentry API token is read-only and already provisioned`
+
+## Implementation Phases
+
+### Phase 0: Verify prerequisites
+
+0.1. Verify `SENTRY_AUTH_TOKEN` exists in Doppler `prd` (canonical name per `sentry-monitors-audit.sh:38`; fall back to `SENTRY_API_TOKEN`):
+```bash
+doppler secrets get SENTRY_AUTH_TOKEN -p soleur -c prd --plain 2>/dev/null | head -c 10 || \
+  doppler secrets get SENTRY_API_TOKEN -p soleur -c prd --plain | head -c 10
+```
+
+0.2. Verify Sentry org slug and live-test the monitors endpoint:
+```bash
+SENTRY_ORG=$(doppler secrets get SENTRY_ORG -p soleur -c prd --plain 2>/dev/null || echo "jikigai")
+SENTRY_TOKEN=$(doppler secrets get SENTRY_AUTH_TOKEN -p soleur -c prd --plain 2>/dev/null || \
+  doppler secrets get SENTRY_API_TOKEN -p soleur -c prd --plain)
+curl -sS -w "\n%{http_code}" -H "Authorization: Bearer ${SENTRY_TOKEN}" \
+  "https://${SENTRY_ORG}.sentry.io/api/0/organizations/${SENTRY_ORG}/monitors/?per_page=1"
+```
+Must return HTTP 200. If 401, token lacks `org:read` scope.
+
+0.3. Verify `test-fix-loop` skill exists and is loadable:
+```bash
+ls plugins/soleur/skills/test-fix-loop/SKILL.md
+```
+
+### Phase 1: Ship Phase 7 — CI auto-fix via `test-fix-loop` delegation
+
+**File:** `plugins/soleur/skills/ship/SKILL.md`
+
+The Phase 7 poll loop has two CI-failure exit paths:
+1. **Required-check failure exit** (lines 1114–1130): loop breaks with `required_failed` set, PR is still OPEN, auto-merge still queued.
+2. **CLOSED exit** (line 1106 + handler at line 1215): PR transitioned to CLOSED state (rare — merge queue rejection or manual close).
+
+**Replace lines 1215–1225 with:**
+
+```markdown
+**If the poll loop exits due to a required-check failure (PR still OPEN) or CLOSED state:**
+
+The agent maintains a `fix_attempt_count` counter (agent-level state, not a bash variable — each Monitor invocation is a fresh shell).
+
+1. Read the failure details:
+
+   ```bash
+   gh pr checks <number> --json name,state,description,detailsUrl \
+     | jq '.[] | select(.state != "SUCCESS")'
+   ```
+
+2. Identify the failing workflow run and read its logs:
+
+   ```bash
+   gh run list --branch <branch> --limit 5 --json databaseId,status,conclusion,workflowName \
+     | jq '.[] | select(.conclusion == "failure")'
+   gh run view <failing-run-id> --log-failed 2>&1 | tail -80
+   ```
+
+3. **If `fix_attempt_count >= 1`:** Escalate to the operator. **Headless mode:** abort with structured error naming the failing check. **Interactive mode:** present failure details and ask whether to investigate manually or abort.
+
+4. **If `fix_attempt_count == 0`:** Increment `fix_attempt_count`. Attempt autonomous fix:
+
+   a. If the failure is in tests or lint: invoke `skill: soleur:test-fix-loop` to diagnose, fix, and commit. After test-fix-loop completes, push and re-queue auto-merge:
+      ```bash
+      git push
+      gh pr merge <number> --squash --auto
+      ```
+      Note: `gh pr reopen` is NOT needed — when auto-merge is cancelled due to CI failure, the PR remains OPEN. Re-queuing auto-merge is sufficient.
+
+   b. If the failure is in a flaky or unrelated check (not reproducible locally): **Headless mode:** abort. **Interactive mode:** ask whether to wait for a re-run or abort.
+
+5. After re-queuing auto-merge, re-invoke the Phase 7 Monitor poll loop from the beginning. The agent carries `fix_attempt_count` across poll invocations.
+```
+
+**Mirror note:** The CI auto-fix logic is OUTSIDE the Phase 7 poll block (`<!-- phase-7-poll-block:start/end -->` markers at lines 1071/1191). The mirror in `merge-pr/SKILL.md §5.2` and fixture at `test/ship-phase-7-poll-fixtures.sh` are NOT affected.
+
+### Phase 2: Ship Phase 7 — chain to postmerge after release verification
+
+**File:** `plugins/soleur/skills/ship/SKILL.md` (insert before "4. Clean up worktree" at line ~1626)
+
+After all release/deploy workflows pass and migration verification completes, add:
+
+```markdown
+3.8. **Chain to postmerge verification.** After release workflows pass and migration verification completes, invoke `/soleur:postmerge` to verify production health, Sentry cron monitors, and file freshness:
+
+   ```
+   skill: soleur:postmerge <PR-number>
+   ```
+
+   If postmerge reports any FAILED phase (production health, Sentry warning, browser regression), display the failures prominently but do NOT block cleanup — the deploy has already happened; the signal is for immediate operator attention, not rollback.
+```
+
+### Phase 3: Postmerge Phase 3.5 — Sentry cron monitor health
+
+**File:** `plugins/soleur/skills/postmerge/SKILL.md` (insert between line 97 and line 99, i.e., between Phase 3 and Phase 4)
+
+Add a new phase:
+
+```markdown
+## Phase 3.5: Sentry Cron Monitor Health
+
+Verify scheduled functions are healthy post-deploy by querying Sentry cron monitors.
+
+**Prerequisites:** `SENTRY_AUTH_TOKEN` (or `SENTRY_API_TOKEN` fallback) must be available. If missing, warn and skip:
+
+```text
+WARNING: SENTRY_AUTH_TOKEN not set. Skipping Sentry health verification.
+```
+
+Query cron monitors:
+
+```bash
+SENTRY_TOKEN=$(doppler secrets get SENTRY_AUTH_TOKEN -p soleur -c prd --plain 2>/dev/null || \
+  doppler secrets get SENTRY_API_TOKEN -p soleur -c prd --plain)
+SENTRY_ORG=$(doppler secrets get SENTRY_ORG -p soleur -c prd --plain 2>/dev/null || echo "jikigai")
+API_HOST="${SENTRY_ORG}.sentry.io"
+
+curl -sS -H "Authorization: Bearer ${SENTRY_TOKEN}" \
+  "https://${API_HOST}/api/0/organizations/${SENTRY_ORG}/monitors/" \
+  | jq '[.[] | {slug: .slug, status: .status}] | map(select(.status != "ok" and .status != "active"))'
+```
+
+- If all monitors report `ok` or `active`: "Sentry cron monitors: all healthy"
+- If any monitor reports `error` or `missed`: flag with monitor name and status. This is a WARNING, not a blocker — the monitor may have been unhealthy before this deploy.
+- If Sentry API is unreachable or returns non-200: warn and skip (do not block on Sentry outages).
+
+**Graceful degradation:** This check is advisory. A Sentry API failure does not block the postmerge pipeline.
+```
+
+Also update Phase 7 report template (line ~157) to include:
+```
+Sentry monitors: <HEALTHY/WARNING/SKIPPED>
+```
+
+And update Phase 6 issue comment template (line ~140) to include the Sentry result.
+
+## Files to Edit
+
+| File | Change |
+|------|--------|
+| `plugins/soleur/skills/ship/SKILL.md` | Phase 7 CI auto-fix via test-fix-loop (lines 1215–1225), postmerge chain (insert before line ~1626) |
+| `plugins/soleur/skills/postmerge/SKILL.md` | New Phase 3.5 Sentry cron monitor check (insert between lines 97–99), update Phase 7 report + Phase 6 comment templates |
+
+## Files to Create
+
+None.
+
+## Open Code-Review Overlap
+
+None.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] AC1: Ship SKILL.md Phase 7 CI failure handler delegates to `test-fix-loop` (1 attempt, then escalate)
+- [ ] AC2: Ship SKILL.md Phase 7 CI failure handler distinguishes required-check-failure exit (PR OPEN) from CLOSED exit — no `gh pr reopen` needed for the primary path
+- [ ] AC3: Ship SKILL.md Phase 7 contains `skill: soleur:postmerge` invocation after release workflow verification passes
+- [ ] AC4: Postmerge SKILL.md contains Phase 3.5 with Sentry cron monitor health check using `SENTRY_AUTH_TOKEN` (with `SENTRY_API_TOKEN` fallback)
+- [ ] AC5: Postmerge Phase 7 report and Phase 6 issue comment include Sentry monitor results
+- [ ] AC6: Phase 7 poll block mirror note (`merge-pr/SKILL.md §5.2`) is NOT affected (CI auto-fix is outside the poll block)
+- [ ] AC7: Sentry check is advisory (warn, don't block) with graceful degradation on API failure
+
+### Post-merge (operator)
+
+- [ ] AC8: Verify `SENTRY_AUTH_TOKEN` in Doppler `prd` has `org:read` scope (required for monitors API)
+- [ ] AC9: Live-test the Sentry monitors API query against production to confirm response shape
+
+## Test Scenarios
+
+- Given a PR where a required CI check fails (PR still OPEN), when ship Phase 7 detects the required-check failure exit, then it invokes `test-fix-loop`, pushes the fix, and re-queues auto-merge
+- Given `test-fix-loop` fails to resolve the issue, when the fix attempt is exhausted (1 attempt), then the agent escalates to the operator
+- Given a PR that merges and release workflows pass, when ship Phase 7 completes, then `/soleur:postmerge` is automatically invoked
+- Given `SENTRY_AUTH_TOKEN` is set, when postmerge Phase 3.5 runs, then cron monitors are queried and any `error`/`missed` status is flagged as WARNING
+- Given `SENTRY_AUTH_TOKEN` is not set, when postmerge Phase 3.5 runs, then it warns and skips without blocking
+- Given postmerge reports a WARNING (unhealthy Sentry monitor), when ship Phase 7 receives the result, then the warning is displayed but cleanup is NOT blocked
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected — internal operator workflow automation. All changes are SKILL.md instruction edits, no application code.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| CI auto-fix via test-fix-loop introduces a bad fix | Single attempt cap; test-fix-loop has built-in regression detection and circular-fix detection |
+| Sentry API shape differs from expected | Phase 0 prerequisite live-tests the monitors endpoint before implementation |
+| Postmerge adds latency to the ship pipeline | Postmerge is advisory-only post-merge; failures don't block cleanup |
+| Phase 7 poll block mirror in merge-pr diverges | CI auto-fix is outside the poll block; mirror is unaffected |
+| `SENTRY_AUTH_TOKEN` vs `SENTRY_API_TOKEN` confusion | Plan uses `SENTRY_AUTH_TOKEN` (canonical per existing scripts) with `SENTRY_API_TOKEN` fallback |
+
+## Sharp Edges
+
+- The Phase 7 poll loop runs in a fresh shell on each Monitor invocation. `fix_attempt_count` is agent-level conversational state, not a bash variable. The agent tracks it across poll invocations.
+- When auto-merge is cancelled due to CI failure, the PR typically remains OPEN (auto-merge queue entry is cancelled, not the PR). `gh pr reopen` is wrong for this case — just push the fix and re-queue.
+- The DIRTY (merge conflict) exit at ship line 1137 is already handled in the poll block. The CI auto-fix handler should NOT duplicate merge conflict resolution.
+
+## Research Insights
+
+- **Sentry API host:** `${SENTRY_ORG}.sentry.io` (org-subdomain) per `apps/web-platform/scripts/sentry-monitors-audit.sh:65`
+- **Sentry org:** `jikigai` per `sentry-monitors-audit.sh:39`
+- **Token naming:** `SENTRY_AUTH_TOKEN` is canonical in existing scripts; `SENTRY_API_TOKEN` exists as a wider-scope fallback per `audit-sentry-extra-text-references.sh:94-101`
+- **Existing `test-fix-loop` skill:** Already handles test runner detection, failure parsing, minimal fixes, checkpoint commit isolation, and regression detection. Delegation avoids reimplementing all of this.
+- **Phase 7 mirror:** Poll block (lines 1070–1192) has explicit `<!-- phase-7-poll-block:start/end -->` markers. CI auto-fix logic is in the post-loop handler (lines 1215+), outside the mirror boundary.
+- **Fail-closed pattern:** Per learning `2026-03-19-ci-squash-fallback-bypasses-merge-gates.md`, merge retry must preserve safety flags.
+
+## Plan Review Applied
+
+| ID | Source | Finding | Resolution |
+|----|--------|---------|------------|
+| P0-1 | DHH | CI auto-fix reimplements test-fix-loop | Delegated to test-fix-loop |
+| P0-1 | Kieran | `gh pr reopen` wrong for primary exit path | Removed; distinguished required-check-failure (OPEN) from CLOSED |
+| P0-2 | Kieran | `fix_attempts` is agent-level, not bash var | Clarified in Sharp Edges |
+| P0-3 | Kieran | Token naming: `SENTRY_API_TOKEN` vs `SENTRY_AUTH_TOKEN` | Fixed to `SENTRY_AUTH_TOKEN` with fallback |
+| P0-2 | Simplicity | Sentry error count comparison uses fabricated header | Dropped Check 2 entirely |
+| P1-1 | DHH | Error count comparison speculative and useless | Dropped |
+| P1-2 | DHH | Phase 4 (work) creates double-invocation | Dropped Phase 4 |
+| P1-3 | Kieran | Required-check failure is primary trigger, not CLOSED | Reframed entry point |
+| P1-3 | Simplicity | Reduce to 1 auto-fix attempt | Applied |
+| P1-4 | Simplicity | Phase 4 (work) redundant | Dropped |
+| P1-5 | Kieran | Missing Sentry in report/comment templates | Added to Phase 3 |

--- a/knowledge-base/project/specs/feat-post-ship-autonomous-monitor/spec.md
+++ b/knowledge-base/project/specs/feat-post-ship-autonomous-monitor/spec.md
@@ -12,10 +12,9 @@ The shipping pipeline stops at "auto-merge enabled." CI failures block merge sil
 
 ## Goals
 
-1. Ship Phase 7 autonomously fixes CI failures that block merge (up to 2 attempts)
+1. Ship Phase 7 autonomously fixes CI failures that block merge (1 attempt, then escalate)
 2. Ship Phase 7 auto-chains to `/soleur:postmerge` after merge + release workflows pass
-3. Postmerge verifies Sentry health post-deploy (cron monitors + error count spike detection)
-4. All polling uses Monitor tool instead of bash `while`/`sleep` loops
+3. Postmerge verifies Sentry cron monitor health post-deploy
 
 ## Non-Goals
 
@@ -26,22 +25,17 @@ The shipping pipeline stops at "auto-merge enabled." CI failures block merge sil
 ## Functional Requirements
 
 - FR1: When a required CI check fails during ship Phase 7 merge poll, the agent attempts to diagnose and fix the failure (run tests locally, identify issue, commit fix, push, re-queue auto-merge)
-- FR2: CI auto-fix is capped at 2 attempts. After 2 failures, escalate to the operator with diagnosis.
+- FR2: CI auto-fix is capped at 1 attempt. After failure, escalate to the operator with diagnosis.
 - FR3: After ship Phase 7 confirms merge + all release workflows pass, automatically invoke `/soleur:postmerge <PR#>`
-- FR4: Postmerge includes a new Sentry verification phase that: (a) checks Sentry cron monitors report `ok`, (b) compares error count 15-min post-deploy vs 15-min pre-deploy baseline, flags >2x spike
-- FR5: All polling loops (merge status, CI status, release workflows, deploy health, Sentry) use the Monitor tool, not bash `while`/`sleep`
+- FR4: Postmerge includes a new Sentry verification phase that checks cron monitors report `ok` or `active`
 
 ## Technical Requirements
 
-- TR1: Sentry API token available via Doppler `prd` (`SENTRY_API_TOKEN`)
-- TR2: Sentry release tag format matches CI workflow output (`web-platform@X.Y.Z+<sha>`)
-- TR3: Monitor tool loops emit state-change events (not every-tick noise)
-- TR4: Ship Phase 7 poll block refactored from bash loop to Monitor tool invocation
+- TR1: Sentry API token available via Doppler `prd` (`SENTRY_AUTH_TOKEN`, with `SENTRY_API_TOKEN` fallback)
+- TR2: Monitor tool loops emit state-change events (not every-tick noise)
 
 ## Acceptance Criteria
 
-- AC1: Ship Phase 7 detects a failing required check, runs tests locally, fixes the issue, pushes, and merge completes — all without operator intervention
+- AC1: Ship Phase 7 detects a failing required check, delegates to test-fix-loop, pushes, and merge completes — all without operator intervention
 - AC2: After merge + release workflows pass, postmerge runs automatically and reports production health
-- AC3: Postmerge Sentry phase catches a >2x error spike and reports it
-- AC4: Postmerge Sentry phase verifies cron monitors are healthy post-deploy
-- AC5: No bash `while`/`sleep` polling loops remain in ship Phase 7 or postmerge
+- AC3: Postmerge Sentry phase verifies cron monitors are healthy post-deploy

--- a/knowledge-base/project/specs/feat-post-ship-autonomous-monitor/spec.md
+++ b/knowledge-base/project/specs/feat-post-ship-autonomous-monitor/spec.md
@@ -1,0 +1,47 @@
+---
+name: post-ship-autonomous-monitor
+lane: single-domain
+brand_survival_threshold: none
+---
+
+# Post-Ship Autonomous Monitor
+
+## Problem Statement
+
+The shipping pipeline stops at "auto-merge enabled." CI failures block merge silently, Sentry regressions go unnoticed, and `/soleur:postmerge` is never invoked automatically. The operator must manually monitor merge status, fix CI failures, and verify production health — defeating the purpose of autonomous shipping.
+
+## Goals
+
+1. Ship Phase 7 autonomously fixes CI failures that block merge (up to 2 attempts)
+2. Ship Phase 7 auto-chains to `/soleur:postmerge` after merge + release workflows pass
+3. Postmerge verifies Sentry health post-deploy (cron monitors + error count spike detection)
+4. All polling uses Monitor tool instead of bash `while`/`sleep` loops
+
+## Non-Goals
+
+- Automated rollback on production regression (out of scope — surface the problem, don't auto-revert)
+- Cross-app deployment coordination (single-app deploy pipeline only)
+- Real-time alerting infrastructure (this is session-scoped monitoring, not a persistent monitoring system)
+
+## Functional Requirements
+
+- FR1: When a required CI check fails during ship Phase 7 merge poll, the agent attempts to diagnose and fix the failure (run tests locally, identify issue, commit fix, push, re-queue auto-merge)
+- FR2: CI auto-fix is capped at 2 attempts. After 2 failures, escalate to the operator with diagnosis.
+- FR3: After ship Phase 7 confirms merge + all release workflows pass, automatically invoke `/soleur:postmerge <PR#>`
+- FR4: Postmerge includes a new Sentry verification phase that: (a) checks Sentry cron monitors report `ok`, (b) compares error count 15-min post-deploy vs 15-min pre-deploy baseline, flags >2x spike
+- FR5: All polling loops (merge status, CI status, release workflows, deploy health, Sentry) use the Monitor tool, not bash `while`/`sleep`
+
+## Technical Requirements
+
+- TR1: Sentry API token available via Doppler `prd` (`SENTRY_API_TOKEN`)
+- TR2: Sentry release tag format matches CI workflow output (`web-platform@X.Y.Z+<sha>`)
+- TR3: Monitor tool loops emit state-change events (not every-tick noise)
+- TR4: Ship Phase 7 poll block refactored from bash loop to Monitor tool invocation
+
+## Acceptance Criteria
+
+- AC1: Ship Phase 7 detects a failing required check, runs tests locally, fixes the issue, pushes, and merge completes — all without operator intervention
+- AC2: After merge + release workflows pass, postmerge runs automatically and reports production health
+- AC3: Postmerge Sentry phase catches a >2x error spike and reports it
+- AC4: Postmerge Sentry phase verifies cron monitors are healthy post-deploy
+- AC5: No bash `while`/`sleep` polling loops remain in ship Phase 7 or postmerge

--- a/knowledge-base/project/specs/feat-post-ship-autonomous-monitor/tasks.md
+++ b/knowledge-base/project/specs/feat-post-ship-autonomous-monitor/tasks.md
@@ -1,29 +1,29 @@
 # Tasks: Post-Ship Autonomous Monitor
 
 ## Phase 0: Prerequisites
-- [ ] 0.1 Verify `SENTRY_AUTH_TOKEN` exists in Doppler `prd` with `org:read` scope
-- [ ] 0.2 Live-test Sentry monitors API endpoint (must return HTTP 200)
-- [ ] 0.3 Verify `test-fix-loop` skill exists and is loadable
+- [x] 0.1 Verify `SENTRY_AUTH_TOKEN` exists in Doppler `prd` with `org:read` scope
+- [x] 0.2 Live-test Sentry monitors API endpoint (must return HTTP 200)
+- [x] 0.3 Verify `test-fix-loop` skill exists and is loadable
 
 ## Phase 1: Ship Phase 7 — CI auto-fix
-- [ ] 1.1 Read ship/SKILL.md lines 1215–1225 (current CI failure handler)
-- [ ] 1.2 Replace with test-fix-loop delegation: distinguish required-check-failure exit (PR OPEN) from CLOSED exit
-- [ ] 1.3 Add `fix_attempt_count` agent-level counter documentation (1 attempt, then escalate)
-- [ ] 1.4 Remove `gh pr reopen` — just push fix + re-queue auto-merge
-- [ ] 1.5 Document that DIRTY/merge-conflict handling is already in the poll block — not duplicated here
+- [x] 1.1 Read ship/SKILL.md lines 1215–1225 (current CI failure handler)
+- [x] 1.2 Replace with test-fix-loop delegation: distinguish required-check-failure exit (PR OPEN) from CLOSED exit
+- [x] 1.3 Add `fix_attempt_count` agent-level counter documentation (1 attempt, then escalate)
+- [x] 1.4 Remove `gh pr reopen` — just push fix + re-queue auto-merge
+- [x] 1.5 Document that DIRTY/merge-conflict handling is already in the poll block — not duplicated here
 
 ## Phase 2: Ship Phase 7 — postmerge chain
-- [ ] 2.1 Insert Step 3.8 before "4. Clean up worktree" (~line 1626): `skill: soleur:postmerge <PR-number>`
-- [ ] 2.2 Document advisory-only semantics: failures display but don't block cleanup
+- [x] 2.1 Insert Step 3.8 before "4. Clean up worktree" (~line 1626): `skill: soleur:postmerge <PR-number>`
+- [x] 2.2 Document advisory-only semantics: failures display but don't block cleanup
 
 ## Phase 3: Postmerge Phase 3.5 — Sentry cron monitor check
-- [ ] 3.1 Insert Phase 3.5 between Phase 3 (line 97) and Phase 4 (line 99)
-- [ ] 3.2 Implement cron monitor health query using `SENTRY_AUTH_TOKEN` with `SENTRY_API_TOKEN` fallback
-- [ ] 3.3 Add graceful degradation: warn and skip on missing token or API failure
-- [ ] 3.4 Update Phase 7 report template to include Sentry monitor results
-- [ ] 3.5 Update Phase 6 issue comment template to include Sentry monitor results
+- [x] 3.1 Insert Phase 3.5 between Phase 3 (line 97) and Phase 4 (line 99)
+- [x] 3.2 Implement cron monitor health query using `SENTRY_AUTH_TOKEN` with `SENTRY_API_TOKEN` fallback
+- [x] 3.3 Add graceful degradation: warn and skip on missing token or API failure
+- [x] 3.4 Update Phase 7 report template to include Sentry monitor results
+- [x] 3.5 Update Phase 6 issue comment template to include Sentry monitor results
 
 ## Phase 4: Verification
-- [ ] 4.1 Verify Phase 7 poll block mirror (`merge-pr/SKILL.md §5.2`) is NOT affected
-- [ ] 4.2 Verify all AC criteria are met
-- [ ] 4.3 Run `bun test plugins/soleur/test/components.test.ts` to check skill description budget
+- [x] 4.1 Verify Phase 7 poll block mirror (`merge-pr/SKILL.md §5.2`) is NOT affected
+- [x] 4.2 Verify all AC criteria are met
+- [x] 4.3 Run `bun test plugins/soleur/test/components.test.ts` to check skill description budget

--- a/knowledge-base/project/specs/feat-post-ship-autonomous-monitor/tasks.md
+++ b/knowledge-base/project/specs/feat-post-ship-autonomous-monitor/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: Post-Ship Autonomous Monitor
+
+## Phase 0: Prerequisites
+- [ ] 0.1 Verify `SENTRY_AUTH_TOKEN` exists in Doppler `prd` with `org:read` scope
+- [ ] 0.2 Live-test Sentry monitors API endpoint (must return HTTP 200)
+- [ ] 0.3 Verify `test-fix-loop` skill exists and is loadable
+
+## Phase 1: Ship Phase 7 — CI auto-fix
+- [ ] 1.1 Read ship/SKILL.md lines 1215–1225 (current CI failure handler)
+- [ ] 1.2 Replace with test-fix-loop delegation: distinguish required-check-failure exit (PR OPEN) from CLOSED exit
+- [ ] 1.3 Add `fix_attempt_count` agent-level counter documentation (1 attempt, then escalate)
+- [ ] 1.4 Remove `gh pr reopen` — just push fix + re-queue auto-merge
+- [ ] 1.5 Document that DIRTY/merge-conflict handling is already in the poll block — not duplicated here
+
+## Phase 2: Ship Phase 7 — postmerge chain
+- [ ] 2.1 Insert Step 3.8 before "4. Clean up worktree" (~line 1626): `skill: soleur:postmerge <PR-number>`
+- [ ] 2.2 Document advisory-only semantics: failures display but don't block cleanup
+
+## Phase 3: Postmerge Phase 3.5 — Sentry cron monitor check
+- [ ] 3.1 Insert Phase 3.5 between Phase 3 (line 97) and Phase 4 (line 99)
+- [ ] 3.2 Implement cron monitor health query using `SENTRY_AUTH_TOKEN` with `SENTRY_API_TOKEN` fallback
+- [ ] 3.3 Add graceful degradation: warn and skip on missing token or API failure
+- [ ] 3.4 Update Phase 7 report template to include Sentry monitor results
+- [ ] 3.5 Update Phase 6 issue comment template to include Sentry monitor results
+
+## Phase 4: Verification
+- [ ] 4.1 Verify Phase 7 poll block mirror (`merge-pr/SKILL.md §5.2`) is NOT affected
+- [ ] 4.2 Verify all AC criteria are met
+- [ ] 4.3 Run `bun test plugins/soleur/test/components.test.ts` to check skill description budget

--- a/plugins/soleur/skills/postmerge/SKILL.md
+++ b/plugins/soleur/skills/postmerge/SKILL.md
@@ -114,8 +114,8 @@ SENTRY_TOKEN=$(doppler secrets get SENTRY_AUTH_TOKEN -p soleur -c prd --plain 2>
 SENTRY_ORG=$(doppler secrets get SENTRY_ORG -p soleur -c prd --plain 2>/dev/null || echo "jikigai")
 API_HOST="${SENTRY_ORG}.sentry.io"
 
-curl -sS -H "Authorization: Bearer ${SENTRY_TOKEN}" \
-  "https://${API_HOST}/api/0/organizations/${SENTRY_ORG}/monitors/" \
+curl -sfS -H "Authorization: Bearer ${SENTRY_TOKEN}" \
+  "https://${API_HOST}/api/0/organizations/${SENTRY_ORG}/monitors/?per_page=100" \
   | jq '[.[] | {slug: .slug, status: .status}] | map(select(.status != "ok" and .status != "active"))'
 ```
 

--- a/plugins/soleur/skills/postmerge/SKILL.md
+++ b/plugins/soleur/skills/postmerge/SKILL.md
@@ -96,6 +96,35 @@ curl -sf --max-time 10 "<production-url>/api/health" | jq .
 WARNING: No production health check available. Skipping deployment verification.
 ```
 
+## Phase 3.5: Sentry Cron Monitor Health
+
+Verify scheduled functions are healthy post-deploy by querying Sentry cron monitors.
+
+**Prerequisites:** `SENTRY_AUTH_TOKEN` (or `SENTRY_API_TOKEN` fallback) must be available. If missing, warn and skip:
+
+```text
+WARNING: SENTRY_AUTH_TOKEN not set. Skipping Sentry health verification.
+```
+
+Query cron monitors:
+
+```bash
+SENTRY_TOKEN=$(doppler secrets get SENTRY_AUTH_TOKEN -p soleur -c prd --plain 2>/dev/null || \
+  doppler secrets get SENTRY_API_TOKEN -p soleur -c prd --plain)
+SENTRY_ORG=$(doppler secrets get SENTRY_ORG -p soleur -c prd --plain 2>/dev/null || echo "jikigai")
+API_HOST="${SENTRY_ORG}.sentry.io"
+
+curl -sS -H "Authorization: Bearer ${SENTRY_TOKEN}" \
+  "https://${API_HOST}/api/0/organizations/${SENTRY_ORG}/monitors/" \
+  | jq '[.[] | {slug: .slug, status: .status}] | map(select(.status != "ok" and .status != "active"))'
+```
+
+- If all monitors report `ok` or `active`: "Sentry cron monitors: all healthy"
+- If any monitor reports `error` or `missed`: flag with monitor name and status. This is a WARNING, not a blocker — the monitor may have been unhealthy before this deploy.
+- If Sentry API is unreachable or returns non-200: warn and skip (do not block on Sentry outages).
+
+**Graceful degradation:** This check is advisory. A Sentry API failure does not block the postmerge pipeline.
+
 ## Phase 4: Verify File Freshness
 
 Read key files from the merged commit to verify they match expectations -- NOT from the bare repo filesystem which may contain stale content.
@@ -141,6 +170,7 @@ gh issue comment <issue-number> --body "Post-merge verification complete for PR 
 
 - CI on main: PASSED
 - Production health: <PASSED/SKIPPED/FAILED>
+- Sentry monitors: <HEALTHY/WARNING/SKIPPED>
 - File freshness: <PASSED/N files checked>
 - Browser verification: <PASSED/SKIPPED>
 "
@@ -163,6 +193,7 @@ PR: #<number>
 Merge commit: <sha>
 CI on main: PASSED
 Production health: <PASSED/SKIPPED/FAILED>
+Sentry monitors: <HEALTHY/WARNING/SKIPPED>
 File freshness: <N files verified>
 Browser verification: <PASSED/SKIPPED>
 ```
@@ -172,6 +203,8 @@ Browser verification: <PASSED/SKIPPED>
 | Missing Prerequisite | Behavior |
 |---------------------|----------|
 | No production URL | Skip health check with warning |
+| No `SENTRY_AUTH_TOKEN` | Skip Sentry cron monitor check with warning |
+| Sentry API unreachable | Skip Sentry cron monitor check with warning |
 | Playwright MCP unavailable | Skip browser verification with warning |
 | CI run not found | Poll up to 5 minutes, then warn and proceed |
 | No UI files in diff | Skip browser verification entirely |

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -1212,16 +1212,41 @@ Two failure paths exit early instead of looping:
 
 This complements the PreToolUse hook [`.claude/hooks/pre-merge-rebase.sh`](../../../../.claude/hooks/pre-merge-rebase.sh) which fires on certain Bash invocations during the ship flow (commit, push, merge). The hook handles the pre-merge case (branch is behind when auto-merge is FIRST queued); this loop handles the post-merge-queue case (branch becomes behind WHILE the queued auto-merge is waiting on CI). The two surfaces don't overlap — the hook fires on operator-triggered git/gh commands; the poll loop fires on a fixed 60-second cadence regardless of operator activity.
 
-**If state becomes `CLOSED` (not `MERGED`):** Auto-merge was cancelled due to a CI failure.
+**If the poll loop exits due to a required-check failure (PR still OPEN) or CLOSED state:**
+
+The agent maintains a `fix_attempt_count` counter (agent-level state, not a bash variable — each Monitor invocation is a fresh shell).
 
 1. Read the failure details:
 
    ```bash
-   gh pr checks --json name,state,description | jq '.[] | select(.state != "SUCCESS")'
+   gh pr checks <number> --json name,state,description,detailsUrl \
+     | jq '.[] | select(.state != "SUCCESS")'
    ```
 
-2. If the failure is in tests: investigate the failing test, fix locally, commit, push, re-queue auto-merge.
-3. If the failure is in a flaky or unrelated check: **Headless mode:** abort the pipeline with a clear error message (do not auto-proceed past failed checks). **Interactive mode:** warn the user and ask whether to proceed or wait for a re-run.
+2. Identify the failing workflow run and read its logs:
+
+   ```bash
+   gh run list --branch <branch> --limit 5 --json databaseId,status,conclusion,workflowName \
+     | jq '.[] | select(.conclusion == "failure")'
+   gh run view <failing-run-id> --log-failed 2>&1 | tail -80
+   ```
+
+3. **If `fix_attempt_count >= 1`:** Escalate to the operator. **Headless mode:** abort with structured error naming the failing check. **Interactive mode:** present failure details and ask whether to investigate manually or abort.
+
+4. **If `fix_attempt_count == 0`:** Increment `fix_attempt_count`. Attempt autonomous fix:
+
+   a. If the failure is in tests or lint: invoke `skill: soleur:test-fix-loop` to diagnose, fix, and commit. After test-fix-loop completes, push and re-queue auto-merge:
+      ```bash
+      git push
+      gh pr merge <number> --squash --auto
+      ```
+      Note: `gh pr reopen` is NOT needed — when auto-merge is cancelled due to CI failure, the PR remains OPEN. Re-queuing auto-merge is sufficient.
+
+   b. If the failure is in a flaky or unrelated check (not reproducible locally): **Headless mode:** abort. **Interactive mode:** ask whether to wait for a re-run or abort.
+
+5. After re-queuing auto-merge, re-invoke the Phase 7 Monitor poll loop from the beginning. The agent carries `fix_attempt_count` across poll invocations.
+
+Note: The DIRTY (merge conflict) exit is already handled inside the poll block — do not duplicate merge conflict resolution here. The CI auto-fix logic is OUTSIDE the Phase 7 poll block (`<!-- phase-7-poll-block:start/end -->` markers) and does NOT affect the mirror in `merge-pr/SKILL.md §5.2`.
 
 **CRITICAL: Do NOT use `--delete-branch` on merge.** The guardrails hook blocks `--delete-branch` whenever ANY worktree exists in the repo -- not just the one for the branch being merged -- so the restriction applies unconditionally during parallel development. Merge with `--squash` only, then `cleanup-merged` handles branch deletion after removing the worktree.
 
@@ -1622,6 +1647,14 @@ This complements the PreToolUse hook [`.claude/hooks/pre-merge-rebase.sh`](../..
    If no matches, skip to Step 4.
 
    **Step 3:** Display the warning and ask: "Run `terraform apply` now, or defer with justification?" If deferred, record the justification in the PR body.
+
+3.8. **Chain to postmerge verification.** After release workflows pass and migration verification completes, invoke `/soleur:postmerge` to verify production health, Sentry cron monitors, and file freshness:
+
+   ```
+   skill: soleur:postmerge <PR-number>
+   ```
+
+   If postmerge reports any FAILED phase (production health, Sentry warning, browser regression), display the failures prominently but do NOT block cleanup — the deploy has already happened; the signal is for immediate operator attention, not rollback.
 
 4. Clean up worktree and local branch:
 

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -1214,6 +1214,8 @@ This complements the PreToolUse hook [`.claude/hooks/pre-merge-rebase.sh`](../..
 
 **If the poll loop exits due to a required-check failure (PR still OPEN) or CLOSED state:**
 
+First, check the PR state. If CLOSED (merge queue rejection or manual close), skip directly to escalation — auto-fix cannot proceed on a closed PR. The autonomous fix path below applies only when the PR is still OPEN (the primary required-check-failure case).
+
 The agent maintains a `fix_attempt_count` counter (agent-level state, not a bash variable — each Monitor invocation is a fresh shell).
 
 1. Read the failure details:


### PR DESCRIPTION
## Summary

- Ship Phase 7: replace manual CI failure handler with `test-fix-loop` delegation (1 attempt, then escalate). Distinguishes required-check-failure exit (PR still OPEN) from CLOSED exit — no `gh pr reopen` needed
- Ship Phase 7: chain to `/soleur:postmerge` after release workflows pass for automated production health verification
- Postmerge Phase 3.5: query Sentry cron monitors via API with graceful degradation (advisory-only, warn on missing token or API failure)

Closes #4506

## Changelog

### Changed
- Ship skill: Phase 7 CI failure handler now delegates to `test-fix-loop` with 1-attempt cap before escalating
- Ship skill: Phase 7 chains to `/soleur:postmerge` after release/deploy verification
- Postmerge skill: new Phase 3.5 Sentry cron monitor health check
- Postmerge skill: Phase 6 issue comment and Phase 7 report templates include Sentry monitor results
- Postmerge skill: graceful degradation table includes Sentry token/API rows

## Test plan

- [x] `bun test plugins/soleur/test/components.test.ts` passes (1106/1106 tests, skill description budget OK)
- [x] `bash scripts/test-all.sh` passes (82/82 suites)
- [x] Verified merge-pr mirror (`<!-- phase-7-poll-block:start/end -->` markers) NOT affected — CI auto-fix is outside the poll block
- [x] Verified `SENTRY_AUTH_TOKEN` exists in Doppler prd with working monitors API endpoint
- [x] All 7 pre-merge acceptance criteria verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
