### PR TITLE
fix(cron): fleet-wide headless /soleur:* skill resolution for claude-eval producers

### DIFF
--- a/apps/web-platform/server/inngest/functions/cron-agent-native-audit.ts
+++ b/apps/web-platform/server/inngest/functions/cron-agent-native-audit.ts
@@ -39,8 +39,11 @@
 //   - repo/                          (in-handler `git clone --depth=1`)
 //   - repo/plugins/soleur            (symlink to getPluginPath())
 //   - repo/.claude/settings.json     (DEFAULT_SETTINGS overlay)
-// Plugin resolution is cwd-relative — the soleur plugin manifest at
-// plugins/soleur/.claude-plugin/plugin.json is discovered from spawn cwd.
+// Plugin resolution under headless `--print` requires the explicit
+// `--plugin-dir plugins/soleur` flag in CLAUDE_CODE_FLAGS below — the symlinked
+// plugins/soleur dir is NOT auto-discovered from spawn cwd in headless mode (the
+// interactive marketplace/enabledPlugins trust flow does not run under --print).
+// See #4993 / #4987.
 //
 // GH TOKEN — installation token minted via createProbeOctokit() →
 // installation discovery → generateInstallationToken(installation.id).
@@ -94,7 +97,9 @@ const CLAUDE_CODE_FLAGS = [
   "--max-turns",
   "50",
   "--allowedTools",
-  "Bash,Read,Write,Edit,Glob,Grep,Task",
+  "Bash,Read,Write,Edit,Glob,Grep,Task,Skill",
+  "--plugin-dir",
+  "plugins/soleur",
   "--",
 ];
 

--- a/apps/web-platform/server/inngest/functions/cron-bug-fixer.ts
+++ b/apps/web-platform/server/inngest/functions/cron-bug-fixer.ts
@@ -26,8 +26,10 @@
 //   - repo/plugins/soleur            (symlink to getPluginPath())
 //   - repo/.claude/settings.json     (DEFAULT_SETTINGS overlay)
 // The spawn cwd is repo/ so that:
-//   (a) claude-code's plugin discovery (cwd-relative) finds the soleur
-//       plugin manifest at plugins/soleur/.claude-plugin/plugin.json;
+//   (a) the explicit `--plugin-dir plugins/soleur` flag (in CLAUDE_CODE_FLAGS
+//       below) registers the soleur plugin manifest at
+//       plugins/soleur/.claude-plugin/plugin.json — headless `--print` does NOT
+//       auto-discover it from spawn cwd (see #4993 / #4987);
 //   (b) the fix-issue skill's worktree-manager.sh has a real git repo
 //       to create worktrees against. Clone is done in-handler (vs.
 //       relying on a pre-seeded repo path) because Hetzner has no
@@ -145,7 +147,9 @@ const CLAUDE_CODE_FLAGS = [
   "--max-turns",
   "55",
   "--allowedTools",
-  "Bash,Read,Write,Edit,Glob,Grep",
+  "Bash,Read,Write,Edit,Glob,Grep,Skill,Task",
+  "--plugin-dir",
+  "plugins/soleur",
   "--",
 ];
 

--- a/apps/web-platform/server/inngest/functions/cron-campaign-calendar.ts
+++ b/apps/web-platform/server/inngest/functions/cron-campaign-calendar.ts
@@ -50,6 +50,11 @@ export { KILL_ESCALATION_MS } from "./_cron-claude-eval-substrate";
 // claude-code spawn argv. `--` is load-bearing per #4017 bug 8/8 (variadic
 // --allowedTools consumes the prompt as a tool name without the end-of-
 // options marker). The prompt is the SOLE positional argument after `--`.
