### PR TITLE
refactor(kb): migrate authenticateAndResolveKbPath to ADR-044 membership-scoped resolvers (#4956)

### DIFF
--- a/apps/web-platform/.service-role-allowlist
+++ b/apps/web-platform/.service-role-allowlist
@@ -264,10 +264,20 @@ apps/web-platform/server/inngest/functions/cron-supabase-disk-io.ts
 # checked resolve_workspace_installation_id SECURITY DEFINER RPC through a
 # tenant client (getFreshTenantClient), so it no longer imports service-role.
 
-# kb-route-helpers.ts was REMOVED from this allowlist in PR #4929 (PIR #4913
-# follow-up): the #4913/#4919 service-role tenant-mint fallback was reverted as
-# dead code (PIR proved the mint failure was a misdiagnosis — it works in prod;
-# the real dead-end was the missing `workspace_id` on NOT-NULL inserts, fixed in
-# #4922). Both resolveUserKbRoot and authenticateAndResolveKbPath are now
-# tenant-only again (RuntimeAuthError → 503/403, no service-role read), so the
-# file no longer imports createServiceClient and must not be allowlisted.
+# resolveUserKbRoot was removed in PR #4929 (PIR #4913 follow-up): the
+# #4913/#4919 service-role tenant-mint fallback was reverted as dead code (PIR
+# proved the mint failure was a misdiagnosis — it works in prod; the real
+# dead-end was the missing `workspace_id` on NOT-NULL inserts, fixed in #4922),
+# and that function was later deleted in the #4953 resolver consolidation.
+#
+# PERMANENT — kb-route-helpers.ts is RE-ADDED in #4956 (ADR-044 migration). The
+# #4929 revert left authenticateAndResolveKbPath on a tenant `users` read; #4956
+# migrates it to the membership-scoped service-role resolvers
+# (resolveActiveWorkspaceKbRoot + resolveActiveWorkspaceRepoMeta — the same path
+# kb/share + kb/upload took in #4953), so the helper again calls
+# createServiceClient() to feed those resolvers. This is NOT the reverted
+# tenant-mint fallback: the service client is handed to resolvers that read the
+# `workspaces` source of truth + the membership-checked installation RPC and
+# fail CLOSED to the solo workspace (never a sibling). The credential read is
+# membership-scoped, not RLS-row-exposed (ADR-044 strengthens isolation).
+apps/web-platform/server/kb-route-helpers.ts

--- a/apps/web-platform/infra/sentry/issue-alerts.tf
+++ b/apps/web-platform/infra/sentry/issue-alerts.tf
@@ -562,11 +562,13 @@ resource "sentry_issue_alert" "workspace_sync_health" {
 # the identical RuntimeAuthError→503 mint-failure class the issue body omitted;
 # at brand-survival threshold `single-user incident`, scoping out the next-most-
 # likely sibling is anti-pattern, so it is folded into the IS_IN value.
-# (The `resolveUserKbRoot.tenant-mint` slug was dropped when that function was
-# removed in the ADR-044 resolver consolidation; share + upload now resolve via
-# the service-role `resolveActiveWorkspaceKbRoot` — no tenant-mint surface — so
-# its absence does NOT dark the alert: authenticateAndResolveKbPath retains the
-# tenant path + its op slug.)
+# (Both the resolveUserKbRoot and authenticateAndResolveKbPath helpers' own
+# tenant-mint op slugs were dropped as their functions migrated to the ADR-044 service-role
+# resolvers — resolveUserKbRoot was removed in the share+upload consolidation
+# (#4953); authenticateAndResolveKbPath migrated to resolveActiveWorkspaceKbRoot +
+# resolveActiveWorkspaceRepoMeta in #4956, so the kb/file + kb/c4 write routes no
+# longer mint a tenant client. Neither absence darks the alert: `kb-sync.tenant-mint`
+# (sync/route.ts:62) is the surviving live tenant-mint surface that keeps it armed.)
 #
 # `action_match="any"`: first_seen/reappeared/regression are mutually-exclusive
 # event-lifecycle states (a captured event is exactly one) — "all" is never
@@ -604,7 +606,7 @@ resource "sentry_issue_alert" "kb_tenant_mint_silent_fallback" {
       tagged_event = {
         key   = "op"
         match = "IS_IN"
-        value = "authenticateAndResolveKbPath.tenant-mint,kb-sync.tenant-mint"
+        value = "kb-sync.tenant-mint"
       }
     },
   ]

--- a/apps/web-platform/server/kb-route-helpers.ts
+++ b/apps/web-platform/server/kb-route-helpers.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from "next/server";
 import path from "path";
 import { promises as fs } from "node:fs";
-import { createClient } from "@/lib/supabase/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
 import {
-  getFreshTenantClient,
-  RuntimeAuthError,
-} from "@/lib/supabase/tenant";
-import { reportSilentFallback } from "@/server/observability";
+  resolveActiveWorkspaceKbRoot,
+  resolveActiveWorkspaceRepoMeta,
+} from "@/server/workspace-resolver";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 import { isPathInWorkspace } from "@/server/sandbox";
 // `syncWorkspace` (the git-pull reconcile + gated self-heal) was extracted to
@@ -71,73 +70,57 @@ export async function authenticateAndResolveKbPath(
   } = await supabase.auth.getUser();
   if (!user) return err(401, "Unauthorized");
 
-  // PR-C §2.8 (#3244): tenant-scoped workspace read. RLS on `users`
-  // enforces `auth.uid() = id`. The `.single()` SELECT IS the auth
-  // probe (the route flow reads only the caller's own row before any
-  // cross-row work).
+  // ADR-044 resolver consolidation (#4543, #4956). Resolve the active
+  // workspace's kbRoot + repo metadata via the two membership-scoped
+  // service-role resolvers instead of the legacy tenant `users` read:
+  //   - resolveActiveWorkspaceKbRoot → workspacePath + readiness/connectivity
+  //     gate, reading the SOURCE OF TRUTH (`workspaces.repo_status` +
+  //     the active workspace owner's readiness) — the SAME active workspace the
+  //     UI file tree renders from;
+  //   - resolveActiveWorkspaceRepoMeta → repo_url + GitHub installation id via
+  //     the membership-checked `resolve_workspace_installation_id` SECURITY
+  //     DEFINER RPC (the credential is REVOKED from a direct tenant SELECT).
+  // This FIXES the #4543 dual-ownership trap on the write routes: the legacy
+  // resolver read the CALLER's own `users.{workspace_path,repo_url,installation}`
+  // row, which is the empty solo row for an invited member operating on a shared
+  // workspace → spurious "Workspace not ready" / "No repository connected". The
+  // active-id resolution fails CLOSED to the SOLO workspace (never a sibling),
+  // so it is also the IDOR guard. The resolvers return typed Responses and mirror
+  // every query error to Sentry, so a credential-read failure stays observable
+  // (cq-silent-fallback-must-mirror-to-sentry) — no bare 404/503.
   //
