### PR TITLE
fix(deploy): report inngest-heartbeat.timer liveness in deploy-state JSON (#4896)

### DIFF
--- a/apps/web-platform/infra/cat-deploy-state.sh
+++ b/apps/web-platform/infra/cat-deploy-state.sh
@@ -106,10 +106,9 @@ HEARTBEAT_STATUS="$(service_status inngest-heartbeat.service)"
 # inngest-heartbeat.timer (OnUnitActiveSec=60s, inngest-bootstrap.sh:216-245). It
 # reports `inactive` from `systemctl is-active` as soon as each 60s ExecStart
 # completes successfully — i.e. `inactive` is the NORMAL, healthy steady state
-# between fires, NOT a fault. (`failed` here is the real fault, e.g. the empty-URL
-# #4116 class.) The durable liveness signal is the TIMER's active-state below;
-# read both so a healthy oneshot never again mis-frames a deploy incident the way
-# #4896 read `inngest_heartbeat: inactive` as the root cause when it was a red herring.
+# between fires, NOT a fault (`failed` is the real fault, e.g. the empty-URL
+# #4116 class). The durable liveness signal is the TIMER's active-state below;
+# read both so `inactive` alone is never re-read as a deploy failure (#4896).
 HEARTBEAT_TIMER_STATUS="$(service_status inngest-heartbeat.timer)"
 INNGEST_SERVER_STATUS="$(service_status inngest-server.service)"
 VECTOR_STATUS="$(service_status vector.service)"

--- a/apps/web-platform/infra/cat-deploy-state.sh
+++ b/apps/web-platform/infra/cat-deploy-state.sh
@@ -3,10 +3,12 @@ set -euo pipefail
 
 # Read-only deploy state reporter for #2185 webhook observability.
 # Invoked by /hooks/deploy-status (adnanh/webhook) -- see hooks.json.tmpl.
-# Returns the JSON written by ci-deploy.sh write_state, MERGED with a
-# `services.inngest_heartbeat` field reading live `systemctl is-active`
-# state (#4116 — discoverability_test for the new plan-skill observability
-# gate). Sentinels:
+# Returns the JSON written by ci-deploy.sh write_state, MERGED with live
+# `systemctl is-active` fields: `services.inngest_heartbeat` (the oneshot
+# .service, #4116 — discoverability_test for the plan-skill observability gate)
+# and `services.inngest_heartbeat_timer` (the .timer, #4896 — the durable
+# liveness signal; the oneshot .service reads `inactive` as its healthy steady
+# state, so the timer's active-state is what proves liveness). Sentinels:
 #   {"exit_code":-2,"reason":"no_prior_deploy"} -- no state file exists
 #   {"exit_code":-3,"reason":"corrupt_state"}   -- state file unparseable
 # Exit-code protocol defined in ci-deploy.sh header (#2205).
@@ -100,6 +102,15 @@ inngest_crons_json() {
 }
 
 HEARTBEAT_STATUS="$(service_status inngest-heartbeat.service)"
+# inngest-heartbeat.service is a Type=oneshot unit (no RemainAfterExit) driven by
+# inngest-heartbeat.timer (OnUnitActiveSec=60s, inngest-bootstrap.sh:216-245). It
+# reports `inactive` from `systemctl is-active` as soon as each 60s ExecStart
+# completes successfully — i.e. `inactive` is the NORMAL, healthy steady state
+# between fires, NOT a fault. (`failed` here is the real fault, e.g. the empty-URL
+# #4116 class.) The durable liveness signal is the TIMER's active-state below;
+# read both so a healthy oneshot never again mis-frames a deploy incident the way
+# #4896 read `inngest_heartbeat: inactive` as the root cause when it was a red herring.
+HEARTBEAT_TIMER_STATUS="$(service_status inngest-heartbeat.timer)"
 INNGEST_SERVER_STATUS="$(service_status inngest-server.service)"
 VECTOR_STATUS="$(service_status vector.service)"
 VECTOR_JOURNAL_TAIL="$(service_journal_tail vector.service)"
@@ -120,6 +131,7 @@ fi
 jq -nc \
   --argjson base "$BASE" \
   --arg hb "$HEARTBEAT_STATUS" \
+  --arg hbt "$HEARTBEAT_TIMER_STATUS" \
   --arg is "$INNGEST_SERVER_STATUS" \
   --arg vs "$VECTOR_STATUS" \
   --arg vj "$VECTOR_JOURNAL_TAIL" \
@@ -127,6 +139,7 @@ jq -nc \
   --argjson js "$JOURNALD_STORAGE" \
   '$base + {journald_storage: $js, services: (($base.services // {}) + {
     inngest_heartbeat: $hb,
+    inngest_heartbeat_timer: $hbt,
     inngest_server: $is,
     vector: $vs,
     vector_journal_tail: $vj,

--- a/apps/web-platform/infra/cat-deploy-state.test.sh
+++ b/apps/web-platform/infra/cat-deploy-state.test.sh
@@ -38,6 +38,8 @@ assert "no_prior_deploy sentinel exit_code = -2" \
   "[[ \$(printf '%s' '$NO_DEPLOY_OUT' | jq -r .exit_code) == '-2' ]]"
 assert "no_prior_deploy carries services.inngest_heartbeat" \
   "printf '%s' '$NO_DEPLOY_OUT' | jq -e '.services.inngest_heartbeat' >/dev/null"
+assert "no_prior_deploy carries services.inngest_heartbeat_timer" \
+  "printf '%s' '$NO_DEPLOY_OUT' | jq -e '.services.inngest_heartbeat_timer' >/dev/null"
 
 # --- successful state file merge ---
 echo '{"exit_code":0,"target":"inngest","tag":"vinngest-v1.2.3"}' > "$TMP/ok.state"
@@ -48,6 +50,8 @@ assert "OK state preserves target field" \
   "[[ \$(printf '%s' '$OK_OUT' | jq -r .target) == 'inngest' ]]"
 assert "OK state injects services.inngest_heartbeat" \
   "printf '%s' '$OK_OUT' | jq -e '.services.inngest_heartbeat' >/dev/null"
+assert "OK state injects services.inngest_heartbeat_timer" \
+  "printf '%s' '$OK_OUT' | jq -e '.services.inngest_heartbeat_timer' >/dev/null"
 
 # --- pre-existing services.* keys preserved ---
 echo '{"exit_code":0,"services":{"web":"healthy"}}' > "$TMP/svc.state"
@@ -56,6 +60,8 @@ assert "pre-existing services.web preserved" \
   "[[ \$(printf '%s' '$SVC_OUT' | jq -r .services.web) == 'healthy' ]]"
 assert "services.inngest_heartbeat still added alongside services.web" \
   "printf '%s' '$SVC_OUT' | jq -e '.services.inngest_heartbeat' >/dev/null"
+assert "services.inngest_heartbeat_timer still added alongside services.web" \
+  "printf '%s' '$SVC_OUT' | jq -e '.services.inngest_heartbeat_timer' >/dev/null"
 
 # --- corrupt state sentinel ---
 echo 'not valid json {' > "$TMP/corrupt.state"
@@ -64,6 +70,8 @@ assert "corrupt_state sentinel exit_code = -3" \
   "[[ \$(printf '%s' '$CORRUPT_OUT' | jq -r .exit_code) == '-3' ]]"
 assert "corrupt_state carries services.inngest_heartbeat" \
   "printf '%s' '$CORRUPT_OUT' | jq -e '.services.inngest_heartbeat' >/dev/null"
+assert "corrupt_state carries services.inngest_heartbeat_timer" \
+  "printf '%s' '$CORRUPT_OUT' | jq -e '.services.inngest_heartbeat_timer' >/dev/null"
 
 echo ""
 echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="

--- a/knowledge-base/engineering/operations/post-mortems/web-platform-deploy-stuck-oneshot-misreport-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/web-platform-deploy-stuck-oneshot-misreport-postmortem.md
@@ -1,0 +1,192 @@
+---
+title: "web-platform deploys stuck on stale image — #4886 .cron ENOSPC + oneshot-heartbeat misreport"
+date: 2026-06-03
+incident_pr: 4886
+incident_window: "2026-06-03 17:24Z–18:00Z"
+recovery_at: "2026-06-03 18:00Z"
+suspected_change: "#4886 (cron-workspace-gc: sudo mkdir -p /mnt/data/workspaces/.cron added to ci-deploy.sh critical path)"
+brand_survival_threshold: aggregate pattern
+status: resolved
+triggers:
+  - deploy-pipeline availability (web-platform-release.yml deploy-completion gate)
+art_33_triggered: false
+art_34_triggered: false
+art_33_deadline: "n/a — availability/deploy incident, no personal-data exposure"
+---
+
+## Actor key
+
+- `agent` — Claude Code did this autonomously (no operator ack required).
+- `agent-with-ack` — Claude Code did this AFTER operator confirmed via menu option per `hr-menu-option-ack-not-prod-write-auth`.
+- `human` — Operator did this directly.
+
+# Incident Overview
+
+`web-platform-release.yml` deploy jobs failed on three consecutive merges to `main`
+(17:24–17:42 UTC, 2026-06-03), leaving production stuck on a stale image
+(`v0.101.100`). Each run exited non-zero at the "Verify deploy script completion"
+step with `reason=unhandled`. The failure JSON also reported
+`services.inngest_heartbeat: inactive`, which the `/ship` Phase 7 post-merge
+auto-filer surfaced as the suspected root signal when it filed #4896 — a
+misdiagnosis. The real cause was an ENOSPC `mkdir` introduced by #4886 on the
+already-full shared volume; recovery came from #4895's revert at 18:00 UTC.
+
+## Status
+
+resolved — recovered by #4895 (`fix(cron): revert .cron isolation that deadlocked
+the deploy on a full volume`); production current on `v0.102.0` (build `f78bb0a1`).
+
+## Symptom
+
+- 3 consecutive `web-platform-release.yml` deploy failures (17:24 / 17:35 / 17:42
+  UTC) at the deploy-completion gate, all `reason=unhandled`.
+- Production `/health` stuck on `v0.101.100`; new merges merged-but-not-deployed.
+- Failure JSON showed `services.inngest_heartbeat: inactive`, `inngest_server: active`,
+  `vector: active`, `journald_storage.persistent: false`, `root_avail: 54G`.
+
+## Incident Timeline
+
+- **Start time (detected):** 2026-06-03 ~17:42Z (third consecutive failure / #4887 ship session)
+- **End time (recovered):** 2026-06-03 18:00Z
+- **Duration (MTTR):** ~18 minutes (from detection to #4895 merge + first green deploy)
+
+| Actor | Time (UTC) | Action |
+|---|---|---|
+| agent | 17:24 | Deploy for #4886 (`1998af5f`) fails at completion gate (`reason=unhandled`). |
+| agent | 17:35 | Deploy for #4871 (`251b80ea`) fails (same gate). |
+| agent | 17:42 | Deploy for #4887 (`4d1e1cb8`) fails (same gate); /ship Phase 7 auto-filer opens #4896, naming `inngest_heartbeat: inactive` as the suspected root signal. |
+| agent | ~18:00 | #4895 reverts the `.cron` mkdir + repoints `CRON_WORKSPACE_ROOT` to `/workspaces`. |
+| agent | 18:00 | Deploy for `b06de5b6` (#4895) succeeds. Queue unstuck. |
+| agent | 18:06 / 18:17 | Subsequent deploys (`1350733f`, `f78bb0a1`) succeed; prod swaps to `v0.102.0`. |
+
+## Participants and Systems Involved
+
+`web-platform-release.yml` (deploy-completion gate), `ci-deploy.sh` (EXIT trap +
+`final_write_state`), `cat-deploy-state.sh` (deploy-status reporter), the shared
+20 GB `/mnt/data` volume (full — the #4882 ENOSPC condition), `cron-workspace-gc`
+(the GC introduced by #4886).
+
+## Detection (+ MTTD)
+
+- **How detected:** automated — the `/ship` Phase 7 post-merge release-verification
+  step (which monitors `web-platform-release.yml`) caught the failed deploys and
+  filed #4896.
+- **MTTD:** ~18 min from the first failed deploy (17:24) to the filing during the
+  #4887 ship session. The three-deploy gap is the cost of not failing the merge
+  itself on a failed *deploy* (merge CI and deploy are decoupled).
+
+## Triggered by
+
+system — a code change (#4886) interacting with a pre-existing degraded
+environment (the full `/mnt/data` volume, #4882).
+
+## Root-cause hypothesis (triage)
+
+| Hypothesis | Supporting evidence | Disconfirming evidence | Status |
+|---|---|---|---|
+| `inngest_heartbeat: inactive` = broken heartbeat unit (the #4896 framing) | field present in failure JSON | gate never reads the field (`grep -c inngest_heartbeat web-platform-release.yml` = 0); `inactive` is the healthy steady state for a `Type=oneshot` timer-driven unit | REJECTED (red herring) |
+| #4886 moved/broke the heartbeat systemd unit or its storage | #4886 touched the cron substrate | `#4886 --stat` touches none of `inngest-bootstrap.sh`/`inngest.tf`; heartbeat unit untouched | REJECTED |
+| #4886's `sudo mkdir -p /mnt/data/workspaces/.cron` ENOSPC'd under `set -e` | full 20 GB volume (#4882); mkdir on critical path; EXIT trap wrote `reason=unhandled` | — | CONFIRMED |
+
+## Resolution
+
+#4895 reverted #4886's `.cron` mkdir and repointed `CRON_WORKSPACE_ROOT` back to
+`/workspaces`, removing the ENOSPC-on-critical-path failure. Deploys recovered
+immediately (success at 18:00 / 18:06 / 18:17 UTC).
+
+## Recovery verification
+
+`gh run list --workflow=web-platform-release.yml` shows `success` from `b06de5b6`
+(#4895) onward; `https://app.soleur.ai/health` returns `version: 0.102.0,
+build_sha: f78bb0a1, status: ok`. Both verified read-only (no SSH) at PIR-write time.
+
+---
+
+# Incident Post-Mortem Analysis
+
+## Root Cause(s) — 5-Whys
+
+1. **Why did deploys fail?** The deploy-completion gate saw `reason=unhandled`.
+2. **Why `reason=unhandled`?** `ci-deploy.sh` exited non-zero without calling
+   `final_write_state`, so the `EXIT` trap wrote the `unhandled` sentinel.
+3. **Why did `ci-deploy.sh` exit non-zero?** `sudo mkdir -p /mnt/data/workspaces/.cron`
+   (added by #4886) failed with ENOSPC under `set -e`.
+4. **Why ENOSPC?** The shared 20 GB `/mnt/data` volume was already full (the #4882
+   condition — leaked cron clones), and #4886 put a new write on the deploy's
+   critical path.
+5. **Why was this misdiagnosed as a heartbeat fault?** `cat-deploy-state.sh`
+   reported `inngest_heartbeat` from the **oneshot** `.service`, whose healthy
+   steady state is `inactive`; the auto-filer read the correlated field as causal.
+
+**Final root cause:** a new critical-path filesystem write (#4886) on a full
+volume, compounded by a deploy-status reporter that surfaced a misleading
+oneshot-unit state, steering the first triage at the wrong subsystem.
+
+## Versions of Components
+
+- **Version(s) that triggered the outage:** `v0.102.0` build attempt for #4886 (deploy failed; prod stayed on `v0.101.100`).
+- **Version(s) that restored the service:** `v0.102.0` via #4895 (`b06de5b6`).
+
+## Impact details
+
+### Services Impacted
+
+web-platform deploy pipeline (3 deploys stuck). Production *serving* was unaffected
+— it continued serving the last good image (`v0.101.100`); only the deploy of newer
+code was blocked.
+
+### Customer Impact (by role)
+
+- Prospect: none (marketing/app served normally on the prior image).
+- Authenticated app user: none observable — prod stayed healthy on `v0.101.100`; only *new* code was delayed ~36 min.
+- Legal-document signer: none.
+- Admin via Access: none.
+- Billing customer: none.
+- OAuth installation owner: none.
+
+### Revenue Impact
+
+None.
+
+### Team Impact
+
+~1 ship session of triage misdirection (the `inngest_heartbeat` red herring) before
+#4895's revert landed.
+
+## Lessons Learned
+
+### Where we got lucky
+
+The three stuck deploys were all low-risk (a workspace-pill UI change and two
+docs/KB refactors), so the ~36-min stale-code window had no user-facing
+consequence. A user-facing hotfix stuck behind the same gate would have been an
+actual outage.
+
+### What went well
+
+- The `/ship` post-merge release-verification auto-filer caught the silent deploy
+  failures and opened an issue rather than letting them rot (this is exactly the
+  "merged ≠ deployed" gap the gate exists to close).
+- #4895's revert was fast and surgical.
+
+### What went wrong
+
+- A new filesystem write was added to the deploy's critical path without guarding
+  against the known-full shared volume (#4882).
+- The deploy-status reporter surfaced a `Type=oneshot` unit's transient `inactive`
+  state as if it were a liveness fault, steering triage at the wrong subsystem and
+  costing a misdiagnosis (the #4896 framing).
+
+## Follow-ups
+
+- [x] Fix the reporter misreport: add `services.inngest_heartbeat_timer` (durable
+      liveness) + document the oneshot steady-state semantics — **this PR** (Ref #4896).
+- [ ] Dedicated cron-clone volume / capacity isolation so the shared `/mnt/data`
+      volume cannot ENOSPC the deploy critical path — tracked in #4891 (open).
+- [ ] journald `persistent: false` on the host (orthogonal) — tracked in #4792.
+
+## Action Items
+
+- Reporter misreport fix — **this PR** (Ref #4896); closes the mis-signal class.
+- Capacity isolation for cron clones — #4891 (deferred, open).
+- journald persistence — #4792 (deferred, open).

--- a/knowledge-base/project/learnings/best-practices/2026-06-03-oneshot-systemd-unit-inactive-is-healthy-report-the-timer.md
+++ b/knowledge-base/project/learnings/best-practices/2026-06-03-oneshot-systemd-unit-inactive-is-healthy-report-the-timer.md
@@ -1,0 +1,84 @@
+---
+title: "A Type=oneshot systemd unit reports `inactive` as its HEALTHY steady state — report the .timer for liveness"
+date: 2026-06-03
+category: best-practices
+module: apps/web-platform/infra
+tags: [systemd, observability, deploy-status, oneshot, timer, incident-triage]
+issue: 4896
+related_prs: [4895, 4886]
+---
+
+# `systemctl is-active` on a `Type=oneshot` timer-driven unit reads `inactive` when healthy
+
+## Problem
+
+Issue #4896 reported web-platform deploys "failing since #4886" with the root
+signal `inngest_heartbeat: inactive` in the deploy-status JSON, framing the
+cause as "#4886 moved/broke the heartbeat systemd unit or its storage path" and
+asking to "restore the heartbeat service."
+
+Two things were wrong with that framing:
+
+1. **The incident had already self-resolved.** PR #4895 (the revert cited *in
+   the issue body itself*) merged at 18:00 UTC; `gh run list
+   --workflow=web-platform-release.yml` showed `success` from `b06de5b6`
+   onward and `/health` already reported v0.102.0. The deploy queue was
+   unstuck before the issue was even triaged. The actual cause was #4886's
+   `sudo mkdir -p /mnt/data/workspaces/.cron` ENOSPC-ing under `set -e` on the
+   already-full volume → `ci-deploy.sh`'s EXIT trap wrote `reason=unhandled`.
+
+2. **`inngest_heartbeat: inactive` was a red herring, never the gate input.**
+   The deploy-completion gate (`web-platform-release.yml`) keys ONLY on
+   `exit_code`/`reason` — `grep -c inngest_heartbeat` against it returns **0**.
+   The field is reporter-only (`cat-deploy-state.sh`).
+
+## Key Insight
+
+`inngest-heartbeat.service` is a `Type=oneshot` unit (no `RemainAfterExit=yes`)
+driven by `inngest-heartbeat.timer` (`OnUnitActiveSec=60s`). `systemctl
+is-active` returns `inactive` the instant a oneshot's `ExecStart` completes
+successfully — so **`inactive` is the NORMAL, healthy steady state between the
+60s timer fires**, not a fault. A reporter that surfaces only the `.service`
+state shows `inactive` on a perfectly healthy host, which is exactly the
+misleading signal that mis-framed this incident (a /ship auto-filer read the
+correlated field as the root cause).
+
+For a timer-driven oneshot, the durable liveness signal is the **`.timer`'s**
+active-state (`active` on a healthy host), NOT the `.service`'s transient state.
+Report both:
+
+- `.timer` `active` → liveness (the schedule is still running)
+- `.service` `failed` → the real fault (e.g. the empty-URL #4116 class)
+- `.service` `inactive` → healthy between fires (do not alert on this)
+
+## Solution
+
+Add a parallel `services.inngest_heartbeat_timer` field to
+`cat-deploy-state.sh` reading `systemctl is-active inngest-heartbeat.timer`, via
+the existing best-effort `service_status()` helper + `--arg`/`jq` emit (same
+shape as the three existing `.service` readers). Retain the `.service` field for
+fault detection. Document the oneshot steady-state semantics inline so the next
+operator/auto-filer does not re-read `inactive` as a failure. Touch no systemd
+unit and no gate logic.
+
+## What NOT to do
+
+- **Do NOT add `RemainAfterExit=yes`** to make `is-active` read `active` — that
+  mutates a healthy unit's semantics on the prod host (a redeploy, larger blast
+  radius) to paper over a reporter bug.
+- **Do NOT gate the deploy on `inngest_heartbeat == active`** — a healthy
+  oneshot is `inactive`, so this would fail *every* healthy deploy. This is the
+  wrong fix the issue's framing nudges toward.
+
+## Generalizable lesson
+
+When a deploy-status / health reporter surfaces `systemctl is-active <unit>` and
+`<unit>` is `Type=oneshot` driven by a `.timer`, report the **timer's** state as
+the liveness signal. A bare `is-active` read of the oneshot service is a
+guaranteed false `inactive` between fires. Incident-triage corollary: when an
+issue cites a revert PR in its own body, verify current state (`gh run list` +
+`/health`) before planning a fix — the incident may already be resolved.
+
+## Tags
+category: best-practices
+module: apps/web-platform/infra

--- a/knowledge-base/project/plans/2026-06-03-fix-inngest-heartbeat-oneshot-misreport-and-confirm-deploy-recovery-plan.md
+++ b/knowledge-base/project/plans/2026-06-03-fix-inngest-heartbeat-oneshot-misreport-and-confirm-deploy-recovery-plan.md
@@ -160,29 +160,29 @@ is present.)
 
 ### Pre-merge (PR)
 
-- [ ] **AC1 — Recovery confirmed read-only.** Plan body (Phase 0) records: latest
+- [x] **AC1 — Recovery confirmed read-only.** Plan body (Phase 0) records: latest
       `web-platform-release.yml` run conclusion = `success`; `/health` `version` ≥
       `0.102.0`; the three issue-cited failing runs are all strictly before the first
       post-#4895 success. Verification commands are baked into Phase 0, no SSH.
-- [ ] **AC2 — Reporter reports the durable liveness signal.** `cat-deploy-state.sh`
+- [x] **AC2 — Reporter reports the durable liveness signal.** `cat-deploy-state.sh`
       adds an `inngest_heartbeat_timer` field reading `systemctl is-active
       inngest-heartbeat.timer` (the timer is `active` on a healthy host), and the
       existing `inngest_heartbeat` (oneshot `.service`) field is retained with an
       inline comment documenting that `inactive` is the expected steady state for a
       timer-driven oneshot. Verified by `jq -e '.services.inngest_heartbeat_timer'`
       against a synthesized state fixture.
-- [ ] **AC3 — Test coverage.** `cat-deploy-state.test.sh` asserts the new
+- [x] **AC3 — Test coverage.** `cat-deploy-state.test.sh` asserts the new
       `inngest_heartbeat_timer` field is present across all 4 base-state branches
       (no_prior_deploy, OK, services-merge, corrupt_state), mirroring the existing
       `inngest_heartbeat` assertions at `cat-deploy-state.test.sh:39-66`. Run:
       `bash apps/web-platform/infra/cat-deploy-state.test.sh` — exits 0, all asserts pass.
-- [ ] **AC4 — No gate-logic change.** `git diff` shows zero edits to
+- [x] **AC4 — No gate-logic change.** `git diff` shows zero edits to
       `web-platform-release.yml` and zero edits to the `inngest-heartbeat.{service,timer}`
       heredocs in `inngest-bootstrap.sh` (this plan does NOT touch the unit; it fixes
       only the reporter). Grep-verify: `git diff --name-only` contains
       `cat-deploy-state.sh` + `cat-deploy-state.test.sh` and NOT `inngest-bootstrap.sh`
       or `web-platform-release.yml`.
-- [ ] **AC5 — Full infra test suite green.** The owning suite passes:
+- [x] **AC5 — Full infra test suite green.** The owning suite passes:
       `bash apps/web-platform/infra/cat-deploy-state.test.sh` AND any harness that
       exercises the reporter (confirm the runner in Phase 0 via `ls
       apps/web-platform/infra/*.test.sh`; do not assume a framework).

--- a/knowledge-base/project/plans/2026-06-03-fix-inngest-heartbeat-oneshot-misreport-and-confirm-deploy-recovery-plan.md
+++ b/knowledge-base/project/plans/2026-06-03-fix-inngest-heartbeat-oneshot-misreport-and-confirm-deploy-recovery-plan.md
@@ -15,6 +15,54 @@ related_issues: [4891, 4882, 4881, 4650, 4652, 4116]
 > Note: this one-shot path ran no brainstorm; no `spec.md` exists for the branch, so
 > `lane:` defaulted to `cross-domain` (TR2 fail-closed).
 
+## Enhancement Summary
+
+**Deepened on:** 2026-06-03
+**Halt gates passed:** 4.6 User-Brand Impact (threshold `aggregate pattern`), 4.7
+Observability (5/5 fields, no-SSH discoverability_test), 4.8 PAT-shaped (none), 4.9
+UI-wireframe (no UI surface — skipped).
+
+### Key verifications (all live, this pass)
+
+1. **Premise is stale — recovery already happened.** `gh run list --workflow=web-platform-release.yml`:
+   failures at `1998af5f`/`251b80ea`/`4d1e1cb8` (17:24–17:42), then **success** from
+   `b06de5b6` (#4895, 18:00) onward (18:00/18:06/18:17). `/health` = v0.102.0, build
+   `f78bb0a1`. Deploy queue unstuck, prod current.
+2. **Gate does NOT read `inngest_heartbeat`.** `git show origin/main:.github/workflows/web-platform-release.yml
+   | grep -c inngest_heartbeat` → **0**. The completion gate keys only on
+   `exit_code`/`reason`. The field is a reporter-only red herring. (Confirms the
+   Research Reconciliation row + the load-bearing Sharp Edge.)
+3. **#4886 did NOT touch the heartbeat unit or its storage.** `git show 1998af5f --stat`
+   touches none of `inngest-bootstrap.sh` / `inngest.tf` / `cat-deploy-state.sh`. The
+   "moved/broke the heartbeat systemd unit or its storage path" premise is false.
+4. **The oneshot-is-inactive-is-healthy claim is grounded in code.** `inngest-bootstrap.sh:216-245`
+   defines `inngest-heartbeat.service` as `Type=oneshot` (no `RemainAfterExit`) driven by
+   `inngest-heartbeat.timer` (`OnUnitActiveSec=60s`). `cron-inngest-cron-watchdog.ts:14`:
+   "The /health heartbeat (inngest-heartbeat.timer → Better Stack) proves only process liveness."
+5. **No new scheduled job introduced (Phase 4.4).** 39 existing `cron-*` Inngest functions;
+   the plan only *fires* the existing `cron-workspace-gc` manual-trigger
+   (`cron-manifest.ts:60`) as the no-SSH reclaim lever — no new cron, Inngest path already
+   canonical (ADR-033). No GH-Actions-cron anti-pattern.
+6. **All cited refs verified live:** #4886 MERGED, #4895 MERGED, #4891 OPEN (deferred
+   capacity work), #4882 CLOSED (incident origin), #4881 MERGED, #4650/#4652/#4116/#4792
+   CLOSED, #4890 MERGED.
+
+### Precedent-Diff Gate (Phase 4.4 — pattern-bound reader extension)
+
+The new `inngest_heartbeat_timer` field extends the **existing** `service_status` reader
+pattern in `cat-deploy-state.sh`, which already reads three units verbatim:
+
+```
+HEARTBEAT_STATUS="$(service_status inngest-heartbeat.service)"   # :102
+INNGEST_SERVER_STATUS="$(service_status inngest-server.service)" # :103
+VECTOR_STATUS="$(service_status vector.service)"                 # :104
+```
+
+The plan's `HEARTBEAT_TIMER_STATUS="$(service_status inngest-heartbeat.timer)"` is the
+same shape (same helper, same `--arg`/`jq` emit). **Precedent exists; pattern is not
+novel** — the change is a fourth identical reader call + one `jq` key, the lowest-risk
+form. No `SECURITY DEFINER`, atomic-write, lock, or RPC-permission surface involved.
+
 ## Overview
 
 Issue #4896 reports that web-platform deploys have failed on 3 consecutive merges

--- a/knowledge-base/project/plans/2026-06-03-fix-inngest-heartbeat-oneshot-misreport-and-confirm-deploy-recovery-plan.md
+++ b/knowledge-base/project/plans/2026-06-03-fix-inngest-heartbeat-oneshot-misreport-and-confirm-deploy-recovery-plan.md
@@ -1,0 +1,328 @@
+---
+title: "fix(deploy): correct oneshot heartbeat misreport + confirm #4886 deploy recovery (#4896)"
+date: 2026-06-03
+type: ops-remediation
+classification: ops-only-prod-write
+lane: cross-domain
+brand_survival_threshold: aggregate pattern
+issue: 4896
+related_prs: [4886, 4895]
+related_issues: [4891, 4882, 4881, 4650, 4652, 4116]
+---
+
+# fix(deploy): correct oneshot heartbeat misreport + confirm #4886 deploy recovery (#4896)
+
+> Note: this one-shot path ran no brainstorm; no `spec.md` exists for the branch, so
+> `lane:` defaulted to `cross-domain` (TR2 fail-closed).
+
+## Overview
+
+Issue #4896 reports that web-platform deploys have failed on 3 consecutive merges
+since #4886, the deploy-completion gate fails with `reason=unhandled`, the root
+signal is `inngest_heartbeat: inactive`, and prod is stuck on a stale image
+(v0.101.100). It asks us to root-cause #4886's cron/KB-volume isolation change as
+having "moved/broken the heartbeat systemd unit or its storage path," restore the
+heartbeat service, and unstick the deploy queue.
+
+**Premise validation (Phase 0.6) found the premise substantially stale.** The
+incident is already resolved by PR #4895 (the revert cited in the issue), which
+merged at 2026-06-03 18:00:06 UTC. Verified facts as of plan-write time:
+
+- **Deploy queue is unstuck.** `gh run list --workflow=web-platform-release.yml`
+  shows the three failures at 17:24 / 17:35 / 17:42 (exactly the issue's table),
+  then **success** at 18:00, 18:06, and 18:17 — all after #4895's revert.
+- **Prod is current, not stale.** `https://app.soleur.ai/health` returns
+  `version: 0.102.0, build_sha: f78bb0a1` (the latest merge #4890), uptime ~54 min.
+  v0.101.100 is gone; prod swapped forward.
+- **#4886 did NOT break the heartbeat systemd unit.** `inngest-bootstrap.sh`'s
+  `inngest-heartbeat.{service,timer}` and `HEARTBEAT_SCRIPT` were untouched by
+  #4886 (its diff touched only `ci-deploy.sh` line 432-465 — the `.cron` mkdir +
+  `CRON_WORKSPACE_ROOT` — plus the GC function and tests). No storage-path move.
+- **The actual gate failure was `.cron` mkdir ENOSPC under `set -e`.** #4886 added
+  `sudo mkdir -p /mnt/data/workspaces/.cron` to ci-deploy.sh's critical path. On
+  the already-full 20 GB shared volume (the exact #4882 ENOSPC state), the mkdir
+  failed under `set -e`, ci-deploy.sh exited without calling `final_write_state`,
+  and the `EXIT` trap (`ci-deploy.sh:111`) wrote `reason=unhandled`. #4895 reverted
+  the mkdir and pointed `CRON_WORKSPACE_ROOT` back to `/workspaces`.
+- **`inngest_heartbeat: inactive` was a red herring, not the gate input.** The
+  "Verify deploy script completion" gate (`web-platform-release.yml:356-382`) keys
+  **only** on `exit_code` and `reason`. It never reads `services.inngest_heartbeat`.
+  The field is reported by `cat-deploy-state.sh:102,129` via `systemctl is-active
+  inngest-heartbeat.service` and was surfaced in the failure JSON only because the
+  reporter always attaches it — the /ship Phase 7 auto-filer (who filed #4896)
+  mis-read the correlated field as the root signal.
+
+There IS a genuine latent bug worth fixing, distinct from the (already-reverted)
+deadlock: **`inngest-heartbeat.service` is a `Type=oneshot` unit driven by
+`inngest-heartbeat.timer`** (`inngest-bootstrap.sh:216-245`). A oneshot unit
+without `RemainAfterExit=yes` reports `inactive` from `systemctl is-active` as soon
+as its `ExecStart` completes successfully — i.e. **`inactive` is the NORMAL,
+healthy steady state between the 60s timer fires**, not a fault. `cat-deploy-state.sh`
+reports the `.service` state, so the deploy-status JSON shows `inactive` on a
+perfectly healthy host, which is exactly the misleading signal that mis-framed this
+incident. The watchdog code comment confirms the design:
+`cron-inngest-cron-watchdog.ts:14` — "The /health heartbeat
+(inngest-heartbeat.timer → Better Stack) proves only process liveness."
+
+This plan therefore does NOT "restore a broken heartbeat" (it was never broken). It:
+
+1. **Confirms recovery is durable** (read-only verification — no prod write needed).
+2. **Fixes the latent observability misreport** so a healthy oneshot heartbeat never
+   again reads as a scary `inactive` and mis-frames the next incident: report the
+   `.timer`'s active state (the durable liveness signal) alongside (or instead of)
+   the oneshot `.service`'s transient state.
+3. **Closes #4896 with the corrected RCA** (post-merge, `gh issue close`), referencing
+   #4895 as the actual fix and #4891 as the deferred capacity work.
+
+This is a small, surgical change to a read-only no-SSH reporter plus its test, framed
+as the durable fix for the mis-signal — NOT a re-litigation of the #4895 revert.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Issue/premise claim | Codebase reality (verified) | Plan response |
+|---|---|---|
+| "deploys failing since #4886, prod stuck on v0.101.100" | `gh run list` shows success at 18:00/18:06/18:17 post-#4895; `/health` = v0.102.0 build f78bb0a1, uptime ~54m | Already recovered. Plan confirms read-only; no re-deploy needed. |
+| "deploy-completion gate fails with `reason=unhandled`" | Gate (`web-platform-release.yml:356-382`) keys on `exit_code`/`reason` only; `reason=unhandled` = `EXIT` trap (`ci-deploy.sh:111`) on a non-zero exit that skipped `final_write_state` | True at incident time; cause was the `.cron` mkdir, reverted in #4895. No gate change needed. |
+| "root signal `inngest_heartbeat: inactive`" | `inngest_heartbeat` is NOT read by the gate; it is a reporter field (`cat-deploy-state.sh:102,129`). For a `Type=oneshot` timer-driven unit, `inactive` is the healthy steady state | Red herring. Fix the reporter so the field reflects timer liveness, not the transient oneshot state. |
+| "#4886 moved/broke the heartbeat systemd unit or its storage path" | #4886's diff touched `ci-deploy.sh` (`.cron` mkdir + `CRON_WORKSPACE_ROOT`), the GC fn, and tests — NOT `inngest-bootstrap.sh`'s heartbeat unit/script/storage | False. No unit or storage-path change occurred. Reframe: no restore needed. |
+| "restore the heartbeat service" | Heartbeat unit + timer are intact and healthy on prod (the betteruptime ping is the liveness proof, separate from the systemd `is-active` read) | Nothing to restore. Fix the misreport that made a healthy unit look broken. |
+| "`journald_storage.persistent: false`" in the failure JSON | `cat-deploy-state.sh:54-83` reports journald persistence; tracked separately under #4792. `root_avail: 54G` shows root disk was fine | Out of scope (separate concern, separate issue). Note in Non-Goals. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** no direct user-facing artifact — this
+edits a read-only no-SSH deploy-status reporter (`cat-deploy-state.sh`) and its test.
+The indirect risk is the one this incident already demonstrated: a misleading
+deploy-status field that causes a future operator (or the auto-filer) to mis-diagnose
+the next deploy incident, delaying recovery of a genuinely stuck deploy — which CAN
+become user-facing (stale code on prod) if a real failure is masked or misattributed.
+
+**If this leaks, the user's data / workflow / money is exposed via:** nothing — the
+reporter is read-only, returns only systemd unit-state words and disk-headroom
+numbers (no secrets; the heartbeat URL is deliberately kept out of the unit's journal
+per `inngest-bootstrap.sh:195-198`). No regulated-data surface.
+
+**Brand-survival threshold:** aggregate pattern. A single misread of one field is not
+a per-user incident; the harm is the aggregate pattern of mis-signalled deploy health
+eroding trust in the deploy-status gate over time. (Threshold `none` would require a
+sensitive-path scope-out bullet; `aggregate pattern` requires the section only, which
+is present.)
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] **AC1 — Recovery confirmed read-only.** Plan body (Phase 0) records: latest
+      `web-platform-release.yml` run conclusion = `success`; `/health` `version` ≥
+      `0.102.0`; the three issue-cited failing runs are all strictly before the first
+      post-#4895 success. Verification commands are baked into Phase 0, no SSH.
+- [ ] **AC2 — Reporter reports the durable liveness signal.** `cat-deploy-state.sh`
+      adds an `inngest_heartbeat_timer` field reading `systemctl is-active
+      inngest-heartbeat.timer` (the timer is `active` on a healthy host), and the
+      existing `inngest_heartbeat` (oneshot `.service`) field is retained with an
+      inline comment documenting that `inactive` is the expected steady state for a
+      timer-driven oneshot. Verified by `jq -e '.services.inngest_heartbeat_timer'`
+      against a synthesized state fixture.
+- [ ] **AC3 — Test coverage.** `cat-deploy-state.test.sh` asserts the new
+      `inngest_heartbeat_timer` field is present across all 4 base-state branches
+      (no_prior_deploy, OK, services-merge, corrupt_state), mirroring the existing
+      `inngest_heartbeat` assertions at `cat-deploy-state.test.sh:39-66`. Run:
+      `bash apps/web-platform/infra/cat-deploy-state.test.sh` — exits 0, all asserts pass.
+- [ ] **AC4 — No gate-logic change.** `git diff` shows zero edits to
+      `web-platform-release.yml` and zero edits to the `inngest-heartbeat.{service,timer}`
+      heredocs in `inngest-bootstrap.sh` (this plan does NOT touch the unit; it fixes
+      only the reporter). Grep-verify: `git diff --name-only` contains
+      `cat-deploy-state.sh` + `cat-deploy-state.test.sh` and NOT `inngest-bootstrap.sh`
+      or `web-platform-release.yml`.
+- [ ] **AC5 — Full infra test suite green.** The owning suite passes:
+      `bash apps/web-platform/infra/cat-deploy-state.test.sh` AND any harness that
+      exercises the reporter (confirm the runner in Phase 0 via `ls
+      apps/web-platform/infra/*.test.sh`; do not assume a framework).
+- [ ] **AC6 — PR body uses `Ref #4896`, not `Closes #4896`.** Per
+      `ops-remediation`/`ops-only-prod-write` convention: the issue is closed in a
+      post-merge step after recovery is re-confirmed, not auto-closed at merge.
+
+### Post-merge (operator / automated)
+
+- [ ] **AC7 — Re-confirm recovery post-merge.** After this PR's own
+      `web-platform-release.yml` run completes, `/health` reports this PR's `build_sha`
+      and `version`. Automatable via the deploy-status webhook + `/health` curl (no SSH).
+      Automation: feasible (curl + jq).
+- [ ] **AC8 — Volume-pressure check (no-SSH).** Read the deploy-status JSON
+      `journald_storage.root_avail` and (if present) the latest
+      `scheduled-workspace-gc` Sentry `freeMb`/`freedMb` trend to confirm the shared
+      volume is not re-pressured. If pressured, fire the GC via
+      `/soleur:trigger-cron cron/workspace-gc.manual-trigger` (the no-SSH reclaim
+      lever — `cron-workspace-gc` is in the manifest at `cron-manifest.ts:60` with a
+      derived manual-trigger event). Automation: feasible (deploy-status webhook +
+      trigger-cron skill). NOT operator-SSH.
+- [ ] **AC9 — Close #4896 with corrected RCA.** `gh issue close 4896` with a comment:
+      actual cause = `.cron` mkdir ENOSPC under `set -e` (not a broken heartbeat unit),
+      fixed by #4895; `inngest_heartbeat: inactive` was a oneshot-misreport red herring,
+      now corrected by this PR; capacity isolation deferred to #4891. Automation:
+      feasible (`gh issue close`).
+
+## Implementation Phases
+
+### Phase 0 — Preconditions & recovery confirmation (read-only, no prod write)
+
+1. Confirm the deploy queue recovered:
+   `gh run list --workflow=web-platform-release.yml --limit 12 --json conclusion,createdAt,headSha`
+   — assert the first run after #4895's merge commit `b06de5b6` is `success` and the
+   three issue-cited SHAs (`1998af5f`, `251b80ea`, `4d1e1cb8`) are the failures.
+2. Confirm prod is current: `curl -fsS --max-time 12 https://app.soleur.ai/health | jq .`
+   — assert `version >= 0.102.0` and `status == "ok"`.
+3. Identify the reporter test runner: `ls apps/web-platform/infra/*.test.sh` and read
+   the head of `cat-deploy-state.test.sh` to confirm the `assert` harness shape (it is
+   a bash assert helper, not a JS framework — do NOT prescribe bun/vitest here).
+4. Re-read `cat-deploy-state.sh:19-26` (`service_status`) and `:102-134` (the field
+   assembly) and `inngest-bootstrap.sh:216-245` (the oneshot `.service` + `.timer`
+   heredocs) to confirm the timer unit name is exactly `inngest-heartbeat.timer`.
+
+### Phase 1 — Add the durable timer-liveness field to the reporter (RED → GREEN)
+
+**File: `apps/web-platform/infra/cat-deploy-state.test.sh`** (write the failing
+assertions first, per `cq-write-failing-tests-before`):
+
+- Mirror the existing 4 `inngest_heartbeat` assertions (lines 39-66) with parallel
+  `inngest_heartbeat_timer` assertions across no_prior_deploy / OK / services-merge /
+  corrupt_state. Each: `jq -e '.services.inngest_heartbeat_timer' >/dev/null`.
+
+**File: `apps/web-platform/infra/cat-deploy-state.sh`:**
+
+- Add `HEARTBEAT_TIMER_STATUS="$(service_status inngest-heartbeat.timer)"` next to the
+  existing `HEARTBEAT_STATUS` read (line 102).
+- Add `--arg hbt "$HEARTBEAT_TIMER_STATUS"` to the final `jq -nc` (after line 122) and
+  emit `inngest_heartbeat_timer: $hbt` inside the `services` object (after line 129).
+- Add an inline comment on the existing `inngest_heartbeat` field documenting that the
+  oneshot `.service` reports `inactive` as its NORMAL steady state between 60s timer
+  fires, and that `inngest_heartbeat_timer` (`active` on a healthy host) is the durable
+  liveness signal — citing #4896 as the incident this prevents recurring.
+
+Run `bash apps/web-platform/infra/cat-deploy-state.test.sh` → green.
+
+### Phase 2 — Verify no unintended blast radius
+
+- `git diff --name-only` MUST list exactly `cat-deploy-state.sh` +
+  `cat-deploy-state.test.sh` (plus plan/spec/tasks docs). Confirm
+  `inngest-bootstrap.sh` and `web-platform-release.yml` are untouched (AC4).
+- Run the full infra reporter test surface identified in Phase 0 step 3 (AC5).
+
+### Phase 3 — Ship + post-merge close
+
+- PR body: `Ref #4896` (not `Closes`), summarizing the corrected RCA and pointing at
+  #4895 as the deadlock fix and #4891 as deferred capacity isolation.
+- After this PR's release run lands (AC7), run AC8 (volume-pressure check, fire GC via
+  trigger-cron only if pressured), then AC9 (`gh issue close 4896` with the corrected RCA).
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "inngest-heartbeat.timer active-state + Better Stack 60s ping (betteruptime_heartbeat.inngest_prd)"
+  cadence: "60s (OnUnitActiveSec=60s, inngest-bootstrap.sh:240); Better Stack grace 30s"
+  alert_target: "Better Stack email on missed ping (free-tier, inngest.tf:13,149)"
+  configured_in: "apps/web-platform/infra/inngest-bootstrap.sh (timer heredoc) + inngest.tf (betteruptime_heartbeat)"
+error_reporting:
+  destination: "deploy-status webhook JSON (cat-deploy-state.sh) surfaces services.inngest_heartbeat + new services.inngest_heartbeat_timer; Better Stack for the actual ping"
+  fail_loud: "true — a dead timer reads inngest_heartbeat_timer != active in the deploy-status JSON AND Better Stack flips to missed/down"
+failure_modes:
+  - mode: "heartbeat timer dead (no 60s ping)"
+    detection: "services.inngest_heartbeat_timer != 'active' in deploy-status JSON; Better Stack missed-ping email"
+    alert_route: "Better Stack email; deploy-status webhook field for no-SSH triage"
+  - mode: "oneshot .service stuck in 'failed' (curl errored, e.g. empty URL #4116 class)"
+    detection: "services.inngest_heartbeat == 'failed' (distinct from the healthy 'inactive')"
+    alert_route: "deploy-status JSON; bootstrap logs warn on heartbeat oneshot non-zero (inngest-bootstrap.sh:308)"
+  - mode: "deploy gate failure (reason=unhandled)"
+    detection: "web-platform-release.yml Verify-completion step: exit_code!=0; reason field carries detail"
+    alert_route: "GitHub Actions run failure; deploy-status JSON reason field"
+logs:
+  where: "journald on the prod host (inngest-heartbeat.service ExecStart); Better Stack Logs via vector.service; deploy-status webhook for read-only no-SSH tail"
+  retention: "journald persistent (#4792); Better Stack per plan tier"
+discoverability_test:
+  command: "curl -fsS --max-time 12 https://deploy.soleur.ai/hooks/deploy-status -H 'X-Signature-256: sha256=<hmac>' -H 'CF-Access-Client-Id: <id>' -H 'CF-Access-Client-Secret: <secret>' | jq '.services.inngest_heartbeat_timer'"
+  expected_output: "\"active\" on a healthy host (the oneshot .service may read \"inactive\" — that is healthy steady state)"
+```
+
+## Domain Review
+
+**Domains relevant:** Engineering (CTO)
+
+### Engineering (CTO)
+
+**Status:** reviewed
+**Assessment:** Pure infra/observability change to a read-only no-SSH deploy-status
+reporter (`cat-deploy-state.sh`) + its bash test. No runtime code, no schema, no
+secrets, no new infrastructure surface (the `inngest-heartbeat.timer` already exists;
+we only read its state). No new systemd unit, no Terraform resource, no DNS/cert/cron.
+The change makes an existing healthy unit's status legible instead of misleading.
+Blast radius is bounded to the JSON shape of the deploy-status endpoint, which is
+consumed by the release workflow's verify steps (which key on `exit_code`/`reason`,
+not the heartbeat fields) and by operators doing no-SSH triage.
+
+No Product/UX surface (no file under `components/**`, `app/**/page.tsx`, or any
+UI-surface path). Product/UX Gate: NONE.
+
+## Infrastructure (IaC)
+
+Skipped — this plan introduces NO new infrastructure. It edits a read-only host-side
+reporter script (`cat-deploy-state.sh`) that already ships in the deploy image and is
+invoked by the existing `/hooks/deploy-status` webhook. No new systemd unit, secret,
+vendor, DNS record, TLS cert, firewall rule, or persistent process. The
+`inngest-heartbeat.timer` whose state we read is already provisioned by
+`inngest-bootstrap.sh`. The deferred dedicated-volume work (a real IaC change — new
+`hcloud_volume` + attachment + mount) lives in #4891, explicitly out of scope here.
+
+## Open Code-Review Overlap
+
+None — no open `code-review`-labeled issue touches `cat-deploy-state.sh` or
+`cat-deploy-state.test.sh` (verified at plan time; re-run the `gh issue list --label
+code-review` + per-path `jq contains` check at Step 1.7.5 once Files-to-Edit is frozen,
+which it now is: the two files above).
+
+## Non-Goals / Out of Scope
+
+- **Re-litigating #4895's revert.** The `.cron` deadlock is already fixed and merged;
+  this plan does not re-touch `ci-deploy.sh`'s `CRON_WORKSPACE_ROOT` or the mkdir.
+- **Dedicated cron-clone volume / capacity isolation.** Deferred to #4891 (open). A
+  separate Terraform planning cycle.
+- **`journald_storage.persistent: false`.** Tracked under #4792; orthogonal to the
+  heartbeat misreport. The incident JSON showed `root_avail: 54G` (root disk fine).
+- **Changing the deploy-completion gate logic** (`web-platform-release.yml`). The gate
+  correctly keys on `exit_code`/`reason`; no change needed.
+- **Modifying the `inngest-heartbeat` systemd unit/timer/script.** They are healthy;
+  the bug is in how their state is *reported*, not in the units.
+
+## Alternative Approaches Considered
+
+| Approach | Decision | Rationale |
+|---|---|---|
+| Close #4896 as already-fixed (no PR), since #4895 resolved the deadlock | Rejected (partial) | #4895 fixed the deploy deadlock but left the latent oneshot-misreport that mis-framed the incident. Closing without fixing the misreport guarantees the next deploy incident is mis-diagnosed the same way. We fix the reporter, THEN close. |
+| Add `RemainAfterExit=yes` to `inngest-heartbeat.service` so `is-active` reads `active` | Rejected | That changes a healthy unit's semantics on the prod host (a systemd-unit edit + redeploy, larger blast radius) to paper over a reporter that should simply read the timer. The timer IS the canonical liveness signal; report it. |
+| Replace the `inngest_heartbeat` (.service) field entirely with the timer field | Rejected | The `.service` field still distinguishes `failed` (curl errored, the #4116 class) from healthy `inactive`. Keep both: `.timer` for liveness, `.service` for last-fire fault detection. |
+| Change the deploy gate to also assert `inngest_heartbeat == active` | Rejected (would have re-broken deploys) | A oneshot's healthy state is `inactive`; gating on `active` would fail every healthy deploy. This is precisely the wrong fix the issue's framing nudges toward — explicitly avoided. |
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only TBD/TODO
+  placeholder text, or omits the threshold will fail `deepen-plan` Phase 4.6. The
+  section above is filled with threshold `aggregate pattern`.
+- **The issue's own framing is the trap.** #4896 asserts "restore the broken heartbeat
+  service" and names `inngest_heartbeat: inactive` as the root signal. Both are wrong:
+  the unit was never broken, and `inactive` is healthy for a oneshot. Any implementer
+  who takes the issue at face value will either (a) "fix" a healthy unit, or (b) add an
+  `is-active == active` gate that re-breaks every deploy. The plan's reframe (read the
+  timer, keep both fields, touch no unit) is load-bearing — do not regress to the
+  issue's literal ask.
+- **`Closes #4896` would false-resolve.** This is `ops-only-prod-write`: the issue is
+  closed post-merge after recovery is re-confirmed (AC9), so the PR body must say
+  `Ref #4896`. `Closes` auto-closes at merge before the post-merge confirmation.
+- **Do not assume the test runner.** `cat-deploy-state.test.sh` is a self-contained
+  bash `assert`-helper script, NOT bun/vitest. Run it directly with `bash`; do not
+  prescribe `bun test` (the package's runner is vitest for `.test.ts`, but `.test.sh`
+  infra scripts run standalone).
+- **`service_status` returns empty/`unknown` off-host.** In the test + non-systemd
+  contexts the reporter's `service_status` yields `"unknown"` or empty; the new field
+  assertions check *presence* (`jq -e '.services.inngest_heartbeat_timer'`), not a
+  specific value — mirroring the existing `inngest_heartbeat` assertions which never
+  pin the word.

--- a/knowledge-base/project/specs/feat-one-shot-4896-inngest-heartbeat-inactive-deploy-stuck/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-4896-inngest-heartbeat-inactive-deploy-stuck/session-state.md
@@ -1,0 +1,21 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-03-fix-inngest-heartbeat-oneshot-misreport-and-confirm-deploy-recovery-plan.md
+- Status: complete
+
+### Errors
+None. CWD verified, both skills ran, all halt gates (4.6/4.7/4.8) passed, 4.9 skipped (no UI surface), all citations verified live.
+
+### Decisions
+- Premise is substantially stale — surfaced, not planned-against. Phase 0.6 validation found the incident is already resolved by PR #4895 (the revert cited in the issue, merged 18:00 UTC): deploys recovered (success at 18:00/18:06/18:17), /health reports prod current on v0.102.0 (build f78bb0a1), not stale v0.101.100. Deploy queue is unstuck.
+- Reframed root cause: #4886 never touched the heartbeat unit or its storage. Real cause was #4886's `sudo mkdir -p /mnt/data/workspaces/.cron` ENOSPC-failing under `set -e` on the already-full volume → ci-deploy.sh EXIT trap wrote `reason=unhandled` — already reverted by #4895.
+- `inngest_heartbeat: inactive` is a red herring. The completion gate (web-platform-release.yml) has 0 references to `inngest_heartbeat`; it keys only on exit_code/reason. For a Type=oneshot timer-driven unit, `inactive` is the healthy steady state.
+- Scoped the plan to the genuine latent bug: fix the reporter to also emit `inngest_heartbeat_timer` (durable liveness signal) so a healthy oneshot never again mis-frames an incident. Surgical 2-file change (cat-deploy-state.sh + its bash test); explicitly does NOT touch the systemd unit or the gate.
+- Classified ops-only-prod-write: PR uses `Ref #4896` (not Closes); post-merge closes the issue with corrected RCA and runs a no-SSH volume-pressure check, firing cron-workspace-gc via /soleur:trigger-cron only if pressured (#4891 deferred capacity work referenced).
+
+### Components Invoked
+- cd/pwd CWD verification (Step 0)
+- Skill soleur:plan (Phase 0.6 premise validation, 1.7.5 code-review overlap, 2.6 User-Brand Impact, 2.7 GDPR [skipped], 2.8 IaC [skipped], 2.9 Observability)
+- Skill soleur:deepen-plan (halt gates 4.6/4.7/4.8 passed, 4.9 skipped; Phase 4.4 scheduled-work precedent-diff; live PR/issue/attribution verification)
+- gh CLI, git show/ls-files, curl+jq (prod /health), KB-citation + AGENTS rule-id integrity greps

--- a/knowledge-base/project/specs/feat-one-shot-4896-inngest-heartbeat-inactive-deploy-stuck/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-4896-inngest-heartbeat-inactive-deploy-stuck/tasks.md
@@ -9,23 +9,23 @@ issue: 4896
 
 ## Phase 0 — Preconditions & recovery confirmation (read-only, no prod write)
 
-- [ ] 0.1 Confirm deploy queue recovered: `gh run list --workflow=web-platform-release.yml --limit 12 --json conclusion,createdAt,headSha`; assert first run after #4895 (`b06de5b6`) is `success` and the 3 issue SHAs (`1998af5f`/`251b80ea`/`4d1e1cb8`) are the failures.
-- [ ] 0.2 Confirm prod current: `curl -fsS --max-time 12 https://app.soleur.ai/health | jq .`; assert `version >= 0.102.0`, `status == "ok"`.
-- [ ] 0.3 Identify reporter test runner: `ls apps/web-platform/infra/*.test.sh`; confirm `cat-deploy-state.test.sh` is a bash `assert`-helper script (NOT bun/vitest).
-- [ ] 0.4 Re-read `cat-deploy-state.sh:19-26,102-134` + `inngest-bootstrap.sh:216-245`; confirm timer unit name is exactly `inngest-heartbeat.timer`.
+- [x] 0.1 Confirm deploy queue recovered: `gh run list --workflow=web-platform-release.yml --limit 12 --json conclusion,createdAt,headSha`; assert first run after #4895 (`b06de5b6`) is `success` and the 3 issue SHAs (`1998af5f`/`251b80ea`/`4d1e1cb8`) are the failures.
+- [x] 0.2 Confirm prod current: `curl -fsS --max-time 12 https://app.soleur.ai/health | jq .`; assert `version >= 0.102.0`, `status == "ok"`.
+- [x] 0.3 Identify reporter test runner: `ls apps/web-platform/infra/*.test.sh`; confirm `cat-deploy-state.test.sh` is a bash `assert`-helper script (NOT bun/vitest).
+- [x] 0.4 Re-read `cat-deploy-state.sh:19-26,102-134` + `inngest-bootstrap.sh:216-245`; confirm timer unit name is exactly `inngest-heartbeat.timer`.
 
 ## Phase 1 — Add durable timer-liveness field (RED → GREEN)
 
-- [ ] 1.1 (RED) In `cat-deploy-state.test.sh`, add 4 `inngest_heartbeat_timer` presence assertions mirroring the existing `inngest_heartbeat` asserts at lines 39-66 (no_prior_deploy / OK / services-merge / corrupt_state). Run → fails.
-- [ ] 1.2 In `cat-deploy-state.sh`: add `HEARTBEAT_TIMER_STATUS="$(service_status inngest-heartbeat.timer)"` beside the `.service` read (line 102). Precedent: this is the 4th identical `service_status` reader call (`.service` units already read at :102-104) — same helper, same shape, lowest-risk extension (deepen-plan Phase 4.4 precedent-diff: pattern is NOT novel).
-- [ ] 1.3 In `cat-deploy-state.sh`: add `--arg hbt "$HEARTBEAT_TIMER_STATUS"` to the final `jq -nc` and emit `inngest_heartbeat_timer: $hbt` inside the `services` object (after line 129).
-- [ ] 1.4 Add inline comment on the `inngest_heartbeat` (.service) field: `inactive` is the NORMAL steady state for a timer-driven oneshot; `inngest_heartbeat_timer` (`active` on healthy host) is the durable liveness signal. Cite #4896.
-- [ ] 1.5 (GREEN) `bash apps/web-platform/infra/cat-deploy-state.test.sh` → all asserts pass.
+- [x] 1.1 (RED) In `cat-deploy-state.test.sh`, add 4 `inngest_heartbeat_timer` presence assertions mirroring the existing `inngest_heartbeat` asserts at lines 39-66 (no_prior_deploy / OK / services-merge / corrupt_state). Run → fails.
+- [x] 1.2 In `cat-deploy-state.sh`: add `HEARTBEAT_TIMER_STATUS="$(service_status inngest-heartbeat.timer)"` beside the `.service` read (line 102). Precedent: this is the 4th identical `service_status` reader call (`.service` units already read at :102-104) — same helper, same shape, lowest-risk extension (deepen-plan Phase 4.4 precedent-diff: pattern is NOT novel).
+- [x] 1.3 In `cat-deploy-state.sh`: add `--arg hbt "$HEARTBEAT_TIMER_STATUS"` to the final `jq -nc` and emit `inngest_heartbeat_timer: $hbt` inside the `services` object (after line 129).
+- [x] 1.4 Add inline comment on the `inngest_heartbeat` (.service) field: `inactive` is the NORMAL steady state for a timer-driven oneshot; `inngest_heartbeat_timer` (`active` on healthy host) is the durable liveness signal. Cite #4896.
+- [x] 1.5 (GREEN) `bash apps/web-platform/infra/cat-deploy-state.test.sh` → all asserts pass.
 
 ## Phase 2 — Blast-radius verification
 
-- [ ] 2.1 `git diff --name-only` lists exactly `cat-deploy-state.sh` + `cat-deploy-state.test.sh` (+ plan/spec docs); `inngest-bootstrap.sh` + `web-platform-release.yml` untouched (AC4).
-- [ ] 2.2 Run full infra reporter test surface from 0.3 (AC5).
+- [x] 2.1 `git diff --name-only` lists exactly `cat-deploy-state.sh` + `cat-deploy-state.test.sh` (+ plan/spec docs); `inngest-bootstrap.sh` + `web-platform-release.yml` untouched (AC4).
+- [x] 2.2 Run full infra reporter test surface from 0.3 (AC5).
 
 ## Phase 3 — Ship + post-merge close
 

--- a/knowledge-base/project/specs/feat-one-shot-4896-inngest-heartbeat-inactive-deploy-stuck/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-4896-inngest-heartbeat-inactive-deploy-stuck/tasks.md
@@ -17,7 +17,7 @@ issue: 4896
 ## Phase 1 — Add durable timer-liveness field (RED → GREEN)
 
 - [ ] 1.1 (RED) In `cat-deploy-state.test.sh`, add 4 `inngest_heartbeat_timer` presence assertions mirroring the existing `inngest_heartbeat` asserts at lines 39-66 (no_prior_deploy / OK / services-merge / corrupt_state). Run → fails.
-- [ ] 1.2 In `cat-deploy-state.sh`: add `HEARTBEAT_TIMER_STATUS="$(service_status inngest-heartbeat.timer)"` beside the `.service` read (line 102).
+- [ ] 1.2 In `cat-deploy-state.sh`: add `HEARTBEAT_TIMER_STATUS="$(service_status inngest-heartbeat.timer)"` beside the `.service` read (line 102). Precedent: this is the 4th identical `service_status` reader call (`.service` units already read at :102-104) — same helper, same shape, lowest-risk extension (deepen-plan Phase 4.4 precedent-diff: pattern is NOT novel).
 - [ ] 1.3 In `cat-deploy-state.sh`: add `--arg hbt "$HEARTBEAT_TIMER_STATUS"` to the final `jq -nc` and emit `inngest_heartbeat_timer: $hbt` inside the `services` object (after line 129).
 - [ ] 1.4 Add inline comment on the `inngest_heartbeat` (.service) field: `inactive` is the NORMAL steady state for a timer-driven oneshot; `inngest_heartbeat_timer` (`active` on healthy host) is the durable liveness signal. Cite #4896.
 - [ ] 1.5 (GREEN) `bash apps/web-platform/infra/cat-deploy-state.test.sh` → all asserts pass.

--- a/knowledge-base/project/specs/feat-one-shot-4896-inngest-heartbeat-inactive-deploy-stuck/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-4896-inngest-heartbeat-inactive-deploy-stuck/tasks.md
@@ -1,0 +1,35 @@
+---
+title: "Tasks — fix oneshot heartbeat misreport + confirm #4886 deploy recovery (#4896)"
+plan: knowledge-base/project/plans/2026-06-03-fix-inngest-heartbeat-oneshot-misreport-and-confirm-deploy-recovery-plan.md
+lane: cross-domain
+issue: 4896
+---
+
+# Tasks
+
+## Phase 0 — Preconditions & recovery confirmation (read-only, no prod write)
+
+- [ ] 0.1 Confirm deploy queue recovered: `gh run list --workflow=web-platform-release.yml --limit 12 --json conclusion,createdAt,headSha`; assert first run after #4895 (`b06de5b6`) is `success` and the 3 issue SHAs (`1998af5f`/`251b80ea`/`4d1e1cb8`) are the failures.
+- [ ] 0.2 Confirm prod current: `curl -fsS --max-time 12 https://app.soleur.ai/health | jq .`; assert `version >= 0.102.0`, `status == "ok"`.
+- [ ] 0.3 Identify reporter test runner: `ls apps/web-platform/infra/*.test.sh`; confirm `cat-deploy-state.test.sh` is a bash `assert`-helper script (NOT bun/vitest).
+- [ ] 0.4 Re-read `cat-deploy-state.sh:19-26,102-134` + `inngest-bootstrap.sh:216-245`; confirm timer unit name is exactly `inngest-heartbeat.timer`.
+
+## Phase 1 — Add durable timer-liveness field (RED → GREEN)
+
+- [ ] 1.1 (RED) In `cat-deploy-state.test.sh`, add 4 `inngest_heartbeat_timer` presence assertions mirroring the existing `inngest_heartbeat` asserts at lines 39-66 (no_prior_deploy / OK / services-merge / corrupt_state). Run → fails.
+- [ ] 1.2 In `cat-deploy-state.sh`: add `HEARTBEAT_TIMER_STATUS="$(service_status inngest-heartbeat.timer)"` beside the `.service` read (line 102).
+- [ ] 1.3 In `cat-deploy-state.sh`: add `--arg hbt "$HEARTBEAT_TIMER_STATUS"` to the final `jq -nc` and emit `inngest_heartbeat_timer: $hbt` inside the `services` object (after line 129).
+- [ ] 1.4 Add inline comment on the `inngest_heartbeat` (.service) field: `inactive` is the NORMAL steady state for a timer-driven oneshot; `inngest_heartbeat_timer` (`active` on healthy host) is the durable liveness signal. Cite #4896.
+- [ ] 1.5 (GREEN) `bash apps/web-platform/infra/cat-deploy-state.test.sh` → all asserts pass.
+
+## Phase 2 — Blast-radius verification
+
+- [ ] 2.1 `git diff --name-only` lists exactly `cat-deploy-state.sh` + `cat-deploy-state.test.sh` (+ plan/spec docs); `inngest-bootstrap.sh` + `web-platform-release.yml` untouched (AC4).
+- [ ] 2.2 Run full infra reporter test surface from 0.3 (AC5).
+
+## Phase 3 — Ship + post-merge close
+
+- [ ] 3.1 PR body uses `Ref #4896` (NOT `Closes`); summarize corrected RCA, point at #4895 (deadlock fix) + #4891 (deferred capacity isolation). (AC6)
+- [ ] 3.2 (post-merge) After this PR's release run, `/health` reports this PR's `build_sha`/`version` (AC7) — curl + jq, no SSH.
+- [ ] 3.3 (post-merge) Volume-pressure check via deploy-status JSON `journald_storage.root_avail` + `scheduled-workspace-gc` Sentry trend; if pressured, fire GC via `/soleur:trigger-cron cron/workspace-gc.manual-trigger` (no SSH). (AC8)
+- [ ] 3.4 (post-merge) `gh issue close 4896` with corrected-RCA comment. (AC9)


### PR DESCRIPTION
## Summary
- The deploy-status reporter (`cat-deploy-state.sh`) emitted `services.inngest_heartbeat` from the **oneshot** `inngest-heartbeat.service`, whose healthy steady state is `inactive` between 60s timer fires. That misleading field led the `/ship` auto-filer (#4896) to read `inngest_heartbeat: inactive` as a deploy-failure root cause.
- The actual incident (3 failed deploys 17:24–17:42 UTC, prod stuck on v0.101.100) was an ENOSPC `.cron` mkdir under `set -e` introduced by #4886 — already reverted by #4895 (deploys recovered at 18:00 UTC; prod current on v0.102.0). The gate keys only on `exit_code`/`reason`; `inngest_heartbeat` was a reporter-only red herring.
- This adds `services.inngest_heartbeat_timer` (reads `inngest-heartbeat.timer`, `active` on a healthy host) as the durable liveness signal, retains the `.service` field for real-fault detection (`failed`), and documents the oneshot steady-state semantics inline so the mis-signal cannot recur.

Read-only, no-SSH reporter change. No systemd unit, deploy-completion gate, or infra change.

Ref #4896

## User-Brand Impact
- **Exposed artifact:** none directly — edits a read-only no-SSH deploy-status reporter that returns only systemd unit-state words + disk-headroom numbers (no secrets; the heartbeat URL is deliberately kept out of the unit journal).
- **Exposure vector:** indirect — a misleading deploy-status field can cause a future operator (or the auto-filer) to mis-diagnose the next deploy incident, delaying recovery of a genuinely stuck deploy (the exact failure mode this PR fixes). No regulated-data surface; reporter is read-only.
- **Brand-survival threshold:** aggregate pattern

## Changelog
### Web Platform
- `cat-deploy-state.sh`: add `services.inngest_heartbeat_timer` liveness field + inline oneshot steady-state documentation (`inactive` is healthy for a timer-driven oneshot).
- `cat-deploy-state.test.sh`: assert the new field is present across all 4 base-state branches.

## Test plan
- [x] `bash apps/web-platform/infra/cat-deploy-state.test.sh` → 14/14 passed
- [x] `shellcheck -x cat-deploy-state.sh cat-deploy-state.test.sh` → clean
- [x] Sibling suites green: journald-config (33/33), infra-config-install (29/29), infra-config-apply (56/56), ship-deploy-pipeline-fix-gate (57 pass)
- [x] Blast radius: only `cat-deploy-state.{sh,test.sh}` touched; `inngest-bootstrap.sh` + `web-platform-release.yml` untouched

Generated with [Claude Code](https://claude.com/claude-code)
