### PR TITLE
fix(hooks): PreToolUse denies silently ignored — add required hookEventName

### DIFF
--- a/.claude/hooks/doppler-secrets-delete-redirect.sh
+++ b/.claude/hooks/doppler-secrets-delete-redirect.sh
@@ -18,7 +18,7 @@ if printf '%s' "$CMD" | grep -qE 'doppler\s+secrets\s+(delete|set|upload)'; then
     SUBCMD=$(printf '%s' "$CMD" | grep -oE 'doppler\s+secrets\s+(delete|set|upload)' | awk '{print $3}')
     jq -n --arg subcmd "$SUBCMD" '{
       hookSpecificOutput: {
-        permissionDecision: "deny",
+        hookEventName: "PreToolUse",        permissionDecision: "deny",
         permissionDecisionReason: ("BLOCKED: `doppler secrets " + $subcmd + "` without `> /dev/null` — the CLI prints ALL remaining secrets to stdout. Add `> /dev/null` and verify with a separate `doppler secrets get` call.")
       }
     }'

--- a/.claude/hooks/git-commit-secret-scan.sh
+++ b/.claude/hooks/git-commit-secret-scan.sh
@@ -19,7 +19,7 @@
 # lefthook would have used — no rule duplication.
 #
 # Hook stdin: JSON payload from Claude Code with tool_name + tool_input.
-# Hook stdout: JSON {hookSpecificOutput: {permissionDecision, permissionDecisionReason}}.
+# Hook stdout: JSON {hookSpecificOutput: {hookEventName, permissionDecision, permissionDecisionReason}}.
 # Hook exit code: 0 always (JSON output controls the gate).
 #
 # Fail-open conditions (the hook allows the commit + emits a warn):
@@ -41,7 +41,7 @@ fi
 emit() { command -v emit_incident >/dev/null 2>&1 && emit_incident "$@" || true; }
 
 allow() {
-  echo '{"hookSpecificOutput":{"permissionDecision":"allow"}}'
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
   exit 0
 }
 
@@ -49,7 +49,7 @@ deny() {
   local reason="$1"
   emit git-commit-secret-scan deny "git-commit-secret-scan: $reason"
   jq -nc --arg r "$reason" \
-    '{hookSpecificOutput: {permissionDecision: "deny", permissionDecisionReason: $r}}'
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $r}}'
   exit 0
 }
 

--- a/.claude/hooks/guardrails.sh
+++ b/.claude/hooks/guardrails.sh
@@ -55,7 +55,7 @@ if echo "$COMMAND" | grep -qE '(^|&&|\|\||;)\s*git\s+commit'; then
     emit_incident "guardrails-block-commit-on-main" "deny" "Never allow agents to work directly on default branch" "$COMMAND"
     jq -n '{
       hookSpecificOutput: {
-        permissionDecision: "deny",
+        hookEventName: "PreToolUse",        permissionDecision: "deny",
         permissionDecisionReason: "BLOCKED: Committing directly to main/master is not allowed. Create a feature branch first."
       }
     }'
@@ -71,7 +71,7 @@ if echo "$COMMAND" | grep -qE 'rm\s+(-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*|-[a-zA-Z]*f[
   emit_incident "guardrails-block-rm-rf-worktrees" "deny" "Never rm -rf on a worktree path" "$COMMAND"
   jq -n '{
     hookSpecificOutput: {
-      permissionDecision: "deny",
+      hookEventName: "PreToolUse",      permissionDecision: "deny",
       permissionDecisionReason: "BLOCKED: rm -rf on worktree paths is not allowed. Use git worktree remove or worktree-manager.sh cleanup-merged instead."
     }
   }'
@@ -85,7 +85,7 @@ if echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge.*--delete-branch'; then
     emit_incident "guardrails-block-delete-branch" "deny" "Never use --delete-branch with gh pr merge" "$COMMAND"
     jq -n '{
       hookSpecificOutput: {
-        permissionDecision: "deny",
+        hookEventName: "PreToolUse",        permissionDecision: "deny",
         permissionDecisionReason: "BLOCKED: --delete-branch with active worktrees will orphan them. Remove worktrees first, then merge."
       }
     }'
@@ -109,7 +109,7 @@ if echo "$COMMAND" | grep -qE '(^|&&|\|\||;)\s*git\s+(-C\s+\S+\s+)?(commit|merge
     emit_incident "guardrails-block-conflict-markers" "deny" "Resolve conflicts before committing" "$COMMAND"
     jq -n '{
       hookSpecificOutput: {
-        permissionDecision: "deny",
+        hookEventName: "PreToolUse",        permissionDecision: "deny",
         permissionDecisionReason: "BLOCKED: Staged content contains conflict markers (<<<<<<<, =======, or >>>>>>>). Resolve all conflicts before committing."
       }
     }'
