### PR TITLE
improve(flag-set-role): use AskUserQuestion for operator ack (#4503)

### DIFF
--- a/knowledge-base/project/plans/2026-05-26-improve-flag-set-role-ask-user-question-plan.md
+++ b/knowledge-base/project/plans/2026-05-26-improve-flag-set-role-ask-user-question-plan.md
@@ -7,6 +7,18 @@ lane: single-domain
 
 # improve: flag-set-role should use AskUserQuestion for operator ack
 
+## Enhancement Summary
+
+**Deepened on:** 2026-05-26
+**Sections enhanced:** 3 (Implementation Phase 1, Observability, Risks & Mitigations)
+**Research methods:** precedent-diff (worktree-manager.sh `--yes`, deploy SKILL.md AskUserQuestion), line-number verification against source, sibling-script scope validation, AGENTS.md rule-ID verification
+
+### Key Improvements
+1. Added `## Observability` section (required by `hr-observability-as-plan-quality-gate`)
+2. Verified precedent alignment — `--yes`/`YES_FLAG` in worktree-manager.sh:54-55 confirms identical implementation shape
+3. Documented `--confirmed` + `--dry-run` edge case (no-op, correct behavior — no defensive code needed)
+4. Confirmed sibling scripts (`flag-create/scripts/create.sh:77`, `user-set-role/scripts/set-role.sh:82`) have same `read -p` pattern, validating out-of-scope boundary
+
 ## Overview
 
 `flag-set-role/scripts/flip.sh` uses a raw `read -p` terminal prompt for operator acknowledgment (line 251). This breaks the agent-driven UX: the agent cannot pipe input into the prompt, forcing it to either expose raw CLI commands to the operator or bypass the script entirely (as happened during the 2026-05-26 TEAM_WORKSPACE_INVITE_ENABLED flag-flip session). The fix adds a `--confirmed` flag to `flip.sh` that skips the `read -p` prompt, and updates SKILL.md to instruct the agent to use `AskUserQuestion` before passing `--confirmed`. All precondition checks (fallback-fidelity, segment resolution, arg validation) remain unchanged.
@@ -20,6 +32,16 @@ lane: single-domain
 - **If this lands broken, the user experiences:** flag flip silently runs without operator confirmation (the `--confirmed` flag bypasses the ack gate)
 - **If this leaks, the user's workflow is exposed via:** N/A -- no data exposure; the change is UX-only on operator-side tooling
 - **Brand-survival threshold:** `none`
+
+## Observability
+
+- liveness_signal: operator-side CLI script invoked on-demand — no persistent process; liveness verified by exit code 0 on each invocation
+- error_reporting: script exits non-zero with diagnostic on stderr (exit 1: fidelity rule, 2: prerequisite, 3: Flagsmith API, 4: Doppler write); no Sentry integration (operator-local CLI context)
+- failure_modes: (1) --confirmed passed without prior AskUserQuestion — mitigated by SKILL.md agent instruction; (2) Flagsmith API unreachable — exit 3 with curl error; (3) Doppler partial write — exit 4 with reconciliation message
+- logs: stdout prints resolve/state/delta/audit/write trace per invocation; no persistent log sink (operator terminal only)
+- discoverability_test:
+  command: bash plugins/soleur/skills/flag-set-role/scripts/flip.sh kb-chat-sidebar dev on --dry-run
+  expected: exit 0, pre/post matrix printed to stdout
 
 ## Files to Edit
 
@@ -78,6 +100,16 @@ None.
    ```
 
 **Key invariant:** All precondition checks (prerequisite validation, fallback-fidelity rule, segment resolution, Doppler token fetch) still run regardless of `--confirmed`. The flag skips ONLY the `read -p` prompt.
+
+### Precedent Verification
+
+**`--yes` in worktree-manager.sh (line 54-55):** `YES_FLAG=false` default, `--yes` sets to true, skips all interactive prompts. Identical shape — boolean init + arg-parse case + conditional guard around `read`. Confirmed via `grep -n '\-\-yes' plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh`.
+
+**AskUserQuestion in deploy SKILL.md (line 40):** The deploy skill presents a confirmation question via AskUserQuestion before running `deploy.sh`. Same agent-mediated-ack pattern this plan prescribes. Confirmed via `grep -n 'AskUserQuestion' plugins/soleur/skills/deploy/SKILL.md`.
+
+### Edge Case: `--confirmed` + `--dry-run`
+
+When both flags are passed, `--dry-run` exits at line 244 (before the operator-ack block at line 249), so `--confirmed` is a no-op. This is correct — dry-run should exit cleanly regardless of `--confirmed`. No defensive code needed.
 
 ### Phase 2: Update SKILL.md
 

--- a/knowledge-base/project/plans/2026-05-26-improve-flag-set-role-ask-user-question-plan.md
+++ b/knowledge-base/project/plans/2026-05-26-improve-flag-set-role-ask-user-question-plan.md
@@ -1,0 +1,155 @@
+---
+title: "improve: flag-set-role should use AskUserQuestion for operator ack"
+type: feat
+date: 2026-05-26
+lane: single-domain
+---
+
+# improve: flag-set-role should use AskUserQuestion for operator ack
+
+## Overview
+
+`flag-set-role/scripts/flip.sh` uses a raw `read -p` terminal prompt for operator acknowledgment (line 251). This breaks the agent-driven UX: the agent cannot pipe input into the prompt, forcing it to either expose raw CLI commands to the operator or bypass the script entirely (as happened during the 2026-05-26 TEAM_WORKSPACE_INVITE_ENABLED flag-flip session). The fix adds a `--confirmed` flag to `flip.sh` that skips the `read -p` prompt, and updates SKILL.md to instruct the agent to use `AskUserQuestion` before passing `--confirmed`. All precondition checks (fallback-fidelity, segment resolution, arg validation) remain unchanged.
+
+**Precedent:** `git-worktree/scripts/worktree-manager.sh` uses `--yes` for the same pattern (line 54: `# Auto-confirm flag (--yes skips all interactive prompts)`). The deploy skill uses `AskUserQuestion` for operator ack before running `deploy.sh`. This change aligns `flag-set-role` with both established patterns.
+
+**Scope note:** Sibling scripts `flag-create/scripts/create.sh:77` and `user-set-role/scripts/set-role.sh:82` have the same `read -p` pattern. These are tracked as follow-up work, not in scope for this PR.
+
+## User-Brand Impact
+
+- **If this lands broken, the user experiences:** flag flip silently runs without operator confirmation (the `--confirmed` flag bypasses the ack gate)
+- **If this leaks, the user's workflow is exposed via:** N/A -- no data exposure; the change is UX-only on operator-side tooling
+- **Brand-survival threshold:** `none`
+
+## Files to Edit
+
+| File | Change |
+|------|--------|
+| `plugins/soleur/skills/flag-set-role/scripts/flip.sh` | Add `--confirmed` flag parsing; skip `read -p` block when set; keep all other checks |
+| `plugins/soleur/skills/flag-set-role/SKILL.md` | Update Procedure section: agent uses AskUserQuestion with pre/post matrix, then passes `--confirmed`; update Arguments to document `--confirmed` |
+
+## Files to Create
+
+None.
+
+## Open Code-Review Overlap
+
+None.
+
+## Implementation Phases
+
+### Phase 1: Add `--confirmed` flag to `flip.sh`
+
+**Contract change (must come first per plan-phase-order rule).**
+
+1. In the arg-parsing block (lines 46-59), add a `--confirmed` case **before the `--*)` catch-all** (line 51 -- the catch-all would otherwise intercept `--confirmed` and exit 2):
+   ```bash
+   --confirmed) CONFIRMED=1; shift ;;
+   ```
+   Initialize `CONFIRMED=0` alongside `DRY_RUN=0` (line 39).
+
+2. Replace the interactive prompt block (lines 249-252):
+   ```bash
+   # --- operator ack ----------------------------------------------------------
+   echo
+   read -p "Proceed? Type 'yes' to apply: " ACK
+   [[ "$ACK" == "yes" ]] || { echo "aborted (ack was '$ACK')" >&2; exit 0; }
+   ```
+   With:
+   ```bash
+   # --- operator ack ----------------------------------------------------------
+   if [[ $CONFIRMED -eq 0 ]]; then
+     echo
+     read -p "Proceed? Type 'yes' to apply: " ACK
+     [[ "$ACK" == "yes" ]] || { echo "aborted (ack was '$ACK')" >&2; exit 0; }
+   else
+     echo "(--confirmed: skipping interactive prompt)"
+   fi
+   ```
+
+3. Update the `usage()` function (line 62) to include `--confirmed`:
+   ```bash
+   echo "Usage: flip.sh <flag> <prd|dev> <on|off> [--confirmed] [--target role|org] [--org <orgId>] [--dry-run]" >&2
+   ```
+
+4. Update the script header comment (line 7) to document the flag:
+   ```bash
+   # Usage: bash flip.sh <flag> <prd|dev> <on|off> [--confirmed] [--dry-run]
+   ```
+
+**Key invariant:** All precondition checks (prerequisite validation, fallback-fidelity rule, segment resolution, Doppler token fetch) still run regardless of `--confirmed`. The flag skips ONLY the `read -p` prompt.
+
+### Phase 2: Update SKILL.md
+
+1. **Arguments section** (line 30): Add `--confirmed` documentation:
+   ```
+   Flag `--confirmed` skips the interactive `read -p` prompt (for agent-driven use; the agent must obtain operator ack via AskUserQuestion before passing this flag).
+   ```
+
+2. **Procedure section** (lines 40-57): Update Step 6 (Operator ack) to describe the agent-driven flow:
+   - The agent runs the script with `--dry-run` first to get the pre/post matrix output (exits 0, no writes, no prompt).
+   - The agent presents the matrix to the operator via **AskUserQuestion** with options: "Yes, apply" / "Cancel".
+   - On confirmation, the agent re-runs with `--confirmed` (skips the `read -p` prompt, proceeds to write).
+   - On cancel, the agent aborts.
+   - **Important:** The agent must NOT run the script without both `--dry-run` and `--confirmed` -- running without either flag would hit the interactive `read -p` prompt and hang the agent shell.
+
+3. **Procedure code block** (line 43): Update to show both forms:
+   ```bash
+   # Dry-run to see the matrix:
+   bash plugins/soleur/skills/flag-set-role/scripts/flip.sh <flag> <role> <on|off> --dry-run
+   # After AskUserQuestion confirmation:
+   bash plugins/soleur/skills/flag-set-role/scripts/flip.sh <flag> <role> <on|off> --confirmed
+   ```
+
+## Acceptance Criteria
+
+- [ ] **AC1:** `flip.sh --confirmed` skips the `read -p` prompt and proceeds directly to the audit + Flagsmith write steps.
+  Verification: `grep -c 'read -p' plugins/soleur/skills/flag-set-role/scripts/flip.sh` returns 1 (still present, guarded by `CONFIRMED` check).
+- [ ] **AC2:** `flip.sh` without `--confirmed` still prompts interactively (backward compatible).
+  Verification: `grep -A2 'CONFIRMED -eq 0' plugins/soleur/skills/flag-set-role/scripts/flip.sh | grep -c 'read -p'` returns 1.
+- [ ] **AC3:** All precondition checks (arg validation, fallback-fidelity rule, prerequisite checks) run regardless of `--confirmed`.
+  Verification: `--confirmed` flag case appears ONLY in the operator-ack block, NOT in the prerequisite or fallback-fidelity sections. `grep -n 'CONFIRMED' plugins/soleur/skills/flag-set-role/scripts/flip.sh` shows exactly 3 occurrences: initialization, arg-parse case, and the ack-guard if-block.
+- [ ] **AC4:** SKILL.md Procedure section instructs the agent to use **AskUserQuestion** before passing `--confirmed`.
+  Verification: `grep -c 'AskUserQuestion' plugins/soleur/skills/flag-set-role/SKILL.md` returns >= 1.
+- [ ] **AC5:** SKILL.md Arguments section documents `--confirmed`.
+  Verification: `grep -c '\-\-confirmed' plugins/soleur/skills/flag-set-role/SKILL.md` returns >= 2 (Arguments + Procedure).
+
+## Test Scenarios
+
+- Given the agent runs `flip.sh kb-chat-sidebar prd on --dry-run`, when the script completes, then the pre/post matrix is printed and exit code is 0 (no prompt).
+- Given the agent runs `flip.sh kb-chat-sidebar prd on --confirmed`, when preconditions pass, then the script proceeds to audit + Flagsmith write without prompting.
+- Given the agent runs `flip.sh kb-chat-sidebar prd on` (no `--confirmed`), when the script reaches the ack block, then it prompts interactively via `read -p`.
+- Given the agent runs `flip.sh kb-chat-sidebar dev off --confirmed` while prd is on, when the fallback-fidelity rule fires, then the script exits 1 regardless of `--confirmed`.
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected -- infrastructure/tooling change.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| `--confirmed` bypasses safety ack | The flag skips ONLY the terminal prompt; all precondition checks (fallback-fidelity, segment resolution, Doppler auth) still run. The agent is instructed to use AskUserQuestion first, preserving the intent of `hr-menu-option-ack-not-prod-write-auth`. |
+| Sibling scripts diverge | Follow-up issues for `flag-create` and `user-set-role` to apply the same pattern. Noted in scope note above. |
+
+## Alternative Approaches Considered
+
+| Approach | Why Not |
+|----------|---------|
+| Pipe `echo "yes"` into stdin | Fragile; depends on shell TTY behavior; violates the spirit of `hr-menu-option-ack-not-prod-write-auth` |
+| Remove the prompt entirely | Loses operator protection; silent prod writes are the failure mode the ack prevents |
+| Use `--yes` like worktree-manager | `--confirmed` is more specific -- `--yes` implies blanket consent; `--confirmed` implies the ack already happened elsewhere (at the AskUserQuestion layer). Either name works; `--confirmed` chosen per issue #4503 spec. |
+
+## Context
+
+Surfaced during the TEAM_WORKSPACE_INVITE_ENABLED flag-flip session (2026-05-26). The agent had to work around the interactive prompt by calling the Flagsmith API directly, bypassing the skill's precondition checks and audit trail.
+
+## References
+
+- Issue: #4503
+- `hr-menu-option-ack-not-prod-write-auth` (AGENTS.core.md:32)
+- Precedent: `plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh` `--yes` flag (line 54)
+- Precedent: `plugins/soleur/skills/deploy/SKILL.md` AskUserQuestion pattern (line 40)
+- Sibling scripts with same problem: `plugins/soleur/skills/flag-create/scripts/create.sh:77`, `plugins/soleur/skills/user-set-role/scripts/set-role.sh:82`

--- a/knowledge-base/project/specs/feat-one-shot-4503-flag-set-role-ask-user-question/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-4503-flag-set-role-ask-user-question/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-05-26-improve-flag-set-role-ask-user-question-plan.md
+- Status: complete
+
+### Errors
+None
+
+### Decisions
+- Use `--confirmed` flag (not `--yes`) per issue #4503 spec — `--confirmed` implies the ack already happened elsewhere
+- Skip only the `read -p` prompt; all precondition checks (fallback-fidelity, segment resolution, Doppler auth) still run
+- Agent uses AskUserQuestion for operator ack before passing `--confirmed`
+- Sibling scripts (`flag-create`, `user-set-role`) are follow-up work, not in scope
+- Observability section added for Phase 4.7 gate compliance (operator-side CLI, no persistent service)
+
+### Components Invoked
+- soleur:plan
+- soleur:plan-review (DHH, Kieran, Code Simplicity)
+- soleur:deepen-plan (inline, precedent-diff gate + observability gate)

--- a/knowledge-base/project/specs/feat-one-shot-4503-flag-set-role-ask-user-question/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-4503-flag-set-role-ask-user-question/tasks.md
@@ -8,22 +8,22 @@ branch: feat-one-shot-4503-flag-set-role-ask-user-question
 
 ## Phase 1: Add `--confirmed` flag to `flip.sh`
 
-- [ ] 1.1 Initialize `CONFIRMED=0` alongside `DRY_RUN=0` (line 39)
-- [ ] 1.2 Add `--confirmed) CONFIRMED=1; shift ;;` case before `--*)` catch-all (line 51)
-- [ ] 1.3 Replace interactive prompt block (lines 249-252) with `CONFIRMED` guard
-- [ ] 1.4 Update `usage()` function to include `--confirmed`
-- [ ] 1.5 Update script header comment (line 7) to document `--confirmed`
+- [x] 1.1 Initialize `CONFIRMED=0` alongside `DRY_RUN=0` (line 39)
+- [x] 1.2 Add `--confirmed) CONFIRMED=1; shift ;;` case before `--*)` catch-all (line 51)
+- [x] 1.3 Replace interactive prompt block (lines 249-252) with `CONFIRMED` guard
+- [x] 1.4 Update `usage()` function to include `--confirmed`
+- [x] 1.5 Update script header comment (line 7) to document `--confirmed`
 
 ## Phase 2: Update SKILL.md
 
-- [ ] 2.1 Add `--confirmed` to Arguments section (line 30)
-- [ ] 2.2 Update Procedure section Step 6 with agent-driven flow (dry-run, AskUserQuestion, --confirmed)
-- [ ] 2.3 Update Procedure code block to show both `--dry-run` and `--confirmed` forms
+- [x] 2.1 Add `--confirmed` to Arguments section (line 30)
+- [x] 2.2 Update Procedure section Step 6 with agent-driven flow (dry-run, AskUserQuestion, --confirmed)
+- [x] 2.3 Update Procedure code block to show both `--dry-run` and `--confirmed` forms
 
 ## Verification
 
-- [ ] 3.1 AC1: `grep -c 'read -p' flip.sh` returns 1
-- [ ] 3.2 AC2: `grep -A2 'CONFIRMED -eq 0' flip.sh | grep -c 'read -p'` returns 1
-- [ ] 3.3 AC3: `grep -n 'CONFIRMED' flip.sh` shows exactly 3 occurrences
-- [ ] 3.4 AC4: `grep -c 'AskUserQuestion' SKILL.md` returns >= 1
-- [ ] 3.5 AC5: `grep -c '\-\-confirmed' SKILL.md` returns >= 2
+- [x] 3.1 AC1: `grep -c 'read -p' flip.sh` returns 1
+- [x] 3.2 AC2: `grep -A2 'CONFIRMED -eq 0' flip.sh | grep -c 'read -p'` returns 1
+- [x] 3.3 AC3: `grep -n 'CONFIRMED' flip.sh` shows exactly 3 occurrences
+- [x] 3.4 AC4: `grep -c 'AskUserQuestion' SKILL.md` returns >= 1
+- [x] 3.5 AC5: `grep -c '\-\-confirmed' SKILL.md` returns >= 2

--- a/knowledge-base/project/specs/feat-one-shot-4503-flag-set-role-ask-user-question/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-4503-flag-set-role-ask-user-question/tasks.md
@@ -1,0 +1,29 @@
+---
+title: "Tasks: flag-set-role AskUserQuestion for operator ack"
+plan: knowledge-base/project/plans/2026-05-26-improve-flag-set-role-ask-user-question-plan.md
+branch: feat-one-shot-4503-flag-set-role-ask-user-question
+---
+
+# Tasks
+
+## Phase 1: Add `--confirmed` flag to `flip.sh`
+
+- [ ] 1.1 Initialize `CONFIRMED=0` alongside `DRY_RUN=0` (line 39)
+- [ ] 1.2 Add `--confirmed) CONFIRMED=1; shift ;;` case before `--*)` catch-all (line 51)
+- [ ] 1.3 Replace interactive prompt block (lines 249-252) with `CONFIRMED` guard
+- [ ] 1.4 Update `usage()` function to include `--confirmed`
+- [ ] 1.5 Update script header comment (line 7) to document `--confirmed`
+
+## Phase 2: Update SKILL.md
+
+- [ ] 2.1 Add `--confirmed` to Arguments section (line 30)
+- [ ] 2.2 Update Procedure section Step 6 with agent-driven flow (dry-run, AskUserQuestion, --confirmed)
+- [ ] 2.3 Update Procedure code block to show both `--dry-run` and `--confirmed` forms
+
+## Verification
+
+- [ ] 3.1 AC1: `grep -c 'read -p' flip.sh` returns 1
+- [ ] 3.2 AC2: `grep -A2 'CONFIRMED -eq 0' flip.sh | grep -c 'read -p'` returns 1
+- [ ] 3.3 AC3: `grep -n 'CONFIRMED' flip.sh` shows exactly 3 occurrences
+- [ ] 3.4 AC4: `grep -c 'AskUserQuestion' SKILL.md` returns >= 1
+- [ ] 3.5 AC5: `grep -c '\-\-confirmed' SKILL.md` returns >= 2

--- a/plugins/soleur/skills/flag-set-role/SKILL.md
+++ b/plugins/soleur/skills/flag-set-role/SKILL.md
@@ -28,6 +28,7 @@ Required positional args: `<flag-name> <role> <on|off>`.
 - `<on|off>`: target enablement.
 
 Flag `--dry-run` runs detect/diff/validate steps (no writes).
+Flag `--confirmed` skips the interactive `read -p` prompt (for agent-driven use; the agent must obtain operator ack via AskUserQuestion before passing this flag).
 
 ## Prerequisites
 
@@ -40,8 +41,20 @@ Flag `--dry-run` runs detect/diff/validate steps (no writes).
 Invoke the script:
 
 ```bash
-bash plugins/soleur/skills/flag-set-role/scripts/flip.sh <flag> <role> <on|off> [--dry-run]
+# Dry-run to see the matrix:
+bash plugins/soleur/skills/flag-set-role/scripts/flip.sh <flag> <role> <on|off> --dry-run
+# After AskUserQuestion confirmation:
+bash plugins/soleur/skills/flag-set-role/scripts/flip.sh <flag> <role> <on|off> --confirmed
 ```
+
+**Agent-driven flow (recommended):**
+
+1. Run with `--dry-run` to get the pre/post matrix (exits 0, no writes, no prompt).
+2. Present the matrix output to the operator via **AskUserQuestion** with options: "Yes, apply" / "Cancel".
+3. On confirmation, re-run with `--confirmed` (skips the `read -p` prompt, proceeds to write).
+4. On cancel, abort.
+
+**Important:** The agent must NOT run the script without both `--dry-run` and `--confirmed` — running without either flag hits the interactive `read -p` prompt and hangs the agent shell.
 
 The script (full procedure in [scripts/flip.sh](./scripts/flip.sh)):
 
@@ -50,7 +63,7 @@ The script (full procedure in [scripts/flip.sh](./scripts/flip.sh)):
 3. **Read current state.** For each env (dev `90722`, prd `90721`), fetch the live version's feature-states + per-segment override.
 4. **Apply fallback-fidelity rule.** If proposed = `dev off` AND current `prd on` in either env, abort with exit 1 + clear message. (See ADR-038 v2 §"Fallback semantics" — the env-var fallback can only mirror one state; `dev off / prd on` cannot be represented and would silently re-enable the dev cohort on outage.)
 5. **Print pre/post matrix.** Show current (env × segment) enablement table and the proposed delta.
-6. **Operator ack.** Wait for literal `yes` (per `hr-menu-option-ack-not-prod-write-auth`). Anything else aborts.
+6. **Operator ack.** If `--confirmed` is passed, skip (the agent already obtained ack via AskUserQuestion). Otherwise, wait for literal `yes` at the terminal prompt (per `hr-menu-option-ack-not-prod-write-auth`). Anything else aborts.
 7. **Flip Flagsmith.** For each env, POST to `/api/v1/environments/{env_id}/features/{feature_id}/versions/` with `feature_states_to_create` (first-time) OR `feature_states_to_update` (subsequent), `publish_immediately: true`.
 8. **Mirror Doppler (only on `role=prd` flip).** Run `doppler secrets set FLAG_<X>=<0|1> -p soleur -c dev` AND `-c prd` via stdin-piped 0600 temp file (no CLI-arg leak).
 9. **Re-verify.** Re-fetch state in both envs and assert matches proposed.

--- a/plugins/soleur/skills/flag-set-role/SKILL.md
+++ b/plugins/soleur/skills/flag-set-role/SKILL.md
@@ -54,7 +54,7 @@ bash plugins/soleur/skills/flag-set-role/scripts/flip.sh <flag> <role> <on|off> 
 3. On confirmation, re-run with `--confirmed` (skips the `read -p` prompt, proceeds to write).
 4. On cancel, abort.
 
-**Important:** The agent must NOT run the script without both `--dry-run` and `--confirmed` — running without either flag hits the interactive `read -p` prompt and hangs the agent shell.
+**Important:** The agent must always pass `--dry-run` (for preview) or `--confirmed` (for apply) — never invoke without one of these flags, or the interactive prompt will hang the agent shell.
 
 The script (full procedure in [scripts/flip.sh](./scripts/flip.sh)):
 

--- a/plugins/soleur/skills/flag-set-role/scripts/flip.sh
+++ b/plugins/soleur/skills/flag-set-role/scripts/flip.sh
@@ -46,11 +46,11 @@ VALUE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --dry-run)    DRY_RUN=1; shift ;;
-    --confirmed) CONFIRMED=1; shift ;;
-    --target)    TARGET_TYPE="$2"; shift 2 ;;
-    --org)       TARGET_ORG="$2"; shift 2 ;;
-    --*)         echo "unknown flag: $1" >&2; exit 2 ;;
+    --dry-run)     DRY_RUN=1; shift ;;
+    --confirmed)   CONFIRMED=1; shift ;;
+    --target)      TARGET_TYPE="$2"; shift 2 ;;
+    --org)         TARGET_ORG="$2"; shift 2 ;;
+    --*)           echo "unknown flag: $1" >&2; exit 2 ;;
     *)
       if [[ -z "$FLAG" ]]; then FLAG="$1"
       elif [[ -z "$ROLE" ]]; then ROLE="$1"

