### PR TITLE
fix(infra): non-blocking bwrap userns drift detector + correct #4932 learning

### DIFF
--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -661,6 +661,32 @@ case "$COMPONENT" in
           logger -t "$LOG_TAG" "INNGEST_WARN: inngest-server not reachable after deploy — consider running restart-inngest-server.yml workflow"
         fi
 
+        # bwrap userns drift detector (#4927/#4928; follow-up to #4932/#4941).
+        #
+        # The cron Bash sandbox (bwrap) creates an unprivileged user namespace
+        # and mounts /proc; that path is gated by the host sysctl
+        # kernel.apparmor_restrict_unprivileged_userns, which MUST be 0 (asserted
+        # on every boot by bwrap-userns-sysctl.service, see server.tf). When it
+        # drifted to 1 on 2026-06-04, every cron Bash call failed silently and
+        # three producers went dark for ~2 weeks before the watchdog noticed.
+        #
+        # This reads the EXACT value that drifted — not a synthetic `bwrap` probe
+        # with guessed flags (an earlier attempt at the latter, #4932, failed on a
+        # healthy host because its invocation did not match the real sandbox, and
+        # because it GATED it rolled back every deploy; reverted in #4941). Reading
+        # the sysctl is unambiguous and false-positive-free.
+        #
+        # NON-BLOCKING by design (mirrors INNGEST_HEALTH_CHECK above): the actual
+        # fix is the boot-persistent sysctl unit; this is detection only and must
+        # never gate a deploy. Surfaces a loud WARN to journald → Better Stack so a
+        # future drift pages within one deploy cycle instead of going dark.
+        userns_restrict=$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns 2>/dev/null || echo "unreadable")
+        if [[ "$userns_restrict" == "0" ]]; then
+          logger -t "$LOG_TAG" "BWRAP_USERNS_SYSCTL_CHECK: ok (apparmor_restrict_unprivileged_userns=0)"
+        else
+          logger -t "$LOG_TAG" "BWRAP_USERNS_SYSCTL_DRIFT: apparmor_restrict_unprivileged_userns=${userns_restrict} (expected 0) — cron Bash sandbox will fail silently; restart bwrap-userns-sysctl.service"
+        fi
+
         echo "Deploy succeeded"
         final_write_state 0 "ok"
         exit 0

