### PR TITLE
fix(concierge): derive owner/repo from active workspace, stop prompting for repo

### DIFF
--- a/apps/web-platform/server/cc-dispatcher.ts
+++ b/apps/web-platform/server/cc-dispatcher.ts
@@ -279,14 +279,20 @@ const GH_403_PROMPT_DIRECTIVE =
 // active-workspace repo_url (ADR-044), so we surface it directly. Mirrors the
 // leader path at agent-runner.ts:1429-1441 (lock-step the lead phrase "The
 // connected repository is ${owner}/${repo}" so the two surfaces stay
-// greppable together).
+// greppable together). PARITY: the static baseline counterpart is
+// GH_AUTH_STATUS_GUIDANCE_DIRECTIVE in soleur-go-runner.ts — both tell the
+// agent to pass `-R owner/repo` and never infer from a git remote; keep the
+// two in lock-step.
 //
 // The `${owner}/${repo}` interpolation is safe because both are validated
 // against CC_GITHUB_NAME_RE at the call site before assignment (see
 // connectedOwner/connectedRepo resolution below) — no whitespace, backticks,
 // `$`, `{`, newlines, or markdown fences can slip through. If that regex ever
 // relaxes, this becomes a prompt-injection sink.
-function buildConnectedRepoContext(owner: string, repo: string): string {
+//
+// Exported so the test suite can assert on the builder's OUTPUT directly
+// (behavioral), not only on source-presence of the call site.
+export function buildConnectedRepoContext(owner: string, repo: string): string {
   return (
     "## Connected repository\n" +
     `The connected repository is ${owner}/${repo}. For any repo gh operation, ` +

--- a/apps/web-platform/server/cc-dispatcher.ts
+++ b/apps/web-platform/server/cc-dispatcher.ts
@@ -270,6 +270,33 @@ const GH_403_PROMPT_DIRECTIVE =
   "installed on the repository's owner account. Beyond that, state only what " +
   "the error literally says.";
 
+// feat-one-shot-concierge-workspace-repo-context — name the connected
+// repository to the Concierge so it stops trying to infer owner/repo from a
+// git origin remote. On a `.git`-less workspace `git config --get
+// remote.origin.url` returns empty and the agent falsely concludes "no repo
+// connected" and prompts the user — even though the workspace header plainly
+// shows the connected repo. The server already resolves owner/repo from the
+// active-workspace repo_url (ADR-044), so we surface it directly. Mirrors the
+// leader path at agent-runner.ts:1429-1441 (lock-step the lead phrase "The
+// connected repository is ${owner}/${repo}" so the two surfaces stay
+// greppable together).
+//
+// The `${owner}/${repo}` interpolation is safe because both are validated
+// against CC_GITHUB_NAME_RE at the call site before assignment (see
+// connectedOwner/connectedRepo resolution below) — no whitespace, backticks,
+// `$`, `{`, newlines, or markdown fences can slip through. If that regex ever
+// relaxes, this becomes a prompt-injection sink.
+function buildConnectedRepoContext(owner: string, repo: string): string {
+  return (
+    "## Connected repository\n" +
+    `The connected repository is ${owner}/${repo}. For any repo gh operation, ` +
+    `pass -R ${owner}/${repo} explicitly (for example: gh issue view 123 -R ` +
+    `${owner}/${repo}). Use this value directly — do NOT try to infer the ` +
+    "repository from a git remote or a .git directory; the workspace may not " +
+    "contain one. The installation token resolves the repo server-side."
+  );
+}
+
 // Max length cap for `block.name` before passing to Sentry/pino. Defense-in-
 // depth against future model regressions that might emit pathologically long
 // tool names; the SDK validation gate constrains names to the registered
@@ -1530,6 +1557,15 @@ export const realSdkQueryFactory: QueryFactory = async (
   // Always append the gh-403 honesty directive (feat-one-shot-concierge-gh-403)
   // — independent of repo/flag state, since any conversation can run `gh`.
   effectiveSystemPrompt += `\n\n${GH_403_PROMPT_DIRECTIVE}`;
+  // feat-one-shot-concierge-workspace-repo-context — name the server-resolved
+  // connected repo so the agent uses it for `-R owner/repo` instead of probing
+  // a (possibly absent) git remote. Guarded ONLY on the CC_GITHUB_NAME_RE-
+  // validated owner/repo truthiness — NOT a `.git` presence check, which is
+  // the exact dependency the bug stems from. Fed only connectedOwner/
+  // connectedRepo (validated above), never raw repoUrl or tool input.
+  if (connectedOwner && connectedRepo) {
+    effectiveSystemPrompt += `\n\n${buildConnectedRepoContext(connectedOwner, connectedRepo)}`;
+  }
 
   // nosemgrep: path-join-resolve-traversal -- workspacePath is server-resolved (fetchUserWorkspacePath, ADR-044), never user-tainted input.
   const pluginPath = path.join(workspacePath, "plugins", "soleur");

--- a/apps/web-platform/server/soleur-go-runner.ts
+++ b/apps/web-platform/server/soleur-go-runner.ts
@@ -154,9 +154,11 @@ export const GH_AUTH_STATUS_GUIDANCE_DIRECTIVE =
   "against your connected repo are credentialed automatically in your " +
   "workspace — you do not need gh for them. For any repo operation, pass " +
   "-R owner/repo explicitly (for example: gh issue view 123 -R owner/repo, " +
-  "gh pr create -R owner/repo); discover your owner/repo from the origin " +
-  "remote with git config --get remote.origin.url. The installation token " +
-  "resolves the repo server-side and gh cannot infer it without -R owner/repo.";
+  "gh pr create -R owner/repo); use the connected repository named in your " +
+  "context for that owner/repo value (do not try to infer it from a git " +
+  "remote or a .git directory — your workspace may not contain one). The " +
+  "installation token resolves the repo server-side and gh cannot infer it " +
+  "without -R owner/repo.";
 
 // On a failure-recovery turn (a tool or skill the agent just ran reported an
 // error), the Concierge should mirror the static failure-card "File an issue"

--- a/apps/web-platform/test/cc-dispatcher-connected-repo-context.test.ts
+++ b/apps/web-platform/test/cc-dispatcher-connected-repo-context.test.ts
@@ -16,55 +16,63 @@ import { describe, test, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { buildConnectedRepoContext } from "@/server/cc-dispatcher";
+
 const SRC = readFileSync(
   join(__dirname, "..", "server", "cc-dispatcher.ts"),
   "utf8",
 );
 
+// AC1/AC4 are behavioral — assert on the exported builder's OUTPUT, so they
+// survive any benign refactor of the call site (rename, reformat, reflow).
+// AC3/AC5 prove the WIRING (the builder is appended inside the server-resolved
+// guard, not a `.git` probe) via reflow-tolerant source-presence checks — the
+// per-dispatch factory is impractical to invoke in a unit test (same framing
+// as cc-dispatcher-gh-403-directive.test.ts).
 describe("Concierge connected-repo context addendum", () => {
-  test("AC1: a connected-repo context builder names the repo and references -R", () => {
-    const idx = SRC.indexOf("buildConnectedRepoContext");
-    expect(
-      idx,
-      "buildConnectedRepoContext builder must exist",
-    ).toBeGreaterThan(-1);
-    // The builder body (window after the definition) names the connected repo
-    // and instructs passing `-R owner/repo` using that resolved value.
-    const body = SRC.slice(idx, idx + 1200);
+  test("AC1: the builder names the connected repo and instructs -R owner/repo", () => {
+    const out = buildConnectedRepoContext("jikig-ai", "soleur");
     // Lock-step lead phrase with agent-runner.ts:1433.
-    expect(body).toMatch(/connected repository is \$\{owner\}\/\$\{repo\}/);
-    expect(body).toMatch(/-R \$\{owner\}\/\$\{repo\}/);
+    expect(out).toContain("The connected repository is jikig-ai/soleur");
+    expect(out).toContain("-R jikig-ai/soleur");
+    // Names the actual values, not a placeholder.
+    expect(out).not.toContain("owner/repo");
   });
 
-  test("AC3/AC5: addendum is appended only inside the connectedOwner && connectedRepo guard", () => {
-    // Guard on server-resolved truthiness — NOT existsSync(.git). The append
-    // sits immediately inside the guard so it fires on a `.git`-less workspace
-    // (the failing case) and is omitted when no repo is connected (byte-parity).
+  test("AC1: the builder tells the agent NOT to infer from a git remote / .git", () => {
+    const out = buildConnectedRepoContext("acme", "widgets");
+    expect(out).toMatch(/do NOT try to infer/i);
+    expect(out).toMatch(/git remote or a \.git directory/);
+  });
+
+  test("AC3/AC5: the append is wired inside the connectedOwner && connectedRepo guard (not a .git probe)", () => {
+    // Reflow-tolerant: tolerate whitespace/newlines between the guard and the
+    // append, but bound the gap so it cannot match across unrelated code. The
+    // guard keys on server-resolved truthiness — NOT existsSync('.git').
     expect(SRC).toMatch(
-      /if \(connectedOwner && connectedRepo\) \{\s*effectiveSystemPrompt\s*\+=\s*`\\n\\n\$\{buildConnectedRepoContext\(connectedOwner, connectedRepo\)\}`;\s*\}/,
+      /if \(connectedOwner && connectedRepo\)\s*\{[\s\S]{0,200}?effectiveSystemPrompt\s*\+=[\s\S]{0,80}?buildConnectedRepoContext\(connectedOwner, connectedRepo\)/,
     );
-  });
-
-  test("AC5: addendum is NOT gated on a .git presence check", () => {
-    // The append must not be conditioned on a filesystem `.git` probe.
+    // The guard window must not be a filesystem `.git` presence check.
+    const guardIdx = SRC.search(/if \(connectedOwner && connectedRepo\)/);
     const appendIdx = SRC.indexOf(
       "buildConnectedRepoContext(connectedOwner, connectedRepo)",
     );
-    expect(appendIdx).toBeGreaterThan(-1);
-    const window = SRC.slice(appendIdx - 300, appendIdx);
-    expect(window).not.toMatch(/existsSync[\s\S]*\.git/);
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(appendIdx).toBeGreaterThan(guardIdx);
+    expect(SRC.slice(guardIdx, appendIdx)).not.toMatch(/existsSync/);
   });
 
-  test("AC4: builder is fed only the CC_GITHUB_NAME_RE-validated bindings", () => {
-    // Call site passes connectedOwner/connectedRepo (validated at :1330),
+  test("AC4: the call site is fed only the CC_GITHUB_NAME_RE-validated bindings", () => {
+    // Passes connectedOwner/connectedRepo (validated before assignment),
     // never raw repoUrl or tool input.
-    expect(SRC).toMatch(
-      /buildConnectedRepoContext\(connectedOwner, connectedRepo\)/,
+    expect(SRC).toContain(
+      "buildConnectedRepoContext(connectedOwner, connectedRepo)",
     );
     expect(SRC).not.toMatch(/buildConnectedRepoContext\(repoUrl/);
-    // Injection-safety comment carried forward from agent-runner.ts:1425-1428.
-    const idx = SRC.indexOf("buildConnectedRepoContext");
-    const comment = SRC.slice(Math.max(0, idx - 600), idx + 200);
+    // Injection-safety reasoning carried forward from agent-runner.ts:1425-1428
+    // stays adjacent to the builder so a regex relaxation is greppable here.
+    const idx = SRC.indexOf("export function buildConnectedRepoContext");
+    const comment = SRC.slice(Math.max(0, idx - 800), idx);
     expect(comment).toMatch(/CC_GITHUB_NAME_RE/);
     expect(comment).toMatch(/injection sink/i);
   });

--- a/apps/web-platform/test/cc-dispatcher-connected-repo-context.test.ts
+++ b/apps/web-platform/test/cc-dispatcher-connected-repo-context.test.ts
@@ -1,0 +1,71 @@
+/**
+ * feat-one-shot-concierge-workspace-repo-context — the Concierge derives
+ * owner/repo from the active workspace instead of inferring it from a git
+ * origin remote (which is empty on a `.git`-less workspace, producing the
+ * false "no connected git repository" reply).
+ *
+ * cc-dispatcher's prompt assembly lives deep in a per-dispatch factory that is
+ * impractical to invoke in a unit test (same framing as
+ * `cc-dispatcher-gh-403-directive.test.ts`), so per AC1's own framing this is a
+ * source-presence check: the connected-repo context builder exists naming the
+ * repo and referencing `-R`, AND is appended to `effectiveSystemPrompt` only
+ * inside the server-resolved `connectedOwner && connectedRepo` guard (NOT a
+ * `.git` presence check), fed only the CC_GITHUB_NAME_RE-validated bindings.
+ */
+import { describe, test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC = readFileSync(
+  join(__dirname, "..", "server", "cc-dispatcher.ts"),
+  "utf8",
+);
+
+describe("Concierge connected-repo context addendum", () => {
+  test("AC1: a connected-repo context builder names the repo and references -R", () => {
+    const idx = SRC.indexOf("buildConnectedRepoContext");
+    expect(
+      idx,
+      "buildConnectedRepoContext builder must exist",
+    ).toBeGreaterThan(-1);
+    // The builder body (window after the definition) names the connected repo
+    // and instructs passing `-R owner/repo` using that resolved value.
+    const body = SRC.slice(idx, idx + 1200);
+    // Lock-step lead phrase with agent-runner.ts:1433.
+    expect(body).toMatch(/connected repository is \$\{owner\}\/\$\{repo\}/);
+    expect(body).toMatch(/-R \$\{owner\}\/\$\{repo\}/);
+  });
+
+  test("AC3/AC5: addendum is appended only inside the connectedOwner && connectedRepo guard", () => {
+    // Guard on server-resolved truthiness — NOT existsSync(.git). The append
+    // sits immediately inside the guard so it fires on a `.git`-less workspace
+    // (the failing case) and is omitted when no repo is connected (byte-parity).
+    expect(SRC).toMatch(
+      /if \(connectedOwner && connectedRepo\) \{\s*effectiveSystemPrompt\s*\+=\s*`\\n\\n\$\{buildConnectedRepoContext\(connectedOwner, connectedRepo\)\}`;\s*\}/,
+    );
+  });
+
+  test("AC5: addendum is NOT gated on a .git presence check", () => {
+    // The append must not be conditioned on a filesystem `.git` probe.
+    const appendIdx = SRC.indexOf(
+      "buildConnectedRepoContext(connectedOwner, connectedRepo)",
+    );
+    expect(appendIdx).toBeGreaterThan(-1);
+    const window = SRC.slice(appendIdx - 300, appendIdx);
+    expect(window).not.toMatch(/existsSync[\s\S]*\.git/);
+  });
+
+  test("AC4: builder is fed only the CC_GITHUB_NAME_RE-validated bindings", () => {
+    // Call site passes connectedOwner/connectedRepo (validated at :1330),
+    // never raw repoUrl or tool input.
+    expect(SRC).toMatch(
+      /buildConnectedRepoContext\(connectedOwner, connectedRepo\)/,
+    );
+    expect(SRC).not.toMatch(/buildConnectedRepoContext\(repoUrl/);
+    // Injection-safety comment carried forward from agent-runner.ts:1425-1428.
+    const idx = SRC.indexOf("buildConnectedRepoContext");
+    const comment = SRC.slice(Math.max(0, idx - 600), idx + 200);
+    expect(comment).toMatch(/CC_GITHUB_NAME_RE/);
+    expect(comment).toMatch(/injection sink/i);
+  });
+});

--- a/apps/web-platform/test/soleur-go-runner-gh-auth-status.test.ts
+++ b/apps/web-platform/test/soleur-go-runner-gh-auth-status.test.ts
@@ -43,4 +43,23 @@ describe("buildSoleurGoSystemPrompt — gh auth status guidance (item 2)", () =>
     expect(prompt).toContain("gh auth status");
     expect(prompt).toContain("-R owner/repo");
   });
+
+  // AC2 (feat-one-shot-concierge-workspace-repo-context) — the baseline no
+  // longer tells the agent to infer owner/repo from the git origin remote.
+  // On a `.git`-less workspace `git config --get remote.origin.url` returns
+  // empty, producing the false "no connected git repository" reply. The
+  // server-resolved owner/repo (injected per-dispatch by cc-dispatcher) is the
+  // authoritative source; the baseline must point at the connected repository
+  // named in the agent's context, not a git remote.
+  it("directive no longer instructs deriving owner/repo from the git origin remote", () => {
+    expect(GH_AUTH_STATUS_GUIDANCE_DIRECTIVE).not.toContain(
+      "remote.origin.url",
+    );
+  });
+
+  it("directive references the connected repository named in the agent context", () => {
+    expect(GH_AUTH_STATUS_GUIDANCE_DIRECTIVE).toMatch(
+      /connected repository/i,
+    );
+  });
 });

--- a/knowledge-base/project/learnings/integration-issues/2026-06-07-concierge-cc-path-derive-owner-repo-from-workspace.md
+++ b/knowledge-base/project/learnings/integration-issues/2026-06-07-concierge-cc-path-derive-owner-repo-from-workspace.md
@@ -1,0 +1,84 @@
+---
+module: cc-dispatcher
+date: 2026-06-07
+problem_type: integration_issue
+component: server
+symptoms:
+  - "Concierge replies 'no connected git repository' on a workspace whose header shows the repo"
+  - "Agent asks the user to provide owner/repo even though the workspace is connected"
+  - "gh issue/repo lookups fail because no -R owner/repo is passed"
+root_cause: agent_inferred_context_from_fragile_filesystem_source_instead_of_server_resolved_value
+severity: high
+tags: [concierge, system-prompt, owner-repo, agent-native, context-parity, adr-044]
+synced_to: []
+---
+
+# Concierge cc-path must derive owner/repo from the active workspace, not a git remote
+
+## Problem
+
+In the Dashboard "Soleur Concierge" chat, asking to "Fix Issue 4826" produced a reply
+claiming there is **no connected git repository** — `gh` can't infer the repo and there's
+no `.git` directory — and the agent prompted the user to type `owner/repo`. This happened
+even though the workspace header plainly showed the connected repo (`jikig-ai/soleur`).
+
+## Root Cause
+
+The cc-path baseline directive `GH_AUTH_STATUS_GUIDANCE_DIRECTIVE`
+(`apps/web-platform/server/soleur-go-runner.ts`) instructed the agent to "discover your
+owner/repo from the origin remote with `git config --get remote.origin.url`". On a
+`.git`-less workspace (cold workspace, or `ensureWorkspaceRepoCloned` self-heal not yet
+run) that command returns empty, so the agent concluded "no repo connected".
+
+Meanwhile the server **already** resolves and validates the owner/repo for every dispatch:
+`cc-dispatcher.ts` parses `connectedOwner`/`connectedRepo` from the membership-scoped
+`getCurrentRepoUrl(userId)` (active-workspace `repo_url`, ADR-044) and validates each
+against `CC_GITHUB_NAME_RE`. Those values were in scope (already used for the GH_TOKEN mint
+and the C4 write-tool gate) but were never surfaced into the Concierge's system prompt. The
+sibling **leader path** (`agent-runner.ts:1429-1441`) already did the right thing —
+appending `The connected repository is ${owner}/${repo}` — but the cc-path had no equivalent.
+
+## Solution
+
+1. Added `buildConnectedRepoContext(owner, repo)` to `cc-dispatcher.ts` and appended its
+   output to `effectiveSystemPrompt` inside an `if (connectedOwner && connectedRepo)` guard
+   — lock-stepping the lead phrase with the leader path so the two surfaces stay greppable.
+2. Rewrote `GH_AUTH_STATUS_GUIDANCE_DIRECTIVE` to drop the `git config --get
+   remote.origin.url` clause and instead point at "the connected repository named in your
+   context" for the `-R owner/repo` value (keeping the `gh auth status` false-negative
+   guidance + both paren-safe test anchors intact).
+
+Prompt-text only — no new infra, schema, or data path. The owner/repo interpolation is
+injection-safe because both bindings are `CC_GITHUB_NAME_RE`-validated before assignment
+(carried the `agent-runner.ts:1425-1428` "if that regex relaxes, this becomes a
+prompt-injection sink" warning forward).
+
+## Key Insight
+
+When two agent paths (Concierge cc-path vs. leader-path) each assemble a system prompt, and
+one path tells the agent to **infer context from a fragile filesystem source** (a git
+remote / `.git` directory) while the server **already holds the validated value**, surface
+the server-resolved value into the prompt rather than having the agent probe the filesystem.
+Guard the injection on the **resolved-value truthiness**, NOT on a `.git` presence check —
+that filesystem dependency is the exact root cause. This is the system-prompt analogue of
+agent-user context parity: anything the user can see (the connected repo in the workspace
+header) the agent must see too, from the same server source of truth.
+
+## Session Errors
+
+1. **Bash CWD drift** — `./node_modules/.bin/vitest` / `tsc` / the full-suite run failed
+   with `cd: apps/web-platform: No such file or directory` because the Bash tool does not
+   persist CWD across calls. **Recovery:** chained `cd <worktree-abs-path> && <cmd>` in a
+   single Bash invocation. **Prevention:** already covered by the work skill's "chain `cd
+   <worktree-abs-path> && <cmd>` in one Bash call" rule — application lapse, not a missing
+   rule.
+2. **Edit `old_string` mid-comment mismatch** — the first attempt to add `export` + the
+   parity comment failed (`String to replace not found`) because the `old_string` began
+   mid-comment and did not match byte-for-byte. **Recovery:** re-read the exact lines, then
+   matched a unique trailing slice. **Prevention:** already covered by
+   `hr-always-read-a-file-before-editing-it` — read the exact bytes before constructing an
+   Edit `old_string`.
+
+## Tags
+category: integration-issues
+module: cc-dispatcher

--- a/knowledge-base/project/plans/2026-06-07-fix-concierge-derive-owner-repo-from-workspace-plan.md
+++ b/knowledge-base/project/plans/2026-06-07-fix-concierge-derive-owner-repo-from-workspace-plan.md
@@ -1,0 +1,273 @@
+---
+title: "fix: Concierge derives owner/repo from active workspace (stop prompting for repo)"
+type: fix
+date: 2026-06-07
+branch: feat-one-shot-concierge-workspace-repo-context
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+---
+
+# 🐛 fix: Concierge derives owner/repo from the active workspace
+
+## Overview
+
+In the Dashboard "Soleur Concierge" chat, asking to **"Fix Issue 4826"** makes the
+Concierge reply that **there is no connected git repository** — it claims `gh` cannot
+infer the repo and there is no `.git` directory, then asks the user to provide
+`owner/repo`. This is wrong: the active workspace already has the repo connected
+(`jikig-ai/soleur` per the workspace header), and the server already knows the
+owner/repo for the dispatch.
+
+**Root cause (verified against current source):** The Concierge router runs through
+`soleur-go-runner.ts` → `cc-dispatcher.ts` (the `realSdkQueryFactory`). The router's
+baseline system prompt embeds `GH_AUTH_STATUS_GUIDANCE_DIRECTIVE`
+(`apps/web-platform/server/soleur-go-runner.ts:148-159`), which instructs the agent to
+**"discover your owner/repo from the origin remote with `git config --get
+remote.origin.url`"**. When the workspace has no `.git` (cold workspace, or the
+`ensureWorkspaceRepoCloned` self-heal failed/has not run), that command returns nothing,
+so the agent concludes "no repo connected" and falls back to prompting the user.
+
+Meanwhile, the **server already resolves and validates the owner/repo** for every
+dispatch: `cc-dispatcher.ts:1323-1337` parses `connectedOwner`/`connectedRepo` from the
+membership-scoped `getCurrentRepoUrl(userId)` (active-workspace repo URL, ADR-044) and
+validates each against `CC_GITHUB_NAME_RE`. These values are *already in scope* in the
+factory and are reused for the GH_TOKEN mint + the C4 write-tool gate — they are simply
+never surfaced into the Concierge's system prompt.
+
+The sibling leader path already does the right thing: `agent-runner.ts:1429-1441` appends
+`## GitHub read access\n\nThe connected repository is ${owner}/${repo}. …` to its system
+prompt. The Concierge (cc path) has no equivalent. **The fix is to mirror that pattern in
+the cc path** and to retire the "discover owner/repo from the git origin remote"
+instruction that produces the false "no repo connected" reply.
+
+**Approach (minimal, mirrors existing patterns):**
+
+1. In `cc-dispatcher.ts` `realSdkQueryFactory`, when `connectedOwner && connectedRepo`
+   are non-empty (already resolved at `:1323-1337`), append a **connected-repo context
+   addendum** to `effectiveSystemPrompt` — byte-shaped exactly like the unconditional
+   `GH_403_PROMPT_DIRECTIVE` append at `:1532` and the conditional `c4PromptAddendum`
+   append at `:1527-1529`. The addendum states the connected repo as `owner/repo` and
+   instructs the agent to pass `-R owner/repo` using **that** value (never inferring from
+   a git remote).
+2. In `soleur-go-runner.ts`, **rewrite the owner/repo-discovery clause** of
+   `GH_AUTH_STATUS_GUIDANCE_DIRECTIVE` so the baseline no longer tells the agent to derive
+   owner/repo from `git config --get remote.origin.url`. The baseline keeps the
+   installation-token / `gh auth status` false-negative guidance (still load-bearing) but
+   points at "the connected repository named in your context" for the `-R owner/repo`
+   value. The dispatcher-injected addendum (item 1) supplies that name.
+
+This keeps the server as the single source of truth for owner/repo (it is the only
+trustworthy source — `repo_url` is membership-scoped and validated), removes the
+git-origin dependency that breaks on a `.git`-less workspace, and changes **prompt text
+only** — no new infra, no schema, no new runtime data path.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (from bug report) | Reality (verified in source) | Plan response |
+| --- | --- | --- |
+| "concierge says no connected git repository … `gh` can't infer the repo, no `.git`" | The baseline directive at `soleur-go-runner.ts:157` tells the agent to derive owner/repo from `git config --get remote.origin.url`; a `.git`-less workspace makes that return empty → false "no repo" conclusion. | Rewrite the directive's owner/repo-discovery clause; inject server-resolved owner/repo. |
+| "the workspace already has the repo connected (jikig-ai/soleur)" | True: `getCurrentRepoUrl(userId)` (active-workspace `repo_url`, ADR-044) is resolved at `cc-dispatcher.ts:1250` and parsed to `connectedOwner`/`connectedRepo` at `:1323-1337`. | Surface those already-resolved values into the system prompt. |
+| "should derive owner/repo from current workspace context" | The leader path already does this (`agent-runner.ts:1429-1441`); the cc/Concierge path does not. | Mirror the leader's `The connected repository is ${owner}/${repo}` addendum in the cc path. |
+| Issue #4826 is the issue to fix | #4826 is a real OPEN issue ("feat: nav-rail position resume …") — unrelated to this bug; it is only the example the user typed to trigger the broken reply. `gh issue view 4826` succeeds. | No premise change. The fix is the Concierge repo-context, not #4826 itself. |
+
+**Premise Validation:** The cited issue (#4826) exists and is OPEN; it is an example trigger,
+not a blocker. The cited symptom ("`gh` can't infer the repo / no `.git`") maps to a real
+baseline directive (`soleur-go-runner.ts:157`) that depends on a git origin remote. The
+claim "the workspace already knows the repo" is confirmed: `connectedOwner`/`connectedRepo`
+are resolved and validated server-side at `cc-dispatcher.ts:1323-1337`. No stale premise.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** the Concierge continues to deny that a
+repo is connected and asks them to type `owner/repo` (or worse, the agent passes a wrong
+`-R` value and `gh` 404s the issue), so the single most-marketed Concierge flow
+("Fix Issue N") is a dead end on a workspace that visibly shows the repo in its header.
+
+**If this leaks, the user's data/workflow is exposed via:** the owner/repo string injected
+into the prompt is the user's own active-workspace `repo_url` — already validated by
+`CC_GITHUB_NAME_RE` and never tool-tainted. The risk is **mis-pairing**, not leakage: a
+concurrent `set_current_workspace_id` switch could pair workspace A's repo name with a
+later dispatch — same sub-ms window already documented at `cc-dispatcher.ts:1323-1337` and
+out of scope here. No new exposure vector; both repos belong to the SAME user.
+
+**Brand-survival threshold:** single-user incident — the Concierge is the flagship
+agent-native surface; a user whose repo is plainly connected being told "no repo
+connected" is a trust-eroding, brand-survival-class failure for that one user.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] **AC1 — Server injects connected-repo context (cc path).** When `connectedOwner` and
+  `connectedRepo` are both non-empty, `cc-dispatcher.ts` appends a system-prompt addendum
+  naming the connected repository as `${connectedOwner}/${connectedRepo}` and instructing
+  the agent to use that value for `-R owner/repo`. Verify by source-presence test (the
+  factory is impractical to invoke in a unit test — same framing as the existing
+  `cc-dispatcher-gh-403-directive.test.ts`): the addendum constant exists, carries the
+  `${connectedOwner}/${connectedRepo}` interpolation and an `-R` reference, and is appended
+  to `effectiveSystemPrompt` inside the `if (connectedOwner && connectedRepo)` guard.
+- [ ] **AC2 — Baseline directive no longer tells the agent to infer owner/repo from the git
+  origin remote.** `GH_AUTH_STATUS_GUIDANCE_DIRECTIVE` in `soleur-go-runner.ts` MUST NOT
+  contain the substring `remote.origin.url`. It MUST still contain the paren-safe anchors
+  `gh auth status` and `-R owner/repo` (the existing
+  `soleur-go-runner-gh-auth-status.test.ts` anchors stay green) and MUST reference the
+  connected repository named in the agent's context.
+- [ ] **AC3 — Addendum injection is guarded on resolved owner/repo, not on a `.git`
+  presence check.** The new addendum append is inside the `connectedOwner && connectedRepo`
+  truthiness guard (server-resolved values), NOT gated on `existsSync(.git)` — so it fires
+  even on a `.git`-less workspace (the exact failing case).
+- [ ] **AC4 — Owner/repo interpolation is injection-safe.** The plan reuses
+  `connectedOwner`/`connectedRepo`, which are validated against `CC_GITHUB_NAME_RE` at
+  `cc-dispatcher.ts:1330` before assignment. A test asserts the addendum builder is fed
+  only those validated bindings (no raw `repoUrl`, no tool input). Mirror the
+  `agent-runner.ts:1425-1428` safety comment.
+- [ ] **AC5 — No behavioral change when no repo is connected.** When `connectedOwner`/
+  `connectedRepo` are empty (no connected repo / non-member), the addendum is NOT appended
+  and the prompt is byte-identical to today's (graceful degradation parity with the
+  existing GH_TOKEN no-op). Source/test assertion that the append sits inside the guard.
+- [ ] **AC6 — `tsc --noEmit` and the web-platform test suite pass.** Run via the package's
+  actual runner (`apps/web-platform` uses vitest — confirm via `package.json scripts.test`
+  before running; place new tests under `apps/web-platform/test/` per the repo's vitest
+  `include:` globs, not co-located).
+
+### Post-merge (operator)
+
+- [ ] **AC7 — Live Concierge smoke (automatable via Playwright MCP).** In the Dashboard
+  Concierge on a workspace connected to `jikig-ai/soleur`, send "Fix Issue 4826"; assert the
+  reply does NOT claim "no connected git repository" / "provide owner/repo" and that the
+  agent routes the issue through the fix workflow (or reads the issue via `gh … -R
+  jikig-ai/soleur`). Automation: `mcp__playwright__*` against the dashboard.
+  `Automation: feasible` — do not punt to a manual operator step.
+
+## Files to Edit
+
+- `apps/web-platform/server/cc-dispatcher.ts`
+  - Add a `CONNECTED_REPO_CONTEXT` directive builder (module-scope `const` or small
+    `function`, mirroring `GH_403_PROMPT_DIRECTIVE` at `:260-271`) that takes validated
+    `owner`/`repo` and returns the `## Connected repository` block stating
+    `The connected repository is ${owner}/${repo}. For any repo gh operation, pass -R
+    ${owner}/${repo}` (lock-step wording with `agent-runner.ts:1429-1441`).
+  - In `realSdkQueryFactory`, after the `GH_403_PROMPT_DIRECTIVE` append (`:1530-1532`),
+    add: `if (connectedOwner && connectedRepo) { effectiveSystemPrompt += \`\n\n${builder(connectedOwner, connectedRepo)}\`; }`.
+    Add the `agent-runner.ts:1425-1428`-style injection-safety comment (owner/repo are
+    `CC_GITHUB_NAME_RE`-validated; if that regex relaxes this becomes an injection sink).
+- `apps/web-platform/server/soleur-go-runner.ts`
+  - Rewrite the trailing clause of `GH_AUTH_STATUS_GUIDANCE_DIRECTIVE` (`:148-159`):
+    remove `discover your owner/repo from the origin remote with git config --get
+    remote.origin.url` (and the `gh cannot infer it without -R owner/repo` sentence that
+    frames git-origin discovery). Replace with guidance to use **the connected repository
+    named in your context** for `-R owner/repo`. Keep the `gh auth status` false-negative
+    guidance and both paren-safe anchors (`gh auth status`, `-R owner/repo`) intact.
+
+## Files to Create
+
+- `apps/web-platform/test/cc-dispatcher-connected-repo-context.test.ts` — source-presence
+  test for AC1/AC3/AC4/AC5 (mirrors `cc-dispatcher-gh-403-directive.test.ts` shape: read
+  `cc-dispatcher.ts`, assert the directive constant/builder exists with the
+  `${connectedOwner}/${connectedRepo}` interpolation + `-R` reference, and that the append
+  is inside the `connectedOwner && connectedRepo` guard).
+- Extend `apps/web-platform/test/soleur-go-runner-gh-auth-status.test.ts` (existing file)
+  with an AC2 assertion: `GH_AUTH_STATUS_GUIDANCE_DIRECTIVE` does NOT contain
+  `remote.origin.url` and still contains both paren-safe anchors.
+
+## Test Scenarios
+
+1. **Connected repo, `.git`-less workspace (the failing case):** `connectedOwner`/
+   `connectedRepo` resolve from `repo_url`; addendum is appended; agent has owner/repo
+   without touching a git remote. (Source/integration assertion + post-merge Playwright.)
+2. **No connected repo:** addendum NOT appended; prompt byte-identical to today (AC5).
+3. **Baseline directive:** no `remote.origin.url`; anchors `gh auth status` + `-R
+   owner/repo` still present (AC2).
+4. **Injection safety:** addendum fed only `CC_GITHUB_NAME_RE`-validated bindings (AC4).
+
+## Open Code-Review Overlap
+
+2 open scope-outs name `cc-dispatcher.ts` and 2 name `agent-runner.ts`:
+- **#3243** (arch: decompose cc-dispatcher.ts into focused modules) — **Acknowledge.**
+  Different concern (file decomposition); this fix adds one guarded append, not a
+  refactor. Folding the decomposition in would balloon scope. Remains open.
+- **#3242** (review: tool_use WS event lacks raw name field) — **Acknowledge.** Unrelated
+  to system-prompt repo context (WS event shape). Remains open.
+- **#3454** (review: expose pdf_metadata as agent-callable MCP tool) — **Acknowledge.**
+  Unrelated (PDF tooling on the leader path). Remains open.
+
+None of the four touch the system-prompt owner/repo assembly this fix targets.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "Concierge dispatch completes and routes 'Fix Issue N' through the fix workflow (no 'no repo connected' reply)"
+  cadence: "per Concierge dispatch (interactive)"
+  alert_target: "existing chat-write-absence alert (knowledge-base/project/brainstorms/2026-06-03-chat-write-absence-alert-brainstorm.md) — no new alert needed"
+  configured_in: "existing cc-dispatcher Sentry breadcrumbs"
+error_reporting:
+  destination: "Sentry via reportSilentFallback (cq-silent-fallback-must-mirror-to-sentry)"
+  fail_loud: "owner/repo resolution failure already mirrors at cc-dispatcher.ts:1340-1349 (repo_url present but null installation) and the malformed-repoUrl catch at :1334-1336 degrades silently by design (no owner/repo → no addendum, same as no-repo case)"
+failure_modes:
+  - mode: "repo_url present, owner/repo parse fails (malformed URL)"
+    detection: "no addendum appended → agent degrades to existing baseline behavior"
+    alert_route: "none (benign degrade; pre-existing malformed-repoUrl catch)"
+  - mode: "repo_url present, installation null (revoked grant)"
+    detection: "existing reportSilentFallback at cc-dispatcher.ts:1340-1349"
+    alert_route: "Sentry (existing)"
+  - mode: "prompt addendum present but model still refuses"
+    detection: "post-merge Playwright smoke (AC7) + chat-write-absence alert"
+    alert_route: "Sentry / existing chat alert"
+logs:
+  where: "cc-dispatcher childLogger (pino) — existing dispatch breadcrumbs; owner/repo NEVER includes token (GH_TOKEN excluded)"
+  retention: "existing pino/Sentry retention"
+discoverability_test:
+  command: "grep -n 'connected repository is' apps/web-platform/server/cc-dispatcher.ts && ./node_modules/.bin/vitest run apps/web-platform/test/cc-dispatcher-connected-repo-context.test.ts"
+  expected_output: "directive constant present; test passes (NO ssh)"
+```
+
+## Domain Review
+
+**Domains relevant:** Product (Concierge UX), Engineering (prompt assembly).
+
+### Product/UX Gate
+
+**Tier:** none (orchestration/prompt-text change; no new UI surface, no `components/**`,
+`app/**/page.tsx`, or `app/**/layout.tsx` file in Files to Create/Edit). The Concierge
+chat UI is unchanged — only the agent's server-side system prompt text changes.
+**Decision:** auto-accepted (pipeline) — NONE tier, no wireframe required
+(`wg-ui-feature-requires-pen-wireframe` does not fire: no UI-surface file touched).
+
+#### Findings
+
+The change is invisible in the DOM; the only user-visible effect is a *correct* Concierge
+reply instead of the false "no repo connected" one. CPO sign-off is required at plan time
+per the `single-user incident` threshold (frontmatter `requires_cpo_signoff: true`) —
+confirm CPO has reviewed the approach (mirror the leader path, server-as-source-of-truth)
+before `/work` begins. `user-impact-reviewer` runs at review-time per the threshold.
+
+## Infrastructure (IaC)
+
+No new infrastructure — pure prompt-text change against an already-provisioned surface
+(`apps/web-platform/server/*`). No server, service, secret, vendor, DNS, cron, or
+persistent runtime process introduced. Phase 2.8 gate: skip.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/
+  placeholder text, or omits the threshold will fail `deepen-plan` Phase 4.6. (This plan's
+  section is filled with the `single-user incident` threshold.)
+- **Lock-step the addendum wording with `agent-runner.ts:1429-1441`.** The leader path
+  already says `The connected repository is ${owner}/${repo}`. Use the same lead phrase so
+  the two surfaces stay greppable together and a future copy edit to one is easy to mirror.
+- **Do NOT gate the addendum on `.git` presence.** The entire bug is that the agent
+  depends on a git artifact that may be absent; the server-resolved owner/repo is the
+  authoritative source. Gate only on `connectedOwner && connectedRepo` truthiness.
+- **`GH_AUTH_STATUS_GUIDANCE_DIRECTIVE` anchors are paren-safe and asserted by an existing
+  test.** When rewriting the directive, keep the literal tokens `gh auth status` and
+  `-R owner/repo` intact (no punctuation straddling the phrase) or
+  `soleur-go-runner-gh-auth-status.test.ts:33,38` will fail.
+- **Owner/repo interpolation is a prompt-injection sink IF `CC_GITHUB_NAME_RE` relaxes.**
+  The addendum is only safe because owner/repo are regex-validated at `:1330`. Carry the
+  `agent-runner.ts:1425-1428` warning comment forward to the new builder.
+- The cc-path system prompt is assembled in `cc-dispatcher.ts` `effectiveSystemPrompt`
+  (factory), NOT in `buildSoleurGoSystemPrompt` (runner). The baseline directive lives in
+  the runner; the per-dispatch owner/repo addendum lives in the factory (only there are
+  `connectedOwner`/`connectedRepo` in scope). Edit BOTH files accordingly.

--- a/knowledge-base/project/plans/2026-06-07-fix-concierge-derive-owner-repo-from-workspace-plan.md
+++ b/knowledge-base/project/plans/2026-06-07-fix-concierge-derive-owner-repo-from-workspace-plan.md
@@ -10,6 +10,69 @@ requires_cpo_signoff: true
 
 # 🐛 fix: Concierge derives owner/repo from the active workspace
 
+## Enhancement Summary
+
+**Deepened on:** 2026-06-07
+**Sections enhanced:** Research Insights added; all source attributions + premise verified live.
+
+### Key Improvements
+1. Verified every load-bearing file:line attribution against current source (no drift):
+   `soleur-go-runner.ts:148` (directive) + `:158` (`remote.origin.url`),
+   `agent-runner.ts:1433` (`The connected repository is ${owner}/${repo}` precedent),
+   `cc-dispatcher.ts:260` (`GH_403_PROMPT_DIRECTIVE`), `:1323-1337` (owner/repo parse),
+   `:1330` (`CC_GITHUB_NAME_RE` validation), `:1532` (unconditional append precedent).
+2. Confirmed the package test runner is **vitest** (not bun) and pinned the exact run
+   command + test placement (`test/**/*.test.ts` → node project) — closes the bun-vs-vitest
+   sharp edge before /work.
+3. Verified the two negative security claims (owner/repo never tool-tainted; token never
+   in the owner/repo string) against source.
+
+### New Considerations Discovered
+- `apps/web-platform/bunfig.toml:11` has `pathIgnorePatterns = ["**"]` — `bun test <file>`
+  reports "filter did not match" even for existing tests. The implementer MUST use vitest.
+- The cc-path system prompt is assembled in TWO places: the baseline directive lives in
+  `soleur-go-runner.ts` (`buildSoleurGoSystemPrompt`), but the per-dispatch owner/repo
+  addendum must live in `cc-dispatcher.ts` (the factory) — the ONLY scope where
+  `connectedOwner`/`connectedRepo` exist. Both files must change.
+
+### Research Insights
+
+**Precedent-diff (Phase 4.4) — pattern is NOT novel; two in-repo precedents:**
+
+- *System-prompt addendum injection*: `cc-dispatcher.ts:1532` appends `GH_403_PROMPT_DIRECTIVE`
+  unconditionally; `:1527-1529` appends `c4PromptAddendum` conditionally inside a guard. The
+  new connected-repo addendum mirrors the conditional form (guard:
+  `connectedOwner && connectedRepo`).
+- *Naming the connected repo to the agent*: `agent-runner.ts:1429-1441` (leader path) already
+  emits `## GitHub read access\n\nThe connected repository is ${owner}/${repo}.` — the cc path
+  simply lacks the equivalent. Lock-step the lead phrase `The connected repository is
+  ${owner}/${repo}` so both surfaces stay greppable together.
+- *Injection-safety precedent*: `agent-runner.ts:1425-1428` documents that owner/repo are
+  `GITHUB_NAME_RE`-validated and "If that regex ever relaxes, this becomes a prompt-injection
+  sink." `cc-dispatcher.ts` validates identically via `CC_GITHUB_NAME_RE` at `:1330`. Carry the
+  same warning comment to the new builder.
+
+**Verified test command (AC6):**
+
+```bash
+# Runner is vitest (apps/web-platform/package.json scripts.test = "vitest").
+# New test MUST live under test/ (node project include: "test/**/*.test.ts").
+# Do NOT use `bun test` — apps/web-platform/bunfig.toml:11 pathIgnorePatterns=["**"].
+cd apps/web-platform && ./node_modules/.bin/vitest run \
+  test/cc-dispatcher-connected-repo-context.test.ts \
+  test/soleur-go-runner-gh-auth-status.test.ts
+```
+
+**Premise + attribution verification (live, 2026-06-07):**
+
+```text
+gh issue view 4826 → OPEN "feat: nav-rail position resume …"  (example trigger, not blocker)
+gh issue view 3242/3243/3454 → all OPEN (code-review overlaps; acknowledged, not folded in)
+grep remote.origin.url soleur-go-runner.ts → :158 (the clause to rewrite)
+grep "The connected repository is" agent-runner.ts → :1433 (precedent confirmed)
+grep connectedOwner/CC_GITHUB_NAME_RE.test/effectiveSystemPrompt cc-dispatcher.ts → :1323/:1330/:1532
+```
+
 ## Overview
 
 In the Dashboard "Soleur Concierge" chat, asking to **"Fix Issue 4826"** makes the

--- a/knowledge-base/project/plans/2026-06-07-fix-concierge-derive-owner-repo-from-workspace-plan.md
+++ b/knowledge-base/project/plans/2026-06-07-fix-concierge-derive-owner-repo-from-workspace-plan.md
@@ -162,7 +162,7 @@ connected" is a trust-eroding, brand-survival-class failure for that one user.
 
 ### Pre-merge (PR)
 
-- [ ] **AC1 — Server injects connected-repo context (cc path).** When `connectedOwner` and
+- [x] **AC1 — Server injects connected-repo context (cc path).** When `connectedOwner` and
   `connectedRepo` are both non-empty, `cc-dispatcher.ts` appends a system-prompt addendum
   naming the connected repository as `${connectedOwner}/${connectedRepo}` and instructing
   the agent to use that value for `-R owner/repo`. Verify by source-presence test (the
@@ -170,26 +170,26 @@ connected" is a trust-eroding, brand-survival-class failure for that one user.
   `cc-dispatcher-gh-403-directive.test.ts`): the addendum constant exists, carries the
   `${connectedOwner}/${connectedRepo}` interpolation and an `-R` reference, and is appended
   to `effectiveSystemPrompt` inside the `if (connectedOwner && connectedRepo)` guard.
-- [ ] **AC2 — Baseline directive no longer tells the agent to infer owner/repo from the git
+- [x] **AC2 — Baseline directive no longer tells the agent to infer owner/repo from the git
   origin remote.** `GH_AUTH_STATUS_GUIDANCE_DIRECTIVE` in `soleur-go-runner.ts` MUST NOT
   contain the substring `remote.origin.url`. It MUST still contain the paren-safe anchors
   `gh auth status` and `-R owner/repo` (the existing
   `soleur-go-runner-gh-auth-status.test.ts` anchors stay green) and MUST reference the
   connected repository named in the agent's context.
-- [ ] **AC3 — Addendum injection is guarded on resolved owner/repo, not on a `.git`
+- [x] **AC3 — Addendum injection is guarded on resolved owner/repo, not on a `.git`
   presence check.** The new addendum append is inside the `connectedOwner && connectedRepo`
   truthiness guard (server-resolved values), NOT gated on `existsSync(.git)` — so it fires
   even on a `.git`-less workspace (the exact failing case).
-- [ ] **AC4 — Owner/repo interpolation is injection-safe.** The plan reuses
+- [x] **AC4 — Owner/repo interpolation is injection-safe.** The plan reuses
   `connectedOwner`/`connectedRepo`, which are validated against `CC_GITHUB_NAME_RE` at
   `cc-dispatcher.ts:1330` before assignment. A test asserts the addendum builder is fed
   only those validated bindings (no raw `repoUrl`, no tool input). Mirror the
   `agent-runner.ts:1425-1428` safety comment.
-- [ ] **AC5 — No behavioral change when no repo is connected.** When `connectedOwner`/
+- [x] **AC5 — No behavioral change when no repo is connected.** When `connectedOwner`/
   `connectedRepo` are empty (no connected repo / non-member), the addendum is NOT appended
   and the prompt is byte-identical to today's (graceful degradation parity with the
   existing GH_TOKEN no-op). Source/test assertion that the append sits inside the guard.
-- [ ] **AC6 — `tsc --noEmit` and the web-platform test suite pass.** Run via the package's
+- [x] **AC6 — `tsc --noEmit` and the web-platform test suite pass.** Run via the package's
   actual runner (`apps/web-platform` uses vitest — confirm via `package.json scripts.test`
   before running; place new tests under `apps/web-platform/test/` per the repo's vitest
   `include:` globs, not co-located).

--- a/knowledge-base/project/specs/feat-one-shot-concierge-workspace-repo-context/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-concierge-workspace-repo-context/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-07-fix-concierge-derive-owner-repo-from-workspace-plan.md
+- Status: complete
+
+### Errors
+None.
+
+### Decisions
+- Root cause: baseline directive `GH_AUTH_STATUS_GUIDANCE_DIRECTIVE` (soleur-go-runner.ts:148-159) tells the agent to infer owner/repo from `git config --get remote.origin.url`, which is empty on a `.git`-less workspace → false "no repo connected" reply.
+- Server already resolves `connectedOwner`/`connectedRepo` from the workspace's `repo_url` at cc-dispatcher.ts:1323-1337 but never surfaces them into the cc-path system prompt.
+- Fix mirrors leader-path precedent (agent-runner.ts:1429-1441): inject "The connected repository is ${owner}/${repo}" in the cc factory + rewrite baseline directive to drop git-origin inference. Pure prompt-text change.
+- Two-file edit: baseline directive in soleur-go-runner.ts; per-dispatch owner/repo addendum in cc-dispatcher.ts.
+- Tests: vitest (bun test disabled via bunfig.toml). Threshold = single-user incident → requires_cpo_signoff: true.
+
+### Components Invoked
+- Skill: soleur:plan
+- Skill: soleur:deepen-plan
+- gh issue view (ref verification)

--- a/knowledge-base/project/specs/feat-one-shot-concierge-workspace-repo-context/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-concierge-workspace-repo-context/tasks.md
@@ -1,0 +1,42 @@
+# Tasks — fix: Concierge derives owner/repo from active workspace
+
+Plan: `knowledge-base/project/plans/2026-06-07-fix-concierge-derive-owner-repo-from-workspace-plan.md`
+Lane: cross-domain
+
+## Phase 1 — Setup / RED (failing tests first)
+
+- [ ] 1.1 Confirm the package test runner: read `apps/web-platform/package.json`
+  `scripts.test` and the vitest `include:` globs (`apps/web-platform/vitest.config.ts`)
+  so new tests land where vitest collects them (`test/**`, not co-located).
+- [ ] 1.2 Write failing source-presence test
+  `apps/web-platform/test/cc-dispatcher-connected-repo-context.test.ts`
+  (AC1/AC3/AC4/AC5): assert a connected-repo directive builder/constant exists with the
+  `${connectedOwner}/${connectedRepo}` interpolation + an `-R` reference, and that the
+  append sits inside the `connectedOwner && connectedRepo` guard.
+- [ ] 1.3 Extend `apps/web-platform/test/soleur-go-runner-gh-auth-status.test.ts` (AC2):
+  assert `GH_AUTH_STATUS_GUIDANCE_DIRECTIVE` does NOT contain `remote.origin.url` and
+  still contains both paren-safe anchors (`gh auth status`, `-R owner/repo`).
+
+## Phase 2 — Core Implementation / GREEN
+
+- [ ] 2.1 `cc-dispatcher.ts`: add a `CONNECTED_REPO_CONTEXT` directive builder
+  (module-scope, mirroring `GH_403_PROMPT_DIRECTIVE` at `:260-271`) returning a
+  `## Connected repository` block that states `The connected repository is
+  ${owner}/${repo}` and instructs `-R ${owner}/${repo}` (lock-step with
+  `agent-runner.ts:1429-1441`). Carry the `agent-runner.ts:1425-1428` injection-safety
+  comment.
+- [ ] 2.2 `cc-dispatcher.ts` `realSdkQueryFactory`: after the `GH_403_PROMPT_DIRECTIVE`
+  append (`:1530-1532`), append the new directive inside
+  `if (connectedOwner && connectedRepo) { … }` (AC1/AC3/AC5).
+- [ ] 2.3 `soleur-go-runner.ts`: rewrite the trailing clause of
+  `GH_AUTH_STATUS_GUIDANCE_DIRECTIVE` (`:148-159`) — remove the `remote.origin.url`
+  discovery instruction; point at "the connected repository named in your context" for
+  `-R owner/repo`; keep the `gh auth status` false-negative guidance + both anchors (AC2).
+
+## Phase 3 — Verification
+
+- [ ] 3.1 Run `tsc --noEmit` and the web-platform vitest suite (AC6); all green.
+- [ ] 3.2 Confirm no-connected-repo path is byte-identical to baseline (AC5).
+- [ ] 3.3 Post-merge: Playwright MCP smoke against the Dashboard Concierge on a
+  `jikig-ai/soleur`-connected workspace — "Fix Issue 4826" must NOT reply "no repo
+  connected" and must route through the fix workflow (AC7).

--- a/knowledge-base/project/specs/feat-one-shot-concierge-workspace-repo-context/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-concierge-workspace-repo-context/tasks.md
@@ -5,9 +5,11 @@ Lane: cross-domain
 
 ## Phase 1 — Setup / RED (failing tests first)
 
-- [ ] 1.1 Confirm the package test runner: read `apps/web-platform/package.json`
-  `scripts.test` and the vitest `include:` globs (`apps/web-platform/vitest.config.ts`)
-  so new tests land where vitest collects them (`test/**`, not co-located).
+- [ ] 1.1 Test runner is **vitest** (verified: `apps/web-platform/package.json`
+  `scripts.test = "vitest"`; node project `include: ["test/**/*.test.ts", "lib/**/*.test.ts"]`).
+  New tests go under `apps/web-platform/test/` as `*.test.ts`. Do NOT use `bun test` —
+  `apps/web-platform/bunfig.toml:11` has `pathIgnorePatterns = ["**"]`. Run:
+  `cd apps/web-platform && ./node_modules/.bin/vitest run test/cc-dispatcher-connected-repo-context.test.ts test/soleur-go-runner-gh-auth-status.test.ts`.
 - [ ] 1.2 Write failing source-presence test
   `apps/web-platform/test/cc-dispatcher-connected-repo-context.test.ts`
   (AC1/AC3/AC4/AC5): assert a connected-repo directive builder/constant exists with the


### PR DESCRIPTION
## Summary

In the Dashboard "Soleur Concierge" chat, asking to "Fix Issue N" made the Concierge reply that there was **no connected git repository** — it claimed `gh` couldn't infer the repo and there was no `.git` directory, then asked the user to provide `owner/repo`. This was wrong: the active workspace already has the repo connected (the workspace header shows e.g. `jikig-ai/soleur`).

**Root cause:** the cc-path baseline directive `GH_AUTH_STATUS_GUIDANCE_DIRECTIVE` (`soleur-go-runner.ts`) told the agent to derive `owner/repo` from `git config --get remote.origin.url`, which returns empty on a `.git`-less workspace. The server already resolves and validates `connectedOwner`/`connectedRepo` from the membership-scoped `workspaces.repo_url` (ADR-044) in `cc-dispatcher.ts` — it was simply never surfaced into the Concierge's system prompt. The leader path (`agent-runner.ts:1429-1441`) already did this.

**Fix (prompt-text only — no infra/schema/data-path change):**
- `cc-dispatcher.ts`: add `buildConnectedRepoContext(owner, repo)` and append it to `effectiveSystemPrompt` inside an `if (connectedOwner && connectedRepo)` guard (guarded on resolved-value truthiness, NOT a `.git` presence check). Lock-steps the lead phrase "The connected repository is ${owner}/${repo}" with the leader path.
- `soleur-go-runner.ts`: rewrite `GH_AUTH_STATUS_GUIDANCE_DIRECTIVE` to drop the git-origin-remote inference clause and point at "the connected repository named in your context" (keeps the `gh auth status` false-negative guidance + both paren-safe test anchors).

## User-Brand Impact

- **Exposed artifact:** the active-workspace `repo_url`-derived `owner/repo` string injected into the Concierge system prompt.
- **Exposure/failure vector:** if this lands broken, the flagship "Fix Issue N" Concierge flow remains a dead end (agent denies a connected repo and prompts for `owner/repo`) on a workspace that visibly shows the repo. The injected `owner/repo` is the user's own `CC_GITHUB_NAME_RE`-validated workspace value, never tool-tainted — no new leak vector; intra-user mis-pairing is a pre-existing sub-ms workspace-switch window, out of scope.
- **Brand-survival threshold:** single-user incident

## Changelog

### Web Platform
- Fixed: the Soleur Concierge now derives the connected `owner/repo` from the active workspace instead of inferring it from a git remote, so "Fix Issue N" works on workspaces without a local `.git` directory.

## Test plan

- [x] `cc-dispatcher-connected-repo-context.test.ts` — behavioral builder output (AC1) + wiring/guard source-presence (AC3/AC4/AC5)
- [x] `soleur-go-runner-gh-auth-status.test.ts` — AC2 (no `remote.origin.url`; connected-repo reference; paren-safe anchors intact)
- [x] `tsc --noEmit` clean; web-platform vitest suite green (CI-equivalent bare run: 738 files passed)
- AC7 (post-merge live Concierge smoke) liveness is covered by the existing chat-write-absence alert per the plan's Observability section — no new monitor required.

Generated with [Claude Code](https://claude.com/claude-code)
