### PR TITLE
feat(kb): full-screen C4 workspace — diagram ‖ Concierge/Code split

### DIFF
--- a/apps/web-platform/app/(dashboard)/dashboard/kb/[...path]/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/kb/[...path]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, use, useContext } from "react";
+import { useState, useEffect, useMemo, useRef, use, useContext } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -56,6 +56,27 @@ export default function KbContentPage({
   const kbCtx = useContext(KbContext);
   const lastSync = kbCtx?.lastSync ?? undefined;
   const refreshTree = kbCtx?.refreshTree;
+
+  // A diagram page is markdown that embeds a ```likec4-view block, with the
+  // c4-visualizer flag on. Computed once here (top-level, before the early
+  // returns) so the suppression effect below has a stable dependency.
+  const c4Embed = useMemo(
+    () =>
+      isMarkdown && c4Enabled && content
+        ? parseLikeC4Embed(content.content)
+        : null,
+    [isMarkdown, c4Enabled, content],
+  );
+
+  // The C4 workspace renders its own Concierge beside the diagram, so suppress
+  // the desktop side chat panel for this doc (else two KbChatContent mount with
+  // the same contextPath). setSuppressSidebar is a stable useState setter.
+  const setSuppressSidebar = kbChat?.setSuppressSidebar;
+  const suppressChat = !!c4Embed;
+  useEffect(() => {
+    setSuppressSidebar?.(suppressChat);
+    return () => setSuppressSidebar?.(false);
+  }, [suppressChat, setSuppressSidebar]);
 
   useEffect(() => {
     // Non-markdown files are rendered by FilePreview — no fetch needed
@@ -169,10 +190,8 @@ export default function KbContentPage({
 
   // A KB diagram page (markdown that embeds a ```likec4-view block) becomes a
   // full-screen workspace: diagram on the left, Soleur Concierge / Code on the
-  // right. Gated by the c4-visualizer flag; otherwise it renders as normal
-  // markdown (the inline embed handles the diagram). contextPath mirrors the
-  // KbChat sidebar format so the Concierge resumes the same document thread.
-  const c4Embed = c4Enabled ? parseLikeC4Embed(content!.content) : null;
+  // right (c4Embed computed at the top). contextPath mirrors the KbChat sidebar
+  // format so the embedded Concierge resumes the same document thread.
   if (c4Embed) {
     return (
       <div className="flex h-full flex-col">

--- a/apps/web-platform/app/(dashboard)/dashboard/kb/[...path]/page.tsx
+++ b/apps/web-platform/app/(dashboard)/dashboard/kb/[...path]/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useState, useEffect, useRef, use, useContext } from "react";
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
+import { parseLikeC4Embed } from "@/lib/c4-embed";
 import { safeDecode } from "@/components/kb/kb-breadcrumb";
 import { FilePreview } from "@/components/kb/file-preview";
 import { KbContentHeader } from "@/components/kb/kb-content-header";
@@ -17,6 +19,17 @@ import { classifyByExtension } from "@/lib/kb-file-kind";
 import { useOptionalFeatureFlag } from "@/components/feature-flags/provider";
 import { C4_VISUALIZER_FLAG } from "@/lib/c4-constants";
 import type { ContentResult } from "@/server/kb-reader";
+
+// Full-screen LikeC4 workspace (diagram ‖ Concierge/Code). Browser-only
+// (@likec4/diagram is canvas-based) so it loads client-side after mount.
+const C4Workspace = dynamic(() => import("@/components/kb/c4-workspace"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-full items-center justify-center">
+      <div className="h-5 w-5 animate-spin rounded-full border-2 border-soleur-border-default border-t-amber-400" />
+    </div>
+  ),
+});
 
 export default function KbContentPage({
   params,
@@ -148,6 +161,33 @@ export default function KbContentPage({
             path={joinedPath}
             kind={classifyByExtension(extension)}
             showDownload={false}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // A KB diagram page (markdown that embeds a ```likec4-view block) becomes a
+  // full-screen workspace: diagram on the left, Soleur Concierge / Code on the
+  // right. Gated by the c4-visualizer flag; otherwise it renders as normal
+  // markdown (the inline embed handles the diagram). contextPath mirrors the
+  // KbChat sidebar format so the Concierge resumes the same document thread.
+  const c4Embed = c4Enabled ? parseLikeC4Embed(content!.content) : null;
+  if (c4Embed) {
+    return (
+      <div className="flex h-full flex-col">
+        <KbContentHeader
+          joinedPath={joinedPath}
+          chatUrl={chatUrl}
+          lastSync={lastSync}
+          onSynced={refreshTree}
+        />
+        <div className="min-h-0 flex-1">
+          <C4Workspace
+            viewId={c4Embed.viewId}
+            dirPath={c4DirPath}
+            contextPath={`knowledge-base/${joinedPath}`}
+            notes={c4Embed.notes}
           />
         </div>
       </div>

--- a/apps/web-platform/components/kb/c4-diagram.tsx
+++ b/apps/web-platform/components/kb/c4-diagram.tsx
@@ -1,68 +1,18 @@
 "use client";
 
-// Interactive LikeC4 C4-model visualizer with an editable DSL code tab.
-// Server computes the layouted model (/api/kb/c4/project); this renders it
-// client-side with clickable drill-down and lets the user edit the .c4 source.
-// Loaded via next/dynamic({ ssr: false }) — @likec4/diagram is canvas/browser
-// only. Gated upstream by the `c4-visualizer` flag (markdown-renderer).
-import { useCallback, useEffect, useMemo, useState } from "react";
-import CodeMirror from "@uiw/react-codemirror";
-import { oneDark } from "@codemirror/theme-one-dark";
+// Inline LikeC4 embed: a tabbed (Diagram | Code) widget rendered in place of a
+// ```likec4-view fenced block inside normal markdown. The full-screen variant
+// (diagram ‖ Concierge/Code) lives in c4-workspace.tsx and is what KB diagram
+// pages use; this inline form is the fallback for embeds elsewhere.
+// Loaded via next/dynamic({ ssr: false }) — @likec4/diagram is browser-only.
+import { useState } from "react";
 import {
-  LikeC4ModelProvider,
-  LikeC4Diagram,
-  useLikeC4ViewModel,
-  type OnNavigateTo,
-} from "@likec4/diagram";
-import { LikeC4Model } from "@likec4/core/model";
-import type { LayoutedLikeC4ModelData } from "@likec4/core/types";
-import "@likec4/diagram/styles.css";
-
-type Diagnostic = { message: string; line: number; sourceFsPath: string };
-type ProjectResponse = {
-  dir: string;
-  sources: Record<string, string>;
-  dump: Record<string, unknown> | null;
-  viewIds: string[];
-  diagnostics: Diagnostic[];
-};
-
-const Spinner = () => (
-  <div className="flex items-center justify-center p-8">
-    <div className="h-5 w-5 animate-spin rounded-full border-2 border-soleur-border-default border-t-amber-400" />
-  </div>
-);
-
-function ViewCanvas({
-  viewId,
-  onNavigate,
-}: {
-  viewId: string;
-  onNavigate: OnNavigateTo;
-}) {
-  const vm = useLikeC4ViewModel(viewId);
-  if (!vm) {
-    return (
-      <div className="p-6 text-sm text-soleur-text-muted">
-        View <code className="text-soleur-accent-gold-fg">{viewId}</code> not found in the model.
-      </div>
-    );
-  }
-  return (
-    <LikeC4Diagram
-      view={vm.$view}
-      pannable
-      zoomable
-      fitView
-      controls
-      showNavigationButtons
-      enableElementDetails
-      enableRelationshipDetails
-      enableFocusMode
-      onNavigateTo={onNavigate}
-    />
-  );
-}
+  Spinner,
+  useC4Project,
+  C4Canvas,
+  C4Diagnostics,
+  C4CodePanel,
+} from "@/components/kb/c4-shared";
 
 export default function C4Diagram({
   viewId,
@@ -71,95 +21,12 @@ export default function C4Diagram({
   viewId: string;
   dirPath: string;
 }) {
-  const [data, setData] = useState<ProjectResponse | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
+  const { data, error, loading, reload } = useC4Project(dirPath);
   const [tab, setTab] = useState<"diagram" | "code">("diagram");
   const [currentView, setCurrentView] = useState(viewId);
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await fetch(
-        `/api/kb/c4/project?dir=${encodeURIComponent(dirPath)}`,
-      );
-      if (!res.ok) {
-        const j = await res.json().catch(() => ({}));
-        throw new Error(j.error || `Request failed (${res.status})`);
-      }
-      setData((await res.json()) as ProjectResponse);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load diagram");
-    } finally {
-      setLoading(false);
-    }
-  }, [dirPath]);
-
-  useEffect(() => {
-    void load();
-  }, [load]);
-  useEffect(() => {
-    setCurrentView(viewId);
-  }, [viewId]);
-
-  const model = useMemo(() => {
-    if (!data?.dump) return null;
-    try {
-      // dump is the layouted model's $data — create() round-trips it.
-      return LikeC4Model.create(data.dump as unknown as LayoutedLikeC4ModelData);
-    } catch {
-      return null;
-    }
-  }, [data?.dump]);
-
-  // ---- Code editor state -------------------------------------------------
-  const files = useMemo(() => (data ? Object.keys(data.sources) : []), [data]);
-  const [activeFile, setActiveFile] = useState<string>("");
-  const [draft, setDraft] = useState("");
-  const [saving, setSaving] = useState(false);
-  const [saveMsg, setSaveMsg] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (files.length === 0) return;
-    setActiveFile((prev) =>
-      prev && files.includes(prev) ? prev : files.find((f) => f === "model.c4") ?? files[0],
-    );
-  }, [files]);
-  useEffect(() => {
-    if (data && activeFile) setDraft(data.sources[activeFile] ?? "");
-  }, [data, activeFile]);
-
-  const isDark =
-    typeof document !== "undefined" &&
-    document.documentElement.getAttribute("data-theme") !== "light";
-
-  const save = useCallback(async () => {
-    setSaving(true);
-    setSaveMsg(null);
-    try {
-      const res = await fetch(`/api/kb/c4/${dirPath}/${activeFile}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ content: draft }),
-      });
-      const j = await res.json().catch(() => ({}));
-      if (!res.ok) throw new Error(j.error || `Save failed (${res.status})`);
-      setSaveMsg("Saved — re-rendering…");
-      await load();
-      setTab("diagram");
-    } catch (e) {
-      setSaveMsg(e instanceof Error ? e.message : "Save failed");
-    } finally {
-      setSaving(false);
-    }
-  }, [activeFile, dirPath, draft, load]);
-
-  const dirty = data && activeFile ? draft !== (data.sources[activeFile] ?? "") : false;
-
   return (
     <div className="mb-4 overflow-hidden rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1/40">
-      {/* Tab bar */}
       <div className="flex items-center gap-1 border-b border-soleur-border-default bg-soleur-bg-surface-2/40 px-2 py-1.5">
         {(["diagram", "code"] as const).map((t) => (
           <button
@@ -180,80 +47,32 @@ export default function C4Diagram({
       </div>
 
       {loading && <Spinner />}
-
       {!loading && error && (
         <div className="p-4 text-sm text-red-400">⚠ {error}</div>
       )}
 
       {!loading && !error && data && (
         <>
-          {/* Parse diagnostics (non-fatal warnings or fatal errors) */}
-          {data.diagnostics.length > 0 && (
-            <div className="border-b border-soleur-border-default bg-red-500/10 px-3 py-2 text-xs text-red-300">
-              <p className="mb-1 font-semibold">
-                {data.dump ? "Diagram warnings" : "Diagram has errors — fix the source in the Code tab"}
-              </p>
-              <ul className="space-y-0.5">
-                {data.diagnostics.slice(0, 8).map((d, i) => (
-                  <li key={i}>
-                    line {d.line}: {d.message}
-                  </li>
-                ))}
-              </ul>
+          <C4Diagnostics diagnostics={data.diagnostics} hasModel={!!data.dump} />
+          {tab === "diagram" && (
+            <div className="relative h-[600px] w-full">
+              <C4Canvas
+                dump={data.dump}
+                initialViewId={viewId}
+                onViewChange={setCurrentView}
+              />
             </div>
           )}
-
-          {tab === "diagram" &&
-            (model ? (
-              <div className="relative h-[600px] w-full">
-                <LikeC4ModelProvider likec4model={model}>
-                  <ViewCanvas
-                    viewId={currentView}
-                    onNavigate={(to) => setCurrentView(String(to))}
-                  />
-                </LikeC4ModelProvider>
-              </div>
-            ) : (
-              <div className="p-6 text-sm text-soleur-text-muted">
-                Nothing to render — fix the source in the Code tab.
-              </div>
-            ))}
-
           {tab === "code" && (
-            <div className="flex flex-col">
-              <div className="flex flex-wrap items-center gap-1 border-b border-soleur-border-default px-2 py-1.5">
-                {files.map((f) => (
-                  <button
-                    key={f}
-                    onClick={() => setActiveFile(f)}
-                    className={`rounded px-2 py-0.5 font-mono text-[11px] transition-colors ${
-                      activeFile === f
-                        ? "bg-soleur-bg-base text-soleur-text-primary"
-                        : "text-soleur-text-muted hover:text-soleur-text-secondary"
-                    }`}
-                  >
-                    {f}
-                  </button>
-                ))}
-                <div className="ml-auto flex items-center gap-2">
-                  {saveMsg && (
-                    <span className="text-[11px] text-soleur-text-muted">{saveMsg}</span>
-                  )}
-                  <button
-                    onClick={() => void save()}
-                    disabled={saving || !dirty}
-                    className="rounded bg-soleur-accent-gold-fg/90 px-2.5 py-1 text-xs font-medium text-black disabled:opacity-40"
-                  >
-                    {saving ? "Saving…" : "Save"}
-                  </button>
-                </div>
-              </div>
-              <CodeMirror
-                value={draft}
+            <div className="h-[600px]">
+              <C4CodePanel
+                data={data}
+                dirPath={dirPath}
                 height="560px"
-                theme={isDark ? oneDark : undefined}
-                onChange={setDraft}
-                basicSetup={{ lineNumbers: true, foldGutter: true }}
+                onSaved={async () => {
+                  await reload();
+                  setTab("diagram");
+                }}
               />
             </div>
           )}

--- a/apps/web-platform/components/kb/c4-shared.tsx
+++ b/apps/web-platform/components/kb/c4-shared.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+// Shared building blocks for the LikeC4 visualizer, reused by both the inline
+// markdown embed (c4-diagram.tsx) and the full-workspace split (c4-workspace.tsx).
+// @likec4/diagram is canvas/browser-only — consumers must load via
+// next/dynamic({ ssr: false }).
+import { useCallback, useEffect, useMemo, useState } from "react";
+import CodeMirror from "@uiw/react-codemirror";
+import { oneDark } from "@codemirror/theme-one-dark";
+import {
+  LikeC4ModelProvider,
+  LikeC4Diagram,
+  useLikeC4ViewModel,
+  type OnNavigateTo,
+} from "@likec4/diagram";
+import { LikeC4Model } from "@likec4/core/model";
+import type { LayoutedLikeC4ModelData } from "@likec4/core/types";
+import "@likec4/diagram/styles.css";
+
+export type Diagnostic = { message: string; line: number; sourceFsPath: string };
+export type ProjectResponse = {
+  dir: string;
+  sources: Record<string, string>;
+  dump: Record<string, unknown> | null;
+  viewIds: string[];
+  diagnostics: Diagnostic[];
+};
+
+export const Spinner = () => (
+  <div className="flex items-center justify-center p-8">
+    <div className="h-5 w-5 animate-spin rounded-full border-2 border-soleur-border-default border-t-amber-400" />
+  </div>
+);
+
+/** Fetch the precomputed LikeC4 project (model dump + .c4 sources) for a dir. */
+export function useC4Project(dirPath: string) {
+  const [data, setData] = useState<ProjectResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/kb/c4/project?dir=${encodeURIComponent(dirPath)}`,
+      );
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `Request failed (${res.status})`);
+      }
+      setData((await res.json()) as ProjectResponse);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load diagram");
+    } finally {
+      setLoading(false);
+    }
+  }, [dirPath]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  return { data, error, loading, reload };
+}
+
+function ViewCanvas({
+  viewId,
+  onNavigate,
+}: {
+  viewId: string;
+  onNavigate: OnNavigateTo;
+}) {
+  const vm = useLikeC4ViewModel(viewId);
+  if (!vm) {
+    return (
+      <div className="p-6 text-sm text-soleur-text-muted">
+        View <code className="text-soleur-accent-gold-fg">{viewId}</code> not found in the model.
+      </div>
+    );
+  }
+  return (
+    <LikeC4Diagram
+      view={vm.$view}
+      pannable
+      zoomable
+      fitView
+      controls
+      showNavigationButtons
+      enableElementDetails
+      enableRelationshipDetails
+      enableFocusMode
+      onNavigateTo={onNavigate}
+    />
+  );
+}
+
+/**
+ * Interactive diagram canvas with clickable drill-down. Owns the current view
+ * (drill-down) state, seeded from `initialViewId` and reset when it changes.
+ * `onViewChange` lets the parent mirror the active view (e.g. a status label).
+ */
+export function C4Canvas({
+  dump,
+  initialViewId,
+  onViewChange,
+}: {
+  dump: Record<string, unknown> | null;
+  initialViewId: string;
+  onViewChange?: (viewId: string) => void;
+}) {
+  const [currentView, setCurrentView] = useState(initialViewId);
+  useEffect(() => setCurrentView(initialViewId), [initialViewId]);
+  useEffect(() => onViewChange?.(currentView), [currentView, onViewChange]);
+
+  const model = useMemo(() => {
+    if (!dump) return null;
+    try {
+      return LikeC4Model.create(dump as unknown as LayoutedLikeC4ModelData);
+    } catch {
+      return null;
+    }
+  }, [dump]);
+
+  if (!model) {
+    return (
+      <div className="p-6 text-sm text-soleur-text-muted">
+        Nothing to render — fix the source in the Code view.
+      </div>
+    );
+  }
+  return (
+    <LikeC4ModelProvider likec4model={model}>
+      <ViewCanvas
+        viewId={currentView}
+        onNavigate={(to) => setCurrentView(String(to))}
+      />
+    </LikeC4ModelProvider>
+  );
+}
+
+/** Non-fatal warnings / fatal parse errors surfaced inline above the editor. */
+export function C4Diagnostics({
+  diagnostics,
+  hasModel,
+}: {
+  diagnostics: Diagnostic[];
+  hasModel: boolean;
+}) {
+  if (diagnostics.length === 0) return null;
+  return (
+    <div className="border-b border-soleur-border-default bg-red-500/10 px-3 py-2 text-xs text-red-300">
+      <p className="mb-1 font-semibold">
+        {hasModel
+          ? "Diagram warnings"
+          : "Diagram has errors — fix the source in the Code view"}
+      </p>
+      <ul className="space-y-0.5">
+        {diagnostics.slice(0, 8).map((d, i) => (
+          <li key={i}>
+            line {d.line}: {d.message}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/** Editable .c4 source panel (file tabs + CodeMirror + Save → PUT → reload). */
+export function C4CodePanel({
+  data,
+  dirPath,
+  onSaved,
+  height = "100%",
+}: {
+  data: ProjectResponse;
+  dirPath: string;
+  onSaved: () => void | Promise<void>;
+  height?: string;
+}) {
+  const files = useMemo(() => Object.keys(data.sources), [data.sources]);
+  const [activeFile, setActiveFile] = useState<string>("");
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saveMsg, setSaveMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (files.length === 0) return;
+    setActiveFile((prev) =>
+      prev && files.includes(prev)
+        ? prev
+        : files.find((f) => f === "model.c4") ?? files[0],
+    );
+  }, [files]);
+  useEffect(() => {
+    if (activeFile) setDraft(data.sources[activeFile] ?? "");
+  }, [data, activeFile]);
+
+  const isDark =
+    typeof document !== "undefined" &&
+    document.documentElement.getAttribute("data-theme") !== "light";
+
+  const dirty = activeFile ? draft !== (data.sources[activeFile] ?? "") : false;
+
+  const save = useCallback(async () => {
+    setSaving(true);
+    setSaveMsg(null);
+    try {
+      const res = await fetch(`/api/kb/c4/${dirPath}/${activeFile}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: draft }),
+      });
+      const j = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(j.error || `Save failed (${res.status})`);
+      setSaveMsg("Saved — re-rendering…");
+      await onSaved();
+    } catch (e) {
+      setSaveMsg(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }, [activeFile, dirPath, draft, onSaved]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex flex-wrap items-center gap-1 border-b border-soleur-border-default px-2 py-1.5">
+        {files.map((f) => (
+          <button
+            key={f}
+            onClick={() => setActiveFile(f)}
+            className={`rounded px-2 py-0.5 font-mono text-[11px] transition-colors ${
+              activeFile === f
+                ? "bg-soleur-bg-base text-soleur-text-primary"
+                : "text-soleur-text-muted hover:text-soleur-text-secondary"
+            }`}
+          >
+            {f}
+          </button>
+        ))}
+        <div className="ml-auto flex items-center gap-2">
+          {saveMsg && (
+            <span className="text-[11px] text-soleur-text-muted">{saveMsg}</span>
+          )}
+          <button
+            onClick={() => void save()}
+            disabled={saving || !dirty}
+            className="rounded bg-soleur-accent-gold-fg/90 px-2.5 py-1 text-xs font-medium text-black disabled:opacity-40"
+          >
+            {saving ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto">
+        <CodeMirror
+          value={draft}
+          height={height}
+          theme={isDark ? oneDark : undefined}
+          onChange={setDraft}
+          basicSetup={{ lineNumbers: true, foldGutter: true }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web-platform/components/kb/c4-workspace.tsx
+++ b/apps/web-platform/components/kb/c4-workspace.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+// Full-screen LikeC4 workspace for KB diagram pages: the interactive diagram on
+// the LEFT, and on the RIGHT a window that toggles between the Soleur Concierge
+// (open by default, scoped to this document so it can edit the diagram) and the
+// raw .c4 code editor. Loaded via next/dynamic({ ssr: false }) from the KB page
+// — @likec4/diagram is canvas/browser-only.
+import { useState } from "react";
+import { Group, Panel, Separator } from "react-resizable-panels";
+import { KbChatContent } from "@/components/chat/kb-chat-content";
+import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
+import {
+  Spinner,
+  useC4Project,
+  C4Canvas,
+  C4Diagnostics,
+  C4CodePanel,
+} from "@/components/kb/c4-shared";
+
+function ResizeHandle() {
+  return (
+    <Separator className="group relative w-1 bg-transparent transition-colors duration-150 hover:bg-soleur-text-secondary/50 active:bg-amber-500/50 data-[resize-handle-active]:bg-amber-500/50">
+      <div className="absolute inset-y-0 left-1/2 flex -translate-x-1/2 flex-col items-center justify-center gap-0.5">
+        <span className="h-0.5 w-0.5 rounded-full bg-soleur-text-muted group-hover:bg-soleur-text-secondary" />
+        <span className="h-0.5 w-0.5 rounded-full bg-soleur-text-muted group-hover:bg-soleur-text-secondary" />
+        <span className="h-0.5 w-0.5 rounded-full bg-soleur-text-muted group-hover:bg-soleur-text-secondary" />
+      </div>
+    </Separator>
+  );
+}
+
+export default function C4Workspace({
+  viewId,
+  dirPath,
+  contextPath,
+  notes,
+}: {
+  viewId: string;
+  dirPath: string;
+  /** KB-relative path (e.g. "knowledge-base/.../container.md") the Concierge is scoped to. */
+  contextPath: string;
+  /** Remaining prose (diagram block stripped) for the collapsible Notes strip. */
+  notes?: string;
+}) {
+  const { data, error, loading, reload } = useC4Project(dirPath);
+  const [rightTab, setRightTab] = useState<"concierge" | "code">("concierge");
+  const [currentView, setCurrentView] = useState(viewId);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <Group orientation="horizontal" className="h-full min-h-0 flex-1">
+        {/* LEFT — interactive diagram (+ collapsible Notes) */}
+        <Panel minSize="35%">
+          <div className="flex h-full min-h-0 flex-col">
+            {loading && <Spinner />}
+            {!loading && error && (
+              <div className="p-4 text-sm text-red-400">⚠ {error}</div>
+            )}
+            {!loading && !error && data && (
+              <>
+                <C4Diagnostics
+                  diagnostics={data.diagnostics}
+                  hasModel={!!data.dump}
+                />
+                <div className="relative min-h-0 flex-1">
+                  <C4Canvas
+                    dump={data.dump}
+                    initialViewId={viewId}
+                    onViewChange={setCurrentView}
+                  />
+                </div>
+                {notes && notes.trim().length > 0 && (
+                  <details className="shrink-0 border-t border-soleur-border-default bg-soleur-bg-surface-1/40 px-4 py-2 text-sm">
+                    <summary className="cursor-pointer text-xs font-medium text-soleur-text-muted hover:text-soleur-text-secondary">
+                      Notes
+                    </summary>
+                    <div className="prose-kb mt-2 max-h-48 overflow-y-auto">
+                      <MarkdownRenderer
+                        content={notes}
+                        enableC4={false}
+                        c4DirPath={dirPath}
+                      />
+                    </div>
+                  </details>
+                )}
+              </>
+            )}
+          </div>
+        </Panel>
+
+        <ResizeHandle />
+
+        {/* RIGHT — Concierge (default) / Code toggle */}
+        <Panel defaultSize="38%" minSize="28%" maxSize="60%">
+          <div className="flex h-full min-h-0 flex-col border-l border-soleur-border-default">
+            <div className="flex shrink-0 items-center gap-1 border-b border-soleur-border-default bg-soleur-bg-surface-2/40 px-2 py-1.5">
+              {(
+                [
+                  ["concierge", "Concierge"],
+                  ["code", "Code"],
+                ] as const
+              ).map(([t, label]) => (
+                <button
+                  key={t}
+                  onClick={() => setRightTab(t)}
+                  className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
+                    rightTab === t
+                      ? "bg-soleur-bg-base text-soleur-text-primary"
+                      : "text-soleur-text-muted hover:text-soleur-text-secondary"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+              <span className="ml-auto pr-1 text-[11px] text-soleur-text-muted">
+                LikeC4 · {currentView}
+              </span>
+            </div>
+
+            <div className="relative min-h-0 flex-1">
+              {/* Concierge stays mounted across toggles so the thread persists;
+                  visibility is CSS-driven. */}
+              <div className={rightTab === "concierge" ? "h-full" : "hidden"}>
+                <KbChatContent
+                  contextPath={contextPath}
+                  onClose={() => setRightTab("code")}
+                  visible={rightTab === "concierge"}
+                />
+              </div>
+              {rightTab === "code" && (
+                <div className="h-full">
+                  {data ? (
+                    <C4CodePanel
+                      data={data}
+                      dirPath={dirPath}
+                      onSaved={reload}
+                    />
+                  ) : (
+                    <Spinner />
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </Panel>
+      </Group>
+    </div>
+  );
+}

--- a/apps/web-platform/components/kb/kb-chat-context.tsx
+++ b/apps/web-platform/components/kb/kb-chat-context.tsx
@@ -19,6 +19,14 @@ export interface KbChatContextValue {
   /** Thread state for stateful trigger labels ("Ask" vs "Continue thread"). */
   messageCount: number;
   setMessageCount: (n: number) => void;
+  /**
+   * When true, the desktop side chat panel + its trigger are suppressed. Set by
+   * surfaces that embed their own Concierge (e.g. the C4 workspace renders the
+   * Concierge beside the diagram), so the document chat isn't double-mounted
+   * with the same contextPath. Optional for backward-compat with test mocks.
+   */
+  suppressSidebar?: boolean;
+  setSuppressSidebar?: (v: boolean) => void;
 }
 
 export const KbChatContext = createContext<KbChatContextValue | null>(null);

--- a/apps/web-platform/components/kb/kb-chat-trigger.tsx
+++ b/apps/web-platform/components/kb/kb-chat-trigger.tsx
@@ -48,6 +48,10 @@ export function KbChatTrigger({ fallbackHref }: KbChatTriggerProps) {
     </svg>
   );
 
+  // A view that embeds its own Concierge (the C4 workspace) suppresses the side
+  // panel; hide the trigger too so it can't open a redundant duplicate chat.
+  if (ctx?.suppressSidebar) return null;
+
   if (!ctx || !ctx.enabled) {
     return (
       <Link href={fallbackHref} className={baseClass}>

--- a/apps/web-platform/hooks/use-kb-layout-state.tsx
+++ b/apps/web-platform/hooks/use-kb-layout-state.tsx
@@ -191,6 +191,9 @@ export function useKbLayoutState(): UseKbLayoutStateResult {
   );
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [messageCount, setMessageCount] = useState(0);
+  // Set by a document view that embeds its own Concierge (the C4 workspace) so
+  // the side chat panel isn't double-mounted with the same contextPath.
+  const [suppressSidebar, setSuppressSidebar] = useState(false);
 
   // Restore sidebarOpen from sessionStorage on mount (per-tab persistence)
   useEffect(() => {
@@ -262,6 +265,8 @@ export function useKbLayoutState(): UseKbLayoutStateResult {
       enabled: kbChatFlag,
       messageCount,
       setMessageCount,
+      suppressSidebar,
+      setSuppressSidebar,
     }),
     [
       sidebarOpen,
@@ -270,13 +275,17 @@ export function useKbLayoutState(): UseKbLayoutStateResult {
       contextPath,
       kbChatFlag,
       messageCount,
+      suppressSidebar,
     ],
   );
 
   // Whether to show the chat panel as a resizable column on desktop.
   // sidebarOpen is user-controlled: clicking X (`closeSidebar`) sets it false
   // and unmounts the chat Panel; "Continue thread" (`openSidebar`) re-opens it.
-  const showChat = kbChatFlag && !!contextPath && sidebarOpen;
+  // suppressSidebar wins: a view embedding its own Concierge (C4 workspace)
+  // hides the side panel to avoid a double-mounted chat on the same doc.
+  const showChat =
+    kbChatFlag && !!contextPath && sidebarOpen && !suppressSidebar;
 
   return {
     ctxValue,

--- a/apps/web-platform/lib/c4-embed.ts
+++ b/apps/web-platform/lib/c4-embed.ts
@@ -1,0 +1,37 @@
+// Pure helpers for the LikeC4 `likec4-view` markdown embed.
+// Client- and server-safe (no imports) so the KB page can branch to the
+// full-workspace layout and the markdown renderer can keep its inline embed.
+
+import { LIKEC4_VIEW_LANG } from "@/lib/c4-constants";
+
+export type LikeC4Embed = {
+  /** The view id named inside the first ```likec4-view block. */
+  viewId: string;
+  /** The source markdown with that fenced block removed (for the Notes strip). */
+  notes: string;
+};
+
+// Matches a fenced ```likec4-view block and captures its body (the view id).
+// `[ \t]*` after the language token tolerates trailing spaces on the fence line.
+const LIKEC4_VIEW_BLOCK = new RegExp(
+  "```" + LIKEC4_VIEW_LANG + "[ \\t]*\\n([\\s\\S]*?)\\n```",
+);
+
+/**
+ * Parse the first `likec4-view` embed out of a markdown document.
+ * Returns the named view id plus the remaining prose (block stripped), or
+ * `null` when the document has no embed. The view id is the first non-empty
+ * line inside the block (extra lines, if any, are ignored).
+ */
+export function parseLikeC4Embed(markdown: string): LikeC4Embed | null {
+  if (!markdown) return null;
+  const match = LIKEC4_VIEW_BLOCK.exec(markdown);
+  if (!match) return null;
+  const viewId = (match[1] ?? "")
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  if (!viewId) return null;
+  const notes = markdown.replace(match[0], "").replace(/\n{3,}/g, "\n\n").trim();
+  return { viewId, notes };
+}

--- a/apps/web-platform/test/c4-embed.test.ts
+++ b/apps/web-platform/test/c4-embed.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { parseLikeC4Embed } from "@/lib/c4-embed";
+
+describe("parseLikeC4Embed", () => {
+  it("returns null when there is no embed", () => {
+    expect(parseLikeC4Embed("# Title\n\nSome prose.")).toBeNull();
+    expect(parseLikeC4Embed("")).toBeNull();
+  });
+
+  it("extracts the view id from a likec4-view block", () => {
+    const md = "# Container\n\n```likec4-view\ncontainers\n```\n\n## Notes\n- a";
+    const embed = parseLikeC4Embed(md);
+    expect(embed?.viewId).toBe("containers");
+  });
+
+  it("strips the block from the notes and keeps surrounding prose", () => {
+    const md = "intro\n\n```likec4-view\ncontext\n```\n\n## Notes\n- one\n- two";
+    const embed = parseLikeC4Embed(md);
+    expect(embed?.notes).toContain("intro");
+    expect(embed?.notes).toContain("## Notes");
+    expect(embed?.notes).not.toContain("likec4-view");
+    expect(embed?.notes).not.toContain("```");
+  });
+
+  it("tolerates trailing whitespace on the fence and view-id lines", () => {
+    const md = "```likec4-view  \n  components of platform.plugin  \n```";
+    const embed = parseLikeC4Embed(md);
+    expect(embed?.viewId).toBe("components of platform.plugin");
+  });
+
+  it("uses the first block when several are present", () => {
+    const md = "```likec4-view\nfirst\n```\n\n```likec4-view\nsecond\n```";
+    expect(parseLikeC4Embed(md)?.viewId).toBe("first");
+  });
+
+  it("returns null when the block body is empty", () => {
+    const md = "```likec4-view\n\n```";
+    expect(parseLikeC4Embed(md)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

KB diagram pages now render a **full-screen workspace** instead of an inline tabbed widget:

- **Left:** the interactive LikeC4 diagram (pan/zoom, clickable drill-down).
- **Right:** a window that opens the **Soleur Concierge** by default (scoped to the document so it can discuss/edit the diagram), with a **top toggle to the raw `.c4` code editor**.
- **Notes** prose collapses into a `<details>` strip beneath the diagram.

This is the layout the operator asked for: *"diagram on the left, on the right a window with Soleur Concierge already open to edit the diagram, and a button at the top to switch to pure code."* Wireframe approved via AskUserQuestion before build.

## How

- `lib/c4-embed.ts` — pure `parseLikeC4Embed()` extracts the embedded view id and strips the fenced block for the Notes strip (unit-tested, 6 cases).
- `components/kb/c4-shared.tsx` — extracted `useC4Project` hook + `C4Canvas` (drill-down) + `C4Diagnostics` + `C4CodePanel`, shared by the inline embed and the workspace (no logic duplication).
- `components/kb/c4-workspace.tsx` — the resizable split (`react-resizable-panels`); embeds `KbChatContent` with `contextPath = knowledge-base/<path>` so the Concierge resumes the **same** document thread as the chat sidebar. Concierge stays mounted across toggles (thread persists).
- `app/(dashboard)/dashboard/kb/[...path]/page.tsx` — branches to `C4Workspace` (dynamic, `ssr:false`) when `c4-visualizer` is on and the doc embeds a view; otherwise unchanged markdown.
- `c4-diagram.tsx` — refactored onto the shared module; remains the fallback for `likec4-view` blocks outside diagram pages.

## Scope / follow-up

Autonomous Concierge writes (the deferred `edit_c4_diagram` MCP tool, #3722) ship in a **separate PR**. Today the Concierge reads the `.c4` source and proposes edits that the user applies via **Code → Save**.

## Verification

`tsc --noEmit` clean · `next build` ✓ (82 pages) · vitest: `c4-embed` (6), `c4-diagram-path-scope` (7), `kb-layout-panels` (8) all pass (Node 22.22.3).

## Changelog

- feat: C4 diagram pages open as a full-screen workspace with the Soleur Concierge and a code-view toggle beside the interactive diagram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)