### PR TITLE
fix(workspace-logo): rewrite proxy signed-URL host to public domain (CSP img-src block)

### DIFF
--- a/apps/web-platform/app/api/workspace/[id]/logo/route.ts
+++ b/apps/web-platform/app/api/workspace/[id]/logo/route.ts
@@ -89,10 +89,33 @@ export async function GET(
     return NextResponse.json({ error: "Bad gateway" }, { status: 502 });
   }
 
+  // The service client signs storage URLs against SUPABASE_URL, which in prod is
+  // the raw <ref>.supabase.co host. The browser's CSP img-src is built from
+  // NEXT_PUBLIC_SUPABASE_URL (the public custom domain), so a 302 to the raw host
+  // is BLOCKED by CSP → <img> onError → monogram (#4996 follow-up: the logo
+  // persisted + served fine, but the redirect host was not in img-src). Rewrite
+  // the origin to the public host so the redirect target matches img-src. Both
+  // hosts route to the same project and the signed token is host-agnostic.
+  let location = signed.data.signedUrl;
+  const publicBase = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (publicBase) {
+    try {
+      const signedUrl = new URL(signed.data.signedUrl);
+      const publicUrl = new URL(publicBase);
+      if (signedUrl.host !== publicUrl.host) {
+        signedUrl.protocol = publicUrl.protocol;
+        signedUrl.host = publicUrl.host;
+        location = signedUrl.toString();
+      }
+    } catch {
+      // Malformed URL on either side — fall back to the original signed URL.
+    }
+  }
+
   return new NextResponse(null, {
     status: 302,
     headers: {
-      Location: signed.data.signedUrl,
+      Location: location,
       "Cache-Control": `private, max-age=${SIGNED_TTL_SECONDS}`,
       "X-Content-Type-Options": "nosniff",
     },

--- a/apps/web-platform/test/workspace-logo-proxy-route.test.ts
+++ b/apps/web-platform/test/workspace-logo-proxy-route.test.ts
@@ -77,6 +77,30 @@ describe("GET /api/workspace/[id]/logo (AC6)", () => {
     expect(mockCreateSignedUrl).toHaveBeenCalledWith(`${WS}/logo.webp`, 300);
   });
 
+  it("rewrites the signed-URL host to NEXT_PUBLIC_SUPABASE_URL so the 302 target matches CSP img-src (#4996 follow-up)", async () => {
+    // The service client signs against SUPABASE_URL (the raw <ref>.supabase.co
+    // host in prod). CSP img-src is built from NEXT_PUBLIC_SUPABASE_URL (the
+    // public custom domain), so a 302 to the raw host is blocked by the browser
+    // → <img> onError → monogram. The proxy must rewrite the origin to the
+    // public host (token is host-agnostic; both hosts route to the same project).
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://public.soleur.test");
+    mockCreateSignedUrl.mockResolvedValue({
+      data: {
+        signedUrl:
+          "https://ifsccnjhymdmidffkzhl.supabase.co/storage/v1/object/sign/workspace-logos/x?token=abc",
+      },
+      error: null,
+    });
+    const res = await GET(req(), ctx());
+    expect(res.status).toBe(302);
+    const loc = res.headers.get("Location")!;
+    expect(new URL(loc).host).toBe("public.soleur.test");
+    // path + token preserved (only the origin is rewritten)
+    expect(loc).toContain("/storage/v1/object/sign/workspace-logos/x");
+    expect(loc).toContain("token=abc");
+    vi.unstubAllEnvs();
+  });
+
   it("502 + reportSilentFallback when signed-URL mint fails", async () => {
     mockCreateSignedUrl.mockResolvedValue({ data: null, error: { message: "mint failed" } });
     const res = await GET(req(), ctx());


### PR DESCRIPTION
## Summary
- The workspace logo still didn't display after PR #4996. Live diagnosis against prod proved the logo **persists and serves fine** — the bug is **read-side**: the proxy `GET /api/workspace/[id]/logo` 302-redirects the `<img>` to a host the browser's CSP refuses.

### Root cause (verified live, prod)
- `logo_path` is set (`754ee124…/logo.webp`), the storage object exists (17 KB webp), `createSignedUrl` works, and the signed URL serves **200 image/webp**.
- `createServiceClient` signs storage URLs against `SUPABASE_URL` = `https://ifsccnjhymdmidffkzhl.supabase.co` (the raw Supabase ref host).
- The browser CSP `img-src` is built from `NEXT_PUBLIC_SUPABASE_URL` = `https://api.soleur.ai` (the public custom domain): `img-src 'self' blob: data: https://api.soleur.ai`.
- So the proxy's 302 → `ifsccnjhymdmidffkzhl.supabase.co/storage/v1/...` is **blocked by CSP** → `<img onError>` → monogram. Both the settings card and the switcher use this proxy, so both showed the monogram.

### Fix
Rewrite the proxy's 302 Location origin to `NEXT_PUBLIC_SUPABASE_URL` (the exact host CSP `img-src` is built from). Both hosts route to the same project and the signed token is host-agnostic (verified: both serve 200), so the redirect target is now always CSP-allowed.

This corrects PR #4996's write-side "0-rows guard" hypothesis, which was a wrong localization (I substituted code-tracing for the plan-mandated live reproduction). The 0-rows guard is still a valid robustness improvement and stays.

## User-Brand Impact
- **Artifact:** the workspace logo rendered in settings + the top-left workspace switcher (proxy `/api/workspace/[id]/logo`).
- **Vector:** an uploaded logo that persists but never displays (always reverts to the monogram), because the proxy redirects to a host CSP blocks — the exact reported defect.
- **Brand-survival threshold:** single-user incident

## Changelog
### Web Platform
- Fix workspace logos never displaying: the proxy now redirects to the public Supabase domain (`NEXT_PUBLIC_SUPABASE_URL`) so the image passes CSP `img-src` instead of being blocked.

## Test plan
- [x] Regression test: proxy 302 Location host is rewritten to `NEXT_PUBLIC_SUPABASE_URL` (asserts host, preserves path + token)
- [x] `vitest run` proxy route suite green (7 passed); `tsc --noEmit` clean
- [x] Live prod verification: logo_path set, object present, signed URL serves 200 from both hosts — only the CSP host differed

Generated with [Claude Code](https://claude.com/claude-code)
