### PR TITLE
chore(infra): bump inngest-bootstrap image pin v1.1.11 -> v1.1.12

### DIFF
--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -558,20 +558,20 @@ runcmd:
   # bootstrap-script SHAPE version), NOT the inngest-cli version (the latter is
   # sourced from the image's Config.Env at run time). This pin MUST be bumped to
   # the latest released bootstrap image on every bootstrap-script change, or
-  # fresh-host reprovision installs a stale script. Bumped to v1.1.11 for the
+  # fresh-host reprovision installs a stale script. Bumped to v1.1.12 for the
   # #4652 --poll-interval/--sdk-url ExecStart (running hosts get it via the
   # deploy webhook path: push vinngest-vX.Y.Z tag → deploy inngest …:vX.Y.Z;
   # cloud-init installs only on fresh hosts).
   - |
     set -e
-    docker pull ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.11
+    docker pull ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.12
     EXTRACT_DIR=$(mktemp -d)
     cleanup() { docker rm -f soleur-inngest-bootstrap-extract >/dev/null 2>&1 || true; rm -rf "$EXTRACT_DIR"; }
     trap cleanup EXIT
-    docker create --name soleur-inngest-bootstrap-extract ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.11
+    docker create --name soleur-inngest-bootstrap-extract ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.12
     docker cp soleur-inngest-bootstrap-extract:/inngest-bootstrap.sh "$EXTRACT_DIR/inngest-bootstrap.sh"
     docker cp soleur-inngest-bootstrap-extract:/vector.toml /tmp/vector.toml 2>/dev/null || true
-    image_env=$(docker inspect ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.11 -f '{{range .Config.Env}}{{println .}}{{end}}')
+    image_env=$(docker inspect ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.12 -f '{{range .Config.Env}}{{println .}}{{end}}')
     chmod +x "$EXTRACT_DIR/inngest-bootstrap.sh"
     INNGEST_CLI_VERSION=$(printf '%s\n' "$image_env" | grep '^INNGEST_CLI_VERSION=' | head -1 | cut -d= -f2-)
     INNGEST_CLI_SHA256=$(printf '%s\n' "$image_env" | grep '^INNGEST_CLI_SHA256=' | head -1 | cut -d= -f2-)


### PR DESCRIPTION
## Summary

Lockstep cloud-init pin bump for tag `vinngest-v1.1.12` (built from PR #5105's merge commit — vector.toml host-metrics quota fix). The AC6 drift guard (`cloud-init-inngest-bootstrap.test.sh`) requires the pinned image tag to equal the semver-max published `vinngest-v*` tag; the tag + image now exist, so this bump keeps the guard green. All 4 occurrences flipped. Precedent: PR #4669.

## Changelog

- cloud-init inngest-bootstrap image pin v1.1.11 → v1.1.12 (fresh-host path picks up the quota-tuned vector.toml automatically).

## Test plan

- [x] `cloud-init-inngest-bootstrap.test.sh` 21/21 (incl. AC6 pin == latest tag, AC6b pin-consistency 3/3 refs)
- [x] zero residual `v1.1.11` references in cloud-init.yml

Generated with [Claude Code](https://claude.com/claude-code)