### PR TITLE
chore(obs): ratchet soleur_www resume probe cap 15min→5min

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -251,14 +251,15 @@ jobs:
         run: |
           set -uo pipefail
           # Propagation grace + confirming probe (best-effort; never block resume).
-          # Cap = 30 × 30s ≈ 15 min, matching the observed deploy-window flap; the
-          # resume runs regardless, so an under-sized cap only weakens the
-          # "confirming" log line, it never strands the monitor.
+          # Cap = 30 × 10s ≈ 5 min. The pause/resume bracket already covers the
+          # whole deploy window, so this probe only decides whether to log
+          # "301 confirmed" vs a warning before resuming — the resume runs
+          # regardless, so the cap never strands the monitor.
           confirmed=0
           for attempt in $(seq 1 30); do
             code=$(curl -s --max-time 10 -o /dev/null -w '%{http_code}' "https://www.soleur.ai/")
             if [[ "$code" == "301" ]]; then confirmed=1; break; fi
-            if [[ "$attempt" -lt 30 ]]; then sleep 30; fi  # no trailing sleep after the last probe
+            if [[ "$attempt" -lt 30 ]]; then sleep 10; fi  # no trailing sleep after the last probe
           done
           if [[ "$confirmed" -eq 1 ]]; then
             echo "www→apex 301 confirmed."


### PR DESCRIPTION
## Summary

Follow-up to #4603/#4620. The resume step's www→apex 301 probe cap was set to 30 × 30s ≈ 15 min during initial work (to match the observed deploy-window flap). Now that pause/resume works (#4620), the `soleur_www` detector is paused for the **entire** deploy window regardless of probe outcome, and the resume runs unconditionally — so the 15-min cap only added deploy wall-clock for no benefit. Reverted to the plan's original 30 × 10s ≈ 5 min (`sleep 30` → `sleep 10`).

Ref #4596

## User-Brand Impact

- **Brand-survival threshold:** `none`
- `threshold: none, reason: pure CI timing-constant change — the diff touches only .github/workflows/deploy-docs.yml (a public docs-site deploy workflow); a single sleep value + comment, no schema, auth, API route, .sql, or user-data surface.`

## Test plan

- [x] `actionlint .github/workflows/deploy-docs.yml` clean
- [x] Mechanism already validated end-to-end in #4620 (pause/resume PUT 200, monitor enabled); this only shortens the best-effort confirming-probe cap

Generated with [Claude Code](https://claude.com/claude-code)