### PR TITLE
docs(reconcile): document WORKSPACE_RECONCILE_IGNORE_REPOS in .env.example

### DIFF
--- a/apps/web-platform/.env.example
+++ b/apps/web-platform/.env.example
@@ -163,3 +163,8 @@ CC_GLOBAL_DAILY_USD_CAP=500.00
 # PORT=3000
 # WORKSPACES_ROOT=/workspaces
 # SOLEUR_PLUGIN_PATH=/app/shared/plugins/soleur
+# Comma-separated repo-URL substrings (owner/repo slugs) the push-reconcile
+# Inngest function skips silently — repos the GitHub App is installed on but
+# that are NOT customer workspaces (e.g. Soleur's own dev repo). Matched as exact
+# owner/repo equality; defaults to "jikig-ai/soleur" when unset (#4666).
+# WORKSPACE_RECONCILE_IGNORE_REPOS=jikig-ai/soleur


### PR DESCRIPTION
## Summary
- Documents the `WORKSPACE_RECONCILE_IGNORE_REPOS` env override in `apps/web-platform/.env.example`.
- Follow-up to #4666: the handler-side override landed, but the `.env.example` edit in that PR silently no-op'd on a stale anchor and never committed. The observability review flagged the plan-vs-code doc gap.

## Changelog
### Web Platform
- Document the optional `WORKSPACE_RECONCILE_IGNORE_REPOS` reconcile ignore-list env var (defaults to `jikig-ai/soleur`).

## Test plan
- [x] Docs-only change; no behavior change. The feature works without it (env var has a default). Verified the line renders under the `# --- Optional ---` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
