### PR TITLE
feat(docs): evergreen freshness block (last_updated + byline + stat summary) + getting-started citations

### DIFF
--- a/knowledge-base/project/learnings/2026-06-01-eleventy-nunjucks-not-rendered-in-frontmatter-string-values.md
+++ b/knowledge-base/project/learnings/2026-06-01-eleventy-nunjucks-not-rendered-in-frontmatter-string-values.md
@@ -1,0 +1,45 @@
+# Learning: Eleventy does not re-render Nunjucks inside frontmatter string values
+
+## Problem
+
+Building a per-page stat-led summary (#3169/#3994), the natural approach was a
+frontmatter override like:
+
+```yaml
+pageSummary: "Soleur ships {{ stats.agents }} agents across 8 departments."
+```
+
+Eleventy does NOT evaluate `{{ ... }}` inside plain frontmatter *string values* —
+the literal `{{ stats.agents }}` braces leak into the rendered HTML.
+
+## Solution
+
+Build the dynamic variants inside the template/include from the data globals
+(`stats.*`) and select among them with a plain frontmatter *flag*, keeping a
+literal string override only for fully-static text:
+
+```njk
+{# page-freshness.njk #}
+{% if summaryRegister == "technical" %}
+  <p class="page-summary">Soleur: {{ stats.agents }} agents, {{ stats.skills }} skills…</p>
+{% elif pageSummary %}
+  <p class="page-summary">{{ pageSummary }}</p>   {# static text only #}
+{% else %}
+  <p class="page-summary">Soleur is a Company-as-a-Service platform: {{ stats.agents }}…</p>
+{% endif %}
+```
+
+Frontmatter carries the flag (`summaryRegister: technical`) or a static string —
+never an interpolation expression.
+
+## Key Insight
+
+Frontmatter values are data, not templates. Interpolation expressions only
+evaluate in the template body. To make per-page dynamic content driven by
+frontmatter, pass a *selector flag* (enum/boolean) and do the interpolation in
+the include. After any such change, grep the built site for leaked `{{`:
+`grep -rn '{{' _site/ && echo LEAK`.
+
+## Tags
+category: build-errors
+module: plugins/soleur/docs

--- a/knowledge-base/project/plans/2026-06-01-mktg-evergreen-freshness-plan.md
+++ b/knowledge-base/project/plans/2026-06-01-mktg-evergreen-freshness-plan.md
@@ -1,0 +1,106 @@
+# Plan — Evergreen Page Freshness + Stat-Led Summary + /getting-started/ Citations
+
+Date: 2026-06-01
+Branch: feat-one-shot-mktg-evergreen-freshness-3169-3170-3994-4410
+Closes: #3169, #3170, #3994, #4410
+
+## Problem
+
+Four P1 AEO issues converge on the evergreen marketing pages of the Eleventy
+docs site (`plugins/soleur/docs/`):
+
+- **#3169** — no stat-led summary paragraph below the hero (AEO citation target).
+- **#3170** — no visible "last updated" + author byline (E-E-A-T freshness).
+- **#3994** — same two gaps, framed against the AEO Presence ≥55% exit gate;
+  wants `last_updated` frontmatter rendered + a stat-led `<p>` under each H1.
+- **#4410** — `/getting-started/` specifically needs a 2-line plain-language
+  Soleur definition at the top + 2–3 external citations.
+
+## Canonical evergreen page set
+
+From #3169/#3170/#3994 (homepage + the 5 cited pages):
+
+1. `index.njk` (homepage, `/`)
+2. `pages/about.njk` (`/about/`)
+3. `pages/vision.njk` (`/vision/`)
+4. `pages/pricing.njk` (`/pricing/`)
+5. `pages/agents.njk` (`/agents/`)
+6. `pages/skills.njk` (`/skills/`)
+
+`/getting-started/` (`pages/getting-started.njk`) gets the freshness block too
+(it's evergreen) PLUS the #4410-specific definition + citations.
+
+## What already exists (reconciled — do NOT duplicate)
+
+- `site.author` (name/role/bio/image/sameAs) already in `site.json` — reuse for byline.
+- `base.njk` already emits `WebPage.dateModified` from `page.date` (JSON-LD).
+- Blog posts already have an `author-card` + per-entry `card-byline`; evergreen
+  pages do **not**. No existing `last_updated` / page-level byline / stat-led
+  summary on the 6 evergreen pages.
+- `/agents/` and `/skills/` already have a descriptive sub-hero `<p>` but no
+  single stat-dense extraction-target sentence and no freshness line.
+- `/getting-started/` already cites Claude Code plugins docs + links MCP/Claude
+  in body prose, but has no top-of-page plain definition and no explicit
+  Apache-2.0 / Claude Code docs / MCP spec citation cluster near the top.
+
+## Approach (DRY, frontmatter-driven)
+
+### New shared include: `_includes/page-freshness.njk`
+Renders, in order:
+1. `<p class="page-summary">…</p>` — stat-led summary. Text from per-page
+   frontmatter `pageSummary` (lets register vary per #3169); falls back to a
+   sensible default built from `stats.*`.
+2. `<p class="page-meta">` with a visible "Last updated <time datetime=…>" +
+   "By <a>Jean Deruelle</a>" byline. Date from frontmatter `last_updated`.
+
+Included by the 6 evergreen page templates + getting-started, placed
+immediately after the hero `<section>` (below the H1 → "below the hero").
+
+**Fixture safety:** the include reads only `site.author.name` (present in the
+jsonld-escaping fixture stub) and per-page frontmatter. It is included ONLY by
+real page templates, never by `base.njk`/`blog-post.njk`, so the fixture's
+`index.njk`/`test-post.njk` never reach it. No new `site.*` field → no fixture
+stub edit needed. Summary text lives in per-page frontmatter (not `site.*`).
+
+### dateModified alignment
+Set frontmatter `date: 2026-06-01` AND `last_updated: 2026-06-01` on each page.
+`date` feeds the existing `page.date` → JSON-LD `dateModified` + sitemap lastmod;
+`last_updated` feeds the visible line. Same value → consistent freshness signal.
+
+### #4410 /getting-started/
+- Add a `<p class="page-definition">` 2-line plain definition directly under H1.
+- Add a citations cluster (`.page-citations`) with 3 real external links,
+  verified to resolve:
+  - Apache-2.0: https://www.apache.org/licenses/LICENSE-2.0
+  - Claude Code docs: https://docs.claude.com/en/docs/claude-code
+  - MCP spec: https://modelcontextprotocol.io
+
+### CSS
+Add `.page-summary`, `.page-meta`, `.page-definition`, `.page-citations` to
+`docs/css/style.css`. These render below the fold (after hero) so NOT required
+in the critical-CSS inline block, but `.page-meta`/`.page-summary` sit just
+below `.page-hero` — keep them lightweight; no above-fold critical addition.
+
+## Tests — `test/seo-aeo-drift-guard.test.ts` (extend)
+
+New describe block asserting, for every evergreen built page:
+- exactly one `<p class="page-summary">` rendered, non-empty, length ≥ ~80 chars.
+- one `<p class="page-meta">` containing "Last updated", a `<time datetime=`
+  attribute, and the byline "Jean Deruelle".
+- summary appears AFTER the page H1 (below-hero ordering).
+- `checked > 0` counter guards against vacuous skip-all.
+
+For `/getting-started/`:
+- `<p class="page-definition">` present.
+- ≥2 external citations (count distinct external hrefs in `.page-citations`),
+  including apache.org + modelcontextprotocol.io + docs.claude.com.
+
+**CodeQL-safe:** no `.replace(/<[^>]+>/g,"")` tag-strip, no `&amp;→&` decode.
+Summaries are plain text → `.trim()` only; decode only `&#39;`/`&quot;` if ever
+needed. Count hrefs via attribute regex, not text extraction.
+
+## Verification
+- `npx @11ty/eleventy --output=/tmp/site-prB` exits 0.
+- `validate-seo.sh /tmp/site-prB` exits 0.
+- `bun test` drift-guard + jsonld-escaping + validate-seo all green.
+- full `plugins/soleur/test/` green.

--- a/knowledge-base/project/specs/feat-one-shot-mktg-evergreen-freshness-3169-3170-3994-4410/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-mktg-evergreen-freshness-3169-3170-3994-4410/tasks.md
@@ -1,0 +1,17 @@
+# Tasks — Evergreen Freshness + Stat-Led Summary + Citations
+
+Closes #3169, #3170, #3994, #4410. Plan:
+`knowledge-base/project/plans/2026-06-01-mktg-evergreen-freshness-plan.md`
+
+- [ ] T1 Add `_includes/page-freshness.njk` (stat-led summary + last-updated + byline).
+- [ ] T2 Add CSS for `.page-summary` / `.page-meta` / `.page-definition` / `.page-citations`.
+- [ ] T3 index.njk: `date`+`last_updated`+`pageSummary` frontmatter, include after hero.
+- [ ] T4 about.njk: same.
+- [ ] T5 vision.njk: same (technical register summary).
+- [ ] T6 pricing.njk: same.
+- [ ] T7 agents.njk: same (technical register; eleventyComputed page already).
+- [ ] T8 skills.njk: same.
+- [ ] T9 getting-started.njk: freshness block + plain definition + 3 citations (#4410).
+- [ ] T10 Extend drift-guard test: per-page summary+meta+byline; getting-started defn+citations; checked>0.
+- [ ] T11 Verify: eleventy build, validate-seo, bun test (drift/jsonld/validate-seo + full suite).
+- [ ] T12 Commit (conventional, no `Closes #N`).

--- a/plugins/soleur/docs/_includes/page-freshness.njk
+++ b/plugins/soleur/docs/_includes/page-freshness.njk
@@ -1,0 +1,34 @@
+{# page-freshness.njk — shared AEO freshness + authority block for evergreen pages.
+   Closes #3169 (stat-led summary), #3170 (last-updated + byline), #3994 (Presence gate).
+
+   Drivers (per-page frontmatter — NOT site.*, to keep the jsonld-escaping fixture stub
+   minimal; this partial is included ONLY by real page templates, never by base.njk):
+     - last_updated    : date string (e.g. 2026-06-01). Visible "Last updated" line +
+                         <time datetime>. Set `date:` to the same value so the existing
+                         base.njk WebPage.dateModified JSON-LD + sitemap lastmod align.
+     - summaryRegister : optional "technical" to select the technical-register summary
+                         variant (#3169 wants Technical register on Vision/Agents);
+                         anything else (or unset) → the general register. Both variants
+                         are built from live stats.* so the proof points never go stale.
+     - pageSummary     : optional literal override (plain text, NO {{ }} template syntax —
+                         frontmatter strings are not re-rendered). Wins over the variants.
+
+   Reads site.author.name only (present in the fixture stub) for the byline. #}
+{% if pageSummary %}
+  {% set _summary = pageSummary %}
+{% elif summaryRegister == "technical" %}
+  {% set _summary = "Soleur is a model-agnostic Company-as-a-Service orchestration engine: " + stats.agents + " specialist AI agents and " + stats.skills + " workflow skills across " + stats.departments + " departments, coordinated through one shared compounding knowledge base. Apache-2.0 open source, built on Claude Code and the Model Context Protocol (MCP)." %}
+{% else %}
+  {% set _summary = "Soleur is the Company-as-a-Service platform: " + stats.agents + " AI agents and " + stats.skills + " skills across " + stats.departments + " departments — engineering, marketing, legal, finance, operations, product, sales, and support — Apache-2.0 open source, built on Claude Code and the Model Context Protocol." %}
+{% endif %}
+<section class="page-freshness" aria-label="Page summary and last updated">
+  <div class="container">
+    <p class="page-summary">{{ _summary | safe }}</p>
+    {% if last_updated %}
+    <p class="page-meta">
+      <span class="page-meta-updated">Last updated <time datetime="{{ last_updated | dateToShort }}">{{ last_updated | readableDate }}</time></span>
+      <span class="page-meta-byline">By <a href="/about/" rel="author">{{ site.author.name }}</a></span>
+    </p>
+    {% endif %}
+  </div>
+</section>

--- a/plugins/soleur/docs/css/style.css
+++ b/plugins/soleur/docs/css/style.css
@@ -336,6 +336,58 @@
   }
   .community-text a { color: var(--color-accent); }
 
+  /* Evergreen page freshness block — stat-led summary + last-updated + byline.
+     Rendered immediately below .page-hero / .landing-hero on every evergreen
+     page (see _includes/page-freshness.njk). Below the fold → not inlined in
+     the base.njk critical-CSS block. */
+  .page-freshness {
+    padding: var(--space-6) var(--space-5) var(--space-4);
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-bg-secondary);
+  }
+  .page-summary {
+    font-size: 1.0625rem;
+    line-height: 1.7;
+    color: var(--color-text);
+    max-width: 760px;
+    margin-inline: auto;
+    text-align: center;
+  }
+  .page-meta {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--space-2) var(--space-5);
+    margin-top: var(--space-4);
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+  }
+  .page-meta a { color: var(--color-accent); }
+  .page-meta time { color: var(--color-text); }
+
+  /* /getting-started/ #4410 — plain-language definition + external citations */
+  .page-definition {
+    font-size: 1.0625rem;
+    line-height: 1.7;
+    color: var(--color-text);
+    max-width: 720px;
+    margin: var(--space-4) auto 0;
+  }
+  .page-citations {
+    margin: var(--space-4) auto 0;
+    max-width: 720px;
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    line-height: 1.7;
+  }
+  .page-citations ul {
+    list-style: none;
+    padding: 0;
+    margin: var(--space-2) 0 0;
+  }
+  .page-citations li { margin-top: var(--space-1); }
+  .page-citations a { color: var(--color-accent); }
+
   /* Footer social links */
   .footer-social {
     display: flex;

--- a/plugins/soleur/docs/index.njk
+++ b/plugins/soleur/docs/index.njk
@@ -4,6 +4,8 @@ seoTitle: "Soleur — AI Agents for Solo Founders | Every Department, One Platfo
 description: "Company-as-a-Service for solo founders. AI agents across 8 departments — engineering, marketing, legal, finance, operations, product, sales, support."
 layout: base.njk
 permalink: index.html
+date: 2026-06-01
+last_updated: 2026-06-01
 ---
 
     <!-- Hero -->
@@ -31,6 +33,8 @@ permalink: index.html
         <a href="/getting-started/" class="cta-link">Or try the open-source version <span aria-hidden="true">&rarr;</span></a>
       </div>
     </section>
+
+    {% include "page-freshness.njk" %}
 
     <!-- Stats Strip -->
     <section class="landing-stats" aria-label="Platform statistics">

--- a/plugins/soleur/docs/pages/about.njk
+++ b/plugins/soleur/docs/pages/about.njk
@@ -3,6 +3,8 @@ title: About Jean Deruelle
 description: "Jean Deruelle is the founder of Soleur, a Company-as-a-Service platform giving solo founders the operational capacity of a full organization through AI agents."
 layout: base.njk
 permalink: about/index.html
+date: 2026-06-01
+last_updated: 2026-06-01
 ---
 
     <section class="page-hero">
@@ -11,6 +13,8 @@ permalink: about/index.html
         <p>The founder behind Soleur.</p>
       </div>
     </section>
+
+    {% include "page-freshness.njk" %}
 
     <div class="container">
       <section id="jean-deruelle" class="category-section">

--- a/plugins/soleur/docs/pages/agents.njk
+++ b/plugins/soleur/docs/pages/agents.njk
@@ -2,6 +2,9 @@
 description: "AI agents for every business department -- engineering, marketing, legal, finance, operations, product, sales, and support. The full Soleur agent roster."
 layout: base.njk
 permalink: agents/
+date: 2026-06-01
+last_updated: 2026-06-01
+summaryRegister: technical
 eleventyComputed:
   title: "{{ stats.agents }} AI Agents for Solo Founders"
   seoTitle: "{{ stats.agents }} AI Agents for Solo Founders — Every Department | Soleur"
@@ -14,6 +17,8 @@ eleventyComputed:
         <p><span data-last-verified="{{ site.statsLastVerified }}">{{ stats.agents }} AI agents</span> across {{ stats.departments }} business departments — from code review and architecture to marketing strategy, legal compliance, and financial reporting.</p>
       </div>
     </section>
+
+    {% include "page-freshness.njk" %}
 
     <section class="content">
       <div class="container">

--- a/plugins/soleur/docs/pages/getting-started.njk
+++ b/plugins/soleur/docs/pages/getting-started.njk
@@ -3,6 +3,8 @@ title: Getting Started with Soleur
 description: "The AI that already knows your business. Soleur remembers every decision and customer so your team stops re-explaining context. Reserve access."
 layout: base.njk
 permalink: getting-started/
+date: 2026-06-01
+last_updated: 2026-06-01
 ---
 
     <!-- Hero -->
@@ -18,6 +20,23 @@ permalink: getting-started/
         <p class="cta-helper">Takes 30 seconds. We&rsquo;ll email when your spot opens.</p>
         <p class="hero-meta"><a href="mailto:ops@jikigai.com?subject=Soleur%20founding%20cohort%20intro">Founding cohort &mdash; limited to 10. Book intro <span aria-hidden="true">&rarr;</span></a><span class="hero-meta-fallback">(or email <code>ops@jikigai.com</code>)</span></p>
         <p class="hero-meta"><a href="/changelog/">Shipping weekly <span aria-hidden="true">&rarr;</span></a></p>
+      </div>
+    </section>
+
+    {% include "page-freshness.njk" %}
+
+    <!-- Plain-language definition + external citations (#4410) -->
+    <section class="page-freshness" aria-label="What Soleur is">
+      <div class="container">
+        <p class="page-definition">Soleur is an open-source <a href="https://docs.claude.com/en/docs/claude-code" rel="noopener noreferrer">Claude Code</a> platform that turns a solo founder into a full company: {{ stats.agents }} AI agents and {{ stats.skills }} workflow skills across {{ stats.departments }} departments, all sharing one knowledge base. You delegate work in plain language; the agents execute and remember every decision.</p>
+        <div class="page-citations">
+          <p>Built on open standards:</p>
+          <ul>
+            <li>Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0" rel="noopener noreferrer">Apache License 2.0</a> &mdash; free to use, modify, and self-host.</li>
+            <li>Runs on <a href="https://docs.claude.com/en/docs/claude-code" rel="noopener noreferrer">Claude Code</a>, Anthropic&rsquo;s agentic coding environment.</li>
+            <li>Connects tools and context through the <a href="https://modelcontextprotocol.io" rel="noopener noreferrer">Model Context Protocol (MCP)</a> open specification.</li>
+          </ul>
+        </div>
       </div>
     </section>
 

--- a/plugins/soleur/docs/pages/pricing.njk
+++ b/plugins/soleur/docs/pages/pricing.njk
@@ -6,6 +6,8 @@ layout: base.njk
 permalink: pricing/
 ogImage: pricing-og.png
 ogImageAlt: "Soleur Pricing — Every department. One price."
+date: 2026-06-01
+last_updated: 2026-06-01
 ---
 
     <!-- Hero -->
@@ -17,6 +19,8 @@ ogImageAlt: "Soleur Pricing — Every department. One price."
         <p class="hero-stat">{{ stats.agents }} Agents &middot; {{ stats.departments }} Departments &middot; {{ stats.skills }} Skills &middot; Compounding Knowledge</p>
       </div>
     </section>
+
+    {% include "page-freshness.njk" %}
 
     <!-- Waitlist CTA -->
     <section class="landing-cta" id="waitlist">

--- a/plugins/soleur/docs/pages/skills.njk
+++ b/plugins/soleur/docs/pages/skills.njk
@@ -3,6 +3,9 @@ title: Soleur Skills
 description: "Multi-step workflow skills for the Soleur platform — from feature development and code review to content writing, deployment, and agentic engineering."
 layout: base.njk
 permalink: skills/
+date: 2026-06-01
+last_updated: 2026-06-01
+summaryRegister: technical
 ---
 
     <section class="page-hero">
@@ -11,6 +14,8 @@ permalink: skills/
         <p><span data-last-verified="{{ site.statsLastVerified }}">{{ stats.skills }} workflow skills</span> that orchestrate agents, tools, and knowledge for complex multi-step tasks.</p>
       </div>
     </section>
+
+    {% include "page-freshness.njk" %}
 
     <section class="content">
       <div class="container">

--- a/plugins/soleur/docs/pages/vision.njk
+++ b/plugins/soleur/docs/pages/vision.njk
@@ -3,6 +3,9 @@ title: "Soleur Vision: Company-as-a-Service"
 description: "The Soleur vision: company-as-a-service for solo founders. AI agents across every department giving one person the operational capacity of a full organization."
 layout: base.njk
 permalink: vision/
+date: 2026-06-01
+last_updated: 2026-06-01
+summaryRegister: technical
 ---
 
     <section class="page-hero">
@@ -11,6 +14,8 @@ permalink: vision/
         <p>Where Soleur is headed.</p>
       </div>
     </section>
+
+    {% include "page-freshness.njk" %}
 
     <div class="container">
       <section class="category-section">

--- a/plugins/soleur/test/seo-aeo-drift-guard.test.ts
+++ b/plugins/soleur/test/seo-aeo-drift-guard.test.ts
@@ -673,3 +673,179 @@ describe("#3171 FAQPage JSON-LD matches the visible FAQ on every Q&A page", () =
     });
   }
 });
+
+// -- Test 14: #3169 / #3170 / #3994 evergreen freshness block ---------------
+// Every evergreen page must render, below the hero: (1) a stat-led summary
+// paragraph (AEO citation target, #3169), and (2) a visible "Last updated"
+// line + author byline (#3170), driven by per-page last_updated frontmatter
+// rendered through _includes/page-freshness.njk. The combination targets the
+// AEO Presence ≥55% exit gate (#3994). Shared partial → assert on every page.
+
+describe("#3169/#3170/#3994 evergreen pages render stat-led summary + last-updated byline below the hero", () => {
+  // Canonical evergreen set (homepage + the five cited pages) plus
+  // /getting-started/ (also evergreen; carries the #4410 block too).
+  const EVERGREEN: { label: string; rel: string }[] = [
+    { label: "homepage", rel: "index.html" },
+    { label: "/about/", rel: "about/index.html" },
+    { label: "/vision/", rel: "vision/index.html" },
+    { label: "/pricing/", rel: "pricing/index.html" },
+    { label: "/agents/", rel: "agents/index.html" },
+    { label: "/skills/", rel: "skills/index.html" },
+    { label: "/getting-started/", rel: "getting-started/index.html" },
+  ];
+
+  // Byline name is the single source of truth in site.json — pin to it so a
+  // rename in the data file must update the rendered byline in lockstep.
+  const authorName = () =>
+    (JSON.parse(readFileSync(SITE_JSON, "utf8")) as { author: { name: string } })
+      .author.name;
+
+  test("every evergreen page has exactly one stat-led summary + one last-updated byline, summary below the H1", () => {
+    let checked = 0;
+    for (const { label, rel } of EVERGREEN) {
+      const abs = resolve(SITE, rel);
+      if (!existsSync(abs)) continue; // build/permalink drift — skip, counter guards vacuity
+      checked++;
+      const html = readFileSync(abs, "utf8");
+
+      // (1) Stat-led summary — exactly one, non-trivial length. The summary is
+      // plain text inside the <p>; capture the inner text and .trim() only — no
+      // tag-strip regex (js/incomplete-multi-character-sanitization) and no
+      // &amp;->& decode (js/double-escaping). The summary contains no nested
+      // markup by construction (page-freshness.njk emits a bare text node).
+      const summaryMatches = [
+        ...html.matchAll(/<p class="page-summary">([\s\S]*?)<\/p>/g),
+      ];
+      expect(summaryMatches.length, `${label}: exactly one .page-summary`).toBe(1);
+      const summaryText = summaryMatches[0][1].trim();
+      expect(
+        summaryText.length,
+        `${label}: stat-led summary is a real sentence`,
+      ).toBeGreaterThan(80);
+      // Proof points the AEO audit wants extractable from the summary.
+      expect(summaryText, `${label}: summary names Company-as-a-Service`).toContain(
+        "Company-as-a-Service",
+      );
+      expect(
+        /Model Context Protocol/.test(summaryText),
+        `${label}: summary cites MCP`,
+      ).toBe(true);
+
+      // (2) Last-updated + byline block — exactly one, with a machine-readable
+      // <time datetime="YYYY-MM-DD"> and the author byline.
+      const metaMatches = [
+        ...html.matchAll(/<p class="page-meta">([\s\S]*?)<\/p>/g),
+      ];
+      expect(metaMatches.length, `${label}: exactly one .page-meta`).toBe(1);
+      const metaText = metaMatches[0][1];
+      expect(metaText, `${label}: visible "Last updated" label`).toContain(
+        "Last updated",
+      );
+      expect(
+        /<time datetime="\d{4}-\d{2}-\d{2}">/.test(metaText),
+        `${label}: machine-readable <time datetime>`,
+      ).toBe(true);
+      expect(metaText, `${label}: author byline`).toContain(authorName());
+
+      // (3) Ordering — the summary must sit BELOW the page H1 (below-the-hero).
+      const h1Pos = html.search(/<h1[ >]/);
+      const summaryPos = html.indexOf('class="page-summary"');
+      expect(h1Pos, `${label}: page has an H1`).toBeGreaterThanOrEqual(0);
+      expect(
+        summaryPos > h1Pos,
+        `${label}: stat-led summary renders below the hero H1`,
+      ).toBe(true);
+    }
+    expect(
+      checked,
+      "at least one evergreen page asserted against built HTML",
+    ).toBe(EVERGREEN.length);
+  });
+
+  test("every evergreen page's WebPage JSON-LD dateModified reflects the freshness date", () => {
+    let checked = 0;
+    for (const { label, rel } of EVERGREEN) {
+      const abs = resolve(SITE, rel);
+      if (!existsSync(abs)) continue;
+      checked++;
+      const html = readFileSync(abs, "utf8");
+      // base.njk emits a single JSON-LD script holding a @graph array; the
+      // WebPage node lives inside that graph, not as a top-level block.
+      const nodes = jsonLdBlocks(html).flatMap((b) => {
+        if (typeof b !== "object" || b === null) return [];
+        const graph = (b as { "@graph"?: unknown[] })["@graph"];
+        return Array.isArray(graph) ? graph : [b];
+      });
+      const webPage = nodes.find(
+        (b): b is { "@type": string; dateModified?: string } =>
+          typeof b === "object" &&
+          b !== null &&
+          (b as { "@type"?: string })["@type"] === "WebPage",
+      );
+      expect(webPage, `${label}: WebPage JSON-LD block`).toBeDefined();
+      expect(
+        typeof webPage!.dateModified,
+        `${label}: WebPage.dateModified present (freshness signal)`,
+      ).toBe("string");
+      // RFC-3339-ish — the dateToRfc3339 filter emits an ISO timestamp.
+      expect(
+        /^\d{4}-\d{2}-\d{2}T/.test(webPage!.dateModified!),
+        `${label}: dateModified is an ISO timestamp`,
+      ).toBe(true);
+    }
+    expect(checked, "dateModified asserted on every evergreen page").toBe(
+      EVERGREEN.length,
+    );
+  });
+});
+
+// -- Test 15: #4410 /getting-started/ definition + external citations -------
+// The single weakest page for AI-engine extractability gets a plain-language
+// Soleur definition at the top and ≥2 external citations (Apache-2.0, Claude
+// Code docs, MCP spec). Assert on the built page.
+
+describe("#4410 /getting-started/ has a plain-language definition + external citations", () => {
+  test("renders one .page-definition and ≥2 distinct external citation hrefs", () => {
+    const html = readSite("getting-started/index.html");
+
+    const defMatches = [
+      ...html.matchAll(/<p class="page-definition">([\s\S]*?)<\/p>/g),
+    ];
+    expect(defMatches.length, "exactly one .page-definition").toBe(1);
+    expect(
+      defMatches[0][1].trim().length,
+      "definition is a real plain-language sentence",
+    ).toBeGreaterThan(60);
+
+    // Count distinct external hrefs inside the citations block. Match on the
+    // href attribute only (no text extraction → no sanitization CodeQL flags).
+    const citeBlock = html.match(
+      /<div class="page-citations">([\s\S]*?)<\/div>/,
+    );
+    expect(citeBlock, ".page-citations block present").not.toBeNull();
+    const hrefs = new Set(
+      [...citeBlock![1].matchAll(/href="(https?:\/\/[^"]+)"/g)].map(
+        (m) => m[1],
+      ),
+    );
+    expect(
+      hrefs.size,
+      "≥2 distinct external citations in /getting-started/",
+    ).toBeGreaterThanOrEqual(2);
+
+    // Pin the three audit-mandated sources (host-anchored, not bare substring).
+    const hostMatched = (re: RegExp) => [...hrefs].some((h) => re.test(h));
+    expect(
+      hostMatched(/^https:\/\/www\.apache\.org\//),
+      "cites Apache-2.0 license",
+    ).toBe(true);
+    expect(
+      hostMatched(/^https:\/\/docs\.claude\.com\//),
+      "cites Claude Code docs",
+    ).toBe(true);
+    expect(
+      hostMatched(/^https:\/\/modelcontextprotocol\.io/),
+      "cites the MCP spec",
+    ).toBe(true);
+  });
+});

--- a/plugins/soleur/test/seo-aeo-drift-guard.test.ts
+++ b/plugins/soleur/test/seo-aeo-drift-guard.test.ts
@@ -844,7 +844,7 @@ describe("#4410 /getting-started/ has a plain-language definition + external cit
       "cites Claude Code docs",
     ).toBe(true);
     expect(
-      hostMatched(/^https:\/\/modelcontextprotocol\.io/),
+      hostMatched(/^https:\/\/modelcontextprotocol\.io(\/|$)/),
       "cites the MCP spec",
     ).toBe(true);
   });


