### PR TITLE
feat(flag-tooling): per-feature segment org scoping (#4581 PR-2)

### DIFF
--- a/knowledge-base/engineering/architecture/decisions/ADR-043-flagsmith-per-org-targeting.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-043-flagsmith-per-org-targeting.md
@@ -1,9 +1,16 @@
 # ADR-043: Flagsmith Per-Org Targeting via Identity Trait
 
-**Status:** accepted
+**Status:** superseded-in-part (see "Per-feature segment scoping (2026-05-29)" below)
 **Date:** 2026-05-25
 **Deciders:** Jean Deruelle (CTO), Claude (engineering)
-**Related:** ADR-038 (feature-flag architecture), umbrella #4456 PR-2
+**Related:** ADR-038 (feature-flag architecture), umbrella #4456 PR-2, #4581 PR-2 (per-feature segment scoping)
+
+> **Supersession note (2026-05-29):** The "Segment Design" section below — a
+> *single* shared `org-targeted` segment gating *all* per-org features — is
+> superseded by the per-feature-segment model documented at the end of this ADR
+> (#4581 PR-2). The Identity Strategy and Cache Key Widening sections remain in
+> force. The shared `org-targeted` segment is retained until `team-workspace-invite`
+> is migrated off it (follow-up); new per-org features use `<flag>-orgs`.
 
 ## Context
 
@@ -51,3 +58,55 @@ Replace the `Map<Role, ...>` (max 2 entries) with an LRU cache keyed on `${role}
 - **Cache bounded:** LRU(1000) prevents unbounded memory growth from org diversity
 - **WORM audit trail:** Every flag flip (via skill) appends to `flag_flip_audit` table (migration 071)
 - **Async propagation:** `isTeamWorkspaceInviteEnabled` and `isByokDelegationsEnabled` become async; all consumers must await
+
+## Per-feature segment scoping (2026-05-29)
+
+**Supersedes:** the "Segment Design" section (single shared `org-targeted` segment).
+**Context:** #4581 PR-2 — enabling a legally-sensitive flag (`byok-delegations`) for
+**one** org (#4232) without exposing it to the *other* org that happens to share the
+`org-targeted` segment. The original "one segment for all per-org features" design
+made per-(feature, org) granularity impossible: any feature attached to `org-targeted`
+is enabled for **every** org in its membership. `byok-delegations` and
+`team-workspace-invite` cannot have different org sets under one shared segment.
+
+**Decision:** Each org-targetable feature `<flag>` gets its **own** project-level
+segment `<flag>-orgs`. The feature has an ON feature-state override on its own segment
+in both envs; the segment's membership (one `EQUAL orgId <uuid>` condition per org,
+inside the `ANY` rule — same rule envelope as `org-targeted`, **not** an `IN` clause)
+is the per-org gate **for that feature only**. Adding/removing an org for a feature =
+mutating `<flag>-orgs` conditions, via `soleur:flag-set-role <flag> <env> <on|off>
+--org <orgId>`. Provisioning (`provision_feature_segment <flag>`) is idempotent:
+segment-create-if-absent + override-ON-in-both-envs.
+
+### Why this does not reintroduce the rejected "N per-org segments" explosion
+
+The original ADR rejected "one segment per org" because membership management is
+**O(orgs)** — the customer axis is unbounded, so segment count grows with every
+customer. The per-feature model is **O(features)**: one segment per *org-targetable
+feature*, a small, slow-growing, product-controlled axis (today: 2). Org churn changes
+*conditions inside* an existing segment, never the segment *count*. The explosion the
+ADR feared lives on the org axis; this design keeps the segment count on the feature
+axis, which is exactly where it is bounded.
+
+### Fallback-fidelity property (unchanged invariant, re-stated for per-feature segments)
+
+Per-org segment overrides are **invisible to the Doppler `FLAG_*` env-var mirror**
+(the mirror reflects the prd *role-segment* override state, not segment rule
+definitions — ADR-038 v2 §"Fallback semantics"). Consequence: on a Flagsmith outage,
+a flag whose *only* enablement is a per-org `<flag>-orgs` override **falls back OFF**
+(env-var = 0). For `byok-delegations` this is the **safe** direction and a verified
+precondition: `FLAG_BYOK_DELEGATIONS` is `0` in prd Doppler (verified 2026-05-29), and
+no prd role-segment override pins it ON. A per-org BYOK grant therefore degrades closed
+(feature disabled) rather than open (feature enabled for a non-opted-in org) when
+Flagsmith is unreachable — consistent with the legitimate-interest assessment for the
+flag-flip audit and the single-user-incident brand-survival threshold.
+
+### Re-verification is at the evaluation layer, not segment membership
+
+A correct membership set is **not** sufficient proof a flag is enabled: a missing
+feature-state override, or an override present in only one env, leaves the flag OFF
+while the org is "in" the segment. The skill therefore re-verifies by **evaluating the
+flag** for a transient identity carrying the `orgId` trait (the production
+`getIdentityFlags("org:<orgId>:<role>", {role, orgId}, transient=true)` path), asserting
+`enabled=true` for the target org **and** `enabled=false` for a control org — an
+absolute invariant, not a check against the script's own computed membership.

--- a/knowledge-base/project/learnings/best-practices/2026-05-29-http-verification-gates-must-check-status-not-just-transport.md
+++ b/knowledge-base/project/learnings/best-practices/2026-05-29-http-verification-gates-must-check-status-not-just-transport.md
@@ -1,0 +1,62 @@
+---
+title: HTTP verification gates must check status, not just transport (curl -sS fails open on 4xx/5xx)
+date: 2026-05-29
+category: shell-scripting
+tags: [verification-gate, fail-open, curl, http-status, flagsmith, eval-verify, single-user-incident, review-finding]
+symptoms: [A verification step passes (exit 0) during an upstream API error, A control-negative / leak assertion reads an error body as the safe state, "✓ verified" printed while the real state was never observed]
+module: flag-tooling (plugins/soleur/skills/flag-set-role)
+problem_type: silent_failure
+resolution_type: code_fix
+root_cause: missing_validation
+---
+
+## What happened
+
+PR-2 of #4581 added an **evaluation-layer re-verify** to `flip.sh --org`: after writing
+per-org segment membership it evaluates the flag for a transient identity (the production
+`getIdentityFlags` path, `POST edge.api.flagsmith.com/api/v1/identities/`) and asserts the
+target org is enabled AND a **control org is NOT enabled** (the load-bearing "no leak to a
+second org" gate, at a `single-user incident` brand-survival threshold).
+
+The first implementation called `curl -sS` (no `-f`, no status inspection) and parsed the
+JSON with a fall-through: "flag absent from `flags[]` → print `false` (disabled)". Two
+multi-agent reviewers (user-impact-reviewer + code-reviewer) independently flagged that this
+**fails open**: `curl -sS` exits `0` on a 4xx/5xx, the error body has no `flags[]`, so the
+parser returns `false` — and `false` is exactly the value the control-negative assertion
+(`[[ "$GOT_CONTROL" != "false" ]]`) and the `off`-case target assertion treat as **pass**.
+An operator running the enable during an edge-API blip would get a green `✓ eval-verified`
+having observed nothing. The unit tests all used well-formed `200` bodies, so the suite
+never exercised the error path — the fail-open was invisible.
+
+## The rule
+
+**A verification/gate that reads an external HTTP response must require a success status
+before interpreting the body, and must treat any non-2xx (or transport error) as
+UNVERIFIED → fail loud, never as the safe/negative outcome.** Concretely for shell+curl:
+
+- `resp=$(curl -sS -w '\n%{http_code}' …)`; split the trailing code; `[[ "$code" =~ ^2[0-9][0-9]$ ]] || return <err>`.
+- Only after a 2xx may "field absent → negative" be treated as authoritative.
+- Add a test that returns a 5xx / `{}` and asserts the gate exits non-zero. A gate whose
+  tests only feed healthy bodies is not testing the gate's failure semantics.
+
+`curl -sS` silences progress, NOT HTTP errors; `curl -f` turns 4xx/5xx into a non-zero exit
+but discards the body. When you need both the body and a hard failure, capture
+`%{http_code}` explicitly.
+
+## Secondary finding (same review): isolate what the gate measures
+
+The eval identity originally carried `role=prd|dev`, which also matches the `role-prd`/
+`role-dev` segments — so a flag with a role-segment override would evaluate enabled for
+*every* identity and the control-negative would fire spuriously. Fix: use a sentinel role
+trait (`__flag-verify__`) that matches no role segment, so the per-org assertion measures
+the **per-org segment gate** specifically, decoupled from any role rollout. General lesson:
+a verification identity/fixture should activate exactly the gate under test and nothing else.
+
+## Why it matters
+
+The fail-open turned the single automated barrier between an operator command and a
+legally-sensitive `byok-delegations` flag reaching a non-opted-in org into a no-op under
+the exact condition (upstream flakiness) where you most need it. Caught pre-merge by
+adversarial multi-agent review; the cheap permanent guard is the HTTP-error test, not the
+reviewers. See [[2026-05-29-feat-flag-org-scoping-plan]] (FR8), ADR-043 §"Per-feature
+segment scoping".

--- a/plugins/soleur/skills/flag-create/SKILL.md
+++ b/plugins/soleur/skills/flag-create/SKILL.md
@@ -26,7 +26,15 @@ adding a flag that the app needs to read.
 
 Required positional: `<kebab-flag-name>`.
 Optional: `--description "<text>"`, `--dev-on` (default off), `--prd-on`
-(default off), `--dry-run`.
+(default off), `--dry-run`, `--flagsmith-only`.
+
+`--flagsmith-only` creates **only** the Flagsmith feature for a flag that is
+**already code-wired** (already in `RUNTIME_FLAGS` + `.env.example` + Doppler).
+It skips the server.ts / `.env.example` / Doppler mutations **and** the "already
+appears in server.ts" exit-1 precheck (which would otherwise fire precisely
+because the flag is already wired). Use it to back-fill the Flagsmith feature for
+a flag that shipped its code wiring in an earlier PR, before scoping it per-org
+with `soleur:flag-set-role <flag> <env> on --org <orgId>`.
 
 ## Prerequisites
 

--- a/plugins/soleur/skills/flag-create/scripts/create.sh
+++ b/plugins/soleur/skills/flag-create/scripts/create.sh
@@ -20,34 +20,43 @@ readonly ENV_EXAMPLE="apps/web-platform/.env.example"
 DRY_RUN=0
 DEV_ON=0
 PRD_ON=0
+FLAGSMITH_ONLY=0
 DESCRIPTION=""
 NAME=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --dry-run)     DRY_RUN=1; shift ;;
-    --dev-on)      DEV_ON=1; shift ;;
-    --prd-on)      PRD_ON=1; shift ;;
-    --description) DESCRIPTION="$2"; shift 2 ;;
-    --*)           echo "unknown flag: $1" >&2; exit 1 ;;
-    *)             NAME="$1"; shift ;;
+    --dry-run)        DRY_RUN=1; shift ;;
+    --dev-on)         DEV_ON=1; shift ;;
+    --prd-on)         PRD_ON=1; shift ;;
+    --flagsmith-only) FLAGSMITH_ONLY=1; shift ;;
+    --description)    DESCRIPTION="$2"; shift 2 ;;
+    --*)              echo "unknown flag: $1" >&2; exit 1 ;;
+    *)                NAME="$1"; shift ;;
   esac
 done
 
 [[ -z "$NAME" ]] && { echo "Usage: create.sh <kebab-name> [--description ...] [--dev-on] [--prd-on] [--dry-run]" >&2; exit 1; }
 [[ ! "$NAME" =~ ^[a-z][a-z0-9-]*[a-z0-9]$ ]] && { echo "name must be lowercase kebab-case (got: $NAME)" >&2; exit 1; }
 
-[[ ! -f "$SERVER_TS" ]] && { echo "missing $SERVER_TS (run from repo root)" >&2; exit 2; }
-[[ ! -f "$ENV_EXAMPLE" ]] && { echo "missing $ENV_EXAMPLE" >&2; exit 2; }
-
 ENV_VAR="FLAG_$(echo "$NAME" | tr 'a-z-' 'A-Z_')"
 
-# Pre-check: flag name not already registered.
-if grep -qE "[\"']${NAME}[\"']" "$SERVER_TS"; then
-  echo "'$NAME' already appears in $SERVER_TS" >&2; exit 1
-fi
-if grep -qE "^${ENV_VAR}=" "$ENV_EXAMPLE"; then
-  echo "$ENV_VAR already in $ENV_EXAMPLE" >&2; exit 1
+# --flagsmith-only (gap 1, #4581 PR-2): the flag is ALREADY code-wired (in
+# RUNTIME_FLAGS + .env.example) — this run only creates the Flagsmith feature.
+# Skip the file-existence checks AND the "already appears in server.ts" exit-1
+# precheck (which would fire precisely because the flag IS already wired), plus
+# the server.ts/.env.example edits and the Doppler mirror further down.
+if [[ $FLAGSMITH_ONLY -eq 0 ]]; then
+  [[ ! -f "$SERVER_TS" ]] && { echo "missing $SERVER_TS (run from repo root)" >&2; exit 2; }
+  [[ ! -f "$ENV_EXAMPLE" ]] && { echo "missing $ENV_EXAMPLE" >&2; exit 2; }
+
+  # Pre-check: flag name not already registered.
+  if grep -qE "[\"']${NAME}[\"']" "$SERVER_TS"; then
+    echo "'$NAME' already appears in $SERVER_TS" >&2; exit 1
+  fi
+  if grep -qE "^${ENV_VAR}=" "$ENV_EXAMPLE"; then
+    echo "$ENV_VAR already in $ENV_EXAMPLE" >&2; exit 1
+  fi
 fi
 
 TOKEN=$(doppler secrets get FLAGSMITH_MANAGEMENT_API_KEY -p soleur -c cli_ops --plain 2>/dev/null || true)
@@ -69,9 +78,13 @@ echo "→ Proposed mutations:"
 echo "  1. Flagsmith: create feature '$NAME' (default_enabled=false)"
 [[ $DEV_ON -eq 1 ]] && echo "     + segment override role-dev=ON in BOTH envs"
 [[ $PRD_ON -eq 1 ]] && echo "     + segment override role-prd=ON in BOTH envs"
-echo "  2. $SERVER_TS: add \"$NAME\": \"$ENV_VAR\" to RUNTIME_FLAGS"
-echo "  3. $ENV_EXAMPLE: add $ENV_VAR=$PRD_DOPPLER_VAL"
-echo "  4. Doppler: $ENV_VAR=$PRD_DOPPLER_VAL in soleur/dev AND soleur/prd"
+if [[ $FLAGSMITH_ONLY -eq 1 ]]; then
+  echo "  (--flagsmith-only: skipping server.ts / $ENV_EXAMPLE / Doppler — flag is already code-wired)"
+else
+  echo "  2. $SERVER_TS: add \"$NAME\": \"$ENV_VAR\" to RUNTIME_FLAGS"
+  echo "  3. $ENV_EXAMPLE: add $ENV_VAR=$PRD_DOPPLER_VAL"
+  echo "  4. Doppler: $ENV_VAR=$PRD_DOPPLER_VAL in soleur/dev AND soleur/prd"
+fi
 
 if [[ $DRY_RUN -eq 1 ]]; then
   echo "(dry-run — exiting 0)"
@@ -132,6 +145,15 @@ if [[ $PRD_ON -eq 1 ]]; then
   SEG=$(resolve_segment "role-prd")
   echo "→ Applying role-prd=ON in dev env…"; apply_override "$FLAGSMITH_ENV_DEV_ID" "$SEG"
   echo "→ Applying role-prd=ON in prd env…"; apply_override "$FLAGSMITH_ENV_PRD_ID" "$SEG"
+fi
+
+# --- code-wiring + Doppler mirror (skipped under --flagsmith-only) ----------
+if [[ $FLAGSMITH_ONLY -eq 1 ]]; then
+  echo
+  echo "✓ Done (--flagsmith-only). Flagsmith feature '$NAME' created; server.ts /"
+  echo "  $ENV_EXAMPLE / Doppler left untouched (flag is already code-wired)."
+  echo "  Next: scope it per-org with soleur:flag-set-role $NAME prd on --org <orgId>."
+  exit 0
 fi
 
 # --- edit server.ts ---------------------------------------------------------

--- a/plugins/soleur/skills/flag-set-role/SKILL.md
+++ b/plugins/soleur/skills/flag-set-role/SKILL.md
@@ -5,7 +5,9 @@ description: "This skill should be used to flip a flag's per-role or per-org sta
 
 # flag-set-role
 
-Flips one role-segment's enablement on a runtime feature flag in Flagsmith, or manages per-org segment membership. The skill is the **only** approved path for mutating Flagsmith segment overrides and org-targeted segment rules — direct UI/curl edits break the fallback-fidelity contract documented in ADR-038 v2 §"Fallback semantics".
+Flips one role-segment's enablement on a runtime feature flag in Flagsmith, or manages per-org segment membership. The skill is the **only** approved path for mutating Flagsmith segment overrides and per-feature org-segment rules — direct UI/curl edits break the fallback-fidelity contract documented in ADR-038 v2 §"Fallback semantics".
+
+Per-org targeting uses a **per-feature segment** `<flag>-orgs` (ADR-043 §"Per-feature segment scoping", 2026-05-29) — each org-targetable flag gets its own segment, so the org set for one flag is independent of another's. (The legacy shared `org-targeted` segment is retained until `team-workspace-invite` is migrated off it; new per-org scoping uses `<flag>-orgs`.)
 
 ## When to use
 
@@ -25,11 +27,12 @@ Flips one role-segment's enablement on a runtime feature flag in Flagsmith, or m
 <arguments> #$ARGUMENTS </arguments>
 
 Required positional args: `<flag-name> <role> <on|off>`.
-- `<flag-name>`: must be a key in `apps/web-platform/lib/feature-flags/server.ts` `RUNTIME_FLAGS` (currently `kb-chat-sidebar`).
+- `<flag-name>`: must be a key in `apps/web-platform/lib/feature-flags/server.ts` `RUNTIME_FLAGS` (and in the script's `FLAG_ENV_VARS` map).
 - `<role>`: `prd` or `dev`.
 - `<on|off>`: target enablement.
 
-Flag `--org <orgId>` switches to per-org targeting mode. When provided, the script modifies the `org-targeted` segment's rule definition (adds/removes an `EQUAL orgId <uuid>` condition in the `ANY` rule) instead of flipping a role-segment override. The orgId must be a valid UUID.
+Flag `--org <orgId>` switches to per-org targeting mode. When provided, the script provisions the feature's own `<flag>-orgs` segment (creates it + ensures an ON feature-state override in both envs) and adds/removes an `EQUAL orgId <uuid>` condition in its `ANY` rule, instead of flipping a role-segment override. The orgId must be a valid UUID.
+Flag `--control-org <orgId>` (per-org mode only) sets the control org for the eval-layer re-verify (the org asserted to be NOT enabled — proves no leak). Defaults to a synthetic non-member UUID; pass a real sibling org (e.g. one sharing the legacy `org-targeted` segment) for a stronger leak check.
 Flag `--dry-run` runs detect/diff/validate steps (no writes).
 Flag `--confirmed` skips the interactive `read -p` prompt (for agent-driven use; the agent must obtain operator ack via AskUserQuestion before passing this flag).
 
@@ -75,17 +78,16 @@ The script (full procedure in [scripts/flip.sh](./scripts/flip.sh)):
 
 **Org targeting (when `--org <orgId>` is provided):**
 
-1. **Validate args.** Same as role targeting, plus UUID format validation on the orgId.
-2. **Resolve segment.** Look up `org-targeted` segment by name via `resolve_segment_id`.
-3. **Read segment rules.** GET the full segment definition, extract all orgIds from the `rules[0].rules[0].conditions[]` array (each condition is `EQUAL orgId <uuid>` inside an `ANY` rule).
-4. **Compute new list.** Check presence. If adding and already present, exit 0 ("already present"). If removing and not present, exit 0 ("not present"). Handle empty segment (first org added).
-5. **Dry-run display.** Print current membership (one orgId per line), proposed action, and new membership list.
-6. **Operator ack.** Same as role targeting.
-7. **Audit trail.** WORM audit entry with `target: org:<orgId>` (audit-before-write ordering).
-8. **Write segment.** PUT the full segment body back with the conditions array rebuilt (one `EQUAL` condition per org).
-9. **Re-verify.** Re-read segment, confirm orgId present/absent as expected.
+1. **Validate args.** Same as role targeting, plus UUID format validation on `--org` and `--control-org` (and they must differ).
+2. **Read current membership.** Resolve the feature's own `<flag>-orgs` segment (may not exist yet → empty membership) and extract its orgIds from the `rules[0].rules[0].conditions[]` array (each condition is `EQUAL orgId <uuid>` inside an `ANY` rule).
+3. **Compute new membership + display.** Add (on) or remove (off) the target org. Print current membership, proposed action, control org, and the new membership. No "already present" early-exit — the override may still be missing, so provisioning + eval-verify always run.
+4. **Dry-run / operator ack.** `--dry-run` prints the plan and exits 0 with no writes. Otherwise wait for `yes` (or `--confirmed`).
+5. **Audit trail.** WORM audit entry with `target: org:<orgId>` BEFORE any Flagsmith mutation (append-before-flip).
+6. **Provision `<flag>-orgs`.** Idempotently create the segment (ALL→ANY/EQUAL-orgId envelope) and ensure an ON feature-state override for the flag in BOTH envs (`provision_feature_segment`).
+7. **Write membership.** Re-read the segment immediately before the PUT (shrinks the read-modify-write window), then PUT the conditions array rebuilt from the fresh read (one `EQUAL` condition per org).
+8. **Eval-layer re-verify (the load-bearing check).** Evaluate the flag for a transient identity carrying the `orgId` trait (the production `getIdentityFlags("org:<orgId>:<role>", {role, orgId}, transient)` path, against `edge.api.flagsmith.com`): assert the **target** org resolves `enabled == (on)` AND the **control** org resolves `enabled == false`. Membership-set equality alone is NOT sufficient — a missing override, or an override present in only one env, leaves the flag OFF while the org is "in" the segment. Eval propagation is polled (eventual, completes within seconds).
 
-No Doppler mirror runs for org-targeting (segment membership is not reflected in env vars per ADR-038). No fallback-fidelity check applies (org-targeting modifies segment rule definitions, not per-env overrides).
+No Doppler mirror runs for org-targeting (segment membership is not reflected in env vars per ADR-038/ADR-043 — a per-org-only flag falls back **OFF** on a Flagsmith outage). No fallback-fidelity check applies (org-targeting modifies segment rule definitions, not per-env role overrides).
 
 ## Exit codes
 
@@ -100,14 +102,15 @@ No Doppler mirror runs for org-targeting (segment membership is not reflected in
 - The cache TTL in `apps/web-platform/lib/feature-flags/server.ts` is 30s per role. After a flip, the new state propagates per replica within 30s. Skill prints this hint after a successful flip.
 - The `dev off` rejection (Step 4) catches the case where prd is currently on AND you want to remove the dev cohort's preview. The correct sequence is: flip `prd off` first (which auto-flips both segments off via env-var mirror semantics, sort of), then leave dev where you want it. The plan's `dev off / prd on` case is intentionally unreachable.
 - Doppler mirror writes (Step 8) happen sequentially: dev first, then prd. If dev write fails, prd is not attempted (avoids cross-config divergence). Exit code 4.
-- The `org-targeted` segment is project-level in Flagsmith, not environment-level. A rule change affects all environments (dev + prd). This is by design (ADR-043: "Single-control — Flagsmith segment rule is the sole per-org gate").
-- No Doppler mirror runs for `--org` operations — org segment membership is not reflected in env vars.
-- The segment uses `EQUAL` conditions (one per org) inside an `ANY` rule, not a single `IN` condition. Matching is case-sensitive.
-- `resolve_segment_id` uses `GET /segments/` without pagination. Safe with 3 segments; may need pagination if segment count exceeds 10.
+- The `<flag>-orgs` segment is project-level in Flagsmith, not environment-level. A membership (conditions) change affects all environments; the ON feature-state override is applied per-env to both. This is by design (ADR-043: the segment rule is the per-org gate, the override makes the flag ON for matched orgs).
+- No Doppler mirror runs for `--org` operations — per-org segment membership is not reflected in env vars, so a per-org-only flag falls back **OFF** on a Flagsmith outage (env-var = 0). Verify `FLAG_<X>` is `0` in prd Doppler before relying on this for a legally-sensitive flag.
+- The segment uses `EQUAL` conditions (one per org) inside an `ANY` rule, not a single `IN` condition. Matching is case-sensitive. An empty `<flag>-orgs` (last org removed) matches nobody → the flag is OFF for all via that segment.
+- Re-verify is at the **evaluation** layer (identity + orgId trait), not segment membership: a correct membership set with a missing/one-env override silently leaves the flag OFF. The control-org assertion catches a leak to a non-targeted org.
+- `resolve_segment_id` uses `GET /segments/` without pagination. Safe with a handful of segments; may need pagination as the per-feature segment count grows.
 
 ## Cross-references
 
-- ADR: `knowledge-base/engineering/architecture/decisions/ADR-038-feature-flags-flagsmith.md`
-- Plan: `knowledge-base/project/plans/2026-05-22-feat-flagsmith-operator-skills-plan.md`
+- ADR: `knowledge-base/engineering/architecture/decisions/ADR-038-feature-flags-flagsmith.md`, `ADR-043-flagsmith-per-org-targeting.md` (§"Per-feature segment scoping")
+- Plan: `knowledge-base/project/plans/2026-05-22-feat-flagsmith-operator-skills-plan.md`, `2026-05-29-feat-flag-org-scoping-plan.md`
 - Predecessor PR: #4331 (resolution path)
 - Sibling skills: `soleur:flag-create`, `soleur:user-set-role`

--- a/plugins/soleur/skills/flag-set-role/scripts/flip.sh
+++ b/plugins/soleur/skills/flag-set-role/scripts/flip.sh
@@ -341,12 +341,14 @@ print('false')  # flag absent from payload -> not enabled for this identity
 
 # Poll eval until it matches the expected value (edge propagation is eventual).
 # Echoes the final observed value; returns 0 on match within budget, 1 otherwise.
+# Cadence overridable for tests (EVAL_POLL_TRIES / EVAL_POLL_SLEEP); live default
+# ~24s budget. No sleep after the final attempt.
 eval_until() { # $1=env_key $2=flag $3=org $4=role $5=expected
-  local got i
-  for i in $(seq 1 12); do
+  local got i tries="${EVAL_POLL_TRIES:-12}" naptime="${EVAL_POLL_SLEEP:-2}"
+  for i in $(seq 1 "$tries"); do
     got=$(eval_flag_enabled "$1" "$2" "$3" "$4") || return 3
     [[ "$got" == "$5" ]] && { printf '%s' "$got"; return 0; }
-    sleep 2
+    [[ "$i" -lt "$tries" ]] && sleep "$naptime"
   done
   printf '%s' "$got"; return 1
 }

--- a/plugins/soleur/skills/flag-set-role/scripts/flip.sh
+++ b/plugins/soleur/skills/flag-set-role/scripts/flip.sh
@@ -30,6 +30,15 @@ readonly FLAGSMITH_ENV_PRD_ID=90721
 readonly FLAGSMITH_ENV_DEV_KEY="PRHE5c9eWXYuRDFFPtbFxj"
 readonly FLAGSMITH_ENV_PRD_KEY="QMEpRRzFx8kpEcY7nZmhJd"
 readonly FLAGSMITH_API="https://api.flagsmith.com/api/v1"
+# Edge SDK eval endpoint (client-side X-Environment-Key). Mirrors the production
+# resolution path: flagsmith-nodejs getIdentityFlags() against edge.api.flagsmith.com
+# (apps/web-platform/lib/feature-flags/server.ts DEFAULT_FLAGSMITH_API_URL).
+readonly FLAGSMITH_EDGE_API="https://edge.api.flagsmith.com/api/v1"
+# Synthetic non-member orgId — default control for the eval-layer control-negative
+# assertion. Guaranteed to match no segment, so the flag must eval OFF for it; if it
+# evals ON the flag is globally enabled (a real leak). Override with --control-org to
+# assert against a specific real sibling org (e.g. the org sharing org-targeted).
+readonly DEFAULT_CONTROL_ORG="00000000-0000-0000-0000-000000000000"
 
 # Map known flag-name → Doppler env-var name. Keep in sync with
 # apps/web-platform/lib/feature-flags/server.ts RUNTIME_FLAGS.
@@ -44,6 +53,7 @@ DRY_RUN=0
 CONFIRMED=0
 TARGET_TYPE="role"
 TARGET_ORG=""
+CONTROL_ORG=""
 FLAG=""
 ROLE=""
 VALUE=""
@@ -54,6 +64,7 @@ while [[ $# -gt 0 ]]; do
     --confirmed)   CONFIRMED=1; shift ;;
     --target)      TARGET_TYPE="$2"; shift 2 ;;
     --org)         TARGET_ORG="$2"; shift 2 ;;
+    --control-org) CONTROL_ORG="$2"; shift 2 ;;
     --*)           echo "unknown flag: $1" >&2; exit 2 ;;
     *)
       if [[ -z "$FLAG" ]]; then FLAG="$1"
@@ -83,6 +94,11 @@ usage() {
 if [[ "$TARGET_TYPE" == "org" ]]; then
   [[ "$TARGET_ORG" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]] \
     || { echo "invalid orgId format (expected UUID): $TARGET_ORG" >&2; exit 2; }
+  [[ -z "$CONTROL_ORG" ]] && CONTROL_ORG="$DEFAULT_CONTROL_ORG"
+  [[ "$CONTROL_ORG" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]] \
+    || { echo "invalid control orgId format (expected UUID): $CONTROL_ORG" >&2; exit 2; }
+  [[ "$CONTROL_ORG" == "$TARGET_ORG" ]] \
+    && { echo "--control-org must differ from --org (got both = $TARGET_ORG)" >&2; exit 2; }
 fi
 
 ENV_VAR="${FLAG_ENV_VARS[$FLAG]}"
@@ -248,23 +264,112 @@ audit_append() {
   echo "  audit_id=$audit_id"
 }
 
-# --- org-targeting branch --------------------------------------------------
-# When --org is provided, modify the org-targeted segment's rule definition
-# directly (add/remove EQUAL orgId conditions in the ANY rule), then exit. No Doppler
-# mirror — org segment membership is not reflected in env vars (ADR-038
-# fallback mirrors prd-segment override state, not segment rule definitions).
+# Idempotently provision a feature's OWN org segment `<flag>-orgs` (ADR-043
+# per-feature scoping, 2026-05-29): create the segment with the ALL→ANY/EQUAL-orgId
+# envelope (zero conditions initially) if absent, then ensure an ON feature-state
+# override for the feature on that segment in BOTH envs. Echoes the segment id on
+# stdout (progress to stderr). Idempotent: re-running converges (no churn when the
+# override is already ON). The per-org gate is the segment's conditions, added later.
+provision_feature_segment() {
+  local flag="$1"
+  local seg_name="${flag}-orgs"
+  local seg_id feat_id env_id cur resp body
+  seg_id=$(resolve_segment_id "$seg_name" 2>/dev/null) || seg_id=""
+  if [[ -z "$seg_id" ]]; then
+    echo "  → creating segment '$seg_name'…" >&2
+    # Same rule envelope as org-targeted (flip.sh source-of-truth), zero conditions.
+    body=$(python3 -c "
+import json
+print(json.dumps({
+  'name': '${seg_name}',
+  'project': ${FLAGSMITH_PROJECT_ID},
+  'rules': [{'type':'ALL','rules':[{'type':'ANY','rules':[],'conditions':[]}],'conditions':[]}],
+}))")
+    resp=$(echo "$body" | fs_api -X POST "${FLAGSMITH_API}/projects/${FLAGSMITH_PROJECT_ID}/segments/" -d @-) \
+      || { echo "failed to create segment $seg_name" >&2; return 3; }
+    seg_id=$(echo "$resp" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("id",""))')
+    [[ -n "$seg_id" ]] || { echo "segment create returned no id: $resp" >&2; return 3; }
+    echo "    created $seg_name segment_id=$seg_id" >&2
+  else
+    echo "  → segment '$seg_name' exists (id=$seg_id)" >&2
+  fi
+  feat_id=$(resolve_feature_id "$flag") || { echo "feature '$flag' not found in Flagsmith" >&2; return 3; }
+  # ON override in BOTH envs (idempotent: only publish when not already ON).
+  for env_id in "$FLAGSMITH_ENV_DEV_ID" "$FLAGSMITH_ENV_PRD_ID"; do
+    cur=$(read_segment_state "$env_id" "$feat_id" "$seg_id")
+    if [[ "$cur" != "true" ]]; then
+      echo "  → ON override for '$flag' on '$seg_name' (env $env_id)…" >&2
+      flip_segment_in_env "$env_id" "$feat_id" "$seg_id" true >/dev/null
+    fi
+  done
+  printf '%s' "$seg_id"
+}
+
+# Evaluate <flag> for a transient identity carrying the orgId trait, exactly as the
+# production path does (getIdentityFlags("org:<org>:<role>", {role, orgId}, transient)).
+# Echoes "true"/"false". This is the FR8 load-bearing check: a correct segment
+# membership is NOT proof the flag is enabled (override missing / one-env-only leaves
+# it OFF), so re-verify reads the EVALUATED flag, not the membership set.
+eval_flag_enabled() { # $1=env_key $2=flag $3=orgId $4=role
+  local env_key="$1" flag="$2" org="$3" role="$4" body resp
+  body=$(python3 -c "
+import json
+print(json.dumps({
+  'identifier': 'org:${org}:${role}',
+  'traits': [
+    {'trait_key':'role','trait_value':'${role}'},
+    {'trait_key':'orgId','trait_value':'${org}'},
+  ],
+  'transient': True,
+}))")
+  resp=$(curl -sS -X POST "${FLAGSMITH_EDGE_API}/identities/" \
+    -H "X-Environment-Key: ${env_key}" -H "Content-Type: application/json" \
+    -d "$body") || { echo "eval request failed for org $org" >&2; return 3; }
+  echo "$resp" | FS_FLAG="$flag" python3 -c "
+import json, os, sys
+flag = os.environ['FS_FLAG']
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print('eval response not JSON', file=sys.stderr); sys.exit(3)
+for f in d.get('flags', []):
+    if f.get('feature', {}).get('name') == flag:
+        print(str(bool(f.get('enabled'))).lower()); sys.exit(0)
+print('false')  # flag absent from payload -> not enabled for this identity
+"
+}
+
+# Poll eval until it matches the expected value (edge propagation is eventual).
+# Echoes the final observed value; returns 0 on match within budget, 1 otherwise.
+eval_until() { # $1=env_key $2=flag $3=org $4=role $5=expected
+  local got i
+  for i in $(seq 1 12); do
+    got=$(eval_flag_enabled "$1" "$2" "$3" "$4") || return 3
+    [[ "$got" == "$5" ]] && { printf '%s' "$got"; return 0; }
+    sleep 2
+  done
+  printf '%s' "$got"; return 1
+}
+
+# --- org-targeting branch (ADR-043 per-feature segment scoping) -------------
+# When --org is provided, target the feature's OWN segment `<flag>-orgs` (NOT the
+# shared org-targeted segment): provision it (segment + ON override both envs), then
+# add/remove the org's EQUAL orgId condition, then re-verify by EVALUATING the flag
+# for the target org (must be enabled) and a control org (must be disabled). No Doppler
+# mirror — per-org segment membership is invisible to the FLAG_* env-var fallback
+# (ADR-038/ADR-043: a per-org-only flag falls back OFF on a Flagsmith outage).
 if [[ "$TARGET_TYPE" == "org" ]]; then
-  echo "→ Resolving org-targeted segment…"
-  ORG_SEG_ID=$(resolve_segment_id "org-targeted") || { echo "segment 'org-targeted' not found in Flagsmith" >&2; exit 3; }
-  echo "  org-targeted segment_id=$ORG_SEG_ID"
+  SEG_NAME="${FLAG}-orgs"
+  echo "→ Per-feature org segment: $SEG_NAME"
+  ENV_KEY=$([[ "$ROLE" == "prd" ]] && echo "$FLAGSMITH_ENV_PRD_KEY" || echo "$FLAGSMITH_ENV_DEV_KEY")
 
-  echo "→ Reading segment rules…"
-  SEG_JSON=$(fs_api "${FLAGSMITH_API}/projects/${FLAGSMITH_PROJECT_ID}/segments/${ORG_SEG_ID}/") \
-    || { echo "failed to read segment $ORG_SEG_ID" >&2; exit 3; }
-
-  # The org-targeted segment uses ANY(EQUAL orgId <uuid>, EQUAL orgId <uuid>, ...)
-  # — one condition per org, not a single IN condition with comma-separated values.
-  PARSED=$(echo "$SEG_JSON" | python3 -c "
+  # Read current membership (segment may not exist yet -> empty).
+  PRE_SEG_ID=$(resolve_segment_id "$SEG_NAME" 2>/dev/null) || PRE_SEG_ID=""
+  CURRENT_ORGS=""
+  if [[ -n "$PRE_SEG_ID" ]]; then
+    PRE_JSON=$(fs_api "${FLAGSMITH_API}/projects/${FLAGSMITH_PROJECT_ID}/segments/${PRE_SEG_ID}/") \
+      || { echo "failed to read segment $PRE_SEG_ID" >&2; exit 3; }
+    CURRENT_ORGS=$(echo "$PRE_JSON" | python3 -c "
 import json, sys
 seg = json.load(sys.stdin)
 conditions = seg['rules'][0]['rules'][0]['conditions']
@@ -275,98 +380,114 @@ for c in conditions:
         sys.exit(3)
     orgs.append(c['value'])
 print(','.join(orgs) if orgs else '')
-") || { echo "failed to parse segment rules (unexpected structure)" >&2; exit 3; }
+") || { echo "failed to parse $SEG_NAME rules (unexpected structure)" >&2; exit 3; }
+  fi
 
-  CURRENT_ORGS="$PARSED"
-
-  RESULT=$(CURRENT_ORGS="$CURRENT_ORGS" TARGET_ORG="$TARGET_ORG" VALUE="$VALUE" python3 -c "
-import os, sys
+  # Compute new membership (add on / remove off). No early-exit on 'already present':
+  # the override may still be missing, so we always provision + eval-verify.
+  NEW_ORGS=$(CURRENT_ORGS="$CURRENT_ORGS" TARGET_ORG="$TARGET_ORG" VALUE="$VALUE" python3 -c "
+import os
 current = os.environ['CURRENT_ORGS']
 target = os.environ['TARGET_ORG']
 action = os.environ['VALUE']
 orgs = [x for x in current.split(',') if x] if current else []
-
 if action == 'on':
-    if target in orgs:
-        print('IDEMPOTENT:already present')
-    else:
-        orgs.append(target)
-        print(','.join(orgs))
+    if target not in orgs: orgs.append(target)
 else:
-    if target not in orgs:
-        print('IDEMPOTENT:not present')
-    else:
-        orgs.remove(target)
-        print(','.join(orgs))
+    orgs = [o for o in orgs if o != target]
+print(','.join(orgs))
 ") || exit 3
 
-  if [[ "$RESULT" == "IDEMPOTENT:already present" ]]; then
-    echo "  orgId $TARGET_ORG is already in the org-targeted segment — no change needed."
-    exit 0
-  fi
-  if [[ "$RESULT" == "IDEMPOTENT:not present" ]]; then
-    echo "  orgId $TARGET_ORG is not in the org-targeted segment — no change needed."
-    exit 0
-  fi
-
-  NEW_ORGS="$RESULT"
-
-  echo "→ Current membership:"
-  if [[ -z "$CURRENT_ORGS" ]]; then
-    echo "  (empty)"
-  else
-    echo "$CURRENT_ORGS" | tr ',' '\n' | sed 's/^/  /'
-  fi
-  echo "→ Proposed: $VALUE orgId $TARGET_ORG"
+  echo "→ Current membership of $SEG_NAME:"
+  if [[ -z "$CURRENT_ORGS" ]]; then echo "  (empty)"; else echo "$CURRENT_ORGS" | tr ',' '\n' | sed 's/^/  /'; fi
+  echo "→ Proposed: $VALUE orgId $TARGET_ORG (control: $CONTROL_ORG)"
   echo "→ New membership:"
-  echo "$NEW_ORGS" | tr ',' '\n' | sed 's/^/  /'
+  if [[ -z "$NEW_ORGS" ]]; then echo "  (empty — feature OFF for all via $SEG_NAME)"; else echo "$NEW_ORGS" | tr ',' '\n' | sed 's/^/  /'; fi
 
-  gate_or_confirm
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "(dry-run — would provision $SEG_NAME (+ON override both envs), set membership above, then eval-verify; exiting 0 without mutation)"
+    exit 0
+  fi
+  if [[ $CONFIRMED -eq 0 ]]; then
+    echo
+    read -p "Proceed? Type 'yes' to apply: " ACK
+    [[ "$ACK" == "yes" ]] || { echo "aborted (ack was '$ACK')" >&2; exit 0; }
+  else
+    echo "(--confirmed: skipping interactive prompt)"
+  fi
+
+  # Append-before-flip: WORM audit precedes the first Flagsmith mutation (provision).
   audit_append "org:$TARGET_ORG"
 
-  echo "→ Writing updated segment to Flagsmith…"
-  UPDATED_JSON=$(echo "$SEG_JSON" | NEW_ORGS="$NEW_ORGS" python3 -c "
+  echo "→ Provisioning $SEG_NAME (segment + ON override both envs)…"
+  ORG_SEG_ID=$(provision_feature_segment "$FLAG") || exit 3
+
+  # Re-read immediately before the PUT to shrink the read-modify-write window (P1-1),
+  # then rebuild the conditions from the fresh read + target delta.
+  echo "→ Reading segment rules…"
+  SEG_JSON=$(fs_api "${FLAGSMITH_API}/projects/${FLAGSMITH_PROJECT_ID}/segments/${ORG_SEG_ID}/") \
+    || { echo "failed to read segment $ORG_SEG_ID" >&2; exit 3; }
+
+  # Recompute the delta from the FRESH read (the segment may have just been created
+  # empty by provision_feature_segment). One EQUAL orgId condition per org in the ANY
+  # rule — NOT a single IN condition (org-targeted source-of-truth, flip.sh history).
+  UPDATED_JSON=$(echo "$SEG_JSON" | TARGET_ORG="$TARGET_ORG" VALUE="$VALUE" python3 -c "
 import json, os, sys
 seg = json.load(sys.stdin)
-new_orgs = os.environ['NEW_ORGS']
-orgs = [x for x in new_orgs.split(',') if x] if new_orgs else []
-seg['rules'][0]['rules'][0]['conditions'] = [
-    {'operator': 'EQUAL', 'property': 'orgId', 'value': o} for o in orgs
-]
+target = os.environ['TARGET_ORG']
+action = os.environ['VALUE']
+anyrule = seg['rules'][0]['rules'][0]
+orgs = []
+for c in anyrule['conditions']:
+    if c.get('operator') != 'EQUAL' or c.get('property') != 'orgId':
+        print(f\"unexpected condition: operator={c.get('operator')} property={c.get('property')}\", file=sys.stderr)
+        sys.exit(3)
+    orgs.append(c['value'])
+if action == 'on':
+    if target not in orgs: orgs.append(target)
+else:
+    orgs = [o for o in orgs if o != target]
+anyrule['conditions'] = [{'operator':'EQUAL','property':'orgId','value':o} for o in orgs]
 json.dump(seg, sys.stdout)
-") || { echo "failed to build updated segment JSON" >&2; exit 3; }
+") || { echo "failed to build updated $SEG_NAME JSON (unexpected structure)" >&2; exit 3; }
 
+  echo "→ Writing updated $SEG_NAME membership to Flagsmith…"
   RESP=$(echo "$UPDATED_JSON" | fs_api -X PUT "${FLAGSMITH_API}/projects/${FLAGSMITH_PROJECT_ID}/segments/${ORG_SEG_ID}/" -d @-) \
     || { echo "PUT segment failed" >&2; exit 3; }
-
   echo "$RESP" | python3 -c "
 import json, sys
 seg = json.load(sys.stdin)
 if 'id' not in seg:
-    print(json.dumps(seg), file=sys.stderr)
-    sys.exit(3)
+    print(json.dumps(seg), file=sys.stderr); sys.exit(3)
 print('  updated segment id=' + str(seg['id']))
 " || exit 3
 
-  echo "→ Re-verifying…"
-  VERIFY_VALUE=$(fs_api "${FLAGSMITH_API}/projects/${FLAGSMITH_PROJECT_ID}/segments/${ORG_SEG_ID}/" \
-    | python3 -c "
-import json, sys
-seg = json.load(sys.stdin)
-conditions = seg['rules'][0]['rules'][0]['conditions']
-orgs = sorted(c['value'] for c in conditions if c.get('property') == 'orgId')
-print(','.join(orgs))
-") || { echo "re-verification read failed" >&2; exit 3; }
+  # --- eval-layer re-verify (FR8, the load-bearing fix) ---------------------
+  # Membership-set equality is NOT sufficient (override-missing / one-env-only leaves
+  # the flag OFF while the org is 'in' the segment). Evaluate the flag for a transient
+  # identity carrying the orgId trait (production getIdentityFlags path), asserting:
+  #   target org  -> enabled == (VALUE==on)         [the per-org enable actually works]
+  #   control org -> enabled == false               [no leak to a non-targeted org]
+  EXPECT_TARGET=$([[ "$VALUE" == "on" ]] && echo true || echo false)
+  echo "→ Eval-verify ($ROLE env): $FLAG for target $TARGET_ORG must be enabled=$EXPECT_TARGET…"
+  GOT_TARGET=$(eval_until "$ENV_KEY" "$FLAG" "$TARGET_ORG" "$ROLE" "$EXPECT_TARGET") || {
+    echo "EVAL VERIFY FAILED: $FLAG for org $TARGET_ORG expected enabled=$EXPECT_TARGET, last observed=$GOT_TARGET" >&2
+    echo "  (segment membership was written, but the flag does not EVALUATE as expected — likely a missing/one-env override)" >&2
+    exit 3
+  }
+  echo "  ✓ target $TARGET_ORG: enabled=$GOT_TARGET"
 
-  EXPECT_ORGS=$(echo "$NEW_ORGS" | tr ',' '\n' | sort | paste -sd,)
-  if [[ "$VERIFY_VALUE" != "$EXPECT_ORGS" ]]; then
-    echo "VERIFICATION FAILED: expected [$EXPECT_ORGS] but got [$VERIFY_VALUE]" >&2
+  echo "→ Eval-verify ($ROLE env): control org $CONTROL_ORG must be enabled=false (no leak)…"
+  GOT_CONTROL=$(eval_flag_enabled "$ENV_KEY" "$FLAG" "$CONTROL_ORG" "$ROLE") || { echo "control eval request failed" >&2; exit 3; }
+  if [[ "$GOT_CONTROL" != "false" ]]; then
+    echo "EVAL VERIFY FAILED (control leak): $FLAG is enabled for control org $CONTROL_ORG — the flag is reaching a non-targeted org." >&2
     exit 3
   fi
-  echo "  ✓ verified: orgId $TARGET_ORG is $([[ "$VALUE" == "on" ]] && echo 'present' || echo 'absent') in org-targeted segment."
+  echo "  ✓ control $CONTROL_ORG: enabled=$GOT_CONTROL"
 
   echo
-  echo "✓ Done. Segment rule change is immediate — no cache TTL applies to segment definitions."
+  echo "✓ Done. $SEG_NAME membership updated + flag eval-verified. Segment changes are"
+  echo "  immediate; edge eval propagation completes within seconds."
   exit 0
 fi
 

--- a/plugins/soleur/skills/flag-set-role/scripts/flip.sh
+++ b/plugins/soleur/skills/flag-set-role/scripts/flip.sh
@@ -99,6 +99,10 @@ if [[ "$TARGET_TYPE" == "org" ]]; then
     || { echo "invalid control orgId format (expected UUID): $CONTROL_ORG" >&2; exit 2; }
   [[ "$CONTROL_ORG" == "$TARGET_ORG" ]] \
     && { echo "--control-org must differ from --org (got both = $TARGET_ORG)" >&2; exit 2; }
+  # The synthetic default only proves "not globally ON"; pass a real sibling org for a
+  # leak check against the shared org-targeted blast radius. [review: user-impact F4]
+  [[ "$CONTROL_ORG" == "$DEFAULT_CONTROL_ORG" ]] \
+    && echo "⚠ control-negative uses the synthetic default org ($DEFAULT_CONTROL_ORG) — pass --control-org <real-sibling-uuid> for a stronger leak assertion." >&2
 fi
 
 ENV_VAR="${FLAG_ENV_VARS[$FLAG]}"
@@ -287,7 +291,8 @@ print(json.dumps({
 }))")
     resp=$(echo "$body" | fs_api -X POST "${FLAGSMITH_API}/projects/${FLAGSMITH_PROJECT_ID}/segments/" -d @-) \
       || { echo "failed to create segment $seg_name" >&2; return 3; }
-    seg_id=$(echo "$resp" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("id",""))')
+    seg_id=$(echo "$resp" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("id",""))') \
+      || { echo "segment create response not JSON: $resp" >&2; return 3; }
     [[ -n "$seg_id" ]] || { echo "segment create returned no id: $resp" >&2; return 3; }
     echo "    created $seg_name segment_id=$seg_id" >&2
   else
@@ -305,27 +310,41 @@ print(json.dumps({
   printf '%s' "$seg_id"
 }
 
-# Evaluate <flag> for a transient identity carrying the orgId trait, exactly as the
-# production path does (getIdentityFlags("org:<org>:<role>", {role, orgId}, transient)).
-# Echoes "true"/"false". This is the FR8 load-bearing check: a correct segment
-# membership is NOT proof the flag is enabled (override missing / one-env-only leaves
-# it OFF), so re-verify reads the EVALUATED flag, not the membership set.
-eval_flag_enabled() { # $1=env_key $2=flag $3=orgId $4=role
-  local env_key="$1" flag="$2" org="$3" role="$4" body resp
+# Verification identity role trait. Deliberately a value that matches NO role
+# segment (role-prd/role-dev match role=='prd'/'dev'), so eval-verify isolates the
+# PER-ORG segment gate (`<flag>-orgs` / org-targeted match on orgId, role-independent)
+# from any role-segment rollout. Without this, a flag carrying a role-<env>=ON override
+# would evaluate enabled for EVERY identity and the control-negative assertion would
+# fire spuriously. [review: code-reviewer "Important" / user-impact F4]
+readonly FLAG_VERIFY_ROLE="__flag-verify__"
+
+# Evaluate <flag> for a transient identity carrying the orgId trait, mirroring the
+# production getIdentityFlags() path (edge.api.flagsmith.com /identities/). Echoes
+# "true"/"false" ONLY on a 2xx; returns 3 on any transport OR HTTP error so the
+# verify FAILS LOUD instead of fail-open. This is the FR8 load-bearing check: a correct
+# segment membership is NOT proof the flag is enabled (override missing / one-env-only
+# leaves it OFF) — re-verify reads the EVALUATED flag, not the membership set.
+# [review P0: do NOT treat an error body's missing flag as "disabled".]
+eval_flag_enabled() { # $1=env_key $2=flag $3=orgId
+  local env_key="$1" flag="$2" org="$3" body resp code payload
   body=$(python3 -c "
 import json
 print(json.dumps({
-  'identifier': 'org:${org}:${role}',
+  'identifier': 'org:${org}:${FLAG_VERIFY_ROLE}',
   'traits': [
-    {'trait_key':'role','trait_value':'${role}'},
+    {'trait_key':'role','trait_value':'${FLAG_VERIFY_ROLE}'},
     {'trait_key':'orgId','trait_value':'${org}'},
   ],
   'transient': True,
 }))")
-  resp=$(curl -sS -X POST "${FLAGSMITH_EDGE_API}/identities/" \
+  resp=$(curl -sS -w '\n%{http_code}' -X POST "${FLAGSMITH_EDGE_API}/identities/" \
     -H "X-Environment-Key: ${env_key}" -H "Content-Type: application/json" \
-    -d "$body") || { echo "eval request failed for org $org" >&2; return 3; }
-  echo "$resp" | FS_FLAG="$flag" python3 -c "
+    -d "$body") || { echo "eval request failed (curl transport) for org $org" >&2; return 3; }
+  code=$(printf '%s' "$resp" | tail -n1)
+  payload=$(printf '%s' "$resp" | sed '$d')
+  [[ "$code" =~ ^2[0-9][0-9]$ ]] \
+    || { echo "eval HTTP $code for org $org (treating as UNVERIFIED, not disabled): $payload" >&2; return 3; }
+  printf '%s' "$payload" | FS_FLAG="$flag" python3 -c "
 import json, os, sys
 flag = os.environ['FS_FLAG']
 try:
@@ -335,7 +354,7 @@ except Exception:
 for f in d.get('flags', []):
     if f.get('feature', {}).get('name') == flag:
         print(str(bool(f.get('enabled'))).lower()); sys.exit(0)
-print('false')  # flag absent from payload -> not enabled for this identity
+print('false')  # 2xx + flag absent -> authoritatively not enabled for this identity
 "
 }
 
@@ -343,11 +362,11 @@ print('false')  # flag absent from payload -> not enabled for this identity
 # Echoes the final observed value; returns 0 on match within budget, 1 otherwise.
 # Cadence overridable for tests (EVAL_POLL_TRIES / EVAL_POLL_SLEEP); live default
 # ~24s budget. No sleep after the final attempt.
-eval_until() { # $1=env_key $2=flag $3=org $4=role $5=expected
+eval_until() { # $1=env_key $2=flag $3=org $4=expected
   local got i tries="${EVAL_POLL_TRIES:-12}" naptime="${EVAL_POLL_SLEEP:-2}"
   for i in $(seq 1 "$tries"); do
-    got=$(eval_flag_enabled "$1" "$2" "$3" "$4") || return 3
-    [[ "$got" == "$5" ]] && { printf '%s' "$got"; return 0; }
+    got=$(eval_flag_enabled "$1" "$2" "$3") || return 3
+    [[ "$got" == "$4" ]] && { printf '%s' "$got"; return 0; }
     [[ "$i" -lt "$tries" ]] && sleep "$naptime"
   done
   printf '%s' "$got"; return 1
@@ -472,15 +491,15 @@ print('  updated segment id=' + str(seg['id']))
   #   control org -> enabled == false               [no leak to a non-targeted org]
   EXPECT_TARGET=$([[ "$VALUE" == "on" ]] && echo true || echo false)
   echo "→ Eval-verify ($ROLE env): $FLAG for target $TARGET_ORG must be enabled=$EXPECT_TARGET…"
-  GOT_TARGET=$(eval_until "$ENV_KEY" "$FLAG" "$TARGET_ORG" "$ROLE" "$EXPECT_TARGET") || {
+  GOT_TARGET=$(eval_until "$ENV_KEY" "$FLAG" "$TARGET_ORG" "$EXPECT_TARGET") || {
     echo "EVAL VERIFY FAILED: $FLAG for org $TARGET_ORG expected enabled=$EXPECT_TARGET, last observed=$GOT_TARGET" >&2
-    echo "  (segment membership was written, but the flag does not EVALUATE as expected — likely a missing/one-env override)" >&2
+    echo "  (membership was written, but the flag does not EVALUATE as expected — missing/one-env override OR the edge endpoint errored; this is UNVERIFIED, investigate before relying on it)" >&2
     exit 3
   }
   echo "  ✓ target $TARGET_ORG: enabled=$GOT_TARGET"
 
   echo "→ Eval-verify ($ROLE env): control org $CONTROL_ORG must be enabled=false (no leak)…"
-  GOT_CONTROL=$(eval_flag_enabled "$ENV_KEY" "$FLAG" "$CONTROL_ORG" "$ROLE") || { echo "control eval request failed" >&2; exit 3; }
+  GOT_CONTROL=$(eval_flag_enabled "$ENV_KEY" "$FLAG" "$CONTROL_ORG") || { echo "control eval request failed / errored — UNVERIFIED, aborting (no fail-open)" >&2; exit 3; }
   if [[ "$GOT_CONTROL" != "false" ]]; then
     echo "EVAL VERIFY FAILED (control leak): $FLAG is enabled for control org $CONTROL_ORG — the flag is reaching a non-targeted org." >&2
     exit 3

--- a/plugins/soleur/test/audit-flag-flip.test.sh
+++ b/plugins/soleur/test/audit-flag-flip.test.sh
@@ -95,7 +95,14 @@ assert_order() { # $1=script $2=audit_call_regex $3=mutation_call_regex $4=label
 }
 assert_order "$CREATE"  'audit_flag_flip_rpc ' 'fs_api -X POST'                        "create.sh"
 assert_order "$SETROLE" 'audit_flag_flip_rpc ' 'supa -X PATCH|fs_api -X POST'          "set-role.sh"
-assert_order "$FLIP"    'audit_append "'        'fs_api -X PUT|flip_segment_in_env "\$' "flip.sh"
+# flip.sh has two main-flow paths; assert append-before-flip on each by its OWN audit
+# call site + first real (main-flow) mutation. The org path's provision_feature_segment
+# helper DEFINITION contains a `flip_segment_in_env "$env_id"` call, so the mutation
+# regexes are pinned to main-flow forms (`flip_segment_in_env "$FLAGSMITH_ENV…` for the
+# role path; `provision_feature_segment "$FLAG"` / `fs_api -X PUT` for the org path) to
+# avoid matching that helper-internal call (#4581 PR-2).
+assert_order "$FLIP"    'audit_append "role:'   'flip_segment_in_env "\$FLAGSMITH_ENV'  "flip.sh role path"
+assert_order "$FLIP"    'audit_append "org:'     'provision_feature_segment "\$FLAG"|fs_api -X PUT' "flip.sh org path"
 
 [ "$fail" -eq 0 ] || exit 1
 echo "audit-flag-flip: ok"

--- a/plugins/soleur/test/flag-org-scoping-pr2.test.sh
+++ b/plugins/soleur/test/flag-org-scoping-pr2.test.sh
@@ -152,9 +152,11 @@ OLD_TRAP_DIR="$S1_STUB"
 trap 'rm -rf "$S1_STUB" "$S2_STUB"' EXIT
 
 run_flip() { # env knobs come from caller; runs from repo root (FLAG_ENV_VARS resolution)
+  # EVAL_POLL_SLEEP=0 / fewer tries keeps the no-match (silent-leak) paths fast.
   ( cd "$REPO_ROOT" \
     && PATH="$S2_STUB:$PATH" CURL_LOG="$CURL_LOG" DOPPLER_SET_LOG="$DOPPLER_SET_LOG" \
        TARGET_ORG_FULL="$TARGET_ORG_FULL" CONTROL_ORG_FULL="$CONTROL_ORG_FULL" FLAG_NAME="$FLAG_NAME" \
+       EVAL_POLL_SLEEP=0 EVAL_POLL_TRIES=2 \
        bash "$FLIP" "$@" )
 }
 

--- a/plugins/soleur/test/flag-org-scoping-pr2.test.sh
+++ b/plugins/soleur/test/flag-org-scoping-pr2.test.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# Tests for #4581 PR-2 — per-feature-segment org scoping (gaps 1+2+3):
+#   1. create.sh --flagsmith-only (gap 1): create the Flagsmith feature only,
+#      skipping the server.ts/.env.example/Doppler mutations + the "already
+#      code-wired" exit-1 precheck.
+#   2. provision_feature_segment <flag> (gap 2): idempotent create of <flag>-orgs
+#      segment + ON feature-state override in BOTH envs.
+#   3. flip.sh --org reshape (gaps 2/3): target <flag>-orgs (NOT the shared
+#      org-targeted segment) + evaluation-layer re-verify (positive target +
+#      control-negative) + empty-membership eval=false.
+set -euo pipefail
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CREATE="$REPO_ROOT/plugins/soleur/skills/flag-create/scripts/create.sh"
+FLIP="$REPO_ROOT/plugins/soleur/skills/flag-set-role/scripts/flip.sh"
+fail=0
+
+# Shared stub for `doppler`: `secrets get` returns canned values; `secrets set`
+# is recorded to $DOPPLER_SET_LOG so a test can assert no mirror write happened.
+make_doppler_stub() { # $1=dir
+  cat > "$1/doppler" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "secrets" && "${2:-}" == "get" ]]; then
+  case "${3:-}" in
+    FLAGSMITH_MANAGEMENT_API_KEY) echo "fake-mgmt-key" ;;
+    OPERATOR_EMAIL)               echo "op@jikigai.com" ;;
+    SUPABASE_URL)                 echo "https://x.supabase.co" ;;
+    SUPABASE_SERVICE_ROLE_KEY)    echo "srk" ;;
+    *)                            echo "" ;;
+  esac
+  exit 0
+fi
+if [[ "${1:-}" == "secrets" && "${2:-}" == "set" ]]; then
+  echo "set:${3:-}" >> "${DOPPLER_SET_LOG:-/dev/null}"
+  exit 0
+fi
+exit 0
+STUB
+  chmod +x "$1/doppler"
+}
+
+# --- Section 1: create.sh --flagsmith-only ---------------------------------
+# curl stub: audit RPC -> uuid+200; feature lookup -> not-found; feature POST -> id.
+# Every invocation is logged to $CURL_LOG (URL only) for create-happened assertion.
+make_create_curl_stub() { # $1=dir
+  cat > "$1/curl" <<'STUB'
+#!/usr/bin/env bash
+url=""
+for a in "$@"; do case "$a" in http*) url="$a" ;; esac; done
+echo "$url" >> "${CURL_LOG:-/dev/null}"
+if [[ "$url" == *"/rpc/audit_flag_flip"* ]]; then
+  printf '%s\n%s' '"11111111-1111-1111-1111-111111111111"' '200'; exit 0
+fi
+if [[ "$url" == *"/features/?q="* ]]; then echo '{"results":[]}'; exit 0; fi
+if [[ "$url" == *"/features/"* ]];   then echo '{"id":12345}';   exit 0; fi
+echo '{}'; exit 0
+STUB
+  chmod +x "$1/curl"
+}
+
+S1_STUB="$(mktemp -d)"; trap 'rm -rf "$S1_STUB"' EXIT
+make_doppler_stub "$S1_STUB"
+make_create_curl_stub "$S1_STUB"
+
+run_create() { # runs create.sh in an EMPTY dir (no server.ts/.env.example).
+  local rundir; rundir="$(mktemp -d)"
+  ( cd "$rundir" \
+    && echo yes | PATH="$S1_STUB:$PATH" \
+         CURL_LOG="$CURL_LOG" DOPPLER_SET_LOG="$DOPPLER_SET_LOG" \
+         bash "$CREATE" "$@" )
+}
+
+# 1a. NEGATIVE CONTROL: without --flagsmith-only, an empty dir (no server.ts)
+#     must fail (missing file / precheck) — proves the flag is the lever.
+CURL_LOG="$(mktemp)"; DOPPLER_SET_LOG="$(mktemp)"
+if run_create byok-delegations >/dev/null 2>&1; then
+  echo "pr2: FAIL — create.sh without --flagsmith-only should fail in a dir lacking server.ts" >&2; fail=1
+fi
+
+# 1b. --flagsmith-only from an empty dir -> exit 0 (no server.ts/.env needed).
+CURL_LOG="$(mktemp)"; DOPPLER_SET_LOG="$(mktemp)"
+if run_create byok-delegations --flagsmith-only >/dev/null 2>&1; then
+  : # ok
+else
+  echo "pr2: FAIL — create.sh --flagsmith-only should exit 0 without touching server.ts" >&2; fail=1
+fi
+
+# 1c. --flagsmith-only must NOT mirror Doppler (no `secrets set`).
+if grep -q '^set:' "$DOPPLER_SET_LOG" 2>/dev/null; then
+  echo "pr2: FAIL — --flagsmith-only wrote Doppler ($(cat "$DOPPLER_SET_LOG"))" >&2; fail=1
+fi
+
+# 1d. --flagsmith-only DID create the Flagsmith feature (POST /features/).
+if ! grep -q '/features/$' "$CURL_LOG" 2>/dev/null; then
+  echo "pr2: FAIL — --flagsmith-only did not POST the Flagsmith feature (curl log: $(cat "$CURL_LOG"))" >&2; fail=1
+fi
+
+# --- Section 2+3: flip.sh --org reshape (provision <flag>-orgs + eval-verify) ---
+# Stateless Flagsmith stub covering every endpoint the reshaped org path hits.
+# Eval (/identities/) returns enabled per EVAL_TARGET_ENABLED / EVAL_CONTROL_ENABLED,
+# keyed on which org UUID appears in the request body — so a test can simulate a
+# control-org leak and assert the script fails loud.
+TARGET_ORG_FULL="70a70ab0-0000-0000-0000-000000000001"
+CONTROL_ORG_FULL="1a8045bf-0000-0000-0000-000000000002"
+FLAG_NAME="byok-delegations"
+
+make_flip_curl_stub() { # $1=dir
+  cat > "$1/curl" <<'STUB'
+#!/usr/bin/env bash
+url=""; method="GET"; data=""; prev=""
+for a in "$@"; do
+  case "$prev" in -X) method="$a" ;; -d) data="$a" ;; esac
+  case "$a" in http*) url="$a" ;; esac
+  prev="$a"
+done
+echo "$method $url" >> "${CURL_LOG:-/dev/null}"
+case "$url" in
+  *"/rpc/audit_flag_flip"*)
+    printf '%s\n%s' '"11111111-1111-1111-1111-111111111111"' '200'; exit 0 ;;
+  *"/identities/"*)
+    # edge eval: enabled keyed on which org is in the body + the test's knobs.
+    en="false"
+    if [[ "$data" == *"$TARGET_ORG_FULL"* ]];  then en="${EVAL_TARGET_ENABLED:-false}"; fi
+    if [[ "$data" == *"$CONTROL_ORG_FULL"* ]]; then en="${EVAL_CONTROL_ENABLED:-false}"; fi
+    printf '{"flags":[{"feature":{"name":"%s"},"enabled":%s}],"traits":[]}' "$FLAG_NAME" "$en"
+    exit 0 ;;
+  *"/features/?q="*)
+    printf '{"results":[{"id":777,"name":"%s"}]}' "$FLAG_NAME"; exit 0 ;;
+  *"/segments/")
+    if [[ "$method" == "POST" ]]; then echo '{"id":888,"name":"created"}'
+    else echo '{"results":[]}'; fi   # list: <flag>-orgs absent -> provision creates it
+    exit 0 ;;
+  *"/segments/"*[0-9]"/"|*"/segments/"*[0-9])
+    if [[ "$method" == "PUT" ]]; then echo '{"id":888}'
+    else echo '{"id":888,"rules":[{"type":"ALL","rules":[{"type":"ANY","rules":[],"conditions":[]}],"conditions":[]}]}'; fi
+    exit 0 ;;
+  *"/featurestates/"*) echo '[]'; exit 0 ;;          # read_segment_state -> missing
+  *"/versions/"*)
+    if [[ "$method" == "POST" ]]; then echo '{"uuid":"v-uuid"}'
+    else echo '{"results":[{"uuid":"v-uuid","is_live":true}]}'; fi
+    exit 0 ;;
+  *"/feature-segments/"*) echo '{"results":[]}'; exit 0 ;;  # no existing override row
+  *) echo '{}'; exit 0 ;;
+esac
+STUB
+  chmod +x "$1/curl"
+}
+
+S2_STUB="$(mktemp -d)"
+make_doppler_stub "$S2_STUB"
+make_flip_curl_stub "$S2_STUB"
+OLD_TRAP_DIR="$S1_STUB"
+trap 'rm -rf "$S1_STUB" "$S2_STUB"' EXIT
+
+run_flip() { # env knobs come from caller; runs from repo root (FLAG_ENV_VARS resolution)
+  ( cd "$REPO_ROOT" \
+    && PATH="$S2_STUB:$PATH" CURL_LOG="$CURL_LOG" DOPPLER_SET_LOG="$DOPPLER_SET_LOG" \
+       TARGET_ORG_FULL="$TARGET_ORG_FULL" CONTROL_ORG_FULL="$CONTROL_ORG_FULL" FLAG_NAME="$FLAG_NAME" \
+       bash "$FLIP" "$@" )
+}
+
+# 2a. Source-level: org branch must target the per-feature <flag>-orgs segment
+#     and provision it — NOT the shared org-targeted segment.
+if ! grep -q 'provision_feature_segment' "$FLIP"; then
+  echo "pr2: FAIL — flip.sh lacks provision_feature_segment" >&2; fail=1
+fi
+if grep -q 'resolve_segment_id "org-targeted"' "$FLIP"; then
+  echo "pr2: FAIL — flip.sh --org still resolves the shared org-targeted segment" >&2; fail=1
+fi
+if ! grep -qE '\$\{?FLAG\}?-orgs|\$FLAG-orgs' "$FLIP"; then
+  echo "pr2: FAIL — flip.sh does not reference the <flag>-orgs per-feature segment" >&2; fail=1
+fi
+# eval-layer re-verify against the edge identities endpoint (per ADR-043 identity model)
+if ! grep -q 'edge.api.flagsmith.com' "$FLIP"; then
+  echo "pr2: FAIL — flip.sh eval-verify must hit the edge identities endpoint" >&2; fail=1
+fi
+
+# 2b. POSITIVE: on --org <target>, eval true for target / false for control -> exit 0,
+#     and the eval (/identities/) + segment POST (provision) actually happened.
+CURL_LOG="$(mktemp)"; DOPPLER_SET_LOG="$(mktemp)"
+if EVAL_TARGET_ENABLED=true EVAL_CONTROL_ENABLED=false \
+     run_flip "$FLAG_NAME" prd on --org "$TARGET_ORG_FULL" --control-org "$CONTROL_ORG_FULL" --confirmed \
+     >/dev/null 2>&1; then
+  grep -q 'POST https://edge.api.flagsmith.com/api/v1/identities/' "$CURL_LOG" \
+    || { echo "pr2: FAIL — eval-verify did not POST the edge identities endpoint" >&2; fail=1; }
+  grep -q 'POST .*/segments/$' "$CURL_LOG" \
+    || { echo "pr2: FAIL — provision did not POST a per-feature segment" >&2; fail=1; }
+else
+  echo "pr2: FAIL — on --org with target-enabled/control-disabled should exit 0" >&2; fail=1
+fi
+
+# 2c. CONTROL-LEAK (gate-present test): if the flag also evaluates enabled for the
+#     control org, the script MUST fail loud (the FR8 control-negative assertion).
+CURL_LOG="$(mktemp)"; DOPPLER_SET_LOG="$(mktemp)"
+if EVAL_TARGET_ENABLED=true EVAL_CONTROL_ENABLED=true \
+     run_flip "$FLAG_NAME" prd on --org "$TARGET_ORG_FULL" --control-org "$CONTROL_ORG_FULL" --confirmed \
+     >/dev/null 2>&1; then
+  echo "pr2: FAIL — control-org leak (eval true for control) must fail loud, not exit 0" >&2; fail=1
+fi
+
+# 2d. POSITIVE off-case + empty-membership semantics: off --org <target> with the
+#     flag evaluating OFF for the target -> exit 0 (eval=false is the expected state).
+CURL_LOG="$(mktemp)"; DOPPLER_SET_LOG="$(mktemp)"
+if ! EVAL_TARGET_ENABLED=false EVAL_CONTROL_ENABLED=false \
+       run_flip "$FLAG_NAME" prd off --org "$TARGET_ORG_FULL" --control-org "$CONTROL_ORG_FULL" --confirmed \
+       >/dev/null 2>&1; then
+  echo "pr2: FAIL — off --org with eval=false target should exit 0" >&2; fail=1
+fi
+
+# 2e. SILENT-LEAK guard (gate-present): on --org but the flag does NOT actually
+#     evaluate enabled for the target (override missing / one-env-only) -> fail loud.
+#     Membership-set equality alone would pass here; eval-verify must catch it.
+CURL_LOG="$(mktemp)"; DOPPLER_SET_LOG="$(mktemp)"
+if EVAL_TARGET_ENABLED=false EVAL_CONTROL_ENABLED=false \
+     run_flip "$FLAG_NAME" prd on --org "$TARGET_ORG_FULL" --control-org "$CONTROL_ORG_FULL" --confirmed \
+     >/dev/null 2>&1; then
+  echo "pr2: FAIL — on --org with target NOT enabled must fail loud (silent-leak guard)" >&2; fail=1
+fi
+
+[ "$fail" -eq 0 ] || exit 1
+echo "flag-org-scoping-pr2: ok"

