### PR TITLE
fix(delegations): align grant_byok_delegation RPC args so "Share a key" toggle works

### DIFF
--- a/apps/web-platform/app/api/workspace/delegations/route.ts
+++ b/apps/web-platform/app/api/workspace/delegations/route.ts
@@ -76,13 +76,19 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "not_owner" }, { status: 403 });
   }
 
+  // Canonical 7-arg contract from migration 064 (mirrors scripts/byok-grant.ts).
+  // PostgREST resolves rpc() by argument NAME — these MUST match the function
+  // signature exactly or resolution fails (PGRST202 → 400 → silent toggle revert).
+  // hourly defaults to the daily cap (RPC rejects NULL with 22003; the UI exposes
+  // only a daily stepper). expires_at is null = never expires (UI-created grants).
   const { data, error } = await service.rpc("grant_byok_delegation", {
     p_grantor_user_id: user.id,
     p_grantee_user_id: body.granteeUserId,
     p_workspace_id: body.workspaceId,
-    p_daily_cap_cents: body.dailyCapCents,
-    p_hourly_cap_cents: body.hourlyCapCents ?? null,
-    p_created_by_user_id: user.id,
+    p_daily_usd_cap_cents: body.dailyCapCents,
+    p_hourly_usd_cap_cents: body.hourlyCapCents ?? body.dailyCapCents,
+    p_expires_at: null,
+    p_actor_user_id: user.id,
   });
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 });

--- a/apps/web-platform/components/settings/delegation-toggle.tsx
+++ b/apps/web-platform/components/settings/delegation-toggle.tsx
@@ -122,6 +122,13 @@ function OwnerDelegationControl({
           window.alert("Couldn't share a key with this member. Please try again.");
         }
       }
+    } catch (err) {
+      // A thrown fetch (offline, DNS/TLS failure, aborted request) bypasses the
+      // !res.ok branches above; without this catch the toggle would snap back
+      // to its prior state with no signal — the same silent no-op AC5 fixes for
+      // non-OK responses. Surface it the same way.
+      console.error("[delegation-toggle] request failed:", err);
+      window.alert("Something went wrong. Please check your connection and try again.");
     } finally {
       setLoading(false);
     }

--- a/apps/web-platform/components/settings/delegation-toggle.tsx
+++ b/apps/web-platform/components/settings/delegation-toggle.tsx
@@ -97,7 +97,14 @@ function OwnerDelegationControl({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ delegationId: delegation.id, reason: "grantor_revoke" }),
         });
-        if (res.ok) setActive(false);
+        if (res.ok) {
+          setActive(false);
+        } else {
+          // AC5: never silently swallow a non-OK response — a failed write must
+          // be operator-visible, not a toggle that snaps back with no signal.
+          console.error("[delegation-toggle] revoke failed:", res.status);
+          window.alert("Couldn't stop sharing the key. Please try again.");
+        }
       } else {
         const res = await fetch("/api/workspace/delegations", {
           method: "POST",
@@ -108,7 +115,12 @@ function OwnerDelegationControl({
             dailyCapCents: capCents,
           }),
         });
-        if (res.ok) setActive(true);
+        if (res.ok) {
+          setActive(true);
+        } else {
+          console.error("[delegation-toggle] grant failed:", res.status);
+          window.alert("Couldn't share a key with this member. Please try again.");
+        }
       }
     } finally {
       setLoading(false);

--- a/apps/web-platform/test/api-delegation-grant-route.test.ts
+++ b/apps/web-platform/test/api-delegation-grant-route.test.ts
@@ -136,11 +136,19 @@ describe("POST /api/workspace/delegations (grant — AC1/AC2/AC3/AC4)", () => {
     mockMembershipMaybeSingle.mockResolvedValue({ data: null });
     const res = await POST(makeRequest(validBody()));
     expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "not_owner" });
     expect(mockServiceRpc).not.toHaveBeenCalled();
   });
 
   test("400 missing_fields when a required field is absent", async () => {
     const res = await POST(makeRequest({ workspaceId: WORKSPACE_ID, granteeUserId: GRANTEE_ID }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "missing_fields" });
+    expect(mockServiceRpc).not.toHaveBeenCalled();
+  });
+
+  test("400 missing_fields when dailyCapCents is 0 (falsy guard, never reaches the RPC)", async () => {
+    const res = await POST(makeRequest(validBody({ dailyCapCents: 0 })));
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: "missing_fields" });
     expect(mockServiceRpc).not.toHaveBeenCalled();

