### PR TITLE
fix(inngest): scope cloud-task-heartbeat to output-producing tasks; fix thresholds

### DIFF
--- a/apps/web-platform/server/inngest/functions/cron-cloud-task-heartbeat.ts
+++ b/apps/web-platform/server/inngest/functions/cron-cloud-task-heartbeat.ts
@@ -39,16 +39,28 @@ export interface TaskEntry {
   maxGapDays: number;
 }
 
+// INVENTORY SCOPE — output-producing scheduled tasks ONLY.
+//
+// The heartbeat's only valid signal is "did this task produce its expected
+// `scheduled-<task>` issue artifact within its cadence window?" — so a task
+// belongs here ONLY if its cron function actually creates a `scheduled-<task>`
+// labeled issue. Three tasks were removed because they are NON-PRODUCERS and
+// would false-fire forever via the `daysSince === null → silent: true` branch:
+//   - daily-triage: labels existing issues only (prompt forbids `gh issue create`)
+//   - ux-audit: runs UX_AUDIT_DRY_RUN=true → writes Supabase/stdout, no issue
+//   - bug-fixer: opens bot-fix PRs, never a `scheduled-bug-fixer` issue
+// Cron LIVENESS for ALL tasks (including these three) is covered separately by
+// the per-function Sentry cron monitors — see #4708, which retired the sibling
+// cron-inngest-cron-watchdog for the same reason (Inngest `/v1/*` run-history is
+// loopback-gated and unreachable from the app container). maxGapDays is derived
+// from each task's real cron cadence; see the runbook's Threshold Derivation.
 export const TASK_INVENTORY: TaskEntry[] = [
-  { name: "content-generator", label: "scheduled-content-generator", maxGapDays: 4 },
-  { name: "daily-triage", label: "scheduled-daily-triage", maxGapDays: 2 },
+  { name: "content-generator", label: "scheduled-content-generator", maxGapDays: 9 },
   { name: "strategy-review", label: "scheduled-strategy-review", maxGapDays: 9 },
-  { name: "legal-audit", label: "scheduled-legal-audit", maxGapDays: 9 },
-  { name: "competitive-analysis", label: "scheduled-competitive-analysis", maxGapDays: 32 },
-  { name: "community-monitor", label: "scheduled-community-monitor", maxGapDays: 9 },
+  { name: "legal-audit", label: "scheduled-legal-audit", maxGapDays: 95 },
+  { name: "competitive-analysis", label: "scheduled-competitive-analysis", maxGapDays: 40 },
+  { name: "community-monitor", label: "scheduled-community-monitor", maxGapDays: 3 },
   { name: "roadmap-review", label: "scheduled-roadmap-review", maxGapDays: 9 },
-  { name: "ux-audit", label: "scheduled-ux-audit", maxGapDays: 32 },
-  { name: "bug-fixer", label: "scheduled-bug-fixer", maxGapDays: 9 },
 ];
 
 const SILENCE_ISSUE_TITLE_PREFIX = "[cloud-task-silence]";

--- a/apps/web-platform/test/server/inngest/cron-cloud-task-heartbeat.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-cloud-task-heartbeat.test.ts
@@ -3,7 +3,13 @@
 // Test coverage:
 //   (a) Registration smoke test — import loads without throwing.
 //   (b) Source-shape anchor tests — id, cron, event, concurrency, retries.
