### PR TITLE
fix(kb): render model.likec4.json off-tree, stop reconcile dirty-tree churn

### DIFF
--- a/apps/web-platform/server/c4-render.ts
+++ b/apps/web-platform/server/c4-render.ts
@@ -14,10 +14,19 @@
 // ElementKind named '…'` to stderr but returns 0 and writes an EMPTY-elements
 // model). So exit-0 is NOT sufficient evidence of a usable render. We render to
 // a temp path, parse it, and only treat it as success when the model has ≥1
-// element — then copy it onto the real `model.likec4.json`. An empty/invalid
-// export therefore NEVER clobbers the previously-good committed model; it
-// returns `{ ok:false, reason:"empty_model" }` so the writer keeps the old JSON
-// and the client shows the honest staleness banner.
+// element — then RETURN the validated bytes (the caller commits them and the
+// resync pull lands them on disk). An empty/invalid export therefore NEVER
+// reaches a commit; it returns `{ ok:false, reason:"empty_model" }` so the
+// writer keeps the old JSON and the client shows the honest staleness banner.
+//
+// OFF-TREE RENDER (#4976): the validated model is NEVER written onto the tracked
+// `model.likec4.json` working-tree path. The render produces only a process-temp
+// artifact and returns the bytes; the writer commits them via the GitHub
+// Contents API and the `op:"manual"` resync pull brings the committed bytes down
+// onto the clone (where the GET `/api/kb/c4/project` route reads them). This
+// removes the dirty-tree reconcile churn that the in-place publish used to cause
+// on every `.c4` save. Mirrors `pdf-linearize.ts`, which likewise returns bytes
+// and leaves persistence to its caller.
 //
 // SECURITY: the only path that reaches the spawn is `diagramsDir`, derived from
 // `workspacePath` + the `C4_DIAGRAMS_DIR` constant — never a user-controlled
@@ -31,9 +40,9 @@
 // esbuild cannot resolve the `server-only` guard package. Server-only by
 // construction (spawns a CLI), only imported by server code.
 import { spawn } from "node:child_process";
