### PR TITLE
fix(postmerge): use SENTRY_ISSUE_RW_TOKEN for the single-issue GET in Phase 3.6

### DIFF
--- a/plugins/soleur/skills/postmerge/SKILL.md
+++ b/plugins/soleur/skills/postmerge/SKILL.md
@@ -131,7 +131,7 @@ A merged-and-deployed fix can pass every gate above and still not work — the d
 
 **Run only when** the PR body or linked issue names a specific Sentry issue (a `*.sentry.io/issues/<id>` URL, a `SENTRY-<SHORTID>`, or a `Closes #N` whose issue references one). If no Sentry issue is identified, skip silently — there is no error to measure.
 
-**Prerequisites:** same `SENTRY_AUTH_TOKEN` resolution as Phase 3.5. If missing, warn and skip.
+**Prerequisites:** same `SENTRY_AUTH_TOKEN` resolution as Phase 3.5 for the aggregate Discover count. **The single-issue GET below, however, requires the write-scoped `SENTRY_ISSUE_RW_TOKEN`** — the `/organizations/<org>/issues/<id>/` endpoint returns `403` on the read-only `SENTRY_AUTH_TOKEN`/`SENTRY_API_TOKEN` (they carry Discover/ingest scope, not `event:read` on the issue resource). Using the read token here makes the `curl -sfS` GET exit non-zero, leaving `ISSUE_JSON` empty → `ISSUE_STOPPED` stuck `false` → auto-resolve never fires. Resolve the RW token first; if it is absent, skip this phase (warn) since the GET cannot succeed without it.
 
 ```bash
 # ISSUE_ID = the Sentry issue short-id or numeric id from the PR/issue body
@@ -139,9 +139,15 @@ A merged-and-deployed fix can pass every gate above and still not work — the d
 # committer date (Phase 1 recorded the merge SHA) — the reference point for
 # "did the error stop firing post-deploy?".
 DEPLOY_TS=$(git show -s --format=%cI "<merge-commit-sha-from-phase-1>")
+# The single-issue endpoint needs the write-scoped token (read tokens 403 here).
+# Reused by the auto-resolve PUT below, so resolve it once. Absent → skip phase.
+SENTRY_RW_TOKEN=$(doppler secrets get SENTRY_ISSUE_RW_TOKEN -p soleur -c prd --plain 2>/dev/null || true)
+if [[ -z "$SENTRY_RW_TOKEN" ]]; then
+  echo "WARNING: SENTRY_ISSUE_RW_TOKEN not set — cannot read the issue (read tokens 403 on /issues/<id>/). Skipping error-count delta + auto-resolve."
+fi
 # Query the issue; capture the response so the auto-resolve guard below can
 # read status + lastSeen without a second GET.
-ISSUE_JSON=$(curl -sfS -H "Authorization: Bearer ${SENTRY_TOKEN}" \
+ISSUE_JSON=$(curl -sfS -H "Authorization: Bearer ${SENTRY_RW_TOKEN}" \
   "https://${API_HOST}/api/0/organizations/${SENTRY_ORG}/issues/${ISSUE_ID}/")
 echo "$ISSUE_JSON" | jq '{shortId, status, count, lastSeen}'
 ISSUE_STATUS=$(echo "$ISSUE_JSON" | jq -r '.status')
@@ -169,8 +175,8 @@ Interpretation (all outcomes are **WARN-only — never a merge blocker**):
 **Auto-resolve (expected-good-outcome branch only).** When the GET above shows the error has stopped firing (`lastSeen` older than the deploy **or** `status` already `resolved`/`ignored`) **and** the issue is not already `resolved`, PUT `status:"resolved"` so the historical issue leaves the active list automatically. This requires a dedicated write-scoped token — the `SENTRY_AUTH_TOKEN`/`SENTRY_API_TOKEN` read tokens lack `event:write`/`event:admin` and return 403 on the write endpoint, so resolve a separate token and **skip (do NOT fall back to a read token)** when it is absent:
 
 ```bash
-# Write-only token; absent → skip auto-resolve, keep read-only delta above.
-SENTRY_RW_TOKEN=$(doppler secrets get SENTRY_ISSUE_RW_TOKEN -p soleur -c prd --plain 2>/dev/null || true)
+# SENTRY_RW_TOKEN was already resolved in Phase 3.6 above (the issue GET needs
+# it too). Reused here for the PUT.
 
 # Fire ONLY when the mechanical ISSUE_STOPPED signal is true (the still-firing
 # branch is structurally unreachable here, never prose-gated), a write token is
@@ -279,7 +285,7 @@ Browser verification: <PASSED/SKIPPED>
 |---------------------|----------|
 | No production URL | Skip health check with warning |
 | No `SENTRY_AUTH_TOKEN` | Skip Sentry cron monitor check AND error-count delta with warning |
-| No `SENTRY_ISSUE_RW_TOKEN` | Skip auto-resolve; keep the read-only error-count delta (recommend manual resolution as today) |
+| No `SENTRY_ISSUE_RW_TOKEN` | Skip the entire error-count-delta + auto-resolve phase (the single-issue GET 403s on read tokens); recommend manual resolution as today |
 | Sentry API unreachable | Skip Sentry cron monitor check with warning |
 | No Sentry issue identified in PR/linked issue | Skip error-count delta silently (nothing to measure) |
 | Sentry issue not found via API | Skip error-count delta with warning |


### PR DESCRIPTION
## Summary
Fixes a real defect in PR #4683's postmerge auto-resolve flow, found by testing it end-to-end against the live `WEB-PLATFORM-X` Sentry issue.

**Defect:** Phase 3.6's single-issue GET used the read-only `SENTRY_TOKEN` (`SENTRY_AUTH_TOKEN`/`SENTRY_API_TOKEN`). The `/organizations/<org>/issues/<id>/` endpoint returns **403** on those tokens (Discover/ingest scope, not `event:read` on the issue resource). Because the GET is `curl -sfS`, the 403 makes curl exit non-zero → `ISSUE_JSON` empty → `ISSUE_STOPPED` stuck `false` → **auto-resolve never fires**. The PUT already used the RW token, so only the GET was broken — the flow would silently no-op in production.

**Verified live:** `RW_GET=200`, `READ_GET=403` on issue `123373554`.

## Fix
- Phase 3.6 GET now uses `SENTRY_ISSUE_RW_TOKEN` (resolved once at the top of 3.6, reused by the 3.7 PUT).
- Warn + skip the whole error-count-delta + auto-resolve phase when the RW token is absent (the GET can't succeed without it).
- Updated the graceful-degradation row to match.
- Phase 3.5 cron-monitor check keeps `SENTRY_TOKEN` (that endpoint works with the read token — unchanged).

## Changelog
### Skills
- `postmerge`: fix Phase 3.6 to read the single Sentry issue with the write-scoped token (read tokens 403), so auto-resolve actually fires.

## Test plan
- [x] Live: `RW_GET=200 / READ_GET=403` on the issue endpoint.
- [x] Full Phase 3.6+3.7 flow drives `unresolved → resolved` (PUT 200) end-to-end with the RW token.
- [x] `bun test plugins/soleur/test/components.test.ts` → 1138 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
