### PR TITLE
fix(migration): privilege-free WORM bypass for the two non-erasure RPCs (088)

### DIFF
--- a/apps/web-platform/supabase/migrations/088_worm_bypass_non_erasure_rpcs.down.sql
+++ b/apps/web-platform/supabase/migrations/088_worm_bypass_non_erasure_rpcs.down.sql
@@ -1,0 +1,113 @@
+-- 088_worm_bypass_non_erasure_rpcs.down.sql
+-- Rollback of 088 — restores the pre-088 RPC bodies (the
+-- session_replication_role WORM bypass) for purge_workspace_member_actions and
+-- revoke_template_authorization.
+--
+-- WARNING — FORWARD-ONLY REALITY: this down migration REINSTATES the
+-- prod-broken behavior. `SET LOCAL session_replication_role = 'replica'` is
+-- superuser-only and raises `42501 permission denied to set parameter` on
+-- managed Supabase (the postgres role owning these SECURITY DEFINER functions is
+-- NOT a superuser). After this down runs on a managed project, the 7-year
+-- retention purge silently no-ops again (Art. 5(1)(e) drift) and template-
+-- authorization revoke 500s again (Art. 7(3)). This file exists for LOCAL
+-- rollback symmetry only — it is NOT a production remediation. 088 touches only
+-- these two function bodies, so there is no table/trigger/grant DDL to revert;
+-- the trigger functions converted by 087 are left untouched (they still honor
+-- app.worm_bypass, which the restored RPC bodies simply no longer set).
+
+-- =====================================================================
+-- 1. purge_workspace_member_actions — restore mig 063 §7 body
+-- =====================================================================
+
+CREATE OR REPLACE FUNCTION public.purge_workspace_member_actions()
+  RETURNS int
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_rows int;
+BEGIN
+  SET LOCAL session_replication_role = 'replica';
+  DELETE FROM public.workspace_member_actions
+   WHERE created_at < now() - interval '7 years';
+  GET DIAGNOSTICS v_rows = ROW_COUNT;
+  RESET session_replication_role;
+  RAISE LOG 'audit_retention_purge table=workspace_member_actions deleted_count=%', v_rows;
+  RETURN v_rows;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.purge_workspace_member_actions()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.purge_workspace_member_actions()
+  TO postgres;
+
+COMMENT ON FUNCTION public.purge_workspace_member_actions() IS
+  'pg_cron-invoked 7-year retention purge. SET LOCAL session_replication_role='
+  '''replica'' bypasses the pure-reject WORM trigger (direct DELETE from cron '
+  'would silently fail — learning 2026-05-15-worm-trigger-blocks-pg-cron-'
+  'retention-sweep). Observability: cron.job_run_details (auto) + RAISE LOG. #4231.';
+
+-- =====================================================================
+-- 2. revoke_template_authorization — restore mig 053 §(f) body
+-- =====================================================================
+
+CREATE OR REPLACE FUNCTION public.revoke_template_authorization(
+  p_template_hash text,
+  p_reason        text
+) RETURNS integer
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_temp
+AS $$
+DECLARE
+  affected integer;
+  v_founder_id uuid := auth.uid();
+BEGIN
+  IF v_founder_id IS NULL THEN
+    RAISE EXCEPTION 'revoke_template_authorization: authenticated session required'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_reason NOT IN (
+    'founder_revoked', 'quota_exhausted', 'expired', 'dsr_erasure',
+    'regulator_ordered', 'vendor_tos_revoked', 'policy_violation',
+    'quarantine_retroactive'
+  ) THEN
+    RAISE EXCEPTION 'revoke_template_authorization: invalid reason %', p_reason
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF auth.uid() IS NOT NULL AND p_reason <> 'founder_revoked' THEN
+    RAISE EXCEPTION 'revoke_template_authorization: authenticated callers must use reason=founder_revoked (got %)', p_reason
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- WORM trigger blocks all UPDATEs including founder-initiated revoke; bypass is required.
+  -- session_replication_role='replica' makes Postgres skip BEFORE
+  -- triggers in this transaction. RESET below.
+  SET LOCAL session_replication_role = 'replica';
+  UPDATE public.template_authorizations
+     SET revoked_at = now(),
+         revocation_reason = p_reason
+   WHERE founder_id = v_founder_id
+     AND template_hash = p_template_hash
+     AND revoked_at IS NULL;
+  GET DIAGNOSTICS affected = ROW_COUNT;
+  RESET session_replication_role;
+
+  RETURN affected;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.revoke_template_authorization(text, text)
+  FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.revoke_template_authorization(text, text)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.revoke_template_authorization(text, text) IS
+  'Founder-initiated revoke (Art. 7(3) "as easily withdrawable as given"). '
+  'Also called auto-revoke-side-effect from the isTemplateAuthorized '
+  'predicate on quota/expired detection so the scope-grants UI does '
+  'not display lying rows.';

--- a/apps/web-platform/supabase/migrations/088_worm_bypass_non_erasure_rpcs.sql
+++ b/apps/web-platform/supabase/migrations/088_worm_bypass_non_erasure_rpcs.sql
@@ -177,4 +177,6 @@ COMMENT ON FUNCTION public.revoke_template_authorization(text, text) IS
   'Founder-initiated revoke (Art. 7(3) "as easily withdrawable as given"). '
   'Also called auto-revoke-side-effect from the isTemplateAuthorized '
   'predicate on quota/expired detection so the scope-grants UI does '
-  'not display lying rows.';
+  'not display lying rows. WORM bypass via SET LOCAL app.worm_bypass=''on'' '
+  '(privilege-free; replaces the prior superuser-only replica-role GUC that '
+  'raised 42501 on managed Supabase); re-armed ''off'' after the UPDATE. #4702.';

--- a/apps/web-platform/supabase/migrations/088_worm_bypass_non_erasure_rpcs.sql
+++ b/apps/web-platform/supabase/migrations/088_worm_bypass_non_erasure_rpcs.sql
@@ -1,0 +1,180 @@
+-- 088_worm_bypass_non_erasure_rpcs.sql
+-- GDPR — privilege-free WORM bypass for the two NON-erasure RPCs. Issue #4702.
+--
+-- PROBLEM (broken in production): migration 087 (#4696) converted the entire
+-- account-delete (Art. 17 erasure) saga off the superuser-only
+--   SET LOCAL session_replication_role = 'replica';
+-- WORM bypass onto the privilege-free custom GUC `app.worm_bypass`. That GUC is
+-- superuser-only (PGC_SUSET); the SECURITY DEFINER RPCs are owned by `postgres`,
+-- which on managed Supabase is NOT a superuser, so the SET raises
+-- `42501 permission denied to set parameter "session_replication_role"` BEFORE
+-- the DML. 087 deliberately scoped itself to the erasure path and deferred the
+-- two NON-erasure RPCs that carry the identical broken bypass to #4702
+-- (087.sql lines 57-59):
+--
+--   * purge_workspace_member_actions()        — the pg_cron 7-year retention
+--     DELETE sweep (defined mig 063). The 42501 raises before the DELETE, so the
+--     sweep is silently a permanent no-op → workspace_member_actions audit PII
+--     accumulates past its lawful 7-year window (Art. 5(1)(e) storage-limitation
+--     drift).
+--   * revoke_template_authorization(text, text) — the founder/auto-revoke UPDATE
+--     (defined mig 053). The 42501 raises on every call that reaches the bypass,
+--     for both the founder-initiated revoke (/api/template-authorizations/revoke)
+--     and the service-role auto-revoke side effect (is-template-authorized.ts,
+--     reasons 'expired'/'quota_exhausted'). Founders cannot withdraw a template
+--     authorization (Art. 7(3) "as easily withdrawable as given").
+--
+-- WHY NO TRIGGER EDITS: migration 087 §1.2/§1.5 already rewrote the trigger
+-- functions `template_authorizations_no_mutate()` and
+-- `workspace_member_actions_no_mutate()` to honor
+--   current_setting('app.worm_bypass', true) = 'on'
+-- and the triggers EXECUTE FUNCTION those same functions (mig 063 L133/L139,
+-- mig 053 L181/L187). So ONLY the two RPC bodies need the bypass-GUC swap.
+-- 088 is RPC-body-only — re-CREATEing the trigger functions here would be
+-- needless drift the 087 test's list↔migration reconciliation does not cover.
+--
+-- FIX: in each RPC body replace
+--   SET LOCAL session_replication_role = 'replica';   →  SET LOCAL app.worm_bypass = 'on';
+--   RESET session_replication_role;                    →  SET LOCAL app.worm_bypass = 'off';
+-- (re-arm immediately after the single write). Custom namespaced GUCs require no
+-- special privilege, so the 42501 is gone. Every other line of each RPC body is
+-- preserved verbatim — authz checks, the 8-value reason-enum gate, the
+-- founder-attribution gate, search_path, grants, RAISE LOG.
+--
+-- SCOPE — the two non-erasure RPCs deferred from 087, only:
+--   * purge_workspace_member_actions      (mig 063) — retention DELETE
+--   * revoke_template_authorization        (mig 053) — revoke UPDATE
+-- NOT in scope: the trigger functions (already correct after 087), any table /
+-- trigger / index / RLS / grant change, and the pg_cron schedule (already exists,
+-- mig 063 — untouched here).
+--
+-- Conventions: idempotent (CREATE OR REPLACE), no outer BEGIN/COMMIT (Supabase
+-- wraps), search_path pinned on SECURITY DEFINER functions
+-- (cq-pg-security-definer-search-path-pin-pg-temp). Existing function grants are
+-- preserved by CREATE OR REPLACE; re-stated below (defense-in-depth, mirrors 087).
+
+-- =====================================================================
+-- 1. purge_workspace_member_actions — pg_cron 7-year retention DELETE
+-- =====================================================================
+--
+-- Re-CREATE verbatim from mig 063 §7 EXCEPT the two bypass lines. pg_cron
+-- invokes this wrapper instead of a direct DELETE; the pure-reject WORM trigger
+-- would silently block a direct DELETE (learning
+-- 2026-05-15-worm-trigger-blocks-pg-cron-retention-sweep.md). Observability:
+-- cron.job_run_details (auto) + the RAISE LOG row → Supabase logs → Vector →
+-- Better Stack.
+
+CREATE OR REPLACE FUNCTION public.purge_workspace_member_actions()
+  RETURNS int
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_rows int;
+BEGIN
+  SET LOCAL app.worm_bypass = 'on';
+  DELETE FROM public.workspace_member_actions
+   WHERE created_at < now() - interval '7 years';
+  GET DIAGNOSTICS v_rows = ROW_COUNT;
+  SET LOCAL app.worm_bypass = 'off';
+  RAISE LOG 'audit_retention_purge table=workspace_member_actions deleted_count=%', v_rows;
+  RETURN v_rows;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.purge_workspace_member_actions()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.purge_workspace_member_actions()
+  TO postgres;
+
+COMMENT ON FUNCTION public.purge_workspace_member_actions() IS
+  'pg_cron-invoked 7-year retention purge. SET LOCAL app.worm_bypass=''on'' '
+  'bypasses the pure-reject WORM trigger (direct DELETE from cron would silently '
+  'fail — learning 2026-05-15-worm-trigger-blocks-pg-cron-retention-sweep); '
+  're-armed ''off'' after the DELETE. Privilege-free GUC (replaces the prior '
+  'superuser-only replica-role bypass that raised 42501 on managed Supabase). '
+  'Observability: cron.job_run_details (auto) + RAISE LOG. #4231 #4702.';
+
+-- =====================================================================
+-- 2. revoke_template_authorization — founder / auto-revoke UPDATE
+-- =====================================================================
+--
+-- Re-CREATE verbatim from mig 053 §(f) EXCEPT the two bypass lines. Preserves the
+-- authenticated-session guard, the full 8-value p_reason enum gate, and the
+-- founder-attribution gate (PR-I user-impact-reviewer FINDING 1) — only the
+-- bypass GUC changes.
+
+CREATE OR REPLACE FUNCTION public.revoke_template_authorization(
+  p_template_hash text,
+  p_reason        text
+) RETURNS integer
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_temp
+AS $$
+DECLARE
+  affected integer;
+  v_founder_id uuid := auth.uid();
+BEGIN
+  IF v_founder_id IS NULL THEN
+    RAISE EXCEPTION 'revoke_template_authorization: authenticated session required'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_reason NOT IN (
+    'founder_revoked', 'quota_exhausted', 'expired', 'dsr_erasure',
+    'regulator_ordered', 'vendor_tos_revoked', 'policy_violation',
+    'quarantine_retroactive'
+  ) THEN
+    RAISE EXCEPTION 'revoke_template_authorization: invalid reason %', p_reason
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- Authenticated callers (founder-initiated revoke surface at
+  -- /api/template-authorizations/revoke) MUST use reason='founder_revoked'.
+  -- The other 7 enum values are reserved for service-role / postgres
+  -- callers: 'quota_exhausted' / 'expired' fire from the
+  -- isTemplateAuthorized predicate's auto-revoke side effect; 'dsr_erasure'
+  -- fires from anonymise_template_authorizations; the remaining four are
+  -- reserved for operator surfaces (regulator orders, vendor TOS, AUP
+  -- enforcement, classifier feedback in PR-I+1). Without this gate, an
+  -- authenticated founder calling supabase-js RPC directly could stamp
+  -- their OWN row with any reason in the enum (RLS scopes by auth.uid()
+  -- so cross-tenant is impossible, but the founder's own audit-trail
+  -- attribution would break — surfaced by PR-I multi-agent review,
+  -- user-impact-reviewer FINDING 1).
+  IF auth.uid() IS NOT NULL AND p_reason <> 'founder_revoked' THEN
+    RAISE EXCEPTION 'revoke_template_authorization: authenticated callers must use reason=founder_revoked (got %)', p_reason
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- WORM trigger blocks all UPDATEs including founder-initiated revoke; bypass is required.
+  -- app.worm_bypass='on' makes the no-mutate trigger function skip its reject for
+  -- this transaction (privilege-free GUC honored by template_authorizations_no_mutate
+  -- after mig 087; was session_replication_role, superuser-only → 42501 on managed
+  -- Supabase, #4702). Re-armed 'off' after the UPDATE.
+  SET LOCAL app.worm_bypass = 'on';
+  UPDATE public.template_authorizations
+     SET revoked_at = now(),
+         revocation_reason = p_reason
+   WHERE founder_id = v_founder_id
+     AND template_hash = p_template_hash
+     AND revoked_at IS NULL;
+  GET DIAGNOSTICS affected = ROW_COUNT;
+  SET LOCAL app.worm_bypass = 'off';
+
+  RETURN affected;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.revoke_template_authorization(text, text)
+  FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.revoke_template_authorization(text, text)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.revoke_template_authorization(text, text) IS
+  'Founder-initiated revoke (Art. 7(3) "as easily withdrawable as given"). '
+  'Also called auto-revoke-side-effect from the isTemplateAuthorized '
+  'predicate on quota/expired detection so the scope-grants UI does '
+  'not display lying rows.';

--- a/apps/web-platform/test/supabase-migrations/088-worm-bypass-non-erasure-rpcs.test.ts
+++ b/apps/web-platform/test/supabase-migrations/088-worm-bypass-non-erasure-rpcs.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// Migration-shape test for 088_worm_bypass_non_erasure_rpcs.sql (#4702).
+// Offline lint — runs in default CI without a live DB.
+//
+// Context: migration 087 (#4696) converted the GDPR Art. 17 account-delete
+// saga off the superuser-only `SET LOCAL session_replication_role = 'replica'`
+// WORM bypass (which raises 42501 on managed Supabase, where the postgres role
+// owning the SECURITY DEFINER RPCs is NOT a superuser) onto the privilege-free
+// custom `app.worm_bypass` GUC. 087 deliberately deferred the two NON-erasure
+// RPCs that use the identical broken bypass to this follow-up (087.sql L57-59):
+//
+//   * purge_workspace_member_actions()        — pg_cron 7-year retention DELETE
+//                                                (defined mig 063). Silently
+//                                                no-ops on prod (42501) → audit
+//                                                PII over-retains, Art. 5(1)(e).
+//   * revoke_template_authorization(text,text) — founder/auto revoke UPDATE
+//                                                (defined mig 053). 42501 on
+//                                                every call that reaches the
+//                                                bypass → founders cannot
+//                                                withdraw (Art. 7(3)).
+//
+// The trigger functions (workspace_member_actions_no_mutate,
+// template_authorizations_no_mutate) ALREADY honor app.worm_bypass after 087,
+// so 088 swaps the bypass GUC in only the two RPC bodies — no trigger edits.
+//
+// Pins the load-bearing invariants:
+//   1. The forward migration references session_replication_role NOWHERE.
+//   2. Each RPC sets `app.worm_bypass = 'on'` (SET LOCAL) and re-arms 'off'.
+//   3. search_path stays pinned on each SECURITY DEFINER RPC.
+//   4. The two RPCs preserve their content gates (revoke's reason-enum +
+//      founder-attribution gates; purge's 7-year DELETE + RAISE LOG) — so a
+//      careless re-CREATE that drops authz/retention logic fails here.
+//   5. list ↔ migration reconciliation: no function escapes coverage (a future
+//      edit reintroducing session_replication_role on a 3rd function can't stay
+//      green).
+//   6. down migration restores session_replication_role (forward-only reality).
+
+const MIGRATION_PATH = path.join(
+  __dirname,
+  "../../supabase/migrations/088_worm_bypass_non_erasure_rpcs.sql",
+);
+const DOWN_PATH = path.join(
+  __dirname,
+  "../../supabase/migrations/088_worm_bypass_non_erasure_rpcs.down.sql",
+);
+
+const sql = readFileSync(MIGRATION_PATH, "utf8");
+const downSql = readFileSync(DOWN_PATH, "utf8");
+// Strip line comments so assertions match executable SQL, not prose.
+const executable = sql.replace(/--[^\n]*/g, "");
+const downExecutable = downSql.replace(/--[^\n]*/g, "");
+
+// The two non-erasure RPCs deferred from 087 to #4702. Both use the `$$`
+// dollar-quote tag (verified in mig 063/053); revoke is two-arg, purge is
+// zero-arg — fnBlock's `public\.${name}\s*\(` prefix is signature-agnostic.
+const NON_ERASURE_RPCS = [
+  "purge_workspace_member_actions",
+  "revoke_template_authorization",
+];
+
+function fnBlock(src: string, name: string): string {
+  // CREATE OR REPLACE FUNCTION public.<name>(...) ... $function$ ... $function$;
+  // or $$ ... $$; — match either dollar-quote tag, non-greedy to the first
+  // closing tag that terminates the body.
+  const re = new RegExp(
+    `CREATE\\s+OR\\s+REPLACE\\s+FUNCTION\\s+public\\.${name}\\s*\\([\\s\\S]*?\\$([A-Za-z_]*)\\$[\\s\\S]*?\\$\\1\\$\\s*;`,
+    "i",
+  );
+  const m = src.match(re);
+  expect(m, `expected function block for public.${name}`).not.toBeNull();
+  return m![0];
+}
+
+describe("migration 088_worm_bypass_non_erasure_rpcs", () => {
+  describe("no privileged GUC anywhere", () => {
+    it("forward migration never references session_replication_role", () => {
+      expect(executable).not.toMatch(/session_replication_role/i);
+    });
+  });
+
+  describe("non-erasure RPCs use the privilege-free app.worm_bypass GUC", () => {
+    for (const rpc of NON_ERASURE_RPCS) {
+      it(`${rpc} sets app.worm_bypass = 'on' (SET LOCAL) and not session_replication_role`, () => {
+        const block = fnBlock(executable, rpc);
+        expect(block).toMatch(/SET\s+LOCAL\s+app\.worm_bypass\s*=\s*'on'/i);
+        expect(block).not.toMatch(/session_replication_role/i);
+      });
+
+      it(`${rpc} re-arms WORM with SET LOCAL app.worm_bypass = 'off' after the write`, () => {
+        // The re-arm is the single most security-load-bearing line: if it were
+        // dropped, the GUC would leak to the rest of the transaction and any
+        // subsequent statement would silently bypass WORM. SET LOCAL is already
+        // txn-scoped, but each RPC re-arms immediately after its one write
+        // (mirrors the prior RESET session_replication_role, and 087's pattern).
+        const block = fnBlock(executable, rpc);
+        expect(block).toMatch(/SET\s+LOCAL\s+app\.worm_bypass\s*=\s*'off'/i);
+      });
+
+      it(`${rpc} keeps search_path pinned`, () => {
+        const block = fnBlock(executable, rpc);
+        expect(block).toMatch(
+          /SET\s+search_path\s*(?:=|TO)\s*'?public'?\s*,\s*'?pg_temp'?/i,
+        );
+      });
+    }
+  });
+
+  describe("content gates preserved through the re-CREATE", () => {
+    it("purge_workspace_member_actions keeps the 7-year DELETE and the audit_retention_purge RAISE LOG", () => {
+      const block = fnBlock(executable, "purge_workspace_member_actions");
+      expect(block).toMatch(/interval\s+'7 years'/i);
+      expect(block).toMatch(/RAISE\s+LOG\s+'audit_retention_purge/i);
+    });
+
+    it("revoke_template_authorization keeps the 8-value reason-enum gate and the founder-attribution gate", () => {
+      const block = fnBlock(executable, "revoke_template_authorization");
+      // 8-value reason enum (sentinel: the last, least-likely-to-be-typed value)
+      expect(block).toMatch(/'quarantine_retroactive'/i);
+      expect(block).toMatch(/p_reason\s+NOT\s+IN\s*\(/i);
+      // founder-attribution gate
+      expect(block).toMatch(
+        /auth\.uid\(\)\s+IS\s+NOT\s+NULL\s+AND\s+p_reason\s*<>\s*'founder_revoked'/i,
+      );
+      // authenticated-session guard
+      expect(block).toMatch(/v_founder_id\s+uuid\s*:=\s*auth\.uid\(\)/i);
+    });
+  });
+
+  describe("list ↔ migration reconciliation (no function escapes coverage)", () => {
+    it("every CREATE OR REPLACE FUNCTION in the migration is in NON_ERASURE_RPCS", () => {
+      // Regression guard mirroring 087's: if a future edit adds a function
+      // (e.g. reintroducing session_replication_role on a 3rd RPC), the
+      // hardcoded list would silently not cover it and the suite would stay
+      // green. Reconcile the declared set against the migration body.
+      const declared = new Set(NON_ERASURE_RPCS);
+      const created = new Set(
+        [
+          ...executable.matchAll(
+            /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.([a-z0-9_]+)\s*\(/gi,
+          ),
+        ].map((m) => m[1].toLowerCase()),
+      );
+      const uncovered = [...created].filter((n) => !declared.has(n));
+      expect(
+        uncovered,
+        `migration creates functions not in the test's coverage list: ${uncovered.join(", ")}`,
+      ).toEqual([]);
+      const missing = [...declared].filter((n) => !created.has(n));
+      expect(
+        missing,
+        `listed functions absent from the migration: ${missing.join(", ")}`,
+      ).toEqual([]);
+    });
+  });
+
+  describe("down migration", () => {
+    it("restores session_replication_role in both RPCs (forward-only reality)", () => {
+      expect(downExecutable).toMatch(/session_replication_role/i);
+    });
+
+    it("re-CREATEs both RPCs", () => {
+      for (const rpc of NON_ERASURE_RPCS) {
+        expect(
+          downExecutable,
+          `down migration must re-CREATE public.${rpc}`,
+        ).toMatch(
+          new RegExp(
+            `CREATE\\s+OR\\s+REPLACE\\s+FUNCTION\\s+public\\.${rpc}\\s*\\(`,
+            "i",
+          ),
+        );
+      }
+    });
+  });
+});

--- a/apps/web-platform/test/supabase-migrations/088-worm-bypass-non-erasure-rpcs.test.ts
+++ b/apps/web-platform/test/supabase-migrations/088-worm-bypass-non-erasure-rpcs.test.ts
@@ -105,6 +105,26 @@ describe("migration 088_worm_bypass_non_erasure_rpcs", () => {
           /SET\s+search_path\s*(?:=|TO)\s*'?public'?\s*,\s*'?pg_temp'?/i,
         );
       });
+
+      it(`${rpc} arms 'on' BEFORE the single write and re-arms 'off' AFTER it`, () => {
+        // The security property is the ORDERING, not mere presence: arm the
+        // bypass, do exactly one write, re-arm. A body that re-armed 'off'
+        // before the write would leave the write WORM-rejected; one that armed
+        // 'on' after the write would never bypass. Pin arm < write < re-arm.
+        const block = fnBlock(executable, rpc);
+        const onIdx = block.search(/SET\s+LOCAL\s+app\.worm_bypass\s*=\s*'on'/i);
+        const dmlIdx = block.search(/\b(DELETE\s+FROM|UPDATE)\b/i);
+        const offIdx = block.search(
+          /SET\s+LOCAL\s+app\.worm_bypass\s*=\s*'off'/i,
+        );
+        expect(onIdx, "arm 'on' must be present").toBeGreaterThanOrEqual(0);
+        expect(dmlIdx, "single write must follow arm 'on'").toBeGreaterThan(
+          onIdx,
+        );
+        expect(offIdx, "re-arm 'off' must follow the write").toBeGreaterThan(
+          dmlIdx,
+        );
+      });
     }
   });
 
@@ -159,6 +179,14 @@ describe("migration 088_worm_bypass_non_erasure_rpcs", () => {
   describe("down migration", () => {
     it("restores session_replication_role in both RPCs (forward-only reality)", () => {
       expect(downExecutable).toMatch(/session_replication_role/i);
+    });
+
+    it("removes app.worm_bypass from the restored bodies (rollback symmetry)", () => {
+      // Symmetric with the forward migration's `not.toMatch(session_replication_role)`:
+      // a botched down that restored session_replication_role but left a stray
+      // app.worm_bypass line (double-bypass / wrong-GUC re-arm) would otherwise
+      // stay green.
+      expect(downExecutable).not.toMatch(/app\.worm_bypass/i);
     });
 
     it("re-CREATEs both RPCs", () => {

--- a/knowledge-base/project/learnings/2026-05-31-worm-bypass-migration-comment-literal-trips-comment-stripped-test.md
+++ b/knowledge-base/project/learnings/2026-05-31-worm-bypass-migration-comment-literal-trips-comment-stripped-test.md
@@ -1,0 +1,103 @@
+# Learning: WORM-bypass migration COMMENT string literals trip the comment-stripped guardrail test
+
+## Problem
+
+The migration-shape guardrail tests for the WORM-bypass migrations (087, now 088)
+assert the forward migration nowhere references the old privileged GUC:
+
+```ts
+const executable = sql.replace(/--[^\n]*/g, ""); // strips LINE comments only
+expect(executable).not.toMatch(/session_replication_role/i);
+```
+
+The comment-strip removes `-- …` line comments but **not SQL string literals**.
+`COMMENT ON FUNCTION … IS '…'` bodies are string literals, not comments, so any
+mention of `session_replication_role` inside a `COMMENT ON FUNCTION` string
+survives the strip and fails the assertion.
+
+While writing migration 088 (mirroring 087's `session_replication_role →
+app.worm_bypass` swap), the first `purge_workspace_member_actions` COMMENT
+included the explanatory phrase `(was session_replication_role, superuser-only →
+42501…)`. The test failed:
+
+```
+FAIL > no privileged GUC anywhere > forward migration never references session_replication_role
+```
+
+A raw `grep -c session_replication_role <file>` returned 6 (all the `--` header
+lines + the one COMMENT string), which is misleading — only the COMMENT-string
+occurrence is load-bearing for the test, because the test strips `--` lines.
+
+## Solution
+
+In the forward migration, never name the retired GUC literally in any
+`COMMENT ON FUNCTION` string (or any other SQL string literal). Describe it
+generically instead:
+
+```sql
+-- BAD  (string literal trips the comment-stripped test):
+COMMENT ON FUNCTION … IS 'Privilege-free GUC (was session_replication_role …).';
+
+-- GOOD:
+COMMENT ON FUNCTION … IS 'Privilege-free GUC (replaces the prior superuser-only
+  replica-role bypass that raised 42501 on managed Supabase).';
+```
+
+`-- …` header/inline comments may freely mention the old GUC (they are stripped
+before the assertion). The `.down.sql` SHOULD reference it (the down test asserts
+`expect(downExecutable).toMatch(/session_replication_role/i)`).
+
+Verification one-liner that matches the test (NOT a raw grep):
+
+```bash
+sed 's/--.*//' <forward-migration>.sql | grep -c session_replication_role   # must be 0
+```
+
+## Key Insight
+
+When a guardrail test strips comments before a negative `not.toMatch`
+assertion, enumerate every SQL surface that is *not* a `--` comment — string
+literals (`COMMENT ON …`, `RAISE LOG '…'`, `RAISE EXCEPTION '…'`), dollar-quoted
+bodies, and identifiers all survive the strip. The forbidden token must be
+absent from all of them, not just from the executable statements you were
+focused on. A raw `grep -c` over-counts (includes the stripped `--` lines) and
+mis-points; mirror the test's own strip (`sed 's/--.*//'`) when self-checking.
+
+This also hardened the 088 test beyond the 087 pattern: added an
+arm-`'on'` < write < re-arm-`'off'` **ordering** assertion (presence alone is
+vacuous — a body that re-armed before the write would WORM-reject the write) and
+a down-migration `not.toMatch(/app\.worm_bypass/i)` rollback-symmetry assertion.
+
+## Session Errors
+
+1. **`worktree-manager.sh create` blocked on interactive `Proceed? (y/n)`** — the
+   Bash tool is non-interactive, so the first create (without `--yes`) hung.
+   Recovery: piped `printf 'y\n'`; the one-shot path used `--yes`.
+   **Prevention:** always pass `--yes` to `worktree-manager.sh create` in
+   non-interactive/agent sessions.
+2. **one-shot collision gate false-positive on closed contextual ref `#4696`** —
+   the `#N` regex matched a closed predecessor citation and aborted the first
+   `/soleur:one-shot` invocation. Recovery: re-invoked with `#4696` rewritten as
+   `issue 4696` (no `#`), leaving only the open work-target `#4702` in `#N` form.
+   **Prevention:** scrub closed contextual `#N` refs to non-hash phrasing before
+   invoking one-shot (already documented in one-shot Step 0a.5 sharp edges +
+   learning `2026-05-25-one-shot-closed-issue-gate-fires-on-contextual-refs`).
+3. **`gh issue create` blocked: missing `--milestone`** (PreToolUse hook).
+   Recovery: added `--milestone "Post-MVP / Later"` for the operational bug.
+   **Prevention:** include `--milestone` on every `gh issue create` (already
+   hook-enforced; not a workflow gap).
+4. **`/tmp/<file>` did not persist between Bash tool calls** — a heredoc-written
+   body-file was absent ("no such file or directory") on the next Bash
+   invocation. Recovery: write the body-file and consume it (`gh issue create
+   --body-file`) in the SAME Bash call. **Prevention:** never assume `/tmp`
+   artifacts survive across separate Bash tool calls in this environment; write +
+   use in one invocation, or write inside the repo worktree.
+5. **Forward-migration COMMENT string literal tripped the comment-stripped test**
+   (the subject of this learning). Recovery: reworded the COMMENT to avoid the
+   literal `session_replication_role`. **Prevention:** see Solution above; the
+   verification one-liner mirrors the test's `--`-strip.
+
+## Tags
+category: build-errors
+module: apps/web-platform/supabase/migrations
+related: 087_worm_bypass_privilege_independence, 088_worm_bypass_non_erasure_rpcs, "#4702", "#4709"

--- a/knowledge-base/project/plans/2026-05-31-fix-migration-088-worm-bypass-non-erasure-rpcs-plan.md
+++ b/knowledge-base/project/plans/2026-05-31-fix-migration-088-worm-bypass-non-erasure-rpcs-plan.md
@@ -174,19 +174,18 @@ required at plan time; `user-impact-reviewer` runs at review-time.
 ## Acceptance Criteria
 
 ### Pre-merge (PR)
-- [ ] `088_worm_bypass_non_erasure_rpcs.sql` exists; `grep -c session_replication_role` on it returns `0`.
-- [ ] `grep -c "SET LOCAL app.worm_bypass = 'on'"` on the forward migration returns `2` (one per RPC).
-- [ ] `grep -c "SET LOCAL app.worm_bypass = 'off'"` on the forward migration returns `2`.
-- [ ] Each RPC block retains `SET search_path = public, pg_temp` (asserted by the test's per-RPC `search_path` check).
-- [ ] `revoke_template_authorization` body still contains the 8-value `p_reason` enum gate and the
-      `auth.uid() IS NOT NULL AND p_reason <> 'founder_revoked'` founder-attribution gate (diff shows
-      only the two bypass lines + comment changed vs. mig 053 body).
-- [ ] `purge_workspace_member_actions` body still contains the `created_at < now() - interval '7 years'`
-      DELETE and the `RAISE LOG 'audit_retention_purge …'` line.
-- [ ] `088_…down.sql` exists; `grep -c session_replication_role` returns `≥ 2` (both RPCs restored).
-- [ ] New test file `088-worm-bypass-non-erasure-rpcs.test.ts` passes; the list↔migration reconciliation
+- [x] `088_worm_bypass_non_erasure_rpcs.sql` exists; comment-stripped executable references `session_replication_role` `0` times (test-pinned).
+- [x] Forward migration sets `SET LOCAL app.worm_bypass = 'on'` once per RPC (test-pinned per-RPC fnBlock).
+- [x] Forward migration sets `SET LOCAL app.worm_bypass = 'off'` (re-arm) once per RPC (test-pinned).
+- [x] Each RPC block retains `SET search_path = public, pg_temp` (asserted by the test's per-RPC `search_path` check).
+- [x] `revoke_template_authorization` body still contains the 8-value `p_reason` enum gate and the
+      `auth.uid() IS NOT NULL AND p_reason <> 'founder_revoked'` founder-attribution gate (test-pinned content gate; copied verbatim from mig 053 modulo the two bypass lines + comment).
+- [x] `purge_workspace_member_actions` body still contains the `created_at < now() - interval '7 years'`
+      DELETE and the `RAISE LOG 'audit_retention_purge …'` line (test-pinned content gate).
+- [x] `088_…down.sql` exists; `grep -c session_replication_role` returns `8` (both RPCs restored).
+- [x] New test file `088-worm-bypass-non-erasure-rpcs.test.ts` passes; the list↔migration reconciliation
       test reports zero uncovered functions.
-- [ ] 087 test still passes (no regression on the shared trigger functions / shared assertions).
+- [x] 087 test still passes (45 tests; no regression on the shared trigger functions / shared assertions).
 - [ ] PR body uses `Closes #4702`.
 
 ### Post-merge (operator)

--- a/knowledge-base/project/plans/2026-05-31-fix-migration-088-worm-bypass-non-erasure-rpcs-plan.md
+++ b/knowledge-base/project/plans/2026-05-31-fix-migration-088-worm-bypass-non-erasure-rpcs-plan.md
@@ -44,10 +44,17 @@ superuser, so that GUC raises `42501 permission denied to set parameter "session
 - `purge_workspace_member_actions` is invoked by pg_cron and **never deletes anything** — the
   7-year retention sweep is silently a no-op, an Art. 5(1)(e) storage-limitation drift (audit PII
   accumulates past its lawful retention window indefinitely).
-- `revoke_template_authorization` throws `42501` on every call that reaches the bypass — both the
-  founder-initiated revoke (`/api/template-authorizations/revoke`) and the service-role auto-revoke
-  side-effect (`is-template-authorized.ts`, reasons `expired`/`quota_exhausted`). Founders cannot
-  withdraw a template authorization (Art. 7(3) "as easily withdrawable as given").
+- `revoke_template_authorization` throws `42501` when the founder-initiated revoke
+  (`/api/template-authorizations/revoke`, `reason='founder_revoked'`) reaches the bypass line. Founders
+  cannot withdraw a template authorization (Art. 7(3) "as easily withdrawable as given"). 088 fixes
+  **this** path. **Correction (review FINDING 4):** the auto-revoke side-effect
+  (`is-template-authorized.ts`, reasons `expired`/`quota_exhausted`) does NOT also benefit from 088 — its
+  caller runs the authenticated SSR client (`createClient()`, `auth.uid()` non-NULL), so the pre-existing
+  founder-attribution gate (`auth.uid() IS NOT NULL AND p_reason <> 'founder_revoked'` → 42501) rejects
+  it *before* the bypass line, independent of which GUC the bypass uses. That path is a pre-existing
+  latent defect outside 088's scope (it is fire-and-forget — `warnSilentFallback`, no user-facing 500 —
+  and read-time denial keeps the gate behavior correct; only the persisted `revoked_at` never lands).
+  Tracked separately as a discovered bug (#4709); 088 neither fixes nor regresses it.
 
 **The trigger functions are already fixed.** Migration 087 §1.2 rewrote
 `template_authorizations_no_mutate()` and §1.5 rewrote `workspace_member_actions_no_mutate()` to honor
@@ -71,7 +78,7 @@ RAISE LOG). Add a migration-shape guardrail test mirroring
 | Trigger functions already honor `app.worm_bypass` after 087 | Confirmed: 087 §1.2 `template_authorizations_no_mutate` + §1.5 `workspace_member_actions_no_mutate` both check `current_setting('app.worm_bypass', true) = 'on'`. Triggers `EXECUTE FUNCTION` those functions (mig 063 L133/L139, mig 053 L181/L187). | No trigger-function edits in 088. Down migration also leaves triggers untouched. |
 | Guardrail test should assert neither **function** references `session_replication_role` | The two trigger functions never referenced it post-087 anyway; the live references are in the two **RPC** bodies. | Test asserts (a) the 088 forward migration nowhere references `session_replication_role`, and (b) each of the two RPCs sets `app.worm_bypass='on'`/`'off'` and keeps `search_path` pinned. Mirrors 087 test structure. |
 | `purge` is "scheduled" / cron-invoked | mig 063 COMMENT: "pg_cron-invoked 7-year retention purge." Caller is pg_cron (no app-code call site). | Plan notes the cron path; verification is migration-shape + a DEV-only live probe (no PROD writes). |
-| `revoke` has a single call path | TWO callers: `app/api/template-authorizations/revoke/route.ts` (authenticated founder, `reason='founder_revoked'`) and `server/templates/is-template-authorized.ts:180` (service-role auto-revoke, `reason='expired'`/`'quota_exhausted'`). Both reach the same bypassed UPDATE. | Preserve the full reason-enum gate + `auth.uid()` authz block verbatim; only swap the two bypass lines. Both callers benefit. |
+| `revoke` has a single call path | TWO callers: `app/api/template-authorizations/revoke/route.ts` (authenticated founder, `reason='founder_revoked'`) and `server/templates/is-template-authorized.ts:180` (auto-revoke, `reason='expired'`/`'quota_exhausted'`). **Correction (review FINDING 4):** the auto-revoke caller is NOT service-role — it runs the authenticated SSR client (`send/route.ts:82` → `runTemplateGate` → `isTemplateAuthorized`, `auth.uid()` non-NULL), so it is rejected at the founder-attribution gate (42501) *before* the bypass, independent of the GUC swap. Only the founder path reaches the bypassed UPDATE. | Preserve the full reason-enum gate + `auth.uid()` authz block verbatim; only swap the two bypass lines. **Only the founder-initiated path benefits**; the auto-revoke path is a pre-existing defect tracked separately (a real fix needs a service-role client or a gate carve-out — a security design call outside 088's mirror-087 scope). |
 
 ## User-Brand Impact
 

--- a/knowledge-base/project/plans/2026-05-31-fix-migration-088-worm-bypass-non-erasure-rpcs-plan.md
+++ b/knowledge-base/project/plans/2026-05-31-fix-migration-088-worm-bypass-non-erasure-rpcs-plan.md
@@ -1,0 +1,314 @@
+---
+title: "Migration 088 — privilege-free WORM bypass for the two non-erasure RPCs"
+type: fix
+issue: 4702
+branch: feat-one-shot-migration-088-worm-bypass-non-erasure-rpcs
+date: 2026-05-31
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+---
+
+# Migration 088 — privilege-free WORM bypass for `purge_workspace_member_actions` + `revoke_template_authorization`
+
+## Enhancement Summary
+
+**Deepened on:** 2026-05-31
+**Sections enhanced:** Risks & Mitigations (precedent-diff), Files to Create (test-helper edge cases)
+**Gates run:** GDPR-gate (Phase 2.7, no findings), deepen-plan 4.4 (precedent-diff), 4.6 (User-Brand Impact present), 4.7 (Observability present, no SSH), 4.8 (no PAT-shaped vars)
+
+### Key Improvements
+1. Precedent-diff confirmed both target RPCs use the `AS $$` dollar-quote tag and `SECURITY DEFINER` — byte-identical to the mig 063/053 originals modulo the two bypass lines; the 087 `fnBlock` test helper handles `$$` (verified).
+2. Confirmed the 087 `fnBlock` regex prefix `public\.${name}\s*\(` matches `purge_workspace_member_actions()` (zero-arg, empty parens) and `revoke_template_authorization(text, text)` (two-arg) — the new test can reuse it verbatim.
+3. Confirmed the trigger functions need NO edits (087 §1.2/§1.5 already converted them); 088 is RPC-body-only, eliminating a redundant-CREATE drift risk.
+
+### New Considerations Discovered
+- The 087 forward migration uses a MIX of dollar-quote tags (`$fn$` for the anonymise RPCs, but the two target RPCs in 063/053 use `$$`). The new 088 test MUST keep the 087 `fnBlock` regex's `\$([A-Za-z_]*)\$ … \$\1\$` backreference form so it matches the `$$` (empty-tag) case — do not hard-code `$fn$`.
+- `purge_workspace_member_actions` has no app-code call site (pg_cron only), so the "wired call site" Art-17-caller check is N/A; its liveness is the `cron.job_run_details` + `RAISE LOG audit_retention_purge` path, captured in Observability.
+
+## Overview
+
+Migration 087 (PR #4679, closed #4696) converted the entire GDPR Art. 17 account-delete saga from the
+superuser-only `SET LOCAL session_replication_role = 'replica'` WORM bypass to the privilege-free
+custom GUC `app.worm_bypass`. It explicitly deferred two **non-erasure** RPCs to follow-up #4702
+(087.sql lines 57-59):
+
+- `purge_workspace_member_actions()` — the pg_cron 7-year retention DELETE sweep (defined in mig 063).
+- `revoke_template_authorization(text, text)` — the founder/auto-revoke UPDATE (defined in mig 053).
+
+Both still issue `SET LOCAL session_replication_role = 'replica'` … `RESET session_replication_role`.
+On managed Supabase the `postgres` role that owns these `SECURITY DEFINER` functions is **not** a
+superuser, so that GUC raises `42501 permission denied to set parameter "session_replication_role"`
+**before** the DML runs. Consequences:
+
+- `purge_workspace_member_actions` is invoked by pg_cron and **never deletes anything** — the
+  7-year retention sweep is silently a no-op, an Art. 5(1)(e) storage-limitation drift (audit PII
+  accumulates past its lawful retention window indefinitely).
+- `revoke_template_authorization` throws `42501` on every call that reaches the bypass — both the
+  founder-initiated revoke (`/api/template-authorizations/revoke`) and the service-role auto-revoke
+  side-effect (`is-template-authorized.ts`, reasons `expired`/`quota_exhausted`). Founders cannot
+  withdraw a template authorization (Art. 7(3) "as easily withdrawable as given").
+
+**The trigger functions are already fixed.** Migration 087 §1.2 rewrote
+`template_authorizations_no_mutate()` and §1.5 rewrote `workspace_member_actions_no_mutate()` to honor
+`current_setting('app.worm_bypass', true) = 'on'`. The triggers (`workspace_member_actions_no_delete`,
+the `template_authorizations` no-update/no-delete pair) `EXECUTE FUNCTION` those same functions
+(verified in mig 063 L133/L139 and mig 053 L181/L187). So **only the two RPC bodies need the swap** —
+no trigger-function edits in 088.
+
+Migration 088 mirrors 087 exactly: replace `SET LOCAL session_replication_role = 'replica'` with
+`SET LOCAL app.worm_bypass = 'on'` and `RESET session_replication_role` with
+`SET LOCAL app.worm_bypass = 'off'` (re-arm immediately after the single write), preserving every
+other line of each RPC body verbatim (authz checks, reason-enum gate, `search_path`, grants, COMMENTs,
+RAISE LOG). Add a migration-shape guardrail test mirroring
+`test/supabase-migrations/087-worm-bypass-privilege-independence.test.ts`.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Cited claim (task description) | Reality (verified) | Plan response |
+|---|---|---|
+| Replace `session_replication_role` in the RPC bodies of `purge_workspace_member_actions` and `revoke_template_authorization` | Both RPCs still carry `SET LOCAL session_replication_role = 'replica'` … `RESET …` (purge: mig 063 body; revoke: mig 053 body). Neither was redefined by 087. | Re-CREATE both via `CREATE OR REPLACE` in 088 with `app.worm_bypass`. |
+| Trigger functions already honor `app.worm_bypass` after 087 | Confirmed: 087 §1.2 `template_authorizations_no_mutate` + §1.5 `workspace_member_actions_no_mutate` both check `current_setting('app.worm_bypass', true) = 'on'`. Triggers `EXECUTE FUNCTION` those functions (mig 063 L133/L139, mig 053 L181/L187). | No trigger-function edits in 088. Down migration also leaves triggers untouched. |
+| Guardrail test should assert neither **function** references `session_replication_role` | The two trigger functions never referenced it post-087 anyway; the live references are in the two **RPC** bodies. | Test asserts (a) the 088 forward migration nowhere references `session_replication_role`, and (b) each of the two RPCs sets `app.worm_bypass='on'`/`'off'` and keeps `search_path` pinned. Mirrors 087 test structure. |
+| `purge` is "scheduled" / cron-invoked | mig 063 COMMENT: "pg_cron-invoked 7-year retention purge." Caller is pg_cron (no app-code call site). | Plan notes the cron path; verification is migration-shape + a DEV-only live probe (no PROD writes). |
+| `revoke` has a single call path | TWO callers: `app/api/template-authorizations/revoke/route.ts` (authenticated founder, `reason='founder_revoked'`) and `server/templates/is-template-authorized.ts:180` (service-role auto-revoke, `reason='expired'`/`'quota_exhausted'`). Both reach the same bypassed UPDATE. | Preserve the full reason-enum gate + `auth.uid()` authz block verbatim; only swap the two bypass lines. Both callers benefit. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a founder clicks "revoke template authorization" and
+gets a 500 (the `42501` surfaces as an RPC error at `/api/template-authorizations/revoke`); separately,
+their audit-trail PII silently outlives its lawful 7-year retention window because the cron purge is a
+permanent no-op.
+
+**If this leaks, the user's data is exposed via:** the re-arm line is the single most security-load-
+bearing statement — if `SET LOCAL app.worm_bypass = 'off'` were omitted, the `'on'` GUC would persist
+for the rest of the transaction and any subsequent statement in that txn would silently bypass the WORM
+trigger (audit-trail tamper surface). `SET LOCAL` is already txn-scoped, but the explicit re-arm
+mirrors 087 and is pinned by the guardrail test.
+
+**Brand-survival threshold:** single-user incident — a single founder's failed revoke (Art. 7(3)) or a
+single user's over-retained audit PII (Art. 5(1)(e)) is a compliance-visible regression. CPO sign-off
+required at plan time; `user-impact-reviewer` runs at review-time.
+
+## Files to Create
+
+- `apps/web-platform/supabase/migrations/088_worm_bypass_non_erasure_rpcs.sql`
+  - Header comment block mirroring 087's structure: problem (42501 on the two deferred non-erasure
+    RPCs), why the trigger functions are already correct (087 §1.2/§1.5), the fix (GUC swap only),
+    scope (these two RPCs only), conventions (idempotent `CREATE OR REPLACE`, no outer
+    `BEGIN/COMMIT`, `search_path` pinned per `cq-pg-security-definer-search-path-pin-pg-temp`, grants
+    preserved by `CREATE OR REPLACE`). Cite #4702 and the 087 precedent.
+  - **§1 `purge_workspace_member_actions()`** — re-CREATE verbatim from mig 063 EXCEPT:
+    - `SET LOCAL session_replication_role = 'replica';` → `SET LOCAL app.worm_bypass = 'on';`
+    - `RESET session_replication_role;` → `SET LOCAL app.worm_bypass = 'off';`
+    - Keep `RETURNS int`, `SECURITY DEFINER`, `SET search_path = public, pg_temp`, the
+      `DELETE … WHERE created_at < now() - interval '7 years'`, `GET DIAGNOSTICS`, the
+      `RAISE LOG 'audit_retention_purge …'`, and `RETURN v_rows`.
+    - Re-issue the existing `REVOKE ALL … FROM PUBLIC, anon, authenticated` and
+      `GRANT EXECUTE … TO postgres` (defense-in-depth; `CREATE OR REPLACE` preserves them but
+      re-stating mirrors 087's REVOKE pattern).
+    - Refresh the `COMMENT ON FUNCTION` to cite `app.worm_bypass` + #4702 (drop the stale
+      `session_replication_role` wording in the existing comment).
+  - **§2 `revoke_template_authorization(text, text)`** — re-CREATE verbatim from mig 053 EXCEPT the
+    same two bypass-line swaps. **Preserve verbatim:** the `v_founder_id := auth.uid()` + NULL check,
+    the full 8-value `p_reason` enum gate, the `auth.uid() IS NOT NULL AND p_reason <> 'founder_revoked'`
+    founder-attribution gate, `RETURNS integer`, `SECURITY DEFINER`, `search_path`, the
+    `UPDATE … SET revoked_at=now(), revocation_reason=p_reason WHERE founder_id=v_founder_id AND
+    template_hash=p_template_hash AND revoked_at IS NULL`, `GET DIAGNOSTICS`, `RETURN affected`.
+    - Re-issue the existing `REVOKE ALL … FROM PUBLIC, anon, authenticated, service_role` and
+      `GRANT EXECUTE … TO authenticated`.
+    - Update the inline bypass comment (currently describes `session_replication_role` skipping BEFORE
+      triggers) to describe `app.worm_bypass`; refresh the `COMMENT ON FUNCTION` if it names the old GUC
+      (it does not — leave the Art. 7(3) prose intact).
+
+- `apps/web-platform/supabase/migrations/088_worm_bypass_non_erasure_rpcs.down.sql`
+  - Re-CREATE both RPCs with the original `session_replication_role` bypass bodies (copy the exact
+    pre-088 bodies from mig 063 / mig 053), restoring `RESET session_replication_role`. Mirror 087's
+    down structure. Header WARNING: forward-only reality — the down reinstates the prod-broken `42501`
+    behavior and is for local rollback only, NOT a production remediation. No table/trigger DDL to
+    revert (088 touches only these two function bodies).
+
+- `apps/web-platform/test/supabase-migrations/088-worm-bypass-non-erasure-rpcs.test.ts`
+  - Mirror 087's offline migration-shape test (vitest, `readFileSync` + comment strip). Pins:
+    1. Forward migration nowhere references `session_replication_role` (`expect(executable).not.toMatch(/session_replication_role/i)`).
+    2. For each of `["purge_workspace_member_actions", "revoke_template_authorization"]`: the function
+       block sets `SET LOCAL app.worm_bypass = 'on'`, sets `SET LOCAL app.worm_bypass = 'off'` (re-arm),
+       does NOT match `session_replication_role`, and keeps `search_path` pinned. Reuse 087's
+       `fnBlock` regex helper (handles `$$`/`$fn$`/`$function$` tags) — but note both target RPCs use
+       the `$$` dollar-quote tag (verified in mig 053/063), and `revoke_template_authorization` has a
+       **two-arg signature** so the helper's `public\.${name}\s*\(` prefix already matches.
+    3. List ↔ migration reconciliation: every `CREATE OR REPLACE FUNCTION public.<name>(` in the
+       088 forward migration is in the declared 2-RPC set (regression guard mirroring 087's, so a future
+       edit that reintroduces `session_replication_role` on a 3rd function cannot stay green).
+    4. Down migration restores `session_replication_role` (`expect(downExecutable).toMatch(/session_replication_role/i)`).
+
+## Implementation Phases
+
+### Phase 0 — Preconditions (verify before writing)
+- `cat apps/web-platform/supabase/migrations/063_workspace_member_actions.sql` — copy the exact current
+  `purge_workspace_member_actions()` body (lines around the `$$ … $$;` block) as the pre-088 baseline.
+- `cat apps/web-platform/supabase/migrations/053_template_authorizations.sql` — copy the exact current
+  `revoke_template_authorization(text, text)` body as the pre-088 baseline.
+- Confirm 088 is the next free number: `ls apps/web-platform/supabase/migrations/ | grep '^08'`
+  (087 is the highest — verified).
+- Confirm vitest include glob covers the new test: `test/**/*.test.ts` (vitest.config.ts:44) matches
+  `test/supabase-migrations/088-…test.ts` (087's test runs under the same glob — verified).
+
+### Phase 1 — RED (cq-write-failing-tests-before)
+- Write `088-worm-bypass-non-erasure-rpcs.test.ts`. Run it; it fails because the 088 migration files
+  do not yet exist (`readFileSync` ENOENT) → red as required.
+
+### Phase 2 — GREEN
+- Write `088_worm_bypass_non_erasure_rpcs.sql` (both RPC re-CREATEs with the GUC swap).
+- Write `088_worm_bypass_non_erasure_rpcs.down.sql` (both RPC re-CREATEs with the original
+  `session_replication_role` bodies).
+- Run the new test → green. Run the 087 test too (unchanged, must stay green).
+
+### Phase 3 — Full suite + migration lint
+- Run the web-platform vitest suite for the migration-shape directory:
+  `./node_modules/.bin/vitest run test/supabase-migrations/` (from `apps/web-platform`).
+- If the repo has a migration-apply DEV smoke path, exercise it DEV-only (see Observability
+  `discoverability_test`). Never apply against PROD; never create synthetic rows on PROD
+  (`hr-dev-prd-distinct-supabase-projects`).
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- [ ] `088_worm_bypass_non_erasure_rpcs.sql` exists; `grep -c session_replication_role` on it returns `0`.
+- [ ] `grep -c "SET LOCAL app.worm_bypass = 'on'"` on the forward migration returns `2` (one per RPC).
+- [ ] `grep -c "SET LOCAL app.worm_bypass = 'off'"` on the forward migration returns `2`.
+- [ ] Each RPC block retains `SET search_path = public, pg_temp` (asserted by the test's per-RPC `search_path` check).
+- [ ] `revoke_template_authorization` body still contains the 8-value `p_reason` enum gate and the
+      `auth.uid() IS NOT NULL AND p_reason <> 'founder_revoked'` founder-attribution gate (diff shows
+      only the two bypass lines + comment changed vs. mig 053 body).
+- [ ] `purge_workspace_member_actions` body still contains the `created_at < now() - interval '7 years'`
+      DELETE and the `RAISE LOG 'audit_retention_purge …'` line.
+- [ ] `088_…down.sql` exists; `grep -c session_replication_role` returns `≥ 2` (both RPCs restored).
+- [ ] New test file `088-worm-bypass-non-erasure-rpcs.test.ts` passes; the list↔migration reconciliation
+      test reports zero uncovered functions.
+- [ ] 087 test still passes (no regression on the shared trigger functions / shared assertions).
+- [ ] PR body uses `Closes #4702`.
+
+### Post-merge (operator)
+- [ ] Migration 088 applied to PROD via the existing `web-platform-release.yml#migrate` job on merge to
+      `main` (path-filtered on `apps/web-platform/**`). Automation: handled by the release pipeline — no
+      separate operator apply step. Verify applied via `mcp__plugin_supabase_supabase__*` (read-only:
+      confirm the function body no longer contains `session_replication_role`).
+
+## Domain Review
+
+**Domains relevant:** Engineering (CTO), Legal/Compliance (CLO), Product (CPO)
+
+### Engineering (CTO)
+**Status:** reviewed (carry-forward from 087 / inline)
+**Assessment:** Pure RPC-body swap mirroring a merged, tested precedent (087). No trigger, table, index,
+RLS, or grant changes. `SECURITY DEFINER` + pinned `search_path` preserved
+(`cq-pg-security-definer-search-path-pin-pg-temp`). Idempotent `CREATE OR REPLACE`, Supabase-wrapped
+transaction (no outer `BEGIN/COMMIT`). The deepen-plan precedent-diff gate (Phase 4.4) should diff the
+088 RPC bodies against the 087 anonymise-RPC pattern and against the mig 063/053 originals to confirm
+byte-identical bodies modulo the two bypass lines + comments.
+
+### Legal/Compliance (CLO)
+**Status:** reviewed (inline)
+**Assessment:** Unblocks two compliance-load-bearing operations broken on PROD: Art. 5(1)(e)
+storage-limitation (the 7-year purge currently no-ops, so audit PII over-retains) and Art. 7(3)
+withdrawal-as-easy-as-consent (founder revoke currently 500s). gdpr-gate runs at Phase 2.7 (migration +
+`.sql` surface).
+
+### Product/UX Gate
+**Tier:** none
+**Decision:** N/A — no new user-facing page, flow, or component. The fix repairs an existing failing
+API path (`/api/template-authorizations/revoke`) and a backend cron; no UI surface is created or
+restyled.
+
+## Infrastructure (IaC)
+
+Skipped — no new infrastructure. Migration 088 edits two existing function bodies on an
+already-provisioned Supabase project; it is applied by the existing `web-platform-release.yml#migrate`
+job (path-filtered on `apps/web-platform/**`) on merge to `main`. No new server, secret, vendor, cron,
+DNS, or TLS resource. The pg_cron schedule that invokes `purge_workspace_member_actions` already exists
+(mig 063); 088 does not touch the cron.job entry.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "purge_workspace_member_actions RAISE LOG 'audit_retention_purge table=workspace_member_actions deleted_count=%' fires non-zero after the next 7-year-old row exists; revoke succeeds (HTTP 200 at /api/template-authorizations/revoke)"
+  cadence: "purge: pg_cron schedule (mig 063); revoke: per founder/auto-revoke call"
+  alert_target: "Supabase Postgres logs (cron.job_run_details auto-captures purge runs); Sentry for revoke-route 5xx"
+  configured_in: "mig 063 RAISE LOG (purge); apps/web-platform/app/api/template-authorizations/revoke/route.ts reportSilentFallback (revoke)"
+error_reporting:
+  destination: "Sentry (revoke route already wraps the RPC error and reports op=revoke_template_authorization); Postgres log for the purge 42501 (pre-fix) / success (post-fix)"
+  fail_loud: true
+failure_modes:
+  - mode: "re-arm line dropped (app.worm_bypass leaks past the write)"
+    detection: "guardrail test asserts SET LOCAL app.worm_bypass='off' present in each RPC block"
+    alert_route: "CI test failure (blocks merge)"
+  - mode: "purge still no-ops (session_replication_role left in body)"
+    detection: "guardrail test: grep session_replication_role == 0 on forward migration"
+    alert_route: "CI test failure"
+  - mode: "revoke regression (reason-enum gate or authz block accidentally dropped during re-CREATE)"
+    detection: "AC diff-check: body byte-identical to mig 053 modulo bypass lines"
+    alert_route: "PR review + AC checklist"
+logs:
+  where: "Supabase Postgres logs (RAISE LOG audit_retention_purge); Sentry (revoke 5xx)"
+  retention: "Supabase log retention (project default); Sentry retention"
+discoverability_test:
+  command: "cd apps/web-platform && ./node_modules/.bin/vitest run test/supabase-migrations/088-worm-bypass-non-erasure-rpcs.test.ts && ./node_modules/.bin/vitest run test/supabase-migrations/087-worm-bypass-privilege-independence.test.ts"
+  expected_output: "both test files pass; 088 reports 2 RPCs covered with app.worm_bypass on/off and zero session_replication_role references"
+```
+
+## Test Scenarios
+
+- **Offline migration-shape (primary, CI default):** the new vitest file (mirrors 087). Asserts the GUC
+  swap, the re-arm, `search_path` pinning, zero `session_replication_role` in the forward migration, and
+  list↔migration reconciliation. Runs without a live DB.
+- **DEV-only live probe (optional, if a DEV Supabase apply path is wired):** apply 088 on DEV; insert a
+  synthesized `workspace_member_actions` row with `created_at` > 7 years old (synthesized fixture only,
+  `cq-test-fixtures-synthesized-only`), call `purge_workspace_member_actions()` as `postgres`/service
+  role, assert `deleted_count = 1` and no `42501`. Call `revoke_template_authorization(<hash>,
+  'founder_revoked')` as an authenticated test user on a synthesized authorization row, assert
+  `revoked_at` set and no `42501`. **DEV only** — never on PROD (`hr-dev-prd-distinct-supabase-projects`).
+
+## Risks & Mitigations
+
+- **Risk: re-CREATE drops a line of the revoke authz/reason gate.** Mitigation: copy the exact pre-088
+  body from mig 053 and change only the two bypass lines + the inline bypass comment; AC requires a
+  diff-check confirming byte-identity modulo those lines.
+- **Risk: the re-arm GUC line is omitted** (the security-load-bearing line per 087's test rationale).
+  Mitigation: guardrail test pins `SET LOCAL app.worm_bypass = 'off'` per RPC.
+- **Risk: down migration desync** — down must restore the *exact* pre-088 bodies. Mitigation: down test
+  asserts `session_replication_role` is present; copy the pre-088 bodies verbatim into the down file.
+- **Precedent diff (deepen-plan Phase 4.4 — performed):** the canonical WORM-bypass-RPC form is
+  established by migration 087 §3 (nine anonymise RPCs). Side-by-side against the 088 targets:
+
+  | Aspect | 087 anonymise RPCs (precedent) | 088 `purge` / `revoke` (this plan) | Match? |
+  |---|---|---|---|
+  | Bypass set | `SET LOCAL app.worm_bypass = 'on';` | same | yes |
+  | Re-arm | `SET LOCAL app.worm_bypass = 'off';` (after the single write) | same | yes |
+  | Security clause | `SECURITY DEFINER` | `SECURITY DEFINER` (both 063/053 originals are DEFINER — verified) | yes |
+  | `search_path` | `SET search_path = public, pg_temp` | preserved verbatim | yes |
+  | Dollar-quote tag | mix (`$fn$` and `$$`) | both targets use `$$` (verified in 063/053) | n/a (test helper handles both) |
+  | DML scope | one UPDATE/DELETE between on/off | purge: one DELETE; revoke: one UPDATE | yes |
+
+  No deviation from precedent. The only structural difference from the 087 RPCs is the **absence of an
+  `auth.uid()` block in `purge`** (it is a service-role/postgres-only cron RPC, gated by its existing
+  `GRANT EXECUTE … TO postgres` + `REVOKE … FROM PUBLIC, anon, authenticated`) — this matches the
+  original mig 063 body and is correct; do NOT add an authz block. `revoke` keeps its existing
+  `auth.uid()` + reason-enum gate. **No novel pattern; precedent is migration 087.**
+
+## Open Code-Review Overlap
+
+None (check ran against the 3 planned files; no open `code-review`-labeled issue names them).
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder text, or
+  omits the threshold will fail `deepen-plan` Phase 4.6. (Filled above.)
+- Both target RPCs use the `$$` dollar-quote tag (not `$fn$`); the 087 `fnBlock` regex helper matches
+  either, but when reusing it verify the non-greedy `$\1$` close still terminates on the function's own
+  `$$;` and not a later one. `revoke_template_authorization` is two-arg — the helper's
+  `public\.${name}\s*\(` prefix is signature-agnostic, so it matches.
+- Do NOT touch the trigger functions in 088 — they were already converted by 087, and editing them here
+  would create a redundant second `CREATE OR REPLACE` that the 087 test's list↔migration reconciliation
+  does not cover (and is needless drift). 088 is RPC-body-only.

--- a/knowledge-base/project/specs/feat-one-shot-migration-088-worm-bypass-non-erasure-rpcs/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-migration-088-worm-bypass-non-erasure-rpcs/session-state.md
@@ -1,0 +1,19 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-one-shot-migration-088-worm-bypass-non-erasure-rpcs/knowledge-base/project/plans/2026-05-31-fix-migration-088-worm-bypass-non-erasure-rpcs-plan.md
+- Status: complete
+
+### Errors
+None. CWD verified equal to WORKING DIRECTORY before any other action. Premise validation passed: #4702 OPEN (target), #4696 CLOSED by merged PR #4679, migration 087 is the highest number (088 next free).
+
+### Decisions
+- RPC-body-only scope confirmed: migration 087 already converted both trigger functions to honor `app.worm_bypass`; 088 swaps the bypass GUC in only the two RPC bodies — no trigger edits.
+- Current RPC definitions live in 053 (revoke_template_authorization, UPDATE) and 063 (purge_workspace_member_actions, DELETE), both still carrying `SET LOCAL session_replication_role='replica'` (the 42501 on managed Supabase).
+- Preserve revoke's full authz surface (two callers, 8-value reason enum + founder-attribution gate) — byte-identity modulo the two bypass lines.
+- Re-arm (`'off'`) is the security-load-bearing line — pinned by the new guardrail test.
+- Test reuses 087's `fnBlock` helper verbatim (handles `$$` tag + zero-arg and two-arg signatures).
+
+### Components Invoked
+- Skill: soleur:plan, soleur:gdpr-gate (no findings), soleur:deepen-plan (gates 4.4/4.6/4.7/4.8 pass)
+- Bash, Read, Write, Edit

--- a/knowledge-base/project/specs/feat-one-shot-migration-088-worm-bypass-non-erasure-rpcs/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-migration-088-worm-bypass-non-erasure-rpcs/tasks.md
@@ -1,0 +1,40 @@
+---
+title: "Tasks — Migration 088 WORM bypass for non-erasure RPCs"
+plan: knowledge-base/project/plans/2026-05-31-fix-migration-088-worm-bypass-non-erasure-rpcs-plan.md
+issue: 4702
+lane: cross-domain
+---
+
+# Tasks — Migration 088
+
+## Phase 0 — Preconditions
+- [ ] 0.1 Copy exact pre-088 `purge_workspace_member_actions()` body from `apps/web-platform/supabase/migrations/063_workspace_member_actions.sql` (the `AS $$ … $$;` block).
+- [ ] 0.2 Copy exact pre-088 `revoke_template_authorization(text, text)` body from `apps/web-platform/supabase/migrations/053_template_authorizations.sql`.
+- [ ] 0.3 Confirm 088 is the next free migration number (`ls apps/web-platform/supabase/migrations/ | grep '^08'` — 087 is highest).
+- [ ] 0.4 Confirm vitest include glob `test/**/*.test.ts` covers the new test path.
+
+## Phase 1 — RED (cq-write-failing-tests-before)
+- [ ] 1.1 Write `apps/web-platform/test/supabase-migrations/088-worm-bypass-non-erasure-rpcs.test.ts` mirroring the 087 test (reuse the `fnBlock` regex helper verbatim — handles `$$`/`$fn$`).
+  - [ ] 1.1.1 Assert forward migration nowhere matches `/session_replication_role/i`.
+  - [ ] 1.1.2 Per RPC (`purge_workspace_member_actions`, `revoke_template_authorization`): block matches `SET LOCAL app.worm_bypass = 'on'`, matches `'off'` (re-arm), does NOT match `session_replication_role`, keeps `search_path` pinned.
+  - [ ] 1.1.3 List↔migration reconciliation: every `CREATE OR REPLACE FUNCTION public.<name>(` in 088 forward is in the declared 2-RPC set.
+  - [ ] 1.1.4 Down migration matches `/session_replication_role/i`.
+- [ ] 1.2 Run the test → fails (migration files absent / ENOENT).
+
+## Phase 2 — GREEN
+- [ ] 2.1 Write `apps/web-platform/supabase/migrations/088_worm_bypass_non_erasure_rpcs.sql`:
+  - [ ] 2.1.1 §1 `purge_workspace_member_actions()` — verbatim 063 body with the two bypass-line swaps (`'on'` / `'off'`); re-issue REVOKE + GRANT; refresh COMMENT to cite `app.worm_bypass` + #4702. NO authz block (matches 063).
+  - [ ] 2.1.2 §2 `revoke_template_authorization(text, text)` — verbatim 053 body with the two bypass-line swaps; preserve the `auth.uid()` + 8-value reason-enum + founder-attribution gates; re-issue REVOKE + GRANT; update inline bypass comment.
+  - [ ] 2.1.3 Header comment block mirroring 087 (problem, why triggers already correct, fix = GUC swap only, scope = these 2 RPCs, conventions).
+- [ ] 2.2 Write `apps/web-platform/supabase/migrations/088_worm_bypass_non_erasure_rpcs.down.sql` — both RPCs restored to the original `session_replication_role` bodies; forward-only WARNING header.
+- [ ] 2.3 Run the new test → green.
+- [ ] 2.4 Run the 087 test → still green (no shared-function regression).
+
+## Phase 3 — Full suite + lint
+- [ ] 3.1 `cd apps/web-platform && ./node_modules/.bin/vitest run test/supabase-migrations/`.
+- [ ] 3.2 (Optional) DEV-only live probe with synthesized fixtures (never PROD; `hr-dev-prd-distinct-supabase-projects`).
+
+## Phase 4 — Ship
+- [ ] 4.1 PR body uses `Closes #4702`.
+- [ ] 4.2 Pre-merge AC checklist (see plan `## Acceptance Criteria → Pre-merge`).
+- [ ] 4.3 Post-merge: migration applied by `web-platform-release.yml#migrate`; verify read-only via Supabase MCP (function body no longer contains `session_replication_role`).


### PR DESCRIPTION
## Summary

Migration **088** mirrors migration 087's privilege-free WORM-bypass pattern into the two **non-erasure** RPCs that 087 deliberately deferred (`087.sql` L57-59):

- `purge_workspace_member_actions()` — the pg_cron 7-year retention DELETE. Was a silent no-op on prod (the superuser-only `SET LOCAL session_replication_role='replica'` raises `42501` on managed Supabase before the DELETE), so `workspace_member_actions` audit PII over-retained (Art. 5(1)(e) storage-limitation drift).
- `revoke_template_authorization(text, text)` — the founder-initiated revoke UPDATE. The same `42501` fired before the bypass, so founders could not withdraw a template authorization (Art. 7(3)).

RPC-bodies-only: migration 087 already converted the trigger functions (`workspace_member_actions_no_mutate`, `template_authorizations_no_mutate`) to honor `app.worm_bypass`, so 088 swaps only the two bypass lines (`session_replication_role` → `SET LOCAL app.worm_bypass='on'` / re-arm `'off'`) in each RPC body and adds an offline migration-shape guardrail test mirroring the 087 test.

Closes #4702

## User-Brand Impact

- **Artifact:** `template_authorizations.revoked_at`/`revocation_reason` (founder revoke) and `workspace_member_actions` audit PII (retention purge).
- **Vector:** the `SET LOCAL app.worm_bypass='off'` re-arm is the security-load-bearing line — if dropped, the bypass would leak to the rest of the transaction (audit-trail tamper surface). Pinned by the guardrail test's per-RPC arm→write→re-arm ordering assertion. The revoke authz surface (auth.uid() guard, 8-value reason-enum gate, founder-attribution gate) is preserved byte-identical to mig 053, so no authz regression is introduced.
- **Brand-survival threshold:** single-user incident — a single founder's failed revoke (Art. 7(3)) or a single user's over-retained audit PII (Art. 5(1)(e)) is a compliance-visible regression.

Note: review surfaced a pre-existing latent bug in a different subsystem (template auto-revoke always 42501s because its caller is the authenticated SSR client) — filed as #4709, outside this PR's migration scope.

## Changelog

- Add migration `088_worm_bypass_non_erasure_rpcs.sql` + paired `.down.sql` (privilege-free WORM bypass for `purge_workspace_member_actions` and `revoke_template_authorization`).
- Add offline migration-shape guardrail test pinning the GUC swap, arm→write→re-arm ordering, `search_path` pin, content gates, list↔migration reconciliation, and down rollback-symmetry.

## Test plan

- [x] `vitest run test/supabase-migrations/088-worm-bypass-non-erasure-rpcs.test.ts` — 16 tests pass.
- [x] `vitest run test/supabase-migrations/087-...test.ts` — 45 tests pass (no regression on shared trigger functions).
- [x] Full web-platform shard (`TEST_GROUP=webplat bash scripts/test-all.sh`) — 7575 tests pass.
- [ ] Post-merge: migration applied to prod by `web-platform-release.yml#migrate`; verify the function bodies no longer reference `session_replication_role`.

Generated with [Claude Code](https://claude.com/claude-code)
