### PR TITLE
docs(legal): backfill PR number in #4051 counsel-review audit + close out the legal gate

### DIFF
--- a/knowledge-base/legal/audits/2026-05-counsel-review-4051.md
+++ b/knowledge-base/legal/audits/2026-05-counsel-review-4051.md
@@ -3,7 +3,7 @@ title: "Counsel review audit — #4051 (LIA + Privacy Policy + DPD)"
 type: counsel-review
 date: 2026-05-19
 issue: 4051
-pr: TBD
+pr: 4081
 status: SIGNED-OFF (operator-attested)
 signed_off_at: 2026-05-19
 signed_off_by: "Jean Deruelle (Jikigai SARL gérant)"


### PR DESCRIPTION
## Summary

Closes #4051.

All five acceptance criteria of #4051 are already satisfied in main — the three legal documents merged via PR #4081 on 2026-05-19:

1. ✅ LIA at `knowledge-base/legal/legitimate-interest-assessments/2026-05-19-linkedin-org-page-lia.md` with all three Art. 6(1)(f) prongs (Purpose / Necessity / Balancing)
2. ✅ Privacy Policy Section 4.10 + 5.12 (LinkedIn Ireland as Art. 13(1)(e) recipient) + Art. 17 carve-out (Section 8.1)
3. ✅ DPD mirrors: Section 2.3(p), §4.2 recipient rows, §6.4 transfers, §10.3 erasure carve-out
4. ✅ Counsel review: `knowledge-base/legal/audits/2026-05-counsel-review-4051.md` — SIGNED-OFF (operator-attested) 2026-05-19, all three artifact rows ☑
5. ✅ Linked from #4046 plan Phase 5.4 gate (plan item F1)

The issue never auto-closed because #4081 referenced it in the title rather than via `Closes #N` in the body.

## Change

One-line fix: the counsel-review audit file shipped inside PR #4081 itself, so its frontmatter was authored before the PR number existed (`pr: TBD`). Backfill to `pr: 4081` so the load-bearing evidence file resolves to its merging PR.

## Context

LinkedIn approved Community Management API access for app 229658411 on 2026-06-10 (Development Tier), making this legal gate the critical-path check for #4046 Phase 5.4+. With #4051 confirmed complete, the remaining blockers for org-page publishing are operational only (token rotation, re-publish backlog — tracked in #4046).

🤖 Generated with [Claude Code](https://claude.com/claude-code)