### PR TITLE
fix(community): escape LinkedIn Little Text reserved chars + sanitize markdown artifacts

### DIFF
--- a/plugins/soleur/skills/community/scripts/linkedin-community.sh
+++ b/plugins/soleur/skills/community/scripts/linkedin-community.sh
@@ -213,6 +213,47 @@ post_request() {
   fi
 }
 
+# --- LinkedIn "Little Text Format" handling ---
+#
+# The Posts API commentary field is "Little Text Format": the characters
+# \ | { } [ ] ( ) < > * ~ are reserved, and LinkedIn silently TRUNCATES the
+# post at the first unescaped occurrence (observed 2026-06-10: nine org posts
+# cut mid-sentence at the first "(", which also dropped the trailing article
+# links). '#' and '@' stay unescaped so hashtags and mentions keep their
+# linking behavior; '_' stays unescaped because escaping it corrupts URLs
+# (utm_source=...) and it does not trigger the truncation failure class.
+
+sanitize_commentary() {
+  # Markdown-source artifacts that must not reach LinkedIn verbatim: strip
+  # whole-line HTML comments (e.g. markdownlint directives), unwrap
+  # <https://...> autolinks (angle brackets are reserved characters), and
+  # drop trailing horizontal rules / blank lines.
+  sed -e '/^[[:space:]]*<!--.*-->[[:space:]]*$/d' \
+      -e 's/<\(https\{0,1\}:\/\/[^>]*\)>/\1/g' |
+    awk '{ lines[++n] = $0 }
+         END {
+           while (n > 0 && (lines[n] ~ /^[[:space:]]*$/ || lines[n] ~ /^[[:space:]]*-{3,}[[:space:]]*$/)) n--
+           for (i = 1; i <= n; i++) print lines[i]
+         }'
+}
+
+escape_little_text() {
+  local t="$1"
+  t="${t//\\/\\\\}"
+  t="${t//|/\\|}"
+  t="${t//\{/\\\{}"
+  t="${t//\}/\\\}}"
+  t="${t//\[/\\[}"
+  t="${t//\]/\\]}"
+  t="${t//(/\\(}"
+  t="${t//)/\\)}"
+  t="${t//</\\<}"
+  t="${t//>/\\>}"
+  t="${t//\*/\\*}"
+  t="${t//\~/\\~}"
+  printf '%s' "$t"
+}
+
 # --- Commands ---
 
 cmd_post_content() {
@@ -258,10 +299,18 @@ cmd_post_content() {
     exit 1
   fi
 
+  # Strip markdown-source artifacts before the length check (the limit
+  # applies to visible characters; Little Text escape backslashes added
+  # below do not count toward it).
+  text=$(printf '%s\n' "$text" | sanitize_commentary)
+
   if (( ${#text} > LINKEDIN_POST_MAX_LENGTH )); then
     echo "Error: Post text is ${#text} characters, exceeds LinkedIn's ${LINKEDIN_POST_MAX_LENGTH}-character limit." >&2
     exit 1
   fi
+
+  local escaped_text
+  escaped_text=$(escape_little_text "$text")
 
   # Build request body (--author overrides default LINKEDIN_PERSON_URN)
   local author="${author_override:-${LINKEDIN_PERSON_URN:-}}"
@@ -289,7 +338,7 @@ cmd_post_content() {
   local json_body
   json_body=$(jq -n \
     --arg author "$author" \
-    --arg text "$text" \
+    --arg text "$escaped_text" \
     '{
       author: $author,
       commentary: $text,


### PR DESCRIPTION
## Summary

Fixes three content-quality defects the operator spotted in the 2026-06-10 9-article burst to the Soleur Company Page:

1. **Mid-sentence truncation** (4 posts) — LinkedIn's Posts API `commentary` is *Little Text Format*: `\ | { } [ ] ( ) < > * ~` are reserved, and the API silently truncates at the first unescaped occurrence. Posts died at their first `(`, which also dropped the trailing soleur.ai article links.
2. **Leaked markdownlint directive** (1 post) — a `<!-- markdownlint-disable-next-line -->` HTML comment in the source had its angle brackets eaten, rendering `!-- markdownlint... --` in the post.
3. **Trailing `---`** (the rest) — the LinkedIn section is last in each distribution-content file, so the file's closing horizontal rule rode along.

## Fix

`cmd_post_content` in `linkedin-community.sh` now:
- **sanitize_commentary**: strips whole-line HTML comments, unwraps `<https://…>` autolinks (angle brackets are reserved; escaping them would render literal brackets around links), drops trailing horizontal rules/blank lines — before the 3000-char visible-length check.
- **escape_little_text**: backslash-escapes the reserved set. `#`/`@` stay unescaped (hashtag/mention linking); `_` stays unescaped (escaping corrupts `utm_source` URLs and underscores don't trigger the truncation class).

## Verification

- Offline byte-level checks on the worst three source sections: parens escaped (`\(7 do's, 7 don'ts\)`), links intact at tail, no markdownlint text, no trailing `---`.
- Operationally: all 9 flawed posts deleted (HTTP 204 each) and re-posted with the fixed script — 9/9 new share URNs returned.

## Changelog

- Fixed: LinkedIn posts no longer truncate at parentheses/brackets (Little Text escaping), and markdown artifacts (HTML comments, autolink brackets, trailing horizontal rules) are stripped before posting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)