### PR TITLE
fix(sentry-infra): add 3 untargeted cron monitors to apply allowlist + parity guard

### DIFF
--- a/.github/workflows/apply-sentry-infra.yml
+++ b/.github/workflows/apply-sentry-infra.yml
@@ -202,6 +202,9 @@ jobs:
             -target=sentry_cron_monitor.scheduled_compound_promote \
             -target=sentry_cron_monitor.scheduled_stale_deferred_scope_outs \
             -target=sentry_cron_monitor.scheduled_inngest_cron_watchdog \
+            -target=sentry_cron_monitor.scheduled_bug_fixer \
+            -target=sentry_cron_monitor.scheduled_content_generator \
+            -target=sentry_cron_monitor.scheduled_ux_audit \
             -target=sentry_uptime_monitor.soleur_apex \
             -target=sentry_uptime_monitor.soleur_www \
             -target=sentry_uptime_monitor.soleur_changelog_deep \

--- a/apps/web-platform/test/server/inngest/function-registry-count.test.ts
+++ b/apps/web-platform/test/server/inngest/function-registry-count.test.ts
@@ -24,9 +24,39 @@ const CRON_MONITORS_TF = resolve(
   __dirname,
   "../../../infra/sentry/cron-monitors.tf",
 );
+// The apply-sentry-infra workflow applies a HARDCODED `-target=` allowlist, not
+// the whole module. A sentry_cron_monitor resource added to the .tf without a
+// matching -target line is silently never created in prod (the apply reports
+// success over a plan that doesn't include it) — the exact gap that left
+// scheduled-content-generator's monitor absent post-#4714. Guard (f) below
+// forces .tf resources and workflow targets into lockstep.
+const APPLY_SENTRY_WF = resolve(
+  __dirname,
+  "../../../../../.github/workflows/apply-sentry-infra.yml",
+);
 
 const routeSrc = readFileSync(ROUTE_PATH, "utf8");
 const tfSrc = readFileSync(CRON_MONITORS_TF, "utf8");
+const applyWfSrc = readFileSync(APPLY_SENTRY_WF, "utf8");
+
+// Terraform resource *names* (the `"<name>"` in `resource "sentry_cron_monitor"
+// "<name>"`) — distinct from the monitor *slug* (`name = "..."`) that
+// extractTfMonitorNames reads. The workflow targets by resource name.
+function extractTfCronResourceNames(): Set<string> {
+  return new Set(
+    [...tfSrc.matchAll(/resource\s+"sentry_cron_monitor"\s+"([^"]+)"/g)].map(
+      (m) => m[1],
+    ),
+  );
+}
+
+function extractWorkflowCronTargets(): Set<string> {
+  return new Set(
+    [...applyWfSrc.matchAll(/-target=sentry_cron_monitor\.([A-Za-z0-9_]+)/g)].map(
+      (m) => m[1],
+    ),
+  );
+}
 
 function extractRouteArrayEntries(): string[] {
   return [...routeSrc.matchAll(/^\s+(\w+),$/gm)].map((m) => m[1]);
@@ -148,5 +178,28 @@ describe("Inngest function registry — drift guards", () => {
   // silently stop monitoring it — this parity guard forces the two in lockstep.
   it("(e) watchdog EXPECTED_CRON_FUNCTIONS matches the cron-*.ts file set", () => {
     expect(new Set(EXPECTED_CRON_FUNCTIONS)).toEqual(new Set(cronFiles));
+  });
+
+  // apply-sentry-infra.yml applies a hardcoded `-target=` allowlist. A monitor
+  // resource in the .tf without a matching target is never created in prod and
+  // the apply still reports success — invisible until a postmerge Sentry probe
+  // notices the monitor is absent. This guard forces the two lists into lockstep.
+  it("(f) every sentry_cron_monitor resource has a -target line in apply-sentry-infra.yml", () => {
+    const tfResources = extractTfCronResourceNames();
+    const wfTargets = extractWorkflowCronTargets();
+    // Vacuous-pass guard: a regex that silently matches nothing would make the
+    // subset assertion pass trivially.
+    expect(tfResources.size).toBeGreaterThan(0);
+    expect(wfTargets.size).toBeGreaterThan(0);
+
+    const untargeted = [...tfResources].filter((r) => !wfTargets.has(r)).sort();
+    expect(untargeted).toEqual([]);
+  });
+
+  it("(f2) apply-sentry-infra.yml has no -target for a non-existent monitor resource", () => {
+    const tfResources = extractTfCronResourceNames();
+    const wfTargets = extractWorkflowCronTargets();
+    const phantomTargets = [...wfTargets].filter((t) => !tfResources.has(t)).sort();
+    expect(phantomTargets).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

`apply-sentry-infra.yml` applies a **hardcoded `-target=` allowlist**, not the whole Terraform module. Three `sentry_cron_monitor` resources existed in `cron-monitors.tf` without a matching `-target` line, so they were **never created in prod** — the apply reported success over a plan that excluded them.

Caught by `/soleur:postmerge` after PR #4714: a live Sentry probe showed `scheduled-content-generator` was still absent (20 monitors, not 21) despite "Apply sentry infra: success". The #4684 output-aware heartbeat is **inert without the monitor** — the producer POSTs `?status=error` to a slug Sentry never knew about, so no issue opens.

## Fix
- Added 3 missing monitors to the workflow `-target` set (now **21 targets = 21 tf resources**):
  - `scheduled_content_generator` (the #4714 regression)
  - `scheduled_bug_fixer` (pre-existing gap)
  - `scheduled_ux_audit` (pre-existing gap)
- Added parity guards **(f)/(f2)** to `function-registry-count.test.ts`:
  - (f) every `sentry_cron_monitor` resource has a `-target` line
  - (f2) no `-target` references a non-existent resource
  - Verified **non-vacuous**: (f) fails when a target is removed.

## Test plan
- [x] `function-registry-count.test.ts` 9/9 pass with fix; (f) fails on revert (anti-vacuous)
- [x] `tsc --noEmit` clean
- [ ] ⏳ Post-merge: `apply-sentry-infra.yml` creates the 3 monitors; verify via Sentry monitors API that `scheduled-content-generator` is present (closes the #4684 alerting gap for real)

Refs #4684

🤖 Generated with [Claude Code](https://claude.com/claude-code)