### PR TITLE
WIP: feat-one-shot-drain-p4-3399-3413-3415

### DIFF
--- a/.github/workflows/apply-sentry-infra.yml
+++ b/.github/workflows/apply-sentry-infra.yml
@@ -187,6 +187,7 @@ jobs:
             -target=sentry_cron_monitor.scheduled_terraform_drift \
             -target=sentry_cron_monitor.scheduled_oauth_probe \
             -target=sentry_cron_monitor.scheduled_github_app_drift_guard \
+            -target=sentry_cron_monitor.cron_kb_template_health \
             -target=sentry_cron_monitor.scheduled_daily_triage \
             -target=sentry_cron_monitor.scheduled_realtime_probe \
             -target=sentry_cron_monitor.scheduled_skill_freshness \

--- a/apps/web-platform/app/api/inngest/route.ts
+++ b/apps/web-platform/app/api/inngest/route.ts
@@ -37,6 +37,7 @@ import { cronGithubAppDriftGuard } from "@/server/inngest/functions/cron-github-
 import { cronGrowthAudit } from "@/server/inngest/functions/cron-growth-audit";
 import { cronGrowthExecution } from "@/server/inngest/functions/cron-growth-execution";
 import { cronInngestCronWatchdog } from "@/server/inngest/functions/cron-inngest-cron-watchdog";
+import { cronKbTemplateHealth } from "@/server/inngest/functions/cron-kb-template-health";
 import { cronLegalAudit } from "@/server/inngest/functions/cron-legal-audit";
 import { cronLinkedinTokenCheck } from "@/server/inngest/functions/cron-linkedin-token-check";
 import { cronMainHealthMonitor } from "@/server/inngest/functions/cron-main-health-monitor";
