### PR TITLE
fix(dashboard): move theme toggle to rail footer (D4 wireframe parity)

### DIFF
--- a/apps/web-platform/app/(dashboard)/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/layout.tsx
@@ -331,14 +331,6 @@ export default function DashboardLayout({
           </button>
         </div>
 
-        {/* Theme toggle — sidebar header (spec TR7). #4810 Bug 1: top-level
-            chrome, render-conditional on top level only (drill-hide). */}
-        {drill === null && (
-          <div className={`border-b border-soleur-border-default ${collapsed ? "px-2 py-3" : "px-3 py-3"}`}>
-            <ThemeToggle collapsed={collapsed} />
-          </div>
-        )}
-
         {/* Persistent workspace context band (ADR-047). Mounted OUTSIDE the
             rail swap region and NEVER gated on `collapsed` — this fixes the
             live bug where OrgSwitcherContainer + LiveRepoBadge unmounted on
@@ -395,6 +387,14 @@ export default function DashboardLayout({
 
             {/* Footer links */}
             <div className={`border-t border-soleur-border-default safe-bottom ${collapsed ? "p-1" : "p-3"}`}>
+              {/* Theme toggle — relocated to the footer to match the committed
+                  D4 wireframe (frames 16/23: a quiet theme affordance at the
+                  bottom of the rail, NOT a prominent control at the top). Stays
+                  top-level chrome, render-conditional via the `drill === null`
+                  branch this footer lives in. */}
+              <div className={collapsed ? "pb-2" : "px-1 pb-2"}>
+                <ThemeToggle collapsed={collapsed} />
+              </div>
               {userEmail && !collapsed && (
                 <p
                   className="truncate px-3 py-1 text-xs text-soleur-text-muted"

--- a/apps/web-platform/e2e/nav-states-shell.e2e.ts
+++ b/apps/web-platform/e2e/nav-states-shell.e2e.ts
@@ -616,8 +616,13 @@ test.describe("widenable KB rail — desktop", () => {
     const aside = page.locator("aside").first();
     await expect(aside).toHaveClass(/md:w-14/, { timeout: 15_000 });
     await expect(resizeHandle(page)).toHaveCount(0);
-    const width = await asideWidth(page);
-    expect(width).toBeLessThanOrEqual(64); // ~56px collapsed rail
+    // The rail hydrates expanded (224px) → collapsed (56px) over a 200ms
+    // `md:transition-[width]`. Poll until the width settles, matching the
+    // sibling widenable-rail tests — a single synchronous read races the
+    // transition and catches a mid-animation frame (~126px).
+    await expect
+      .poll(async () => asideWidth(page), { timeout: 7_000 })
+      .toBeLessThanOrEqual(64); // ~56px collapsed rail
     // Stored width is untouched (returns on expand).
     const stored = await page.evaluate(
       (key) => localStorage.getItem(key),

--- a/apps/web-platform/test/nav-rail-drill.test.tsx
+++ b/apps/web-platform/test/nav-rail-drill.test.tsx
@@ -95,6 +95,30 @@ describe("Single nav rail — URL-derived drill swap (AC3/AC4c)", () => {
     expect(screen.queryByText("Soleur")).not.toBeInTheDocument();
   });
 
+  it("places the theme toggle in the FOOTER (after the primary nav), not the rail header — matches the D4 wireframe", () => {
+    render(
+      <Wrap>
+        <DashboardLayout>
+          <div>content</div>
+        </DashboardLayout>
+      </Wrap>,
+    );
+    const theme = screen.getByRole("group", { name: /theme/i });
+    const navLink = screen.getByRole("link", { name: "Knowledge Base" });
+    // The theme control must FOLLOW the primary nav in the DOM (footer region),
+    // not precede it (the old top-of-rail placement the wireframe rejects).
+    expect(
+      navLink.compareDocumentPosition(theme) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // Co-located with the footer Sign-out control (same footer container).
+    const signOut = screen.getByRole("button", { name: /sign out/i });
+    expect(
+      theme.compareDocumentPosition(signOut) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("KEEPS the primary nav on /dashboard/admin/analytics (allowlist, RQ6)", () => {
     mockPathname = "/dashboard/admin/analytics";
     render(


### PR DESCRIPTION
## Summary

Follow-up to #4915 (KB nav redesign). After that PR removed the global "Soleur" wordmark, the **theme toggle was left stranded at the top of the rail** — promoting a low-frequency setting above the workspace identity, which inverts the committed D4 wireframes (frames `16`/`23`: a quiet theme affordance at the **bottom** of the rail).

- Relocate `ThemeToggle` from the rail header into the **footer** (still top-level chrome, render-conditional on `drill === null`; absent when drilled, unchanged).
- Add a DOM-order regression test: theme control follows the primary nav and is co-located with Sign-out (footer region), guarding against drift back to the top.
- Fix a **pre-existing flaky** AC12 nav-states assertion that read the animated collapsed-rail width synchronously (caught a ~126px mid-transition frame); switch to `expect.poll`, matching its sibling widenable-rail tests.

Refs #4915.

## Changelog

### Web Platform
- The light/dark theme switcher now sits at the bottom of the sidebar (matching the navigation redesign), instead of above the workspace name.

## Test plan
- [x] `nav-rail-drill` + theme suites green (44 tests) incl. new footer-placement regression test
- [x] `tsc --noEmit` clean
- [x] ADR-049 `nav-states` Playwright gate green (theme renders in footer, no overflow; AC12 flake fixed + verified 2/2)

Generated with [Claude Code](https://claude.com/claude-code)
