### PR TITLE
feat(cron): self-armed Inngest oneshot to verify watchdog recovery (#4881 follow-up)

### DIFF
--- a/apps/web-platform/app/api/inngest/route.ts
+++ b/apps/web-platform/app/api/inngest/route.ts
@@ -61,6 +61,7 @@ import { eventCfTokenExpiryCheck } from "@/server/inngest/functions/event-cf-tok
 import { eventShipMerge } from "@/server/inngest/functions/event-ship-merge";
 import { githubOnEvent } from "@/server/inngest/functions/github-on-event";
 import { oneshot4650MonitorClose } from "@/server/inngest/functions/oneshot-4650-monitor-close";
+import { oneshotHeartbeatRecoveryVerify } from "@/server/inngest/functions/oneshot-heartbeat-recovery-verify";
 import { oneshotF2DeferGateReview } from "@/server/inngest/functions/oneshot-f2-defer-gate-review";
 import { oneshotGdprGate50dEval } from "@/server/inngest/functions/oneshot-gdpr-gate-50d-eval";
 import { oneshotRecheck4217Calibration } from "@/server/inngest/functions/oneshot-recheck-4217-calibration";
@@ -123,6 +124,7 @@ export const { GET, POST, PUT } = serve({
     eventShipMerge,
     githubOnEvent,
     oneshot4650MonitorClose,
+    oneshotHeartbeatRecoveryVerify,
     oneshotF2DeferGateReview,
     oneshotGdprGate50dEval,
     oneshotRecheck4217Calibration,

--- a/apps/web-platform/server/index.ts
+++ b/apps/web-platform/server/index.ts
@@ -156,6 +156,41 @@ app.prepare().then(() => {
         });
       }
     })();
