### PR TITLE
chore(marketing): cloud-platform positioning across public surfaces

### DIFF
--- a/knowledge-base/marketing/brand-guide.md
+++ b/knowledge-base/marketing/brand-guide.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-05-05
-last_reviewed: 2026-05-05
+last_reviewed: 2026-06-01
 review_cadence: quarterly
 owner: CMO
 depends_on:

--- a/knowledge-base/marketing/marketing-strategy.md
+++ b/knowledge-base/marketing/marketing-strategy.md
@@ -201,7 +201,7 @@ No paid acquisition until organic channels prove the thesis. The validation phas
 
 **Priority actions:**
 
-1. Treat the open-source / self-hosted path (Claude Code plugin registry listing, keywords, categories) as a technical-discovery channel that feeds the cloud waitlist -- not the primary conversion surface
+1. Optimize the open-source / self-hosted listing (Claude Code plugin registry: description, keywords, categories). Treat it as a technical-discovery channel that feeds the cloud waitlist, not the primary conversion surface.
 2. Ensure the self-hosted `claude plugin install soleur` experience is clean and immediate, with a clear path to reserve cloud-platform access
 3. Build onboarding flow that demonstrates cross-domain value in the first 10 minutes
 4. Create "Built with Soleur" showcase starting with soleur.ai itself
