### PR TITLE
fix(community): add w_organization_social to generate-token OAuth scope

### DIFF
--- a/plugins/soleur/skills/community/scripts/linkedin-setup.sh
+++ b/plugins/soleur/skills/community/scripts/linkedin-setup.sh
@@ -172,7 +172,13 @@ cmd_generate_token() {
   fi
 
   local redirect_uri="${LINKEDIN_REDIRECT_URI:-$LINKEDIN_DEFAULT_REDIRECT_URI}"
-  local scopes="openid%20profile%20w_member_social"
+  # w_organization_social is REQUIRED to post as a Company Page (author
+  # urn:li:organization:<id>). Without it the /rest/posts call fails with
+  # HTTP 400 "Organization Or Events permissions must be used when using
+  # organization as author" (#4046 — surfaced when a member-only token was
+  # rotated in and the Phase-6 test post hit this). The app must have the
+  # Community Management API product approved for LinkedIn to grant it.
+  local scopes="openid%20profile%20w_member_social%20w_organization_social"
   local auth_url="${LINKEDIN_OAUTH}/authorization?response_type=code&client_id=${LINKEDIN_CLIENT_ID}&redirect_uri=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${redirect_uri}', safe=''))" 2>/dev/null || echo "${redirect_uri}")&scope=${scopes}"
 
   echo "=== LinkedIn OAuth Token Generation ===" >&2


### PR DESCRIPTION
## Changelog
Fixed: `linkedin-setup.sh generate-token` now requests `w_organization_social`, so tokens minted via the documented flow can post to the LinkedIn Company Page.

## Why
The #4046 Phase-6 test post (after the org token rotation) reached LinkedIn but failed:
```
HTTP 400 /rest/posts: Organization Or Events permissions must be used when using organization as author
```
Root cause: `generate-token` requested only `openid profile w_member_social` (line 175), so any token it produced was **member-only** and could not author posts as `urn:li:organization:<id>` — regardless of the Community Management API approval.

## Fix
Add `w_organization_social` to the authorization-URL scope. The app must have the Community Management API product approved for LinkedIn to grant it (229658411 is approved). A new token must be minted with this scope and rotated in.

Ref #4046

🤖 Generated with [Claude Code](https://claude.com/claude-code)