### PR TITLE
fix(test): stop doppler-dev env leak from flaking webplat unit tests

### DIFF
--- a/apps/web-platform/test/mu1-integration.test.ts
+++ b/apps/web-platform/test/mu1-integration.test.ts
@@ -199,7 +199,20 @@ if (AC2_HAS_REPO_URL !== AC2_HAS_INSTALL_ID) {
 // GitHub installation ids fit in i32; cap at 10 digits (~10B) for headroom.
 const INSTALLATION_ID_RE = /^[1-9][0-9]{0,9}$/;
 
-describe.skipIf(!AC2_HAS_REPO_URL || !AC2_HAS_INSTALL_ID)(
+// AC-2 mints a LIVE GitHub installation token to clone the fixture repo, so it
+// requires an explicit opt-in (MU1_INTEGRATION=1) like the AC-1 block above —
+// NOT merely the presence of the MU1_FIXTURE_* vars. The fixture vars live in
+// the Doppler `dev`/`dev_scheduled` configs, so without this gate a routine
+// `doppler run -c dev -- <full suite>` run fired AC-2 and hard-failed with
+// `GitHub installation token request failed: 401` (the local env's App creds
+// can't mint a token for the fixture installation). CI never sets MU1_FIXTURE_*
+// so AC-2 already skips there; the partial-set canary above still guards the
+// one-var-set misconfig. See #4663. Run the live check with:
+//   MU1_INTEGRATION=1 doppler run -p soleur -c dev -- env TENANT_INTEGRATION_TEST=1 \
+//     npm run test:ci -- test/mu1-integration.test.ts --project unit
+const AC2_OPTED_IN = process.env.MU1_INTEGRATION === "1";
+
+describe.skipIf(!AC2_OPTED_IN || !AC2_HAS_REPO_URL || !AC2_HAS_INSTALL_ID)(
   "MU1 AC-2: provisionWorkspaceWithRepo clones fixture",
   () => {
     test("clones the fixture repo and overlays plugin symlink", async () => {

--- a/apps/web-platform/test/team-membership-resolver.test.ts
+++ b/apps/web-platform/test/team-membership-resolver.test.ts
@@ -107,6 +107,15 @@ describe("resolveTeamMembershipPageData", () => {
     vi.unstubAllEnvs();
     vi.stubEnv("FLAG_TEAM_WORKSPACE_INVITE", "");
     vi.stubEnv("FLAGSMITH_ENVIRONMENT_KEY", "");
+    // Force the byok-delegations runtime flag OFF so the resolver's
+    // `isByokDelegationsEnabled` branch (which queries the byok_delegations
+    // table — not covered by this file's mockSupabaseClients) stays dormant.
+    // Without this, `doppler run -c dev` injects FLAG_BYOK_DELEGATIONS=1 and
+    // the resolver hits the mock's `unmocked table: byok_delegations` throw.
+    // vi.unstubAllEnvs() cannot clear a process-inherited var; vi.stubEnv("")
+    // overwrites it. See #4663 and the env-leak learning
+    // 2026-05-20-vitest-unstub-does-not-clear-process-inherited-env-vars.
+    vi.stubEnv("FLAG_BYOK_DELEGATIONS", "");
     __resetFeatureFlagsForTests();
   });
 


### PR DESCRIPTION
## Summary

Closes #4663. Two web-platform unit tests hard-failed under `doppler run -p soleur -c dev -- … bash scripts/test-all.sh` (the canonical local full-suite command `/soleur:work` recommends) but pass in CI and without Doppler. Discovered during the #4660 exit gate, where they nearly misled the pipeline into diagnosing a regression.

Both are env-leak false-positives — Doppler dev injects flags/fixtures that flip *untouched* code paths:

1. **`team-membership-resolver.test.ts`** — doppler dev sets `FLAG_BYOK_DELEGATIONS=1`, so the resolver's `isByokDelegationsEnabled` branch queries `byok_delegations`, a table the file's `mockSupabaseClients` doesn't cover → `Error: unmocked table: byok_delegations`. **Fix:** stub `FLAG_BYOK_DELEGATIONS=""` in `beforeEach`, mirroring the existing `FLAG_TEAM_WORKSPACE_INVITE` stub. (`vi.unstubAllEnvs()` can't clear a process-inherited var; `vi.stubEnv("")` overwrites it — per the 2026-05-20 env-leak learning.)

2. **`mu1-integration.test.ts` AC-2** — gated only on `MU1_FIXTURE_*` presence, which lives in Doppler `dev`/`dev_scheduled`, so a routine dev run fired the live GitHub installation-token call and 401'd. **Fix:** require explicit `MU1_INTEGRATION=1` opt-in (consistent with the AC-1 block). Routine runs skip it; the partial-set canary and the deliberate live check are preserved. CI never sets `MU1_FIXTURE_*`, so AC-2 already skipped there.

## Changelog

### Web Platform
- Fix two webplat unit tests that false-failed under `doppler run -c dev` due to env-injected feature flags / fixtures flipping unmocked code paths.

## Test plan
- [x] Both files under `doppler run -c dev` (previously failing) → 8 passed | 2 skipped
- [x] Both files without Doppler (CI-equivalent) → 8 passed | 2 skipped (no regression)
- [x] `MU1_INTEGRATION=1` + fixtures → AC-2 executes (not skipped) — opt-in path intact
- [x] `./node_modules/.bin/tsc --noEmit` → clean

Generated with [Claude Code](https://claude.com/claude-code)