### PR TITLE
docs(adr-043): mark org-targeted retirement complete (#4617)

### DIFF
--- a/apps/web-platform/lib/feature-flags/server.ts
+++ b/apps/web-platform/lib/feature-flags/server.ts
@@ -25,10 +25,10 @@ const CACHE_TTL_MS = 30_000;
 // with per-org targeting via per-feature `<flag>-orgs` segments (ADR-043
 // §"Per-feature segment scoping"): each org-targetable flag gets its own segment
 // whose `EQUAL orgId` conditions are the sole per-org gate for that flag. byok runs
-// on `byok-delegations-orgs`; team-workspace-invite is being migrated off the legacy
-// shared `org-targeted` segment onto `team-workspace-invite-orgs` (#4617). Which
-// segment carries the override is transparent to getRuntimeFlag here. FLAG_* env vars
-// remain as the Flagsmith outage fallback (env-fallback mirror).
+// on `byok-delegations-orgs`; team-workspace-invite runs on `team-workspace-invite-orgs`
+// (migrated off the legacy shared `org-targeted` segment, which was retired 2026-05-29
+// per #4617). Which segment carries the override is transparent to getRuntimeFlag here.
+// FLAG_* env vars remain as the Flagsmith outage fallback (env-fallback mirror).
 //
 // New flags: if the call-site needs DCE elimination → ENV. Otherwise → RUNTIME.
 // See ADR-038 + ADR-043.

--- a/knowledge-base/engineering/architecture/decisions/ADR-043-flagsmith-per-org-targeting.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-043-flagsmith-per-org-targeting.md
@@ -1,6 +1,6 @@
 # ADR-043: Flagsmith Per-Org Targeting via Identity Trait
 
-**Status:** superseded-in-part (see "Per-feature segment scoping (2026-05-29)" below)
+**Status:** superseded-in-part — the shared-segment "Segment Design" is **fully retired** (the `org-targeted` segment was deleted 2026-05-29, #4617); the Identity Strategy and Cache Key Widening sections remain in force. See "Per-feature segment scoping (2026-05-29)" below.
 **Date:** 2026-05-25
 **Deciders:** Jean Deruelle (CTO), Claude (engineering)
 **Related:** ADR-038 (feature-flag architecture), umbrella #4456 PR-2, #4581 PR-2 (per-feature segment scoping)
@@ -9,20 +9,20 @@
 > *single* shared `org-targeted` segment gating *all* per-org features — is
 > superseded by the per-feature-segment model documented at the end of this ADR
 > (#4581 PR-2). The Identity Strategy and Cache Key Widening sections remain in
-> force. The shared `org-targeted` segment is retained until `team-workspace-invite`
-> is migrated off it (follow-up); new per-org features use `<flag>-orgs`.
+> force. New per-org features use `<flag>-orgs`.
 >
-> **[Updated 2026-05-29 — #4617]** The migration tooling now exists:
-> `soleur:flag-set-role <flag> <env> on --detach-shared --org <memberId>` removes a
-> feature's override on `org-targeted` (both envs) and eval-verifies the feature still
-> resolves enabled for the member via its own `<flag>-orgs` segment. `byok-delegations`
-> already runs on `byok-delegations-orgs` (PR-2); `team-workspace-invite` is the last
-> feature on the shared segment. The shared `org-targeted` segment is **slated for
-> retirement** once `team-workspace-invite` is detached and zero features remain
-> attached. Status stays `superseded-in-part` until that live retirement completes —
-> the segment still exists in Flagsmith until the post-merge `--detach-shared` run +
-> segment DELETE land; this ADR flips to fully-superseded in a follow-up edit gated on
-> that retirement.
+> **[Updated 2026-05-29 — #4617, retirement COMPLETE]** The migration tooling
+> (`soleur:flag-set-role <flag> <env> on --detach-shared --org <memberId>`) shipped in
+> #4619, and the live prd migration has been executed and verified:
+> `team-workspace-invite` was provisioned onto its own `team-workspace-invite-orgs`
+> segment (both member orgs), detached from `org-targeted` in both envs, and the now-
+> orphaned `org-targeted` segment was **deleted** (Flagsmith segment id 1130454; DELETE
+> 204, 2026-05-29). Post-retirement eval confirmed both member orgs still resolve
+> `team-workspace-invite` enabled via the per-feature segment, and `byok-delegations`
+> (on `byok-delegations-orgs` since PR-2) was unaffected. **No feature references the
+> shared `org-targeted` segment anymore** — the per-(feature, org) model is the sole
+> per-org gate for all org-targetable flags. The remaining project segments are
+> `role-dev`, `role-prd`, `byok-delegations-orgs`, and `team-workspace-invite-orgs`.
 
 ## Context
 


### PR DESCRIPTION
## Summary

Completes #4617. The live prd Flagsmith migration of `team-workspace-invite` off
the legacy shared `org-targeted` segment has been executed and verified:

- Provisioned `team-workspace-invite-orgs` + added both member orgs (ON override both envs).
- Detached `team-workspace-invite` from `org-targeted` in both envs (eval-verified both members stay `enabled=true`).
- Deleted the now-orphaned `org-targeted` segment (Flagsmith id 1130454, DELETE 204).
- `byok-delegations` (on `byok-delegations-orgs` since PR-2) unaffected — regression witness confirmed.

Post-retirement, the project's only segments are `role-dev`, `role-prd`,
`byok-delegations-orgs`, `team-workspace-invite-orgs`. The per-(feature, org)
model is now the sole per-org gate.

This PR flips ADR-043's Segment Design to fully-retired (Identity Strategy +
Cache Key Widening remain in force) and updates the `server.ts` comment to past tense.

## Changelog

- **ADR-043:** status note updated — `org-targeted` retired 2026-05-29; shared-segment design fully superseded.
- **server.ts:** comment updated — twi now runs on `team-workspace-invite-orgs` (migration complete).

## Test plan

- [x] Docs + code-comment only; no behavioral change (eval path is segment-transparent).
- [x] Live migration eval-verified at each step (provision / detach / retire) against the prd edge.

Closes #4617

Generated with [Claude Code](https://claude.com/claude-code)