### PR TITLE
fix(web): workspaces no longer display as "Untitled" — org rename RPC + default names + backfill

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/settings/team/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/settings/team/page.tsx
@@ -4,6 +4,7 @@ import { resolveTeamMembershipPageData } from "@/server/team-membership-resolver
 import { TeamMembershipList } from "@/components/settings/team-membership-list";
 import { InviteMemberAction } from "@/components/settings/invite-member-action";
 import { PendingInvitesList } from "@/components/settings/pending-invites-list";
+import { RenameWorkspaceAction } from "@/components/settings/rename-workspace-action";
 
 // AC-A: flag OFF → HTTP 404 via notFound(). Flagsmith single-control gate
 // lives inside resolveTeamMembershipPageData. The "/dashboard/settings/team"
@@ -52,10 +53,16 @@ export default async function TeamMembershipPage() {
   return (
     <div>
       <h1 className="mb-2 text-2xl font-semibold text-soleur-text-primary">Team</h1>
-      <p className="mb-8 text-sm text-soleur-text-secondary">
+      <p className="mb-6 text-sm text-soleur-text-secondary">
         People who can act in this workspace. All members share the same
         workspace data, agents, and billing.
       </p>
+
+      <RenameWorkspaceAction
+        organizationId={data.organizationId}
+        organizationName={data.organizationName}
+        isOwner={isOwner}
+      />
 
       <div className="rounded-lg border border-soleur-border-default">
         <div className="flex items-center justify-between border-b border-soleur-border-default px-6 py-4">

--- a/apps/web-platform/app/(dashboard)/dashboard/settings/team/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/settings/team/page.tsx
@@ -72,7 +72,11 @@ export default async function TeamMembershipPage() {
               {memberCount === 1 ? "1 member" : `${memberCount} members`}
             </p>
           </div>
-          <InviteMemberAction workspaceId={data.workspaceId} />
+          <InviteMemberAction
+            workspaceId={data.workspaceId}
+            organizationId={data.organizationId}
+            organizationName={data.organizationName}
+          />
         </div>
 
         <TeamMembershipList

--- a/apps/web-platform/app/api/workspace/rename/route.ts
+++ b/apps/web-platform/app/api/workspace/rename/route.ts
@@ -4,6 +4,7 @@ import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 import { isTeamWorkspaceInviteEnabled, type Identity } from "@/lib/feature-flags/server";
 import { resolveTeamMembershipPageData } from "@/server/team-membership-resolver";
 import { renameOrganization } from "@/server/workspace-membership";
+import { validateWorkspaceName } from "@/lib/workspace-name";
 
 // POST /api/workspace/rename
 // Body: { organizationId, name }
@@ -45,8 +46,8 @@ export async function POST(request: Request) {
   if (typeof organizationId !== "string" || typeof name !== "string") {
     return NextResponse.json({ error: "invalid_body" }, { status: 400 });
   }
-  const trimmed = name.trim();
-  if (trimmed.length === 0 || trimmed.length > 60) {
+  const validated = validateWorkspaceName(name);
+  if (!validated.ok) {
     return NextResponse.json({ error: "invalid_body" }, { status: 400 });
   }
 
@@ -56,12 +57,12 @@ export async function POST(request: Request) {
 
   const callerRow = pageData.data.members.find((m) => m.userId === user.id);
   if (!callerRow || callerRow.role !== "owner") {
-    return NextResponse.json({ error: "not_owner" }, { status: 403 });
+    return NextResponse.json({ error: "caller_not_owner" }, { status: 403 });
   }
 
   const result = await renameOrganization({
     organizationId,
-    name: trimmed,
+    name: validated.trimmed,
     callerUserId: user.id,
   });
 
@@ -79,5 +80,5 @@ export async function POST(request: Request) {
       { status },
     );
   }
-  return NextResponse.json({ ok: true, name: trimmed });
+  return NextResponse.json({ ok: true, name: validated.trimmed });
 }

--- a/apps/web-platform/app/api/workspace/rename/route.ts
+++ b/apps/web-platform/app/api/workspace/rename/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from "next/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
+import { isTeamWorkspaceInviteEnabled, type Identity } from "@/lib/feature-flags/server";
+import { resolveTeamMembershipPageData } from "@/server/team-membership-resolver";
+import { renameOrganization } from "@/server/workspace-membership";
+
+// POST /api/workspace/rename
+// Body: { organizationId, name }
+//
+// Owner-gated rename of the organization display name (the org switcher label).
+// Flag gate: reuses isTeamWorkspaceInviteEnabled (Flagsmith single-control) —
+// returns 404 when disabled. CSRF: validateOrigin gated. Defense stack mirrors
+// transfer-ownership/route.ts.
+export async function POST(request: Request) {
+  const { valid: originValid, origin } = validateOrigin(request);
+  if (!originValid) return rejectCsrf("api/workspace/rename", origin);
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const service = createServiceClient();
+  const pageData = await resolveTeamMembershipPageData(supabase, service);
+  if (!pageData.ok) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+  const identity: Identity = { userId: user.id, role: "prd", orgId: pageData.data.organizationId };
+  if (!(await isTeamWorkspaceInviteEnabled(pageData.data.organizationId, identity))) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  let body: { organizationId?: unknown; name?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  const organizationId = body.organizationId;
+  const name = body.name;
+  if (typeof organizationId !== "string" || typeof name !== "string") {
+    return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+  }
+  const trimmed = name.trim();
+  if (trimmed.length === 0 || trimmed.length > 60) {
+    return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+  }
+
+  if (organizationId !== pageData.data.organizationId) {
+    return NextResponse.json({ error: "org_mismatch" }, { status: 403 });
+  }
+
+  const callerRow = pageData.data.members.find((m) => m.userId === user.id);
+  if (!callerRow || callerRow.role !== "owner") {
+    return NextResponse.json({ error: "not_owner" }, { status: 403 });
+  }
+
+  const result = await renameOrganization({
+    organizationId,
+    name: trimmed,
+    callerUserId: user.id,
+  });
+
+  if (!result.ok) {
+    const status =
+      result.reason === "invalid_name"
+        ? 400
+        : result.reason === "not_found"
+          ? 404
+          : result.reason === "caller_not_owner"
+            ? 403
+            : 500;
+    return NextResponse.json(
+      { error: result.reason, detail: result.detail },
+      { status },
+    );
+  }
+  return NextResponse.json({ ok: true, name: trimmed });
+}

--- a/apps/web-platform/components/settings/invite-member-action.tsx
+++ b/apps/web-platform/components/settings/invite-member-action.tsx
@@ -6,7 +6,15 @@ import { InviteMemberModal } from "@/components/settings/invite-member-modal";
 // Small client wrapper that pairs the "+ Invite member" trigger with the
 // modal — separated from the server-rendered page so the page itself stays
 // async + RSC-clean.
-export function InviteMemberAction({ workspaceId }: { workspaceId: string }) {
+export function InviteMemberAction({
+  workspaceId,
+  organizationId,
+  organizationName,
+}: {
+  workspaceId: string;
+  organizationId?: string;
+  organizationName?: string | null;
+}) {
   const [open, setOpen] = useState(false);
   return (
     <>
@@ -20,6 +28,8 @@ export function InviteMemberAction({ workspaceId }: { workspaceId: string }) {
       <InviteMemberModal
         open={open}
         workspaceId={workspaceId}
+        organizationId={organizationId}
+        organizationName={organizationName}
         onClose={() => setOpen(false)}
       />
     </>

--- a/apps/web-platform/components/settings/invite-member-modal.tsx
+++ b/apps/web-platform/components/settings/invite-member-modal.tsx
@@ -13,14 +13,24 @@ const ATTESTATION_TEXT =
 // it is the migration-058 workspace_member_attestations consent of record.
 // DRAFT consent copy — pending CLO/counsel review per #4558.
 
+// AC6: the org name is "still the default" (and so worth prompting for at
+// first-invite) when it is empty/NULL or the generic backfill/trigger default.
+const DEFAULT_ORG_NAME = "My Workspace";
+
 export function InviteMemberModal({
   open,
   workspaceId,
   onClose,
+  organizationId,
+  organizationName,
 }: {
   open: boolean;
   workspaceId: string;
   onClose: () => void;
+  /** Org being invited into — enables the optional first-invite rename. */
+  organizationId?: string;
+  /** Current org name — the rename field only shows while it's still default. */
+  organizationName?: string | null;
 }) {
   const [email, setEmail] = useState("");
   const [role, setRole] = useState<"member" | "owner">("member");
@@ -28,6 +38,15 @@ export function InviteMemberModal({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const [workspaceName, setWorkspaceName] = useState("");
+
+  const isDefaultName =
+    !organizationName ||
+    organizationName.trim() === "" ||
+    organizationName.trim() === DEFAULT_ORG_NAME;
+  // Only prompt for a name when we know which org to rename AND it's still the
+  // default — once named, the rename UI on the team page owns subsequent edits.
+  const showNameField = Boolean(organizationId) && isDefaultName;
 
   // Reset form whenever the modal toggles open. Closes a leaky-state hazard
   // when an operator cancels then reopens for a different invitee.
@@ -39,6 +58,7 @@ export function InviteMemberModal({
       setSubmitting(false);
       setError(null);
       setSuccess(false);
+      setWorkspaceName("");
     }
   }, [open]);
 
@@ -49,6 +69,22 @@ export function InviteMemberModal({
       setSubmitting(true);
       setError(null);
       try {
+        // AC6: opportunistic first-invite rename. Best-effort — a rename
+        // failure must not block the invite (the invite is the primary action).
+        if (showNameField && organizationId && workspaceName.trim()) {
+          try {
+            await fetch("/api/workspace/rename", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                organizationId,
+                name: workspaceName.trim(),
+              }),
+            });
+          } catch {
+            // swallow — invite proceeds regardless
+          }
+        }
         const res = await fetch("/api/workspace/invite-member", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -83,7 +119,17 @@ export function InviteMemberModal({
         setSubmitting(false);
       }
     },
-    [email, role, attested, submitting, workspaceId, onClose],
+    [
+      email,
+      role,
+      attested,
+      submitting,
+      workspaceId,
+      onClose,
+      showNameField,
+      organizationId,
+      workspaceName,
+    ],
   );
 
   if (!open) return null;
@@ -126,6 +172,26 @@ export function InviteMemberModal({
           <div className="mb-4 rounded-md bg-green-500/10 px-3 py-2 text-sm text-green-400">
             Invite sent! They&apos;ll receive an email with a join link.
           </div>
+        )}
+
+        {showNameField && (
+          <label className="mb-4 block">
+            <span className="mb-1 block text-sm font-medium text-soleur-text-primary">
+              Name your workspace
+            </span>
+            <input
+              type="text"
+              value={workspaceName}
+              maxLength={60}
+              onChange={(e) => setWorkspaceName(e.target.value)}
+              placeholder="e.g. Acme Studio"
+              className="w-full rounded-md border border-soleur-border-default bg-soleur-bg-surface-2/50 px-3 py-2 text-sm text-soleur-text-primary placeholder:text-soleur-text-muted outline-none focus:border-soleur-border-emphasized"
+            />
+            <span className="mt-1 block text-xs text-soleur-text-muted">
+              Optional. Helps teammates tell this workspace apart in the
+              switcher. You can change it later in Team settings.
+            </span>
+          </label>
         )}
 
         <label className="mb-4 block">

--- a/apps/web-platform/components/settings/invite-member-modal.tsx
+++ b/apps/web-platform/components/settings/invite-member-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { DEFAULT_ORG_NAME, WORKSPACE_NAME_MAX } from "@/lib/workspace-name";
 
 const ATTESTATION_TEXT =
   "I confirm this member is my employee or contractor under written agreement, and I consent to them accessing this workspace's connected repository and knowledge-base.";
@@ -14,8 +15,8 @@ const ATTESTATION_TEXT =
 // DRAFT consent copy — pending CLO/counsel review per #4558.
 
 // AC6: the org name is "still the default" (and so worth prompting for at
-// first-invite) when it is empty/NULL or the generic backfill/trigger default.
-const DEFAULT_ORG_NAME = "My Workspace";
+// first-invite) when it is empty/NULL or the generic backfill/trigger default
+// (DEFAULT_ORG_NAME, shared with the migration literal via lib/workspace-name).
 
 export function InviteMemberModal({
   open,
@@ -182,9 +183,9 @@ export function InviteMemberModal({
             <input
               type="text"
               value={workspaceName}
-              maxLength={60}
+              maxLength={WORKSPACE_NAME_MAX}
               onChange={(e) => setWorkspaceName(e.target.value)}
-              placeholder="e.g. Acme Studio"
+              placeholder="e.g. Marketing team"
               className="w-full rounded-md border border-soleur-border-default bg-soleur-bg-surface-2/50 px-3 py-2 text-sm text-soleur-text-primary placeholder:text-soleur-text-muted outline-none focus:border-soleur-border-emphasized"
             />
             <span className="mt-1 block text-xs text-soleur-text-muted">

--- a/apps/web-platform/components/settings/rename-workspace-action.tsx
+++ b/apps/web-platform/components/settings/rename-workspace-action.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import {
+  UNTITLED_FALLBACK,
+  WORKSPACE_NAME_MAX,
+  validateWorkspaceName,
+} from "@/lib/workspace-name";
 
 // AC5: owner-only inline rename for the organization display name (the org
 // switcher label). Non-owners see the name read-only — the edit affordance is
@@ -22,11 +27,12 @@ export function RenameWorkspaceAction({
   const [error, setError] = useState<string | null>(null);
 
   const save = useCallback(async () => {
-    const trimmed = draft.trim();
-    if (trimmed.length === 0 || trimmed.length > 60) {
-      setError("Workspace name must be 1–60 characters.");
+    const validated = validateWorkspaceName(draft);
+    if (!validated.ok) {
+      setError(`Workspace name must be 1–${WORKSPACE_NAME_MAX} characters.`);
       return;
     }
+    const trimmed = validated.trimmed;
     setSubmitting(true);
     setError(null);
     try {
@@ -59,7 +65,7 @@ export function RenameWorkspaceAction({
           data-testid="workspace-name"
           className="text-sm font-medium text-soleur-text-primary"
         >
-          {name || "Untitled"}
+          {name || UNTITLED_FALLBACK}
         </span>
         {isOwner && !editing && (
           <button
@@ -81,7 +87,7 @@ export function RenameWorkspaceAction({
             <input
               aria-label="Workspace name"
               value={draft}
-              maxLength={60}
+              maxLength={WORKSPACE_NAME_MAX}
               onChange={(e) => setDraft(e.target.value)}
               className="rounded-md border border-soleur-border-default bg-soleur-bg-surface-2/50 px-3 py-1.5 text-sm text-soleur-text-primary outline-none focus:border-soleur-border-emphasized"
             />

--- a/apps/web-platform/components/settings/rename-workspace-action.tsx
+++ b/apps/web-platform/components/settings/rename-workspace-action.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+// AC5: owner-only inline rename for the organization display name (the org
+// switcher label). Non-owners see the name read-only — the edit affordance is
+// gated on isOwner. Posts to POST /api/workspace/rename and updates the
+// displayed name in place on success (no full reload).
+export function RenameWorkspaceAction({
+  organizationId,
+  organizationName,
+  isOwner,
+}: {
+  organizationId: string;
+  organizationName: string | null;
+  isOwner: boolean;
+}) {
+  const [name, setName] = useState(organizationName ?? "");
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(name);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const save = useCallback(async () => {
+    const trimmed = draft.trim();
+    if (trimmed.length === 0 || trimmed.length > 60) {
+      setError("Workspace name must be 1–60 characters.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/workspace/rename", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ organizationId, name: trimmed }),
+      });
+      if (!res.ok) {
+        setError("Couldn't rename workspace. Please try again.");
+        setSubmitting(false);
+        return;
+      }
+      setName(trimmed);
+      setEditing(false);
+      setSubmitting(false);
+    } catch {
+      setError("Couldn't rename workspace. Please try again.");
+      setSubmitting(false);
+    }
+  }, [draft, organizationId]);
+
+  return (
+    <div className="mb-6 flex flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="text-xs uppercase tracking-wider text-soleur-text-muted">
+          Workspace
+        </span>
+        <span
+          data-testid="workspace-name"
+          className="text-sm font-medium text-soleur-text-primary"
+        >
+          {name || "Untitled"}
+        </span>
+        {isOwner && !editing && (
+          <button
+            type="button"
+            onClick={() => {
+              setDraft(name);
+              setError(null);
+              setEditing(true);
+            }}
+            className="text-xs text-soleur-accent-gold-fg underline decoration-dotted underline-offset-2 hover:opacity-90"
+          >
+            Rename
+          </button>
+        )}
+      </div>
+      {editing && (
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              aria-label="Workspace name"
+              value={draft}
+              maxLength={60}
+              onChange={(e) => setDraft(e.target.value)}
+              className="rounded-md border border-soleur-border-default bg-soleur-bg-surface-2/50 px-3 py-1.5 text-sm text-soleur-text-primary outline-none focus:border-soleur-border-emphasized"
+            />
+            <button
+              type="button"
+              onClick={save}
+              disabled={submitting}
+              className="rounded-md bg-soleur-accent-gold-fg px-3 py-1.5 text-sm font-medium text-soleur-bg-surface-1 disabled:cursor-not-allowed disabled:opacity-50 hover:opacity-90"
+            >
+              {submitting ? "Saving…" : "Save"}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setEditing(false);
+                setError(null);
+              }}
+              className="px-2 py-1.5 text-sm text-soleur-text-secondary hover:text-soleur-text-primary"
+            >
+              Cancel
+            </button>
+          </div>
+          {error && (
+            <p className="text-xs text-red-400" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web-platform/lib/workspace-name.ts
+++ b/apps/web-platform/lib/workspace-name.ts
@@ -1,0 +1,35 @@
+// Shared workspace/organization name constants + validation.
+//
+// DEFAULT_ORG_NAME is the generic non-PII label that migration 091's
+// handle_new_user trigger + backfill write for new/legacy organizations
+// (was NULL in mig 053). It is peer-visible via orgs_select_for_members, so
+// it MUST stay generic (never an email-derived value).
+//
+// IMPORTANT: this value is duplicated as a SQL literal in
+// apps/web-platform/supabase/migrations/091_rename_organization_and_default_names.sql
+// (SQL cannot import TS). If you change it here, change it there too — the
+// invite modal's "is this still the default name?" heuristic compares against
+// DEFAULT_ORG_NAME, so drift silently breaks the first-invite rename prompt.
+export const DEFAULT_ORG_NAME = "My Workspace";
+
+// Render-time fallback when an org name is somehow still NULL/empty. After
+// migration 091 this is unreachable (defense-in-depth only).
+export const UNTITLED_FALLBACK = "Untitled";
+
+// Max length for a user-supplied workspace name, enforced at every layer
+// (rename RPC, route, wrapper, component). The SQL RPC re-states `60` (it
+// cannot import this constant) — keep them in sync.
+export const WORKSPACE_NAME_MAX = 60;
+
+export type WorkspaceNameValidation =
+  | { ok: true; trimmed: string }
+  | { ok: false };
+
+/** Trim + bound a user-supplied workspace name (1..WORKSPACE_NAME_MAX chars). */
+export function validateWorkspaceName(raw: string): WorkspaceNameValidation {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0 || trimmed.length > WORKSPACE_NAME_MAX) {
+    return { ok: false };
+  }
+  return { ok: true, trimmed };
+}

--- a/apps/web-platform/server/org-memberships-resolver.ts
+++ b/apps/web-platform/server/org-memberships-resolver.ts
@@ -1,4 +1,5 @@
 import { resolveCurrentOrganizationId } from "@/server/workspace-resolver";
+import { UNTITLED_FALLBACK } from "@/lib/workspace-name";
 
 // Returns the user's full list of organization memberships with role + member
 // count. Powers the dashboard OrgSwitcher (Phase 5.3) which hides itself when
@@ -145,9 +146,9 @@ export async function resolveOrgMemberships(
       if (!ws) return null;
       // Defense-in-depth: migration 091 backfills every NULL org name to a
       // non-NULL default and handle_new_user no longer inserts NULL, so a
-      // stored NULL (→ "Untitled") should be unreachable in production. The
-      // guard remains as a last resort. See feat-one-shot-workspace-untitled-name.
-      const orgName = orgNameById.get(ws.organization_id) ?? "Untitled";
+      // stored NULL (→ UNTITLED_FALLBACK) should be unreachable in production.
+      // The guard remains as a last resort. See feat-one-shot-workspace-untitled-name.
+      const orgName = orgNameById.get(ws.organization_id) ?? UNTITLED_FALLBACK;
       return {
         organizationId: ws.organization_id,
         organizationName: orgName,

--- a/apps/web-platform/server/org-memberships-resolver.ts
+++ b/apps/web-platform/server/org-memberships-resolver.ts
@@ -143,6 +143,10 @@ export async function resolveOrgMemberships(
     .map((m) => {
       const ws = workspaceById.get(m.workspace_id);
       if (!ws) return null;
+      // Defense-in-depth: migration 091 backfills every NULL org name to a
+      // non-NULL default and handle_new_user no longer inserts NULL, so a
+      // stored NULL (→ "Untitled") should be unreachable in production. The
+      // guard remains as a last resort. See feat-one-shot-workspace-untitled-name.
       const orgName = orgNameById.get(ws.organization_id) ?? "Untitled";
       return {
         organizationId: ws.organization_id,

--- a/apps/web-platform/server/workspace-membership.ts
+++ b/apps/web-platform/server/workspace-membership.ts
@@ -6,6 +6,7 @@ import { sessions } from "@/server/session-registry";
 import { closeWithPreamble } from "@/lib/ws-close-helper";
 import { WS_CLOSE_CODES } from "@/lib/types";
 import { reportSilentFallback } from "@/server/observability";
+import { validateWorkspaceName } from "@/lib/workspace-name";
 
 // PERMANENT service-role surface (.service-role-allowlist line 133):
 // invite_workspace_member + remove_workspace_member RPCs require service-role
@@ -446,20 +447,22 @@ export type RenameOrganizationFailureReason =
 export async function renameOrganization(
   args: RenameOrganizationArgs,
 ): Promise<RenameOrganizationResult> {
-  const trimmed = args.name.trim();
-  if (trimmed.length === 0 || trimmed.length > 60) {
+  const validated = validateWorkspaceName(args.name);
+  if (!validated.ok) {
     return { ok: false, reason: "invalid_name" };
   }
 
   const service = createServiceClient();
   const { error } = await service.rpc("rename_organization", {
     p_organization_id: args.organizationId,
-    p_name: trimmed,
+    p_name: validated.trimmed,
     p_caller_user_id: args.callerUserId,
   });
 
   if (error) {
     const msg = error.message ?? "";
+    // caller_not_owner / invalid_name are expected, caller-correctable
+    // outcomes — not silent failures, so they are not mirrored to Sentry.
     if (msg.includes("caller is not an owner")) {
       return { ok: false, reason: "caller_not_owner" };
     }
@@ -469,6 +472,15 @@ export async function renameOrganization(
     if (msg.includes("no organization row")) {
       return { ok: false, reason: "not_found" };
     }
+    // rpc_failed is an unexpected DB-side failure — mirror to Sentry per
+    // cq-silent-fallback-must-mirror-to-sentry (matches workspace-invitations).
+    // The 28000 NULL-caller arm also lands here (unreachable from the route,
+    // which always forwards a verified getUser() id).
+    reportSilentFallback(error, {
+      feature: "workspace-membership",
+      op: "rename-organization-rpc",
+      extra: { organizationId: args.organizationId, callerUserId: args.callerUserId },
+    });
     return { ok: false, reason: "rpc_failed", detail: msg };
   }
 

--- a/apps/web-platform/server/workspace-membership.ts
+++ b/apps/web-platform/server/workspace-membership.ts
@@ -415,3 +415,62 @@ export async function transferWorkspaceOwnership(
 
   return { ok: true, attestationId: String(data) };
 }
+
+export interface RenameOrganizationArgs {
+  organizationId: string;
+  name: string;
+  /**
+   * Verified getUser() id from the route — forwarded as p_caller_user_id so
+   * the rename_organization owner-gate resolves the caller correctly under
+   * the service-role client (auth.uid() is NULL there). See migration 091.
+   */
+  callerUserId: string;
+}
+
+export type RenameOrganizationResult =
+  | { ok: true }
+  | { ok: false; reason: RenameOrganizationFailureReason; detail?: string };
+
+export type RenameOrganizationFailureReason =
+  | "invalid_name"
+  | "caller_not_owner"
+  | "not_found"
+  | "rpc_failed";
+
+/**
+ * Rename an organization (the org switcher's display name). Owner-gated via the
+ * rename_organization RPC (migration 091) — a single-row UPDATE on
+ * organizations.name. Unlike the membership RPCs there is no session abort:
+ * a rename revokes no one's access.
+ */
+export async function renameOrganization(
+  args: RenameOrganizationArgs,
+): Promise<RenameOrganizationResult> {
+  const trimmed = args.name.trim();
+  if (trimmed.length === 0 || trimmed.length > 60) {
+    return { ok: false, reason: "invalid_name" };
+  }
+
+  const service = createServiceClient();
+  const { error } = await service.rpc("rename_organization", {
+    p_organization_id: args.organizationId,
+    p_name: trimmed,
+    p_caller_user_id: args.callerUserId,
+  });
+
+  if (error) {
+    const msg = error.message ?? "";
+    if (msg.includes("caller is not an owner")) {
+      return { ok: false, reason: "caller_not_owner" };
+    }
+    if (msg.includes("name must")) {
+      return { ok: false, reason: "invalid_name" };
+    }
+    if (msg.includes("no organization row")) {
+      return { ok: false, reason: "not_found" };
+    }
+    return { ok: false, reason: "rpc_failed", detail: msg };
+  }
+
+  return { ok: true };
+}

--- a/apps/web-platform/supabase/migrations/091_rename_organization_and_default_names.down.sql
+++ b/apps/web-platform/supabase/migrations/091_rename_organization_and_default_names.down.sql
@@ -1,0 +1,49 @@
+-- Down-migration for 091_rename_organization_and_default_names.
+-- Drops the rename_organization RPC and restores the 053 handle_new_user
+-- body (NULL default names). The backfill is NOT reverted — organization /
+-- workspace names are user data; restoring them to NULL would destroy
+-- user-supplied content. Provided for reversibility symmetry of the
+-- schema-level objects only.
+
+DROP FUNCTION IF EXISTS public.rename_organization(uuid, text, uuid);
+
+-- Restore handle_new_user to the 053:289-329 body (NULL name literals).
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_org_id uuid;
+BEGIN
+  INSERT INTO public.users (id, email, workspace_path)
+  VALUES (
+    NEW.id,
+    NEW.email,
+    '/workspaces/' || NEW.id::text
+  )
+  ON CONFLICT (id) DO NOTHING;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.workspace_members m
+    WHERE m.user_id = NEW.id AND m.workspace_id = NEW.id AND m.role = 'owner'
+  ) THEN
+    INSERT INTO public.organizations (id, name, domain, owner_user_id)
+    VALUES (gen_random_uuid(), NULL, NULL, NEW.id)
+    RETURNING id INTO v_org_id;
+
+    INSERT INTO public.workspaces (id, organization_id, name)
+    VALUES (NEW.id, v_org_id, NULL)
+    ON CONFLICT (id) DO NOTHING;
+
+    INSERT INTO public.workspace_members (workspace_id, user_id, role, attestation_id)
+    VALUES (NEW.id, NEW.id, 'owner', NULL)
+    ON CONFLICT (workspace_id, user_id) DO NOTHING;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.handle_new_user() FROM PUBLIC, anon, authenticated, service_role;

--- a/apps/web-platform/supabase/migrations/091_rename_organization_and_default_names.sql
+++ b/apps/web-platform/supabase/migrations/091_rename_organization_and_default_names.sql
@@ -1,0 +1,201 @@
+-- 091_rename_organization_and_default_names.sql
+-- feat-one-shot-workspace-untitled-name — close the organizations.name
+-- contract that migration 053 deferred to "Phase 5.4" and never built.
+--
+-- Symptom: every organization row carries name = NULL (the 053 backfill,
+-- the handle_new_user() signup trigger, and every other write path insert
+-- NULL). The dashboard org switcher renders `organizationName ?? "Untitled"`
+-- (server/org-memberships-resolver.ts), so multi-workspace users see a list
+-- of indistinguishable "Untitled" rows.
+--
+-- This migration makes organizations.name effectively non-NULL at every
+-- write surface, WITHOUT adding a NOT NULL constraint (053:47-48 chose
+-- app-layer enforcement to keep the backfill single-statement):
+--   1. rename_organization RPC — the only runtime user-reachable write path
+--      (owner-gated SECURITY DEFINER; mirrors 075_transfer_workspace_ownership).
+--   2. handle_new_user() re-derived from 053:289-329 with the two NULL name
+--      literals changed to a generic non-PII default ('My Workspace').
+--   3. one-time backfill of existing NULL-name org + workspace rows.
+--
+-- Privacy (GDPR, advisory): the backfill default is a generic label, NOT the
+-- owner's email/name. organizations.name is peer-visible via
+-- orgs_select_for_members (053:159); an email-derived default would disclose
+-- the owner's email to every workspace member.
+--
+-- Per cq-pg-security-definer-search-path-pin-pg-temp: every SECURITY DEFINER
+-- function pins SET search_path = public, pg_temp (pg_temp LAST).
+-- Per 2026-05-06-supabase-default-privileges-defeat-revoke-from-public:
+-- explicit REVOKE from PUBLIC + anon + authenticated; explicit GRANT to
+-- authenticated.
+
+-- =====================================================================
+-- 1. rename_organization RPC (sole authenticated write path)
+-- =====================================================================
+-- Strict simplification of transfer_workspace_ownership (mig 075): same
+-- owner-gate/grant spine, none of the multi-row/attestation/audit machinery.
+-- organizations carries NO audit trigger (audit triggers target
+-- workspace_members only), so this RPC does NOT set the workspace_audit
+-- actor GUC — it would be dead.
+--
+-- Caller identity: COALESCE(p_caller_user_id, auth.uid()), mirroring
+-- accept_workspace_invitation (mig 076/085). The TS wrapper invokes this via
+-- the service-role client (createServiceClient), under which auth.uid() is
+-- NULL — a pure auth.uid() gate (the 075 shape) would raise 28000 on every
+-- service-role call. The route passes the verified getUser() id explicitly;
+-- when auth.uid() IS populated (authenticated-client call) COALESCE returns
+-- the same value, so the gate is correct under both invocation modes.
+
+CREATE OR REPLACE FUNCTION public.rename_organization(
+  p_organization_id uuid,
+  p_name            text,
+  p_caller_user_id  uuid DEFAULT NULL
+) RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_caller_user_id uuid := COALESCE(p_caller_user_id, auth.uid());
+  v_is_owner       boolean;
+  v_trimmed        text;
+BEGIN
+  -- 1. Authenticate
+  IF v_caller_user_id IS NULL THEN
+    RAISE EXCEPTION 'caller_user_id is NULL — caller must be authenticated'
+      USING ERRCODE = '28000';
+  END IF;
+
+  -- 2. Caller must be an owner of a workspace in the target org. FOR UPDATE
+  -- matches the 075 precedent (a rename race is benign — last-write-wins —
+  -- but the lock keeps the owner-read consistent under READ COMMITTED).
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.workspace_members m
+    JOIN public.workspaces w ON w.id = m.workspace_id
+    WHERE w.organization_id = p_organization_id
+      AND m.user_id         = v_caller_user_id
+      AND m.role            = 'owner'
+    FOR UPDATE
+  ) INTO v_is_owner;
+
+  IF NOT v_is_owner THEN
+    RAISE EXCEPTION 'caller is not an owner of organization %', p_organization_id
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- 3. Validate name: trim, reject empty/whitespace-only, bound length.
+  v_trimmed := btrim(COALESCE(p_name, ''));
+  IF length(v_trimmed) = 0 THEN
+    RAISE EXCEPTION 'name must not be empty'
+      USING ERRCODE = '22023';
+  END IF;
+  IF length(v_trimmed) > 60 THEN
+    RAISE EXCEPTION 'name must be at most 60 characters'
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- 4. Single-row UPDATE.
+  UPDATE public.organizations SET name = v_trimmed WHERE id = p_organization_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'no organization row for id=%', p_organization_id
+      USING ERRCODE = 'P0001';
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.rename_organization(uuid, text, uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.rename_organization(uuid, text, uuid)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.rename_organization(uuid, text, uuid) IS
+  'Owner-gated single-row rename of organizations.name. SECURITY DEFINER '
+  'so the RPC is the sole authenticated write path (no RLS UPDATE policy '
+  'on organizations). Mirrors transfer_workspace_ownership owner-gate '
+  '(mig 075) minus attestation/audit machinery. '
+  'feat-one-shot-workspace-untitled-name.';
+
+-- =====================================================================
+-- 2. handle_new_user() — non-NULL default names for new signups
+-- =====================================================================
+-- Full body re-derived from 053:289-329. ONLY change: the two NULL name
+-- literals (organizations.name, workspaces.name) become the generic default
+-- 'My Workspace'. Dropping any other arm (public.users insert, canary guard,
+-- org/workspace/member creation, ON CONFLICT idempotency) would break signup.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_org_id uuid;
+BEGIN
+  -- 1. Insert public.users row (original 001 behavior).
+  INSERT INTO public.users (id, email, workspace_path)
+  VALUES (
+    NEW.id,
+    NEW.email,
+    '/workspaces/' || NEW.id::text
+  )
+  ON CONFLICT (id) DO NOTHING;
+
+  -- 2. Insert organization (default-named) for this user IF they don't
+  -- already have the canary owner row. Idempotent via the same
+  -- discriminator as the 053 backfill DO block.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.workspace_members m
+    WHERE m.user_id = NEW.id AND m.workspace_id = NEW.id AND m.role = 'owner'
+  ) THEN
+    INSERT INTO public.organizations (id, name, domain, owner_user_id)
+    VALUES (gen_random_uuid(), 'My Workspace', NULL, NEW.id)
+    RETURNING id INTO v_org_id;
+
+    INSERT INTO public.workspaces (id, organization_id, name)
+    VALUES (NEW.id, v_org_id, 'My Workspace')
+    ON CONFLICT (id) DO NOTHING;
+
+    INSERT INTO public.workspace_members (workspace_id, user_id, role, attestation_id)
+    VALUES (NEW.id, NEW.id, 'owner', NULL)
+    ON CONFLICT (workspace_id, user_id) DO NOTHING;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- handle_new_user is a trigger function (fires AFTER INSERT on auth.users)
+-- and is not invoked via direct CALL. The REVOKE is defensive (satisfies
+-- migration-rpc-grants lint + closes the direct-EXECUTE surface). Triggers
+-- fire under the owner's identity regardless of EXECUTE grant, so this
+-- REVOKE does NOT break signup.
+REVOKE ALL ON FUNCTION public.handle_new_user() FROM PUBLIC, anon, authenticated, service_role;
+
+COMMENT ON FUNCTION public.handle_new_user() IS
+  'Auth signup hook. Creates public.users row + default-named organization '
+  '+ workspace (id = users.id per ADR-038 N2) + workspace_members(role=owner). '
+  'Idempotent via canary owner-row discriminator + per-table ON CONFLICT DO '
+  'NOTHING. SECURITY DEFINER so RLS does not block during the auth.users '
+  'INSERT trigger. Default name set per feat-one-shot-workspace-untitled-name '
+  '(was NULL in mig 053).';
+
+-- =====================================================================
+-- 3. Backfill existing NULL-name rows to the default
+-- =====================================================================
+-- Idempotent: WHERE name IS NULL discriminator → re-running this migration
+-- on a populated DB updates 0 rows. Privacy: generic non-PII label only.
+
+DO $$
+DECLARE
+  v_org_rc int;
+  v_ws_rc  int;
+BEGIN
+  UPDATE public.organizations SET name = 'My Workspace' WHERE name IS NULL;
+  GET DIAGNOSTICS v_org_rc = ROW_COUNT;
+  RAISE NOTICE '[091-backfill] organizations renamed from NULL: %', v_org_rc;
+
+  UPDATE public.workspaces SET name = 'My Workspace' WHERE name IS NULL;
+  GET DIAGNOSTICS v_ws_rc = ROW_COUNT;
+  RAISE NOTICE '[091-backfill] workspaces renamed from NULL: %', v_ws_rc;
+END $$;

--- a/apps/web-platform/supabase/migrations/091_rename_organization_and_default_names.sql
+++ b/apps/web-platform/supabase/migrations/091_rename_organization_and_default_names.sql
@@ -25,8 +25,10 @@
 -- Per cq-pg-security-definer-search-path-pin-pg-temp: every SECURITY DEFINER
 -- function pins SET search_path = public, pg_temp (pg_temp LAST).
 -- Per 2026-05-06-supabase-default-privileges-defeat-revoke-from-public:
--- explicit REVOKE from PUBLIC + anon + authenticated; explicit GRANT to
--- authenticated.
+-- explicit REVOKE from PUBLIC + anon + authenticated. rename_organization is
+-- then GRANTed to service_role ONLY (NOT authenticated) — it takes a forgeable
+-- caller-override param, so it must be unreachable via PostgREST by an
+-- authenticated user; see the grant block below for the full rationale.
 
 -- =====================================================================
 -- 1. rename_organization RPC (sole authenticated write path)
@@ -103,10 +105,18 @@ BEGIN
 END;
 $$;
 
+-- GRANT to service_role ONLY (NOT authenticated). The RPC takes a
+-- caller-override param (p_caller_user_id) that COALESCE prefers over
+-- auth.uid(); if authenticated could reach it via PostgREST, any user could
+-- forge p_caller_user_id = <victim owner uuid> and bypass the route's
+-- owner-gate. Mirrors accept_workspace_invitation's grant matrix (mig 076/085)
+-- exactly — the forgeable-override pattern is ONLY safe behind service-role,
+-- because the sole caller (server/workspace-membership.ts renameOrganization)
+-- invokes via createServiceClient() and passes the verified getUser() id.
 REVOKE ALL ON FUNCTION public.rename_organization(uuid, text, uuid)
   FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.rename_organization(uuid, text, uuid)
-  TO authenticated;
+  TO service_role;
 
 COMMENT ON FUNCTION public.rename_organization(uuid, text, uuid) IS
   'Owner-gated single-row rename of organizations.name. SECURITY DEFINER '
@@ -183,19 +193,23 @@ COMMENT ON FUNCTION public.handle_new_user() IS
 -- =====================================================================
 -- 3. Backfill existing NULL-name rows to the default
 -- =====================================================================
--- Idempotent: WHERE name IS NULL discriminator → re-running this migration
--- on a populated DB updates 0 rows. Privacy: generic non-PII label only.
+-- Idempotent: the `name IS NULL OR btrim(name) = ''` discriminator → re-running
+-- this migration on a populated DB updates 0 rows (the default is non-empty).
+-- The empty-string arm is belt-and-braces: no write path emits '' (the rename
+-- RPC trims+rejects empty, and mig 053 only ever wrote NULL), but the runtime
+-- guards render '' as the "Untitled" sentinel, so the backfill normalizes any
+-- stray empty row too. Privacy: generic non-PII label only.
 
 DO $$
 DECLARE
   v_org_rc int;
   v_ws_rc  int;
 BEGIN
-  UPDATE public.organizations SET name = 'My Workspace' WHERE name IS NULL;
+  UPDATE public.organizations SET name = 'My Workspace' WHERE name IS NULL OR btrim(name) = '';
   GET DIAGNOSTICS v_org_rc = ROW_COUNT;
-  RAISE NOTICE '[091-backfill] organizations renamed from NULL: %', v_org_rc;
+  RAISE NOTICE '[091-backfill] organizations renamed from NULL/empty: %', v_org_rc;
 
-  UPDATE public.workspaces SET name = 'My Workspace' WHERE name IS NULL;
+  UPDATE public.workspaces SET name = 'My Workspace' WHERE name IS NULL OR btrim(name) = '';
   GET DIAGNOSTICS v_ws_rc = ROW_COUNT;
-  RAISE NOTICE '[091-backfill] workspaces renamed from NULL: %', v_ws_rc;
+  RAISE NOTICE '[091-backfill] workspaces renamed from NULL/empty: %', v_ws_rc;
 END $$;

--- a/apps/web-platform/supabase/verify/091_rename_organization_and_default_names.sql
+++ b/apps/web-platform/supabase/verify/091_rename_organization_and_default_names.sql
@@ -1,0 +1,38 @@
+-- Verify 091_rename_organization_and_default_names.sql.
+--
+-- Contract: every row returns `check_name` + `bad`. Any `bad > 0` row
+-- fails CI verify-migrations.
+--
+-- Sentinels confirm post-apply state from migration 091:
+--   * no organization carries a NULL/empty name (backfill + trigger default)
+--   * no workspace carries a NULL/empty name
+--   * rename_organization RPC exists
+--   * rename_organization is NOT EXECUTE-able by `authenticated` (the P1
+--     owner-gate-bypass guard — it must be service_role-only because it takes
+--     a forgeable caller-override param)
+
+-- (1) no NULL/empty organization names
+SELECT 'organizations_have_names' AS check_name,
+       (SELECT count(*) FROM public.organizations
+         WHERE name IS NULL OR btrim(name) = '')::int AS bad
+UNION ALL
+-- (2) no NULL/empty workspace names
+SELECT 'workspaces_have_names',
+       (SELECT count(*) FROM public.workspaces
+         WHERE name IS NULL OR btrim(name) = '')::int
+UNION ALL
+-- (3) rename_organization RPC exists
+SELECT 'rename_organization_exists',
+       CASE WHEN EXISTS (
+         SELECT 1 FROM pg_proc p
+         JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'public' AND p.proname = 'rename_organization'
+       ) THEN 0 ELSE 1 END::int
+UNION ALL
+-- (4) rename_organization is NOT executable by authenticated (P1 guard)
+SELECT 'rename_organization_not_granted_to_authenticated',
+       CASE WHEN has_function_privilege(
+         'authenticated',
+         'public.rename_organization(uuid, text, uuid)',
+         'EXECUTE'
+       ) THEN 1 ELSE 0 END::int;

--- a/apps/web-platform/test/invite-member-modal.test.tsx
+++ b/apps/web-platform/test/invite-member-modal.test.tsx
@@ -138,4 +138,39 @@ describe("InviteMemberModal", () => {
     const body = JSON.parse((renameCall[1] as RequestInit).body as string);
     expect(body).toEqual({ organizationId: ORG_ID, name: "Acme Studio" });
   });
+
+  it("a failed first-invite rename does NOT block the invite POST (best-effort)", async () => {
+    // The rename is fired before the invite and wrapped in a swallow-catch so a
+    // rename failure never aborts the primary action (the invite).
+    const mockFetch = vi.fn(async (url: string) => {
+      if (url === "/api/workspace/rename") throw new Error("network down");
+      return { ok: true, json: () => Promise.resolve({}) } as unknown as Response;
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(
+      <InviteMemberModal
+        open
+        workspaceId={WORKSPACE_ID}
+        organizationId={ORG_ID}
+        organizationName="My Workspace"
+        onClose={() => {}}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/name your workspace/i), {
+      target: { value: "Acme Studio" },
+    });
+    fireEvent.change(screen.getByLabelText(/Email address/i), {
+      target: { value: "harry@jikigai.com" },
+    });
+    fireEvent.click(screen.getByLabelText(/employee or contractor/i));
+    fireEvent.click(screen.getByRole("button", { name: /send invite/i }));
+
+    await vi.waitFor(() => {
+      const inviteCalled = mockFetch.mock.calls.some(
+        ([url]) => url === "/api/workspace/invite-member",
+      );
+      expect(inviteCalled).toBe(true);
+    });
+  });
 });

--- a/apps/web-platform/test/invite-member-modal.test.tsx
+++ b/apps/web-platform/test/invite-member-modal.test.tsx
@@ -67,4 +67,75 @@ describe("InviteMemberModal", () => {
     expect(body.role).toBe("member");
     expect(body.attestationText).toMatch(/employee or contractor/i);
   });
+
+  // AC6: first-invite workspace-name capture.
+  const ORG_ID = "org-1";
+
+  it("shows the 'Name your workspace' field when the org still has the default name", () => {
+    render(
+      <InviteMemberModal
+        open
+        workspaceId={WORKSPACE_ID}
+        organizationId={ORG_ID}
+        organizationName="My Workspace"
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText(/name your workspace/i)).toBeInTheDocument();
+  });
+
+  it("hides the name field when the org already has a real name", () => {
+    render(
+      <InviteMemberModal
+        open
+        workspaceId={WORKSPACE_ID}
+        organizationId={ORG_ID}
+        organizationName="Acme Studio"
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.queryByLabelText(/name your workspace/i)).not.toBeInTheDocument();
+  });
+
+  it("hides the name field when no organizationId is provided", () => {
+    render(
+      <InviteMemberModal open workspaceId={WORKSPACE_ID} onClose={() => {}} />,
+    );
+    expect(screen.queryByLabelText(/name your workspace/i)).not.toBeInTheDocument();
+  });
+
+  it("submitting with a workspace name also POSTs the rename endpoint", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(
+      <InviteMemberModal
+        open
+        workspaceId={WORKSPACE_ID}
+        organizationId={ORG_ID}
+        organizationName="My Workspace"
+        onClose={() => {}}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/name your workspace/i), {
+      target: { value: "Acme Studio" },
+    });
+    fireEvent.change(screen.getByLabelText(/Email address/i), {
+      target: { value: "harry@jikigai.com" },
+    });
+    fireEvent.click(screen.getByLabelText(/employee or contractor/i));
+    fireEvent.click(screen.getByRole("button", { name: /send invite/i }));
+
+    await vi.waitFor(() => {
+      const renameCall = mockFetch.mock.calls.find(
+        ([url]) => url === "/api/workspace/rename",
+      );
+      expect(renameCall).toBeTruthy();
+    });
+    const renameCall = mockFetch.mock.calls.find(
+      ([url]) => url === "/api/workspace/rename",
+    )!;
+    const body = JSON.parse((renameCall[1] as RequestInit).body as string);
+    expect(body).toEqual({ organizationId: ORG_ID, name: "Acme Studio" });
+  });
 });

--- a/apps/web-platform/test/org-memberships-resolver.test.ts
+++ b/apps/web-platform/test/org-memberships-resolver.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// AC7 (feat-one-shot-workspace-untitled-name): the org-memberships resolver is
+// the ACTUAL source of the "Untitled" sentinel — it substitutes
+// UNTITLED_FALLBACK only when an org name is NULL, and passes real names
+// through verbatim. Migration 091 backfills names so the fallback is
+// defense-in-depth; this test pins both arms so a regression that drops the
+// fallback (or that mis-substitutes a real name) is caught.
+
+const { mockResolveCurrentOrg } = vi.hoisted(() => ({
+  mockResolveCurrentOrg: vi.fn(),
+}));
+
+vi.mock("@/server/workspace-resolver", () => ({
+  resolveCurrentOrganizationId: mockResolveCurrentOrg,
+}));
+
+import { resolveOrgMemberships } from "@/server/org-memberships-resolver";
+import { UNTITLED_FALLBACK } from "@/lib/workspace-name";
+
+const USER_ID = "u1";
+
+function makeSupabase() {
+  return {
+    auth: {
+      getUser: async () => ({ data: { user: { id: USER_ID } }, error: null }),
+    },
+  };
+}
+
+// org-1 has a real name, org-2 has a NULL name (pre-091 / unreachable post-091).
+function makeService() {
+  return {
+    from: (table: string) => {
+      if (table === "workspace_members") {
+        return {
+          select: (_cols: string) => ({
+            // memberships lookup (.eq user_id)
+            eq: async () => ({
+              data: [
+                { workspace_id: "ws-1", role: "owner" },
+                { workspace_id: "ws-2", role: "member" },
+              ],
+              error: null,
+            }),
+            // member-count lookup (.in workspace_id)
+            in: async () => ({
+              data: [
+                { workspace_id: "ws-1", user_id: "u1" },
+                { workspace_id: "ws-1", user_id: "u2" },
+                { workspace_id: "ws-2", user_id: "u1" },
+              ],
+              error: null,
+            }),
+          }),
+        };
+      }
+      if (table === "workspaces") {
+        return {
+          select: (_cols: string) => ({
+            in: async () => ({
+              data: [
+                { id: "ws-1", organization_id: "org-1" },
+                { id: "ws-2", organization_id: "org-2" },
+              ],
+              error: null,
+            }),
+          }),
+        };
+      }
+      if (table === "organizations") {
+        return {
+          select: (_cols: string) => ({
+            in: async () => ({
+              data: [
+                { id: "org-1", name: "jikigai" },
+                { id: "org-2", name: null },
+              ],
+              error: null,
+            }),
+          }),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  };
+}
+
+describe("resolveOrgMemberships — AC7 name fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveCurrentOrg.mockResolvedValue("org-1");
+  });
+
+  it("passes a real org name through verbatim", async () => {
+    const summaries = await resolveOrgMemberships(
+      makeSupabase() as never,
+      makeService() as never,
+    );
+    const org1 = summaries.find((s) => s.organizationId === "org-1");
+    expect(org1?.organizationName).toBe("jikigai");
+    expect(org1?.organizationName).not.toBe(UNTITLED_FALLBACK);
+  });
+
+  it("substitutes UNTITLED_FALLBACK only when the stored name is NULL", async () => {
+    const summaries = await resolveOrgMemberships(
+      makeSupabase() as never,
+      makeService() as never,
+    );
+    const org2 = summaries.find((s) => s.organizationId === "org-2");
+    expect(org2?.organizationName).toBe(UNTITLED_FALLBACK);
+  });
+});

--- a/apps/web-platform/test/org-switcher.test.tsx
+++ b/apps/web-platform/test/org-switcher.test.tsx
@@ -82,4 +82,17 @@ describe("OrgSwitcher", () => {
     fireEvent.click(within(menu).getByText("jikigai"));
     expect(onSwitch).not.toHaveBeenCalled();
   });
+
+  // AC7 (feat-one-shot-workspace-untitled-name): once migration 091 backfills
+  // non-NULL names, the resolver's `?? "Untitled"` guard is unreachable. A
+  // two-org fixture with real names must render both names and never the
+  // "Untitled" sentinel.
+  it("AC7: renders real org names, never the 'Untitled' sentinel", () => {
+    render(<OrgSwitcher memberships={[JIKIGAI, ACME]} />);
+    fireEvent.click(screen.getByRole("button", { name: /switch workspace/i }));
+    const menu = screen.getByRole("menu");
+    expect(within(menu).getByText("jikigai")).toBeInTheDocument();
+    expect(within(menu).getByText("Acme Studio")).toBeInTheDocument();
+    expect(within(menu).queryByText("Untitled")).not.toBeInTheDocument();
+  });
 });

--- a/apps/web-platform/test/org-switcher.test.tsx
+++ b/apps/web-platform/test/org-switcher.test.tsx
@@ -83,16 +83,8 @@ describe("OrgSwitcher", () => {
     expect(onSwitch).not.toHaveBeenCalled();
   });
 
-  // AC7 (feat-one-shot-workspace-untitled-name): once migration 091 backfills
-  // non-NULL names, the resolver's `?? "Untitled"` guard is unreachable. A
-  // two-org fixture with real names must render both names and never the
-  // "Untitled" sentinel.
-  it("AC7: renders real org names, never the 'Untitled' sentinel", () => {
-    render(<OrgSwitcher memberships={[JIKIGAI, ACME]} />);
-    fireEvent.click(screen.getByRole("button", { name: /switch workspace/i }));
-    const menu = screen.getByRole("menu");
-    expect(within(menu).getByText("jikigai")).toBeInTheDocument();
-    expect(within(menu).getByText("Acme Studio")).toBeInTheDocument();
-    expect(within(menu).queryByText("Untitled")).not.toBeInTheDocument();
-  });
+  // AC7 note: the switcher renders whatever organizationName the resolver
+  // supplies (covered by the render tests above). The "Untitled" fallback is
+  // owned by the resolver, NOT this component — that arm is tested directly in
+  // test/org-memberships-resolver.test.ts (feat-one-shot-workspace-untitled-name).
 });

--- a/apps/web-platform/test/rename-workspace-action.test.tsx
+++ b/apps/web-platform/test/rename-workspace-action.test.tsx
@@ -36,8 +36,9 @@ describe("RenameWorkspaceAction", () => {
   });
 
   it("owner can rename: input is prefilled, POSTs the new name, updates display", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response(JSON.stringify({ ok: true, name: "Acme Studio" }), { status: 200 }),
+    const fetchMock = vi.fn(
+      async (_url: string, _init?: RequestInit) =>
+        new Response(JSON.stringify({ ok: true, name: "Acme Studio" }), { status: 200 }),
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -57,7 +58,8 @@ describe("RenameWorkspaceAction", () => {
         expect.objectContaining({ method: "POST" }),
       );
     });
-    const sentBody = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    const init = fetchMock.mock.calls[0][1]!;
+    const sentBody = JSON.parse(init.body as string);
     expect(sentBody).toEqual({ organizationId: ORG_ID, name: "Acme Studio" });
 
     await waitFor(() => {

--- a/apps/web-platform/test/rename-workspace-action.test.tsx
+++ b/apps/web-platform/test/rename-workspace-action.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { RenameWorkspaceAction } from "@/components/settings/rename-workspace-action";
+
+// AC5: owner-only rename control on /dashboard/settings/team, prefilled with
+// the current org name. Non-owners see the name but no edit affordance.
+
+const ORG_ID = "00000000-0000-0000-0000-0000000000aa";
+
+describe("RenameWorkspaceAction", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("owner sees the current name and a Rename control", () => {
+    render(
+      <RenameWorkspaceAction organizationId={ORG_ID} organizationName="My Workspace" isOwner />,
+    );
+    expect(screen.getByTestId("workspace-name").textContent).toBe("My Workspace");
+    expect(screen.getByRole("button", { name: /rename/i })).toBeInTheDocument();
+  });
+
+  it("non-owner sees the name but no Rename control", () => {
+    render(
+      <RenameWorkspaceAction
+        organizationId={ORG_ID}
+        organizationName="My Workspace"
+        isOwner={false}
+      />,
+    );
+    expect(screen.getByTestId("workspace-name").textContent).toBe("My Workspace");
+    expect(screen.queryByRole("button", { name: /rename/i })).not.toBeInTheDocument();
+  });
+
+  it("owner can rename: input is prefilled, POSTs the new name, updates display", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ ok: true, name: "Acme Studio" }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <RenameWorkspaceAction organizationId={ORG_ID} organizationName="My Workspace" isOwner />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /rename/i }));
+
+    const input = screen.getByLabelText(/workspace name/i) as HTMLInputElement;
+    expect(input.value).toBe("My Workspace"); // prefilled
+    fireEvent.change(input, { target: { value: "Acme Studio" } });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/workspace/rename",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const sentBody = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(sentBody).toEqual({ organizationId: ORG_ID, name: "Acme Studio" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workspace-name").textContent).toBe("Acme Studio");
+    });
+  });
+
+  it("rejects empty/whitespace name without calling the API", () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <RenameWorkspaceAction organizationId={ORG_ID} organizationName="My Workspace" isOwner />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /rename/i }));
+    const input = screen.getByLabelText(/workspace name/i);
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("surfaces an error when the API call fails", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ error: "rpc_failed" }), { status: 500 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <RenameWorkspaceAction organizationId={ORG_ID} organizationName="My Workspace" isOwner />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /rename/i }));
+    fireEvent.change(screen.getByLabelText(/workspace name/i), {
+      target: { value: "Acme Studio" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    // Display name unchanged on failure.
+    expect(screen.getByTestId("workspace-name").textContent).toBe("My Workspace");
+  });
+});

--- a/apps/web-platform/test/server/rename-organization.test.ts
+++ b/apps/web-platform/test/server/rename-organization.test.ts
@@ -1,0 +1,195 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// POST /api/workspace/rename (feat-one-shot-workspace-untitled-name).
+// Mirrors transfer-ownership's auth chain: CSRF → auth → page-data resolve →
+// flag gate → org-match → owner-check → renameOrganization. Owner-only
+// (single-user-incident threshold): non-owner and cross-org callers are
+// rejected before the RPC runs; RPC failure reasons map to 400/403/404/500.
+
+const {
+  mockGetUser,
+  mockValidateOrigin,
+  mockRejectCsrf,
+  mockResolvePageData,
+  mockIsTeamWorkspaceInviteEnabled,
+  mockRename,
+} = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockValidateOrigin: vi.fn(() => ({ valid: true, origin: "https://app.soleur.ai" })),
+  mockRejectCsrf: vi.fn(() => new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 })),
+  mockResolvePageData: vi.fn(),
+  mockIsTeamWorkspaceInviteEnabled: vi.fn(async () => true),
+  mockRename: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } })),
+  createServiceClient: vi.fn(() => ({})),
+}));
+
+vi.mock("@/lib/auth/validate-origin", () => ({
+  validateOrigin: mockValidateOrigin,
+  rejectCsrf: mockRejectCsrf,
+}));
+
+vi.mock("@/lib/feature-flags/server", () => ({
+  isTeamWorkspaceInviteEnabled: mockIsTeamWorkspaceInviteEnabled,
+}));
+
+vi.mock("@/server/team-membership-resolver", () => ({
+  resolveTeamMembershipPageData: mockResolvePageData,
+}));
+
+vi.mock("@/server/workspace-membership", () => ({
+  renameOrganization: mockRename,
+}));
+
+import { POST } from "@/app/api/workspace/rename/route";
+
+const OWNER_ID = "owner-uuid";
+const WORKSPACE_ID = "ws-uuid";
+const ORG_ID = "org-uuid";
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request("https://app.soleur.ai/api/workspace/rename", {
+    method: "POST",
+    headers: { origin: "https://app.soleur.ai", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function ownerPageData() {
+  return {
+    ok: true,
+    data: {
+      workspaceId: WORKSPACE_ID,
+      organizationId: ORG_ID,
+      organizationName: "My Workspace",
+      currentUserId: OWNER_ID,
+      members: [{ userId: OWNER_ID, role: "owner" }],
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockValidateOrigin.mockReturnValue({ valid: true, origin: "https://app.soleur.ai" });
+  mockRejectCsrf.mockReturnValue(new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 }));
+  mockIsTeamWorkspaceInviteEnabled.mockResolvedValue(true);
+  mockGetUser.mockResolvedValue({ data: { user: { id: OWNER_ID, email: "o@example.com" } } });
+  mockResolvePageData.mockResolvedValue(ownerPageData());
+  mockRename.mockResolvedValue({ ok: true });
+});
+
+describe("POST /api/workspace/rename", () => {
+  test("200 happy path — owner renames; RPC called with org, name, caller", async () => {
+    const res = await POST(makeRequest({ organizationId: ORG_ID, name: "Acme Studio" }));
+    expect(res.status).toBe(200);
+    expect(mockRename).toHaveBeenCalledWith({
+      organizationId: ORG_ID,
+      name: "Acme Studio",
+      callerUserId: OWNER_ID,
+    });
+  });
+
+  test("403 (CSRF) when origin invalid", async () => {
+    mockValidateOrigin.mockReturnValue({ valid: false, origin: "https://evil.example" });
+    const res = await POST(makeRequest({ organizationId: ORG_ID, name: "Acme" }));
+    expect(res.status).toBe(403);
+    expect(mockRename).not.toHaveBeenCalled();
+  });
+
+  test("401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(makeRequest({ organizationId: ORG_ID, name: "Acme" }));
+    expect(res.status).toBe(401);
+    expect(mockRename).not.toHaveBeenCalled();
+  });
+
+  test("404 when the flag is disabled", async () => {
+    mockIsTeamWorkspaceInviteEnabled.mockResolvedValue(false);
+    const res = await POST(makeRequest({ organizationId: ORG_ID, name: "Acme" }));
+    expect(res.status).toBe(404);
+    expect(mockRename).not.toHaveBeenCalled();
+  });
+
+  test("404 when page-data resolution fails", async () => {
+    mockResolvePageData.mockResolvedValue({ ok: false, reason: "no-membership" });
+    const res = await POST(makeRequest({ organizationId: ORG_ID, name: "Acme" }));
+    expect(res.status).toBe(404);
+    expect(mockRename).not.toHaveBeenCalled();
+  });
+
+  test("400 when name missing", async () => {
+    const res = await POST(makeRequest({ organizationId: ORG_ID }));
+    expect(res.status).toBe(400);
+    expect(mockRename).not.toHaveBeenCalled();
+  });
+
+  test("400 when name is whitespace-only", async () => {
+    const res = await POST(makeRequest({ organizationId: ORG_ID, name: "   " }));
+    expect(res.status).toBe(400);
+    expect(mockRename).not.toHaveBeenCalled();
+  });
+
+  test("400 when name exceeds 60 chars", async () => {
+    const res = await POST(makeRequest({ organizationId: ORG_ID, name: "x".repeat(61) }));
+    expect(res.status).toBe(400);
+    expect(mockRename).not.toHaveBeenCalled();
+  });
+
+  test("403 org_mismatch when body org != caller's org", async () => {
+    const res = await POST(makeRequest({ organizationId: "other-org", name: "Acme" }));
+    expect(res.status).toBe(403);
+    expect(mockRename).not.toHaveBeenCalled();
+  });
+
+  test("403 not_owner when caller is a member, not owner", async () => {
+    mockResolvePageData.mockResolvedValue({
+      ok: true,
+      data: {
+        workspaceId: WORKSPACE_ID,
+        organizationId: ORG_ID,
+        organizationName: "My Workspace",
+        currentUserId: OWNER_ID,
+        members: [{ userId: OWNER_ID, role: "member" }],
+      },
+    });
+    const res = await POST(makeRequest({ organizationId: ORG_ID, name: "Acme" }));
+    expect(res.status).toBe(403);
+    expect(mockRename).not.toHaveBeenCalled();
+  });
+
+  test("403 when RPC reports caller_not_owner", async () => {
+    mockRename.mockResolvedValue({ ok: false, reason: "caller_not_owner" });
+    const res = await POST(makeRequest({ organizationId: ORG_ID, name: "Acme" }));
+    expect(res.status).toBe(403);
+  });
+
+  test("400 when RPC reports invalid_name", async () => {
+    mockRename.mockResolvedValue({ ok: false, reason: "invalid_name" });
+    const res = await POST(makeRequest({ organizationId: ORG_ID, name: "Acme" }));
+    expect(res.status).toBe(400);
+  });
+
+  test("404 when RPC reports not_found", async () => {
+    mockRename.mockResolvedValue({ ok: false, reason: "not_found" });
+    const res = await POST(makeRequest({ organizationId: ORG_ID, name: "Acme" }));
+    expect(res.status).toBe(404);
+  });
+
+  test("500 when RPC reports rpc_failed", async () => {
+    mockRename.mockResolvedValue({ ok: false, reason: "rpc_failed" });
+    const res = await POST(makeRequest({ organizationId: ORG_ID, name: "Acme" }));
+    expect(res.status).toBe(500);
+  });
+
+  test("name is trimmed before forwarding to the RPC wrapper", async () => {
+    await POST(makeRequest({ organizationId: ORG_ID, name: "  Acme Studio  " }));
+    expect(mockRename).toHaveBeenCalledWith({
+      organizationId: ORG_ID,
+      name: "Acme Studio",
+      callerUserId: OWNER_ID,
+    });
+  });
+});

--- a/apps/web-platform/test/supabase-migrations/091-rename-organization.test.ts
+++ b/apps/web-platform/test/supabase-migrations/091-rename-organization.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// Migration-shape test for 091_rename_organization_and_default_names.sql.
+//
+// Pins the SQL invariants of the org-name fix (feat-one-shot-workspace-
+// untitled-name) so a future edit that drops them is caught at PR-time
+// without requiring a live Supabase. Structural pattern mirrors
+// 063-workspace-member-actions.test.ts (readFileSync + regex on source).
+//
+// Covers:
+//   - AC1 (trigger default): handle_new_user re-derives the FULL 053 body
+//     and inserts a non-NULL default for organizations.name + workspaces.name,
+//     WITHOUT dropping any 053 arm (public.users insert, canary guard,
+//     org/workspace/member creation).
+//   - AC2 (backfill): UPDATE organizations SET name = default WHERE name IS NULL.
+//   - AC3 (rename RPC): rename_organization SECURITY DEFINER + pinned
+//     search_path + auth.uid() owner-gate + name validation + REVOKE/GRANT.
+//   - SECURITY DEFINER hygiene (search_path pin on every definer fn).
+//   - down migration drops the RPC + restores the prior handle_new_user body.
+
+const MIGRATION_PATH = path.join(
+  __dirname,
+  "../../supabase/migrations/091_rename_organization_and_default_names.sql",
+);
+const DOWN_PATH = path.join(
+  __dirname,
+  "../../supabase/migrations/091_rename_organization_and_default_names.down.sql",
+);
+
+describe("migration 091_rename_organization_and_default_names", () => {
+  const sql = readFileSync(MIGRATION_PATH, "utf8");
+  const down = readFileSync(DOWN_PATH, "utf8");
+  // Strip line comments so prose mentioning "NULL" / "auth.uid()" doesn't
+  // satisfy executable-code assertions.
+  const executable = sql.replace(/--[^\n]*/g, "");
+
+  describe("AC3: rename_organization RPC", () => {
+    it("declares rename_organization(p_organization_id uuid, p_name text, p_caller_user_id uuid DEFAULT NULL)", () => {
+      expect(executable).toMatch(
+        /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.rename_organization\(\s*p_organization_id\s+uuid\s*,\s*p_name\s+text\s*,\s*p_caller_user_id\s+uuid\s+DEFAULT\s+NULL\s*\)/i,
+      );
+    });
+
+    it("resolves caller via COALESCE(p_caller_user_id, auth.uid()) for service-role invocation", () => {
+      const body = executable.match(
+        /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.rename_organization\([\s\S]*?\$\$([\s\S]*?)\$\$;/i,
+      );
+      expect(body![1]).toMatch(
+        /COALESCE\(\s*p_caller_user_id\s*,\s*auth\.uid\(\)\s*\)/i,
+      );
+    });
+
+    it("is SECURITY DEFINER plpgsql with pinned search_path", () => {
+      const fn = executable.match(
+        /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.rename_organization\([\s\S]*?AS\s+\$\$/i,
+      );
+      expect(fn).not.toBeNull();
+      expect(fn![0]).toMatch(/LANGUAGE\s+plpgsql/i);
+      expect(fn![0]).toMatch(/SECURITY\s+DEFINER/i);
+      expect(fn![0]).toMatch(/SET\s+search_path\s*=\s*public,\s*pg_temp/i);
+    });
+
+    it("authenticates via auth.uid() and raises 28000 when NULL", () => {
+      const body = executable.match(
+        /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.rename_organization\([\s\S]*?\$\$([\s\S]*?)\$\$;/i,
+      );
+      expect(body).not.toBeNull();
+      expect(body![1]).toMatch(/auth\.uid\(\)/i);
+      expect(body![1]).toMatch(/ERRCODE\s*=\s*'28000'/i);
+    });
+
+    it("owner-gates on workspace_members role='owner' joined to the org and raises 42501", () => {
+      const body = executable.match(
+        /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.rename_organization\([\s\S]*?\$\$([\s\S]*?)\$\$;/i,
+      );
+      expect(body![1]).toMatch(/role\s*=\s*'owner'/i);
+      expect(body![1]).toMatch(
+        /JOIN\s+public\.workspaces\s+w\s+ON\s+w\.id\s*=\s*m\.workspace_id/i,
+      );
+      expect(body![1]).toMatch(/caller is not an owner/i);
+      expect(body![1]).toMatch(/ERRCODE\s*=\s*'42501'/i);
+    });
+
+    it("validates name: trims, rejects empty, bounds length to 60", () => {
+      const body = executable.match(
+        /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.rename_organization\([\s\S]*?\$\$([\s\S]*?)\$\$;/i,
+      );
+      expect(body![1]).toMatch(/btrim\(/i);
+      expect(body![1]).toMatch(/length\([^)]*\)\s*=\s*0/i);
+      expect(body![1]).toMatch(/length\([^)]*\)\s*>\s*60/i);
+      expect(body![1]).toMatch(/ERRCODE\s*=\s*'22023'/i);
+    });
+
+    it("updates organizations.name and REVOKE/GRANTs per convention", () => {
+      const body = executable.match(
+        /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.rename_organization\([\s\S]*?\$\$([\s\S]*?)\$\$;/i,
+      );
+      expect(body![1]).toMatch(
+        /UPDATE\s+public\.organizations\s+SET\s+name\s*=/i,
+      );
+      expect(executable).toMatch(
+        /REVOKE\s+ALL\s+ON\s+FUNCTION\s+public\.rename_organization\(uuid,\s*text,\s*uuid\)\s+FROM\s+PUBLIC,\s*anon,\s*authenticated/i,
+      );
+      expect(executable).toMatch(
+        /GRANT\s+EXECUTE\s+ON\s+FUNCTION\s+public\.rename_organization\(uuid,\s*text,\s*uuid\)\s+TO\s+authenticated/i,
+      );
+    });
+  });
+
+  describe("AC1: handle_new_user re-derivation with non-NULL defaults", () => {
+    const triggerBody = (sqlSrc: string) =>
+      sqlSrc
+        .replace(/--[^\n]*/g, "")
+        .match(
+          /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.handle_new_user\(\)[\s\S]*?\$\$([\s\S]*?)\$\$;/i,
+        );
+
+    it("re-issues handle_new_user as SECURITY DEFINER with pinned search_path", () => {
+      const fn = executable.match(
+        /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.handle_new_user\(\)[\s\S]*?AS\s+\$\$/i,
+      );
+      expect(fn).not.toBeNull();
+      expect(fn![0]).toMatch(/SECURITY\s+DEFINER/i);
+      expect(fn![0]).toMatch(/SET\s+search_path\s*=\s*public,\s*pg_temp/i);
+    });
+
+    it("preserves every 053 arm (public.users insert, canary guard, workspace + member creation)", () => {
+      const body = triggerBody(sql);
+      expect(body).not.toBeNull();
+      expect(body![1]).toMatch(/INSERT\s+INTO\s+public\.users/i);
+      expect(body![1]).toMatch(/ON\s+CONFLICT\s+\(id\)\s+DO\s+NOTHING/i);
+      // canary owner-row idempotency guard
+      expect(body![1]).toMatch(
+        /SELECT\s+1\s+FROM\s+public\.workspace_members[\s\S]*?role\s*=\s*'owner'/i,
+      );
+      expect(body![1]).toMatch(/INSERT\s+INTO\s+public\.organizations/i);
+      expect(body![1]).toMatch(/INSERT\s+INTO\s+public\.workspaces/i);
+      expect(body![1]).toMatch(
+        /INSERT\s+INTO\s+public\.workspace_members[\s\S]*?'owner'/i,
+      );
+    });
+
+    it("inserts a non-NULL default org name (NOT a NULL literal)", () => {
+      const body = triggerBody(sql);
+      // The organizations INSERT must not pass NULL for name. Assert the
+      // default-name constant is present and the bare `NULL, NULL` pair from
+      // 053 (name, domain) no longer appears in the org insert.
+      expect(body![1]).toMatch(/INSERT\s+INTO\s+public\.organizations[\s\S]*?'My Workspace'/i);
+    });
+  });
+
+  describe("AC2: backfill NULL org names to the default", () => {
+    it("UPDATEs organizations SET name to the default WHERE name IS NULL", () => {
+      expect(executable).toMatch(
+        /UPDATE\s+public\.organizations\s+SET\s+name\s*=\s*'My Workspace'\s+WHERE\s+name\s+IS\s+NULL/i,
+      );
+    });
+
+    it("also backfills NULL workspace names (defensive)", () => {
+      expect(executable).toMatch(
+        /UPDATE\s+public\.workspaces\s+SET\s+name\s*=\s*'My Workspace'\s+WHERE\s+name\s+IS\s+NULL/i,
+      );
+    });
+  });
+
+  describe("SECURITY DEFINER hygiene", () => {
+    it("every SECURITY DEFINER function pins SET search_path = public, pg_temp", () => {
+      const definerFns = executable.match(
+        /CREATE\s+OR\s+REPLACE\s+FUNCTION[\s\S]*?SECURITY\s+DEFINER[\s\S]*?(?=\$\$)/gi,
+      );
+      expect(definerFns).not.toBeNull();
+      for (const fn of definerFns!) {
+        expect(
+          fn,
+          `SECURITY DEFINER fn missing search_path pin:\n${fn.slice(0, 160)}`,
+        ).toMatch(/SET\s+search_path\s*=\s*public,\s*pg_temp/i);
+      }
+    });
+  });
+
+  describe("down migration", () => {
+    it("drops rename_organization", () => {
+      expect(down).toMatch(
+        /DROP\s+FUNCTION\s+IF\s+EXISTS\s+public\.rename_organization/i,
+      );
+    });
+
+    it("restores handle_new_user with the prior NULL-name body", () => {
+      expect(down).toMatch(
+        /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.handle_new_user\(\)/i,
+      );
+      const body = down
+        .replace(/--[^\n]*/g, "")
+        .match(
+          /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.handle_new_user\(\)[\s\S]*?\$\$([\s\S]*?)\$\$;/i,
+        );
+      expect(body).not.toBeNull();
+      // The restored body inserts NULL for the org name (053 shape).
+      expect(body![1]).toMatch(
+        /INSERT\s+INTO\s+public\.organizations[\s\S]*?VALUES\s*\(\s*gen_random_uuid\(\)\s*,\s*NULL\s*,\s*NULL/i,
+      );
+    });
+
+    it("does NOT revert the backfill (names are user data)", () => {
+      expect(down).not.toMatch(
+        /UPDATE\s+public\.organizations\s+SET\s+name\s*=\s*NULL/i,
+      );
+    });
+  });
+});

--- a/apps/web-platform/test/supabase-migrations/091-rename-organization.test.ts
+++ b/apps/web-platform/test/supabase-migrations/091-rename-organization.test.ts
@@ -103,7 +103,13 @@ describe("migration 091_rename_organization_and_default_names", () => {
       expect(executable).toMatch(
         /REVOKE\s+ALL\s+ON\s+FUNCTION\s+public\.rename_organization\(uuid,\s*text,\s*uuid\)\s+FROM\s+PUBLIC,\s*anon,\s*authenticated/i,
       );
+      // SECURITY: grant to service_role ONLY. The RPC accepts a caller-override
+      // (p_caller_user_id) — granting EXECUTE to `authenticated` would let any
+      // user forge the owner identity via PostgREST and bypass the route gate.
       expect(executable).toMatch(
+        /GRANT\s+EXECUTE\s+ON\s+FUNCTION\s+public\.rename_organization\(uuid,\s*text,\s*uuid\)\s+TO\s+service_role/i,
+      );
+      expect(executable).not.toMatch(
         /GRANT\s+EXECUTE\s+ON\s+FUNCTION\s+public\.rename_organization\(uuid,\s*text,\s*uuid\)\s+TO\s+authenticated/i,
       );
     });

--- a/knowledge-base/project/learnings/security-issues/2026-06-01-caller-override-rpc-needs-service-role-only-grant.md
+++ b/knowledge-base/project/learnings/security-issues/2026-06-01-caller-override-rpc-needs-service-role-only-grant.md
@@ -1,0 +1,78 @@
+# Learning: a SECURITY DEFINER caller-override param is ONLY safe behind a service_role-only grant
+
+## Problem
+
+Migration 091 added `rename_organization`, an owner-gated SECURITY DEFINER RPC. The
+TS wrapper invokes it via `createServiceClient()` (service-role key), under which
+`auth.uid()` is NULL — so a pure `auth.uid()` owner-gate (the mig 075
+`transfer_workspace_ownership` shape) would `RAISE 28000` on every call. To make
+the gate work, the RPC was given a caller-override parameter:
+
+```sql
+CREATE OR REPLACE FUNCTION public.rename_organization(
+  p_organization_id uuid, p_name text, p_caller_user_id uuid DEFAULT NULL
+) ... AS $$
+  v_caller := COALESCE(p_caller_user_id, auth.uid());
+  -- owner-gate on v_caller ...
+$$;
+GRANT EXECUTE ON FUNCTION public.rename_organization(uuid, text, uuid) TO authenticated;  -- BUG
+```
+
+This shipped through plan + work + the migration's own 16-test shape suite, all
+green. **security-sentinel caught it at review as a P1:** because the override is
+client-supplied AND `authenticated` could reach the RPC via PostgREST
+(`POST /rest/v1/rpc/rename_organization`), any logged-in user could forge
+`p_caller_user_id = <victim owner uuid>` and rename any organization — bypassing
+the route's entire CSRF/flag/owner-check defense stack. Victim owner uuids are
+discoverable via the peer-visible `workspace_members` select.
+
+## Solution
+
+Grant the RPC to `service_role` **only** (REVOKE from authenticated), mirroring
+`accept_workspace_invitation` (mig 076/085) — the precedent the override pattern
+was actually copied from:
+
+```sql
+REVOKE ALL ON FUNCTION public.rename_organization(uuid, text, uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.rename_organization(uuid, text, uuid)
+  TO service_role;
+```
+
+The sole caller is the trusted server wrapper (`createServiceClient()`), which
+forwards the route's verified `getUser()` id. `authenticated`/`anon` can no longer
+reach the forgeable override. A regression guard was added to the migration shape
+test (`not.toMatch(/GRANT ... rename_organization ... TO authenticated/)`) and a
+CI verify sentinel (`has_function_privilege('authenticated', ...) = false`).
+
+## Key Insight
+
+There are exactly two safe SECURITY DEFINER owner-gate shapes in this codebase, and
+they form one rule, not a menu:
+
+| Shape | Caller identity | Grant | Why safe |
+|---|---|---|---|
+| `transfer_workspace_ownership` (075) | pure `auth.uid()` (non-forgeable) | `TO authenticated` | the JWT `sub` cannot be forged |
+| `accept_workspace_invitation` (076/085), `rename_organization` (091) | `COALESCE(p_caller_user_id, auth.uid())` (forgeable) | `TO service_role` only | the override is unreachable except via the trusted service-role server layer |
+
+**The invariant: a function that accepts a forgeable caller-override param MUST be
+service_role-only.** Mixing the override param (from one precedent) with
+`GRANT TO authenticated` (from the other) is a privilege-escalation primitive. When
+copying a SECURITY DEFINER precedent, copy BOTH halves — the identity source AND the
+grant scope are a matched pair.
+
+Corollary surfaced in the same review: `transfer_workspace_ownership` itself may be
+latently broken — pure `auth.uid()` under its service-role wrapper means
+`auth.uid()` is NULL → 28000 on every call. Filed as #4765 for verification (the
+reason 091 correctly diverged from the 075 shape).
+
+## Tags
+category: security-issues
+module: apps/web-platform/supabase/migrations
+
+## Session Errors
+
+1. **P1 owner-gate bypass self-introduced** (forgeable override + `GRANT TO authenticated`) — Recovery: grant to `service_role` only + regression test + verify sentinel. Prevention: when adopting a caller-override SECURITY DEFINER pattern, copy the grant scope from the SAME precedent as the param, never mix.
+2. **Bash CWD drift across calls** — the harness persists shell CWD; it flipped between worktree root and `apps/web-platform`, causing `apps/web-platform/apps/web-platform/` path errors and missing `./node_modules/.bin/vitest`. Recovery: re-anchor. Prevention: prefix every Bash call with an absolute `cd <worktree>/apps/web-platform &&`.
+3. **tsc errors after rename refactor** (missed `trimmed`→`validated.trimmed` in the route success return; untyped fetch mock zero-arg tuple) — Recovery: fix references + type the mock signature. Prevention: run pinned `./node_modules/.bin/tsc --noEmit` after every rename/extract refactor (the gate caught it pre-commit).
+4. **psql unavailable locally** — QA DB-verify could not run directly. Recovery: graceful degradation to the CI verify sentinel (the no-eyeball automated mechanism). Not a defect; no prevention needed.

--- a/knowledge-base/project/plans/2026-06-01-fix-org-name-null-untitled-switcher-plan.md
+++ b/knowledge-base/project/plans/2026-06-01-fix-org-name-null-untitled-switcher-plan.md
@@ -1,0 +1,282 @@
+---
+title: "Fix: workspaces display as \"Untitled\" because organizations.name is always NULL"
+type: fix
+date: 2026-06-01
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+---
+
+<!-- iac-routing-ack: plan-phase-2-8-reviewed -->
+<!-- Phase 2.8 reviewed: this plan introduces NO new infrastructure (no server, secret, vendor, cron, DNS, TLS, firewall). It is a pure code change against the already-provisioned web-platform — one Supabase migration (applied by the existing web-platform-release.yml#migrate pipeline on merge), one RPC, one Next.js route, two component edits. The only "operator runs" phrasing is a read-only psql discoverability probe (SELECT count), not provisioning. No Terraform changes required. -->
+
+## Enhancement Summary
+
+**Deepened on:** 2026-06-01
+**Sections enhanced:** Technical Considerations (precedent-diff), Dependencies & Risks, Sharp Edges
+**Gates passed:** 4.6 User-Brand Impact (present, threshold `single-user incident`), 4.7 Observability (5/5 fields, no SSH), 4.8 PAT-shaped (none), 4.4 Precedent-Diff (SECURITY DEFINER RPC + owner-gate diffed against mig 075). 4.5 Network-Outage: skipped (no SSH/network triggers). 4.4 Scheduled-work: skipped (no new cron).
+
+### Key Improvements
+1. **Precedent-diff (Phase 4.4):** the rename RPC is confirmed *simpler* than the cited transfer-ownership precedent — no audit GUC, no attestation, no multi-row transaction (see Research Insights below). The `organizations` table has **no** audit trigger (audit triggers target `workspace_members` only), so the rename RPC must NOT set `workspace_audit.actor_user_id`.
+2. **Verify-the-negative (Phase 4.45):** confirmed both load-bearing negative claims hold against `origin`-state code — (a) no `NOT NULL` to be added on `organizations.name`; (b) no RLS UPDATE policy exists on `organizations` for `authenticated` (grep of mig 053 shows only SELECT policies), so the RPC is genuinely the sole authenticated write path.
+3. **No external infra / scheduled work** — pure code change; IaC + cron gates correctly skip.
+
+### New Considerations Discovered
+- The rename RPC's owner-check should use `auth.uid()` + `FOR UPDATE` row lock + `ERRCODE = '42501'` (insufficient_privilege) exactly as mig 075:55-62, but WITHOUT the attestation/self-transfer/target-member guards (irrelevant to a name change).
+- Because `organizations` carries no audit trigger, a future audit requirement on org renames would need a NEW trigger — out of scope here, but note it so a reviewer doesn't expect actor-GUC plumbing.
+
+# Fix: workspaces display as "Untitled" in the org switcher (organizations.name is always NULL)
+
+## Overview
+
+Every organization row carries `name = NULL`. The backfill (migration `053_organizations_and_workspace_members.sql:229`), the signup trigger `handle_new_user()` (`053:314`), and every other write path insert `name = NULL`. The dashboard org switcher renders `organizationName ?? "Untitled"` (`server/org-memberships-resolver.ts:146`), so multi-workspace users see a list of indistinguishable "Untitled" rows. The switcher hides itself for solo users (`components/dashboard/org-switcher.tsx:63`, `memberships.length <= 1`), which is why the defect only surfaces once a user belongs to 2+ workspaces.
+
+Migration 053 documented the intended contract verbatim (`053:44-48`): *"New organizations created post-flag-flip MUST set name (enforced at application layer via the invite flow; no NOT NULL constraint here so the backfill stays single-statement)."* That enforcement was deferred to "Phase 5.4" and never built — there is no onboarding name prompt, no name capture in the invite flow, and no rename UI (`/dashboard/settings/team` only lists members + invites).
+
+This plan closes the contract three ways: (a) **name capture at the only moment that matters** — when an owner first invites a teammate (the org/workspace already exists by then; see Research Reconciliation), plus a generic non-NULL default so no org is ever displayed as the literal sentinel "Untitled"; (b) a **rename UI** in `/dashboard/settings/team` so owners can name/rename their workspace; (c) a **one-time backfill** of existing NULL-name orgs to a non-PII default so current multi-workspace users stop seeing "Untitled".
+
+## Problem Statement / Motivation
+
+The org switcher is the operator's primary signal of *which workspace am I acting in*. When every row reads "Untitled", a user with a personal workspace + a team workspace cannot tell them apart — they can switch into the wrong billing/data context blind. For Soleur's non-technical target user this is a trust-eroding, potentially data-exposing defect (acting in the wrong workspace), which is why the brand-survival threshold is `single-user incident`.
+
+## Research Reconciliation — Spec vs. Codebase
+
+The one-shot context framed three fix levers. Direct file verification (2026-06-01) confirmed the bug mechanism exactly but **corrected the framing of lever (a)**:
+
+| Premise (from one-shot context) | Reality (verified) | Plan response |
+|---|---|---|
+| `organizations.name` nullable; backfill + `handle_new_user()` insert NULL | CONFIRMED — `053:49` (`name text NULL`), `053:229` (backfill `SELECT gen_random_uuid(), NULL, …`), `053:314-319` (trigger inserts NULL org + NULL workspace) | Address at all three write surfaces |
+| `org-memberships-resolver.ts:146` falls back to "Untitled" | CONFIRMED — `const orgName = orgNameById.get(ws.organization_id) ?? "Untitled"` (stored value is `null` → `?? "Untitled"`) | Keep the `?? "Untitled"` as a last-resort guard; the real fix is making `name` non-NULL upstream so the guard never fires |
+| `org-switcher.tsx:63` hides for `<= 1` memberships | CONFIRMED — `if (memberships.length <= 1) return null` | No change needed; explains why the bug only shows for 2+ workspaces |
+| "capture a name … in the invite flow" | **CORRECTED**: the invite flow (`server/workspace-invitations.ts:153`, `app/api/workspace/invite-member/route.ts`) adds a member to the **inviter's existing** workspace via `p_workspace_id`. It does **not** create an org. The inviter's org already exists (as a backfilled NULL-name row) before they ever invite. | Name-capture for lever (a) = prompt the owner to name their workspace **at first-invite time** (the invite modal), writing to the existing org — not "create org with name". |
+| "capture a name at signup/onboarding" | **MOOT for the NULL problem**: there is no onboarding flow and no `server/auth/` TS signup fallback (the "TS fallback" referenced at `053:198,277` was never built). Every signup org is NULL by the trigger. | The non-NULL default belongs in the **trigger + backfill** (a generic label), not a signup UI we'd have to build from scratch. A signup name-prompt is explicitly a Non-Goal. |
+| No rename UI exists | CONFIRMED — `app/(dashboard)/dashboard/settings/team/page.tsx` lists members + pending invites only; it already resolves `data.organizationName` and passes it to `TeamMembershipList` (`page.tsx:77`), so the display surface exists but no edit control | Add rename control to the team page (owner-only) |
+| No rename RPC exists | CONFIRMED — `grep` for `set_organization_name`/`update … organizations` returns nothing in `server/` or `supabase/migrations/` | Add migration `091` rename RPC (mirror `075_transfer_workspace_ownership.sql` owner-gate + SECURITY DEFINER shape) |
+
+**Premise Validation note:** All cited artifacts exist and behave as described; the only correction is the invite-flow framing (invite != org creation). Latest migration on disk is `090` → new migration is `091`. No external premises (issue/PR references) were cited. The team page + rename route are gated behind the Flagsmith flag `isTeamWorkspaceInviteEnabled` (`lib/feature-flags/server.ts`), so the rename UI is naturally scoped to the same multi-user population that sees the switcher.
+
+## Proposed Solution
+
+Make `organizations.name` effectively non-NULL at every write surface, give owners a way to set/change it, and backfill the existing NULL rows:
+
+1. **Trigger default (DB):** `handle_new_user()` inserts a generic non-PII default name (e.g. `'My Workspace'`) for the new org and workspace instead of `NULL`. Solo users still never see the switcher, but the value is meaningful the moment they go multi-workspace or open team settings.
+2. **First-invite name capture (UI + route):** the invite modal (`components/settings/invite-member-action.tsx`) gains an optional "Name your workspace" field shown when the current org still carries the default/NULL name. Submitting the invite also calls the rename RPC. This is the "enforced at application layer via the invite flow" contract from `053:46`, implemented at the correct grain (rename existing org, not create).
+3. **Rename UI + RPC (UI + route + DB):** owner-only rename control on `/dashboard/settings/team`, posting to `POST /api/workspace/rename` → `rename_organization` RPC (migration `091`), mirroring the `transfer-ownership` owner-gate + CSRF + flag-gate precedent.
+4. **Backfill (DB):** migration `091` updates existing `organizations.name IS NULL` rows to a generic default. **Default to a generic label, NOT the owner's email/name** (privacy: the org name is visible to all workspace peers via `orgs_select_for_members`; leaking the owner's email into a peer-visible field is an avoidable disclosure — see Technical Considerations).
+5. **Resolver guard retained:** keep `?? "Untitled"` in `org-memberships-resolver.ts:146` as defense-in-depth; after this change it should be unreachable, and a test asserts no production row is NULL post-backfill.
+
+## Technical Considerations
+
+- **Architecture impacts:** One new migration (`091`), one new RPC, one new route, one resolver/UI touch. No schema-type change to `organizations.name` (stays `text NULL` — adding `NOT NULL` would break the single-statement backfill invariant `053:47-48` and any in-flight insert ordering; we enforce non-NULL at the application + trigger + backfill layers instead, exactly as the 053 contract intended). State this explicitly so a reviewer does not push for a `NOT NULL` constraint.
+- **Security / RLS:** `rename_organization` must be `SECURITY DEFINER LANGUAGE plpgsql SET search_path = public, pg_temp` (per `cq-pg-security-definer-search-path-pin-pg-temp`), with an `auth.uid()` owner-check (caller must be `role='owner'` on a workspace in the target org) — mirror `075:35-55`. `REVOKE ALL … FROM PUBLIC, anon, authenticated, service_role; GRANT EXECUTE … TO authenticated` per the 053/075 grant convention. Do NOT add an RLS UPDATE policy to `organizations` for `authenticated` — route the write through the RPC only (same pattern as 053:154-157 "INSERT/UPDATE/DELETE routed through SECURITY DEFINER RPCs").
+- **Privacy (GDPR, advisory):** the `name` column is user-supplied free-text rendered to all workspace peers (`orgs_select_for_members`, `053:159`). Backfilling NULL → owner email would surface the owner's email to every peer who can read the org. Default to a generic `'My Workspace'` (or owner-display-name only if a non-email display name is already peer-visible elsewhere). No new Article 30 Processing Activity is required: this is value-population within the already-registered `organizations` table under the existing Art. 6(1)(b) lawful basis (`053:6-11`); no new collection, disclosure, or third-party transfer. (Confirm with `/soleur:gdpr-gate` at /work.)
+- **Input validation:** rename RPC + route must bound name length (e.g. 1–60 chars after trim), reject empty/whitespace-only, and trim. Mirror the `attestationText.length` validation pattern in `transfer-ownership/route.ts:54`.
+- **NFR impacts:** negligible — single-row UPDATE on rename; one-time UPDATE on backfill (bounded by user count). No hot-path latency change.
+
+### Research Insights — Precedent-Diff (Phase 4.4)
+
+**Pattern-bound behavior:** SECURITY DEFINER plpgsql RPC + `auth.uid()` owner-gate + REVOKE/GRANT. Canonical precedent: `supabase/migrations/075_transfer_workspace_ownership.sql`. Side-by-side:
+
+| Aspect | `transfer_workspace_ownership` (precedent, mig 075) | `rename_organization` (this plan, mig 091) |
+|---|---|---|
+| Language / security | `LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp` (075:33-35) | **Same** (required by `cq-pg-security-definer-search-path-pin-pg-temp`) |
+| Caller auth | `v_caller := auth.uid(); IF NULL RAISE 28000` (075:40-44) | **Same** |
+| Owner-gate | `SELECT EXISTS(... role='owner') FOR UPDATE; IF NOT RAISE 42501` (075:50-62) | **Same shape** — resolve the org's owning workspace and require caller `role='owner'`; `FOR UPDATE` lock; `ERRCODE='42501'` |
+| Attestation guard | `length(p_attestation_text) >= 16` (075:88-92) | **DROP** — a rename is not an attested act; validate name length 1–60 + non-empty instead |
+| Self-transfer / target-member guards | present (075:64-86) | **DROP** — N/A to a name change |
+| Audit GUC | `PERFORM set_config('workspace_audit.actor_user_id', …)` (075:94) | **DROP** — verified: `organizations` has NO audit trigger (audit triggers target `workspace_members` only; `grep "CREATE TRIGGER … ON public.organizations"` returns nothing). Setting the GUC would be dead. |
+| Grant | `REVOKE ALL … FROM PUBLIC, anon, authenticated, service_role; GRANT EXECUTE … TO authenticated` (075:156-158) | **Same** |
+| Transaction scope | multi-row (promote/demote/org-owner/attestation/removal) | **single-row UPDATE** on `organizations.name` |
+
+**Net:** the rename RPC is a strict simplification of the precedent — same auth/owner/grant spine, none of the multi-row/attestation/audit machinery. No novel pattern; reviewers can apply the 075 lens directly.
+
+**Verify-the-negative (Phase 4.45):** both negative claims hold against current code — (a) the plan adds no `NOT NULL` (mig 053:49 keeps `name text NULL`, contract-mandated at 053:47-48); (b) `grep "CREATE POLICY.*organizations"` in mig 053 returns only `orgs_select_for_members` (SELECT) — no UPDATE policy for `authenticated`, so the RPC is the sole authenticated write path as claimed.
+
+### Attack Surface Enumeration (rename write surface)
+
+- Ways to mutate `organizations.name`: (1) `handle_new_user()` trigger (system, signup-time, owner identity); (2) backfill DO block in `091` (one-time, migration-time); (3) new `rename_organization` RPC (the only runtime user-reachable path). No RLS UPDATE policy is granted to `authenticated`, so the RPC is the sole authenticated write path.
+- Owner-gate on the RPC (`auth.uid()` must be `role='owner'` in the target org) closes member-escalation. The route additionally enforces CSRF (`validateOrigin`), auth (`getUser`), flag-gate (`isTeamWorkspaceInviteEnabled`), and `workspaceId`/`orgId` match against `resolveTeamMembershipPageData` — identical defense stack to `transfer-ownership/route.ts:14-58`.
+- Gap check: the first-invite name field posts through the same authenticated owner-gated path; no new surface beyond the rename RPC.
+
+## User-Brand Impact
+
+- **If this lands broken, the user experiences:** the org switcher (`components/dashboard/org-switcher.tsx`) still showing "Untitled" for one or more workspaces, OR a rename that silently no-ops / writes to the wrong org, leaving the user unable to distinguish their personal vs. team workspace and at risk of acting in the wrong billing/data context.
+- **If this leaks, the user's workflow/identity is exposed via:** the org `name` is rendered to all workspace peers via `orgs_select_for_members` — a backfill that defaults NULL → owner email would disclose the owner's email address to every member of every shared workspace.
+- **Brand-survival threshold:** `single-user incident`
+
+Because the threshold is `single-user incident`, **CPO sign-off is required at plan time** before `/work` begins, and `user-impact-reviewer` will be invoked at review time (handled by the review skill's conditional-agent block). Invoke CPO domain leader if not already covered by the Domain Review below.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "Vitest assertion (post-backfill no-NULL guard) + Sentry on rename RPC failure"
+  cadence: "per-CI-run (test); per-rename (runtime error path)"
+  alert_target: "CI red on test failure; Sentry issue (web-platform) on rename failure"
+  configured_in: "apps/web-platform/test/server/rename-organization.test.ts (new); apps/web-platform/app/api/workspace/rename/route.ts (new, reportSilentFallback)"
+
+error_reporting:
+  destination: "Sentry web-platform via SENTRY_DSN"
+  fail_loud: "POST /api/workspace/rename returns non-2xx with {error:...}; rename RPC failure mirrored via reportSilentFallback (cq-silent-fallback-must-mirror-to-sentry), matching workspace-invitations.ts:232"
+
+failure_modes:
+  - mode: "rename_organization RPC fails (caller_not_owner, rpc_failed, invalid name)"
+    detection: "route returns mapped status; reportSilentFallback then Sentry on rpc_failed"
+    alert_route: "Sentry issue to operator"
+  - mode: "backfill leaves residual NULL org names after migration 091 applies"
+    detection: "post-deploy read-only probe (see discoverability_test) returns count > 0; CI test asserts default substitution"
+    alert_route: "operator runs probe post-deploy; non-zero = investigate"
+  - mode: "trigger regression — new signup org still NULL"
+    detection: "migration 091 trigger test (BEGIN; INSERT auth.users; assert org.name NOT NULL; ROLLBACK) red in CI"
+    alert_route: "CI red"
+
+logs:
+  where: "Vercel/Docker app logs (pino childLogger 'workspace' / route); Sentry breadcrumbs"
+  retention: "per existing app log retention"
+
+discoverability_test:
+  command: "doppler run -c dev -- psql \"$DATABASE_URL\" -c \"SELECT count(*) FROM public.organizations WHERE name IS NULL;\""
+  expected_output: "count = 0 (no org rows carry NULL name after backfill)"
+```
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [x] **AC1 (trigger default):** After migration `091`, `handle_new_user()` inserts a non-NULL default for `organizations.name` (and `workspaces.name`) on new signups. Verify: `BEGIN; INSERT INTO auth.users(...) VALUES (...); SELECT name FROM public.organizations WHERE owner_user_id = <new id>; ROLLBACK;` returns a non-NULL default. *(handle_new_user re-derived from 053:289-329; both name literals → 'My Workspace'. SQL-shape test asserts non-NULL + every 053 arm preserved.)*
+- [x] **AC2 (backfill):** After migration `091` applies, `SELECT count(*) FROM public.organizations WHERE name IS NULL` returns `0`. Backfill default is a **generic non-PII label** (not owner email). *(UPDATE … WHERE name IS NULL for organizations + workspaces; idempotent.)*
+- [x] **AC3 (rename RPC):** `rename_organization(p_organization_id, p_name, p_caller_user_id)` is `SECURITY DEFINER plpgsql SET search_path = public, pg_temp`, owner-gated via `COALESCE(p_caller_user_id, auth.uid())` (deviation from plan's auth.uid()-only — see note), with `REVOKE … FROM PUBLIC, anon, authenticated` + `GRANT EXECUTE … TO authenticated`. A member (non-owner) calling it gets `42501`/`caller_not_owner`. Name is trimmed; empty/whitespace-only rejected; length bounded (1–60).
+- [x] **AC4 (rename route):** `POST /api/workspace/rename` enforces CSRF (`validateOrigin`), auth, flag-gate (`isTeamWorkspaceInviteEnabled`), and org match (mirror `transfer-ownership/route.ts`). Returns mapped statuses for `unauthorized`/`not_found`/`invalid_body`/`caller_not_owner`. *(15 route tests.)*
+- [x] **AC5 (rename UI):** `/dashboard/settings/team` shows an owner-only rename control prefilled with the current org name; non-owners do not see it. Successful rename updates the displayed name in place (no full reload). *(new `RenameWorkspaceAction`; 5 component tests.)*
+- [x] **AC6 (first-invite capture):** when the current org name is still the default, the invite modal (`invite-member-modal.tsx`) shows an optional "Name your workspace" field; submitting renames the org via the same rename path. *(path corrected from invite-member-action.tsx; the form lives in the modal.)*
+- [x] **AC7 (resolver guard retained, unreachable):** `org-memberships-resolver.ts:146` keeps `?? "Untitled"` (now commented as defense-in-depth); a test asserts the switcher renders the real name (not "Untitled") for a two-org fixture with non-NULL names.
+
+> **Deviation note (AC3):** the plan specified an `auth.uid()`-only owner-gate mirroring mig 075. Implemented as `COALESCE(p_caller_user_id, auth.uid())` mirroring `accept_workspace_invitation` (mig 076/085) because the TS wrapper invokes the RPC via the **service-role** client, under which `auth.uid()` is NULL — the 075 shape would raise `28000` on every call. The route forwards the verified `getUser()` id; when `auth.uid()` is populated COALESCE returns the same value, so the gate is correct under both invocation modes. REVOKE list follows the 075 3-role form (`PUBLIC, anon, authenticated`), which the `migration-rpc-grants` lint requires.
+
+### Non-Functional Requirements
+
+- [x] Rename RPC is a single-row UPDATE; backfill is a single bounded UPDATE statement (idempotent — re-running migration `091` updates 0 rows on a populated DB; use `WHERE name IS NULL` discriminator).
+- [x] No `NOT NULL` constraint added to `organizations.name` (preserves `053:47-48` single-statement backfill invariant; non-NULL enforced at app+trigger+backfill layers).
+- [x] `/soleur:gdpr-gate` run at /work confirms no new Processing Activity required (advisory).
+
+### Quality Gates
+
+- [x] RED tests written before implementation (`cq-write-failing-tests-before`): rename RPC owner-gate, route status mapping, trigger non-NULL, backfill no-NULL, resolver/switcher non-"Untitled".
+- [x] Test files land where vitest collects them: `apps/web-platform/test/**/*.test.ts(x)` per `vitest.config.ts` `include:` globs (NOT co-located under `components/` or `server/` — those are silently skipped; see Sharp Edges).
+
+## Test Scenarios
+
+### Acceptance Tests (RED phase targets)
+
+- **AC1:** Given a fresh signup, when `handle_new_user()` fires, then `organizations.name` and `workspaces.name` are the non-NULL default. (Test: `test/supabase-migrations/091-rename-organization.test.ts` — `BEGIN; … ROLLBACK;` against a seeded auth.users insert, mirroring `063-workspace-member-actions.test.ts` harness.)
+- **AC2:** Given a pre-091 DB with NULL-name orgs, when migration `091` applies, then `count(name IS NULL) = 0` and re-applying updates 0 rows.
+- **AC3:** Given a non-owner member, when they call `rename_organization`, then it raises/returns `caller_not_owner`. Given an owner with a valid trimmed name, then `organizations.name` is updated. Given empty/whitespace name, then rejected.
+- **AC4:** Given a cross-origin request, when `POST /api/workspace/rename`, then CSRF reject. Given flag OFF, then 404. Given owner + valid body, then 200 + updated name. (Test: `test/server/rename-organization.test.ts` mirroring an existing route test.)
+- **AC5:** Given an owner on the team page, when they rename, then the new name renders; given a member, no control is shown. (Test: extend/`test/` component test for `team-membership-list`.)
+- **AC6:** Given an org with the default name, when the owner opens the invite modal, the name field appears; submitting renames. (Test: `invite-member-action` component test.)
+- **AC7:** Given a two-org fixture with non-NULL names, when the switcher renders, then both real names show and neither is "Untitled". (Extend `test/org-switcher.test.tsx` / `test/org-switcher-container.test.tsx`.)
+
+### Regression Tests
+
+- Given the original bug (two orgs, both NULL name), when the resolver + switcher run after backfill, then no row reads "Untitled".
+
+### Integration Verification (for /soleur:qa)
+
+- **Browser:** Navigate to `/dashboard/settings/team` (multi-user flag ON, as owner) → rename workspace → verify org switcher shows the new name.
+- **DB verify:** `doppler run -c dev -- psql "$DATABASE_URL" -c "SELECT count(*) FROM public.organizations WHERE name IS NULL;"` expects `0`.
+
+## Files to Edit
+
+- `apps/web-platform/supabase/migrations/091_rename_organization_and_default_names.sql` (NEW) — `rename_organization` RPC + `handle_new_user()` default-name update (`CREATE OR REPLACE`, re-derive full body from `053:289-329` to avoid dropping existing behavior — see Sharp Edges) + NULL-name backfill DO block.
+- `apps/web-platform/supabase/migrations/091_rename_organization_and_default_names.down.sql` (NEW) — revert RPC + restore prior `handle_new_user()` body. (Backfill is not reverted — names are user data.)
+- `apps/web-platform/server/workspace-membership.ts` (EDIT) — add `renameOrganization(...)` wrapper calling the RPC, mirroring `transferWorkspaceOwnership` shape; map `caller_not_owner`/`rpc_failed` reasons.
+- `apps/web-platform/app/api/workspace/rename/route.ts` (NEW) — owner-gated POST, mirror `app/api/workspace/transfer-ownership/route.ts`.
+- `apps/web-platform/components/settings/team-membership-list.tsx` (EDIT) — owner-only rename control prefilled with `organizationName`.
+- `apps/web-platform/components/settings/invite-member-action.tsx` (EDIT) — optional "Name your workspace" field when org name is still default; call rename on submit.
+- `apps/web-platform/server/org-memberships-resolver.ts` (EDIT — minimal) — keep `?? "Untitled"` guard; no behavioral change (add a code comment that it is now defense-in-depth, unreachable post-backfill).
+- `apps/web-platform/lib/feature-flags/server.ts` — read-only (reuse `isTeamWorkspaceInviteEnabled`; confirm no new flag needed).
+
+## Files to Create
+
+- `apps/web-platform/test/supabase-migrations/091-rename-organization.test.ts` — RPC owner-gate, trigger non-NULL, backfill no-NULL (mirror `063-workspace-member-actions.test.ts`).
+- `apps/web-platform/test/server/rename-organization.test.ts` — route status mapping + flag/CSRF gates.
+- (Extend existing) `apps/web-platform/test/org-switcher.test.tsx` — AC7 non-"Untitled" assertion.
+
+## Open Code-Review Overlap
+
+None. `gh issue list --label code-review --state open` (74 open) was queried; none reference `org-memberships-resolver.ts`, `org-switcher.tsx`, `team-membership-resolver.ts`, `team-membership-list.tsx`, or `workspace-invitations.ts`.
+
+## Dependencies & Risks
+
+- **Migration ordering / numbering:** latest on disk is `090`; new is `091`. Note: migration `053` exists with THREE files at the same number (`053_organizations_and_workspace_members`, `053_append_kb_sync_row_rpc`, `053_template_authorizations`) — a pre-existing collision. Do NOT reuse `053`; `091` is unambiguous.
+- **Trigger `CREATE OR REPLACE` risk:** `091` must re-issue the FULL `handle_new_user()` body (the version at `053:289-329`), changing only the two `NULL` name literals to the default. Dropping any of the existing 001+053 behavior (public.users insert, org/workspace/member creation, idempotency canary) would break signup. Diff against the current definition before shipping (see Sharp Edges).
+- **Flag gating:** rename UI + route live behind `isTeamWorkspaceInviteEnabled`. The trigger default + backfill are unconditional (DB-level), so even flag-OFF solo users get a non-NULL name — correct, since they may go multi-workspace later.
+- **GDPR (advisory):** backfill default must be non-PII (generic label), not owner email. Confirmed no new PA.
+
+## Alternative Approaches Considered
+
+| Approach | Rejected because |
+|---|---|
+| Add `NOT NULL` + default to `organizations.name` | Breaks `053:47-48` single-statement backfill invariant; the 053 contract explicitly chose app-layer enforcement. A DB default would still be a generic string (no better than the trigger default) and complicates the backfill ordering. |
+| Capture name by *creating* an org in the invite flow | Misreads the architecture — invite adds a member to the existing org (`workspace-invitations.ts:153`, `p_workspace_id`); there is no org-creation-at-invite. |
+| Build a signup/onboarding name prompt | No onboarding flow or TS signup fallback exists; building one is out of scope. The trigger default + rename UI cover the need. Deferred — see Non-Goals. |
+| Backfill NULL → owner email/name | Privacy: org name is peer-visible (`orgs_select_for_members`); leaks owner email to all workspace members. |
+| Remove the `?? "Untitled"` guard | Keep as defense-in-depth; removing a guard requires the defense-relaxation analysis and offers no user benefit. |
+
+## Non-Goals
+
+- A dedicated signup/onboarding workspace-naming wizard (deferred; covered by trigger default + rename UI). **Deferral tracking:** file a GitHub issue at /work — "onboarding workspace-name prompt" with re-evaluation criteria (revisit if multi-workspace adoption shows users never rename the default).
+- Multi-workspace-per-org naming (`workspaces.name` UX beyond the default) — `#2778` post-MVP projects scope per `team-membership-resolver.ts:118`.
+- Adding a `NOT NULL` DB constraint (intentional per 053 contract).
+
+## Domain Review
+
+**Domains relevant:** Product, Engineering, Legal
+
+This plan creates a new user-facing rename control + modifies the invite modal (new interactive UI surface) → **Product/UX Gate tier: BLOCKING** (mechanical: edits create/modify `components/settings/*.tsx` interactive controls). Engineering relevant (migration + RPC + RLS-adjacent write path). Legal relevant (peer-visible user free-text + email-leak risk in backfill default).
+
+> NOTE (pipeline/subagent context): this plan skill is running inside the one-shot pipeline as a Task subagent, so domain-leader sub-agents (CPO, CTO, CLO, spec-flow-analyzer, ux-design-lead) could not be spawned from here. The BLOCKING Product/UX gate and the `requires_cpo_signoff: true` obligation are therefore **carried forward to deepen-plan / review**, where domain agents run. The frontmatter flag `requires_cpo_signoff: true` enforces the plan-time CPO ack before `/work`.
+
+### Engineering
+**Status:** reviewed (inline)
+**Assessment:** Change rides established precedents — SECURITY DEFINER plpgsql owner-gated RPC (`075`), owner-gated CSRF+flag route (`transfer-ownership`), team-page UI host. Lowest-risk shape is RPC-only write (no new RLS UPDATE policy). Primary engineering risk is the `CREATE OR REPLACE handle_new_user()` body-drop hazard (mitigated by full-body re-derivation + diff).
+
+### Legal
+**Status:** reviewed (inline, advisory)
+**Assessment:** No new Article 30 Processing Activity (value-population in already-registered `organizations` table, existing Art. 6(1)(b) basis). Backfill default MUST be non-PII to avoid disclosing owner email to workspace peers. Confirm via `/soleur:gdpr-gate` at /work.
+
+### Product/UX Gate
+**Tier:** blocking
+**Decision:** deferred to deepen-plan/review (pipeline subagent cannot spawn domain agents)
+**Agents invoked:** none (carried forward)
+**Skipped specialists:** spec-flow-analyzer, cpo, ux-design-lead (deferred to deepen-plan/review — Pencil availability unknown in this context)
+**Pencil available:** N/A (not invokable here)
+
+#### Findings
+The rename control is a small, well-scoped owner-only surface on an existing settings page; the first-invite name field is an optional addition to an existing modal. spec-flow-analyzer should validate: rename error states (caller_not_owner, invalid name), the "default name still set" detection that triggers the first-invite field, and that a member (non-owner) sees no rename affordance.
+
+## References & Research
+
+### Internal References
+- Migration contract + NULL inserts: `apps/web-platform/supabase/migrations/053_organizations_and_workspace_members.sql:44-49,229,289-329`
+- Resolver "Untitled" fallback: `apps/web-platform/server/org-memberships-resolver.ts:146`
+- Switcher hide-on-solo: `apps/web-platform/components/dashboard/org-switcher.tsx:63`
+- Owner-gated RPC precedent: `apps/web-platform/supabase/migrations/075_transfer_workspace_ownership.sql:30-55`
+- Owner-gated route precedent: `apps/web-platform/app/api/workspace/transfer-ownership/route.ts:12-58`
+- Team page (UI host, resolves org name): `apps/web-platform/app/(dashboard)/dashboard/settings/team/page.tsx:77`
+- Org-name source in resolver: `apps/web-platform/server/team-membership-resolver.ts:89-96`
+- RPC wrapper pattern: `apps/web-platform/server/workspace-invitations.ts:213-264`, `apps/web-platform/server/workspace-membership.ts`
+- Migration RPC test harness: `apps/web-platform/test/supabase-migrations/063-workspace-member-actions.test.ts`
+- Existing switcher tests: `apps/web-platform/test/org-switcher.test.tsx`, `test/org-switcher-container.test.tsx`
+
+### Related Work
+- ADR-038 (workspaces.id = users.id solo invariant) referenced throughout migration 053.
+- `#2778` — post-MVP multi-workspace-per-org projects (Non-Goal boundary).
+
+## Sharp Edges
+
+- **`CREATE OR REPLACE handle_new_user()` must re-derive the FULL body.** The current definition lives at `053:289-329` and does public.users insert + org/workspace/member creation + idempotency canary. Migration `091` changes only the two `NULL` name literals → default. Diff the new body against `053:289-329` before shipping; dropping any arm breaks signup (per AGENTS.md Sharp Edge on `CREATE OR REPLACE` body re-derivation, e.g. mig 085 silently dropping mig 076's identity check).
+- **vitest discovery globs.** `apps/web-platform/vitest.config.ts` collects only `test/**/*.test.ts` (node) and `test/**/*.test.tsx` (jsdom). Co-located tests under `components/**` or `server/**` are silently NEVER run. Place all new tests under `apps/web-platform/test/...`.
+- **A plan whose `## User-Brand Impact` section is empty, placeholder, or omits the threshold will fail `deepen-plan` Phase 4.6.** This section is filled (threshold `single-user incident`).
+- **Backfill default must be non-PII.** `name` is peer-visible via `orgs_select_for_members`; an email-derived default leaks the owner's email to all workspace members. Use a generic label.
+- **Migration number collision precedent.** `053` is triple-numbered on disk; this is pre-existing and unrelated, but confirm `091` is unused before writing (`ls supabase/migrations/091*`).

--- a/knowledge-base/project/specs/feat-one-shot-workspace-untitled-name/migration-checklist.md
+++ b/knowledge-base/project/specs/feat-one-shot-workspace-untitled-name/migration-checklist.md
@@ -1,0 +1,27 @@
+# Migration checklist — 091_rename_organization_and_default_names
+
+Migration: `apps/web-platform/supabase/migrations/091_rename_organization_and_default_names.sql`
+Verify sentinel: `apps/web-platform/supabase/verify/091_rename_organization_and_default_names.sql`
+
+## prd apply — pending
+
+The migration applies to prd on merge via the existing
+`web-platform-release.yml#migrate` job (per the plan's Phase 2.8 IaC-ack — this is
+a pure code change against the already-provisioned web-platform; no operator
+apply step). The `verify-migrations` job in the same release workflow then runs
+the committed verify sentinel, which asserts post-apply:
+
+- 0 `organizations` rows with NULL/empty `name`
+- 0 `workspaces` rows with NULL/empty `name`
+- `rename_organization` RPC exists
+- `rename_organization` is NOT EXECUTE-able by `authenticated` (the P1 owner-gate-bypass guard)
+
+Preflight Check 1 SKIPs on this documented deferral and re-verifies post-merge via
+the release workflow's `verify-migrations` job. No manual psql apply.
+
+## dev apply — not required pre-merge
+
+dev apply is exercised by the same release pipeline path; local psql is unavailable
+in the build sandbox (psql not installed), so the migration shape is validated by
+`test/supabase-migrations/091-rename-organization.test.ts` (16 source-regex
+invariants) + the global `migration-rpc-grants` lint (378 fns scanned).

--- a/knowledge-base/project/specs/feat-one-shot-workspace-untitled-name/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-workspace-untitled-name/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-01-fix-org-name-null-untitled-switcher-plan.md
+- Status: complete
+
+### Errors
+- IaC-routing PreToolUse hook initially blocked the plan Write (flagged "operator runs"/"manual" prose). Resolved by reviewing Phase 2.8 (pure code change, no new infra) and embedding the documented `<!-- iac-routing-ack: plan-phase-2-8-reviewed -->` opt-out. No other errors.
+
+### Decisions
+- Reframed lever (a): the invite flow adds a member to the inviter's existing (NULL-name) org via p_workspace_id — it does NOT create an org. So "capture name in invite flow" became "prompt the owner to name their existing org at first-invite," plus a generic non-NULL trigger default. Signup/onboarding name capture made a Non-Goal (no onboarding flow or TS signup fallback exists to hook into).
+- No NOT NULL constraint on organizations.name — enforce non-NULL at trigger + backfill + app layers, per migration 053's contract (preserves single-statement backfill invariant).
+- RPC-only write path: add rename_organization (migration 091) as SECURITY DEFINER plpgsql with auth.uid() owner-gate, mirroring 075_transfer_workspace_ownership.sql; no new RLS UPDATE policy on organizations.
+- Privacy: backfill defaults NULL names to a generic non-PII label ('My Workspace'), NOT owner email — org name is peer-visible via orgs_select_for_members, so email would leak the owner's address.
+- Threshold single-user incident → requires_cpo_signoff: true; Product/UX gate is BLOCKING and carried forward to review.
+
+### Components Invoked
+- Skill: soleur:plan
+- Skill: soleur:deepen-plan
+- Inline gates: code-review overlap, GDPR (advisory), IaC routing (acked), precedent-diff, verify-the-negative, User-Brand Impact, Observability (5/5), PAT-shaped scan

--- a/plugins/soleur/skills/work/references/sql-security-definer-rpc-scaffold.sql
+++ b/plugins/soleur/skills/work/references/sql-security-definer-rpc-scaffold.sql
@@ -53,4 +53,16 @@ REVOKE ALL ON FUNCTION public.<fn_name>(uuid, text)
   FROM PUBLIC, anon, authenticated, service_role;
 
 -- Grant back EXECUTE only to the role(s) that should call it.
+-- SAFE here because this scaffold gates on the NON-forgeable auth.uid().
+--
+-- CALLER-OVERRIDE VARIANT (forgeable identity → service_role ONLY): if the
+-- function instead resolves the caller via COALESCE(p_caller_user_id, auth.uid())
+-- — necessary when the TS wrapper invokes via createServiceClient() (service-role
+-- key) where auth.uid() is NULL — then p_caller_user_id is client-forgeable.
+-- Granting such a function TO authenticated lets any logged-in user call it via
+-- PostgREST with a forged caller id and bypass the owner-gate. In that case GRANT
+-- to service_role ONLY (mirror accept_workspace_invitation mig 076/085), never
+-- authenticated. Rule: a forgeable caller-override param and TO service_role are a
+-- matched pair — copy BOTH halves of the precedent. See
+-- knowledge-base/project/learnings/security-issues/2026-06-01-caller-override-rpc-needs-service-role-only-grant.md (#4762/#4765).
 GRANT EXECUTE ON FUNCTION public.<fn_name>(uuid, text) TO authenticated;


### PR DESCRIPTION
## Summary

Workspaces/organizations rendered as "Untitled" in the dashboard org switcher because `organizations.name` was NULL for every org and no code path ever set it (migration 053 deferred the name-capture contract to "Phase 5.4", never built). The switcher hides itself for solo users, so the bug only surfaced for users in 2+ workspaces — both rows showed "Untitled".

Closes the contract three ways:
- **Migration 091**: `handle_new_user()` re-derived from 053 to default new org/workspace names to `'My Workspace'` (was NULL); one-time backfill of existing NULL/empty names; new owner-gated `rename_organization` RPC (service_role-only grant — see security note).
- **Rename UI**: owner-only rename control on `/dashboard/settings/team` (`POST /api/workspace/rename`, CSRF + flag + owner-gated).
- **First-invite capture**: optional "Name your workspace" field in the invite modal when the org still has the default name.

## User-Brand Impact

- **Artifact exposed if broken:** the org switcher (`components/dashboard/org-switcher.tsx`) renders `organizations.name`, which is peer-visible to all workspace members via `orgs_select_for_members`. A user with a personal + a team workspace could act in the wrong billing/data context if the names are indistinguishable.
- **Exposure vector:** (a) cross-tenant rename — closed: `rename_organization` is granted to `service_role` only; the forgeable `p_caller_user_id` override is unreachable via PostgREST by an authenticated user (a regression test + CI verify sentinel assert it is NOT granted to `authenticated`). (b) owner-email leak into the peer-visible name — closed: the backfill default is the generic non-PII `'My Workspace'`, never an email.
- **Brand-survival threshold:** `single-user incident`

## Changelog

### Web Platform
- Migration 091: non-NULL default org/workspace names + NULL/empty backfill + `rename_organization` RPC (owner-gated, service_role-only).
- New `POST /api/workspace/rename` route (CSRF + flag + owner-gate, mirrors transfer-ownership).
- New owner-only workspace rename control on the team settings page.
- Optional first-invite workspace-name capture in the invite modal.
- Resolver `?? "Untitled"` guard retained as defense-in-depth (now unreachable post-backfill).

## Test plan
- [x] Migration shape test (16 invariants: owner-gate, service_role-only grant + negative-space guard, name validation, trigger arm-preservation, backfill)
- [x] `migration-rpc-grants` global lint (378 SECURITY DEFINER fns)
- [x] Route test (15: CSRF / auth / flag / org-match / owner-check / RPC-reason→status / caller-id forwarding / trim)
- [x] Resolver AC7 test (null→fallback, real→passthrough)
- [x] Rename component + invite-modal AC6 + swallowed-rename tests
- [x] Full web-platform suite (7865 passed)
- [x] Multi-agent review (P1 owner-gate bypass found + fixed inline)
- [ ] ⏳ Post-merge: `verify-migrations` job runs supabase/verify/091 (0 NULL/empty names + RPC-not-granted-to-authenticated)

Generated with [Claude Code](https://claude.com/claude-code)