### PR TITLE
fix(auth): stop Sentry alerts from firing on expected OAuth access_denied

### DIFF
--- a/apps/web-platform/app/(auth)/callback/route.ts
+++ b/apps/web-platform/app/(auth)/callback/route.ts
@@ -82,18 +82,36 @@ export async function GET(request: NextRequest) {
     const providerErrorCode = isKnownProviderErrorCode(rawErrorCode)
       ? rawErrorCode
       : "unknown";
-    warnSilentFallback(null, {
-      feature: "auth",
-      op: "callback_provider_error",
-      message: `OAuth provider returned error=${providerErrorCode}`,
-      extra: {
-        providerErrorCode,
-        bucket: providerErrorBucket,
-        urlPath: pathname,
-        refererHost,
-        origin,
-      },
-    });
+    if (providerErrorBucket === "oauth_cancelled") {
+      // User clicked Cancel — expected per RFC 6749 §4.1.2.1; structured log
+      // only. Sentry alert rules count ALL captureMessage events regardless of
+      // level, so even warning-level emission triggers auth-per-user-loop.
+      logger.info(
+        {
+          feature: "auth",
+          op: "callback_provider_error",
+          providerErrorCode,
+          bucket: providerErrorBucket,
+          urlPath: pathname,
+          refererHost,
+          origin,
+        },
+        `OAuth provider returned error=${providerErrorCode}`,
+      );
+    } else {
+      warnSilentFallback(null, {
+        feature: "auth",
+        op: "callback_provider_error",
+        message: `OAuth provider returned error=${providerErrorCode}`,
+        extra: {
+          providerErrorCode,
+          bucket: providerErrorBucket,
+          urlPath: pathname,
+          refererHost,
+          origin,
+        },
+      });
+    }
     // Verifier cookies are intentionally NOT cleared on this branch — no
     // `exchangeCodeForSession` was attempted, so the verifier in the cookie
     // jar is still valid for a retry.

--- a/apps/web-platform/test/app/auth/callback-route-branches.test.ts
+++ b/apps/web-platform/test/app/auth/callback-route-branches.test.ts
@@ -8,11 +8,13 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const {
   mockReportSilentFallback,
   mockWarnSilentFallback,
+  mockLoggerInfo,
   mockExchangeCodeForSession,
   mockGetUser,
 } = vi.hoisted(() => ({
   mockReportSilentFallback: vi.fn(),
   mockWarnSilentFallback: vi.fn(),
+  mockLoggerInfo: vi.fn(),
   mockExchangeCodeForSession: vi.fn(),
   mockGetUser: vi.fn(),
 }));
@@ -24,7 +26,7 @@ vi.mock("@/server/observability", () => ({
 }));
 
 vi.mock("@/server/logger", () => ({
-  default: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+  default: { warn: vi.fn(), error: vi.fn(), info: mockLoggerInfo },
 }));
 
 vi.mock("@/lib/auth/resolve-origin", () => ({
@@ -101,13 +103,42 @@ describe("GET /callback — no-code branches", () => {
     vi.clearAllMocks();
   });
 
+  it("?error=access_denied → /login?error=oauth_cancelled with logger.info only (no Sentry)", async () => {
+    const res = await GET(makeRequest("?error=access_denied"));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "https://app.soleur.ai/login?error=oauth_cancelled",
+    );
+    expect(res.headers.get("cache-control")).toBe("no-store");
+
+    expect(mockWarnSilentFallback).not.toHaveBeenCalled();
+    expect(mockReportSilentFallback).not.toHaveBeenCalled();
+
+    expect(mockLoggerInfo).toHaveBeenCalledTimes(1);
+    const [context, message] = mockLoggerInfo.mock.calls[0];
+    expect(context.feature).toBe("auth");
+    expect(context.op).toBe("callback_provider_error");
+    expect(context.providerErrorCode).toBe("access_denied");
+    expect(context.bucket).toBe("oauth_cancelled");
+    expect(message).toBe("OAuth provider returned error=access_denied");
+    expect(Object.keys(context).sort()).toEqual([
+      "bucket",
+      "feature",
+      "op",
+      "origin",
+      "providerErrorCode",
+      "refererHost",
+      "urlPath",
+    ]);
+  });
+
   it.each([
-    ["?error=access_denied", "access_denied", "oauth_cancelled"],
     ["?error=server_error", "server_error", "oauth_failed"],
     ["?error=temporarily_unavailable", "temporarily_unavailable", "oauth_failed"],
     ["?error=invalid_scope", "invalid_scope", "oauth_failed"],
   ])(
-    "%s → /login?error=%s with op callback_provider_error",
+    "%s → /login?error=%s with warnSilentFallback (Sentry visibility)",
     async (query, expectedRawCode, expectedBucket) => {
       const res = await GET(makeRequest(query));
 
@@ -118,13 +149,12 @@ describe("GET /callback — no-code branches", () => {
       expect(res.headers.get("cache-control")).toBe("no-store");
 
       expect(mockWarnSilentFallback).toHaveBeenCalledTimes(1);
+      expect(mockLoggerInfo).not.toHaveBeenCalled();
       const [, opts] = mockWarnSilentFallback.mock.calls[0];
       expect(opts.feature).toBe("auth");
       expect(opts.op).toBe("callback_provider_error");
       expect(opts.extra.providerErrorCode).toBe(expectedRawCode);
       expect(opts.extra.bucket).toBe(expectedBucket);
-      // Closed-set assertion — fails the day someone adds error_description,
-      // url, or any other PII-bearing key.
       expect(Object.keys(opts.extra).sort()).toEqual(PROVIDER_ERROR_EXTRA_KEYS);
     },
   );
@@ -190,13 +220,13 @@ describe("GET /callback — no-code branches", () => {
     );
 
     expect(res.status).toBe(307);
-    const [, opts] = mockWarnSilentFallback.mock.calls[0];
-    expect(opts.extra.refererHost).toBe("accounts.google.com");
+    const [context] = mockLoggerInfo.mock.calls[0];
+    expect(context.refererHost).toBe("accounts.google.com");
     // Lock down: no port, no path, no query.
-    expect(opts.extra.refererHost).not.toContain(":");
-    expect(opts.extra.refererHost).not.toContain("/");
-    expect(opts.extra.refererHost).not.toContain("?");
-    expect(opts.extra.refererHost).not.toContain("email");
+    expect(context.refererHost).not.toContain(":");
+    expect(context.refererHost).not.toContain("/");
+    expect(context.refererHost).not.toContain("?");
+    expect(context.refererHost).not.toContain("email");
   });
 
   it("searchParamKeys is capped, shape-filtered, and keys-only", async () => {

--- a/knowledge-base/project/learnings/best-practices/2026-05-27-sentry-warning-level-still-triggers-alert-rules.md
+++ b/knowledge-base/project/learnings/best-practices/2026-05-27-sentry-warning-level-still-triggers-alert-rules.md
@@ -1,0 +1,49 @@
+---
+module: web-platform/auth
+date: 2026-05-27
+problem_type: best_practice
+component: authentication
+symptoms:
+  - "Recurring Sentry alerts (auth-exchange-code-burst, auth-callback-no-code-burst) on expected OAuth access_denied"
+  - "Alerts continued after PR #4487 downgraded reportSilentFallback to warnSilentFallback"
+root_cause: config_error
+resolution_type: code_fix
+severity: medium
+tags: [sentry, observability, alert-noise, oauth, access-denied, warning-level]
+synced_to: []
+---
+
+# Sentry warning-level captureMessage still triggers EventFrequencyCondition alert rules
+
+## Problem
+
+After PR #4487 downgraded the OAuth `access_denied` callback emission from `reportSilentFallback` (error level) to `warnSilentFallback` (warning level), Sentry alerts continued firing. Two alerts triggered on 2026-05-27 at 07:00 and 08:00 CEST (IDs `4ec8f51d` and `d2e86815`).
+
+## Root Cause
+
+`warnSilentFallback` calls `Sentry.captureMessage(message, { level: "warning" })` (see `observability.ts:231`). Sentry `EventFrequencyCondition` alert rules count ALL issue events regardless of `level` — both `error` and `warning` level `captureMessage` calls create Sentry issues that increment the frequency counter. The `auth-per-user-loop` alert rule filters only on `feature=auth` with no `op` filter, catching all auth events including `callback_provider_error`.
+
+Downgrading from error to warning changed the Sentry dashboard classification but did NOT stop events from being counted by alert rules.
+
+## Solution
+
+Split the provider-error emission path in `apps/web-platform/app/(auth)/callback/route.ts`:
+
+1. `access_denied` (user-cancel, `oauth_cancelled` bucket): `logger.info` only — no Sentry emission
+2. All other provider errors (`server_error`, `temporarily_unavailable`, etc.): keep `warnSilentFallback`
+
+Updated tests in `callback-route-branches.test.ts` to verify cross-channel exclusion (access_denied asserts `mockWarnSilentFallback.not.toHaveBeenCalled()`; provider errors assert `mockLoggerInfo.not.toHaveBeenCalled()`).
+
+## Key Insight
+
+Downgrading Sentry emission level (error → warning) does NOT reduce alert noise. Sentry alert rules count events, not severity. The only way to stop an expected-behavior path from triggering alerts is to remove Sentry emission entirely and use structured logging (`logger.info`) for operational visibility. This is the second instance of this pattern — see also `best-practices/2026-05-26-sentry-captureMessage-on-expected-paths-creates-alert-noise.md` (webhook no-grant path, PR #4485).
+
+## Session Errors
+
+1. **Vitest CWD mismatch.** Ran vitest from bare repo root instead of `apps/web-platform/`, producing "Cannot find package" error. Recovery: re-ran with correct CWD (`cd apps/web-platform && ./node_modules/.bin/vitest run`). **Prevention:** Work skill should always run vitest from the app root when the test path is relative to the app package.
+
+## See Also
+
+- `knowledge-base/project/learnings/best-practices/2026-05-26-sentry-captureMessage-on-expected-paths-creates-alert-noise.md` (same pattern, webhook context)
+- PR #4487 (insufficient downgrade fix)
+- PR #4485 (precedent: webhook no-grant path removal)

--- a/knowledge-base/project/plans/2026-05-27-fix-oauth-callback-access-denied-sentry-alert-noise-plan.md
+++ b/knowledge-base/project/plans/2026-05-27-fix-oauth-callback-access-denied-sentry-alert-noise-plan.md
@@ -8,6 +8,20 @@ brand_survival_threshold: none
 
 # fix: Stop Sentry alerts from firing on expected OAuth access_denied callbacks
 
+## Enhancement Summary
+
+**Deepened on:** 2026-05-27
+**Sections enhanced:** Implementation Phases (mock wiring precision), Acceptance Criteria (refined grep counts), Risks (added R4 logger.info context-shape)
+**Research agents used:** repo-research (callback route, test mock structure, observability module), PR-citation verifier, AGENTS.md rule-ID verifier
+
+### Key Improvements
+
+1. **Verified test mock wiring pattern.** The logger mock at `callback-route-branches.test.ts:26-28` creates `info: vi.fn()` inline but does NOT expose it as a named mock. Phase 2 now prescribes adding `mockLoggerInfo` to the `vi.hoisted` block (matching the pattern for `mockReportSilentFallback` / `mockWarnSilentFallback`) and wiring it through the `vi.mock("@/server/logger")` factory.
+2. **Verified all PR citations.** PR #4487 (MERGED: "fix(auth): downgrade OAuth callback provider-error from error to warning"), PR #4485 (MERGED: "fix(webhook): remove Sentry noise from expected no-grant path"), #3739 (OPEN: "review: extract reportSilentFallbackWithUser helper") -- all confirmed via `gh pr view`/`gh issue view`.
+3. **Verified AGENTS.md rule ID.** `cq-silent-fallback-must-mirror-to-sentry` is active in AGENTS.md (confirmed via grep).
+4. **Refined AC2 grep count.** After the fix, `grep -c "warnSilentFallback"` on the callback route should return 2 (import line + provider-error-non-cancelled call), not the current 2 (import + the single call that will be split).
+5. **Added logger.info context-shape verification.** The `logger.info` call must include the same structured context fields (`feature`, `op`, `providerErrorCode`, `bucket`, `urlPath`, `refererHost`, `origin`) as the former `warnSilentFallback` call, so pino/Better Stack log aggregator queries are not disrupted.
+
 ## Overview
 
 The OAuth callback route at `apps/web-platform/app/(auth)/callback/route.ts` still triggers Sentry issue alerts (`auth-exchange-code-burst`, `auth-callback-no-code-burst`, and `auth-per-user-loop`) when a user denies OAuth consent (`?error=access_denied`), despite PR #4487 (commit `c38699c6`) downgrading the emission from `reportSilentFallback` (error level) to `warnSilentFallback` (warning level).
@@ -171,21 +185,48 @@ if (providerErrorBucket === "oauth_cancelled") {
 
 **File:** `apps/web-platform/test/app/auth/callback-route-branches.test.ts`
 
-1. **Add `mockLoggerInfo`** to the `vi.hoisted` block and wire it into the logger mock.
+1. **Add `mockLoggerInfo` to `vi.hoisted` block** (line 8-18). The current `vi.hoisted` returns `mockReportSilentFallback`, `mockWarnSilentFallback`, `mockExchangeCodeForSession`, `mockGetUser`. Add `mockLoggerInfo: vi.fn()` to the returned object:
 
-2. **Split the `test.each` block** (currently lines 104-129):
-   - Separate `access_denied` into its own test case that asserts:
-     - `mockWarnSilentFallback` NOT called (`.not.toHaveBeenCalled()`)
-     - `mockReportSilentFallback` NOT called
-     - `mockLoggerInfo` called with `op: "callback_provider_error"` context
-     - Redirect still goes to `/login?error=oauth_cancelled`
-   - Keep `server_error`, `temporarily_unavailable`, `invalid_scope` in a `test.each` that asserts `mockWarnSilentFallback` IS called.
+   ```typescript
+   const {
+     mockReportSilentFallback,
+     mockWarnSilentFallback,
+     mockLoggerInfo,
+     mockExchangeCodeForSession,
+     mockGetUser,
+   } = vi.hoisted(() => ({
+     mockReportSilentFallback: vi.fn(),
+     mockWarnSilentFallback: vi.fn(),
+     mockLoggerInfo: vi.fn(),
+     mockExchangeCodeForSession: vi.fn(),
+     mockGetUser: vi.fn(),
+   }));
+   ```
 
-3. **Update "refererHost" test** (line 182): This test uses `?error=access_denied`. Change its assertion from `mockWarnSilentFallback` to `mockLoggerInfo` for the refererHost check.
+2. **Wire `mockLoggerInfo` into the logger mock** (line 26-28). Replace the inline `info: vi.fn()` with the hoisted reference:
 
-4. **Verify "searchParamKeys" test** (line 202): This tests the bare-`/callback` path (no `error=` param), which correctly uses `reportSilentFallback`. This test must remain unchanged.
+   ```typescript
+   vi.mock("@/server/logger", () => ({
+     default: { warn: vi.fn(), error: vi.fn(), info: mockLoggerInfo },
+   }));
+   ```
 
-5. **Verify "unrecognized `?error=`" test** (line 132): This sends `?error=user@example.com`, which `classifyProviderError` maps to `"oauth_failed"` (not `"oauth_cancelled"`). This should assert `mockWarnSilentFallback` IS called (unknown errors are provider-side, not user-cancel). Update if needed.
+3. **Split the `test.each` block** (currently lines 104-129):
+   - Extract `access_denied` into its own test case that asserts:
+     - `mockWarnSilentFallback.not.toHaveBeenCalled()`
+     - `mockReportSilentFallback.not.toHaveBeenCalled()`
+     - `mockLoggerInfo` called once with context including `op: "callback_provider_error"`, `providerErrorCode: "access_denied"`, `bucket: "oauth_cancelled"`
+     - Redirect to `/login?error=oauth_cancelled`
+     - `Cache-Control: no-store`
+   - Keep `server_error`, `temporarily_unavailable`, `invalid_scope` in a `test.each` that asserts `mockWarnSilentFallback` IS called with `op: "callback_provider_error"` and `mockLoggerInfo` is NOT called (the logger.info path is only for user-cancel; `warnSilentFallback` already calls `logger.warn` internally for provider errors).
+
+   **Important edge case:** For the provider-error `test.each` rows, assert `mockLoggerInfo.not.toHaveBeenCalled()` to confirm no `logger.info` is emitted for provider-side errors. The `warnSilentFallback` helper internally calls `logger.warn` (not `logger.info`), which is tested by the helper's own unit tests.
+
+4. **Update "refererHost" test** (line 182): This test uses `?error=access_denied`. Change assertions from `mockWarnSilentFallback` to `mockLoggerInfo` for the refererHost extraction check. The test should verify `mockLoggerInfo` was called and that the first call's args object contains `refererHost: "accounts.google.com"` (hostname only, no port/path/query).
+
+5. **Verify "searchParamKeys" test** (line 202): This tests the bare-`/callback` path (no `error=` param), which correctly uses `reportSilentFallback`. This test must remain unchanged.
+
+6. **Verify "unrecognized `?error=`" test** (line 132): This sends `?error=user@example.com`, which `classifyProviderError` maps to `"oauth_failed"` (not `"oauth_cancelled"`). This should assert `mockWarnSilentFallback` IS called (unknown errors are provider-side, not user-cancel). Verify the existing assertion is correct.
 
 ### Phase 3: Verify
 
@@ -200,6 +241,7 @@ if (providerErrorBucket === "oauth_cancelled") {
 | Loss of `access_denied` spike visibility | Low | Low | `logger.info` preserves the structured log in pino/Better Stack. An operator can query for `op:callback_provider_error` + `bucket:oauth_cancelled` in logs. A spike in user cancellations is more likely a UX or consent-screen issue, not a system failure. |
 | Provider outage signal diluted by remaining alert noise | Low | Low | Provider errors (`server_error`, etc.) still emit `warnSilentFallback` to Sentry. The `auth-per-user-loop` rule will still fire on genuine provider outages. |
 | Test refactor introduces false negatives | Low | Medium | The split test structure makes assertions more explicit. Each branch has its own test with dedicated mock assertions. |
+| `logger.info` context shape drifts from `warnSilentFallback` `extra` shape | Low | Medium | The `logger.info` call in the implementation sketch explicitly includes all 5 context fields (`providerErrorCode`, `bucket`, `urlPath`, `refererHost`, `origin`) plus `feature` and `op`. The `access_denied` test must assert these fields are present in the `mockLoggerInfo` call args. |
 
 ## Domain Review
 

--- a/knowledge-base/project/plans/2026-05-27-fix-oauth-callback-access-denied-sentry-alert-noise-plan.md
+++ b/knowledge-base/project/plans/2026-05-27-fix-oauth-callback-access-denied-sentry-alert-noise-plan.md
@@ -120,13 +120,13 @@ None.
 
 ### Pre-merge (PR)
 
-- [ ] **AC1:** `grep -n "logger.info" apps/web-platform/app/\(auth\)/callback/route.ts` shows a `logger.info` call on the `access_denied` / `oauth_cancelled` branch with `op: "callback_provider_error"` context.
-- [ ] **AC2:** `grep -n "warnSilentFallback" apps/web-platform/app/\(auth\)/callback/route.ts` still shows a `warnSilentFallback` call for the non-`oauth_cancelled` provider error branch.
-- [ ] **AC3:** The `access_denied` test case in `callback-route-branches.test.ts` asserts that `mockWarnSilentFallback` was NOT called (`.not.toHaveBeenCalled()` or `.toHaveBeenCalledTimes(0)`).
-- [ ] **AC4:** The `server_error`, `temporarily_unavailable`, and `invalid_scope` test cases assert `mockWarnSilentFallback` IS called with `op: "callback_provider_error"`.
-- [ ] **AC5:** The bare-`/callback` test still asserts `mockReportSilentFallback` with `op: "callback_no_code"` (unchanged).
-- [ ] **AC6:** Tests pass: `apps/web-platform/node_modules/.bin/vitest run apps/web-platform/test/app/auth/callback-route-branches.test.ts apps/web-platform/test/lib/auth/callback-error-mapping.test.ts apps/web-platform/test/lib/auth/callback-route-no-substring-match.test.ts apps/web-platform/test/lib/auth/provider-error-classifier.test.ts apps/web-platform/test/lib/auth/provider-error-classifier-no-substring-match.test.ts`.
-- [ ] **AC7:** TypeScript compiles: `npx tsc --noEmit --project apps/web-platform/tsconfig.json`.
+- [x] **AC1:** `grep -n "logger.info" apps/web-platform/app/\(auth\)/callback/route.ts` shows a `logger.info` call on the `access_denied` / `oauth_cancelled` branch with `op: "callback_provider_error"` context.
+- [x] **AC2:** `grep -n "warnSilentFallback" apps/web-platform/app/\(auth\)/callback/route.ts` still shows a `warnSilentFallback` call for the non-`oauth_cancelled` provider error branch.
+- [x] **AC3:** The `access_denied` test case in `callback-route-branches.test.ts` asserts that `mockWarnSilentFallback` was NOT called (`.not.toHaveBeenCalled()` or `.toHaveBeenCalledTimes(0)`).
+- [x] **AC4:** The `server_error`, `temporarily_unavailable`, and `invalid_scope` test cases assert `mockWarnSilentFallback` IS called with `op: "callback_provider_error"`.
+- [x] **AC5:** The bare-`/callback` test still asserts `mockReportSilentFallback` with `op: "callback_no_code"` (unchanged).
+- [x] **AC6:** Tests pass: `apps/web-platform/node_modules/.bin/vitest run apps/web-platform/test/app/auth/callback-route-branches.test.ts apps/web-platform/test/lib/auth/callback-error-mapping.test.ts apps/web-platform/test/lib/auth/callback-route-no-substring-match.test.ts apps/web-platform/test/lib/auth/provider-error-classifier.test.ts apps/web-platform/test/lib/auth/provider-error-classifier-no-substring-match.test.ts`.
+- [x] **AC7:** TypeScript compiles: `npx tsc --noEmit --project apps/web-platform/tsconfig.json`.
 
 ## Test Scenarios
 

--- a/knowledge-base/project/plans/2026-05-27-fix-oauth-callback-access-denied-sentry-alert-noise-plan.md
+++ b/knowledge-base/project/plans/2026-05-27-fix-oauth-callback-access-denied-sentry-alert-noise-plan.md
@@ -1,0 +1,226 @@
+---
+title: "fix: stop Sentry alerts from firing on expected OAuth access_denied callbacks"
+type: fix
+date: 2026-05-27
+lane: single-domain
+brand_survival_threshold: none
+---
+
+# fix: Stop Sentry alerts from firing on expected OAuth access_denied callbacks
+
+## Overview
+
+The OAuth callback route at `apps/web-platform/app/(auth)/callback/route.ts` still triggers Sentry issue alerts (`auth-exchange-code-burst`, `auth-callback-no-code-burst`, and `auth-per-user-loop`) when a user denies OAuth consent (`?error=access_denied`), despite PR #4487 (commit `c38699c6`) downgrading the emission from `reportSilentFallback` (error level) to `warnSilentFallback` (warning level).
+
+**Why the previous fix was insufficient:** `warnSilentFallback` still calls `Sentry.captureMessage` at `level: "warning"` (see `apps/web-platform/server/observability.ts:231`). Sentry issue alert rules with `EventFrequencyCondition` count ALL issue events regardless of level -- both `error` and `warning` level `captureMessage` calls create Sentry issues that increment the frequency counter. The downgrade from error to warning changed the Sentry dashboard classification but did NOT stop the events from being counted by the alert rules.
+
+**Which alert rules fire:** The `auth-per-user-loop` rule (configured in `apps/web-platform/scripts/configure-sentry-alerts.sh:165-168`) filters only on `feature=auth` with no `op` filter, catching ALL auth events including `callback_provider_error`. The `auth-exchange-code-burst` and `auth-callback-no-code-burst` rules filter on specific ops (`exchangeCodeForSession` and `callback_no_code` respectively), but Sentry issue-grouping can merge events with different `op` values into the same issue -- once grouped, any event in the group increments the alert counter for any rule that matches the issue.
+
+**Root cause:** User-cancelled OAuth consent (`access_denied`) is expected behavior per RFC 6749 section 4.1.2.1. Expected behavior should use structured logging only (`logger.info`), not Sentry emission at any level. The learning at `knowledge-base/project/learnings/best-practices/2026-05-26-sentry-captureMessage-on-expected-paths-creates-alert-noise.md` already documents this principle: "Expected business-logic outcomes should use structured logging only."
+
+**Proposed fix:** Split the `callback_provider_error` path into two sub-branches:
+1. `access_denied` (user-cancel): `logger.info` only, no Sentry emission.
+2. All other provider errors (`server_error`, `temporarily_unavailable`, `invalid_request`, `invalid_scope`, `unauthorized_client`, `unsupported_response_type`): Keep `warnSilentFallback` for provider-outage diagnostic value.
+
+This mirrors the PR #4485 pattern (webhook no-grant path) which removed Sentry emission entirely for expected-state paths while keeping it for genuine error conditions.
+
+## Research Reconciliation -- Spec vs. Codebase
+
+| Spec/plan claim | Reality | Plan response |
+|---|---|---|
+| PR #4487 fix (downgrade to `warnSilentFallback`) resolves alert noise | `warnSilentFallback` still emits to Sentry (`captureMessage` at `level: "warning"`); Sentry alert rules count all events regardless of level | Split into `logger.info` (user-cancel) vs `warnSilentFallback` (provider error) |
+| Alert rules `auth-exchange-code-burst` and `auth-callback-no-code-burst` match by `op` tag | `auth-per-user-loop` rule filters only on `feature=auth` (no `op` filter) -- catches all auth events. Sentry issue-grouping can also cause cross-op alert hits. | Fix the emission source (stop emitting to Sentry for `access_denied`), not the alert rules |
+| Release `web-platform@0.102.0+00325db3` includes PR #4487 fix | Confirmed: `git merge-base --is-ancestor c38699c6 00325db3` returns true | Current production already has the downgrade; only the Sentry-emission-removal fix remains |
+
+## User-Brand Impact
+
+- **If this lands broken, the user experiences:** No change. The redirect to `/login?error=oauth_cancelled` is preserved. Only the Sentry emission is removed for user-cancel; the user-facing behavior is identical.
+- **If this leaks, the user's data/workflow/money is exposed via:** N/A. No data surface is affected. The change removes an observability emission for an expected condition.
+- **Brand-survival threshold:** `none`
+
+## Research Insights
+
+- **`warnSilentFallback` implementation** (`observability.ts:211-241`): Calls `Sentry.captureMessage(message, { level: "warning", tags, extra })`. This creates a Sentry issue that is counted by `EventFrequencyCondition` alert rules regardless of the `level` field.
+- **`auth-per-user-loop` alert rule** (`configure-sentry-alerts.sh:165-168`): `EventUniqueUserFrequencyCondition` with `value: 3, interval: 5m` filtering only on `feature=auth`. This is the most likely alert to fire on `callback_provider_error` events since it has no `op` filter.
+- **`classifyProviderError` returns bucket, not raw error code**: The function at `provider-error-classifier.ts:34-46` returns `"oauth_cancelled"` for `access_denied` and `"oauth_failed"` for everything else. The bucket is already available in the callback route to discriminate user-cancel from provider-error.
+- **PR #4485 precedent** (`knowledge-base/project/learnings/best-practices/2026-05-26-sentry-captureMessage-on-expected-paths-creates-alert-noise.md`): Removed Sentry emission entirely from the webhook no-grant path because that path is the default state. The OAuth `access_denied` path is analogous -- user-cancel is expected.
+- **`cq-silent-fallback-must-mirror-to-sentry` skip clause** (`observability.ts:126-130`): "Skip this helper when the error is EXPECTED (CSRF reject, rate-limit hit, first-time 404)." User-cancelled OAuth consent is expected.
+- **Existing test coverage** (`callback-route-branches.test.ts:104-129`): The `test.each` block tests `access_denied` -> `mockWarnSilentFallback`. This must be updated to assert `mockWarnSilentFallback` is NOT called for `access_denied`, but IS called for `server_error` etc.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "Sentry auth-per-user-loop and auth-exchange-code-burst issue alert rules"
+  cadence: "continuous (event-driven)"
+  alert_target: "operator email via IssueOwners+ActiveMembers"
+  configured_in: "apps/web-platform/infra/sentry/issue-alerts.tf"
+
+error_reporting:
+  destination: "Sentry web-platform project via SENTRY_DSN (warning level for provider errors, none for user-cancel)"
+  fail_loud: "Provider-side errors (server_error, temporarily_unavailable) still emit warnSilentFallback; user-cancel emits logger.info only"
+
+failure_modes:
+  - mode: "access_denied events stop appearing in pino structured logs"
+    detection: "logger.info is still present; grep pino stdout for op:callback_provider_error"
+    alert_route: "Better Stack log aggregator query"
+  - mode: "provider outage (server_error) events stop appearing in Sentry"
+    detection: "warnSilentFallback is preserved for non-access_denied bucket; Sentry dashboards still show feature:auth op:callback_provider_error"
+    alert_route: "auth-per-user-loop alert rule fires on warning-level provider-error events"
+
+logs:
+  where: "container stdout (pino structured JSON)"
+  retention: "Better Stack retention policy"
+
+discoverability_test:
+  command: "grep -c 'warnSilentFallback\\|logger.info' apps/web-platform/app/\\(auth\\)/callback/route.ts"
+  expected_output: "Both helpers appear: warnSilentFallback for provider-errors, logger.info for user-cancel"
+```
+
+## Files to Edit
+
+| File | Change |
+|------|--------|
+| `apps/web-platform/app/(auth)/callback/route.ts` | Split the `callback_provider_error` emission: (1) When `providerErrorBucket === "oauth_cancelled"`, emit `logger.info` only (no Sentry). (2) When `providerErrorBucket !== "oauth_cancelled"` (provider-side errors), keep `warnSilentFallback`. |
+| `apps/web-platform/test/app/auth/callback-route-branches.test.ts` | (1) Split the `test.each` block: `access_denied` row asserts `mockWarnSilentFallback` NOT called and `mockLoggerInfo` IS called. Other rows (`server_error`, `temporarily_unavailable`, `invalid_scope`) assert `mockWarnSilentFallback` IS called. (2) Update "unrecognized `?error=`" test to assert `mockWarnSilentFallback` (unknown errors are `oauth_failed` bucket, not user-cancel). (3) Update "refererHost" test (uses `?error=access_denied`) to assert `logger.info` NOT `mockWarnSilentFallback`. |
+
+## Files to Create
+
+None.
+
+## Do NOT Change
+
+- The redirect logic (`return noStoreRedirect(...)`) -- the user-facing behavior is correct.
+- The `classifyProviderError` or `isKnownProviderErrorCode` functions -- the classification logic is correct.
+- The `providerErrorCode` sanitization (lines 79-81) -- the Sentry tag cardinality guard is correct (it is still relevant for the `warnSilentFallback` path on provider errors).
+- The `callback_no_code` branch (line 249) -- this is a different code path that correctly uses `reportSilentFallback` at error level.
+- The `exchangeCodeForSession` error branch (line 153) -- system failure that correctly uses `reportSilentFallback`.
+- The Sentry alert rules or their Terraform definitions -- the fix is at the emission source, not the alert configuration.
+- `apps/web-platform/lib/auth/provider-error-classifier.ts` -- classification logic is correct.
+
+## Open Code-Review Overlap
+
+`#3739: review: extract reportSilentFallbackWithUser helper` -- touches `server/observability.ts` but targets the `withIsolationScope+setUser` duplication pattern (11 sites), which is a different concern from this fix. The callback provider-error call at line 85 does NOT use `withIsolationScope` (no userId is available before code exchange). **Disposition: Acknowledge** -- no overlap with the specific call site being modified.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] **AC1:** `grep -n "logger.info" apps/web-platform/app/\(auth\)/callback/route.ts` shows a `logger.info` call on the `access_denied` / `oauth_cancelled` branch with `op: "callback_provider_error"` context.
+- [ ] **AC2:** `grep -n "warnSilentFallback" apps/web-platform/app/\(auth\)/callback/route.ts` still shows a `warnSilentFallback` call for the non-`oauth_cancelled` provider error branch.
+- [ ] **AC3:** The `access_denied` test case in `callback-route-branches.test.ts` asserts that `mockWarnSilentFallback` was NOT called (`.not.toHaveBeenCalled()` or `.toHaveBeenCalledTimes(0)`).
+- [ ] **AC4:** The `server_error`, `temporarily_unavailable`, and `invalid_scope` test cases assert `mockWarnSilentFallback` IS called with `op: "callback_provider_error"`.
+- [ ] **AC5:** The bare-`/callback` test still asserts `mockReportSilentFallback` with `op: "callback_no_code"` (unchanged).
+- [ ] **AC6:** Tests pass: `apps/web-platform/node_modules/.bin/vitest run apps/web-platform/test/app/auth/callback-route-branches.test.ts apps/web-platform/test/lib/auth/callback-error-mapping.test.ts apps/web-platform/test/lib/auth/callback-route-no-substring-match.test.ts apps/web-platform/test/lib/auth/provider-error-classifier.test.ts apps/web-platform/test/lib/auth/provider-error-classifier-no-substring-match.test.ts`.
+- [ ] **AC7:** TypeScript compiles: `npx tsc --noEmit --project apps/web-platform/tsconfig.json`.
+
+## Test Scenarios
+
+- Given a user who cancels OAuth consent (`?error=access_denied`), when the callback route processes it, then it redirects to `/login?error=oauth_cancelled`, emits `logger.info` with context, and does NOT emit `warnSilentFallback` or `reportSilentFallback`.
+- Given a provider server error (`?error=server_error`), when the callback route processes it, then it redirects to `/login?error=oauth_failed` and emits `warnSilentFallback` (NOT `logger.info`-only).
+- Given a provider temporarily_unavailable error, when the callback route processes it, then it emits `warnSilentFallback`.
+- Given a bare `/callback` with no params, when the route processes it, then it emits `reportSilentFallback` at error level (unchanged).
+- Given a valid `?code=`, when `exchangeCodeForSession` fails, then it emits `reportSilentFallback` at error level (unchanged).
+
+## Implementation Phases
+
+### Phase 1: Split provider-error emission in callback route
+
+**File:** `apps/web-platform/app/(auth)/callback/route.ts`
+
+Replace the single `warnSilentFallback` call on the `providerErrorBucket` branch (currently line 85) with a conditional:
+
+```typescript
+if (providerErrorBucket === "oauth_cancelled") {
+  // User clicked Cancel at the consent screen — expected behavior.
+  // Structured log only; no Sentry emission (the alert rules count
+  // ALL captureMessage events regardless of level, and user-cancel
+  // is not actionable). See learning 2026-05-26-sentry-captureMessage-
+  // on-expected-paths-creates-alert-noise.md.
+  logger.info(
+    {
+      feature: "auth",
+      op: "callback_provider_error",
+      providerErrorCode,
+      bucket: providerErrorBucket,
+      urlPath: pathname,
+      refererHost,
+      origin,
+    },
+    `OAuth provider returned error=${providerErrorCode}`,
+  );
+} else {
+  // Provider-side failure (server_error, temporarily_unavailable, etc.)
+  // — unexpected, warrants Sentry visibility for operator dashboards.
+  warnSilentFallback(null, {
+    feature: "auth",
+    op: "callback_provider_error",
+    message: `OAuth provider returned error=${providerErrorCode}`,
+    extra: {
+      providerErrorCode,
+      bucket: providerErrorBucket,
+      urlPath: pathname,
+      refererHost,
+      origin,
+    },
+  });
+}
+```
+
+### Phase 2: Update test file
+
+**File:** `apps/web-platform/test/app/auth/callback-route-branches.test.ts`
+
+1. **Add `mockLoggerInfo`** to the `vi.hoisted` block and wire it into the logger mock.
+
+2. **Split the `test.each` block** (currently lines 104-129):
+   - Separate `access_denied` into its own test case that asserts:
+     - `mockWarnSilentFallback` NOT called (`.not.toHaveBeenCalled()`)
+     - `mockReportSilentFallback` NOT called
+     - `mockLoggerInfo` called with `op: "callback_provider_error"` context
+     - Redirect still goes to `/login?error=oauth_cancelled`
+   - Keep `server_error`, `temporarily_unavailable`, `invalid_scope` in a `test.each` that asserts `mockWarnSilentFallback` IS called.
+
+3. **Update "refererHost" test** (line 182): This test uses `?error=access_denied`. Change its assertion from `mockWarnSilentFallback` to `mockLoggerInfo` for the refererHost check.
+
+4. **Verify "searchParamKeys" test** (line 202): This tests the bare-`/callback` path (no `error=` param), which correctly uses `reportSilentFallback`. This test must remain unchanged.
+
+5. **Verify "unrecognized `?error=`" test** (line 132): This sends `?error=user@example.com`, which `classifyProviderError` maps to `"oauth_failed"` (not `"oauth_cancelled"`). This should assert `mockWarnSilentFallback` IS called (unknown errors are provider-side, not user-cancel). Update if needed.
+
+### Phase 3: Verify
+
+1. Run the test suite (AC6).
+2. Run TypeScript compile check (AC7).
+3. Run AC1-AC5 verification commands.
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Loss of `access_denied` spike visibility | Low | Low | `logger.info` preserves the structured log in pino/Better Stack. An operator can query for `op:callback_provider_error` + `bucket:oauth_cancelled` in logs. A spike in user cancellations is more likely a UX or consent-screen issue, not a system failure. |
+| Provider outage signal diluted by remaining alert noise | Low | Low | Provider errors (`server_error`, etc.) still emit `warnSilentFallback` to Sentry. The `auth-per-user-loop` rule will still fire on genuine provider outages. |
+| Test refactor introduces false negatives | Low | Medium | The split test structure makes assertions more explicit. Each branch has its own test with dedicated mock assertions. |
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected -- observability emission adjustment in a single auth callback route.
+
+## Context
+
+- **Sentry event IDs (today, 2026-05-27):** `4ec8f51d324747f1bb8bfc5c84ab5906` (07:00 CEST), `d2e86815ab4341c59f6ec7198b2c24fb` (08:00 CEST)
+- **Alert rules:** `auth-exchange-code-burst`, `auth-callback-no-code-burst` (per user report; likely also `auth-per-user-loop` which has no `op` filter)
+- **PR #4487 (`c38699c6`):** Previous fix that downgraded `reportSilentFallback` to `warnSilentFallback` -- insufficient because Sentry still counts warning-level events.
+- **PR #4485:** Same-class fix for webhook no-grant path -- removed Sentry emission entirely.
+- **Learning:** `knowledge-base/project/learnings/best-practices/2026-05-26-sentry-captureMessage-on-expected-paths-creates-alert-noise.md`
+- **Release:** `web-platform@0.102.0+00325db3` (includes PR #4487)
+
+## References
+
+- `apps/web-platform/app/(auth)/callback/route.ts:70-100` -- the provider-error branch
+- `apps/web-platform/server/observability.ts:211-241` -- `warnSilentFallback` (still emits to Sentry at warning level)
+- `apps/web-platform/server/observability.ts:164-203` -- `reportSilentFallback` (error level)
+- `apps/web-platform/lib/auth/provider-error-classifier.ts` -- provider error classification logic
+- `apps/web-platform/scripts/configure-sentry-alerts.sh:165-168` -- `auth-per-user-loop` rule (no `op` filter)
+- `apps/web-platform/test/app/auth/callback-route-branches.test.ts` -- test coverage for callback route branches

--- a/knowledge-base/project/specs/feat-one-shot-fix-oauth-callback-access-denied/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-oauth-callback-access-denied/session-state.md
@@ -1,0 +1,19 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-05-27-fix-oauth-callback-access-denied-sentry-alert-noise-plan.md
+- Status: complete
+
+### Errors
+None
+
+### Decisions
+- The previous fix (PR #4487, downgrading `reportSilentFallback` to `warnSilentFallback`) was insufficient because `warnSilentFallback` still emits to Sentry via `captureMessage` at warning level, and Sentry `EventFrequencyCondition` alert rules count ALL events regardless of level
+- The `auth-per-user-loop` alert rule filters only on `feature=auth` (no `op` filter), so it catches `callback_provider_error` events including user-cancel
+- The fix splits the provider-error branch: `access_denied` (user-cancel) uses `logger.info` only (no Sentry emission), while all other provider errors keep `warnSilentFallback` for diagnostic value
+- This mirrors the PR #4485 pattern (webhook no-grant path) which removed Sentry emission entirely for expected-state conditions
+- Test mock wiring requires adding `mockLoggerInfo` to `vi.hoisted` block and wiring it through the logger factory
+
+### Components Invoked
+- soleur:plan
+- soleur:deepen-plan

--- a/knowledge-base/project/specs/feat-one-shot-fix-oauth-callback-access-denied/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-oauth-callback-access-denied/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: fix OAuth callback access_denied Sentry alert noise
+
+## Phase 1: Split provider-error emission in callback route
+
+- [ ] 1.1 In `apps/web-platform/app/(auth)/callback/route.ts`, replace the single `warnSilentFallback` call on the `providerErrorBucket` branch with a conditional: `logger.info` for `oauth_cancelled` bucket, `warnSilentFallback` for all other buckets.
+- [ ] 1.2 Verify the `logger.info` call includes all structured context fields (`feature`, `op`, `providerErrorCode`, `bucket`, `urlPath`, `refererHost`, `origin`).
+- [ ] 1.3 Verify the `warnSilentFallback` call for non-`oauth_cancelled` buckets preserves the existing signature and all extra fields.
+
+## Phase 2: Update test file
+
+- [ ] 2.1 Add `mockLoggerInfo` to `vi.hoisted` block and wire into the logger mock in `callback-route-branches.test.ts`.
+- [ ] 2.2 Split the `test.each` block: extract `access_denied` into its own test asserting `mockWarnSilentFallback.not.toHaveBeenCalled()` and `mockLoggerInfo` called with correct context.
+- [ ] 2.3 Keep `server_error`, `temporarily_unavailable`, `invalid_scope` in a `test.each` asserting `mockWarnSilentFallback` IS called.
+- [ ] 2.4 Update "refererHost" test (uses `?error=access_denied`) to assert `mockLoggerInfo` context instead of `mockWarnSilentFallback`.
+- [ ] 2.5 Verify "searchParamKeys" test (bare `/callback` path) remains unchanged with `mockReportSilentFallback`.
+- [ ] 2.6 Verify "unrecognized `?error=`" test asserts `mockWarnSilentFallback` (unknown errors are `oauth_failed` bucket).
+
+## Phase 3: Verify
+
+- [ ] 3.1 Run vitest suite: `apps/web-platform/node_modules/.bin/vitest run apps/web-platform/test/app/auth/callback-route-branches.test.ts apps/web-platform/test/lib/auth/callback-error-mapping.test.ts apps/web-platform/test/lib/auth/callback-route-no-substring-match.test.ts apps/web-platform/test/lib/auth/provider-error-classifier.test.ts apps/web-platform/test/lib/auth/provider-error-classifier-no-substring-match.test.ts`.
+- [ ] 3.2 Run TypeScript compile check: `npx tsc --noEmit --project apps/web-platform/tsconfig.json`.
+- [ ] 3.3 Run AC1-AC5 verification grep commands.

--- a/knowledge-base/project/specs/feat-one-shot-fix-oauth-callback-access-denied/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-oauth-callback-access-denied/tasks.md
@@ -2,25 +2,25 @@
 
 ## Phase 1: Split provider-error emission in callback route
 
-- [ ] 1.1 In `apps/web-platform/app/(auth)/callback/route.ts` line 85, replace the single `warnSilentFallback` call with a conditional on `providerErrorBucket === "oauth_cancelled"`.
-- [ ] 1.2 For `oauth_cancelled` bucket: emit `logger.info` with all 7 structured context fields (`feature`, `op`, `providerErrorCode`, `bucket`, `urlPath`, `refererHost`, `origin`) and the message string `OAuth provider returned error=${providerErrorCode}`.
-- [ ] 1.3 For non-`oauth_cancelled` buckets: keep `warnSilentFallback(null, { feature: "auth", op: "callback_provider_error", ... })` with all existing `extra` fields.
-- [ ] 1.4 Add inline comment explaining why user-cancel is logger.info-only (Sentry alert rules count all captureMessage events regardless of level).
+- [x] 1.1 In `apps/web-platform/app/(auth)/callback/route.ts` line 85, replace the single `warnSilentFallback` call with a conditional on `providerErrorBucket === "oauth_cancelled"`.
+- [x] 1.2 For `oauth_cancelled` bucket: emit `logger.info` with all 7 structured context fields (`feature`, `op`, `providerErrorCode`, `bucket`, `urlPath`, `refererHost`, `origin`) and the message string `OAuth provider returned error=${providerErrorCode}`.
+- [x] 1.3 For non-`oauth_cancelled` buckets: keep `warnSilentFallback(null, { feature: "auth", op: "callback_provider_error", ... })` with all existing `extra` fields.
+- [x] 1.4 Add inline comment explaining why user-cancel is logger.info-only (Sentry alert rules count all captureMessage events regardless of level).
 
 ## Phase 2: Update test file
 
-- [ ] 2.1 Add `mockLoggerInfo: vi.fn()` to the `vi.hoisted` block in `callback-route-branches.test.ts` (alongside existing `mockReportSilentFallback`, `mockWarnSilentFallback`).
-- [ ] 2.2 Wire `mockLoggerInfo` into the logger mock: replace `info: vi.fn()` at line 27 with `info: mockLoggerInfo`.
-- [ ] 2.3 Extract `access_denied` from the `test.each` block into its own test: assert `mockWarnSilentFallback.not.toHaveBeenCalled()`, `mockReportSilentFallback.not.toHaveBeenCalled()`, `mockLoggerInfo` called once with `op: "callback_provider_error"` + `providerErrorCode: "access_denied"` + `bucket: "oauth_cancelled"`.
-- [ ] 2.4 Keep `server_error`, `temporarily_unavailable`, `invalid_scope` in a `test.each` asserting `mockWarnSilentFallback` IS called and `mockLoggerInfo.not.toHaveBeenCalled()`.
-- [ ] 2.5 Update "refererHost" test (uses `?error=access_denied`) to assert `mockLoggerInfo` context contains `refererHost: "accounts.google.com"` instead of `mockWarnSilentFallback`.
-- [ ] 2.6 Verify "searchParamKeys" test (bare `/callback` path) remains unchanged with `mockReportSilentFallback`.
-- [ ] 2.7 Verify "unrecognized `?error=`" test asserts `mockWarnSilentFallback` (unknown errors are `oauth_failed` bucket, not user-cancel).
+- [x] 2.1 Add `mockLoggerInfo: vi.fn()` to the `vi.hoisted` block in `callback-route-branches.test.ts` (alongside existing `mockReportSilentFallback`, `mockWarnSilentFallback`).
+- [x] 2.2 Wire `mockLoggerInfo` into the logger mock: replace `info: vi.fn()` at line 27 with `info: mockLoggerInfo`.
+- [x] 2.3 Extract `access_denied` from the `test.each` block into its own test: assert `mockWarnSilentFallback.not.toHaveBeenCalled()`, `mockReportSilentFallback.not.toHaveBeenCalled()`, `mockLoggerInfo` called once with `op: "callback_provider_error"` + `providerErrorCode: "access_denied"` + `bucket: "oauth_cancelled"`.
+- [x] 2.4 Keep `server_error`, `temporarily_unavailable`, `invalid_scope` in a `test.each` asserting `mockWarnSilentFallback` IS called and `mockLoggerInfo.not.toHaveBeenCalled()`.
+- [x] 2.5 Update "refererHost" test (uses `?error=access_denied`) to assert `mockLoggerInfo` context contains `refererHost: "accounts.google.com"` instead of `mockWarnSilentFallback`.
+- [x] 2.6 Verify "searchParamKeys" test (bare `/callback` path) remains unchanged with `mockReportSilentFallback`.
+- [x] 2.7 Verify "unrecognized `?error=`" test asserts `mockWarnSilentFallback` (unknown errors are `oauth_failed` bucket, not user-cancel).
 
 ## Phase 3: Verify
 
-- [ ] 3.1 Run vitest suite: `apps/web-platform/node_modules/.bin/vitest run apps/web-platform/test/app/auth/callback-route-branches.test.ts apps/web-platform/test/lib/auth/callback-error-mapping.test.ts apps/web-platform/test/lib/auth/callback-route-no-substring-match.test.ts apps/web-platform/test/lib/auth/provider-error-classifier.test.ts apps/web-platform/test/lib/auth/provider-error-classifier-no-substring-match.test.ts`.
-- [ ] 3.2 Run TypeScript compile check: `npx tsc --noEmit --project apps/web-platform/tsconfig.json`.
-- [ ] 3.3 Run AC1: `grep -n "logger.info" apps/web-platform/app/\(auth\)/callback/route.ts` shows logger.info on the oauth_cancelled branch.
-- [ ] 3.4 Run AC2: `grep -n "warnSilentFallback" apps/web-platform/app/\(auth\)/callback/route.ts` shows warnSilentFallback for non-cancelled provider errors.
-- [ ] 3.5 Run AC3-AC5: verify test assertions in callback-route-branches.test.ts.
+- [x] 3.1 Run vitest suite: `apps/web-platform/node_modules/.bin/vitest run apps/web-platform/test/app/auth/callback-route-branches.test.ts apps/web-platform/test/lib/auth/callback-error-mapping.test.ts apps/web-platform/test/lib/auth/callback-route-no-substring-match.test.ts apps/web-platform/test/lib/auth/provider-error-classifier.test.ts apps/web-platform/test/lib/auth/provider-error-classifier-no-substring-match.test.ts`.
+- [x] 3.2 Run TypeScript compile check: `npx tsc --noEmit --project apps/web-platform/tsconfig.json`.
+- [x] 3.3 Run AC1: `grep -n "logger.info" apps/web-platform/app/\(auth\)/callback/route.ts` shows logger.info on the oauth_cancelled branch.
+- [x] 3.4 Run AC2: `grep -n "warnSilentFallback" apps/web-platform/app/\(auth\)/callback/route.ts` shows warnSilentFallback for non-cancelled provider errors.
+- [x] 3.5 Run AC3-AC5: verify test assertions in callback-route-branches.test.ts.

--- a/knowledge-base/project/specs/feat-one-shot-fix-oauth-callback-access-denied/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-oauth-callback-access-denied/tasks.md
@@ -2,21 +2,25 @@
 
 ## Phase 1: Split provider-error emission in callback route
 
-- [ ] 1.1 In `apps/web-platform/app/(auth)/callback/route.ts`, replace the single `warnSilentFallback` call on the `providerErrorBucket` branch with a conditional: `logger.info` for `oauth_cancelled` bucket, `warnSilentFallback` for all other buckets.
-- [ ] 1.2 Verify the `logger.info` call includes all structured context fields (`feature`, `op`, `providerErrorCode`, `bucket`, `urlPath`, `refererHost`, `origin`).
-- [ ] 1.3 Verify the `warnSilentFallback` call for non-`oauth_cancelled` buckets preserves the existing signature and all extra fields.
+- [ ] 1.1 In `apps/web-platform/app/(auth)/callback/route.ts` line 85, replace the single `warnSilentFallback` call with a conditional on `providerErrorBucket === "oauth_cancelled"`.
+- [ ] 1.2 For `oauth_cancelled` bucket: emit `logger.info` with all 7 structured context fields (`feature`, `op`, `providerErrorCode`, `bucket`, `urlPath`, `refererHost`, `origin`) and the message string `OAuth provider returned error=${providerErrorCode}`.
+- [ ] 1.3 For non-`oauth_cancelled` buckets: keep `warnSilentFallback(null, { feature: "auth", op: "callback_provider_error", ... })` with all existing `extra` fields.
+- [ ] 1.4 Add inline comment explaining why user-cancel is logger.info-only (Sentry alert rules count all captureMessage events regardless of level).
 
 ## Phase 2: Update test file
 
-- [ ] 2.1 Add `mockLoggerInfo` to `vi.hoisted` block and wire into the logger mock in `callback-route-branches.test.ts`.
-- [ ] 2.2 Split the `test.each` block: extract `access_denied` into its own test asserting `mockWarnSilentFallback.not.toHaveBeenCalled()` and `mockLoggerInfo` called with correct context.
-- [ ] 2.3 Keep `server_error`, `temporarily_unavailable`, `invalid_scope` in a `test.each` asserting `mockWarnSilentFallback` IS called.
-- [ ] 2.4 Update "refererHost" test (uses `?error=access_denied`) to assert `mockLoggerInfo` context instead of `mockWarnSilentFallback`.
-- [ ] 2.5 Verify "searchParamKeys" test (bare `/callback` path) remains unchanged with `mockReportSilentFallback`.
-- [ ] 2.6 Verify "unrecognized `?error=`" test asserts `mockWarnSilentFallback` (unknown errors are `oauth_failed` bucket).
+- [ ] 2.1 Add `mockLoggerInfo: vi.fn()` to the `vi.hoisted` block in `callback-route-branches.test.ts` (alongside existing `mockReportSilentFallback`, `mockWarnSilentFallback`).
+- [ ] 2.2 Wire `mockLoggerInfo` into the logger mock: replace `info: vi.fn()` at line 27 with `info: mockLoggerInfo`.
+- [ ] 2.3 Extract `access_denied` from the `test.each` block into its own test: assert `mockWarnSilentFallback.not.toHaveBeenCalled()`, `mockReportSilentFallback.not.toHaveBeenCalled()`, `mockLoggerInfo` called once with `op: "callback_provider_error"` + `providerErrorCode: "access_denied"` + `bucket: "oauth_cancelled"`.
+- [ ] 2.4 Keep `server_error`, `temporarily_unavailable`, `invalid_scope` in a `test.each` asserting `mockWarnSilentFallback` IS called and `mockLoggerInfo.not.toHaveBeenCalled()`.
+- [ ] 2.5 Update "refererHost" test (uses `?error=access_denied`) to assert `mockLoggerInfo` context contains `refererHost: "accounts.google.com"` instead of `mockWarnSilentFallback`.
+- [ ] 2.6 Verify "searchParamKeys" test (bare `/callback` path) remains unchanged with `mockReportSilentFallback`.
+- [ ] 2.7 Verify "unrecognized `?error=`" test asserts `mockWarnSilentFallback` (unknown errors are `oauth_failed` bucket, not user-cancel).
 
 ## Phase 3: Verify
 
 - [ ] 3.1 Run vitest suite: `apps/web-platform/node_modules/.bin/vitest run apps/web-platform/test/app/auth/callback-route-branches.test.ts apps/web-platform/test/lib/auth/callback-error-mapping.test.ts apps/web-platform/test/lib/auth/callback-route-no-substring-match.test.ts apps/web-platform/test/lib/auth/provider-error-classifier.test.ts apps/web-platform/test/lib/auth/provider-error-classifier-no-substring-match.test.ts`.
 - [ ] 3.2 Run TypeScript compile check: `npx tsc --noEmit --project apps/web-platform/tsconfig.json`.
-- [ ] 3.3 Run AC1-AC5 verification grep commands.
+- [ ] 3.3 Run AC1: `grep -n "logger.info" apps/web-platform/app/\(auth\)/callback/route.ts` shows logger.info on the oauth_cancelled branch.
+- [ ] 3.4 Run AC2: `grep -n "warnSilentFallback" apps/web-platform/app/\(auth\)/callback/route.ts` shows warnSilentFallback for non-cancelled provider errors.
+- [ ] 3.5 Run AC3-AC5: verify test assertions in callback-route-branches.test.ts.


### PR DESCRIPTION
## Summary

- Split OAuth callback provider-error emission: `access_denied` (user-cancel) now uses `logger.info` only — no Sentry `captureMessage`. Provider-side errors (`server_error`, `temporarily_unavailable`, etc.) keep `warnSilentFallback` for diagnostic visibility.
- Previous fix (PR #4487) downgraded from `reportSilentFallback` to `warnSilentFallback`, but `warnSilentFallback` still calls `Sentry.captureMessage` at warning level. Sentry `EventFrequencyCondition` alert rules count ALL events regardless of level, so the downgrade did not stop alert noise.
- Updated tests to verify cross-channel exclusion: `access_denied` asserts `mockWarnSilentFallback.not.toHaveBeenCalled()`; provider errors assert `mockLoggerInfo.not.toHaveBeenCalled()`.

## Changelog

- **fix:** OAuth `access_denied` callbacks no longer emit to Sentry, stopping recurring `auth-exchange-code-burst` and `auth-per-user-loop` alert noise

## Test plan

- [x] Vitest: 54 auth tests pass (callback-route-branches, error-mapping, provider-error-classifier)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Full test suite: 82/82 suites pass (`scripts/test-all.sh`)
- [x] AC1-AC7 grep checks verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)