### PR TITLE
fix(inngest): retire watchdog to liveness-only beacon (/v1/functions is loopback-gated)

### DIFF
--- a/apps/web-platform/infra/sentry/cron-monitors.tf
+++ b/apps/web-platform/infra/sentry/cron-monitors.tf
@@ -426,15 +426,15 @@ resource "sentry_cron_monitor" "scheduled_ux_audit" {
 
 # Issue #4650: Inngest-fired via
 # `apps/web-platform/server/inngest/functions/cron-inngest-cron-watchdog.ts`.
-# NEW monitor — self-healing watchdog for the cron-trigger desync regression
-# (runbook H9). Every 4h it queries the running server's /v1/functions registry
-# and self-restores dropped (H9a) / de-planned (H9b) cron triggers; an ok=false
-# heartbeat flips THIS monitor to error when any monitored function is defective.
-# 4-hourly (0 */4 * * *) — 120-min margin per the Inngest ≤2-min jitter plus
-# slack for the loopback fetch + heal steps. 5 min runtime (pure-IO: loopback
-# fetch + inngest.send + optional webhook POST, no claude-eval spawn).
-# The watchdog rides the substrate it monitors — if it stops firing entirely,
-# this monitor's own missed check-in surfaces the meta-failure.
+# LIVENESS BEACON (#4682 retired the self-heal). The watchdog originally queried
+# the server's /v1/functions registry to classify + self-restore dropped (H9a) /
+# de-planned (H9b) cron triggers, but that introspection API is loopback-gated
+# and unreachable from the app container (health=200, /v1/functions=404), and the
+# self-heal is redundant with --poll-interval 60 (#4652) + the per-function cron
+# monitors. The function now just posts ok=true every 4h: its own check-in proves
+# the inngest cron scheduler is alive enough to fire it. So THIS monitor pages
+# only on a MISSED check-in (scheduler dead / function dropped), never on ok=false.
+# 4-hourly (0 */4 * * *) — 120-min margin per the Inngest ≤2-min jitter.
 resource "sentry_cron_monitor" "scheduled_inngest_cron_watchdog" {
   organization            = var.sentry_org
   project                 = data.sentry_project.web_platform.slug

--- a/apps/web-platform/server/inngest/functions/cron-inngest-cron-watchdog.ts
+++ b/apps/web-platform/server/inngest/functions/cron-inngest-cron-watchdog.ts
@@ -42,15 +42,8 @@
 // re-syncs everything), (b) its own Sentry monitor
 // (scheduled-inngest-cron-watchdog) flips to missed if it stops firing.
 
-import { createHmac } from "node:crypto";
-
 import { inngest } from "@/server/inngest/client";
-import { reportSilentFallback } from "@/server/observability";
-import { sendInngestWithRetry } from "@/server/inngest/send-with-retry";
 import {
-  REPO_OWNER,
-  REPO_NAME,
-  mintInstallationToken,
   postSentryHeartbeat,
   type HandlerArgs,
 } from "./_cron-shared";
@@ -83,27 +76,7 @@ export const RESTART_COOLDOWN_MS = 6 * 60 * 60 * 1000;
 // backstop restart is initiated; the ok=false heartbeat pages the whole time.
 export const POLL_RECOVERY_GRACE_TICKS = 2;
 
-// State persisted to the container-local filesystem (NOT a host bind-mount —
-// only /mnt/data/workspaces and /mnt/data/plugins are mounted into this
-// container; this path is a plain writable-layer dir). That is sufficient for
-// a read-own-write cooldown: it survives the event it gates — H9a heal restarts
-// `inngest-server.service`, a SEPARATE process, leaving this container (and
-// this file) untouched. A web-platform REDEPLOY resets it, but a redeploy
-// re-syncs every function (no MISSING → no restart attempted), so the reset is
-// benign. In-memory state would be cleared on every Inngest function replay, so
-// an on-disk file is still required between the 4h ticks.
-const COOLDOWN_DIR = "/var/lib/inngest/cron-watchdog";
-const COOLDOWN_FILE = `${COOLDOWN_DIR}/restart-cooldown.json`;
-
 const FETCH_TIMEOUT_MS = 10_000;
-const WEBHOOK_TIMEOUT_MS = 30_000;
-
-const TOKEN_MIN_LIFETIME_MS = 15 * 60 * 1000;
-
-// Sentinel label the D1-B fallback issue carries; inngest-watchdog-restart-
-// dispatch.yml listens for it and dispatches restart-inngest-server.yml,
-// keeping the H9a restart autonomous even when the direct webhook POST fails.
-const RESTART_ESCALATION_LABEL = "inngest-desync-restart";
 
 // Expected-cron manifest — every cron-*.ts function that MUST have a live
 // cron trigger. function-registry-count.test.ts (e) asserts this set equals
@@ -315,98 +288,6 @@ export async function fetchRegistry(host: string): Promise<RegistryFunction[]> {
   );
 }
 
-async function readState(): Promise<WatchdogState> {
-  try {
-    const { readFile } = await import("node:fs/promises");
-    const raw = await readFile(COOLDOWN_FILE, "utf8");
-    return JSON.parse(raw) as WatchdogState;
-  } catch {
-    return {}; // no prior state recorded
-  }
-}
-
-async function writeState(state: WatchdogState): Promise<void> {
-  const { mkdir, writeFile } = await import("node:fs/promises");
-  await mkdir(COOLDOWN_DIR, { recursive: true });
-  await writeFile(COOLDOWN_FILE, JSON.stringify(state));
-}
-
-// D1-A: POST the deploy webhook to restart inngest-server (same HMAC + CF-Access
-// path as restart-inngest-server.yml). The webhook's ci-deploy.sh rejects any
-// restart whose component is not `inngest` (the `restart` action branch in
-// ci-deploy.sh), so runtime scope is bounded to inngest-server restarts.
-async function postRestartWebhook(): Promise<{ ok: boolean; status: number }> {
-  const secret = process.env.WEBHOOK_DEPLOY_SECRET;
-  const cfId = process.env.CF_ACCESS_CLIENT_ID;
-  const cfSecret = process.env.CF_ACCESS_CLIENT_SECRET;
-  if (!secret || !cfId || !cfSecret) {
-    return { ok: false, status: 0 }; // creds absent → escalate to D1-B
-  }
-  const payload = JSON.stringify({ command: "restart inngest _ latest" });
-  const signature = createHmac("sha256", secret).update(payload).digest("hex");
-  const res = await fetch("https://deploy.soleur.ai/hooks/deploy", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "X-Signature-256": `sha256=${signature}`,
-      "CF-Access-Client-Id": cfId,
-      "CF-Access-Client-Secret": cfSecret,
-    },
-    body: payload,
-    signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),
-  });
-  return { ok: res.status === 202, status: res.status };
-}
-
-// D1-B fallback: file (or comment on) a p0 escalation issue carrying the
-// sentinel label that inngest-watchdog-restart-dispatch.yml acts on. Keeps the
-// restart autonomous when the direct webhook POST is unreachable.
-async function fileRestartEscalationIssue(
-  token: string,
-  affectedFnIds: string[],
-): Promise<void> {
-  const { Octokit } = await import("@octokit/core");
-  const octokit = new Octokit({ auth: token });
-  const title = "[inngest-desync] cron functions need a server restart (H9a/H9b)";
-  const search = await octokit.request("GET /search/issues", {
-    q: `repo:${REPO_OWNER}/${REPO_NAME} is:issue is:open in:title "${title}"`,
-    per_page: 1,
-  });
-  const existing = (search.data.items ?? [])[0];
-  const detail = `Cron-plan defect (dropped or persistently de-planned) at ${new Date().toISOString()}: ${affectedFnIds.join(", ")}`;
-  if (existing) {
-    await octokit.request(
-      "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
-      {
-        owner: REPO_OWNER,
-        repo: REPO_NAME,
-        issue_number: existing.number,
-        body: `Still desynced — ${detail}`,
-      },
-    );
-    return;
-  }
-  await octokit.request("POST /repos/{owner}/{repo}/issues", {
-    owner: REPO_OWNER,
-    repo: REPO_NAME,
-    title,
-    labels: ["priority/p0-critical", RESTART_ESCALATION_LABEL],
-    body: [
-      "## Inngest cron functions need a server restart (H9a dropped / H9b persistently de-planned)",
-      "",
-      detail,
-      "",
-      "The watchdog could not reach the deploy webhook directly (D1-A). This",
-      `issue carries the \`${RESTART_ESCALATION_LABEL}\` label so`,
-      "`inngest-watchdog-restart-dispatch.yml` dispatches `restart-inngest-server.yml`.",
-      "",
-      "Runbook: [cloud-scheduled-tasks.md H9](https://github.com/jikig-ai/soleur/blob/main/knowledge-base/engineering/ops/runbooks/cloud-scheduled-tasks.md).",
-      "",
-      "_Auto-filed by the [cron-inngest-cron-watchdog Inngest function](https://github.com/jikig-ai/soleur/blob/main/apps/web-platform/server/inngest/functions/cron-inngest-cron-watchdog.ts)._",
-    ].join("\n"),
-  });
-}
-
 // =============================================================================
 // Handler
 // =============================================================================
