### PR TITLE
docs: deepagents portability scan (4th harness assessment)

### DIFF
--- a/knowledge-base/engineering/platform-portability-comparison.md
+++ b/knowledge-base/engineering/platform-portability-comparison.md
@@ -1,10 +1,11 @@
 ---
 title: "Platform Portability Comparison"
-last_updated: 2026-04-07
+last_updated: 2026-06-08
 platforms:
   - codex-cli
   - gemini-cli
   - openhands
+  - deepagents
 ---
 
 # Platform Portability Comparison
@@ -13,97 +14,100 @@ Unified comparison of Soleur portability across all analyzed agent platforms. Up
 
 ## Summary
 
-| Metric | Codex CLI | Gemini CLI | OpenHands |
-|---|---|---|---|
-| **Scan date** | 2026-03-10 | 2026-04-07 | 2026-04-07 |
-| **Platform version** | 0.113.0 | 0.36.0 | SDK 1.15.0 |
-| **Components scanned** | 122 | 129 | 129 |
-| **GREEN** (ports as-is) | 47.5% (58) | 54.3% (70) | 46.5% (60) |
-| **YELLOW** (needs adaptation) | 7.4% (9) | 45.0% (58) | 53.5% (69) |
-| **RED** (requires rewrite) | 43.4% (53) | 0.8% (1) | 0% (0) |
-| **Decision** | Wait and monitor | Conditional go | Conditional go |
-| **Issue** | #509 | #1738 | #1770 |
+| Metric | Codex CLI | Gemini CLI | OpenHands | deepagents |
+|---|---|---|---|---|
+| **Scan date** | 2026-03-10 | 2026-04-07 | 2026-04-07 | 2026-06-08 |
+| **Platform version** | 0.113.0 | 0.36.0 | SDK 1.15.0 | 0.6.8 + dcode |
+| **Components scanned** | 122 | 129 | 129 | 152 |
+| **GREEN** (ports as-is) | 47.5% (58) | 54.3% (70) | 46.5% (60) | 19.7% (30) |
+| **YELLOW** (needs adaptation) | 7.4% (9) | 45.0% (58) | 53.5% (69) | 80.3% (122) |
+| **RED** (requires rewrite) | 43.4% (53) | 0.8% (1) | 0% (0) | 0% (0) |
+| **Decision** | Wait and monitor | Conditional go | Conditional go | No-go (port) / conditional (rebuild) |
+| **Issue** | #509 | #1738 | #1770 | #5034 |
+
+**deepagents is the second zero-RED target but has the lowest GREEN% of any platform.** Every Soleur primitive has an equivalent (like OpenHands), yet GREEN drops to 19.7% because deepagents subagents are Python `SubAgent` dicts — there is no markdown-agent loader, so all 67 markdown agents flip to YELLOW. Skills port *better* than on any prior target (identical `SKILL.md` format). The OpenHands portability pattern inverts: agents expensive, skills cheap, no plugin distribution.
 
 ## Primitive Mapping
 
-| Claude Code Primitive | Codex CLI | Gemini CLI | OpenHands |
-|---|---|---|---|
-| AskUserQuestion | RED: no equivalent | GREEN: `ask_user` | YELLOW: freeform only |
-| TodoWrite / TaskCreate | RED: no equivalent | GREEN: `write_todos` | GREEN: `TaskTrackerTool` (plan/view) |
-| WebSearch | YELLOW: `web_search` flag | GREEN: `google_web_search` | GREEN: MCP bundled |
-| WebFetch | YELLOW: unclear | GREEN: `web_fetch` | GREEN: MCP bundled |
-| MCP tools | YELLOW: stdio only | GREEN: stdio + HTTP | GREEN: stdio + HTTP |
-| Task / Agent (subagent) | RED: no equivalent | YELLOW: single-level sequential | GREEN: multi-level parallel |
-| Skill tool (chaining) | RED: no equivalent | YELLOW: `activate_skill` (context) | YELLOW: context injection |
-| $ARGUMENTS | RED: no equivalent | YELLOW: commands only (`{{args}}`) | YELLOW: TaskTrigger `inputs` |
-| hookSpecificOutput | RED: no equivalent | RED: different protocol | GREEN: JSON `additionalContext` |
-| SessionStart/Stop hooks | RED: no equivalent | RED: no equivalent | GREEN: full lifecycle |
+| Claude Code Primitive | Codex CLI | Gemini CLI | OpenHands | deepagents |
+|---|---|---|---|---|
+| AskUserQuestion | RED: no equivalent | GREEN: `ask_user` | YELLOW: freeform only | YELLOW: HITL respond (no options) |
+| TodoWrite / TaskCreate | RED: no equivalent | GREEN: `write_todos` | GREEN: `TaskTrackerTool` | GREEN: `write_todos` (built-in) |
+| WebSearch | YELLOW: `web_search` flag | GREEN: `google_web_search` | GREEN: MCP bundled | YELLOW: BYO tool |
+| WebFetch | YELLOW: unclear | GREEN: `web_fetch` | GREEN: MCP bundled | YELLOW: BYO tool |
+| MCP tools | YELLOW: stdio only | GREEN: stdio + HTTP | GREEN: stdio + HTTP | GREEN: stdio+HTTP+SSE+WS (explicit wiring) |
+| Task / Agent (subagent) | RED: no equivalent | YELLOW: single-level sequential | GREEN: multi-level parallel | GREEN: parallel (Python dicts; nesting untested) |
+| Skill tool (chaining) | RED: no equivalent | YELLOW: `activate_skill` (context) | YELLOW: context injection | YELLOW: SkillsMiddleware (identical SKILL.md) |
+| $ARGUMENTS | RED: no equivalent | YELLOW: commands only (`{{args}}`) | YELLOW: TaskTrigger inputs | YELLOW: dcode `/skill` args only |
+| hookSpecificOutput | RED: no equivalent | RED: different protocol | GREEN: JSON additionalContext | GREEN: middleware (Python) |
+| SessionStart/Stop hooks | RED: no equivalent | RED: no equivalent | GREEN: full lifecycle | GREEN: before/after_agent + checkpointers |
+| Agent authoring format | Config YAML | Markdown (flat) | Markdown (flat) | **Python `SubAgent` dict** |
+| Plugin / distribution | None | None | Full (install/enable/disable) | None (Python pkg + skills dir) |
 
 ## Architecture Comparison
 
-| Capability | Codex CLI | Gemini CLI | OpenHands |
-|---|---|---|---|
-| Agent format | Config YAML (agents/openai.yaml) | `.gemini/agents/*.md` (flat) | `.agents/agents/*.md` (flat) |
-| Skill format | SKILL.md (same frontmatter) | SKILL.md (same frontmatter) | SKILL.md (same frontmatter) |
-| Agent discovery | Config-based registration | Flat directory scan | Flat directory scan |
-| Subagent nesting | None (max_depth=1) | Single-level only | Multi-level (unlimited documented) |
-| Subagent parallelism | N/A | Sequential only | Parallel threads |
-| Hook system | SessionStart (feature request) | Post-hoc only (notify) | Full lifecycle (6 event types) |
-| Plugin system | None | None | Full (install/enable/disable/uninstall) |
-| Model support | OpenAI models only | Gemini models only | Any LLM (Claude, GPT, Gemini, open-source) |
-| Execution sandbox | None | None (direct shell) | Docker sandbox (optional) |
-| Per-agent tool scoping | No | No | Yes (tools field in frontmatter) |
-| Per-agent hooks | No | No | Yes (hooks field in frontmatter) |
-| Per-agent MCP | No | No | Yes (mcp_servers field in frontmatter) |
+| Capability | Codex CLI | Gemini CLI | OpenHands | deepagents |
+|---|---|---|---|---|
+| Agent format | Config YAML | `.gemini/agents/*.md` | `.agents/agents/*.md` | Python `SubAgent` TypedDict |
+| Skill format | SKILL.md | SKILL.md | SKILL.md | SKILL.md (progressive disclosure) |
+| Agent discovery | Config registration | Flat dir scan | Flat dir scan | Python (passed to `create_deep_agent`) |
+| Subagent nesting | None | Single-level | Multi-level | Multi-level (not prevented; untested) |
+| Subagent parallelism | N/A | Sequential | Parallel | Parallel |
+| Hook system | SessionStart (request) | Post-hoc only | Full lifecycle (6 events) | LangGraph middleware (Python) |
+| Plugin system | None | None | Full | None (skills dir only) |
+| Model support | OpenAI only | Gemini only | Any LLM | Any LangChain chat model |
+| Execution sandbox | None | None (direct shell) | Docker | Remote sandbox backends (optional) |
+| Persistence | None | None | Docker state | Durable checkpointers (Postgres/Redis) |
+| Per-agent tool scoping | No | No | Yes | Yes (`tools` on SubAgent) |
+| Per-agent hooks | No | No | Yes | Yes (`middleware` on SubAgent) |
+| Per-agent MCP | No | No | Yes | Yes (via tools) |
+| Operator harness | CLI | CLI | CLI + SDK | SDK + dcode CLI (young) |
 
 ## Platform Strengths
 
 ### Codex CLI
