### PR TITLE
fix(c4): keep saved .c4 source on a stale-clone reload (optimistic apply)

### DIFF
--- a/apps/web-platform/components/kb/c4-shared.tsx
+++ b/apps/web-platform/components/kb/c4-shared.tsx
@@ -382,6 +382,10 @@ export function C4CodePanel({
   // the just-saved content as the editor value until the reloaded source catches
   // up to it. Diagram staleness (the dump half) is surfaced honestly by the
   // existing Layer-1 banner (#4963) — this only fixes the source revert.
+  // The marker self-clears once `incoming === optimistic` (clone caught up). For
+  // a PERMANENTLY-diverged clone (the H1 liveness gap, tracked in #5221) it
+  // persists for the session, masking external edits to that file until remount —
+  // an accepted trade vs. the silent revert; the next local save re-pins it.
   const savedContentRef = useRef<Record<string, string>>({});
   // Per-editor font zoom (0 = default 12px), clamped to [10px, 24px]. Drives a
   // CodeMirror theme extension so content + gutter scale together — scoped to
@@ -426,11 +430,13 @@ export function C4CodePanel({
 
   // Compare against the optimistically-saved content (if any) so a just-saved
   // file is not shown as "dirty" while the clone catches up; falls back to the
-  // server source for files with no pending save.
-  const baseline =
-    (activeFile ? savedContentRef.current[activeFile] : undefined) ??
-    (activeFile ? data.sources[activeFile] ?? "" : "");
-  const dirty = activeFile ? draft !== baseline : false;
+  // server source for files with no pending save. `dirty` already guards on
+  // activeFile, so the baseline lookup needs no second guard (a "" key is a
+  // harmless miss).
+  const dirty = activeFile
+    ? draft !==
+      (savedContentRef.current[activeFile] ?? data.sources[activeFile] ?? "")
+    : false;
 
   const save = useCallback(async () => {
     setSaving(true);

--- a/apps/web-platform/components/kb/c4-shared.tsx
+++ b/apps/web-platform/components/kb/c4-shared.tsx
@@ -372,6 +372,17 @@ export function C4CodePanel({
   const [draft, setDraft] = useState("");
   const [saving, setSaving] = useState(false);
   const [saveMsg, setSaveMsg] = useState<string | null>(null);
+  // Optimistic apply (F-A1): content the user has SUCCESSFULLY saved this
+  // session, keyed by file. On a 200 PUT the GitHub commit is the source of
+  // truth, but GET /project reads the on-disk workspace clone, which can lag —
+  // a diverged/un-fast-forwardable clone (self-heal aborts to preserve un-pushed
+  // session work) or Contents-API→fetch replica propagation lag returns the
+  // PRE-edit text. Without this, the `[data, activeFile]` re-seed below clobbers
+  // the editor back to the stale source and the save silently reverts. We keep
+  // the just-saved content as the editor value until the reloaded source catches
+  // up to it. Diagram staleness (the dump half) is surfaced honestly by the
+  // existing Layer-1 banner (#4963) — this only fixes the source revert.
+  const savedContentRef = useRef<Record<string, string>>({});
   // Per-editor font zoom (0 = default 12px), clamped to [10px, 24px]. Drives a
   // CodeMirror theme extension so content + gutter scale together — scoped to
   // this editor, independent of browser page zoom.
@@ -394,14 +405,32 @@ export function C4CodePanel({
     );
   }, [files]);
   useEffect(() => {
-    if (activeFile) setDraft(data.sources[activeFile] ?? "");
+    if (!activeFile) return;
+    const incoming = data.sources[activeFile] ?? "";
+    const optimistic = savedContentRef.current[activeFile];
+    if (optimistic !== undefined && incoming !== optimistic) {
+      // The reloaded clone has not caught up to our just-saved content yet —
+      // keep showing the saved text instead of reverting to the stale source.
+      setDraft(optimistic);
+      return;
+    }
+    // Clone caught up (incoming === optimistic) or no pending save — clear the
+    // marker so future external edits to this file apply normally, then sync.
+    if (optimistic !== undefined) delete savedContentRef.current[activeFile];
+    setDraft(incoming);
   }, [data, activeFile]);
 
   const isDark =
     typeof document !== "undefined" &&
     document.documentElement.getAttribute("data-theme") !== "light";
 
-  const dirty = activeFile ? draft !== (data.sources[activeFile] ?? "") : false;
+  // Compare against the optimistically-saved content (if any) so a just-saved
+  // file is not shown as "dirty" while the clone catches up; falls back to the
+  // server source for files with no pending save.
+  const baseline =
+    (activeFile ? savedContentRef.current[activeFile] : undefined) ??
+    (activeFile ? data.sources[activeFile] ?? "" : "");
+  const dirty = activeFile ? draft !== baseline : false;
 
   const save = useCallback(async () => {
     setSaving(true);
@@ -414,6 +443,10 @@ export function C4CodePanel({
       });
       const j = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(j.error || `Save failed (${res.status})`);
+      // F-A1: the commit landed on origin (200). Pin the saved content as the
+      // optimistic editor value BEFORE onSaved triggers the parent reload(), so
+      // a stale-clone GET /project cannot revert the editor to the pre-edit text.
+      savedContentRef.current[activeFile] = draft;
       // Layer 2 (#4964): the server re-renders the diagram after a .c4 save.
       // `rerendered` reports whether that succeeded. On success the reloaded
       // dump is the fresh geometry; on failure the diagram stays stale and the

--- a/apps/web-platform/test/c4-code-panel.test.tsx
+++ b/apps/web-platform/test/c4-code-panel.test.tsx
@@ -1,11 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import {
-  render,
-  screen,
-  fireEvent,
-  cleanup,
-  waitFor,
-} from "@testing-library/react";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import type { ReactCodeMirrorProps } from "@uiw/react-codemirror";
 
 // Capture the props the editor is mounted with so we can assert wiring
@@ -73,6 +67,9 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   document.documentElement.removeAttribute("data-theme");
+  // Exception-safe restore of any globalThis.fetch spy — a mid-test assertion
+  // throw would otherwise leak the spy into sibling tests.
+  vi.restoreAllMocks();
 });
 
 describe("C4CodePanel — zoom controls (AC1/AC2/AC3)", () => {
@@ -187,6 +184,7 @@ describe("C4CodePanel — save path unchanged (AC7)", () => {
 
 const OLD_SOURCE = "model {\n  // a note\n  user = element\n}";
 const NEW_SOURCE = "model {\n  // a note\n  user = element TEST\n}";
+const EXTERNAL_SOURCE = "model {\n  // edited elsewhere\n  user = element X\n}";
 
 function mockFetchOnce(status: number, body: Record<string, unknown>) {
   return vi.spyOn(globalThis, "fetch").mockResolvedValue({
@@ -196,28 +194,32 @@ function mockFetchOnce(status: number, body: Record<string, unknown>) {
   } as Response);
 }
 
+function project(source: string): ProjectResponse {
+  return {
+    dir: "knowledge-base/diagrams",
+    sources: { "model.c4": source },
+    dump: null,
+    viewIds: [],
+    diagnostics: [],
+  };
+}
+
 // F-A1 + F-B: a successful Save must NOT be reverted by a subsequent stale
 // reload(), and a failed Save must surface honestly without discarding the edit.
 // The revert mechanism is the [data, activeFile] effect re-seeding `draft` from
 // `data.sources` — when the on-disk clone GET /project reads is stale (diverged
 // clone / Contents-API→fetch replica lag), that source is the PRE-edit text.
 describe("C4CodePanel — save persistence (F-A1 / F-B)", () => {
-  it("F-A1: a 200 save survives a stale reload() (no silent revert)", async () => {
-    const fetchMock = mockFetchOnce(200, { rerendered: true, commitSha: "abc" });
-    // The parent re-fetches after onSaved; simulate a STALE clone by returning a
-    // fresh object whose source is still the PRE-edit text.
-    const stale = (): ProjectResponse => ({
-      dir: "knowledge-base/diagrams",
-      sources: { "model.c4": OLD_SOURCE },
-      dump: null,
-      viewIds: [],
-      diagnostics: [],
-    });
+  it("F-A1: a 200 save survives a stale reload(), then external edits apply once the clone catches up", async () => {
+    mockFetchOnce(200, { rerendered: true, commitSha: "abc" });
+    const onSaved = vi.fn();
+    // The parent re-fetches after onSaved; each render gets a fresh object so the
+    // [data, activeFile] effect re-fires (mirrors useC4Project's setData).
     const { rerender } = render(
       <C4CodePanel
-        data={stale()}
+        data={project(OLD_SOURCE)}
         dirPath="knowledge-base/diagrams"
-        onSaved={vi.fn()}
+        onSaved={onSaved}
       />,
     );
     fireEvent.change(screen.getByTestId("cm"), {
@@ -225,12 +227,16 @@ describe("C4CodePanel — save persistence (F-A1 / F-B)", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
     await screen.findByText(/Saved/);
-    // Parent reload returns the stale clone (new object ref, old content).
+    // Positive control: the 200 path called onSaved(true) — proves the spy is
+    // wired, so F-B's `not.toHaveBeenCalled()` is a meaningful assertion.
+    expect(onSaved).toHaveBeenCalledWith(true);
+
+    // Parent reload returns the STALE clone (new object ref, pre-edit content).
     rerender(
       <C4CodePanel
-        data={stale()}
+        data={project(OLD_SOURCE)}
         dirPath="knowledge-base/diagrams"
-        onSaved={vi.fn()}
+        onSaved={onSaved}
       />,
     );
     // The editor must still show the saved text, not snap back to OLD_SOURCE.
@@ -242,24 +248,38 @@ describe("C4CodePanel — save persistence (F-A1 / F-B)", () => {
       (screen.getByRole("button", { name: /save/i }) as HTMLButtonElement)
         .disabled,
     ).toBe(true);
-    fetchMock.mockRestore();
+
+    // Clone catches up (incoming === optimistic) → the marker clears (c4-shared
+    // :419). A SUBSEQUENT external edit must now apply normally rather than being
+    // masked by the stale optimistic value.
+    rerender(
+      <C4CodePanel
+        data={project(NEW_SOURCE)}
+        dirPath="knowledge-base/diagrams"
+        onSaved={onSaved}
+      />,
+    );
+    rerender(
+      <C4CodePanel
+        data={project(EXTERNAL_SOURCE)}
+        dirPath="knowledge-base/diagrams"
+        onSaved={onSaved}
+      />,
+    );
+    expect((screen.getByTestId("cm") as HTMLTextAreaElement).value).toBe(
+      EXTERNAL_SOURCE,
+    );
   });
 
   it("F-B: a 500 SYNC_FAILED shows the error and keeps the edited draft", async () => {
-    const fetchMock = mockFetchOnce(500, {
+    mockFetchOnce(500, {
       error: "Workspace sync failed",
       code: "SYNC_FAILED",
     });
     const onSaved = vi.fn();
     render(
       <C4CodePanel
-        data={{
-          dir: "knowledge-base/diagrams",
-          sources: { "model.c4": OLD_SOURCE },
-          dump: null,
-          viewIds: [],
-          diagnostics: [],
-        }}
+        data={project(OLD_SOURCE)}
         dirPath="knowledge-base/diagrams"
         onSaved={onSaved}
       />,
@@ -268,13 +288,14 @@ describe("C4CodePanel — save persistence (F-A1 / F-B)", () => {
       target: { value: NEW_SOURCE },
     });
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    // The error only renders in the catch block — i.e. AFTER the save await
+    // chain has fully settled, so a synchronous assertion below is not racy.
     await screen.findByText(/Workspace sync failed/);
     // The edited draft is retained (no revert) and onSaved (which triggers the
     // reload) is never called on a non-2xx.
     expect((screen.getByTestId("cm") as HTMLTextAreaElement).value).toBe(
       NEW_SOURCE,
     );
-    await waitFor(() => expect(onSaved).not.toHaveBeenCalled());
-    fetchMock.mockRestore();
+    expect(onSaved).not.toHaveBeenCalled();
   });
 });

--- a/apps/web-platform/test/c4-code-panel.test.tsx
+++ b/apps/web-platform/test/c4-code-panel.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitFor,
+} from "@testing-library/react";
 import type { ReactCodeMirrorProps } from "@uiw/react-codemirror";
 
 // Capture the props the editor is mounted with so we can assert wiring
@@ -176,5 +182,99 @@ describe("C4CodePanel — save path unchanged (AC7)", () => {
       target: { value: "model { changed }" },
     });
     expect(save.disabled).toBe(false);
+  });
+});
+
+const OLD_SOURCE = "model {\n  // a note\n  user = element\n}";
+const NEW_SOURCE = "model {\n  // a note\n  user = element TEST\n}";
+
+function mockFetchOnce(status: number, body: Record<string, unknown>) {
+  return vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response);
+}
+
+// F-A1 + F-B: a successful Save must NOT be reverted by a subsequent stale
+// reload(), and a failed Save must surface honestly without discarding the edit.
+// The revert mechanism is the [data, activeFile] effect re-seeding `draft` from
+// `data.sources` — when the on-disk clone GET /project reads is stale (diverged
+// clone / Contents-API→fetch replica lag), that source is the PRE-edit text.
+describe("C4CodePanel — save persistence (F-A1 / F-B)", () => {
+  it("F-A1: a 200 save survives a stale reload() (no silent revert)", async () => {
+    const fetchMock = mockFetchOnce(200, { rerendered: true, commitSha: "abc" });
+    // The parent re-fetches after onSaved; simulate a STALE clone by returning a
+    // fresh object whose source is still the PRE-edit text.
+    const stale = (): ProjectResponse => ({
+      dir: "knowledge-base/diagrams",
+      sources: { "model.c4": OLD_SOURCE },
+      dump: null,
+      viewIds: [],
+      diagnostics: [],
+    });
+    const { rerender } = render(
+      <C4CodePanel
+        data={stale()}
+        dirPath="knowledge-base/diagrams"
+        onSaved={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("cm"), {
+      target: { value: NEW_SOURCE },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    await screen.findByText(/Saved/);
+    // Parent reload returns the stale clone (new object ref, old content).
+    rerender(
+      <C4CodePanel
+        data={stale()}
+        dirPath="knowledge-base/diagrams"
+        onSaved={vi.fn()}
+      />,
+    );
+    // The editor must still show the saved text, not snap back to OLD_SOURCE.
+    expect((screen.getByTestId("cm") as HTMLTextAreaElement).value).toBe(
+      NEW_SOURCE,
+    );
+    // And the just-saved content is no longer "dirty" — Save re-disables.
+    expect(
+      (screen.getByRole("button", { name: /save/i }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    fetchMock.mockRestore();
+  });
+
+  it("F-B: a 500 SYNC_FAILED shows the error and keeps the edited draft", async () => {
+    const fetchMock = mockFetchOnce(500, {
+      error: "Workspace sync failed",
+      code: "SYNC_FAILED",
+    });
+    const onSaved = vi.fn();
+    render(
+      <C4CodePanel
+        data={{
+          dir: "knowledge-base/diagrams",
+          sources: { "model.c4": OLD_SOURCE },
+          dump: null,
+          viewIds: [],
+          diagnostics: [],
+        }}
+        dirPath="knowledge-base/diagrams"
+        onSaved={onSaved}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("cm"), {
+      target: { value: NEW_SOURCE },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    await screen.findByText(/Workspace sync failed/);
+    // The edited draft is retained (no revert) and onSaved (which triggers the
+    // reload) is never called on a non-2xx.
+    expect((screen.getByTestId("cm") as HTMLTextAreaElement).value).toBe(
+      NEW_SOURCE,
+    );
+    await waitFor(() => expect(onSaved).not.toHaveBeenCalled());
+    fetchMock.mockRestore();
   });
 });

--- a/knowledge-base/project/learnings/bug-fixes/2026-06-12-c4-save-revert-stale-clone-optimistic-apply.md
+++ b/knowledge-base/project/learnings/bug-fixes/2026-06-12-c4-save-revert-stale-clone-optimistic-apply.md
@@ -1,0 +1,95 @@
+---
+title: "C4 Code-tab Save reverted because a React re-seed effect re-read a stale workspace clone — fix with optimistic apply"
+date: 2026-06-12
+category: bug-fixes
+module: apps/web-platform/components/kb
+tags: [react, useEffect, cache-coherence, c4, likec4, optimistic-update, workspace-sync]
+pr: feat-one-shot-c4-save-not-persisting
+related_issues: [4963, 4965, 4967, 4976, 4979, 5221]
+---
+
+# C4 Code-tab Save reverted: stale-clone re-seed → optimistic apply
+
+## Problem
+
+Editing a `.c4` source in the LikeC4 Code-tab editor (e.g. `Founder` → `Founder TEST`
+in `model.c4`), clicking **Save**, and getting a **silent revert**: the editor snapped
+back to the pre-edit text and the diagram did not change. The save *looked* like it did
+nothing.
+
+This was NOT the previously-fixed diagram-staleness bug (#4963 Layer-1 banner, #4965
+Layer-2 re-render). Those kept the source and only the *diagram* lagged. Here the
+**source itself** reverted.
+
+## Root cause
+
+The PUT **succeeded** (200): the `.c4` was committed to GitHub via the Contents API.
+The revert was downstream, in the editor's read path:
+
+1. `C4Workspace` `onSaved` calls `await reload()` → `useC4Project` re-fetches
+   `GET /api/kb/c4/project`, which reads `sources` from the **on-disk workspace clone**.
+2. `C4CodePanel` had an effect `useEffect(() => { if (activeFile) setDraft(data.sources[activeFile] ?? ""); }, [data, activeFile])` that **re-seeds the editor `draft` from `data.sources` on every `data` change**.
+3. When the clone is **stale** — a diverged/un-fast-forwardable clone whose self-heal
+   aborts to preserve un-pushed agent-session work (`workspace-sync.ts`), or a
+   Contents-API→fetch replica that hasn't propagated yet — `data.sources[activeFile]`
+   is the **pre-edit text**. The effect clobbers `draft` back to it → the revert.
+
+The GitHub commit is the source of truth; the on-disk clone is a **cache**. A
+cache-coherence lag was presenting as **data loss**.
+
+## Solution (F-A1: optimistic apply)
+
+Keep the just-saved content as the editor value until the reloaded clone catches up —
+purely client-side in `c4-shared.tsx`, no server change:
+
+- A `savedContentRef: useRef<Record<string,string>>` records per-file content on a
+  **confirmed 200** (written AFTER the `if (!res.ok) throw` guard so a failed save can
+  never show un-committed text as persisted).
+- The re-seed effect prefers the optimistic value while `incoming !== optimistic`, and
+  **clears the marker** once `incoming === optimistic` (clone caught up) so later
+  external edits apply normally:
+
+  ```ts
+  const optimistic = savedContentRef.current[activeFile];
+  if (optimistic !== undefined && incoming !== optimistic) { setDraft(optimistic); return; }
+  if (optimistic !== undefined) delete savedContentRef.current[activeFile];
+  setDraft(incoming);
+  ```
+
+- `dirty` compares against the optimistic baseline (falling back to `data.sources`) so
+  the Save button correctly re-disables after a save.
+
+The diagram half stays eventually-consistent and is surfaced honestly by the existing
+Layer-1 staleness banner (#4963). The true root cause (the perpetually-diverged shared
+clone + the working-tree git TOCTOU) is a workspace-wide liveness gap, deferred to
+tracking issue **#5221** — `workspace-sync.ts` is deliberately untouched, preserving its
+gated `@{u}..HEAD` self-heal (never destroy un-pushed work).
+
+## Key insight
+
+When a React component re-seeds local edit state from a server fetch (`useEffect(..., [data])`),
+and that fetch reads a **cache that can lag the write's source of truth**, a successful
+write can be silently clobbered by the next reload. The fix is the same one #4976 applied
+to the diagram render: **don't depend on the reconcile pull to make just-saved content
+visible** — hold the client's own just-written value until the cache demonstrably
+catches up (`incoming === optimistic`), then release it. Optimistic apply must fire ONLY
+on a confirmed 2xx, never on the error path.
+
+## Session Errors
+
+1. **Spec-dir name vs branch name drift** — the plan subagent created
+   `knowledge-base/project/specs/feat-one-shot-c4-code-save-not-persisting/` (slug
+   `c4-code-save`) while the branch is `feat-one-shot-c4-save-not-persisting` (slug
+   `c4-save`). **Recovery:** co-located `session-state.md` in the same dir as the
+   subagent's `tasks.md` (where the work phase looks), not the exact-branch-name dir.
+   **Prevention:** one-shot's session-state.md step should locate the existing spec dir
+   via `ls knowledge-base/project/specs/ | grep <slug-core>` rather than assuming
+   `<exact-branch-name>`; the plan subagent's slug can differ from the branch slug.
+   Low recurrence (cosmetic; co-location resolves it).
+2. **Unused `waitFor` import** after removing a vacuous `waitFor(() => expect(...).not.toHaveBeenCalled())`. **Recovery:** removed the import same cycle. **Prevention:** when deleting the only consumer of a test util, drop its import in the same edit.
+3. **Mangled `PIPESTATUS` in a compound bash command** printed `TSC_EXIT=` empty.
+   **Recovery:** re-ran `tsc` standalone (`; echo "TSC_EXIT=$?"`). **Prevention:** capture
+   exit codes with a standalone `; echo $?` rather than `${PIPESTATUS[0]}` inside a
+   multi-stage `&&` chain.
+
+All one-offs; none recurring-subsystem bugs warranting a fix or issue.

--- a/knowledge-base/project/plans/2026-06-12-fix-c4-code-save-not-persisting-plan.md
+++ b/knowledge-base/project/plans/2026-06-12-fix-c4-code-save-not-persisting-plan.md
@@ -1,0 +1,518 @@
+---
+title: "Fix: C4 Code-tab Save does not persist — model.c4 and the diagram revert after Save"
+type: fix
+date: 2026-06-12
+lane: cross-domain
+brand_survival_threshold: none
+---
+
+# Fix: C4 Code-tab Save does not persist — `model.c4` and the diagram revert after Save
+
+## Enhancement Summary
+
+**Deepened on:** 2026-06-12
+
+### Key Improvements
+
+1. **Verify-the-negative pass confirmed all 6 load-bearing claims** against live
+   code, including the decisive one: on a 500 `SYNC_FAILED` the editor already
+   throws BEFORE `onSaved` (`c4-shared.tsx:416`), shows the error inline
+   (`:497-499`), and does NOT reload — so **F-B is already satisfied for the 500
+   path**. The real silent-revert is the **200-but-stale-clone** case (H2), which
+   F-A1 targets. This narrows the fix.
+2. **Committed to F-A1 + F-B as the mandatory, hypothesis-independent fix**
+   (DHH + Kieran + architecture-strategist all converged): keeping the client's
+   just-saved `draft` instead of round-tripping through a stale `reload()` cures
+   H1/H2/H4 the same way. **F-A2 demoted** from mandatory to a contingency
+   (Alternatives) — the diagram half is already covered by the Layer-1 staleness
+   banner (#4963). Phase 0 is narrowed to a dogfood-time confirmation that sizes
+   the F-C deferral, not a gate that blocks the whole fix.
+3. **Promoted H3 (concurrency) from open-question to a finding** with a concrete
+   TOCTOU: `withWorkspacePermissionLock` exists but guards only
+   `.claude/settings.json` — NO mutex serializes working-tree git ops, so the
+   self-heal `rev-list→reset` (`workspace-sync.ts:191→221`) has a window where a
+   concurrent `session-sync` commit can be destroyed, violating the
+   "never destroy un-pushed work" invariant. Tracked alongside F-C.
+4. **Scoped F-C as a workspace-wide liveness gap** (best-effort `session-sync`
+   push leaves the clone perpetually un-fast-forwardable, degrading EVERY sync
+   consumer — not C4-cosmetic), referencing the kb-sync-stale post-mortem.
+
+### New Considerations Discovered
+
+- **F-A1 alone converts silent-revert into persistent diagram-staleness** when
+  the clone is diverged (source shows new text, diagram shows old layout). This
+  is honest (Layer-1 banner) but split-brain; the strategic fix that resolves
+  both at the authoritative read layer is F-A2-server (SHA-aware / canonical
+  GitHub read on GET `/project`). Ship F-A1 as the correctness floor; reach for
+  F-A2 only if dogfooding proves the banner insufficient.
+
+## Overview
+
+In the LikeC4 C4 visualizer Code-tab editor (web-platform), editing a `.c4`
+source (e.g. changing `Founder` → `Founder TEST` in `model.c4`) and clicking
+**Save** results in: (a) the diagram does not change, AND (b) the `.c4` source
+itself **reverts to its prior state** — the editor reloads the old text. The
+edit is lost.
+
+This is materially different from the previously-shipped Layer-1/Layer-2 bug
+(`2026-06-05-fix-likec4-code-editor-save-noop-plan.md`, PRs #4963 + #4965). That
+bug was "the source persists but the *diagram* stays stale." The symptom here is
+that **the source itself does not survive** — the Code tab shows the pre-edit
+text after reload. That points at the **workspace-sync / reconcile layer**
+clobbering or failing to advance the on-disk clone, not at the render layer.
+
+> Sharp Edge (plan-time): A plan whose `## User-Brand Impact` section is empty,
+> contains only `TBD`/`TODO`/placeholder text, or omits the threshold will fail
+> `deepen-plan` Phase 4.6. This plan's section is filled below.
+
+## Premise Validation
+
+All cited artifacts verified live on the branch
+`feat-one-shot-c4-save-not-persisting`:
+
+- **The feature is built and previously fixed, not absent.** `git log` confirms
+  the visualizer + Save shipped (#4883, #4925, #4926) and the save-noop bug was
+  fixed in two layers: **#4963 (Layer 1 honest UX)** and **#4965 (Layer 2
+  out-of-process re-render)**, hardened by **#4967** (empty-render honesty /
+  atomic publish), **#4979** (render off-tree, stop reconcile dirty-tree churn),
+  **#5007** (shared-link render), **#5027** (fullscreen). So this is a
+  **regression / residual failure mode**, NOT a never-built feature and NOT the
+  same diagram-staleness bug #4963/#4965 already closed.
+- **The write/read paths exist and were read end-to-end:**
+  `apps/web-platform/server/c4-writer.ts` (`writeC4Diagram` + `rerenderAndCommit`),
+  `apps/web-platform/server/c4-render.ts` (`renderC4Model`, off-tree),
+  `apps/web-platform/server/workspace-sync.ts` (`syncWorkspace` +
+  `selfHealNonFastForward`),
+  `apps/web-platform/app/api/kb/c4/[...path]/route.ts` (PUT),
+  `apps/web-platform/app/api/kb/c4/project/route.ts` (GET project),
+  `apps/web-platform/components/kb/c4-shared.tsx`,
+  `apps/web-platform/server/session-sync.ts` (auto-commit/push into the same clone).
+- **Falsified hypothesis (write-vs-read clone mismatch):** I initially suspected
+  the PUT route wrote the *caller's own* clone while GET read the *active*
+  workspace clone (ADR-044). **This is FALSE.** `authenticateAndResolveKbPath`
+  (`kb-route-helpers.ts:98,120`) already resolves `ctx.userData.workspace_path`
+  via `resolveActiveWorkspaceKbRoot`, the SAME resolver the GET `/project` route
+  uses (`project/route.ts:48`). Both read and write operate on the active
+  workspace clone. The revert is NOT a path mismatch.
+- **Falsified hypothesis (render dirties the tree):** Also FALSE post-#4976/#4979.
+  `renderC4Model` renders to a `mkdtemp` temp dir and RETURNS bytes
+  (`c4-render.ts:155-205`); it never writes the tracked `model.likec4.json`. The
+  per-save dirty-tree churn the in-place publish used to cause is gone.
+
+**Conclusion of premise validation:** the revert is a **`syncWorkspace`
+failure-or-abort on the shared active-workspace clone**, leaving the on-disk
+`.c4` source un-advanced (so the editor's `reload()` re-reads the pre-edit text).
+The exact trigger MUST be captured by a live reproduction (Phase 0) before
+choosing the fix — see Hypotheses. Do not pin the cause without the repro
+(`hr` write-path: "internally-consistent claim is a hypothesis to falsify").
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (from bug report) | Reality (code-verified) | Plan response |
+|---|---|---|
+| "edit the code … does not save even after clicking Save" | The PUT commits the `.c4` to GitHub (Contents API) and returns 200 with `commitSha`; the *editor reload* re-reads the **on-disk clone**, which is stale if `syncWorkspace` failed/aborted | Fix targets the sync/reconcile clone-advance, not the commit |
+| "the diagram does not change" | Same root cause: GET `/project` reads `dump` + `sources` from the same clone; if the clone didn't advance, both are stale | One fix addresses both symptoms |
+| "model.c4 reverts back to the previous state" | The Code tab is populated from GET `/project` `sources`, read from `<active-workspace clone>/knowledge-base/engineering/architecture/diagrams/*.c4`; a non-advanced clone returns the old text | Confirmed: revert = clone not advanced, NOT a discarded commit |
+| Implied: "the commit was lost" | Unverified — the commit likely DID land on GitHub `origin`; the clone just never pulled it. Phase 0 repro confirms via `git log origin/<branch>` | Repro distinguishes "commit lost" from "clone stale" |
+
+## Hypotheses (root cause — confirm via Phase 0 repro before fixing)
+
+The save path is (`c4-writer.ts:113-163`): commit `.c4` to `origin` via Contents
+API → `syncWorkspace(op:"manual")` → (for `.c4`) re-render → commit
+`model.likec4.json` → `syncWorkspace(op:"manual")` again. The editor then
+`reload()`s GET `/project`, which reads `sources` + `dump` from the **on-disk
+clone**. The revert means the clone's working tree does NOT reflect the commit.
+Ranked candidates:
+
+1. **H1 — Diverged clone, self-heal aborts on un-pushed local commits
+   (PRIME).** The active-workspace clone (`<WORKSPACES_ROOT>/<workspace_id>`) is
+   **shared** with agent sessions: `session-sync.ts` auto-commits
+   (`["commit",…]` at :513/:581) and pushes (`["push"]` at :602) into it. If a
+   prior push failed (network, auth, race), the clone holds **un-pushed local
+   commits**. Then the C4 save's `git pull --ff-only` (`workspace-sync.ts:107`)
+   fails → `classifyGitSyncError` → `non_fast_forward` → `selfHealNonFastForward`
+   computes `git rev-list --count @{u}..HEAD` (:191) > 0 → **aborts without
+   resetting** (:198-218), returns `ok:false`. `writeC4Diagram` returns
+   `SYNC_FAILED`. The on-disk `.c4` is never advanced → reload shows old text.
+   **This is deterministic-per-save while the clone stays diverged**, matching
+   "does not save even after editing" (every attempt fails the same way).
+   *Verified (deepen-plan):* on a 500 `SYNC_FAILED`, `c4-shared.tsx:save()`
+   throws at `:416` BEFORE `onSaved`, shows the error inline (`:497-499`), and
+   does NOT call `reload()` — so the editor preserves the draft and F-B is
+   **already satisfied for the 500 path**. The user-visible silent revert is
+   therefore the **200-but-stale-clone** path (H2), not the 500 path.
+
+2. **H2 — GitHub Contents API → fetch propagation lag (INTERMITTENT).** The
+   commit lands on `origin`, but the immediately-following `git pull --ff-only`
+   hits a replica whose branch ref does not yet include the commit. `--ff-only`
+   succeeds as a no-op (already up to date with the stale ref) and the file is
+   not advanced. No error is raised; the save reports success but the reload
+   shows the old text. This is timing-dependent, not every-save, so it fits
+   "sometimes" but not a hard deterministic revert. (Pairs with the
+   Layer-2 double-commit: two commits + two pulls widen the lag window.)
+
+3. **H3 — Concurrent working-tree git ops with NO mutex (FINDING, not just a
+   hypothesis — confirmed in deepen-plan).** `withWorkspacePermissionLock`
+   (`server/workspace-permission-lock.ts`) exists but its ONLY consumer is
+   `agent-runner.ts patchWorkspacePermissions` (serializing `.claude/settings.json`)
+   — it wraps **no** `git pull/reset/commit/push`. `syncWorkspace` and
+   `session-sync` acquire no lock; `workspace-reconcile-on-push`'s Inngest
+   `concurrency limit:1` (`workspace-reconcile-on-push.ts:402-405`) serializes
+   only reconcile-vs-reconcile for the same installation and gives **zero**
+   exclusion against the HTTP/WS git paths (those run in the Next/cc-dispatcher
+   worker, outside the Inngest runtime). So THREE actors can mutate one working
+   tree uncoordinated: (1) `writeC4Diagram`'s two `op:"manual"` syncs, (2)
+   `session-sync` auto-commit/push, (3) reconcile-on-push `op:"push"`. **TOCTOU:**
+   between the self-heal `git rev-list --count @{u}..HEAD` (`workspace-sync.ts:191`)
+   and the `git reset --hard` (`:221`), a concurrent `session-sync` commit can
+   make the "0 un-pushed commits" reading stale and the reset destroys a commit
+   that did not exist at check-time — violating the "never destroy un-pushed
+   work" invariant. This is a residual even after F-A1/F-B; track it with F-C
+   (same shared-clone-invariant blast radius). The fix is to route all
+   working-tree git mutations for a `workspacePath` through the existing
+   `withWorkspacePermissionLock` primitive.
+
+4. **H4 — `--ff-only` cannot advance because the clone's local HEAD is the
+   Contents-API commit's *parent on a different ref*.** If the Contents API
+   commits against the repo default branch but the clone tracks a different
+   upstream, the pull is a no-op. Confirm the clone's `@{u}` matches the branch
+   the Contents API writes to.
+
+**Per the network-outage / git-diagnosis discipline:** the fix for H1 must NOT
+propose an ungated `reset --hard` (would destroy un-pushed agent-session work —
+see learning `2026-06-03-self-heal-reset-must-gate-on-actual-repo-state-not-assumed-mirror.md`).
+The diverged-clone state is the *symptom*; the fix is to make the C4 save
+**resilient to a stale/diverged clone** (e.g. read the just-committed bytes the
+writer already holds, rather than depending on the clone pull), and/or to
+**surface the failure honestly** instead of reverting silently.
+
+## Proposed Solution
+
+**The mandatory fix is F-A1 + F-B, committed now — it is hypothesis-independent**
+(it cures H1/H2/H4 the same way: a successful write must not be invalidated by a
+downstream cache-sync failure). It follows the same insight #4976 applied to the
+re-render: **do not depend on the reconcile pull to make just-saved content
+visible** — the GitHub commit is the source of truth, the on-disk clone is a
+cache, and a cache-coherence failure must not present as data loss.
+
+- **F-A1 (MANDATORY) — optimistic editor apply on a 200.** Have the client keep
+  the saved source it just sent (its `draft`) instead of round-tripping through a
+  possibly-stale `reload()` that re-reads the on-disk clone. On a successful PUT,
+  the editor reflects the saved text regardless of whether the clone advanced.
+  This removes the **200-but-stale-clone** revert (the actual user-visible bug).
+  The diagram `dump` still depends on the clone advancing; when it lags, surface
+  honestly via the **already-shipped Layer-1 staleness banner** (#4963) — do not
+  build a new read path for the diagram half.
+- **F-B (MANDATORY baseline; already partly satisfied).** On a non-2xx the editor
+  MUST show a distinct, honest error and MUST NOT reload to a stale source.
+  *Verified:* `c4-shared.tsx:save()` already throws at `:416` before `onSaved`,
+  renders the error inline (`:497-499`), and does not `reload()` on failure — so
+  the **500 path is already honest**. F-B's remaining work is only to ensure the
+  F-A1 optimistic-apply change does not regress this (a vitest test pins it).
+- **F-C (DEFERRED — file a tracking issue).** The true root cause of H1: a
+  best-effort `session-sync` push that swallows failures leaves the shared clone
+  with un-pushed commits, after which EVERY `git pull --ff-only` consumer (C4
+  save, KB delete, webhook reconcile) aborts — a **workspace-wide liveness gap**,
+  not a C4-cosmetic one. Plus the H3 `rev-list→reset` TOCTOU. Defer because it
+  touches the shared reconcile invariant (largest blast radius) and the fix is a
+  real reconciliation design (recover un-pushed commits, not blind-reset). The
+  tracking issue MUST scope it workspace-wide and reference
+  `kb-sync-stale-no-manual-recovery-postmortem.md`.
+
+**F-A2 is NOT in the mandatory set** — see Alternatives. It is the *strategic*
+read-layer fix (SHA-aware / canonical GitHub read on GET `/project`, resolving
+both source AND diagram at the authoritative layer), but the diagram half is
+already covered honestly by the Layer-1 banner, so F-A2 is a contingency reached
+for only if dogfooding proves the banner insufficient.
+
+**Phase 0 (narrowed):** capture the live git state to confirm the failure mode
+and **size the F-C tracking issue** — it does NOT gate the F-A1/F-B fix (which is
+correct for all hypotheses). Record: `git log origin/<branch>` shows the commit
+landed; `git -C <clone> rev-list --count @{u}..HEAD` / `git status` shows why the
+pull didn't advance; the returned `SyncWorkspaceResult`.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** the C4 Code-tab Save continues to
+silently discard edits — the user types a change, clicks Save, and the editor
+snaps back to the old text with no diagram update and (per H1) possibly no error,
+making the entire editor feel non-functional.
+
+**If this leaks, the user's data / workflow is exposed via:** N/A — no new data
+surface. The write path already commits only within the `isC4DiagramPath`
+scope-guarded diagrams dir; this fix touches the sync/visibility path and UI
+copy, not auth, scope, or PII.
+
+**Brand-survival threshold:** `none`
+
+`threshold: none, reason: the touched paths (server/c4-writer.ts, server/workspace-sync.ts, app/api/kb/c4/*, components/kb/c4-shared.tsx) change clone-visibility/retry and editor-reload behavior on the existing isC4DiagramPath-scoped write path; they add no new data exposure, auth, scope, or PII surface.`
+
+## Observability
+
+```yaml
+liveness_signal:
+  what:            "logger.info event:c4_write (source committed) + event:c4_rerender (diagram regenerated) in c4-writer.ts; on sync failure the existing reportSilentFallback(op:workspace-sync-manual / self-heal-aborted-dirty) fires"
+  cadence:         "per-save (user-triggered)"
+  alert_target:    "Sentry web-platform issue (operator email on error spike) via existing reportSilentFallback mirror"
+  configured_in:   "apps/web-platform/server/c4-writer.ts + apps/web-platform/server/workspace-sync.ts (existing logger + reportSilentFallback/warnSilentFallback)"
+
+error_reporting:
+  destination:     "Sentry web-platform via SENTRY_DSN; existing reportSilentFallback in workspace-sync.ts (self-heal-aborted-dirty / self-heal-failed / sync_failed) and c4-writer.ts (c4-rerender ops)"
+  fail_loud:       "PUT returns non-2xx {error,code} (SYNC_FAILED/SHA_MISMATCH/GITHUB_API_ERROR); the fix MUST make the editor render that error distinctly and NOT reload to the stale source"
+
+failure_modes:
+  - mode:          "Diverged clone aborts self-heal (un-pushed local commits) → source committed but clone never advances → editor reverts"
+    detection:     "existing reportSilentFallback op:self-heal-aborted-dirty in workspace-sync.ts; add an event tying it to the c4 save so it is greppable per-save"
+    alert_route:   "Sentry issue -> operator email"
+  - mode:          "GitHub Contents API commit not yet visible to the fetch replica (propagation lag) → pull --ff-only no-ops → stale clone"
+    detection:     "new: after resync, assert the committed SHA is present on the clone (git rev-parse/cat-file); log+mirror when absent"
+    alert_route:   "Sentry issue -> operator email"
+  - mode:          "Editor silently reloads stale source on a non-2xx PUT (masks the SYNC_FAILED error)"
+    detection:     "vitest on c4-shared.tsx save flow: a 500 SYNC_FAILED must show an error and NOT overwrite the editor with reloaded sources"
+    alert_route:   "caught pre-merge by tests"
+
+logs:
+  where:           "pino structured logs (logger.info/error in c4-writer.ts + workspace-sync.ts) -> container stdout -> existing aggregator (Better Stack drain)"
+  retention:       "per existing web-platform log retention"
+
+discoverability_test:
+  command:         "cd apps/web-platform && ./node_modules/.bin/vitest run test/c4-code-panel.test.tsx test/c4-writer-rerender.test.ts"
+  expected_output: "tests assert: (a) on PUT 200 the editor reflects the saved source without depending on a stale clone reload; (b) on PUT 500 SYNC_FAILED the editor shows an error and does NOT revert to reloaded sources"
+```
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] **Phase 0 repro captured (sizes F-C, does NOT gate F-A1/F-B):** the PR body
+      records which hypothesis (H1–H4) reproduces, with the observed git state
+      (`git log origin/<branch>` shows the commit landed; `git -C <clone> rev-list
+      --count @{u}..HEAD` / `git status` shows why the pull didn't advance) and the
+      returned `SyncWorkspaceResult`. Drives the F-C tracking-issue scope.
+- [ ] Editing a `.c4` source, clicking Save, and a **successful** PUT (200) leaves
+      the **edited text visible in the Code tab** (not reverted) — verified by a
+      vitest test that does NOT rely on the on-disk clone having advanced
+      (optimistic apply of the saved content, or GitHub-canonical read).
+- [ ] On a PUT that returns **500 `SYNC_FAILED`**, the editor shows a distinct,
+      honest error and does **NOT** overwrite the editor with a stale reloaded
+      source (no silent revert). Verified by a vitest test on `c4-shared.tsx`.
+- [ ] No regression: the `.c4` source still commits to GitHub via
+      `writeC4Diagram` within the `isC4DiagramPath` scope guard; the re-render +
+      `model.likec4.json` commit path (#4965/#4967/#4976) is unchanged or
+      improved, never weakened.
+- [ ] **No ungated `reset --hard`** is added to any save/sync path — the
+      diverged-clone guard (`@{u}..HEAD == 0`) is preserved; un-pushed
+      agent-session work is never destroyed
+      (learning `2026-06-03-self-heal-reset-must-gate-on-actual-repo-state-not-assumed-mirror.md`).
+- [ ] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` clean; vitest
+      suite green (`c4-code-panel.test.tsx`, `c4-writer-rerender.test.ts`,
+      `c4-workspace.test.tsx`, and any new sync-resilience test).
+
+### Post-merge (operator)
+
+- [ ] **Live dogfood** (the only manual step): on the dev-cohort deployment, open
+      a C4 KB page → Code tab → change a label in `model.c4` → Save → confirm the
+      edit persists in the editor AND (after re-render) the diagram updates; if a
+      `SYNC_FAILED` is encountered, confirm the honest error renders.
+      *Automation: not feasible because it exercises the live GitHub-clone
+      reconcile against the operator's actual workspace clone state, which is the
+      exact condition the bug depends on; a synthetic CI clone cannot reproduce a
+      perpetually-diverged prod clone. Bounded to one human dogfood per the
+      dev-cohort flag.*
+
+## Test Scenarios
+
+- Given an edited `.c4` source and a PUT that returns 200, when the save
+  completes, then the Code tab shows the edited text (no revert), independent of
+  whether the on-disk clone advanced.
+- Given a PUT that returns 500 `SYNC_FAILED`, when the save completes, then the
+  editor shows a distinct error and retains the user's edited text (does not snap
+  to a reloaded stale source).
+- Given a diverged clone with un-pushed local commits, when a C4 save runs, then
+  `selfHealNonFastForward` still aborts without resetting (un-pushed work
+  preserved) AND the save surfaces an honest error rather than a silent revert.
+- Regression: given a clean fast-forwardable clone, when a `.c4` save runs, then
+  the source commits, the diagram re-renders (#4965/#4967), and the editor + GET
+  `/project` reflect the change.
+
+## Dependencies & Risks
+
+- **Risk:** the fix must not weaken the diverged-clone guard or introduce a path
+  that destroys un-pushed agent-session work (shared clone invariant). Any
+  retry-pull must be bounded (timeout/attempt cap) per the "pin a timeout on
+  network calls in loops" learning.
+- **Risk:** GitHub Contents API propagation lag is intermittent — F-A1 (make the
+  save self-sufficient for the source) covers both H1 and H2 because it does not
+  depend on the clone advancing at all. The diagram half remains eventually-
+  consistent and is surfaced honestly by the Layer-1 banner.
+- **Risk (residual, tracked in F-C):** even after F-A1/F-B, the H3 working-tree
+  TOCTOU and the perpetual-divergence liveness gap persist — they are NOT closed
+  by this PR and MUST be captured in the F-C tracking issue.
+- **Risk:** F-A1 must not show edited text that did NOT commit — the optimistic
+  apply fires ONLY on a confirmed 200 (commit landed on `origin`), never on a
+  non-2xx. The vitest test pins both paths.
+- **Dependency:** reuses the existing GitHub Contents API + `syncWorkspace` paths
+  in `c4-writer.ts`; the optimistic-apply reuses the content the client already
+  sent (no new network call).
+
+## Network-Outage Deep-Dive
+
+Phase 4.5 fired on the `timeout` / propagation-lag substrings, but this is a
+**git-clone reconcile** issue, not an L3/L7 connectivity outage:
+
+- **L3 firewall / egress IP:** N/A — the failure is an in-process `git pull
+  --ff-only` against an already-authenticated GitHub remote on a healthy
+  container, not a blocked connection. No firewall hypothesis applies.
+- **L3 DNS / routing:** N/A — GitHub reachability is proven by the *successful*
+  Contents API commit that immediately precedes the failing pull.
+- **L7 TLS / proxy:** N/A — same auth/transport as the successful commit.
+- **L7 application (the actual layer):** the `git pull --ff-only` aborts on a
+  diverged/dirty clone (H1) or no-ops against a lagging replica ref (H2). The
+  "timeout" references in this plan are the in-code `RENDER_TIMEOUT_MS=25s` ceiling
+  and a (deferred) bounded retry budget — not a network handshake timeout. No
+  connectivity verification artifact is required.
+
+## Alternative Approaches Considered
+
+| Approach | Mechanism | Verdict |
+|---|---|---|
+| **F-A1. Optimistic editor apply on 200** | Client keeps the saved source it sent; diagram staleness uses the Layer-1 banner if the clone lags | **MANDATORY (chosen).** Removes the source revert regardless of clone state; smallest blast radius; faithful to #4976 (cache-coherence failure ≠ data loss). |
+| **F-B. Honest error, no silent revert** | On non-2xx, show the error and don't reload to a stale source | **MANDATORY baseline (already partly satisfied at `c4-shared.tsx:416`).** F-A1 must not regress it. |
+| **F-A2. SHA-aware / canonical GitHub read on GET `/project`** | Server resolves sources+dump against the just-committed SHA or reads `origin` when the clone is stale | **Contingency, NOT mandatory.** The *strategic* read-layer fix (resolves source AND diagram at the authoritative layer), but the diagram half is already honest via the Layer-1 banner; adds GitHub-read latency / retry budget. Reach for it only if dogfooding shows the banner insufficient. |
+| **F-C. Fix shared-clone divergence + working-tree git lock (session-sync recovery)** | Make failed-push state recoverable; route working-tree git ops through `withWorkspacePermissionLock` to close the `rev-list→reset` TOCTOU | **DEFER to a workspace-wide tracking issue.** True root cause of H1 + the H3 concurrency finding; largest blast radius (shared reconcile invariant); fix is a real reconciliation design, not a one-liner. |
+| **Ungated `reset --hard` in the save sync** | Force the clone to `origin` on every save | **Rejected.** Destroys un-pushed agent-session work; violates the gated-self-heal invariant. |
+
+**F-C deferral (required tracking issue):** file an issue scoping the shared-clone
+divergence-recovery gap as a **workspace-wide liveness failure** (a clone left
+with un-pushed commits by a best-effort `session-sync` push degrades EVERY
+`git pull --ff-only` consumer — C4 save, KB delete/rename/upload, webhook
+reconcile — not just C4), PLUS the H3 `rev-list→reset` TOCTOU (route working-tree
+git ops through `withWorkspacePermissionLock`). Reference
+`knowledge-base/engineering/operations/post-mortems/kb-sync-stale-no-manual-recovery-postmortem.md`
+and the milestone from `knowledge-base/product/roadmap.md`. Re-evaluation
+criterion: any Sentry `self-heal-aborted-dirty` recurrence or a second
+clone-stuck report.
+
+## Files to Edit
+
+Committed to F-A1 + F-B, the edit surface collapses to the client save flow plus
+tests (`workspace-sync.ts` and `project/route.ts` come OFF the list — they belong
+to the deferred F-A2/F-C). Verify whether the PUT already echoes enough
+(`commitSha`) for the client to apply optimistically before editing the route.
+
+- `apps/web-platform/components/kb/c4-shared.tsx` — `C4CodePanel` save flow:
+  on a 200, keep the client's `draft` (optimistic apply) instead of resetting it
+  from a possibly-stale `reload()` (F-A1); preserve the existing non-2xx
+  error-inline-no-reload behavior at `:416/:497-499` (F-B regression guard).
+- `apps/web-platform/server/c4-writer.ts` — only if needed to return the written
+  `content` to the route for the client to apply, and to tie a greppable
+  observability event to the diverged-clone abort (the `SYNC_FAILED`/
+  `self-heal-aborted-dirty` per-save signal). No retry loop here.
+- `apps/web-platform/app/api/kb/c4/[...path]/route.ts` — only if the client needs
+  the written content echoed back for optimistic apply (likely `commitSha`/the
+  already-sent body suffices).
+- `apps/web-platform/test/c4-code-panel.test.tsx` — assert no-revert on 200 and
+  honest-error-no-revert on 500 `SYNC_FAILED`.
+- `apps/web-platform/test/c4-writer-rerender.test.ts` — assert the writer returns
+  the content needed for optimistic apply (if that edit is made).
+- `apps/web-platform/test/c4-workspace.test.tsx` — regression on the workspace
+  save flow.
+
+## Files to Create
+
+- None. (The deferred F-A2, if ever taken, would add a canonical GitHub-read
+  helper under `apps/web-platform/server/` with a colocated test — out of scope
+  for this PR.)
+
+## Open Code-Review Overlap
+
+To be populated at /work time: run
+`gh issue list --label code-review --state open --json number,title,body --limit 200`
+and grep the bodies for `c4-shared.tsx`, `c4-writer.ts`, `workspace-sync.ts`,
+`app/api/kb/c4/`. Record matches with an explicit fold-in / acknowledge / defer
+disposition; record `None` if the grep is empty.
+
+## Domain Review
+
+**Domains relevant:** Product (UI behavior)
+
+### Product/UX Gate
+
+**Tier:** advisory
+**Decision:** auto-accepted (pipeline)
+**Agents invoked:** none
+**Skipped specialists:** none — this fix modifies the existing C4 Code-tab Save
+behavior (editor reload + error copy). It creates no new page, route, or
+interactive surface (no new `components/**/*.tsx`, `app/**/page.tsx`, or
+`app/**/layout.tsx`), so the mechanical UI-surface override resolves to ADVISORY.
+**Pencil available:** N/A (no new UI surface)
+
+**Wireframe gate (`wg-ui-feature-requires-pen-wireframe` / deepen-plan Phase
+4.9):** The glob superset matches `components/kb/c4-shared.tsx`, but the change
+renders **zero new pixels** — F-A1 changes only *when* the editor reloads its
+`draft` (it stops resetting from a stale `reload()` on a 200), and F-B is an
+already-shipped error-inline path. No new banner/overlay/modal/toast/component,
+no layout change, no new interactive surface — squarely the gate's **Excluded**
+"pure copy / behavior tweak, no structural/layout change" carve-out. This is the
+**accepted precedent** set by `2026-06-05-fix-likec4-code-editor-save-noop-plan.md`,
+which touched the same `c4-shared.tsx` Save flow and resolved via the same
+carve-out with no `.pen`. If implementation deviates to a NEW visual component,
+the gate re-fires and a `.pen` must be produced under
+`knowledge-base/product/design/kb-viewer/`.
+
+#### Findings
+
+The change corrects when/whether the editor reloads its source and how a sync
+failure is surfaced. UX risk is confined to the error-copy and the
+optimistic-apply correctness (the editor must not show edited text that did NOT
+commit) — covered by the both-outcomes (200 / 500) test requirement in the
+Acceptance Criteria.
+
+## Infrastructure (IaC)
+
+**No infrastructure.** Pure code change against the already-provisioned
+web-platform — edits `components/kb/c4-shared.tsx`, optionally
+`server/c4-writer.ts` + `app/api/kb/c4/[...path]/route.ts`, and tests. No new
+server, service, secret, vendor, or persistent process. The `likec4` CLI
+re-render path (out-of-process) and `workspace-sync.ts` are unchanged by this PR.
+
+## References & Research
+
+### Internal References
+
+- `apps/web-platform/server/c4-writer.ts` — `writeC4Diagram` (commit + sync +
+  re-render), `rerenderAndCommit`
+- `apps/web-platform/server/workspace-sync.ts` — `syncWorkspace` (`git pull
+  --ff-only` at :107) + `selfHealNonFastForward` (gated reset at :221, abort on
+  un-pushed commits at :198-218)
+- `apps/web-platform/server/c4-render.ts` — `renderC4Model` (off-tree, returns
+  bytes, #4976)
+- `apps/web-platform/app/api/kb/c4/[...path]/route.ts` — PUT route
+- `apps/web-platform/app/api/kb/c4/project/route.ts` — GET project (reads
+  sources/dump from the on-disk clone at :69,:118)
+- `apps/web-platform/server/kb-route-helpers.ts:98,120` — `workspace_path`
+  resolves via `resolveActiveWorkspaceKbRoot` (same as GET — falsifies the
+  path-mismatch hypothesis)
+- `apps/web-platform/server/session-sync.ts:513,581,602` — auto-commit/push into
+  the SAME active-workspace clone (the divergence source for H1)
+- `apps/web-platform/components/kb/c4-shared.tsx` — `C4CodePanel`, `useC4Project`,
+  reload/`onSaved`
+
+### Related Work / Learnings
+
+- `knowledge-base/project/plans/2026-06-05-fix-likec4-code-editor-save-noop-plan.md`
+  — the prior (diagram-staleness) fix; this plan is the residual source-revert
+  failure mode.
+- `knowledge-base/engineering/operations/post-mortems/c4-empty-render-clobber-and-silent-success-postmortem.md`
+  — #4967 empty-render clobber (exit-0-not-proof); related save path.
+- `knowledge-base/project/learnings/best-practices/2026-06-05-render-off-tree-return-bytes-and-drop-toctou-with-the-reread.md`
+  — #4979 render off-tree (the insight this fix extends: don't depend on the
+  reconcile pull to make just-saved content visible).
+- `knowledge-base/project/learnings/2026-06-05-report-error-on-final-recoverability-not-first-failure.md`
+  — `syncWorkspace` error-by-recoverability reporting.
+- `knowledge-base/project/learnings/2026-06-03-self-heal-reset-must-gate-on-actual-repo-state-not-assumed-mirror.md`
+  — gated reset; un-pushed work must be preserved (bounds the fix).
+- `knowledge-base/engineering/operations/post-mortems/kb-sync-stale-no-manual-recovery-postmortem.md`
+  — diverged-clone classification + gated self-heal (the H1 mechanism).
+- #4883, #4925, #4926, #4963, #4965, #4967, #4979, #5007, #5027 — the C4
+  visualizer + Save lineage.

--- a/knowledge-base/project/plans/2026-06-12-fix-c4-code-save-not-persisting-plan.md
+++ b/knowledge-base/project/plans/2026-06-12-fix-c4-code-save-not-persisting-plan.md
@@ -284,29 +284,30 @@ discoverability_test:
 
 ### Pre-merge (PR)
 
-- [ ] **Phase 0 repro captured (sizes F-C, does NOT gate F-A1/F-B):** the PR body
-      records which hypothesis (H1–H4) reproduces, with the observed git state
-      (`git log origin/<branch>` shows the commit landed; `git -C <clone> rev-list
-      --count @{u}..HEAD` / `git status` shows why the pull didn't advance) and the
-      returned `SyncWorkspaceResult`. Drives the F-C tracking-issue scope.
-- [ ] Editing a `.c4` source, clicking Save, and a **successful** PUT (200) leaves
-      the **edited text visible in the Code tab** (not reverted) — verified by a
-      vitest test that does NOT rely on the on-disk clone having advanced
-      (optimistic apply of the saved content, or GitHub-canonical read).
-- [ ] On a PUT that returns **500 `SYNC_FAILED`**, the editor shows a distinct,
+- [x] **Phase 0 repro captured (sizes F-C, does NOT gate F-A1/F-B):** PR body
+      records **H1 (diverged clone → self-heal aborts)** PRIME + **H2 (replica
+      propagation lag)** for the intermittent case; live-clone capture deferred to
+      the 5.1 dogfood (a synthetic CI clone cannot reproduce a perpetually-diverged
+      prod clone). Code-trace confirms the revert mechanism (`c4-shared.tsx:396-398`
+      re-seeds `draft` from the stale clone). Drives the F-C tracking-issue scope.
+- [x] Editing a `.c4` source, clicking Save, and a **successful** PUT (200) leaves
+      the **edited text visible in the Code tab** (not reverted) — verified by the
+      F-A1 vitest test that re-renders with a stale clone (OLD source) and asserts
+      the editor keeps the NEW saved text. Optimistic apply of the saved content.
+- [x] On a PUT that returns **500 `SYNC_FAILED`**, the editor shows a distinct,
       honest error and does **NOT** overwrite the editor with a stale reloaded
-      source (no silent revert). Verified by a vitest test on `c4-shared.tsx`.
-- [ ] No regression: the `.c4` source still commits to GitHub via
+      source (no silent revert). Verified by the F-B vitest test on `c4-shared.tsx`.
+- [x] No regression: the `.c4` source still commits to GitHub via
       `writeC4Diagram` within the `isC4DiagramPath` scope guard; the re-render +
-      `model.likec4.json` commit path (#4965/#4967/#4976) is unchanged or
-      improved, never weakened.
-- [ ] **No ungated `reset --hard`** is added to any save/sync path — the
-      diverged-clone guard (`@{u}..HEAD == 0`) is preserved; un-pushed
-      agent-session work is never destroyed
+      `model.likec4.json` commit path (#4965/#4967/#4976) is unchanged
+      (server untouched).
+- [x] **No ungated `reset --hard`** is added to any save/sync path — the
+      diverged-clone guard (`@{u}..HEAD == 0`) is preserved; `workspace-sync.ts`
+      is untouched, so un-pushed agent-session work is never destroyed
       (learning `2026-06-03-self-heal-reset-must-gate-on-actual-repo-state-not-assumed-mirror.md`).
-- [ ] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` clean; vitest
+- [x] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` clean; vitest
       suite green (`c4-code-panel.test.tsx`, `c4-writer-rerender.test.ts`,
-      `c4-workspace.test.tsx`, and any new sync-resilience test).
+      `c4-workspace.test.tsx` = 28/28; full web-platform suite 9613 passed, 0 fail).
 
 ### Post-merge (operator)
 

--- a/knowledge-base/project/specs/feat-one-shot-c4-code-save-not-persisting/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-c4-code-save-not-persisting/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-12-fix-c4-code-save-not-persisting-plan.md
+- Status: complete
+
+### Errors
+None. (CWD verified equal to the worktree on first tool call; branch confirmed feat-one-shot-c4-save-not-persisting.)
+
+### Decisions
+- Regression / residual failure mode, not a new build. Prior plan (2026-06-05-fix-likec4-code-editor-save-noop) and PRs #4963/#4965/#4967/#4979/#5007/#5027 already shipped; user's distinct symptom (model.c4 itself reverts) points at the workspace-sync/reconcile layer, not the render layer.
+- Root cause: a diverged shared clone whose `git pull --ff-only` aborts, leaving the on-disk .c4 un-advanced so the editor's reload() re-reads stale text. Two competing hypotheses (write/read clone path-mismatch; render dirties tree) falsified by reading code.
+- Committed fix: F-A1 (optimistic editor apply) + F-B (honest error). F-B already satisfied on the 500 path; real silent revert is the 200-but-stale-clone case. F-A2 demoted to contingency.
+- Promoted concurrency finding H3: no mutex serializes working-tree git ops; self-heal rev-list→reset has a TOCTOU that can destroy un-pushed session-sync work. F-C deferred as a workspace-wide liveness gap with a required tracking issue.
+- All deepen-plan halt gates passed (User-Brand Impact + scope-out, Observability 5-field no-SSH, no PAT vars, wireframe-gate Excluded carve-out); all 7 KB/pen citations resolve.
+
+### Components Invoked
+- Skills: soleur:plan, soleur:deepen-plan
+- Agents (plan research): repo-research-analyst, learnings-researcher, Explore
+- Agents (deepen-plan review): Explore, dhh-rails-reviewer, kieran-rails-reviewer, architecture-strategist

--- a/knowledge-base/project/specs/feat-one-shot-c4-code-save-not-persisting/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-c4-code-save-not-persisting/tasks.md
@@ -6,32 +6,29 @@ Mandatory fix: **F-A1 (optimistic editor apply) + F-B (honest error, no silent r
 
 ## Phase 0 — Confirm failure mode (sizes the F-C deferral; does NOT gate the fix)
 
-- [ ] 0.1 Reproduce against the dev-cohort workspace clone. Capture:
-  - `git log origin/<branch>` shows the `.c4` commit landed on origin.
-  - `git -C <clone> rev-list --count @{u}..HEAD` and `git -C <clone> status` show why `git pull --ff-only` did not advance the working tree.
-  - the `SyncWorkspaceResult` the C4 save returned (`ok:true` no-op vs `SYNC_FAILED`).
-- [ ] 0.2 Record the dominant hypothesis (H1 diverged-clone abort / H2 propagation lag / H3 concurrency / H4 wrong upstream) in the PR body. This drives the F-C tracking-issue scope, not the F-A1/F-B implementation.
-- [ ] 0.3 Open Code-Review overlap check: `gh issue list --label code-review --state open --json number,title,body --limit 200`, grep bodies for `c4-shared.tsx`, `c4-writer.ts`, `app/api/kb/c4/`. Record fold-in / acknowledge / defer (or `None`).
+- [x] 0.1 Live-clone repro deferred to the post-merge dogfood (5.1) — a synthetic CI clone cannot reproduce a perpetually-diverged prod clone. Code-trace confirms the mechanism: GET `/project` reads `data.sources` from the on-disk clone; the `[data, activeFile]` effect (`c4-shared.tsx:396-398`) re-seeds `draft` from it, so a stale clone reverts the editor. F-A1/F-B are correct for all hypotheses regardless.
+- [x] 0.2 Dominant hypothesis recorded in PR body: **H1 (diverged clone → self-heal aborts on un-pushed commits)** as PRIME for the deterministic "every save reverts" symptom; **H2 (Contents-API→fetch replica lag)** for the intermittent case. Both cured identically by F-A1 (the editor stops depending on the clone advancing). Drives the F-C tracking-issue scope.
+- [x] 0.3 Open Code-Review overlap check run: `gh issue list --label code-review --state open` grep for `c4-shared.tsx` / `c4-writer.ts` / `app/api/kb/c4/` → **None**.
 
 ## Phase 1 — RED (failing tests first)
 
-- [ ] 1.1 `apps/web-platform/test/c4-code-panel.test.tsx`: add a failing test — after a PUT 200, the editor reflects the saved source WITHOUT depending on the on-disk clone having advanced (mock `reload()` to return the OLD source; assert the editor shows the NEW saved text).
-- [ ] 1.2 `apps/web-platform/test/c4-code-panel.test.tsx`: add/confirm a test — on a PUT 500 `SYNC_FAILED`, the editor shows the error inline AND retains the user's edited draft (no revert, no `reload()` on failure). (Verify-the-negative confirmed this is already the behavior at `c4-shared.tsx:416/:497-499` — the test pins it against regression from 1.1.)
-- [ ] 1.3 (Only if the writer must echo content) `apps/web-platform/test/c4-writer-rerender.test.ts`: assert `writeC4Diagram` returns the written `content` needed for optimistic apply.
+- [x] 1.1 `c4-code-panel.test.tsx` F-A1 test added — after a 200, a stale reload() (new object, OLD source) must not revert the editor. RED confirmed: received `user = element`, expected `user = element TEST`.
+- [x] 1.2 `c4-code-panel.test.tsx` F-B test added — on a 500 `SYNC_FAILED` the editor shows the error AND retains the edited draft, and `onSaved` (the reload trigger) is never called. Passed at RED (already-shipped behavior); pins it against the F-A1 change.
+- [x] 1.3 N/A — F-A1 reuses the client's own `draft` (no server echo needed). Writer/route untouched.
 
 ## Phase 2 — GREEN (minimal implementation)
 
-- [ ] 2.1 `apps/web-platform/components/kb/c4-shared.tsx`: on a successful PUT (200), keep the client's `draft` (optimistic apply) instead of resetting it from the `reload()`-fetched `data.sources` (F-A1). Confirm the diagram-staleness path still falls through to the existing Layer-1 banner when the clone lags.
-- [ ] 2.2 `apps/web-platform/components/kb/c4-shared.tsx`: confirm/preserve the non-2xx error-inline-no-reload behavior at `:416/:497-499` (F-B regression guard).
-- [ ] 2.3 (Only if needed for 2.1) `apps/web-platform/server/c4-writer.ts` + `apps/web-platform/app/api/kb/c4/[...path]/route.ts`: return the written `content` to the client. First verify whether the existing `commitSha`/already-sent body suffices before editing the route.
-- [ ] 2.4 (Observability) `apps/web-platform/server/c4-writer.ts`: tie a greppable per-save event to the diverged-clone abort (`SYNC_FAILED` / `self-heal-aborted-dirty`) so the failure mode is dashboard-discoverable.
+- [x] 2.1 `c4-shared.tsx`: added `savedContentRef` (per-file optimistic content); the `[data, activeFile]` effect now keeps the saved text when the reloaded source is stale, clearing the marker once the clone catches up. Diagram staleness still falls through to the Layer-1 banner.
+- [x] 2.2 `c4-shared.tsx`: non-2xx still `throw`s before `onSaved` (`:416`) → error inline, no reload (F-B preserved). Pinned by the 1.2 test.
+- [x] 2.3 N/A — verified `commitSha` + the client's already-sent `draft` suffice; no route/writer change.
+- [x] 2.4 N/A — already satisfied: `c4-writer.ts:138` logs `event:c4_write` per-save; `c4-writer.ts:318` + `workspace-sync.ts:204` (`op:self-heal-aborted-dirty`) already mirror the diverged-clone abort to Sentry via `reportSilentFallback`.
 
 ## Phase 3 — Guards & regression
 
-- [ ] 3.1 Assert NO ungated `reset --hard` was added to any save/sync path; the `@{u}..HEAD == 0` gated self-heal is untouched (un-pushed agent-session work preserved).
-- [ ] 3.2 `apps/web-platform/test/c4-workspace.test.tsx`: regression on the full workspace save flow (source commits, diagram re-renders on a clean clone).
-- [ ] 3.3 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` clean.
-- [ ] 3.4 `cd apps/web-platform && ./node_modules/.bin/vitest run test/c4-code-panel.test.tsx test/c4-writer-rerender.test.ts test/c4-workspace.test.tsx` green.
+- [x] 3.1 No `reset --hard` added — `workspace-sync.ts` untouched; the gated `@{u}..HEAD` self-heal is preserved (un-pushed session work safe).
+- [x] 3.2 `c4-workspace.test.tsx` regression green (clean-clone save flow unchanged).
+- [x] 3.3 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` clean (EXIT=0).
+- [x] 3.4 `vitest run` of the three C4 suites green (28/28); full web-platform suite green (9613 passed, 0 failures).
 
 ## Phase 4 — Deferrals
 

--- a/knowledge-base/project/specs/feat-one-shot-c4-code-save-not-persisting/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-c4-code-save-not-persisting/tasks.md
@@ -1,0 +1,42 @@
+# Tasks — Fix: C4 Code-tab Save does not persist (model.c4 reverts after Save)
+
+Plan: `knowledge-base/project/plans/2026-06-12-fix-c4-code-save-not-persisting-plan.md`
+Lane: cross-domain
+Mandatory fix: **F-A1 (optimistic editor apply) + F-B (honest error, no silent revert)**. F-A2 and F-C are deferred.
+
+## Phase 0 — Confirm failure mode (sizes the F-C deferral; does NOT gate the fix)
+
+- [ ] 0.1 Reproduce against the dev-cohort workspace clone. Capture:
+  - `git log origin/<branch>` shows the `.c4` commit landed on origin.
+  - `git -C <clone> rev-list --count @{u}..HEAD` and `git -C <clone> status` show why `git pull --ff-only` did not advance the working tree.
+  - the `SyncWorkspaceResult` the C4 save returned (`ok:true` no-op vs `SYNC_FAILED`).
+- [ ] 0.2 Record the dominant hypothesis (H1 diverged-clone abort / H2 propagation lag / H3 concurrency / H4 wrong upstream) in the PR body. This drives the F-C tracking-issue scope, not the F-A1/F-B implementation.
+- [ ] 0.3 Open Code-Review overlap check: `gh issue list --label code-review --state open --json number,title,body --limit 200`, grep bodies for `c4-shared.tsx`, `c4-writer.ts`, `app/api/kb/c4/`. Record fold-in / acknowledge / defer (or `None`).
+
+## Phase 1 — RED (failing tests first)
+
+- [ ] 1.1 `apps/web-platform/test/c4-code-panel.test.tsx`: add a failing test — after a PUT 200, the editor reflects the saved source WITHOUT depending on the on-disk clone having advanced (mock `reload()` to return the OLD source; assert the editor shows the NEW saved text).
+- [ ] 1.2 `apps/web-platform/test/c4-code-panel.test.tsx`: add/confirm a test — on a PUT 500 `SYNC_FAILED`, the editor shows the error inline AND retains the user's edited draft (no revert, no `reload()` on failure). (Verify-the-negative confirmed this is already the behavior at `c4-shared.tsx:416/:497-499` — the test pins it against regression from 1.1.)
+- [ ] 1.3 (Only if the writer must echo content) `apps/web-platform/test/c4-writer-rerender.test.ts`: assert `writeC4Diagram` returns the written `content` needed for optimistic apply.
+
+## Phase 2 — GREEN (minimal implementation)
+
+- [ ] 2.1 `apps/web-platform/components/kb/c4-shared.tsx`: on a successful PUT (200), keep the client's `draft` (optimistic apply) instead of resetting it from the `reload()`-fetched `data.sources` (F-A1). Confirm the diagram-staleness path still falls through to the existing Layer-1 banner when the clone lags.
+- [ ] 2.2 `apps/web-platform/components/kb/c4-shared.tsx`: confirm/preserve the non-2xx error-inline-no-reload behavior at `:416/:497-499` (F-B regression guard).
+- [ ] 2.3 (Only if needed for 2.1) `apps/web-platform/server/c4-writer.ts` + `apps/web-platform/app/api/kb/c4/[...path]/route.ts`: return the written `content` to the client. First verify whether the existing `commitSha`/already-sent body suffices before editing the route.
+- [ ] 2.4 (Observability) `apps/web-platform/server/c4-writer.ts`: tie a greppable per-save event to the diverged-clone abort (`SYNC_FAILED` / `self-heal-aborted-dirty`) so the failure mode is dashboard-discoverable.
+
+## Phase 3 — Guards & regression
+
+- [ ] 3.1 Assert NO ungated `reset --hard` was added to any save/sync path; the `@{u}..HEAD == 0` gated self-heal is untouched (un-pushed agent-session work preserved).
+- [ ] 3.2 `apps/web-platform/test/c4-workspace.test.tsx`: regression on the full workspace save flow (source commits, diagram re-renders on a clean clone).
+- [ ] 3.3 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` clean.
+- [ ] 3.4 `cd apps/web-platform && ./node_modules/.bin/vitest run test/c4-code-panel.test.tsx test/c4-writer-rerender.test.ts test/c4-workspace.test.tsx` green.
+
+## Phase 4 — Deferrals
+
+- [ ] 4.1 File the **F-C tracking issue**: workspace-wide shared-clone divergence-recovery gap (best-effort `session-sync` push leaves the clone un-fast-forwardable, degrading EVERY sync consumer) + the H3 `rev-list→reset` TOCTOU (route working-tree git ops through `withWorkspacePermissionLock`). Reference `kb-sync-stale-no-manual-recovery-postmortem.md` and a roadmap milestone. Re-eval: any `self-heal-aborted-dirty` recurrence or a second clone-stuck report.
+
+## Phase 5 — Post-merge (operator)
+
+- [ ] 5.1 Live dogfood on the dev-cohort deployment: C4 KB page → Code tab → edit a label in `model.c4` → Save → confirm the edit persists in the editor AND (after re-render) the diagram updates; if `SYNC_FAILED`, confirm the honest error renders. (Automation not feasible — requires the live operator clone's diverged state, which a synthetic CI clone cannot reproduce.)


### PR DESCRIPTION
## Summary

The C4 Code-tab editor silently reverted `.c4` edits: editing `model.c4` (e.g. `Founder` → `Founder TEST`), clicking **Save**, and the editor snapped back to the pre-edit text with no diagram change. The PUT actually **succeeded** (200, committed to GitHub) — the revert was in the editor's read path.

**Root cause:** after `onSaved`, the parent re-fetches `GET /api/kb/c4/project`, which reads `sources` from the on-disk **workspace clone**. A React effect re-seeded the editor `draft` from `data.sources` on every reload. When the clone is **stale** — a diverged/un-fast-forwardable clone whose self-heal aborts to preserve un-pushed agent-session work, or a Contents-API→fetch replica that hasn't propagated — that source is the **pre-edit text**, so the effect clobbered the editor back to it.

**Fix (F-A1, optimistic apply):** the GitHub commit is the source of truth; the on-disk clone is a cache, and a cache-coherence lag must not present as data loss (same insight as #4976's render-off-tree). Client-side only in `c4-shared.tsx`: pin the just-saved content per file on a confirmed 200, keep it as the editor value until the reloaded source catches up, then release the marker so later external edits apply normally.

## Phase 0 — failure mode (sizes the F-C deferral; does not gate the fix)

- **Dominant hypothesis: H1** (diverged clone → `selfHealNonFastForward` aborts on un-pushed local commits) for the deterministic "every save reverts" symptom; **H2** (Contents-API→fetch replica propagation lag) for the intermittent case. Both are cured identically by F-A1 (the editor no longer depends on the clone advancing).
- Live-clone capture is deferred to the post-merge dogfood — a synthetic CI clone cannot reproduce a perpetually-diverged prod clone. Code-trace confirms the mechanism (`c4-shared.tsx` `[data, activeFile]` re-seed effect).
- The true root cause (perpetually-diverged shared clone recovery + the working-tree git TOCTOU) is a workspace-wide liveness gap, deferred to **Ref #5221**. `server/workspace-sync.ts` is deliberately **untouched** — its gated `@{u}..HEAD` self-heal (never destroy un-pushed work) is preserved.

## Changelog

### Web Platform

- **Fixed:** C4 Code-tab Save no longer reverts the editor when the workspace clone lags behind the just-committed source. The saved text persists optimistically until the clone catches up; the diagram half remains honestly surfaced by the existing Layer-1 staleness banner (#4963).
- A failed save (non-2xx `SYNC_FAILED`) still shows an honest inline error and retains the user's edit (no silent revert) — pinned by a regression test.

## Test plan

- [x] `c4-code-panel.test.tsx`: F-A1 — a 200 save survives a stale reload() (RED-verified), and external edits apply once the clone catches up.
- [x] `c4-code-panel.test.tsx`: F-B — a 500 `SYNC_FAILED` shows the error and keeps the edited draft; `onSaved` (the reload trigger) is never called.
- [x] `tsc --noEmit` clean; C4 suite 28/28; full web-platform vitest suite 9613 passed / 0 failed.
- [x] 8-agent review (no P1/P2 blockers); convergent P2/P3 polish fixed inline (commit history).

Ref #5221

Generated with [Claude Code](https://claude.com/claude-code)
