### PR TITLE
fix(chat): converge leader agent to ACTIVE workspace + harden ensure-repo clone race

### DIFF
--- a/apps/web-platform/server/agent-runner.ts
+++ b/apps/web-platform/server/agent-runner.ts
@@ -54,6 +54,7 @@ import { buildAuthStatusTools } from "./auth-status-tools";
 import { buildAccountTools } from "./account-tools";
 import { buildWorkspaceSettingsTools } from "./workspace-settings-tools";
 import { getCurrentRepoUrl } from "./current-repo-url";
+import { resolveActiveWorkspacePath } from "./workspace-resolver";
 import { resolveInstallationId } from "./resolve-installation-id";
 import { buildGithubTools } from "./github-tools";
 import { buildPlausibleTools } from "./plausible-tools";
@@ -971,15 +972,28 @@ export async function startAgentSession(
     const sessionTenant = await getFreshTenantClient(userId);
     const { data: user } = await sessionTenant
       .from("users")
-      .select("workspace_path, repo_status, email")
+      .select("repo_status, email")
       .eq("id", userId)
       .single();
 
-    if (!user?.workspace_path) {
+    if (!user) {
       throw new Error(ERR_WORKSPACE_NOT_PROVISIONED);
     }
 
-    const workspacePath = user.workspace_path;
+    // Resolve the leader's workspace dir from the ACTIVE workspace (ADR-044) —
+    // NOT the legacy `users.workspace_path` column. That column is stale/empty
+    // for invited members and for users provisioned after the ADR-044
+    // `users → workspaces` relocation (#4559), so reading it pointed the leader
+    // (agent cwd, KB root, doc resolver, vision, sync) at a dir that diverged
+    // from the UI KB file tree (`resolveActiveWorkspaceKbRoot`) and from the
+    // Concierge (#4910 converged the Concierge half via `fetchUserWorkspacePath`;
+    // this converges the leader half). `resolveActiveWorkspacePath` fails closed
+    // to the SOLO workspace (never a sibling) and always returns a path, so the
+    // provisioning guard above keys only on the `users` row existing.
+    // NOTE: `user.repo_status` (the syncPull gate below) is still the legacy
+    // column — repo state relocated to `workspaces` under ADR-044; converging
+    // that gate is tracked separately (the git-workspace-plumbing scope).
+    const workspacePath = await resolveActiveWorkspacePath(userId, sessionTenant);
     const pluginPath = path.join(workspacePath, "plugins", "soleur");
 
     // Extract MCP server names from plugin.json for canUseTool allowlisting.

--- a/apps/web-platform/server/agent-runner.ts
+++ b/apps/web-platform/server/agent-runner.ts
@@ -972,7 +972,7 @@ export async function startAgentSession(
     const sessionTenant = await getFreshTenantClient(userId);
     const { data: user } = await sessionTenant
       .from("users")
-      .select("repo_status, email")
+      .select("email")
       .eq("id", userId)
       .single();
 
@@ -990,9 +990,6 @@ export async function startAgentSession(
     // this converges the leader half). `resolveActiveWorkspacePath` fails closed
     // to the SOLO workspace (never a sibling) and always returns a path, so the
     // provisioning guard above keys only on the `users` row existing.
-    // NOTE: `user.repo_status` (the syncPull gate below) is still the legacy
-    // column — repo state relocated to `workspaces` under ADR-044; converging
-    // that gate is tracked separately (the git-workspace-plumbing scope).
     const workspacePath = await resolveActiveWorkspacePath(userId, sessionTenant);
     const pluginPath = path.join(workspacePath, "plugins", "soleur");
 
@@ -1027,10 +1024,15 @@ export async function startAgentSession(
     // through `atomicWriteJson`).
     await patchWorkspacePermissions(workspacePath);
 
-    // Sync: pull latest from remote before session (connected repos only)
-    if (user.repo_status === "ready") {
-      await syncPull(userId, workspacePath);
-    }
+    // Sync: pull latest from the ACTIVE workspace's remote before the session.
+    // No outer `repo_status` gate — `syncPull` self-guards on
+    // `hasRemote(workspacePath)` + the active-workspace installation
+    // (`resolveInstallationId`), so it no-ops for an unconnected/empty workspace
+    // and pulls for a connected one. Gating on the caller's legacy SOLO
+    // `users.repo_status` would skip the pull for an invited member whose ACTIVE
+    // (shared) workspace is connected — the exact #4543 divergence the converged
+    // `workspacePath` above fixes, re-created one branch away.
+    await syncPull(userId, workspacePath);
 
     // Create vision.md on first message if it doesn't exist (fire-and-forget).
     // Runs in startAgentSession (not sendUserMessage) to reuse the already-fetched
@@ -2070,10 +2072,12 @@ issues/PRs, 4 KB comments); follow the html_url for the full text.`;
               : undefined,
           );
 
-          // Sync: push changes to remote after session (connected repos only)
-          if (user.repo_status === "ready") {
-            await syncPush(userId, workspacePath);
-          }
+          // Sync: push changes to the ACTIVE workspace's remote after the
+          // session. Same rationale as the session-start pull — `syncPush`
+          // self-guards (`hasRemote` + `hasLocalCommits` + active installation),
+          // so no legacy `repo_status` gate (which would silently drop an
+          // invited member's leader edits to a connected shared workspace).
+          await syncPush(userId, workspacePath);
 
           // Notify client that this leader finished streaming. The finally block
           // below emits the same event as a fallback for exception paths; guard

--- a/apps/web-platform/server/ensure-workspace-repo.ts
+++ b/apps/web-platform/server/ensure-workspace-repo.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { rm, rename, cp, readdir } from "node:fs/promises";
 import { join } from "node:path";
+import { randomUUID } from "node:crypto";
 
 import { gitWithInstallationAuth } from "@/server/git-auth";
 import { reportSilentFallback } from "@/server/observability";
@@ -115,14 +116,22 @@ export async function ensureWorkspaceRepoCloned(
  * sentinel. The token is supplied via GIT_ASKPASS (env) inside
  * `gitWithInstallationAuth`, never embedded in the remote URL, and `--` guards
  * the URL arg against flag-smuggling.
+ *
+ * CONCURRENCY (review PR #4890 follow-up): the temp dir is unique per attempt
+ * (`randomUUID` suffix), NOT a fixed `.ensure-repo-tmp`. Two cold dispatches for
+ * the SAME user (two tabs / a rapid re-open) can both observe no `.git` and run
+ * this concurrently against the shared `workspacePath`. A fixed temp dir let one
+ * attempt's cleanup `rm` nuke the other's in-flight clone and let the cp/rename
+ * interleave; a unique dir isolates each attempt's clone + cleanup. The `.git`
+ * sentinel move is then guarded by a re-check (below) so the loser no-ops
+ * instead of `rename`-ing onto the winner's populated `.git` (ENOTEMPTY).
  */
-async function realGraftRepoClone(
+export async function realGraftRepoClone(
   workspacePath: string,
   repoUrl: string,
   installationId: number,
 ): Promise<void> {
-  const tmp = join(workspacePath, ".ensure-repo-tmp");
-  await rm(tmp, { recursive: true, force: true });
+  const tmp = join(workspacePath, `.ensure-repo-tmp-${randomUUID()}`);
   try {
     await gitWithInstallationAuth(
       ["clone", "--depth", "1", "--", repoUrl, tmp],
@@ -138,6 +147,13 @@ async function realGraftRepoClone(
         force: true,
       });
     }
+    // Re-check the sentinel immediately before the move. A concurrent attempt
+    // (another cold dispatch that also saw no `.git`) may have grafted first
+    // while this one was cloning. `.git` is the all-or-nothing success sentinel,
+    // so if it now exists we lost the race — leave the winner's clone intact and
+    // skip, rather than `rename`-ing onto a populated `.git` (which throws
+    // ENOTEMPTY and would mirror a spurious failure to Sentry).
+    if (existsSync(join(workspacePath, ".git"))) return;
     // .git LAST — the success sentinel. A failure before this leaves the
     // workspace `.git`-less so the next cold dispatch retries cleanly.
     await rename(join(tmp, ".git"), join(workspacePath, ".git")); // same fs

--- a/apps/web-platform/server/ensure-workspace-repo.ts
+++ b/apps/web-platform/server/ensure-workspace-repo.ts
@@ -120,12 +120,21 @@ export async function ensureWorkspaceRepoCloned(
  * CONCURRENCY (review PR #4890 follow-up): the temp dir is unique per attempt
  * (`randomUUID` suffix), NOT a fixed `.ensure-repo-tmp`. Two cold dispatches for
  * the SAME user (two tabs / a rapid re-open) can both observe no `.git` and run
- * this concurrently against the shared `workspacePath`. A fixed temp dir let one
- * attempt's cleanup `rm` nuke the other's in-flight clone and let the cp/rename
- * interleave; a unique dir isolates each attempt's clone + cleanup. The `.git`
- * sentinel move is then guarded by a re-check (below) so the loser no-ops
- * instead of `rename`-ing onto the winner's populated `.git` (ENOTEMPTY).
+ * this concurrently against the shared `workspacePath`. The unique dir isolates
+ * each attempt's clone + cleanup `rm` (a fixed dir let one attempt's `rm` nuke
+ * the other's in-flight clone), and the `.git` sentinel move is guarded by a
+ * re-check (below) so the loser no-ops instead of `rename`-ing onto the winner's
+ * populated `.git` (ENOTEMPTY).
+ *   NOTE: the working-tree `cp` loop below is NOT serialized — both racers may
+ *   materialize their tree over `workspacePath`. That is benign here ONLY because
+ *   both clone the same `repoUrl` at the same shallow HEAD, so the bytes are
+ *   identical and `{force:true}` overwrites converge. This holds because the
+ *   function acts only on a `.git`-less workspace (no local edits to lose) and
+ *   repo *reconnect* (a different origin) is `/api/repo/setup`'s job, never this
+ *   self-heal. If that premise ever changes, serialize via the existing
+ *   `withWorkspacePermissionLock(workspacePath, …)` instead.
  */
+/** @internal — exported only for the direct concurrency unit test (graft-race). */
 export async function realGraftRepoClone(
   workspacePath: string,
   repoUrl: string,

--- a/apps/web-platform/server/leader-document-resolver.ts
+++ b/apps/web-platform/server/leader-document-resolver.ts
@@ -57,15 +57,14 @@ export async function resolveLeaderDocumentContext(args: {
   providedContent?: string | null;
   /**
    * Optional pre-resolved workspace path. The leader's `startAgentSession`
-   * already SELECTs `workspace_path` (alongside repo_status/installation_id)
-   * for the session — passing it through here avoids a second Supabase
-   * round-trip via `fetchUserWorkspacePath` on every leader turn. When
-   * omitted, the resolver falls back to `fetchUserWorkspacePath` (which now
-   * resolves the ACTIVE workspace, Concierge shape). NOTE: the production
-   * leader run path supplies `preResolvedPath` from `startAgentSession`'s
-   * legacy `users.workspace_path` SELECT, so it does NOT yet flow through the
-   * active-workspace resolution — that convergence is tracked with the
-   * leader/git workspace plumbing (PR #4868 / git-workspace-plumbing plan).
+   * resolves the ACTIVE workspace path once (via `resolveActiveWorkspacePath`)
+   * and passes it through here — avoiding a second Supabase round-trip via
+   * `fetchUserWorkspacePath` on every leader turn. When omitted, the resolver
+   * falls back to `fetchUserWorkspacePath` (which also resolves the ACTIVE
+   * workspace, Concierge shape). Both paths now flow through the same
+   * active-workspace resolution (the leader convergence; the Concierge half
+   * landed in #4910), so the leader doc resolver reads the same workspace the
+   * UI KB file tree renders from.
    */
   workspacePath?: string;
 }): Promise<ResolvedLeaderDocumentContext> {

--- a/apps/web-platform/test/agent-runner-kb-share-preview.test.ts
+++ b/apps/web-platform/test/agent-runner-kb-share-preview.test.ts
@@ -211,27 +211,24 @@ describe("agent-runner kb_share_preview tool wiring", () => {
     expect(result.behavior).toBe("allow");
   });
 
-  test("does not register kb_share_preview when workspace unavailable (test 33)", async () => {
+  test("wires kb_share_preview even when the legacy users.workspace_path is null (ADR-044 active-workspace convergence, test 33)", async () => {
+    // Convergence regression guard (#4910 leader half). Pre-fix, a null
+    // `users.workspace_path` threw ERR_WORKSPACE_NOT_PROVISIONED and the leader
+    // session never wired its tools — the exact founder-class break for invited
+    // members / post-relocation users whose legacy column is empty but whose
+    // ACTIVE workspace is healthy. The leader now resolves the workspace via
+    // `resolveActiveWorkspacePath` (fail-closed to solo, never throws on an empty
+    // column), so the session wires normally against the active workspace's
+    // kbRoot.
     setupSupabaseMock(USER_WITHOUT_WORKSPACE);
     setupQueryMockImmediate();
 
-    // Workspace path is null — startAgentSession is expected to reject
-    // via ERR_WORKSPACE_NOT_PROVISIONED before tool registration runs.
-    // The invariant: either the session rejects, or allowedTools does NOT
-    // include kb_share_preview. Defense in depth against registering the
-    // preview tool against an undefined kbRoot.
-    let threw = false;
-    try {
-      await startAgentSession("user-1", "conv-1", "cpo");
-    } catch {
-      threw = true;
-    }
+    // Must NOT throw — the empty legacy column is no longer a provisioning gate.
+    await startAgentSession("user-1", "conv-1", "cpo");
 
-    if (!threw && mockQuery.mock.calls.length > 0) {
-      const options = mockQuery.mock.calls[0][0].options;
-      expect(options.allowedTools ?? []).not.toContain(
-        "mcp__soleur_platform__kb_share_preview",
-      );
-    }
+    const options = mockQuery.mock.calls[0][0].options;
+    expect(options.allowedTools).toContain(
+      "mcp__soleur_platform__kb_share_preview",
+    );
   });
 });

--- a/apps/web-platform/test/agent-runner-leader-active-workspace-parity.test.ts
+++ b/apps/web-platform/test/agent-runner-leader-active-workspace-parity.test.ts
@@ -130,6 +130,7 @@ vi.mock("../server/vision-helpers", () => ({
 }));
 
 import { startAgentSession } from "../server/agent-runner";
+import { syncPull } from "../server/session-sync";
 import { createApiKeysMock, createQueryMock } from "./helpers/agent-runner-mocks";
 
 const MEMBER_ID = "member-1";
@@ -229,5 +230,20 @@ describe("agent-runner leader — active-workspace cwd parity", () => {
     const options = mockQuery.mock.calls[0][0].options;
     expect(options.cwd).toBe(ACTIVE_DIR);
     expect(options.cwd).not.toBe(SOLO_DIR);
+  });
+
+  test("session-start sync targets the ACTIVE workspace and runs despite a null legacy repo_status", async () => {
+    // The member's legacy solo `users.repo_status` is null (see the `users` mock),
+    // yet their ACTIVE (shared) workspace is connected. Pre-fix the leader gated
+    // syncPull/syncPush on the solo `repo_status` → an invited member's leader
+    // edits were never pulled/pushed to the shared remote. The gate is dropped;
+    // syncPull self-guards (hasRemote + active installation) and now targets the
+    // ACTIVE dir.
+    setupSupabaseMock();
+    createQueryMock(mockQuery);
+
+    await startAgentSession(MEMBER_ID, "conv-1", "cpo");
+
+    expect(vi.mocked(syncPull)).toHaveBeenCalledWith(MEMBER_ID, ACTIVE_DIR);
   });
 });

--- a/apps/web-platform/test/agent-runner-leader-active-workspace-parity.test.ts
+++ b/apps/web-platform/test/agent-runner-leader-active-workspace-parity.test.ts
@@ -1,0 +1,233 @@
+// Regression: the LEADER agent session (`startAgentSession` in agent-runner.ts)
+// must operate in the caller's ACTIVE workspace dir — the same source the UI KB
+// file tree renders from (`resolveActiveWorkspaceKbRoot`) and the Concierge uses
+// post-#4910 — NOT the legacy `users.workspace_path` column.
+//
+// Agent-native parity bug (ADR-044 / #4543 class), leader half: pre-fix
+// agent-runner set `workspacePath = user.workspace_path` (the caller's SOLO
+// column — empty for an invited member, stale post-relocation), so the leader's
+// cwd / KB root / doc resolver / vision / sync all pointed at the wrong dir.
+// #4910 converged the Concierge half via `fetchUserWorkspacePath`; this converges
+// the leader half via `resolveActiveWorkspacePath`.
+//
+// RED on origin/main: `workspacePath = user.workspace_path` (the solo dir) → the
+// SDK query cwd is the solo dir → assertion fails.
+// GREEN after the fix: `workspacePath = resolveActiveWorkspacePath(...)` (the
+// active workspace dir) → cwd is the active dir.
+
+import { vi, describe, test, expect, beforeEach } from "vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL ??= "https://test.supabase.co";
+process.env.NEXT_PUBLIC_APP_URL ??= "https://app.soleur.ai";
+process.env.WORKSPACES_ROOT = "/tmp/soleur-leader-parity-root";
+
+const { mockFrom, mockRpc, mockQuery, mockReadFileSync } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockRpc: vi.fn(),
+  mockQuery: vi.fn(),
+  mockReadFileSync: vi.fn(),
+}));
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: mockQuery,
+  tool: vi.fn(
+    (name: string, _desc: string, _schema: unknown, handler: Function) => ({
+      name,
+      handler,
+    }),
+  ),
+  createSdkMcpServer: vi.fn((opts: { name: string; tools: unknown[] }) => ({
+    type: "sdk",
+    name: opts.name,
+    instance: { tools: opts.tools },
+  })),
+}));
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return { ...actual, readFileSync: mockReadFileSync };
+});
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/supabase/tenant", () => ({
+  getFreshTenantClient: vi.fn(async () => ({ from: mockFrom, rpc: mockRpc })),
+  mintFounderJwt: vi.fn(),
+  RuntimeAuthError: class RuntimeAuthError extends Error {
+    cause: string;
+    constructor(cause: string, msg: string) {
+      super(msg);
+      this.name = "RuntimeAuthError";
+      this.cause = cause;
+    }
+  },
+}));
+
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+vi.mock("../server/ws-handler", () => ({ sendToClient: vi.fn() }));
+vi.mock("../server/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  createChildLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock("../server/byok", () => ({
+  decryptKey: vi.fn(() => Buffer.from("sk-test-key", "utf8")),
+  decryptKeyLegacy: vi.fn(() => Buffer.from("sk-test-key", "utf8")),
+  zeroize: vi.fn(),
+  encryptKey: vi.fn(),
+}));
+vi.mock("../server/error-sanitizer", () => ({
+  sanitizeErrorForClient: vi.fn(() => "error"),
+}));
+vi.mock("../server/sandbox", () => ({ isPathInWorkspace: vi.fn(() => true) }));
+vi.mock("../server/tool-path-checker", () => ({
+  UNVERIFIED_PARAM_TOOLS: [],
+  extractToolPath: vi.fn(),
+  isFileTool: vi.fn(() => false),
+  isSafeTool: vi.fn(() => false),
+}));
+vi.mock("../server/agent-env", () => ({ buildAgentEnv: vi.fn(() => ({})) }));
+vi.mock("../server/sandbox-hook", () => ({
+  createSandboxHook: vi.fn(() => vi.fn()),
+}));
+vi.mock("../server/review-gate", () => ({
+  abortableReviewGate: vi.fn().mockResolvedValue("Approve"),
+  validateSelection: vi.fn(),
+  extractReviewGateInput: vi.fn(),
+  buildReviewGateResponse: vi.fn(),
+  MAX_SELECTION_LENGTH: 200,
+  REVIEW_GATE_TIMEOUT_MS: 300_000,
+}));
+vi.mock("../server/domain-leaders", () => {
+  const leaders = [
+    { id: "cpo", name: "CPO", title: "Chief Product Officer", description: "Product" },
+  ];
+  return { DOMAIN_LEADERS: leaders, ROUTABLE_DOMAIN_LEADERS: leaders };
+});
+vi.mock("../server/domain-router", () => ({ routeMessage: vi.fn() }));
+vi.mock("../server/session-sync", () => ({ syncPull: vi.fn(), syncPush: vi.fn() }));
+vi.mock("../server/github-api", () => ({
+  githubApiGet: vi.fn().mockResolvedValue({ default_branch: "main" }),
+  githubApiGetText: vi.fn().mockResolvedValue(""),
+  githubApiPost: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("../server/service-tools", () => ({
+  plausibleCreateSite: vi.fn(),
+  plausibleAddGoal: vi.fn(),
+  plausibleGetStats: vi.fn(),
+}));
+vi.mock("../server/observability", () => ({
+  reportSilentFallback: vi.fn(),
+  reportSilentFallbackWarning: vi.fn(),
+  warnSilentFallback: vi.fn(),
+}));
+// Vision is fire-and-forget against the resolved workspacePath; stub it so the
+// real fs is never touched.
+vi.mock("../server/vision-helpers", () => ({
+  tryCreateVision: vi.fn().mockResolvedValue(undefined),
+  buildVisionEnhancementPrompt: vi.fn().mockResolvedValue(""),
+}));
+
+import { startAgentSession } from "../server/agent-runner";
+import { createApiKeysMock, createQueryMock } from "./helpers/agent-runner-mocks";
+
+const MEMBER_ID = "member-1";
+// The member's ACTIVE workspace is a SHARED one, distinct from their solo
+// workspace (= MEMBER_ID per the N2 invariant). The document/work lives here.
+const ACTIVE_WS_ID = "team-workspace-99";
+const ROOT = "/tmp/soleur-leader-parity-root";
+const SOLO_DIR = `${ROOT}/${MEMBER_ID}`;
+const ACTIVE_DIR = `${ROOT}/${ACTIVE_WS_ID}`;
+
+// Recursive chain whose terminal single/maybeSingle resolve `row`.
+function singleRowChain(row: unknown) {
+  const chain: Record<string, unknown> = {};
+  chain.select = () => chain;
+  chain.eq = () => chain;
+  chain.single = () => ({ data: row, error: null });
+  chain.maybeSingle = () => ({ data: row, error: null });
+  return chain;
+}
+
+function setupSupabaseMock() {
+  mockRpc.mockImplementation(() => Promise.resolve({ data: null, error: null }));
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "api_keys") return createApiKeysMock();
+    if (table === "users") {
+      // Pre-fix source: the legacy column points at the SOLO dir. Post-fix this
+      // is no longer read for the path (only repo_status / email are).
+      return singleRowChain({
+        workspace_path: SOLO_DIR,
+        repo_status: null,
+        email: "member@example.com",
+      });
+    }
+    if (table === "user_session_state") {
+      // Post-fix source: the member's ACTIVE workspace is the shared one.
+      return singleRowChain({ current_workspace_id: ACTIVE_WS_ID });
+    }
+    if (table === "workspace_members") {
+      // Membership self-heal probe: the member IS a member of the active ws, so
+      // resolution stays on the active workspace (no solo fallback).
+      return singleRowChain({ user_id: MEMBER_ID });
+    }
+    if (table === "workspaces") {
+      return singleRowChain({ repo_url: null });
+    }
+    if (table === "conversations") {
+      const sel: Record<string, unknown> = {
+        eq: vi.fn(),
+        single: vi.fn(() => ({
+          data: { domain_leader: "cpo", session_id: null, workspace_id: ACTIVE_WS_ID },
+          error: null,
+        })),
+      };
+      (sel.eq as ReturnType<typeof vi.fn>).mockReturnValue(sel);
+      const upd: Record<string, unknown> = {
+        error: null,
+        eq: vi.fn(),
+        select: vi.fn(() => Promise.resolve({ data: [{ id: "mock" }], error: null })),
+      };
+      (upd.eq as ReturnType<typeof vi.fn>).mockReturnValue(upd);
+      return { update: vi.fn(() => upd), select: vi.fn(() => sel) };
+    }
+    if (table === "messages") {
+      return {
+        insert: () => ({ error: null }),
+        select: () => {
+          const chain: Record<string, unknown> = {
+            eq: () => chain,
+            order: () => Promise.resolve({ data: [], error: null }),
+            then: (resolve: (v: unknown) => void) => resolve({ data: [], error: null }),
+          };
+          return chain;
+        },
+      };
+    }
+    return singleRowChain(null);
+  });
+}
+
+describe("agent-runner leader — active-workspace cwd parity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReadFileSync.mockImplementation((filePath: string) => {
+      if (String(filePath).includes("plugin.json")) {
+        return JSON.stringify({ mcpServers: {} });
+      }
+      throw new Error(`ENOENT: no such file ${filePath}`);
+    });
+  });
+
+  test("SDK query cwd is the ACTIVE workspace dir, not the legacy solo column", async () => {
+    setupSupabaseMock();
+    createQueryMock(mockQuery);
+
+    await startAgentSession(MEMBER_ID, "conv-1", "cpo");
+
+    const options = mockQuery.mock.calls[0][0].options;
+    expect(options.cwd).toBe(ACTIVE_DIR);
+    expect(options.cwd).not.toBe(SOLO_DIR);
+  });
+});

--- a/apps/web-platform/test/agent-runner-system-prompt.test.ts
+++ b/apps/web-platform/test/agent-runner-system-prompt.test.ts
@@ -128,6 +128,21 @@ vi.mock("../server/leader-document-resolver", () => ({
   resolveLeaderDocumentContext: resolveLeaderDocumentContextSpy,
 }));
 
+// agent-runner now resolves the leader cwd from the ACTIVE workspace via
+// `resolveActiveWorkspacePath` (ADR-044 convergence) instead of the legacy
+// `users.workspace_path` column. Pin the seam to the seeded workspace_path so
+// the absolute-path assertions below stay deterministic (mirrors #4910's
+// Concierge test repoint). `importActual` keeps the other real exports that
+// byok-resolver depends on.
+vi.mock("../server/workspace-resolver", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../server/workspace-resolver")>();
+  return {
+    ...actual,
+    resolveActiveWorkspacePath: vi.fn(async () => "/tmp/test-workspace"),
+  };
+});
+
 import { startAgentSession, sendUserMessage } from "../server/agent-runner";
 import type { ConversationContext } from "../lib/types";
 import {

--- a/apps/web-platform/test/ensure-workspace-repo-graft-race.test.ts
+++ b/apps/web-platform/test/ensure-workspace-repo-graft-race.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Concurrency hardening for `realGraftRepoClone` (review PR #4890 follow-up):
+// two cold dispatches for the SAME user can both observe no `.git` and run the
+// graft concurrently against the shared `workspacePath`. The fix is a per-attempt
+// unique temp dir (so cleanup/clone don't collide) plus a pre-move `.git`
+// re-check (so the loser no-ops instead of `rename`-ing onto a populated `.git`).
+// These tests mock fs + git so the decision logic is covered without real git/fs.
+
+const {
+  mockExistsSync,
+  mockGitWithInstallationAuth,
+  mockReaddir,
+  mockCp,
+  mockRename,
+  mockRm,
+} = vi.hoisted(() => ({
+  mockExistsSync: vi.fn(),
+  mockGitWithInstallationAuth: vi.fn(),
+  mockReaddir: vi.fn(),
+  mockCp: vi.fn(),
+  mockRename: vi.fn(),
+  mockRm: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({ existsSync: mockExistsSync }));
+vi.mock("node:fs/promises", () => ({
+  readdir: mockReaddir,
+  cp: mockCp,
+  rename: mockRename,
+  rm: mockRm,
+}));
+vi.mock("@/server/git-auth", () => ({
+  gitWithInstallationAuth: mockGitWithInstallationAuth,
+}));
+vi.mock("@/server/observability", () => ({ reportSilentFallback: vi.fn() }));
+vi.mock("@/server/logger", () => ({
+  createChildLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { realGraftRepoClone } from "@/server/ensure-workspace-repo";
+
+const WS = "/workspaces/ws-uuid";
+const REPO = "https://github.com/acme/widget";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGitWithInstallationAuth.mockResolvedValue(undefined);
+  mockReaddir.mockResolvedValue([".git", "knowledge-base"]);
+  mockCp.mockResolvedValue(undefined);
+  mockRename.mockResolvedValue(undefined);
+  mockRm.mockResolvedValue(undefined);
+});
+
+describe("realGraftRepoClone concurrency hardening", () => {
+  it("clones into a UNIQUE per-attempt temp dir (not the fixed .ensure-repo-tmp)", async () => {
+    mockExistsSync.mockReturnValue(false);
+    await realGraftRepoClone(WS, REPO, 123);
+
+    const cloneArgv = mockGitWithInstallationAuth.mock.calls[0][0] as string[];
+    const tmpArg = cloneArgv[cloneArgv.length - 1];
+    // Unique suffix: `<ws>/.ensure-repo-tmp-<uuid>`, never the bare shared name.
+    expect(tmpArg).toMatch(
+      /\/\.ensure-repo-tmp-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(tmpArg).not.toBe(`${WS}/.ensure-repo-tmp`);
+  });
+
+  it("two concurrent grafts use DISTINCT temp dirs", async () => {
+    mockExistsSync.mockReturnValue(false);
+    await Promise.all([
+      realGraftRepoClone(WS, REPO, 123),
+      realGraftRepoClone(WS, REPO, 123),
+    ]);
+    const tmpA = (mockGitWithInstallationAuth.mock.calls[0][0] as string[]).at(-1);
+    const tmpB = (mockGitWithInstallationAuth.mock.calls[1][0] as string[]).at(-1);
+    expect(tmpA).not.toBe(tmpB);
+  });
+
+  it("skips the .git rename when a concurrent attempt grafted first (no ENOTEMPTY)", async () => {
+    // `.git` is absent at the top-level guard but APPEARS by the pre-move
+    // re-check (the winning concurrent attempt grafted while this one cloned).
+    mockExistsSync.mockReturnValue(true);
+    await realGraftRepoClone(WS, REPO, 123);
+    expect(mockRename).not.toHaveBeenCalled();
+    // The loser still cleans up its own unique temp dir.
+    expect(mockRm).toHaveBeenCalledTimes(1);
+  });
+
+  it("moves .git last when no concurrent winner exists", async () => {
+    mockExistsSync.mockReturnValue(false);
+    await realGraftRepoClone(WS, REPO, 123);
+    expect(mockRename).toHaveBeenCalledTimes(1);
+    const [src, dest] = mockRename.mock.calls[0];
+    expect(src).toMatch(/\/\.ensure-repo-tmp-.+\/\.git$/);
+    expect(dest).toBe(`${WS}/.git`);
+  });
+
+  it("cleans up the temp dir even when the clone fails", async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockGitWithInstallationAuth.mockRejectedValueOnce(new Error("clone boom"));
+    await expect(realGraftRepoClone(WS, REPO, 123)).rejects.toThrow("clone boom");
+    expect(mockRm).toHaveBeenCalledTimes(1);
+    expect(mockRename).not.toHaveBeenCalled();
+  });
+});

--- a/knowledge-base/project/learnings/2026-06-04-partial-convergence-sibling-gate-mismatch-is-pr-introduced.md
+++ b/knowledge-base/project/learnings/2026-06-04-partial-convergence-sibling-gate-mismatch-is-pr-introduced.md
@@ -1,0 +1,49 @@
+# Learning: partial source-convergence leaves a pr-introduced sibling-gate mismatch
+
+## Problem
+
+PR #4921 converged the leader agent's `workspacePath` from the legacy
+`users.workspace_path` column to the ACTIVE workspace (`resolveActiveWorkspacePath`,
+ADR-044) — mirroring #4910's Concierge half. The change moved ONE read (the path)
+to the new source but left a SIBLING gate on the legacy source: `syncPull`/`syncPush`
+in `agent-runner.ts` were still gated on the caller's solo `users.repo_status`.
+
+The plan framed `repo_status` as "still legacy, tracked separately (out of scope)".
+That framing was wrong. **Five orthogonal review agents** (data-integrity,
+architecture, code-quality, user-impact, agent-native) independently flagged it: for
+an invited member whose solo `repo_status` is null/`not_connected` but whose ACTIVE
+(shared) workspace IS connected, the gate evaluated false → the leader's edits were
+never pulled from / pushed to the shared remote. A silent write-loss window on shared
+content — the exact #4543 divergence the path convergence fixes, re-created one branch
+away.
+
+## Insight
+
+When a PR re-sources read A (path) to a new source of truth but leaves sibling gate B
+(repo_status, an installation flag, a status enum) reading the OLD source, the
+path/gate **grain mismatch is pr-introduced**, NOT a pre-existing scope-out — even
+though gate B's code is untouched. Before the PR both reads were solo-keyed and
+consistent (the skip was harmless); the PR creates the divergent state where they
+disagree. Per `rf-review-finding-default-fix-inline`'s pr-introduced rule, this MUST
+be fixed inline, not deferred.
+
+Mechanical test: did this PR move read A to a source that read B does not also read?
+If yes, B is now mis-keyed relative to A and the PR owns the fix.
+
+## Fix
+
+Don't re-derive gate B on the new source (extra query, more coupling). Prefer to
+**drop the redundant outer gate** when the gated operation already self-guards on the
+correct grain. `syncPull`/`syncPush` already check `hasRemote(workspacePath)` +
+`resolveInstallationId(userId)` (active-workspace installation) + (push)
+`hasLocalCommits` — so the outer `repo_status === "ready"` filter was redundant AND
+mis-keyed. Removing it lets the operation's own guards (keyed on the converged path)
+decide, and removes the dual-grain read entirely.
+
+## Reusable rule
+
+A "documented out-of-scope, tracked separately" note in a plan does not make a
+finding pre-existing. If the diff is the surface that introduces the divergence
+between two related reads, it is pr-introduced — fix it in the same PR or reduce the
+PR's scope. Multi-agent review reliably surfaces this when the spawn prompt names the
+two reads and asks "do they resolve from the same source post-diff?".


### PR DESCRIPTION
## Summary

Two follow-ups to the Concierge workspace-plumbing line (#4868 / #4890 / #4910), both diagnosed from the founder's in-app "No Git repository found" / "the document didn't come through" reports. No GitHub issue.

### 1. Leader/agent-runner active-workspace convergence — the #4910 leader half

#4910 converged the **Concierge** doc resolver + agent cwd onto the ACTIVE workspace (`resolveActiveWorkspacePath`) but **explicitly scoped out** the **leader** path. `agent-runner.ts:startAgentSession` still set `workspacePath = users.workspace_path` (the legacy column), which is stale/empty for invited members and for users provisioned after the ADR-044 `users → workspaces` relocation (#4559). That pointed the leader's **agent cwd, KB root, doc resolver, vision, and sync** at a dir that diverged from the UI KB file tree (`resolveActiveWorkspaceKbRoot`) and from the now-converged Concierge — the same agent-native parity break, leader side.

Now resolves via `resolveActiveWorkspacePath(userId, sessionTenant)`, which fails closed to the SOLO workspace (never a sibling), always returns a path, and matches the UI's resolution exactly. The provisioning guard now keys only on the `users` row existing (the empty-column case is no longer a false "not provisioned").

**Out of scope (tracked):** `user.repo_status` (the `syncPull` gate) is still the legacy column — repo state relocated to `workspaces` under ADR-044; converging that gate belongs to the git-workspace-plumbing scope, consistent with #4910's scope note.

### 2. ensure-workspace-repo clone-race hardening — #4890 follow-up

`realGraftRepoClone` used a fixed `.ensure-repo-tmp`. Two concurrent cold dispatches for the **same** user (two tabs / a rapid re-open) could collide: one attempt's cleanup `rm` nuking the other's in-flight clone, and the cp/rename interleaving. Now each attempt uses a unique `randomUUID`-suffixed temp dir, and the `.git` sentinel move is guarded by a pre-move re-check so the loser no-ops instead of `rename`-ing onto the winner's populated `.git` (ENOTEMPTY → spurious Sentry mirror).

## User-Brand Impact

- **Artifact / vector:** the leader agent's working directory + KB root (vector: cross-tenant — pointing at another user's workspace [mitigated: `resolveActiveWorkspacePath` is membership-checked via the ADR-044 RPC + `.eq("user_id", userId)` self-scoped reads, fails closed to the caller's SOLO workspace, NEVER a sibling]; data-blindness — agent operating in the wrong/empty dir [the bug this fixes]). The ensure-repo graft (vector: half-graft / clone clobber under same-user concurrency [mitigated: unique per-attempt temp dir + `.git`-last sentinel + pre-move re-check; the existing "never touch an existing `.git`" guard is unchanged]).
- **Brand-survival threshold:** single-user incident — one user's leader agent reading/writing another user's workspace would be an unrecoverable trust breach. The convergence routes exclusively through the fail-closed-to-solo membership resolver (same one #4910 shipped under `user-impact-reviewer` + `security-sentinel` sign-off); the clone-race fix only narrows an existing same-user concurrency window and cannot widen tenancy.

## Changelog

### Web Platform
- The leader (CPO/advisor) chat now operates in your ACTIVE workspace — same as the file tree and the Concierge — so invited members and recently-provisioned users no longer get a leader that can't see their files.
- The Concierge repo self-heal is now safe under concurrent conversations (two tabs / rapid re-open) — no clobbered or half-grafted clones.

## Test plan

- [x] New `agent-runner-leader-active-workspace-parity.test.ts`: leader SDK `cwd` is the ACTIVE workspace dir, not the legacy solo column (RED on `main`, GREEN after).
- [x] New `ensure-workspace-repo-graft-race.test.ts`: unique per-attempt temp dir, distinct dirs across concurrent grafts, pre-move `.git` re-check skips the rename, cleanup on clone failure.
- [x] Repointed `agent-runner-system-prompt.test.ts` to the `resolveActiveWorkspacePath` seam (mirrors #4910's Concierge repoint); rewrote `kb-share-preview` test 33 as a convergence regression guard (a null legacy column no longer blocks tool wiring).
- [x] All 30 `startAgentSession` consumer suites green (239 tests).
- [x] Full `vitest run`: **8493 passed / 0 failed** (227 skipped); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
