### PR TITLE
fix(flags): add c4-visualizer to flip.sh known-flags map

### DIFF
--- a/plugins/soleur/skills/flag-set-role/scripts/flip.sh
+++ b/plugins/soleur/skills/flag-set-role/scripts/flip.sh
@@ -51,6 +51,7 @@ declare -A FLAG_ENV_VARS=(
   ["kb-chat-sidebar"]="FLAG_KB_CHAT_SIDEBAR"
   ["team-workspace-invite"]="FLAG_TEAM_WORKSPACE_INVITE"
   ["byok-delegations"]="FLAG_BYOK_DELEGATIONS"
+  ["c4-visualizer"]="FLAG_C4_VISUALIZER"
 )
 
 # --- arg parsing ------------------------------------------------------------


### PR DESCRIPTION
## What

Adds `["c4-visualizer"]="FLAG_C4_VISUALIZER"` to the `FLAG_ENV_VARS` map in `plugins/soleur/skills/flag-set-role/scripts/flip.sh`.

## Why

PR #4883 wired `c4-visualizer` into `RUNTIME_FLAGS` (`apps/web-platform/lib/feature-flags/server.ts`) and `.env.example`, but the `flag-set-role` operator script keeps its own parallel known-flags map that was not updated. As a result `soleur:flag-set-role c4-visualizer dev on` rejected the flag as `unknown flag`, blocking the approved Flagsmith-mutation path for rolling the visualizer out to the dev cohort.

Verified via `flip.sh c4-visualizer dev on --dry-run`: resolves `feature_id=212597`, segments `role-dev`/`role-prd`, no mutation.

## Changelog

- fix: `soleur:flag-set-role` now recognizes the `c4-visualizer` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)