-  // Tenant-ONLY mint handling (reverted #4919's per-cause service-role fallback).
-  // PR #4919 fell back to a SERVICE-ROLE read on the availability causes
-  // (`jwt_mint`/`rotation`); PIR #4913 proved that mint failure was a
-  // MISDIAGNOSIS — the tenant-JWT mint works in prod (the dead "Generate link"
-  // button was the missing-`workspace_id` NOT-NULL insert bug, fixed in #4922).
-  // So the service-role escape hatch was dead code that re-widened the read
-  // credential; this revert restores the tenant-only boundary:
-  //   - `jwt_mint` | `rotation` (availability failures) → 503 "Workspace not
-  //     ready" (the surface retries; the genuine prod path never trips this).
-  //   - `denied_jti` (deliberate revocation) and any future cause → FAIL CLOSED
-  //     with 403, honoring the deny-list on these mutation routes.
-  // `reportSilentFallback` still fires for EVERY cause BEFORE the branch, so a
-  // chronic mint failure (ceiling trip / GoTrue outage) AND a revocation-hit
-  // both stay Sentry-visible (cq-silent-fallback-must-mirror-to-sentry) and the
-  // #4920 `kb_tenant_mint_silent_fallback` alert keeps its signal. The path MUST
-  // RETURN a Response (never throw): both route handlers call this helper
-  // OUTSIDE their try block, so a thrown RuntimeAuthError would escape to
-  // Next.js → an uncontrolled 500.
-  let tenant;
-  try {
-    tenant = await getFreshTenantClient(user.id);
-  } catch (mintErr) {
-    if (mintErr instanceof RuntimeAuthError) {
-      reportSilentFallback(mintErr, {
-        feature: "kb-route-helpers",
-        op: "authenticateAndResolveKbPath.tenant-mint",
-        extra: { userId: user.id },
-      });
-      if (mintErr.cause === "jwt_mint" || mintErr.cause === "rotation") {
-        // Availability failure — no service-role fallback; surface 503.
-        return err(503, "Workspace not ready");
-      }
-      // `denied_jti` (revocation) or any future cause — honor the deny-list.
-      return err(403, "Access denied");
-    }
-    throw mintErr;
-  }
-  const { data: userData } = await tenant
-    .from("users")
-    .select(
-      "workspace_path, workspace_status, repo_url, github_installation_id",
-    )
-    .eq("id", user.id)
-    .single();
-
-  if (!userData?.workspace_path || userData.workspace_status !== "ready") {
-    return err(503, "Workspace not ready");
-  }
-  // Fallback to workspace-sibling installation only when the user has a
-  // repo but no installation ID (#4543). Skip the fallback when repo_url
-  // is also null ("no repository connected" — nothing to resolve for).
-  let installationId = userData.github_installation_id;
-  if (!installationId && userData.repo_url) {
-    const { resolveInstallationId } = await import(
-      "@/server/resolve-installation-id"
+  // Status→message parity (#4956 AC10): the legacy helper returned
+  // 503 "Workspace not ready" and 400 "No repository connected"; the resolvers
+  // use 404 for not-connected. Clients render `body.error` (not the numeric
+  // code), so map to the legacy MESSAGE strings — 503 → "Workspace not ready",
+  // 404/400 → "No repository connected".
+  const serviceClient = createServiceClient();
+  const access = await resolveActiveWorkspaceKbRoot(user.id, serviceClient);
+  if (!access.ok) {
+    return err(
+      access.status,
+      access.status === 503 ? "Workspace not ready" : "No repository connected",
     );
-    installationId = await resolveInstallationId(user.id);
   }
-  if (!userData.repo_url || !installationId) {
-    return err(400, "No repository connected");
+  // Pass the already-resolved active id so kbRoot, repo metadata, and the
+  // credential all key to ONE membership-resolved id (no divergence under a
+  // stale-claim self-heal; no redundant resolution) — mirrors kb/upload.
+  const repoMeta = await resolveActiveWorkspaceRepoMeta(
+    user.id,
+    serviceClient,
+    access.activeWorkspaceId,
+  );
+  if (!repoMeta.ok) {
+    return err(
+      repoMeta.status,
+      repoMeta.status === 503 ? "Workspace not ready" : "No repository connected",
+    );
   }
-  userData.github_installation_id = installationId;
+  const userData = {
+    workspace_path: access.workspacePath,
+    repo_url: repoMeta.repoUrl,
+    github_installation_id: repoMeta.githubInstallationId,
+  };
 
   // Path
   const { path: pathSegments } = await params;

--- a/apps/web-platform/test/kb-delete.test.ts
+++ b/apps/web-platform/test/kb-delete.test.ts
@@ -7,6 +7,8 @@ import { describe, test, expect, vi, beforeEach } from "vitest";
 const {
   mockGetUser,
   mockFrom,
+  mockResolveKbRoot,
+  mockResolveRepoMeta,
   mockGithubApiGet,
   mockGithubApiDelete,
   mockGitWithAuth,
@@ -25,6 +27,8 @@ const {
   return {
     mockGetUser: vi.fn(),
     mockFrom: vi.fn(),
+    mockResolveKbRoot: vi.fn(),
+    mockResolveRepoMeta: vi.fn(),
     mockGithubApiGet: vi.fn(),
     mockGithubApiDelete: vi.fn(),
     mockGitWithAuth: vi.fn(),
@@ -43,12 +47,13 @@ vi.mock("@/lib/supabase/server", () => ({
   })),
 }));
 
-// PR-C §2.8 (#3244): kb-route-helpers (authenticateAndResolveKbPath) mints
-// tenant clients via `getFreshTenantClient`. Reuse `mockFrom` so existing
-// per-test chains continue to drive it.
-vi.mock("@/lib/supabase/tenant", () => ({
-  getFreshTenantClient: vi.fn(async () => ({ from: mockFrom })),
-  RuntimeAuthError: class RuntimeAuthError extends Error {},
+// #4956 ADR-044: authenticateAndResolveKbPath now resolves the active
+// workspace's kbRoot + repo metadata via the membership-scoped service-role
+// resolvers (replacing the legacy tenant `users` read). `setupUserData` drives
+// these mocks below.
+vi.mock("@/server/workspace-resolver", () => ({
+  resolveActiveWorkspaceKbRoot: mockResolveKbRoot,
+  resolveActiveWorkspaceRepoMeta: mockResolveRepoMeta,
 }));
 
 vi.mock("@/lib/auth/validate-origin", () => ({
@@ -118,26 +123,45 @@ function setupAuthenticatedUser() {
   });
 }
 
+// Translate the legacy `users`-row override shape into the #4956 resolver
+// returns so existing call sites keep working:
+//   - workspace_status !== "ready" → resolveActiveWorkspaceKbRoot 503;
+//   - repo_url/installation absent → resolveActiveWorkspaceRepoMeta 404
+//     ("No repository connected"; status moves 400→404, message preserved —
+//     clients render body.error, not the code, per AC10).
 function setupUserData(overrides: Record<string, unknown> = {}) {
-  const mockSingle = vi.fn().mockResolvedValue({
-    data: {
-      workspace_path: TEST_WORKSPACE_PATH,
-      workspace_status: "ready",
-      repo_url: TEST_REPO_URL,
-      github_installation_id: TEST_INSTALLATION_ID,
-      ...overrides,
-    },
-    error: null,
-  });
-  const mockEq = vi.fn(() => ({ single: mockSingle }));
-  const mockSelect = vi.fn(() => ({ eq: mockEq }));
+  const workspaceStatus =
+    "workspace_status" in overrides
+      ? (overrides.workspace_status as string | null)
+      : "ready";
+  const repoUrl =
+    "repo_url" in overrides ? (overrides.repo_url as string | null) : TEST_REPO_URL;
+  const installationId =
+    "github_installation_id" in overrides
+      ? (overrides.github_installation_id as number | null)
+      : TEST_INSTALLATION_ID;
 
-  mockFrom.mockImplementation((table: string) => {
-    if (table === "users") {
-      return { select: mockSelect };
-    }
-    return {};
-  });
+  if (workspaceStatus !== "ready") {
+    mockResolveKbRoot.mockResolvedValue({ ok: false, status: 503 });
+  } else {
+    mockResolveKbRoot.mockResolvedValue({
+      ok: true,
+      activeWorkspaceId: TEST_USER_ID,
+      workspacePath: TEST_WORKSPACE_PATH,
+      kbRoot: `${TEST_WORKSPACE_PATH}/knowledge-base`,
+      repoStatus: "ready",
+    });
+  }
+
+  if (!repoUrl || !installationId) {
+    mockResolveRepoMeta.mockResolvedValue({ ok: false, status: 404 });
+  } else {
+    mockResolveRepoMeta.mockResolvedValue({
+      ok: true,
+      repoUrl,
+      githubInstallationId: installationId,
+    });
+  }
 }
 
 function setupFullMocks() {

--- a/apps/web-platform/test/kb-rename.test.ts
+++ b/apps/web-platform/test/kb-rename.test.ts
@@ -7,6 +7,8 @@ import { describe, test, expect, vi, beforeEach } from "vitest";
 const {
   mockGetUser,
   mockFrom,
+  mockResolveKbRoot,
+  mockResolveRepoMeta,
   mockGithubApiGet,
   mockGithubApiPost,
   mockGitWithAuth,
@@ -25,6 +27,8 @@ const {
   return {
     mockGetUser: vi.fn(),
     mockFrom: vi.fn(),
+    mockResolveKbRoot: vi.fn(),
+    mockResolveRepoMeta: vi.fn(),
     mockGithubApiGet: vi.fn(),
     mockGithubApiPost: vi.fn(),
     mockGitWithAuth: vi.fn(),
@@ -43,10 +47,13 @@ vi.mock("@/lib/supabase/server", () => ({
   })),
 }));
 
-// PR-C §2.8 (#3244): kb-route-helpers tenant migration.
-vi.mock("@/lib/supabase/tenant", () => ({
-  getFreshTenantClient: vi.fn(async () => ({ from: mockFrom })),
-  RuntimeAuthError: class RuntimeAuthError extends Error {},
+// #4956 ADR-044: authenticateAndResolveKbPath now resolves the active
+// workspace's kbRoot + repo metadata via the membership-scoped service-role
+// resolvers (replacing the legacy tenant `users` read). `setupUserData` drives
+// these mocks below.
+vi.mock("@/server/workspace-resolver", () => ({
+  resolveActiveWorkspaceKbRoot: mockResolveKbRoot,
+  resolveActiveWorkspaceRepoMeta: mockResolveRepoMeta,
 }));
 
 vi.mock("@/lib/auth/validate-origin", () => ({
@@ -121,26 +128,45 @@ function setupAuthenticatedUser() {
   });
 }
 
+// Translate the legacy `users`-row override shape into the #4956 resolver
+// returns so existing call sites keep working:
+//   - workspace_status !== "ready" → resolveActiveWorkspaceKbRoot 503;
+//   - repo_url/installation absent → resolveActiveWorkspaceRepoMeta 404
+//     ("No repository connected"; status moves 400→404, message preserved —
+//     clients render body.error, not the code, per AC10).
 function setupUserData(overrides: Record<string, unknown> = {}) {
-  const mockSingle = vi.fn().mockResolvedValue({
-    data: {
-      workspace_path: TEST_WORKSPACE_PATH,
-      workspace_status: "ready",
-      repo_url: TEST_REPO_URL,
-      github_installation_id: TEST_INSTALLATION_ID,
-      ...overrides,
-    },
-    error: null,
-  });
-  const mockEq = vi.fn(() => ({ single: mockSingle }));
-  const mockSelect = vi.fn(() => ({ eq: mockEq }));
+  const workspaceStatus =
+    "workspace_status" in overrides
+      ? (overrides.workspace_status as string | null)
+      : "ready";
+  const repoUrl =
+    "repo_url" in overrides ? (overrides.repo_url as string | null) : TEST_REPO_URL;
+  const installationId =
+    "github_installation_id" in overrides
+      ? (overrides.github_installation_id as number | null)
+      : TEST_INSTALLATION_ID;
 
-  mockFrom.mockImplementation((table: string) => {
-    if (table === "users") {
-      return { select: mockSelect };
-    }
-    return {};
-  });
+  if (workspaceStatus !== "ready") {
+    mockResolveKbRoot.mockResolvedValue({ ok: false, status: 503 });
+  } else {
+    mockResolveKbRoot.mockResolvedValue({
+      ok: true,
+      activeWorkspaceId: TEST_USER_ID,
+      workspacePath: TEST_WORKSPACE_PATH,
+      kbRoot: `${TEST_WORKSPACE_PATH}/knowledge-base`,
+      repoStatus: "ready",
+    });
+  }
+
+  if (!repoUrl || !installationId) {
+    mockResolveRepoMeta.mockResolvedValue({ ok: false, status: 404 });
+  } else {
+    mockResolveRepoMeta.mockResolvedValue({
+      ok: true,
+      repoUrl,
+      githubInstallationId: installationId,
+    });
+  }
 }
 
 function setupFullMocks() {
@@ -562,14 +588,19 @@ describe("PATCH /api/kb/file/[...path] (rename)", () => {
     expect(res.status).toBe(200);
   });
 
-  // 22. No repo connected
-  test("returns 400 when no repository is connected", async () => {
+  // 22. No repo connected — #4956: resolver returns 404 (message parity with
+  // the legacy "No repository connected"; clients render body.error, not the
+  // numeric code, so the 400→404 shift is not client-observable per AC10).
+  test("returns 'No repository connected' when no repository is connected", async () => {
     setupAuthenticatedUser();
     setupUserData({ repo_url: null, github_installation_id: null });
 
     const req = createRequest(["overview", "test.png"], { newName: "renamed.png" });
     const res = await PATCH(req, { params: createParams(["overview", "test.png"]) });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(404);
+
+    const body = await res.json();
+    expect(body.error).toMatch(/no repository connected/i);
   });
 
   // 23. Credential helper cleanup

--- a/apps/web-platform/test/kb-route-helpers.test.ts
+++ b/apps/web-platform/test/kb-route-helpers.test.ts
@@ -6,9 +6,9 @@ import { describe, test, expect, vi, beforeEach } from "vitest";
 
 const {
   mockGetUser,
-  mockFrom,
   mockServiceFrom,
-  mockGetFreshTenantClient,
+  mockResolveKbRoot,
+  mockResolveRepoMeta,
   mockGitWithAuth,
   mockIsPathInWorkspace,
   mockLstat,
@@ -16,13 +16,14 @@ const {
   mockRejectCsrf,
 } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
-  mockFrom: vi.fn(),
-  // Distinct service-role `.from` so the mint-failure fallback tests can
-  // prove the SERVICE-ROLE client (not the tenant client) produced the
-  // resolved workspace — wiring both clients to the same `mockFrom` would
-  // let a fallback assertion pass vacuously (deepen-plan P1).
+  // The service-role client is created via createServiceClient() and handed
+  // to the (mocked) resolvers — its `.from` is never reached in these tests,
+  // but a stub keeps the createServiceClient() call non-throwing.
   mockServiceFrom: vi.fn(),
-  mockGetFreshTenantClient: vi.fn(),
+  // ADR-044 (#4956): the helper now composes the two membership-scoped
+  // service-role resolvers instead of a tenant `users` read. Mock both.
+  mockResolveKbRoot: vi.fn(),
+  mockResolveRepoMeta: vi.fn(),
   mockGitWithAuth: vi.fn(),
   mockIsPathInWorkspace: vi.fn(),
   mockLstat: vi.fn(),
@@ -34,32 +35,19 @@ vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({
     auth: { getUser: mockGetUser },
   })),
-  // Service-role client → distinct `mockServiceFrom` (see hoisted note).
   createServiceClient: vi.fn(() => ({
     from: mockServiceFrom,
   })),
 }));
 
-// PR-C §2.8 (#3244): kb-route-helpers imports `getFreshTenantClient` from
-// `@/lib/supabase/tenant`. Default impl resolves to the tenant `mockFrom`
-// (the same per-table setup `setupUserData` drives); individual tests
-// override with `mockGetFreshTenantClient.mockRejectedValueOnce(...)` to
-// simulate a tenant-mint failure. The mock RuntimeAuthError mirrors the
-// real two-arg `(cause, message)` signature + public `cause` field so the
-// fallback's `instanceof` check and any cause-discrimination work in tests.
-vi.mock("@/lib/supabase/tenant", () => ({
-  getFreshTenantClient: mockGetFreshTenantClient,
-  RuntimeAuthError: class RuntimeAuthError extends Error {
-    public readonly cause: "jwt_mint" | "rotation" | "denied_jti";
-    constructor(
-      cause: "jwt_mint" | "rotation" | "denied_jti",
-      message: string,
-    ) {
-      super(message);
-      this.name = "RuntimeAuthError";
-      this.cause = cause;
-    }
-  },
+// #4956 ADR-044 — the helper resolves the active workspace's kbRoot + repo
+// metadata via these two membership-scoped resolvers (service-role, read from
+// the `workspaces` source of truth via the membership-checked installation
+// RPC), replacing the legacy tenant `users` read. The pre-resolved active id
+// is threaded from kbRoot → repoMeta so both key to ONE membership-resolved id.
+vi.mock("@/server/workspace-resolver", () => ({
+  resolveActiveWorkspaceKbRoot: mockResolveKbRoot,
+  resolveActiveWorkspaceRepoMeta: mockResolveRepoMeta,
 }));
 
 const { mockReportSilentFallback, mockWarnSilentFallback } = vi.hoisted(() => ({
@@ -96,7 +84,6 @@ import {
   authenticateAndResolveKbPath,
   syncWorkspace,
 } from "@/server/kb-route-helpers";
-import { RuntimeAuthError } from "@/lib/supabase/tenant";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -122,54 +109,28 @@ function setupAuthenticatedUser() {
   mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
 }
 
-function setupUserData(overrides: Record<string, unknown> = {}) {
-  const mockSingle = vi.fn().mockResolvedValue({
-    data: {
-      workspace_path: TEST_WORKSPACE_PATH,
-      workspace_status: "ready",
-      repo_url: TEST_REPO_URL,
-      github_installation_id: TEST_INSTALLATION_ID,
-      ...overrides,
-    },
-    error: null,
+// Wire both resolvers to the solo-owner happy path (activeWorkspaceId === userId,
+// kbRoot/repo identical to the legacy read). `activeWorkspaceId` overrides the
+// solo default so the member-vs-solo id-threading test can assert it propagates.
+function setupResolvers(activeWorkspaceId: string = TEST_USER_ID) {
+  mockResolveKbRoot.mockResolvedValue({
+    ok: true,
+    activeWorkspaceId,
+    workspacePath: TEST_WORKSPACE_PATH,
+    kbRoot: `${TEST_WORKSPACE_PATH}/knowledge-base`,
+    repoStatus: "ready",
   });
-  const mockEq = vi.fn(() => ({ single: mockSingle }));
-  const mockSelect = vi.fn(() => ({ eq: mockEq }));
-  mockFrom.mockImplementation((table: string) => {
-    if (table === "users") return { select: mockSelect };
-    return {};
-  });
-  // Default: the tenant mint succeeds and the tenant client reads via mockFrom.
-  mockGetFreshTenantClient.mockResolvedValue({ from: mockFrom });
-}
-
-// Wire the SERVICE-ROLE client's `.from` (distinct from the tenant `mockFrom`)
-// to a `users` row. Used by the tenant-mint-failure fallback tests so the
-// assertion proves the service-role read — not the tenant read — produced the
-// result. Returns nothing when called for a table other than "users".
-function setupServiceUserData(overrides: Record<string, unknown> = {}) {
-  const mockSingle = vi.fn().mockResolvedValue({
-    data: {
-      workspace_path: TEST_WORKSPACE_PATH,
-      workspace_status: "ready",
-      repo_url: TEST_REPO_URL,
-      github_installation_id: TEST_INSTALLATION_ID,
-      ...overrides,
-    },
-    error: null,
-  });
-  const mockEq = vi.fn(() => ({ single: mockSingle }));
-  const mockSelect = vi.fn(() => ({ eq: mockEq }));
-  mockServiceFrom.mockImplementation((table: string) => {
-    if (table === "users") return { select: mockSelect };
-    return {};
+  mockResolveRepoMeta.mockResolvedValue({
+    ok: true,
+    repoUrl: TEST_REPO_URL,
+    githubInstallationId: TEST_INSTALLATION_ID,
   });
 }
 
 function setupHappyPath() {
   mockValidateOrigin.mockReturnValue({ valid: true, origin: "https://app.soleur.ai" });
   setupAuthenticatedUser();
-  setupUserData();
+  setupResolvers();
   mockIsPathInWorkspace.mockReturnValue(true);
   mockLstat.mockResolvedValue({
     isSymbolicLink: () => false,
@@ -210,6 +171,8 @@ describe("authenticateAndResolveKbPath", () => {
       expect(result.response).toBe(csrfResponse);
       expect(mockRejectCsrf).toHaveBeenCalledWith("api/kb/file", "https://evil.com");
     }
+    // CSRF rejected before any credential resolution.
+    expect(mockResolveKbRoot).not.toHaveBeenCalled();
   });
 
   test("returns 401 when unauthenticated", async () => {
@@ -224,30 +187,90 @@ describe("authenticateAndResolveKbPath", () => {
     if (!result.ok) {
       expect(result.response.status).toBe(401);
     }
+    expect(mockResolveKbRoot).not.toHaveBeenCalled();
   });
 
-  test("returns 503 when workspace is not ready", async () => {
+  test("returns 503 'Workspace not ready' when kbRoot resolver reports 503", async () => {
     setupHappyPath();
-    setupUserData({ workspace_status: "provisioning" });
+    mockResolveKbRoot.mockResolvedValue({ ok: false, status: 503 });
 
     const result = await authenticateAndResolveKbPath(
       createRequest(),
       createParams(["overview", "test.pdf"]),
     );
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.response.status).toBe(503);
+    if (!result.ok) {
+      expect(result.response.status).toBe(503);
+      const body = await result.response.json();
+      expect(body.error).toMatch(/workspace not ready/i);
+    }
+    // No repo-meta resolution once the kbRoot gate fails.
+    expect(mockResolveRepoMeta).not.toHaveBeenCalled();
   });
 
-  test("returns 400 when no repo connected", async () => {
+  test("returns 'No repository connected' when kbRoot resolver reports 404 (not connected)", async () => {
     setupHappyPath();
-    setupUserData({ repo_url: null });
+    mockResolveKbRoot.mockResolvedValue({ ok: false, status: 404 });
 
     const result = await authenticateAndResolveKbPath(
       createRequest(),
       createParams(["overview", "test.pdf"]),
     );
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.response.status).toBe(400);
+    if (!result.ok) {
+      expect(result.response.status).toBe(404);
+      const body = await result.response.json();
+      expect(body.error).toMatch(/no repository connected/i);
+    }
+    expect(mockResolveRepoMeta).not.toHaveBeenCalled();
+  });
+
+  test("returns 'No repository connected' when repoMeta resolver reports 404 (no repo_url)", async () => {
+    setupHappyPath();
+    mockResolveRepoMeta.mockResolvedValue({ ok: false, status: 404 });
+
+    const result = await authenticateAndResolveKbPath(
+      createRequest(),
+      createParams(["overview", "test.pdf"]),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(404);
+      const body = await result.response.json();
+      expect(body.error).toMatch(/no repository connected/i);
+    }
+  });
+
+  test("returns 'No repository connected' when repoMeta resolver reports 400 (no installation)", async () => {
+    setupHappyPath();
+    mockResolveRepoMeta.mockResolvedValue({ ok: false, status: 400 });
+
+    const result = await authenticateAndResolveKbPath(
+      createRequest(),
+      createParams(["overview", "test.pdf"]),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(400);
+      const body = await result.response.json();
+      expect(body.error).toMatch(/no repository connected/i);
+    }
+  });
+
+  test("returns 503 'Workspace not ready' when repoMeta resolver reports 503", async () => {
+    setupHappyPath();
+    mockResolveRepoMeta.mockResolvedValue({ ok: false, status: 503 });
+
+    const result = await authenticateAndResolveKbPath(
+      createRequest(),
+      createParams(["overview", "test.pdf"]),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(503);
+      const body = await result.response.json();
+      expect(body.error).toMatch(/workspace not ready/i);
+    }
   });
 
   test("returns 400 for empty path", async () => {
@@ -351,7 +374,7 @@ describe("authenticateAndResolveKbPath", () => {
     if (!result.ok) expect(result.response.status).toBe(403);
   });
 
-  test("happy path returns populated context", async () => {
+  test("happy path returns populated context sourced from the resolvers", async () => {
     setupHappyPath();
 
     const result = await authenticateAndResolveKbPath(
@@ -376,6 +399,32 @@ describe("authenticateAndResolveKbPath", () => {
       expect(result.ctx.kbRoot).toContain("knowledge-base");
       expect(result.ctx.fullPath).toContain("overview/test.pdf");
     }
+    // The credential read goes through the service-role resolvers, not a
+    // tenant `users` read.
+    expect(mockResolveKbRoot).toHaveBeenCalledWith(TEST_USER_ID, expect.anything());
+  });
+
+  test("threads the resolved active workspace id from kbRoot into repoMeta (member-vs-solo)", async () => {
+    // An invited member operating on a shared workspace: the kbRoot resolver
+    // returns an activeWorkspaceId distinct from the caller's user id; the
+    // repoMeta resolver MUST be called with that same pre-resolved id so the
+    // kbRoot, repo, and credential all key to ONE membership-resolved workspace
+    // (no second independent resolution → no stale-claim divergence). This is
+    // the #4543 write-route fix.
+    setupHappyPath();
+    const SHARED_WORKSPACE_ID = "11111111-2222-3333-4444-555555555555";
+    setupResolvers(SHARED_WORKSPACE_ID);
+
+    const result = await authenticateAndResolveKbPath(
+      createRequest(),
+      createParams(["overview", "test.pdf"]),
+    );
+    expect(result.ok).toBe(true);
+    expect(mockResolveRepoMeta).toHaveBeenCalledWith(
+      TEST_USER_ID,
+      expect.anything(),
+      SHARED_WORKSPACE_ID,
+    );
   });
 
   test("blockMarkdown: false allows .md paths through", async () => {
@@ -731,144 +780,5 @@ describe("syncWorkspace", () => {
       (c: unknown[]) => (c[0] as string[])[0],
     );
     expect(verbs).toEqual(["pull"]);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Tests — authenticateAndResolveKbPath — tenant-mint failure (REVERTED)
-//
-// PR #4919 added a per-cause service-role fallback (availability causes
-// jwt_mint/rotation fell back to a service-role read; denied_jti failed closed).
-// PIR #4913 proved the mint failure was a misdiagnosis, so #4919's fallback is
-// the same dead-code class as #4913's. This revert restores the pre-#4919
-// behavior on the file mutation routes: availability causes → 503 (workspace
-// not resolvable right now), revocation/unknown → 403 (fail closed). The emit
-// is PRESERVED for EVERY cause so the #4920 alert keeps its signal, and the
-// service-role client is never reached. The distinct mockServiceFrom keeps each
-// `not called` assertion non-vacuous.
-// ---------------------------------------------------------------------------
-
-describe("authenticateAndResolveKbPath — tenant-mint failure (reverted)", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    // Happy-path wiring for CSRF / auth / path / lstat; the per-test mint
-    // override forces the RuntimeAuthError branch. A ready service-role row is
-    // wired but MUST NOT be read after the revert (keeps negatives non-vacuous).
-    setupHappyPath();
-    setupServiceUserData();
-  });
-
-  // Availability causes (jwt_mint / rotation) → 503, NO service-role fallback.
-  test.each(["jwt_mint", "rotation"] as const)(
-    "availability cause %s → 503 Workspace not ready, NO service-role fallback",
-    async (cause) => {
-      mockGetFreshTenantClient.mockRejectedValueOnce(
-        new RuntimeAuthError(cause, `mint failed: ${cause}`),
-      );
-
-      const result = await authenticateAndResolveKbPath(
-        createRequest(),
-        createParams(["overview", "test.pdf"]),
-      );
-
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.response.status).toBe(503);
-        const body = await result.response.json();
-        expect(body.error).toMatch(/workspace not ready/i);
-      }
-      // The service-role escape hatch is gone — neither client is reached.
-      expect(mockServiceFrom).not.toHaveBeenCalled();
-      expect(mockFrom).not.toHaveBeenCalled();
-    },
-  );
-
-  // Revocation (denied_jti) and any unknown cause → fail CLOSED with 403.
-  test("denied_jti → fail closed with 403, NO read of any kind", async () => {
-    mockGetFreshTenantClient.mockRejectedValueOnce(
-      new RuntimeAuthError("denied_jti", "jti on deny-list"),
-    );
-
-    const result = await authenticateAndResolveKbPath(
-      createRequest(),
-      createParams(["overview", "test.pdf"]),
-    );
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.response.status).toBe(403);
-      const body = await result.response.json();
-      expect(body.error).toMatch(/access denied/i);
-    }
-    expect(mockServiceFrom).not.toHaveBeenCalled();
-    expect(mockFrom).not.toHaveBeenCalled();
-  });
-
-  // Load-bearing: both route handlers call this helper OUTSIDE their try block,
-  // so the mint-failure path must RESOLVE to a Response, never reject (a thrown
-  // RuntimeAuthError would escape to Next.js → uncontrolled 500).
-  test("mint-failure path RESOLVES to a Response, never rejects", async () => {
-    mockGetFreshTenantClient.mockRejectedValueOnce(
-      new RuntimeAuthError("denied_jti", "jti on deny-list"),
-    );
-
-    await expect(
-      authenticateAndResolveKbPath(
-        createRequest(),
-        createParams(["overview", "test.pdf"]),
-      ),
-    ).resolves.toMatchObject({ ok: false });
-  });
-
-  // reportSilentFallback fires exactly once for EVERY cause, including
-  // denied_jti (the revocation hit must stay Sentry-visible BEFORE the 403
-  // early-return) — this is the #4920 alert's signal, preserved across the revert.
-  test.each(["jwt_mint", "rotation", "denied_jti"] as const)(
-    "%s emits exactly one reportSilentFallback with op:authenticateAndResolveKbPath.tenant-mint",
-    async (cause) => {
-      const mintErr = new RuntimeAuthError(cause, `mint failure: ${cause}`);
-      mockGetFreshTenantClient.mockRejectedValueOnce(mintErr);
-
-      await authenticateAndResolveKbPath(
-        createRequest(),
-        createParams(["overview", "test.pdf"]),
-      );
-
-      expect(mockReportSilentFallback).toHaveBeenCalledTimes(1);
-      expect(mockReportSilentFallback).toHaveBeenCalledWith(
-        mintErr,
-        expect.objectContaining({
-          feature: "kb-route-helpers",
-          op: "authenticateAndResolveKbPath.tenant-mint",
-          extra: expect.objectContaining({ userId: TEST_USER_ID }),
-        }),
-      );
-    },
-  );
-
-  // A non-RuntimeAuthError mint failure is re-thrown unchanged.
-  test("a non-RuntimeAuthError from the mint is re-thrown (not swallowed)", async () => {
-    mockGetFreshTenantClient.mockRejectedValueOnce(new Error("unexpected boom"));
-
-    await expect(
-      authenticateAndResolveKbPath(
-        createRequest(),
-        createParams(["overview", "test.pdf"]),
-      ),
-    ).rejects.toThrow("unexpected boom");
-    expect(mockServiceFrom).not.toHaveBeenCalled();
-  });
-
-  // Regression guard — happy path (mint succeeds): tenant read, no fallback.
-  test("happy path (mint succeeds) reads via the TENANT client, no fallback", async () => {
-    const result = await authenticateAndResolveKbPath(
-      createRequest(),
-      createParams(["overview", "test.pdf"]),
-    );
-
-    expect(result.ok).toBe(true);
-    expect(mockFrom).toHaveBeenCalledWith("users");
-    expect(mockServiceFrom).not.toHaveBeenCalled();
-    expect(mockReportSilentFallback).not.toHaveBeenCalled();
   });
 });

--- a/apps/web-platform/test/sentry-kb-tenant-mint-alert-op-contract.test.ts
+++ b/apps/web-platform/test/sentry-kb-tenant-mint-alert-op-contract.test.ts
@@ -6,13 +6,20 @@ import { describe, it, expect } from "vitest";
 // Cross-artifact contract test (#4918, PIR #4913 follow-up).
 //
 // The `kb-tenant-mint-silent-fallback` Sentry issue-alert filters on
-// `feature == "kb-route-helpers"` AND `op IS_IN` the two tenant-mint
-// failure slugs. Because the alert uses `filter_match = "all"`, a rename of
-// the `feature` tag OR any op slug on EITHER side (the emit sites in
-// kb-route-helpers.ts / kb/sync/route.ts, or the filter value in
-// issue-alerts.tf) would silently zero the alert's matches — recreating the
-// ~19-day-silent regression class one rename later. This test pins both
-// filter dimensions against that drift.
+// `feature == "kb-route-helpers"` AND `op IS_IN` the surviving tenant-mint
+// failure slug. Because the alert uses `filter_match = "all"`, a rename of
+// the `feature` tag OR the op slug on EITHER side (the emit site in
+// kb/sync/route.ts, or the filter value in issue-alerts.tf) would silently
+// zero the alert's matches — recreating the ~19-day-silent regression class
+// one rename later. This test pins both filter dimensions against that drift.
+//
+// #4956: authenticateAndResolveKbPath migrated to the ADR-044 service-role
+// resolvers (resolveActiveWorkspaceKbRoot + resolveActiveWorkspaceRepoMeta),
+// so the kb/file + kb/c4 write routes no longer mint a tenant client. Its
+// tenant-mint op slug was dropped from the emit site, the IS_IN filter, and
+// OP_SLUGS below. `kb-sync.tenant-mint` (sync/route.ts) is the surviving live
+// tenant-mint surface — the single remaining slug still proves the alert is
+// armed.
 //
 // Substring match only (code-simplicity, mirrors sentry-chat-alert-op-contract):
 // each slug is an inline string literal at its emit site; a whole-file match
@@ -36,10 +43,6 @@ const tfBlock =
   blockStart === -1
     ? ""
     : tf.slice(blockStart, nextResource === -1 ? undefined : nextResource);
-const kbRouteHelpers = readFileSync(
-  join(here, "../server/kb-route-helpers.ts"),
-  "utf8",
-);
 const kbSyncRoute = readFileSync(
   join(here, "../app/api/kb/sync/route.ts"),
   "utf8",
@@ -50,16 +53,12 @@ const FEATURE_TAG = "kb-route-helpers";
 // Each op slug paired with the emit file that must contain it.
 const OP_SLUGS: ReadonlyArray<{ slug: string; emit: string; emitName: string }> =
   [
-    // The legacy per-user KB-root helper's tenant-mint op slug was removed in
-    // the ADR-044 resolver consolidation (share + upload migrated to the
-    // service-role resolveActiveWorkspaceKbRoot, which has no tenant-mint
-    // surface). The alert keeps a live tenant-mint op via
-    // authenticateAndResolveKbPath below.
-    {
-      slug: "authenticateAndResolveKbPath.tenant-mint",
-      emit: kbRouteHelpers,
-      emitName: "kb-route-helpers.ts",
-    },
+    // Both legacy KB-write tenant-mint op slugs were removed as their functions
+    // migrated to the ADR-044 service-role resolvers: resolveUserKbRoot in the
+    // share+upload consolidation (#4953), and authenticateAndResolveKbPath in
+    // #4956 (resolveActiveWorkspaceKbRoot + resolveActiveWorkspaceRepoMeta — no
+    // tenant-mint surface). `kb-sync.tenant-mint` is the surviving live slug
+    // that keeps the alert armed.
     {
       slug: "kb-sync.tenant-mint",
       emit: kbSyncRoute,
@@ -73,8 +72,9 @@ describe("kb-tenant-mint-silent-fallback alert op/feature contract", () => {
     expect(tfBlock).toContain(RESOURCE_DECL);
   });
 
-  it("the feature tag appears in both the emit sites and the alert filter", () => {
-    expect(kbRouteHelpers).toContain(FEATURE_TAG);
+  it("the feature tag appears in the surviving emit site and the alert filter", () => {
+    // kb/sync/route.ts emits under feature "kb-route-helpers" (the alert's
+    // feature filter). Post-#4956 it is the sole emit site for this alert.
     expect(kbSyncRoute).toContain(FEATURE_TAG);
     // Filter side scoped to THIS rule's block, not the whole file.
     expect(tfBlock).toContain(FEATURE_TAG);

--- a/apps/web-platform/test/server/kb-route-helpers.tenant-isolation.test.ts
+++ b/apps/web-platform/test/server/kb-route-helpers.tenant-isolation.test.ts
@@ -1,23 +1,22 @@
 /**
- * Tenant isolation — kb-route-helpers.ts (PR-C §2.8, #3244).
+ * `users`-table RLS regression guard (originally PR-C §2.8, #3244).
  *
- * Covers the surviving tenant `users` reader:
+ * History: both KB-root helpers have now migrated OFF the tenant `users` read.
+ * `resolveUserKbRoot` was removed in the ADR-044 share+upload consolidation
+ * (#4953); `authenticateAndResolveKbPath` migrated to the membership-scoped
+ * service-role resolvers `resolveActiveWorkspaceKbRoot` /
+ * `resolveActiveWorkspaceRepoMeta` in #4956. Neither helper reads
+ * `users.{workspace_path,workspace_status,repo_url,github_installation_id}`
+ * via a tenant client any more.
  *
- *   - `authenticateAndResolveKbPath` — SELECT users.* via tenant
+ * These cases survive as a standalone RLS regression guard on the `users`
+ * row + extras columns (`auth.uid() = id`): the columns remain RLS-protected
+ * and other code paths still read them, so a policy regression must stay
+ * caught even though the KB write routes no longer depend on this read.
  *
- * (The legacy per-user KB-root helper was removed in the ADR-044 resolver
- * consolidation; share + upload now read the ACTIVE workspace via the
- * membership-scoped service-role resolvers `resolveActiveWorkspaceKbRoot` /
- * `resolveActiveWorkspaceRepoMeta`. The second case below retains an RLS
- * regression guard on the `users` extras columns it used to read.)
- *
- * RLS on `users`: `auth.uid() = id`.
- *
- * Asserts: A's tenant JWT cannot read B's row through either helper's
- * underlying query. Tested at the data-layer (the helpers are exercised
- * via their typed exports' `getFreshTenantClient` path; the
- * `app/api/kb/share` and `app/api/kb/upload` route handlers' overall
- * 503/400 behavior is covered by route-level tests).
+ * Asserts: A's tenant JWT cannot read B's `users` row / extras columns.
+ * Tested at the data-layer. The KB route handlers' 404/503/400 behavior is
+ * covered by route-level tests (kb-rename / kb-delete / kb-route-helpers).
  *
  * Opt-in via TENANT_INTEGRATION_TEST=1.
  */
@@ -57,7 +56,7 @@ function requireEnv(name: string): string {
 }
 
 describe.skipIf(!INTEGRATION_ENABLED)(
-  "tenant isolation — kb-route-helpers.ts (2 sites)",
+  "users-table RLS regression guard (post-#4956 KB resolver migration)",
   () => {
     let service: SupabaseClient;
     let aClient: SupabaseClient;
@@ -118,7 +117,7 @@ describe.skipIf(!INTEGRATION_ENABLED)(
       }
     }, 30_000);
 
-    test("baseline: A reads own users row (mirrors `:69` + `:188` shapes)", async () => {
+    test("baseline: A reads own users row", async () => {
       const { data, error } = await aClient
         .from("users")
         .select(
@@ -130,7 +129,7 @@ describe.skipIf(!INTEGRATION_ENABLED)(
       expect(data?.workspace_path).toContain("/tmp/synthetic/");
     });
 
-    test("`:69` authenticateAndResolveKbPath — A cannot read B's workspace tuple", async () => {
+    test("users-RLS — A cannot read B's workspace tuple (former KB-helper read shape)", async () => {
       const { data, error } = await aClient
         .from("users")
         .select(

--- a/knowledge-base/project/learnings/best-practices/2026-06-05-helper-datasource-migration-must-sweep-route-level-test-mocks.md
+++ b/knowledge-base/project/learnings/best-practices/2026-06-05-helper-datasource-migration-must-sweep-route-level-test-mocks.md
@@ -1,0 +1,90 @@
+---
+title: "Migrating a shared route helper's data source must sweep the route-level test mocks, not just the helper's own test"
+date: 2026-06-05
+category: best-practices
+tags: [testing, vitest, mocks, adr-044, refactor, resolver-migration]
+issue: 4956
+pr: 4969
+related:
+  - knowledge-base/project/learnings/best-practices/2026-04-27-wrapper-extension-test-mock-chain-sweep.md
+  - knowledge-base/project/learnings/best-practices/2026-06-05-adr-resolver-migration-must-sweep-write-routes-not-just-read-routes.md
+---
+
+# Helper data-source migration must sweep the route-level test mocks
+
+## Problem
+
+#4956 migrated `authenticateAndResolveKbPath` (`apps/web-platform/server/kb-route-helpers.ts`)
+off a tenant `users` read onto the ADR-044 service-role resolvers
+(`resolveActiveWorkspaceKbRoot` + `resolveActiveWorkspaceRepoMeta`). The plan's
+`## Files to Edit` listed the helper's OWN test (`test/kb-route-helpers.test.ts`)
+and updated it correctly — RED→GREEN passed, touched-file suite green, tsc clean.
+
+But the **route handlers** that call the helper (`kb/file` PATCH/DELETE, exercised
+by `test/kb-rename.test.ts` + `test/kb-delete.test.ts`) have their OWN test files
+that mock the helper's transitive dependencies — they mocked
+`getFreshTenantClient` + drove a tenant `users` row via `mockFrom`. After the
+migration the helper no longer imports `getFreshTenantClient`; it calls the
+(un-mocked-in-those-files) resolvers, which then ran against an incomplete mock
+and threw. **33 tests in 2 files failed** — caught only by the Phase 2 exit
+full-suite gate (`./node_modules/.bin/vitest run`), NOT by the touched-file
+inner loop.
+
+## Solution
+
+When migrating a shared route helper's data-source/credential layer, enumerate
+EVERY test that exercises the helper — directly AND through its routes — before
+declaring the test edits done:
+
+```bash
+git grep -l "<helperName>" -- 'test/**'                 # direct + route-level callers
+git grep -l "<oldDependencyImport>" -- 'test/**'        # files mocking the old data source
+```
+
+Each route-level test gets the same mock migration as the helper's own test:
+replace the old-dependency `vi.mock(...)` with the new one, and translate any
+fixture-builder (`setupUserData({overrides})`) so existing call sites keep
+working against the new contract. Status-shape changes propagate: the kb/file
+"no repository connected" case moved 400→404 (the resolver's status), with the
+message preserved — so the assertion flips to the new code while the message
+match stays (clients render `body.error`, not the numeric code).
+
+Also sweep stale **citations**: an opt-in integration test
+(`test/server/kb-route-helpers.tenant-isolation.test.ts`) documented the
+helper's old `users`-read shape in its header/test names. The RLS assertions
+stayed valid, but the labels now misled — reframed as a standalone `users`-table
+RLS regression guard.
+
+## Key Insight
+
+`## Files to Edit` enumerating "the test for the file I changed" is necessary
+but not sufficient. A helper's behavior contract is also asserted by its
+**consumers'** tests, which mock the helper's transitive deps. The
+cheapest detection is `git grep -l "<helper>" test/` at plan time (add the
+route-level test files to Files-to-Edit) — otherwise the full-suite exit gate
+catches it after the fact. This is the test-side analogue of
+[[2026-04-27-wrapper-extension-test-mock-chain-sweep]] (sweep all supabase mock
+chains when extending a wrapper) and the route-side
+[[2026-06-05-adr-resolver-migration-must-sweep-write-routes-not-just-read-routes]]
+(sweep all write-route consumers when migrating a resolver).
+
+## Session Errors
+
+1. **Route-level test mocks not swept with the helper migration** — Recovery:
+   migrated `kb-rename.test.ts` + `kb-delete.test.ts` mocks to the resolvers via
+   a `setupUserData` translation shim; flipped the 400→404 assertion.
+   Prevention: at plan time, `git grep -l "<helper>" test/` and add every
+   route-level test to `## Files to Edit`; the Phase 2 full-suite exit gate is
+   the backstop, not the first line of defense.
+2. **Plan subagent's initial plan-file Write hit the bare-repo root** (forwarded
+   from session-state.md) — Recovery: re-issued with the explicit worktree path.
+   Prevention: already enforced by the worktree-write guard (one-off).
+3. **`git grep "pat" .`** treated `.` as a revision ("unable to resolve
+   revision") — Recovery: dropped the `.` (pathspecs only). Prevention: one-off.
+4. **Review agents returned `529 Overloaded`** (6 attempts across 2 batches)
+   before 2 succeeded on retry — Recovery: per the review skill's Rate-Limit
+   Fallback gate, performed an inline review across the dimensions the
+   overloaded agents would have covered, then retried the 2 highest-value lenses
+   (security-sentinel + user-impact-reviewer), which both succeeded and returned
+   CONCUR / no-real-findings. Prevention: one-off (transient API); the fallback
+   gate is the existing mitigation.

--- a/knowledge-base/project/plans/2026-06-05-refactor-authenticate-kb-path-adr044-resolver-plan.md
+++ b/knowledge-base/project/plans/2026-06-05-refactor-authenticate-kb-path-adr044-resolver-plan.md
@@ -1,0 +1,489 @@
+---
+title: "Migrate authenticateAndResolveKbPath to the ADR-044 membership-scoped resolvers"
+date: 2026-06-05
+type: refactor
+issue: 4956
+branch: feat-one-shot-4956-kb-route-helpers-adr044
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+status: draft
+related_adrs: [ADR-044, ADR-038]
+related:
+  - 4953  # share+upload consolidation (Workstream B) — direct precedent
+  - 4559  # ADR-044 read-cutover + resolve-installation-id rework
+  - 4543  # joined-workspace dual-ownership bug this class fixes
+  - 4929  # tenant-mint fallback revert (removed kb-route-helpers from allowlist)
+  - 4918  # kb_tenant_mint_silent_fallback Sentry alert
+related_learnings:
+  - knowledge-base/project/learnings/best-practices/2026-06-05-adr-resolver-migration-must-sweep-write-routes-not-just-read-routes.md
+---
+
+# Migrate `authenticateAndResolveKbPath` to the ADR-044 resolvers ♻️
+
+## Enhancement Summary
+
+**Deepened on:** 2026-06-05
+**Gates passed:** 4.6 User-Brand Impact (threshold present + valid), 4.7 Observability
+(5/5 fields, no SSH, no placeholders), 4.8 PAT-shaped (no match), 4.9 UI-wireframe
+(no UI surface → skip).
+
+### Key Improvements (verified against code)
+
+1. **Status-code reconciliation (the v1 "highest-risk" Sharp Edge) is DE-RISKED.**
+   Verified the three client callers — `components/kb/file-tree.tsx:330-332` (rename),
+   `:346-348` (delete), `components/kb/c4-shared.tsx:271` (c4 save) — discriminate ONLY
+   on `!res.ok` (any non-2xx) and render `body.error` (the message string). They do NOT
+   branch on the specific status code. So the legacy-vs-resolver status divergence
+   (503/400 → 404) is NOT load-bearing for client behavior; only the user-facing
+   **message string** matters. The helper should map resolver statuses to the legacy
+   messages, but a 404-where-was-503 will not break the UI. AC10 downgraded from
+   blocking-risk to message-parity check.
+2. **Allowlist gate mechanics nailed down.** The enforcing gate is
+   `apps/web-platform/scripts/service-role-allowlist-gate.sh` (test:
+   `test/ci/service-role-allowlist-gate.test.sh`). It greps each `.ts` for a
+   `createServiceClient` import and FAILs if the importing file is not a verbatim line
+   in `.service-role-allowlist`. Re-add the EXACT path
+   `apps/web-platform/server/kb-route-helpers.ts` AND update the removal-comment at
+   `.service-role-allowlist:66` (which currently lists `kb-route-helpers` among removed
+   files).
+3. **The Sentry alert does NOT go dark.** Confirmed `kb-sync.tenant-mint`
+   (`app/api/kb/sync/route.ts:62`) is an independent live tenant-mint surface; this
+   migration only narrows the IS_IN, it does not disarm the alert.
+
+### New Considerations Discovered
+
+- The helper currently passes `userData.workspace_path` into both `syncWorkspace` and
+  (for c4) `writeC4Diagram` → `renderC4Model(workspacePath)`. After migration this
+  becomes `access.workspacePath`. The upload route already proves `syncWorkspace` works
+  off `access.workspacePath`; the c4 re-render path (`renderC4Model`) is the only
+  active-path consumer not yet exercised by a shipped migration — call it out in tests.
+- `resolveActiveWorkspaceRepoMeta` returns `400` (repo connected, no installation),
+  `404` (no repo_url), `503` (workspaces read error). The legacy helper returned `400
+  "No repository connected"` for BOTH the no-repo and no-installation cases. Map both
+  resolver `400` and `404` to the legacy `"No repository connected"` message for
+  message parity (the client shows the string, not the code).
+
+## Overview
+
+`authenticateAndResolveKbPath` (`apps/web-platform/server/kb-route-helpers.ts:50`)
+is the last KB write-route consumer still on the legacy pre-ADR-044 path. It mints
+a **per-request tenant client** (`getFreshTenantClient`) and reads the CALLER's
+`users.{workspace_path, workspace_status, repo_url, github_installation_id}` under
+RLS. It serves the two URL-segment write routes:
+
+- `PATCH` + `DELETE /api/kb/file/[...path]` (rename / delete)
+- `PUT /api/kb/c4/[...path]` (save edited LikeC4 source)
+
+PR #4953 (Workstream B) already migrated `kb/share` + `kb/upload` onto the
+membership-scoped, service-role resolvers (`resolveActiveWorkspaceKbRoot` +
+`resolveActiveWorkspaceRepoMeta`) and removed `resolveUserKbRoot`. This issue is the
+remaining write-route sweep called out verbatim in the learning that PR shipped
+(`2026-06-05-adr-resolver-migration-must-sweep-write-routes-not-just-read-routes.md`):
+"the migration is NOT done until EVERY consumer of the old resolver moves — write
+routes are consumers too."
+
+**Why it matters:** the legacy resolver reads the caller's own `users` row, which is
+stale/empty for (a) users provisioned after the ADR-044 `users → workspaces`
+relocation and (b) an invited member operating on a shared workspace (#4543
+dual-ownership). For those users, rename / delete / c4-save returns `503 "Workspace
+not ready"` or `400 "No repository connected"` while the service-role resolver
+(reading `workspaces.repo_status` + the membership-checked installation RPC) would
+succeed. The two resolvers compute the **same** path for a solo owner — the
+divergence is the read credential + readiness source + an extra tenant-mint failure
+surface, **not the path** (per the learning file).
+
+This is a refactor with no new feature surface, no new infrastructure, and no schema
+change. It is a pure consumer-cutover plus one observability-contract edit.
+
+**No new dependency.** Reuses `resolveActiveWorkspaceKbRoot`,
+`resolveActiveWorkspaceRepoMeta`, `createServiceClient`, `validateOrigin` — all
+already imported elsewhere in `apps/web-platform`.
+
+## Research Reconciliation — Spec vs. Codebase
+
+No spec exists for this branch; planning input is the issue body + the precedent PR
+#4953 + the ADR-044 read of source. Premise validation (issue cites #4953, the helper
+path, two route paths, the resolvers, and the Sentry alert):
+
+| Claim (issue body) | Reality (verified) | Plan response |
+| --- | --- | --- |
+| `authenticateAndResolveKbPath` still reads `users.*` via a tenant/RLS client | TRUE — `kb-route-helpers.ts:97-122` mints `getFreshTenantClient` and `.select("workspace_path, workspace_status, repo_url, github_installation_id")` on `users` | Migrate to the service-role resolvers |
+| Serves `kb/file` PATCH/DELETE + `kb/c4` mutations | TRUE — `kb/file/[...path]/route.ts:22,136`; `kb/c4/[...path]/route.ts:25` | Both routes preserved; helper signature retained |
+| Should migrate to `resolveActiveWorkspaceKbRoot` + `resolveActiveWorkspaceRepoMeta` | Both exist, exported from `server/workspace-resolver.ts:350,473`; `resolveActiveWorkspaceRepoMeta` accepts an optional pre-resolved active id | Compose both inside the helper, passing `access.activeWorkspaceId` to skip the redundant round-trip (mirrors `kb/upload/route.ts:87-91`) |
+| Migrating must re-home the `authenticateAndResolveKbPath.tenant-mint` op or adjust the alert IS_IN filter + op-contract test | TRUE — alert `kb_tenant_mint_silent_fallback` filters `op IS_IN "authenticateAndResolveKbPath.tenant-mint,kb-sync.tenant-mint"` (`infra/sentry/issue-alerts.tf:607`); op-contract test pins both slugs (`test/sentry-kb-tenant-mint-alert-op-contract.test.ts:58-67`) | **`kb-sync.tenant-mint` (a SEPARATE live surface in `kb/sync/route.ts:62`) survives this migration — so the alert does NOT go dark.** Drop only the `authenticateAndResolveKbPath.tenant-mint` slug from the IS_IN value AND the op-contract test's `OP_SLUGS` array. See §Sharp Edges. |
+| `kb-route-helpers.ts` is on the service-role allowlist | FALSE — REMOVED in PR #4929 (`.service-role-allowlist:267-273`); it is tenant-only today | The migration RE-ADDS service-role to this file (the helper now calls `createServiceClient()`). Must re-add `kb-route-helpers.ts` to `.service-role-allowlist` with a one-line justification — see Phase 4. |
+
+Premise Validation note: all five issue-cited references hold. The single material
+divergence from the issue's own framing is favorable: the issue worried the alert
+might go dark; verification of `kb/sync/route.ts:62` shows `kb-sync.tenant-mint` is an
+independent live tenant-mint surface that keeps the alert armed, so this migration
+**narrows** the alert's IS_IN rather than darkening it.
+
+## Chosen Approach — migrate the helper internals, keep the signature
+
+Two designs were considered (see Alternatives). The chosen design keeps
+`authenticateAndResolveKbPath`'s **name, signature, options, and `KbRouteContext`
+return shape unchanged**, and swaps only its credential-resolution body:
+
+1. Keep CSRF (`validateOrigin` / `rejectCsrf`) and `supabase.auth.getUser()` exactly
+   as-is (the auth probe).
+2. **Replace** the `getFreshTenantClient` + `users` SELECT block (lines 97-140) with:
+   - `const serviceClient = createServiceClient();`
+   - `const access = await resolveActiveWorkspaceKbRoot(user.id, serviceClient);`
+     → maps `access.{ok:false,status}` to the legacy response contract
+     (404 → "Workspace not found"/"No repository connected"; 503 → "Workspace not
+     ready"). **See §Sharp Edges for the status-code reconciliation** — the legacy
+     helper returned `503` for not-ready and `400` for no-repo, but
+     `resolveActiveWorkspaceKbRoot` returns `404` for not-connected. The client hook
+     contract must be checked.
+   - `const repoMeta = await resolveActiveWorkspaceRepoMeta(user.id, serviceClient, access.activeWorkspaceId);`
+     → provides `repo_url` + `github_installation_id`.
+3. Build the `userData` object from `{ access.workspacePath, repoMeta.repoUrl, repoMeta.githubInstallationId }` instead of the `users` row.
+4. Keep the path / null-byte / markdown / symlink / owner-repo parsing block
+   (lines 142-177) **byte-identical** — it operates on `userData.workspace_path` and
+   `userData.repo_url`, which are now populated from the active workspace.
+5. Remove the now-dead `getFreshTenantClient` / `RuntimeAuthError` /
+   `resolveInstallationId` dynamic-import code and their imports.
+
+This preserves: the route call-sites (no edits to `kb/file` or `kb/c4` route bodies),
+the CSRF-coverage delegation regex (`csrf-coverage.test.ts:64-70` matches
+`authenticateAndResolveKbPath(`), and the `syncWorkspace` re-export.
+
+**Why not inline at the route level (like upload):** `kb/file` has TWO handlers
+(PATCH + DELETE) and `kb/c4` has the `blockMarkdown:false` variant + owner/repo
+parsing + symlink + markdown-block validation — duplicating the resolver composition
+and the validation block across 2 files / 3 handlers is more blast radius and would
+break the CSRF-coverage delegation path. Keeping the helper is the YAGNI choice and
+matches the learning's "sweep the write routes onto the same resolver" framing.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** rename / delete a KB file, or save an
+edited C4 diagram, fails with "Workspace not ready" / "No repository connected" /
+"No Project Connected" — OR (worse) a path mismatch writes to / deletes from the
+WRONG workspace's clone. For an invited member of a shared workspace this is the exact
+#4543 surface the migration is meant to fix; a regression here re-breaks it.
+
+**If this leaks, the user's repo credential / workspace data is exposed via:** the
+`github_installation_id` is a GitHub App token grant. The migration moves its read
+from the caller's RLS-scoped `users` row to the membership-checked
+`resolve_workspace_installation_id` SECURITY DEFINER RPC (via
+`resolveActiveWorkspaceRepoMeta`). A mis-wired active-id resolution could let one user
+push to / delete from a sibling workspace's repo (cross-tenant write). The resolvers
+fail CLOSED to the SOLO workspace (`= userId`), never an arbitrary sibling — the
+single load-bearing IDOR guard.
+
+**Brand-survival threshold:** single-user incident — inherited verbatim from ADR-044
+(the relocated columns are credentials and the change spans cross-tenant repo access).
+
+> CPO sign-off required at plan time before `/work` begins. CPO is invoked in the
+> Domain Review below (Engineering + Product sweep). `user-impact-reviewer` will be
+> invoked at review-time per `plugins/soleur/skills/review/SKILL.md`.
+
+## Files to Edit
+
+- `apps/web-platform/server/kb-route-helpers.ts` — swap the credential-resolution
+  body of `authenticateAndResolveKbPath` (steps 1-5 above); remove `getFreshTenantClient`
+  / `RuntimeAuthError` imports + the dynamic `resolveInstallationId` import; add
+  `createServiceClient` + the two resolver imports. The `tenant-mint` try/catch and its
+  `op: "authenticateAndResolveKbPath.tenant-mint"` mirror are removed.
+- `apps/web-platform/infra/sentry/issue-alerts.tf` — drop
+  `authenticateAndResolveKbPath.tenant-mint,` from the `kb_tenant_mint_silent_fallback`
+  IS_IN value (line 607), leaving `kb-sync.tenant-mint`; update the block comment
+  (lines 565-569) to reflect that `authenticateAndResolveKbPath` no longer has a
+  tenant-mint surface (now reads via service-role resolvers), so the live slug is
+  `kb-sync.tenant-mint` only.
+- `apps/web-platform/test/sentry-kb-tenant-mint-alert-op-contract.test.ts` — remove the
+  `authenticateAndResolveKbPath.tenant-mint` entry from `OP_SLUGS` (lines 58-62) and
+  update the comment (lines 53-57). The remaining single slug still proves the alert is
+  armed.
+- `apps/web-platform/test/kb-route-helpers.test.ts` — rewrite the
+  `authenticateAndResolveKbPath` test blocks: the happy-path + validation tests
+  (`describe` at line 192) must drive the new resolver-mocked path; DELETE the
+  `tenant-mint failure (reverted)` describe block (lines 751-end of that block) since
+  the tenant-mint surface no longer exists in this helper. Add coverage for: 404/503
+  mapping from `resolveActiveWorkspaceKbRoot`, the `repoMeta` not-ok branches, and the
+  member-vs-solo active-id resolution (mock both resolvers).
+- `apps/web-platform/.service-role-allowlist` — RE-ADD `kb-route-helpers.ts` with a
+  one-line note: the ADR-044 migration (#4956) restores a service-role read (the helper
+  now calls `createServiceClient()` to feed the membership-scoped resolvers), reversing
+  the #4929 removal. Verify the allowlist's enforcing test passes (find via
+  `git grep -l "service-role-allowlist" apps/web-platform/test`).
+
+## Files to Create
+
+- None. (New tests land in the existing `kb-route-helpers.test.ts`.)
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] AC1 — `git grep -n "getFreshTenantClient" apps/web-platform/server/kb-route-helpers.ts`
+  returns ZERO. The helper no longer mints a tenant client.
+- [ ] AC2 — `git grep -n "authenticateAndResolveKbPath.tenant-mint" apps/web-platform`
+  (excluding `knowledge-base/`) returns ZERO. The op slug is gone from the helper, the
+  Sentry IS_IN, AND the op-contract test.
+- [ ] AC3 — The `kb_tenant_mint_silent_fallback` alert's IS_IN value contains
+  `kb-sync.tenant-mint` and NOT `authenticateAndResolveKbPath.tenant-mint`. Verify the
+  block: `awk '/resource "sentry_issue_alert" "kb_tenant_mint_silent_fallback"/{f=1} f{print} f&&/^}/{exit}' apps/web-platform/infra/sentry/issue-alerts.tf | grep "value ="`
+  shows the narrowed value.
+- [ ] AC4 — `sentry-kb-tenant-mint-alert-op-contract.test.ts` passes with the single
+  `kb-sync.tenant-mint` slug (and its `kb/sync/route.ts` emit-site assertion).
+- [ ] AC5 — `kb-route-helpers.test.ts` passes: happy path returns the populated
+  `KbRouteContext` with `userData.{workspace_path, repo_url, github_installation_id}`
+  sourced from the resolvers; all validation branches (CSRF/401/path/markdown/symlink/
+  owner-repo) preserved; resolver-not-ok branches mapped to the correct status.
+- [ ] AC6 — `csrf-coverage.test.ts` passes: `kb/file` and `kb/c4` routes still satisfy
+  the `delegatesToKbHelper` path (the regex `authenticateAndResolveKbPath(` + the
+  `if(!x.ok)return x.response` early-return both still match).
+- [ ] AC7 — `.service-role-allowlist` enforcing test passes with `kb-route-helpers.ts`
+  re-added.
+- [ ] AC8 — `npx tsc --noEmit` clean in `apps/web-platform` (the `KbRouteContext` shape
+  is unchanged, so route call-sites compile without edit).
+- [ ] AC9 — Full `apps/web-platform` vitest suite green
+  (`./node_modules/.bin/vitest run` from `apps/web-platform`, per `package.json`
+  `scripts.test`).
+- [ ] AC10 — **Message parity** for the client (VERIFIED de-risked at deepen — clients
+  show `body.error`, not the status code). The migrated helper maps resolver-not-ok to
+  the legacy MESSAGE strings: `resolveActiveWorkspaceKbRoot` 503 → "Workspace not ready";
+  `resolveActiveWorkspaceKbRoot` 404 (not-connected) → "No repository connected";
+  `resolveActiveWorkspaceRepoMeta` 400/404 → "No repository connected"; 503 → "Workspace
+  not ready". Confirm `components/kb/file-tree.tsx:330-332,346-348` (rename/delete) and
+  `components/kb/c4-shared.tsx:271` (c4 save) still render the message via the existing
+  `!res.ok` + `body.error` branch — no client edit required.
+
+### Post-merge (operator)
+
+- [ ] AC11 — Apply the Sentry IS_IN change to prod. `Automation:` the
+  `apply-sentry-infra.yml` workflow (or the canonical `prd_terraform` triplet) applies
+  the `sentry_issue_alert.kb_tenant_mint_silent_fallback` change on merge. PR body uses
+  `Ref #4956` (not `Closes`) if the prod apply is post-merge; `gh issue close 4956`
+  after the apply succeeds. If the Sentry alert is apply-on-merge via an existing
+  workflow, `Closes #4956` is fine — confirm the workflow at ship time.
+
+## Domain Review
+
+**Domains relevant:** Engineering, Product (security/credential surface), Legal/Privacy
+(credential read-path; GDPR gate)
+
+### Engineering (CTO)
+
+**Status:** reviewed (deepen-plan will spawn data-integrity-guardian +
+security-sentinel + architecture-strategist at single-user-incident threshold)
+**Assessment:** Pure consumer-cutover onto already-shipped, already-reviewed resolvers
+(PR #4953). The precedent-diff is exact: `kb/upload/route.ts:77-107` is the
+copy-from template. Sharp edges are the status-code remap (404 vs 503/400) and the
+service-role allowlist re-add. No new infra, no schema, no migration.
+
+### Product/UX Gate
+
+**Tier:** none
+**Decision:** N/A — no UI surface. Files edited are API route helpers, a Terraform
+alert, tests, and an allowlist. No `components/**/*.tsx`, `app/**/page.tsx`, or
+`app/**/layout.tsx` in Files to Edit. CPO sign-off (required by the single-user-incident
+threshold) is on the SECURITY/credential approach, recorded here, not a page design.
+**Pencil available:** N/A (no UI surface)
+
+#### Findings
+
+The user-visible behavior is the SAME success path; the change is which credential/
+readiness source is read. The improvement is that invited members of shared workspaces
+can now rename/delete/c4-save (the #4543 fix extends to write routes).
+
+## Infrastructure (IaC)
+
+This plan edits an EXISTING Terraform resource (`sentry_issue_alert.kb_tenant_mint_silent_fallback`
+in `apps/web-platform/infra/sentry/issue-alerts.tf`) — it does NOT introduce new
+infrastructure (no new server, service, cron, vendor, secret, DNS, or firewall rule).
+
+### Terraform changes
+
+- `apps/web-platform/infra/sentry/issue-alerts.tf` — narrow one `filters_v2[].tagged_event.value`
+  string (drop one comma-joined slug). No new resource, provider, or variable.
+
+### Apply path
+
+Cloud-init: N/A. The Sentry alert change is applied via the existing
+`apply-sentry-infra.yml` workflow (or the canonical `prd_terraform` triplet:
+`export AWS_ACCESS_KEY_ID=$(doppler secrets get … -c prd_terraform --plain)` + same for
+secret + `terraform init -input=false` + `doppler run -p soleur -c prd_terraform
+--name-transformer tf-var -- terraform apply -target=sentry_issue_alert.kb_tenant_mint_silent_fallback`).
+deepen-plan Phase 4.4 confirms the exact workflow/scope. Blast radius: one alert's
+filter value; no app downtime.
+
+### Distinctness / drift safeguards
+
+`dev != prd`: the alert is prod-Sentry-scoped. `lifecycle { ignore_changes = [environment] }`
+already present on the resource — preserved.
+
+### Vendor-tier reality check
+
+No tier gate: editing an existing `sentry_issue_alert` value, not creating a
+paid-tier-only resource.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "kb_tenant_mint_silent_fallback Sentry issue-alert remains armed via the surviving kb-sync.tenant-mint op slug"
+  cadence: "event-driven (first_seen / reappeared / regression), frequency=12"
+  alert_target: "IssueOwners → ActiveMembers fallthrough (solo founder)"
+  configured_in: "apps/web-platform/infra/sentry/issue-alerts.tf:582"
+error_reporting:
+  destination: "Sentry (reportSilentFallback → captureException with feature/op tags)"
+  fail_loud: "the migrated helper's resolver-not-ok branches return typed Responses; the resolvers themselves mirror every query error to Sentry (resolveActiveWorkspaceKbRoot.workspaces-read / .organizations-read / .owner-readiness-read; resolveActiveWorkspaceRepoMeta.workspaces-read; resolve-installation-id.rpc-read) — so a credential-read failure on this brand-survival write path stays Sentry-visible, not a bare 404/503"
+failure_modes:
+  - mode: "active-id resolution membership-probe error"
+    detection: "reportSilentFallback op:resolveActiveWorkspaceKbRoot.membership-probe"
+    alert_route: "feature=workspace-resolver Sentry events (existing)"
+  - mode: "workspaces repo_status / repo_url read error"
+    detection: "reportSilentFallback op:resolveActiveWorkspaceKbRoot.workspaces-read | resolveActiveWorkspaceRepoMeta.workspaces-read"
+    alert_route: "feature=workspace-resolver Sentry events (existing)"
+  - mode: "installation RPC deny / failure"
+    detection: "reportSilentFallback op:resolve-installation-id.rpc-read"
+    alert_route: "feature=resolve-installation-id Sentry events (existing)"
+  - mode: "regression: IS_IN narrowed AND kb-sync.tenant-mint slug also removed → alert darks"
+    detection: "sentry-kb-tenant-mint-alert-op-contract.test.ts asserts the surviving slug exists on BOTH the emit site (kb/sync/route.ts) and the filter block"
+    alert_route: "CI fails the merge"
+logs:
+  where: "pino structured logs (kb_delete / kb_rename / kb_upload events) + Sentry"
+  retention: "Sentry default project retention; pino to stdout is the diagnostic log, not the alert sink"
+discoverability_test:
+  command: "cd apps/web-platform && ./node_modules/.bin/vitest run test/sentry-kb-tenant-mint-alert-op-contract.test.ts test/kb-route-helpers.test.ts lib/auth/csrf-coverage.test.ts"
+  expected_output: "all suites pass — proves the alert contract, the helper behavior, and CSRF delegation all hold post-migration, without SSH"
+```
+
+## Test Scenarios
+
+1. **Solo owner rename** — `PATCH /api/kb/file/foo.pdf` → resolver returns the solo
+   workspace (`activeWorkspaceId === userId`), kbRoot/repo identical to legacy; 200.
+2. **Invited member delete on shared workspace** — `current_workspace_id` claim → a
+   workspace the caller is a member of but does not own; resolver reads
+   `workspaces.repo_status` + the membership-checked installation RPC; 200 (the #4543
+   write-route fix). Previously 400 "No repository connected" from the empty solo
+   `users` row.
+3. **Stale non-member claim** — claim points at a workspace the caller is no longer a
+   member of → `resolveActiveWorkspaceIdWithMembership` self-heals to SOLO (never the
+   sibling); write lands in the solo workspace, never cross-tenant.
+4. **Repo not connected** — `workspaces.repo_url` null → resolver returns the
+   no-repo status; helper maps to the legacy contract (AC10 reconciliation).
+5. **Workspace not ready** — owner `users.workspace_status !== "ready"` → 503.
+6. **C4 save (.md allowed)** — `PUT /api/kb/c4/...` with `blockMarkdown:false` →
+   `writeC4Diagram` receives `ctx.userData.{workspace_path, github_installation_id}`
+   from the active workspace; commit + re-render.
+7. **CSRF reject** — bad origin → 403 before any resolver call (unchanged).
+8. **Path traversal / null byte / symlink** — all 400/403 branches unchanged.
+
+## Alternatives Considered
+
+| Alternative | Rejected because |
+| --- | --- |
+| Inline the two resolvers into each route body (PATCH+DELETE+PUT), like `kb/upload` did | 3 handlers across 2 files duplicate the resolver composition + the owner/repo/symlink validation block; breaks the `csrf-coverage.test.ts` delegation regex; more blast radius for zero benefit. The upload route inlined because it has ONE handler and a bespoke FormData flow. |
+| Add a service-role escape only on the availability causes (re-introduce #4919) | Explicitly reverted in #4929 as dead code (PIR #4913 proved the mint works in prod). Do not re-widen. |
+| Keep the tenant `users` read as a fallback when the resolver returns not-ready | Re-introduces the dual-source-of-truth divergence ADR-044 forbids; the resolver IS the source of truth. |
+| Re-home `authenticateAndResolveKbPath.tenant-mint` to a new op slug | No tenant-mint surface remains in this helper after migration, so there is nothing to re-home. `kb-sync.tenant-mint` keeps the alert armed. Adding a synthetic slug would be a dead emit site. |
+
+## Open Code-Review Overlap
+
+(Run at /work after Files to Edit is frozen, per plan Phase 1.7.5:
+`gh issue list --label code-review --state open --json number,title,body --limit 200`
+then `jq` each path. Pre-recorded here:) None expected — this is a fresh follow-up
+issue; no open code-review scope-out is known to touch `kb-route-helpers.ts`,
+`issue-alerts.tf`, or the named tests. Confirm at /work.
+
+## GDPR / Compliance Gate
+
+This plan touches an auth-flow / credential read-path (the `github_installation_id`
+token grant) and an API route surface → `/soleur:gdpr-gate` is in-scope and will be
+invoked against the plan during /work Phase 2.7 (advisory-only output). The migration
+STRENGTHENS tenant isolation (credential read moves from RLS-row-exposed to
+membership-scoped definer RPC, per ADR-044 NFR Impacts) — no new processing activity,
+no new data field, no new external transfer.
+
+## Precedent Diff (Phase 4.4)
+
+This is a pattern-bound consumer-cutover; the canonical precedent is the migrated
+upload route (`app/api/kb/upload/route.ts:76-107`), shipped + reviewed in PR #4953:
+
+```ts
+// PRECEDENT — kb/upload/route.ts (already merged):
+const serviceClient = createServiceClient();
+const access = await resolveActiveWorkspaceKbRoot(user.id, serviceClient);
+if (!access.ok) { /* map status → message → NextResponse.json */ }
+const repoMeta = await resolveActiveWorkspaceRepoMeta(
+  user.id, serviceClient, access.activeWorkspaceId,  // pass pre-resolved id
+);
+if (!repoMeta.ok) { /* map status → message */ }
+const userData = {
+  workspace_path: access.workspacePath,
+  repo_url: repoMeta.repoUrl,
+  github_installation_id: repoMeta.githubInstallationId,
+};
+```
+
+The migrated `authenticateAndResolveKbPath` body is byte-for-byte this block, dropped
+in place of `kb-route-helpers.ts:97-140` (the `getFreshTenantClient` + `users` SELECT +
+the `resolveInstallationId` fallback). The IDOR fail-closed guard
+(`resolveActiveWorkspaceIdWithMembership` → solo on non-member,
+`workspace-resolver.ts:322-324`) is inherited unchanged from the precedent. **No novel
+pattern** — the only deltas from the precedent are: (a) the helper KEEPS the CSRF +
+path/symlink/owner-repo validation block (upload inlines its own), and (b) the helper
+returns the `KbRouteContext` discriminated union instead of writing the response inline.
+
+## Sharp Edges
+
+- **Status-code reconciliation (AC10 — VERIFIED de-risked at deepen).** The legacy
+  helper returns `503 "Workspace not ready"` and `400 "No repository connected"`.
+  `resolveActiveWorkspaceKbRoot` returns `{status: 404 | 503}`;
+  `resolveActiveWorkspaceRepoMeta` returns `{status: 400 | 404 | 503}`. Deepen verified
+  the three client callers discriminate ONLY on `!res.ok` and render `body.error` — they
+  do NOT switch on the numeric code: `file-tree.tsx:330-332` (rename),
+  `file-tree.tsx:346-348` (delete), `c4-shared.tsx:271` (c4 save). So the only
+  correctness requirement is **message parity** (AC10), not code parity. Map resolver
+  404/400 → "No repository connected", 503 → "Workspace not ready". Do NOT copy the
+  upload route's `404 → "Workspace not found"` message — kb/file/kb/c4 used "No
+  repository connected" for the no-repo case and the legacy message must be preserved.
+- **Service-role allowlist re-add is load-bearing.** The helper now imports
+  `createServiceClient`. PR #4929 explicitly REMOVED `kb-route-helpers.ts` from
+  `.service-role-allowlist`. The enforcing gate
+  (`apps/web-platform/scripts/service-role-allowlist-gate.sh`, exercised by
+  `test/ci/service-role-allowlist-gate.test.sh`) greps each `.ts` for a
+  `createServiceClient` import and FAILs the merge if the importing file is not a
+  verbatim allowlist line. Re-add the EXACT path
+  `apps/web-platform/server/kb-route-helpers.ts` AND update the removal-comment at
+  `.service-role-allowlist:66` (which lists `kb-route-helpers` among removed files). Do
+  NOT defer.
+- **Avoid importing service-role into the App-Router `next/headers` graph.** The c4
+  write path was deliberately split (`syncWorkspace` re-exported from
+  `@/server/workspace-sync`, see `kb-route-helpers.ts:12-20`) so the cc-dispatcher WS
+  bundle can import sync without `@/lib/supabase/server`. `authenticateAndResolveKbPath`
+  is only reached from App-Router routes (it already imports `@/lib/supabase/server` for
+  `createClient`), so adding `createServiceClient` here is safe — but at /work confirm no
+  WS-bundle module imports `authenticateAndResolveKbPath` (grep returned only the two
+  App-Router route files + the CSRF test). Do not let the resolver imports leak into
+  `workspace-sync.ts`.
+- **The op-contract test would silently pass if BOTH slugs were removed only from the
+  filter but one lingered elsewhere in the .tf** — the test already scopes to the
+  resource block (`sentry-kb-tenant-mint-alert-op-contract.test.ts:31-38`). Keep that
+  block-scoping; do not loosen to whole-file `toContain`.
+- **`writeC4Diagram` reads `ctx.userData.workspace_path`.** After migration this is
+  `access.workspacePath` (the active workspace's on-disk path). Confirm `writeC4Diagram`
+  + `syncWorkspace` operate on that path — they already do for upload, but c4 has its own
+  re-render step (`renderC4Model(workspacePath)`); verify the active path resolves the
+  diagrams dir.
+- **Do not edit the `kb/file` / `kb/c4` route bodies.** The whole point of keeping the
+  helper signature is that the routes are untouched. If a route edit becomes necessary,
+  the CSRF-coverage delegation regex (`csrf-coverage.test.ts:64-70`) must still match.
+- A plan whose `## User-Brand Impact` section is empty, contains only TBD/placeholder,
+  or omits the threshold will fail `deepen-plan` Phase 4.6. (Filled above.)
+
+## Notes
+
+- Spec lacks valid `lane:` (no spec file for this branch) — defaulted to `cross-domain`
+  (TR2 fail-closed).
+- At `single-user incident` threshold, the exit gate recommends running
+  `deepen-plan` (already queued in this pipeline) so the data-integrity-guardian +
+  security-sentinel + architecture-strategist triad audits the credential read-path and
+  the status-code reconciliation — issue classes plan-review (DHH/Kieran/Simplicity)
+  is structurally blind to.

--- a/knowledge-base/project/plans/2026-06-05-refactor-authenticate-kb-path-adr044-resolver-plan.md
+++ b/knowledge-base/project/plans/2026-06-05-refactor-authenticate-kb-path-adr044-resolver-plan.md
@@ -219,32 +219,32 @@ single load-bearing IDOR guard.
 
 ### Pre-merge (PR)
 
-- [ ] AC1 — `git grep -n "getFreshTenantClient" apps/web-platform/server/kb-route-helpers.ts`
+- [x] AC1 — `git grep -n "getFreshTenantClient" apps/web-platform/server/kb-route-helpers.ts`
   returns ZERO. The helper no longer mints a tenant client.
-- [ ] AC2 — `git grep -n "authenticateAndResolveKbPath.tenant-mint" apps/web-platform`
+- [x] AC2 — `git grep -n "authenticateAndResolveKbPath.tenant-mint" apps/web-platform`
   (excluding `knowledge-base/`) returns ZERO. The op slug is gone from the helper, the
   Sentry IS_IN, AND the op-contract test.
-- [ ] AC3 — The `kb_tenant_mint_silent_fallback` alert's IS_IN value contains
+- [x] AC3 — The `kb_tenant_mint_silent_fallback` alert's IS_IN value contains
   `kb-sync.tenant-mint` and NOT `authenticateAndResolveKbPath.tenant-mint`. Verify the
   block: `awk '/resource "sentry_issue_alert" "kb_tenant_mint_silent_fallback"/{f=1} f{print} f&&/^}/{exit}' apps/web-platform/infra/sentry/issue-alerts.tf | grep "value ="`
   shows the narrowed value.
-- [ ] AC4 — `sentry-kb-tenant-mint-alert-op-contract.test.ts` passes with the single
+- [x] AC4 — `sentry-kb-tenant-mint-alert-op-contract.test.ts` passes with the single
   `kb-sync.tenant-mint` slug (and its `kb/sync/route.ts` emit-site assertion).
-- [ ] AC5 — `kb-route-helpers.test.ts` passes: happy path returns the populated
+- [x] AC5 — `kb-route-helpers.test.ts` passes: happy path returns the populated
   `KbRouteContext` with `userData.{workspace_path, repo_url, github_installation_id}`
   sourced from the resolvers; all validation branches (CSRF/401/path/markdown/symlink/
   owner-repo) preserved; resolver-not-ok branches mapped to the correct status.
-- [ ] AC6 — `csrf-coverage.test.ts` passes: `kb/file` and `kb/c4` routes still satisfy
+- [x] AC6 — `csrf-coverage.test.ts` passes: `kb/file` and `kb/c4` routes still satisfy
   the `delegatesToKbHelper` path (the regex `authenticateAndResolveKbPath(` + the
   `if(!x.ok)return x.response` early-return both still match).
-- [ ] AC7 — `.service-role-allowlist` enforcing test passes with `kb-route-helpers.ts`
+- [x] AC7 — `.service-role-allowlist` enforcing test passes with `kb-route-helpers.ts`
   re-added.
-- [ ] AC8 — `npx tsc --noEmit` clean in `apps/web-platform` (the `KbRouteContext` shape
+- [x] AC8 — `npx tsc --noEmit` clean in `apps/web-platform` (the `KbRouteContext` shape
   is unchanged, so route call-sites compile without edit).
-- [ ] AC9 — Full `apps/web-platform` vitest suite green
+- [x] AC9 — Full `apps/web-platform` vitest suite green
   (`./node_modules/.bin/vitest run` from `apps/web-platform`, per `package.json`
   `scripts.test`).
-- [ ] AC10 — **Message parity** for the client (VERIFIED de-risked at deepen — clients
+- [x] AC10 — **Message parity** for the client (VERIFIED de-risked at deepen — clients
   show `body.error`, not the status code). The migrated helper maps resolver-not-ok to
   the legacy MESSAGE strings: `resolveActiveWorkspaceKbRoot` 503 → "Workspace not ready";
   `resolveActiveWorkspaceKbRoot` 404 (not-connected) → "No repository connected";

--- a/knowledge-base/project/specs/feat-one-shot-4956-kb-route-helpers-adr044/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-4956-kb-route-helpers-adr044/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-05-refactor-authenticate-kb-path-adr044-resolver-plan.md
+- Status: complete
+
+### Errors
+None. (One transient: the initial Write resolved to the bare-repo root and was BLOCKED by the worktree guard — re-issued against the explicit worktree path and succeeded. No content lost.)
+
+### Decisions
+- Chosen approach: migrate the helper internals, keep the signature. Swap `authenticateAndResolveKbPath`'s tenant-`users` read for the service-role `resolveActiveWorkspaceKbRoot` + `resolveActiveWorkspaceRepoMeta` (the PR #4953 precedent), leaving the `KbRouteContext` shape, both route call-sites, and the CSRF-coverage delegation untouched.
+- The Sentry `kb_tenant_mint_silent_fallback` alert does NOT go dark — `kb-sync.tenant-mint` (`kb/sync/route.ts:62`) is an independent live tenant-mint surface; the migration only narrows the IS_IN filter + the op-contract test, dropping the now-removed `authenticateAndResolveKbPath.tenant-mint` slug.
+- Status-code reconciliation de-risked at deepen — rename/delete/c4-save clients discriminate only on `!res.ok` and render `body.error`; only message-string parity matters (AC10 downgraded).
+- Service-role allowlist re-add is mandatory — the helper now imports `createServiceClient`; PR #4929 removed `kb-route-helpers.ts` from `.service-role-allowlist`; the gate FAILs the merge unless the exact path is re-added and the removal-comment updated.
+- Threshold = single-user incident (inherited from ADR-044, credential read-path), so `requires_cpo_signoff: true`; deepen triad + `user-impact-reviewer` + gdpr-gate queued for review-time. Lane: cross-domain. All 4 deepen gates passed; all KB citations and cited PRs verified live.
+
+### Components Invoked
+- Skill `soleur:plan` (#4956)
+- Skill `soleur:deepen-plan` (plan path)
+- Bash, Read, Write, Edit (plan + tasks authoring); no review/research sub-agents spawned for this low-novelty consumer-cutover.

--- a/knowledge-base/project/specs/feat-one-shot-4956-kb-route-helpers-adr044/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-4956-kb-route-helpers-adr044/tasks.md
@@ -1,0 +1,96 @@
+---
+title: "Tasks — migrate authenticateAndResolveKbPath to ADR-044 resolvers"
+issue: 4956
+lane: cross-domain
+plan: knowledge-base/project/plans/2026-06-05-refactor-authenticate-kb-path-adr044-resolver-plan.md
+---
+
+# Tasks — `authenticateAndResolveKbPath` → ADR-044 resolvers (#4956)
+
+Derived from the finalized (deepened) plan. Brand-survival threshold: single-user
+incident — run the security/integrity/architecture review triad before merge.
+
+## Phase 0 — Preconditions (read-before-write, RED before GREEN)
+
+1.1. Confirm only the two App-Router routes + the CSRF test reference the helper:
+   `git grep -n "authenticateAndResolveKbPath" apps/web-platform -- ':!**/test/**' ':!knowledge-base/**'`
+   → expect `kb/file/[...path]/route.ts`, `kb/c4/[...path]/route.ts`,
+   `infra/sentry/issue-alerts.tf` (comment + IS_IN), `kb-route-helpers.ts`.
+1.2. Confirm `kb-sync.tenant-mint` still lives in `app/api/kb/sync/route.ts:62` (the
+   surviving live tenant-mint surface that keeps the alert armed).
+1.3. Read the three client error branches to lock message parity:
+   `components/kb/file-tree.tsx:330-348`, `components/kb/c4-shared.tsx:271` — all use
+   `!res.ok` + `body.error` (no numeric-code switch).
+1.4. Read the allowlist gate: `apps/web-platform/scripts/service-role-allowlist-gate.sh`
+   and `.service-role-allowlist:66` (removal comment listing `kb-route-helpers`).
+
+## Phase 1 — Migrate the helper (Files to Edit #1)
+
+2.1. In `apps/web-platform/server/kb-route-helpers.ts`, replace the
+   `getFreshTenantClient` + `users` SELECT + `resolveInstallationId` fallback block
+   (lines ~97-140) with the precedent block (plan §Precedent Diff): `createServiceClient()`
+   → `resolveActiveWorkspaceKbRoot` → `resolveActiveWorkspaceRepoMeta(... access.activeWorkspaceId)`.
+2.2. Build `userData = { workspace_path: access.workspacePath, repo_url: repoMeta.repoUrl,
+   github_installation_id: repoMeta.githubInstallationId }`.
+2.3. Map resolver-not-ok to the LEGACY message strings (message parity, plan AC10):
+   `resolveActiveWorkspaceKbRoot` 503 → "Workspace not ready", 404 → "No repository
+   connected"; `resolveActiveWorkspaceRepoMeta` 400/404 → "No repository connected",
+   503 → "Workspace not ready".
+2.4. Keep the CSRF + auth probe + path/null-byte/markdown/symlink/owner-repo block
+   byte-identical. Keep the `KbRouteContext` return shape unchanged.
+2.5. Remove now-dead imports: `getFreshTenantClient`, `RuntimeAuthError`, the dynamic
+   `resolveInstallationId` import, and the `authenticateAndResolveKbPath.tenant-mint`
+   `reportSilentFallback` mirror. Add `createServiceClient` + the two resolver imports.
+   Do NOT let resolver imports leak into `workspace-sync.ts` (WS-bundle boundary).
+
+## Phase 2 — Observability contract (Files to Edit #2, #3)
+
+3.1. `apps/web-platform/infra/sentry/issue-alerts.tf` — drop
+   `authenticateAndResolveKbPath.tenant-mint,` from the IS_IN value (line ~607); leave
+   `kb-sync.tenant-mint`. Update the block comment (lines ~565-569) to state the helper
+   now reads via service-role resolvers (no tenant-mint surface).
+3.2. `apps/web-platform/test/sentry-kb-tenant-mint-alert-op-contract.test.ts` — remove
+   the `authenticateAndResolveKbPath.tenant-mint` entry from `OP_SLUGS` and update the
+   comment. The single surviving slug still proves the alert is armed (emit-site +
+   filter-block assertions).
+
+## Phase 3 — Allowlist (Files to Edit #4)
+
+4.1. `apps/web-platform/.service-role-allowlist` — RE-ADD the verbatim line
+   `apps/web-platform/server/kb-route-helpers.ts` with a one-line justification (#4956
+   ADR-044 migration restores a service-role read for the membership-scoped resolvers).
+4.2. Update the removal comment at `.service-role-allowlist:66` so it no longer lists
+   `kb-route-helpers` among removed files.
+
+## Phase 4 — Tests (Files to Edit #5)
+
+5.1. `apps/web-platform/test/kb-route-helpers.test.ts` — rewrite the
+   `authenticateAndResolveKbPath` describe: mock both resolvers; cover happy path
+   (populated `KbRouteContext`), CSRF/401/path/markdown/symlink/owner-repo branches,
+   resolver-not-ok → message-parity, and member-vs-solo active-id resolution.
+5.2. DELETE the `tenant-mint failure (reverted)` describe block (no tenant-mint surface
+   remains in this helper).
+5.3. Add a c4 active-path test note: `writeC4Diagram` / `renderC4Model(workspacePath)`
+   operates on `access.workspacePath` (the active workspace), not `users.workspace_path`.
+
+## Phase 5 — Verification gates (Acceptance Criteria)
+
+6.1. AC1 — `git grep getFreshTenantClient server/kb-route-helpers.ts` = 0.
+6.2. AC2 — `git grep authenticateAndResolveKbPath.tenant-mint apps/web-platform`
+   (excl. knowledge-base) = 0.
+6.3. AC3/AC4 — Sentry IS_IN narrowed; op-contract test green.
+6.4. AC5/AC6/AC7 — `kb-route-helpers.test.ts`, `csrf-coverage.test.ts`, and the
+   allowlist gate (`test/ci/service-role-allowlist-gate.test.sh`) all green.
+6.5. AC8 — `npx tsc --noEmit` clean.
+6.6. AC9 — full `apps/web-platform` vitest suite green (`./node_modules/.bin/vitest run`).
+6.7. AC10 — message parity confirmed (clients render `body.error`).
+
+## Phase 6 — Review + ship
+
+7.1. Run the single-user-incident review triad (data-integrity-guardian +
+   security-sentinel + architecture-strategist) + `user-impact-reviewer`.
+7.2. `/soleur:gdpr-gate` advisory pass (credential read-path) — expect "strengthens
+   isolation, no new processing activity".
+7.3. PR body: `Ref #4956` if the Sentry apply is post-merge; `gh issue close 4956`
+   after the prod apply succeeds (or `Closes #4956` if apply-on-merge is confirmed at
+   ship time).


### PR DESCRIPTION
## Summary

Migrate `authenticateAndResolveKbPath` (`apps/web-platform/server/kb-route-helpers.ts`) off the legacy tenant `users` read onto the ADR-044 membership-scoped service-role resolvers `resolveActiveWorkspaceKbRoot` + `resolveActiveWorkspaceRepoMeta` — the same path `kb/share` + `kb/upload` took in #4953. The helper signature and `KbRouteContext` shape are unchanged, so the two write-route call-sites (`kb/file` PATCH/DELETE, `kb/c4` PUT) are untouched.

This is the last KB write-route consumer still on the pre-ADR-044 path. It fixes the #4543 dual-ownership trap on the write routes: the legacy resolver read the **caller's own** `users.{workspace_path,repo_url,github_installation_id}` row — the empty solo row for an invited member operating on a shared workspace → spurious "Workspace not ready" / "No repository connected". Invited members can now rename/delete files and save C4 diagrams in a shared workspace.

Closes #4956

## User-Brand Impact

- **Artifact exposed:** the workspace `github_installation_id` (a GitHub App token grant) + `repo_url` + on-disk `workspace_path`.
- **Exposure vector:** a mis-wired active-workspace resolution could let one user push to / delete from a sibling workspace's clone (cross-tenant repo write). Mitigated: the active-id resolution fails **closed to the solo workspace** (`= userId`, never an arbitrary sibling) via `resolveActiveWorkspaceIdWithMembership`, and the single pre-resolved `activeWorkspaceId` is threaded from `resolveActiveWorkspaceKbRoot` into `resolveActiveWorkspaceRepoMeta` so kbRoot, repo, and credential cannot diverge. The credential read moves from the RLS-row-exposed `users` row to the membership-checked `resolve_workspace_installation_id` SECURITY DEFINER RPC — ADR-044 **strengthens** tenant isolation.
- **Brand-survival threshold:** single-user incident

## Changelog

- `authenticateAndResolveKbPath` now resolves the active workspace's kbRoot + repo metadata via the service-role resolvers instead of a tenant `users` read (ADR-044, #4543).
- Resolver-not-ok branches map to the **legacy message strings** (AC10 message parity — clients render `body.error`, not the numeric code; the "no repository connected" case shifts 400→404 with the message preserved).
- Dropped the `authenticateAndResolveKbPath` tenant-mint op slug from the helper, the `kb_tenant_mint_silent_fallback` Sentry IS_IN filter, and the op-contract test `OP_SLUGS`; `kb-sync.tenant-mint` is the surviving live slug that keeps the alert armed.
- Re-added `kb-route-helpers.ts` to `.service-role-allowlist` (the helper again calls `createServiceClient` to feed the membership-scoped resolvers; reverses #4929).
- Swept the route-level + isolation test mocks (`kb-rename`, `kb-delete`, `kb-route-helpers.tenant-isolation`) onto the resolvers.

## Test plan

- [x] `kb-route-helpers.test.ts` rewritten to mock the resolvers (happy path, CSRF/401, all path/markdown/symlink branches, resolver-not-ok → message parity, member-vs-solo active-id threading) — 30/30 pass.
- [x] `sentry-kb-tenant-mint-alert-op-contract.test.ts` green with the single surviving `kb-sync.tenant-mint` slug.
- [x] `kb-rename.test.ts` + `kb-delete.test.ts` route tests migrated to the resolver mocks — 37/37 pass.
- [x] `csrf-coverage.test.ts` green (kb/file + kb/c4 still satisfy the delegation regex).
- [x] `.service-role-allowlist` enforcing gate green with `kb-route-helpers.ts` re-added.
- [x] `tsc --noEmit` clean; full `apps/web-platform` vitest suite green (8839 passing).
- [x] AC greps: `getFreshTenantClient` = 0 in the helper; `authenticateAndResolveKbPath.tenant-mint` = 0 (excl. knowledge-base).
- [x] Sentry IS_IN change auto-applies on merge via `apply-sentry-infra.yml` (`kb_tenant_mint_silent_fallback` is in its `-target` set + path filter).

Generated with [Claude Code](https://claude.com/claude-code)
