### PR TITLE
fix(test): update integration assertions for migration 091 default org name

### DIFF
--- a/apps/web-platform/test/server/dsar-export-workspace-tables.integration.test.ts
+++ b/apps/web-platform/test/server/dsar-export-workspace-tables.integration.test.ts
@@ -38,6 +38,7 @@ import {
   tearDownSharedWorkspace,
   type SharedWorkspaceFixture,
 } from "@/test/helpers/workspace-members-fixtures";
+import { DEFAULT_ORG_NAME } from "@/lib/workspace-name";
 
 const INTEGRATION_ENABLED = process.env.TENANT_INTEGRATION_TEST === "1";
 
@@ -149,14 +150,16 @@ describe.skipIf(!INTEGRATION_ENABLED)(
     test("organizations chain returns Harry's solo backfill org (Phase 7.2 / AC10)", async () => {
       if (SCHEMA_CACHE_READY === false) return;
       const harry = fixture.members[1];
-      // Harry has a backfill-shaped solo org (created by handle_new_user
+      // Harry has a default-named solo org (created by handle_new_user
       // trigger at signup). Owner_user_id keys directly on his auth id.
       const { data } = await service
         .from("organizations")
         .select("id, owner_user_id, name")
         .eq("owner_user_id", harry.userId);
       expect(data?.length ?? 0).toBeGreaterThanOrEqual(1);
-      expect(data![0].name).toBeNull();
+      // Migration 091 (#4762): the signup trigger seeds DEFAULT_ORG_NAME
+      // (was NULL in mig 053). Art. 15 export still includes the org row.
+      expect(data![0].name).toBe(DEFAULT_ORG_NAME);
     });
 
     test("deleteAccount(Harry) end-to-end — FK-reverse cascade clears the chain (AC-GDPR-17-CALLER)", async () => {

--- a/apps/web-platform/test/server/workspace-backfill-trigger-parity.test.ts
+++ b/apps/web-platform/test/server/workspace-backfill-trigger-parity.test.ts
@@ -31,6 +31,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { randomBytes } from "node:crypto";
+import { DEFAULT_ORG_NAME } from "@/lib/workspace-name";
 
 const INTEGRATION_ENABLED = process.env.TENANT_INTEGRATION_TEST === "1";
 
@@ -154,8 +155,10 @@ describe.skipIf(!INTEGRATION_ENABLED)(
         .select("id, owner_user_id, name")
         .eq("owner_user_id", user.id);
       expect(organizations).toHaveLength(1);
-      // Backfill-shaped org has NULL name.
-      expect(organizations![0].name).toBeNull();
+      // Migration 091 (#4762): handle_new_user now seeds DEFAULT_ORG_NAME at
+      // signup (was NULL in mig 053) so the org switcher never renders the
+      // "Untitled" sentinel for multi-workspace users.
+      expect(organizations![0].name).toBe(DEFAULT_ORG_NAME);
     });
 
     test("TS fallback upsert is a no-op after trigger — no duplicate rows", async () => {

--- a/knowledge-base/project/learnings/test-failures/2026-06-01-db-invariant-change-must-grep-integration-tests-for-old-contract.md
+++ b/knowledge-base/project/learnings/test-failures/2026-06-01-db-invariant-change-must-grep-integration-tests-for-old-contract.md
@@ -1,0 +1,44 @@
+# Learning: changing a DB-default invariant must grep TENANT_INTEGRATION_TEST tests for the old contract
+
+## Problem
+
+PR #4762 changed `handle_new_user()` + the backfill so `organizations.name` defaults to
+`'My Workspace'` instead of NULL (migration 091). The full local `vitest run` passed
+(7884) and the PR merged. Then main's `Tenant integration (dev-Supabase)` job went RED
+on two assertions that still encoded the OLD contract:
+
+- `workspace-backfill-trigger-parity.test.ts:158` — `expect(organizations![0].name).toBeNull()`
+- `dsar-export-workspace-tables.integration.test.ts:159` — `expect(data![0].name).toBeNull()`
+
+Both are gated behind `TENANT_INTEGRATION_TEST=1` and run against **live dev Supabase**,
+so the local `vitest run` (no env flag, no live creds) **skipped** them. The behavioral
+change to the signup trigger surfaced only post-merge, in the CI job that exercises the
+real DB.
+
+## Solution
+
+Fix-forward PR #4766: update both assertions to `expect(...name).toBe(DEFAULT_ORG_NAME)`
+via the shared `@/lib/workspace-name` constant.
+
+## Key Insight
+
+When a migration changes a **default-value or nullability invariant** on a column
+(`NULL → default`, `default → NULL`, enum-value change), the unit suite is blind to it
+two ways: (1) migration-shape tests only regex the SQL source, and (2) the
+behavioral tests that would catch it are `TENANT_INTEGRATION_TEST`-gated and skipped by
+the default `vitest run`. The cheap forward gate at /work time is a grep of the WHOLE
+test tree for assertions on the changed column, **before** committing the migration:
+
+```bash
+grep -rnE '<table>|<column>' test/ | grep -iE '<column>.*(toBeNull|=== null|: null|toBe\()'
+```
+
+For this change: `grep -rn 'organizations' test/ | grep -iE 'name.*toBeNull'` would have
+surfaced both files at /work time. This is the integration-test analog of the existing
+"sweep-class fixes use grep-enumerated work-lists" rule — extend the grep to
+integration tests whose live-DB behavior depends on the invariant, not just the unit
+mocks.
+
+## Tags
+category: test-failures
+module: apps/web-platform/supabase/migrations


### PR DESCRIPTION
## Summary

Fix-forward for main's red `Tenant integration (dev-Supabase)` job after PR #4762 merged.

Migration 091 changed `handle_new_user()` + the backfill to seed `organizations.name = 'My Workspace'` (was NULL in mig 053). Two `TENANT_INTEGRATION_TEST`-gated tests still asserted `name.toBeNull()`:
- `test/server/workspace-backfill-trigger-parity.test.ts` (trigger creates the canonical solo trio)
- `test/server/dsar-export-workspace-tables.integration.test.ts` (Harry's solo backfill org)

Both now assert `DEFAULT_ORG_NAME` via the shared `@/lib/workspace-name` constant. These tests run against live dev Supabase, so #4762's local `vitest run` skipped them — the gap was not grepping existing integration tests for the old NULL-name contract when changing the invariant.

## Changelog

### Web Platform
- Update two integration-test assertions to the post-091 default org-name contract.

## Test plan
- [x] tsc --noEmit clean
- [x] Verified fixture mints Harry via auth.admin.createUser (trigger fires → default name)
- [x] Swept test/ for other org-name NULL assertions (none — the 2 remaining are intended mock/WS-preamble cases)
- [ ] ⏳ Post-merge: tenant-integration job green on main

Ref #4762

Generated with [Claude Code](https://claude.com/claude-code)