### PR TITLE
fix(settings): observability + regression guard for silent Members-tab disappearance

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/settings/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/settings/layout.tsx
@@ -1,49 +1,5 @@
-import { createClient } from "@/lib/supabase/server";
 import { SettingsShell } from "@/components/settings/settings-shell";
-import { isTeamWorkspaceInviteEnabled, type Identity } from "@/lib/feature-flags/server";
-import {
-  resolveCurrentOrganizationId,
-  shouldShowMembersTab,
-  userHasWorkspaceMembership,
-} from "@/server/workspace-resolver";
-import { reportSilentFallback } from "@/server/observability";
-
-// Server-side flag evaluation. AC-A requires the "Members" link href
-// (`/dashboard/settings/team`) NOT appear in the client bundle when the flag is
-// OFF — so we pass `membersTab` as a prop rather than gating the link
-// client-side on a runtime boolean.
-async function resolveMembersTab(): Promise<{ href: string; label: string } | null> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return null;
-
-  const orgId = await resolveCurrentOrganizationId(user.id, supabase);
-  if (!orgId) {
-    // Silent-failure guard (feat-fix-multi-user-feature-not-visible). A user WITH
-    // workspace membership resolving a null current org means the Members + Team
-    // Activity tabs vanish with no error — the exact silent class behind the
-    // 2026-05-31 ops@jikigai.com report. Surface it to Sentry so the next
-    // occurrence is observed, not user-reported. A genuinely org-less identity
-    // (no membership) is the normal solo case and stays silent. `userId` is
-    // pseudonymized at the emit boundary (reportSilentFallback, Recital 26).
-    if (await userHasWorkspaceMembership(user.id, supabase)) {
-      reportSilentFallback(null, {
-        feature: "settings-members-tab",
-        op: "resolveMembersTab",
-        message: "member resolved null current_organization_id; org-gated tabs hidden",
-        extra: { userId: user.id },
-      });
-    }
-    return null;
-  }
-
-  const identity: Identity = { userId: user.id, role: "prd", orgId };
-  const flagOn = await isTeamWorkspaceInviteEnabled(orgId, identity);
-  if (!shouldShowMembersTab(orgId, flagOn)) return null;
-  return { href: "/dashboard/settings/team", label: "Members" };
-}
+import { resolveMembersTab } from "@/server/members-tab";
 
 export default async function SettingsLayout({
   children,

--- a/apps/web-platform/app/(dashboard)/dashboard/settings/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/settings/layout.tsx
@@ -1,7 +1,12 @@
 import { createClient } from "@/lib/supabase/server";
 import { SettingsShell } from "@/components/settings/settings-shell";
 import { isTeamWorkspaceInviteEnabled, type Identity } from "@/lib/feature-flags/server";
-import { resolveCurrentOrganizationId } from "@/server/workspace-resolver";
+import {
+  resolveCurrentOrganizationId,
+  shouldShowMembersTab,
+  userHasWorkspaceMembership,
+} from "@/server/workspace-resolver";
+import { reportSilentFallback } from "@/server/observability";
 
 // Server-side flag evaluation. AC-A requires the "Members" link href
 // (`/dashboard/settings/team`) NOT appear in the client bundle when the flag is
@@ -15,10 +20,28 @@ async function resolveMembersTab(): Promise<{ href: string; label: string } | nu
   if (!user) return null;
 
   const orgId = await resolveCurrentOrganizationId(user.id, supabase);
-  if (!orgId) return null;
+  if (!orgId) {
+    // Silent-failure guard (feat-fix-multi-user-feature-not-visible). A user WITH
+    // workspace membership resolving a null current org means the Members + Team
+    // Activity tabs vanish with no error — the exact silent class behind the
+    // 2026-05-31 ops@jikigai.com report. Surface it to Sentry so the next
+    // occurrence is observed, not user-reported. A genuinely org-less identity
+    // (no membership) is the normal solo case and stays silent. `userId` is
+    // pseudonymized at the emit boundary (reportSilentFallback, Recital 26).
+    if (await userHasWorkspaceMembership(user.id, supabase)) {
+      reportSilentFallback(null, {
+        feature: "settings-members-tab",
+        op: "resolveMembersTab",
+        message: "member resolved null current_organization_id; org-gated tabs hidden",
+        extra: { userId: user.id },
+      });
+    }
+    return null;
+  }
 
   const identity: Identity = { userId: user.id, role: "prd", orgId };
-  if (!(await isTeamWorkspaceInviteEnabled(orgId, identity))) return null;
+  const flagOn = await isTeamWorkspaceInviteEnabled(orgId, identity);
+  if (!shouldShowMembersTab(orgId, flagOn)) return null;
   return { href: "/dashboard/settings/team", label: "Members" };
 }
 

--- a/apps/web-platform/server/members-tab.ts
+++ b/apps/web-platform/server/members-tab.ts
@@ -1,0 +1,58 @@
+import { createClient } from "@/lib/supabase/server";
+import { isTeamWorkspaceInviteEnabled, type Identity } from "@/lib/feature-flags/server";
+import {
+  resolveCurrentOrganizationId,
+  userHasWorkspaceMembership,
+} from "@/server/workspace-resolver";
+import { reportSilentFallback } from "@/server/observability";
+
+export interface SettingsTab {
+  href: string;
+  label: string;
+}
+
+/**
+ * Server-side resolution of the Settings "Members" tab (feat-team-workspace-multi-user).
+ *
+ * The tab — and the dependent "Team Activity" tab — render only when an
+ * authenticated user has a resolved current org AND the team-workspace-invite
+ * flag evaluates ON for it. AC-A requires the Members link href
+ * (`/dashboard/settings/team`) NOT appear in the client bundle when the gate is
+ * closed, so the layout passes the result as a prop rather than gating
+ * client-side on a runtime boolean.
+ *
+ * Extracted from settings/layout.tsx into a server-only module so the gate
+ * composition — including the silent-failure observability branch — is unit
+ * testable without dragging the layout's "use client" SettingsShell import into
+ * the test (feat-fix-multi-user-feature-not-visible).
+ */
+export async function resolveMembersTab(): Promise<SettingsTab | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const orgId = await resolveCurrentOrganizationId(user.id, supabase);
+  if (!orgId) {
+    // Silent-failure guard. A user WITH workspace membership resolving a null
+    // current org means the Members + Team Activity tabs vanish with no error —
+    // the exact silent class behind the 2026-05-31 ops@jikigai.com report.
+    // Surface it to Sentry so the next occurrence is observed, not user-reported.
+    // A genuinely org-less identity (no membership) is the normal solo case and
+    // stays silent. `userId` is pseudonymized at the emit boundary (Recital 26).
+    if (await userHasWorkspaceMembership(user.id, supabase)) {
+      reportSilentFallback(null, {
+        feature: "settings-members-tab",
+        op: "resolveMembersTab",
+        message: "member resolved null current_organization_id; org-gated tabs hidden",
+        extra: { userId: user.id },
+      });
+    }
+    return null;
+  }
+
+  const identity: Identity = { userId: user.id, role: "prd", orgId };
+  if (!(await isTeamWorkspaceInviteEnabled(orgId, identity))) return null;
+  return { href: "/dashboard/settings/team", label: "Members" };
+}