@@ -384,7 +384,7 @@ Weekly snapshots are generated automatically by CI (`scheduled-weekly-analytics.
 **Response:**
 
 1. Publish immediate comparison content: "Soleur vs. Notion Custom Agents"
-2. Emphasize founder-controlled operations with compounding memory vs. workspace-first collaboration (different audiences) -- delivery surface is no longer a differentiating axis now that Soleur ships as a web product
+2. Emphasize founder-controlled operations with compounding memory vs. workspace-first collaboration (different audiences). Delivery surface is no longer a differentiating axis now that Soleur ships as a web product.
 3. Emphasize compounding knowledge base scoped to solo founder operations vs. team collaboration
 4. Lean into engineering depth (Notion's agents will start shallow)
 

--- a/knowledge-base/marketing/marketing-strategy.md
+++ b/knowledge-base/marketing/marketing-strategy.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-03-22
-last_reviewed: 2026-03-22
+last_updated: 2026-06-01
+last_reviewed: 2026-06-01
 review_cadence: quarterly
 owner: CMO
 depends_on:
@@ -55,7 +55,7 @@ Soleur is the Company-as-a-Service platform -- 60+ agents, 60+ skills, 3 command
 | dateModified signals | No blog post has `updated` frontmatter. Google freshness assessment blocked. | High |
 | Social proof (external) | 5 case studies published but no testimonials from external users. | High |
 | User validation | 1-2 informal conversations. Need 10+ problem interviews. | High |
-| Brand term compliance | "Plugin" still appears in homepage hero subtitle, FAQ texts, llms.txt, Getting Started meta description. | High |
+| Brand term compliance | Resolved (2026-06-01, #1051). Primary surfaces -- homepage hero, llms.txt, Getting Started, About, Community -- lead with the Company-as-a-Service platform. "Plugin" remains only in exception-permitted contexts (CLI install commands, SEO pillar pages, legal defined terms) per brand-guide line 96. | Low |
 | Pricing | Undecided. Vision page mentions "success tax" but no committed model. | Medium |
 | Email / newsletter | Does not exist. No way to capture or nurture leads. | Medium |
 | Page-specific OG images | Single generic OG image on all pages. Low social sharing CTR. | Medium |
@@ -75,7 +75,7 @@ For **solo founders building real companies** who are frustrated that AI helps w
 
 These are the structural advantages that competitors cannot replicate by shipping features. All marketing messaging must ladder up to at least one.
 
-1. **Compounding knowledge base.** Cross-domain institutional memory that persists across sessions. The brand guide informs marketing content. The competitive analysis shapes product positioning. The legal audit references the privacy policy. No competitor -- not Cowork, not Notion, not Tanka -- has this across business domains within a terminal-first workflow. **[2026-03-22]** The moat itself is validated by user research -- founders described cross-domain pain unprompted. The "terminal-first workflow" qualifier should be removed in the next rewrite; the compounding knowledge base moat is delivery-agnostic.
+1. **Compounding knowledge base.** Cross-domain institutional memory that persists across sessions. The brand guide informs marketing content. The competitive analysis shapes product positioning. The legal audit references the privacy policy. No competitor -- not Cowork, not Notion, not Tanka -- has this across business domains. **[2026-03-22]** The moat itself is validated by user research -- founders described cross-domain pain unprompted. **[2026-06-01]** The "terminal-first workflow" qualifier has been removed; the compounding knowledge base moat is delivery-agnostic.
 
 2. **Cross-domain coherence.** 60+ agents share context across 8 domains. A decision in product strategy propagates to engineering planning, marketing copy, and legal review. Competitors are either deep in one domain (Cursor, Devin) or broad but stateless across many (Cowork).
 
@@ -141,7 +141,7 @@ For the PIVOT validation, narrow to:
 | X/Twitter solopreneur network | Medium | Medium | P1 -- amplification and thought leadership |
 | IndieHackers | Medium | Medium | P2 -- active solopreneur community |
 | Claude Code Discord | High | Low | P2 -- technical builders (beachhead) |
-| GitHub (issue engagement, plugin discovery) | Medium | Low | P2 -- technical discovery surface |
+| GitHub (issue engagement, open-source discovery) | Medium | Low | P2 -- technical discovery surface feeding the cloud waitlist |
 | Hacker News | High (when triggered) | Low (organic) | P3 -- submit articles, not product launches |
 | Reddit (r/ClaudeAI, r/SaaS, r/solopreneur) | Medium | Low | P3 -- respond to relevant threads |
 
@@ -201,8 +201,8 @@ No paid acquisition until organic channels prove the thesis. The validation phas
 
 **Priority actions:**
 
-1. Optimize Claude Code plugin registry listing (description, keywords, categories)
-2. Ensure `claude plugin install soleur` experience is clean and immediate
+1. Treat the open-source / self-hosted path (Claude Code plugin registry listing, keywords, categories) as a technical-discovery channel that feeds the cloud waitlist -- not the primary conversion surface
+2. Ensure the self-hosted `claude plugin install soleur` experience is clean and immediate, with a clear path to reserve cloud-platform access
 3. Build onboarding flow that demonstrates cross-domain value in the first 10 minutes
 4. Create "Built with Soleur" showcase starting with soleur.ai itself
 
@@ -334,7 +334,7 @@ Completed: CaaS category definition (Gap 2), Cursor positioning (Gap 6). See `co
 |--------|--------|--------|
 | Monthly organic visitors | 500+ | Plausible |
 | Article pageviews | 100+ per article | Plausible |
-| Plugin installs | 50+ total | Claude Code registry (if available) |
+| Self-hosted installs (waitlist feeder) | 50+ total | Claude Code registry (if available) |
 | Testimonials collected | 3-5 | Validation participants |
 | Case studies published | 1+ | soleur.ai |
 | AEO citation rate | Soleur mentioned in 2+ AI search results for target queries | Manual audit |
@@ -384,7 +384,7 @@ Weekly snapshots are generated automatically by CI (`scheduled-weekly-analytics.
 **Response:**
 
 1. Publish immediate comparison content: "Soleur vs. Notion Custom Agents"
-2. Emphasize terminal-first workflow vs. workspace-first (different audiences)
+2. Emphasize founder-controlled operations with compounding memory vs. workspace-first collaboration (different audiences) -- delivery surface is no longer a differentiating axis now that Soleur ships as a web product
 3. Emphasize compounding knowledge base scoped to solo founder operations vs. team collaboration
 4. Lean into engineering depth (Notion's agents will start shallow)
 

--- a/knowledge-base/project/learnings/2026-06-02-resumed-uncommitted-work-may-be-partial-against-the-plan.md
+++ b/knowledge-base/project/learnings/2026-06-02-resumed-uncommitted-work-may-be-partial-against-the-plan.md
@@ -1,0 +1,72 @@
+---
+title: "On resume, diff uncommitted prior-session work against every plan phase — interrupted work is partial, not done"
+date: 2026-06-02
+category: workflow-patterns
+tags: [resume, crash-recovery, plan-verification, work-skill, marketing]
+issue: 1051
+pr: 4769
+---
+
+# Learning: resumed uncommitted work may be partial against the plan
+
+## Problem
+
+Resuming `feat-one-shot-1051-cloud-platform-positioning` after a laptop crash. The task framed
+the on-disk uncommitted changes (4 modified files) as "at-risk work to commit first." The
+natural move is to commit the on-disk diff verbatim and proceed to ship.
+
+But the prior session had been interrupted **mid-phase**. The plan's M3 phase
+(`marketing-strategy.md` rewrite) prescribed edits at five sites:
+
+- Moat #1 terminal-first qualifier (line ~78) — **applied** on disk
+- "What Is Broken" status row (line ~58) — **applied** on disk
+- Notion-response "terminal-first vs workspace-first" (line ~387) — **NOT applied**
+- plugin-registry channel lines (~144 / ~204-205 / ~337) — **NOT applied**
+
+Had I committed the on-disk diff and shipped, AC2 ("terminal-first removed at line ~78 **AND**
+line ~387; channel lines reframed") would have failed, and the CMO-gate reviewer would have
+received a half-done M3.
+
+## Solution
+
+On resume, treat the on-disk uncommitted diff as a **claim of progress, not a record of
+completion**. Before committing:
+
+1. Read the plan's full phase/AC list.
+2. For each phase, re-run its verification grep against the **current working tree** (not the
+   diff) — e.g. `grep -n "terminal-first" marketing-strategy.md`, `grep -niE "plugin (registry|install)"`.
+3. Compare the live grep result to the plan's enumerated edit sites. Any site the plan names
+   that the grep still shows in its pre-edit form is **outstanding work**, regardless of what
+   the on-disk diff already touched.
+4. Finish the outstanding edits, then commit the whole phase as one unit.
+
+Here that surfaced 4 unapplied M3 edits (line 387 + three channel lines), which I completed
+before the first commit.
+
+## Key Insight
+
+A crash-interrupted session leaves a diff that is internally consistent (every applied edit is
+correct) yet **incomplete against the plan**. The on-disk diff cannot tell you what is missing —
+only the plan's phase list can. This is the non-contamination sibling of
+[[2026-06-01-resumed-session-artifacts-from-contaminated-tool-layer-are-unverified]]: there the
+prior artifacts were *wrong* (bad tool layer); here they are *partial* (interrupted). Both share
+the remedy — re-derive completeness from the authoritative source (the plan / the file it
+mirrors), never from the prior session's stopping point.
+
+The plan's per-phase verification greps are the cheapest completeness check available; they exist
+precisely so a fresh session can re-establish "what's left" in seconds.
+
+## Session Errors
+
+- **`git branch`/`git status` failed (exit 128, "must be run in a work tree")** — ran from the
+  bare-repo root before locating the worktree. Recovery: `git worktree list` → `cd` into the
+  worktree. **Prevention:** on resume in a `core.bare=true` repo, run `git worktree list` and
+  enter the feature worktree before any working-tree git command. Already covered in spirit by
+  `hr-when-in-a-worktree-never-read-from-bare`; no new rule needed.
+- **brand-guide.md Edit rejected ("File has not been read yet")** — attempted Edit before Read.
+  Recovery: Read then Edit. **Prevention:** already hook-enforced by
+  `hr-always-read-a-file-before-editing-it`; no new rule needed.
+
+## Tags
+category: workflow-patterns
+module: work-skill

--- a/knowledge-base/project/plans/2026-06-01-marketing-cloud-platform-positioning-plan.md
+++ b/knowledge-base/project/plans/2026-06-01-marketing-cloud-platform-positioning-plan.md
@@ -225,11 +225,11 @@ do not erase the delivery truth, just stop leading with it.
 
 ### Pre-merge (PR)
 
-- [ ] Zero *lead-with-plugin* prose in primary positioning surfaces: `index.njk` hero,
+- [x] Zero *lead-with-plugin* prose in primary positioning surfaces: `index.njk` hero,
       `brand-guide.md` Positioning, `about.njk` (lines 33 + 51), `community.njk:47`,
       README "What is Soleur?". (Secondary "open source / runs in Claude Code" mentions are
       permitted.) Verify: `grep -niE "is (an? )?(open-source )?claude code plugin" plugins/soleur/docs/pages/about.njk plugins/soleur/docs/pages/community.njk` returns no *lede* hits.
-- [ ] `marketing-strategy.md`: "terminal-first" removed/reframed as a *positioning advantage*
+- [x] `marketing-strategy.md`: "terminal-first" removed/reframed as a *positioning advantage*
       per brand-guide line 91 — at line ~78 (Moat #1 qualifier) and line ~387 ("emphasize
       terminal-first vs workspace-first"). The 2026-03-22 review *note* at line ~72 that
       explains the change may remain (it documents the rationale). Verify:
@@ -237,11 +237,11 @@ do not erase the delivery truth, just stop leading with it.
       *advocacy* of terminal-first as a differentiator (review-note mentions OK). Channel/metric
       lines (plugin registry, lines ~144/204-205/337) reframed as self-host→waitlist funnel;
       `last_updated: 2026-06-01`.
-- [ ] `plugins/soleur/docs/_data/skills.js:11` comment count matches the live SKILL.md count.
-- [ ] `bash scripts/sync-readme-counts.sh --check` exits 0 (README counts in sync).
-- [ ] `bun test plugins/soleur/test/marketing-content-drift.test.ts` passes (or the project's
+- [x] `plugins/soleur/docs/_data/skills.js:11` comment count matches the live SKILL.md count.
+- [x] `bash scripts/sync-readme-counts.sh --check` exits 0 (README counts in sync).
+- [x] `bun test plugins/soleur/test/marketing-content-drift.test.ts` passes (or the project's
       `package.json scripts.test` runner equivalent — confirm runner before invoking).
-- [ ] Eleventy build succeeds: `npm run docs:build` exits 0 (catches `.njk` syntax / JSON-LD
+- [x] Eleventy build succeeds: `npm run docs:build` exits 0 (catches `.njk` syntax / JSON-LD
       breakage on edited pages).
 - [ ] PR body documents the verify-and-close findings for M1/M2/M5 (which surfaces were already
       compliant) so the CMO gate reviewer can confirm coverage.

--- a/knowledge-base/project/plans/2026-06-01-marketing-cloud-platform-positioning-plan.md
+++ b/knowledge-base/project/plans/2026-06-01-marketing-cloud-platform-positioning-plan.md
@@ -1,0 +1,362 @@
+---
+title: "marketing: update all public surfaces for cloud platform positioning"
+type: chore
+issue: 1051
+branch: feat-one-shot-1051-cloud-platform-positioning
+lane: single-domain
+brand_survival_threshold: aggregate pattern
+date: 2026-06-01
+owner: CMO
+status: planned
+---
+
+# 📣 marketing: update all public surfaces for cloud platform positioning
+
+## Enhancement Summary
+
+**Deepened on:** 2026-06-01
+**Sections enhanced:** Overview, Research Reconciliation, Research Insights (new), Acceptance Criteria
+
+### Key Improvements
+
+1. **Corrected a false premise** caught by the verify-the-negative pass: the CMO's cited quote
+   *does* exist (one non-rendered #1142 spec copy-deck), not "nowhere". The initial grep was
+   docs+README-scoped and missed `knowledge-base/project/specs/`. Reconciled in-place.
+2. **Grounded every positioning edit in the canonical authority** — `brand-guide.md` Prohibited
+   Terms (lines 90/91/96/437). Line 96's three-part exception (CLI commands, legal defined-term,
+   technical install docs) independently ratifies this plan's Non-Goals.
+3. **Sharpened the M3 AC** — "terminal-first" must be reframed at *two* strategy sites
+   (`:78` Moat, `:387` advocacy), not one; the rationale review-note may remain.
+
+### New Considerations Discovered
+
+- Prohibited-terms list extends beyond "plugin" ("copilot", "assistant", "terminal-first",
+  "AI-powered", "just", "simply") — implementer must not introduce these while rewriting.
+- All three deepen-plan gates pass: 4.6 User-Brand Impact (threshold `aggregate pattern`),
+  4.7 Observability (correct skip — no code-class paths; `skills.js` is build-data not a
+  `plugins/*/scripts/` runtime surface), 4.8 no PAT-shaped variables.
+
+## Overview
+
+Issue #1051 (Pre-Phase 4 Marketing Positioning Gate, CMO review) asserts that every public
+surface says "Claude Code plugin" while the roadmap positions Soleur as a cross-platform cloud
+service, and that recruiting beta founders must not begin until the contradiction is resolved.
+
+**Premise validation changed the shape of this work substantially.** Most of the homepage,
+brand guide, marketing strategy, and `llms.txt` have *already* been migrated to
+Company-as-a-Service platform positioning (the homepage hero, getting-started hero, and
+`about.njk` carry a `2026-06-01` `last_updated`; the brand guide already states "We lead with
+the ambitious platform vision, never the plugin description"). The CMO's cited quote
+("orchestrated from a single Claude Code plugin") exists in exactly **one** place —
+`knowledge-base/project/specs/feat-website-conversion-review/copy-deck.md:43`, a non-rendered
+2026-03-26 spec draft (issue #1142) — and on **zero live public surfaces**. This is therefore a
+**residual-cleanup + consistency** task, not a from-scratch pivot.
+
+The genuine remaining work is:
+1. A handful of surfaces that still *lead* with plugin framing where they should lead with the
+   platform (e.g. `about.njk` "launched as a plugin", `community.njk` "is an open-source Claude
+   Code plugin", `plugins/soleur/README.md`).
+2. Count/term consistency cleanup (one stale `74 skills` comment; verify the auto-synced README
+   exact counts; confirm prose soft-floors are uniform).
+3. Marketing-strategy edits the strategy doc *itself* already flags as outstanding (remove
+   "terminal-first workflow" qualifiers, refresh the plugin-registry channel lines, update the
+   self-reported "What Is Broken" status row).
+
+**What this plan deliberately does NOT do** (see Non-Goals): rewrite the SEO/AEO *pillar* pages
+whose subject matter *is* "Claude Code plugin" (`claude-code-plugins.njk`, `glossary.njk`,
+`company-as-a-service.njk`, `agentic-engineering.njk`); remove `claude plugin install soleur`
+install commands (the correct, verified CLI form for the open-source path); or edit legal docs
+that use "the Plugin" as a defined legal term.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Issue/spec claim | Codebase reality (verified 2026-06-01) | Plan response |
+|---|---|---|
+| "Every public surface says 'Claude Code plugin'" | Homepage hero, getting-started hero, `llms.txt`, brand guide, pricing all already lead with "Company-as-a-Service platform". Plugin framing survives only on a minority of surfaces. | Scope to the residual surfaces (M1/M2 mostly already done — verify-and-close; M5 partly done). |
+| CMO quote: "orchestrated from a single Claude Code plugin" | Repo-wide `grep` finds it in exactly ONE non-rendered spec draft (`knowledge-base/project/specs/feat-website-conversion-review/copy-deck.md:43`, issue #1142, 2026-03-26); **zero** live public surfaces. [Corrected during deepen-plan — initial plan grep was scoped to `docs`+README and missed the spec dir.] | Do not chase the literal quote on live surfaces (none exist); treat it as illustrative of the *class* (lead-with-plugin) and fix the real lead-with-plugin surfaces. The stale copy-deck is a #1142 spec artifact, not this issue's surface — out of scope. |
+| M6: "agent/skill counts: 4 different numbers" | README `67/82/3` (exact, **auto-synced & currently correct** via `scripts/sync-readme-counts.sh`); prose `60+ agents / 60+ skills` (soft floors, correct per content-plan SF-10); `skills.js:11` comment `74 skills` (**stale**); blog posts `63`/`65+` agents (allowlisted historical, frozen — OK). | Fix only the genuinely stale `skills.js` comment + run the canonical count-propagation grep. Do NOT replace soft floors with exact counts (would re-introduce drift and fail `marketing-content-drift.test.ts`). |
+| M2: "Update homepage hero subtitle + meta description" | `index.njk` hero subtitle + `description` frontmatter already CaaS-platform-positioned, dated 2026-06-01. | Verify-and-close; no edit expected unless residual "plugin" found. |
+| M1: "Update brand guide positioning paragraph (remove plugin framing)" | `brand-guide.md` Positioning already says "never the plugin description"; carries the 2026-03-22 Business Validation Review notes prescribing exactly this pivot. | Verify-and-close; confirm no plugin-led prose remains in Identity/Positioning/Voice. |
+| M3: "Update marketing strategy for cloud pivot" | `marketing-strategy.md` self-documents the outstanding edits: line 58 "Plugin still appears…", line 78 "terminal-first workflow qualifier should be removed", lines 144/204-205/337 plugin-registry channel assumptions. | Real work: apply the strategy doc's own prescribed rewrites. |
+| M4: "Draft recruitment messaging templates per channel" | **Separate open issue #1445 (M4)** owns this; roadmap row maps `#1051 = M3 only`. `validation-outreach-template.md` already exists (problem-interview outreach). | Coordinate, do not double-build. Recommend M4 be executed under #1445; this plan references it (no new deferral issue needed — #1445 already tracks it). See "Open Questions". |
+| M5: "Getting Started page (cloud primary, CLI secondary)" | `getting-started.njk` already structures cloud-hosted as primary CTA ("Reserve access") and self-hosted as a `#self-hosted` secondary section, dated 2026-06-01. | Verify-and-close; minor copy polish only if a plugin-led line remains. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a recruited founder lands on a public surface
+(About page, community page, plugin README) that pitches a "Claude Code plugin" instead of the
+cloud platform they were recruited for, undercutting the pitch — OR inconsistent agent/skill
+counts across surfaces that read as carelessness.
+
+**If this leaks, the user's data / workflow / money is exposed via:** N/A — this is
+public-facing marketing copy only. No user data, auth, secrets, or money-handling surface is
+touched.
+
+**Brand-survival threshold:** `aggregate pattern` — a single residual "plugin" line is
+cosmetic; the brand risk is the *aggregate* of inconsistent positioning across many surfaces at
+once during recruitment. No per-PR CPO sign-off required; the section is present per the gate.
+
+## Premise Validation
+
+Checked all referenced premises: issue #1051 is OPEN (not already closed by a merged PR);
+sibling issue #1445 (M4 recruitment templates) is OPEN; roadmap row 78 + line 239 authoritatively
+scope `#1051 = M3`. Cited file/symbol paths verified to exist: `knowledge-base/marketing/brand-guide.md`,
+`marketing-strategy.md`, `plugins/soleur/docs/index.njk`, `getting-started.njk`, `about.njk`,
+`community.njk`, `README.md`, `scripts/sync-readme-counts.sh`,
+`plugins/soleur/docs/_data/skills.js`, `plugins/soleur/test/marketing-content-drift.test.ts`.
+**Stale premise found:** the CMO's literal quote does not exist and ~M1/M2/M5 are largely
+already complete — surfaced in Research Reconciliation rather than planned against as-if-greenfield.
+
+## Research Insights
+
+**Canonical authority for the "lead-with-platform, plugin-secondary" rule** — `knowledge-base/marketing/brand-guide.md` Prohibited Terms (the load-bearing source; all M1-M3/M5 edits trace to it):
+
+- **Line 96** — "Call it a 'plugin' or 'tool' in public-facing content -- it is a platform.
+  **Exception:** 'plugin' is permitted in (a) literal CLI commands (`claude plugin install`),
+  (b) legal documents where 'Plugin' is a defined term, (c) technical documentation describing
+  the installation mechanism." → This *exactly* ratifies this plan's Non-Goals. The pillar/SEO
+  pages, install commands, and legal docs are explicitly exception-permitted; touching them
+  would violate the brand guide's own carve-out, not enforce it.
+- **Line 90** — "Say 'assistant' or 'copilot' -- Soleur is an organization, not a helper" (avoid).
+- **Line 91** — "Say 'terminal-first' or 'CLI-native' as a positioning advantage -- the delivery
+  pivot requires device-agnostic language [added 2026-03-22, per business validation]" (avoid).
+  → This is the canonical backing for the M3 `marketing-strategy.md` "terminal-first" removal
+  (strategy line 78 / 387). Confirmed: "terminal-first" appears at `marketing-strategy.md:72`
+  (review note — leave), `:78` (Moat #1 prose — **remove qualifier**), `:387` ("emphasize
+  terminal-first vs workspace-first" — **reframe**, this is now a prohibited positioning advantage).
+- **Line 437** — "the website CTA must shift from plugin installation to platform signup/login …
+  Do not reference CLI installation as the primary CTA." → Already satisfied on
+  `getting-started.njk` (primary CTA = "Reserve access"; self-host secondary). Verify-and-close.
+
+**Verify-the-negative pass results (deepen-plan Phase 4.45):**
+
+- "CMO quote does not exist" → **CONTRADICTED then corrected**: it exists in one non-rendered
+  spec draft (see Research Reconciliation). Reconciled above.
+- "lead-with-plugin lines exist on about.njk:51 + community.njk:47" → **CONFIRMED** (grep hits).
+- "terminal-first exists in marketing-strategy" → **CONFIRMED** (`:78`, `:387`).
+- "README counts in sync via script" → **CONFIRMED** (`sync-readme-counts.sh --check` exit 0;
+  `67 agents, 3 commands, 82 skills`).
+- "skills.js:11 comment stale (74 vs live 82)" → **CONFIRMED** (comment says 74; live = 82).
+
+**Edge case discovered:** the prohibited-terms list also flags "AI-powered", "just", "simply",
+"disrupt", "synergy" (per the #1142 copy-deck, mirroring brand-guide voice). Out of scope for
+#1051 (plugin/cloud positioning), but the implementer should not *introduce* any of these while
+rewriting — keep edits to platform-first phrasing without reaching for prohibited filler.
+
+## Implementation Phases
+
+> Each editing phase is a content edit. Order: low-risk verify-and-close first (M1/M2/M5),
+> then the substantive strategy rewrite (M3), then consistency cleanup (M6). No phase has a
+> code-contract dependency on another, so order is by risk, not by data flow.
+
+### Phase 1 — M1/M2/M5 verify-and-close
+
+For each of `brand-guide.md` (Identity/Positioning/Voice), `index.njk` (hero subtitle +
+`description` frontmatter), `getting-started.njk` (hero + section ordering):
+
+1. Re-grep each for any *lead-with-plugin* prose (`grep -niE "\bplugin\b" <file>`).
+2. If a line *leads* with plugin framing as the primary identity, rewrite it platform-first
+   (keep any factually-correct secondary "open-source, runs in Claude Code today" mention).
+3. If no lead-with-plugin prose remains, record "verified — already platform-positioned
+   (2026-06-01)" in the PR body; do **not** make cosmetic edits for the sake of a diff.
+
+**Expected outcome:** likely zero or near-zero edits; the value is the documented verification.
+
+### Phase 2 — M3 marketing-strategy rewrite (`knowledge-base/marketing/marketing-strategy.md`)
+
+Apply the edits the strategy doc already prescribes for itself:
+
+- **Line ~58** ("What Is Broken or Missing" → "Plugin still appears in homepage hero subtitle,
+  FAQ texts, llms.txt, Getting Started meta description"): update to reflect current reality
+  (hero + llms.txt + meta already fixed); narrow the open item to the genuine residual surfaces
+  this PR addresses, or mark resolved.
+- **Line ~78** (Moat #1): remove the "within a terminal-first workflow" qualifier per the
+  2026-03-22 review note; the compounding-KB moat is delivery-agnostic.
+- **Lines ~144 / ~204-205 / ~337** (channel strategy: "GitHub plugin discovery", "Optimize
+  Claude Code plugin registry listing", "Plugin installs 50+" metric): reframe as
+  *open-source / self-hosted acquisition channel feeding the cloud waitlist*, not the primary
+  conversion surface. Keep plugin-registry as a P2 technical-discovery channel (it is real),
+  but the primary funnel is cloud signup/waitlist.
+- Bump `last_updated` / `last_reviewed` frontmatter to 2026-06-01.
+
+### Phase 3 — M1 lead-with-platform residual surfaces
+
+Rewrite the surfaces that still *lead* with plugin identity:
+
+- `plugins/soleur/docs/pages/about.njk:33` — "The platform launched as an open-source Claude
+  Code plugin and has grown to…" → lead with platform, keep launch-origin as secondary clause.
+- `plugins/soleur/docs/pages/about.njk:51` — "Soleur is an open-source Claude Code plugin that
+  turns a solo founder into a full AI organization. The cloud platform is in development." →
+  lead with the Company-as-a-Service platform; self-host/open-source as the secondary access path.
+- `plugins/soleur/docs/pages/community.njk:47` — "Soleur is an open-source Claude Code plugin
+  with an active community…" → platform-first phrasing (community para can still note it is
+  open source and built as a Claude Code plugin further down at line 104, which is a
+  factual build-detail, not the lede).
+- `README.md` "## What is Soleur?" + intro — already platform-first ("The Company-as-a-Service
+  platform"); the installation section's `claude plugin install` commands stay (correct CLI).
+  Verify the lede leads with platform; minimal/no change expected.
+- `plugins/soleur/README.md` — plugin-developer-facing; leave install-centric framing but
+  confirm the top-line description matches `plugin.json` ("A full AI organization…"). Low
+  priority; this is the component-reference README, not a recruitment surface.
+
+For each: keep the secondary, factually-correct "open source, runs in Claude Code" mention —
+do not erase the delivery truth, just stop leading with it.
+
+### Phase 4 — M6 count/term consistency
+
+1. Fix the one genuinely stale comment: `plugins/soleur/docs/_data/skills.js:11`
+   `// Last verified: 2026-05-21 (4 categories, 74 skills)` → update to current
+   (`82 skills` as of 2026-06-01; the count is computed at build time, the comment is just a
+   note). Re-verify the live count at edit time: `find plugins/soleur/skills -maxdepth 2 -name SKILL.md | wc -l`.
+2. Run the canonical count-propagation grep (from learning
+   `2026-02-22-skill-count-propagation-locations.md`) to confirm no other stale exact counts:
+   ```bash
+   grep -rn '\b[0-9]\+ \(agents\?\|skills\?\)\b' . --include='*.md' --include='*.js' --include='*.json' \
+     | grep -vE 'node_modules|CHANGELOG|knowledge-base/project/(plans|specs|learnings)|knowledge-base/marketing/(audits|distribution-content|copy)|/blog/'
+   ```
+3. Confirm README exact counts (`67 agents / 82 skills / 3 commands`) are current by running
+   `bash scripts/sync-readme-counts.sh --check` (exit 0 = in sync). Do **not** hand-edit
+   README counts — the script owns them.
+4. Confirm `marketing-content-drift.test.ts` Test 1 passes (no bare exact counts in the
+   `59|61|62|63|65|66|67 agents/skills` window in swept prose) — this is the regression guard
+   for M6.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] Zero *lead-with-plugin* prose in primary positioning surfaces: `index.njk` hero,
+      `brand-guide.md` Positioning, `about.njk` (lines 33 + 51), `community.njk:47`,
+      README "What is Soleur?". (Secondary "open source / runs in Claude Code" mentions are
+      permitted.) Verify: `grep -niE "is (an? )?(open-source )?claude code plugin" plugins/soleur/docs/pages/about.njk plugins/soleur/docs/pages/community.njk` returns no *lede* hits.
+- [ ] `marketing-strategy.md`: "terminal-first" removed/reframed as a *positioning advantage*
+      per brand-guide line 91 — at line ~78 (Moat #1 qualifier) and line ~387 ("emphasize
+      terminal-first vs workspace-first"). The 2026-03-22 review *note* at line ~72 that
+      explains the change may remain (it documents the rationale). Verify:
+      `grep -n "terminal-first" knowledge-base/marketing/marketing-strategy.md` shows no
+      *advocacy* of terminal-first as a differentiator (review-note mentions OK). Channel/metric
+      lines (plugin registry, lines ~144/204-205/337) reframed as self-host→waitlist funnel;
+      `last_updated: 2026-06-01`.
+- [ ] `plugins/soleur/docs/_data/skills.js:11` comment count matches the live SKILL.md count.
+- [ ] `bash scripts/sync-readme-counts.sh --check` exits 0 (README counts in sync).
+- [ ] `bun test plugins/soleur/test/marketing-content-drift.test.ts` passes (or the project's
+      `package.json scripts.test` runner equivalent — confirm runner before invoking).
+- [ ] Eleventy build succeeds: `npm run docs:build` exits 0 (catches `.njk` syntax / JSON-LD
+      breakage on edited pages).
+- [ ] PR body documents the verify-and-close findings for M1/M2/M5 (which surfaces were already
+      compliant) so the CMO gate reviewer can confirm coverage.
+- [ ] PR body uses `Ref #1051` and `Ref #1445` (M4 coordination); does not `Closes #1051`
+      unless M3 is fully satisfied here (it is, so `Closes #1051` is acceptable — M4 lives under #1445).
+
+### Post-merge (operator)
+
+- [ ] None. All verification is automatable via the test suite + Eleventy build in CI. No
+      external-service state, deploy step, or manual browser action required.
+
+## Domain Review
+
+**Domains relevant:** Marketing (Product advisory)
+
+### Marketing (CMO)
+
+**Status:** reviewed (carry-forward — issue #1051 is itself a CMO-review artifact; brand-guide
+and marketing-strategy already encode the 2026-03-22 Business Validation Review pivot direction)
+**Assessment:** The pivot direction (platform-first, plugin-secondary, delivery-agnostic moat
+framing) is already CMO-ratified in `brand-guide.md` and `marketing-strategy.md`. This plan
+applies the residual edits those documents already prescribe. No new positioning *decision* is
+made — only execution of an existing CMO-approved direction. Recommend no separate domain-leader
+spawn; if the one-shot pipeline runs domain leaders, the CMO assessment is "execute as planned".
+
+### Product/UX Gate
+
+**Tier:** none
+**Rationale:** No new user-facing pages, flows, or components. All changes are prose edits to
+existing pages and knowledge-base docs. `index.njk` / `getting-started.njk` edits (if any) are
+copy-only, not new interactive surfaces. Mechanical escalation does not fire — no new files
+matching `components/**/*.tsx`, `app/**/page.tsx`, or `app/**/layout.tsx`.
+
+## Observability
+
+Skip — pure content/docs change. No Files-to-Edit under `apps/*/server/`, `apps/*/src/`,
+`apps/*/infra/`, or `plugins/*/scripts/` (the one `.js` edit is a build-time data comment, not a
+runtime code surface; the `sync-readme-counts.sh` invocation is read-only `--check`). The
+regression surface is covered by `marketing-content-drift.test.ts` + the Eleventy build gate,
+both of which run in CI with no SSH.
+
+## Infrastructure (IaC)
+
+Skip — no new infrastructure (server, service, cron, vendor account, DNS, cert, secret,
+firewall rule, or persistent runtime process) is introduced. Pure content edits against an
+already-provisioned static-docs surface.
+
+## Files to Edit
+
+- `knowledge-base/marketing/marketing-strategy.md` — M3 rewrites (moat qualifier, channel
+  lines, status row, frontmatter date). **Substantive.**
+- `plugins/soleur/docs/pages/about.njk` — lines 33 + 51, lead-with-platform. **Substantive.**
+- `plugins/soleur/docs/pages/community.njk` — line 47, lead-with-platform. **Substantive.**
+- `plugins/soleur/docs/_data/skills.js` — line 11 stale count comment. **Trivial.**
+- `knowledge-base/marketing/brand-guide.md` — verify-and-close (likely no edit; bump
+  `last_reviewed` to 2026-06-01 to record the review). **Verify.**
+- `plugins/soleur/docs/index.njk` — verify-and-close (likely no edit). **Verify.**
+- `plugins/soleur/docs/pages/getting-started.njk` — verify-and-close (likely no edit). **Verify.**
+- `README.md` — verify lede leads with platform (likely no edit; counts script-owned). **Verify.**
+- `plugins/soleur/README.md` — verify top-line matches `plugin.json` (low priority). **Verify.**
+
+## Files to Create
+
+- None.
+
+## Open Code-Review Overlap
+
+None. Queried 74 open `code-review`-labelled issues; zero reference any file in this plan's
+Files-to-Edit list.
+
+## Non-Goals / Out of Scope
+
+- **SEO/AEO pillar pages whose subject IS "Claude Code plugin"** — `claude-code-plugins.njk`,
+  `glossary.njk` (the "Claude Code Plugin" defined term), `company-as-a-service.njk`,
+  `agentic-engineering.njk`, and the `best-claude-code-plugins-2026` / `plugin-vs-skill-vs-mcp`
+  blog posts. These intentionally use "plugin" as their ranking topic. Editing them would harm
+  AEO/SEO coverage and is not "primary positioning". (No deferral issue needed — these are
+  permanent by design, not deferred work.)
+- **`claude plugin install soleur` install commands** across pages — the correct, CLI-verified
+  open-source install path. Keep verbatim (`<!-- verified: 2026-04-19 source: https://code.claude.com/docs/en/plugins -->` already present in getting-started).
+- **Legal docs** (`terms-and-conditions.md`, `gdpr-policy.md`, `cookie-policy.md`) — use "the
+  Plugin" as a *defined legal term* alongside "the Web Platform". Changing legal definitions is
+  a CLO-domain change with its own review path; out of scope for a marketing-positioning PR.
+- **M4 recruitment messaging templates** — owned by **open issue #1445** (already tracked; no
+  new deferral issue required). This plan coordinates with it but does not author the templates,
+  to avoid double-work. If the one-shot pipeline owner wants M4 folded in here, that is a scope
+  decision to confirm with the user (see Open Questions).
+- **Replacing prose soft-floors (`60+ agents`) with exact counts** — would re-introduce the
+  drift `marketing-content-drift.test.ts` guards against. Soft floors are the correct pattern.
+
+## Open Questions
+
+1. **M4 scope:** the issue body lists M4 (recruitment templates) but the roadmap maps
+   `#1051 = M3` and a dedicated issue #1445 owns M4. Default: execute M1-M3/M5/M6 here, leave M4
+   to #1445. Confirm if the pipeline should instead fold M4 into this PR.
+
+## Test Scenarios
+
+- **Count consistency:** `bun test plugins/soleur/test/marketing-content-drift.test.ts` Test 1
+  passes (no stale exact counts in swept prose); `scripts/sync-readme-counts.sh --check` exits 0.
+- **Build integrity:** `npm run docs:build` exits 0 after `.njk` edits (no Nunjucks/JSON-LD
+  breakage on `about.njk` / `community.njk`).
+- **No-plugin-lede grep:** the AC grep commands return no lede hits on the edited primary surfaces.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder
+  text, or omits the threshold will fail `deepen-plan` Phase 4.6. This section is filled above
+  (threshold: `aggregate pattern`).
+- **Do not hand-edit README component counts** — `scripts/sync-readme-counts.sh` owns them and a
+  CI `--check` will flag drift. Use the script.
+- **Do not replace prose `60+` soft floors with exact counts** — `marketing-content-drift.test.ts`
+  Test 1 rejects bare exact counts in the `59|61|62|63|65|66|67 agents/skills` window. The blog
+  posts using `63`/`65+` agents are allowlisted historical files; leave them frozen.
+- **Resist editing pillar/SEO pages** — they rank on "Claude Code plugin"; touching them trades
+  the (already-done) positioning win for an AEO loss.
+- Confirm the test runner before invoking an AC test command (`package.json scripts.test`);
+  this repo uses `bun test` for `.test.ts` and `bash` for `.test.sh` — do not assume.

--- a/knowledge-base/project/specs/feat-one-shot-1051-cloud-platform-positioning/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-1051-cloud-platform-positioning/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-01-marketing-cloud-platform-positioning-plan.md
+- Status: complete
+
+### Errors
+None. (One in-plan self-correction during deepen-plan: the initial plan claimed the CMO's "orchestrated from a single Claude Code plugin" quote did not exist anywhere; the verify-the-negative pass found it in one non-rendered spec draft. Corrected in-place — no live public surface affected.)
+
+### Decisions
+- Premise validation reshaped the work: M1 (brand guide), M2 (homepage hero), M5 (getting-started) are already cloud-platform-positioned (dated 2026-06-01). Plan treats these as verify-and-close; scopes real work to genuine residuals: about.njk:33/51, community.njk:47, M3 marketing-strategy edits, and one stale skills.js count comment.
+- Grounded every positioning edit in canonical authority — brand-guide.md Prohibited Terms (lines 90/91/96). Line 96's three-part exception (CLI commands, legal defined-term, technical install docs) independently ratifies the Non-Goals.
+- Scoped out by design, not deferred: SEO/AEO pillar pages ranking on "Claude Code plugin", `claude plugin install` commands (verified CLI form), and legal docs using "Plugin" as a defined term — all brand-guide-exception-permitted. M6 counts are tooling-governed (sync-readme-counts.sh + marketing-content-drift.test.ts).
+- M4 scope reconciliation: roadmap maps #1051 = M3 only; recruitment templates (M4) owned by separate open issue #1445. Plan coordinates rather than double-builds; raised as the one Open Question.
+- All three deepen-plan gates pass: 4.6 User-Brand Impact (threshold aggregate pattern), 4.7 Observability (correct skip — pure docs/content), 4.8 no PAT-shaped variables. No code-review overlap (74 open issues queried, zero matches).
+
+### Components Invoked
+- skill: soleur:plan (#1051)
+- skill: soleur:deepen-plan (plan file path)
+- Targeted mechanical verification (verify-the-negative pass, citation/path resolution, gate checks)

--- a/plugins/soleur/docs/_data/skills.js
+++ b/plugins/soleur/docs/_data/skills.js
@@ -8,7 +8,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Category mapping -- update here when skills are added/reorganized
 // Source of truth: plugins/soleur/docs/pages/skills.njk (renders at /skills/)
-// Last verified: 2026-05-21 (4 categories, 74 skills)
+// Last verified: 2026-06-01 (4 categories, 82 skills)
 const SKILL_CATEGORIES = {
   // Content & Release (17)
   "brainstorm-techniques": "Review & Planning",

--- a/plugins/soleur/docs/pages/about.njk
+++ b/plugins/soleur/docs/pages/about.njk
@@ -30,7 +30,7 @@ last_updated: 2026-06-01
             Jean is a software engineer with over 15 years of experience building distributed systems and developer tools. Before founding Soleur, he worked across the full stack &mdash; from backend infrastructure to developer experience &mdash; at companies ranging from early-stage startups to enterprise organizations. His background spans Java, Ruby, Go, and TypeScript ecosystems.
           </p>
           <p>
-            He founded Soleur in early 2026 after recognizing that AI agent orchestration could collapse the operational overhead of running a company. The platform launched as an open-source <a href="https://docs.anthropic.com/en/docs/claude-code" rel="noopener noreferrer">Claude Code</a> plugin and has grown to 60+ agents across {{ stats.departments }} departments, with 60+ automated workflow skills. Soleur is built using Soleur itself &mdash; every agent, workflow, and decision compounds into the product through <a href="https://modelcontextprotocol.io/" rel="noopener noreferrer">the Model Context Protocol (MCP)</a>.
+            He founded Soleur in early 2026 after recognizing that AI agent orchestration could collapse the operational overhead of running a company. The Company-as-a-Service platform &mdash; open-source and running in <a href="https://docs.anthropic.com/en/docs/claude-code" rel="noopener noreferrer">Claude Code</a> today &mdash; has grown to 60+ agents across {{ stats.departments }} departments, with 60+ automated workflow skills. Soleur is built using Soleur itself &mdash; every agent, workflow, and decision compounds into the product through <a href="https://modelcontextprotocol.io/" rel="noopener noreferrer">the Model Context Protocol (MCP)</a>.
           </p>
           <p>
             Jean writes about agentic engineering, solo founding, and the mechanics of the billion-dollar one-person company on the <a href="/blog/">Soleur blog</a>. His thesis: the combination of AI agent orchestration and compounding institutional knowledge will enable <a href="https://www.inc.com/ben-sherry/anthropic-ceo-dario-amodei-predicts-the-first-billion-dollar-solopreneur-by-2026/91193609" rel="noopener noreferrer">the first single-person billion-dollar company</a>.
@@ -48,7 +48,7 @@ last_updated: 2026-06-01
           <h2 class="category-title">About Soleur</h2>
         </div>
         <p class="community-text">
-          Soleur is an open-source Claude Code plugin that turns a solo founder into a full AI organization. The cloud platform is in development. Everything Soleur does is built using Soleur &mdash; the platform is its own proving ground.
+          Soleur is the Company-as-a-Service platform that turns a solo founder into a full AI organization &mdash; open-source and running in Claude Code today, with the cloud platform in development. Everything Soleur does is built using Soleur &mdash; the platform is its own proving ground.
         </p>
         <p class="community-text">
           Soleur is operated by Jikigai, the legal entity behind the platform.

--- a/plugins/soleur/docs/pages/community.njk
+++ b/plugins/soleur/docs/pages/community.njk
@@ -101,7 +101,7 @@ permalink: community/
         </div>
         <p class="community-text">
           We welcome contributions of all kinds &mdash; bug reports, feature requests, documentation improvements, and code.
-          Soleur is built as a <a href="https://docs.anthropic.com/en/docs/claude-code/plugins" rel="noopener noreferrer">Claude Code plugin</a>, and contributions follow <a href="https://opensource.guide/how-to-contribute/" rel="noopener noreferrer">open source best practices</a>.
+          The platform ships as a <a href="https://docs.anthropic.com/en/docs/claude-code/plugins" rel="noopener noreferrer">Claude Code plugin</a>, and contributions follow <a href="https://opensource.guide/how-to-contribute/" rel="noopener noreferrer">open source best practices</a>.
           Read the <a href="{{ site.github }}/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">contributing guide</a> to get started.
         </p>
       </section>

--- a/plugins/soleur/docs/pages/community.njk
+++ b/plugins/soleur/docs/pages/community.njk
@@ -44,7 +44,7 @@ permalink: community/
 
     <div class="container">
       <section class="community-summary">
-        <p>Soleur is an open-source Claude Code plugin with an active community across Discord, GitHub, and X. The project is Apache 2.0, accepts contributions through the standard GitHub pull-request flow, and publishes development discussions in the public Discord. Every agent, skill, and release ships through the same compound-engineering workflow the product itself uses.</p>
+        <p>Soleur is an open-source Company-as-a-Service platform with an active community across Discord, GitHub, and X. The project is Apache 2.0, accepts contributions through the standard GitHub pull-request flow, and publishes development discussions in the public Discord. Every agent, skill, and release ships through the same compound-engineering workflow the product itself uses.</p>
       </section>
 
       <section class="category-section">


### PR DESCRIPTION
## Summary

Aligns every public-facing surface with Soleur's cloud-platform ("Company-as-a-Service") positioning, resolving the Pre-Phase-4 Marketing Positioning Gate (CMO review). Premise validation showed most surfaces (homepage hero, brand guide, `llms.txt`, getting-started) were already migrated on 2026-06-01 — this PR closes the residual lead-with-plugin surfaces and the M3 strategy edits the strategy doc flagged for itself.

Closes #1051

M4 (per-channel recruitment templates) is tracked separately under #1445 — referenced, not closed here.

## Changelog

### Marketing positioning (M1/M3)
- `about.njk` (bio + "About Soleur"): lead with the Company-as-a-Service platform; open-source / runs-in-Claude-Code retained as the secondary access path.
- `community.njk`: summary lede + contributing line reframed platform-first (plugin kept as a factual build-detail per brand-guide line 96 exception).
- `marketing-strategy.md` (M3): removed "terminal-first" as a positioning advantage (brand-guide line 91) at the Moat #1 qualifier and the Notion-response section; reframed plugin-registry channel + metric lines as a self-host→cloud-waitlist funnel; resolved the "Brand term compliance" status row; bumped `last_updated`/`last_reviewed` to 2026-06-01.
- `brand-guide.md`: recorded the review pass (`last_reviewed: 2026-06-01`); positioning already compliant.

### Consistency (M6)
- `skills.js`: stale count comment `74 → 82` (live `SKILL.md` count). README exact counts are script-owned and verified in sync; prose soft-floors (`60+`) left intact per `marketing-content-drift.test.ts`.

### Verify-and-close (M2/M5)
- `index.njk` hero, `getting-started.njk`, README lede confirmed already platform-first (2026-06-01) — no edit needed.

## Out of scope (by design, not deferred)
- SEO/AEO pillar pages that rank on "Claude Code plugin" (`claude-code-plugins.njk`, `glossary.njk`, `company-as-a-service.njk`, blog posts).
- `claude plugin install soleur` CLI commands (verified install path).
- Legal docs using "the Plugin" as a defined term (CLO-domain change).

## Test plan
- [x] `bun test plugins/soleur/test/marketing-content-drift.test.ts` — 5 pass
- [x] `bash scripts/test-all.sh` (bun shard — covers `plugins/soleur/`) green
- [x] Eleventy build (`npx @11ty/eleventy`) exits 0, 103 files
- [x] `bash scripts/sync-readme-counts.sh --check` exits 0
- [x] Multi-agent review (pattern-recognition, security-sentinel, code-simplicity) + anti-slop scanner — 3 findings, all fixed inline; 0 P1; 0 issues filed
- [x] No lead-with-plugin lede on edited primary surfaces (AC grep)

Generated with [Claude Code](https://claude.com/claude-code)
