### PR TITLE
chore(flag-set-role): add debug-mode to FLAG_ENV_VARS map

### DIFF
--- a/plugins/soleur/skills/flag-set-role/scripts/flip.sh
+++ b/plugins/soleur/skills/flag-set-role/scripts/flip.sh
@@ -52,6 +52,7 @@ declare -A FLAG_ENV_VARS=(
   ["team-workspace-invite"]="FLAG_TEAM_WORKSPACE_INVITE"
   ["byok-delegations"]="FLAG_BYOK_DELEGATIONS"
   ["c4-visualizer"]="FLAG_C4_VISUALIZER"
+  ["debug-mode"]="FLAG_DEBUG_MODE"
 )
 
 # --- arg parsing ------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #5042 (feat-debug-mode-stream). That PR added `debug-mode` to `RUNTIME_FLAGS` in `apps/web-platform/lib/feature-flags/server.ts` but not to the hardcoded `FLAG_ENV_VARS` map in `plugins/soleur/skills/flag-set-role/scripts/flip.sh`, so `flag-set-role debug-mode <env> <on|off>` failed with `unknown flag`.

The Flagsmith feature already exists (created post-merge via `flag-create --flagsmith-only --dev-on`, feature_id 213401, dev cohort ON / prd OFF). This one-line map entry makes the flag fully manageable via the skill — to disable it for the dev cohort or promote it to prd.

Verified: `flag-set-role debug-mode dev on --dry-run` now resolves the feature and prints the pre/post matrix instead of `unknown flag`.

## Changelog

### Plugin
- `flag-set-role`: register `debug-mode` → `FLAG_DEBUG_MODE` in the `FLAG_ENV_VARS` map so the flag shipped in #5042 is manageable via the skill.

## Test plan

- [x] `bash -n flip.sh` syntax check passes
- [x] `flag-set-role debug-mode dev on --dry-run` resolves feature_id 213401 + prints matrix (was: `unknown flag`)

Note: the map is hardcoded and kept-in-sync-by-comment with `RUNTIME_FLAGS`; a future parity test asserting `FLAG_ENV_VARS` keys ⊆ `RUNTIME_FLAGS` would prevent this drift class, but is out of scope for this one-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)