@@ -123,7 +123,7 @@ if echo "$COMMAND" | grep -qE '(^|&&|\|\||;)\s*gh\s+issue\s+create'; then
     emit_incident "guardrails-require-milestone" "deny" "gh issue create must include --milestone" "$COMMAND"
     jq -n '{
       hookSpecificOutput: {
-        permissionDecision: "deny",
+        hookEventName: "PreToolUse",        permissionDecision: "deny",
         permissionDecisionReason: "BLOCKED: gh issue create must include --milestone. Default to '\''Post-MVP / Later'\'' for operational issues. Read knowledge-base/product/roadmap.md for feature issues."
       }
     }'
@@ -140,7 +140,7 @@ if echo "$COMMAND" | grep -qE '(^|&&|\|\||;)\s*git\s+stash'; then
   emit_incident "hr-never-git-stash-in-worktrees" "deny" "Never git stash in worktrees" "$COMMAND"
   jq -n '{
     hookSpecificOutput: {
-      permissionDecision: "deny",
+      hookEventName: "PreToolUse",      permissionDecision: "deny",
       permissionDecisionReason: "BLOCKED: git stash is not allowed. Use git show <commit>:<path> to inspect old code, or commit WIP first."
     }
   }'

--- a/.claude/hooks/hookeventname-coverage.test.sh
+++ b/.claude/hooks/hookeventname-coverage.test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Meta-test: every PreToolUse hook that emits a `permissionDecision` MUST also
+# emit `hookEventName: "PreToolUse"` in the same output object — otherwise
+# Claude Code silently ignores the decision and the tool call proceeds (the
+# deny/ask never takes effect).
+#
+# This guards the bug class fixed in the hook-deny-enforcement PR: 9 hooks
+# (including git-commit-secret-scan, guardrails, no-memory-write) shipped deny
+# JSON without hookEventName and were silently non-enforcing. The per-file
+# count check below makes that class un-shippable going forward — any new or
+# edited hook that adds a permissionDecision without the paired hookEventName
+# fails this test.
+#
+# Source: official Claude Code PreToolUse hook contract — hookEventName is a
+# required field in hookSpecificOutput for permissionDecision to be honored.
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fail=0
+
+for h in "$HOOK_DIR"/*.sh; do
+  base="$(basename "$h")"
+  # Skip test scripts themselves.
+  [[ "$base" == *.test.sh ]] && continue
+
+  # Count non-comment lines that emit a permissionDecision, and lines that
+  # emit hookEventName. Comment lines (leading # after optional whitespace)
+  # are excluded so the doc-comment describing the shape is not counted.
+  # Match the decision FIELD only — `permissionDecision":` / `permissionDecision:`
+  # — never `permissionDecisionReason` (which contains "permissionDecision" as a
+  # substring and would double-count).
+  pd=$(grep -vE '^[[:space:]]*#' "$h" | grep -cE 'permissionDecision"?[[:space:]]*:' || true)
+  hen=$(grep -vE '^[[:space:]]*#' "$h" | grep -c 'hookEventName' || true)
+
+  if [[ "$pd" -gt 0 && "$hen" -lt "$pd" ]]; then
+    echo "FAIL: $base emits $pd permissionDecision(s) but only $hen hookEventName(s)."
+    echo "      Every permissionDecision output object must include hookEventName: \"PreToolUse\"."
+    fail=1
+  fi
+done
+
+if [[ "$fail" -eq 0 ]]; then
+  echo "PASS: all PreToolUse hooks pair permissionDecision with hookEventName."
+fi
+
+exit "$fail"

--- a/.claude/hooks/hookeventname-coverage.test.sh
+++ b/.claude/hooks/hookeventname-coverage.test.sh
@@ -33,6 +33,12 @@ for h in "$HOOK_DIR"/*.sh; do
   pd=$(grep -vE '^[[:space:]]*#' "$h" | grep -cE 'permissionDecision"?[[:space:]]*:' || true)
   hen=$(grep -vE '^[[:space:]]*#' "$h" | grep -c 'hookEventName' || true)
 
+  # Per-file count check (count(hookEventName) >= count(permissionDecision)),
+  # not per-emission pairing. This catches the realistic regression — a new
+  # decision block added without hookEventName bumps `pd` without `hen` and
+  # fails. It does NOT catch a contrived case of two hookEventName in one block
+  # plus zero in a sibling; that is not reachable today (every block has exactly
+  # one) and would require an AST-level parse to detect.
   if [[ "$pd" -gt 0 && "$hen" -lt "$pd" ]]; then
     echo "FAIL: $base emits $pd permissionDecision(s) but only $hen hookEventName(s)."
     echo "      Every permissionDecision output object must include hookEventName: \"PreToolUse\"."

--- a/.claude/hooks/iac-plan-write-guard.sh
+++ b/.claude/hooks/iac-plan-write-guard.sh
@@ -10,7 +10,7 @@
 # section in the plan output.
 #
 # Hook stdin: JSON payload from Claude Code with tool_name + tool_input.
-# Hook stdout: JSON {hookSpecificOutput: {permissionDecision, permissionDecisionReason}}.
+# Hook stdout: JSON {hookSpecificOutput: {hookEventName, permissionDecision, permissionDecisionReason}}.
 # Hook exit code: 0 always (JSON output controls the gate).
 
 set -euo pipefail
@@ -24,7 +24,7 @@ fi
 emit() { command -v emit_incident >/dev/null 2>&1 && emit_incident "$@" || true; }
 
 allow() {
-  echo '{"hookSpecificOutput":{"permissionDecision":"allow"}}'
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
   exit 0
 }
 
@@ -33,7 +33,7 @@ deny() {
   emit hr-all-infrastructure-provisioning-servers deny "iac-plan-write-guard: $reason"
   # jq -n -c keeps the JSON on a single line; --arg escapes safely.
   jq -nc --arg r "$reason" \
-    '{hookSpecificOutput: {permissionDecision: "deny", permissionDecisionReason: $r}}'
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $r}}'
   exit 0
 }
 

--- a/.claude/hooks/new-scheduled-cron-prefer-inngest.sh
+++ b/.claude/hooks/new-scheduled-cron-prefer-inngest.sh
@@ -22,7 +22,7 @@
 # exists, so commit-message overrides are structurally unreachable here.)
 #
 # Hook stdin: JSON payload from Claude Code with tool_name + tool_input.
-# Hook stdout: JSON {hookSpecificOutput: {permissionDecision, ...}}.
+# Hook stdout: JSON {hookSpecificOutput: {hookEventName, permissionDecision, ...}}.
 # Hook exit code: 0 always (JSON output controls the gate).
 
 set -euo pipefail
@@ -36,7 +36,7 @@ fi
 emit() { command -v emit_incident >/dev/null 2>&1 && emit_incident "$@" || true; }
 
 allow() {
-  echo '{"hookSpecificOutput":{"permissionDecision":"allow"}}'
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
   exit 0
 }
 
@@ -44,7 +44,7 @@ deny() {
   local reason="$1"
   emit adr-033-inngest-cron-canonical deny "new-scheduled-cron-prefer-inngest: $reason"
   jq -nc --arg r "$reason" \
-    '{hookSpecificOutput: {permissionDecision: "deny", permissionDecisionReason: $r}}'
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $r}}'
   exit 0
 }
 

--- a/.claude/hooks/no-memory-write.sh
+++ b/.claude/hooks/no-memory-write.sh
@@ -51,7 +51,7 @@ if [[ "$TARGET" =~ /\.claude/projects/[^/]+/memory(/|$|[\"\'[:space:]]) ]]; then
     "Memory writes do not transfer across machines/operators" "$TARGET"
   jq -n --arg target "$TARGET" '{
     hookSpecificOutput: {
-      permissionDecision: "deny",
+      hookEventName: "PreToolUse",      permissionDecision: "deny",
       permissionDecisionReason: ("BLOCKED: hr-never-write-to-claude-code-memory-claude (Source: AGENTS.core.md).\n\nTarget: " + $target + "\n\nWrites to ~/.claude/projects/*/memory/ do not transfer across machines or operators. Commit knowledge to one of these committed repo files instead:\n  - AGENTS.md / AGENTS.{core,docs,rest}.md (hard rules + workflow gates)\n  - knowledge-base/overview/constitution.md (architecture + style)\n  - knowledge-base/project/learnings/<category>/<slug>.md (session learnings)\n\nSee plugins/soleur/skills/compound for the canonical learning-write flow.")
     }
   }'

