### PR TITLE
fix(auth): fail closed on malformed-UUID userId in tenant mint

### DIFF
--- a/apps/web-platform/lib/supabase/tenant.ts
+++ b/apps/web-platform/lib/supabase/tenant.ts
@@ -146,8 +146,11 @@ const DEFAULT_TTL_SEC = 600;
  * rejection deep in `resolveFounderEmail` (`getUserById`). That raw error is
  * NOT a `RuntimeAuthError`, so it escapes `tenantFor`'s typed catch and, in the
  * WebSocket connect path, becomes a process-killing `unhandledRejection` that
- * crashes the dev/prod server. Same shape as the `server/workspace.ts`
- * `UUID_RE` precondition guards.
+ * crashes the dev/prod server. The regex shape mirrors the
+ * `server/workspace.ts` `UUID_RE` precondition guards; the failure SEMANTICS
+ * differ deliberately — this throws a typed `RuntimeAuthError` (caught by
+ * `tenantFor` → fail-open `null`) rather than a plain validation error, which
+ * is the entire mechanism by which the WS path degrades instead of crashing.
  */
 const TENANT_USER_ID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/apps/web-platform/lib/supabase/tenant.ts
+++ b/apps/web-platform/lib/supabase/tenant.ts
@@ -137,6 +137,22 @@ export function mapRuntimeAuthCauseToErrorCode(
 const DEFAULT_TTL_SEC = 600;
 
 /**
+ * `auth.uid()` is ALWAYS a UUID. A non-UUID `userId` reaching the tenant-mint
+ * path is a programming/test-fixture error (e.g. an e2e mock seeding a literal
+ * "test-user-id") — it can never resolve a real tenant. The mint guard below
+ * rejects it as a `RuntimeAuthError` so callers fail-open
+ * (`ws-handler.tenantFor` → `null`, server callers early-return) instead of
+ * letting the Supabase Admin SDK throw a RAW `Expected parameter to be UUID`
+ * rejection deep in `resolveFounderEmail` (`getUserById`). That raw error is
+ * NOT a `RuntimeAuthError`, so it escapes `tenantFor`'s typed catch and, in the
+ * WebSocket connect path, becomes a process-killing `unhandledRejection` that
+ * crashes the dev/prod server. Same shape as the `server/workspace.ts`
+ * `UUID_RE` precondition guards.
+ */
+const TENANT_USER_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
  * Audience claim baked into runtime JWTs by `public.runtime_jwt_mint_hook`
  * (migration 047). Node holds this constant for parity with the hook —
  * future PostgREST-level aud filtering (dashboard-replay defense) reads
@@ -253,6 +269,17 @@ export async function mintFounderJwt(
   userId: UserId,
   opts: MintFounderJwtOpts = {},
 ): Promise<MintedJwt> {
+  // Fail closed on a malformed (non-UUID) userId BEFORE any Admin SDK call —
+  // see TENANT_USER_ID_RE docblock. A raw `getUserById` UUID-validation throw
+  // would otherwise escape the RuntimeAuthError-only catch in ws-handler and
+  // crash the process via unhandledRejection.
+  if (!TENANT_USER_ID_RE.test(userId)) {
+    throw new RuntimeAuthError(
+      "jwt_mint",
+      "Authentication unavailable; retry shortly",
+    );
+  }
+
   const ttlSec = opts.ttlSec ?? DEFAULT_TTL_SEC;
   const service = getServiceClient();
 

--- a/apps/web-platform/test/server/tenant-jwt-refresh.test.ts
+++ b/apps/web-platform/test/server/tenant-jwt-refresh.test.ts
@@ -393,6 +393,41 @@ describe("mintFounderJwt — claim shape (Resolution C — asymmetric substrate)
   });
 });
 