@@ -419,202 +300,35 @@ export async function cronInngestCronWatchdogHandler({
   results: ClassifyResult[];
   healed: { manualTriggers: string[]; restartRequested: boolean };
 }> {
-  // Step 1: query the running server's function registry (loopback, no SSH).
-  // NON-FATAL (#4682): a registry-read failure must NOT abort the handler
-  // before the heartbeat — that produced a SILENT watchdog (0 check-ins for
-  // ~5 fires) when /v1/functions 404'd. Catch inside the step, return null on
-  // failure, and treat "can't read the registry" as a defect that pages below.
-  const registry = await step.run("fetch-registry", async () => {
-    const host = resolveInngestHost(process.env.INNGEST_BASE_URL);
-    try {
-      return await fetchRegistry(host);
-    } catch (err) {
-      // SSH-free root-cause probe (#4682): /v1/functions 404s from the app
-      // container while the host's 127.0.0.1:8288/v1/functions returns 200, and
-      // dropping the auth header did NOT change it — so the cause is the network
-      // path, not auth. Probe /health on the SAME host so the next fire's Sentry
-      // event definitively separates the two hypotheses:
-      //   - health 200 → connectivity is fine; the 404 is path-/loopback-gated
-      //     introspection (fix host-side: expose /v1/functions or move the read).
-      //   - health unreachable → broad container→server connectivity loss
-      //     (fix INNGEST_BASE_URL / docker networking).
-      let healthStatus = "unprobed";
-      try {
-        const hr = await fetch(`${host}/health`, {
-          signal: AbortSignal.timeout(5_000),
-        });
-        healthStatus = String(hr.status);
-      } catch (he) {
-        healthStatus = `unreachable:${(he as Error)?.name ?? "error"}`;
-      }
-      reportSilentFallback(err, {
-        feature: "cron-inngest-cron-watchdog",
-        op: "fetch-registry",
-        message: "Failed to read /v1/functions — cannot verify cron substrate (#4682)",
-        extra: { fn: "cron-inngest-cron-watchdog", registryHost: host, healthStatus },
-      });
-      return null;
-    }
-  });
-
-  // Registry unreadable → substrate health UNKNOWN → page (ok=false) and skip
-  // heal (no data to act on). The heartbeat ALWAYS posts so the watchdog's own
-  // monitor is never silent — the failure mode #4682 fixed.
-  if (registry === null) {
-    await step.run("sentry-heartbeat-registry-unreadable", async () => {
-      await postSentryHeartbeat({
-        ok: false,
-        sentryMonitorSlug: SENTRY_MONITOR_SLUG,
-        cronName: "cron-inngest-cron-watchdog",
-        logger,
-      });
-    });
-    return {
-      ok: false,
-      results: [],
-      healed: { manualTriggers: [], restartRequested: false },
-    };
-  }
-
-  // Pure classification (no IO — safe in the handler body).
-  const results = classifyRegistry(registry);
-  const plan = planHeal(results);
-
-  // Step 2: heal H9b (UNPLANNED) — fire each manual-trigger so the function
-  // runs once and re-posts its check-in NOW. With --poll-interval 60 (#4652)
-  // the server re-plans the de-planned cron from the SDK manifest within <=60s
-  // on its own, so this manual-trigger is a LATENCY OPTIMIZATION (restores the
-  // missed check-in immediately rather than waiting up to one poll interval),
-  // not the primary repair. If a defect persists across ticks despite polling,
-  // Step 3's backstop restart escalates it.
-  const manualTriggers = await step.run("heal-unplanned", async () => {
-    const fired: string[] = [];
-    for (const eventName of plan.manualTriggerEvents) {
-      try {
-        await sendInngestWithRetry(
-          () => inngest.send({ name: eventName, data: {} }),
-          { feature: "cron-inngest-cron-watchdog", eventId: eventName },
-        );
-        fired.push(eventName);
-        logger.info(
-          { fn: "cron-inngest-cron-watchdog", event: eventName },
-          "H9b heal: fired manual-trigger for de-planned cron",
-        );
-      } catch (err) {
-        reportSilentFallback(err, {
-          feature: "cron-inngest-cron-watchdog",
-          op: "heal-unplanned",
-          message: `Failed to fire manual-trigger ${eventName}`,
-          extra: { fn: "cron-inngest-cron-watchdog", event: eventName },
-        });
-      }
-    }
-    return fired;
-  });
-
-  // Step 3: BACKSTOP restart path (#4652). Polling (--poll-interval 60)
-  // re-syncs/re-plans dropped (H9a) AND de-planned (H9b) functions within <=60s
-  // automatically, so the watchdog no longer restarts on the first defective
-  // tick. A restart fires ONLY when a function stays defective (MISSING ∪
-  // UNPLANNED) for POLL_RECOVERY_GRACE_TICKS consecutive ticks — evidence that
-  // polling has FAILED (app /api/inngest down, poll loop wedged) — and the
-  // cooldown permits it (defense-in-depth, AC6). Streaks persist across ticks
-  // in the same state file.
-  const restartRequested = await step.run("heal-restart-path", async () => {
-    const state = await readState();
-    const defectFnIds = [...plan.missingFnIds, ...plan.unplannedFnIds];
-    const streaks = nextDefectStreaks(state.defect_streaks, defectFnIds);
-    const restartFnIds = escalatedDefectFnIds(streaks);
-
-    if (restartFnIds.length === 0) {
-      // No restart needed this tick — persist streaks (resets recovered fns),
-      // preserve the cooldown timestamp.
-      await writeState({
-        last_restart_at: state.last_restart_at,
-        defect_streaks: streaks,
-      });
-      return false;
-    }
-    if (!shouldRestart(restartFnIds, state.last_restart_at ?? null, Date.now())) {
-      logger.warn(
-        { fn: "cron-inngest-cron-watchdog", restartFnIds },
-        "Restart warranted (H9a/escalated-H9b) but within cooldown — skipping (ok=false heartbeat still pages)",
-      );
-      await writeState({
-        last_restart_at: state.last_restart_at,
-        defect_streaks: streaks,
-      });
-      return false;
-    }
-
-    // A restart re-syncs + re-plans ALL functions, so clear streaks on success.
-    const onRestarted = async () =>
-      writeState({ last_restart_at: new Date().toISOString(), defect_streaks: {} });
-
-    try {
-      const webhook = await postRestartWebhook();
-      if (webhook.ok) {
-        await onRestarted();
-        logger.info(
-          { fn: "cron-inngest-cron-watchdog", restartFnIds },
-          "Restart webhook accepted (HTTP 202)",
-        );
-        return true;
-      }
-      reportSilentFallback(
-        new Error(`restart webhook non-202 (status=${webhook.status})`),
-        {
-          feature: "cron-inngest-cron-watchdog",
-          op: "heal-restart-webhook",
-          message: "Restart webhook POST failed — escalating to D1-B issue",
-          extra: { fn: "cron-inngest-cron-watchdog", status: webhook.status },
-        },
-      );
-    } catch (err) {
-      reportSilentFallback(err, {
-        feature: "cron-inngest-cron-watchdog",
-        op: "heal-restart-webhook",
-        message: "Restart webhook POST threw — escalating to D1-B issue",
-        extra: { fn: "cron-inngest-cron-watchdog" },
-      });
-    }
-    // D1-B: file the escalation issue (best-effort).
-    try {
-      const token = await mintInstallationToken({
-        tokenMinLifetimeMs: TOKEN_MIN_LIFETIME_MS,
-      });
-      await fileRestartEscalationIssue(token, restartFnIds);
-      await onRestarted();
-      return true;
-    } catch (err) {
-      reportSilentFallback(err, {
-        feature: "cron-inngest-cron-watchdog",
-        op: "heal-restart-escalate",
-        message: "D1-B escalation-issue filing failed",
-        extra: { fn: "cron-inngest-cron-watchdog" },
-      });
-      // Restart not initiated — keep streaks so the next tick retries.
-      await writeState({
-        last_restart_at: state.last_restart_at,
-        defect_streaks: streaks,
-      });
-      return false;
-    }
-  });
-
-  // Step 4: Sentry heartbeat — ok=false when any monitored function is
-  // MISSING/UNPLANNED, so the watchdog's own monitor flips to error and pages.
-  const ok = plan.defectCount === 0;
+  // RETIRED to a liveness-only beacon (#4682). The original self-heal read the
+  // inngest server's /v1/functions registry to classify MISSING/UNPLANNED crons
+  // and manual-trigger/restart to repair. That introspection API is
+  // loopback-gated on the server: from the app container /health=200 but
+  // /v1/functions=404, while the host's 127.0.0.1:8288/v1/functions=200
+  // (confirmed via the #4682 /health probe) — so a containerized watchdog
+  // CANNOT read it; no auth/network change fixes that.
+  //
+  // The self-heal is also redundant now:
+  //   - `--poll-interval 60` (#4652, live) re-syncs AND re-plans dropped/
+  //     de-planned functions within <=60s — the PRIMARY self-heal.
+  //   - the per-function Sentry cron monitors (failure_issue_threshold) already
+  //     page on missed check-ins (how the #4650 regression was caught).
+  //
+  // So this function just posts an ok=true liveness heartbeat: its own check-in
+  // proves the inngest cron scheduler is alive enough to fire it (if the whole
+  // scheduler dies, this monitor goes missed and pages). It no longer reads the
+  // registry, fires manual-triggers, or restarts — and no longer false-pages
+  // ok=false every 4h on an introspection it cannot perform.
   await step.run("sentry-heartbeat", async () => {
     await postSentryHeartbeat({
-      ok,
+      ok: true,
       sentryMonitorSlug: SENTRY_MONITOR_SLUG,
       cronName: "cron-inngest-cron-watchdog",
       logger,
     });
   });
 
-  return { ok, results, healed: { manualTriggers, restartRequested } };
+  return { ok: true, results: [], healed: { manualTriggers: [], restartRequested: false } };
 }
 
 // =============================================================================

--- a/apps/web-platform/test/server/inngest/cron-inngest-cron-watchdog-handler.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-inngest-cron-watchdog-handler.test.ts
@@ -1,31 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Separate file (per work-skill guidance): the handler test needs vi.mock for
-// fs / fetch / Sentry / _cron-shared, which would clobber the real-import pure
-// helper tests in cron-inngest-cron-watchdog.test.ts. NEXT_PHASE hoisted so the
-// inngest client load-time key check short-circuits.
+// NEXT_PHASE hoisted so the inngest client's load-time key check short-circuits
+// when the module under test is imported.
 vi.hoisted(() => {
   process.env.NEXT_PHASE = "phase-production-build";
 });
 
-const writeFileMock = vi.fn(async (..._args: unknown[]): Promise<void> => {});
-const readFileMock = vi.fn(async (..._args: unknown[]): Promise<string> => {
-  throw new Error("ENOENT"); // no prior state by default
-});
-
-vi.mock("node:fs/promises", () => ({
-  readFile: (...a: unknown[]) => readFileMock(...a),
-  writeFile: (...a: unknown[]) => writeFileMock(...a),
-  mkdir: vi.fn(async () => {}),
-}));
-
-vi.mock("@/server/observability", () => ({
-  reportSilentFallback: vi.fn(),
-}));
-
-// Preserve the real pure helpers + constants; stub only the IO-heavy exports
-// the handler calls (postSentryHeartbeat does its own fs/fetch; mintInstallationToken
-// hits GitHub).
+// Stub only postSentryHeartbeat (it does its own fs/fetch); keep the real
+// module otherwise.
 vi.mock("@/server/inngest/functions/_cron-shared", async () => {
   const actual = await vi.importActual<
     typeof import("@/server/inngest/functions/_cron-shared")
@@ -33,257 +15,64 @@ vi.mock("@/server/inngest/functions/_cron-shared", async () => {
   return {
     ...actual,
     postSentryHeartbeat: vi.fn(async () => {}),
-    mintInstallationToken: vi.fn(async () => "ghs_faketoken"),
   };
 });
 
-import { cronInngestCronWatchdogHandler, EXPECTED_CRON_FUNCTIONS } from "@/server/inngest/functions/cron-inngest-cron-watchdog";
+import { cronInngestCronWatchdogHandler } from "@/server/inngest/functions/cron-inngest-cron-watchdog";
 import { postSentryHeartbeat } from "@/server/inngest/functions/_cron-shared";
-import { reportSilentFallback } from "@/server/observability";
 
 // Fake Inngest step: runs each step body inline (no replay machinery).
 const fakeStep = { run: <T>(_name: string, fn: () => Promise<T>) => fn() };
 const fakeLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
-// Build a /v1/functions registry where exactly `omit` is MISSING (H9a); all
-// others present + cron-planned.
-function registryMissing(omit: string): unknown[] {
-  return EXPECTED_CRON_FUNCTIONS.filter((f) => f !== omit).map((fnId) => ({
-    slug: `soleur-runtime-${fnId}`,
-    triggers: [{ cron: "0 8 * * *" }],
-  }));
-}
-
-function mockFetch(registry: unknown[], webhookStatus: number) {
-  return vi.fn(async (url: string | URL) => {
-    const u = String(url);
-    if (u.includes("/v1/functions")) {
-      return { ok: true, json: async () => registry } as unknown as Response;
-    }
-    if (u.includes("deploy.soleur.ai")) {
-      return { status: webhookStatus } as unknown as Response;
-    }
-    throw new Error(`unexpected fetch ${u}`);
-  });
-}
-
-describe("cronInngestCronWatchdogHandler — backstop restart orchestration (#4652 / AC4–AC7)", () => {
-  const ORIG = { ...process.env };
-
+// #4682: the watchdog was retired to a liveness-only beacon. Inngest's
+// /v1/functions introspection is loopback-gated and unreachable from the app
+// container (health=200 but /v1/functions=404), and the self-heal is redundant
+// with --poll-interval 60 (#4652) + the per-function Sentry monitors. The
+// handler now just posts an ok=true heartbeat proving the cron scheduler fired
+// it — no registry read, no manual-trigger, no restart, no 4-hourly false-page.
+describe("cronInngestCronWatchdogHandler — liveness-only beacon (#4682)", () => {
   beforeEach(() => {
-    writeFileMock.mockClear();
-    readFileMock.mockClear();
-    process.env.INNGEST_BASE_URL = "http://host.docker.internal:8288";
-    process.env.WEBHOOK_DEPLOY_SECRET = "secret";
-    process.env.CF_ACCESS_CLIENT_ID = "cf-id";
-    process.env.CF_ACCESS_CLIENT_SECRET = "cf-secret";
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    process.env = { ...ORIG };
-  });
-
-  it("AC4: H9a single tick → NO restart, ok=false, NO deploy-webhook fetch (polling gets its grace window)", async () => {
-    // Default readFileMock throws ENOENT → no prior state → streak starts at 1
-    // < POLL_RECOVERY_GRACE_TICKS, so the demoted watchdog must NOT restart on
-    // the first defective tick (pre-#4652 this restarted immediately).
-    const fetchMock = mockFetch(registryMissing("cron-community-monitor"), 202);
-    vi.stubGlobal("fetch", fetchMock);
-
-    const out = await cronInngestCronWatchdogHandler({
-      step: fakeStep,
-      logger: fakeLogger,
-    } as never);
-
-    expect(out.ok).toBe(false); // defect present → ok=false heartbeat still pages (AC7 safety net intact)
-    expect(out.healed.restartRequested).toBe(false); // AC4: no restart on tick 1
-    // The load-bearing assertion: the deploy webhook was NOT POSTed this tick.
-    expect(
-      fetchMock.mock.calls.some((c) => String(c[0]).includes("deploy.soleur.ai")),
-    ).toBe(false);
-    // Streak persisted at 1; no last_restart_at written.
-    const lastWrite = writeFileMock.mock.calls.at(-1);
-    expect(lastWrite).toBeDefined();
-    const persisted = JSON.parse(String(lastWrite![1]));
-    expect(persisted.defect_streaks).toEqual({ "cron-community-monitor": 1 });
-    expect(persisted.last_restart_at).toBeUndefined();
-  });
-
-  it("AC5: H9a sustained to the grace threshold → restartRequested, webhook 202, streaks cleared", async () => {
-    // Seed a prior defect streak of (grace-1) so THIS defective tick crosses
-    // POLL_RECOVERY_GRACE_TICKS and escalates to the backstop restart.
-    readFileMock.mockResolvedValueOnce(
-      JSON.stringify({ defect_streaks: { "cron-community-monitor": 1 } }),
-    );
-    const fetchMock = mockFetch(registryMissing("cron-community-monitor"), 202);
-    vi.stubGlobal("fetch", fetchMock);
-
-    const out = await cronInngestCronWatchdogHandler({
-      step: fakeStep,
-      logger: fakeLogger,
-    } as never);
-
-    expect(out.ok).toBe(false);
-    expect(out.healed.restartRequested).toBe(true);
-    expect(
-      fetchMock.mock.calls.some((c) => String(c[0]).includes("deploy.soleur.ai")),
-    ).toBe(true);
-    // last_restart_at set, streaks cleared (a restart re-syncs + re-plans all).
-    const restartWrite = writeFileMock.mock.calls.find((c) =>
-      String(c[1]).includes("last_restart_at"),
-    );
-    expect(restartWrite).toBeDefined();
-    const persisted = JSON.parse(String(restartWrite![1]));
-    expect(typeof persisted.last_restart_at).toBe("string");
-    expect(persisted.defect_streaks).toEqual({});
-  });
-
-  it("AC5: sustained H9a + webhook non-202 → falls back to D1-B, handler does not reject", async () => {
-    // Sustained defect (seeded streak crosses the threshold this tick) so the
-    // restart path is reached; webhook returns 500 → D1-A fails → D1-B.
-    readFileMock.mockResolvedValueOnce(
-      JSON.stringify({ defect_streaks: { "cron-community-monitor": 1 } }),
-    );
-    const fetchMock = mockFetch(registryMissing("cron-community-monitor"), 500);
-    vi.stubGlobal("fetch", fetchMock);
-
-    const out = await cronInngestCronWatchdogHandler({
-      step: fakeStep,
-      logger: fakeLogger,
-    } as never).catch((e) => e);
-
-    // Either D1-B completed (restartRequested true) or Octokit threw (caught →
-    // reportSilentFallback → returns false). Both are non-throwing; assert the
-    // handler did not reject AND the webhook was attempted before D1-B.
-    expect(out).not.toBeInstanceOf(Error);
-    expect(
-      fetchMock.mock.calls.some((c) => String(c[0]).includes("deploy.soleur.ai")),
-    ).toBe(true);
-  });
-
-  it("AC7: clean registry → no restart, ok=true, persists empty streaks (cooldown timestamp preserved)", async () => {
-    readFileMock.mockResolvedValueOnce(
-      JSON.stringify({ last_restart_at: "2026-05-29T00:00:00Z", defect_streaks: {} }),
-    );
-    const fullRegistry = EXPECTED_CRON_FUNCTIONS.map((fnId) => ({
-      slug: `soleur-runtime-${fnId}`,
-      triggers: [{ cron: "0 8 * * *" }],
-    }));
-    vi.stubGlobal("fetch", mockFetch(fullRegistry, 202));
-
-    const out = await cronInngestCronWatchdogHandler({
-      step: fakeStep,
-      logger: fakeLogger,
-    } as never);
-
-    expect(out.ok).toBe(true);
-    expect(out.healed.restartRequested).toBe(false);
-    // State still written to persist (empty) streaks while preserving timestamp.
-    const lastWrite = writeFileMock.mock.calls.at(-1);
-    expect(lastWrite).toBeDefined();
-    const persisted = JSON.parse(String(lastWrite![1]));
-    expect(persisted.last_restart_at).toBe("2026-05-29T00:00:00Z");
-    expect(persisted.defect_streaks).toEqual({});
-  });
-});
-
-describe("cronInngestCronWatchdogHandler — registry-fetch is non-fatal (#4682)", () => {
-  const ORIG = { ...process.env };
-
-  beforeEach(() => {
-    writeFileMock.mockClear();
-    readFileMock.mockClear();
     vi.mocked(postSentryHeartbeat).mockClear();
-    vi.mocked(reportSilentFallback).mockClear();
-    process.env.INNGEST_BASE_URL = "http://host.docker.internal:8288";
-    process.env.WEBHOOK_DEPLOY_SECRET = "secret";
-    process.env.CF_ACCESS_CLIENT_ID = "cf-id";
-    process.env.CF_ACCESS_CLIENT_SECRET = "cf-secret";
   });
 
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    process.env = { ...ORIG };
-  });
-
-  it("404 from /v1/functions → handler does NOT crash, posts ok=false heartbeat, no restart (#4682)", async () => {
-    // The exact prod failure: /v1/functions returns 404 → fetchRegistry throws.
-    // Pre-#4682 this aborted the handler before the heartbeat → 0 check-ins
-    // (silent watchdog). Now it must catch, page ok=false, and skip heal.
-    const fetchMock = vi.fn(async (url: string | URL) => {
-      const u = String(url);
-      // /health probe must be matched before /v1/functions has no overlap, but
-      // order defensively: /health is the #4682 diagnostic probe on failure.
-      if (u.includes("/health")) {
-        return { ok: true, status: 200 } as unknown as Response;
-      }
-      if (u.includes("/v1/functions")) {
-        return { ok: false, status: 404, json: async () => ({}) } as unknown as Response;
-      }
-      if (u.includes("deploy.soleur.ai")) {
-        return { status: 202 } as unknown as Response;
-      }
-      throw new Error(`unexpected fetch ${u}`);
-    });
-    vi.stubGlobal("fetch", fetchMock);
-
+  it("posts an ok=true liveness heartbeat and returns the liveness shape", async () => {
     const out = await cronInngestCronWatchdogHandler({
       step: fakeStep,
       logger: fakeLogger,
-    } as never).catch((e) => e);
+    } as never);
 
-    // Did NOT reject (the silent-death failure mode is gone).
-    expect(out).not.toBeInstanceOf(Error);
-    expect(out.ok).toBe(false);
-    expect(out.results).toEqual([]);
-    expect(out.healed.restartRequested).toBe(false);
-    // The load-bearing fix: a heartbeat (ok=false) IS posted so the monitor pages
-    // instead of going silent.
+    expect(out).toEqual({
+      ok: true,
+      results: [],
+      healed: { manualTriggers: [], restartRequested: false },
+    });
     const hb = vi.mocked(postSentryHeartbeat).mock.calls.at(-1);
     expect(hb).toBeDefined();
-    expect(hb![0]).toMatchObject({ ok: false, sentryMonitorSlug: "scheduled-inngest-cron-watchdog" });
-    // No restart webhook on the degraded path (no registry data to act on).
-    expect(
-      fetchMock.mock.calls.some((c) => String(c[0]).includes("deploy.soleur.ai")),
-    ).toBe(false);
-    // #4682 diagnostic: on a registry-read failure the watchdog probes /health
-    // on the same host so the next fire's Sentry event pins path-404 vs
-    // connectivity. Assert the probe fired AND its result reached the report.
-    expect(
-      fetchMock.mock.calls.some((c) => String(c[0]).includes("/health")),
-    ).toBe(true);
-    const reportCall = vi.mocked(reportSilentFallback).mock.calls.find(
-      (c) => (c[1] as { op?: string })?.op === "fetch-registry",
-    );
-    expect(reportCall).toBeDefined();
-    expect((reportCall![1] as { extra?: { healthStatus?: string } }).extra?.healthStatus).toBe("200");
+    expect(hb![0]).toMatchObject({
+      ok: true,
+      sentryMonitorSlug: "scheduled-inngest-cron-watchdog",
+      cronName: "cron-inngest-cron-watchdog",
+    });
   });
 
-  it("does NOT send an Authorization header to /v1/functions (#4682 — unauth loopback endpoint)", async () => {
-    // INNGEST_SIGNING_KEY is present in prod; the header it would carry caused
-    // the 404. Assert the registry fetch is unauthenticated regardless.
-    process.env.INNGEST_SIGNING_KEY = "signkey-prod-deadbeef";
-    const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
-    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
-      calls.push({ url: String(url), init });
-      return {
-        ok: true,
-        json: async () =>
-          EXPECTED_CRON_FUNCTIONS.map((fnId) => ({
-            slug: `soleur-runtime-${fnId}`,
-            triggers: [{ cron: "0 8 * * *" }],
-          })),
-      } as unknown as Response;
+  it("does NOT read the inngest registry — the retired self-heal makes no fetch", async () => {
+    // Regression guard for the retirement: the handler must not attempt the
+    // (loopback-gated, 404ing) /v1/functions read or any restart webhook.
+    const fetchSpy = vi.fn(async () => {
+      throw new Error("fetch should not be called by the liveness-only watchdog");
     });
-    vi.stubGlobal("fetch", fetchMock);
-
-    await cronInngestCronWatchdogHandler({ step: fakeStep, logger: fakeLogger } as never);
-
-    const regCall = calls.find((c) => c.url.includes("/v1/functions"));
-    expect(regCall).toBeDefined();
-    const headers = (regCall!.init?.headers ?? {}) as Record<string, string>;
-    const headerKeys = Object.keys(headers).map((k) => k.toLowerCase());
-    expect(headerKeys).not.toContain("authorization");
+    vi.stubGlobal("fetch", fetchSpy);
+    try {
+      const out = await cronInngestCronWatchdogHandler({
+        step: fakeStep,
+        logger: fakeLogger,
+      } as never);
+      expect(out.ok).toBe(true);
+      expect(out.healed.restartRequested).toBe(false);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/knowledge-base/engineering/ops/runbooks/cloud-scheduled-tasks.md
+++ b/knowledge-base/engineering/ops/runbooks/cloud-scheduled-tasks.md
@@ -366,56 +366,42 @@ does).
 
 ### Self-healing (automated — primary path, no SSH)
 
-The CI guard above is build-time only; the manual restore is SSH-gated. The
-`cron-inngest-cron-watchdog` Inngest function
-(`apps/web-platform/server/inngest/functions/cron-inngest-cron-watchdog.ts`,
-shipped for regression #4650) closes both gaps — it runs **every 4 hours** and
-needs **no operator action**:
+**The H9 self-heal is now `--poll-interval 60` (#4652), not the watchdog.** The
+self-hosted server polls the co-located app's `/api/inngest` manifest every 60s
+and re-syncs (H9a) AND re-plans (H9b) any dropped/de-planned function within one
+interval, with no restart. This is the automatic, no-operator-action repair for
+both sub-modes.
 
-1. **Detect.** Queries the running server's loopback `/v1/functions` (via
-   `INNGEST_BASE_URL` → `host.docker.internal:8288`, the container's existing
-   loopback bridge — no SSH) and classifies each function in its
-   `EXPECTED_CRON_FUNCTIONS` manifest as `OK`, `MISSING` (H9a), or `UNPLANNED`
-   (H9b).
-2. **Heal H9b (cron de-planned) — latency optimization.** Fires
-   `cron/<name>.manual-trigger` for each affected function via
-   `sendInngestWithRetry`. With `--poll-interval 60` the server re-plans the
-   de-planned cron from the SDK manifest within ≤60s on its own, so this
-   manual-trigger is now a **latency optimization** (it restores the missed
-   check-in *immediately* rather than waiting up to one poll interval), NOT the
-   primary repair.
-3. **Backstop restart (polling has failed).** Polling re-syncs (H9a) and
-   re-plans (H9b) automatically, so the watchdog no longer restarts on the first
-   defective tick. It restarts ONLY after a function stays defective
-   (MISSING ∪ UNPLANNED) for `POLL_RECOVERY_GRACE_TICKS` (2) consecutive ticks —
-   evidence that polling itself has failed (app `/api/inngest` down, poll loop
-   wedged). When that threshold is crossed it POSTs the deploy webhook
-   `restart inngest _ latest` directly (D1-A, same HMAC + CF-Access path as
-   `restart-inngest-server.yml`). If that POST is unreachable, it files a
-   `priority/p0-critical` issue carrying the `inngest-desync-restart` label,
-   which `inngest-watchdog-restart-dispatch.yml` acts on to dispatch the restart
-   workflow (D1-B). A cooldown (`/var/lib/inngest/cron-watchdog/restart-cooldown.json`,
-   6h) is a second guard against restart-looping. NOTE: that path is
-   **container-local** (not a host bind-mount); it survives the inngest-server
-   restart it gates (a separate process) and is reset only by a web-platform
-   redeploy — which itself re-syncs all functions, so the reset is benign.
-4. **Surface (SSH-free read).** Posts an `ok`/`error` heartbeat to the
-   `scheduled-inngest-cron-watchdog` Sentry monitor every 4h; `ok=false` when
-   any monitored function is MISSING/UNPLANNED. Read its state via the Sentry
-   Crons API (no SSH):
+**Alerting** is the per-function Sentry cron monitors: each monitored cron has
+its own `scheduled-*` monitor with `failure_issue_threshold`, so a cron that
+stops checking in pages on its own (that is how the original #4650 regression —
+`scheduled-community-monitor` / `scheduled-gh-pages-cert-state` missed check-ins
+— was caught). Read any monitor's state via the Sentry Crons API (no SSH):
 
-   ```bash
-   curl -s -H "Authorization: Bearer $SENTRY_API_TOKEN" \
-     "https://sentry.io/api/0/organizations/$SENTRY_ORG/monitors/?per_page=100" \
-     | jq '.[] | select(.slug=="scheduled-inngest-cron-watchdog") | {slug, envs: [.environments[]? | {name, status, lastCheckIn}]}'
-   ```
+```bash
+curl -s -H "Authorization: Bearer $SENTRY_API_TOKEN" \
+  "https://sentry.io/api/0/organizations/$SENTRY_ORG/monitors/?per_page=100" \
+  | jq '.[] | {slug, envs: [.environments[]? | {name, status, lastCheckIn}]}'
+```
 
-   If the watchdog itself stops firing (a full-substrate H9a can drop the
-   watchdog too), its own monitor's missed check-in surfaces the meta-failure.
+**The `cron-inngest-cron-watchdog` function is RETIRED to a liveness-only beacon
+(#4682).** Its original design queried the server's `/v1/functions` registry to
+classify MISSING/UNPLANNED crons and manual-trigger/restart to repair — but that
+introspection API is **loopback-gated** on the inngest server: from the app
+container `/health` returns 200 yet `/v1/functions` returns 404, while the host's
+`127.0.0.1:8288/v1/functions` returns 200 (confirmed via the #4682 `/health`
+probe). A containerized watchdog therefore can never read the registry, and the
+self-heal it provided is redundant with polling + the per-function monitors
+above. It now just posts an `ok=true` heartbeat to `scheduled-inngest-cron-watchdog`
+proving the cron scheduler fired it (a coarse substrate-liveness signal; if the
+whole scheduler dies, this monitor goes missed and pages). It no longer reads the
+registry, fires manual-triggers, or restarts. The `inngest-watchdog-restart-dispatch.yml`
+workflow + the exported heal/restart helpers in the watchdog module are now
+dormant (cleanup tracked separately).
 
 The manual SSH fallback below is retained as a **last resort** only
-(`hr-no-ssh-fallback-in-runbooks`); the watchdog + restart workflow are the
-primary paths.
+(`hr-no-ssh-fallback-in-runbooks`); polling + the per-function monitors + the
+`restart-inngest-server.yml` workflow (above) are the primary paths.
 
 ## Restore Procedure (generalized)
 


### PR DESCRIPTION
## Summary

Retire `cron-inngest-cron-watchdog` to a **liveness-only beacon**. Root cause of the watchdog never working (confirmed via the #4682 `/health` probe at the 20:00Z fire): Inngest's `/v1/functions` introspection API is **loopback-gated** — from the app container `host.docker.internal:8288/health`=200 but `/v1/functions`=404, while the host's `127.0.0.1:8288/v1/functions`=200. A containerized watchdog can **never** read the registry (dropping the auth header in #4694 didn't change it — the 404 recurred on the fixed code).

Closes #4682.

## Why retire (vs. fix the read)
The self-heal is redundant now:
- `--poll-interval 60` (#4652, live) re-syncs AND re-plans dropped/de-planned functions within ≤60s — the **primary** self-heal.
- the **per-function Sentry monitors** (`failure_issue_threshold`) already page on missed check-ins — that is how the original #4650 regression was caught.

So the watchdog's container-side registry introspection is both impossible and unnecessary.

## Change
- **Handler → liveness-only:** posts an `ok=true` heartbeat (proves the cron scheduler fired it; goes `missed`→pages if the scheduler dies). No registry read, classify, manual-trigger, or restart → **stops the 4-hourly `ok=false` false-page**.
- **Removed dead private code:** `readState`/`writeState`, `postRestartWebhook` (HMAC deploy-webhook poster), `fileRestartEscalationIssue` (Octokit issue filer) + their constants + now-unused imports.
- **Kept exported:** `fetchRegistry`, `classifyRegistry`, `resolveInngestHost`, `EXPECTED_CRON_FUNCTIONS`, `ClassifyResult`, `RegistryFunction` (the `oneshot-4650-monitor-close.ts` consumer still imports them).
- **Runbook H9:** self-heal is polling; alerting is per-function monitors; the watchdog is a liveness beacon.
- Net −511 lines.

## Follow-up (deferred, #4707)
Dead exported heal/restart helpers + the orphaned `inngest-watchdog-restart-dispatch.yml` + the **same-root-cause** breakage of `oneshot-4650-monitor-close.ts` (#4654/#4655 — it also 404s on `/v1/functions`). Kept out of this PR to ship the false-page fix minimally.

## User-Brand Impact
**If this lands broken:** none beyond status quo — the watchdog was already non-functional (paging `ok=false` every fire). This restores a truthful liveness signal and removes a dead self-heal; polling + per-function monitors are the real coverage. **If it leaks:** N/A — removes a credentialed deploy-webhook poster + issue filer from the watchdog (strictly less surface); no new secret/data path.

- **Brand-survival threshold:** aggregate pattern — internal ops observability of the cron substrate; no single-user data/credential exposure.

## Test plan
- [x] Watchdog unit + handler + oneshot consumer + function-registry-count: 48/48
- [x] `tsc --noEmit` clean
- [x] Handler test rewritten for liveness-only (no fetch, `ok=true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
