### PR TITLE
fix(kb-share): resolve shared-read KB root from workspace_id; fix Copy button overflow

### DIFF
--- a/apps/web-platform/app/api/shared/[token]/route.ts
+++ b/apps/web-platform/app/api/shared/[token]/route.ts
@@ -25,6 +25,7 @@ import {
   SHARED_CONTENT_KIND_HEADER,
 } from "@/server/kb-serve";
 import { shareHashVerdictCache } from "@/server/share-hash-verdict-cache";
+import { workspacePathForWorkspaceId } from "@/server/workspace-resolver";
 import {
   shareEndpointThrottle,
   extractClientIpFromHeaders,
@@ -98,10 +99,12 @@ type ShareRow = {
   document_path: string;
   revoked: boolean;
   content_sha256: string | null;
-  users:
-    | { workspace_path: string | null; workspace_status: string | null }
-    | { workspace_path: string | null; workspace_status: string | null }[]
-    | null;
+  // ADR-044: the KB root is keyed off the share's workspace_id (the same id
+  // the create path wrote via resolveActiveWorkspaceKbRoot), NOT the owner's
+  // legacy users.workspace_path/workspace_status columns — those are
+  // stale/empty for users provisioned after the users → workspaces relocation,
+  // which 404'd freshly-created shares on this read path.
+  workspace_id: string;
 };
 
 /**
@@ -138,9 +141,7 @@ async function prepareSharedRequest(
   const serviceClient = createServiceClient();
   const { data: shareLink, error: fetchError } = await serviceClient
     .from("kb_share_links")
-    .select(
-      "document_path, revoked, content_sha256, users!inner(workspace_path, workspace_status)",
-    )
+    .select("document_path, revoked, content_sha256, workspace_id")
     .eq("token", token)
     .single<ShareRow>();
 
@@ -183,17 +184,21 @@ async function prepareSharedRequest(
     };
   }
 
-  const owner = Array.isArray(shareLink.users)
-    ? shareLink.users[0]
-    : shareLink.users;
-  if (!owner?.workspace_path || owner.workspace_status !== "ready") {
-    logSharedFailed(token, shareLink.document_path, "workspace-unavailable");
-    return { kind: "response", response: notFoundResponse() };
-  }
+  // Resolve the KB root from the share's workspace_id — the same workspace-id-
+  // keyed on-disk path the create route wrote to (workspacePathForWorkspaceId).
+  // A workspace that was de-provisioned after share creation surfaces naturally
+  // as KbNotFoundError → 404 at the file-read step, with the content hash gate
+  // guaranteeing the served bytes still match what was shared. No owner-row
+  // readiness gate: reading users.workspace_status here 404'd valid shares whose
+  // create path had already migrated to the workspace resolver (ADR-044).
+  const kbRoot = path.join(
+    workspacePathForWorkspaceId(shareLink.workspace_id),
+    "knowledge-base",
+  );
 
   return {
     kind: "ready",
-    kbRoot: path.join(owner.workspace_path, "knowledge-base"),
+    kbRoot,
     documentPath: shareLink.document_path,
     contentSha256: shareLink.content_sha256,
     strongETag,

--- a/apps/web-platform/components/kb/share-popover.tsx
+++ b/apps/web-platform/components/kb/share-popover.tsx
@@ -212,7 +212,7 @@ export function SharePopover({ documentPath }: SharePopoverProps) {
                   type="text"
                   readOnly
                   value={state.url}
-                  className="flex-1 truncate rounded border border-soleur-border-default bg-soleur-bg-surface-2 px-2 py-1.5 text-xs text-soleur-text-primary"
+                  className="min-w-0 flex-1 truncate rounded border border-soleur-border-default bg-soleur-bg-surface-2 px-2 py-1.5 text-xs text-soleur-text-primary"
                 />
                 <button
                   type="button"

--- a/apps/web-platform/server/kb-share.ts
+++ b/apps/web-platform/server/kb-share.ts
@@ -43,6 +43,7 @@ import {
 import { createChildLogger } from "@/server/logger";
 import { reportSilentFallback } from "@/server/observability";
 import { purgeSharedToken } from "@/server/cf-cache-purge";
+import { workspacePathForWorkspaceId } from "@/server/workspace-resolver";
 
 const log = createChildLogger("kb-share");
 
@@ -589,10 +590,9 @@ type PreviewShareRow = {
   document_path: string;
   revoked: boolean;
   content_sha256: string | null;
-  users:
-    | { workspace_path: string | null; workspace_status: string | null }
-    | { workspace_path: string | null; workspace_status: string | null }[]
-    | null;
+  // ADR-044: KB root is keyed off the share's workspace_id (matching the create
+  // path), NOT the owner's legacy users.workspace_path/workspace_status columns.
+  workspace_id: string;
 };
 
 // Map any error thrown by validateBinaryFile / readContentRaw /
@@ -755,9 +755,7 @@ export async function previewShare(
         };
       }
     )
-      .select(
-        "document_path, revoked, content_sha256, users!inner(workspace_path, workspace_status)",
-      )
+      .select("document_path, revoked, content_sha256, workspace_id")
       .eq("token", token)
       .single()) as {
       data: PreviewShareRow | null;
@@ -838,17 +836,11 @@ export async function previewShare(
     };
   }
 
-  const owner = Array.isArray(row.users) ? row.users[0] : row.users;
-  if (!owner?.workspace_path || owner.workspace_status !== "ready") {
-    return {
-      ok: false,
-      status: 404,
-      code: "not-found",
-      error: "Document no longer available",
-    };
-  }
-
-  const kbRoot = kbRootResolver(owner.workspace_path);
+  // ADR-044: resolve the KB root from the share's workspace_id (matching the
+  // create path), NOT the owner's legacy users row. A de-provisioned workspace
+  // surfaces as KbNotFoundError → 404 at the file-read step below; the content
+  // hash gate guarantees the bytes still match what was shared.
+  const kbRoot = kbRootResolver(workspacePathForWorkspaceId(row.workspace_id));
   const documentPath = row.document_path;
   const contentSha256 = row.content_sha256;
 

--- a/apps/web-platform/test/helpers/share-mocks.ts
+++ b/apps/web-platform/test/helpers/share-mocks.ts
@@ -18,6 +18,7 @@
 // Tests declare intent by TABLE NAME, not by call index. Reordering
 // queries inside the route handler is no longer a test-breaking change.
 
+import path from "node:path";
 import type { Mock } from "vitest";
 import { vi } from "vitest";
 
@@ -172,17 +173,35 @@ function kbShareLinksChain(
         workspace_status: usersFixture.workspaceStatus ?? "ready",
       }
     : null;
+  // ADR-044: the shared read path + previewShare resolve the KB root from the
+  // share row's `workspace_id` via `workspacePathForWorkspaceId`
+  // (`<WORKSPACES_ROOT>/<workspace_id>`), NOT the legacy `users` join. Derive
+  // the id from the fixture's workspacePath basename so a test whose temp
+  // workspace lives at `<WORKSPACES_ROOT>/<id>/knowledge-base` resolves to the
+  // same on-disk dir the create path wrote to — no per-test shareRow churn.
+  // The legacy `users` nesting is still attached below for any owner-route /
+  // backward-compat reader; the share read path now ignores it.
+  const derivedWorkspaceId = usersFixture?.workspacePath
+    ? path.basename(usersFixture.workspacePath)
+    : undefined;
   // When a route uses PostgREST embedded resources (e.g.,
   // `.select("…, users!inner(…)")`) the nested row appears under
   // `shareRow.users`. Auto-attach the users fixture so tests don't have
   // to know which query shape the route uses. If the shareRow already
-  // defines `users`, it wins — an explicit override beats the default.
+  // defines `users` / `workspace_id`, it wins — an explicit override beats
+  // the default.
   const attachUsers = <T extends Record<string, unknown> | null>(
     row: T,
   ): T => {
-    if (!row || !usersNested) return row;
-    if ("users" in row) return row;
-    return { ...row, users: usersNested } as T;
+    if (!row) return row;
+    let next: Record<string, unknown> = row;
+    if (derivedWorkspaceId !== undefined && !("workspace_id" in next)) {
+      next = { ...next, workspace_id: derivedWorkspaceId };
+    }
+    if (usersNested && !("users" in next)) {
+      next = { ...next, users: usersNested };
+    }
+    return next as T;
   };
   const single = vi.fn().mockImplementation(async () => {
     const row = attachUsers(resolve(fixture.shareRow ?? null));

--- a/apps/web-platform/test/kb-share-preview.test.ts
+++ b/apps/web-platform/test/kb-share-preview.test.ts
@@ -200,6 +200,54 @@ describe("previewShare — lookup and row-state branches", () => {
     expect(result.documentPath).toBe("readme.md");
   });
 
+  it("resolves off workspace_id even when it DIFFERS from the owner's workspace_path (ADR-044 divergence)", async () => {
+    // Stronger guard: the prior test couples workspace_id to the owner's
+    // workspace_path (both basename to the same temp dir), so it cannot prove
+    // the read keys off workspace_id rather than workspace_path. Here the two
+    // DIVERGE — the file lives ONLY under the workspace_id-resolved dir, while
+    // the owner's workspace_path points at a file-less dir. A regression that
+    // re-read workspace_path would 404; resolving off workspace_id returns 200.
+    const divergentId = "ws-divergent-from-userpath";
+    const divergentKbRoot = path.join(
+      // WORKSPACES_ROOT is set to dirname(tmpWorkspace) in beforeEach, so
+      // workspacePathForWorkspaceId(divergentId) lands here.
+      path.dirname(tmpWorkspace),
+      divergentId,
+      "knowledge-base",
+    );
+    fs.mkdirSync(divergentKbRoot, { recursive: true });
+    const bytes = Buffer.from("# lives only under workspace_id\n");
+    fs.writeFileSync(path.join(divergentKbRoot, "readme.md"), bytes);
+
+    const client = makeClient({
+      // Owner's legacy path points at tmpWorkspace, which does NOT contain the
+      // file — only the divergent workspace_id dir does.
+      users: { workspacePath: tmpWorkspace, workspaceStatus: "ready" },
+      kb_share_links: {
+        shareRow: {
+          document_path: "readme.md",
+          revoked: false,
+          content_sha256: hex(bytes),
+          // Explicit workspace_id wins over the mock's basename derivation.
+          workspace_id: divergentId,
+        },
+      },
+    });
+
+    const result = await previewShare(client as never, "tok");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.status).toBe(200);
+    expect(result.kind).toBe("markdown");
+    expect(result.documentPath).toBe("readme.md");
+
+    fs.rmSync(path.join(path.dirname(tmpWorkspace), divergentId), {
+      recursive: true,
+      force: true,
+    });
+  });
+
   it("returns 500 db-error and reports to Sentry on DB error (test 6)", async () => {
     const client = makeClient({
       users: readyWorkspace(),

--- a/apps/web-platform/test/kb-share-preview.test.ts
+++ b/apps/web-platform/test/kb-share-preview.test.ts
@@ -79,11 +79,16 @@ beforeEach(async () => {
   metadataMocks.readPdfMetadata.mockResolvedValue(null);
   metadataMocks.readImageMetadata.mockResolvedValue(null);
   tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), "kb-share-preview-"));
+  // ADR-044: previewShare resolves kbRoot via workspacePathForWorkspaceId
+  // (`<WORKSPACES_ROOT>/<workspace_id>`). The mock derives workspace_id from
+  // this dir's basename, so point WORKSPACES_ROOT at its parent.
+  process.env.WORKSPACES_ROOT = path.dirname(tmpWorkspace);
   kbRoot = path.join(tmpWorkspace, "knowledge-base");
   fs.mkdirSync(kbRoot, { recursive: true });
 });
 
 afterEach(() => {
+  delete process.env.WORKSPACES_ROOT;
   fs.rmSync(tmpWorkspace, { recursive: true, force: true });
 });
 
@@ -165,44 +170,34 @@ describe("previewShare — lookup and row-state branches", () => {
     expect(result.code).toBe("legacy-null-hash");
   });
 
-  it("returns 404 not-found when workspace_status !== 'ready' (test 4)", async () => {
+  it("resolves the KB root from the share's workspace_id, not the owner users row (tests 4-5, ADR-044)", async () => {
+    // Regression guard for the shared-read 404 bug. The create path resolves
+    // kbRoot via the workspace_id-keyed resolver, but this read path used to
+    // gate on the owner's legacy users.workspace_status/workspace_path columns.
+    // Those are stale/empty for users provisioned after the users → workspaces
+    // relocation, so a freshly-created share 404'd even though the file exists.
+    // Here the owner row is NOT "ready" (would have tripped the removed gate),
+    // yet the document resolves and previews successfully off workspace_id.
+    const bytes = Buffer.from("# resolves off workspace_id\n");
+    fs.writeFileSync(path.join(kbRoot, "readme.md"), bytes);
     const client = makeClient({
       users: { workspacePath: tmpWorkspace, workspaceStatus: "provisioning" },
       kb_share_links: {
         shareRow: {
           document_path: "readme.md",
           revoked: false,
-          content_sha256: hex(Buffer.from("x")),
+          content_sha256: hex(bytes),
         },
       },
     });
 
     const result = await previewShare(client as never, "tok");
 
-    expect(result.ok).toBe(false);
-    if (result.ok) throw new Error("unreachable");
-    expect(result.status).toBe(404);
-    expect(result.code).toBe("not-found");
-  });
-
-  it("returns 404 not-found when workspace_path is null (test 5)", async () => {
-    const client = makeClient({
-      users: { workspacePath: undefined, workspaceStatus: "ready" },
-      kb_share_links: {
-        shareRow: {
-          document_path: "readme.md",
-          revoked: false,
-          content_sha256: hex(Buffer.from("x")),
-        },
-      },
-    });
-
-    const result = await previewShare(client as never, "tok");
-
-    expect(result.ok).toBe(false);
-    if (result.ok) throw new Error("unreachable");
-    expect(result.status).toBe(404);
-    expect(result.code).toBe("not-found");
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.status).toBe(200);
+    expect(result.kind).toBe("markdown");
+    expect(result.documentPath).toBe("readme.md");
   });
 
   it("returns 500 db-error and reports to Sentry on DB error (test 6)", async () => {

--- a/apps/web-platform/test/shared-head-get-verdict-cache-sharing.test.ts
+++ b/apps/web-platform/test/shared-head-get-verdict-cache-sharing.test.ts
@@ -88,11 +88,16 @@ beforeEach(() => {
   __resetShareHashVerdictCacheForTest();
   mocks.mockIsAllowed.mockReturnValue(true);
   tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), "share-cache-parity-"));
+  // ADR-044: the route resolves kbRoot via workspacePathForWorkspaceId
+  // (`<WORKSPACES_ROOT>/<workspace_id>`). The mock derives workspace_id from
+  // this dir's basename, so point WORKSPACES_ROOT at its parent.
+  process.env.WORKSPACES_ROOT = path.dirname(tmpWorkspace);
   kbRoot = path.join(tmpWorkspace, "knowledge-base");
   fs.mkdirSync(kbRoot, { recursive: true });
 });
 
 afterEach(() => {
+  delete process.env.WORKSPACES_ROOT;
   fs.rmSync(tmpWorkspace, { recursive: true, force: true });
 });
 

--- a/apps/web-platform/test/shared-page-binary.test.ts
+++ b/apps/web-platform/test/shared-page-binary.test.ts
@@ -90,11 +90,16 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.mockIsAllowed.mockReturnValue(true);
   tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), "shared-page-bin-"));
+  // ADR-044: the route resolves kbRoot via workspacePathForWorkspaceId
+  // (`<WORKSPACES_ROOT>/<workspace_id>`). The mock derives workspace_id from
+  // this dir's basename, so point WORKSPACES_ROOT at its parent.
+  process.env.WORKSPACES_ROOT = path.dirname(tmpWorkspace);
   kbRoot = path.join(tmpWorkspace, "knowledge-base");
   fs.mkdirSync(kbRoot, { recursive: true });
 });
 
 afterEach(() => {
+  delete process.env.WORKSPACES_ROOT;
   fs.rmSync(tmpWorkspace, { recursive: true, force: true });
 });
 

--- a/apps/web-platform/test/shared-token-content-hash.test.ts
+++ b/apps/web-platform/test/shared-token-content-hash.test.ts
@@ -69,6 +69,10 @@ async function callGET() {
 beforeEach(() => {
   vi.clearAllMocks();
   tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), "shared-hash-"));
+  // ADR-044: the route resolves kbRoot via workspacePathForWorkspaceId
+  // (`<WORKSPACES_ROOT>/<workspace_id>`). The mock derives workspace_id from
+  // this dir's basename, so point WORKSPACES_ROOT at its parent.
+  process.env.WORKSPACES_ROOT = path.dirname(tmpWorkspace);
   kbRoot = path.join(tmpWorkspace, "knowledge-base");
   fs.mkdirSync(kbRoot, { recursive: true });
   mocks.mockIsAllowed.mockReturnValue(true);
@@ -77,6 +81,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  delete process.env.WORKSPACES_ROOT;
   fs.rmSync(tmpWorkspace, { recursive: true, force: true });
 });
 

--- a/apps/web-platform/test/shared-token-head.test.ts
+++ b/apps/web-platform/test/shared-token-head.test.ts
@@ -87,11 +87,16 @@ beforeEach(() => {
   __resetShareHashVerdictCacheForTest();
   mocks.mockIsAllowed.mockReturnValue(true);
   tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), "shared-head-"));
+  // ADR-044: the route resolves kbRoot via workspacePathForWorkspaceId
+  // (`<WORKSPACES_ROOT>/<workspace_id>`). The mock derives workspace_id from
+  // this dir's basename, so point WORKSPACES_ROOT at its parent.
+  process.env.WORKSPACES_ROOT = path.dirname(tmpWorkspace);
   kbRoot = path.join(tmpWorkspace, "knowledge-base");
   fs.mkdirSync(kbRoot, { recursive: true });
 });
 
 afterEach(() => {
+  delete process.env.WORKSPACES_ROOT;
   fs.rmSync(tmpWorkspace, { recursive: true, force: true });
 });
 

--- a/apps/web-platform/test/shared-token-verdict-cache.test.ts
+++ b/apps/web-platform/test/shared-token-verdict-cache.test.ts
@@ -85,12 +85,17 @@ beforeEach(() => {
   hashStreamSpy.mockClear();
   __resetShareHashVerdictCacheForTest();
   tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), "shared-cache-"));
+  // ADR-044: the route resolves kbRoot via workspacePathForWorkspaceId
+  // (`<WORKSPACES_ROOT>/<workspace_id>`). The mock derives workspace_id from
+  // this dir's basename, so point WORKSPACES_ROOT at its parent.
+  process.env.WORKSPACES_ROOT = path.dirname(tmpWorkspace);
   kbRoot = path.join(tmpWorkspace, "knowledge-base");
   fs.mkdirSync(kbRoot, { recursive: true });
 });
 
 afterEach(() => {
   __resetShareHashVerdictCacheForTest();
+  delete process.env.WORKSPACES_ROOT;
   fs.rmSync(tmpWorkspace, { recursive: true, force: true });
 });
 

--- a/knowledge-base/engineering/operations/post-mortems/shared-document-404-post-adr044-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/shared-document-404-post-adr044-postmortem.md
@@ -1,0 +1,111 @@
+---
+title: "Shared documents return 'Document not found' for users provisioned after the ADR-044 relocation"
+date: 2026-06-08
+incident_pr: feat-fix-share-popup-copy-overflow
+incident_window: "unknown start (ADR-044 read-path cutover) → 2026-06-08"
+recovery_at: "2026-06-08 (fix merged)"
+suspected_change: "ADR-044 users→workspaces relocation: the share CREATE path migrated to the workspace_id-keyed KB resolver, but the share READ path (/api/shared/[token]) and previewShare were never migrated."
+brand_survival_threshold: single-user incident
+status: resolved
+triggers:
+  - feature-breakage
+art_33_triggered: false
+art_34_triggered: false
+art_33_deadline: "n/a"
+---
+
+## Actor key
+
+- `agent` — Claude Code did this autonomously (no operator ack required).
+- `human` — Operator did this directly.
+
+# Incident Overview
+
+The KB document-sharing feature was broken for any account whose legacy
+`users.workspace_path` / `users.workspace_status` columns were stale or empty —
+the expected state for users provisioned after the ADR-044 `users → workspaces`
+relocation. Such a user could generate a share link successfully, but opening
+`/shared/<token>` returned **"Document not found."** The share *created* fine and
+*read* as a 404.
+
+## Status
+
+resolved — fix re-points the read path to resolve the KB root from the share
+row's `workspace_id` (matching the create path).
+
+## Symptom
+
+Visiting a freshly-generated share link rendered the public "Document not found —
+This document may have been removed or the link is invalid" error page (HTTP 404),
+even though the document existed and the share was active.
+
+## Incident Timeline
+
+| Actor | Time (UTC) | Action |
+|---|---|---|
+| human | (ADR-044 read-path cutover) | Create path migrated to `resolveActiveWorkspaceKbRoot`; read paths left reading legacy `users` columns. Latent breakage begins for post-relocation users. |
+| human | 2026-06-07 | Founder, dogfooding, copies a share link and gets "Document not found"; reports it (with screenshots) alongside the Copy-button overflow. |
+| agent | 2026-06-08 | Root cause traced to the unmigrated read path; fix + tests landed; multi-agent review (security/data-integrity/architecture/quality/test) APPROVED; merged. |
+
+## Detection (+ MTTD)
+
+- **How detected:** external/manual — the founder hit it while dogfooding the
+  share feature. NOT caught by monitoring (the read path returned a clean 404,
+  not a 5xx or Sentry error — it looked like a legitimate "no such document").
+- **MTTD:** unknown (latent since the ADR-044 read-path cutover; surfaced only
+  on first dogfood of a post-relocation account).
+
+## Root Cause
+
+ADR-044 relocated KB-root resolution from the per-user `users.workspace_path` /
+`users.workspace_status` columns to a workspace-id-keyed layout
+(`<WORKSPACES_ROOT>/<workspace_id>/knowledge-base`, via
+`workspacePathForWorkspaceId`). The migration swept the **create** path
+(`app/api/kb/share/route.ts` → `resolveActiveWorkspaceKbRoot`) but NOT the
+**read** paths:
+
+- `app/api/shared/[token]/route.ts` (`prepareSharedRequest`, feeds GET + HEAD)
+- `server/kb-share.ts` (`previewShare`, also the `kb_share_preview` MCP tool)
+
+Both kept resolving kbRoot + a `workspace_status !== "ready"` readiness gate from
+the owner's legacy `users` row. For a post-relocation user those columns are
+stale/empty, so the read 404'd either at the readiness gate or at the file-read
+(`KbNotFoundError`) against the wrong/empty path. The create route's own comment
+documented the exact divergence — but only the write side had been fixed.
+
+## Resolution
+
+Resolve the read-side kbRoot from the share row's stored `workspace_id` (NOT NULL
+since migration 059) via `workspacePathForWorkspaceId`, byte-identical to the
+create path; drop the stale owner-row readiness gate (a de-provisioned workspace
+still 404s at the file-read step, and the `content_sha256` hash gate still guards
+served bytes). Backward-compatible for existing share rows (N2 invariant:
+`workspace_id == user_id` for solo users → same on-disk dir the legacy path
+pointed at).
+
+## GDPR / Data-Exposure Assessment
+
+- **Art. 33 (breach notification):** not triggered. This was an
+  **over-restrictive denial** (valid documents wrongly 404'd) — the *opposite* of
+  a disclosure. No personal data was exposed; no cross-tenant read occurred
+  (security-sentinel confirmed `workspace_id` is server-stored and not
+  attacker-controllable).
+- **Art. 34 (data-subject notification):** not triggered (no exposure).
+
+## Follow-ups
+
+- [x] Read-path resolution migrated to `workspace_id` (this PR).
+- [x] Regression guard added that fails if resolution ever re-reads
+  `workspace_path` (divergent-`workspace_id` test).
+- [ ] Sweep remaining legacy `users.workspace_path`/`workspace_status` readers
+  (owner/sync/agent/export paths) before the ADR-044 pre-decommission column drop
+  — tracked by ADR-044's own drift gate, out of scope for this fix.
+
+## Lessons (see also the learning file)
+
+A relocation migration must sweep **every** consumer of the old source, not just
+the most visible (write) path. A create-path-only migration leaves read paths
+resolving against the stale source — green CI, passing create, silent 404 on read.
+This is the read-side analogue of `hr-write-boundary-sentinel-sweep-all-write-sites`.
+Full write-up:
+`knowledge-base/project/learnings/bug-fixes/2026-06-08-migration-relocating-a-resolver-must-sweep-all-read-paths-not-just-create.md`.

--- a/knowledge-base/project/learnings/bug-fixes/2026-06-08-migration-relocating-a-resolver-must-sweep-all-read-paths-not-just-create.md
+++ b/knowledge-base/project/learnings/bug-fixes/2026-06-08-migration-relocating-a-resolver-must-sweep-all-read-paths-not-just-create.md
@@ -1,0 +1,103 @@
+---
+title: A migration that relocates a resolution source must sweep ALL read paths, not just create/owner
+date: 2026-06-08
+category: bug-fixes
+module: kb-share
+tags: [adr-044, workspace-resolver, kb-share, shared-documents, migration-completeness, public-endpoint]
+severity: high
+---
+
+# Learning: a relocation migration must migrate every consumer of the old source, not just the write path
+
+## Problem
+
+A user shared a KB document, copied the link (`/shared/<token>`), and opening it
+returned **"Document not found"** — even though the share was freshly created and
+the document existed. The share *created* fine but *read* as a 404.
+
+A second, cosmetic issue was reported in the same screenshot: the Copy/"Copied!"
+button overflowed the fixed-width share popup.
+
+## Root cause
+
+ADR-044 relocated KB-root resolution off the per-user `users.workspace_path` /
+`users.workspace_status` columns onto a workspace-id-keyed layout
+(`<WORKSPACES_ROOT>/<workspace_id>/knowledge-base`, via
+`workspacePathForWorkspaceId`). The **create** path
+(`app/api/kb/share/route.ts`) was migrated to `resolveActiveWorkspaceKbRoot`.
+
+But the **read** paths were never migrated:
+- `app/api/shared/[token]/route.ts` (`prepareSharedRequest`, feeds GET + HEAD)
+- `server/kb-share.ts` (`previewShare`, also the `kb_share_preview` MCP tool)
+
+Both still resolved kbRoot + a readiness gate from the owner's legacy `users`
+columns, which are stale/empty for accounts provisioned after the
+`users → workspaces` relocation. So a share created via the migrated write path
+404'd on the unmigrated read path — either the `workspace_status !== "ready"`
+gate tripped, or the empty `workspace_path` made the file unfindable.
+
+The create route's own comment (`route.ts:34-40`) literally documented the
+divergence ("stale/empty for users provisioned after the ADR-044 relocation …
+the divergent failure surface that dead-ended Generate link") — but only the
+write path had been fixed.
+
+## Solution
+
+Resolve the read-side kbRoot from the share row's stored `workspace_id` (NOT NULL
+since migration 059, backfilled to the N2 invariant `workspace_id == user_id`
+for solo users) via `workspacePathForWorkspaceId`, exactly matching create. Drop
+the legacy owner-row readiness gate: a de-provisioned workspace still surfaces as
+`KbNotFoundError → 404` at the file-read step, and the `content_sha256` hash gate
+still guards the served bytes. Backward-compatible: for existing rows,
+`workspacePathForWorkspaceId(workspace_id)` resolves to the byte-identical dir the
+old `users.workspace_path` pointed at.
+
+CSS fix: add `min-w-0` to the `flex-1 truncate` share-link input — the canonical
+fix for the flexbox `min-width: auto` trap (a flex child won't shrink below its
+intrinsic width, defeating `truncate` and shoving the `shrink-0` button out).
+
+## Key Insight
+
+When a migration **relocates a resolution source** (a column, a lookup table, an
+ID key), the write path is the *most visible* consumer but rarely the only one.
+Sweep every consumer of the old source in the same migration:
+
+```
+git grep -n '<old_column_or_join>'   # e.g. users!inner(workspace_path, workspace_status)
+```
+
+…and classify each hit as create / owner-read / anonymous-read / sync / export.
+A create-path-only migration leaves read paths resolving against the now-stale
+source — green CI, passing create, silent 404 on read. This is the read-side
+analogue of `hr-write-boundary-sentinel-sweep-all-write-sites`: **a relocation
+needs a read-boundary sentinel sweep too.**
+
+Create/read symmetry is the test that matters: does the read path resolve to the
+exact dir the write path wrote to, for the same row? Prove it with a test where
+the new key **diverges** from the old source (here: `workspace_id` ≠
+`basename(workspace_path)`), so a regression that re-reads the old source fails.
+
+## Session Errors
+
+1. **Delegated exploration returned an over-confident wrong root cause.** An
+   Explore subagent concluded ("BINGO!") that the `workspace_status` gate was THE
+   cause; the actual cause was the entire read path never migrating to ADR-044.
+   Recovery: read the create + read code directly and found the asymmetry.
+   **Prevention:** treat a subagent's root-cause hypothesis as a lead, not a
+   verdict — verify it against the code (especially the *symmetric* path) before
+   acting. A single-branch explanation for a 404 is suspect when the same 404
+   code has 3 reachable branches.
+2. **Lint not runnable in the worktree.** `next lint` required interactive config
+   setup; direct `eslint` failed (no v9 `eslint.config.js`). Recovery: `tsc
+   --noEmit` + full share/shared test suite (clean); CI runs lint. **Prevention:**
+   one-off/env — don't block a worktree ship on local lint; CI is the gate.
+3. **Flat-layout share tests broke after the resolver change** (expected).
+   Recovery: migrated 6 test files + the shared mock helper to the ADR-044 nested
+   layout (`WORKSPACES_ROOT=dirname(tmpWorkspace)`, mock derives `workspace_id`
+   from the workspace-path basename). **Prevention:** when a resolver's source
+   changes, the test fixtures that model the OLD source must move with it — model
+   the production `<WORKSPACES_ROOT>/<id>` layout, not a flat temp dir.
+
+## Tags
+category: bug-fixes
+module: kb-share


### PR DESCRIPTION
## Summary
Two fixes to the KB document share feature, both surfaced by founder dogfooding:

1. **Shared links returned "Document not found" (functional, production).** ADR-044 relocated KB-root resolution to a workspace-id-keyed layout and migrated the share **create** path, but the **read** paths (`/api/shared/[token]` + `previewShare`) still resolved kbRoot + a readiness gate from the owner's legacy `users.workspace_path`/`workspace_status` columns — stale/empty for users provisioned after the relocation. Result: shares created fine but read as 404. Fix: resolve the read-side kbRoot from the share row's stored `workspace_id` (NOT NULL since migration 059) via `workspacePathForWorkspaceId`, matching create; drop the stale owner-row readiness gate (file-existence + content-hash gate remain the real guards). Backward-compatible for existing share rows.

2. **Copy/"Copied!" button overflowed the share popup (CSS).** The `flex-1 truncate` share-link input refused to shrink below its intrinsic width (flexbox `min-width: auto` trap), pushing the `shrink-0` button past the fixed-width popup edge. Fix: add `min-w-0` so the input shrinks and truncates.

## Changelog
- Shared document links now resolve correctly for all accounts (previously 404'd for users provisioned after the ADR-044 users→workspaces relocation).
- Share-link popup Copy/Copied! button no longer overflows the popup box.

## Test plan
- [x] `tsc --noEmit` clean
- [x] 485 share/shared tests pass (incl. migrated route/preview suites)
- [x] New regression guard: a share resolves even when the owner `users` row is not "ready", and when `workspace_id` diverges from the legacy `workspace_path`
- [x] semgrep SAST: 0 findings; multi-agent review (security/data-integrity/architecture/quality/test): APPROVED

## Incident
Post-incident report: `knowledge-base/engineering/operations/post-mortems/shared-document-404-post-adr044-postmortem.md` (over-restrictive denial; no data exposure, Art. 33/34 not triggered).

Generated with [Claude Code](https://claude.com/claude-code)