### PR TITLE
fix(infra): widen soleur_www uptime fuse 3→5 so docs deploys stop false-paging

### DIFF
--- a/apps/web-platform/infra/sentry/uptime-monitors.tf
+++ b/apps/web-platform/infra/sentry/uptime-monitors.tf
@@ -89,7 +89,18 @@ resource "sentry_uptime_monitor" "soleur_www" {
   interval_seconds = 300
   timeout_ms       = 10000
 
-  downtime_threshold = 3
+  # 2026-05-29: longer fuse than the apex monitor (5 checks ≈ 25 min vs 3 ≈ 15).
+  # This monitor is the redirect-HEALTH guard, NOT the user-facing outage signal —
+  # soleur_apex (downtime_threshold=3, UNCHANGED) covers a real user-facing outage.
+  # A docs deploy rebuilds GitHub Pages and re-propagates the custom-domain
+  # apex-canonical redirect; during that window www transiently serves its own
+  # 200 instead of the 301, which empirically exceeds the apex monitor's 15-min
+  # fuse (PR #4573/#4578 deploy on 2026-05-29 paged soleur_www at 12:30 for a
+  # self-recovered ~15-min flap). The 25-min fuse absorbs the deploy window so
+  # self-inflicted rebuilds stop paging, at the cost of +10 min MTTD on a
+  # www-ONLY redirect regression — acceptable for that lower-severity failure
+  # mode, since a real user-facing outage still pages via soleur_apex at 15 min.
+  downtime_threshold = 5
   recovery_threshold = 1
 
   # Success = exactly 301 (www must redirect to apex). Sentry fires when this is

--- a/knowledge-base/project/learnings/best-practices/2026-05-29-uptime-monitor-fuse-must-tolerate-self-inflicted-deploy-windows.md
+++ b/knowledge-base/project/learnings/best-practices/2026-05-29-uptime-monitor-fuse-must-tolerate-self-inflicted-deploy-windows.md
@@ -1,0 +1,50 @@
+---
+date: 2026-05-29
+category: best-practices
+tags: [observability, sentry, uptime-monitor, alert-fatigue, terraform, deploy]
+component: apps/web-platform/infra/sentry/uptime-monitors.tf
+---
+
+# Uptime-monitor fuses must tolerate self-inflicted deploy windows
+
+## Problem
+
+`soleur_www` (a Sentry uptime monitor asserting `equals 301` — www must redirect
+to apex) paged "monitored domain is down" at 2026-05-29 12:30 CEST, ~12 min after
+#4578 tightened its assertion to `equals 301` and #4573/#4578 triggered a GitHub
+Pages rebuild. During the Pages rebuild + custom-domain redirect re-propagation,
+`https://www.soleur.ai/` transiently served its own `200` instead of the `301`.
+The monitor's `downtime_threshold = 3` (≈15 min) was shorter than the deploy
+window, so the project paged itself on its own deploy. It self-recovered.
+
+## Root cause
+
+Two independent changes stacked: (a) the assertion was newly **tightened** from a
+`2xx` check to an exact `equals 301`, and (b) the same deploy rebuilt the static
+host whose redirect the assertion guards. A freshly-strict assertion + a fuse
+shorter than the deploy's own propagation window = guaranteed false page.
+
+## Fix / principle
+
+- An uptime monitor that guards a **statically-hosted redirect/page** must have a
+  `downtime_threshold` longer than that host's deploy/propagation window, or it
+  pages on every deploy. Here: `soleur_www` 3 → 5 (≈25 min).
+- Tier the fuse by **severity, not uniformity**: `soleur_apex` (the user-facing
+  outage signal) stays at threshold 3 / 15 min; `soleur_www` (a redirect-HEALTH
+  guard whose failure is lower-severity) gets the longer fuse. Lengthening the
+  low-severity monitor does NOT weaken real-outage detection because a different
+  monitor carries the user-facing signal.
+- When you **tighten an assertion** (`2xx` → `equals N`), re-check the fuse in the
+  same change — a stricter success condition is more likely to trip during the
+  normal deploy window.
+- The precise alternative (no MTTD cost) is **deploy-window suppression**: pause
+  the monitor in the deploy workflow during the rebuild and resume after a
+  confirming probe. Higher plumbing cost (Sentry API in CI); filed as a follow-up.
+
+## Don't be fooled by the alert-email footer
+
+The Sentry "domain down" email carried "triggered by auth-callback-no-code-burst".
+That footer is a **documented red-herring** — a coincidental issue-alert routed to
+the same operator email, unrelated to the uptime monitor that actually fired. See
+`knowledge-base/project/learnings/bug-fixes/2026-05-27-sentry-cron-community-monitor-missed-checkin.md`.
+Identify the firing monitor from the alert *body* (URL + assertion), not the footer.

--- a/knowledge-base/project/plans/2026-05-29-fix-soleur-www-uptime-deploy-window-false-page-plan.md
+++ b/knowledge-base/project/plans/2026-05-29-fix-soleur-www-uptime-deploy-window-false-page-plan.md
@@ -1,0 +1,83 @@
+<!-- iac-routing-ack: plan-phase-2-8-reviewed -->
+<!--
+  Phase 2.8 reviewed: this change adds NO infrastructure resource and provisions
+  NO server. It mutates ONE attribute (downtime_threshold) on an EXISTING
+  Terraform-managed resource (sentry_uptime_monitor.soleur_www). The "operator
+  runs terraform apply" step is PRE-EXISTING architecture — uptime-monitors.tf is
+  operator-applied per its own file header (apply-sentry-infra.yml auto-applies
+  sentry_cron_monitor.* only). Extending auto-apply to uptime monitors is the
+  separately-tracked, intentionally-out-of-scope #4585. No SSH, no manual install,
+  no new .tf root. The apply path is surfaced explicitly in the PR body, not buried.
+-->
+---
+title: "Harden soleur_www uptime monitor against deploy-window false pages"
+date: 2026-05-29
+branch: feat-one-shot-soleur-www-uptime-threshold
+status: complete
+labels: [app:web-platform, semver:patch, domain/engineering]
+---
+
+# Harden `soleur_www` uptime monitor against deploy-window false pages
+
+## Overview
+
+The `soleur_www` Sentry uptime monitor (`apps/web-platform/infra/sentry/uptime-monitors.tf`)
+asserts `equals 301` — www must redirect to apex. Its `downtime_threshold` was `3`
+(3 × 5-min checks ≈ 15 min). A docs deploy (`deploy-docs.yml`) rebuilds GitHub
+Pages and re-propagates the custom-domain apex-canonical redirect; during that
+window `https://www.soleur.ai/` transiently serves its own `200` instead of the
+`301`. That window empirically exceeds 15 min, so the monitor false-pages on the
+project's **own** deploys.
+
+This change raises `soleur_www.downtime_threshold` to `5` (≈ 25 min) so the deploy
+window is absorbed. `soleur_apex` (threshold `3`) is **unchanged** and remains the
+user-facing-outage signal, so this does NOT weaken real-outage detection.
+
+## Incident that motivated this
+
+On 2026-05-29 ~12:30 CEST a Sentry uptime alert "monitored domain is down" fired
+for `https://www.soleur.ai/` (Status `200`, "Assertion failed"). Root cause: #4578
+(merged 12:18) flipped the `soleur_www` assertion to `equals 301`; #4573 (11:45) +
+#4578 triggered a GitHub Pages rebuild. During Pages rebuild/propagation, www
+served `200` for ≥3 consecutive checks, tripping the freshly-tightened assertion.
+It self-recovered (live probe: www → 301 → apex, apex → 200). The
+`auth-callback-no-code-burst` footer in the alert email is a documented red-herring
+(coincidental issue-alert on the same email), not the cause.
+
+## Decision: Option B (threshold) over Option A (deploy-window suppression)
+
+- **Option B (this PR):** raise `soleur_www.downtime_threshold` 3→5. Two-line change;
+  defensible because `soleur_apex` carries the user-facing signal at threshold 3.
+  Cost: +10 min MTTD on a www-ONLY redirect regression (lower severity).
+- **Option A (deferred follow-up):** pause the monitor in `deploy-docs.yml` during a
+  Pages rebuild. Zero MTTD cost, but more CI plumbing + Sentry API access. Filed as a
+  follow-up issue.
+
+## Scope
+
+- IN: `soleur_www.downtime_threshold` 3 → 5, with a justifying comment.
+- OUT: `soleur_apex`, `soleur_changelog_deep`, `soleur_acme_probe` thresholds (unchanged).
+- OUT: the #4584 drift-guard work (dns.tf / PR #4592, separate parallel session) —
+  different file, different concern; #4584 does NOT cover this runtime failure mode.
+
+## Apply path (no silent operator step)
+
+`uptime-monitors.tf` is **operator-applied**, not auto-applied (see file header):
+`apply-sentry-infra.yml` auto-applies `sentry_cron_monitor.*` only. So this change
+takes effect when the operator runs `terraform apply` in `apps/web-platform/infra/sentry/`,
+OR once **#4585** (extend auto-apply to `sentry_uptime_monitor.*`) lands. This is
+stated explicitly in the PR body — not buried — per `hr-never-label-any-step-as-manual-without`.
+
+## Acceptance criteria
+
+- [x] `soleur_www.downtime_threshold == 5`; justifying comment present.
+- [x] Other three monitors' thresholds unchanged.
+- [x] `terraform fmt -check` clean; `terraform validate` Success in the sentry root.
+- [x] Change is an in-place attribute mutation (no resource replacement/destroy).
+- [x] PR body front-loads incident evidence + the apply-path note + #4585 reference.
+- [ ] Follow-up issue filed for Option A (deploy-window suppression).
+
+## Test scenarios
+
+None (browser/API QA N/A — this is a Terraform monitor-config attribute change;
+validation is `terraform fmt`/`validate`, already run).

--- a/knowledge-base/project/plans/2026-05-29-fix-soleur-www-uptime-deploy-window-false-page-plan.md
+++ b/knowledge-base/project/plans/2026-05-29-fix-soleur-www-uptime-deploy-window-false-page-plan.md
@@ -75,7 +75,7 @@ stated explicitly in the PR body — not buried — per `hr-never-label-any-step
 - [x] `terraform fmt -check` clean; `terraform validate` Success in the sentry root.
 - [x] Change is an in-place attribute mutation (no resource replacement/destroy).
 - [x] PR body front-loads incident evidence + the apply-path note + #4585 reference.
-- [ ] Follow-up issue filed for Option A (deploy-window suppression).
+- [x] Follow-up issue filed for Option A (deploy-window suppression) — #4596.
 
 ## Test scenarios
 

--- a/knowledge-base/project/specs/feat-one-shot-soleur-www-uptime-threshold/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-soleur-www-uptime-threshold/session-state.md
@@ -1,0 +1,25 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-05-29-fix-soleur-www-uptime-deploy-window-false-page-plan.md
+- Status: complete (pipeline compressed — see Decisions)
+
+### Errors
+None.
+
+### Decisions
+- One-shot pipeline run **compressed** for proportionality: the change is a fully-specified
+  2-line Terraform attribute mutation. Skipped deepen-plan parallel-research fan-out,
+  multi-agent soleur:review, and browser QA (no value for a monitor-threshold config change);
+  validation is `terraform fmt`/`validate`, both run and passing. API-budget judgment per the
+  one-shot decision-gate off-ramp.
+- Chose **Option B** (raise `soleur_www.downtime_threshold` 3→5) over Option A (deploy-window
+  suppression in deploy-docs.yml). B is defensible because `soleur_apex` (threshold 3) carries
+  the user-facing-outage signal; B costs only +10min MTTD on a www-only redirect regression.
+- Stayed strictly clear of the parallel #4584 / PR #4592 session (dns.tf drift-guard) — different
+  file, different concern.
+- Apply path surfaced explicitly: `uptime-monitors.tf` is operator-applied (or auto-applies once
+  #4585 lands); stated in PR body, not buried.
+
+### Components Invoked
+- soleur:one-shot (compressed); terraform fmt/validate; direct Edit/Write.

--- a/knowledge-base/project/specs/feat-one-shot-soleur-www-uptime-threshold/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-soleur-www-uptime-threshold/tasks.md
@@ -1,0 +1,32 @@
+<!-- iac-routing-ack: plan-phase-2-8-reviewed -->
+<!--
+  Phase 2.8 reviewed in the linked plan: single-attribute mutation on an existing
+  Terraform-managed resource; the operator-apply step is pre-existing architecture
+  tracked by #4585. No new resource, no server, no SSH.
+-->
+---
+title: "Tasks — harden soleur_www uptime monitor against deploy-window false pages"
+plan: "../../plans/2026-05-29-fix-soleur-www-uptime-deploy-window-false-page-plan.md"
+branch: feat-one-shot-soleur-www-uptime-threshold
+lane: engineering
+---
+
+# Tasks — soleur_www deploy-window false-page hardening
+
+## Phase 1 — Implement
+- [x] 1.1 Raise `sentry_uptime_monitor.soleur_www.downtime_threshold` 3 → 5 in `apps/web-platform/infra/sentry/uptime-monitors.tf`, with a justifying comment (redirect-health guard, apex carries user-facing signal, deploy-window rationale, +10min MTTD trade-off).
+- [x] 1.2 Confirm `soleur_apex`, `soleur_changelog_deep`, `soleur_acme_probe` thresholds UNCHANGED.
+
+## Phase 2 — Validate
+- [x] 2.1 `terraform fmt -check` clean in the sentry root.
+- [x] 2.2 `terraform validate` Success (pre-existing issue-alert deprecation warnings only).
+- [x] 2.3 Confirm in-place attribute mutation (no resource replacement).
+
+## Phase 3 — Ship
+- [x] 3.1 PR body front-loads incident evidence + apply-path note (#4585) + Option A follow-up.
+- [ ] 3.2 File follow-up issue for Option A (deploy-window suppression in deploy-docs.yml).
+- [ ] 3.3 Merge; CI green.
+
+## Acceptance gates
+- [x] Diff touches only `uptime-monitors.tf` (+ KB artifacts).
+- [x] Apply path explicit (operator `terraform apply` in sentry root OR #4585), not buried.

--- a/knowledge-base/project/specs/feat-one-shot-soleur-www-uptime-threshold/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-soleur-www-uptime-threshold/tasks.md
@@ -24,7 +24,7 @@ lane: engineering
 
 ## Phase 3 — Ship
 - [x] 3.1 PR body front-loads incident evidence + apply-path note (#4585) + Option A follow-up.
-- [ ] 3.2 File follow-up issue for Option A (deploy-window suppression in deploy-docs.yml).
+- [x] 3.2 File follow-up issue for Option A (deploy-window suppression in deploy-docs.yml) — #4596.
 - [ ] 3.3 Merge; CI green.
 
 ## Acceptance gates


### PR DESCRIPTION
## Incident (front-loaded)

On **2026-05-29 ~12:30 CEST** a Sentry uptime alert *"monitored domain is down"* fired for `https://www.soleur.ai/` — **Status 200, "Assertion failed"**. Live probe taken during triage shows it **already self-recovered**:

```
GET https://www.soleur.ai/  → HTTP 301 → https://soleur.ai/   ✅ (served via Fastly/GitHub Pages)
GET https://soleur.ai/      → HTTP 200                          ✅
```

**Root cause:** the `soleur_www` uptime monitor asserts `equals 301` (www must redirect to apex). #4578 (merged 12:18) flipped that assertion from `2xx` → `equals 301`, and #4573 (11:45) + #4578 triggered a GitHub Pages rebuild. During the Pages rebuild + custom-domain redirect re-propagation, www transiently served its own `200` instead of the `301` for ≥3 consecutive 5-min checks (`downtime_threshold = 3` ≈ 15 min) — i.e. the project paged itself on its own deploy.

> The `auth-callback-no-code-burst` line in the alert email is a **documented red-herring** (a coincidental issue-alert routed to the same operator email), **not** the cause. The firing monitor is identified from the alert body (URL + assertion), not the footer.

## Change

Raise `sentry_uptime_monitor.soleur_www.downtime_threshold` **3 → 5** (≈25 min) in `apps/web-platform/infra/sentry/uptime-monitors.tf`, with a justifying comment. The 25-min fuse absorbs the deploy window.

- `soleur_apex` (threshold **3**, UNCHANGED) remains the **user-facing-outage** signal → real-outage detection is **not** weakened.
- `soleur_changelog_deep`, `soleur_acme_probe` UNCHANGED.
- Cost: **+10 min MTTD** on a *www-only* redirect regression — acceptable for that lower-severity failure mode.

### Why Option B (threshold) not Option A (suppression)
Option A (pause the monitor during the Pages rebuild in `deploy-docs.yml`) has zero MTTD cost but needs CI Sentry-API plumbing. Filed as follow-up **#4596** (which, once done, supersedes this and could ratchet the threshold back to 3).

## ⚠️ Apply path (not auto-applied)

`uptime-monitors.tf` is **operator-applied** — `apply-sentry-infra.yml` auto-applies `sentry_cron_monitor.*` only. This change takes effect when:

- an operator runs `terraform apply` in `apps/web-platform/infra/sentry/`, **OR**
- **#4585** (extend auto-apply to `sentry_uptime_monitor.*`) lands.

Until then the monitor keeps the old threshold=3 and may re-page on the next docs deploy. This is surfaced here (not buried) per `hr-never-label-any-step-as-manual-without`.

## Verification
- `terraform fmt -check` clean; `terraform validate` **Success** in the sentry root (pre-existing `sentry_issue_alert` deprecation warnings only).
- In-place attribute mutation — no resource replacement/destroy.
- No test/script hard-codes the www threshold (grep clean).

## Not in scope
Independent of the **#4584 / PR #4592** drift-guard work (dns.tf, separate parallel session) — different file, different concern. #4584 does NOT cover this runtime failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)