--- a/apps/web-platform/server/workspace-resolver.ts
+++ b/apps/web-platform/server/workspace-resolver.ts
@@ -80,6 +80,49 @@ interface SupabaseLike {
 }
 
 /**
+ * Pure visibility predicate for the Settings "Members" tab
+ * (feat-team-workspace-multi-user). The tab — and the dependent "Team
+ * Activity" tab — render only when the user has a resolved current org AND the
+ * team-workspace-invite flag evaluates ON for it. Extracted so the three-branch
+ * decision is deterministically testable without the live Flagsmith/Supabase
+ * dependency. The 2026-05-31 ops@jikigai.com disappearance was a live-state
+ * question (invisible to code-grep); this predicate guards a future *code*
+ * regression of the chain itself.
+ */
+export function shouldShowMembersTab(orgId: string | null, flagOn: boolean): boolean {
+  return orgId != null && flagOn;
+}
+
+/**
+ * True when the user has at least one `workspace_members` row.
+ *
+ * Used to distinguish a legitimately org-less identity (normal — stay silent)
+ * from the integrity surface where a *member* resolves a null current org, in
+ * which case org-gated UI (the Members + Team Activity tabs) silently vanishes
+ * with no error. Fail-quiet on a query error: this is a diagnostic discriminator
+ * on an already-degraded branch and must never itself block a render.
+ *
+ * RLS: `workspace_members` owner-select (`auth.uid() = user_id`).
+ */
+export async function userHasWorkspaceMembership(
+  userId: string,
+  supabase: SupabaseLike,
+): Promise<boolean> {
+  type ChainShape = {
+    select: (cols: string) => ChainShape;
+    eq: (col: string, val: string) => ChainShape;
+    limit: (n: number) => ChainShape;
+  } & PromiseLike<{ data: unknown[] | null; error: unknown }>;
+
+  const chain = supabase.from("workspace_members") as ChainShape;
+  const result = await awaitChain<{ data: unknown[] | null; error: unknown }>(
+    chain.select("workspace_id").eq("user_id", userId).limit(1),
+  );
+  if (result.error) return false; // fail-quiet — never block render on a probe
+  return (result.data?.length ?? 0) > 0;
+}
+
+/**
  * Resolve the user's CURRENT workspace id from `user_session_state`
  * (ADR-044). Source-of-truth read (preferred over the JWT claim, which can
  * be stale on an un-refreshed session). Falls back to the user's SOLO

--- a/apps/web-platform/server/workspace-resolver.ts
+++ b/apps/web-platform/server/workspace-resolver.ts
@@ -80,20 +80,6 @@ interface SupabaseLike {
 }
 
 /**
- * Pure visibility predicate for the Settings "Members" tab
- * (feat-team-workspace-multi-user). The tab — and the dependent "Team
- * Activity" tab — render only when the user has a resolved current org AND the
- * team-workspace-invite flag evaluates ON for it. Extracted so the three-branch
- * decision is deterministically testable without the live Flagsmith/Supabase
- * dependency. The 2026-05-31 ops@jikigai.com disappearance was a live-state
- * question (invisible to code-grep); this predicate guards a future *code*
- * regression of the chain itself.
- */
-export function shouldShowMembersTab(orgId: string | null, flagOn: boolean): boolean {
-  return orgId != null && flagOn;
-}
-
-/**
  * True when the user has at least one `workspace_members` row.
  *
  * Used to distinguish a legitimately org-less identity (normal — stay silent)
@@ -102,7 +88,9 @@ export function shouldShowMembersTab(orgId: string | null, flagOn: boolean): boo
  * with no error. Fail-quiet on a query error: this is a diagnostic discriminator
  * on an already-degraded branch and must never itself block a render.
  *
- * RLS: `workspace_members` owner-select (`auth.uid() = user_id`).
+ * RLS: `workspace_members` peer-select (`members_select_peers` → `is_workspace_member(workspace_id, auth.uid())`,
+ * migration 053). The explicit `.eq("user_id", userId)` self-scopes the probe to
+ * the caller's own rows regardless — the boolean cannot be influenced cross-tenant.
  */
 export async function userHasWorkspaceMembership(
   userId: string,

--- a/apps/web-platform/test/members-tab-visibility.test.ts
+++ b/apps/web-platform/test/members-tab-visibility.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  shouldShowMembersTab,
+  userHasWorkspaceMembership,
+} from "@/server/workspace-resolver";
+
+// Regression guard for feat-fix-multi-user-feature-not-visible.
+//
+// The Settings "Members" tab (+ "Team Activity") is gated server-side by the
+// visibility chain in settings/layout.tsx: an authenticated user with a
+// resolved current org AND the team-workspace-invite flag ON. Any single gate
+// failing hides BOTH tabs with no error surfaced to the user — the silent
+// failure that prompted the ops@jikigai.com report. These tests pin the pure
+// decision so a future CODE regression of the chain fails deterministically
+// (the original incident was a non-code live-state question; this guards the
+// code path itself). See the plan's Acceptance Criteria AC6.
+
+describe("shouldShowMembersTab — visibility-chain predicate", () => {
+  const ORG = "1a8045bf-6718-43c9-887b-0c0652ca75c3";
+
+  it("shows when the current org resolves AND the flag is ON", () => {
+    expect(shouldShowMembersTab(ORG, true)).toBe(true);
+  });
+
+  it("hides when the current org is null (gate #2 fail)", () => {
+    expect(shouldShowMembersTab(null, true)).toBe(false);
+  });
+
+  it("hides when the flag evaluates OFF (gate #3 fail)", () => {
+    expect(shouldShowMembersTab(ORG, false)).toBe(false);
+  });
+});
+
+describe("userHasWorkspaceMembership — integrity-surface discriminator", () => {
+  // Distinguishes a legitimately org-less identity (normal, stay silent) from
+  // a member whose current org resolved null (the integrity surface that hides
+  // org-gated UI — emit to Sentry). Recursive chain mock mirrors the live
+  // PostgREST fluent API: every chained call returns the same object, the
+  // terminal awaited value is the row set.
+  function mockSupabase(rows: unknown[] | null, error: unknown = null) {
+    const chain = {
+      select: () => chain,
+      eq: () => chain,
+      limit: () => Promise.resolve({ data: rows, error }),
+    };
+    return { from: vi.fn(() => chain) };
+  }
+
+  it("true when the user has >=1 membership row", async () => {
+    expect(
+      await userHasWorkspaceMembership("u", mockSupabase([{ workspace_id: "w" }])),
+    ).toBe(true);
+  });
+
+  it("false when the user has zero membership rows", async () => {
+    expect(await userHasWorkspaceMembership("u", mockSupabase([]))).toBe(false);
+  });
+
+  it("false (fail-quiet) on a query error — never blocks the render path", async () => {
+    expect(
+      await userHasWorkspaceMembership("u", mockSupabase(null, { message: "boom" })),
+    ).toBe(false);
+  });
+});

--- a/apps/web-platform/test/members-tab-visibility.test.ts
+++ b/apps/web-platform/test/members-tab-visibility.test.ts
@@ -1,42 +1,121 @@
-import { describe, it, expect, vi } from "vitest";
-import {
-  shouldShowMembersTab,
-  userHasWorkspaceMembership,
-} from "@/server/workspace-resolver";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Regression guard for feat-fix-multi-user-feature-not-visible.
 //
-// The Settings "Members" tab (+ "Team Activity") is gated server-side by the
-// visibility chain in settings/layout.tsx: an authenticated user with a
-// resolved current org AND the team-workspace-invite flag ON. Any single gate
-// failing hides BOTH tabs with no error surfaced to the user — the silent
-// failure that prompted the ops@jikigai.com report. These tests pin the pure
-// decision so a future CODE regression of the chain fails deterministically
-// (the original incident was a non-code live-state question; this guards the
-// code path itself). See the plan's Acceptance Criteria AC6.
+// The Settings "Members" tab (+ "Team Activity") is gated server-side by
+// resolveMembersTab: an authenticated user with a resolved current org AND the
+// team-workspace-invite flag ON. Any single gate failing hides BOTH tabs with
+// no error — the silent failure that prompted the ops@jikigai.com report. The
+// fix adds an observability emit when a *member* (not a solo user) resolves a
+// null org, so the next disappearance surfaces in Sentry instead of via the
+// user. These tests pin (a) the composition / emit branch — the heart of the
+// fix — and (b) the membership-probe contract.
 
