### PR TITLE
fix(kb): per-cause tenant-mint fallback for authenticateAndResolveKbPath (file routes)

### DIFF
--- a/apps/web-platform/.service-role-allowlist
+++ b/apps/web-platform/.service-role-allowlist
@@ -289,7 +289,13 @@ apps/web-platform/server/inngest/functions/cron-supabase-disk-io.ts
 #       so the deny-list never gated a privileged action here — `denied_jti`
 #       only ever blocked a self-read.
 # The sibling helper authenticateAndResolveKbPath (file PATCH/DELETE
-# *mutation* routes) intentionally stays tenant-only and 503s on mint
-# failure — there a `denied_jti` MUST block the action; applying the same
-# fallback there needs a per-cause adjudication, tracked in #4914.
+# *mutation* routes) ALSO uses the service-role client as an availability
+# fallback (#4914), but with a PER-CAUSE policy that diverges from
+# resolveUserKbRoot's all-causes fallback: it falls back ONLY for the
+# availability causes `jwt_mint` | `rotation` (same self-row `.eq("id", user.id)`
+# scoping ceiling), and FAILS CLOSED with a 403 on `denied_jti` (and any future
+# un-named cause). The divergence is load-bearing: unlike the share path (whose
+# createShare write was already service-role), this helper's downstream GitHub
+# mutation is gated on it resolving, so a `denied_jti` deny-list trip MUST block
+# the action — a fallback there would defeat the revocation.
 apps/web-platform/server/kb-route-helpers.ts

--- a/apps/web-platform/server/kb-route-helpers.ts
+++ b/apps/web-platform/server/kb-route-helpers.ts
@@ -91,12 +91,29 @@ export async function authenticateAndResolveKbPath(
   // probe (the route flow reads only the caller's own row before any
   // cross-row work).
   //
-  // NOTE: unlike `resolveUserKbRoot` (which falls back to a service-role
-  // read on mint failure), this helper intentionally 503s — it serves the
-  // file PATCH/DELETE *mutation* routes, where a `denied_jti` deny-list trip
-  // is MEANT to block the action; a service-role fallback there would defeat
-  // that revocation. Applying the same fallback to the mutation paths needs
-  // an explicit per-cause adjudication, tracked in #4914.
+  // PER-CAUSE tenant-mint fallback (#4914), diverging from `resolveUserKbRoot`'s
+  // all-causes fallback because this helper serves the file PATCH/DELETE
+  // *mutation* routes (not the read/share path):
+  //   - `jwt_mint` | `rotation` (availability failures — signing/RPC failure, or
+  //     the 60/hr per-founder mint ceiling tripped): fall back to a SERVICE-ROLE
+  //     read of the caller's OWN row, exactly as `resolveUserKbRoot` does. The
+  //     read stays hard-scoped `.eq("id", user.id)` (server-derived session
+  //     user, never request-controlled), so the fallback restores availability
+  //     without weakening cross-tenant isolation — the mutation then proceeds.
+  //   - `denied_jti` (the cached JWT's jti landed in `public.denied_jti` — a
+  //     DELIBERATE revocation) and any future un-named cause: FAIL CLOSED with a
+  //     403. Unlike the share path (whose privileged `createShare` write was
+  //     already service-role, so the deny-list never gated it), here the
+  //     downstream GitHub mutation IS gated on this helper resolving — a
+  //     service-role fallback would defeat the revocation's intent. We branch on
+  //     the POSITIVE allow-list of availability causes so an unknown 4th cause
+  //     fails closed (the safe default on a mutation route), not open.
+  // `reportSilentFallback` fires for EVERY cause (incl. `denied_jti`) BEFORE the
+  // branch, so a chronic mint failure AND a revocation-hit both stay Sentry-
+  // visible (cq-silent-fallback-must-mirror-to-sentry). The fail-closed path
+  // MUST RETURN a Response (never throw): both route handlers call this helper
+  // OUTSIDE their try block, so a thrown RuntimeAuthError would escape to
+  // Next.js → an uncontrolled 500.
   let tenant;
   try {
     tenant = await getFreshTenantClient(user.id);
@@ -107,9 +124,16 @@ export async function authenticateAndResolveKbPath(
         op: "authenticateAndResolveKbPath.tenant-mint",
         extra: { userId: user.id },
       });
-      return err(503, "Workspace not ready");
+      if (mintErr.cause === "jwt_mint" || mintErr.cause === "rotation") {
+        // Availability failure — restore availability via a self-row read.
+        tenant = createServiceClient();
+      } else {
+        // `denied_jti` (revocation) or any future cause — honor the deny-list.
+        return err(403, "Access denied");
+      }
+    } else {
+      throw mintErr;
     }
-    throw mintErr;
   }
   const { data: userData } = await tenant
     .from("users")

