### PR TITLE
fix(kb): service-role fallback when tenant-mint dead-ends Generate-link button

### DIFF
--- a/apps/web-platform/.service-role-allowlist
+++ b/apps/web-platform/.service-role-allowlist
@@ -263,3 +263,33 @@ apps/web-platform/server/inngest/functions/cron-supabase-disk-io.ts
 # fallback were deleted; it now reads the credential ONLY via the membership-
 # checked resolve_workspace_installation_id SECURITY DEFINER RPC through a
 # tenant client (getFreshTenantClient), so it no longer imports service-role.
+
+# ── #4913 — Generate-link tenant-mint regression fix ─────────────────
+#
+# RE-INTRODUCED (PR #4913). kb-route-helpers.ts was removed from this
+# allowlist in PR-C §2 when resolveUserKbRoot migrated to a tenant-scoped
+# read. That migration silently broke the "Generate link" share button for
+# ~19 days (PR #3854 regression): on any tenant-JWT mint failure
+# (jwt_mint | rotation | denied_jti) the helper 503'd, which the client
+# resets to idle — a brand-survival single-user incident. See the PIR at
+# knowledge-base/engineering/operations/post-mortems/generate-link-tenant-mint-regression-postmortem.md.
+#
+# PERMANENT (fallback only) — resolveUserKbRoot keeps the tenant-scoped read
+# as the PRIMARY path; the service-role client is used ONLY in the
+# RuntimeAuthError catch branch as an availability fallback. Ceiling that
+# keeps this safe for ALL three causes (incl. the deny-list `denied_jti`
+# case), independently verified by security-sentinel + user-impact-reviewer
+# at PR #4913 review time:
+#   (a) the fallback read is hard-scoped `.eq("id", userId)` where userId is
+#       the already-authenticated session user (server-derived, never
+#       request-controlled) — so even a revoked tenant token can read only
+#       its OWN workspace row, never another tenant's; and
+#   (b) the privileged share *write* (createShare) on this path was NEVER
+#       tenant-scoped (it uses service-role at app/api/kb/share/route.ts),
+#       so the deny-list never gated a privileged action here — `denied_jti`
+#       only ever blocked a self-read.
+# The sibling helper authenticateAndResolveKbPath (file PATCH/DELETE
+# *mutation* routes) intentionally stays tenant-only and 503s on mint
+# failure — there a `denied_jti` MUST block the action; applying the same
+# fallback there needs a per-cause adjudication, tracked in #4914.
+apps/web-platform/server/kb-route-helpers.ts

--- a/apps/web-platform/server/kb-route-helpers.ts
+++ b/apps/web-platform/server/kb-route-helpers.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import path from "path";
 import { promises as fs } from "node:fs";
-import { createClient } from "@/lib/supabase/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
 import {
   getFreshTenantClient,
   RuntimeAuthError,
@@ -233,9 +233,27 @@ export async function resolveUserKbRoot<
       ? `workspace_path, workspace_status, ${opts.extras.join(", ")}`
       : "workspace_path, workspace_status";
 
-  // PR-C §2.8 (#3244): tenant-scoped. Single-row SELECT IS the auth
-  // probe. RuntimeAuthError → same "Workspace not ready" response so
-  // callers don't have to discriminate.
+  // PR-C §2.8 (#3244): tenant-scoped read is the PRIMARY path. Single-row
+  // SELECT IS the auth probe.
+  //
+  // Regression fix (PR #3854 dead-ended the "Generate link" button): when the
+  // tenant JWT mint fails, fall back to a SERVICE-ROLE read of the user's OWN
+  // row instead of returning 503. A 503 here resets the share popover to idle
+  // — the silent dead-end the user reported.
+  //
+  // Ceiling that keeps the fallback safe for ALL three `RuntimeAuthError`
+  // causes (`jwt_mint` | `rotation` | `denied_jti`): the fallback read is
+  // scoped to `.eq("id", userId)` where `userId` is the already-authenticated
+  // session user, so even a deny-listed / revoked tenant token can only ever
+  // read its OWN workspace row — never another tenant's. The privileged share
+  // *write* (`createShare`) on this path was never tenant-scoped (it uses the
+  // service-role client at `route.ts`), so the deny-list never gated a
+  // privileged action here in the first place; `denied_jti` only blocked this
+  // self-read. We still emit `reportSilentFallback` so a chronically-failing
+  // mint (ceiling trip / GoTrue outage) stays visible to the operator in
+  // Sentry even though users now recover. The fallback applies the same
+  // `workspace_status === "ready"` + `extras` validation below, so a
+  // genuinely-not-ready workspace still gets the 503.
   let tenant;
   try {
     tenant = await getFreshTenantClient(userId);
@@ -246,15 +264,10 @@ export async function resolveUserKbRoot<
         op: "resolveUserKbRoot.tenant-mint",
         extra: { userId },
       });
-      return {
-        ok: false,
-        response: NextResponse.json(
-          { error: "Workspace not ready" },
-          { status: 503 },
-        ),
-      };
+      tenant = createServiceClient();
+    } else {
+      throw mintErr;
     }
-    throw mintErr;
   }
   const { data: userData } = await tenant
     .from("users")