@@ -102,6 +103,7 @@ export const { GET, POST, PUT } = serve({
     cronGrowthAudit,
     cronGrowthExecution,
     cronInngestCronWatchdog,
+    cronKbTemplateHealth,
     cronLegalAudit,
     cronLinkedinTokenCheck,
     cronMainHealthMonitor,

--- a/apps/web-platform/infra/sentry/cron-monitors.tf
+++ b/apps/web-platform/infra/sentry/cron-monitors.tf
@@ -114,6 +114,26 @@ resource "sentry_cron_monitor" "scheduled_github_app_drift_guard" {
   timezone                = "UTC"
 }
 
+# #3413: Inngest-fired via
+# `apps/web-platform/server/inngest/functions/cron-kb-template-health.ts`.
+# NEW hourly probe — no GHA-era predecessor (the issue body named a
+# GitHub Actions workflow but the work landed as an Inngest cron per the
+# 45-cron-vs-4-workflow precedent + ADR-030; the structural sibling is
+# scheduled_github_app_drift_guard above). The slug `cron-kb-template-health`
+# matches SENTRY_MONITOR_SLUG in the handler; hourly cadence + 30-min margin
+# + 10-min runtime mirror the drift-guard sibling (same API-probe shape).
+resource "sentry_cron_monitor" "cron_kb_template_health" {
+  organization            = var.sentry_org
+  project                 = data.sentry_project.web_platform.slug
+  name                    = "cron-kb-template-health"
+  schedule                = { crontab = "0 * * * *" }
+  checkin_margin_minutes  = 30
+  max_runtime_minutes     = 10
+  failure_issue_threshold = 1
+  recovery_threshold      = 1
+  timezone                = "UTC"
+}
+
 # TR9 PR-5 (closes #4376): Inngest-fired via
 # `apps/web-platform/server/inngest/functions/cron-bug-fixer.ts`. NEW
 # monitor — no GHA-era predecessor (the workflow ran on GHA's runner pool

--- a/apps/web-platform/server/inngest/cron-manifest.ts
+++ b/apps/web-platform/server/inngest/cron-manifest.ts
@@ -38,6 +38,7 @@ export const EXPECTED_CRON_FUNCTIONS: string[] = [
   "cron-growth-audit",
   "cron-growth-execution",
   "cron-inngest-cron-watchdog",
+  "cron-kb-template-health",
   "cron-legal-audit",
   "cron-linkedin-token-check",
   "cron-main-health-monitor",

--- a/apps/web-platform/server/inngest/functions/cron-github-app-drift-guard.ts
+++ b/apps/web-platform/server/inngest/functions/cron-github-app-drift-guard.ts
@@ -136,7 +136,7 @@ export function assertNoLeak(label: string, s: string): void {
  * included the key body. This is a defensive ban on raw .message
  * forwarding to the observability pipe.
  */
-function redactedError(e: unknown): Error {
+export function redactedError(e: unknown): Error {
   const orig = e instanceof Error ? e : new Error(String(e));
   const msg = orig.message ?? "";
   if (LEAK_TRIPWIRE_RE.test(msg)) {

--- a/apps/web-platform/server/inngest/functions/cron-kb-template-health.ts
+++ b/apps/web-platform/server/inngest/functions/cron-kb-template-health.ts
@@ -1,0 +1,398 @@
+// #3413 — kb-template health probe (Inngest cron).
+//
+// Every user-account "Create Project" routes through jikig-ai/kb-template's
+// /generate endpoint (server/github-app.ts header @ KB_TEMPLATE_OWNER/NAME).
+// If an operator deletes/renames/privatizes the template or drops its
+// `is_template` flag, every create returns 404/422 — previously detected only
+// post-hoc via Sentry. This hourly cron proactively probes the template's
+// documented success shape and files a P1 ops issue on drift.
+//
+// ARCHITECTURE: Inngest cron, NOT a GitHub Actions workflow. The codebase runs
+// ~45 cron-*.ts Inngest functions vs 4 legacy scheduled-*.yml workflows; the
+// direct structural sibling is cron-github-app-drift-guard.ts. Governing
+// ADR-030 (Inngest as durable trigger layer for server-side agents).
+//
+// AUTH: createProbeOctokit() mints an installation-scoped Octokit via
+// @octokit/auth-app internally — NO PAT, NO JWT-mint here
+// (hr-github-app-auth-not-pat satisfied by construction).
+//
+// LEAK TRIPWIRE: assertNoLeak is EXPORTED by cron-github-app-drift-guard.ts and
+// imported here (single source of truth for the PEM/JWT/base64-PEM regexes).
+// Run every captured GitHub body through it before any issue-body write.
+//
+// FAILURE-LABEL FAMILIES (distinct from the drift-guard's taxonomy):
+//   ops/kb-template-broken  — drift detected, user-impacting: the template was
+//                             deleted/renamed (404), un-marked as a template
+//                             (is_template !== true), or made private
+//                             (private !== false). Onboarding "Create Project"
+//                             breaks for every user.
+//   ci/guard-broken         — the probe itself malfunctioned: a non-object body,
+//                             a missing is_template/private field, or a non-404
+//                             HTTP/network error. NOT a template-drift signal.
+//
+// DUPLICATION NOTE (for a future dedup issue, not filed here): the
+// issue-handling shape below (dedup-search → comment-or-open → auto-close on
+// PATCH state:closed) mirrors cron-github-app-drift-guard.ts's file-private
+// handleFailureIssue. Those helpers are not exported by the sibling, so a
+// minimal mirror is co-located here with a kb-template-specific title-phrase.
+// A future PR may extract server/github/probe-issue-handler.ts shared by both.
+
+import type { Octokit } from "@octokit/core";
+import { inngest } from "@/server/inngest/client";
+import { reportSilentFallback } from "@/server/observability";
+import { createProbeOctokit, PROBE_ISSUE_OWNER, PROBE_ISSUE_REPO } from "@/server/github/probe-octokit";
+import { KB_TEMPLATE_NAME, KB_TEMPLATE_OWNER } from "@/server/github-app";
+import { assertNoLeak } from "./cron-github-app-drift-guard";
+import { postSentryHeartbeat, type HandlerArgs } from "./_cron-shared";
+
+const SENTRY_MONITOR_SLUG = "cron-kb-template-health";
+const CRON_NAME = "cron-kb-template-health";
+
+// Dedup title-phrase — distinct from the drift-guard's "GitHub App drift-guard".
+const ISSUE_TITLE_PHRASE = "kb-template health";
+const ISSUE_TITLE_DRIFT = "[ops/kb-template-broken] kb-template health probe fired";
+const ISSUE_TITLE_GUARD_BROKEN =
+  "[ci/guard-broken] kb-template health probe malfunctioned";
+
+const RUNBOOK_URL =
+  "https://github.com/jikig-ai/soleur/blob/main/knowledge-base/engineering/operations/runbooks/kb-template-health.md";
+const RUN_URL =
+  "https://de.sentry.io/organizations/jikigai-eu/crons/cron-kb-template-health/";
+
+// =============================================================================
+// Documented-success-shape predicate (pure — exported for the dry-run test)
+// =============================================================================
+
+// `ops/kb-template-broken` = real template drift (user-impacting); the create
+// flow is broken. `ci/guard-broken` = the probe itself could not assert (the
+// body was not the documented object shape) — a guard malfunction, NOT drift.
+export type KbTemplateFailureLabel = "ops/kb-template-broken" | "ci/guard-broken";
+
+export interface KbTemplateVerdict {
+  ok: boolean;
+  failureMode: string;
+  failureDetail: string;
+  failureLabel: KbTemplateFailureLabel;
+}
+
+const PASS_VERDICT: KbTemplateVerdict = {
+  ok: true,
+  failureMode: "",
+  failureDetail: "",
+  failureLabel: "ops/kb-template-broken",
+};
+
+/**
+ * Assert the DOCUMENTED success shape of a `GET /repos/{owner}/{repo}` body for
+ * the kb-template: an object carrying `is_template === true` AND
+ * `private === false`.
+ *
+ * Pure + total — never throws, never does I/O. Exported so the dry-run test can
+ * exercise it directly against the canonical synthesized repo-metadata fixture,
+ * proving the probe asserts the documented shape (not merely HTTP 200).
+ *
+ * Routing:
+ *   - non-object body / missing is_template|private field → `ci/guard-broken`
+ *     (the probe could not even read the documented shape).
+ *   - is_template !== true OR private !== false → `ops/kb-template-broken`
+ *     (the shape was readable and the template drifted — user-impacting).
+ */
+export function assertKbTemplateHealthy(data: unknown): KbTemplateVerdict {
+  if (!data || typeof data !== "object") {
+    return {
+      ok: false,
+      failureMode: "response_not_object",
+      failureDetail: "GET /repos returned a non-object body",
+      failureLabel: "ci/guard-broken",
+    };
+  }
+  const body = data as Record<string, unknown>;
+  if (typeof body.is_template !== "boolean" || typeof body.private !== "boolean") {
+    return {
+      ok: false,
+      failureMode: "response_missing_fields",
+      failureDetail:
+        "GET /repos response missing boolean is_template or private field",
+      failureLabel: "ci/guard-broken",
+    };
+  }
+  if (body.is_template !== true) {
+    return {
+      ok: false,
+      failureMode: "is_template_dropped",
+      failureDetail: `${KB_TEMPLATE_OWNER}/${KB_TEMPLATE_NAME} is no longer marked as a template (is_template=false); cross-account /generate returns 404 for every user`,
+      failureLabel: "ops/kb-template-broken",
+    };
+  }
+  if (body.private !== false) {
+    return {
+      ok: false,
+      failureMode: "template_private",
+      failureDetail: `${KB_TEMPLATE_OWNER}/${KB_TEMPLATE_NAME} was made private; cross-account /generate from user-installation tokens returns 404 for every user`,
+      failureLabel: "ops/kb-template-broken",
+    };
+  }
+  return PASS_VERDICT;
+}
+
+// =============================================================================
+// Probe — GET /repos/{owner}/{repo} + documented-shape assertion
+// =============================================================================
+
+async function probeKbTemplate(args: {
+  octokit: Octokit;
+}): Promise<KbTemplateVerdict> {
+  const { octokit } = args;
+  let data: unknown;
+  try {
+    const res = await octokit.request("GET /repos/{owner}/{repo}", {
+      owner: KB_TEMPLATE_OWNER,
+      repo: KB_TEMPLATE_NAME,
+    });
+    data = res.data;
+  } catch (err) {
+    const e = err as Error & { status?: number };
+    if (e.status === 404) {
+      return {
+        ok: false,
+        failureMode: "repo_not_found",
+        failureDetail: `GET /repos/${KB_TEMPLATE_OWNER}/${KB_TEMPLATE_NAME} -> 404. Template deleted, renamed, or made private — every user "Create Project" returns 404/422.`,
+        failureLabel: "ops/kb-template-broken",
+      };
+    }
+    if (typeof e.status === "number") {
+      return {
+        ok: false,
+        failureMode: "github_api_http",
+        failureDetail: `GET /repos/${KB_TEMPLATE_OWNER}/${KB_TEMPLATE_NAME} -> HTTP ${e.status}`,
+        failureLabel: "ci/guard-broken",
+      };
+    }
+    return {
+      ok: false,
+      failureMode: "github_api_network",
+      failureDetail: `GET /repos/${KB_TEMPLATE_OWNER}/${KB_TEMPLATE_NAME} -> network error: ${e.name}: ${e.message ?? ""}`,
+      failureLabel: "ci/guard-broken",
+    };
+  }
+  return assertKbTemplateHealthy(data);
+}
+
+// =============================================================================
+// Issue body builder + filing (co-located mirror of the sibling's shape)
+// =============================================================================
+
+function buildFailureIssueBody(args: {
+  verdict: KbTemplateVerdict;
+  detectedAtIso: string;
+}): string {
+  return [
+    "## kb-template health probe failed",
+    "",
+    `- **Failure mode:** \`${args.verdict.failureMode}\``,
+    `- **Detail:** ${args.verdict.failureDetail}`,
+    `- **Routed to:** \`${args.verdict.failureLabel}\``,
+    `- **Detected at:** ${args.detectedAtIso}`,
+    `- **Probed:** \`GET /repos/${KB_TEMPLATE_OWNER}/${KB_TEMPLATE_NAME}\``,
+    "",
+    "### What to do",
+    "",
+    `See [kb-template-health.md runbook](${RUNBOOK_URL}).`,
+    "",
+    "**Tracks:** #3413",
+    "",
+  ].join("\n");
+}
+
+async function handleKbTemplateIssue(args: {
+  octokit: Octokit;
+  verdict: KbTemplateVerdict;
+  detectedAtIso: string;
+}): Promise<void> {
+  const { octokit, verdict } = args;
+  const owner = PROBE_ISSUE_OWNER;
+  const repo = PROBE_ISSUE_REPO;
+
+  // Failure path: dedup-search → comment-or-open.
+  if (!verdict.ok) {
+    const title =
+      verdict.failureLabel === "ci/guard-broken"
+        ? ISSUE_TITLE_GUARD_BROKEN
+        : ISSUE_TITLE_DRIFT;
+    const body = buildFailureIssueBody({
+      verdict,
+      detectedAtIso: args.detectedAtIso,
+    });
+    // Pre-emission leak scan — guards the failureDetail field from carrying a
+    // PEM/JWT shape echoed out of an upstream error into the issue body.
+    assertNoLeak("issue-body", body);
+
+    const search = await octokit.request("GET /search/issues", {
+      q: `repo:${owner}/${repo} is:issue is:open label:"${verdict.failureLabel}" in:title "${ISSUE_TITLE_PHRASE}"`,
+      per_page: 1,
+    });
+    const existing = (search.data.items ?? [])[0];
+    if (existing) {
+      const commentBody = `kb-template probe failed again at ${args.detectedAtIso} — \`${verdict.failureMode}\`: ${verdict.failureDetail}.`;
+      assertNoLeak("issue-comment", commentBody);
+      await octokit.request(
+        "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+        { owner, repo, issue_number: existing.number, body: commentBody },
+      );
+      return;
+    }
+    await octokit.request("POST /repos/{owner}/{repo}/issues", {
+      owner,
+      repo,
+      title,
+      labels: ["priority/p1-high", verdict.failureLabel],
+      body,
+    });
+    return;
+  }
+
+  // Success path: auto-close any open issue across both label families
+  // (records last-success by closing).
+  for (const label of [
+    "ops/kb-template-broken",
+    "ci/guard-broken",
+  ] as const) {
+    const search = await octokit.request("GET /search/issues", {
+      q: `repo:${owner}/${repo} is:issue is:open label:"${label}" in:title "${ISSUE_TITLE_PHRASE}"`,
+      per_page: 1,
+    });
+    const stale = (search.data.items ?? [])[0];
+    if (!stale) continue;
+    await octokit.request(
+      "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+      {
+        owner,
+        repo,
+        issue_number: stale.number,
+        body: `kb-template probe green at ${args.detectedAtIso}. is_template===true && private===false. Auto-closing.`,
+      },
+    );
+    await octokit.request("PATCH /repos/{owner}/{repo}/issues/{issue_number}", {
+      owner,
+      repo,
+      issue_number: stale.number,
+      state: "closed",
+    });
+  }
+}
+
+// =============================================================================
+// Handler entry point
+// =============================================================================
+
+export async function cronKbTemplateHealthHandler({
+  step,
+  logger,
+}: HandlerArgs): Promise<{
+  failureMode: string;
+  failureLabel: KbTemplateFailureLabel;
+}> {
+  // Step 1: probe — installation-scoped Octokit (no PAT) reads the template
+  // metadata and asserts the documented success shape.
+  let verdict: KbTemplateVerdict = PASS_VERDICT;
+  try {
+    verdict = await step.run("kb-template-probe", async () => {
+      const octokit = await createProbeOctokit();
+      return probeKbTemplate({ octokit: octokit as unknown as Octokit });
+    });
+  } catch (err) {
+    const e = err as Error;
+    reportSilentFallback(e, {
+      feature: CRON_NAME,
+      op: "probeKbTemplate",
+      message: "kb-template probe threw — converting to github_api_network",
+      extra: { fn: CRON_NAME },
+    });
+    verdict = {
+      ok: false,
+      failureMode: "github_api_network",
+      failureDetail: `probeKbTemplate threw: ${e.name}: ${e.message}`,
+      failureLabel: "ci/guard-broken",
+    };
+  }
+
+  // Probe failures mirror to Sentry (cq-silent-fallback-must-mirror-to-sentry).
+  if (!verdict.ok) {
+    reportSilentFallback(
+      new Error(`${verdict.failureMode}: ${verdict.failureDetail}`),
+      {
+        feature: CRON_NAME,
+        op: "kb-template-drift",
+        message: "kb-template health probe detected a failure",
+        extra: {
+          fn: CRON_NAME,
+          failureMode: verdict.failureMode,
+          failureLabel: verdict.failureLabel,
+        },
+      },
+    );
+  }
+
+  const detectedAtIso = new Date().toISOString();
+
+  // Step 2: issue-handling — file/comment on failure, auto-close on success.
+  await step.run("issue-handling", async () => {
+    try {
+      const octokit = await createProbeOctokit();
+      await handleKbTemplateIssue({
+        octokit: octokit as unknown as Octokit,
+        verdict,
+        detectedAtIso,
+      });
+    } catch (err) {
+      const op =
+        (err as { status?: number }).status === 403
+          ? "issue_write_403"
+          : "handleKbTemplateIssue";
+      reportSilentFallback(err, {
+        feature: CRON_NAME,
+        op,
+        message: "kb-template tracking-issue file/comment/close failed",
+        extra: {
+          fn: CRON_NAME,
+          failureMode: verdict.failureMode,
+        },
+      });
+    }
+  });
+
+  // Step 3: sentry-heartbeat — single end-of-job POST.
+  await step.run("sentry-heartbeat", async () => {
+    await postSentryHeartbeat({
+      ok: verdict.ok,
+      sentryMonitorSlug: SENTRY_MONITOR_SLUG,
+      cronName: CRON_NAME,
+      logger,
+    });
+  });
+
+  void RUN_URL;
+  return { failureMode: verdict.failureMode, failureLabel: verdict.failureLabel };
+}
+
+// =============================================================================
+// Registration
+// =============================================================================
+
+export const cronKbTemplateHealth = inngest.createFunction(
+  {
+    id: "cron-kb-template-health",
+    concurrency: [
+      { scope: "fn", limit: 1 },
+      { scope: "account", key: '"cron-platform"', limit: 1 },
+    ],
+    retries: 1,
+  },
+  [
+    { cron: "0 * * * *" },
+    { event: "cron/kb-template-health.manual-trigger" },
+  ],
+  cronKbTemplateHealthHandler as unknown as Parameters<
+    typeof inngest.createFunction
+  >[2],
+);

--- a/apps/web-platform/server/inngest/functions/cron-kb-template-health.ts
+++ b/apps/web-platform/server/inngest/functions/cron-kb-template-health.ts
@@ -42,7 +42,7 @@ import { inngest } from "@/server/inngest/client";
 import { reportSilentFallback } from "@/server/observability";
 import { createProbeOctokit, PROBE_ISSUE_OWNER, PROBE_ISSUE_REPO } from "@/server/github/probe-octokit";
 import { KB_TEMPLATE_NAME, KB_TEMPLATE_OWNER } from "@/server/github-app";
-import { assertNoLeak } from "./cron-github-app-drift-guard";
+import { assertNoLeak, redactedError } from "./cron-github-app-drift-guard";
 import { postSentryHeartbeat, type HandlerArgs } from "./_cron-shared";
 
 const SENTRY_MONITOR_SLUG = "cron-kb-template-health";
@@ -178,6 +178,18 @@ async function probeKbTemplate(args: {
   return assertKbTemplateHealthy(data);
 }
 
+// A TRANSIENT probe failure is a non-404 HTTP error (5xx, 429 rate-limit) or a
+// network blip — NOT a real deletion (404 → repo_not_found) and NOT a drift
+// verdict (is_template/private). The sibling retries-once on a transient
+// github_app_401 so a single GitHub blip auto-resolves before paging P1.
+function isTransientProbeFailure(verdict: KbTemplateVerdict): boolean {
+  return (
+    !verdict.ok &&
+    (verdict.failureMode === "github_api_http" ||
+      verdict.failureMode === "github_api_network")
+  );
+}
+
 // =============================================================================
 // Issue body builder + filing (co-located mirror of the sibling's shape)
 // =============================================================================
@@ -193,6 +205,7 @@ function buildFailureIssueBody(args: {
     `- **Detail:** ${args.verdict.failureDetail}`,
     `- **Routed to:** \`${args.verdict.failureLabel}\``,
     `- **Detected at:** ${args.detectedAtIso}`,
+    `- **Run log:** ${RUN_URL}`,
     `- **Probed:** \`GET /repos/${KB_TEMPLATE_OWNER}/${KB_TEMPLATE_NAME}\``,
     "",
     "### What to do",
@@ -263,13 +276,18 @@ async function handleKbTemplateIssue(args: {
     });
     const stale = (search.data.items ?? [])[0];
     if (!stale) continue;
+    const successBody = `kb-template probe green at ${args.detectedAtIso}. is_template===true && private===false. Auto-closing.`;
+    // Defense-in-depth: this body is provably leak-free today (static template
+    // + ISO timestamp), but route it through the tripwire for symmetry so a
+    // future edit that interpolates captured data cannot silently bypass it.
+    assertNoLeak("issue-comment-success", successBody);
     await octokit.request(
       "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
       {
         owner,
         repo,
         issue_number: stale.number,
-        body: `kb-template probe green at ${args.detectedAtIso}. is_template===true && private===false. Auto-closing.`,
+        body: successBody,
       },
     );
     await octokit.request("PATCH /repos/{owner}/{repo}/issues/{issue_number}", {
@@ -298,11 +316,28 @@ export async function cronKbTemplateHealthHandler({
   try {
     verdict = await step.run("kb-template-probe", async () => {
       const octokit = await createProbeOctokit();
-      return probeKbTemplate({ octokit: octokit as unknown as Octokit });
+      const firstVerdict = await probeKbTemplate({
+        octokit: octokit as unknown as Octokit,
+      });
+      // Transient HTTP/network blip (5xx, 429, network — NOT a 404 and NOT a
+      // drift verdict): retry ONCE after 1s so a single GitHub blip self-heals
+      // before filing a P1-high page. A real 404 deletion and an is_template/
+      // private drift verdict still file immediately (no retry — those are real).
+      if (!isTransientProbeFailure(firstVerdict)) return firstVerdict;
+      logger.warn(
+        { fn: CRON_NAME },
+        `${firstVerdict.failureMode} on kb-template-probe — retrying once after 1s`,
+      );
+      await new Promise((r) => setTimeout(r, 1_000));
+      const retryOctokit = await createProbeOctokit();
+      return probeKbTemplate({ octokit: retryOctokit as unknown as Octokit });
     });
   } catch (err) {
-    const e = err as Error;
-    reportSilentFallback(e, {
+    // Redact upstream error BEFORE it reaches Sentry OR the failureDetail field
+    // (which is re-emitted to Sentry below). Mirror of the sibling's defensive
+    // ban on raw .message forwarding to the observability pipe.
+    const safe = redactedError(err);
+    reportSilentFallback(safe, {
       feature: CRON_NAME,
       op: "probeKbTemplate",
       message: "kb-template probe threw — converting to github_api_network",
@@ -311,15 +346,18 @@ export async function cronKbTemplateHealthHandler({
     verdict = {
       ok: false,
       failureMode: "github_api_network",
-      failureDetail: `probeKbTemplate threw: ${e.name}: ${e.message}`,
+      failureDetail: `probeKbTemplate threw: ${safe.name}: ${safe.message}`,
       failureLabel: "ci/guard-broken",
     };
   }
 
   // Probe failures mirror to Sentry (cq-silent-fallback-must-mirror-to-sentry).
   if (!verdict.ok) {
+    // failureDetail can carry a raw upstream error message (probe network-error
+    // branch interpolates e.message). Redact before it reaches Sentry — the
+    // issue-body path is assertNoLeak-gated, but this Sentry path is not.
     reportSilentFallback(
-      new Error(`${verdict.failureMode}: ${verdict.failureDetail}`),
+      redactedError(new Error(`${verdict.failureMode}: ${verdict.failureDetail}`)),
       {
         feature: CRON_NAME,
         op: "kb-template-drift",
@@ -345,11 +383,14 @@ export async function cronKbTemplateHealthHandler({
         detectedAtIso,
       });
     } catch (err) {
+      // Read `.status` off the ORIGINAL error BEFORE redactedError(err) —
+      // redactedError returns a fresh Error WITHOUT `.status` when the message
+      // matches the leak regex, which would silently defeat this discriminator.
       const op =
         (err as { status?: number }).status === 403
           ? "issue_write_403"
           : "handleKbTemplateIssue";
-      reportSilentFallback(err, {
+      reportSilentFallback(redactedError(err), {
         feature: CRON_NAME,
         op,
         message: "kb-template tracking-issue file/comment/close failed",
@@ -371,7 +412,6 @@ export async function cronKbTemplateHealthHandler({
     });
   });
 
-  void RUN_URL;
   return { failureMode: verdict.failureMode, failureLabel: verdict.failureLabel };
 }
 

--- a/apps/web-platform/test/fixtures/github/error-403.json
+++ b/apps/web-platform/test/fixtures/github/error-403.json
@@ -1,0 +1,4 @@
+{
+  "message": "Resource not accessible by integration",
+  "documentation_url": "https://docs.github.com/rest"
+}

--- a/apps/web-platform/test/fixtures/github/error-404.json
+++ b/apps/web-platform/test/fixtures/github/error-404.json
@@ -1,0 +1,4 @@
+{
+  "message": "Not Found",
+  "documentation_url": "https://docs.github.com/rest"
+}

--- a/apps/web-platform/test/fixtures/github/error-422-duplicate.json
+++ b/apps/web-platform/test/fixtures/github/error-422-duplicate.json
@@ -1,0 +1,12 @@
+{
+  "message": "Validation Failed",
+  "errors": [
+    {
+      "resource": "Repository",
+      "code": "custom",
+      "field": "name",
+      "message": "name already exists on this account"
+    }
+  ],
+  "documentation_url": "https://docs.github.com/rest"
+}

--- a/apps/web-platform/test/fixtures/github/error-422-not-template.json
+++ b/apps/web-platform/test/fixtures/github/error-422-not-template.json
@@ -1,0 +1,11 @@
+{
+  "message": "Validation Failed",
+  "errors": [
+    {
+      "resource": "Repository",
+      "code": "custom",
+      "message": "is not a template repository"
+    }
+  ],
+  "documentation_url": "https://docs.github.com/rest"
+}

--- a/apps/web-platform/test/fixtures/github/installation-200.json
+++ b/apps/web-platform/test/fixtures/github/installation-200.json
@@ -1,0 +1,8 @@
+{
+  "id": 42,
+  "account": {
+    "login": "synthetic-user",
+    "id": 1002,
+    "type": "User"
+  }
+}

--- a/apps/web-platform/test/fixtures/github/installation-access-token.json
+++ b/apps/web-platform/test/fixtures/github/installation-access-token.json
@@ -1,0 +1,10 @@
+{
+  "token": "ghs_<<synthetic>>",
+  "expires_at": "2099-01-01T01:00:00Z",
+  "repository_selection": "selected",
+  "permissions": {
+    "issues": "write",
+    "contents": "read",
+    "metadata": "read"
+  }
+}

--- a/apps/web-platform/test/fixtures/github/installation-account-org.json
+++ b/apps/web-platform/test/fixtures/github/installation-account-org.json
@@ -1,0 +1,7 @@
+{
+  "account": {
+    "login": "synthetic-org",
+    "id": 1001,
+    "type": "Organization"
+  }
+}

--- a/apps/web-platform/test/fixtures/github/installation-account-user.json
+++ b/apps/web-platform/test/fixtures/github/installation-account-user.json
@@ -1,0 +1,7 @@
+{
+  "account": {
+    "login": "synthetic-user",
+    "id": 1002,
+    "type": "User"
+  }
+}

--- a/apps/web-platform/test/fixtures/github/installations-list.json
+++ b/apps/web-platform/test/fixtures/github/installations-list.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": 4001,
+    "account": {
+      "login": "synthetic-user",
+      "id": 1002,
+      "type": "User"
+    }
+  },
+  {
+    "id": 4002,
+    "account": {
+      "login": "synthetic-org",
+      "id": 1001,
+      "type": "Organization"
+    }
+  }
+]

--- a/apps/web-platform/test/fixtures/github/issue-201.json
+++ b/apps/web-platform/test/fixtures/github/issue-201.json
@@ -1,0 +1,7 @@
+{
+  "number": 7,
+  "html_url": "https://github.com/synthetic-user/synthetic-repo/issues/7",
+  "url": "https://api.github.com/repos/synthetic-user/synthetic-repo/issues/7",
+  "title": "Synthetic issue title",
+  "state": "open"
+}

--- a/apps/web-platform/test/fixtures/github/load.ts
+++ b/apps/web-platform/test/fixtures/github/load.ts
@@ -1,0 +1,55 @@
+/**
+ * Single read path for synthesized GitHub REST API response-body fixtures
+ * (#3415). Tests import `loadGithubFixture(name)` instead of inlining JSON
+ * literals or calling `readFileSync` directly, so the mock bodies match
+ * GitHub's public response shapes and never drift into prod-shaped data
+ * (cq-test-fixtures-synthesized-only).
+ *
+ * Only the response BODY lives here. The vitest mock wrapper (`ok`/`status`)
+ * stays inline at each call site — it is mock mechanics, not API data.
+ *
+ * Fixtures are SYNTHESIZED: `@example.com`/`@test.local`-class identifiers,
+ * small synthetic integer IDs, no prod UUIDs, and token fields use the
+ * obvious `ghs_<<synthetic>>` placeholder (the `<<>>` shape is non-alphanumeric
+ * so GitHub push-protection cannot mistake it for a real token).
+ */
+import { readFileSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const FIXTURE_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * The synthesized fixture names available under `test/fixtures/github/`.
+ * Keep in sync with the `.json` files in this directory.
+ */
+export type GithubFixtureName =
+  | "installation-account-org"
+  | "installation-account-user"
+  | "installation-access-token"
+  | "installation-200"
+  | "installations-list"
+  | "repo-create-201"
+  | "template-generate-201"
+  | "repo-metadata-200"
+  | "pull-request-201"
+  | "issue-201"
+  | "error-403"
+  | "error-404"
+  | "error-422-duplicate"
+  | "error-422-not-template";
+
+/**
+ * Read + parse a synthesized GitHub API fixture by name. Returns a fresh
+ * (deeply independent) object on every call so a test mutating a fixture body
+ * never bleeds into another test.
+ *
+ * @typeParam T - the expected parsed shape (caller-supplied; fixtures are JSON
+ *   so this is an unchecked cast, matching `import`-of-JSON ergonomics).
+ */
+export function loadGithubFixture<T = Record<string, unknown>>(
+  name: GithubFixtureName,
+): T {
+  const raw = readFileSync(path.join(FIXTURE_DIR, `${name}.json`), "utf8");
+  return JSON.parse(raw) as T;
+}

--- a/apps/web-platform/test/fixtures/github/pull-request-201.json
+++ b/apps/web-platform/test/fixtures/github/pull-request-201.json
@@ -1,0 +1,7 @@
+{
+  "number": 42,
+  "html_url": "https://github.com/synthetic-user/synthetic-repo/pull/42",
+  "url": "https://api.github.com/repos/synthetic-user/synthetic-repo/pulls/42",
+  "title": "feat: synthetic pull request",
+  "state": "open"
+}

--- a/apps/web-platform/test/fixtures/github/repo-create-201.json
+++ b/apps/web-platform/test/fixtures/github/repo-create-201.json
@@ -1,0 +1,17 @@
+{
+  "id": 2001,
+  "name": "synthetic-repo",
+  "full_name": "synthetic-org/synthetic-repo",
+  "private": true,
+  "owner": {
+    "login": "synthetic-org",
+    "id": 1001,
+    "type": "Organization"
+  },
+  "html_url": "https://github.com/synthetic-org/synthetic-repo",
+  "description": "Knowledge base managed by Soleur",
+  "language": null,
+  "default_branch": "main",
+  "is_template": false,
+  "updated_at": "2099-01-01T00:00:00Z"
+}

--- a/apps/web-platform/test/fixtures/github/repo-metadata-200.json
+++ b/apps/web-platform/test/fixtures/github/repo-metadata-200.json
@@ -1,0 +1,17 @@
+{
+  "id": 2000,
+  "name": "kb-template",
+  "full_name": "synthetic-org/kb-template",
+  "private": false,
+  "owner": {
+    "login": "synthetic-org",
+    "id": 1001,
+    "type": "Organization"
+  },
+  "html_url": "https://github.com/synthetic-org/kb-template",
+  "description": "Synthetic canonical GET /repos/{owner}/{repo} 200 — template, public",
+  "default_branch": "main",
+  "is_template": true,
+  "visibility": "public",
+  "updated_at": "2099-01-01T00:00:00Z"
+}

--- a/apps/web-platform/test/fixtures/github/template-generate-201.json
+++ b/apps/web-platform/test/fixtures/github/template-generate-201.json
@@ -1,0 +1,17 @@
+{
+  "id": 2002,
+  "name": "synthetic-repo",
+  "full_name": "synthetic-user/synthetic-repo",
+  "private": true,
+  "owner": {
+    "login": "synthetic-user",
+    "id": 1002,
+    "type": "User"
+  },
+  "html_url": "https://github.com/synthetic-user/synthetic-repo",
+  "description": "Knowledge base managed by Soleur",
+  "language": null,
+  "default_branch": "main",
+  "is_template": false,
+  "updated_at": "2099-01-01T00:00:00Z"
+}

--- a/apps/web-platform/test/github-app-create-repo.test.ts
+++ b/apps/web-platform/test/github-app-create-repo.test.ts
@@ -33,6 +33,7 @@ import {
   KB_TEMPLATE_NAME,
   KB_TEMPLATE_OWNER,
 } from "../server/github-app";
+import { loadGithubFixture } from "./fixtures/github/load";
 
 // Resolve a fetch call by URL substring rather than positional index, so
 // inserting a preflight call (cache miss, retry, etc.) won't silently shift
@@ -65,17 +66,27 @@ describe("createRepo", () => {
     id: number;
     type: string;
   }) {
+    // Body shape sourced from the synthesized installation fixture; the test's
+    // account fields override the canonical synthetic ones (the per-test
+    // login/id/type are load-bearing for routing assertions).
+    const base =
+      account.type === "Organization"
+        ? loadGithubFixture<{ account: object }>("installation-account-org")
+        : loadGithubFixture<{ account: object }>("installation-account-user");
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account }),
+      json: async () => ({ ...base, account }),
     });
   }
 
   function mockTokenResponse() {
+    const body = loadGithubFixture<{ token: string; expires_at: string }>(
+      "installation-access-token",
+    );
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        token: "ghs_test_token",
+        ...body,
         expires_at: new Date(Date.now() + 3600_000).toISOString(),
       }),
     });
@@ -99,12 +110,10 @@ describe("createRepo", () => {
       ok: true,
       status: 201,
       json: async () => ({
+        ...loadGithubFixture("repo-create-201"),
         name: "new-repo",
         full_name: "my-org/new-repo",
         private: true,
-        description: "Knowledge base managed by Soleur",
-        language: null,
-        updated_at: new Date().toISOString(),
         html_url: "https://github.com/my-org/new-repo",
       }),
     });
@@ -139,12 +148,10 @@ describe("createRepo", () => {
       ok: true,
       status: 201,
       json: async () => ({
+        ...loadGithubFixture("template-generate-201"),
         name: "my-repo",
         full_name: "alice/my-repo",
         private: true,
-        description: "Knowledge base managed by Soleur",
-        language: null,
-        updated_at: new Date().toISOString(),
         html_url: "https://github.com/alice/my-repo",
       }),
     });
@@ -188,12 +195,10 @@ describe("createRepo", () => {
       ok: true,
       status: 201,
       json: async () => ({
+        ...loadGithubFixture("template-generate-201"),
         name: "public-repo",
         full_name: "bob/public-repo",
         private: false,
-        description: "Knowledge base managed by Soleur",
-        language: null,
-        updated_at: new Date().toISOString(),
         html_url: "https://github.com/bob/public-repo",
       }),
     });
@@ -247,10 +252,7 @@ describe("createRepo", () => {
       ok: false,
       status: 422,
       text: async () =>
-        JSON.stringify({
-          message: "Validation Failed",
-          errors: [{ message: "is not a template repository" }],
-        }),
+        JSON.stringify(loadGithubFixture("error-422-not-template")),
     });
 
     await expect(
@@ -275,7 +277,7 @@ describe("createRepo", () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 404,
-      text: async () => JSON.stringify({ message: "Not Found" }),
+      text: async () => JSON.stringify(loadGithubFixture("error-404")),
     });
 
     await expect(
@@ -304,11 +306,7 @@ describe("createRepo", () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 422,
-      text: async () =>
-        JSON.stringify({
-          message: "Validation Failed",
-          errors: [{ message: "name already exists on this account" }],
-        }),
+      text: async () => JSON.stringify(loadGithubFixture("error-422-duplicate")),
     });
 
     await expect(
@@ -340,10 +338,7 @@ describe("createRepo", () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 403,
-      text: async () =>
-        JSON.stringify({
-          message: "Resource not accessible by integration",
-        }),
+      text: async () => JSON.stringify(loadGithubFixture("error-403")),
     });
 
     await expect(
@@ -362,7 +357,7 @@ describe("createRepo", () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 404,
-      json: async () => ({ message: "Not Found" }),
+      json: async () => loadGithubFixture("error-404"),
     });
 
     await expect(
@@ -388,6 +383,7 @@ describe("getInstallationAccount", () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
+        ...loadGithubFixture<{ account: object }>("installation-account-org"),
         account: { login: "my-org", id: 42, type: "Organization" },
       }),
     });
@@ -414,7 +410,7 @@ describe("getInstallationAccount", () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 404,
-      json: async () => ({ message: "Not Found" }),
+      json: async () => loadGithubFixture("error-404"),
     });
 
     await expect(

--- a/apps/web-platform/test/github-app-default-branch-commit.test.ts
+++ b/apps/web-platform/test/github-app-default-branch-commit.test.ts
@@ -40,6 +40,7 @@ vi.mock("../server/logger", () => ({
 }));
 
 import { getDefaultBranchHeadCommitAt } from "../server/github-app";
+import { loadGithubFixture } from "./fixtures/github/load";
 
 // Unique installation ids so the per-id token cache never short-circuits the
 // token-mint fetch between tests.
@@ -47,11 +48,14 @@ let nextId = 70_000;
 const uid = () => nextId++;
 
 function tokenSuccess() {
+  const body = loadGithubFixture<{ token: string; expires_at: string }>(
+    "installation-access-token",
+  );
   return {
     ok: true,
     status: 200,
     json: async () => ({
-      token: "ghs_dbc_test_token",
+      ...body,
       expires_at: new Date(Date.now() + 3_600_000).toISOString(),
     }),
     text: async () => "",

--- a/apps/web-platform/test/github-app-find-installation-by-account.test.ts
+++ b/apps/web-platform/test/github-app-find-installation-by-account.test.ts
@@ -39,17 +39,25 @@ vi.mock("../server/observability", () => ({
 }));
 
 import { findInstallationByAccountLogin } from "../server/github-app";
+import { loadGithubFixture } from "./fixtures/github/load";
 
-// Mirrors the prod reproduce-harness output: a personal (User) install and the
-// repo-owning org install, both reachable.
+// Synthesized installations-list body (cq-test-fixtures-synthesized-only):
+// a personal (User) install and the repo-owning org install, both reachable —
+// the same dual-reachability shape the prod reproduce-harness exposed, with
+// synthetic logins/IDs. The list's two entries are the load-bearing data; the
+// `id` of each is what the selection logic returns.
+const INSTALLATIONS =
+  loadGithubFixture<{ id: number; account: { login: string; type: string } }[]>(
+    "installations-list",
+  );
+const PERSONAL = INSTALLATIONS.find((i) => i.account.type === "User")!;
+const ORG = INSTALLATIONS.find((i) => i.account.type === "Organization")!;
+
 function mockInstallationsList() {
   mockFetch.mockResolvedValueOnce({
     ok: true,
     status: 200,
-    json: async () => [
-      { id: 130018654, account: { login: "Elvalio", type: "User" } },
-      { id: 122213433, account: { login: "jikig-ai", type: "Organization" } },
-    ],
+    json: async () => loadGithubFixture("installations-list"),
   });
 }
 
@@ -58,22 +66,24 @@ describe("findInstallationByAccountLogin", () => {
     mockFetch.mockReset();
   });
 
-  test("returns the org install (122213433) for the repo owner 'jikig-ai'", async () => {
+  test(`returns the org install (${ORG.id}) for the repo owner '${ORG.account.login}'`, async () => {
     mockInstallationsList();
-    const result = await findInstallationByAccountLogin("jikig-ai");
-    expect(result).toBe(122213433);
+    const result = await findInstallationByAccountLogin(ORG.account.login);
+    expect(result).toBe(ORG.id);
   });
 
   test("matches account login case-insensitively", async () => {
     mockInstallationsList();
-    const result = await findInstallationByAccountLogin("JIKIG-AI");
-    expect(result).toBe(122213433);
+    const result = await findInstallationByAccountLogin(
+      ORG.account.login.toUpperCase(),
+    );
+    expect(result).toBe(ORG.id);
   });
 
   test("returns the personal install when the owner is the personal account", async () => {
     mockInstallationsList();
-    const result = await findInstallationByAccountLogin("Elvalio");
-    expect(result).toBe(130018654);
+    const result = await findInstallationByAccountLogin(PERSONAL.account.login);
+    expect(result).toBe(PERSONAL.id);
   });
 
   test("returns null when no installation account matches the owner", async () => {
@@ -88,7 +98,7 @@ describe("findInstallationByAccountLogin", () => {
       status: 401,
       text: async () => JSON.stringify({ message: "Bad credentials" }),
     });
-    const result = await findInstallationByAccountLogin("jikig-ai");
+    const result = await findInstallationByAccountLogin(ORG.account.login);
     expect(result).toBeNull();
   });
 });

--- a/apps/web-platform/test/github-app-find-installation.test.ts
+++ b/apps/web-platform/test/github-app-find-installation.test.ts
@@ -27,6 +27,7 @@ afterAll(() => {
 
 // Import AFTER env and fetch mocking
 import { findInstallationForLogin } from "../server/github-app";
+import { loadGithubFixture } from "./fixtures/github/load";
 
 describe("findInstallationForLogin", () => {
   beforeEach(() => {
@@ -37,7 +38,9 @@ describe("findInstallationForLogin", () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        id: 42,
+        ...loadGithubFixture<{ id: number; account: object }>(
+          "installation-200",
+        ),
         account: { login: "testuser", id: 1, type: "User" },
       }),
     });
@@ -104,7 +107,12 @@ describe("findInstallationForLogin", () => {
     // Installation token exchange for membership check
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ token: "ghs_test_token", expires_at: new Date(Date.now() + 3600000).toISOString() }),
+      json: async () => ({
+        ...loadGithubFixture<{ token: string; expires_at: string }>(
+          "installation-access-token",
+        ),
+        expires_at: new Date(Date.now() + 3600000).toISOString(),
+      }),
     });
     // Membership check: 204 = is a member
     mockFetch.mockResolvedValueOnce({ status: 204 });

--- a/apps/web-platform/test/github-app-mint-observability.test.ts
+++ b/apps/web-platform/test/github-app-mint-observability.test.ts
@@ -50,6 +50,7 @@ vi.mock("../server/logger", () => ({
 }));
 
 import { generateInstallationToken } from "../server/github-app";
+import { loadGithubFixture } from "./fixtures/github/load";
 
 let nextId = 90_000;
 function uniqueId() {
@@ -68,10 +69,10 @@ describe("generateInstallationToken — mint-time observability", () => {
       ok: true,
       status: 200,
       json: async () => ({
+        ...loadGithubFixture("installation-access-token"),
+        // Distinct sentinel value the test asserts is NEVER logged.
         token: "ghs_super_secret_value",
         expires_at: new Date(Date.now() + 3_600_000).toISOString(),
-        repository_selection: "selected",
-        permissions: { issues: "write", contents: "read", metadata: "read" },
       }),
       text: async () => "",
     });

--- a/apps/web-platform/test/github-app-pr.test.ts
+++ b/apps/web-platform/test/github-app-pr.test.ts
@@ -27,6 +27,7 @@ afterAll(() => {
 
 // Import AFTER env and fetch mocking
 import { createPullRequest, createIssue } from "../server/github-app";
+import { loadGithubFixture } from "./fixtures/github/load";
 
 describe("createPullRequest", () => {
   beforeEach(() => {
@@ -40,10 +41,13 @@ describe("createPullRequest", () => {
   }
 
   function mockTokenResponse() {
+    const body = loadGithubFixture<{ token: string; expires_at: string }>(
+      "installation-access-token",
+    );
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        token: "ghs_test_token",
+        ...body,
         expires_at: new Date(Date.now() + 3600_000).toISOString(),
       }),
     });
@@ -56,11 +60,11 @@ describe("createPullRequest", () => {
       ok: true,
       status: 201,
       json: async () => ({
+        ...loadGithubFixture("pull-request-201"),
         number: 42,
         html_url: "https://github.com/alice/my-repo/pull/42",
         url: "https://api.github.com/repos/alice/my-repo/pulls/42",
         title: "feat: new feature",
-        state: "open",
       }),
     });
 
@@ -90,6 +94,7 @@ describe("createPullRequest", () => {
       ok: true,
       status: 201,
       json: async () => ({
+        ...loadGithubFixture("pull-request-201"),
         number: 43,
         html_url: "https://github.com/alice/my-repo/pull/43",
         url: "https://api.github.com/repos/alice/my-repo/pulls/43",
@@ -146,7 +151,7 @@ describe("createPullRequest", () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 404,
-      text: async () => JSON.stringify({ message: "Not Found" }),
+      text: async () => JSON.stringify(loadGithubFixture("error-404")),
     });
 
     await expect(
@@ -194,10 +199,13 @@ describe("createIssue", () => {
   }
 
   function mockTokenResponse() {
+    const body = loadGithubFixture<{ token: string; expires_at: string }>(
+      "installation-access-token",
+    );
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        token: "ghs_test_token",
+        ...body,
         expires_at: new Date(Date.now() + 3600_000).toISOString(),
       }),
     });
@@ -210,11 +218,11 @@ describe("createIssue", () => {
       ok: true,
       status: 201,
       json: async () => ({
+        ...loadGithubFixture("issue-201"),
         number: 7,
         html_url: "https://github.com/alice/my-repo/issues/7",
         url: "https://api.github.com/repos/alice/my-repo/issues/7",
         title: "Something broke",
-        state: "open",
       }),
     });
 
@@ -243,6 +251,7 @@ describe("createIssue", () => {
       ok: true,
       status: 201,
       json: async () => ({
+        ...loadGithubFixture("issue-201"),
         number: 8,
         html_url: "https://github.com/alice/my-repo/issues/8",
         url: "https://api.github.com/repos/alice/my-repo/issues/8",
@@ -267,7 +276,7 @@ describe("createIssue", () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 404,
-      text: async () => JSON.stringify({ message: "Not Found" }),
+      text: async () => JSON.stringify(loadGithubFixture("error-404")),
     });
 
     await expect(

--- a/apps/web-platform/test/github-app-repo-owner-installation.test.ts
+++ b/apps/web-platform/test/github-app-repo-owner-installation.test.ts
@@ -36,28 +36,42 @@ afterAll(() => {
 vi.mock("../server/observability", () => ({ reportSilentFallback: vi.fn() }));
 
 import { findRepoOwnerInstallationForUser } from "../server/github-app";
+import { loadGithubFixture } from "./fixtures/github/load";
 
 let nextOwnerId = 700_000;
 function uniqueOwnerId() {
   return nextOwnerId++;
 }
 
+// Synthetic personal (User) install that co-exists with the repo-owning org
+// install in the list (cq-test-fixtures-synthesized-only). The login is read
+// from the synthesized fixture; the org entry is parametric per test.
+const PERSONAL_INSTALL = loadGithubFixture<
+  { id: number; account: { login: string; type: string } }[]
+>("installations-list").find((i) => i.account.type === "User")!;
+
 function mockInstallList(ownerId: number, ownerLogin: string) {
   mockFetch.mockResolvedValueOnce({
     ok: true,
     status: 200,
     json: async () => [
-      { id: 130018654, account: { login: "Elvalio", type: "User" } },
+      {
+        id: PERSONAL_INSTALL.id,
+        account: { login: PERSONAL_INSTALL.account.login, type: "User" },
+      },
       { id: ownerId, account: { login: ownerLogin, type: "Organization" } },
     ],
   });
 }
 function mockTokenMint() {
+  const body = loadGithubFixture<{ token: string; expires_at: string }>(
+    "installation-access-token",
+  );
   mockFetch.mockResolvedValueOnce({
     ok: true,
     status: 200,
     json: async () => ({
-      token: "ghs_owner",
+      ...body,
       expires_at: new Date(Date.now() + 3_600_000).toISOString(),
     }),
     text: async () => "",
@@ -76,10 +90,13 @@ describe("findRepoOwnerInstallationForUser — entitlement-gated owner selection
 
   test("promotes to org install when the user is a verified org member (204)", async () => {
     const ownerId = uniqueOwnerId();
-    mockInstallList(ownerId, "jikig-ai");
+    mockInstallList(ownerId, "synthetic-org");
     mockTokenMint();
     mockMembership(204);
-    const result = await findRepoOwnerInstallationForUser("jikig-ai", "Elvalio");
+    const result = await findRepoOwnerInstallationForUser(
+      "synthetic-org",
+      PERSONAL_INSTALL.account.login,
+    );
     expect(result).toBe(ownerId);
   });
 
@@ -110,7 +127,7 @@ describe("findRepoOwnerInstallationForUser — entitlement-gated owner selection
   });
 
   test("returns null (degrades) when githubLogin is null", async () => {
-    const result = await findRepoOwnerInstallationForUser("jikig-ai", null);
+    const result = await findRepoOwnerInstallationForUser("synthetic-org", null);
     expect(result).toBeNull();
     // Must not even list installations without a login to gate on.
     expect(mockFetch).not.toHaveBeenCalled();

--- a/apps/web-platform/test/github-app-token-hardening.test.ts
+++ b/apps/web-platform/test/github-app-token-hardening.test.ts
@@ -69,6 +69,7 @@ vi.mock("../server/logger", () => ({
 
 // Import AFTER env and mocking
 import { generateInstallationToken } from "../server/github-app";
+import { loadGithubFixture } from "./fixtures/github/load";
 
 // Unique installation IDs to avoid token cache interference
 let nextId = 50_000;
@@ -81,6 +82,8 @@ function mockTokenSuccess() {
     ok: true,
     status: 200,
     json: async () => ({
+      ...loadGithubFixture("installation-access-token"),
+      // Distinct value the retry/success tests assert is returned verbatim.
       token: "ghs_hardening_test_token",
       expires_at: new Date(Date.now() + 3_600_000).toISOString(),
     }),
@@ -98,14 +101,12 @@ function mock401() {
 }
 
 function mock403() {
+  const body = loadGithubFixture("error-403");
   return {
     ok: false,
     status: 403,
-    text: async () =>
-      JSON.stringify({ message: "Resource not accessible by integration" }),
-    json: async () => ({
-      message: "Resource not accessible by integration",
-    }),
+    text: async () => JSON.stringify(body),
+    json: async () => body,
   };
 }
 

--- a/apps/web-platform/test/server/inngest/cron-kb-template-health.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-kb-template-health.test.ts
@@ -131,7 +131,7 @@ function issueCreates() {
 // ---------------------------------------------------------------------------
 
 describe("cronKbTemplateHealthHandler — happy path", () => {
-  it("is_template:true/private:false → no issue filed, auto-close searched", async () => {
+  it("is_template:true/private:false → no issue filed on green", async () => {
     const { cronKbTemplateHealthHandler } = await importHandler();
     const step = makeStep();
     const out = await cronKbTemplateHealthHandler({ step, logger });
@@ -175,6 +175,11 @@ describe("cronKbTemplateHealthHandler — failure modes", () => {
     expect((creates[0]![1] as { labels: string[] }).labels).toContain(
       "priority/p1-high",
     );
+    // Drift routes through the ops/kb-template-broken label family (proven
+    // through the actual issue-write path, not just the pure predicate).
+    expect((creates[0]![1] as { labels: string[] }).labels).toContain(
+      "ops/kb-template-broken",
+    );
   });
 
   it("private:true → issue filed (template made private)", async () => {
@@ -193,7 +198,14 @@ describe("cronKbTemplateHealthHandler — failure modes", () => {
     const step = makeStep();
     const out = await cronKbTemplateHealthHandler({ step, logger });
     expect(out.failureMode).not.toBe("");
-    expect(issueCreates().length).toBe(1);
+    const creates = issueCreates();
+    expect(creates.length).toBe(1);
+    expect((creates[0]![1] as { labels: string[] }).labels).toContain(
+      "priority/p1-high",
+    );
+    expect((creates[0]![1] as { labels: string[] }).labels).toContain(
+      "ops/kb-template-broken",
+    );
   });
 
   it("404 → issue filed (repo missing/renamed)", async () => {
@@ -288,6 +300,122 @@ describe("cronKbTemplateHealthHandler — auto-close", () => {
     );
     expect(comment).toBeDefined();
     expect((comment![1] as { issue_number: number }).issue_number).toBe(555);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Leak tripwire — a PEM/JWT-shaped error message must fail the issue-body gate
+// CLOSED (LeakDetectedError thrown) before any POST /issues mock is reached.
+// ---------------------------------------------------------------------------
+
+describe("cronKbTemplateHealthHandler — leak tripwire", () => {
+  it("PEM-shaped probe error → assertNoLeak fires before any issue is created", async () => {
+    // A network-error probe whose message carries a PEM block. The handler's
+    // failureDetail interpolates the (redacted) message, but the issue-body
+    // assertNoLeak gate must independently fail closed for any future path
+    // that smuggles a raw PEM/JWT into the body.
+    const pem =
+      "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA\n-----END RSA PRIVATE KEY-----";
+    // Force the leak into the issue body directly by stubbing the search to
+    // return no existing issue (open path → buildFailureIssueBody → assertNoLeak)
+    // and making the probe yield a verdict whose failureDetail carries the PEM.
+    octokitRequestSpy.mockImplementation(async (route: string) => {
+      if (route === "GET /repos/{owner}/{repo}") {
+        const err = new Error(pem) as Error & { status?: number; name: string };
+        err.name = "PemLeakError";
+        // No numeric status → network-error branch; failureDetail = name+message.
+        throw err;
+      }
+      if (route === "GET /search/issues") return { data: { items: [] } };
+      return { data: {} };
+    });
+    const { cronKbTemplateHealthHandler } = await importHandler();
+    const step = makeStep();
+    // Handler swallows the issue-handling error into reportSilentFallback; it
+    // must NOT create an issue, and the Sentry report must NOT carry raw PEM.
+    await cronKbTemplateHealthHandler({ step, logger });
+    expect(issueCreates().length).toBe(0);
+    // Sentry never sees raw PEM bytes (redactedError stripped them).
+    for (const call of reportSilentFallbackSpy.mock.calls) {
+      const err = call[0] as Error;
+      expect(err.message).not.toContain("BEGIN RSA PRIVATE KEY");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transient retry — a single HTTP 500 blip is retried once before filing.
+// ---------------------------------------------------------------------------
+
+describe("cronKbTemplateHealthHandler — transient retry", () => {
+  it("HTTP 500 self-heals on retry → no issue filed", async () => {
+    let probeCallCount = 0;
+    octokitRequestSpy.mockImplementation(async (route: string) => {
+      if (route === "GET /repos/{owner}/{repo}") {
+        probeCallCount++;
+        if (probeCallCount === 1) {
+          const err = new Error("Server error") as Error & { status?: number };
+          err.status = 500;
+          throw err;
+        }
+        return { status: 200, data: healthyRepoResponse, headers: {} };
+      }
+      if (route === "GET /search/issues") return { data: { items: [] } };
+      return { data: {} };
+    });
+    const { cronKbTemplateHealthHandler } = await importHandler();
+    const step = makeStep();
+    const out = await cronKbTemplateHealthHandler({ step, logger });
+    expect(probeCallCount).toBe(2);
+    expect(out.failureMode).toBe("");
+    expect(issueCreates().length).toBe(0);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ fn: "cron-kb-template-health" }),
+      expect.stringContaining("github_api_http"),
+    );
+  });
+
+  it("persistent HTTP 500 retried once → routes to ci/guard-broken", async () => {
+    let probeCallCount = 0;
+    octokitRequestSpy.mockImplementation(async (route: string) => {
+      if (route === "GET /repos/{owner}/{repo}") {
+        probeCallCount++;
+        const err = new Error("Server error") as Error & { status?: number };
+        err.status = 500;
+        throw err;
+      }
+      if (route === "GET /search/issues") return { data: { items: [] } };
+      return { data: {} };
+    });
+    const { cronKbTemplateHealthHandler } = await importHandler();
+    const step = makeStep();
+    const out = await cronKbTemplateHealthHandler({ step, logger });
+    expect(probeCallCount).toBe(2);
+    expect(out.failureLabel).toBe("ci/guard-broken");
+    const creates = issueCreates();
+    expect(creates.length).toBe(1);
+    expect((creates[0]![1] as { labels: string[] }).labels).toContain(
+      "ci/guard-broken",
+    );
+  });
+
+  it("404 deletion files immediately (no retry — a real deletion)", async () => {
+    let probeCallCount = 0;
+    octokitRequestSpy.mockImplementation(async (route: string) => {
+      if (route === "GET /repos/{owner}/{repo}") {
+        probeCallCount++;
+        const err = new Error("Not Found") as Error & { status?: number };
+        err.status = 404;
+        throw err;
+      }
+      if (route === "GET /search/issues") return { data: { items: [] } };
+      return { data: {} };
+    });
+    const { cronKbTemplateHealthHandler } = await importHandler();
+    const step = makeStep();
+    await cronKbTemplateHealthHandler({ step, logger });
+    expect(probeCallCount).toBe(1);
+    expect(issueCreates().length).toBe(1);
   });
 });
 

--- a/apps/web-platform/test/server/inngest/cron-kb-template-health.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-kb-template-health.test.ts
@@ -1,0 +1,354 @@
+// #3413 — cron-kb-template-health handler unit tests.
+//
+// The probe reads kb-template's GET /repos/{owner}/{repo} metadata and asserts
+// the DOCUMENTED success shape (is_template === true AND private === false). On
+// failure it dedup-files a P1 [ops/kb-template-broken] issue against
+// jikig-ai/soleur; on success it auto-closes any open such issue.
+//
+// All fetches/Octokit stubbed — no real network. Mirrors the stub harness of
+// cron-github-app-drift-guard.test.ts (same Octokit-request-spy shape).
+//
+// The dry-run test exercises the EXPORTED pure predicate assertKbTemplateHealthy
+// against the shared synthesized fixture (loadGithubFixture("repo-metadata-200"))
+// to prove the probe asserts the documented shape, not just HTTP 200.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadGithubFixture } from "../../fixtures/github/load";
+
+// --- Module mocks (hoisted by vitest) --------------------------------------
+
+const reportSilentFallbackSpy = vi.fn();
+vi.mock("@/server/observability", () => ({
+  reportSilentFallback: reportSilentFallbackSpy,
+}));
+
+const octokitRequestSpy = vi.fn();
+const createProbeOctokitSpy = vi.fn();
+vi.mock("@/server/github/probe-octokit", () => ({
+  createProbeOctokit: createProbeOctokitSpy,
+  PROBE_ISSUE_OWNER: "jikig-ai",
+  PROBE_ISSUE_REPO: "soleur",
+}));
+
+// KB_TEMPLATE_* are imported by the handler from server/github-app.ts; pin them
+// here so the test does not pull in the whole github-app module surface.
+vi.mock("@/server/github-app", () => ({
+  KB_TEMPLATE_OWNER: "jikig-ai",
+  KB_TEMPLATE_NAME: "kb-template",
+}));
+
+// --- Helpers ---------------------------------------------------------------
+
+interface MockStep {
+  calls: { name: string; result: unknown }[];
+  run<T>(name: string, cb: () => Promise<T>): Promise<T>;
+}
+
+function makeStep(): MockStep {
+  const calls: { name: string; result: unknown }[] = [];
+  return {
+    calls,
+    async run<T>(name: string, cb: () => Promise<T>): Promise<T> {
+      const result = await cb();
+      calls.push({ name, result });
+      return result;
+    },
+  };
+}
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+// Default healthy GET /repos response — template, public.
+const healthyRepoResponse = {
+  id: 2000,
+  full_name: "jikig-ai/kb-template",
+  is_template: true,
+  private: false,
+};
+
+const ORIGINAL_ENV = {
+  GITHUB_APP_ID: process.env.GITHUB_APP_ID,
+  GITHUB_APP_PRIVATE_KEY: process.env.GITHUB_APP_PRIVATE_KEY,
+  INNGEST_SIGNING_KEY: process.env.INNGEST_SIGNING_KEY,
+  INNGEST_EVENT_KEY: process.env.INNGEST_EVENT_KEY,
+  INNGEST_DEV: process.env.INNGEST_DEV,
+};
+
+function restoreEnv(key: keyof typeof ORIGINAL_ENV) {
+  if (ORIGINAL_ENV[key] === undefined) delete process.env[key];
+  else process.env[key] = ORIGINAL_ENV[key];
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  reportSilentFallbackSpy.mockReset();
+  octokitRequestSpy.mockReset();
+  createProbeOctokitSpy.mockReset();
+  createProbeOctokitSpy.mockImplementation(async () => ({
+    request: octokitRequestSpy,
+  }));
+  // Healthy default: GET /repos returns template+public; search returns empty.
+  octokitRequestSpy.mockImplementation(async (route: string) => {
+    if (route === "GET /repos/{owner}/{repo}") {
+      return { status: 200, data: healthyRepoResponse, headers: {} };
+    }
+    if (route === "GET /search/issues") {
+      return { data: { items: [] } };
+    }
+    return { data: {} };
+  });
+  logger.info.mockReset();
+  logger.warn.mockReset();
+  logger.error.mockReset();
+  process.env.GITHUB_APP_ID = "12345";
+  process.env.GITHUB_APP_PRIVATE_KEY =
+    "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----";
+  process.env.INNGEST_SIGNING_KEY =
+    "signkey-test-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  process.env.INNGEST_EVENT_KEY =
+    "evtkey-test-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+  process.env.INNGEST_DEV = "1";
+});
+
+afterEach(() => {
+  (Object.keys(ORIGINAL_ENV) as Array<keyof typeof ORIGINAL_ENV>).forEach(
+    restoreEnv,
+  );
+});
+
+async function importHandler() {
+  return import("@/server/inngest/functions/cron-kb-template-health");
+}
+
+function issueCreates() {
+  return octokitRequestSpy.mock.calls.filter(
+    ([route]) => route === "POST /repos/{owner}/{repo}/issues",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// (a) Happy path — template+public → no issue, auto-close path
+// ---------------------------------------------------------------------------
+
+describe("cronKbTemplateHealthHandler — happy path", () => {
+  it("is_template:true/private:false → no issue filed, auto-close searched", async () => {
+    const { cronKbTemplateHealthHandler } = await importHandler();
+    const step = makeStep();
+    const out = await cronKbTemplateHealthHandler({ step, logger });
+    expect(out.failureMode).toBe("");
+    expect(issueCreates().length).toBe(0);
+    // Probed the right repo.
+    const probe = octokitRequestSpy.mock.calls.find(
+      ([route]) => route === "GET /repos/{owner}/{repo}",
+    );
+    expect(probe).toBeDefined();
+    expect(probe![1]).toMatchObject({ owner: "jikig-ai", repo: "kb-template" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b)-(e) Failure modes
+// ---------------------------------------------------------------------------
+
+describe("cronKbTemplateHealthHandler — failure modes", () => {
+  it("is_template:false → issue filed (template flag dropped)", async () => {
+    octokitRequestSpy.mockImplementation(async (route: string) => {
+      if (route === "GET /repos/{owner}/{repo}") {
+        return {
+          status: 200,
+          data: { ...healthyRepoResponse, is_template: false },
+          headers: {},
+        };
+      }
+      if (route === "GET /search/issues") return { data: { items: [] } };
+      return { data: {} };
+    });
+    const { cronKbTemplateHealthHandler } = await importHandler();
+    const step = makeStep();
+    const out = await cronKbTemplateHealthHandler({ step, logger });
+    expect(out.failureMode).not.toBe("");
+    const creates = issueCreates();
+    expect(creates.length).toBe(1);
+    expect(creates[0]![1]).toMatchObject({
+      title: expect.stringContaining("[ops/kb-template-broken]"),
+    });
+    expect((creates[0]![1] as { labels: string[] }).labels).toContain(
+      "priority/p1-high",
+    );
+  });
+
+  it("private:true → issue filed (template made private)", async () => {
+    octokitRequestSpy.mockImplementation(async (route: string) => {
+      if (route === "GET /repos/{owner}/{repo}") {
+        return {
+          status: 200,
+          data: { ...healthyRepoResponse, private: true },
+          headers: {},
+        };
+      }
+      if (route === "GET /search/issues") return { data: { items: [] } };
+      return { data: {} };
+    });
+    const { cronKbTemplateHealthHandler } = await importHandler();
+    const step = makeStep();
+    const out = await cronKbTemplateHealthHandler({ step, logger });
+    expect(out.failureMode).not.toBe("");
+    expect(issueCreates().length).toBe(1);
+  });
+
+  it("404 → issue filed (repo missing/renamed)", async () => {
+    octokitRequestSpy.mockImplementation(async (route: string) => {
+      if (route === "GET /repos/{owner}/{repo}") {
+        const err = new Error("Not Found") as Error & { status?: number };
+        err.status = 404;
+        throw err;
+      }
+      if (route === "GET /search/issues") return { data: { items: [] } };
+      return { data: {} };
+    });
+    const { cronKbTemplateHealthHandler } = await importHandler();
+    const step = makeStep();
+    const out = await cronKbTemplateHealthHandler({ step, logger });
+    expect(out.failureMode).not.toBe("");
+    expect(issueCreates().length).toBe(1);
+    // 404 reports to Sentry.
+    expect(reportSilentFallbackSpy).toHaveBeenCalled();
+  });
+
+  it("malformed body (missing fields) → guard-broken label, distinct from drift", async () => {
+    octokitRequestSpy.mockImplementation(async (route: string) => {
+      if (route === "GET /repos/{owner}/{repo}") {
+        return { status: 200, data: { id: 2000 }, headers: {} };
+      }
+      if (route === "GET /search/issues") return { data: { items: [] } };
+      return { data: {} };
+    });
+    const { cronKbTemplateHealthHandler } = await importHandler();
+    const step = makeStep();
+    const out = await cronKbTemplateHealthHandler({ step, logger });
+    expect(out.failureLabel).toBe("ci/guard-broken");
+    const creates = issueCreates();
+    expect(creates.length).toBe(1);
+    expect((creates[0]![1] as { labels: string[] }).labels).toContain(
+      "ci/guard-broken",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (f) Success auto-closes a prior open issue
+// ---------------------------------------------------------------------------
+
+describe("cronKbTemplateHealthHandler — auto-close", () => {
+  it("healthy probe closes a prior open [ops/kb-template-broken] issue", async () => {
+    octokitRequestSpy.mockImplementation(async (route: string) => {
+      if (route === "GET /repos/{owner}/{repo}") {
+        return { status: 200, data: healthyRepoResponse, headers: {} };
+      }
+      if (route === "GET /search/issues") {
+        return { data: { items: [{ number: 777 }] } };
+      }
+      return { data: {} };
+    });
+    const { cronKbTemplateHealthHandler } = await importHandler();
+    const step = makeStep();
+    await cronKbTemplateHealthHandler({ step, logger });
+    const closed = octokitRequestSpy.mock.calls.find(
+      ([route, params]) =>
+        route === "PATCH /repos/{owner}/{repo}/issues/{issue_number}" &&
+        (params as { state?: string }).state === "closed",
+    );
+    expect(closed).toBeDefined();
+    expect((closed![1] as { issue_number: number }).issue_number).toBe(777);
+    // No new issue filed on the green path.
+    expect(issueCreates().length).toBe(0);
+  });
+
+  it("dedup: failure with an existing open issue comments instead of re-filing", async () => {
+    octokitRequestSpy.mockImplementation(async (route: string) => {
+      if (route === "GET /repos/{owner}/{repo}") {
+        return {
+          status: 200,
+          data: { ...healthyRepoResponse, is_template: false },
+          headers: {},
+        };
+      }
+      if (route === "GET /search/issues") {
+        return { data: { items: [{ number: 555 }] } };
+      }
+      return { data: {} };
+    });
+    const { cronKbTemplateHealthHandler } = await importHandler();
+    const step = makeStep();
+    await cronKbTemplateHealthHandler({ step, logger });
+    expect(issueCreates().length).toBe(0);
+    const comment = octokitRequestSpy.mock.calls.find(
+      ([route]) =>
+        route === "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+    );
+    expect(comment).toBeDefined();
+    expect((comment![1] as { issue_number: number }).issue_number).toBe(555);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dry-run: exported success-shape predicate against the canonical fixture
+// ---------------------------------------------------------------------------
+
+describe("assertKbTemplateHealthy — documented-shape predicate", () => {
+  it("returns pass verdict for the shared synthesized repo-metadata-200 fixture", async () => {
+    const { assertKbTemplateHealthy } = await importHandler();
+    const fixture = loadGithubFixture("repo-metadata-200");
+    const verdict = assertKbTemplateHealthy(fixture);
+    expect(verdict.ok).toBe(true);
+  });
+
+  it("fails (not just non-200) when is_template is false", async () => {
+    const { assertKbTemplateHealthy } = await importHandler();
+    const fixture = loadGithubFixture<Record<string, unknown>>(
+      "repo-metadata-200",
+    );
+    const verdict = assertKbTemplateHealthy({ ...fixture, is_template: false });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.failureLabel).not.toBe("ci/guard-broken");
+  });
+
+  it("fails when private is true", async () => {
+    const { assertKbTemplateHealthy } = await importHandler();
+    const fixture = loadGithubFixture<Record<string, unknown>>(
+      "repo-metadata-200",
+    );
+    const verdict = assertKbTemplateHealthy({ ...fixture, private: true });
+    expect(verdict.ok).toBe(false);
+  });
+
+  it("guard-broken (not drift) when the body is a non-object", async () => {
+    const { assertKbTemplateHealthy } = await importHandler();
+    const verdict = assertKbTemplateHealthy(null);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.failureLabel).toBe("ci/guard-broken");
+  });
+
+  it("guard-broken when required fields are missing", async () => {
+    const { assertKbTemplateHealthy } = await importHandler();
+    const verdict = assertKbTemplateHealthy({ id: 2000 });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.failureLabel).toBe("ci/guard-broken");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+describe("cronKbTemplateHealth — registration", () => {
+  it("function id is cron-kb-template-health", async () => {
+    const mod = await importHandler();
+    const fn = mod.cronKbTemplateHealth as unknown as {
+      id: () => string;
+      opts: { id: string };
+    };
+    const id = typeof fn.id === "function" ? fn.id() : fn.opts.id;
+    expect(id).toContain("cron-kb-template-health");
+  });
+});

--- a/apps/web-platform/test/server/inngest/function-registry-count.test.ts
+++ b/apps/web-platform/test/server/inngest/function-registry-count.test.ts
@@ -128,7 +128,7 @@ describe("Inngest function registry — drift guards", () => {
 
   // UPDATE this number when adding/removing Inngest functions.
   it("(a) route.ts functions array has expected count", () => {
-    expect(routeEntries.length).toBe(51);
+    expect(routeEntries.length).toBe(52);
   });
 
   it("(b) every cron-*.ts file is registered in route.ts functions array", () => {

--- a/knowledge-base/engineering/operations/post-mortems/kb-template-create-repo-403-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/kb-template-create-repo-403-postmortem.md
@@ -1,0 +1,79 @@
+---
+title: "Postmortem: user-account 'Create Project' 403 — user-installation tokens cannot POST /user/repos (mocked 201 for ~30 days)"
+date: 2026-06-05
+incident_pr: 3399
+incident_window: "~2026-04-07 (POST /user/repos path shipped, unit-tested with a hand-mocked 201) → ~2026-05-07 (PR #3399 deployed: routed Create Project through jikig-ai/kb-template /generate)"
+recovery_at: "2026-05-07T00:00:00Z"
+suspected_change: "POST /user/repos for user-account repo creation was unit-tested with a hand-rolled mockFetch returning 201, but GitHub App user-installation tokens cannot POST /user/repos — production returned 403. The drift went undetected for ~30 days because the path was never exercised end-to-end against the real API."
+brand_survival_threshold: single-user incident
+status: closed
+closed_on: 2026-05-07
+closed_via: "PR #3399 (routed Create Project through jikig-ai/kb-template /generate template-seed). This PIR is authored retroactively (2026-06-05) while building the structural prevention (#3413 health probe + #3415 synthesized fixtures) — the incident was shipped-and-fixed without a post-mortem; the standing rule (every detected incident gets a PIR, even found incidentally) is satisfied here."
+triggers:
+  - create project 403
+  - user/repos forbidden
+  - github app installation token
+  - mock vs real API drift
+  - test fixture 201 vs prod 403
+art_33_triggered: false
+art_34_triggered: false
+art_33_deadline: "n/a — availability/functional outage (repo-create was BLOCKED), no personal-data exposure or breach"
+---
+
+## Actor key
+
+- `agent` — Claude Code did this autonomously.
+- `agent-with-ack` — Claude Code did this after operator confirmation.
+- `human` — Operator did this directly.
+
+# Incident Overview
+
+For roughly 30 days, a non-technical founder clicking **"Create Project"** (the user-account repo-creation path) received an opaque failure. The server attempted `POST /user/repos` with a GitHub App **user-installation** token, which GitHub forbids (403). The path had shipped green because its unit test mocked `fetch` to return `201` — a hand-imagined shape that never matched production. PR #3399 resolved it by routing Create Project through `jikig-ai/kb-template`'s `/generate` template-seed endpoint instead.
+
+## Status
+
+closed — fixed by PR #3399 (~2026-05-07). This PIR is retroactive.
+
+## Symptom
+
+"Create Project" failed with a generic error toast; the founder could not create a project at all. Server logs showed `403` from `POST /user/repos`.
+
+## Incident Timeline
+
+- **Start time (detected):** ~2026-05-06 (first user-reported failure, #3183/#3401 class)
+- **End time (recovered):** ~2026-05-07 (PR #3399 deployed)
+- **Duration (MTTR):** ~1 day from report to fix; ~30 days latent (ship → first report)
+
+| Actor | Time (UTC) | Action |
+|---|---|---|
+| human | ~2026-04-07 | `POST /user/repos` path ships; unit test mocks a `201` response. |
+| — | ~2026-04-07 → ~2026-05-06 | Latent: no user exercises the path end-to-end; green CI masks the 403. |
+| human | ~2026-05-06 | User reports "Create Project" broken (403). |
+| agent | ~2026-05-07 | PR #3399 reroutes through `kb-template` `/generate`; incident resolved. |
+| agent | 2026-06-05 | This PIR authored + structural prevention shipped (#3413 probe, #3415 synthesized fixtures). |
+
+## Participants and Systems Involved
+
+GitHub App installation-token auth surface (`server/github-app.ts`); the Create-Project route; `jikig-ai/kb-template` (the new template seed).
+
+## Detection (+ MTTD)
+
+- **How detected:** external/manual — a user reported the failure. There was NO proactive monitoring of the path.
+- **MTTD:** ~30 days (ship → first user report). This is the core failure: the only detection channel was a user hitting it.
+
+## Root Cause
+
+Two compounding causes:
+1. **Wrong API for the auth context.** GitHub App user-installation tokens cannot `POST /user/repos`. The correct path for cross-account repo creation is the template `/generate` endpoint (PR #3399's fix).
+2. **Test-fixture-vs-real-API drift.** The unit test mocked `POST /user/repos → 201` from imagination. A mock can assert any shape; nothing forced the fixture to match GitHub's real `403`. The green test actively masked the bug for ~30 days.
+
+## Prevention / Follow-ups (this PR: #3413 + #3415)
+
+- **#3413 — hourly kb-template health probe** (`cron-kb-template-health.ts`, this PR): proactively probes `GET /repos/jikig-ai/kb-template`, asserts `is_template===true && private===false`, files a P1 ops issue on drift, auto-closes on recovery. Moves detection from "a user hits it" (~30-day MTTD) to "hourly" (≤1h MTTD) for the template-drift class that would break Create Project the same way.
+- **#3415 — synthesized GitHub API fixtures** (this PR): replaces hand-imagined mock bodies with fixtures synthesized to GitHub's documented response shapes, closing the mock-vs-real-API drift class for the github-app test surface.
+- **Residual (already tracked):** #3414 (Playwright E2E smoke for `/api/repo/create` against a real dev GitHub installation) is the true end-to-end guard — a unit test cannot catch an auth-context-vs-API mismatch. It remains an open `deferred-scope-out` because it needs a dedicated dev GitHub App installation account.
+
+## Lessons
+
+- A mocked third-party API response is only as trustworthy as its fidelity to the real shape — a path never exercised end-to-end against the real API is unverified, regardless of green unit tests.
+- Detection-by-user-report is a ~30-day MTTD; proactive probes on user-onboarding-critical dependencies are worth their weight.

--- a/knowledge-base/engineering/operations/runbooks/kb-template-health.md
+++ b/knowledge-base/engineering/operations/runbooks/kb-template-health.md
@@ -1,0 +1,176 @@
+---
+title: kb-template health probe runbook
+date: 2026-06-05
+owners: engineering/ops
+applies_to:
+  - apps/web-platform/server/inngest/functions/cron-kb-template-health.ts
+related_issues: [3413, 3399, 3401]
+brand_survival_threshold: single-user incident
+---
+
+# kb-template health probe runbook
+
+**Before debugging the probe code path, check Better Stack
+`inngest-heartbeat` last_alive_at** — if >2 min ago, this issue is likely a
+substrate-down false-positive (cross-check sibling
+`cron-github-app-drift-guard` / `cron-oauth-probe` monitors). When the
+Inngest substrate is healthy but this monitor pages alone, the cause is in
+the handler logic or a genuine template drift below.
+
+Triage for the hourly kb-template health probe at
+`apps/web-platform/server/inngest/functions/cron-kb-template-health.ts`. The
+handler mints an installation-scoped Octokit via `createProbeOctokit()` (in
+`apps/web-platform/server/github/probe-octokit.ts` — no PAT, no JWT-mint),
+calls `GET /repos/{owner}/{repo}` with `owner=KB_TEMPLATE_OWNER` /
+`repo=KB_TEMPLATE_NAME` (from `server/github-app.ts`), and asserts the
+documented success shape: **`is_template === true` AND `private === false`**.
+
+## Why this probe exists
+
+Every user-account "Create Project" routes through `jikig-ai/kb-template`'s
+`/generate` endpoint (user-installation tokens cannot call
+`POST /user/repos` — that returns 403; `/generate` is the only path that
+accepts them). The template **MUST be public AND `is_template`** — a
+cross-account `/generate` call from a user-installation token returns 404
+against a private or non-template repo. If an operator deletes/renames/
+privatizes the template or drops its `is_template` flag, every user's
+onboarding "Create Project" returns an opaque 404/422 (the exact #3401
+failure). This probe detects that drift within 60 minutes instead of
+post-hoc via a user-filed Sentry error.
+
+## Failure-label families
+
+A failure surfaces under one of two label families — the title prefix tells
+you which:
+
+- `[ops/kb-template-broken] kb-template health probe fired` — **template
+  drift detected, user-impacting.** One of:
+  - `repo_not_found` — `GET /repos` returned 404. The template was deleted,
+    renamed, or made private (404 is GitHub's response for both
+    not-found and private-without-access).
+  - `is_template_dropped` — the repo exists and is readable, but
+    `is_template !== true`. Someone un-marked it as a template in the
+    GitHub UI.
+  - `template_private` — `is_template === true` but `private !== false`.
+    The repo was flipped to private.
+- `[ci/guard-broken] kb-template health probe malfunctioned` — **the probe
+  itself could not assert** (NOT a template-drift signal). Modes:
+  - `response_not_object` — `GET /repos` returned a non-object body.
+  - `response_missing_fields` — the body is an object but is missing the
+    boolean `is_template` or `private` field (an upstream GitHub API shape
+    change).
+  - `github_api_http` — a non-404 HTTP error from `GET /repos`.
+  - `github_api_network` — `GET /repos` threw a network-class error, or the
+    probe step itself threw.
+
+**Important:** `ci/guard-broken` does NOT mean user "Create Project" is
+broken — it means the probe couldn't get a clean answer. Triage the probe,
+not the template, for those modes. `ops/kb-template-broken` is the
+user-impacting family.
+
+## Alert response
+
+### 1. Verify the live template state (no dashboard eyeballing)
+
+```bash
+gh repo view jikig-ai/kb-template --json isTemplate,visibility
+```
+
+Expected healthy output:
+
+```json
+{ "isTemplate": true, "visibility": "public" }
+```
+
+Map the result to the failure mode:
+
+| `gh repo view` result | Failure mode | Remediation |
+|---|---|---|
+| Command errors / repo not found | `repo_not_found` | The template was deleted or renamed — see remediation below. |
+| `"isTemplate": false` | `is_template_dropped` | **Re-mark as template** (below). |
+| `"visibility": "private"` (or `"internal"`) | `template_private` | **Make public** (below). |
+| Healthy (`isTemplate:true`, `visibility:public`) but issue still open | guard transient (likely `github_api_network`/`github_api_http`) | No template change needed; confirm the next hourly tick auto-closes the issue. |
+
+### 2. Remediation
+
+All three remediations are GitHub-UI / `gh`-driven on `jikig-ai/kb-template`:
+
+- **Re-mark as template** (`is_template_dropped`):
+  ```bash
+  gh repo edit jikig-ai/kb-template --template
+  ```
+  (or GitHub UI → repo Settings → check "Template repository".)
+- **Make public** (`template_private`):
+  ```bash
+  gh repo edit jikig-ai/kb-template --visibility public --accept-visibility-change-consequences
+  ```
+  (or GitHub UI → repo Settings → Danger Zone → Change visibility → Public.)
+- **Un-rename / restore** (`repo_not_found`): if the repo was renamed,
+  rename it back to `kb-template`:
+  ```bash
+  gh repo rename kb-template --repo jikig-ai/<current-name>
+  ```
+  If it was deleted, restore it from GitHub's deleted-repo recovery window
+  (Settings → restore, available ~90 days) `[human-only: GitHub UI;
+  repo-restore has no public REST endpoint]`, or re-create from a clone.
+
+  Note: `KB_TEMPLATE_OWNER` / `KB_TEMPLATE_NAME` are env-overridable
+  (`server/github-app.ts`). If the template was intentionally moved to a
+  new owner/name, set those env vars in Doppler `prd` instead of un-naming
+  the repo — the probe and the create flow both read them.
+
+### 3. Verify recovery
+
+The probe self-heals: the next hourly tick re-runs `GET /repos`, sees the
+documented success shape, comments "green … Auto-closing", and closes the
+open `[ops/kb-template-broken]` / `[ci/guard-broken]` issue. To verify
+without waiting an hour, trigger on-demand (see `inngest-server.md`
+"On-demand cron trigger (HTTP)" path):
+
+```bash
+# Via the allowlisted manual-trigger event:
+inngest send cron/kb-template-health.manual-trigger --data '{}'
+```
+
+Then confirm the tracking issue auto-closed:
+
+```bash
+gh issue list --repo jikig-ai/soleur \
+  --search 'in:title "kb-template health" is:open' --json number,title
+```
+
+An empty list confirms recovery.
+
+## Substrate-down false-positive cross-check
+
+This probe shares the self-hosted Inngest substrate with ~45 other crons.
+If the substrate is down, this monitor cannot tick — but a *missing* tick
+reds the `inngest-heartbeat` Better Stack monitor, not this probe's issue
+surface (the probe only files an issue when it actually RUNS and sees
+drift). So:
+
+- **Issue filed + `inngest-heartbeat` healthy** → genuine template drift or
+  a guard malfunction. Triage above.
+- **No issue + `inngest-heartbeat` red (>2 min stale)** → substrate down;
+  the probe isn't running. This is a "guard-itself-dark" failure mode
+  tracked by the heartbeat monitor, NOT a kb-template problem. Do not
+  remediate the template.
+- **Issue filed AND `inngest-heartbeat` red** → check whether the issue is
+  stale (filed before the substrate went down). A fresh substrate-down does
+  not file a new kb-template issue, so a recent `[ops/kb-template-broken]`
+  issue alongside a red heartbeat means the probe ran, saw drift, filed,
+  THEN the substrate degraded — treat the template drift as real.
+
+Mirror of the `github-app-drift.md` runbook's same cross-check; the
+`cron-github-app-drift-guard` sibling is the structural precedent for this
+probe.
+
+## Cross-references
+
+- `github-app-drift.md` — sibling hourly App-integrity probe (same
+  issue-handling + leak-tripwire + Sentry-mirror shape).
+- `oauth-probe-failure.md` — sibling user-facing OAuth probe.
+- `inngest-server.md` — on-demand cron-trigger (HTTP) path.
+- Issue #3401 — the user-facing onboarding break this probe pre-empts.
+- PR #3399 — routed user-installation repo create through the template
+  `/generate` endpoint (the dependency this probe guards).

--- a/knowledge-base/project/learnings/2026-06-05-new-inngest-cron-requires-five-registry-lockstep.md
+++ b/knowledge-base/project/learnings/2026-06-05-new-inngest-cron-requires-five-registry-lockstep.md
@@ -1,0 +1,61 @@
+# Learning: a new Inngest cron must update FIVE parallel registries in lockstep
+
+## Problem
+
+Adding `cron-kb-template-health.ts` (a new hourly Inngest cron) tripped three
+registry-integrity invariants in `function-registry-count.test.ts` on the first
+test run. A new server-side cron is not "done" when the handler compiles — it is
+done when every parallel registry that tracks crons agrees.
+
+## Solution
+
+When adding a new Inngest cron function, update ALL of these in the SAME PR
+(the `function-registry-count.test.ts` guards are the forcing function — they
+fail until each is consistent):
+
+1. **`apps/web-platform/app/api/inngest/route.ts`** — import the function +
+   add it to the served-functions array.
+2. **`apps/web-platform/server/inngest/cron-manifest.ts`** — add the slug to
+   `EXPECTED_CRON_FUNCTIONS` (this also auto-extends the manual-trigger
+   allowlist; no separate edit needed).
+3. **`apps/web-platform/test/server/inngest/function-registry-count.test.ts`**
+   — bump the expected route count by 1.
+4. **`apps/web-platform/infra/sentry/cron-monitors.tf`** — add a
+   `sentry_cron_monitor` resource whose **name slugifies to exactly the
+   handler's `SENTRY_MONITOR_SLUG` constant** (a mismatch silently never
+   creates the monitor → the dead-probe alarm never fires).
+5. **`.github/workflows/apply-sentry-infra.yml`** — add the matching
+   `-target=sentry_cron_monitor.<name>` line so the monitor is applied on
+   merge.
+
+The slug must be byte-identical across handler `SENTRY_MONITOR_SLUG` → `.tf`
+`name` → `.tf` resource address → workflow `-target` suffix. The count test's
+own guards machine-enforce the slug↔tf↔workflow lockstep.
+
+## Key Insight
+
+The repo has 39+ Inngest crons vs 4 legacy GitHub-Actions scheduled workflows
+(`git ls-files | grep -c "server/inngest/functions/cron-"`). **When an issue
+prescribes a literal mechanism (`.github/workflows/*.yml` cron) but the codebase
+has an overwhelming established pattern + a direct structural sibling
+(`cron-github-app-drift-guard.ts`), follow the established architecture (ADR-030),
+not the issue's literal mechanism** — the issue is authoritative for intent
+(detect kb-template drift proactively), never for the substrate. Reusing the
+Inngest path also reuses `createProbeOctokit()` (installation-token auth, no PAT),
+`assertNoLeak`, the Sentry mirror, and the inngest-heartbeat substrate — a
+GH-Actions cron would re-implement JWT minting in inline shell (a known
+silent-failure-trap class).
+
+## Session Errors
+
+- **Planning subagent could not spawn nested Task subagents** (plan/review
+  fan-out agents unavailable to an agent that is itself a subagent). Recovery:
+  the subagent compensated by doing the research/premise-validation/precedent-diff
+  inline. Prevention: this is a harness constraint (nested-agent Task restriction),
+  not a fix-in-repo item — expect plan/deepen fan-out to degrade to inline
+  research when planning runs inside a one-shot subagent; the plan quality was
+  unaffected (the decisive precedent-diff finding was reached inline).
+
+## Tags
+category: integration-issues
+module: apps/web-platform/server/inngest

--- a/knowledge-base/project/plans/2026-06-05-fix-drain-kb-template-probe-and-github-fixtures-plan.md
+++ b/knowledge-base/project/plans/2026-06-05-fix-drain-kb-template-probe-and-github-fixtures-plan.md
@@ -1,0 +1,241 @@
+---
+title: "Drain #3399 test-infra follow-ups — kb-template health probe (#3413) + synthesized GitHub fixtures (#3415)"
+deepened: 2026-06-05
+date: 2026-06-05
+type: fix
+branch: feat-one-shot-drain-p4-3399-3413-3415
+issues: [3413, 3415]
+references_pr: [3399, 2486]
+milestone: "Phase 4: Validate + Scale"
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+labels_for_tracking: [code-review, deferred-scope-out, domain/engineering]
+---
+
+# Drain #3399 test-infra follow-ups in one PR
+
+## Enhancement Summary
+
+**Deepened on:** 2026-06-05
+
+### Key Improvements
+1. **Phase 4.4 precedent-diff gate ran and is decisive:** 39 Inngest crons vs 4 GH-Actions scheduled workflows → the #3413 probe MUST be an Inngest cron (`cron-kb-template-health.ts`), NOT the `.github/workflows/kb-template-health-probe.yml` the issue body names. Governing ADR-030 cited (path-verified).
+2. **Precedent-diff table against `cron-github-app-drift-guard.ts`** — every reuse claim grounded to a line number: `assertNoLeak` is EXPORTED (reuse directly); `handleFailureIssue`/`handleLeakIssue` are file-private (co-locate a mirror); `PROBE_ISSUE_OWNER/REPO` + `createProbeOctokit` exported from `probe-octokit.ts`.
+3. **Verify-the-negative pass** confirmed the `hr-github-app-auth-not-pat` claim: `createProbeOctokit()` mints via `@octokit/auth-app` internally, no PAT/JWT literal — the new cron must reuse it, not re-implement minting.
+
+### New Considerations Discovered
+- The directional divergence (Inngest vs GH-Actions) is real and `requires_cpo_signoff` — the PR body must note the workflow file was intentionally not created so the #3413 author sees it.
+- `assertNoLeak` reuse means the leak tripwire is free; only the issue-handling shape needs mirroring (its dedup title-phrase differs anyway).
+- All 8 cited AGENTS rule IDs verified active; all heading gates (4.6/4.7) pass after stripping emoji from `## User-Brand Impact` / `## Observability`.
+
+🐛 **fix** — closes two `deferred-scope-out` / `code-review` issues filed against the merged PR #3399 (route user-installation repo create through template `/generate`). Both are in-repo, automatable, no DB migration, no external account. One coherent PR following the #2486 one-PR-multiple-closures precedent.
+
+- **#3413** — operational gap: every user-account "Create Project" routes through `jikig-ai/kb-template`'s `/generate` endpoint. If an operator deletes/renames/privatizes the template or drops its `is_template` flag, every create returns 404/422 — detected only post-hoc via Sentry. Needs a proactive hourly probe + runbook.
+- **#3415** — test-fixture-vs-real-API drift class: `github-app-create-repo.test.ts` (and siblings) mock `globalThis.fetch` with hand-rolled JSON literals. #3399's own root cause was a mock returning 201 while prod returned 403 for ~30 days. Replace inline literals with **synthesized** fixtures loaded via a helper.
+
+---
+
+## ⚠️ Research Reconciliation — Spec vs. Codebase
+
+The issue body for #3413 prescribes a **new `.github/workflows/kb-template-health-probe.yml` GitHub Actions cron**. Codebase reality contradicts this prescription on the architecture axis (the *outcome* — hourly proactive probe + auto-filed P0 issue + runbook — is unchanged):
+
+| Issue-body claim | Codebase reality (verified) | Plan response |
+|---|---|---|
+| Add a new GitHub Actions cron workflow `.github/workflows/kb-template-health-probe.yml` | The codebase runs ~45 `cron-*.ts` Inngest functions under `apps/web-platform/server/inngest/functions/`; **only 4** `scheduled-*.yml` GH-Actions crons remain (drift/probe/sweeper legacy). The canonical hourly-health-probe sibling is **`cron-github-app-drift-guard.ts`** (`{ cron: "0 * * * *" }`, TR9 PR-4, #4235). | **Implement as an Inngest cron** `cron-kb-template-health.ts` mirroring the drift-guard sibling, NOT a GH-Actions workflow. See **Directional Decision** below. The issue's *intent* (hourly proactive probe) is fully satisfied. |
+| "Use the existing GitHub App installation-token auth surface; do NOT mint a new PAT" (`hr-github-app-auth-not-pat`) | `apps/web-platform/server/github/probe-octokit.ts` exports `createProbeOctokit()` → installation-scoped Octokit (auto-refreshing installation token via `@octokit/auth-app`), already used by `cron-github-app-drift-guard` + `cron-oauth-probe`. | **Reuse `createProbeOctokit()`** verbatim. Satisfies `hr-github-app-auth-not-pat` by construction; no new auth surface, no PAT. |
+| "opens/updates a P0 ops issue on failure, records last-success" | `cron-github-app-drift-guard.ts` already has dedup-search → comment-or-open → auto-close-on-success machinery (`GET /search/issues`, `POST /repos/{owner}/{repo}/issues`, `PATCH .../issues/{n}`) against `jikig-ai/soleur`, plus a PEM/JWT leak-tripwire and `reportSilentFallback` Sentry mirror. | **Reuse the same issue-handling shape**; factor shared helpers if `cron-github-app-drift-guard` already exposes them, else co-locate a minimal mirror. Probe failure files `[ops/kb-template-broken]` titled issue with `priority/p1-high`. |
+| "Files: new `apps/web-platform/test/fixtures/github/*.json`; new loader helper" (#3415) | `apps/web-platform/test/fixtures/` exists (4 `.ts` fixtures); **no `github/` subdir**, **no JSON-fixture loader convention** (tests use inline literals). | Create `test/fixtures/github/` + a loader helper. Confirmed greenfield. |
+
+**Premise validation:** #3413 OPEN, #3415 OPEN, both carry milestone #4 "Phase 4: Validate + Scale" on the issue already. #3399 MERGED, #3401 CLOSED, #2486 MERGED (one-PR-multiple-closures precedent confirmed). 10 `github-app-*.test.ts` files exist; `is_template`/`KB_TEMPLATE_OWNER`/`KB_TEMPLATE_NAME` live at `apps/web-platform/server/github-app.ts:888-891`. No external premises stale.
+
+---
+
+## 🧭 Directional Decision — Inngest cron vs. GitHub Actions cron (REQUIRES sign-off)
+
+The issue literally names a GH-Actions workflow file. The plan deliberately diverges to an Inngest cron. **This is a directional-ambiguity gate (plan Phase 0.5) that MUST be confirmed before `/work`.**
+
+**Why Inngest is correct here:**
+1. **Precedent (`hr-verify-repo-capability-claim-before-assert` + deepen-plan Phase 4.4 precedent-diff):** `cron-github-app-drift-guard.ts` is a byte-for-byte structural sibling — hourly cron, App-JWT/installation-token auth, GitHub-API probe, issue open/update/auto-close, leak tripwire, Sentry mirror, a runbook, and a unit-test harness. #3413's probe is the same shape against a different endpoint.
+2. **Auth reuse:** `createProbeOctokit()` already solves the exact "installation token, no PAT" requirement the issue calls out. A GH-Actions workflow would have to re-implement JWT minting in inline shell (the silent-failure-trap class in `2026-05-05-workflow-jwt-mint-silent-failure-traps.md`).
+3. **Observability convention:** Inngest crons land in the `inngest-heartbeat` Better Stack monitor + Sentry; a standalone GH-Actions cron is a separate dark surface (cf. `#4116` inngest-heartbeat dark-zone learning).
+4. **The `soleur:schedule` skill scaffolds GH-Actions crons for *agent-invoking* tasks (push commits, run skills). This is a server-side API probe, not an agent task — Inngest is the right substrate.**
+
+**Cost of divergence:** the PR-body `Closes #3413` text must note the architecture deviation so the issue author sees the workflow file was intentionally not created. If sign-off rejects the divergence, fall back to a `scheduled-*.yml` GH-Actions cron with inline JWT minting per `2026-05-05-workflow-jwt-mint-silent-failure-traps.md` (three traps pre-addressed) — but this is the dispreferred path.
+
+---
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences (for #3413):** the probe silently fails to detect kb-template drift, so a non-technical founder clicking "Create Project" gets an opaque 404/422 and a broken onboarding — the exact #3401 failure the probe exists to pre-empt. **For #3415:** a future mock-vs-real-API drift (the #3399 class: 201-mocked / 403-real) ships green for ~30 days, breaking real repo creation for every user.
+
+**If this leaks, the user's data is exposed via:** the probe handler captures GitHub API responses into issue bodies / logs. A leaked installation token or App PEM in captured step output would expose the org's GitHub App credentials → all connected user KB repos. Mitigated by reusing the existing drift-guard **leak tripwire** (PEM-block / JWT-shape detection) before any capture is written.
+
+**Brand-survival threshold:** `single-user incident` — one user's broken "Create Project" or one leaked token is a brand-survival event. `requires_cpo_signoff: true`; `user-impact-reviewer` runs at review time (review/SKILL.md conditional-agent block).
+
+---
+
+## 🎯 Acceptance Criteria
+
+### Pre-merge (PR)
+
+**#3413 — kb-template health probe (Inngest cron path):**
+- [ ] `apps/web-platform/server/inngest/functions/cron-kb-template-health.ts` exists, registers an hourly `{ cron: "0 * * * *" }` Inngest function, and is wired into `apps/web-platform/app/api/inngest/route.ts`'s function array (grep: `grep -n cronKbTemplateHealth apps/web-platform/app/api/inngest/route.ts` returns ≥1).
+- [ ] The handler calls `createProbeOctokit()` from `server/github/probe-octokit.ts` (NO new PAT, NO new JWT-mint code — `hr-github-app-auth-not-pat`; grep confirms `createProbeOctokit` import and zero `process.env.*PAT*`/`ghp_` literals in the new file).
+- [ ] The handler probes `GET /repos/{owner}/{repo}` with `owner=KB_TEMPLATE_OWNER`, `repo=KB_TEMPLATE_NAME` (imported from `server/github-app.ts`, not re-literalized) and asserts the **documented success shape**: `data.is_template === true` AND `data.private === false`. A response missing either field, or a non-object body, is a guard failure (distinct label from drift).
+- [ ] On probe failure: dedup-search + open-or-comment a P1 ops issue against `jikig-ai/soleur` titled `[ops/kb-template-broken] …` with labels `["priority/p1-high", <failure-label>]`; on success: auto-close any open such issue (records last-success by closing). Mirrors `cron-github-app-drift-guard.ts` issue-handling.
+- [ ] Probe failures `reportSilentFallback(...)` to Sentry (`cq-silent-fallback-must-mirror-to-sentry`); captured GitHub output passes a PEM/JWT leak tripwire before any issue-body write.
+- [ ] Unit test `apps/web-platform/test/server/inngest/cron-kb-template-health.test.ts` covers: (a) happy path (`is_template:true, private:false` → no issue, auto-close path); (b) `is_template:false` → issue filed; (c) `private:true` → issue filed; (d) 404 (repo missing/renamed) → issue filed; (e) malformed body (missing fields) → guard-broken label; (f) success auto-closes a prior open issue. All fetches/Octokit stubbed — no real network. Runner: `./node_modules/.bin/vitest run test/server/inngest/cron-kb-template-health.test.ts` (NOT `bun test` — `apps/web-platform/bunfig.toml` sets `pathIgnorePatterns=["**"]`).
+- [ ] **Dry-run assertion of documented success shape:** a test (or a `--dry-run`-style exported pure function) exercises the probe's success-shape predicate against a synthesized `GET /repos` 200 fixture and asserts the pass verdict — proving the probe asserts the documented shape, not just HTTP 200.
+- [ ] Runbook `knowledge-base/engineering/operations/runbooks/kb-template-health.md` exists with: title/owners/`applies_to`/`related_issues:[3413,3399,3401]` frontmatter; the three failure-label families and their meaning; alert-response steps (verify template state via `gh repo view jikig-ai/kb-template --json isTemplate,visibility`; remediation = re-mark template / make public / un-rename); and a "substrate-down false-positive" cross-check against `inngest-heartbeat` mirroring `github-app-drift.md`.
+
+**#3415 — synthesized GitHub fixtures:**
+- [ ] `apps/web-platform/test/fixtures/github/` contains synthesized JSON fixtures for the GitHub API response shapes the github-app tests mock: at minimum `installation-account.json` (org + user variants), `installation-access-token.json`, `repo-create-201.json`, `template-generate-201.json`, `error-403.json`, `error-404.json`, `error-422-duplicate.json`, `error-422-not-template.json`. **All synthesized per `cq-test-fixtures-synthesized-only`:** `@example.com`/`@test.local` emails only, NO prod-shape UUIDs, NO live tokens (token fixtures use obvious placeholders like `ghs_<<synthetic>>`), all IDs small synthetic integers. Field names/types/status codes match GitHub's public REST API docs.
+- [ ] A loader helper (e.g. `apps/web-platform/test/fixtures/github/load.ts` exporting `loadGithubFixture(name)`) reads + parses the JSON and returns a typed object. Helper is the single read path; tests import it rather than `readFileSync` inline.
+- [ ] `github-app-create-repo.test.ts` (and every sibling identified by the enumeration grep below) replaces its inline `mockFetch.mockResolvedValueOnce({ ok, status, json: async () => ({...}) })` JSON literals with `loadGithubFixture(...)`-sourced bodies. The `ok`/`status` wrapper stays inline (it's vitest mock mechanics, not API data); only the **response body** moves to the fixture.
+- [ ] Enumeration is grep-derived, NOT issue-body-derived: `git grep -lnE 'mockResolvedValueOnce|json: async' apps/web-platform/test/github-app-*.test.ts` produces the file list; every file with a literal API-shaped body is in scope or explicitly scoped-out with a one-line reason.
+- [ ] The synthesized fixtures' `is_template`/`private` shape for the kb-template `/repos` response is shared between the #3413 dry-run test and the #3415 fixture set (one canonical synthesized repo-metadata fixture, not two divergent copies).
+- [ ] Full github-app test suite green: `./node_modules/.bin/vitest run test/github-app-create-repo.test.ts <…siblings…>`.
+- [ ] `tsc --noEmit` clean for `apps/web-platform`.
+
+### Post-merge (operator)
+- [ ] First hourly Inngest tick of `cron-kb-template-health` fires and records a success (auto-close path with no open issue) — verify via `inngest-heartbeat` monitor + Sentry absence-of-error. **Automation:** the merge to `apps/web-platform/**` redeploys the container (`web-platform-release.yml` path-filtered push) which registers the new Inngest function; no separate operator step. On-demand verification available via the `inngest-server.md` runbook "On-demand cron trigger (HTTP)" path if needed.
+
+---
+
+## Research Insights (deepen-plan 2026-06-05)
+
+### Phase 4.4 Precedent-Diff Gate — scheduled-work pattern (DECISIVE for #3413)
+
+Ran the prescribed checks:
+
+```
+$ git ls-files | grep -cE "apps/web-platform/server/inngest/functions/cron-"
+39
+$ git ls-files | grep -E "^\.github/workflows/scheduled-" | wc -l
+4
+```
+
+39 Inngest crons vs 4 legacy GH-Actions scheduled workflows → **Inngest is canonical**; the new probe MUST be an Inngest cron, not a `scheduled-*.yml`. This confirms the Directional Decision. The GH-Actions path fails the deepen-plan precedent-check criteria: the work is NOT purely git/repo-scoped — it needs app context (`createProbeOctokit()`), app secrets (GitHub App PEM in Doppler `prd`), Sentry integration (`reportSilentFallback`), and benefits from `step.run` memoization. **Governing ADR: ADR-030 "Inngest as durable trigger layer for server-side agents"** (`knowledge-base/engineering/architecture/decisions/ADR-030-inngest-as-durable-trigger-layer.md`, status: accepted) — the substrate decision for scheduled server-side work. (ADR-033 also exists but is narrower — "Inngest cron functions invoke claude-code via child_process.spawn" — it governs *agent-task* crons, not a pure API-probe cron; ADR-030 is the correct citation here.)
+
+### Precedent diff — `cron-github-app-drift-guard.ts` (the structural sibling)
+
+| Concern | Sibling (`cron-github-app-drift-guard.ts`) | New `cron-kb-template-health.ts` |
+|---|---|---|
+| Schedule | `inngest.createFunction(..., { cron: "0 * * * *" }, handler)` (line 868-878) | identical — hourly |
+| Auth | `createAppJwtOctokit()` (App-JWT, hits `GET /app` + `GET /app/installations`) | `createProbeOctokit()` (installation-scoped, auto-refreshing installation token via `@octokit/auth-app`) — correct for `GET /repos/{owner}/{repo}` repo-metadata read. **No PAT.** |
+| Probe | `GET /app`; assert `id`+`client_id` byte-for-byte | `GET /repos/{owner}/{repo}`; assert `is_template===true` AND `private===false` |
+| Leak tripwire | `assertNoLeak(label, s)` — **EXPORTED** at line 121 | **Reuse `assertNoLeak` directly** (import from the sibling) — guards every issue-body/comment before write |
+| Issue handling | `handleFailureIssue` (line 542) — dedup `GET /search/issues` by label+title-phrase → comment-or-`POST /issues` → success auto-closes via `PATCH .../issues/{n}` state:closed | **file-private in the sibling** (`handleFailureIssue`/`handleLeakIssue` NOT exported). Mirror the same shape co-located in the new cron, OR extract a shared `server/github/probe-issue-handler.ts` helper. deepen-plan recommends the **co-located mirror** first (smaller blast radius; the dedup query differs by title-phrase anyway — "GitHub App drift-guard" vs a kb-template phrase) and notes the duplication for a future dedup issue. |
+| Issue target repo | `PROBE_ISSUE_OWNER`/`PROBE_ISSUE_REPO` = `jikig-ai`/`soleur` (exported from `probe-octokit.ts:94-95`) | reuse the same exports |
+| Sentry mirror | `reportSilentFallback` (warn/error) | reuse `@/server/observability` |
+| Registration | served in `apps/web-platform/app/api/inngest/route.ts` | add `cronKbTemplateHealth` to the same array |
+| Runbook | `knowledge-base/engineering/operations/runbooks/github-app-drift.md` (3 failure-label families + inngest-heartbeat false-positive cross-check) | author `kb-template-health.md` mirroring its structure |
+
+**Implication for `## Files to Edit`:** prefer the co-located-mirror approach → the only edit to the sibling file is none (import `assertNoLeak` from it). If `/work` finds the issue-handling extraction is clean, that becomes a new shared file under `server/github/` rather than an edit to the drift-guard.
+
+### Verify-the-negative pass — `hr-github-app-auth-not-pat`
+
+Plan asserts "NO new PAT, NO new JWT-mint code". Verified against the implementation surface: `createProbeOctokit()` (`probe-octokit.ts:116`) mints via `@octokit/auth-app` `App` + `getInstallationOctokit(installation.id)` — the installation token is internal and auto-refreshed; the caller never sees a raw token. There is no `process.env.*PAT*` / `ghp_` / `github_pat_` literal in `probe-octokit.ts`. **Confirms** the negative claim. The new cron MUST NOT introduce its own `jsonwebtoken`/`openssl` minting (the GH-Actions-fallback silent-failure-trap class, `2026-05-05-workflow-jwt-mint-silent-failure-traps.md`) — reuse `createProbeOctokit()`.
+
+### #3415 — fixture loader convention (greenfield, confirmed)
+
+No existing JSON-fixture-loader helper in `apps/web-platform/test/` (the 4 existing `test/fixtures/*.ts` are TS module fixtures, not JSON loaded via a helper). The loader is genuinely new. The mock bodies to replace are inline `vi.fn().mockResolvedValueOnce({ ok, status, json: async () => ({...}) })` literals (verified in `github-app-create-repo.test.ts:88-110, 138-150, ...`). Only the `({...})` **body** moves to a fixture; `ok`/`status` stay inline (vitest mock mechanics). GitHub's real `/repos` response carries `is_template`, `private`, `full_name`, `html_url`, `default_branch`, `owner.login`, etc.; synthesize to that shape with `@example.com`/synthetic-integer-IDs.
+
+## Files to Create
+
+- `apps/web-platform/server/inngest/functions/cron-kb-template-health.ts` — hourly Inngest cron, `createProbeOctokit()` → `GET /repos/{owner}/{repo}`, success-shape assertion, issue open/update/close, leak tripwire, Sentry mirror.
+- `apps/web-platform/test/server/inngest/cron-kb-template-health.test.ts` — unit tests (stubs, no network).
+- `apps/web-platform/test/fixtures/github/*.json` — synthesized fixtures (list above).
+- `apps/web-platform/test/fixtures/github/load.ts` — fixture loader helper.
+- `knowledge-base/engineering/operations/runbooks/kb-template-health.md` — alert-response runbook.
+
+## ✏️ Files to Edit
+
+- `apps/web-platform/app/api/inngest/route.ts` — register `cronKbTemplateHealth` in the served-functions array.
+- `apps/web-platform/test/github-app-create-repo.test.ts` — swap inline JSON literals → `loadGithubFixture(...)`.
+- Sibling `github-app-*.test.ts` files surfaced by the enumeration grep (candidates from density scan: `github-app-pr.test.ts`, `github-app-default-branch-commit.test.ts`, `github-app-find-installation.test.ts`, `github-app-token-hardening.test.ts`) — confirm-or-scope-out each at /work Phase 1.
+- (Optional, deepen-plan to confirm) extract shared issue-handling helpers from `cron-github-app-drift-guard.ts` if reuse is clean; otherwise co-locate a minimal mirror in the new cron and note the duplication for a future dedup issue.
+
+---
+
+## 🧩 Open Code-Review Overlap
+
+`code-review`/`deferred-scope-out` issues touching the planned files were checked. **#3413 and #3415 are themselves the overlap** — both are folded in (`Closes #3413`, `Closes #3415`). No *other* open scope-out names `cron-kb-template-health.ts` (new file), `test/fixtures/github/**` (new dir), or the `github-app-*.test.ts` mock bodies. If `/work` Phase 1 enumeration surfaces a sibling test file already tracked by another open scope-out, fold-in or acknowledge per the overlap rule. Recorded so the next planner sees the check ran.
+
+---
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: cron-kb-template-health hourly tick (success = auto-close path, no open issue)
+  cadence: hourly ("0 * * * *")
+  alert_target: inngest-heartbeat Better Stack monitor (shared substrate) + auto-filed [ops/kb-template-broken] issue on drift
+  configured_in: apps/web-platform/server/inngest/functions/cron-kb-template-health.ts
+error_reporting:
+  destination: Sentry via reportSilentFallback (warn/error) — cq-silent-fallback-must-mirror-to-sentry
+  fail_loud: true (probe failure opens a priority/p1-high ops issue; never silently swallowed)
+failure_modes:
+  - {mode: kb-template deleted/renamed (404), detection: GET /repos 404, alert_route: "[ops/kb-template-broken] issue + Sentry"}
+  - {mode: is_template flag dropped, detection: data.is_template !== true, alert_route: same}
+  - {mode: flipped to private, detection: data.private !== false, alert_route: same}
+  - {mode: malformed/empty body, detection: non-object or missing fields, alert_route: "[ci/guard-broken]-style issue (guard malfunction, not drift)"}
+  - {mode: token/PEM leak in captured output, detection: leak tripwire (PEM-block / JWT shape), alert_route: "[security/leak-suspected] issue"}
+logs:
+  where: Inngest run logs + Sentry events; issue bodies on jikig-ai/soleur
+  retention: Sentry default; issues persist until auto-closed on next success
+discoverability_test:
+  command: "./node_modules/.bin/vitest run apps/web-platform/test/server/inngest/cron-kb-template-health.test.ts"
+  expected_output: "all tests pass — happy path asserts is_template===true && private===false; failure modes file issues; success auto-closes"
+```
+
+(No `ssh` in `discoverability_test.command`.)
+
+---
+
+## 🔐 GDPR / Compliance Gate
+
+Probe reads **public repo metadata** (`is_template`, `private`) of an org-owned template — no operator personal data, no regulated-data surface (no schema/migration/auth/API-route change). Fixtures are synthesized (no real user data — `cq-test-fixtures-synthesized-only`). Trigger (a) "LLM/external API on operator-session-derived data" does NOT fire (GitHub metadata, not session data). **gdpr-gate skipped** — no regulated-data surface. (deepen-plan may re-confirm.)
+
+---
+
+## 🏗 Infrastructure (IaC)
+
+No new infrastructure. The Inngest substrate (`apps/web-platform/infra/inngest.tf`, ADR-030 self-hosted) and the GitHub App secrets in Doppler `prd` already exist and are consumed by `createProbeOctokit()`. The new cron is application code registered into the existing `/api/inngest` serve route — no server, secret, vendor, or persistent process is added. **Phase 2.8 skipped** (pure code against already-provisioned surface). If sign-off forces the GH-Actions fallback path, that workflow uses the existing GitHub App secrets via repo secrets — still no new infra.
+
+---
+
+## 🧪 Test Strategy
+
+Runner: `vitest run` (per `apps/web-platform/package.json scripts.test`; **never `bun test`** — `bunfig.toml pathIgnorePatterns=["**"]`). New cron test lives at `test/server/inngest/cron-kb-template-health.test.ts` (matches vitest node project glob `test/**/*.test.ts`). Fixtures under `test/fixtures/github/*.json` are data, not tests — not collected by any vitest project (`.json` ∉ `*.test.ts`/`*.test.tsx`). RED-first per `cq-write-failing-tests-before`: write the cron + fixture tests failing, then implement.
+
+---
+
+## 🔁 Alternative Approaches Considered
+
+| Approach | Why not chosen |
+|---|---|
+| New `.github/workflows/kb-template-health-probe.yml` GH-Actions cron (issue-body literal) | Diverges from the 45-cron Inngest convention + the direct `cron-github-app-drift-guard` sibling; forces inline JWT-mint re-implementation (silent-failure-trap class); separate dark observability surface. Kept as documented fallback if sign-off rejects the Inngest path. |
+| Literal-capture fixtures from real GitHub responses | Violates `cq-test-fixtures-synthesized-only` (real IDs/tokens). Value is shape-fidelity, not data-fidelity — synthesize to the public-API shape. |
+| Two PRs (one per issue) | #2486 precedent + the shared synthesized repo-metadata fixture (used by both the #3413 dry-run and the #3415 fixture set) make one coherent PR cheaper and DRY. |
+
+---
+
+## 📌 Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty / `TBD` / lacks the threshold fails `deepen-plan` Phase 4.6. (Filled above; threshold = single-user incident.)
+- The fixture **token** fields must use a non-`[a-zA-Z0-9]` placeholder shape (`ghs_<<synthetic>>`, not a literal 40-char token) or GitHub push-protection rejects the push even for synthetic data (`2026-05-15-github-push-protection-rejects-synthetic-tokens-in-plan-prose.md`). The real fixture FILE may carry an obviously-fake token only if `cq-test-fixtures-synthesized-only`-compliant and gitleaks-allowlisted.
+- Enumerate the github-app mock files via `git grep`, NOT the issue body — the issue names `github-app-create-repo.test.ts` but the density scan shows ≥5 files with literal API bodies.
+- Test path must satisfy the vitest `include` glob (`test/**/*.test.ts`) AND avoid `bun test` (bunfig blocks discovery). Use `./node_modules/.bin/vitest run <path>`.
+- Reuse `KB_TEMPLATE_OWNER`/`KB_TEMPLATE_NAME` from `server/github-app.ts:888-891` — do not re-literalize `jikig-ai`/`kb-template` in the new cron.
+
+---
+
+## 🚢 PR Requirements
+
+- PR body MUST include `Closes #3413` and `Closes #3415` (in body, not title — `wg-use-closes-n-in-pr-body-not-title-to`). This is a code change merged atomically (not an ops-remediation), so `Closes` is correct (not `Ref`).
+- Reference PR **#2486** as the one-PR-multiple-closures precedent.
+- Note the **architecture deviation** for #3413 (Inngest cron, not the GH-Actions workflow the issue names) in the PR body so the issue author sees the workflow file was intentionally not created.
+- Set milestone **"Phase 4: Validate + Scale"** on the PR (`gh pr edit <n> --milestone "Phase 4: Validate + Scale"`).
+- `requires_cpo_signoff: true` — CPO sign-off on the technical approach at plan time; `user-impact-reviewer` at review time.

--- a/knowledge-base/project/specs/feat-one-shot-drain-p4-3399-3413-3415/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-drain-p4-3399-3413-3415/session-state.md
@@ -1,0 +1,18 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-05-fix-drain-kb-template-probe-and-github-fixtures-plan.md
+- Status: complete
+
+### Errors
+None. (Task tool unavailable to the planning subagent → plan/deepen fan-out agents could not be dispatched; compensated with inline codebase research.)
+
+### Decisions
+- #3413 implemented as an Inngest cron (cron-kb-template-health.ts) NOT a GitHub Actions workflow — codebase has 39 Inngest crons vs 4 legacy GH-Actions; direct sibling cron-github-app-drift-guard.ts (hourly, App-token auth, issue open/update/auto-close, Sentry mirror, runbook); governed by ADR-030. PR body must flag the deliberate divergence from the issue's literal prescription.
+- Auth reuse: new cron reuses createProbeOctokit() (probe-octokit.ts) which mints via @octokit/auth-app internally — satisfies hr-github-app-auth-not-pat by construction (no PAT/JWT literal).
+- Reuse boundary: assertNoLeak is exported (reuse for leak tripwire); handleFailureIssue/handleLeakIssue are file-private → co-locate a mirror (note future dedup issue).
+- #3415 greenfield: no existing JSON-fixture-loader; mocks are inline vi.fn().mockResolvedValueOnce({ok,status,json}) across 8 github-app test files (grep-enumerated). Fixtures synthesized to GitHub public /repos shape per cq-test-fixtures-synthesized-only (ghs_<<synthetic>> placeholders, no real IDs).
+- Premise: #3413/#3415 OPEN w/ milestone #4; #3399 MERGED, #2486 MERGED. Closes (not Ref) correct.
+
+### Components Invoked
+- Skill: soleur:plan, soleur:deepen-plan; Bash, Read, Write, Edit, ToolSearch


### PR DESCRIPTION
## Summary

Drains two Phase-4 `deferred-scope-out` test-infra follow-ups from the merged PR #3399 in one PR (pattern: PR #2486). Both are in-repo, automatable, no DB migration, no external account.

- **#3413** — proactive hourly health probe for `jikig-ai/kb-template` (every user "Create Project" routes through its `/generate`). **Architecture note (deliberate divergence from the issue's literal text):** the issue names a `.github/workflows/*.yml` GitHub Actions cron, but this ships an **Inngest cron** (`cron-kb-template-health.ts`) instead — the codebase has 39 Inngest crons vs 4 legacy GH-Actions and a direct structural sibling (`cron-github-app-drift-guard.ts`), governed by ADR-030. Reuses `createProbeOctokit()` (installation-token auth, no PAT), `assertNoLeak`, the Sentry mirror, and the inngest-heartbeat substrate. Probes `GET /repos`, asserts `is_template===true && private===false`, files a P1 ops issue on drift (distinct `ci/guard-broken` label for probe malfunction), auto-closes on recovery. + runbook.
- **#3415** — replaces hand-rolled inline `mockFetch` JSON literals across 8 `github-app-*.test.ts` files with **synthesized** fixtures (`test/fixtures/github/*.json` + `load.ts` loader). Per `cq-test-fixtures-synthesized-only`: synthetic IDs/logins, `ghs_<<synthetic>>` token placeholders, shapes matching GitHub's public REST API. Closes the #3399 mock-vs-real-API drift class (a mock returned 201 while prod returned 403 for ~30 days).

Closes #3413
Closes #3415

## User-Brand Impact

**If this lands broken (#3413):** the probe silently fails to detect kb-template drift → a non-technical founder clicking "Create Project" gets an opaque 404/422 broken onboarding (the #3401 failure the probe pre-empts). **(#3415):** a future mock-vs-real-API drift ships green for weeks, breaking real repo creation.
**If this leaks:** the probe captures GitHub API responses into issue bodies/Sentry — a leaked installation token / App PEM would expose the org's GitHub App credentials → all connected user KB repos. Mitigated by `assertNoLeak` (PEM/JWT tripwire) before every issue write AND `redactedError()` on every Sentry mirror (added in review).

- **Brand-survival threshold:** single-user incident

## Changelog

### Web Platform
- Add an hourly Inngest cron that health-probes the `jikig-ai/kb-template` repo and files a P1 ops issue on drift (deletion/rename/private-flip/is_template-drop), auto-closing on recovery. New Sentry cron-monitor + runbook.
- Replace hand-rolled GitHub API test mocks with synthesized fixtures + a loader, closing the mock-vs-real-API drift class.

## Test plan

- [x] `tsc --noEmit` clean; full `vitest run` green (8868 passed)
- [x] `test-all.sh` bun + scripts shards green
- [x] 13→17 cron unit tests (happy/drift/404/malformed/auto-close/dedup/leak-tripwire/transient-retry/dry-run-predicate); 58 github-app tests unchanged on synthesized fixtures
- [x] terraform fmt + validate clean on infra/sentry; registry-lockstep guards green (route/manifest/count/tf/apply-workflow)
- [x] Multi-agent review (user-impact, security-sentinel, pattern, test-design, code-quality, semgrep) — P2 findings (Sentry redaction, run-log parity, transient retry) fixed inline
- [ ] ⏳ Post-merge: first hourly `cron-kb-template-health` tick records success via inngest-heartbeat + Sentry (auto on redeploy; no operator step)

Generated with [Claude Code](https://claude.com/claude-code)
