### PR TITLE
fix(operator-digest): List API not --search for cross-repo reads (#5085)

### DIFF
--- a/knowledge-base/project/learnings/2026-06-12-gh-search-api-empty-cross-repo-under-in-action-app-token.md
+++ b/knowledge-base/project/learnings/2026-06-12-gh-search-api-empty-cross-repo-under-in-action-app-token.md
@@ -1,0 +1,77 @@
+# Learning: `gh ... --search` returns empty cross-repo under the in-action App token; use the List API
+
+## Problem
+
+The operator-digest's first live run (#5085) posted a digest whose **"What your
+company built"** section read *"Nothing shipped this week"* — despite ~100 PRs
+merged in the window (a Phase-4 dry-run on the same window returned 100). The
+other three sections (money via `git log`, incidents via `ls`, action-needed via
+`gh issue list --label`) were all accurate. The run concluded `success`; the scrub
+post-step ran clean. So the pipeline mechanically worked, but the **primary section
+was silently wrong** — exactly the comprehension-failure the feature exists to prevent.
+
+## Root cause
+
+The merged-PR read used the **Search API**:
+
+```bash
+gh pr list -R jikig-ai/soleur --state merged --search "merged:>=$SINCE" --limit 100
+```
+
+`gh pr list --search` (and `gh issue list --search`) routes to GitHub's **Search
+API** (`/search/issues`), which is a distinct endpoint from the **List API**
+(`/repos/{owner}/{repo}/pulls` | `/issues`). Under `claude-code-action`'s
+**in-action App-installation token** (the token the agent's Bash bridge uses), a
+**cross-repo Search-API query returns empty** — the #3403 cross-repo-read class,
+but manifesting specifically on the Search API. The List API works cross-repo under
+the same token (that is why `gh issue list --label action-required` returned all 7
+items correctly).
+
+Locally, both forms return 100 PRs — because a developer's personal token has full
+Search-API access. The divergence only appears under the in-action token, so it
+cannot be caught by a local dry-run; only the live run surfaced it.
+
+A second `--search` lurked in the prior-week continuity query
+(`gh issue list ... --search "Digest in:title"`). Even though it targets the action's
+*own* repo, the same Search-API behaviour would have broken the liveness loop —
+every week falsely reading "this is the first digest" and never emitting the
+"Last week: #N" back-reference.
+
+## Solution
+
+Switch both reads to the **List API** + client-side filtering:
+
+```bash
+# merged PRs — filter mergedAt >= $SINCE in synthesis
+gh pr list -R jikig-ai/soleur --state merged --limit 100 --json title,labels,mergedAt
+# prior digest — take the highest-numbered issue whose title starts with "Digest:"
+gh issue list -R jikig-ai/operator-digest --state all --json number,title --limit 20
+```
+
+Added a contract-test regression guard: any `gh pr/issue list` command that
+reintroduces `--search` fails the test (comment lines documenting "NOT --search"
+are exempt).
+
+## Key insight
+
+`--search` ≠ `--list` at the API layer. The GitHub **Search API** behaves
+differently under a scoped/App-installation token than the **List/REST API** —
+cross-repo Search queries can return empty while the equivalent List query
+succeeds. For any read that must work inside `claude-code-action` (or any
+App-installation-token context), **prefer the List API + client-side filter over
+`--search`**. A local dry-run with a personal token cannot detect this — the
+in-action token is the only faithful test, so a live smoke run is mandatory before
+trusting a cross-repo `--search` read.
+
+## Session Errors
+
+- **First live digest's primary section was a false "Nothing shipped".**
+  Recovery: diagnosed the Search-vs-List API divergence, switched both reads to the
+  List API + client-side filter, added a regression guard.
+  Prevention: the contract-test guard now rejects `--search` in `gh pr/issue list`
+  commands; this learning documents the API-layer distinction. A live smoke run
+  (not just a local dry-run) is required to catch in-action-token-only behaviour.
+
+## Tags
+category: integration-issues
+module: plugins/soleur/skills/operator-digest

--- a/plugins/soleur/skills/operator-digest/SKILL.md
+++ b/plugins/soleur/skills/operator-digest/SKILL.md
@@ -74,7 +74,7 @@ Source: merged pull requests in the window.
 # EMPTY for a cross-repo query under the in-action App-installation token (#3403 class) — it
 # would silently render "Nothing shipped" every week. The List API works cross-repo (same path
 # as the action-required read below). Filter by mergedAt >= $SINCE in your synthesis.
-gh pr list -R jikig-ai/soleur --state merged --limit 100 \
+gh pr list -R jikig-ai/soleur --state merged --limit 300 \
   --json title,labels,mergedAt
 ```
 

--- a/plugins/soleur/skills/operator-digest/SKILL.md
+++ b/plugins/soleur/skills/operator-digest/SKILL.md
@@ -70,12 +70,17 @@ Only emit the "Nothing …" fallback when the command **succeeded** and genuinel
 Source: merged pull requests in the window.
 
 ```bash
-gh pr list -R jikig-ai/soleur --state merged --search "merged:>=$SINCE" --limit 100 \
-  --json title,labels,body
+# Use the List API (NOT --search): --search routes to GitHub's Search API, which returns
+# EMPTY for a cross-repo query under the in-action App-installation token (#3403 class) — it
+# would silently render "Nothing shipped" every week. The List API works cross-repo (same path
+# as the action-required read below). Filter by mergedAt >= $SINCE in your synthesis.
+gh pr list -R jikig-ai/soleur --state merged --limit 100 \
+  --json title,labels,mergedAt
 ```
 
-Rewrite each meaningful change into its **business consequence** in plain language. Group related
-work. Drop pure chores/dependency bumps unless they matter to the owner. No PR numbers, no paths.
+Keep only PRs whose `mergedAt` is on or after `$SINCE`. Rewrite each meaningful change into its
+**business consequence** in plain language. Group related work. Drop pure chores/dependency bumps
+unless they matter to the owner. No PR numbers, no paths.
 
 ### 2. Money & vendors
 
@@ -131,12 +136,16 @@ is a failure.
 Find the most recent prior digest issue and reference it so a skipped week is visible:
 
 ```bash
-gh issue list -R jikig-ai/operator-digest --state all --search "Digest in:title" \
-  --json number,title --limit 1
+# List API, NOT --search (same Search-API-empty-under-App-token reason as section 1): list this
+# repo's recent issues and pick the most recent whose title starts with "Digest:". A false-empty
+# from --search would break the liveness loop — every week would falsely read "first digest".
+gh issue list -R jikig-ai/operator-digest --state all \
+  --json number,title --limit 20
 ```
 
-Add a final line to the digest: **"Last week: #N"** (the prior week's issue number). If no prior
-digest exists, write "Last week: (this is the first digest)." A missing prior-week back-reference is
+From that list, take the highest-numbered issue whose title begins with `Digest:` (ignore the
+withheld-notice issues) and add a final line to the digest: **"Last week: #N"**. If no prior digest
+issue exists, write "Last week: (this is the first digest)." A missing prior-week back-reference is
 the operator-visible signal that a week was skipped.
 
 ## Output

--- a/plugins/soleur/test/operator-digest-skill.test.sh
+++ b/plugins/soleur/test/operator-digest-skill.test.sh
@@ -93,5 +93,15 @@ assert "references the prior week's issue"       'prior week|last week'
 # --- Negative: the agent must not be told to create issues itself ---
 refute "agent is not instructed to 'gh issue create'" 'gh issue create'
 
+# --- Regression guard: data reads must use the List API, never --search. GitHub's Search API
+# returns EMPTY for a cross-repo query under the in-action App-installation token (#3403 class),
+# which would silently render "Nothing shipped" / "first digest" every week. Comment lines that
+# document "NOT --search" are allowed; an actual `gh pr/issue list ... --search` command is not. ---
+if grep -E 'gh (pr|issue) list' "$SKILL" | grep -vE '^[[:space:]]*#' | grep -q -- '--search'; then
+  fail=$((fail+1)); echo "FAIL: a 'gh pr/issue list' command uses --search (breaks cross-repo under the in-action token)" >&2
+else
+  pass=$((pass+1))
+fi
+
 echo "=== operator-digest-skill: ${pass} passed, ${fail} failed ===" >&2
 [[ "$fail" == 0 ]]


### PR DESCRIPTION
## Summary

Fix-forward for the just-shipped operator-digest (#5085). The **first live digest run** rendered **"Nothing shipped this week"** despite ~129 PRs merged in the window — the primary section was silently wrong, exactly the comprehension-failure the feature exists to prevent.

**Root cause:** `gh pr list --search` (and `gh issue list --search`) route to GitHub's **Search API**, which returns **empty for a cross-repo query under `claude-code-action`'s in-action App-installation token** (the #3403 cross-repo-read class, on the Search API). The **List API** works cross-repo under the same token — which is why the money (`git log`), incident (`ls`), and action-needed (`gh issue list --label`) sections were all accurate. Only the two `--search` reads were affected.

A second `--search` lurked in the prior-week continuity query, which would have broken the liveness loop (every week falsely reading "this is the first digest", never emitting "Last week: #N").

## Fix

- Both reads switch to the **List API + client-side filter**: merged-PRs by `mergedAt >= $SINCE`, prior-digest by highest-numbered `Digest:`-titled issue.
- Merged-PR fetch cap raised `100 → 300` so the 7-day window filter (not the fetch cap) bounds the set — the live window already held 129 merged PRs, so the old 100 cap was a live undercount.
- Contract-test **regression guard**: any `gh pr/issue list` command reintroducing `--search` fails the test (comment lines documenting "NOT --search" exempt; mutation-verified RED).

Ref #5085

## Changelog

### Plugin
- **fix(operator-digest):** cross-repo reads use the GitHub List API instead of `--search`, so the weekly digest's "what your company built" section is accurate under the in-action App token (was always "Nothing shipped"). Prior-week continuity read likewise fixed.

## Test plan

- [x] contract test 18/18 (incl. new `--search` regression guard; mutation → RED)
- [x] List API verified to return all 129 in-window merged PRs locally (`--limit 300` + `mergedAt` filter)
- [x] focused security review: no containment regression (allowlist/L2/no-post/scrub all outside the diff; dropping PR `body` from the read is a net leak-surface reduction)
- [x] lint-fixture-content clean on the learning doc

Generated with [Claude Code](https://claude.com/claude-code)
