### PR TITLE
fix(docs): renumber operator-cc-oauth ADR 047→048 (ordinal collision)

### DIFF
--- a/knowledge-base/engineering/architecture/decisions/ADR-048-operator-cc-oauth-credential-selection-by-consumer-class.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-048-operator-cc-oauth-credential-selection-by-consumer-class.md
@@ -1,5 +1,5 @@
 ---
-adr: ADR-047
+adr: ADR-048
 title: Operator Claude Code subscription credential — selection by consumer class + structural REST/SDK boundary
 status: accepted
 date: 2026-06-02
@@ -10,7 +10,7 @@ related_plans:
 brand_survival_threshold: single-user incident
 ---
 
-# ADR-047: Operator CC OAuth credential — selection by consumer class + structural REST/SDK boundary
+# ADR-048: Operator CC OAuth credential — selection by consumer class + structural REST/SDK boundary
 
 ## Status
 

--- a/knowledge-base/project/learnings/2026-06-02-two-row-by-provider-credential-and-lease-accessor-rename-sweep.md
+++ b/knowledge-base/project/learnings/2026-06-02-two-row-by-provider-credential-and-lease-accessor-rename-sweep.md
@@ -3,7 +3,7 @@ date: 2026-06-02
 category: best-practices
 module: web-platform/byok
 related: [4825, 4824]
-related_adrs: [ADR-047]
+related_adrs: [ADR-048]
 tags: [byok, credentials, oauth, structural-boundary, migration, test-mocks]
 ---
 

--- a/knowledge-base/project/specs/feat-operator-cc-oauth/tasks.md
+++ b/knowledge-base/project/specs/feat-operator-cc-oauth/tasks.md
@@ -48,4 +48,4 @@ status: ready-for-work  # P0 fork resolved by deepen-plan triad (two-row consume
 - [x] 7.5 migration 096 up/down validated against the LIVE dev schema via a transactional dry-run (BEGIN→up→assert→down→assert→ROLLBACK, drift-free): up adds `anthropic_oauth` to the real `api_keys_provider_check`; `store_oauth_credential` created SECURITY DEFINER with authenticated/anon EXECUTE denied + service_role granted; down restores the CHECK + drops the fn. Real apply runs via the automated deploy pipeline on merge (`run-migrations.sh`; the unmerged-apply gate funnels there — applying unmerged to dev would create #4241-class drift).
 
 ## Phase 0 (advisory)
-- [x] ADR-047 — "Operator CC OAuth credential — selection by consumer class + structural REST/SDK boundary" (absorbed inline at review time per the review sharp-edge for already-shipping-architecture ADRs).
+- [x] ADR-048 — "Operator CC OAuth credential — selection by consumer class + structural REST/SDK boundary" (absorbed inline at review time per the review sharp-edge for already-shipping-architecture ADRs).


### PR DESCRIPTION
## Summary
Post-merge hotfix: `feat-single-nav-rail` (ADR-047-nav-context-band-outside-swap) and `feat-operator-cc-oauth` (ADR-047-operator-cc-oauth-...) both landed ADR-047 on `main` concurrently. The squash-merge of #4824 produced two ADR-047 files → the `adr-ordinals` CI job is red on `main`.

This renumbers the operator-cc-oauth ADR to **048** (next free ordinal) and updates its frontmatter `adr:`, title, the learning file's `related_adrs`, and the tasks.md reference. `bash scripts/check-adr-ordinals.sh` passes.

Ref #4825

## Test plan
- [x] `bash scripts/check-adr-ordinals.sh` → "ADR ordinal + content checks passed"
- [x] No stray ADR-047 reference to the operator-cc-oauth ADR remains (nav-rail ADR-047 untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)