### PR TITLE
fix(test): backdate revocation-probe iat to absorb GoTrue↔Postgres clock skew

### DIFF
--- a/apps/web-platform/test/server/workspace-member-revocation.tenant-isolation.test.ts
+++ b/apps/web-platform/test/server/workspace-member-revocation.tenant-isolation.test.ts
@@ -48,7 +48,7 @@ const INTEGRATION_ENABLED = process.env.TENANT_INTEGRATION_TEST === "1";
 // "JWT issued well before removal" case and absorbs cross-service skew up to
 // this many seconds. The strict-`>` boundary itself stays covered by 3.2.3,
 // which derives both iat probes from the DB-written revoked_after (one clock).
-const REVOCATION_IAT_SKEW_BUFFER_SEC = 30;
+const PROBE_IAT_BACKDATE_SEC = 30;
 
 function requireEnv(name: string): string {
   const value = process.env[name];
@@ -190,9 +190,9 @@ describe.skipIf(!INTEGRATION_ENABLED)(
       const bClient = clientWithJwt(url, anonKey, bJwtPre);
       // Backdate by the skew buffer so revoked_after (Postgres clock) is
       // reliably > the probed iat regardless of GoTrue↔Postgres skew. See
-      // REVOCATION_IAT_SKEW_BUFFER_SEC.
+      // PROBE_IAT_BACKDATE_SEC.
       const iatIso = new Date(
-        (bIatPre - REVOCATION_IAT_SKEW_BUFFER_SEC) * 1000,
+        (bIatPre - PROBE_IAT_BACKDATE_SEC) * 1000,
       ).toISOString();
       const { data: revoke, error: revokeErr } = await bClient.rpc(
         "check_my_revocation",
@@ -217,9 +217,9 @@ describe.skipIf(!INTEGRATION_ENABLED)(
       const bClient = clientWithJwt(url, anonKey, bJwtPre);
       // Backdate by the skew buffer so revoked_after (Postgres clock) is
       // reliably > the probed iat regardless of GoTrue↔Postgres skew. See
-      // REVOCATION_IAT_SKEW_BUFFER_SEC.
+      // PROBE_IAT_BACKDATE_SEC.
       const iatIso = new Date(
-        (bIatPre - REVOCATION_IAT_SKEW_BUFFER_SEC) * 1000,
+        (bIatPre - PROBE_IAT_BACKDATE_SEC) * 1000,
       ).toISOString();
       const { data: revoke } = await bClient.rpc("check_my_revocation", {
         p_jwt_iat: iatIso,

--- a/apps/web-platform/test/server/workspace-member-revocation.tenant-isolation.test.ts
+++ b/apps/web-platform/test/server/workspace-member-revocation.tenant-isolation.test.ts
@@ -35,6 +35,21 @@ import {
 
 const INTEGRATION_ENABLED = process.env.TENANT_INTEGRATION_TEST === "1";
 
+// `bIatPre` is the second-precision `iat` of B's pre-removal JWT, set by
+// Supabase GoTrue's clock. `check_my_revocation` compares it (strict `>`)
+// against `workspace_member_removals.revoked_after`, set by the Postgres
+// clock. Those are two independently-NTP'd Supabase services: under the
+// concurrent load of the full `*.tenant-isolation.test.ts` run, the Postgres
+// clock can lag GoTrue's by more than the (~1-2s) mint→remove gap, making
+// `revoked_after <= floor(iat)` and flipping the positive-control assertion
+// to `revoked: false` (green in isolation, red under the full CI run — #4660
+// merge exposed it once byok ran to completion instead of failing fast).
+// Backdating the iat the positive-control probes pass models the realistic
+// "JWT issued well before removal" case and absorbs cross-service skew up to
+// this many seconds. The strict-`>` boundary itself stays covered by 3.2.3,
+// which derives both iat probes from the DB-written revoked_after (one clock).
+const REVOCATION_IAT_SKEW_BUFFER_SEC = 30;
+
 function requireEnv(name: string): string {
   const value = process.env[name];
   if (!value) throw new Error(`[wm-revocation] ${name} is required`);
@@ -173,7 +188,12 @@ describe.skipIf(!INTEGRATION_ENABLED)(
 
       // B's pre-removal JWT should now be flagged revoked.
       const bClient = clientWithJwt(url, anonKey, bJwtPre);
-      const iatIso = new Date(bIatPre * 1000).toISOString();
+      // Backdate by the skew buffer so revoked_after (Postgres clock) is
+      // reliably > the probed iat regardless of GoTrue↔Postgres skew. See
+      // REVOCATION_IAT_SKEW_BUFFER_SEC.
+      const iatIso = new Date(
+        (bIatPre - REVOCATION_IAT_SKEW_BUFFER_SEC) * 1000,
+      ).toISOString();
       const { data: revoke, error: revokeErr } = await bClient.rpc(
         "check_my_revocation",
         { p_jwt_iat: iatIso },
@@ -195,7 +215,12 @@ describe.skipIf(!INTEGRATION_ENABLED)(
       // context, regardless of current_organization_id.
       const userB = fixtureX.members[1];
       const bClient = clientWithJwt(url, anonKey, bJwtPre);
-      const iatIso = new Date(bIatPre * 1000).toISOString();
+      // Backdate by the skew buffer so revoked_after (Postgres clock) is
+      // reliably > the probed iat regardless of GoTrue↔Postgres skew. See
+      // REVOCATION_IAT_SKEW_BUFFER_SEC.
+      const iatIso = new Date(
+        (bIatPre - REVOCATION_IAT_SKEW_BUFFER_SEC) * 1000,
+      ).toISOString();
       const { data: revoke } = await bClient.rpc("check_my_revocation", {
         p_jwt_iat: iatIso,
       });

--- a/knowledge-base/project/learnings/2026-05-30-shared-live-db-integration-test-cross-service-clock-skew-flake.md
+++ b/knowledge-base/project/learnings/2026-05-30-shared-live-db-integration-test-cross-service-clock-skew-flake.md
@@ -1,0 +1,27 @@
+---
+title: "Shared-live-DB integration tests comparing a GoTrue-clock JWT iat against a Postgres-clock timestamp flake under concurrent load"
+date: 2026-05-30
+category: test-failures
+tags: [tenant-isolation, integration-tests, clock-skew, supabase, gotrue, postgres, flaky-test, check_my_revocation]
+pr: 4664
+---
+
+# Cross-service clock-skew flake in shared-live-DB integration tests
+
+## Problem
+
+`tenant-integration.yml` ran `*.tenant-isolation.test.ts` against live dev-Supabase, all files concurrently (vitest default file parallelism). `workspace-member-revocation.tenant-isolation.test.ts` (#4307) passed in isolation and on every prior main run, but flaked red (`expected false to be true`, `revoked:false`) on the post-merge run for the #4660 fix — the moment the byok integration test started passing (running to completion, adding concurrent DB load) instead of failing fast.
+
+## Root Cause
+
+Tests 3.2.1/3.2.2 mint user B's JWT (`iat` set by **Supabase GoTrue**, the Auth server, **second-precision**), remove B (writing `workspace_member_removals.revoked_after = now()`, set by the **Postgres** clock), then call `check_my_revocation(p_jwt_iat)` whose predicate is `revoked_after > p_jwt_iat` (strict, mig 067:87). GoTrue and Postgres are independently-NTP'd Supabase services. Under concurrent load the Postgres clock can lag GoTrue's by more than the ~1-2s mint→remove gap, making `revoked_after <= floor(iat)` → the RPC's `NOT FOUND` branch fires → `revoked:false`. The removal row provably exists (the `toHaveLength(1)` assertion passes first), so the only failure path is the cross-clock timestamp comparison.
+
+The suite's *own* clock-skew test (3.2.3) was already robust: it derives both iat probes from the DB-written `revoked_after` — staying on **one clock** — and so has no cross-service skew to absorb. Only the positive-control tests used the raw GoTrue-minted iat against the DB clock.
+
+## Solution
+
+Backdate the iat the positive-control probes pass by a 30s `PROBE_IAT_BACKDATE_SEC` buffer (test-only). This models the realistic "JWT issued well before removal" case and absorbs cross-service skew. The production `check_my_revocation` RPC and its deliberate strict-`>` fail-safe design are untouched; the boundary stays covered by 3.2.3. The backdate is provably safe: `revoked_after > iat` is monotone in the backdate direction, so a smaller iat can only flip a row toward `revoked=true` (the asserted direction) — it can never manufacture a false pass, and the same-iat negative control (owner A → `revoked=false`) proves the RPC still discriminates.
+
+## Key Insight
+
+**Live-DB integration tests that share one database and run concurrently must not compare a value stamped by one service's clock against a value stamped by another's with a strict, near-now boundary.** The two canonical fixes: (1) derive both sides of the comparison from a single clock (read the DB-written timestamp, probe relative to it — what 3.2.3 does), or (2) widen the gap with a deliberate buffer so sub-second / ±N-second cross-service skew can't cross the boundary (what the positive-control fix does). A test that's green in isolation but red under the full concurrent suite is the signature — the load doesn't change the logic, it widens the skew window. Relatedly: such a flake can stay *hidden* behind an unrelated failing test in the same suite (here byok failed fast, masking the latent skew flake) and surface only when the masking failure is fixed. See [[2026-05-30-rpc-precondition-gate-drifts-live-db-integration-fixtures]] for the byok fix that exposed this.


### PR DESCRIPTION
## Summary

`workspace-member-revocation.tenant-isolation.test.ts` (#4307) flaked red on the post-merge `tenant-integration.yml` run for f00e3d7 (the #4660 merge), failing 3.2.1 + 3.2.2 with `expected false to be true`. It passes in isolation and passed on every prior main run — it broke only once #4660's fix made the byok integration test run to completion (adding concurrent load) instead of failing fast.

**Root cause:** 3.2.1/3.2.2 compare B's GoTrue-minted JWT `iat` (Auth-server clock, second-precision) against `workspace_member_removals.revoked_after` (Postgres clock) through `check_my_revocation`'s strict `>`. These are two independently-NTP'd Supabase services. Under concurrent load the Postgres clock can lag GoTrue's by more than the ~1-2s mint→remove gap, making `revoked_after <= floor(iat)` → `check_my_revocation` hits its NOT-FOUND branch → `revoked:false`. (The removal row provably exists — line 170's `toHaveLength(1)` passes — so the only failure path is the timestamp comparison.)

**Fix (test-only):** backdate the iat the positive-control probes pass by a 30s skew buffer, modeling the realistic "JWT issued well before removal" case. The production `check_my_revocation` RPC and its deliberate strict-`>` fail-safe design are untouched; the strict-`>` boundary stays covered by 3.2.3, which derives both iat probes from the DB-written `revoked_after` (single clock — already robust).

## Changelog

### Web Platform
- Fix flaky `workspace-member-revocation.tenant-isolation.test.ts` positive-control assertions (3.2.1/3.2.2) by absorbing GoTrue↔Postgres clock skew in the probed iat.

## Test plan
- [x] `wmr + byok` run concurrently under `TENANT_INTEGRATION_TEST=1` → 20/20 pass
- [x] `./node_modules/.bin/tsc --noEmit` → clean
- [ ] Post-merge: `tenant-integration.yml` green on first push to main (the load-bearing confirmation)

Context: surfaced during the #4660 / PR #4661 post-merge verification.

Generated with [Claude Code](https://claude.com/claude-code)