### PR TITLE
feat(observability): alert on KB tenant-mint reportSilentFallback rate (PIR #4913 follow-up)

### DIFF
--- a/.github/workflows/apply-sentry-infra.yml
+++ b/.github/workflows/apply-sentry-infra.yml
@@ -215,6 +215,7 @@ jobs:
             -target=sentry_issue_alert.byok_cap_exceeded \
             -target=sentry_issue_alert.chat_message_save_failure \
             -target=sentry_issue_alert.workspace_sync_health \
+            -target=sentry_issue_alert.kb_tenant_mint_silent_fallback \
             -no-color -input=false -out=tfplan
           rc=$?
           if [[ $rc -ne 0 ]]; then

--- a/apps/web-platform/infra/sentry/issue-alerts.tf
+++ b/apps/web-platform/infra/sentry/issue-alerts.tf
@@ -457,3 +457,84 @@ resource "sentry_issue_alert" "workspace_sync_health" {
     ignore_changes = [environment]
   }
 }
+
+# ── KB tenant-mint silent-fallback alert (#4918) — APPLY-CREATED, NOT import ──
+# Pages on the first occurrence of any KB tenant-JWT mint failure. PIR #4913
+# (generate-link-tenant-mint-regression-postmortem.md) found the durability gap
+# the #4913 service-role fallback did NOT close: the mint failure emitted a
+# `reportSilentFallback` Sentry signal on EVERY tenant-mint dead-end, yet no
+# alert routed it to attention, so it sat latent ~19 days until the founder hit
+# the dead Generate-link button while dogfooding. This rule is the missing
+# NOTIFICATION layer (hr-no-dashboard-eyeball-pull-data-yourself) — the signal
+# already exists (RuntimeAuthError → captureException with feature/op tags); no
+# app change needed.
+#
+# op-SCOPED filter (op IS_IN, NOT feature-only): unlike workspace_sync_health
+# (whose feature tag is dedicated to one cron), `feature=kb-route-helpers` spans
+# 6 ops — the 3 tenant-mint slugs PLUS workspace-sync-*, self-heal-*, and
+# kb-sync.unexpected. A feature-only filter would over-page on those unrelated
+# self-heal/workspace-sync events. So this mirrors chat_message_save_failure's
+# op-scoped shape. The THIRD slug `kb-sync.tenant-mint` (sync/route.ts:62) is
+# the identical RuntimeAuthError→503 mint-failure class the issue body omitted;
+# at brand-survival threshold `single-user incident`, scoping out the next-most-
+# likely sibling is anti-pattern, so it is folded into the IS_IN value.
+#
+# `action_match="any"`: first_seen/reappeared/regression are mutually-exclusive
+# event-lifecycle states (a captured event is exactly one) — "all" is never
+# satisfiable. reappeared+regression re-page a recurrence after the founder
+# resolves the Sentry issue — the issue-alert equivalent of the issue text's
+# `failure_issue_threshold = 1` (which is a cron/uptime-monitor attribute, NOT
+# valid on sentry_issue_alert). Distinct `frequency=12` avoids Sentry POST-time
+# exact-duplicate dedup (taken: 5,10,11,15,30,60,61,62; keyed on action-shape +
+# frequency + match, NOT conditions — not evaluated by lifecycle-condition rules
+# but must be unique). `IS_IN` proven in beta2 at byok_cap_exceeded above.
+# Cross-artifact op/feature contract pinned by
+# test/sentry-kb-tenant-mint-alert-op-contract.test.ts.
+resource "sentry_issue_alert" "kb_tenant_mint_silent_fallback" {
+  organization = var.sentry_org
+  project      = data.sentry_project.web_platform.slug
+  name         = "kb-tenant-mint-silent-fallback"
+  action_match = "any"
+  filter_match = "all"
+  frequency    = 12
+
+  conditions_v2 = [
+    { first_seen_event = {} },
+    { reappeared_event = {} },
+    { regression_event = {} },
+  ]
+  filters_v2 = [
+    {
+      tagged_event = {
+        key   = "feature"
+        match = "EQUAL"
+        value = "kb-route-helpers"
+      }
+    },
+    {
+      tagged_event = {
+        key   = "op"
+        match = "IS_IN"
+        value = "resolveUserKbRoot.tenant-mint,authenticateAndResolveKbPath.tenant-mint,kb-sync.tenant-mint"
+      }
+    },
+  ]
+  # N=1 accepted risk (mirrors chat_message_save_failure:378-383): IssueOwners
+  # has no ownership rule on this project → falls through to ActiveMembers,
+  # correctly paging the solo founder. These events carry NO cross-tenant
+  # content (only hashed userId + op + pg_code tags) so the fallthrough does not
+  # over-disclose. Revisit recipient pinning (target_type="Member") before the
+  # first non-founder Sentry seat.
+  actions_v2 = [
+    {
+      notify_email = {
+        target_type      = "IssueOwners"
+        fallthrough_type = "ActiveMembers"
+      }
+    },
+  ]
+
+  lifecycle {
+    ignore_changes = [environment]
+  }
+}

