### PR TITLE
fix(db): pg_cron dollar-quote collision in mig 076

### DIFF
--- a/apps/web-platform/supabase/migrations/076_workspace_activity.sql
+++ b/apps/web-platform/supabase/migrations/076_workspace_activity.sql
@@ -90,7 +90,7 @@ CREATE INDEX workspace_activity_actor_idx
 -- 5. pg_cron 90-day retention purge (idempotent per Kieran H3)
 -- =====================================================================
 
-DO $$
+DO $cron_block$
 BEGIN
   IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'workspace_activity_purge') THEN
     PERFORM cron.unschedule('workspace_activity_purge');
@@ -101,7 +101,7 @@ BEGIN
     $$DELETE FROM public.workspace_activity WHERE created_at < now() - interval '90 days'$$
   );
 EXCEPTION WHEN duplicate_object THEN NULL;
-END $$;
+END $cron_block$;
 
 -- =====================================================================
 -- 6. Art-17 anonymisation RPC (follows mig 063 pattern)


### PR DESCRIPTION
## Summary

Hotfix for the Web Platform Release failure on #4524 merge. Migration 076's pg_cron `DO $$` block used `$$` as both the outer block delimiter and the inner `cron.schedule()` SQL string delimiter, causing PostgreSQL to misparse the block boundary.

Fix: outer block uses `$cron_block$` to disambiguate from the inner `$$`.

## Changelog

### Web Platform
- Fixed pg_cron dollar-quote collision in migration 076_workspace_activity.sql

## Test plan

- [x] SQL syntax verified (distinct dollar-quote tags)
- [ ] Web Platform Release workflow passes post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)