### PR TITLE
fix(obs): use bare partial PUT to toggle soleur_www monitor (#4603 hotfix)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -202,22 +202,17 @@ jobs:
             echo "::warning::soleur-ai-www detector not found; skipping pause (deploy continues)."
             exit 0
           fi
-          # Full-body GET-then-PUT: updateProjectMonitor requires the full
-          # ProjectMonitorRequest; a bare {"enabled":false} PUT risks a 400.
-          full=$(curl -sS --max-time 20 \
-            -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
-            "https://${SENTRY_API_HOST}/api/0/organizations/${SENTRY_ORG}/detectors/${id}/") || {
-              echo "::warning::Failed to fetch detector ${id}; skipping pause (deploy continues)."
-              exit 0
-            }
-          body=$(jq '.enabled = false' <<<"$full" 2>/dev/null) || {
-            echo "::warning::Failed to build pause payload; skipping pause (deploy continues)."
-            exit 0
-          }
+          # Toggle via a bare partial PUT {"enabled": false} (verified 200).
+          # Echoing the full GET response back instead 400s: the GET (response)
+          # shape includes nested fields (dataSources[].queryObj.url) that
+          # serialize as null on read, but the PUT (request) schema requires a
+          # non-null string — the response and request schemas differ. A bare
+          # partial body avoids the whole class. See #4596 hotfix (#4603 shipped
+          # the broken GET-then-PUT and reddened every docs deploy).
           status=$(curl -sS --max-time 20 -X PUT \
             -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
             -H "Content-Type: application/json" \
-            -d "$body" \
+            -d '{"enabled":false}' \
             "https://${SENTRY_API_HOST}/api/0/organizations/${SENTRY_ORG}/detectors/${id}/" \
             -o /dev/null -w '%{http_code}')
           echo "pause PUT status: ${status}"
@@ -255,7 +250,6 @@ jobs:
           MONITOR_ID: ${{ steps.pause_www_monitor.outputs.monitor_id }}
         run: |
           set -uo pipefail
-          which jq >/dev/null 2>&1 || { apt-get update && apt-get install -y jq; }
           # Propagation grace + confirming probe (best-effort; never block resume).
           # Cap = 30 × 30s ≈ 15 min, matching the observed deploy-window flap; the
           # resume runs regardless, so an under-sized cap only weakens the
@@ -276,23 +270,14 @@ jobs:
             echo "No monitor id captured at pause; nothing to resume."
             exit 0
           fi
-          # Guard GET+jq explicitly so a resume-time blip fails loud with an
-          # actionable message (not a raw jq parse error). A stranded-paused
-          # monitor is worse than a red workflow, so exit 1 on any failure.
-          full=$(curl -sS --max-time 20 \
-            -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
-            "https://${SENTRY_API_HOST}/api/0/organizations/${SENTRY_ORG}/detectors/${MONITOR_ID}/") || {
-              echo "::error::Failed to fetch detector ${MONITOR_ID} for resume; monitor may remain paused — re-run deploy-docs.yml or re-enable manually."
-              exit 1
-            }
-          body=$(jq '.enabled = true' <<<"$full" 2>/dev/null) || {
-            echo "::error::Failed to build resume payload for detector ${MONITOR_ID}; monitor may remain paused — re-run deploy-docs.yml or re-enable manually."
-            exit 1
-          }
+          # Resume via a bare partial PUT {"enabled": true} (verified 200) — same
+          # reason as the pause step: echoing the full GET body back 400s on the
+          # null nested fields. A stranded-paused monitor is worse than a red
+          # workflow, so a non-200 exits 1 (fail-loud).
           http=$(curl -sS --max-time 20 -X PUT \
             -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
             -H "Content-Type: application/json" \
-            -d "$body" \
+            -d '{"enabled":true}' \
             "https://${SENTRY_API_HOST}/api/0/organizations/${SENTRY_ORG}/detectors/${MONITOR_ID}/" \
             -o /dev/null -w '%{http_code}')
           echo "resume PUT status: ${http}"

--- a/knowledge-base/project/learnings/integration-issues/2026-05-29-sentry-detectors-put-bare-partial-not-full-body-echo.md
+++ b/knowledge-base/project/learnings/integration-issues/2026-05-29-sentry-detectors-put-bare-partial-not-full-body-echo.md
@@ -1,0 +1,78 @@
+# Learning: Sentry `/detectors/` PUT takes a bare partial body — never echo the GET response back
+
+## Problem
+
+PR #4603 (#4596) added pause/resume of the `soleur_www` Sentry uptime detector
+to `deploy-docs.yml`. The plan's Research-Reconciliation table asserted (citing
+the `jianyuan/terraform-provider-sentry` OpenAPI `requestBody.required: true`)
+that `PUT /api/0/organizations/{org}/detectors/{id}/` requires the **full**
+`ProjectMonitorRequest` body, so a bare `{"enabled": false}` PUT would 400 —
+and prescribed a GET-then-PUT round-trip (fetch full object, mutate `.enabled`,
+PUT it back).
+
+In production both PUTs returned **400**:
+
+```
+{"dataSources":{"assertion":{"error":"serialization_error",
+  "details":"Failed to deserialize the JSON body into the target type:
+   url: invalid type: null, expected a string ..."}}}
+```
+
+The pause PUT 400'd (monitor never paused → no alerting gap, since it stayed
+enabled), but the resume step's non-200 path `exit 1` reddened **every** docs
+deploy. The feature was non-functional and the workflow was broken.
+
+## Solution
+
+The plan's reconciliation was **backwards**. Against the live API
+(`jikigai-eu.sentry.io`, detector `1221117`):
+
+- `PUT {"enabled": false}` / `PUT {"enabled": true}` (bare partial) → **HTTP 200** ✓
+- `PATCH {"enabled": true}` → **HTTP 403** (method not permitted for this token)
+- Echoing the full GET response back as the PUT body → **HTTP 400**
+
+The GET **response** (`ProjectMonitor`) and the PUT **request** schemas differ:
+the GET response embeds nested `dataSources[].queryObj.url`-class fields that
+serialize as `null` on read, but the request schema requires a non-null string.
+Echoing GET→PUT therefore fails deserialization. A bare partial body sidesteps
+the entire class.
+
+Fix: replace the GET-then-PUT with a single bare `PUT {"enabled": <bool>}` in
+both pause and resume steps. (Full pause→`false`→resume→`true` cycle
+live-validated, monitor restored to `enabled: true`.)
+
+## Key Insight
+
+**For a REST resource where you only need to toggle one field, try the bare
+partial `PUT {"field": value}` FIRST — do not assume "full-body required" from
+an OpenAPI `requestBody.required: true` and echo the GET response back.** A GET
+response routinely carries read-only/computed/null-on-read fields (`id`,
+`dateCreated`, nested `*.url`) that the request schema rejects; response and
+request schemas are NOT interchangeable. When a plan prescribes a specific API
+body shape, treat it as an **unverified open question** until a live probe
+confirms it (the plan even flagged the partial-PUT question but resolved it the
+wrong way). A 5-minute `curl` against the live endpoint at /work time would have
+caught this before it shipped — the same "plan-prescribed runtime shapes must be
+grepped/probed against the live API, not assumed" discipline that applies to CLI
+flags and installed library versions. See
+[[2026-05-29-plan-mandated-compound-selector-must-be-implemented-fully]].
+
+## Session Errors
+
+1. **Shipped a P1 that broke deploy-docs (resume PUT 400 → exit 1 on every
+   run).** Root cause: the plan's API-contract reconciliation was wrong
+   (assumed full-body PUT required; reality is bare partial works, full echo
+   400s), and no live probe ran at /work or QA time because the change had no
+   `## Test Scenarios` and the discoverability probe only checked the www→apex
+   301, not the Sentry PUT. — Recovery: hotfix to bare partial PUT, live-
+   validated full cycle. — Prevention: the Key Insight above — when a workflow
+   makes a vendor-API write whose body shape is plan-asserted-but-unverified,
+   run one live `curl` against the real endpoint before shipping (QA Test
+   Scenario or a /work live-probe), especially when the plan itself flags the
+   shape as an open question.
+
+## Tags
+category: integration-issues
+module: ci/sentry-iac
+issue: 4596
+pr: 4603