--- a/.claude/hooks/pencil-open-guard.sh
+++ b/.claude/hooks/pencil-open-guard.sh
@@ -41,7 +41,7 @@ REL_PATH=$(realpath --relative-to="$REPO_ROOT" "$FILE_PATH" 2>/dev/null || echo 
 # Check if file is tracked in git
 if ! git -C "$REPO_ROOT" ls-files --error-unmatch "$REL_PATH" &>/dev/null 2>&1; then
   emit_incident "cq-before-calling-mcp-pencil-open-document" "deny" "Pencil MCP open_document can clear untracked files" "$FILE_PATH"
-  jq -n '{hookSpecificOutput:{permissionDecision:"deny",permissionDecisionReason:"BLOCKED: .pen file is untracked in git. Pencil MCP open_document can silently clear file contents. Commit the file first (git add <file> && git commit) to enable recovery."}}'
+  jq -n '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:"BLOCKED: .pen file is untracked in git. Pencil MCP open_document can silently clear file contents. Commit the file first (git add <file> && git commit) to enable recovery."}}'
   exit 0
 fi
 

--- a/.claude/hooks/skill-security-scan-write.sh
+++ b/.claude/hooks/skill-security-scan-write.sh
@@ -13,7 +13,7 @@
 #   LOW-RISK                        → permissionDecision: allow (silent)
 #
 # Hook stdin: JSON payload from Claude Code with tool_name + tool_input.
-# Hook stdout: JSON {hookSpecificOutput: {permissionDecision, permissionDecisionReason}}.
+# Hook stdout: JSON {hookSpecificOutput: {hookEventName, permissionDecision, permissionDecisionReason}}.
 # Hook exit code: 0 always (the JSON output is what controls the gate).
 
 set -euo pipefail
@@ -37,7 +37,7 @@ content="$(echo "$payload" | jq -r '.tool_input.content // empty' 2>/dev/null)"
 
 # Only fire on Write to relevant paths.
 if [ "$tool_name" != "Write" ]; then
-  echo '{"hookSpecificOutput":{"permissionDecision":"allow"}}'
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
   exit 0
 fi
 
@@ -51,7 +51,7 @@ case "$file_path" in
   *.claude/skills/*SKILL.md|*plugins/soleur/skills/*SKILL.md|*.claude/agents/*.md|*plugins/soleur/agents/*.md)
     file_kind="skill" ;;
   *)
-    echo '{"hookSpecificOutput":{"permissionDecision":"allow"}}'
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
     exit 0
     ;;
 esac
@@ -74,12 +74,12 @@ path_to_slug() {
 # their creation in the same way they approve the underlying HIGH-RISK skill.
 if [ "$file_kind" = "override" ]; then
   emit skill-security-scan applied "override-artifact-write"
-  jq -cn '{hookSpecificOutput: {permissionDecision: "ask", permissionDecisionReason: "skill-security-scan: override artifact write requires explicit operator confirmation. Auto-approval is not permitted (agent-native parity gate)."}}'
+  jq -cn '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask", permissionDecisionReason: "skill-security-scan: override artifact write requires explicit operator confirmation. Auto-approval is not permitted (agent-native parity gate)."}}'
   exit 0
 fi
 
 if [ -z "$content" ]; then
-  echo '{"hookSpecificOutput":{"permissionDecision":"allow"}}'
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
   exit 0
 fi
 
@@ -88,7 +88,7 @@ if [ ! -f "$SCANNER" ]; then
   # silently-removed scanner must surface for operator approval rather than
   # silently disable enforcement. (Architecture review F4.)
   emit skill-security-scan applied "scanner-missing"
-  jq -cn '{hookSpecificOutput: {permissionDecision: "ask", permissionDecisionReason: "skill-security-scan: scanner not installed; cannot evaluate. Approve only if you have manually reviewed the content."}}'
+  jq -cn '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask", permissionDecisionReason: "skill-security-scan: scanner not installed; cannot evaluate. Approve only if you have manually reviewed the content."}}'
   exit 0
 fi
 
@@ -114,27 +114,27 @@ case "$verdict" in
     fi
     if [ "$override_ok" = "1" ]; then
       emit skill-security-scan applied "high-risk-with-override"
-      jq -cn --arg s "$slug" '{hookSpecificOutput: {permissionDecision: "allow", permissionDecisionReason: ("skill-security-scan: HIGH-RISK with valid override artifact for skill=" + $s + " (proceeding).")}}'
+      jq -cn --arg s "$slug" '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow", permissionDecisionReason: ("skill-security-scan: HIGH-RISK with valid override artifact for skill=" + $s + " (proceeding).")}}'
     else
       emit skill-security-scan applied "high-risk-no-override"
       reason="BLOCKED: skill-security-scan HIGH-RISK on $file_path (slug=$slug) without matching override artifact. Required: knowledge-base/security/skill-overrides/YYYY-MM-DD-${slug}.md with frontmatter skill: ${slug}. See plugins/soleur/skills/skill-security-scan/references/override-mechanism.md"
-      jq -cn --arg r "$reason" '{hookSpecificOutput: {permissionDecision: "deny", permissionDecisionReason: $r}}'
+      jq -cn --arg r "$reason" '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $r}}'
     fi
     ;;
   REVIEW)
     emit skill-security-scan applied "review"
-    jq -cn '{hookSpecificOutput: {permissionDecision: "ask", permissionDecisionReason: "skill-security-scan REVIEW finding(s); see scan output above."}}'
+    jq -cn '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask", permissionDecisionReason: "skill-security-scan REVIEW finding(s); see scan output above."}}'
     ;;
   LOW-RISK)
     emit skill-security-scan applied "low-risk"
-    echo '{"hookSpecificOutput":{"permissionDecision":"allow"}}'
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
     ;;
   *)
     # Unknown verdict → ask, not allow. At single-user incident threshold a
     # broken scanner must surface for operator review rather than silently
     # disable enforcement. (Architecture review F8.)
     emit skill-security-scan applied "unknown-verdict"
-    jq -cn '{hookSpecificOutput: {permissionDecision: "ask", permissionDecisionReason: "skill-security-scan returned UNKNOWN verdict; manual review required."}}'
+    jq -cn '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask", permissionDecisionReason: "skill-security-scan returned UNKNOWN verdict; manual review required."}}'
     ;;
 esac
 

--- a/.claude/hooks/worktree-write-guard.sh
+++ b/.claude/hooks/worktree-write-guard.sh
@@ -43,7 +43,7 @@ if [[ -d "$WORKTREE_DIR" ]] && [[ -n "$(ls -A "$WORKTREE_DIR" 2>/dev/null)" ]]; 
   emit_incident "guardrails-worktree-write-guard" "deny" "Never edit main when a worktree is active" "$FILE_PATH"
   jq -n --arg names "$WORKTREE_NAMES" --arg path "$GIT_ROOT/.worktrees/<name>/$RELATIVE_PATH" '{
     hookSpecificOutput: {
-      permissionDecision: "deny",
+      hookEventName: "PreToolUse",      permissionDecision: "deny",
       permissionDecisionReason: ("BLOCKED: Writing to main repo checkout while worktrees exist (" + $names + "). Write to the worktree path instead: " + $path)
     }
   }'


### PR DESCRIPTION
## Summary

**9 PreToolUse guard hooks have been silently non-enforcing.** They emit `{hookSpecificOutput:{permissionDecision:"deny",...}}` with exit 0 but omit the mandatory `hookEventName:"PreToolUse"` field. Per the Claude Code hook contract, without `hookEventName` the harness can't associate the output with the event, so the decision is **silently ignored and the tool call proceeds**.

Several are security gates:
- `git-commit-secret-scan` (gitleaks at commit time)
- `skill-security-scan-write`
- `guardrails` (6 rules: no-commit-to-main, no rm -rf worktree, no git stash, conflict-marker block, milestone-required, no --delete-branch-with-worktrees)
- `worktree-write-guard`, `iac-plan-write-guard`, `doppler-secrets-delete-redirect`, `new-scheduled-cron-prefer-inngest`, `pencil-open-guard`, `no-memory-write`

### How it was found

`no-memory-write.sh` failed to block a memory write despite being correctly wired in `settings.json`. The incidents log showed `event_type: deny` fired — but the `Write` succeeded. Confirmed against the official PreToolUse contract (`hookEventName` is required; omitting it = deny silently ignored).

## Changes

- Added `hookEventName: "PreToolUse"` to every `permissionDecision` output (deny/ask/allow) across the 9 hooks. The 3 already-correct hooks (`follow-through-directive-gate`, `pre-merge-rebase`, `prod-write-defer-gate`) were the pattern reference.
- Updated the 4 doc-comments that documented the incomplete JSON shape.
- **New `hookeventname-coverage.test.sh`** meta-test: fails if any hook emits a `permissionDecision` without a paired `hookEventName` — covers all current AND future hooks, so this bug class cannot recur. Proven to catch a reintroduced regression.

## Test plan

- [x] All 20 `.claude/hooks/*.test.sh` green (incl. the new meta-test)
- [x] `no-memory-write` deny now parses as valid JSON with `hookEventName=="PreToolUse"` + `permissionDecision=="deny"`
- [x] `bash -n` syntax check on all 9 hooks
- [x] Meta-test proven to fail when `hookEventName` is removed, pass when restored
- [x] CI discovers the new test (`scripts/test-all.sh` line 173 glob includes `.claude/hooks/*.test.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)