### PR TITLE
fix(docker): bump gh CLI 2.92.0 → 2.93.0 in production image

### DIFF
--- a/apps/web-platform/Dockerfile
+++ b/apps/web-platform/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
        > /etc/apt/sources.list.d/github-cli.list \
-    && apt-get update && apt-get install -y --no-install-recommends gh=2.92.0 \
+    && apt-get update && apt-get install -y --no-install-recommends gh=2.93.0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Playwright Chromium system deps + browser binary (TR9 PR-11).


### PR DESCRIPTION
## Summary

- Bumps `gh` CLI from 2.92.0 to 2.93.0 in the production Dockerfile
- 2.92.0 was removed from the GitHub CLI APT repo after 2.93.0 released, breaking Docker builds with exit code 100

## Test plan

- [ ] Docker build succeeds in CI release job

🤖 Generated with [Claude Code](https://claude.com/claude-code)