### PR DESCRIPTION
## Summary

Hotfix for PR #4603 (#4596). That PR paused/resumed the `soleur_www` Sentry uptime detector in `deploy-docs.yml` via a GET-then-PUT round-trip. Both PUTs returned **HTTP 400** in production: echoing the full GET response back as the PUT body fails the request schema — the response carries nested `dataSources` fields whose `url` serializes as `null` on read, but the request schema requires a non-null string (GET and PUT schemas differ). Net effect: the pause never took (monitor stayed `enabled` — **no alerting gap**), but the resume step `exit 1` reddened **every docs deploy**.

A bare partial `PUT {"enabled": false|true}` is accepted (**verified HTTP 200**; full pause→`false`→resume→`true` cycle live-validated against detector 1221117, monitor restored to `enabled: true`). This drops the GET-for-body + jq body construction in both steps; the resume step no longer needs `jq`.

Ref #4596

## Changelog

### Web Platform / CI
- `deploy-docs.yml`: pause/resume the `soleur_www` uptime detector with a bare `PUT {"enabled": …}` instead of the full GET-body echo (which 400s). Removes the now-unused `jq` guard from the resume step.

## User-Brand Impact

- **Brand-survival threshold:** `none`
- `threshold: none, reason: pure CI fix — the diff touches only .github/workflows/deploy-docs.yml (a public docs-site deploy workflow); no schema, auth flow, API route, .sql, or user-data surface, and the only secret (SENTRY_IAC_AUTH_TOKEN) is pre-existing and env-routed (static JSON body, no interpolation).`

## Test plan

- [x] `actionlint .github/workflows/deploy-docs.yml` clean
- [x] Live cycle validated: pause `PUT {enabled:false}`→200→`enabled=false`; resume `PUT {enabled:true}`→200→`enabled=true` (monitor left enabled)
- [x] security review clean (static literal body, no new injection surface, secrets still env-routed)

Generated with [Claude Code](https://claude.com/claude-code)