### PR TITLE
fix(inngest): follow-through-monitor & daily-triage crons mint GitHub App token instead of unauthenticated gh CLI

### DIFF
--- a/apps/web-platform/server/inngest/functions/cron-daily-triage.ts
+++ b/apps/web-platform/server/inngest/functions/cron-daily-triage.ts
@@ -38,6 +38,7 @@ import { spawn } from "node:child_process";
 import { inngest } from "@/server/inngest/client";
 import { reportSilentFallback } from "@/server/observability";
 import {
+  mintInstallationToken,
   postSentryHeartbeat,
   type HandlerArgs,
 } from "./_cron-shared";
@@ -147,6 +148,12 @@ const CLAUDE_CODE_FLAGS = [
 // (cron-daily-triage.test.ts imports to avoid hard-coded timing drift).
 export const MAX_TURN_DURATION_MS = 60 * 60 * 1000;
 
+// Token-lifetime floor passed to generateInstallationToken (via
+// mintInstallationToken). The agent runs ≤60 min (MAX_TURN_DURATION_MS); the
+// 60-min min-lifetime token re-mints if the cached one has <60 min left, so a
+// freshly minted token always covers the run. Same value as peer crons.
+const TOKEN_MIN_LIFETIME_MS = 50 * 60 * 1000 + 10 * 60 * 1000;
+
 // Sentry slug stays "scheduled-daily-triage" for continuity (NOT renamed
 // to cron-daily-triage). The function file name follows the cron-* TR9
 // convention; the Sentry monitor slug carries forward from PR-F.
@@ -157,15 +164,23 @@ const SENTRY_MONITOR_SLUG = "scheduled-daily-triage";
 // INNGEST_SIGNING_KEY, GH PAT, etc.) into a process whose Bash tool can
 // `env | curl`. The allowlist below caps the blast radius of a successful
 // prompt injection to "issue-label tampering" instead of "full-tenant
-// secret exfil". GH_TOKEN/GITHUB_TOKEN are the only credential the
-// prompt's gh-CLI verbs need.
-function buildSpawnEnv(): NodeJS.ProcessEnv {
+// secret exfil". GH_TOKEN is the only credential the prompt's gh-CLI verbs
+// need.
+//
+// GH_TOKEN is the freshly minted GitHub App installation token (deliberately
+// NOT process.env.GH_TOKEN/GITHUB_TOKEN — both empty inside the prod Next.js
+// container, so the agent's `gh` calls would fail unauthenticated, same root
+// cause as Sentry 512e253141294ac1a808b2ef03a21289 on cron-follow-through-monitor).
+// Per hr-github-app-auth-not-pat, production authenticates via the short-lived
+// installation token, never an ambient PAT / `gh auth login`. Mirrors
+// cron-bug-fixer.ts:187-195.
+function buildSpawnEnv(installationToken: string): NodeJS.ProcessEnv {
   return {
     PATH: process.env.PATH,
     HOME: process.env.HOME,
     NODE_ENV: process.env.NODE_ENV,
     ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
-    GH_TOKEN: process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN,
+    GH_TOKEN: installationToken,
   };
 }
 
@@ -177,6 +192,17 @@ export async function cronDailyTriageHandler({
   durationMs: number;
   abortedByTimeout: boolean;
 }> {
+  // Step 0: mint-installation-token — authenticate the agent's gh subprocess
+  // with a short-lived GitHub App installation token. Memoized across Inngest
+  // replay (its own step.run). Without this the agent's in-prompt `gh issue
+  // list/view/edit/comment` calls run unauthenticated inside the prod
+  // container and fail `gh auth login` (same root cause as Sentry
+  // 512e253141294ac1a808b2ef03a21289 on cron-follow-through-monitor). NEVER
+  // log this value.
+  const installationToken = await step.run("mint-installation-token", () =>
+    mintInstallationToken({ tokenMinLifetimeMs: TOKEN_MIN_LIFETIME_MS }),
+  );
+
   const result = await step.run("claude-eval", async (): Promise<SpawnResult> => {
     const claudeBin = resolveClaudeBin();
     const ac = new AbortController();
@@ -194,7 +220,7 @@ export async function cronDailyTriageHandler({
           {
             detached: true, // own process group so SIGTERM propagates to grandchildren
             stdio: ["ignore", "inherit", "inherit"],
-            env: buildSpawnEnv(),
+            env: buildSpawnEnv(installationToken),
           },
         );
 

--- a/apps/web-platform/server/inngest/functions/cron-follow-through-monitor.ts
+++ b/apps/web-platform/server/inngest/functions/cron-follow-through-monitor.ts
@@ -75,6 +75,7 @@ import { spawn, execFileSync } from "node:child_process";
 import { inngest } from "@/server/inngest/client";
 import { reportSilentFallback } from "@/server/observability";
 import {
+  mintInstallationToken,
   postSentryHeartbeat,
   type HandlerArgs,
 } from "./_cron-shared";
@@ -243,6 +244,12 @@ const CLAUDE_CODE_FLAGS = [
 // hard-coded timing drift).
 export const MAX_TURN_DURATION_MS = 15 * 60 * 1000;
 
+// Token-lifetime floor passed to generateInstallationToken (via
+// mintInstallationToken). The cron agent runs ≤15 min (MAX_TURN_DURATION_MS),
+// so a 60-min min-lifetime token leaves ≥45 min headroom. Same value as the
+// peer crons (cron-bug-fixer/community-monitor/roadmap-review).
+const TOKEN_MIN_LIFETIME_MS = 50 * 60 * 1000 + 10 * 60 * 1000;
+
 // Sentry slug — NEW resource added in apps/web-platform/infra/sentry/cron-monitors.tf
 // at this PR. Function id and slug naming match (no continuity rename hazard).
 const SENTRY_MONITOR_SLUG = "scheduled-follow-through";
@@ -251,13 +258,20 @@ const SENTRY_MONITOR_SLUG = "scheduled-follow-through";
 // ANTHROPIC_API_KEY, GH_TOKEN reach the subprocess. Caps SSRF + secret-
 // exfil blast radius (Layer 2 of dual defense; Layer 1 is the in-prompt
 // HTTPS-and-non-RFC1918 guard).
-function buildSpawnEnv(): NodeJS.ProcessEnv {
+//
+// GH_TOKEN is the freshly minted GitHub App installation token (deliberately
+// NOT process.env.GH_TOKEN/GITHUB_TOKEN — those are empty inside the prod
+// Next.js container, which is why this cron threw `gh auth login` on every
+// run; Sentry 512e253141294ac1a808b2ef03a21289). Per hr-github-app-auth-not-pat,
+// production code authenticates via the short-lived installation token, never
+// an ambient PAT / `gh auth login`. Mirrors cron-bug-fixer.ts:187-195.
+function buildSpawnEnv(installationToken: string): NodeJS.ProcessEnv {
   return {
     PATH: process.env.PATH,
     HOME: process.env.HOME,
     NODE_ENV: process.env.NODE_ENV,
     ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
-    GH_TOKEN: process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN,
+    GH_TOKEN: installationToken,
   };
 }
 
@@ -269,6 +283,16 @@ export async function cronFollowThroughMonitorHandler({
   durationMs: number;
   abortedByTimeout: boolean;
 }> {
+  // Step 0: mint-installation-token — authenticate every gh subprocess with a
+  // short-lived GitHub App installation token. Memoized across Inngest replay
+  // (its own step.run), so it is minted once per invocation, not per gh call.
+  // Without this the `gh issue list`/`gh label create`/agent gh calls run
+  // unauthenticated inside the prod container and throw `gh auth login`
+  // (Sentry 512e253141294ac1a808b2ef03a21289). NEVER log this value.
+  const installationToken = await step.run("mint-installation-token", () =>
+    mintInstallationToken({ tokenMinLifetimeMs: TOKEN_MIN_LIFETIME_MS }),
+  );
+
   // Step 1: ensure-labels — carries the GHA `Ensure labels exist` step's
   // intent into the Inngest function so the labels exist before the agent
   // touches them. Three labels: `follow-through` (the corpus filter),
@@ -302,7 +326,7 @@ export async function cronFollowThroughMonitorHandler({
         description: "Opt out of @-mention notifications from cron-follow-through-monitor",
       },
     ];
-    const ghEnv = buildSpawnEnv();
+    const ghEnv = buildSpawnEnv(installationToken);
     interface LabelOutcome {
       name: string;
       ok: boolean;
@@ -410,7 +434,7 @@ export async function cronFollowThroughMonitorHandler({
           "gh",
           ["issue", "list", "--label", "follow-through", "--state", "open",
            "--json", "number,title,body", "--limit", "100"],
-          { env: buildSpawnEnv(), timeout: 30_000 },
+          { env: buildSpawnEnv(installationToken), timeout: 30_000 },
         ).toString("utf-8");
         const issues: IssueData[] = JSON.parse(stdout || "[]");
 
@@ -453,7 +477,7 @@ export async function cronFollowThroughMonitorHandler({
           {
             detached: true, // own process group so SIGTERM propagates to grandchildren
             stdio: ["ignore", "inherit", "inherit"],
-            env: buildSpawnEnv(),
+            env: buildSpawnEnv(installationToken),
           },
         );
 

--- a/apps/web-platform/test/server/inngest/cron-daily-triage.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-daily-triage.test.ts
@@ -26,6 +26,22 @@ vi.mock("@/server/observability", () => ({
   reportSilentFallback: reportSilentFallbackSpy,
 }));
 
+// Mint-token deps (#512e25 fix): the handler now mints a GitHub App
+// installation token (mintInstallationToken → createProbeOctokit +
+// generateInstallationToken) and injects it as GH_TOKEN so `gh` is
+// authenticated inside the prod container (hr-github-app-auth-not-pat).
+// Same root cause + fix as cron-follow-through-monitor; mocks mirror
+// cron-bug-fixer.test.ts:60-70.
+const createProbeOctokitSpy = vi.fn();
+vi.mock("@/server/github/probe-octokit", () => ({
+  createProbeOctokit: createProbeOctokitSpy,
+}));
+
+const generateInstallationTokenSpy = vi.fn();
+vi.mock("@/server/github-app", () => ({
+  generateInstallationToken: generateInstallationTokenSpy,
+}));
+
 // --- Helpers ----------------------------------------------------------------
 
 interface MockStep {
@@ -72,6 +88,17 @@ beforeEach(() => {
   vi.resetModules();
   spawnSpy.mockReset();
   reportSilentFallbackSpy.mockReset();
+  createProbeOctokitSpy.mockReset();
+  generateInstallationTokenSpy.mockReset();
+  createProbeOctokitSpy.mockImplementation(async () => ({
+    request: vi.fn(async (route: string) => {
+      if (route === "GET /repos/{owner}/{repo}/installation") {
+        return { data: { id: 12345 } };
+      }
+      return { data: {} };
+    }),
+  }));
+  generateInstallationTokenSpy.mockResolvedValue("ghs_TESTTOKEN_REDACT_ME");
   logger.info.mockReset();
   logger.warn.mockReset();
   logger.error.mockReset();
@@ -134,11 +161,38 @@ describe("cron-daily-triage — T1 happy path", () => {
     expect(url).toContain("status=ok");
     expect(reportSilentFallbackSpy).not.toHaveBeenCalled();
 
-    // step.run called for claude-eval AND sentry-heartbeat.
+    // #512e25: step.run order is mint-installation-token → claude-eval →
+    // sentry-heartbeat. The token mint runs first so GH_TOKEN is authenticated.
     expect(step.calls.map((c) => c.name)).toEqual([
+      "mint-installation-token",
       "claude-eval",
       "sentry-heartbeat",
     ]);
+  });
+});
+
+describe("cron-daily-triage — T6 GitHub App token injection (#512e25)", () => {
+  it("mints an installation token first and injects it as GH_TOKEN into the claude spawn", async () => {
+    const child = makeChild();
+    spawnSpy.mockImplementation(() => {
+      queueMicrotask(() => child.emit("exit", 0, null));
+      return child;
+    });
+
+    const handler = await importHandler();
+    const step = makeStep();
+    await handler({ step, logger });
+
+    // mint ran, and ran first.
+    expect(generateInstallationTokenSpy).toHaveBeenCalledTimes(1);
+    expect(step.calls[0].name).toBe("mint-installation-token");
+    expect(step.calls[0].result).toBe("ghs_TESTTOKEN_REDACT_ME");
+
+    // the claude spawn env carries the minted token (not process.env.GH_TOKEN).
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const spawnEnv = (spawnSpy.mock.calls[0][2] as { env: NodeJS.ProcessEnv })
+      .env;
+    expect(spawnEnv.GH_TOKEN).toBe("ghs_TESTTOKEN_REDACT_ME");
   });
 });
 

--- a/apps/web-platform/test/server/inngest/cron-daily-triage.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-daily-triage.test.ts
@@ -194,6 +194,39 @@ describe("cron-daily-triage — T6 GitHub App token injection (#512e25)", () => 
       .env;
     expect(spawnEnv.GH_TOKEN).toBe("ghs_TESTTOKEN_REDACT_ME");
   });
+
+  it("the minted token OVERRIDES any ambient process.env.GH_TOKEN (the incident vector)", async () => {
+    // Positive control (test-design review MEDIUM): seed a bogus ambient PAT
+    // (the pre-fix env the bug fell back to) and assert the SUBPROCESS sees the
+    // minted token, NOT the ambient one — the hr-github-app-auth-not-pat contract.
+    const prior = process.env.GH_TOKEN;
+    process.env.GH_TOKEN = "ghp_AMBIENT_PAT_SHOULD_NOT_LEAK";
+    try {
+      const child = makeChild();
+      spawnSpy.mockImplementation(() => {
+        queueMicrotask(() => child.emit("exit", 0, null));
+        return child;
+      });
+
+      const handler = await importHandler();
+      const step = makeStep();
+      await handler({ step, logger });
+
+      // the 60-min lifetime floor propagates to generateInstallationToken
+      // (installation id 12345 from the createProbeOctokit mock).
+      expect(generateInstallationTokenSpy).toHaveBeenCalledWith(12345, {
+        minRemainingMs: 50 * 60 * 1000 + 10 * 60 * 1000,
+      });
+
+      const spawnEnv2 = (spawnSpy.mock.calls[0][2] as { env: NodeJS.ProcessEnv })
+        .env;
+      expect(spawnEnv2.GH_TOKEN).toBe("ghs_TESTTOKEN_REDACT_ME");
+      expect(spawnEnv2.GH_TOKEN).not.toBe("ghp_AMBIENT_PAT_SHOULD_NOT_LEAK");
+    } finally {
+      if (prior === undefined) delete process.env.GH_TOKEN;
+      else process.env.GH_TOKEN = prior;
+    }
+  });
 });
 
 describe("cron-daily-triage — T2 spawn error (ENOENT)", () => {

--- a/apps/web-platform/test/server/inngest/cron-follow-through-monitor.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-follow-through-monitor.test.ts
@@ -288,6 +288,44 @@ describe("cron-follow-through-monitor — T7 GitHub App token injection (#512e25
       expect(ghEnv.GH_TOKEN).toBe("ghs_TESTTOKEN_REDACT_ME");
     }
   });
+
+  it("the minted token OVERRIDES any ambient process.env.GH_TOKEN (the incident vector)", async () => {
+    // Positive control (test-design review MEDIUM): the GH_TOKEN value-equality
+    // assertion in the prior test rides behind the mint-step-existence gate, so
+    // it is never independently observed as RED. Seed a bogus ambient PAT (the
+    // exact pre-fix env the bug fell back to) and assert the SUBPROCESS sees the
+    // minted token, NOT the ambient one — this is the hr-github-app-auth-not-pat
+    // contract and would fail if buildSpawnEnv ever reverted to reading env.
+    const prior = process.env.GH_TOKEN;
+    process.env.GH_TOKEN = "ghp_AMBIENT_PAT_SHOULD_NOT_LEAK";
+    try {
+      const child = makeChild();
+      spawnSpy.mockImplementation(
+        withEnsureLabelsAutoExit(() => {
+          queueMicrotask(() => child.emit("exit", 0, null));
+          return child;
+        }),
+      );
+
+      const handler = await importHandler();
+      const step = makeStep();
+      await handler({ step, logger });
+
+      // the 60-min lifetime floor propagates to generateInstallationToken
+      // (installation id 12345 from the createProbeOctokit mock).
+      expect(generateInstallationTokenSpy).toHaveBeenCalledWith(12345, {
+        minRemainingMs: 50 * 60 * 1000 + 10 * 60 * 1000,
+      });
+
+      const claudeCalls = spawnSpy.mock.calls.filter((c) => c[0] !== "gh");
+      const claudeEnv = (claudeCalls[0][2] as { env: NodeJS.ProcessEnv }).env;
+      expect(claudeEnv.GH_TOKEN).toBe("ghs_TESTTOKEN_REDACT_ME");
+      expect(claudeEnv.GH_TOKEN).not.toBe("ghp_AMBIENT_PAT_SHOULD_NOT_LEAK");
+    } finally {
+      if (prior === undefined) delete process.env.GH_TOKEN;
+      else process.env.GH_TOKEN = prior;
+    }
+  });
 });
 
 describe("cron-follow-through-monitor — T2 spawn error (ENOENT)", () => {

--- a/apps/web-platform/test/server/inngest/cron-follow-through-monitor.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-follow-through-monitor.test.ts
@@ -51,6 +51,21 @@ vi.mock("@/server/observability", () => ({
   reportSilentFallback: reportSilentFallbackSpy,
 }));
 
+// Mint-token deps (#512e25 fix): the handler now mints a GitHub App
+// installation token via mintInstallationToken() → createProbeOctokit() +
+// generateInstallationToken(), injected as GH_TOKEN so `gh` is authenticated
+// inside the prod container (hr-github-app-auth-not-pat). Mock the underlying
+// deps, matching cron-bug-fixer.test.ts:60-70.
+const createProbeOctokitSpy = vi.fn();
+vi.mock("@/server/github/probe-octokit", () => ({
+  createProbeOctokit: createProbeOctokitSpy,
+}));
+
+const generateInstallationTokenSpy = vi.fn();
+vi.mock("@/server/github-app", () => ({
+  generateInstallationToken: generateInstallationTokenSpy,
+}));
+
 // --- Helpers ----------------------------------------------------------------
 
 interface MockStep {
@@ -122,6 +137,18 @@ beforeEach(() => {
   formatPredicateResultsSpy.mockReset();
   formatPredicateResultsSpy.mockReturnValue("## Pre-Validated Predicate Results\n\nNo predicates.");
   reportSilentFallbackSpy.mockReset();
+  createProbeOctokitSpy.mockReset();
+  generateInstallationTokenSpy.mockReset();
+  // Default mint path: installation lookup → 60-min token.
+  createProbeOctokitSpy.mockImplementation(async () => ({
+    request: vi.fn(async (route: string) => {
+      if (route === "GET /repos/{owner}/{repo}/installation") {
+        return { data: { id: 12345 } };
+      }
+      return { data: {} };
+    }),
+  }));
+  generateInstallationTokenSpy.mockResolvedValue("ghs_TESTTOKEN_REDACT_ME");
   logger.info.mockReset();
   logger.warn.mockReset();
   logger.error.mockReset();
@@ -206,16 +233,58 @@ describe("cron-follow-through-monitor — T1 happy path", () => {
     expect(url).toContain("status=ok");
     expect(reportSilentFallbackSpy).not.toHaveBeenCalled();
 
-    // #4068: FOUR step.run steps: ensure-labels → validate-predicates →
-    // claude-eval → sentry-heartbeat. validate-predicates is the Layer 3
-    // SSRF hardening step that executes predicates server-side before the
-    // agent runs.
+    // #512e25 + #4068: FIVE step.run steps: mint-installation-token →
+    // ensure-labels → validate-predicates → claude-eval → sentry-heartbeat.
+    // mint-installation-token is the first step (memoized across Inngest
+    // replay) so a valid GH_TOKEN is available to every gh subprocess.
     expect(step.calls.map((c) => c.name)).toEqual([
+      "mint-installation-token",
       "ensure-labels",
       "validate-predicates",
       "claude-eval",
       "sentry-heartbeat",
     ]);
+  });
+});
+
+describe("cron-follow-through-monitor — T7 GitHub App token injection (#512e25)", () => {
+  it("mints an installation token first and injects it as GH_TOKEN into every gh subprocess", async () => {
+    const child = makeChild();
+    spawnSpy.mockImplementation(
+      withEnsureLabelsAutoExit(() => {
+        queueMicrotask(() => child.emit("exit", 0, null));
+        return child;
+      }),
+    );
+
+    const handler = await importHandler();
+    const step = makeStep();
+    await handler({ step, logger });
+
+    // (a) the mint step ran, and ran FIRST.
+    expect(generateInstallationTokenSpy).toHaveBeenCalledTimes(1);
+    expect(step.calls[0].name).toBe("mint-installation-token");
+    expect(step.calls[0].result).toBe("ghs_TESTTOKEN_REDACT_ME");
+
+    // (b) the server-side `gh issue list` (execFileSync) env carries the token.
+    expect(execFileSyncSpy).toHaveBeenCalledTimes(1);
+    const execEnv = (execFileSyncSpy.mock.calls[0][2] as { env: NodeJS.ProcessEnv })
+      .env;
+    expect(execEnv.GH_TOKEN).toBe("ghs_TESTTOKEN_REDACT_ME");
+
+    // (c) the claude-eval spawn env carries the token.
+    const claudeCalls = spawnSpy.mock.calls.filter((c) => c[0] !== "gh");
+    expect(claudeCalls).toHaveLength(1);
+    const claudeEnv = (claudeCalls[0][2] as { env: NodeJS.ProcessEnv }).env;
+    expect(claudeEnv.GH_TOKEN).toBe("ghs_TESTTOKEN_REDACT_ME");
+
+    // (d) the ensure-labels `gh label create` spawn envs carry the token.
+    const ghCalls = spawnSpy.mock.calls.filter((c) => c[0] === "gh");
+    expect(ghCalls.length).toBeGreaterThan(0);
+    for (const call of ghCalls) {
+      const ghEnv = (call[2] as { env: NodeJS.ProcessEnv }).env;
+      expect(ghEnv.GH_TOKEN).toBe("ghs_TESTTOKEN_REDACT_ME");
+    }
   });
 });
 

--- a/apps/web-platform/test/server/inngest/cron-follow-through-monitor.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-follow-through-monitor.test.ts
@@ -268,8 +268,10 @@ describe("cron-follow-through-monitor — T7 GitHub App token injection (#512e25
 
     // (b) the server-side `gh issue list` (execFileSync) env carries the token.
     expect(execFileSyncSpy).toHaveBeenCalledTimes(1);
-    const execEnv = (execFileSyncSpy.mock.calls[0][2] as { env: NodeJS.ProcessEnv })
-      .env;
+    // execFileSyncSpy is typed with no params, so widen the call tuple before
+    // indexing the options (3rd) arg.
+    const execCall = execFileSyncSpy.mock.calls[0] as unknown as unknown[];
+    const execEnv = (execCall[2] as { env: NodeJS.ProcessEnv }).env;
     expect(execEnv.GH_TOKEN).toBe("ghs_TESTTOKEN_REDACT_ME");
 
     // (c) the claude-eval spawn env carries the token.

--- a/knowledge-base/project/learnings/2026-06-01-inngest-cron-gh-cli-needs-minted-app-token-not-ambient-env.md
+++ b/knowledge-base/project/learnings/2026-06-01-inngest-cron-gh-cli-needs-minted-app-token-not-ambient-env.md
@@ -1,0 +1,39 @@
+# Learning: Inngest crons that shell out to `gh` need a minted GitHub App token, not ambient `process.env.GH_TOKEN`
+
+## Problem
+
+`cron-follow-through-monitor` (fnId `soleur-runtime-cron-follow-through-monitor`) threw on **every** `0 9 * * 1-5` run (Sentry `512e253141294ac1a808b2ef03a21289`, release `web-platform@0.102.0+14c06d9f`):
+
+```
+Error: Command failed: gh issue list --label follow-through --state open --json number,title,body --limit 100
+To get started with GitHub CLI, please run:  gh auth login
+Alternatively, populate the GH_TOKEN environment variable with a GitHub API authentication token.
+```
+
+The `validate-predicates` step ran `execFileSync("gh", [...], { env: buildSpawnEnv() })`, and `buildSpawnEnv()` populated `GH_TOKEN` from `process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN`. **Both are empty inside the production Next.js container** (there is no `gh auth login`, no PAT injected), so the fallback resolved to `undefined` and `gh` ran unauthenticated.
+
+## Solution
+
+Mint a short-lived GitHub App installation token in a dedicated first `step.run("mint-installation-token", …)` (memoized across Inngest replay), and inject it as `GH_TOKEN` into every `gh` subprocess env. `buildSpawnEnv()` becomes `buildSpawnEnv(installationToken: string)` returning `GH_TOKEN: installationToken`. This is the **exact established precedent** in `cron-bug-fixer.ts` (and ~22 peer crons), using the shared `mintInstallationToken({ tokenMinLifetimeMs })` helper in `_cron-shared.ts`. Satisfies hard rule `hr-github-app-auth-not-pat` (production authenticates via short-lived App token, never an ambient PAT / `gh auth login`).
+
+## Key Insight
+
+The bug is a **class**, not an instance. The canonical grep to find every cron with it:
+
+```
+grep -rn "GH_TOKEN: process.env.GH_TOKEN" apps/web-platform/server/inngest/functions/
+```
+
+At fix time this returned 2 hits — `cron-follow-through-monitor.ts` (the Sentry-cited one) and `cron-daily-triage.ts` (same root cause, but no server-side `execFileSync`, so its `gh` calls failed *inside* the spawned agent and never produced the exact server-side Sentry signature). **A function being silent in Sentry does NOT mean it is healthy** — daily-triage was equally broken. Both were folded into one PR (`wg-defer-only-after-inline-triage`). Changing `buildSpawnEnv` to *require* the token argument makes `tsc` flag every un-migrated call site, so the signature change is the cheapest way to guarantee the whole file is covered.
+
+Test the *override*, not just the presence: a value-equality assertion (`GH_TOKEN === minted`) rides behind the mint-step-existence gate and is never independently RED. Seed a bogus ambient `process.env.GH_TOKEN` and assert the subprocess sees the **minted** token, not the ambient one — that is the actual incident vector and makes the assertion load-bearing.
+
+## Session Errors
+
+1. **Bash CWD non-persistence** — after `cd <worktree-root> && git commit`, the next `./node_modules/.bin/vitest run …` executed from the bare-repo root (`EXIT=127, No such file or directory`). **Recovery:** re-ran with explicit `cd apps/web-platform && …`. **Prevention:** chain `cd <abs-path> && <cmd>` in a single Bash call for every test/typecheck invocation in a worktree pipeline (already documented in work/SKILL.md and `2026-04-19-admin-ip-drift-misdiagnosed-as-fail2ban.md`).
+2. **TS tuple-index errors (TS2352 + TS2493)** — indexing `execFileSyncSpy.mock.calls[0][2]` on a `vi.fn(() => Buffer.from("[]"))` spy whose inferred call tuple has arity 0. **Recovery:** widen via `const execCall = spy.mock.calls[0] as unknown as unknown[];` before indexing the options arg. **Prevention:** when a typed `vi.fn()` spy's call tuple is indexed beyond its declared arity, widen with `as unknown as unknown[]` first (untyped `vi.fn()` spies like `spawnSpy` don't need this).
+3. **Single Edit anchor miss** — a multiline handler-signature `old_string` failed to match. **Recovery:** used a shorter unique anchor (`}> {` + the following comment line). One-off; no rule warranted.
+
+## Tags
+category: integration-issues
+module: apps/web-platform/server/inngest/functions

--- a/knowledge-base/project/plans/2026-06-01-fix-follow-through-monitor-gh-app-auth-plan.md
+++ b/knowledge-base/project/plans/2026-06-01-fix-follow-through-monitor-gh-app-auth-plan.md
@@ -11,6 +11,26 @@ fn_id: soleur-runtime-cron-follow-through-monitor
 
 # fix: cron-follow-through-monitor — replace unauthenticated `gh` CLI shell-out with GitHub App installation token 🐛
 
+## Enhancement Summary
+
+**Deepened on:** 2026-06-01
+
+**Deepen-plan gates run:**
+- Phase 4.4 Precedent-Diff Gate — PASS. Pattern (GitHub App installation-token mint + inject as `GH_TOKEN`) has a canonical in-repo precedent: `cron-bug-fixer.ts`. Side-by-side diff added to Risks & Mitigations (R6). Scheduled-work check: the plan modifies an EXISTING Inngest cron (canonical per ADR-033) — no new scheduled job, no GH-Actions-cron migration concern.
+- Phase 4.45 Verify-the-Negative Pass — PASS. All negative claims grep-verified: (a) "`buildSpawnEnv` no longer reads `process.env.GH_TOKEN`" confirmed as a fix target (current code reads it at `cron-follow-through-monitor.ts:260` — the bug); (b) "token is never logged" confirmed — zero token-logging sites in the file.
+- Phase 4.6 User-Brand Impact Halt — PASS. Section present, threshold `none` with a non-empty scope-out reason (sensitive-path `apps/web-platform/server/` matched → scope-out bullet required and present).
+- Phase 4.7 Observability Gate — PASS. All 5 fields present, non-placeholder; `discoverability_test.command` is SSH-free.
+- Phase 4.8 PAT-Shaped Variable Halt — PASS. Zero PAT-shaped vars/literals; the fix uses a minted GitHub App installation token (the rule's prescribed alternative).
+
+### Key Improvements
+1. Confirmed the exact peer precedent (`cron-bug-fixer.ts`) and pinned the line-level diff so /work copies the proven shape rather than re-deriving.
+2. Confirmed blast-radius: `cron-daily-triage.ts` is the ONLY other function with the identical bug (`grep` = 2 hits repo-wide) — folding it in is net-positive.
+3. Confirmed the no-BYOK build-time gate forbids only `runWithByokLease` imports — the installation-token fix is orthogonal and passes (bug-fixer proves it).
+
+### New Considerations Discovered
+- The server-side `execFileSync` is the surface that throws the cited Sentry error FIRST; the in-prompt agent `gh` calls would also fail but are secondary. Both are fixed by the single token-mint change.
+- `_predicate-validator.ts` has NO server-side `gh` shell-out (parses HTML-comment YAML), so it needs no change — the only server-side `gh` is the handler's `execFileSync`.
+
 ## Overview
 
 The Inngest cron `cron-follow-through-monitor` (fnId `soleur-runtime-cron-follow-through-monitor`) throws on **every** scheduled run (`0 9 * * 1-5`, i.e. 09:00 UTC weekdays). The `validate-predicates` `step.run` shells out to the `gh` CLI via `execFileSync` to list open `follow-through` issues:
@@ -141,6 +161,20 @@ Run AC7-AC9 (and AC10 if folded). Confirm `grep -n "GH_TOKEN: process.env.GH_TOK
 - **R3 — Installation token scope.** The App installation token already grants `issues:write` + `pull_requests:write` (proven by `cron-bug-fixer.ts` running `gh issue view/edit/comment/close` and `gh pr create` against the same token). No new permission needed; this is the identical credential.
 - **R4 — `mintInstallationToken` throws (App private key missing/invalid in prod).** Then the new mint step throws and Inngest's `retries: 1` retries; on persistent failure the step error surfaces (Inngest run marked failed + the function's existing Sentry instrumentation). This is the correct loud-failure behavior — a missing App key is a real prod misconfiguration, not something to swallow. Precedent: bug-fixer's mint step has the same failure semantics.
 - **R5 — `buildSpawnEnv` signature change is a breaking contract within the file.** Mitigated by phase ordering: the signature change + all three call-site updates land in the same edit (Phase 2). `tsc --noEmit` (AC9) catches any missed call site.
+
+### R6 — Precedent-Diff (Phase 4.4): mirror `cron-bug-fixer.ts` exactly
+
+This is a pattern-bound behavior (GitHub App installation-token mint + inject as `GH_TOKEN`). Canonical precedent in the same directory, verified line-level on 2026-06-01:
+
+| Concern | Precedent — `cron-bug-fixer.ts` | This fix — `cron-follow-through-monitor.ts` |
+| --- | --- | --- |
+| Import | `mintInstallationToken` from `./_cron-shared` (line 54) | Extend existing `./_cron-shared` import (adds `mintInstallationToken`) |
+| Min-lifetime const | `TOKEN_MIN_LIFETIME_MS = 50*60*1000 + 10*60*1000` (line 79) | Same value (60 min); agent runs ≤15 min → ≥45 min headroom |
+| Mint step | `step.run(...)` → `mintInstallationToken({ tokenMinLifetimeMs })` (line 628-631) | New first `step.run("mint-installation-token", …)` before `ensure-labels` |
+| Env builder | `buildSpawnEnv(installationToken)` → `GH_TOKEN: installationToken` (line 187-194); drops ambient PAT per `hr-github-app-auth-not-pat` | Identical: `buildSpawnEnv(installationToken: string)` returning `GH_TOKEN: installationToken` |
+| Allowlisted env keys | PATH, HOME, NODE_ENV, ANTHROPIC_API_KEY, GH_TOKEN | Same set (already matches; only the GH_TOKEN source changes) |
+
+**Divergence (intentional):** bug-fixer ALSO builds an authenticated clone URL from the token and uses `redactToken` to keep it out of logs. follow-through builds NO clone URL — so `redactToken`/`buildAuthenticatedCloneUrl` are NOT needed here. The token only ever appears as a subprocess env var. This is the only divergence; everything else is a 1:1 copy.
 
 ## Observability
 

--- a/knowledge-base/project/plans/2026-06-01-fix-follow-through-monitor-gh-app-auth-plan.md
+++ b/knowledge-base/project/plans/2026-06-01-fix-follow-through-monitor-gh-app-auth-plan.md
@@ -1,0 +1,193 @@
+---
+type: fix
+classification: production-bug
+brand_survival_threshold: none
+lane: single-domain
+status: draft
+created: 2026-06-01
+sentry_id: 512e253141294ac1a808b2ef03a21289
+fn_id: soleur-runtime-cron-follow-through-monitor
+---
+
+# fix: cron-follow-through-monitor — replace unauthenticated `gh` CLI shell-out with GitHub App installation token 🐛
+
+## Overview
+
+The Inngest cron `cron-follow-through-monitor` (fnId `soleur-runtime-cron-follow-through-monitor`) throws on **every** scheduled run (`0 9 * * 1-5`, i.e. 09:00 UTC weekdays). The `validate-predicates` `step.run` shells out to the `gh` CLI via `execFileSync` to list open `follow-through` issues:
+
+```ts
+// apps/web-platform/server/inngest/functions/cron-follow-through-monitor.ts:409-414
+const stdout = execFileSync(
+  "gh",
+  ["issue", "list", "--label", "follow-through", "--state", "open",
+   "--json", "number,title,body", "--limit", "100"],
+  { env: buildSpawnEnv(), timeout: 30_000 },
+).toString("utf-8");
+```
+
+Inside the production Next.js container `gh` is **unauthenticated** — there is no `gh auth login`, and `buildSpawnEnv()` populates `GH_TOKEN` from `process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN`, both of which are empty in prod. `gh` exits non-zero with:
+
+```
+Error: Command failed: gh issue list --label follow-through --state open --json number,title,body --limit 100
+To get started with GitHub CLI, please run:  gh auth login
+Alternatively, populate the GH_TOKEN environment variable with a GitHub API authentication token.
+```
+
+This is wrapped by `reportSilentFallback` (handled=yes / Sentry-mirrored) at the `try/catch` around the step — but the function still produces zero useful work every run and floods Sentry with a daily error (ID `512e253141294ac1a808b2ef03a21289`, release `web-platform@0.102.0+14c06d9f`).
+
+**Root cause:** the function never mints a GitHub credential. It inherits the substrate shape from before the GitHub-App-token pattern was applied to it. Per hard rule `hr-github-app-auth-not-pat`, production code must authenticate via the GitHub App installation token (Octokit), **not** the `gh` CLI relying on an ambient PAT/`gh auth login`.
+
+**Fix:** mint a GitHub App installation token (via the existing `mintInstallationToken` helper in `_cron-shared.ts`) in a new first `step.run`, and inject it as `GH_TOKEN` into BOTH (a) the server-side `execFileSync("gh", …)` env in `validate-predicates`, and (b) the agent-spawn env in `claude-eval` (the agent itself runs `gh issue view/edit/comment/close`). This mirrors the established precedent in `cron-bug-fixer.ts` exactly. No `gh auth login`, no PAT, no new infrastructure.
+
+The existing `reportSilentFallback` observability stays in place — the catch block remains the failure surface; with a valid token the happy path now succeeds.
+
+## Research Reconciliation — Spec vs. Codebase
+
+No spec exists for this branch. All claims below verified against `origin`-tracked code on 2026-06-01.
+
+| Claim (from task description) | Reality (verified) | Plan response |
+| --- | --- | --- |
+| Function shells out to `gh issue list` | Confirmed at `cron-follow-through-monitor.ts:409-414` (server-side `execFileSync`) AND in the agent prompt (`FOLLOW_THROUGH_PROMPT` lines 108, 137, 140, 157, 160-161). The **server-side** `execFileSync` is what throws the cited Sentry error first. | Fix both surfaces by threading a minted token into both env builders. |
+| A GitHub App / Octokit auth path is "already used elsewhere in the server runtime" | Confirmed: `_cron-shared.ts` exports `mintInstallationToken({ tokenMinLifetimeMs })` (line 31) → `createProbeOctokit()` → installation discovery → `generateInstallationToken(installation.id)`. **22+ cron functions already use it** (`cron-bug-fixer`, `cron-community-monitor`, `cron-roadmap-review`, etc.). | Reuse `mintInstallationToken` verbatim. No new helper. |
+| Failure must stay observable (handled=yes / Sentry-mirrored) | Confirmed: the `validate-predicates` catch calls `reportSilentFallback(...)` (line 424); `ensure-labels` and `claude-eval` also report via `reportSilentFallback`. | Keep all three `reportSilentFallback` sites unchanged. |
+| Only one server-side `gh` shell-out in this flow | Confirmed: `_predicate-validator.ts` has NO `gh`/`spawn`/`execFileSync` (it parses HTML-comment YAML). The only server-side `gh` is the `execFileSync` in the handler. | Single server-side fix site. |
+
+## Open Code-Review Overlap
+
+**Files to Edit:** `apps/web-platform/server/inngest/functions/cron-follow-through-monitor.ts`, `apps/web-platform/test/server/inngest/cron-follow-through-monitor.test.ts`
+
+Ran `gh issue list --label code-review --state open` (via the standard two-stage `--json` + standalone `jq --arg` pattern) against both paths: **None**. No open code-review scope-outs name these files.
+
+## Blast-Radius Note — `cron-daily-triage` has the identical bug
+
+`grep -n "GH_TOKEN: process.env.GH_TOKEN" apps/web-platform/server/inngest/functions/` returns exactly **two** hits:
+
+1. `cron-follow-through-monitor.ts:260` (this fix)
+2. `cron-daily-triage.ts:168` (**same root cause**)
+
+`cron-daily-triage` has the identical `buildSpawnEnv()` reading `process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN`, and its agent prompt also runs `gh issue list` (line 64). It is **also broken in production** — but it differs in failure shape: daily-triage has NO server-side `execFileSync` (it only spawns the agent), so the `gh` failures occur *inside* the agent (agent exits non-zero) rather than throwing the exact server-side `Command failed` Sentry error this plan targets.
+
+**Disposition: Acknowledge + fold-in (recommended).** The Sentry error in scope is follow-through's server-side `execFileSync`. However, daily-triage shares the root cause and the identical fix shape (mint token → inject as `GH_TOKEN`). Folding both into one PR is the net-positive path (one review, one deploy, closes the whole class). The plan's phases are written so daily-triage is a trivial mechanical mirror (Phase 3). If the operator prefers to keep the PR scoped to the Sentry-cited function only, daily-triage MUST get a same-session follow-up issue (`fix: cron-daily-triage unauthenticated gh CLI — same root cause as #<this PR>`) so it is not invisible. **Default per `wg-defer-only-after-inline-triage`: fold in.**
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** follow-through GitHub issues (external-dependency verification trackers) silently stop being monitored — SLA-exceeded issues never get the `needs-attention` label or `@author` ping, and passed predicates never auto-close. This is an internal operator-facing automation; non-technical Soleur end-users are not directly exposed. Currently it is *already* broken (the bug this plan fixes).
+
+**If this leaks, the user's data / workflow / money is exposed via:** N/A — the fix narrows exposure. The minted installation token is short-lived (≤60 min, scoped to the App installation) and replaces any ambient long-lived `GH_TOKEN`/PAT inherited from the parent env (the `hr-github-app-auth-not-pat` rationale). The token is injected only as `GH_TOKEN` into the `gh`/agent subprocess env (already allowlisted); it is never logged. The `redactToken` helper is available if the token must appear near any logged URL (not needed here — no clone URL is built).
+
+**Brand-survival threshold:** none — internal operator automation, no end-user data surface, and the fix strictly reduces credential exposure.
+
+`threshold: none, reason: internal operator cron automation with no end-user-facing surface; fix reduces credential blast radius by replacing ambient PAT with a short-lived installation token.`
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] **AC1 — Token minted via GitHub App, not gh CLI.** `cron-follow-through-monitor.ts` imports `mintInstallationToken` from `./_cron-shared` and calls it inside a `step.run("mint-installation-token", …)` that runs BEFORE `validate-predicates`. Verify: `grep -n "mintInstallationToken" apps/web-platform/server/inngest/functions/cron-follow-through-monitor.ts` returns the import + the call site.
+- [ ] **AC2 — Server-side `gh issue list` uses the minted token.** The `execFileSync("gh", …)` in `validate-predicates` is passed `buildSpawnEnv(installationToken)` (the token-parameterized form), NOT the zero-arg `buildSpawnEnv()`. Verify: `grep -n "buildSpawnEnv()" apps/web-platform/server/inngest/functions/cron-follow-through-monitor.ts` returns **zero** hits after the fix (all call sites take the token argument).
+- [ ] **AC3 — Agent spawn uses the minted token.** `buildSpawnEnv(installationToken)` is passed to the `claude-eval` `spawn(...)` env. Verify: the `spawn(claudeBin, …, { env: buildSpawnEnv(<token-var>) })` call passes the token variable.
+- [ ] **AC4 — `buildSpawnEnv` no longer reads `process.env.GH_TOKEN`.** `grep -n "GH_TOKEN: process.env.GH_TOKEN" apps/web-platform/server/inngest/functions/cron-follow-through-monitor.ts` returns **zero** hits; the function instead returns `GH_TOKEN: installationToken` (mirroring `cron-bug-fixer.ts:193`).
+- [ ] **AC5 — `ensure-labels` step also uses the minted token.** The `ensure-labels` step's `gh label create` subprocess (line 305-328) receives `buildSpawnEnv(installationToken)` so label creation is authenticated too. (This step currently uses `buildSpawnEnv()` and would have the same auth failure once labels need creating.)
+- [ ] **AC6 — Observability preserved.** All three `reportSilentFallback` call sites (`cron-ensure-labels`, `cron-validate-predicates`, `cron-claude-eval`) remain present and unchanged in semantics. Verify: `grep -c "reportSilentFallback" apps/web-platform/server/inngest/functions/cron-follow-through-monitor.ts` ≥ 3.
+- [ ] **AC7 — Tests updated and pass.** `cron-follow-through-monitor.test.ts` mocks `mintInstallationToken` (via mocking its underlying deps `createProbeOctokit` + `generateInstallationToken`, OR by mocking `@/server/inngest/functions/_cron-shared` — match whichever the repo's existing tests use; bug-fixer mocks the underlying deps) and asserts: (a) the mint step ran before validate-predicates; (b) the `execFileSync` `gh issue list` call receives an env carrying the mocked token; (c) the `spawn` claude-eval env carries the mocked token. Verify: `cd apps/web-platform && ./node_modules/.bin/vitest run test/server/inngest/cron-follow-through-monitor.test.ts` passes.
+- [ ] **AC8 — No-BYOK gate still passes.** `cd apps/web-platform && ./node_modules/.bin/vitest run test/server/cron-no-byok-lease-sweep.test.ts` passes (the minted installation token is NOT a BYOK lease; bug-fixer already proves this shape is compliant).
+- [ ] **AC9 — Typecheck clean.** `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` reports no new errors.
+- [ ] **AC10 (if daily-triage folded in) — daily-triage mirrors the fix.** `cron-daily-triage.ts` mints + injects the token identically; `grep -n "GH_TOKEN: process.env.GH_TOKEN" apps/web-platform/server/inngest/functions/` returns **zero** hits repo-wide; daily-triage tests updated and pass. If NOT folded in, AC10 is replaced by: a follow-up issue exists (`gh issue view <N>`) titled for the daily-triage same-root-cause fix.
+
+### Post-merge (operator)
+
+- [ ] **AC11 — Container restart applies the fix.** `web-platform-release.yml` path-filtered `on.push` restarts the Docker container on merge to `main` touching `apps/web-platform/**` — the merge IS the remediation (no separate operator restart per `hr-monitor-not-run-in-background-for-polling` automation gate). No manual step.
+- [ ] **AC12 — Next scheduled run is clean.** After the next `0 9 * * 1-5` fire (or a manual trigger `inngest send cron/follow-through-monitor.manual-trigger`), confirm via the Inngest run log / Sentry that the `validate-predicates` step no longer throws the `gh auth login` error. Verify via Sentry API (read-only) that no new event with the `gh auth login` signature lands for `soleur-runtime-cron-follow-through-monitor` after the deploy SHA. **Automation:** Sentry issue-events query by `fnId` + release SHA — deterministic verdict (zero new events = pass), per `hr-no-dashboard-eyeball-pull-data-yourself`.
+
+## Implementation Phases
+
+> NEVER CODE during planning. The phases below are the work-time blueprint. The contract-changing edit (token mint + `buildSpawnEnv` signature) comes BEFORE the consumer edits (per `2026-05-10-plan-phase-order-load-bearing`).
+
+### Phase 0 — Preconditions (verify before editing)
+
+1. Read `apps/web-platform/server/inngest/functions/cron-bug-fixer.ts` lines 50-79, 179-195, 626-635 — the canonical mint + `buildSpawnEnv(token)` pattern.
+2. Read `_cron-shared.ts:31-42` — confirm `mintInstallationToken({ tokenMinLifetimeMs }): Promise<string>` signature.
+3. Confirm `TOKEN_MIN_LIFETIME_MS` precedent: `cron-community-monitor.ts:75` and `cron-roadmap-review.ts:71` both use `50*60*1000 + 10*60*1000` (60 min). Adopt the same constant — the cron agent runs ≤15 min (`MAX_TURN_DURATION_MS`), so a 60-min min-lifetime token has ≥45 min headroom.
+4. Read the test file `cron-follow-through-monitor.test.ts` (full) and `cron-bug-fixer.test.ts:60-70,142-166` to mirror the mock shape for `createProbeOctokit` + `generateInstallationToken` (the deps `mintInstallationToken` calls).
+
+### Phase 1 — Write failing tests first (cq-write-failing-tests-before)
+
+In `cron-follow-through-monitor.test.ts`:
+- Add module mocks for `@/server/github/probe-octokit` (`createProbeOctokit`) and `@/server/github-app` (`generateInstallationToken`), mirroring `cron-bug-fixer.test.ts:60-70`. `generateInstallationTokenSpy.mockResolvedValue("ghs_TESTTOKEN_REDACT_ME")`.
+- Add tests asserting: (a) a `mint-installation-token` step runs first; (b) the `execFileSync` `gh issue list` call's `env` argument carries `GH_TOKEN === "ghs_TESTTOKEN_REDACT_ME"`; (c) the claude-eval `spawn` `env` carries the same token; (d) `ensure-labels` `gh label create` spawn env carries the token.
+- Run RED: confirm these fail against current code.
+
+### Phase 2 — Fix `cron-follow-through-monitor.ts` (contract-changing edit first)
+
+1. Add import: `mintInstallationToken` from `./_cron-shared` (extend the existing import block — currently imports `postSentryHeartbeat`, `type HandlerArgs`).
+2. Add constant `const TOKEN_MIN_LIFETIME_MS = 50 * 60 * 1000 + 10 * 60 * 1000;` with the 60-min/15-min-agent rationale comment.
+3. Change `buildSpawnEnv()` → `buildSpawnEnv(installationToken: string)` returning `GH_TOKEN: installationToken` (drop the `process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN` read; update the comment to cite `hr-github-app-auth-not-pat` and the dropped-ambient-PAT rationale, mirroring `cron-bug-fixer.ts:179-186`).
+4. Add a first `step.run("mint-installation-token", () => mintInstallationToken({ tokenMinLifetimeMs: TOKEN_MIN_LIFETIME_MS }))` at the top of `cronFollowThroughMonitorHandler`, BEFORE `ensure-labels`. (Mint in its own step so the token is memoized across Inngest replay and not re-minted per step.)
+5. Thread `installationToken` into all three `buildSpawnEnv(...)` call sites: `ensure-labels` (`const ghEnv = buildSpawnEnv(installationToken)`), `validate-predicates` (`execFileSync(..., { env: buildSpawnEnv(installationToken), … })`), `claude-eval` (`spawn(..., { env: buildSpawnEnv(installationToken) })`).
+6. Run GREEN: Phase 1 tests pass.
+
+### Phase 3 — (Conditional, recommended) Mirror in `cron-daily-triage.ts`
+
+Apply the identical transform to `cron-daily-triage.ts` (mint step + `buildSpawnEnv(token)` + `GH_TOKEN: installationToken`). Update `cron-daily-triage.test.ts` to match. If the operator scopes daily-triage out, file the follow-up issue instead (see Open Code-Review Overlap / Blast-Radius Note) — do NOT leave it silent.
+
+### Phase 4 — Verify
+
+Run AC7-AC9 (and AC10 if folded). Confirm `grep -n "GH_TOKEN: process.env.GH_TOKEN" apps/web-platform/server/inngest/functions/` returns zero hits across the fixed files.
+
+## Risks & Mitigations
+
+- **R1 — Token min-lifetime too short for the 15-min agent run.** Mitigated: 60-min min-lifetime token (precedent: community-monitor/roadmap-review) gives ≥45 min headroom over the `MAX_TURN_DURATION_MS = 15min` agent budget. `generateInstallationToken`'s `minRemainingMs` guarantees the cached token has ≥60 min left or it re-mints (`github-app.ts:481`).
+- **R2 — Mint step adds a GitHub App API round-trip per run.** Acceptable: 5 weekday runs/day; `generateInstallationToken` caches the token across invocations within its lifetime (`github-app.ts:480-481`). Same cost profile as 22+ peer crons already in production.
+- **R3 — Installation token scope.** The App installation token already grants `issues:write` + `pull_requests:write` (proven by `cron-bug-fixer.ts` running `gh issue view/edit/comment/close` and `gh pr create` against the same token). No new permission needed; this is the identical credential.
+- **R4 — `mintInstallationToken` throws (App private key missing/invalid in prod).** Then the new mint step throws and Inngest's `retries: 1` retries; on persistent failure the step error surfaces (Inngest run marked failed + the function's existing Sentry instrumentation). This is the correct loud-failure behavior — a missing App key is a real prod misconfiguration, not something to swallow. Precedent: bug-fixer's mint step has the same failure semantics.
+- **R5 — `buildSpawnEnv` signature change is a breaking contract within the file.** Mitigated by phase ordering: the signature change + all three call-site updates land in the same edit (Phase 2). `tsc --noEmit` (AC9) catches any missed call site.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "Sentry cron monitor check-in (postSentryHeartbeat) at end of every run"
+  cadence: "0 9 * * 1-5 (weekday 09:00 UTC) + manual-trigger event"
+  alert_target: "Sentry cron monitor slug 'scheduled-follow-through' (apps/web-platform/infra/sentry/cron-monitors.tf)"
+  configured_in: "cron-follow-through-monitor.ts:523-530 (sentry-heartbeat step)"
+error_reporting:
+  destination: "Sentry via reportSilentFallback (cron-validate-predicates, cron-ensure-labels, cron-claude-eval, cron-claude-eval spawn-error)"
+  fail_loud: "yes — handled=yes Sentry events; mint-step failure surfaces as Inngest run failure (R4)"
+failure_modes:
+  - mode: "gh CLI unauthenticated (THIS BUG)"
+    detection: "Sentry event with 'gh auth login' signature on fnId soleur-runtime-cron-follow-through-monitor"
+    alert_route: "Sentry issue alert (existing); fixed by this PR — should drop to zero post-deploy"
+  - mode: "GitHub App key missing/invalid in prod"
+    detection: "mint-installation-token step throws → Inngest run failure + Sentry"
+    alert_route: "Sentry + Inngest failed-run surface"
+  - mode: "predicate validation fails (DNS/HTTP)"
+    detection: "reportSilentFallback in validate-predicates catch; agent proceeds SLA-only"
+    alert_route: "Sentry (handled)"
+logs:
+  where: "logger.info/warn structured logs (Inngest run logs); Sentry for errors"
+  retention: "per Sentry/Inngest platform defaults"
+discoverability_test:
+  command: "After deploy, query Sentry issue-events for fnId=soleur-runtime-cron-follow-through-monitor with release>deploy-SHA; OR manually trigger: inngest send cron/follow-through-monitor.manual-trigger and read the Inngest run log"
+  expected_output: "validate-predicates step succeeds (no 'gh auth login' error); summary table emitted; sentry-heartbeat check-in OK"
+```
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected — this is an infrastructure/runtime auth fix on an internal operator cron. No user-facing UI, no schema, no regulated data, no new infrastructure (reuses the existing GitHub App installation-token path). Product/UX gate: NONE. GDPR gate (Phase 2.7): skipped — no regulated-data surface; the fix narrows credential exposure. IaC gate (Phase 2.8): skipped — no new server/secret/vendor/cron; the cron already exists and the GitHub App credential is already provisioned.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/placeholder text, or omits the threshold will fail `deepen-plan` Phase 4.6. (This plan's section is filled; threshold = none with a non-empty reason.)
+- **`buildSpawnEnv()` zero-arg form must be fully eliminated.** There are THREE call sites (`ensure-labels`, `validate-predicates`, `claude-eval`) — missing any one leaves an unauthenticated subprocess that fails at runtime but passes `tsc` only if the old zero-arg signature is also kept. The fix MUST change the signature (so `tsc` flags every un-migrated caller) — do not add an overload.
+- **Do not log the token.** `buildSpawnEnv` injects it only as an env var; no clone URL is built here (unlike bug-fixer), so `redactToken`/`buildAuthenticatedCloneUrl` are not needed. If a future edit logs subprocess env, redact `GH_TOKEN`.
+- **daily-triage's failure shape differs.** Its `gh` calls fail *inside* the agent (no server-side `execFileSync`), so it does NOT throw the exact Sentry signature this plan targets — but it is the same root cause and the same fix. Don't assume "no Sentry error = not broken."
+
+## Alternative Approaches Considered
+
+| Approach | Why not |
+| --- | --- |
+| Run `gh auth login` / set `GH_TOKEN` env in the container | Violates `hr-github-app-auth-not-pat` (PAT in prod). Long-lived credential, no rotation, larger blast radius. |
+| Replace the `gh issue list` `execFileSync` with a direct Octokit `issues.listForRepo` call | Cleaner for the server-side step in isolation, BUT the AGENT still runs `gh issue view/edit/comment/close` in-prompt and needs `GH_TOKEN` regardless. Minting the token covers both surfaces with one change; rewriting only the server-side call would leave the agent's `gh` calls still broken. The mint-and-inject approach is strictly necessary and is the established peer pattern. (A follow-up could migrate the server-side list to Octokit for type-safety, but that's out of scope for the prod-fix.) |
+| Mint the token inside `validate-predicates` (not a separate step) | Inngest replay would re-mint per retry and the agent step wouldn't share it cleanly. A dedicated first `step.run` memoizes the token across replay — peer-cron precedent (bug-fixer, community-monitor). |

--- a/knowledge-base/project/specs/feat-one-shot-follow-through-monitor-gh-auth/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-follow-through-monitor-gh-auth/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-01-fix-follow-through-monitor-gh-app-auth-plan.md
+- Status: complete
+
+### Errors
+None. CWD verified, branch is a feature branch (not main), all deepen-plan hard gates (4.4 precedent-diff, 4.45 verify-negative, 4.6 user-brand-impact, 4.7 observability, 4.8 PAT-halt) passed.
+
+### Decisions
+- Root cause: server-side `execFileSync("gh", ["issue","list",...])` in the `validate-predicates` step (`cron-follow-through-monitor.ts:409-414`) fails because `buildSpawnEnv()` reads `process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN` (both empty in prod) at line 260.
+- Fix = mint + inject, mirroring `cron-bug-fixer.ts`: add `step.run("mint-installation-token", …)` using `mintInstallationToken` in `_cron-shared.ts`, then thread the token through `buildSpawnEnv(installationToken)` into all three subprocess env sites. Satisfies hr-github-app-auth-not-pat, zero new infra.
+- Blast-radius: `cron-daily-triage.ts:168` has the identical bug. Plan recommends folding into the same PR; if scoped out, a same-session follow-up issue is mandated.
+- Observability preserved: all three `reportSilentFallback` Sentry-mirror sites stay; failure surface unchanged.
+- External research skipped: strong local context + exact in-repo precedent.
+
+### Components Invoked
+- Skill: soleur:plan
+- Skill: soleur:deepen-plan
+- Bash, Read, Write, Edit, git


### PR DESCRIPTION
## Summary

Two Inngest crons shelled out to the `gh` CLI with an unauthenticated environment — `buildSpawnEnv()` populated `GH_TOKEN` from `process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN`, both empty inside the production Next.js container. `cron-follow-through-monitor` therefore threw `gh auth login` on **every** `0 9 * * 1-5` run (Sentry `512e253141294ac1a808b2ef03a21289`), and `cron-daily-triage` shared the identical root cause (its `gh` calls failed inside the spawned agent rather than server-side, so it produced no distinct Sentry signature but was equally broken).

The fix mints a short-lived **GitHub App installation token** (`mintInstallationToken` from `_cron-shared.ts`) in a new first `step.run("mint-installation-token", …)`, memoized across Inngest replay, and injects it as `GH_TOKEN` into every `gh` subprocess env. `buildSpawnEnv()` now takes the token as a required parameter (so `tsc` flags any un-migrated call site). This mirrors the established precedent in `cron-bug-fixer.ts` and ~22 peer crons, and satisfies hard rule `hr-github-app-auth-not-pat` (production authenticates via the short-lived App token, never an ambient PAT / `gh auth login`).

## Changelog

### Web Platform
- `cron-follow-through-monitor`: mint + inject GitHub App installation token into the `ensure-labels`, `validate-predicates`, and `claude-eval` `gh` subprocess envs (fixes the daily `gh auth login` Sentry error).
- `cron-daily-triage`: same fix (mint + inject) for its `claude-eval` agent spawn — closes the whole unauthenticated-`gh` cron class (`grep "GH_TOKEN: process.env.GH_TOKEN"` is now zero repo-wide).
- Tests: both cron suites assert the mint step runs first, the token reaches every `gh` subprocess env, the minted token **overrides** any ambient `process.env.GH_TOKEN`, and the 60-min lifetime floor propagates to `generateInstallationToken`.

## User-Brand Impact

**If this lands broken, the user experiences:** follow-through GitHub issues (external-dependency verification trackers) and daily issue triage silently stop running. This is internal operator-facing cron automation; non-technical Soleur end-users are not directly exposed. It is *currently* broken (this PR fixes it).

**If this leaks, the user's data / workflow / money is exposed via:** N/A — the fix strictly **reduces** exposure. The minted installation token is short-lived (≤60 min, scoped to the App installation) and replaces any ambient long-lived `GH_TOKEN`/PAT inherited from the parent env. It is injected only as a subprocess env var, never logged, and no clone URL is built (so `redactToken` is unnecessary).

- **Brand-survival threshold:** none

threshold: none, reason: internal operator cron automation with no end-user-facing surface; the fix reduces credential blast radius by replacing an ambient PAT with a short-lived GitHub App installation token.

## Test plan

- [x] `vitest run test/server/inngest/cron-follow-through-monitor.test.ts test/server/inngest/cron-daily-triage.test.ts` — 16/16 pass (mint-order, token-injection across all subprocess envs, ambient-override, lifetime-floor).
- [x] `vitest run test/server/cron-no-byok-lease-sweep.test.ts` — passes (minted installation token is not a BYOK lease).
- [x] `tsc --noEmit` — clean.
- [x] `grep -rn "GH_TOKEN: process.env.GH_TOKEN" apps/web-platform/server/inngest/functions/` — zero hits repo-wide.
- [x] Full webplat suite (`TEST_GROUP=webplat scripts/test-all.sh`) — 7734 passed / 0 failed.
- [x] Post-deploy verification is automated, no manual step: the cron's existing Sentry cron-monitor (`scheduled-follow-through`) pages on any new `gh auth login` event for `soleur-runtime-cron-follow-through-monitor`, and the next `0 9 * * 1-5` fire exercises the fixed path. No follow-through tracker needed.

Generated with [Claude Code](https://claude.com/claude-code)