--- a/plugins/soleur/test/flag-org-scoping-pr2.test.sh
+++ b/plugins/soleur/test/flag-org-scoping-pr2.test.sh
@@ -117,11 +117,12 @@ case "$url" in
   *"/rpc/audit_flag_flip"*)
     printf '%s\n%s' '"11111111-1111-1111-1111-111111111111"' '200'; exit 0 ;;
   *"/identities/"*)
-    # edge eval: enabled keyed on which org is in the body + the test's knobs.
+    # edge eval: emits body + '\n<http_code>' (matches curl -w). enabled keyed on
+    # which org is in the body + the test's knobs; EVAL_HTTP_CODE simulates errors.
     en="false"
     if [[ "$data" == *"$TARGET_ORG_FULL"* ]];  then en="${EVAL_TARGET_ENABLED:-false}"; fi
     if [[ "$data" == *"$CONTROL_ORG_FULL"* ]]; then en="${EVAL_CONTROL_ENABLED:-false}"; fi
-    printf '{"flags":[{"feature":{"name":"%s"},"enabled":%s}],"traits":[]}' "$FLAG_NAME" "$en"
+    printf '{"flags":[{"feature":{"name":"%s"},"enabled":%s}],"traits":[]}\n%s' "$FLAG_NAME" "$en" "${EVAL_HTTP_CODE:-200}"
     exit 0 ;;
   *"/features/?q="*)
     printf '{"results":[{"id":777,"name":"%s"}]}' "$FLAG_NAME"; exit 0 ;;
