### PR TITLE
fix(deploy): use /health endpoint for inngest restart verification

### DIFF
--- a/.github/workflows/restart-inngest-server.yml
+++ b/.github/workflows/restart-inngest-server.yml
@@ -6,6 +6,14 @@ name: Restart Inngest Server
 
 on:
   workflow_dispatch: {}
+  # push trigger scoped to this file forces GitHub to register the workflow
+  # in the Actions UI. Without a non-dispatch trigger, workflow_dispatch-only
+  # workflows can take 30+ minutes to appear. The path filter ensures this
+  # trigger only fires when the workflow file itself is edited.
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/restart-inngest-server.yml'
 
 permissions:
   contents: read

--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -188,43 +188,29 @@ resolve_env_file() {
   return 0
 }
 
-# Verify inngest-server is healthy and has registered functions (#4538).
-# Returns 0 if healthy with >= 1 function.
-# Returns 1 if server never became reachable (health failure).
-# Returns 2 if server is reachable but has 0 registered functions.
+# Verify inngest-server is healthy after restart (#4538).
+# Returns 0 if /health returns {"status":200}.
+# Returns 1 if server never became reachable within the retry window.
 # Uses `|| true` after curl instead of set +e/-e toggle — toggling set -e
 # inside a function re-enables it globally and causes the caller's non-zero
 # capture (`VERIFY_RC=$?`) to never execute.
