### PR TITLE
docs(runbook): correct GitHub App install ID + two-step permission flow

### DIFF
--- a/knowledge-base/engineering/ops/runbooks/github-app-provisioning.md
+++ b/knowledge-base/engineering/ops/runbooks/github-app-provisioning.md
@@ -76,15 +76,27 @@ integration` on any endpoint the new permission gates (e.g.,
 
 Procedure:
 
-1. Navigate to `https://github.com/organizations/jikig-ai/settings/installations/130018654`
-   (the App was reinstalled; the current installation ID is `130018654`, was
-   `122213433`). Note: the #4189 fix widened `issues: read → write`, and the
-   live install was already missing the long-declared `members: read`. Both are
-   manifest-RAISED relative to the live grant, so a SINGLE re-consent click
-   grants both — restoring the cron issue-filing trail AND clearing the
-   `installation_permission_drift {members:read}` that kept #4189 open.
-   (`members: read` is load-bearing for org-level installation ownership
-   verification in `server/github-app.ts`; it is granted, not dropped.)
+1. Find the current installation ID first — do NOT hard-code it (the ID
+   changes whenever the App is reinstalled). Run:
+
+   ```bash
+   gh api /orgs/jikig-ai/installations \
+     --jq '.installations[] | select(.app_slug=="soleur-ai") | .id'
+   ```
+
+   As of 2026-05-28 this is `122213433`. Navigate to
+   `https://github.com/organizations/jikig-ai/settings/installations/<id>`.
+
+   Note on the #4189 fix: raising a key in the App's permissions (e.g. the
+   `issues: read → write` widen) is a TWO-step UI flow — first raise the
+   permission in App settings (`.../settings/apps/soleur-ai/permissions`,
+   editing the manifest JSON in the repo does NOT propagate to the live App),
+   then accept the resulting update on the installation (steps below). The
+   #4189 `members: read` drift the guard reported cited a stale installation
+   ID (`130018654`) that does not match the live org install (`122213433`);
+   `members: read` was already granted on the live install and is load-bearing
+   for org-level installation-ownership verification in `server/github-app.ts`
+   (granted, not dropped).
 2. GitHub renders a "Soleur AI is requesting an update to its permissions"
    banner with a "Review request" link when any declared permission exceeds
    the installation's current grants. Click **Review request** then


### PR DESCRIPTION
## Summary

Follow-up to PR #4561. During the #4189 re-consent (driven via Playwright), the live state was verified: the `jikig-ai` org installation is **`122213433`** with `members: read` **already granted** — only `issues: write` needed raising. The #4561 runbook edit had hard-coded a stale install ID (`130018654`) and mis-stated the `members:read` drift.

- Replace the hard-coded install ID with a `gh api` lookup (the ID changes on reinstall).
- Document the **two-step** permission-raise flow: raise in App settings first (editing the repo manifest JSON does NOT propagate to the live App), then accept on the installation.
- Correct the `members:read` note (already granted; load-bearing for org-ownership verification, not dropped).

Ref #4189

## Changelog

- docs(runbook): github-app-provisioning Step 2.1 — correct install ID, gh-api lookup, two-step permission-raise flow.

## Test plan

- [x] Docs-only; `git grep 130018654` shows no remaining operational hard-coded references.

Generated with [Claude Code](https://claude.com/claude-code)