### PR TITLE
fix(ci): register restart-inngest-server.yml in GitHub Actions

### DIFF
--- a/.github/workflows/restart-inngest-server.yml
+++ b/.github/workflows/restart-inngest-server.yml
@@ -6,6 +6,14 @@ name: Restart Inngest Server
 
 on:
   workflow_dispatch: {}
+  # push trigger scoped to this file forces GitHub to register the workflow
+  # in the Actions UI. Without a non-dispatch trigger, workflow_dispatch-only
+  # workflows can take 30+ minutes to appear. The path filter ensures this
+  # trigger only fires when the workflow file itself is edited.
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/restart-inngest-server.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Add self-scoped `push` trigger to `restart-inngest-server.yml` so GitHub indexes it immediately on merge
- `workflow_dispatch`-only workflows can take 30+ min to appear in the Actions UI without a secondary trigger

Ref #4538

## Test plan

- [x] YAML valid
- [x] Push trigger scoped to the workflow file itself (inert for all other pushes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)