+describe("malformed (non-UUID) userId — fail closed before the Admin SDK", () => {
+  // Regression: a non-UUID userId (e.g. the e2e mock's literal "test-user-id")
+  // made auth.admin.getUserById throw a raw "Expected parameter to be UUID"
+  // error that escaped ws-handler.tenantFor's RuntimeAuthError-only catch and
+  // crashed the server via unhandledRejection. The mint guard now rejects it
+  // as a RuntimeAuthError BEFORE any Admin SDK call, so callers fail-open.
+  it("mintFounderJwt rejects RuntimeAuthError{cause:jwt_mint} without calling getUserById", async () => {
+    await expect(mintFounderJwt("test-user-id")).rejects.toMatchObject({
+      name: "RuntimeAuthError",
+      cause: "jwt_mint",
+    });
+    expect(mocks.getUserByIdCalls).toEqual([]);
+    expect(mocks.generateLinkCalls).toEqual([]);
+  });
+
+  it("getFreshTenantClient rejects RuntimeAuthError for a non-UUID userId (ws-handler fails open)", async () => {
+    await expect(getFreshTenantClient("not-a-uuid")).rejects.toBeInstanceOf(
+      RuntimeAuthError,
+    );
+    expect(mocks.getUserByIdCalls).toEqual([]);
+  });
+
+  it("a valid UUID userId passes the guard and reaches the Admin SDK", async () => {
+    // A fresh UUID not minted elsewhere — tenant.ts's module-level emailCache
+    // persists across tests, so a previously-minted founder would skip
+    // getUserById on a cache hit and make this assertion vacuous.
+    const FRESH = "00000000-0000-0000-0000-00000000cccc";
+    mocks.setEmail(FRESH, "fresh@soleur.test");
+    mocks.setMintResult({ sub: FRESH });
+    await getFreshTenantClient(FRESH);
+    // proves the guard is not vacuously rejecting every input
+    expect(mocks.getUserByIdCalls).toContain(FRESH);
+  });
+});
+
 describe("getFreshTenantClient — auto-remint at TTL/4", () => {
   beforeEach(() => {
     vi.useFakeTimers();


### PR DESCRIPTION
## Summary

Fail closed on a malformed (non-UUID) `userId` in the tenant-JWT mint path so it can never reach the Supabase Admin SDK.

Previously, a non-UUID `userId` (e.g. the e2e mock's literal `test-user-id`) made `auth.admin.getUserById` throw a raw `@supabase/auth-js: Expected parameter to be UUID` error deep inside `resolveFounderEmail`. That error is not a `RuntimeAuthError`, so it escaped `ws-handler.tenantFor`'s typed catch and, in the WebSocket connect path, became a process-killing `unhandledRejection` — crashing the local dev server and non-deterministically flaking the (blocking) `nav-states` structural-UI e2e gate on every dashboard/layout PR.

The fix guards `mintFounderJwt` at entry: `auth.uid()` is always a UUID, so a non-UUID `userId` can never resolve a real tenant — reject it as `RuntimeAuthError{cause:"jwt_mint"}` before any Admin SDK call. Callers already fail-open on `RuntimeAuthError` (`tenantFor` → `null`; server callers early-return), so the path now degrades gracefully. This also hardens prod against any malformed `userId` reaching the mint path, not just the e2e fixture.

## User-Brand Impact

- **Artifact exposed:** none — this adds an input-validation rejection; it reads no new field, moves no data, and writes nothing.
- **Exposure vector:** none — the guard strictly narrows the set of inputs that reach the Admin SDK. If the guard regex were wrong, a valid UUID could be wrongly rejected → the WS tenant features fail-open to `null` (the same degraded path as any mint failure); the `valid UUID still reaches the Admin SDK` test guards against that.
- **Brand-survival threshold:** none

threshold: none, reason: defensive fail-closed input-validation guard on the auth-mint path; no new data movement, write, or field selection — it only prevents a crash and is fully covered by unit tests.

## Changelog

### Web Platform
- Tenant JWT mint now fail-closes on a malformed (non-UUID) `userId` with a typed `RuntimeAuthError` instead of letting the Supabase Admin SDK throw an uncaught error that could crash the server.

## Test plan

- [x] 3 new unit tests in `tenant-jwt-refresh.test.ts` (both rejection paths assert `getUserById`/`generateLink` are never called; a fresh-UUID case proves the guard is non-vacuous)
- [x] `tsc --noEmit` clean
- [x] Full web-platform vitest suite green (8455 passed)
- [x] `test-all.sh` 98/98 suites
- [x] Review: security-sentinel + semgrep clean (no bypass, no ReDoS); pattern-recognition P3 docblock fixed inline

> Note (review P2, not fixed here): the `auth.uid()` UUID-shape regex now has 5 byte-identical copies across `tenant.ts`, `workspace.ts`, `api-usage.ts`, `list-runs.ts`. This PR follows the established local precedent; consolidating into one shared constant is a separate cross-cutting cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
