### PR TITLE
fix(flag-tooling): eval-verify control-negative must poll until it settles

### DIFF
--- a/knowledge-base/project/learnings/best-practices/2026-05-29-http-verification-gates-must-check-status-not-just-transport.md
+++ b/knowledge-base/project/learnings/best-practices/2026-05-29-http-verification-gates-must-check-status-not-just-transport.md
@@ -52,6 +52,23 @@ trait (`__flag-verify__`) that matches no role segment, so the per-org assertion
 the **per-org segment gate** specifically, decoupled from any role rollout. General lesson:
 a verification identity/fixture should activate exactly the gate under test and nothing else.
 
+## Follow-on (caught at the live cutover): tolerate propagation SYMMETRICALLY
+
+The first fix added an HTTP-status gate and an `eval_until` retry on the **target**
+assertion (poll until enabled), but left the **control-negative** as a single-shot read.
+At the real byok@jikigai cutover this false-positived: immediately after creating the
+segment + override, the eventually-consistent edge environment document briefly reported
+the *non-member* control org as enabled for one refresh window, and the single-shot
+control read aborted a correct enable (exit 3 "control leak"). Direct re-eval a moment
+later, and an idempotent re-run, both showed the correct state (target ON, control OFF).
+
+Lesson: when a verification gate reads an eventually-consistent source, **every** leg of
+the assertion must tolerate propagation the same way — poll until the value *settles*, not
+a single read. Fix: control now `eval_until … false` (polls until it settles to disabled;
+a genuine leak never settles → budget exhausts → fail loud; an HTTP error still returns
+non-zero). A one-sided retry (happy path tolerant, negative path single-shot) is itself a
+flake/false-positive vector.
+
 ## Why it matters
 
 The fail-open turned the single automated barrier between an operator command and a

--- a/plugins/soleur/skills/flag-set-role/scripts/flip.sh
+++ b/plugins/soleur/skills/flag-set-role/scripts/flip.sh
@@ -498,12 +498,17 @@ print('  updated segment id=' + str(seg['id']))
   }
   echo "  ✓ target $TARGET_ORG: enabled=$GOT_TARGET"
 
-  echo "→ Eval-verify ($ROLE env): control org $CONTROL_ORG must be enabled=false (no leak)…"
-  GOT_CONTROL=$(eval_flag_enabled "$ENV_KEY" "$FLAG" "$CONTROL_ORG") || { echo "control eval request failed / errored — UNVERIFIED, aborting (no fail-open)" >&2; exit 3; }
-  if [[ "$GOT_CONTROL" != "false" ]]; then
-    echo "EVAL VERIFY FAILED (control leak): $FLAG is enabled for control org $CONTROL_ORG — the flag is reaching a non-targeted org." >&2
+  # Poll until the control SETTLES to disabled — same propagation tolerance as the
+  # target check. The edge environment document is eventually consistent: right after a
+  # segment+override create, a non-member org can transiently read enabled=true for one
+  # refresh window before the segment's orgId condition propagates. A single-shot read
+  # here false-positives on that window. A genuine leak never settles to false → the
+  # poll exhausts its budget and fails loud (and an HTTP error returns 3 → exit 3).
+  echo "→ Eval-verify ($ROLE env): control org $CONTROL_ORG must settle to enabled=false (no leak)…"
+  GOT_CONTROL=$(eval_until "$ENV_KEY" "$FLAG" "$CONTROL_ORG" "false") || {
+    echo "EVAL VERIFY FAILED (control leak): $FLAG did not settle to disabled for control org $CONTROL_ORG within the propagation budget (last observed=$GOT_CONTROL) — the flag is reaching a non-targeted org, OR the edge endpoint errored. UNVERIFIED." >&2
     exit 3
-  fi
+  }
   echo "  ✓ control $CONTROL_ORG: enabled=$GOT_CONTROL"
 
   echo


### PR DESCRIPTION
## Summary

Follow-up to #4612 (#4581 PR-2). The eval-verify control-negative assertion in
`flip.sh --org` was a single-shot read while the target assertion used `eval_until`
(retry). Caught at the live byok@jikigai cutover (#4232): immediately after creating the
`byok-delegations-orgs` segment + ON override, the eventually-consistent Flagsmith edge
environment document briefly reported the **non-member** control org as enabled for one
refresh window, false-positiving the leak check and aborting an otherwise-correct enable
(exit 3 "control leak"). Direct re-eval moments later, and an idempotent re-run, both
showed the correct state (target ON, control OFF).

## Changelog

- `flag-set-role`: the per-org eval-verify control-negative now polls until the control
  org **settles** to `enabled=false` (`eval_until … false`), the same propagation
  tolerance the target assertion already had. A genuine persistent leak never settles →
  the poll exhausts its budget and fails loud; an edge HTTP error still returns non-zero.
  Symmetric propagation tolerance closes a one-sided false-positive vector.

## Testing

- `plugins/soleur/test/flag-org-scoping-pr2.test.sh` green (control-leak guard 2c now
  exhausts the poll budget then fails loud; fail-open guard 2f unchanged).
- Verified live: re-running the byok@jikigai cutover idempotently now exits 0 with
  `target=enabled`, `control settled to enabled=false`.

`Ref #4581`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