### PR DESCRIPTION
## Summary
Drains 4 domain/marketing AEO issues from the Phase 4 milestone in one focused PR. Adds a shared `page-freshness.njk` partial rendering a stat-led summary, a visible "Last updated" line, and the founder byline on every evergreen page, driven by per-page frontmatter.

- **#3169** — stat-led summary paragraph below the hero on every evergreen page (general + technical register, built from live `stats.*`).
- **#3170** — visible "Last updated" timestamp + Jean Deruelle byline on every evergreen page (`<time datetime>`).
- **#3994** — `last_updated` frontmatter on every evergreen page + `WebPage.dateModified` in JSON-LD; targets the AEO Presence ≥55% gate.
- **#4410** — /getting-started/: top-of-page plain-language definition + 3 external citations (Apache-2.0, Claude Code docs, MCP spec).

Pages covered: homepage, /about/, /vision/, /pricing/, /agents/, /skills/, /getting-started/ (7).

Closes #3169
Closes #3170
Closes #3994
Closes #4410

## Changelog
- Every evergreen marketing page now surfaces a stat-led summary, a freshness timestamp, and an author byline — improving AI-extraction targets and freshness signals.
- /getting-started/ gains a plain-language Soleur definition and external citations.

## Test plan
- [x] `npx @11ty/eleventy` build clean
- [x] `validate-seo.sh` exits 0
- [x] `bun test plugins/soleur/test/` — 1572 pass / 0 fail (+ new drift-guards for summary/byline/dateModified/citations)
- [x] New test code CodeQL-safe (no tag-strip, no &amp; decode; verified via pattern self-check + semgrep)
- [x] All 3 external citation URLs verified HTTP 200; rel=noopener
- [x] Review: pattern-recognition CLEAN (empirically verified test non-vacuity)

Generated with [Claude Code](https://claude.com/claude-code)