### PR TITLE
fix(infra): APP_DOMAIN_BASE fallback in CF Tunnel bridge step (#4829 hotfix)

### DIFF
--- a/.github/workflows/apply-deploy-pipeline-fix.yml
+++ b/.github/workflows/apply-deploy-pipeline-fix.yml
@@ -253,7 +253,11 @@ jobs:
           DOPPLER_CONFIG: prd_terraform
         run: |
           set -euo pipefail
-          APP_DOMAIN_BASE=$(doppler secrets get APP_DOMAIN_BASE --plain)
+          # APP_DOMAIN_BASE is NOT in the prd_terraform config — fall back to the
+          # canonical default exactly like the verify steps below (do NOT use the
+          # bare form: it exits non-zero under `set -e` and kills the step before
+          # cloudflared starts; #4829 post-merge hotfix).
+          APP_DOMAIN_BASE=$(doppler secrets get APP_DOMAIN_BASE --plain 2>/dev/null || echo "soleur.ai")
           SERVER_IP=$(terraform output -raw server_ip)
           if [[ -z "$SERVER_IP" ]]; then
             echo "::error::terraform output server_ip is empty — state not populated; cannot scope the NAT redirect to the prod host."


### PR DESCRIPTION
## Summary

Post-merge hotfix for #4829. The new CF Tunnel SSH bridge step in `apply-deploy-pipeline-fix.yml` used the bare `APP_DOMAIN_BASE=$(doppler secrets get APP_DOMAIN_BASE --plain)` (copied verbatim from the #4181 history), but `APP_DOMAIN_BASE` is **not** present in the `prd_terraform` Doppler config. Under `set -euo pipefail` the step exited non-zero **before cloudflared started**, so the post-merge `apply-deploy-pipeline-fix` run (run 26846303094) failed at "Start cloudflared SSH bridge + iptables NAT redirect" with `Doppler Error: Could not find requested secret: APP_DOMAIN_BASE`.

Fix: use the same `2>/dev/null || echo "soleur.ai"` fallback the **three** existing verify steps in this file already use (lines 377/424/544). One-line change.

**No production impact:** the step failed before any `terraform apply` ran, and #4829 changed only the bridge's connection *mechanism* + workflow — not the delivered handler files — so nothing on the host was stale or broken. This hotfix recovers the workflow so future handler changes auto-apply over the tunnel as designed.

Ref #4829.

## Changelog

- `apply-deploy-pipeline-fix.yml`: add the canonical `APP_DOMAIN_BASE` fallback to the cloudflared-bridge step so it no longer dies under `set -e` when the secret is absent from `prd_terraform`.

## Test plan

- [x] `actionlint` clean
- [x] All 4 `APP_DOMAIN_BASE=` sites now use the identical fallback form
- [ ] ⏳ Post-merge: `apply-deploy-pipeline-fix` re-fires on this merge (the workflow file is in its own `paths:` filter) and gets past the cloudflared step

Generated with [Claude Code](https://claude.com/claude-code)