--- a/apps/web-platform/infra/ci-deploy.test.sh
+++ b/apps/web-platform/infra/ci-deploy.test.sh
@@ -1286,6 +1286,42 @@ assert_bwrap_canary_failure_rollback() {
 assert_bwrap_canary_failure_rollback
 
 echo ""
+echo "--- Bwrap userns sysctl drift detector (non-blocking) ---"
+
+assert_bwrap_userns_drift_detector_nonblocking() {
+  # Follow-up to #4932/#4941: ci-deploy.sh must read the host sysctl
+  # kernel.apparmor_restrict_unprivileged_userns after the prod container starts
+  # and surface a drift WARN — but it must be NON-BLOCKING (detection only), so a
+  # drift reading never rolls back a deploy the way the reverted #4932 gating
+  # probe did. Source-level guard: the drift branch must use `logger`, and the
+  # whole userns check must NOT call `final_write_state 1` or `exit` (anchored on
+  # the unique message tokens; non-vacuous — neither token existed pre-#4941).
+  TOTAL=$((TOTAL + 1))
+
+  local block
+  # Extract the userns check block: the logger lines from the first
+  # BWRAP_USERNS_SYSCTL token through the trailing "Deploy succeeded".
+  block=$(awk '/BWRAP_USERNS_SYSCTL/{f=1} f{print} /Deploy succeeded/{f=0}' "$DEPLOY_SCRIPT" 2>/dev/null)
+
+  # `|| true`: grep -c exits 1 on zero matches, which would abort under set -e.
+  local has_ok has_drift gates
+  has_ok=$(printf '%s\n' "$block" | grep -cF "BWRAP_USERNS_SYSCTL_CHECK: ok" || true)
+  has_drift=$(printf '%s\n' "$block" | grep -cF "BWRAP_USERNS_SYSCTL_DRIFT" || true)
+  # Non-blocking: the block must not contain a failure-write or exit.
+  gates=$(printf '%s\n' "$block" | grep -cE 'final_write_state 1|exit 1|exit 0' || true)
+
+  if [[ "$has_ok" -ge 1 && "$has_drift" -ge 1 && "$gates" -eq 0 ]]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: userns sysctl drift detector present and non-blocking"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: userns drift detector must be present and non-blocking (ok=$has_ok drift=$has_drift gating_calls=$gates)"
+  fi
+}
+
+assert_bwrap_userns_drift_detector_nonblocking
+
+echo ""
 echo "--- Env file cleanup on all exit paths ---"
 
 assert_env_file_cleanup() {

--- a/knowledge-base/project/learnings/2026-06-04-cron-silence-was-bwrap-userns-drift-not-turn-budget.md
+++ b/knowledge-base/project/learnings/2026-06-04-cron-silence-was-bwrap-userns-drift-not-turn-budget.md
@@ -1,10 +1,10 @@
 ---
-title: "Cron silent-producer root cause was bwrap userns drift, not turn budget — and the canary probe had a coverage gap that hid it"
+title: "Cron silent-producer root cause was bwrap userns drift, not turn budget — and a gating health-check shipped unvalidated then blocked all deploys"
 date: 2026-06-04
-tags: [incident, cron, inngest, bwrap, sandbox, observability, terraform, live-evidence]
+tags: [incident, cron, inngest, bwrap, sandbox, observability, terraform, live-evidence, deploy-gate, regression]
 related_issues: ["#4927", "#4928"]
 related_sentry: ["4d67bdc8e3564efdb6afb5d8ff23527c"]
-related_prs: ["#4932"]
+related_prs: ["#4932", "#4941"]
 ---
 
 # Cron silence was bwrap userns drift, not turn budget
@@ -19,16 +19,21 @@ Three scheduled Inngest cron producers went silent (community-monitor, content-g
 
 Real root cause: the host sysctl `kernel.apparmor_restrict_unprivileged_userns=0` (required for bwrap's userns + `/proc` mount) had drifted back to `1` and nothing re-asserted it.
 
-## Two mechanisms, both fixed in #4932
+## The fix (#4932) and the regression it caused (#4941)
 
-1. **Provisioning was not drift-proof.** The sysctl was set by a `terraform_data` provisioner keyed ONLY on `sha256(seccomp-bwrap.json)` — identical on a replaced VM (the fresh-host trap, `hr-fresh-host-provisioning-reachable-from-terraform-apply`) — and a bare `sysctl -w` lost on reboot. Fix: key the trigger on `{ seccomp hash, server_id }` and assert via a boot-persistent oneshot systemd unit (`bwrap-userns-sysctl.service`).
-2. **The canary gate had a coverage gap.** `ci-deploy.sh` already ran a bwrap probe that *gated* the deploy — but with `--unshare-pid --bind / /` only, never `--unshare-user`/`--proc /proc`. So it passed even when the userns sysctl had reverted, and the canary swapped a broken host to prod "healthy." Fix: the probe now exercises `--unshare-user --proc /proc` — the exact path the cron sandbox uses — turning a silent ~2-week outage into a deploy-time rollback.
+**The real fix — drift-proof provisioning (#4932, kept, verified).** The sysctl was set by a `terraform_data` provisioner keyed ONLY on `sha256(seccomp-bwrap.json)` — identical on a replaced VM (the fresh-host trap, `hr-fresh-host-provisioning-reachable-from-terraform-apply`) — and a bare `sysctl -w` lost on reboot. Fix: key the trigger on `{ seccomp hash, server_id }` and assert via a boot-persistent oneshot systemd unit (`bwrap-userns-sysctl.service`). The post-merge `terraform apply` recovered the host; a manual `community-monitor` trigger then produced a healthy digest issue (#4943) — verified recovery.
+
+**The regression — a gating health-check shipped unvalidated (#4932 → reverted in #4941).** `ci-deploy.sh` already ran a bwrap probe that *gated* the deploy (rollback on failure) but tested only `--unshare-pid --bind / /`, never the cron's `--unshare-user`/`--proc /proc` path — a real coverage gap. The attempted fix added `--unshare-user --proc /proc` to that *gating* probe. It was **validated only against the test mock (which always succeeds)**, never against a real host, and the synthetic invocation did not match what claude's sandbox actually does: it **failed on a healthy host** (the apply asserted the sysctl at 14:30:31, the probe still failed at 14:38:43) and **rolled back every web-platform deploy**. Reverted in #4941; the userns/proc coverage was re-added as a **non-blocking** sysctl-value check (reads `kernel.apparmor_restrict_unprivileged_userns`, zero false-positive risk) — detection without the power to block deploys.
 
 ## Key insights (reusable)
 
 - **A plan's root-cause hypothesis is a hypothesis. Pull the live evidence before coding.** The `--max-turns` bump would have been a false fix: it cannot help when bwrap can't run bash, and #4927/#4928 would not have recovered. Sentry event `extra` (`exitCode`/`stdoutTail`/`stderrTail`, threaded by the output-aware heartbeat) was the authoritative source — read it via the org-issues API with `SENTRY_ISSUE_RW_TOKEN`, no SSH.
 - **Evidence captured while a dependency is broken is contaminated.** "Reached max turns (50)" looked like a budget problem but was a symptom of broken bash. Don't pattern-match a symptom to the nearest prior fix (community-monitor's 50→80 bump).
-- **A gating health-check that doesn't exercise the production-critical path is worse than none** — it manufactures false confidence. The canary bwrap probe must mirror what the real sandbox does (userns + `/proc`), or drift in that exact capability sails through green.
+- **A health-check that diverges from production reality is worse than none — in BOTH directions.** The old gating probe passed while crons were broken (didn't test userns); the "improved" one failed while the host was healthy (tested a synthetic userns invocation the real sandbox doesn't use). Same root flaw: the probe and the reality diverged.
+- **Never ship a deploy-*gating* check validated only against a mock.** The test asserted the probe's command *shape* (flags present) against an always-succeeding mock — it confirmed nothing about the probe's *outcome* on a real host. For a check whose correctness depends on real kernel/container behavior, mock-green is not coverage; the change is runtime-unvalidated until observed on the real target.
+- **Dark-launch deploy gates.** A new/changed check that can block or roll back a deploy must ship **non-blocking (log-only) first**, be observed passing on ≥1 real deploy, then be promoted to gating. Never validate a gate change with the same deploy it gates. When the safer non-blocking form already exists, do not "upgrade" it to gating without that observation — exactly the step skipped here.
+- **Prefer reading the root-cause value over a synthetic capability probe.** The drift was `kernel.apparmor_restrict_unprivileged_userns` flipping to 1. A non-blocking read of that exact sysctl is unambiguous and false-positive-free; a synthetic `bwrap … -- true` with guessed flags is not. Detect the specific thing that drifted.
+- **Don't bundle speculative detection into a verified recovery.** The evidence demanded the sysctl fix; it did NOT demand the canary-probe change. Bundling the unvalidated enhancement into the recovery PR coupled a safe change to a risky one. Ship recovery alone → verify → detection as its own change with its own validation.
 - **One-time `terraform_data` provisioners gated on a file hash silently skip on host replacement.** Fold the server id into the trigger so a fresh VM re-runs them; assert reboot-critical kernel state via an enabled systemd unit, not a one-shot `sysctl -w`.
 
 See [[2026-06-01-output-aware-cron-heartbeat-and-live-evidence-refutes-plan-hypothesis]] — same "live evidence refutes plan" pattern, prior occurrence.


### PR DESCRIPTION
Follow-ups to the 2026-06-04 cron silent-producer incident (#4927/#4928), per the post-incident retro.

## 1. Non-blocking userns drift detector (`ci-deploy.sh`)
Re-adds the userns/proc coverage that #4932 attempted — but **non-blocking** and done right. It reads the host sysctl `kernel.apparmor_restrict_unprivileged_userns` (the exact value that drifted) and logs a loud WARN to journald/Better Stack on drift. Contrast with the reverted #4932 approach:

| | #4932 (reverted in #4941) | This PR |
|---|---|---|
| Mechanism | synthetic `bwrap --unshare-user --proc /proc` probe | read the sysctl value |
| False-positive risk | high (flags didn't match real sandbox; failed on healthy host) | none (reads the actual value) |
| Blast radius | **gated** → rolled back every deploy | **non-blocking** → can't block a deploy |

`ci-deploy.test.sh` gains a guard asserting the detector is present and non-blocking (no `exit`/`final_write_state 1` in its branch). **80/80.**

## 2. Correct the #4932 learning file
Its 'mechanism 2' wrongly described the reverted gating probe as the fix. Now records the revert and the reusable lessons: **dark-launch deploy gates**, **mock-shape ≠ runtime-outcome**, **read the root-cause value over a synthetic probe**, **don't bundle speculative detection into a verified recovery**.

The actual recovery (server.tf sysctl drift-proofing) shipped + verified in #4932/#4941; this is detection + docs only. No gating logic.