### PR TITLE
fix(kb): clear reconnect banner once workspace-scoped sync can resume

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/settings/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/settings/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { SettingsContent } from "@/components/settings/settings-content";
 import type { RepoStatus } from "@/components/settings/project-setup-card";
-import { repoNeedsReconnect } from "@/lib/repo-status";
+import { resolveNeedsReconnect } from "@/lib/repo-status";
 
 export default async function SettingsPage() {
   const supabase = await createClient();
@@ -34,9 +34,10 @@ export default async function SettingsPage() {
       .single(),
   ]);
 
-  const needsReconnect = repoNeedsReconnect(
+  const needsReconnect = await resolveNeedsReconnect(
     userData?.repo_status ?? null,
     userData?.github_installation_id ?? null,
+    user.id,
   );
 
   return (

--- a/apps/web-platform/app/api/kb/tree/route.ts
+++ b/apps/web-platform/app/api/kb/tree/route.ts
@@ -5,7 +5,7 @@ import { createServiceClient } from "@/lib/supabase/server";
 import logger from "@/server/logger";
 import { buildTree } from "@/server/kb-reader";
 import { withUserRateLimit } from "@/server/with-user-rate-limit";
-import { repoNeedsReconnect } from "@/lib/repo-status";
+import { resolveNeedsReconnect } from "@/lib/repo-status";
 
 async function getHandler(_req: Request, user: User) {
   const serviceClient = createServiceClient();
@@ -34,11 +34,14 @@ async function getHandler(_req: Request, user: User) {
     : [];
   const lastSync = historyArr.length > 0 ? historyArr[historyArr.length - 1] : null;
 
-  // #4712 — deterministic reconnect signal. `ready` + NULL install id is the
-  // #4706 silent-freeze class (webhook reconcile selects by install id).
-  const needsReconnect = repoNeedsReconnect(
+  // #4712 — capability-aware reconnect signal. `ready` + NULL user install id
+  // is EITHER the #4706 silent-freeze class OR a workspace-shared install whose
+  // credential lives on the workspace (ADR-044); resolveNeedsReconnect reads the
+  // same signal the sync path uses so the banner clears once sync can resume.
+  const needsReconnect = await resolveNeedsReconnect(
     userData.repo_status,
     userData.github_installation_id,
+    user.id,
   );
 
   try {

--- a/apps/web-platform/lib/repo-status.ts
+++ b/apps/web-platform/lib/repo-status.ts
@@ -35,9 +35,13 @@ export function repoNeedsReconnect(
  * personal install already on the user column) so only the `ready + NULL user
  * column` cohort pays the extra workspace-credential read.
  *
- * Fail toward the alarm: a null/error RPC result (non-member, no install, or a
- * reported failure) keeps `needsReconnect=true` so the genuine #4706 silent
- * freeze still surfaces the banner. Do NOT swallow to `false`.
+ * Fail toward the alarm: resolveInstallationId converts the expected failure
+ * modes (non-member, no install, RPC error, tenant-auth error) to `null`
+ * itself (all Sentry-mirrored), and `null` keeps `needsReconnect=true` so the
+ * genuine #4706 silent freeze still surfaces the banner. A truly unexpected
+ * (non-RuntimeAuthError) throw propagates and fails loud — matching the
+ * `kb/sync` precedent rather than being swallowed to `false`. Do NOT add a
+ * catch that returns `false`.
  */
 export async function resolveNeedsReconnect(
   repoStatus: string | null,

--- a/apps/web-platform/lib/repo-status.ts
+++ b/apps/web-platform/lib/repo-status.ts
@@ -17,3 +17,43 @@ export function repoNeedsReconnect(
   // return either). The rest of the codebase is `===`; this is the exception.
   return repoStatus === "ready" && installationId == null;
 }
+
+/**
+ * Capability-aware reconnect signal (#4712 follow-up).
+ *
+ * `repoNeedsReconnect` above reads ONLY `users.github_installation_id`, but for
+ * an org-owned / workspace-shared install (the ADR-044 membership case) that
+ * column is NULL *by design* — `detect-installation` never writes it, yet sync
+ * resumes via the workspace-scoped credential (`resolve_workspace_installation_id`
+ * RPC). The pure predicate therefore reports `needsReconnect=true` forever even
+ * though syncing works, leaving the orange banner stuck on after a successful
+ * reconnect. This resolver reads the SAME sync-capability signal the manual sync
+ * path uses (`app/api/kb/sync/route.ts`: `users.github_installation_id ||
+ * resolveInstallationId(userId)`) so the banner reflects true capability.
+ *
+ * Short-circuits before the RPC on the common paths (non-ready status, or a
+ * personal install already on the user column) so only the `ready + NULL user
+ * column` cohort pays the extra workspace-credential read.
+ *
+ * Fail toward the alarm: a null/error RPC result (non-member, no install, or a
+ * reported failure) keeps `needsReconnect=true` so the genuine #4706 silent
+ * freeze still surfaces the banner. Do NOT swallow to `false`.
+ */
+export async function resolveNeedsReconnect(
+  repoStatus: string | null,
+  userInstallationId: number | bigint | null | undefined,
+  userId: string,
+): Promise<boolean> {
+  // Cheap paths first — no RPC round-trip on non-ready or personal-install rows.
+  if (repoStatus !== "ready") return false;
+  if (userInstallationId != null) return false;
+
+  // ready + NULL user column: only NOW resolve the workspace-scoped credential.
+  // Dynamic import mirrors the kb/sync precedent and keeps the server-only
+  // Supabase deps out of any eager import graph of this lib module.
+  const { resolveInstallationId } = await import(
+    "@/server/resolve-installation-id"
+  );
+  const wsInstall = await resolveInstallationId(userId);
+  return wsInstall == null;
+}

--- a/apps/web-platform/test/api/kb-tree.test.ts
+++ b/apps/web-platform/test/api/kb-tree.test.ts
@@ -5,8 +5,9 @@ import { mockQueryChain } from "../helpers/mock-supabase";
 // Mocks — vi.hoisted ensures these are available when vi.mock factories run
 // ---------------------------------------------------------------------------
 
-const { mockFrom } = vi.hoisted(() => ({
+const { mockFrom, mockResolveInstallationId } = vi.hoisted(() => ({
   mockFrom: vi.fn(),
+  mockResolveInstallationId: vi.fn(),
 }));
 
 const TEST_USER = { id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" };
@@ -29,6 +30,14 @@ vi.mock("@/server/kb-reader", () => ({
   buildTree: vi.fn(async () => ({ name: "knowledge-base", path: "", children: [] })),
 }));
 
+// #4712 follow-up — the route now derives needsReconnect via the async
+// `resolveNeedsReconnect`, which (for ready + NULL user install) resolves the
+// workspace-scoped credential. Mock that read so a `ready + null` row no longer
+// reaches the real Supabase client.
+vi.mock("@/server/resolve-installation-id", () => ({
+  resolveInstallationId: mockResolveInstallationId,
+}));
+
 vi.mock("@/server/logger", () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
@@ -49,9 +58,12 @@ const BASE_USER = {
 describe("GET /api/kb/tree — needsReconnect", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: no workspace-scoped credential resolves (the #4706 silent-freeze
+    // shape). Individual tests override to exercise the workspace-shared case.
+    mockResolveInstallationId.mockResolvedValue(null);
   });
 
-  test("needsReconnect=true for ready repo with null installation id", async () => {
+  test("needsReconnect=true for ready repo with null user install AND no workspace credential (#4706 freeze)", async () => {
     mockFrom.mockReturnValue(
       mockQueryChain({ ...BASE_USER, github_installation_id: null }),
     );
@@ -60,9 +72,21 @@ describe("GET /api/kb/tree — needsReconnect", () => {
     const body = await res.json();
     expect(body.needsReconnect).toBe(true);
     expect(body.tree).toBeTruthy();
+    expect(mockResolveInstallationId).toHaveBeenCalledWith(TEST_USER.id);
   });
 
-  test("needsReconnect=false for ready repo with an installation id", async () => {
+  test("needsReconnect=false for ready repo with null user install but a resolvable workspace credential (the bug fix)", async () => {
+    mockResolveInstallationId.mockResolvedValue(424242);
+    mockFrom.mockReturnValue(
+      mockQueryChain({ ...BASE_USER, github_installation_id: null }),
+    );
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.needsReconnect).toBe(false);
+  });
+
+  test("needsReconnect=false for ready repo with an installation id (short-circuits before workspace credential)", async () => {
     mockFrom.mockReturnValue(
       mockQueryChain({ ...BASE_USER, github_installation_id: 98765 }),
     );
@@ -70,6 +94,7 @@ describe("GET /api/kb/tree — needsReconnect", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.needsReconnect).toBe(false);
+    expect(mockResolveInstallationId).not.toHaveBeenCalled();
   });
 
   test("not_connected short-circuits to 404 (no needsReconnect)", async () => {

--- a/apps/web-platform/test/lib/resolve-needs-reconnect.test.ts
+++ b/apps/web-platform/test/lib/resolve-needs-reconnect.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { resolveNeedsReconnect } from "@/lib/repo-status";
+import { resolveInstallationId } from "@/server/resolve-installation-id";
+
+// `resolveNeedsReconnect` resolves the workspace-scoped install credential via
+// a dynamic `import("@/server/resolve-installation-id")`. vitest intercepts the
+// dynamic import too, so mocking the module controls the credential read.
+vi.mock("@/server/resolve-installation-id", () => ({
+  resolveInstallationId: vi.fn(),
+}));
+
+const mockResolve = vi.mocked(resolveInstallationId);
+
+describe("resolveNeedsReconnect", () => {
+  beforeEach(() => {
+    mockResolve.mockReset();
+  });
+
+  // AC1 — ready + NULL user column but a resolvable workspace install → the
+  // workspace IS connected (org/workspace-shared install, ADR-044), so the
+  // banner must NOT show. This is the bug: sync resumes via the workspace
+  // credential while the old predicate read the always-NULL user column.
+  it("is false for ready + null user install when workspace credential resolves", async () => {
+    mockResolve.mockResolvedValue(987654);
+    expect(await resolveNeedsReconnect("ready", null, "user-1")).toBe(false);
+    expect(mockResolve).toHaveBeenCalledWith("user-1");
+  });
+
+  // AC2 — ready + NULL user column AND no resolvable workspace install → the
+  // genuine #4706 silent-freeze class. The banner MUST still appear.
+  // (verify-the-negative: the fix must not blind the alarm it backstops.)
+  it("is true for ready + null user install when no workspace credential resolves", async () => {
+    mockResolve.mockResolvedValue(null);
+    expect(await resolveNeedsReconnect("ready", null, "user-1")).toBe(true);
+    expect(mockResolve).toHaveBeenCalledWith("user-1");
+  });
+
+  it("is true for ready + undefined user install when no workspace credential resolves", async () => {
+    mockResolve.mockResolvedValue(null);
+    expect(await resolveNeedsReconnect("ready", undefined, "user-1")).toBe(true);
+  });
+
+  // AC3 — personal install set on the user column → connected, and the cheap
+  // path short-circuits BEFORE the RPC (no redundant DB round-trip on the
+  // common path).
+  it("is false for ready + non-null user install WITHOUT resolving the workspace credential", async () => {
+    expect(await resolveNeedsReconnect("ready", 12345, "user-1")).toBe(false);
+    expect(mockResolve).not.toHaveBeenCalled();
+  });
+
+  it("is false for ready + bigint user install without resolving the workspace credential", async () => {
+    expect(await resolveNeedsReconnect("ready", 12345n, "user-1")).toBe(false);
+    expect(mockResolve).not.toHaveBeenCalled();
+  });
+
+  // AC4 — non-ready statuses short-circuit to false with no RPC, mirroring the
+  // pure predicate's existing contract.
+  it("is false for non-ready statuses without resolving the workspace credential", async () => {
+    expect(await resolveNeedsReconnect("not_connected", null, "user-1")).toBe(false);
+    expect(await resolveNeedsReconnect("error", null, "user-1")).toBe(false);
+    expect(await resolveNeedsReconnect("cloning", null, "user-1")).toBe(false);
+    expect(mockResolve).not.toHaveBeenCalled();
+  });
+
+  it("is false for null repoStatus without resolving the workspace credential", async () => {
+    expect(await resolveNeedsReconnect(null, null, "user-1")).toBe(false);
+    expect(mockResolve).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-platform/test/lib/resolve-needs-reconnect.test.ts
+++ b/apps/web-platform/test/lib/resolve-needs-reconnect.test.ts
@@ -38,6 +38,19 @@ describe("resolveNeedsReconnect", () => {
   it("is true for ready + undefined user install when no workspace credential resolves", async () => {
     mockResolve.mockResolvedValue(null);
     expect(await resolveNeedsReconnect("ready", undefined, "user-1")).toBe(true);
+    // undefined must reach the RPC just like null — a regression that
+    // short-circuits undefined before the RPC would skip the alarm check.
+    expect(mockResolve).toHaveBeenCalledWith("user-1");
+  });
+
+  // Fail-loud contract: resolveInstallationId swallows the EXPECTED failures to
+  // null itself (covered above), but a truly unexpected throw must propagate —
+  // not be caught and swallowed to false (which would hide the #4706 freeze).
+  it("propagates an unexpected credential-read rejection (fails loud, not swallowed to false)", async () => {
+    mockResolve.mockRejectedValue(new Error("unexpected RPC failure"));
+    await expect(resolveNeedsReconnect("ready", null, "user-1")).rejects.toThrow(
+      "unexpected RPC failure",
+    );
   });
 
   // AC3 — personal install set on the user column → connected, and the cheap
@@ -54,13 +67,15 @@ describe("resolveNeedsReconnect", () => {
   });
 
   // AC4 — non-ready statuses short-circuit to false with no RPC, mirroring the
-  // pure predicate's existing contract.
-  it("is false for non-ready statuses without resolving the workspace credential", async () => {
-    expect(await resolveNeedsReconnect("not_connected", null, "user-1")).toBe(false);
-    expect(await resolveNeedsReconnect("error", null, "user-1")).toBe(false);
-    expect(await resolveNeedsReconnect("cloning", null, "user-1")).toBe(false);
-    expect(mockResolve).not.toHaveBeenCalled();
-  });
+  // pure predicate's existing contract. it.each so a regression on a single
+  // status reports the offending value rather than a bundled failure.
+  it.each(["not_connected", "error", "cloning"])(
+    "is false for non-ready status %s without resolving the workspace credential",
+    async (status) => {
+      expect(await resolveNeedsReconnect(status, null, "user-1")).toBe(false);
+      expect(mockResolve).not.toHaveBeenCalled();
+    },
+  );
 
   it("is false for null repoStatus without resolving the workspace credential", async () => {
     expect(await resolveNeedsReconnect(null, null, "user-1")).toBe(false);

--- a/knowledge-base/project/learnings/best-practices/2026-06-01-pure-to-server-import-derivation-breaks-route-tests.md
+++ b/knowledge-base/project/learnings/best-practices/2026-06-01-pure-to-server-import-derivation-breaks-route-tests.md
@@ -1,0 +1,93 @@
+---
+module: web-platform/kb
+date: 2026-06-01
+problem_type: test_failure
+component: nextjs_route
+symptoms:
+  - "Missing SUPABASE_URL and NEXT_PUBLIC_SUPABASE_URL in a route-handler test"
+  - "touched-file test run green but full-suite exit gate red"
+  - "route test reaches a real Supabase client after a derivation change"
+root_cause: unmocked_dynamic_import
+severity: medium
+tags: [vitest, vi-mock, dynamic-import, full-suite-exit-gate, mock-sweep, test-blast-radius]
+synced_to: [work]
+---
+
+# Learning: switching a route's derivation from pure → server-importing breaks every route test that exercised the old pure path
+
+## Problem
+
+PR #4737 changed the KB reconnect-banner signal. The `/api/kb/tree` route and the
+settings page previously derived `needsReconnect` from the **pure** synchronous
+helper `repoNeedsReconnect(repo_status, github_installation_id)`. The fix replaced
+that with a new **async** `resolveNeedsReconnect(repoStatus, userInstallationId, userId)`
+that, for the `ready + NULL user-install` cohort, lazy-imports a server-only module:
+
+```ts
+const { resolveInstallationId } = await import("@/server/resolve-installation-id");
+const wsInstall = await resolveInstallationId(userId); // pulls the Supabase tenant client
+```
+
+The touched-file test run was **green** — the pure `test/lib/repo-status.test.ts`
+and the new `test/lib/resolve-needs-reconnect.test.ts` (which mocks the module)
+both passed. But `test/api/kb-tree.test.ts` — an *orphan* relative to the touched
+file set — failed:
+
+```
+Error: Missing SUPABASE_URL and NEXT_PUBLIC_SUPABASE_URL
+ ❯ resolveInstallationId server/resolve-installation-id.ts:35:26
+ ❯ resolveNeedsReconnect lib/repo-status.ts:57:27
+```
+
+Its `ready + null-install` case used to exercise a synchronous pure boolean; after
+the change it reached the dynamic import and tried to instantiate a real Supabase
+client. The break only surfaced when the work-phase **full-suite exit gate** ran
+every consumer of the signal (`grep -rln "needsReconnect" test/`), not the
+touched-file inner loop.
+
+## Solution
+
+Add the module mock to the orphan route test in the same change:
+
+```ts
+const { mockResolveInstallationId } = vi.hoisted(() => ({ mockResolveInstallationId: vi.fn() }));
+vi.mock("@/server/resolve-installation-id", () => ({ resolveInstallationId: mockResolveInstallationId }));
+// ...
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockResolveInstallationId.mockResolvedValue(null); // default = safe "freeze/alarm" shape
+});
+```
+
+`vi.mock` intercepts both static AND dynamic `import()` of the specifier, so the
+route's `await import("@/server/resolve-installation-id")` resolves to the mock.
+Default the mock to the conservative shape in `beforeEach` so a test that forgets
+to set it fails toward the alarm, never toward a real client call.
+
+## Key Insight
+
+When a derivation a route/page depends on switches from a **pure** helper to one
+that imports a **server-only** module (static OR dynamic import), the change's
+blast radius is not the files you edited — it is **every route-handler/page test
+that exercised the old pure path**. Those tests never needed the server-module
+mock before, so they are orphans relative to the touched-file set and pass the
+inner loop. Sweep them with `grep -rln "<signal-or-helper>" test/` and add the
+new module mock in the same edit cycle; rely on the **full-suite exit gate** (not
+the touched-file run) to catch the orphan. Same family as
+[[2026-04-27-wrapper-extension-test-mock-chain-sweep]] (mock-chain sweep on
+wrapper extension) and [[2026-05-18-sweep-class-fixes-grep-enumerated-not-intuited]]
+(grep-enumerated work-lists).
+
+Secondary: a dynamic `import()` inside a `lib/` module bypasses `tsc`'s static
+path check, but that tradeoff is acceptable when a test mocks the same specifier —
+a path typo then fails the test rather than shipping silently.
+
+## Session Errors
+
+1. **Orphan route test broke after the pure→async derivation swap** — `test/api/kb-tree.test.ts` hit a real Supabase client (`Missing SUPABASE_URL`) because it didn't mock the newly-lazy-imported `@/server/resolve-installation-id`. **Recovery:** added `vi.mock` + `vi.hoisted` for the module, defaulted to `mockResolvedValue(null)` in `beforeEach`. **Prevention:** when a route's derivation switches from a pure helper to one importing a server-only module, `grep -rln "<signal>" test/` and add the module mock to every covering test in the same change; trust the full-suite exit gate over the touched-file run.
+
+2. **JSDoc overclaimed the error contract** — the `resolveNeedsReconnect` comment said "null/error RPC result keeps needsReconnect=true," but the impl has no try/catch, so an unexpected (non-`RuntimeAuthError`) throw *propagates* rather than returning true. Surfaced by test-design review. **Recovery:** tightened the comment to distinguish handled failures (→null→banner stays) from an unexpected throw (→propagates, fail-loud, matching the `kb/sync` precedent), and added a rejection-propagation test. **Prevention:** when a JSDoc asserts a "fail toward X" contract, back it with a test that exercises the failure mode, or word it to match what the code actually does.
+
+## Tags
+category: best-practices
+module: web-platform/kb

--- a/knowledge-base/project/plans/2026-06-01-fix-kb-reconnect-banner-stale-after-reconnect-plan.md
+++ b/knowledge-base/project/plans/2026-06-01-fix-kb-reconnect-banner-stale-after-reconnect-plan.md
@@ -1,0 +1,216 @@
+---
+title: "fix(kb): reconnect banner persists after successful workspace-shared reconnect"
+issue: TBD
+parent: 4712
+branch: feat-one-shot-kb-sync-banner-stale-after-reconnect
+date: 2026-06-01
+type: fix
+lane: single-domain
+requires_cpo_signoff: false
+brand_survival_threshold: aggregate pattern
+---
+
+# 🐛 fix(kb): "can't sync — reconnect" banner persists after a successful reconnect
+
+🐛 **Type:** bug · **Surface:** KB layout reconnect banner (#4712) + settings ProjectSetupCard · **Related:** #4712 (banner feature), #4726 (went-quiet detection), #4736/#4728 (workspace_id discriminator), ADR-044 (workspace-scoped install credential)
+
+## Enhancement Summary
+
+**Deepened on:** 2026-06-01 · **Sections enhanced:** Research Reconciliation, Risks (precedent-diff gate 4.4), Research Insights
+**Gates run inline (no subagent tooling in this environment):** 4.6 User-Brand Impact (PASS — section present, threshold `aggregate pattern`), 4.7 Observability (PASS — 5 fields, no ssh in `discoverability_test.command`), 4.8 PAT-shaped variable scan (PASS — none), 4.5 network-outage (N/A — no real trigger), 4.4 precedent-diff gate, live PR/issue-state checks for every cited number.
+
+### Key Improvements
+1. **#4712 confirmed CLOSED — and its title is the smoking gun.** Live check: #4712 = *"KB sync (#4706 follow-ups): UI reconnect affordance for **NULL-install workspaces** + stale-last-sync heuristic"* (CLOSED). The banner was purpose-built for NULL-install workspaces; this bug is its predicate over-firing on the *workspace-shared-but-user-column-NULL* sub-case. Confirms the fix is a predicate refinement of an existing, intended feature — not a new build.
+2. **Precedent-diff gate satisfied.** The capability expression (`users.github_installation_id || resolveInstallationId(userId)`) is NOT novel — it is the established canonical form at `app/api/kb/sync/route.ts:101-106`. The fix adopts the precedent verbatim rather than inventing a new capability check. Side-by-side in Risks below.
+3. **Placement de-risked at plan time.** Grep confirmed the only `.tsx` importer of `lib/repo-status` is the server component `settings/page.tsx` — no client importer exists, so the async resolver lands in `lib/repo-status.ts` with no client-bundle risk.
+
+### New Considerations Discovered
+- **Cite #4706 as a PR, not an issue.** Live check: #4706 is a MERGED **PR** (*"reconcile ignored repos with connected workspaces + detect ready-but-unreachable workspaces"*), and #4728 is an OPEN **issue** (not yet a merged feature). Citations corrected.
+- **`resolveInstallationId` returns `Promise<number | null>`** (verified `resolve-installation-id.ts:30-33`), so `wsInstall == null` is the correct null-check (loose `==`, matching the existing `repoNeedsReconnect` convention for null-or-undefined). No symbol collision: `resolveNeedsReconnect` does not exist anywhere in `apps/web-platform`.
+
+## Overview
+
+The orange reconnect banner (`This project can't sync — reconnect to restore Knowledge Base updates…`) stays displayed even after a reconnect succeeds and syncing visibly resumes (operator screenshot: `INDEX.md`, `kb-categories.txt`, `kb-tags.txt` all synced "1m ago").
+
+**Root cause — signal divergence between "can sync" and "the banner's predicate".** The banner is driven by `repoNeedsReconnect(repo_status, github_installation_id)` (`apps/web-platform/lib/repo-status.ts:12`), which returns `true` when `repo_status === "ready" && users.github_installation_id == null`. But the **actual sync-capability** of the workspace does **not** depend on `users.github_installation_id` — it depends on the *workspace-scoped* installation credential resolved via the `resolve_workspace_installation_id` SECURITY DEFINER RPC (ADR-044, migration 079), surfaced by `resolveInstallationId(userId)` (`apps/web-platform/server/resolve-installation-id.ts:30`).
+
+For an **org-owned or workspace-shared install** (the ADR-044 membership case), `users.github_installation_id` is **NULL by design** and is deliberately never written:
+
+- `POST /api/repo/detect-installation` returns `{ installed: true }` for a *membership-reachable* install (`route.ts:186-199`) **without** writing `users.github_installation_id` — and on the unique-constraint path (`route.ts:144-166`) the UPDATE silently no-ops (logged `info`, "shared via workspace membership"), again leaving the column NULL.
+- Sync resumes anyway: the push-webhook reconcile (`workspace-reconcile-on-push.ts:165`) selects workspaces by the **org install id** from the webhook payload, and the manual `/api/kb/sync` route (`route.ts:101-106`) falls back to `resolveInstallationId(userId)` when `users.github_installation_id` is falsy.
+
+So files update "1m ago" (sync works via the workspace credential) while `repoNeedsReconnect("ready", null)` stays `true` forever (banner reads the *user* column). The client side is **not** the bug: `useReconnect` → `onReconnected` → `refreshTree` (`use-kb-layout-state.tsx:100`) correctly re-fetches `/api/kb/tree` and re-derives `needsReconnect` from the server response. The server simply re-returns `true` because its predicate reads the wrong column.
+
+**The fix:** make the banner predicate read the **same sync-capability signal the sync path uses** — i.e., treat the workspace as connected when *either* `users.github_installation_id` is set *or* a workspace-scoped installation credential resolves. The `kb/sync` route already encodes the canonical "true capability" expression (`users.github_installation_id || resolveInstallationId(userId)`); the banner must adopt it instead of reading the user column alone.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Bug-report claim | Codebase reality | Plan response |
+|---|---|---|
+| "Banner's clear condition is not re-evaluated after reconnect" | Partially true *as a symptom*. Client `refreshTree` DOES re-evaluate (`use-kb-layout-state.tsx:100`); the server predicate re-returns `true` because it reads `users.github_installation_id`, which the reconnect never sets for workspace-shared installs. | Fix is **server-side predicate**, not client re-fetch wiring. No client change needed. |
+| "Likely related to #4726 went-quiet detection" | #4726 is Sentry-only, **no UI** (PR body: "no UI"). It does not touch the banner. | Out of scope. Cite as related context only. |
+| "Likely related to feat-one-shot-4728-kb-sync-workspace-id" | #4736/#4728 adds an optional `workspace_id` to `kb_sync_history` rows; **reader-inert, no banner touch**. | Orthogonal. The shared underlying theme is "the per-user column is the wrong granularity once workspaces are shared" — this plan fixes the *banner* read of that signal; #4728 fixes the *history-row* attribution. No file overlap. |
+| Banner predicate lives in one place | Two derivation sites import `repoNeedsReconnect`: `app/api/kb/tree/route.ts:39` and `app/(dashboard)/dashboard/settings/page.tsx:37`. The helper's own doc forbids inline re-derivation. | Fix must keep a single shared predicate; both sites updated to feed it the capability signal. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a permanent, false "your Knowledge Base can't sync" alarm on a KB that is in fact syncing every push — eroding trust in every other status signal the product shows, and prompting needless repeated reconnect clicks (each a GitHub OAuth round-trip). Conversely, if over-corrected, a genuinely broken sync (the #4706 5-week silent freeze) shows *no* banner — the regression the #4712 banner exists to prevent.
+
+**If this leaks, the user's data/workflow is exposed via:** N/A — read-only signal derivation; no new data surface, no new write, no PII. The install-id is already read on these paths.
+
+**Brand-survival threshold:** aggregate pattern. (A single stale banner is an annoyance, not an incident; the brand cost accrues across every workspace-shared/org-install user, which is the growing majority as multi-tenant workspaces land. No single-user incident class — sync itself is unaffected either way.)
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [x] **AC1 — Predicate reflects true capability.** A user with `repo_status='ready'`, `users.github_installation_id IS NULL`, but a resolvable workspace-scoped install (RPC returns a non-null id) yields `needsReconnect === false` from BOTH derivation sites (`/api/kb/tree` and `settings/page`). Verified by a test that stubs the capability inputs and asserts the boolean.
+- [x] **AC2 — The #4706 freeze still alarms.** A user with `repo_status='ready'`, `users.github_installation_id IS NULL`, AND no resolvable workspace install (RPC returns null) yields `needsReconnect === true`. The banner MUST still appear for the genuine silent-freeze class. (verify-the-negative)
+- [x] **AC3 — Personal-install path unchanged.** `repo_status='ready'` + non-null `users.github_installation_id` → `needsReconnect === false` (no extra RPC call needed; short-circuit before resolving the workspace credential to avoid a redundant DB round-trip on the common path).
+- [x] **AC4 — Non-ready statuses unchanged.** `not_connected`/`error`/`cloning` → `needsReconnect === false` regardless of install id (existing `repo-status.test.ts` cases still pass verbatim).
+- [x] **AC5 — Single source of truth preserved.** `grep -rn "repo_status === \"ready\"" apps/web-platform --include=*.ts --include=*.tsx | grep -v repo-status.ts` returns zero inline re-derivations (the helper doc forbids them; the fix must not introduce a second).
+- [x] **AC6 — `tsc --noEmit` clean** for `apps/web-platform`.
+- [x] **AC7 — Existing reconnect-banner + kb-layout + repo-status suites pass:** `./node_modules/.bin/vitest run test/components/kb/kb-reconnect-banner.test.tsx test/kb-layout.test.tsx test/lib/repo-status.test.ts` (run from `apps/web-platform/`).
+
+## Implementation Phases
+
+### Phase 0 — Preconditions (grep-verify before coding)
+
+0.1 Confirm the capability fallback expression in the sync route is current: `sed -n '101,114p' apps/web-platform/app/api/kb/sync/route.ts` shows `installationId = userData.github_installation_id; if (!installationId) installationId = await resolveInstallationId(userId)`.
+0.2 Confirm `resolveInstallationId(userId)` returns `number | null` and is import-safe from a route module (it is — already dynamically imported by `kb/sync`).
+0.3 Confirm both predicate callers and their available columns: `kb/tree/route.ts` already SELECTs `github_installation_id` and has `user.id`; `settings/page.tsx` already SELECTs it and has `user.id`. Both can resolve the workspace credential.
+0.3b **Placement resolved (grep ran at plan time):** `grep -rln "@/lib/repo-status" apps/web-platform --include=*.tsx` returns ONLY `app/(dashboard)/dashboard/settings/page.tsx`, which is a **server component** (`export default async function SettingsPage()` — no `"use client"` directive). All three importers of `lib/repo-status` (`kb/tree/route.ts`, `settings/page.tsx`, `test/lib/repo-status.test.ts`) are server-side. **Therefore the async resolver can live in `lib/repo-status.ts` directly** — no genuine client importer exists, so bundling `resolveInstallationId`'s server deps will not break a client build. The `server/repo-status.ts` fallback in Files-to-Create is NOT needed.
+0.4 Confirm vitest globs so the new test lands where the runner collects it: `lib/**/*.test.ts` and `test/**/*.test.ts` (node project), `test/**/*.test.tsx` (jsdom). A pure-predicate test belongs at `test/lib/` (matches `test/**/*.test.ts`).
+
+### Phase 1 — RED: failing test for the workspace-shared case
+
+Extend `apps/web-platform/test/lib/repo-status.test.ts` (or a new sibling if the predicate signature changes shape) with the AC1/AC2 cases. Because the new capability check is *async* (it calls the RPC), the cleanest shape is **NOT** to make `repoNeedsReconnect` itself async (it is a pure boolean used in two server contexts) — instead introduce a thin async resolver at the route/page layer and keep `repoNeedsReconnect` pure. See Phase 2 for the chosen shape; write the RED test against that shape.
+
+### Phase 2 — GREEN: introduce a capability-aware reconnect resolver
+
+**Design decision (keep the pure predicate; add an async capability resolver).** `repoNeedsReconnect` stays a pure `(repoStatus, installationId) => boolean`. Add a single shared async helper — `resolveNeedsReconnect(repoStatus, userInstallationId, userId)` in `apps/web-platform/lib/repo-status.ts` (or a server-only sibling `server/repo-status.ts` if `lib/` must stay client-safe — verify `lib/repo-status.ts` has no client importers via `grep -rn "@/lib/repo-status" apps/web-platform --include=*.tsx` before adding a server import; `resolveInstallationId` pulls in server-only Supabase, so the async resolver MUST live server-side). The resolver:
+
+```ts
+// pseudocode — server-only module
+export async function resolveNeedsReconnect(
+  repoStatus: string | null,
+  userInstallationId: number | bigint | null | undefined,
+  userId: string,
+): Promise<boolean> {
+  // Short-circuit: non-ready or personal install set → cheap, no RPC (AC3/AC4)
+  if (repoStatus !== "ready") return false;
+  if (userInstallationId != null) return false;
+  // ready + null user-column → only NOW pay the workspace-credential read (AC1/AC2)
+  const wsInstall = await resolveInstallationId(userId);
+  return wsInstall == null;
+}
+```
+
+Then:
+- `app/api/kb/tree/route.ts:39` — replace `repoNeedsReconnect(repo_status, github_installation_id)` with `await resolveNeedsReconnect(repo_status, github_installation_id, user.id)`.
+- `app/(dashboard)/dashboard/settings/page.tsx:37` — same substitution with `user.id`.
+
+Keep `repoNeedsReconnect` exported and used *inside* `resolveNeedsReconnect` for the pure-boolean portion (and its existing unit tests stay green, AC4). This preserves the single-source-of-truth invariant the helper doc mandates.
+
+### Research Insights
+
+**Verify-the-negative (deepen 4.45) — both load-bearing negative claims confirmed by grep:**
+- "Client re-derivation is correct; bug is server-side" → `use-kb-layout-state.tsx:189` (`refreshTree: fetchTree`) + `:100` (`setNeedsReconnect(data.needsReconnect === true)`). `refreshTree` IS `fetchTree`; on reconnect it re-fetches `/api/kb/tree` and re-derives from the server response. **Confirmed** — client clears correctly; the server re-returns `true`.
+- "No client importer of `lib/repo-status` → async resolver is bundle-safe in `lib/`" → the sole `.tsx` importer `settings/page.tsx` has zero `"use client"` directives (it is `export default async function SettingsPage()`). **Confirmed** — server-only importers.
+
+**Implementation detail — null-check polarity matches existing convention.** `resolveInstallationId` returns `Promise<number | null>`. Use loose `wsInstall == null` (mirrors `repoNeedsReconnect`'s documented loose-`== null` intent for null-or-undefined) so a `null` RPC result (non-member / no install / RPC error already reported to Sentry) → `return true` → banner shows. This is the fail-toward-alarm default (see Sharp Edges).
+
+**Edge case — concurrent personal + workspace install.** If a user later acquires a personal install (`users.github_installation_id` set) while also being a workspace member, AC3's short-circuit returns `false` before the RPC — correct and cheaper. No double-resolution.
+
+### Phase 3 — REFACTOR / verify
+
+- Run AC5 grep (no inline re-derivation introduced).
+- Run AC6 `tsc --noEmit`.
+- Run AC7 suites.
+
+## Files to Edit
+
+- `apps/web-platform/lib/repo-status.ts` — add `resolveNeedsReconnect` async capability resolver; keep `repoNeedsReconnect` pure. **Placement resolved at plan time (Phase 0.3b):** the only `.tsx` importer is the server component `settings/page.tsx`; all importers are server-side, so the async resolver lives here directly (no client-bundle risk).
+- `apps/web-platform/app/api/kb/tree/route.ts` — call the async resolver with `user.id`.
+- `apps/web-platform/app/(dashboard)/dashboard/settings/page.tsx` — call the async resolver with `user.id`.
+- `apps/web-platform/test/lib/repo-status.test.ts` — add AC1/AC2 cases for `resolveNeedsReconnect` (workspace-shared install resolves → false; no install resolves → true).
+
+## Files to Create
+
+- (none) — placement resolved to existing `lib/repo-status.ts` (Phase 0.3b).
+
+## Open Code-Review Overlap
+
+None. `gh issue list --label code-review --state open` returned 50 open items; none reference `repo-status.ts`, `kb/tree/route.ts`, `settings/page.tsx`, or the reconnect banner.
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected — this is a read-only signal-derivation correction on an existing UI affordance. No new user-facing surface (the banner already exists), no schema change, no new write, no auth-flow change, no regulated-data surface. Product/UX gate: NONE (modifies the *visibility condition* of an existing banner, adds no new component or flow). GDPR gate (2.7): skipped — no regulated-data surface touched; the install-id is already read on these exact paths. IaC gate (2.8): skipped — pure code change against already-provisioned surface.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "needsReconnect derivation runs on every /api/kb/tree GET and settings page render"
+  cadence: "per request (KB layout mount + settings load)"
+  alert_target: "n/a — synchronous request-path boolean, no background producer"
+  configured_in: "app/api/kb/tree/route.ts, app/(dashboard)/dashboard/settings/page.tsx"
+error_reporting:
+  destination: "Sentry via existing reportSilentFallback in resolveInstallationId (server/resolve-installation-id.ts:44,58) — RPC failure already mirrors"
+  fail_loud: "yes — resolveInstallationId already reports RPC/tenant errors to Sentry; a failed credential read returns null, which surfaces the banner (fail-toward-alarm, matches #4706 intent)"
+failure_modes:
+  - mode: "RPC resolve_workspace_installation_id transiently fails"
+    detection: "reportSilentFallback feature=resolve-installation-id op=rpc-read (existing)"
+    alert_route: "Sentry"
+  - mode: "false-negative (banner hidden while sync truly broken)"
+    detection: "resolveInstallationId returns null on real failure → resolver returns true → banner shows (fail-toward-alarm); plus #4726 went-quiet Sentry arm independently detects silent freeze"
+    alert_route: "in-product banner + Sentry went-quiet arm"
+  - mode: "false-positive (banner shown while sync works) — THE BUG BEING FIXED"
+    detection: "AC1 test; manual repro per operator screenshot"
+    alert_route: "n/a after fix"
+logs:
+  where: "existing logger in kb/tree route (kb/tree: unexpected error) + Sentry breadcrumbs"
+  retention: "Sentry default"
+discoverability_test:
+  command: "cd apps/web-platform && ./node_modules/.bin/vitest run test/lib/repo-status.test.ts"
+  expected_output: "all repoNeedsReconnect + resolveNeedsReconnect cases pass (AC1-AC4)"
+```
+
+## Hypotheses
+
+(No SSH/network-outage trigger keywords matched — section omitted per Phase 1.4 unless reviewer requests.)
+
+## Sharp Edges
+
+- **Keep `repoNeedsReconnect` pure.** It is imported and unit-tested as a synchronous boolean in two places and documented as the single source of truth. Do not make it `async` — wrap it in the new async resolver instead. Making it async would force `await` into the pure-unit test surface and ripple into any future synchronous caller.
+- **Short-circuit before the RPC.** The common path (personal install set, or non-ready status) must NOT pay an extra `resolveInstallationId` DB round-trip on every KB-tree fetch. Resolve the workspace credential ONLY in the `ready && user-column-null` branch. (AC3 enforces this ordering.)
+- **Fail toward the alarm, not away from it.** If the workspace-credential RPC errors or returns null, treat the workspace as needing reconnect (show the banner). The #4712 banner exists to catch the #4706 silent freeze; a false-positive banner is an annoyance, a false-negative is the incident class. `resolveInstallationId` already returns `null` on error (it catches and reports to Sentry), so `wsInstall == null → return true` is the correct fail-open-to-alarm default. Do NOT add a try/catch that swallows to `false`.
+- **`lib/` vs `server/` placement is load-bearing.** `resolveInstallationId` pulls in server-only Supabase + `getFreshTenantClient`. If the async resolver lands in `lib/repo-status.ts` and any client component imports that module, the bundler will try to pull server deps into the client and break the build. Grep for client importers of `@/lib/repo-status` first; if any exist, put the async resolver in a server-only module and import `repoNeedsReconnect` (the pure half) into it.
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/placeholder text, or omits the threshold will fail `deepen-plan` Phase 4.6. (This plan's section is filled; threshold = aggregate pattern.)
+
+## Risks & Mitigations — Precedent-Diff Gate (deepen Phase 4.4)
+
+**Pattern-bound behavior:** "resolve the GitHub-App installation credential for a workspace whose `users.github_installation_id` is NULL." This is NOT novel — there is an established sibling precedent. Side-by-side:
+
+| | Precedent (`app/api/kb/sync/route.ts:101-106`) | This plan (`resolveNeedsReconnect`) |
+|---|---|---|
+| Cheap path | `let installationId = userData.github_installation_id` | `if (userInstallationId != null) return false` |
+| Fallback | `if (!installationId) installationId = await resolveInstallationId(userId)` | `const wsInstall = await resolveInstallationId(userId)` |
+| Verdict | `if (!installationId) → 409 "Workspace not connected"` | `return wsInstall == null` (true → banner shown) |
+
+The plan adopts the precedent's fallback (`resolveInstallationId(userId)`) verbatim. The only difference is the verdict polarity (the sync route *blocks*; the banner *shows an alarm*), which is intentional and correct. **No novel pattern is introduced.** Risk of divergence from the precedent: low — both now key off the same workspace-scoped credential, which is the entire point of the fix (collapse the two-signal divergence into one signal).
+
+**Residual risk — added DB round-trip.** The `ready && user-column-null` branch adds one `resolveInstallationId` RPC call per `/api/kb/tree` fetch and per settings render *for the affected cohort only* (workspace-shared installs). Mitigation: the short-circuit (AC3) ensures the common personal-install path pays nothing. The RPC is the same one `kb/sync` already calls, membership-checked and SECURITY DEFINER — no new attack surface.
+
+## Premise Validation
+
+Live-checked every cited reference (state + title):
+
+- **#4712** — CLOSED PR, *"KB sync (#4706 follow-ups): UI reconnect affordance for NULL-install workspaces + stale-last-sync heuristic"*. This is the banner's origin; the title confirms it was built for NULL-install workspaces — this bug is that intended feature over-firing on the workspace-shared sub-case. **Cite as `Ref #4712`** (closed; do not re-open).
+- **#4726** — MERGED PR, went-quiet detection, Sentry-only, **no UI** (PR body: "no UI"). Related context only; not the bug site.
+- **#4728** — OPEN **issue** (`workspace_id discriminator`); its work lives in OPEN PR **#4736**. Reader-inert optional `workspace_id` on `kb_sync_history` rows — orthogonal to the banner predicate, zero file overlap.
+- **#4706** — MERGED **PR** (not an issue), *"reconcile ignored repos with connected workspaces + detect ready-but-unreachable workspaces"* — the original 5-week-freeze fix this banner backstops.
+
+The banner copy, predicate, and both derivation sites were verified present on the working tree (`reconnect-notice.tsx`, `lib/repo-status.ts:12`, `kb/tree/route.ts:39`, `settings/page.tsx:37`). The reconnect→refreshTree→re-derive client wiring was verified intact (`use-kb-layout-state.tsx:100`), confirming the bug is the *server predicate*, not the client clear-condition — so this is a behavioral fix to existing, present code, not a build-the-missing-feature plan. **PR-body issue link:** there is no open issue for this bug yet; if one is filed, use `Closes #N` (pre-merge code fix, not an ops-remediation — auto-close at merge is correct).

--- a/knowledge-base/project/plans/2026-06-01-fix-kb-reconnect-banner-stale-after-reconnect-plan.md
+++ b/knowledge-base/project/plans/2026-06-01-fix-kb-reconnect-banner-stale-after-reconnect-plan.md
@@ -174,8 +174,9 @@ logs:
   where: "existing logger in kb/tree route (kb/tree: unexpected error) + Sentry breadcrumbs"
   retention: "Sentry default"
 discoverability_test:
-  command: "cd apps/web-platform && ./node_modules/.bin/vitest run test/lib/repo-status.test.ts"
-  expected_output: "all repoNeedsReconnect + resolveNeedsReconnect cases pass (AC1-AC4)"
+  command: curl -sS -o /dev/null -w "%{http_code}" --max-time 10 https://app.soleur.ai/api/kb/tree
+  expected_output: 307 or 401
+  note: "SSH-free liveness probe — an unauthenticated GET to the route that derives needsReconnect redirects (307) or 401s, proving the route is live. The needsReconnect logic itself is covered by the unit + route suites (cd apps/web-platform; ./node_modules/.bin/vitest run test/lib/resolve-needs-reconnect.test.ts test/lib/repo-status.test.ts test/api/kb-tree.test.ts)."
 ```
 
 ## Hypotheses

--- a/knowledge-base/project/specs/feat-one-shot-kb-sync-banner-stale-after-reconnect/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-kb-sync-banner-stale-after-reconnect/session-state.md
@@ -1,0 +1,19 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-01-fix-kb-reconnect-banner-stale-after-reconnect-plan.md
+- Status: complete
+
+### Errors
+None. CWD verified at start. Branch-safety check passed (feature branch, not main). All four deepen-plan mandatory gates passed inline (4.6 User-Brand Impact, 4.7 Observability 5-field schema, 4.8 PAT-shaped variable scan, 4.5 network-outage N/A). Subagent fan-out tooling unavailable in this environment; research/precedent-diff/verify-the-negative/live PR-issue checks run inline via Bash/grep.
+
+### Decisions
+- Root cause is server-side predicate signal divergence, not client wiring. Banner reads `repoNeedsReconnect(repo_status, users.github_installation_id)`, but real sync-capability is the workspace-scoped credential (`resolveInstallationId` → `resolve_workspace_installation_id` RPC, ADR-044). For org/workspace-shared installs `users.github_installation_id` is NULL by design → banner persists forever while sync resumes via the workspace credential.
+- Fix adopts the existing canonical capability expression (`app/api/kb/sync/route.ts:101-106`). Adds async `resolveNeedsReconnect(repoStatus, userInstallationId, userId)` in `lib/repo-status.ts`, keeps `repoNeedsReconnect` pure, updates both derivation sites (`kb/tree/route.ts:39`, `settings/page.tsx:37`).
+- Fail-toward-alarm + short-circuit: resolve RPC only in the `ready && user-column-null` branch (AC3, no extra round-trip on common path); null/error RPC keeps banner up so the #4706 silent-freeze still alarms (AC2 verify-the-negative).
+- Placement de-risked: sole `.tsx` importer of `lib/repo-status` is the server component `settings/page.tsx` — no client importer, async resolver lands in `lib/repo-status.ts` with no client-bundle risk.
+- Citations live-checked: #4712 CLOSED PR (banner origin, NULL-install workspaces), #4726 MERGED Sentry-only no-UI, #4728 OPEN issue / #4736 OPEN PR (orthogonal workspace_id discriminator, zero file overlap), #4706 MERGED PR. No open code-review issues touch edited files.
+
+### Components Invoked
+- Skill: soleur:plan
+- Skill: soleur:deepen-plan


### PR DESCRIPTION
## Summary

The Knowledge Base "**This project can't sync — reconnect to restore Knowledge Base updates**" banner stayed displayed after a successful reconnect, even though syncing visibly resumed (operator screenshot: `INDEX.md`, `kb-categories.txt`, `kb-tags.txt` all synced "1m ago").

**Root cause — signal divergence.** The banner predicate `repoNeedsReconnect(repo_status, users.github_installation_id)` returns `true` when `repo_status === "ready" && users.github_installation_id == null`. But actual sync-capability for an **org-owned / workspace-shared install** (ADR-044) does not depend on the per-user column — it depends on the **workspace-scoped** credential resolved via `resolve_workspace_installation_id` (`resolveInstallationId`). For shared installs `users.github_installation_id` is **NULL by design** (`detect-installation` never writes it), so sync resumes via the workspace credential while the banner reads the always-NULL user column → banner persists forever. The client (`refreshTree` → re-derive) was already correct; the server predicate re-returned `true`.

**Fix.** Add an async `resolveNeedsReconnect(repoStatus, userInstallationId, userId)` that adopts the same capability signal the manual sync path already uses (`app/api/kb/sync/route.ts`: `users.github_installation_id || resolveInstallationId(userId)`). The pure `repoNeedsReconnect` stays pure. Both derivation sites (`/api/kb/tree`, settings page) call the resolver. It short-circuits before the RPC on the common paths (non-ready status, or a personal install already set) and **fails toward the alarm** — a null/error workspace-credential read keeps the banner up so the #4706 silent-freeze class still surfaces.

Plan: `knowledge-base/project/plans/2026-06-01-fix-kb-reconnect-banner-stale-after-reconnect-plan.md`

Ref #4712 (banner origin — UI reconnect affordance for NULL-install workspaces)

## User-Brand Impact

**If this lands broken, the user experiences:** a permanent, false "your Knowledge Base can't sync" alarm on a KB that is in fact syncing every push — eroding trust in every status signal and prompting needless reconnect clicks (each a GitHub OAuth round-trip). Conversely, if over-corrected, a genuinely broken sync (the #4706 5-week silent freeze) shows no banner — the regression the #4712 banner exists to prevent. The fix fails toward the alarm to preserve the #4706 guard.

**Exposure if leaked:** N/A — read-only signal derivation; no new data surface, no new write, no PII. The install-id is already read on these paths; `resolveNeedsReconnect` returns only a boolean.

- **Brand-survival threshold:** aggregate pattern

(A single stale banner is an annoyance, not an incident; the brand cost accrues across every workspace-shared / org-install user, the growing majority as multi-tenant workspaces land. Sync itself is unaffected either way.)

## Changelog

- Fixed: the KB reconnect banner now clears once a workspace-scoped GitHub install can resume syncing, instead of staying displayed forever for org/workspace-shared installs whose per-user `github_installation_id` is NULL by design.

## Test plan

- [x] `resolveNeedsReconnect` unit suite (`test/lib/resolve-needs-reconnect.test.ts`) — AC1 (workspace credential resolves → false), AC2 (no credential → true, #4706 still alarms), AC3 (personal install short-circuits before RPC), AC4 (non-ready → false), plus undefined-install and fail-loud rejection-propagation cases
- [x] Route-level integration (`test/api/kb-tree.test.ts`) — `ready + null user install` with/without a resolvable workspace credential, and short-circuit assertion for the personal-install path
- [x] Existing `repo-status.test.ts`, `kb-reconnect-banner.test.tsx`, `kb-layout.test.tsx`, `settings-page.test.tsx` suites pass unchanged
- [x] `tsc --noEmit` clean; full `scripts/test-all.sh` green (92/92 suites)
- [x] AC5 — no new inline `repo_status === "ready"` re-derivation introduced

Generated with [Claude Code](https://claude.com/claude-code)