--- a/apps/web-platform/server/kb-route-helpers.ts
+++ b/apps/web-platform/server/kb-route-helpers.ts
@@ -90,6 +90,13 @@ export async function authenticateAndResolveKbPath(
   // enforces `auth.uid() = id`. The `.single()` SELECT IS the auth
   // probe (the route flow reads only the caller's own row before any
   // cross-row work).
+  //
+  // NOTE: unlike `resolveUserKbRoot` (which falls back to a service-role
+  // read on mint failure), this helper intentionally 503s — it serves the
+  // file PATCH/DELETE *mutation* routes, where a `denied_jti` deny-list trip
+  // is MEANT to block the action; a service-role fallback there would defeat
+  // that revocation. Applying the same fallback to the mutation paths needs
+  // an explicit per-cause adjudication, tracked in #4914.
   let tenant;
   try {
     tenant = await getFreshTenantClient(user.id);

--- a/apps/web-platform/test/kb-route-helpers.test.ts
+++ b/apps/web-platform/test/kb-route-helpers.test.ts
@@ -816,6 +816,9 @@ describe("resolveUserKbRoot — tenant-mint fallback", () => {
       expect(result.extras.github_installation_id).toBe(TEST_INSTALLATION_ID);
     }
     expect(mockServiceFrom).toHaveBeenCalledWith("users");
+    // Non-vacuity: extras must come from the SERVICE read, not a split read
+    // that fetches base cols via service and extras via the (thrown) tenant.
+    expect(mockFrom).not.toHaveBeenCalled();
   });
 
   test("fallback still 503s when the SERVICE-ROLE read yields a non-ready workspace (no false-positive resolution)", async () => {
@@ -842,6 +845,8 @@ describe("resolveUserKbRoot — tenant-mint fallback", () => {
 
     expect(result.ok).toBe(true);
     expect(mockServiceFrom).toHaveBeenCalledWith("users");
+    // Non-vacuity: a denied_jti must NOT fall through to a tenant read.
+    expect(mockFrom).not.toHaveBeenCalled();
   });
 
   test("a non-RuntimeAuthError from the mint is re-thrown (not swallowed by the fallback)", async () => {

--- a/apps/web-platform/test/kb-route-helpers.test.ts
+++ b/apps/web-platform/test/kb-route-helpers.test.ts
@@ -7,6 +7,8 @@ import { describe, test, expect, vi, beforeEach } from "vitest";
 const {
   mockGetUser,
   mockFrom,
+  mockServiceFrom,
+  mockGetFreshTenantClient,
   mockGitWithAuth,
   mockIsPathInWorkspace,
   mockLstat,
@@ -15,6 +17,12 @@ const {
 } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
   mockFrom: vi.fn(),
+  // Distinct service-role `.from` so the mint-failure fallback tests can
+  // prove the SERVICE-ROLE client (not the tenant client) produced the
+  // resolved workspace — wiring both clients to the same `mockFrom` would
+  // let a fallback assertion pass vacuously (deepen-plan P1).
+  mockServiceFrom: vi.fn(),
+  mockGetFreshTenantClient: vi.fn(),
   mockGitWithAuth: vi.fn(),
   mockIsPathInWorkspace: vi.fn(),
   mockLstat: vi.fn(),
@@ -26,18 +34,32 @@ vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({
     auth: { getUser: mockGetUser },
   })),
+  // Service-role client → distinct `mockServiceFrom` (see hoisted note).
   createServiceClient: vi.fn(() => ({
-    from: mockFrom,
+    from: mockServiceFrom,
   })),
 }));
 
-// PR-C §2.8 (#3244): kb-route-helpers now imports `getFreshTenantClient`
-// from `@/lib/supabase/tenant`. Mock to the same `mockFrom` so the
-// existing per-table setup (`setupUserData`) drives both legacy
-// service-role and the new tenant path without per-test duplication.
+// PR-C §2.8 (#3244): kb-route-helpers imports `getFreshTenantClient` from
+// `@/lib/supabase/tenant`. Default impl resolves to the tenant `mockFrom`
+// (the same per-table setup `setupUserData` drives); individual tests
+// override with `mockGetFreshTenantClient.mockRejectedValueOnce(...)` to
+// simulate a tenant-mint failure. The mock RuntimeAuthError mirrors the
+// real two-arg `(cause, message)` signature + public `cause` field so the
+// fallback's `instanceof` check and any cause-discrimination work in tests.
 vi.mock("@/lib/supabase/tenant", () => ({
-  getFreshTenantClient: vi.fn(async () => ({ from: mockFrom })),
-  RuntimeAuthError: class RuntimeAuthError extends Error {},
+  getFreshTenantClient: mockGetFreshTenantClient,
+  RuntimeAuthError: class RuntimeAuthError extends Error {
+    public readonly cause: "jwt_mint" | "rotation" | "denied_jti";
+    constructor(
+      cause: "jwt_mint" | "rotation" | "denied_jti",
+      message: string,
+    ) {
+      super(message);
+      this.name = "RuntimeAuthError";
+      this.cause = cause;
+    }
+  },
 }));
 
 const { mockReportSilentFallback, mockWarnSilentFallback } = vi.hoisted(() => ({
@@ -72,8 +94,10 @@ vi.mock("node:fs", () => ({
 
 import {
   authenticateAndResolveKbPath,
+  resolveUserKbRoot,
   syncWorkspace,
 } from "@/server/kb-route-helpers";
+import { RuntimeAuthError } from "@/lib/supabase/tenant";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -113,6 +137,31 @@ function setupUserData(overrides: Record<string, unknown> = {}) {
   const mockEq = vi.fn(() => ({ single: mockSingle }));
   const mockSelect = vi.fn(() => ({ eq: mockEq }));
   mockFrom.mockImplementation((table: string) => {
+    if (table === "users") return { select: mockSelect };
+    return {};
+  });
+  // Default: the tenant mint succeeds and the tenant client reads via mockFrom.
+  mockGetFreshTenantClient.mockResolvedValue({ from: mockFrom });
+}
+
+// Wire the SERVICE-ROLE client's `.from` (distinct from the tenant `mockFrom`)
+// to a `users` row. Used by the tenant-mint-failure fallback tests so the
+// assertion proves the service-role read — not the tenant read — produced the
+// result. Returns nothing when called for a table other than "users".
+function setupServiceUserData(overrides: Record<string, unknown> = {}) {
+  const mockSingle = vi.fn().mockResolvedValue({
+    data: {
+      workspace_path: TEST_WORKSPACE_PATH,
+      workspace_status: "ready",
+      repo_url: TEST_REPO_URL,
+      github_installation_id: TEST_INSTALLATION_ID,
+      ...overrides,
+    },
+    error: null,
+  });
+  const mockEq = vi.fn(() => ({ single: mockSingle }));
+  const mockSelect = vi.fn(() => ({ eq: mockEq }));
+  mockServiceFrom.mockImplementation((table: string) => {
     if (table === "users") return { select: mockSelect };
     return {};
   });
@@ -683,5 +732,124 @@ describe("syncWorkspace", () => {
       (c: unknown[]) => (c[0] as string[])[0],
     );
     expect(verbs).toEqual(["pull"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — resolveUserKbRoot tenant-mint fallback (#regression from PR #3854)
+//
+// PR #3854 routed the user's-own-`workspace_path` read through a tenant-scoped
+// JWT mint; on mint failure the helper returned 503, which the "Generate link"
+// popover treats as "reset to idle" — the silent dead-end. The fix falls back
+// to a SERVICE-ROLE read of the user's own row (the share *write* was already
+// service-role) instead of 503-ing the button.
+// ---------------------------------------------------------------------------
+
+describe("resolveUserKbRoot — tenant-mint fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: a ready service-role row is available for the fallback to read.
+    setupServiceUserData();
+  });
+
+  test("happy path (mint succeeds) reads via the TENANT client, no fallback, no reportSilentFallback", async () => {
+    setupUserData(); // tenant mint resolves → tenant mockFrom serves the row
+
+    const result = await resolveUserKbRoot(TEST_USER_ID);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.workspacePath).toBe(TEST_WORKSPACE_PATH);
+      expect(result.kbRoot).toContain("knowledge-base");
+    }
+    expect(mockFrom).toHaveBeenCalledWith("users"); // tenant read happened
+    expect(mockServiceFrom).not.toHaveBeenCalled(); // fallback NOT taken
+    expect(mockReportSilentFallback).not.toHaveBeenCalled();
+  });
+
+  test("RuntimeAuthError → service-role fallback returns {ok:true, kbRoot} (NOT 503)", async () => {
+    mockGetFreshTenantClient.mockRejectedValueOnce(
+      new RuntimeAuthError("jwt_mint", "mint failed"),
+    );
+
+    const result = await resolveUserKbRoot(TEST_USER_ID);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.workspacePath).toBe(TEST_WORKSPACE_PATH);
+      expect(result.kbRoot).toContain("knowledge-base");
+    }
+    // The SERVICE-ROLE client produced the row — not the (thrown) tenant client.
+    expect(mockServiceFrom).toHaveBeenCalledWith("users");
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  test("mint-failure fallback emits exactly one reportSilentFallback carrying the RuntimeAuthError", async () => {
+    const mintErr = new RuntimeAuthError("rotation", "mint ceiling tripped");
+    mockGetFreshTenantClient.mockRejectedValueOnce(mintErr);
+
+    await resolveUserKbRoot(TEST_USER_ID);
+
+    expect(mockReportSilentFallback).toHaveBeenCalledTimes(1);
+    expect(mockReportSilentFallback).toHaveBeenCalledWith(
+      mintErr,
+      expect.objectContaining({
+        feature: "kb-route-helpers",
+        op: "resolveUserKbRoot.tenant-mint",
+        extra: expect.objectContaining({ userId: TEST_USER_ID }),
+      }),
+    );
+  });
+
+  test("extras (repo_url, github_installation_id) resolve through the fallback (covers /api/kb/upload)", async () => {
+    mockGetFreshTenantClient.mockRejectedValueOnce(
+      new RuntimeAuthError("jwt_mint", "mint failed"),
+    );
+
+    const result = await resolveUserKbRoot(TEST_USER_ID, {
+      extras: ["repo_url", "github_installation_id"] as const,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.extras.repo_url).toBe(TEST_REPO_URL);
+      expect(result.extras.github_installation_id).toBe(TEST_INSTALLATION_ID);
+    }
+    expect(mockServiceFrom).toHaveBeenCalledWith("users");
+  });
+
+  test("fallback still 503s when the SERVICE-ROLE read yields a non-ready workspace (no false-positive resolution)", async () => {
+    mockGetFreshTenantClient.mockRejectedValueOnce(
+      new RuntimeAuthError("jwt_mint", "mint failed"),
+    );
+    // Distinct service-role mock returns a not-ready row, INDEPENDENT of the
+    // (thrown) tenant read — proves the 503 derives from the service read.
+    setupServiceUserData({ workspace_status: "provisioning" });
+
+    const result = await resolveUserKbRoot(TEST_USER_ID);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(503);
+    expect(mockServiceFrom).toHaveBeenCalledWith("users");
+  });
+
+  test("fallback fires for the denied_jti cause too (ceiling: self-row-scoped read; write was never tenant-scoped)", async () => {
+    mockGetFreshTenantClient.mockRejectedValueOnce(
+      new RuntimeAuthError("denied_jti", "jti on deny-list"),
+    );
+
+    const result = await resolveUserKbRoot(TEST_USER_ID);
+
+    expect(result.ok).toBe(true);
+    expect(mockServiceFrom).toHaveBeenCalledWith("users");
+  });
+
+  test("a non-RuntimeAuthError from the mint is re-thrown (not swallowed by the fallback)", async () => {
+    mockGetFreshTenantClient.mockRejectedValueOnce(new Error("unexpected boom"));
+
+    await expect(resolveUserKbRoot(TEST_USER_ID)).rejects.toThrow(
+      "unexpected boom",
+    );
+    expect(mockServiceFrom).not.toHaveBeenCalled();
   });
 });

--- a/knowledge-base/engineering/operations/post-mortems/generate-link-tenant-mint-regression-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/generate-link-tenant-mint-regression-postmortem.md
@@ -1,0 +1,144 @@
+---
+title: "Generate-link button silently broken by tenant-mint dependency (PR #3854 regression)"
+date: 2026-06-04
+incident_pr: 4913
+incident_window: "2026-05-16 → 2026-06-04 (~19 days)"
+recovery_at: "on merge of PR #4913"
+suspected_change: "PR #3854 (#3244 PR-C tenant migration, merged 2026-05-16)"
+brand_survival_threshold: single-user incident
+status: resolved
+triggers:
+  - system
+art_33_triggered: false
+art_34_triggered: false
+art_33_deadline: "n/a"
+---
+
+## Actor key
+
+- `agent` — Claude Code did this autonomously (no operator ack required).
+- `agent-with-ack` — Claude Code did this AFTER operator confirmed via menu option.
+- `human` — Operator did this directly.
+
+# Incident Overview
+
+The "Generate link" button in the KB document Share popover silently stopped producing public share links. Clicking it returned the user to the identical idle panel instead of rendering the `/shared/<token>` link + Copy/Revoke controls. The regression was introduced ~19 days earlier by PR #3854 (the `#3244` PR-C tenant-scoped-query migration) and ran unnoticed in production until the founder hit it while dogfooding.
+
+## Status
+
+resolved — fix landed in PR #4913 (service-role fallback on tenant-mint failure).
+
+## Symptom
+
+Clicking "Generate link" bounced back to the "Generate a public link to share this document with anyone." idle panel with no error toast. The popover *opened* normally (the GET/`checkShare` path was unaffected), which masked the failure as "nothing happens on click" rather than an obvious error.
+
+## Incident Timeline
+
+- **Start time (detected):** 2026-06-04 (founder report via screenshot)
+- **End time (recovered):** on merge of PR #4913
+- **Duration (MTTR):** ~hours from report to fix (≈19 days latent in prod before detection)
+
+| Actor | Time (UTC) | Action |
+|---|---|---|
+| system | 2026-05-16 | PR #3854 merges; `POST /api/kb/share` read path now depends on a tenant-JWT mint that 503s on failure. |
+| human | 2026-06-04 | Founder reports the dead "Generate link" button (screenshot). |
+| agent | 2026-06-04 | Root cause traced via git archaeology to PR #3854 `route.ts:37`; service-role fallback implemented + tested (PR #4913). |
+| agent | 2026-06-04 | Multi-agent review (security/user-impact/test-design/code-quality) — `denied_jti` fallback ceiling verified sound. |
+
+## Participants and Systems Involved
+
+`apps/web-platform` Next.js API routes (`/api/kb/share`, `/api/kb/upload`), `server/kb-route-helpers.ts` (`resolveUserKbRoot`), `lib/supabase/tenant.ts` (`getFreshTenantClient` / `mintFounderJwt`), Supabase GoTrue (JWT mint), the per-founder mint ceiling (migration 048, 60/hr).
+
+## Detection (+ MTTD)
+
+- **How detected:** external/manual — founder dogfooding, not monitoring. The failure DID emit a `reportSilentFallback` Sentry signal on each mint failure, but no alert routed it to attention and no one was watching the share-POST 503 rate.
+- **MTTD:** ~19 days (merge 2026-05-16 → report 2026-06-04).
+
+## Triggered by
+
+system — a sibling migration PR changed a helper signature, swapping a reliable service-role read for a failure-prone tenant-JWT mint on a user-facing path.
+
+## Root-cause hypothesis (triage)
+
+| Hypothesis | Supporting evidence | Disconfirming evidence | Status |
+|---|---|---|---|
+| `resolveUserKbRoot` 503s on tenant-mint failure | `route.ts:37` diff in #3854; client resets to idle on non-ok | — | confirmed |
+| Deterministic RLS block on the self-SELECT | — | RLS policy `auth.uid()=id` permits the self-read under a successful mint | ruled out |
+| Field rename (`kbRoot`) | — | both old/new helper return `kbRoot`; no drift | ruled out |
+
+## Resolution
+
+On `RuntimeAuthError`, `resolveUserKbRoot` now falls back to a service-role read of the caller's own `users` row (`.eq("id", userId)`) instead of returning 503. The same `workspace_status === "ready"` + `extras` validation runs on the fallback, so a genuinely not-ready workspace still 503s. `reportSilentFallback` still fires so a chronically-failing mint stays visible. Carries `extras` through, covering `POST /api/kb/upload`.
+
+## Recovery verification
+
+Pre-merge: new RED→GREEN tests in `kb-route-helpers.test.ts` (4 cases fail against pre-fix code, pass after); full webplat vitest shard green (8483 passed). Post-merge: the plan's Playwright probe (open KB doc → Share → Generate link → assert active state with `/shared/<token>`) runs against the deployed app.
+
+---
+
+# Incident Post-Mortem Analysis
+
+## Root Cause(s) — 5-Whys
+
+1. **Why did the button do nothing?** The `POST /api/kb/share` handler returned 503 and the client `generateLink` callback resets to idle on any non-ok response.
+2. **Why did the handler 503?** `resolveUserKbRoot` threw/caught a `RuntimeAuthError` from `getFreshTenantClient` and mapped it to a 503 "Workspace not ready".
+3. **Why did `getFreshTenantClient` fail?** It performs a full GoTrue `generateLink + verifyOtp` JWT mint gated by a 60/hr per-founder ceiling — a heavyweight, rate-limited, failure-prone dependency.
+4. **Why was a JWT mint in the path at all?** PR #3854 changed the self-row `workspace_path` read from a service-role read to a tenant-scoped read for isolation, but the privileged *write* (`createShare`) on this path was already service-role — so the tenant scoping bought no isolation benefit while adding a failure mode.
+5. **Why did it go unnoticed for ~19 days?** The failure emitted a Sentry breadcrumb but no alert was wired to the share-POST 503 / mint-failure rate, and the popover still opened (GET path healthy), masking the break as "nothing happens."
+
+## Versions of Components
+
+- **Version(s) that triggered the outage:** the build shipping PR #3854 (merged 2026-05-16).
+- **Version(s) that restored the service:** the build shipping PR #4913.
+
+## Impact details
+
+### Services Impacted
+
+KB document public-link generation (`POST /api/kb/share`) and KB upload (`POST /api/kb/upload`) — both 503'd whenever the tenant mint failed (ceiling trip or GoTrue hiccup).
+
+### Customer Impact (by role)
+
+- Prospect: none (auth-gated feature).
+- Authenticated app user: **primary impact** — could not generate a public share link for any KB document, and KB uploads could fail, whenever the tenant mint failed. Silent (no error surfaced).
+- Legal-document signer: none.
+- Admin via Access: none.
+- Billing customer: none (no charge path).
+- OAuth installation owner: indirect — `repo_url`/`github_installation_id` reads via the upload path were affected on mint failure.
+
+### Revenue Impact
+
+None directly; brand/trust cost of a silently-broken core sharing feature for the founder (tenant-zero), brand-survival threshold `single-user incident`.
+
+### Team Impact
+
+One founder-reported bug; ~one session to root-cause + fix.
+
+## Lessons Learned
+
+### Where we got lucky
+
+- The fix was a verbatim re-introduction of the pre-#3854 service-role read (byte-identical query shape), so column parity was guaranteed and the blast radius was tiny.
+- The privileged write was already service-role, so the fallback introduced no new privilege — the `denied_jti` ceiling held without re-architecture.
+
+### What went well
+
+- Git archaeology pinned the exact regression commit/line quickly; the asymmetry (GET healthy, POST broken) confirmed the locus.
+- The existing `reportSilentFallback` plumbing meant the fix could restore availability *and* keep the underlying mint failure observable.
+
+### What went wrong
+
+- A migration optimizing for isolation introduced a heavyweight, rate-limited dependency into a user-facing read path **whose write was already service-role** — no isolation benefit, pure new failure surface.
+- No alert was wired to the share-POST 503 / tenant-mint-failure rate, so a Sentry-visible signal went unwatched for ~19 days.
+- The client treats *any* non-ok as "reset to idle" with no error toast, turning a server 503 into an invisible dead-end.
+
+## Follow-ups
+
+- [ ] Apply the same mint-failure resilience to `authenticateAndResolveKbPath` (file PATCH/DELETE routes), with a per-cause `denied_jti` adjudication — tracked in #4914.
+- [ ] Wire an alert on the `resolveUserKbRoot.tenant-mint` / `authenticateAndResolveKbPath.tenant-mint` `reportSilentFallback` rate so a recurring mint failure pages instead of sitting latent.
+- [ ] Consider surfacing a user-facing error toast on a genuine share 503 (client `share-popover.tsx`) so a real not-ready state is not an invisible idle bounce.
+
+## Action Items
+
+- #4914 — file-route tenant-mint fallback (already filed; `type/chore` + `deferred-scope-out`).
+- Alert on tenant-mint `reportSilentFallback` rate — to file as a `type/chore` observability item (no existing alert covers the share/upload mint-failure rate).

--- a/knowledge-base/project/learnings/bug-fixes/2026-06-04-tenant-mint-failure-needs-self-row-service-role-fallback.md
+++ b/knowledge-base/project/learnings/bug-fixes/2026-06-04-tenant-mint-failure-needs-self-row-service-role-fallback.md
@@ -1,0 +1,89 @@
+# Learning: tenant-JWT-mint failure on a self-row read should fall back to service-role, not 503
+
+## Problem
+
+The "Generate link" button in the Share popover silently dead-ended — clicking it
+bounced back to the identical idle panel instead of producing a `/shared/<token>`
+link. Regression introduced by PR #3854 (`#3244` PR-C tenant migration, merged
+2026-05-16), which changed `apps/web-platform/app/api/kb/share/route.ts:37` from
+`resolveUserKbRoot(serviceClient, user.id)` → `resolveUserKbRoot(user.id)`.
+
+After #3854, `resolveUserKbRoot` mints a **tenant-scoped JWT** internally
+(`getFreshTenantClient` → full GoTrue `generateLink + verifyOtp`, gated by a
+60/hr per-founder ceiling, migration 048) just to read the caller's own
+`users.workspace_path`. On any mint failure it threw `RuntimeAuthError` and the
+helper returned **503 "Workspace not ready"**. The client `generateLink`
+callback (`share-popover.tsx`) resets to `status: "idle"` on any non-ok response
+— so a transient mint failure or a ceiling trip rendered as "the button does
+nothing." The GET path was unaffected (it uses `createServiceClient()` directly),
+which is why the popover still opened — a classic POST-only regression where
+"the popover opens fine" is NOT evidence the feature works.
+
+## Solution
+
+On `RuntimeAuthError`, fall back to a **service-role read of the user's own row**
+(`createServiceClient().from("users").select(cols).eq("id", userId).single()`)
+instead of returning 503. The same post-read validation (`workspace_status ===
+"ready"` + `extras` null-check) runs on the fallback result, so a genuinely
+not-ready workspace still 503s. `reportSilentFallback` still fires so a
+chronically-failing mint stays visible in Sentry even though users recover.
+
+Implementation: reassign `tenant = createServiceClient()` in the
+`catch (mintErr instanceof RuntimeAuthError)` branch and let the existing
+`.from("users")...` read + validation run unchanged against it. ~12 LOC.
+
+## Key Insight
+
+**A tenant-scoped JWT mint is the wrong dependency to put in front of a
+self-row read whose downstream write is already service-role.** The ceiling
+that makes the fallback safe for ALL three `RuntimeAuthError` causes
+(`jwt_mint | rotation | denied_jti`, incl. the deliberate-revocation case):
+
+1. The fallback read is hard-scoped `.eq("id", userId)` where `userId` is the
+   already-authenticated session user (`supabase.auth.getUser()`), so even a
+   deny-listed token can only ever read its OWN row — never another tenant's.
+2. The privileged **write** on this path (`createShare`) was never tenant-scoped
+   — it uses service-role at the route — so the deny-list never gated a
+   privileged action here in the first place; `denied_jti` only blocked a
+   self-read.
+
+The deny-list's real purpose (blocking a replayed runtime JWT's cross-tenant
+PostgREST reach) is fully preserved. When relaxing a defense, **name the new
+ceiling explicitly in a code comment** (per
+[[2026-05-05-defense-relaxation-must-name-new-ceiling]]) — the choice must be
+explicit, not incidental.
+
+**Caveat — mutation paths differ.** The sibling helper
+`authenticateAndResolveKbPath` has the identical 503-on-mint-failure pattern but
+serves file PATCH/DELETE *mutation* routes, where a `denied_jti` deny-list trip
+IS meant to block the action. Do NOT blindly copy the fallback there — a
+service-role fallback on a mutation path needs a per-cause adjudication
+(fall back for `jwt_mint`/`rotation` availability failures only; re-throw on
+`denied_jti`). Tracked in #4914; the unchanged helper now carries a NOTE comment
+explaining the deliberate asymmetry.
+
+## Test note
+
+The existing test wired the tenant client and service-role client to the SAME
+`mockFrom`, so a fallback assertion would pass **vacuously** (it couldn't prove
+the service-role client — not the tenant client — produced the row). Fix: a
+distinct `mockServiceFrom` wired only to `createServiceClient`, plus
+`expect(mockFrom).not.toHaveBeenCalled()` counter-assertions so a regression
+where the fallback silently reads via the tenant client fails the test.
+
+## Session Errors
+
+- **CWD-not-persisted vitest run** — ran a multi-file `./node_modules/.bin/vitest`
+  sweep without `cd`-ing into `apps/web-platform` in the same Bash call →
+  `EXIT=127 No such file or directory`. **Recovery:** re-ran as
+  `cd <worktree>/apps/web-platform && ./node_modules/.bin/vitest …`.
+  **Prevention:** already covered by the existing "Bash tool does NOT persist
+  CWD; chain `cd <abs> && <cmd>`" rules — no new rule warranted.
+- **Wrong `gh` label guess** — `gh issue create --label type/enhancement` failed
+  ("not found"). **Recovery:** `gh label list` then used `type/chore` +
+  `deferred-scope-out`. **Prevention:** verify labels against the live set
+  before filing (one `gh label list` call). One-off.
+
+## Tags
+category: bug-fixes
+module: apps/web-platform/server/kb-route-helpers

--- a/knowledge-base/project/plans/2026-06-04-fix-share-link-tenant-mint-regression-plan.md
+++ b/knowledge-base/project/plans/2026-06-04-fix-share-link-tenant-mint-regression-plan.md
@@ -142,10 +142,18 @@ call sites) but the test strategy and observability section are unchanged in spi
   route's call still resolves;
   (3) fallback still returns the 503-equivalent only when the *service-role* read also
   yields no `workspace_path` / non-`ready` status;
-  (4) `reportSilentFallback` is invoked on the mint-failure fallback. The existing
-  `vi.mock("@/lib/supabase/tenant", …)` already exposes a mockable `getFreshTenantClient`
-  and `RuntimeAuthError`, and `createServiceClient` is already mocked to `mockFrom` — reuse
-  both.
+  (4) `reportSilentFallback` is invoked on the mint-failure fallback.
+  **Mock-distinguishability gotcha (deepen P1):** the existing test file wires BOTH
+  `vi.mock("@/lib/supabase/tenant", … getFreshTenantClient: vi.fn(async () => ({ from: mockFrom })))`
+  AND `vi.mock("@/lib/supabase/server", … createServiceClient: vi.fn(() => ({ from: mockFrom })))`
+  to the **same `mockFrom`** (test file lines 22-40). A fallback test that throws from
+  `getFreshTenantClient` and asserts `mockFrom` returned a ready row passes *vacuously* — it
+  cannot prove the **service-role** client (not the tenant client) produced the result. The
+  new fallback tests MUST introduce a **distinct service-role mock** (e.g. a separate
+  `mockServiceFrom` wired only into `createServiceClient`) so test (1)/(3) assert the
+  service client was the one consulted, and so test (3) can return a not-ready row from the
+  service read *independently* of the (thrown) tenant read. Do NOT reuse the shared
+  `mockFrom` for the service-role fallback assertions.
 
 ## Files to Create
 
@@ -167,7 +175,11 @@ None.
       `{ extras: ["repo_url", "github_installation_id"] as const }`.
 - [ ] When BOTH the tenant mint fails AND the service-role read yields no
       `workspace_path` / non-`ready` status, the helper still returns the 503 "Workspace
-      not ready" response (no false-positive resolution) — asserted by a test.
+      not ready" response (no false-positive resolution) — asserted by a test that wires the
+      **service-role** read (distinct `mockServiceFrom`) to a not-ready row.
+- [ ] The fallback tests prove the **service-role** client (not the shared tenant mock)
+      produced the resolved workspace — i.e. the test uses a distinct `createServiceClient`
+      mock, so the assertion does not pass vacuously through the shared `mockFrom`.
 - [ ] `GET /api/kb/share` and `createShare` are unchanged (no diff to `route.ts` GET
       handler or to `kb-share.ts`).
 - [ ] `apps/web-platform` typechecks and the vitest suite for the edited file passes via
@@ -332,6 +344,69 @@ entry required. Advisory-only; mandatory disclaimer: this is not legal advice.
 - The fallback must carry `extras` through, or the upload route (`extras: ["repo_url",
   "github_installation_id"]`) regresses to "No repository connected" 400 on mint failure.
   Test the `extras` path explicitly.
+
+## Research Insights (deepen-plan, 2026-06-04)
+
+Deepen pass ran inside the one-shot pipeline (sub-agent context — Task fan-out
+unavailable), so the substance-level checks were executed directly against the code.
+Three load-bearing findings:
+
+### 1. Precedent-diff (4.4) — fallback is a verbatim re-use, not novel
+
+`git show abcb3765~1:apps/web-platform/server/kb-route-helpers.ts` (the pre-#3854 form)
+and the current tenant read (`kb-route-helpers.ts:259-300`) are **byte-identical** query
+shapes:
+`.from("users").select(selectCols).eq("id", userId).single<Record<string, unknown>>()`,
+same `selectCols` builder, same `!userData?.workspace_path || workspace_status !== "ready"`
+validation, same `extras` loop. The fallback re-introduces the exact read #3854 removed —
+**no novel pattern**, column parity guaranteed. No correction needed.
+
+### 2. Defense-relaxation — name the ceiling for the `denied_jti` cause (P1 decision)
+
+`RuntimeAuthError.cause` is one of `"jwt_mint" | "rotation" | "denied_jti"`
+(`tenant.ts:91`). `jwt_mint` and `rotation` are **availability** failures (GoTrue error,
+mint-ceiling trip) — the fallback is unambiguously correct for these. `denied_jti` is a
+**deliberate security action** (the jti is on the deny-list). Per
+`knowledge-base/project/learnings/2026-05-05-defense-relaxation-must-name-new-ceiling.md`,
+when a fix relaxes a load-bearing defense it must name the new ceiling.
+
+**Decision (to confirm at /work):** the fallback fires for ALL three causes, and that is
+acceptable because the **ceiling still holds**: (a) the fallback read is scoped to the
+authenticated user's **own** row (`.eq("id", userId)` where `userId` = `user.id` from the
+already-validated session), so a denied jti cannot read another tenant's workspace; and
+(b) the share **write** on this path was never tenant-scoped (`createShare` uses
+service-role, `route.ts:40`), so the deny-list never gated this path's privileged action in
+the first place — `denied_jti` here only blocked a read of the user's own `workspace_path`.
+The deny-list's actual purpose (revoking a tenant token's broad DB reach) is unaffected:
+this fallback grants only the single-row self-read, not the tenant client. **/work MUST add
+a code comment at the fallback site stating this ceiling**, and the implementer should
+confirm with the auth-domain owner whether `denied_jti` should instead re-throw (fail
+closed) rather than fall back — if so, scope the fallback to `cause !== "denied_jti"` and
+keep the 503 for denied jtis. Either choice is defensible; the plan's requirement is that
+the choice be **explicit**, not incidental.
+
+### 3. Test vacuity (P1) — distinct service-role mock required
+
+Folded into `## Files to Edit` and Acceptance Criteria above: the existing test wires the
+tenant and service clients to the **same `mockFrom`**, so a fallback test must use a
+distinct `mockServiceFrom` or it passes vacuously.
+
+## Enhancement Summary
+
+**Deepened on:** 2026-06-04 (one-shot pipeline; halt gates 4.6/4.7/4.8 passed, 4.9 skipped —
+no UI-surface file edited).
+**Key improvements:**
+1. Test-mock vacuity gap closed — fallback tests now require a distinct service-role mock
+   (the shared `mockFrom` would let the fallback assertion pass without proving the
+   service client was consulted).
+2. `denied_jti` defense-relaxation decision made explicit with a named ceiling
+   (self-row-scope + write-was-never-tenant-scoped) and a /work fail-closed escape hatch.
+3. Precedent-diff confirmed the fallback is a verbatim re-use of the pre-#3854 read
+   (column parity guaranteed; not a novel pattern).
+
+**New considerations:** the `denied_jti` cause is the only substance-level surprise — a
+naive "catch RuntimeAuthError → fall back" silently extends the fallback to a security-deny
+case; the plan now forces an explicit decision there.
 
 ## References
 

--- a/knowledge-base/project/plans/2026-06-04-fix-share-link-tenant-mint-regression-plan.md
+++ b/knowledge-base/project/plans/2026-06-04-fix-share-link-tenant-mint-regression-plan.md
@@ -1,0 +1,345 @@
+---
+title: "Fix Generate-link button regression (tenant-mint dead-ends share-create)"
+type: fix
+date: 2026-06-04
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+---
+
+# 🐛 Fix: "Generate link" button silently fails — tenant-mint dead-ends share-create POST
+
+## Summary
+
+The "Generate link" button in the Share popover (top of the document/canvas view) no
+longer generates a public share link. Clicking it returns to the identical idle panel
+("Generate a public link to share this document with anyone.") instead of showing the
+link + Copy/Revoke UI. This is a **regression** introduced by PR #3854
+(`feat(runtime): PR-C sibling-query tenant migration (#3244 §2)`, MERGED 2026-05-16).
+
+The fix restores reliable share-link generation by making the user's-own-`workspace_path`
+read in `resolveUserKbRoot` resilient to tenant-JWT-mint failure — falling back to the
+service-role read that the route already uses for the actual share write.
+
+## Root Cause (confirmed)
+
+PR #3854 changed the `POST /api/kb/share` handler at
+`apps/web-platform/app/api/kb/share/route.ts:37`:
+
+```diff
+- const workspace = await resolveUserKbRoot(serviceClient, user.id);
++ const workspace = await resolveUserKbRoot(user.id);
+```
+
+- **Before #3854**, `resolveUserKbRoot(serviceClient, userId)` read
+  `users.workspace_path` via the **service-role** client (RLS-bypass, always succeeds).
+- **After #3854**, `resolveUserKbRoot(userId)`
+  (`apps/web-platform/server/kb-route-helpers.ts:225`) mints a **tenant-scoped** client
+  internally via `getFreshTenantClient` (`apps/web-platform/lib/supabase/tenant.ts:766`
+  → `mintFounderJwt`), which performs a full GoTrue `generateLink + verifyOtp` JWT mint
+  gated by a per-founder rate ceiling (`precheck_jwt_mint`, 60/hr, migration 048). On any
+  mint failure it throws `RuntimeAuthError`; `resolveUserKbRoot` catches it and returns
+  `{ ok: false, response: NextResponse.json({ error: "Workspace not ready" }, { status: 503 }) }`
+  (`kb-route-helpers.ts:242-256`).
+
+The POST then returns 503. The client `generateLink` callback
+(`apps/web-platform/components/kb/share-popover.tsx:84-86`) treats **any** non-ok
+response by resetting state to `status: "idle"`, re-rendering the identical idle panel —
+exactly the reported "returns to the same box" symptom.
+
+**Asymmetry confirming a POST-only regression:** `GET /api/kb/share`
+(`route.ts:56`) does **not** call `resolveUserKbRoot` — it uses `createServiceClient()`
+directly — so the popover still opens and `checkShare` still works; only the POST
+generate path is broken.
+
+**Important context:** the actual privileged write (`createShare`) still uses the
+**service-role** client (`route.ts:40`; comment `route.ts:34-35`: "kb_shares writer is
+allowlisted PERMANENT for now — see PR-D scope"). So the tenant-scoped client introduced
+by #3854 is used **only** to read the user's own `users.workspace_path` (RLS predicate
+`auth.uid() = id`, `001_initial_schema.sql:17-19`) — a read the service-role client
+performed fine before #3854. The tenant scoping bought no isolation benefit on this path
+(the write is still service-role) while introducing a heavyweight, rate-limited,
+failure-prone JWT-mint dependency into a user-facing button.
+
+### Ruled out
+
+- **Deterministic RLS block:** the `users` SELECT policy is `auth.uid() = id` and the
+  tenant JWT sets `role='authenticated'` + `auth.uid()=userId`, so the self-SELECT is
+  permitted under a *successful* mint. The failure is in the **mint**, not in RLS.
+- **Field rename:** both old and new `resolveUserKbRoot` return `kbRoot`; the route reads
+  `workspace.kbRoot`. No drift.
+
+## User-Brand Impact
+
+- **If this lands broken, the user experiences:** the Share popover's "Generate link"
+  button does nothing on click (silently bounces back to the idle panel); the user cannot
+  produce a public share link for any KB document.
+- **If this leaks, the user's workflow is exposed via:** N/A for the read fallback — the
+  fallback reads only the *requesting user's own* `workspace_path` keyed on the
+  already-authenticated `user.id` (the service-role read is scoped by
+  `.eq("id", userId)`), and the share-link write surface is unchanged. No new data is
+  exposed; the change restores prior (pre-#3854) read behavior.
+- **Brand-survival threshold:** `single-user incident` (carried forward from #3244 / PR-C;
+  a single founder hitting a dead "Generate link" button is a brand-survival-class
+  user-facing failure). `requires_cpo_signoff: true`.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (feature description) | Codebase reality | Plan response |
+| --- | --- | --- |
+| Regression at `route.ts:37` from `resolveUserKbRoot(serviceClient, user.id)` → `resolveUserKbRoot(user.id)` | Confirmed via `git show abcb3765 -- apps/web-platform/app/api/kb/share/route.ts` (PR #3854) | Fix targets `resolveUserKbRoot` mint-failure path |
+| `createShare` still uses service-role | Confirmed `route.ts:40` + comment `route.ts:34-35` | Fallback read uses the same service-role client; no new privilege |
+| GET path unaffected (uses `createServiceClient` directly) | Confirmed `route.ts:56-73` | No GET change |
+| Upload route has the same migrated call | Confirmed `apps/web-platform/app/api/kb/upload/route.ts:70` (`resolveUserKbRoot(user.id, {extras})`) | Same helper fix covers it; upload's `extras` (`repo_url`, `github_installation_id`) read from the same `users` row must be carried through the fallback |
+| Sibling helper `authenticateAndResolveKbPath` also mints tenant | Confirmed `kb-route-helpers.ts:95` | **Out of scope** (file GET/PATCH/DELETE routes; not the reported bug) — note as a follow-up, see Non-Goals |
+| Issue #3244 state | CLOSED (umbrella, "Command Center server-side agentic runtime") | Do not reopen; reference only |
+| PR #3854 state | MERGED 2026-05-16 | Regression source; reference in PR body |
+
+## Chosen Approach
+
+**Direction B — service-role fallback on mint failure (recommended).**
+
+Keep the tenant-scoped `users.workspace_path` read as the **primary** path (honoring the
+#3244 gate-zero isolation intent), but when `getFreshTenantClient` throws
+`RuntimeAuthError`, fall back to a **service-role** read of the same row
+(`.from("users").select(selectCols).eq("id", userId).single()`) instead of returning 503.
+The fallback is scoped to the requesting user's own id, reads the same columns, and the
+route already uses service-role for the share write — so no new privilege or exposure is
+introduced. A transient mint failure or a per-founder mint-ceiling trip no longer
+dead-ends a user-facing button.
+
+Rationale for B over A (full revert to service-role-only read):
+
+- B preserves the tenant-scoped read as the default, so the #3244 isolation posture is
+  retained whenever the mint succeeds (the common case).
+- B is a strictly additive fallback — smaller blast radius than re-threading a
+  `serviceClient` argument back through both call sites and reverting the helper signature.
+- A (revert) would re-introduce the exact service-role read #3854 deliberately removed,
+  with no path to ever exercising the tenant-scoped read; B keeps the migration's intent
+  while closing the availability hole.
+
+The mint-failure fallback MUST emit a `reportSilentFallback` / structured-log signal so
+the operator sees that the tenant mint is failing (the underlying mint problem — e.g.
+ceiling trip — is still worth surfacing even though the user flow now recovers).
+
+`plan-review` and `deepen-plan` should adjudicate B vs A; if review prefers A, the
+`## Files to Edit` set changes (revert helper signature + re-thread `serviceClient` at both
+call sites) but the test strategy and observability section are unchanged in spirit.
+
+## Files to Edit
+
+- `apps/web-platform/server/kb-route-helpers.ts` — in `resolveUserKbRoot`, on
+  `getFreshTenantClient` throwing `RuntimeAuthError`, fall back to a service-role read of
+  the same `users` row (same `selectCols`, same `.eq("id", userId).single()`), apply the
+  identical `workspace_path` / `workspace_status` / `extras` validation to the fallback
+  result, and emit `reportSilentFallback` so the mint failure is still observable. Only the
+  503-on-mint-failure branch (`:242-256`) changes; the RLS-permitted happy path and the
+  `extras`-missing 400 path are unchanged.
+- `apps/web-platform/test/kb-route-helpers.test.ts` — add RED→GREEN coverage:
+  (1) `getFreshTenantClient` throws `RuntimeAuthError` → `resolveUserKbRoot` returns
+  `{ ok: true, kbRoot }` from the service-role fallback (NOT 503);
+  (2) the fallback honors `extras` (`repo_url`, `github_installation_id`) so the upload
+  route's call still resolves;
+  (3) fallback still returns the 503-equivalent only when the *service-role* read also
+  yields no `workspace_path` / non-`ready` status;
+  (4) `reportSilentFallback` is invoked on the mint-failure fallback. The existing
+  `vi.mock("@/lib/supabase/tenant", …)` already exposes a mockable `getFreshTenantClient`
+  and `RuntimeAuthError`, and `createServiceClient` is already mocked to `mockFrom` — reuse
+  both.
+
+## Files to Create
+
+None.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] `resolveUserKbRoot` returns `{ ok: true, kbRoot, workspacePath, extras }` (not a 503
+      response) when `getFreshTenantClient` throws `RuntimeAuthError`, provided the
+      service-role read of the user's own row yields a `ready` workspace — asserted by a
+      new test in `kb-route-helpers.test.ts`.
+- [ ] The mint-failure fallback emits exactly one `reportSilentFallback` call carrying the
+      `RuntimeAuthError` (so the operator still sees the mint failure) — asserted via
+      `mockReportSilentFallback`.
+- [ ] The `extras` path (`repo_url`, `github_installation_id`) resolves through the
+      fallback (covers the `POST /api/kb/upload` call site) — asserted by a test passing
+      `{ extras: ["repo_url", "github_installation_id"] as const }`.
+- [ ] When BOTH the tenant mint fails AND the service-role read yields no
+      `workspace_path` / non-`ready` status, the helper still returns the 503 "Workspace
+      not ready" response (no false-positive resolution) — asserted by a test.
+- [ ] `GET /api/kb/share` and `createShare` are unchanged (no diff to `route.ts` GET
+      handler or to `kb-share.ts`).
+- [ ] `apps/web-platform` typechecks and the vitest suite for the edited file passes via
+      the package runner: `cd apps/web-platform && ./node_modules/.bin/vitest run test/kb-route-helpers.test.ts`
+      (package `scripts.test` is `vitest`; node-project include glob is `test/**/*.test.ts`).
+
+### Post-merge (operator)
+
+- [ ] After the `web-platform-release.yml` pipeline restarts the container on merge to
+      main (path-filtered `on.push` over `apps/web-platform/**` — a PR merge IS the
+      remediation), verify the live "Generate link" button via Playwright MCP: open a KB
+      document, click Share → "Generate link", assert the popover transitions to the
+      active state showing a `/shared/<token>` URL and the Copy/Revoke controls.
+      `Automation: feasible via mcp__playwright__*` — runs against the authenticated app.
+
+## Test Scenarios
+
+- Given a user with a `ready` workspace, when `getFreshTenantClient` throws
+  `RuntimeAuthError("jwt_mint")`, then `resolveUserKbRoot(userId)` returns
+  `{ ok: true, kbRoot: "<workspace>/knowledge-base" }` via the service-role fallback and
+  emits one `reportSilentFallback`.
+- Given the same, when called with `extras: ["repo_url", "github_installation_id"]`, then
+  the fallback returns those extras populated from the same row.
+- Given a user whose service-role row has `workspace_status !== "ready"`, when the mint
+  throws, then the helper returns the 503 "Workspace not ready" response (fallback does not
+  paper over a genuinely-not-ready workspace).
+- Given a successful mint (no throw), then the tenant-scoped read path is taken unchanged
+  (no service-role fallback, no `reportSilentFallback`).
+- **Browser (post-merge):** open KB doc → Share → "Generate link"; expect the popover to
+  render the `/shared/<token>` input + Copy button (active state), not bounce to idle.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "Sentry breadcrumb/event via reportSilentFallback on tenant-mint fallback in resolveUserKbRoot"
+  cadence: "per share/upload POST when the tenant mint fails"
+  alert_target: "Sentry web-platform project (operator dashboard)"
+  configured_in: "apps/web-platform/server/kb-route-helpers.ts (resolveUserKbRoot mint-failure branch)"
+error_reporting:
+  destination: "Sentry web-platform via SENTRY_DSN, routed through server/observability.ts reportSilentFallback"
+  fail_loud: "POST /api/kb/share now succeeds (200/201) on mint failure; the Sentry event records that the tenant mint failed even though the user flow recovered"
+failure_modes:
+  - mode: "tenant JWT mint failing on every share/upload POST (ceiling trip or GoTrue outage)"
+    detection: "reportSilentFallback events accumulating with feature=kb-route-helpers op=resolveUserKbRoot.tenant-mint"
+    alert_route: "Sentry issue to operator"
+  - mode: "service-role fallback ALSO failing (user genuinely not ready)"
+    detection: "POST returns 503 'Workspace not ready'; client stays idle (pre-fix behavior preserved for the genuinely-not-ready case)"
+    alert_route: "Sentry (existing resolveUserKbRoot.tenant-mint reportSilentFallback) + user sees no link"
+logs:
+  where: "pino structured logs (server/logger.ts child loggers) + Sentry; container stdout via docker logs on the web-platform host"
+  retention: "Sentry default project retention; container logs ephemeral per deploy"
+discoverability_test:
+  command: "cd apps/web-platform && ./node_modules/.bin/vitest run test/kb-route-helpers.test.ts"
+  expected_output: "all tests pass, including the new mint-failure-fallback cases (no ssh required)"
+```
+
+## Domain Review
+
+**Domains relevant:** Product (UI surface), Engineering (auth/runtime)
+
+### Engineering
+
+**Status:** reviewed (plan-author assessment; CTO carry-forward from #3244 PR-C lives in
+the original brainstorm/spec for that umbrella)
+**Assessment:** The change is a localized availability fix on an auth-adjacent read path.
+It does NOT relax a security boundary: the share *write* remains service-role (unchanged),
+the fallback read is scoped to the authenticated user's own id, and the tenant-scoped read
+stays the default. The mint-failure path is the only branch modified. CTO probe (mirroring
+a sibling-layer predicate): this is not a new recovery primitive duplicating a SQL/scheduler
+predicate — it is a fallback within a single read helper, so the
+"name-the-load-bearing-sub-value" gate does not apply. No infra surface.
+
+### Product/UX Gate
+
+**Tier:** advisory
+**Decision:** auto-accepted (pipeline)
+**Agents invoked:** none (no NEW user-facing surface; the fix restores an EXISTING
+button's behavior — no new pages/components/flows, no copy change). The mechanical
+UI-surface override does not fire: `## Files to Edit` contains no `components/**`,
+`app/**/page.tsx`, or `app/**/layout.tsx` path (the only UI file, `share-popover.tsx`, is
+referenced for diagnosis but is NOT edited — the bug is server-side).
+**Skipped specialists:** none
+**Pencil available:** N/A (no UI surface created or modified)
+
+#### Findings
+
+Restores prior behavior of an existing control; no design or copy decisions required.
+
+## Open Code-Review Overlap
+
+1 open code-review scope-out touches an edited file:
+
+- **#2246** (`refactor(kb): low-severity polish from PR #2235 review`) names
+  `kb-route-helpers.ts` (P3: helper return type is `Response` not `NextResponse`; callers
+  can't add cookies/headers without casting). **Disposition: Acknowledge.** Different
+  concern — this plan only modifies the mint-failure branch of `resolveUserKbRoot` to add a
+  service-role fallback; it does not touch the helper's return-type union. The P3 polish
+  remains open and is not coupled to the availability fix. Folding it in would broaden the
+  diff beyond the regression and risk the `single-user incident` brand-survival scope.
+
+## GDPR / Compliance Gate (advisory)
+
+The fix touches an auth-adjacent API-route read path (canonical regex fires on
+`apps/*/app/api/**` + auth-flow), so this gate is recorded rather than skipped. **No
+Critical findings.** The service-role fallback reads only the *requesting user's own*
+`users` row (`.eq("id", userId)`, columns `workspace_path, workspace_status[, repo_url,
+github_installation_id]`) — no new personal-data field, no new processing activity, no
+LLM/external-API data movement, and no new distribution surface. The change *reduces* the
+broken-state footprint (it restores a previously-working read) rather than expanding data
+movement. No new lawful-basis question, no Art. 9 special-category data, no Art. 30 register
+entry required. Advisory-only; mandatory disclaimer: this is not legal advice.
+
+## Risks & Mitigations
+
+- **Fallback masks a persistent mint outage.** Mitigated: the fallback emits
+  `reportSilentFallback`, so a chronically-failing mint is still visible to the operator in
+  Sentry even though users recover. The fallback restores *availability*, not silence.
+- **Fallback over-resolves a genuinely-not-ready workspace.** Mitigated: the fallback
+  applies the *same* `workspace_path` + `workspace_status === "ready"` + `extras`
+  validation to the service-role read; a non-ready user still gets the 503.
+- **Precedent check (deepen-plan Phase 4.4):** the service-role read shape already exists
+  in this very helper's pre-#3854 form (`git show abcb3765~1:apps/web-platform/server/kb-route-helpers.ts`)
+  and in `createServiceClient()` consumers; no novel pattern. deepen-plan should diff the
+  fallback read against the pre-#3854 service-role read to confirm column parity
+  (`workspace_path, workspace_status[, extras…]`).
+- **supabase-js query-shape:** the fallback uses
+  `.from("users").select(selectCols).eq("id", userId).single<Record<string, unknown>>()` —
+  identical to the existing tenant read in the same function; confirm against the installed
+  supabase-js before implementing (it is a copy of the adjacent call, so risk is minimal).
+
+## Non-Goals
+
+- **Not fixing `authenticateAndResolveKbPath`** (the sibling helper at
+  `kb-route-helpers.ts:95` used by `/api/kb/file/*` GET/PATCH/DELETE), which also mints a
+  tenant client and would 503 the same way on mint failure. The reported bug is share-create
+  only. **Deferral:** file a follow-up issue to apply the same mint-failure resilience to
+  `authenticateAndResolveKbPath` (or to lift the fallback into a shared sub-helper both
+  call), with re-evaluation criterion "next time a KB file route 503s on mint failure," and
+  milestone from `knowledge-base/product/roadmap.md`. Do NOT silently leave it
+  unaddressed — a deferral without a tracking issue is invisible.
+- **Not changing the client `share-popover.tsx`** error handling (it correctly falls back
+  to idle on non-ok; the fix is to stop the server returning non-ok on transient mint
+  failure). A separate UX improvement — surfacing an error toast on genuine 503 — is out of
+  scope.
+- **Not touching the tenant-mint internals** (`mintFounderJwt`, the 60/hr ceiling). The
+  ceiling is a deliberate auth-domain control; this plan only stops it from dead-ending a
+  read that has a safe service-role fallback.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/
+  placeholder text, or omits the threshold will fail `deepen-plan` Phase 4.6. (This plan's
+  section is filled with a `single-user incident` threshold.)
+- When verifying the fix, exercise the **POST** path specifically — the GET path was never
+  broken, so a popover that "opens fine" is not evidence the fix works. The active-state
+  transition (link URL + Copy/Revoke) after clicking "Generate link" is the load-bearing
+  assertion.
+- Test FILE PATH must satisfy the vitest node-project include glob
+  (`test/**/*.test.ts`); `kb-route-helpers.test.ts` already lives under `test/` so it is
+  collected — do not co-locate the new cases next to the helper.
+- The fallback must carry `extras` through, or the upload route (`extras: ["repo_url",
+  "github_installation_id"]`) regresses to "No repository connected" 400 on mint failure.
+  Test the `extras` path explicitly.
+
+## References
+
+- Regression source: PR #3854 (`feat(runtime): PR-C sibling-query tenant migration (#3244 §2)`), MERGED 2026-05-16.
+- Umbrella: #3244 (CLOSED).
+- `apps/web-platform/app/api/kb/share/route.ts:37` (regression locus), `:40` (service-role write), `:56` (GET, unaffected).
+- `apps/web-platform/server/kb-route-helpers.ts:225` (`resolveUserKbRoot`), `:242-256` (mint-failure 503 branch).
+- `apps/web-platform/lib/supabase/tenant.ts:766` (`getFreshTenantClient`), `mintFounderJwt` + `RuntimeAuthError`.
+- `apps/web-platform/components/kb/share-popover.tsx:76-99` (client `generateLink`; resets to idle on non-ok).
+- `apps/web-platform/test/kb-route-helpers.test.ts` (existing mock harness reused for the new cases).
+- Premise-validation scratch: `/tmp/plan-scratch/premise-validation.md`.

--- a/knowledge-base/project/plans/2026-06-04-fix-share-link-tenant-mint-regression-plan.md
+++ b/knowledge-base/project/plans/2026-06-04-fix-share-link-tenant-mint-regression-plan.md
@@ -163,26 +163,26 @@ None.
 
 ### Pre-merge (PR)
 
-- [ ] `resolveUserKbRoot` returns `{ ok: true, kbRoot, workspacePath, extras }` (not a 503
+- [x] `resolveUserKbRoot` returns `{ ok: true, kbRoot, workspacePath, extras }` (not a 503
       response) when `getFreshTenantClient` throws `RuntimeAuthError`, provided the
       service-role read of the user's own row yields a `ready` workspace — asserted by a
       new test in `kb-route-helpers.test.ts`.
-- [ ] The mint-failure fallback emits exactly one `reportSilentFallback` call carrying the
+- [x] The mint-failure fallback emits exactly one `reportSilentFallback` call carrying the
       `RuntimeAuthError` (so the operator still sees the mint failure) — asserted via
       `mockReportSilentFallback`.
-- [ ] The `extras` path (`repo_url`, `github_installation_id`) resolves through the
+- [x] The `extras` path (`repo_url`, `github_installation_id`) resolves through the
       fallback (covers the `POST /api/kb/upload` call site) — asserted by a test passing
       `{ extras: ["repo_url", "github_installation_id"] as const }`.
-- [ ] When BOTH the tenant mint fails AND the service-role read yields no
+- [x] When BOTH the tenant mint fails AND the service-role read yields no
       `workspace_path` / non-`ready` status, the helper still returns the 503 "Workspace
       not ready" response (no false-positive resolution) — asserted by a test that wires the
       **service-role** read (distinct `mockServiceFrom`) to a not-ready row.
-- [ ] The fallback tests prove the **service-role** client (not the shared tenant mock)
+- [x] The fallback tests prove the **service-role** client (not the shared tenant mock)
       produced the resolved workspace — i.e. the test uses a distinct `createServiceClient`
       mock, so the assertion does not pass vacuously through the shared `mockFrom`.
-- [ ] `GET /api/kb/share` and `createShare` are unchanged (no diff to `route.ts` GET
+- [x] `GET /api/kb/share` and `createShare` are unchanged (no diff to `route.ts` GET
       handler or to `kb-share.ts`).
-- [ ] `apps/web-platform` typechecks and the vitest suite for the edited file passes via
+- [x] `apps/web-platform` typechecks and the vitest suite for the edited file passes via
       the package runner: `cd apps/web-platform && ./node_modules/.bin/vitest run test/kb-route-helpers.test.ts`
       (package `scripts.test` is `vitest`; node-project include glob is `test/**/*.test.ts`).
 

--- a/knowledge-base/project/specs/feat-one-shot-fix-generate-link-button/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-generate-link-button/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-04-fix-share-link-tenant-mint-regression-plan.md
+- Status: complete
+
+### Errors
+None. (Deepen-plan Task fan-out unavailable inside pipeline sub-agent; review lenses executed directly against code instead — all load-bearing checks performed.)
+
+### Decisions
+- Root cause: PR #3854 (#3244 PR-C tenant migration, merged 2026-05-16) changed apps/web-platform/app/api/kb/share/route.ts:37 from resolveUserKbRoot(serviceClient, user.id) -> resolveUserKbRoot(user.id). Helper now mints a tenant-scoped JWT internally; on mint failure returns 503, and the client generateLink callback resets to idle -> "returns to the same box" symptom. GET path still uses service-role, confirming POST-only regression.
+- Chose Direction B (service-role fallback on mint failure) over Direction A (full revert): preserves #3244 tenant-read default while closing the availability hole. Share write (createShare) already service-role, so fallback introduces no new privilege/exposure (read scoped .eq("id", userId)).
+- Deepen P1: existing test wires tenant + service clients to same mockFrom; fallback tests must use distinct mockServiceFrom or pass vacuously.
+- Deepen P1: RuntimeAuthError.cause includes denied_jti security-deny case; /work must decide fall-back-for-all-causes-with-ceiling vs fail-closed on denied_jti.
+- Scoped authenticateAndResolveKbPath (/api/kb/file/*, same 503 class) OUT with tracked follow-up.
+
+### Components Invoked
+- Skill: soleur:plan, soleur:deepen-plan
+- Bash, Read, Edit, Write
+- Commits: e252e3fe (plan+tasks), 8d9a39ac (deepen)

--- a/knowledge-base/project/specs/feat-one-shot-fix-generate-link-button/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-generate-link-button/tasks.md
@@ -11,13 +11,15 @@ Lane: cross-domain | Brand-survival threshold: single-user incident (requires CP
 
 ## 2. Core Implementation (RED → GREEN)
 
-- 2.1 **RED** — add failing tests in `kb-route-helpers.test.ts`:
-  - 2.1.1 `getFreshTenantClient` throws `RuntimeAuthError` + service-role row has `ready` workspace → expect `{ ok: true, kbRoot }` (currently 503).
+- 2.0 **Test-mock prep (deepen P1):** the existing test wires tenant + service clients to the SAME `mockFrom` (test file lines 22-40). Introduce a DISTINCT `mockServiceFrom` wired only into the `createServiceClient` mock, so fallback tests prove the service-role read (not the thrown tenant read) produced the result and can set the service read's row independently. Do NOT assert the fallback through the shared `mockFrom`.
+- 2.1 **RED** — add failing tests in `kb-route-helpers.test.ts` (using `mockServiceFrom` for the service-role read):
+  - 2.1.1 `getFreshTenantClient` throws `RuntimeAuthError` + service-role row (`mockServiceFrom`) has `ready` workspace → expect `{ ok: true, kbRoot }` (currently 503); assert the service mock was consulted.
   - 2.1.2 Same, with `extras: ["repo_url", "github_installation_id"]` → expect extras populated from the fallback row.
-  - 2.1.3 Mint throws + service-role row NOT ready → expect the 503 "Workspace not ready" response preserved.
+  - 2.1.3 Mint throws + service-role row NOT ready (`mockServiceFrom` returns non-`ready`) → expect the 503 "Workspace not ready" response preserved.
   - 2.1.4 Mint throws → expect exactly one `mockReportSilentFallback` call carrying the error.
   - 2.1.5 Mint succeeds (no throw) → tenant read path unchanged, no service-role fallback, no `reportSilentFallback`.
 - 2.2 **GREEN** — in `resolveUserKbRoot` (`kb-route-helpers.ts`), replace the `RuntimeAuthError` → 503 branch with: emit `reportSilentFallback` (feature `kb-route-helpers`, op `resolveUserKbRoot.tenant-mint`), then read the same `users` row via `createServiceClient()` (`.from("users").select(selectCols).eq("id", userId).single()`), and run the existing `workspace_path`/`workspace_status === "ready"`/`extras` validation against the fallback result. Keep the happy path and the non-`RuntimeAuthError` rethrow unchanged.
+  - 2.2.1 **`denied_jti` ceiling decision (deepen P1):** `RuntimeAuthError.cause` ∈ `{jwt_mint, rotation, denied_jti}`. Decide explicitly whether the fallback fires for ALL three or only the availability causes (`jwt_mint`/`rotation`). Default: fire for all three, and ADD a code comment at the fallback site naming the ceiling (read scoped to the user's own row; the share write was never tenant-scoped). If the auth-domain owner prefers fail-closed on `denied_jti`, scope the fallback to `cause !== "denied_jti"` and keep the 503 for denied jtis. The choice must be explicit in code, not incidental.
 - 2.3 Verify NO change to `app/api/kb/share/route.ts` GET handler, `kb-share.ts`, or `share-popover.tsx`.
 
 ## 3. Testing & Verification

--- a/knowledge-base/project/specs/feat-one-shot-fix-generate-link-button/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-generate-link-button/tasks.md
@@ -1,0 +1,37 @@
+# Tasks — Fix Generate-link button regression (tenant-mint dead-ends share-create)
+
+Plan: `knowledge-base/project/plans/2026-06-04-fix-share-link-tenant-mint-regression-plan.md`
+Lane: cross-domain | Brand-survival threshold: single-user incident (requires CPO sign-off)
+
+## 1. Setup / Preconditions
+
+- 1.1 Confirm regression locus unchanged on branch base: `git show abcb3765 -- apps/web-platform/app/api/kb/share/route.ts` shows the `resolveUserKbRoot(serviceClient, user.id)` → `resolveUserKbRoot(user.id)` change.
+- 1.2 Re-read `apps/web-platform/server/kb-route-helpers.ts:225-301` (current `resolveUserKbRoot`) and the existing mock harness in `apps/web-platform/test/kb-route-helpers.test.ts` (`getFreshTenantClient`, `RuntimeAuthError`, `createServiceClient`→`mockFrom`, `mockReportSilentFallback` are all already mocked).
+- 1.3 Confirm the pre-#3854 service-role read shape for column parity: `git show abcb3765~1:apps/web-platform/server/kb-route-helpers.ts` (columns `workspace_path, workspace_status[, extras]`).
+
+## 2. Core Implementation (RED → GREEN)
+
+- 2.1 **RED** — add failing tests in `kb-route-helpers.test.ts`:
+  - 2.1.1 `getFreshTenantClient` throws `RuntimeAuthError` + service-role row has `ready` workspace → expect `{ ok: true, kbRoot }` (currently 503).
+  - 2.1.2 Same, with `extras: ["repo_url", "github_installation_id"]` → expect extras populated from the fallback row.
+  - 2.1.3 Mint throws + service-role row NOT ready → expect the 503 "Workspace not ready" response preserved.
+  - 2.1.4 Mint throws → expect exactly one `mockReportSilentFallback` call carrying the error.
+  - 2.1.5 Mint succeeds (no throw) → tenant read path unchanged, no service-role fallback, no `reportSilentFallback`.
+- 2.2 **GREEN** — in `resolveUserKbRoot` (`kb-route-helpers.ts`), replace the `RuntimeAuthError` → 503 branch with: emit `reportSilentFallback` (feature `kb-route-helpers`, op `resolveUserKbRoot.tenant-mint`), then read the same `users` row via `createServiceClient()` (`.from("users").select(selectCols).eq("id", userId).single()`), and run the existing `workspace_path`/`workspace_status === "ready"`/`extras` validation against the fallback result. Keep the happy path and the non-`RuntimeAuthError` rethrow unchanged.
+- 2.3 Verify NO change to `app/api/kb/share/route.ts` GET handler, `kb-share.ts`, or `share-popover.tsx`.
+
+## 3. Testing & Verification
+
+- 3.1 Run the edited suite: `cd apps/web-platform && ./node_modules/.bin/vitest run test/kb-route-helpers.test.ts` — all pass (node-project include glob `test/**/*.test.ts`).
+- 3.2 Typecheck `apps/web-platform`.
+- 3.3 (Post-merge / operator) Playwright MCP: open a KB doc → Share → "Generate link"; assert the popover transitions to the active state (`/shared/<token>` URL + Copy/Revoke), not back to idle.
+
+## 4. Follow-ups (file as issues — do NOT silently defer)
+
+- 4.1 File a follow-up issue: apply the same mint-failure resilience to `authenticateAndResolveKbPath` (`kb-route-helpers.ts:95`, used by `/api/kb/file/*`), or lift the fallback into a shared sub-helper both functions call. Re-eval criterion: "next time a KB file route 503s on mint failure." Milestone from `knowledge-base/product/roadmap.md`.
+- 4.2 (Optional, separate PR) UX: surface an error toast in `share-popover.tsx` on a genuine 503 instead of silently bouncing to idle.
+
+## 5. PR
+
+- 5.1 PR body: reference regression source PR #3854 and umbrella #3244 with `Ref` (not `Closes` — #3244 is already CLOSED). If a tracking issue is created for this regression, use `Closes #<N>` for that.
+- 5.2 Acceptance Criteria split into Pre-merge (PR) and Post-merge (operator) per plan.


### PR DESCRIPTION
## Summary

The "Generate link" button in the Share popover silently dead-ended — clicking it bounced back to the identical idle panel instead of producing a `/shared/<token>` link. Regression from **PR #3854** (`#3244` PR-C tenant migration, merged 2026-05-16), which routed `resolveUserKbRoot`'s read of the caller's own `users.workspace_path` through a tenant-scoped JWT mint. On any mint failure (`jwt_mint` / `rotation` / `denied_jti`) the helper returned **503 "Workspace not ready"**, which the client `generateLink` callback treats as "reset to idle" — the reported "returns to the same box" symptom. The GET path was unaffected (uses service-role directly), so the popover still opened — a POST-only regression.

**Fix:** on `RuntimeAuthError`, fall back to a **service-role read of the user's own row** (`createServiceClient().from("users").select(cols).eq("id", userId).single()`) instead of 503. The same `workspace_status === "ready"` + `extras` validation runs on the fallback, so a genuinely not-ready workspace still 503s. `reportSilentFallback` still fires so a chronically-failing mint stays visible in Sentry even though users recover. Carries `extras` through so `POST /api/kb/upload` is covered too.

## User-Brand Impact

- **If this lands broken, the user experiences:** the Share popover's "Generate link" button does nothing on click (silently bounces back to the idle panel); the user cannot produce a public share link for any KB document.
- **If this leaks, the user's workflow is exposed via:** N/A — the service-role fallback reads only the *requesting user's own* row (`.eq("id", userId)`, where `userId` is the already-authenticated session user), so even a deny-listed tenant token can read only its OWN `workspace_path`/`repo_url`/`github_installation_id` — never another tenant's. The privileged share write (`createShare`) was already service-role, so no new privilege or data exposure is introduced; the change restores prior (pre-#3854) read behavior.
- **Brand-survival threshold:** `single-user incident` — a single founder hitting a dead "Generate link" button is a brand-survival-class user-facing failure.

## Safety ceiling (denied_jti)

The fallback fires for all three `RuntimeAuthError` causes including the deliberate-revocation `denied_jti` case. This is safe because (a) the read is hard-scoped to the authenticated user's own row, and (b) the privileged write on this path was never tenant-scoped — the deny-list never gated a privileged action here; `denied_jti` only ever blocked a self-read. The sibling helper `authenticateAndResolveKbPath` (file PATCH/DELETE mutation routes, where `denied_jti` *should* block the action) is intentionally left at 503 and carries a NOTE comment; applying the fallback there needs a per-cause adjudication, tracked in #4914.

## Changelog

- `fix(kb)`: `resolveUserKbRoot` falls back to a self-row service-role read on tenant-mint failure instead of returning 503, restoring the "Generate link" share button and the KB upload flow.

## Test plan

- [x] New `resolveUserKbRoot — tenant-mint fallback` test block in `kb-route-helpers.test.ts` (7 cases: happy-path-no-fallback, fallback-returns-ok, exactly-one-reportSilentFallback, extras-through-fallback, not-ready-still-503, denied_jti-covered, non-RuntimeAuthError-rethrown). RED-verified: 4 fail against pre-fix code.
- [x] Distinct `mockServiceFrom` proves the service-role client (not the tenant client) produced the row — fallback assertions are non-vacuous.
- [x] `apps/web-platform` typechecks; full webplat vitest shard green (8483 passed).
- [x] Multi-agent review (security-sentinel, user-impact-reviewer, test-design-reviewer, code-quality-analyst) — no P1/P2 blockers; the `denied_jti` ceiling independently verified sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