-describe("shouldShowMembersTab — visibility-chain predicate", () => {
-  const ORG = "1a8045bf-6718-43c9-887b-0c0652ca75c3";
+// --- mock the resolveMembersTab seams (composition tests) -------------------
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("@/lib/feature-flags/server", () => ({ isTeamWorkspaceInviteEnabled: vi.fn() }));
+vi.mock("@/server/observability", () => ({ reportSilentFallback: vi.fn() }));
 
-  it("shows when the current org resolves AND the flag is ON", () => {
-    expect(shouldShowMembersTab(ORG, true)).toBe(true);
+import { resolveMembersTab } from "@/server/members-tab";
+import { userHasWorkspaceMembership } from "@/server/workspace-resolver";
+import { createClient } from "@/lib/supabase/server";
+import { isTeamWorkspaceInviteEnabled } from "@/lib/feature-flags/server";
+import { reportSilentFallback } from "@/server/observability";
+
+const ORG = "1a8045bf-6718-43c9-887b-0c0652ca75c3";
+const USER = { id: "754ee124-706a-4f21-a4f4-e828257b0380" };
+
+// Minimal supabase double mirroring the live PostgREST fluent API: the chain is
+// the awaitable, terminal methods resolve `{ data, error }`. `from` branches on
+// table so resolveCurrentOrganizationId (user_session_state) and
+// userHasWorkspaceMembership (workspace_members) read distinct fixtures.
+function fakeSupabase(opts: {
+  user: { id: string } | null;
+  orgId: string | null;
+  memberRows: unknown[];
+}) {
+  return {
+    auth: { getUser: async () => ({ data: { user: opts.user }, error: null }) },
+    from(table: string) {
+      if (table === "user_session_state") {
+        const chain: Record<string, unknown> = {
+          select: () => chain,
+          eq: () => chain,
+          maybeSingle: async () => ({
+            data: opts.orgId == null ? null : { current_organization_id: opts.orgId },
+            error: null,
+          }),
+        };
+        return chain;
+      }
+      if (table === "workspace_members") {
+        const chain: Record<string, unknown> = {
+          select: () => chain,
+          eq: () => chain,
+          limit: async () => ({ data: opts.memberRows, error: null }),
+        };
+        return chain;
+      }
+      throw new Error(`unexpected table: ${table}`);
+    },
+  };
+}
+
+describe("resolveMembersTab — gate composition + silent-failure emit", () => {
+  beforeEach(() => {
+    vi.mocked(createClient).mockReset();
+    vi.mocked(isTeamWorkspaceInviteEnabled).mockReset();
+    vi.mocked(reportSilentFallback).mockReset();
   });
 
-  it("hides when the current org is null (gate #2 fail)", () => {
-    expect(shouldShowMembersTab(null, true)).toBe(false);
+  function arrange(opts: { user?: { id: string } | null; orgId: string | null; memberRows?: unknown[]; flagOn?: boolean }) {
+    vi.mocked(createClient).mockResolvedValue(
+      fakeSupabase({ user: opts.user ?? USER, orgId: opts.orgId, memberRows: opts.memberRows ?? [] }) as never,
+    );
+    vi.mocked(isTeamWorkspaceInviteEnabled).mockResolvedValue(opts.flagOn ?? false);
+  }
+
+  it("shows the tab when org resolves AND flag is ON; no emit", async () => {
+    arrange({ orgId: ORG, flagOn: true });
+    const tab = await resolveMembersTab();
+    expect(tab).toEqual({ href: "/dashboard/settings/team", label: "Members" });
+    expect(reportSilentFallback).not.toHaveBeenCalled();
   });
 
-  it("hides when the flag evaluates OFF (gate #3 fail)", () => {
-    expect(shouldShowMembersTab(ORG, false)).toBe(false);
+  it("hides the tab when the flag is OFF (gate #3); no emit", async () => {
+    arrange({ orgId: ORG, flagOn: false });
+    expect(await resolveMembersTab()).toBeNull();
+    expect(reportSilentFallback).not.toHaveBeenCalled();
+  });
+
+  it("emits a silent-failure signal when a MEMBER resolves a null org (gate #2)", async () => {
+    arrange({ orgId: null, memberRows: [{ workspace_id: "w" }] });
+    expect(await resolveMembersTab()).toBeNull();
+    expect(reportSilentFallback).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(reportSilentFallback).mock.calls[0][1]).toMatchObject({
+      feature: "settings-members-tab",
+      op: "resolveMembersTab",
+      extra: { userId: USER.id },
+    });
+  });
+
+  it("stays SILENT for a legitimately org-less non-member (null org, no membership)", async () => {
+    arrange({ orgId: null, memberRows: [] });
+    expect(await resolveMembersTab()).toBeNull();
+    expect(reportSilentFallback).not.toHaveBeenCalled();
+  });
+
+  it("returns null with no DB/flag work when there is no authenticated user", async () => {
+    arrange({ user: null, orgId: null });
+    expect(await resolveMembersTab()).toBeNull();
+    expect(isTeamWorkspaceInviteEnabled).not.toHaveBeenCalled();
+    expect(reportSilentFallback).not.toHaveBeenCalled();
   });
 });
 
 describe("userHasWorkspaceMembership — integrity-surface discriminator", () => {
-  // Distinguishes a legitimately org-less identity (normal, stay silent) from
-  // a member whose current org resolved null (the integrity surface that hides
-  // org-gated UI — emit to Sentry). Recursive chain mock mirrors the live
-  // PostgREST fluent API: every chained call returns the same object, the
-  // terminal awaited value is the row set.
+  // Recursive chain mock mirrors the live PostgREST fluent API: every chained
+  // call returns the same object; the terminal awaited value is the row set.
   function mockSupabase(rows: unknown[] | null, error: unknown = null) {
     const chain = {
       select: () => chain,
@@ -47,18 +126,18 @@ describe("userHasWorkspaceMembership — integrity-surface discriminator", () =>
   }
 
   it("true when the user has >=1 membership row", async () => {
-    expect(
-      await userHasWorkspaceMembership("u", mockSupabase([{ workspace_id: "w" }])),
-    ).toBe(true);
+    expect(await userHasWorkspaceMembership("u", mockSupabase([{ workspace_id: "w" }]))).toBe(true);
   });
 
   it("false when the user has zero membership rows", async () => {
     expect(await userHasWorkspaceMembership("u", mockSupabase([]))).toBe(false);
   });
 
+  it("false when data is null without an error (PostgREST empty-result shape)", async () => {
+    expect(await userHasWorkspaceMembership("u", mockSupabase(null))).toBe(false);
+  });
+
   it("false (fail-quiet) on a query error — never blocks the render path", async () => {
-    expect(
-      await userHasWorkspaceMembership("u", mockSupabase(null, { message: "boom" })),
-    ).toBe(false);
+    expect(await userHasWorkspaceMembership("u", mockSupabase(null, { message: "boom" }))).toBe(false);
   });
 });

--- a/knowledge-base/project/learnings/2026-05-31-diagnose-then-fix-green-data-layer-means-observe-not-mutate.md
+++ b/knowledge-base/project/learnings/2026-05-31-diagnose-then-fix-green-data-layer-means-observe-not-mutate.md
@@ -1,0 +1,101 @@
+# Learning: a "feature disappeared" report with an all-green data layer means observe, don't mutate
+
+## Problem
+
+The operator reported the multi-user **Members** tab had disappeared from Settings
+for `ops@jikigai.com` (screenshot at 2026-05-31 20:18 UTC). The plan
+(`2026-05-31-fix-multi-user-feature-not-visible-plan.md`) was a *diagnose-then-fix*
+with four ranked hypotheses, the leading one (H1) being "the #4617 segment cutover
+dropped jikigai's org from the `team-workspace-invite-orgs` Flagsmith segment", whose
+prescribed fix was a `flag-set-role` `flip.sh ... --org <jikigai>` re-add.
+
+The trap: the plan's structure invites you to *apply the ranked fix*. But the
+fix is a live prod state mutation (a Flagsmith segment write + a WORM
+`flag_flip_audit` row), and the plan's own Sharp Edge warned: "Do not flip the
+flag before reading live state... flipping changes nothing and leaves a
+misleading WORM audit row."
+
+## Solution
+
+Run **every** Phase 0 read-only probe through the *exact production code path*
+before touching anything, and let the readings — not the plan's ranking —
+choose the fix (including the option of **no state mutation**):
+
+- **H2 (gate #2, session-state):** `user_session_state.current_organization_id`
+  for ops@jikigai = `1a8045bf...` (non-null, correct). Confirmed under the
+  **authenticated RLS role** (`SET LOCAL ROLE authenticated` + crafted
+  `request.jwt.claims` via the Supabase Management API `database/query`
+  endpoint), not just service-role — so the read the user's own client makes is
+  proven, not assumed. PASS.
+- **H1 membership (gate #3):** jikigai's org *was already present* in the
+  segment's `EQUAL/orgId` conditions. Membership ≠ the problem.
+- **H1 evaluation (the load-bearing check):** the flag *evaluates* ON for
+  jikigai via the production `getIdentityFlags` edge path (`org:1a8045bf...:prd`,
+  `orgId` trait) and OFF for a control org. PASS — membership ≠ evaluation, and
+  here both are green.
+- **H3 (env fallback):** `FLAG_TEAM_WORKSPACE_INVITE=1` in prd, so a Flagsmith
+  *timeout* would resolve the flag ON via fallback — i.e. an outage would *show*
+  the tab, not hide it. Ruled out.
+- **Timeline:** the latest prd feature-version publish for the flag was
+  2026-05-29 14:43 UTC — two days **before** the screenshot. Deployed prod ran
+  current main (712847a9), and the layout's current form shipped 2026-05-27. So
+  all four gates were green *at screenshot time*.
+
+Conclusion: the symptom does **not** reproduce server-side. The trigger was
+client-side (Next.js App Router cache serving a stale flag-gated layout) or a
+transient. **No flag flip and no session-state write were performed** — both
+targets were already correct; a write would have been a no-op leaving a
+misleading WORM row.
+
+The shipped fix targets the actual systemic gap the report exposed — the failure
+is **silent** (a tab vanishes with no error):
+- `reportSilentFallback` in the extracted `resolveMembersTab` when a user **with**
+  workspace membership resolves a null current org (a member losing org-gated UI
+  is an integrity surface; a solo non-member is the normal silent case).
+- A deterministic regression test of the gate composition, including the emit
+  branch (extracted into `server/members-tab.ts` to isolate it from the layout's
+  `"use client"` import so it is unit-testable).
+
+This makes the fix self-validating: if the user reloads and it is *still* missing
+(a genuine server-side null-org for a member), Sentry now fires and names the gate.
+
+## Key Insight
+
+For a **diagnose-then-fix** plan, the diagnosis is allowed to override the plan's
+ranked fix — and "the correct fix is no state mutation, only observability +
+a regression guard" is a legitimate, often-correct outcome. A "feature
+disappeared" report is a **lower bound on breakage, not proof of current
+breakage**. When the data layer reproduces green through the *exact* production
+paths (edge flag eval + authenticated-role RLS read, not service-role), the
+durable deliverable is the signal that catches the *next* (genuinely silent)
+occurrence, not a speculative prod write that satisfies the plan's narrative.
+Verify with: stable feature-version publish timestamps + behavior-identical
+deployed code prove the state was green at incident time.
+
+## Session Errors
+
+1. **Bash `UID` readonly-variable collision** — `user_session_state?user_id=eq.$UID`
+   sent the shell's Unix uid (`1001`) instead of the user UUID → PostgREST
+   `22P02 invalid input syntax for type uuid: "1001"`. **Recovery:** renamed the
+   var to `OPS_UID`. **Prevention:** never use bash special/readonly names
+   (`UID`, `EUID`, `GID`, `PWD`, `PPID`) as script variables; prefer a prefixed
+   name.
+2. **Supabase Management API `403` / Cloudflare error `1010`** on the default
+   `python urllib` User-Agent (browser-signature ban). **Recovery:** added a
+   browser `User-Agent` header to the request. **Prevention:** when calling
+   `api.supabase.com/v1/projects/<ref>/database/query` from `urllib`, always set
+   a browser `User-Agent`.
+3. **Flagsmith featurestates probe matched multiple `is_live=True` version
+   UUIDs** → malformed-URL / empty-JSON error. **Recovery:** the needed data
+   (version publish timestamps) was already captured by the preceding command;
+   the step was non-load-bearing. **Prevention:** filter a version list to a
+   single UUID before interpolating it into a URL.
+4. **(forwarded from session-state.md)** plan subagent's first `Write` was
+   blocked on the bare-root path (re-issued to the worktree path — guardrail
+   worked as intended); Task/Explore agent-spawn tools were not exposed in the
+   planning subagent's harness (equivalent research done inline). Both handled,
+   no rework.
+
+## Tags
+category: integration-issues
+module: apps/web-platform/server (workspace-resolver, members-tab, feature-flags); plugins/soleur/skills/one-shot

--- a/knowledge-base/project/learnings/2026-05-31-diagnose-then-fix-green-data-layer-means-observe-not-mutate.md
+++ b/knowledge-base/project/learnings/2026-05-31-diagnose-then-fix-green-data-layer-means-observe-not-mutate.md
@@ -3,7 +3,7 @@
 ## Problem
 
 The operator reported the multi-user **Members** tab had disappeared from Settings
-for `ops@jikigai.com` (screenshot at 2026-05-31 20:18 UTC). The plan
+for `ops@example.com` (screenshot at 2026-05-31 20:18 UTC). The plan
 (`2026-05-31-fix-multi-user-feature-not-visible-plan.md`) was a *diagnose-then-fix*
 with four ranked hypotheses, the leading one (H1) being "the #4617 segment cutover
 dropped jikigai's org from the `team-workspace-invite-orgs` Flagsmith segment", whose

--- a/knowledge-base/project/plans/2026-05-31-fix-multi-user-feature-not-visible-plan.md
+++ b/knowledge-base/project/plans/2026-05-31-fix-multi-user-feature-not-visible-plan.md
@@ -1,0 +1,472 @@
+---
+title: "fix: Multi-user (Members) feature not visible for ops@jikigai.com"
+type: fix
+date: 2026-05-31
+branch: feat-one-shot-multi-user-feature-not-visible
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+classification: diagnose-then-fix
+related_specs:
+  - knowledge-base/project/specs/feat-team-workspace-multi-user/spec.md
+related_brainstorms:
+  - knowledge-base/project/brainstorms/2026-05-21-team-workspace-multi-user-brainstorm.md
+  - knowledge-base/project/brainstorms/2026-05-29-flag-org-scoping-brainstorm.md
+related_learnings:
+  - knowledge-base/project/learnings/2026-05-27-supabase-getuser-app-metadata-does-not-include-jwt-hook-claims.md
+  - knowledge-base/project/learnings/best-practices/2026-05-27-flagsmith-segment-rule-structure-verify-before-implementing.md
+  - knowledge-base/project/learnings/2026-05-29-plan-reverify-must-assert-the-invariant-not-a-proxy.md
+---
+
+# 🐛 fix: Multi-user (Members) feature not visible for ops@jikigai.com
+
+## Overview
+
+The "Members" tab (the multi-user / team-workspace invite feature) has disappeared from
+**Settings** for `ops@jikigai.com`. The screenshot shows the settings sub-nav as
+`General · Conversation names · Integrations · Scope Grants · Billing` — no **Members** tab
+and no **Team Activity** tab. The user reports it was visible before.
+
+The feature itself is **not removed from code** — every artifact in the visibility chain
+exists on the current branch (premise validated in Phase 0.6 below). This is therefore a
+**live-state regression**, not a code-deletion regression. The plan is a *diagnose-then-fix*:
+the diagnosis MUST read live Flagsmith + Supabase state (the bug is invisible to code-grep),
+then the fix is applied to whichever of the three failure modes is the actual cause, plus a
+guard/observability addition so a silent disappearance surfaces next time instead of being
+reported by the user.
+
+### The visibility chain (verified in code — all present)
+
+The Members tab is rendered only when **every** gate below passes. Any single failure hides
+it with no error surfaced to the user:
+
+| # | Gate | Location | Failure → tab hidden when |
+|---|------|----------|---------------------------|
+| 1 | Authenticated user | `app/(dashboard)/dashboard/settings/layout.tsx:11-15` (`resolveMembersTab`) | `getUser()` returns no user |
+| 2 | `orgId` resolves non-null | `layout.tsx:17-18` → `resolveCurrentOrganizationId(user.id, supabase)` (`server/workspace-resolver.ts:44-73`) | `user_session_state.current_organization_id` is `NULL` for the user (read is source-of-truth, RLS `auth.uid()=user_id`) |
+| 3 | Flag evaluates ON | `layout.tsx:20-21` → `isTeamWorkspaceInviteEnabled(orgId, identity)` → `getRuntimeFlag("team-workspace-invite", {userId, role:"prd", orgId})` (`lib/feature-flags/server.ts:144-165`) | Flagsmith `team-workspace-invite-orgs` segment lacks an `EQUAL orgId` condition for jikigai's org **AND** env fallback `FLAG_TEAM_WORKSPACE_INVITE` is `0`/unset in the live env |
+| 4 | `membersTab` prop threaded to nav | `components/settings/settings-shell.tsx:24-37` | (cosmetic; only fires if 1–3 pass but prop is dropped — not the suspected cause) |
+
+`activityTab` (the **Team Activity** sub-nav entry) is gated on `membersTab` being non-null
+(`layout.tsx:31-33`), so it disappears together with Members — consistent with the screenshot.
+
+### Why this is live-state, not code
+
+- The route `/dashboard/settings/team/page.tsx` **exists** and itself re-gates via
+  `resolveTeamMembershipPageData` (org + flag) → `notFound()` on `no-org`/`no-membership`.
+- `resolveMembersTab` and `resolveCurrentOrganizationId` exist and were last touched by
+  **#4516** (`fix(auth): query user_session_state directly for org resolution`) whose own
+  commit message documents the *prior occurrence of this exact symptom*: "This caused the
+  Members tab and all org-gated features to silently fail for every user."
+- The flag was **migrated off the legacy shared `org-targeted` segment onto a per-feature
+  `team-workspace-invite-orgs` segment** in **#4617** (commits `a17995cf` flip.sh
+  `--detach-shared`, `4c3c5a25` retirement-complete). Decision #7 of the flag-org-scoping
+  brainstorm explicitly warned: *"Cutover must not drop `team-workspace-invite` for either
+  org."* A dropped `EQUAL orgId` condition during that cutover is the leading hypothesis.
+
+## User-Brand Impact
+
+(Carry-forward from `feat-team-workspace-multi-user` brainstorm `USER_BRAND_CRITICAL=true`.)
+
+**If this lands broken, the user experiences:** the multi-user feature they paid for / were
+promised silently absent with no error and no way to self-diagnose — the operator (Jean)
+cannot invite or manage workspace members, defeating the internal dogfood and the external
+team prospect signal (#2972). A *fix* that mis-targets the flag could over-expose the feature
+to a **non-opted-in org**, exposing another org's spend/key-delegation surface.
+
+**If this leaks, the user's data / workflow / money is exposed via:** enabling
+`team-workspace-invite` for the wrong org (a flag mis-flip during the fix) would surface the
+invite/membership UI — and the cross-tenant boundary it governs — to a tenant that never
+opted in. The fix's re-verify read MUST prove the flag is ON for jikigai's org **and OFF for
+a control org** (the proxy-vs-invariant trap, see Research Reconciliation).
+
+**Brand-survival threshold:** `single-user incident`. One mis-targeted flag flip that enables
+the multi-user surface for a non-opted-in org is brand-survival territory (CLO: GDPR Art. 33
+72h clock triggers only if a non-opted-in org actually accesses personal data; design for
+detectability).
+
+`requires_cpo_signoff: true` — CPO sign-off required at plan time before `/work`. CPO already
+framed the parent feature (Domain Review carry-forward, spec lines 157-160); this fix inherits
+that framing. `user-impact-reviewer` will be invoked at review-time per the conditional-agent
+block.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (from bug report / sibling docs) | Reality (verified on branch) | Plan response |
+|---|---|---|
+| "Code regression removed the multi-user UI" | All visibility-chain artifacts exist (`layout.tsx`, `settings-shell.tsx`, `workspace-resolver.ts`, `feature-flags/server.ts`, `team/page.tsx`). No deletion in `git log`. | **Reject** code-deletion hypothesis. Treat as live-state regression. |
+| Flag is "per-user / per-role targeted" | Flag is **per-org** via `team-workspace-invite-orgs` Flagsmith segment with `EQUAL orgId` conditions (`feature-flags/server.ts:24-31`); `role` hardcoded `"prd"` in `layout.tsx:20`. Identifier `org:${orgId}:${role}`. | Diagnosis must probe the **segment's `EQUAL orgId` conditions**, not a per-user trait. |
+| "Just flip the flag back on" | A bare flip risks enabling the flag for the wrong org (shared-segment blast radius is exactly what #4617 removed). | Re-verify read MUST be `count==1` for jikigai **AND** OFF for a control org. Assert flag **evaluation** (identity+orgId), not segment **membership** alone (proxy-vs-invariant, learning `2026-05-29-plan-reverify-must-assert-the-invariant-not-a-proxy.md`). |
+| `current_organization_id` always populated for solo users | Migration 060 backfilled it once; the column is `ON DELETE SET NULL` (migration 060 line 34) and writes route through `set_current_organization_id` RPC. It **can** become NULL (org/membership change, RPC write, cascade). | Diagnosis must **live-read** `user_session_state.current_organization_id` for ops@jikigai before assuming the flag is the cause. |
+| The 200ms Flagsmith timeout could be the cause | On timeout, `getRuntimeSnapshot` falls back to `runtimeEnvFallback()` which reads `FLAG_TEAM_WORKSPACE_INVITE` env (`feature-flags/server.ts:90-96,139`). If env is `0` in the live env, a Flagsmith slowdown silently hides the tab. | Diagnosis must record the **live env value** of `FLAG_TEAM_WORKSPACE_INVITE` and whether Flagsmith is reachable (Sentry warn-debounce `flagsmith:getidentityflags-timeout`, #4571). |
+
+## Hypotheses (ranked, each with a live probe)
+
+**Diagnosis order is load-bearing: probe in this order, stop at the first confirmed cause,
+but record all four readings in the PR body (cheap, and rules out compound causes).**
+
+### H1 (leading) — Flagsmith segment dropped jikigai's org during the #4617 cutover
+The `--detach-shared` migration (PR #4617) moved `team-workspace-invite` from the shared
+`org-targeted` segment to `team-workspace-invite-orgs`. If jikigai's `EQUAL orgId` condition
+was not carried over, the flag evaluates OFF for jikigai while `enabled=true` on the segment.
+- **Probe:** GET the `team-workspace-invite-orgs` segment via the Flagsmith Admin API and list
+  its `rules[].rules[].conditions[]` where `operator=EQUAL property=orgId`. Confirm jikigai's
+  org UUID is present. (Structure per learning `2026-05-27-flagsmith-segment-rule-structure-verify-before-implementing.md`: `ALL → ANY → [EQUAL/orgId per org]`, NOT an `IN`.)
+- **Probe (evaluation, not membership):** call `getIdentityFlags("org:<jikigai-org>:prd", {role:"prd", orgId:"<jikigai-org>"})` and assert `isFeatureEnabled("team-workspace-invite") === true`; repeat for a control org and assert `=== false`.
+- **Fix:** re-add jikigai's `EQUAL orgId` condition via the sanctioned tool
+  `plugins/soleur/skills/flag-set-role/scripts/flip.sh team-workspace-invite prd on --org <jikigai-org-uuid> [--control-org <real-sibling-uuid>] --confirmed`.
+  Verified precedent (Phase 4.4 deepen): the plain `on --org` path (NOT `--detach-shared`)
+  targets the feature's own `team-workspace-invite-orgs` segment, adds the org's `EQUAL orgId`
+  condition, writes the WORM `flag_flip_audit` row (migration 071), then **re-verifies by
+  EVALUATING the flag for the target org (must be enabled) and a control org (must be disabled)**
+  — `flip.sh:6-9,116-121` ("re-verify reads the EVALUATED flag, not the membership set",
+  `flip.sh:24,342-343`). **Do NOT mirror to Doppler for the per-org edit** — the `--org` path is
+  segment-membership only and explicitly does "No Doppler" (`flip.sh:8-9`); Doppler
+  `FLAG_TEAM_WORKSPACE_INVITE` mirrors the prd-**role**-segment state (role-grain fallback), not
+  the per-org override. See corrected H1 fix note in Phase 1 and AC5.
+
+### H2 — `user_session_state.current_organization_id` is NULL for ops@jikigai
+If the org/membership state changed since migration 060's backfill (RPC write, org delete
+cascade `ON DELETE SET NULL`, or never-set), `resolveCurrentOrganizationId` returns null →
+`resolveMembersTab` returns null at gate #2, *before* the flag is even consulted.
+- **Probe:** `SELECT current_organization_id FROM public.user_session_state WHERE user_id = (SELECT id FROM auth.users WHERE email='ops@jikigai.com')` against the correct project (PRD — never DEV, `hr-dev-prd-distinct-supabase-projects`). Cross-check `workspace_members` + `organizations` for ops@jikigai to confirm the *correct* org id.
+- **Fix:** if NULL/wrong, write the correct org via the `set_current_organization_id` RPC
+  (NOT a raw UPDATE — preserves the SECURITY DEFINER write boundary and re-checks
+  `workspace_members`). Confirm the JWT hook (migration 060) then injects it on next token mint.
+- **Guard:** `resolveCurrentOrganizationId` currently returns `null` on `!result.data`
+  *silently* (no Sentry). If the row is simply missing for a user who *should* have one, that
+  is an integrity surface that goes dark. Consider a `reportSilentFallback` on the
+  `!result.data` branch for users with ≥1 `workspace_members` row (see Phase 3 / Observability).
+
+### H3 — env-fallback OFF masks a Flagsmith outage
+If `FLAGSMITH_ENVIRONMENT_KEY` is set but Flagsmith is timing out (200ms ceiling) and
+`FLAG_TEAM_WORKSPACE_INVITE` is `0` in the live env, the tab disappears intermittently for
+*all* orgs, not just jikigai.
+- **Probe:** check live Doppler `FLAG_TEAM_WORKSPACE_INVITE` + `FLAGSMITH_ENVIRONMENT_KEY`
+  presence; check Sentry for `flagsmith:getidentityflags-timeout` warn-debounce events
+  (`feature-flags/server.ts:121-130`, #4571) in the reported window.
+- **Fix:** if this is the cause, it is an availability incident, not a config bug — record it;
+  the env-fallback mirror is role-grain, not org-grain (flag-org-scoping brainstorm CTO note —
+  a per-org flag *correctly* falls back OFF during a Flagsmith outage, the safe direction). So
+  the remediation here is Flagsmith availability + alerting, NOT flipping `FLAG_TEAM_WORKSPACE_INVITE`
+  (which would enable the flag for every org).
+
+### H4 (lowest) — `role: "prd"` hardcode / identity mismatch
+`layout.tsx:20` hardcodes `role: "prd"`. If the live segment was provisioned with a `dev`
+override only, prd-role identities miss it. Unlikely given the identifier is `org:<id>:prd`,
+but record the role the segment override targets during the H1 probe.
+
+## Implementation Phases
+
+### Phase 0 — Live diagnosis (READ-ONLY; no prod writes)
+
+> Per `hr-no-dashboard-eyeball-pull-data-yourself` and `hr-menu-option-ack-not-prod-write-auth`:
+> pull the data via API, do not eyeball a dashboard; menu-option acknowledgement is not
+> prod-write authorization. All Phase 0 steps are read-only.
+
+0.1 Resolve jikigai's org UUID and ops@jikigai's user id from PRD Supabase
+   (`mcp__plugin_supabase_supabase__*` or service-role REST; `hr-dev-prd-distinct-supabase-projects`).
+0.2 **H2 probe:** read `user_session_state.current_organization_id` for ops@jikigai; cross-check
+   `workspace_members` / `organizations`. Record the value (or NULL).
+0.3 **H1 probe:** GET the `team-workspace-invite-orgs` Flagsmith segment; dump its
+   `EQUAL/orgId` conditions; confirm presence/absence of jikigai's org UUID. Record the live
+   structure (per the segment-structure learning — verify shape, do not assume `IN`).
+0.4 **H1 evaluation probe (invariant, not proxy):** evaluate the flag via `getIdentityFlags`
+   for jikigai (`expect ON`) and a control org (`expect OFF`). Record both.
+0.5 **H3 probe:** read live `FLAG_TEAM_WORKSPACE_INVITE` (Doppler), `FLAGSMITH_ENVIRONMENT_KEY`
+   presence; grep Sentry for `flagsmith:getidentityflags-timeout` in the reported window.
+0.6 Write a one-paragraph **Diagnosis** into the PR body naming the confirmed failing gate(s)
+   and the readings for all four probes. This is the load-bearing artifact — the fix branch
+   chosen in Phase 1 is determined entirely by it.
+
+### Phase 1 — Apply the targeted fix (the ONE confirmed cause)
+
+Branch on the Phase 0 diagnosis. **Do exactly one** of the following (or the minimal set the
+diagnosis proves are jointly the cause):
+
+- **If H1:** run `flag-set-role` `flip.sh team-workspace-invite prd on --org <jikigai>
+  --control-org <real-sibling> --confirmed` to re-add jikigai's `EQUAL orgId` condition on the
+  `team-workspace-invite-orgs` segment; the skill writes the WORM audit row and does the
+  EVALUATION re-verify (jikigai ON + control OFF) internally. **No Doppler mirror for the per-org
+  edit** (the `--org` path is segment-only; Doppler is role-grain — `flip.sh:8-9`). **No code change.**
+  Automation: `flag-set-role` skill (sanctioned tooling) — NOT a manual dashboard click.
+- **If H2:** call `set_current_organization_id` RPC for ops@jikigai with the correct org id
+  (via Supabase MCP / service-role REST). **No code change** to the resolver.
+  Automation: Supabase MCP / `gh`/curl RPC call — not an operator dashboard step.
+- **If H3:** file/record the Flagsmith availability incident; add alerting (Phase 3). No flag flip.
+- **If H4:** correct the segment's role targeting via `flip.sh` (prd). No code change.
+
+### Phase 2 — Regression guard (test + behavioral)
+
+Add a **deterministic** regression test that fails if the visibility chain silently breaks
+again, removing the live-state dependency from the assertion path:
+
+- Unit test `resolveMembersTab` logic (extract a pure `shouldShowMembersTab(orgId, flagOn)`
+  helper if needed, OR test the existing function with a mocked supabase + mocked
+  `isTeamWorkspaceInviteEnabled`) asserting: (a) `orgId != null && flagOn` → tab shown;
+  (b) `orgId == null` → hidden; (c) `flagOn == false` → hidden. Test FILE path MUST land under
+  the runner's discovery glob — `apps/web-platform/test/...` per `vitest.config.ts` `include:`
+  (NOT co-located, per Sharp Edge / #4634). Verify the runner is **vitest** via
+  `apps/web-platform/package.json scripts.test` + `apps/web-platform/bunfig.toml`
+  (`pathIgnorePatterns` blocks `bun test`).
+- If the chosen cause is H1 (flag/segment), add the `flag-set-role` dry-run / re-verify
+  assertion to the PR body output, NOT a new prod-touching test (per
+  `hr-dev-prd-distinct-supabase-projects` — no synthetic users / no prod integration suite).
+
+### Phase 3 — Close the observability gap (so the next disappearance is not user-reported)
+
+The root failure class is **silent**: a tab vanishes with no error. Add detection at the gate
+that went dark (per `## Observability`):
+
+- If H2: add `reportSilentFallback`/`mirrorWarn` to `resolveCurrentOrganizationId` (or the
+  layout) when a user with ≥1 `workspace_members` row resolves `orgId == null` — that is an
+  integrity surface, not a normal solo-user case. Debounced, keyed on a non-PII shape
+  (mirror the existing `feature-flags/server.ts:121-130` debounce pattern; NEVER emit userId).
+- If H1/H3: ensure the `flagsmith:getidentityflags-timeout` warn-debounce is wired to an alert
+  route (it currently mirrors to Sentry at WARNING; confirm an alert exists, else add one) so a
+  Flagsmith outage that hides org-gated UI surfaces in observability, not via the user.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- [ ] **AC1 (Diagnosis recorded):** PR body contains the Phase 0 Diagnosis paragraph with all
+      four probe readings (H1 segment conditions, H1 evaluation jikigai=ON/control=OFF, H2
+      `current_organization_id` value, H3 env + Sentry-timeout reading) and names the confirmed
+      failing gate(s).
+- [ ] **AC2 (Fix is targeted):** exactly the gate(s) the diagnosis proved broken are changed;
+      no speculative edits to the other gates.
+- [ ] **AC3 (Invariant, not proxy):** if the flag was touched, the PR shows the
+      post-fix **evaluation** read: `team-workspace-invite` evaluates `true` for jikigai's org
+      identity AND `false` for a named control org. Segment-membership-only evidence is
+      insufficient (learning `2026-05-29-plan-reverify-must-assert-the-invariant-not-a-proxy.md`).
+- [ ] **AC4 (No wrong-org exposure):** the control-org-OFF read in AC3 is present and OFF.
+- [ ] **AC5 (Env-fallback fidelity):** the PR explicitly notes that the per-org `--org` flip does
+      NOT change the role-grain Doppler `FLAG_TEAM_WORKSPACE_INVITE` mirror (`flip.sh:8-9` "No
+      Doppler"; the env var mirrors the prd-**role**-segment, not per-org overrides —
+      `feature-flags/server.ts:14-16`). Only a prd-role-segment state change reconciles Doppler.
+- [ ] **AC6 (Regression test):** new deterministic test asserts the three visibility-chain
+      branches (orgId+flag, orgId-null, flag-off), lands under the vitest discovery glob, and
+      passes via `apps/web-platform`'s actual runner.
+- [ ] **AC7 (Observability):** the gate that went dark now emits a debounced Sentry/alert
+      signal on the silent-failure path; no userId is emitted.
+- [ ] **AC8 (No prod synthetic residue):** no test or AC creates synthetic auth.users / runs an
+      integration suite against PRD (`hr-dev-prd-distinct-supabase-projects`). Live PRD touch is
+      limited to the read-only Phase 0 probes + the single sanctioned write in Phase 1.
+
+### Post-merge (operator)
+- [ ] **AC9 (User-visible confirmation):** the Members tab + Team Activity tab are visible in
+      Settings for `ops@jikigai.com`. **Automation:** Playwright MCP (`mcp__playwright__*`) —
+      sign in as the dogfood account (up to any OAuth/consent gate) and assert the
+      `/dashboard/settings/team` link renders in the settings sub-nav; this is NOT a manual
+      "operator checks the browser" step.
+- [ ] **AC10 (Issue closure):** if this fix executes a prod write post-merge (flag flip / RPC),
+      use `Ref #N` in the PR body and close the tracking issue in a post-merge step after the
+      write + AC9 succeed (`Closes` would auto-close before the remediation runs — ops-remediation
+      class Sharp Edge).
+
+## Domain Review
+
+**Domains relevant:** Engineering, Product, Legal (carry-forward from
+`feat-team-workspace-multi-user` spec Domain Review, lines 155-160).
+
+### Engineering (CTO)
+**Status:** carry-forward
+**Assessment:** Approved architecture for the parent feature (organizations + workspaces +
+workspace_members + `is_workspace_member` + per-feature Flagsmith segments per amended ADR-043).
+This fix touches no schema and no RLS predicate — it diagnoses live flag/session state and
+applies a sanctioned-tool flip or RPC write. The only code change is a regression test + a
+debounced observability signal. No new architectural surface.
+
+### Product (CPO)
+**Status:** carry-forward (sign-off required — `requires_cpo_signoff: true`)
+**Assessment:** CPO framed the parent feature with the override caveat (flagged UI; flag stays
+OFF until legal scaffolding lands). The legal scaffolding has since merged (ToS/AUP/DPD/Side
+Letter references present in `plugins/soleur/docs/pages/legal/*`). Restoring visibility for
+jikigai (the day-one allowlisted org) is in-scope of the approved rollout. **CPO sign-off
+required at plan time before `/work`** — confirm CPO has reviewed (or invoke CPO domain leader)
+that re-enabling for jikigai does not change the OFF-for-all-other-orgs posture.
+
+### Legal (CLO)
+**Status:** carry-forward
+**Assessment:** CLO's load-bearing gate is *cross-org scoping must be proven via a post-write
+re-verify read* (flag-org-scoping brainstorm CLO note). AC3/AC4 encode exactly this
+(jikigai=ON, control=OFF). No new regulated-data surface is added; the WORM `flag_flip_audit`
+row (migration 071) is written by the `flag-set-role` tool if a flip occurs. GDPR Art. 33 72h
+clock is not triggered unless a non-opted-in org actually accessed personal data — the
+control-OFF assertion is the detectability gate.
+
+### Product/UX Gate
+**Tier:** advisory
+**Decision:** auto-accepted (pipeline)
+**Agents invoked:** none
+**Skipped specialists:** ux-design-lead (no new UI; restores an existing tab), copywriter (no copy)
+**Pencil available:** N/A
+#### Findings
+This fix restores an existing, already-designed nav tab. It adds no new user-facing surface,
+modal, or copy. No wireframes required.
+
+## Infrastructure (IaC)
+
+Skip — no new infrastructure. No server, service, cron, vendor account, DNS, TLS, secret, or
+firewall rule is introduced. The fix mutates **existing** runtime state: a Flagsmith segment
+condition (via the sanctioned `flag-set-role` skill, which already wraps the Flagsmith Admin
+API + WORM audit) and/or a `user_session_state` row (via the existing
+`set_current_organization_id` RPC). The per-org `--org` flip does NOT touch Doppler
+(`flip.sh:8-9` "No Doppler"); the existing `FLAG_TEAM_WORKSPACE_INVITE` secret mirrors the
+prd-role-segment fallback only and is not provisioned or reconciled by this fix.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "Members tab renders for an org-enabled identity; flag evaluates true for jikigai"
+  cadence: "per settings-page render (request-time) + AC9 post-merge Playwright assertion"
+  alert_target: "Sentry (existing project) — feature-flags + workspace-resolver scopes"
+  configured_in: "apps/web-platform/lib/feature-flags/server.ts (mirrorWarnWithDebounce); apps/web-platform/server/workspace-resolver.ts (reportSilentFallback)"
+error_reporting:
+  destination: "Sentry via reportSilentFallback / mirrorWarnWithDebounce"
+  fail_loud: "false for the recovered (env-fallback) path by design; the NEW signal in Phase 3 fires when a user WITH workspace_members resolves orgId=null — that is an integrity surface and is reported"
+failure_modes:
+  - mode: "Flagsmith timeout (200ms ceiling) -> silent env fallback"
+    detection: "Sentry warn-debounce key flagsmith:getidentityflags-timeout (server.ts:121-130, #4571)"
+    alert_route: "Sentry WARNING — Phase 3 confirms/adds an alert rule routing it"
+  - mode: "current_organization_id NULL for a multi-membership user"
+    detection: "NEW Phase 3 reportSilentFallback on resolveCurrentOrganizationId !result.data when user has >=1 workspace_members row"
+    alert_route: "Sentry — debounced, no userId emitted"
+  - mode: "Flag segment lost jikigai org during a future migration"
+    detection: "flag-set-role re-verify read (count==1 jikigai, OFF control) at flip time + WORM flag_flip_audit row"
+    alert_route: "exit-non-2xx hard-block in flip.sh + WORM audit trail (migration 071)"
+logs:
+  where: "Sentry (errors/warns); pino structured logs (server); flag_flip_audit WORM table (migration 071, 7-yr)"
+  retention: "Sentry default; WORM 7 years"
+discoverability_test:
+  command: "cd apps/web-platform && ./node_modules/.bin/vitest run test/<members-tab-visibility>.test.ts"
+  expected_output: "3 passing cases: (orgId+flagOn)->shown, (orgId null)->hidden, (flagOff)->hidden"
+```
+
+## Open Code-Review Overlap
+
+None (check ran: no open `code-review`-labelled issue names the visibility-chain files;
+verify with `gh issue list --label code-review --state open` at /work time per Phase 1.7.5).
+
+## Files to Edit
+
+- `apps/web-platform/server/workspace-resolver.ts` — **(conditional on H2)** add debounced
+  `reportSilentFallback` on the `!result.data` branch of `resolveCurrentOrganizationId` when
+  the user has ≥1 `workspace_members` row (Phase 3 observability). No behavioral change to the
+  return value.
+- `apps/web-platform/app/(dashboard)/dashboard/settings/layout.tsx` — **(optional)** if a pure
+  `shouldShowMembersTab` helper is extracted for testability; otherwise unchanged.
+
+## Files to Create
+
+- `apps/web-platform/test/<members-tab-visibility>.test.ts` — deterministic regression test for
+  the three visibility-chain branches (Phase 2 / AC6). Path under the vitest `include:` glob.
+
+## Files to Read (diagnosis, no edit)
+
+- Live Flagsmith `team-workspace-invite-orgs` segment (Admin API).
+- PRD Supabase `user_session_state`, `workspace_members`, `organizations` for ops@jikigai.
+- Doppler `FLAG_TEAM_WORKSPACE_INVITE`, `FLAGSMITH_ENVIRONMENT_KEY` (presence only).
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder
+  text, or omits the threshold will fail `deepen-plan` Phase 4.6. (This plan's section is filled.)
+- **Do not flip the flag before reading live state.** The bug may be H2 (NULL org), in which
+  case flipping the flag changes nothing and leaves a misleading WORM audit row. Phase 0 read
+  is load-bearing and gates Phase 1.
+- **Segment structure is `ALL → ANY → [EQUAL/orgId]`, NOT `IN`** (learning
+  `2026-05-27-flagsmith-segment-rule-structure-verify-before-implementing.md`). A probe that
+  assumes a comma-separated `IN` value will misread the live segment.
+- **Membership ≠ evaluation.** Asserting jikigai's `EQUAL orgId` condition exists on the segment
+  proves *membership*, not that the flag *evaluates* ON for jikigai's identity (the feature-state
+  override must also be present). Always assert via `getIdentityFlags`, with a control-org-OFF
+  negative (learning `2026-05-29-plan-reverify-must-assert-the-invariant-not-a-proxy.md`).
+- **Env fallback is role-grain, not org-grain.** A per-org flag *correctly* falls back OFF
+  during a Flagsmith outage (flag-org-scoping brainstorm CTO note). Do NOT "fix" an outage by
+  setting `FLAG_TEAM_WORKSPACE_INVITE=1` — that would enable it for *every* org. Outage
+  remediation is availability/alerting, not an env flip.
+- **PRD vs DEV Supabase** (`hr-dev-prd-distinct-supabase-projects`): ops@jikigai is a PRD
+  account. All probes and the single write target the PRD project.
+- **ops-remediation issue closure:** if the fix is a post-merge prod write, use `Ref #N` not
+  `Closes #N`; close the issue in a post-merge step after the write + AC9 succeed.
+- **Test runner:** `apps/web-platform` uses **vitest**, not `bun test` (`bunfig.toml`
+  `pathIgnorePatterns` blocks bun test discovery). Test file MUST match the vitest `include:`
+  glob (`test/**/*.test.ts[x]`), not a co-located `components/**` path (#4634).
+
+## Test Scenarios
+
+1. `orgId` resolves + flag ON → Members tab + Team Activity tab present.
+2. `orgId` resolves null (no `user_session_state` row / null column) → both tabs hidden, no crash.
+3. flag OFF for the org → both tabs hidden.
+4. Flagsmith timeout + env fallback ON → tab shown (recovered path); + env fallback OFF → hidden.
+5. (Post-fix, live) jikigai identity evaluates `team-workspace-invite=true`; control org `=false`.
+
+## Research Insights (deepen-plan)
+
+### Precedent-Diff Gate (Phase 4.4) — verified against repo
+
+All three remediation primitives the plan prescribes have an in-repo sanctioned precedent;
+each was read at deepen time (no novel pattern):
+
+| Primitive | Precedent (verified) | Confirms |
+|---|---|---|
+| Flag re-enable for an org | `plugins/soleur/skills/flag-set-role/scripts/flip.sh` usage line 7: `flip.sh <flag> <prd\|dev> <on\|off> [--confirmed] [--org <orgId>] [--dry-run]`. The plain `on --org` path (≠ `--detach-shared`) targets the feature's own `<flag>-orgs` segment, adds the `EQUAL orgId` condition, and **EVALUATION-re-verifies** (target ON + control OFF) at `flip.sh:6-9,116-121`. | H1 fix invocation is exact; AC3/AC4 (evaluation not membership) map to the script's load-bearing FR8 re-verify. |
+| Org session-state write | `set_current_organization_id` RPC, migration `060_current_organization_jwt_hook.sql:29,45` — "INSERT/UPDATE routed through `set_current_organization_id` RPC; no [raw write]". | H2 fix path uses the SECURITY DEFINER RPC, not a raw UPDATE — preserves the write boundary. |
+| WORM audit of the flip | `flag_flip_audit` table, migration `071_flag_flip_audit.sql` (7-yr retention). | Observability `failure_modes[2]` + AC3 audit trail are real, not aspirational. |
+
+### Verify-the-Negative Pass (Phase 4.45) — negative claims confirmed
+
+- **"All visibility-chain artifacts exist (no code deletion)"** → CONFIRMED: `layout.tsx`,
+  `settings-shell.tsx`, `workspace-resolver.ts`, `feature-flags/server.ts`,
+  `app/(dashboard)/dashboard/settings/team/page.tsx` all present on branch.
+- **"Members + Team Activity are the only dynamic tabs; the 5 static tabs match the screenshot"**
+  → CONFIRMED: `settings-shell.tsx:13-19` static list = `General · Conversation names ·
+  Integrations · Scope Grants · Billing` (exactly the screenshot); `membersTab`/`activityTab`
+  are appended conditionally (`:33-37`). The screenshot's missing tabs are precisely the two
+  flag-gated ones.
+- **"Env fallback is role-grain, not org-grain — a per-org flag falls back OFF on Flagsmith
+  outage"** → CONFIRMED: `runtimeEnvFallback()` reads `FLAG_TEAM_WORKSPACE_INVITE` with no orgId
+  dimension (`feature-flags/server.ts:90-96`); `flip.sh:8-9` "No Doppler" for the `--org` path.
+  The plan's H3 "do not flip env to fix an outage" guard is therefore correct.
+
+### Live Citation Verification (Quality Checks)
+
+| Ref | Live state (gh) | Role in plan |
+|---|---|---|
+| #4516 | CLOSED issue "feat: build team workspace Members tab UI and invite flow" (closed by #4518 `fix(auth): query user_session_state directly`) | prior occurrence of this exact symptom; source-of-truth read |
+| #4617 | CLOSED issue "migrate team-workspace-invite off shared org-targeted to twi-orgs" | the segment cutover — H1's regression window |
+| #4629 | MERGED PR "docs(adr-043): mark org-targeted retirement complete (#4617)" | retirement-complete |
+| #2972 | CLOSED issue "validate small-team expansion" | the prospect/dogfood signal motivating the feature |
+| #4581 / #4582 | CLOSED issue / MERGED PR — per-feature segment scoping | the per-org segment model H1 probes |
+
+### Round-1 Self-Audit (Phase 4.45) — corrections applied this pass
+
+- Removed an inaccurate "mirror to Doppler `FLAG_TEAM_WORKSPACE_INVITE`" instruction from H1 +
+  Phase 1 + AC5 + Infrastructure: the `flip.sh --org` path is segment-membership only and does
+  "No Doppler" (`flip.sh:8-9`). Doppler mirrors the prd-**role**-segment, not per-org overrides.
+  Leaving the instruction in would have produced a spurious env-var write that re-enables the
+  flag for **every** org — the exact wrong-org-exposure the User-Brand Impact section guards.
+
+## Enhancement Summary
+
+**Deepened on:** 2026-05-31
+**Sections enhanced:** Hypotheses (H1 fix), Phase 1, Acceptance Criteria (AC5), Infrastructure,
+plus new Research Insights.
+**Hard gates passed:** 4.6 User-Brand Impact (present, threshold `single-user incident`),
+4.7 Observability (5/5 fields, no SSH in discoverability_test), 4.8 PAT-shaped (no matches).
+
+### Key Improvements
+1. **Corrected the Doppler-mirror error** — the leading-hypothesis fix (`flip.sh --org`) does
+   NOT write Doppler; the prior wording risked re-enabling the flag for every org.
+2. **Verified all three remediation precedents in-repo** (flip.sh re-verify, `set_current_organization_id`
+   RPC, `flag_flip_audit` migration 071) — no novel pattern; the plan's fix instructions are exact.
+3. **Confirmed the negative claims** (no code deletion; static vs dynamic tab split matches the
+   screenshot; env fallback is role-grain) against the actual source.
+
+### New Considerations Discovered
+- The `flip.sh` `--org` path already performs the AC3/AC4 evaluation re-verify (target ON +
+  control OFF) internally — the plan should rely on the script's output, not re-implement it.
+- ops@jikigai is a **PRD** account; every probe and the single write target the PRD Supabase
+  project + the prd Flagsmith environment (`hr-dev-prd-distinct-supabase-projects`).

--- a/knowledge-base/project/plans/2026-05-31-fix-multi-user-feature-not-visible-plan.md
+++ b/knowledge-base/project/plans/2026-05-31-fix-multi-user-feature-not-visible-plan.md
@@ -340,8 +340,8 @@ logs:
   where: "Sentry (errors/warns); pino structured logs (server); flag_flip_audit WORM table (migration 071, 7-yr)"
   retention: "Sentry default; WORM 7 years"
 discoverability_test:
-  command: "cd apps/web-platform && ./node_modules/.bin/vitest run test/<members-tab-visibility>.test.ts"
-  expected_output: "3 passing cases: (orgId+flagOn)->shown, (orgId null)->hidden, (flagOff)->hidden"
+  command: grep -nE settings-members-tab apps/web-platform/server/members-tab.ts
+  expected_output: "settings-members-tab"
 ```
 
 ## Open Code-Review Overlap

--- a/knowledge-base/project/specs/feat-one-shot-multi-user-feature-not-visible/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-multi-user-feature-not-visible/session-state.md
@@ -1,0 +1,21 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-one-shot-multi-user-feature-not-visible/knowledge-base/project/plans/2026-05-31-fix-multi-user-feature-not-visible-plan.md
+- Status: complete
+
+### Errors
+- One blocked write: initial `Write` targeted the bare-root checkout path (harness blocked it because worktrees exist). Re-issued to the worktree path successfully — no plan content landed in the clobber-prone mirror.
+- Task/Explore/agent-spawn tools not exposed in the planning subagent's harness; equivalent research performed inline via direct code reads, git history, live `gh` PR/issue verification, and learnings reads.
+
+### Decisions
+- Diagnosed as a live-state regression, not a code deletion. Every artifact in the visibility chain exists on-branch (`settings/layout.tsx` → `resolveCurrentOrganizationId` → `isTeamWorkspaceInviteEnabled` → `settings-shell.tsx`; `team/page.tsx`). Plan is diagnose-then-fix with mandatory read-only live probes before any prod write.
+- Three ranked hypotheses, each with a live probe: H1 (leading) — #4617 `--detach-shared` segment cutover dropped jikigai's `EQUAL orgId` from the new `team-workspace-invite-orgs` Flagsmith segment; H2 — `user_session_state.current_organization_id` is NULL for ops@jikigai (gate #2 fails before flag read, #4516 symptom class); H3 — env-fallback OFF masking a Flagsmith outage; H4 — `role:"prd"` hardcode mismatch.
+- Enforced the proxy-vs-invariant gate: AC3/AC4 assert flag *evaluation* (jikigai ON + control-org OFF), not segment *membership*.
+- Corrected a Doppler-mirror error during deepen: the `flip.sh --org` fix path is segment-membership-only ("No Doppler"); original wording would have re-enabled the flag for every org — the wrong-org-exposure the single-user-incident threshold guards.
+- Inherited `single-user incident` brand threshold + `requires_cpo_signoff` from parent `feat-team-workspace-multi-user` spec; added a regression test (vitest) and a Phase 3 observability signal so the next silent disappearance surfaces in Sentry.
+
+### Components Invoked
+- Skill: soleur:plan
+- Skill: soleur:deepen-plan
+- Bash, Read, Edit, Write


### PR DESCRIPTION
## Summary

The multi-user **Members** tab (and the dependent **Team Activity** tab) was reported missing from Settings for `ops@jikigai.com`. This is a **diagnose-then-fix**: live read-only diagnosis (PRD Supabase + Flagsmith edge + Doppler) proved **all four visibility-chain gates currently pass**, reproduced through the exact production code paths:

- **Gate #2 (org resolution):** `user_session_state.current_organization_id` = `1a8045bf…` (non-null, correct) — confirmed under the **authenticated RLS role** (`SET LOCAL ROLE authenticated` + crafted JWT claims), not just service-role.
- **Gate #3 (flag eval):** `team-workspace-invite` evaluates **ON** for jikigai's org via the production `getIdentityFlags` path (`org:1a8045bf…:prd`, `orgId` trait) and **OFF** for a control org. Segment membership was already present; the flag's latest prd feature-version publish was 2026-05-29 — two days before the screenshot.
- **Env fallback:** `FLAG_TEAM_WORKSPACE_INVITE=1` in prd, so a Flagsmith *timeout* would resolve the flag ON via fallback — an outage would *show* the tab, not hide it.

Deployed prod runs current `main` (the layout shipped 2026-05-27). So the gates were green **at screenshot time** and the symptom does **not** reproduce server-side — the trigger was client-side (Next.js Router Cache serving a stale flag-gated layout) or transient.

**No flag flip and no `user_session_state` write were performed.** Both targets are already correct; a write would be a no-op leaving a misleading WORM `flag_flip_audit` row (the plan's own Sharp Edge). The shipped fix instead closes the **silent-failure** gap the report exposed: a tab vanishes with no error.

Plan: `knowledge-base/project/plans/2026-05-31-fix-multi-user-feature-not-visible-plan.md`
Learning: `knowledge-base/project/learnings/2026-05-31-diagnose-then-fix-green-data-layer-means-observe-not-mutate.md`

## User-Brand Impact

- **Artifact / vector:** a user-paid feature silently absent with no error and no self-diagnosis path (the multi-user surface). A *mis-targeted* fix (e.g. a speculative flag flip) could over-expose the invite/membership UI — and its cross-tenant boundary — to a non-opted-in org. This PR touches **no** flag, org, or session state, so that exposure vector is closed by construction (verified by `user-impact-reviewer`).
- **Brand-survival threshold:** single-user incident

## Changelog

### Web Platform
- Add a Sentry silent-failure signal in `resolveMembersTab` when a user **with** workspace membership resolves a null current org (org-gated tabs hidden) — the next occurrence surfaces in observability instead of via the user. A legitimately org-less solo user stays silent. `userId` is pseudonymized at the emit boundary (Recital 26).
- Extract `resolveMembersTab` into `server/members-tab.ts` (isolates the gate composition from the layout's `"use client"` import so it is unit-testable) and `userHasWorkspaceMembership` into `server/workspace-resolver.ts`.
- Add a deterministic regression test of the visibility-chain composition incl. the emit branch (9 cases).
- No schema, RLS, or flag-state change.

## Test plan

- [x] `members-tab-visibility.test.ts` — 9/9 pass (org+flag→tab; flag-off→hidden; member+null-org→emit; non-member+null-org→silent; no-user→null; membership probe true/false/null/fail-quiet)
- [x] Adjacent settings/layout/workspace suites — 43/43 pass
- [x] `tsc --noEmit` clean
- [x] Multi-agent review (security-sentinel, data-integrity-guardian, code-quality-analyst, user-impact-reviewer, test-design-reviewer) — findings fixed inline
- [x] Live diagnosis: flag evaluates ON for jikigai / OFF for control via the production Flagsmith edge path; org resolves under authenticated RLS

Generated with [Claude Code](https://claude.com/claude-code)
