### PR TITLE
fix(waitlist): migrate signup to Buttondown authenticated v1 API

### DIFF
--- a/apps/web-platform/.env.example
+++ b/apps/web-platform/.env.example
@@ -111,6 +111,13 @@ SENTRY_PUBLIC_KEY=
 #   find ../../plugins/soleur/agents -name "*.md" | wc -l
 # NEXT_PUBLIC_AGENT_COUNT=63
 
+# --- Buttondown (waitlist) ---
+# Authenticated REST API key for the marketing waitlist relay (/api/waitlist →
+# api.buttondown.com/v1/subscribers). Token-format key from
+# buttondown.com/settings/api. Without it, /api/waitlist fails closed to a
+# graceful JSON 502 (the worker never crashes). Present in Doppler soleur/prd.
+BUTTONDOWN_API_KEY=
+
 # --- Runtime Feature Flags ---
 # Each FLAG_* mirrors its prd-segment Flagsmith state (env-var fallback path —
 # applies when Flagsmith is unreachable). Only "1" is truthy. See ADR-038 v2

--- a/apps/web-platform/app/api/waitlist/route.ts
+++ b/apps/web-platform/app/api/waitlist/route.ts
@@ -8,11 +8,11 @@ import {
 } from "./waitlist";
 
 // Same-origin-checked, per-IP rate-limited proxy that forwards an anonymous
-// visitor's email to Buttondown's public embed-subscribe endpoint (marketing
-// waitlist). Lives here rather than as a direct client POST because prod CSP
-// `connect-src` (lib/csp.ts) excludes buttondown.com and `form-action 'self'`
-// would block a native cross-origin form; a same-origin route needs no CSP
-// change and lets the honeypot + rate-limit be enforced server-side.
+// visitor's email to Buttondown's authenticated v1 subscribers API (marketing
+// waitlist). Lives here rather than as a direct client POST because the API key
+// must stay server-side, prod CSP `connect-src` (lib/csp.ts) excludes
+// buttondown.com, and a same-origin route lets the honeypot + rate-limit be
+// enforced server-side.
 //
 // Success contract is `200 {ok:true}` (NOT 204) so the client can parse a body
 // to drive its idle→success state machine. All errors share `{error:"<code>"}`.

--- a/apps/web-platform/app/api/waitlist/waitlist.ts
+++ b/apps/web-platform/app/api/waitlist/waitlist.ts
@@ -10,13 +10,6 @@ import { createChildLogger } from "@/server/logger";
 
 const log = createChildLogger("waitlist-subscribe");
 
-// Soleur's own public newsletter handle (already public in
-// plugins/soleur/docs/_data/site.json). The Buttondown embed-subscribe endpoint
-// needs no API key — this is a username-only, non-secret constant. A hardcoded
-// constant rather than an env var: same handle in dev and prod, single consumer
-// (YAGNI — add the env read the day a second handle is needed).
-export const WAITLIST_USERNAME = "soleur";
-
 // Same tag as the pricing-page waitlist form so shared-doc signups land in the
 // existing Buttondown bucket (Art. 30 PA6, single waitlist purpose).
 export const WAITLIST_TAG = "pricing-waitlist";
@@ -28,7 +21,16 @@ export const HONEYPOT_FIELD = "url";
 const MAX_PER_WINDOW = 5;
 const WINDOW_MS = 60_000;
 
-const BUTTONDOWN_EMBED_URL = `https://buttondown.com/api/emails/embed-subscribe/${WAITLIST_USERNAME}`;
+// Buttondown's AUTHENTICATED REST API. The previously-used keyless public
+// embed-subscribe endpoint was moved behind Cloudflare Turnstile (returns a 400
+// challenge page to any server-side caller), so a same-origin proxy can no
+// longer use it. The authenticated v1 API is not behind Turnstile.
+const BUTTONDOWN_SUBSCRIBE_URL = "https://api.buttondown.com/v1/subscribers";
+
+// Mirror token-validators.ts:VALIDATION_TIMEOUT_MS — a bounded upstream call so
+// a Buttondown stall degrades to the route's own JSON 502 instead of hanging
+// the worker into a Cloudflare gateway 502.
+const WAITLIST_TIMEOUT_MS = 5_000;
 
 // Single-instance in-memory counter — inherits the Redis-switch caveat
 // documented in server/rate-limiter.ts (see analyticsTrackThrottle).
@@ -43,24 +45,57 @@ export function __resetWaitlistThrottleForTest(): void {
   waitlistThrottle.reset();
 }
 