-verify_inngest_functions() {
+verify_inngest_health() {
   local max_attempts="${1:-10}"
   local interval="${2:-3}"
-  local server_reached=false
-  local count=0
   local response=""
 
   for i in $(seq 1 "$max_attempts"); do
-    response=$(curl -sf --max-time 5 http://127.0.0.1:8288/v1/functions 2>/dev/null) || true
+    response=$(curl -sf --max-time 5 http://127.0.0.1:8288/health 2>/dev/null) || true
 
-    if [[ -z "$response" ]]; then
-      logger -t "$LOG_TAG" "INNGEST_HEALTH: attempt $i/$max_attempts — connection failed or empty response"
-      sleep "$interval"
-      continue
-    fi
-
-    server_reached=true
-    count=$(printf '%s' "$response" | jq 'if type == "array" then length else 0 end' 2>/dev/null || echo "0")
-    if [[ "$count" -ge 1 ]]; then
-      logger -t "$LOG_TAG" "INNGEST_VERIFY: healthy=true count=$count"
+    if [[ -n "$response" ]]; then
+      logger -t "$LOG_TAG" "INNGEST_HEALTH: healthy=true (attempt $i/$max_attempts)"
       return 0
     fi
-    logger -t "$LOG_TAG" "INNGEST_HEALTH: attempt $i/$max_attempts — server up but 0 functions"
+    logger -t "$LOG_TAG" "INNGEST_HEALTH: attempt $i/$max_attempts — connection failed or empty response"
     sleep "$interval"
   done
 
-  logger -t "$LOG_TAG" "INNGEST_VERIFY: healthy=false server_reached=$server_reached count=$count"
-  if [[ "$server_reached" == "true" ]]; then
-    return 2
-  fi
+  logger -t "$LOG_TAG" "INNGEST_HEALTH: healthy=false after $max_attempts attempts"
   return 1
 }
 
@@ -341,16 +327,13 @@ if [[ "$ACTION" == "restart" ]]; then
   fi
 
   set +e
-  verify_inngest_functions
+  verify_inngest_health
   VERIFY_RC=$?
   set -e
   if [[ "$VERIFY_RC" -eq 0 ]]; then
     logger -t "$LOG_TAG" "SUCCESS: restart $COMPONENT"
     final_write_state 0 "success"
     exit 0
-  elif [[ "$VERIFY_RC" -eq 2 ]]; then
-    final_write_state 1 "inngest_no_functions"
-    exit 1
   else
     final_write_state 1 "inngest_health_failed"
     exit 1
@@ -612,15 +595,14 @@ case "$COMPONENT" in
         { docker stop soleur-web-platform-canary 2>/dev/null || true; }
         { docker rm soleur-web-platform-canary 2>/dev/null || true; }
 
-        # Inngest function registry sanity check (informational, #4538).
+        # Inngest health sanity check (informational, #4538).
         # Non-blocking: does NOT gate deploy success.
         sleep 5
-        inngest_count=$(curl -sf --max-time 5 http://127.0.0.1:8288/v1/functions 2>/dev/null \
-          | jq 'if type == "array" then length else 0 end' 2>/dev/null || echo "0")
-        inngest_count="${inngest_count:-0}"
-        logger -t "$LOG_TAG" "INNGEST_FUNCTION_COUNT: ${inngest_count}"
-        if [[ "$inngest_count" -eq 0 ]]; then
-          logger -t "$LOG_TAG" "INNGEST_WARN: zero functions registered after deploy — consider running restart-inngest-server.yml workflow"
+        inngest_health=$(curl -sf --max-time 5 http://127.0.0.1:8288/health 2>/dev/null || echo "")
+        if [[ -n "$inngest_health" ]]; then
+          logger -t "$LOG_TAG" "INNGEST_HEALTH_CHECK: ok"
+        else
+          logger -t "$LOG_TAG" "INNGEST_WARN: inngest-server not reachable after deploy — consider running restart-inngest-server.yml workflow"
         fi
 
         echo "Deploy succeeded"

--- a/apps/web-platform/infra/ci-deploy.test.sh
+++ b/apps/web-platform/infra/ci-deploy.test.sh
@@ -259,9 +259,16 @@ write_body() {
   if [[ -n "$OUTPUT_FILE" ]]; then printf '%s' "$1" > "$OUTPUT_FILE"; else printf '%s' "$1"; fi
 }
 
-# Per-route mock behavior. Order matters: /health must short-circuit first
+# Per-route mock behavior. Order matters: 8288 must match before generic /health
 # because the canary loop's curl -sf for /health does NOT pass -w.
 case "$URL" in
+  *"8288/health"*)
+    if [[ "${MOCK_CURL_INNGEST_HEALTH_FAIL:-}" == "1" ]]; then
+      exit 1
+    fi
+    write_body '{"status":200,"message":"OK"}'
+    exit 0
+    ;;
   *"/health"*)
     write_body "OK"
     if [[ "$WANT_HTTP_CODE" == "1" ]]; then echo "200"; fi
@@ -299,17 +306,6 @@ case "$URL" in
     # Default: middleware-redirected unauthenticated request.
     write_body ""
     if [[ "$WANT_HTTP_CODE" == "1" ]]; then echo "307"; fi
-    exit 0
-    ;;
-  *"/v1/functions"*)
-    if [[ "${MOCK_CURL_INNGEST_HEALTH_FAIL:-}" == "1" ]]; then
-      exit 1
-    fi
-    if [[ "${MOCK_CURL_INNGEST_ZERO_FUNCTIONS:-}" == "1" ]]; then
-      write_body "[]"
-      exit 0
-    fi
-    write_body '[{"id":"fn-1","name":"test-fn-1"},{"id":"fn-2","name":"test-fn-2"}]'
     exit 0
     ;;
 esac
@@ -1873,12 +1869,6 @@ assert_state_contains "restart inngest health failure" \
   "inngest_health_failed" "1" \
   "restart inngest _ latest" \
   "export MOCK_CURL_INNGEST_HEALTH_FAIL=1"
-
-# AC5(d): restart with zero functions
-assert_state_contains "restart inngest zero functions" \
-  "inngest_no_functions" "1" \
-  "restart inngest _ latest" \
-  "export MOCK_CURL_INNGEST_ZERO_FUNCTIONS=1"
 
 # Existing deploy validation still rejects `deploy inngest restart latest`
 # (image mismatch since "restart" != expected image)


### PR DESCRIPTION
## Summary

- Inngest self-hosted v1.19.4 does not expose `/v1/functions` REST API — the endpoint returns 404
- Switch `verify_inngest_functions` → `verify_inngest_health` using `/health` endpoint
- Simplify to health-only check (no function count — not available via REST)
- Update post-deploy informational check to use `/health`

Ref #4538

## Test plan

- [x] 76/76 ci-deploy.test.sh passing
- [x] Verified `/health` returns `{"status":200}` on production server
- [x] Verified `/v1/functions` returns 404 on Inngest v1.19.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)