### PR TITLE
docs(marketing): draft ship tweet for waitlist firewall hardening

### DIFF
--- a/knowledge-base/marketing/distribution-content/2026-06-11-waitlist-signups-survive-firewall-re-escalation.md
+++ b/knowledge-base/marketing/distribution-content/2026-06-11-waitlist-signups-survive-firewall-re-escalation.md
@@ -1,0 +1,18 @@
+---
+title: "Waitlist signups now survive vendor firewall re-escalation"
+type: feature-launch
+publish_date: ""
+channels: x
+status: draft
+pr_reference: "#5153"
+---
+
+<!-- To publish: set BOTH publish_date AND status: scheduled -->
+
+## X/Twitter Thread
+
+Our waitlist silently rejected every signup for 65 hours. The code was fine. The server was fine. The blocker: our email vendor's own anti-spam firewall was risk-scoring our datacenter IP — because we weren't telling it who the actual visitor was.
+
+2/ An AI agent diagnosed it with no SSH and no dashboard: read the error stream, replayed the exact API call with the real key from the secret store, and got the vendor's hidden error body in one curl. Recovery was a one-field API PATCH.
+
+3/ Just shipped the hardening: the signup route now forwards each visitor's real IP, so the vendor scores the human, not our server. Signups survive even if the firewall re-escalates on its own. Full build-in-public post-mortem coming this week.


### PR DESCRIPTION
## Summary
- Postmerge Phase 3.8 feature-tweet draft for the merged waitlist-hardening PR (eligibility: eligible; production health verified via /health build_sha match).
- Draft state: `status: draft`, `publish_date: ""` — the content-publisher cron skips it until the operator sets BOTH `publish_date` and `status: scheduled`.
- Copy follows the brand guide Ship Tweets rules: 3-tweet thread, ≤280 chars each (249/237/245), benefit-framed, no contributor names, no vendor FUD, the single statistic (65 hours) is verifiable from the committed post-mortem.

## Test plan
- [x] `bash scripts/lib/validate-tweet-draft.sh` — pass
- [x] `bash scripts/lint-distribution-content.sh` — pass

Generated with [Claude Code](https://claude.com/claude-code)