### PR TITLE
fix(dashboard): move theme toggle below Sign out (rail bottom)

### DIFF
--- a/apps/web-platform/app/(dashboard)/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/layout.tsx
@@ -387,14 +387,6 @@ export default function DashboardLayout({
 
             {/* Footer links */}
             <div className={`border-t border-soleur-border-default safe-bottom ${collapsed ? "p-1" : "p-3"}`}>
-              {/* Theme toggle — relocated to the footer to match the committed
-                  D4 wireframe (frames 16/23: a quiet theme affordance at the
-                  bottom of the rail, NOT a prominent control at the top). Stays
-                  top-level chrome, render-conditional via the `drill === null`
-                  branch this footer lives in. */}
-              <div className={collapsed ? "pb-2" : "px-1 pb-2"}>
-                <ThemeToggle collapsed={collapsed} />
-              </div>
               {userEmail && !collapsed && (
                 <p
                   className="truncate px-3 py-1 text-xs text-soleur-text-muted"
@@ -434,6 +426,13 @@ export default function DashboardLayout({
                 <LogOutIcon className="h-4 w-4 shrink-0" />
                 <span className={`overflow-hidden whitespace-nowrap ${collapsed ? "md:hidden" : ""}`}>Sign out</span>
               </button>
+              {/* Theme toggle — the quiet, lowest-priority affordance sits at the
+                  very bottom of the rail, BELOW Sign out (matches the D4 wireframe
+                  frames 16/23). Stays top-level chrome, render-conditional via the
+                  `drill === null` branch this footer lives in. */}
+              <div className={collapsed ? "pt-2" : "px-1 pt-2"}>
+                <ThemeToggle collapsed={collapsed} />
+              </div>
             </div>
           </>
         ) : (

--- a/apps/web-platform/test/nav-rail-drill.test.tsx
+++ b/apps/web-platform/test/nav-rail-drill.test.tsx
@@ -95,7 +95,7 @@ describe("Single nav rail — URL-derived drill swap (AC3/AC4c)", () => {
     expect(screen.queryByText("Soleur")).not.toBeInTheDocument();
   });
 
-  it("places the theme toggle in the FOOTER (after the primary nav), not the rail header — matches the D4 wireframe", () => {
+  it("places the theme toggle at the very BOTTOM of the rail — after the primary nav AND below Sign out (matches the D4 wireframe)", () => {
     render(
       <Wrap>
         <DashboardLayout>
@@ -111,10 +111,11 @@ describe("Single nav rail — URL-derived drill swap (AC3/AC4c)", () => {
       navLink.compareDocumentPosition(theme) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
-    // Co-located with the footer Sign-out control (same footer container).
+    // …and it is the LAST footer affordance — below Sign out (the quietest,
+    // lowest-priority control sits at the very bottom of the rail).
     const signOut = screen.getByRole("button", { name: /sign out/i });
     expect(
-      theme.compareDocumentPosition(signOut) &
+      signOut.compareDocumentPosition(theme) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });


### PR DESCRIPTION
## Summary

Follow-up to #4933 / #4915. Move the theme switcher to the **very bottom** of the sidebar footer, **below Sign out** — the quietest, lowest-priority affordance sits last (matches the D4 wireframe frames 16/23). Updates the DOM-order regression test (theme now follows Sign out).

Refs #4915.

## Changelog

### Web Platform
- The theme switcher now sits at the very bottom of the sidebar, below Sign out.

## Test plan
- [x] nav-rail-drill + collapse suites green (28 tests) incl. updated placement test
- [x] tsc --noEmit clean
- [x] ADR-049 nav-states gate runs in CI (footer-internal reorder)

Generated with [Claude Code](https://claude.com/claude-code)