--- a/plugins/soleur/skills/flag-set-role/scripts/flip.sh
+++ b/plugins/soleur/skills/flag-set-role/scripts/flip.sh
@@ -4,7 +4,7 @@
 # Contract: SKILL.md in the parent directory. ADR-038 v2 §"Fallback semantics"
 # documents the env-var mirror invariant this script enforces.
 #
-# Usage: bash flip.sh <flag> <prd|dev> <on|off> [--dry-run]
+# Usage: bash flip.sh <flag> <prd|dev> <on|off> [--confirmed] [--dry-run]
 #
 # Exit codes:
 #   0 — success / dry-run clean
@@ -37,6 +37,7 @@ declare -A FLAG_ENV_VARS=(
 
 # --- arg parsing ------------------------------------------------------------
 DRY_RUN=0
+CONFIRMED=0
 TARGET_TYPE="role"
 TARGET_ORG=""
 FLAG=""
@@ -45,10 +46,11 @@ VALUE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --dry-run) DRY_RUN=1; shift ;;
-    --target)  TARGET_TYPE="$2"; shift 2 ;;
-    --org)     TARGET_ORG="$2"; shift 2 ;;
-    --*)       echo "unknown flag: $1" >&2; exit 2 ;;
+    --dry-run)    DRY_RUN=1; shift ;;
+    --confirmed) CONFIRMED=1; shift ;;
+    --target)    TARGET_TYPE="$2"; shift 2 ;;
+    --org)       TARGET_ORG="$2"; shift 2 ;;
+    --*)         echo "unknown flag: $1" >&2; exit 2 ;;
     *)
       if [[ -z "$FLAG" ]]; then FLAG="$1"
       elif [[ -z "$ROLE" ]]; then ROLE="$1"
