### PR TITLE
fix(test): end the dsar-worm-guc / run-migrations-gate fixture race via producer-side temp-dir staging (#4957)

### DIFF
--- a/apps/web-platform/scripts/run-migrations.sh
+++ b/apps/web-platform/scripts/run-migrations.sh
@@ -61,7 +61,15 @@ if [[ "${BOOTSTRAP_MIGRATIONS:-1}" == "0" ]]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATIONS_DIR="$SCRIPT_DIR/../supabase/migrations"
+# Default to the real dir; tests may override via RUN_MIGRATIONS_TEST_DIR to
+# a temp staging dir so they never write transient *.sql into the real
+# migrations tree (#4957). The git ls-tree gate (below) intentionally stays
+# anchored to the canonical repo path — a temp-dir filename absent from
+# origin/main still trips the gate, which is exactly what the gate test
+# exercises. A test-scoped var name (not MIGRATIONS_DIR) avoids any collision
+# with a same-named secret a future Doppler config might inject via
+# `doppler run` in the prod migrate step.
+MIGRATIONS_DIR="${RUN_MIGRATIONS_TEST_DIR:-$SCRIPT_DIR/../supabase/migrations}"
 
 command -v psql >/dev/null 2>&1 || { echo "::error::psql not found on PATH"; exit 1; }
 

--- a/apps/web-platform/test/scripts/run-migrations-unmerged-gate.test.ts
+++ b/apps/web-platform/test/scripts/run-migrations-unmerged-gate.test.ts
@@ -143,6 +143,11 @@ describe("scripts/run-migrations.sh — unmerged-apply gate (#4241)", () => {
     // is needed — a leftover temp dir from a crashed run is harmless and lives
     // under os.tmpdir(), not the repo.
     tempMigrationsDir = mkdtempSync(join(tmpdir(), "run-migrations-gate-"));
+    // Guard against a future refactor leaving tempMigrationsDir empty: the
+    // script's `${RUN_MIGRATIONS_TEST_DIR:-<real dir>}` default would then
+    // silently fall back to the REAL dir, and the gate-blocks test could pass
+    // for the wrong reason (firing on a real worktree file, not the synthetic).
+    expect(tempMigrationsDir).toBeTruthy();
     cpSync(REAL_MIGRATIONS_DIR, tempMigrationsDir, { recursive: true });
     writeFileSync(
       join(tempMigrationsDir, SYNTHETIC_FILE),
@@ -163,13 +168,17 @@ describe("scripts/run-migrations.sh — unmerged-apply gate (#4241)", () => {
       ALLOW_UNMERGED_DEV_APPLY: undefined,
     });
     expect(status).toBe(1);
-    // The gate fires on the FIRST unmerged file the *.sql glob hits (this is
-    // the synthetic `zzz_*` if no other unmerged migration exists locally, or
-    // a lower-prefix unmerged migration introduced by this same PR if one
-    // sorts first). Assert the contract — the script exits with `::error::`
-    // referencing the unmerged-on-main predicate — not the specific filename.
-    // ::error:: lands on stdout (the script uses `echo`, not `echo >&2`).
+    // The temp staging dir holds a copy of the real (all on-origin/main)
+    // migrations plus exactly one unmerged file: SYNTHETIC_FILE. So the gate
+    // fires deterministically on the synthetic basename. Assert the contract
+    // (`::error::` + the unmerged-on-main predicate) AND pin the synthetic
+    // filename so a regression that trips the gate on a *different* file (or
+    // fires it for everything) cannot pass. ::error:: lands on stdout (the
+    // script uses `echo`, not `echo >&2`).
     expect(stdout).toMatch(/::error::Migration .*\.sql is NOT on origin\/main/i);
+    expect(stdout).toMatch(
+      new RegExp(`Migration ${SYNTHETIC_FILE} is NOT on origin/main`, "i"),
+    );
     expect(stdout).toMatch(/ALLOW_UNMERGED_DEV_APPLY=1/);
     expect(stderr).toBe("");
   });

--- a/apps/web-platform/test/scripts/run-migrations-unmerged-gate.test.ts
+++ b/apps/web-platform/test/scripts/run-migrations-unmerged-gate.test.ts
@@ -1,15 +1,11 @@
 import { describe, test, expect, beforeAll, afterAll } from "vitest";
 import { spawnSync } from "node:child_process";
 import {
-  openSync,
-  writeSync,
   writeFileSync,
-  closeSync,
-  unlinkSync,
   mkdtempSync,
   chmodSync,
+  cpSync,
   rmSync,
-  constants as fsConstants,
 } from "node:fs";
 import { resolve, join } from "node:path";
 import { tmpdir } from "node:os";
@@ -24,23 +20,31 @@ import { randomBytes } from "node:crypto";
 // grant_action_class shape).
 //
 // The gate is git-local: `git ls-tree origin/main -- <path>` returns empty
-// for files not on main; non-empty (a blob entry) for files on main. The
-// test writes a synthetic file with a randomized suffix into the real
-// migrations dir (the SUT's *.sql glob roots there); on-disk leak protection
-// runs via afterAll + a process.on("exit") sweep + a beforeAll precondition
-// that fails fast if a stale synthetic file from a prior crashed run
-// already exists.
+// for files not on main; non-empty (a blob entry) for files on main.
+//
+// Test isolation (#4957): the synthetic `zzz_*` fixture is staged in a
+// per-process temp dir (a copy of the real migrations dir) and the SUT is
+// pointed at it via RUN_MIGRATIONS_TEST_DIR — it is NEVER written into the
+// real apps/web-platform/supabase/migrations/ tree. Previously the fixture
+// was written into the real dir, where four sibling suites
+// (dsar-worm-guc-sites, dsar-message-redact-fields-sweep, migration-rpc-grants,
+// dsar-allowlist-completeness) readdirSync + readFileSync the same directory;
+// when this producer's afterAll unlinkSync'd the fixture between a reader's
+// readdir and its read, the reader hit ENOENT. Staging in a temp dir removes
+// the shared write surface entirely. The git ls-tree gate below stays anchored
+// to the canonical repo path (basename-only lookup), so a temp-dir filename
+// absent from origin/main still trips the gate — exactly what these tests
+// exercise.
 
 const REPO_ROOT = resolve(__dirname, "../../../..");
 const SCRIPT_PATH = resolve(__dirname, "../../scripts/run-migrations.sh");
-const MIGRATIONS_DIR = resolve(__dirname, "../../supabase/migrations");
+const REAL_MIGRATIONS_DIR = resolve(__dirname, "../../supabase/migrations");
 
 // Per-process randomized filename — survives parallel vitest workers + watch-
 // mode reruns. The `zzz_` prefix sorts after every real migration so the
 // glob's *.sql expansion processes it last (real migrations run first; the
 // gate fires on this synthetic file at the end of the loop).
 const SYNTHETIC_FILE = `zzz_unmerged_gate_${randomBytes(4).toString("hex")}.sql`;
-const SYNTHETIC_MIGRATION = join(MIGRATIONS_DIR, SYNTHETIC_FILE);
 
 // A known-merged migration (PR-I, on origin/main as of 2026-05-21). Used by
 // the positive control test below; if PR-I is ever reverted, switch to
@@ -49,6 +53,11 @@ const KNOWN_MERGED_FILE = "053_template_authorizations.sql";
 
 // Track every tempdir mkdtempSync allocates so afterAll can sweep them.
 const stubDirs: string[] = [];
+
+// The per-process staging dir holding a copy of the real migrations + the
+// synthetic fixture. Set in beforeAll, swept in afterAll. The SUT globs this
+// dir via RUN_MIGRATIONS_TEST_DIR instead of the real migrations tree.
+let tempMigrationsDir = "";
 
 function makePsqlStub(): string {
   const dir = mkdtempSync(join(tmpdir(), "psql-stub-"));
@@ -87,6 +96,12 @@ function runScript(env: Record<string, string | undefined>): {
     env: {
       ...process.env,
       ...env,
+      // Point the SUT's *.sql glob at the temp staging dir (#4957) so the
+      // synthetic fixture never lands in the real migrations tree. The gate's
+      // `git ls-tree origin/main -- apps/web-platform/supabase/migrations/<name>`
+      // predicate stays anchored to the canonical path (basename-only), so it
+      // still fires for the temp-dir-only `zzz_*` file.
+      RUN_MIGRATIONS_TEST_DIR: tempMigrationsDir,
       PATH: `${stubDir}:${process.env.PATH ?? ""}`,
     },
     encoding: "utf8",
@@ -100,13 +115,16 @@ function runScript(env: Record<string, string | undefined>): {
 }
 
 function sweep(): void {
-  // Try-unlink + tolerate-ENOENT. Avoids the TOCTOU pattern of
-  // `if (existsSync(path)) unlinkSync(path)` flagged by CodeQL
-  // js/file-system-race.
-  try {
-    unlinkSync(SYNTHETIC_MIGRATION);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  // Best-effort recursive removal of the temp staging dir + psql stub dirs.
+  // No file is ever written into the real migrations tree, so there is
+  // nothing to unlink there. `force: true` tolerates already-removed dirs
+  // (e.g., a process.on("exit") sweep after afterAll already ran).
+  if (tempMigrationsDir) {
+    try {
+      rmSync(tempMigrationsDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort sweep — already-removed dir is fine */
+    }
   }
   for (const dir of stubDirs) {
     try {
@@ -119,33 +137,17 @@ function sweep(): void {
 
 describe("scripts/run-migrations.sh — unmerged-apply gate (#4241)", () => {
   beforeAll(() => {
-    // Atomic exclusive create (O_CREAT|O_EXCL|O_WRONLY) — fails fast with
-    // EEXIST if the file is present, no TOCTOU window between exists-check
-    // and write. CodeQL js/file-system-race compliance.
-    let fd: number;
-    try {
-      fd = openSync(
-        SYNTHETIC_MIGRATION,
-        fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY,
-        0o644,
-      );
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "EEXIST") {
-        throw new Error(
-          `precondition: ${SYNTHETIC_MIGRATION} already exists. ` +
-            `Likely orphaned from a prior crashed run — delete manually before re-running.`,
-        );
-      }
-      throw err;
-    }
-    try {
-      writeSync(
-        fd,
-        "-- synthetic test migration; never on origin/main.\nSELECT 1;\n",
-      );
-    } finally {
-      closeSync(fd);
-    }
+    // Stage a per-process copy of the real migrations dir, then drop the
+    // synthetic unmerged fixture into the COPY (never the real tree). mkdtemp
+    // is collision-free by construction, so no atomic-exclusive precondition
+    // is needed — a leftover temp dir from a crashed run is harmless and lives
+    // under os.tmpdir(), not the repo.
+    tempMigrationsDir = mkdtempSync(join(tmpdir(), "run-migrations-gate-"));
+    cpSync(REAL_MIGRATIONS_DIR, tempMigrationsDir, { recursive: true });
+    writeFileSync(
+      join(tempMigrationsDir, SYNTHETIC_FILE),
+      "-- synthetic test migration; never on origin/main.\nSELECT 1;\n",
+    );
     // Belt-and-braces: process.on("exit") fires even on uncaught throws /
     // explicit process.exit() that vitest's afterAll cannot intercept.
     process.on("exit", sweep);

--- a/knowledge-base/project/learnings/test-failures/2026-06-05-shared-migrations-dir-fixture-race-fix-producer-side-temp-dir.md
+++ b/knowledge-base/project/learnings/test-failures/2026-06-05-shared-migrations-dir-fixture-race-fix-producer-side-temp-dir.md
@@ -1,0 +1,73 @@
+# Learning: shared-mutable-dir test fixture race — fix producer-side, not consumer-side
+
+## Problem
+
+`scripts/test-all.sh webplat` intermittently failed locally with
+`ENOENT: no such file or directory, open '.../supabase/migrations/zzz_unmerged_gate_<hex>.sql'`
+while **main CI stayed green** (#4957).
+
+Root cause: `run-migrations-unmerged-gate.test.ts` wrote a synthetic
+`zzz_unmerged_gate_<hex>.sql` fixture into the **real**
+`apps/web-platform/supabase/migrations/` dir (the SUT's `*.sql` glob roots there)
+and `unlinkSync`'d it in `afterAll`. Four sibling suites
+(`dsar-worm-guc-sites`, `dsar-message-redact-fields-sweep`, `migration-rpc-grants`,
+`dsar-allowlist-completeness`) `readdirSync` + `readFileSync` that same dir. When
+the local unsharded `vitest run` co-located the producer and a reader in one
+process tree, the reader listed the fixture, the producer's `afterAll` deleted
+it, and the reader's `readFileSync` hit ENOENT.
+
+## Solution
+
+**Producer-side elimination, not a consumer-side guard.** There was exactly ONE
+writer and FOUR readers, so removing the single write surface fixes all readers
+(current + future) at once; a `readdir` filter on one reader would leave three
+racing.
+
+1. Added an opt-in seam to `run-migrations.sh`:
+   `MIGRATIONS_DIR="${RUN_MIGRATIONS_TEST_DIR:-$SCRIPT_DIR/../supabase/migrations}"`
+   — `:-` default is byte-identical for every prod/CI caller (none set the var).
+2. The gate test now stages a temp copy of the real dir
+   (`mkdtempSync` + `cpSync(real, temp, {recursive:true})`), writes the synthetic
+   fixture into the **temp** dir, and passes `RUN_MIGRATIONS_TEST_DIR=<temp>` to
+   the SUT. The real dir is never written again.
+3. The `git ls-tree origin/main -- "apps/web-platform/supabase/migrations/$filename"`
+   gate predicate stays anchored to the **canonical repo path** (basename-only
+   lookup), so a temp-dir-only `zzz_*` file still trips the gate — the test's
+   three contracts are preserved.
+
+## Key Insight
+
+- **CI-green / local-red asymmetry is a sharding artifact, not a flaky test.**
+  Sharded CI (`VITEST_SHARD`) splits producer and readers across processes that
+  never co-execute; the unsharded local full-suite is the only place they race.
+  When a test passes in isolation and in CI but fails in the local full suite,
+  suspect a shared-mutable-filesystem surface, not the test logic.
+- **`isolate: true` does not isolate the filesystem.** Per-file module-graph /
+  process isolation is irrelevant to a shared on-disk directory; forked workers
+  share the real FS. The fix must remove the shared write surface.
+- **Pick the lever with the smallest fan-out.** 1 producer fixing 4 readers beats
+  4 consumer guards that must be re-applied to every future reader.
+- **Test-scoped env-override name, not a generic one.** `RUN_MIGRATIONS_TEST_DIR`
+  (not `MIGRATIONS_DIR`) is collision-proof against a same-named secret a future
+  Doppler config might inject via `doppler run` into the prod migrate step.
+- Precedent for the temp-dir staging idiom already existed in-repo:
+  `apps/web-platform/test/legal-doc-shas-guard.test.ts` (`mkdtempSync` + `cpSync`
+  + `rmSync`). See also [[cq-test-fixtures-synthesized-only]] and the
+  write-boundary discipline.
+
+## Session Errors
+
+1. **Planning subagent could not spawn nested Task agents** — `plan-review` /
+   `deepen-plan` fan-out degraded to in-context self-review.
+   Recovery: self-review covered the same halt-gates + verify-the-negative pass.
+   Prevention: environmental constraint (nested-subagent spawn unavailable);
+   already handled by the plan skill's graceful degradation — no workflow change.
+2. **`git diff main...HEAD` returned stale-ref noise** — local `main` ref lagged
+   `origin/main`, listing ~50 unrelated already-merged files.
+   Recovery: re-diffed against `origin/main` (the branch's real base).
+   Prevention: already covered by the work-skill bare-repo stale-ref guard; use
+   `origin/main...HEAD` (three-dot) for scope checks in a bare-repo worktree.
+
+## Tags
+category: test-failures
+module: apps/web-platform/test/scripts

--- a/knowledge-base/project/plans/2026-06-05-fix-dsar-worm-migrations-fixture-race-plan.md
+++ b/knowledge-base/project/plans/2026-06-05-fix-dsar-worm-migrations-fixture-race-plan.md
@@ -1,0 +1,385 @@
+---
+title: "fix: dsar-worm-guc-sites races run-migrations-unmerged-gate synthetic fixture in real migrations dir (ENOENT)"
+date: 2026-06-05
+type: fix
+issue: 4957
+branch: feat-one-shot-4957-dsar-worm-migrations-fixture-race
+lane: single-domain
+brand_survival_threshold: none
+status: planned
+---
+
+# fix: dsar-worm-guc-sites races run-migrations-unmerged-gate fixture in real migrations dir (ENOENT) 🐛
+
+Closes #4957.
+
+## Enhancement Summary
+
+**Deepened on:** 2026-06-05
+**Sections enhanced:** Overview, Research Reconciliation, Phase 1, Phase 2, AC3, Risks, Sharp Edges
+
+### Key Improvements (deepen-plan pass)
+
+1. **Env-var name hardened** `MIGRATIONS_DIR` → `RUN_MIGRATIONS_TEST_DIR` — the generic name
+   risked silent collision with a same-named Doppler-`prd` secret injected by `doppler run` in
+   the prod migrate step. Test-scoped name is collision-proof by construction.
+2. **Verify-the-negative pass** confirmed all three load-bearing claims against live code: the
+   gate predicate interpolates only `basename` (`run-migrations.sh:157,200`); `zzz_*` is absent
+   from origin/main (`git ls-tree` empty); no prod/CI caller passes the override
+   (`web-platform-release.yml:57` + `tenant-integration.yml` set only `DOPPLER_TOKEN`).
+3. **Precedent-diff gate** confirmed the temp-dir staging is NOT novel — it is the exact
+   `mkdtempSync`+`cpSync`+`rmSync` idiom already at `legal-doc-shas-guard.test.ts:32,39,67` and
+   already used by the gate test's own psql-stub lifecycle (lines 51,54,113).
+
+### New Considerations Discovered
+
+- Sibling scripts `lint-migration-fk-preconditions.sh` / `preflight-schema-vs-ledger.sh` carry
+  their own hardcoded `MIGRATIONS_DIR` and are NOT callers of `run-migrations.sh` — unaffected.
+- Two prod invocation sites exist (release + tenant-integration); both verified env-clean.
+
+## Overview
+
+`scripts/test-all.sh webplat` (the local full-suite exit gate) intermittently fails with
+`ENOENT: no such file or directory, open '.../supabase/migrations/zzz_unmerged_gate_<hex>.sql'`.
+
+The named file is a **synthetic test fixture** that
+`apps/web-platform/test/scripts/run-migrations-unmerged-gate.test.ts` creates inside the
+**real** `apps/web-platform/supabase/migrations/` directory and deletes in `afterAll`. Four
+sibling suites enumerate that same real directory with `readdirSync(...)` and then
+`readFileSync` each entry. When the local `vitest run` (no `--shard`) runs the producer suite
+and a reader suite concurrently across forked workers, the reader lists the synthetic `zzz_*`
+file, the producer's `afterAll` `unlinkSync`s it, and the reader's `readFileSync` hits ENOENT.
+
+This is a **shared-mutable-directory test-isolation bug**, independent of all product code.
+Main CI is green because the webplat job sets `VITEST_SHARD` (`scripts/test-all.sh:157-158`),
+splitting the producer and readers across separate shard processes that never co-execute. The
+local path (`VITEST_SHARD` unset → plain `vitest run` over all 470+ files) is the only place
+the two suites land in the same process tree, so it is the only place the race fires.
+
+**Chosen fix: producer-side elimination (issue Option 2), adapted to the SUT's path coupling.**
+The producer is the *single* writer into the real migrations dir; every reader (4 today, N
+tomorrow) is a passive victim. Removing the one write surface closes the entire race class at
+once, whereas a consumer-side guard (issue Option 1) would have to be applied to all four
+readers and re-applied to every future reader. Option 2 is structurally the YAGNI-correct
+choice here because the producer count is exactly 1.
+
+**Critical adaptation surfaced at plan time (see Research Reconciliation):** the issue's
+Option 2 prose ("point the SUT at a temp migrations dir") is **not directly achievable** —
+`run-migrations.sh` hardcodes both its glob root (`MIGRATIONS_DIR="$SCRIPT_DIR/../supabase/migrations"`,
+line 63-64) and its gate predicate path (`git ls-tree origin/main -- "apps/web-platform/supabase/migrations/$filename"`,
+line 200), with no dir-override env var. Pointing the SUT at a temp dir therefore requires a
+**production-script change** (adding an env override and keeping the `git ls-tree` predicate
+anchored to the canonical path) — a larger blast radius than the issue implies. The plan
+accounts for this by choosing the **lowest-blast-radius variant of Option 2**: add a single
+optional **`RUN_MIGRATIONS_TEST_DIR`** env override to the script (defaulting to current
+behavior, zero change for prod/CI callers) and have the gate test stage a temp dir containing
+real-`*.sql` copies plus the synthetic file. The real migrations dir is never written to again.
+A test-scoped env-var name (not the generic `MIGRATIONS_DIR`) is chosen so the override can
+never be tripped by an unrelated same-named secret injected via `doppler run` in the prod
+migrate step.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (issue body) | Reality (verified against branch HEAD) | Plan response |
+| --- | --- | --- |
+| Race is between `dsar-worm-guc-sites.test.ts` and `run-migrations-unmerged-gate.test.ts` | Confirmed. Producer writes `zzz_*` via `openSync` (`gate.test.ts:127-140`); `dsar-worm-guc` does unguarded `readFileSync` in its top-level collection loop (`dsar-worm-guc-sites.test.ts:131-133`, outside any try/catch). | Fix the producer; this reader (and 3 others) become safe automatically. |
+| Only `dsar-worm-guc` reads the dir | **Four** suites `readdirSync` the real dir and `readFileSync` each entry: `dsar-worm-guc-sites`, `dsar-message-redact-fields-sweep`, `migration-rpc-grants`, `dsar-allowlist-completeness`. All let `zzz_*.sql` pass their `.sql` filter. | Confirms producer-side is the correct lever (1 producer fixes 4+ readers). Option 1 on a single reader would leave 3 racing. |
+| Option 2: "point the SUT at a temp migrations dir … without losing fidelity" | **Not directly achievable.** `run-migrations.sh` hardcodes the glob root (L63-64) *and* the `git ls-tree origin/main -- apps/web-platform/supabase/migrations/$filename` predicate (L200, where `filename="$(basename "$migration_file")"` at L157 — basename only). No dir override exists. | Add an optional **`RUN_MIGRATIONS_TEST_DIR`** env override to the script (default unchanged). Keep the gate predicate path literal — it interpolates only the basename, which for `zzz_*` is absent from origin/main, so `git ls-tree` returns empty and the gate still fires. See Phase 1. **Deepen note:** a generic `MIGRATIONS_DIR` name was rejected — too collision-prone with a possible Doppler-`prd` secret of the same name that `doppler run` would inject into the `web-platform-release.yml` migrate step's env (verified no such secret exists today, but the test-scoped name is collision-proof by construction). |
+| `isolate: true` on the unit project should prevent this | `isolate: true` (`vitest.config.ts`) gives each file a fresh module graph / process, but does **not** isolate a shared on-disk directory. Forked workers share the real filesystem. | Isolation is irrelevant to this bug; the fix must remove the shared write surface, not rely on isolate. |
+| CI green / local red | Confirmed. `scripts/test-all.sh:157-158` forwards `VITEST_SHARD` (set in CI matrix, unset locally). Sharding splits producer/readers across processes in CI; local unsharded `vitest run` co-locates them. | No CI workflow change needed; fix is in test/script source only. |
+| Pre-existing, not caused by PR #4954 | `gh pr view 4954 --json files` → zero files under `apps/web-platform/test/` or `.../supabase/`. | Treat as pre-existing flake; no regression introduced by the discovering PR. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** nothing user-facing — this is a developer-only
+test-isolation flake in the local full-suite gate. A broken fix would, at worst, leave the
+local `test-all.sh webplat` shard intermittently red (the status quo) or, in the bad case,
+write a stray `zzz_*.sql` into the real migrations dir that a developer accidentally commits.
+The plan's AC explicitly guards the no-stray-file invariant.
+
+**If this leaks, the user's data/workflow/money is exposed via:** N/A — no user data, secret,
+or runtime surface is touched. The change is confined to a test file and a dev/CI migration
+script's directory-resolution logic (which already runs only against dev/CI databases behind
+the `ALLOW_UNMERGED_DEV_APPLY` + `git ls-tree` gates).
+
+**Brand-survival threshold:** none — developer-tooling reliability fix, no production code path,
+no regulated-data surface. (Sensitive-path scope-out: `threshold: none, reason: change is
+limited to test files plus a dev/CI migration script's MIGRATIONS_DIR resolution; no schema
+DDL, auth flow, API route, or user-data surface is modified.`)
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] **AC1 — Race eliminated at the source.** `run-migrations-unmerged-gate.test.ts` no longer
+  writes any `*.sql` file into `apps/web-platform/supabase/migrations/`. Verify:
+  `grep -nE "join\(MIGRATIONS_DIR|supabase/migrations" apps/web-platform/test/scripts/run-migrations-unmerged-gate.test.ts`
+  returns **no** line where a synthetic file is `openSync`/`writeFileSync`/`writeSync`-created
+  under the real dir. (The const `MIGRATIONS_DIR` may remain referenced only for copying real
+  `*.sql` *out* of the real dir into the temp staging dir.)
+- [ ] **AC2 — Gate test still asserts the same three contracts.** The three `test(...)` cases
+  (gate-blocks-exit-1, ack-warns-exit-0, positive-control) still exist and pass against the
+  temp-dir staging. Verify: `./node_modules/.bin/vitest run test/scripts/run-migrations-unmerged-gate.test.ts`
+  from `apps/web-platform/` → all tests pass; output contains the three case titles unchanged
+  in intent.
+- [ ] **AC3 — Production/CI callers unchanged.** `run-migrations.sh` with no
+  `RUN_MIGRATIONS_TEST_DIR` env set resolves to `"$SCRIPT_DIR/../supabase/migrations"` exactly
+  as before. Verify: `grep -nE 'MIGRATIONS_DIR=' apps/web-platform/scripts/run-migrations.sh`
+  shows the override form is
+  `MIGRATIONS_DIR="${RUN_MIGRATIONS_TEST_DIR:-$SCRIPT_DIR/../supabase/migrations}"` (default
+  preserves current behavior). Verify no caller passes it:
+  `grep -rn 'RUN_MIGRATIONS_TEST_DIR' .github/ apps/web-platform/ | grep -v 'test/'` →
+  only the script's own default assignment.
+- [ ] **AC4 — No stray fixture in the real dir after a full run.** After running the gate suite
+  (and a full `vitest run`), `git status --porcelain apps/web-platform/supabase/migrations/`
+  is empty and `ls apps/web-platform/supabase/migrations/zzz_* 2>/dev/null` returns nothing.
+- [ ] **AC5 — Local full-suite shard is green and stable.** `scripts/test-all.sh webplat`
+  (no `VITEST_SHARD`) passes across **≥5 consecutive runs** with zero ENOENT on a
+  `supabase/migrations/zzz_*` path. Capture the 5 exit codes in the PR body.
+- [ ] **AC6 — Reader suites unmodified (or, if any consumer-side belt-and-braces guard is
+  added, scoped to all four readers).** Default plan modifies only the producer + script;
+  if a defensive readdir-filter is added (see Phase 3, optional), it MUST be applied to all
+  four readers (`dsar-worm-guc-sites`, `dsar-message-redact-fields-sweep`, `migration-rpc-grants`,
+  `dsar-allowlist-completeness`), not just the one in the issue title. Default: no reader
+  changes.
+- [ ] **AC7 — PR body uses `Closes #4957`** (in body, not title).
+
+### Post-merge (operator)
+
+- [ ] None. Pure test/dev-script change; merge to main is the only required action. CI
+  re-runs the webplat shards on the PR.
+
+## Implementation Phases
+
+### Phase 1 — Add an optional `RUN_MIGRATIONS_TEST_DIR` override to `run-migrations.sh`
+
+**File to edit:** `apps/web-platform/scripts/run-migrations.sh`
+
+- Change line 64 from:
+  ```bash
+  MIGRATIONS_DIR="$SCRIPT_DIR/../supabase/migrations"
+  ```
+  to:
+  ```bash
+  # Default to the real dir; tests may override via RUN_MIGRATIONS_TEST_DIR to
+  # a temp staging dir so they never write transient *.sql into the real
+  # migrations tree (#4957). The git ls-tree gate (below) intentionally stays
+  # anchored to the canonical repo path — a temp-dir filename absent from
+  # origin/main still trips the gate, which is exactly what the gate test
+  # exercises. A test-scoped var name (not MIGRATIONS_DIR) avoids any collision
+  # with a same-named secret a future Doppler config might inject via
+  # `doppler run` in the prod migrate step.
+  MIGRATIONS_DIR="${RUN_MIGRATIONS_TEST_DIR:-$SCRIPT_DIR/../supabase/migrations}"
+  ```
+- **Do NOT** change the gate predicate at line 200
+  (`git ls-tree origin/main -- "apps/web-platform/supabase/migrations/$filename"`). It uses
+  only the *basename* (`filename="$(basename "$migration_file")"` at line 157), and a synthetic
+  `zzz_*` basename is absent from origin/main regardless of where the glob rooted — so the gate
+  still fires. This preserves the test's existing assertions verbatim. (Verified: `git ls-tree
+  origin/main -- apps/web-platform/supabase/migrations/ | grep zzz_unmerged` → empty.)
+- Verify the script still parses: `bash -n apps/web-platform/scripts/run-migrations.sh`.
+
+**Why a script change is unavoidable:** the SUT has no dir-injection seam today (confirmed:
+`grep -n 'MIGRATIONS_DIR' run-migrations.sh` shows only the hardcoded assignment at L64). The
+override is the minimal seam; defaulting via `${VAR:-...}` makes it a strict no-op for every
+existing caller. **Callers verified (deepen pass):** `web-platform-release.yml:57`
+(`doppler run -c prd -- bash …run-migrations.sh`, env = `DOPPLER_TOKEN` only) and
+`tenant-integration.yml` — neither sets `RUN_MIGRATIONS_TEST_DIR`; default behavior preserved.
+The sibling scripts `lint-migration-fk-preconditions.sh` and `preflight-schema-vs-ledger.sh`
+each carry their *own* hardcoded `MIGRATIONS_DIR` (they are not callers of `run-migrations.sh`)
+and are unaffected.
+
+### Phase 2 — Rewrite the gate test to stage a temp migrations dir
+
+**File to edit:** `apps/web-platform/test/scripts/run-migrations-unmerged-gate.test.ts`
+
+- In `beforeAll`: `mkdtempSync(join(tmpdir(), "run-migrations-gate-"))`, then copy every real
+  `*.sql` from the real `MIGRATIONS_DIR` into the temp dir (`copyFileSync` per file, or
+  `cpSync(realDir, tempDir, { recursive: true })`). Track the temp dir for `afterAll` sweep
+  (reuse the existing `stubDirs`-style tracking array, or a new `tempMigrationsDir` var).
+- Write the synthetic `zzz_unmerged_gate_<hex>.sql` into the **temp** dir (not the real dir).
+  Keep the randomized suffix and the `zzz_` prefix (so it still sorts last under the glob).
+- In `runScript`, pass `RUN_MIGRATIONS_TEST_DIR: <tempDir>` in the `env` object handed to
+  `spawnSync`, alongside the existing `PATH` stub. The script's Phase-1 override then roots its
+  `*.sql` glob at the temp dir, sees the synthetic file there, and the `git ls-tree` gate (still
+  anchored to the canonical repo path) returns empty for `zzz_*` → gate fires, exactly as today.
+- Update `SYNTHETIC_MIGRATION` to point at the temp dir; the three assertions remain unchanged
+  (they match on the basename `SYNTHETIC_FILE` and the `::error::`/`::warning::` contract, not
+  on the absolute path).
+- Keep the `process.on("exit", sweep)` + `afterAll(sweep)` belt-and-braces, but the sweep now
+  `rmSync(tempDir, { recursive: true, force: true })` instead of `unlinkSync`ing a file in the
+  real dir. The `beforeAll` precondition (atomic `O_CREAT|O_EXCL` against the real dir, lines
+  124-140) becomes unnecessary — there is no longer a real-dir file to collide with; replace it
+  with the temp-dir staging. (A leftover temp dir under `os.tmpdir()` from a crashed run is
+  harmless and `mkdtempSync` is collision-free by construction.)
+- **Fidelity check:** the positive-control test references `KNOWN_MERGED_FILE =
+  "053_template_authorizations.sql"`. Because we copy *all* real `*.sql` into the temp dir, the
+  merged file is present in the glob and its `git ls-tree` lookup (canonical path) still returns
+  non-empty → control still passes. No fidelity loss.
+
+**Pseudocode shape (illustrative, not load-bearing):**
+```ts
+// beforeAll
+tempMigrationsDir = mkdtempSync(join(tmpdir(), "run-migrations-gate-"));
+cpSync(REAL_MIGRATIONS_DIR, tempMigrationsDir, { recursive: true }); // real *.sql copied in
+writeFileSync(join(tempMigrationsDir, SYNTHETIC_FILE),
+  "-- synthetic test migration; never on origin/main.\nSELECT 1;\n");
+
+// runScript env
+env: { ...process.env, ...env, RUN_MIGRATIONS_TEST_DIR: tempMigrationsDir, PATH: `${stubDir}:...` }
+
+// sweep / afterAll
+rmSync(tempMigrationsDir, { recursive: true, force: true });
+```
+
+**Precedent (deepen-plan Phase 4.4 — pattern is NOT novel).** This is the canonical temp-dir
+staging idiom already in this test directory:
+- `apps/web-platform/test/legal-doc-shas-guard.test.ts:32,39,67` — exact
+  `mkdtempSync(join(tmpdir(), "..."))` → `cpSync(real, tmp, { recursive: true })` →
+  `rmSync(tmp, { recursive: true, force: true })` sequence the plan adopts verbatim.
+- The gate test **itself already** uses `mkdtempSync(join(tmpdir(), "psql-stub-"))` for the
+  psql stub (line 54), tracks dirs in `stubDirs[]` (line 51), and sweeps via
+  `rmSync(dir, { recursive: true, force: true })` (line 113). The new temp migrations dir
+  reuses the file's own established lifecycle — no new pattern introduced.
+
+### Phase 3 — (Optional, default OFF) defensive readdir filter on all four readers
+
+Default: **skip.** Phase 1+2 fully closes the race by removing the only writer. A consumer-side
+filter is pure belt-and-braces and adds churn to four files. Only add if review explicitly
+requests defense-in-depth. **If added, it MUST cover all four readers** (`dsar-worm-guc-sites`,
+`dsar-message-redact-fields-sweep`, `migration-rpc-grants`, `dsar-allowlist-completeness`) with
+the same one-line filter `&& !f.startsWith("zzz_unmerged_gate_")` on their `readdirSync(...)`
+result, per AC6 — never just the one named in the issue title. (See Sharp Edges: applying it to
+a single reader recreates the partial-coverage failure mode.)
+
+### Phase 4 — Verify
+
+- From `apps/web-platform/`: `./node_modules/.bin/vitest run test/scripts/run-migrations-unmerged-gate.test.ts`
+  → 3/3 pass.
+- From `apps/web-platform/`: `./node_modules/.bin/vitest run test/dsar-worm-guc-sites.test.ts test/dsar-message-redact-fields-sweep.test.ts test/migration-rpc-grants.test.ts test/dsar-allowlist-completeness.test.ts test/scripts/run-migrations-unmerged-gate.test.ts`
+  in one process → all pass, no ENOENT (forces co-location of producer + all readers).
+- From repo root: run `scripts/test-all.sh webplat` **5×** (loop), confirm green each time and
+  capture exit codes for AC5.
+- `git status --porcelain apps/web-platform/supabase/migrations/` empty (AC4).
+
+## Files to Edit
+
+- `apps/web-platform/scripts/run-migrations.sh` — change L64 to
+  `MIGRATIONS_DIR="${RUN_MIGRATIONS_TEST_DIR:-$SCRIPT_DIR/../supabase/migrations}"` (Phase 1).
+- `apps/web-platform/test/scripts/run-migrations-unmerged-gate.test.ts` — stage temp dir, write
+  synthetic file there, pass `MIGRATIONS_DIR` env to the SUT, sweep temp dir (Phase 2).
+
+## Files to Create
+
+- None.
+
+## Test Strategy
+
+Runner: **vitest** (per `apps/web-platform/package.json` `test:ci = "vitest run"` and
+`apps/web-platform/vitest.config.ts`; the `unit` project collects `test/**/*.test.ts` and
+`isolate: true`). No new framework. The gate test stays under `test/scripts/` (matches the
+`unit` project's `test/**/*.test.ts` glob). The verification step intentionally runs the
+producer + all four readers in **one** `vitest run` invocation to reproduce the co-location that
+the sharded CI path hides — a green run there is the canonical proof the race is gone.
+
+### Research Insights
+
+**Verification artifacts captured this pass (all against branch HEAD / origin/main):**
+
+- Gate predicate is basename-scoped:
+  ```
+  run-migrations.sh:157  filename="$(basename "$migration_file")"
+  run-migrations.sh:200  if [[ -z "$(git ls-tree origin/main -- "apps/web-platform/supabase/migrations/$filename" 2>/dev/null)" ]]; then
+  ```
+- Synthetic file absent from main: `git ls-tree origin/main -- apps/web-platform/supabase/migrations/ | grep zzz_unmerged` → (empty).
+- Four readdir-based readers race the same dir (only consumer-side blast radius):
+  `dsar-worm-guc-sites`, `dsar-message-redact-fields-sweep`, `migration-rpc-grants`,
+  `dsar-allowlist-completeness`. One producer: `run-migrations-unmerged-gate.test.ts`.
+- `isolate: true` (both `unit` and `component` projects, `vitest.config.ts`) gives per-file
+  module-graph/process isolation but does NOT isolate the shared on-disk migrations dir — which
+  is precisely why a producer-side fix (remove the write), not an isolation knob, is required.
+
+**Pattern precedent (canonical, in-repo):** `legal-doc-shas-guard.test.ts` copies real source
+into a `mkdtempSync` dir via `cpSync(..., { recursive: true })` and sweeps with
+`rmSync(..., { recursive: true, force: true })` — the plan adopts this verbatim.
+
+## Risks & Mitigations
+
+- **`cpSync` of the whole migrations dir per run is I/O.** ~100 small `*.sql` files; negligible
+  (< a few ms) and one-time in `beforeAll`. Mitigation: copy only `*.sql` (skip `.down.sql` is
+  unnecessary — they're inert for the gate, but copying them keeps fidelity; either is fine).
+- **`git ls-tree` path stays canonical while the glob roots elsewhere.** This is intentional and
+  is the load-bearing fidelity property: the gate's job is to compare a *basename* against
+  origin/main's canonical migrations path, independent of where the runner physically reads
+  files. Verified against `run-migrations.sh:200` — the predicate interpolates only `$filename`
+  (basename). Mitigation: AC2 asserts the three contracts still pass; the positive-control test
+  proves a merged basename does not trip the gate.
+- **A future env var could collide with the override.** Mitigated by choosing the test-scoped
+  name `RUN_MIGRATIONS_TEST_DIR` (deepen-plan finding) rather than the generic `MIGRATIONS_DIR`.
+  A generic name risked being silently honored if a Doppler `prd` secret of the same name were
+  ever injected by `doppler run` in the `web-platform-release.yml` migrate step. Verified no such
+  secret exists today; the test-scoped name makes the class impossible regardless. The override
+  is opt-in and no prod/CI path sets it (confirmed via grep over `.github/` + `apps/web-platform/`).
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected — developer test-isolation / tooling change. No user-facing
+surface (Product NONE; no file under `components/**`, `app/**/page.tsx`, or `app/**/layout.tsx`).
+No legal/compliance surface (no regulated-data write; the touched script already runs only
+against dev/CI DBs behind existing gates). No infrastructure surface (no new server, secret,
+vendor, cron, or persistent process — the migration script's *directory resolution* changes,
+not any provisioned resource).
+
+## Infrastructure (IaC)
+
+N/A — no new infrastructure. The change edits a test file and adds an env-var default to an
+existing dev/CI shell script. No Terraform, no new secret, no new vendor or runtime process.
+
+## Observability
+
+N/A — no new code-class file under `apps/*/server/`, `apps/*/src/`, `apps/*/infra/`, or
+`plugins/*/scripts/`, and no new infrastructure surface. The change is a test file plus a
+directory-resolution default in an existing dev/CI script. The race's *detection* signal is
+already the local `scripts/test-all.sh webplat` shard turning red on ENOENT; AC5 makes "5×
+green" the regression-proof. (Plan Phase 2.9 skip condition met: no observable runtime surface
+is introduced.)
+
+## Open Code-Review Overlap
+
+None. (Checked open `code-review`-labeled issues against `Files to Edit`:
+`apps/web-platform/scripts/run-migrations.sh` and
+`apps/web-platform/test/scripts/run-migrations-unmerged-gate.test.ts` — no open scope-out
+touches either path.)
+
+## Sharp Edges
+
+- **Do not "fix" only `dsar-worm-guc-sites`.** Three other suites
+  (`dsar-message-redact-fields-sweep`, `migration-rpc-grants`, `dsar-allowlist-completeness`)
+  read the same real dir and race the same fixture. A consumer-side guard on the single named
+  reader leaves the race live for the other three — the exact partial-coverage trap the
+  producer-side fix avoids. If review insists on belt-and-braces consumer guards (Phase 3),
+  apply the filter to **all four** readers (AC6).
+- **Do not change the `git ls-tree` predicate path.** It must stay anchored to the canonical
+  `apps/web-platform/supabase/migrations/` path even when the glob roots at a temp dir — that
+  decoupling is what lets the synthetic file trip the gate while the runner reads the temp dir.
+  Repointing it to the temp dir would break the gate's semantics (a temp-dir path is never on
+  origin/main *as a path*, but the gate compares basenames).
+- **The override default must be `MIGRATIONS_DIR="${RUN_MIGRATIONS_TEST_DIR:-$SCRIPT_DIR/../supabase/migrations}"`,
+  not a bare reassignment.** A bare `MIGRATIONS_DIR=$SCRIPT_DIR/...` would ignore the test's
+  injected value; omitting the `:-` default would break prod (unset → empty dir). The `:-`
+  default form with the test-scoped var name is the only correct shape (AC3 asserts it).
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder
+  text, or omits the threshold will fail `deepen-plan` Phase 4.6. (This plan's section is
+  filled with threshold `none` + sensitive-path scope-out reason.)
+
+## Alternative Approaches Considered
+
+| Approach | Verdict | Rationale |
+| --- | --- | --- |
+| **Option 1 — consumer-side guard on `dsar-worm-guc-sites` only** | Rejected | Leaves 3 other readers racing; recreates the bug under any new reader. |
+| **Option 1b — consumer-side guard on all 4 readers** | Fallback (Phase 3, default off) | Works, but 4-file churn + must be re-applied to every future reader; treats the symptom, not the shared-write surface. Kept as belt-and-braces only if review requests it. |
+| **Option 2 — producer stages a temp dir (chosen)** | **Chosen** | Removes the single write surface; fixes all readers (current + future) at once. Requires a minimal `MIGRATIONS_DIR` override in the SUT (the issue's prose understated this; see Research Reconciliation). |
+| Exclude the gate test from the `unit` project / mark it serial | Rejected | Hides the race rather than removing it; loses coverage or couples the fix to vitest scheduling internals. `isolate: true` already doesn't help (shared FS), and a serial/exclude hack is brittle across vitest versions. |
+| Move all migration-reading suites to read a git-tracked snapshot instead of the live dir | Rejected (YAGNI) | Large refactor across 4+ suites for a problem the 2-file producer fix already closes. No deferral issue needed — superseded by the chosen fix. |

--- a/knowledge-base/project/specs/feat-one-shot-4957-dsar-worm-migrations-fixture-race/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-4957-dsar-worm-migrations-fixture-race/tasks.md
@@ -1,0 +1,61 @@
+---
+title: "Tasks — fix dsar-worm-guc-sites / run-migrations-unmerged-gate fixture race (#4957)"
+date: 2026-06-05
+issue: 4957
+branch: feat-one-shot-4957-dsar-worm-migrations-fixture-race
+lane: single-domain
+plan: knowledge-base/project/plans/2026-06-05-fix-dsar-worm-migrations-fixture-race-plan.md
+---
+
+# Tasks — #4957 fixture-race fix
+
+Derived from the finalized + deepened plan. Producer-side fix: remove the only writer into the
+real `apps/web-platform/supabase/migrations/` dir so all four readdir-based readers stop racing.
+
+## Phase 1 — Script seam (`run-migrations.sh`)
+
+- [ ] 1.1 Edit `apps/web-platform/scripts/run-migrations.sh` line 64 to
+  `MIGRATIONS_DIR="${RUN_MIGRATIONS_TEST_DIR:-$SCRIPT_DIR/../supabase/migrations}"` with the
+  comment block from the plan (explains the test-scoped name + the canonical-path gate anchor).
+- [ ] 1.2 Do NOT touch the `git ls-tree origin/main -- "apps/web-platform/supabase/migrations/$filename"`
+  predicate (line 200) — it stays anchored to the canonical path (basename-only lookup).
+- [ ] 1.3 Verify the script parses: `bash -n apps/web-platform/scripts/run-migrations.sh`.
+
+## Phase 2 — Gate test stages a temp dir (`run-migrations-unmerged-gate.test.ts`)
+
+- [ ] 2.1 In `beforeAll`: `mkdtempSync(join(tmpdir(), "run-migrations-gate-"))`, then
+  `cpSync(realMigrationsDir, tempDir, { recursive: true })` (precedent:
+  `legal-doc-shas-guard.test.ts:32,39`). Track the temp dir for sweep.
+- [ ] 2.2 Write the synthetic `zzz_unmerged_gate_<hex>.sql` into the **temp** dir (not the real
+  dir). Keep the `zzz_` prefix + randomized suffix.
+- [ ] 2.3 Pass `RUN_MIGRATIONS_TEST_DIR: <tempDir>` in the `runScript` `env` object alongside the
+  existing `PATH` stub.
+- [ ] 2.4 Point `SYNTHETIC_MIGRATION` at the temp dir; keep the three assertions unchanged (they
+  match the basename + `::error::`/`::warning::` contract).
+- [ ] 2.5 Replace the real-dir `beforeAll` atomic-create precondition (O_CREAT|O_EXCL, lines
+  124-140) with the temp-dir staging; change `sweep` to `rmSync(tempDir, { recursive: true, force: true })`
+  (precedent: same file's `stubDirs` sweep, line 113). Keep `process.on("exit", sweep)` +
+  `afterAll(sweep)`.
+
+## Phase 3 — (Optional, default OFF) consumer-side belt-and-braces
+
+- [ ] 3.1 SKIP by default. Only if review requests defense-in-depth: add
+  `&& !f.startsWith("zzz_unmerged_gate_")` to the `readdirSync` filter in ALL FOUR readers
+  (`dsar-worm-guc-sites`, `dsar-message-redact-fields-sweep`, `migration-rpc-grants`,
+  `dsar-allowlist-completeness`) — never just one (AC6).
+
+## Phase 4 — Verify
+
+- [ ] 4.1 `cd apps/web-platform && ./node_modules/.bin/vitest run test/scripts/run-migrations-unmerged-gate.test.ts` → 3/3 pass (AC2).
+- [ ] 4.2 Co-location run (one process, producer + all 4 readers):
+  `./node_modules/.bin/vitest run test/dsar-worm-guc-sites.test.ts test/dsar-message-redact-fields-sweep.test.ts test/migration-rpc-grants.test.ts test/dsar-allowlist-completeness.test.ts test/scripts/run-migrations-unmerged-gate.test.ts`
+  → all pass, no ENOENT.
+- [ ] 4.3 `scripts/test-all.sh webplat` 5× (loop), green each time; capture exit codes for AC5.
+- [ ] 4.4 `git status --porcelain apps/web-platform/supabase/migrations/` empty (AC4);
+  `ls apps/web-platform/supabase/migrations/zzz_* 2>/dev/null` empty.
+
+## Ship
+
+- [ ] 5.1 PR body uses `Closes #4957` (body, not title) (AC7).
+- [ ] 5.2 Paste the 5 webplat exit codes (AC5) into the PR body.
+- [ ] 5.3 No post-merge operator steps — merge is the only action.

--- a/knowledge-base/project/specs/feat-one-shot-4957-dsar-worm-migrations-fixture-race/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-4957-dsar-worm-migrations-fixture-race/tasks.md
@@ -14,25 +14,25 @@ real `apps/web-platform/supabase/migrations/` dir so all four readdir-based read
 
 ## Phase 1 — Script seam (`run-migrations.sh`)
 
-- [ ] 1.1 Edit `apps/web-platform/scripts/run-migrations.sh` line 64 to
+- [x] 1.1 Edit `apps/web-platform/scripts/run-migrations.sh` line 64 to
   `MIGRATIONS_DIR="${RUN_MIGRATIONS_TEST_DIR:-$SCRIPT_DIR/../supabase/migrations}"` with the
   comment block from the plan (explains the test-scoped name + the canonical-path gate anchor).
-- [ ] 1.2 Do NOT touch the `git ls-tree origin/main -- "apps/web-platform/supabase/migrations/$filename"`
+- [x] 1.2 Do NOT touch the `git ls-tree origin/main -- "apps/web-platform/supabase/migrations/$filename"`
   predicate (line 200) — it stays anchored to the canonical path (basename-only lookup).
-- [ ] 1.3 Verify the script parses: `bash -n apps/web-platform/scripts/run-migrations.sh`.
+- [x] 1.3 Verify the script parses: `bash -n apps/web-platform/scripts/run-migrations.sh`.
 
 ## Phase 2 — Gate test stages a temp dir (`run-migrations-unmerged-gate.test.ts`)
 
-- [ ] 2.1 In `beforeAll`: `mkdtempSync(join(tmpdir(), "run-migrations-gate-"))`, then
+- [x] 2.1 In `beforeAll`: `mkdtempSync(join(tmpdir(), "run-migrations-gate-"))`, then
   `cpSync(realMigrationsDir, tempDir, { recursive: true })` (precedent:
   `legal-doc-shas-guard.test.ts:32,39`). Track the temp dir for sweep.
-- [ ] 2.2 Write the synthetic `zzz_unmerged_gate_<hex>.sql` into the **temp** dir (not the real
+- [x] 2.2 Write the synthetic `zzz_unmerged_gate_<hex>.sql` into the **temp** dir (not the real
   dir). Keep the `zzz_` prefix + randomized suffix.
-- [ ] 2.3 Pass `RUN_MIGRATIONS_TEST_DIR: <tempDir>` in the `runScript` `env` object alongside the
+- [x] 2.3 Pass `RUN_MIGRATIONS_TEST_DIR: <tempDir>` in the `runScript` `env` object alongside the
   existing `PATH` stub.
-- [ ] 2.4 Point `SYNTHETIC_MIGRATION` at the temp dir; keep the three assertions unchanged (they
+- [x] 2.4 Point `SYNTHETIC_MIGRATION` at the temp dir; keep the three assertions unchanged (they
   match the basename + `::error::`/`::warning::` contract).
-- [ ] 2.5 Replace the real-dir `beforeAll` atomic-create precondition (O_CREAT|O_EXCL, lines
+- [x] 2.5 Replace the real-dir `beforeAll` atomic-create precondition (O_CREAT|O_EXCL, lines
   124-140) with the temp-dir staging; change `sweep` to `rmSync(tempDir, { recursive: true, force: true })`
   (precedent: same file's `stubDirs` sweep, line 113). Keep `process.on("exit", sweep)` +
   `afterAll(sweep)`.
@@ -46,12 +46,12 @@ real `apps/web-platform/supabase/migrations/` dir so all four readdir-based read
 
 ## Phase 4 — Verify
 
-- [ ] 4.1 `cd apps/web-platform && ./node_modules/.bin/vitest run test/scripts/run-migrations-unmerged-gate.test.ts` → 3/3 pass (AC2).
-- [ ] 4.2 Co-location run (one process, producer + all 4 readers):
+- [x] 4.1 `cd apps/web-platform && ./node_modules/.bin/vitest run test/scripts/run-migrations-unmerged-gate.test.ts` → 3/3 pass (AC2).
+- [x] 4.2 Co-location run (one process, producer + all 4 readers):
   `./node_modules/.bin/vitest run test/dsar-worm-guc-sites.test.ts test/dsar-message-redact-fields-sweep.test.ts test/migration-rpc-grants.test.ts test/dsar-allowlist-completeness.test.ts test/scripts/run-migrations-unmerged-gate.test.ts`
   → all pass, no ENOENT.
-- [ ] 4.3 `scripts/test-all.sh webplat` 5× (loop), green each time; capture exit codes for AC5.
-- [ ] 4.4 `git status --porcelain apps/web-platform/supabase/migrations/` empty (AC4);
+- [x] 4.3 `scripts/test-all.sh webplat` 5× (loop), green each time; capture exit codes for AC5.
+- [x] 4.4 `git status --porcelain apps/web-platform/supabase/migrations/` empty (AC4);
   `ls apps/web-platform/supabase/migrations/zzz_* 2>/dev/null` empty.
 
 ## Ship


### PR DESCRIPTION
## Summary

Fixes the intermittent local-only `scripts/test-all.sh webplat` failure (#4957):
`ENOENT … supabase/migrations/zzz_unmerged_gate_<hex>.sql`.

`run-migrations-unmerged-gate.test.ts` wrote a synthetic `zzz_*` fixture into the
**real** `apps/web-platform/supabase/migrations/` dir and deleted it in `afterAll`.
Four sibling suites (`dsar-worm-guc-sites`, `dsar-message-redact-fields-sweep`,
`migration-rpc-grants`, `dsar-allowlist-completeness`) `readdirSync` + `readFileSync`
that same dir. The local unsharded `vitest run` co-located the producer and a reader
in one process tree, so the reader listed the fixture and the producer's `afterAll`
deleted it before the reader's `readFileSync` — ENOENT. Sharded CI never co-located
them, so main stayed green.

**Producer-side fix (issue Option 2):** one writer, four readers → remove the single
write surface and all readers stop racing.

Closes #4957

## Changelog

- `run-migrations.sh`: add an opt-in `RUN_MIGRATIONS_TEST_DIR` override
  (`MIGRATIONS_DIR="${RUN_MIGRATIONS_TEST_DIR:-$SCRIPT_DIR/../supabase/migrations}"`).
  The `:-` default is byte-identical for every prod/CI caller (none set the var);
  the `git ls-tree origin/main` gate stays anchored to the canonical repo path
  (basename-only), so a temp-dir-only `zzz_*` file still trips the gate.
- `run-migrations-unmerged-gate.test.ts`: stage a temp copy of the real migrations
  dir (`mkdtempSync`+`cpSync`), write the synthetic fixture there, pass
  `RUN_MIGRATIONS_TEST_DIR` to the SUT, and `rmSync` the temp dir on sweep. The real
  dir is never written again. Review hardening: pin `SYNTHETIC_FILE` in the gate-blocks
  assertion + guard against an empty temp-dir fallback.

## Test plan

- `vitest run test/scripts/run-migrations-unmerged-gate.test.ts` → 3/3 pass (AC2).
- Co-location run (producer + all 4 readers, one process) → 429/429 pass, zero ENOENT (AC1).
- `scripts/test-all.sh webplat` × 5 → green, exit codes `0 0 0 0 0` (AC5).
- `git status --porcelain apps/web-platform/supabase/migrations/` empty; no `zzz_*` stray (AC4).
- No prod/CI caller sets `RUN_MIGRATIONS_TEST_DIR` (AC3).

No post-merge operator steps — merge is the only required action.

Generated with [Claude Code](https://claude.com/claude-code)