### PR TITLE
feat(docs): keyword-rich titles + meta descriptions for /getting-started/ and /blog/

### DIFF
--- a/knowledge-base/project/plans/2026-06-01-mktg-titles-meta-plan.md
+++ b/knowledge-base/project/plans/2026-06-01-mktg-titles-meta-plan.md
@@ -1,0 +1,46 @@
+# Plan — Marketing docs SEO: titles + meta descriptions (#4405, #4406, #4407)
+
+Date: 2026-06-01
+Branch: feat-one-shot-mktg-titles-meta-4405-4406-4407
+Source audit: `knowledge-base/marketing/audits/soleur-ai/2026-05-25-content-audit.md` (C1/C3/C4, R1/R2/R5)
+
+## Rendering facts (from `plugins/soleur/docs/_includes/base.njk`)
+
+- `<title>` = `{% if seoTitle %}{{ seoTitle }}{% elif title == site.name %}{{ site.name }} - {{ site.tagline }}{% elif 'Soleur' in title %}{{ title }}{% else %}{{ title }} - {{ site.name }}{% endif %}`
+  - A per-page `seoTitle` is the authoritative override. Pages set it to control the exact `<title>`.
+- `<meta name="description">` = `{{ description or site.description }}`
+  - Always non-empty: a page with no `description` frontmatter falls back to `site.description`.
+  - Therefore #4407's "no meta description on any page" finding (a stale WebFetch artifact) is FALSE for the built output — every canonical page already renders a non-empty meta description.
+
+## Verification of #4407 (built-output audit)
+
+Built once with `npx @11ty/eleventy --output=/tmp/site-prC` (canonical config input). Every
+canonical (non-redirect) HTML page renders a non-empty `<meta name="description">`. The only
+HTML files lacking one are `<meta http-equiv="refresh">` redirect stubs (`pages/*.html`,
+dated `blog/YYYY-MM-DD-*` aliases) and the `articles/` collection wrapper — none are real
+routes. Conclusion: no per-page `description` additions are required; #4407 is satisfied by
+the existing fallback chain. Value-add is (a) confirming the audit-named pages carry bespoke
+descriptions and (b) a drift-guard so a future regression that drops the fallback is caught.
+
+## Changes
+
+1. `/getting-started/` (#4405 / R1, R2): add `seoTitle` = "Get Started with Soleur — Install
+   Your AI Organization in Two Commands"; replace `description` with the R2 copy.
+2. `/blog/` (#4406 / R5): replace `seoTitle` with the R5 category-keyword title; replace
+   `description` with the R5 founder-attributed meta.
+3. No other page frontmatter changes — every other sampled page already carries a bespoke
+   `seoTitle` (where needed) and `description`.
+
+## Tests (`plugins/soleur/test/seo-aeo-drift-guard.test.ts`)
+
+- Drift-guard: `/getting-started/` and `/blog/` `<title>` are NOT brand-only — each contains a
+  non-brand keyword token (asserted by stripping "Soleur"/"Blog"/separators and requiring a
+  meaningful remainder, plus pinning a specific keyword).
+- Drift-guard: every canonical (non-redirect) sampled/evergreen page renders a non-empty
+  `<meta name="description">` within a SERP-ish length envelope; loop carries a
+  `checked === expected` vacuity guard.
+
+## CodeQL constraints honored
+
+Attribute-capture regexes only (`<meta name="description" content="([^"]*)"`); no
+single-pass tag-strip; no `&amp;`→`&` decode; any `.test()` validation regex fully anchored.

--- a/knowledge-base/project/specs/feat-one-shot-mktg-titles-meta-4405-4406-4407/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-mktg-titles-meta-4405-4406-4407/tasks.md
@@ -1,0 +1,13 @@
+# Tasks — mktg titles + meta (#4405, #4406, #4407)
+
+- [x] Read base.njk to find title/description render + fallback chain
+- [x] Read audit R1/R2/R5 exact rewrite copy
+- [x] Build site, verify which built pages actually lack `<meta name="description">` (only redirect stubs do)
+- [x] #4405: add `seoTitle` (R1) + R2 `description` to `pages/getting-started.njk`
+- [x] #4406: replace `seoTitle` + `description` (R5) on `pages/blog.njk`
+- [x] #4407: confirm no per-page `description` additions needed (fallback covers all canonical pages)
+- [x] Add drift-guard: /getting-started/ + /blog/ titles are not brand-only
+- [x] Add drift-guard: every canonical sampled page renders non-empty meta description (with vacuity guard)
+- [x] Build (exit 0), validate-seo (exit 0), bun test suite green
+- [x] CodeQL self-check grep prints clean
+- [x] Commit (conventional, no Closes #N)

--- a/plugins/soleur/docs/pages/blog.njk
+++ b/plugins/soleur/docs/pages/blog.njk
@@ -1,7 +1,7 @@
 ---
 title: Blog
 seoTitle: "Soleur Blog — Company-as-a-Service, Agentic Engineering, and Building at Scale With AI Teams"
-description: "Field notes on building a billion-dollar company alone. Company-as-a-Service strategy, agentic engineering case studies, and engineering deep dives — by Jean Deruelle, founder of Soleur."
+description: "Field notes on building a billion-dollar company alone — Company-as-a-Service strategy, agentic engineering case studies, and engineering deep dives from Soleur."
 layout: base.njk
 permalink: blog/index.html
 ---

--- a/plugins/soleur/docs/pages/blog.njk
+++ b/plugins/soleur/docs/pages/blog.njk
@@ -1,7 +1,7 @@
 ---
 title: Blog
-seoTitle: "Blog — Soleur"
-description: "Insights on agentic engineering, company-as-a-service, and building at scale with AI teams."
+seoTitle: "Soleur Blog — Company-as-a-Service, Agentic Engineering, and Building at Scale With AI Teams"
+description: "Field notes on building a billion-dollar company alone. Company-as-a-Service strategy, agentic engineering case studies, and engineering deep dives — by Jean Deruelle, founder of Soleur."
 layout: base.njk
 permalink: blog/index.html
 ---

--- a/plugins/soleur/docs/pages/getting-started.njk
+++ b/plugins/soleur/docs/pages/getting-started.njk
@@ -1,6 +1,7 @@
 ---
 title: Getting Started with Soleur
-description: "The AI that already knows your business. Soleur remembers every decision and customer so your team stops re-explaining context. Reserve access."
+seoTitle: "Get Started with Soleur — Install Your AI Organization in Two Commands"
+description: "Install Soleur in two commands and run a full AI organization — marketing, legal, finance, operations, sales, and support — without hiring anyone."
 layout: base.njk
 permalink: getting-started/
 date: 2026-06-01

--- a/plugins/soleur/test/seo-aeo-drift-guard.test.ts
+++ b/plugins/soleur/test/seo-aeo-drift-guard.test.ts
@@ -849,3 +849,174 @@ describe("#4410 /getting-started/ has a plain-language definition + external cit
     ).toBe(true);
   });
 });
