### PR TITLE
fix(web): lift collapsed-rail toggle higher (top-3) so it doesn't crowd the workspace logo

### DIFF
--- a/apps/web-platform/app/(dashboard)/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/layout.tsx
@@ -340,8 +340,11 @@ export default function DashboardLayout({
             -translate-x-1/2` centers it on the same vertical axis as the monogram tile
             and the icon-only nav column below, so the collapsed rail reads as one clean
             centered column (the right-3 corner control sat off-axis above the logo).
-            `top-10` (40px) vertically CENTERS the h-6 (24px) button on the
-            workspace pill row's center. The toggle is positioned against the <aside>,
+            Vertical: EXPANDED `top-10` (40px) vertically CENTERS the h-6 (24px) button
+            on the workspace pill row's center. COLLAPSED `top-3` pins it HIGH near the
+            rail top — there is no pill to center on, and at top-10 the button's bottom
+            edge (64px) landed flush with the monogram tile (pt-16 → 64px) and read as
+            crowding the logo; top-3 lifts it clear. The toggle is positioned against the <aside>,
             but the band (and its pill) sits ~12px BELOW the aside top (the reclaimed-
             space offset — VRT-measured, asserted ≤12). The pill leads the band at pt-2
             (8px) and is 64px tall (lg h-11 tile + py-2.5), so its center sits at
@@ -364,7 +367,7 @@ export default function DashboardLayout({
           onClick={toggleCollapsed}
           aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
           title={collapsed ? "Expand sidebar (⌘B)" : "Collapse sidebar (⌘B)"}
-          className={`absolute ${collapsed ? "left-1/2 -translate-x-1/2" : "right-3"} top-10 z-10 hidden h-6 w-6 items-center justify-center rounded text-soleur-text-muted hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary md:flex`}
+          className={`absolute ${collapsed ? "left-1/2 -translate-x-1/2 top-3" : "right-3 top-10"} z-10 hidden h-6 w-6 items-center justify-center rounded text-soleur-text-muted hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary md:flex`}
         >
           <PanelToggleIcon className="h-4 w-4" />
         </button>

--- a/apps/web-platform/test/dashboard-sidebar-collapse.test.tsx
+++ b/apps/web-platform/test/dashboard-sidebar-collapse.test.tsx
@@ -134,8 +134,11 @@ describe("Dashboard sidebar collapse", () => {
     expect(toggle.className).toContain("left-1/2");
     expect(toggle.className).toContain("-translate-x-1/2");
     expect(toggle.className).not.toContain("right-3");
-    // Vertical offset is unchanged — still top-10.
-    expect(toggle.className).toContain("top-10");
+    // Collapsed has no workspace pill to center on, so the toggle pins HIGH
+    // (top-3) near the rail top instead of top-10 — top-10 left its bottom edge
+    // flush with the monogram tile and read as "too close to the logo".
+    expect(toggle.className).toContain("top-3");
+    expect(toggle.className).not.toContain("top-10");
   });
 
   it("toggles aria-label when collapse toggle is clicked", async () => {


### PR DESCRIPTION
## Summary
- Follow-up to #5015 screenshot feedback: in the **collapsed** rail the floated collapse toggle was still too close to the workspace switcher/logo.
- Root cause: the toggle used `top-10` (tuned to vertically center on the *expanded* workspace pill). In the collapsed rail there is no pill, and the button's bottom edge (64px) landed flush with the monogram tile (`pt-16` → 64px), reading as crowding the logo.
- Fix: decouple the vertical offset — **collapsed pins high at `top-3`** near the rail top; **expanded keeps `top-10`** (the VRT-asserted pill-center alignment from #5015 is untouched). Horizontal centering (`left-1/2 -translate-x-1/2` collapsed / `right-3` expanded) is unchanged.

## Changelog
### Web Platform
- Collapsed sidebar: collapse toggle moved up to the rail top so it no longer sits flush against the workspace logo.

## Test plan
- [x] `dashboard-sidebar-collapse` + `theme-toggle` vitest green (31/31); collapsed-toggle test asserts `top-3` (not `top-10`)
- [x] `tsc --noEmit` clean
- [ ] Visual confirm in collapsed rail post-deploy

Generated with [Claude Code](https://claude.com/claude-code)