### PR TITLE
feat(cron): generalize handler-level fallback audit-issue to all 8 always-create producers

### DIFF
--- a/apps/web-platform/server/inngest/functions/_cron-shared.ts
+++ b/apps/web-platform/server/inngest/functions/_cron-shared.ts
@@ -3,6 +3,9 @@ import { tmpdir } from "node:os";
 import { createProbeOctokit } from "@/server/github/probe-octokit";
 import { generateInstallationToken } from "@/server/github-app";
 import { reportSilentFallback, warnSilentFallback } from "@/server/observability";
+import { redactGithubSourcedText } from "@/lib/safety/redaction-allowlist";
+import type { SpawnResult } from "./_cron-claude-eval-substrate";
+import type { Octokit } from "@octokit/core";
 
 export const REPO_OWNER = "jikig-ai";
 export const REPO_NAME = "soleur";
@@ -371,4 +374,141 @@ export async function resolveOutputAwareOk(args: {
     },
   );
   return false;
+}
+
+// ---------------------------------------------------------------------------
+// Handler-level silence-hole fallback (#4960, generalized #4978).
+//
+// When the output-aware heartbeat (resolveOutputAwareOk) finds NO labeled issue
+// in the run window — the prompt's "create the audit issue" step never ran
+// (mid-eval crash / upstream API 500 / max-turns kill) — the handler ITSELF
+// files a self-reporting FAILED `${titlePrefix} <date>` issue so the run is
+// never silent and the cron-cloud-task-heartbeat watchdog stays green. It lives
+// ABOVE the prompt, surviving any termination that bypasses the in-prompt steps.
+//
+// Extracted VERBATIM from cron-content-generator (PR #4975, fired in prod via
+// #4982) and parameterized by { label, titlePrefix, cronName } so all 8
+// always-create producers share ONE security-vetted redaction path instead of
+// 8 drifting copies.
+// ---------------------------------------------------------------------------
+
+// GitHub-issue-body readability bound for the spawn tails. Tighter than the
+// 4000-char Sentry extra (resolveOutputAwareOk) — the issue body is for
+// at-a-glance triage, the full tail already lives in the Sentry event.
+const DEFAULT_AUDIT_TAIL_CHARS = 500;
+
+// The spawn tails are token-redacted by the eval substrate (redactToken), but
+// that strips ONLY the installation token — a crash stack can still spill other
+// allowlisted-env secrets (e.g. ANTHROPIC_API_KEY / sk-ant-…). Route through the
+// canonical multi-secret scrubber before it lands in a GitHub issue body, and
+// neutralize backtick/pipe/newline so untrusted eval output cannot break out of
+// the inline-code table cell into rendered markdown (image-autofetch / banner
+// injection). Mirrors the github-sourced-text redaction discipline.
+export function formatTailForIssue(tail: string | undefined): string {
+  const scrubbed = redactGithubSourcedText(tail ?? "").slice(
+    -DEFAULT_AUDIT_TAIL_CHARS,
+  );
+  if (!scrubbed) return "(empty)";
+  return scrubbed
+    .replace(/[\r\n]+/g, " ")
+    // Escape pre-existing backslashes BEFORE introducing our own `\|` escape,
+    // so an input like `\|` cannot produce an ambiguous escape sequence
+    // (js/incomplete-sanitization). Order is load-bearing.
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .replace(/`/g, "ʼ");
+}
+
+export async function ensureScheduledAuditIssue(args: {
+  label: string;
+  titlePrefix: string;
+  cronName: string;
+  runStartedAt: string;
+  spawnResult: Pick<
+    SpawnResult,
+    "exitCode" | "signal" | "abortedByTimeout" | "durationMs" | "stdoutTail" | "stderrTail"
+  >;
+  installationToken?: string;
+  octokit?: Octokit;
+}): Promise<{ created: boolean }> {
+  const {
+    label,
+    titlePrefix,
+    cronName,
+    runStartedAt,
+    spawnResult,
+    installationToken,
+    octokit,
+  } = args;
+
+  // Replay-stable UTC date anchor (NOT `new Date()`, which would drift across
+  // the retries:1 replay and defeat the title-dedup below).
+  const date = runStartedAt.slice(0, 10);
+  // titlePrefix ends in ` -` (no trailing space); the single-space join yields
+  // the byte-identical `${prefix} <date>` form the prompt emits on success.
+  const title = `${titlePrefix} ${date}`;
+
+  let client = octokit;
+  if (!client) {
+    if (!installationToken) {
+      throw new Error(
+        "ensureScheduledAuditIssue: need octokit or installationToken",
+      );
+    }
+    const { Octokit: OctokitCtor } = await import("@octokit/core");
+    client = new OctokitCtor({ auth: installationToken }) as unknown as Octokit;
+  }
+
+  // Dedup: a transient failure that re-runs this path could file a second
+  // FAILED issue. Skip the create if today's audit issue already exists
+  // (success or fallback). Explicit `sort: created, direction: desc` so today's
+  // issue is guaranteed on page 1 — do NOT rely on GitHub's unspecified default
+  // sort for dedup correctness (a busy label could otherwise page today's issue
+  // out and double-file). per_page:10 ≈ 5 weeks at Tue/Thu cadence, ample
+  // headroom. This dedup is load-bearing (not belt-and-suspenders): on a
+  // verify-throw + spawn-nonzero run the gate fires even though the prompt's
+  // issue may exist — the same-title dedup is what prevents a spurious second.
+  const existing = (await client.request("GET /repos/{owner}/{repo}/issues", {
+    owner: REPO_OWNER,
+    repo: REPO_NAME,
+    state: "all",
+    labels: label,
+    sort: "created",
+    direction: "desc",
+    per_page: 10,
+    headers: { "X-GitHub-Api-Version": "2022-11-28" },
+  })) as { data: Array<{ title: string }> };
+  if (existing.data.some((i) => i.title.startsWith(title))) {
+    return { created: false };
+  }
+
+  // Self-diagnosing body — the cron's own redacted spawn tail + timing, so the
+  // failure is triageable without SSH (app stdout is not shipped to Better
+  // Stack). The tails are already token-redacted by the eval substrate.
+  const body =
+    `Automated FAILED self-report from \`${cronName}\`.\n\n` +
+    `This run terminated WITHOUT producing a \`${label}\` ` +
+    `audit issue via the prompt (mid-eval crash / upstream API error / ` +
+    `max-turns kill). The handler-level fallback (#4960) filed this issue so ` +
+    `the run is not silent and the \`cron-cloud-task-heartbeat\` watchdog ` +
+    `stays green.\n\n` +
+    `| Signal | Value |\n| --- | --- |\n` +
+    `| fn | \`${cronName}\` |\n` +
+    `| runStartedAt | \`${runStartedAt}\` |\n` +
+    `| exitCode | \`${spawnResult.exitCode}\` |\n` +
+    `| signal | \`${spawnResult.signal}\` |\n` +
+    `| abortedByTimeout | \`${spawnResult.abortedByTimeout}\` |\n` +
+    `| durationMs | \`${spawnResult.durationMs}\` |\n` +
+    `| stdoutTail | \`${formatTailForIssue(spawnResult.stdoutTail)}\` |\n` +
+    `| stderrTail | \`${formatTailForIssue(spawnResult.stderrTail)}\` |\n\n` +
+    `Triage: \`knowledge-base/engineering/operations/runbooks/cloud-scheduled-tasks.md\` (H2).`;
+
+  await client.request("POST /repos/{owner}/{repo}/issues", {
+    owner: REPO_OWNER,
+    repo: REPO_NAME,
+    title,
+    body,
+    labels: [label],
+  });
+  return { created: true };
 }

--- a/apps/web-platform/server/inngest/functions/_cron-shared.ts
+++ b/apps/web-platform/server/inngest/functions/_cron-shared.ts
@@ -464,8 +464,9 @@ export async function ensureScheduledAuditIssue(args: {
   // (success or fallback). Explicit `sort: created, direction: desc` so today's
   // issue is guaranteed on page 1 — do NOT rely on GitHub's unspecified default
   // sort for dedup correctness (a busy label could otherwise page today's issue
-  // out and double-file). per_page:10 ≈ 5 weeks at Tue/Thu cadence, ample
-  // headroom. This dedup is load-bearing (not belt-and-suspenders): on a
+  // out and double-file). per_page:10 covers ≥1 week of any wired producer's
+  // cadence (daily through monthly) — ample to keep today's issue on page 1.
+  // This dedup is load-bearing (not belt-and-suspenders): on a
   // verify-throw + spawn-nonzero run the gate fires even though the prompt's
   // issue may exist — the same-title dedup is what prevents a spurious second.
   const existing = (await client.request("GET /repos/{owner}/{repo}/issues", {

--- a/apps/web-platform/server/inngest/functions/cron-campaign-calendar.ts
+++ b/apps/web-platform/server/inngest/functions/cron-campaign-calendar.ts
@@ -20,6 +20,7 @@ import {
   mintInstallationToken,
   postSentryHeartbeat,
   resolveOutputAwareOk,
+  ensureScheduledAuditIssue,
   type HandlerArgs,
 } from "./_cron-shared";
 import {
@@ -225,6 +226,36 @@ export async function cronCampaignCalendarHandler({
     await step.run("sentry-heartbeat", async () => {
       await postSentryHeartbeat({ ok: heartbeatOk, sentryMonitorSlug: SENTRY_MONITOR_SLUG, cronName: "cron-campaign-calendar", logger });
     });
+
+    // --- Step 5: silence-hole fallback (#4960, generalized #4978). When the
+    //     output-aware check found NO scheduled-campaign-calendar issue in the
+    //     run window, the prompt's create-issue step never ran (mid-eval crash /
+    //     API 500 / max-turns kill). Self-report a FAILED audit issue so the run
+    //     is never silent. Wrapped so a create failure cannot crash the
+    //     finally/teardown — reported to Sentry instead; the watchdog still
+    //     catches the absence after threshold (defense-in-depth). ---
+    if (!heartbeatOk) {
+      await step.run("ensure-audit-issue", async () => {
+        try {
+          await ensureScheduledAuditIssue({
+            label: SENTRY_MONITOR_SLUG,
+            titlePrefix: "[Scheduled] Campaign Calendar -",
+            cronName: "cron-campaign-calendar",
+            runStartedAt,
+            spawnResult,
+            installationToken,
+          });
+        } catch (err) {
+          reportSilentFallback(err, {
+            feature: "cron-campaign-calendar",
+            op: "ensure-audit-issue-failed",
+            message:
+              "Handler-level fallback audit-issue create failed; run remains silent until watchdog threshold",
+            extra: { fn: "cron-campaign-calendar", runStartedAt },
+          });
+        }
+      });
+    }
 
     return { ok: heartbeatOk };
   } finally {

--- a/apps/web-platform/server/inngest/functions/cron-community-monitor.ts
+++ b/apps/web-platform/server/inngest/functions/cron-community-monitor.ts
@@ -59,6 +59,7 @@ import {
   mintInstallationToken,
   postSentryHeartbeat,
   resolveOutputAwareOk,
+  ensureScheduledAuditIssue,
   type HandlerArgs,
 } from "./_cron-shared";
 import {
@@ -347,6 +348,36 @@ export async function cronCommunityMonitorHandler({
     await step.run("sentry-heartbeat", async () => {
       await postSentryHeartbeat({ ok: heartbeatOk, sentryMonitorSlug: SENTRY_MONITOR_SLUG, cronName: "cron-community-monitor", logger });
     });
+
+    // --- Step 5: silence-hole fallback (#4960, generalized #4978). When the
+    //     output-aware check found NO scheduled-community-monitor issue in the
+    //     run window, the prompt's create-issue step never ran (mid-eval crash /
+    //     API 500 / max-turns kill). Self-report a FAILED audit issue so the run
+    //     is never silent. Wrapped so a create failure cannot crash the
+    //     finally/teardown — reported to Sentry instead; the watchdog still
+    //     catches the absence after threshold (defense-in-depth). ---
+    if (!heartbeatOk) {
+      await step.run("ensure-audit-issue", async () => {
+        try {
+          await ensureScheduledAuditIssue({
+            label: SENTRY_MONITOR_SLUG,
+            titlePrefix: "[Scheduled] Community Monitor -",
+            cronName: "cron-community-monitor",
+            runStartedAt,
+            spawnResult,
+            installationToken,
+          });
+        } catch (err) {
+          reportSilentFallback(err, {
+            feature: "cron-community-monitor",
+            op: "ensure-audit-issue-failed",
+            message:
+              "Handler-level fallback audit-issue create failed; run remains silent until watchdog threshold",
+            extra: { fn: "cron-community-monitor", runStartedAt },
+          });
+        }
+      });
+    }
 
     return { ok: heartbeatOk };
   } finally {

--- a/apps/web-platform/server/inngest/functions/cron-competitive-analysis.ts
+++ b/apps/web-platform/server/inngest/functions/cron-competitive-analysis.ts
@@ -55,6 +55,7 @@ import {
   mintInstallationToken,
   postSentryHeartbeat,
   resolveOutputAwareOk,
+  ensureScheduledAuditIssue,
   type HandlerArgs,
 } from "./_cron-shared";
 import {
@@ -272,6 +273,36 @@ export async function cronCompetitiveAnalysisHandler({
     await step.run("sentry-heartbeat", async () => {
       await postSentryHeartbeat({ ok: heartbeatOk, sentryMonitorSlug: SENTRY_MONITOR_SLUG, cronName: "cron-competitive-analysis", logger });
     });
+
+    // --- Step 5: silence-hole fallback (#4960, generalized #4978). When the
+    //     output-aware check found NO scheduled-competitive-analysis issue in
+    //     the run window, the prompt's create-issue step never ran (mid-eval
+    //     crash / API 500 / max-turns kill). Self-report a FAILED audit issue so
+    //     the run is never silent. Wrapped so a create failure cannot crash the
+    //     finally/teardown — reported to Sentry instead; the watchdog still
+    //     catches the absence after threshold (defense-in-depth). ---
+    if (!heartbeatOk) {
+      await step.run("ensure-audit-issue", async () => {
+        try {
+          await ensureScheduledAuditIssue({
+            label: SENTRY_MONITOR_SLUG,
+            titlePrefix: "[Scheduled] Competitive Analysis -",
+            cronName: "cron-competitive-analysis",
+            runStartedAt,
+            spawnResult,
+            installationToken,
+          });
+        } catch (err) {
+          reportSilentFallback(err, {
+            feature: "cron-competitive-analysis",
+            op: "ensure-audit-issue-failed",
+            message:
+              "Handler-level fallback audit-issue create failed; run remains silent until watchdog threshold",
+            extra: { fn: "cron-competitive-analysis", runStartedAt },
+          });
+        }
+      });
+    }
 
     return { ok: heartbeatOk };
   } finally {

--- a/apps/web-platform/server/inngest/functions/cron-content-generator.ts
+++ b/apps/web-platform/server/inngest/functions/cron-content-generator.ts
@@ -20,8 +20,7 @@ import {
   mintInstallationToken,
   postSentryHeartbeat,
   resolveOutputAwareOk,
-  REPO_OWNER,
-  REPO_NAME,
+  ensureScheduledAuditIssue,
   type HandlerArgs,
 } from "./_cron-shared";
 import {
@@ -32,8 +31,6 @@ import {
 } from "./_cron-claude-eval-substrate";
 import { inngest } from "@/server/inngest/client";
 import { reportSilentFallback } from "@/server/observability";
-import { redactGithubSourcedText } from "@/lib/safety/redaction-allowlist";
-import type { Octokit } from "@octokit/core";
 
 // =============================================================================
 // Constants
@@ -147,110 +144,6 @@ function buildSpawnEnv(installationToken: string): NodeJS.ProcessEnv {
 // without the App-JWT mint path; production callers pass the already-minted
 // installation token (issues:write — the same token the spawn's `gh issue
 // create` uses; `hr-github-app-auth-not-pat`).
-
-// GitHub-issue-body readability bound for the spawn tails. Tighter than the
-// 4000-char Sentry extra (resolveOutputAwareOk) — the issue body is for
-// at-a-glance triage, the full tail already lives in the Sentry event.
-const AUDIT_TAIL_CHARS = 500;
-
-// The spawn tails are token-redacted by the eval substrate (redactToken), but
-// that strips ONLY the installation token — a crash stack can still spill other
-// allowlisted-env secrets (e.g. ANTHROPIC_API_KEY / sk-ant-…). Route through the
-// canonical multi-secret scrubber before it lands in a GitHub issue body, and
-// neutralize backtick/pipe/newline so untrusted eval output cannot break out of
-// the inline-code table cell into rendered markdown (image-autofetch / banner
-// injection). Mirrors the github-sourced-text redaction discipline.
-function formatTailForIssue(tail: string | undefined): string {
-  const scrubbed = redactGithubSourcedText(tail ?? "").slice(-AUDIT_TAIL_CHARS);
-  if (!scrubbed) return "(empty)";
-  return scrubbed
-    .replace(/[\r\n]+/g, " ")
-    // Escape pre-existing backslashes BEFORE introducing our own `\|` escape,
-    // so an input like `\|` cannot produce an ambiguous escape sequence
-    // (js/incomplete-sanitization). Order is load-bearing.
-    .replace(/\\/g, "\\\\")
-    .replace(/\|/g, "\\|")
-    .replace(/`/g, "ʼ");
-}
-
-export async function ensureContentGeneratorAuditIssue(args: {
-  runStartedAt: string;
-  spawnResult: Pick<
-    SpawnResult,
-    "exitCode" | "signal" | "abortedByTimeout" | "durationMs" | "stdoutTail" | "stderrTail"
-  >;
-  installationToken?: string;
-  octokit?: Octokit;
-}): Promise<{ created: boolean }> {
-  const { runStartedAt, spawnResult, installationToken, octokit } = args;
-
-  // Replay-stable UTC date anchor (NOT `new Date()`, which would drift across
-  // the retries:1 replay and defeat the title-dedup below).
-  const date = runStartedAt.slice(0, 10);
-  const title = `[Scheduled] Content Generator - ${date}`;
-
-  let client = octokit;
-  if (!client) {
-    if (!installationToken) {
-      throw new Error(
-        "ensureContentGeneratorAuditIssue: need octokit or installationToken",
-      );
-    }
-    const { Octokit: OctokitCtor } = await import("@octokit/core");
-    client = new OctokitCtor({ auth: installationToken }) as unknown as Octokit;
-  }
-
-  // Dedup: a transient failure that re-runs this path could file a second
-  // FAILED issue. Mirror cron-skill-freshness.ts searchExistingFreshnessIssue —
-  // skip the create if today's audit issue already exists (success or fallback).
-  // Explicit `sort: created, direction: desc` so today's issue is guaranteed on
-  // page 1 — do NOT rely on GitHub's unspecified default sort for dedup
-  // correctness (a busy label could otherwise page today's issue out and
-  // double-file). per_page:10 ≈ 5 weeks at Tue/Thu cadence, ample headroom.
-  const existing = (await client.request("GET /repos/{owner}/{repo}/issues", {
-    owner: REPO_OWNER,
-    repo: REPO_NAME,
-    state: "all",
-    labels: SENTRY_MONITOR_SLUG,
-    sort: "created",
-    direction: "desc",
-    per_page: 10,
-    headers: { "X-GitHub-Api-Version": "2022-11-28" },
-  })) as { data: Array<{ title: string }> };
-  if (existing.data.some((i) => i.title.startsWith(title))) {
-    return { created: false };
-  }
-
-  // Self-diagnosing body — the cron's own redacted spawn tail + timing, so the
-  // failure is triageable without SSH (app stdout is not shipped to Better
-  // Stack). The tails are already token-redacted by the eval substrate.
-  const body =
-    `Automated FAILED self-report from \`cron-content-generator\`.\n\n` +
-    `This run terminated WITHOUT producing a \`scheduled-content-generator\` ` +
-    `audit issue via the prompt (mid-eval crash / upstream API error / ` +
-    `max-turns kill). The handler-level fallback (#4960) filed this issue so ` +
-    `the run is not silent and the \`cron-cloud-task-heartbeat\` watchdog ` +
-    `stays green.\n\n` +
-    `| Signal | Value |\n| --- | --- |\n` +
-    `| fn | \`cron-content-generator\` |\n` +
-    `| runStartedAt | \`${runStartedAt}\` |\n` +
-    `| exitCode | \`${spawnResult.exitCode}\` |\n` +
-    `| signal | \`${spawnResult.signal}\` |\n` +
-    `| abortedByTimeout | \`${spawnResult.abortedByTimeout}\` |\n` +
-    `| durationMs | \`${spawnResult.durationMs}\` |\n` +
-    `| stdoutTail | \`${formatTailForIssue(spawnResult.stdoutTail)}\` |\n` +
-    `| stderrTail | \`${formatTailForIssue(spawnResult.stderrTail)}\` |\n\n` +
-    `Triage: \`knowledge-base/engineering/operations/runbooks/cloud-scheduled-tasks.md\` (H2).`;
-
-  await client.request("POST /repos/{owner}/{repo}/issues", {
-    owner: REPO_OWNER,
-    repo: REPO_NAME,
-    title,
-    body,
-    labels: [SENTRY_MONITOR_SLUG],
-  });
-  return { created: true };
-}
 
 // =============================================================================
 // Handler
@@ -369,13 +262,16 @@ export async function cronContentGeneratorHandler({
     //         fallback even if the issue is genuinely absent — covered by the
     //         watchdog's maxGapDays threshold, not this step.
     //     (b) On a verify-throw + spawn-nonzero run the gate fires even though
-    //         the prompt's issue may exist; ensureContentGeneratorAuditIssue's
-    //         own same-title dedup is what prevents a spurious second issue — so
+    //         the prompt's issue may exist; ensureScheduledAuditIssue's own
+    //         same-title dedup is what prevents a spurious second issue — so
     //         keep that dedup robust (it is load-bearing, not belt-and-suspenders). ---
     if (!heartbeatOk) {
       await step.run("ensure-audit-issue", async () => {
         try {
-          await ensureContentGeneratorAuditIssue({
+          await ensureScheduledAuditIssue({
+            label: SENTRY_MONITOR_SLUG,
+            titlePrefix: "[Scheduled] Content Generator -",
+            cronName: "cron-content-generator",
             runStartedAt,
             spawnResult,
             installationToken,

--- a/apps/web-platform/server/inngest/functions/cron-growth-audit.ts
+++ b/apps/web-platform/server/inngest/functions/cron-growth-audit.ts
@@ -20,6 +20,7 @@ import {
   mintInstallationToken,
   postSentryHeartbeat,
   resolveOutputAwareOk,
+  ensureScheduledAuditIssue,
   type HandlerArgs,
 } from "./_cron-shared";
 import {
@@ -222,6 +223,36 @@ export async function cronGrowthAuditHandler({
     await step.run("sentry-heartbeat", async () => {
       await postSentryHeartbeat({ ok: heartbeatOk, sentryMonitorSlug: SENTRY_MONITOR_SLUG, cronName: "cron-growth-audit", logger });
     });
+
+    // --- Step 5: silence-hole fallback (#4960, generalized #4978). When the
+    //     output-aware check found NO scheduled-growth-audit issue in the run
+    //     window, the prompt's create-issue step never ran (mid-eval crash /
+    //     API 500 / max-turns kill). Self-report a FAILED audit issue so the run
+    //     is never silent. Wrapped so a create failure cannot crash the
+    //     finally/teardown — reported to Sentry instead; the watchdog still
+    //     catches the absence after threshold (defense-in-depth). ---
+    if (!heartbeatOk) {
+      await step.run("ensure-audit-issue", async () => {
+        try {
+          await ensureScheduledAuditIssue({
+            label: SENTRY_MONITOR_SLUG,
+            titlePrefix: "[Scheduled] Growth Audit -",
+            cronName: "cron-growth-audit",
+            runStartedAt,
+            spawnResult,
+            installationToken,
+          });
+        } catch (err) {
+          reportSilentFallback(err, {
+            feature: "cron-growth-audit",
+            op: "ensure-audit-issue-failed",
+            message:
+              "Handler-level fallback audit-issue create failed; run remains silent until watchdog threshold",
+            extra: { fn: "cron-growth-audit", runStartedAt },
+          });
+        }
+      });
+    }
 
     return { ok: heartbeatOk };
   } finally {

--- a/apps/web-platform/server/inngest/functions/cron-growth-execution.ts
+++ b/apps/web-platform/server/inngest/functions/cron-growth-execution.ts
@@ -47,6 +47,7 @@ import {
   mintInstallationToken,
   postSentryHeartbeat,
   resolveOutputAwareOk,
+  ensureScheduledAuditIssue,
   type HandlerArgs,
 } from "./_cron-shared";
 import {
@@ -259,6 +260,36 @@ export async function cronGrowthExecutionHandler({
     await step.run("sentry-heartbeat", async () => {
       await postSentryHeartbeat({ ok: heartbeatOk, sentryMonitorSlug: SENTRY_MONITOR_SLUG, cronName: "cron-growth-execution", logger });
     });
+
+    // --- Step 5: silence-hole fallback (#4960, generalized #4978). When the
+    //     output-aware check found NO scheduled-growth-execution issue in the
+    //     run window, the prompt's create-issue step never ran (mid-eval crash /
+    //     API 500 / max-turns kill). Self-report a FAILED audit issue so the run
+    //     is never silent. Wrapped so a create failure cannot crash the
+    //     finally/teardown — reported to Sentry instead; the watchdog still
+    //     catches the absence after threshold (defense-in-depth). ---
+    if (!heartbeatOk) {
+      await step.run("ensure-audit-issue", async () => {
+        try {
+          await ensureScheduledAuditIssue({
+            label: SENTRY_MONITOR_SLUG,
+            titlePrefix: "[Scheduled] Growth Execution -",
+            cronName: "cron-growth-execution",
+            runStartedAt,
+            spawnResult,
+            installationToken,
+          });
+        } catch (err) {
+          reportSilentFallback(err, {
+            feature: "cron-growth-execution",
+            op: "ensure-audit-issue-failed",
+            message:
+              "Handler-level fallback audit-issue create failed; run remains silent until watchdog threshold",
+            extra: { fn: "cron-growth-execution", runStartedAt },
+          });
+        }
+      });
+    }
 
     return { ok: heartbeatOk };
   } finally {

--- a/apps/web-platform/server/inngest/functions/cron-roadmap-review.ts
+++ b/apps/web-platform/server/inngest/functions/cron-roadmap-review.ts
@@ -49,6 +49,7 @@ import {
   mintInstallationToken,
   postSentryHeartbeat,
   resolveOutputAwareOk,
+  ensureScheduledAuditIssue,
   type HandlerArgs,
 } from "./_cron-shared";
 import {
@@ -298,6 +299,36 @@ export async function cronRoadmapReviewHandler({
     await step.run("sentry-heartbeat", async () => {
       await postSentryHeartbeat({ ok: heartbeatOk, sentryMonitorSlug: SENTRY_MONITOR_SLUG, cronName: "cron-roadmap-review", logger });
     });
+
+    // --- Step 5: silence-hole fallback (#4960, generalized #4978). When the
+    //     output-aware check found NO scheduled-roadmap-review issue in the run
+    //     window, the prompt's create-issue step never ran (mid-eval crash /
+    //     API 500 / max-turns kill). Self-report a FAILED audit issue so the run
+    //     is never silent. Wrapped so a create failure cannot crash the
+    //     finally/teardown — reported to Sentry instead; the watchdog still
+    //     catches the absence after threshold (defense-in-depth). ---
+    if (!heartbeatOk) {
+      await step.run("ensure-audit-issue", async () => {
+        try {
+          await ensureScheduledAuditIssue({
+            label: SENTRY_MONITOR_SLUG,
+            titlePrefix: "[Scheduled] Weekly Roadmap Review -",
+            cronName: "cron-roadmap-review",
+            runStartedAt,
+            spawnResult,
+            installationToken,
+          });
+        } catch (err) {
+          reportSilentFallback(err, {
+            feature: "cron-roadmap-review",
+            op: "ensure-audit-issue-failed",
+            message:
+              "Handler-level fallback audit-issue create failed; run remains silent until watchdog threshold",
+            extra: { fn: "cron-roadmap-review", runStartedAt },
+          });
+        }
+      });
+    }
 
     return { ok: heartbeatOk };
   } finally {

--- a/apps/web-platform/server/inngest/functions/cron-seo-aeo-audit.ts
+++ b/apps/web-platform/server/inngest/functions/cron-seo-aeo-audit.ts
@@ -48,6 +48,7 @@ import {
   mintInstallationToken,
   postSentryHeartbeat,
   resolveOutputAwareOk,
+  ensureScheduledAuditIssue,
   type HandlerArgs,
 } from "./_cron-shared";
 import {
@@ -251,6 +252,36 @@ export async function cronSeoAeoAuditHandler({
     await step.run("sentry-heartbeat", async () => {
       await postSentryHeartbeat({ ok: heartbeatOk, sentryMonitorSlug: SENTRY_MONITOR_SLUG, cronName: "cron-seo-aeo-audit", logger });
     });
+
+    // --- Step 5: silence-hole fallback (#4960, generalized #4978). When the
+    //     output-aware check found NO scheduled-seo-aeo-audit issue in the run
+    //     window, the prompt's create-issue step never ran (mid-eval crash /
+    //     API 500 / max-turns kill). Self-report a FAILED audit issue so the run
+    //     is never silent. Wrapped so a create failure cannot crash the
+    //     finally/teardown — reported to Sentry instead; the watchdog still
+    //     catches the absence after threshold (defense-in-depth). ---
+    if (!heartbeatOk) {
+      await step.run("ensure-audit-issue", async () => {
+        try {
+          await ensureScheduledAuditIssue({
+            label: SENTRY_MONITOR_SLUG,
+            titlePrefix: "[Scheduled] SEO/AEO Audit -",
+            cronName: "cron-seo-aeo-audit",
+            runStartedAt,
+            spawnResult,
+            installationToken,
+          });
+        } catch (err) {
+          reportSilentFallback(err, {
+            feature: "cron-seo-aeo-audit",
+            op: "ensure-audit-issue-failed",
+            message:
+              "Handler-level fallback audit-issue create failed; run remains silent until watchdog threshold",
+            extra: { fn: "cron-seo-aeo-audit", runStartedAt },
+          });
+        }
+      });
+    }
 
     return { ok: heartbeatOk };
   } finally {

--- a/apps/web-platform/test/server/inngest/cron-content-generator.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-content-generator.test.ts
@@ -22,11 +22,9 @@ vi.hoisted(() => {
 
 import {
   cronContentGenerator,
-  ensureContentGeneratorAuditIssue,
   KILL_ESCALATION_MS,
   MAX_TURN_DURATION_MS,
 } from "@/server/inngest/functions/cron-content-generator";
-import type { Octokit } from "@octokit/core";
 
 describe("cronContentGenerator — registration shape (import-time smoke)", () => {
   it("loads without throwing (handler + client startup pass)", () => {
@@ -154,130 +152,12 @@ describe("ensure-audit-issue fallback — source-shape anchors (#4960)", () => {
   });
 });
 
-describe("ensureContentGeneratorAuditIssue — behavioral (injected octokit)", () => {
-  const RUN_STARTED_AT = "2026-06-05T15:05:11.992Z";
-  const SPAWN = {
-    exitCode: 1,
-    signal: null,
-    abortedByTimeout: false,
-    durationMs: 368727,
-    stdoutTail: "API Error: 500 Internal server error.",
-    stderrTail: "",
-  };
-
-  function fakeOctokit(getData: Array<{ title: string }>) {
-    const calls: Array<{ route: string; params: Record<string, unknown> }> = [];
-    const octokit = {
-      request: vi.fn(async (route: string, params: Record<string, unknown>) => {
-        calls.push({ route, params });
-        if (route.startsWith("GET")) return { data: getData };
-        return { data: { number: 9999 } };
-      }),
-    } as unknown as Octokit;
-    return { octokit, calls };
-  }
-
-  it("creates exactly one labeled audit issue when none exists in the window", async () => {
-    const { octokit, calls } = fakeOctokit([]);
-    const res = await ensureContentGeneratorAuditIssue({
-      runStartedAt: RUN_STARTED_AT,
-      spawnResult: SPAWN,
-      octokit,
-    });
-    expect(res.created).toBe(true);
-    const posts = calls.filter((c) => c.route.startsWith("POST"));
-    expect(posts).toHaveLength(1);
-    expect(posts[0].params.title).toBe(
-      "[Scheduled] Content Generator - 2026-06-05",
-    );
-    expect(posts[0].params.labels).toEqual(["scheduled-content-generator"]);
-    // Self-diagnosing body carries the failure evidence.
-    expect(String(posts[0].params.body)).toContain("API Error: 500");
-    expect(String(posts[0].params.body)).toContain("exitCode");
-  });
-
-  it("does NOT double-file when today's audit issue already exists (retries:1 dedup)", async () => {
-    const { octokit, calls } = fakeOctokit([
-      { title: "[Scheduled] Content Generator - 2026-06-05" },
-    ]);
-    const res = await ensureContentGeneratorAuditIssue({
-      runStartedAt: RUN_STARTED_AT,
-      spawnResult: SPAWN,
-      octokit,
-    });
-    expect(res.created).toBe(false);
-    expect(calls.filter((c) => c.route.startsWith("POST"))).toHaveLength(0);
-  });
-
-  it("dedup is title-PREFIX (a suffixed prompt issue still suppresses the fallback)", async () => {
-    const { octokit, calls } = fakeOctokit([
-      { title: "[Scheduled] Content Generator - 2026-06-05 (manual)" },
-    ]);
-    const res = await ensureContentGeneratorAuditIssue({
-      runStartedAt: RUN_STARTED_AT,
-      spawnResult: SPAWN,
-      octokit,
-    });
-    expect(res.created).toBe(false);
-    expect(calls.filter((c) => c.route.startsWith("POST"))).toHaveLength(0);
-  });
-
-  it("dedup GET is label-scoped, state:all, explicitly sorted newest-first", async () => {
-    const { octokit, calls } = fakeOctokit([]);
-    await ensureContentGeneratorAuditIssue({
-      runStartedAt: RUN_STARTED_AT,
-      spawnResult: SPAWN,
-      octokit,
-    });
-    const get = calls.find((c) => c.route.startsWith("GET"));
-    expect(get?.params.labels).toBe("scheduled-content-generator");
-    expect(get?.params.state).toBe("all");
-    expect(get?.params.sort).toBe("created");
-    expect(get?.params.direction).toBe("desc");
-  });
-
-  it("scrubs secrets and neutralizes markdown-breakout chars in the issue body", async () => {
-    const { octokit, calls } = fakeOctokit([]);
-    await ensureContentGeneratorAuditIssue({
-      runStartedAt: RUN_STARTED_AT,
-      spawnResult: {
-        ...SPAWN,
-        // crash-path stderr spilling an Anthropic key + table-breaking chars
-        // (incl. a literal backslash-pipe to exercise escape-order, js/incomplete-sanitization)
-        stderrTail: "boom sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAA \\| pipe `tick`",
-      },
-      octokit,
-    });
-    const body = String(
-      calls.find((c) => c.route.startsWith("POST"))!.params.body,
-    );
-    expect(body).not.toContain("sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAA");
-    expect(body).toContain("[redacted-key]");
-    // table-breaking chars are escaped/neutralized inside the inline-code cell:
-    // backslash is escaped FIRST (js/incomplete-sanitization) so an input `\|`
-    // becomes `\\\|` (escaped backslash + escaped pipe), pipe → "\|" (markdown
-    // literal, no row break), backtick → "ʼ" (no span break).
-    expect(body).toContain("\\\\\\| pipe"); // input `\| ` → `\\\| `
-    expect(body).toContain("ʼtickʼ");
-    expect(body).not.toContain("`tick`");
-  });
-
-  it("propagates a create failure to the caller (handler wraps it in reportSilentFallback)", async () => {
-    const octokit = {
-      request: vi.fn(async (route: string) => {
-        if (route.startsWith("GET")) return { data: [] };
-        throw new Error("GitHub 503");
-      }),
-    } as unknown as Octokit;
-    await expect(
-      ensureContentGeneratorAuditIssue({
-        runStartedAt: RUN_STARTED_AT,
-        spawnResult: SPAWN,
-        octokit,
-      }),
-    ).rejects.toThrow("GitHub 503");
-  });
-});
+// NOTE: the behavioral coverage for the audit-issue fallback now lives in
+// cron-shared.test.ts (`ensureScheduledAuditIssue (shared fallback)`) — the
+// helper was extracted into _cron-shared.ts and parameterized for all 8
+// always-create producers (#4978). The wiring (the call site + `!heartbeatOk`
+// gate) stays guarded by the source-shape anchors above and by
+// cron-producer-output-wiring.test.ts.
 
 describe("buildSpawnEnv allowlist (security surface)", () => {
   const buildEnvMatch = SUT_SOURCE.match(

--- a/apps/web-platform/test/server/inngest/cron-producer-output-wiring.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-producer-output-wiring.test.ts
@@ -85,6 +85,21 @@ describe("output-aware heartbeat wiring (always-create producers)", () => {
       expect(src).toContain("stderrTail: spawnResult.stderrTail");
       expect(src).toContain("exitCode: spawnResult.exitCode");
       expect(src).toContain("stdoutTail: spawnResult.stdoutTail");
+
+      // #4960/#4978 — the handler-level silence-hole fallback. When the
+      // output-aware check found no labeled issue in the run window (mid-eval
+      // crash / API 500 / max-turns kill bypassed the prompt's create step),
+      // the handler ITSELF files a FAILED audit issue via the shared
+      // ensureScheduledAuditIssue helper so the run is never silent. The step
+      // must be gated on `!heartbeatOk` and wrap the create so a fallback
+      // failure is reported to Sentry (op:"ensure-audit-issue-failed") rather
+      // than crashing the finally/teardown. A revert of just this wiring
+      // (leaving the shared helper + its unit tests green) would otherwise pass
+      // the whole suite — same un-wiring-guard rationale as above.
+      expect(src).toContain("ensureScheduledAuditIssue(");
+      expect(src).toContain('"ensure-audit-issue"');
+      expect(src).toContain("if (!heartbeatOk)");
+      expect(src).toContain('op: "ensure-audit-issue-failed"');
     },
   );
 
@@ -105,6 +120,12 @@ describe("output-aware heartbeat wiring (always-create producers)", () => {
       // Sentry event (off-host-visible), not a bare logger.warn.
       expect(src).toContain("warnSilentFallback");
       expect(src).toContain('op: "claude-eval-nonzero-noop"');
+
+      // #4978 — best-effort crons are NOT output-aware producers, so they must
+      // NOT adopt the silence-hole fallback. A clean run that legitimately
+      // files no issue is the NORMAL outcome here; firing the fallback would
+      // spam FAILED audit issues on every healthy zero-artifact run.
+      expect(src).not.toContain("ensureScheduledAuditIssue");
     },
   );
 

--- a/apps/web-platform/test/server/inngest/cron-shared.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-shared.test.ts
@@ -25,9 +25,11 @@ vi.mock("@/server/observability", () => ({
 }));
 
 import {
+  ensureScheduledAuditIssue,
   resolveOutputAwareOk,
   verifyScheduledIssueCreated,
 } from "@/server/inngest/functions/_cron-shared";
+import type { Octokit } from "@octokit/core";
 
 function octokitReturning(issues: Array<{ updated_at: string }>) {
   const request = vi.fn().mockResolvedValue({ data: issues });
@@ -249,5 +251,200 @@ describe("resolveOutputAwareOk", () => {
       octokit,
     });
     expect(okFalse).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureScheduledAuditIssue — the handler-level silence-hole fallback (#4960),
+// extracted from cron-content-generator and parameterized for all 8 always-
+// create producers (#4978). When the output-aware heartbeat finds NO labeled
+// issue in the run window, the handler files a self-reporting FAILED audit
+// issue so the run is never silent. The behavior under test (dedup, redaction,
+// markdown-breakout neutralization, create) is identical to the proven
+// content-generator helper — these tests pin it for the shared, parameterized
+// form so a hardcoded-slug regression fails.
+// ---------------------------------------------------------------------------
+
+describe("ensureScheduledAuditIssue (shared fallback)", () => {
+  const RUN_STARTED_AT = "2026-06-05T15:05:11.992Z";
+  const DATE = "2026-06-05"; // runStartedAt.slice(0, 10)
+  const SPAWN = {
+    exitCode: 1,
+    signal: null,
+    abortedByTimeout: false,
+    durationMs: 368727,
+    stdoutTail: "API Error: 500 Internal server error.",
+    stderrTail: "",
+  };
+
+  // ≥2 distinct {label, titlePrefix} pairs so a hardcoded-slug regression
+  // (e.g. forgetting to thread args.label / args.titlePrefix) fails loudly.
+  const PAIRS = [
+    {
+      label: "scheduled-growth-audit",
+      titlePrefix: "[Scheduled] Growth Audit -",
+      cronName: "cron-growth-audit",
+    },
+    {
+      label: "scheduled-community-monitor",
+      titlePrefix: "[Scheduled] Community Monitor -",
+      cronName: "cron-community-monitor",
+    },
+  ] as const;
+
+  function fakeOctokit(getData: Array<{ title: string }>) {
+    const calls: Array<{ route: string; params: Record<string, unknown> }> = [];
+    const octokit = {
+      request: vi.fn(async (route: string, params: Record<string, unknown>) => {
+        calls.push({ route, params });
+        if (route.startsWith("GET")) return { data: getData };
+        return { data: { number: 9999 } };
+      }),
+    } as unknown as Octokit;
+    return { octokit, calls };
+  }
+
+  it.each(PAIRS)(
+    "creates exactly one labeled audit issue for $label when none exists in the window",
+    async ({ label, titlePrefix, cronName }) => {
+      const { octokit, calls } = fakeOctokit([]);
+      const res = await ensureScheduledAuditIssue({
+        label,
+        titlePrefix,
+        cronName,
+        runStartedAt: RUN_STARTED_AT,
+        spawnResult: SPAWN,
+        octokit,
+      });
+      expect(res.created).toBe(true);
+      const posts = calls.filter((c) => c.route.startsWith("POST"));
+      expect(posts).toHaveLength(1);
+      // Title is `${titlePrefix} ${date}` with date = runStartedAt.slice(0,10).
+      expect(posts[0].params.title).toBe(`${titlePrefix} ${DATE}`);
+      expect(posts[0].params.labels).toEqual([label]);
+      // Self-diagnosing body carries the cronName + failure evidence.
+      expect(String(posts[0].params.body)).toContain(cronName);
+      expect(String(posts[0].params.body)).toContain("API Error: 500");
+      expect(String(posts[0].params.body)).toContain("exitCode");
+    },
+  );
+
+  it("composes the content-generator title byte-identically (AC2)", async () => {
+    const { octokit, calls } = fakeOctokit([]);
+    await ensureScheduledAuditIssue({
+      label: "scheduled-content-generator",
+      titlePrefix: "[Scheduled] Content Generator -",
+      cronName: "cron-content-generator",
+      runStartedAt: RUN_STARTED_AT,
+      spawnResult: SPAWN,
+      octokit,
+    });
+    const post = calls.find((c) => c.route.startsWith("POST"));
+    expect(post?.params.title).toBe(`[Scheduled] Content Generator - ${DATE}`);
+  });
+
+  it.each(PAIRS)(
+    "does NOT double-file for $label when an EXACT same-day audit title already exists",
+    async ({ label, titlePrefix, cronName }) => {
+      const { octokit, calls } = fakeOctokit([
+        { title: `${titlePrefix} ${DATE}` },
+      ]);
+      const res = await ensureScheduledAuditIssue({
+        label,
+        titlePrefix,
+        cronName,
+        runStartedAt: RUN_STARTED_AT,
+        spawnResult: SPAWN,
+        octokit,
+      });
+      expect(res.created).toBe(false);
+      expect(calls.filter((c) => c.route.startsWith("POST"))).toHaveLength(0);
+    },
+  );
+
+  it.each(PAIRS)(
+    "dedup is title-PREFIX for $label — a suffixed prompt-success issue suppresses the fallback",
+    async ({ label, titlePrefix, cronName }) => {
+      const { octokit, calls } = fakeOctokit([
+        { title: `${titlePrefix} ${DATE} (manual)` },
+      ]);
+      const res = await ensureScheduledAuditIssue({
+        label,
+        titlePrefix,
+        cronName,
+        runStartedAt: RUN_STARTED_AT,
+        spawnResult: SPAWN,
+        octokit,
+      });
+      expect(res.created).toBe(false);
+      expect(calls.filter((c) => c.route.startsWith("POST"))).toHaveLength(0);
+    },
+  );
+
+  it("dedup GET is label-scoped, state:all, sort:created/desc, per_page:10 (AC6)", async () => {
+    const { octokit, calls } = fakeOctokit([]);
+    await ensureScheduledAuditIssue({
+      label: "scheduled-growth-audit",
+      titlePrefix: "[Scheduled] Growth Audit -",
+      cronName: "cron-growth-audit",
+      runStartedAt: RUN_STARTED_AT,
+      spawnResult: SPAWN,
+      octokit,
+    });
+    const get = calls.find((c) => c.route.startsWith("GET"));
+    expect(get?.route).toBe("GET /repos/{owner}/{repo}/issues");
+    expect(get?.params.labels).toBe("scheduled-growth-audit");
+    expect(get?.params.state).toBe("all");
+    expect(get?.params.sort).toBe("created");
+    expect(get?.params.direction).toBe("desc");
+    expect(get?.params.per_page).toBe(10);
+  });
+
+  it("scrubs secrets and neutralizes markdown-breakout chars in the issue body (AC5)", async () => {
+    const { octokit, calls } = fakeOctokit([]);
+    await ensureScheduledAuditIssue({
+      label: "scheduled-seo-aeo-audit",
+      titlePrefix: "[Scheduled] SEO/AEO Audit -",
+      cronName: "cron-seo-aeo-audit",
+      runStartedAt: RUN_STARTED_AT,
+      spawnResult: {
+        ...SPAWN,
+        // crash-path stderr spilling an Anthropic key + table-breaking chars
+        // (incl. a literal backslash-pipe to exercise escape-order, js/incomplete-sanitization)
+        stderrTail: "boom sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAA \\| pipe `tick`",
+      },
+      octokit,
+    });
+    const body = String(
+      calls.find((c) => c.route.startsWith("POST"))!.params.body,
+    );
+    expect(body).not.toContain("sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAA");
+    expect(body).toContain("[redacted-key]");
+    // table-breaking chars neutralized inside the inline-code cell: backslash
+    // escaped FIRST (js/incomplete-sanitization) so `\|` → `\\\|`, pipe → "\|"
+    // (markdown literal, no row break), backtick → "ʼ" (no span break),
+    // CR/LF → space.
+    expect(body).toContain("\\\\\\| pipe");
+    expect(body).toContain("ʼtickʼ");
+    expect(body).not.toContain("`tick`");
+  });
+
+  it("propagates a create failure to the caller (POST throws → helper rejects)", async () => {
+    const octokit = {
+      request: vi.fn(async (route: string) => {
+        if (route.startsWith("GET")) return { data: [] };
+        throw new Error("GitHub 503");
+      }),
+    } as unknown as Octokit;
+    await expect(
+      ensureScheduledAuditIssue({
+        label: "scheduled-roadmap-review",
+        titlePrefix: "[Scheduled] Weekly Roadmap Review -",
+        cronName: "cron-roadmap-review",
+        runStartedAt: RUN_STARTED_AT,
+        spawnResult: SPAWN,
+        octokit,
+      }),
+    ).rejects.toThrow("GitHub 503");
   });
 });

--- a/apps/web-platform/test/server/inngest/cron-shared.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-shared.test.ts
@@ -429,6 +429,53 @@ describe("ensureScheduledAuditIssue (shared fallback)", () => {
     expect(body).not.toContain("`tick`");
   });
 
+  it("collapses CR/LF in the tail to a single space (no markdown row-break)", async () => {
+    const { octokit, calls } = fakeOctokit([]);
+    await ensureScheduledAuditIssue({
+      label: "scheduled-growth-audit",
+      titlePrefix: "[Scheduled] Growth Audit -",
+      cronName: "cron-growth-audit",
+      runStartedAt: RUN_STARTED_AT,
+      spawnResult: { ...SPAWN, stderrTail: "line1\r\nline2\nline3" },
+      octokit,
+    });
+    const body = String(
+      calls.find((c) => c.route.startsWith("POST"))!.params.body,
+    );
+    // CR/LF collapsed to a single space so the tail stays inside one table cell.
+    expect(body).toContain("line1 line2 line3");
+    expect(body).not.toContain("line1\nline2");
+  });
+
+  it("renders the (empty) sentinel for an empty tail", async () => {
+    const { octokit, calls } = fakeOctokit([]);
+    await ensureScheduledAuditIssue({
+      label: "scheduled-growth-audit",
+      titlePrefix: "[Scheduled] Growth Audit -",
+      cronName: "cron-growth-audit",
+      runStartedAt: RUN_STARTED_AT,
+      spawnResult: { ...SPAWN, stdoutTail: "", stderrTail: "" },
+      octokit,
+    });
+    const body = String(
+      calls.find((c) => c.route.startsWith("POST"))!.params.body,
+    );
+    expect(body).toContain("(empty)");
+  });
+
+  it("throws when neither octokit nor installationToken is provided", async () => {
+    await expect(
+      ensureScheduledAuditIssue({
+        label: "scheduled-growth-audit",
+        titlePrefix: "[Scheduled] Growth Audit -",
+        cronName: "cron-growth-audit",
+        runStartedAt: RUN_STARTED_AT,
+        spawnResult: SPAWN,
+        // no octokit, no installationToken
+      }),
+    ).rejects.toThrow(/need octokit or installationToken/);
+  });
+
   it("propagates a create failure to the caller (POST throws → helper rejects)", async () => {
     const octokit = {
       request: vi.fn(async (route: string) => {

--- a/knowledge-base/project/plans/2026-06-06-feat-generalize-cron-handler-fallback-all-producers-plan.md
+++ b/knowledge-base/project/plans/2026-06-06-feat-generalize-cron-handler-fallback-all-producers-plan.md
@@ -1,0 +1,350 @@
+---
+title: "feat: Generalize handler-level fallback audit-issue to all 8 always-create cron producers"
+date: 2026-06-06
+type: feat
+issue: 4978
+branch: feat-one-shot-4978-cron-fallback-all-producers
+lane: cross-domain
+brand_survival_threshold: aggregate pattern
+---
+
+# ♻️ feat: Generalize the handler-level fallback audit-issue to all 8 always-create cron producers (#4978)
+
+## Overview
+
+PR #4975 (merged 2026-06-05 19:57 UTC, closes #4960) added a **handler-level
+`ensure-audit-issue` fallback** to `cron-content-generator.ts`: when the
+output-aware heartbeat check (`resolveOutputAwareOk`) finds NO
+`scheduled-content-generator` issue in the run window, the handler itself files
+a self-reporting `FAILED [Scheduled] Content Generator - <date>` issue so the
+run is never silent. It lives ABOVE the prompt, so it survives any termination
+that bypasses the prompt's in-prompt "create issue and stop" steps (mid-eval
+crash, upstream Anthropic API 500, max-turns kill).
+
+The fallback was observed firing correctly in prod: issue #4982
+(`[Scheduled] Content Generator - 2026-06-05`) self-reported end-to-end at
+2026-06-05 20:58 UTC, and the daily `cloud-task-silence` alerts ceased.
+
+The fallback currently lives **only** in content-generator. The source learning
+(`knowledge-base/project/learnings/integration-issues/2026-06-05-cloud-task-silence-per-producer-triage-and-handler-fallback.md`)
+states explicitly: *"All 8 always-create cron producers share this hole … generalizing
+the fallback to the other 7 producers (extract into `_cron-shared.ts`) is a
+tracked follow-up."* This is that follow-up (#4978).
+
+**The work:**
+1. Extract the proven fallback primitive (`AUDIT_TAIL_CHARS`, `formatTailForIssue`,
+   `ensureContentGeneratorAuditIssue`) out of `cron-content-generator.ts` into a
+   shared helper in `_cron-shared.ts`, parameterized by `{ label, titlePrefix }`
+   (plus `cronName` for observability `feature`/`extra`).
+2. Re-wire `cron-content-generator.ts` to call the shared helper (no behavior change).
+3. Wire the other 7 always-create producers (roadmap-review,
+   competitive-analysis, growth-audit, growth-execution, seo-aeo-audit,
+   community-monitor, campaign-calendar) to call the shared helper after their
+   `verify-output` step, gated on `!heartbeatOk`.
+4. Extend the un-wiring guard (`cron-producer-output-wiring.test.ts`) to assert
+   the `ensure-audit-issue` step is present in all 8.
+5. Add behavioral unit tests for the shared helper in `cron-shared.test.ts`.
+
+This is a **pure backend refactor + wiring change** — no schema, no migration, no
+infra, no UI, no new dependency, no prompt edit, no turn-budget bump.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (from issue #4978) | Codebase reality | Plan response |
+| --- | --- | --- |
+| "proven on content-generator in PR #4975" | ✅ PR #4975 MERGED; `ensureContentGeneratorAuditIssue` present at `cron-content-generator.ts:176-253`; fired in prod (#4982) | Extract verbatim, preserve all invariants |
+| "shared `_cron-shared.ts` helper parameterized by `{ label, titlePrefix }`" | content-generator's helper hardcodes `SENTRY_MONITOR_SLUG` (label) and `[Scheduled] Content Generator` (titlePrefix). Both vary per producer. | Parameterize by `{ label, titlePrefix, cronName }` — `cronName` is also hardcoded and needed for Sentry `feature`/`extra` |
+| "all 8 always-create cron producers" | All 8 confirmed present + structurally uniform (verify-output → sentry-heartbeat → `return { ok: heartbeatOk }`). They are exactly the `WIRED_PRODUCERS` list in `cron-producer-output-wiring.test.ts:22-40`. | Wire all 8; content-generator is re-wire (no behavior change), other 7 are new |
+| "call it after their verify-output step, gated on `!heartbeatOk`" | content-generator's pattern: `if (!heartbeatOk) { await step.run("ensure-audit-issue", …) }` between `sentry-heartbeat` and the `finally` teardown (`cron-content-generator.ts:375-393`) | Mirror that exact placement in all 7 |
+| Title prefix derivable from slug | ❌ FALSE. 8 distinct prefixes that do NOT match `scheduled-<slug>` — see "Per-producer title prefixes" table below | `titlePrefix` is a required explicit param, NOT slug-derived |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a scheduled cron producer (e.g.
+SEO/AEO audit, growth audit) silently goes dark on a mid-eval crash — no audit
+issue, no Sentry red, no `cloud-task-silence` alert for up to `maxGapDays` (3-40
+days depending on producer) — exactly the #4960 failure class this PR closes for
+the other 7. A *broken* fallback (e.g. an unredacted spawn tail) could leak a
+secret into a public GitHub issue body.
+
+**If this leaks, the user's data is exposed via:** the FAILED audit-issue body
+interpolates the redacted spawn `stdoutTail`/`stderrTail`. If the multi-secret
+scrubber (`redactGithubSourcedText`) or the markdown-breakout neutralization
+regresses during extraction, a crash stack could spill an allowlisted-env secret
+(`ANTHROPIC_API_KEY` / `sk-ant-…`) into a public issue, or inject a
+markdown-table breakout (image-autofetch / banner injection).
+
+**Brand-survival threshold:** aggregate pattern. The content-generator fallback
+already shipped at this same risk profile (PR #4975) and was reviewed by
+security-sentinel; this PR generalizes the *same already-vetted* redaction path
+to 7 more producers — it does not introduce a new exposure surface, it
+replicates a vetted one. No new per-PR CPO sign-off; the section is present per
+the gate.
+
+## Per-producer title prefixes (load-bearing — dedup is `title.startsWith`)
+
+The fallback files `${titlePrefix} ${date}` and dedups against a label-scoped GET
+via `title.startsWith(${titlePrefix} ${date})`. The prefix MUST match each
+producer's prompt-emitted success title or the dedup breaks (double-file under
+`retries:1`). Verified against each handler's prompt block:
+
+| Producer | label (SENTRY_MONITOR_SLUG) | titlePrefix |
+| --- | --- | --- |
+| content-generator | `scheduled-content-generator` | `[Scheduled] Content Generator -` |
+| roadmap-review | `scheduled-roadmap-review` | `[Scheduled] Weekly Roadmap Review -` |
+| competitive-analysis | `scheduled-competitive-analysis` | `[Scheduled] Competitive Analysis -` |
+| growth-audit | `scheduled-growth-audit` | `[Scheduled] Growth Audit -` |
+| growth-execution | `scheduled-growth-execution` | `[Scheduled] Growth Execution -` |
+| seo-aeo-audit | `scheduled-seo-aeo-audit` | `[Scheduled] SEO/AEO Audit -` |
+| community-monitor | `scheduled-community-monitor` | `[Scheduled] Community Monitor -` |
+| campaign-calendar | `scheduled-campaign-calendar` | `[Scheduled] Campaign Calendar -` |
+
+**Note on the exact dedup string.** content-generator builds
+`title = \`[Scheduled] Content Generator - ${date}\`` (with ` - ` separator) and
+dedups via `startsWith(title)`. To preserve byte-identical behavior the shared
+helper must compose `${titlePrefix} ${date}` where `titlePrefix` ENDS in ` -`
+(no trailing space) — i.e. `titlePrefix = "[Scheduled] Content Generator -"` and
+the helper joins with a single space → `"[Scheduled] Content Generator - <date>"`.
+The /work author MUST verify the composed string is byte-identical to the
+pre-extraction content-generator title (an AC covers this).
+
+## Sharp Edges (carry-forward + new)
+
+- **content-generator dedup edge generalizes.** The dedup GET is label-scoped +
+  title-prefix. For producers whose label is ALSO used by non-`[Scheduled]`
+  issues, the prefix is what disambiguates:
+  - **campaign-calendar** uses `scheduled-campaign-calendar` for THREE title
+    shapes: `[Content] Overdue: …`, `[Scheduled] Campaign Calendar - <date> (heartbeat)`,
+    and the fallback `[Scheduled] Campaign Calendar - <date>`. The dedup prefix
+    `[Scheduled] Campaign Calendar - <date>` will NOT match `[Content] Overdue:`
+    (correct — those are not the heartbeat artifact) but WILL match the
+    `(heartbeat)`-suffixed title via `startsWith` (correct — that IS a same-day
+    artifact, suppressing the fallback). Confirm the prompt's heartbeat title is
+    `[Scheduled] Campaign Calendar - <today> (heartbeat)` so the prefix-match
+    holds. **This is the right behavior**: if the prompt's heartbeat issue
+    landed, the run was NOT silent, so the fallback should not fire.
+  - **community-monitor** emits `[Scheduled] Community Monitor - FAILED` (a
+    prompt-driven failure path) AND `[Scheduled] Community Monitor - YYYY-MM-DD`.
+    The fallback title is `[Scheduled] Community Monitor - <date>`; its
+    prefix-match will NOT match `- FAILED` (different — and that's fine; a prompt
+    FAILED issue is itself a non-silent artifact, but `verifyScheduledIssueCreated`
+    already counts ANY same-label issue in the window via `updated_at`, so
+    `heartbeatOk` would be true and the fallback never fires). No double-file risk.
+- **Two coupling residuals carry over verbatim** (already documented at
+  `cron-content-generator.ts:366-374`): (a) `resolveOutputAwareOk` returns
+  `spawnOk` when its verify-list THREW (transient GitHub 5xx) → a verify-throw +
+  spawn-ok run skips the fallback even if the issue is genuinely absent (covered
+  by the watchdog `maxGapDays`, not this step); (b) on a verify-throw +
+  spawn-nonzero run the gate fires even though the prompt's issue may exist —
+  the helper's same-title dedup is what prevents a spurious second issue, so the
+  dedup is **load-bearing, not belt-and-suspenders**. Keep it robust in all 8.
+- **Empty `## User-Brand Impact` would fail deepen-plan Phase 4.6** — section is
+  filled above; threshold is `aggregate pattern`.
+- **`redactGithubSourcedText` is the canonical multi-secret scrubber**
+  (`apps/web-platform/lib/safety/redaction-allowlist.ts:145`). The extraction must
+  route the tails through it (NOT just the substrate's installation-token-only
+  `redactToken`). The backslash-then-pipe escape ORDER in `formatTailForIssue`
+  is load-bearing (js/incomplete-sanitization) — preserve byte-for-byte.
+
+## Implementation Phases
+
+### Phase 0 — Preconditions (verify before editing)
+
+- [ ] Confirm PR #4975 is merged and the fallback exists: `gh pr view 4975 --json state` → MERGED; `grep -n "ensureContentGeneratorAuditIssue" apps/web-platform/server/inngest/functions/cron-content-generator.ts` → present.
+- [ ] Confirm all 8 producers are structurally uniform (verify-output → sentry-heartbeat → `return { ok: heartbeatOk }`): already enumerated in `cron-producer-output-wiring.test.ts:22-40`.
+- [ ] Confirm each producer's `titlePrefix` against its prompt block (the table above): `grep -nE "\[Scheduled\]" <producer>.ts` for each.
+- [ ] Confirm `redactGithubSourcedText` import path is `@/lib/safety/redaction-allowlist`.
+- [ ] Run baseline: `cd apps/web-platform && ./node_modules/.bin/vitest run test/server/inngest/cron-content-generator.test.ts test/server/inngest/cron-shared.test.ts test/server/inngest/cron-producer-output-wiring.test.ts` → all green pre-change (capture counts).
+
+### Phase 1 — RED: failing tests for the shared helper (`cq-write-failing-tests-before`)
+
+- [ ] In `apps/web-platform/test/server/inngest/cron-shared.test.ts`, add a
+      `describe("ensureScheduledAuditIssue (shared fallback)")` block mirroring
+      the existing `cron-content-generator.test.ts` behavioral suite (lines
+      157-281): inject a fake octokit, assert:
+  - creates exactly one labeled audit issue (`{ created: true }`) when none exists in the window;
+  - title is `${titlePrefix} ${date}` with `date = runStartedAt.slice(0,10)`;
+  - does NOT double-file when today's audit issue already exists (`{ created: false }`) — exercise BOTH an exact-title hit and a title-PREFIX hit (suffixed prompt issue suppresses the fallback);
+  - the dedup GET is label-scoped (`labels: <label>`), `state: "all"`, explicitly `sort: "created", direction: "desc"`, `per_page: 10`;
+  - the body scrubs secrets (feed a fixture tail containing a synthesized `sk-ant-…`-shape token per `cq-test-fixtures-synthesized-only`) and neutralizes markdown-breakout chars (backtick → `ʼ`, `|` → `\|`, CR/LF → space);
+  - propagates a create failure to the caller (POST throws → helper rejects).
+  - parameterization works: run the create/dedup assertions for ≥2 distinct `{ label, titlePrefix }` pairs (e.g. growth-audit + community-monitor) so a hardcoded-slug regression fails.
+- [ ] Confirm these FAIL (helper does not exist yet).
+
+### Phase 2 — GREEN: extract the shared helper into `_cron-shared.ts`
+
+- [ ] Add to `_cron-shared.ts`:
+  - `const DEFAULT_AUDIT_TAIL_CHARS = 500;` (rename of `AUDIT_TAIL_CHARS`; keep value).
+  - `export function formatTailForIssue(tail: string | undefined): string` — moved VERBATIM from `cron-content-generator.ts:163-174` (the backslash→pipe→backtick escape chain, order preserved). Import `redactGithubSourcedText` at the top of `_cron-shared.ts`.
+  - `export async function ensureScheduledAuditIssue(args: { label: string; titlePrefix: string; cronName: string; runStartedAt: string; spawnResult: Pick<SpawnResult, "exitCode" | "signal" | "abortedByTimeout" | "durationMs" | "stdoutTail" | "stderrTail">; installationToken?: string; octokit?: Octokit; }): Promise<{ created: boolean }>` — the body of `ensureContentGeneratorAuditIssue` (`cron-content-generator.ts:176-253`) with:
+    - `SENTRY_MONITOR_SLUG` → `args.label` (used in dedup GET `labels:` AND create `labels: [label]`);
+    - `[Scheduled] Content Generator -` → `args.titlePrefix` (the `title` becomes `\`${titlePrefix} ${date}\``);
+    - `cron-content-generator` literal in the body prose + the `fn` table row → `args.cronName`;
+    - keep `date = runStartedAt.slice(0, 10)`, the `octokit ?? new OctokitCtor({ auth: installationToken })` resolution, the `startsWith` dedup, and the self-diagnosing markdown table body.
+  - `SpawnResult` type: import from `./_cron-claude-eval-substrate`. `Octokit` type: import from `@octokit/core` (mirror content-generator's imports). NOTE: `_cron-shared.ts` already imports `createProbeOctokit`; adding the `SpawnResult` + `Octokit` type imports is the only new import surface besides `redactGithubSourcedText`.
+- [ ] Run the Phase 1 tests → GREEN.
+
+### Phase 3 — Re-wire content-generator (no behavior change)
+
+- [ ] In `cron-content-generator.ts`: DELETE `AUDIT_TAIL_CHARS`, `formatTailForIssue`, and `ensureContentGeneratorAuditIssue` (now in `_cron-shared.ts`).
+- [ ] Replace the `ensure-audit-issue` step body to call
+      `ensureScheduledAuditIssue({ label: SENTRY_MONITOR_SLUG, titlePrefix: "[Scheduled] Content Generator -", cronName: "cron-content-generator", runStartedAt, spawnResult, installationToken })`.
+- [ ] **Compatibility shim decision:** `cron-content-generator.test.ts:25` imports
+      `ensureContentGeneratorAuditIssue`. Choose ONE (record in spec):
+  - (a) re-export a thin wrapper `export const ensureContentGeneratorAuditIssue = (args) => ensureScheduledAuditIssue({ ...args, label: SENTRY_MONITOR_SLUG, titlePrefix: "[Scheduled] Content Generator -", cronName: "cron-content-generator" })` so the existing test keeps passing unchanged; OR
+  - (b) update `cron-content-generator.test.ts` to import + call `ensureScheduledAuditIssue` directly with the explicit params, and delete the content-generator-specific behavioral block (now covered by `cron-shared.test.ts`).
+  - **Recommended: (b)** — avoids a vestigial wrapper; the behavioral coverage moves to `cron-shared.test.ts` (Phase 1) and the wiring coverage stays in `cron-producer-output-wiring.test.ts` (Phase 5). Keep content-generator's source-shape anchors that assert the `ensure-audit-issue` step + `!heartbeatOk` gate (those are wiring, not behavior).
+- [ ] Run `cron-content-generator.test.ts` → GREEN (adjust the import/assertions per the chosen option).
+
+### Phase 4 — Wire the other 7 producers
+
+For EACH of `cron-roadmap-review`, `cron-competitive-analysis`,
+`cron-growth-audit`, `cron-growth-execution`, `cron-seo-aeo-audit`,
+`cron-community-monitor`, `cron-campaign-calendar`:
+
+- [ ] Add `ensureScheduledAuditIssue` to the `_cron-shared` import.
+- [ ] Insert AFTER the `sentry-heartbeat` step and BEFORE the `finally` teardown
+      (mirror `cron-content-generator.ts:358-393`):
+      ```ts
+      if (!heartbeatOk) {
+        await step.run("ensure-audit-issue", async () => {
+          try {
+            await ensureScheduledAuditIssue({
+              label: SENTRY_MONITOR_SLUG,
+              titlePrefix: "<the producer's prefix from the table>",
+              cronName: "<cron-name>",
+              runStartedAt,
+              spawnResult,
+              installationToken,
+            });
+          } catch (err) {
+            reportSilentFallback(err, {
+              feature: "<cron-name>",
+              op: "ensure-audit-issue-failed",
+              message: "Handler-level fallback audit-issue create failed; run remains silent until watchdog threshold",
+              extra: { fn: "<cron-name>", runStartedAt },
+            });
+          }
+        });
+      }
+      ```
+- [ ] Confirm `installationToken` is in scope at the insertion point (all 7
+      mint it as `step.run("mint-installation-token", …)` — verified). Confirm
+      `reportSilentFallback` is already imported (all 7 import it — verified).
+- [ ] `titlePrefix` per the table above. Double-check each against the
+      producer's prompt block (the `grep -nE "\[Scheduled\]"` from Phase 0).
+
+### Phase 5 — Extend the un-wiring guard
+
+- [ ] In `cron-producer-output-wiring.test.ts`, inside the
+      `it.each(WIRED_PRODUCERS)` block, add anchors asserting the fallback wiring
+      is present in ALL 8:
+  - `expect(src).toContain("ensureScheduledAuditIssue(")`;
+  - `expect(src).toContain('"ensure-audit-issue"')`;
+  - `expect(src).toContain("if (!heartbeatOk)")`;
+  - `expect(src).toContain('op: "ensure-audit-issue-failed"')`.
+- [ ] Add a guard that the fallback is NOT present in the 3 `BEST_EFFORT_CRONS`
+      (`expect(src).not.toContain("ensureScheduledAuditIssue")`) — they are not
+      output-aware producers and must not adopt the fallback.
+
+### Phase 6 — Full verification
+
+- [ ] `cd apps/web-platform && ./node_modules/.bin/vitest run test/server/inngest/` (all inngest tests).
+- [ ] `cd apps/web-platform && npx tsc --noEmit` (extraction must not break types; `tsc` is the canonical enumerator for any missed consumer).
+- [ ] `grep -rn "ensureContentGeneratorAuditIssue" apps/web-platform/` → only the chosen shim/test references remain (zero if option (b)).
+- [ ] `grep -c 'op: "ensure-audit-issue-failed"' apps/web-platform/server/inngest/functions/cron-*.ts` summed across the 8 producers = 8.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] **AC1** — `_cron-shared.ts` exports `ensureScheduledAuditIssue` and `formatTailForIssue`; the helper accepts `{ label, titlePrefix, cronName }` and uses each (verified by the ≥2-pair parameterization test in `cron-shared.test.ts`).
+- [ ] **AC2** — the composed fallback title for content-generator is byte-identical to the pre-extraction string `[Scheduled] Content Generator - <date>` (a test asserts `title === \`[Scheduled] Content Generator - ${date}\`` given `titlePrefix = "[Scheduled] Content Generator -"`).
+- [ ] **AC3** — all 8 producers contain the `ensure-audit-issue` step gated on `if (!heartbeatOk)` with the `ensure-audit-issue-failed` Sentry fallback: `grep -c 'op: "ensure-audit-issue-failed"'` across the 8 `cron-*.ts` producers sums to 8 (verified by `cron-producer-output-wiring.test.ts`).
+- [ ] **AC4** — the 3 `BEST_EFFORT_CRONS` do NOT contain `ensureScheduledAuditIssue` (asserted in `cron-producer-output-wiring.test.ts`).
+- [ ] **AC5** — body-redaction is preserved: the helper routes tails through `redactGithubSourcedText` AND neutralizes backtick/pipe/CR-LF (test feeds a synthesized `sk-ant-`-shape token + a `|`/backtick payload and asserts neither survives in the issue body).
+- [ ] **AC6** — dedup is label-scoped + title-prefix, `state:all`, `sort:created/desc`, `per_page:10` (test asserts the exact GET params) and suppresses a same-day prompt-success issue (no double-file under `retries:1`).
+- [ ] **AC7** — `npx tsc --noEmit` clean; full `test/server/inngest/` suite green.
+- [ ] **AC8** — no turn-budget change in any producer (`--max-turns` unchanged); no prompt edit; no new runtime dependency (`cq-before-pushing-package-json-changes` — `package.json` untouched).
+- [ ] **AC9** — PR body uses `Closes #4978`.
+
+### Post-merge (operator)
+
+- [ ] **AC10** — **Automation: deploy is automatic.** `web-platform-release.yml`
+      path-filtered `on.push` restarts the container on merge to main touching
+      `apps/web-platform/**`; the PR merge IS the deploy + function-sync
+      remediation. No operator step. (Per the automation-feasibility gate: a cron
+      handler change deploys via the existing release pipeline.)
+- [ ] **AC11** — optional smoke (operator, automatable via `/soleur:trigger-cron`):
+      fire one wired producer's manual-trigger from a worktree (e.g.
+      `cron/seo-aeo-audit.manual-trigger`) AFTER deploy and confirm a
+      `[Scheduled] SEO/AEO Audit - <date>` issue lands (success path) — the
+      fallback path itself is exercised by the unit suite, not requiring a forced
+      prod crash.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: each producer's per-function Sentry monitor (scheduled-<slug>) goes RED via resolveOutputAwareOk when no issue lands; the handler-level fallback then files a FAILED [Scheduled] … issue so cron-cloud-task-heartbeat stays green
+  cadence: per cron fire (producer-specific: Tue/Thu, daily, weekly, monthly)
+  alert_target: Sentry Crons monitor per slug + cron-cloud-task-heartbeat watchdog (maxGapDays per producer, cron-cloud-task-heartbeat.ts:70-74)
+  configured_in: apps/web-platform/server/inngest/functions/_cron-shared.ts (postSentryHeartbeat + resolveOutputAwareOk) and each producer handler
+error_reporting:
+  destination: Sentry via reportSilentFallback / warnSilentFallback (cq-silent-fallback-must-mirror-to-sentry)
+  fail_loud: true — a fallback create failure emits op:"ensure-audit-issue-failed"; the watchdog still catches the absence after maxGapDays (defense-in-depth)
+failure_modes:
+  - mode: producer terminates without its audit issue (mid-eval crash / API 500 / max-turns kill)
+    detection: resolveOutputAwareOk finds no labeled issue in window → heartbeatOk=false
+    alert_route: handler files FAILED [Scheduled] … issue (this PR) + scheduled-output-missing Sentry event; monitor RED
+  - mode: fallback create itself fails (GitHub 5xx)
+    detection: try/catch in the ensure-audit-issue step.run
+    alert_route: reportSilentFallback op:"ensure-audit-issue-failed"; cron-cloud-task-heartbeat catches absence after maxGapDays
+  - mode: verify-list THREW (transient GitHub 5xx) on a spawn-ok run
+    detection: resolveOutputAwareOk returns spawnOk → fallback skipped
+    alert_route: verify-output-failed Sentry event (already emitted); watchdog maxGapDays backstop
+logs:
+  where: Sentry (errors/warnings); GitHub issues (the audit-issue artifacts themselves); app stdout is NOT shipped to Better Stack (hence the redacted tail in the issue body)
+  retention: Sentry default; GitHub issues indefinite
+discoverability_test:
+  command: cd apps/web-platform && ./node_modules/.bin/vitest run test/server/inngest/cron-producer-output-wiring.test.ts test/server/inngest/cron-shared.test.ts
+  expected_output: all green; 8 producers assert the ensure-audit-issue wiring, 3 best-effort crons assert its absence
+```
+
+## Open Code-Review Overlap
+
+(Filled at Step 1.7.5 after the Files lists below are frozen — see check output appended during planning.)
+
+## Files to Edit
+
+- `apps/web-platform/server/inngest/functions/_cron-shared.ts` — add `ensureScheduledAuditIssue`, `formatTailForIssue`, `DEFAULT_AUDIT_TAIL_CHARS`; import `redactGithubSourcedText`, `SpawnResult` type, `Octokit` type.
+- `apps/web-platform/server/inngest/functions/cron-content-generator.ts` — delete the now-extracted helpers; call `ensureScheduledAuditIssue`.
+- `apps/web-platform/server/inngest/functions/cron-roadmap-review.ts` — add the `!heartbeatOk` fallback step.
+- `apps/web-platform/server/inngest/functions/cron-competitive-analysis.ts` — add the fallback step.
+- `apps/web-platform/server/inngest/functions/cron-growth-audit.ts` — add the fallback step.
+- `apps/web-platform/server/inngest/functions/cron-growth-execution.ts` — add the fallback step.
+- `apps/web-platform/server/inngest/functions/cron-seo-aeo-audit.ts` — add the fallback step.
+- `apps/web-platform/server/inngest/functions/cron-community-monitor.ts` — add the fallback step.
+- `apps/web-platform/server/inngest/functions/cron-campaign-calendar.ts` — add the fallback step.
+- `apps/web-platform/test/server/inngest/cron-shared.test.ts` — behavioral tests for `ensureScheduledAuditIssue`.
+- `apps/web-platform/test/server/inngest/cron-producer-output-wiring.test.ts` — extend `it.each(WIRED_PRODUCERS)` with the fallback-wiring anchors; add the best-effort negative anchor.
+- `apps/web-platform/test/server/inngest/cron-content-generator.test.ts` — adjust import/assertions per the Phase 3 shim decision.
+
+## Files to Create
+
+(None — all edits are to existing files.)
+
+## Non-Goals / Out of Scope
+
+- No change to `resolveOutputAwareOk` / `verifyScheduledIssueCreated` semantics.
+- No new producers; the 3 `BEST_EFFORT_CRONS` and `cron-strategy-review` stay excluded by design.
+- No turn-budget or prompt changes.
+- The two verify-throw coupling residuals are intentionally absorbed (documented; the watchdog `maxGapDays` is the backstop). Not deferred — they are an accepted design property carried over from PR #4975, not a new gap.
+
+## Alternative Approaches Considered
+
+| Approach | Verdict |
+| --- | --- |
+| Slug-derive `titlePrefix` from `label` | Rejected — title prefixes do NOT match the slug (8 distinct human-readable forms); deriving would break the dedup `startsWith`. |
+| Keep per-producer copies of the helper (no extraction) | Rejected — issue #4978 mandates extraction; 7 copies of a security-sensitive redaction path is a maintenance + drift hazard. |
+| Add the fallback inside `resolveOutputAwareOk` (one call site) | Rejected — `resolveOutputAwareOk` is read-only by contract (documented at `_cron-shared.ts:201-202`); mixing a write into the read-only resolver violates its invariant and couples the heartbeat to `installationToken`/`spawnResult` it doesn't currently take. Keep the fallback a separate gated `step.run` (Inngest replay isolation). |

--- a/knowledge-base/project/plans/2026-06-06-feat-generalize-cron-handler-fallback-all-producers-plan.md
+++ b/knowledge-base/project/plans/2026-06-06-feat-generalize-cron-handler-fallback-all-producers-plan.md
@@ -150,15 +150,15 @@ pre-extraction content-generator title (an AC covers this).
 
 ### Phase 0 — Preconditions (verify before editing)
 
-- [ ] Confirm PR #4975 is merged and the fallback exists: `gh pr view 4975 --json state` → MERGED; `grep -n "ensureContentGeneratorAuditIssue" apps/web-platform/server/inngest/functions/cron-content-generator.ts` → present.
-- [ ] Confirm all 8 producers are structurally uniform (verify-output → sentry-heartbeat → `return { ok: heartbeatOk }`): already enumerated in `cron-producer-output-wiring.test.ts:22-40`.
-- [ ] Confirm each producer's `titlePrefix` against its prompt block (the table above): `grep -nE "\[Scheduled\]" <producer>.ts` for each.
-- [ ] Confirm `redactGithubSourcedText` import path is `@/lib/safety/redaction-allowlist`.
-- [ ] Run baseline: `cd apps/web-platform && ./node_modules/.bin/vitest run test/server/inngest/cron-content-generator.test.ts test/server/inngest/cron-shared.test.ts test/server/inngest/cron-producer-output-wiring.test.ts` → all green pre-change (capture counts).
+- [x] Confirm PR #4975 is merged and the fallback exists: `gh pr view 4975 --json state` → MERGED; `grep -n "ensureContentGeneratorAuditIssue" apps/web-platform/server/inngest/functions/cron-content-generator.ts` → present.
+- [x] Confirm all 8 producers are structurally uniform (verify-output → sentry-heartbeat → `return { ok: heartbeatOk }`): already enumerated in `cron-producer-output-wiring.test.ts:22-40`.
+- [x] Confirm each producer's `titlePrefix` against its prompt block (the table above): `grep -nE "\[Scheduled\]" <producer>.ts` for each.
+- [x] Confirm `redactGithubSourcedText` import path is `@/lib/safety/redaction-allowlist`.
+- [x] Run baseline: `cd apps/web-platform && ./node_modules/.bin/vitest run test/server/inngest/cron-content-generator.test.ts test/server/inngest/cron-shared.test.ts test/server/inngest/cron-producer-output-wiring.test.ts` → all green pre-change (capture counts).
 
 ### Phase 1 — RED: failing tests for the shared helper (`cq-write-failing-tests-before`)
 
-- [ ] In `apps/web-platform/test/server/inngest/cron-shared.test.ts`, add a
+- [x] In `apps/web-platform/test/server/inngest/cron-shared.test.ts`, add a
       `describe("ensureScheduledAuditIssue (shared fallback)")` block mirroring
       the existing `cron-content-generator.test.ts` behavioral suite (lines
       157-281): inject a fake octokit, assert:
@@ -169,11 +169,11 @@ pre-extraction content-generator title (an AC covers this).
   - the body scrubs secrets (feed a fixture tail containing a synthesized `sk-ant-…`-shape token per `cq-test-fixtures-synthesized-only`) and neutralizes markdown-breakout chars (backtick → `ʼ`, `|` → `\|`, CR/LF → space);
   - propagates a create failure to the caller (POST throws → helper rejects).
   - parameterization works: run the create/dedup assertions for ≥2 distinct `{ label, titlePrefix }` pairs (e.g. growth-audit + community-monitor) so a hardcoded-slug regression fails.
-- [ ] Confirm these FAIL (helper does not exist yet).
+- [x] Confirm these FAIL (helper does not exist yet).
 
 ### Phase 2 — GREEN: extract the shared helper into `_cron-shared.ts`
 
-- [ ] Add to `_cron-shared.ts`:
+- [x] Add to `_cron-shared.ts`:
   - `const DEFAULT_AUDIT_TAIL_CHARS = 500;` (rename of `AUDIT_TAIL_CHARS`; keep value).
   - `export function formatTailForIssue(tail: string | undefined): string` — moved VERBATIM from `cron-content-generator.ts:163-174` (the backslash→pipe→backtick escape chain, order preserved). Import `redactGithubSourcedText` at the top of `_cron-shared.ts`.
   - `export async function ensureScheduledAuditIssue(args: { label: string; titlePrefix: string; cronName: string; runStartedAt: string; spawnResult: Pick<SpawnResult, "exitCode" | "signal" | "abortedByTimeout" | "durationMs" | "stdoutTail" | "stderrTail">; installationToken?: string; octokit?: Octokit; }): Promise<{ created: boolean }>` — the body of `ensureContentGeneratorAuditIssue` (`cron-content-generator.ts:176-253`) with:
@@ -182,19 +182,19 @@ pre-extraction content-generator title (an AC covers this).
     - `cron-content-generator` literal in the body prose + the `fn` table row → `args.cronName`;
     - keep `date = runStartedAt.slice(0, 10)`, the `octokit ?? new OctokitCtor({ auth: installationToken })` resolution, the `startsWith` dedup, and the self-diagnosing markdown table body.
   - `SpawnResult` type: import from `./_cron-claude-eval-substrate`. `Octokit` type: import from `@octokit/core` (mirror content-generator's imports). NOTE: `_cron-shared.ts` already imports `createProbeOctokit`; adding the `SpawnResult` + `Octokit` type imports is the only new import surface besides `redactGithubSourcedText`.
-- [ ] Run the Phase 1 tests → GREEN.
+- [x] Run the Phase 1 tests → GREEN.
 
 ### Phase 3 — Re-wire content-generator (no behavior change)
 
-- [ ] In `cron-content-generator.ts`: DELETE `AUDIT_TAIL_CHARS`, `formatTailForIssue`, and `ensureContentGeneratorAuditIssue` (now in `_cron-shared.ts`).
-- [ ] Replace the `ensure-audit-issue` step body to call
+- [x] In `cron-content-generator.ts`: DELETE `AUDIT_TAIL_CHARS`, `formatTailForIssue`, and `ensureContentGeneratorAuditIssue` (now in `_cron-shared.ts`).
+- [x] Replace the `ensure-audit-issue` step body to call
       `ensureScheduledAuditIssue({ label: SENTRY_MONITOR_SLUG, titlePrefix: "[Scheduled] Content Generator -", cronName: "cron-content-generator", runStartedAt, spawnResult, installationToken })`.
-- [ ] **Compatibility shim decision:** `cron-content-generator.test.ts:25` imports
+- [x] **Compatibility shim decision:** `cron-content-generator.test.ts:25` imports
       `ensureContentGeneratorAuditIssue`. Choose ONE (record in spec):
   - (a) re-export a thin wrapper `export const ensureContentGeneratorAuditIssue = (args) => ensureScheduledAuditIssue({ ...args, label: SENTRY_MONITOR_SLUG, titlePrefix: "[Scheduled] Content Generator -", cronName: "cron-content-generator" })` so the existing test keeps passing unchanged; OR
   - (b) update `cron-content-generator.test.ts` to import + call `ensureScheduledAuditIssue` directly with the explicit params, and delete the content-generator-specific behavioral block (now covered by `cron-shared.test.ts`).
   - **Recommended: (b)** — avoids a vestigial wrapper; the behavioral coverage moves to `cron-shared.test.ts` (Phase 1) and the wiring coverage stays in `cron-producer-output-wiring.test.ts` (Phase 5). Keep content-generator's source-shape anchors that assert the `ensure-audit-issue` step + `!heartbeatOk` gate (those are wiring, not behavior).
-- [ ] Run `cron-content-generator.test.ts` → GREEN (adjust the import/assertions per the chosen option).
+- [x] Run `cron-content-generator.test.ts` → GREEN (adjust the import/assertions per the chosen option).
 
 ### Phase 4 — Wire the other 7 producers
 
@@ -202,8 +202,8 @@ For EACH of `cron-roadmap-review`, `cron-competitive-analysis`,
 `cron-growth-audit`, `cron-growth-execution`, `cron-seo-aeo-audit`,
 `cron-community-monitor`, `cron-campaign-calendar`:
 
-- [ ] Add `ensureScheduledAuditIssue` to the `_cron-shared` import.
-- [ ] Insert AFTER the `sentry-heartbeat` step and BEFORE the `finally` teardown
+- [x] Add `ensureScheduledAuditIssue` to the `_cron-shared` import.
+- [x] Insert AFTER the `sentry-heartbeat` step and BEFORE the `finally` teardown
       (mirror `cron-content-generator.ts:358-393`):
       ```ts
       if (!heartbeatOk) {
@@ -228,49 +228,49 @@ For EACH of `cron-roadmap-review`, `cron-competitive-analysis`,
         });
       }
       ```
-- [ ] Confirm `installationToken` is in scope at the insertion point (all 7
+- [x] Confirm `installationToken` is in scope at the insertion point (all 7
       mint it as `step.run("mint-installation-token", …)` — verified). Confirm
       `reportSilentFallback` is already imported (all 7 import it — verified).
-- [ ] `titlePrefix` per the table above. Double-check each against the
+- [x] `titlePrefix` per the table above. Double-check each against the
       producer's prompt block (the `grep -nE "\[Scheduled\]"` from Phase 0).
 
 ### Phase 5 — Extend the un-wiring guard
 
-- [ ] In `cron-producer-output-wiring.test.ts`, inside the
+- [x] In `cron-producer-output-wiring.test.ts`, inside the
       `it.each(WIRED_PRODUCERS)` block, add anchors asserting the fallback wiring
       is present in ALL 8:
   - `expect(src).toContain("ensureScheduledAuditIssue(")`;
   - `expect(src).toContain('"ensure-audit-issue"')`;
   - `expect(src).toContain("if (!heartbeatOk)")`;
   - `expect(src).toContain('op: "ensure-audit-issue-failed"')`.
-- [ ] Add a guard that the fallback is NOT present in the 3 `BEST_EFFORT_CRONS`
+- [x] Add a guard that the fallback is NOT present in the 3 `BEST_EFFORT_CRONS`
       (`expect(src).not.toContain("ensureScheduledAuditIssue")`) — they are not
       output-aware producers and must not adopt the fallback.
 
 ### Phase 6 — Full verification
 
-- [ ] `cd apps/web-platform && ./node_modules/.bin/vitest run test/server/inngest/` (all inngest tests).
-- [ ] `cd apps/web-platform && npx tsc --noEmit` (extraction must not break types; `tsc` is the canonical enumerator for any missed consumer).
-- [ ] `grep -rn "ensureContentGeneratorAuditIssue" apps/web-platform/` → only the chosen shim/test references remain (zero if option (b)).
-- [ ] `grep -c 'op: "ensure-audit-issue-failed"' apps/web-platform/server/inngest/functions/cron-*.ts` summed across the 8 producers = 8.
+- [x] `cd apps/web-platform && ./node_modules/.bin/vitest run test/server/inngest/` (all inngest tests).
+- [x] `cd apps/web-platform && npx tsc --noEmit` (extraction must not break types; `tsc` is the canonical enumerator for any missed consumer).
+- [x] `grep -rn "ensureContentGeneratorAuditIssue" apps/web-platform/` → only the chosen shim/test references remain (zero if option (b)).
+- [x] `grep -c 'op: "ensure-audit-issue-failed"' apps/web-platform/server/inngest/functions/cron-*.ts` summed across the 8 producers = 8.
 
 ## Acceptance Criteria
 
 ### Pre-merge (PR)
 
-- [ ] **AC1** — `_cron-shared.ts` exports `ensureScheduledAuditIssue` and `formatTailForIssue`; the helper accepts `{ label, titlePrefix, cronName }` and uses each (verified by the ≥2-pair parameterization test in `cron-shared.test.ts`).
-- [ ] **AC2** — the composed fallback title for content-generator is byte-identical to the pre-extraction string `[Scheduled] Content Generator - <date>` (a test asserts `title === \`[Scheduled] Content Generator - ${date}\`` given `titlePrefix = "[Scheduled] Content Generator -"`).
-- [ ] **AC3** — all 8 producers contain the `ensure-audit-issue` step gated on `if (!heartbeatOk)` with the `ensure-audit-issue-failed` Sentry fallback: `grep -c 'op: "ensure-audit-issue-failed"'` across the 8 `cron-*.ts` producers sums to 8 (verified by `cron-producer-output-wiring.test.ts`).
-- [ ] **AC4** — the 3 `BEST_EFFORT_CRONS` do NOT contain `ensureScheduledAuditIssue` (asserted in `cron-producer-output-wiring.test.ts`).
-- [ ] **AC5** — body-redaction is preserved: the helper routes tails through `redactGithubSourcedText` AND neutralizes backtick/pipe/CR-LF (test feeds a synthesized `sk-ant-`-shape token + a `|`/backtick payload and asserts neither survives in the issue body).
-- [ ] **AC6** — dedup is label-scoped + title-prefix, `state:all`, `sort:created/desc`, `per_page:10` (test asserts the exact GET params) and suppresses a same-day prompt-success issue (no double-file under `retries:1`).
-- [ ] **AC7** — `npx tsc --noEmit` clean; full `test/server/inngest/` suite green.
-- [ ] **AC8** — no turn-budget change in any producer (`--max-turns` unchanged); no prompt edit; no new runtime dependency (`cq-before-pushing-package-json-changes` — `package.json` untouched).
-- [ ] **AC9** — PR body uses `Closes #4978`.
+- [x] **AC1** — `_cron-shared.ts` exports `ensureScheduledAuditIssue` and `formatTailForIssue`; the helper accepts `{ label, titlePrefix, cronName }` and uses each (verified by the ≥2-pair parameterization test in `cron-shared.test.ts`).
+- [x] **AC2** — the composed fallback title for content-generator is byte-identical to the pre-extraction string `[Scheduled] Content Generator - <date>` (a test asserts `title === \`[Scheduled] Content Generator - ${date}\`` given `titlePrefix = "[Scheduled] Content Generator -"`).
+- [x] **AC3** — all 8 producers contain the `ensure-audit-issue` step gated on `if (!heartbeatOk)` with the `ensure-audit-issue-failed` Sentry fallback: `grep -c 'op: "ensure-audit-issue-failed"'` across the 8 `cron-*.ts` producers sums to 8 (verified by `cron-producer-output-wiring.test.ts`).
+- [x] **AC4** — the 3 `BEST_EFFORT_CRONS` do NOT contain `ensureScheduledAuditIssue` (asserted in `cron-producer-output-wiring.test.ts`).
+- [x] **AC5** — body-redaction is preserved: the helper routes tails through `redactGithubSourcedText` AND neutralizes backtick/pipe/CR-LF (test feeds a synthesized `sk-ant-`-shape token + a `|`/backtick payload and asserts neither survives in the issue body).
+- [x] **AC6** — dedup is label-scoped + title-prefix, `state:all`, `sort:created/desc`, `per_page:10` (test asserts the exact GET params) and suppresses a same-day prompt-success issue (no double-file under `retries:1`).
+- [x] **AC7** — `npx tsc --noEmit` clean; full `test/server/inngest/` suite green.
+- [x] **AC8** — no turn-budget change in any producer (`--max-turns` unchanged); no prompt edit; no new runtime dependency (`cq-before-pushing-package-json-changes` — `package.json` untouched).
+- [x] **AC9** — PR body uses `Closes #4978`.
 
 ### Post-merge (operator)
 
-- [ ] **AC10** — **Automation: deploy is automatic.** `web-platform-release.yml`
+- [x] **AC10** — **Automation: deploy is automatic.** `web-platform-release.yml`
       path-filtered `on.push` restarts the container on merge to main touching
       `apps/web-platform/**`; the PR merge IS the deploy + function-sync
       remediation. No operator step. (Per the automation-feasibility gate: a cron


### PR DESCRIPTION
## Summary

Generalizes the handler-level fallback audit-issue pattern — proven on `content-generator` in PR #4975 — to **all 8 always-create cron producers**. Previously only `content-generator` self-reported a `FAILED` audit issue when a producer terminated mid-eval (crash / API-500 / `--max-turns` kill) without writing its success issue; the other 7 went silent, leaving `resolveOutputAwareOk` (read-only) with no way to mark the heartbeat red from the handler.

The `ensureContentGeneratorAuditIssue` logic is now extracted into a shared, parameterized `_cron-shared.ts` helper (`ensureScheduledAuditIssue({ label, titlePrefix, cronName })` + `formatTailForIssue`), and every always-create producer calls it after its `sentry-heartbeat` step, gated on `!heartbeatOk`.

## Changes

- **`_cron-shared.ts`** — new `ensureScheduledAuditIssue` + `formatTailForIssue` helpers (label-scoped + title-prefix dedup, `state:all`, `sort:created/desc`, `per_page:10`; body routed through `redactGithubSourcedText` with backtick/pipe/CR-LF neutralization).
- **8 producers** wired to the shared helper with the `ensure-audit-issue` step + `ensure-audit-issue-failed` Sentry fallback: roadmap-review, content-generator (migrated off its private copy), competitive-analysis, growth-audit, growth-execution, seo-aeo-audit, community-monitor, campaign-calendar.
- **Tests** — `cron-shared.test.ts` (≥2-pair parameterization, byte-identical title, redaction, dedup), `cron-producer-output-wiring.test.ts` (8 producers gated; 3 `BEST_EFFORT_CRONS` explicitly NOT gated), `cron-content-generator.test.ts` (updated for extraction).

## Testing

- `vitest run test/server/inngest/` → 1397 passing (the lone failure is a pre-existing cold-start timeout flake in `signature-verify.test.ts`, untouched by this branch — passes 5/5 in isolation).
- `tsc --noEmit` → clean.
- `grep -c 'op: "ensure-audit-issue-failed"'` across the 8 producers = 8; the 3 best-effort crons remain ungated.
- No `--max-turns` / prompt / `package.json` changes.

## Deploy & verification

Deploy is automatic: `web-platform-release.yml` path-filtered `on.push` restarts the container on merge touching `apps/web-platform/**`. The fallback path is exercised by the unit suite; the live success path for each producer is covered by its per-function Sentry Crons monitor (`scheduled-<slug>`) plus the `cron-cloud-task-heartbeat` watchdog (`failure_issue_threshold = 1`) — no operator gaze required.

Source learning: `knowledge-base/project/learnings/integration-issues/2026-06-05-cloud-task-silence-per-producer-triage-and-handler-fallback.md`. Proof-of-pattern PR: #4975.

Closes #4978
