### PR TITLE
fix(infra): revert too-strict canary bwrap userns/proc probe (unblock deploys)

### DIFF
--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -581,25 +581,20 @@ case "$COMPONENT" in
     # Verify bwrap sandbox works inside canary (#1557).
     # If bwrap fails, the OS-level sandbox (Layer 1) is non-functional.
     #
-    # The probe MUST exercise --unshare-user + --proc /proc, not just
-    # --unshare-pid --bind. The cron Bash sandbox creates an unprivileged USER
-    # namespace and mounts /proc inside it; that path is gated by the host
-    # sysctl kernel.apparmor_restrict_unprivileged_userns (asserted on every
-    # boot by bwrap-userns-sysctl.service, see server.tf). A probe that omits
-    # --unshare-user/--proc passes even when that sysctl has drifted to 1, so
-    # the canary swaps to prod healthy while EVERY cron Bash call then fails
-    # silently (spawn exits 0 with a degraded report, no scheduled-* issue) —
-    # the exact 2026-06-04 silent-producer incident (#4927/#4928). Exercising
-    # the userns+/proc path here turns that silent 2-week outage into a
-    # deploy-time rollback.
+    # NOTE: a prior change (#4932) added --unshare-user --proc /proc here to
+    # mirror the cron Bash sandbox's userns+/proc path. It was reverted — that
+    # synthetic invocation failed in the canary even with the host userns sysctl
+    # correctly asserted (verified: the apply set the sysctl at 14:30:31, the
+    # probe still failed at 14:38:43), so it does NOT track the real cron
+    # capability and instead rolled back EVERY web-platform deploy. The userns
+    # drift it was meant to catch is now PREVENTED at the source by the
+    # boot-persistent bwrap-userns-sysctl.service unit + fresh-host trigger in
+    # server.tf. A faithful, non-blocking userns/proc canary check (matched to
+    # the actual claude bwrap invocation, validated against the host) is a
+    # follow-up — it must not gate deploys until proven to pass on a healthy host.
     if [[ "$CANARY_HEALTHY" == "true" ]]; then
-      echo "Verifying bwrap sandbox (userns + /proc mount)..."
-      # Arg order is significant: bwrap applies filesystem ops in sequence, so
-      # bind the rootfs FIRST, then overlay /dev and /proc on top (the canonical
-      # order the Claude Code sandbox itself uses). --unshare-user is the
-      # load-bearing addition — creating the user namespace + writing uid_map is
-      # what fails when kernel.apparmor_restrict_unprivileged_userns has drifted.
-      if ! docker exec soleur-web-platform-canary bwrap --new-session --die-with-parent --unshare-user --unshare-pid --bind / / --dev /dev --proc /proc -- true 2>&1; then
+      echo "Verifying bwrap sandbox..."
+      if ! docker exec soleur-web-platform-canary bwrap --new-session --die-with-parent --dev /dev --unshare-pid --bind / / -- true 2>&1; then
         echo "Canary sandbox check failed, rolling back..."
         logger -t "$LOG_TAG" "DEPLOY_ROLLBACK: bwrap sandbox non-functional in $IMAGE:$TAG"
         { docker stop soleur-web-platform-canary 2>/dev/null || true; }

--- a/apps/web-platform/infra/ci-deploy.test.sh
+++ b/apps/web-platform/infra/ci-deploy.test.sh
@@ -1263,39 +1263,6 @@ assert_bwrap_canary_check() {
 
 assert_bwrap_canary_check
 
-assert_bwrap_canary_probe_exercises_userns_proc() {
-  # Regression guard for the 2026-06-04 cron silent-producer incident
-  # (#4927/#4928): the canary bwrap probe MUST exercise --unshare-user AND
-  # --proc /proc — the unprivileged-userns + /proc-mount path the cron Bash
-  # sandbox uses and that kernel.apparmor_restrict_unprivileged_userns gates.
-  # The pre-fix probe (--unshare-pid --bind / / only) passed even when that
-  # sysctl had drifted, so the canary swapped to prod healthy while every cron
-  # Bash call failed silently. Anchored on both flags (non-vacuous: the old
-  # command contained neither).
-  TOTAL=$((TOTAL + 1))
-
-  local output actual_exit
-  output=$(
-    export MOCK_DOCKER_MODE="bwrap-trace"
-    run_deploy "deploy web-platform ghcr.io/jikig-ai/soleur-web-platform v1.0.0" 2>&1
-  ) && actual_exit=0 || actual_exit=$?
-
-  local exec_line
-  exec_line=$(printf '%s\n' "$output" | grep -F "DOCKER_EXEC:" | grep -F "bwrap" || true)
-
-  if printf '%s' "$exec_line" | grep -qF -- "--unshare-user" \
-    && printf '%s' "$exec_line" | grep -qF -- "--proc /proc"; then
-    PASS=$((PASS + 1))
-    echo "  PASS: canary bwrap probe exercises --unshare-user + --proc /proc"
-  else
-    FAIL=$((FAIL + 1))
-    echo "  FAIL: canary bwrap probe must exercise --unshare-user + --proc /proc (the cron userns/proc path)"
-    echo "        exec line: $exec_line"
-  fi
-}
-
-assert_bwrap_canary_probe_exercises_userns_proc
-
 assert_bwrap_canary_failure_rollback() {
   # Verify that bwrap check failure triggers canary rollback.
   TOTAL=$((TOTAL + 1))


### PR DESCRIPTION
## Why — urgent (production deploys blocked)

#4932 added `--unshare-user --proc /proc` to the canary bwrap probe in `ci-deploy.sh` to catch userns drift. It is **rolling back every web-platform deploy** (`reason=canary_sandbox_failed`).

The timing rules out a sequencing race: the post-merge `terraform apply` asserted the host userns sysctl + installed `bwrap-userns-sysctl.service` at **14:30:31**, yet the canary probe still failed at **14:38:43** (8 min later). So the synthetic `bwrap --unshare-user --proc /proc -- true` invocation does **not** track the real cron sandbox capability on a healthy host — it is too strict and must not gate deploys.

## What
- Revert the canary probe to the proven `--new-session --die-with-parent --dev /dev --unshare-pid --bind / / -- true` form (unblocks deploys).
- Remove the now-false ci-deploy.test.sh regression guard.

## Kept (the actual recovery, already applied via #4932)
The `server.tf` boot-persistent `bwrap-userns-sysctl.service` unit + fresh-host trigger that re-assert `kernel.apparmor_restrict_unprivileged_userns=0` — that is the source-level fix that prevents the cron silent-producer drift (#4927/#4928).

## Follow-up
Re-add a **non-blocking** userns/proc canary check matched to claude's actual bwrap invocation, validated against a healthy host before it ever gates a deploy.

Tests: ci-deploy.test.sh 79/79; bwrap-userns-sysctl.test.sh 5/5.