### PR TITLE
infra(deploy): raise deploy-completion ceiling 900s→1800s for one-time full image re-pulls

### DIFF
--- a/.github/workflows/web-platform-release.yml
+++ b/.github/workflows/web-platform-release.yml
@@ -287,18 +287,24 @@ jobs:
     # during-flight unsafety:
     # knowledge-base/project/learnings/best-practices/2026-05-07-deploy-poll-ceiling-must-track-realistic-deploy-window.md
     # Runbook: plugins/soleur/skills/postmerge/references/deploy-status-debugging.md
+    # Ceiling raised 900s→1800s (#5061): a build-driver switch or a base-layer
+    # bump (claude-code/playwright/node) forces a one-time FULL image re-pull on
+    # the prod server, which a 900s ceiling cannot fit — see the v0.116.1 buildx
+    # full-repull PIR (post-mortems/v0116-1-buildx-driver-full-repull-deploy-timeout).
+    # All four windows move together (asserted at runtime + by ci-deploy-wrapper.test.sh):
+    #   STATUS: 360 * 5s = 1800   HEALTH: 180 * 10s = 1800   IN_FLIGHT_CEILING_S: 1800   wrapper: 1800s
     env:
-      STATUS_POLL_MAX_ATTEMPTS: 180
+      STATUS_POLL_MAX_ATTEMPTS: 360
       STATUS_POLL_INTERVAL_S: 5
-      HEALTH_POLL_MAX_ATTEMPTS: 90
+      HEALTH_POLL_MAX_ATTEMPTS: 180
       HEALTH_POLL_INTERVAL_S: 10
       # IN_FLIGHT_CEILING_S MUST equal the wall-clock cap in
-      # apps/web-platform/infra/ci-deploy-wrapper.sh (timeout ... 900s ...)
+      # apps/web-platform/infra/ci-deploy-wrapper.sh (timeout ... 1800s ...)
       # so the server-side hard-kill fires exactly when the workflow gives
       # up polling (#3704). Drift produces either a perpetual "running"
       # state (workflow gives up before kill) or wasted polling cycles
       # (kill fires before workflow times out).
-      IN_FLIGHT_CEILING_S: 900
+      IN_FLIGHT_CEILING_S: 1800
     steps:
       - name: Pre-rerun lock probe
         # #3408: short-circuit if the prior deploy is still in flight, so a

--- a/apps/web-platform/infra/ci-deploy-wrapper.sh
+++ b/apps/web-platform/infra/ci-deploy-wrapper.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
-# Wall-clock cap on ci-deploy.sh: SIGTERM at 900s, SIGKILL 20s later (#3704, #2207).
+# Wall-clock cap on ci-deploy.sh: SIGTERM at 1800s, SIGKILL 20s later (#3704, #2207, #5061).
 #
 # Inert by construction — single `exec timeout` line so the wrapper itself
 # cannot become a hang surface (the timeout only protects what it spawns,
 # not what runs before it). Env vars (SSH_ORIGINAL_COMMAND, DOPPLER_TOKEN,
 # CI_DEPLOY_STATE, etc.) inherit naturally through `exec`.
 #
-# The 900s literal MUST equal IN_FLIGHT_CEILING_S in
+# The 1800s literal MUST equal IN_FLIGHT_CEILING_S in
 # .github/workflows/web-platform-release.yml — the workflow-side step
 # `Pre-rerun lock probe` runtime-asserts STATUS_POLL × INTERVAL ==
 # HEALTH_POLL × INTERVAL == IN_FLIGHT_CEILING_S, so a future ceiling change
-# must update both files.
-exec timeout --signal=TERM --kill-after=20s 900s /usr/local/bin/ci-deploy.sh
+# must update both files. Raised 900s→1800s (#5061) so a one-time FULL image
+# re-pull (build-driver switch / base-layer bump) fits — see the v0.116.1 PIR.
+exec timeout --signal=TERM --kill-after=20s 1800s /usr/local/bin/ci-deploy.sh

--- a/apps/web-platform/infra/ci-deploy-wrapper.test.sh
+++ b/apps/web-platform/infra/ci-deploy-wrapper.test.sh
@@ -28,10 +28,10 @@ if [[ ! -f "$WRAPPER" ]]; then
 elif [[ ! -x "$WRAPPER" ]]; then
   FAIL=$((FAIL + 1))
   echo "  FAIL: wrapper file is not executable (0755 expected)"
-elif ! grep -qF 'exec timeout --signal=TERM --kill-after=20s 900s /usr/local/bin/ci-deploy.sh' "$WRAPPER"; then
+elif ! grep -qF 'exec timeout --signal=TERM --kill-after=20s 1800s /usr/local/bin/ci-deploy.sh' "$WRAPPER"; then
   FAIL=$((FAIL + 1))
   echo "  FAIL: wrapper missing canonical exec line"
-  echo "        expected literal: exec timeout --signal=TERM --kill-after=20s 900s /usr/local/bin/ci-deploy.sh"
+  echo "        expected literal: exec timeout --signal=TERM --kill-after=20s 1800s /usr/local/bin/ci-deploy.sh"
   echo "        file contents:"
   sed 's/^/          /' "$WRAPPER"
 else


### PR DESCRIPTION
Closes #5061

## What

Raise the coupled deploy-completion ceiling from 900s to **1800s**, all four windows in lockstep:
- `web-platform-release.yml`: `STATUS_POLL_MAX_ATTEMPTS 180→360` (×5s), `HEALTH_POLL_MAX_ATTEMPTS 90→180` (×10s), `IN_FLIGHT_CEILING_S 900→1800`
- `apps/web-platform/infra/ci-deploy-wrapper.sh`: `timeout … 900s → 1800s`
- `ci-deploy-wrapper.test.sh`: parity assertion updated (Test 6 green: `wrapper 1800s == IN_FLIGHT_CEILING_S 1800`)

## Why

From the v0.116.1 deploy incident (PIR, PR #5060): a build-driver switch (PR #5051's buildx) — or any future base-layer bump (claude-code/playwright/node) — changes every image layer digest, forcing a one-time **full** image re-pull on the prod server. A multi-GB full re-pull does not fit the 900s ceiling, so the deploy job times out even though the pull is still progressing. 1800s tolerates a one-time full re-pull while still bounding genuinely-stuck deploys.

## User-Brand Impact

- **If this lands broken, the user experiences:** nothing directly — this changes deploy-pipeline timing constants only (no app code). A mis-set ceiling (windows out of lockstep) would surface as a CI failure (the runtime assertion + `ci-deploy-wrapper.test.sh` Test 6), not a prod issue.
- **If WS fails:** the deploy job either times out early (too-low ceiling) or polls longer before declaring a genuinely-stuck deploy (too-high) — an operator-visible Actions signal, never a silent user-facing failure.
- **Brand-survival threshold:** single-user incident — verified: coupling math (360×5 = 180×10 = 1800 = IN_FLIGHT_CEILING_S = wrapper), wrapper test 6/6 green, actionlint clean.

## Deploy-pipeline-fix auto-apply

`ci-deploy-wrapper.sh` is a `terraform_data.deploy_pipeline_fix` trigger file → `apply-deploy-pipeline-fix.yml` auto-applies the new 1800s wrapper to the prod host on merge (no operator action).

## Verification

- Coupling: all four windows == 1800s (no stray 900 in the deploy ceiling surfaces).
- `ci-deploy-wrapper.test.sh`: 6/6 PASS incl. Test 6 ceiling parity.
- `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)