--- a/apps/web-platform/infra/sentry/issue-alerts.tf
+++ b/apps/web-platform/infra/sentry/issue-alerts.tf
@@ -471,9 +471,10 @@ resource "sentry_issue_alert" "workspace_sync_health" {
 #
 # op-SCOPED filter (op IS_IN, NOT feature-only): unlike workspace_sync_health
 # (whose feature tag is dedicated to one cron), `feature=kb-route-helpers` spans
-# 6 ops — the 3 tenant-mint slugs PLUS workspace-sync-*, self-heal-*, and
-# kb-sync.unexpected. A feature-only filter would over-page on those unrelated
-# self-heal/workspace-sync events. So this mirrors chat_message_save_failure's
+# several ops beyond tenant-mint — the 3 tenant-mint slugs PLUS workspace-sync-*,
+# 3x self-heal-*, and kb-sync.unexpected. A feature-only filter would over-page
+# on those unrelated self-heal/workspace-sync events. So this mirrors
+# chat_message_save_failure's
 # op-scoped shape. The THIRD slug `kb-sync.tenant-mint` (sync/route.ts:62) is
 # the identical RuntimeAuthError→503 mint-failure class the issue body omitted;
 # at brand-survival threshold `single-user incident`, scoping out the next-most-

--- a/apps/web-platform/test/sentry-kb-tenant-mint-alert-op-contract.test.ts
+++ b/apps/web-platform/test/sentry-kb-tenant-mint-alert-op-contract.test.ts
@@ -20,6 +20,22 @@ import { describe, it, expect } from "vitest";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const tf = readFileSync(join(here, "../infra/sentry/issue-alerts.tf"), "utf8");
+
+// Scope the filter-side assertions to the kb_tenant_mint_silent_fallback
+// resource BLOCK, not the whole file. A whole-file `toContain` would pass
+// vacuously if a slug were deleted from THIS rule's IS_IN value while still
+// lingering elsewhere in issue-alerts.tf (e.g. a comment or a sibling rule) —
+// the removal would silently zero THIS alert's matches while the test stayed
+// green. Slicing from the resource marker to the next `resource ` (or EOF)
+// pins the assertion to this rule alone.
+const RESOURCE_DECL =
+  'resource "sentry_issue_alert" "kb_tenant_mint_silent_fallback"';
+const blockStart = tf.indexOf(RESOURCE_DECL);
+const nextResource = tf.indexOf("\nresource ", blockStart + RESOURCE_DECL.length);
+const tfBlock =
+  blockStart === -1
+    ? ""
+    : tf.slice(blockStart, nextResource === -1 ? undefined : nextResource);
 const kbRouteHelpers = readFileSync(
   join(here, "../server/kb-route-helpers.ts"),
   "utf8",
@@ -53,30 +69,33 @@ const OP_SLUGS: ReadonlyArray<{ slug: string; emit: string; emitName: string }> 
 
 describe("kb-tenant-mint-silent-fallback alert op/feature contract", () => {
   it("declares the kb_tenant_mint_silent_fallback issue alert resource", () => {
-    expect(tf).toContain(
-      'resource "sentry_issue_alert" "kb_tenant_mint_silent_fallback"',
-    );
+    expect(blockStart).toBeGreaterThanOrEqual(0);
+    expect(tfBlock).toContain(RESOURCE_DECL);
   });
 
   it("the feature tag appears in both the emit sites and the alert filter", () => {
     expect(kbRouteHelpers).toContain(FEATURE_TAG);
     expect(kbSyncRoute).toContain(FEATURE_TAG);
-    expect(tf).toContain(FEATURE_TAG);
+    // Filter side scoped to THIS rule's block, not the whole file.
+    expect(tfBlock).toContain(FEATURE_TAG);
   });
 
   for (const { slug, emit, emitName } of OP_SLUGS) {
-    it(`op slug "${slug}" appears in both ${emitName} and issue-alerts.tf`, () => {
+    it(`op slug "${slug}" appears in both ${emitName} and the alert's filter block`, () => {
       // Emit side: the literal exists in its emit file.
       expect(emit).toContain(slug);
-      // Filter side: the same literal must be in the alert's op IS_IN value.
-      expect(tf).toContain(slug);
+      // Filter side: the same literal must be in THIS alert's block (not a
+      // comment or sibling rule elsewhere in issue-alerts.tf).
+      expect(tfBlock).toContain(slug);
     });
   }
 
-  it("issue-alerts.tf binds the three slugs into one IS_IN filter value", () => {
-    // Guard against the slugs appearing in unrelated rules: the IS_IN value is
-    // a single comma-joined string containing all three, in declaration order.
+  it("the alert block binds the three slugs into one IS_IN filter value", () => {
+    // The IS_IN value is a single comma-joined string containing all three, in
+    // declaration order. Asserting against tfBlock (not the whole file) means
+    // removing or reordering any slug in THIS rule fails CI even if the slug
+    // survives elsewhere in the file.
     const isInValue = OP_SLUGS.map((o) => o.slug).join(",");
-    expect(tf).toContain(isInValue);
+    expect(tfBlock).toContain(isInValue);
   });
 });

--- a/apps/web-platform/test/sentry-kb-tenant-mint-alert-op-contract.test.ts
+++ b/apps/web-platform/test/sentry-kb-tenant-mint-alert-op-contract.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+// Cross-artifact contract test (#4918, PIR #4913 follow-up).
+//
+// The `kb-tenant-mint-silent-fallback` Sentry issue-alert filters on
+// `feature == "kb-route-helpers"` AND `op IS_IN` the three tenant-mint
+// failure slugs. Because the alert uses `filter_match = "all"`, a rename of
+// the `feature` tag OR any op slug on EITHER side (the emit sites in
+// kb-route-helpers.ts / kb/sync/route.ts, or the filter value in
+// issue-alerts.tf) would silently zero the alert's matches — recreating the
+// ~19-day-silent regression class one rename later. This test pins both
+// filter dimensions against that drift.
+//
+// Substring match only (code-simplicity, mirrors sentry-chat-alert-op-contract):
+// each slug is an inline string literal at its emit site; a whole-file match
+// finds it. No TS const/AST resolution required.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const tf = readFileSync(join(here, "../infra/sentry/issue-alerts.tf"), "utf8");
+const kbRouteHelpers = readFileSync(
+  join(here, "../server/kb-route-helpers.ts"),
+  "utf8",
+);
+const kbSyncRoute = readFileSync(
+  join(here, "../app/api/kb/sync/route.ts"),
+  "utf8",
+);
+
+const FEATURE_TAG = "kb-route-helpers";
+
+// Each op slug paired with the emit file that must contain it.
+const OP_SLUGS: ReadonlyArray<{ slug: string; emit: string; emitName: string }> =
+  [
+    {
+      slug: "resolveUserKbRoot.tenant-mint",
+      emit: kbRouteHelpers,
+      emitName: "kb-route-helpers.ts",
+    },
+    {
+      slug: "authenticateAndResolveKbPath.tenant-mint",
+      emit: kbRouteHelpers,
+      emitName: "kb-route-helpers.ts",
+    },
+    {
+      slug: "kb-sync.tenant-mint",
+      emit: kbSyncRoute,
+      emitName: "app/api/kb/sync/route.ts",
+    },
+  ];
+
+describe("kb-tenant-mint-silent-fallback alert op/feature contract", () => {
+  it("declares the kb_tenant_mint_silent_fallback issue alert resource", () => {
+    expect(tf).toContain(
+      'resource "sentry_issue_alert" "kb_tenant_mint_silent_fallback"',
+    );
+  });
+
+  it("the feature tag appears in both the emit sites and the alert filter", () => {
+    expect(kbRouteHelpers).toContain(FEATURE_TAG);
+    expect(kbSyncRoute).toContain(FEATURE_TAG);
+    expect(tf).toContain(FEATURE_TAG);
+  });
+
+  for (const { slug, emit, emitName } of OP_SLUGS) {
+    it(`op slug "${slug}" appears in both ${emitName} and issue-alerts.tf`, () => {
+      // Emit side: the literal exists in its emit file.
+      expect(emit).toContain(slug);
+      // Filter side: the same literal must be in the alert's op IS_IN value.
+      expect(tf).toContain(slug);
+    });
+  }
+
+  it("issue-alerts.tf binds the three slugs into one IS_IN filter value", () => {
+    // Guard against the slugs appearing in unrelated rules: the IS_IN value is
+    // a single comma-joined string containing all three, in declaration order.
+    const isInValue = OP_SLUGS.map((o) => o.slug).join(",");
+    expect(tf).toContain(isInValue);
+  });
+});

--- a/knowledge-base/engineering/operations/post-mortems/generate-link-tenant-mint-regression-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/generate-link-tenant-mint-regression-postmortem.md
@@ -135,10 +135,10 @@ One founder-reported bug; ~one session to root-cause + fix.
 ## Follow-ups
 
 - [ ] Apply the same mint-failure resilience to `authenticateAndResolveKbPath` (file PATCH/DELETE routes), with a per-cause `denied_jti` adjudication — tracked in #4914.
-- [ ] Wire an alert on the `resolveUserKbRoot.tenant-mint` / `authenticateAndResolveKbPath.tenant-mint` `reportSilentFallback` rate so a recurring mint failure pages instead of sitting latent.
+- [x] Wire an alert on the `resolveUserKbRoot.tenant-mint` / `authenticateAndResolveKbPath.tenant-mint` `reportSilentFallback` rate so a recurring mint failure pages instead of sitting latent. — `sentry_issue_alert.kb_tenant_mint_silent_fallback` (#4918); op-scoped IS_IN over the 3 tenant-mint slugs (incl. the `kb-sync.tenant-mint` sibling).
 - [ ] Consider surfacing a user-facing error toast on a genuine share 503 (client `share-popover.tsx`) so a real not-ready state is not an invisible idle bounce.
 
 ## Action Items
 
 - #4914 — file-route tenant-mint fallback (already filed; `type/chore` + `deferred-scope-out`).
-- Alert on tenant-mint `reportSilentFallback` rate — to file as a `type/chore` observability item (no existing alert covers the share/upload mint-failure rate).
+- #4918 — alert on tenant-mint `reportSilentFallback` rate (landed): `sentry_issue_alert.kb_tenant_mint_silent_fallback` pages on the first occurrence of any KB tenant-mint failure across the 3 mint-failure ops.

--- a/knowledge-base/project/learnings/best-practices/2026-06-04-cross-artifact-contract-test-scope-filter-assertions-to-the-resource-block.md
+++ b/knowledge-base/project/learnings/best-practices/2026-06-04-cross-artifact-contract-test-scope-filter-assertions-to-the-resource-block.md
@@ -1,0 +1,75 @@
+---
+title: "Cross-artifact contract test: scope filter-side assertions to the resource block, not the whole file"
+date: 2026-06-04
+category: best-practices
+tags: [testing, contract-test, sentry, terraform, observability, vacuous-assertion]
+pr: 4920
+issue: 4918
+---
+
+# Learning: cross-artifact contract test must scope filter-side assertions to the resource block
+
+## Problem
+
+A cross-artifact contract test (`sentry-kb-tenant-mint-alert-op-contract.test.ts`,
+mirroring `sentry-chat-alert-op-contract.test.ts`) pins op slugs + a feature tag
+in BOTH the emit sites (`*.ts`) AND the Sentry alert's Terraform filter
+(`issue-alerts.tf`), so a rename on either side breaks CI instead of silently
+zeroing the alert's `filter_match = "all"` matches.
+
+The first cut asserted the filter side with whole-file `toContain`:
+`expect(tf).toContain(slug)`. That is **vacuous-prone**: the new alert resource's
+own leading doc comment mentions one of the slugs literally
+(`# ... kb-sync.tenant-mint (sync/route.ts:62) is the identical RuntimeAuthError ...`).
+So the per-slug assertion for that slug would pass even if the slug were deleted
+from the rule's `IS_IN` value — the comment alone satisfies `toContain`.
+`user-impact-reviewer` flagged this as the gate failing open on the removal case.
+
+## Solution
+
+Slice the asserted file down to the **specific resource block** before asserting:
+
+```ts
+const RESOURCE_DECL = 'resource "sentry_issue_alert" "kb_tenant_mint_silent_fallback"';
+const blockStart = tf.indexOf(RESOURCE_DECL);
+const nextResource = tf.indexOf("\nresource ", blockStart + RESOURCE_DECL.length);
+const tfBlock = blockStart === -1 ? "" : tf.slice(blockStart, nextResource === -1 ? undefined : nextResource);
+// then assert against tfBlock, not tf
+```
+
+Two assertions carry the contract:
+1. **Per-slug** `expect(tfBlock).toContain(slug)` + `expect(emitFile).toContain(slug)` — proves the slug is present on both sides.
+2. **Composite** `expect(tfBlock).toContain(slugs.join(","))` — the comma-joined `IS_IN` value is the LOAD-BEARING removal guard: removing/reordering ANY slug breaks the contiguous substring → RED. This composite string exists ONLY at the filter value, never in prose.
+
+## Key Insight
+
+For a contract test that asserts a literal appears in a config file, the literal
+frequently ALSO appears in that block's own explanatory comment. Whole-file (or
+even whole-block) per-literal `toContain` is therefore weakly non-vacuous — the
+real guarantee comes from a **composite assertion** (the exact comma-joined
+multi-value string) that only the live config line can satisfy. Scope per-literal
+assertions to the resource block to shrink the comment-collision surface, and lean
+on the composite string for the removal/reorder guarantee.
+
+Validation method that settled it: `data-integrity-guardian` empirically mutated
+the slug in ONLY the `IS_IN` value (leaving the comment intact) and confirmed the
+composite assertion went RED — proving the suite catches removals even before the
+block-scoping hardening. The hardening reduces the surface further for the
+per-slug checks.
+
+## Review cross-reconcile note
+
+`user-impact-reviewer` (single agent, reasoned-only) rated the whole-file
+weakness HIGH; `data-integrity-guardian` (orthogonal, empirical mutation proof)
+falsified the stated harm ("removal stays green") because the composite assertion
+already caught it. Per the `multi-agent-review-cross-reconcile` sharp edge, the
+HIGH was downgraded from a blocker — but the cheap, pr-introduced hardening it
+pointed at was still applied inline (block-scoping). Falsified-severity does not
+mean "do nothing" when the underlying nudge is a ≤30-line robustness win.
+
+## Session Errors
+
+1. **Multi-match `Edit` on `issue-alerts.tf`** — anchoring on `lifecycle { ignore_changes = [environment] }` matched all 4 alert-resource tails. **Recovery:** re-anchored on the unique `workspace_sync_health` feature-only filter tail. **Prevention:** when appending after the LAST of N structurally-identical blocks, anchor on a token unique to that specific block (here, the only feature-only `filters_v2` with no `op` sub-block), not on the shared closing shape.
+2. **`Edit` before `Read` on `apply-sentry-infra.yml`** — tool rejected with "File has not been read yet" (`hr-always-read-a-file-before-editing-it`). **Recovery:** read the target lines, re-applied. **Prevention:** already tool-enforced; no workflow change needed — the harness blocks it deterministically.
+
+Both one-off; no recurrence vector warranting a hook or rule change.

--- a/knowledge-base/project/plans/2026-06-04-feat-kb-tenant-mint-silent-fallback-alert-plan.md
+++ b/knowledge-base/project/plans/2026-06-04-feat-kb-tenant-mint-silent-fallback-alert-plan.md
@@ -1,0 +1,215 @@
+---
+title: "observability: alert on KB tenant-mint reportSilentFallback rate (PIR #4913 follow-up)"
+issue: 4918
+type: chore
+classification: observability
+lane: single-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+source_pir: knowledge-base/engineering/operations/post-mortems/generate-link-tenant-mint-regression-postmortem.md
+date: 2026-06-04
+---
+
+# ✨ observability: alert on KB tenant-mint `reportSilentFallback` rate (#4918)
+
+## Enhancement Summary
+
+**Deepened on:** 2026-06-04
+**Sections enhanced:** Research Reconciliation, Observability, IaC, Risks (deepen-pass verification folded in below).
+
+### Key Improvements (deepen-pass verifications — all live, against repo state)
+1. **Premise reframe confirmed (R1).** `failure_issue_threshold` exists only on `sentry_cron_monitor`/`sentry_uptime_monitor` (`cron-monitors.tf`), NOT on `sentry_issue_alert` — verified via `grep`. Issue-alert first-occurrence paging = `conditions_v2` triad + `action_match="any"`, the proven `chat_message_save_failure`/`workspace_sync_health` shape.
+2. **Op enumeration confirmed (R3).** Verify-the-negative pass: the ONLY `reportSilentFallback`/`warnSilentFallback`/`infoSilentFallback` emits carrying `feature: "kb-route-helpers"` are the 6 ops named in R3 (3 tenant-mint + `workspace-sync-*` + 3 `self-heal-*` + `kb-sync.unexpected`). `op: "delete"` (kb-route-helpers.ts:430) is a TS type-union literal, NOT an emit; `op: "manual"` (sync/route.ts:117) is an unrelated structured-log call — neither is a tenant-mint emit. The feature-only vs op-scoped decision stands: **op IS_IN is mandatory.**
+3. **Third sibling op confirmed (R2).** `kb-sync.tenant-mint` (sync/route.ts:60) is the identical `RuntimeAuthError → 503` class — folded into the IS_IN filter.
+4. **Apply-workflow shape confirmed.** `apply-sentry-infra.yml` produces `-out=tfplan` (plan step, targets at lines 186-217) and the apply step runs `terraform apply tfplan` (line 268) — it reuses the saved plan and does NOT re-list targets. So a single `-target=` add in the plan block is sufficient (one edit, not two). This matches the saved-plan AC-grep expectation: `-target=` appears in the plan step only.
+5. **Frequency 12 free (R6), payload PII-safe.** Taken set `5,10,11,15,30,60,61,62`; `12` free. `observability.ts:200` pseudonymizes `userId → userIdHash` (Recital 26) at the emit boundary; events carry only hashed id + op + pg_code — no raw userId, no content, so the IssueOwners→ActiveMembers fallthrough is safe at N=1.
+
+### Precedent-Diff (Phase 4.4)
+The alert is a pattern-bound resource with an exact in-repo precedent — `sentry_issue_alert.chat_message_save_failure` (issue-alerts.tf:349-396): same `action_match="any"`, `filter_match="all"`, `conditions_v2` triad, `tagged_event` feature EQUAL + op IS_IN, `actions_v2` IssueOwners→ActiveMembers, `lifecycle.ignore_changes=[environment]`. This plan mirrors it byte-for-byte, differing only in `name`, `frequency` (12), feature value (`kb-route-helpers`), and the 3 op slugs. **Not novel — strong precedent.** No new scheduled job (no Inngest/cron precedent check needed).
+
+## Overview
+
+PR #4913 fixed the KB Generate-link regression by adding a service-role fallback when the tenant-JWT mint fails — but the PIR ([generate-link-tenant-mint-regression-postmortem.md](../../engineering/operations/post-mortems/generate-link-tenant-mint-regression-postmortem.md)) names the *root durability gap*: the failure emitted a `reportSilentFallback` Sentry signal on every mint failure, yet **no alert routed it to attention**, so a Sentry-visible signal sat latent for ~19 days until the founder hit the dead button while dogfooding.
+
+This plan wires a single **Sentry issue alert** (`sentry_issue_alert`) that pages on the first occurrence of a KB tenant-mint `reportSilentFallback` event, closing the operator-blind-zone for this regression class. It is a pure IaC + observability change against the already-provisioned `apps/web-platform/infra/sentry/` Terraform root, mirroring the `chat_message_save_failure` (#4849) and `workspace_sync_health` (#4882) alert precedents byte-for-byte.
+
+**Why an issue alert, not a cron/uptime monitor:** the signal is an *event* (`Sentry.captureException` with `feature`/`op` tags), not a missed scheduled check-in. The issue text's `failure_issue_threshold = 1` is a `sentry_cron_monitor` / `sentry_uptime_monitor` attribute and does not exist on `sentry_issue_alert` (see Research Reconciliation R1). The issue-alert equivalent of "auto-page on the first occurrence" is `conditions_v2 = [{ first_seen_event = {} }, { reappeared_event = {} }, { regression_event = {} }]` with `action_match = "any"` — the exact shape the two precedent alerts use. This delivers the intent of `failure_issue_threshold = 1` (page on the very first event, re-page on recurrence after resolve) per `hr-observability-as-plan-quality-gate` and `hr-no-dashboard-eyeball-pull-data-yourself`.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Issue/PIR claim | Reality (verified in repo) | Plan response |
+|---|---|---|
+| R1: "Alert must auto-page (`failure_issue_threshold = 1`)" | `failure_issue_threshold` is a `sentry_cron_monitor`/`sentry_uptime_monitor` attribute (`cron-monitors.tf:70…526`). `sentry_issue_alert` has **no such attribute**; first-occurrence paging is expressed via `conditions_v2 = [{first_seen_event={}}, {reappeared_event={}}, {regression_event={}}]` + `action_match="any"`. | Reframe the requirement to the issue-alert equivalent. Use the `chat_message_save_failure`/`workspace_sync_health` conditions_v2 triad. AC asserts the triad, not the literal `failure_issue_threshold`. |
+| R2: Issue names two ops: `resolveUserKbRoot.tenant-mint` + `authenticateAndResolveKbPath.tenant-mint` | **A third sibling tenant-mint op exists**: `kb-sync.tenant-mint` at `app/api/kb/sync/route.ts:60-65` — identical `RuntimeAuthError → 503` mint-failure class, same regression class, same user-invisible dead-end. | **Fold `kb-sync.tenant-mint` into the `op IS_IN` filter.** At brand-survival threshold `single-user incident`, scoping out the next-most-likely sibling is anti-pattern (AGENTS.md). The alert exists to catch the mint-failure class; all three ops ARE that class. |
+| R3: `feature: "kb-route-helpers"` is dedicated to tenant-mint | **False — 6 distinct ops** carry `feature: "kb-route-helpers"`: the 3 tenant-mint ops above PLUS `workspace-sync-${context.op}` (kb-route-helpers.ts:448), `self-heal-aborted-dirty/reset/failed` (:530/:557/:570), `kb-sync.unexpected` (sync/route.ts:40). | **Must filter by `op IS_IN`, NOT feature-only.** A feature-only filter (the `workspace_sync_health` shape) would page on unrelated self-heal/workspace-sync events. Use the `chat_message_save_failure` op-scoped shape. |
+| R4: alert is "import-only" like the 4 auth rules | The 4 auth rules are import-only (mirror legacy script rules); the 2 BYOK rules + chat + workspace-sync rules are **apply-created** from real `conditions_v2`/`filters_v2`. No pre-existing Sentry rule for KB tenant-mint. | This is an **apply-created** rule (no import). `conditions_v2`/`filters_v2`/`actions_v2` are the source of truth (NOT under `ignore_changes`); only `environment` is ignored. Must be added to BOTH `-target` blocks in `apply-sentry-infra.yml`. |
+| R5: `reportSilentFallback` emits the `feature`/`op` tags the filter needs | Verified: `observability.ts:188-189` sets `tags = { feature }; if (op) tags.op = op;` then `Sentry.captureException(err, { tags, … })` (`:220`). `RuntimeAuthError extends Error` → captureException path. | Tags `feature` + `op` are queryable in Sentry exactly as the `tagged_event` filter expects. No app-code change required. |
+| R6: free Sentry alert `frequency` value | Taken set in `issue-alerts.tf`: `5,10,11,15,30,60,61,62`. Sentry dedups POST-time on action-shape+frequency+match (not conditions) — needs a unique value. | Use `frequency = 12` (free). Not evaluated by lifecycle-condition rules but must be unique to dodge create-time dedup. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** nothing changes for the end user directly (this is an observability layer); but the *operator* stays blind to a recurring KB tenant-mint failure — the exact ~19-day latent-regression failure mode the PIR documents. A broken/silent alert recreates the operator-blind-zone for KB Generate-link / KB upload / KB sync.
+
+**If this leaks, the user's data/workflow is exposed via:** the alert payload carries only the pseudonymized `userIdHash` (Recital-26 hashed at the emit boundary, `observability.ts:hashExtraUserId`), the `op` slug, and `pg_code` — no raw userId, no document content, no share token. The notify-email fallthrough (`IssueOwners → ActiveMembers`) over-discloses only to active Sentry seats; with a solo founder this is correct. There is **no cross-tenant content** in these events (unlike the BYOK Art-33 rule), so the fallthrough does not over-disclose at N=1.
+
+**Brand-survival threshold:** single-user incident — carried forward from the source PIR frontmatter (`brand_survival_threshold: single-user incident`). The tenant-zero founder is the primary affected user; a silently-broken core sharing feature for the founder is the brand-survival cost this alert guards.
+
+> **CPO sign-off required at plan time before `/work` begins.** Confirm CPO has reviewed (or is covered by the Phase 2.5 Domain Review carry-forward) before implementation. `user-impact-reviewer` will be invoked at review-time.
+
+## Goals
+
+1. A `sentry_issue_alert.kb_tenant_mint_silent_fallback` resource in `apps/web-platform/infra/sentry/issue-alerts.tf` that pages on the first occurrence of any KB tenant-mint `reportSilentFallback` event.
+2. The alert filters on `feature == "kb-route-helpers"` AND `op IS_IN {resolveUserKbRoot.tenant-mint, authenticateAndResolveKbPath.tenant-mint, kb-sync.tenant-mint}` — scoped to the mint-failure class, excluding the unrelated self-heal / workspace-sync / unexpected ops.
+3. The alert is wired into BOTH the `terraform plan` and `terraform apply` `-target` blocks of `.github/workflows/apply-sentry-infra.yml` (apply-created, not import-only).
+4. A cross-artifact op/feature contract test (`sentry-kb-tenant-mint-alert-op-contract.test.ts`) pins the 3 op slugs + feature tag in both the emit sites and the tf filter, so a rename of either breaks CI instead of silently zeroing the alert's matches.
+5. PIR follow-up checkbox (line 138) ticked; issue #4918 closed.
+
+## Non-Goals
+
+- **Applying the alert to prod.** The `apply-sentry-infra.yml` workflow auto-applies on merge to `main` (path-filtered on `apps/web-platform/infra/sentry/**`). No operator SSH / dashboard step. Verification is read-only via the workflow run + `gh`/Sentry API (see Observability §discoverability_test).
+- **User-facing error toast on a genuine share 503** (PIR follow-up line 139) — separate concern, separate issue if pursued.
+- **Mint-failure resilience for `authenticateAndResolveKbPath`** (PIR follow-up line 137 / #4914) — already filed/tracked; out of scope here. This plan only ADDS the alert; #4914 is the fallback behavior.
+- **Migrating `sentry_issue_alert` → `sentry_alert`** — blocked on provider GA (#4610), see issue-alerts.tf header.
+
+## Files to Edit
+
+- `apps/web-platform/infra/sentry/issue-alerts.tf` — add `resource "sentry_issue_alert" "kb_tenant_mint_silent_fallback"` (apply-created shape mirroring `chat_message_save_failure`: `action_match="any"`, `filter_match="all"`, `frequency=12`, `conditions_v2` triad, `filters_v2` = feature EQUAL + op IS_IN 3-slug, `actions_v2` IssueOwners→ActiveMembers, `lifecycle.ignore_changes=[environment]`).
+- `.github/workflows/apply-sentry-infra.yml` — add `-target=sentry_issue_alert.kb_tenant_mint_silent_fallback` to BOTH the `terraform plan` target block (after :217) AND ensure the `terraform apply tfplan` at :268 consumes the same plan (it applies the saved `tfplan`, so the single `-target` add in the plan block suffices — **verify** the apply step reuses `tfplan` and does not re-list targets).
+- `knowledge-base/engineering/operations/post-mortems/generate-link-tenant-mint-regression-postmortem.md` — tick the follow-up checkbox at line 138 (`[ ]` → `[x]`) and update the Action Items note to cite #4918 as filed/landed.
+
+## Files to Create
+
+- `apps/web-platform/test/sentry-kb-tenant-mint-alert-op-contract.test.ts` — cross-artifact contract test mirroring `sentry-chat-alert-op-contract.test.ts`. Reads `infra/sentry/issue-alerts.tf` + `server/kb-route-helpers.ts` + `app/api/kb/sync/route.ts`; asserts (a) `feature == "kb-route-helpers"` present in both emit + tf, (b) each of the 3 op slugs present in its emit file AND in the tf filter, (c) the tf binds the 3 slugs into one comma-joined `IS_IN` value, (d) the tf declares `resource "sentry_issue_alert" "kb_tenant_mint_silent_fallback"`.
+
+## Open Code-Review Overlap
+
+None — verified `gh issue list --label code-review --state open` against the planned file paths returns no matches. (To be re-run at Step 2 against the finalized file list.)
+
+## Implementation Phases
+
+### Phase 0 — Preconditions (verify before writing)
+1. `terraform providers schema -json` (or read existing precedent) confirms `conditions_v2` accepts `first_seen_event`/`reappeared_event`/`regression_event` and `filters_v2.tagged_event.match` accepts `IS_IN` — both already proven in `byok_cap_exceeded` / `chat_message_save_failure` (no re-verify needed; cite those resources).
+2. Confirm frequency `12` is free (taken: `5,10,11,15,30,60,61,62`).
+3. Confirm `apply-sentry-infra.yml` apply step (:268) applies the saved `tfplan` and does not maintain a SEPARATE target list — grep the apply step. If it re-lists targets, edit both blocks.
+
+### Phase 1 — Write the contract test (RED)
+Create `sentry-kb-tenant-mint-alert-op-contract.test.ts`. It fails initially (the tf resource + op-in-filter do not yet exist).
+
+### Phase 2 — Add the alert resource (GREEN)
+Add the `kb_tenant_mint_silent_fallback` block to `issue-alerts.tf` with the op-scoped 3-slug `IS_IN` filter. Re-run the contract test → green.
+
+### Phase 3 — Wire the apply workflow
+Add the `-target` to `apply-sentry-infra.yml`. Run `bash tests/scripts/test-destroy-guard-sentry-scope-guard.sh` (already allow-lists `sentry_issue_alert` — confirm still green) and `terraform validate` / `terraform fmt -check` in the sentry root.
+
+### Phase 4 — PIR follow-up + issue close
+Tick PIR line 138, update Action Items note, ensure PR body uses `Closes #4918` (this is a pre-merge code change, not an ops-remediation, so `Closes` is correct — the alert ships at merge, not via a post-merge operator apply; the auto-apply workflow handles prod).
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- [x] `issue-alerts.tf` declares `resource "sentry_issue_alert" "kb_tenant_mint_silent_fallback"` with `action_match = "any"`, `filter_match = "all"`, `frequency = 12`.
+- [x] `conditions_v2` contains exactly `first_seen_event`, `reappeared_event`, `regression_event` (the first-occurrence + recurrence triad — the issue-alert equivalent of `failure_issue_threshold = 1`).
+- [x] `filters_v2` contains a `tagged_event` with `key="feature" match="EQUAL" value="kb-route-helpers"` AND a `tagged_event` with `key="op" match="IS_IN" value="resolveUserKbRoot.tenant-mint,authenticateAndResolveKbPath.tenant-mint,kb-sync.tenant-mint"` (the comma-joined 3-slug value, verified as one literal string).
+- [x] `actions_v2` = `notify_email { target_type="IssueOwners" fallthrough_type="ActiveMembers" }`; `lifecycle.ignore_changes = [environment]`.
+- [x] `apply-sentry-infra.yml` `terraform plan` `-target` block includes `-target=sentry_issue_alert.kb_tenant_mint_silent_fallback` (and the apply step consumes the same `tfplan`).
+- [x] `apps/web-platform/test/sentry-kb-tenant-mint-alert-op-contract.test.ts` passes: all 3 op slugs + feature tag present in BOTH emit sites and tf filter; the 3-slug `IS_IN` value present as one literal.
+- [x] `bash tests/scripts/test-destroy-guard-sentry-scope-guard.sh` exits 0 (issue_alert still in allow-list scope).
+- [x] `terraform fmt -check` and `terraform validate` pass in `apps/web-platform/infra/sentry/` (the deprecation warning on `sentry_issue_alert` is EXPECTED — see file header).
+- [x] webplat vitest shard green for the new test (`./node_modules/.bin/vitest run test/sentry-kb-tenant-mint-alert-op-contract.test.ts` from `apps/web-platform/`).
+- [x] PIR line 138 checkbox is `[x]`; PR body says `Closes #4918`.
+
+### Post-merge (operator)
+- [ ] None requiring manual action. `apply-sentry-infra.yml` auto-applies on merge (path-filtered `on.push` to `apps/web-platform/infra/sentry/**`). **Automation: feasible — handled by the existing auto-apply workflow.** Verify via `gh run watch` on the triggered apply run (see Observability discoverability_test) — no SSH, no dashboard eyeballing.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "sentry_issue_alert.kb_tenant_mint_silent_fallback fires on first KB tenant-mint reportSilentFallback event"
+  cadence: "event-driven (on any RuntimeAuthError mint failure in the 3 KB ops)"
+  alert_target: "Sentry IssueOwners → ActiveMembers (solo founder)"
+  configured_in: "apps/web-platform/infra/sentry/issue-alerts.tf"
+error_reporting:
+  destination: "Sentry (captureException) + pino mirror (Better Stack) via reportSilentFallback"
+  fail_loud: true
+failure_modes:
+  - mode: "tenant-mint RuntimeAuthError on resolveUserKbRoot (Generate-link / KB read)"
+    detection: "feature=kb-route-helpers op=resolveUserKbRoot.tenant-mint Sentry event"
+    alert_route: "kb_tenant_mint_silent_fallback issue alert → email"
+  - mode: "tenant-mint RuntimeAuthError on authenticateAndResolveKbPath (file PATCH/DELETE)"
+    detection: "feature=kb-route-helpers op=authenticateAndResolveKbPath.tenant-mint Sentry event"
+    alert_route: "kb_tenant_mint_silent_fallback issue alert → email"
+  - mode: "tenant-mint RuntimeAuthError on kb-sync (POST /api/kb/sync)"
+    detection: "feature=kb-route-helpers op=kb-sync.tenant-mint Sentry event"
+    alert_route: "kb_tenant_mint_silent_fallback issue alert → email"
+  - mode: "alert silently zeroed by op-slug or feature-tag rename drift"
+    detection: "sentry-kb-tenant-mint-alert-op-contract.test.ts fails in CI"
+    alert_route: "CI red on PR"
+logs:
+  where: "Sentry issues (tag: feature=kb-route-helpers, op IS_IN 3 slugs) + container stdout (pino) → Better Stack"
+  retention: "Sentry plan default; Better Stack log retention default"
+discoverability_test:
+  command: "gh run list --workflow=apply-sentry-infra.yml --limit 1 --json conclusion,databaseId && gh run watch <id>  # then, optionally, query the Sentry rules API for the rule by name via configure-sentry-alerts.sh pattern"
+  expected_output: "apply-sentry-infra run conclusion=success; sentry_issue_alert.kb_tenant_mint_silent_fallback present in tf state / Sentry rules list"
+```
+
+## Infrastructure (IaC)
+
+This plan modifies the already-provisioned `apps/web-platform/infra/sentry/` Terraform root (R2 backend per the existing root). No new vendor, server, secret, or persistent process.
+
+### Terraform changes
+- Files: `apps/web-platform/infra/sentry/issue-alerts.tf` (add one `sentry_issue_alert` resource). Provider already pinned: `jianyuan/sentry` `0.15.0-beta2` (`versions.tf:10`). Required vars unchanged (`sentry_org`, the `data.sentry_project.web_platform` data source). No new sensitive variables.
+
+### Apply path
+- **(a) apply-created via the existing auto-apply workflow.** `apply-sentry-infra.yml` runs `terraform plan -target=… -out=tfplan` then `terraform apply tfplan` on merge to `main` (path-filtered). The new `-target` scopes the apply to this resource + the existing monitor/alert set. No taint, no replace, no downtime — pure resource create. Blast radius: one new Sentry rule; the 4 import-only auth rules are untouched (their `-target`s are not in the untargeted apply path).
+
+### Distinctness / drift safeguards
+- `dev != prd`: the Sentry root targets the single Sentry org/project (`var.sentry_org`); there is no dev/prd split for Sentry monitoring infra (it observes prod). No `dev`-vs-`prd` precondition applies.
+- `lifecycle.ignore_changes = [environment]` only (matches the apply-created BYOK/chat/workspace rules) — `conditions_v2`/`filters_v2`/`actions_v2` are the source of truth and must NOT be ignored (the whole point of the rule).
+- State: `terraform.tfstate` in the R2 backend; no secret values land in state for this resource (alert config only).
+
+### Vendor-tier reality check
+- `sentry_issue_alert` (issue alerts) is available on the project's Sentry tier — already in use by 8 existing rules in this file. No paid-tier gate needed (unlike `betteruptime_policy`). The `sentry_alert` (v2) migration is deferred to provider GA (#4610), not relevant here.
+
+## Domain Review
+
+**Domains relevant:** Product (observability/operator-experience axis), Engineering/CTO (IaC).
+
+### Engineering / CTO
+
+**Status:** reviewed (carry-forward from PIR + this plan's IaC analysis)
+**Assessment:** Pure additive IaC against a well-established precedent (`chat_message_save_failure`, `workspace_sync_health`). The op-scoping decision (IS_IN vs feature-only) is the single load-bearing design choice and is grounded in the 6-op enumeration (R3). The third sibling op `kb-sync.tenant-mint` (R2) is the highest-value plan-time catch. No new failure surface introduced; the alert is read-only observability.
+
+### Product/UX Gate
+
+**Tier:** none
+**Decision:** N/A — no user-facing surface. This is operator-facing observability infra (Sentry rule + Terraform + test). No `components/**`, `app/**/page.tsx`, or UI-surface file in Files to Edit/Create.
+**Pencil available:** N/A (no UI surface)
+
+## Risks & Mitigations
+
+- **Risk: op-slug drift silently zeroes the alert.** Mitigation: the contract test pins all 3 slugs in both emit + tf (the `chat`/`workspace-sync` precedent pattern). A rename breaks CI.
+- **Risk: feature-only filter pages on unrelated kb-route-helpers ops** (self-heal, workspace-sync). Mitigation: `op IS_IN` 3-slug scoping (R3). Verified the 6-op enumeration.
+- **Risk: missing the third sibling `kb-sync.tenant-mint`.** Mitigation: folded into the filter (R2); enumerated all `feature: "kb-route-helpers"` emit sites via grep.
+- **Risk: frequency collision triggers Sentry POST-time exact-duplicate dedup.** Mitigation: `frequency = 12`, verified free against the taken set (R6).
+- **Risk: apply workflow applies a stale plan or re-lists targets.** Mitigation: Phase 0.3 greps the apply step to confirm it consumes the saved `tfplan`; if it re-lists, edit both blocks.
+- **Risk: `notify_email` fallthrough over-discloses at N>1 seats.** Mitigation: accepted N=1 risk (mirrors the 8 existing rules); these events carry NO cross-tenant content (only hashed userId + op + pg_code), so even the fallthrough is safe. Revisit `target_type="Member"` before the first non-founder Sentry seat (same note as `chat_message_save_failure:378-383`).
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty or omits the threshold fails `deepen-plan` Phase 4.6. This plan's section is filled with threshold `single-user incident` (carried from the PIR).
+- The issue's `failure_issue_threshold = 1` is a **cron/uptime-monitor** attribute, NOT an issue-alert attribute — do not add it to the `sentry_issue_alert` block (it will fail `terraform validate`). The issue-alert equivalent is the `conditions_v2` triad. (R1)
+- `feature: "kb-route-helpers"` spans 6 ops — a feature-only filter would over-page. MUST use `op IS_IN`. (R3)
+- There is a THIRD tenant-mint op (`kb-sync.tenant-mint`) the issue body did not name. (R2)
+- The `terraform validate` deprecation warning on `sentry_issue_alert` is EXPECTED (provider beta2; GA migration deferred to #4610) — do not treat it as a regression, do not migrate to `sentry_alert`.
+
+## Provenance / References
+
+- Source PIR: `knowledge-base/engineering/operations/post-mortems/generate-link-tenant-mint-regression-postmortem.md` (PR #4913, follow-up line 138).
+- Precedent alerts: `apps/web-platform/infra/sentry/issue-alerts.tf` — `chat_message_save_failure` (#4849, lines 329-396), `workspace_sync_health` (#4882, lines 398-459), `byok_cap_exceeded` (#4364, op IS_IN pattern, lines 288-327).
+- Precedent contract test: `apps/web-platform/test/sentry-chat-alert-op-contract.test.ts`.
+- Emit sites: `server/kb-route-helpers.ts:105` (authenticateAndResolveKbPath), `:269` (resolveUserKbRoot); `app/api/kb/sync/route.ts:60` (kb-sync).
+- `reportSilentFallback` tag emit: `server/observability.ts:183-235`.
+- Apply workflow: `.github/workflows/apply-sentry-infra.yml` (plan targets :186-217, apply :268).
+- Scope guard: `tests/scripts/test-destroy-guard-sentry-scope-guard.sh` (already allow-lists `sentry_issue_alert`).
+- ADR: `knowledge-base/engineering/architecture/decisions/ADR-031-sentry-as-iac.md`.

--- a/knowledge-base/project/specs/feat-one-shot-4918-alert-kb-tenant-mint-silent-fallback/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-4918-alert-kb-tenant-mint-silent-fallback/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-04-feat-kb-tenant-mint-silent-fallback-alert-plan.md
+- Status: complete
+
+### Errors
+None. CWD verified equal to WORKING DIRECTORY on the first tool call. Premise validated: issue #4918 OPEN/unresolved, PR #4913 MERGED (2026-06-03), PIR file present — legitimate follow-up.
+
+### Decisions
+- Reframed the premise (R1): `failure_issue_threshold = 1` is a cron/uptime-monitor attribute, NOT valid on `sentry_issue_alert`. The issue-alert equivalent of "auto-page on first occurrence" is `conditions_v2 = [{first_seen_event},{reappeared_event},{regression_event}]` + `action_match="any"` — the `chat_message_save_failure` (#4849) / `workspace_sync_health` (#4882) precedent shape. Plan uses `sentry_issue_alert.kb_tenant_mint_silent_fallback`.
+- Op-scoping, not feature-only (R3): `feature: "kb-route-helpers"` spans 6 ops, so the alert MUST filter `op IS_IN` the tenant-mint slugs — a feature-only filter would page on unrelated self-heal/workspace-sync events.
+- Caught a third sibling op the issue omitted (R2): `kb-sync.tenant-mint` (`app/api/kb/sync/route.ts:60`) is the identical `RuntimeAuthError → 503` mint-failure class. Folded into the `IS_IN` filter.
+- No new app code or operator step: signal already exists (`reportSilentFallback` emits `feature`/`op` tags); `apply-sentry-infra.yml` auto-applies on merge. Cross-artifact op/feature contract test pins the 3 slugs in both emit sites + tf.
+- CPO sign-off flagged (`requires_cpo_signoff: true`) carried from the PIR's `single-user incident` threshold; `user-impact-reviewer` will run at review-time.
+
+### Components Invoked
+- Skill: soleur:plan
+- Skill: soleur:deepen-plan (gates 4.4, 4.45, 4.6, 4.7, 4.8, 4.9 — all pass)
+- Bash, Read, Write, Edit


### PR DESCRIPTION
## Summary

Wire a Sentry **issue alert** (`sentry_issue_alert.kb_tenant_mint_silent_fallback`) that pages on the **first occurrence** of any KB tenant-JWT mint failure, closing the ~19-day operator-blind-zone the PIR (PR #4913) documented. The mint failure already emitted a `reportSilentFallback` Sentry signal on every tenant-mint dead-end, but **no alert routed it to attention** — this adds the missing notification layer (`hr-no-dashboard-eyeball-pull-data-yourself`). Pure IaC + contract-test change against the already-provisioned `apps/web-platform/infra/sentry/` Terraform root; no app code, no operator step.

Closes #4918

## User-Brand Impact

**If this lands broken, the user experiences:** nothing changes for the end user directly (this is an observability layer); but the *operator* stays blind to a recurring KB tenant-mint failure — the exact ~19-day latent-regression failure mode the PIR documents. A broken/silent alert recreates the operator-blind-zone for KB Generate-link / KB upload / KB sync.

**If this leaks, the user's data/workflow is exposed via:** the alert payload carries only the pseudonymized `userIdHash` (Recital-26 hashed at the emit boundary, `observability.ts` `hashExtraUserId`), the `op` slug, and `pg_code` — no raw userId, no document content, no share token. The `notify_email` fallthrough (`IssueOwners → ActiveMembers`) over-discloses only to active Sentry seats; with a solo founder this is correct. There is **no cross-tenant content** in these events, so the fallthrough does not over-disclose at N=1.

- **Brand-survival threshold:** single-user incident — carried from the source PIR frontmatter (`brand_survival_threshold: single-user incident`). The tenant-zero founder is the primary affected user; a silently-broken core sharing feature for the founder is the brand-survival cost this alert guards.

## Design notes

- **op-scoped `IS_IN`, not feature-only:** `feature=kb-route-helpers` spans several ops (workspace-sync-*, 3× self-heal-*, kb-sync.unexpected) beyond the 3 tenant-mint slugs, so the alert filters `op IS_IN {resolveUserKbRoot.tenant-mint, authenticateAndResolveKbPath.tenant-mint, kb-sync.tenant-mint}` to avoid over-paging. The third slug (`kb-sync.tenant-mint`) is the identical `RuntimeAuthError → 503` class the issue body omitted, folded in at the `single-user incident` threshold.
- **`conditions_v2` triad + `action_match="any"`** is the issue-alert equivalent of the issue text's `failure_issue_threshold = 1` (a cron/uptime-monitor attribute that does not exist on `sentry_issue_alert`): page on first occurrence, re-page on recurrence after resolve. Mirrors the `chat_message_save_failure` (#4849) precedent byte-for-byte.
- **Cross-artifact contract test** pins all 3 op slugs + the feature tag in BOTH the emit sites and the tf filter (filter-side assertions scoped to the resource block), so a rename breaks CI instead of silently zeroing the alert.

## Changelog

- **Observability:** new Sentry issue alert pages on the first KB tenant-mint `reportSilentFallback` event across all 3 mint-failure ops (Generate-link/read, file PATCH/DELETE, kb-sync).
- **CI:** wired `sentry_issue_alert.kb_tenant_mint_silent_fallback` into the `apply-sentry-infra.yml` plan `-target` block — auto-applies on merge (the apply step consumes the saved `tfplan`).
- **Tests:** added `sentry-kb-tenant-mint-alert-op-contract.test.ts` (cross-artifact op/feature drift guard).
- **Docs:** ticked the PIR follow-up checkbox + Action Items.

## Test plan

- [x] `sentry-kb-tenant-mint-alert-op-contract.test.ts` passes (6/6); sibling sentry contract tests still green (14 total).
- [x] `terraform fmt -check` + `terraform validate` pass in `apps/web-platform/infra/sentry/` (the `sentry_issue_alert` deprecation warning is expected per the file header).
- [x] `tests/scripts/test-destroy-guard-sentry-scope-guard.sh` + counter/regex-parity guards exit 0 (issue_alert still in allow-list scope).
- [x] Scripts-shard exit gate green (93/93 suites).
- Post-merge (automated, no operator step): the `apply-sentry-infra.yml` workflow auto-applies on merge and creates the Sentry rule. Verify via the triggered workflow run (`gh run watch`) — no SSH, no dashboard eyeballing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