@@ -216,6 +217,17 @@ if EVAL_TARGET_ENABLED=false EVAL_CONTROL_ENABLED=false \
      run_flip "$FLAG_NAME" prd on --org "$TARGET_ORG_FULL" --control-org "$CONTROL_ORG_FULL" --confirmed \
      >/dev/null 2>&1; then
   echo "pr2: FAIL — on --org with target NOT enabled must fail loud (silent-leak guard)" >&2; fail=1
+fi
+
+# 2f. FAIL-OPEN guard: an edge eval HTTP error must NOT be read as "disabled" and pass
+#     the verify — the gate must fail loud (exit non-zero). Without the HTTP-2xx check,
+#     curl -sS exits 0 on a 5xx and the parser's flag-absent fall-through returns
+#     "false", silently passing the control-negative + off assertions.
+CURL_LOG="$(mktemp)"; DOPPLER_SET_LOG="$(mktemp)"
+if EVAL_TARGET_ENABLED=true EVAL_CONTROL_ENABLED=false EVAL_HTTP_CODE=500 \
+     run_flip "$FLAG_NAME" prd on --org "$TARGET_ORG_FULL" --control-org "$CONTROL_ORG_FULL" --confirmed \
+     >/dev/null 2>&1; then
+  echo "pr2: FAIL — edge eval HTTP 500 must fail loud (no fail-open), not exit 0" >&2; fail=1
 fi
 
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

