### PR TITLE
fix(chat): set messages.template_id on interactive INSERTs (2nd NOT-NULL layer)

### DIFF
--- a/apps/web-platform/server/agent-runner.ts
+++ b/apps/web-platform/server/agent-runner.ts
@@ -466,6 +466,9 @@ async function saveMessage(
     id: randomUUID(),
     conversation_id: conversationId,
     workspace_id: convWsRow.workspace_id,
+    // mig 053: messages.template_id NOT NULL (no default). Interactive
+    // (non-template) messages use the 'default_legacy' sentinel. #4839.
+    template_id: "default_legacy",
     role,
     content,
     tool_calls: toolCalls || null,
@@ -2467,6 +2470,9 @@ export async function sendUserMessage(
     id: messageId,
     conversation_id: conversationId,
     workspace_id: conv.workspace_id,
+    // mig 053: messages.template_id NOT NULL (no default). Interactive
+    // messages use the 'default_legacy' sentinel. #4839.
+    template_id: "default_legacy",
     role: "user",
     content,
     tool_calls: null,

--- a/apps/web-platform/server/cc-dispatcher.ts
+++ b/apps/web-platform/server/cc-dispatcher.ts
@@ -453,6 +453,11 @@ function buildRow(
     // mig 059: messages.workspace_id NOT NULL + member-keyed INSERT RLS.
     // Derived from the parent conversation by the caller; see saveAssistantMessage.
     workspace_id: workspaceId,
+    // mig 053: messages.template_id NOT NULL (no default) + CHECK
+    // (^[a-z][a-z0-9_]*$). Interactive (non-template) messages use the
+    // 'default_legacy' sentinel — same value the draft-card helper and the
+    // 053 backfill use. Omitting it violates the NOT-NULL constraint (#4839).
+    template_id: "default_legacy",
     role: "assistant",
     content: text,
     tool_calls: null,
@@ -1483,6 +1488,9 @@ export async function dispatchSoleurGo(
     id: messageId,
     conversation_id: conversationId,
     workspace_id: conversationWorkspaceId,
+    // mig 053: messages.template_id NOT NULL (no default). Interactive
+    // messages use the 'default_legacy' sentinel (see buildRow). #4839.
+    template_id: "default_legacy",
     role: "user",
     content: rawUserMessage,
     tool_calls: null,

--- a/apps/web-platform/test/server/messages-insert-workspace-id-sweep.test.ts
+++ b/apps/web-platform/test/server/messages-insert-workspace-id-sweep.test.ts
@@ -164,15 +164,33 @@ function extractBalancedBrace(src: string, openIdx: number): string {
   return src.slice(openIdx);
 }
 
-/** Does the resolved payload assign `workspace_id`? */
-function payloadHasWorkspaceId(payload: string): boolean {
+/**
+ * The `messages` columns that are NOT NULL with NO column default — every
+ * INSERT payload MUST supply each one or the insert fails at runtime (RLS
+ * WITH CHECK for workspace_id, NOT-NULL constraint for template_id). This
+ * list is the authoritative set verified against prod `information_schema`
+ * on 2026-06-02 (#4831 missed template_id because the workspace_id RLS error
+ * fired first and masked it — #4839). If a future migration adds another
+ * NOT-NULL-no-default column to `messages`, add it here AND to every insert
+ * site in the same change.
+ */
+const REQUIRED_MESSAGE_COLUMNS = ["workspace_id", "template_id"] as const;
+
+/** Does the resolved payload assign `col`? */
+function payloadHasColumn(payload: string, col: string): boolean {
   // Matches all three field forms:
-  //   - `workspace_id: value`  (object key)
-  //   - `workspace_id =`/`row.workspace_id =`  (builder-function assignment)
-  //   - `workspace_id,` / `workspace_id }`  (ES6 shorthand property, e.g.
-  //      insert-draft-card.ts's `const workspace_id = …; insert({ workspace_id })`).
-  return /workspace_id\s*[:=]/.test(payload) ||
-    /(?:^|[{,]\s*)workspace_id\s*(?:,|\n|\}|$)/.test(payload);
+  //   - `col: value`  (object key)
+  //   - `col =`/`row.col =`  (builder-function assignment)
+  //   - `col,` / `col }`  (ES6 shorthand, e.g. insert-draft-card.ts's
+  //      `const workspace_id = …; insert({ workspace_id })`).
+  const escaped = col.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`${escaped}\\s*[:=]`).test(payload) ||
+    new RegExp(`(?:^|[{,]\\s*)${escaped}\\s*(?:,|\\n|\\}|$)`).test(payload);
+}
+
+/** Back-compat alias for the negative-control test. */
+function payloadHasWorkspaceId(payload: string): boolean {
+  return payloadHasColumn(payload, "workspace_id");
 }
 
 describe("messages INSERT write-boundary sweep — workspace_id present (mig 059)", () => {
@@ -185,10 +203,12 @@ describe("messages INSERT write-boundary sweep — workspace_id present (mig 059
       const src = readFileSync(file, "utf8");
       for (const finding of findMessagesInserts(src)) {
         totalFindings += 1;
-        if (!payloadHasWorkspaceId(finding.resolvedPayload)) {
-          violations.push(
-            `${file}: insert payload missing workspace_id → ${finding.argSource.slice(0, 80)}`,
-          );
+        for (const col of REQUIRED_MESSAGE_COLUMNS) {
+          if (!payloadHasColumn(finding.resolvedPayload, col)) {
+            violations.push(
+              `${file}: insert payload missing ${col} → ${finding.argSource.slice(0, 80)}`,
+            );
+          }
         }
       }
     }

--- a/knowledge-base/engineering/ops/post-mortems/chat-rls-workspace-id-outage-postmortem.md
+++ b/knowledge-base/engineering/ops/post-mortems/chat-rls-workspace-id-outage-postmortem.md
@@ -85,3 +85,13 @@ Sending any message in the interactive chat returned the generic bubble **"An un
 - A liveness alert on write absence (factor 2 follow-up).
 - Lower error-noise floor so real errors surface (the #4816 noise reduction, in hindsight, was the enabling diagnostic step).
 - Triage discipline: trace the user-visible symptom to its producer, not the alert's named op.
+
+## Update (2026-06-02): second un-swept NOT-NULL column — `template_id` (#4839)
+
+After PR #4831 deployed, chat **still** errored on send. The workspace_id RLS error was gone, but the insert now reached the **next** un-swept required column: `Failed to save user message: null value in column "template_id" of relation "messages" violates not-null constraint` (`dispatchSoleurGo`, 2026-06-02T21:14Z). `messages.template_id` was made NOT NULL (no default) by **migration 053** — a separate, earlier instance of the *same* un-swept-INSERT-site class as 059's workspace_id. The 059 RLS WITH CHECK fired first and masked the 053 NOT-NULL violation.
+
+**Process miss:** when fixing #4831 I added only the column named in the error (workspace_id) instead of querying `information_schema` for the **complete** set of NOT-NULL-no-default columns and sweeping them all at once.
+
+**Authoritative fix (PR #4839-fix):** queried prod `information_schema.columns` — the ONLY two NOT-NULL-no-default columns on `messages` are `workspace_id` and `template_id`. Added `template_id: "default_legacy"` (the migration-053 backfill sentinel, satisfies the `^[a-z][a-z0-9_]*$` CHECK) to all 4 interactive INSERT sites, and **generalized the grep-sweep guard test to require BOTH columns** (`REQUIRED_MESSAGE_COLUMNS`) so a third un-swept column would fail CI.
+
+**Added prevention:** when fixing a NOT-NULL/RLS insert failure, enumerate ALL required columns via `information_schema` (NOT NULL + no default) and sweep every site in one pass — a single error message names only the first violation; RLS-check-before-constraint and one-constraint-at-a-time evaluation both mask the rest.


### PR DESCRIPTION
## Summary

**Hotfix — chat still broken after #4831.** Sending a message returned "An unexpected error occurred." again. #4831 fixed `messages.workspace_id` (RLS), but the insert then reached the **next** un-swept required column: `messages.template_id` (NOT NULL, no default — migration 053). The 059 RLS WITH CHECK fired first and masked the 053 NOT-NULL violation. Sentry: `Failed to save user message: null value in column "template_id" ... violates not-null constraint` [dispatchSoleurGo] @ 21:14Z.

Queried prod `information_schema`: the ONLY NOT-NULL-no-default columns on `messages` are `workspace_id` + `template_id` — so this completes the set (no third layer).

## Changelog
### Web Platform
- Set `template_id: "default_legacy"` (the migration-053 backfill sentinel; satisfies the `^[a-z][a-z0-9_]*$` CHECK) on all 4 interactive `messages` INSERT sites.
- Generalized the write-boundary grep-sweep test to require BOTH `workspace_id` AND `template_id` (`REQUIRED_MESSAGE_COLUMNS`) — a future un-swept required column now fails CI.
- Updated the chat-RLS-outage post-mortem with the second-layer finding + the "enumerate ALL required columns via information_schema" prevention.

## User-Brand Impact

**If this lands broken:** interactive chat stays fully unusable (every send errors) — the same outage. **If it leaks:** N/A — no new data surface; `template_id` is a non-PII sentinel.

- **Brand-survival threshold:** single-user incident

## Test plan
- [x] 74 tests pass (sweep + cc-dispatcher + agent-runner); tsc clean
- [x] All 4 insert sites carry template_id; sweep guard requires both columns
- [x] information_schema confirms workspace_id + template_id are the complete required set
- [ ] ⏳ Post-deploy: a fresh send persists (Ref #4839)

Ref #4839, #4831.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