-//   (c) Exported constant — TASK_INVENTORY (9 tasks with correct shape).
+//   (c) Exported constant — TASK_INVENTORY (6 output-producing tasks).
+//
+// INVENTORY SCOPE (see knowledge-base/engineering/ops/runbooks/cloud-scheduled-tasks.md):
+// The heartbeat monitors ONLY scheduled tasks that produce a `scheduled-<task>`
+// issue artifact. Non-producers (daily-triage, ux-audit, bug-fixer) were removed
+// because the label-presence signal can never observe output they never create —
+// their cron LIVENESS is covered by per-function Sentry monitors (#4708), not here.
 
 import { describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
@@ -34,8 +40,8 @@ describe("cronCloudTaskHeartbeat — registration shape (import-time smoke)", ()
 // =============================================================================
 
 describe("cronCloudTaskHeartbeat — TASK_INVENTORY", () => {
-  it("contains exactly 9 tasks", () => {
-    expect(TASK_INVENTORY).toHaveLength(9);
+  it("contains exactly 6 output-producing tasks", () => {
+    expect(TASK_INVENTORY).toHaveLength(6);
   });
 
   it("every entry has name, label, and maxGapDays", () => {
@@ -49,16 +55,19 @@ describe("cronCloudTaskHeartbeat — TASK_INVENTORY", () => {
     }
   });
 
+  it("label is always `scheduled-` + name (guards future typos)", () => {
+    for (const task of TASK_INVENTORY) {
+      expect(task.label).toBe(`scheduled-${task.name}`);
+    }
+  });
+
   it.each([
-    ["content-generator", "scheduled-content-generator", 4],
-    ["daily-triage", "scheduled-daily-triage", 2],
+    ["content-generator", "scheduled-content-generator", 9],
     ["strategy-review", "scheduled-strategy-review", 9],
-    ["legal-audit", "scheduled-legal-audit", 9],
-    ["competitive-analysis", "scheduled-competitive-analysis", 32],
-    ["community-monitor", "scheduled-community-monitor", 9],
+    ["legal-audit", "scheduled-legal-audit", 95],
+    ["competitive-analysis", "scheduled-competitive-analysis", 40],
+    ["community-monitor", "scheduled-community-monitor", 3],
     ["roadmap-review", "scheduled-roadmap-review", 9],
-    ["ux-audit", "scheduled-ux-audit", 32],
-    ["bug-fixer", "scheduled-bug-fixer", 9],
   ] as const)(
     "task %s has label %s and maxGapDays %d",
     (name, label, maxGapDays) => {
@@ -68,6 +77,26 @@ describe("cronCloudTaskHeartbeat — TASK_INVENTORY", () => {
       expect(entry!.maxGapDays).toBe(maxGapDays);
     },
   );
+
+  // Non-producer exclusion guard: these three never create a `scheduled-<task>`
+  // issue (daily-triage labels existing issues only; ux-audit runs dry-run to
+  // Supabase/stdout; bug-fixer opens bot-fix PRs) so the label-presence signal
+  // false-fires forever. They must NOT be in the inventory. (#4708 rationale.)
+  it.each(["daily-triage", "ux-audit", "bug-fixer"])(
+    "non-producer %s is excluded from the inventory",
+    (removed) => {
+      expect(TASK_INVENTORY.find((t) => t.name === removed)).toBeUndefined();
+    },
+  );
+
+  // Cadence-vs-threshold anchor: legal-audit runs quarterly
+  // (`0 11 1 1,4,7,10 *`); the longest quarter gap (Jul 1 → Oct 1) is 92 days,
+  // so its threshold MUST clear that floor or it false-fires every quarter.
+  it("legal-audit threshold clears the quarterly (92-day) floor", () => {
+    const legal = TASK_INVENTORY.find((t) => t.name === "legal-audit");
+    expect(legal).toBeDefined();
+    expect(legal!.maxGapDays).toBeGreaterThanOrEqual(92);
+  });
 });
 
 // =============================================================================

--- a/knowledge-base/engineering/ops/runbooks/cloud-scheduled-tasks.md
+++ b/knowledge-base/engineering/ops/runbooks/cloud-scheduled-tasks.md
@@ -41,24 +41,47 @@ did not run at all.
 
 ## Task Inventory
 
-Nine tasks are monitored. Thresholds derived from observed natural cadence +
-one cadence-cycle of slack; see Threshold Derivation below.
+**The heartbeat monitors ONLY output-PRODUCING scheduled tasks** — tasks whose
+Inngest cron function actually creates a `scheduled-<task>`-labeled issue. Its
+single signal is: *"did this task produce its expected `scheduled-<task>` issue
+artifact within its cadence window?"* (`TASK_INVENTORY` in
+`apps/web-platform/server/inngest/functions/cron-cloud-task-heartbeat.ts`).
+Thresholds are derived from each task's real cron cadence + one cadence-cycle of
+slack; see Threshold Derivation below.
 
-| Task | Execution surface | Schedule | Audit label | Threshold (days) |
-|------|-------------------|----------|-------------|------------------|
-| content-generator | Claude Code Cloud (`soleur-scheduled`) | Tue+Thu 10:00 UTC | `scheduled-content-generator` | 4 |
-| community-monitor | Claude Code Cloud (`soleur-scheduled`) | Daily | `scheduled-community-monitor` | 2 |
-| growth-audit | Claude Code Cloud (`soleur-scheduled`) | Weekly Mon | `scheduled-growth-audit` | 10 |
-| campaign-calendar | GitHub Actions | Weekly Mon | `scheduled-campaign-calendar` | 10 |
-| competitive-analysis | GitHub Actions | Monthly 1st | `scheduled-competitive-analysis` | 35 |
-| roadmap-review | GitHub Actions | Monthly 1st | `scheduled-roadmap-review` | 35 |
-| growth-execution | GitHub Actions | Bi-monthly (1st, 15th) | `scheduled-growth-execution` | 18 |
-| seo-aeo-audit | GitHub Actions | Weekly Mon | `scheduled-seo-aeo-audit` | 10 |
-| daily-triage | GitHub Actions | Daily | `scheduled-daily-triage` | 2 |
+| Task | Execution surface | Cron (UTC) | Audit label | Threshold (days) |
+|------|-------------------|-----------|-------------|------------------|
+| content-generator | Inngest cron | `0 10 * * 2,4` (Tue+Thu) | `scheduled-content-generator` | 9 |
+| strategy-review | Inngest cron | `0 8 * * 1` (Weekly Mon) | `scheduled-strategy-review` | 9 |
+| legal-audit | Inngest cron | `0 11 1 1,4,7,10 *` (Quarterly) | `scheduled-legal-audit` | 95 |
+| competitive-analysis | Inngest cron | `0 9 1 * *` (Monthly 1st) | `scheduled-competitive-analysis` | 40 |
+| community-monitor | Inngest cron | `0 8 * * *` (Daily) | `scheduled-community-monitor` | 3 |
+| roadmap-review | Inngest cron | `0 9 * * 1` (Weekly Mon) | `scheduled-roadmap-review` | 9 |
 
-The Max plan caps the `soleur-scheduled` environment at **3 Cloud task
-definitions**. Adding a 4th Cloud task evicts an existing one silently — this
-is the top-priority risk the watchdog protects against.
+### Excluded NON-PRODUCERS (do not re-add)
+
+These scheduled tasks run on their own Inngest crons but **never create a
+`scheduled-<task>` issue**, so the heartbeat's label-presence signal can never
+observe them — including them produces a permanent false-positive
+`[cloud-task-silence]` alert via the `daysSince === null → silent: true` branch.
+They were removed deliberately:
+
+| Task | Why it produces no `scheduled-<task>` issue |
+|------|---------------------------------------------|
+| daily-triage | Labels existing issues only; its prompt forbids `gh issue create`. |
+| ux-audit | Runs `UX_AUDIT_DRY_RUN=true` → writes findings to Supabase/stdout, no issue. |
+| bug-fixer | Opens `bot-fix/*` PRs; never attaches a `scheduled-bug-fixer` label to an issue. |
+
+**Liveness for these three (and every cron) is covered separately** by the
+per-function Sentry cron monitors (see Self-healing below and **#4708**) — the
+heartbeat was never their liveness signal. Do NOT "restore" them to
+`TASK_INVENTORY` to regain coverage; that coverage already exists in Sentry.
+
+The heartbeat does **not** and **cannot** use Inngest `/v1/*` run-history as a
+liveness signal: that introspection API is loopback-gated and unreachable from
+the app container (proven in #4708 — see the loopback note in Self-healing
+below). The "did the cron fire" question belongs to the per-function Sentry
+monitors; this watchdog answers only the orthogonal "did it produce output".
 
 ## Diagnosis Checklist
 
@@ -429,40 +452,56 @@ Documented here so a future operator can update without re-deriving.
 
 | Task | Cadence | Max natural gap | Threshold | Slack |
 |------|---------|-----------------|-----------|-------|
-| content-generator | Tue+Thu | 5 days (Thu→Tue) | 4 | -1 (tight — see below) |
-| community-monitor | Daily | 1 day | 2 | +1 day |
-| growth-audit | Weekly Mon | 7 days | 10 | +3 days |
-| campaign-calendar | Weekly Mon | 7 days | 10 | +3 days |
-| competitive-analysis | Monthly 1st | ~31 days | 35 | +4 days |
-| roadmap-review | Monthly 1st | ~31 days | 35 | +4 days |
-| growth-execution | Bi-monthly | 16 days | 18 | +2 days |
-| seo-aeo-audit | Weekly Mon | 7 days | 10 | +3 days |
-| daily-triage | Daily | 1 day | 2 | +1 day |
+| content-generator | Tue+Thu | 5 days (Thu→Tue) | 9 | +4 days (one missed cycle) |
+| strategy-review | Weekly Mon | 7 days | 9 | +2 days |
+| legal-audit | Quarterly (1st Jan/Apr/Jul/Oct) | 92 days (Jul→Oct) | 95 | +3 days |
+| competitive-analysis | Monthly 1st | ~31 days | 40 | +9 days (one missed month) |
+| community-monitor | Daily | 1 day | 3 | +2 days (weekend/transient) |
+| roadmap-review | Weekly Mon | 7 days | 9 | +2 days |
 
-**Why content-generator is aggressive (4 days):** The prior silence incident
-was 21 days. A conservative threshold (e.g., 7 days) defeats the point of the
-watchdog. 4 days covers exactly one missed Thu→Tue fire with ~24h headroom
-before alert. If a single upstream transient (Anthropic API blip, WebSearch
-failure, Cloud rate-limit) knocks out one fire, the watchdog opens one issue
-and auto-closes on the next successful fire — sustainable noise level (~1
-issue/week worst case).
+**Why content-generator is 9, not 4:** The Thu→Tue gap alone is 5 days, so the
+prior `4`-day threshold false-fired on a perfectly on-time week. 9 = one full
+cadence cycle (5d max gap) + one missed firing of slack — it surfaces a genuine
+two-cycle outage without alerting on a single transient miss.
+
+**Why legal-audit is 95 (headline defect):** legal-audit runs quarterly; the
+longest quarter gap is 92 days (Jul 1 → Oct 1). The prior `9`-day threshold
+guaranteed a false `[cloud-task-silence]` alert ~9 days into every quarter. 95 =
+92-day floor + 3d slack.
+
+**Why community-monitor is 3, not 9:** it is a daily producer, so a 9-day
+threshold would let a real 8-day outage go unnoticed. 3 = 1d cadence + 2d slack
+(absorbs a weekend / single transient). This is a tightening that improves
+true-positive latency, safe because community-monitor genuinely fires daily.
 
 ## Updating the Watchdog
 
-When a new scheduled task is added:
+The watchdog is now the `cron-cloud-task-heartbeat` **Inngest cron function**
+(`apps/web-platform/server/inngest/functions/cron-cloud-task-heartbeat.ts`),
+not the (deleted, post-TR9) `.github/workflows/scheduled-cloud-task-heartbeat.yml`.
 
-1. Add a row to the `TASKS` array in
-   `.github/workflows/scheduled-cloud-task-heartbeat.yml` in the format
-   `task-name:audit-issue-label:max_gap_days`.
-2. Add a matching row to the Task Inventory and Threshold Derivation tables
-   above.
-3. Verify the label exists (`gh label list | grep <label>`); create if
-   missing.
-4. Dispatch the workflow manually (`gh workflow run scheduled-cloud-task-heartbeat.yml`)
-   and confirm the new row is processed without a silence flag.
+**Eligibility check FIRST — is the task a producer?** Only add a task to
+`TASK_INVENTORY` if its cron function actually creates a `scheduled-<task>`
+labeled issue (grep its `cron-<task>.ts` for an `octokit … POST /issues` /
+`gh issue create` that attaches the `scheduled-<task>` label). If it does not —
+a dry-run, a labels-only triage, a PR-only fixer — do **not** add it; its
+liveness is covered by its own per-function Sentry monitor instead (see the
+Excluded Non-Producers table above).
 
-When a task is removed: delete the row from both the TASKS array and this
-runbook's tables in the same PR.
+When a new producing task is added:
+
+1. Add an entry to `TASK_INVENTORY` in `cron-cloud-task-heartbeat.ts` —
+   `{ name, label: "scheduled-<name>", maxGapDays }` — with `maxGapDays` derived
+   from the task's real cron cadence (Threshold Derivation above).
+2. Add matching rows to the Task Inventory and Threshold Derivation tables here.
+3. Update the cardinality + threshold assertions in
+   `apps/web-platform/test/server/inngest/cron-cloud-task-heartbeat.test.ts`
+   (the `toHaveLength(N)`, the `it.each` table, the non-producer guard).
+4. Verify the label exists (`gh label list | grep <label>`); create if missing.
+
+When a task is removed: delete its entry from `TASK_INVENTORY`, update the test
+assertions, and update both tables here in the same PR — and add it to the
+Excluded Non-Producers table if it was removed for being a non-producer.
 
 ## Dedup Contract
 

--- a/knowledge-base/engineering/ops/runbooks/cloud-scheduled-tasks.md
+++ b/knowledge-base/engineering/ops/runbooks/cloud-scheduled-tasks.md
@@ -7,7 +7,7 @@ date: 2026-04-21
 # Cloud Scheduled Tasks -- Silence Diagnosis and Restore Runbook
 
 **Tracking issue:** #2714
-**Watchdog workflow:** `.github/workflows/scheduled-cloud-task-heartbeat.yml`
+**Watchdog:** `apps/web-platform/server/inngest/functions/cron-cloud-task-heartbeat.ts` (Inngest cron, post-TR9; the former `.github/workflows/scheduled-cloud-task-heartbeat.yml` was deleted in the TR9 migration)
 **Migration context:** PR #1095 (issue #1094) migrated content-generator, campaign-calendar, and growth-audit execution from GitHub Actions to Claude Code Cloud scheduled tasks on 2026-03-25.
 **Foundational learning:** `knowledge-base/project/learnings/2026-04-03-content-cadence-gap-cloud-task-migration.md`
 

--- a/knowledge-base/project/learnings/2026-05-31-inngest-v1-loopback-gated-and-halt-on-stale-premise.md
+++ b/knowledge-base/project/learnings/2026-05-31-inngest-v1-loopback-gated-and-halt-on-stale-premise.md
@@ -1,0 +1,78 @@
+# Learning: Inngest `/v1/*` is loopback-gated from the app container; halt one-shot when a just-merged HEAD invalidates the task premise
+
+## Problem
+
+A `/soleur:go` request asked to re-architect the `cron-cloud-task-heartbeat`
+watchdog to detect scheduled-task silence via **Inngest run-history** instead of
+the presence of a `scheduled-<task>` GitHub issue. The operator (via
+AskUserQuestion) explicitly chose "switch to Inngest run-history".
+
+Two traps:
+
+1. **The chosen approach was technically infeasible.** Inngest here is
+   self-hosted (`host.docker.internal:8288`, SQLite at `/var/lib/inngest`). Inngest
+   gates its **entire `/v1/*` introspection surface to loopback** — from the app
+   container `/health` returns 200 but `/v1/functions` (and `/v1/runs`,
+   `/v1/events` — same namespace) returns **404**; only the host's
+   `127.0.0.1:8288` can read it. So a containerized watchdog can never read
+   run-history, exactly the way it can never read the registry.
+
+2. **A commit merged hours earlier had already proven this.** `#4708`
+   (HEAD commit `8535bdf1`, "retire watchdog to liveness-only beacon") retired the
+   *sibling* `cron-inngest-cron-watchdog.ts` for this exact reason. The one-shot
+   pipeline created its worktree from fresh `origin/main`, which surfaced #4708 in
+   the base — visible only because the worktree was freshly cut.
+
+## Solution
+
+Halt the one-shot pipeline **before** spawning the planning subagent, surface the
+#4708 evidence, and re-ask the operator. The viable fix (operator chose it) was
+the minimal one: keep the GitHub-issue-label detection — a valid "did this task
+produce its output artifact?" signal — and instead **correct `TASK_INVENTORY`**:
+
+- Remove the 3 non-producers (daily-triage / ux-audit / bug-fixer) that never
+  create a `scheduled-<task>` issue, so they false-fired forever via the
+  `daysSince === null → silent: true` branch.
+- Re-derive every remaining producer's `maxGapDays` from its real cron cadence
+  (legal-audit 9→95 was the headline: a 9-day gate on a quarterly cron).
+
+Cron **liveness** for all tasks (including the 3 removed) is covered separately by
+per-function Sentry cron monitors (`failure_issue_threshold = 1` in
+`cron-monitors.tf`) — verified at review time. The heartbeat answers only the
+orthogonal "did it produce output" question.
+
+## Key Insight
+
+- **Self-hosted Inngest `/v1/*` (registry AND run-history) is loopback-gated —
+  unreachable from any app-container code.** Never propose a containerized
+  function that reads Inngest introspection/run-history; no auth or network change
+  fixes it (#4694 tried dropping the auth header; the 404 recurred). Use
+  per-function Sentry cron monitors for "did the cron fire" liveness.
+- **When a one-shot task proposes a re-architecture, scan the fresh worktree base
+  (`git log --oneline -8 <subsystem>` + the HEAD commit body) for recently-merged
+  commits touching the same subsystem BEFORE spawning the planning subagent.** A
+  commit that merged between request and dispatch can invalidate the whole
+  premise; halting pre-plan saves a full plan→work→review→ship cycle and avoids
+  producing a confidently-wrong plan. The operator's chosen option is a strong
+  signal, not a constraint to honor when fresh evidence contradicts it
+  (`cm-challenge-reasoning-instead-of`).
+
+## Session Errors
+
+1. **CWD drift on first RED test run** — ran
+   `./node_modules/.bin/vitest run …` after `cd`-ing to the bare-root
+   `apps/web-platform` (not the worktree), producing a "Tests no tests" / FAIL that
+   looked like a collection error. **Recovery:** re-ran from the worktree-absolute
+   path. **Prevention:** always chain `cd <worktree-abs-path> && <cmd>` in a single
+   Bash call; the Bash tool does not persist CWD and the bare root holds stale
+   synced copies (already documented; reinforced).
+2. **Planning subagent transient Edit path-typo** (forwarded from
+   session-state.md) — dropped the worktree prefix on one Edit; retried with the
+   absolute path and succeeded. **Prevention:** subagents must run the CWD-verify
+   first tool call and use worktree-absolute paths (already in the one-shot
+   subagent contract).
+
+## Tags
+category: integration-issues
+module: apps/web-platform/server/inngest
+related: "#4708, #2714, #4682"

--- a/knowledge-base/project/plans/2026-05-31-fix-cloud-task-heartbeat-inventory-false-positives-plan.md
+++ b/knowledge-base/project/plans/2026-05-31-fix-cloud-task-heartbeat-inventory-false-positives-plan.md
@@ -1,0 +1,245 @@
+---
+title: "fix: Correct cloud-task-heartbeat TASK_INVENTORY to eliminate false-positive [cloud-task-silence] alerts"
+type: fix
+date: 2026-05-31
+branch: feat-one-shot-heartbeat-inngest-run-history
+lane: cross-domain
+brand_survival_threshold: none
+status: ready
+---
+
+# fix: Correct `cloud-task-heartbeat` TASK_INVENTORY to eliminate false-positive `[cloud-task-silence]` alerts
+
+> Spec lacks valid `lane:` (no spec.md for this branch) — defaulted to `cross-domain` (TR2 fail-closed).
+
+## Enhancement Summary
+
+**Deepened on:** 2026-05-31
+**Sections enhanced:** Research Reconciliation, Risks & Sharp Edges, Precedent-Diff
+**Gates passed:** 4.4 precedent-diff (Inngest cron is canonical, already in use — no trigger change), 4.6 User-Brand Impact (threshold `none` + sensitive-path scope-out present), 4.7 Observability (5 fields, non-placeholder, no SSH), 4.8 PAT-shaped (no match)
+
+### Key Improvements
+1. **Strict-mode crash is a bash-era artifact — does NOT apply.** The original GHA watchdog crashed under `set -euo pipefail` on `[[ $n -gt $malformed ]]` (learning `2026-04-21-cloud-task-silence-watchdog-pattern.md` §T10, fixed in PR #2716 commit `dc57a601`). The TR9 Inngest migration replaced that with TypeScript `daysSince > task.maxGapDays` (`cron-cloud-task-heartbeat.ts:130`) — no bash, no strict-mode crash. The plan must NOT prescribe a bash numeric guard; a future maintainer should not re-introduce one.
+2. **Removing the 3 non-producers is reinforced by the foundational learning.** Learning Prevention #2 states "audit-issue labels are a contract; every scheduled-task prompt must produce a labeled audit issue on BOTH success and failure paths." The 3 non-producers structurally violate this contract (dry-run / PR-only / label-only) — they can never satisfy it, so removing them is the correct resolution. Their liveness is covered by per-function Sentry monitors (#4708), not the heartbeat.
+3. **Threshold-doc co-location (learning Prevention #3) is satisfied** by the runbook `## Threshold Derivation` update in Phase 3.
+
+### New Considerations Discovered
+- The `daysSince === null → silent: true` branch (`:111-119`) is exactly why a non-producer false-fires forever: a task that never creates a labeled issue always returns 0 issues → `daysSince === null` → `silent: true`. Removing it from the inventory is the only fix (the branch itself is correct for genuine producers that have truly never fired).
+- community-monitor 9→3 tightening improves dead-man's-switch latency, consistent with the learning's "conservative threshold defeats the point" note (§Key design choices).
+
+## Overview
+
+The `cron-cloud-task-heartbeat` Inngest function (`apps/web-platform/server/inngest/functions/cron-cloud-task-heartbeat.ts`) watches for "scheduled task went silent" by querying GitHub for the most-recent issue labeled `scheduled-<task>` and comparing its age against a per-task `maxGapDays`. When the gap is exceeded — or **when no such labeled issue has ever existed** — it files a `[cloud-task-silence] <task> silent` issue.
+
+The watchdog is currently producing **false-positive** alerts because its `TASK_INVENTORY` is wrong on two axes:
+
+1. **Non-producer tasks are in the inventory.** Three of the nine listed tasks **never create a `scheduled-<task>`-labeled issue by design**. The heartbeat can never observe an output artifact that is never produced, so it false-fires forever (the `daysSince === null → silent: true` branch at `cron-cloud-task-heartbeat.ts:111-119`). These MUST be removed.
+2. **Stale thresholds.** Several producers carry a `maxGapDays` that does not match their real cron cadence. The headline defect: `legal-audit` runs **quarterly** (`0 11 1 1,4,7,10 *`) but has a **9-day** threshold, guaranteeing a silence alert ~9 days into every quarter.
+
+This fix **corrects the inventory and thresholds only**. It explicitly does **NOT** switch to Inngest run-history: the Inngest `/v1/*` introspection API is loopback-gated and unreachable from the app container (proven in **#4708** / HEAD commit `8535bdf1`, which retired the sibling `cron-inngest-cron-watchdog.ts` to a liveness-only beacon for exactly this reason). The "did the cron fire" liveness question is already covered separately by the per-function Sentry cron monitors (see #4708). The heartbeat's job is narrowed to its only valid signal: **"did this output-producing task produce its expected `scheduled-<task>` issue artifact within its cadence window?"**
+
+This is a pure code + test + docs change against an already-provisioned surface. No new infrastructure, no new secrets, no new vendor, no migration.
+
+## Research Reconciliation — Prior Investigation vs. Source
+
+Each claim in the task framing was re-verified by reading the actual cron function source. **No discrepancies found** — source confirms all three flagged non-producers and the quarterly/9-day legal-audit defect.
+
+| Prior claim | Source reality (file:line) | Plan response |
+| --- | --- | --- |
+| bug-fixer is a non-producer (opens bot-fix PRs, no labeled issue) | **CONFIRMED.** `cron-bug-fixer.ts` — `scheduled-bug-fixer` appears only as the Sentry monitor slug (`:73`) and header comments. Issue creation uses `labels: "${priority},type/bug"` (`:254`) and PR-side `labels: ["bot-fix/review-required"]` (`:376,:419`). No `scheduled-bug-fixer` label is ever attached to a created issue. | **REMOVE** from inventory. |
+| ux-audit is a non-producer (`UX_AUDIT_DRY_RUN=true` → Supabase/stdout, no issue) | **CONFIRMED.** `cron-ux-audit.ts:285` hardwires `UX_AUDIT_DRY_RUN: "true"`; prompt (`:80-81`) says dry-run "writes findings to stdout and to" Supabase `ux-audit-artifacts` bucket (`:143,:169`). No `scheduled-ux-audit` issue is created in dry-run. `scheduled-ux-audit` appears only as Sentry slug (`:55`). | **REMOVE** from inventory. |
+| daily-triage is a non-producer (labels existing issues only; prompt forbids creating issues/PRs) | **CONFIRMED.** `cron-daily-triage.ts:60` "You must NOT write code, create PRs, or modify any files"; `:112` "NEVER close, reopen, delete, or assign issues. Only add labels and comments"; allowlist `:140` is `Bash(gh issue list/view/edit/comment:*)` only — **no `gh issue create`**. `scheduled-daily-triage` is the Sentry slug only (`:153`). | **REMOVE** from inventory. |
+| legal-audit runs quarterly but has a 9-day threshold | **CONFIRMED.** `cron-legal-audit.ts:303` → `{ cron: "0 11 1 1,4,7,10 *" }` (1st of Jan/Apr/Jul/Oct). Inventory threshold is 9. | **FIX** threshold to ~95 days. |
+
+**Producer status of all 9 tasks (empirically verified):**
+
+| Task | Cron (file:line) | Cadence | Producer? | Evidence |
+| --- | --- | --- | --- | --- |
+| content-generator | `0 10 * * 2,4` (`:235`) | Twice weekly (Tue, Thu) | **YES** | Prompt `:74,:93` create issue with label `scheduled-content-generator` |
+| daily-triage | `0 4 * * *` (`:305`) | Daily | **NO** | Labels-only; create forbidden (see above) |
+| strategy-review | `0 8 * * 1` (`:669`) | Weekly (Mon) | **YES** | `REVIEW_LABEL = "scheduled-strategy-review"` (`:76`), `octokit POST /issues` with `labels: [REVIEW_LABEL]` (`:477,:482`) |
+| legal-audit | `0 11 1 1,4,7,10 *` (`:303`) | Quarterly | **YES** | Prompt creates issue labeled `scheduled-legal-audit` (`:143`) |
+| competitive-analysis | `0 9 1 * *` (`:292`) | Monthly (1st) | **YES** | Prompt `:126` create issue with label `scheduled-competitive-analysis` |
+| community-monitor | `0 8 * * *` (`:327`) | Daily | **YES** | Prompt `:177` create issue labeled `scheduled-community-monitor` |
+| roadmap-review | `0 9 * * 1` (`:316`) | Weekly (Mon) | **YES** | Prompt `:159` create issue labeled `scheduled-roadmap-review` |
+| ux-audit | `0 9 1 * *` (`:374`) | Monthly (1st) | **NO** | Dry-run, no issue (see above) |
+| bug-fixer | `0 6 * * *` (`:837`) | Daily | **NO** | Bot-fix PRs, no labeled issue (see above) |
+
+**Note — community-monitor was not classified in the task framing.** Source confirms it IS a producer (creates `scheduled-community-monitor` issues, daily cadence with a 24h dedup window). It STAYS in the inventory. Its alert (#4683-class, if any) is not in either the close-list or keep-open-list; no alert issue exists for it in the provided set, so no post-merge action is needed for it.
+
+## Threshold Derivation (remaining 6 producers)
+
+Rule of thumb: `maxGapDays = (max expected inter-issue gap) + slack for a single missed firing`. Cron cadence is the source of truth, not the current value.
+
+| Task | Cadence | Max inter-fire gap | Current | New `maxGapDays` | Rationale |
+| --- | --- | --- | --- | --- | --- |
+| content-generator | Tue + Thu | 5 days (Thu→Tue) | 4 | **9** | 4 is **too tight** — the Thu→Tue gap alone is 5d, so a single on-time week false-fires. 9 = ~one full cadence cycle (5d max gap) + one missed firing of slack. |
+| strategy-review | Weekly (Mon) | 7 days | 9 | **9** (unchanged) | 7d cadence + 2d slack. Correct. |
+| legal-audit | Quarterly (1st Jan/Apr/Jul/Oct) | 92 days (Jul→Oct) | 9 | **95** | **Headline defect.** Longest quarter gap is 92 days (92 between Jul 1 and Oct 1); 95 = 92 + 3d slack. |
+| competitive-analysis | Monthly (1st) | 31 days | 32 | **40** | 31d max month + slack for one missed firing. 32 is borderline (a single missed month false-fires at day 32); 40 gives one-missed-firing headroom. |
+| community-monitor | Daily (24h dedup) | 1 day | 9 | **3** | Daily cadence; 9 is far too loose (a 9-day true outage would go unnoticed for 9 days). 3 = 1d cadence + 2d slack (weekend/transient). Tightening is safe — community-monitor IS a daily producer. |
+| roadmap-review | Weekly (Mon) | 7 days | 9 | **9** (unchanged) | 7d cadence + 2d slack. Correct. |
+
+**Decision points for plan-review / deepen-plan:**
+- content-generator 4→9 and competitive-analysis 32→40 are *loosenings* that fix false-positives.
+- community-monitor 9→3 is a *tightening* that improves true-positive latency. It is in scope as part of "re-derive every producer's threshold against its real cadence" (task requirement #2: "Verify each other producer's threshold against its real cadence too and correct any mismatch"). If a reviewer prefers minimal scope, community-monitor MAY be left at 9 (it does not false-fire), but the plan's default is to correct it.
+
+## Corrected `TASK_INVENTORY` (target state — 6 producers)
+
+```ts
+export const TASK_INVENTORY: TaskEntry[] = [
+  { name: "content-generator", label: "scheduled-content-generator", maxGapDays: 9 },
+  { name: "strategy-review", label: "scheduled-strategy-review", maxGapDays: 9 },
+  { name: "legal-audit", label: "scheduled-legal-audit", maxGapDays: 95 },
+  { name: "competitive-analysis", label: "scheduled-competitive-analysis", maxGapDays: 40 },
+  { name: "community-monitor", label: "scheduled-community-monitor", maxGapDays: 3 },
+  { name: "roadmap-review", label: "scheduled-roadmap-review", maxGapDays: 9 },
+];
+```
+
+Removed (non-producers): `daily-triage`, `ux-audit`, `bug-fixer`.
+
+## User-Brand Impact
+
+- **If this lands broken, the user experiences:** a recurring stream of false `[cloud-task-silence]` issues cluttering the operator's GitHub issue list, training the (solo, non-technical) operator to ignore the watchdog entirely — so a *real* scheduled-task outage gets lost in the noise. This is an internal-ops watchdog; no end-user-facing surface.
+- **If this leaks, the user's data/workflow/money is exposed via:** N/A — the change touches no PII, no auth, no schema. The heartbeat reads issue metadata (`created_at`, labels) via an installation-scoped Octokit token and writes only `[cloud-task-silence]` ops issues.
+- **Brand-survival threshold:** `none` — internal ops watchdog tuning. **Reason (sensitive-path scope-out):** the diff touches only `apps/web-platform/server/inngest/functions/cron-cloud-task-heartbeat.ts` (a cron watchdog, not an auth/API/schema surface), its test, and a runbook; no regulated-data surface, no auth flow, no migration.
+
+## Files to Edit
+
+- `apps/web-platform/server/inngest/functions/cron-cloud-task-heartbeat.ts` — replace `TASK_INVENTORY` (lines 42-52) with the 6-producer corrected inventory + thresholds above. No other logic changes (detection mechanism, issue handling, Sentry heartbeat all unchanged).
+- `apps/web-platform/test/server/inngest/cron-cloud-task-heartbeat.test.ts` — update the `TASK_INVENTORY` assertions (lines 37-70) to expect **6** tasks with corrected thresholds; add a **non-producer-exclusion guard** test (assert removed names are absent) and a **cadence-vs-threshold consistency** test. (This file matches the vitest node glob `test/**/*.test.ts` per `apps/web-platform/vitest.config.ts:44`.)
+- `knowledge-base/engineering/ops/runbooks/cloud-scheduled-tasks.md` — document the monitors-only-producers scoping, the Sentry-liveness split (cite #4708), and the loopback-gated `/v1/*` non-use. Natural edit points: `## Task Inventory` (`:42`), `## Threshold Derivation` (`:425`), `## Updating the Watchdog` (`:450`). The loopback-gating is already documented at `:388-395`; add a heartbeat-specific cross-reference.
+
+## Files to Create
+
+None.
+
+## Open Code-Review Overlap
+
+None. (No open `code-review`-labeled issues reference these files. `gh issue list --label code-review --state open` returned no overlap with the three edited paths.)
+
+## Implementation Phases (TDD — failing tests first)
+
+### Phase 0 — Preconditions (verify, do not code)
+- Re-confirm the 9 cron schedules and producer status are unchanged on `origin/main` (the source reads above were against the worktree HEAD; cheap re-grep if main has diverged).
+- Confirm test runner: `apps/web-platform` uses **vitest** (`vitest.config.ts`), node project glob `test/**/*.test.ts`. Run command: `./node_modules/.bin/vitest run test/server/inngest/cron-cloud-task-heartbeat.test.ts` from `apps/web-platform/` (NOT `bun test` — `apps/web-platform/bunfig.toml` ignores all paths).
+
+### Phase 1 — RED (write failing tests against current code)
+Edit `cron-cloud-task-heartbeat.test.ts` to encode the *target* state. Against the current (9-task) inventory these MUST fail:
+1. `TASK_INVENTORY` has length **6** (currently 9 → fails).
+2. `it.each` table updated to the 6 producers with corrected thresholds (legal-audit 95, content-generator 9, competitive-analysis 40, community-monitor 3, strategy-review 9, roadmap-review 9) → fails on thresholds and on missing/extra rows.
+3. **Non-producer exclusion guard:** `for (const removed of ["daily-triage", "ux-audit", "bug-fixer"]) expect(TASK_INVENTORY.find(t => t.name === removed)).toBeUndefined();` → fails (all three present now).
+4. **Cadence consistency anchor:** assert `legal-audit` threshold `>= 92` (quarterly floor) to lock the headline defect → fails (currently 9).
+
+Run vitest; capture the failures (RED proof).
+
+### Phase 2 — GREEN (correct the inventory)
+Replace `TASK_INVENTORY` (lines 42-52) in `cron-cloud-task-heartbeat.ts` with the 6-producer corrected block. No other code changes. Re-run vitest → all green.
+
+Also run the full `apps/web-platform` vitest suite (or at least the inngest test dir) to confirm no cross-test breakage (e.g., a registry-count test that enumerates monitored tasks).
+
+### Phase 3 — Runbook
+Update `cloud-scheduled-tasks.md`:
+- (a) State that the heartbeat monitors **only output-producing scheduled tasks**, observed via their `scheduled-<task>` issue label; list the 6 producers and explicitly name the 3 excluded non-producers (daily-triage, ux-audit, bug-fixer) with one-line reasons.
+- (b) State that cron **liveness** for ALL tasks is covered separately by the per-function Sentry cron monitors (cite **#4708**); the heartbeat covers only the orthogonal "did it produce output" question.
+- (c) State that Inngest `/v1/*` run-history is **loopback-gated** and intentionally NOT used by the heartbeat (cross-reference the existing `:388-395` H9a note).
+- Update the `## Threshold Derivation` table to match the new thresholds and the cadence basis.
+
+### Phase 4 — Post-merge follow-up (documented, NOT a code change)
+See "Post-merge (operator/automation)" acceptance criteria below.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- [x] `TASK_INVENTORY` in `cron-cloud-task-heartbeat.ts` contains exactly 6 entries, all producers, with thresholds: content-generator 9, strategy-review 9, legal-audit 95, competitive-analysis 40, community-monitor 3, roadmap-review 9.
+- [x] `daily-triage`, `ux-audit`, `bug-fixer` are absent from `TASK_INVENTORY`.
+- [x] Heartbeat detection/issue-handling/Sentry logic is otherwise byte-unchanged (diff is limited to the inventory array + comments).
+- [x] Test file asserts 6 entries, the corrected thresholds, the non-producer exclusion guard, and the legal-audit `>= 92` cadence anchor; full inngest vitest dir is green (1154/1154) via `./node_modules/.bin/vitest run`; tsc clean.
+- [x] Runbook documents (a) producers-only scoping + the 3 excluded non-producers, (b) Sentry-liveness split citing #4708, (c) loopback-gated `/v1/*` non-use.
+- [ ] PR body uses `Ref #2714` (the heartbeat tracking issue), and references #4708 for the liveness/loopback rationale. *(ship phase)*
+
+### Post-merge (operator/automation — `gh` CLI, automatable)
+**Automation: feasible via `gh issue close` + `gh issue comment` (Bash). Bake into ship post-merge verification, not operator-manual.**
+- [ ] Close the false-positive alerts for removed/corrected tasks, each with a comment referencing this PR and the root cause:
+  - `#4691` (bug-fixer) — removed: non-producer (opens bot-fix PRs, never a `scheduled-bug-fixer` issue).
+  - `#4690` (ux-audit) — removed: non-producer (`UX_AUDIT_DRY_RUN=true`, writes Supabase/stdout, no issue).
+  - `#4685` (daily-triage) — removed: non-producer (labels existing issues only; prompt forbids `gh issue create`).
+  - `#4687` (legal-audit) — corrected: silence was solely the 9d-vs-quarterly threshold; now 95d.
+- [ ] **Leave OPEN** (genuine cadence drift, separate investigation): `#4689` (roadmap-review), `#4688` (competitive-analysis), `#4686` (strategy-review), `#4684` (content-generator). Do NOT close these.
+
+## Test Scenarios
+
+| # | Scenario | Input / Setup | Expected | Type |
+| --- | --- | --- | --- | --- |
+| TS1 | Inventory cardinality | Import `TASK_INVENTORY` | length === 6 | unit (RED-first) |
+| TS2 | Producer membership | Import `TASK_INVENTORY` | names === {content-generator, strategy-review, legal-audit, competitive-analysis, community-monitor, roadmap-review} | unit (RED-first) |
+| TS3 | Non-producer exclusion | Import `TASK_INVENTORY` | daily-triage, ux-audit, bug-fixer all `undefined` via `.find()` | unit (RED-first) |
+| TS4 | legal-audit quarterly threshold | Import entry `legal-audit` | `maxGapDays === 95` AND `>= 92` | unit (RED-first) |
+| TS5 | content-generator threshold ≥ Thu→Tue gap | Import entry `content-generator` | `maxGapDays === 9` (was 4; 4 < 5d cadence gap → false-fire) | unit (RED-first) |
+| TS6 | competitive-analysis monthly threshold | Import entry `competitive-analysis` | `maxGapDays === 40` (≥ 31d month + slack) | unit (RED-first) |
+| TS7 | community-monitor daily threshold | Import entry `community-monitor` | `maxGapDays === 3` | unit (RED-first) |
+| TS8 | each entry well-formed | Iterate `TASK_INVENTORY` | every entry has non-empty `name`, `label === "scheduled-"+name`, `maxGapDays > 0` | unit |
+| TS9 | label-name coupling | Iterate `TASK_INVENTORY` | `t.label === "scheduled-" + t.name` for all 6 (guards future typos) | unit (new) |
+| TS10 | registration smoke unchanged | Import `cronCloudTaskHeartbeat` | defined, object (existing test still green) | unit |
+| TS11 | source-shape anchors unchanged | Read SUT source | cron `30 9 * * *`, slug, `[cloud-task-silence]`, `#2714` still present | unit (existing) |
+| TS12 | full-suite regression | `vitest run` over `apps/web-platform/test/server/inngest/` | no other inngest test references the removed task names | integration |
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "Sentry cron check-in posted by step 'sentry-heartbeat' (postSentryHeartbeat, ok=silentCount===0)"
+  cadence: "daily at 09:30 UTC (cron '30 9 * * *', unchanged)"
+  alert_target: "Sentry cron monitor slug 'scheduled-cloud-task-heartbeat' (missed check-in → Sentry alert)"
+  configured_in: "apps/web-platform/server/inngest/functions/cron-cloud-task-heartbeat.ts:31,256-263"
+error_reporting:
+  destination: "Sentry via reportSilentFallback (per-task check failure + issue-handling failure)"
+  fail_loud: "yes — reportSilentFallback mirrors to Sentry per cq-silent-fallback-must-mirror-to-sentry"
+failure_modes:
+  - mode: "Octokit token mint fails"
+    detection: "step.run throws; Inngest run marked failed; Sentry heartbeat not posted → missed check-in alert"
+    alert_route: "Sentry cron monitor missed-check-in"
+  - mode: "per-task issues GET fails"
+    detection: "reportSilentFallback(err) at :135; task pushed as silent:true (conservative)"
+    alert_route: "Sentry message 'Failed to check task <name>'"
+  - mode: "false-positive silence (the bug being fixed)"
+    detection: "[cloud-task-silence] issue volume; post-fix, only genuine producer drift fires"
+    alert_route: "GitHub issue label 'cloud-task-silence'"
+logs:
+  where: "Inngest run logs + pino logger.info('Task is silent — issue filed/commented')"
+  retention: "Inngest dashboard run history (host-side); Sentry 90d"
+discoverability_test:
+  command: "cd apps/web-platform && ./node_modules/.bin/vitest run test/server/inngest/cron-cloud-task-heartbeat.test.ts"
+  expected: "TASK_INVENTORY length 6, thresholds match, non-producer guard passes — all green"
+```
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected — internal ops/tooling change (cron watchdog inventory tuning). No user-facing surface, no schema, no auth, no pricing/legal/marketing impact.
+
+## Infrastructure (IaC)
+
+Skipped — no new infrastructure. The change edits only `apps/web-platform/server/...` (already-provisioned runtime), its test, and a runbook. No server, service, cron resource, secret, vendor, or DNS record introduced. The Inngest cron itself is already registered (unchanged `30 9 * * *` trigger).
+
+## Risks & Sharp Edges
+
+- **Removing a task from inventory silences its watchdog entirely.** That is the intended behavior for the 3 non-producers (they have no observable output artifact). Liveness for those 3 crons is still covered by their per-function Sentry cron monitors (#4708) — the heartbeat was never the liveness signal. Document this explicitly so a future maintainer does not "restore" them.
+- **community-monitor 9→3 is a tightening, not a loosening.** It will surface a real outage faster but could fire on a transient 2-day gap. 3d (= 1d cadence + 2d slack) absorbs a weekend. If plan-review prefers strictly-minimal scope, leaving it at 9 is acceptable (it does not false-fire) — but the default corrects it per task requirement #2.
+- **`Ref #2714`, not `Closes #2714`.** #2714 is the umbrella heartbeat tracking issue; this PR does not resolve it. The post-merge alert closures (#4691/#4690/#4685/#4687) happen via `gh issue close` after merge, not via PR body keywords.
+- **Do NOT close #4689/#4688/#4686/#4684.** These are genuine cadence drift for separate investigation (real producers that have actually gone silent). Closing them would hide a real problem.
+- **A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder text, or omits the threshold will fail `deepen-plan` Phase 4.6.** This section is filled (threshold `none` with sensitive-path scope-out reason).
+- **Test path must satisfy the vitest glob.** `apps/web-platform/test/server/inngest/cron-cloud-task-heartbeat.test.ts` matches `test/**/*.test.ts` (node project). Do not co-locate the test next to the source — vitest would skip it. `bun test` will report "filter did not match" (bunfig ignores all) — use `vitest run`.
+- **Do NOT re-introduce a bash numeric guard.** The original GHA watchdog crashed under `set -euo pipefail` when `maxGapDays` was non-numeric (`[[ $n -gt $malformed ]]`; learning §T10, PR #2716 `dc57a601`). The current code is TypeScript — `maxGapDays` is a typed `number` literal in `TASK_INVENTORY` and the comparison at `:130` is JS `>`, which cannot crash a step. No regex guard is needed or wanted.
+- **Precedent-diff (deepen Phase 4.4):** No new scheduled-job pattern is introduced. `cron-cloud-task-heartbeat` is already an Inngest cron function (canonical per ADR-033); 32 sibling `cron-*.ts` functions exist. The trigger (`30 9 * * *`) is unchanged. This is an in-place data edit to an existing canonical-pattern file — no precedent decision required.
+- **Sensitive-path note (deepen Phase 4.6):** the diff path `apps/web-platform/server/inngest/...` matches the preflight sensitive-path regex prefix, but the threshold is `none` with an explicit one-sentence scope-out reason in `## User-Brand Impact` (a cron watchdog is not an auth/API/schema surface). This satisfies preflight Check 6 at ship time.
+
+## References
+- `apps/web-platform/server/inngest/functions/cron-cloud-task-heartbeat.ts` (SUT)
+- `apps/web-platform/test/server/inngest/cron-cloud-task-heartbeat.test.ts` (test)
+- `knowledge-base/engineering/ops/runbooks/cloud-scheduled-tasks.md` (runbook, esp. `:375` Sentry-liveness, `:388-395` loopback-gating)
+- #4708 / commit `8535bdf1` — sibling watchdog retired to liveness-only beacon; loopback-gating proof
+- #2714 — heartbeat umbrella tracking issue
+- Alert issues: close #4691/#4690/#4685/#4687; keep open #4689/#4688/#4686/#4684

--- a/knowledge-base/project/specs/feat-one-shot-heartbeat-inngest-run-history/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-heartbeat-inngest-run-history/session-state.md
@@ -1,0 +1,22 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-05-31-fix-cloud-task-heartbeat-inventory-false-positives-plan.md
+- Status: complete
+
+### Re-scope note
+Original task asked to switch heartbeat detection to Inngest run-history. Halted before planning: #4708 (HEAD) proved Inngest `/v1/*` is loopback-gated and unreachable from the app container. Operator chose "fix inventory only" — keep GitHub-issue-label detection, drop non-producers, fix thresholds.
+
+### Errors
+None. (One transient Edit path-typo during planning, immediately retried and succeeded.)
+
+### Decisions
+- 3 non-producers re-verified in source and removed: bug-fixer, ux-audit (UX_AUDIT_DRY_RUN=true), daily-triage (no `gh issue create`).
+- Thresholds re-derived from real cron cadences: legal-audit 9→95, content-generator 4→9, competitive-analysis 32→40, community-monitor 9→3; strategy-review & roadmap-review stay 9. Final inventory = 6 producers.
+- community-monitor confirmed a producer (stays); no alert issue exists for it.
+- Did NOT re-introduce the strict-mode bash numeric-comparison crash (TR9 replaced it with TS).
+- TDD-first; runbook documents producers-only scoping + Sentry-liveness split (#4708) + loopback-gated /v1/* non-use.
+- Post-merge: close #4691/#4690/#4685/#4687 (false positives); leave #4689/#4688/#4686/#4684 OPEN (genuine drift).
+
+### Components Invoked
+- Skill: soleur:plan, soleur:deepen-plan; Bash, Read, Write, Edit


### PR DESCRIPTION
## Summary

Corrects the `cron-cloud-task-heartbeat` watchdog's `TASK_INVENTORY` so it stops filing false-positive `[cloud-task-silence]` alerts.

The watchdog detects silence via the presence of a `scheduled-<task>`-labeled GitHub issue. Three tasks in the inventory **never create such an issue by design**, so they false-fired forever (via the `daysSince === null → silent: true` branch):

- **daily-triage** — labels existing issues only; its prompt forbids `gh issue create`.
- **ux-audit** — runs `UX_AUDIT_DRY_RUN=true`; writes findings to Supabase/stdout, no issue.
- **bug-fixer** — opens `bot-fix/*` PRs; never attaches a `scheduled-bug-fixer` label to an issue.

They are removed. Their cron **liveness** is already covered by per-function Sentry cron monitors (`failure_issue_threshold = 1`), not this heartbeat — see #4708, which retired the sibling `cron-inngest-cron-watchdog` because Inngest's `/v1/*` introspection (registry **and** run-history) is loopback-gated and unreachable from the app container. This PR deliberately does **not** switch detection to Inngest run-history for that same reason.

Every remaining producer's `maxGapDays` is re-derived from its real cron cadence:

| Task | Cadence | Old | New |
|------|---------|-----|-----|
| legal-audit | quarterly (`0 11 1 1,4,7,10 *`) | 9 | **95** (92-day Jul→Oct floor + 3) — headline defect |
| content-generator | Tue+Thu | 4 | **9** (Thu→Tue gap is 5d) |
| competitive-analysis | monthly | 32 | **40** |
| community-monitor | daily | 9 | **3** (tightened for true-positive latency) |
| strategy-review | weekly | 9 | 9 |
| roadmap-review | weekly | 9 | 9 |

Final inventory = 6 producers.

Ref #2714

## User-Brand Impact

- **If this lands broken, the user experiences:** a recurring stream of false `[cloud-task-silence]` issues cluttering the operator's GitHub issue list, training the (solo, non-technical) operator to ignore the watchdog entirely — so a *real* scheduled-task outage gets lost in the noise. Internal-ops watchdog; no end-user-facing surface.
- **If this leaks, the user's data/workflow/money is exposed via:** N/A — touches no PII, no auth, no schema. The heartbeat reads issue metadata via an installation-scoped Octokit token and writes only `[cloud-task-silence]` ops issues.
- **Brand-survival threshold:** none — internal ops watchdog tuning.
- Scope-out: threshold: none, reason: the diff touches only the cron-watchdog function, its test, and a runbook; no regulated-data surface, no auth flow, no migration.

## Changelog

- **Web Platform:** `cron-cloud-task-heartbeat` now monitors only the 6 output-producing scheduled tasks; thresholds re-derived from real cron cadences (legal-audit 9→95 fixes a guaranteed quarterly false-alarm).
- **Docs:** `cloud-scheduled-tasks.md` runbook documents the producers-only scoping, the 3 excluded non-producers, the Sentry-liveness split (#4708), and the loopback-gated `/v1/*` non-use.

## Test plan

- [x] `vitest run test/server/inngest/cron-cloud-task-heartbeat.test.ts` — 26/26 (RED→GREEN: 9 failing → all pass); asserts 6 producers, corrected thresholds, non-producer exclusion guard, legal-audit ≥92 quarterly anchor.
- [x] Full inngest test dir green (1154/1154); `tsc --noEmit` clean.
- [x] `scripts/test-all.sh` — 92/92 suites passed.
- [x] Review: security-sentinel verified all 3 removed tasks retain Sentry monitors in `cron-monitors.tf` (no blind spot); pattern-recognition verified three-way TS/test/runbook consistency.

## Post-merge

- Close the false-positive alerts (each with a comment naming the root cause): #4691 (bug-fixer), #4690 (ux-audit), #4685 (daily-triage), #4687 (legal-audit — silence was solely the 9d-vs-quarterly threshold, now 95d). Tracks #2714.
- Leave OPEN (genuine cadence drift, separate investigation): #4689, #4688, #4686, #4684.

Generated with [Claude Code](https://claude.com/claude-code)
