### PR TITLE
fix(inngest): watchdog registry read — drop auth header + non-fatal fetch

### DIFF
--- a/apps/web-platform/server/inngest/functions/cron-inngest-cron-watchdog.ts
+++ b/apps/web-platform/server/inngest/functions/cron-inngest-cron-watchdog.ts
@@ -288,12 +288,16 @@ export function shouldRestart(
 // =============================================================================
 
 // Exported for reuse by oneshot-4650-monitor-close.ts (#4654) — the canonical
-// registry read. Auth via INNGEST_SIGNING_KEY (already in the container env;
-// route.ts throws at load if absent). No new credential.
+// registry read. UNAUTHENTICATED: the loopback /v1/functions introspection
+// endpoint answers without auth (see the header note below). No credential.
 export async function fetchRegistry(host: string): Promise<RegistryFunction[]> {
-  const signingKey = process.env.INNGEST_SIGNING_KEY;
+  // Do NOT send an Authorization header. /v1/functions is an unauthenticated
+  // loopback introspection endpoint — ci-deploy.sh's verify_inngest_health
+  // curls it with no auth and gets 200. Sending
+  // `Authorization: Bearer <signkey-prod-...>` returned 404 from the app
+  // container (#4682: WEB-PLATFORM-14 fired 5x — the watchdog ran on schedule
+  // but threw here before its heartbeat step, leaving its monitor silent).
   const res = await fetch(`${host}/v1/functions`, {
-    headers: signingKey ? { Authorization: `Bearer ${signingKey}` } : {},
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
   if (!res.ok) {
@@ -416,10 +420,43 @@ export async function cronInngestCronWatchdogHandler({
   healed: { manualTriggers: string[]; restartRequested: boolean };
 }> {
   // Step 1: query the running server's function registry (loopback, no SSH).
+  // NON-FATAL (#4682): a registry-read failure must NOT abort the handler
+  // before the heartbeat — that produced a SILENT watchdog (0 check-ins for
+  // ~5 fires) when /v1/functions 404'd. Catch inside the step, return null on
+  // failure, and treat "can't read the registry" as a defect that pages below.
   const registry = await step.run("fetch-registry", async () => {
     const host = resolveInngestHost(process.env.INNGEST_BASE_URL);
-    return fetchRegistry(host);
+    try {
+      return await fetchRegistry(host);
+    } catch (err) {
+      reportSilentFallback(err, {
+        feature: "cron-inngest-cron-watchdog",
+        op: "fetch-registry",
+        message: "Failed to read /v1/functions — cannot verify cron substrate",
+        extra: { fn: "cron-inngest-cron-watchdog", host },
+      });
+      return null;
+    }
   });
+
+  // Registry unreadable → substrate health UNKNOWN → page (ok=false) and skip
+  // heal (no data to act on). The heartbeat ALWAYS posts so the watchdog's own
+  // monitor is never silent — the failure mode #4682 fixed.
+  if (registry === null) {
+    await step.run("sentry-heartbeat-registry-unreadable", async () => {
+      await postSentryHeartbeat({
+        ok: false,
+        sentryMonitorSlug: SENTRY_MONITOR_SLUG,
+        cronName: "cron-inngest-cron-watchdog",
+        logger,
+      });
+    });
+    return {
+      ok: false,
+      results: [],
+      healed: { manualTriggers: [], restartRequested: false },
+    };
+  }
 
   // Pure classification (no IO — safe in the handler body).
   const results = classifyRegistry(registry);

--- a/apps/web-platform/test/server/inngest/cron-inngest-cron-watchdog-handler.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-inngest-cron-watchdog-handler.test.ts
@@ -38,6 +38,7 @@ vi.mock("@/server/inngest/functions/_cron-shared", async () => {
 });
 
 import { cronInngestCronWatchdogHandler, EXPECTED_CRON_FUNCTIONS } from "@/server/inngest/functions/cron-inngest-cron-watchdog";
+import { postSentryHeartbeat } from "@/server/inngest/functions/_cron-shared";
 
 // Fake Inngest step: runs each step body inline (no replay machinery).
 const fakeStep = { run: <T>(_name: string, fn: () => Promise<T>) => fn() };
@@ -183,5 +184,88 @@ describe("cronInngestCronWatchdogHandler — backstop restart orchestration (#46
     const persisted = JSON.parse(String(lastWrite![1]));
     expect(persisted.last_restart_at).toBe("2026-05-29T00:00:00Z");
     expect(persisted.defect_streaks).toEqual({});
+  });
+});
+
+describe("cronInngestCronWatchdogHandler — registry-fetch is non-fatal (#4682)", () => {
+  const ORIG = { ...process.env };
+
+  beforeEach(() => {
+    writeFileMock.mockClear();
+    readFileMock.mockClear();
+    vi.mocked(postSentryHeartbeat).mockClear();
+    process.env.INNGEST_BASE_URL = "http://host.docker.internal:8288";
+    process.env.WEBHOOK_DEPLOY_SECRET = "secret";
+    process.env.CF_ACCESS_CLIENT_ID = "cf-id";
+    process.env.CF_ACCESS_CLIENT_SECRET = "cf-secret";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    process.env = { ...ORIG };
+  });
+
+  it("404 from /v1/functions → handler does NOT crash, posts ok=false heartbeat, no restart (#4682)", async () => {
+    // The exact prod failure: /v1/functions returns 404 → fetchRegistry throws.
+    // Pre-#4682 this aborted the handler before the heartbeat → 0 check-ins
+    // (silent watchdog). Now it must catch, page ok=false, and skip heal.
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.includes("/v1/functions")) {
+        return { ok: false, status: 404, json: async () => ({}) } as unknown as Response;
+      }
+      if (u.includes("deploy.soleur.ai")) {
+        return { status: 202 } as unknown as Response;
+      }
+      throw new Error(`unexpected fetch ${u}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const out = await cronInngestCronWatchdogHandler({
+      step: fakeStep,
+      logger: fakeLogger,
+    } as never).catch((e) => e);
+
+    // Did NOT reject (the silent-death failure mode is gone).
+    expect(out).not.toBeInstanceOf(Error);
+    expect(out.ok).toBe(false);
+    expect(out.results).toEqual([]);
+    expect(out.healed.restartRequested).toBe(false);
+    // The load-bearing fix: a heartbeat (ok=false) IS posted so the monitor pages
+    // instead of going silent.
+    const hb = vi.mocked(postSentryHeartbeat).mock.calls.at(-1);
+    expect(hb).toBeDefined();
+    expect(hb![0]).toMatchObject({ ok: false, sentryMonitorSlug: "scheduled-inngest-cron-watchdog" });
+    // No restart webhook on the degraded path (no registry data to act on).
+    expect(
+      fetchMock.mock.calls.some((c) => String(c[0]).includes("deploy.soleur.ai")),
+    ).toBe(false);
+  });
+
+  it("does NOT send an Authorization header to /v1/functions (#4682 — unauth loopback endpoint)", async () => {
+    // INNGEST_SIGNING_KEY is present in prod; the header it would carry caused
+    // the 404. Assert the registry fetch is unauthenticated regardless.
+    process.env.INNGEST_SIGNING_KEY = "signkey-prod-deadbeef";
+    const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return {
+        ok: true,
+        json: async () =>
+          EXPECTED_CRON_FUNCTIONS.map((fnId) => ({
+            slug: `soleur-runtime-${fnId}`,
+            triggers: [{ cron: "0 8 * * *" }],
+          })),
+      } as unknown as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await cronInngestCronWatchdogHandler({ step: fakeStep, logger: fakeLogger } as never);
+
+    const regCall = calls.find((c) => c.url.includes("/v1/functions"));
+    expect(regCall).toBeDefined();
+    const headers = (regCall!.init?.headers ?? {}) as Record<string, string>;
+    const headerKeys = Object.keys(headers).map((k) => k.toLowerCase());
+    expect(headerKeys).not.toContain("authorization");
   });
 });


### PR DESCRIPTION
## Summary

The `cron-inngest-cron-watchdog` Inngest function (the #4649 durable self-heal) fired on schedule but **never recorded a single check-in** since it shipped — its step-1 `fetchRegistry` GET to `http://host.docker.internal:8288/v1/functions` returned **404** (confirmed via Sentry `WEB-PLATFORM-14`, 5×), throwing before the heartbeat step → the `scheduled-inngest-cron-watchdog` monitor stayed silent.

Closes #4682.

## Fix (two parts)
1. **Drop the `Authorization: Bearer ${INNGEST_SIGNING_KEY}` header** in `fetchRegistry`. `/v1/functions` is an unauthenticated loopback introspection endpoint — `ci-deploy.sh`'s `verify_inngest_health` curls it with **no auth** and gets 200; the Bearer header (full `signkey-prod-…` form) is what produced the 404 from the app container. Also fixes the shared `oneshot-4650-monitor-close.ts` consumer (`WEB-PLATFORM-18` "registry unreadable").
2. **Non-fatal registry read**: catch inside the `fetch-registry` step → `reportSilentFallback` + post an `ok=false` heartbeat and skip heal, instead of throwing. A watchdog whose job is alerting must **never go silent** when it can't read the substrate — it must page. This guarantees a check-in on every fire regardless of the fetch outcome, and de-risks the residual "what if it's the network path, not the header" uncertainty (the monitor still pages + the 404 still surfaces in Sentry).

## User-Brand Impact
**If this lands broken:** the cron self-heal monitor stays silent (status quo) — no *new* user-facing regression; this only restores lost ops safety-net coverage (defect paging + restart backstop). Polling (`--poll-interval 60`, #4652) remains the primary self-heal regardless. **If it leaks:** N/A — dropping the header removes a credential from a loopback request (strictly less exposure); no data/secret surface added. The endpoint is unauthenticated by design (host proof).

- **Brand-survival threshold:** aggregate pattern — restores ops observability/resilience of the cron substrate; no single-user data or credential exposure.

## Test plan
- [x] Watchdog vitest 41/41 (+2 new #4682 tests: 404 → no crash + `ok=false` heartbeat + no restart; registry fetch sends no `Authorization` header)
- [x] `oneshot-4650-monitor-close.test.ts` 11/11 (shared `fetchRegistry` consumer)
- [x] `tsc --noEmit` clean

## Post-merge
Ships via **Web Platform Release** on merge (the watchdog is an app-side Inngest function, no bootstrap-image rebuild). The watchdog should record its first `ok` check-in on the next 4h fire — then #4650 can close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