+
+    // Self-arm the one-time watchdog-recovery verifier (PR #4881 follow-up).
+    // Fires at 2026-06-04 09:45 UTC (15 min after the daily 09:30 heartbeat) to
+    // confirm the legal-audit/strategy-review false positives do NOT re-fire and
+    // report community-monitor's genuine recovery to #2714. Same deploy-and-forget
+    // contract as the 4650 arm above: stable event `id` dedups across re-deploys,
+    // future-`ts` is the supported delivery primitive, and the oneshot has NO
+    // Sentry monitor so this catch is the only signal for a lost arm.
+    void (async () => {
+      try {
+        const { inngest } = await import("@/server/inngest/client");
+        await sendInngestWithRetry(
+          () =>
+            inngest.send({
+              name: "oneshot/heartbeat-recovery-verify.fire",
+              id: "oneshot-heartbeat-recovery-verify-2026-06-04-v1",
+              ts: new Date("2026-06-04T09:45:00Z").getTime(),
+              data: {
+                expected_date: "2026-06-04",
+                actor: "platform" as const,
+              },
+            }),
+          {
+            feature: "oneshot-heartbeat-recovery-verify-arm",
+            eventId: "oneshot-heartbeat-recovery-verify-2026-06-04-v1",
+          },
+        );
+      } catch (err) {
+        reportSilentFallback(err, {
+          feature: "oneshot-heartbeat-recovery-verify-arm",
+          op: "self-arm-send",
+          message: "failed to arm oneshot-heartbeat-recovery-verify at boot",
+        });
+      }
+    })();
   }
 
   server.listen(port, () => {

--- a/apps/web-platform/server/inngest/functions/oneshot-heartbeat-recovery-verify.ts
+++ b/apps/web-platform/server/inngest/functions/oneshot-heartbeat-recovery-verify.ts
@@ -1,0 +1,242 @@
+// One-time Inngest oneshot: verify the cron-cloud-task-heartbeat watchdog
+// recovery after PR #4881 (false-positive calibration), on/after the
+// 2026-06-04 09:30 UTC heartbeat run.
+//
+// PR #4881 fixed two false-positive [cloud-task-silence] alerts:
+//   - legal-audit (#4875): never-produced grace (zero-rows → pending-first-run).
+//   - strategy-review (#4874): removed from TASK_INVENTORY (conditional producer).
+// This oneshot confirms in production that neither false positive RE-FIRES on
+// the first post-deploy heartbeat run, and reports whether the genuine
+// community-monitor failure (#4876) has recovered. It posts a verification
+// summary to the tracking issue #2714 and routes a REGRESSION (a false positive
+// that came back) to Sentry at error level.
+//
+// Self-armed from server/index.ts boot block (deploy-and-forget) — no manual
+// `inngest send`. Mirrors oneshot-4650-monitor-close.ts (ADR-046).
+//
+// ADR-033 invariants:
+//   I1 — all outbound IO inside step.run (replay memoization).
+//   I2 — operator-owned data only (installation token, no BYOK lease).
+//   I5 — deterministic step.run return shapes (plain JSON union).
+//   I6 — event payload carries actor:"platform".
+// Per ADR-033's prefix table, oneshots get NO Sentry cron monitor (would
+// false-alert on a non-recurring fn); errors route via reportSilentFallback.
+
+import { inngest } from "@/server/inngest/client";
+import { reportSilentFallback, warnSilentFallback } from "@/server/observability";
+import {
+  mintInstallationToken,
+  REPO_OWNER,
+  REPO_NAME,
+  type HandlerArgs,
+} from "./_cron-shared";
+
+const FUNCTION_NAME = "oneshot-heartbeat-recovery-verify";
+
+// The tracking issue this oneshot reports its verdict to.
+const TRACKING_ISSUE = 2714;
+
+// The two false-positive silence-issue titles that MUST NOT reappear after
+// PR #4881. Their presence as an OPEN issue is a regression (error-level).
+const FALSE_POSITIVE_TITLES = [
+  "[cloud-task-silence] legal-audit silent",
+  "[cloud-task-silence] strategy-review silent",
+] as const;
+
+const TOKEN_MIN_LIFETIME_MS = 15 * 60 * 1000;
+
+interface EventData {
+  expected_date: string;
+  date_override?: string;
+  actor?: "platform";
+}
+
+type HandlerResult = { ok: false; reason: string } | { ok: true; reason: string };
+
+// Validate a YYYY-MM-DD string is both well-shaped AND a real calendar date.
+function isValidYmd(s: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
+  const d = new Date(`${s}T00:00:00Z`);
+  return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s;
+}
+
+export async function oneshotHeartbeatRecoveryVerifyHandler({
+  event,
+  step,
+}: HandlerArgs & { event: { data: EventData } }): Promise<HandlerResult> {
+  const { data } = event;
+
+  if (data.date_override !== undefined && !isValidYmd(data.date_override)) {
+    reportSilentFallback(
+      new Error(`Invalid date_override: ${JSON.stringify(data.date_override)}`),
+      {
+        feature: FUNCTION_NAME,
+        op: "date-override-validation",
+        message: "date_override must be a real YYYY-MM-DD date",
+        extra: { fn: FUNCTION_NAME, raw: String(data.date_override).slice(0, 20) },
+      },
+    );
+    return { ok: false, reason: "invalid-date-override" };
+  }
+  if (!isValidYmd(data.expected_date)) {
+    reportSilentFallback(
+      new Error(`Invalid expected_date: ${JSON.stringify(data.expected_date)}`),
+      {
+        feature: FUNCTION_NAME,
+        op: "expected-date-validation",
+        message: "expected_date must be a real YYYY-MM-DD date",
+        extra: { fn: FUNCTION_NAME, raw: String(data.expected_date).slice(0, 20) },
+      },
+    );
+    return { ok: false, reason: "invalid-expected-date" };
+  }
+  const today = data.date_override ?? new Date().toISOString().slice(0, 10);
+  if (today < data.expected_date) {
+    // Early replay/desync — expected and benign, so warn-level (not error).
+    warnSilentFallback(
+      new Error(`date guard: today=${today} < expected=${data.expected_date}`),
+      {
+        feature: FUNCTION_NAME,
+        op: "date-guard",
+        message: "fired before expected_date — no-op",
+        extra: { fn: FUNCTION_NAME, today, expected: data.expected_date },
+      },
+    );
+    return { ok: false, reason: "date-guard" };
+  }
+
+  // --- Step 1: gather verification facts via the installation token --------
+  const facts = await step.run("gather-facts", async () => {
+    const token = await mintInstallationToken({
+      tokenMinLifetimeMs: TOKEN_MIN_LIFETIME_MS,
+    });
+    const { Octokit } = await import("@octokit/core");
+    const octokit = new Octokit({ auth: token });
+
+    // (a) my-fix invariant: NO open silence issue for the two false positives.
+    const openSilence = await octokit.request(
+      "GET /repos/{owner}/{repo}/issues",
+      {
+        owner: REPO_OWNER,
+        repo: REPO_NAME,
+        labels: "cloud-task-silence",
+        state: "open",
+        per_page: 100,
+      },
+    );
+    const openTitles = (openSilence.data as Array<{ title: string }>).map(
+      (i) => i.title,
+    );
+    const regressed = FALSE_POSITIVE_TITLES.filter((t) =>
+      openTitles.includes(t),
+    );
+
+    // (b) community-monitor genuine recovery: did its daily run produce a
+    // recent scheduled-community-monitor issue, and is its silence issue closed?
+    const cmIssues = await octokit.request(
+      "GET /repos/{owner}/{repo}/issues",
+      {
+        owner: REPO_OWNER,
+        repo: REPO_NAME,
+        labels: "scheduled-community-monitor",
+        state: "all",
+        per_page: 1,
+        sort: "created",
+        direction: "desc",
+      },
+    );
+    const cmLatest = (cmIssues.data as Array<{ created_at: string }>)[0];
+    const cmLatestCreatedAt = cmLatest?.created_at ?? null;
+    const cmDaysSince = cmLatestCreatedAt
+      ? Math.floor(
+          (Date.parse(`${today}T23:59:59Z`) - Date.parse(cmLatestCreatedAt)) /
+            (86400 * 1000),
+        )
+      : null;
+    const communityMonitorRecovered =
+      cmDaysSince !== null && cmDaysSince <= 1;
+
+    return {
+      regressed,
+      openSilenceCount: openTitles.length,
+      cmLatestCreatedAt,
+      communityMonitorRecovered,
+    };
+  });
+
+  // --- Step 2: post the verdict to the tracking issue ----------------------
+  await step.run("post-verdict", async () => {
+    const token = await mintInstallationToken({
+      tokenMinLifetimeMs: TOKEN_MIN_LIFETIME_MS,
+    });
+    const { Octokit } = await import("@octokit/core");
+    const octokit = new Octokit({ auth: token });
+
+    const myFixPass = facts.regressed.length === 0;
+    const body = [
+      `## Watchdog recovery verification — ${today} (PR #4881)`,
+      "",
+      `**Calibration fix (deterministic):** ${myFixPass ? "✅ PASS" : "🔴 REGRESSION"}`,
+      myFixPass
+        ? `- No open \`[cloud-task-silence]\` issue for legal-audit or strategy-review reappeared on the post-deploy heartbeat run.`
+        : `- A false positive RE-FIRED: ${facts.regressed.map((t) => `\`${t}\``).join(", ")}. This is a regression in PR #4881.`,
+      "",
+      `**community-monitor genuine recovery:** ${facts.communityMonitorRecovered ? "✅ recovered" : "⏳ not yet"}`,
+      `- Latest \`scheduled-community-monitor\` issue: ${facts.cmLatestCreatedAt ?? "none found"}.`,
+      facts.communityMonitorRecovered
+        ? `- The daily run produced a fresh digest issue (#4770/#4870 deploy effective).`
+        : `- No fresh digest issue yet — community-monitor's daily run may still be failing (tracked by the in-flight community-monitor spawn-liveness work; not a new issue).`,
+      "",
+      `_Open \`cloud-task-silence\` issues at check time: ${facts.openSilenceCount}. content-generator/roadmap-review staying open is EXPECTED (their crons fire after this heartbeat)._`,
+      "",
+      `_Posted by \`${FUNCTION_NAME}\` at ${new Date().toISOString()}. actor: platform._`,
+    ].join("\n");
+
+    try {
+      await octokit.request(
+        "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+        { owner: REPO_OWNER, repo: REPO_NAME, issue_number: TRACKING_ISSUE, body },
+      );
+    } catch (err) {
+      reportSilentFallback(err, {
+        feature: FUNCTION_NAME,
+        op: "post-verdict",
+        message: `failed to comment verdict on #${TRACKING_ISSUE}`,
+        extra: { fn: FUNCTION_NAME, issue: TRACKING_ISSUE },
+      });
+    }
+  });
+
+  // --- Regression is an error; a clean pass is just an info return. --------
+  if (facts.regressed.length > 0) {
+    reportSilentFallback(
+      new Error(
+        `PR #4881 regression: false-positive silence issue(s) re-fired: ${facts.regressed.join(", ")}`,
+      ),
+      {
+        feature: FUNCTION_NAME,
+        op: "calibration-regression",
+        message: "a [cloud-task-silence] false positive re-fired after PR #4881",
+        extra: { fn: FUNCTION_NAME, regressed: facts.regressed },
+      },
+    );
+    return { ok: false, reason: "calibration-regression" };
+  }
+
+  return { ok: true, reason: "verified" };
+}
+
+export const oneshotHeartbeatRecoveryVerify = inngest.createFunction(
+  {
+    id: "oneshot-heartbeat-recovery-verify",
+    concurrency: [
+      { scope: "fn", limit: 1 },
+      { scope: "account", key: '"cron-platform"', limit: 1 },
+    ],
+    retries: 1,
+  },
+  { event: "oneshot/heartbeat-recovery-verify.fire" },
+  oneshotHeartbeatRecoveryVerifyHandler as unknown as Parameters<
+    typeof inngest.createFunction
+  >[2],
+);

