### PR TITLE
fix(hooks): no-memory-write points to real constitution path (project/ not overview/)

### DIFF
--- a/.claude/hooks/no-memory-write.sh
+++ b/.claude/hooks/no-memory-write.sh
@@ -52,7 +52,7 @@ if [[ "$TARGET" =~ /\.claude/projects/[^/]+/memory(/|$|[\"\'[:space:]]) ]]; then
   jq -n --arg target "$TARGET" '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",      permissionDecision: "deny",
-      permissionDecisionReason: ("BLOCKED: hr-never-write-to-claude-code-memory-claude (Source: AGENTS.core.md).\n\nTarget: " + $target + "\n\nWrites to ~/.claude/projects/*/memory/ do not transfer across machines or operators. Commit knowledge to one of these committed repo files instead:\n  - AGENTS.md / AGENTS.{core,docs,rest}.md (hard rules + workflow gates)\n  - knowledge-base/overview/constitution.md (architecture + style)\n  - knowledge-base/project/learnings/<category>/<slug>.md (session learnings)\n\nSee plugins/soleur/skills/compound for the canonical learning-write flow.")
+      permissionDecisionReason: ("BLOCKED: hr-never-write-to-claude-code-memory-claude (Source: AGENTS.core.md).\n\nTarget: " + $target + "\n\nWrites to ~/.claude/projects/*/memory/ do not transfer across machines or operators. Commit knowledge to one of these committed repo files instead:\n  - AGENTS.md / AGENTS.{core,docs,rest}.md (hard rules + workflow gates)\n  - knowledge-base/project/constitution.md (architecture + style)\n  - knowledge-base/project/learnings/<category>/<slug>.md (session learnings)\n\nSee plugins/soleur/skills/compound for the canonical learning-write flow.")
     }
   }'
   exit 0

--- a/.claude/hooks/no-memory-write.test.sh
+++ b/.claude/hooks/no-memory-write.test.sh
@@ -37,7 +37,8 @@ reason=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecisionReaso
 if [[ "$decision" == "deny" ]] \
    && [[ "$reason" == *"hr-never-write-to-claude-code-memory-claude"* ]] \
    && [[ "$reason" == *"Source: AGENTS.core.md"* ]] \
-   && [[ "$reason" == *"knowledge-base/project/learnings"* ]]; then
+   && [[ "$reason" == *"knowledge-base/project/learnings"* ]] \
+   && [[ "$reason" == *"knowledge-base/project/constitution.md"* ]]; then
   pass "deny + rule + source-file + remediation"
 else
   fail "decision=$decision reason_head=${reason:0:120}"

--- a/knowledge-base/project/plans/2026-06-07-fix-no-memory-write-constitution-path-plan.md
+++ b/knowledge-base/project/plans/2026-06-07-fix-no-memory-write-constitution-path-plan.md
@@ -8,6 +8,36 @@ brand_survival_threshold: none
 
 # 🐛 Fix stale constitution path in no-memory-write hook
 
+## Enhancement Summary
+
+**Deepened on:** 2026-06-07
+**Sections enhanced:** 1 (Files to Edit — verbatim edit anchor added)
+**Gates run:** 4.6 User-Brand Impact (PASS), 4.7 Observability (PASS — all 5 fields, no ssh),
+4.8 PAT-shaped variable (PASS — none), 4.9 UI-wireframe (skip — no UI surface),
+4.45 verify-the-negative (PASS — "changes no runtime behavior" confirmed: the regex match
+and `emit_incident` sit on line 50, a different line than the string-literal edit on line 55).
+
+### Key Improvements
+
+1. Pinned the **exact verbatim** line-55 content as the edit anchor (below), so the implementer
+   does a surgical `overview` → `project` token swap with zero collateral on the `\n`-joined
+   `jq` payload.
+2. Confirmed via live grep that the existing test suite needs **no** change (T1 pins the
+   `learnings` bullet, not the constitution bullet) — recorded as AC3/Non-Goal.
+3. Verify-the-negative pass validated every "changes no runtime" claim against the source:
+   match-logic, deny decision, and `emit_incident` are all on lines other than 55.
+
+### New Considerations Discovered
+
+- The repo-wide grep for `overview/constitution` returns this hook PLUS many dated records under
+  `knowledge-base/project/{plans,specs,brainstorms,learnings}/` (incl. the rename plan/spec that
+  *describe* the `overview/`→`project/` move). All are explicitly out of scope — do not "tidy" them.
+- This plan file itself quotes `overview/constitution.md` as the before-value; a future repo-wide
+  residual-zero grep MUST carve out this plan + tasks (migration-record carve-out), exactly like
+  archive/historical files.
+
+---
+
 `.claude/hooks/no-memory-write.sh` line 55 builds the BLOCKED `permissionDecisionReason`
 message that fires when an agent attempts to write to `~/.claude/projects/*/memory/`.
 That message tells the agent to commit knowledge to one of three committed repo files.
@@ -123,9 +153,24 @@ discoverability_test:
 
 - `.claude/hooks/no-memory-write.sh` — line 55: change the middle remediation bullet from
   `knowledge-base/overview/constitution.md (architecture + style)` to
-  `knowledge-base/project/constitution.md (architecture + style)`. **Single-character-class
-  change** (`overview` → `project`); everything else on the line and in the surrounding
-  `jq -n` payload is preserved verbatim.
+  `knowledge-base/project/constitution.md (architecture + style)`. **Single token change**
+  (`overview` → `project`); everything else on the line and in the surrounding `jq -n` payload
+  is preserved verbatim.
+
+  ### Implementation Detail — exact edit anchor
+
+  The change is confined to the `\n  - knowledge-base/...constitution.md (architecture + style)`
+  substring inside the long `permissionDecisionReason` string. Old → new substring:
+
+  ```diff
+  -  - knowledge-base/overview/constitution.md (architecture + style)
+  +  - knowledge-base/project/constitution.md (architecture + style)
+  ```
+
+  The match logic (`[[ "$TARGET" =~ /\.claude/projects/[^/]+/memory... ]]`), the
+  `emit_incident hr-never-write-to-claude-code-memory-claude deny` call, the `hookEventName`,
+  and the `permissionDecision: "deny"` payload are all unchanged — they live on lines other than
+  the edited bullet. This is a help-string correction only.
 - `.claude/hooks/no-memory-write.test.sh` — **only if AC4 is taken** (optional). Add one
   `&& [[ "$reason" == *"knowledge-base/project/constitution.md"* ]]` clause to the T1
   conditional. Do not change any other test.

--- a/knowledge-base/project/plans/2026-06-07-fix-no-memory-write-constitution-path-plan.md
+++ b/knowledge-base/project/plans/2026-06-07-fix-no-memory-write-constitution-path-plan.md
@@ -1,0 +1,200 @@
+---
+title: Fix stale constitution path in no-memory-write hook
+type: fix
+date: 2026-06-07
+lane: single-domain
+brand_survival_threshold: none
+---
+
+# 🐛 Fix stale constitution path in no-memory-write hook
+
+`.claude/hooks/no-memory-write.sh` line 55 builds the BLOCKED `permissionDecisionReason`
+message that fires when an agent attempts to write to `~/.claude/projects/*/memory/`.
+That message tells the agent to commit knowledge to one of three committed repo files.
+The middle bullet currently reads:
+
+```
+  - knowledge-base/overview/constitution.md (architecture + style)
+```
+
+The constitution does **not** live at `overview/`. It was relocated to
+`knowledge-base/project/constitution.md` (migration recorded in
+`knowledge-base/project/plans/2026-03-13-refactor-rename-kb-overview-to-project-plan.md`
+and `knowledge-base/project/specs/feat-rename-kb-overview/`). The `overview/` directory
+no longer exists in the repo. Every other **live, operative** reference already uses the
+correct `project/` path (`knowledge-base/INDEX.md`, `plugins/soleur/commands/sync.md`,
+`scripts/rule-audit.sh`, `knowledge-base/project/components/knowledge-base.md`, and the
+compound / compound-capture / plan / work skills). This hook is the **only** live file
+still pointing at the phantom `overview/` location — so an agent that hits the block is
+handed a path that 404s.
+
+The entire functional change is one line.
+
+## Research Reconciliation — Premise vs. Codebase
+
+| Premise (from task) | Verified reality | Plan response |
+|---|---|---|
+| `no-memory-write.sh:55` says `overview/constitution.md` | Confirmed — `grep -n "overview/constitution" .claude/hooks/no-memory-write.sh` returns line 55 only | Edit line 55 |
+| Constitution lives at `project/constitution.md` | Confirmed — `knowledge-base/project/constitution.md` exists (73 KB); `knowledge-base/overview/constitution.md` does **not** exist | Change bullet to `project/` |
+| A sibling test may pin the `overview/constitution.md` substring | **No such assertion exists.** `no-memory-write.test.sh` has zero references to `constitution` or `overview`. Its T1 message assertion (line 40) checks only `*"knowledge-base/project/learnings"*` | **No test edit required.** Suite stays green after the fix. (Optional hardening noted under Non-Goals.) |
+| `SANCTIONED_DIRS` in `kb-domain-allowlist-guard.sh` must be left alone | Confirmed it does **not** contain `overview` (`engineering finance legal marketing operations product project sales support`) | Out of scope — not touched |
+| Remaining `overview/constitution` refs are historical/out-of-scope | Confirmed — all remaining matches are under `knowledge-base/project/{plans,specs,brainstorms,learnings}/` (dated records, incl. the rename plan/spec) or under `apps/web-platform` (user-workspace KB) | Out of scope — not touched |
+
+## User-Brand Impact
+
+- **If this lands broken, the user experiences:** an agent that is correctly blocked from
+  writing to CC memory is then told to commit its knowledge to
+  `knowledge-base/overview/constitution.md` — a path that does not exist — so the
+  redirection fails and institutional knowledge is silently dropped instead of captured.
+- **If this leaks, the user's data / workflow / money is exposed via:** N/A. This is a
+  static help-string correction inside a deny-path message. It touches no data, no auth,
+  no network, no PII surface. The hook's matching regex, deny decision, and incident emit
+  are all unchanged.
+- **Brand-survival threshold:** `none`
+
+*Scope-out override:* `threshold: none, reason: a one-line correction to a hook's BLOCKED
+help-message string changes no runtime decision, touches no sensitive path, and moves no
+user data — it only fixes a dangling doc pointer shown to the agent.*
+
+## Observability
+
+This is a docs-string correction to a hook's BLOCKED message; it changes no runtime
+behavior (regex, deny logic, `emit_incident` call are untouched). Its correctness is fully
+captured by the existing local bash test suite — no production telemetry surface is added
+or modified.
+
+```yaml
+liveness_signal:
+  what:            "no-memory-write.test.sh bash test suite (T1–T12)"
+  cadence:         "per-run (local, pre-commit / CI)"
+  alert_target:    "non-zero exit (developer terminal / CI job)"
+  configured_in:   ".claude/hooks/no-memory-write.test.sh"
+
+error_reporting:
+  destination:     "test runner exit code (no Sentry surface — no runtime change)"
+  fail_loud:       "Results line prints 'N passed, M failed' and exits 1 on any failure"
+
+failure_modes:
+  - mode:          "BLOCKED message regresses to a non-existent path again"
+    detection:     "optional new test assertion (see AC4) fails in no-memory-write.test.sh"
+    alert_route:   "developer terminal / CI on the next hook edit"
+
+logs:
+  where:           "stdout of bash .claude/hooks/no-memory-write.test.sh"
+  retention:       "ephemeral (CI job log / local terminal)"
+
+discoverability_test:
+  command:         "bash .claude/hooks/no-memory-write.test.sh"
+  expected_output: "Results: <N> passed, 0 failed (exit 0)"
+```
+
+## Acceptance Criteria
+
+- [ ] AC1 — `.claude/hooks/no-memory-write.sh` line 55 reads
+      `knowledge-base/project/constitution.md (architecture + style)` (was `overview/`).
+      Verify: `grep -c "knowledge-base/project/constitution.md (architecture + style)" .claude/hooks/no-memory-write.sh` returns `1`.
+- [ ] AC2 — No live reference to `overview/constitution.md` remains in `.claude/hooks/`.
+      Verify: `grep -rl "overview/constitution" .claude/hooks/` returns nothing (empty).
+- [ ] AC3 — The existing suite is green with no test edits.
+      Verify: `bash .claude/hooks/no-memory-write.test.sh` prints `0 failed` and exits 0.
+- [ ] AC4 (optional hardening — see Non-Goals) — IF the planner/implementer elects to add a
+      regression assertion, T1 in `no-memory-write.test.sh` additionally asserts
+      `[[ "$reason" == *"knowledge-base/project/constitution.md"* ]]`. This is the cheapest
+      guard against the exact bug recurring. Default: **skip** (keeps the diff to one line);
+      include only if explicitly desired.
+- [ ] AC5 — Out-of-scope surfaces untouched: `git diff --name-only` lists **only**
+      `.claude/hooks/no-memory-write.sh` (and, if AC4 is taken, `.claude/hooks/no-memory-write.test.sh`)
+      plus this plan + tasks. No change to `kb-domain-allowlist-guard.sh`, no change to any
+      dated file under `knowledge-base/project/{plans,specs,brainstorms,learnings}/`, no change
+      to any `apps/web-platform` `overview/` reference, no change to CC-local `MEMORY.md`.
+
+## Test Scenarios
+
+- Given an agent attempts a Write to `~/.claude/projects/<slug>/memory/foo.md`, when the
+  hook fires, then the BLOCKED message lists `knowledge-base/project/constitution.md` as the
+  architecture+style destination (a path that exists). Covered by T1 (deny decision +
+  message substrings) — `bash .claude/hooks/no-memory-write.test.sh`.
+- Given the hook source after the edit, when grepped, then it contains zero `overview/constitution`
+  substrings: `grep -c overview/constitution .claude/hooks/no-memory-write.sh` returns `0`.
+- Given the cited destination path in the corrected message, then the file exists on disk:
+  `test -f knowledge-base/project/constitution.md && echo OK` prints `OK`.
+
+## Files to Edit
+
+- `.claude/hooks/no-memory-write.sh` — line 55: change the middle remediation bullet from
+  `knowledge-base/overview/constitution.md (architecture + style)` to
+  `knowledge-base/project/constitution.md (architecture + style)`. **Single-character-class
+  change** (`overview` → `project`); everything else on the line and in the surrounding
+  `jq -n` payload is preserved verbatim.
+- `.claude/hooks/no-memory-write.test.sh` — **only if AC4 is taken** (optional). Add one
+  `&& [[ "$reason" == *"knowledge-base/project/constitution.md"* ]]` clause to the T1
+  conditional. Do not change any other test.
+
+## Files to Create
+
+- None. (Plan + tasks artifacts under `knowledge-base/project/` are created by the plan
+  workflow, not by the implementation.)
+
+## Out-of-Scope (do NOT modify)
+
+- `SANCTIONED_DIRS` in `.claude/hooks/kb-domain-allowlist-guard.sh` — verified it does not
+  list `overview`; we are **not** sanctioning an `overview/` domain.
+- Any historical / dated record under `knowledge-base/project/{plans,specs,brainstorms,learnings}/`
+  — these (e.g. the `2026-03-13-refactor-rename-kb-overview-to-project-plan.md` plan and the
+  `feat-rename-kb-overview/` spec) document the *past* `overview/` state and must keep citing
+  the old path.
+- Any `apps/web-platform` reference to `overview/...` (vision.md, screenshots, kb-chat
+  fixtures) — that is the generated **user-workspace** knowledge-base, a different `overview/`
+  dir, and is correct as-is.
+- The CC-local `MEMORY.md` (hard rule `hr-never-write-to-claude-code-memory`; it is
+  machine-local and must not be edited).
+
+## Non-Goals
+
+- **No broad `overview/` → `project/` sweep.** The task is explicitly the single live hook
+  file. The other matches are historical or a different (user-workspace) `overview/`.
+- **No mandatory test change.** The strict instruction was "update the test *if* an assertion
+  pins the `overview/constitution.md` substring." Investigation confirms **no such assertion
+  exists** — so the default plan adds none and the suite stays green. AC4 records the optional
+  regression-hardening assertion for the implementer's discretion; it is a Non-Goal to require it.
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected — this is a one-line correction to a developer-tooling
+hook's help-string. No UI surface (no path under `components/**`, `app/**`), no product,
+legal, security, finance, marketing, operations, or sales implication. The mechanical
+UI-surface override does not fire (Files to Edit contains no UI-surface path). Product/UX
+Gate skipped (Product NONE). GDPR/Compliance gate (Phase 2.7) skipped — no regulated-data
+surface (no schema, migration, auth flow, API route, or `.sql`; no LLM/external-API
+processing of operator data; threshold is `none`; no new cron/distribution surface).
+Infrastructure-as-Code gate (Phase 2.8) skipped — no new server, service, cron, secret,
+vendor, or persistent runtime process; pure string edit to an existing hook.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder
+  text, or omits the threshold will fail `deepen-plan` Phase 4.6. This plan's section is
+  filled with a concrete artifact, an explicit N/A exposure rationale, and the `none` threshold
+  plus the required scope-out-override reason (sensitive-path-safe).
+- The edit is `overview` → `project`, **not** a whole-path rewrite. Preserve the trailing
+  ` (architecture + style)` annotation and the exact two-space `  - ` list indentation inside
+  the `\n`-joined `jq` string; a stray indentation change would not break behavior but would
+  dirty the diff beyond the one intended token.
+- Do **not** "helpfully" also fix the historical `overview/constitution` matches surfaced by a
+  repo-wide grep — they are point-in-time records (the rename plan/spec literally describes
+  moving constitution out of `overview/`) and rewriting them is an explicit Non-Goal.
+
+## References
+
+- Source file: `.claude/hooks/no-memory-write.sh:55`
+- Test: `.claude/hooks/no-memory-write.test.sh` (T1 message assertion at line 40 pins
+  `knowledge-base/project/learnings`, not the constitution bullet)
+- Correct destination: `knowledge-base/project/constitution.md`
+- Migration provenance (out of scope, cite-only):
+  `knowledge-base/project/plans/2026-03-13-refactor-rename-kb-overview-to-project-plan.md`,
+  `knowledge-base/project/specs/feat-rename-kb-overview/`
+- Already-correct operative references (no change): `knowledge-base/INDEX.md`,
+  `plugins/soleur/commands/sync.md`, `scripts/rule-audit.sh`,
+  `knowledge-base/project/components/knowledge-base.md`

--- a/knowledge-base/project/plans/2026-06-07-fix-no-memory-write-constitution-path-plan.md
+++ b/knowledge-base/project/plans/2026-06-07-fix-no-memory-write-constitution-path-plan.md
@@ -120,19 +120,19 @@ discoverability_test:
 
 ## Acceptance Criteria
 
-- [ ] AC1 — `.claude/hooks/no-memory-write.sh` line 55 reads
+- [x] AC1 — `.claude/hooks/no-memory-write.sh` line 55 reads
       `knowledge-base/project/constitution.md (architecture + style)` (was `overview/`).
       Verify: `grep -c "knowledge-base/project/constitution.md (architecture + style)" .claude/hooks/no-memory-write.sh` returns `1`.
-- [ ] AC2 — No live reference to `overview/constitution.md` remains in `.claude/hooks/`.
+- [x] AC2 — No live reference to `overview/constitution.md` remains in `.claude/hooks/`.
       Verify: `grep -rl "overview/constitution" .claude/hooks/` returns nothing (empty).
-- [ ] AC3 — The existing suite is green with no test edits.
+- [x] AC3 — The existing suite is green with no test edits.
       Verify: `bash .claude/hooks/no-memory-write.test.sh` prints `0 failed` and exits 0.
-- [ ] AC4 (optional hardening — see Non-Goals) — IF the planner/implementer elects to add a
+- [x] AC4 (optional hardening — see Non-Goals) — IF the planner/implementer elects to add a
       regression assertion, T1 in `no-memory-write.test.sh` additionally asserts
       `[[ "$reason" == *"knowledge-base/project/constitution.md"* ]]`. This is the cheapest
       guard against the exact bug recurring. Default: **skip** (keeps the diff to one line);
       include only if explicitly desired.
-- [ ] AC5 — Out-of-scope surfaces untouched: `git diff --name-only` lists **only**
+- [x] AC5 — Out-of-scope surfaces untouched: `git diff --name-only` lists **only**
       `.claude/hooks/no-memory-write.sh` (and, if AC4 is taken, `.claude/hooks/no-memory-write.test.sh`)
       plus this plan + tasks. No change to `kb-domain-allowlist-guard.sh`, no change to any
       dated file under `knowledge-base/project/{plans,specs,brainstorms,learnings}/`, no change

--- a/knowledge-base/project/specs/feat-one-shot-no-memory-write-constitution-path/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-no-memory-write-constitution-path/session-state.md
@@ -1,0 +1,19 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-07-fix-no-memory-write-constitution-path-plan.md
+- Status: complete
+
+### Errors
+None. CWD verified equal to the worktree on first tool call; one Write correctly redirected by worktree-isolation hook (no impact).
+
+### Decisions
+- Fix is exactly one line: `.claude/hooks/no-memory-write.sh:55`, `overview` -> `project`. Constitution exists at `knowledge-base/project/constitution.md`; `overview/constitution.md` does not exist.
+- No test change required: `no-memory-write.test.sh` has zero constitution/overview references; T1 pins the learnings bullet, not the constitution bullet. Suite stays green. Optional regression assertion recorded as AC4 (default skip, keep diff to one line).
+- All OUT-OF-SCOPE boundaries honored: SANCTIONED_DIRS untouched (no `overview`); remaining `overview/constitution` matches are dated historical records or apps/web-platform user-workspace paths, all left as-is.
+- Skipped external research and full fan-out (trivial docs-string fix); ran mandatory deepen halt gates (User-Brand PASS, Observability PASS, PAT PASS, UI skip).
+- Brand-survival threshold: none (touched `.claude/hooks/*.sh` not on sensitive-path regex).
+
+### Components Invoked
+- Skill: soleur:plan
+- Skill: soleur:deepen-plan

--- a/knowledge-base/project/specs/feat-one-shot-no-memory-write-constitution-path/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-no-memory-write-constitution-path/tasks.md
@@ -9,7 +9,7 @@ plan: knowledge-base/project/plans/2026-06-07-fix-no-memory-write-constitution-p
 
 ## 1. Core Implementation
 
-- [ ] 1.1 Edit `.claude/hooks/no-memory-write.sh` line 55: change the middle remediation
+- [x] 1.1 Edit `.claude/hooks/no-memory-write.sh` line 55: change the middle remediation
       bullet inside the `permissionDecisionReason` string from
       `knowledge-base/overview/constitution.md (architecture + style)` to
       `knowledge-base/project/constitution.md (architecture + style)`. Change only the
@@ -18,15 +18,15 @@ plan: knowledge-base/project/plans/2026-06-07-fix-no-memory-write-constitution-p
 
 ## 2. Verification
 
-- [ ] 2.1 (AC1) `grep -c "knowledge-base/project/constitution.md (architecture + style)" .claude/hooks/no-memory-write.sh` → `1`.
-- [ ] 2.2 (AC2) `grep -rl "overview/constitution" .claude/hooks/` → empty (no live ref left).
-- [ ] 2.3 (AC3) `bash .claude/hooks/no-memory-write.test.sh` → `0 failed`, exit 0 (suite green, no test edit).
-- [ ] 2.4 (AC5) `git diff --name-only` lists only `.claude/hooks/no-memory-write.sh` (+ plan/tasks);
+- [x] 2.1 (AC1) `grep -c "knowledge-base/project/constitution.md (architecture + style)" .claude/hooks/no-memory-write.sh` → `1`.
+- [x] 2.2 (AC2) `grep -rl "overview/constitution" .claude/hooks/` → empty (no live ref left).
+- [x] 2.3 (AC3) `bash .claude/hooks/no-memory-write.test.sh` → `0 failed`, exit 0 (suite green, no test edit).
+- [x] 2.4 (AC5) `git diff --name-only` lists only `.claude/hooks/no-memory-write.sh` (+ plan/tasks);
       `kb-domain-allowlist-guard.sh`, dated `knowledge-base/project/{plans,specs,brainstorms,learnings}/`
       files, `apps/web-platform` `overview/` refs, and `MEMORY.md` are all untouched.
 
 ## 3. Optional (default: skip)
 
-- [ ] 3.1 (AC4) Add regression assertion to T1 in `no-memory-write.test.sh`:
+- [x] 3.1 (AC4) Add regression assertion to T1 in `no-memory-write.test.sh`:
       `&& [[ "$reason" == *"knowledge-base/project/constitution.md"* ]]`. Only if explicitly
       desired — keeps the default diff to a single line otherwise.

--- a/knowledge-base/project/specs/feat-one-shot-no-memory-write-constitution-path/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-no-memory-write-constitution-path/tasks.md
@@ -1,0 +1,32 @@
+---
+title: Tasks — Fix stale constitution path in no-memory-write hook
+lane: single-domain
+date: 2026-06-07
+plan: knowledge-base/project/plans/2026-06-07-fix-no-memory-write-constitution-path-plan.md
+---
+
+# Tasks — Fix stale constitution path in no-memory-write hook
+
+## 1. Core Implementation
+
+- [ ] 1.1 Edit `.claude/hooks/no-memory-write.sh` line 55: change the middle remediation
+      bullet inside the `permissionDecisionReason` string from
+      `knowledge-base/overview/constitution.md (architecture + style)` to
+      `knowledge-base/project/constitution.md (architecture + style)`. Change only the
+      `overview` → `project` token; preserve indentation, the trailing
+      ` (architecture + style)`, and the rest of the `jq -n` payload verbatim.
+
+## 2. Verification
+
+- [ ] 2.1 (AC1) `grep -c "knowledge-base/project/constitution.md (architecture + style)" .claude/hooks/no-memory-write.sh` → `1`.
+- [ ] 2.2 (AC2) `grep -rl "overview/constitution" .claude/hooks/` → empty (no live ref left).
+- [ ] 2.3 (AC3) `bash .claude/hooks/no-memory-write.test.sh` → `0 failed`, exit 0 (suite green, no test edit).
+- [ ] 2.4 (AC5) `git diff --name-only` lists only `.claude/hooks/no-memory-write.sh` (+ plan/tasks);
+      `kb-domain-allowlist-guard.sh`, dated `knowledge-base/project/{plans,specs,brainstorms,learnings}/`
+      files, `apps/web-platform` `overview/` refs, and `MEMORY.md` are all untouched.
+
+## 3. Optional (default: skip)
+
+- [ ] 3.1 (AC4) Add regression assertion to T1 in `no-memory-write.test.sh`:
+      `&& [[ "$reason" == *"knowledge-base/project/constitution.md"* ]]`. Only if explicitly
+      desired — keeps the default diff to a single line otherwise.


### PR DESCRIPTION
## Summary

- Fixes a stale path in the `no-memory-write.sh` PreToolUse hook's BLOCKED remediation message.
- When an agent is denied a write to `~/.claude/projects/*/memory/`, the hook tells it where to commit knowledge instead. The middle bullet pointed at `knowledge-base/overview/constitution.md` — a path that **does not exist**. The constitution was relocated to `knowledge-base/project/constitution.md` (2026-03-13 rename); the `overview/` directory is gone.
- This hook was the only **live, operative** reference still pointing at the phantom path. Every other operative reference (`knowledge-base/INDEX.md`, `plugins/soleur/commands/sync.md`, the compound / compound-capture / plan / work skills, `scripts/rule-audit.sh`, `knowledge-base/project/components/knowledge-base.md`) already uses the correct `project/` path.

## Changelog

### Hooks
- `no-memory-write.sh`: BLOCKED-message remediation bullet now points to the real `knowledge-base/project/constitution.md` (was `overview/`).
- `no-memory-write.test.sh`: T1 now also asserts the message contains `knowledge-base/project/constitution.md`, a regression guard against the path drifting back to a non-existent location.

## Out of scope (deliberately untouched)

- `SANCTIONED_DIRS` in `kb-domain-allowlist-guard.sh` — not sanctioning an `overview/` domain.
- Historical/dated records under `knowledge-base/project/{plans,specs,brainstorms,learnings}/` that document the past `overview/` state.
- `apps/web-platform` `overview/` references — that is the generated user-workspace knowledge-base, a different directory.

## Test plan

- [x] `bash .claude/hooks/no-memory-write.test.sh` — 12/12 pass (T1 RED-verified against the unfixed source, then GREEN after the fix).
- [x] `TEST_GROUP=scripts bash scripts/test-all.sh` — 94/94 suites pass (shard that globs `.claude/hooks/*.test.sh`).
- [x] `grep -c "knowledge-base/project/constitution.md (architecture + style)" .claude/hooks/no-memory-write.sh` returns 1; `grep -rl "overview/constitution" .claude/hooks/` returns nothing.

Generated with [Claude Code](https://claude.com/claude-code)
