### PR TITLE
feat(tr9): Sentry monitor targets, KPI-miss Discord alert, per-cron last-fire metric

### DIFF
--- a/apps/web-platform/infra/cat-deploy-state.sh
+++ b/apps/web-platform/infra/cat-deploy-state.sh
@@ -45,10 +45,28 @@ service_journal_tail() {
   fi
 }
 
+# Per-cron last-fire timestamps written by postSentryHeartbeat (#4131).
+# Glob is best-effort; empty dir or missing path produces "{}".
+inngest_crons_json() {
+  local dir="/var/lib/inngest/cron-fires"
+  if [[ ! -d "$dir" ]]; then echo "{}"; return; fi
+  local result="{}"
+  for f in "$dir"/*.json; do
+    [[ -f "$f" ]] || continue
+    local slug last_ok
+    slug=$(jq -r '.slug // empty' "$f" 2>/dev/null) || continue
+    last_ok=$(jq -r '.last_ok_at // empty' "$f" 2>/dev/null) || continue
+    [[ -n "$slug" && -n "$last_ok" ]] || continue
+    result=$(echo "$result" | jq --arg s "$slug" --arg t "$last_ok" '. + {($s): {last_ok_at: $t}}')
+  done
+  echo "$result"
+}
+
 HEARTBEAT_STATUS="$(service_status inngest-heartbeat.service)"
 INNGEST_SERVER_STATUS="$(service_status inngest-server.service)"
 VECTOR_STATUS="$(service_status vector.service)"
 VECTOR_JOURNAL_TAIL="$(service_journal_tail vector.service)"
+INNGEST_CRONS="$(inngest_crons_json)"
 
 STATE_FILE="${CI_DEPLOY_STATE:-/var/lock/ci-deploy.state}"
 
@@ -67,9 +85,11 @@ jq -nc \
   --arg is "$INNGEST_SERVER_STATUS" \
   --arg vs "$VECTOR_STATUS" \
   --arg vj "$VECTOR_JOURNAL_TAIL" \
+  --argjson ic "$INNGEST_CRONS" \
   '$base + {services: (($base.services // {}) + {
     inngest_heartbeat: $hb,
     inngest_server: $is,
     vector: $vs,
-    vector_journal_tail: $vj
+    vector_journal_tail: $vj,
+    inngest_crons: $ic
   })}'

--- a/apps/web-platform/server/inngest/functions/_cron-shared.ts
+++ b/apps/web-platform/server/inngest/functions/_cron-shared.ts
@@ -50,6 +50,20 @@ export async function postSentryHeartbeat(args: {
   logger: HandlerArgs["logger"];
 }): Promise<void> {
   const { ok, sentryMonitorSlug, cronName, logger } = args;
+
+  if (ok) {
+    try {
+      const dir = "/var/lib/inngest/cron-fires";
+      const { mkdir, writeFile } = await import("node:fs/promises");
+      await mkdir(dir, { recursive: true });
+      await writeFile(
+        `${dir}/${sentryMonitorSlug}.json`,
+        JSON.stringify({ last_ok_at: new Date().toISOString(), slug: sentryMonitorSlug }),
+      );
+    } catch {
+      // Best-effort; do not block heartbeat on file-write failure
+    }
+  }
   const domain = process.env.SENTRY_INGEST_DOMAIN;
   const projectId = process.env.SENTRY_PROJECT_ID;
   const publicKey = process.env.SENTRY_PUBLIC_KEY;

--- a/apps/web-platform/server/inngest/functions/cron-weekly-analytics.ts
+++ b/apps/web-platform/server/inngest/functions/cron-weekly-analytics.ts
@@ -213,6 +213,37 @@ export async function cronWeeklyAnalyticsHandler({
           { name: "cron/content-generator.manual-trigger", data: { source: "weekly-analytics-kpi-miss" } },
         ]);
       });
+
+      await step.run("notify-kpi-miss-discord", async () => {
+        const webhookUrl = process.env.DISCORD_WEBHOOK_URL;
+        if (!webhookUrl) {
+          reportSilentFallback(
+            new Error("DISCORD_WEBHOOK_URL not set"),
+            { feature: FUNCTION_NAME, op: "notify-kpi-miss", message: "Discord webhook URL missing" },
+          );
+          return;
+        }
+        const body = JSON.stringify({
+          content: [
+            `**KPI miss detected** — weekly analytics (${new Date().toISOString().slice(0, 10)})`,
+            `Phase: ${scriptResult.kpiPhase}`,
+            `Target: ${scriptResult.kpiTarget} | Actual: ${scriptResult.kpiActual}`,
+            `Visitors: ${scriptResult.kpiVisitors}`,
+            `Cascade dispatched: seo-aeo-audit, growth-execution, content-generator`,
+          ].join("\n"),
+        });
+        const resp = await fetch(webhookUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body,
+        });
+        if (!resp.ok) {
+          reportSilentFallback(
+            new Error(`Discord webhook returned ${resp.status}`),
+            { feature: FUNCTION_NAME, op: "notify-kpi-miss", message: "Discord notification failed" },
+          );
+        }
+      });
     }
 
     // --- Step 4: create bot-PR with snapshot ----------------------------------


### PR DESCRIPTION
## Summary
- Add `scheduled_bug_fixer` + `scheduled_ux_audit` to `apply-sentry-infra.yml` target list — root cause of #4465 blocker (monitors defined in TF but never applied because they weren't in the workflow's `-target` list)
- Add Discord webhook notification on KPI miss in `cron-weekly-analytics.ts` via `DISCORD_WEBHOOK_URL` — supplementary operator visibility per #4489
- Record per-cron last-fire timestamps in `/var/lib/inngest/cron-fires/` via `postSentryHeartbeat`, expose in `cat-deploy-state.sh` as `services.inngest_crons` — per #4131

Ref #4465
Closes #4489
Closes #4131

## Changelog
- `apply-sentry-infra.yml`: added 2 missing monitor targets (`scheduled_bug_fixer`, `scheduled_ux_audit`)
- `cron-weekly-analytics.ts`: added `notify-kpi-miss-discord` step posting to Discord webhook on KPI miss
- `_cron-shared.ts`: `postSentryHeartbeat` now writes last-fire timestamp to `/var/lib/inngest/cron-fires/<slug>.json` on `ok: true`
- `cat-deploy-state.sh`: added `inngest_crons_json()` function reading per-cron fire files into `services.inngest_crons`

## Test plan
- [x] `tsc --noEmit` passes
- [x] `bash -n cat-deploy-state.sh` passes
- [ ] After merge: `apply-sentry-infra.yml` creates the ux-audit + bug-fixer monitors on Sentry
- [ ] After first cron fire: `curl deploy-status | jq '.services.inngest_crons'` returns per-cron timestamps
- [ ] On next KPI miss: Discord channel receives notification

Generated with [Claude Code](https://claude.com/claude-code)