### PR TITLE
fix(ci): sentry apply broken by mid-continuation comment (#5108 follow-up)

### DIFF
--- a/.github/workflows/apply-sentry-infra.yml
+++ b/.github/workflows/apply-sentry-infra.yml
@@ -183,6 +183,16 @@ jobs:
           # after the rc-capture window per
           # `2026-05-16-adr-amendment-required-when-reversing-and-destroy-guard-empty-string-bypass.md`.
           set -uo pipefail
+          # NOTE: kb_tenant_mint_silent_fallback is deliberately ABSENT from
+          # the -target list below. The resource left issue-alerts.tf in #4929
+          # (superseded by kb_db_error) but was never destroy-applied, so an
+          # orphan remains in STATE and the live Sentry rule is inert (its
+          # producer is dead code). Purge on the next sentry apply by re-adding
+          # the target + an `[ack-destroy]` line in that PR's merge commit
+          # (PR #5089 postmerge exposed the latent destroy; the guard halted).
+          # Comments must NEVER sit inside the backslash-continued command —
+          # a mid-continuation comment terminates the command and the next
+          # `-target=` line executes as a bare command (exit 127; PR #5108).
           terraform plan \
             -target=sentry_cron_monitor.scheduled_terraform_drift \
             -target=sentry_cron_monitor.scheduled_oauth_probe \
@@ -217,13 +227,6 @@ jobs:
             -target=sentry_issue_alert.byok_cap_exceeded \
             -target=sentry_issue_alert.chat_message_save_failure \
             -target=sentry_issue_alert.workspace_sync_health \
-            # kb_tenant_mint_silent_fallback: -target REMOVED 2026-06-10. The
-            # resource left the .tf in #4929 (superseded by kb_db_error) but was
-            # never destroy-applied, so the orphan remains in STATE and the live
-            # Sentry rule is inert (its producer is dead code). Purge on the next
-            # sentry apply by re-adding the target + an `[ack-destroy]` line in
-            # that PR's merge commit (PR #5089 postmerge exposed the latent
-            # destroy and the guard correctly halted).
             -target=sentry_issue_alert.kb_db_error \
             -target=sentry_issue_alert.egress_blocked \
             -no-color -input=false -out=tfplan


### PR DESCRIPTION
## Summary

PR #5108 removed the stale `kb_tenant_mint_silent_fallback` target but placed its documentation comment INSIDE the backslash-continued `terraform plan` command. A mid-continuation comment terminates the command, so `-target=sentry_issue_alert.kb_db_error` executed as a bare shell command (exit 127) and the apply failed on every fire — blocking the PR #5089 `cron-egress-resolve` monitor + `egress_blocked` alert from applying.

This restores a contiguous target list and re-homes the note (plus an explicit never-comment-inside-continuation warning) above the command. After merge, the apply re-fires via `workflow_dispatch`.

## Changelog

- fix(ci): sentry infra apply unblocked — comment moved out of the continued command

Generated with [Claude Code](https://claude.com/claude-code)