### PR TITLE
chore(brainstorm): auto-approve Phase 0.1 user-impact gate — always brand-critical, no prompt

### DIFF
--- a/knowledge-base/project/learnings/2026-06-11-auto-approve-a-workflow-gate-without-gutting-it.md
+++ b/knowledge-base/project/learnings/2026-06-11-auto-approve-a-workflow-gate-without-gutting-it.md
@@ -1,0 +1,58 @@
+# Learning: Auto-approving a workflow gate without gutting it
+
+## Problem
+
+An operator asked, mid-brainstorm, to stop being prompted by the brainstorm skill's
+Phase 0.1 user-impact framing question — they always answered "all of them," so the
+`AskUserQuestion` was pure friction that never changed the posture (#5175, captured
+from the #5085 brainstorm). The naive implementation — "just delete the prompt" — risks
+two regressions: (a) silently *weakening* the gate if the deletion also drops the
+flag-set, and (b) turning an always-on default into a rubber stamp that suppresses real
+per-feature reasoning.
+
+## Solution
+
+Encode the operator's standing answer as an **unconditional default**, not a deleted gate:
+
+1. **Set the flag unconditionally** (`USER_BRAND_CRITICAL=true`), no prompt, no keyword
+   parse. Direction matters: the change must make the gate fire *more* (fail-safe /
+   over-protect), never less. The old "no keyword → set false" branch is removed entirely.
+2. **Keep the telemetry emit.** The `emit_incident … applied` block stays — the rule still
+   records every application. Correct the now-false comment that described a "fired vs
+   asked" ratio (there is no "asked" path anymore); state the accepted constant-ratio
+   tradeoff explicitly rather than leaving a comment that lies.
+3. **Add an anti-rubber-stamp guard.** The synthesized `## User-Brand Impact` block's
+   *artifact* must be derived dynamically from the feature description (the real surface
+   being built), never a static literal. Vector and threshold may be generic/fixed, but a
+   concrete artifact keeps plan-time carry-forward and the review-time `user-impact-reviewer`
+   honest.
+4. **Ship it as its own PR.** The request surfaced inside an unrelated feature brainstorm
+   (#5085); the workflow change went on a separate branch/PR (#5177 / #5175), never bundled.
+
+## Key Insight
+
+**A default-flip on a conditional gate can orphan a downstream block that branched on the
+old condition.** Phase 0.1 setting the flag unconditionally made Phase 0.4's `Skip if
+USER_BRAND_CRITICAL=true` *always* fire, rendering its `**Otherwise:**` lane-inference block
+unreachable. The block can't simply be deleted (it's the escape hatch for a future
+per-feature override), so the fix is a one-line clarifying note marking it vestigial. When
+you make a flag unconditional, grep every downstream `if <flag>` / `Skip if <flag>` / `when
+<flag> is set` site and either rewire it or annotate the now-dead branch — a reviewer
+(pattern-recognition) reliably catches this, but it's cheaper to sweep at write time.
+
+A secondary tell: prose that still says "when X sets the flag" or "the framing question was
+answered" after X now sets it *always*. Sweep for conditional phrasing that implies a branch
+that no longer exists.
+
+## Session Errors
+
+- **`gh issue create` denied for missing `--milestone`** (filing #5175) — Recovery: re-ran
+  with `--milestone "Post-MVP / Later"`. Prevention: already hook-enforced by the
+  `guardrails:require-milestone` PreToolUse gate; the hook fired as designed. One-off
+  recovery, no workflow gap. (Also: never heredoc the issue body in the *same* Bash call as
+  a hook-gated `gh issue create` — a denial takes the heredoc down with it; here the body
+  was inline so no loss, but the Write-body-first pattern is the safe default.)
+
+## Tags
+category: workflow-patterns
+module: brainstorm

--- a/knowledge-base/project/plans/2026-06-11-chore-brainstorm-auto-approve-phase01-brand-critical-plan.md
+++ b/knowledge-base/project/plans/2026-06-11-chore-brainstorm-auto-approve-phase01-brand-critical-plan.md
@@ -1,0 +1,152 @@
+---
+title: "chore(brainstorm): auto-approve Phase 0.1 user-impact gate (always brand-critical, no prompt)"
+issue: 5175
+branch: feat-one-shot-5175-phase01-auto-brand-critical
+lane: cross-domain
+brand_survival_threshold: none
+requires_cpo_signoff: false
+---
+
+# chore(brainstorm): Auto-approve Phase 0.1 user-impact gate — always brand-critical, no prompt 🛠️
+
+## Overview
+
+The brainstorm skill's **Phase 0.1: User-Impact Framing** currently presents an `AskUserQuestion` prompt on every brainstorm, parses the operator's free-text answer for trigger keywords, and conditionally sets `USER_BRAND_CRITICAL=true`/`false`. Operator feedback from the **#5085 brainstorm** (captured in issue #5175 on 2026-06-11): they **always answer "all of them"**, so the prompt is pure friction and never changes the posture.
+
+This change makes Phase 0.1 **unconditional**:
+
+1. Skip the `AskUserQuestion` framing prompt entirely (delete Step 1's interactive call and the Step 2 keyword-parse branch).
+2. Set `USER_BRAND_CRITICAL=true` unconditionally.
+3. Synthesize a generic `## User-Brand Impact` block (artifact = the feature's named surface; vector = generic; threshold = `single-user incident`) so Phase 3.5 still persists it for plan-time carry-forward.
+4. **Keep** the telemetry emit (`emit_incident hr-weigh-every-decision-against-target-user-impact applied`) — the rule still records when it fires; the now-constant "fired vs asked" ratio is an accepted tradeoff.
+5. Lane auto-sets to `cross-domain` (this is **existing** behavior — Phase 0.4 already forces `LANE=cross-domain` when `USER_BRAND_CRITICAL=true`; no new logic).
+
+**This is a focused prose edit to ONE file** (`plugins/soleur/skills/brainstorm/SKILL.md`, Phase 0.1, plus the one-line cross-reference at Phase 0.4). There is no application source code or test to write — the "tests" are the skill's own self-consistency. The plan is deliberately proportionate to a prose edit.
+
+**Type:** chore (skill-instruction change). **Semver:** `patch` (behavior change to an existing skill, no new component, no breaking API). **Why patch not minor:** no new skill/agent/command is added; this is a default-flip on an existing skill.
+
+## Research Reconciliation — Spec vs. Codebase
+
+The issue/ARGUMENTS say to edit Phase 0.1 "**and any spec references under `knowledge-base/project/specs/feat-agents-md-*` or the brainstorm references dir**." Repo research found those references do **not** describe the Phase 0.1 mechanism and must **NOT** be edited.
+
+| ARGUMENTS claim | Codebase reality | Plan response |
+|---|---|---|
+| "spec references under `feat-agents-md-*` … so that [Phase 0.1 changes]" | `feat-agents-md-change-class-loader/spec.md:7` (`**Brand-survival threshold:** single-user incident (USER_BRAND_CRITICAL=true)`) and `:195` (AC: `user-impact-reviewer` sign-off) merely **annotate that feature's own** brand-survival posture. They do not prescribe or describe the Phase 0.1 gate. `feat-agents-md-shrink/spec.md` has **zero** Phase 0.1 / USER_BRAND_CRITICAL references. | **Do NOT edit either spec.** Editing them would corrupt an unrelated feature's recorded threshold. Documented as an explicit no-op (see Non-Goals). |
+| "or the brainstorm references dir" | `brainstorm-domain-config.md` `## User-Brand-Critical Tag Processing` + `## Lane Inference` already handle `USER_BRAND_CRITICAL=true` correctly (triad always fires, lane forced `cross-domain`, fail-closed-expand is a no-op). The triad/lane logic is **functionally inert** under the unconditional flag — it already works. | **Light prose touch only** (optional, see Phase 2): reword "When brainstorm Phase 0.1 *sets* `USER_BRAND_CRITICAL=true`" → reflect that it is now *always* set. No structural change. If the wording already reads correctly under always-true, leave it. |
+| Telemetry comment is fine as-is | `SKILL.md:103` says *"Do NOT emit telemetry when `USER_BRAND_CRITICAL=false` — the gate only records when it activates. The aggregate ratio of 'fired vs. asked' is itself a signal worth tracking."* Once the flag is always-true there is no `false` branch and no "asked" path — this comment becomes a **lie**. | **Update line 103's comment** so it stops describing a "fired vs asked" distinction that no longer exists. The emit itself is KEPT (per issue requirement 4). This is a real touch point the bare ARGUMENTS did not name. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** No direct end-user-facing artifact. This edits an internal authoring-workflow skill (`brainstorm`). The worst realistic failure is a malformed Phase 0.1 that (a) fails to set `USER_BRAND_CRITICAL=true`, silently **weakening** the user-impact gate (the opposite of the intended direction), or (b) skips persisting the `## User-Brand Impact` block, so plan Phase 2.6 carry-forward finds nothing. Both are caught by the skill's own self-consistency and by the existing downstream gates (deepen-plan Phase 4.6 halt, preflight Check 6).
+
+**If this leaks:** N/A — no data, credentials, or user workflow are processed by this skill change.
+
+**Brand-survival threshold:** `none`, reason: this is a meta-workflow prose edit to an internal skill that processes no user data and ships no user-facing surface; the change's *direction* is to strengthen (always-on) the user-impact gate, not weaken it. The diff touches no sensitive path (no schema, migration, auth flow, API route, `.sql`, infra, or Doppler surface — it is a single `.md` skill-instruction file under `plugins/soleur/skills/`), so preflight Check 6 will pass on the `threshold: none, reason: …` scope-out bullet above.
+
+> **Note on the irony:** this very change makes *future* brainstorms always brand-critical. This plan's own threshold is `none` because the plan itself is the meta-edit, not a user-facing feature — assessed on its own merits per the standard plan-time gate.
+
+## Background — what Phase 0.1 protects (do not weaken)
+
+The gate originates from **#2887**: dev and prd Doppler configs both pointed at the *same* Supabase project — a single-user data breach that shipped for months because no workflow step ever asked "what is the worst thing the target user experiences if this fails?" (origin: `knowledge-base/project/brainstorms/2026-04-24-target-user-impact-gate-brainstorm.md`). The original design (#2887 Decision #2) made the question **mandatory and interactive on every brainstorm** — "the whole point is to force the framing."
+
+This change does **not** weaken the gate — it makes it **unconditionally on** (fail-safe / over-protect direction, consistent with `knowledge-base/project/learnings/2026-06-03-self-heal-on-brand-path-only-acts-on-safe-symptom.md`). The operator's "all of them" answer already produced `USER_BRAND_CRITICAL=true` every time; this removes the friction of asking while preserving the always-protective posture. The one guard to keep in mind: the always-on default must not become a **rubber-stamp** that suppresses real per-feature user-impact reasoning. Mitigation: the synthesized `## User-Brand Impact` block must still name the **feature's actual surface** as the artifact (not a static literal), so plan-time carry-forward and the `user-impact-reviewer` at PR time still have a concrete artifact to reason against.
+
+## Files to Edit
+
+- **`plugins/soleur/skills/brainstorm/SKILL.md`** (lines 63–107, the `### Phase 0.1: User-Impact Framing` section) — the sole substantive edit. Rewrite per Phase 1 below.
+  - Also: the cross-reference clause at **line 113** (Phase 0.4 `**Skip if** USER_BRAND_CRITICAL=true … "The framing question was already answered; avoid double-prompting."`) — update the rationale so it no longer implies a "framing *question*" was asked (it is now always-set, not answered). Functionally the skip already fires; only the rationale wording needs a light touch.
+- **`plugins/soleur/skills/brainstorm/references/brainstorm-domain-config.md`** (lines 16–18, `## User-Brand-Critical Tag Processing` opening sentence) — OPTIONAL light prose touch: "When brainstorm Phase 0.1 *sets* `USER_BRAND_CRITICAL=true`" → reflect that Phase 0.1 now *always* sets it. **No structural/logic change** — the triad + cross-domain + fail-closed-expand behavior is already correct under always-true (verified: `## Lane Inference` "USER_BRAND_CRITICAL × lane composition" paragraph). Skip this edit if the existing wording reads correctly under unconditional setting; it is documentation polish, not a correctness fix.
+
+## Files to Create
+
+None.
+
+## Files NOT to Edit (explicit no-ops — guard against scope creep)
+
+- `knowledge-base/project/specs/feat-agents-md-change-class-loader/spec.md` — annotates a *different* feature's threshold (see Reconciliation table). Editing it corrupts that feature's record.
+- `knowledge-base/project/specs/feat-agents-md-shrink/spec.md` — zero Phase 0.1 references.
+- `plugins/soleur/skills/plan/SKILL.md` Phase 2.6, `deepen-plan/SKILL.md` Phase 4.6, `preflight/SKILL.md` Check 6, `review/SKILL.md` user-impact-reviewer block — all **consume** `USER_BRAND_CRITICAL` / `## User-Brand Impact` correctly and require no change. An always-true flag means these gates fire more often (intended), not differently.
+- `plugins/soleur/test/components.test.ts` — validates only the SKILL.md `description:` frontmatter field; this edit touches Phase 0.1 **body prose**, not the description. Not triggered. (`cq-skill-description-budget-headroom` likewise not triggered.)
+- **`feat-operator-weekly-digest` (#5085) branch** — MUST NOT be touched. This is its own PR per the issue.
+
+## Implementation Phases
+
+### Phase 1 — Rewrite Phase 0.1 in `brainstorm/SKILL.md` (the substantive edit)
+
+Replace the current Step 1 (ask) + Step 2 (keyword-parse branch) + the `if no keyword matches` branch with an unconditional set. Target shape (prose, not literal — author at edit time):
+
+- **Drop:** Step 1's `AskUserQuestion` framing call (Header "User impact", the question text, the multi-select=false note, the 6-preset options list). With it goes the only consumer of the 4-option-cap preset constraints — confirm no later Phase 0.1 prose references the menu after the edit (per `knowledge-base/project/learnings/2026-05-04-askuserquestion-4-option-cap.md`).
+- **Drop:** Step 2's keyword tables (user-data/auth lens + infra/data-store lens) and the `If any keyword matches / If no keyword matches` branch. There is no longer a branch — the flag is always set.
+- **Replace with** a single unconditional block:
+  1. `Set USER_BRAND_CRITICAL=true` for the rest of the brainstorm session (no prompt, no parse). One-line rationale: operator decision per #5175 — they always answered "all of them," so the prompt is pure friction. Cite #5175.
+  2. **Synthesize the `## User-Brand Impact` block** with: **artifact = the feature's named surface** (derive from the feature description / `$ARGUMENTS` — the concrete thing being built, e.g. "the X endpoint", "the Y skill"; NOT a static literal — this preserves a real artifact for downstream reasoning per the rubber-stamp guard in Background), **vector = generic** (a single generic exposure-vector sentence), **threshold = `single-user incident`**. This is what Phase 3.5 persists and plan Phase 2.6 carries forward.
+  3. **Announce** (keep the existing announce intent): "Tagged as **user-brand-critical** (auto, per #5175). CPO + CLO + CTO will be spawned in parallel at Phase 0.5 before other specialists. The plan derived from this brainstorm will inherit `Brand-survival threshold: single-user incident` unless overridden."
+- **KEEP Step 3 (telemetry emit) verbatim** — the `emit_incident hr-weigh-every-decision-against-target-user-impact applied` bash block stays unchanged (issue requirement 4). It now fires on every brainstorm.
+- **UPDATE the line-103 comment** (currently *"Do NOT emit telemetry when `USER_BRAND_CRITICAL=false` — the gate only records when it activates. The aggregate ratio of 'fired vs. asked' is itself a signal worth tracking."*). Since there is no `=false` branch anymore, rewrite to reflect reality: the gate now fires on every brainstorm by design (per #5175); the emit records *every* application of the rule. State the accepted tradeoff explicitly: the "fired vs asked" ratio is now constant — that signal was traded away for zero operator friction (issue "Tradeoff (accepted)" section). Do **not** delete the emit; only correct the comment that lies about a distinction that no longer exists.
+- **KEEP Step 4** (Phase 3.5 persist contract) — it already says the brainstorm capture MUST include the `## User-Brand Impact` section when `USER_BRAND_CRITICAL=true`; now always true, so always persisted. Light touch: reword any "reflecting the operator's answer" phrasing → "reflecting the synthesized framing (artifact = feature surface, vector = generic, threshold = single-user incident)" since there is no operator answer to reflect.
+- **KEEP the `**Why:**` #2887 paragraph** — the origin rationale is still accurate; optionally append one sentence noting #5175 made the gate unconditional to remove operator friction while preserving the always-protective posture.
+
+### Phase 2 — Update the Phase 0.4 cross-reference rationale (`brainstorm/SKILL.md` line 113) and optional domain-config polish
+
+- **Phase 0.4 line 113:** the `**Skip if** USER_BRAND_CRITICAL=true … set LANE=cross-domain` clause is functionally correct (the skip already fires). Update only the trailing rationale "The framing question was already answered; avoid double-prompting." → it was never "answered" now; reword to "Phase 0.1 unconditionally sets it; lane is fixed to cross-domain — no prompt." Confirms lane auto-set is **existing** behavior (issue requirement 5), not new logic.
+- **`brainstorm-domain-config.md` lines 16–18 (optional):** reword "When brainstorm Phase 0.1 *sets*…" → "Brainstorm Phase 0.1 always sets `USER_BRAND_CRITICAL=true` (per #5175); …". Verify the `## Lane Inference` "USER_BRAND_CRITICAL × lane composition" paragraph still reads correctly (it does — the cross-domain force + no-op fail-closed-expand are unchanged). No logic edit.
+
+### Phase 3 — Self-consistency verification (the "tests")
+
+There is no automated test for Phase 0.1 prose. Verify by reading:
+
+1. **Grep for dangling `false` references:** `grep -n "USER_BRAND_CRITICAL=false\|no keyword matches\|If any keyword" plugins/soleur/skills/brainstorm/SKILL.md` → MUST return zero hits after the edit (the conditional branch is gone).
+2. **Grep the telemetry emit survived:** `grep -n "emit_incident hr-weigh-every-decision-against-target-user-impact applied" plugins/soleur/skills/brainstorm/SKILL.md` → MUST return exactly 1 hit (Step 3 kept).
+3. **Grep the persist contract survived:** `grep -n "## User-Brand Impact" plugins/soleur/skills/brainstorm/SKILL.md` → Step 2 synthesis + Step 4 persist must both reference it.
+4. **Read Phase 0.1 + Phase 0.4 (lines ~63–127) top to bottom** and confirm: no "ask the question" prose remains; the unconditional set is unambiguous; the lane skip rationale matches reality; the synthesized artifact is described as "the feature's named surface" (dynamic), not a static literal.
+5. **Run the brainstorm-adjacent tests as a smoke check** (they don't assert Phase 0.1 but read the file): `bun test plugins/soleur/test/mandatory-wireframes-hardening.test.ts` and `bash plugins/soleur/test/lane-frontmatter.test.sh` → MUST still pass (no regression in Phase 3.55 / lane logic). Reference `package.json scripts.test` for the canonical runner if `bun` is not the configured runner.
+6. **`components.test.ts` sanity:** `bun test plugins/soleur/test/components.test.ts` → MUST pass (description field unchanged; this confirms no accidental frontmatter edit).
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- [ ] Phase 0.1 in `brainstorm/SKILL.md` no longer contains an `AskUserQuestion` framing prompt for user-impact (grep for the removed question text returns zero).
+- [ ] `grep -cE "USER_BRAND_CRITICAL=false" plugins/soleur/skills/brainstorm/SKILL.md` returns `0` (no false branch remains).
+- [ ] `grep -c "emit_incident hr-weigh-every-decision-against-target-user-impact applied" plugins/soleur/skills/brainstorm/SKILL.md` returns `1` (telemetry emit KEPT, issue req. 4).
+- [ ] Phase 0.1 synthesizes a `## User-Brand Impact` block with artifact = the feature's named surface (described as dynamic, derived from the feature description — NOT a static literal), vector = generic, threshold = `single-user incident`.
+- [ ] Phase 0.1 sets `USER_BRAND_CRITICAL=true` unconditionally (no keyword parse, no branch).
+- [ ] The line-103 telemetry comment is corrected so it no longer claims a "fired vs asked" distinction that no longer exists; the accepted constant-ratio tradeoff is stated.
+- [ ] Phase 0.4 line-113 skip rationale reworded so it no longer says "the framing question was already answered"; lane auto-set to `cross-domain` confirmed as existing behavior.
+- [ ] No edit was made to `knowledge-base/project/specs/feat-agents-md-change-class-loader/spec.md` or `feat-agents-md-shrink/spec.md` (verify via `git diff --name-only` — these paths absent).
+- [ ] No file under the `feat-operator-weekly-digest` (#5085) scope is touched (verify `git diff --name-only` contains only `brainstorm/SKILL.md`, optionally `brainstorm-domain-config.md`, and this plan/spec/tasks).
+- [ ] `bun test plugins/soleur/test/components.test.ts` passes (description-field budget untouched).
+- [ ] `bash plugins/soleur/test/lane-frontmatter.test.sh` and `bun test plugins/soleur/test/mandatory-wireframes-hardening.test.ts` pass (no Phase 0.4 / 3.55 regression).
+- [ ] PR body uses `Closes #5175` and includes a `## Changelog` section with `semver:patch`.
+
+### Post-merge (operator)
+- None. Pure prose edit; merge IS the delivery. No migration, no infra, no external-service config.
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected — internal authoring-workflow (skill-instruction) prose change. No UI surface (no path under `components/**`, `app/**/page.tsx`, or the UI-surface term list — the only files edited are `.md` skill-instruction files under `plugins/soleur/skills/`). Product/UX Gate mechanical override does not fire. No regulated-data surface (GDPR gate 2.7 skipped). No new infrastructure (2.8 skipped). No code-class file under `apps/*/server|src|infra` or `plugins/*/scripts/` (Observability gate 2.9 skipped — pure-docs/skill-prose).
+
+## Non-Goals / Out of Scope
+
+- **Editing the `feat-agents-md-*` specs.** They annotate a different feature's threshold; not the Phase 0.1 mechanism. (Documented no-op, not a deferral — there is nothing to defer.)
+- **Changing the triad / lane / Phase 0.5 logic.** Already correct under always-true; only optional prose polish in domain-config.
+- **Touching downstream consumers** (plan 2.6, deepen-plan 4.6, preflight Check 6, review user-impact-reviewer). They consume the flag/section correctly; firing more often is the intended effect.
+- **Re-introducing a low-stakes escape hatch.** The operator explicitly accepted the tradeoff (issue "Tradeoff (accepted)"): full CPO+CLO+CTO triad on every brainstorm including pure infra/CI, for zero prompts. This plan does NOT add a "skip triad for trivial brainstorms" path — that would re-introduce the friction the operator asked to remove. (Noted here so a reviewer doesn't read the always-on triad as an oversight; it is the explicit decision.)
+- **`feat-operator-weekly-digest` / #5085** — separate PR, not bundled.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder text, or omits the threshold will fail `deepen-plan` Phase 4.6. This plan's section is filled with a concrete `threshold: none, reason: …` scope-out (the diff touches no sensitive path), which satisfies preflight Check 6.
+- **Do not over-edit.** The single load-bearing edit is the Phase 0.1 rewrite in `brainstorm/SKILL.md`. Everything else (line-113 rationale, domain-config opener) is light prose alignment. Resist editing downstream consumer skills — they are correct.
+- **The synthesized artifact must be dynamic.** If the edit hard-codes a static literal as the `## User-Brand Impact` artifact (e.g. "the feature surface" verbatim), every brainstorm produces an identical, content-free block — exactly the rubber-stamp the gate's origin (#2887) warns against. The artifact MUST be derived from the feature description so plan Phase 2.6 carry-forward and the PR-time `user-impact-reviewer` have a real surface to reason against.
+- **Telemetry comment is a real touch point.** The bare ARGUMENTS named only the emit ("KEEP it") but not its surrounding comment. Leaving line 103 unchanged ships a comment that lies. Update it; keep the emit.
+
+## Alternative Approaches Considered
+
+| Approach | Why not chosen |
+|---|---|
+| Keep the prompt but pre-select "all of them" as default | Still a prompt = still friction. Operator asked for **zero** prompts. |
+| Remove the telemetry emit too (since the ratio is now constant) | Issue explicitly requires KEEPING the emit (req. 4) so the rule still records when it fires. Constant ratio is the accepted tradeoff, not a reason to drop the emit. |
+| Add a "low-stakes brainstorm → skip triad" escape hatch | Re-introduces friction and a branch; operator accepted the always-on triad cost. Out of scope (see Non-Goals). |
+| Edit the `feat-agents-md-*` specs as ARGUMENTS literally suggested | Those specs annotate a different feature's threshold; editing them is wrong. Research confirmed they do not describe the Phase 0.1 mechanism. |

--- a/knowledge-base/project/plans/2026-06-11-chore-brainstorm-auto-approve-phase01-brand-critical-plan.md
+++ b/knowledge-base/project/plans/2026-06-11-chore-brainstorm-auto-approve-phase01-brand-critical-plan.md
@@ -9,6 +9,29 @@ requires_cpo_signoff: false
 
 # chore(brainstorm): Auto-approve Phase 0.1 user-impact gate — always brand-critical, no prompt 🛠️
 
+## Enhancement Summary
+
+**Deepened on:** 2026-06-11
+**Sections enhanced:** verification (Phase 3) tightened; deepen halt gates 4.6–4.9 cleared.
+
+### Deepen-plan gate results
+- **4.6 User-Brand Impact halt:** PASS — section present, threshold `none` with a non-empty scope-out reason (no sensitive path touched).
+- **4.7 Observability gate:** SKIP (pure skill-prose; only `.md` files under `plugins/soleur/skills/`, no `apps/*/server|src|infra` or `plugins/*/scripts/` code-class file).
+- **4.8 PAT-shaped variable halt:** PASS — no PAT-shaped variables/literals.
+- **4.9 UI-wireframe halt:** SKIP — no UI-surface file in Files lists.
+
+### Key validations (verify-the-negative pass, all CONFIRMED)
+1. `brainstorm-domain-config.md` triad + lane logic is **already correct under always-true** — the `## User-Brand-Critical Tag Processing` triad fires unconditionally and `## Lane Inference` forces `cross-domain` with the fail-closed-expand clause an explicit no-op (lines 18, 44). No structural edit needed.
+2. `feat-agents-md-change-class-loader/spec.md:7,195` and `feat-agents-md-shrink/spec.md` only annotate their **own** feature's threshold — they do NOT describe the Phase 0.1 mechanism. Confirmed must-NOT-edit.
+3. `plugins/soleur/test/components.test.ts` asserts only the `description:` frontmatter field — Phase 0.1 body-prose edit does not trigger it.
+4. The line-103 telemetry comment ("fired vs. asked … signal") becomes inaccurate once the flag is always-true — confirmed real touch point (update the comment, KEEP the emit).
+
+### In-file precedent (precedent-diff pass)
+The plan's "skip the prompt → set the value unconditionally → echo the decision" pattern matches the **existing** Phase 0.4 pipeline/headless lane auto-set (`brainstorm/SKILL.md:119,127`). The change applies an established in-file pattern to a sibling gate; it is not novel.
+
+### Deepen adjustment applied
+- Phase 3 step 1 and the matching AC now also grep for answer-parse remnants (`operator's answer` / `Parse the answer` / `Ask the framing question`) so a forgotten Step 4 reword is caught (code-simplicity-reviewer P2).
+
 ## Overview
 
 The brainstorm skill's **Phase 0.1: User-Impact Framing** currently presents an `AskUserQuestion` prompt on every brainstorm, parses the operator's free-text answer for trigger keywords, and conditionally sets `USER_BRAND_CRITICAL=true`/`false`. Operator feedback from the **#5085 brainstorm** (captured in issue #5175 on 2026-06-11): they **always answer "all of them"**, so the prompt is pure friction and never changes the posture.
@@ -95,7 +118,7 @@ Replace the current Step 1 (ask) + Step 2 (keyword-parse branch) + the `if no ke
 
 There is no automated test for Phase 0.1 prose. Verify by reading:
 
-1. **Grep for dangling `false` references:** `grep -n "USER_BRAND_CRITICAL=false\|no keyword matches\|If any keyword" plugins/soleur/skills/brainstorm/SKILL.md` → MUST return zero hits after the edit (the conditional branch is gone).
+1. **Grep for dangling conditional/answer-parse remnants:** `grep -n "USER_BRAND_CRITICAL=false\|no keyword matches\|If any keyword\|operator's answer\|Parse the answer\|Ask the framing question" plugins/soleur/skills/brainstorm/SKILL.md` → MUST return zero hits after the edit (the conditional branch AND the answer-parse prose are gone; the Step 4 "reflecting the operator's answer" phrase must have been reworded per Phase 1).
 2. **Grep the telemetry emit survived:** `grep -n "emit_incident hr-weigh-every-decision-against-target-user-impact applied" plugins/soleur/skills/brainstorm/SKILL.md` → MUST return exactly 1 hit (Step 3 kept).
 3. **Grep the persist contract survived:** `grep -n "## User-Brand Impact" plugins/soleur/skills/brainstorm/SKILL.md` → Step 2 synthesis + Step 4 persist must both reference it.
 4. **Read Phase 0.1 + Phase 0.4 (lines ~63–127) top to bottom** and confirm: no "ask the question" prose remains; the unconditional set is unambiguous; the lane skip rationale matches reality; the synthesized artifact is described as "the feature's named surface" (dynamic), not a static literal.
@@ -110,6 +133,7 @@ There is no automated test for Phase 0.1 prose. Verify by reading:
 - [ ] `grep -c "emit_incident hr-weigh-every-decision-against-target-user-impact applied" plugins/soleur/skills/brainstorm/SKILL.md` returns `1` (telemetry emit KEPT, issue req. 4).
 - [ ] Phase 0.1 synthesizes a `## User-Brand Impact` block with artifact = the feature's named surface (described as dynamic, derived from the feature description — NOT a static literal), vector = generic, threshold = `single-user incident`.
 - [ ] Phase 0.1 sets `USER_BRAND_CRITICAL=true` unconditionally (no keyword parse, no branch).
+- [ ] No answer-parse remnants survive: `grep -n "operator's answer\|Parse the answer\|Ask the framing question" plugins/soleur/skills/brainstorm/SKILL.md` returns zero (Step 4 reworded).
 - [ ] The line-103 telemetry comment is corrected so it no longer claims a "fired vs asked" distinction that no longer exists; the accepted constant-ratio tradeoff is stated.
 - [ ] Phase 0.4 line-113 skip rationale reworded so it no longer says "the framing question was already answered"; lane auto-set to `cross-domain` confirmed as existing behavior.
 - [ ] No edit was made to `knowledge-base/project/specs/feat-agents-md-change-class-loader/spec.md` or `feat-agents-md-shrink/spec.md` (verify via `git diff --name-only` — these paths absent).

--- a/knowledge-base/project/specs/feat-one-shot-5175-phase01-auto-brand-critical/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-5175-phase01-auto-brand-critical/tasks.md
@@ -12,29 +12,29 @@ Derived from `knowledge-base/project/plans/2026-06-11-chore-brainstorm-auto-appr
 
 ## Phase 1 — Rewrite Phase 0.1 (substantive edit)
 
-- [ ] 1.1 In `plugins/soleur/skills/brainstorm/SKILL.md`, delete Step 1's `AskUserQuestion` framing call (Header/Question/multi-select note/6-preset options list) in the `### Phase 0.1: User-Impact Framing` section.
-- [ ] 1.2 Delete Step 2's keyword tables (user-data/auth lens + infra/data-store lens) and the `If any keyword matches / If no keyword matches` branch.
-- [ ] 1.3 Replace with an unconditional block: set `USER_BRAND_CRITICAL=true` (no prompt, no parse) with a one-line rationale citing #5175.
-- [ ] 1.4 Synthesize the `## User-Brand Impact` block: artifact = the feature's named surface (DYNAMIC, derived from the feature description — not a static literal), vector = generic, threshold = `single-user incident`.
-- [ ] 1.5 Keep the announce line (reword to note auto/per-#5175).
-- [ ] 1.6 KEEP Step 3 telemetry emit (`emit_incident hr-weigh-every-decision-against-target-user-impact applied`) verbatim.
-- [ ] 1.7 Update the line-103 comment so it no longer describes a "fired vs asked" distinction (now always fires); state the accepted constant-ratio tradeoff. Do NOT delete the emit.
-- [ ] 1.8 Keep Step 4 (Phase 3.5 persist contract); reword "reflecting the operator's answer" → "reflecting the synthesized framing".
-- [ ] 1.9 Keep the `**Why:**` #2887 paragraph; optionally append one sentence on the #5175 unconditional change.
+- [x] 1.1 In `plugins/soleur/skills/brainstorm/SKILL.md`, delete Step 1's `AskUserQuestion` framing call (Header/Question/multi-select note/6-preset options list) in the `### Phase 0.1: User-Impact Framing` section.
+- [x] 1.2 Delete Step 2's keyword tables (user-data/auth lens + infra/data-store lens) and the `If any keyword matches / If no keyword matches` branch.
+- [x] 1.3 Replace with an unconditional block: set `USER_BRAND_CRITICAL=true` (no prompt, no parse) with a one-line rationale citing #5175.
+- [x] 1.4 Synthesize the `## User-Brand Impact` block: artifact = the feature's named surface (DYNAMIC, derived from the feature description — not a static literal), vector = generic, threshold = `single-user incident`.
+- [x] 1.5 Keep the announce line (reword to note auto/per-#5175).
+- [x] 1.6 KEEP Step 3 telemetry emit (`emit_incident hr-weigh-every-decision-against-target-user-impact applied`) verbatim.
+- [x] 1.7 Update the line-103 comment so it no longer describes a "fired vs asked" distinction (now always fires); state the accepted constant-ratio tradeoff. Do NOT delete the emit.
+- [x] 1.8 Keep Step 4 (Phase 3.5 persist contract); reword "reflecting the operator's answer" → "reflecting the synthesized framing".
+- [x] 1.9 Keep the `**Why:**` #2887 paragraph; optionally append one sentence on the #5175 unconditional change.
 
 ## Phase 2 — Cross-reference alignment
 
-- [ ] 2.1 Update `brainstorm/SKILL.md` Phase 0.4 line-113 skip rationale ("The framing question was already answered" → "Phase 0.1 unconditionally sets it; lane fixed to cross-domain — no prompt"). Lane auto-set is EXISTING behavior.
-- [ ] 2.2 (Optional) Light prose touch to `brainstorm-domain-config.md` lines 16–18 opener ("When brainstorm Phase 0.1 sets…" → "always sets…"). No logic change. Skip if the existing wording reads correctly under always-true.
+- [x] 2.1 Update `brainstorm/SKILL.md` Phase 0.4 line-113 skip rationale ("The framing question was already answered" → "Phase 0.1 unconditionally sets it; lane fixed to cross-domain — no prompt"). Lane auto-set is EXISTING behavior.
+- [x] 2.2 (Optional) Light prose touch to `brainstorm-domain-config.md` lines 16–18 opener ("When brainstorm Phase 0.1 sets…" → "always sets…"). No logic change. Skip if the existing wording reads correctly under always-true.
 
 ## Phase 3 — Self-consistency verification
 
-- [ ] 3.1 `grep -n "USER_BRAND_CRITICAL=false\|no keyword matches\|If any keyword" plugins/soleur/skills/brainstorm/SKILL.md` → zero hits.
-- [ ] 3.2 `grep -c "emit_incident hr-weigh-every-decision-against-target-user-impact applied" plugins/soleur/skills/brainstorm/SKILL.md` → exactly 1.
-- [ ] 3.3 `grep -n "## User-Brand Impact" plugins/soleur/skills/brainstorm/SKILL.md` → present in Step 2 + Step 4.
-- [ ] 3.4 Read Phase 0.1 + 0.4 (lines ~63–127) end-to-end: no "ask the question" prose; unconditional set unambiguous; artifact dynamic.
-- [ ] 3.5 Run smoke tests: `bun test plugins/soleur/test/mandatory-wireframes-hardening.test.ts`, `bash plugins/soleur/test/lane-frontmatter.test.sh`, `bun test plugins/soleur/test/components.test.ts` → all pass. (Use `package.json scripts.test` runner if `bun` is not configured.)
-- [ ] 3.6 `git diff --name-only` confirms only `brainstorm/SKILL.md` (+ optionally `brainstorm-domain-config.md`) and this plan/spec/tasks are touched; NO `feat-agents-md-*` spec, NO `feat-operator-weekly-digest` file.
+- [x] 3.1 `grep -n "USER_BRAND_CRITICAL=false\|no keyword matches\|If any keyword" plugins/soleur/skills/brainstorm/SKILL.md` → zero hits.
+- [x] 3.2 `grep -c "emit_incident hr-weigh-every-decision-against-target-user-impact applied" plugins/soleur/skills/brainstorm/SKILL.md` → exactly 1.
+- [x] 3.3 `grep -n "## User-Brand Impact" plugins/soleur/skills/brainstorm/SKILL.md` → present in Step 2 + Step 4.
+- [x] 3.4 Read Phase 0.1 + 0.4 (lines ~63–127) end-to-end: no "ask the question" prose; unconditional set unambiguous; artifact dynamic.
+- [x] 3.5 Run smoke tests: `bun test plugins/soleur/test/mandatory-wireframes-hardening.test.ts`, `bash plugins/soleur/test/lane-frontmatter.test.sh`, `bun test plugins/soleur/test/components.test.ts` → all pass. (Use `package.json scripts.test` runner if `bun` is not configured.)
+- [x] 3.6 `git diff --name-only` confirms only `brainstorm/SKILL.md` (+ optionally `brainstorm-domain-config.md`) and this plan/spec/tasks are touched; NO `feat-agents-md-*` spec, NO `feat-operator-weekly-digest` file.
 
 ## Phase 4 — Ship
 

--- a/knowledge-base/project/specs/feat-one-shot-5175-phase01-auto-brand-critical/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-5175-phase01-auto-brand-critical/tasks.md
@@ -1,0 +1,41 @@
+---
+title: "Tasks: auto-approve brainstorm Phase 0.1 user-impact gate"
+issue: 5175
+branch: feat-one-shot-5175-phase01-auto-brand-critical
+lane: cross-domain
+plan: ../../plans/2026-06-11-chore-brainstorm-auto-approve-phase01-brand-critical-plan.md
+---
+
+# Tasks — chore(brainstorm): auto-approve Phase 0.1 user-impact gate
+
+Derived from `knowledge-base/project/plans/2026-06-11-chore-brainstorm-auto-approve-phase01-brand-critical-plan.md`. Pure prose edit to one skill file; no application code, no new tests.
+
+## Phase 1 — Rewrite Phase 0.1 (substantive edit)
+
+- [ ] 1.1 In `plugins/soleur/skills/brainstorm/SKILL.md`, delete Step 1's `AskUserQuestion` framing call (Header/Question/multi-select note/6-preset options list) in the `### Phase 0.1: User-Impact Framing` section.
+- [ ] 1.2 Delete Step 2's keyword tables (user-data/auth lens + infra/data-store lens) and the `If any keyword matches / If no keyword matches` branch.
+- [ ] 1.3 Replace with an unconditional block: set `USER_BRAND_CRITICAL=true` (no prompt, no parse) with a one-line rationale citing #5175.
+- [ ] 1.4 Synthesize the `## User-Brand Impact` block: artifact = the feature's named surface (DYNAMIC, derived from the feature description — not a static literal), vector = generic, threshold = `single-user incident`.
+- [ ] 1.5 Keep the announce line (reword to note auto/per-#5175).
+- [ ] 1.6 KEEP Step 3 telemetry emit (`emit_incident hr-weigh-every-decision-against-target-user-impact applied`) verbatim.
+- [ ] 1.7 Update the line-103 comment so it no longer describes a "fired vs asked" distinction (now always fires); state the accepted constant-ratio tradeoff. Do NOT delete the emit.
+- [ ] 1.8 Keep Step 4 (Phase 3.5 persist contract); reword "reflecting the operator's answer" → "reflecting the synthesized framing".
+- [ ] 1.9 Keep the `**Why:**` #2887 paragraph; optionally append one sentence on the #5175 unconditional change.
+
+## Phase 2 — Cross-reference alignment
+
+- [ ] 2.1 Update `brainstorm/SKILL.md` Phase 0.4 line-113 skip rationale ("The framing question was already answered" → "Phase 0.1 unconditionally sets it; lane fixed to cross-domain — no prompt"). Lane auto-set is EXISTING behavior.
+- [ ] 2.2 (Optional) Light prose touch to `brainstorm-domain-config.md` lines 16–18 opener ("When brainstorm Phase 0.1 sets…" → "always sets…"). No logic change. Skip if the existing wording reads correctly under always-true.
+
+## Phase 3 — Self-consistency verification
+
+- [ ] 3.1 `grep -n "USER_BRAND_CRITICAL=false\|no keyword matches\|If any keyword" plugins/soleur/skills/brainstorm/SKILL.md` → zero hits.
+- [ ] 3.2 `grep -c "emit_incident hr-weigh-every-decision-against-target-user-impact applied" plugins/soleur/skills/brainstorm/SKILL.md` → exactly 1.
+- [ ] 3.3 `grep -n "## User-Brand Impact" plugins/soleur/skills/brainstorm/SKILL.md` → present in Step 2 + Step 4.
+- [ ] 3.4 Read Phase 0.1 + 0.4 (lines ~63–127) end-to-end: no "ask the question" prose; unconditional set unambiguous; artifact dynamic.
+- [ ] 3.5 Run smoke tests: `bun test plugins/soleur/test/mandatory-wireframes-hardening.test.ts`, `bash plugins/soleur/test/lane-frontmatter.test.sh`, `bun test plugins/soleur/test/components.test.ts` → all pass. (Use `package.json scripts.test` runner if `bun` is not configured.)
+- [ ] 3.6 `git diff --name-only` confirms only `brainstorm/SKILL.md` (+ optionally `brainstorm-domain-config.md`) and this plan/spec/tasks are touched; NO `feat-agents-md-*` spec, NO `feat-operator-weekly-digest` file.
+
+## Phase 4 — Ship
+
+- [ ] 4.1 PR body: `Closes #5175`, `## Changelog` section, `semver:patch` label.

--- a/plugins/soleur/skills/brainstorm/SKILL.md
+++ b/plugins/soleur/skills/brainstorm/SKILL.md
@@ -94,7 +94,7 @@ Select an orchestration lane that describes the Phase 0.5 domain-leader breadth.
 
 **Skip if** `USER_BRAND_CRITICAL=true` from Phase 0.1 — set `LANE=cross-domain` and proceed to Phase 0.25 without prompting. Phase 0.1 now sets this unconditionally (per #5175), so the lane is always fixed to `cross-domain` here; there is no framing prompt to double up on.
 
-**Otherwise:**
+**Otherwise** (vestigial fallback — under #5175 Phase 0.1 sets `USER_BRAND_CRITICAL=true` unconditionally in every mode, so the skip above always fires and this block is currently unreachable; retained as the escape hatch for any future per-feature `USER_BRAND_CRITICAL` override):
 
 1. **Keyword scan** the feature description against the `## Lane Inference` table.
 

--- a/plugins/soleur/skills/brainstorm/SKILL.md
+++ b/plugins/soleur/skills/brainstorm/SKILL.md
@@ -62,37 +62,19 @@ If one-shot is selected, pass the original feature description (including any is
 
 ### Phase 0.1: User-Impact Framing
 
-Per AGENTS.md `hr-weigh-every-decision-against-target-user-impact`, every brainstorm MUST surface the framing question before any domain leader is spawned. The point is to force the user-impact lens onto every decision — even ones that look purely technical at first glance.
+Per AGENTS.md `hr-weigh-every-decision-against-target-user-impact`, every brainstorm is **unconditionally treated as user-brand-critical** before any domain leader is spawned. Per #5175 (operator decision from the #5085 brainstorm): the operator always answered the prior framing question with "all of them," so prompting added friction without ever changing the posture. The user-impact lens is now forced onto every decision by default — there is no question to ask.
 
-**Step 1 — Ask the framing question.** Use the **AskUserQuestion** tool to present:
+**Step 1 — Set the flag unconditionally (no prompt, no parse).** Set `USER_BRAND_CRITICAL=true` for the rest of the brainstorm session. Do NOT present an `AskUserQuestion`; do NOT scan the request for trigger keywords. The always-on posture is intentional — it over-protects (fail-safe direction) rather than risk under-protecting a feature whose impact looks purely technical at first glance.
 
-- **Header:** "User impact"
-- **Question:** "If this decision ships as designed, what is the worst outcome the target user experiences? If it silently fails, what do they see? If it leaks, what data of theirs is exposed? (Answer even if the request seems purely technical — the framing is the point.)"
-- **Multi-select:** false. Use a single free-text answer (the operator may type into the `other` escape if no preset option fits).
-- **Options:** the AskUserQuestion tool caps `options` at 4 (`maxItems: 4`), and "Other" is auto-appended by the runtime — do NOT include "Other" in your options list, it wastes a slot. Pick the 3 presets most likely to fit the feature being brainstormed from this menu and let auto-"Other" carry the long tail: "User data exposure", "Credential leak / auth bypass", "Billing surprise / payment error", "Data loss / corruption", "Trust breach / cross-tenant read", "No direct user impact". The free-text answer is what drives Step 2 — presets are scaffolding, not exhaustive.
+**Step 2 — Synthesize the `## User-Brand Impact` block.** Capture a `## User-Brand Impact` block so Phase 3.5 can persist it into the brainstorm document for plan-time carry-forward:
 
-**Step 2 — Parse the answer for trigger keywords.** Scan the case-insensitive concatenation of (a) the free-text answer and (b) the **endorsed option labels and descriptions** (when the operator picks a preset, multi-options shorthand like "All of them", or any other selection) for any of:
+- **Artifact:** the feature's named surface — derive it dynamically from the feature description / `$ARGUMENTS` (the concrete thing being built, e.g. "the X endpoint", "the Y skill"). This MUST be the real surface, never a static literal — a concrete artifact keeps plan-time carry-forward and the `user-impact-reviewer` honest, preventing the always-on default from degrading into a rubber stamp.
+- **Vector:** a single generic exposure-vector sentence (worst-case data exposure / silent failure / trust breach for the named artifact).
+- **Threshold:** `single-user incident`.
 
-User-data + auth lens:
+Then announce: "Tagged as **user-brand-critical** (auto, per #5175). CPO + CLO + CTO will be spawned in parallel at Phase 0.5 before other specialists. The plan derived from this brainstorm will inherit `Brand-survival threshold: single-user incident` unless overridden."
 
-`data loss` | `trust breach` | `credential exposure` | `credential leak` | `billing surprise` | `user data` | `credentials` | `payment` | `auth` | `session` | `pii` | `private` | `cross-tenant` | `RLS` | `secret` | `secrets` | `token` | `api key` | `api keys` | `webhook`
-
-Infrastructure / data-store lens (covers the #2887 vocabulary the user-data lens alone misses — every term here has a corresponding sensitive-path glob in preflight Check 6):
-
-`migration` | `doppler` | `infra` | `infrastructure` | `terraform` | `firewall` | `dev/prd` | `dev to prd` | `supabase` | `service token` | `service-token` | `rotation` | `rotate` | `byok`
-
-If any keyword matches:
-
-1. Set `USER_BRAND_CRITICAL=true` for the rest of the brainstorm session.
-2. Capture a `## User-Brand Impact` block from the answer (artifact named, vector named, threshold inferred — defaulting to `single-user incident` when keywords match) so Phase 3.5 can persist it into the brainstorm document for plan-time carry-forward.
-3. Announce: "Tagged as **user-brand-critical**. CPO + CLO + CTO will be spawned in parallel at Phase 0.5 before other specialists. The plan derived from this brainstorm will inherit `Brand-survival threshold: single-user incident` unless overridden."
-
-If no keyword matches:
-
-1. Set `USER_BRAND_CRITICAL=false`.
-2. Proceed silently to Phase 0.25.
-
-**Step 3 — Emit telemetry on match.** When `USER_BRAND_CRITICAL=true`, emit rule-application telemetry so the weekly aggregator records that the brainstorm enforcement layer fired (see AGENTS.md `hr-weigh-every-decision-against-target-user-impact`):
+**Step 3 — Emit telemetry.** Emit rule-application telemetry so the weekly aggregator records that the brainstorm enforcement layer fired (see AGENTS.md `hr-weigh-every-decision-against-target-user-impact`):
 
 ```bash
 source "$(git rev-parse --show-toplevel)/.claude/hooks/lib/incidents.sh" && \
@@ -100,17 +82,17 @@ source "$(git rev-parse --show-toplevel)/.claude/hooks/lib/incidents.sh" && \
   "Every plan/PR touching credentials, auth, data, paym"
 ```
 
-Do NOT emit telemetry when `USER_BRAND_CRITICAL=false` — the gate only records when it activates. The aggregate ratio of "fired vs. asked" is itself a signal worth tracking.
+The gate now fires on every brainstorm by design (per #5175), so this emit records every application of the rule. Accepted tradeoff: the "fired vs. asked" ratio is now constant (always fired) — that diagnostic signal was deliberately traded away for zero operator friction. Do NOT delete the emit; the per-application record is still consumed by the weekly aggregator.
 
-**Step 4 — Persist the framing into the brainstorm document.** When `USER_BRAND_CRITICAL=true`, the brainstorm capture in Phase 3.5 MUST include a `## User-Brand Impact` section reflecting the operator's answer (artifact, vector, threshold). The plan skill's Phase 2.6 carries this section forward into the plan, so re-authoring at plan time is unnecessary and risks drift.
+**Step 4 — Persist the framing into the brainstorm document.** The brainstorm capture in Phase 3.5 MUST include a `## User-Brand Impact` section reflecting the synthesized framing (artifact = the feature's named surface, vector = generic, threshold = single-user incident). The plan skill's Phase 2.6 carries this section forward into the plan, so re-authoring at plan time is unnecessary and risks drift.
 
-**Why:** Triggered by #2887 — the dev/prd Doppler-config collapse shipped because every prior gate weighed the decision on technical and convenience axes only, and no gate asked what one user's data breach would cost the brand. This is the earliest layer of enforcement for the workflow gate; it pairs with plan Phase 2.6 (template), deepen-plan Phase 4.6 (halt), preflight Check 6 (ship gate), and the `user-impact-reviewer` conditional agent to close the loop.
+**Why:** Triggered by #2887 — the dev/prd Doppler-config collapse shipped because every prior gate weighed the decision on technical and convenience axes only, and no gate asked what one user's data breach would cost the brand. This is the earliest layer of enforcement for the workflow gate; it pairs with plan Phase 2.6 (template), deepen-plan Phase 4.6 (halt), preflight Check 6 (ship gate), and the `user-impact-reviewer` conditional agent to close the loop. #5175 made the gate unconditional — the operator's standing "all of them" answer is encoded as an always-on default, removing the per-brainstorm prompt while preserving (and strengthening) the always-protective posture.
 
 ### Phase 0.4: Lane Auto-Detect and Selection
 
 Select an orchestration lane that describes the Phase 0.5 domain-leader breadth. Canonical vocabulary: `plugins/soleur/skills/brainstorm/references/brainstorm-domain-config.md` `## Lane Inference`. Written to spec.md frontmatter at Phase 3.6.
 
-**Skip if** `USER_BRAND_CRITICAL=true` from Phase 0.1 — set `LANE=cross-domain` and proceed to Phase 0.25 without prompting. The framing question was already answered; avoid double-prompting.
+**Skip if** `USER_BRAND_CRITICAL=true` from Phase 0.1 — set `LANE=cross-domain` and proceed to Phase 0.25 without prompting. Phase 0.1 now sets this unconditionally (per #5175), so the lane is always fixed to `cross-domain` here; there is no framing prompt to double up on.
 
 **Otherwise:**
 

--- a/plugins/soleur/skills/brainstorm/references/brainstorm-domain-config.md
+++ b/plugins/soleur/skills/brainstorm/references/brainstorm-domain-config.md
@@ -15,7 +15,7 @@ Read the user's message or feature description and assess relevance against each
 
 ## User-Brand-Critical Tag Processing
 
-When brainstorm Phase 0.1 sets `USER_BRAND_CRITICAL=true`, override the standard domain-sweep ordering: spawn **CPO + CLO + CTO** in parallel FIRST, before any other relevant domain leader determined by the Assessment Questions above. Other domain leaders still run in parallel where their assessment questions match, but CPO + CLO + CTO are mandatory for user-brand-critical sessions regardless of assessment-question matches.
+Brainstorm Phase 0.1 always sets `USER_BRAND_CRITICAL=true` (unconditionally, per #5175). Under that flag, override the standard domain-sweep ordering: spawn **CPO + CLO + CTO** in parallel FIRST, before any other relevant domain leader determined by the Assessment Questions above. Other domain leaders still run in parallel where their assessment questions match, but CPO + CLO + CTO are mandatory for user-brand-critical sessions regardless of assessment-question matches.
 
 Rationale:
 


### PR DESCRIPTION
## Summary
- Makes the brainstorm skill's **Phase 0.1 user-impact gate unconditional**: `USER_BRAND_CRITICAL=true` is now always set, with no `AskUserQuestion` prompt and no keyword-parse branch.
- The `## User-Brand Impact` block is still synthesized — its **artifact is derived dynamically** from the feature description (anti-rubber-stamp guard), with a generic vector and `single-user incident` threshold.
- **Telemetry emit kept** (`hr-weigh-…-applied`); the line-103 comment that described a now-impossible "fired vs asked" ratio is corrected to state the accepted constant-ratio tradeoff.
- Phase 0.4 lane cross-ref + the domain-config opener reworded for the always-set flag; a review fix clarifies that Phase 0.4's `Otherwise` lane-inference block is now a vestigial override escape hatch.

Operator decision from the #5085 brainstorm: they always answered the framing question "all of them," so the prompt was pure friction. The change **strengthens** (always-on) the gate — it cannot weaken it.

Closes #5175

## Changelog
- brainstorm: Phase 0.1 user-impact framing is now unconditional (always user-brand-critical, no prompt). Removes the per-brainstorm `AskUserQuestion` while preserving the always-protective posture, the telemetry emit, and a dynamic-artifact guard against rubber-stamping.

## Test plan
- [x] `lane-frontmatter.test.sh` (19/0), `components.test.ts` (1162/0), `mandatory-wireframes-hardening.test.ts` (13/0) — all green post-edit
- [x] Self-consistency greps: zero false-branch/keyword remnants; exactly 1 telemetry emit; `## User-Brand Impact` present in Steps 2 & 4
- [x] Multi-agent review (git-history / pattern / code-quality): 1 P2 fixed inline, 0 P1
- [x] Preflight: PASS (no sensitive paths; markdown-only diff)

Generated with [Claude Code](https://claude.com/claude-code)