@@ -59,7 +61,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 usage() {
-  echo "Usage: flip.sh <flag> <prd|dev> <on|off> [--target role|org] [--org <orgId>] [--dry-run]" >&2
+  echo "Usage: flip.sh <flag> <prd|dev> <on|off> [--confirmed] [--target role|org] [--org <orgId>] [--dry-run]" >&2
   echo "Known flags: ${!FLAG_ENV_VARS[*]}" >&2
   exit 2
 }
@@ -247,9 +249,13 @@ if [[ $DRY_RUN -eq 1 ]]; then
 fi
 
 # --- operator ack ----------------------------------------------------------
-echo
-read -p "Proceed? Type 'yes' to apply: " ACK
-[[ "$ACK" == "yes" ]] || { echo "aborted (ack was '$ACK')" >&2; exit 0; }
+if [[ $CONFIRMED -eq 0 ]]; then
+  echo
+  read -p "Proceed? Type 'yes' to apply: " ACK
+  [[ "$ACK" == "yes" ]] || { echo "aborted (ack was '$ACK')" >&2; exit 0; }
+else
+  echo "(--confirmed: skipping interactive prompt)"
+fi
 
 # --- audit append (WORM) ---------------------------------------------------
 ACTOR=$(doppler secrets get OPERATOR_EMAIL -p soleur -c cli_ops --plain 2>/dev/null | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
## Summary

- Add `--confirmed` flag to `flip.sh` that skips the interactive `read -p` prompt for agent-driven use
- Update SKILL.md with agent-driven flow: dry-run → AskUserQuestion → `--confirmed`
- All precondition checks (fallback-fidelity, segment resolution, Doppler auth) still run regardless of `--confirmed`

Closes #4503

## Changelog

- `flag-set-role/scripts/flip.sh`: Added `--confirmed` flag that skips interactive prompt (agent obtains ack via AskUserQuestion first)
- `flag-set-role/SKILL.md`: Documented agent-driven flow and `--confirmed` flag usage

## Test plan

- [ ] `grep -c 'read -p' flip.sh` returns 1 (prompt still present, guarded)
- [ ] `grep -n 'CONFIRMED' flip.sh` shows exactly 3 occurrences (init, arg-parse, ack-guard)
- [ ] `grep -c 'AskUserQuestion' SKILL.md` returns >= 1
- [ ] `grep -c '\-\-confirmed' SKILL.md` returns >= 2
- [ ] `flip.sh --dry-run` exits 0 without prompt (unchanged behavior)
- [ ] `flip.sh --confirmed` skips prompt, proceeds to write (new behavior)
- [ ] `flip.sh` without flags still prompts interactively (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)