### PR TITLE
fix(chat): wrap Concierge status label instead of overflowing card

### DIFF
--- a/apps/web-platform/components/chat/message-bubble.tsx
+++ b/apps/web-platform/components/chat/message-bubble.tsx
@@ -24,7 +24,7 @@ export function ThinkingDots() {
 export function ToolStatusChip({ label }: { label: string }) {
   return (
     <div className="flex items-center gap-2 py-0.5" data-testid="tool-status-chip">
-      <span className="whitespace-nowrap text-sm text-soleur-text-secondary">{label}</span>
+      <span className="min-w-0 text-sm text-soleur-text-secondary [overflow-wrap:anywhere]">{label}</span>
     </div>
   );
 }

--- a/apps/web-platform/components/chat/message-bubble.tsx
+++ b/apps/web-platform/components/chat/message-bubble.tsx
@@ -162,6 +162,7 @@ export const MessageBubble = memo(function MessageBubble({
         )}
 
         <div
+          data-testid="message-bubble-card"
           className={`relative min-w-0 rounded-xl px-4 py-3 text-sm leading-relaxed ${
             isUser
               ? "bg-soleur-bg-surface-2 text-soleur-text-primary"

--- a/apps/web-platform/e2e/cc-soleur-go-bubbles.e2e.ts
+++ b/apps/web-platform/e2e/cc-soleur-go-bubbles.e2e.ts
@@ -282,3 +282,104 @@ test.describe("cc-soleur-go bubbles: tool-use-chip unregistered-mcp-fqn", () => 
     assertNoPageErrors(injector);
   });
 });
+
+// ---------------------------------------------------------------------------
+// 3.5 Concierge status-box overflow — inverse of #4852 (#4855-class)
+//
+// #4852 added bare `whitespace-nowrap` to the `ToolStatusChip` label
+// (message-bubble.tsx:27) to stop premature wrapping of a short status label.
+// With the bubble `max-w` cap + `min-w-0` ancestor chain, that left a label
+// *wider* than the cap no way to wrap and no way to grow → it overflowed the
+// Concierge card's right border. The fix swaps `nowrap` for the wrap-capable
+// `[overflow-wrap:anywhere]` idiom (already on the streaming body, :269).
+//
+// jsdom returns 0 for layout values (constitution line 312), so the no-overflow
+// proof MUST live in Playwright. Overflow assertion mirrors the
+// `nav-states-shell.e2e.ts:259,277` precedent: `scrollWidth - clientWidth`
+// with an empty-band guard (assert the label text is populated) so a
+// collapsed/empty card cannot vacuously pass.
+//
+// Both render contexts (`full` chat-surface + narrow `sidebar`) are exercised:
+// the sidebar (`kb-chat-content.tsx`) is narrower so overflow is MORE likely.
+// The deterministic harness drives the same `tool_use` bubble both times; the
+// long-label assertion is the regression guard, the short-label single-line
+// assertion proves #4852 is not re-broken.
+// ---------------------------------------------------------------------------
+
+const LONG_STATUS_LABEL =
+  "Routing to the right experts and coordinating across every domain leader to assemble the most accurate, comprehensive response possible for this request";
+const SHORT_STATUS_LABEL = "Working";
+
+/** Measure the Concierge card (the bordered `rounded-xl` ancestor of the
+ *  status chip) for horizontal overflow. Returns the layout band plus the
+ *  label text so the caller can assert the band is non-empty (empty-band
+ *  guard — an unpopulated card would vacuously satisfy scroll<=client). */
+async function measureCardOverflow(page: Page) {
+  const chip = page.locator('[data-testid="tool-status-chip"]').first();
+  await expect(chip).toBeVisible();
+  return chip.evaluate((el) => {
+    const card = el.closest(".rounded-xl") as HTMLElement | null;
+    if (!card) throw new Error("status chip has no .rounded-xl card ancestor");
+    return {
+      overflow: card.scrollWidth - card.clientWidth,
+      labelText: el.textContent ?? "",
+    };
+  });
+}
+
+test.describe("cc-soleur-go bubbles: Concierge status-box overflow", () => {
+  test("long status label wraps inside the card — no horizontal overflow", async ({
+    page,
+  }) => {
+    const injector = await bootChat(page);
+
+    injector.send({
+      type: "tool_use",
+      leaderId: "cc_router",
+      label: LONG_STATUS_LABEL,
+    } satisfies StreamEvent);
+
+    const { overflow, labelText } = await measureCardOverflow(page);
+
+    // Empty-band guard (nav-states-shell.e2e.ts:19 precedent): the card must
+    // actually contain the long label, else scroll<=client passes vacuously.
+    expect(labelText).toContain("Routing to the right experts");
+    // 1px tolerance for sub-pixel rounding; a real overflow is tens of px.
+    expect(overflow).toBeLessThanOrEqual(1);
+
+    assertNoPageErrors(injector);
+  });
+
+  test("short status label stays single-line (does not re-break #4852)", async ({
+    page,
+  }) => {
+    const injector = await bootChat(page);
+
+    injector.send({
+      type: "tool_use",
+      leaderId: "cc_router",
+      label: SHORT_STATUS_LABEL,
+    } satisfies StreamEvent);
+
+    const chip = page.locator('[data-testid="tool-status-chip"]').first();
+    await expect(chip).toBeVisible();
+
+    const lineInfo = await chip.locator("span").first().evaluate((el) => {
+      const style = getComputedStyle(el);
+      const lineHeight = parseFloat(style.lineHeight);
+      return {
+        height: (el as HTMLElement).offsetHeight,
+        lineHeight: Number.isFinite(lineHeight) ? lineHeight : null,
+      };
+    });
+
+    // A short label with available width must occupy a single line. If
+    // `nowrap`-removal had reintroduced #4852's premature wrap, the span would
+    // span two line-boxes (height ≈ 2× lineHeight).
+    if (lineInfo.lineHeight) {
+      expect(lineInfo.height).toBeLessThan(lineInfo.lineHeight * 1.8);
+    }
+
+    assertNoPageErrors(injector);
+  });
+});

--- a/apps/web-platform/e2e/cc-soleur-go-bubbles.e2e.ts
+++ b/apps/web-platform/e2e/cc-soleur-go-bubbles.e2e.ts
@@ -287,123 +287,141 @@ test.describe("cc-soleur-go bubbles: tool-use-chip unregistered-mcp-fqn", () => 
 // 3.5 Concierge status-box overflow — inverse of #4852 (#4855-class)
 //
 // #4852 added bare `whitespace-nowrap` to the `ToolStatusChip` label
-// (message-bubble.tsx:27) to stop premature wrapping of a short status label.
-// With the bubble `max-w` cap + `min-w-0` ancestor chain, that left a label
-// *wider* than the cap no way to wrap and no way to grow → it overflowed the
-// Concierge card's right border. The fix swaps `nowrap` for the wrap-capable
-// `[overflow-wrap:anywhere]` idiom (already on the streaming body, :269).
+// (message-bubble.tsx:27) to stop premature wrapping of the routing-chip status
+// label. With the bubble `max-w` cap + `min-w-0` ancestor chain, that left a
+// label *wider* than the available card width no way to wrap and no way to grow
+// → it overflowed the Concierge card's right border. The fix swaps `nowrap`
+// for the wrap-capable `[overflow-wrap:anywhere]` idiom (already on the
+// streaming body, :269).
+//
+// This drives the REAL routing chip (`chat-surface.tsx:737-755` `isClassifying`
+// → `MessageBubble role=assistant messageState=tool_use toolLabel="Routing to
+// the right experts..."`), NOT a synthetic `tool_use` stream event (which
+// renders the lifecycle `data-tool-chip-id` chip, a DIFFERENT element). The
+// chip appears when there is a user message and no assistant reply yet, so we
+// type + send and inject no assistant frame.
 //
 // jsdom returns 0 for layout values (constitution line 312), so the no-overflow
-// proof MUST live in Playwright. Overflow assertion mirrors the
-// `nav-states-shell.e2e.ts:259,277` precedent: `scrollWidth - clientWidth`
-// with an empty-band guard (assert the label text is populated) so a
-// collapsed/empty card cannot vacuously pass.
+// proof MUST live in Playwright. Both render variants ("full" chat-surface and
+// the narrow "sidebar" `kb-chat-content.tsx`) share this SAME render path; the
+// only difference is available container width. We exercise the SAME chip at a
+// wide desktop viewport (single-line non-regression for #4852) AND a narrow
+// viewport that forces the fixed label to wrap.
 //
-// Variant coverage note: both render variants ("full" chat-surface and the
-// narrow "sidebar" `kb-chat-content.tsx`) share the SAME `MessageBubble` →
-// `ToolStatusChip` render path; the only difference between them is the
-// available container width (the sidebar is narrower, so overflow is more
-// likely). Standing up the kb-chat sidebar harness here would duplicate the
-// mock surface for zero additional component coverage, so instead we exercise
-// the long-label overflow at TWO viewport widths — the default desktop width
-// AND a deliberately narrow (sidebar-class, 420px) viewport that drives the
-// bubble's `max-w-[90%]` cap down to the overflow-prone band the sidebar
-// represents. The long-label assertion is the regression guard; the
-// short-label single-line assertion proves #4852 is not re-broken.
+// Non-vacuity (the empty-band concern from nav-states-shell.e2e.ts:19): a bare
+// `scrollWidth<=clientWidth` assertion passes vacuously if the label never
+// needed to wrap. So the narrow case asserts BOTH (a) the card does not
+// overflow AND (b) the label actually wrapped onto ≥2 line-boxes — wrapping is
+// proof the width was constrained, i.e. exactly the condition under which the
+// pre-fix `nowrap` overflowed. (a)+(b) together fail against the pre-fix code
+// (nowrap → 1 line → overflow) and pass against the fix (wrap → no overflow).
 // ---------------------------------------------------------------------------
 
-const LONG_STATUS_LABEL =
-  "Routing to the right experts and coordinating across every domain leader to assemble the most accurate, comprehensive response possible for this request";
-const SHORT_STATUS_LABEL = "Working";
+/** Drive the real `isClassifying` routing chip. The chip renders when there is
+ *  a user message and no assistant reply yet (chat-surface.tsx:456-462), which
+ *  depends ONLY on reducer state — NOT on the WS "connected" status (the input
+ *  is disabled in this offline harness, but the chip is not). So we seed the
+ *  mount-time history fetch (`/api/conversations/:id/messages`,
+ *  ws-client.ts:1041) with a single USER message and inject no assistant frame;
+ *  `workflow.state` stays "idle" (only a `workflow_started` event activates it),
+ *  so `isClassifying` is true and the fixed "Routing to the right experts..."
+ *  ToolStatusChip renders. */
+async function triggerRoutingChip(page: Page): Promise<WsInjector> {
+  await page.route("**/api/conversations/*/messages", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        messages: [
+          {
+            id: "user-msg-overflow-1",
+            role: "user",
+            content: "Fix the reported issue end to end",
+            leader_id: null,
+          },
+        ],
+        totalCostUsd: 0,
+      }),
+    }),
+  );
+  const injector = await bootChat(page);
+  await expect(page.locator('[data-testid="routing-chip"]')).toBeVisible();
+  return injector;
+}
 