--- a/apps/web-platform/test/kb-route-helpers.test.ts
+++ b/apps/web-platform/test/kb-route-helpers.test.ts
@@ -883,6 +883,12 @@ describe("authenticateAndResolveKbPath — tenant-mint fallback (#4914)", () => 
 
   // FR1 / AC1 — jwt_mint availability failure → service-role fallback resolves.
   test("jwt_mint → service-role fallback resolves OK (NOT 503)", async () => {
+    // Give the service-role row a DISTINCT workspace_path so the value
+    // assertion itself proves provenance (the row came from the service-role
+    // client, not the thrown tenant client) — not just the `mockFrom not
+    // called` negative assertion.
+    const SERVICE_ONLY_WORKSPACE = "/workspaces/service-role-only";
+    setupServiceUserData({ workspace_path: SERVICE_ONLY_WORKSPACE });
     mockGetFreshTenantClient.mockRejectedValueOnce(
       new RuntimeAuthError("jwt_mint", "mint failed"),
     );
@@ -894,7 +900,10 @@ describe("authenticateAndResolveKbPath — tenant-mint fallback (#4914)", () => 
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.ctx.userData.workspace_path).toBe(TEST_WORKSPACE_PATH);
+      // The resolved path is the SERVICE row's value — independent proof of
+      // provenance, not just the negative `mockFrom not called` assertion.
+      expect(result.ctx.userData.workspace_path).toBe(SERVICE_ONLY_WORKSPACE);
+      expect(result.ctx.kbRoot).toContain(SERVICE_ONLY_WORKSPACE);
       expect(result.ctx.owner).toBe("test-owner");
       expect(result.ctx.repo).toBe("test-repo");
     }

--- a/apps/web-platform/test/kb-route-helpers.test.ts
+++ b/apps/web-platform/test/kb-route-helpers.test.ts
@@ -858,3 +858,177 @@ describe("resolveUserKbRoot — tenant-mint fallback", () => {
     expect(mockServiceFrom).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tests — authenticateAndResolveKbPath — per-cause tenant-mint fallback (#4914)
+//
+// Mirrors the resolveUserKbRoot fallback block, but diverges on POLICY: this
+// helper serves the file PATCH/DELETE *mutation* routes, so a `denied_jti`
+// (deliberate revocation) must FAIL CLOSED (403) rather than fall back to a
+// service-role read. Only the availability causes (`jwt_mint`, `rotation`)
+// fall back. The distinct mockServiceFrom keeps every fallback assertion
+// non-vacuous (proves the SERVICE-ROLE client — not the thrown tenant client —
+// produced the row).
+// ---------------------------------------------------------------------------
+
+describe("authenticateAndResolveKbPath — tenant-mint fallback (#4914)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Happy-path wiring for CSRF / auth / path / lstat; the per-test mint
+    // override below forces the RuntimeAuthError branch. A ready service-role
+    // row is available so the availability fallback can resolve.
+    setupHappyPath();
+    setupServiceUserData();
+  });
+
+  // FR1 / AC1 — jwt_mint availability failure → service-role fallback resolves.
+  test("jwt_mint → service-role fallback resolves OK (NOT 503)", async () => {
+    mockGetFreshTenantClient.mockRejectedValueOnce(
+      new RuntimeAuthError("jwt_mint", "mint failed"),
+    );
+
+    const result = await authenticateAndResolveKbPath(
+      createRequest(),
+      createParams(["overview", "test.pdf"]),
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.ctx.userData.workspace_path).toBe(TEST_WORKSPACE_PATH);
+      expect(result.ctx.owner).toBe("test-owner");
+      expect(result.ctx.repo).toBe("test-repo");
+    }
+    // The SERVICE-ROLE client produced the row — not the (thrown) tenant client.
+    expect(mockServiceFrom).toHaveBeenCalledWith("users");
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  // FR1 / AC1 — rotation (60/hr ceiling trip) → fallback resolves.
+  test("rotation (ceiling trip) → service-role fallback resolves OK (NOT 503)", async () => {
+    mockGetFreshTenantClient.mockRejectedValueOnce(
+      new RuntimeAuthError("rotation", "mint ceiling tripped"),
+    );
+
+    const result = await authenticateAndResolveKbPath(
+      createRequest(),
+      createParams(["overview", "test.pdf"]),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(mockServiceFrom).toHaveBeenCalledWith("users");
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  // FR2 / AC2 — denied_jti revocation → fail CLOSED with 403, NO fallback read.
+  test("denied_jti → fail closed with 403, NO service-role fallback read", async () => {
+    mockGetFreshTenantClient.mockRejectedValueOnce(
+      new RuntimeAuthError("denied_jti", "jti on deny-list"),
+    );
+
+    const result = await authenticateAndResolveKbPath(
+      createRequest(),
+      createParams(["overview", "test.pdf"]),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(403);
+      const body = await result.response.json();
+      expect(body.error).toMatch(/access denied/i);
+    }
+    // Revocation must NOT fall back to a service-role read…
+    expect(mockServiceFrom).not.toHaveBeenCalled();
+    // …and must NOT proceed to a tenant read either.
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  // FR2 / AC3 — the denied_jti path RESOLVES to a Response, never rejects.
+  // Load-bearing: both route handlers call this helper OUTSIDE their try block,
+  // so a thrown RuntimeAuthError would escape to Next.js → uncontrolled 500.
+  test("denied_jti does NOT re-throw (resolves to a Response)", async () => {
+    mockGetFreshTenantClient.mockRejectedValueOnce(
+      new RuntimeAuthError("denied_jti", "jti on deny-list"),
+    );
+
+    await expect(
+      authenticateAndResolveKbPath(
+        createRequest(),
+        createParams(["overview", "test.pdf"]),
+      ),
+    ).resolves.toMatchObject({ ok: false });
+  });
+
+  // FR3 / AC4 — reportSilentFallback fires exactly once for EVERY cause,
+  // including denied_jti (the revocation hit must stay Sentry-visible BEFORE
+  // the 403 early-return).
+  test.each(["jwt_mint", "rotation", "denied_jti"] as const)(
+    "%s emits exactly one reportSilentFallback with op:authenticateAndResolveKbPath.tenant-mint",
+    async (cause) => {
+      const mintErr = new RuntimeAuthError(cause, `mint failure: ${cause}`);
+      mockGetFreshTenantClient.mockRejectedValueOnce(mintErr);
+
+      await authenticateAndResolveKbPath(
+        createRequest(),
+        createParams(["overview", "test.pdf"]),
+      );
+
+      expect(mockReportSilentFallback).toHaveBeenCalledTimes(1);
+      expect(mockReportSilentFallback).toHaveBeenCalledWith(
+        mintErr,
+        expect.objectContaining({
+          feature: "kb-route-helpers",
+          op: "authenticateAndResolveKbPath.tenant-mint",
+          extra: expect.objectContaining({ userId: TEST_USER_ID }),
+        }),
+      );
+    },
+  );
+
+  // FR1 / AC5 — no false-positive: a not-ready service row still 503s under
+  // the availability fallback.
+  test("fallback still 503s when the SERVICE-ROLE read yields a not-ready workspace", async () => {
+    mockGetFreshTenantClient.mockRejectedValueOnce(
+      new RuntimeAuthError("jwt_mint", "mint failed"),
+    );
+    // Distinct service-role mock returns a not-ready row, INDEPENDENT of the
+    // (thrown) tenant read — proves the 503 derives from the service read.
+    setupServiceUserData({ workspace_status: "provisioning" });
+
+    const result = await authenticateAndResolveKbPath(
+      createRequest(),
+      createParams(["overview", "test.pdf"]),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(503);
+    expect(mockServiceFrom).toHaveBeenCalledWith("users");
+  });
+
+  // FR4 / AC6 — a non-RuntimeAuthError mint failure is re-thrown unchanged.
+  test("a non-RuntimeAuthError from the mint is re-thrown (not swallowed)", async () => {
+    mockGetFreshTenantClient.mockRejectedValueOnce(new Error("unexpected boom"));
+
+    await expect(
+      authenticateAndResolveKbPath(
+        createRequest(),
+        createParams(["overview", "test.pdf"]),
+      ),
+    ).rejects.toThrow("unexpected boom");
+    expect(mockServiceFrom).not.toHaveBeenCalled();
+  });
+
+  // Regression guard — happy path (mint succeeds): tenant read, no fallback,
+  // no reportSilentFallback.
+  test("happy path (mint succeeds) reads via the TENANT client, no fallback", async () => {
+    // setupHappyPath() already wired the tenant mint to resolve.
+    const result = await authenticateAndResolveKbPath(
+      createRequest(),
+      createParams(["overview", "test.pdf"]),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(mockFrom).toHaveBeenCalledWith("users");
+    expect(mockServiceFrom).not.toHaveBeenCalled();
+    expect(mockReportSilentFallback).not.toHaveBeenCalled();
+  });
+});

--- a/knowledge-base/project/learnings/bug-fixes/2026-06-04-per-cause-mint-fallback-on-mutation-routes-fail-closed-return-not-throw.md
+++ b/knowledge-base/project/learnings/bug-fixes/2026-06-04-per-cause-mint-fallback-on-mutation-routes-fail-closed-return-not-throw.md
@@ -1,0 +1,70 @@
+---
+title: "Per-cause tenant-mint fallback on mutation routes: positive allow-list + return-not-throw"
+date: 2026-06-04
+category: bug-fixes
+module: apps/web-platform/server/kb-route-helpers.ts
+issue: 4914
+pr: 4919
+tags: [auth, tenant-jwt, service-role, fail-closed, kb-routes, runtime-auth-error]
+related:
+  - knowledge-base/project/learnings/bug-fixes/2026-06-04-tenant-mint-failure-needs-self-row-service-role-fallback.md
+  - knowledge-base/project/learnings/2026-05-05-defense-relaxation-must-name-new-ceiling.md
+---
+
+# Per-cause tenant-mint fallback on mutation routes
+
+## Problem
+
+`authenticateAndResolveKbPath` (the KB file PATCH/DELETE *mutation* helper) 503'd on
+**any** tenant-JWT mint failure, dead-ending a founder's KB file rename/delete during a
+transient mint blip (`jwt_mint`) or a 60/hr ceiling trip (`rotation`). This is the same
+brand-survival dead-end PR #4913 fixed for the share button's `resolveUserKbRoot` — but
+#4913 deliberately scoped this sibling **out** because it gates a mutation, not a read.
+
+## Solution
+
+A **per-cause** fallback on `RuntimeAuthError.cause`, diverging from #4913's all-causes shape:
+
+- `jwt_mint` | `rotation` (availability failures) → fall back to a service-role read of the
+  caller's own row (`.eq("id", user.id)`, server-derived) and let the mutation proceed.
+- `denied_jti` (deliberate revocation) + **any future un-named cause** → fail CLOSED with
+  `err(403, "Access denied")`.
+
+## Key Insights (reusable)
+
+1. **On a mutation route, branch on the POSITIVE allow-list of availability causes, not a
+   negated `!== "denied_jti"`.** `if (cause === "jwt_mint" || cause === "rotation") { fallback }
+   else { 403 }` makes a hypothetical future 4th `RuntimeAuthError.cause` fail CLOSED (the safe
+   default when the fallback would otherwise let a revoked/unknown token proceed to mutate). The
+   negated form fails OPEN. The read-route sibling (`resolveUserKbRoot`) can safely fall back for
+   all causes only because its privileged write (`createShare`) was *already* service-role — the
+   deny-list never gated a privileged action there.
+
+2. **The fail-closed arm MUST RETURN a Response, never throw.** Both route handlers
+   (`app/api/kb/file/[...path]/route.ts` DELETE + PATCH) call this helper **outside** their `try`
+   block. A thrown `RuntimeAuthError` would escape to Next.js → an uncontrolled 500. Always check
+   the call-site try-boundary before choosing throw-vs-return in a shared helper.
+
+3. **`reportSilentFallback` fires for EVERY cause (incl. `denied_jti`) BEFORE the branch**, so a
+   chronic mint failure AND a revocation hit both stay Sentry-visible
+   (`cq-silent-fallback-must-mirror-to-sentry`).
+
+4. **Inline the per-cause branch; do NOT extract a shared `resolve…(userId, policy)` helper.** A
+   `policy` parameter re-couples two call sites whose entire reason for separate existence is
+   divergent revocation semantics — and is the exact seam a future maintainer "simplifies" to
+   re-introduce the `denied_jti` bypass. Six agents concurred (architecture-strategist explicitly).
+
+5. **Test non-vacuity:** give the service-role mock a DISTINCT `workspace_path` from the tenant
+   mock so the *value* assertion proves provenance, not just a `mockFrom not called` negative.
+
+## Session Errors
+
+1. **`vitest -t "...(#4914)"` filter matched 0 tests** — `#`/parens in the test-name filter
+   matched nothing (43 skipped). **Prevention:** filter on a plain alphanumeric substring of the
+   describe name, not one containing regex/shell metacharacters.
+2. **`cd apps/web-platform` → "No such file or directory"** — the Bash tool persists CWD across
+   calls, so a prior `cd apps/web-platform` left the shell already inside it. **Prevention:** chain
+   `cd <absolute-path> && <cmd>` in a single call (already in the work-skill guidance) or use
+   absolute paths.
+3. **Plan `Edit` → "File has been modified since read"** after an in-band `sed` mutated the file.
+   **Prevention:** re-read a file after any non-Edit mutation (sed/awk) before Editing it.

--- a/knowledge-base/project/plans/2026-06-04-fix-kb-file-route-tenant-mint-fallback-plan.md
+++ b/knowledge-base/project/plans/2026-06-04-fix-kb-file-route-tenant-mint-fallback-plan.md
@@ -258,31 +258,31 @@ Test path `test/kb-route-helpers.test.ts` matches the node `test/**/*.test.ts` i
 
 ### Pre-merge (PR)
 
-- [ ] **AC1 (FR1):** `jwt_mint` and `rotation` mint failures resolve via the service-role fallback —
+- [x] **AC1 (FR1):** `jwt_mint` and `rotation` mint failures resolve via the service-role fallback —
   `authenticateAndResolveKbPath` returns `{ ok: true, ctx }`, NOT 503. Verified by Test 1 + 2 green
   (and RED against pre-fix `kb-route-helpers.ts`).
-- [ ] **AC2 (FR2):** `denied_jti` returns `{ ok: false, response }` with `response.status === 403` and
+- [x] **AC2 (FR2):** `denied_jti` returns `{ ok: false, response }` with `response.status === 403` and
   body `{ error: "Access denied" }`; `mockServiceFrom` is **not** called (no service-role fallback on
   revocation). Verified by Test 3 green.
-- [ ] **AC3 (FR2, fail-closed shape):** the `denied_jti` path **resolves to a Response object, never
+- [x] **AC3 (FR2, fail-closed shape):** the `denied_jti` path **resolves to a Response object, never
   rejects** — `.resolves.toMatchObject({ ok: false })`. Verified by Test 4 green. (Guards the
   out-of-try-block uncontrolled-500 escape.)
-- [ ] **AC4 (FR3):** `reportSilentFallback` fires exactly once for each of all three causes with
+- [x] **AC4 (FR3):** `reportSilentFallback` fires exactly once for each of all three causes with
   `op: "authenticateAndResolveKbPath.tenant-mint"` and `extra: { userId }`. Verified by Test 5 green.
-- [ ] **AC5 (FR1, no false-positive):** a service-role read returning a not-ready workspace still
+- [x] **AC5 (FR1, no false-positive):** a service-role read returning a not-ready workspace still
   503s under fallback. Verified by Test 6 green.
-- [ ] **AC6 (FR4):** a non-`RuntimeAuthError` mint failure is re-thrown unchanged. Verified by Test 7.
-- [ ] **AC7 (FR5):** the NOTE comment at `kb-route-helpers.ts` no longer says "intentionally 503s …
+- [x] **AC6 (FR4):** a non-`RuntimeAuthError` mint failure is re-thrown unchanged. Verified by Test 7.
+- [x] **AC7 (FR5):** the NOTE comment at `kb-route-helpers.ts` no longer says "intentionally 503s …
   tracked in #4914"; it names the per-cause ceiling (`jwt_mint`/`rotation` fall back; `denied_jti`
   fails closed) and the rationale. Verified by `grep -n "denied_jti" apps/web-platform/server/kb-route-helpers.ts`
   returning a match inside the `authenticateAndResolveKbPath` comment block + manual read.
-- [ ] **AC8 (FR6):** `apps/web-platform/.service-role-allowlist` "#4913" block mentions
+- [x] **AC8 (FR6):** `apps/web-platform/.service-role-allowlist` "#4913" block mentions
   `authenticateAndResolveKbPath`'s availability-only fallback (#4914). No new path line added (the
   file is already allowlisted). Verified by `grep -c "apps/web-platform/server/kb-route-helpers.ts"
   apps/web-platform/.service-role-allowlist` returning exactly `1` (unchanged count).
-- [ ] **AC9 (gate):** the `service-role-allowlist-gate` CI job stays green — no new disallowed
+- [x] **AC9 (gate):** the `service-role-allowlist-gate` CI job stays green — no new disallowed
   service-role importer (the file is already allowlisted; no new `createServiceClient` *file* added).
-- [ ] **AC10:** `apps/web-platform` typechecks (`cd apps/web-platform && ./node_modules/.bin/tsc --noEmit`)
+- [x] **AC10:** `apps/web-platform` typechecks (`cd apps/web-platform && ./node_modules/.bin/tsc --noEmit`)
   and the `kb-route-helpers.test.ts` vitest file is fully green.
 
 ### Post-merge (operator)

--- a/knowledge-base/project/plans/2026-06-04-fix-kb-file-route-tenant-mint-fallback-plan.md
+++ b/knowledge-base/project/plans/2026-06-04-fix-kb-file-route-tenant-mint-fallback-plan.md
@@ -122,7 +122,13 @@ is the identical brand-survival dead-end PR #4913 fixed for the share button, on
 **If this leaks, the user's workflow is exposed via:** N/A for the `jwt_mint`/`rotation` fallback —
 the service-role read is hard-scoped `.eq("id", user.id)` where `user.id` is the already-authenticated
 session user (`supabase.auth.getUser()`), so even under fallback a caller reads only its OWN
-`workspace_path`/`repo_url`/`github_installation_id` — never another tenant's. The privileged
+`workspace_path`/`repo_url`/`github_installation_id` — never another tenant's. The second read the
+fallback path can reach — `resolveInstallationId(user.id)` (when the row has `repo_url` but a null
+`github_installation_id`, `:157`) — is also self-scoped: it resolves the workspace internally from the
+same server-derived `user.id` and reads the credential only via the membership-checked
+`resolve_workspace_installation_id` SECURITY DEFINER RPC (the `github_installation_id` column is
+revoked from the `authenticated` grant), so a non-member resolves `null` → a clean `400 "No
+repository connected"`, never another tenant's installation. The privileged
 mutation downstream still requires the resolved installation-id to belong to that same row. The
 `denied_jti` path is the *opposite* of a leak: it **tightens** behavior (a revoked token is now
 blocked with 403 instead of silently 503'd, but it never falls back to service-role on revocation).

--- a/knowledge-base/project/plans/2026-06-04-fix-kb-file-route-tenant-mint-fallback-plan.md
+++ b/knowledge-base/project/plans/2026-06-04-fix-kb-file-route-tenant-mint-fallback-plan.md
@@ -1,0 +1,440 @@
+---
+title: "fix(kb): per-cause tenant-mint fallback for authenticateAndResolveKbPath (file routes)"
+type: fix
+issue: 4914
+branch: feat-one-shot-4914-kb-tenant-mint-fallback
+date: 2026-06-04
+lane: single-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+status: planned
+---
+
+# fix(kb): per-cause tenant-mint fallback for `authenticateAndResolveKbPath` 🐛
+
+## Enhancement Summary
+
+**Deepened on:** 2026-06-04
+**Sections enhanced:** Overview, FRs, Risks, Test Scenarios (Research Insights added)
+**Deepen passes run:** Phase 4.4 precedent-diff, Phase 4.45 verify-the-negative + post-edit self-audit, Phase 4.6/4.7/4.8/4.9 halt gates (all PASS), framework-docs verification of `RuntimeAuthError` semantics against installed source.
+
+### Key Improvements
+
+1. **Branch shape pinned to fail-CLOSED-on-unknown-cause.** Verified the `RuntimeAuthError.cause` union has a `: never` exhaustiveness rail at `tenant.ts:131` (`mapRuntimeAuthCauseToErrorCode`). FR1/FR2 are pinned to the `if (cause === "jwt_mint" || cause === "rotation") { fallback } else { 403 }` shape so a hypothetical future 4th cause fails CLOSED on a mutation route (safe default), NOT open. This is the load-bearing precedent-DIVERGENCE from `resolveUserKbRoot`'s all-causes shape.
+2. **Re-throw → uncontrolled-500 hazard confirmed and gated.** Read both route handlers (`route.ts:22` DELETE, `route.ts:135` PATCH): the helper is called OUTSIDE the `try` block in both. A thrown `RuntimeAuthError` on `denied_jti` would escape to Next.js → 500. FR2/AC3/Test 4 mandate a returned `err(403, …)`, never a throw.
+3. **Zero-infra-change verified.** `createServiceClient` is already imported (`kb-route-helpers.ts:4`); `kb-route-helpers.ts` is already on `.service-role-allowlist` (count == 1, PR #4913). No new import, no new allowlist path line, no migration, no infra.
+
+### New Considerations Discovered
+
+- The `denied_jti` 403 must fire `reportSilentFallback` BEFORE returning (FR3/AC4) — a revocation-hit on a mutation route is operationally interesting (a revoked founder retrying), so it must stay Sentry-visible, not silently dropped on the early-return.
+- `rotation`'s 60/hr ceiling "won't clear in seconds, no retry" (`tenant.ts:169`) — confirms a client-retry alternative is wrong; server-side fallback is the only correct fix for that cause.
+
+## Overview
+
+`authenticateAndResolveKbPath` (`apps/web-platform/server/kb-route-helpers.ts:65-202`) mints a
+tenant-scoped JWT (`getFreshTenantClient(user.id)`) just to read the caller's **own** `users` row,
+and returns **503 "Workspace not ready"** when the mint throws `RuntimeAuthError`
+(`:104-110`). This is the same regression class fixed for `resolveUserKbRoot` in **PR #4913** (the
+"Generate link" dead-end). A transient mint failure (`jwt_mint`) or a per-founder mint-ceiling trip
+(`rotation`) dead-ends the KB **file mutation** routes — `PATCH/DELETE /api/kb/file/[...path]` — the
+same way the share POST was dead-ended.
+
+PR #4913 deliberately scoped `authenticateAndResolveKbPath` **out** as a Non-Goal and left a NOTE
+comment (`:94-99`) because this helper serves **mutation** routes (PATCH = rename, DELETE = delete),
+where the `denied_jti` `RuntimeAuthError` cause is a *deliberate token revocation*. Blindly copying
+the all-causes fallback PR #4913 applied to the read/share path would let a revoked tenant fall
+through to a service-role read and proceed to mutate — defeating the revocation's intent.
+
+**This fix applies a *per-cause* fallback** (the adjudication the issue and the PR #4913 learning
+both demand):
+
+- **`jwt_mint` | `rotation`** (availability failures — signing/RPC failure, or the 60/hr per-founder
+  ceiling tripped): fall back to a **service-role read of the caller's own row**, exactly as
+  `resolveUserKbRoot` does. The mutation then proceeds — these causes are transient infrastructure
+  failures, not authorization signals.
+- **`denied_jti`** (the cached JWT's jti landed in `public.denied_jti` — a deliberate revocation):
+  **fail closed**. Do NOT fall back. Return a clean `403 "Access denied"` response so the mutation is
+  blocked, honoring the revocation.
+
+This is a single-file behavioral change to one helper (~15 LOC + the err-helper) plus a new test
+block. `kb-route-helpers.ts` is **already on the service-role allowlist** (re-introduced by PR #4913
+for `resolveUserKbRoot`'s fallback — see `.service-role-allowlist` "#4913" section), and
+`createServiceClient` is **already imported** at `kb-route-helpers.ts:4`. **No allowlist edit and no
+new import is required.**
+
+### Why per-cause here but all-causes for `resolveUserKbRoot`
+
+The asymmetry is load-bearing and is the entire point of the issue (per
+`knowledge-base/project/learnings/2026-05-05-defense-relaxation-must-name-new-ceiling.md`):
+
+| | `resolveUserKbRoot` (PR #4913) | `authenticateAndResolveKbPath` (this fix) |
+|---|---|---|
+| Routes served | share POST (read self-row), upload | file **PATCH/DELETE** (mutation) |
+| Privileged write on the path | `createShare` — **service-role at the route** (`app/api/kb/share/route.ts:36,40`); never tenant-scoped | the GitHub mutation (`githubApiPost`/`githubApiDelete`) + `syncWorkspace`, gated on this helper resolving |
+| Does the deny-list gate a privileged action here? | **No** — `denied_jti` only ever blocked a self-read; the write was already service-role | **Yes** — `denied_jti` is meant to block the *mutation* |
+| Correct `denied_jti` behavior | fall back (read-only, self-scoped — see PR #4913 ceiling) | **fail closed (403)** — honor the revocation |
+
+For `jwt_mint`/`rotation` the *same* ceiling that makes PR #4913 safe applies verbatim: the fallback
+read is hard-scoped `.eq("id", user.id)` where `user.id` comes from `supabase.auth.getUser()`
+(server-derived, never request-controlled), so even under fallback the read touches only the caller's
+OWN row. The availability fallback does not weaken cross-tenant isolation — it only restores
+availability when the tenant-JWT *minting infrastructure* (not the authorization decision) is down.
+
+## Premise Validation
+
+Checked the four cited references; all held, none stale:
+
+- **PR #4913** — `gh pr view 4913` → `MERGED 2026-06-03`; on `origin/main` as `7c868015`. The NOTE
+  comment `// … tracked in #4914.` is live at `kb-route-helpers.ts:99` on main. Premise (this is the
+  scoped-out sibling) confirmed.
+- **`kb-route-helpers.ts:95` / `:96-104`** — confirmed: `getFreshTenantClient(user.id)` at `:102`,
+  `RuntimeAuthError` catch returning `err(503, "Workspace not ready")` at `:104-110` (issue's
+  line numbers are off-by-a-few post-#4913 but the code is exactly as described). `Read` verified.
+- **`RuntimeAuthError.cause`** — `apps/web-platform/lib/supabase/tenant.ts:91` declares
+  `public readonly cause: "jwt_mint" | "rotation" | "denied_jti"`. The discriminant is a clean
+  3-member string union, so the per-cause branch is a simple `if (mintErr.cause === "denied_jti")`.
+  `mapRuntimeAuthCauseToErrorCode` (`tenant.ts:121`) confirms the same union. **No widening risk** —
+  the union is the source of truth and TS will break if a 4th cause is added (the `: never` rail at
+  `tenant.ts:131`).
+- **Route try-boundary** — both `DELETE` (`route.ts:22`) and `PATCH` (`route.ts:135`) call
+  `authenticateAndResolveKbPath` **outside** their `try` blocks (the `try` starts at `:27` / after
+  the JSON parse). So a *thrown* `RuntimeAuthError` would escape to Next.js's framework error
+  boundary → an uncontrolled 500. **Therefore the `denied_jti` fail-closed path MUST return a clean
+  `{ ok: false, response: err(403, …) }`, NOT re-throw.** This is the single most important
+  implementation detail and is reflected in FR2 below.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Issue/PR claim | Codebase reality | Plan response |
+|---|---|---|
+| "fall back to service-role read … OR lift into a shared sub-helper both call" | The two helpers differ structurally: `authenticateAndResolveKbPath` does CSRF + auth + path-validation + installation-id fallback + symlink check inline and returns a rich `KbRouteContext`; `resolveUserKbRoot` is the simpler body-path building block. The shared portion is only the ~8-line mint+catch+read. | **Do NOT extract a shared sub-helper.** A shared helper would have to carry the per-cause *policy* (all-causes vs deny-on-`denied_jti`) as a parameter, re-introducing the coupling the two call sites deliberately keep separate. Inline the per-cause branch in `authenticateAndResolveKbPath`, mirroring `resolveUserKbRoot`'s inline shape. DHH/simplicity-aligned: ~15 LOC inline beats a parameterized policy helper. (If plan-review disagrees, the fold-in is trivial — but default to inline.) |
+| Issue says line `:95-104` | Post-#4913 the block is `:100-113` (NOTE comment added 6 lines). | Cosmetic; FRs reference the *code shape*, not line numbers. |
+| "service-role fallback … more aggressive than read-only share-link generation" | Correct. The mutation routes' privileged action (GitHub write + `syncWorkspace`) IS gated on this helper. | Per-cause split: availability causes fall back, `denied_jti` fails closed. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a founder editing or deleting a KB file (rename via
+PATCH, delete via DELETE in the dashboard file viewer) gets a silent **503 "Workspace not ready"**
+during a transient tenant-JWT mint blip or after tripping the 60/hr mint ceiling — the file
+operation appears to fail for no visible reason, even though their workspace is perfectly ready. This
+is the identical brand-survival dead-end PR #4913 fixed for the share button, on the mutation routes.
+
+**If this leaks, the user's workflow is exposed via:** N/A for the `jwt_mint`/`rotation` fallback —
+the service-role read is hard-scoped `.eq("id", user.id)` where `user.id` is the already-authenticated
+session user (`supabase.auth.getUser()`), so even under fallback a caller reads only its OWN
+`workspace_path`/`repo_url`/`github_installation_id` — never another tenant's. The privileged
+mutation downstream still requires the resolved installation-id to belong to that same row. The
+`denied_jti` path is the *opposite* of a leak: it **tightens** behavior (a revoked token is now
+blocked with 403 instead of silently 503'd, but it never falls back to service-role on revocation).
+
+**Brand-survival threshold:** `single-user incident` — a single founder hitting a dead rename/delete
+button is a brand-survival-class user-facing failure, identical to the #4913 share-button class.
+
+> **CPO sign-off required at plan time before `/work` begins.** Threshold is `single-user incident`.
+> CPO domain leader (Product/UX gate below) reviews the *availability-restore vs revocation-honor*
+> trade-off. `user-impact-reviewer` will be invoked at review-time (handled by the review skill's
+> conditional-agent block). Recommend ultrathink/`deepen-plan` (already invoked by this pipeline) so
+> the security-sentinel + data-integrity-guardian lens lands on the per-cause adjudication — per the
+> learning that plan-review (DHH/Kieran/simplicity) is structurally blind to security-primitive
+> findings at this threshold.
+
+## Functional Requirements
+
+**FR1 — Availability fallback (`jwt_mint` | `rotation`).** In the `catch (mintErr instanceof
+RuntimeAuthError)` branch at `kb-route-helpers.ts:104`, branch on **the named availability causes
+explicitly** — `if (mintErr.cause === "jwt_mint" || mintErr.cause === "rotation")` — and in that arm
+reassign `tenant = createServiceClient()` and let the existing `.from("users").select(...)
+.eq("id", user.id).single()` read + the existing `workspace_status === "ready"` / installation-id /
+repo validation run unchanged against the service-role client. **Branch on the allow-list of
+availability causes, NOT `cause !== "denied_jti"`** — the negated form falls OPEN for any future 4th
+cause, which on a mutation route is the unsafe default. The positive allow-list form makes FR2 the
+`else` arm, so an unknown cause fails closed (403). Implementation location:
+`kb-route-helpers.ts:104-113` (the existing catch branch, edited).
+
+**FR2 — Revocation (and any unknown cause) fail-closed.** The `else` arm of FR1's branch (i.e.
+`denied_jti` today, plus any future un-named cause): do **NOT** fall back. Return
+`err(403, "Access denied")` (the helper's existing `err()` factory at `:196`, reused — same
+403/"Access denied" shape the symlink guard already returns at `:163`). This MUST be a returned
+`{ ok: false, response }` — **never a re-throw** — because both route handlers call this helper
+outside their try block (`route.ts:22` DELETE, `route.ts:135` PATCH; verified — a throw escapes to
+Next.js → uncontrolled 500). Implementation location: `kb-route-helpers.ts:104` catch branch, the
+`else` arm after the availability-causes `if`.
+
+**FR3 — Observability preserved for ALL causes.** `reportSilentFallback(mintErr, { feature:
+"kb-route-helpers", op: "authenticateAndResolveKbPath.tenant-mint", extra: { userId: user.id } })`
+MUST still fire on every `RuntimeAuthError` — including `denied_jti` — so a chronically-failing mint
+(ceiling trip / GoTrue outage) AND a revocation-hit both stay visible to the operator in Sentry. The
+existing call at `:105-109` already does this; keep it firing *before* the per-cause branch so it is
+not skipped on the `denied_jti` return. (`cq-silent-fallback-must-mirror-to-sentry`.)
+
+**FR4 — Non-`RuntimeAuthError` still re-thrown.** The existing `throw mintErr` at `:112` for a
+non-`RuntimeAuthError` mint failure is unchanged — an unexpected (non-auth) error must not be
+swallowed by the fallback.
+
+**FR5 — NOTE comment updated.** Replace the `:94-99` NOTE comment (which says this helper
+"intentionally 503s … tracked in #4914") with a comment naming the **new ceiling** explicitly per
+`2026-05-05-defense-relaxation-must-name-new-ceiling.md`: which causes fall back, which fails closed,
+and *why* (the deny-list gates the mutation here, unlike the share path). Mirror the prose style of
+`resolveUserKbRoot`'s ceiling comment (`:251-263`).
+
+**FR6 — `.service-role-allowlist` rationale updated (comment-only).** `kb-route-helpers.ts` is
+already on the allowlist (PR #4913). Extend the "#4913" rationale block in
+`apps/web-platform/.service-role-allowlist` with a sentence noting that
+`authenticateAndResolveKbPath` now *also* uses the service-role client as an availability fallback
+(for `jwt_mint`/`rotation` only) per #4914, and that `denied_jti` fails closed. **No new path line**
+— the file is already allowlisted; this is a documentation update to keep the rationale honest.
+(CODEOWNERS pins this file; a comment-only edit does not add a path, so it does not require the
+`@jeanderuelle` path-add approval — but flag for reviewer awareness.)
+
+## Non-Goals
+
+- **No shared sub-helper extraction** (see Research Reconciliation). Default to inline; fold in only
+  if plan-review explicitly prefers it.
+- **No change to `resolveUserKbRoot`** — PR #4913's all-causes fallback there is correct and stays.
+- **No change to the GET file route** — GET uses service-role directly and was never affected (same
+  as the #4913 analysis).
+- **No new client-facing UX copy** — the 403 reuses the existing "Access denied" message; the file
+  viewer already surfaces 4xx/5xx as a generic failure. (A per-cause "your session was revoked" toast
+  is out of scope; `mapRuntimeAuthCauseToErrorCode` exists for a future UX pass — not this fix.)
+
+## Files to Edit
+
+- `apps/web-platform/server/kb-route-helpers.ts` — FR1–FR5: per-cause branch in the
+  `authenticateAndResolveKbPath` mint-failure catch (`:104-113`) + NOTE comment rewrite (`:94-99`).
+- `apps/web-platform/test/kb-route-helpers.test.ts` — new test block (see Test Scenarios); extend the
+  `authenticateAndResolveKbPath` describe or add a sibling `authenticateAndResolveKbPath — tenant-mint
+  fallback` describe mirroring the `resolveUserKbRoot — tenant-mint fallback` block at `:748-870`.
+- `apps/web-platform/.service-role-allowlist` — FR6: comment-only rationale extension under the
+  "#4913" section.
+
+## Files to Create
+
+- None. (Learning capture happens at ship time via `/soleur:compound` into
+  `knowledge-base/project/learnings/bug-fixes/`; do not pre-create with a hardcoded dated filename.)
+
+## Test Scenarios
+
+New test block mirroring `resolveUserKbRoot — tenant-mint fallback` (`:748-870`). The scaffolding
+already exists: `mockServiceFrom` (distinct service-role `.from`), `setupServiceUserData()`,
+`setupHappyPath()`, and the two-arg mock `RuntimeAuthError(cause, message)` with a public `cause`
+field (`:52-62`). Use `setupServiceUserData()` in `beforeEach` so the fallback has a ready row, and
+the distinct `mockServiceFrom`/`mockFrom` assertions to keep every fallback assertion **non-vacuous**
+(prove the SERVICE-ROLE client — not the thrown tenant client — produced the row).
+
+1. **`jwt_mint` → service-role fallback resolves OK (NOT 503).** Mint rejects with
+   `RuntimeAuthError("jwt_mint", …)`; `setupHappyPath()` + `setupServiceUserData()`.
+   Assert `result.ok === true`, populated `ctx`, `mockServiceFrom` called with `"users"`,
+   `mockFrom` (tenant) **not** called. *(RED against pre-fix code — currently 503.)*
+2. **`rotation` (ceiling trip) → service-role fallback resolves OK (NOT 503).** Same as (1) with
+   `cause: "rotation"`. *(RED.)*
+3. **`denied_jti` → fail closed with 403, NO fallback read.** Mint rejects with
+   `RuntimeAuthError("denied_jti", …)`. Assert `result.ok === false`, `result.response.status === 403`,
+   body error matches `/access denied/i`, **`mockServiceFrom` NOT called** (no fallback read happened),
+   `mockFrom` NOT called. *(RED — currently 503, not 403, and would silently 503 rather than block.)*
+4. **`denied_jti` does NOT re-throw (returns a Response).** Assert the call **resolves** (does not
+   reject) — `await expect(authenticateAndResolveKbPath(...)).resolves.toMatchObject({ ok: false })`.
+   This is the load-bearing guard against the uncontrolled-500 escape (Premise Validation). *(RED.)*
+5. **All three causes emit exactly one `reportSilentFallback` carrying the `RuntimeAuthError`** (FR3).
+   Parametrize over `["jwt_mint", "rotation", "denied_jti"]`; assert
+   `mockReportSilentFallback` called exactly once with `{ feature: "kb-route-helpers", op:
+   "authenticateAndResolveKbPath.tenant-mint", extra: { userId: TEST_USER_ID } }`. Critically asserts
+   the `denied_jti` arm still mirrors to Sentry *before* returning 403.
+6. **Fallback still 503s when the SERVICE-ROLE read yields a not-ready workspace** (no false-positive
+   resolution). `jwt_mint` mint failure + `setupServiceUserData({ workspace_status: "provisioning" })`.
+   Assert 503 derives from the *service* read (`mockServiceFrom` called; result 503).
+7. **A non-`RuntimeAuthError` mint failure is re-thrown** (FR4). Mint rejects with `new Error("boom")`;
+   `await expect(...).rejects.toThrow("boom")`; `mockServiceFrom` NOT called.
+8. **Happy path unchanged: mint succeeds → tenant read, no fallback, no `reportSilentFallback`**
+   (regression guard for FR1 not firing on success).
+
+**Runner:** `apps/web-platform` uses **vitest** (not bun test — `apps/web-platform/bunfig.toml`
+ignores `**`). Run from inside the app dir:
+`cd apps/web-platform && ./node_modules/.bin/vitest run test/kb-route-helpers.test.ts`.
+Test path `test/kb-route-helpers.test.ts` matches the node `test/**/*.test.ts` include glob
+(`apps/web-platform/vitest.config.ts`) — confirmed by the existing file living there. RED-verify the
+4 new-behavior cases (1,2,3,4) fail against pre-fix code before implementing (`cq-write-failing-tests-before`).
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] **AC1 (FR1):** `jwt_mint` and `rotation` mint failures resolve via the service-role fallback —
+  `authenticateAndResolveKbPath` returns `{ ok: true, ctx }`, NOT 503. Verified by Test 1 + 2 green
+  (and RED against pre-fix `kb-route-helpers.ts`).
+- [ ] **AC2 (FR2):** `denied_jti` returns `{ ok: false, response }` with `response.status === 403` and
+  body `{ error: "Access denied" }`; `mockServiceFrom` is **not** called (no service-role fallback on
+  revocation). Verified by Test 3 green.
+- [ ] **AC3 (FR2, fail-closed shape):** the `denied_jti` path **resolves to a Response object, never
+  rejects** — `.resolves.toMatchObject({ ok: false })`. Verified by Test 4 green. (Guards the
+  out-of-try-block uncontrolled-500 escape.)
+- [ ] **AC4 (FR3):** `reportSilentFallback` fires exactly once for each of all three causes with
+  `op: "authenticateAndResolveKbPath.tenant-mint"` and `extra: { userId }`. Verified by Test 5 green.
+- [ ] **AC5 (FR1, no false-positive):** a service-role read returning a not-ready workspace still
+  503s under fallback. Verified by Test 6 green.
+- [ ] **AC6 (FR4):** a non-`RuntimeAuthError` mint failure is re-thrown unchanged. Verified by Test 7.
+- [ ] **AC7 (FR5):** the NOTE comment at `kb-route-helpers.ts` no longer says "intentionally 503s …
+  tracked in #4914"; it names the per-cause ceiling (`jwt_mint`/`rotation` fall back; `denied_jti`
+  fails closed) and the rationale. Verified by `grep -n "denied_jti" apps/web-platform/server/kb-route-helpers.ts`
+  returning a match inside the `authenticateAndResolveKbPath` comment block + manual read.
+- [ ] **AC8 (FR6):** `apps/web-platform/.service-role-allowlist` "#4913" block mentions
+  `authenticateAndResolveKbPath`'s availability-only fallback (#4914). No new path line added (the
+  file is already allowlisted). Verified by `grep -c "apps/web-platform/server/kb-route-helpers.ts"
+  apps/web-platform/.service-role-allowlist` returning exactly `1` (unchanged count).
+- [ ] **AC9 (gate):** the `service-role-allowlist-gate` CI job stays green — no new disallowed
+  service-role importer (the file is already allowlisted; no new `createServiceClient` *file* added).
+- [ ] **AC10:** `apps/web-platform` typechecks (`cd apps/web-platform && ./node_modules/.bin/tsc --noEmit`)
+  and the `kb-route-helpers.test.ts` vitest file is fully green.
+
+### Post-merge (operator)
+
+- None. This is a pure code change against an already-provisioned surface; no migration, no infra, no
+  external-service config. The fix deploys via the standard `web-platform-release.yml` pipeline on
+  merge to main (path-filtered `apps/web-platform/**`).
+
+## Domain Review
+
+**Domains relevant:** Engineering (CTO), Product (CPO — Product/UX Gate, single-user-incident threshold)
+
+### Engineering (CTO)
+
+**Status:** reviewed (plan-author assessment; deepen-plan will spawn data-integrity-guardian +
+security-sentinel + architecture-strategist for the per-cause adjudication)
+**Assessment:** Single-file behavioral change mirroring an established, security-reviewed sibling
+pattern (PR #4913). The novel surface is the per-cause split on `RuntimeAuthError.cause`. Two
+load-bearing facts make it safe: (1) the `cause` union is the source of truth with a `: never`
+exhaustiveness rail (`tenant.ts:131`), so the branch cannot silently miss a future cause; (2) the
+fail-closed path MUST return a Response (not throw) because the call sites are outside their try
+blocks — encoded as FR2 + AC3. No SQL, no schema, no migration. Defense-relaxation discipline applied
+(FR5 names the new ceiling per `2026-05-05-defense-relaxation-must-name-new-ceiling.md`).
+
+### Product/UX Gate
+
+**Tier:** none (no UI-surface file touched — `## Files to Edit`/`## Files to Create` contain only
+`server/*.ts`, `test/*.ts`, and `.service-role-allowlist`; the mechanical UI-surface override does
+not fire). Product domain is flagged relevant only for the **CPO sign-off** required by the
+`single-user incident` threshold (User-Brand Impact, FR-policy adjudication), not for a wireframe.
+**Decision:** auto-accepted (pipeline) for the UX-producer steps (no UI surface → no `.pen`). CPO
+sign-off on the availability-vs-revocation trade-off is requested at plan time per the threshold.
+**Agents invoked:** none (no UI surface; spec-flow/ux-design-lead/copywriter not applicable — no
+user flow, no page, no copy beyond the reused "Access denied" string).
+**Skipped specialists:** none — `ux-design-lead` is N/A (no UI surface).
+**Pencil available:** N/A (no UI surface).
+
+#### Findings
+
+No new user-facing surface. The only user-observable behavioral deltas: (a) rename/delete now
+*succeed* during a transient mint blip instead of failing with 503 (strict improvement), and (b) a
+deny-listed/revoked session now gets a 403 instead of a silent 503 on a mutation route (correct
+tightening — the revocation is now honored). Both are positive or neutral for the founder; neither
+introduces a new screen, flow, or copy.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: Sentry events tagged op:"authenticateAndResolveKbPath.tenant-mint" (existing reportSilentFallback)
+  cadence: per mint-failure occurrence (event-driven, no fixed cadence)
+  alert_target: Sentry issue grouping on feature:"kb-route-helpers" + op:"authenticateAndResolveKbPath.tenant-mint"
+  configured_in: apps/web-platform/server/kb-route-helpers.ts (reportSilentFallback call, FR3) + Sentry project rules
+error_reporting:
+  destination: Sentry (via reportSilentFallback → server/observability.ts)
+  fail_loud: true — fires for ALL three causes including the denied_jti fail-closed path (FR3); a chronically failing mint OR a revocation-hit both surface
+failure_modes:
+  - mode: tenant-JWT mint availability failure (jwt_mint signing/RPC, or rotation 60/hr ceiling)
+    detection: Sentry event op:authenticateAndResolveKbPath.tenant-mint with RuntimeAuthError.cause in {jwt_mint, rotation}; user-invisible (mutation now succeeds via fallback)
+    alert_route: Sentry — a SPIKE indicates a GoTrue outage or a founder repeatedly tripping the mint ceiling
+  - mode: deliberate token revocation hit on a mutation route (denied_jti)
+    detection: Sentry event op:authenticateAndResolveKbPath.tenant-mint with cause denied_jti + the caller receiving 403; expected/intended when a jti is on the deny-list
+    alert_route: Sentry — a denied_jti hit is informational (the revocation is working); a SPIKE could indicate a revoked founder repeatedly retrying
+  - mode: service-role read returns not-ready workspace under fallback
+    detection: 503 returned to caller after a successful fallback read (FR1/AC5); same as the non-fallback not-ready 503
+    alert_route: existing 503 client handling; no new alert
+logs:
+  where: Sentry (structured event); no new pino log line added (reportSilentFallback already routes to Sentry + structured logger per server/observability.ts)
+  retention: Sentry project default retention
+discoverability_test:
+  command: "cd apps/web-platform && ./node_modules/.bin/vitest run test/kb-route-helpers.test.ts -t 'tenant-mint' (asserts reportSilentFallback fires for all 3 causes — Test 5)"
+  expected_output: vitest reports the 'reportSilentFallback fires exactly once for each cause' test green, proving the Sentry-mirror path is exercised for jwt_mint, rotation, AND denied_jti
+```
+
+## Risks & Mitigations
+
+### Precedent-Diff (Phase 4.4) — vs `resolveUserKbRoot` (PR #4913)
+
+`git grep` precedent: the canonical mint-failure catch shape lives in the SAME file at
+`kb-route-helpers.ts:264-278` (`resolveUserKbRoot`). Side-by-side:
+
+```
+resolveUserKbRoot (PR #4913, ALL causes)        authenticateAndResolveKbPath (this fix, PER-cause)
+------------------------------------------       --------------------------------------------------
+catch (mintErr) {                                catch (mintErr) {
+  if (mintErr instanceof RuntimeAuthError) {       if (mintErr instanceof RuntimeAuthError) {
+    reportSilentFallback(mintErr, {...});            reportSilentFallback(mintErr, {...});   // FR3: ALL causes
+    tenant = createServiceClient();    // ALL        if (mintErr.cause === "jwt_mint" ||
+  } else {                                               mintErr.cause === "rotation") {
+    throw mintErr;                                       tenant = createServiceClient();    // FR1
+  }                                                  } else {
+}                                                      return err(403, "Access denied");  // FR2 (denied_jti + unknown)
+                                                     }
+                                                   } else {
+                                                     throw mintErr;                       // FR4
+                                                   }
+                                                 }
+```
+
+The divergence (per-cause `else`-403 vs all-causes fallback) is intentional and is the entire point
+of #4914: `resolveUserKbRoot`'s downstream write was already service-role (deny-list gated nothing),
+whereas this helper's downstream GitHub mutation IS gated on it resolving. **Not novel** — the catch
+skeleton is copied verbatim from the precedent; only the cause-branch is added.
+
+### Risk register
+
+- **Risk: future 4th `RuntimeAuthError.cause` falls OPEN (silently falls back on a mutation route).**
+  *Mitigation:* FR1 branches on the **positive allow-list** `cause === "jwt_mint" || cause ===
+  "rotation"`, so the `else` (FR2) catches `denied_jti` AND any future cause → 403 (fail-closed).
+  Verified the `cause` union has a `: never` exhaustiveness rail at `tenant.ts:120-134`
+  (`mapRuntimeAuthCauseToErrorCode`) — a 4th cause is a TS build break there, a compile-time signal to
+  revisit this branch. (The branch itself does not need the rail; the allow-list form is safe
+  regardless.)
+- **Risk: re-throw on `denied_jti` escapes to an uncontrolled 500.** *Mitigation:* FR2 + AC3 mandate a
+  returned `err(403, …)`, never a throw; Test 4 asserts `.resolves`. The call sites are outside their
+  try blocks (Premise Validation), so this is load-bearing.
+- **Risk: vacuous fallback test (tenant + service client wired to the same mock).** *Mitigation:* the
+  test scaffold already separates `mockFrom` (tenant) from `mockServiceFrom` (service-role); every
+  fallback AC asserts `mockServiceFrom` called AND `mockFrom` not called (the PR #4913 deepen-plan P1
+  lesson, already encoded in the sibling block).
+- **Risk: `reportSilentFallback` skipped on the `denied_jti` early-return.** *Mitigation:* FR3 + AC4
+  require the `reportSilentFallback` call to fire *before* the per-cause branch returns, so the
+  `denied_jti` 403 path still mirrors to Sentry.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder text,
+  or omits the threshold will fail `deepen-plan` Phase 4.6. This plan's section is filled with a
+  concrete artifact (dead rename/delete button), a concrete exposure analysis (N/A — self-scoped
+  read), and the `single-user incident` threshold.
+- **The fail-closed branch must RETURN a Response, not throw** — both route handlers call this helper
+  outside their `try` blocks, so a thrown `RuntimeAuthError` becomes an uncontrolled Next.js 500
+  instead of a clean 403. (FR2/AC3.)
+- **Do not extend `.service-role-allowlist` with a new path line** — `kb-route-helpers.ts` is already
+  on it (PR #4913). The edit is comment-only; a new path line would trip CODEOWNERS path-add review
+  for no reason.
+- **Prefer the explicit-availability-causes branch shape** (`if jwt_mint||rotation → fallback; else →
+  403`) over `if denied_jti → 403; else → fallback`, so a future unknown 4th cause fails CLOSED on a
+  mutation route rather than silently falling back.
+
+## Alternative Approaches Considered
+
+| Approach | Verdict | Rationale |
+|---|---|---|
+| Extract a shared `resolveSelfRowWithMintFallback(userId, policy)` helper both entry points call | **Rejected (default)** | The policy parameter (all-causes vs deny-on-`denied_jti`) re-couples the two deliberately-divergent call sites; the shared body is only ~8 lines. Inline mirrors `resolveUserKbRoot` and keeps each helper's policy local + readable. Trivial to fold in if plan-review prefers. |
+| Apply all-causes fallback (copy PR #4913 verbatim) | **Rejected** | Defeats the `denied_jti` revocation on a *mutation* route — the exact "more aggressive than read-only share" hazard the issue flags. |
+| Fail closed on ALL three causes (no availability fallback) | **Rejected** | Leaves the `jwt_mint`/`rotation` brand-survival dead-end unfixed — the whole point of the issue. Availability failures are not authorization signals. |
+| Return 503 (current) but add a client retry | **Rejected** | Treats a deterministic ceiling-trip (`rotation`) as transient; the 60/hr ceiling won't clear in retry-seconds (`tenant.ts:169`). Server-side fallback is the correct fix, matching #4913. |
+
+---
+
+Follow-up from PR #4913 (`fix(kb): service-role fallback when tenant-mint dead-ends Generate-link
+button`). See that PR's body §"Safety ceiling (denied_jti)" and the learning at
+`knowledge-base/project/learnings/bug-fixes/2026-06-04-tenant-mint-failure-needs-self-row-service-role-fallback.md`
+§"Caveat — mutation paths differ". PR body should use `Closes #4914`.

--- a/knowledge-base/project/specs/feat-one-shot-4914-kb-tenant-mint-fallback/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-4914-kb-tenant-mint-fallback/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-04-fix-kb-file-route-tenant-mint-fallback-plan.md
+- Status: complete
+
+### Errors
+None. CWD verified equal to WORKING DIRECTORY. All four deepen-plan halt gates (4.6 User-Brand Impact, 4.7 Observability, 4.8 PAT-shaped, 4.9 UI-wireframe) passed. Task tool unavailable in nested-subagent context; precedent-diff, verify-the-negative, and post-edit self-audit passes performed directly against the codebase (all claims confirmed).
+
+### Decisions
+- Per-cause adjudication: fall back to self-row service-role read on `jwt_mint`/`rotation` (availability failures); fail closed with 403 on `denied_jti` (deliberate revocation) — helper serves file PATCH/DELETE mutation routes where the deny-list IS meant to block.
+- Branch shape pinned fail-CLOSED-on-unknown: FR1 uses positive allow-list `cause === "jwt_mint" || cause === "rotation"` so a future 4th `RuntimeAuthError.cause` fails closed on the mutation route. Verified `: never` exhaustiveness rail at `tenant.ts:131`.
+- Fail-closed must RETURN a Response, never throw: both route handlers call the helper outside their `try` blocks (`route.ts:22`/`:135`); a re-throw would escape to uncontrolled Next.js 500. Encoded as FR2/AC3/Test 4.
+- Zero infra change: `createServiceClient` already imported (`kb-route-helpers.ts:4`); file already on `.service-role-allowlist` (PR #4913). No new import, allowlist line, or migration.
+- Rejected shared-helper extraction (default to inline mirroring `resolveUserKbRoot`) to avoid re-coupling the two deliberately-divergent call sites' policies.
+
+### Components Invoked
+- skill: soleur:plan (#4914)
+- skill: soleur:deepen-plan (plan file path)
+- Bash, Read, Edit, Write, ToolSearch

--- a/knowledge-base/project/specs/feat-one-shot-4914-kb-tenant-mint-fallback/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-4914-kb-tenant-mint-fallback/tasks.md
@@ -13,74 +13,74 @@ behavioral change mirroring PR #4913's sibling pattern with a per-cause adjudica
 
 ## Phase 1 — Setup / RED (write failing tests first)
 
-- [ ] 1.1 In `apps/web-platform/test/kb-route-helpers.test.ts`, add a new
+- [x] 1.1 In `apps/web-platform/test/kb-route-helpers.test.ts`, add a new
   `describe("authenticateAndResolveKbPath — tenant-mint fallback")` block mirroring the
   `resolveUserKbRoot — tenant-mint fallback` block (`:748-870`). Use `setupServiceUserData()` in
   `beforeEach`; reuse `setupHappyPath()`, `mockGetFreshTenantClient.mockRejectedValueOnce(...)`, the
   two-arg mock `RuntimeAuthError(cause, message)`, and the distinct `mockFrom`/`mockServiceFrom`
   non-vacuity assertions.
-  - [ ] 1.1.1 Test 1 — `jwt_mint` → service-role fallback resolves `{ ok: true, ctx }` (NOT 503);
+  - [x] 1.1.1 Test 1 — `jwt_mint` → service-role fallback resolves `{ ok: true, ctx }` (NOT 503);
     `mockServiceFrom` called with `"users"`, `mockFrom` NOT called.
-  - [ ] 1.1.2 Test 2 — `rotation` → same as Test 1.
-  - [ ] 1.1.3 Test 3 — `denied_jti` → `{ ok: false, response.status === 403 }`, body
+  - [x] 1.1.2 Test 2 — `rotation` → same as Test 1.
+  - [x] 1.1.3 Test 3 — `denied_jti` → `{ ok: false, response.status === 403 }`, body
     `{ error: "Access denied" }`, `mockServiceFrom` NOT called, `mockFrom` NOT called.
-  - [ ] 1.1.4 Test 4 — `denied_jti` path RESOLVES (does not reject):
+  - [x] 1.1.4 Test 4 — `denied_jti` path RESOLVES (does not reject):
     `await expect(authenticateAndResolveKbPath(...)).resolves.toMatchObject({ ok: false })`.
-  - [ ] 1.1.5 Test 5 — parametrize `["jwt_mint","rotation","denied_jti"]`; assert exactly one
+  - [x] 1.1.5 Test 5 — parametrize `["jwt_mint","rotation","denied_jti"]`; assert exactly one
     `reportSilentFallback(mintErr, { feature: "kb-route-helpers", op:
     "authenticateAndResolveKbPath.tenant-mint", extra: { userId } })` per cause.
-  - [ ] 1.1.6 Test 6 — `jwt_mint` + `setupServiceUserData({ workspace_status: "provisioning" })` →
+  - [x] 1.1.6 Test 6 — `jwt_mint` + `setupServiceUserData({ workspace_status: "provisioning" })` →
     503 derived from the service read.
-  - [ ] 1.1.7 Test 7 — non-`RuntimeAuthError` mint failure re-thrown; `mockServiceFrom` NOT called.
-  - [ ] 1.1.8 Test 8 — happy path (mint succeeds) → tenant read, no fallback, no `reportSilentFallback`.
-- [ ] 1.2 RED-verify Tests 1, 2, 3, 4 FAIL against pre-fix code
+  - [x] 1.1.7 Test 7 — non-`RuntimeAuthError` mint failure re-thrown; `mockServiceFrom` NOT called.
+  - [x] 1.1.8 Test 8 — happy path (mint succeeds) → tenant read, no fallback, no `reportSilentFallback`.
+- [x] 1.2 RED-verify Tests 1, 2, 3, 4 FAIL against pre-fix code
   (`cd apps/web-platform && ./node_modules/.bin/vitest run test/kb-route-helpers.test.ts`). The
   current code returns 503 for all causes, so 1/2/3/4 must be red. (`cq-write-failing-tests-before`.)
 
 ## Phase 2 — Core implementation (GREEN)
 
-- [ ] 2.1 Edit `apps/web-platform/server/kb-route-helpers.ts` `authenticateAndResolveKbPath`
+- [x] 2.1 Edit `apps/web-platform/server/kb-route-helpers.ts` `authenticateAndResolveKbPath`
   mint-failure catch (`:104-113`). Inside `if (mintErr instanceof RuntimeAuthError)`:
-  - [ ] 2.1.1 Keep `reportSilentFallback(mintErr, { feature: "kb-route-helpers", op:
+  - [x] 2.1.1 Keep `reportSilentFallback(mintErr, { feature: "kb-route-helpers", op:
     "authenticateAndResolveKbPath.tenant-mint", extra: { userId: user.id } })` firing FIRST, before
     the cause branch (FR3 — fires for all causes incl. `denied_jti`).
-  - [ ] 2.1.2 Add `if (mintErr.cause === "jwt_mint" || mintErr.cause === "rotation") { tenant =
+  - [x] 2.1.2 Add `if (mintErr.cause === "jwt_mint" || mintErr.cause === "rotation") { tenant =
     createServiceClient(); }` (FR1 — positive allow-list, NOT `!== "denied_jti"`).
-  - [ ] 2.1.3 Add `else { return err(403, "Access denied"); }` (FR2 — `denied_jti` + any future
+  - [x] 2.1.3 Add `else { return err(403, "Access denied"); }` (FR2 — `denied_jti` + any future
     unknown cause fail closed; RETURN a Response, never throw).
-  - [ ] 2.1.4 Leave the outer `else { throw mintErr; }` for non-`RuntimeAuthError` unchanged (FR4).
-  - [ ] 2.1.5 Let the existing `.from("users").select(...).eq("id", user.id).single()` + the
+  - [x] 2.1.4 Leave the outer `else { throw mintErr; }` for non-`RuntimeAuthError` unchanged (FR4).
+  - [x] 2.1.5 Let the existing `.from("users").select(...).eq("id", user.id).single()` + the
     `workspace_status === "ready"` / installation-id / repo validation run unchanged against the
     (possibly service-role) `tenant`.
-- [ ] 2.2 Rewrite the NOTE comment at `:94-99` (FR5): name the new ceiling per
+- [x] 2.2 Rewrite the NOTE comment at `:94-99` (FR5): name the new ceiling per
   `knowledge-base/project/learnings/2026-05-05-defense-relaxation-must-name-new-ceiling.md` —
   `jwt_mint`/`rotation` fall back to a self-row service-role read (availability failures, same
   `.eq("id", user.id)` ceiling as `resolveUserKbRoot`); `denied_jti` (and any unknown cause) fail
   closed with 403 because the deny-list IS meant to block the *mutation* here. Mirror the prose style
   of `resolveUserKbRoot`'s ceiling comment (`:251-263`).
-- [ ] 2.3 Run vitest GREEN:
+- [x] 2.3 Run vitest GREEN:
   `cd apps/web-platform && ./node_modules/.bin/vitest run test/kb-route-helpers.test.ts` — all 8 new
   tests + the pre-existing `authenticateAndResolveKbPath` block green.
 
 ## Phase 3 — Allowlist rationale + typecheck
 
-- [ ] 3.1 Edit `apps/web-platform/.service-role-allowlist` "#4913" rationale block (FR6): add a
+- [x] 3.1 Edit `apps/web-platform/.service-role-allowlist` "#4913" rationale block (FR6): add a
   sentence noting `authenticateAndResolveKbPath` now ALSO uses the service-role client as an
   availability-only fallback (`jwt_mint`/`rotation`) per #4914, and that `denied_jti` fails closed.
   Do NOT add a new path line — the file is already allowlisted (count stays exactly 1).
-- [ ] 3.2 Typecheck: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (AC10).
-- [ ] 3.3 Confirm `service-role-allowlist-gate` CI job stays green — no new disallowed service-role
+- [x] 3.2 Typecheck: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (AC10).
+- [x] 3.3 Confirm `service-role-allowlist-gate` CI job stays green — no new disallowed service-role
   importer (AC9; no new `createServiceClient` *file* added — already imported in this file).
 
 ## Phase 4 — Acceptance verification
 
-- [ ] 4.1 AC1–AC6: the 8 vitest tests green and the new-behavior cases (1,2,3,4) were RED pre-fix.
-- [ ] 4.2 AC7: `grep -n "denied_jti" apps/web-platform/server/kb-route-helpers.ts` returns a match
+- [x] 4.1 AC1–AC6: the 8 vitest tests green and the new-behavior cases (1,2,3,4) were RED pre-fix.
+- [x] 4.2 AC7: `grep -n "denied_jti" apps/web-platform/server/kb-route-helpers.ts` returns a match
   inside the `authenticateAndResolveKbPath` comment block + the NOTE no longer says "intentionally
   503s … tracked in #4914".
-- [ ] 4.3 AC8: `grep -c "apps/web-platform/server/kb-route-helpers.ts"
+- [x] 4.3 AC8: `grep -c "apps/web-platform/server/kb-route-helpers.ts"
   apps/web-platform/.service-role-allowlist` returns exactly `1` (unchanged).
-- [ ] 4.4 AC10: `tsc --noEmit` clean + full `kb-route-helpers.test.ts` green.
+- [x] 4.4 AC10: `tsc --noEmit` clean + full `kb-route-helpers.test.ts` green.
 
 ## Notes
 

--- a/knowledge-base/project/specs/feat-one-shot-4914-kb-tenant-mint-fallback/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-4914-kb-tenant-mint-fallback/tasks.md
@@ -1,0 +1,94 @@
+---
+title: "Tasks — per-cause tenant-mint fallback for authenticateAndResolveKbPath (#4914)"
+plan: knowledge-base/project/plans/2026-06-04-fix-kb-file-route-tenant-mint-fallback-plan.md
+issue: 4914
+branch: feat-one-shot-4914-kb-tenant-mint-fallback
+lane: single-domain
+---
+
+# Tasks — fix(kb): per-cause tenant-mint fallback for `authenticateAndResolveKbPath`
+
+Derived from `2026-06-04-fix-kb-file-route-tenant-mint-fallback-plan.md` (post-deepen). Single-file
+behavioral change mirroring PR #4913's sibling pattern with a per-cause adjudication.
+
+## Phase 1 — Setup / RED (write failing tests first)
+
+- [ ] 1.1 In `apps/web-platform/test/kb-route-helpers.test.ts`, add a new
+  `describe("authenticateAndResolveKbPath — tenant-mint fallback")` block mirroring the
+  `resolveUserKbRoot — tenant-mint fallback` block (`:748-870`). Use `setupServiceUserData()` in
+  `beforeEach`; reuse `setupHappyPath()`, `mockGetFreshTenantClient.mockRejectedValueOnce(...)`, the
+  two-arg mock `RuntimeAuthError(cause, message)`, and the distinct `mockFrom`/`mockServiceFrom`
+  non-vacuity assertions.
+  - [ ] 1.1.1 Test 1 — `jwt_mint` → service-role fallback resolves `{ ok: true, ctx }` (NOT 503);
+    `mockServiceFrom` called with `"users"`, `mockFrom` NOT called.
+  - [ ] 1.1.2 Test 2 — `rotation` → same as Test 1.
+  - [ ] 1.1.3 Test 3 — `denied_jti` → `{ ok: false, response.status === 403 }`, body
+    `{ error: "Access denied" }`, `mockServiceFrom` NOT called, `mockFrom` NOT called.
+  - [ ] 1.1.4 Test 4 — `denied_jti` path RESOLVES (does not reject):
+    `await expect(authenticateAndResolveKbPath(...)).resolves.toMatchObject({ ok: false })`.
+  - [ ] 1.1.5 Test 5 — parametrize `["jwt_mint","rotation","denied_jti"]`; assert exactly one
+    `reportSilentFallback(mintErr, { feature: "kb-route-helpers", op:
+    "authenticateAndResolveKbPath.tenant-mint", extra: { userId } })` per cause.
+  - [ ] 1.1.6 Test 6 — `jwt_mint` + `setupServiceUserData({ workspace_status: "provisioning" })` →
+    503 derived from the service read.
+  - [ ] 1.1.7 Test 7 — non-`RuntimeAuthError` mint failure re-thrown; `mockServiceFrom` NOT called.
+  - [ ] 1.1.8 Test 8 — happy path (mint succeeds) → tenant read, no fallback, no `reportSilentFallback`.
+- [ ] 1.2 RED-verify Tests 1, 2, 3, 4 FAIL against pre-fix code
+  (`cd apps/web-platform && ./node_modules/.bin/vitest run test/kb-route-helpers.test.ts`). The
+  current code returns 503 for all causes, so 1/2/3/4 must be red. (`cq-write-failing-tests-before`.)
+
+## Phase 2 — Core implementation (GREEN)
+
+- [ ] 2.1 Edit `apps/web-platform/server/kb-route-helpers.ts` `authenticateAndResolveKbPath`
+  mint-failure catch (`:104-113`). Inside `if (mintErr instanceof RuntimeAuthError)`:
+  - [ ] 2.1.1 Keep `reportSilentFallback(mintErr, { feature: "kb-route-helpers", op:
+    "authenticateAndResolveKbPath.tenant-mint", extra: { userId: user.id } })` firing FIRST, before
+    the cause branch (FR3 — fires for all causes incl. `denied_jti`).
+  - [ ] 2.1.2 Add `if (mintErr.cause === "jwt_mint" || mintErr.cause === "rotation") { tenant =
+    createServiceClient(); }` (FR1 — positive allow-list, NOT `!== "denied_jti"`).
+  - [ ] 2.1.3 Add `else { return err(403, "Access denied"); }` (FR2 — `denied_jti` + any future
+    unknown cause fail closed; RETURN a Response, never throw).
+  - [ ] 2.1.4 Leave the outer `else { throw mintErr; }` for non-`RuntimeAuthError` unchanged (FR4).
+  - [ ] 2.1.5 Let the existing `.from("users").select(...).eq("id", user.id).single()` + the
+    `workspace_status === "ready"` / installation-id / repo validation run unchanged against the
+    (possibly service-role) `tenant`.
+- [ ] 2.2 Rewrite the NOTE comment at `:94-99` (FR5): name the new ceiling per
+  `knowledge-base/project/learnings/2026-05-05-defense-relaxation-must-name-new-ceiling.md` —
+  `jwt_mint`/`rotation` fall back to a self-row service-role read (availability failures, same
+  `.eq("id", user.id)` ceiling as `resolveUserKbRoot`); `denied_jti` (and any unknown cause) fail
+  closed with 403 because the deny-list IS meant to block the *mutation* here. Mirror the prose style
+  of `resolveUserKbRoot`'s ceiling comment (`:251-263`).
+- [ ] 2.3 Run vitest GREEN:
+  `cd apps/web-platform && ./node_modules/.bin/vitest run test/kb-route-helpers.test.ts` — all 8 new
+  tests + the pre-existing `authenticateAndResolveKbPath` block green.
+
+## Phase 3 — Allowlist rationale + typecheck
+
+- [ ] 3.1 Edit `apps/web-platform/.service-role-allowlist` "#4913" rationale block (FR6): add a
+  sentence noting `authenticateAndResolveKbPath` now ALSO uses the service-role client as an
+  availability-only fallback (`jwt_mint`/`rotation`) per #4914, and that `denied_jti` fails closed.
+  Do NOT add a new path line — the file is already allowlisted (count stays exactly 1).
+- [ ] 3.2 Typecheck: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (AC10).
+- [ ] 3.3 Confirm `service-role-allowlist-gate` CI job stays green — no new disallowed service-role
+  importer (AC9; no new `createServiceClient` *file* added — already imported in this file).
+
+## Phase 4 — Acceptance verification
+
+- [ ] 4.1 AC1–AC6: the 8 vitest tests green and the new-behavior cases (1,2,3,4) were RED pre-fix.
+- [ ] 4.2 AC7: `grep -n "denied_jti" apps/web-platform/server/kb-route-helpers.ts` returns a match
+  inside the `authenticateAndResolveKbPath` comment block + the NOTE no longer says "intentionally
+  503s … tracked in #4914".
+- [ ] 4.3 AC8: `grep -c "apps/web-platform/server/kb-route-helpers.ts"
+  apps/web-platform/.service-role-allowlist` returns exactly `1` (unchanged).
+- [ ] 4.4 AC10: `tsc --noEmit` clean + full `kb-route-helpers.test.ts` green.
+
+## Notes
+
+- Runner: vitest only (`apps/web-platform/bunfig.toml` blocks bun test). Always
+  `cd apps/web-platform && ./node_modules/.bin/vitest …`. Test path `test/kb-route-helpers.test.ts`
+  matches the node project `test/**/*.test.ts` include glob (`vitest.config.ts:44`).
+- No migration, no infra, no UI surface, no post-merge operator step. Deploys via
+  `web-platform-release.yml` on merge.
+- PR body: use `Closes #4914`.
+- Learning capture at ship time via `/soleur:compound` into
+  `knowledge-base/project/learnings/bug-fixes/` — do NOT pre-create a dated filename.


### PR DESCRIPTION
## Summary

Fix `authenticateAndResolveKbPath` (the KB file PATCH/DELETE **mutation** helper) returning **503 "Workspace not ready"** on any tenant-JWT mint failure — dead-ending a founder's KB file rename/delete during a transient mint blip (`jwt_mint`) or a 60/hr ceiling trip (`rotation`). This is the mutation-route sibling that PR #4913 deliberately scoped **out** as a Non-Goal.

Applies a **per-cause** fallback on `RuntimeAuthError.cause`:

- `jwt_mint` | `rotation` (availability failures) → fall back to a service-role read of the caller's **own** row (`.eq("id", user.id)`, server-derived) and let the mutation proceed.
- `denied_jti` (deliberate revocation) + any future un-named cause → **fail CLOSED** with `err(403, "Access denied")`.

The branch uses the **positive allow-list** of availability causes, so an unknown 4th `RuntimeAuthError.cause` fails closed (the safe default on a mutation route). The fail-closed arm **RETURNS** a Response — never throws — because both route handlers call this helper **outside** their `try` block (a throw would escape to an uncontrolled Next.js 500). `reportSilentFallback` fires for **every** cause (incl. `denied_jti`) so revocation hits and chronic mint failures both stay Sentry-visible.

No new import or `.service-role-allowlist` path line — `kb-route-helpers.ts` was already allowlisted by #4913 and already imports `createServiceClient`; the allowlist edit is a comment-only rationale update.

Closes #4914

## User-Brand Impact

- **Artifact:** a founder's KB file rename (PATCH) / delete (DELETE) operation; under fallback, only their own `users` row (`workspace_path` / `repo_url` / `github_installation_id`).
- **Vector:** the prior code 503'd on any transient tenant-JWT mint blip or ceiling trip, silently dead-ending the file operation even though the workspace is ready. The availability fallback reads only the caller's OWN row (`.eq("id", user.id)`, server-derived — never request-controlled), so it cannot expose another tenant's data. The `denied_jti` path **tightens** behavior (a clean 403 instead of a silent 503) and never falls back to service-role on revocation.
- **Brand-survival threshold:** single-user incident

## Changelog

### Web Platform

- KB file routes (`PATCH/DELETE /api/kb/file/[...path]`) now recover from transient tenant-JWT mint failures via a self-row service-role fallback instead of returning 503.
- A revoked session (`denied_jti`) on a KB file mutation now receives a clean 403 instead of a silent 503 — the deny-list is honored on the mutation path.

## Test plan

- [x] `vitest run test/kb-route-helpers.test.ts` — 43/43 green; 10 new tests in the `authenticateAndResolveKbPath — tenant-mint fallback (#4914)` block (4 RED-verified against pre-fix all-causes-503 code).
- [x] `tsc --noEmit` clean in `apps/web-platform`.
- [x] `.service-role-allowlist` path-line count unchanged (exactly 1).
- [x] Full `apps/web-platform` vitest shard green (8495 passed).
- [x] Multi-agent review (security-sentinel, user-impact-reviewer, data-integrity-guardian, architecture-strategist, code-quality-analyst, test-design-reviewer) — all SOUND; 2 P3 nits fixed inline.

Generated with [Claude Code](https://claude.com/claude-code)