+// A v1 collision (duplicate email) returns 400. The body is JSON with a
+// `code` like `email_already_exists` and/or a `detail` message; older/plaintext
+// shapes simply contain "already". Match tolerantly across both so a genuine
+// duplicate is idempotent success, not a 502.
+const ALREADY_SUBSCRIBED_RE = /already|exists|subscrib|duplicate/i;
+
+function isAlreadySubscribed(body: string): boolean {
+  try {
+    const parsed = JSON.parse(body) as { code?: unknown; detail?: unknown };
+    const signal = `${typeof parsed.code === "string" ? parsed.code : ""} ${
+      typeof parsed.detail === "string" ? parsed.detail : ""
+    }`;
+    if (ALREADY_SUBSCRIBED_RE.test(signal)) return true;
+  } catch {
+    // Non-JSON body — fall through to the raw-text match.
+  }
+  return ALREADY_SUBSCRIBED_RE.test(body);
+}
+
 /**
- * Forward an email to Buttondown's public embed-subscribe endpoint with the
- * pricing-waitlist tag. Resolves on success OR already-subscribed (idempotent
- * from the visitor's perspective). Throws on any unexpected upstream status or
- * network error so the route maps it to 502 + a Sentry mirror — the raw
- * Buttondown body is never surfaced to the client.
+ * Subscribe an email to the marketing waitlist via Buttondown's authenticated
+ * v1 REST API (`POST /v1/subscribers`, `Authorization: Token`) with the
+ * pricing-waitlist tag. Resolves on success (201) OR already-subscribed
+ * (idempotent from the visitor's perspective). Throws on a missing API key, any
+ * unexpected upstream status, an upstream timeout, or a network error so the
+ * route maps it to 502 + a Sentry mirror — the raw Buttondown body and the API
+ * key are never surfaced to the client.
+ *
+ * `type` is intentionally omitted from the body so Buttondown's DEFAULT double
+ * opt-in is preserved: the visitor receives a confirmation email (the success
+ * copy promises "check your inbox to confirm") which is also the GDPR Art.
+ * 6(1)(a) consent step. Sending `type: "regular"` would silently skip both.
  */
 export async function subscribeToWaitlist(email: string): Promise<{ ok: true }> {
-  const body = new URLSearchParams({
-    email,
-    tag: WAITLIST_TAG,
-    embed: "1",
-  });
+  // Fail-closed key read at call time (NOT module load) — a missing key throws
+  // INSIDE the function so the route's try/catch maps it to a graceful JSON 502
+  // and the worker never crashes at boot.
+  const apiKey = process.env.BUTTONDOWN_API_KEY;
+  if (!apiKey) {
+    log.warn("BUTTONDOWN_API_KEY missing — waitlist subscribe disabled");
+    throw new Error("waitlist subscribe unconfigured");
+  }
 
-  const res = await fetch(BUTTONDOWN_EMBED_URL, {
+  const res = await fetch(BUTTONDOWN_SUBSCRIBE_URL, {
     method: "POST",
-    headers: { "content-type": "application/x-www-form-urlencoded" },
-    body,
+    headers: {
+      Authorization: `Token ${apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ email_address: email, tags: [WAITLIST_TAG] }),
+    signal: AbortSignal.timeout(WAITLIST_TIMEOUT_MS),
   });
 
   if (res.ok) return { ok: true };
@@ -69,11 +104,11 @@ export async function subscribeToWaitlist(email: string): Promise<{ ok: true }> 
   // for the visitor (they are on the list; a re-submit shouldn't error).
   if (res.status === 400) {
     const text = await res.text().catch(() => "");
-    if (/already/i.test(text)) return { ok: true };
+    if (isAlreadySubscribed(text)) return { ok: true };
   }
 
   // Unexpected upstream status — throw so the route mirrors to Sentry and
-  // returns 502. Status only (never the raw body) reaches logs.
+  // returns 502. Status only (never the raw body, never the key) reaches logs.
   log.warn({ status: res.status }, "Buttondown subscribe returned non-ok status");
   throw new Error(`Buttondown subscribe failed: ${res.status}`);
 }

--- a/apps/web-platform/app/api/waitlist/waitlist.ts
+++ b/apps/web-platform/app/api/waitlist/waitlist.ts
@@ -45,29 +45,32 @@ export function __resetWaitlistThrottleForTest(): void {
   waitlistThrottle.reset();
 }
 
-// A v1 collision (duplicate email) returns 400. The body is JSON with a
-// `code` like `email_already_exists` and/or a `detail` message; older/plaintext
-// shapes simply contain "already". Match tolerantly across both so a genuine
-// duplicate is idempotent success, not a 502.
-const ALREADY_SUBSCRIBED_RE = /already|exists|subscrib|duplicate/i;
+// A v1 collision (duplicate email) returns 400 with the machine code
+// `email_already_exists` (and a "…already exists" detail); legacy/plaintext
+// shapes read "already subscribed". Match the code EXACTLY plus a narrow
+// "already subscribed/exists" phrase — deliberately NOT a bare `exists` /
+// `subscrib` / `duplicate` token, which would misclassify a genuine validation
+// 400 (e.g. "domain does not exist", "invalid subscriber") as success and
+// silently drop the signup with no Sentry mirror.
+const ALREADY_SUBSCRIBED_RE = /already\s+(subscribed|exists)/i;
 
 function isAlreadySubscribed(body: string): boolean {
   try {
     const parsed = JSON.parse(body) as { code?: unknown; detail?: unknown };
-    const signal = `${typeof parsed.code === "string" ? parsed.code : ""} ${
-      typeof parsed.detail === "string" ? parsed.detail : ""
-    }`;
-    if (ALREADY_SUBSCRIBED_RE.test(signal)) return true;
+    // JSON branch is authoritative — return from it rather than falling through
+    // to a whole-body scan (which would also match field NAMES, not just text).
+    if (parsed.code === "email_already_exists") return true;
+    return typeof parsed.detail === "string" && ALREADY_SUBSCRIBED_RE.test(parsed.detail);
   } catch {
-    // Non-JSON body — fall through to the raw-text match.
+    // Legacy / non-JSON plaintext body shape.
+    return ALREADY_SUBSCRIBED_RE.test(body);
   }
-  return ALREADY_SUBSCRIBED_RE.test(body);
 }
 
 /**
  * Subscribe an email to the marketing waitlist via Buttondown's authenticated
  * v1 REST API (`POST /v1/subscribers`, `Authorization: Token`) with the
- * pricing-waitlist tag. Resolves on success (201) OR already-subscribed
+ * pricing-waitlist tag. Resolves on success (any 2xx) OR already-subscribed
  * (idempotent from the visitor's perspective). Throws on a missing API key, any
  * unexpected upstream status, an upstream timeout, or a network error so the
  * route maps it to 502 + a Sentry mirror — the raw Buttondown body and the API

--- a/apps/web-platform/test/api-waitlist-subscribe.test.ts
+++ b/apps/web-platform/test/api-waitlist-subscribe.test.ts
@@ -1,12 +1,15 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 
-// POST /api/waitlist — same-origin proxy to Buttondown's embed-subscribe.
+// POST /api/waitlist — same-origin proxy to Buttondown's authenticated v1 API
+//   (POST api.buttondown.com/v1/subscribers, Authorization: Token).
 //   - Rejects missing / disallowed Origin with 403 (browser-only form)
 //   - Honeypot filled → silent 200, no forward
 //   - Per-IP rate limit → 429 after threshold (MAX_PER_WINDOW = 5)
-//   - Valid email → forwards email+tag+embed urlencoded, returns 200 {ok:true}
-//   - Already-subscribed (Buttondown 400 "already…") → 200 {ok:true}
-//   - Unexpected Buttondown status / network throw → 502 + warnSilentFallback
+//   - Valid email → POSTs JSON {email_address, tags:["pricing-waitlist"]} (no `type`,
+//     so Buttondown's default double opt-in is preserved), returns 200 {ok:true}
+//   - Already-subscribed (v1 collision 400) → 200 {ok:true}
+//   - Unexpected status / network throw / timeout → 502 + warnSilentFallback
+//   - Missing BUTTONDOWN_API_KEY → fail-closed 502 before any fetch
 //   - Invalid email / invalid JSON → 400
 
 const { mockFetch, warnSilentFallback, logWarn } = vi.hoisted(() => ({
@@ -58,6 +61,7 @@ function makeRequest({
 }
 
 const OK_ORIGIN = "https://app.soleur.ai";
+const TEST_API_KEY = "test-buttondown-key";
 
 describe("POST /api/waitlist", () => {
   beforeEach(() => {
@@ -66,9 +70,11 @@ describe("POST /api/waitlist", () => {
     warnSilentFallback.mockReset();
     vi.resetModules();
     process.env.APP_URL = OK_ORIGIN;
+    process.env.BUTTONDOWN_API_KEY = TEST_API_KEY;
   });
   afterEach(() => {
     delete process.env.APP_URL;
+    delete process.env.BUTTONDOWN_API_KEY;
   });
 
   test("rejects disallowed Origin with 403", async () => {
@@ -87,8 +93,8 @@ describe("POST /api/waitlist", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  test("valid email forwards email+tag+embed and returns 200 {ok:true}", async () => {
-    mockFetch.mockResolvedValue(new Response("", { status: 200 }));
+  test("valid email POSTs v1 subscribers JSON (no type) and returns 200 {ok:true}", async () => {
+    mockFetch.mockResolvedValue(new Response("", { status: 201 }));
     const { POST } = await importRoute();
     const res = await POST(
       makeRequest({ origin: OK_ORIGIN, body: { email: "user@company.com" } }),
@@ -97,16 +103,32 @@ describe("POST /api/waitlist", () => {
     expect(await res.json()).toEqual({ ok: true });
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url, init] = mockFetch.mock.calls[0];
-    expect(String(url)).toContain("buttondown.com/api/emails/embed-subscribe/soleur");
-    const sent = new URLSearchParams(String((init as RequestInit).body));
-    expect(sent.get("email")).toBe("user@company.com");
-    expect(sent.get("tag")).toBe("pricing-waitlist");
-    expect(sent.get("embed")).toBe("1");
+    expect(String(url)).toContain("api.buttondown.com/v1/subscribers");
+
+    const headers = new Headers((init as RequestInit).headers);
+    expect(headers.get("authorization")).toBe(`Token ${TEST_API_KEY}`);
+    expect(headers.get("content-type")).toBe("application/json");
+
+    const sent = JSON.parse(String((init as RequestInit).body)) as Record<string, unknown>;
+    expect(sent.email_address).toBe("user@company.com");
+    expect(sent.tags).toEqual(["pricing-waitlist"]);
+    // Double-opt-in preservation guard: never send `type` (would skip the
+    // confirmation email + the GDPR Art. 6(1)(a) consent step).
+    expect(sent).not.toHaveProperty("type");
+
+    // The abort timeout must be wired so an upstream stall degrades to a JSON 502.
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
   });
 
-  test("already-subscribed (Buttondown 400 'already') is treated as success 200", async () => {
+  test("already-subscribed (v1 collision 400) is treated as success 200", async () => {
     mockFetch.mockResolvedValue(
-      new Response("This email is already subscribed.", { status: 400 }),
+      new Response(
+        JSON.stringify({
+          code: "email_already_exists",
+          detail: "A subscriber with this email address already exists.",
+        }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      ),
     );
     const { POST } = await importRoute();
     const res = await POST(
@@ -157,7 +179,7 @@ describe("POST /api/waitlist", () => {
   });
 
   test("per-IP rate limit (keyed on cf-connecting-ip) returns 429 after 5 allowed", async () => {
-    mockFetch.mockResolvedValue(new Response("", { status: 200 }));
+    mockFetch.mockResolvedValue(new Response("", { status: 201 }));
     const { POST } = await importRoute();
     const ip = "9.9.9.9";
     for (let i = 0; i < 5; i++) {
@@ -178,7 +200,7 @@ describe("POST /api/waitlist", () => {
     // attacker rotates it to spam Buttondown opt-in emails. With no
     // cf-connecting-ip, every request shares the single "unknown" bucket, so a
     // rotated-XFF flood is still capped at 5/window total → 6th is 429.
-    mockFetch.mockResolvedValue(new Response("", { status: 200 }));
+    mockFetch.mockResolvedValue(new Response("", { status: 201 }));
     const { POST } = await importRoute();
     const statuses: number[] = [];
     for (let i = 0; i < 6; i++) {
@@ -209,6 +231,18 @@ describe("POST /api/waitlist", () => {
     });
   });
 
+  test("bad key (401) → 502 + Sentry mirror", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ detail: "Invalid token." }), { status: 401 }),
+    );
+    const { POST } = await importRoute();
+    const res = await POST(
+      makeRequest({ origin: OK_ORIGIN, body: { email: "user@company.com" } }),
+    );
+    expect(res.status).toBe(502);
+    expect(warnSilentFallback).toHaveBeenCalledTimes(1);
+  });
+
   test("network throw → 502 + Sentry mirror", async () => {
     mockFetch.mockRejectedValue(new Error("ECONNRESET"));
     const { POST } = await importRoute();
@@ -217,5 +251,33 @@ describe("POST /api/waitlist", () => {
     );
     expect(res.status).toBe(502);
     expect(warnSilentFallback).toHaveBeenCalledTimes(1);
+  });
+
+  test("upstream timeout (AbortSignal.timeout → TimeoutError) → 502 + Sentry mirror", async () => {
+    mockFetch.mockRejectedValue(
+      Object.assign(new Error("The operation was aborted due to timeout"), {
+        name: "TimeoutError",
+      }),
+    );
+    const { POST } = await importRoute();
+    const res = await POST(
+      makeRequest({ origin: OK_ORIGIN, body: { email: "user@company.com" } }),
+    );
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "upstream_unavailable" });
+    expect(warnSilentFallback).toHaveBeenCalledTimes(1);
+  });
+
+  test("missing BUTTONDOWN_API_KEY → fail-closed 502 before any fetch", async () => {
+    delete process.env.BUTTONDOWN_API_KEY;
+    const { POST } = await importRoute();
+    const res = await POST(
+      makeRequest({ origin: OK_ORIGIN, body: { email: "user@company.com" } }),
+    );
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "upstream_unavailable" });
+    expect(warnSilentFallback).toHaveBeenCalledTimes(1);
+    // Fail closed: the worker must never reach the upstream call without a key.
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/apps/web-platform/test/api-waitlist-subscribe.test.ts
+++ b/apps/web-platform/test/api-waitlist-subscribe.test.ts
@@ -139,6 +139,40 @@ describe("POST /api/waitlist", () => {
     expect(warnSilentFallback).not.toHaveBeenCalled();
   });
 
+  test("already-subscribed plaintext 400 (legacy body) is treated as success 200", async () => {
+    mockFetch.mockResolvedValue(
+      new Response("This email is already subscribed.", { status: 400 }),
+    );
+    const { POST } = await importRoute();
+    const res = await POST(
+      makeRequest({ origin: OK_ORIGIN, body: { email: "dup2@company.com" } }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(warnSilentFallback).not.toHaveBeenCalled();
+  });
+
+  test("non-duplicate validation 400 is NOT swallowed → 502 + Sentry mirror", async () => {
+    // A genuine validation error (not a collision) must surface as 502, never a
+    // false success — otherwise a real signup is silently dropped.
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          code: "invalid_email_address",
+          detail: "Enter a valid email address.",
+        }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const { POST } = await importRoute();
+    const res = await POST(
+      makeRequest({ origin: OK_ORIGIN, body: { email: "user@company.com" } }),
+    );
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "upstream_unavailable" });
+    expect(warnSilentFallback).toHaveBeenCalledTimes(1);
+  });
+
   test("filled honeypot returns silent 200 without forwarding", async () => {
     const { POST } = await importRoute();
     const res = await POST(

--- a/knowledge-base/engineering/operations/post-mortems/waitlist-buttondown-turnstile-502-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/waitlist-buttondown-turnstile-502-postmortem.md
@@ -1,0 +1,131 @@
+---
+title: "Waitlist signup 502 — Buttondown moved the public embed endpoint behind Cloudflare Turnstile"
+date: 2026-06-09
+incident_pr: 5077
+incident_window: "unknown start (Buttondown Turnstile rollout) → 2026-06-09 (fix merged)"
+recovery_at: "on deploy of PR #5077"
+suspected_change: "External: Buttondown gated its public embed-subscribe endpoint behind Cloudflare Turnstile"
+brand_survival_threshold: aggregate pattern
+status: resolved
+triggers:
+  - provider
+art_33_triggered: false
+art_34_triggered: false
+art_33_deadline: "n/a"
+---
+
+## Actor key
+
+- `agent` — Claude Code did this autonomously.
+- `human` — Operator did this directly.
+
+# Incident Overview
+
+The marketing waitlist banner (`CtaBanner`, rendered on the pricing page and every shared document) failed for every visitor: `POST /api/waitlist` returned a Cloudflare-synthesized gateway 502 and the banner showed "Something went wrong. Please try again." No signup could complete. Externally triggered — Buttondown moved its public `embed-subscribe` endpoint behind Cloudflare Turnstile, which a server-side same-origin proxy cannot solve. No Soleur deploy caused it.
+
+## Status
+
+resolved — fix in PR #5077 (migrate to Buttondown's authenticated v1 API, which is not behind Turnstile).
+
+## Symptom
+
+`POST https://app.soleur.ai/api/waitlist` → `502`, `server: cloudflare`, `content-type: text/plain`, body `error code: 502` (NOT the app's own `{"error":"upstream_unavailable"}` JSON). Banner displays "Something went wrong. Please try again."
+
+## Incident Timeline
+
+- **Start time (detected):** 2026-06-09 (operator reported the banner error while using a shared document)
+- **End time (recovered):** on deploy of PR #5077
+- **Duration (MTTR):** ~hours from detection to fix-merged (true onset unknown — silent external regression)
+
+| Actor | Time (UTC) | Action |
+|---|---|---|
+| human | 2026-06-09 | Operator hit "Something went wrong" submitting an email on the shared-doc waitlist banner; reported the 502 XHR trace. |
+| agent | 2026-06-09 | Reproduced against prod; isolated CF-502 (origin failure) vs app-JSON-502; direct Buttondown probe revealed a 400 + Turnstile challenge page. |
+| agent | 2026-06-09 | Fixed: migrated `subscribeToWaitlist` to the authenticated v1 API + timeout + fail-closed key read (PR #5077). |
+
+## Participants and Systems Involved
+
+`/api/waitlist` route (`apps/web-platform/app/api/waitlist/`), Buttondown (US email processor), Cloudflare (edge in front of both app.soleur.ai and buttondown.com).
+
+## Detection (+ MTTD)
+
+- **How detected:** external/manual — operator using the feature, not a monitor. The app returned the broken upstream call as a gateway 502 with a warn-level Sentry mirror only when the app's own catch was reached; the gateway-level 502 produced no app-side error event, so no alert fired.
+- **MTTD:** unknown — the regression was silent (no alert on a third-party endpoint contract change).
+
+## Triggered by
+
+provider — Buttondown added a Cloudflare Turnstile challenge to its public embed-subscribe endpoint.
+
+## Root-cause hypothesis (triage)
+
+| Hypothesis | Supporting evidence | Disconfirming evidence | Status |
+|---|---|---|---|
+| App route handler bug | — | Early-exit paths returned correct app JSON (403/405); only the upstream-call path failed | rejected |
+| Origin/whole-app outage | — | `GET /` healthy (307, 0.2s) | rejected |
+| Buttondown public endpoint now requires Turnstile | Direct POST to embed-subscribe returns 400 + HTML "Verify Your Subscription" loading challenges.cloudflare.com/turnstile | — | confirmed |
+
+## Resolution
+
+Rewrote `subscribeToWaitlist` to call Buttondown's authenticated v1 REST API (`POST api.buttondown.com/v1/subscribers`, `Authorization: Token`), which is not behind Turnstile. Added `AbortSignal.timeout(5s)` (a future stall now degrades to the app's JSON 502, not a gateway hang), a fail-closed call-time key read, and a tightened duplicate-400 predicate. `type` is omitted to preserve double opt-in.
+
+## Recovery verification
+
+Post-deploy: `POST /api/waitlist` with a valid email returns `200 {ok:true}` and the subscriber appears (status unconfirmed, pending double opt-in) under the `pricing-waitlist` tag. Covered by the PR's post-merge ⏳ test-plan item and the `/soleur:postmerge` health check.
+
+---
+
+# Incident Post-Mortem Analysis
+
+## Root Cause(s) — 5-Whys
+
+1. Why did signups fail? `POST /api/waitlist` returned a gateway 502.
+2. Why a gateway 502? The origin's upstream call to Buttondown failed/hung; the request died before the app's own error branch returned JSON.
+3. Why did the upstream call fail? Buttondown's public embed-subscribe endpoint returned a 400 + Turnstile challenge a server cannot solve.
+4. Why were we calling a Turnstile-gated endpoint? `subscribeToWaitlist` proxied Buttondown's public browser-form endpoint server-side.
+5. Why was a public browser-form endpoint chosen? It was keyless (no secret to wire) at build time — but public form endpoints can sprout bot defenses at any time. The authenticated REST API is the supported server-to-server path.
+
+## Versions of Components
+
+- **Version(s) that triggered the outage:** web-platform @ 0.117.3 (and earlier — onset coincides with Buttondown's external Turnstile rollout, not a Soleur version)
+- **Version(s) that restored the service:** the release containing PR #5077
+
+## Impact details
+
+### Services Impacted
+
+Marketing waitlist signup only (`/api/waitlist`). No authenticated product surface, data, auth, or billing path affected.
+
+### Customer Impact (by role)
+
+- Prospect: HIGH — could not join the early-access waitlist from the pricing page or any shared doc; submission always errored.
+- Authenticated app user: none.
+- Legal-document signer: none.
+- Admin via Access: none.
+- Billing customer: none.
+- OAuth installation owner: none.
+
+### Revenue Impact
+
+Indirect — lost top-of-funnel leads for the duration. No direct revenue path.
+
+### Team Impact
+
+Low — single-session diagnosis + fix.
+
+## Lessons Learned
+
+### Where we got lucky
+
+The app already returned a generic error to the client and logged status-only, so no key or PII leaked despite the failing upstream call.
+
+### What went well
+
+Fast root-cause via the CF-502-vs-app-JSON-502 distinction (the gateway 502's `server: cloudflare`/`text/plain` shape localized the fault to the origin/upstream layer, not the handler) plus a direct Buttondown probe that surfaced the Turnstile challenge.
+
+### What went wrong
+
+A silent third-party contract change broke a user-facing feature with no alert. The failure manifested as a gateway 502 that never reached the app's Sentry mirror, so nothing paged.
+
+## Action Items & Follow-ups
+
+_No action items — incident fully resolved in the source PR with no residual work._

--- a/knowledge-base/project/learnings/integration-issues/2026-06-09-buttondown-embed-endpoint-behind-turnstile-use-authenticated-api.md
+++ b/knowledge-base/project/learnings/integration-issues/2026-06-09-buttondown-embed-endpoint-behind-turnstile-use-authenticated-api.md
@@ -1,0 +1,83 @@
+# Learning: Buttondown's public embed-subscribe endpoint moved behind Cloudflare Turnstile — proxy the authenticated API instead
+
+## Problem
+
+The waitlist banner (`CtaBanner`, pricing page + shared docs) showed "Something
+went wrong. Please try again." on every email submit. `POST /api/waitlist`
+returned a **502** in ~2–4s.
+
+The 502 was a **Cloudflare-synthesized gateway 502** (`server: cloudflare`,
+`cf-ray`, `content-type: text/plain`, body `error code: 502`), NOT the app's own
+`{"error":"upstream_unavailable"}` JSON 502. That distinction localized the
+fault to the origin failing to return a clean response during the upstream call,
+not the route handler.
+
+Root cause: `subscribeToWaitlist` (`apps/web-platform/app/api/waitlist/waitlist.ts`)
+proxied Buttondown's **keyless public embed-subscribe endpoint**
+(`https://buttondown.com/api/emails/embed-subscribe/<user>`). Buttondown moved
+that public endpoint **behind Cloudflare Turnstile** — a direct server-side POST
+now returns `400` + an HTML "Verify Your Subscription" page that loads
+`challenges.cloudflare.com/turnstile`. A same-origin server-side proxy can never
+solve a Turnstile challenge, so every submission failed (400/challenge, or an
+egress stall that collapsed into the gateway 502).
+
+## Solution
+
+Rewrite `subscribeToWaitlist` to call Buttondown's **authenticated v1 REST API**
+(`POST https://api.buttondown.com/v1/subscribers`, header
+`Authorization: Token ${BUTTONDOWN_API_KEY}`, JSON body
+`{ email_address, tags: [...] }`), which is **not** behind Turnstile. Supporting
+changes:
+
+- Add `AbortSignal.timeout(5_000)` so a future upstream stall degrades to the
+  app's own JSON 502 instead of hanging the worker into a gateway 502 (mirrors
+  the existing `token-validators.ts` buttondown validator pattern).
+- Read `BUTTONDOWN_API_KEY` **fail-closed at call time** (throw inside the
+  function → route try/catch → graceful JSON 502), never at module load — a
+  missing key must not crash the worker at boot.
+- **Omit `type: "regular"`** from the body to preserve Buttondown's default
+  double opt-in (the confirmation email is the GDPR Art. 6(1)(a) consent step
+  the success copy promises).
+- Match the v1 duplicate signal on the machine code `email_already_exists` (and
+  a narrow `/already (subscribed|exists)/i` detail/plaintext phrase) — NOT a
+  broad `exists`/`subscrib`/`duplicate` token, which misclassifies genuine
+  validation 400s as success and silently drops the signup.
+
+## Key Insight
+
+Two generalizable lessons:
+
+1. **A server-side proxy of a vendor's *public embed/form* endpoint is fragile.**
+   Public form endpoints are designed for a real browser and can sprout bot
+   defenses (Turnstile/reCAPTCHA) at any time, silently breaking a server
+   relay. When a vendor offers an authenticated REST API for the same action,
+   proxy that instead — it is the supported server-to-server path and is not
+   gated by browser challenges.
+
+2. **A Cloudflare-synthesized 5xx (`server: cloudflare`, `cf-ray`, `text/plain`
+   `error code: NNN`) is NOT the app's own error response.** When debugging a
+   5xx behind Cloudflare, compare the captured body/headers against what the
+   app's handler is coded to return. If the app returns JSON but you see CF's
+   HTML/text error page, the origin never returned a clean response — the fault
+   is at the origin/upstream layer, not in the handler's error branch. Probe the
+   route's early-exit paths (bad origin → app JSON 403, etc.) to confirm the
+   handler is reachable, then bisect to the specific upstream call.
+
+## Session Errors
+
+- **Task tool unavailable in the planning subagent's environment** (forwarded
+  from session-state.md) — the deepen-plan research/review fan-out ran inline
+  instead of via parallel subagents. One-off environment constraint; the inline
+  verification (Context7 + WebFetch + live prod probes) covered the same ground.
+  Prevention: none needed — graceful inline fallback already exists.
+- **`curl -H origin:https://...` (unquoted) returned a spurious 403** during prod
+  probing — the malformed Origin header failed `validateOrigin`. Recovery: use
+  quoted `-H "origin: https://..."`. Prevention: always quote `curl -H` header
+  args.
+- **`git grep ... -- ':!*.md'` errored `fatal: unable to resolve revision`** —
+  mixing a revision-less grep with a pathspec exclusion. Recovery: fell back to a
+  plain `git grep <pattern> <path>` + post-filter. One-off.
+
+## Tags
+category: integration-issues
+module: web-platform/api/waitlist

--- a/knowledge-base/project/plans/2026-06-09-fix-waitlist-buttondown-authenticated-api-plan.md
+++ b/knowledge-base/project/plans/2026-06-09-fix-waitlist-buttondown-authenticated-api-plan.md
@@ -1,0 +1,445 @@
+---
+title: "Fix broken waitlist signup — migrate to Buttondown authenticated v1 API"
+date: 2026-06-09
+type: fix
+branch: feat-one-shot-waitlist-buttondown-api
+lane: single-domain
+requires_cpo_signoff: false
+brand_survival_threshold: aggregate pattern
+status: planned
+---
+
+# 🐛 Fix: Waitlist signup returns gateway 502 — migrate to Buttondown authenticated v1 API
+
+## Enhancement Summary
+
+**Deepened on:** 2026-06-09
+**Sections enhanced:** Overview (verified-claims block), Implementation Phase 1/3, Risks
+**Verification performed inline** (the deepen-plan parallel skill/learning/review subagents
+require the Task tool, which is unavailable in this environment; the equivalent checks were
+run directly):
+
+### Key Improvements (all live-verified this pass)
+1. **Buttondown v1 API contract confirmed from two independent sources** (Context7
+   `/buttondown/docs` + WebFetch of docs.buttondown.com): `email_address` (required),
+   `tags` (JSON array), `type: "regular"` BYPASSES double opt-in, `Authorization: Token`,
+   201 success, 400 collision.
+2. **Precedent-diff (Phase 4.4):** the `Authorization: Token ${token}` header AND
+   `AbortSignal.timeout(VALIDATION_TIMEOUT_MS)` (5_000) pattern already exist verbatim at
+   `token-validators.ts:59,74,3` for the buttondown provider. The plan mirrors the
+   established codebase form exactly — no novel pattern.
+3. **`AbortSignal.timeout` rejection shape confirmed:** `name: "TimeoutError"`,
+   `msg: "The operation was aborted due to timeout"` (Node runtime, live `node -e` probe).
+   The Phase 3 timeout-test mock is correct.
+4. **Verify-the-negative pass — all negative claims confirmed, zero contradictions:**
+   `BUTTONDOWN_API_KEY` has no `NEXT_PUBLIC_` form (server-only, never client-exposed);
+   `WAITLIST_USERNAME` has no consumer outside the lines being removed (safe to delete);
+   no env-validation framework exists (`envalid`/`createEnv`/`@t3-oss/env`/`env.ts` all
+   absent) → confirms the "no boot-schema edit; runtime fail-closed guard" decision.
+
+### New Considerations Discovered
+- **Double opt-in is the highest-risk drift surface** (already a Sharp Edge): the v1 API
+  silently activates the subscriber if `type: "regular"` is sent. The original feature
+  (`2026-03-25-feat-waitlist-signup-form-plan.md`) and the live `cta-banner.tsx:102-103`
+  copy ("check your inbox to confirm") both depend on the confirmation email. Omitting
+  `type` is load-bearing — promoted to AC and test assertion.
+- **The v1 duplicate-400 body differs from the embed body** (already a Sharp Edge): the
+  `/already/i` heuristic must be re-derived against a real v1 collision response at /work
+  time, not copied. Left as a /work-time read because no synthetic collision can be
+  exercised without writing a real subscriber to prod.
+
+## Overview
+
+The waitlist banner (`CtaBanner`, rendered on the pricing page and shared docs) is
+broken for every visitor: `POST /api/waitlist` with a valid email returns a
+**Cloudflare-synthesized gateway 502** (`server: cloudflare`, `content-type: text/plain`,
+body `error code: 502`), and the banner shows "Something went wrong. Please try again."
+
+The root cause is upstream, not in our code: `subscribeToWaitlist`
+(`apps/web-platform/app/api/waitlist/waitlist.ts:53`) proxies Buttondown's **keyless
+public embed-subscribe endpoint** (`https://buttondown.com/api/emails/embed-subscribe/soleur`).
+Buttondown has moved that public endpoint behind **Cloudflare Turnstile** — a direct
+POST now returns HTTP 400 + an HTML "Verify Your Subscription" page that loads
+`challenges.cloudflare.com/turnstile`, which a server-side proxy cannot solve. The
+outbound request either gets the 400/challenge or hangs on egress until the origin
+dies, which Cloudflare reports to the browser as a gateway 502.
+
+**The fix:** rewrite `subscribeToWaitlist` to call Buttondown's **authenticated REST
+API** (`POST https://api.buttondown.com/v1/subscribers`, `Authorization: Token
+${BUTTONDOWN_API_KEY}`), which is **not** behind Turnstile. Add a request timeout so a
+future upstream stall degrades to the app's own JSON 502 rather than a gateway hang.
+Wire the already-registered `BUTTONDOWN_API_KEY` secret. Update the existing test.
+
+This is a single-file behavioral fix to an already-built, already-broken route. No
+client change, no route-handler change, no new infrastructure, no new vendor.
+
+### Confirmed root cause (verified by direct prod + Buttondown probing, 2026-06-09)
+
+- `GET /` healthy (307, 0.2s); `GET /api/waitlist` → 405; POST with bad origin → app's
+  clean `{"error":"Forbidden"}` JSON. The route module loads and the handler runs.
+- POST with a valid email → 502 with `server: cloudflare`, `cf-ray`,
+  `content-type: text/plain`, body `error code: 502` — Cloudflare-synthesized, NOT the
+  app's own `{"error":"upstream_unavailable"}` JSON. The request dies at the origin
+  during the upstream call.
+- Direct POST to `https://buttondown.com/api/emails/embed-subscribe/soleur` → HTTP 400 +
+  HTML "Verify Your Subscription" page loading Cloudflare Turnstile.
+- The error handler (`warnSilentFallback` wraps Sentry in try/catch) and the client
+  (`cta-banner.tsx`) are both fine — no change needed there.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (from task framing) | Reality (verified this session) | Plan response |
+| --- | --- | --- |
+| `subscribeToWaitlist` proxies the keyless public embed endpoint | Confirmed: `waitlist.ts:31,60` POSTs `BUTTONDOWN_EMBED_URL` urlencoded, no auth header | Rewrite to authenticated v1 JSON API |
+| `BUTTONDOWN_API_KEY` is a registered provider | Confirmed: `providers.ts:23` (`category: "social"`, `envVar: "BUTTONDOWN_API_KEY"`), validated `token-validators.ts:57-60` against `api.buttondown.com/v1` with `Authorization: Token ${token}` | Read `process.env.BUTTONDOWN_API_KEY` |
+| Key is present in web-platform Doppler config | Confirmed live: `doppler secrets get BUTTONDOWN_API_KEY -p soleur -c prd --plain` → PRESENT | No provisioning step needed |
+| `AbortSignal.timeout(...)` pattern exists to follow | Confirmed: `token-validators.ts:3,74` uses `AbortSignal.timeout(VALIDATION_TIMEOUT_MS)` (5_000) | Mirror the pattern with a `WAITLIST_TIMEOUT_MS` |
+| web-platform validates env at boot | **False** — no `envalid`/`createEnv`/zod-env/`env.ts` exists; convention is plain `process.env.<VAR>` | No boot-schema edit; runtime fail-closed guard instead (see Phase 2) |
+| `.env.example` exists at `apps/web-platform/.env.example` | Confirmed (9.9KB, `# --- Section ---` headers); has **no** `BUTTONDOWN_API_KEY` line | Add a `# --- Buttondown (waitlist) ---` section |
+| Existing test mocks the embed endpoint | Confirmed: `api-waitlist-subscribe.test.ts:100` asserts `buttondown.com/api/emails/embed-subscribe/soleur` + urlencoded body | Rewrite mock to the v1 JSON endpoint |
+| Already-subscribed handling: HTTP 400 + `/already/i` body | Current code at `waitlist.ts:70-72`. **v1 API duplicate semantics differ** — see Sharp Edges | Re-derive duplicate handling for v1 (see Phase 1) |
+
+### Buttondown v1 API contract (verified 2026-06-09 via Context7 `/buttondown/docs` + WebFetch of docs.buttondown.com)
+
+`POST https://api.buttondown.com/v1/subscribers`
+- Header: `Authorization: Token ${BUTTONDOWN_API_KEY}` (verbatim — same form as `token-validators.ts:59`)
+- Header: `Content-Type: application/json`
+- Body (JSON): `email_address` (string, **required**), `tags` (array of strings, optional),
+  `type` (string, optional — `"regular"` BYPASSES double opt-in), `metadata` (object, optional),
+  `utm_source` / `utm_campaign` (optional).
+- Success: **201** (created). Response carries `id`, `email_address`, `type`, `tags`, `creation_date`, `source`.
+- Duplicate email: **400** (collision). Collision behavior is governed by the
+  `X-Buttondown-Collision-Behavior` header (`overwrite` | `add`); default is to reject.
+- The field is `email_address`, NOT `email`. Tags are a JSON array, NOT a urlencoded `tag` field.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** the waitlist banner on the pricing
+page and every shared doc continues to show "Something went wrong. Please try again."
+on submit — the single top-of-funnel conversion surface stays dead, and any visitor
+who tries to join silently bounces.
+
+**If this leaks, the user's data is exposed via:** the route forwards a visitor's email
+address (PII) to Buttondown (US processor, SCCs Module 2 — see
+`knowledge-base/project/learnings/2026-03-18-buttondown-gdpr-transfer-mechanism-sccs-only.md`).
+The only new exposure vector is the `BUTTONDOWN_API_KEY` itself: it must never be logged,
+never be returned in a response body, and never reach the client. The existing handler
+already logs status-only (never the raw Buttondown body); the rewrite preserves that.
+
+**Brand-survival threshold:** aggregate pattern. (Marketing waitlist relay; a single
+failed signup is a lost lead, not a brand-survival incident. No per-PR CPO sign-off.)
+
+## Implementation Phases
+
+### Phase 1 — Rewrite `subscribeToWaitlist` to the authenticated v1 API
+
+File: `apps/web-platform/app/api/waitlist/waitlist.ts`
+
+1. Replace the `BUTTONDOWN_EMBED_URL` constant with the authenticated endpoint:
+   ```ts
+   const BUTTONDOWN_SUBSCRIBE_URL = "https://api.buttondown.com/v1/subscribers";
+   ```
+   Keep `WAITLIST_TAG = "pricing-waitlist"` unchanged (same bucket). The
+   `WAITLIST_USERNAME = "soleur"` constant becomes dead once the embed URL is gone —
+   `git grep -n "WAITLIST_USERNAME" apps/web-platform` to confirm it has no other
+   consumer, then remove it (and its comment) in the same commit per
+   `cq-ref-removal-sweep-cleanup-closures`. (Verified this session: zero other consumers.)
+
+2. Add a timeout constant mirroring `token-validators.ts:3`:
+   ```ts
+   const WAITLIST_TIMEOUT_MS = 5_000;
+   ```
+
+3. Read the key fail-closed at call time (NOT module load — a missing key must not crash
+   the worker per the acceptance criterion; the route's try/catch maps a throw to a
+   graceful JSON 502):
+   ```ts
+   const apiKey = process.env.BUTTONDOWN_API_KEY;
+   if (!apiKey) {
+     log.warn("BUTTONDOWN_API_KEY missing — waitlist subscribe disabled");
+     throw new Error("waitlist subscribe unconfigured");
+   }
+   ```
+   (Plain `process.env` is the codebase convention — no env wrapper exists. The throw is
+   caught by `route.ts:72` → `warnSilentFallback` + `{error:"upstream_unavailable"}` 502.)
+
+4. Issue the authenticated POST with a JSON body, the `Authorization: Token` header, and
+   the abort timeout:
+   ```ts
+   const res = await fetch(BUTTONDOWN_SUBSCRIBE_URL, {
+     method: "POST",
+     headers: {
+       Authorization: `Token ${apiKey}`,
+       "content-type": "application/json",
+     },
+     body: JSON.stringify({ email_address: email, tags: [WAITLIST_TAG] }),
+     signal: AbortSignal.timeout(WAITLIST_TIMEOUT_MS),
+   });
+   ```
+   **Do NOT set `type: "regular"`.** Omitting `type` preserves Buttondown's default
+   **double opt-in** — the visitor receives a confirmation email, which the existing
+   success copy promises ("You're on the list ✓ — check your inbox to confirm.",
+   `cta-banner.tsx:102-103`) and which is the documented GDPR Art. 6(1)(a) consent step
+   (original plan `2026-03-25-feat-waitlist-signup-form-plan.md:273,293-295`). Setting
+   `type: "regular"` would silently strip the confirmation email and the consent step.
+   See Sharp Edges.
+
+5. Map responses (mirror the current idempotent-success contract):
+   - `res.ok` (200/201) → `return { ok: true }`.
+   - `400` → read body (`.text().catch(() => "")`); treat duplicate/already-subscribed
+     as **idempotent success** (`return { ok: true }`). **Re-derive the match** against
+     the v1 body shape rather than copying `/already/i` blindly — the v1 collision 400
+     body differs from the old embed body. Prefer a tolerant predicate that matches the
+     v1 collision signal (e.g. `/already|subscrib|exists|duplicate/i`, OR parse the JSON
+     and check for a collision `code`). Confirm the exact v1 400 body during /work by
+     reading a real collision response (or the Context7 schema) before freezing the regex.
+   - Any other status → `log.warn({ status }, "...")` and `throw` (route → 502). Status
+     only ever reaches logs; never the raw body, never the key.
+
+6. Update the function's doc comment to describe the authenticated v1 API.
+
+#### Research Insights (Phase 1)
+
+**Precedent-diff — the canonical form already exists in-repo** (`token-validators.ts`,
+verified this pass):
+```ts
+// token-validators.ts:3,59,74 — the buttondown validator already does exactly this:
+const VALIDATION_TIMEOUT_MS = 5_000;
+headers: (token) => ({ Authorization: `Token ${token}` }),   // buttondown @ api.buttondown.com/v1
+signal: AbortSignal.timeout(VALIDATION_TIMEOUT_MS),
+```
+The rewrite is a 1:1 mirror of this established pattern (header form, timeout primitive,
+5s window) applied to the subscribe endpoint. No novel pattern; nothing for reviewers to
+scrutinize on shape.
+
+**AbortSignal.timeout rejection shape** (live `node -e` probe): rejects with a `DOMException`
+whose `name === "TimeoutError"` and `message === "The operation was aborted due to timeout"`.
+The Phase 3 timeout test mocks exactly this. The fetch throw is caught by `route.ts:72`.
+
+**Edge case — fail-closed key read at call time, not module load.** Reading
+`process.env.BUTTONDOWN_API_KEY` at module-evaluation time would make a missing key a
+module-load crash (the worker dies), violating the "never crash the worker" requirement.
+Reading inside `subscribeToWaitlist` lets the throw be caught by the route's try/catch →
+graceful JSON 502. This matches `token-validators.ts` reading `token` per-call.
+
+### Phase 2 — Wire the secret into `.env.example`
+
+File: `apps/web-platform/.env.example`
+
+Add a section (the file uses `# --- Section ---` headers; Buttondown is the only
+`category: "social"` provider with a server-side consumer). Place it near the other
+infrastructure/social secrets:
+```
+# --- Buttondown (waitlist) ---
+# Authenticated REST API key for the marketing waitlist relay (/api/waitlist →
+# api.buttondown.com/v1/subscribers). Token-format key from
+# buttondown.com/settings/api. Without it, /api/waitlist fails closed to a graceful
+# 502 (the worker never crashes). Present in Doppler soleur/prd.
+BUTTONDOWN_API_KEY=
+```
+
+**No boot-time env-schema edit** — web-platform has no env-validation framework
+(verified: no `envalid`/`createEnv`/zod-env/`env.ts`). The Phase 1 fail-closed guard is
+the runtime validation. Document this decision in the PR body.
+
+### Phase 3 — Update the test
+
+File: `apps/web-platform/test/api-waitlist-subscribe.test.ts`
+
+The test already stubs global `fetch` and mocks observability + logger. Rewrite the
+upstream-shape assertions:
+
+1. **Header comment** (lines 2-9): change "proxy to Buttondown's embed-subscribe" to the
+   authenticated v1 API description.
+2. **`valid email ... returns 200` test** (lines 90-105):
+   - Mock `mockFetch.mockResolvedValue(new Response("", { status: 201 }))`.
+   - Assert `String(url)` contains `api.buttondown.com/v1/subscribers`.
+   - Assert the request `init` headers include `Authorization: Token <...>` and
+     `content-type: application/json`.
+   - Parse `init.body` as JSON; assert `email_address === "user@company.com"` and
+     `tags` deep-equals `["pricing-waitlist"]`. Assert **no** `type` field is sent
+     (double-opt-in preservation guard).
+   - Set `process.env.BUTTONDOWN_API_KEY` in `beforeEach` and delete it in `afterEach`.
+3. **already-subscribed test** (lines 107-118): mock the v1 collision 400 body shape
+   (use the exact body the Phase 1 predicate matches); assert 200 `{ok:true}` and
+   `warnSilentFallback` NOT called.
+4. **unexpected-status test** (lines 198-210): keep the 503 → 502 + `warnSilentFallback`
+   assertion (status mapping unchanged).
+5. **NEW: timeout → 502 test.** `mockFetch.mockRejectedValue(Object.assign(new Error("The operation was aborted due to timeout"), { name: "TimeoutError" }))`
+   (or `new DOMException("aborted", "TimeoutError")`); assert 502 + `warnSilentFallback`
+   called once. (`AbortSignal.timeout` rejects the fetch with a `TimeoutError`; mocking
+   the rejection is the deterministic way to exercise the path without a real timer.)
+6. **NEW: missing-key → 502 test.** `delete process.env.BUTTONDOWN_API_KEY` before the
+   call; assert 502 + `warnSilentFallback` called, and `mockFetch` NOT called (fail-closed
+   before any upstream call).
+7. The rate-limit, honeypot, origin, and invalid-email tests are unaffected — keep them
+   (but ensure they don't depend on a real upstream call; the rate-limit test mocks a
+   200, which should become a 201).
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] `subscribeToWaitlist` POSTs `https://api.buttondown.com/v1/subscribers` with header
+      `Authorization: Token ${process.env.BUTTONDOWN_API_KEY}` and JSON body
+      `{ email_address, tags: ["pricing-waitlist"] }` — verified by
+      `git grep -n "api.buttondown.com/v1/subscribers" apps/web-platform/app/api/waitlist/waitlist.ts` returning 1.
+- [ ] The body sends **no** `type` field (double opt-in preserved) — verified by a test
+      assertion that the parsed request body has no `type` key.
+- [ ] The fetch carries `signal: AbortSignal.timeout(WAITLIST_TIMEOUT_MS)` — verified by
+      `git grep -n "AbortSignal.timeout" apps/web-platform/app/api/waitlist/waitlist.ts`.
+- [ ] A missing `BUTTONDOWN_API_KEY` throws before any fetch (fail-closed) → route returns
+      `{error:"upstream_unavailable"}` 502, worker does not crash — covered by the
+      missing-key test.
+- [ ] `apps/web-platform/.env.example` contains a `BUTTONDOWN_API_KEY=` line under a
+      Buttondown section — verified by `grep -c "^BUTTONDOWN_API_KEY=" apps/web-platform/.env.example` returning 1.
+- [ ] The old embed endpoint and `WAITLIST_USERNAME` are gone — verified by
+      `git grep -n "embed-subscribe\|WAITLIST_USERNAME" apps/web-platform` returning 0.
+- [ ] Test suite covers: success (201), already-subscribed idempotent (400) success,
+      unexpected status → 502, timeout → 502, missing-key → 502.
+- [ ] `cd apps/web-platform && ./node_modules/.bin/vitest run test/api-waitlist-subscribe.test.ts` passes.
+- [ ] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` passes.
+
+### Post-merge (operator)
+
+- [ ] After deploy, a valid email POST to prod `/api/waitlist` (via the banner or curl
+      with a valid Origin + cf-connecting-ip) returns `200 {ok:true}` and the subscriber
+      appears (status: unconfirmed, pending double opt-in) in Buttondown under the
+      `pricing-waitlist` tag. Automation: Playwright MCP can drive the banner submit on
+      the live pricing page to confirm the success state renders; Buttondown subscriber
+      presence is confirmed via `GET api.buttondown.com/v1/subscribers?tag=pricing-waitlist`
+      with the Doppler key (read-only). `Ref` the tracking issue; do not `Closes`-auto-close
+      until prod is verified.
+
+## Domain Review
+
+**Domains relevant:** Legal/Compliance (email PII → US processor), Product (top-of-funnel
+conversion surface), Engineering.
+
+(Note: the plan skill's domain-leader subagents and Product/UX Gate specialists could not
+be spawned in this environment — the Task tool is unavailable. The Product/UX Gate is
+**NONE** by the mechanical UI-surface override: this plan's Files-to-Edit contains NO
+`components/**/*.tsx`, `app/**/page.tsx`, or `app/**/layout.tsx` — it only edits a server
+helper, an env example, and a test. The client `cta-banner.tsx` is explicitly NOT changed.
+A `.pen` wireframe already exists at
+`knowledge-base/product/design/shared-document/cta-banner-waitlist.pen`; no new UI surface
+is introduced.)
+
+### Legal/Compliance
+
+**Status:** reviewed (carry-forward from existing artifacts)
+**Assessment:** Email is PII forwarded to Buttondown (US processor, SCCs Module 2 — see
+learning `2026-03-18-buttondown-gdpr-transfer-mechanism-sccs-only.md`). No new processor,
+no new data type, no new purpose: this is the **same** Art. 6(1)(a) consent basis, the
+**same** `pricing-waitlist` Art. 30 PA6 bucket, and the **same** double opt-in consent
+step as the already-shipped waitlist. The fix changes only the transport (keyless embed →
+authenticated REST), not the data flow, the lawful basis, or the consent mechanism. The
+critical compliance guard is **preserving double opt-in** (Phase 1 step 4) — omitting
+`type: "regular"`. Phase 2.7 GDPR gate fires (email PII → external API on a regulated
+surface) but produces no new fold-in: the privacy posture is unchanged from the current
+shipped state.
+
+### Product/UX Gate
+
+**Tier:** none
+**Decision:** auto-accepted (pipeline) — no UI surface in Files-to-Edit; mechanical
+override did not fire.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "Buttondown subscriber count under the pricing-waitlist tag increments on real signups"
+  cadence: "on-demand (low-volume marketing funnel; no scheduled probe warranted)"
+  alert_target: "none (aggregate-pattern threshold; not a paged surface)"
+  configured_in: "Buttondown dashboard / GET api.buttondown.com/v1/subscribers?tag=pricing-waitlist"
+error_reporting:
+  destination: "Sentry via warnSilentFallback({ feature: 'waitlist-subscribe', op: 'subscribe' }) at route.ts:76 (unchanged)"
+  fail_loud: "warn-level (best-effort marketing forward; the route returns a graceful JSON 502, never a crash)"
+failure_modes:
+  - mode: "BUTTONDOWN_API_KEY missing/unset at runtime"
+    detection: "log.warn 'BUTTONDOWN_API_KEY missing' + Sentry warn via route catch → JSON 502"
+    alert_route: "Sentry (warn), surfaced as the app's {error:'upstream_unavailable'} 502 (NOT a gateway 502)"
+  - mode: "Buttondown upstream non-ok status (e.g. 401 bad key, 5xx)"
+    detection: "log.warn({ status }) in waitlist.ts + throw → route catch → Sentry warn"
+    alert_route: "Sentry (warn)"
+  - mode: "Buttondown upstream stall / hang"
+    detection: "AbortSignal.timeout(5s) rejects → route catch → Sentry warn → JSON 502"
+    alert_route: "Sentry (warn); the timeout converts a would-be gateway 502 into the app's JSON 502"
+logs:
+  where: "createChildLogger('waitlist-subscribe') — status-only, never the raw upstream body, never the key"
+  retention: "platform log retention (unchanged)"
+discoverability_test:
+  command: "curl -sS -X POST https://app.soleur.ai/api/waitlist -H 'origin: https://app.soleur.ai' -H 'content-type: application/json' -d '{\"email\":\"probe@example.com\"}' -w '%{http_code}'"
+  expected_output: "200 with body {\"ok\":true} (NOT 'error code: 502' text/plain from Cloudflare)"
+```
+
+## Open Code-Review Overlap
+
+None. (No open `code-review`-labelled issue references
+`apps/web-platform/app/api/waitlist/waitlist.ts` or the waitlist test. Verified via the
+two-stage `gh issue list --json` + standalone `jq --arg` pattern at plan time; the
+GitHub query surfaced no matches against the planned file paths. If `gh` is offline at
+/work time, re-run the check before finalizing.)
+
+## Test Scenarios
+
+| Scenario | Mock | Expected |
+| --- | --- | --- |
+| Valid email, key present | fetch → 201 | 200 `{ok:true}`; body `{email_address, tags:["pricing-waitlist"]}`, no `type`; `Authorization: Token` header |
+| Already subscribed | fetch → 400 (v1 collision body) | 200 `{ok:true}`; `warnSilentFallback` NOT called |
+| Bad key / unexpected status | fetch → 401/503 | 502 `{error:"upstream_unavailable"}`; `warnSilentFallback` once |
+| Upstream timeout | fetch → reject `TimeoutError` | 502; `warnSilentFallback` once |
+| Missing key | `delete process.env.BUTTONDOWN_API_KEY` | 502; `warnSilentFallback` once; fetch NOT called |
+| Honeypot / bad origin / invalid email / rate limit | (unchanged) | unchanged (no upstream call) |
+
+## Sharp Edges
+
+- **Double opt-in must be preserved — do NOT send `type: "regular"`.** The v1 API defaults
+  to double opt-in (visitor gets a confirmation email) ONLY when `type` is omitted; sending
+  `type: "regular"` activates the subscriber immediately and skips the confirmation email.
+  The existing success copy (`cta-banner.tsx:102-103`: "check your inbox to confirm") and
+  the documented GDPR Art. 6(1)(a) consent step (original plan
+  `2026-03-25-feat-waitlist-signup-form-plan.md:273,293-295,323`) both depend on the
+  confirmation email being sent. Omitting `type` is load-bearing, not an oversight.
+- **The v1 duplicate-400 body differs from the old embed body.** The current
+  `/already/i.test(text)` heuristic was written against the embed endpoint's plaintext
+  response. The v1 collision-400 body shape is different (JSON with a collision code, or
+  a different message). Re-read a real v1 400 collision body (or the Context7 schema)
+  during /work and widen the predicate accordingly — do NOT copy `/already/i` blindly, or
+  a genuine duplicate could fall through to a 502.
+- **The field is `email_address`, not `email`; tags are a JSON array, not a urlencoded
+  `tag`.** The embed endpoint took `email`+`tag` urlencoded; the v1 API takes
+  `email_address`+`tags:[...]` as JSON. Mixing the two shapes silently produces a 400.
+- **Test runner is vitest, not bun.** `apps/web-platform/bunfig.toml` has
+  `[test] pathIgnorePatterns = ["**"]` — `bun test` discovers nothing. Use
+  `./node_modules/.bin/vitest run test/api-waitlist-subscribe.test.ts`. Typecheck is
+  `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (the repo root has no
+  `workspaces` field, so `npm run -w` fails).
+- **The test file path must match the vitest `node` project glob** (`test/**/*.test.ts`).
+  The existing file already lives at `apps/web-platform/test/api-waitlist-subscribe.test.ts`
+  — keep it there; do not co-locate.
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/placeholder
+  text, or omits the threshold will fail `deepen-plan` Phase 4.6. (This plan's section is
+  filled; threshold = aggregate pattern.)
+
+## Infrastructure (IaC)
+
+None. This plan introduces no new server, service, cron, vendor account, DNS record, TLS
+cert, or firewall rule. `BUTTONDOWN_API_KEY` is an **already-provisioned** Doppler secret
+(verified present in `soleur/prd`) and an already-registered provider (`providers.ts:23`)
+— no new secret is created. The change edits only `apps/web-platform/app/`,
+`apps/web-platform/.env.example`, and `apps/web-platform/test/`. Phase 2.8 gate skipped
+(pure code change against an already-provisioned surface).
+
+## Files to Edit
+
+- `apps/web-platform/app/api/waitlist/waitlist.ts` — rewrite `subscribeToWaitlist` to the
+  authenticated v1 API; add timeout; fail-closed key read; remove embed URL + `WAITLIST_USERNAME`.
+- `apps/web-platform/.env.example` — add `# --- Buttondown (waitlist) ---` + `BUTTONDOWN_API_KEY=`.
+- `apps/web-platform/test/api-waitlist-subscribe.test.ts` — re-mock to the v1 endpoint;
+  add timeout + missing-key cases; assert no `type` field.
+
+## Files to Create
+
+None.

--- a/knowledge-base/project/specs/feat-one-shot-waitlist-buttondown-api/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-waitlist-buttondown-api/session-state.md
@@ -1,0 +1,19 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/harry/Documents/Stage/Soleur/soleur/.worktrees/feat-one-shot-waitlist-buttondown-api/knowledge-base/project/plans/2026-06-09-fix-waitlist-buttondown-authenticated-api-plan.md
+- Status: complete
+
+### Errors
+- Task tool unavailable in planning subagent env; parallel research/review fan-out was done inline instead. All deepen-plan enforcement halts (4.6–4.9) passed. CWD verified.
+
+### Decisions
+- Migrate to authenticated v1 API (POST api.buttondown.com/v1/subscribers, Authorization: Token, JSON {email_address, tags:["pricing-waitlist"]}) — not behind Turnstile; mirrors token-validators.ts buttondown form.
+- Preserve double opt-in — do NOT send type:"regular" (cta-banner "check your inbox to confirm" copy + GDPR Art. 6(1)(a) consent depend on the confirmation email). Promoted to AC + test assertion.
+- Fail-closed key read at call time, not module load — missing BUTTONDOWN_API_KEY throws inside the function so the route try/catch maps to graceful JSON 502, never crashing the worker. web-platform has no env-validation framework; convention is plain process.env.
+- Re-derive the duplicate-400 predicate at /work time against a real v1 response (the v1 collision body differs from the old embed body; do not copy /already/i). Key confirmed PRESENT in Doppler soleur/prd via live read.
+- Threshold = aggregate pattern; no UI surface (server helper + env example + test only); no new infrastructure. Product/UX Gate NONE.
+
+### Components Invoked
+- Skill: soleur:plan, soleur:deepen-plan
+- Bash, Read, Write, Edit, WebFetch, mcp__plugin_soleur_context7__query-docs (/buttondown/docs)

--- a/knowledge-base/project/specs/feat-one-shot-waitlist-buttondown-api/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-waitlist-buttondown-api/tasks.md
@@ -1,0 +1,58 @@
+# Tasks — Fix waitlist signup (Buttondown authenticated v1 API)
+
+Plan: `knowledge-base/project/plans/2026-06-09-fix-waitlist-buttondown-authenticated-api-plan.md`
+Branch: `feat-one-shot-waitlist-buttondown-api`
+
+## Phase 0 — Preconditions (verify, do not assume)
+
+- [ ] 0.1 Read a real Buttondown v1 collision-400 body (Context7 schema or a sandbox call)
+      to fix the exact duplicate-match predicate before editing. Do NOT copy `/already/i`.
+- [ ] 0.2 Confirm `git grep -n "WAITLIST_USERNAME" apps/web-platform` shows only the
+      define + embed-URL lines being removed (verified at plan time: zero other consumers).
+
+## Phase 1 — Rewrite `subscribeToWaitlist` (`apps/web-platform/app/api/waitlist/waitlist.ts`)
+
+- [ ] 1.1 Replace `BUTTONDOWN_EMBED_URL` with
+      `BUTTONDOWN_SUBSCRIBE_URL = "https://api.buttondown.com/v1/subscribers"`.
+- [ ] 1.2 Remove the now-dead `WAITLIST_USERNAME` constant + comment (same commit,
+      `cq-ref-removal-sweep-cleanup-closures`).
+- [ ] 1.3 Add `const WAITLIST_TIMEOUT_MS = 5_000;` (mirror `token-validators.ts:3`).
+- [ ] 1.4 Read `process.env.BUTTONDOWN_API_KEY` at call time; if falsy, `log.warn` + throw
+      (fail-closed → route maps to graceful 502, never a module-load crash).
+- [ ] 1.5 POST JSON `{ email_address: email, tags: [WAITLIST_TAG] }` with headers
+      `Authorization: Token ${apiKey}` + `content-type: application/json` and
+      `signal: AbortSignal.timeout(WAITLIST_TIMEOUT_MS)`. **Do NOT send `type`** (preserve
+      double opt-in).
+- [ ] 1.6 Map: 200/201 → `{ok:true}`; 400-duplicate → `{ok:true}` (predicate from 0.1);
+      other → `log.warn({status})` + throw. Never log/return the body or the key.
+- [ ] 1.7 Update the function doc comment to describe the authenticated v1 API.
+
+## Phase 2 — `.env.example` (`apps/web-platform/.env.example`)
+
+- [ ] 2.1 Add `# --- Buttondown (waitlist) ---` section + `BUTTONDOWN_API_KEY=` with the
+      "fails closed to a graceful 502" comment. No boot-schema edit (no env framework exists).
+
+## Phase 3 — Tests (`apps/web-platform/test/api-waitlist-subscribe.test.ts`)
+
+- [ ] 3.1 Update header comment; set/delete `process.env.BUTTONDOWN_API_KEY` in
+      beforeEach/afterEach.
+- [ ] 3.2 Success: mock 201; assert URL `api.buttondown.com/v1/subscribers`, header
+      `Authorization: Token`, JSON body `{email_address, tags:["pricing-waitlist"]}`, NO `type` key.
+- [ ] 3.3 Already-subscribed: mock v1 collision 400 body → 200 `{ok:true}`,
+      `warnSilentFallback` not called.
+- [ ] 3.4 Unexpected status (503) → 502 + `warnSilentFallback` (keep).
+- [ ] 3.5 NEW timeout: mock rejection `name:"TimeoutError"` → 502 + `warnSilentFallback`.
+- [ ] 3.6 NEW missing-key: `delete process.env.BUTTONDOWN_API_KEY` → 502, fetch NOT called.
+- [ ] 3.7 Update the rate-limit test's mocked upstream 200 → 201.
+
+## Phase 4 — Verify
+
+- [ ] 4.1 `cd apps/web-platform && ./node_modules/.bin/vitest run test/api-waitlist-subscribe.test.ts` passes.
+- [ ] 4.2 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` passes.
+- [ ] 4.3 `git grep -n "embed-subscribe\|WAITLIST_USERNAME" apps/web-platform` returns 0.
+
+## Phase 5 — Post-merge (operator)
+
+- [ ] 5.1 After deploy, POST a valid email to prod `/api/waitlist` → 200 `{ok:true}`;
+      subscriber appears under `pricing-waitlist` (pending double opt-in). `Ref` the issue;
+      `gh issue close` only after prod verification.


### PR DESCRIPTION
## Summary

The waitlist banner (`CtaBanner`, pricing page + every shared doc) was broken for every visitor: `POST /api/waitlist` returned a **Cloudflare gateway 502** and the banner showed "Something went wrong. Please try again."

**Root cause (verified by direct prod + Buttondown probing):** `subscribeToWaitlist` proxied Buttondown's **keyless public embed-subscribe endpoint**, which Buttondown moved **behind Cloudflare Turnstile**. A direct server-side POST now gets a `400` + an HTML "Verify Your Subscription" Turnstile challenge a same-origin proxy cannot solve — so every submission failed (the request died at the origin → Cloudflare-synthesized 502, not the app's own JSON 502).

**Fix:** rewrite `subscribeToWaitlist` to call Buttondown's **authenticated v1 REST API** (`POST api.buttondown.com/v1/subscribers`, `Authorization: Token`), which is not behind Turnstile.

## Changelog

### Web Platform
- Migrate `/api/waitlist` from the Turnstile-gated public embed endpoint to Buttondown's authenticated v1 subscribers API.
- Omit `type: "regular"` from the request body to preserve Buttondown's default **double opt-in** (the confirmation email is the GDPR Art. 6(1)(a) consent step the success copy promises).
- Add `AbortSignal.timeout(5s)` so a future upstream stall degrades to the app's graceful JSON 502 instead of a gateway hang.
- Read `BUTTONDOWN_API_KEY` **fail-closed at call time** — a missing key returns a JSON 502, never a worker crash.
- Tighten the duplicate-400 predicate to the v1 `email_already_exists` code (+ narrow phrase) so genuine validation 400s aren't misclassified as success and silently dropped.
- Wire `BUTTONDOWN_API_KEY` into `apps/web-platform/.env.example` (already present in Doppler `prd`).

## User-Brand Impact

**If this lands broken, the user experiences:** the waitlist banner on the pricing page and every shared doc keeps showing "Something went wrong" on submit — the single top-of-funnel conversion surface stays dead and any visitor who tries to join silently bounces.

**If this leaks, the user's data is exposed via:** the route forwards a visitor's email (PII) to Buttondown (US processor, SCCs Module 2). The only new exposure vector is `BUTTONDOWN_API_KEY` — it is never logged, never returned in a response body, and never reaches the client (status-only logging preserved).

- **Brand-survival threshold:** aggregate pattern

(Marketing waitlist relay; a single failed signup is a lost lead, not a brand-survival incident.)

## Test plan

- [x] `cd apps/web-platform && ./node_modules/.bin/vitest run test/api-waitlist-subscribe.test.ts` — 16/16 pass (success 201, already-subscribed JSON + plaintext, non-duplicate 400 → 502, bad key, network throw, timeout, missing-key fail-closed, no `type` field assertion)
- [x] Full web-platform vitest suite — 9136 pass / 0 fail
- [x] `./node_modules/.bin/tsc --noEmit` clean
- [ ] ⏳ Post-deploy: a valid email POST to prod `/api/waitlist` returns `200 {ok:true}` and the subscriber appears (status unconfirmed, pending double opt-in) in Buttondown under the `pricing-waitlist` tag.

Generated with [Claude Code](https://claude.com/claude-code)
