### PR TITLE
fix(test): changelog guard asserts APEX_RE removal at source (deterministic)

### DIFF
--- a/plugins/soleur/test/seo-aeo-drift-guard.test.ts
+++ b/plugins/soleur/test/seo-aeo-drift-guard.test.ts
@@ -441,16 +441,24 @@ describe("GSC coverage regression guard (www→apex host flip)", () => {
     ).toEqual([]);
   });
 
-  test("changelog page renders apex links and zero www-host links (APEX_RE rewriter removed)", () => {
+  test("changelog page canonical is apex + github.js APEX_RE rewriter removed", () => {
     const html = readSite("changelog/index.html");
-    // Positive anchor first so the negative assertion is never vacuous: the
-    // page's canonical <link> always renders the apex host regardless of
-    // whether the GitHub release fetch returned content (offline/non-CI), so
-    // this holds in every environment. Matched as an HTML-element regex (not a
-    // bare URL substring) to avoid the js/incomplete-url-substring-sanitization
-    // CodeQL pattern that fires on `.includes("https://…")` host checks.
+    // Canonical <link> renders the apex host (deterministic — derives from
+    // site.url). Matched as an HTML-element regex (not a bare URL substring) to
+    // avoid the js/incomplete-url-substring-sanitization CodeQL pattern that
+    // fires on `.includes("https://…")` host checks.
     expect(html).toMatch(/rel="canonical"[^>]*href="https:\/\/soleur\.ai\//);
-    expect(html.includes("www.soleur.ai")).toBe(false);
+    // AC15: the apex→www rewriter is gone from the data loader. Asserted at the
+    // SOURCE (deterministic) — NOT against rendered changelog text. The
+    // changelog is built from LIVE GitHub release bodies fetched at build time,
+    // and a release note can legitimately contain the literal "www.soleur.ai"
+    // (e.g. the release describing this very www→apex flip), so a rendered-text
+    // absence check is non-deterministic and produces false CI failures.
+    const githubJs = readFileSync(
+      resolve(REPO_ROOT, "plugins/soleur/docs/_data/github.js"),
+      "utf8",
+    );
+    expect(githubJs).not.toMatch(/APEX_RE|www\.soleur\.ai/);
   });
 
   test("legacy terms-of-service redirect stub resolves to terms-and-conditions", () => {


### PR DESCRIPTION
## Summary

Hotfix for a non-deterministic regression test introduced by #4573 that turned `main`'s CI red post-merge (the `test-bun` shard). **Production was never affected** — the docs deploy + web-platform release both succeeded and the apex-canonical SEO fix is live.

## Root cause

#4573's changelog regression guard asserted the rendered `/changelog/` page contains zero `www.soleur.ai`. But the changelog is built from **live GitHub release bodies fetched at build time**, and the Version Bump workflow created a release for #4573 whose body (the PR's own Changelog) literally contains "www.soleur.ai" describing the flip. So the assertion failed on main while the fix itself was correct. It passed in PR CI only because that build hit empty/rate-limited releases — a non-deterministic dependency on mutable external content.

## Fix

Assert AC15 ("APEX_RE apex→www rewriter removed") at the **source** — `github.js` contains no `APEX_RE` or `www.soleur.ai` — which is deterministic and directly guards the regression. The deterministic canonical-apex build assertion is retained.

## Changelog

- Fix `seo-aeo-drift-guard.test.ts` changelog guard to assert APEX_RE removal at the github.js source instead of against live-fetched rendered changelog content (eliminates the non-deterministic CI failure).

Ref #4573.

## Test plan

- [x] `bun test plugins/soleur/test/seo-aeo-drift-guard.test.ts` → 15/15 pass with a fresh build that fetches the live www-mentioning release

Generated with [Claude Code](https://claude.com/claude-code)
