### PR TITLE
fix(ci): drop stale kb_tenant_mint -target blocking the sentry apply

### DIFF
--- a/.github/workflows/apply-sentry-infra.yml
+++ b/.github/workflows/apply-sentry-infra.yml
@@ -217,7 +217,13 @@ jobs:
             -target=sentry_issue_alert.byok_cap_exceeded \
             -target=sentry_issue_alert.chat_message_save_failure \
             -target=sentry_issue_alert.workspace_sync_health \
-            -target=sentry_issue_alert.kb_tenant_mint_silent_fallback \
+            # kb_tenant_mint_silent_fallback: -target REMOVED 2026-06-10. The
+            # resource left the .tf in #4929 (superseded by kb_db_error) but was
+            # never destroy-applied, so the orphan remains in STATE and the live
+            # Sentry rule is inert (its producer is dead code). Purge on the next
+            # sentry apply by re-adding the target + an `[ack-destroy]` line in
+            # that PR's merge commit (PR #5089 postmerge exposed the latent
+            # destroy and the guard correctly halted).
             -target=sentry_issue_alert.kb_db_error \
             -target=sentry_issue_alert.egress_blocked \
             -no-color -input=false -out=tfplan


### PR DESCRIPTION
## Summary

PR #5089's merge triggered `apply-sentry-infra.yml`, whose hardcoded `-target` list still referenced `sentry_issue_alert.kb_tenant_mint_silent_fallback` — removed from config in #4929 but never destroy-applied. The targeted plan therefore included a latent destroy and the destroy-guard halted the apply, leaving the new `cron-egress-resolve` monitor + `egress_blocked` alert (#5089) unapplied.

This drops the stale target (plan becomes 2 adds / 0 destroys) and documents the state-orphan purge path in-place (re-add target + `[ack-destroy]` on the next sentry apply). After merge, the apply is re-fired via `workflow_dispatch`.

Pre-existing gap (noted by PR #5089's review): the sentry workflow's target list has no parity guard against the .tf — the registry test covers cron monitors only.

## Changelog

- fix(ci): sentry infra apply unblocked — stale destroy-target removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)