+
+// -- Test 16: #4405 / #4406 high-traffic <title> is not brand-only ----------
+// The audit (C1, C3) flagged /getting-started/ and /blog/ as brand-only titles
+// that forfeit all non-branded search traffic. R1/R5 rewrites surface
+// non-brand keywords. This guard fails if either title regresses to a
+// brand-only string (just "Soleur" + the page noun + separators).
+
+describe("#4405/#4406 /getting-started/ + /blog/ <title> surfaces non-brand keywords", () => {
+  // Each page must surface at least one of these non-brand keyword tokens in
+  // its <title>. Lowercased substring checks (no regex validation → no anchor
+  // CodeQL concern). Pulled from R1 (install/AI organization/two commands) and
+  // R5 (Company-as-a-Service/agentic/at scale/AI teams).
+  const PAGES: { label: string; rel: string; keywords: string[] }[] = [
+    {
+      label: "/getting-started/",
+      rel: "getting-started/index.html",
+      keywords: ["install", "ai organization", "two commands"],
+    },
+    {
+      label: "/blog/",
+      rel: "blog/index.html",
+      keywords: [
+        "company-as-a-service",
+        "agentic engineering",
+        "at scale",
+        "ai teams",
+      ],
+    },
+  ];
+
+  // Brand/structural tokens that, on their own, do NOT count as a search hook.
+  // If stripping these from the title leaves nothing, the title is brand-only.
+  const BRAND_NOISE = ["soleur", "blog", "—", "|", "-", "with"];
+
+  let checked = 0;
+  for (const { label, rel, keywords } of PAGES) {
+    test(`${label} <title> contains a non-brand keyword (not brand-only)`, () => {
+      const html = readSite(rel);
+      const title = extractTitle(html);
+      const lower = title.toLowerCase();
+
+      // (1) At least one audit-named keyword token is present.
+      const present = keywords.filter((k) => lower.includes(k));
+      expect(
+        present.length,
+        `${label}: <title> "${title}" surfaces no non-brand keyword (${keywords.join(", ")})`,
+      ).toBeGreaterThan(0);
+
+      // (2) Stripping brand/structural noise must leave real residual words —
+      // proves the title is more than "Blog — Soleur". Split on whitespace and
+      // drop pure-noise tokens; a brand-only title collapses to zero residual.
+      const residual = lower
+        .split(/\s+/)
+        .map((w) => w.trim())
+        .filter((w) => w.length > 0 && !BRAND_NOISE.includes(w));
+      expect(
+        residual.length,
+        `${label}: <title> "${title}" is brand-only after removing brand/structural tokens`,
+      ).toBeGreaterThan(0);
+
+      checked++;
+    });
+  }
+
+  test("both high-traffic titles were asserted (no vacuous skip)", () => {
+    expect(checked).toBe(PAGES.length);
+  });
+});
+
+// -- Test 17: #4407 every canonical sampled page renders a non-empty meta ----
+// The audit (C4) claimed no <meta name="description"> on any sampled page — a
+// stale WebFetch artifact. base.njk renders `{{ description or site.description }}`,
+// so every canonical page is non-empty by construction. This guard pins that:
+// a regression that drops the fallback (or a page that somehow renders an empty
+// description) fails. Redirect stubs (<meta http-equiv="refresh">) are excluded.
+
+describe("#4407 canonical sampled pages render a non-empty <meta name=\"description\">", () => {
+  // The nine audit-sampled pages plus the always-present home + company page.
+  const SAMPLED: { label: string; rel: string }[] = [
+    { label: "homepage", rel: "index.html" },
+    { label: "/pricing/", rel: "pricing/index.html" },
+    { label: "/getting-started/", rel: "getting-started/index.html" },
+    { label: "/agents/", rel: "agents/index.html" },
+    { label: "/skills/", rel: "skills/index.html" },
+    { label: "/vision/", rel: "vision/index.html" },
+    { label: "/about/", rel: "about/index.html" },
+    { label: "/community/", rel: "community/index.html" },
+    { label: "/blog/", rel: "blog/index.html" },
+    { label: "/changelog/", rel: "changelog/index.html" },
+    { label: "/legal/", rel: "legal/index.html" },
+    { label: "/company-as-a-service/", rel: "company-as-a-service/index.html" },
+  ];
+
+  // SERP envelope: a meta description should be a real sentence, not a single
+  // word, and not absurdly long. The lower bound (≥50) catches truncated/empty
+  // descriptions; the upper bound is generous (≤220) because audit-mandated
+  // copy (R5 /blog/) intentionally runs long. The homepage's stricter 120-160
+  // window is pinned separately by Test #2808 above.
+  const META_MIN = 50;
+  const META_MAX = 220;
+
+  // Attribute-capture extraction (no generic tag regex → avoids
+  // js/incomplete-multi-character-sanitization). Returns the first meta
+  // description content or null.
+  function metaDescription(html: string): string | null {
+    const m = [
+      ...html.matchAll(/<meta name="description" content="([^"]*)"/g),
+    ];
+    return m.length > 0 ? m[0][1] : null;
+  }
+
+  test("every sampled canonical page has exactly one non-empty meta description within SERP bounds", () => {
+    let checked = 0;
+    const seen = new Map<string, string>();
+    for (const { label, rel } of SAMPLED) {
+      const abs = resolve(SITE, rel);
+      if (!existsSync(abs)) continue; // build/permalink drift — counter guards vacuity
+      const html = readFileSync(abs, "utf8");
+
+      // Skip any redirect stub defensively (a sampled permalink should never be
+      // one, but exclude by mechanism rather than by trusting the path).
+      // Plain substring presence check (.includes, not a regex) — this is
+      // trusted built HTML and the marker can appear anywhere in <head>, so a
+      // regex anchor would be semantically wrong; .includes sidesteps the
+      // js/regex/missing-regexp-anchor pattern entirely.
+      if (html.length < 2000 && html.includes('http-equiv="refresh"')) {
+        continue;
+      }
+      checked++;
+
+      const matches = [
+        ...html.matchAll(/<meta name="description" content="([^"]*)"/g),
+      ];
+      expect(
+        matches.length,
+        `${label}: exactly one <meta name="description">`,
+      ).toBe(1);
+
+      const content = metaDescription(html)!.trim();
+      expect(
+        content.length,
+        `${label}: meta description is a real sentence (≥${META_MIN})`,
+      ).toBeGreaterThanOrEqual(META_MIN);
+      expect(
+        content.length,
+        `${label}: meta description within ${META_MAX} chars`,
+      ).toBeLessThanOrEqual(META_MAX);
+
+      seen.set(label, content);
+    }
+
+    // The two audit-named pages must carry their bespoke (non-default) copy —
+    // proves they did not silently fall back to site.description.
+    const siteDefault = (
+      JSON.parse(readFileSync(SITE_JSON, "utf8")) as { description: string }
+    ).description;
+    for (const label of ["/getting-started/", "/blog/"]) {
+      const d = seen.get(label);
+      expect(d, `${label}: present in sampled set`).toBeTruthy();
+      expect(
+        d,
+        `${label}: carries a bespoke meta, not the site default`,
+      ).not.toBe(siteDefault);
+    }
+
+    expect(
+      checked,
+      "every sampled canonical page asserted against built HTML",
+    ).toBe(SAMPLED.length);
+  });
+});