-/** Measure the Concierge bubble card (anchored by the stable
- *  `data-testid="message-bubble-card"` hook, NOT a generic Tailwind utility
- *  class) for horizontal overflow. Returns the layout band plus the label text
- *  so the caller can assert the band is non-empty (empty-band guard — an
- *  unpopulated card would vacuously satisfy scroll<=client). */
-async function measureCardOverflow(page: Page) {
-  const chip = page.locator('[data-testid="tool-status-chip"]').first();
-  await expect(chip).toBeVisible();
-  return chip.evaluate((el) => {
-    const card = el.closest('[data-testid="message-bubble-card"]') as
-      | HTMLElement
-      | null;
-    if (!card) throw new Error("status chip has no message-bubble-card ancestor");
+/** Measure the routing chip's bubble card (anchored by the stable
+ *  `data-testid="message-bubble-card"` hook, NOT a generic Tailwind class) for
+ *  horizontal overflow, plus the label span's line-box height vs line-height so
+ *  the caller can prove the label wrapped (non-vacuity guard). */
+async function measureRoutingChip(page: Page) {
+  const card = page
+    .locator('[data-testid="routing-chip"] [data-testid="message-bubble-card"]')
+    .first();
+  await expect(card).toBeVisible();
+  return card.evaluate((cardEl) => {
+    const label = cardEl.querySelector(
+      '[data-testid="tool-status-chip"] span',
+    ) as HTMLElement | null;
+    if (!label) throw new Error("routing chip has no tool-status-chip label");
+    const lineHeight = parseFloat(getComputedStyle(label).lineHeight);
     return {
-      overflow: card.scrollWidth - card.clientWidth,
-      labelText: el.textContent ?? "",
+      overflow: cardEl.scrollWidth - cardEl.clientWidth,
+      labelText: label.textContent ?? "",
+      labelHeight: label.offsetHeight,
+      lineHeight,
     };
   });
 }
 
 test.describe("cc-soleur-go bubbles: Concierge status-box overflow", () => {
-  // Default desktop width + a narrow sidebar-class width. The narrow case is
-  // the proxy for the `kb-chat-content.tsx` sidebar variant: same render path,
-  // smaller container → the overflow-prone band where #4852's bare nowrap
-  // spilled past the card border.
+  // Harness-fidelity note (#4855 QA): in this offline authenticated harness the
+  // dashboard chat column renders at ~265px wide regardless of the browser
+  // viewport, so the routing chip card only ever has ~160px of content width —
+  // less than the fixed label's ~210px single-line width. The label therefore
+  // ALWAYS wraps here, and the "stays single-line when horizontal space is
+  // available" #4852-non-regression cannot be exhibited at this layer (the
+  // production chat column is far wider). That non-regression is instead pinned
+  // structurally by the vitest className assertion in
+  // `test/message-bubble-tool-status-chip.test.tsx`: the label carries
+  // `[overflow-wrap:anywhere]` (which, by CSS definition, introduces a soft-wrap
+  // opportunity ONLY when the content would otherwise overflow — it never forces
+  // a break when the line fits) and no longer carries `whitespace-nowrap`. What
+  // this Playwright layer CAN and MUST prove is the actual reported bug: the
+  // label NEVER spills past the card's right border. We assert that at the
+  // default viewport AND a deliberately narrow viewport, with a non-vacuity
+  // guard that the label genuinely wrapped (so a collapsed/empty card cannot
+  // pass trivially).
   for (const variant of [
-    { name: "full (default viewport)", width: 0 },
-    { name: "narrow (sidebar-class 420px viewport)", width: 420 },
+    { name: "default viewport", width: 0 },
+    { name: "narrow 300px viewport", width: 300 },
   ] as const) {
-    test(`long status label wraps inside the card — no horizontal overflow — ${variant.name}`, async ({
+    test(`routing chip label wraps inside the card — no horizontal overflow — ${variant.name}`, async ({
       page,
     }) => {
       if (variant.width > 0) {
         await page.setViewportSize({ width: variant.width, height: 900 });
       }
-      const injector = await bootChat(page);
+      const injector = await triggerRoutingChip(page);
 
-      injector.send({
-        type: "tool_use",
-        leaderId: "cc_router",
-        label: LONG_STATUS_LABEL,
-      } satisfies StreamEvent);
-
-      const { overflow, labelText } = await measureCardOverflow(page);
+      const m = await measureRoutingChip(page);
 
       // Empty-band guard (nav-states-shell.e2e.ts:19 precedent): the card must
-      // actually contain the long label, else scroll<=client passes vacuously.
-      expect(labelText).toContain("Routing to the right experts");
-      // 1px tolerance for sub-pixel rounding; a real overflow is tens of px.
-      expect(overflow).toBeLessThanOrEqual(1);
+      // actually contain the routing label, else scroll<=client is vacuous.
+      expect(m.labelText).toContain("Routing to the right experts");
+      // `text-sm` sets an explicit px line-height; assert finite (don't skip on
+      // NaN) so a future line-height regression to `normal` cannot make the
+      // wrap check below pass vacuously.
+      expect(Number.isFinite(m.lineHeight)).toBe(true);
+      // Non-vacuity: the constrained card forced the label to wrap onto ≥2
+      // line-boxes. This is the exact condition under which the pre-fix `nowrap`
+      // spilled past the border instead of wrapping — so the no-overflow
+      // assertion below is meaningful, not trivially satisfied by a short line.
+      expect(m.labelHeight).toBeGreaterThan(m.lineHeight * 1.5);
+      // The fix: the wrapped label stays inside the card — no horizontal
+      // overflow (1px sub-pixel tolerance; a real overflow is tens of px).
+      expect(m.overflow).toBeLessThanOrEqual(1);
 
       assertNoPageErrors(injector);
     });
   }
-
-  test("short status label stays single-line (does not re-break #4852)", async ({
-    page,
-  }) => {
-    const injector = await bootChat(page);
-
-    injector.send({
-      type: "tool_use",
-      leaderId: "cc_router",
-      label: SHORT_STATUS_LABEL,
-    } satisfies StreamEvent);
-
-    const chip = page.locator('[data-testid="tool-status-chip"]').first();
-    await expect(chip).toBeVisible();
-
-    const lineInfo = await chip.locator("span").first().evaluate((el) => {
-      const style = getComputedStyle(el);
-      const lineHeight = parseFloat(style.lineHeight);
-      return {
-        height: (el as HTMLElement).offsetHeight,
-        lineHeight,
-      };
-    });
-
-    // `text-sm` sets an explicit px line-height on the span, so getComputedStyle
-    // returns a finite value here. Assert it (rather than skipping on NaN) so a
-    // future line-height regression to `normal` cannot silently turn this
-    // #4852-non-regression guard into a vacuous pass.
-    expect(Number.isFinite(lineInfo.lineHeight)).toBe(true);
-    // A short label with available width must occupy a single line. If
-    // `nowrap`-removal had reintroduced #4852's premature wrap, the span would
-    // span two line-boxes (height ≈ 2× lineHeight).
-    expect(lineInfo.height).toBeLessThan(lineInfo.lineHeight * 1.8);
-
-    assertNoPageErrors(injector);
-  });
 });

--- a/apps/web-platform/e2e/cc-soleur-go-bubbles.e2e.ts
+++ b/apps/web-platform/e2e/cc-soleur-go-bubbles.e2e.ts
@@ -299,27 +299,36 @@ test.describe("cc-soleur-go bubbles: tool-use-chip unregistered-mcp-fqn", () => 
 // with an empty-band guard (assert the label text is populated) so a
 // collapsed/empty card cannot vacuously pass.
 //
-// Both render contexts (`full` chat-surface + narrow `sidebar`) are exercised:
-// the sidebar (`kb-chat-content.tsx`) is narrower so overflow is MORE likely.
-// The deterministic harness drives the same `tool_use` bubble both times; the
-// long-label assertion is the regression guard, the short-label single-line
-// assertion proves #4852 is not re-broken.
+// Variant coverage note: both render variants ("full" chat-surface and the
+// narrow "sidebar" `kb-chat-content.tsx`) share the SAME `MessageBubble` →
+// `ToolStatusChip` render path; the only difference between them is the
+// available container width (the sidebar is narrower, so overflow is more
+// likely). Standing up the kb-chat sidebar harness here would duplicate the
+// mock surface for zero additional component coverage, so instead we exercise
+// the long-label overflow at TWO viewport widths — the default desktop width
+// AND a deliberately narrow (sidebar-class, 420px) viewport that drives the
+// bubble's `max-w-[90%]` cap down to the overflow-prone band the sidebar
+// represents. The long-label assertion is the regression guard; the
+// short-label single-line assertion proves #4852 is not re-broken.
 // ---------------------------------------------------------------------------
 
 const LONG_STATUS_LABEL =
   "Routing to the right experts and coordinating across every domain leader to assemble the most accurate, comprehensive response possible for this request";
 const SHORT_STATUS_LABEL = "Working";
 
-/** Measure the Concierge card (the bordered `rounded-xl` ancestor of the
- *  status chip) for horizontal overflow. Returns the layout band plus the
- *  label text so the caller can assert the band is non-empty (empty-band
- *  guard — an unpopulated card would vacuously satisfy scroll<=client). */
+/** Measure the Concierge bubble card (anchored by the stable
+ *  `data-testid="message-bubble-card"` hook, NOT a generic Tailwind utility
+ *  class) for horizontal overflow. Returns the layout band plus the label text
+ *  so the caller can assert the band is non-empty (empty-band guard — an
+ *  unpopulated card would vacuously satisfy scroll<=client). */
 async function measureCardOverflow(page: Page) {
   const chip = page.locator('[data-testid="tool-status-chip"]').first();
   await expect(chip).toBeVisible();
   return chip.evaluate((el) => {
-    const card = el.closest(".rounded-xl") as HTMLElement | null;
-    if (!card) throw new Error("status chip has no .rounded-xl card ancestor");
+    const card = el.closest('[data-testid="message-bubble-card"]') as
+      | HTMLElement
+      | null;
+    if (!card) throw new Error("status chip has no message-bubble-card ancestor");
     return {
       overflow: card.scrollWidth - card.clientWidth,
       labelText: el.textContent ?? "",
@@ -328,27 +337,39 @@ async function measureCardOverflow(page: Page) {
 }
 
 test.describe("cc-soleur-go bubbles: Concierge status-box overflow", () => {
-  test("long status label wraps inside the card — no horizontal overflow", async ({
-    page,
-  }) => {
-    const injector = await bootChat(page);
+  // Default desktop width + a narrow sidebar-class width. The narrow case is
+  // the proxy for the `kb-chat-content.tsx` sidebar variant: same render path,
+  // smaller container → the overflow-prone band where #4852's bare nowrap
+  // spilled past the card border.
+  for (const variant of [
+    { name: "full (default viewport)", width: 0 },
+    { name: "narrow (sidebar-class 420px viewport)", width: 420 },
+  ] as const) {
+    test(`long status label wraps inside the card — no horizontal overflow — ${variant.name}`, async ({
+      page,
+    }) => {
+      if (variant.width > 0) {
+        await page.setViewportSize({ width: variant.width, height: 900 });
+      }
+      const injector = await bootChat(page);
 
-    injector.send({
-      type: "tool_use",
-      leaderId: "cc_router",
-      label: LONG_STATUS_LABEL,
-    } satisfies StreamEvent);
+      injector.send({
+        type: "tool_use",
+        leaderId: "cc_router",
+        label: LONG_STATUS_LABEL,
+      } satisfies StreamEvent);
 
-    const { overflow, labelText } = await measureCardOverflow(page);
+      const { overflow, labelText } = await measureCardOverflow(page);
 
-    // Empty-band guard (nav-states-shell.e2e.ts:19 precedent): the card must
-    // actually contain the long label, else scroll<=client passes vacuously.
-    expect(labelText).toContain("Routing to the right experts");
-    // 1px tolerance for sub-pixel rounding; a real overflow is tens of px.
-    expect(overflow).toBeLessThanOrEqual(1);
+      // Empty-band guard (nav-states-shell.e2e.ts:19 precedent): the card must
+      // actually contain the long label, else scroll<=client passes vacuously.
+      expect(labelText).toContain("Routing to the right experts");
+      // 1px tolerance for sub-pixel rounding; a real overflow is tens of px.
+      expect(overflow).toBeLessThanOrEqual(1);
 
-    assertNoPageErrors(injector);
-  });
+      assertNoPageErrors(injector);
+    });
+  }
 
   test("short status label stays single-line (does not re-break #4852)", async ({
     page,
@@ -369,16 +390,19 @@ test.describe("cc-soleur-go bubbles: Concierge status-box overflow", () => {
       const lineHeight = parseFloat(style.lineHeight);
       return {
         height: (el as HTMLElement).offsetHeight,
-        lineHeight: Number.isFinite(lineHeight) ? lineHeight : null,
+        lineHeight,
       };
     });
 
+    // `text-sm` sets an explicit px line-height on the span, so getComputedStyle
+    // returns a finite value here. Assert it (rather than skipping on NaN) so a
+    // future line-height regression to `normal` cannot silently turn this
+    // #4852-non-regression guard into a vacuous pass.
+    expect(Number.isFinite(lineInfo.lineHeight)).toBe(true);
     // A short label with available width must occupy a single line. If
     // `nowrap`-removal had reintroduced #4852's premature wrap, the span would
     // span two line-boxes (height ≈ 2× lineHeight).
-    if (lineInfo.lineHeight) {
-      expect(lineInfo.height).toBeLessThan(lineInfo.lineHeight * 1.8);
-    }
+    expect(lineInfo.height).toBeLessThan(lineInfo.lineHeight * 1.8);
 
     assertNoPageErrors(injector);
   });

--- a/apps/web-platform/test/message-bubble-tool-status-chip.test.tsx
+++ b/apps/web-platform/test/message-bubble-tool-status-chip.test.tsx
@@ -64,11 +64,21 @@ describe("MessageBubble tool_use ToolStatusChip (no redundant dot)", () => {
     expect(container.querySelector(".message-bubble-active")).not.toBeNull();
   });
 
-  // Regression (#4852): the short status label ("Routing to the right
-  // experts…") wrapped onto two lines even when horizontal space was
-  // available. The label span must be `whitespace-nowrap` so the bubble
-  // grows to its natural single-line width instead of wrapping.
-  test("label span is whitespace-nowrap (no unnecessary wrap of short status text)", () => {
+  // Regression (#4852 + inverse fix #4855-class): #4852 added bare
+  // `whitespace-nowrap` to stop a short status label ("Routing to the right
+  // experts…") wrapping prematurely. But with the bubble's `max-w` cap +
+  // `min-w-0` ancestor chain, `nowrap` left no degree of freedom for a label
+  // *wider* than the cap — it overflowed the card's right border. The fix
+  // swaps `nowrap` for the wrap-capable `[overflow-wrap:anywhere]` idiom
+  // already used on the streaming body (message-bubble.tsx:269): short labels
+  // still stay single-line (the `min-w-0` chain, not nowrap, is what prevented
+  // #4852's premature wrap), long labels wrap at the cap instead of spilling.
+  //
+  // jsdom returns 0 for layout values (constitution line 312), so the actual
+  // no-overflow proof lives in Playwright (cc-soleur-go-bubbles.e2e.ts). Here
+  // we only assert the className mechanism: the wrap-capable class is present
+  // and the overflow-forcing `whitespace-nowrap` is gone.
+  test("label span carries the wrap-capable mechanism (not overflow-forcing nowrap)", () => {
     const { getByTestId } = render(
       <MessageBubble
         role="assistant"
@@ -79,6 +89,7 @@ describe("MessageBubble tool_use ToolStatusChip (no redundant dot)", () => {
     );
     const chip = getByTestId("tool-status-chip");
     const labelSpan = chip.children[0] as HTMLElement;
-    expect(labelSpan.className).toContain("whitespace-nowrap");
+    expect(labelSpan.className).toContain("[overflow-wrap:anywhere]");
+    expect(labelSpan.className).not.toContain("whitespace-nowrap");
   });
 });

--- a/knowledge-base/project/learnings/test-failures/2026-06-03-cc-soleur-go-routing-chip-e2e-element-and-harness-width-cap.md
+++ b/knowledge-base/project/learnings/test-failures/2026-06-03-cc-soleur-go-routing-chip-e2e-element-and-harness-width-cap.md
@@ -1,0 +1,144 @@
+---
+title: "cc-soleur-go ToolStatusChip e2e: drive the real routing chip, and the harness caps the chat column at ~265px"
+date: 2026-06-03
+category: test-failures
+module: apps/web-platform/components/chat
+tags: [playwright, e2e, cc-soleur-go, message-bubble, tool-status-chip, harness-fidelity, layout]
+related_pr: 4866
+related_issues: [4852]
+---
+
+# Learning: the Concierge ToolStatusChip is NOT rendered by a `tool_use` stream event, and the offline e2e harness can't show a wide chat column
+
+## Problem
+
+Fixing the Concierge status-box overflow (`ToolStatusChip` label "Routing to the
+right experts..." spilling past the card's right border — the inverse of #4852's
+bare `whitespace-nowrap`). The CSS fix (`whitespace-nowrap` →
+`min-w-0 [overflow-wrap:anywhere]`, message-bubble.tsx:27) was trivial and
+vitest-green. The Playwright e2e proof is where the time went — two wrong
+premises, each caught only by actually running the test.
+
+## Root causes (two distinct e2e premises that were wrong)
+
+### 1. A `tool_use` StreamEvent renders the lifecycle chip, NOT the ToolStatusChip
+
+In `e2e/cc-soleur-go-bubbles.e2e.ts`, the first test did:
+
+```ts
+injector.send({ type: "tool_use", leaderId: "cc_router", label: LONG_LABEL });
+const chip = page.locator('[data-testid="tool-status-chip"]'); // never appears
+```
+
+A `tool_use` stream event creates a **lifecycle tool chip** (`[data-tool-chip-id^="cc_router-…"]`,
+the existing tests assert on that), which is a DIFFERENT element from
+`ToolStatusChip` (`data-testid="tool-status-chip"`). The actually-overflowing
+`ToolStatusChip` renders only via:
+
+- the `isClassifying` **routing chip** at `chat-surface.tsx:737-755`
+  (`MessageBubble role=assistant messageState="tool_use" toolLabel="Routing to
+  the right experts..."`, wrapper `data-testid="routing-chip"`, FIXED label), or
+- a general assistant message in `messageState="tool_use"` with an arbitrary
+  `toolLabel`.
+
+`isClassifying` (`chat-surface.tsx:456-462`) = `hasUserMessage &&
+!hasAssistantMessage && routeSource === null && workflow.state === "idle" &&
+!historyLoading && resumedFrom === null`.
+
+### 2. The input is disabled offline; seed history instead
+
+Driving the chip via `getByPlaceholder(...)` + "Send message" failed: the
+ChatInput is `disabled={status !== "connected"}` and the offline mock-WS harness
+never reports `status === "connected"` (textbox renders "Reconnecting...").
+**But the routing chip does NOT depend on connection status** — only on reducer
+state. The deterministic trigger is to seed the mount-time history fetch
+(`/api/conversations/:id/messages`, ws-client.ts:1041) with a single USER
+message:
+
+```ts
+await page.route("**/api/conversations/*/messages", (route) =>
+  route.fulfill({ status: 200, contentType: "application/json",
+    body: JSON.stringify({ messages: [{ id: "u1", role: "user",
+      content: "…", leader_id: null }], totalCostUsd: 0 }) }));
+// then bootChat(page) → isClassifying fires on mount → routing chip renders.
+```
+
+`workflow.state` stays `"idle"` (only a `workflow_started` event activates it —
+the mock conversation's `active_workflow: "cc-router"` is NOT hydrated into it),
+so `isClassifying` is true.
+
+### 3. The harness caps the chat column at ~265px (behavioral single-line is unprovable)
+
+Diagnostics at a 1280px viewport: `rowParentClientWidth=265`, `rowClientWidth=212`
+(`max-w-[90%]`), `cardClientWidth=168`, label single-line width ~210px. The
+dashboard chat column renders at ~265px **regardless of browser viewport**, so
+the routing chip card never gets the ~210px it needs to show the fixed label on
+one line — it ALWAYS wraps here. The #4852 "single-line when horizontal space is
+available" non-regression therefore **cannot be exhibited at the Playwright
+layer** (production columns are far wider). This is the same class as
+constitution line 312 (jsdom returns 0 for layout): some properties are
+structurally unrenderable in the harness and must be pinned elsewhere.
+
+`w-fit` on the card (plan Option B) did NOT help — the binding constraint is the
+265px row, not the card's intrinsic sizing — so it was reverted; clean Option A
+(label `[overflow-wrap:anywhere]`) is the whole fix.
+
+## Solution
+
+- Drive the **real** routing chip via seeded history (not a synthetic event, not
+  the disabled input). Anchor measurement on `data-testid="message-bubble-card"`
+  (added to the card), not a generic `.rounded-xl` utility class.
+- Assert the provable invariant (**no horizontal overflow**) at default + narrow
+  viewports, with a non-vacuity guard that the label **actually wrapped** (≥2
+  line-boxes) — the exact state pre-fix `nowrap` spilled in. RED-verified: both
+  fail against `nowrap`, pass against the fix.
+- Pin the "single-line when space available" #4852 non-regression **structurally**
+  via the vitest className assertion (`[overflow-wrap:anywhere]` present,
+  `whitespace-nowrap` absent) — `overflow-wrap: anywhere` introduces a soft-wrap
+  opportunity ONLY on overflow by CSS definition, so it cannot force a premature
+  break when the line fits.
+
+## Key Insight
+
+For cc-soleur-go bubble e2e: **match the StreamEvent/state to the exact element
+you're asserting on** — `tool_use` events → lifecycle `data-tool-chip-id` chips;
+the `ToolStatusChip` needs the `isClassifying` routing-chip state (seed one user
+message in the history mock, no WS "connected" needed). And know the harness's
+structural limits: the offline dashboard chat column is ~265px regardless of
+viewport, so width-dependent *behavioral* assertions belong in vitest className
+checks, not Playwright. A green CSS-className unit test does not prove the layout;
+only running the real component in real Chromium does — and the QA phase, not the
+review phase, is what caught the wrong-element test.
+
+## Session Errors
+
+1. **e2e test asserted on `data-testid="tool-status-chip"` but injected a
+   `tool_use` event** (renders the lifecycle `data-tool-chip-id` chip instead) —
+   element never appeared; 3 tests failed at `toBeVisible`. Recovery: traced the
+   real render path (`isClassifying` routing chip) and rewrote the test.
+   **Prevention:** when writing a bubble e2e, grep the component for the
+   `data-testid`/`data-*` you assert on and confirm which StreamEvent/state path
+   actually renders it before injecting events.
+2. **Drove the chip via the chat input** — failed because ChatInput is disabled
+   (`status !== "connected"`) in the offline harness. Recovery: seeded the
+   history fetch with a user message. **Prevention:** the offline mock-WS harness
+   never reaches "connected"; reducer-state-only UI (chips, bubbles) must be
+   driven by injected frames or seeded history, never by input interaction.
+3. **"single-line at desktop" assertion failed** — harness caps the chat column
+   at ~265px regardless of viewport. Recovery: dropped the unprovable behavioral
+   assertion, pinned the non-regression via vitest className. **Prevention:**
+   before asserting a width-dependent behavior in this harness, measure the
+   actual container width — it does not track the browser viewport.
+4. **tsc false error in `.next/types/app/(dashboard)/layout.ts`** (unrelated
+   `PaymentWarningBanner`) after the Playwright dev build regenerated `.next`.
+   Recovery: `rm -rf .next/types && tsc --noEmit` → clean. **Prevention:** a
+   stale/regenerated `.next/types` can introduce generated-type errors unrelated
+   to the diff; rebuild `.next/types` before treating a Next.js tsc error in a
+   `.next/types/**` path as real.
+5. **(forwarded from session-state.md)** plan Write blocked by bare-root guard
+   (re-wrote to worktree path); Task tool unavailable in planning env (inline
+   fan-out). Already recovered in the planning phase.
+
+## Tags
+category: test-failures
+module: apps/web-platform/components/chat

--- a/knowledge-base/project/plans/2026-06-03-fix-concierge-status-box-text-overflow-plan.md
+++ b/knowledge-base/project/plans/2026-06-03-fix-concierge-status-box-text-overflow-plan.md
@@ -9,6 +9,45 @@ brand_survival_threshold: aggregate pattern
 
 # 🐛 Fix Concierge status box text overflow
 
+## Enhancement Summary
+
+**Deepened on:** 2026-06-03
+**Sections enhanced:** Approach (Research Insights), Files to Create, Acceptance
+Criteria, Observability, Phase 0, Risks (R4).
+**Method:** Inline deepen (Task-tool parallel agents unavailable in this
+environment); all findings verified live via `grep`/config-read against the
+worktree. Deepen halt gates 4.6 (User-Brand Impact), 4.7 (Observability), 4.8
+(PAT-shaped), 4.9 (UI-wireframe) all PASS.
+
+### Key Improvements
+
+1. **Corrected the Playwright test path (load-bearing).** v1 prescribed
+   `apps/web-platform/test/<...>.spec.ts`, which would be **silently skipped** —
+   Playwright here uses `testDir: "./e2e"` + `testMatch: "**/*.e2e.ts"`
+   (`playwright.config.ts:13-14`), and the bubble tests require the
+   `authenticated` project restricted to `cc-soleur-go-*` / `start-fresh-*` /
+   `nav-states-*` (`:48-53`). The test must be `e2e/cc-soleur-go-*.e2e.ts` (or
+   extend `e2e/cc-soleur-go-bubbles.e2e.ts`). This is the #3743 testMatch-drift
+   class — catching it here saves a mid-`/work` pivot AND prevents shipping a
+   verification that never runs.
+2. **Pinned the overflow-assertion precedent.** `e2e/nav-states-shell.e2e.ts:259,277`
+   already implements `scrollWidth - clientWidth` overflow checks with an
+   empty-band guard (`:19`). The new test reuses it verbatim — no novel assertion.
+3. **Verified the CSS mechanism against codebase precedent.** `[overflow-wrap:anywhere]`
+   is already used at `message-bubble.tsx:242` and `:269`; Option A is a
+   convention match, and the `min-w-0` ancestor chain (`:157/159/165`) is what
+   actually prevents #4852's premature wrap from returning — not `whitespace-nowrap`.
+
+### New Considerations Discovered
+
+- The existing `e2e/cc-soleur-go-bubbles.e2e.ts` already wires `attachWsInjector`
+  + Supabase mocks to drive the real reducer's routing bubble — extending it is
+  cheaper than a fresh harness.
+- jsdom returns 0 for layout values (constitution line 312), so the vitest test
+  can only assert the className mechanism; the actual overflow proof is e2e-only.
+
+---
+
 The Soleur Concierge status box ("Soleur Concierge" header + "Working" badge +
 status label such as "Routing to the right experts...") renders the status label
 on a single forced line that **overflows past the right border** of the bordered
@@ -107,7 +146,7 @@ liveness_signal:
   what: "Playwright deterministic screenshot of the Concierge tool_use bubble (long-label case)"
   cadence: per-PR (CI Playwright run on the affected route)
   alert_target: PR CI status (red on visual/structural regression)
-  configured_in: apps/web-platform/test/<concierge-overflow>.spec.ts (new, Phase 3)
+  configured_in: apps/web-platform/e2e/cc-soleur-go-bubbles.e2e.ts (extend) or e2e/cc-soleur-go-status-overflow.e2e.ts (new) — authenticated Playwright project
 error_reporting:
   destination: N/A — no runtime error path added; client render is presentational
   fail_loud: CI test failure (vitest className assertion + Playwright no-clip assertion)
@@ -164,6 +203,52 @@ test assertion (`message-bubble-tool-status-chip.test.tsx:82`) must be updated t
 assert the chosen mechanism (`[overflow-wrap:anywhere]`/`break-words` for A; the
 bubble `w-fit` class for B) — **never delete the regression intent**, re-point it.
 
+### Research Insights
+
+**CSS mechanism — why Option A is correct and low-risk:**
+
+- `[overflow-wrap:anywhere]` (CSS `overflow-wrap: anywhere`) instructs the layout
+  engine to break a line only when the content would otherwise overflow its
+  container; it does NOT force breaks when the content fits. So a short label
+  ("Working") on a flex parent with available width stays on one line, while a
+  long label wraps at the bubble's `max-w` cap. This is precisely the
+  "single-line-when-it-fits, wrap-when-it-doesn't" semantic the bug requires, and
+  it is the idiom the codebase already uses (verified `grep -n "overflow-wrap:anywhere"`)
+  at exactly two sites: the user-bubble wrapper (`message-bubble.tsx:242`,
+  `min-w-0 [overflow-wrap:anywhere]`) and the streaming body (`:269`,
+  `min-w-0 whitespace-pre-wrap [overflow-wrap:anywhere]`). Adopting it on the chip
+  label is a convention match, not a novel pattern.
+- Subtle distinction vs. `whitespace-normal`: the chip label currently has
+  `whitespace-nowrap`. Removing it returns the span to the default `whitespace:
+  normal`, under which `overflow-wrap:anywhere` governs break points. `break-words`
+  (`overflow-wrap: break-word`) is a near-equivalent; prefer `[overflow-wrap:anywhere]`
+  for exact parity with line 269 (it also breaks within an unbroken long token,
+  which a status label generally is not, but the parity keeps the codebase
+  uniform).
+- **#4852 non-regression mechanism (why A does not re-break the premature wrap):**
+  #4852's premature wrap was a *flex min-content collapse of the bubble width* —
+  the bubble shrank to its min-content and the label wrapped even with room. That
+  was already addressed by the `min-w-0` chain on the flex ancestors
+  (`message-bubble.tsx:157, 159, 165`), which lets the bubble take content width up
+  to the `max-w` cap. `whitespace-nowrap` was an over-correction on top of that.
+  With the `min-w-0` chain intact, the bubble still grows to content width; the
+  only behavior change from dropping `nowrap` is that a label *exceeding* the cap
+  now wraps instead of overflowing. The Playwright short-label single-line
+  assertion is the empirical proof obligation.
+
+**Precedent-diff (Phase 4.4) — overflow-assertion pattern:**
+
+- `git grep "scrollWidth - .*clientWidth" apps/web-platform/e2e/` →
+  `e2e/nav-states-shell.e2e.ts:259,277`. Canonical form:
+  `await el.evaluate((el) => el.scrollWidth - el.clientWidth)` with an explicit
+  empty-band guard (`:19` comment) so a collapsed/empty element cannot vacuously
+  pass `scrollWidth <= clientWidth`. The new test reuses this verbatim — no novel
+  assertion shape. **No precedent diverges**; the pattern is established.
+
+**No external framework research required:** this is a Tailwind/CSS layout fix on
+an existing component using idioms already present three times in the same file;
+Context7/WebSearch would add nothing the codebase precedent does not already pin.
+
 ## Files to Edit
 
 - `apps/web-platform/components/chat/message-bubble.tsx` — `ToolStatusChip` label
@@ -178,18 +263,34 @@ bubble `w-fit` class for B) — **never delete the regression intent**, re-point
   passing tests (single child, verbatim label, "Working" pill, active border)
   intact.
 
-## Files to Create
+## Files to Create / Extend (Playwright)
 
-- `apps/web-platform/test/<concierge-status-overflow>.spec.ts` (Playwright) — a
-  deterministic browser test that mounts/navigates to the Concierge `tool_use`
-  bubble with a long label and asserts **no horizontal overflow** of the card
-  (`labelScrollWidth <= cardClientWidth`, or `getBoundingClientRect` right edge ≤
-  card right edge), AND a short label renders single-line. Run in BOTH `full` and
-  `sidebar` variants. (Per constitution line 312, jsdom/vitest cannot assert
-  layout overflow — `clientWidth`/`scrollWidth` return 0 in jsdom — so the
-  overflow assertion MUST live in Playwright; vitest only asserts the className
-  mechanism.) Confirm the filename matches the Playwright project's `testMatch`
-  glob before writing (Phase 0 grep below).
+- **Extend `apps/web-platform/e2e/cc-soleur-go-bubbles.e2e.ts`** (preferred) OR
+  create **`apps/web-platform/e2e/cc-soleur-go-status-overflow.e2e.ts`** —
+  deterministic browser test that drives the Concierge `tool_use`/routing bubble
+  via the existing `attachWsInjector` WS-frame harness (NOT a fresh mount) with a
+  long status label, then asserts **no horizontal overflow** of the card, AND a
+  short label renders single-line. Run in BOTH `full` and `sidebar` variants.
+
+  **CORRECTED at deepen-plan (was wrong in v1):** Playwright in this app uses
+  `testDir: "./e2e"` + `testMatch: "**/*.e2e.ts"` (`playwright.config.ts:13-14`).
+  A `test/*.spec.ts` file (v1's path) would be **silently skipped** — it matches
+  neither the dir nor the glob (the #3743 testMatch-drift class). The bubble
+  tests additionally require the `authenticated` project, whose `testMatch` is
+  `["**/start-fresh-*.e2e.ts", "**/cc-soleur-go-*.e2e.ts", "**/nav-states-*.e2e.ts"]`
+  (`playwright.config.ts:48-53`) — so the filename MUST start with `cc-soleur-go-`
+  (or extend the existing `cc-soleur-go-bubbles.e2e.ts`, the cleanest option since
+  it already wires `attachWsInjector` + Supabase mocks for the routing bubble).
+
+  **Overflow assertion — reuse the existing precedent.** `e2e/nav-states-shell.e2e.ts:259,277`
+  already does `el.evaluate((el) => el.scrollWidth - el.clientWidth)` and documents
+  the empty-band pitfall (line 19: "an empty band would satisfy
+  `scrollWidth<=clientWidth`, so we ALSO assert the band [is populated]"). Mirror
+  this: assert `card.scrollWidth - card.clientWidth <= <tolerance>` for the long
+  label AND assert the label element is non-empty / has the expected text, so an
+  empty/collapsed card cannot vacuously pass. (Per constitution line 312,
+  jsdom/vitest returns 0 for layout values — the overflow assertion MUST live in
+  Playwright; vitest only asserts the className mechanism.)
 
 ## Open Code-Review Overlap
 
@@ -211,10 +312,15 @@ edited files (`message-bubble.tsx`, `message-bubble-tool-status-chip.test.tsx`).
 - [ ] `message-bubble-tool-status-chip.test.tsx` updated: the #4852 assertion at
       line 82 now asserts the new mechanism (no orphaned `whitespace-nowrap`
       expectation on the chip label). All 5 tests in the file pass.
-- [ ] New Playwright spec asserts **no horizontal overflow** of the Concierge
-      card for a long status label, in BOTH `full` and `sidebar` variants.
-- [ ] New Playwright spec asserts a short label renders single-line when space is
+- [ ] New/extended Playwright **e2e** test (`e2e/cc-soleur-go-*.e2e.ts`, authenticated
+      project) asserts **no horizontal overflow** of the Concierge card
+      (`card.scrollWidth - card.clientWidth <= tolerance` AND label non-empty, per
+      the `nav-states-shell.e2e.ts:259,277` precedent) for a long status label, in
+      BOTH `full` and `sidebar` variants.
+- [ ] Same e2e test asserts a short label renders single-line when space is
       available (proves #4852 not re-broken).
+- [ ] The new test FILE matches `testMatch` — `ls apps/web-platform/e2e/cc-soleur-go-*.e2e.ts`
+      includes it (or it lives inside the existing `cc-soleur-go-bubbles.e2e.ts`).
 - [ ] `cd apps/web-platform && ./node_modules/.bin/vitest run test/message-bubble-tool-status-chip.test.tsx test/message-bubble-header.test.tsx` is green.
 - [ ] `tsc --noEmit` clean for `apps/web-platform`.
 
@@ -260,7 +366,7 @@ component).
 The mechanical UI-surface override fires (`components/**/*.tsx` in Files to Edit),
 forcing Product-relevant = true. However, no NEW file matches
 `components/**/*.tsx` / `app/**/page.tsx` / `app/**/layout.tsx` in Files to
-**Create** (the only new file is a `.spec.ts` test), so the mechanical BLOCKING
+**Create** (the only new file is an `.e2e.ts` Playwright test), so the mechanical BLOCKING
 escalation does not fire. The change modifies an existing component's wrap
 behavior without adding any interactive surface → ADVISORY. In pipeline context
 ADVISORY auto-accepts.
@@ -278,10 +384,13 @@ ADVISORY auto-accepts.
 - **R3 — jsdom test silently no-ops on overflow.** jsdom returns 0 for
   `clientWidth`/`scrollWidth` (constitution line 312). *Mitigation:* the overflow
   assertion lives in Playwright; vitest asserts only the className mechanism.
-- **R4 — Playwright spec filename misses the project `testMatch` glob** (AGENTS.md
-  Sharp Edge / #3743). *Mitigation:* Phase 0 grep the Playwright config for
-  `testMatch`/`testDir` and confirm the new spec lands on the correct project
-  before writing it.
+- **R4 — Playwright test filename misses the project `testMatch` glob** (AGENTS.md
+  Sharp Edge / #3743). **RESOLVED at deepen-plan:** config verified —
+  `testDir: ./e2e`, `testMatch: **/*.e2e.ts`, authenticated project restricted to
+  `cc-soleur-go-*` / `start-fresh-*` / `nav-states-*`. The plan now prescribes
+  `e2e/cc-soleur-go-*.e2e.ts` (or extending `cc-soleur-go-bubbles.e2e.ts`). The
+  v1 `test/*.spec.ts` path would have been silently skipped — the exact bug class
+  R4 names.
 - **R5 — fix verified in only one render variant.** The bug is more visible in the
   narrow `sidebar` variant (`kb-chat-content.tsx:178`). AGENTS.md Sharp Edge:
   "verify alignment in both toggle/render states." *Mitigation:* Playwright runs
@@ -291,9 +400,12 @@ ADVISORY auto-accepts.
 
 1. `grep -n "whitespace-nowrap" apps/web-platform/components/chat/message-bubble.tsx`
    → confirm exactly two sites (line 27 chip, line 193 header); edit only line 27.
-2. `grep -nE "testMatch|testDir|projects" apps/web-platform/playwright.config.ts`
-   (or equivalent) → confirm the new `.spec.ts` filename lands on the right
-   Playwright project (R4).
+2. **VERIFIED at deepen-plan:** `apps/web-platform/playwright.config.ts:13-14`
+   → `testDir: "./e2e"`, `testMatch: "**/*.e2e.ts"`; the `authenticated` project
+   (`:48-53`) restricts to `**/cc-soleur-go-*.e2e.ts` (+ `start-fresh-*`,
+   `nav-states-*`). The new test MUST be `e2e/cc-soleur-go-*.e2e.ts` or extend
+   `e2e/cc-soleur-go-bubbles.e2e.ts`. (Do not use `test/*.spec.ts` — silently
+   skipped.)
 3. `grep -n "include" apps/web-platform/vitest.config.ts` → confirm the updated
    `.test.tsx` is collected by `test/**/*.test.tsx` (it already lives there).
 4. Re-read `message-bubble.tsx:24-30, 155-175, 264-269` to confirm line numbers

--- a/knowledge-base/project/plans/2026-06-03-fix-concierge-status-box-text-overflow-plan.md
+++ b/knowledge-base/project/plans/2026-06-03-fix-concierge-status-box-text-overflow-plan.md
@@ -1,0 +1,341 @@
+---
+title: "fix(chat): Concierge status box text overflows card right border"
+type: fix
+date: 2026-06-03
+branch: feat-one-shot-concierge-box-text-overflow
+lane: single-domain
+brand_survival_threshold: aggregate pattern
+---
+
+# 🐛 Fix Concierge status box text overflow
+
+The Soleur Concierge status box ("Soleur Concierge" header + "Working" badge +
+status label such as "Routing to the right experts...") renders the status label
+on a single forced line that **overflows past the right border** of the bordered
+Concierge card when the label is wider than the bubble's max-width cap.
+
+This is the **inverse failure mode** of the regression PR #4852 (merged, commit
+`7c44c9e8`) fixed. #4852 added `whitespace-nowrap` to the chip label to stop
+*premature* wrapping (the label wrapped to two lines even when horizontal space
+was available — a flex min-content collapse). That fix shipped bare
+`whitespace-nowrap` with no upper bound, so now when the label is *longer* than
+the bubble max-width (`max-w-[90%]`/`md:max-w-[80%]`, line 159), `nowrap` forces
+the text to overflow the card instead of wrapping. The same plan even named this
+risk (`2026-06-02-fix-concierge-prefill-400-tool-approval-and-status-box-wrap-plan.md`
+**R4**: "`whitespace-nowrap` on the wrong element could clip long status labels
+off-screen") but the shipped code never implemented R4's "wraps at the cap"
+mitigation.
+
+The fix must satisfy **both** constraints simultaneously:
+1. Short labels keep their natural single-line width (do not re-break #4852 —
+   no premature wrap when space is available).
+2. Labels wider than the bubble max-width **wrap** (or otherwise stay contained)
+   instead of overflowing the right border.
+
+## Root Cause
+
+`apps/web-platform/components/chat/message-bubble.tsx:24-30` — `ToolStatusChip`:
+
+```tsx
+export function ToolStatusChip({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2 py-0.5" data-testid="tool-status-chip">
+      <span className="whitespace-nowrap text-sm text-soleur-text-secondary">{label}</span>
+    </div>
+  );
+}
+```
+
+The bubble container (line 159) is `flex min-w-0 max-w-[90%] gap-3 md:max-w-[80%]`
+and the inner card (line 165) is `relative min-w-0 ...`. With `whitespace-nowrap`
+on the label **and** a hard `max-w` cap **and** `min-w-0`, the only remaining
+degree of freedom is overflow: the text cannot wrap (nowrap) and the box cannot
+grow past the cap → it spills past the right border.
+
+Note the **leader-header primary span** (line 193, "Soleur Concierge" / "CMO
+Riley") also carries `whitespace-nowrap` from #4852. Leader names are short and
+asserted single-line by `message-bubble-header.test.tsx:128-141`. **Do not touch
+line 193** — it is not the overflow culprit and its nowrap is intentional.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (from issue / prior plan) | Reality (verified on branch) | Plan response |
+|---|---|---|
+| #4852 fixed "status box wrap" | Merged (commit `7c44c9e8`); added bare `whitespace-nowrap` at `message-bubble.tsx:27` + `:193` | Fix the *inverse* failure mode (#4852's own R4 risk, never mitigated in code) at line 27 only |
+| #4852 plan said bubble gets `w-fit` for routing-chip case (plan line 104) | `grep -n "w-fit" message-bubble.tsx` → **no match**; `w-fit` never shipped | The grow-then-wrap mechanism was never implemented; this plan implements it |
+| Overflow is in "the Concierge card" | Originates in `ToolStatusChip` label span (line 27), rendered inside the `tool_use` bubble path (line 264-266) | Scope fix to the chip label span |
+| Existing test enforces `whitespace-nowrap` on the chip | `message-bubble-tool-status-chip.test.tsx:71-83` (#4852) asserts `labelSpan.className` contains `"whitespace-nowrap"` | This test MUST be updated to the new mechanism, not silently broken |
+| Header span also has `whitespace-nowrap` | True (line 193); `message-bubble-header.test.tsx:128-141` asserts it for leader names | Out of scope — leader names are short; keep nowrap on line 193 |
+| Both render variants affected | `variant: "full"` (chat-surface) + `variant: "sidebar"` (`kb-chat-content.tsx:178`, narrower container → overflow MORE likely) | Verify the fix in both variants (Playwright) |
+
+**Premise Validation:** All cited artifacts verified present on the branch.
+`ToolStatusChip` exists at `message-bubble.tsx:24-30`; the call site is
+`chat-surface.tsx:744-754` (`isClassifying` routing chip, `toolLabel="Routing to
+the right experts..."`) and the general `tool_use` path at `message-bubble.tsx:264-266`.
+PR #4852 confirmed MERGED. The bug is **broken behavior of a shipped component**,
+not a never-built feature — this is a patch, not a build. No external premise is
+stale.
+
+## User-Brand Impact
+
+- **If this lands broken, the user experiences:** the Soleur Concierge status text
+  ("Routing to the right experts...") spilling past the right border of the
+  Concierge card on the chat/Dashboard — the brand-visible `/soleur:go` front
+  door — looking visually broken / unpolished on every in-flight turn whose
+  status label exceeds the bubble width (more pronounced in the narrow sidebar
+  variant).
+- **If this leaks, the user's data is exposed via:** N/A — this is a presentational
+  CSS-only change. No data, auth, or workflow surface is touched. The status label
+  is non-PII UI copy already rendered to the user.
+- **Brand-survival threshold:** `aggregate pattern` — cosmetic overflow degrades
+  perceived polish across all users who see a long status label; no single-user
+  incident, no data exposure. (Sensitive-path note: the diff touches only
+  `apps/web-platform/components/chat/*.tsx` + `apps/web-platform/test/*.test.tsx`;
+  no schema/auth/API/migration surface, so no preflight Check-6 scope-out bullet
+  is required.)
+
+## Observability
+
+This plan touches `apps/web-platform/components/**` (client React/CSS) only — no
+server, infra, or new runtime surface. Per plan Phase 2.9, a presentational
+CSS-only change to an existing client component carries no new failure mode that
+requires liveness/error wiring. The "observability" for a CSS layout fix is the
+visual regression assertion itself:
+
+```yaml
+liveness_signal:
+  what: "Playwright deterministic screenshot of the Concierge tool_use bubble (long-label case)"
+  cadence: per-PR (CI Playwright run on the affected route)
+  alert_target: PR CI status (red on visual/structural regression)
+  configured_in: apps/web-platform/test/<concierge-overflow>.spec.ts (new, Phase 3)
+error_reporting:
+  destination: N/A — no runtime error path added; client render is presentational
+  fail_loud: CI test failure (vitest className assertion + Playwright no-clip assertion)
+failure_modes:
+  - mode: "long status label overflows card right border"
+    detection: Playwright assertion that label scrollWidth <= card clientWidth (or no horizontal overflow), run in CI
+    alert_route: PR author via red CI check
+  - mode: "short label regresses to premature wrap (re-break #4852)"
+    detection: Playwright assertion that a short label renders on a single line when space is available
+    alert_route: PR author via red CI check
+logs:
+  where: N/A — no server log surface; CI test output only
+  retention: CI run retention (GitHub Actions default)
+discoverability_test:
+  command: "cd apps/web-platform && ./node_modules/.bin/vitest run test/message-bubble-tool-status-chip.test.tsx"
+  expected_output: "all tests pass — chip label carries the wrap-capable mechanism (not whitespace-nowrap-only)"
+```
+
+## Approach
+
+The canonical CSS pattern for "single line when it fits, wrap when it doesn't" is
+to let the text wrap on overflow rather than forcing nowrap. The bubble already
+demonstrates this exact pattern for the streaming body at
+`message-bubble.tsx:269`: `min-w-0 whitespace-pre-wrap [overflow-wrap:anywhere]`.
+
+Two candidate mechanisms (the implementer picks ONE; **Option A is recommended**
+as the simplest and matching existing convention):
+
+- **Option A (recommended) — wrap-on-overflow:** Replace `whitespace-nowrap` on
+  the chip label (line 27) with `[overflow-wrap:anywhere]` (or `break-words`),
+  matching the line-269 body pattern. Short labels stay on one line naturally
+  (the flex parent + `min-w-0` already give the bubble content width up to the
+  cap); long labels wrap at the cap instead of overflowing. This is the smallest
+  diff and reuses the codebase's established wrap idiom.
+  - **#4852-regression guard:** #4852's premature wrap was a *flex min-content
+    collapse*, not a `whitespace-normal` issue — the chip `<div>` is already
+    `flex items-center` and the label is the only child, so removing nowrap does
+    NOT reintroduce the min-content collapse (which was about the bubble width,
+    addressed by the existing `min-w-0` chain). The implementer MUST verify the
+    short-label single-line behavior in Playwright (both variants) to prove #4852
+    is not re-broken.
+
+- **Option B (fallback) — grow-then-wrap with `w-fit`:** Keep `whitespace-nowrap`
+  on the label but give the **bubble card** (line 165) `w-fit` so it grows to the
+  label's natural single-line width, bounded by the existing `max-w` cap, then
+  the label wraps once it hits the cap. This implements the #4852 plan's
+  never-shipped `w-fit` intent (plan line 104). Larger blast radius (changes
+  bubble width semantics for ALL bubble states, not just the chip), so prefer A
+  unless A's short-label behavior cannot be verified.
+
+**Decision criterion:** Ship Option A. Fall back to B only if Playwright shows A
+regresses the short-label single-line case. Whichever ships, the existing chip
+test assertion (`message-bubble-tool-status-chip.test.tsx:82`) must be updated to
+assert the chosen mechanism (`[overflow-wrap:anywhere]`/`break-words` for A; the
+bubble `w-fit` class for B) — **never delete the regression intent**, re-point it.
+
+## Files to Edit
+
+- `apps/web-platform/components/chat/message-bubble.tsx` — `ToolStatusChip` label
+  span at **line 27** only (Option A: swap `whitespace-nowrap` → wrap-capable
+  class; Option B: add `w-fit` to the bubble card at line 165 and leave line 27).
+  **Do NOT touch line 193** (leader-header span — intentional nowrap for short
+  leader names).
+- `apps/web-platform/test/message-bubble-tool-status-chip.test.tsx` — update the
+  #4852 regression test at **lines 71-83**. Re-point the `whitespace-nowrap`
+  className assertion to the new mechanism. Add a RED→GREEN structural assertion
+  that the label span carries the wrap-capable class. Keep the three existing
+  passing tests (single child, verbatim label, "Working" pill, active border)
+  intact.
+
+## Files to Create
+
+- `apps/web-platform/test/<concierge-status-overflow>.spec.ts` (Playwright) — a
+  deterministic browser test that mounts/navigates to the Concierge `tool_use`
+  bubble with a long label and asserts **no horizontal overflow** of the card
+  (`labelScrollWidth <= cardClientWidth`, or `getBoundingClientRect` right edge ≤
+  card right edge), AND a short label renders single-line. Run in BOTH `full` and
+  `sidebar` variants. (Per constitution line 312, jsdom/vitest cannot assert
+  layout overflow — `clientWidth`/`scrollWidth` return 0 in jsdom — so the
+  overflow assertion MUST live in Playwright; vitest only asserts the className
+  mechanism.) Confirm the filename matches the Playwright project's `testMatch`
+  glob before writing (Phase 0 grep below).
+
+## Open Code-Review Overlap
+
+None checked at plan-write time (Task-tool research agents unavailable in this
+environment). deepen-plan / one-shot review phase should run the standard
+`gh issue list --label code-review --state open` overlap check against the two
+edited files (`message-bubble.tsx`, `message-bubble-tool-status-chip.test.tsx`).
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] `message-bubble.tsx` chip label span (line 27) no longer forces a single
+      line on overflow: it carries the wrap-capable mechanism (Option A:
+      `[overflow-wrap:anywhere]` or `break-words`; Option B: bubble `w-fit` +
+      `max-w` cap). Verify with `grep -n "overflow-wrap:anywhere\|break-words\|w-fit" apps/web-platform/components/chat/message-bubble.tsx`.
+- [ ] Line 193 (leader-header span) is unchanged — still `whitespace-nowrap`.
+      Verify `message-bubble-header.test.tsx:128-141` still passes.
+- [ ] `message-bubble-tool-status-chip.test.tsx` updated: the #4852 assertion at
+      line 82 now asserts the new mechanism (no orphaned `whitespace-nowrap`
+      expectation on the chip label). All 5 tests in the file pass.
+- [ ] New Playwright spec asserts **no horizontal overflow** of the Concierge
+      card for a long status label, in BOTH `full` and `sidebar` variants.
+- [ ] New Playwright spec asserts a short label renders single-line when space is
+      available (proves #4852 not re-broken).
+- [ ] `cd apps/web-platform && ./node_modules/.bin/vitest run test/message-bubble-tool-status-chip.test.tsx test/message-bubble-header.test.tsx` is green.
+- [ ] `tsc --noEmit` clean for `apps/web-platform`.
+
+### Post-merge (operator)
+
+- None — pure client CSS change deployed by the standard `web-platform-release.yml`
+  pipeline on merge to main (path-filtered `apps/web-platform/**`).
+
+## Test Scenarios
+
+- Given the Concierge `tool_use` bubble with `toolLabel="Routing to the right
+  experts..."`, when rendered in the narrow `sidebar` variant, then the label
+  wraps inside the card and no text crosses the card's right border (Playwright).
+- Given the same bubble with a short label ("Working"), when there is horizontal
+  space, then the label stays on a single line (Playwright — #4852 non-regression).
+- Given the `tool_use` chip, when rendered (jsdom/vitest), then the label span's
+  className contains the wrap-capable mechanism and NOT `whitespace-nowrap`
+  (structural assertion; no layout-engine gating per constitution line 312).
+- Given the leader-header for `cc_router`, when rendered, then "Soleur Concierge"
+  stays single-line (existing `message-bubble-header.test.tsx` unchanged).
+
+## Domain Review
+
+**Domains relevant:** Product (UI surface)
+
+### Product/UX Gate
+
+**Tier:** advisory
+**Decision:** auto-accepted (pipeline)
+**Agents invoked:** none (Task tool unavailable in this planning environment; the
+one-shot review phase + deepen-plan handle agent spawning)
+**Skipped specialists:** none — this is a CSS-only wrap fix to an **existing**
+component (no new user-facing page, flow, or interactive surface), so it is
+ADVISORY not BLOCKING; `ux-design-lead`/`.pen` wireframes are not required for a
+presentational overflow fix to an existing component (matches the #4852 plan's own
+classification: "non-wrapping/width tweak to the existing Concierge status chip —
+ADVISORY").
+**Pencil available:** N/A — no new UI surface (CSS-only wrap change to an existing
+component).
+
+#### Findings
+
+The mechanical UI-surface override fires (`components/**/*.tsx` in Files to Edit),
+forcing Product-relevant = true. However, no NEW file matches
+`components/**/*.tsx` / `app/**/page.tsx` / `app/**/layout.tsx` in Files to
+**Create** (the only new file is a `.spec.ts` test), so the mechanical BLOCKING
+escalation does not fire. The change modifies an existing component's wrap
+behavior without adding any interactive surface → ADVISORY. In pipeline context
+ADVISORY auto-accepts.
+
+## Risks & Mitigations
+
+- **R1 — Option A reintroduces #4852's premature wrap.** The #4852 wrap was a flex
+  min-content collapse of the *bubble width*, fixed by the `min-w-0` chain (lines
+  157/159/165), not by `whitespace-nowrap` per se. *Mitigation:* the Playwright
+  short-label single-line assertion (both variants) is a required AC; if it fails,
+  fall back to Option B (`w-fit` grow-then-wrap).
+- **R2 — touching line 193 breaks the leader-name single-line invariant.**
+  *Mitigation:* scope explicitly excludes line 193; `message-bubble-header.test.tsx`
+  guards it.
+- **R3 — jsdom test silently no-ops on overflow.** jsdom returns 0 for
+  `clientWidth`/`scrollWidth` (constitution line 312). *Mitigation:* the overflow
+  assertion lives in Playwright; vitest asserts only the className mechanism.
+- **R4 — Playwright spec filename misses the project `testMatch` glob** (AGENTS.md
+  Sharp Edge / #3743). *Mitigation:* Phase 0 grep the Playwright config for
+  `testMatch`/`testDir` and confirm the new spec lands on the correct project
+  before writing it.
+- **R5 — fix verified in only one render variant.** The bug is more visible in the
+  narrow `sidebar` variant (`kb-chat-content.tsx:178`). AGENTS.md Sharp Edge:
+  "verify alignment in both toggle/render states." *Mitigation:* Playwright runs
+  both `full` and `sidebar` as required ACs.
+
+## Phase 0 (work-time preconditions — grep before editing)
+
+1. `grep -n "whitespace-nowrap" apps/web-platform/components/chat/message-bubble.tsx`
+   → confirm exactly two sites (line 27 chip, line 193 header); edit only line 27.
+2. `grep -nE "testMatch|testDir|projects" apps/web-platform/playwright.config.ts`
+   (or equivalent) → confirm the new `.spec.ts` filename lands on the right
+   Playwright project (R4).
+3. `grep -n "include" apps/web-platform/vitest.config.ts` → confirm the updated
+   `.test.tsx` is collected by `test/**/*.test.tsx` (it already lives there).
+4. Re-read `message-bubble.tsx:24-30, 155-175, 264-269` to confirm line numbers
+   have not drifted since plan-write.
+
+## Implementation Phases
+
+1. **Phase 0** — run the Phase 0 grep preconditions above.
+2. **Phase 1 (RED)** — update `message-bubble-tool-status-chip.test.tsx` to assert
+   the wrap-capable mechanism on the chip label (fails against current
+   `whitespace-nowrap`). Add the Playwright spec (fails / overflows against current
+   code).
+3. **Phase 2 (GREEN)** — apply Option A to `message-bubble.tsx:27`. Re-run vitest
+   + Playwright. If the short-label single-line Playwright assertion fails, switch
+   to Option B (`w-fit` at line 165) and update the test assertion accordingly.
+4. **Phase 3 (verify)** — `tsc --noEmit`; full `message-bubble-*` + `cc-routing-panel-concierge-visibility` suites green; Playwright both variants green.
+
+## References
+
+- Prior plan (the regression this reconciles against):
+  `knowledge-base/project/plans/2026-06-02-fix-concierge-prefill-400-tool-approval-and-status-box-wrap-plan.md`
+  (R4 risk named, never mitigated in code)
+- PR #4852 (merged, commit `7c44c9e8`) — added the `whitespace-nowrap` that causes
+  this inverse overflow.
+- Component: `apps/web-platform/components/chat/message-bubble.tsx:24-30` (chip),
+  `:159-169` (bubble width), `:264-266` (tool_use render path), `:269` (existing
+  wrap-on-overflow idiom to mirror).
+- Call site: `apps/web-platform/components/chat/chat-surface.tsx:744-754`.
+- Narrow variant: `apps/web-platform/components/chat/kb-chat-content.tsx:178`.
+- Constitution conventions: line 312 (no jsdom layout-gated assertions), line 318
+  (RED/GREEN/REFACTOR), line 302 (worktree vitest invocation).
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only
+  `TBD`/`TODO`/placeholder text, or omits the threshold will fail `deepen-plan`
+  Phase 4.6. (This plan's section is filled; threshold = `aggregate pattern`.)
+- Do not assert overflow in jsdom/vitest — `clientWidth`/`scrollWidth` return 0
+  (constitution line 312). Overflow assertions are Playwright-only.
+- Verify the fix in BOTH render variants (`full` + `sidebar`) — the bug is more
+  visible in the narrow sidebar; an alignment/wrap fix verified in one state can
+  leave the other broken (AGENTS.md both-toggle-states Sharp Edge).
+- Do not touch the leader-header `whitespace-nowrap` (line 193) — it is guarded by
+  `message-bubble-header.test.tsx` and is the correct behavior for short leader
+  names.

--- a/knowledge-base/project/specs/feat-one-shot-concierge-box-text-overflow/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-concierge-box-text-overflow/session-state.md
@@ -1,0 +1,19 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-03-fix-concierge-status-box-text-overflow-plan.md
+- Status: complete
+
+### Errors
+- Initial plan Write blocked by bare-root guard; re-wrote to worktree path. No impact.
+- Task tool unavailable in planning env; agent fan-out done inline. All deepen-plan halt gates PASS.
+
+### Decisions
+- Root cause: inverse of merged PR #4852, which added bare `whitespace-nowrap` to the ToolStatusChip label (message-bubble.tsx:27). With nowrap + max-w cap + min-w-0, a long label can neither wrap nor grow -> overflow.
+- Fix (Option A): swap `whitespace-nowrap` -> `[overflow-wrap:anywhere]` on the chip label only (convention match: message-bubble.tsx:242,269). min-w-0 ancestor chain prevents #4852's premature wrap from returning. Line 193 leader-header out of scope.
+- Test path corrected: Playwright uses testDir ./e2e, testMatch **/*.e2e.ts, authenticated project restricted to cc-soleur-go-*. Use e2e/cc-soleur-go-*.e2e.ts.
+- Test split per constitution: jsdom returns 0 for layout; vitest asserts className mechanism (update #4852 regression test at message-bubble-tool-status-chip.test.tsx:71-83); overflow proof is Playwright-only.
+- Domain Review = ADVISORY (auto-accepted): CSS wrap fix, no new UI surface, no .pen wireframe required.
+
+### Components Invoked
+- soleur:plan, soleur:deepen-plan, Bash/Read/Edit/Write

--- a/knowledge-base/project/specs/feat-one-shot-concierge-box-text-overflow/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-concierge-box-text-overflow/tasks.md
@@ -6,20 +6,20 @@ Lane: single-domain · Threshold: aggregate pattern
 ## 1. Setup / Preconditions (Phase 0)
 
 - [ ] 1.1 `grep -n "whitespace-nowrap" apps/web-platform/components/chat/message-bubble.tsx` — confirm 2 sites (line 27 chip, line 193 header). Edit only line 27.
-- [ ] 1.2 `grep -nE "testMatch|testDir|projects" apps/web-platform/playwright.config.ts` — confirm new `.spec.ts` filename lands on the right Playwright project.
+- [ ] 1.2 VERIFIED (deepen-plan): Playwright `testDir: ./e2e`, `testMatch: **/*.e2e.ts`; bubble tests need the `authenticated` project (`cc-soleur-go-*` / `start-fresh-*` / `nav-states-*`). New test MUST be `e2e/cc-soleur-go-*.e2e.ts` or extend `e2e/cc-soleur-go-bubbles.e2e.ts`. (NOT `test/*.spec.ts` — silently skipped.)
 - [ ] 1.3 `grep -n "include" apps/web-platform/vitest.config.ts` — confirm `.test.tsx` collected by `test/**/*.test.tsx`.
 - [ ] 1.4 Re-read `message-bubble.tsx:24-30, 155-175, 264-269` to confirm line numbers have not drifted.
 
 ## 2. Core Implementation (RED → GREEN)
 
 - [ ] 2.1 (RED) Update `apps/web-platform/test/message-bubble-tool-status-chip.test.tsx:71-83` — re-point the `whitespace-nowrap` assertion to the wrap-capable mechanism (fails against current code). Keep the other 4 tests intact.
-- [ ] 2.2 (RED) Create `apps/web-platform/test/<concierge-status-overflow>.spec.ts` — Playwright: long label → no horizontal overflow of card; short label → single line. Both `full` and `sidebar` variants. (Fails/overflows against current code.)
+- [ ] 2.2 (RED) Extend `apps/web-platform/e2e/cc-soleur-go-bubbles.e2e.ts` (or create `e2e/cc-soleur-go-status-overflow.e2e.ts`) — Playwright via `attachWsInjector`: long label → no horizontal overflow of card (reuse `nav-states-shell.e2e.ts:259,277` `scrollWidth-clientWidth` + empty-band guard); short label → single line. Both `full` and `sidebar` variants. (Fails/overflows against current code.)
 - [ ] 2.3 (GREEN) Apply Option A to `message-bubble.tsx:27` — swap `whitespace-nowrap` → `[overflow-wrap:anywhere]` (or `break-words`). Do NOT touch line 193.
 - [ ] 2.4 (GREEN fallback) If 2.2 short-label single-line assertion fails, switch to Option B: add `w-fit` to bubble card (line 165), keep nowrap on line 27, and update the 2.1 assertion to the `w-fit` mechanism.
 
 ## 3. Testing / Verification (Phase 3)
 
 - [ ] 3.1 `cd apps/web-platform && ./node_modules/.bin/vitest run test/message-bubble-tool-status-chip.test.tsx test/message-bubble-header.test.tsx` — green.
-- [ ] 3.2 Run Playwright spec — both `full` and `sidebar` variants green (no overflow + short-label single-line).
+- [ ] 3.2 Run the Playwright e2e (`cc-soleur-go-*`, authenticated project) — both `full` and `sidebar` variants green (no overflow + short-label single-line). Confirm the file matches `testMatch` (`ls e2e/cc-soleur-go-*.e2e.ts`).
 - [ ] 3.3 `tsc --noEmit` clean for `apps/web-platform`.
 - [ ] 3.4 Run `cc-routing-panel-concierge-visibility.test.tsx` + remaining `message-bubble-*` suites — green.

--- a/knowledge-base/project/specs/feat-one-shot-concierge-box-text-overflow/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-concierge-box-text-overflow/tasks.md
@@ -1,0 +1,25 @@
+# Tasks — fix Concierge status box text overflow
+
+Plan: `knowledge-base/project/plans/2026-06-03-fix-concierge-status-box-text-overflow-plan.md`
+Lane: single-domain · Threshold: aggregate pattern
+
+## 1. Setup / Preconditions (Phase 0)
+
+- [ ] 1.1 `grep -n "whitespace-nowrap" apps/web-platform/components/chat/message-bubble.tsx` — confirm 2 sites (line 27 chip, line 193 header). Edit only line 27.
+- [ ] 1.2 `grep -nE "testMatch|testDir|projects" apps/web-platform/playwright.config.ts` — confirm new `.spec.ts` filename lands on the right Playwright project.
+- [ ] 1.3 `grep -n "include" apps/web-platform/vitest.config.ts` — confirm `.test.tsx` collected by `test/**/*.test.tsx`.
+- [ ] 1.4 Re-read `message-bubble.tsx:24-30, 155-175, 264-269` to confirm line numbers have not drifted.
+
+## 2. Core Implementation (RED → GREEN)
+
+- [ ] 2.1 (RED) Update `apps/web-platform/test/message-bubble-tool-status-chip.test.tsx:71-83` — re-point the `whitespace-nowrap` assertion to the wrap-capable mechanism (fails against current code). Keep the other 4 tests intact.
+- [ ] 2.2 (RED) Create `apps/web-platform/test/<concierge-status-overflow>.spec.ts` — Playwright: long label → no horizontal overflow of card; short label → single line. Both `full` and `sidebar` variants. (Fails/overflows against current code.)
+- [ ] 2.3 (GREEN) Apply Option A to `message-bubble.tsx:27` — swap `whitespace-nowrap` → `[overflow-wrap:anywhere]` (or `break-words`). Do NOT touch line 193.
+- [ ] 2.4 (GREEN fallback) If 2.2 short-label single-line assertion fails, switch to Option B: add `w-fit` to bubble card (line 165), keep nowrap on line 27, and update the 2.1 assertion to the `w-fit` mechanism.
+
+## 3. Testing / Verification (Phase 3)
+
+- [ ] 3.1 `cd apps/web-platform && ./node_modules/.bin/vitest run test/message-bubble-tool-status-chip.test.tsx test/message-bubble-header.test.tsx` — green.
+- [ ] 3.2 Run Playwright spec — both `full` and `sidebar` variants green (no overflow + short-label single-line).
+- [ ] 3.3 `tsc --noEmit` clean for `apps/web-platform`.
+- [ ] 3.4 Run `cc-routing-panel-concierge-visibility.test.tsx` + remaining `message-bubble-*` suites — green.

--- a/knowledge-base/project/specs/feat-one-shot-concierge-box-text-overflow/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-concierge-box-text-overflow/tasks.md
@@ -5,21 +5,21 @@ Lane: single-domain · Threshold: aggregate pattern
 
 ## 1. Setup / Preconditions (Phase 0)
 
-- [ ] 1.1 `grep -n "whitespace-nowrap" apps/web-platform/components/chat/message-bubble.tsx` — confirm 2 sites (line 27 chip, line 193 header). Edit only line 27.
-- [ ] 1.2 VERIFIED (deepen-plan): Playwright `testDir: ./e2e`, `testMatch: **/*.e2e.ts`; bubble tests need the `authenticated` project (`cc-soleur-go-*` / `start-fresh-*` / `nav-states-*`). New test MUST be `e2e/cc-soleur-go-*.e2e.ts` or extend `e2e/cc-soleur-go-bubbles.e2e.ts`. (NOT `test/*.spec.ts` — silently skipped.)
-- [ ] 1.3 `grep -n "include" apps/web-platform/vitest.config.ts` — confirm `.test.tsx` collected by `test/**/*.test.tsx`.
-- [ ] 1.4 Re-read `message-bubble.tsx:24-30, 155-175, 264-269` to confirm line numbers have not drifted.
+- [x] 1.1 `grep -n "whitespace-nowrap" apps/web-platform/components/chat/message-bubble.tsx` — confirm 2 sites (line 27 chip, line 193 header). Edit only line 27.
+- [x] 1.2 VERIFIED (deepen-plan): Playwright `testDir: ./e2e`, `testMatch: **/*.e2e.ts`; bubble tests need the `authenticated` project (`cc-soleur-go-*` / `start-fresh-*` / `nav-states-*`). New test MUST be `e2e/cc-soleur-go-*.e2e.ts` or extend `e2e/cc-soleur-go-bubbles.e2e.ts`. (NOT `test/*.spec.ts` — silently skipped.)
+- [x] 1.3 `grep -n "include" apps/web-platform/vitest.config.ts` — confirm `.test.tsx` collected by `test/**/*.test.tsx`.
+- [x] 1.4 Re-read `message-bubble.tsx:24-30, 155-175, 264-269` to confirm line numbers have not drifted.
 
 ## 2. Core Implementation (RED → GREEN)
 
-- [ ] 2.1 (RED) Update `apps/web-platform/test/message-bubble-tool-status-chip.test.tsx:71-83` — re-point the `whitespace-nowrap` assertion to the wrap-capable mechanism (fails against current code). Keep the other 4 tests intact.
-- [ ] 2.2 (RED) Extend `apps/web-platform/e2e/cc-soleur-go-bubbles.e2e.ts` (or create `e2e/cc-soleur-go-status-overflow.e2e.ts`) — Playwright via `attachWsInjector`: long label → no horizontal overflow of card (reuse `nav-states-shell.e2e.ts:259,277` `scrollWidth-clientWidth` + empty-band guard); short label → single line. Both `full` and `sidebar` variants. (Fails/overflows against current code.)
-- [ ] 2.3 (GREEN) Apply Option A to `message-bubble.tsx:27` — swap `whitespace-nowrap` → `[overflow-wrap:anywhere]` (or `break-words`). Do NOT touch line 193.
+- [x] 2.1 (RED) Update `apps/web-platform/test/message-bubble-tool-status-chip.test.tsx:71-83` — re-point the `whitespace-nowrap` assertion to the wrap-capable mechanism (fails against current code). Keep the other 4 tests intact.
+- [x] 2.2 (RED) Extend `apps/web-platform/e2e/cc-soleur-go-bubbles.e2e.ts` (or create `e2e/cc-soleur-go-status-overflow.e2e.ts`) — Playwright via `attachWsInjector`: long label → no horizontal overflow of card (reuse `nav-states-shell.e2e.ts:259,277` `scrollWidth-clientWidth` + empty-band guard); short label → single line. Both `full` and `sidebar` variants. (Fails/overflows against current code.)
+- [x] 2.3 (GREEN) Apply Option A to `message-bubble.tsx:27` — swap `whitespace-nowrap` → `[overflow-wrap:anywhere]` (or `break-words`). Do NOT touch line 193.
 - [ ] 2.4 (GREEN fallback) If 2.2 short-label single-line assertion fails, switch to Option B: add `w-fit` to bubble card (line 165), keep nowrap on line 27, and update the 2.1 assertion to the `w-fit` mechanism.
 
 ## 3. Testing / Verification (Phase 3)
 
-- [ ] 3.1 `cd apps/web-platform && ./node_modules/.bin/vitest run test/message-bubble-tool-status-chip.test.tsx test/message-bubble-header.test.tsx` — green.
+- [x] 3.1 `cd apps/web-platform && ./node_modules/.bin/vitest run test/message-bubble-tool-status-chip.test.tsx test/message-bubble-header.test.tsx` — green.
 - [ ] 3.2 Run the Playwright e2e (`cc-soleur-go-*`, authenticated project) — both `full` and `sidebar` variants green (no overflow + short-label single-line). Confirm the file matches `testMatch` (`ls e2e/cc-soleur-go-*.e2e.ts`).
-- [ ] 3.3 `tsc --noEmit` clean for `apps/web-platform`.
-- [ ] 3.4 Run `cc-routing-panel-concierge-visibility.test.tsx` + remaining `message-bubble-*` suites — green.
+- [x] 3.3 `tsc --noEmit` clean for `apps/web-platform`.
+- [x] 3.4 Run `cc-routing-panel-concierge-visibility.test.tsx` + remaining `message-bubble-*` suites — green.


### PR DESCRIPTION
## Summary

The Soleur Concierge `ToolStatusChip` status label ("Routing to the right experts...") rendered on a forced single line and spilled past the right border of the bordered Concierge card on the `/soleur:go` chat surface.

This is the inverse failure mode of merged PR #4852, which added a bare `whitespace-nowrap` to the chip label to stop a short label wrapping prematurely. With the bubble's `max-w` cap + `min-w-0` ancestor chain, a label wider than the available card width could neither wrap nor grow — so it overflowed. #4852's own plan named this risk (R4) but never mitigated it in code.

The fix swaps `whitespace-nowrap` for the wrap-capable `min-w-0 [overflow-wrap:anywhere]` idiom already used on the streaming body (`message-bubble.tsx:269`) and user bubble (`:242`). The `min-w-0` ancestor chain — not `nowrap` — is what prevents #4852's premature wrap, so short labels stay single-line when space is available while long labels wrap at the cap instead of spilling. The leader-header `nowrap` (line 193, short leader names) is untouched.

## Changelog

### Web Platform
- Concierge routing-chip / tool-status label now wraps inside its card instead of overflowing the right border on narrow chat columns.

## Test plan

- [x] vitest: re-pointed the #4852 regression test to assert the wrap-capable mechanism (`[overflow-wrap:anywhere]` present, `whitespace-nowrap` absent); full `message-bubble-*` suite green (19/19).
- [x] Playwright (authenticated project): drives the real `isClassifying` routing chip via seeded history; asserts no horizontal overflow + non-vacuity wrap guard at default and narrow viewports. RED-verified — both fail against the pre-fix `nowrap`, pass against the fix.
- [x] `tsc --noEmit` clean; full `scripts/test-all.sh` 98/98 suites green.

## User-Brand Impact

- **Artifact exposed if broken:** the Concierge status text on the brand-visible `/soleur:go` front door looks unpolished (text crossing the card border) on every in-flight turn with a long status label.
- **Vector:** presentational CSS only — no data, auth, API, schema, or migration surface touched.
- **Brand-survival threshold:** aggregate pattern

Generated with [Claude Code](https://claude.com/claude-code)