### PR TITLE
feat(shared): two-way banner animation + single rotating-arrow toggle

### DIFF
--- a/apps/web-platform/components/shared/cta-banner.tsx
+++ b/apps/web-platform/components/shared/cta-banner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type FormEvent, type ReactNode } from "react";
+import { useState, type FormEvent } from "react";
 
 // web-platform has no public privacy page; the established convention links the
 // marketing-site absolute URL (see app/(auth)/signup/page.tsx).
@@ -9,47 +9,17 @@ const PRIVACY_POLICY_URL = "https://soleur.ai/pages/legal/privacy-policy.html";
 type Status = "idle" | "submitting" | "success" | "error";
 type Panel = "expanded" | "collapsed";
 
-// Eases its children in on mount: a freshly-mounted element starts slightly
-// offset + transparent, then a one-frame flag flips it to its resting state so
-// the named transform/opacity transition plays. Conditional-rendered panels
-// mount a fresh Reveal on every collapse/expand, so the slide/fade plays each
-// time. `motion-reduce:` makes the change instant under prefers-reduced-motion.
-function Reveal({
-  children,
-  className = "",
-}: {
-  children: ReactNode;
-  className?: string;
-}) {
-  const [entered, setEntered] = useState(false);
-  useEffect(() => {
-    const id = requestAnimationFrame(() => setEntered(true));
-    return () => cancelAnimationFrame(id);
-  }, []);
-  return (
-    <div
-      className={`${className} transition-[transform,opacity] duration-300 ease-out motion-reduce:transition-none motion-reduce:duration-0 ${
-        entered ? "translate-y-0 opacity-100" : "translate-y-1 opacity-0"
-      }`}
-    >
-      {children}
-    </div>
-  );
-}
-
 export function CtaBanner() {
-  // In-memory only — closing collapses to a thin re-openable bar; a page
+  // In-memory only — closing collapses the body to a thin header bar; a page
   // reload restores the full banner (the dismissal is never persisted).
   const [panel, setPanel] = useState<Panel>("expanded");
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<Status>("idle");
 
-  function handleCollapse() {
-    setPanel("collapsed");
-  }
+  const expanded = panel === "expanded";
 
-  function handleExpand() {
-    setPanel("expanded");
+  function toggle() {
+    setPanel((p) => (p === "expanded" ? "collapsed" : "expanded"));
   }
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
@@ -74,54 +44,10 @@ export function CtaBanner() {
     }
   }
 
-  const shellClass =
-    "fixed bottom-0 left-0 right-0 z-40 border-t border-soleur-border-default bg-soleur-bg-surface-1/95 backdrop-blur-sm";
-
-  // Collapsed — a slim full-width strip; clicking anywhere re-expands.
-  if (panel === "collapsed") {
-    return (
-      <div className={`${shellClass} px-4 py-2`}>
-        <Reveal className="mx-auto max-w-3xl">
-          <button
-            type="button"
-            onClick={handleExpand}
-            aria-label="Reopen Soleur signup banner"
-            aria-expanded={false}
-            data-testid="cta-banner-reopen"
-            className="flex w-full items-center justify-between gap-4 rounded text-soleur-text-secondary transition-colors hover:text-soleur-text-primary"
-          >
-            <span className="text-sm">
-              Built with{" "}
-              <span className="font-medium text-soleur-accent-gold-fg">
-                Soleur
-              </span>
-            </span>
-            {/* Up-chevron (⌃) — reopen affordance. */}
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-              className="shrink-0"
-            >
-              <polyline points="18 15 12 9 6 15" />
-            </svg>
-          </button>
-        </Reveal>
-      </div>
-    );
-  }
-
-  // Expanded — the full two-tier banner.
   return (
-    <div className={`${shellClass} px-4 py-3`}>
-      <Reveal className="mx-auto flex max-w-3xl flex-col gap-2">
-        {/* Tier 1 — message + collapse */}
+    <div className="fixed bottom-0 left-0 right-0 z-40 border-t border-soleur-border-default bg-soleur-bg-surface-1/95 px-4 py-3 backdrop-blur-sm">
+      <div className="mx-auto flex max-w-3xl flex-col gap-2">
+        {/* Persistent header row — message + the single rotating-arrow toggle. */}
         <div className="flex items-start justify-between gap-4">
           <p className="text-sm text-soleur-text-secondary">
             Built with{" "}
@@ -130,12 +56,15 @@ export function CtaBanner() {
           </p>
           <button
             type="button"
-            onClick={handleCollapse}
-            aria-label="Collapse signup banner"
-            aria-expanded={true}
+            onClick={toggle}
+            aria-expanded={expanded}
+            aria-label={expanded ? "Collapse signup banner" : "Reopen Soleur signup banner"}
             className="shrink-0 rounded p-1 text-soleur-text-muted transition-colors hover:text-soleur-text-secondary"
-            data-testid="cta-banner-dismiss"
+            data-testid="cta-banner-toggle"
           >
+            {/* One chevron, rotated 180° between states — the arrow points toward
+                the action. COLLAPSED = rotate-0 (chevron points UP = "expand");
+                EXPANDED = rotate-180 (points DOWN = "collapse"). */}
             <svg
               width="16"
               height="16"
@@ -146,80 +75,96 @@ export function CtaBanner() {
               strokeLinecap="round"
               strokeLinejoin="round"
               aria-hidden="true"
+              className={`transition-transform duration-300 ease-out motion-reduce:transition-none motion-reduce:duration-0 ${
+                expanded ? "rotate-180" : "rotate-0"
+              }`}
             >
-              <line x1="18" y1="6" x2="6" y2="18" />
-              <line x1="6" y1="6" x2="18" y2="18" />
+              <polyline points="18 15 12 9 6 15" />
             </svg>
           </button>
         </div>
 
-        {/* Tier 2 — inline waitlist form, or success confirmation */}
-        {status === "success" ? (
-          <p role="status" className="text-sm font-medium text-soleur-text-secondary">
-            <span className="text-soleur-accent-gold-fg">You&apos;re on the list ✓</span>{" "}
-            — check your inbox to confirm.
-          </p>
-        ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col gap-1.5">
-            <label
-              htmlFor="waitlist-email"
-              className="text-sm font-medium text-soleur-text-primary"
-            >
-              Join the waitlist for early access.
-            </label>
-            <div className="flex flex-col gap-2 sm:flex-row">
-              <input
-                id="waitlist-email"
-                name="email"
-                type="email"
-                required
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="you@company.com"
-                autoComplete="email"
-                inputMode="email"
-                disabled={status === "submitting"}
-                className="w-full rounded-lg border border-soleur-border-default bg-transparent px-3 py-2 text-sm text-soleur-text-primary placeholder:text-soleur-text-muted sm:flex-1"
-              />
-              {/* Honeypot — a real browser never fills this. autoComplete=off +
-                  tabIndex=-1 keeps password-manager/email autofill out of it. */}
-              <input
-                type="text"
-                name="url"
-                tabIndex={-1}
-                autoComplete="off"
-                aria-hidden="true"
-                className="hidden"
-              />
-              <button
-                type="submit"
-                disabled={status === "submitting"}
-                className="shrink-0 rounded-lg bg-soleur-accent-gold-fill px-4 py-2 text-sm font-medium text-soleur-text-on-accent transition-colors hover:bg-amber-400 disabled:opacity-60 sm:w-auto"
-              >
-                {status === "submitting" ? "Joining…" : "Join"}
-              </button>
-            </div>
-            <p className="text-xs text-soleur-text-muted">
-              No spam. We email you once when early access opens.{" "}
-              <a
-                href={PRIVACY_POLICY_URL}
-                className="text-soleur-accent-gold-fg underline"
-              >
-                Privacy Policy
-              </a>
-            </p>
-            {/* Persistent aria-live region (empty in idle) so assistive tech
-                announces the error text when it is swapped in. */}
-            <p
-              role="status"
-              aria-live="polite"
-              className="min-h-[1rem] text-xs text-soleur-accent-gold-fg"
-            >
-              {status === "error" ? "Something went wrong. Please try again." : ""}
-            </p>
-          </form>
-        )}
-      </Reveal>
+        {/* Collapsible body — grid-template-rows 0fr↔1fr animates height in BOTH
+            directions. When collapsed it is inert + aria-hidden so the form is
+            out of the tab order and silent to assistive tech. */}
+        <div
+          data-testid="cta-banner-body"
+          inert={!expanded || undefined}
+          aria-hidden={!expanded || undefined}
+          className={`grid transition-[grid-template-rows] duration-300 ease-out motion-reduce:transition-none motion-reduce:duration-0 ${
+            expanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+          }`}
+        >
+          <div className="overflow-hidden">
+            {/* Inline waitlist form, or success confirmation. */}
+            {status === "success" ? (
+              <p role="status" className="text-sm font-medium text-soleur-text-secondary">
+                <span className="text-soleur-accent-gold-fg">You&apos;re on the list ✓</span>{" "}
+                — check your inbox to confirm.
+              </p>
+            ) : (
+              <form onSubmit={handleSubmit} className="flex flex-col gap-1.5 pt-0.5">
+                <label
+                  htmlFor="waitlist-email"
+                  className="text-sm font-medium text-soleur-text-primary"
+                >
+                  Join the waitlist for early access.
+                </label>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <input
+                    id="waitlist-email"
+                    name="email"
+                    type="email"
+                    required
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="you@company.com"
+                    autoComplete="email"
+                    inputMode="email"
+                    disabled={status === "submitting"}
+                    className="w-full rounded-lg border border-soleur-border-default bg-transparent px-3 py-2 text-sm text-soleur-text-primary placeholder:text-soleur-text-muted sm:flex-1"
+                  />
+                  {/* Honeypot — a real browser never fills this. autoComplete=off +
+                      tabIndex=-1 keeps password-manager/email autofill out of it. */}
+                  <input
+                    type="text"
+                    name="url"
+                    tabIndex={-1}
+                    autoComplete="off"
+                    aria-hidden="true"
+                    className="hidden"
+                  />
+                  <button
+                    type="submit"
+                    disabled={status === "submitting"}
+                    className="shrink-0 rounded-lg bg-soleur-accent-gold-fill px-4 py-2 text-sm font-medium text-soleur-text-on-accent transition-colors hover:bg-amber-400 disabled:opacity-60 sm:w-auto"
+                  >
+                    {status === "submitting" ? "Joining…" : "Join"}
+                  </button>
+                </div>
+                <p className="text-xs text-soleur-text-muted">
+                  No spam. We email you once when early access opens.{" "}
+                  <a
+                    href={PRIVACY_POLICY_URL}
+                    className="text-soleur-accent-gold-fg underline"
+                  >
+                    Privacy Policy
+                  </a>
+                </p>
+                {/* Persistent aria-live region (empty in idle) so assistive tech
+                    announces the error text when it is swapped in. */}
+                <p
+                  role="status"
+                  aria-live="polite"
+                  className="min-h-[1rem] text-xs text-soleur-accent-gold-fg"
+                >
+                  {status === "error" ? "Something went wrong. Please try again." : ""}
+                </p>
+              </form>
+            )}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web-platform/components/shared/cta-banner.tsx
+++ b/apps/web-platform/components/shared/cta-banner.tsx
@@ -103,7 +103,12 @@ export function CtaBanner() {
                 — check your inbox to confirm.
               </p>
             ) : (
-              <form onSubmit={handleSubmit} className="flex flex-col gap-1.5 pt-0.5">
+              /* pt-0.5 keeps the first row's focus ring off the overflow-hidden
+                 clip boundary during the grid-rows collapse transition. */
+              <form
+                onSubmit={handleSubmit}
+                className="flex flex-col gap-1.5 pt-0.5"
+              >
                 <label
                   htmlFor="waitlist-email"
                   className="text-sm font-medium text-soleur-text-primary"

--- a/apps/web-platform/test/shared-cta-banner-close.test.tsx
+++ b/apps/web-platform/test/shared-cta-banner-close.test.tsx
@@ -8,10 +8,13 @@ const formPresent = () => screen.queryByPlaceholderText(/you@company.com/i);
 const toggle = () => screen.getByTestId("cta-banner-toggle");
 const body = () => screen.getByTestId("cta-banner-body");
 
-// happy-dom reflects the boolean `inert` attribute via hasAttribute, not the
-// IDL property — assert on the attribute.
-const isHidden = (el: HTMLElement) =>
-  el.hasAttribute("inert") || el.getAttribute("aria-hidden") === "true";
+// `inert` and `aria-hidden` are DISTINCT contracts — `inert` removes the body
+// from tab order + interaction, `aria-hidden` silences it for assistive tech.
+// Assert each separately so dropping one (a half-regression) cannot pass green.
+const expectBodyHidden = (hidden: boolean) => {
+  expect(body().hasAttribute("inert")).toBe(hidden);
+  expect(body().getAttribute("aria-hidden")).toBe(hidden ? "true" : null);
+};
 
 beforeEach(() => {
   sessionStorage.clear();
@@ -29,8 +32,8 @@ describe("CtaBanner single-toggle collapse / reopen", () => {
     expect(formPresent()).toBeTruthy();
     expect(toggle().getAttribute("aria-expanded")).toBe("true");
     expect(toggle().getAttribute("aria-label")).toBe("Collapse signup banner");
-    // The body is open (not inert/hidden) when expanded.
-    expect(isHidden(body())).toBe(false);
+    // The body is open (neither inert nor aria-hidden) when expanded.
+    expectBodyHidden(false);
   });
 
   it("clicking the toggle collapses — banner persists, body hidden, header stays", () => {
@@ -44,8 +47,8 @@ describe("CtaBanner single-toggle collapse / reopen", () => {
     );
     // The brand header survives (persistent header row).
     expect(screen.getByText(/built with/i)).toBeTruthy();
-    // The collapsible body is inert / aria-hidden — but NOT removed from the DOM.
-    expect(isHidden(body())).toBe(true);
+    // The collapsible body is inert AND aria-hidden — but NOT removed from the DOM.
+    expectBodyHidden(true);
     expect(formPresent()).toBeTruthy(); // still in the DOM, just height-collapsed
   });
 
@@ -56,17 +59,19 @@ describe("CtaBanner single-toggle collapse / reopen", () => {
 
     expect(toggle().getAttribute("aria-expanded")).toBe("true");
     expect(toggle().getAttribute("aria-label")).toBe("Collapse signup banner");
-    expect(isHidden(body())).toBe(false);
+    expectBodyHidden(false);
     expect(formPresent()).toBeTruthy();
   });
 
-  it("the toggle is a single persistent <button> present in BOTH states", () => {
+  it("the toggle is the SAME persistent <button> node across both states", () => {
     render(<CtaBanner />);
-    expect(toggle().tagName).toBe("BUTTON");
+    const before = toggle();
+    expect(before.tagName).toBe("BUTTON");
 
-    fireEvent.click(toggle());
-    // Still resolvable by the same test id after collapse (it did not unmount).
-    expect(toggle().tagName).toBe("BUTTON");
+    fireEvent.click(before);
+    // Same DOM node after collapse — proves it did not unmount/remount (which is
+    // what makes the 180° rotation animate rather than snap).
+    expect(Object.is(toggle(), before)).toBe(true);
   });
 
   it("does NOT persist collapsed state — no sessionStorage write occurs on toggle", () => {

--- a/apps/web-platform/test/shared-cta-banner-close.test.tsx
+++ b/apps/web-platform/test/shared-cta-banner-close.test.tsx
@@ -1,11 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { CtaBanner } from "@/components/shared/cta-banner";
 
 const STORAGE_KEY = "soleur:shared:cta-dismissed";
 
 const formPresent = () => screen.queryByPlaceholderText(/you@company.com/i);
-const reopenPresent = () => screen.queryByTestId("cta-banner-reopen");
+const toggle = () => screen.getByTestId("cta-banner-toggle");
+const body = () => screen.getByTestId("cta-banner-body");
+
+// happy-dom reflects the boolean `inert` attribute via hasAttribute, not the
+// IDL property — assert on the attribute.
+const isHidden = (el: HTMLElement) =>
+  el.hasAttribute("inert") || el.getAttribute("aria-hidden") === "true";
 
 beforeEach(() => {
   sessionStorage.clear();
@@ -17,79 +23,58 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("CtaBanner collapse / reopen affordance", () => {
-  it("renders the waitlist form and the collapse button by default", () => {
+describe("CtaBanner single-toggle collapse / reopen", () => {
+  it("renders the waitlist form and a single toggle (expanded) by default", () => {
     render(<CtaBanner />);
     expect(formPresent()).toBeTruthy();
-    expect(screen.getByTestId("cta-banner-dismiss")).toBeTruthy();
-    // The reopen affordance only exists once collapsed.
-    expect(reopenPresent()).toBeNull();
+    expect(toggle().getAttribute("aria-expanded")).toBe("true");
+    expect(toggle().getAttribute("aria-label")).toBe("Collapse signup banner");
+    // The body is open (not inert/hidden) when expanded.
+    expect(isHidden(body())).toBe(false);
   });
 
-  it("collapsing shows the thin bar — the banner is NOT unmounted", () => {
+  it("clicking the toggle collapses — banner persists, body hidden, header stays", () => {
     render(<CtaBanner />);
-    fireEvent.click(screen.getByTestId("cta-banner-dismiss"));
+    fireEvent.click(toggle());
 
-    // Collapsed strip is present (banner still mounted, just collapsed).
-    const reopen = screen.getByRole("button", {
-      name: /reopen soleur signup banner/i,
-    });
-    expect(reopen).toBeTruthy();
-    // The full form is gone in the collapsed state.
-    expect(formPresent()).toBeNull();
-    // The brand label survives INSIDE the collapsed strip specifically
-    // (scoped so it can't pass by matching the expanded banner copy).
-    expect(within(reopen).getByText(/built with/i)).toBeTruthy();
-    expect(within(reopen).getByText(/soleur/i)).toBeTruthy();
-  });
-
-  it("the collapsed bar exposes the reopen affordance with correct aria", () => {
-    render(<CtaBanner />);
-    fireEvent.click(screen.getByTestId("cta-banner-dismiss"));
-
-    const reopen = screen.getByRole("button", {
-      name: /reopen soleur signup banner/i,
-    });
-    expect(reopen.getAttribute("aria-label")).toBe("Reopen Soleur signup banner");
-    expect(reopen.getAttribute("aria-expanded")).toBe("false");
-  });
-
-  it("clicking the collapsed bar re-expands the full banner with the form", () => {
-    render(<CtaBanner />);
-    fireEvent.click(screen.getByTestId("cta-banner-dismiss"));
-    expect(formPresent()).toBeNull();
-
-    fireEvent.click(
-      screen.getByRole("button", { name: /reopen soleur signup banner/i }),
+    // The toggle is still present (persistent) and now signals "reopen".
+    expect(toggle().getAttribute("aria-expanded")).toBe("false");
+    expect(toggle().getAttribute("aria-label")).toMatch(
+      /reopen soleur signup banner/i,
     );
+    // The brand header survives (persistent header row).
+    expect(screen.getByText(/built with/i)).toBeTruthy();
+    // The collapsible body is inert / aria-hidden — but NOT removed from the DOM.
+    expect(isHidden(body())).toBe(true);
+    expect(formPresent()).toBeTruthy(); // still in the DOM, just height-collapsed
+  });
 
-    // Round-trip restored without any reload.
+  it("clicking again re-expands — aria + body restored", () => {
+    render(<CtaBanner />);
+    fireEvent.click(toggle()); // collapse
+    fireEvent.click(toggle()); // re-expand
+
+    expect(toggle().getAttribute("aria-expanded")).toBe("true");
+    expect(toggle().getAttribute("aria-label")).toBe("Collapse signup banner");
+    expect(isHidden(body())).toBe(false);
     expect(formPresent()).toBeTruthy();
-    expect(reopenPresent()).toBeNull();
   });
 
-  it("the expanded close control reflects aria-expanded=true", () => {
+  it("the toggle is a single persistent <button> present in BOTH states", () => {
     render(<CtaBanner />);
-    expect(
-      screen.getByTestId("cta-banner-dismiss").getAttribute("aria-expanded"),
-    ).toBe("true");
+    expect(toggle().tagName).toBe("BUTTON");
+
+    fireEvent.click(toggle());
+    // Still resolvable by the same test id after collapse (it did not unmount).
+    expect(toggle().tagName).toBe("BUTTON");
   });
 
-  it("both controls are real <button> elements (keyboard-operable)", () => {
-    render(<CtaBanner />);
-    expect(screen.getByTestId("cta-banner-dismiss").tagName).toBe("BUTTON");
-
-    fireEvent.click(screen.getByTestId("cta-banner-dismiss"));
-    expect(screen.getByTestId("cta-banner-reopen").tagName).toBe("BUTTON");
-  });
-
-  it("does NOT persist collapsed state — no sessionStorage write occurs on collapse", () => {
+  it("does NOT persist collapsed state — no sessionStorage write occurs on toggle", () => {
     // Spy directly so the assertion is non-vacuous: it proves the component
-    // issues zero writes, independent of the beforeEach clear (the residue
-    // checks below alone would pass even if a write landed under a new key).
+    // issues zero writes, independent of the beforeEach clear.
     const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
     render(<CtaBanner />);
-    fireEvent.click(screen.getByTestId("cta-banner-dismiss"));
+    fireEvent.click(toggle());
 
     expect(setItemSpy).not.toHaveBeenCalled();
     expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
@@ -102,6 +87,6 @@ describe("CtaBanner collapse / reopen affordance", () => {
     sessionStorage.setItem(STORAGE_KEY, "1");
     render(<CtaBanner />);
     expect(formPresent()).toBeTruthy();
-    expect(reopenPresent()).toBeNull();
+    expect(toggle().getAttribute("aria-expanded")).toBe("true");
   });
 });

--- a/knowledge-base/project/learnings/best-practices/2026-06-09-jsx-comment-braces-break-ternary-branch.md
+++ b/knowledge-base/project/learnings/best-practices/2026-06-09-jsx-comment-braces-break-ternary-branch.md
@@ -1,0 +1,76 @@
+---
+title: A `{/* */}` JSX comment beside an expression inside a parenthesized ternary branch breaks parsing
+date: 2026-06-09
+category: best-practices
+module: apps/web-platform/components
+tags: [jsx, tsx, react, syntax, ternary]
+pr: 5076
+---
+
+# Learning: `{/* */}` JSX comments are child-position only — don't put them in a `( … )` ternary branch
+
+## Problem
+
+Adding an inline rationale comment above a `<form>` that lives in the `else`
+branch of a JSX ternary produced a cascade of opaque TypeScript syntax errors:
+
+```
+error TS1005: ')' expected.
+error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
+error TS17002: Expected corresponding JSX closing tag for 'div'.
+```
+
+The offending edit:
+
+```tsx
+{status === "success" ? (
+  <p>…</p>
+) : (
+  {/* pt-0.5 keeps the focus ring off the clip boundary */}   // ← breaks it
+  <form …>…</form>
+)}
+```
+
+## Root cause
+
+A `{/* … */}` JSX comment is **not** a general-purpose comment — it is a
+*child-position* construct (an empty JSX expression container). The parens of a
+ternary branch `( … )` may contain exactly **one** expression. Writing
+`{/* … */}<form/>` inside them is two sibling expressions, which is a syntax
+error. The same `{/* */}` is perfectly valid one level down, *as a child* of a
+JSX element (`<div>{/* ok here */}<form/></div>`), because there the parser is
+already in child position.
+
+## Solution
+
+Inside a parenthesized ternary branch (or anywhere you need a comment beside a
+single returned element), use a **plain block comment** — no braces:
+
+```tsx
+) : (
+  /* pt-0.5 keeps the focus ring off the clip boundary */
+  <form …>…</form>
+)}
+```
+
+`( /* comment */ <form/> )` is a single expression with a leading block comment —
+valid. Alternatives: move the `{/* */}` comment to be the first *child* of an
+element, or hoist the comment to a normal `//` line above the whole `{ternary}`.
+
+## Key insight
+
+`{/* */}` works as a JSX *child*, not as a free-standing statement. The "it
+breaks in a ternary branch" symptom is the tell: the branch's `( … )` wants one
+expression, and the JSX-comment container is a second one. Reach for a bare
+`/* */` block comment in expression position; reserve `{/* */}` for between an
+element's children.
+
+## Session Errors
+
+1. **`{/* */}` JSX comment in a ternary `else` branch → TS1005 / TS1382 / TS17002**
+   (this learning). Recovery: switched to a plain `/* */` block comment.
+   Prevention: in expression/ternary-branch position use `/* */` (no braces);
+   `{/* */}` is for child position only. tsc catches it immediately — run
+   `tsc --noEmit` right after the edit rather than discovering it at suite run.
+2. **`${PIPESTATUS[0]}` after `| head` rendered empty** — transient shell quirk;
+   re-ran `tsc` with `echo "tsc-exit=$?"`. One-off, no recurrence vector.

--- a/knowledge-base/project/plans/2026-06-09-feat-cta-banner-rotating-arrow-two-way-animation-plan.md
+++ b/knowledge-base/project/plans/2026-06-09-feat-cta-banner-rotating-arrow-two-way-animation-plan.md
@@ -1,0 +1,252 @@
+---
+type: feat
+lane: single-domain
+brand_survival_threshold: none
+branch: feat-one-shot-banner-rotating-arrow-twoway-anim
+created: 2026-06-09
+component: apps/web-platform/components/shared/cta-banner.tsx
+---
+
+# ✨ feat: CTA banner — single rotating arrow + two-way collapse animation
+
+## Enhancement Summary
+
+**Deepened on:** 2026-06-09
+**Sections enhanced:** Research Insights (Tailwind/inert/motion-reduce verification), Risks (happy-dom inert), Domain Review (wireframe reference)
+**Verification passes used:** verify-the-negative, Tailwind-arbitrary-value confirmation (installed v4.2.1 + in-repo precedent), inert precedent-diff (Phase 4.4), mandatory gates 4.6/4.7/4.8/4.9
+
+### Key Improvements
+1. Confirmed the one novel-to-this-file technique (`grid-rows-[0fr↔1fr]` + `transition-[grid-template-rows]`) compiles under the installed Tailwind v4.2.1 — proven by in-repo `grid-cols-[1fr_auto…]` and `transition-[width]` usage, including a ternary-of-two-whole-literals precedent at `team-membership-list.tsx:52`.
+2. Pinned the exact `inert={cond || undefined}` precedent (`layout.tsx:293,519`) and the in-file `motion-reduce` idiom — both adopted verbatim, zero novelty.
+3. Resolved the Phase 4.9 wireframe gate via the already-committed `cta-banner-waitlist.pen` (PR #5035) for this exact surface.
+
+### New Considerations Discovered
+- happy-dom `inert` IDL reflection is unreliable → assert on `hasAttribute("inert")` / `aria-hidden`, not `.inert`.
+- The state-swapped shell padding (`py-2`/`py-3`) from PR #5075 collapses to a single `py-3` since height now animates via the grid, not padding.
+
+## Overview
+
+Refine the shared-document waitlist CTA banner (`apps/web-platform/components/shared/cta-banner.tsx`, last changed by **PR #5075** which added collapse/reopen) with two presentational UX improvements:
+
+1. **Animate both directions** (open AND close). Re-architect from two mutually-exclusive conditionally-rendered panels (each wrapped in the `<Reveal>` mount-flag helper that animates only the *incoming* panel) to a **single persistent structure**: a persistent header row + a collapsible body animated with the CSS `grid-template-rows: 0fr ↔ 1fr` technique. Both open and close ease smoothly with no JS height measurement.
+2. **One rotating arrow** (no cross). Replace the X close icon with a **single persistent chevron** `<button>` that stays mounted across both states and rotates 180° between them via `transition-transform`. No X/cross icon anywhere.
+
+Single-component change plus its test rewrite. **No backend/API change** — `/api/waitlist` and the form-submit state machine (`idle | submitting | success | error`) stay byte-for-byte identical. Persistence stays in-memory only (reload restores expanded); sessionStorage/safeSession are NOT reintroduced.
+
+**Scope:** `apps/web-platform/components/shared/cta-banner.tsx` + `apps/web-platform/test/shared-cta-banner-close.test.tsx`. The waitlist test (`shared-cta-banner-waitlist.test.tsx`) must stay green **and unedited**.
+
+## Premise Validation
+
+- **PR #5075** (`feat(shared): collapse shared-doc waitlist banner to a reopenable bar`) — `gh pr view 5075` confirms `state: MERGED`, `mergedAt: 2026-06-09T08:18:12Z`. The current-state description (expanded/collapsed `useState`, `<Reveal>` helper, `data-testid="cta-banner-dismiss"` X-icon with two `<line>`, `data-testid="cta-banner-reopen"` up-chevron polyline) was confirmed by reading the file directly — **matches exactly**.
+- **Legacy sessionStorage key** `"soleur:shared:cta-dismissed"` — the component already does NOT read or write it (grep of the file shows zero `sessionStorage`/`safeSession` references; the test pre-seeds the key purely to assert the component ignores it). Premise holds.
+- No external blocker/dependency issues cited. No stale premise found.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Spec/args claim | Codebase reality | Plan response |
+| --- | --- | --- |
+| `cta-banner-dismiss` = X-icon (two `<line>` cross) in expanded; `cta-banner-reopen` = up-chevron in collapsed | Confirmed at `cta-banner.tsx:137-152` (cross) and `:90-113` (polyline `18 15 12 9 6 15`) | Both testids retired; replaced by a single `cta-banner-toggle` |
+| `<Reveal>` mount-flag helper animates incoming panel only | Confirmed at `cta-banner.tsx:17-38` (rAF `entered` flag, `transition-[transform,opacity]`) | Helper deleted entirely |
+| Persistence already removed; in-memory only | Confirmed — no `sessionStorage` in file | Unchanged; do NOT reintroduce |
+| Waitlist test must stay green & unedited | `shared-cta-banner-waitlist.test.tsx` renders default (expanded) state, exercises form/success/error swap; line 60 asserts `queryByPlaceholderText(...)` is `null` **on success** | The form↔success conditional (`status === "success" ? … : <form>`) is ORTHOGONAL to collapse and is preserved verbatim inside the collapsible body. Line 60 stays true because success still swaps the form out. The aria-live region (test line 34-41) renders in default-expanded state → present. ✅ No component change is forced by this suite. |
+| 5 other test files reference the banner | `shared-image-a11y`, `shared-page-diagram`, `shared-page-head-first`, `shared-page-ui`, `shared-token-content-changed-ui` all `vi.mock` `CtaBanner` to a stub `<div data-testid="cta-banner" />` | Fully insulated — they never touch internals. No edits needed. |
+| `inert` attribute support | Prior art at `app/(dashboard)/layout.tsx:289,293,519` uses React's `inert={cond \|\| undefined}` pattern (React 19 strips `undefined`; `inert` is a real boolean attr) | Adopt verbatim: `inert={collapsed \|\| undefined}` on the body wrapper |
+| `grid-rows-[1fr]/[0fr]` technique | **No prior art** in `apps/web-platform/**/*.tsx` (grep returned zero) | Pattern is novel in this repo but is a well-established CSS idiom; documented inline with a comment |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a shared-document viewer whose waitlist banner either fails to collapse/expand (stuck panel), shows a janky snap instead of a smooth animation, or has a tab-trap (form inputs reachable while visually collapsed). Worst realistic case: the toggle does nothing and the banner is permanently expanded — annoying, not destructive; the document content above it is unaffected.
+
+**If this leaks, the user's data is exposed via:** N/A — this component sends only the email the user voluntarily types into the existing waitlist form to the unchanged `/api/waitlist` endpoint. No new data flow, no new persistence, no PII surface introduced.
+
+**Brand-survival threshold:** `none`. Rationale: presentational micro-interaction on an already-shipped banner; a regression degrades polish, not user data, money, or workflow. The diff touches no sensitive path (component is client-only presentational TSX; no schema/auth/API/migration). `threshold: none, reason: presentational micro-interaction on an existing client component; no data/money/workflow surface and no sensitive-path file touched.`
+
+## Implementation Phases
+
+> TDD: rewrite the close test first (RED), then re-architect the component (GREEN). The waitlist test must stay green throughout — run it after every component change.
+
+### Phase 0 — Preconditions (verify before editing)
+
+- [ ] `tsc --noEmit` baseline clean: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (NOT `npm run -w` — repo root declares no `workspaces`).
+- [ ] Both target suites green at baseline: `cd apps/web-platform && ./node_modules/.bin/vitest run test/shared-cta-banner-close.test.tsx test/shared-cta-banner-waitlist.test.tsx`.
+- [ ] Confirm React major supports bare `inert` boolean prop (prior art `app/(dashboard)/layout.tsx:293` already ships `inert={cond || undefined}` → supported).
+
+### Phase 1 — Rewrite the close test (RED)
+
+Rewrite `apps/web-platform/test/shared-cta-banner-close.test.tsx` for the single-toggle structure. Drive ALL transitions via `fireEvent.click` on the **same render** (in-component state machine; never remount). Keep `STORAGE_KEY = "soleur:shared:cta-dismissed"`, `beforeEach`/`afterEach` `sessionStorage.clear()` + `vi.restoreAllMocks()`.
+
+Required cases (the test file is the contract):
+
+1. **Default render**: form present (`queryByPlaceholderText(/you@company.com/i)` truthy) + single toggle `getByTestId("cta-banner-toggle")` with `aria-expanded === "true"`.
+2. **Click toggle collapses**: after one click — `aria-expanded === "false"`; `aria-label` matches `/reopen soleur signup banner/i`; the persistent "Built with Soleur" header is **still visible** (`getByText(/built with/i)` truthy — it lives in the always-rendered header now); the collapsible **body wrapper is `inert` OR `aria-hidden="true"`**. **Do NOT assert the form is removed** — grid-collapse keeps it in the DOM. Assert on the body wrapper via a stable hook (`data-testid="cta-banner-body"`): `body.hasAttribute("inert") || body.getAttribute("aria-hidden") === "true"`.
+3. **Click again re-expands**: `aria-expanded === "true"`; `aria-label` matches `/collapse signup banner/i`; body no longer `inert` (and `aria-hidden` absent/false).
+4. **Toggle is a single persistent `<button>`**: `getByTestId("cta-banner-toggle").tagName === "BUTTON"`; present in BOTH states (capture the element ref before the first click, assert the same testid resolves after collapse and after re-expand — it does not unmount). A clean way: assert `getByTestId("cta-banner-toggle")` is non-null in default, after collapse, and after re-expand.
+5. **No sessionStorage write on toggle**: `vi.spyOn(Storage.prototype, "setItem")` not called after a collapse click; `sessionStorage.getItem(STORAGE_KEY)` null; `sessionStorage.length === 0`.
+6. **Fresh mount with legacy key pre-seeded still renders expanded**: `sessionStorage.setItem(STORAGE_KEY, "1")` then `render(<CtaBanner />)` → form present + `aria-expanded === "true"` on the toggle.
+
+Retire the old selectors entirely: no `cta-banner-dismiss`, no `cta-banner-reopen`, no `reopenPresent()` helper. Run → expect RED (component still uses old structure).
+
+### Phase 2 — Re-architect the component (GREEN)
+
+Edit `apps/web-platform/components/shared/cta-banner.tsx`:
+
+1. **Delete the `<Reveal>` helper** (lines 12-38) and its `ReactNode` import usage if now unused (keep `FormEvent`; drop `ReactNode` and the `useEffect` import if `Reveal` was their only consumer — verify with `tsc`).
+2. **Remove the two-panel conditional return** (the `if (panel === "collapsed") return …` block and the separate expanded `return`). Keep the `Panel = "expanded" | "collapsed"` type and `useState<Panel>("expanded")`; rename handlers to a single `toggle()` that flips the panel (or inline an `onClick={() => setPanel(p => p === "expanded" ? "collapsed" : "expanded")}`).
+3. **Single persistent shell** keeping the exact footprint: `fixed bottom-0 left-0 right-0 z-40 border-t border-soleur-border-default bg-soleur-bg-surface-1/95 backdrop-blur-sm`. Inner `mx-auto max-w-3xl`. (Note: the shell's vertical padding previously differed by state — `py-2` collapsed vs `py-3` expanded. Use a single stable padding, e.g. `px-4 py-3`, since the body now collapses to 0fr; document that the strip height shrinks via the grid, not via padding swap.)
+4. **Persistent header row** (always rendered): left = the "Built with **Soleur**" line (gold `text-soleur-accent-gold-fg` on "Soleur"); right = the toggle button. Keep the "— AI agents for every department of your startup." tail copy in the expanded header if desired, but the load-bearing test text is "Built with" + "Soleur", which must always render. (Simplest: keep the full sentence in the header at all times — it is short and reads fine above the collapsed strip.)
+5. **Toggle button** — single persistent `<button type="button" data-testid="cta-banner-toggle">`:
+   - `onClick` flips `expanded ↔ collapsed`.
+   - `aria-expanded={panel === "expanded"}`.
+   - `aria-label`: `"Collapse signup banner"` when expanded, `"Reopen Soleur signup banner"` when collapsed (flips with state).
+   - One chevron-up svg: `<polyline points="18 15 12 9 6 15" />` (points up). Wrap the svg (or apply to it) `transition-transform duration-300 ease-out motion-reduce:transition-none motion-reduce:duration-0` and toggle `rotate-180` by state.
+   - **Mapping comment (verbatim intent):** `// COLLAPSED = rotate-0 (chevron points UP = "expand toward me"); EXPANDED = rotate-180 (points DOWN = "collapse"). Arrow points toward the action; 180° via transition-transform.`
+6. **Collapsible body** — the grid technique:
+   ```tsx
+   {/* grid-template-rows 0fr↔1fr animates height in BOTH directions, no JS measurement. */}
+   <div
+     data-testid="cta-banner-body"
+     className={`grid transition-[grid-template-rows] duration-300 ease-out motion-reduce:transition-none motion-reduce:duration-0 ${
+       panel === "expanded" ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+     }`}
+     inert={panel === "collapsed" || undefined}
+     aria-hidden={panel === "collapsed" || undefined}
+   >
+     <div className="overflow-hidden">
+       {/* form OR success message — UNCHANGED conditional */}
+     </div>
+   </div>
+   ```
+   - The inner `overflow-hidden` div holds the existing `status === "success" ? <success-message> : <form>` block **verbatim** (preserve the form, honeypot, Privacy Policy link, and the persistent `role="status" aria-live="polite"` error region exactly — these are the waitlist-test selectors).
+7. **Reduced motion**: every `transition-*`/`duration-*` utility (the grid-rows transition AND the transform rotation) MUST be paired with `motion-reduce:transition-none motion-reduce:duration-0`. The file already imports this idiom (it was on `<Reveal>`); re-apply to both new transition sites.
+
+Run both suites → expect GREEN. Run `./node_modules/.bin/tsc --noEmit` → clean.
+
+### Phase 3 — Verify
+
+- [ ] `cd apps/web-platform && ./node_modules/.bin/vitest run test/shared-cta-banner-close.test.tsx test/shared-cta-banner-waitlist.test.tsx` — both green.
+- [ ] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` — clean.
+- [ ] Grep the component for residue: no `Reveal`, no `cta-banner-dismiss`, no `cta-banner-reopen`, no `<line `, no `sessionStorage`/`safeSession`.
+- [ ] Grep both transition utilities are motion-reduce-paired (`transition-[grid-template-rows]` and `transition-transform` each followed by `motion-reduce:transition-none motion-reduce:duration-0`).
+- [ ] (Optional, broader confidence) full component-project run: `./node_modules/.bin/vitest run test/shared-*.test.tsx` — the 5 mocked sibling suites should be unaffected.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] **AC1 — two-way animation**: component contains a single body wrapper with `grid transition-[grid-template-rows] … ease-out` toggling `grid-rows-[1fr]` (expanded) ↔ `grid-rows-[0fr]` (collapsed); the `<Reveal>` helper and the two-mutually-exclusive-panel conditional returns are gone. Verify: `grep -c "Reveal" cta-banner.tsx` returns 0; `grep -E "grid-rows-\[1fr\]|grid-rows-\[0fr\]" cta-banner.tsx` matches both.
+- [ ] **AC2 — single rotating arrow, no cross**: exactly one `<polyline points="18 15 12 9 6 15" />` chevron, wrapped in `transition-transform … rotate-180` toggled by state; **no `<line ` element anywhere** (`grep -c "<line " cta-banner.tsx` returns 0). Single `data-testid="cta-banner-toggle"`; old `cta-banner-dismiss`/`cta-banner-reopen` testids absent.
+- [ ] **AC3 — reduced motion**: both the grid-rows transition and the transform rotation are paired with `motion-reduce:transition-none motion-reduce:duration-0` (every `transition-`/`duration-` utility on the component has the motion-reduce pairing).
+- [ ] **AC4 — accessibility**: collapsed body wrapper carries `inert` (and `aria-hidden`); expanded removes both. Toggle has correct `aria-expanded` (`true` expanded / `false` collapsed) and flipping `aria-label` (`/collapse signup banner/i` expanded, `/reopen soleur signup banner/i` collapsed). Toggle is a real keyboard-operable `<button>` (`tagName === "BUTTON"`).
+- [ ] **AC5 — persistence unchanged**: no `sessionStorage`/`safeSession` in the component; the close-test's "no setItem on toggle" + "legacy key pre-seeded still renders expanded" cases pass.
+- [ ] **AC6 — close test rewritten & green**: `shared-cta-banner-close.test.tsx` covers the six cases above and passes; transitions driven via `fireEvent.click` on a single render (no remount).
+- [ ] **AC7 — waitlist test green & UNEDITED**: `shared-cta-banner-waitlist.test.tsx` is byte-for-byte unchanged and passes (`git diff --quiet -- apps/web-platform/test/shared-cta-banner-waitlist.test.tsx` returns clean after the work). If it would break, fix the **component**, not the test.
+- [ ] **AC8 — typecheck clean**: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` exits 0.
+
+### Post-merge (operator)
+
+- None. Pure client-component change; no migration, deploy gate, or external-service config. The `web-platform-release.yml` path-filtered pipeline restarts the container on merge to `main` touching `apps/web-platform/**` — no separate operator step.
+
+## Test Scenarios
+
+| Scenario | Expectation |
+| --- | --- |
+| Default mount | Header "Built with Soleur" visible; body expanded (`grid-rows-[1fr]`); form present; toggle `aria-expanded=true`, chevron rotate-0 |
+| Click toggle (collapse) | `grid-rows-[0fr]`; body `inert`+`aria-hidden`; form still in DOM but out of tab order; toggle `aria-expanded=false`, `aria-label` → reopen; chevron rotate-180 |
+| Click toggle (re-expand) | Round-trips to default; body no longer inert; `aria-label` → collapse |
+| Submit success (no collapse) | Form swaps to "You're on the list ✓" inside the body; email input gone (waitlist test line 60) — unaffected by collapse mechanism |
+| Reload | In-memory state resets → expanded (no sessionStorage) |
+| prefers-reduced-motion | Both collapse and rotation instant (motion-reduce pairing) — manual/visual; not unit-asserted |
+
+## Risks & Mitigations
+
+- **Waitlist test regression (highest risk).** The single-structure rewrite must NOT disturb the form/success/error conditional or its selectors (placeholder `you@company.com`, `/^join$/i` button, Privacy Policy link, the `role="status" aria-live="polite"` error region, the success `/you're on the list/i` copy). *Mitigation:* move the existing Tier-2 block **verbatim** into the inner `overflow-hidden` div; run the waitlist suite after every edit; AC7 asserts the test file is unedited.
+- **Success-state + collapse interaction.** Test line 60 asserts the email input is `null` on success. This holds because success swaps `<form>`→`<success>` regardless of expand/collapse — orthogonal axes. *Mitigation:* keep `status === "success" ? … : <form>` as the inner conditional; do NOT gate it on `panel`.
+- **`inert` + `aria-hidden` double-application.** React strips `false`/`undefined` boolean attrs; use `inert={panel === "collapsed" || undefined}` (prior art `layout.tsx:293`). Avoid `inert={false}` (renders `inert=""` in some DOM impls). *Mitigation:* the `|| undefined` idiom; the close test asserts the attribute is absent when expanded.
+- **happy-dom `inert` reflection.** The component-project env is happy-dom; assert via `hasAttribute("inert")` (attribute presence), not the `.inert` IDL property, to avoid env-specific reflection gaps. *Mitigation:* test on the attribute; allow `aria-hidden="true"` as the OR-fallback per the args.
+- **`grid-rows-[0fr]` arbitrary-value purge.** Tailwind must emit the arbitrary `grid-template-rows` utilities. *Mitigation:* both classes are static string literals in the className (not interpolated fragments), so Tailwind's content scanner picks them up; the ternary selects between two whole literals. Do NOT build the class via string concatenation of `grid-rows-[` + value.
+
+## Domain Review
+
+**Domains relevant:** Product (UI-surface override — edits `components/shared/cta-banner.tsx`).
+
+### Product/UX Gate
+
+**Tier:** advisory
+**Decision:** auto-accepted (pipeline)
+**Agents invoked:** none
+**Skipped specialists:** none — ADVISORY tier modifies an existing component without adding a new page, multi-step flow, or new interactive surface (the collapse/expand toggle already exists from PR #5075; this refines its icon and animation). No new `*.tsx` file is created, so the BLOCKING mechanical escalation (`components/**/*.tsx` *new file*) does not fire. `ux-design-lead` is N/A — no new user-facing surface to wireframe.
+**Pencil available:** N/A (no new UI surface; presentational refinement of an existing control)
+
+#### Findings
+
+Presentational micro-interaction. No new flow, copy, or surface. Brand-survival threshold `none`. Auto-accepted per pipeline ADVISORY path.
+
+**Wireframe reference:** This surface already has a committed wireframe — `knowledge-base/product/design/shared-document/cta-banner-waitlist.pen` (committed in PR #5035, 20.6 KB). This change refines the icon and animation of the *already-wireframed* shared-document CTA banner; it adds no new surface requiring a fresh `.pen`. The existing wireframe is the design-of-record for the banner's layout (header line + email-capture body), which this plan preserves structurally (header row + collapsible form body). Per `wg-ui-feature-requires-pen-wireframe`, the committed `.pen` for this surface satisfies the wireframe requirement.
+
+## Infrastructure (IaC)
+
+None. No server, service, cron, secret, DNS, cert, or vendor surface introduced. Pure client-component edit under `apps/web-platform/components/`. Phase 2.8 skipped.
+
+## Observability
+
+Skipped — no Files-to-Edit under `apps/*/server/`, `apps/*/src/`, `apps/*/infra/`, or `plugins/*/scripts/`, and no new infrastructure surface. The only edited code file is a client-only presentational component (`apps/web-platform/components/shared/cta-banner.tsx`) plus its test. Phase 2.9 skip condition (pure client/component change, no new code/infra runtime surface) applies.
+
+## Research Insights
+
+**Deepened on:** 2026-06-09 (single-component presentational change — targeted verification rather than broad fan-out).
+
+### Tailwind arbitrary-value support (the one novel-to-this-file technique) — VERIFIED
+
+The `grid-rows-[1fr]`/`grid-rows-[0fr]` + `transition-[grid-template-rows]` technique has no prior art in `cta-banner.tsx`, but is fully supported by the installed toolchain and used elsewhere in the repo:
+
+- **Installed Tailwind: v4.2.1** (`package.json` declares `tailwindcss: ^4.1.0`). Tailwind v4 JIT-compiles arbitrary values with no `safelist` config needed for static class literals.
+- **Arbitrary `fr` grid values already ship**: `components/settings/delegation-funded-pane.tsx:57,68` and `team-membership-list.tsx:52,145` use `grid-cols-[1fr_auto_auto…]`. Arbitrary `fr` units compile correctly here.
+- **Arbitrary-property transitions already ship**: `app/(dashboard)/layout.tsx:309`, `components/chat/review-gate-card.tsx:63`, `components/connect-repo/setting-up-state.tsx:29` all use `transition-[width]`. `transition-[grid-template-rows]` uses the identical arbitrary-property mechanism → will emit.
+- **Ternary-of-two-whole-literals is a proven pattern**: `team-membership-list.tsx:52` selects between two whole arbitrary-value class strings via a ternary — exactly the `panel === "expanded" ? "grid-rows-[1fr]" : "grid-rows-[0fr]"` shape the plan prescribes. Confirms the content scanner picks up both branches when each is a complete literal (do NOT build the class via `"grid-rows-[" + value + "]"` concatenation).
+
+### `inert` precedent (Phase 4.4 precedent-diff) — VERIFIED
+
+`app/(dashboard)/layout.tsx:293` (`inert={signOutModalOpen || undefined}`) and `:519` (`inert={drawerOpen || undefined}`) ship the exact `inert={cond || undefined}` form the plan prescribes. React strips `false`/`undefined` boolean attrs; `inert` is a real boolean DOM attribute in React 19. Adopt verbatim. No deviation from precedent.
+
+### `motion-reduce` precedent — VERIFIED
+
+The current `<Reveal>` helper (`cta-banner.tsx:31`) already pairs `transition-[transform,opacity] duration-300 ease-out` with `motion-reduce:transition-none motion-reduce:duration-0`. The plan re-applies this exact pairing to the two new transition sites (grid-rows + transform). Idiom already in-file; zero novelty.
+
+### Verify-the-negative pass — all CONFIRM
+
+- "No `sessionStorage`/`safeSession`/`localStorage` in the component" → grep of `cta-banner.tsx` returns zero. CONFIRMS.
+- "Only consumer is `app/shared/[token]/page.tsx`" → grep CONFIRMS (one import + one `{data && <CtaBanner />}` mount).
+- "Waitlist test renders default (expanded) and never touches collapse controls" → grep of `shared-cta-banner-waitlist.test.tsx` for any collapse/toggle/reopen selector returns zero. CONFIRMS the form/success/error selectors are reachable in the default-expanded render and are unaffected by the collapse mechanism.
+- "5 sibling shared-page test files mock `CtaBanner`" → each `vi.mock`s it to `<div data-testid="cta-banner" />`; fully insulated. CONFIRMS.
+
+### Edge cases surfaced
+
+- **happy-dom `inert` reflection**: assert via `element.hasAttribute("inert")` (attribute presence), not the `.inert` IDL property — happy-dom's IDL reflection of `inert` is less reliable than attribute presence. The args already allow `aria-hidden="true"` as the OR-fallback, which is robust in happy-dom.
+- **Single padding vs state-swapped padding**: PR #5075 used `py-2` (collapsed) vs `py-3` (expanded) on the shell. With grid-collapse the body height is driven by `0fr↔1fr`, so collapse no longer needs a padding swap; use one stable `py-3`. The visible collapsed height is header-row + padding, which is intentional (a slim strip), matching the PR #5075 collapsed footprint closely enough for a polish change.
+- **Success state inside the collapsible body**: the `status === "success" ? <success> : <form>` conditional must live INSIDE the inner `overflow-hidden` div and must NOT be gated on `panel`. The waitlist test's success case (input removed on success) depends on this being orthogonal to collapse.
+
+### References
+
+- Tailwind v4 arbitrary values / arbitrary properties: https://tailwindcss.com/docs/grid-template-rows (and the arbitrary-property `transition-[…]` form) — cross-checked against installed v4.2.1 and in-repo usage above.
+- CSS `grid-template-rows: 0fr ↔ 1fr` height-animation technique: a well-established idiom for animating to/from auto height without JS measurement (works because `fr` is an interpolatable length-percentage in grid track sizing).
+
+## Files to Edit
+
+- `apps/web-platform/components/shared/cta-banner.tsx` — re-architect to single persistent structure; delete `<Reveal>`; single rotating-chevron toggle; grid-rows two-way animation; `inert`/`aria-hidden` on collapsed body; motion-reduce pairing on both transitions.
+- `apps/web-platform/test/shared-cta-banner-close.test.tsx` — rewrite for the single-toggle structure (six cases above); retire `cta-banner-dismiss`/`cta-banner-reopen`; assert on `cta-banner-toggle` + `cta-banner-body`.
+
+## Files to Create
+
+- None.
+
+## Open Code-Review Overlap
+
+None. `gh issue list --label code-review --state open` (63 open) scanned against all three planned paths (`components/shared/cta-banner.tsx`, `shared-cta-banner-close.test.tsx`, `shared-cta-banner-waitlist.test.tsx`) — zero matches.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder text, or omits the threshold will fail `deepen-plan` Phase 4.6. (This plan's section is filled; threshold `none` with reason.)
+- **Both toggle states must render correctly** (collapse/expand control alignment + icon). Per learning `2026-04-17-alignment-fixes-must-verify-both-toggle-states.md`: verify the chevron and header align in BOTH expanded and collapsed states — the single-structure rewrite makes them share one DOM subtree, which de-risks this vs. the old two-panel split, but confirm the collapsed strip (header-only, body at 0fr) still aligns the chevron right.
+- **Typecheck command is `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit`** — NOT `npm run -w apps/web-platform typecheck` (repo root declares no `workspaces`; the `-w` form aborts with "No workspaces found").
+- **Test runner is vitest, not bun** — `apps/web-platform/bunfig.toml` has `[test] pathIgnorePatterns = ["**"]` blocking bun test discovery. Run `./node_modules/.bin/vitest run <path>`. Test files MUST live under `test/**/*.test.tsx` (the component-project `include:` glob) — both target files already do.
+- **Waitlist test is load-bearing and unedited** — its success-case (line 60) and aria-live-region (lines 34-41) selectors constrain the component's inner form/success conditional. Do not move or rename those.

--- a/knowledge-base/project/plans/2026-06-09-feat-cta-banner-rotating-arrow-two-way-animation-plan.md
+++ b/knowledge-base/project/plans/2026-06-09-feat-cta-banner-rotating-arrow-two-way-animation-plan.md
@@ -133,14 +133,14 @@ Run both suites → expect GREEN. Run `./node_modules/.bin/tsc --noEmit` → cle
 
 ### Pre-merge (PR)
 
-- [ ] **AC1 — two-way animation**: component contains a single body wrapper with `grid transition-[grid-template-rows] … ease-out` toggling `grid-rows-[1fr]` (expanded) ↔ `grid-rows-[0fr]` (collapsed); the `<Reveal>` helper and the two-mutually-exclusive-panel conditional returns are gone. Verify: `grep -c "Reveal" cta-banner.tsx` returns 0; `grep -E "grid-rows-\[1fr\]|grid-rows-\[0fr\]" cta-banner.tsx` matches both.
-- [ ] **AC2 — single rotating arrow, no cross**: exactly one `<polyline points="18 15 12 9 6 15" />` chevron, wrapped in `transition-transform … rotate-180` toggled by state; **no `<line ` element anywhere** (`grep -c "<line " cta-banner.tsx` returns 0). Single `data-testid="cta-banner-toggle"`; old `cta-banner-dismiss`/`cta-banner-reopen` testids absent.
-- [ ] **AC3 — reduced motion**: both the grid-rows transition and the transform rotation are paired with `motion-reduce:transition-none motion-reduce:duration-0` (every `transition-`/`duration-` utility on the component has the motion-reduce pairing).
-- [ ] **AC4 — accessibility**: collapsed body wrapper carries `inert` (and `aria-hidden`); expanded removes both. Toggle has correct `aria-expanded` (`true` expanded / `false` collapsed) and flipping `aria-label` (`/collapse signup banner/i` expanded, `/reopen soleur signup banner/i` collapsed). Toggle is a real keyboard-operable `<button>` (`tagName === "BUTTON"`).
-- [ ] **AC5 — persistence unchanged**: no `sessionStorage`/`safeSession` in the component; the close-test's "no setItem on toggle" + "legacy key pre-seeded still renders expanded" cases pass.
-- [ ] **AC6 — close test rewritten & green**: `shared-cta-banner-close.test.tsx` covers the six cases above and passes; transitions driven via `fireEvent.click` on a single render (no remount).
-- [ ] **AC7 — waitlist test green & UNEDITED**: `shared-cta-banner-waitlist.test.tsx` is byte-for-byte unchanged and passes (`git diff --quiet -- apps/web-platform/test/shared-cta-banner-waitlist.test.tsx` returns clean after the work). If it would break, fix the **component**, not the test.
-- [ ] **AC8 — typecheck clean**: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` exits 0.
+- [x] **AC1 — two-way animation**: component contains a single body wrapper with `grid transition-[grid-template-rows] … ease-out` toggling `grid-rows-[1fr]` (expanded) ↔ `grid-rows-[0fr]` (collapsed); the `<Reveal>` helper and the two-mutually-exclusive-panel conditional returns are gone. Verify: `grep -c "Reveal" cta-banner.tsx` returns 0; `grep -E "grid-rows-\[1fr\]|grid-rows-\[0fr\]" cta-banner.tsx` matches both.
+- [x] **AC2 — single rotating arrow, no cross**: exactly one `<polyline points="18 15 12 9 6 15" />` chevron, wrapped in `transition-transform … rotate-180` toggled by state; **no `<line ` element anywhere** (`grep -c "<line " cta-banner.tsx` returns 0). Single `data-testid="cta-banner-toggle"`; old `cta-banner-dismiss`/`cta-banner-reopen` testids absent.
+- [x] **AC3 — reduced motion**: both the grid-rows transition and the transform rotation are paired with `motion-reduce:transition-none motion-reduce:duration-0` (every `transition-`/`duration-` utility on the component has the motion-reduce pairing).
+- [x] **AC4 — accessibility**: collapsed body wrapper carries `inert` (and `aria-hidden`); expanded removes both. Toggle has correct `aria-expanded` (`true` expanded / `false` collapsed) and flipping `aria-label` (`/collapse signup banner/i` expanded, `/reopen soleur signup banner/i` collapsed). Toggle is a real keyboard-operable `<button>` (`tagName === "BUTTON"`).
+- [x] **AC5 — persistence unchanged**: no `sessionStorage`/`safeSession` in the component; the close-test's "no setItem on toggle" + "legacy key pre-seeded still renders expanded" cases pass.
+- [x] **AC6 — close test rewritten & green**: `shared-cta-banner-close.test.tsx` covers the six cases above and passes; transitions driven via `fireEvent.click` on a single render (no remount).
+- [x] **AC7 — waitlist test green & UNEDITED**: `shared-cta-banner-waitlist.test.tsx` is byte-for-byte unchanged and passes (`git diff --quiet -- apps/web-platform/test/shared-cta-banner-waitlist.test.tsx` returns clean after the work). If it would break, fix the **component**, not the test.
+- [x] **AC8 — typecheck clean**: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` exits 0.
 
 ### Post-merge (operator)
 

--- a/knowledge-base/project/specs/feat-one-shot-banner-rotating-arrow-twoway-anim/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-banner-rotating-arrow-twoway-anim/session-state.md
@@ -1,0 +1,17 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-09-feat-cta-banner-rotating-arrow-two-way-animation-plan.md
+- Status: complete
+
+### Errors
+None. CWD verified. Deepen gates 4.6/4.7/4.8/4.9 passed (threshold none; advisory wireframe gate satisfied by existing .pen from #5035).
+
+### Decisions
+- PR 5075 premise confirmed MERGED; current file matches brief (two-panel Reveal, X-icon dismiss, chevron reopen).
+- Waitlist test renders only default expanded state; stays unedited & green.
+- grid-rows-[0fr↔1fr] + transition-[grid-template-rows] verified to compile under Tailwind 4.2.1; inert={cond||undefined} + motion-reduce: idioms already in-repo.
+- Typecheck: cd apps/web-platform && ./node_modules/.bin/tsc --noEmit. Tests: ./node_modules/.bin/vitest run. happy-dom inert asserted via hasAttribute.
+
+### Components Invoked
+- soleur:plan, soleur:deepen-plan

--- a/knowledge-base/project/specs/feat-one-shot-banner-rotating-arrow-twoway-anim/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-banner-rotating-arrow-twoway-anim/tasks.md
@@ -1,0 +1,56 @@
+---
+lane: single-domain
+plan: knowledge-base/project/plans/2026-06-09-feat-cta-banner-rotating-arrow-two-way-animation-plan.md
+branch: feat-one-shot-banner-rotating-arrow-twoway-anim
+---
+
+# Tasks — CTA banner: single rotating arrow + two-way collapse animation
+
+Single-component change + its test rewrite. No backend/API/infra change. TDD: rewrite the close test (RED) → re-architect the component (GREEN). Waitlist test stays green AND unedited.
+
+## Phase 0 — Setup & Preconditions
+
+- [ ] 0.1 Baseline typecheck: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (NOT `npm run -w`; repo root declares no `workspaces`).
+- [ ] 0.2 Baseline both target suites green: `cd apps/web-platform && ./node_modules/.bin/vitest run test/shared-cta-banner-close.test.tsx test/shared-cta-banner-waitlist.test.tsx`.
+- [ ] 0.3 Re-confirm structure of `components/shared/cta-banner.tsx`: `<Reveal>` helper (lines ~12-38), two conditional-return panels, `cta-banner-dismiss` X (two `<line>`), `cta-banner-reopen` up-chevron.
+
+## Phase 1 — Rewrite close test (RED)
+
+- [ ] 1.1 Rewrite `test/shared-cta-banner-close.test.tsx` for the single-toggle structure. Keep `STORAGE_KEY = "soleur:shared:cta-dismissed"`, `beforeEach/afterEach` `sessionStorage.clear()` + `vi.restoreAllMocks()`. Drive all transitions via `fireEvent.click` on the SAME render (no remount). Retire `cta-banner-dismiss`/`cta-banner-reopen` and the `reopenPresent()` helper.
+  - [ ] 1.1.1 Default render: form present (`queryByPlaceholderText(/you@company.com/i)`) + `getByTestId("cta-banner-toggle")` with `aria-expanded === "true"`.
+  - [ ] 1.1.2 Click toggle collapses: `aria-expanded === "false"`; `aria-label` matches `/reopen soleur signup banner/i`; "Built with" header still visible (persistent); body wrapper (`data-testid="cta-banner-body"`) has `inert` OR `aria-hidden="true"`. Do NOT assert the form is removed.
+  - [ ] 1.1.3 Click again re-expands: `aria-expanded === "true"`; `aria-label` matches `/collapse signup banner/i`; body no longer `inert`/`aria-hidden`.
+  - [ ] 1.1.4 Toggle is a single persistent `<button>` (`tagName === "BUTTON"`), resolvable by `cta-banner-toggle` in default, after collapse, and after re-expand (does not unmount).
+  - [ ] 1.1.5 No sessionStorage write on toggle: `vi.spyOn(Storage.prototype, "setItem")` not called; `sessionStorage.getItem(STORAGE_KEY)` null; `sessionStorage.length === 0`.
+  - [ ] 1.1.6 Fresh mount with legacy key pre-seeded (`sessionStorage.setItem(STORAGE_KEY, "1")`) still renders expanded (form present + toggle `aria-expanded="true"`).
+- [ ] 1.2 Run close test → expect RED (component still old structure). Confirm waitlist test still green (untouched).
+
+## Phase 2 — Re-architect component (GREEN)
+
+- [ ] 2.1 Delete the `<Reveal>` helper; drop now-unused imports (`ReactNode`, and `useEffect` if `Reveal` was its only consumer — confirm via `tsc`). Keep `FormEvent`.
+- [ ] 2.2 Remove the two conditional-return panels. Keep `Panel = "expanded" | "collapsed"` + `useState<Panel>("expanded")`. Add a single `toggle()` (or inline `setPanel(p => p === "expanded" ? "collapsed" : "expanded")`).
+- [ ] 2.3 Single persistent shell, exact footprint preserved: `fixed bottom-0 left-0 right-0 z-40 border-t border-soleur-border-default bg-soleur-bg-surface-1/95 backdrop-blur-sm`; inner `mx-auto max-w-3xl`; single stable `px-4 py-3` (no state-swapped padding).
+- [ ] 2.4 Persistent header row (always rendered): left = "Built with **Soleur**" (gold `text-soleur-accent-gold-fg` on "Soleur"; keep the full "— AI agents…" sentence); right = the toggle button.
+- [ ] 2.5 Toggle `<button type="button" data-testid="cta-banner-toggle">`:
+  - [ ] 2.5.1 `onClick` flips panel; `aria-expanded={panel === "expanded"}`.
+  - [ ] 2.5.2 `aria-label`: "Collapse signup banner" (expanded) / "Reopen Soleur signup banner" (collapsed).
+  - [ ] 2.5.3 One chevron-up svg `<polyline points="18 15 12 9 6 15" />` with `transition-transform duration-300 ease-out motion-reduce:transition-none motion-reduce:duration-0`; toggle `rotate-180` by state.
+  - [ ] 2.5.4 Mapping comment: `// COLLAPSED = rotate-0 (chevron points UP = "expand"); EXPANDED = rotate-180 (points DOWN = "collapse").`
+- [ ] 2.6 Collapsible body wrapper `data-testid="cta-banner-body"`: `grid transition-[grid-template-rows] duration-300 ease-out motion-reduce:transition-none motion-reduce:duration-0` + ternary `panel === "expanded" ? "grid-rows-[1fr]" : "grid-rows-[0fr]"` (two WHOLE literals, no string concat); `inert={panel === "collapsed" || undefined}`; `aria-hidden={panel === "collapsed" || undefined}`. Inner `<div className="overflow-hidden">` holds the form/success block.
+- [ ] 2.7 Move the existing `status === "success" ? <success-message> : <form>` block VERBATIM into the inner `overflow-hidden` div. Preserve: email input + placeholder, honeypot `url` field, Privacy Policy link, success copy, and the persistent `role="status" aria-live="polite"` error region. Do NOT gate this conditional on `panel`.
+- [ ] 2.8 Run close test → GREEN. Run waitlist test → still GREEN (and unedited).
+
+## Phase 3 — Verify
+
+- [ ] 3.1 `cd apps/web-platform && ./node_modules/.bin/vitest run test/shared-cta-banner-close.test.tsx test/shared-cta-banner-waitlist.test.tsx` — both green.
+- [ ] 3.2 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` — clean.
+- [ ] 3.3 Component residue grep: no `Reveal`, no `cta-banner-dismiss`, no `cta-banner-reopen`, no `<line `, no `sessionStorage`/`safeSession`.
+- [ ] 3.4 Motion-reduce pairing grep: both `transition-[grid-template-rows]` and `transition-transform` are each paired with `motion-reduce:transition-none motion-reduce:duration-0`.
+- [ ] 3.5 `git diff --quiet -- apps/web-platform/test/shared-cta-banner-waitlist.test.tsx` returns clean (waitlist test unedited).
+- [ ] 3.6 (Optional) `./node_modules/.bin/vitest run test/shared-*.test.tsx` — the 5 mocked sibling suites unaffected.
+
+## Acceptance Criteria (see plan for full text)
+
+AC1 two-way grid animation · AC2 single rotating chevron / no cross · AC3 reduced-motion pairing on both transitions · AC4 inert/aria-hidden + aria-expanded + flipping aria-label + keyboard-operable button · AC5 persistence unchanged (no sessionStorage) · AC6 close test rewritten & green · AC7 waitlist test green & UNEDITED · AC8 tsc --noEmit clean.
+
+Post-merge (operator): none.

--- a/knowledge-base/project/specs/feat-one-shot-banner-rotating-arrow-twoway-anim/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-banner-rotating-arrow-twoway-anim/tasks.md
@@ -10,44 +10,44 @@ Single-component change + its test rewrite. No backend/API/infra change. TDD: re
 
 ## Phase 0 — Setup & Preconditions
 
-- [ ] 0.1 Baseline typecheck: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (NOT `npm run -w`; repo root declares no `workspaces`).
-- [ ] 0.2 Baseline both target suites green: `cd apps/web-platform && ./node_modules/.bin/vitest run test/shared-cta-banner-close.test.tsx test/shared-cta-banner-waitlist.test.tsx`.
-- [ ] 0.3 Re-confirm structure of `components/shared/cta-banner.tsx`: `<Reveal>` helper (lines ~12-38), two conditional-return panels, `cta-banner-dismiss` X (two `<line>`), `cta-banner-reopen` up-chevron.
+- [x] 0.1 Baseline typecheck: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (NOT `npm run -w`; repo root declares no `workspaces`).
+- [x] 0.2 Baseline both target suites green: `cd apps/web-platform && ./node_modules/.bin/vitest run test/shared-cta-banner-close.test.tsx test/shared-cta-banner-waitlist.test.tsx`.
+- [x] 0.3 Re-confirm structure of `components/shared/cta-banner.tsx`: `<Reveal>` helper (lines ~12-38), two conditional-return panels, `cta-banner-dismiss` X (two `<line>`), `cta-banner-reopen` up-chevron.
 
 ## Phase 1 — Rewrite close test (RED)
 
-- [ ] 1.1 Rewrite `test/shared-cta-banner-close.test.tsx` for the single-toggle structure. Keep `STORAGE_KEY = "soleur:shared:cta-dismissed"`, `beforeEach/afterEach` `sessionStorage.clear()` + `vi.restoreAllMocks()`. Drive all transitions via `fireEvent.click` on the SAME render (no remount). Retire `cta-banner-dismiss`/`cta-banner-reopen` and the `reopenPresent()` helper.
-  - [ ] 1.1.1 Default render: form present (`queryByPlaceholderText(/you@company.com/i)`) + `getByTestId("cta-banner-toggle")` with `aria-expanded === "true"`.
-  - [ ] 1.1.2 Click toggle collapses: `aria-expanded === "false"`; `aria-label` matches `/reopen soleur signup banner/i`; "Built with" header still visible (persistent); body wrapper (`data-testid="cta-banner-body"`) has `inert` OR `aria-hidden="true"`. Do NOT assert the form is removed.
-  - [ ] 1.1.3 Click again re-expands: `aria-expanded === "true"`; `aria-label` matches `/collapse signup banner/i`; body no longer `inert`/`aria-hidden`.
-  - [ ] 1.1.4 Toggle is a single persistent `<button>` (`tagName === "BUTTON"`), resolvable by `cta-banner-toggle` in default, after collapse, and after re-expand (does not unmount).
-  - [ ] 1.1.5 No sessionStorage write on toggle: `vi.spyOn(Storage.prototype, "setItem")` not called; `sessionStorage.getItem(STORAGE_KEY)` null; `sessionStorage.length === 0`.
-  - [ ] 1.1.6 Fresh mount with legacy key pre-seeded (`sessionStorage.setItem(STORAGE_KEY, "1")`) still renders expanded (form present + toggle `aria-expanded="true"`).
-- [ ] 1.2 Run close test → expect RED (component still old structure). Confirm waitlist test still green (untouched).
+- [x] 1.1 Rewrite `test/shared-cta-banner-close.test.tsx` for the single-toggle structure. Keep `STORAGE_KEY = "soleur:shared:cta-dismissed"`, `beforeEach/afterEach` `sessionStorage.clear()` + `vi.restoreAllMocks()`. Drive all transitions via `fireEvent.click` on the SAME render (no remount). Retire `cta-banner-dismiss`/`cta-banner-reopen` and the `reopenPresent()` helper.
+  - [x] 1.1.1 Default render: form present (`queryByPlaceholderText(/you@company.com/i)`) + `getByTestId("cta-banner-toggle")` with `aria-expanded === "true"`.
+  - [x] 1.1.2 Click toggle collapses: `aria-expanded === "false"`; `aria-label` matches `/reopen soleur signup banner/i`; "Built with" header still visible (persistent); body wrapper (`data-testid="cta-banner-body"`) has `inert` OR `aria-hidden="true"`. Do NOT assert the form is removed.
+  - [x] 1.1.3 Click again re-expands: `aria-expanded === "true"`; `aria-label` matches `/collapse signup banner/i`; body no longer `inert`/`aria-hidden`.
+  - [x] 1.1.4 Toggle is a single persistent `<button>` (`tagName === "BUTTON"`), resolvable by `cta-banner-toggle` in default, after collapse, and after re-expand (does not unmount).
+  - [x] 1.1.5 No sessionStorage write on toggle: `vi.spyOn(Storage.prototype, "setItem")` not called; `sessionStorage.getItem(STORAGE_KEY)` null; `sessionStorage.length === 0`.
+  - [x] 1.1.6 Fresh mount with legacy key pre-seeded (`sessionStorage.setItem(STORAGE_KEY, "1")`) still renders expanded (form present + toggle `aria-expanded="true"`).
+- [x] 1.2 Run close test → expect RED (component still old structure). Confirm waitlist test still green (untouched).
 
 ## Phase 2 — Re-architect component (GREEN)
 
-- [ ] 2.1 Delete the `<Reveal>` helper; drop now-unused imports (`ReactNode`, and `useEffect` if `Reveal` was its only consumer — confirm via `tsc`). Keep `FormEvent`.
-- [ ] 2.2 Remove the two conditional-return panels. Keep `Panel = "expanded" | "collapsed"` + `useState<Panel>("expanded")`. Add a single `toggle()` (or inline `setPanel(p => p === "expanded" ? "collapsed" : "expanded")`).
-- [ ] 2.3 Single persistent shell, exact footprint preserved: `fixed bottom-0 left-0 right-0 z-40 border-t border-soleur-border-default bg-soleur-bg-surface-1/95 backdrop-blur-sm`; inner `mx-auto max-w-3xl`; single stable `px-4 py-3` (no state-swapped padding).
-- [ ] 2.4 Persistent header row (always rendered): left = "Built with **Soleur**" (gold `text-soleur-accent-gold-fg` on "Soleur"; keep the full "— AI agents…" sentence); right = the toggle button.
-- [ ] 2.5 Toggle `<button type="button" data-testid="cta-banner-toggle">`:
-  - [ ] 2.5.1 `onClick` flips panel; `aria-expanded={panel === "expanded"}`.
-  - [ ] 2.5.2 `aria-label`: "Collapse signup banner" (expanded) / "Reopen Soleur signup banner" (collapsed).
-  - [ ] 2.5.3 One chevron-up svg `<polyline points="18 15 12 9 6 15" />` with `transition-transform duration-300 ease-out motion-reduce:transition-none motion-reduce:duration-0`; toggle `rotate-180` by state.
-  - [ ] 2.5.4 Mapping comment: `// COLLAPSED = rotate-0 (chevron points UP = "expand"); EXPANDED = rotate-180 (points DOWN = "collapse").`
-- [ ] 2.6 Collapsible body wrapper `data-testid="cta-banner-body"`: `grid transition-[grid-template-rows] duration-300 ease-out motion-reduce:transition-none motion-reduce:duration-0` + ternary `panel === "expanded" ? "grid-rows-[1fr]" : "grid-rows-[0fr]"` (two WHOLE literals, no string concat); `inert={panel === "collapsed" || undefined}`; `aria-hidden={panel === "collapsed" || undefined}`. Inner `<div className="overflow-hidden">` holds the form/success block.
-- [ ] 2.7 Move the existing `status === "success" ? <success-message> : <form>` block VERBATIM into the inner `overflow-hidden` div. Preserve: email input + placeholder, honeypot `url` field, Privacy Policy link, success copy, and the persistent `role="status" aria-live="polite"` error region. Do NOT gate this conditional on `panel`.
-- [ ] 2.8 Run close test → GREEN. Run waitlist test → still GREEN (and unedited).
+- [x] 2.1 Delete the `<Reveal>` helper; drop now-unused imports (`ReactNode`, and `useEffect` if `Reveal` was its only consumer — confirm via `tsc`). Keep `FormEvent`.
+- [x] 2.2 Remove the two conditional-return panels. Keep `Panel = "expanded" | "collapsed"` + `useState<Panel>("expanded")`. Add a single `toggle()` (or inline `setPanel(p => p === "expanded" ? "collapsed" : "expanded")`).
+- [x] 2.3 Single persistent shell, exact footprint preserved: `fixed bottom-0 left-0 right-0 z-40 border-t border-soleur-border-default bg-soleur-bg-surface-1/95 backdrop-blur-sm`; inner `mx-auto max-w-3xl`; single stable `px-4 py-3` (no state-swapped padding).
+- [x] 2.4 Persistent header row (always rendered): left = "Built with **Soleur**" (gold `text-soleur-accent-gold-fg` on "Soleur"; keep the full "— AI agents…" sentence); right = the toggle button.
+- [x] 2.5 Toggle `<button type="button" data-testid="cta-banner-toggle">`:
+  - [x] 2.5.1 `onClick` flips panel; `aria-expanded={panel === "expanded"}`.
+  - [x] 2.5.2 `aria-label`: "Collapse signup banner" (expanded) / "Reopen Soleur signup banner" (collapsed).
+  - [x] 2.5.3 One chevron-up svg `<polyline points="18 15 12 9 6 15" />` with `transition-transform duration-300 ease-out motion-reduce:transition-none motion-reduce:duration-0`; toggle `rotate-180` by state.
+  - [x] 2.5.4 Mapping comment: `// COLLAPSED = rotate-0 (chevron points UP = "expand"); EXPANDED = rotate-180 (points DOWN = "collapse").`
+- [x] 2.6 Collapsible body wrapper `data-testid="cta-banner-body"`: `grid transition-[grid-template-rows] duration-300 ease-out motion-reduce:transition-none motion-reduce:duration-0` + ternary `panel === "expanded" ? "grid-rows-[1fr]" : "grid-rows-[0fr]"` (two WHOLE literals, no string concat); `inert={panel === "collapsed" || undefined}`; `aria-hidden={panel === "collapsed" || undefined}`. Inner `<div className="overflow-hidden">` holds the form/success block.
+- [x] 2.7 Move the existing `status === "success" ? <success-message> : <form>` block VERBATIM into the inner `overflow-hidden` div. Preserve: email input + placeholder, honeypot `url` field, Privacy Policy link, success copy, and the persistent `role="status" aria-live="polite"` error region. Do NOT gate this conditional on `panel`.
+- [x] 2.8 Run close test → GREEN. Run waitlist test → still GREEN (and unedited).
 
 ## Phase 3 — Verify
 
-- [ ] 3.1 `cd apps/web-platform && ./node_modules/.bin/vitest run test/shared-cta-banner-close.test.tsx test/shared-cta-banner-waitlist.test.tsx` — both green.
-- [ ] 3.2 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` — clean.
-- [ ] 3.3 Component residue grep: no `Reveal`, no `cta-banner-dismiss`, no `cta-banner-reopen`, no `<line `, no `sessionStorage`/`safeSession`.
-- [ ] 3.4 Motion-reduce pairing grep: both `transition-[grid-template-rows]` and `transition-transform` are each paired with `motion-reduce:transition-none motion-reduce:duration-0`.
-- [ ] 3.5 `git diff --quiet -- apps/web-platform/test/shared-cta-banner-waitlist.test.tsx` returns clean (waitlist test unedited).
-- [ ] 3.6 (Optional) `./node_modules/.bin/vitest run test/shared-*.test.tsx` — the 5 mocked sibling suites unaffected.
+- [x] 3.1 `cd apps/web-platform && ./node_modules/.bin/vitest run test/shared-cta-banner-close.test.tsx test/shared-cta-banner-waitlist.test.tsx` — both green.
+- [x] 3.2 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` — clean.
+- [x] 3.3 Component residue grep: no `Reveal`, no `cta-banner-dismiss`, no `cta-banner-reopen`, no `<line `, no `sessionStorage`/`safeSession`.
+- [x] 3.4 Motion-reduce pairing grep: both `transition-[grid-template-rows]` and `transition-transform` are each paired with `motion-reduce:transition-none motion-reduce:duration-0`.
+- [x] 3.5 `git diff --quiet -- apps/web-platform/test/shared-cta-banner-waitlist.test.tsx` returns clean (waitlist test unedited).
+- [x] 3.6 (Optional) `./node_modules/.bin/vitest run test/shared-*.test.tsx` — the 5 mocked sibling suites unaffected.
 
 ## Acceptance Criteria (see plan for full text)
 


### PR DESCRIPTION
## Summary
- The shared-document waitlist banner (collapse/reopen shipped in #5075) now animates **both** opening AND closing — previously only the incoming panel eased in; closing snapped.
- Replaces the cross-to-close + arrow-to-open with a **single arrow shown in both states** that rotates 180° between them (down = collapse, up = expand), per request.
- Re-architected from two conditionally-rendered panels into one persistent structure: a fixed header row (`Built with Soleur` + the rotating-chevron toggle) and a collapsible body that animates via CSS `grid-template-rows: 0fr↔1fr` (smooth in both directions, no JS height measurement).
- When collapsed, the body is `inert` + `aria-hidden` so the form leaves the tab order; the toggle keeps `aria-expanded` + a flipping `aria-label` and is keyboard-operable. Every transition is `motion-reduce`-paired (instant under prefers-reduced-motion). State stays in-memory only.

## Changelog
### Web Platform
- Shared-doc waitlist banner: smooth open/close animation in both directions + a single rotating-arrow toggle (no more cross-to-close).

## Test plan
- [x] `shared-cta-banner-close.test.tsx` rewritten to the single-toggle contract (6 cases): default-expanded, collapse (body inert+aria-hidden, header persists, form stays in DOM), re-expand, same-node toggle across both states (Object.is), no sessionStorage write (spy), legacy-key ignored.
- [x] `shared-cta-banner-waitlist.test.tsx` unchanged + green.
- [x] Full web-platform vitest suite: 9133 passed, 0 failures. `tsc --noEmit` clean. anti-slop: no high/transition findings.

## User-Brand Impact
- **Artifact:** the public shared-document waitlist banner.
- **Vector:** worst case is a janky/non-functional animation or toggle — a presentational glitch. No data read/written/transmitted; `/api/waitlist` untouched.
- **Brand-survival threshold:** none, reason: presentational micro-interaction on a marketing banner; no auth, data, payment, or sensitive path.

Generated with [Claude Code](https://claude.com/claude-code)