### PR TITLE
fix(verify): bump JTI deny policy count 21→23 for mig 076/077

### DIFF
--- a/apps/web-platform/supabase/migrations/076_workspace_activity.sql
+++ b/apps/web-platform/supabase/migrations/076_workspace_activity.sql
@@ -90,7 +90,7 @@ CREATE INDEX workspace_activity_actor_idx
 -- 5. pg_cron 90-day retention purge (idempotent per Kieran H3)
 -- =====================================================================
 
-DO $$
+DO $cron_block$
 BEGIN
   IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'workspace_activity_purge') THEN
     PERFORM cron.unschedule('workspace_activity_purge');
@@ -101,7 +101,7 @@ BEGIN
     $$DELETE FROM public.workspace_activity WHERE created_at < now() - interval '90 days'$$
   );
 EXCEPTION WHEN duplicate_object THEN NULL;
-END $$;
+END $cron_block$;
 
 -- =====================================================================
 -- 6. Art-17 anonymisation RPC (follows mig 063 pattern)

--- a/apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql
+++ b/apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql
@@ -12,8 +12,8 @@
 --     (REVOKED FROM authenticated, service_role only).
 --   * revoke_jti is NOT granted to authenticated (service-role-only).
 --   * my_revocation_status is granted TO authenticated.
---   * Exactly 21 RESTRICTIVE policies named *_jti_not_denied exist.
---   * Each of the 21 tenant tables has its own policy.
+--   * Exactly 23 RESTRICTIVE policies named *_jti_not_denied exist.
+--   * Each of the 23 tenant tables has its own policy.
 
 -- (1) revoke_jti present + SECURITY DEFINER
 SELECT 'revoke_jti_fn_present' AS check_name,
@@ -69,9 +69,9 @@ SELECT 'my_revocation_status_authenticated_grant_present',
               'EXECUTE'
             ) THEN 0 ELSE 1 END::int
 UNION ALL
--- (7) Exactly 21 RESTRICTIVE jti_not_denied policies
-SELECT 'jti_deny_policies_count_21',
-       CASE WHEN count(*) = 21 THEN 0 ELSE 1 END::int
+-- (7) Exactly 23 RESTRICTIVE jti_not_denied policies (21 base + workspace_activity + kb_files from mig 076/077)
+SELECT 'jti_deny_policies_count_23',
+       CASE WHEN count(*) = 23 THEN 0 ELSE 1 END::int
   FROM pg_policies
  WHERE schemaname = 'public'
    AND policyname LIKE '%_jti_not_denied'


### PR DESCRIPTION
## Summary

Hotfix #2 for #4521 release. Migrations 076/077 added 2 new JTI deny RESTRICTIVE policies (`workspace_activity_jti_not_denied`, `kb_files_jti_not_denied`), bumping the total from 21 to 23. The verify sentinel in `068_jti_deny_rls_predicate_and_revoke_rpc.sql` was hardcoded to 21.

## Changelog

### Web Platform
- Bumped JTI deny policy count sentinel from 21 to 23

## Test plan

- [x] Verify sentinel count matches: 21 base + 2 new tables = 23

🤖 Generated with [Claude Code](https://claude.com/claude-code)