### PR TITLE
fix(incident): require GitHub issue numbers for PIR action items; merge Follow-ups + Action Items

### DIFF
--- a/knowledge-base/engineering/operations/post-mortems/shared-document-404-post-adr044-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/shared-document-404-post-adr044-postmortem.md
@@ -92,14 +92,23 @@ pointed at).
   attacker-controllable).
 - **Art. 34 (data-subject notification):** not triggered (no exposure).
 
-## Follow-ups
+## Action Items & Follow-ups
 
-- [x] Read-path resolution migrated to `workspace_id` (this PR).
-- [x] Regression guard added that fails if resolution ever re-reads
-  `workspace_path` (divergent-`workspace_id` test).
-- [ ] Sweep remaining legacy `users.workspace_path`/`workspace_status` readers
-  (owner/sync/agent/export paths) before the ADR-044 pre-decommission column drop
-  — tracked by ADR-044's own drift gate, out of scope for this fix.
+Resolved in the source PR (#5003): read-path resolution migrated to `workspace_id`,
+plus a regression guard that fails if resolution ever re-reads `workspace_path`
+(the divergent-`workspace_id` test).
+
+Residual work — issue-backed:
+
+| Issue | Action | Status |
+|---|---|---|
+| #5005 | Audit + converge the remaining direct readers of `users.workspace_path` / `users.workspace_status` (owner/sync/agent/export paths) onto the workspace-id resolver — same latent-bug class as this incident. | open |
+
+**Correction (was inaccurate in the first draft):** ADR-044's own pre-decommission
+drift gate covers only the relocated *repo* columns (`repo_url`,
+`github_installation_id`, `repo_status`, `repo_last_synced_at`) — it does **not**
+cover `workspace_path`/`workspace_status`, so the sweep above was untracked until
+#5005 was filed.
 
 ## Lessons (see also the learning file)
 

--- a/plugins/soleur/skills/incident/SKILL.md
+++ b/plugins/soleur/skills/incident/SKILL.md
@@ -56,7 +56,7 @@ Collect from the operator (or from the dry-run fixture):
 18. `revenue_impact` — operator prose. Default `Unknown / N/A` (never fabricate a number).
 19. `team_impact` — operator prose. Default `Unknown / N/A`.
 
-The post-resolution review fields (`{{ROOT_CAUSE_5WHYS}}`, `{{LUCKY}}`, `{{WENT_WELL}}`, `{{WENT_WRONG}}`, `{{ACTION_ITEMS}}`) are NOT captured at Phase 0 — they do not exist yet at incident-open time. They scaffold with a static `TBD` default and the operator fills them during the Phase 7 review. This keeps Phase 0 inside the <60s classification budget (only operator-answerable-at-open fields are prompted).
+The post-resolution review fields (`{{ROOT_CAUSE_5WHYS}}`, `{{LUCKY}}`, `{{WENT_WELL}}`, `{{WENT_WRONG}}`, `{{ACTION_ITEM_ISSUE}}`/`{{ACTION_ITEM_DESC}}`) are NOT captured at Phase 0 — they do not exist yet at incident-open time. They scaffold with a static `TBD` default and the operator fills them during the Phase 7 review. This keeps Phase 0 inside the <60s classification budget (only operator-answerable-at-open fields are prompted).
 
 Compute locally (FR7 LLM-trust boundary — never accept these from an LLM-emitted blob):
 
@@ -180,7 +180,7 @@ Selected runbook slugs auto-populate Phase 4 `triggers[]` verbatim (SpecFlow Imp
 | `{{LUCKY}}` | Phase 7 review (default `TBD`) |
 | `{{WENT_WELL}}` | Phase 7 review (default `TBD`) |
 | `{{WENT_WRONG}}` | Phase 7 review (default `TBD`) |
-| `{{ACTION_ITEMS}}` | Phase 7 review (default `TBD — file as GitHub issues`) |
+| `{{ACTION_ITEM_ISSUE}}` / `{{ACTION_ITEM_DESC}}` | Phase 7 review — the merged **Action Items & Follow-ups** table. **Every row REQUIRES a filed GitHub issue number:** run `gh issue create` (cross-referencing the source PR in the body) FIRST, then fill `#<n>` + description. No bare bullets, no `TBD`. If there are genuinely zero follow-ups, replace the table with the single permitted sentence `_No action items — incident fully resolved in the source PR with no residual work._`. The `/ship` Incident-PIR gate blocks merge on any item lacking a `#NNNN`. |
 
 **Secret-leak preamble** (TR2): if `triggers[]` contains any of `api_key_leaked`, `credentials_exposed`, `token_exposed`, `secret_in_logs`, replace `{{SECRET_LEAK_PREAMBLE}}` with:
 

--- a/plugins/soleur/skills/incident/scripts/dry-run.sh
+++ b/plugins/soleur/skills/incident/scripts/dry-run.sh
@@ -378,13 +378,14 @@ TBD
 
 TBD
 
-## Follow-ups
+## Action Items & Follow-ups
 
-- [ ] TBD
+Each row MUST cite a filed GitHub issue (#NNNN). If none, replace the table with:
+_No action items — incident fully resolved in the source PR with no residual work._
 
-## Action Items
-
-TBD — file as GitHub issues
+| Issue | Action | Status |
+|---|---|---|
+| #TBD | TBD | open |
 EOF
 } > "${draft_file}"
 

--- a/plugins/soleur/skills/incident/templates/pir.md
+++ b/plugins/soleur/skills/incident/templates/pir.md
@@ -128,12 +128,12 @@ Per learning `2026-05-06-user-impact-section-by-role-not-surface.md` — enumera
 
 {{WENT_WRONG}}
 
-## Follow-ups
+## Action Items & Follow-ups
 
-- [ ] TBD
+Every action item and follow-up so this incident cannot recur (save logs, add tests, set up alerts, automation, documentation, code sweeps, PRs).
 
-## Action Items
+**Each row MUST cite a filed GitHub issue number.** A bare bullet or a `TBD`/`(none)` placeholder is not allowed — file the issue first (`gh issue create`, cross-referencing the source PR in the body), then record its number here. An item with no `#NNNN` is shelf-ware that rots the moment the session ends; the `/ship` Incident-PIR gate blocks merge on any item that lacks an issue reference. If there are genuinely zero follow-ups, write exactly `_No action items — incident fully resolved in the source PR with no residual work._` (the only permitted no-item form).
 
-GitHub issues to file so this incident cannot recur (save logs, add tests, set up alerts, automation, documentation, PRs). May overlap with Follow-ups — keep one bullet per concern, cross-referenced, not duplicated.
-
-{{ACTION_ITEMS}}
+| Issue | Action | Status |
+|---|---|---|
+| #{{ACTION_ITEM_ISSUE}} | {{ACTION_ITEM_DESC}} | open |

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -814,22 +814,29 @@ git diff --name-only origin/main...HEAD | grep -E '^knowledge-base/engineering/o
 
 - **Match (a PIR was added/modified on this branch):** Pass *only after* confirming BOTH (1) frontmatter and (2) issue-backed action items:
   1. **Frontmatter** carries `brand_survival_threshold` and the Art. 33/34 fields (availability outages set both `false` with an `n/a` rationale; data-exposure incidents must evaluate the GDPR gate per `/soleur:incident` Phase 2).
-  2. **Every row of the merged `## Action Items & Follow-ups` table cites a `#NNNN` GitHub issue** — OR the section is exactly the permitted no-item sentence. A bare bullet, an unchecked `- [ ]` without `#NNNN`, or a `TBD`/`(none)` placeholder FAILS the gate (a follow-up with no issue rots the moment the session ends — the exact gap that left PR #5003's `workspace_path`/`workspace_status` sweep untracked until #5005 was filed retroactively). Detection:
+  2. The merged `## Action Items & Follow-ups` section is in exactly ONE of two valid shapes: (a) a table where **every item row cites a `#NNNN` GitHub issue in its first (Issue) cell**, or (b) the standalone permitted no-item sentence as a line of its own. Any other shape — a row with an empty Issue cell (even if it mentions `#NNNN` in prose elsewhere), a bare `- [ ]` bullet, free-form prose, an unfilled `#TBD`/placeholder, or an empty section — FAILS the gate (a follow-up with no issue rots the moment the session ends — the exact gap that left PR #5003's `workspace_path`/`workspace_status` sweep untracked until #5005 was filed retroactively). Detection (table-and-first-cell-anchored; `[[:space:]]` not `\s` for ugrep/BusyBox portability):
 
      ```bash
      PIR=$(git diff --name-only origin/main...HEAD | grep -E 'post-mortems/.+-postmortem\.md$' | head -n1)
      sec=$(awk '/^## Action Items & Follow-ups/{f=1;next} /^## /{f=0} f' "$PIR")
-     if printf '%s' "$sec" | grep -qF 'No action items — incident fully resolved'; then
-       : # permitted no-item form — pass
-     else
-       # item rows = table rows minus the header and the |---|---| divider
-       rows=$(printf '%s\n' "$sec" | grep -E '^\s*\|' \
-              | grep -vE '^\s*\|\s*Issue\s*\|' \
-              | grep -vE '^\s*\|[-:| ]+\|\s*$')
-       bad=$(printf '%s\n' "$rows" | grep -vE '#[0-9]+' | sed '/^[[:space:]]*$/d')
+     # Item rows = table rows minus the header (| Issue |) and the |---| divider.
+     rows=$(printf '%s\n' "$sec" | grep -E '^[[:space:]]*\|' \
+            | grep -vE '^[[:space:]]*\|[[:space:]]*Issue[[:space:]]*\|' \
+            | grep -vE '^[[:space:]]*\|[-:|[:space:]]+\|[[:space:]]*$')
+     rows=$(printf '%s\n' "$rows" | sed '/^[[:space:]]*$/d')
+     if [ -n "$rows" ]; then
+       # Shape (a): every item row MUST begin with a #NNNN Issue cell.
+       bad=$(printf '%s\n' "$rows" | grep -vE '^[[:space:]]*\|[[:space:]]*#[0-9]+[[:space:]]*\|')
        if [ -n "$bad" ]; then
-         echo "[FAIL] PIR Action Items & Follow-ups has rows with no #NNNN issue:" >&2
+         echo "[FAIL] PIR action-item rows without a #NNNN in the Issue cell:" >&2
          echo "$bad" >&2
+       fi
+     else
+       # No table rows → Shape (b): the standalone no-item sentence is the ONLY
+       # valid form. Anchored to start-of-line so the template's instructional
+       # prose ("…write exactly `_No action items …`") cannot satisfy it.
+       if ! printf '%s\n' "$sec" | grep -qE '^_No action items — incident fully resolved'; then
+         echo "[FAIL] PIR Action Items & Follow-ups has no issue-backed table and no permitted no-item sentence." >&2
        fi
      fi
      ```

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -812,10 +812,32 @@ Enforces the operator's standing rule — **every detected incident gets a post-
 git diff --name-only origin/main...HEAD | grep -E '^knowledge-base/engineering/operations/post-mortems/.+-postmortem\.md$'
 ```
 
-- **Match (a PIR was added/modified on this branch):** Pass. Confirm its frontmatter carries `brand_survival_threshold` and the Art. 33/34 fields (availability outages set both `false` with an `n/a` rationale; data-exposure incidents must evaluate the GDPR gate per `/soleur:incident` Phase 2).
+- **Match (a PIR was added/modified on this branch):** Pass *only after* confirming BOTH (1) frontmatter and (2) issue-backed action items:
+  1. **Frontmatter** carries `brand_survival_threshold` and the Art. 33/34 fields (availability outages set both `false` with an `n/a` rationale; data-exposure incidents must evaluate the GDPR gate per `/soleur:incident` Phase 2).
+  2. **Every row of the merged `## Action Items & Follow-ups` table cites a `#NNNN` GitHub issue** — OR the section is exactly the permitted no-item sentence. A bare bullet, an unchecked `- [ ]` without `#NNNN`, or a `TBD`/`(none)` placeholder FAILS the gate (a follow-up with no issue rots the moment the session ends — the exact gap that left PR #5003's `workspace_path`/`workspace_status` sweep untracked until #5005 was filed retroactively). Detection:
+
+     ```bash
+     PIR=$(git diff --name-only origin/main...HEAD | grep -E 'post-mortems/.+-postmortem\.md$' | head -n1)
+     sec=$(awk '/^## Action Items & Follow-ups/{f=1;next} /^## /{f=0} f' "$PIR")
+     if printf '%s' "$sec" | grep -qF 'No action items — incident fully resolved'; then
+       : # permitted no-item form — pass
+     else
+       # item rows = table rows minus the header and the |---|---| divider
+       rows=$(printf '%s\n' "$sec" | grep -E '^\s*\|' \
+              | grep -vE '^\s*\|\s*Issue\s*\|' \
+              | grep -vE '^\s*\|[-:| ]+\|\s*$')
+       bad=$(printf '%s\n' "$rows" | grep -vE '#[0-9]+' | sed '/^[[:space:]]*$/d')
+       if [ -n "$bad" ]; then
+         echo "[FAIL] PIR Action Items & Follow-ups has rows with no #NNNN issue:" >&2
+         echo "$bad" >&2
+       fi
+     fi
+     ```
+
+     If `bad` is non-empty: halt and require each unbacked item to be filed as a GitHub issue (cross-referencing the source PR) and its `#NNNN` recorded in the table, OR collapsed into the permitted no-item sentence when genuinely resolved. This applies in BOTH headless and interactive modes — file the issues, do not defer.
 - **No match:** the incident has no PIR. **Headless mode:** invoke `/soleur:incident` (or, if unavailable in the loaded plugin snapshot, author the PIR directly using `plugins/soleur/skills/incident/templates/pir.md` → `knowledge-base/engineering/operations/post-mortems/<slug>-postmortem.md`), commit it, then re-run the gate. **Interactive mode:** prompt — (a) run `/soleur:incident` now, (b) author the PIR inline, or (c) defer with a tracked `type/chore` issue carrying a `Re-eval by:` criterion AND the `deferred-automation` sentinel (only when the PIR genuinely needs data not yet available). Default-deny on "we'll write it later" with no tracked issue.
 
-**Also file the systemic follow-ups the PIR names** (alerting gaps, write-site sweeps) as their own issues — a PIR with `## Follow-ups` that never become issues is shelf-ware.
+**The merged `## Action Items & Follow-ups` table is the single home for residual work** (the former split `## Follow-ups` + `## Action Items` sections were consolidated so a concern cannot hide as a bare bullet in one while the issue-bearing list lives in the other). Each row's issue is filed BEFORE the row is written — a PIR whose follow-ups never become issues is shelf-ware.
 
 **If not triggered:** Skip silently (greenfield features, docs, refactors with no production-incident framing).
 


### PR DESCRIPTION
## Summary
Follow-up to PR #5003, which exposed two gaps: (1) its PIR left an untracked follow-up as a bare bullet, and (2) the PIR claimed the follow-up was "tracked by ADR-044's drift gate" — but that gate only covers the relocated *repo* columns, not `workspace_path`/`workspace_status`.

- **Merge the PIR template's split `## Follow-ups` + `## Action Items` into one `## Action Items & Follow-ups` table.** Every row MUST cite a filed GitHub issue (`#NNNN`); one permitted no-item sentence covers fully-resolved incidents.
- **Enforce it at the merge boundary:** `/ship`'s Incident-PIR gate now blocks on any action-item row lacking a `#NNNN` (mechanical grep check added).
- **Sync** incident `SKILL.md` placeholder map + `dry-run.sh` scaffold to the merged section.
- **Correct the PR #5003 PIR:** the `workspace_path`/`workspace_status` reader sweep is now tracked by **#5005**, with an explicit correction note about the ADR-044 drift-gate scope.

Ref #5005

## Changelog
- Incident PIRs now require a GitHub issue number for every action item / follow-up; the two sections are merged into one issue-backed table, enforced by the ship Incident-PIR gate.

## Test plan
- [x] `bun test plugins/soleur/test/components.test.ts` (1146 pass)
- [x] dry-run.sh syntax + shellcheck
- [x] ship-gate detection validated against the corrected PIR (PASS: all rows cite #NNNN)

Generated with [Claude Code](https://claude.com/claude-code)