### PR TITLE
fix(kb): c4 project route reads active workspace, not caller's own (ADR-044)

### DIFF
--- a/apps/web-platform/app/api/kb/c4/project/route.ts
+++ b/apps/web-platform/app/api/kb/c4/project/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import path from "path";
 import { promises as fs, constants as fsConstants } from "node:fs";
-import { createClient } from "@/lib/supabase/server";
-import { resolveUserKbRoot } from "@/server/kb-route-helpers";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { resolveActiveWorkspaceKbRoot } from "@/server/workspace-resolver";
 import { isPathInWorkspace } from "@/server/sandbox";
 import { renameUserIdToHash } from "@/server/userid-pseudonymize";
 import { C4_DIAGRAMS_DIR, C4_SOURCE_EXT, C4_MODEL_JSON } from "@/lib/c4-constants";
@@ -33,9 +33,19 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const resolved = await resolveUserKbRoot(user.id);
-  if (!resolved.ok) return resolved.response;
-  const { kbRoot } = resolved;
+  // ADR-044 (#4543): the KB (and its C4 diagrams) live on the ACTIVE
+  // workspace, not the caller's own `users` row — an invited member viewing a
+  // shared workspace has an empty solo row. Mirror the tree/content READ paths
+  // so the visualizer reads the same clone the sidebar renders from; reading
+  // the caller's own root here surfaced as a spurious "Diagram model not built".
+  const serviceClient = createServiceClient();
+  const access = await resolveActiveWorkspaceKbRoot(user.id, serviceClient);
+  if (!access.ok) {
+    return access.status === 404
+      ? NextResponse.json({ error: "Workspace not found" }, { status: 404 })
+      : NextResponse.json({ error: "Workspace not ready" }, { status: 503 });
+  }
+  const { kbRoot } = access;
 
   const requestedDir =
     new URL(request.url).searchParams.get("dir") || C4_DIAGRAMS_DIR;


### PR DESCRIPTION
## Problem

The LikeC4 visualizer rendered **"Diagram model not built. Run `/soleur:architecture render` to generate it."** even though `model.likec4.json` is committed and visible in the KB sidebar.

## Root cause

`GET /api/kb/c4/project` resolved the **caller's own** `users`-row workspace via `resolveUserKbRoot(user.id)`. But the KB tree (`/api/kb/tree`) and content (`/api/kb/content`) read paths use `resolveActiveWorkspaceKbRoot` (ADR-044 / #4543): the KB lives on the **active** workspace, not the caller's own row. For a member viewing a shared/team workspace, their own row is an empty solo clone with no `model.likec4.json` → `fs.open` ENOENT → the `MODEL_NOT_BUILT` 404 branch. The sidebar showed the file because `buildTree` reads the active-workspace root; the c4 route read a different (own) root.

## Fix

Switch the GET route to `resolveActiveWorkspaceKbRoot(user.id, serviceClient)`, mirroring the tree/content read paths, so the diagram reads the same clone the sidebar and document render from.

The write path (`PUT /api/kb/c4/[...path]` → `c4-writer`) intentionally stays on the caller's-own resolver — consistent with the existing `kb/upload` GitHub-committing mutation, which ADR-044 left on `resolveUserKbRoot`.

Verified: `tsc --noEmit` clean (Node 22.22.3).

## Changelog

- fix: C4 visualizer now reads the active workspace's model, fixing a spurious "Diagram model not built" for members of shared workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)