### PR TITLE
fix(chat): Concierge reads the open KB doc from the ACTIVE workspace (agent-native parity)

### DIFF
--- a/apps/web-platform/server/cc-dispatcher.ts
+++ b/apps/web-platform/server/cc-dispatcher.ts
@@ -905,12 +905,12 @@ export function cleanupCcBashGatesForConversation(
 // the factory once per cold conversation; reused dispatches skip.
 // ---------------------------------------------------------------------------
 
-// `fetchUserWorkspacePath`, `resolveConciergeDocumentContext`, and the
-// per-process workspace memo were extracted to `./kb-document-resolver`
-// so this orchestration module no longer owns filesystem responsibilities
-// alongside SDK Query construction, MCP wiring, BYOK token resolution,
-// bash-approval, and rate-limiting. Both modules share the workspace
-// memo via the resolver's exported helper.
+// `fetchUserWorkspacePath` and `resolveConciergeDocumentContext` were
+// extracted to `./kb-document-resolver` so this orchestration module no
+// longer owns filesystem responsibilities alongside SDK Query construction,
+// MCP wiring, BYOK token resolution, bash-approval, and rate-limiting. Both
+// modules resolve the active-workspace path via the same exported helper
+// (one source of truth; no value cache — the active workspace is mutable).
 
 /**
  * Build a real SDK `Query` for one cold cc-soleur-go conversation. Async
@@ -2187,9 +2187,10 @@ export function __resetDispatcherForTests(): void {
   // prefix in test A can survive into test B (cross-file leak via the
   // module-level Map). Mirrors the centralization Fix 6 of PR #2954.
   _resetBashApprovalCacheForTests();
-  // Drain the workspace-path memo so a `users.workspace_path` swap in
-  // tests is observable. Lives in `kb-document-resolver.ts` for the same
-  // reason as the bash cache: shared across files, drained centrally.
+  // Retained no-op: the workspace-path value cache was removed in the ADR-044
+  // cutover (the active workspace is mutable per session). Kept in the central
+  // reset so test files that call it keep compiling. See
+  // `kb-document-resolver.ts` `_resetWorkspacePathCacheForTests`.
   _resetWorkspacePathCacheForTests();
 }
 

--- a/apps/web-platform/server/cc-dispatcher.ts
+++ b/apps/web-platform/server/cc-dispatcher.ts
@@ -1661,10 +1661,11 @@ export async function dispatchSoleurGo(
   // Resolve workspace path in parallel with `runner.dispatch` so cold-start
   // LTFT (latency-to-first-token) does not pay an extra serial Supabase RTT.
   // The closure-shared `workspacePath` is filled by the `.then` below; in
-  // production, `realSdkQueryFactory` (line 419) awaits the SAME memo before
-  // the SDK Query can emit any block, so by the time `onToolUse` fires the
-  // value is set. On warm dispatches the memo returns synchronously inside
-  // `fetchUserWorkspacePath` and the `.then` resolves on the next microtask.
+  // production, `realSdkQueryFactory` independently resolves the same active
+  // workspace before the SDK Query can emit any block, so by the time
+  // `onToolUse` fires the value is set. `fetchUserWorkspacePath` resolves the
+  // ACTIVE workspace (ADR-044) on each call — a single indexed
+  // `user_session_state` read — so this `.then` is a cheap parallel resolve.
   // On failure, fall back to `undefined` — `buildToolLabel` still produces
   // the verbose label (just without the workspace-prefix scrub) and the
   // error is mirrored to Sentry per `cq-silent-fallback-must-mirror-to-sentry`.

--- a/apps/web-platform/server/kb-document-resolver.ts
+++ b/apps/web-platform/server/kb-document-resolver.ts
@@ -21,6 +21,7 @@ import {
   RuntimeAuthError,
 } from "@/lib/supabase/tenant";
 import { reportSilentFallback, mirrorWithDebounce } from "./observability";
+import { resolveActiveWorkspacePath } from "./workspace-resolver";
 import { isPathInWorkspace } from "./sandbox";
 import {
   extractPdfText,
@@ -60,25 +61,35 @@ export const FULL_TEXT_CAP_BYTES = 5 * 1024 * 1024;
 
 // PR-C §2.7 (#3244): module-level service-role lazy singleton retired;
 // `getFreshTenantClient(userId)` has its own per-userId TTL cache, so
-// per-call mint cost is bounded. The workspace_path cache below is
-// orthogonal — it memoizes the VALUE, not the client.
+// per-call mint cost is bounded.
 
-// Per-process memo for `users.workspace_path`. The workspace path is
-// immutable per user lifetime — without this, every Concierge turn re-hits
-// Supabase from `resolveConciergeDocumentContext` even though the answer
-// never changes. Key: userId.
-const _workspacePathCache = new Map<string, string>();
-
+/**
+ * Resolve the on-disk workspace path the Concierge document resolver and the
+ * agent sandbox cwd should operate against.
+ *
+ * ADR-044 (#4543) cutover: this resolves the caller's ACTIVE workspace
+ * (`<WORKSPACES_ROOT>/<active_workspace_id>`, computed) — the SAME source the
+ * UI KB file tree renders from (`resolveActiveWorkspaceKbRoot`). It no longer
+ * reads the legacy `users.workspace_path` column, which is stale/empty for
+ * invited members and for users provisioned after the `users → workspaces`
+ * relocation — the divergence that left the agent blind to the document the
+ * user has open (agent-native parity bug). The membership self-heal inside
+ * `resolveActiveWorkspacePath` fails closed to the solo workspace (never a
+ * sibling), preserving cross-workspace read containment.
+ *
+ * No value cache: unlike the legacy column (immutable per user), the active
+ * workspace can change within a session (workspace switch), so a userId-keyed
+ * memo would serve a stale path after a switch. The underlying reads are a
+ * single indexed `user_session_state` lookup (+ one membership probe only when
+ * the active workspace is non-solo), and `getFreshTenantClient` already TTL-
+ * caches the client itself.
+ *
+ * RLS: the tenant client scopes `user_session_state` to `auth.uid() = user_id`.
+ * `RuntimeAuthError` from `getFreshTenantClient` is the load-bearing "workspace
+ * not provisioned" signal; callers catch it and mirror via
+ * `reportSilentFallback`.
+ */
 export async function fetchUserWorkspacePath(userId: string): Promise<string> {
-  const cached = _workspacePathCache.get(userId);
-  if (cached) return cached;
-  // PR-C §2.7 (#3244): tenant client. RLS on `users` enforces
-  // `auth.uid() = id`. The `.single()` SELECT IS the auth probe (reads
-  // only the caller's own row); RuntimeAuthError from
-  // `getFreshTenantClient` is the load-bearing distinction from
-  // "workspace not provisioned". Surface JWT-mint failure as the same
-  // contract ("Workspace not provisioned") since the caller catches and
-  // mirrors via `reportSilentFallback` in `resolveConciergeDocumentContext`.
   let tenant;
   try {
     tenant = await getFreshTenantClient(userId);
@@ -88,23 +99,18 @@ export async function fetchUserWorkspacePath(userId: string): Promise<string> {
     }
     throw err;
   }
-  const { data, error } = await tenant
-    .from("users")
-    .select("workspace_path")
-    .eq("id", userId)
-    .single();
-  if (error || !data?.workspace_path) {
-    throw new Error("Workspace not provisioned");
-  }
-  const workspacePath = data.workspace_path as string;
-  _workspacePathCache.set(userId, workspacePath);
-  return workspacePath;
+  return resolveActiveWorkspacePath(userId, tenant);
 }
 
-/** Test seam — tests that swap workspace_path between cases drain the
- *  cache to make the swap observable. Production callers never need this. */
+/**
+ * Test seam retained for import-site stability. The per-process workspace-path
+ * value cache was removed in the ADR-044 cutover (the active workspace is
+ * mutable per session), so there is nothing to drain — this is now a no-op.
+ * Kept so the document-resolver test suite that calls it between cases keeps
+ * compiling without a cross-file sweep.
+ */
 export function _resetWorkspacePathCacheForTests(): void {
-  _workspacePathCache.clear();
+  // no-op — value cache removed (see fetchUserWorkspacePath doc-comment).
 }
 
 /**

--- a/apps/web-platform/server/kb-document-resolver.ts
+++ b/apps/web-platform/server/kb-document-resolver.ts
@@ -7,10 +7,9 @@
 // Extracted from `cc-dispatcher.ts` so the orchestration layer doesn't
 // own filesystem responsibilities on top of SDK Query construction, MCP
 // wiring, BYOK token resolution, bash-approval, and rate-limiting. The
-// per-process `_workspacePathCache` lives here too because it's the
-// resolver's hot path; the cc-dispatcher's `realSdkQueryFactory`
-// re-imports `fetchUserWorkspacePath` from this module so both paths
-// share one cache and one source of truth.
+// cc-dispatcher's `realSdkQueryFactory` re-imports `fetchUserWorkspacePath`
+// from this module so the document resolver and the agent sandbox cwd share
+// one source of truth for the active-workspace path.
 
 import { readFile } from "fs/promises";
 import path from "path";

--- a/apps/web-platform/server/leader-document-resolver.ts
+++ b/apps/web-platform/server/leader-document-resolver.ts
@@ -60,8 +60,12 @@ export async function resolveLeaderDocumentContext(args: {
    * already SELECTs `workspace_path` (alongside repo_status/installation_id)
    * for the session — passing it through here avoids a second Supabase
    * round-trip via `fetchUserWorkspacePath` on every leader turn. When
-   * omitted, the resolver falls back to the cached fetcher (Concierge
-   * shape).
+   * omitted, the resolver falls back to `fetchUserWorkspacePath` (which now
+   * resolves the ACTIVE workspace, Concierge shape). NOTE: the production
+   * leader run path supplies `preResolvedPath` from `startAgentSession`'s
+   * legacy `users.workspace_path` SELECT, so it does NOT yet flow through the
+   * active-workspace resolution — that convergence is tracked with the
+   * leader/git workspace plumbing (PR #4868 / git-workspace-plumbing plan).
    */
   workspacePath?: string;
 }): Promise<ResolvedLeaderDocumentContext> {

--- a/apps/web-platform/server/workspace-resolver.ts
+++ b/apps/web-platform/server/workspace-resolver.ts
@@ -268,17 +268,32 @@ type MaybeSingleChain<T> = {
   maybeSingle: () => MaybeSingleChain<T>;
 } & PromiseLike<{ data: T | null; error: unknown }>;
 
-export async function resolveActiveWorkspaceKbRoot(
+/**
+ * Resolve the caller's ACTIVE workspace id (ADR-044), self-healing a stale
+ * non-member claim back to the SOLO workspace (fail-closed — never a sibling).
+ *
+ * This is steps 1-2 of `resolveActiveWorkspaceKbRoot`, extracted so the
+ * Concierge document resolver and the agent sandbox cwd
+ * (`fetchUserWorkspacePath`) resolve the SAME workspace the UI KB file tree
+ * renders from. Without sharing this resolution, the agent goes blind to the
+ * document the user has open — the agent-native parity bug (#4543 class) this
+ * resolver exists to prevent.
+ *
+ * RLS: `user_session_state` + `workspace_members` reads are self-scoped via
+ * `.eq("user_id", userId)`; a tenant client cannot influence the result
+ * cross-tenant, and the non-member fallback is unconditionally solo.
+ */
+export async function resolveActiveWorkspaceIdWithMembership(
   userId: string,
   supabase: SupabaseLike,
-): Promise<ActiveWorkspaceKbAccess> {
+): Promise<string> {
   // 1. Active workspace id — claim → solo fallback (never a sibling).
   let activeWorkspaceId = await resolveCurrentWorkspaceId(userId, supabase);
 
   // 2. J5 self-heal parity: a non-solo claim the caller is no longer a member
-  //    of must NOT read the sibling's KB. Fall back to solo (read-only — the
-  //    active-repo route's corrective set_current_workspace_id write is for the
-  //    badge; a GET must stay side-effect-free).
+  //    of must NOT read the sibling's workspace. Fall back to solo (read-only —
+  //    the active-repo route's corrective set_current_workspace_id write is for
+  //    the badge; a GET / agent dispatch must stay side-effect-free).
   if (activeWorkspaceId !== userId) {
     const memberChain = supabase.from("workspace_members") as MaybeSingleChain<{
       user_id: string;
@@ -308,6 +323,41 @@ export async function resolveActiveWorkspaceKbRoot(
       activeWorkspaceId = userId; // never the sibling
     }
   }
+  return activeWorkspaceId;
+}
+
+/**
+ * The on-disk workspace path for the caller's ACTIVE workspace
+ * (`<WORKSPACES_ROOT>/<active_workspace_id>`). This is the path the UI KB file
+ * tree renders from (`resolveActiveWorkspaceKbRoot`). The Concierge document
+ * resolver and the agent sandbox cwd MUST use this — NOT the legacy
+ * `users.workspace_path` column, which is stale/empty for invited members and
+ * for users provisioned after the ADR-044 `users → workspaces` relocation
+ * (#4559). Always returns a path (the active-id resolution fails closed to
+ * solo), never throws "not provisioned".
+ */
+export async function resolveActiveWorkspacePath(
+  userId: string,
+  supabase: SupabaseLike,
+): Promise<string> {
+  const activeWorkspaceId = await resolveActiveWorkspaceIdWithMembership(
+    userId,
+    supabase,
+  );
+  return workspacePathForWorkspaceId(activeWorkspaceId);
+}
+
+export async function resolveActiveWorkspaceKbRoot(
+  userId: string,
+  supabase: SupabaseLike,
+): Promise<ActiveWorkspaceKbAccess> {
+  // 1-2. Active workspace id (claim → solo fallback) with the J5 membership
+  //      self-heal — shared with the Concierge/agent workspace-path resolver so
+  //      both read the identical fail-closed source (ADR-044 parity).
+  const activeWorkspaceId = await resolveActiveWorkspaceIdWithMembership(
+    userId,
+    supabase,
+  );
 
   // 3. Connectivity gate — read the SOURCE OF TRUTH (`workspaces`), not
   //    `users.repo_status` (ADR-044 relocated repo state to `workspaces`).

--- a/apps/web-platform/server/ws-handler.ts
+++ b/apps/web-platform/server/ws-handler.ts
@@ -1092,16 +1092,16 @@ export async function dispatchSoleurGoForConversation(
   }
 
   // 2026-05-06 Bug A1 fix — resolve workspacePath up-front when an
-  // artifact directive is going to be built. The resolver above already
-  // populated the per-process `_workspacePathCache` for non-warm turns
-  // with a contextPath; this fetch is a synchronous map lookup in that
-  // case. For warm turns or no-context dispatches, the runner skips
-  // system-prompt construction entirely (the prompt is baked at cold
-  // construction), so a missing workspacePath here is a no-op. On
-  // failure (DB transient error, missing workspace_path row), fall
-  // through with undefined — the runner's directive builder gracefully
-  // falls back to the relative path, which the Bug A2 sandbox fix
-  // tolerates for in-workspace files.
+  // artifact directive is going to be built. `fetchUserWorkspacePath`
+  // resolves the caller's ACTIVE workspace (ADR-044) — a single indexed
+  // `user_session_state` read (the resolver above made the same call, but
+  // the value is not cached, so this is an independent cheap resolve). For
+  // warm turns or no-context dispatches, the runner skips system-prompt
+  // construction entirely (the prompt is baked at cold construction), so a
+  // missing workspacePath here is a no-op. On failure (DB transient error,
+  // workspace not provisioned), fall through with undefined — the runner's
+  // directive builder gracefully falls back to the relative path, which the
+  // Bug A2 sandbox fix tolerates for in-workspace files.
   let workspacePath: string | undefined;
   if (context?.path && !warmCcQuery) {
     try {

--- a/apps/web-platform/test/cc-concierge-pdf-summarize-e2e.test.ts
+++ b/apps/web-platform/test/cc-concierge-pdf-summarize-e2e.test.ts
@@ -28,12 +28,17 @@ import {
 import { tmpdir } from "os";
 import path from "path";
 
-const { fetchUserWorkspacePathSpy, extractPdfTextSpy, reportSilentFallbackSpy } =
-  vi.hoisted(() => ({
-    fetchUserWorkspacePathSpy: vi.fn(),
-    extractPdfTextSpy: vi.fn(),
-    reportSilentFallbackSpy: vi.fn(),
-  }));
+const {
+  fetchUserWorkspacePathSpy,
+  resolveActiveWorkspacePathSpy,
+  extractPdfTextSpy,
+  reportSilentFallbackSpy,
+} = vi.hoisted(() => ({
+  fetchUserWorkspacePathSpy: vi.fn(),
+  resolveActiveWorkspacePathSpy: vi.fn(),
+  extractPdfTextSpy: vi.fn(),
+  reportSilentFallbackSpy: vi.fn(),
+}));
 
 vi.mock("@/lib/supabase/service", () => ({
   createServiceClient: () => ({
@@ -61,6 +66,13 @@ vi.mock("@/lib/supabase/tenant", () => ({
   }),
   RuntimeAuthError: class RuntimeAuthError extends Error {},
 }));
+
+vi.mock("@/server/workspace-resolver", async () => {
+  const actual = await vi.importActual<typeof import("@/server/workspace-resolver")>(
+    "@/server/workspace-resolver",
+  );
+  return { ...actual, resolveActiveWorkspacePath: resolveActiveWorkspacePathSpy };
+});
 
 vi.mock("@/server/observability", () => ({
   reportSilentFallback: reportSilentFallbackSpy,
@@ -94,6 +106,7 @@ beforeEach(() => {
     data: { workspace_path: tmpRoot },
     error: null,
   });
+  resolveActiveWorkspacePathSpy.mockResolvedValue(tmpRoot);
   extractPdfTextSpy.mockReset();
   reportSilentFallbackSpy.mockReset();
   _resetWorkspacePathCacheForTests();

--- a/apps/web-platform/test/cc-dispatcher-concierge-context.test.ts
+++ b/apps/web-platform/test/cc-dispatcher-concierge-context.test.ts
@@ -11,11 +11,13 @@ import path from "path";
 
 const {
   fetchUserWorkspacePathSpy,
+  resolveActiveWorkspacePathSpy,
   extractPdfTextSpy,
   extractPdfMetadataSpy,
   reportSilentFallbackSpy,
 } = vi.hoisted(() => ({
   fetchUserWorkspacePathSpy: vi.fn(),
+  resolveActiveWorkspacePathSpy: vi.fn(),
   extractPdfTextSpy: vi.fn(),
   // 2026-05-07 follow-up to #3429: the resolver now imports
   // `extractPdfMetadata` for the page-count gate on the oversized_buffer
@@ -53,6 +55,13 @@ vi.mock("@/lib/supabase/tenant", () => ({
   }),
   RuntimeAuthError: class RuntimeAuthError extends Error {},
 }));
+
+vi.mock("@/server/workspace-resolver", async () => {
+  const actual = await vi.importActual<typeof import("@/server/workspace-resolver")>(
+    "@/server/workspace-resolver",
+  );
+  return { ...actual, resolveActiveWorkspacePath: resolveActiveWorkspacePathSpy };
+});
 
 vi.mock("@/server/observability", () => ({
   reportSilentFallback: reportSilentFallbackSpy,
@@ -93,6 +102,7 @@ beforeEach(() => {
     data: { workspace_path: tmpRoot },
     error: null,
   });
+  resolveActiveWorkspacePathSpy.mockResolvedValue(tmpRoot);
   extractPdfTextSpy.mockReset();
   reportSilentFallbackSpy.mockReset();
   // Drain the per-process workspace-path memo so each test sees its own

--- a/apps/web-platform/test/cc-dispatcher-concierge-context.test.ts
+++ b/apps/web-platform/test/cc-dispatcher-concierge-context.test.ts
@@ -102,13 +102,14 @@ beforeEach(() => {
     data: { workspace_path: tmpRoot },
     error: null,
   });
+  // Per-test isolation comes from re-seeding this spy each case; the resolver
+  // resolves the active-workspace path via `resolveActiveWorkspacePath` (no
+  // value cache to leak across tests).
   resolveActiveWorkspacePathSpy.mockResolvedValue(tmpRoot);
   extractPdfTextSpy.mockReset();
   reportSilentFallbackSpy.mockReset();
-  // Drain the per-process workspace-path memo so each test sees its own
-  // tmpRoot (the resolver caches `users.workspace_path` for the
-  // conversation lifetime — without a reset, test N's tmpRoot leaks into
-  // test N+1).
+  // Retained no-op (the workspace-path value cache was removed in the ADR-044
+  // cutover); harmless.
   _resetWorkspacePathCacheForTests();
 });
 

--- a/apps/web-platform/test/cc-dispatcher-prefill-guard.test.ts
+++ b/apps/web-platform/test/cc-dispatcher-prefill-guard.test.ts
@@ -22,6 +22,7 @@ const {
   mockBuildAgentEnv,
   mockBuildAgentSandboxConfig,
   mockSupabaseFrom,
+  mockResolveActiveWorkspacePath,
 } = vi.hoisted(() => ({
   mockQuery: vi.fn(),
   mockApplyPrefillGuard: vi.fn(),
@@ -33,6 +34,7 @@ const {
   mockBuildAgentEnv: vi.fn(),
   mockBuildAgentSandboxConfig: vi.fn(),
   mockSupabaseFrom: vi.fn(),
+  mockResolveActiveWorkspacePath: vi.fn(),
 }));
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
@@ -125,6 +127,16 @@ vi.mock("@/lib/supabase/tenant", () => ({
   RuntimeAuthError: class RuntimeAuthError extends Error {},
 }));
 
+// ADR-044: fetchUserWorkspacePath resolves the ACTIVE workspace via
+// resolveActiveWorkspacePath. Override only that export; importActual keeps the
+// rest of workspace-resolver real.
+vi.mock("@/server/workspace-resolver", async () => {
+  const actual = await vi.importActual<typeof import("@/server/workspace-resolver")>(
+    "@/server/workspace-resolver",
+  );
+  return { ...actual, resolveActiveWorkspacePath: mockResolveActiveWorkspacePath };
+});
+
 // PR-C §2.11 (#3244): cc-dispatcher.ts now wraps `realSdkQueryFactory`
 // body in `runWithByokLease(args.userId, body)`. Short-circuit the lease
 // so the test does not pull the real `fetchAndDecryptIntoSlot` chain
@@ -196,6 +208,8 @@ function makeFakeQuery() {
 const WORKSPACE_PATH = "/tmp/cc-test-workspace";
 
 function setupSupabaseMockReturning(workspacePath: string = WORKSPACE_PATH) {
+  // ADR-044: workspace path comes from resolveActiveWorkspacePath now.
+  mockResolveActiveWorkspacePath.mockResolvedValue(workspacePath);
   mockSupabaseFrom.mockImplementation((table: string) => {
     if (table === "users") {
       return {

--- a/apps/web-platform/test/cc-dispatcher-real-factory.test.ts
+++ b/apps/web-platform/test/cc-dispatcher-real-factory.test.ts
@@ -32,6 +32,7 @@ const {
   mockResolveBashAutonomous,
   mockWriteAskpassScriptTo,
   mockCleanupAskpassScript,
+  mockResolveActiveWorkspacePath,
 } = vi.hoisted(() => ({
   mockQuery: vi.fn(),
   mockGetUserApiKey: vi.fn(),
@@ -47,6 +48,7 @@ const {
   mockResolveBashAutonomous: vi.fn(),
   mockWriteAskpassScriptTo: vi.fn(),
   mockCleanupAskpassScript: vi.fn(),
+  mockResolveActiveWorkspacePath: vi.fn(),
 }));
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
@@ -106,6 +108,16 @@ vi.mock("@/server/resolve-bash-autonomous", () => ({
 
 // Session-start ensure-repo self-heal (cold-path deps). Default no-op so the
 // factory-shape tests are unaffected.
+// ADR-044: fetchUserWorkspacePath now resolves the ACTIVE workspace via
+// resolveActiveWorkspacePath. Override only that export (importActual keeps the
+// rest of workspace-resolver real for any other consumer cc-dispatcher pulls).
+vi.mock("@/server/workspace-resolver", async () => {
+  const actual = await vi.importActual<typeof import("@/server/workspace-resolver")>(
+    "@/server/workspace-resolver",
+  );
+  return { ...actual, resolveActiveWorkspacePath: mockResolveActiveWorkspacePath };
+});
+
 vi.mock("@/server/current-repo-url", () => ({
   getCurrentRepoUrl: vi.fn(async () => null),
 }));
@@ -231,6 +243,16 @@ const WORKSPACE_PATH = "/tmp/cc-test-workspace";
 function setupSupabaseMockReturning(
   workspacePath: string | null = WORKSPACE_PATH,
 ) {
+  // ADR-044: the workspace path is resolved via resolveActiveWorkspacePath
+  // (active workspace), not the users.workspace_path read. A null workspacePath
+  // models the legacy "not provisioned" throw the factory's error path expects.
+  if (workspacePath) {
+    mockResolveActiveWorkspacePath.mockResolvedValue(workspacePath);
+  } else {
+    mockResolveActiveWorkspacePath.mockRejectedValue(
+      new Error("Workspace not provisioned"),
+    );
+  }
   mockSupabaseFrom.mockImplementation((table: string) => {
     if (table === "users") {
       return {

--- a/apps/web-platform/test/concierge-active-workspace-doc-parity.test.ts
+++ b/apps/web-platform/test/concierge-active-workspace-doc-parity.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression: the Concierge document resolver must read the open KB document
+ * from the caller's ACTIVE workspace — the same source the UI KB file tree
+ * renders from (`resolveActiveWorkspaceKbRoot`) — NOT the legacy
+ * `users.workspace_path` column.
+ *
+ * Agent-native parity bug (ADR-044 / #4543 class): pre-fix,
+ * `fetchUserWorkspacePath` read `users.workspace_path` (the caller's SOLO
+ * workspace, empty for an invited member or stale post-relocation), so the
+ * Concierge replied "the document didn't come through" while the UI showed a
+ * populated tree. This test seeds a member whose ACTIVE workspace differs from
+ * their solo workspace, puts the document ONLY in the active workspace, and
+ * asserts the resolver finds the body.
+ *
+ * RED on origin/main: the resolver reads `users.workspace_path` → the (empty)
+ * solo dir → ENOENT → `{}` → assertion fails.
+ * GREEN after the fix: the resolver computes the active-workspace path →
+ * reads the body.
+ *
+ * Drives the resolver/dispatch boundary deterministically (no LLM): the
+ * structural tenant-client mock returns BOTH the old (`users.workspace_path`)
+ * and new (`user_session_state` + `workspace_members`) read shapes, so the
+ * pass/fail signal isolates the workspace-source change, not a mock gap.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+
+// Structural tenant client implementing both the pre-fix `users` read and the
+// post-fix `user_session_state` / `workspace_members` reads. `.from(table)`
+// returns a recursive chain; the terminal `single`/`maybeSingle` resolve the
+// table-specific row. Mutated per-test via `rowsByTable`.
+const rowsByTable: Record<string, { data: unknown; error: unknown }> = {};
+
+function makeTenantClient() {
+  return {
+    from(table: string) {
+      const result = rowsByTable[table] ?? { data: null, error: null };
+      const chain: Record<string, unknown> = {};
+      chain.select = () => chain;
+      chain.eq = () => chain;
+      chain.maybeSingle = () => Promise.resolve(result);
+      chain.single = () => Promise.resolve(result);
+      return chain;
+    },
+  };
+}
+
+vi.mock("@/lib/supabase/tenant", () => ({
+  getFreshTenantClient: async () => makeTenantClient(),
+  RuntimeAuthError: class RuntimeAuthError extends Error {},
+}));
+
+vi.mock("@/server/observability", () => ({
+  reportSilentFallback: vi.fn(),
+  warnSilentFallback: vi.fn(),
+  mirrorWithDebounce: vi.fn(),
+  __resetMirrorDebounceForTests: vi.fn(),
+  MIRROR_DEBOUNCE_MS: 5 * 60 * 1000,
+}));
+
+// Avoid dragging the pdfjs lazy-import into a text-only test. The fixture is a
+// `.md` file so these are never invoked; the mock just keeps the import cheap.
+vi.mock("@/server/pdf-text-extract", async () => {
+  const actual = await vi.importActual<typeof import("@/server/pdf-text-extract")>(
+    "@/server/pdf-text-extract",
+  );
+  return { ...actual, extractPdfText: vi.fn(), extractPdfMetadata: vi.fn() };
+});
+
+import {
+  resolveConciergeDocumentContext,
+  _resetWorkspacePathCacheForTests,
+} from "@/server/kb-document-resolver";
+
+const MEMBER_ID = "member-0000-0000-0000-000000000001";
+const ACTIVE_WS_ID = "teamws-0000-0000-0000-000000000099";
+
+let workspacesRoot: string;
+let prevWorkspacesRoot: string | undefined;
+
+beforeEach(() => {
+  workspacesRoot = mkdtempSync(path.join(tmpdir(), "ws-root-"));
+  prevWorkspacesRoot = process.env.WORKSPACES_ROOT;
+  process.env.WORKSPACES_ROOT = workspacesRoot;
+
+  // Solo workspace = the member's own id (N2 invariant). Created EMPTY — the
+  // document is NOT here. Pre-fix this is where the resolver looked.
+  const soloDir = path.join(workspacesRoot, MEMBER_ID);
+  mkdirSync(path.join(soloDir, "knowledge-base"), { recursive: true });
+
+  // Active (shared) workspace — the document lives ONLY here. This is what the
+  // UI file tree renders from.
+  const activeDir = path.join(workspacesRoot, ACTIVE_WS_ID);
+  mkdirSync(path.join(activeDir, "knowledge-base"), { recursive: true });
+  writeFileSync(
+    path.join(activeDir, "knowledge-base", "shared-postmortem.md"),
+    "# Shared Postmortem\n\nMigration 059 made messages.workspace_id NOT NULL.\n",
+  );
+
+  rowsByTable.users = {
+    // Pre-fix source: points at the EMPTY solo dir.
+    data: { workspace_path: soloDir },
+    error: null,
+  };
+  rowsByTable.user_session_state = {
+    // Post-fix source: the member's active workspace is the shared one.
+    data: { current_workspace_id: ACTIVE_WS_ID },
+    error: null,
+  };
+  rowsByTable.workspace_members = {
+    // Membership self-heal probe: the member IS a member of the active ws, so
+    // resolution stays on the active workspace (does not fall back to solo).
+    data: { user_id: MEMBER_ID },
+    error: null,
+  };
+
+  _resetWorkspacePathCacheForTests();
+});
+
+afterEach(() => {
+  rmSync(workspacesRoot, { recursive: true, force: true });
+  if (prevWorkspacesRoot === undefined) delete process.env.WORKSPACES_ROOT;
+  else process.env.WORKSPACES_ROOT = prevWorkspacesRoot;
+  vi.clearAllMocks();
+  for (const k of Object.keys(rowsByTable)) delete rowsByTable[k];
+});
+
+describe("Concierge open-document context — active-workspace parity", () => {
+  it("resolves the open doc from the ACTIVE workspace, not the solo column", async () => {
+    const out = await resolveConciergeDocumentContext({
+      userId: MEMBER_ID,
+      contextPath: "knowledge-base/shared-postmortem.md",
+    });
+
+    expect(out.documentKind).toBe("text");
+    expect(out.artifactPath).toBe("knowledge-base/shared-postmortem.md");
+    // The body proves the resolver read the ACTIVE workspace dir. Pre-fix it
+    // read the empty solo dir and `documentContent` was undefined.
+    expect(out.documentContent).toContain("Shared Postmortem");
+    expect(out.documentContent).toContain("messages.workspace_id NOT NULL");
+  });
+
+  it("falls back to the SOLO workspace when the active claim is non-member", async () => {
+    // Stale claim the caller is no longer a member of: the membership probe
+    // returns no row → self-heal to solo (never the sibling). Put a solo doc to
+    // prove the solo path is read (not the sibling's).
+    rowsByTable.workspace_members = { data: null, error: null };
+    const soloDir = path.join(workspacesRoot, MEMBER_ID);
+    writeFileSync(
+      path.join(soloDir, "knowledge-base", "solo-note.md"),
+      "# Solo Note\n",
+    );
+
+    const out = await resolveConciergeDocumentContext({
+      userId: MEMBER_ID,
+      contextPath: "knowledge-base/solo-note.md",
+    });
+
+    expect(out.documentKind).toBe("text");
+    expect(out.documentContent).toContain("Solo Note");
+  });
+});

--- a/apps/web-platform/test/kb-document-resolver-chapter-chunked.test.ts
+++ b/apps/web-platform/test/kb-document-resolver-chapter-chunked.test.ts
@@ -21,12 +21,14 @@ import path from "path";
 
 const {
   fetchUserWorkspacePathSpy,
+  resolveActiveWorkspacePathSpy,
   extractPdfTextSpy,
   extractPdfMetadataSpy,
   extractPdfOutlineSpy,
   reportSilentFallbackSpy,
 } = vi.hoisted(() => ({
   fetchUserWorkspacePathSpy: vi.fn(),
+  resolveActiveWorkspacePathSpy: vi.fn(),
   extractPdfTextSpy: vi.fn(),
   extractPdfMetadataSpy: vi.fn(),
   extractPdfOutlineSpy: vi.fn(),
@@ -47,6 +49,13 @@ vi.mock("@/lib/supabase/tenant", () => ({
   }),
   RuntimeAuthError: class RuntimeAuthError extends Error {},
 }));
+
+vi.mock("@/server/workspace-resolver", async () => {
+  const actual = await vi.importActual<typeof import("@/server/workspace-resolver")>(
+    "@/server/workspace-resolver",
+  );
+  return { ...actual, resolveActiveWorkspacePath: resolveActiveWorkspacePathSpy };
+});
 
 vi.mock("@/server/observability", () => ({
   reportSilentFallback: reportSilentFallbackSpy,
@@ -85,6 +94,7 @@ beforeEach(() => {
     data: { workspace_path: tmpRoot },
     error: null,
   });
+  resolveActiveWorkspacePathSpy.mockResolvedValue(tmpRoot);
   extractPdfTextSpy.mockReset();
   extractPdfMetadataSpy.mockReset();
   extractPdfOutlineSpy.mockReset();

--- a/apps/web-platform/test/kb-document-resolver-pdf-page-gate.test.ts
+++ b/apps/web-platform/test/kb-document-resolver-pdf-page-gate.test.ts
@@ -24,11 +24,13 @@ import path from "path";
 
 const {
   fetchUserWorkspacePathSpy,
+  resolveActiveWorkspacePathSpy,
   extractPdfTextSpy,
   extractPdfMetadataSpy,
   reportSilentFallbackSpy,
 } = vi.hoisted(() => ({
   fetchUserWorkspacePathSpy: vi.fn(),
+  resolveActiveWorkspacePathSpy: vi.fn(),
   extractPdfTextSpy: vi.fn(),
   extractPdfMetadataSpy: vi.fn(),
   reportSilentFallbackSpy: vi.fn(),
@@ -47,6 +49,13 @@ vi.mock("@/lib/supabase/tenant", () => ({
   }),
   RuntimeAuthError: class RuntimeAuthError extends Error {},
 }));
+
+vi.mock("@/server/workspace-resolver", async () => {
+  const actual = await vi.importActual<typeof import("@/server/workspace-resolver")>(
+    "@/server/workspace-resolver",
+  );
+  return { ...actual, resolveActiveWorkspacePath: resolveActiveWorkspacePathSpy };
+});
 
 vi.mock("@/server/observability", () => ({
   reportSilentFallback: reportSilentFallbackSpy,
@@ -88,6 +97,7 @@ beforeEach(() => {
     data: { workspace_path: tmpRoot },
     error: null,
   });
+  resolveActiveWorkspacePathSpy.mockResolvedValue(tmpRoot);
   extractPdfTextSpy.mockReset();
   extractPdfMetadataSpy.mockReset();
   reportSilentFallbackSpy.mockReset();

--- a/apps/web-platform/test/leader-document-resolver-chapter-chunked.test.ts
+++ b/apps/web-platform/test/leader-document-resolver-chapter-chunked.test.ts
@@ -16,12 +16,14 @@ import path from "path";
 
 const {
   fetchUserWorkspacePathSpy,
+  resolveActiveWorkspacePathSpy,
   extractPdfTextSpy,
   extractPdfMetadataSpy,
   extractPdfOutlineSpy,
   reportSilentFallbackSpy,
 } = vi.hoisted(() => ({
   fetchUserWorkspacePathSpy: vi.fn(),
+  resolveActiveWorkspacePathSpy: vi.fn(),
   extractPdfTextSpy: vi.fn(),
   extractPdfMetadataSpy: vi.fn(),
   extractPdfOutlineSpy: vi.fn(),
@@ -54,6 +56,13 @@ vi.mock("@/lib/supabase/tenant", () => ({
   RuntimeAuthError: class RuntimeAuthError extends Error {},
 }));
 
+vi.mock("@/server/workspace-resolver", async () => {
+  const actual = await vi.importActual<typeof import("@/server/workspace-resolver")>(
+    "@/server/workspace-resolver",
+  );
+  return { ...actual, resolveActiveWorkspacePath: resolveActiveWorkspacePathSpy };
+});
+
 vi.mock("@/server/observability", () => ({
   reportSilentFallback: reportSilentFallbackSpy,
   warnSilentFallback: vi.fn(),
@@ -84,6 +93,7 @@ beforeEach(() => {
     data: { workspace_path: tmpRoot },
     error: null,
   });
+  resolveActiveWorkspacePathSpy.mockResolvedValue(tmpRoot);
   extractPdfTextSpy.mockReset();
   extractPdfMetadataSpy.mockReset();
   extractPdfOutlineSpy.mockReset();

--- a/apps/web-platform/test/leader-document-resolver.test.ts
+++ b/apps/web-platform/test/leader-document-resolver.test.ts
@@ -24,11 +24,13 @@ import path from "path";
 
 const {
   fetchUserWorkspacePathSpy,
+  resolveActiveWorkspacePathSpy,
   extractPdfTextSpy,
   extractPdfMetadataSpy,
   reportSilentFallbackSpy,
 } = vi.hoisted(() => ({
   fetchUserWorkspacePathSpy: vi.fn(),
+  resolveActiveWorkspacePathSpy: vi.fn(),
   extractPdfTextSpy: vi.fn(),
   extractPdfMetadataSpy: vi.fn(),
   reportSilentFallbackSpy: vi.fn(),
@@ -60,6 +62,13 @@ vi.mock("@/lib/supabase/tenant", () => ({
   RuntimeAuthError: class RuntimeAuthError extends Error {},
 }));
 
+vi.mock("@/server/workspace-resolver", async () => {
+  const actual = await vi.importActual<typeof import("@/server/workspace-resolver")>(
+    "@/server/workspace-resolver",
+  );
+  return { ...actual, resolveActiveWorkspacePath: resolveActiveWorkspacePathSpy };
+});
+
 vi.mock("@/server/observability", () => ({
   reportSilentFallback: reportSilentFallbackSpy,
   warnSilentFallback: vi.fn(),
@@ -89,6 +98,7 @@ beforeEach(() => {
     data: { workspace_path: tmpRoot },
     error: null,
   });
+  resolveActiveWorkspacePathSpy.mockResolvedValue(tmpRoot);
   extractPdfTextSpy.mockReset();
   extractPdfMetadataSpy.mockReset();
   reportSilentFallbackSpy.mockReset();

--- a/apps/web-platform/test/server/kb-document-resolver.tenant-isolation.test.ts
+++ b/apps/web-platform/test/server/kb-document-resolver.tenant-isolation.test.ts
@@ -1,13 +1,20 @@
 /**
- * Tenant isolation — kb-document-resolver.ts (PR-C §2.7, #3244).
+ * Tenant isolation — Concierge document workspace-path resolution.
  *
- * Covers the single migrated site at `:74` —
- * `fetchUserWorkspacePath(userId)` SELECT `users.workspace_path`.
- * RLS on `users`: `auth.uid() = id`.
+ * ADR-044 cutover (feat-one-shot-concierge-doc-context-parity): the Concierge
+ * document resolver + agent sandbox cwd no longer read `users.workspace_path`.
+ * `fetchUserWorkspacePath` (kb-document-resolver.ts) now resolves the caller's
+ * ACTIVE workspace via `resolveActiveWorkspacePath` → `resolveCurrentWorkspaceId`,
+ * which SELECTs `user_session_state.current_workspace_id` scoped to the caller's
+ * own id. RLS on `user_session_state`: `user_session_state_owner_select`
+ * (`auth.uid() = user_id`, migrations 060/064).
  *
- * Asserts: A's tenant JWT cannot read B's workspace_path. A spoofed
- * `.eq("id", userB.id).single()` MUST surface as PGRST116 (no rows)
- * which the SUT translates to `Error("Workspace not provisioned")`.
+ * Asserts: A's tenant JWT cannot read B's `user_session_state` row. B's row
+ * EXISTS (seeded via the service role), so a null result proves RLS DENIAL — not
+ * mere row-absence. This is the isolation guarantee behind the workspace-path
+ * resolution: A can never resolve B's active workspace, so the membership
+ * self-heal in `resolveActiveWorkspaceIdWithMembership` cannot be tricked into
+ * reading a sibling's workspace files.
  *
  * Opt-in via TENANT_INTEGRATION_TEST=1.
  */
@@ -47,7 +54,7 @@ function requireEnv(name: string): string {
 }
 
 describe.skipIf(!INTEGRATION_ENABLED)(
-  "tenant isolation — kb-document-resolver.ts (1 site)",
+  "tenant isolation — Concierge workspace-path resolution (user_session_state)",
   () => {
     let service: SupabaseClient;
     let aClient: SupabaseClient;
@@ -76,11 +83,15 @@ describe.skipIf(!INTEGRATION_ENABLED)(
         expect(user.id).toBeTruthy();
       }
 
+      // Seed a user_session_state row for BOTH users so the cross-tenant read
+      // tests RLS DENIAL (B's row exists) rather than row-absence. Only user_id
+      // is required (current_organization_id / current_workspace_id are nullable
+      // FKs; updated_at defaults). Leaving current_workspace_id NULL avoids the
+      // workspaces FK — the row's existence is what the deny test needs.
       for (const user of [userA, userB]) {
         const { error } = await service
-          .from("users")
-          .update({ workspace_path: `/tmp/synthetic/${user.id.slice(0, 8)}` })
-          .eq("id", user.id);
+          .from("user_session_state")
+          .upsert({ user_id: user.id }, { onConflict: "user_id" });
         expect(error).toBeNull();
       }
 
@@ -99,30 +110,31 @@ describe.skipIf(!INTEGRATION_ENABLED)(
       for (const user of [userA, userB]) {
         if (!user.id) continue;
         assertSynthetic(user.email);
+        // user_session_state row cascades on user delete (ON DELETE CASCADE).
         await service.auth.admin.deleteUser(user.id).catch(() => {});
       }
     }, 30_000);
 
-    test("baseline: A reads own workspace_path", async () => {
+    test("baseline: A reads own user_session_state row", async () => {
       const { data, error } = await aClient
-        .from("users")
-        .select("workspace_path")
-        .eq("id", userA.id)
-        .single();
+        .from("user_session_state")
+        .select("user_id, current_workspace_id")
+        .eq("user_id", userA.id)
+        .maybeSingle();
       expect(error).toBeNull();
-      expect(data?.workspace_path).toContain("/tmp/synthetic/");
+      expect(data?.user_id).toBe(userA.id);
     });
 
-    test("`:74` — A's tenant JWT cannot read B's workspace_path", async () => {
+    test("A's tenant JWT cannot read B's user_session_state (RLS denial)", async () => {
       const { data, error } = await aClient
-        .from("users")
-        .select("workspace_path")
-        .eq("id", userB.id)
-        .single();
-      // .single() on zero rows returns PGRST116 — the SUT translates this
-      // to `Error("Workspace not provisioned")`.
+        .from("user_session_state")
+        .select("user_id, current_workspace_id")
+        .eq("user_id", userB.id)
+        .maybeSingle();
+      // B's row EXISTS — a null result is RLS denying the cross-tenant read,
+      // not an absent row.
+      expect(error).toBeNull();
       expect(data).toBeNull();
-      expect(error?.code).toBe("PGRST116");
     });
   },
 );

--- a/knowledge-base/engineering/operations/post-mortems/chat-rls-workspace-id-outage-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/chat-rls-workspace-id-outage-postmortem.md
@@ -150,7 +150,7 @@ See Contributing factors below — the four factors (un-swept write sites, no wr
 
 - [x] PR #4831 — populate `workspace_id` on all 4 interactive `messages` INSERTs + grep-sweep guard test (`hr-write-boundary-sentinel-sweep-all-write-sites`).
 - [ ] #4839 — post-deploy verification a fresh message persists + Sentry signature stops.
-- [ ] **Liveness alert (factor 2):** alert when a workspace records zero interactive `messages` inserts over N hours (catches a silent write-path outage without waiting for a user report). File as a monitoring follow-up.
+- [x] **Liveness alert (factor 2):** alert when a workspace records zero interactive `messages` inserts over N hours (catches a silent write-path outage without waiting for a user report). Tracked: the MVP write-absence alert shipped in **#4849** (closed — code-managed Sentry alert on the `persist-user-message` failure signal); the complementary scheduled prod write-absence probe (defense-in-depth) is deferred under **#4854** (open).
 - [x] **Workflow gate (factor 4 + the after-the-fact-postmortem ask):** ship now requires a PIR for any incident-class fix, even when the incident is discovered incidentally during another change (see this PR's `ship` Phase 5.5 Incident-PIR gate + the `wg-incident-detected-always-run-postmortem` workflow gate).
 - [x] **Migration-author sweep reminder:** the RLS-column-add → write-site-sweep lesson is captured in `2026-06-02-rls-column-add-must-sweep-all-insert-sites-and-alert-op-is-not-the-user-failure.md`.
 
@@ -158,7 +158,7 @@ See Contributing factors below — the four factors (un-swept write sites, no wr
 
 GitHub issues to prevent recurrence:
 
-- **Monitoring/alert (factor 2):** file the write-absence liveness alert (zero interactive `messages` inserts in a workspace over N hours) — tracked as a monitoring follow-up.
+- **Monitoring/alert (factor 2):** write-absence liveness alert (zero interactive `messages` inserts in a workspace over N hours) — tracked under **#4849** (closed — MVP Sentry alert on the `persist-user-message` failure signal) and **#4854** (open — deferred scheduled prod write-absence probe, defense-in-depth).
 - **Verification:** #4839 — confirm a fresh message persists post-deploy and the `Failed to save user message` Sentry signature ceases.
 - **Test/guard:** generalized grep-sweep guard requiring ALL NOT-NULL-no-default `messages` columns (`REQUIRED_MESSAGE_COLUMNS`) — landed in PR #4839-fix.
 

--- a/knowledge-base/project/plans/2026-06-03-fix-concierge-open-doc-context-parity-plan.md
+++ b/knowledge-base/project/plans/2026-06-03-fix-concierge-open-doc-context-parity-plan.md
@@ -12,6 +12,58 @@ requires_cpo_signoff: true
 
 > Spec lacks valid `lane:` (no spec.md for this branch) — defaulted to `cross-domain` (TR2 fail-closed).
 
+## Enhancement Summary
+
+**Deepened on:** 2026-06-03
+**Gates passed:** 4.6 User-Brand Impact (present, threshold `single-user incident`), 4.7 Observability
+(all 5 fields present, no SSH in `discoverability_test`), 4.8 PAT-shaped var halt (none), 4.9
+UI-wireframe (no UI-surface file in Files-to-Edit/Create → skip). Cited rule IDs verified ACTIVE in
+`AGENTS.rest.md`: `cq-write-failing-tests-before`, `cq-silent-fallback-must-mirror-to-sentry`,
+`cq-test-fixtures-synthesized-only`. Cited code lines verified: `kb-chat-content.tsx:111`
+(`type: "kb-viewer"`), `ws-handler.ts:1086/1106` (`if (context?.path && !warmCcQuery)`),
+`ws-handler.ts:997` (`cc-pdf-resolver-skip` captureMessage). Issues #4849 (CLOSED) / #4854 (OPEN)
+verified live — citation-only, not work targets.
+
+> Note: the deepen-plan parallel research/review/skill sub-agents (Phase 2/3/4/5) could not be
+> spawned — the Task tool is unavailable in this planning environment. The structural halt gates
+> (4.6–4.9), precedent-diff (4.4), and verify-the-negative (4.45) passes were run inline below.
+> Given `brand_survival_threshold: single-user incident`, /work SHOULD re-run deepen-plan (or
+> ultrathink) where the substance reviewers (data-integrity-guardian, security-sentinel,
+> architecture-strategist) are available — plan-review style agents cannot cover proxy-vs-invariant
+> or workspace-isolation regressions.
+
+### Key Improvements (over the as-planned draft)
+
+1. **Root cause confirmed as a single workspace-source divergence (Phase 4.45 verify-the-negative).**
+   Both the document resolver (`kb-document-resolver.ts:72-102` `fetchUserWorkspacePath` →
+   `users.workspace_path`) AND the agent sandbox `cwd` (`cc-dispatcher.ts:978` `realSdkQueryFactory`
+   Promise.all → same `fetchUserWorkspacePath`) read the SAME per-user source. The UI "Workspace
+   ready" + file tree render from a different source. This is why failure 1 (doc not read) and
+   failure 2 (no .git / not initialized) co-occur — they are one bug.
+2. **Quote path (⌘⇧L) confirmed already wired** (`kb-chat-content.tsx:41` → `quoteRef` →
+   `ChatSurface` `insertQuote`); the gap is the open-document BODY only. Plan scopes the doc-body
+   fix and explicitly does NOT re-plumb the quote path.
+3. **Injection wiring confirmed intact end-to-end** (resolver → `dispatchSoleurGoForConversation`
+   `...documentArgs` → runner). The fix lives in workspace-source resolution, not the wiring.
+4. **Security-gate precedent-diff (Phase 4.4):** the two read-containment gates
+   (`knowledge-base/` prefix gate at `kb-document-resolver.ts:152`; `isPathInWorkspace` at `:193`)
+   are the ONLY controls preventing cross-workspace / `.git/**` / `attachments/<otherConv>` reads
+   via a Concierge `context.path`. Any workspace-path resolution change MUST preserve both — added
+   to ACs and User-Brand Impact.
+
+### New Considerations Discovered
+
+- **Coordination risk with the in-flight git-workspace-plumbing branch.** The merged PR #4868 and
+  the sibling plan `2026-06-03-fix-concierge-git-workspace-plumbing-per-user-repo-plan.md` both
+  touch workspace-path / repo resolution for the Concierge. If both branches independently change
+  how `fetchUserWorkspacePath` / the sandbox `cwd` resolves, they will conflict or double-fix. The
+  /work phase MUST read that plan's Phase 0 outcome before editing the workspace resolver.
+- **The `_workspacePathCache` per-process memo** (`kb-document-resolver.ts:70`) caches
+  `users.workspace_path` for the user's lifetime. If the bug is "stale workspace_path", a fix that
+  changes the SOURCE must also ensure the cache is keyed/invalidated correctly — the regression
+  test already drains it via `_resetWorkspacePathCacheForTests`, but production cache staleness is
+  a candidate failure mode to check in Phase 0.
+
 ## Overview
 
 Two changes in one PR.

--- a/knowledge-base/project/plans/2026-06-03-fix-concierge-open-doc-context-parity-plan.md
+++ b/knowledge-base/project/plans/2026-06-03-fix-concierge-open-doc-context-parity-plan.md
@@ -158,7 +158,7 @@ mis-resolution could cross-read another user's KB. (See `kb-document-resolver.ts
 ### Phase 1 — RED: failing regression test (TDD, `cq-write-failing-tests-before`)
 - Add a test asserting that an **open KB document is present in the assembled chat context** for
   the Concierge path. Co-locate with `apps/web-platform/test/cc-dispatcher-concierge-context.test.ts`
-  (existing) or add `apps/web-platform/test/ws-handler-concierge-open-doc-context.test.ts`.
+  (existing) or add `apps/web-platform/test/concierge-active-workspace-doc-parity.test.ts`.
   Path MUST match the vitest node glob `test/**/*.test.ts` (`vitest.config.ts:44`). Run with
   `./node_modules/.bin/vitest run <path>` (NOT `bun test` — `bunfig.toml` blocks bun discovery, #1469).
 - The assertion drives through the resolver/dispatch boundary (deterministic, no LLM): given a
@@ -196,7 +196,7 @@ mis-resolution could cross-read another user's KB. (See `kb-document-resolver.ts
   (PIR follow-ups + action items).
 
 ## Files to Create
-- `apps/web-platform/test/ws-handler-concierge-open-doc-context.test.ts` (or extend
+- `apps/web-platform/test/concierge-active-workspace-doc-parity.test.ts` (or extend
   `cc-dispatcher-concierge-context.test.ts`) — open-doc-in-assembled-context regression.
 
 ## Open Code-Review Overlap
@@ -273,7 +273,7 @@ logs:
   where: "Sentry breadcrumbs (cc-pdf-resolver, cc-pdf-extractor) + pino server logs"
   retention: "Sentry default project retention"
 discoverability_test:
-  command: "./node_modules/.bin/vitest run apps/web-platform/test/ws-handler-concierge-open-doc-context.test.ts"
+  command: "./node_modules/.bin/vitest run apps/web-platform/test/concierge-active-workspace-doc-parity.test.ts"
   expected_output: "assertion: assembled context contains the open KB doc body; test passes"
 ```
 

--- a/knowledge-base/project/plans/2026-06-03-fix-concierge-open-doc-context-parity-plan.md
+++ b/knowledge-base/project/plans/2026-06-03-fix-concierge-open-doc-context-parity-plan.md
@@ -1,0 +1,253 @@
+---
+title: "Fix Concierge open-document context parity (KB chat can't read the open doc / workspace files) + PIR follow-up cleanup"
+type: fix
+date: 2026-06-03
+branch: feat-one-shot-concierge-doc-context-parity
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+---
+
+# 🐛 Fix: Concierge cannot read the KB document the user has open (agent-native context parity) + PIR follow-up cleanup
+
+> Spec lacks valid `lane:` (no spec.md for this branch) — defaulted to `cross-domain` (TR2 fail-closed).
+
+## Overview
+
+Two changes in one PR.
+
+**PRIMARY (agent-native parity bug).** In the web-platform Knowledge Base UI, the Concierge
+chat docks beside an OPEN KB document; the input placeholder promises document-grounded Q&A
+("Ask about this document — ⌘⇧L to quote selection"). A user asked about follow-ups in an
+open post-mortem and the Concierge replied that it could **not** see the document ("the document
+didn't come through — no attachment or content arrived with your message") AND that "there's no
+connected git repository available in this session… the workspace may not be fully initialized
+yet" — **despite** the UI showing "Workspace ready" and a fully populated KB file tree.
+
+Agent-native invariant: **anything a user can see, the agent must see.** The doc the agent
+could not READ is itself a PIR about a silent WRITE-path context gap — same class, opposite
+direction.
+
+**SECONDARY (docs cleanup).** In
+`knowledge-base/engineering/operations/post-mortems/chat-rls-workspace-id-outage-postmortem.md`,
+the liveness-alert follow-up still reads "File as a monitoring follow-up" / "tracked as a
+monitoring follow-up" with no issue number. It IS tracked: **#4849** (CLOSED — MVP Sentry
+write-absence alert) and **#4854** (OPEN — deferred scheduled defense-in-depth probe). Update
+the "Follow-ups" and "Action Items" sections to cite both so the liveness item is no longer
+untracked-in-prose.
+
+> Note: #4849 and #4854 are **contextual citations to insert as literal text** in the PIR. They
+> are NOT work targets and MUST NOT be passed as work-item references (no `Closes`/`Ref` for
+> them in the PR body).
+
+This plan does research and design only for /work. **No code is written during planning.**
+
+## Premise Validation (Phase 0.6)
+
+| Cited reference | Probe | Result |
+| --- | --- | --- |
+| Issue #4849 (liveness alert, closed) | `gh issue view 4849 --json state,title` | **CLOSED** — "monitoring: alert on zero interactive message-saves per workspace (write-absence liveness)". Citation-only, not a work target. |
+| Issue #4854 (scheduled probe, open) | `gh issue view 4854 --json state,title` | **OPEN** — "feat(monitoring): scheduled prod write-absence probe for interactive messages (defense-in-depth)". Citation-only, not a work target. |
+| PIR file | `ls` | Exists (`...chat-rls-workspace-id-outage-postmortem.md`, 14 KB). "File as a monitoring follow-up" at line 153; "tracked as a monitoring follow-up" at line 161. |
+| `kb-document-resolver.ts` `resolveConciergeDocumentContext` | `Read` | Exists. Robust server-side resolver (text inline ≤ 50 KB, PDF extract, workspace-validation, Sentry mirrors). |
+| `leader-document-resolver.ts` (#3437) | `Read` | Exists. Sibling resolver for the leader path. |
+| ws-handler `dispatchSoleurGoForConversation` | `Read` | Exists. Calls the resolver and threads `documentArgs` into `dispatchSoleurGo`. |
+| PR #4868 (`feat-one-shot-concierge-git-credentials`) | `git log` / sibling plan | **MERGED** — injected per-workspace GH App installation token as `GH_TOKEN`. Adjacent but distinct work (git **push/auth**, not document **read**). See Research Reconciliation. |
+| Sibling plan `2026-06-03-fix-concierge-git-workspace-plumbing-per-user-repo-plan.md` | `Read` | Exists. Covers the git/workspace-mount + credential half. This plan MUST not duplicate it; it scopes the **document-read parity** dimension. |
+
+Premise holds. The bug is a **fix** (the injection wiring exists end-to-end), not a build —
+the open-document body is failing to *reach* the resolver-readable workspace, OR the resolver is
+returning empty because the per-user `users.workspace_path` it reads diverges from the workspace
+the UI's file tree renders from. Both halves are the same workspace-source divergence.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (from the bug report) | Reality (confirmed in code) | Plan response |
+| --- | --- | --- |
+| "The open KB document is NOT injected into the chat request context" | The **client** never populates `context.content`: `kb-chat-content.tsx:109` builds `initialContext = { path, type: "kb-viewer" }` only. The **server** resolver (`resolveConciergeDocumentContext`) reads the file from `users.workspace_path` when `providedContent` is null. So injection depends entirely on the server-side workspace read succeeding. | Confirm whether the resolver returns empty (workspace path missing/unpopulated) vs. drops on the `knowledge-base/` prefix gate vs. `isPathInWorkspace` rejection. Fix at the failing layer. The `cc-pdf-resolver-skip` Sentry warning (`ws-handler.ts:996`) is the diagnostic anchor. |
+| "Wire the open document + ⌘⇧L quoted selection through to the agent" | **Quote selection already reaches the request** as message text: `kb-chat-content.tsx:41` → `quoteRef` → `ChatSurface` `insertQuote` inserts a blockquote into the textarea; it is sent as normal `chat` content. The **open document body** is the gap, not the quote. | Scope the doc-body injection fix; record that the quote path already works (do NOT re-plumb it). Add a regression assertion that the open doc is present in assembled context regardless of quote. |
+| "No connected git repository / workspace not fully initialized" — separate root cause or same? | **Same root cause.** The agent sandbox `cwd`/workspace AND the document resolver both derive from `fetchUserWorkspacePath(userId)` → `users.workspace_path` (`kb-document-resolver.ts:72-102`, `cc-dispatcher.ts:978`). If that path is unprovisioned or unpopulated, the agent sees no `.git`/no KB tree (failure 2) AND the resolver returns no body (failure 1). The "Workspace ready" UI + file tree render from a **different** workspace source (workspace-scoping divergence, cf. plans `2026-06-02-fix-workspace-scoping-leak*`). | Treat failures 1 and 2 as one workspace-source-divergence root cause. The fix makes the resolver + agent sandbox read the SAME workspace the UI file tree renders from. **Do NOT** re-implement git-credential plumbing — PR #4868 / the git-workspace-plumbing plan own that. |
+| Injection wiring is missing | Wiring EXISTS: `dispatchSoleurGoForConversation` (ws-handler) → resolver → `dispatchSoleurGo` (`...documentArgs`) → runner system prompt. First-turn passes `pendingContext`; warm/turn-2+ rebuilds synthetic context from `session.contextPath` / `conversations.context_path`. | The fix is in the **workspace-source resolution**, not the wiring. Verify the wiring stays intact; the regression test asserts the assembled context carries the doc. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** the Concierge keeps replying "the document didn't
+come through" / "no connected git repository" while the UI shows "Workspace ready" with a full
+file tree — the single most trust-destroying failure for an agent-native product (the agent is
+blind to what the user is plainly looking at).
+
+**If this leaks, the user's data is exposed via:** the resolver's `knowledge-base/` prefix gate
+and `isPathInWorkspace` containment are the controls that stop a Concierge `context.path` from
+reading `attachments/<otherConvId>/*`, `.git/**`, or another user's workspace. Any fix that
+changes how the workspace path is resolved MUST preserve both gates — a per-user workspace
+mis-resolution could cross-read another user's KB. (See `kb-document-resolver.ts:144-197`.)
+
+**Brand-survival threshold:** single-user incident.
+
+## Implementation Phases
+
+### Phase 0 — Reproduce & localize the failing layer (no code)
+- Reproduce against a connected workspace: open a KB doc, ask the Concierge about it; capture the
+  `cc-pdf-resolver` / `cc-pdf-resolver-skip` breadcrumbs + the `concierge document context
+  resolved` breadcrumb (`ws-handler.ts:976`) to see `documentKindResolved`, `documentContentBytes`,
+  `documentExtractError`.
+- Determine which of these is true for the reported case:
+  - (a) `fetchUserWorkspacePath` throws / returns a path with no KB tree → resolver returns
+    `{ artifactPath, documentKind }` with NO `documentContent` (workspace-source divergence).
+  - (b) `context.path` does not start with `knowledge-base/` → resolver returns `{}` (prefix gate).
+  - (c) `isPathInWorkspace` rejects (workspace path ≠ tree root) → resolver returns `{}`.
+- Confirm the agent-sandbox `cwd` (`cc-dispatcher.ts` `realSdkQueryFactory`, `workspacePath` from
+  `fetchUserWorkspacePath`) points at the SAME directory the UI file tree renders from. Identify
+  the UI file-tree data source and diff the two workspace-path resolutions. **This diff is the
+  root cause.** (Cross-reference plans `2026-06-02-fix-workspace-scoping-leak*` and
+  `2026-06-03-fix-concierge-git-workspace-plumbing-per-user-repo-plan.md` — reuse, do not
+  re-derive.)
+
+### Phase 1 — RED: failing regression test (TDD, `cq-write-failing-tests-before`)
+- Add a test asserting that an **open KB document is present in the assembled chat context** for
+  the Concierge path. Co-locate with `apps/web-platform/test/cc-dispatcher-concierge-context.test.ts`
+  (existing) or add `apps/web-platform/test/ws-handler-concierge-open-doc-context.test.ts`.
+  Path MUST match the vitest node glob `test/**/*.test.ts` (`vitest.config.ts:44`). Run with
+  `./node_modules/.bin/vitest run <path>` (NOT `bun test` — `bunfig.toml` blocks bun discovery, #1469).
+- The assertion drives through the resolver/dispatch boundary (deterministic, no LLM): given a
+  user with a provisioned workspace containing a KB file at `knowledge-base/.../doc.md`, and a
+  `start_session` with `context.path` set, the resolved `documentArgs.documentContent` (or the
+  assembled system prompt) contains the doc body. Seed the workspace fixture (filesystem temp dir +
+  `users.workspace_path` swap, draining `_resetWorkspacePathCacheForTests`).
+- Test fixtures synthesized only (`cq-test-fixtures-synthesized-only`).
+
+### Phase 2 — GREEN: align the resolver + agent workspace to the user-visible workspace
+- Fix the workspace-source divergence found in Phase 0 so `fetchUserWorkspacePath` (resolver and
+  agent-sandbox `cwd`) resolves to the same per-user workspace the UI file tree renders from.
+  Exact shape depends on Phase 0 (e.g., the workspace-scoping resolver returning the active
+  workspace, not a stale `users.workspace_path`). Reuse existing workspace-resolver helpers; do not
+  fork a new path.
+- Preserve the two security gates verbatim: the `knowledge-base/` prefix gate and
+  `isPathInWorkspace` containment.
+- Per `cq-silent-fallback-must-mirror-to-sentry`: any new degraded path (workspace unresolved)
+  must mirror to Sentry (the resolver already does for `fetchUserWorkspacePath` failure).
+
+### Phase 3 — Secondary docs cleanup (PIR follow-ups)
+- In `chat-rls-workspace-id-outage-postmortem.md`, edit two lines:
+  - **Follow-ups (line ~153):** replace "File as a monitoring follow-up." with a citation to
+    **#4849 (closed)** and **#4854 (open)**, stating the liveness item is tracked (the MVP alert
+    landed in #4849; the scheduled defense-in-depth probe is deferred under #4854).
+  - **Action Items (line ~161):** replace "tracked as a monitoring follow-up" with the same #4849
+    / #4854 citation.
+- Literal-text citations only — do NOT add `Closes #4849`/`Closes #4854` anywhere.
+
+## Files to Edit
+- `apps/web-platform/server/kb-document-resolver.ts` AND/OR the workspace-source resolver feeding
+  `fetchUserWorkspacePath` / agent-sandbox `cwd` (exact file determined by Phase 0; candidates:
+  `apps/web-platform/server/workspace-resolver.ts`, `apps/web-platform/server/cc-dispatcher.ts`).
+- `knowledge-base/engineering/operations/post-mortems/chat-rls-workspace-id-outage-postmortem.md`
+  (PIR follow-ups + action items).
+
+## Files to Create
+- `apps/web-platform/test/ws-handler-concierge-open-doc-context.test.ts` (or extend
+  `cc-dispatcher-concierge-context.test.ts`) — open-doc-in-assembled-context regression.
+
+## Open Code-Review Overlap
+
+None recorded at plan-write time (Task tool unavailable to query `gh issue list --label
+code-review` in-pipeline; /work MUST run the overlap query against the final Files-to-Edit list:
+`gh issue list --label code-review --state open --json number,title,body --limit 200` then `jq`
+per path).
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- [ ] A failing-first test asserts an open KB document body appears in the Concierge's assembled
+  chat context; it passes after the Phase 2 fix. Verify the test FAILS on `origin/main` and PASSES
+  on the branch (`./node_modules/.bin/vitest run <path>`).
+- [ ] Phase 0 root-cause note in the PR body names the exact workspace-source divergence (UI
+  file-tree workspace vs `fetchUserWorkspacePath` workspace) and the line where they diverge.
+- [ ] The `knowledge-base/` prefix gate and `isPathInWorkspace` containment are unchanged (grep
+  confirms both still present in the resolver).
+- [ ] PIR "Follow-ups" no longer contains "File as a monitoring follow-up"; the liveness bullet
+  cites **#4849** (closed) and **#4854** (open). `grep -c 'File as a monitoring follow-up'
+  <pir>` returns 0; `grep -c '#4849' <pir>` and `grep -c '#4854' <pir>` each ≥ 1.
+- [ ] PIR "Action Items" no longer contains "tracked as a monitoring follow-up"; it cites #4849/#4854.
+- [ ] PR body uses neither `Closes #4849` nor `Closes #4854` (citation-only).
+- [ ] `tsc --noEmit` + the full web-platform vitest node project pass.
+
+## Domain Review
+
+**Domains relevant:** Engineering, Product.
+
+(Domain leaders + Product/UX gate could not be spawned — Task tool unavailable in this planning
+environment. Recorded for /work to run the BLOCKING Product gate if any UI-surface file lands in
+Files-to-Edit; current Files-to-Edit are server + test + docs only — no `components/**/*.tsx`,
+`app/**/page.tsx`, or `app/**/layout.tsx` — so the mechanical UI-surface override does NOT fire and
+the Product gate is **NONE** by file-surface.)
+
+### Product/UX Gate
+
+**Tier:** none (no UI-surface file in Files-to-Edit; the fix is server-side workspace resolution).
+The user-facing behavior change is "the Concierge now reads the open doc" — a backend fix surfaced
+through existing UI; no new surface.
+
+### Engineering
+
+**Status:** reviewed (inline). **Assessment:** workspace-source divergence between the agent
+sandbox / document resolver and the UI file-tree; fix must converge them while preserving the two
+read-containment gates. Adjacent to (but distinct from) the merged git-credential work (#4868) and
+the in-flight git-workspace-plumbing plan — coordinate to avoid double-resolving workspace paths.
+
+## Infrastructure (IaC)
+
+Skip — pure code + docs change against already-provisioned surfaces (no new server, secret, vendor,
+cron, or persistent process). No `apps/<app>/infra/*.tf` change.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "Concierge `concierge document context resolved` breadcrumb with documentContentBytes > 0 on open-doc turns"
+  cadence: "per cold-Query Concierge dispatch with a context.path"
+  alert_target: "Sentry (existing cc-pdf-resolver breadcrumb + cc-pdf-resolver-skip captureMessage)"
+  configured_in: "apps/web-platform/server/ws-handler.ts emitConciergeDocumentResolutionBreadcrumb"
+error_reporting:
+  destination: "Sentry via reportSilentFallback / mirrorWithDebounce (feature: kb-concierge-context)"
+  fail_loud: true
+failure_modes:
+  - mode: "workspace path unresolved/unpopulated → empty documentContent"
+    detection: "cc-pdf-resolver-skip captureMessage (path provided, documentKind null) + documentContentBytes=0 breadcrumb"
+    alert_route: "Sentry warning, tag feature=cc-pdf-resolver op=skip"
+  - mode: "path-traversal / prefix-gate drop"
+    detection: "resolver returns {} (documentKindResolved null) on a knowledge-base/ path"
+    alert_route: "Sentry warning (same skip event)"
+logs:
+  where: "Sentry breadcrumbs (cc-pdf-resolver, cc-pdf-extractor) + pino server logs"
+  retention: "Sentry default project retention"
+discoverability_test:
+  command: "./node_modules/.bin/vitest run apps/web-platform/test/ws-handler-concierge-open-doc-context.test.ts"
+  expected_output: "assertion: assembled context contains the open KB doc body; test passes"
+```
+
+## Test Scenarios
+- Open KB text doc + ask → assembled context contains the doc body (regression test).
+- Workspace path unresolved → resolver mirrors to Sentry and returns no body (degraded, fail-loud).
+- Path outside `knowledge-base/` → resolver returns `{}` (gate preserved; no cross-read).
+- PIR grep: "File as a monitoring follow-up" / "tracked as a monitoring follow-up" both gone;
+  #4849 and #4854 both present.
+
+## Sharp Edges
+- A plan whose `## User-Brand Impact` section is empty, contains only TBD/TODO, or omits the
+  threshold will fail `deepen-plan` Phase 4.6. (This plan's section is filled; threshold =
+  single-user incident.)
+- #4849 / #4854 are **citations**, not work targets — never `Closes`/`Ref` them in the PR body or
+  pass them as work-item references.
+- Do NOT re-plumb the quoted-selection (⌘⇧L) path — it already reaches the request as blockquote
+  text via `quoteRef`/`insertQuote`. The gap is the open-document body only.
+- Do NOT duplicate the git-credential / git-workspace-mount work owned by PR #4868 and the
+  `2026-06-03-fix-concierge-git-workspace-plumbing-per-user-repo-plan.md` branch. This plan fixes
+  the document-**read** workspace-source divergence; coordinate so both don't fork workspace-path
+  resolution.
+- Regression test path MUST match `test/**/*.test.ts` (vitest node glob) and run via vitest, not
+  `bun test` (bunfig blocks bun discovery, #1469).
+- This plan was authored without the Task-spawned research/review/deepen agents (tool unavailable
+  in environment). /work SHOULD run the Open Code-Review Overlap query and, given
+  `brand_survival_threshold: single-user incident`, invoke deepen-plan/ultrathink for the
+  substance-level review (data-integrity-guardian + security-sentinel + architecture-strategist)
+  that plan-review cannot provide.

--- a/knowledge-base/project/specs/feat-one-shot-concierge-doc-context-parity/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-concierge-doc-context-parity/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-03-fix-concierge-open-doc-context-parity-plan.md
+- Status: complete
+
+### Errors
+- Task tool / parallel agent fan-out (repo-research, learnings, plan-review triad, deepen-plan reviewers) unavailable in the planning subagent's environment; investigation + structural halt gates (4.4/4.45/4.6–4.9) run inline. Plan recommends /work re-run deepen-plan/ultrathink for substance reviewers (single-user-incident threshold).
+- Two Write/Edit calls initially resolved to the bare-repo checkout and were blocked by the worktree guard; corrected to worktree-absolute paths. No content landed in bare root.
+
+### Decisions
+- Confirmed both failures share ONE root cause: the document resolver (kb-document-resolver.ts fetchUserWorkspacePath -> users.workspace_path) and the agent sandbox cwd (cc-dispatcher.ts:978) read the same per-user workspace source, which diverges from the source the UI "Workspace ready" file tree renders from. Doc-blindness (#1) and "no git repo / not initialized" (#2) co-occur from this single divergence -> scoped as one fix.
+- The injection wiring already exists end-to-end (resolver -> dispatchSoleurGoForConversation ...documentArgs -> runner system prompt). This is a FIX to workspace-source resolution, not a BUILD of missing plumbing. Regression test asserts the open doc appears in assembled context.
+- The Cmd+Shift+L quote path already reaches the request as blockquote text (quoteRef/insertQuote); plan does NOT re-plumb it — gap is the open-document body only.
+- Disambiguated from in-flight git-credential work (merged PR #4868 + sibling plan 2026-06-03-fix-concierge-git-workspace-plumbing-per-user-repo-plan.md): this plan owns document-READ workspace parity, not git push/auth.
+- Secondary docs cleanup scoped as literal #4849 (CLOSED) / #4854 (OPEN) citations in the PIR Follow-ups + Action Items, guardrailed as citations not work targets (no Closes/Ref).
+
+### Components Invoked
+- soleur:plan, soleur:deepen-plan (inline research/halt-gates in lieu of unavailable Task subagents)
+- Artifacts committed + pushed: plan .md (created + deepened), tasks.md

--- a/knowledge-base/project/specs/feat-one-shot-concierge-doc-context-parity/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-concierge-doc-context-parity/tasks.md
@@ -1,0 +1,50 @@
+# Tasks — Fix Concierge open-document context parity + PIR follow-up cleanup
+
+Plan: `knowledge-base/project/plans/2026-06-03-fix-concierge-open-doc-context-parity-plan.md`
+Branch: `feat-one-shot-concierge-doc-context-parity`
+Lane: cross-domain
+Brand-survival threshold: single-user incident (deepen-plan / ultrathink review recommended at /work)
+
+## Phase 0 — Reproduce & localize (no code)
+- [ ] 0.1 Reproduce: open a KB doc, ask the Concierge about it on a connected workspace.
+- [ ] 0.2 Capture Sentry breadcrumbs: `concierge document context resolved` (documentKindResolved,
+  documentContentBytes, documentExtractError) + `cc-pdf-resolver-skip`.
+- [ ] 0.3 Classify the failing layer: (a) workspace path unresolved/unpopulated, (b) prefix-gate
+  drop (`knowledge-base/`), or (c) `isPathInWorkspace` rejection.
+- [ ] 0.4 Diff the UI file-tree workspace source vs `fetchUserWorkspacePath`/agent-sandbox `cwd`.
+  Name the exact divergence line — this is the root cause. Cross-ref workspace-scoping plans.
+- [ ] 0.5 Run Open Code-Review Overlap query against final Files-to-Edit
+  (`gh issue list --label code-review --state open --json number,title,body --limit 200` + jq).
+
+## Phase 1 — RED (failing regression test first)
+- [ ] 1.1 Add `apps/web-platform/test/ws-handler-concierge-open-doc-context.test.ts` (or extend
+  `cc-dispatcher-concierge-context.test.ts`). Path must match `test/**/*.test.ts` (vitest node).
+- [ ] 1.2 Seed a synthetic workspace fixture (temp dir + `users.workspace_path` swap; drain
+  `_resetWorkspacePathCacheForTests`).
+- [ ] 1.3 Assert the assembled Concierge context (`documentArgs.documentContent` / system prompt)
+  contains the open KB doc body. Drive through resolver/dispatch boundary (no LLM).
+- [ ] 1.4 Confirm the test FAILS on `origin/main` (`./node_modules/.bin/vitest run <path>`).
+
+## Phase 2 — GREEN (fix workspace-source divergence)
+- [ ] 2.1 Converge `fetchUserWorkspacePath` (resolver + agent sandbox `cwd`) onto the same per-user
+  workspace the UI file tree renders from. Reuse existing workspace-resolver helpers.
+- [ ] 2.2 Preserve the `knowledge-base/` prefix gate and `isPathInWorkspace` containment verbatim.
+- [ ] 2.3 Mirror any new degraded path to Sentry (`cq-silent-fallback-must-mirror-to-sentry`).
+- [ ] 2.4 Confirm the Phase 1 test now PASSES.
+- [ ] 2.5 Do NOT re-plumb the ⌘⇧L quote path (already works) and do NOT duplicate PR #4868 /
+  git-workspace-plumbing git-credential work.
+
+## Phase 3 — Secondary docs cleanup (PIR follow-ups)
+- [ ] 3.1 PIR "Follow-ups" line ~153: replace "File as a monitoring follow-up." → cite #4849
+  (closed, MVP alert) and #4854 (open, deferred scheduled probe).
+- [ ] 3.2 PIR "Action Items" line ~161: replace "tracked as a monitoring follow-up" → same
+  #4849/#4854 citation.
+- [ ] 3.3 Literal citations only — no `Closes`/`Ref` for #4849/#4854 in the PR body.
+
+## Phase 4 — Verify & ship
+- [ ] 4.1 `tsc --noEmit` + full web-platform vitest node project pass.
+- [ ] 4.2 grep gates: `File as a monitoring follow-up` → 0; `tracked as a monitoring follow-up`
+  → 0; `#4849` ≥ 1; `#4854` ≥ 1 in the PIR.
+- [ ] 4.3 PR body includes a Phase 0 root-cause note naming the workspace-source divergence.
+- [ ] 4.4 Given single-user-incident threshold: run deepen-plan / ultrathink substance review
+  (data-integrity-guardian + security-sentinel + architecture-strategist).

--- a/knowledge-base/project/specs/feat-one-shot-concierge-doc-context-parity/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-concierge-doc-context-parity/tasks.md
@@ -6,45 +6,45 @@ Lane: cross-domain
 Brand-survival threshold: single-user incident (deepen-plan / ultrathink review recommended at /work)
 
 ## Phase 0 — Reproduce & localize (no code)
-- [ ] 0.1 Reproduce: open a KB doc, ask the Concierge about it on a connected workspace.
-- [ ] 0.2 Capture Sentry breadcrumbs: `concierge document context resolved` (documentKindResolved,
+- [x] 0.1 Reproduce: open a KB doc, ask the Concierge about it on a connected workspace.
+- [x] 0.2 Capture Sentry breadcrumbs: `concierge document context resolved` (documentKindResolved,
   documentContentBytes, documentExtractError) + `cc-pdf-resolver-skip`.
-- [ ] 0.3 Classify the failing layer: (a) workspace path unresolved/unpopulated, (b) prefix-gate
+- [x] 0.3 Classify the failing layer: (a) workspace path unresolved/unpopulated, (b) prefix-gate
   drop (`knowledge-base/`), or (c) `isPathInWorkspace` rejection.
-- [ ] 0.4 Diff the UI file-tree workspace source vs `fetchUserWorkspacePath`/agent-sandbox `cwd`.
+- [x] 0.4 Diff the UI file-tree workspace source vs `fetchUserWorkspacePath`/agent-sandbox `cwd`.
   Name the exact divergence line — this is the root cause. Cross-ref workspace-scoping plans.
-- [ ] 0.5 Run Open Code-Review Overlap query against final Files-to-Edit
+- [x] 0.5 Run Open Code-Review Overlap query against final Files-to-Edit
   (`gh issue list --label code-review --state open --json number,title,body --limit 200` + jq).
 
 ## Phase 1 — RED (failing regression test first)
-- [ ] 1.1 Add `apps/web-platform/test/ws-handler-concierge-open-doc-context.test.ts` (or extend
+- [x] 1.1 Add `apps/web-platform/test/ws-handler-concierge-open-doc-context.test.ts` (or extend
   `cc-dispatcher-concierge-context.test.ts`). Path must match `test/**/*.test.ts` (vitest node).
-- [ ] 1.2 Seed a synthetic workspace fixture (temp dir + `users.workspace_path` swap; drain
+- [x] 1.2 Seed a synthetic workspace fixture (temp dir + `users.workspace_path` swap; drain
   `_resetWorkspacePathCacheForTests`).
-- [ ] 1.3 Assert the assembled Concierge context (`documentArgs.documentContent` / system prompt)
+- [x] 1.3 Assert the assembled Concierge context (`documentArgs.documentContent` / system prompt)
   contains the open KB doc body. Drive through resolver/dispatch boundary (no LLM).
-- [ ] 1.4 Confirm the test FAILS on `origin/main` (`./node_modules/.bin/vitest run <path>`).
+- [x] 1.4 Confirm the test FAILS on `origin/main` (`./node_modules/.bin/vitest run <path>`).
 
 ## Phase 2 — GREEN (fix workspace-source divergence)
-- [ ] 2.1 Converge `fetchUserWorkspacePath` (resolver + agent sandbox `cwd`) onto the same per-user
+- [x] 2.1 Converge `fetchUserWorkspacePath` (resolver + agent sandbox `cwd`) onto the same per-user
   workspace the UI file tree renders from. Reuse existing workspace-resolver helpers.
-- [ ] 2.2 Preserve the `knowledge-base/` prefix gate and `isPathInWorkspace` containment verbatim.
-- [ ] 2.3 Mirror any new degraded path to Sentry (`cq-silent-fallback-must-mirror-to-sentry`).
-- [ ] 2.4 Confirm the Phase 1 test now PASSES.
-- [ ] 2.5 Do NOT re-plumb the ⌘⇧L quote path (already works) and do NOT duplicate PR #4868 /
+- [x] 2.2 Preserve the `knowledge-base/` prefix gate and `isPathInWorkspace` containment verbatim.
+- [x] 2.3 Mirror any new degraded path to Sentry (`cq-silent-fallback-must-mirror-to-sentry`).
+- [x] 2.4 Confirm the Phase 1 test now PASSES.
+- [x] 2.5 Do NOT re-plumb the ⌘⇧L quote path (already works) and do NOT duplicate PR #4868 /
   git-workspace-plumbing git-credential work.
 
 ## Phase 3 — Secondary docs cleanup (PIR follow-ups)
-- [ ] 3.1 PIR "Follow-ups" line ~153: replace "File as a monitoring follow-up." → cite #4849
+- [x] 3.1 PIR "Follow-ups" line ~153: replace "File as a monitoring follow-up." → cite #4849
   (closed, MVP alert) and #4854 (open, deferred scheduled probe).
-- [ ] 3.2 PIR "Action Items" line ~161: replace "tracked as a monitoring follow-up" → same
+- [x] 3.2 PIR "Action Items" line ~161: replace "tracked as a monitoring follow-up" → same
   #4849/#4854 citation.
-- [ ] 3.3 Literal citations only — no `Closes`/`Ref` for #4849/#4854 in the PR body.
+- [x] 3.3 Literal citations only — no `Closes`/`Ref` for #4849/#4854 in the PR body.
 
 ## Phase 4 — Verify & ship
-- [ ] 4.1 `tsc --noEmit` + full web-platform vitest node project pass.
-- [ ] 4.2 grep gates: `File as a monitoring follow-up` → 0; `tracked as a monitoring follow-up`
+- [x] 4.1 `tsc --noEmit` + full web-platform vitest node project pass.
+- [x] 4.2 grep gates: `File as a monitoring follow-up` → 0; `tracked as a monitoring follow-up`
   → 0; `#4849` ≥ 1; `#4854` ≥ 1 in the PIR.
-- [ ] 4.3 PR body includes a Phase 0 root-cause note naming the workspace-source divergence.
+- [x] 4.3 PR body includes a Phase 0 root-cause note naming the workspace-source divergence.
 - [ ] 4.4 Given single-user-incident threshold: run deepen-plan / ultrathink substance review
   (data-integrity-guardian + security-sentinel + architecture-strategist).

--- a/knowledge-base/project/specs/feat-one-shot-concierge-doc-context-parity/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-concierge-doc-context-parity/tasks.md
@@ -17,7 +17,7 @@ Brand-survival threshold: single-user incident (deepen-plan / ultrathink review 
   (`gh issue list --label code-review --state open --json number,title,body --limit 200` + jq).
 
 ## Phase 1 — RED (failing regression test first)
-- [x] 1.1 Add `apps/web-platform/test/ws-handler-concierge-open-doc-context.test.ts` (or extend
+- [x] 1.1 Add `apps/web-platform/test/concierge-active-workspace-doc-parity.test.ts` (or extend
   `cc-dispatcher-concierge-context.test.ts`). Path must match `test/**/*.test.ts` (vitest node).
 - [x] 1.2 Seed a synthetic workspace fixture (temp dir + `users.workspace_path` swap; drain
   `_resetWorkspacePathCacheForTests`).


### PR DESCRIPTION
## Why

A user with a Knowledge Base document open asked the docked **Concierge** chat about it. The Concierge replied it could **not** see the document ("the document didn't come through") and that "there's no connected git repository available… the workspace may not be fully initialized" — **even though the UI showed "Workspace ready" with a fully populated KB file tree.** Agent-native parity break: *anything the user can see, the agent must see.* (The doc it couldn't read is itself a PIR about a silent **write**-path context gap — same class, opposite direction.)

## Root cause (Phase 0)

The UI and the agent resolved the workspace **two different ways**:

| Path | Resolves the workspace dir via |
|------|--------------------------------|
| **UI file tree** — `app/api/kb/tree/route.ts:18` | `resolveActiveWorkspaceKbRoot` → **computes** `<WORKSPACES_ROOT>/<active_workspace_id>` |
| **Concierge doc resolver + agent cwd** — `kb-document-resolver.ts:72` (used by `cc-dispatcher.ts:978`, `ws-handler.ts:1108`) | `fetchUserWorkspacePath` → reads the **`users.workspace_path` column** |

The column is stale/empty for invited members and for users provisioned after the **ADR-044** `users → workspaces` relocation (#4559). When unset, `fetchUserWorkspacePath` threw → the resolver returned no body. The exact divergence line: `cc-dispatcher.ts:978` already resolved `repoUrl` / `installationId` / `bashAutonomous` from the **active** workspace, but `workspacePath` alone still read the solo column — inconsistent within the same `Promise.all`.

## What changed

- **`workspace-resolver.ts`**: extracted steps 1-2 of `resolveActiveWorkspaceKbRoot` (active-id + J5 membership self-heal, **fail-closed to solo — never a sibling**) into `resolveActiveWorkspaceIdWithMembership`; added `resolveActiveWorkspacePath`. `resolveActiveWorkspaceKbRoot` now reuses them (one source of truth).
- **`kb-document-resolver.ts`**: `fetchUserWorkspacePath` now resolves the **active** workspace path. Because it's the shared function, the **Concierge doc resolver, agent sandbox cwd, and ws-handler** converge at once. The `knowledge-base/` prefix gate and `isPathInWorkspace` containment are preserved verbatim (now relative to the active path). Removed the per-user value cache (the active workspace is mutable per session, so a userId-keyed memo would serve a stale path after a switch).
- **Regression test** `concierge-active-workspace-doc-parity.test.ts`: asserts the open doc resolves from the active workspace (verified RED against the old solo-column read, GREEN after the fix).
- **Test migration**: resolver/factory tests repointed to the new `resolveActiveWorkspacePath` seam; the tenant-isolation test repointed to the new effective read site (`user_session_state`, RLS denial proven with a seeded sibling row).
- **PIR cleanup** (`chat-rls-workspace-id-outage-postmortem.md`): the liveness follow-up now cites its tracking issues #4849 (closed — MVP write-absence Sentry alert) and #4854 (open — deferred scheduled probe), replacing the untracked "File as a monitoring follow-up" prose. (Citation-only — these are **not** closed by this PR.)

## Scope / not in scope

- **Leader chat production path is NOT converged here.** `agent-runner.ts` supplies `resolveLeaderDocumentContext` a `preResolvedPath` from the legacy `users.workspace_path` SELECT, bypassing the new resolution. That convergence belongs to the leader/git workspace plumbing (PR #4868 / the git-workspace-plumbing plan).
- `users.workspace_path` is still read by other surfaces (kb upload/file/sync/share, DSAR export, `agent-runner`) — a pre-existing dual-source-of-truth, out of scope for this parity fix.

## Substance review (single-user-incident threshold)

Ran security-sentinel (**SAFE** — cross-workspace containment preserved, fail-closed verified branch-by-branch), data-integrity-guardian (**SAFE**), architecture-strategist (**SOUND**), code-reviewer (**APPROVE**). All findings (stale cache comments + the leader-scope clarification) addressed inline.

## Test plan

- `tsc --noEmit` ✅
- Full web-platform vitest: **8477 passed, 0 failed** ✅
- New regression test RED→GREEN verified ✅
- PIR grep gates: `File as a monitoring follow-up` = 0, `tracked as a monitoring follow-up` = 0, `#4849` ≥ 1, `#4854` ≥ 1 ✅

## User-Brand Impact

- **If this lands broken:** the Concierge keeps replying "the document didn't come through" / "no connected git repository" while the UI shows "Workspace ready" with a populated tree — the most trust-destroying failure for an agent-native product (the agent blind to what the user is plainly looking at).
- **If this leaks:** the resolver's `knowledge-base/` prefix gate + `isPathInWorkspace` containment are the controls that stop a Concierge `context.path` from reading another workspace / `.git/**` / `attachments/<otherConv>`. The fix preserves both verbatim and resolves only workspaces the caller is a member of (fail-closed to solo, never a sibling) — verified SAFE by security-sentinel.
- **Brand-survival threshold:** single-user incident

## Signoff

Founder signoff received (2026-06-04). This PR changes a tenant-isolation-sensitive workspace-resolution path (plan `requires_cpo_signoff: true`, `brand_survival_threshold: single-user incident`); reviewed and approved to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
