### PR TITLE
fix(auth): query user_session_state directly for org resolution (#4516)

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/chat/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/chat/layout.tsx
@@ -3,7 +3,7 @@ import { ConversationsRail } from "@/components/chat/conversations-rail";
 import { DelegationBanner } from "@/components/chat/delegation-banner";
 import { createClient } from "@/lib/supabase/server";
 import { isByokDelegationsEnabled, type Identity } from "@/lib/feature-flags/server";
-import { getCurrentOrganizationId } from "@/server/workspace-resolver";
+import { resolveCurrentOrganizationId } from "@/server/workspace-resolver";
 import { resolveGranteeDelegation, resolveGranteeAcceptanceStatus } from "@/server/byok-delegation-ui-resolver";
 
 export default async function ChatLayout({ children }: { children: ReactNode }) {
@@ -18,9 +18,7 @@ export default async function ChatLayout({ children }: { children: ReactNode }) 
     const supabase = await createClient();
     const { data: { user } } = await supabase.auth.getUser();
     if (user) {
-      const orgId = getCurrentOrganizationId({
-        user: { id: user.id, app_metadata: user.app_metadata as Record<string, unknown> },
-      });
+      const orgId = await resolveCurrentOrganizationId(user.id, supabase);
       if (orgId) {
         const identity: Identity = { userId: user.id, role: "prd", orgId };
         if (await isByokDelegationsEnabled(orgId, identity)) {

--- a/apps/web-platform/app/(dashboard)/dashboard/settings/billing/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/settings/billing/page.tsx
@@ -4,7 +4,7 @@ import { BillingSection } from "@/components/settings/billing-section";
 import { ApiUsageSection } from "@/components/settings/api-usage-section";
 import { DelegationFundedPane } from "@/components/settings/delegation-funded-pane";
 import { isByokDelegationsEnabled, type Identity } from "@/lib/feature-flags/server";
-import { getCurrentOrganizationId } from "@/server/workspace-resolver";
+import { resolveCurrentOrganizationId } from "@/server/workspace-resolver";
 
 // Dynamic rendering is already forced by the cookies()/getUser() call in
 // createClient() below, so no explicit `export const dynamic` is required.
@@ -23,7 +23,7 @@ export default async function BillingPage() {
 
   const service = createServiceClient();
 
-  const orgId = getCurrentOrganizationId({ user: { id: user.id, app_metadata: user.app_metadata as Record<string, unknown> } });
+  const orgId = await resolveCurrentOrganizationId(user.id, supabase);
   const identity: Identity = { userId: user.id, role: "prd", orgId: orgId ?? "" };
   const byokEnabled = orgId ? await isByokDelegationsEnabled(orgId, identity) : false;
 

--- a/apps/web-platform/app/(dashboard)/dashboard/settings/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/settings/layout.tsx
@@ -1,7 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { SettingsShell } from "@/components/settings/settings-shell";
 import { isTeamWorkspaceInviteEnabled, type Identity } from "@/lib/feature-flags/server";
-import { getCurrentOrganizationId } from "@/server/workspace-resolver";
+import { resolveCurrentOrganizationId } from "@/server/workspace-resolver";
 
 // Server-side flag evaluation. AC-A requires the "Members" link href
 // (`/dashboard/settings/team`) NOT appear in the client bundle when the flag is
@@ -14,9 +14,7 @@ async function resolveMembersTab(): Promise<{ href: string; label: string } | nu
   } = await supabase.auth.getUser();
   if (!user) return null;
 
-  // JWT custom-claim (migration 060). Synchronous; no DB call.
-  const session = { user: { id: user.id, app_metadata: user.app_metadata } };
-  const orgId = getCurrentOrganizationId(session);
+  const orgId = await resolveCurrentOrganizationId(user.id, supabase);
   if (!orgId) return null;
 
   const identity: Identity = { userId: user.id, role: "prd", orgId };

--- a/apps/web-platform/app/api/workspace/delegations/accept/route.ts
+++ b/apps/web-platform/app/api/workspace/delegations/accept/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 import { isByokDelegationsEnabled, type Identity } from "@/lib/feature-flags/server";
-import { getCurrentOrganizationId } from "@/server/workspace-resolver";
+import { resolveCurrentOrganizationId } from "@/server/workspace-resolver";
 import { createHash } from "node:crypto";
 
 export async function POST(request: Request) {
@@ -13,7 +13,7 @@ export async function POST(request: Request) {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
 
-  const orgId = getCurrentOrganizationId({ user: { id: user.id, app_metadata: user.app_metadata as Record<string, unknown> } });
+  const orgId = await resolveCurrentOrganizationId(user.id, supabase);
   if (!orgId) return NextResponse.json({ error: "no_org" }, { status: 403 });
 
   const identity: Identity = { userId: user.id, role: "prd", orgId };

--- a/apps/web-platform/app/api/workspace/delegations/route.ts
+++ b/apps/web-platform/app/api/workspace/delegations/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 import { isByokDelegationsEnabled, type Identity } from "@/lib/feature-flags/server";
-import { getCurrentOrganizationId } from "@/server/workspace-resolver";
+import { resolveCurrentOrganizationId } from "@/server/workspace-resolver";
 import { resolveGrantorDelegations } from "@/server/byok-delegation-ui-resolver";
 
 export async function GET(request: Request) {
@@ -13,7 +13,7 @@ export async function GET(request: Request) {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
 
-  const orgId = getCurrentOrganizationId({ user: { id: user.id, app_metadata: user.app_metadata as Record<string, unknown> } });
+  const orgId = await resolveCurrentOrganizationId(user.id, supabase);
   if (!orgId) return NextResponse.json({ error: "no_org" }, { status: 403 });
 
   const identity: Identity = { userId: user.id, role: "prd", orgId };
@@ -46,7 +46,7 @@ export async function POST(request: Request) {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
 
-  const orgId = getCurrentOrganizationId({ user: { id: user.id, app_metadata: user.app_metadata as Record<string, unknown> } });
+  const orgId = await resolveCurrentOrganizationId(user.id, supabase);
   if (!orgId) return NextResponse.json({ error: "no_org" }, { status: 403 });
 
   const identity: Identity = { userId: user.id, role: "prd", orgId };
@@ -97,7 +97,7 @@ export async function DELETE(request: Request) {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
 
-  const orgId = getCurrentOrganizationId({ user: { id: user.id, app_metadata: user.app_metadata as Record<string, unknown> } });
+  const orgId = await resolveCurrentOrganizationId(user.id, supabase);
   if (!orgId) return NextResponse.json({ error: "no_org" }, { status: 403 });
 
   const identity: Identity = { userId: user.id, role: "prd", orgId };

--- a/apps/web-platform/lib/feature-flags/identity.ts
+++ b/apps/web-platform/lib/feature-flags/identity.ts
@@ -21,6 +21,7 @@ export const resolveIdentity = cache(async (
     .from("workspace_members")
     .select("workspace_id, workspaces!inner(organization_id)")
     .eq("user_id", userId)
+    .order("created_at", { ascending: true })
     .limit(1)
     .single<{ workspace_id: string; workspaces: { organization_id: string } }>();
 

--- a/apps/web-platform/server/org-memberships-resolver.ts
+++ b/apps/web-platform/server/org-memberships-resolver.ts
@@ -1,4 +1,4 @@
-import { getCurrentOrganizationId } from "@/server/workspace-resolver";
+import { resolveCurrentOrganizationId } from "@/server/workspace-resolver";
 
 // Returns the user's full list of organization memberships with role + member
 // count. Powers the dashboard OrgSwitcher (Phase 5.3) which hides itself when
@@ -59,9 +59,7 @@ export async function resolveOrgMemberships(
   const user = userResp.data?.user;
   if (!user) return [];
 
-  const currentOrgId = getCurrentOrganizationId({
-    user: { id: user.id, app_metadata: user.app_metadata as never },
-  });
+  const currentOrgId = await resolveCurrentOrganizationId(user.id, service);
 
   // 1. user's memberships → workspace_ids + role
   type MembershipsChain = {

--- a/apps/web-platform/server/org-memberships-resolver.ts
+++ b/apps/web-platform/server/org-memberships-resolver.ts
@@ -155,7 +155,7 @@ export async function resolveOrgMemberships(
     })
     .filter((s): s is OrgMembershipSummary => s !== null);
 
-  // If the JWT claim is absent (single-membership users; AC-FLOW1 default),
+  // If user_session_state has no row (single-membership users; AC-FLOW1),
   // mark the first membership as current so the UI has a stable anchor.
   if (!summaries.some((s) => s.isCurrent) && summaries.length > 0) {
     summaries[0] = { ...summaries[0], isCurrent: true };

--- a/apps/web-platform/server/team-membership-resolver.ts
+++ b/apps/web-platform/server/team-membership-resolver.ts
@@ -1,5 +1,5 @@
 import { isTeamWorkspaceInviteEnabled, isByokDelegationsEnabled, type Identity } from "@/lib/feature-flags/server";
-import { getCurrentOrganizationId } from "@/server/workspace-resolver";
+import { resolveCurrentOrganizationId } from "@/server/workspace-resolver";
 
 // Server-only resolver for the /dashboard/settings/team membership page.
 // Factored out of the page component so AC-A's flag-OFF → notFound() behavior
@@ -73,9 +73,7 @@ export async function resolveTeamMembershipPageData(
   const user = userResp.data?.user;
   if (!user) return { ok: false, reason: "not-found" };
 
-  const orgId = getCurrentOrganizationId({
-    user: { id: user.id, app_metadata: user.app_metadata as never },
-  });
+  const orgId = await resolveCurrentOrganizationId(user.id, service);
   if (!orgId) return { ok: false, reason: "no-org" };
 
   const identity: Identity = { userId: user.id, role: "prd", orgId };

--- a/apps/web-platform/server/workspace-resolver.ts
+++ b/apps/web-platform/server/workspace-resolver.ts
@@ -1,4 +1,5 @@
 import { join } from "path";
+import { reportSilentFallback } from "@/server/observability";
 
 // Resolver for user → current/default workspace mapping (feat-team-workspace-multi-user).
 //
@@ -72,7 +73,15 @@ export async function resolveCurrentOrganizationId(
     error: unknown;
   }>(chain.select("current_organization_id").eq("user_id", userId).maybeSingle());
 
-  if (result.error || !result.data) return null;
+  if (result.error) {
+    reportSilentFallback(result.error, {
+      feature: "workspace-resolver",
+      op: "resolveCurrentOrganizationId",
+      extra: { userId },
+    });
+    return null;
+  }
+  if (!result.data) return null;
   return result.data.current_organization_id;
 }
 

--- a/apps/web-platform/server/workspace-resolver.ts
+++ b/apps/web-platform/server/workspace-resolver.ts
@@ -2,13 +2,13 @@ import { join } from "path";
 
 // Resolver for user → current/default workspace mapping (feat-team-workspace-multi-user).
 //
-// Two distinct lookups:
-//   1. getCurrentOrganizationId(session) — reads the Supabase Auth JWT custom
-//      claim `app_metadata.current_organization_id` populated by migration 060's
-//      access-token hook. Synchronous, no DB call. Returns null when the claim
-//      is absent (single-membership users) or the session is anonymous; callers
-//      then fall back to getDefaultWorkspaceForUser.
-//   2. getDefaultWorkspaceForUser(userId, supabase) — DB query against
+// Three lookups:
+//   1. resolveCurrentOrganizationId(userId, supabase) — queries
+//      user_session_state directly. Preferred over getCurrentOrganizationId.
+//   2. getCurrentOrganizationId(session) — DEPRECATED. Reads
+//      getUser().app_metadata which returns stored raw_app_meta_data, not
+//      the JWT hook's injected claims.
+//   3. getDefaultWorkspaceForUser(userId, supabase) — DB query against
 //      workspace_members joined to workspaces. Returns the MIN(created_at)
 //      workspace_id. For solo users this collapses to the N2 invariant
 //      (workspaces.id === user.id; see migration 053 §1.1.7 backfill).
@@ -33,17 +33,47 @@ interface SessionLike {
 }
 
 /**
- * Returns the `app_metadata.current_organization_id` JWT custom claim
- * populated by migration 060's `custom_access_token` hook, or null.
- *
- * Phase 5.4 dependency: the org-switcher writes user_session_state then
- * calls `supabase.auth.refreshSession()` to force a token refresh so the
- * new claim propagates to all tabs.
+ * @deprecated Reads from `getUser().app_metadata` which returns the stored
+ * `raw_app_meta_data` — the JWT hook's `current_organization_id` claim is
+ * NOT persisted there. Use `resolveCurrentOrganizationId` instead.
  */
 export function getCurrentOrganizationId(
   session: SessionLike | null | undefined,
 ): string | null {
   return session?.user?.app_metadata?.current_organization_id ?? null;
+}
+
+/**
+ * Queries `user_session_state` directly for the user's current org.
+ *
+ * The JWT hook (migration 060) injects `current_organization_id` into token
+ * claims at mint time, but `supabase.auth.getUser()` returns the stored
+ * `auth.users.raw_app_meta_data` which never includes hook modifications.
+ * This function bypasses the JWT entirely and reads the source of truth.
+ *
+ * RLS: `user_session_state_owner_select` allows `auth.uid() = user_id`.
+ */
+export async function resolveCurrentOrganizationId(
+  userId: string,
+  supabase: SupabaseLike,
+): Promise<string | null> {
+  type ChainShape = {
+    select: (cols: string) => ChainShape;
+    eq: (col: string, val: string) => ChainShape;
+    maybeSingle: () => ChainShape;
+  } & PromiseLike<{
+    data: { current_organization_id: string | null } | null;
+    error: unknown;
+  }>;
+
+  const chain = supabase.from("user_session_state") as ChainShape;
+  const result = await awaitChain<{
+    data: { current_organization_id: string | null } | null;
+    error: unknown;
+  }>(chain.select("current_organization_id").eq("user_id", userId).maybeSingle());
+
+  if (result.error || !result.data) return null;
+  return result.data.current_organization_id;
 }
 
 // Minimal structural type for the test-injected supabase client. We only need

--- a/apps/web-platform/server/ws-handler.ts
+++ b/apps/web-platform/server/ws-handler.ts
@@ -2244,9 +2244,9 @@ export function setupWebSocket(server: HTTPServer) {
         // Phase 5.5 / Kieran C5: bind userId → current workspace_id so
         // workspace-membership.ts:removeWorkspaceMember can SIGTERM only the
         // sessions running against the workspace being revoked (and not
-        // sibling sessions in the user's other workspaces). The JWT custom
-        // claim `current_organization_id` (migration 060) is the source of
-        // truth; the lookup translates org_id → workspace_id once at WS open.
+        // sibling sessions in the user's other workspaces). user_session_state
+        // (migration 060) is the source of truth; the lookup translates
+        // org_id → workspace_id once at WS open.
         try {
           const orgId = await resolveCurrentOrganizationId(
             user.id,
@@ -2352,8 +2352,8 @@ export function setupWebSocket(server: HTTPServer) {
           }
           sessions.delete(userId);
           // Phase 5.5: drop the workspace binding so a future reconnect
-          // re-resolves from the JWT (handles the org-switch + reconnect
-          // sequence cleanly — see AC-FLOW3 multi-tab race coverage).
+          // re-resolves from user_session_state (handles the org-switch +
+          // reconnect sequence cleanly — see AC-FLOW3 multi-tab race coverage).
           clearUserWorkspace(userId);
           // Grace period: defer abort to allow reconnection
           if (current.conversationId) {

--- a/apps/web-platform/server/ws-handler.ts
+++ b/apps/web-platform/server/ws-handler.ts
@@ -45,7 +45,7 @@ import {
   clearUserWorkspace,
 } from "./agent-session-registry";
 import {
-  getCurrentOrganizationId,
+  resolveCurrentOrganizationId,
   getDefaultWorkspaceForUser,
   getWorkspaceForUserInOrganization,
 } from "./workspace-resolver";
@@ -2248,12 +2248,10 @@ export function setupWebSocket(server: HTTPServer) {
         // claim `current_organization_id` (migration 060) is the source of
         // truth; the lookup translates org_id → workspace_id once at WS open.
         try {
-          const orgId = getCurrentOrganizationId({
-            user: {
-              id: user.id,
-              app_metadata: user.app_metadata as never,
-            },
-          });
+          const orgId = await resolveCurrentOrganizationId(
+            user.id,
+            tenantBootstrap as never,
+          );
           let workspaceId: string | null = null;
           if (orgId) {
             workspaceId = await getWorkspaceForUserInOrganization(

--- a/apps/web-platform/test/conversations-rail.test.tsx
+++ b/apps/web-platform/test/conversations-rail.test.tsx
@@ -29,7 +29,7 @@ vi.mock("@/lib/feature-flags/server", () => ({
   isByokDelegationsEnabled: vi.fn().mockResolvedValue(false),
 }));
 vi.mock("@/server/workspace-resolver", () => ({
-  getCurrentOrganizationId: vi.fn().mockReturnValue(null),
+  resolveCurrentOrganizationId: vi.fn().mockResolvedValue(null),
 }));
 vi.mock("@/server/byok-delegation-ui-resolver", () => ({
   resolveGranteeDelegation: vi.fn().mockResolvedValue(null),

--- a/apps/web-platform/test/server/workspace-resolver.test.ts
+++ b/apps/web-platform/test/server/workspace-resolver.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { randomUUID } from "crypto";
 import {
   getCurrentOrganizationId,
+  resolveCurrentOrganizationId,
   getDefaultWorkspaceForUser,
   resolveWorkspacePathForUser,
 } from "@/server/workspace-resolver";
@@ -34,6 +35,30 @@ describe("workspace-resolver: getCurrentOrganizationId", () => {
   it("returns null for an empty/anonymous session", () => {
     expect(getCurrentOrganizationId(null)).toBeNull();
     expect(getCurrentOrganizationId(undefined)).toBeNull();
+  });
+});
+
+describe("workspace-resolver: resolveCurrentOrganizationId", () => {
+  it("returns current_organization_id from user_session_state", async () => {
+    const userId = randomUUID();
+    const orgId = randomUUID();
+    const chain = mockQueryChain({ current_organization_id: orgId });
+    const supabase = supabaseFor(chain);
+
+    const result = await resolveCurrentOrganizationId(userId, supabase);
+
+    expect(result).toBe(orgId);
+    expect(supabase.from).toHaveBeenCalledWith("user_session_state");
+  });
+
+  it("returns null when no user_session_state row exists", async () => {
+    const userId = randomUUID();
+    const chain = mockQueryChain(null);
+    const supabase = supabaseFor(chain);
+
+    const result = await resolveCurrentOrganizationId(userId, supabase);
+
+    expect(result).toBeNull();
   });
 });
 

--- a/apps/web-platform/test/team-membership-resolver.test.ts
+++ b/apps/web-platform/test/team-membership-resolver.test.ts
@@ -62,6 +62,21 @@ function mockSupabaseClients(opts: ResolveOpts) {
         }),
       };
     }
+    if (table === "user_session_state") {
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: () =>
+              Promise.resolve({
+                data: opts.user
+                  ? { current_organization_id: opts.user.app_metadata?.current_organization_id ?? null }
+                  : null,
+                error: null,
+              }),
+          }),
+        }),
+      };
+    }
     throw new Error(`unmocked table: ${table}`);
   });
   const supabase = {

--- a/apps/web-platform/test/team-membership-resolver.test.ts
+++ b/apps/web-platform/test/team-membership-resolver.test.ts
@@ -20,6 +20,7 @@ interface ResolveOpts {
   user: { id: string; email: string; app_metadata: Record<string, unknown> } | null;
   members: MockRow[];
   emails: Record<string, { email: string; created_at: string }>;
+  sessionOrgId?: string | null;
 }
 
 function mockSupabaseClients(opts: ResolveOpts) {
@@ -63,13 +64,14 @@ function mockSupabaseClients(opts: ResolveOpts) {
       };
     }
     if (table === "user_session_state") {
+      const orgId = opts.sessionOrgId !== undefined ? opts.sessionOrgId : null;
       return {
         select: () => ({
           eq: () => ({
             maybeSingle: () =>
               Promise.resolve({
-                data: opts.user
-                  ? { current_organization_id: opts.user.app_metadata?.current_organization_id ?? null }
+                data: orgId !== null
+                  ? { current_organization_id: orgId }
                   : null,
                 error: null,
               }),
@@ -100,8 +102,9 @@ describe("resolveTeamMembershipPageData", () => {
       user: {
         id: USER_ID,
         email: "jean@jikigai.com",
-        app_metadata: { current_organization_id: ORG_ID },
+        app_metadata: {},
       },
+      sessionOrgId: ORG_ID,
       members: [],
       emails: {},
     });
@@ -134,8 +137,9 @@ describe("resolveTeamMembershipPageData", () => {
       user: {
         id: USER_ID,
         email: "jean@jikigai.com",
-        app_metadata: { current_organization_id: ORG_ID },
+        app_metadata: {},
       },
+      sessionOrgId: ORG_ID,
       members: [
         {
           workspace_id: WORKSPACE_ID,
@@ -175,8 +179,9 @@ describe("resolveTeamMembershipPageData", () => {
       user: {
         id: USER_ID,
         email: "jean@jikigai.com",
-        app_metadata: { current_organization_id: ORG_ID },
+        app_metadata: {},
       },
+      sessionOrgId: ORG_ID,
       members: [
         {
           workspace_id: WORKSPACE_ID,


### PR DESCRIPTION
## Summary

- `getUser().app_metadata` returns stored `raw_app_meta_data` from `auth.users`, which does **not** include the `current_organization_id` injected by the JWT hook (migration 060). This caused the Members tab and all org-gated features (BYOK delegations, org-switcher, team membership) to silently fail for **every user**.
- Adds `resolveCurrentOrganizationId()` which queries `user_session_state` directly — the same source of truth the JWT hook reads from.
- Migrates all 10 call sites across 8 files: settings layout, chat layout, billing page, delegations routes, org-memberships resolver, team-membership resolver, and ws-handler.
- Deprecates the old `getCurrentOrganizationId()` (sync, reads from JWT claim that was never populated in stored metadata).

## Root Cause

The custom access token hook (`runtime_jwt_mint_hook`, migration 060) injects `current_organization_id` into **JWT token claims** at mint time, but never persists it to `auth.users.raw_app_meta_data`. Supabase's `getUser()` endpoint returns the stored metadata, not the JWT claims. Every call site reading `getUser().app_metadata.current_organization_id` got `undefined`.

## Test plan

- [x] TypeScript compiles cleanly
- [x] `workspace-resolver.test.ts` — 9 tests pass (2 new for `resolveCurrentOrganizationId`)
- [x] `team-membership-resolver.test.ts` — 4 tests pass (mock updated for `user_session_state`)
- [ ] Deploy to staging and verify Members tab appears for `ops@jikigai.com`
- [ ] Verify org-switcher renders for users with memberships
- [ ] Verify BYOK delegations routes return 200 (not 403 "no_org")

Closes #4516

🤖 Generated with [Claude Code](https://claude.com/claude-code)