### PR TITLE
fix(inngest): watchdog self-diagnoses the /v1/functions 404 (probe /health on failure)

### DIFF
--- a/apps/web-platform/server/inngest/functions/cron-inngest-cron-watchdog.ts
+++ b/apps/web-platform/server/inngest/functions/cron-inngest-cron-watchdog.ts
@@ -429,11 +429,29 @@ export async function cronInngestCronWatchdogHandler({
     try {
       return await fetchRegistry(host);
     } catch (err) {
+      // SSH-free root-cause probe (#4682): /v1/functions 404s from the app
+      // container while the host's 127.0.0.1:8288/v1/functions returns 200, and
+      // dropping the auth header did NOT change it — so the cause is the network
+      // path, not auth. Probe /health on the SAME host so the next fire's Sentry
+      // event definitively separates the two hypotheses:
+      //   - health 200 → connectivity is fine; the 404 is path-/loopback-gated
+      //     introspection (fix host-side: expose /v1/functions or move the read).
+      //   - health unreachable → broad container→server connectivity loss
+      //     (fix INNGEST_BASE_URL / docker networking).
+      let healthStatus = "unprobed";
+      try {
+        const hr = await fetch(`${host}/health`, {
+          signal: AbortSignal.timeout(5_000),
+        });
+        healthStatus = String(hr.status);
+      } catch (he) {
+        healthStatus = `unreachable:${(he as Error)?.name ?? "error"}`;
+      }
       reportSilentFallback(err, {
         feature: "cron-inngest-cron-watchdog",
         op: "fetch-registry",
-        message: "Failed to read /v1/functions — cannot verify cron substrate",
-        extra: { fn: "cron-inngest-cron-watchdog", host },
+        message: "Failed to read /v1/functions — cannot verify cron substrate (#4682)",
+        extra: { fn: "cron-inngest-cron-watchdog", registryHost: host, healthStatus },
       });
       return null;
     }

--- a/apps/web-platform/test/server/inngest/cron-inngest-cron-watchdog-handler.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-inngest-cron-watchdog-handler.test.ts
@@ -39,6 +39,7 @@ vi.mock("@/server/inngest/functions/_cron-shared", async () => {
 
 import { cronInngestCronWatchdogHandler, EXPECTED_CRON_FUNCTIONS } from "@/server/inngest/functions/cron-inngest-cron-watchdog";
 import { postSentryHeartbeat } from "@/server/inngest/functions/_cron-shared";
+import { reportSilentFallback } from "@/server/observability";
 
 // Fake Inngest step: runs each step body inline (no replay machinery).
 const fakeStep = { run: <T>(_name: string, fn: () => Promise<T>) => fn() };
@@ -194,6 +195,7 @@ describe("cronInngestCronWatchdogHandler — registry-fetch is non-fatal (#4682)
     writeFileMock.mockClear();
     readFileMock.mockClear();
     vi.mocked(postSentryHeartbeat).mockClear();
+    vi.mocked(reportSilentFallback).mockClear();
     process.env.INNGEST_BASE_URL = "http://host.docker.internal:8288";
     process.env.WEBHOOK_DEPLOY_SECRET = "secret";
     process.env.CF_ACCESS_CLIENT_ID = "cf-id";
@@ -211,6 +213,11 @@ describe("cronInngestCronWatchdogHandler — registry-fetch is non-fatal (#4682)
     // (silent watchdog). Now it must catch, page ok=false, and skip heal.
     const fetchMock = vi.fn(async (url: string | URL) => {
       const u = String(url);
+      // /health probe must be matched before /v1/functions has no overlap, but
+      // order defensively: /health is the #4682 diagnostic probe on failure.
+      if (u.includes("/health")) {
+        return { ok: true, status: 200 } as unknown as Response;
+      }
       if (u.includes("/v1/functions")) {
         return { ok: false, status: 404, json: async () => ({}) } as unknown as Response;
       }
@@ -240,6 +247,17 @@ describe("cronInngestCronWatchdogHandler — registry-fetch is non-fatal (#4682)
     expect(
       fetchMock.mock.calls.some((c) => String(c[0]).includes("deploy.soleur.ai")),
     ).toBe(false);
+    // #4682 diagnostic: on a registry-read failure the watchdog probes /health
+    // on the same host so the next fire's Sentry event pins path-404 vs
+    // connectivity. Assert the probe fired AND its result reached the report.
+    expect(
+      fetchMock.mock.calls.some((c) => String(c[0]).includes("/health")),
+    ).toBe(true);
+    const reportCall = vi.mocked(reportSilentFallback).mock.calls.find(
+      (c) => (c[1] as { op?: string })?.op === "fetch-registry",
+    );
+    expect(reportCall).toBeDefined();
+    expect((reportCall![1] as { extra?: { healthStatus?: string } }).extra?.healthStatus).toBe("200");
   });
 
   it("does NOT send an Authorization header to /v1/functions (#4682 — unauth loopback endpoint)", async () => {


### PR DESCRIPTION
## Summary

The 16:00Z verification of #4694 confirmed its non-fatal half works (the watchdog now records check-ins) **but** the `/v1/functions` 404 persists on the no-auth-header code (`WEB-PLATFORM-14` recurred at 16:00:00Z) — proving the 404 is the **network path**, not the auth header. I can't reach the host SSH-free to confirm whether `/v1/functions` is loopback-gated, so this makes the watchdog **pin the root cause on its next fire**.

Refs #4682 (does not close — this is the diagnostic step that unblocks the real fix).

## Change (observability-only)
On a registry-read failure, the watchdog now probes `/health` on the same resolved host (5s timeout) and records `{registryHost, healthStatus}` in the `reportSilentFallback` extra. The next fire's Sentry event then definitively separates:
- `health 200` → connectivity is fine; the 404 is **path-/loopback-gated introspection** → fix host-side (expose `/v1/functions` or move the registry read to where it works).
- `health unreachable` → broad container→server **connectivity loss** → fix `INNGEST_BASE_URL` / docker networking.

No change to heal/restart/heartbeat semantics (still non-fatal `ok=false` on failure).

## User-Brand Impact
**If this lands broken:** none beyond status quo — the watchdog is already paging `ok=false` every fire (it can't read the registry); this only adds a bounded diagnostic probe to its existing failure path. **If it leaks:** N/A — `/health` is an unauthenticated loopback endpoint; no secret/data surface.

- **Brand-survival threshold:** aggregate pattern — restores diagnosability of the cron-watchdog substrate; no single-user data/credential exposure.

## Test plan
- [x] Watchdog vitest 45/45 (+/health-probe + healthStatus-in-report assertions)
- [x] `oneshot-4650-monitor-close.test.ts` green (shared `fetchRegistry`)
- [x] `tsc --noEmit` clean

## Post-merge
Ships via Web Platform Release (app-side function). The next watchdog fire (20:00 UTC) emits the `healthStatus` diagnostic → pins the #4682 root cause for the real fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