+//
+// #4993 — headless /soleur:* skill resolution (fleet fix mirroring #4987 /
+// PR #4989): `--plugin-dir plugins/soleur` registers the symlinked plugin under
+// `--print` (a bare plugins/ dir is NOT auto-discovered in headless mode), and
+// `Skill` (+`Task` for subagent fan-out) in --allowedTools gates skill invocation.
 const CLAUDE_CODE_FLAGS = [
   "--print",
   "--model",
@@ -57,7 +62,9 @@ const CLAUDE_CODE_FLAGS = [
   "--max-turns",
   "40",
   "--allowedTools",
-  "Bash,Read,Write,Edit,Glob,Grep",
+  "Bash,Read,Write,Edit,Glob,Grep,Skill,Task",
+  "--plugin-dir",
+  "plugins/soleur",
   "--",
 ];
 

--- a/apps/web-platform/server/inngest/functions/cron-community-monitor.ts
+++ b/apps/web-platform/server/inngest/functions/cron-community-monitor.ts
@@ -46,8 +46,13 @@
 //   - repo/                          (in-handler `git clone --depth=1`)
 //   - repo/plugins/soleur            (symlink to getPluginPath())
 //   - repo/.claude/settings.json     (DEFAULT_SETTINGS overlay)
-// Plugin resolution is cwd-relative — the soleur plugin manifest at
-// plugins/soleur/.claude-plugin/plugin.json is discovered from spawn cwd.
+// Plugin resolution under headless `--print` requires the explicit
+// `--plugin-dir plugins/soleur` flag — the symlinked plugins/soleur dir is NOT
+// auto-discovered from spawn cwd in headless mode (the interactive
+// marketplace/enabledPlugins trust flow does not run under --print). This
+// producer's prompt invokes no /soleur:* skill, so it needs no flag change; the
+// comment is corrected so the disproven spawn-cwd auto-discovery theory cannot
+// mislead future edits. See #4993 / #4987.
 //
 // GH TOKEN — installation token minted via createProbeOctokit() →
 // installation discovery → generateInstallationToken(installation.id).

--- a/apps/web-platform/server/inngest/functions/cron-competitive-analysis.ts
+++ b/apps/web-platform/server/inngest/functions/cron-competitive-analysis.ts
@@ -41,8 +41,11 @@
 //   - repo/                          (in-handler `git clone --depth=1`)
 //   - repo/plugins/soleur            (symlink to getPluginPath())
 //   - repo/.claude/settings.json     (DEFAULT_SETTINGS overlay)
-// Plugin resolution is cwd-relative — the soleur plugin manifest at
-// plugins/soleur/.claude-plugin/plugin.json is discovered from spawn cwd.
+// Plugin resolution under headless `--print` requires the explicit
+// `--plugin-dir plugins/soleur` flag in CLAUDE_CODE_FLAGS below — the symlinked
+// plugins/soleur dir is NOT auto-discovered from spawn cwd in headless mode (the
+// interactive marketplace/enabledPlugins trust flow does not run under --print).
+// See #4993 / #4987.
 //
 // GH TOKEN — installation token minted via createProbeOctokit() →
 // installation discovery → generateInstallationToken(installation.id).
@@ -99,7 +102,9 @@ const CLAUDE_CODE_FLAGS = [
   "--max-turns",
   "45",
   "--allowedTools",
-  "Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,Task",
+  "Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,Task,Skill",
+  "--plugin-dir",
+  "plugins/soleur",
   "--",
 ];
 

--- a/apps/web-platform/server/inngest/functions/cron-growth-audit.ts
+++ b/apps/web-platform/server/inngest/functions/cron-growth-audit.ts
@@ -52,6 +52,11 @@ export { KILL_ESCALATION_MS } from "./_cron-claude-eval-substrate";
 // options marker). The prompt is the SOLE positional argument after `--`.
 //
 // NOTE: claude-opus-4-7 model for deep multi-step growth audit.
+//
+// #4993 — headless /soleur:* skill resolution (fleet fix mirroring #4987 /
+// PR #4989): `--plugin-dir plugins/soleur` registers the symlinked plugin under
+// `--print` (a bare plugins/ dir is NOT auto-discovered in headless mode), and
+// `Skill` (+`Task` for subagent fan-out) in --allowedTools gates skill invocation.
 const CLAUDE_CODE_FLAGS = [
   "--print",
   "--model",
@@ -59,7 +64,9 @@ const CLAUDE_CODE_FLAGS = [
   "--max-turns",
   "70",
   "--allowedTools",
-  "Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch",
+  "Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,Skill,Task",
+  "--plugin-dir",
+  "plugins/soleur",
   "--",
 ];
 

--- a/apps/web-platform/server/inngest/functions/cron-growth-execution.ts
+++ b/apps/web-platform/server/inngest/functions/cron-growth-execution.ts
@@ -34,8 +34,11 @@
 //   - repo/                          (in-handler `git clone --depth=1`)
 //   - repo/plugins/soleur            (symlink to getPluginPath())
 //   - repo/.claude/settings.json     (DEFAULT_SETTINGS overlay)
-// Plugin resolution is cwd-relative — the soleur plugin manifest at
-// plugins/soleur/.claude-plugin/plugin.json is discovered from spawn cwd.
+// Plugin resolution under headless `--print` requires the explicit
+// `--plugin-dir plugins/soleur` flag in CLAUDE_CODE_FLAGS below — the symlinked
+// plugins/soleur dir is NOT auto-discovered from spawn cwd in headless mode (the
+// interactive marketplace/enabledPlugins trust flow does not run under --print).
+// See #4993 / #4987.
 //
 // GH TOKEN — installation token minted via createProbeOctokit() →
 // installation discovery → generateInstallationToken(installation.id).
@@ -90,7 +93,9 @@ const CLAUDE_CODE_FLAGS = [
   "--max-turns",
   "40",
   "--allowedTools",
-  "Bash,Read,Write,Edit,Glob,Grep,WebSearch",
+  "Bash,Read,Write,Edit,Glob,Grep,WebSearch,Skill,Task",
+  "--plugin-dir",
+  "plugins/soleur",
   "--",
 ];
 

--- a/apps/web-platform/server/inngest/functions/cron-legal-audit.ts
+++ b/apps/web-platform/server/inngest/functions/cron-legal-audit.ts
@@ -43,8 +43,11 @@
 //   - repo/                          (in-handler `git clone --depth=1`)
 //   - repo/plugins/soleur            (symlink to getPluginPath())
 //   - repo/.claude/settings.json     (DEFAULT_SETTINGS overlay)
-// Plugin resolution is cwd-relative — the soleur plugin manifest at
-// plugins/soleur/.claude-plugin/plugin.json is discovered from spawn cwd.
+// Plugin resolution under headless `--print` requires the explicit
+// `--plugin-dir plugins/soleur` flag in CLAUDE_CODE_FLAGS below — the symlinked
+// plugins/soleur dir is NOT auto-discovered from spawn cwd in headless mode (the
+// interactive marketplace/enabledPlugins trust flow does not run under --print).
+// See #4993 / #4987.
 //
 // GH TOKEN — installation token minted via createProbeOctokit() →
 // installation discovery → generateInstallationToken(installation.id).
@@ -98,7 +101,9 @@ const CLAUDE_CODE_FLAGS = [
   "--max-turns",
   "60",
   "--allowedTools",
-  "Bash,Read,Write,Edit,Glob,Grep,Task",
+  "Bash,Read,Write,Edit,Glob,Grep,Task,Skill",
+  "--plugin-dir",
+  "plugins/soleur",
   "--",
 ];
 

--- a/apps/web-platform/server/inngest/functions/cron-roadmap-review.ts
+++ b/apps/web-platform/server/inngest/functions/cron-roadmap-review.ts
@@ -36,8 +36,13 @@
 //   - repo/                          (in-handler `git clone --depth=1`)
 //   - repo/plugins/soleur            (symlink to getPluginPath())
 //   - repo/.claude/settings.json     (DEFAULT_SETTINGS overlay)
-// Plugin resolution is cwd-relative — the soleur plugin manifest at
-// plugins/soleur/.claude-plugin/plugin.json is discovered from spawn cwd.
+// Plugin resolution under headless `--print` requires the explicit
+// `--plugin-dir plugins/soleur` flag — the symlinked plugins/soleur dir is NOT
+// auto-discovered from spawn cwd in headless mode (the interactive
+// marketplace/enabledPlugins trust flow does not run under --print). This
+// producer's prompt invokes no /soleur:* skill, so it needs no flag change; the
+// comment is corrected so the disproven spawn-cwd auto-discovery theory cannot
+// mislead future edits. See #4993 / #4987.
 //
 // GH TOKEN — installation token minted via createProbeOctokit() →
 // installation discovery → generateInstallationToken(installation.id).

--- a/apps/web-platform/server/inngest/functions/cron-seo-aeo-audit.ts
+++ b/apps/web-platform/server/inngest/functions/cron-seo-aeo-audit.ts
@@ -35,8 +35,11 @@
 //   - repo/                          (in-handler `git clone --depth=1`)
 //   - repo/plugins/soleur            (symlink to getPluginPath())
 //   - repo/.claude/settings.json     (DEFAULT_SETTINGS overlay)
-// Plugin resolution is cwd-relative — the soleur plugin manifest at
-// plugins/soleur/.claude-plugin/plugin.json is discovered from spawn cwd.
+// Plugin resolution under headless `--print` requires the explicit
+// `--plugin-dir plugins/soleur` flag in CLAUDE_CODE_FLAGS below — the symlinked
+// plugins/soleur dir is NOT auto-discovered from spawn cwd in headless mode (the
+// interactive marketplace/enabledPlugins trust flow does not run under --print).
+// See #4993 / #4987.
 //
 // GH TOKEN — installation token minted via createProbeOctokit() →
 // installation discovery → generateInstallationToken(installation.id).
@@ -91,7 +94,9 @@ const CLAUDE_CODE_FLAGS = [
   "--max-turns",
   "40",
   "--allowedTools",
-  "Bash,Read,Write,Edit,Glob,Grep",
+  "Bash,Read,Write,Edit,Glob,Grep,Skill,Task",
+  "--plugin-dir",
+  "plugins/soleur",
   "--",
 ];
 

--- a/apps/web-platform/server/inngest/functions/cron-ux-audit.ts
+++ b/apps/web-platform/server/inngest/functions/cron-ux-audit.ts
@@ -60,7 +60,10 @@ const TOKEN_MIN_LIFETIME_MS = 50 * 60 * 1000 + 10 * 60 * 1000;
 export const MAX_TURN_DURATION_MS = 50 * 60 * 1000;
 export { KILL_ESCALATION_MS } from "./_cron-claude-eval-substrate";
 
-
+// #4993 — headless /soleur:* skill resolution (fleet fix mirroring #4987 /
+// PR #4989): `--plugin-dir plugins/soleur` registers the symlinked plugin under
+// `--print` (a bare plugins/ dir is NOT auto-discovered in headless mode), and
+// `Skill` (+`Task` for subagent fan-out) in --allowedTools gates skill invocation.
 const CLAUDE_CODE_FLAGS = [
   "--print",
   "--model",
@@ -68,7 +71,9 @@ const CLAUDE_CODE_FLAGS = [
   "--max-turns",
   "60",
   "--allowedTools",
-  "Bash,Read,Write,Edit,Glob,Grep,Task,mcp__playwright__browser_navigate,mcp__playwright__browser_take_screenshot,mcp__playwright__browser_resize,mcp__playwright__browser_close,mcp__playwright__browser_wait_for",
+  "Bash,Read,Write,Edit,Glob,Grep,Task,Skill,mcp__playwright__browser_navigate,mcp__playwright__browser_take_screenshot,mcp__playwright__browser_resize,mcp__playwright__browser_close,mcp__playwright__browser_wait_for",
+  "--plugin-dir",
+  "plugins/soleur",
   "--",
 ];
 

--- a/apps/web-platform/server/inngest/functions/event-ship-merge.ts
+++ b/apps/web-platform/server/inngest/functions/event-ship-merge.ts
@@ -40,6 +40,11 @@ const TOKEN_MIN_LIFETIME_MS = 30 * 60 * 1000 + 10 * 60 * 1000;
 
 export const MAX_TURN_DURATION_MS = 30 * 60 * 1000;
 
+// #4993 — headless /soleur:* skill resolution (fleet fix mirroring #4987 /
+// PR #4989): `--plugin-dir plugins/soleur` registers the symlinked plugin under
+// `--print` (a bare plugins/ dir is NOT auto-discovered in headless mode), and
+// `Skill`+`Task` (/soleur:ship fans out review/QA subagents) in --allowedTools
+// gate skill invocation + subagent fan-out.
 const CLAUDE_CODE_FLAGS = [
   "--print",
   "--model",
@@ -47,7 +52,9 @@ const CLAUDE_CODE_FLAGS = [
   "--max-turns",
   "40",
   "--allowedTools",
-  "Bash,Read,Write,Edit,Glob,Grep",
+  "Bash,Read,Write,Edit,Glob,Grep,Skill,Task",
+  "--plugin-dir",
+  "plugins/soleur",
   "--",
 ];
 

--- a/apps/web-platform/test/server/inngest/cron-producer-output-wiring.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-producer-output-wiring.test.ts
@@ -156,10 +156,12 @@ describe("output-aware heartbeat wiring (always-create producers)", () => {
 // the functions dir and classifies a file as skill-invoking when it BOTH spawns
 // a claude eval (defines CLAUDE_CODE_FLAGS) AND invokes /soleur: in a non-comment
 // (prompt) line. That excludes the two text-only false positives
-// (cron-nag-4216-readiness, cron-skill-freshness — they emit /soleur: as
-// issue/nag TEXT and define no CLAUDE_CODE_FLAGS) and the four eval producers
-// that carry CLAUDE_CODE_FLAGS but invoke no skill (roadmap-review,
-// community-monitor, follow-through-monitor, daily-triage). The discovered set
+// (cron-nag-4216-readiness, cron-skill-freshness — these define NO
+// CLAUDE_CODE_FLAGS, so the CLAUDE_CODE_FLAGS predicate ALONE excludes them;
+// their /soleur: text lives in generated issue/nag bodies, not an eval prompt)
+// and the four eval producers that carry CLAUDE_CODE_FLAGS but invoke no skill
+// (roadmap-review, community-monitor, follow-through-monitor, daily-triage —
+// excluded by the prompt-body predicate). The discovered set
 // is asserted === the known expected set so a new producer must be classified
 // (and flagged) explicitly. content-generator is INCLUDED — it is itself a
 // self-discovered skill-invoking producer, so this guard also protects the
@@ -168,7 +170,10 @@ describe("headless skill resolution parity (#4993)", () => {
   // The authoritative skill-invoking-producer set: every cron/event handler whose
   // eval PROMPT runs a /soleur:* skill. Drift here is intentional friction — a new
   // producer that invokes a skill MUST be added (and carry the flags) or the
-  // discovery assertion below fails loud.
+  // discovery assertion below fails loud. This list slices the producer corpus on
+  // a DIFFERENT axis than WIRED_PRODUCERS / BEST_EFFORT_CRONS above (skill
+  // invocation vs. heartbeat-wiring class); the lists overlap by design and are
+  // maintained independently.
   const EXPECTED_SKILL_PRODUCERS = [
     "cron-agent-native-audit.ts",
     "cron-bug-fixer.ts",
@@ -183,15 +188,19 @@ describe("headless skill resolution parity (#4993)", () => {
     "event-ship-merge.ts",
   ].sort();
 
-  // Strip `//` line comments and jsdoc `*` lines so a /soleur: mention in a
-  // comment (sibling-skill references abound) does not misclassify a file.
+  // Strip `//` line comments so a /soleur: mention in a comment (sibling-skill
+  // references abound — content-generator's header, and roadmap-review /
+  // community-monitor's reconciled "invokes no /soleur:* skill" notes) does not
+  // misclassify a file. We deliberately do NOT strip `*`/`/*`-prefixed lines:
+  // every real prompt invocation lives on a `Run /soleur:…` line inside a
+  // template literal, and stripping `*` would risk silently false-EXCLUDING a
+  // future prompt whose text starts with a markdown bullet (`* Run /soleur:…`) —
+  // the dangerous-quiet direction (producer ships unguarded, test stays green).
+  // Verified: no flag-carrying producer carries /soleur: in a block comment.
   const promptBody = (src: string): string =>
     src
       .split("\n")
-      .filter((line) => {
-        const t = line.trim();
-        return !t.startsWith("//") && !t.startsWith("*") && !t.startsWith("/*");
-      })
+      .filter((line) => !line.trim().startsWith("//"))
       .join("\n");
 
   const discovered = readdirSync(FN_DIR)

--- a/apps/web-platform/test/server/inngest/cron-producer-output-wiring.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-producer-output-wiring.test.ts
@@ -14,7 +14,7 @@
 // cron-roadmap-review.test.ts.
 
 import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { resolve } from "node:path";
 
 const FN_DIR = resolve(__dirname, "../../../server/inngest/functions");
@@ -138,4 +138,102 @@ describe("output-aware heartbeat wiring (always-create producers)", () => {
     expect(src).not.toContain("resolveOutputAwareOk");
     expect(src).toContain("ok: result.ok");
   });
+});
+
+// #4993 — fleet-wide headless /soleur:* skill resolution parity guard.
+//
+// A headless `claude --print` cron eval can only resolve+invoke a /soleur:*
+// plugin skill when its CLAUDE_CODE_FLAGS carry BOTH `--plugin-dir
+// plugins/soleur` (registers the symlinked plugin — the interactive
+// marketplace/enabledPlugins trust flow is skipped under --print) AND `Skill`
+// (+`Task` for skills that fan out subagents) in --allowedTools. #4987/PR #4989
+// fixed cron-content-generator (the first instance); this guard makes the fix
+// fleet-wide and self-protecting so the gap cannot silently re-open when a NEW
+// producer adds a /soleur:* prompt.
+//
+// SELF-DISCOVERING: rather than 10 near-duplicate per-file test blocks (the
+// duplicate-coverage anti-pattern), this reads every cron-*.ts / event-*.ts in
+// the functions dir and classifies a file as skill-invoking when it BOTH spawns
+// a claude eval (defines CLAUDE_CODE_FLAGS) AND invokes /soleur: in a non-comment
+// (prompt) line. That excludes the two text-only false positives
+// (cron-nag-4216-readiness, cron-skill-freshness — they emit /soleur: as
+// issue/nag TEXT and define no CLAUDE_CODE_FLAGS) and the four eval producers
+// that carry CLAUDE_CODE_FLAGS but invoke no skill (roadmap-review,
+// community-monitor, follow-through-monitor, daily-triage). The discovered set
+// is asserted === the known expected set so a new producer must be classified
+// (and flagged) explicitly. content-generator is INCLUDED — it is itself a
+// self-discovered skill-invoking producer, so this guard also protects the
+// original #4987 fix from regressing.
+describe("headless skill resolution parity (#4993)", () => {
+  // The authoritative skill-invoking-producer set: every cron/event handler whose
+  // eval PROMPT runs a /soleur:* skill. Drift here is intentional friction — a new
+  // producer that invokes a skill MUST be added (and carry the flags) or the
+  // discovery assertion below fails loud.
+  const EXPECTED_SKILL_PRODUCERS = [
+    "cron-agent-native-audit.ts",
+    "cron-bug-fixer.ts",
+    "cron-campaign-calendar.ts",
+    "cron-competitive-analysis.ts",
+    "cron-content-generator.ts",
+    "cron-growth-audit.ts",
+    "cron-growth-execution.ts",
+    "cron-legal-audit.ts",
+    "cron-seo-aeo-audit.ts",
+    "cron-ux-audit.ts",
+    "event-ship-merge.ts",
+  ].sort();
+
+  // Strip `//` line comments and jsdoc `*` lines so a /soleur: mention in a
+  // comment (sibling-skill references abound) does not misclassify a file.
+  const promptBody = (src: string): string =>
+    src
+      .split("\n")
+      .filter((line) => {
+        const t = line.trim();
+        return !t.startsWith("//") && !t.startsWith("*") && !t.startsWith("/*");
+      })
+      .join("\n");
+
+  const discovered = readdirSync(FN_DIR)
+    .filter((f) => /^(cron|event)-.*\.ts$/.test(f))
+    .filter((f) => {
+      const src = readFileSync(resolve(FN_DIR, f), "utf-8");
+      return src.includes("CLAUDE_CODE_FLAGS") && promptBody(src).includes("/soleur:");
+    })
+    .sort();
+
+  it("discovers exactly the known skill-invoking producers (empty-corpus / drift guard)", () => {
+    // Non-vacuity: a glob that silently matches nothing must fail loud.
+    expect(discovered.length).toBeGreaterThan(0);
+    expect(discovered).toEqual(EXPECTED_SKILL_PRODUCERS);
+  });
+
+  it.each(EXPECTED_SKILL_PRODUCERS)(
+    "%s carries --plugin-dir + Skill + Task in CLAUDE_CODE_FLAGS, plugin-dir before --",
+    (file) => {
+      const src = readFileSync(resolve(FN_DIR, file), "utf-8");
+      const flagsMatch = src.match(/const CLAUDE_CODE_FLAGS = \[([\s\S]*?)\];/);
+      const flagsBlock = flagsMatch ? flagsMatch[1] : "";
+      expect(flagsBlock.length).toBeGreaterThan(0);
+
+      // Registers the symlinked plugin (headless --print does not auto-discover it).
+      expect(flagsBlock).toContain('"--plugin-dir"');
+      expect(flagsBlock).toContain('"plugins/soleur"');
+      expect(flagsBlock).toMatch(/"--plugin-dir",\s*\n\s*"plugins\/soleur",/);
+
+      // --allowedTools allowlist must let the eval invoke the skill (Skill) and
+      // any subagent the skill fans out (Task). Both must appear in the single
+      // allowlist string, not merely somewhere in the block.
+      const allowMatch = flagsBlock.match(/"--allowedTools",\s*\n\s*"([^"]*)"/);
+      const allowList = allowMatch ? allowMatch[1] : "";
+      expect(allowList.split(",")).toContain("Skill");
+      expect(allowList.split(",")).toContain("Task");
+
+      // --plugin-dir must precede the load-bearing `--` end-of-options marker.
+      const endMarker = flagsBlock.indexOf('"--"');
+      expect(endMarker).toBeGreaterThan(-1);
+      expect(flagsBlock.indexOf('"--plugin-dir"')).toBeLessThan(endMarker);
+      expect(flagsBlock.indexOf('"plugins/soleur"')).toBeLessThan(endMarker);
+    },
+  );
 });

--- a/knowledge-base/engineering/operations/post-mortems/cron-eval-fleet-headless-skill-resolution-degradation-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/cron-eval-fleet-headless-skill-resolution-degradation-postmortem.md
@@ -1,0 +1,143 @@
+---
+title: "Silent headless /soleur:* skill-resolution degradation across the cron-eval producer fleet"
+date: 2026-06-08
+incident_pr: 4995
+incident_window: "~since each producer's claude-eval introduction through 2026-06-08 (heartbeat-invisible)"
+recovery_at: "2026-06-08 (on merge of PR #4995)"
+suspected_change: "Headless `claude --print` cron evals never carried `--plugin-dir plugins/soleur` + `Skill` in `--allowedTools`; the symlinked plugin was never registered under `--print`."
+brand_survival_threshold: aggregate pattern
+status: resolved
+triggers:
+  - silent quality degradation (no uptime/error-rate signal)
+art_33_triggered: false
+art_34_triggered: false
+art_33_deadline: "n/a"
+---
+
+## Actor key
+
+- `agent` — Claude Code did this autonomously (no operator ack required).
+- `agent-with-ack` — Claude Code did this AFTER operator confirmed via menu option per `hr-menu-option-ack-not-prod-write-auth`.
+- `human` — Operator did this directly.
+
+# Incident Overview
+
+The scheduled "claude-eval producer" crons (`apps/web-platform/server/inngest/functions/cron-*.ts` + `event-ship-merge.ts`) spawn a headless `claude --print` process whose prompt instructs it to run a `/soleur:<skill>` plugin skill. Under `--print`, the interactive marketplace/`enabledPlugins` trust flow that registers the symlinked `plugins/soleur` directory is skipped, so the eval could not resolve or invoke the skill unless its spawn argv carried `--plugin-dir plugins/soleur` AND `Skill` (+`Task`) in `--allowedTools`. None of the producers did. The evals silently fell back to the agent hand-rolling the work — degraded output — while the per-producer `cron-cloud-task-heartbeat` watchdog stayed GREEN (an audit issue was still filed every run), so the degradation was invisible to monitoring.
+
+PR #4989 (#4987) fixed the first instance (`cron-content-generator`) after the #4982 verification run surfaced a "content-writer skill unavailable" symptom. Multi-agent review of #4989 found content-generator was not the only affected producer — 10 siblings shared the identical latent gap. This PIR covers the fleet-wide class; PR #4995 applies the fix to all 10 and adds a self-discovering parity guard so the gap cannot silently re-open.
+
+## Status
+
+resolved — fix landed fleet-wide in PR #4995; a source-shape parity test now fails CI if any producer regresses or a new producer adds a `/soleur:*` prompt without the flags.
+
+## Symptom
+
+Scheduled audit/content/SEO/UX/legal/competitive/ship/bug-fix crons file their `[Scheduled] …` summary issues on schedule (heartbeat green), but the eval's `/soleur:*` skill invocation does not resolve, so the agent produces hand-rolled, degraded output instead of running the real skill. No error surfaced to Sentry or the watchdog.
+
+## Incident Timeline
+
+- **Start time (detected):** 2026-06-07 (analytically, during multi-agent review of PR #4989)
+- **End time (recovered):** 2026-06-08 (PR #4995 merge)
+- **Duration (MTTR):** ~1 day from fleet-wide detection to fleet-wide fix (root-cause fix for the first instance landed in #4989 on 2026-06-07).
+
+| Actor | Time (UTC) | Action |
+|---|---|---|
+| agent | 2026-06-07 | #4982 verification run surfaces "content-writer skill unavailable" for content-generator. |
+| agent | 2026-06-07 | PR #4989 fixes content-generator (`--plugin-dir` + `Skill,Task`); multi-agent review flags the fleet-wide gap → issue #4993. |
+| agent | 2026-06-08 | PR #4995 applies the fix to all 10 sibling producers + adds the self-discovering parity guard. |
+
+## Participants and Systems Involved
+
+- Inngest scheduled functions under `apps/web-platform/server/inngest/functions/` (10 producers).
+- The shared `_cron-claude-eval-substrate.ts` spawn path (symlinks `plugins/soleur`, injects GH token).
+- Claude Code CLI `--print` headless mode (plugin registration semantics).
+
+## Detection (+ MTTD)
+
+- **How detected:** analytic — multi-agent code review of the content-generator fix (#4989), not a monitoring alert. The `cron-cloud-task-heartbeat` watchdog could not detect it because the heartbeat keys on artifact-creation, which still happened (degraded).
+- **MTTD (mean time to detect):** unbounded for the silent-degradation period — the defect produced no monitorable signal; it was caught only by extending the #4989 root-cause analysis to sibling producers.
+
+## Triggered by
+
+system — a latent gap in the eval spawn argv, present since each producer's claude-eval introduction.
+
+## Root-cause hypothesis (triage)
+
+| Hypothesis | Supporting evidence | Disconfirming evidence | Status |
+|---|---|---|---|
+| Headless `--print` does not auto-register the symlinked plugin; `--plugin-dir` + `Skill` in `--allowedTools` are required | `claude --help` documents `--plugin-dir`; `feature-request-plugin-dir-settings.md` root-cause doc; #4989 validated against the #4982 symptom; `~/.claude.json` had 60 inherited soleur refs masking a local probe while the ephemeral container has none | none | confirmed |
+
+## Resolution
+
+Applied the `--plugin-dir plugins/soleur` + `Skill`(+`Task`) fix to all 10 sibling producers (PR #4995), mirroring the merged #4989 shape verbatim. Reconciled the disproven "cwd-relative discovery" comments across 8 files. Added a self-discovering cross-producer parity guard (`cron-producer-output-wiring.test.ts`) that classifies any `cron-*`/`event-*` spawning a claude eval with a `/soleur:` prompt and asserts each carries the three flags — discovered set `=== 11` (the 10 + content-generator, which self-discovers, so the guard also protects the original fix).
+
+## Recovery verification
+
+- `tsc --noEmit` clean; full `test/server/inngest/` vitest suite green (1419 passed); parity guard RED→GREEN (24/24).
+- A live fully-isolated `claude --print` probe was infeasible (no `ANTHROPIC_API_KEY` in env or Doppler); the mechanism is triple-confirmed (root-cause doc + contamination trace + merged #4989), and the CI source-shape parity test is the binding recurrence gate.
+
+---
+
+# Incident Post-Mortem Analysis
+
+## Root Cause(s) — 5-Whys
+
+1. **Why did the crons produce degraded output?** The eval could not invoke its `/soleur:*` skill.
+2. **Why couldn't it invoke the skill?** The plugin was not registered in the headless process.
+3. **Why was it not registered?** Under `claude --print`, the interactive marketplace/`enabledPlugins` trust flow is skipped, so a bare symlinked `plugins/` dir is not auto-discovered; `--plugin-dir` is required and was absent. `Skill` was also missing from `--allowedTools`.
+4. **Why was the flag absent across the fleet?** The producers were authored from a shared template predating the headless-plugin-registration understanding; a since-disproven "plugin resolution is cwd-relative" comment was copied into 8 files and treated as fact.
+5. **Why did it go undetected?** The heartbeat watchdog keys on artifact-creation (the summary issue still filed) rather than on output quality, so a degraded-but-non-empty run reads as healthy.
+
+## Versions of Components
+
+- **Version(s) that triggered the outage:** all producer versions prior to PR #4995 (content-generator prior to #4989).
+- **Version(s) that restored the service:** PR #4995 (fleet) / PR #4989 (content-generator).
+
+## Impact details
+
+### Services Impacted
+
+Scheduled automation: agent-native audit, growth audit, growth execution, UX audit, competitive analysis, legal audit, SEO/AEO audit, campaign calendar, event-ship-merge, bug-fixer. Each ran but produced hand-rolled output instead of skill-driven output.
+
+### Customer Impact (by role)
+
+- Prospect: none (internal automation only).
+- Authenticated app user: none directly; downstream content/SEO/growth artifacts may have been lower quality than skill-driven runs.
+- Legal-document signer: none.
+- Admin via Access: degraded internal audit/report quality (the operator consumes these artifacts).
+- Billing customer: none.
+- OAuth installation owner: none.
+
+### Revenue Impact
+
+None.
+
+### Team Impact
+
+Solo operator consumed degraded audit/content artifacts of unknown extent; no rework attributable yet.
+
+## Lessons Learned
+
+### Where we got lucky
+
+The #4982 verification run happened to surface an explicit "skill unavailable" string for content-generator; without it the fleet-wide gap could have persisted indefinitely behind the green heartbeat.
+
+### What went well
+
+Multi-agent review of the first fix (#4989) generalized the root cause to siblings rather than treating it as a one-off; the fleet fix is self-protecting via the parity guard.
+
+### What went wrong
+
+A heartbeat that keys on artifact-creation, not output quality, gave a false-green for a degraded run. A disproven theory ("cwd-relative discovery") was copied as fact into 8 files.
+
+## Follow-ups
+
+- [x] Apply the fix to all 10 sibling producers (PR #4995).
+- [x] Add a self-discovering parity guard so a new `/soleur:*` producer without the flags fails CI.
+- [x] Reconcile the disproven cwd-relative comments fleet-wide.
+- [ ] Consider an output-quality signal (beyond artifact-creation) for the claude-eval heartbeat so silent-degradation is detectable at runtime, not only analytically. (Tracked as a non-blocking improvement — the parity guard already prevents the flag-absence recurrence class.)
+
+## Action Items
+
+- The recurrence gate is the CI parity test (`cron-producer-output-wiring.test.ts`); no separate GitHub issue required for the flag-absence class — the test fails CI on regression.
+- The runtime output-quality-signal idea is captured in Follow-ups; promote to an issue only if a future degraded run recurs despite the flags being present.

--- a/knowledge-base/project/learnings/2026-06-07-self-discovering-parity-guard-for-cross-producer-drift.md
+++ b/knowledge-base/project/learnings/2026-06-07-self-discovering-parity-guard-for-cross-producer-drift.md
@@ -1,0 +1,79 @@
+# Learning: self-discovering parity guard for cross-producer drift fixes (and its edited-vs-discovered count trap)
+
+## Problem
+
+A bug fix lands on ONE instance of a replicated pattern (PR #4989 fixed headless
+`/soleur:*` skill resolution on `cron-content-generator.ts` by adding
+`--plugin-dir plugins/soleur` + `Skill`/`Task` to `--allowedTools`). The SAME
+latent gap exists across N sibling producers (#4993: 10 more cron/event
+claude-eval producers). Fixing the siblings is mechanical — the harder problem is
+making the gap **unable to silently re-open** when a future producer adds a
+`/soleur:*` prompt without the flags. A static per-file test list rots: the next
+producer is simply never added to it, and the suite stays green.
+
+## Solution
+
+Add ONE **self-discovering** parity guard rather than N per-file test blocks
+(which is also the duplicate-coverage anti-pattern). The guard:
+
+1. `readdirSync` the producers dir, filter to `^(cron|event)-.*\.ts$`.
+2. Classify a file as skill-invoking when it BOTH spawns a claude eval
+   (`src.includes("CLAUDE_CODE_FLAGS")`) AND has `/soleur:` in a **non-comment**
+   (prompt) line. The two-predicate AND is what excludes the false positives:
+   text-only emitters that print `/soleur:` into a generated issue/nag body
+   (no `CLAUDE_CODE_FLAGS`) and flag-carrying eval producers that invoke no skill.
+3. Assert `discovered === EXPECTED_SKILL_PRODUCERS` (belt-and-suspenders: a new
+   skill producer must be added to the list AND given the flags, or the suite
+   fails loud) with a non-vacuity guard (`discovered.length > 0`).
+4. `it.each` over the set asserting each carries `--plugin-dir` + `Skill` + `Task`,
+   with `--plugin-dir` before the `--` end-of-options marker.
+
+Home it in the existing cross-producer source-shape test
+(`cron-producer-output-wiring.test.ts`) — it already establishes the
+`readFileSync` + discovered/listed-set convention.
+
+**Comment-strip robustness (the dangerous-quiet direction):** strip ONLY `//`
+line comments when computing the prompt body. Do NOT strip `*`/`/*`-prefixed
+lines — a future prompt whose template-literal text starts with a markdown
+bullet (`* Run /soleur:foo`) would be silently dropped, false-EXCLUDING the
+producer so it ships unguarded with the test still green. Verify no flag-carrying
+producer carries `/soleur:` inside a block comment before relying on this.
+
+## Key Insight
+
+**A self-discovering guard's EXPECTED count is "files DISCOVERED", not "files this
+PR EDITS".** The plan authored the expected set as 10 (the siblings it edits), but
+the discovery predicate inevitably re-matches the already-fixed precedent
+(`cron-content-generator.ts`, fixed in #4989) — so the real count is 11. This is
+a feature, not a bug: including the already-fixed item means the same guard now
+also protects the original fix from regressing. Whenever you write a
+self-discovering test against a pattern that a PRIOR PR already partially fixed,
+the expected set MUST include the prior-PR items. Reconcile the plan's
+"edited" count against the test's "discovered" count before trusting either.
+
+## Session Errors
+
+1. **Live isolated empirical probe infeasible** — no `ANTHROPIC_API_KEY` in env or
+   Doppler `dev`, so the plan-prescribed `claude --print` with/without
+   `--plugin-dir` probe could not run. **Recovery:** proceeded on the triple-confirmed
+   mechanism (root-cause doc + contamination trace + the merged #4989 validation)
+   with CI source-shape parity as the binding gate. **Prevention:** for fixes that
+   are a verbatim repeat of an already-merged-and-validated pattern, a live probe is
+   confirmatory, not load-bearing — gate on the deterministic source-shape test
+   instead of blocking on an unavailable credential.
+2. **Edit string-not-found** on `cron-campaign-calendar.ts` (omitted the `)` in
+   `// options marker).`). **Recovery:** re-read the exact lines, retried.
+   **Prevention:** one-off typo; read the exact anchor text rather than
+   reconstructing it from a sibling file's near-identical comment.
+3. **Plan "10" vs discovered "11" count divergence.** **Recovery:** used 11 in the
+   test (correct) and corrected `session-state.md` inline during review.
+   **Prevention:** the Key Insight above — reconcile edited-vs-discovered counts
+   for any self-discovering guard built on top of a prior partial fix.
+
+## Tags
+category: best-practices
+module: apps/web-platform/server/inngest/functions
+
+## Related
+- [[2026-06-07-headless-claude-print-plugin-skill-resolution-needs-plugin-dir]] — the root-cause fix this PR applied fleet-wide.
+- #4993 (this fix) / #4987 / PR #4989 (content-generator, the pattern source).

--- a/knowledge-base/project/plans/2026-06-07-fix-fleet-headless-skill-resolution-plan.md
+++ b/knowledge-base/project/plans/2026-06-07-fix-fleet-headless-skill-resolution-plan.md
@@ -133,9 +133,9 @@ bug-fix automation.
 **If this leaks, the user's workflow is exposed via:** N/A — no data exposure
 vector; this is a quality/observability defect, not a confidentiality one.
 
-**Brand-survival threshold:** aggregate pattern. The blast radius is the *fleet* of
-producers degrading together over time (the #4982/#4987 class), not a single-user
-data incident. No per-PR CPO sign-off required; section present per Phase 2.6.
+- **Brand-survival threshold:** aggregate pattern — the blast radius is the *fleet*
+  of producers degrading together over time (the #4982/#4987 class), not a single-user
+  data incident. No per-PR CPO sign-off required; section present per Phase 2.6.
 
 ## Acceptance Criteria
 
@@ -296,9 +296,14 @@ logs:
   where: existing stdout-tail capture (#4786) routed to Better Stack; unchanged.
   retention: existing Better Stack retention.
 discoverability_test:
-  command: ./node_modules/.bin/vitest run test/server/inngest/cron-producer-output-wiring.test.ts
-  expected_output: parity block passes — all 10 skill-invoking producers carry
-                   --plugin-dir + Skill + Task; discovered set length === 10.
+  command: grep -l plugin-dir apps/web-platform/server/inngest/functions/event-ship-merge.ts
+  expected_output: event-ship-merge.ts
+  note: |
+    Root-runnable local probe confirming a representative fixed producer carries
+    the --plugin-dir flag. The authoritative correctness gate is the source-shape
+    parity test (./node_modules/.bin/vitest run test/server/inngest/, run in CI +
+    /work Phase 2); this PR changes spawn FLAGS only — there is no runtime endpoint
+    to curl-probe (the fix is gated at CI, not at a live HTTP surface).
 ```
 
 > Note: this PR changes spawn FLAGS, not the observability layer. The fix's own

--- a/knowledge-base/project/plans/2026-06-07-fix-fleet-headless-skill-resolution-plan.md
+++ b/knowledge-base/project/plans/2026-06-07-fix-fleet-headless-skill-resolution-plan.md
@@ -1,0 +1,341 @@
+---
+title: "fix(cron): fleet-wide headless skill resolution for /soleur:* claude-eval producers"
+issue: 4993
+branch: feat-one-shot-4993-fleet-headless-skill-resolution
+type: bug
+classification: code-fix
+lane: single-domain
+brand_survival_threshold: aggregate pattern
+created: 2026-06-07
+---
+
+# 🐛 fix(cron): fleet-wide headless skill resolution — sibling claude-eval producers can't invoke /soleur:* skills
+
+## Enhancement Summary
+
+**Deepened on:** 2026-06-07
+**Sections enhanced:** Premise Validation, Implementation, Precedent-Diff (new)
+**Verification done live:** `claude --help` (flag grounding), `git grep` (authoritative
+set), content-generator precedent (`cc3e9ab5`).
+
+### Key Improvements
+1. **Authoritative set expanded 8 → 10** — `event-ship-merge.ts` and `cron-bug-fixer.ts`
+   (both missed by the issue table) confirmed in-scope via prompt grep.
+2. **Load-bearing flag claim grounded in live `claude --help`** — `--plugin-dir <path>`
+   "Load a plugin from a directory or .zip" is a real documented flag; `Skill`/`Task`
+   are valid `--allowedTools` tokens. No fabricated CLI tokens.
+3. **Precedent-diff gate satisfied (pattern is NOT novel)** — the fix is a verbatim
+   repetition of the merged #4987 content-generator shape (see Precedent-Diff section).
+
+### New Considerations Discovered
+- The "cwd-relative discovery" comment is in 9 files (not just the 1 cited), incl.
+  two non-skill-invoking producers (roadmap-review, community-monitor) — comment-only fix there.
+- 6/10 producers already carry `Task` — the `--allowedTools` edit must be surgical
+  (add only missing tokens) to avoid duplicating `Task`.
+
+## Overview
+
+PR #4989 (issue #4987) fixed `cron-content-generator`: a headless `claude --print`
+cron eval cannot **resolve or invoke** `/soleur:*` plugin skills unless its spawn
+argv carries **`--plugin-dir plugins/soleur`** (registers the symlinked plugin —
+the interactive marketplace/`enabledPlugins` trust flow is skipped under `--print`)
+**AND** `Skill` in `--allowedTools` (the allowlist gates skill invocation), plus
+`Task` where the skill fans out subagents.
+
+Multi-agent review of #4989 found content-generator is **not the only** producer
+whose prompt instructs the eval to `Run /soleur:<skill>`. This plan applies the
+identical, already-validated #4987 fix to every sibling producer that shares the
+gap, reconciles the now-disproven "cwd-relative discovery" comments, and adds a
+self-discovering cross-producer parity guard so the gap cannot silently re-open.
+
+This is a **pure code change** against an already-provisioned surface
+(`apps/web-platform/server/inngest/functions/`) — no new infrastructure, no schema,
+no regulated-data surface. It is a mechanical repetition of a merged, validated fix.
+
+## Premise Validation (Phase 0.6)
+
+- **#4987 / PR #4989** (`cron-content-generator` fix): `gh` confirms merged
+  (commit `cc3e9ab5`). The canonical fix is on `main`; this plan extends it. **Holds.**
+- **Authoritative producer set re-grepped** (issue says "re-grep to confirm"):
+  `git grep -n "/soleur:" apps/web-platform/server/inngest/functions/*.ts` plus a
+  prompt-vs-comment audit. The issue's 8-row table is **incomplete** — two more
+  producers invoke `/soleur:*` in their eval prompts and were missed:
+  - **`event-ship-merge.ts`** → `Run /soleur:ship --headless` (no `Skill`, no `--plugin-dir`)
+  - **`cron-bug-fixer.ts`** → `/soleur:fix-issue <N>` (no `Skill`, no `--plugin-dir`)
+  Both use the same `setupEphemeralWorkspace` symlink mechanism, so they share the
+  identical root-cause gap. **Premise expanded from 8 → 10.**
+- **False positives excluded** (mention `/soleur:` but do NOT require the eval to
+  invoke a skill): `cron-skill-freshness.ts` (emits `/soleur:archive-kb` as text in
+  a generated issue checklist for humans), `cron-nag-4216-readiness.ts` (emits
+  `/soleur:go #4216` as nag-message text). Out of scope.
+- **Root-cause doc** `feature-request-plugin-dir-settings.md` confirms: headless
+  `--print` skips the trust dialog, so `extraKnownMarketplaces`+`enabledPlugins`
+  never auto-installs; the supported mechanism is the `--plugin-dir` flag. **Holds.**
+- **Empirical probe** (issue suggested step #1): a contaminated local probe
+  (passed) was traced to inherited user-level registration — `~/.claude.json`
+  carries 60 soleur references; the ephemeral cron container has none. The
+  fully-isolated authenticated probe was **infeasible at plan time** (no
+  `ANTHROPIC_API_KEY` in this environment). The mechanism is nonetheless
+  triple-confirmed (root-cause doc + contamination trace + the already-merged
+  #4987 validation against the identical #4982 symptom). A live isolated probe is
+  prescribed as a /work Phase 0 precondition (see below) so empirical confirmation
+  is not skipped.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Issue claim | Codebase reality | Plan response |
+| --- | --- | --- |
+| 8 producers invoke `/soleur:*` | 10 do (issue missed `event-ship-merge`, `cron-bug-fixer`) | Fix all 10; document the two additions |
+| "none pass `--plugin-dir`, several lack `Skill`" | Confirmed: 0/10 have `--plugin-dir`; 0/10 have `Skill`; 6/10 already have `Task` | Add `Skill,Task` + `--plugin-dir` to all 10 |
+| `cron-competitive-analysis.ts:44-45` asserts disproven "cwd-relative" theory | The comment exists in **9** files (agent-native-audit, roadmap-review, legal-audit, growth-execution, seo-aeo-audit, competitive-analysis, community-monitor) + bug-fixer | Reconcile every occurrence, not just the one cited |
+
+## Precedent-Diff (Phase 4.4) — pattern is NOT novel
+
+This fix is a verbatim repetition of the canonical #4987 shape merged in PR #4989
+(`cc3e9ab5`). Live-verified evidence:
+
+- **`claude --help` (v2.1.168, grounding the load-bearing claim):**
+  ```
+  --plugin-dir <path>   Load a plugin from a directory or .zip
+  --allowedTools, --allowed-tools <tools...>
+  ```
+  Confirms `--plugin-dir` is a real, documented flag and `--allowedTools` is the
+  allowlist that `Skill`/`Task` must appear in. No fabricated CLI tokens (per the
+  CLI-verification gate; addresses the #4989 Session-Error-1 dangling-citation class).
+
+- **Canonical precedent — `cron-content-generator.ts` `CLAUDE_CODE_FLAGS` (target shape per producer):**
+  ```ts
+  "--allowedTools",
+  "Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,Skill,Task",  // Skill,Task appended
+  "--plugin-dir",
+  "plugins/soleur",                                                 // inserted before --
+  "--",
+  ```
+  Each of the 10 producers keeps its OWN `--allowedTools` base set + its OWN
+  `--model`/`--max-turns`; only `Skill`(+`Task` if missing) is appended and
+  `--plugin-dir plugins/soleur` is inserted before `--`.
+
+- **Test precedent — `cron-content-generator.test.ts:133-161`:** three assertions
+  (`Skill`+`Task` present; `--plugin-dir plugins/soleur` present; `--plugin-dir`
+  index < `--` index) — mirror per producer.
+
+No SQL/atomic-write/lock/RPC pattern is involved. No novel pattern; reviewers can
+scrutinize against the merged #4989 diff directly.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** the affected audit/content crons
+keep filing their `[Scheduled] …` issues (watchdog stays green) while the eval
+silently hand-rolls degraded output instead of running the real skill — invisible
+quality decay across content, growth, SEO, UX, legal, competitive, ship, and
+bug-fix automation.
+
+**If this leaks, the user's workflow is exposed via:** N/A — no data exposure
+vector; this is a quality/observability defect, not a confidentiality one.
+
+**Brand-survival threshold:** aggregate pattern. The blast radius is the *fleet* of
+producers degrading together over time (the #4982/#4987 class), not a single-user
+data incident. No per-PR CPO sign-off required; section present per Phase 2.6.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] **AC1** — `git grep -L '"--plugin-dir"' <each of the 10 in-scope files>` returns
+  empty (every in-scope producer carries `--plugin-dir` followed by `"plugins/soleur"`).
+- [ ] **AC2** — For each of the 10 producers, the `CLAUDE_CODE_FLAGS` `--allowedTools`
+  string contains `Skill` and `Task` (verified by per-producer source-regex test).
+- [ ] **AC3** — For each of the 10 producers, `--plugin-dir`'s index in `CLAUDE_CODE_FLAGS`
+  is **before** the `--` end-of-options marker (mirrors content-generator test:
+  `cron-content-generator.test.ts:155`).
+- [ ] **AC4** — The disproven "Plugin resolution is cwd-relative … discovered from
+  spawn cwd" comment is corrected in all occurrences:
+  `git grep -c "cwd-relative" apps/web-platform/server/inngest/functions/*.ts` returns
+  0 lines asserting auto-discovery-without-flag as fact (re-grounded in the
+  `--plugin-dir` mechanism). Scope-out: `cron-bug-fixer.ts:29` comment (a) about
+  plugin discovery is reworded too.
+- [ ] **AC5** — A self-discovering cross-producer parity test exists: it greps every
+  `cron-*.ts` + `event-*.ts` in the functions dir, and for any whose **prompt**
+  (not comment) contains `Run /soleur:` or `/soleur:<skill>`, asserts the file's
+  `CLAUDE_CODE_FLAGS` contains `--plugin-dir`, `Skill`, and `Task`. The test's
+  discovered set MUST equal the 10 known producers (a sanity assertion guards
+  against the glob silently matching zero, per the awk-self-match / empty-corpus
+  Sharp Edges).
+- [ ] **AC6** — Full `vitest` suite for `test/server/inngest/` passes
+  (`./node_modules/.bin/vitest run test/server/inngest/`); `tsc --noEmit` clean.
+
+### Post-merge (operator)
+
+- [ ] **AC7** — `Ref #4993` (not `Closes`) in PR body; close #4993 after merge via
+  `gh issue close 4993` once CI is green. (Standard code-fix; merge IS the
+  remediation — no separate operator apply step.)
+  *Automation: `gh issue close` runs in /soleur:ship post-merge; no manual step.*
+
+## Implementation Phases
+
+### Phase 0 — Preconditions (/work)
+
+1. **Live isolated probe** (completes the plan-time-infeasible empirical step).
+   With an `ANTHROPIC_API_KEY` available in the dev environment, run the substrate
+   shape in an **isolated** config to prove the gap and the fix:
+   - Set up a temp workspace symlinking `plugins/soleur` into `<tmp>/plugins/soleur`.
+   - Run `CLAUDE_CONFIG_DIR=<fresh-tmp> claude --print --max-turns 2 --allowedTools "Bash,Read,Skill" -- "<probe>"` (no `--plugin-dir`) → expect skill UNAVAILABLE.
+   - Re-run with `--plugin-dir plugins/soleur` → expect skill AVAILABLE.
+   Pin the two outputs into the PR body / spec. If the no-flag probe resolves the
+   skill anyway, **stop and reconcile** — #4987's root-cause analysis would be
+   incomplete (issue possibility #2). [Automation: feasible — `claude` CLI v2.1.168
+   is on PATH; only blocker at plan time was the missing API key.]
+2. Re-confirm the authoritative set with the AC5 grep before editing.
+
+### Phase 1 — Apply the #4987 flag fix to all 10 producers
+
+For each file below, edit `CLAUDE_CODE_FLAGS`: (a) append `,Skill,Task` to the
+`--allowedTools` string if not already present (6 already have `Task`; none have
+`Skill`), and (b) insert `"--plugin-dir", "plugins/soleur",` immediately before the
+`"--",` marker. Preserve each producer's existing `--model` and `--max-turns`
+(they differ per producer — do NOT homogenize). Mirror the comment block from
+`cron-content-generator.ts:53-76` (grounded in `claude --plugin-dir` help text),
+adapted per file.
+
+`## Files to Edit`
+
+1. `apps/web-platform/server/inngest/functions/cron-agent-native-audit.ts` — add `Skill` (+ keep `Task`) + `--plugin-dir`
+2. `apps/web-platform/server/inngest/functions/cron-growth-audit.ts` — add `Skill,Task` + `--plugin-dir`
+3. `apps/web-platform/server/inngest/functions/cron-growth-execution.ts` — add `Skill,Task` + `--plugin-dir`
+4. `apps/web-platform/server/inngest/functions/cron-ux-audit.ts` — add `Skill` (+ keep `Task`) + `--plugin-dir`
+5. `apps/web-platform/server/inngest/functions/cron-competitive-analysis.ts` — add `Skill` (+ keep `Task`) + `--plugin-dir`; fix cwd-relative comment
+6. `apps/web-platform/server/inngest/functions/cron-legal-audit.ts` — add `Skill` (+ keep `Task`) + `--plugin-dir`; fix cwd-relative comment
+7. `apps/web-platform/server/inngest/functions/cron-seo-aeo-audit.ts` — add `Skill,Task` + `--plugin-dir`; fix cwd-relative comment
+8. `apps/web-platform/server/inngest/functions/cron-campaign-calendar.ts` — add `Skill,Task` + `--plugin-dir`
+9. `apps/web-platform/server/inngest/functions/event-ship-merge.ts` — add `Skill,Task` + `--plugin-dir` *(missed by issue table)*
+10. `apps/web-platform/server/inngest/functions/cron-bug-fixer.ts` — add `Skill,Task` + `--plugin-dir`; reword comment (a) *(missed by issue table)*
+
+> Rationale for `Skill,Task` on all (not per-skill subagent analysis): mirrors the
+> merged #4987 fix verbatim. `--allowedTools` is an allowlist — adding `Task` where
+> a skill does not fan out subagents is harmless and avoids fragile per-skill
+> fan-out inference. `growth`, `seo-aeo`, `ship` DO spawn subagents; `fix-issue`,
+> `campaign-calendar` do not — but uniform `Skill,Task` is the robust, precedent-aligned choice.
+
+### Phase 2 — Reconcile disproven "cwd-relative" comments
+
+`## Files to Edit` (comment-only, additionally to any above):
+
+11. `apps/web-platform/server/inngest/functions/cron-roadmap-review.ts` — fix cwd-relative comment (prompt does NOT invoke `/soleur:` so NO flag change; comment correction only)
+12. `apps/web-platform/server/inngest/functions/cron-community-monitor.ts` — fix cwd-relative comment (prompt does NOT invoke `/soleur:`; comment-only)
+
+Replace the "Plugin resolution is cwd-relative — … discovered from spawn cwd"
+assertion with the verified mechanism: the symlinked `plugins/soleur` is registered
+**only** via `--plugin-dir` under `--print`; cwd-relative discovery does NOT apply
+in headless mode. For roadmap-review/community-monitor (no skill invocation), the
+comment correction prevents the disproven theory from misleading future edits.
+
+### Phase 3 — Tests (RED → GREEN)
+
+`## Files to Edit / Create`
+
+13. Extend each in-scope producer's existing `*.test.ts` (all 10 exist) with the
+    three #4987 assertions (mirror `cron-content-generator.test.ts:133-161`):
+    `--allowedTools` includes `Skill`+`Task`; `--plugin-dir plugins/soleur` present;
+    `--plugin-dir` before `--`.
+14. Add the **self-discovering parity guard**. Preferred home:
+    `apps/web-platform/test/server/inngest/cron-producer-output-wiring.test.ts`
+    already hosts list-driven cross-producer source-shape tests — add a new
+    `describe("headless skill resolution parity (#4993)")` block there, OR create
+    `cron-producer-skill-resolution.test.ts` if cleaner. The test:
+    - reads every `cron-*.ts` + `event-*.ts` in `server/inngest/functions/`;
+    - classifies each as skill-invoking if its **prompt** (a string the eval runs,
+      excluding `//` comment lines) contains `/soleur:`;
+    - asserts the discovered skill-invoking set === the 10 known files (sanity:
+      length > 0 and equals expected, per empty-corpus Sharp Edge);
+    - for each, asserts `CLAUDE_CODE_FLAGS` contains `--plugin-dir`, `Skill`, `Task`.
+
+> Test runner: `vitest` (`package.json` `scripts.test`). Files live under
+> `test/**/*.test.ts` to match `vitest.config.ts` `include` glob. Run:
+> `./node_modules/.bin/vitest run test/server/inngest/`.
+
+## Files to Create
+
+- `apps/web-platform/test/server/inngest/cron-producer-skill-resolution.test.ts`
+  *(only if not folded into `cron-producer-output-wiring.test.ts` — decide at /work)*
+
+## Open Code-Review Overlap
+
+None — no open `code-review` issues touch the 12 functions files or the test files
+in scope (the only recent overlap, PR #4989, is already merged and is the source of
+the pattern this plan extends).
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications — engineering-only tooling change to server-side cron
+eval spawn flags. No user-facing UI surface (no `components/**`, `app/**/page.tsx`),
+no schema/auth/API route, no infrastructure, no regulated data. Product/UX Gate,
+GDPR Gate (2.7), IaC Gate (2.8) all skip.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: cron-cloud-task-heartbeat watchdog per producer (existing) + the #4730
+        output-aware heartbeat wiring (existing) — unchanged by this PR.
+  cadence: per producer's existing cron schedule.
+  alert_target: Sentry (existing postSentryHeartbeat sites).
+  configured_in: each producer + _cron-claude-eval-substrate.ts (existing).
+error_reporting:
+  destination: existing Sentry capture sites in each producer; unchanged.
+  fail_loud: yes — existing audit-issue fallback (#4988) + heartbeat unchanged.
+failure_modes:
+  - mode: skill still fails to resolve after fix (flag typo / wrong path)
+    detection: Phase 0 live isolated probe + AC5 parity test (CI source-shape gate)
+    alert_route: CI red on PR (blocks merge); no runtime regression possible.
+  - mode: a NEW producer adds /soleur:* without the flags (gap re-opens)
+    detection: AC5 self-discovering parity test fails in CI
+    alert_route: CI red on the offending PR.
+logs:
+  where: existing stdout-tail capture (#4786) routed to Better Stack; unchanged.
+  retention: existing Better Stack retention.
+discoverability_test:
+  command: ./node_modules/.bin/vitest run test/server/inngest/cron-producer-output-wiring.test.ts
+  expected_output: parity block passes — all 10 skill-invoking producers carry
+                   --plugin-dir + Skill + Task; discovered set length === 10.
+```
+
+> Note: this PR changes spawn FLAGS, not the observability layer. The fix's own
+> correctness is gated at CI (source-shape parity test) + the Phase 0 live probe,
+> not at runtime — there is no new runtime failure mode to instrument. The existing
+> heartbeat + audit-issue fallback already cover the runtime silence axis.
+
+## Test Scenarios
+
+1. Each of the 10 producers: `--allowedTools` contains `Skill` and `Task`. (RED before fix.)
+2. Each of the 10 producers: `--plugin-dir`,`plugins/soleur` present and before `--`. (RED before fix.)
+3. Parity guard: discovered skill-invoking set === 10 expected files; no producer
+   in the set lacks any of the three flags. (RED before fix, for the 9 non-content-generator producers.)
+4. `tsc --noEmit` clean; full `test/server/inngest/` vitest suite green.
+
+## Sharp Edges
+
+- **A plan whose `## User-Brand Impact` section is empty, contains only
+  TBD/TODO/placeholder, or omits the threshold will fail `deepen-plan` Phase 4.6.**
+  (This plan's section is filled: threshold = aggregate pattern.)
+- The parity test (AC5) MUST distinguish a `/soleur:` token in a **prompt string**
+  from one in a `//` comment — `cron-content-generator.ts` and others mention
+  sibling skill names in comments. Classify on prompt content only, or the
+  discovered set will over-match (e.g., `cron-skill-freshness`, `cron-nag-4216`).
+  Sanity-assert the set equals exactly the 10 known files.
+- Do NOT homogenize `--model` / `--max-turns` across producers — each was tuned
+  per #4987-era PRs (opus vs sonnet; turns 40–80). Only add the two/three flags.
+- `Task` is already present in 6/10 producers — appending `,Task` blindly would
+  duplicate it. Edit the `--allowedTools` string surgically per file (add only the
+  missing tokens), do not string-concat a fixed suffix.
+- Mirror the empty-corpus / awk-self-match guard: the parity test's directory walk
+  must assert `discovered.length > 0` (and === 10) so a glob that silently matches
+  nothing fails loud instead of passing vacuously.
+
+## Related
+
+- #4987 / PR #4989 (`cc3e9ab5`) — content-generator fix (the first instance; pattern source).
+- #4982 — verification run that surfaced the content-generator degradation.
+- `feature-request-plugin-dir-settings.md` — headless plugin-registration root cause.
+- `knowledge-base/project/learnings/2026-06-07-headless-claude-print-plugin-skill-resolution-needs-plugin-dir.md` — captured learning from #4987.

--- a/knowledge-base/project/specs/feat-one-shot-4993-fleet-headless-skill-resolution/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-4993-fleet-headless-skill-resolution/session-state.md
@@ -11,7 +11,7 @@ None. The fully-isolated authenticated `claude --print` probe could not run at p
 - Authoritative producer set expanded 8 → 10 via the issue-mandated re-grep: added `event-ship-merge.ts` (`/soleur:ship`) and `cron-bug-fixer.ts` (`/soleur:fix-issue`). Excluded false positives `cron-skill-freshness` and `cron-nag-4216` (only human-facing `/soleur:` text).
 - Apply uniform `Skill,Task` in `--allowedTools` + `--plugin-dir plugins/soleur` to all 10, mirroring merged #4987/#4989 verbatim. Surgical edits — 6/10 already carry `Task`.
 - Reconcile the disproven "cwd-relative discovery" comment in all 9 occurrences (incl. roadmap-review, community-monitor where it's comment-only).
-- Add a self-discovering cross-producer parity guard test: any `cron-*.ts`/`event-*.ts` prompt containing `/soleur:` must carry the three flags; assert discovered set === 10.
+- Add a self-discovering cross-producer parity guard test: any `cron-*.ts`/`event-*.ts` that BOTH defines `CLAUDE_CODE_FLAGS` AND has `/soleur:` in a non-comment prompt line must carry the three flags. Discovered set === **11** — the 10 edited here PLUS `cron-content-generator.ts` (already fixed in #4989 but still self-discovered, so the guard also protects the original fix from regressing).
 - Every load-bearing claim live-verified: `claude --help` confirms `--plugin-dir`; PR #4989 MERGED; issue #4993 OPEN; "0/10 have --plugin-dir" confirmed by grep.
 
 ### Components Invoked

--- a/knowledge-base/project/specs/feat-one-shot-4993-fleet-headless-skill-resolution/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-4993-fleet-headless-skill-resolution/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-07-fix-fleet-headless-skill-resolution-plan.md
+- Status: complete
+
+### Errors
+None. The fully-isolated authenticated `claude --print` probe could not run at plan time (no ANTHROPIC_API_KEY in env); the mechanism is triple-confirmed otherwise and a live isolated probe is prescribed as a /work Phase 0 precondition.
+
+### Decisions
+- Authoritative producer set expanded 8 → 10 via the issue-mandated re-grep: added `event-ship-merge.ts` (`/soleur:ship`) and `cron-bug-fixer.ts` (`/soleur:fix-issue`). Excluded false positives `cron-skill-freshness` and `cron-nag-4216` (only human-facing `/soleur:` text).
+- Apply uniform `Skill,Task` in `--allowedTools` + `--plugin-dir plugins/soleur` to all 10, mirroring merged #4987/#4989 verbatim. Surgical edits — 6/10 already carry `Task`.
+- Reconcile the disproven "cwd-relative discovery" comment in all 9 occurrences (incl. roadmap-review, community-monitor where it's comment-only).
+- Add a self-discovering cross-producer parity guard test: any `cron-*.ts`/`event-*.ts` prompt containing `/soleur:` must carry the three flags; assert discovered set === 10.
+- Every load-bearing claim live-verified: `claude --help` confirms `--plugin-dir`; PR #4989 MERGED; issue #4993 OPEN; "0/10 have --plugin-dir" confirmed by grep.
+
+### Components Invoked
+- Skill: soleur:plan
+- Skill: soleur:deepen-plan
+- Deepen-plan gates: 4.4 Precedent-Diff (satisfied), 4.45 verify-the-negative (pass), 4.6 User-Brand Impact (pass), 4.7 Observability (pass), 4.8 PAT-shaped (pass), 4.9 UI-wireframe (skip)


### PR DESCRIPTION
## Summary

Fleet-wide follow-up to PR #4989 (#4987). A headless `claude --print` cron eval can only resolve and invoke a `/soleur:*` plugin skill when its `CLAUDE_CODE_FLAGS` carry **both** `--plugin-dir plugins/soleur` (registers the symlinked plugin — the interactive marketplace/`enabledPlugins` trust flow is skipped under `--print`) **and** `Skill` (+`Task` for subagent fan-out) in `--allowedTools`. #4989 fixed `cron-content-generator` (the first instance); multi-agent review found 10 sibling producers share the same latent gap — their prompts invoke `/soleur:*` but none carried `--plugin-dir` and none had `Skill`.

Applies the identical, already-validated fix to all 10 skill-invoking producers, reconciles the disproven "cwd-relative discovery" comments, and adds a self-discovering parity guard so the gap cannot silently re-open.

Closes #4993

## Changelog

### Web Platform — cron/event claude-eval producers
- Added `Skill` (+`Task` where missing) to `--allowedTools` and inserted `--plugin-dir plugins/soleur` before the `--` marker in all 10 producers: `cron-agent-native-audit`, `cron-growth-audit`, `cron-growth-execution`, `cron-ux-audit`, `cron-competitive-analysis`, `cron-legal-audit`, `cron-seo-aeo-audit`, `cron-campaign-calendar`, `event-ship-merge`, `cron-bug-fixer`. Per-producer `--model`/`--max-turns` preserved (not homogenized).
- Re-grep expanded the issue's 8-row table to 10 (`event-ship-merge`, `cron-bug-fixer` were missed by the issue).
- Reconciled the disproven "Plugin resolution is cwd-relative" comment across 8 files (incl. `cron-roadmap-review`, `cron-community-monitor`, which invoke no skill — comment-only).
- Added a **self-discovering** cross-producer parity guard to `cron-producer-output-wiring.test.ts`: classifies any `cron-*`/`event-*` that both spawns a claude eval (`CLAUDE_CODE_FLAGS`) and invokes `/soleur:` in a non-comment prompt line, asserts the discovered set `=== 11` known producers (the 10 + `cron-content-generator`, which self-discovers — so the guard also protects the original #4989 fix), and that each carries `--plugin-dir` + `Skill` + `Task`.

## User-Brand Impact

**If this lands broken, the user experiences:** the affected audit/content crons keep filing their `[Scheduled] …` issues (the heartbeat watchdog stays green) while the eval silently hand-rolls degraded output instead of running the real skill — invisible quality decay across content, growth, SEO, UX, legal, competitive, ship, and bug-fix automation.

**If this leaks:** N/A — no data-exposure vector; this is a quality/observability defect, not a confidentiality one.

- **Brand-survival threshold:** aggregate pattern — the blast radius is the *fleet* of producers degrading together over time (the #4982/#4987 class), not a single-user data incident.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full `test/server/inngest/` vitest suite green (1419 passed)
- [x] Parity guard RED before fix (10/11 failed) → GREEN after (24/24)
- [x] AC1: all 10 producers carry `--plugin-dir plugins/soleur`
- [x] AC4: no comment asserts plugin auto-discovery-from-cwd as fact
- [x] Multi-agent review (security-sentinel, pattern-recognition, code-quality, architecture, semgrep) — 0 P1/P2; P3 findings fixed inline
- Plan: `knowledge-base/project/plans/2026-06-07-fix-fleet-headless-skill-resolution-plan.md`

Generated with [Claude Code](https://claude.com/claude-code)