--- a/apps/web-platform/test/server/inngest/function-registry-count.test.ts
+++ b/apps/web-platform/test/server/inngest/function-registry-count.test.ts
@@ -128,7 +128,7 @@ describe("Inngest function registry — drift guards", () => {
 
   // UPDATE this number when adding/removing Inngest functions.
   it("(a) route.ts functions array has expected count", () => {
-    expect(routeEntries.length).toBe(48);
+    expect(routeEntries.length).toBe(49);
   });
 
   it("(b) every cron-*.ts file is registered in route.ts functions array", () => {

--- a/apps/web-platform/test/server/inngest/oneshot-heartbeat-recovery-verify.test.ts
+++ b/apps/web-platform/test/server/inngest/oneshot-heartbeat-recovery-verify.test.ts
@@ -1,0 +1,172 @@
+// Unit tests for the one-time watchdog-recovery verifier (PR #4881 follow-up).
+//
+// Coverage:
+//   (a) Registration smoke + source-shape anchors (event name, id).
+//   (b) Handler behavior — date guard, clean-pass verdict, regression detection.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+vi.hoisted(() => {
+  process.env.NEXT_PHASE = "phase-production-build";
+});
+
+const reportSilentFallbackSpy = vi.fn();
+const warnSilentFallbackSpy = vi.fn();
+vi.mock("@/server/observability", () => ({
+  reportSilentFallback: (...a: unknown[]) => reportSilentFallbackSpy(...a),
+  warnSilentFallback: (...a: unknown[]) => warnSilentFallbackSpy(...a),
+}));
+
+const octokitRequestSpy = vi.fn();
+vi.mock("@octokit/core", () => ({
+  Octokit: class {
+    request = (...a: unknown[]) => octokitRequestSpy(...a);
+  },
+}));
+
+vi.mock("@/server/inngest/functions/_cron-shared", () => ({
+  REPO_OWNER: "jikig-ai",
+  REPO_NAME: "soleur",
+  mintInstallationToken: vi.fn().mockResolvedValue("ghs_test_token"),
+}));
+
+import {
+  oneshotHeartbeatRecoveryVerify,
+  oneshotHeartbeatRecoveryVerifyHandler,
+} from "@/server/inngest/functions/oneshot-heartbeat-recovery-verify";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/**
+ * Octokit dispatcher. `openSilenceTitles` are the OPEN cloud-task-silence issue
+ * titles; `cmCreatedAt` is the latest scheduled-community-monitor issue's
+ * created_at (or null for none).
+ */
+function dispatcher(opts: {
+  openSilenceTitles?: string[];
+  cmCreatedAt?: string | null;
+}) {
+  return async (route: string, params: Record<string, unknown> = {}) => {
+    if (route === "GET /repos/{owner}/{repo}/issues") {
+      if (params.labels === "cloud-task-silence") {
+        return { data: (opts.openSilenceTitles ?? []).map((title) => ({ title })) };
+      }
+      if (params.labels === "scheduled-community-monitor") {
+        return {
+          data: opts.cmCreatedAt ? [{ created_at: opts.cmCreatedAt }] : [],
+        };
+      }
+    }
+    // POST comment
+    return { data: {} };
+  };
+}
+
+function makeArgs(data: Record<string, unknown>) {
+  return {
+    event: { data },
+    step: { run: async (_name: string, fn: () => unknown) => fn() },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as unknown as Parameters<typeof oneshotHeartbeatRecoveryVerifyHandler>[0];
+}
+
+describe("oneshotHeartbeatRecoveryVerify — registration", () => {
+  it("loads without throwing", () => {
+    expect(oneshotHeartbeatRecoveryVerify).toBeDefined();
+    expect(typeof oneshotHeartbeatRecoveryVerify).toBe("object");
+  });
+
+  const SUT_SOURCE = readFileSync(
+    resolve(
+      __dirname,
+      "../../../server/inngest/functions/oneshot-heartbeat-recovery-verify.ts",
+    ),
+    "utf-8",
+  );
+
+  it.each([
+    ['id: "oneshot-heartbeat-recovery-verify"', "canonical function id"],
+    ['event: "oneshot/heartbeat-recovery-verify.fire"', "self-armed event name"],
+    ["#2714", "tracking issue reference"],
+  ])("source contains %s (%s)", (anchor) => {
+    expect(SUT_SOURCE).toContain(anchor as string);
+  });
+});
+
+describe("oneshotHeartbeatRecoveryVerifyHandler — behavior", () => {
+  beforeEach(() => {
+    octokitRequestSpy.mockReset();
+    reportSilentFallbackSpy.mockReset();
+    warnSilentFallbackSpy.mockReset();
+  });
+
+  it("fires before expected_date → date-guard no-op, no GitHub calls", async () => {
+    octokitRequestSpy.mockImplementation(dispatcher({}));
+    const out = await oneshotHeartbeatRecoveryVerifyHandler(
+      makeArgs({ expected_date: "2026-06-04", date_override: "2026-06-03" }),
+    );
+    expect(out).toEqual({ ok: false, reason: "date-guard" });
+    expect(warnSilentFallbackSpy.mock.calls[0][1].op).toBe("date-guard");
+    expect(octokitRequestSpy).not.toHaveBeenCalled();
+  });
+
+  it("clean pass → posts verdict to #2714, no regression error", async () => {
+    octokitRequestSpy.mockImplementation(
+      dispatcher({
+        // content-generator/roadmap-review may legitimately still be open;
+        // only legal-audit / strategy-review re-firing is a regression.
+        openSilenceTitles: ["[cloud-task-silence] content-generator silent"],
+        cmCreatedAt: "2026-06-04T08:05:00Z",
+      }),
+    );
+    const out = await oneshotHeartbeatRecoveryVerifyHandler(
+      makeArgs({ expected_date: "2026-06-04", date_override: "2026-06-04" }),
+    );
+    expect(out).toEqual({ ok: true, reason: "verified" });
+    expect(reportSilentFallbackSpy).not.toHaveBeenCalled();
+
+    const post = octokitRequestSpy.mock.calls.find(
+      (c) =>
+        c[0] === "POST /repos/{owner}/{repo}/issues/{issue_number}/comments" &&
+        (c[1] as { issue_number?: number }).issue_number === 2714,
+    );
+    expect(post).toBeDefined();
+    const body = (post![1] as { body: string }).body;
+    expect(body).toContain("✅ PASS");
+    expect(body).toContain("recovered"); // community-monitor produced a fresh issue
+  });
+
+  it("false positive re-fired → reportSilentFallback(calibration-regression)", async () => {
+    octokitRequestSpy.mockImplementation(
+      dispatcher({
+        openSilenceTitles: ["[cloud-task-silence] legal-audit silent"],
+        cmCreatedAt: null,
+      }),
+    );
+    const out = await oneshotHeartbeatRecoveryVerifyHandler(
+      makeArgs({ expected_date: "2026-06-04", date_override: "2026-06-04" }),
+    );
+    expect(out).toEqual({ ok: false, reason: "calibration-regression" });
+    expect(reportSilentFallbackSpy).toHaveBeenCalledTimes(1);
+    expect(reportSilentFallbackSpy.mock.calls[0][1].op).toBe("calibration-regression");
+    // still posts the verdict (REGRESSION) before alerting
+    const post = octokitRequestSpy.mock.calls.find(
+      (c) => c[0] === "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+    );
+    expect((post![1] as { body: string }).body).toContain("🔴 REGRESSION");
+  });
+
+  it("invalid expected_date → reportSilentFallback, no GitHub calls", async () => {
+    octokitRequestSpy.mockImplementation(dispatcher({}));
+    const out = await oneshotHeartbeatRecoveryVerifyHandler(
+      makeArgs({ expected_date: "2026-13-45" }),
+    );
+    expect(out).toEqual({ ok: false, reason: "invalid-expected-date" });
+    expect(reportSilentFallbackSpy.mock.calls[0][1].op).toBe("expected-date-validation");
+    expect(octokitRequestSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to PR #4881 (cron-cloud-task-heartbeat false-positive calibration). Adds a **session-independent, one-time Inngest oneshot** that fires at **2026-06-04 09:45 UTC** (15 min after the daily 09:30 heartbeat) to verify the calibration recovered in production — replacing the fragile session-bound check.

On fire it:
- **Asserts the my-fix invariant (deterministic):** no open `[cloud-task-silence]` issue for **legal-audit** or **strategy-review**. If either re-fired, that's a regression → `reportSilentFallback` at error level.
- **Reports community-monitor's genuine recovery:** whether its daily run produced a fresh `scheduled-community-monitor` issue (within 1 day).
- **Posts a verdict comment to the tracking issue #2714**, noting that content-generator/roadmap-review staying open is *expected* (their crons fire after this heartbeat).

## How it works
Mirrors the existing `oneshot-4650-monitor-close.ts` precedent (ADR-046 self-arm-at-boot, ADR-033 invariants, no Sentry monitor for a non-recurring fn). Armed in `server/index.ts` at boot with a stable event `id` + a future `ts`; Inngest natively schedules the delayed delivery — no `sleepUntil`, no cron, no GitHub-Actions dependency. The container redeploys on merge, arms the event, and Inngest holds it until 09:45 UTC tomorrow.

## Changelog
### Web Platform
- New `oneshot-heartbeat-recovery-verify` Inngest function + registration in `app/api/inngest/route.ts` + self-arm in `server/index.ts`.
- `function-registry-count` drift guard bumped 48→49.
- Unit tests: date-guard no-op, clean-pass verdict, regression detection, invalid-date guard, registration anchors.

## Notes
- **Idempotency:** like the 4650 precedent, a late re-deploy past `ts` (after Inngest's dedup window) could post a duplicate informational comment to #2714 — judged cosmetic by review (no state mutation, self-dated comment, regression alert is real regardless). No change.
- **Pre-existing flake:** `signature-verify*.test.ts` exhibit a known cross-file `NEXT_PHASE` env-leak race in the full `test/server/inngest/` worker-pool run (documented: `2026-04-18-bun-test-env-var-leak-across-files-single-process.md`); green in isolation, in the 3-file combo, and on dir-run retry. Not introduced by this change (the new test follows the same convention as its siblings).

## Test plan
- [x] `vitest run test/server/inngest/oneshot-heartbeat-recovery-verify.test.ts` → 8 passed
- [x] `vitest run test/server/inngest/function-registry-count.test.ts` → green (count 49)
- [x] full `test/server/inngest/` dir green on retry (1340 tests)
- [x] `tsc --noEmit` clean
- [x] Focused review (code-reviewer) → green; event trust boundary + ADR-033 invariants verified

references #2714

Generated with [Claude Code](https://claude.com/claude-code)
