### PR TITLE
fix(content): correct LinkedIn test publish_date to 2026-06-02 UTC (#4046)

### DIFF
--- a/knowledge-base/marketing/distribution-content/best-claude-code-plugins-2026.md
+++ b/knowledge-base/marketing/distribution-content/best-claude-code-plugins-2026.md
@@ -1,7 +1,7 @@
 ---
 title: "Best Claude Code Plugins 2026: The Extensions Worth Installing"
 type: pillar
-publish_date: 2026-06-03
+publish_date: 2026-06-02
 channels: linkedin-company
 status: scheduled
 ---


### PR DESCRIPTION
One-line correction: the test article's `publish_date` was bumped to `2026-06-03` based on a harness **local-time** notification, but `scripts/content-publisher.sh` computes `today` in **UTC** on the prod server — where it is still **2026-06-02** (GitHub authoritative `Date` header confirms). A future `publish_date` is silently skipped, so the test post would never fire.

Sets `publish_date: 2026-06-02` (the original value) so the manual `cron/content-publisher.manual-trigger` matches today. Channels still `linkedin-company` only.

Ref #4046

🤖 Generated with [Claude Code](https://claude.com/claude-code)