--- a/apps/web-platform/test/api-delegation-grant-route.test.ts
+++ b/apps/web-platform/test/api-delegation-grant-route.test.ts
@@ -1,0 +1,181 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// fix (feat-one-shot-share-a-key-toggle-not-enabling): POST /api/workspace/
+// delegations creates a BYOK delegation by calling the SECURITY DEFINER RPC
+// grant_byok_delegation on the SERVICE-ROLE client. The route shipped (PR
+// #4508) with named args that do not match migration 064's signature
+// (p_daily_cap_cents / p_hourly_cap_cents / p_created_by_user_id, and
+// p_expires_at omitted), so PostgREST fails function resolution → 400 → the
+// "Share a key" toggle silently reverts. This test pins the exact 7-key
+// canonical arg object (mirrors byok-grant.ts:173-180) so the regression
+// cannot reappear. AC4.
+
+const {
+  mockGetUser,
+  mockServiceRpc,
+  mockMembershipMaybeSingle,
+  mockValidateOrigin,
+  mockRejectCsrf,
+  mockIsByokDelegationsEnabled,
+  mockResolveCurrentOrganizationId,
+} = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockServiceRpc: vi.fn(),
+  mockMembershipMaybeSingle: vi.fn(),
+  mockValidateOrigin: vi.fn(() => ({ valid: true, origin: "https://app.soleur.ai" })),
+  mockRejectCsrf: vi.fn(() => new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 })),
+  mockIsByokDelegationsEnabled: vi.fn(async () => true),
+  mockResolveCurrentOrganizationId: vi.fn(async () => "org-1"),
+}));
+
+// Service client exposes both .from(...) (the workspace_members owner check)
+// and .rpc(...) (grant_byok_delegation). The membership chain is recursive
+// (.select/.eq return the chain) and terminates at .maybeSingle().
+const membershipChain = {
+  select: vi.fn(() => membershipChain),
+  eq: vi.fn(() => membershipChain),
+  maybeSingle: mockMembershipMaybeSingle,
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } })),
+  createServiceClient: vi.fn(() => ({
+    from: vi.fn(() => membershipChain),
+    rpc: mockServiceRpc,
+  })),
+}));
+
+vi.mock("@/lib/auth/validate-origin", () => ({
+  validateOrigin: mockValidateOrigin,
+  rejectCsrf: mockRejectCsrf,
+}));
+
+vi.mock("@/lib/feature-flags/server", () => ({
+  isByokDelegationsEnabled: mockIsByokDelegationsEnabled,
+}));
+
+vi.mock("@/server/workspace-resolver", () => ({
+  resolveCurrentOrganizationId: mockResolveCurrentOrganizationId,
+}));
+
+// byok-delegation-ui-resolver is imported by the route module (GET path);
+// stub it so the module loads without a real DB client.
+vi.mock("@/server/byok-delegation-ui-resolver", () => ({
+  resolveGrantorDelegations: vi.fn(async () => []),
+}));
+
+import { POST } from "@/app/api/workspace/delegations/route";
+
+const OWNER_ID = "owner-uuid";
+const GRANTEE_ID = "grantee-uuid";
+const WORKSPACE_ID = "workspace-uuid";
+const DAILY_CAP = 2000;
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request("https://app.soleur.ai/api/workspace/delegations", {
+    method: "POST",
+    headers: { origin: "https://app.soleur.ai", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return { workspaceId: WORKSPACE_ID, granteeUserId: GRANTEE_ID, dailyCapCents: DAILY_CAP, ...overrides };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockValidateOrigin.mockReturnValue({ valid: true, origin: "https://app.soleur.ai" });
+  mockRejectCsrf.mockReturnValue(new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 }));
+  mockIsByokDelegationsEnabled.mockResolvedValue(true);
+  mockResolveCurrentOrganizationId.mockResolvedValue("org-1");
+  mockGetUser.mockResolvedValue({ data: { user: { id: OWNER_ID, email: "owner@example.com" } } });
+  mockMembershipMaybeSingle.mockResolvedValue({ data: { role: "owner" } });
+  mockServiceRpc.mockResolvedValue({ data: "delegation-uuid", error: null });
+});
+
+describe("POST /api/workspace/delegations (grant — AC1/AC2/AC3/AC4)", () => {
+  test("calls grant_byok_delegation with the exact 7-key canonical arg object", async () => {
+    const res = await POST(makeRequest(validBody()));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ delegationId: "delegation-uuid" });
+    expect(mockServiceRpc).toHaveBeenCalledTimes(1);
+    expect(mockServiceRpc).toHaveBeenCalledWith("grant_byok_delegation", {
+      p_grantor_user_id: OWNER_ID,
+      p_grantee_user_id: GRANTEE_ID,
+      p_workspace_id: WORKSPACE_ID,
+      p_daily_usd_cap_cents: DAILY_CAP,
+      p_hourly_usd_cap_cents: DAILY_CAP, // AC2: defaults to daily when client omits hourly
+      p_expires_at: null, // AC3: UI-created delegations never expire
+      p_actor_user_id: OWNER_ID,
+    });
+    // Guard against the broken legacy names reappearing.
+    const arg = mockServiceRpc.mock.calls[0][1] as Record<string, unknown>;
+    expect(arg).not.toHaveProperty("p_daily_cap_cents");
+    expect(arg).not.toHaveProperty("p_hourly_cap_cents");
+    expect(arg).not.toHaveProperty("p_created_by_user_id");
+  });
+
+  test("honours an explicit hourlyCapCents when the client supplies one (AC2)", async () => {
+    await POST(makeRequest(validBody({ hourlyCapCents: 500 })));
+    expect(mockServiceRpc).toHaveBeenCalledWith(
+      "grant_byok_delegation",
+      expect.objectContaining({ p_hourly_usd_cap_cents: 500, p_daily_usd_cap_cents: DAILY_CAP }),
+    );
+  });
+
+  test("403 not_owner when the caller is not the workspace owner", async () => {
+    mockMembershipMaybeSingle.mockResolvedValue({ data: { role: "member" } });
+    const res = await POST(makeRequest(validBody()));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "not_owner" });
+    expect(mockServiceRpc).not.toHaveBeenCalled();
+  });
+
+  test("403 not_owner when the caller is not a member at all", async () => {
+    mockMembershipMaybeSingle.mockResolvedValue({ data: null });
+    const res = await POST(makeRequest(validBody()));
+    expect(res.status).toBe(403);
+    expect(mockServiceRpc).not.toHaveBeenCalled();
+  });
+
+  test("400 missing_fields when a required field is absent", async () => {
+    const res = await POST(makeRequest({ workspaceId: WORKSPACE_ID, granteeUserId: GRANTEE_ID }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "missing_fields" });
+    expect(mockServiceRpc).not.toHaveBeenCalled();
+  });
+
+  test("401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(makeRequest(validBody()));
+    expect(res.status).toBe(401);
+    expect(mockServiceRpc).not.toHaveBeenCalled();
+  });
+
+  test("404 when the flag is disabled", async () => {
+    mockIsByokDelegationsEnabled.mockResolvedValue(false);
+    const res = await POST(makeRequest(validBody()));
+    expect(res.status).toBe(404);
+    expect(mockServiceRpc).not.toHaveBeenCalled();
+  });
+
+  test("403 (CSRF) when origin invalid", async () => {
+    mockValidateOrigin.mockReturnValue({ valid: false, origin: "https://evil.example" });
+    const res = await POST(makeRequest(validBody()));
+    expect(res.status).toBe(403);
+    expect(mockServiceRpc).not.toHaveBeenCalled();
+  });
+
+  test("400 with the RPC error message when the grant RPC fails", async () => {
+    mockServiceRpc.mockResolvedValue({
+      data: null,
+      error: { message: "grant_byok_delegation: hourly_usd_cap_cents out of range" },
+    });
+    const res = await POST(makeRequest(validBody()));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "grant_byok_delegation: hourly_usd_cap_cents out of range",
+    });
+  });
+});