-
 - Identical SKILL.md format (zero content changes for green skills)
 - Growing ecosystem backed by OpenAI
 
 ### Gemini CLI
-
 - Best developer UX primitives (`ask_user`, `write_todos` — direct equivalents)
 - Highest GREEN percentage (54.3%)
 - Command argument interpolation (`{{args}}` in TOML)
 - Unlimited skill chaining depth (context injection)
 
 ### OpenHands
+- First zero-RED target; multi-level parallel subagents preserve the domain-leader hierarchy as markdown
+- Full lifecycle hook system + full plugin system (install/enable/disable)
+- Model-agnostic; Docker sandbox; per-agent scoping
+- AgentDefinition is a superset of Soleur's markdown format (cheapest mechanical port)
 
-- Only platform with 0% RED (zero blockers)
-- Multi-level parallel subagent support (preserves domain leader architecture)
-- Full lifecycle hook system (PreToolUse, PostToolUse, Stop, SessionStart, SessionEnd)
-- Plugin system with install/enable/disable/uninstall
-- Model-agnostic (Claude, GPT, Gemini, open-source)
-- Per-agent tool scoping, hooks, and MCP configuration
-- AgentDefinition is a superset of Soleur's format (gains features on port)
-- Docker sandbox for security isolation
+### deepagents
+- Second zero-RED target; every primitive has an equivalent
+- **Identical SKILL.md format** — skills port better than any prior target
+- **Built-in `write_todos`** (only OpenHands lacked it)
+- **True model-agnosticism** — any LangChain chat model (the #1 differentiator)
+- **Durable checkpointer persistence** (Postgres/Redis) — strongest of any target; ideal for a server-side runtime
+- **Now a real harness** (`dcode`), explicitly modeled on Claude Code
+- MIT, ~24k★, LangChain Inc.-backed, frequent releases; LangSmith observability
 
 ## Platform Weaknesses
 
 ### Codex CLI
-
-- 43.4% RED — 4 fundamental blockers with no equivalent
-- No hooks, no subagent delegation, no plugin system
-- Verdict: not viable without major platform changes
+- 43.4% RED — 4 fundamental blockers; not viable without major platform changes
 
 ### Gemini CLI
-
-- Single-level subagent nesting (breaks domain leader hierarchy)
-- Sequential-only agent execution (no parallelism)
-- No hook system (post-hoc only)
-- No plugin system (manual file distribution)
-- Flat agent directory (no subdirectory organization)
+- Single-level sequential subagents (breaks domain-leader hierarchy); no hooks; no plugin system; flat agent dir
 
 ### OpenHands
+- No structured user prompts; skills are context-injection only; flat agent directory; young plugin ecosystem
 
-- No structured user prompts (no `ask_user` equivalent)
-- Skills are context injection only (no programmatic invocation with args)
-- Flat agent directory (no subdirectory organization)
-- Docker sandbox may limit host-level operations
-- Young plugin ecosystem (no public registry)
+### deepagents
+- **Lowest GREEN% (19.7%)** — all 67 agents require markdown→Python rewrite (no markdown-agent loader)
+- **No plugin/distribution system** — ship as Python package + skills dir; no enable/disable/marketplace (worse than OpenHands)
+- No structured user prompts (HITL respond only)
+- Bash hooks must be rewritten as Python middleware
+- `dcode` harness is young (v0.1.0, packaging churn); long-pipeline maturity unverified
+- MCP requires explicit Python wiring (no `.mcp.json` auto-load)
 
 ## Investment Triggers
 
@@ -111,7 +115,10 @@ Unified comparison of Soleur portability across all analyzed agent platforms. Up
 |---|---|---|
 | Codex CLI | Wait for: PreToolUse hooks, subagent delegation | N/A (not viable today) |
 | Gemini CLI | Any of: Anthropic restricts Max plan, API rate limits, competitor ships multi-harness, Gemini adds multi-level subagents | 1-2 weeks (degraded pipeline) |
-| OpenHands | Any of: open-source demand, model flexibility need, enterprise sandbox requirement, Gemini port done first, OpenHands adds ask_user | 1-2 weeks (degraded pipeline) |
+| OpenHands | Any of: open-source demand, model flexibility, enterprise sandbox, Gemini port done first, OpenHands adds ask_user | 1-2 weeks (degraded pipeline) |
+| deepagents | Any of: hard model-agnosticism requirement, server-side durable runtime greenlit, LangGraph/LangSmith adopted in stack, skills-as-product, dcode matures past v0.1.0 | Skills-only 1-2 wk; full port 6-10 wk (not recommended); server-side rebuild = separate initiative |
+
+**Harness redundancy → OpenHands. Model-agnosticism / server-side durable runtime → deepagents.** They serve different goals; deepagents is not a cheaper OpenHands.
 
 ## Source Inventories
 
@@ -120,3 +127,6 @@ Unified comparison of Soleur portability across all analyzed agent platforms. Up
 - OpenHands: `knowledge-base/project/specs/openhands-portability/inventory.md`
 - OpenHands PoC: `knowledge-base/project/specs/openhands-portability/poc-results.md`
 - Gemini CLI PoC: `knowledge-base/project/specs/gemini-cli-portability/poc-results.md`
+- deepagents: `knowledge-base/project/specs/feat-deepagents-portability/inventory.md`
+- deepagents recommendation: `knowledge-base/project/specs/feat-deepagents-portability/recommendation.md`
+- deepagents critical unknowns: `knowledge-base/project/specs/feat-deepagents-portability/critical-unknowns.md`

--- a/knowledge-base/project/brainstorms/2026-06-08-deepagents-portability-brainstorm.md
+++ b/knowledge-base/project/brainstorms/2026-06-08-deepagents-portability-brainstorm.md
@@ -1,0 +1,69 @@
+---
+title: "deepagents (LangChain) Portability Brainstorm"
+date: 2026-06-08
+issue: 5034
+lane: single-domain
+brand_survival_threshold: not-applicable
+status: complete
+---
+
+# deepagents Portability Brainstorm
+
+## What We're Exploring
+
+Whether `langchain-ai/deepagents` could replace the Claude Code harness for Soleur — the fourth platform portability scan after Codex CLI (#509), Gemini CLI (#1738), and OpenHands (#1770). Deliverable mirrors the OpenHands experiment: inventory, primitive-mapping, GREEN/YELLOW/RED classification, critical unknowns, go/no-go recommendation, and a 4th column on `platform-portability-comparison.md`.
+
+## Premise Correction (caught during research)
+
+The brief framed deepagents as "a LangChain library, a different architectural category from the interactive harnesses." **Research invalidated that premise.** As of v0.6.8 (2026-06-03), deepagents ships `deepagents-code` / `dcode` — an interactive terminal harness self-described as *"similar to Claude Code or Cursor,"* and the repo tagline is *"the batteries-included agent harness."* deepagents is now a genuine OpenHands-class peer (SDK + harness), explicitly inspired by Claude Code. The scan proceeded on that corrected framing.
+
+## Key Findings
+
+| Dimension | Result |
+|---|---|
+| Components scanned | 152 (67 agents, 82 skills, 3 commands) |
+| GREEN / YELLOW / RED | 19.7% (30) / 80.3% (122) / 0% |
+| Zero-RED? | Yes — second target after OpenHands; every primitive has an equivalent |
+| GREEN% rank | **Lowest of all four platforms** |
+
+**The defining fact:** deepagents subagents are Python `SubAgent` TypedDicts; there is **no markdown-agent loader**. All 67 markdown agents flip from GREEN (markdown→markdown on OpenHands) to YELLOW (markdown→Python rewrite). Prose ports verbatim into `system_prompt`, so it's mechanical, but it's 67 rewrites + 5 bash-hook rewrites. Conversely, **skills port better than on any prior target** — `SkillsMiddleware` reads the identical `SKILL.md` + frontmatter + 3-level progressive disclosure. The OpenHands pattern inverts: agents expensive, skills cheap, no plugin distribution.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Verdict (mechanical port) | **NO-GO** | 67 Python agent rewrites + 5 hook rewrites + no plugin distribution → 6-10 wk for a worse outcome than OpenHands' 1-2 wk |
+| Verdict (strategic rebuild) | **CONDITIONAL-GO** | deepagents is the strongest target for model-agnosticism + durable server-side runtime |
+| Recommended play | **Hybrid, not replacement** | Port skills (GREEN) as a server-side skill-execution runtime; keep agent orchestration on Claude Code |
+| Harness redundancy goal | **Use OpenHands, not deepagents** | OpenHands keeps agents markdown + has a plugin system at a fraction of the cost |
+| Deliverable depth | Full inventory + recommendation + critical-unknowns + 4th comparison column | Operator chose full scope |
+
+## Why This Approach
+
+deepagents is **expensive to port but the most strategically valuable destination**. Its differentiators — true model-agnosticism (any LangChain chat model), durable checkpointer persistence (Postgres/Redis), MIT + 24k★ LangChain backing, and a now-real harness — are exactly what a *server-side, model-agnostic agent runtime* needs. That ties to existing Soleur work (`2026-05-05-feat-soleur-server-side-agentic-runtime-plan.md`, ADR-030 Inngest durable trigger layer) surfaced during research. So the value is not "same Soleur on a different CLI" (OpenHands wins that) but "Soleur unbound from Claude, durably persisted server-side."
+
+## Open Questions (→ critical-unknowns.md)
+
+1. **dcode harness maturity** — can the v0.1.0 CLI run Soleur's long multi-step pipelines? (HIGH)
+2. **Subagent nesting depth** — multi-level in practice, or one level? (MEDIUM)
+3. **Structured-prompt absence** — real impact on brainstorm/plan/ship gates (HITL respond only). (MEDIUM)
+4. **Skill arg injection** — does dcode `/skill args` substitute into SKILL.md body? (MEDIUM)
+5. **Shell-hook → middleware parity** — deny-with-feedback via `wrap_tool_call`? (MEDIUM)
+6. **Plugin/distribution packaging** — how to ship 152 components as one installable unit? (MEDIUM)
+
+## Domain Assessments
+
+**Assessed:** Engineering (CTO lens)
+
+### Engineering
+
+**Summary:** Internal-infra/research assessment, synthesized directly with cited deepagents research rather than spawning the leader fan-out (no user-facing surface, no credential/data/billing axis → `USER_BRAND_CRITICAL=false`, lane=single-domain). Engineering verdict: deepagents is architecturally sound and zero-RED, but the markdown→Python agent rewrite and missing plugin-distribution layer make it a poor mechanical port and a strong strategic-rebuild candidate. Recommend hybrid (skills port + server-side runtime), gate on model-agnosticism / durable-runtime triggers, and resolve U1/U3/U6 via PoC before any scope beyond skills-only.
+
+## Effort Summary
+
+| Scope | Effort |
+|---|---|
+| Skills-only port (29 GREEN + ~20 light-YELLOW) | 1-2 wk |
+| GREEN skills + 43 prose agents (bulk-scripted) | 2-3 wk |
+| Full harness parity | 6-10 wk (not recommended) |
+| Server-side runtime (greenfield) | Separate initiative |

--- a/knowledge-base/project/learnings/2026-06-08-portability-scan-reverify-target-architecture-and-carrier-format-drives-green.md
+++ b/knowledge-base/project/learnings/2026-06-08-portability-scan-reverify-target-architecture-and-carrier-format-drives-green.md
@@ -1,0 +1,47 @@
+---
+title: Portability Scans — Re-verify Target Architecture and Watch the Agent Carrier Format
+date: 2026-06-08
+category: engineering
+tags: [implementation-patterns, plugin-architecture, portability]
+issue: 5034
+---
+
+# Learning: Portability Scans Must Re-verify the Target's Current Architecture, and GREEN% Is Driven by Agent Carrier Format
+
+## Problem
+
+Running the fourth platform portability scan (`deepagents`, after Codex CLI #509, Gemini CLI #1738, OpenHands #1770). Two assumptions baked into the brief would have produced a wrong analysis if accepted:
+
+1. **Stale category framing.** The brief framed deepagents as "a LangChain *library*, a different architectural category from the interactive harnesses." That was true at some earlier snapshot but false by 2026-06: deepagents v0.6.8 had shipped `deepagents-code`/`dcode`, an interactive terminal harness self-described as *"similar to Claude Code,"* with the repo tagline *"the batteries-included agent harness."* Had the scan accepted the "library, different category" premise, it would have under-scoped deepagents as a non-harness and skipped the harness-level comparison entirely.
+
+2. **Implicit "zero-RED ≈ cheap port" assumption.** OpenHands was zero-RED and cheap to port (1-2 wk). The natural prior is that another zero-RED target is similarly cheap. False.
+
+## Solution
+
+Two methodology rules for the next portability scan:
+
+### Rule 1 — Re-verify the target's current architecture before scanning; a platform's *category* can change between assessments.
+
+A platform analyzed N months ago may have crossed the library↔harness boundary, gained/lost a plugin system, or added a structured-prompt primitive. Always WebFetch the current README + version + docs index FIRST and re-confirm the category, not just the per-primitive equivalents. The premise-correction is cheap (one fetch) and load-bearing — it determines whether you scan against an SDK, a harness, or both.
+
+### Rule 2 — GREEN% is governed by the agent *carrier format*, not by primitive coverage. Zero-RED ≠ cheap port.
+
+deepagents is the second zero-RED target (every Soleur primitive has an equivalent) yet has the **lowest GREEN% of any platform** (19.7% vs OpenHands' 46.5%). The entire delta is one fact: deepagents subagents are **Python `SubAgent` dicts** and there is **no markdown-agent loader**, so all 67 markdown agents flip GREEN→YELLOW (carrier rewrite), even though their prose system prompts port verbatim. Meanwhile skills port *better* than on any prior target because the `SKILL.md` carrier is identical.
+
+**The classification driver is: does the target read the same carrier file (markdown agent / SKILL.md), or must the component be re-authored in another language/format?** Primitive coverage (does `task`/`write_todos`/MCP exist?) determines RED-vs-not; carrier format determines GREEN-vs-YELLOW. Separate the two axes explicitly in the inventory, or you will conflate "every capability exists" with "everything ports cheaply."
+
+Corollary: report the verdict **by goal**, not as a single go/no-go. deepagents is no-go for a mechanical port (carrier rewrite + no plugin distribution → 6-10 wk) but conditional-go for a strategic rebuild (model-agnostic, durable checkpointer persistence). OpenHands wins harness-redundancy; deepagents wins model-agnosticism. A single verdict hides this.
+
+## Key Insight
+
+When the prior scans all share a property (markdown agents → GREEN), that property becomes an invisible assumption. The first target that breaks it (Python-dict agents) tanks GREEN% without adding a single RED. Audit the *carrier format* as a first-class primitive row in the mapping table — this scan added an explicit "Agent authoring format" row, which is the row that explains the whole result.
+
+## Session Errors
+
+1. **Stale "different category" premise in the brief.** Recovery: WebFetch'd the deepagents README/docs first (per brainstorm Phase 1.0 external-platform verification), discovered `dcode`, corrected the framing before classifying. Prevention: Rule 1 above — re-verify target architecture every scan.
+2. **`platform-portability-comparison.md` edit failed "file not read."** Read the bare-root copy at session start, then edited the worktree copy — different tracked path (`hr-when-in-a-worktree-never-read-from-bare`). Recovery: Read the worktree copy first. Prevention: after worktree creation, all reads/edits use the worktree path; never carry a bare-root Read into a worktree Edit.
+
+## Tags
+
+category: implementation-patterns
+module: plugin-architecture

--- a/knowledge-base/project/specs/feat-deepagents-portability/critical-unknowns.md
+++ b/knowledge-base/project/specs/feat-deepagents-portability/critical-unknowns.md
@@ -1,0 +1,80 @@
+---
+title: "deepagents Portability — Critical Unknowns"
+date: 2026-06-08
+issue: 5034
+confidence: "docs-only — items below require a PoC to verify before any investment decision"
+---
+
+# deepagents Critical Unknowns
+
+These are flagged **docs-only confidence**. The inventory and recommendation are sound on the architecture-level facts (Python subagents, identical SKILL.md, built-in write_todos, checkpointers, no plugin system — all source-verified). The items below could each shift the effort estimate or the verdict and must be resolved by a proof-of-concept before committing.
+
+## U1 — dcode harness maturity (HIGH impact)
+
+**Unknown:** Can `deepagents-code` / `dcode` reliably run Soleur's long, multi-step pipelines (go→brainstorm→plan→work→review→ship, 10+ tool turns, parallel subagent fan-out)?
+
+**Why it matters:** The CLI is at v0.1.0 with documented packaging churn (the REPL was split out of `deepagents-cli` into `deepagents-code`). The recommendation's "now a real harness" framing depends on this. If dcode can't sustain long pipelines, the only viable surface is the SDK with a self-built operator UX — raising effort.
+
+**PoC:** Run a 5-turn skill chain + a 2-level subagent fan-out under `dcode` and observe stability, context handling, and HITL behavior.
+
+## U2 — Subagent nesting depth (MEDIUM impact)
+
+**Unknown:** Does `SubAgentMiddleware` support multi-level nesting (domain leader → specialist → sub-specialist) in practice, or only one level?
+
+**Why it matters:** Research found nesting is "not prevented in code" but "theoretically possible / unverified." Soleur's domain leaders (cmo with 11 specialists) assume at least 2 levels. If nesting is unsupported/unstable, the hierarchy flattens (closer to the Gemini CLI degradation).
+
+**PoC:** Spawn a subagent that itself spawns a subagent via `task`; confirm isolation and result propagation.
+
+## U3 — Structured-prompt absence — real impact on gates (MEDIUM impact)
+
+**Unknown:** Is there *any* options-list schema in `HumanInTheLoopMiddleware`, or strictly approve/edit/reject/respond + free text?
+
+**Why it matters:** 31 components use AskUserQuestion. If only freeform `respond` exists, Soleur's routing/approval gates (go, brainstorm, plan, ship) degrade to natural-language parsing. Workaround viability was rated HIGH for OpenHands under the same constraint, but it should be confirmed for deepagents' resume/`Command(resume=...)` flow.
+
+**PoC:** Implement one brainstorm-style multi-option gate via `respond` and measure routing reliability.
+
+## U4 — Skill argument injection semantics (MEDIUM impact)
+
+**Unknown:** Does `dcode` `/skill:<name> [args]` perform `$ARGUMENTS`-style substitution into the SKILL.md body, or merely prepend the args as a user message?
+
+**Why it matters:** 30+ skills/commands pass arguments. The substitution model determines whether arg-dependent skills (fix-issue, drain-labeled-backlog, flag-set-role) port cleanly or need rework.
+
+**PoC:** Invoke a skill that references a positional arg in its body and inspect how args reach the model.
+
+## U5 — Shell-hook → middleware parity for deny-with-feedback (MEDIUM impact)
+
+**Unknown:** Does `wrap_tool_call` middleware reproduce Soleur's hook pattern of *blocking a tool call with exit code 2 and surfacing a reason to the model* (guardrails.sh, worktree-write-guard.sh)?
+
+**Why it matters:** Soleur's safety rails (never-git-stash, worktree-write-guard, pre-merge-rebase) are PreToolUse bash hooks that deny + explain. The middleware must support raising/short-circuiting a tool call AND returning a model-visible reason, not just observing.
+
+**PoC:** Port `worktree-write-guard.sh` to a `wrap_tool_call` middleware that blocks a write and returns a correction message; confirm the model sees and acts on it.
+
+## U6 — Plugin/distribution packaging story (MEDIUM impact)
+
+**Unknown:** What is the canonical way to ship a large bundle (67 agents + 82 skills + middleware) as an installable, versioned unit a third party can `enable`/`disable`?
+
+**Why it matters:** deepagents has no plugin manifest. Best current guess: a Python package (agents/middleware) + a `skills/` directory. There is no enable/disable/uninstall lifecycle. This affects how Soleur would distribute — and whether a "Soleur on deepagents" product is even shippable as one artifact.
+
+**PoC:** Package the 29 GREEN skills as a pip-installable `skills/` provider and consume it from a fresh deepagents project.
+
+## U7 — MCP wiring at scale (LOW impact)
+
+**Unknown:** Operational overhead of replacing `.mcp.json` auto-load with explicit `MultiServerMCPClient` wiring for Soleur's MCP servers (Context7, Cloudflare, Stripe, Supabase, Pencil, Playwright, Linear).
+
+**Why it matters:** Capability is GREEN, but per-server Python wiring + auth handling for ~8 servers adds boilerplate and an auth-refresh story (some servers are interactively authenticated).
+
+**PoC:** Wire 2 MCP servers (one stdio, one HTTP) via `MultiServerMCPClient` and confirm tool availability inside a subagent.
+
+## U8 — Cost / token profile of durable checkpointing (LOW impact)
+
+**Unknown:** Token/latency/storage cost of checkpointing state every superstep over Soleur's long pipelines.
+
+**Why it matters:** Durable persistence is a strength, but checkpoint-every-superstep on 10+ turn pipelines with large context could be expensive. Needs measurement before a server-side runtime commit.
+
+**PoC:** Run a representative pipeline with a Postgres checkpointer and measure storage growth + latency overhead.
+
+---
+
+## Resolution gate
+
+Do not advance past the **skills-only** scope (1–2 wk, lowest risk) until U1, U3, and U6 are resolved — they gate whether a fuller migration is viable at all. U2/U4/U5 gate the agent-and-pipeline scope. U7/U8 gate the server-side-runtime scope.

--- a/knowledge-base/project/specs/feat-deepagents-portability/inventory.md
+++ b/knowledge-base/project/specs/feat-deepagents-portability/inventory.md
@@ -1,0 +1,338 @@
+---
+title: "deepagents Portability Inventory"
+date: 2026-06-08
+issue: 5034
+deepagents_version: "deepagents 0.6.8 (PyPI, 2026-06-03); deepagents-code / dcode CLI; docs.langchain.com/oss/python/deepagents, accessed 2026-06-08"
+methodology: "Grep-based scan for Claude Code-specific primitives across the live repo (152 components), classified against deepagents/LangGraph equivalents. Reclassification rule: agents flip to YELLOW because deepagents subagents are Python dicts (no markdown-agent loader); skills stay GREEN unless they depend on a degraded primitive (ASK, SKILL-chaining, ARGS, HOOK)."
+---
+
+# deepagents Portability Inventory
+
+## Framing correction (vs the original assumption)
+
+The prior three targets (Codex CLI, Gemini CLI, OpenHands) were framed as interactive harnesses and deepagents as "just a LangChain library, different category." **That framing is outdated as of 2026.** deepagents v0.6.8 ships `deepagents-code` (command `dcode`) — an interactive terminal coding agent the README self-describes as *"similar to Claude Code or Cursor,"* and the repo tagline is now *"the batteries-included agent harness."* deepagents is therefore a genuine OpenHands-class peer: a Python SDK **and** an operator-facing harness, explicitly inspired by Claude Code's architecture and generalizing it across model providers.
+
+This inventory treats deepagents as a harness candidate and classifies against both the SDK and the `dcode` CLI.
+
+## Summary Statistics
+
+| Classification | Count | Percentage | Description |
+|---|---|---|---|
+| GREEN | 30 | 19.7% | Ports as-is (skill `SKILL.md` format identical; tool names differ but semantics match) |
+| YELLOW | 122 | 80.3% | Needs adaptation — agents rewrite from markdown to Python `SubAgent` dicts; skills using degraded primitives (ASK/SKILL-chain/ARGS) lose fidelity |
+| RED | 0 | 0% | — (no component is unportable; every primitive has an equivalent) |
+| **Total** | **152** | **100%** | |
+
+**By component type:**
+
+| Type | Green | Yellow | Red | Total |
+|---|---|---|---|---|
+| Agents | 0 (0%) | 67 (100%) | 0 | 67 |
+| Skills | 29 (35.4%) | 53 (64.6%) | 0 | 82 |
+| Commands | 1 (33.3%) | 2 (66.7%) | 0 | 3 |
+
+**Four-way comparison:**
+
+| Classification | Codex CLI (2026-03-10) | Gemini CLI (2026-04-07) | OpenHands (2026-04-07) | deepagents (2026-06-08) |
+|---|---|---|---|---|
+| GREEN | 47.5% (58/122) | 54.3% (70/129) | 46.5% (60/129) | **19.7% (30/152)** |
+| YELLOW | 7.4% (9/122) | 45.0% (58/129) | 53.5% (69/129) | **80.3% (122/152)** |
+| RED | 43.4% (53/122) | 0.8% (1/129) | 0% (0/129) | **0% (0/152)** |
+| Blockers with no equivalent | 4 | 1 | 0 | 0 |
+| Subagent support | None | Single-level only | Multi-level + parallel | Multi-level (untested) + parallel |
+| Agent authoring format | Config YAML | Markdown (flat) | Markdown (flat) | **Python `SubAgent` dict** |
+| Skill authoring format | SKILL.md | SKILL.md | SKILL.md | **SKILL.md (identical, progressive disclosure)** |
+| Plugin/distribution system | None | None | Full (install/enable/disable) | **None (skills dir only)** |
+
+**Key insight — the pattern inverts OpenHands.** deepagents is the *second* zero-RED target (every Soleur primitive has at least a partial equivalent) yet has the **lowest GREEN% of any platform analyzed** (19.7%). The reason is a single architectural fact: deepagents subagents are **Python `SubAgent` TypedDicts**, and there is no markdown-agent loader. So all 67 of Soleur's markdown agents — including the entire domain-leader hierarchy — flip from GREEN (markdown→markdown on OpenHands) to YELLOW (markdown→Python rewrite). Conversely, deepagents `SkillsMiddleware` reads the **identical** `SKILL.md` + YAML-frontmatter + 3-level progressive-disclosure format, so skills port *better* than on OpenHands (where they were context-injection YELLOW).
+
+**Net:** OpenHands = cheap-port-friendly (agents stay markdown, full plugin system). deepagents = expensive-port (agent rewrite + no plugin distribution) but **strongest strategic upside** (model-agnostic, durable persistence, MIT, 24k★ LangChain-backed).
+
+## Primitive Mapping
+
+| Claude Code Primitive | deepagents Equivalent | Classification | Delta vs OpenHands |
+|---|---|---|---|
+| AskUserQuestion | `HumanInTheLoopMiddleware` via `interrupt_on={tool: ...}` — decisions: approve / edit / reject / **respond** (free text). No structured multi-choice option set. Requires a checkpointer. | YELLOW | Same (both lack structured prompts) |
+| TodoWrite / TaskCreate | `write_todos` tool via `TodoListMiddleware` — **built-in, default, 1:1** | GREEN | **Better** (OH had no equivalent → was YELLOW) |
+| WebSearch | BYO tool (`tools=[tavily_tool]` etc.) — not built-in | YELLOW (GREEN-with-config) | Slightly worse (OH bundled via MCP) |
+| WebFetch | BYO tool — not built-in | YELLOW (GREEN-with-config) | Slightly worse |
+| MCP tools (mcp__*) | `langchain-mcp-adapters` `MultiServerMCPClient` — stdio + HTTP + SSE + WebSocket; `tools=client.get_tools()`. Explicit Python wiring (no `.mcp.json` auto-load). | GREEN | Same capability; worse ergonomics (no zero-config) |
+| Task / Agent (subagent) | `task` tool via `SubAgentMiddleware` — parallel, context-isolated (`messages`/`todos`/`structured_response` filtered out of subagent state). Subagents defined as **Python `SubAgent` dicts**. | GREEN (capability) | Same parallelism; **worse authoring** (Python vs markdown) |
+| Skill tool (chaining) | `SkillsMiddleware` — markdown `SKILL.md` + frontmatter, 3-level progressive disclosure. Model-driven activation; no programmatic mid-run invocation. | YELLOW | **Better format** (identical SKILL.md) but same chaining limit |
+| $ARGUMENTS | `dcode` `/skill:<name> [args]` (CLI only). No SDK-level string interpolation into SKILL.md body. | YELLOW | Same |
+| hookSpecificOutput | LangGraph middleware (`wrap_tool_call`, `before/after_model`) — inject context via state. **Python classes, not declarative shell hooks.** | GREEN (Python) | Same/better capability; worse for shell-based hooks |
+| SessionStart / Stop hooks | `before_agent` / `after_agent` (run-scoped) + **durable checkpointers** (Postgres/Redis) for cross-session recall | GREEN | **Better** (durable persistence > CC + OH) |
+| **Agent authoring format** (new dimension) | Python `SubAgent` TypedDict (`name`/`description`/`system_prompt`/`tools`/`model`/`middleware`). **No markdown-agent loader.** | YELLOW (drives all 67 agents) | **Worse** (OH read markdown agents) |
+
+---
+
+## Agents (67) — all YELLOW
+
+deepagents has no markdown-agent loader; agents are Python `SubAgent` dicts. Every agent requires a carrier rewrite (markdown → `SubAgent(name=…, description=…, system_prompt=…)`). The **prose body ports verbatim** into `system_prompt`, so the conversion is mechanical for prose-only agents and scriptable in bulk. Agents that additionally reference ASK/TASK/MCP/WEB need primitive-level adaptation on top.
+
+### YELLOW-mechanical (43) — prose-only, pure carrier rewrite (scriptable in bulk)
+
+| Agent | Domain | Adaptation |
+|---|---|---|
+| cto | engineering | wrap body in SubAgent dict |
+| ddd-architect | engineering/design | wrap |
+| infra-security | engineering/infra | wrap (MCP refs → client wiring if any) |
+| platform-strategist | engineering/infra | wrap |
+| terraform-architect | engineering/infra | wrap |
+| best-practices-researcher | engineering/research | wrap |
+| framework-docs-researcher | engineering/research | wrap |
+| git-history-analyzer | engineering/research | wrap |
+| learnings-researcher | engineering/research | wrap |
+| repo-research-analyst | engineering/research | wrap |
+| architecture-strategist | engineering/review | wrap |
+| code-quality-analyst | engineering/review | wrap |
+| code-simplicity-reviewer | engineering/review | wrap |
+| data-integrity-guardian | engineering/review | wrap |
+| data-migration-expert | engineering/review | wrap |
+| deployment-verification-agent | engineering/review | wrap |
+| dhh-rails-reviewer | engineering/review | wrap |
+| kieran-rails-reviewer | engineering/review | wrap |
+| legacy-code-expert | engineering/review | wrap |
+| observability-coverage-reviewer | engineering/review | wrap |
+| pattern-recognition-specialist | engineering/review | wrap |
+| performance-oracle | engineering/review | wrap |
+| security-sentinel | engineering/review | wrap |
+| test-design-reviewer | engineering/review | wrap |
+| user-impact-reviewer | engineering/review | wrap |
+| pr-comment-resolver | engineering/workflow | wrap |
+| budget-analyst | finance | wrap |
+| financial-reporter | finance | wrap |
+| revenue-analyst | finance | wrap |
+| legal-document-generator | legal | wrap |
+| analytics-analyst | marketing | wrap |
+| conversion-optimizer | marketing | wrap |
+| paid-media-strategist | marketing | wrap |
+| pricing-strategist | marketing | wrap |
+| programmatic-seo-specialist | marketing | wrap |
+| retention-strategist | marketing | wrap |
+| seo-aeo-analyst | marketing | wrap |
+| ops-advisor | operations | wrap |
+| spec-flow-analyzer | product | wrap |
+| deal-architect | sales | wrap |
+| outbound-strategist | sales | wrap |
+| pipeline-analyst | sales | wrap |
+| ticket-triage | support | wrap |
+
+### YELLOW-primitive (24) — carrier rewrite + primitive adaptation
+
+| Agent | Domain | Primitives | Adaptation |
+|---|---|---|---|
+| agent-finder | engineering/discovery | ASK | HITL `respond` (loses structured options) |
+| functional-discovery | engineering/discovery | ASK | HITL `respond` |
+| agent-native-reviewer | engineering/review | TASK | `task` tool + Python subagent refs |
+| semgrep-sast | engineering/review | TASK | `task` tool |
+| cfo | finance | TASK | delegates to 3 specialists → `task` (parallel preserved) |
+| clo | legal | TASK | delegates to 2 specialists → `task` |
+| legal-compliance-auditor | legal | WEB | BYO web tool |
+| brand-architect | marketing | ASK | HITL `respond` |
+| cmo | marketing | TASK | delegates to 11 specialists → `task` (parallel preserved) |
+| copywriter | marketing | WEB | BYO web tool |
+| fact-checker | marketing | WEB | BYO web tool |
+| growth-strategist | marketing | WEB | BYO web tool |
+| coo | operations | TASK | delegates to 3 specialists → `task` |
+| ops-provisioner | operations | ASK | HITL `respond` |
+| ops-research | operations | WEB | BYO web tool |
+| service-deep-links | operations | ASK | HITL `respond` |
+| service-automator | operations | ASK, MCP | HITL + MCP client wiring |
+| business-validator | product | ASK, WEB | HITL + BYO web tool |
+| competitive-intelligence | product | ASK, TASK, WEB | all three primitives adapted |
+| cpo | product | TASK | delegates to 4 specialists → `task` |
+| ux-design-lead | product/design | ASK, MCP | HITL + MCP (Pencil) client wiring |
+| cro | sales | TASK | delegates to 3 specialists → `task` |
+| cco | support | TASK | delegates to 2 specialists → `task` |
+| community-manager | support | ASK | HITL `respond` |
+
+**Domain-leader pattern preserved at the capability level:** `SubAgentMiddleware`'s `task` tool supports parallel, context-isolated subagents, so cmo/cfo/clo/coo/cpo/cro/cco still fan out to their specialists. But each leader AND specialist must be authored as a Python dict — the markdown hierarchy does not survive as-is.
+
+---
+
+## Skills (82) — 29 GREEN, 53 YELLOW
+
+`SkillsMiddleware` reads `SKILL.md` + YAML frontmatter with 3-level progressive disclosure — the **same format Soleur already uses**. A skill is GREEN when it ports as-is with no degraded primitive. Degraded primitives: **ASK** (no structured prompts), **SKILL-chaining** (model-driven only), **ARGS** ($ARGUMENTS interpolation absent in SDK). **TODO** (`write_todos`) and **MCP** now have equivalents, so skills YELLOW-only-for-TODO/MCP on OpenHands become GREEN here.
+
+### GREEN Skills (29)
+
+| Skill | Signature | Notes |
+|---|---|---|
+| agent-browser | prose | bash CLI automation |
+| andrew-kane-gem-writer | prose | authoring rules |
+| archive-kb | prose | bash wrapper |
+| brainstorm-techniques | prose | context injection (reference skill) |
+| changelog | prose | git log analysis |
+| code-to-prd | prose | file walk + redaction |
+| deploy-docs | prose | Eleventy build validation |
+| dhh-rails-style | prose | style rules |
+| docs-site | prose | scaffold generation |
+| dspy-ruby | WEB | BYO web tool (config) |
+| every-style-editor | prose | copy editing rules |
+| frontend-design | prose | design generation |
+| gemini-imagegen | prose | API image generation |
+| git-worktree | prose | worktree CLI |
+| incident | prose | PIR scaffold |
+| merge-pr | prose | git merge automation |
+| pencil-setup | prose | MCP setup → deepagents MCP client |
+| provision-cloudflare | prose | provisioning script |
+| provision-doppler | prose | provisioning script |
+| provision-github | prose | provisioning script |
+| provision-hetzner | prose | provisioning script |
+| rclone | prose | cloud storage CLI |
+| release-announce | prose | gh CLI release |
+| release-docs | prose | docs metadata |
+| resolve-debt | prose | debt ledger triage |
+| skill-security-scan | prose | advisory scanner |
+| spec-templates | prose | template generation |
+| trigger-cron | prose | cron trigger |
+| user-story-writer | prose | story decomposition |
+
+### YELLOW Skills (53)
+
+| Skill | Signature | Primary degraded primitive(s) |
+|---|---|---|
+| admin-ip-refresh | ARGS | args via context |
+| agent-native-architecture | TASK | `task` tool |
+| agent-native-audit | TASK ARGS | `task` + args |
+| architecture | ASK ARGS | HITL + args |
+| atdd-developer | TASK | `task` tool |
+| brainstorm | ASK TASK SKILL ARGS WEB MCP | core orchestrator — highest density |
+| campaign-calendar | ARGS | args via context |
+| community | ASK TASK ARGS | HITL + `task` + args |
+| competitive-analysis | ASK TASK | HITL + `task` |
+| compound-capture | ASK ARGS | HITL + args |
+| compound | TASK ARGS MCP HOOK | hook → middleware; `task` + args |
+| content-writer | ASK TASK ARGS WEB | multi-primitive |
+| deepen-plan | ASK TASK ARGS WEB MCP | multi-primitive |
+| deploy | ASK | HITL |
+| discord-content | ASK | HITL |
+| drain-labeled-backlog | TASK SKILL ARGS | `task` + chaining + args |
+| feature-video | ARGS | args via context |
+| file-todos | TASK ARGS TODO | `task` + args (TODO=GREEN) |
+| fix-issue | ARGS | args via context |
+| flag-create | ARGS | args via context |
+| flag-set-role | ASK ARGS | HITL + args |
+| frontend-anti-slop | SKILL ARGS | chaining + args |
+| gdpr-gate | TASK ARGS | `task` + args |
+| growth | TASK WEB | `task` + BYO web |
+| heal-skill | ARGS | args via context |
+| kb-search | ARGS | args via context |
+| legal-audit | ASK TASK | HITL + `task` |
+| legal-generate | ASK TASK | HITL + `task` |
+| linear-fetch | ASK ARGS MCP | HITL + args + MCP |
+| one-shot | ASK TASK SKILL ARGS | core pipeline orchestrator |
+| plan-review | TASK ARGS | `task` + args |
+| plan | ASK TASK ARGS WEB MCP | core pipeline orchestrator |
+| postmerge | ARGS | args via context |
+| preflight | ASK ARGS | HITL + args |
+| product-roadmap | ASK TASK ARGS | multi-primitive |
+| qa | ARGS | args via context |
+| reproduce-bug | ARGS MCP | args + MCP |
+| resolve-parallel | TASK ARGS TODO | `task` + args (TODO=GREEN) |
+| resolve-pr-parallel | TASK ARGS TODO | `task` + args |
+| resolve-todo-parallel | TASK ARGS TODO | `task` + args |
+| review | TASK ARGS WEB | core pipeline orchestrator |
+| schedule | ASK TASK ARGS WEB | multi-primitive |
+| seo-aeo | TASK | `task` tool |
+| ship | ASK TASK SKILL ARGS TODO | core pipeline orchestrator |
+| skill-creator | TASK | `task` tool |
+| social-distribute | ASK ARGS | HITL + args |
+| test-browser | ASK ARGS MCP | HITL + args + MCP |
+| test-fix-loop | ARGS | args via context |
+| triage | ARGS TODO | args (TODO=GREEN) |
+| user-set-role | ARGS | args via context |
+| ux-audit | TASK SKILL ARGS | `task` + chaining + args |
+| work | TASK ARGS MCP TODO | core pipeline orchestrator |
+| xcode-test | ASK TASK MCP | HITL + `task` + MCP |
+
+**Shift vs OpenHands:** skills YELLOW *only* for TodoWrite on OpenHands (e.g., bare `triage`/`file-todos` TODO use) gain a built-in `write_todos`. They remain YELLOW here only because they *also* carry ARGS/TASK. No skill is GREEN-er on OpenHands than on deepagents; several are GREEN-er on deepagents.
+
+---
+
+## Commands (3) — 1 GREEN, 2 YELLOW
+
+| Command | Signature | Classification | Notes |
+|---|---|---|---|
+| help | SKILL | GREEN | skill listing → directory scan / dcode `/help` |
+| go | ASK TASK SKILL ARGS | YELLOW | router — HITL + `task` + chaining + args |
+| sync | ASK TASK ARGS | YELLOW | HITL + `task` + args |
+
+deepagents has no command/slash system in the SDK; `dcode` provides built-in slash commands (`/model`, `/skill`, `/remember`, `/threads`, etc.) but no user-defined command registry. `go`/`sync` would be re-expressed as skills or dcode-level routing.
+
+---
+
+## Gap Analysis by Primitive (with four-platform comparison)
+
+### P1: Agent authoring format — YELLOW (drives the whole result)
+**The defining gap.** Soleur's 67 agents are markdown files; deepagents subagents are Python `SubAgent` dicts. No markdown-agent loader exists. Prose system prompts port verbatim into `system_prompt`, so a bulk script (`for f in agents/**/*.md: SubAgent(name=…, system_prompt=read(f))`) handles the 43 prose-only agents. The 24 primitive-bearing agents need additional adaptation. **No agent is unportable (RED), but none is free (GREEN).** This single fact moves GREEN% from ~46% (OpenHands) to 19.7%.
+
+### P2: AskUserQuestion — YELLOW (no structured multi-choice)
+**Usage:** 31 components (8 agents, 21 skills, 2 commands). deepagents `HumanInTheLoopMiddleware` offers approve/edit/reject/**respond**; `respond` returns free text (the AskUserQuestion analogue) but there is no options-list schema. Requires a checkpointer. **Workaround viability: HIGH** (freeform), same constraint as OpenHands.
+
+### P3: Skill format & chaining — YELLOW format-GREEN, chaining-YELLOW
+**Usage:** ~15 chaining sites. `SkillsMiddleware` reads identical `SKILL.md` (format GREEN) but activation is model-driven; no programmatic mid-run `Skill()` call. The core pipeline (go→brainstorm→plan→work→review→compound→ship) becomes sequential context loading, same as OpenHands and Gemini CLI.
+
+### P4: $ARGUMENTS — YELLOW
+**Usage:** 30+ skills/commands. SDK has no SKILL.md arg interpolation. `dcode` `/skill:<name> [args]` passes args at the CLI but the substitution semantics are unverified (see critical-unknowns). Skills rely on conversation context.
+
+### P5: Task / subagent — GREEN (capability), YELLOW (authoring)
+**Usage:** 27 files. `task` tool via `SubAgentMiddleware`: parallel, context-isolated, prebuilt general-purpose template. Multi-level nesting "not prevented" but unverified. Capability matches OpenHands; authoring is Python.
+
+### P6: TodoWrite — GREEN
+**Usage:** 7 skills. `write_todos` / `TodoListMiddleware`, built-in and default. **The clearest deepagents win over OpenHands** (which had no equivalent).
+
+### P7: MCP — GREEN (worse ergonomics)
+**Usage:** 17 files. `langchain-mcp-adapters` `MultiServerMCPClient` (stdio/HTTP/SSE/WS). Requires explicit Python wiring per server — no `.mcp.json` auto-load. Capability matches; operational overhead is higher.
+
+### P8: WebSearch / WebFetch — YELLOW (BYO, GREEN-with-config)
+**Usage:** 14 files. Not built-in (unlike Gemini CLI, and unlike OpenHands' MCP-bundle framing). Wire a search tool (Tavily etc.) via `tools=[…]`. Minimal but explicit.
+
+### P9: hookSpecificOutput / hooks — GREEN (Python), shell-hooks YELLOW
+**Usage:** 1 skill (compound) for hookSpecificOutput; plus the infra shell hooks. LangGraph middleware (`wrap_tool_call`) gives full before/after tool interception with state injection — *more* powerful than Claude Code hooks. But Soleur's hooks are **bash** (`guardrails.sh`, `worktree-write-guard.sh`, `pre-merge-rebase.sh`, `welcome-hook.sh`, `stop-hook.sh`); each must be rewritten as a Python middleware subclass. Capability GREEN, implementation YELLOW.
+
+### P10: SessionStart / Stop — GREEN (stronger)
+`before_agent`/`after_agent` (run-scoped) plus durable checkpointers (Postgres/Redis) for cross-session recall — stronger than both Claude Code and OpenHands. Welcome hook and Ralph-loop continuation port to middleware + checkpointer.
+
+### P11: Plugin / distribution system — RED at the infra level (no component counted)
+**deepagents has no plugin marketplace, manifest, or enable/disable/uninstall system.** The only drop-in distributable unit is a **skills directory** (`SKILL.md` packages). There is no equivalent to Soleur's `.claude-plugin/plugin.json` + `marketplace.json`. This is the one place deepagents is *worse than OpenHands* (which has a full plugin system) — and it shapes the recommendation: there is no clean way to ship Soleur's 152 components as one installable harness extension. Agents/middleware ship as a **Python package**, skills as a directory.
+
+---
+
+## CI / Infrastructure (Not Counted in 152)
+
+| Component | Type | deepagents Equivalent | Status |
+|---|---|---|---|
+| hooks/welcome-hook.sh | SessionStart hook | `before_agent` middleware (Python rewrite) | YELLOW |
+| hooks/stop-hook.sh | Stop hook | `after_agent` middleware (Python rewrite) | YELLOW |
+| .claude/hooks/guardrails.sh | PreToolUse hook | `wrap_tool_call` middleware (Python rewrite) | YELLOW |
+| .claude/hooks/pre-merge-rebase.sh | PreToolUse hook | `wrap_tool_call` middleware | YELLOW |
+| .claude/hooks/worktree-write-guard.sh | PreToolUse hook | `wrap_tool_call` middleware | YELLOW |
+| .claude-plugin/plugin.json | Plugin manifest | No equivalent → Python package metadata | RED |
+| .claude-plugin/marketplace.json | Distribution manifest | No equivalent | RED |
+| .mcp.json | MCP auto-load | `MultiServerMCPClient` Python wiring | YELLOW |
+| .claude/settings.json | Project settings | `create_deep_agent(...)` kwargs / dcode config | YELLOW |
+| GitHub Actions workflows | CI/CD | platform-agnostic | GREEN |
+
+**Infrastructure is mostly YELLOW/RED** — the inverse of OpenHands, whose hook system covered all 6 Claude Code hook types as GREEN. deepagents' middleware is more powerful but requires Python rewrites of every bash hook, and there is no distribution manifest.
+
+---
+
+## Platform-Specific Considerations
+
+### Two surfaces: SDK vs dcode
+- **SDK** (`from deepagents import create_deep_agent`): the programmatic path; you build the operator UX yourself (custom CLI, web app, or LangGraph Studio).
+- **dcode** (`deepagents-code`): the batteries-included terminal harness. Young — packaging churn (the REPL was split out of `deepagents-cli` into `deepagents-code`, CLI at v0.1.0). Maturity for running Soleur's long multi-step pipelines is **unverified** (see critical-unknowns).
+
+### Model-agnostic
+Any LangChain chat model (`"provider:model"` strings: `anthropic:…`, `openai:…`, `google:…`, Ollama, vLLM). This is the headline strategic advantage over Claude Code and the main investment trigger.
+
+### Durable persistence
+LangGraph checkpointers (MemorySaver dev; Postgres/Redis prod) checkpoint state every superstep, keyed by `thread_id`. deepagents adds `StateBackend`/`FilesystemBackend`/`CompositeBackend` + `MemoryMiddleware` for cross-session recall. Stronger than Claude Code's session model — a strong fit for a server-side runtime.
+
+### Python requirement
+Subagents, tools, and hooks are Python. Bash tooling (worktree-manager, deploy scripts) runs via a shell/`execute` tool. The 67 agents and 5 bash hooks are the Python-rewrite surface; the 29 GREEN skills and bash scripts are not.
+
+### Maturity
+~24.2k★, `deepagents 0.6.8` (2026-06-03), MIT, Python ≥3.11, maintained by LangChain Inc., frequent releases, JS port available. LangSmith observability, remote sandbox backends (AWS AgentCore, Daytona, Modal, Runloop).

--- a/knowledge-base/project/specs/feat-deepagents-portability/recommendation.md
+++ b/knowledge-base/project/specs/feat-deepagents-portability/recommendation.md
@@ -1,0 +1,105 @@
+---
+title: "deepagents Portability Recommendation"
+date: 2026-06-08
+issue: 5034
+---
+
+# Recommendation: deepagents (LangChain) as Alternative Harness
+
+## Decision: NO-GO as a mechanical port · CONDITIONAL-GO as a strategic server-side rebuild
+
+deepagents is **not** worth a parallel mechanical port the way OpenHands is. But it is the strongest target yet for a *specific* strategic move — a model-agnostic, durably-persistent, server-side agent runtime — and that play connects directly to Soleur's existing `soleur-server-side-agentic-runtime` direction. The highest-value option is a **hybrid**, not a replacement.
+
+## Evidence Summary
+
+| Metric | Codex CLI | Gemini CLI | OpenHands | deepagents |
+|---|---|---|---|---|
+| GREEN (ports as-is) | 47.5% (58/122) | 54.3% (70/129) | 46.5% (60/129) | **19.7% (30/152)** |
+| YELLOW (needs adaptation) | 7.4% | 45.0% | 53.5% | **80.3% (122/152)** |
+| RED (requires rewrite) | 43.4% | 0.8% | 0% | **0%** |
+| Blockers with no equivalent | 4 | 1 | 0 | **0** |
+| Agent authoring format | Config YAML | Markdown | Markdown | **Python dict** |
+| Skill authoring format | SKILL.md | SKILL.md | SKILL.md | **SKILL.md (identical)** |
+| Subagent parallelism | None | Sequential | Parallel | **Parallel** |
+| TodoWrite | None | `write_todos` | None | **`write_todos` (built-in)** |
+| Structured prompts | None | `ask_user` | None | **None (respond only)** |
+| Plugin / distribution | None | None | **Full** | **None (skills dir)** |
+| Model support | OpenAI | Gemini | Any LLM | **Any LLM** |
+| Durable persistence | None | None | Docker state | **Checkpointers (Postgres/Redis)** |
+| Maturity | OpenAI-backed | Google-backed | OSS growing | **24k★ LangChain-backed, MIT** |
+
+## The central finding: the OpenHands pattern inverts
+
+OpenHands was attractive precisely because Soleur's markdown agents ported 1:1 (markdown→markdown) and its plugin system let you ship everything as one installable bundle. deepagents inverts both:
+
+1. **Agents flip GREEN→YELLOW.** Subagents are Python `SubAgent` dicts; there is no markdown-agent loader. All 67 agents — the entire CMO/CFO/CLO/COO/CPO/CRO/CCO domain-leader hierarchy plus 24 review/research specialists — must be re-authored in Python. The prose ports verbatim, so it's *mechanical*, but it's 67 rewrites plus 5 bash-hook rewrites.
+2. **No plugin distribution.** There is no `plugin.json`/`marketplace.json` equivalent. You ship agents/hooks as a **Python package** and skills as a **directory** — two artifacts, no enable/disable/uninstall story.
+
+Against that, deepagents flips two things *for* you:
+3. **Skills port better.** Identical `SKILL.md` + progressive disclosure. 29 skills are GREEN today; the format itself is a non-event.
+4. **It's the only target with built-in `write_todos`, durable checkpointer persistence, true model-agnosticism, and a mature corporate backer — and it is now a real harness (`dcode`), not just a library.**
+
+So: **expensive to port, but the most strategically valuable destination** if the goal is anything other than "same Soleur, different CLI."
+
+## What this means by goal
+
+| If the goal is… | Verdict | Why |
+|---|---|---|
+| A cheap second harness (insurance vs Claude availability/pricing) | **Use OpenHands, not deepagents** | OpenHands keeps agents as markdown + has a plugin system → 1–2 wk degraded pipeline. deepagents costs 67 agent rewrites for the same outcome. |
+| Run Soleur agents on non-Claude models | **deepagents (CONDITIONAL-GO)** | Only target with first-class model-agnosticism *and* a harness. The agent rewrite is unavoidable on any model-agnostic LangGraph path. |
+| Server-side, durable, multi-tenant agent runtime | **deepagents (CONDITIONAL-GO, strong fit)** | Checkpointers (Postgres/Redis) + state backends are a greenfield-grade fit; ties into `soleur-server-side-agentic-runtime` + ADR-030 (Inngest durable trigger layer). |
+| Ship Soleur skills to a broader LangChain audience | **deepagents skills-only port (GO, low cost)** | 29 GREEN + ~20 light-YELLOW skills publish as a `SKILL.md` package consumable by any deepagents/dcode user. |
+
+## Recommended play: hybrid, not replacement
+
+**Do not replace the Claude Code harness.** Instead, if/when a trigger fires:
+
+1. **Skills-first.** Port the 29 GREEN skills (+ light-YELLOW) to a deepagents `skills/` package. Low cost, immediately reusable, and validates the format-parity claim in production. This is the cheapest way to "have a deepagents story."
+2. **deepagents as a server-side skill/agent execution runtime** feeding the existing Claude Code harness — model-agnostic, durably checkpointed — rather than a desktop CLI replacement. Keep the markdown agent hierarchy authoritative on Claude Code; mirror only what the server runtime needs.
+3. **Full harness migration only as a deliberate strategic rebuild**, scoped as its own initiative (not a port), if model-agnosticism becomes a hard product requirement.
+
+## Trigger for Investment
+
+Invest in deepagents when ANY of:
+
+1. **Model-agnosticism becomes a hard requirement** — a customer/compliance need to run Soleur agents on GPT/Gemini/open-source models. (This is deepagents' #1 differentiator vs OpenHands.)
+2. **Server-side durable agent runtime** is greenlit — deepagents' checkpointer model is the strongest fit analyzed; align with `2026-05-05-feat-soleur-server-side-agentic-runtime-plan.md` and ADR-030.
+3. **LangGraph/LangSmith** is adopted elsewhere in the stack (shared observability/tooling lowers marginal cost).
+4. **Skills-as-product** — desire to distribute Soleur skills to the LangChain ecosystem (24k★ reach).
+5. **dcode matures** — the `deepagents-code` CLI graduates past v0.1.0 packaging churn and demonstrably runs long multi-step pipelines (resolves critical-unknown #1).
+
+Do **not** invest merely for harness redundancy — OpenHands dominates that use case at a fraction of the cost.
+
+## Estimated Effort
+
+| Scope | Effort | Outcome |
+|---|---|---|
+| Skills-only port (29 GREEN + ~20 light-YELLOW) | 1–2 weeks | deepagents-consumable skill package; format-parity validated |
+| GREEN skills + 43 prose agents (bulk-scripted SubAgent wrap) | 2–3 weeks | Agent library + simple skills, model-agnostic |
+| Full harness parity (67 agents + 53 YELLOW skills + 5 hook rewrites + MCP wiring + distribution packaging) | **6–10 weeks** | Degraded-but-functional pipeline. **Not recommended as a port** — costs 3–5× OpenHands for a worse distribution story |
+| Server-side runtime built on deepagents (greenfield) | Separate initiative | Model-agnostic durable runtime; scope under `soleur-server-side-agentic-runtime` |
+
+For comparison, OpenHands full-pipeline was estimated at 1–2 weeks. deepagents' agent-rewrite + hook-rewrite + no-plugin-distribution triples-to-quintuples that for the *mechanical* path — which is exactly why the recommendation is hybrid/strategic, not port.
+
+## Critical Constraints
+
+1. **67 Python agent rewrites + 5 Python hook rewrites** — unavoidable on any deepagents path. Mechanical but not free; no markdown-agent loader exists.
+2. **No structured user prompts** — `HumanInTheLoopMiddleware` has approve/edit/reject/respond, no options schema. Soleur's brainstorm/plan/ship gates degrade to freeform (same as OpenHands).
+3. **No plugin distribution** — ship as Python package + skills dir; no enable/disable/marketplace. The one axis where deepagents is worse than OpenHands.
+4. **dcode immaturity** — the operator harness is young; production-readiness for Soleur's pipelines is unverified.
+
+## Follow-up (if proceeding)
+
+1. PoC: run a 3-skill + 2-agent slice on `dcode` to resolve critical-unknowns #1 (harness maturity), #2 (subagent nesting), #3 (structured-prompt absence impact).
+2. Spike: skills-only package + publish-consume round-trip on a non-Claude model (validate model-agnosticism end-to-end).
+3. Align with `soleur-server-side-agentic-runtime` plan owner on whether deepagents' checkpointer model supersedes the current runtime substrate choice.
+4. Monitor `langchain-ai/deepagents` for: a markdown-agent loader (would flip 43 agents back to GREEN), a structured-prompt primitive, and a plugin/distribution system.
+
+## References
+
+- deepagents inventory: `knowledge-base/project/specs/feat-deepagents-portability/inventory.md`
+- deepagents critical unknowns: `knowledge-base/project/specs/feat-deepagents-portability/critical-unknowns.md`
+- OpenHands recommendation: `knowledge-base/project/specs/openhands-portability/recommendation.md`
+- Platform comparison: `knowledge-base/engineering/platform-portability-comparison.md`
+- Server-side runtime: `knowledge-base/project/plans/2026-05-05-feat-soleur-server-side-agentic-runtime-plan.md`
+- ADR-030 (Inngest durable trigger layer): `knowledge-base/engineering/architecture/decisions/ADR-030-inngest-as-durable-trigger-layer.md`

--- a/knowledge-base/project/specs/feat-deepagents-portability/spec.md
+++ b/knowledge-base/project/specs/feat-deepagents-portability/spec.md
@@ -1,0 +1,45 @@
+---
+title: "deepagents Portability Scan"
+date: 2026-06-08
+issue: 5034
+lane: single-domain
+brand_survival_threshold: not-applicable
+status: complete
+---
+
+# Spec: deepagents Portability Scan
+
+## Problem Statement
+
+Soleur has assessed three alternative agent platforms (Codex CLI, Gemini CLI, OpenHands) for harness portability. `langchain-ai/deepagents` is a fourth candidate. Originally assumed to be "a LangChain library, a different category," it has since become a real agent harness (`dcode`), warranting the same portability scan to inform any future multi-harness or model-agnostic strategy.
+
+## Goals
+
+- G1: Classify all 152 Soleur components (agents/skills/commands) GREEN/YELLOW/RED for deepagents.
+- G2: Map the 10+ Claude Code primitives to deepagents equivalents with a delta vs OpenHands.
+- G3: Produce a go/no-go recommendation with investment triggers and effort estimate.
+- G4: Document docs-only critical unknowns gated for PoC.
+- G5: Add deepagents as a 4th column to `platform-portability-comparison.md`.
+
+## Non-Goals
+
+- Building any deepagents port (this is an assessment only).
+- A PoC implementation (deferred; gated by the recommendation's triggers).
+- Re-scanning Codex/Gemini/OpenHands.
+
+## Functional Requirements
+
+- FR1: Inventory with summary stats, four-way comparison, primitive mapping, and full component classification. → `inventory.md`
+- FR2: Recommendation with decision, evidence table, goal-conditioned verdict, triggers, effort. → `recommendation.md`
+- FR3: Critical-unknowns list with impact ratings and PoC gates. → `critical-unknowns.md`
+- FR4: Comparison table updated with deepagents column + strengths/weaknesses/triggers. → `platform-portability-comparison.md`
+- FR5: Brainstorm document capturing the premise correction and key decisions. → `2026-06-08-deepagents-portability-brainstorm.md`
+
+## Technical Requirements
+
+- TR1: Classification derived from a grep-based primitive scan of the live repo (not extrapolation from the April snapshot).
+- TR2: All deepagents capability claims cited to deepagents/LangGraph docs or source (v0.6.8, accessed 2026-06-08); unverified items flagged docs-only.
+
+## Outcome
+
+**NO-GO as a mechanical port; CONDITIONAL-GO as a strategic server-side rebuild.** 19.7% GREEN / 0% RED. The agent hierarchy must be rewritten markdown→Python and there is no plugin-distribution layer, making it 3-5× the cost of the OpenHands port for a worse distribution story. Strategic value (model-agnostic, durable persistence, real harness) is highest of any target. Recommended play: hybrid (skills port + server-side runtime), not replacement. Harness redundancy → OpenHands; model-agnosticism / durable runtime → deepagents.


### PR DESCRIPTION
## Summary

Fourth platform portability scan — `langchain-ai/deepagents` vs the Claude Code harness — mirroring the OpenHands experiment (#1770). Closes #5034.

**Premise correction:** deepagents is no longer "just a library." As of v0.6.8 it ships `deepagents-code`/`dcode`, a real terminal harness ("similar to Claude Code"). Treated as an OpenHands-class peer.

## Result

| | |
|---|---|
| Components scanned | 152 (67 agents, 82 skills, 3 commands) |
| GREEN / YELLOW / RED | 19.7% / 80.3% / 0% |
| Decision | **NO-GO (mechanical port) · CONDITIONAL-GO (strategic rebuild)** |

**The OpenHands pattern inverts.** Zero-RED (every primitive has an equivalent) but the lowest GREEN% of any target: deepagents subagents are Python `SubAgent` dicts (no markdown-agent loader), so all 67 markdown agents flip to YELLOW. Skills port *better* than any prior target (identical `SKILL.md`). No plugin-distribution layer. Recommended play: **hybrid** — port skills as a server-side runtime, keep agent orchestration on Claude Code. Harness redundancy → OpenHands; model-agnosticism / durable runtime → deepagents.

## Artifacts

- `knowledge-base/project/brainstorms/2026-06-08-deepagents-portability-brainstorm.md`
- `knowledge-base/project/specs/feat-deepagents-portability/{inventory,recommendation,critical-unknowns,spec}.md`
- `knowledge-base/engineering/platform-portability-comparison.md` (+deepagents 4th column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)