-import { mkdtemp, readFile, copyFile, rename, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import { join } from "node:path";
 import { C4_DIAGRAMS_DIR, C4_MODEL_JSON } from "@/lib/c4-constants";
 
 export type RenderReason =
@@ -44,11 +53,14 @@ export type RenderReason =
   // source is broken (typically a missing spec.c4). Distinct from io_error so
   // the writer surfaces a source-fault diagnostic ONLY for this reason.
   | "empty_model"
-  // Our own IO failed (mkdtemp / parse / copy-publish) — NOT the user's source.
+  // Our own IO failed (mkdtemp / temp read / parse) — NOT the user's source.
   | "io_error";
 
 export type RenderResult =
-  | { ok: true; durationMs: number }
+  // `json` is the raw, validated UTF-8 model string read from the temp export —
+  // returned verbatim (never re-`JSON.stringify`d) so the committed bytes are
+  // byte-identical to what `likec4` produced and we validated.
+  | { ok: true; durationMs: number; json: string }
   | { ok: false; reason: RenderReason; detail?: string };
 
 // Real prod model exports in <1s (verified 2026-06-05); 25s is a ceiling that
@@ -112,10 +124,13 @@ type SpawnResult =
 /**
  * Regenerate `model.likec4.json` by spawning the preinstalled `likec4` CLI
  * (`likec4 export json -o <temp> .`) with cwd = the workspace's diagrams dir,
- * VALIDATE the produced model is non-empty, and only then copy it onto the real
- * `model.likec4.json` (where the GET `/api/kb/c4/project` route reads it as
- * `dump` and the caller commits it). An empty/invalid export returns
- * `{ ok:false, reason:"empty_model" }` and leaves the real file untouched.
+ * VALIDATE the produced model is non-empty, and on success RETURN the validated
+ * bytes as `json`. The caller commits those bytes via the GitHub Contents API
+ * and the resync pull lands them on the clone (where the GET
+ * `/api/kb/c4/project` route reads them as `dump`). The tracked working-tree
+ * `model.likec4.json` is never written by this path (#4976). An empty/invalid
+ * export returns `{ ok:false, reason:"empty_model" }` with no `json`, so the
+ * caller never commits over the previously-good model.
  */
 export async function renderC4Model(
   workspacePath: string,
@@ -133,27 +148,27 @@ async function renderToValidatedModel(
   diagramsDir: string,
 ): Promise<RenderResult> {
   // Render to a per-call temp dir (collision-proof under POOL_SIZE concurrency
-  // + multi-replica tmpfs; mirrors pdf-linearize.ts). The real model.likec4.json
-  // is only touched on validated success, so an invalid render never clobbers
-  // the previously-good model.
+  // + multi-replica tmpfs; mirrors pdf-linearize.ts). The validated bytes are
+  // RETURNED, never published onto the tracked path (#4976), so an invalid
+  // render never clobbers the previously-good committed model and a successful
+  // render never dirties the working tree.
   const dir = await mkdtemp(join(tmpdir(), "c4-render-")).catch(() => null);
   if (!dir) {
     return { ok: false, reason: "io_error", detail: "mkdtemp failed" };
   }
   const tmpOut = join(dir, C4_MODEL_JSON);
-  const realPath = join(diagramsDir, C4_MODEL_JSON);
-  // Same-dir (same-filesystem) staging path so the final publish is an atomic
-  // `rename` — a crash mid-copy can never truncate the previously-good model.
-  // The mkdtemp suffix keeps it collision-proof under the concurrency gate.
-  const stagePath = `${realPath}.stage-${basename(dir)}`;
   try {
     const run = await runLikeC4(diagramsDir, tmpOut);
     if (!run.ok) return run;
 
     // exit 0 — but likec4 exits 0 on unresolved references too, so validate.
+    // Keep the raw read so the returned bytes are byte-identical to the
+    // validated artifact (no re-`JSON.stringify` key-order/whitespace drift).
+    let raw: string;
     let model: { elements?: unknown };
     try {
-      model = JSON.parse(await readFile(tmpOut, "utf8")) as { elements?: unknown };
+      raw = await readFile(tmpOut, "utf8");
+      model = JSON.parse(raw) as { elements?: unknown };
     } catch (err) {
       return {
         ok: false,
@@ -185,11 +200,9 @@ async function renderToValidatedModel(
       };
     }
 
-    // Validated — publish atomically onto the real path the GET reads + the
-    // writer commits: copy into the same-dir stage, then rename over.
-    await copyFile(tmpOut, stagePath);
-    await rename(stagePath, realPath);
-    return { ok: true, durationMs: run.durationMs };
+    // Validated — return the raw bytes; the caller commits them and the resync
+    // pull lands them on disk. The tracked working-tree file is never written.
+    return { ok: true, durationMs: run.durationMs, json: raw };
   } catch (err) {
     return {
       ok: false,
@@ -198,10 +211,8 @@ async function renderToValidatedModel(
     };
   } finally {
     // Trailing .catch so cleanup can never reject the resolved result (mirrors
-    // pdf-linearize.ts). Clean BOTH the temp dir and any leftover stage file
-    // (present only if rename never ran).
+    // pdf-linearize.ts). Clean the per-call temp dir (the only artifact).
     await rm(dir, { recursive: true, force: true }).catch(() => {});
-    await rm(stagePath, { force: true }).catch(() => {});
   }
 }
 

--- a/apps/web-platform/server/c4-writer.ts
+++ b/apps/web-platform/server/c4-writer.ts
@@ -32,9 +32,6 @@ import { renameUserIdToHash } from "@/server/userid-pseudonymize";
 import { reportSilentFallback } from "@/server/observability";
 import { renderC4Model } from "@/server/c4-render";
 import { sanitizeForLog } from "@/lib/log-sanitize";
-import { open } from "node:fs/promises";
-import { constants as fsConstants } from "node:fs";
-import { join } from "node:path";
 import logger from "@/server/logger";
 import * as Sentry from "@sentry/nextjs";
 
@@ -239,7 +236,9 @@ function buildRerenderDiagnostic(detail: string | undefined): string {
  * (with a user-facing `diagnostic` when the cause is the user's source) — the
  * caller has already committed the `.c4` source, so a re-render failure never
  * fails the save, and an empty/invalid render NEVER commits over the good model
- * (renderC4Model validated to a temp file and left the real JSON untouched).
+ * (renderC4Model returns the validated bytes; we commit them and the resync pull
+ * lands the committed bytes on the clone — the tracked working-tree file is never
+ * written by the render path, #4976).
  */
 async function rerenderAndCommit(
   input: RerenderInput,
@@ -271,37 +270,22 @@ async function rerenderAndCommit(
       };
     }
 
-    // Read the regenerated JSON off the diagrams dir (renderC4Model validated
-    // the temp export and copied it onto this real path) and commit it via the
-    // same Contents API path. The path is constant-derived (no user input), but
-    // open with O_NOFOLLOW + an fd-stat size cap to match the GET /project
-    // route's TOCTOU/symlink hardening (CodeQL js/file-system-race) — the
-    // copyFile target could be a planted symlink at this path.
-    const jsonAbsPath = join(
-      workspacePath,
-      "knowledge-base",
-      C4_DIAGRAMS_DIR,
-      C4_MODEL_JSON,
-    );
-    let json: string;
-    const handle = await open(
-      jsonAbsPath,
-      fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
-    );
-    try {
-      const stat = await handle.stat();
-      if (stat.size > MAX_C4_MODEL_BYTES) {
-        reportSilentFallback(new Error(`model.likec4.json ${stat.size}B exceeds cap`), {
-          feature: "c4-rerender",
-          op: "commit-json",
-          extra: { userId, relativePath, size: stat.size },
-          message: "c4 re-render: regenerated model too large to commit",
-        });
-        return { rerendered: false };
-      }
-      json = await handle.readFile("utf8");
-    } finally {
-      await handle.close();
+    // renderC4Model returned the validated bytes in-process (#4976) — commit
+    // them directly via the same Contents API path. No on-disk re-read: the
+    // model is never written to the tracked working tree, so there is no file to
+    // open (and no TOCTOU/symlink surface to harden — the old O_NOFOLLOW+fd-stat
+    // guard existed only because we used to re-read a tracked file a planted
+    // symlink could swap). Cap on the exact bytes we are about to commit.
+    const json = render.json;
+    const size = Buffer.byteLength(json, "utf8");
+    if (size > MAX_C4_MODEL_BYTES) {
+      reportSilentFallback(new Error(`model.likec4.json ${size}B exceeds cap`), {
+        feature: "c4-rerender",
+        op: "commit-json",
+        extra: { userId, relativePath, size },
+        message: "c4 re-render: regenerated model too large to commit",
+      });
+      return { rerendered: false };
     }
 
     let jsonSha: string | undefined;

--- a/apps/web-platform/server/workspace-sync.ts
+++ b/apps/web-platform/server/workspace-sync.ts
@@ -89,7 +89,9 @@ async function resolveDefaultBranch(
  * class emits the error-level `log.error`+`reportSilentFallback` mirror. See
  * Sentry 9ccf1d86… — the unconditional pre-self-heal `log.error({ err })`
  * pino-mirrored to Sentry on every push for a benign, recovered dirty-tree
- * abort (the c4 re-render writes model.likec4.json into the tracked tree).
+ * abort (historically the c4 re-render published model.likec4.json into the
+ * tracked tree; that source was removed in #4976, but the self-heal stays as
+ * general defense against any other dirty-tree cause).
  */
 export async function syncWorkspace(
   installationId: number,
@@ -111,9 +113,10 @@ export async function syncWorkspace(
     const errorClass = classifyGitSyncError(syncError);
 
     if (errorClass === ERROR_CLASS_NON_FAST_FORWARD) {
-      // Self-healable: a diverged clone OR a dirty working tree (e.g. the c4
-      // re-render's tracked-path write to model.likec4.json, or a spurious
-      // mirror edit). A blocked ff-only pull that the gated `reset --hard`
+      // Self-healable: a diverged clone OR a dirty working tree (e.g. a
+      // spurious mirror edit; historically also the c4 re-render's tracked-path
+      // write to model.likec4.json, removed in #4976). A blocked ff-only pull
+      // that the gated `reset --hard`
       // recovers is BENIGN churn — do NOT emit an error-level mirror here. The
       // pino `log.error({ err })` path mirrors to Sentry (logger.ts →
       // captureException, tag feature:"pino-mirror", level error), which paged

--- a/apps/web-platform/test/c4-render.test.ts
+++ b/apps/web-platform/test/c4-render.test.ts
@@ -8,15 +8,18 @@ vi.mock("node:child_process", () => ({ spawn: spawnMock }));
 // Mock node:fs/promises so renderC4Model's temp-dir lifecycle (mkdtemp →
 // readFile(temp) → rm) is deterministic. The fake `readFile` returns whatever
 // model JSON the test stages — that string is what renderC4Model now RETURNS as
-// `json` (#4976: off-tree render, no copy/rename onto the tracked path).
-// `copyFile`/`rename` are kept as spies so a regression that re-introduces an
-// in-place publish is caught by the `.not.toHaveBeenCalled()` assertions below;
-// the source no longer imports them.
+// `json` (#4976: off-tree render, no write onto the tracked path).
+// `copyFile`/`rename`/`writeFile` are kept as spies even though the source no
+// longer imports them: `vi.mock` replaces the WHOLE module, so any regression
+// that re-introduces an in-place publish — via the old `copyFile`+`rename`
+// shape OR a direct `writeFile(realPath, …)` — would call one of these spies and
+// trip the `.not.toHaveBeenCalled()` assertions below.
 const fsMock = vi.hoisted(() => ({
   mkdtemp: vi.fn(),
   readFile: vi.fn(),
   copyFile: vi.fn(),
   rename: vi.fn(),
+  writeFile: vi.fn(),
   rm: vi.fn(),
 }));
 vi.mock("node:fs/promises", () => fsMock);
@@ -68,6 +71,7 @@ beforeEach(() => {
   fsMock.readFile.mockReset().mockResolvedValue(VALID_MODEL);
   fsMock.copyFile.mockReset().mockResolvedValue(undefined);
   fsMock.rename.mockReset().mockResolvedValue(undefined);
+  fsMock.writeFile.mockReset().mockResolvedValue(undefined);
   fsMock.rm.mockReset().mockResolvedValue(undefined);
   vi.useRealTimers();
 });
@@ -124,10 +128,11 @@ describe("renderC4Model", () => {
     // the writer commits exactly what likec4 produced — never re-stringified.
     if (res.ok) expect(res.json).toBe(VALID_MODEL);
     // #4976: the tracked model.likec4.json is never published onto — the render
-    // produces only a process-temp artifact. No copy/rename onto any path.
+    // produces only a process-temp artifact. No copy/rename/write onto any path.
     expect(fsMock.copyFile).not.toHaveBeenCalled();
     expect(fsMock.rename).not.toHaveBeenCalled();
-    // Temp dir always cleaned.
+    expect(fsMock.writeFile).not.toHaveBeenCalled();
+    // The ONLY fs mutation is the temp-dir cleanup (proves temp-only lifecycle).
     expect(fsMock.rm).toHaveBeenCalledWith(
       TMP_DIR,
       expect.objectContaining({ recursive: true, force: true }),

--- a/apps/web-platform/test/c4-render.test.ts
+++ b/apps/web-platform/test/c4-render.test.ts
@@ -6,8 +6,12 @@ const spawnMock = vi.hoisted(() => vi.fn());
 vi.mock("node:child_process", () => ({ spawn: spawnMock }));
 
 // Mock node:fs/promises so renderC4Model's temp-dir lifecycle (mkdtemp →
-// readFile(temp) → copyFile(temp→real) → rm) is deterministic. The fake
-// `readFile` returns whatever model JSON the test stages.
+// readFile(temp) → rm) is deterministic. The fake `readFile` returns whatever
+// model JSON the test stages — that string is what renderC4Model now RETURNS as
+// `json` (#4976: off-tree render, no copy/rename onto the tracked path).
+// `copyFile`/`rename` are kept as spies so a regression that re-introduces an
+// in-place publish is caught by the `.not.toHaveBeenCalled()` assertions below;
+// the source no longer imports them.
 const fsMock = vi.hoisted(() => ({
   mkdtemp: vi.fn(),
   readFile: vi.fn(),
@@ -74,10 +78,6 @@ afterEach(() => {
 
 const WS = "/workspaces/ws-1";
 const EXPECTED_CWD = "/workspaces/ws-1/knowledge-base/engineering/architecture/diagrams";
-const REAL_JSON = `${EXPECTED_CWD}/model.likec4.json`;
-// Atomic publish stages into a same-dir sibling (suffix = the mkdtemp basename)
-// then renames over the real path.
-const STAGE = `${REAL_JSON}.stage-c4-render-abc123`;
 
 describe("renderC4Model", () => {
   it("spawns the likec4 CLI into a temp -o path in the scope-guarded diagrams dir", async () => {
@@ -113,20 +113,20 @@ describe("renderC4Model", () => {
     expect(env).not.toHaveProperty("SUPABASE_SERVICE_ROLE_KEY");
   });
 
-  it("copies the validated temp model onto the real path on a non-empty export", async () => {
+  it("returns the validated temp model as `json` and NEVER writes the tracked path on a non-empty export", async () => {
     const child = makeChild();
     fsMock.readFile.mockResolvedValue(VALID_MODEL);
     spawnThenEmit(child, () => child.emit("close", 0, null));
     const p = renderC4Model(WS);
     const res = await p;
     expect(res.ok).toBe(true);
-    // Validated → published atomically: copy into the same-dir stage, then
-    // rename over the real model.likec4.json (where GET reads + writer commits).
-    expect(fsMock.copyFile).toHaveBeenCalledWith(
-      `${TMP_DIR}/model.likec4.json`,
-      STAGE,
-    );
-    expect(fsMock.rename).toHaveBeenCalledWith(STAGE, REAL_JSON);
+    // The validated bytes are RETURNED verbatim (byte-identical to the read), so
+    // the writer commits exactly what likec4 produced — never re-stringified.
+    if (res.ok) expect(res.json).toBe(VALID_MODEL);
+    // #4976: the tracked model.likec4.json is never published onto — the render
+    // produces only a process-temp artifact. No copy/rename onto any path.
+    expect(fsMock.copyFile).not.toHaveBeenCalled();
+    expect(fsMock.rename).not.toHaveBeenCalled();
     // Temp dir always cleaned.
     expect(fsMock.rm).toHaveBeenCalledWith(
       TMP_DIR,
@@ -142,6 +142,8 @@ describe("renderC4Model", () => {
     const res = await renderC4Model(WS);
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.reason).toBe("empty_model");
+    // No `json` on a failed render → the writer can never commit a bad model.
+    expect(Object.prototype.hasOwnProperty.call(res, "json")).toBe(false);
     expect(fsMock.copyFile).not.toHaveBeenCalled();
     expect(fsMock.rename).not.toHaveBeenCalled();
   });
@@ -168,6 +170,8 @@ describe("renderC4Model", () => {
       // on stderr substring).
       expect(res.detail).toContain("Could not resolve reference");
     }
+    // No committable bytes leak out of a failed render.
+    expect(Object.prototype.hasOwnProperty.call(res, "json")).toBe(false);
     // The real model.likec4.json was NEVER overwritten with the empty export.
     expect(fsMock.copyFile).not.toHaveBeenCalled();
     // Temp dir still cleaned.
@@ -189,6 +193,7 @@ describe("renderC4Model", () => {
       expect(res.reason).toBe("io_error");
       expect(res.detail).toContain("parse failed");
     }
+    expect(Object.prototype.hasOwnProperty.call(res, "json")).toBe(false);
     expect(fsMock.copyFile).not.toHaveBeenCalled();
   });
 

--- a/apps/web-platform/test/c4-writer-rerender.test.ts
+++ b/apps/web-platform/test/c4-writer-rerender.test.ts
@@ -5,10 +5,6 @@ const mocks = vi.hoisted(() => ({
   githubApiPost: vi.fn(),
   syncWorkspace: vi.fn(),
   renderC4Model: vi.fn(),
-  open: vi.fn(),
-  stat: vi.fn(),
-  readFile: vi.fn(),
-  close: vi.fn(),
   reportSilentFallback: vi.fn(),
 }));
 
@@ -25,10 +21,6 @@ vi.mock("@/server/github-api", () => ({
 }));
 vi.mock("@/server/workspace-sync", () => ({ syncWorkspace: mocks.syncWorkspace }));
 vi.mock("@/server/c4-render", () => ({ renderC4Model: mocks.renderC4Model }));
-vi.mock("node:fs/promises", () => ({ open: mocks.open }));
-vi.mock("node:fs", () => ({
-  constants: { O_RDONLY: 0, O_NOFOLLOW: 0 },
-}));
 vi.mock("@/server/observability", async () => {
   const actual = await vi.importActual<typeof import("@/server/observability")>(
     "@/server/observability",
@@ -54,21 +46,21 @@ function source(relativePath: string, content = "model { }") {
   return { ...BASE, relativePath, content };
 }
 
+// The validated bytes renderC4Model now returns (#4976) — the writer commits
+// these directly, no on-disk re-read.
+const RENDERED_JSON = '{"_stage":"layouted"}';
+
 beforeEach(() => {
   Object.values(mocks).forEach((m) => m.mockReset());
-  // Defaults: blob sha resolves, commits succeed, sync ok, render ok, JSON read ok.
+  // Defaults: blob sha resolves, commits succeed, sync ok, render ok (carrying
+  // the validated bytes the writer commits).
   mocks.githubApiGet.mockResolvedValue({ sha: "blobsha", type: "file" });
   mocks.githubApiPost.mockResolvedValue({ commit: { sha: "commit123" } });
   mocks.syncWorkspace.mockResolvedValue({ ok: true });
-  mocks.renderC4Model.mockResolvedValue({ ok: true, durationMs: 12 });
-  // Fake FileHandle: stat (size under cap) + readFile + close.
-  mocks.stat.mockResolvedValue({ size: 1024 });
-  mocks.readFile.mockResolvedValue('{"_stage":"layouted"}');
-  mocks.close.mockResolvedValue(undefined);
-  mocks.open.mockResolvedValue({
-    stat: mocks.stat,
-    readFile: mocks.readFile,
-    close: mocks.close,
+  mocks.renderC4Model.mockResolvedValue({
+    ok: true,
+    durationMs: 12,
+    json: RENDERED_JSON,
   });
 });
 
@@ -89,6 +81,12 @@ describe("writeC4Diagram — Layer 2 re-render", () => {
       String(c[1]).endsWith("/diagrams/model.likec4.json"),
     );
     expect(jsonCommit).toBeDefined();
+    // #4976: the writer commits EXACTLY the bytes renderC4Model returned — the
+    // base64 `content` decodes back to render.json (pins producer→consumer).
+    const committedContent = (jsonCommit![2] as { content: string }).content;
+    expect(Buffer.from(committedContent, "base64").toString("utf8")).toBe(
+      RENDERED_JSON,
+    );
     // two syncs: one after the .c4 commit, one after the JSON commit
     expect(mocks.syncWorkspace.mock.calls.length).toBe(2);
 
@@ -105,7 +103,12 @@ describe("writeC4Diagram — Layer 2 re-render", () => {
   });
 
   it("AC2c: an oversized regenerated model is NOT committed (size cap)", async () => {
-    mocks.stat.mockResolvedValue({ size: 8 * 1024 * 1024 }); // > 4 MB cap
+    // Cap is enforced on the RETURNED bytes now (#4976), not a mocked fd-stat.
+    mocks.renderC4Model.mockResolvedValue({
+      ok: true,
+      durationMs: 12,
+      json: "x".repeat(8 * 1024 * 1024), // > 4 MB cap
+    });
     const res = await writeC4Diagram(source(C4));
     expect(res.ok).toBe(true);
     if (!res.ok) return;
@@ -164,7 +167,11 @@ describe("writeC4Diagram — Layer 2 re-render", () => {
   });
 
   it("AC2e: a non-source-fault failure (oversized model) carries NO rerenderDiagnostic", async () => {
-    mocks.stat.mockResolvedValue({ size: 8 * 1024 * 1024 });
+    mocks.renderC4Model.mockResolvedValue({
+      ok: true,
+      durationMs: 12,
+      json: "x".repeat(8 * 1024 * 1024),
+    });
     const res = await writeC4Diagram(source(C4));
     expect(res.ok).toBe(true);
     if (!res.ok) return;

--- a/knowledge-base/project/learnings/best-practices/2026-06-05-render-off-tree-return-bytes-and-drop-toctou-with-the-reread.md
+++ b/knowledge-base/project/learnings/best-practices/2026-06-05-render-off-tree-return-bytes-and-drop-toctou-with-the-reread.md
@@ -1,0 +1,92 @@
+---
+title: "Render off-tree: return bytes (caller owns persistence) and drop the TOCTOU guard with the re-read it protected"
+date: 2026-06-05
+issue: 4976
+pr: 4979
+category: best-practices
+module: apps/web-platform/server/c4-render.ts, c4-writer.ts
+tags: [refactor, observability, security, toctou, git-reconcile, producer-consumer]
+---
+
+# Learning: render off-tree — return bytes, and remove TOCTOU hardening together with the re-read it guarded
+
+## Problem
+
+A server render helper (`renderC4Model`, `apps/web-platform/server/c4-render.ts`)
+validated a `likec4 export json` artifact in a temp dir and then **published it
+onto the tracked working-tree path** (`<diagramsDir>/model.likec4.json` via
+`copyFile`→`rename`). Its caller (`rerenderAndCommit`, `c4-writer.ts`) re-opened
+that tracked file (`open(O_RDONLY | O_NOFOLLOW)` + fd-stat 4 MB cap + `readFile`),
+committed the bytes via the GitHub Contents API, and re-synced the clone.
+
+That in-place write was a **reconcile dirty-tree churn source** (#4976):
+- Success path: every `.c4` save left the working tree dirty, so the subsequent
+  `git pull --ff-only` aborted `non_fast_forward` → a gated `reset --hard`
+  self-heal fired on every save (wasteful; silenced-to-error only after #4972).
+- Failure path: any early-return/throw after the render-write stranded the
+  uncommitted file, dirtying the NEXT webhook reconcile (the original Sentry
+  symptom 9ccf1d86 that #4972 only de-noised).
+
+## Solution (Option A — render off-tree)
+
+`renderC4Model` now **returns the validated bytes** (`{ ok, durationMs, json }`)
+instead of writing the tracked path; `rerenderAndCommit` commits `render.json`
+directly and the existing `op:"manual"` resync `git pull --ff-only` (now clean →
+fast-forwards) brings the committed JSON to disk where `GET /api/kb/c4/project`
+(the sole on-disk reader) serves it. The render never touches a tracked path, so
+the dirty-tree source is removed **by construction**.
+
+Two non-obvious moves that the multi-agent review confirmed correct:
+
+1. **Removing the on-disk re-read lets you remove its O_NOFOLLOW/TOCTOU guard —
+   the surface is *gone*, not merely unguarded.** The `open(O_NOFOLLOW)`+fd-stat
+   hardening (CodeQL `js/file-system-race`) existed *only* because the writer
+   re-read a tracked file a planted symlink could swap. Once the bytes come back
+   in-process there is no on-disk round-trip to harden. The 4 MB cap moves to
+   `Buffer.byteLength(render.json, "utf8")` — measuring the *exact* bytes about
+   to be committed, strictly more accurate than the old `stat.size`. (The reader
+   that still touches disk — `GET /project` — keeps its own O_NOFOLLOW.)
+2. **Return the raw validated `utf8` string, never a re-`JSON.stringify`.** The
+   committed bytes must be byte-identical to what `likec4` produced and you
+   validated — re-encoding risks key-order/whitespace drift. Pin it with a test
+   that base64-decodes the GitHub PUT `content` back to the returned string.
+
+## Key Insight
+
+When a producing helper writes its output onto a tracked/destination path and a
+consumer re-reads it, the in-place write is the smell. **Return the bytes and let
+the caller own persistence** — this is usually the codebase-canonical shape
+(here `pdf-linearize.ts`, the helper's own cited precedent, already returned
+`{ ok, buffer }`). Option A (remove the source by construction) beats Option B
+(restore-on-every-exit / `git checkout --`), which re-introduces git mutations on
+the hot path and leaves a wide defensive exit matrix.
+
+Corollary for reviewers/refactorers: **a security guard is only load-bearing
+while the thing it guards exists.** When you delete a re-read/round-trip, audit
+whether its TOCTOU/symlink hardening is now guarding nothing — keeping it is
+cargo-cult, removing it (with the re-read) is the correct net-reduction. Confirm
+with a SAST pass that no NEW file-system-race pattern was introduced elsewhere.
+
+Test-guard note: a `.not.toHaveBeenCalled()` spy on a symbol the source no longer
+imports is near-vacuous. Because `vi.mock("node:fs/promises", () => fsMock)`
+replaces the WHOLE module, keep the spy AND add the *most likely* regression
+shape (`writeFile`) so the guard catches a re-introduced in-place publish in any
+form, not just the exact prior `copyFile`+`rename`.
+
+## Session Errors
+
+1. **(forwarded) Plan write-hook blocks self-corrected.** The IaC-routing gate
+   fired on negation prose in the plan ("introduces no `doppler secrets set`…");
+   reworded + added an `iac-routing-ack`. An initial plan write targeted the
+   bare-root synced mirror instead of the worktree. — Recovery: redirect to the
+   worktree path. — Prevention: already-enforced by the plan subagent's Step-0
+   CWD-verification guard, which caught the mirror write.
+2. **(forwarded) `Task` tool absent from the planning subagent's deferred-tool
+   set**, so deepen-plan ran gates 4.6–4.9 + verify-the-negative + precedent-diff
+   directly instead of via fan-out agents. — Recovery: ran them inline; plan
+   quality unaffected. — Prevention: one-off harness tool-set config; no workflow
+   change warranted.
+3. **`git grep --include='*.ts'` failed twice** ("unknown option `include`") — I
+   used GNU-grep syntax. — Recovery: switched to the pathspec form
+   `git grep -nE '<pat>' -- '*.ts'`. — Prevention: `git grep` scopes by trailing
+   pathspec, not `--include`; reach for `-- '*.ext'` (or `:(glob)`).

--- a/knowledge-base/project/plans/2026-06-05-fix-c4-render-off-tree-plan.md
+++ b/knowledge-base/project/plans/2026-06-05-fix-c4-render-off-tree-plan.md
@@ -1,0 +1,465 @@
+<!-- iac-routing-ack: plan-phase-2-8-reviewed -->
+---
+title: "Harden c4 re-render: render model.likec4.json off-tree (Option A)"
+issue: 4976
+type: fix
+classification: code-hardening
+lane: cross-domain
+brand_survival_threshold: none
+requires_cpo_signoff: false
+date: 2026-06-05
+branch: feat-one-shot-4976-c4-render-off-tree
+---
+
+# fix: Render `model.likec4.json` off-tree — stop dirtying the tracked working tree on every `.c4` save
+
+> Spec lacks valid `lane:` — defaulted to `cross-domain` (TR2 fail-closed).
+
+## Overview
+
+`renderC4Model` (`apps/web-platform/server/c4-render.ts`) currently publishes the
+regenerated `model.likec4.json` **directly onto the tracked working-tree path**
+(`<diagramsDir>/model.likec4.json`, via `copyFile`→`rename` at `c4-render.ts:190-191`)
+on validated success. `rerenderAndCommit` (`c4-writer.ts:244`) then reads those bytes
+back off that same tracked path (`c4-writer.ts:280-305`) and commits them through the
+GitHub Contents API, then re-syncs the clone with `syncWorkspace(... op:"manual")`
+(`c4-writer.ts:329`).
+
+This tracked-path write is the **source of reconcile dirty-tree churn**:
+
+1. **Success path (every `.c4` save):** the uncommitted working-tree write collides
+   with the subsequent `git pull --ff-only` (local file change vs. the incoming
+   identical-bytes commit) → `non_fast_forward` dirty-tree abort → the gated
+   `reset --hard` self-heal fires **every single time**. After the #4972 de-noise fix
+   this is silent-to-error (only a `warn`-level `op:self-heal-reset` per occurrence),
+   but it is wasteful churn on the hot post-save path.
+2. **Failure path:** any early-return/throw in `rerenderAndCommit` **after** the render
+   write but **before** the final resync — the oversized-model early return
+   (`c4-writer.ts:300`), a `commit-json` throw (`c4-writer.ts:318`), or a resync failure
+   (`c4-writer.ts:340`) — **strands** the uncommitted `model.likec4.json` in the working
+   tree. That stranded file then dirties the **next webhook-push reconcile**
+   (`syncWorkspace(... op:"push")`) — the original Sentry symptom
+   `9ccf1d861b3b4c8595772bd116b931e8` that #4972 only de-noised, not removed.
+
+**Chosen fix — Option A (render off-tree).** `renderC4Model` writes the validated
+model only to a process-temp path and **returns the bytes** (plus duration) instead of
+copying onto the tracked file. `rerenderAndCommit` commits the returned bytes via the
+Contents API exactly as today, then the existing `op:"manual"` resync `git pull --ff-only`
+fast-forwards cleanly (working tree is no longer dirty) and brings the committed JSON
+down onto disk. The `GET /api/kb/c4/project` route — the **sole on-disk reader** of
+`model.likec4.json` — continues to read the committed bytes from the clone, now placed
+there by the pull rather than by the render write. **The tracked working-tree file is
+never written by the render path again.**
+
+Option A was chosen over Option B (restore-on-every-exit via `git checkout -- <file>`)
+because Option B re-introduces git mutations into the hot path and leaves a wider
+matrix of exit-paths to cover defensively; Option A removes the dirty-tree source
+entirely by construction (the render never touches a tracked path), which is the
+structurally simpler and more durable fix. The issue itself flags Option A as "cleaner
+but a larger change" — the larger surface is confined to two server modules plus their
+two unit tests, all enumerated below, with no client/route/schema/infra change.
+
+This is a robustness/efficiency hardening change. It introduces **no new
+infrastructure, no new dependency, no schema change, and no UI surface.**
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Spec / issue claim | Codebase reality (verified) | Plan response |
+| --- | --- | --- |
+| `renderC4Model` writes onto the tracked path at `c4-render.ts:144,191` | Confirmed: `realPath` built at `:144`; `copyFile(tmpOut, stagePath)` `:190` then `rename(stagePath, realPath)` `:191` publish onto the tracked file. | Remove the publish; return bytes instead. |
+| `rerenderAndCommit` reads the model off the tracked path then commits | Confirmed: opens `jsonAbsPath` (`workspacePath/knowledge-base/<dir>/model.likec4.json`) with `O_NOFOLLOW`, stat-size-caps, `readFile`, commits (`c4-writer.ts:280-327`). | Replace the on-disk read with the bytes returned by `renderC4Model`; keep the size cap on the returned bytes (no fd/`O_NOFOLLOW` needed once we no longer read a tracked file). |
+| GET `/project` reads the committed `model.likec4.json` after pull | Confirmed: `app/api/kb/c4/project/route.ts` opens `<kbRoot>/<dir>/model.likec4.json` (`O_NOFOLLOW`, size-cap) and returns `dump`. **Sole on-disk reader.** | **No change.** Option A keeps the committed bytes landing on disk via the `op:"manual"` resync pull, so the GET reads them exactly as today. |
+| `[...path]` route also reads the model | NOT a reader — `app/api/kb/c4/[...path]/route.ts` only references `model.likec4.json` in a comment. | No change; no hidden second reader. |
+| Existing `c4-writer-rerender.test.ts` + `kb-route-helpers.test.ts` must stay green | Confirmed both exist; `c4-render.test.ts` also exists and asserts the copyFile/rename publish (lines 116-135, 144-147, 224-225, 260) — **these assertions change under Option A**. | Update `c4-render.test.ts` + `c4-writer-rerender.test.ts` to the new bytes-returning contract; `kb-route-helpers.test.ts` self-heal tests are render-independent and stay verbatim-green. |
+| #4972 de-noise PR is the predecessor | Confirmed merged (`3371005b`, "stop error-level Sentry page for a self-healed reconcile ff-only abort"). | Plan builds on it; this issue is the deferred source-hardening follow-up. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a stale or blank LikeC4 diagram in the
+KB Architecture view after a Code-tab Save (the GET `/project` reads a `model.likec4.json`
+that the resync pull failed to update), OR — if the off-tree change is mis-wired — the
+*same* dirty-tree self-heal churn this change is meant to remove (no regression beyond
+status quo, which is already benign/silent post-#4972).
+
+**If this leaks, the user's data is exposed via:** N/A. The change moves a render
+artifact from a tracked path to a process-temp path and returns bytes in-process; it
+adds no new persistence, no new network egress, no new log field, and no new
+user-controlled input to the spawn (argv stays fixed, cwd stays the constant-derived
+diagrams dir). No data-exposure vector is opened or widened.
+
+**Brand-survival threshold:** none.
+`threshold: none, reason: the worst realistic failure is a per-user stale-diagram banner that self-heals on the next reconcile — no data leak, no aggregate or cross-tenant impact; the diff touches no auth/migration/API-key/secrets sensitive path.`
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- **AC1 — render returns bytes, never writes the tracked path.** `renderC4Model` (and its
+  inner `renderToValidatedModel`) no longer calls `copyFile`/`rename` onto
+  `<diagramsDir>/model.likec4.json`. On validated success it returns
+  `{ ok: true, durationMs, json: <validated-model-string> }`. Verify in
+  `c4-render.test.ts`: assert the success result carries the model JSON and assert
+  `copyFile`/`rename` are **not** called on the real path on any path (success, empty,
+  io_error, timeout). Grep gate: `grep -nE 'copyFile|rename' apps/web-platform/server/c4-render.ts`
+  returns no call that targets `realPath`/`stagePath` (the same-dir staging machinery for
+  the tracked file is removed).
+- **AC2 — writer commits the returned bytes, never re-reads the tracked file.**
+  `rerenderAndCommit` consumes `render.json` from the `renderC4Model` result and commits it
+  via `githubApiPost(... model.likec4.json ...)`. The `open(jsonAbsPath, O_NOFOLLOW)` +
+  `handle.stat()` + `handle.readFile()` block (`c4-writer.ts:287-305`) is removed; the
+  4 MB cap is enforced on `Buffer.byteLength(render.json, "utf8")` before the commit.
+  Grep gate: `grep -nE 'O_NOFOLLOW|jsonAbsPath|handle\.stat' apps/web-platform/server/c4-writer.ts`
+  returns nothing.
+- **AC3 — oversized regenerated model still NOT committed.** When the returned bytes exceed
+  `MAX_C4_MODEL_BYTES` (4 MB), `rerenderAndCommit` returns `{ rerendered: false }`, makes no
+  JSON commit, and calls `reportSilentFallback` with `op:"commit-json"` — preserving the
+  semantics of existing test AC2c. (`c4-writer-rerender.test.ts` AC2c stays green after the
+  fixture is adapted to size the *returned bytes* rather than a mocked `handle.stat`.)
+- **AC4 — no dirty-tree self-heal on the success path (the core fix).** A `.c4` save that
+  re-renders successfully leaves the working tree clean *before* the JSON commit's resync,
+  so the `op:"manual"` `git pull --ff-only` fast-forwards without a `non_fast_forward`
+  abort. Verified at the unit boundary: in `c4-writer-rerender.test.ts` the second
+  `syncWorkspace` call (after the JSON commit) is invoked with `op:"manual"` and the test
+  no longer needs to mock any tracked-file write between render and resync. (The end-to-end
+  "no `reset --hard`" assertion is covered by the structural change — no tracked write
+  exists to dirty the tree — and documented in the PR body.)
+- **AC5 — failure path strands nothing.** On any `rerenderAndCommit` early-return/throw
+  after render (oversized model, commit-json throw, resync failure), the working tree is
+  unchanged because the render produced only a process-temp artifact (cleaned in its
+  `finally`). Verified: `c4-writer-rerender.test.ts` AC2/AC2b/AC2c/AC2d/AC2e assert
+  `rerendered:false` + `reportSilentFallback` called, and assert **no** tracked-path write
+  occurs on those branches (no `copyFile`/`rename`/fs write mocked or expected).
+- **AC6 — empty/invalid render still never commits over the good model.** An `empty_model`
+  or `io_error` render result returns `{ ok:false, reason }` with **no `json`** field, so
+  `rerenderAndCommit` never commits and the previously-good committed model is untouched
+  (preserves #4966/#4967 validate-before-clobber). `c4-render.test.ts` empty/non-object/
+  non-JSON cases assert the result has `ok:false` and no `json` payload.
+- **AC7 — GET `/project` unchanged and still serves fresh bytes.** No edit to
+  `app/api/kb/c4/project/route.ts`. After a successful re-render + resync, the committed
+  `model.likec4.json` is on disk via the pull, so the client `reload()` reads the fresh
+  `dump`. (Asserted by inspection + the existing route's behavior; the route's on-disk read
+  contract is unchanged.)
+- **AC8 — existing self-heal tests stay green verbatim.** `kb-route-helpers.test.ts`
+  `describe("syncWorkspace")` self-heal tests (non-FF classify, dirty-tree self-heal,
+  de-noise no-error-mirror, un-pushed-commit gate) require **no edit** and pass unchanged —
+  the render path is not in their scope.
+- **AC9 — full suite green.** `./node_modules/.bin/vitest run test/c4-render.test.ts
+  test/c4-writer-rerender.test.ts test/kb-route-helpers.test.ts` (from
+  `apps/web-platform/`) passes, and `npx tsc --noEmit` is clean (the
+  `renderC4Model` return-type widening is honored at every call site — currently the single
+  caller `rerenderAndCommit`).
+
+### Post-merge (operator)
+
+- None. This is a pure code change against an already-provisioned surface; the
+  `web-platform-release.yml` pipeline restarts the container on merge to main that touches
+  `apps/web-platform/**`, so the merge IS the deploy. No migration, no secret/Doppler
+  mutation, no Terraform, no vendor-dashboard step.
+  - **Automation note:** the dogfood verification that a real `.c4` Save re-renders without
+    a self-heal is tracked separately by #4966 (already-open dogfood issue); this plan does
+    not re-file it.
+
+## Implementation Phases
+
+> Single atomic PR. Phases are ordered by contract-dependency (the producer
+> `renderC4Model` return-type change lands before the consumer `rerenderAndCommit` change)
+> so no phase leaves dead code. TDD per the constitution: write/adapt the failing test,
+> then make it green.
+
+### Phase 0 — Preconditions (verify-before-code)
+
+- [ ] Confirm `renderC4Model`'s only caller is `rerenderAndCommit`:
+      `git grep -n 'renderC4Model' apps/web-platform` → expect `c4-render.ts` (def +
+      export), `c4-writer.ts` (import + call), `c4-writer-rerender.test.ts` (mock),
+      `c4-render.test.ts` (import). No other production caller → the return-type widening
+      is contained.
+- [ ] Confirm GET `/project` is the sole on-disk reader of `model.likec4.json`:
+      `git grep -nE 'C4_MODEL_JSON|model\.likec4\.json' apps/web-platform --include='*.ts'`
+      and verify only `project/route.ts` performs a `readFile`/`open` of it (writer's read
+      is being removed; `[...path]` route only comments on it).
+- [ ] Confirm test runner + paths: `apps/web-platform/vitest.config.ts` `include`
+      collects `test/**/*.test.ts` (node project) — all three target tests qualify. Runner
+      is vitest (`package.json scripts.test: "vitest"`); invoke via
+      `./node_modules/.bin/vitest run <paths>`.
+
+### Phase 1 — `c4-render.ts`: return bytes, drop the tracked-path publish (producer)
+
+- [ ] Widen `RenderResult` success variant to
+      `{ ok: true; durationMs: number; json: string }`.
+- [ ] In `renderToValidatedModel`: on validated success, return
+      `{ ok: true, durationMs: run.durationMs, json: <the raw temp-read string> }`. Bind the
+      `utf8` read at `c4-render.ts:156` into a local `const raw = await readFile(tmpOut,"utf8")`,
+      `JSON.parse(raw)` for validation, and return `raw` as `json` so the committed bytes
+      are byte-identical to the validated artifact — do not re-`JSON.stringify` (avoids
+      key-order/whitespace drift).
+- [ ] **Delete** the same-dir staging machinery used only for the tracked-file publish:
+      `realPath` (`:144`), `stagePath` (`:148`), the `copyFile`+`rename` publish (`:190-191`),
+      and the trailing `rm(stagePath, …)` cleanup (`:204`). Keep the temp-dir `mkdtemp` +
+      `rm(dir, …)` lifecycle (still needed for the spawn's `-o` target and cleanup).
+- [ ] Remove now-unused imports (`copyFile`, `rename`, `basename` if no longer referenced)
+      from the `node:fs/promises` / `node:path` import lines — let `tsc`/lint confirm.
+- [ ] Update the module header comment block (lines 12-20, 112-118) so the
+      "copy it onto the real `model.likec4.json`" / "where the GET reads it … and the caller
+      commits it" prose reflects the new "return the validated bytes; the writer commits
+      them and the resync pull lands them on disk" contract.
+
+### Phase 2 — `c4-render.test.ts`: assert the new contract (producer test)
+
+- [ ] Replace the copyFile/rename publish assertions (success test lines 116-135) with:
+      success result is `ok:true` and `res.json` equals the staged `VALID_MODEL`; assert
+      `fsMock.copyFile`/`fsMock.rename` are **not** called.
+- [ ] Drop the `STAGE`/`REAL_JSON` fixtures and the `copyFile`/`rename` entries from
+      `fsMock` (no longer part of the success path). Keep `mkdtemp`/`readFile`/`rm`.
+- [ ] In every failure case (empty-elements, non-object elements, non-JSON, non-zero exit,
+      spawn_error, timeout): assert the result has no `json` field (so the writer can never
+      commit on a failed render) and that no publish occurred (already asserted; tighten to
+      the new shape).
+- [ ] The spawn/argv/env scope assertions (lines 83-114) are unchanged — the `-o` temp
+      target and scoped env are unaffected by Option A.
+
+### Phase 3 — `c4-writer.ts`: commit the returned bytes (consumer)
+
+- [ ] In `rerenderAndCommit`, after `const render = await renderC4Model(workspacePath)`
+      and the `!render.ok` early-return, use `render.json` directly: cap-check
+      `Buffer.byteLength(render.json, "utf8") > MAX_C4_MODEL_BYTES` → `reportSilentFallback`
+      (`op:"commit-json"`, `extra:{ userId, relativePath, size }`,
+      `message:"c4 re-render: regenerated model too large to commit"`) + return
+      `{ rerendered:false }` (preserves AC2c semantics; `size` is now the byte length of the
+      returned string).
+- [ ] **Delete** the `open(jsonAbsPath, O_NOFOLLOW)` + `handle.stat()` size-cap +
+      `handle.readFile()` + `handle.close()` block (`c4-writer.ts:280-305`) and the
+      `jsonAbsPath` construction. The TOCTOU/`O_NOFOLLOW` hardening existed because we were
+      re-reading a tracked file that a planted symlink could swap; once we commit the
+      in-process returned bytes there is no on-disk re-read to harden. Remove the now-unused
+      `open` / `constants as fsConstants` / `join` imports if they become unreferenced
+      (let `tsc`/lint confirm; `join` may still be used elsewhere — check).
+- [ ] Keep the rest of the commit flow byte-for-byte: blob-sha resolve
+      (`githubApiGet`), `githubApiPost(... jsonFilePath ...)`, and the `op:"manual"`
+      `syncWorkspace` resync + its `!resync.ok` `reportSilentFallback(op:"resync")`. The
+      success `logger.info({ event:"c4_rerender", … durationMs: render.durationMs })` still
+      reads `render.durationMs` (now alongside `render.json`).
+- [ ] Update the `rerenderAndCommit` doc comment (`c4-writer.ts:233-243`) so the
+      "renderC4Model validated to a temp file and left the real JSON untouched" /
+      "Read the regenerated JSON off the diagrams dir" prose reflects the new
+      "renderC4Model returns the validated bytes; we commit them and the resync pull lands
+      the committed bytes on the clone" contract.
+
+### Phase 4 — `c4-writer-rerender.test.ts`: adapt the consumer mock (consumer test)
+
+- [ ] Change the `renderC4Model` mock default to resolve
+      `{ ok:true, durationMs:12, json:'{"_stage":"layouted"}' }` (carry the JSON the writer
+      now commits) instead of `{ ok:true, durationMs:12 }`.
+- [ ] **Remove** the `node:fs/promises` `open` mock + the `stat`/`readFile`/`close`
+      FileHandle fakes (lines 9-12, 27, 65-74) — the writer no longer opens a file. The
+      AC2c oversized case (lines 152-163) now sizes the **mocked `render.json`** above 4 MB
+      (e.g. `json: "x".repeat(8 * 1024 * 1024)`) rather than mocking `stat.size`.
+- [ ] AC1/AC2/AC2b/AC2d/AC2e/AC3/OUT_OF_SCOPE/first-sync-failure tests: keep their
+      assertions on commit ordering, `rerendered`, `rerenderDiagnostic`, and
+      `reportSilentFallback`. Verify the JSON-commit assertion
+      (`endsWith("/diagrams/model.likec4.json")`) still holds — the commit still happens; only
+      the bytes' provenance changed (mock result vs. mocked file read).
+- [ ] Add an assertion to AC1 (or a new sibling test) that the writer commits the bytes
+      returned by `renderC4Model` (the `githubApiPost` JSON-commit `content` base64-decodes
+      to `render.json`), pinning the new producer→consumer contract.
+
+### Phase 5 — Verify
+
+- [ ] `./node_modules/.bin/vitest run test/c4-render.test.ts test/c4-writer-rerender.test.ts
+      test/kb-route-helpers.test.ts` (from `apps/web-platform/`) → all green; confirm
+      `kb-route-helpers.test.ts` self-heal tests passed **without edit**.
+- [ ] `npx tsc --noEmit` (web-platform) → clean; the widened `RenderResult` is honored at
+      the sole call site.
+- [ ] Run the broader server suite if cheap (`./node_modules/.bin/vitest run test/` scoped
+      to changed-area files) to catch any incidental importer.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: successful c4 re-render emits logger.info { event:"c4_rerender", path, durationMs }
+  cadence: per .c4 Code-tab/Concierge save (user-triggered, not periodic)
+  alert_target: none (success breadcrumb; not an alerting signal)
+  configured_in: apps/web-platform/server/c4-writer.ts (rerenderAndCommit success branch)
+error_reporting:
+  destination: Sentry via reportSilentFallback (feature:"c4-rerender") — existing helper, unchanged by this plan
+  fail_loud: true (warn+ mirrors to Sentry per observability.ts; render/commit/resync failures already routed)
+failure_modes:
+  - mode: render returns ok:false (empty_model / io_error / timeout / non_zero_exit / spawn_error)
+    detection: rerenderAndCommit !render.ok branch reports via reportSilentFallback op:"render"
+    alert_route: Sentry feature:c4-rerender op:render (unchanged)
+  - mode: returned model exceeds 4 MB cap
+    detection: Buffer.byteLength(render.json) over MAX_C4_MODEL_BYTES reports via reportSilentFallback op:"commit-json"
+    alert_route: Sentry feature:c4-rerender op:commit-json (unchanged contract, new size source)
+  - mode: JSON commit or resync fails
+    detection: githubApiPost throw caught op:"commit-json"; not resync.ok reports op:"resync"
+    alert_route: Sentry feature:c4-rerender (unchanged)
+  - mode: REMOVED failure mode — stranded dirty model.likec4.json dirtying the next reconcile
+    detection: n/a (eliminated by construction — render no longer writes a tracked path)
+    alert_route: was Sentry 9ccf1d86… (workspace-sync self-heal); this plan removes the source
+logs:
+  where: pino to Better Stack drain (server logger); Sentry for warn+ mirrors
+  retention: per existing Better Stack / Sentry retention (unchanged)
+discoverability_test:
+  command: "cd apps/web-platform && ./node_modules/.bin/vitest run test/c4-render.test.ts test/c4-writer-rerender.test.ts"
+  expected_output: "all tests pass; c4-render success result carries json and never calls copyFile/rename on the real path; writer commits the returned bytes"
+```
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected — this is a server-side code-hardening change to a
+single feature's render/commit path. No product/UX surface (no new or modified user-facing
+page or component — the GET `/project` route and client components are untouched), no
+legal/compliance surface (no new data processing, no new persistence, no new log field),
+no security surface widened (argv stays fixed, cwd stays constant-derived, no new
+user-controlled input; the removed `O_NOFOLLOW` read is removed *because the on-disk
+re-read it hardened no longer exists*), no infra surface (no new server/service/secret/
+cron/DNS — pure `apps/web-platform/src` + `server/` + `test/` edit).
+
+### UI-surface override check
+
+`## Files to Edit` contains no path matching the UI-surface term list / glob superset
+(`components/**`, `app/**/page.tsx`, `app/**/layout.tsx`) — the only `app/` reference
+(`project/route.ts`) is a **read-only no-change** and is not even edited. Product gate
+does not fire.
+
+## Open Code-Review Overlap
+
+None. `gh issue list --label code-review --state open` matched none of
+`c4-render.ts`, `c4-writer.ts`, `project/route.ts`.
+
+## Infrastructure (IaC)
+
+Not applicable. This plan introduces no new infrastructure (no server, systemd service,
+cron, vendor account, DNS record, TLS cert, secret, firewall rule, or monitoring webhook).
+It edits only `apps/web-platform/{server,test}` files against an already-provisioned
+surface. Phase 2.8 detection scan found no SSH/systemctl/secret-mutation/terraform/
+vendor-dashboard wording in the plan's implementation phases (the `<!-- iac-routing-ack -->`
+at the top records this review).
+
+## Research Insights (deepen-plan)
+
+**Deepened on:** 2026-06-05 · gates 4.6/4.7/4.8/4.9 passed · verify-the-negative +
+precedent-diff passes run against the `origin/main` working tree.
+
+### Verify-the-negative (every load-bearing negative claim probed against code)
+
+| Plan claim | Probe | Result |
+| --- | --- | --- |
+| "render never writes the tracked path" (after fix) | `grep -nE 'writeFile\|copyFile\|rename' c4-render.ts` | **Confirms.** The *only* tracked-path write is `copyFile`/`rename` at `c4-render.ts:190-191` (all other hits are comments/imports). Removing it makes the claim true — there is no second write site to miss (`hr-write-boundary-sentinel-sweep-all-write-sites`). |
+| "GET `/project` is the sole on-disk reader of `model.likec4.json`" | `grep -rn C4_MODEL_JSON apps/web-platform --include='*.ts' \| grep -v test` + per-file read scan | **Confirms.** Only `project/route.ts:66` does `path.join(dirAbs, C4_MODEL_JSON)` → `fs.open`. `c4-writer.ts:284` is the read-back being *removed*; `[...path]/route.ts` references it only in a comment. No hidden second reader. |
+| "renderC4Model's only production caller is rerenderAndCommit" | `grep -rn renderC4Model apps/web-platform --include='*.ts*' \| grep -v test` | **Confirms.** Sole call site `c4-writer.ts:252`. The return-type widening (`hr-type-widening-cross-consumer-grep`) touches exactly one consumer + the `c4-render.test.ts` import. `tsc --noEmit` (AC9) is the backstop. |
+
+### Precedent-diff (Phase 4.4) — `pdf-linearize.ts` is the cited model template
+
+`c4-render.ts`'s own header (`:7`, `:67`, `:136`) says it is "modeled on
+`server/pdf-linearize.ts`." Grepping the precedent:
+
+```
+apps/web-platform/server/pdf-linearize.ts:14:  | { ok: true; buffer: Buffer }
+apps/web-platform/server/pdf-linearize.ts:65:export async function linearizePdf(input: Buffer): Promise<LinearizeResult>
+apps/web-platform/server/pdf-linearize.ts:92:      return { ok: true, buffer };   // returns bytes — does NOT write output in place
+```
+
+`pdf-linearize.ts` **returns `{ ok: true; buffer: Buffer }`** — it never publishes its
+output onto a tracked/destination path; the caller owns persistence. The current
+in-place-write `c4-render.ts` is the *deviation* from its own stated precedent (it gained
+the tracked-path publish in #4965/#4967 for the validate-before-clobber work). **Option A
+restores `c4-render.ts` to the precedent shape** (return the validated bytes; caller owns
+the commit/persist), which is the codebase-canonical form for an out-of-process spawn
+helper. This is a precedent *confirmation*, not a novel pattern — it strengthens the design
+choice. (One shape difference: `pdf` returns a `Buffer`; the c4 model is committed as a
+UTF-8 base64 string and validated as parsed JSON, so returning the raw `utf8` **string** —
+not a re-encoded buffer — is correct here, per the Sharp Edge on byte-identical bytes.)
+
+### Type-widening discipline (`hr-type-widening-cross-consumer-grep`)
+
+The `RenderResult` success variant gains a required `json: string` field. The cross-consumer
+grep (above) confirms the single consumer is `rerenderAndCommit`, which is rewritten in the
+same PR (Phase 3) to read `render.json`. No other site destructures a `renderC4Model`
+success result. `tsc --noEmit` is the mechanical gate that the widening is honored
+everywhere (AC9).
+
+## Files to Edit
+
+- `apps/web-platform/server/c4-render.ts` — widen `RenderResult` success to carry `json`;
+  remove the tracked-path publish (`copyFile`/`rename`/`realPath`/`stagePath`); update
+  header prose.
+- `apps/web-platform/server/c4-writer.ts` — consume `render.json`; remove the
+  `open`/`O_NOFOLLOW`/`stat`/`readFile` re-read block; cap-check on returned byte length;
+  update `rerenderAndCommit` doc comment.
+- `apps/web-platform/test/c4-render.test.ts` — assert the bytes-returning contract; drop
+  copyFile/rename publish assertions + fixtures.
+- `apps/web-platform/test/c4-writer-rerender.test.ts` — mock `renderC4Model` to return
+  `json`; remove the FileHandle (`open`/`stat`/`readFile`/`close`) mocks; resize the
+  oversized case to the returned bytes; add a returned-bytes-committed assertion.
+
+## Files to Create
+
+- None.
+
+## Alternative Approaches Considered
+
+| Approach | Why not chosen |
+| --- | --- |
+| **Option B — restore-on-every-exit** (`git checkout -- model.likec4.json` on every failure exit; stage/commit-or-discard before the pull on success) | Re-introduces git mutations into the hot save path and leaves a multi-branch exit matrix to cover defensively; the issue itself notes Option A is cleaner. Option A removes the dirty-tree source by construction rather than papering over each exit. |
+| **Leave as-is (rely on #4972 de-noise)** | #4972 only silenced the *operator page*; the wasteful per-save `reset --hard` churn and the failure-path stranding remain. This issue exists precisely to harden the source. |
+| **Re-serialize the model with `JSON.stringify` before returning** | Risks key-order/whitespace drift from the validated artifact (and a needless re-encode); return the raw validated `utf8` string so committed bytes are byte-identical to what was validated. |
+
+## Risks & Mitigations
+
+- **Risk: the resync pull does not land the committed bytes on disk, so GET `/project`
+  serves stale/empty.** Mitigation: the `op:"manual"` `git pull --ff-only` already runs
+  after the JSON commit (`c4-writer.ts:329`) and, with no dirty tree, fast-forwards
+  cleanly — bringing the committed `model.likec4.json` down. This is the *same* resync that
+  runs today; Option A makes it succeed cleanly (no abort) rather than triggering a
+  `reset --hard`. The honest-stale banner (#4963 Layer 1) covers the transient window
+  between commit and pull, exactly as today.
+- **Risk: removing `O_NOFOLLOW` re-introduces a symlink/TOCTOU race.** Mitigation: the
+  `O_NOFOLLOW`+fd-stat hardening (CodeQL `js/file-system-race`) was added because the writer
+  **re-read a tracked file** that a planted symlink at that path could swap. Option A
+  removes that re-read entirely — the bytes are produced in-process and committed without
+  any on-disk round-trip — so there is no file-read to harden. The **GET `/project`** route
+  keeps its own `O_NOFOLLOW`+fd-stat hardening (unchanged), which is the path that still
+  reads the on-disk file.
+- **Risk: type-widening breaks an unseen caller of `renderC4Model`.** Mitigation: Phase 0
+  grep confirms the sole production caller is `rerenderAndCommit`; `tsc --noEmit` (AC9) is
+  the backstop.
+- **Risk: byte-size cap regression — the in-memory string size differs from the on-disk
+  file size the old `stat` measured.** Mitigation: `Buffer.byteLength(render.json, "utf8")`
+  measures the exact bytes that will be base64-committed — strictly more accurate than the
+  old `handle.stat().size` (which measured the on-disk copy of the same bytes). AC3 + the
+  resized AC2c fixture pin this.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/
+  placeholder text, or omits the threshold will fail `deepen-plan` Phase 4.6. (This plan's
+  section is filled with concrete artifact + vector + `threshold: none` reason.)
+- The render module is bundled into the WS/custom server via the Concierge
+  `edit_c4_diagram` import chain (no `import "server-only"`, esbuild can't resolve the
+  guard). Keep `c4-render.ts` free of any import that drags `next/headers` or the heavy
+  `likec4` toolchain into the bundle — Option A adds no imports, only removes them.
+- Return the **raw validated `utf8` string**, not a re-`JSON.stringify` of the parsed model —
+  re-encoding risks key-order/whitespace drift from the artifact `likec4` actually produced
+  and that was validated.
+- The `op:"manual"` resync is load-bearing for getting the committed bytes onto the clone
+  for the GET to read. Do not drop it when removing the on-disk read — it is the mechanism
+  by which the committed JSON reaches disk under Option A.
+
+## Test Scenarios
+
+1. `.c4` save, valid model → `renderC4Model` returns `{ok:true, json}`; writer commits
+   those bytes; second resync is `op:"manual"`; `rerendered:true`; **no** `copyFile`/`rename`
+   on the tracked path anywhere.
+2. `.c4` save, empty/invalid model (#4966) → `renderC4Model` returns `{ok:false,
+   reason:"empty_model"}` with no `json`; writer makes no JSON commit; previously-good model
+   untouched; `rerenderDiagnostic` surfaced.
+3. `.c4` save, oversized returned model (>4 MB) → writer returns `{rerendered:false}`, no
+   JSON commit, `reportSilentFallback op:"commit-json"`.
+4. `.c4` save, JSON commit throws / resync fails after a good render → `{rerendered:false}`,
+   reported; working tree unchanged (nothing stranded — render produced only a temp
+   artifact).
+5. `.md` save → no render spawned; unchanged.
+6. `syncWorkspace` self-heal suite (`kb-route-helpers.test.ts`) → green **without edit**.

--- a/knowledge-base/project/plans/2026-06-05-fix-c4-render-off-tree-plan.md
+++ b/knowledge-base/project/plans/2026-06-05-fix-c4-render-off-tree-plan.md
@@ -168,77 +168,77 @@ diagrams dir). No data-exposure vector is opened or widened.
 
 ### Phase 0 — Preconditions (verify-before-code)
 
-- [ ] Confirm `renderC4Model`'s only caller is `rerenderAndCommit`:
+- [x] Confirm `renderC4Model`'s only caller is `rerenderAndCommit`:
       `git grep -n 'renderC4Model' apps/web-platform` → expect `c4-render.ts` (def +
       export), `c4-writer.ts` (import + call), `c4-writer-rerender.test.ts` (mock),
       `c4-render.test.ts` (import). No other production caller → the return-type widening
       is contained.
-- [ ] Confirm GET `/project` is the sole on-disk reader of `model.likec4.json`:
+- [x] Confirm GET `/project` is the sole on-disk reader of `model.likec4.json`:
       `git grep -nE 'C4_MODEL_JSON|model\.likec4\.json' apps/web-platform --include='*.ts'`
       and verify only `project/route.ts` performs a `readFile`/`open` of it (writer's read
       is being removed; `[...path]` route only comments on it).
-- [ ] Confirm test runner + paths: `apps/web-platform/vitest.config.ts` `include`
+- [x] Confirm test runner + paths: `apps/web-platform/vitest.config.ts` `include`
       collects `test/**/*.test.ts` (node project) — all three target tests qualify. Runner
       is vitest (`package.json scripts.test: "vitest"`); invoke via
       `./node_modules/.bin/vitest run <paths>`.
 
 ### Phase 1 — `c4-render.ts`: return bytes, drop the tracked-path publish (producer)
 
-- [ ] Widen `RenderResult` success variant to
+- [x] Widen `RenderResult` success variant to
       `{ ok: true; durationMs: number; json: string }`.
-- [ ] In `renderToValidatedModel`: on validated success, return
+- [x] In `renderToValidatedModel`: on validated success, return
       `{ ok: true, durationMs: run.durationMs, json: <the raw temp-read string> }`. Bind the
       `utf8` read at `c4-render.ts:156` into a local `const raw = await readFile(tmpOut,"utf8")`,
       `JSON.parse(raw)` for validation, and return `raw` as `json` so the committed bytes
       are byte-identical to the validated artifact — do not re-`JSON.stringify` (avoids
       key-order/whitespace drift).
-- [ ] **Delete** the same-dir staging machinery used only for the tracked-file publish:
+- [x] **Delete** the same-dir staging machinery used only for the tracked-file publish:
       `realPath` (`:144`), `stagePath` (`:148`), the `copyFile`+`rename` publish (`:190-191`),
       and the trailing `rm(stagePath, …)` cleanup (`:204`). Keep the temp-dir `mkdtemp` +
       `rm(dir, …)` lifecycle (still needed for the spawn's `-o` target and cleanup).
-- [ ] Remove now-unused imports (`copyFile`, `rename`, `basename` if no longer referenced)
+- [x] Remove now-unused imports (`copyFile`, `rename`, `basename` if no longer referenced)
       from the `node:fs/promises` / `node:path` import lines — let `tsc`/lint confirm.
-- [ ] Update the module header comment block (lines 12-20, 112-118) so the
+- [x] Update the module header comment block (lines 12-20, 112-118) so the
       "copy it onto the real `model.likec4.json`" / "where the GET reads it … and the caller
       commits it" prose reflects the new "return the validated bytes; the writer commits
       them and the resync pull lands them on disk" contract.
 
 ### Phase 2 — `c4-render.test.ts`: assert the new contract (producer test)
 
-- [ ] Replace the copyFile/rename publish assertions (success test lines 116-135) with:
+- [x] Replace the copyFile/rename publish assertions (success test lines 116-135) with:
       success result is `ok:true` and `res.json` equals the staged `VALID_MODEL`; assert
       `fsMock.copyFile`/`fsMock.rename` are **not** called.
-- [ ] Drop the `STAGE`/`REAL_JSON` fixtures and the `copyFile`/`rename` entries from
+- [x] Drop the `STAGE`/`REAL_JSON` fixtures and the `copyFile`/`rename` entries from
       `fsMock` (no longer part of the success path). Keep `mkdtemp`/`readFile`/`rm`.
-- [ ] In every failure case (empty-elements, non-object elements, non-JSON, non-zero exit,
+- [x] In every failure case (empty-elements, non-object elements, non-JSON, non-zero exit,
       spawn_error, timeout): assert the result has no `json` field (so the writer can never
       commit on a failed render) and that no publish occurred (already asserted; tighten to
       the new shape).
-- [ ] The spawn/argv/env scope assertions (lines 83-114) are unchanged — the `-o` temp
+- [x] The spawn/argv/env scope assertions (lines 83-114) are unchanged — the `-o` temp
       target and scoped env are unaffected by Option A.
 
 ### Phase 3 — `c4-writer.ts`: commit the returned bytes (consumer)
 
-- [ ] In `rerenderAndCommit`, after `const render = await renderC4Model(workspacePath)`
+- [x] In `rerenderAndCommit`, after `const render = await renderC4Model(workspacePath)`
       and the `!render.ok` early-return, use `render.json` directly: cap-check
       `Buffer.byteLength(render.json, "utf8") > MAX_C4_MODEL_BYTES` → `reportSilentFallback`
       (`op:"commit-json"`, `extra:{ userId, relativePath, size }`,
       `message:"c4 re-render: regenerated model too large to commit"`) + return
       `{ rerendered:false }` (preserves AC2c semantics; `size` is now the byte length of the
       returned string).
-- [ ] **Delete** the `open(jsonAbsPath, O_NOFOLLOW)` + `handle.stat()` size-cap +
+- [x] **Delete** the `open(jsonAbsPath, O_NOFOLLOW)` + `handle.stat()` size-cap +
       `handle.readFile()` + `handle.close()` block (`c4-writer.ts:280-305`) and the
       `jsonAbsPath` construction. The TOCTOU/`O_NOFOLLOW` hardening existed because we were
       re-reading a tracked file that a planted symlink could swap; once we commit the
       in-process returned bytes there is no on-disk re-read to harden. Remove the now-unused
       `open` / `constants as fsConstants` / `join` imports if they become unreferenced
       (let `tsc`/lint confirm; `join` may still be used elsewhere — check).
-- [ ] Keep the rest of the commit flow byte-for-byte: blob-sha resolve
+- [x] Keep the rest of the commit flow byte-for-byte: blob-sha resolve
       (`githubApiGet`), `githubApiPost(... jsonFilePath ...)`, and the `op:"manual"`
       `syncWorkspace` resync + its `!resync.ok` `reportSilentFallback(op:"resync")`. The
       success `logger.info({ event:"c4_rerender", … durationMs: render.durationMs })` still
       reads `render.durationMs` (now alongside `render.json`).
-- [ ] Update the `rerenderAndCommit` doc comment (`c4-writer.ts:233-243`) so the
+- [x] Update the `rerenderAndCommit` doc comment (`c4-writer.ts:233-243`) so the
       "renderC4Model validated to a temp file and left the real JSON untouched" /
       "Read the regenerated JSON off the diagrams dir" prose reflects the new
       "renderC4Model returns the validated bytes; we commit them and the resync pull lands
@@ -246,30 +246,30 @@ diagrams dir). No data-exposure vector is opened or widened.
 
 ### Phase 4 — `c4-writer-rerender.test.ts`: adapt the consumer mock (consumer test)
 
-- [ ] Change the `renderC4Model` mock default to resolve
+- [x] Change the `renderC4Model` mock default to resolve
       `{ ok:true, durationMs:12, json:'{"_stage":"layouted"}' }` (carry the JSON the writer
       now commits) instead of `{ ok:true, durationMs:12 }`.
-- [ ] **Remove** the `node:fs/promises` `open` mock + the `stat`/`readFile`/`close`
+- [x] **Remove** the `node:fs/promises` `open` mock + the `stat`/`readFile`/`close`
       FileHandle fakes (lines 9-12, 27, 65-74) — the writer no longer opens a file. The
       AC2c oversized case (lines 152-163) now sizes the **mocked `render.json`** above 4 MB
       (e.g. `json: "x".repeat(8 * 1024 * 1024)`) rather than mocking `stat.size`.
-- [ ] AC1/AC2/AC2b/AC2d/AC2e/AC3/OUT_OF_SCOPE/first-sync-failure tests: keep their
+- [x] AC1/AC2/AC2b/AC2d/AC2e/AC3/OUT_OF_SCOPE/first-sync-failure tests: keep their
       assertions on commit ordering, `rerendered`, `rerenderDiagnostic`, and
       `reportSilentFallback`. Verify the JSON-commit assertion
       (`endsWith("/diagrams/model.likec4.json")`) still holds — the commit still happens; only
       the bytes' provenance changed (mock result vs. mocked file read).
-- [ ] Add an assertion to AC1 (or a new sibling test) that the writer commits the bytes
+- [x] Add an assertion to AC1 (or a new sibling test) that the writer commits the bytes
       returned by `renderC4Model` (the `githubApiPost` JSON-commit `content` base64-decodes
       to `render.json`), pinning the new producer→consumer contract.
 
 ### Phase 5 — Verify
 
-- [ ] `./node_modules/.bin/vitest run test/c4-render.test.ts test/c4-writer-rerender.test.ts
+- [x] `./node_modules/.bin/vitest run test/c4-render.test.ts test/c4-writer-rerender.test.ts
       test/kb-route-helpers.test.ts` (from `apps/web-platform/`) → all green; confirm
       `kb-route-helpers.test.ts` self-heal tests passed **without edit**.
-- [ ] `npx tsc --noEmit` (web-platform) → clean; the widened `RenderResult` is honored at
+- [x] `npx tsc --noEmit` (web-platform) → clean; the widened `RenderResult` is honored at
       the sole call site.
-- [ ] Run the broader server suite if cheap (`./node_modules/.bin/vitest run test/` scoped
+- [x] Run the broader server suite if cheap (`./node_modules/.bin/vitest run test/` scoped
       to changed-area files) to catch any incidental importer.
 
 ## Observability

--- a/knowledge-base/project/specs/feat-one-shot-4976-c4-render-off-tree/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-4976-c4-render-off-tree/session-state.md
@@ -1,0 +1,21 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-05-fix-c4-render-off-tree-plan.md
+- Status: complete
+
+### Errors
+None. (Two write-hook blocks hit and self-corrected during planning: an IaC-routing gate on negation prose, and an initial bare-root mirror write redirected to the worktree. Task tool was not in the planning subagent's deferred-tool set, so deepen-plan gates 4.6-4.9, verify-the-negative, and precedent-diff were run directly rather than via fan-out agents.)
+
+### Decisions
+- Chose Option A (render off-tree): `renderC4Model` returns validated bytes instead of writing the tracked `model.likec4.json`; `rerenderAndCommit` commits returned bytes and the existing `op:"manual"` resync pull lands them on the clone. Removes the dirty-tree source by construction.
+- Verified GET `/api/kb/c4/project` (route.ts:66) is the sole on-disk reader of `model.likec4.json`; committed bytes still reach disk via the resync pull, no route change required.
+- Precedent-diff confirmed: `c4-render.ts` header cites `pdf-linearize.ts`, which returns `{ ok, buffer }` rather than writing in place — Option A restores the stated precedent (caller owns persistence).
+- Justified removing the `O_NOFOLLOW`/TOCTOU re-read in the writer: it existed only because the writer re-read a tracked file; Option A eliminates the on-disk re-read.
+- Brand-survival threshold = none (worst case is a self-healing per-user stale-diagram banner; no data leak). Dogfood verification tracked by existing issue #4966.
+
+### Components Invoked
+- Skill soleur:plan (args #4976)
+- Skill soleur:deepen-plan (args plan file path)
+- deepen-plan gates 4.6-4.9, verify-the-negative, 4.4 precedent-diff executed directly via gh/git/grep
+- Committed + pushed plan and tasks.md to branch feat-one-shot-4976-c4-render-off-tree

--- a/knowledge-base/project/specs/feat-one-shot-4976-c4-render-off-tree/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-4976-c4-render-off-tree/tasks.md
@@ -1,0 +1,102 @@
+---
+feature: feat-one-shot-4976-c4-render-off-tree
+issue: 4976
+lane: cross-domain
+plan: knowledge-base/project/plans/2026-06-05-fix-c4-render-off-tree-plan.md
+---
+
+# Tasks — Render `model.likec4.json` off-tree (Option A)
+
+Single atomic PR. TDD: adapt/write the failing test, then make it green. Phases ordered by
+contract-dependency (producer `renderC4Model` return-type change lands before the consumer
+`rerenderAndCommit` change) so no phase leaves dead code.
+
+## Phase 0 — Preconditions (verify-before-code)
+
+- [ ] 0.1 Confirm `renderC4Model`'s only production caller is `rerenderAndCommit`:
+  `git grep -n 'renderC4Model' apps/web-platform` → expect def/export in `c4-render.ts`,
+  import+call in `c4-writer.ts`, mock in `c4-writer-rerender.test.ts`, import in
+  `c4-render.test.ts`. No other caller.
+- [ ] 0.2 Confirm GET `/project` is the sole on-disk reader of `model.likec4.json`:
+  `git grep -nE 'C4_MODEL_JSON|model\.likec4\.json' apps/web-platform --include='*.ts'`;
+  verify only `project/route.ts` does an `fs.open`/`readFile` of it.
+- [ ] 0.3 Confirm runner + path collection: `apps/web-platform/vitest.config.ts` `include`
+  collects `test/**/*.test.ts`; invoke via `./node_modules/.bin/vitest run <paths>`.
+
+## Phase 1 — `c4-render.ts`: return bytes, drop the tracked-path publish (producer)
+
+- [ ] 1.1 Widen `RenderResult` success variant to
+  `{ ok: true; durationMs: number; json: string }`.
+- [ ] 1.2 In `renderToValidatedModel`: bind the validated read into
+  `const raw = await readFile(tmpOut, "utf8")`, `JSON.parse(raw)` for validation, and on
+  validated success return `{ ok: true, durationMs: run.durationMs, json: raw }`. Return the
+  raw `utf8` string (do NOT re-`JSON.stringify`) so committed bytes are byte-identical to the
+  validated artifact.
+- [ ] 1.3 Delete the tracked-file publish machinery: `realPath`, `stagePath`, the
+  `copyFile`+`rename` publish, and the trailing `rm(stagePath, …)` cleanup. Keep the
+  `mkdtemp` temp-dir + `rm(dir, …)` lifecycle (still needed for the spawn `-o` target).
+- [ ] 1.4 Remove now-unused imports (`copyFile`, `rename`, `basename` if unreferenced) — let
+  `tsc`/lint confirm.
+- [ ] 1.5 Update the module header + function-doc prose (was: "copy onto the real
+  model.likec4.json … where the GET reads it and the caller commits it") to the new contract
+  (return the validated bytes; the writer commits them and the resync pull lands them on
+  disk).
+
+## Phase 2 — `c4-render.test.ts`: assert the new contract (producer test)
+
+- [ ] 2.1 Replace the copyFile/rename publish assertions with: success result is `ok:true`
+  and `res.json` equals the staged `VALID_MODEL`; assert `copyFile`/`rename` NOT called.
+- [ ] 2.2 Drop the `STAGE`/`REAL_JSON` fixtures and the `copyFile`/`rename` entries from
+  `fsMock`; keep `mkdtemp`/`readFile`/`rm`.
+- [ ] 2.3 In every failure case (empty-elements, non-object elements, non-JSON, non-zero
+  exit, spawn_error, timeout): assert the result has no `json` field and no publish occurred.
+- [ ] 2.4 Leave the spawn/argv/env scope assertions unchanged.
+
+## Phase 3 — `c4-writer.ts`: commit the returned bytes (consumer)
+
+- [ ] 3.1 After `renderC4Model` + the `!render.ok` early-return, use `render.json`: cap-check
+  `Buffer.byteLength(render.json, "utf8") > MAX_C4_MODEL_BYTES` →
+  `reportSilentFallback(op:"commit-json", extra:{ userId, relativePath, size })` + return
+  `{ rerendered:false }` (preserves AC2c).
+- [ ] 3.2 Delete the `open(jsonAbsPath, O_NOFOLLOW)` + `handle.stat()` + `handle.readFile()`
+  + `handle.close()` block and the `jsonAbsPath` construction. Remove now-unused
+  `open`/`constants as fsConstants`/`join` imports if unreferenced (verify `join` is not
+  used elsewhere).
+- [ ] 3.3 Keep the rest of the commit flow byte-for-byte: `githubApiGet` blob-sha,
+  `githubApiPost(... jsonFilePath ...)`, the `op:"manual"` `syncWorkspace` resync + its
+  `!resync.ok` `reportSilentFallback(op:"resync")`, and the success
+  `logger.info({ event:"c4_rerender", … durationMs: render.durationMs })`.
+- [ ] 3.4 Update the `rerenderAndCommit` doc comment to reflect the new
+  "renderC4Model returns the validated bytes; we commit them; the resync pull lands the
+  committed bytes on the clone" contract.
+
+## Phase 4 — `c4-writer-rerender.test.ts`: adapt the consumer mock (consumer test)
+
+- [ ] 4.1 Change the `renderC4Model` mock default to resolve
+  `{ ok:true, durationMs:12, json:'{"_stage":"layouted"}' }`.
+- [ ] 4.2 Remove the `node:fs/promises` `open` mock + the `stat`/`readFile`/`close`
+  FileHandle fakes. Resize the AC2c oversized case to size the mocked `render.json` above
+  4 MB (e.g. `json: "x".repeat(8 * 1024 * 1024)`) instead of mocking `stat.size`.
+- [ ] 4.3 Keep AC1/AC2/AC2b/AC2d/AC2e/AC3/OUT_OF_SCOPE/first-sync-failure assertions; verify
+  the JSON-commit assertion (`endsWith("/diagrams/model.likec4.json")`) still holds.
+- [ ] 4.4 Add an assertion (AC1 or a sibling test) that the writer commits the bytes returned
+  by `renderC4Model` (JSON-commit `content` base64-decodes to `render.json`), pinning the
+  new producer→consumer contract.
+
+## Phase 5 — Verify
+
+- [ ] 5.1 `./node_modules/.bin/vitest run test/c4-render.test.ts test/c4-writer-rerender.test.ts
+  test/kb-route-helpers.test.ts` (from `apps/web-platform/`) → all green; confirm the
+  `kb-route-helpers.test.ts` self-heal tests passed WITHOUT edit.
+- [ ] 5.2 `npx tsc --noEmit` (web-platform) → clean.
+- [ ] 5.3 Run the broader server suite scoped to changed-area files to catch any incidental
+  importer.
+
+## Definition of Done
+
+- [ ] AC1–AC9 (plan, Pre-merge) all met.
+- [ ] `kb-route-helpers.test.ts` self-heal suite green with zero edits (AC8).
+- [ ] No tracked-path write remains in `c4-render.ts`; no on-disk model re-read remains in
+  `c4-writer.ts`.
+- [ ] PR body references `Closes #4976`; dogfood verification stays tracked by #4966 (not
+  re-filed).

--- a/knowledge-base/project/specs/feat-one-shot-4976-c4-render-off-tree/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-4976-c4-render-off-tree/tasks.md
@@ -13,90 +13,90 @@ contract-dependency (producer `renderC4Model` return-type change lands before th
 
 ## Phase 0 — Preconditions (verify-before-code)
 
-- [ ] 0.1 Confirm `renderC4Model`'s only production caller is `rerenderAndCommit`:
+- [x] 0.1 Confirm `renderC4Model`'s only production caller is `rerenderAndCommit`:
   `git grep -n 'renderC4Model' apps/web-platform` → expect def/export in `c4-render.ts`,
   import+call in `c4-writer.ts`, mock in `c4-writer-rerender.test.ts`, import in
   `c4-render.test.ts`. No other caller.
-- [ ] 0.2 Confirm GET `/project` is the sole on-disk reader of `model.likec4.json`:
+- [x] 0.2 Confirm GET `/project` is the sole on-disk reader of `model.likec4.json`:
   `git grep -nE 'C4_MODEL_JSON|model\.likec4\.json' apps/web-platform --include='*.ts'`;
   verify only `project/route.ts` does an `fs.open`/`readFile` of it.
-- [ ] 0.3 Confirm runner + path collection: `apps/web-platform/vitest.config.ts` `include`
+- [x] 0.3 Confirm runner + path collection: `apps/web-platform/vitest.config.ts` `include`
   collects `test/**/*.test.ts`; invoke via `./node_modules/.bin/vitest run <paths>`.
 
 ## Phase 1 — `c4-render.ts`: return bytes, drop the tracked-path publish (producer)
 
-- [ ] 1.1 Widen `RenderResult` success variant to
+- [x] 1.1 Widen `RenderResult` success variant to
   `{ ok: true; durationMs: number; json: string }`.
-- [ ] 1.2 In `renderToValidatedModel`: bind the validated read into
+- [x] 1.2 In `renderToValidatedModel`: bind the validated read into
   `const raw = await readFile(tmpOut, "utf8")`, `JSON.parse(raw)` for validation, and on
   validated success return `{ ok: true, durationMs: run.durationMs, json: raw }`. Return the
   raw `utf8` string (do NOT re-`JSON.stringify`) so committed bytes are byte-identical to the
   validated artifact.
-- [ ] 1.3 Delete the tracked-file publish machinery: `realPath`, `stagePath`, the
+- [x] 1.3 Delete the tracked-file publish machinery: `realPath`, `stagePath`, the
   `copyFile`+`rename` publish, and the trailing `rm(stagePath, …)` cleanup. Keep the
   `mkdtemp` temp-dir + `rm(dir, …)` lifecycle (still needed for the spawn `-o` target).
-- [ ] 1.4 Remove now-unused imports (`copyFile`, `rename`, `basename` if unreferenced) — let
+- [x] 1.4 Remove now-unused imports (`copyFile`, `rename`, `basename` if unreferenced) — let
   `tsc`/lint confirm.
-- [ ] 1.5 Update the module header + function-doc prose (was: "copy onto the real
+- [x] 1.5 Update the module header + function-doc prose (was: "copy onto the real
   model.likec4.json … where the GET reads it and the caller commits it") to the new contract
   (return the validated bytes; the writer commits them and the resync pull lands them on
   disk).
 
 ## Phase 2 — `c4-render.test.ts`: assert the new contract (producer test)
 
-- [ ] 2.1 Replace the copyFile/rename publish assertions with: success result is `ok:true`
+- [x] 2.1 Replace the copyFile/rename publish assertions with: success result is `ok:true`
   and `res.json` equals the staged `VALID_MODEL`; assert `copyFile`/`rename` NOT called.
-- [ ] 2.2 Drop the `STAGE`/`REAL_JSON` fixtures and the `copyFile`/`rename` entries from
+- [x] 2.2 Drop the `STAGE`/`REAL_JSON` fixtures and the `copyFile`/`rename` entries from
   `fsMock`; keep `mkdtemp`/`readFile`/`rm`.
-- [ ] 2.3 In every failure case (empty-elements, non-object elements, non-JSON, non-zero
+- [x] 2.3 In every failure case (empty-elements, non-object elements, non-JSON, non-zero
   exit, spawn_error, timeout): assert the result has no `json` field and no publish occurred.
-- [ ] 2.4 Leave the spawn/argv/env scope assertions unchanged.
+- [x] 2.4 Leave the spawn/argv/env scope assertions unchanged.
 
 ## Phase 3 — `c4-writer.ts`: commit the returned bytes (consumer)
 
-- [ ] 3.1 After `renderC4Model` + the `!render.ok` early-return, use `render.json`: cap-check
+- [x] 3.1 After `renderC4Model` + the `!render.ok` early-return, use `render.json`: cap-check
   `Buffer.byteLength(render.json, "utf8") > MAX_C4_MODEL_BYTES` →
   `reportSilentFallback(op:"commit-json", extra:{ userId, relativePath, size })` + return
   `{ rerendered:false }` (preserves AC2c).
-- [ ] 3.2 Delete the `open(jsonAbsPath, O_NOFOLLOW)` + `handle.stat()` + `handle.readFile()`
+- [x] 3.2 Delete the `open(jsonAbsPath, O_NOFOLLOW)` + `handle.stat()` + `handle.readFile()`
   + `handle.close()` block and the `jsonAbsPath` construction. Remove now-unused
   `open`/`constants as fsConstants`/`join` imports if unreferenced (verify `join` is not
   used elsewhere).
-- [ ] 3.3 Keep the rest of the commit flow byte-for-byte: `githubApiGet` blob-sha,
+- [x] 3.3 Keep the rest of the commit flow byte-for-byte: `githubApiGet` blob-sha,
   `githubApiPost(... jsonFilePath ...)`, the `op:"manual"` `syncWorkspace` resync + its
   `!resync.ok` `reportSilentFallback(op:"resync")`, and the success
   `logger.info({ event:"c4_rerender", … durationMs: render.durationMs })`.
-- [ ] 3.4 Update the `rerenderAndCommit` doc comment to reflect the new
+- [x] 3.4 Update the `rerenderAndCommit` doc comment to reflect the new
   "renderC4Model returns the validated bytes; we commit them; the resync pull lands the
   committed bytes on the clone" contract.
 
 ## Phase 4 — `c4-writer-rerender.test.ts`: adapt the consumer mock (consumer test)
 
-- [ ] 4.1 Change the `renderC4Model` mock default to resolve
+- [x] 4.1 Change the `renderC4Model` mock default to resolve
   `{ ok:true, durationMs:12, json:'{"_stage":"layouted"}' }`.
-- [ ] 4.2 Remove the `node:fs/promises` `open` mock + the `stat`/`readFile`/`close`
+- [x] 4.2 Remove the `node:fs/promises` `open` mock + the `stat`/`readFile`/`close`
   FileHandle fakes. Resize the AC2c oversized case to size the mocked `render.json` above
   4 MB (e.g. `json: "x".repeat(8 * 1024 * 1024)`) instead of mocking `stat.size`.
-- [ ] 4.3 Keep AC1/AC2/AC2b/AC2d/AC2e/AC3/OUT_OF_SCOPE/first-sync-failure assertions; verify
+- [x] 4.3 Keep AC1/AC2/AC2b/AC2d/AC2e/AC3/OUT_OF_SCOPE/first-sync-failure assertions; verify
   the JSON-commit assertion (`endsWith("/diagrams/model.likec4.json")`) still holds.
-- [ ] 4.4 Add an assertion (AC1 or a sibling test) that the writer commits the bytes returned
+- [x] 4.4 Add an assertion (AC1 or a sibling test) that the writer commits the bytes returned
   by `renderC4Model` (JSON-commit `content` base64-decodes to `render.json`), pinning the
   new producer→consumer contract.
 
 ## Phase 5 — Verify
 
-- [ ] 5.1 `./node_modules/.bin/vitest run test/c4-render.test.ts test/c4-writer-rerender.test.ts
+- [x] 5.1 `./node_modules/.bin/vitest run test/c4-render.test.ts test/c4-writer-rerender.test.ts
   test/kb-route-helpers.test.ts` (from `apps/web-platform/`) → all green; confirm the
   `kb-route-helpers.test.ts` self-heal tests passed WITHOUT edit.
-- [ ] 5.2 `npx tsc --noEmit` (web-platform) → clean.
-- [ ] 5.3 Run the broader server suite scoped to changed-area files to catch any incidental
+- [x] 5.2 `npx tsc --noEmit` (web-platform) → clean.
+- [x] 5.3 Run the broader server suite scoped to changed-area files to catch any incidental
   importer.
 
 ## Definition of Done
 
-- [ ] AC1–AC9 (plan, Pre-merge) all met.
-- [ ] `kb-route-helpers.test.ts` self-heal suite green with zero edits (AC8).
-- [ ] No tracked-path write remains in `c4-render.ts`; no on-disk model re-read remains in
+- [x] AC1–AC9 (plan, Pre-merge) all met.
+- [x] `kb-route-helpers.test.ts` self-heal suite green with zero edits (AC8).
+- [x] No tracked-path write remains in `c4-render.ts`; no on-disk model re-read remains in
   `c4-writer.ts`.
-- [ ] PR body references `Closes #4976`; dogfood verification stays tracked by #4966 (not
+- [x] PR body references `Closes #4976`; dogfood verification stays tracked by #4966 (not
   re-filed).


### PR DESCRIPTION
## Summary

Render the regenerated `model.likec4.json` **off the tracked working tree** (Option A from #4976). `renderC4Model` now returns the validated model bytes (`{ ok, durationMs, json }`) instead of publishing them onto `<diagramsDir>/model.likec4.json`; `rerenderAndCommit` commits the returned bytes via the GitHub Contents API and the existing `op:"manual"` resync `git pull --ff-only` (now on a clean tree) brings the committed JSON down where `GET /api/kb/c4/project` reads it.

This removes the reconcile **dirty-tree churn** by construction:
- **Success path:** every `.c4` save no longer dirties the tree → no `non_fast_forward` abort → no per-save `reset --hard` self-heal.
- **Failure path:** a post-render early-return/throw strands nothing (the render produced only a process-temp artifact) → no stranded file dirties the next webhook reconcile (the original Sentry `9ccf1d86…` symptom that #4972 only de-noised).

The writer's on-disk re-read (`open(O_RDONLY | O_NOFOLLOW)` + fd-stat) is removed: that TOCTOU/symlink hardening existed only because the writer re-read a tracked file a planted symlink could swap — with no on-disk re-read, the surface is gone. The 4 MB cap moves to `Buffer.byteLength(render.json, "utf8")` (the exact bytes committed). `GET /api/kb/c4/project` (the sole on-disk reader) keeps its own `O_NOFOLLOW` and is untouched. Restores `c4-render.ts` to its cited `pdf-linearize.ts` precedent (return bytes, caller owns persistence).

Closes #4976

## User-Brand Impact

**If this lands broken, the user experiences:** a stale or blank LikeC4 diagram in the KB Architecture view after a Code-tab Save, which self-heals on the next reconcile (no regression beyond the already-benign status quo post-#4972).

**If this leaks, the user's data is exposed via:** N/A. The change moves a render artifact from a tracked path to a process-temp path and returns bytes in-process; it adds no new persistence, no new network egress, no new log field, and no new user-controlled spawn input (argv stays fixed, cwd stays constant-derived).

- **Brand-survival threshold:** none
- threshold: none, reason: the worst realistic failure is a per-user stale-diagram banner that self-heals on the next reconcile — no data leak, no aggregate or cross-tenant impact, and the diff touches no auth/migration/API-key/secrets path.

## Changelog

### Web Platform
- `renderC4Model` returns validated model bytes instead of writing the tracked `model.likec4.json` (off-tree render).
- `rerenderAndCommit` commits the returned bytes directly; removed the on-disk re-read + `O_NOFOLLOW`/fd-stat guard; 4 MB cap now applies to the returned bytes.
- Updated stale `workspace-sync.ts` self-heal comments that cited the now-removed tracked-path write (self-heal retained as general dirty-tree defense).

## Test plan

- [x] `vitest run test/c4-render.test.ts test/c4-writer-rerender.test.ts test/kb-route-helpers.test.ts` (from `apps/web-platform/`) — 50/50 green; `kb-route-helpers.test.ts` self-heal tests pass with zero edits.
- [x] `tsc --noEmit` (web-platform) — clean; widened `RenderResult` honored at the sole call site.
- [x] Full suite `scripts/test-all.sh` — 100/100 suites pass.
- [x] Multi-agent review (10 agents incl. security-sentinel, data-integrity-guardian, semgrep-sast) — clean; one P3 test-guard finding fixed inline.

Generated with [Claude Code](https://claude.com/claude-code)