--- a/apps/web-platform/test/delegation-toggle.test.tsx
+++ b/apps/web-platform/test/delegation-toggle.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// fix (feat-one-shot-share-a-key-toggle-not-enabling): the owner "Share a key"
+// toggle must NEVER silently no-op. A non-OK response OR a thrown fetch (offline,
+// DNS/TLS failure, aborted request) must surface a visible error and leave the
+// toggle in its prior state — the original bug was a silent revert with no signal.
+// AC5 + the user-impact review's network-throw finding.
+
+import { DelegationToggle } from "@/components/settings/delegation-toggle";
+
+const baseProps = {
+  memberUserId: "member-1",
+  memberEmail: "harry@jikigai.com",
+  workspaceId: "ws-1",
+  isOwner: true,
+  delegation: null,
+  isSelf: false,
+  flagEnabled: true,
+};
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let alertMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn(async () => new Response(JSON.stringify({ delegationId: "d-1" }), { status: 200 }));
+  alertMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  vi.stubGlobal("alert", alertMock);
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+function getSwitch() {
+  return screen.getByRole("switch", { name: /Fund harry's runs/i });
+}
+
+describe("DelegationToggle — owner grant control", () => {
+  it("turns the toggle on after a successful grant POST", async () => {
+    render(<DelegationToggle {...baseProps} />);
+    const toggle = getSwitch();
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    await userEvent.click(toggle);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/workspace/delegations",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(getSwitch()).toHaveAttribute("aria-checked", "true");
+    expect(alertMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a visible error and stays off when the grant POST returns non-OK", async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ error: "not_owner" }), { status: 403 }));
+    render(<DelegationToggle {...baseProps} />);
+
+    await userEvent.click(getSwitch());
+
+    expect(alertMock).toHaveBeenCalledTimes(1);
+    expect(getSwitch()).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("surfaces a visible error and stays off when fetch itself rejects (offline/network throw)", async () => {
+    // Regression guard for the user-impact finding: a thrown fetch must not be a
+    // silent no-op. Without the catch in handleToggle this assertion fails.
+    fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+    render(<DelegationToggle {...baseProps} />);
+
+    await userEvent.click(getSwitch());
+
+    expect(alertMock).toHaveBeenCalledTimes(1);
+    expect(getSwitch()).toHaveAttribute("aria-checked", "false");
+  });
+});

--- a/knowledge-base/project/learnings/bug-fixes/2026-06-01-postgrest-rpc-named-arg-mismatch-silent-client-revert.md
+++ b/knowledge-base/project/learnings/bug-fixes/2026-06-01-postgrest-rpc-named-arg-mismatch-silent-client-revert.md
@@ -1,0 +1,80 @@
+---
+category: bug-fixes
+module: web-platform/api/workspace/delegations
+tags: [supabase, postgrest, rpc, byok-delegations, silent-failure, named-arguments]
+---
+
+# Learning: PostgREST `rpc()` named-arg mismatch fails resolution → 400 → silent client revert
+
+## Problem
+
+The "Share a key" toggle on Settings → Members → Team did nothing when an org owner
+clicked it: the toggle flipped back to off, no delegation was created, no error shown.
+
+`POST /api/workspace/delegations` called the SECURITY DEFINER RPC `grant_byok_delegation`
+with named arguments that did not match migration 064's signature, and omitted a required
+one:
+
+```ts
+// broken
+service.rpc("grant_byok_delegation", {
+  p_grantor_user_id, p_grantee_user_id, p_workspace_id,
+  p_daily_cap_cents,        // RPC expects p_daily_usd_cap_cents
+  p_hourly_cap_cents,       // RPC expects p_hourly_usd_cap_cents
+  p_created_by_user_id,     // RPC expects p_actor_user_id
+  // MISSING: p_expires_at (required, no DEFAULT)
+});
+```
+
+## Root cause
+
+PostgREST resolves `rpc()` calls by the **set of supplied argument names**. A name set
+that doesn't match any function overload fails to resolve (PGRST202 "Could not find the
+function … in the schema cache"). The route mapped that error to HTTP 400, and the client
+(`delegation-toggle.tsx`) only flipped state `if (res.ok)` — so on a 400 it did nothing and
+never reset, producing the silent "click does nothing" revert.
+
+Two compounding silencers:
+- `tsc` cannot catch it — supabase-js `.rpc(name, params)` takes an untyped params object.
+- The client swallowed the non-OK response with no error path.
+
+## Solution
+
+1. **Caller-only fix.** Align the route's named args to the canonical 7-arg 064 contract,
+   already proven by `scripts/byok-grant.ts:173-180`: `p_daily_usd_cap_cents`,
+   `p_hourly_usd_cap_cents` (defaulting to the daily cap — the RPC rejects NULL hourly with
+   `22003` and the UI exposes only a daily stepper), `p_expires_at: null` (never expires),
+   `p_actor_user_id: user.id`. No migration/schema/RPC change.
+2. **Pin the contract in a test.** New `test/api-delegation-grant-route.test.ts` asserts
+   `toHaveBeenCalledWith` the exact 7-key arg object + negative `not.toHaveProperty` on the
+   three broken legacy names. Confirmed RED against the broken route, GREEN after.
+3. **Stop the silent swallow.** `delegation-toggle.tsx` `handleToggle` now surfaces non-OK
+   responses AND a thrown `fetch` (offline/DNS/TLS) via `console.error` + `window.alert`,
+   matching `team-membership-list.tsx`'s remove-member pattern.
+
+## Key Insight
+
+A `.rpc()` call against an untyped supabase client is an **unchecked stringly-typed contract**
+across the TS↔Postgres boundary — same class as untyped `.select()` against a nonexistent
+column (`2026-06-01-untyped-supabase-select-nonexistent-column-ships-green.md`). When you add
+or edit a route `.rpc()` call, pin the exact arg-name set in a `toHaveBeenCalledWith` test and
+cross-check it against the migration body and any proven sibling caller — neither `tsc` nor a
+select-arg-discarding mock will catch a name drift, and a client that only acts on `res.ok`
+turns the resulting 400 into an invisible no-op.
+
+Corollary: any client write handler whose only success path is `if (res.ok)` MUST have an
+`else` AND a `catch` — a thrown fetch bypasses the `!res.ok` branch entirely.
+
+## Session Errors
+
+1. **Bash CWD drift** — `cd apps/web-platform` returned `No such file or directory` because
+   the Bash tool's working directory had already moved into `apps/web-platform` from a prior
+   call (CWD persists across Bash tool calls; shell state like env vars does not).
+   **Recovery:** re-ran the command from the already-correct CWD; no work lost.
+   **Prevention:** already covered by the work skill's guidance to chain `cd <worktree-abs> &&
+   <cmd>` in a single Bash call with absolute paths rather than relying on prior CWD. One-off;
+   no new rule warranted.
+
+## Tags
+category: bug-fixes
+module: web-platform/api/workspace/delegations

--- a/knowledge-base/project/plans/2026-06-01-fix-share-a-key-delegation-rpc-param-mismatch-plan.md
+++ b/knowledge-base/project/plans/2026-06-01-fix-share-a-key-delegation-rpc-param-mismatch-plan.md
@@ -130,18 +130,18 @@ the DB, so the named-arg mismatch was invisible to CI. `tsc` cannot catch it bec
 
 ### Pre-merge (PR)
 
-- [ ] **AC1 — RPC param alignment.** `route.ts` POST calls `grant_byok_delegation` with exactly the
+- [x] **AC1 — RPC param alignment.** `route.ts` POST calls `grant_byok_delegation` with exactly the
   064 named args: `p_grantor_user_id`, `p_grantee_user_id`, `p_workspace_id`,
   `p_daily_usd_cap_cents`, `p_hourly_usd_cap_cents`, `p_expires_at`, `p_actor_user_id`. Verify:
   `grep -nE 'p_daily_cap_cents|p_hourly_cap_cents|p_created_by_user_id' apps/web-platform/app/api/workspace/delegations/route.ts` returns **zero** matches.
-- [ ] **AC2 — hourly cap supplied.** Because `p_hourly_usd_cap_cents` is mandatory (no DEFAULT) and
+- [x] **AC2 — hourly cap supplied.** Because `p_hourly_usd_cap_cents` is mandatory (no DEFAULT) and
   the 064 RPC rejects `NULL` (`ERRCODE 22003`, range `[1, daily]`), the route MUST send a non-null
   hourly cap. Default to the daily cap when the client omits `hourlyCapCents`
   (`p_hourly_usd_cap_cents: body.hourlyCapCents ?? body.dailyCapCents`). Verify via AC4 test asserting
   the value passed.
-- [ ] **AC3 — expiry supplied.** Route sends `p_expires_at: null` (UI-created delegations never
+- [x] **AC3 — expiry supplied.** Route sends `p_expires_at: null` (UI-created delegations never
   expire, matching `byok-grant.ts` "never" default).
-- [ ] **AC4 — route POST test (RED→GREEN).** New test
+- [x] **AC4 — route POST test (RED→GREEN).** New test
   `apps/web-platform/test/api-delegation-grant-route.test.ts` (mirrors the
   `api-delegation-withdraw-route.test.ts` mock pattern: `mockServiceRpc`, `mockGetUser`,
   `mockValidateOrigin`, `mockIsByokDelegationsEnabled`, `mockResolveCurrentOrganizationId`).
@@ -152,14 +152,14 @@ the DB, so the named-arg mismatch was invisible to CI. `tsc` cannot catch it bec
   Covers: happy path (200 + `delegationId`), non-owner (403 `not_owner`), missing fields (400),
   flag-off (404). Runner: `cd apps/web-platform && ./node_modules/.bin/vitest run test/api-delegation-grant-route.test.ts`
   (file lives under `test/**/*.test.ts` per `vitest.config.ts:44` node-project include glob).
-- [ ] **AC5 — client surfaces failures.** `delegation-toggle.tsx` `handleToggle` no longer silently
+- [x] **AC5 — client surfaces failures.** `delegation-toggle.tsx` `handleToggle` no longer silently
   drops a non-OK POST/DELETE response. On `!res.ok`, surface a visible error (inline message or
   `window.alert`, matching the existing `team-membership-list.tsx` remove-member pattern at line 114)
   so a future RPC/authz failure is operator-visible rather than a silent no-op. The toggle's `active`
   state is only set on success (already true; keep it).
-- [ ] **AC6 — no other miscalls.** `grep -rn 'grant_byok_delegation' apps/web-platform --include=*.ts | grep -v migrations | grep -v test`
+- [x] **AC6 — no other miscalls.** `grep -rn 'grant_byok_delegation' apps/web-platform --include=*.ts | grep -v migrations | grep -v test`
   shows only `route.ts` and `byok-grant.ts`, both using the canonical names.
-- [ ] **AC7 — full suite green.** `cd apps/web-platform && <package.json test script>` passes
+- [x] **AC7 — full suite green.** `cd apps/web-platform && <package.json test script>` passes
   (use the script in `apps/web-platform/package.json`, not a hardcoded runner; check
   `apps/web-platform/bunfig.toml` does not block discovery).
 

--- a/knowledge-base/project/plans/2026-06-01-fix-share-a-key-delegation-rpc-param-mismatch-plan.md
+++ b/knowledge-base/project/plans/2026-06-01-fix-share-a-key-delegation-rpc-param-mismatch-plan.md
@@ -7,6 +7,24 @@ requires_cpo_signoff: true
 
 # 🐛 fix: "Share a key" toggle no-ops — POST /api/workspace/delegations sends wrong RPC param names
 
+## Enhancement Summary
+
+**Deepened on:** 2026-06-01
+**Sections enhanced:** Overview, Acceptance Criteria, Risks & Mitigations
+**Passes run:** mandatory gates (4.6 User-Brand Impact ✓, 4.7 Observability ✓, 4.8 PAT-shaped ✓ — none tripped), precedent-diff gate (4.4), implementation-realism verification (4.45)
+
+### Key Improvements
+
+1. **Verified the load-bearing claims against the code, not memory.** Confirmed `grant_byok_delegation` (064) is the sole definition, has zero parameter DEFAULTs, and that `p_hourly_usd_cap_cents IS NULL → RAISE 22003` — so AC2's hourly-cap-default is mandatory, not stylistic.
+2. **Confirmed the service-role admin path requirement.** The 064 RPC's `auth.uid() IS NULL` branch (service-role, which the route uses via `createServiceClient`) requires BOTH `p_grantor_user_id` AND `p_actor_user_id` non-null. The broken route omits `p_actor_user_id` (sends `p_created_by_user_id`), compounding the resolution failure — fix must supply `p_actor_user_id: user.id`.
+3. **Precedent-diff: route should mirror `byok-grant.ts` exactly.** Both call via service-role client; `byok-grant.ts:173-180` is the proven canonical contract. No novel pattern.
+4. **INSERT-trigger reality check.** `byok_delegations_same_workspace` (BEFORE INSERT) requires grantor + grantee both be workspace members — satisfied for the reported case (owner funding an existing member). No additional precondition needed.
+
+### New Considerations Discovered
+
+- The route's `body` type already declares `hourlyCapCents?: number`, so the `?? body.dailyCapCents` fallback needs no client-contract change.
+- The `byok_delegations` table is a WORM ledger (`byok_delegations_no_update`/`no_mutate` triggers). The grant path is a plain INSERT — unaffected by WORM update-shape rules. Do NOT touch the triggers.
+
 ## Overview
 
 On **Settings → Members → Team**, an org owner clicking the **"Share a key"** toggle next to a
@@ -229,6 +247,34 @@ discoverability_test:
   command: "cd apps/web-platform && ./node_modules/.bin/vitest run test/api-delegation-grant-route.test.ts"
   expected_output: "test passes; mockServiceRpc called with the 7-key canonical arg object incl. p_expires_at"
 ```
+
+## Risks & Mitigations
+
+### Precedent-diff (RPC permissioning + named-arg contract)
+
+`grant_byok_delegation` is invoked from exactly two call sites; the fix makes them identical in arg shape.
+
+| Param | `byok-grant.ts:173-180` (working precedent) | `route.ts:79-86` (current, broken) | `route.ts` (after fix) |
+| --- | --- | --- | --- |
+| `p_grantor_user_id` | `grantorId` | `user.id` ✓ | `user.id` |
+| `p_grantee_user_id` | `granteeId` | `body.granteeUserId` ✓ | `body.granteeUserId` |
+| `p_workspace_id` | `workspaceId` | `body.workspaceId` ✓ | `body.workspaceId` |
+| daily cap | `p_daily_usd_cap_cents` | `p_daily_cap_cents` ✗ | `p_daily_usd_cap_cents` |
+| hourly cap | `p_hourly_usd_cap_cents` | `p_hourly_cap_cents` ✗ | `p_hourly_usd_cap_cents: body.hourlyCapCents ?? body.dailyCapCents` |
+| expiry | `p_expires_at` | *(absent)* ✗ | `p_expires_at: null` |
+| actor | `p_actor_user_id` | `p_created_by_user_id` ✗ | `p_actor_user_id: user.id` |
+
+Both call sites use a **service-role client** (`createServiceClient()` / service-role key), so both take the RPC's `auth.uid() IS NULL` admin branch (064:428-435), which mandates non-null `p_grantor_user_id` + `p_actor_user_id`. The fix satisfies this; the current route cannot (it omits `p_actor_user_id`). Pattern is **not novel** — copy the proven precedent.
+
+### Failure mechanism (why "nothing happens")
+
+- supabase-js `.rpc(name, params)` posts `params` to PostgREST, which resolves the function by **named arguments**. A param set that doesn't match any overload → PGRST202 (`Could not find the function … in the schema cache`). `route.ts:88` maps this to `NextResponse.json({ error }, { status: 400 })`. The client (`delegation-toggle.tsx:111`) only flips `setActive(true)` `if (res.ok)` — on a 400 it does nothing and never resets, so the toggle visibly reverts to off with no message. AC5 makes this class of failure operator-visible going forward.
+
+### Risks
+
+- **Low blast radius.** Pure caller fix; no schema/RPC/migration/infra change. The RPC, its triggers, and the working CLI path are untouched.
+- **Hourly-cap default is a deliberate UX choice** (hourly = daily when the UI exposes only a daily stepper). Documented in Sharp Edges; not a copy from the CLI (which takes an explicit hourly arg).
+- **No new exposure surface.** The corrected path keeps the existing owner-only authz gate (`route.ts:75-77`) and the RPC's cross-tenant + WORM INSERT triggers.
 
 ## Sharp Edges
 

--- a/knowledge-base/project/plans/2026-06-01-fix-share-a-key-delegation-rpc-param-mismatch-plan.md
+++ b/knowledge-base/project/plans/2026-06-01-fix-share-a-key-delegation-rpc-param-mismatch-plan.md
@@ -1,0 +1,248 @@
+---
+type: fix
+lane: single-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+---
+
+# 🐛 fix: "Share a key" toggle no-ops — POST /api/workspace/delegations sends wrong RPC param names
+
+## Overview
+
+On **Settings → Members → Team**, an org owner clicking the **"Share a key"** toggle next to a
+keyless member (e.g. `jean.deruelle@gmail.com`, role "Member", "No API key yet") does nothing —
+the toggle flips back to off and no delegation is created.
+
+**Root cause (verified, not hypothesized):** the POST branch of
+`apps/web-platform/app/api/workspace/delegations/route.ts` invokes the Postgres RPC
+`grant_byok_delegation` with **named arguments that do not match the function's signature**, and
+**omits a required argument**. PostgREST resolves `rpc()` calls by argument *name*; a name set that
+doesn't match any function overload fails to resolve (PGRST202 "Could not find the function … in
+the schema cache"). The route maps that error to HTTP 400, and the client's
+`if (res.ok) setActive(true)` silently swallows the non-OK response — so the toggle reverts with
+no visible error. That is precisely the "click does nothing" symptom.
+
+### The mismatch
+
+Canonical RPC signature — `apps/web-platform/supabase/migrations/064_byok_delegations.sql:412-417`
+(the **only** definition; never redefined by a later migration). **No parameter has a DEFAULT**, so
+all seven are mandatory:
+
+```sql
+grant_byok_delegation(
+  p_grantor_user_id      uuid,
+  p_grantee_user_id      uuid,
+  p_workspace_id         uuid,
+  p_daily_usd_cap_cents  int,
+  p_hourly_usd_cap_cents int,
+  p_expires_at           timestamptz,
+  p_actor_user_id        uuid
+) RETURNS uuid
+```
+
+What the route currently sends — `route.ts:79-86`:
+
+```ts
+service.rpc("grant_byok_delegation", {
+  p_grantor_user_id: user.id,
+  p_grantee_user_id: body.granteeUserId,
+  p_workspace_id: body.workspaceId,
+  p_daily_cap_cents: body.dailyCapCents,        // ✗ RPC expects p_daily_usd_cap_cents
+  p_hourly_cap_cents: body.hourlyCapCents ?? null, // ✗ RPC expects p_hourly_usd_cap_cents
+  p_created_by_user_id: user.id,                // ✗ RPC expects p_actor_user_id
+  // ✗ MISSING: p_expires_at (required, no DEFAULT)
+});
+```
+
+Three names are wrong (`p_daily_cap_cents`, `p_hourly_cap_cents`, `p_created_by_user_id`) and
+`p_expires_at` is absent entirely. **Any one** of these breaks PostgREST function resolution.
+
+### Working precedent (the correct contract already exists)
+
+The CLI script `apps/web-platform/scripts/byok-grant.ts:173-180` calls the same RPC correctly:
+
+```ts
+supabase.rpc("grant_byok_delegation", {
+  p_grantor_user_id: grantorId,
+  p_grantee_user_id: granteeId,
+  p_workspace_id: workspaceId,
+  p_daily_usd_cap_cents: args.capCents,
+  p_hourly_usd_cap_cents: args.hourlyCapCents,
+  p_expires_at: expiresAt,          // null = never expires (column is nullable)
+  p_actor_user_id: actorId,
+});
+```
+
+The route is the **sole outlier**. The fix is to align the route's named arguments to this
+canonical 7-parameter contract. No migration, no schema change, no new infrastructure.
+
+### Why it shipped broken
+
+The POST route was added in PR #4508 (BYOK PR-B — UI surfaces) but never got a route-level test
+that asserts the RPC call shape. The only delegation-route test today is
+`api-delegation-withdraw-route.test.ts` (covers DELETE/withdraw, not POST). The resolver tests mock
+the DB, so the named-arg mismatch was invisible to CI. `tsc` cannot catch it because supabase-js
+`rpc()` accepts an untyped params object.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (from feature description / inferred) | Reality (verified in repo) | Plan response |
+| --- | --- | --- |
+| Toggle UI is broken / never wired | UI is fully wired: `delegation-toggle.tsx` → `team-membership-list.tsx` → POST `/api/workspace/delegations`. This is broken *behavior*, not never-built. | Behavioral fix in the route handler, not a build. |
+| The bug is a precondition ("grantor must have a key") | No grantor-key precondition exists in `grant_byok_delegation` (064) — only cap-range + cross-tenant/WORM trigger checks. The RPC is reached with a malformed param set and fails to resolve. | Fix is the RPC param-name alignment; no precondition logic involved. |
+| A recent migration may have changed the RPC signature | `grant_byok_delegation` is defined exactly once (064) and never `CREATE OR REPLACE`-d again (grep across all migrations). | Align route to the 064 signature. |
+| `p_expires_at` might be optional | RPC has zero DEFAULTs; all 7 params mandatory. `byok-grant.ts` passes `expiresAt` (nullable → "never"). | Pass `p_expires_at: null` from the route (delegations created via the UI never expire — matches CLI default behavior). |
+
+## User-Brand Impact
+
+- **If this lands broken, the user experiences:** an org owner who wants to fund a teammate's
+  agent runs clicks the "Share a key" toggle and it silently does nothing — the single highest-value
+  team action (paying for a keyless member so they can run tasks) is 100% non-functional with no
+  error shown. The owner concludes the product is broken.
+- **If this leaks, the user's data / workflow / money is exposed via:** N/A for the leak axis — this
+  fix corrects a failed write, it does not widen any read/exposure surface. The corrected path still
+  routes through the existing owner-only authz check (`route.ts:75-77`) and the RPC's cross-tenant +
+  WORM triggers.
+- **Brand-survival threshold:** `single-user incident` — a single owner hitting a dead core team
+  feature on their first real attempt is a brand-survival event for a small-team product.
+
+> CPO sign-off required at plan time before `/work` begins (`requires_cpo_signoff: true`). `user-impact-reviewer` runs at review time.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] **AC1 — RPC param alignment.** `route.ts` POST calls `grant_byok_delegation` with exactly the
+  064 named args: `p_grantor_user_id`, `p_grantee_user_id`, `p_workspace_id`,
+  `p_daily_usd_cap_cents`, `p_hourly_usd_cap_cents`, `p_expires_at`, `p_actor_user_id`. Verify:
+  `grep -nE 'p_daily_cap_cents|p_hourly_cap_cents|p_created_by_user_id' apps/web-platform/app/api/workspace/delegations/route.ts` returns **zero** matches.
+- [ ] **AC2 — hourly cap supplied.** Because `p_hourly_usd_cap_cents` is mandatory (no DEFAULT) and
+  the 064 RPC rejects `NULL` (`ERRCODE 22003`, range `[1, daily]`), the route MUST send a non-null
+  hourly cap. Default to the daily cap when the client omits `hourlyCapCents`
+  (`p_hourly_usd_cap_cents: body.hourlyCapCents ?? body.dailyCapCents`). Verify via AC4 test asserting
+  the value passed.
+- [ ] **AC3 — expiry supplied.** Route sends `p_expires_at: null` (UI-created delegations never
+  expire, matching `byok-grant.ts` "never" default).
+- [ ] **AC4 — route POST test (RED→GREEN).** New test
+  `apps/web-platform/test/api-delegation-grant-route.test.ts` (mirrors the
+  `api-delegation-withdraw-route.test.ts` mock pattern: `mockServiceRpc`, `mockGetUser`,
+  `mockValidateOrigin`, `mockIsByokDelegationsEnabled`, `mockResolveCurrentOrganizationId`).
+  Asserts `mockServiceRpc` is called with the exact 7-key canonical arg object via
+  `toHaveBeenCalledWith("grant_byok_delegation", { p_grantor_user_id: …, p_grantee_user_id: …,
+  p_workspace_id: …, p_daily_usd_cap_cents: …, p_hourly_usd_cap_cents: …, p_expires_at: null,
+  p_actor_user_id: … })`. The test MUST fail against the current route and pass after the fix.
+  Covers: happy path (200 + `delegationId`), non-owner (403 `not_owner`), missing fields (400),
+  flag-off (404). Runner: `cd apps/web-platform && ./node_modules/.bin/vitest run test/api-delegation-grant-route.test.ts`
+  (file lives under `test/**/*.test.ts` per `vitest.config.ts:44` node-project include glob).
+- [ ] **AC5 — client surfaces failures.** `delegation-toggle.tsx` `handleToggle` no longer silently
+  drops a non-OK POST/DELETE response. On `!res.ok`, surface a visible error (inline message or
+  `window.alert`, matching the existing `team-membership-list.tsx` remove-member pattern at line 114)
+  so a future RPC/authz failure is operator-visible rather than a silent no-op. The toggle's `active`
+  state is only set on success (already true; keep it).
+- [ ] **AC6 — no other miscalls.** `grep -rn 'grant_byok_delegation' apps/web-platform --include=*.ts | grep -v migrations | grep -v test`
+  shows only `route.ts` and `byok-grant.ts`, both using the canonical names.
+- [ ] **AC7 — full suite green.** `cd apps/web-platform && <package.json test script>` passes
+  (use the script in `apps/web-platform/package.json`, not a hardcoded runner; check
+  `apps/web-platform/bunfig.toml` does not block discovery).
+
+## Files to Edit
+
+- `apps/web-platform/app/api/workspace/delegations/route.ts` — fix the POST `rpc()` call: rename
+  `p_daily_cap_cents`→`p_daily_usd_cap_cents`, `p_hourly_cap_cents`→`p_hourly_usd_cap_cents`,
+  `p_created_by_user_id`→`p_actor_user_id`; add `p_expires_at: null`; default hourly to daily when
+  omitted. Update the `body` type to reflect the cap field names the client actually sends
+  (`dailyCapCents`, `hourlyCapCents?`) — already correct; no client contract change needed.
+- `apps/web-platform/components/settings/delegation-toggle.tsx` — surface non-OK fetch responses in
+  `handleToggle` (AC5) instead of silently swallowing them.
+
+## Files to Create
+
+- `apps/web-platform/test/api-delegation-grant-route.test.ts` — POST route test (AC4).
+
+## Open Code-Review Overlap
+
+None. (`gh issue list --label code-review --state open` checked against `route.ts` and
+`delegation-toggle.tsx` — no open scope-outs touch these files.)
+
+## Test Scenarios
+
+1. **RED:** run the new grant-route test against the unmodified route → fails because
+   `mockServiceRpc` receives `{p_daily_cap_cents, p_hourly_cap_cents, p_created_by_user_id}` not the
+   canonical names (and no `p_expires_at`).
+2. **GREEN:** apply the route fix → test passes; `toHaveBeenCalledWith` matches the 7-key object.
+3. **Non-owner POST** → 403 `not_owner` (authz unchanged).
+4. **Flag-off POST** → 404 `not_found`.
+5. **Client UX:** simulate `res.ok === false` → AC5 surfaces a visible error; toggle stays off but
+   the user is informed (no silent no-op).
+
+## Domain Review
+
+**Domains relevant:** Product, Engineering
+
+### Engineering
+
+**Status:** reviewed
+**Assessment:** Pure bug fix in an already-provisioned API route + a client UX guard. No schema
+change, no new infra, no new dependency. Risk is low and bounded to the delegation POST path; the
+fix copies a contract already proven by `byok-grant.ts`. The one judgment call (hourly cap default =
+daily cap) is forced by the RPC's non-null `[1, daily]` constraint and matches the toggle's
+single-input UX (operator sets only a daily cap via the numeric stepper).
+
+### Product/UX Gate
+
+**Tier:** advisory
+**Decision:** auto-accepted (pipeline)
+**Agents invoked:** none
+**Skipped specialists:** none
+**Pencil available:** N/A
+
+#### Findings
+
+Modifies behavior of an existing control (no new page/component/flow; `delegation-toggle.tsx` and
+`team-membership-list.tsx` already exist). Mechanical escalation check: no new file under
+`components/**/*.tsx`, `app/**/page.tsx`, or `app/**/layout.tsx` (the one new file is a test). Tier
+is ADVISORY; pipeline auto-accept. CPO sign-off still required at plan time per the single-user-incident
+threshold (frontmatter `requires_cpo_signoff: true`).
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "grant_byok_delegation RPC success rate on POST /api/workspace/delegations (delegationId returned, HTTP 200)"
+  cadence: "per owner toggle-on action"
+  alert_target: "Sentry — route catch path already reports RPC errors via NextResponse 400; add explicit Sentry mirror on the error branch"
+  configured_in: "apps/web-platform/app/api/workspace/delegations/route.ts (POST error branch)"
+error_reporting:
+  destination: "Sentry (existing web-platform integration)"
+  fail_loud: true   # AC5 surfaces non-OK to the operator; server error branch mirrors RPC error.message to Sentry
+failure_modes:
+  - mode: "RPC param-name regression reintroduced"
+    detection: "api-delegation-grant-route.test.ts toHaveBeenCalledWith assertion fails in CI"
+    alert_route: "CI red on PR"
+  - mode: "RPC returns error (cap out of range, cross-tenant trigger, WORM)"
+    detection: "route POST returns 400 with error.message; client shows visible error (AC5)"
+    alert_route: "Sentry mirror on the route error branch + operator-visible UI error"
+logs:
+  where: "Next.js server logs (Vercel/container stdout) + Sentry breadcrumbs on the POST route"
+  retention: "per existing platform log retention"
+discoverability_test:
+  command: "cd apps/web-platform && ./node_modules/.bin/vitest run test/api-delegation-grant-route.test.ts"
+  expected_output: "test passes; mockServiceRpc called with the 7-key canonical arg object incl. p_expires_at"
+```
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder text,
+  or omits the threshold will fail `deepen-plan` Phase 4.6. (Filled above.)
+- **Hourly cap default is a design choice, not a copy from `byok-grant.ts`.** The CLI takes an
+  explicit `hourlyCapCents`; the UI toggle exposes only a daily stepper. The RPC requires a non-null
+  hourly cap in `[1, daily]`. Defaulting hourly = daily is the safe interpretation (hourly cap never
+  more restrictive than what the owner set as daily). If a different default is desired, it must be a
+  conscious decision — do not pass `null` (RPC raises `22003`).
+- **Verify the route's `body` type vs. client payload.** The client (`delegation-toggle.tsx:104-109`)
+  sends `{ workspaceId, granteeUserId, dailyCapCents }` (no `hourlyCapCents`). The route `body` type
+  already lists `hourlyCapCents?` as optional — confirm the `?? body.dailyCapCents` fallback at the
+  RPC boundary, not a non-null assertion.
+- **Do not change the RPC.** Migration 064 is the source of truth and is consumed correctly by
+  `byok-grant.ts`. Changing the RPC signature to match the route would break the working CLI and the
+  `064-byok-delegations.test.ts` / tenant-isolation tests. Fix the caller, not the callee.

--- a/knowledge-base/project/specs/feat-one-shot-share-a-key-toggle-not-enabling/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-share-a-key-toggle-not-enabling/session-state.md
@@ -1,0 +1,19 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-one-shot-share-a-key-toggle-not-enabling/knowledge-base/project/plans/2026-06-01-fix-share-a-key-delegation-rpc-param-mismatch-plan.md
+- Status: complete
+
+### Errors
+None.
+
+### Decisions
+- Root cause is a verified RPC named-argument mismatch, not a UI/precondition bug. `POST /api/workspace/delegations` (route.ts:79-86) calls `grant_byok_delegation` with `p_daily_cap_cents`, `p_hourly_cap_cents`, `p_created_by_user_id` and omits required `p_expires_at`; the canonical signature (migration 064) expects `p_daily_usd_cap_cents`, `p_hourly_usd_cap_cents`, `p_expires_at`, `p_actor_user_id`. PostgREST fails resolution → 400 → client's `if (res.ok)` silently swallows it → toggle reverts. Working precedent: byok-grant.ts:173-180.
+- Fix is caller-only. Align the route's named args to the 064 contract; no migration, schema, RPC, or infra change. Do NOT touch the RPC (would break the working CLI and WORM/tenant-isolation tests).
+- Hourly-cap default = daily cap (RPC rejects NULL hourly with ERRCODE 22003; UI exposes only a daily stepper) — deliberate documented UX choice.
+- Secondary UX fix in scope (AC5): delegation-toggle.tsx `handleToggle` should surface non-OK responses instead of silently no-op'ing.
+- TDD-first via new route test (api-delegation-grant-route.test.ts) asserting the exact 7-key RPC call shape. Threshold: single-user incident; requires_cpo_signoff: true.
+
+### Components Invoked
+- Skill: soleur:plan
+- Skill: soleur:deepen-plan

--- a/knowledge-base/project/specs/feat-one-shot-share-a-key-toggle-not-enabling/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-share-a-key-toggle-not-enabling/tasks.md
@@ -1,0 +1,36 @@
+# Tasks — fix: "Share a key" toggle no-ops (delegation RPC param mismatch)
+
+Plan: `knowledge-base/project/plans/2026-06-01-fix-share-a-key-delegation-rpc-param-mismatch-plan.md`
+
+## Phase 1 — RED (failing test first)
+
+- [ ] 1.1 Create `apps/web-platform/test/api-delegation-grant-route.test.ts` mirroring the mock
+  pattern in `apps/web-platform/test/api-delegation-withdraw-route.test.ts`
+  (`mockServiceRpc`, `mockGetUser`, `mockValidateOrigin`, `mockIsByokDelegationsEnabled`,
+  `mockResolveCurrentOrganizationId`).
+- [ ] 1.2 Assert `mockServiceRpc` called with `toHaveBeenCalledWith("grant_byok_delegation", { p_grantor_user_id, p_grantee_user_id, p_workspace_id, p_daily_usd_cap_cents, p_hourly_usd_cap_cents, p_expires_at: null, p_actor_user_id })`.
+- [ ] 1.3 Add cases: 200 happy path (returns `delegationId`), 403 non-owner, 400 missing fields, 404 flag-off.
+- [ ] 1.4 Run `cd apps/web-platform && ./node_modules/.bin/vitest run test/api-delegation-grant-route.test.ts` → confirm it FAILS against current route.
+
+## Phase 2 — GREEN (fix the route)
+
+- [ ] 2.1 In `apps/web-platform/app/api/workspace/delegations/route.ts` POST, rename RPC args:
+  `p_daily_cap_cents`→`p_daily_usd_cap_cents`, `p_hourly_cap_cents`→`p_hourly_usd_cap_cents`,
+  `p_created_by_user_id`→`p_actor_user_id`.
+- [ ] 2.2 Add `p_expires_at: null`.
+- [ ] 2.3 Default hourly to daily when client omits it: `p_hourly_usd_cap_cents: body.hourlyCapCents ?? body.dailyCapCents`.
+- [ ] 2.4 Re-run the grant-route test → GREEN.
+- [ ] 2.5 Verify: `grep -nE 'p_daily_cap_cents|p_hourly_cap_cents|p_created_by_user_id' apps/web-platform/app/api/workspace/delegations/route.ts` returns zero.
+
+## Phase 3 — Client UX guard
+
+- [ ] 3.1 In `apps/web-platform/components/settings/delegation-toggle.tsx` `handleToggle`, surface
+  non-OK POST/DELETE responses (inline error or `window.alert`, matching the remove-member pattern
+  in `team-membership-list.tsx:114`). Keep `setActive(true)` only on success.
+
+## Phase 4 — Verify
+
+- [ ] 4.1 `grep -rn 'grant_byok_delegation' apps/web-platform --include=*.ts | grep -v migrations | grep -v test` → only `route.ts` + `byok-grant.ts`, both canonical names.
+- [ ] 4.2 Run the full web-platform test suite via `apps/web-platform/package.json` test script → green.
+- [ ] 4.3 (Optional, if dev Supabase reachable) end-to-end: owner toggles "Share a key" on a keyless
+  member → delegation row created, toggle stays on.


### PR DESCRIPTION
## Summary

The "Share a key" toggle on **Settings → Members → Team** did nothing when an org owner clicked it — the toggle flipped back to off and no delegation was created.

**Root cause:** `POST /api/workspace/delegations` called the `grant_byok_delegation` RPC with named arguments that did not match migration 064's signature (`p_daily_cap_cents` / `p_hourly_cap_cents` / `p_created_by_user_id`) and omitted the required `p_expires_at`. PostgREST resolves `rpc()` by argument **name**, so the call failed to resolve (PGRST202 → HTTP 400). The client only flipped the toggle `if (res.ok)`, so the 400 became an invisible no-op — the reported symptom.

The fix aligns the route to the canonical 7-arg 064 contract already proven by `scripts/byok-grant.ts`. Caller-only — no migration/schema/RPC change.

## User-Brand Impact

- **If this lands broken, the user experiences:** an org owner clicks "Share a key" to fund a teammate's agent runs and it silently does nothing — the highest-value team action is 100% non-functional with no error shown.
- **If this leaks, the user's data/workflow/money is exposed via:** N/A — this fix corrects a failed write; it does not widen any read/exposure surface. The corrected path keeps the existing owner-only authz gate and the RPC's cross-tenant + WORM INSERT triggers.
- **Brand-survival threshold:** single-user incident — a single owner hitting a dead core team feature on first use is a brand-survival event for a small-team product.

## Changelog

### Web Platform
- Fix `POST /api/workspace/delegations` to call `grant_byok_delegation` with the canonical 064 arg names (`p_daily_usd_cap_cents`, `p_hourly_usd_cap_cents` defaulting to the daily cap, `p_expires_at: null`, `p_actor_user_id`).
- `delegation-toggle.tsx` now surfaces non-OK grant/revoke responses **and** thrown fetches (offline/DNS/TLS) via a visible error instead of silently reverting.

## Test plan

- [x] New `test/api-delegation-grant-route.test.ts` pins the exact 7-key RPC arg object (RED against the broken route, GREEN after); covers owner/non-owner/missing-fields/flag-off/CSRF/RPC-error.
- [x] New `test/delegation-toggle.test.tsx` covers grant success, non-OK error surfacing, and the network-throw regression guard.
- [x] `tsc --noEmit` clean; full web-platform vitest suite green (7828 passed).
- [x] semgrep SAST clean on changed source.

Generated with [Claude Code](https://claude.com/claude-code)
