### PR TITLE
fix(web): resolve dangling aria-describedby on hero waitlist input (a11y)

### DIFF
--- a/plugins/soleur/docs/index.njk
+++ b/plugins/soleur/docs/index.njk
@@ -26,6 +26,7 @@ last_updated: 2026-06-01
         <input type="hidden" name="tag" value="homepage-waitlist" />
         <input type="hidden" name="url" value="" />
         <button type="submit" class="btn btn-primary">Join the waitlist</button>
+        <p id="homepage-waitlist-privacy" class="sr-only">We'll only email you about your Soleur waitlist spot. Unsubscribe anytime. <a href="/legal/privacy-policy/">Privacy Policy</a>.</p>
         <div class="newsletter-status" id="homepage-waitlist-status" aria-live="polite" role="status"></div>
       </form>
       <div class="hero-cta">


### PR DESCRIPTION
## Summary

Fixes a dangling `aria-describedby` on the homepage hero waitlist email input (caught during review of #5064, pre-existing).

The input set `aria-describedby="homepage-waitlist-privacy"`, but no element with that id existed — the hero form is hand-written in `index.njk` and dropped the privacy `<p>` that the shared `newsletter-form.njk` include carries. Screen readers were pointed at nothing.

Added an `sr-only` (visually hidden) `<p id="homepage-waitlist-privacy">` with the waitlist privacy note + Privacy Policy link, mirroring the include's convention. **No visual change** to the hero — purely an accessibility correction.

## Changelog

### Web (marketing site)
- Resolve the broken `aria-describedby` reference on the hero waitlist input by adding a visually-hidden privacy description (screen-reader only).

## Test plan

- [x] `npm run docs:build` (Eleventy) → exit 0; rendered `_site/index.html` now has both `aria-describedby="homepage-waitlist-privacy"` and the matching `id` (reference resolves).
- [x] `.sr-only` confirmed defined (style.css) → element is visually hidden, no design change.
- [x] `TEST_GROUP=bun bash scripts/test-all.sh` → 5/5 suites pass; `/legal/privacy-policy/` builds (link valid).

Generated with [Claude Code](https://claude.com/claude-code)
