### PR TITLE
fix(infra): bump cloud-init inngest-bootstrap pin to v1.1.11 + fix parity test

### DIFF
--- a/apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh
+++ b/apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh
@@ -135,12 +135,16 @@ echo ""
 echo "--- AC5: sudoers parity (deploy-inngest-bootstrap) ---"
 SUDOERS_SRC="$SCRIPT_DIR/deploy-inngest-bootstrap.sudoers"
 SUDOERS_CONTENT_ONLY=$(grep -vE '^\s*#|^\s*$' "$SUDOERS_SRC")
-# Extract the inline sudoers body (#4665 fix): exit at the NEXT write_files
-# list item (`  - path:`) AND the next mapping key (`owner:`/`permissions:`),
-# then strip comments + blank lines so the comparison is content-only on BOTH
-# sides (the source side is already filtered by the grep above). The prior awk
-# over-read past the entry (its only exit was `[a-z]+:`, which does not match
-# `  - path:`) AND compared raw-with-comments against content-only → never matched.
+# Extract the inline sudoers body (#4665 fix). The prior version's two real
+# defects: (1) it compared the raw inline block (WITH comments + blanks) against
+# the source's content-only form (`grep -vE '^\s*#|^\s*$'` above) → never matched
+# even though the alias content is byte-identical; (2) the non-empty assert
+# value-embedded the block (`[[ -n '$VAR' ]]`), which the eval mishandles on
+# special chars. Fix: pipe the extracted block through the SAME content-only
+# filter, and assert by-name (`[[ -n "$VAR" ]]`) below. The added
+# `^[[:space:]]*-[[:space:]]` exit (next write_files `- path:` item) is
+# defense-in-depth — the existing `[a-z]+:` exit already stops at the entry's
+# trailing `owner:`/`permissions:` keys.
 CLOUD_INIT_SUDOERS=$(awk '
   /path: \/etc\/sudoers\.d\/deploy-inngest-bootstrap/ { found = 1; next }
   found && /^[[:space:]]+content:[[:space:]]*\|/      { in_body = 1; next }

--- a/apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh
+++ b/apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh
@@ -2,7 +2,7 @@
 # Tests the Inngest bootstrap runcmd block added to cloud-init.yml in #4118.
 #
 # Asserts the structural invariants the runcmd block must satisfy:
-#   - The pinned OCI image tag is present and exactly v1.0.0 (bootstrap-script
+#   - The pinned OCI image tag is present and exactly v1.1.11 (bootstrap-script
 #     version, NOT the inngest-cli version which is sourced from Config.Env).
 #   - The block sources INNGEST_CLI_VERSION + INNGEST_CLI_SHA256 via `docker
 #     inspect ... Config.Env` (rather than hardcoding them in cloud-init.yml).
@@ -49,8 +49,8 @@ assert "cloud-init.yml exists" "[[ -f '$CLOUD_INIT' ]]"
 # --- AC1: pinned OCI image tag ---
 echo ""
 echo "--- AC1: pinned OCI image tag ---"
-assert "docker pull line for soleur-inngest-bootstrap:v1.0.0 exists" \
-  "grep -qE '^[[:space:]]+docker pull ghcr\.io/jikig-ai/soleur-inngest-bootstrap:v1\.0\.0' '$CLOUD_INIT'"
+assert "docker pull line for soleur-inngest-bootstrap:v1.1.11 exists" \
+  "grep -qE '^[[:space:]]+docker pull ghcr\.io/jikig-ai/soleur-inngest-bootstrap:v1\.1\.11' '$CLOUD_INIT'"
 
 # --- AC1: Config.Env sourcing ---
 echo ""
@@ -71,13 +71,17 @@ assert "Inngest block uses trap cleanup EXIT" \
 # --- AC2: drift comment ---
 echo ""
 echo "--- AC2: drift sentinel comment ---"
-assert "drift comment cites inngest.tf:locals.inngest_cli_version" \
-  "grep -qE '# Pinned image tag tracks apps/web-platform/infra/inngest\.tf:locals\.inngest_cli_version' '$CLOUD_INIT'"
+# The pin's drift-sentinel comment must clarify that the tag is the
+# bootstrap-image SHAPE version (NOT the inngest-cli version) and MUST be
+# bumped on each bootstrap-script change. (#4667 corrected the prior comment
+# which misleadingly claimed the pin "tracks ...inngest_cli_version".)
+assert "drift comment clarifies pin is bootstrap-image version, not inngest-cli version" \
+  "grep -qE 'NOT the inngest-cli version' '$CLOUD_INIT' && grep -qiE 'MUST be bumped' '$CLOUD_INIT'"
 
 # --- AC4: positional ordering ---
 echo ""
 echo "--- AC4: positioned BEFORE soleur-web-platform docker run ---"
-BOOTSTRAP_LINE=$(grep -nE '^[[:space:]]+docker pull ghcr\.io/jikig-ai/soleur-inngest-bootstrap:v1\.0\.0' "$CLOUD_INIT" | head -1 | cut -d: -f1)
+BOOTSTRAP_LINE=$(grep -nE '^[[:space:]]+docker pull ghcr\.io/jikig-ai/soleur-inngest-bootstrap:v1\.1\.11' "$CLOUD_INIT" | head -1 | cut -d: -f1)
 WEBPLATFORM_LINE=$(grep -nE '^[[:space:]]+--name soleur-web-platform' "$CLOUD_INIT" | head -1 | cut -d: -f1)
 assert "bootstrap line found in cloud-init.yml"      "[[ -n '$BOOTSTRAP_LINE' ]]"
 assert "soleur-web-platform run line found"          "[[ -n '$WEBPLATFORM_LINE' ]]"
@@ -131,14 +135,21 @@ echo ""
 echo "--- AC5: sudoers parity (deploy-inngest-bootstrap) ---"
 SUDOERS_SRC="$SCRIPT_DIR/deploy-inngest-bootstrap.sudoers"
 SUDOERS_CONTENT_ONLY=$(grep -vE '^\s*#|^\s*$' "$SUDOERS_SRC")
+# Extract the inline sudoers body (#4665 fix): exit at the NEXT write_files
+# list item (`  - path:`) AND the next mapping key (`owner:`/`permissions:`),
+# then strip comments + blank lines so the comparison is content-only on BOTH
+# sides (the source side is already filtered by the grep above). The prior awk
+# over-read past the entry (its only exit was `[a-z]+:`, which does not match
+# `  - path:`) AND compared raw-with-comments against content-only → never matched.
 CLOUD_INIT_SUDOERS=$(awk '
   /path: \/etc\/sudoers\.d\/deploy-inngest-bootstrap/ { found = 1; next }
   found && /^[[:space:]]+content:[[:space:]]*\|/      { in_body = 1; next }
+  in_body && /^[[:space:]]*-[[:space:]]/              { exit }
   in_body && /^[[:space:]]+[a-z]+:/                   { exit }
   in_body { sub(/^      /, ""); print }
-' "$CLOUD_INIT")
+' "$CLOUD_INIT" | grep -vE '^\s*#|^\s*$')
 assert "deploy-inngest-bootstrap.sudoers exists"         "[[ -s '$SUDOERS_SRC' ]]"
-assert "cloud-init inline block is non-empty"            "[[ -n '$CLOUD_INIT_SUDOERS' ]]"
+assert "cloud-init inline block is non-empty"            "[[ -n \"\$CLOUD_INIT_SUDOERS\" ]]"
 assert "sudoers source and cloud-init inline match"      "[[ \"\$SUDOERS_CONTENT_ONLY\" == \"\$CLOUD_INIT_SUDOERS\" ]]"
 assert "ci-deploy.sh invokes the sudoers-pinned path"    "grep -qE '/usr/bin/bash /tmp/inngest-extract/inngest-bootstrap.sh' '$SCRIPT_DIR/ci-deploy.sh'"
 if command -v visudo >/dev/null 2>&1; then

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -451,20 +451,24 @@ runcmd:
       > /mnt/data/plugins/soleur/.seed-complete
 
   # Bootstrap Inngest server on first boot (#4118, Tier 1).
-  # Pinned image tag tracks apps/web-platform/infra/inngest.tf:locals.inngest_cli_version
-  # (image tag = bootstrap-script version; inngest-cli version is sourced from
-  # the image's Config.Env at run time). Upgrades go through the deploy webhook
-  # path (push vinngest-vX.Y.Z tag); cloud-init installs only on fresh hosts.
+  # Pinned image tag = the soleur-inngest-bootstrap OCI image version (the
+  # bootstrap-script SHAPE version), NOT the inngest-cli version (the latter is
+  # sourced from the image's Config.Env at run time). This pin MUST be bumped to
+  # the latest released bootstrap image on every bootstrap-script change, or
+  # fresh-host reprovision installs a stale script. Bumped to v1.1.11 for the
+  # #4652 --poll-interval/--sdk-url ExecStart (running hosts get it via the
+  # deploy webhook path: push vinngest-vX.Y.Z tag → deploy inngest …:vX.Y.Z;
+  # cloud-init installs only on fresh hosts).
   - |
     set -e
-    docker pull ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.0.0
+    docker pull ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.11
     EXTRACT_DIR=$(mktemp -d)
     cleanup() { docker rm -f soleur-inngest-bootstrap-extract >/dev/null 2>&1 || true; rm -rf "$EXTRACT_DIR"; }
     trap cleanup EXIT
-    docker create --name soleur-inngest-bootstrap-extract ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.0.0
+    docker create --name soleur-inngest-bootstrap-extract ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.11
     docker cp soleur-inngest-bootstrap-extract:/inngest-bootstrap.sh "$EXTRACT_DIR/inngest-bootstrap.sh"
     docker cp soleur-inngest-bootstrap-extract:/vector.toml /tmp/vector.toml 2>/dev/null || true
-    image_env=$(docker inspect ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.0.0 -f '{{range .Config.Env}}{{println .}}{{end}}')
+    image_env=$(docker inspect ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.11 -f '{{range .Config.Env}}{{println .}}{{end}}')
     chmod +x "$EXTRACT_DIR/inngest-bootstrap.sh"
     INNGEST_CLI_VERSION=$(printf '%s\n' "$image_env" | grep '^INNGEST_CLI_VERSION=' | head -1 | cut -d= -f2-)
     INNGEST_CLI_SHA256=$(printf '%s\n' "$image_env" | grep '^INNGEST_CLI_SHA256=' | head -1 | cut -d= -f2-)


### PR DESCRIPTION
## Summary

Fresh-host parity tail of the #4652 inngest `--poll-interval`/`--sdk-url` rollout (#4667). Running hosts already received the new ExecStart via the deploy webhook (`deploy inngest …:v1.1.11`, verified `reason=success`); this bumps the **cloud-init** pin so a fresh-host reprovision installs the same script instead of the stale `v1.0.0`.

Closes #4667
Closes #4665

## Changes
- **`cloud-init.yml`**: bootstrap-image pin `v1.0.0` → `v1.1.11` (3 docker refs) + rewrote the misleading drift comment (the pin is the bootstrap-image *shape* version, NOT the inngest-cli version; **MUST be bumped on each bootstrap-script change**).
- **`cloud-init-inngest-bootstrap.test.sh`**: updated AC1/AC2/AC4 to `v1.1.11`, AND fixed the pre-existing **#4665** AC5 sudoers-parity bug (awk over-read past the write_files entry + raw-vs-content-only comparison + value-embed eval). Now **19/19 pass**, confirming no real sudoers drift.

## Pre-existing systemic note (mitigated, not filed)
The pin was stuck at `v1.0.0` across every prior bootstrap release (v1.0.1…v1.1.10) — fresh-host reprovision would have installed an ancient script. The new "MUST be bumped" comment is the cheap mitigation; fully automating the pin bump in the release pipeline is a candidate future improvement (low priority — bootstrap-script changes are rare).

## User-Brand Impact
**If this lands broken:** a malformed cloud-init pin would break **fresh-host reprovision** (the new host fails to bootstrap the Inngest server). Running hosts are unaffected (`server.tf` `user_data` has `ignore_changes`, so cloud-init never re-applies to existing hosts). Caught pre-merge by the cloud-init YAML parse + the bootstrap test suite (19/19). **If it leaks:** N/A — no secret/data surface; the pin is a public image tag.

- **Brand-survival threshold:** aggregate pattern — fresh-host provisioning reliability; no single-user data/credential exposure.

## Test plan
- [x] `cloud-init-inngest-bootstrap.test.sh` 19/19 (was 17/19 — fixed #4665 AC5)
- [x] `cloud-init.yml` parses as valid YAML
- [x] v1.0.0 fully removed from the bootstrap pin (0 refs); v1.1.11 present (3 refs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