PR-2 of #4581 — **per-feature Flagsmith segment org-scoping** (gaps 1+2+3), the model
change gated by ADR-043. Makes it possible to enable a legally-sensitive org-targetable
runtime flag for **one** org via sanctioned tooling, without exposing it to other orgs
that happen to share the old single `org-targeted` segment. (PR-1 — the WORM-audit
portability + actor seed — landed in #4582.)

Brand-survival threshold: **single-user incident** (`requires_cpo_signoff: true`). Gated
on `user-impact-reviewer` at review (run; see below).

## Changelog

- `flag-create`: new `--flagsmith-only` flag — creates the Flagsmith feature for an
  already code-wired flag, skipping the `server.ts`/`.env.example`/Doppler mutations and
  the "already appears in server.ts" exit-1 precheck (gap 1).
- `flag-set-role`: per-org targeting now uses a **per-feature segment** `<flag>-orgs`
  (idempotent `provision_feature_segment`: create segment + ON override in both envs)
  instead of the shared `org-targeted` segment, and re-verifies at the **evaluation
  layer** (transient identity + `orgId` trait, mirroring production `getIdentityFlags`)
  asserting target-org enabled + a control org NOT enabled (gaps 2+3, FR8). New
  `--control-org` flag.
- ADR-043: status `accepted` → `superseded-in-part`; documents the `<flag>-orgs` model,
  the O(features)-not-O(orgs) rationale, the OFF-on-outage fallback property, and the
  eval-layer re-verify.

## Why per-feature segments

The original shared `org-targeted` segment enables *every* attached feature for *every*
org in its membership — so `byok-delegations` and `team-workspace-invite` cannot have
different org sets. Per-feature `<flag>-orgs` keeps the segment count on the bounded
**feature** axis (O(features), today 2), not the unbounded customer axis the ADR's
explosion rejection feared (O(orgs)). Org churn changes *conditions inside* a segment,
never the segment count.

## Testing

- New `plugins/soleur/test/flag-org-scoping-pr2.test.sh` (RED→GREEN per unit): `--flagsmith-only`
  bypass + no file/Doppler writes; `--org` targets `<flag>-orgs` (not `org-targeted`);
  eval-verify positive + control-negative; silent-leak guard (membership set but flag not
  enabled → fail loud); **fail-open guard** (edge HTTP 500 → fail loud, not "disabled").
- `plugins/soleur/test/audit-flag-flip.test.sh` append-before-flip assertion re-pinned to
  main-flow call sites (provision helper now defines a `flip_segment_in_env` call).
- Full suite green: `scripts/test-all.sh` → **86/86 suites passed, 0 failed**.

## Review (single-user-incident threshold)

`user-impact-reviewer` + `security-sentinel` + `code-reviewer` ran on the diff. Security:
SAFE (no secret leak, no injection — orgIds are UUID-validated, flag is allowlisted; WORM
append-before-flip preserved). One **P0 fixed**: `eval_flag_enabled` used `curl -sS` with
no HTTP-status check, so a 4xx/5xx error body read as "disabled" and **fail-open** through
the control-negative + off-case verifies — now requires a 2xx and returns UNVERIFIED
otherwise (test 2f locks it). Also fixed: eval identity used `role=prd|dev` (matched role
segments → spurious control failure for flags with role overrides) → sentinel
`__flag-verify__` role isolates the per-org gate; synthetic-default-control warning;
segment-create JSON-parse exit-code. Captured the fail-open lesson in
`knowledge-base/project/learnings/best-practices/2026-05-29-http-verification-gates-must-check-status-not-just-transport.md`.

## Consumer proof & issue closure

`Ref #4581` · `Ref #4232` — intentionally **not** auto-closing. The byok-delegations
Flagsmith feature does not exist yet, so the consumer proof is a live cutover the agent
executes **post-merge with operator authorization obtained 2026-05-29** (no operator
action required): `create.sh --flagsmith-only byok-delegations` → `flip.sh byok-delegations
prd on --org 70a70ab0… --control-org 1a8045bf… --confirmed` → eval-verify (jikigai ON,
sibling OFF). Both issues are closed by the agent **after** that eval-verify proves green
(close-after-apply deferral). `FLAG_BYOK_DELEGATIONS` prd Doppler = `0` (verified
2026-05-29) → the per-org flag degrades closed on a Flagsmith outage.

Scope-cut (plan-sanctioned): migrating `team-workspace-invite` off the shared
`org-targeted` segment is a follow-up — not required for the byok unblock (byok gets its
own segment, no leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
