### PR TITLE
feat(work): net-flow gate at the follow-up filing site (Phase 4)

### DIFF
--- a/knowledge-base/project/learnings/workflow-patterns/2026-05-29-net-issue-flow-gate-at-filing-site-not-just-ship.md
+++ b/knowledge-base/project/learnings/workflow-patterns/2026-05-29-net-issue-flow-gate-at-filing-site-not-just-ship.md
@@ -1,0 +1,63 @@
+---
+title: Net-issue-flow / cost-of-filing discipline must fire at the filing site, not only at /ship
+date: 2026-05-29
+category: workflow-patterns
+tags: [backlog, deferred-scope-out, net-issue-flow, cost-of-filing, ship, work, follow-ups]
+related_prs: [4452, 4580, 4613]
+---
+
+# Learning: net-flow gate belongs at the filing site (/work), not only at /ship Phase 5.5
+
+## Problem
+
+PR #4580 (#4579) filed **4** follow-up issues for **1** closed issue (net +3 backlog
+growth): an ADR, a sibling-upstream PR-G tracker, a drill-down-UI feature, and a
+discovered latent bug. This is the exact backlog-accretion pattern PR #4452 fixed earlier
+the same week via (a) the mechanical cost-of-filing auto-flip (≤30 lines AND ≤2 files → fix
+inline) and (b) `/ship` Phase 5.5 **Net-Issue-Flow Surfacing** (display Closing/Filing/Net
+before merge so the operator can pivot).
+
+Both safety nets missed, for two structural reasons:
+
+1. **The filings happened in `/work` Phase 4** (Post-Merge Section Self-Audit + deferral
+   tracking), which is BEFORE `/ship` Phase 5.5 runs. The surfacing is a ship-time advisory;
+   it cannot catch filings made during `/work`.
+2. **`/ship` was hand-rolled.** The agent executed ship's phases as targeted bash instead of
+   invoking `/soleur:ship`, so Phase 5.5's Net-Issue-Flow Surfacing never executed at all.
+
+The mechanical auto-flip would not have flipped any of the 4 to inline (none were ≤30-line
+review findings), but the **surfacing** would have made the agent confront "+3 from one PR"
+and consolidate — which is exactly what happened once the operator asked. 3 of the 4
+(ADR + PR-G upstream + drill-down) consolidated into a single tracker (#4613); the net
+should have been +1 (one consolidated feature tracker + the one genuine discovered bug).
+
+## Solution
+
+Add a **Follow-up Filing Net-Flow Gate** to `/work` Phase 4 (the site where follow-ups are
+actually filed), mirroring `/ship` Phase 5.5 + `review/SKILL.md` §CONCUR:
+
+1. Cost-of-filing per candidate (≤30 lines AND ≤2 files → inline).
+2. Consolidate deferred-FEATURE follow-ups from the same PR into ONE `post-MVP follow-ups`
+   tracker; keep discovered **bugs** separate (never bury a possible-P1 bug in a tracker).
+3. Surface `Closing / Filing / Net` BEFORE filing; if Net > 0, justify each filing.
+
+This is the `/work`-side mirror so the discipline fires at the filing site regardless of
+whether `/ship` runs or is hand-rolled.
+
+## Key Insight
+
+A gate that only fires at the *merge boundary* (ship) is bypassed by (a) work done before
+the boundary and (b) hand-rolling the boundary. When a discipline must hold for an action
+(filing a follow-up), enforce it **at the moment the action is taken**, in every skill that
+takes it — not only at the last pipeline stage. The mirror pattern already exists in this
+repo (SENSITIVE_PATH_RE triple-SSOT across plan/work/ship; the operator-step gate at both
+/work Phase 4 and /ship Phase 5.5) — net-flow surfacing was the one that lived in only one
+place.
+
+**Corollary on consolidation:** N deferred-feature follow-ups from one PR → one tracker with
+a checklist. A genuine discovered defect (different subsystem, possibly P1) is NOT a
+deferred scope-out — it keeps its own issue so triage/priority stays visible.
+
+## Tags
+category: workflow-patterns
+module: skills/work

--- a/plugins/soleur/skills/work/SKILL.md
+++ b/plugins/soleur/skills/work/SKILL.md
@@ -724,6 +724,18 @@ After resolution, re-scan; the section MUST contain zero unaccompanied operator/
 
 **Why:** PR #4227 (TR9 PR-3) shipped with a "Post-merge" section listing four operator items (Doppler secrets check, T+90 min Sentry verify, T+24h auto-resolve verify, file follow-up issue within 48h) — all four were inline-automatable; the agent had hard rules forbidding the deferral (`hr-exhaust-all-automated-options-before`, `hr-never-label-any-step-as-manual-without`, `wg-block-pr-ready-on-undeferred-operator-steps`) and still wrote the bullets. The gate existed at `/ship` Phase 5.5 but the agent reached `gh pr ready` directly. This self-audit + the hook close both halves of that bypass. See `knowledge-base/project/learnings/best-practices/2026-05-21-post-merge-section-self-audit.md`.
 
+#### Follow-up Filing Net-Flow Gate (HARD GATE)
+
+`/work` files follow-up issues HERE (Post-Merge Self-Audit, deferral tracking, discovered-bug capture) — which is BEFORE `/ship` Phase 5.5's Net-Issue-Flow Surfacing runs, and is bypassed entirely when `/ship` is hand-rolled. So the cost-of-filing + net-flow discipline (PR #4452) must ALSO fire at this filing site, not only at ship.
+
+Before issuing ANY `gh issue create` for a follow-up in this phase, run the gate:
+
+1. **Cost-of-filing, per candidate filing** (mirrors `review/SKILL.md` §CONCUR): if the deferred work is **≤30 changed lines AND ≤2 files**, do it inline (fold into THIS PR if unmerged; otherwise it is genuinely a follow-up). Only file when the work is genuinely larger, a separate work-stream/Non-Goal, an operator-only step, or a **discovered defect in a different subsystem** (the last MUST stay its own issue — never bury a possible-P1 bug in a consolidated tracker).
+2. **Consolidate deferred-FEATURE follow-ups into ONE tracker.** Multiple `deferred-scope-out` follow-ups from the same PR (ADR + future-feature + sibling-upstream …) collapse into a single "**\<feature\> (#N): post-MVP follow-ups**" issue with a checklist. Discovered bugs stay separate.
+3. **Surface the net count BEFORE filing.** Compute and print: `Closing: <count of Closes #N in PR body> / Filing: <new issues> / Net: <signed>`. If `Net > 0`, state one sentence per filing on why it could not be inlined or consolidated. Net-positive backlog growth from a single feature PR is the smell this gate exists to catch.
+
+This is the `/work`-side mirror of `/ship` Phase 5.5 Net-Issue-Flow Surfacing — together they cover both the filing site (here) and the merge boundary (ship). **Why:** PR #4580 (#4579) filed **4** follow-ups for **1** closed issue (net +3) during this self-audit; the agent hand-rolled `/ship` so Phase 5.5's surfacing never fired, and there was no filing-site gate. Three were consolidatable into one tracker (#4613); the net should have been +1. See `knowledge-base/project/learnings/workflow-patterns/2026-05-29-net-issue-flow-gate-at-filing-site-not-just-ship.md`.
+
 #### Invocation Mode
 
 **If invoked by one-shot** (the conversation contains `soleur:one-shot` skill output earlier): Output exactly `## Work Phase Complete` and then **immediately invoke** `skill: soleur:review` (step 4 of the one-shot sequence). Do NOT end your turn after outputting the marker — you ARE the orchestrator, so you must continue executing one-shot steps 4 through 10 in order. The marker is a progress signal, not a stopping point.


### PR DESCRIPTION
## Summary

PR #4580 filed 4 follow-up issues for 1 closed issue (net +3) — the backlog-accretion pattern PR #4452 fixed. Root cause: the cost-of-filing + net-issue-flow discipline lived **only** at `/ship` Phase 5.5, which is (a) after `/work` files its follow-ups and (b) bypassed when `/ship` is hand-rolled.

This adds a **Follow-up Filing Net-Flow Gate** to `/work` Phase 4 (the actual filing site), mirroring `/ship` Phase 5.5 + `review` §CONCUR:
- cost-of-filing per candidate (≤30 lines AND ≤2 files → inline);
- consolidate deferred-feature follow-ups into ONE tracker (discovered bugs stay separate);
- surface Closing/Filing/Net before filing.

Net effect: the discipline now fires at the filing site regardless of whether `/ship` runs.

## Changelog
### Plugin
- `/work` Phase 4 gains a follow-up filing net-flow gate (mirror of `/ship` Phase 5.5) to prevent net-positive backlog accretion from a single PR.

## Test plan
- [x] Markdown body edit to `work/SKILL.md` (no `description:` change → skill budget unaffected); reference-link sanity clean.
- [x] Learning documents the #4580 deviation + the filing-site-vs-ship-boundary insight.

Ref #4579

Generated with [Claude Code](https://claude.com/claude-code)