### PR DESCRIPTION
## Summary
Drains 3 domain/marketing SEO issues from the Phase 4 milestone in one focused PR.

- **#4405** — /getting-started/ title rewritten to surface non-brand keywords ("Get Started with Soleur — Install Your AI Organization in Two Commands") + keyword-rich meta description.
- **#4406** — /blog/ index title + meta rewritten to surface category keywords (Company-as-a-Service, agentic engineering, case studies) — was brand-only "Blog — Soleur".
- **#4407** — Verified `base.njk` already renders `<meta name="description">` (via `{{ description or site.description }}`) on every canonical route; the audit's "no meta" finding was a stale WebFetch artifact (only refresh-redirect stubs lack one, by design). Added a drift-guard locking non-empty meta on all sampled pages so a future regression fails loudly.

Closes #4405
Closes #4406
Closes #4407

## Changelog
- /getting-started/ and /blog/ now have keyword-rich, non-brand-only titles and meta descriptions for better SEO/SERP capture.
- New drift-guards: titles must surface a non-brand keyword; every sampled page must render a non-empty meta description within SERP length bounds.

## Test plan
- [x] `npx @11ty/eleventy` build clean
- [x] `validate-seo.sh` exits 0
- [x] `bun test plugins/soleur/test/` — 1576 pass / 0 fail
- [x] New test code CodeQL-safe (attribute-capture regex, anchored .test(), no tag-strip/&amp; decode — self-check CLEAN)
- [x] /blog/ meta trimmed toward the SERP ceiling on review

Generated with [Claude Code](https://claude.com/claude-code)