### PR TITLE
fix(hooks): isolate guardrails.test from branch-dependent block-commit-on-main (#5192 follow-up)

### DIFF
--- a/.claude/hooks/guardrails.test.sh
+++ b/.claude/hooks/guardrails.test.sh
@@ -24,10 +24,20 @@ mk_payload() {
 }
 
 # Returns the permissionDecision or "<none>" when the hook emits no JSON (allow).
+# Runs the hook from the non-git $tmp CWD (not the test process CWD). This
+# isolates the require-milestone / block-stash gates under test from the
+# ORTHOGONAL, branch-dependent block-commit-on-main gate: a `git commit`-based
+# fixture (AC1/AC3/AC4) resolves its branch from the hook's CWD, so on the
+# `main` branch (post-merge CI) block-commit-on-main denies the commit and masks
+# the gate the fixture is actually exercising. A non-git CWD makes branch
+# resolution empty → block-commit-on-main no-ops → the fixture is branch- and
+# environment-independent (passes identically on a feature branch and on main).
+# See #5192 — these fixtures passed on a feature-branch worktree but failed on
+# main-CI until this isolation landed.
 decision_of() {
   local cmd="$1" tmp; tmp="$(mktemp -d)"
   local out
-  out="$(mk_payload "$cmd" | INCIDENTS_REPO_ROOT="$tmp" bash "$HOOK" 2>/dev/null)"
+  out="$(cd "$tmp" && mk_payload "$cmd" | INCIDENTS_REPO_ROOT="$tmp" bash "$HOOK" 2>/dev/null)"
   rm -rf "$tmp"
   # An allow is empty hook output (no JSON emitted); normalize to "<none>".
   if [[ -z "${out//[[:space:]]/}" ]]; then echo "<none>"; return; fi


### PR DESCRIPTION
## Summary

Follow-up forward-fix: PR #5193 (#5192) merged green on its feature branch but turned **main red** — the `test-scripts` shard reported 103/104.

**Root cause:** `guardrails.test.sh`'s new commit-body FP fixtures (AC1/AC3/AC4) use real `git commit` commands as the hook input. The orthogonal `block-commit-on-main` gate resolves the branch from the hook's process CWD; on a feature-branch worktree it never fires, but post-merge CI runs on `main`, so it denies the commit and masks the `require-milestone`/`block-stash` behavior the fixture is testing → the `<none>` (allow) assertions fail.

**Fix:** `decision_of` now runs the hook from the non-git `$tmp` CWD, so branch resolution is empty → `block-commit-on-main` no-ops → the gate-under-test is isolated and the fixtures are branch/environment-independent.

Verified 16/16 on both a feature branch and a simulated committed-`main` CWD; full `.claude/hooks/*.test.sh` suite green from a simulated-main CWD (0 fails).

Ref #5192

## Test plan
- [x] Reproduced the main-CWD failure (AC1 → deny)
- [x] guardrails.test.sh 16/16 on feature branch AND simulated main CWD
- [x] All 27 hook suites green from simulated-main CWD

Generated with [Claude Code](https://claude.com/claude-code)