### PR TITLE
fix(tests): align remove_workspace_member integration calls with mig 094 service-role contract

### DIFF
--- a/apps/web-platform/test/dsar-departed-member.integration.test.ts
+++ b/apps/web-platform/test/dsar-departed-member.integration.test.ts
@@ -165,40 +165,17 @@ describe.skipIf(!INTEGRATION_ENABLED)(
       // RPC's INSERT into workspace_member_removals fires inside the
       // same body as the DELETE — atomic.
       //
-      // The RPC pulls v_caller_user_id from auth.uid(); the service
-      // client bypasses PostgREST's role-switching, so we need to
-      // either (a) mint a runtime JWT for Jean and call via an
-      // anon-role client, or (b) impersonate via the auth header. The
-      // existing dsar-export-workspace-tables test takes path (b) by
-      // setting Authorization on the request via the service client's
-      // global headers.
-      const jeanClient = createClient(
-        requireEnv("SUPABASE_URL"),
-        requireEnv("SUPABASE_ANON_KEY"),
-        { auth: { persistSession: false, autoRefreshToken: false } },
-      );
-      // Sign Jean in to get a real user-scope JWT.
-      const { data: jeanSignIn, error: jeanSignInErr } =
-        await service.auth.admin.generateLink({
-          type: "magiclink",
-          email: jean.email,
-        });
-      if (jeanSignInErr || !jeanSignIn?.properties?.hashed_token) {
-        throw new Error(
-          `generateLink for Jean failed: ${jeanSignInErr?.message ?? "no token"}`,
-        );
-      }
-      const { error: jeanVerifyErr } = await jeanClient.auth.verifyOtp({
-        token_hash: jeanSignIn.properties.hashed_token,
-        type: "magiclink",
-      });
-      if (jeanVerifyErr) {
-        throw new Error(`verifyOtp for Jean failed: ${jeanVerifyErr.message}`);
-      }
-
-      const { error: rmErr } = await jeanClient.rpc("remove_workspace_member", {
+      // mig 094: remove_workspace_member is service_role-only (the
+      // authenticated EXECUTE grant was REVOKED to close the forgeable-
+      // override privilege-escalation class) and resolves the caller via
+      // COALESCE(p_caller_user_id, auth.uid()). The production wrapper
+      // (server/workspace-membership.ts removeWorkspaceMember) invokes it via
+      // the service client forwarding the route-verified owner id — mirror that
+      // (no per-test Jean sign-in / JWT mint is needed under the new contract).
+      const { error: rmErr } = await service.rpc("remove_workspace_member", {
         p_workspace_id: fixture.workspaceId,
         p_user_id: harry.userId,
+        p_caller_user_id: jean.userId,
       });
       if (rmErr) {
         throw new Error(

--- a/apps/web-platform/test/server/attachments-workspace-shared-cascade.integration.test.ts
+++ b/apps/web-platform/test/server/attachments-workspace-shared-cascade.integration.test.ts
@@ -318,24 +318,17 @@ describe.skipIf(!INTEGRATION_ENABLED)(
         if (!fixture) throw new Error("fixture build failed");
         const [alice, bob] = fixture.workspace.members;
 
-        // Caller must be an owner; mig 067 enforces this via auth.uid().
-        // Service-role call: we set request.jwt.claims to Alice's sub so
-        // auth.uid() inside the SECURITY DEFINER RPC resolves correctly.
-        // (Service-role bypasses RLS for the SELECT/DELETE but the RPC
-        // body's `IF v_caller_user_id IS NULL THEN RAISE` check fires
-        // on auth.uid() = NULL, so the claim header is load-bearing.)
-        const url = requireEnv("SUPABASE_URL");
-        const anonKey = requireEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY");
-        const { mintFounderJwt } = await import("@/lib/supabase/tenant");
-        const aliceMint = await mintFounderJwt(alice.userId);
-        const aliceClient = createClient(url, anonKey, {
-          global: { headers: { Authorization: `Bearer ${aliceMint.jwt}` } },
-          auth: { persistSession: false, autoRefreshToken: false },
-        });
-
-        const { error: rpcErr } = await aliceClient.rpc("remove_workspace_member", {
+        // mig 094: remove_workspace_member is service_role-only (the
+        // authenticated EXECUTE grant was REVOKED to close the forgeable-
+        // override privilege-escalation class) and resolves the caller via
+        // COALESCE(p_caller_user_id, auth.uid()). The production wrapper
+        // (server/workspace-membership.ts removeWorkspaceMember) invokes it via
+        // the service client and forwards the route-verified owner id as
+        // p_caller_user_id — mirror that exact call shape here.
+        const { error: rpcErr } = await service.rpc("remove_workspace_member", {
           p_workspace_id: fixture.workspace.workspaceId,
           p_user_id: bob.userId,
+          p_caller_user_id: alice.userId,
         });
         expect(rpcErr, `remove_workspace_member failed: ${rpcErr?.message}`).toBeNull();
 

--- a/apps/web-platform/test/server/dsar-export-workspace-tables.integration.test.ts
+++ b/apps/web-platform/test/server/dsar-export-workspace-tables.integration.test.ts
@@ -107,14 +107,17 @@ describe.skipIf(!INTEGRATION_ENABLED)(
       if (SCHEMA_CACHE_READY === false) return;
       const harry = fixture.members[1];
 
-      // remove_workspace_member is 2-arg (p_workspace_id, p_user_id) per
-      // mig 062:272; the SECURITY DEFINER body reads the actor from
-      // auth.uid(). Service-role contexts have auth.uid() = NULL so the
-      // RPC raises 28000; fallback DELETE is the canonical removal path
-      // here (mirrors workspace-members.test.ts:113-119 precedent).
+      // mig 094: remove_workspace_member is now 3-arg + service_role-only and
+      // resolves the caller via COALESCE(p_caller_user_id, auth.uid()).
+      // Service-role contexts have auth.uid() = NULL, so we forward the owner
+      // (members[0]) as p_caller_user_id — exactly as the production wrapper
+      // does. The fallback DELETE remains as defense-in-depth in case the RPC
+      // is unavailable in a degraded environment.
+      const owner = fixture.members[0];
       const { error: rmErr } = await service.rpc("remove_workspace_member", {
         p_workspace_id: fixture.workspaceId,
         p_user_id: harry.userId,
+        p_caller_user_id: owner.userId,
       });
       if (rmErr) {
         const { error: delErr } = await service

--- a/apps/web-platform/test/server/workspace-member-revocation.tenant-isolation.test.ts
+++ b/apps/web-platform/test/server/workspace-member-revocation.tenant-isolation.test.ts
@@ -163,15 +163,18 @@ describe.skipIf(!INTEGRATION_ENABLED)(
       const userB = fixtureX.members[1];
 
       // Owner A removes B from workspace X.
-      // Note: remove_workspace_member is SECURITY DEFINER and reads
-      // auth.uid() — but service-role calls produce NULL auth.uid().
-      // For this integration test we invoke via authenticated-JWT
-      // routing through PostgREST so the RPC sees a real auth.uid().
+      // mig 094: remove_workspace_member is service_role-only (the authenticated
+      // EXECUTE grant was REVOKED to close the forgeable-override class) and
+      // resolves the caller via COALESCE(p_caller_user_id, auth.uid()). The
+      // production wrapper invokes it via the service client forwarding the
+      // owner id — mirror that. aClient (below) is still used for the
+      // positive-control check_my_revocation read on Owner A's JWT.
       const aJwt = await mintUserJwt(url, serviceKey, ownerA.email);
       const aClient = clientWithJwt(url, anonKey, aJwt);
-      const { error: removeErr } = await aClient.rpc("remove_workspace_member", {
+      const { error: removeErr } = await service.rpc("remove_workspace_member", {
         p_workspace_id: fixtureX.workspaceId,
         p_user_id: userB.userId,
+        p_caller_user_id: ownerA.userId,
       });
       expect(removeErr).toBeNull();
 


### PR DESCRIPTION
## Summary

Hotfix: PR #4802 (migration 094) made `remove_workspace_member` **service_role-only** with a `COALESCE(p_caller_user_id, auth.uid())` caller-override (closing the forgeable-override privilege-escalation class). Four tenant-integration tests still invoked the RPC via an authenticated (anon-key + JWT) client or a 2-arg service call, so the **dev-Supabase tenant-integration shard went red post-merge**:
- `42501 permission denied` for the authenticated-client calls (grant revoked)
- would-raise `28000` for the 2-arg `service.rpc` call (NULL caller)

These `.integration.test.ts` files run only under `TENANT_INTEGRATION_TEST=1` (live dev DB), so they were absent from the unit suite that gated #4802 and slipped to post-merge CI.

## Changelog

### Web Platform (tests only)
- Route all four `remove_workspace_member` integration call sites through the **service client** forwarding the owner id as `p_caller_user_id` — the exact production wrapper contract (`server/workspace-membership.ts`). The revocation test already used this shape for `transfer_workspace_ownership`.
- Files: `attachments-workspace-shared-cascade.integration.test.ts`, `workspace-member-revocation.tenant-isolation.test.ts`, `dsar-departed-member.integration.test.ts`, `dsar-export-workspace-tables.integration.test.ts`.
- Removed the now-unnecessary per-test JWT-mint / sign-in dances.

## Test plan
- [x] `tsc --noEmit` clean (apps/web-platform)
- [x] **4 files / 16 tests pass** against dev with `TENANT_INTEGRATION_TEST=1` and migration 094 live (the exact shard that went red)

No production code changed — test-only alignment with the merged security contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
