### PR TITLE
fix(web-platform): install jq in runner image for content publisher

### DIFF
--- a/apps/web-platform/Dockerfile
+++ b/apps/web-platform/Dockerfile
@@ -54,8 +54,15 @@ RUN npm install -g @anthropic-ai/claude-code@2.1.79
 # `sandbox.failIfUnavailable: true` set in agent-runner.ts (see #2634), the
 # agent process refuses to start instead of silently falling back to
 # unsandboxed Bash execution. Do NOT remove socat in future cleanups.
+#
+# `jq` is load-bearing for the content publisher: cron-content-publisher.ts
+# spawns scripts/content-publisher.sh (jq x5) which spawns the LinkedIn scripts
+# (linkedin-community.sh jq x8). The TR9 migration moved the publisher off the
+# GHA runner (jq preinstalled) into this image without porting the dependency,
+# so every scheduled post failed with "jq is required but not installed" and
+# routed to a per-post fallback issue (e.g. #4858). Do NOT remove jq.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates git bubblewrap socat qpdf \
+    ca-certificates git bubblewrap socat qpdf jq \
     && rm -rf /var/lib/apt/lists/*
 
 # GitHub CLI (needed by cron-follow-through-monitor gh label/issue commands


### PR DESCRIPTION
## Root cause

The #4046 Phase-6 test post (re-publishing *Best Claude Code Plugins 2026* to the LinkedIn Company Page after the token rotation) failed — but **not** on the token. The Inngest `cron-content-publisher` spawns `scripts/content-publisher.sh`, which spawns `linkedin-community.sh`; both require `jq`. The **TR9 migration** moved the publisher off the GitHub Actions runner (where `jq` is preinstalled) into the Next.js container, but never added `jq` to the image.

Result: every scheduled post failed with `Error: jq is required but not installed` and routed to a per-post fallback issue — latest **#4858** (for this exact article). This is **not LinkedIn-specific**: it breaks X / Bluesky / Discord posting via the daily content cron too.

## Fix

Add `jq` to the runner `apt-get install` line in `apps/web-platform/Dockerfile`. `curl` was already present; `jq` was the only missing binary (verified: `linkedin-community.sh` = jq×8/curl×2/sed/grep, `content-publisher.sh` = jq×5/curl — `sed`/`grep` are base packages).

## Verification plan
- Merge → `web-platform-release.yml` builds + deploys the image with `jq`.
- Re-fire `cron/content-publisher.manual-trigger`; expect a `ci: update content distribution status` status-flip PR (the article flips `scheduled→published`) and the post live on `linkedin.com/company/jikigai/posts/`.

Ref #4046
Closes #4858

🤖 Generated with [Claude Code](https://claude.com/claude-code)