### PR TITLE
fix(invite): auto-return keyless invitee to /invite after onboarding (builds on #4638)

### DIFF
--- a/apps/web-platform/app/(auth)/setup-key/page.tsx
+++ b/apps/web-platform/app/(auth)/setup-key/page.tsx
@@ -1,12 +1,27 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { safeReturnTo } from "@/lib/safe-return-to";
 
 type Status = "idle" | "checking" | "valid" | "invalid" | "error";
 
 export default function SetupKeyPage() {
+  return (
+    <Suspense>
+      <SetupKeyForm />
+    </Suspense>
+  );
+}
+
+function SetupKeyForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  // Validated invite return target (e.g. /invite/<token>) threaded from
+  // accept-terms for a keyless invitee. connect-repo is the terminal funnel
+  // hop and consumes `return_to`, so bridge the auth-funnel `redirectTo` param
+  // to connect-repo's `return_to` on the next push. null when absent/rejected.
+  const redirectTo = safeReturnTo(searchParams.get("redirectTo"));
   const [key, setKey] = useState("");
   const [status, setStatus] = useState<Status>("idle");
   const [errorMsg, setErrorMsg] = useState("");
@@ -34,8 +49,18 @@ export default function SetupKeyPage() {
 
       if (body.valid) {
         setStatus("valid");
-        // Brief delay so the user sees the success state
-        setTimeout(() => router.push("/connect-repo"), 600);
+        // Brief delay so the user sees the success state. Carry the invite
+        // target forward as connect-repo's `return_to` so a new invitee lands
+        // back on /invite/<token> after the final onboarding hop.
+        setTimeout(
+          () =>
+            router.push(
+              redirectTo
+                ? `/connect-repo?return_to=${encodeURIComponent(redirectTo)}`
+                : "/connect-repo",
+            ),
+          600,
+        );
       } else {
         setStatus("invalid");
         setErrorMsg("Invalid API key. Please check and try again.");

--- a/apps/web-platform/app/api/accept-terms/route.ts
+++ b/apps/web-platform/app/api/accept-terms/route.ts
@@ -21,10 +21,15 @@ async function getRedirectDestination(
     .eq("is_valid", true)
     .limit(1);
 
-  // No key yet → onboarding takes precedence (the invitee re-opens the invite
-  // link post-onboarding; an authenticated re-open needs no OTP). Keyed → honor
-  // the validated next hop (e.g. /invite/<token>) instead of /dashboard.
-  if (!keys || keys.length === 0) return "/setup-key";
+  // No key yet → onboarding takes precedence, BUT thread the validated next hop
+  // through it so a brand-new invitee auto-returns to /invite/<token> AFTER
+  // onboarding (T&C recorded first, then key → repo → invite). setup-key carries
+  // it to connect-repo, which lands on it. Keyed → honor the next hop directly.
+  if (!keys || keys.length === 0) {
+    return nextHop
+      ? `/setup-key?redirectTo=${encodeURIComponent(nextHop)}`
+      : "/setup-key";
+  }
   return nextHop ?? "/dashboard";
 }
 

--- a/apps/web-platform/test/accept-terms-redirect-to.test.ts
+++ b/apps/web-platform/test/accept-terms-redirect-to.test.ts
@@ -96,6 +96,10 @@ describe("POST /api/accept-terms — redirectTo threading", () => {
     const res = await POST(makeRequest({ redirectTo: "https://evil.example" }));
     const json = await res.json();
     expect(json.redirect).toBe("/setup-key");
+    // Distinguish "rejected" from "feature absent": the hostile value must NOT
+    // be threaded — no ?redirectTo= query, no off-origin host.
+    expect(json.redirect).not.toContain("redirectTo");
+    expect(json.redirect).not.toContain("evil.example");
   });
 
   test("keyed user with no redirectTo → /dashboard (unchanged default)", async () => {

--- a/apps/web-platform/test/accept-terms-redirect-to.test.ts
+++ b/apps/web-platform/test/accept-terms-redirect-to.test.ts
@@ -72,9 +72,28 @@ describe("POST /api/accept-terms — redirectTo threading", () => {
     expect(json.redirect).toBe("/invite/tok123");
   });
 
-  test("no-key user → /setup-key takes precedence over redirectTo", async () => {
+  test("no-key user with redirectTo → /setup-key CARRIES the target forward (auto-return after onboarding)", async () => {
     mockApiKeysLimit.mockResolvedValue({ data: [], error: null });
     const res = await POST(makeRequest({ redirectTo: "/invite/tok123" }));
+    const json = await res.json();
+    // Onboarding still takes precedence, but the invite target is threaded
+    // onto setup-key so a brand-new invitee auto-returns to /invite after
+    // key + repo setup (T&C-first ordering preserved).
+    expect(json.redirect).toBe(
+      `/setup-key?redirectTo=${encodeURIComponent("/invite/tok123")}`,
+    );
+  });
+
+  test("no-key user with no redirectTo → bare /setup-key (genuine new signup unchanged)", async () => {
+    mockApiKeysLimit.mockResolvedValue({ data: [], error: null });
+    const res = await POST(makeRequest({}));
+    const json = await res.json();
+    expect(json.redirect).toBe("/setup-key");
+  });
+
+  test("no-key user with open-redirect redirectTo → bare /setup-key (rejected, not carried)", async () => {
+    mockApiKeysLimit.mockResolvedValue({ data: [], error: null });
+    const res = await POST(makeRequest({ redirectTo: "https://evil.example" }));
     const json = await res.json();
     expect(json.redirect).toBe("/setup-key");
   });

--- a/apps/web-platform/test/components/setup-key-redirect-to.test.tsx
+++ b/apps/web-platform/test/components/setup-key-redirect-to.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// A keyless invitee threads the invite target through setup-key: accept-terms
+// returns /setup-key?redirectTo=/invite/<token>, and on key-save success
+// setup-key must carry it to connect-repo (the terminal funnel hop) as
+// `return_to`, so the new invitee auto-returns to /invite after onboarding.
+
+const routerMock = { push: vi.fn() };
+const searchParamsHolder: { current: URLSearchParams } = {
+  current: new URLSearchParams(),
+};
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => routerMock,
+  useSearchParams: () => searchParamsHolder.current,
+}));
+
+import SetupKeyPage from "@/app/(auth)/setup-key/page";
+
+const INVITE_PATH = "/invite/Zm9vYmFyYmF6cXV4MTIzNDU2Nzg5MGFiY2RlZmdoaWpr";
+
+async function saveKeyWith(redirectToParam: string | null) {
+  searchParamsHolder.current = new URLSearchParams(
+    redirectToParam === null ? {} : { redirectTo: redirectToParam },
+  );
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ valid: true }),
+    }),
+  );
+  render(<SetupKeyPage />);
+  fireEvent.change(screen.getByPlaceholderText("sk-ant-..."), {
+    target: { value: "sk-ant-xyz" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /save key/i }));
+}
+
+describe("setup-key → connect-repo carry-forward", () => {
+  beforeEach(() => {
+    routerMock.push.mockClear();
+    searchParamsHolder.current = new URLSearchParams();
+  });
+
+  it("carries a validated /invite target to connect-repo as return_to", async () => {
+    await saveKeyWith(INVITE_PATH);
+    await waitFor(
+      () =>
+        expect(routerMock.push).toHaveBeenCalledWith(
+          `/connect-repo?return_to=${encodeURIComponent(INVITE_PATH)}`,
+        ),
+      { timeout: 2000 },
+    );
+  });
+
+  it("pushes bare /connect-repo when no redirectTo (genuine new signup)", async () => {
+    await saveKeyWith(null);
+    await waitFor(
+      () => expect(routerMock.push).toHaveBeenCalledWith("/connect-repo"),
+      { timeout: 2000 },
+    );
+  });
+
+  it("drops an open-redirect redirectTo (bare /connect-repo, never off-origin)", async () => {
+    await saveKeyWith("https://evil.example");
+    await waitFor(
+      () => expect(routerMock.push).toHaveBeenCalledWith("/connect-repo"),
+      { timeout: 2000 },
+    );
+    const pushed = routerMock.push.mock.calls.map((c) => c[0]).join(" ");
+    expect(pushed).not.toContain("evil.example");
+    expect(pushed).not.toContain("return_to");
+  });
+});

