### PR TITLE
fix(deploy): close FD-200 lock for orphan-prone docker children (#5062)

### DIFF
--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -327,6 +327,11 @@ fi
 # lifetime of the script. Release is implicit -- the kernel closes FD 200
 # on process exit (any exit code, including SIGKILL). No manual `flock -u`
 # path exists; loser writes reason="lock_contention" and exits non-zero.
+# Long-running foreground docker children (prune/pull) close FD 200 via
+# `200>&-` (#5062) so an orphaned child — bash SIGKILLed mid-`docker pull`
+# before the TERM trap can `pkill` it — cannot hold the lock past this
+# script's death. Without that, the flock outlives ci-deploy.sh and blocks
+# all future deploys until a webhook restart.
 # A "lock_contention" reason on a webhook retry therefore means the prior
 # invocation is still in its critical section, NOT a release-path leak.
 # See #3398 for the cascading-rerun pattern this serialization produces
@@ -384,8 +389,20 @@ fi
 case "$COMPONENT" in
   web-platform)
     echo "Pruning unused Docker images..."
-    docker image prune -af
-    docker pull "$IMAGE:$TAG"
+    # `200>&-` closes the FD-200 advisory lock for these long-running docker
+    # children (#5062). Without it, a `docker pull` blocked on a network syscall
+    # when ci-deploy-wrapper.sh SIGKILLs the script — bash cannot dispatch the
+    # TERM trap mid-foreground-command, so `pkill -P $$` never runs (the caveat
+    # documented at the trap above) — is orphaned, still holding FD 200. The
+    # flock then outlives ci-deploy.sh for the FULL duration of the orphaned pull
+    # (~40 min on a full re-pull), blocking every future deploy with
+    # reason="lock_contention" until a webhook restart. Closing FD 200 for these
+    # children means the kernel releases the lock the instant ci-deploy.sh dies;
+    # the orphaned pull keeps running harmlessly (and warms the layer cache for
+    # the next attempt). prune is included for the same reason — a slow prune on
+    # a disk-full host is the same orphan class.
+    docker image prune -af 200>&-
+    docker pull "$IMAGE:$TAG" 200>&-
 
     # Clean stale canary from previous failed deploy
     { docker stop soleur-web-platform-canary 2>/dev/null || true; }

--- a/apps/web-platform/infra/ci-deploy.test.sh
+++ b/apps/web-platform/infra/ci-deploy.test.sh
@@ -2022,6 +2022,22 @@ assert_state_contains "deploy inngest restart latest rejected as image_mismatch"
   "image_mismatch" "1" \
   "deploy inngest restart latest"
 
+# Regression guard for #5062: the long-running foreground docker children
+# (prune/pull) MUST close the FD-200 advisory lock (`200>&-`) so an orphaned
+# child (bash SIGKILLed mid-`docker pull`, TERM trap never dispatched) cannot
+# hold the flock past ci-deploy.sh's death and block all future deploys. A
+# source-grep gate — a future edit that drops `200>&-` re-introduces the
+# 40-min-stuck-lock class the v0.116.1 PIR documented.
+TOTAL=$((TOTAL + 1))
+if grep -qE '^[[:space:]]*docker pull "\$IMAGE:\$TAG" 200>&-' "$DEPLOY_SCRIPT" \
+   && grep -qE '^[[:space:]]*docker image prune -af 200>&-' "$DEPLOY_SCRIPT"; then
+  PASS=$((PASS + 1))
+  echo "  PASS: long-running docker children close FD-200 lock (200>&-) — #5062 guard"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: docker pull/prune must close FD-200 via '200>&-' (#5062) — an orphaned pull would hold the deploy lock"
+fi
+
 echo ""
 echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
 


### PR DESCRIPTION
Closes #5062

## Root cause

The deploy serializes via an FD-200 advisory `flock` held by `ci-deploy.sh`. The lock releases when FD 200 closes — normally on `ci-deploy.sh` exit. But `ci-deploy.sh`'s children **inherit FD 200**, and the TERM trap that would `pkill` them (`ci-deploy.sh:145`) **cannot fire while bash is blocked in a foreground `docker pull`** (a caveat the script itself documents). So when `ci-deploy-wrapper.sh` SIGKILLs the script at the ceiling, the `docker pull` is **orphaned still holding FD 200** → the flock outlives `ci-deploy.sh` for the full pull duration (~40 min on a full re-pull), and every subsequent deploy returns `lock_contention` until a webhook restart.

This is exactly what happened in the v0.116.1 incident (PIR: `post-mortems/v0116-1-buildx-driver-full-repull-deploy-timeout`).

## Fix

Close FD 200 for the two long-running foreground docker children under the lock — `docker image prune -af 200>&-` and `docker pull "$IMAGE:$TAG" 200>&-`. Now an orphaned pull **cannot** hold the lock: the kernel releases it the instant `ci-deploy.sh` dies, regardless of orphans. The orphaned pull keeps running harmlessly and warms the layer cache for the next attempt. (`docker run -d` for the canary is detached/fast — not an orphan risk.)

## User-Brand Impact

- **If this lands broken, the user experiences:** nothing directly. This is a deploy-pipeline reliability fix; the failure mode it prevents is a *stuck deploy lock* that blocks future releases (operator-visible, not user-facing). A bug in the change would surface as a deploy/test failure, not a prod issue.
- **Brand-survival threshold:** single-user incident — the class it fixes can block an urgent future deploy. Verified: `ci-deploy.test.sh` 81/81 incl. the new #5062 guard; `bash -n` clean.

## Deploy-pipeline-fix auto-apply

`ci-deploy.sh` is a `deploy_pipeline_fix` trigger → `apply-deploy-pipeline-fix.yml` installs the fixed script + restarts `webhook` on merge (no operator action; also clears any current orphan-held lock as a bonus).

## Verification

- `ci-deploy.test.sh`: **81/81 pass**, including a source-grep regression guard asserting `200>&-` on prune+pull.
- `bash -n` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)