--- a/knowledge-base/project/learnings/workflow-patterns/2026-05-29-dirty-conflict-during-ship-may-mean-sibling-shipped-your-feature.md
+++ b/knowledge-base/project/learnings/workflow-patterns/2026-05-29-dirty-conflict-during-ship-may-mean-sibling-shipped-your-feature.md
@@ -1,0 +1,73 @@
+---
+date: 2026-05-29
+category: workflow-patterns
+tags: [one-shot, ship, merge-conflict, collision, sibling-pr, reset-and-rebuild]
+related_pr: 4641
+related_to: [4638]
+---
+
+# A DIRTY conflict during ship can mean a sibling PR shipped your whole feature
+
+## Problem
+
+During a `/soleur:one-shot` run for the workspace-invite-acceptance bug, the
+branch passed every gate (review, full suite, preflight) and queued auto-merge.
+The PR then flipped `OPEN BEHIND → OPEN DIRTY`. The DIRTY was not a stray
+line conflict: a sibling PR (**#4638**, ostensibly an OTP-rate-limit fix) had
+merged to `main` mid-pipeline and implemented the **same feature** — invite
+return-target threading through the auth funnel — with a *different* param
+convention (`redirectTo` vs my `return_to`), a different `safeReturnTo` shape
+(string|null + percent-decode vs my widened-fallback), and the *opposite*
+T&C-timing decision. Six files conflicted, each a competing implementation.
+
+## Root cause
+
+The one-shot collision gate (Step 0a.5) only probes for open/merged PRs that
+reference the SAME issue at pipeline START. It cannot catch a sibling PR that
+(a) targets a different issue but (b) incidentally implements the same feature,
+and (c) merges DURING the 30–90-min pipeline window. The auth surface is
+high-collision; #4633, #4638, #4639 all merged into `app/(auth)` during this
+single session.
+
+## Solution
+
+On a DIRTY conflict during ship, do NOT reflexively resolve conflicts to
+"mine." Instead:
+
+1. `git merge --abort` (get back to a clean tree).
+2. Read `origin/main`'s ACTUAL implementation of the conflicting files —
+   `git show origin/main:<file>` — not just the `<<<<<<<` markers. Ask: "did a
+   sibling PR already implement this feature?"
+3. If main now supersedes the feature: trace main's implementation end-to-end
+   against the original bug to find what (if anything) it still misses. (#4638
+   fixed the existing-user case but deliberately dropped the target for a
+   keyless brand-new invitee — the exact reported case.)
+4. Surface the collision + the residual gap to the operator and get a design
+   decision (the competing approaches had a legal/T&C-timing tradeoff that was
+   not mine to resolve autonomously).
+5. `git reset --hard origin/main` (salvage planning artifacts to /tmp first —
+   the plan/spec live only on the feature branch) and rebuild ONLY the residual
+   delta on top of the sibling's shipped design. The final PR became a 2-file
+   surgical change instead of a 6-file competing rewrite.
+
+## Key Insight
+
+A DIRTY/CONFLICTING merge state where MANY files conflict and the conflicts are
+whole-function competing implementations (not line tweaks) is a signal that a
+sibling shipped your feature — treat it as a "is my PR still needed?" decision,
+not a "resolve the conflict" task. Force-resolving to "mine" would have shipped
+a second, conflicting param convention and overridden a deliberate shipped
+design. Reset-and-rebuild-the-delta is the correct recovery when main
+supersedes; it also keeps the diff small enough for a fast focused re-review.
+
+## Session Errors
+
+1. **Sibling PR #4638 shipped the same feature mid-one-shot → 6-file DIRTY
+   conflict at merge.** — Recovery: abort merge, inspect main's real impl, reset
+   to main, rebuild only the residual keyless-funnel delta. — Prevention: this
+   learning; on DIRTY during ship, diff origin/main against the feature surface
+   and check for supersession before resolving.
+2. **Queued `gh pr merge --auto` while the PR was still a draft** (skipped
+   `gh pr ready`). — Recovery: marked ready, re-queued. — Prevention: ship
+   Phase 6 marks ready before queueing; follow phase order, don't queue merge
+   from the preflight step.

--- a/knowledge-base/project/plans/2026-05-29-fix-invite-accept-workspace-linking-plan.md
+++ b/knowledge-base/project/plans/2026-05-29-fix-invite-accept-workspace-linking-plan.md
@@ -1,0 +1,407 @@
+---
+date: 2026-05-29
+type: fix
+status: draft
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+lane: cross-domain
+branch: feat-one-shot-fix-invite-accept-workspace-linking
+related_brainstorm: knowledge-base/project/brainstorms/2026-05-27-workspace-invite-acceptance-brainstorm.md
+---
+
+# fix: Invite acceptance loses redirect target — new-user signup never joins inviter's workspace 🐛
+
+> **REVISED 2026-05-29 (post-#4638).** While this was in flight, PR #4638
+> ("invited users trip OTP email rate limit on first sign-in") merged to main
+> and implemented most of this fix's redirect threading on the `redirectTo`
+> param: invite links → `/signup?redirectTo=` → `/accept-terms?redirectTo=` →
+> callback `next=` → login `redirectTo`. BUT #4638 deliberately **drops the
+> target for a keyless (brand-new) invitee** — `/api/accept-terms` returns
+> `/setup-key` when the user has no API key (its comment: "the invitee re-opens
+> the invite link post-onboarding"), and `setup-key → connect-repo` was
+> hardcoded. So the EXACT reported case (jean.deruelle, new account, no key)
+> was NOT auto-reconnected. **This branch was reset onto #4638 and now ships
+> only the residual delta** (operator-approved "thread through funnel" option,
+> 2026-05-29): `/api/accept-terms` threads the validated target onto
+> `/setup-key?redirectTo=…`, and `setup-key` carries it to
+> `/connect-repo?return_to=…` (connect-repo's existing terminal consumer). T&C
+> is still recorded BEFORE the invite is accepted (#4638's ordering preserved);
+> the invitee auto-returns to `/invite/<token>` after key + repo setup. The
+> original "land on /invite directly, accept before T&C" design below was NOT
+> taken (it would have accepted the invite before T&C was recorded and
+> conflicted with #4638's shipped `redirectTo` convention).
+
+## Enhancement Summary
+
+**Deepened on:** 2026-05-29
+**Sections enhanced:** Root-Cause Analysis, Acceptance Criteria (AC1-AC3), Files to Edit, Design Decision, Sharp Edges
+**Method:** Direct codebase verification (auth/onboarding flow, existing redirect validator, login-form/signup/oauth components). No SQL/infra/scheduled-job changes → precedent-diff (4.4), network-outage (4.5), PAT-halt (4.8) gates non-applicable. User-Brand Impact (4.6) + Observability (4.7) gates PASS.
+
+### Key Improvements (load-bearing corrections vs. round-1 plan)
+
+1. **AC3 validator is NOT net-new — an existing one exists but is TOO NARROW.** `apps/web-platform/lib/safe-return-to.ts` already implements `safeReturnTo(param)` and rejects open-redirects (absolute, `//`, `\`, `..`). BUT its allowlist is `param.startsWith("/dashboard")` ONLY — it would **reject `/invite/<token>` and silently fall back to `/dashboard`**. The fix MUST widen this allowlist (or add a sibling) to also permit the `/invite/<token>` shape. Naively "reuse the existing validator" would re-break the redirect.
+2. **Param-name drift: `redirectTo` (invite links) vs `return_to` (codebase convention).** `invite-actions.tsx` emits `?redirectTo=…`, but the canonical param across the app is `return_to` (consumed by `connect-repo/page.tsx:461,473,549` via `safeReturnTo`). The fix should standardize on ONE — recommend renaming the invite links to `return_to` to match the existing validator/convention (smaller blast radius than teaching every consumer a second param name).
+3. **THIRD loss point found: login OTP verify.** `components/auth/login-form.tsx:119` does `router.push("/dashboard")` on OTP-verify success — same bug as signup. The **Sign in with the invited account** invite link (`invite-actions.tsx:107`) therefore ALSO drops the target. Round-1 plan listed login as "verify/maybe"; it is confirmed broken.
+4. **OAuth path nuance.** `oauth-buttons.tsx:75` sets Supabase `redirectTo: ${origin}/callback` — that is the *Supabase post-auth callback URL*, NOT the app's internal return target. To preserve the invite through OAuth, the internal target must ride as a query param ON that callback URL (e.g. `${origin}/callback?return_to=/invite/<token>`) and be consumed by `callback/route.ts`.
+5. **Login "no account" bounce drops the target too.** `login-form.tsx:78-85` redirects a no-account email to `/signup?email=…&reason=…` — it must carry `return_to` forward or the invitee who clicks Sign-in-then-gets-bounced-to-signup loses the invite again.
+
+## Overview
+
+A user invited to the `ops@jikigai.com` workspace (`jean.deruelle@gmail.com`) received the
+invite email, opened `/invite/[token]`, clicked **Create an account to join**, completed
+email-OTP signup, signed in — and landed in a brand-new, isolated workspace of his own
+(API-key onboarding → project onboarding → empty dashboard). The invite remained under
+**Pending invites** in the inviter's Team settings; it was never accepted/consumed.
+
+The acceptance RPC (`accept_workspace_invitation`) and the `POST /api/workspace/accept-invite`
+route are **correct and intact** — they were simply **never called**. The new-user path
+loses the `redirectTo=/invite/[token]` parameter, so the freshly-created user is funneled
+straight into their own onboarding instead of being returned to the invite page where the
+Accept button (and thus the RPC) lives.
+
+This is a behavioral fix to the **already-built** invite flow (PR for #4516/#4519). No new
+infrastructure, no schema change, no new vendor surface.
+
+## Root-Cause Analysis (verified against code on this branch)
+
+The `/invite/[token]` page renders, for unauthenticated visitors, two links
+(`apps/web-platform/app/(public)/invite/[token]/invite-actions.tsx:54-73`):
+
+- `/signup?redirectTo=/invite/${token}`
+- `/login?redirectTo=/invite/${token}`
+
+The `redirectTo` query param is **dropped at three independent points** — neither the signup
+page, the login form, nor the auth callback consumes it. A `grep -rn "redirectTo"` across
+`app/(auth)` and `app/(public)` returns **only** the three producer links in
+`invite-actions.tsx` — there is **zero** consumer of `redirectTo` anywhere in the auth or
+onboarding flow. (Note the param-name drift: the app's canonical return param is `return_to`,
+consumed by `safeReturnTo()` in `connect-repo/page.tsx` — the invite links diverge by using
+`redirectTo`, which no validator/consumer reads.)
+
+### Loss point 1 — signup OTP-verify success (email-OTP path; the path the bug report hit)
+
+`apps/web-platform/app/(auth)/signup/page.tsx:68-96` — `handleVerifyOtp` on success does:
+
+```ts
+router.push("/accept-terms");   // line 94 — hardcoded, ignores searchParams.get("redirectTo")
+```
+
+The signup form never reads `redirectTo`. After OTP verify, the user is pushed into the
+onboarding funnel for their **own** new workspace.
+
+### Loss point 2 — auth callback (OAuth / PKCE / magic-link code-exchange path)
+
+`apps/web-platform/app/(auth)/callback/route.ts:53-280` — the `GET` handler exchanges the
+code, calls `ensureWorkspaceProvisioned()` (which **provisions a fresh workspace** for the
+new user, `route.ts:227, 299-371`), then routes through a hardcoded onboarding funnel
+(`/accept-terms` → `/setup-key` → `/connect-repo` → `/dashboard`, `route.ts:229-259`). It
+**never reads any return-destination param** from the request URL. Any invitee who signed up
+via an OAuth provider also loses the invite (the OAuth path lands on `/callback`, not on the
+signup form). Note: `oauth-buttons.tsx:75` sets Supabase's `redirectTo: ${origin}/callback` —
+that is the Supabase post-auth callback URL, NOT an app-internal return target; to survive
+OAuth the internal target must be appended to that callback URL as a query param.
+
+### Loss point 3 — login OTP-verify success (the **Sign in** invite link path)
+
+`apps/web-platform/components/auth/login-form.tsx:119` — `handleVerifyOtp` success does
+`router.push("/dashboard")`, ignoring any return param. The invite's **Sign in with the
+invited account** link (`invite-actions.tsx:107`, `:66`) round-trips through this form and
+loses the target. Additionally, `login-form.tsx:78-85` bounces a no-account email to
+`/signup?email=…&reason=…` and drops the return target there too.
+
+### Why the user got an isolated workspace
+
+`ensureWorkspaceProvisioned()` (`callback/route.ts:299-371`) and/or the `handle_new_user()`
+DB trigger create a `workspaces` row with `workspaces.id = owner_user_id` and a `workspace_members`
+`owner` row for the brand-new user (migration 053 §1.1.7 N2 invariant, cited at
+`callback/route.ts:321-323`). That is correct default behavior for a genuinely new signup —
+but for an **invitee** it is exactly wrong, because the accept RPC was never reached to add
+the user to the **inviter's** workspace. The invite row's `accepted_at` stays NULL, so it
+keeps showing under **Pending invites** (`server/workspace-invitations.ts:78-93` filters on
+`accepted_at IS NULL`).
+
+### What is NOT broken (verified — do not "fix")
+
+- `accept_workspace_invitation` RPC (`migrations/075_workspace_invitations.sql:272+`): locks
+  the row `FOR UPDATE`, checks expiry / already-accepted / already-member, inserts into
+  `workspace_members`, writes the acceptance attestation. Correct.
+- `POST /api/workspace/accept-invite` (`app/api/workspace/accept-invite/route.ts`): CSRF gate,
+  auth gate, invitee-identity gate (user_id OR lower-cased email), maps reasons to statuses.
+  Correct.
+- The authenticated-invitee path (already logged in as the invited email, opens the link):
+  works today — `isIntendedInvitee` is true, the Accept button POSTs the route. The bug is
+  strictly the **new-user / re-auth** path that round-trips through signup/login/callback.
+
+## Research Reconciliation — Spec vs. Codebase
+
+The 2026-05-27 brainstorm (`workspace-invite-acceptance-brainstorm.md`) flagged this exact
+gap as an **unresolved Open Question**, never closed in the shipped PR:
+
+| Brainstorm claim | Codebase reality (this branch) | Plan response |
+|---|---|---|
+| Decision #5: "Non-user invitees: signup + auto-join — `/invite/[token]` → signup flow with token preserved → post-signup callback auto-accepts" | The token is **not** preserved through signup/callback. No callback auto-accept exists. | This is the bug. Fix = thread the return target through signup + callback (and onboarding funnel). |
+| Open Question #1: "Callback route extension — must check for a pending invite token after signup. How should the token be preserved through the OAuth/OTP flow? Likely `redirectTo` query param." | `redirectTo` is produced by `invite-actions.tsx` but consumed **nowhere**. Callback ignores it. | Resolve OQ#1: define a safe internal-redirect contract and consume it in both signup-verify and callback. |
+| Decision #4/RPC: accept requires `accepted_at IS NULL AND ... AND expires_at > now()`, single-use | RPC enforces exactly this; route gates invitee identity | No change to RPC/route — they are correct; only the *call* is missing. |
+
+No external premises to validate beyond the brainstorm (no `#N` blockers cited in the request).
+**Premise Validation:** the invite UI, RPC, and accept route all exist on this branch
+(`git grep` confirmed) — this is a *fix* (behavioral wiring gap), not a *build*.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** an invited teammate creates an account, is
+dropped into an empty isolated workspace, sees onboarding prompts ("Connect your API key",
+"No repo connected"), and never reaches the shared workspace — while the inviter sees the
+invite stuck on "Pending" forever. The flagship multi-user feature appears completely broken
+on first use.
+
+**If this leaks, the user's data/workflow is exposed via:** the redirect-target parameter is
+an **open-redirect / token-routing surface**. If `redirectTo` is consumed without strict
+validation, a crafted `redirectTo=https://evil.example` could phish a freshly-authenticated
+session, or a `redirectTo` pointing at a *different* workspace's invite path could be used to
+mis-route. The accept RPC's invitee-identity gate is the security floor, but the redirect
+consumer MUST be locked to **internal same-origin paths only** (allowlist `/invite/<token>`
+shape, reject absolute URLs, protocol-relative `//host`, and backslash variants).
+
+**Brand-survival threshold:** `single-user incident` — carried forward from the brainstorm
+(`USER_BRAND_CRITICAL=true`). One mis-routed redirect or one invitee landing in the wrong
+workspace is brand-survival territory. **CPO sign-off required at plan time before `/work`.**
+`user-impact-reviewer` runs at review time.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+> **Implementation note (work Phase 0):** `/invite` is in `PUBLIC_PATHS`
+> (`apps/web-platform/lib/routes.ts`) — it has NO T&C / auth funnel gate. A
+> freshly-authenticated invitee can therefore land on `/invite/<token>`
+> **directly** post-auth and click Accept; T&C is enforced by middleware only
+> when they subsequently enter `/dashboard*`. This makes the plan's
+> "carry-forward through the onboarding funnel" (accept-terms/setup-key edits)
+> **unnecessary** — the smaller, correct fix threads the validated `return_to`
+> through the three auth-completion points (signup-verify, login-verify,
+> callback) + the OAuth callback URL, and lets the invitee reach the existing
+> Accept button directly. `accept-terms` / `setup-key` are left untouched.
+> **Decision: Option A (land-on-invite-page, explicit Accept)** — per CTO/CPO
+> assessment in Domain Review.
+
+- [x] **AC1 — Signup OTP verify preserves return target.** `signup/page.tsx` `handleVerifyOtp`
+  success redirects to a **validated** `redirectTo` (internal-path only) when present, else
+  `/accept-terms` as today. Verify: `grep -n "redirectTo" app/(auth)/signup/page.tsx` shows
+  the param is read and passed to a validator before any `router.push`.
+- [x] **AC2 — Callback preserves return target through the onboarding funnel.** The auth
+  callback (`callback/route.ts`) reads a validated return target and, when the user has
+  completed the mandatory gates (T&C accepted), redirects to it instead of `/dashboard`;
+  when a gate is still pending (`/accept-terms`/`/setup-key`/`/connect-repo`), the target is
+  **carried forward** (re-appended) so it survives the funnel. Verify by branch test in
+  `test/app/auth/callback-route-branches.test.ts`.
+- [x] **AC3 — Redirect-target validation reuses + widens the existing validator.** The
+  canonical validator already exists at `apps/web-platform/lib/safe-return-to.ts`
+  (`safeReturnTo(param)`) and already rejects absolute URLs, protocol-relative (`//`),
+  backslash (`\`), and `..`. Its allowlist is currently `param.startsWith("/dashboard")` ONLY
+  — which **rejects `/invite/<token>` and falls back to `/dashboard`**. Widen the allowlist to
+  also accept the `/invite/<token>` shape (e.g. `/invite/` prefix with a safe token charset),
+  keeping all existing rejection vectors. Do NOT add a parallel validator. Unit test
+  (`safe-return-to.test.ts`) must cover: valid `/dashboard*`, valid `/invite/<token>`,
+  `https://evil`, `//evil`, `/\evil`, `\\evil`, `/invite/../dashboard` → each maps to the
+  expected accept/reject. Verify: `grep -n "/invite" apps/web-platform/lib/safe-return-to.ts`
+  shows the widened allowlist.
+- [ ] **AC4 — New-user invitee becomes a member.** End-to-end (or integration-with-mocks, NOT
+  against prod per `hr-dev-prd-distinct-supabase-projects`): invited email → `/invite/[token]`
+  → signup → OTP verify → lands back on `/invite/[token]` authenticated as the invitee →
+  Accept → `accept_workspace_invitation` is invoked → `workspace_members` gains a row for the
+  invitee in the **inviter's** workspace → invite `accepted_at` is set → it disappears from
+  Pending. Assert the RPC-call / membership-row shape, not just an HTTP 200.
+- [x] **AC5 — Auto-accept vs. land-on-page decision is explicit.** The plan/work must choose
+  ONE and document it (see "Design Decision" below). If auto-accept-on-callback is chosen,
+  AC4's "Accept click" step is replaced by "callback invokes accept and redirects to
+  `/dashboard/settings/team`"; the invitee-identity gate (email match) MUST still hold inside
+  the auto-accept path.
+- [x] **AC6 — Existing authenticated-invitee path unchanged.** The already-logged-in-as-invitee
+  happy path still works (regression guard): `test/invite-actions-gating.test.tsx` and any
+  accept-route test stay green.
+- [x] **AC7 — Onboarding funnel still fires for genuine new signups.** A non-invitee new
+  signup (no `redirectTo`) still goes `/accept-terms` → `/setup-key` → `/connect-repo` →
+  `/dashboard`. No `redirectTo` ⇒ identical behavior to today.
+
+### Post-merge (operator)
+
+- [ ] **AC8 — Live verification (automatable, NOT a manual checklist).** Re-run the original
+  scenario via Playwright MCP against the dev environment OR re-invite a synthetic dev-only
+  address and confirm membership lands. `Automation: feasible` via `mcp__playwright__*` +
+  `mcp__plugin_supabase_supabase__*` (read `workspace_members` for the new row). Must run
+  against **dev**, never prod.
+
+## Design Decision (resolve in plan-review / work Phase 0)
+
+Two valid fixes; pick one and record the rationale:
+
+- **Option A — Land back on `/invite/[token]`, user clicks Accept (minimal).** Thread a
+  validated `redirectTo` through signup-verify + callback (+ funnel carry-forward). The
+  invitee returns to the invite page authenticated and matched; the existing Accept button
+  POSTs the route. Smallest diff; reuses the entire existing accept path; the user makes an
+  explicit consent click (good for the WORM acceptance attestation). **Recommended.**
+- **Option B — Auto-accept in the callback.** Callback detects the pending-invite token,
+  calls `acceptWorkspaceInvitation` server-side after the identity gate, redirects to the
+  team page. Fewer clicks, but moves the consent act out of an explicit UI action (attestation
+  semantics — see brainstorm Open Question #2), and adds an accept call-site that must
+  duplicate the invitee-identity gate. More surface, more review cost.
+
+**Lean Option A** unless plan-review/CPO prefers the zero-click UX. Either way, the
+return-target validator (AC3) is mandatory.
+
+## Files to Edit
+
+- `apps/web-platform/lib/safe-return-to.ts` — **widen the allowlist** to accept `/invite/<token>`
+  in addition to `/dashboard*`, preserving every existing rejection vector (`//`, `\`, `..`,
+  absolute). This is the single security-critical edit.
+- `apps/web-platform/lib/safe-return-to.test.ts` (exists? grep — add if absent) — add
+  `/invite/<token>` accept + reject-vector cases (AC3).
+- `apps/web-platform/app/(public)/invite/[token]/invite-actions.tsx` — standardize the link
+  param from `redirectTo` to `return_to` (3 links: `:58`, `:66`, `:107`) to match the codebase
+  convention + the validator's consumer.
+- `apps/web-platform/app/(auth)/signup/page.tsx` — read `return_to` via `useSearchParams`,
+  pass through `safeReturnTo`, use it in `handleVerifyOtp` success instead of the hardcoded
+  `/accept-terms` (loss point 1).
+- `apps/web-platform/components/auth/login-form.tsx` — read `return_to`, validate, use it in
+  `handleVerifyOtp` success instead of hardcoded `router.push("/dashboard")` (`:119`, loss
+  point 3); carry `return_to` forward on the no-account → `/signup` bounce (`:78-85`).
+- `apps/web-platform/components/auth/oauth-buttons.tsx` — append the validated `return_to` to
+  the Supabase `redirectTo` callback URL (`:75`) so it survives the OAuth round-trip.
+- `apps/web-platform/app/(auth)/callback/route.ts` — read + validate `return_to` from the
+  request URL; redirect to it after all mandatory gates pass (instead of `/dashboard`); carry
+  it forward when funneling to `/accept-terms`/`/setup-key`/`/connect-repo` (loss point 2).
+- **(Option B only)** `apps/web-platform/server/workspace-invitations.ts` /
+  `callback/route.ts` — add a guarded server-side accept call (must re-apply the invitee-email
+  identity gate).
+- The accept-terms / setup-key / connect-repo onboarding pages — **only if** they perform
+  their own post-completion `router.push` that would drop the carried-forward `return_to`.
+  `connect-repo/page.tsx` already consumes `return_to` via `safeReturnTo` (`:461,473,549`) —
+  read it to confirm it forwards rather than hardcodes; check accept-terms + setup-key the
+  same way and list any that need the carry-forward threaded.
+
+## Files to Create
+
+- `apps/web-platform/lib/safe-return-to.test.ts` — unit test for AC3 vectors if the file does
+  not already exist (grep first). Cases: valid `/dashboard*`, valid `/invite/<token>`,
+  `https://evil`, `//evil`, `/\evil`, `\\evil`, `/invite/../dashboard`. (Runner per
+  `package.json scripts.test` — vitest expected; verify at work time.)
+- `apps/web-platform/test/.../invite-new-user-join.test.ts` — AC4 integration test
+  (mocked Supabase; asserts membership row + `accepted_at` set + invite leaves Pending).
+
+## Open Code-Review Overlap
+
+To be populated at work time: run
+`gh issue list --label code-review --state open --json number,title,body --limit 200`
+and `jq` each file path in **Files to Edit** against the bodies. Record matches + disposition
+(fold-in / acknowledge / defer), or `None`.
+
+## Hypotheses
+
+(No network-outage trigger pattern — skipped.) Primary hypothesis is **confirmed by code
+reading**, not speculative: the `redirectTo` param has zero consumers in the auth/onboarding
+flow. The only open question is Option A vs B and whether login + onboarding pages need the
+carry-forward (resolved by reading those files at work Phase 0).
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "POST /api/workspace/accept-invite 200 + new workspace_members row for invitee"
+  cadence: per-acceptance (event-driven, not periodic)
+  alert_target: "Sentry — existing reportSilentFallback path in accept-invite route on RPC failure"
+  configured_in: "app/api/workspace/accept-invite/route.ts (existing reason->status map) + server/workspace-invitations.ts log.error"
+error_reporting:
+  destination: "Sentry via reportSilentFallback / warnSilentFallback (existing observability module)"
+  fail_loud: "callback redirect-validator rejection MUST emit warnSilentFallback (feature: auth, op: redirect_target_rejected) so a phishing-attempt redirect is visible, not silently dropped"
+failure_modes:
+  - mode: "redirectTo dropped (regression of this fix)"
+    detection: "invite-new-user-join integration test (AC4) goes red; invite stays Pending"
+    alert_route: "CI test failure (pre-merge)"
+  - mode: "redirectTo points at non-invite/cross-origin target"
+    detection: "validator rejects + warnSilentFallback op=redirect_target_rejected"
+    alert_route: "Sentry auth-feature alert"
+  - mode: "accept RPC fails after redirect lands (expired/already-member)"
+    detection: "accept-invite route returns 404/409; reason mapped; client shows humanized copy"
+    alert_route: "Sentry (RPC error) + UI error box"
+logs:
+  where: "pino child logger 'workspace-invitations' + auth callback structured logs"
+  retention: "per existing Better Stack / pino sink policy (unchanged)"
+discoverability_test:
+  command: "grep -rln redirectTo apps/web-platform/app/api/accept-terms"
+  expected_output: "route.ts"
+```
+
+## Domain Review
+
+**Domains relevant:** Engineering, Product, Legal
+
+### Engineering (CTO)
+
+**Status:** reviewed (plan-author assessment; spawn leader at deepen-plan if depth warranted)
+**Assessment:** Fix is a wiring gap, not an architectural change. Risk concentrated in the
+redirect-target validator (open-redirect class). The validator already exists
+(`lib/safe-return-to.ts`) but its allowlist is `/dashboard`-only and silently rejects
+`/invite/<token>` — widening it (preserving all reject vectors) is the security-critical edit.
+Three drop points (signup-verify, login-verify, callback) all hardcode their destination;
+plus the OAuth callback-URL append and the login no-account bounce. Carry-forward through the
+onboarding funnel is the common case for a new invitee (no T&C/key/repo yet), not an edge case.
+Prefer Option A (smaller surface, reuses accept path, preserves explicit consent click for the
+WORM attestation).
+
+### Product (CPO)
+
+**Status:** requires sign-off (threshold = single-user incident; `requires_cpo_signoff: true`)
+**Assessment:** This is the flagship multi-user onboarding moment failing on first use.
+Option A (land-on-page, explicit Accept) vs Option B (zero-click auto-accept) is a product
+call — Option A keeps an explicit consent act (better for attestation + clarity) at the cost
+of one click. CPO must sign off on the chosen option before `/work`.
+
+### Legal (CLO)
+
+**Status:** reviewed
+**Assessment:** No new data surface. The acceptance attestation (WORM
+`workspace_member_attestations`) already captures consent at accept time. If Option B
+(auto-accept) is chosen, confirm the attestation still records an affirmative acceptance act
+(brainstorm Open Question #2). GDPR gate (Phase 2.7) applies because the flow touches auth +
+membership; no new processing activity beyond what #4519 already registered. Run
+`/soleur:gdpr-gate` against the diff at work Phase 2 exit.
+
+## Test Scenarios
+
+1. New invitee, email-OTP: invite → signup → OTP verify → returns to `/invite/[token]`
+   authenticated + matched → Accept → member of inviter's workspace; invite no longer Pending.
+2. New invitee, OAuth provider: same end state via the callback path.
+3. Existing-user invitee using **Sign in** link: returns to invite page + accepts.
+4. Genuine new signup, no invite: onboarding funnel unchanged, own workspace.
+5. Hostile `redirectTo`: `https://evil.example`, `//evil.example`, `/\evil.example`,
+   `\\evil.example` → all rejected → safe default; `warnSilentFallback` emitted.
+6. Email mismatch: signed-in account ≠ invited email → invitee-identity gate blocks accept
+   (existing 403 path), neutral mismatch copy shown.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder
+  text, or omits the threshold will fail `deepen-plan` Phase 4.6. (Filled above.)
+- **The existing `safeReturnTo()` validator silently rejects `/invite/<token>`** (allowlist is
+  `/dashboard`-only). The single most likely fix-mistake is "reuse the existing validator" →
+  every invite redirect falls back to `/dashboard` and the bug persists in a new disguise.
+  Widening the allowlist (AC3) is mandatory and is the security-critical edit — the widened
+  pattern must still reject `/invite/../dashboard` and any non-`/invite` / non-`/dashboard`
+  path.
+- **Param-name drift:** invite links use `redirectTo`; the validator + every other consumer
+  use `return_to`. Pick `return_to` (the convention) and rename the 3 invite links — do not
+  teach consumers a second param name.
+- Carry-forward is the easy-to-miss half: fixing only the final callback redirect but not the
+  intermediate funnel hops (`/accept-terms`/`/setup-key`/`/connect-repo`) leaves the target
+  dropped for any invitee who hasn't yet accepted T&C or set a key. Trace the full funnel
+  before claiming the fix complete. The new-user invitee ALWAYS hits the funnel (no T&C, no
+  key, no repo) — so the carry-forward path is the common case, not the edge case.
+- The OAuth path's `redirectTo` (`oauth-buttons.tsx:75`) is the *Supabase callback URL*, not
+  the app's return target — do not conflate them. The return target rides as a query param on
+  that callback URL.
+- AC4 must run against **dev**, never prod (`hr-dev-prd-distinct-supabase-projects`) — creating
+  synthetic invitee/`workspace_members` rows in prod leaves DSAR/billing residue.
+- Test runner: the package uses **vitest** (per the `bunfig.toml` `pathIgnorePatterns` note in
+  AGENTS.md Sharp Edges) — confirm via `package.json scripts.test` at work time; do not assume
+  `bun test`.

--- a/knowledge-base/project/specs/feat-one-shot-fix-invite-accept-workspace-linking/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-invite-accept-workspace-linking/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-05-29-fix-invite-accept-workspace-linking-plan.md
+- Status: complete
+
+### Errors
+None. CWD verified against the worktree path on first tool call. Branch is the feature branch (not main). All three deepen-plan mandatory gates passed (4.6 User-Brand Impact, 4.7 Observability, 4.8 PAT-halt).
+
+### Decisions
+- Root cause confirmed by code reading: new-user invite path drops the return-to target at three points — `signup/page.tsx:94` (hardcoded `router.push("/accept-terms")`), `login-form.tsx:119` (hardcoded `/dashboard`), and `callback/route.ts` (never reads any return param, funnels through onboarding + provisions a fresh workspace). So `accept_workspace_invitation` is never called → invitee gets isolated workspace, invite stays Pending. The accept RPC and `/api/workspace/accept-invite` route are correct but never reached.
+- Validator `lib/safe-return-to.ts` `safeReturnTo()` already exists but allowlist is `/dashboard`-only and would silently reject `/invite/<token>`. Plan mandates widening that validator (the single security-critical edit), not adding a parallel one. Flags "naive reuse" as the most likely fix-mistake.
+- Param-name drift: invite links emit `?redirectTo=` while codebase convention + validator use `return_to`. Plan standardizes on `return_to`.
+- OAuth + no-account nuances captured: `oauth-buttons.tsx:75` `redirectTo` is the Supabase callback URL (must append `return_to` to it); login no-account → `/signup` bounce also drops the target.
+- Threshold `single-user incident`; `requires_cpo_signoff: true`; redirect surface treated as open-redirect/phishing vector with mandatory reject-vector tests. Option A (land-on-invite-page, explicit Accept) recommended over Option B (auto-accept) pending CPO sign-off.
+
+### Components Invoked
+- Skill: soleur:plan
+- Skill: soleur:deepen-plan
+- Bash, Read, Write, Edit

--- a/knowledge-base/project/specs/feat-one-shot-fix-invite-accept-workspace-linking/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-invite-accept-workspace-linking/tasks.md
@@ -1,0 +1,45 @@
+---
+feature: feat-one-shot-fix-invite-accept-workspace-linking
+lane: cross-domain
+plan: knowledge-base/project/plans/2026-05-29-fix-invite-accept-workspace-linking-plan.md
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+---
+
+# Tasks — Fix invite-accept → workspace-membership linking
+
+Derived from the finalized plan. The bug: the new-user invite path drops the
+return-to target at three points, so `accept_workspace_invitation` is never called —
+the invitee gets an isolated new workspace and the invite stays Pending.
+
+## Phase 0 — Preconditions (read before editing)
+
+- [ ] 0.1 Confirm CPO sign-off on Option A vs Option B (plan requires_cpo_signoff). Default: Option A (land-on-invite-page, explicit Accept).
+- [ ] 0.2 Confirm test runner: `cat apps/web-platform/package.json | grep -A2 '"test"'` (expect vitest).
+- [ ] 0.3 Read `apps/web-platform/lib/safe-return-to.ts` (validator), `connect-repo/page.tsx` `return_to` usage (`:461,473,549`), `accept-terms` + `setup-key` page post-completion pushes — confirm which forward `return_to` and which hardcode.
+- [ ] 0.4 `gh issue list --label code-review --state open --json number,title,body --limit 200` and jq each Files-to-Edit path → record overlap disposition in plan.
+
+## Phase 1 — Validator (security-critical, RED first)
+
+- [ ] 1.1 Write failing `safe-return-to.test.ts`: assert valid `/dashboard*`, valid `/invite/<token>`, and reject `https://evil`, `//evil`, `/\evil`, `\\evil`, `/invite/../dashboard`.
+- [ ] 1.2 Widen `safeReturnTo()` allowlist to accept `/invite/<token>` shape (safe token charset), keeping all existing rejection vectors. Make 1.1 green.
+
+## Phase 2 — Producer/consumer wiring
+
+- [ ] 2.1 Rename invite links `redirectTo` → `return_to` in `invite-actions.tsx` (`:58`, `:66`, `:107`).
+- [ ] 2.2 `signup/page.tsx` `handleVerifyOtp`: read `return_to`, `safeReturnTo()`, redirect there instead of hardcoded `/accept-terms` (loss point 1).
+- [ ] 2.3 `login-form.tsx` `handleVerifyOtp` (`:119`): same treatment instead of hardcoded `/dashboard` (loss point 3). Carry `return_to` forward on the no-account → `/signup` bounce (`:78-85`).
+- [ ] 2.4 `oauth-buttons.tsx` (`:75`): append validated `return_to` to the Supabase `${origin}/callback` URL.
+- [ ] 2.5 `callback/route.ts`: read + validate `return_to`; redirect there after gates pass (instead of `/dashboard`); carry it forward when funneling to `/accept-terms`/`/setup-key`/`/connect-repo` (loss point 2).
+- [ ] 2.6 Onboarding pages (accept-terms / setup-key / connect-repo): thread carry-forward `return_to` ONLY where a post-completion push would drop it (per 0.3 findings).
+
+## Phase 3 — Tests + verification
+
+- [ ] 3.1 AC4 integration test `invite-new-user-join.test.ts` (mocked Supabase): invite → signup → verify → return to `/invite/<token>` → Accept → `workspace_members` row in inviter's workspace + `accepted_at` set + invite leaves Pending. Assert RPC-call/row shape, not just HTTP 200.
+- [ ] 3.2 Regression: `invite-actions-gating.test.tsx`, accept-invite route test, `callback-route-branches.test.ts`, no-redirectTo new-signup funnel all green (AC6, AC7).
+- [ ] 3.3 Observability: callback validator rejection emits `warnSilentFallback(op: redirect_target_rejected)`.
+- [ ] 3.4 Run `/soleur:gdpr-gate` against the diff (Phase 2 exit). Run full `package.json scripts.test`.
+
+## Phase 4 — Post-merge (operator, automatable)
+
+- [ ] 4.1 AC8 live verification on **dev** (never prod): Playwright MCP re-run of the invite scenario + Supabase MCP read of `workspace_members` for the new row. `Automation: feasible`.

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -1060,6 +1060,7 @@ gh pr view --json mergeable,mergeStateStatus | jq '{mergeable, mergeStateStatus}
 3. Read each conflicted file and resolve. Common conflict patterns:
    - **Component counts**: Use the feature branch count (it includes the new additions)
    - **Code conflicts**: Resolve based on intent of both changes
+   - **Many files conflict with whole-function (not line-level) competing implementations**: a sibling PR may have shipped your feature mid-pipeline (the one-shot collision gate only probes at START and misses a sibling that implements the same feature under a *different* issue). Do NOT reflexively resolve to "mine." `git merge --abort`, read `origin/main`'s ACTUAL implementation (`git show origin/main:<file>`), and decide "is my PR still needed?" If main supersedes it, trace main end-to-end against the original bug for any residual gap, surface the collision + gap to the operator for a design call, then `git reset --hard origin/main` (salvage plan/spec to /tmp first — they live only on the branch) and rebuild ONLY the residual delta. **Why:** PR #4641 — #4638 shipped the same invite-redirect feature mid-one-shot; reset-and-rebuild turned a 6-file competing rewrite into a 2-file delta. See `knowledge-base/project/learnings/workflow-patterns/2026-05-29-dirty-conflict-during-ship-may-mean-sibling-shipped-your-feature.md`.
 
 4. Stage resolved files and commit the merge:
 


### PR DESCRIPTION
## Summary

The reported bug: a new user invited to a workspace accepts, creates an account, signs in — and lands in their **own empty workspace** while the invite stays `Pending` (the `accept_workspace_invitation` RPC was never reached).

Root cause was a dropped `/invite/<token>` return target. **PR #4638 (merged while this was in flight)** wired the target through signup → `/accept-terms?redirectTo=` → callback `next=` → login, which fixes the **existing-user** case — but it *deliberately* drops the target for a brand-new **keyless** invitee (`/api/accept-terms` returns `/setup-key`, and `setup-key → connect-repo` was hardcoded), so the exact reported case (new account, no API key) still wasn't auto-reconnected.

This PR closes that residual gap by threading the validated target through the keyless funnel, **preserving #4638's T&C-first ordering**.

Plan: `knowledge-base/project/plans/2026-05-29-fix-invite-accept-workspace-linking-plan.md`

## User-Brand Impact

- **Artifact:** the post-onboarding redirect destination for a brand-new invitee + their `workspace_members` membership.
- **Vector:** open-redirect / phishing if the carried target were unvalidated; cross-workspace mis-routing.
- **Mitigation:** every hop re-validates through `safeReturnTo()` (rejects absolute / `//` / `\` / `..` on raw + percent-decoded; allowlist `/dashboard` + `/invite/`); a rejected value is never threaded (no `?redirectTo=`/`?return_to=`); the accept RPC's invitee-email identity gate is the unchanged security floor. T&C is recorded **before** the invite can be accepted.
- **Brand-survival threshold:** `single-user incident`

## Changelog

### Web Platform
- `/api/accept-terms`: for a keyless user, thread the validated invite target onto `/setup-key?redirectTo=<target>` instead of dropping it (was bare `/setup-key`).
- `setup-key`: carry the validated target to `/connect-repo?return_to=<target>` (connect-repo's existing terminal consumer) so a new invitee auto-returns to `/invite/<token>` after key + repo setup.

### Plugin
- `ship` skill: Phase 6.5 bullet on recognizing a sibling-shipped-feature DIRTY conflict (reset-and-rebuild-the-delta).

## Test plan
- [x] `/api/accept-terms`: keyless+target carries `?redirectTo=`; keyless+no-target → bare `/setup-key`; keyless+open-redirect → rejected (no `redirectTo=`, no off-origin); keyed paths unchanged
- [x] `setup-key`: carries target → `/connect-repo?return_to=`; bare when absent; drops open-redirect
- [x] Full web-platform suite green (7384 passed, 0 failures); tsc clean
- [x] Focused review: security-sentinel CLEAN (open-redirect safe, T&C ordering preserved), test-design B
- [ ] Post-merge: re-run the invite→signup→onboard flow against dev via Playwright; confirm the `workspace_members` row lands and the invite leaves Pending

Generated with [Claude Code](https://claude.com/claude-code)