### PR TITLE
fix(cc): forward tool_progress to client on cc surface (terminal error bubble on >90s single tool)

### DIFF
--- a/apps/web-platform/server/cc-dispatcher.ts
+++ b/apps/web-platform/server/cc-dispatcher.ts
@@ -141,7 +141,7 @@ import { buildAgentQueryOptions } from "./agent-runner-query-options";
 // (the only verified sandbox-readable allowWrite dir); the token rides
 // GIT_INSTALLATION_TOKEN env, never the script body. NEVER logged.
 import { writeAskpassScriptTo } from "./git-auth";
-import { buildToolUseWSMessage } from "./tool-labels";
+import { buildToolProgressWSMessage, buildToolUseWSMessage } from "./tool-labels";
 import {
   getBashApprovalCache,
   _resetBashApprovalCacheForTests,
@@ -2445,6 +2445,14 @@ export async function dispatchSoleurGo(
     }
   }
 
+  // #5214 — per-`toolUseId` debounce for the `tool_progress` forward. The SDK
+  // emits heartbeats every few seconds; the client only needs one per 5s to
+  // reset its 45s watchdog. Scoped to THIS dispatch (per-call cleanup model —
+  // no module-level cache, so no eviction concern) and keyed by `toolUseId` so
+  // separate tools don't share a window. Mirrors `agent-runner.ts:1864-1865`.
+  const TOOL_PROGRESS_DEBOUNCE_MS = 5_000;
+  const toolProgressLastSentAt = new Map<string, number>();
+
   const events: DispatchEvents = {
     onText: (text) => {
       // #3603 W8 — replace, not append. Mirrors chat-state-machine REPLACE
@@ -2469,6 +2477,38 @@ export async function dispatchSoleurGo(
         conversationId,
         send: (frame) => sendToClient(userId, frame),
       });
+    },
+    onToolProgress: (block) => {
+      // #5214 — forward the runner's mid-tool heartbeat to the client so the
+      // client-side stuck-watchdog (STUCK_TIMEOUT_MS, 45s) is fed during a
+      // long single-tool execution. Without this, a >90s tool flips the
+      // cc_router bubble to a terminal `error` state. Mirrors the legacy
+      // agent-runner forward (agent-runner.ts:1928-1946).
+      //
+      // Debounce per `toolUseId`: the first heartbeat for a tool always
+      // forwards; subsequent heartbeats wait for the 5s window to elapse.
+      const now = Date.now();
+      const last = toolProgressLastSentAt.get(block.toolUseId);
+      if (last === undefined || now - last >= TOOL_PROGRESS_DEBOUNCE_MS) {
+        toolProgressLastSentAt.set(block.toolUseId, now);
+        // `buildToolProgressWSMessage` pins the #2138 invariant: the raw SDK
+        // tool name is routed through `buildToolLabel` (human label only) and
+        // never placed on the wire. Shared with the `tool_use` forward shape.
+        sendToClient(
+          userId,
+          buildToolProgressWSMessage({
+            toolName: block.toolName,
+            elapsedSeconds: block.elapsedSeconds,
+            toolUseId: block.toolUseId,
+            workspacePath,
+            leaderId: CC_ROUTER_LEADER_ID,
+          }),
+        );
+      }
+      // NO debug-event emit for `tool_progress`: it is a heartbeat with no
+      // displayable payload, and `debugEventSchema.kind` has no `tool_progress`
+      // variant (ws-zod-schemas.ts). Parity with agent-runner, which also does
+      // not mirror heartbeats to the debug panel. Do not "fix" this omission.
     },
     onToolUse: (block) => {
       // #2909 FR2 — silent-failure mirror for unregistered platform tools.

--- a/apps/web-platform/server/soleur-go-runner.ts
+++ b/apps/web-platform/server/soleur-go-runner.ts
@@ -889,6 +889,12 @@ export interface DispatchEvents {
    * its own inline forward) and existing tests ignore it; the runner's
    * `try/catch` around the invocation routes throws to Sentry rather than
    * blocking the stream.
+   *
+   * **Load-bearing precondition:** these heartbeats only reach `consumeStream`
+   * because `includePartialMessages: true` is set in the shared query options
+   * (`agent-runner-query-options.ts`). A flip there silently stops every
+   * `tool_progress` (and thus this callback) for BOTH surfaces — grep-anchor
+   * for the cadence-invariant risk.
    */
   onToolProgress?: (block: {
     toolUseId: string;

--- a/apps/web-platform/server/soleur-go-runner.ts
+++ b/apps/web-platform/server/soleur-go-runner.ts
@@ -863,6 +863,38 @@ export interface DispatchEvents {
    * no-op test cases.
    */
   onSessionIdCaptured?: (sessionId: string) => void;
+  /**
+   * #5214 — mid-tool forward-progress heartbeat. Fires once per SDK
+   * `SDKToolProgressMessage` consumed in `consumeStream`, carrying the RAW
+   * SDK fields (`toolUseId` / `toolName` / `elapsedSeconds`). The cc-dispatcher
+   * wires this to a `tool_progress` WS event so the client-side stuck-watchdog
+   * (`STUCK_TIMEOUT_MS`, 45s) is heartbeat-fed during a long single-tool
+   * execution — without it, a >90s tool flips the cc_router bubble to a
+   * terminal `error` state. Mirrors the legacy `agent-runner.ts:1889-1948`
+   * forward, but factored across the runner/dispatcher seam.
+   *
+   * **Cadence:** fires at SDK cadence — un-debounced, every `tool_progress`
+   * message the SDK yields (typically every few seconds). Consumers MUST
+   * debounce before hitting the socket (the cc-dispatcher applies a 5s
+   * per-`toolUseId` debounce); a future second consumer that forgets to
+   * debounce would spam the WS channel.
+   *
+   * **Information-disclosure (#2138 / PR #2115):** `toolName` is the RAW SDK
+   * tool name — the runner does NOT label it. Routing it through
+   * `buildToolLabel` (human label only) is the DISPATCHER's responsibility at
+   * the emit boundary (`buildToolProgressWSMessage`), exactly as the
+   * `onToolUse` forward does. The raw name must NEVER reach the wire.
+   *
+   * Optional + fire-and-forget: non-cc callers (the legacy agent-runner has
+   * its own inline forward) and existing tests ignore it; the runner's
+   * `try/catch` around the invocation routes throws to Sentry rather than
+   * blocking the stream.
+   */
+  onToolProgress?: (block: {
+    toolUseId: string;
+    toolName: string;
+    elapsedSeconds: number;
+  }) => void;
 }
 
 export interface DispatchArgs {
@@ -2188,10 +2220,59 @@ export function createSoleurGoRunner(deps: SoleurGoRunnerDeps): SoleurGoRunner {
           // these heartbeats arriving). Plan:
           // knowledge-base/project/plans/2026-06-12-fix-concierge-stream-timeout-debug-scroll-plan.md.
           //
-          // Deliberately reads NO fields off the message (a pure re-arm), so
-          // it does NOT replicate `agent-runner.ts:1901-1948`'s runtime
-          // shape-guard — there is nothing to validate.
+          // The re-arm runs FIRST and unconditionally on any `tool_progress`
+          // (even a malformed one): the message itself proves the tool is
+          // alive, so re-arming is strictly safer than dropping it. NEVER touch
+          // `state.turnHardCap`: the 10-min absolute ceiling stays anchored on
+          // `firstToolUseAt` (chatty-stall defense, PR #3225).
           if (!state.closed && !state.awaitingUser) armRunaway(state);
+
+          // #5214 — AFTER the re-arm, emit a `tool_progress` DispatchEvent so
+          // the cc-dispatcher can forward a heartbeat to the client (feeds the
+          // 45s client-side stuck-watchdog during a long single tool). Runtime
+          // shape-guard the SDK payload (mirrors `agent-runner.ts:1901-1927`):
+          // a missing `tool_use_id` would poison the dispatcher's debounce map
+          // with `undefined` as the key. On a shape mismatch, mirror to Sentry
+          // and skip ONLY the emit — NOT the re-arm above (the intentional
+          // divergence from agent-runner, which `continue`s past both). The
+          // RAW `tool_name` is passed through unlabeled; the dispatcher routes
+          // it through `buildToolLabel` at the emit boundary (#2138).
+          const progress = msg as Partial<{
+            tool_use_id: string;
+            tool_name: string;
+            elapsed_time_seconds: number;
+          }>;
+          const toolUseId = progress.tool_use_id;
+          const toolName = progress.tool_name;
+          const elapsedSeconds = progress.elapsed_time_seconds;
+          if (
+            typeof toolUseId !== "string" ||
+            !toolUseId ||
+            typeof toolName !== "string" ||
+            typeof elapsedSeconds !== "number"
+          ) {
+            reportSilentFallback(null, {
+              feature: "soleur-go-runner",
+              op: "tool-progress-shape",
+              message: "SDKToolProgressMessage missing required fields",
+              extra: {
+                conversationId: state.conversationId,
+                hasToolUseId: typeof toolUseId === "string" && !!toolUseId,
+                hasToolName: typeof toolName === "string",
+                hasElapsed: typeof elapsedSeconds === "number",
+              },
+            });
+          } else {
+            try {
+              state.events.onToolProgress?.({ toolUseId, toolName, elapsedSeconds });
+            } catch (err) {
+              reportSilentFallback(err, {
+                feature: "soleur-go-runner",
+                op: "onToolProgress",
+                extra: { conversationId: state.conversationId },
+              });
+            }
+          }
         }
         // Other SDKMessage variants (partial assistant, hook, task notifications)
         // are ignored at V1. V2 will route stream_event → WS cumulative deltas.

--- a/apps/web-platform/server/tool-labels.ts
+++ b/apps/web-platform/server/tool-labels.ts
@@ -278,3 +278,30 @@ export function buildToolUseWSMessage(args: {
     label: buildToolLabel(args.name, args.input, args.workspacePath),
   };
 }
+
+/**
+ * #5214 — build the canonical `tool_progress` heartbeat WS message for the
+ * cc-dispatcher's `onToolProgress` forward. Shared in `tool-labels.ts` for the
+ * same reason as {@link buildToolUseWSMessage} (#3235): a future schema change
+ * to the `tool_progress` wire shape flows through one edit. Pins the #2138
+ * invariant — the raw SDK `toolName` is routed through `buildToolLabel` (human
+ * label only) and is intentionally NOT placed on the wire (information-
+ * disclosure mitigation, see PR #2115). `SDKToolProgressMessage` carries no
+ * `tool_input`, so `buildToolLabel(toolName, undefined, …)` falls to
+ * `FALLBACK_LABELS` — a fine heartbeat label (mirrors `agent-runner.ts:1944`).
+ */
+export function buildToolProgressWSMessage(args: {
+  toolName: string;
+  elapsedSeconds: number;
+  toolUseId: string;
+  workspacePath: string | undefined;
+  leaderId: DomainLeaderId;
+}): WSMessage {
+  return {
+    type: "tool_progress",
+    leaderId: args.leaderId,
+    toolUseId: args.toolUseId,
+    toolName: buildToolLabel(args.toolName, undefined, args.workspacePath),
+    elapsedSeconds: args.elapsedSeconds,
+  };
+}

--- a/apps/web-platform/test/cc-dispatcher-tool-progress-forwarding.test.ts
+++ b/apps/web-platform/test/cc-dispatcher-tool-progress-forwarding.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// #5214 — RED tests for the two-layer cc-surface `tool_progress` forward.
+//
+// Server layer 1 (runner): `soleur-go-runner.ts` must EMIT an `onToolProgress`
+// DispatchEvent (shape-guarded) from its `tool_progress` branch, in addition
+// to the existing watchdog re-arm.
+// Server layer 2 (dispatcher): `cc-dispatcher.ts` must WIRE `events.onToolProgress`
+// to `sendToClient(buildToolProgressWSMessage(...))`, debounced ≤1/5s per
+// `toolUseId`, mirroring `agent-runner.ts:1889-1948`.
+//
+// The downstream client consumer (`chat-state-machine.ts:490`, the
+// `tool_progress` WS variant, `ws-constants.ts`) is ALREADY complete — its
+// regression-lock lives in `cc-soleur-go-tool-progress-no-terminal-error.test.ts`.
+//
+// The dispatcher-layer mock header mirrors `cc-dispatcher.test.ts` (the
+// `cc-dispatcher-harness.ts` factories). The runner-layer tests reuse the
+// `soleur-go-fixtures.ts` harness and drive a real `createSoleurGoRunner` with
+// an injected mock query — no SDK, no dispatcher.
+
+const {
+  mockReportSilentFallback,
+  mockFetchUserWorkspacePath,
+  mockMessagesInsert,
+  mockUpdateConversationFor,
+  mockMirrorP0Deduped,
+} = vi.hoisted(() => ({
+  mockReportSilentFallback: vi.fn(),
+  mockFetchUserWorkspacePath: vi.fn(),
+  mockMessagesInsert: vi.fn().mockResolvedValue({ error: null }),
+  mockUpdateConversationFor: vi.fn().mockResolvedValue({ ok: true }),
+  mockMirrorP0Deduped: vi.fn(),
+}));
+
+vi.mock("@/server/conversation-writer", async () => {
+  const { conversationWriterFactory } = await import(
+    "@/test/helpers/cc-dispatcher-harness"
+  );
+  return conversationWriterFactory({ mockUpdateConversationFor });
+});
+
+vi.mock("@/server/observability", async () => {
+  const { observabilityFactory } = await import(
+    "@/test/helpers/cc-dispatcher-harness"
+  );
+  return observabilityFactory({
+    mockReportSilentFallback,
+    mockMirrorP0Deduped,
+    withTtlDedupWrapper: true,
+  });
+});
+
+vi.mock("@/server/cost-writer", async () => {
+  const { costWriterFactory } = await import(
+    "@/test/helpers/cc-dispatcher-harness"
+  );
+  return costWriterFactory();
+});
+
+vi.mock("@/server/kb-document-resolver", async () => {
+  const { kbDocumentResolverFactory } = await import(
+    "@/test/helpers/cc-dispatcher-harness"
+  );
+  return kbDocumentResolverFactory({ mockFetchUserWorkspacePath });
+});
+
+vi.mock("@/lib/supabase/tenant", async () => {
+  const { supabaseTenantFactory } = await import(
+    "@/test/helpers/cc-dispatcher-harness"
+  );
+  return supabaseTenantFactory({
+    mockMessagesInsert,
+    mockConversationWorkspaceId: "ws-A",
+  });
+});
+
+vi.mock("@/lib/supabase/service", async () => {
+  const { supabaseServiceFactory } = await import(
+    "@/test/helpers/cc-dispatcher-harness"
+  );
+  return supabaseServiceFactory({
+    mockMessagesInsert,
+    mockConversationWorkspaceId: "ws-A",
+  });
+});
+
+import {
+  dispatchSoleurGo,
+  __resetDispatcherForTests,
+  __setCcRunnerForTests,
+} from "@/server/cc-dispatcher";
+import { __resetMirrorP0DedupForTests } from "@/server/observability";
+import { createSoleurGoRunner } from "@/server/soleur-go-runner";
+import {
+  createMockQueryScripted as createMockQuery,
+  makeAssistant,
+  makeToolProgress,
+  makeRecordingEvents as makeEvents,
+  flushMicrotasks,
+} from "./helpers/soleur-go-fixtures";
+import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+
+// ---------------------------------------------------------------------------
+// Server layer 1 — the runner emits `onToolProgress`
+// ---------------------------------------------------------------------------
+
+describe("soleur-go-runner — emits onToolProgress heartbeat (server layer 1)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockReportSilentFallback.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Test #1 — the runner's `tool_progress` branch invokes `onToolProgress`
+  // with the RAW SDK fields (toolUseId/toolName/elapsedSeconds). RAW because
+  // label routing is the DISPATCHER's job (#2138 invariant lives at the emit
+  // boundary, not the runner). RED: no `onToolProgress` callback exists yet.
+  it("Test #1: invokes onToolProgress with the raw SDK tool fields", async () => {
+    vi.setSystemTime(0);
+    const mock = createMockQuery();
+    const runner = createSoleurGoRunner({
+      queryFactory: () => mock.query,
+      now: () => Date.now(),
+      wallClockTriggerMs: 10_000,
+    });
+    const events = makeEvents();
+
+    await runner.dispatch({
+      conversationId: "conv-1",
+      userId: "u1",
+      userMessage: "summarize this pdf",
+      currentRouting: { kind: "soleur_go_pending" },
+      events,
+      persistActiveWorkflow: vi.fn().mockResolvedValue(undefined),
+    });
+
+    mock.emit(makeToolProgress("tu-1", 5));
+    await flushMicrotasks();
+
+    expect(events._progress).toHaveLength(1);
+    expect(events._progress[0]).toEqual({
+      toolUseId: "tu-1",
+      // RAW name at the runner boundary — `makeToolProgress` uses "Read".
+      toolName: "Read",
+      elapsedSeconds: 5,
+    });
+    expect(mockReportSilentFallback).not.toHaveBeenCalled();
+  });
+
+  // Test #4 — a malformed `tool_progress` (missing `tool_use_id`) is dropped
+  // by the runtime shape-guard (no emit + a `tool-progress-shape` Sentry
+  // mirror), BUT the watchdog re-arm STILL fires. POSITIVE CONTROL: the
+  // re-arm survives the malformed message, so a `runner_runaway` does NOT
+  // fire after a fresh idle window — proving the shape-guard skips ONLY the
+  // emit, not the re-arm (the intentional divergence from agent-runner, which
+  // `continue`s past both on a shape fail).
+  it("Test #4: malformed tool_progress → no emit + Sentry mirror, but re-arm still fires", async () => {
+    vi.setSystemTime(0);
+    const mock = createMockQuery();
+    const runner = createSoleurGoRunner({
+      queryFactory: () => mock.query,
+      now: () => Date.now(),
+      wallClockTriggerMs: 10_000,
+    });
+    const events = makeEvents();
+
+    await runner.dispatch({
+      conversationId: "conv-4",
+      userId: "u1",
+      userMessage: "summarize",
+      currentRouting: { kind: "soleur_go_pending" },
+      events,
+      persistActiveWorkflow: vi.fn().mockResolvedValue(undefined),
+    });
+
+    // Arm the 10s idle window at t=0 with a real tool_use.
+    mock.emit(
+      makeAssistant({
+        content: [
+          { type: "tool_use", id: "tu-1", name: "Read", input: { file_path: "/x.pdf" } },
+        ],
+      }),
+    );
+    await flushMicrotasks();
+
+    // At t=8s, a MALFORMED tool_progress (no tool_use_id) — the sole
+    // tool_progress in this test, so the "no forward" assertion is
+    // attributable solely to the shape-guard (not a debounce window).
+    vi.advanceTimersByTime(8_000);
+    await flushMicrotasks();
+    const malformed = {
+      type: "tool_progress",
+      tool_name: "Read",
+      elapsed_time_seconds: 8,
+      parent_tool_use_id: null,
+      uuid: "00000000-0000-0000-0000-0000000000cc",
+      session_id: "sess-1",
+      // biome-ignore lint/suspicious/noExplicitAny: malformed SDK fixture (no tool_use_id)
+    } as any as SDKMessage;
+    mock.emit(malformed);
+    await flushMicrotasks();
+
+    // No emit — the shape-guard dropped it.
+    expect(events._progress).toHaveLength(0);
+    // Sentry mirror with the canonical op.
+    const shapeMirrors = mockReportSilentFallback.mock.calls.filter(
+      ([, ctx]) =>
+        ctx?.feature === "soleur-go-runner" && ctx?.op === "tool-progress-shape",
+    );
+    expect(shapeMirrors).toHaveLength(1);
+
+    // POSITIVE CONTROL: the re-arm reset the window at t=8s, so advancing 7s
+    // more (total t=15s) must NOT fire runner_runaway. Under a fix that
+    // skipped the re-arm on malformed, runaway would have fired at t=10s.
+    vi.advanceTimersByTime(7_000);
+    await flushMicrotasks();
+    expect(
+      events._ended.find((e) => e.status === "runner_runaway"),
+    ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Server layer 2 — the dispatcher forwards a `tool_progress` WS message
+// ---------------------------------------------------------------------------
+
+type ToolProgressBlock = {
+  toolUseId: string;
+  toolName: string;
+  elapsedSeconds: number;
+};
+
+interface CapturedEvents {
+  onToolProgress?: (block: ToolProgressBlock) => void;
+}
+
+function makeStubCcRunner(args: {
+  onDispatch: (events: CapturedEvents) => void;
+}) {
+  return {
+    dispatch: vi.fn(async (a: { events: CapturedEvents }) => {
+      // Yield one microtask so the dispatcher's parallel workspace-resolve
+      // `.then` settles before the stub touches the events object (mirrors
+      // the production SDK-construction ordering).
+      await Promise.resolve();
+      args.onDispatch(a.events);
+      return { queryReused: false };
+    }),
+    hasActiveQuery: () => false,
+    activeQueriesSize: () => 0,
+    reapIdle: () => 0,
+    closeConversation: () => {},
+    respondToToolUse: () => false,
+    notifyAwaitingUser: () => {},
+    // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+  } as any;
+}
+
+function captureToolProgressFrames(sendToClient: ReturnType<typeof vi.fn>) {
+  return sendToClient.mock.calls
+    .filter(
+      ([, msg]) =>
+        msg &&
+        typeof msg === "object" &&
+        (msg as { type?: string }).type === "tool_progress",
+    )
+    .map(
+      ([, msg]) =>
+        msg as {
+          type: string;
+          leaderId?: string;
+          toolUseId?: string;
+          toolName?: string;
+          elapsedSeconds?: number;
+        },
+    );
+}
+
+describe("cc-dispatcher — forwards tool_progress WS message (server layer 2)", () => {
+  beforeEach(() => {
+    __resetDispatcherForTests();
+    __resetMirrorP0DedupForTests();
+    mockReportSilentFallback.mockClear();
+    mockFetchUserWorkspacePath.mockReset();
+    mockMessagesInsert.mockClear();
+    mockMessagesInsert.mockResolvedValue({ error: null });
+    mockUpdateConversationFor.mockClear();
+    mockUpdateConversationFor.mockResolvedValue({ ok: true });
+    mockMirrorP0Deduped.mockClear();
+    vi.unstubAllEnvs();
+    vi.stubEnv("CC_PERSIST_USAGE", "");
+    mockFetchUserWorkspacePath.mockResolvedValue("/tmp/claude-XXXX/workspace");
+  });
+
+  // Test #2 — the load-bearing RED for the bug: the dispatcher forwards a
+  // `tool_progress` WS frame on the cc_router leader, routing the raw tool
+  // name through `buildToolLabel` (#2138 invariant — `toolName !== "Read"`).
+  it("Test #2: forwards a tool_progress WS frame with a human label (not the raw name)", async () => {
+    let captured: CapturedEvents | undefined;
+    __setCcRunnerForTests(
+      makeStubCcRunner({ onDispatch: (events) => (captured = events) }),
+    );
+
+    const sendToClient = vi.fn().mockReturnValue(true);
+    await dispatchSoleurGo({
+      userId: "u-tp",
+      conversationId: "conv-tp",
+      userMessage: "summarize this PDF",
+      currentRouting: { kind: "soleur_go_pending" },
+      sendToClient,
+      persistActiveWorkflow: vi.fn().mockResolvedValue(undefined),
+    });
+    await flushMicrotasks();
+
+    expect(captured?.onToolProgress).toBeTypeOf("function");
+    captured!.onToolProgress!({ toolUseId: "tu-1", toolName: "Read", elapsedSeconds: 5 });
+
+    const frames = captureToolProgressFrames(sendToClient);
+    expect(frames).toHaveLength(1);
+    const frame = frames[0]!;
+    expect(frame.leaderId).toBe("cc_router");
+    expect(frame.toolUseId).toBe("tu-1");
+    expect(frame.elapsedSeconds).toBe(5);
+    // #2138 invariant: the raw SDK tool name MUST NOT reach the wire — the
+    // forward routes it through `buildToolLabel` (human label only). "Read"
+    // with no `tool_input` falls to FALLBACK_LABELS.Read ("Reading file...").
+    expect(frame.toolName).not.toBe("Read");
+    expect(frame.toolName).toBe("Reading file...");
+  });
+
+  // Test #3 — debounce: ≤1 forward per 5s per toolUseId. CLOCK-DRIVE: the
+  // debounce compares `Date.now()`, so `vi.setSystemTime()` must advance the
+  // wall clock per heartbeat (mirrors agent-runner precedent
+  // `tool-progress-forwarding.test.ts:204-209`). t=0 forwards, t=2s is
+  // suppressed (<5s), t=6s forwards again → exactly 2 forwards.
+  it("Test #3: debounces to <=1 forward / 5s / toolUseId (clock-driven)", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(0);
+      let captured: CapturedEvents | undefined;
+      __setCcRunnerForTests(
+        makeStubCcRunner({ onDispatch: (events) => (captured = events) }),
+      );
+
+      const sendToClient = vi.fn().mockReturnValue(true);
+      await dispatchSoleurGo({
+        userId: "u-tp3",
+        conversationId: "conv-tp3",
+        userMessage: "long read",
+        currentRouting: { kind: "soleur_go_pending" },
+        sendToClient,
+        persistActiveWorkflow: vi.fn().mockResolvedValue(undefined),
+      });
+      await flushMicrotasks();
+      expect(captured?.onToolProgress).toBeTypeOf("function");
+
+      vi.setSystemTime(0);
+      captured!.onToolProgress!({ toolUseId: "tu-1", toolName: "Read", elapsedSeconds: 0 });
+      vi.setSystemTime(2_000);
+      captured!.onToolProgress!({ toolUseId: "tu-1", toolName: "Read", elapsedSeconds: 2 });
+      vi.setSystemTime(6_000);
+      captured!.onToolProgress!({ toolUseId: "tu-1", toolName: "Read", elapsedSeconds: 6 });
+
+      const frames = captureToolProgressFrames(sendToClient);
+      // t=0 (first always forwards) + t=6s (>=5s window) — NOT t=2s (<5s).
+      expect(frames).toHaveLength(2);
+      expect(frames[0]!.elapsedSeconds).toBe(0);
+      expect(frames[1]!.elapsedSeconds).toBe(6);
+
+      // A DISTINCT toolUseId forwards independently (its own first-heartbeat).
+      vi.setSystemTime(6_500);
+      captured!.onToolProgress!({ toolUseId: "tu-2", toolName: "Read", elapsedSeconds: 1 });
+      const after = captureToolProgressFrames(sendToClient);
+      expect(after).toHaveLength(3);
+      expect(after[2]!.toolUseId).toBe("tu-2");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/web-platform/test/cc-soleur-go-tool-progress-no-terminal-error.test.ts
+++ b/apps/web-platform/test/cc-soleur-go-tool-progress-no-terminal-error.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyStreamEvent,
+  applyTimeout,
+  type ChatMessage,
+  type WorkflowLifecycleState,
+  type SpawnIndex,
+} from "@/lib/chat-state-machine";
+import type { DomainLeaderId } from "@/server/domain-leaders";
+
+// #5214 — consumer-contract guards for the cc-surface `tool_progress` forward.
+//
+// NOT RED for the forwarding defect. The `chat-state-machine.ts` consumer
+// (line 490 `case "tool_progress"` + `applyTimeout`) is ALREADY complete and
+// is UNCHANGED by this fix (AC10). These tests run against the unchanged
+// reducer and are GREEN both before and after — their value is
+// regression-locking the consumer contract the new server forward feeds, so a
+// future `chat-state-machine.ts` refactor cannot silently break the heartbeat
+// path. The RED coverage of the actual bug (cc-dispatcher not forwarding)
+// lives in `cc-dispatcher-tool-progress-forwarding.test.ts` (server #1 + #2).
+//
+// Pure reducer drive (no JSX) — mirrors `chat-state-machine.test.ts`; the
+// `cc-soleur-go-end-to-end-render.test.tsx` `replay()` shape, minus render.
+
+interface ReducerState {
+  messages: ChatMessage[];
+  activeStreams: Map<DomainLeaderId, number>;
+  workflow: WorkflowLifecycleState;
+  spawnIndex: SpawnIndex;
+}
+
+function emptyState(): ReducerState {
+  return {
+    messages: [],
+    activeStreams: new Map(),
+    workflow: { state: "idle" },
+    spawnIndex: new Map(),
+  };
+}
+
+type StreamEventArg = Parameters<typeof applyStreamEvent>[2];
+
+function applyEvent(state: ReducerState, ev: StreamEventArg): ReducerState {
+  const r = applyStreamEvent(
+    state.messages,
+    state.activeStreams,
+    ev,
+    state.spawnIndex,
+    state.workflow,
+  );
+  return {
+    messages: r.messages,
+    activeStreams: r.activeStreams,
+    workflow: r.workflow,
+    spawnIndex: r.spawnIndex,
+  };
+}
+
+function applyTimeoutTo(state: ReducerState, leaderId: DomainLeaderId): ReducerState {
+  const r = applyTimeout(state.messages, state.activeStreams, leaderId);
+  return { ...state, messages: r.messages, activeStreams: r.activeStreams };
+}
+
+const CC: DomainLeaderId = "cc_router" as DomainLeaderId;
+
+function streamStart(): StreamEventArg {
+  return { type: "stream_start", leaderId: CC, source: "auto" } as StreamEventArg;
+}
+function toolUse(): StreamEventArg {
+  return { type: "tool_use", leaderId: CC, label: "Reading file..." } as StreamEventArg;
+}
+function toolProgress(elapsedSeconds: number): StreamEventArg {
+  return {
+    type: "tool_progress",
+    leaderId: CC,
+    toolUseId: "tu-1",
+    toolName: "Reading file...",
+    elapsedSeconds,
+  } as StreamEventArg;
+}
+
+describe("cc-soleur-go tool_progress consumer-contract (no terminal-error on >90s tool)", () => {
+  // Test #5 — a >90s single tool that emits `tool_progress` does NOT flip the
+  // cc_router bubble to terminal `error`, because the heartbeat resets the
+  // consecutive-timeout counter (clears `retrying`). Without the forward, the
+  // second timeout would reach `applyTimeout` stage-2 and evict the leader.
+  it("Test #5: heartbeat between two timeouts prevents the terminal-error flip + eviction", () => {
+    let state = applyEvent(emptyState(), streamStart());
+    state = applyEvent(state, toolUse());
+    const idx = state.activeStreams.get(CC)!;
+    expect(state.messages[idx].state).toBe("tool_use");
+
+    // First 45s timeout → retrying (bubble stays active).
+    state = applyTimeoutTo(state, CC);
+    expect(state.messages[idx].retrying).toBe(true);
+
+    // A `tool_progress` heartbeat arrives (tool still alive) → clears retrying.
+    state = applyEvent(state, toolProgress(50));
+    expect(state.messages[idx].retrying).toBeUndefined();
+
+    // The NEXT timeout is therefore a FIRST timeout again (retrying was
+    // cleared) — it must NOT flip to terminal error or evict the leader.
+    state = applyTimeoutTo(state, CC);
+    expect(state.messages[idx].state).not.toBe("error");
+    expect(state.activeStreams.has(CC)).toBe(true);
+  });
+
+  // Test #6 — distinct contribution: the first-timeout `retrying: true` flag
+  // is CLEARED by a `tool_progress` event. (The "no chip spawn on
+  // tool_progress" half is already covered by
+  // `cc-soleur-go-end-to-end-render.test.tsx:176-187` — not duplicated.)
+  it("Test #6: tool_progress clears the first-timeout retrying flag", () => {
+    let state = applyEvent(emptyState(), streamStart());
+    state = applyEvent(state, toolUse());
+    const idx = state.activeStreams.get(CC)!;
+
+    state = applyTimeoutTo(state, CC);
+    expect(state.messages[idx].retrying).toBe(true);
+
+    state = applyEvent(state, toolProgress(46));
+    expect(state.messages[idx].retrying).toBeUndefined();
+    // Bubble stays active — heartbeat does not terminate or evict.
+    expect(state.messages[idx].state).not.toBe("error");
+    expect(state.activeStreams.has(CC)).toBe(true);
+  });
+
+  // Test #7 — control / regression-preserving: a tool that emits NO
+  // `tool_progress` and times out twice STILL flips to terminal `error` and
+  // evicts the leader. Proves the fix does not relax genuine-failure
+  // detection (defense-pair).
+  it("Test #7: NO heartbeat → two timeouts still flip to terminal error + evict", () => {
+    let state = applyEvent(emptyState(), streamStart());
+    state = applyEvent(state, toolUse());
+    const idx = state.activeStreams.get(CC)!;
+
+    // First timeout → retrying.
+    state = applyTimeoutTo(state, CC);
+    expect(state.messages[idx].retrying).toBe(true);
+
+    // Second consecutive timeout (no heartbeat cleared retrying) → terminal.
+    state = applyTimeoutTo(state, CC);
+    expect(state.messages[idx].state).toBe("error");
+    expect(state.activeStreams.has(CC)).toBe(false);
+  });
+});

--- a/apps/web-platform/test/helpers/soleur-go-fixtures.ts
+++ b/apps/web-platform/test/helpers/soleur-go-fixtures.ts
@@ -402,17 +402,33 @@ export function createMockQueryLean(sessionId = "sess-1") {
 export function makeRecordingEvents(): DispatchEvents & {
   _ended: WorkflowEnd[];
   _tools: Array<{ name: string; input: Record<string, unknown> }>;
+  _progress: Array<{
+    toolUseId: string;
+    toolName: string;
+    elapsedSeconds: number;
+  }>;
 } {
   const ended: WorkflowEnd[] = [];
   const tools: Array<{ name: string; input: Record<string, unknown> }> = [];
+  // #5214 — captures `onToolProgress` heartbeat emits (raw, un-debounced at
+  // the runner boundary). Call sites that ignore progress simply never read
+  // `_progress`; the optional `onToolProgress` field keeps existing recorders
+  // behavior-neutral.
+  const progress: Array<{
+    toolUseId: string;
+    toolName: string;
+    elapsedSeconds: number;
+  }> = [];
   return {
     onText: () => {},
     onToolUse: (b) => tools.push(b),
+    onToolProgress: (b) => progress.push(b),
     onWorkflowDetected: () => {},
     onWorkflowEnded: (e) => ended.push(e),
     onResult: () => {},
     _ended: ended,
     _tools: tools,
+    _progress: progress,
   };
 }
 

--- a/knowledge-base/engineering/operations/post-mortems/cc-tool-progress-terminal-error-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/cc-tool-progress-terminal-error-postmortem.md
@@ -1,0 +1,135 @@
+---
+title: "Concierge cc surface flips chat bubble to terminal error on >90s single tool (tool_progress not forwarded)"
+date: 2026-06-12
+incident_pr: "#5223"
+incident_window: "Latent since the cc/soleur-go surface shipped without tool_progress client-forwarding; user-reachability raised by PR #5208 (server idle-watchdog re-arm). No discrete outage window — defect identified in review, not via a production alert."
+recovery_at: "On merge of #5223 (2026-06-12)."
+suspected_change: "cc-dispatcher.ts delegates the SDK stream to soleur-go-runner.ts, whose tool_progress branch was a pure server-watchdog re-arm that emitted no client event. PR #5208 kept the server stream alive longer, raising how often the >90s path reaches the client's second-timeout terminal logic."
+brand_survival_threshold: single-user incident
+status: resolved
+triggers:
+  - "Surfaced during PR #5208 review by user-impact-reviewer; deferred as review-origin scope-out #5214 with re-eval by 2026-07-12."
+art_33_triggered: false
+art_34_triggered: false
+art_33_deadline: "n/a — no personal-data confidentiality/availability breach; this is a UI-correctness defect on the conversation surface (no data exposure, loss, or unauthorized access)."
+---
+
+## Actor key
+
+- `agent` — Claude Code did this autonomously (no operator ack required).
+- `agent-with-ack` — Claude Code did this AFTER operator confirmed via menu option per `hr-menu-option-ack-not-prod-write-auth`.
+- `human` — Operator did this directly.
+
+# Incident Overview
+
+On the Concierge (cc / `soleur-go`) chat surface, the server did not forward SDK `tool_progress` heartbeats to the client. The client-side stuck-watchdog (`STUCK_TIMEOUT_MS`, 45s) was therefore not heartbeat-fed during a long single-tool execution. On a >90s single tool (routine `Read`/`Bash`/web-search on large input) the client timed out twice and drove the chat bubble to a terminal `error` state, evicting the leader from `activeStreams`; the eventual real answer then rendered as a new bubble appended below the orphaned error bubble — the user saw "the agent failed" immediately followed by the answer.
+
+The defect was a latent residual identified in PR #5208's review (user-impact-reviewer) and deferred as scope-out #5214 — it was never reported as a live production incident, but it is reachable on routine traffic on the product's core conversation surface, so it meets the operator's "any detected incident gets a post-mortem" standing rule.
+
+## Status
+
+resolved — fixed in the source PR (#5223) before reaching a user-reported failure.
+
+## Symptom
+
+A >90s single-tool Concierge turn paints a terminal "the agent failed" error bubble, immediately followed by the correct answer rendered as a separate orphaned bubble below it.
+
+## Incident Timeline
+
+- **Start time (detected):** 2026-06-11 (PR #5208 review, user-impact-reviewer flagged the residual)
+- **End time (recovered):** 2026-06-12 (merge of #5223)
+- **Duration (MTTR):** ~1 day from detection-in-review to fix (no live-outage clock — defect never fired a production alert).
+
+Order of events (load-bearing: the redaction sentinel scans this table; the Actor key feeds the Actor column):
+
+| Actor | Time (UTC) | Action |
+|---|---|---|
+| agent | 2026-06-11 | PR #5208 review (user-impact-reviewer) surfaces the client-side 45s-watchdog residual on the cc surface; filed as deferred-scope-out #5214. |
+| agent | 2026-06-12 | Root-caused via 2-file code trace: cc-dispatcher delegates to soleur-go-runner whose tool_progress branch is a pure re-arm (no client emit). |
+| agent | 2026-06-12 | Two-layer fix implemented (runner emits onToolProgress; cc-dispatcher forwards debounced) and merged via #5223. |
+
+## Participants and Systems Involved
+
+Concierge (cc / `soleur-go`) chat surface: `apps/web-platform/server/cc-dispatcher.ts`, `apps/web-platform/server/soleur-go-runner.ts`, `apps/web-platform/server/tool-labels.ts`, and the client reducer `apps/web-platform/lib/chat-state-machine.ts` (consumer — unchanged). Driven autonomously by Claude Code (`agent`).
+
+## Detection (+ MTTD)
+
+- **How detected:** code review (PR #5208 user-impact-reviewer), NOT a monitoring alert or external user report. The defect is silent to Sentry — it manifests only as a transient UI bubble-state flip.
+- **MTTD (mean time to detect):** the residual existed since the cc surface shipped without tool_progress forwarding; it was detected the first time a reviewer enumerated the >90s-single-tool failure mode against the cc surface (PR #5208).
+
+## Triggered by
+
+system — an architectural gap (the cc runner consumed `tool_progress` for a server-side re-arm only and never emitted a client event), with reachability amplified by an upstream fix (PR #5208's server idle-watchdog re-arm keeping the stream alive longer).
+
+## Root-cause hypothesis (triage)
+
+| Hypothesis | Supporting evidence | Disconfirming evidence | Status |
+|---|---|---|---|
+| cc-dispatcher never forwards tool_progress; the runner swallows it | `git grep tool_progress cc-dispatcher.ts` returned zero forward sites; runner branch comment said "reads NO fields (a pure re-arm)" | none | confirmed |
+| The issue's prescribed "one-line forward at cc-dispatcher.ts:2107" would fix it | — | cc-dispatcher wires DispatchEvents callbacks; it does not iterate SDK messages — a lone sendToClient line would have nothing to call | rejected (two-layer fix required) |
+
+## Resolution
+
+Two-layer fix mirroring the legacy `agent-runner.ts:1889-1948` forward, split across the runner/dispatcher seam: the runner emits a shape-guarded `onToolProgress` DispatchEvent (after the existing `armRunaway` re-arm); `cc-dispatcher.ts` forwards it via `buildToolProgressWSMessage` (routing the raw tool name through `buildToolLabel`, #2138) debounced 5s per `toolUseId`. The client consumer, `tool_progress` WS variant, and zod schema already existed for the agent-runner surface and were reused unchanged.
+
+## Recovery verification
+
+7 new tests green (4 server: runner emit, dispatcher WS-shape, debounce clock-drive, shape-guard + positive-control; 3 client consumer-contract guards) + full `apps/web-platform` vitest suite green (9681 passed) + `tsc --noEmit` clean. Control test #7 proves a genuinely hung tool (no heartbeat) STILL flips to terminal error after two timeouts — genuine-failure detection is preserved, not relaxed.
+
+---
+
+# Incident Post-Mortem Analysis
+
+## Root Cause(s) — 5-Whys
+
+1. Why did the bubble flip to terminal error? The client watchdog timed out twice on a >90s tool. → 2. Why did it time out? It received no heartbeat to reset `STUCK_TIMEOUT_MS`. → 3. Why no heartbeat? The cc surface never forwarded SDK `tool_progress` to the client. → 4. Why not? The cc runner's `tool_progress` branch was a pure server-side watchdog re-arm that read no fields and emitted no DispatchEvent, and cc-dispatcher had no `onToolProgress` wiring. → 5. Why was this only now reachable? PR #5208's server idle-watchdog re-arm kept the stream alive past the point where the server previously tore it down, so the >90s path now reaches the client's second-timeout terminal logic more often (the residual code was unchanged; its user-reachability rose).
+
+## Versions of Components
+
+- **Version(s) that triggered the outage:** every cc-surface build since the surface shipped without tool_progress forwarding (reachability amplified post-PR #5208).
+- **Version(s) that restored the service:** the release cut from #5223.
+
+## Impact details
+
+### Services Impacted
+
+The Concierge (cc / `soleur-go`) conversation surface only. No data, auth, billing, or infra surface touched.
+
+### Customer Impact (by role)
+
+Per learning `2026-05-06-user-impact-section-by-role-not-surface.md` — enumerate by USER ROLE, not by surface.
+
+- Prospect: none.
+- Authenticated app user: on a >90s single-tool Concierge turn, a spurious terminal "the agent failed" bubble appears, immediately followed by the real answer as a separate orphaned bubble — confusing but non-destructive (the answer is delivered; no data is lost).
+- Legal-document signer: none.
+- Admin via Access: none.
+- Billing customer: none.
+- OAuth installation owner: none.
+
+### Revenue Impact
+
+None.
+
+### Team Impact
+
+None beyond the engineering time to fix.
+
+## Lessons Learned
+
+### Where we got lucky
+
+The residual was caught by a reviewer (user-impact-reviewer) enumerating the >90s failure mode during an adjacent PR (#5208), before a user filed a confused "the agent failed but then answered" report.
+
+### What went well
+
+The fix reused an already-complete client contract (the `tool_progress` WS variant + reducer shipped for agent-runner under #2861), so the change was confined to the server forward path with no client-side risk; AC10 git-diff-gated `chat-state-machine.ts`/`ws-constants.ts` as unchanged.
+
+### What went wrong
+
+The cc surface mirrored the agent-runner *consumer* contract but never wired the *producer* — a feature-wiring composition gap where the runner consumed `tool_progress` for one purpose (server re-arm) and silently dropped its client-facing half.
+
+## Action Items & Follow-ups
+
+Every action item and follow-up so this incident cannot recur (save logs, add tests, set up alerts, automation, documentation, code sweeps, PRs).
+
+_No action items — incident fully resolved in the source PR with no residual work._

--- a/knowledge-base/project/learnings/best-practices/2026-06-12-mirror-monolithic-precedent-across-runner-dispatcher-seam.md
+++ b/knowledge-base/project/learnings/best-practices/2026-06-12-mirror-monolithic-precedent-across-runner-dispatcher-seam.md
@@ -1,0 +1,85 @@
+# Learning: mirroring a monolithic precedent across a two-layer seam — emit raw, debounce/label at the transport boundary
+
+## Problem
+
+#5214: the Concierge (cc / `soleur-go`) chat surface did not forward SDK
+`tool_progress` heartbeats to the client, so the 45s client stuck-watchdog
+(`STUCK_TIMEOUT_MS`) was not heartbeat-fed during a long single tool. On a
+>90s tool the client timed out twice and flipped the chat bubble to a terminal
+`error` state, then rendered the real answer in a new bubble below the orphaned
+error bubble.
+
+The issue prescribed a **one-line fix**: "add a `tool_progress` WS forward in
+`cc-dispatcher.ts` (~line 2107) alongside the existing stream/tool_use forwards."
+That premise was wrong in two ways, and taking it literally would have shipped a
+no-op (a `sendToClient` line with nothing to call).
+
+## Solution
+
+Two traces falsified the issue's premise before any code was written:
+
+1. **`cc-dispatcher.ts` does not iterate SDK messages itself.** It wires
+   `DispatchEvents` callbacks (`onText`/`onToolUse`/…) into an `events` object
+   (~line 2448) that it hands to the runner. The line-2107 anchor pointed into a
+   helper region, not the forward site.
+2. **The runner (`soleur-go-runner.ts`) owned the SDK loop and swallowed
+   `tool_progress`.** Its `tool_progress` branch was a *pure re-arm* of the idle
+   watchdog that read no fields and emitted no event. So nothing existed for the
+   dispatcher to forward.
+
+The real fix was **two-layer**, mirroring the legacy `agent-runner.ts:1889-1948`
+forward but split across the runner/dispatcher seam:
+
+- **Runner layer:** add an optional `onToolProgress?` to `DispatchEvents` and
+  EMIT it (shape-guarded) from the `tool_progress` branch, after the existing
+  `armRunaway` re-arm. The runner emits the **RAW** SDK fields at **SDK cadence
+  (un-debounced)**.
+- **Dispatcher layer:** wire `events.onToolProgress` → `sendToClient(...)`,
+  applying the **5s per-`toolUseId` debounce** and routing the raw `toolName`
+  through `buildToolLabel` (shared `buildToolProgressWSMessage`, #2138 invariant).
+
+Everything downstream (the `tool_progress` WS variant, zod schema, ws-client
+passthrough, and the `chat-state-machine.ts:490` consumer) already existed for
+the agent-runner surface and was reused unchanged.
+
+## Key Insight
+
+**When you mirror a monolithic precedent (one inline block doing N things) into
+a codebase that has an architectural seam the precedent lacks, do NOT copy the
+monolith — split the responsibilities across the seam.** `agent-runner.ts`
+inlines emit + debounce + label in one closure because it has no runner/dispatcher
+seam. The cc path does: the runner is **surface-agnostic** (it must work for any
+consumer), so transport policy — cadence (debounce) and wire formatting (label
+routing, #2138) — belongs in the **dispatcher** (the socket consumer), not the
+producer. The architecture review independently rated this split a *better*
+factoring than the precedent: baking 5s/labeling into the runner would be the
+leak, because a future non-WS consumer (test harness, audit sink) wants different
+cadence. Put the cadence contract in JSDoc on the emitting callback so a second
+consumer can't forget to debounce.
+
+Corollary (reinforces an existing rule class): **an issue's prescribed fix
+location/mechanism is a hypothesis, not the work-list.** Grep the literal
+producer and walk the delegation chain (`cc-dispatcher` → `soleur-go-runner`
+`consumeStream`) to the exact determining condition before coding. The "~line
+2107" anchor and "one-line forward" framing were both falsified by a 2-file
+trace. See `2026-06-01-symptom-root-cause-trace-the-actual-redirect-not-the-plan-hypothesis.md`.
+
+## Session Errors
+
+1. **Pre-write hook blocked on the literal `doppler secrets set` in the plan's
+   Phase 2.8 negative-detection prose** (the list asserting infra patterns are
+   absent). — Recovery: added `<!-- iac-routing-ack: plan-phase-2-8-reviewed -->`
+   and rephrased. — Prevention: the `iac-routing-ack` opt-out is the designed
+   escape hatch for negative-detection prose that names infra tokens only to
+   assert their absence; already covered, no new rule.
+2. **Listed a non-existent test file (`test/tool-labels.test.ts`) in a vitest
+   regression invocation** — the runner reported "4 passed" for a 5-file list. —
+   Recovery: `ls` confirmed there is no dedicated tool-labels test (the new
+   `buildToolProgressWSMessage` helper is covered by the forwarding test's
+   WS-shape assertion). — Prevention: glob/verify a test path exists before
+   citing it in a runner command; a silently-absent file inflates the expected
+   suite count.
+
+## Tags
+category: best-practices
+module: apps/web-platform/server (cc-dispatcher, soleur-go-runner, tool-labels)

--- a/knowledge-base/project/plans/2026-06-12-fix-forward-tool-progress-cc-surface-plan.md
+++ b/knowledge-base/project/plans/2026-06-12-fix-forward-tool-progress-cc-surface-plan.md
@@ -1,0 +1,470 @@
+<!-- iac-routing-ack: plan-phase-2-8-reviewed -->
+---
+title: "fix: forward tool_progress to client on cc surface (terminal error bubble on >90s single tool)"
+type: fix
+issue: 5214
+branch: feat-one-shot-fwd-tool-progress-cc-surface-5214
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+created: 2026-06-12
+---
+
+# fix: forward `tool_progress` to client on cc surface 🐛
+
+> Closes #5214. Deferred follow-up filed unconditionally at the ship of PR #5208 /
+> the prior plan `2026-06-12-fix-concierge-stream-timeout-debug-scroll-plan.md`
+> (`## Follow-ups` → "Client 45s watchdog on the cc surface").
+
+## Enhancement Summary
+
+**Deepened on:** 2026-06-12
+**Sections enhanced:** Files to Edit (JSDoc cadence note), Test Strategy (tests #3/#4/#5-#7), Acceptance Criteria (AC5-AC9)
+**Research agents used:** verify-the-negative + precedent-diff + test-compatibility (sonnet), architecture-strategist, test-design-reviewer; local: repo-research-analyst, learnings-researcher
+
+### Key Improvements
+
+1. **Test #3 clock-drive fixed (vacuous-GREEN guard):** the cc-dispatcher debounce
+   compares `Date.now()`; `vi.advanceTimersByTime` alone leaves it at 0 and collapses all
+   emits into one window. Test now drives `vi.setSystemTime()` per heartbeat (precedent
+   `tool-progress-forwarding.test.ts:204-209`).
+2. **Test #4 positive control added:** assert `armRunaway` actually fired (no
+   `runner_runaway` after the idle window), not just that the malformed forward was
+   dropped. Documents the intentional re-arm-on-malformed divergence from agent-runner.
+3. **Client tests re-labeled as consumer-contract guards, not RED:** the
+   `chat-state-machine.ts` consumer is already complete, so #5-#7 are GREEN pre-fix; the
+   real-bug RED coverage lives in server tests #1+#2. Test #6 de-duplicated against the
+   already-shipped chip-no-spawn assertion at `cc-soleur-go-end-to-end-render.test.tsx:176-187`.
+4. **`onToolProgress?` JSDoc cadence contract:** the runner emits at SDK cadence
+   (un-debounced); the JSDoc must instruct consumers to debounce (prevents a future
+   second consumer from spamming the socket).
+
+### New Considerations Discovered
+
+- The shape-guard/debounce seam (guard in runner, debounce in dispatcher) is a *better*
+  factoring than agent-runner's inline both-in-one (transport policy stays out of the
+  surface-agnostic runner) — architecture-strategist confirmed no P0/P1, no drop/duplicate
+  risk, blast radius = the two intended files (agent-runner does NOT use `DispatchEvents`).
+- All 5 plan invariants (raw-name-not-on-wire, consumer-unchanged, WS-variant-exists,
+  cc_router-registered, includePartialMessages-set) verified `confirms` against code.
+- 9 test files construct `DispatchEvents`-shaped objects; none break on the optional-field
+  widening (`tsc --noEmit` clean) — no fixture sweep needed.
+
+## Overview
+
+On the Concierge (cc / `soleur-go`) surface, `apps/web-platform/server/cc-dispatcher.ts`
+does **not** forward SDK `tool_progress` WS events to the client. The client-side
+stuck-watchdog `STUCK_TIMEOUT_MS` (45s, `apps/web-platform/lib/ws-constants.ts:14`)
+is therefore **not heartbeat-fed** during a long single-tool execution — unlike the
+legacy `agent-runner` surface, which forwards `tool_progress` at
+`agent-runner.ts:1889-1948`.
+
+Consequence on a **>90s single tool** (routine for any `Read` / `Bash` / web-search
+on large input):
+
+1. First client timeout at **45s** → the bubble shows the "Retrying…" chip and resets.
+2. A second consecutive timeout at **~90s** drives the client bubble to a **terminal
+   `error`** state (`chat-state-machine.ts` `applyTimeout` stage 2) and evicts the
+   leader from `activeStreams`.
+3. The eventual real answer renders as a **new bubble appended below the orphaned
+   error bubble** — the user sees "the agent failed" immediately followed by the answer.
+
+PR #5208 fixed the **server-side** premature `runner_runaway` by re-arming the server
+idle watchdog on `tool_progress` in `soleur-go-runner.ts:2170`. That is a distinct
+timer and the server fix stands alone — but by keeping the stream alive longer, it
+**increases the reachability** of this client-side residual (the >90s path now reaches
+the client's second-timeout terminal logic more often, no longer masked by a premature
+server teardown). See learning
+`knowledge-base/project/learnings/best-practices/2026-06-12-idle-watchdog-reset-on-sdk-heartbeat-and-upstream-fix-exposes-downstream-timeout.md`.
+
+### Root-cause precision (verified against code, not the issue prose)
+
+The cc surface delegates to `soleur-go-runner.ts` via a runner whose events reach the
+client through `cc-dispatcher.ts`'s `events: DispatchEvents` object. The runner's
+`consumeStream` loop at `soleur-go-runner.ts:2170` **already handles** `tool_progress`,
+but the branch comment is explicit: *"Deliberately reads NO fields off the message (a
+pure re-arm)"* — it re-arms the server watchdog **only** and emits **no DispatchEvent**.
+So nothing reaches the client.
+
+This means the fix is **two-layer**, not a single `sendToClient` line:
+
+- **Runner layer** (`soleur-go-runner.ts`): the `DispatchEvents` interface has no
+  `onToolProgress` callback, and the `tool_progress` branch never invokes one. The
+  runner must EMIT a `tool_progress` event (shape-guarded) in addition to re-arming.
+- **Dispatcher layer** (`cc-dispatcher.ts`): the `events` object passed to
+  `runner.dispatch` (~line 2448) has no `onToolProgress` wiring. It must forward to the
+  client via the existing `tool_progress` WS message variant.
+
+Everything downstream of the dispatcher is **already complete** (no change required):
+
+- The `tool_progress` WS message variant already exists: `lib/types.ts:319`,
+  `lib/ws-zod-schemas.ts:280` (`toolProgressSchema`), `lib/ws-known-types.ts:43`.
+- `lib/ws-client.ts:688` already passes `tool_progress` through to the reducer.
+- `lib/chat-state-machine.ts:490` (`case "tool_progress"`) already (a) resets the
+  watchdog via `timerAction: { type: "reset", leaderId }` and (b) clears the `retrying`
+  chip — and the Stage-4 (#2886) guard ensures it does NOT spawn a chip.
+- `cc_router` is a valid `DomainLeaderId` (`lib/ws-zod-schemas.ts:53`) and the existing
+  cc `tool_use` forward already uses `leaderId: CC_ROUTER_LEADER_ID` successfully — so
+  the consumer's `activeStreams.get("cc_router")` lookup will resolve (it is NOT the
+  "unknown leader inert no-op" branch).
+
+The **load-bearing precondition** holds: the cc path sets `includePartialMessages: true`
+via the shared `buildAgentQueryOptions` (`agent-runner-query-options.ts:160`, consumed by
+`realSdkQueryFactory` at `cc-dispatcher.ts:1214`), so `tool_progress` messages already
+arrive in the runner loop. No SDK option change is needed.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Issue claim | Codebase reality | Plan response |
+| --- | --- | --- |
+| "add a `tool_progress` WS forward in cc-dispatcher.ts (~line 2107) alongside existing stream/tool_use forwards" | cc-dispatcher does NOT iterate SDK messages itself; it wires `DispatchEvents` callbacks (`events.onText`/`onToolUse`/… at ~2448). The runner (`soleur-go-runner.ts`) owns the SDK loop and swallows `tool_progress` (pure re-arm, no event). | Two-layer fix: add `onToolProgress?` to `DispatchEvents` + emit from the runner's `tool_progress` branch (2170); wire `events.onToolProgress` in cc-dispatcher to `sendToClient`. The "~line 2107" anchor is approximate; the real wire-site is the `events` object at ~2448. |
+| "verify chat-state-machine.ts consumer (~line 490) resets STUCK_TIMEOUT_MS on tool_progress" | Verified: `chat-state-machine.ts:490` resets the watchdog AND clears the `retrying` chip; the Stage-4 #2886 guard prevents chip spawn. | **No change** to chat-state-machine. RED tests assert the existing consumer fires once cc-forwarded events arrive. |
+| "wire ws-constants.ts / WS message-type as needed" | The `tool_progress` WS variant + zod schema + ws-client passthrough all already exist (used by agent-runner). `ws-constants.ts` holds only `STUCK_TIMEOUT_MS = 45_000` (no change needed). | **No new WS message type**, **no ws-constants edit**. Reuse the existing `tool_progress` variant. |
+| "mirroring agent-runner" | agent-runner inlines a 5s debounce (`TOOL_PROGRESS_DEBOUNCE_MS = 5_000`, `toolProgressLastSentAt` Map at `agent-runner.ts:1864-1933`) + runtime shape-guard + `buildToolLabel` routing. | Mirror the debounce + shape-guard. Extract a shared `buildToolProgressWSMessage` into `tool-labels.ts` (parity with the #3235 `buildToolUseWSMessage` sharing pattern), so a future schema change is one edit. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** on the Concierge chat surface, a >90s
+single tool (routine `Read`/`Bash`/web-search) paints a terminal "the agent failed"
+error bubble, immediately followed by the real answer rendered as a separate orphaned
+bubble below it — the product's core conversation surface looks broken on routine traffic.
+
+**If this leaks, the user's data is exposed via:** N/A for data leakage — but note the
+**information-disclosure invariant**: the raw SDK `tool_name` must NEVER reach the wire
+(see #2138 / PR #2115). The forward MUST route `tool_name` through `buildToolLabel`
+(human label only), exactly as the `tool_use` forward does. A regression here would leak
+internal tool implementation names to the client.
+
+**Brand-survival threshold:** single-user incident.
+
+> CPO sign-off required at plan time before `/work` begins. The threshold and framing are
+> carried forward verbatim from the prior plan's `## Follow-ups` severity correction
+> (user-impact-reviewer, PR #5208 review). `user-impact-reviewer` will be invoked at
+> review-time per `plugins/soleur/skills/review/SKILL.md`.
+
+## Files to Edit
+
+- `apps/web-platform/server/soleur-go-runner.ts`
+  - Add `onToolProgress?: (block: { toolUseId: string; toolName: string; elapsedSeconds: number }) => void;`
+    to the `DispatchEvents` interface (~798-866), with a JSDoc block mirroring the
+    `onToolResult?` / `onTextTurnEnd?` doc convention (when it fires, why optional,
+    fire-and-forget, the information-disclosure note that raw `tool_name` is routed
+    through `buildToolLabel` at the dispatcher boundary). **The JSDoc MUST state that the
+    callback fires at SDK cadence (un-debounced) — every `tool_progress` message the SDK
+    yields — and that consumers MUST debounce before hitting the socket** (deepen-plan
+    architecture + verify-negative finding: the runner emits raw cadence; cc-dispatcher
+    owns the 5s debounce, so a future second consumer that forgets to debounce would spam).
+  - In the `tool_progress` branch of `consumeStream` (line 2170): AFTER the existing
+    `if (!state.closed && !state.awaitingUser) armRunaway(state);`, extract
+    `tool_use_id` / `tool_name` / `elapsed_time_seconds` with the **same runtime
+    shape-guard** as `agent-runner.ts:1901-1927` (string `toolUseId` non-empty, string
+    `toolName`, number `elapsedSeconds`; on mismatch `reportSilentFallback({ feature:
+    "soleur-go-runner", op: "tool-progress-shape" })` and skip the emit — NOT the
+    re-arm). Invoke `state.events.onToolProgress?.({ toolUseId, toolName, elapsedSeconds })`
+    inside a `try/catch` → `reportSilentFallback({ feature: "soleur-go-runner", op:
+    "onToolProgress" })`, matching the `onTextTurnEnd` invocation pattern (lines 2133-2141).
+    **Update the existing branch comment** ("reads NO fields") to reflect that it now
+    forwards a heartbeat event.
+
+- `apps/web-platform/server/tool-labels.ts`
+  - Add `export function buildToolProgressWSMessage(args: { toolName: string;
+    elapsedSeconds: number; toolUseId: string; workspacePath: string | undefined;
+    leaderId: DomainLeaderId }): WSMessage` returning
+    `{ type: "tool_progress", leaderId, toolUseId, toolName: buildToolLabel(toolName,
+    undefined, workspacePath), elapsedSeconds }`. JSDoc cites #3235 sharing + the #2138
+    raw-name invariant, exactly like `buildToolUseWSMessage` (269-280). `tool_input` is
+    not part of `SDKToolProgressMessage`, so `buildToolLabel(name, undefined, …)` falls
+    to `FALLBACK_LABELS` — fine for a heartbeat label (mirrors `agent-runner.ts:1944`).
+
+- `apps/web-platform/server/cc-dispatcher.ts`
+  - Import `buildToolProgressWSMessage` from `./tool-labels` (the file already imports
+    `buildToolUseWSMessage` at line 144).
+  - In `dispatchSoleurGo`, declare a per-dispatch debounce alongside the `events` object
+    (~before line 2448): `const TOOL_PROGRESS_DEBOUNCE_MS = 5_000;` and
+    `const toolProgressLastSentAt = new Map<string, number>();` (mirrors
+    `agent-runner.ts:1864-1865`; per-dispatch scope matches the per-call cleanup model —
+    no module-level cache, so no eviction concern per learning
+    `2026-05-11-debounce-cache-needs-eviction-and-symmetric-state-reset.md`).
+  - Add an `onToolProgress` property to the `events: DispatchEvents` object that:
+    debounces per `toolUseId` (first heartbeat always forwards; subsequent wait the 5s
+    window), then `sendToClient(userId, buildToolProgressWSMessage({ toolName,
+    elapsedSeconds, toolUseId, workspacePath, leaderId: CC_ROUTER_LEADER_ID }))`.
+  - **Debug-stream parity check (NOT a forward):** the `onText` / `onToolUse` callbacks
+    also `emitDebugEvent`. `tool_progress` is a heartbeat with no displayable payload and
+    the debug panel has no `tool_progress` `kind` (`debugEventSchema.kind` is
+    `["tool_use","reasoning","result"]`, `ws-zod-schemas.ts`); do NOT emit a debug event
+    for `tool_progress` (parity with `agent-runner`, which does not). Note this in a
+    one-line comment so a future reader does not "fix" the omission.
+
+## Files to Create
+
+- `apps/web-platform/test/cc-dispatcher-tool-progress-forwarding.test.ts` — RED tests
+  for the runner-emit + cc-dispatcher-forward path (server side).
+- `apps/web-platform/test/cc-soleur-go-tool-progress-no-terminal-error.test.tsx` — RED
+  tests for the client reducer behavior under a >90s single tool (chat-state-machine via
+  the cc surface), asserting no terminal-error flip and no Retrying chip.
+
+> Both paths must satisfy the vitest `include` globs: `test/**/*.test.ts` (node) and
+> `test/**/*.test.tsx` (happy-dom) — `apps/web-platform/vitest.config.ts:44,60`. Do NOT
+> co-locate under `components/**` (silently never run).
+
+## Test Strategy (RED → GREEN)
+
+Runner is **vitest** via `./node_modules/.bin/vitest run <path>` (NOT `npm -w`).
+Typecheck is `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit`. Fixtures
+`makeToolProgress(toolUseId, elapsedSeconds)` (`test/helpers/soleur-go-fixtures.ts:159`),
+`makeRecordingEvents()`, and `createMockQueryScripted()` already exist. The
+agent-runner precedent suite is `test/tool-progress-forwarding.test.ts` — mirror its
+assertion shape. The closest runner-idle-reset precedent is
+`test/soleur-go-runner-tool-result-idle-reset.test.ts`.
+
+### Server-side RED tests (`cc-dispatcher-tool-progress-forwarding.test.ts`)
+
+1. **Runner emits `onToolProgress`:** drive `createSoleurGoRunner` with
+   `makeRecordingEvents()`, `mock.emit(makeToolProgress("tu-1", 5))`, flush; assert the
+   recording captured `{ toolUseId: "tu-1", elapsedSeconds: 5, toolName: <raw "Read"> }`.
+   (RED: no `onToolProgress` exists yet.)
+2. **Dispatcher forwards a `tool_progress` WS message:** via the cc-dispatcher harness
+   (`test/helpers/cc-dispatcher-harness.ts`) + a `mockSendToClient`, emit a
+   `tool_progress` and assert `mockSendToClient` received
+   `{ type: "tool_progress", leaderId: "cc_router", toolUseId: "tu-1", toolName:
+   <human label, NOT "Read">, elapsedSeconds: 5 }`. Assert `toolName !== "Read"`
+   (the #2138 raw-name invariant — vacuous-RED guard: pick a fixture whose human label
+   differs from the raw name).
+3. **Debounce ≤1/5s per `toolUseId`:** `vi.useFakeTimers()`; emit `tool_progress` at
+   t=0, t=2s, t=6s for the same `tu-1`; assert exactly 2 forwards (t=0 and t=6s).
+   Distinct `toolUseId`s each forward independently. **CLOCK-DRIVE (vacuous-GREEN guard,
+   deepen-plan test-design finding):** the debounce compares `Date.now()`, so
+   `vi.advanceTimersByTime` ALONE leaves `Date.now()` at 0 and all three emits collapse
+   into one window (wrong-reason result). Drive the clock with `vi.setSystemTime()` as
+   each heartbeat is consumed, mirroring the agent-runner precedent
+   `test/tool-progress-forwarding.test.ts:204-209`.
+4. **Shape-guard:** emit a malformed `tool_progress` (missing `tool_use_id`) **as the
+   sole `tool_progress` in the test** (no prior well-formed emit, so the "no forward"
+   assertion is attributable solely to the shape-guard, NOT a debounce window — per
+   learning `2026-05-04-vacuous-red-via-shared-fixture-and-toolchain-pinning.md`); assert
+   NO forward and `reportSilentFallback` `op: "tool-progress-shape"`. **POSITIVE CONTROL
+   (deepen-plan finding):** assert the server watchdog re-arm (`armRunaway`) STILL fired —
+   advance past the idle window and confirm NO `runner_runaway` is emitted, mirroring the
+   re-arm assertion in `test/soleur-go-runner-tool-result-idle-reset.test.ts:132-140`. The
+   malformed-drop assertion alone does not prove the re-arm survived. (This is the
+   intentional divergence from agent-runner, which `continue`s past BOTH emit and re-arm on
+   a shape fail; the soleur-go runner re-arms on malformed-but-present `tool_progress`
+   because the message itself proves the tool is alive — strictly safer.)
+
+### Client-side consumer-contract guard tests (`cc-soleur-go-tool-progress-no-terminal-error.test.tsx`)
+
+> **Not RED for the forwarding defect (deepen-plan test-design finding).** The
+> `chat-state-machine.ts` consumer is already complete (line 490 + `applyTimeout`
+> 1068-1113), so these tests run against an UNCHANGED reducer and are GREEN both before
+> and after the fix. Their value is **regression-locking the consumer contract the new
+> forward feeds** — so a future refactor of `chat-state-machine.ts` cannot silently break
+> the heartbeat path. The RED coverage of the actual bug (cc-dispatcher not forwarding)
+> lives in **server tests #1 (runner emit) + #2 (dispatcher WS shape)**. Do not inflate
+> the RED count: server #1-#4 are RED; client #5-#7 are characterization guards.
+
+Drive the `applyStreamEvent` reducer + `applyTimeout` directly (the
+`cc-soleur-go-end-to-end-render.test.tsx` `replay()` pattern; assertions on `data-*` /
+reducer state, never layout).
+
+5. **>90s single tool does NOT flip to terminal error WHEN `tool_progress` arrives:**
+   replay stream-start (leader `cc_router`) → `tool_use` → `applyTimeout` (first, 45s →
+   `retrying: true`) → `applyStreamEvent({ type: "tool_progress", leaderId: "cc_router" })`
+   → assert `retrying` cleared and watchdog reset → `applyTimeout` again must NOT reach
+   stage-2 terminal because the heartbeat reset the consecutive-timeout counter; assert
+   `messages[idx].state !== "error"` and `activeStreams.has("cc_router") === true`.
+6. **Retrying chip cleared on a progressing tool:** after a first timeout sets
+   `retrying: true`, a `tool_progress` event clears it (`retrying` undefined). NOTE the
+   "no `tool_use_chip` spawn on `tool_progress`" half is ALREADY covered by
+   `cc-soleur-go-end-to-end-render.test.tsx:176-187` — do NOT duplicate that assertion;
+   this test's distinct contribution is the `retrying`-clear transition (first-timeout →
+   heartbeat → retrying undefined), which the existing test does not exercise.
+7. **Control / regression-preserving (NOT a fix-of-the-fix):** a tool that emits NO
+   `tool_progress` and times out twice STILL flips to terminal `error` and evicts the
+   leader — proves the fix does not relax genuine-failure detection. (Defense-pair per
+   learning `2026-05-06-sdk-forward-progress-tool-use-result-resets-per-block-idle.md`.)
+
+### GREEN sweep
+
+- After widening `DispatchEvents`, run `cd apps/web-platform && ./node_modules/.bin/tsc
+  --noEmit`. The new callback is **optional** (`?`), so existing inline `DispatchEvents`
+  constructors in tests do NOT need updating — but run tsc to confirm (per learning
+  `2026-05-07-tdd-ts-expect-error-sweep-and-reducer-fixture-sweep.md`).
+- `git grep -n "onToolProgress" apps/web-platform/` to confirm exactly the runner
+  (definition + invocation) and the cc-dispatcher (wiring) reference it. agent-runner is
+  NOT extended (it uses its own inline forward; `DispatchEvents` is a soleur-go concept).
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [x] **AC1** `DispatchEvents` in `soleur-go-runner.ts` has an optional
+  `onToolProgress?` callback with a JSDoc block; `git grep -n "onToolProgress?" apps/web-platform/server/soleur-go-runner.ts`
+  returns the declaration.
+- [x] **AC2** The `tool_progress` branch at `soleur-go-runner.ts:~2170` invokes
+  `state.events.onToolProgress?.(...)` inside a `try/catch` AND still calls `armRunaway`;
+  the runner-emit RED test (server test #1) passes.
+- [x] **AC3** `buildToolProgressWSMessage` exists in `tool-labels.ts` and routes
+  `toolName` through `buildToolLabel`; a unit assertion confirms the returned `toolName`
+  is the human label, NOT the raw input (`toolName !== "Read"`).
+- [x] **AC4** cc-dispatcher's `events` object wires `onToolProgress` →
+  `sendToClient(... type: "tool_progress", leaderId: CC_ROUTER_LEADER_ID ...)`; server
+  test #2 asserts the forwarded WS shape.
+- [x] **AC5** Debounce holds: server test #3 asserts ≤1 forward per 5s per `toolUseId`
+  (2 forwards across t=0/t=2s/t=6s), driving the clock via `vi.setSystemTime()` per
+  heartbeat (NOT `advanceTimersByTime` alone — the debounce reads `Date.now()`).
+- [x] **AC6** Shape-guard holds: server test #4 asserts a malformed `tool_progress`
+  produces no forward + a `reportSilentFallback` `op: "tool-progress-shape"`, AND the
+  positive control confirms the watchdog re-arm fired (no `runner_runaway` after the idle
+  window).
+- [x] **AC7** Client guard test #5 passes: a >90s single tool that emits `tool_progress`
+  does NOT flip the `cc_router` bubble to `state: "error"` and does NOT evict it from
+  `activeStreams`. (Consumer-contract guard — GREEN pre-fix; locks the reducer the forward
+  feeds.)
+- [x] **AC8** Client guard test #6 passes: the "Retrying…" chip's `retrying` flag is
+  cleared by a `tool_progress` event (the chip-no-spawn half is already covered by
+  `cc-soleur-go-end-to-end-render.test.tsx:176-187`; not duplicated).
+- [x] **AC9** Control guard test #7 passes: a tool emitting NO `tool_progress` STILL flips
+  to terminal error after two timeouts (genuine-failure detection preserved — defense-pair).
+- [x] **AC10** `chat-state-machine.ts` and `ws-constants.ts` are UNCHANGED
+  (`git diff --stat` shows neither file) — the consumer + constant already support this.
+- [x] **AC11** `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` is clean.
+- [x] **AC12** `./node_modules/.bin/vitest run test/cc-dispatcher-tool-progress-forwarding.test.ts
+  test/cc-soleur-go-tool-progress-no-terminal-error.test.ts` is green; the existing
+  `test/tool-progress-forwarding.test.ts` (agent-runner) and `test/chat-state-machine.test.ts`
+  remain green (no regression).
+- [x] **AC13** PR body uses `Closes #5214`.
+
+### Post-merge (operator)
+
+- None. Pure client-WS-forwarding code change against an already-provisioned surface;
+  the `web-platform-release.yml` pipeline restarts the container on merge to
+  `apps/web-platform/**`. No migration, secret, infra, or dashboard step.
+
+## Domain Review
+
+**Domains relevant:** Product (UX gate)
+
+### Product/UX Gate
+
+**Tier:** advisory
+**Decision:** auto-accepted (pipeline)
+**Agents invoked:** none
+**Skipped specialists:** none — N/A (no UI-surface file created/edited)
+**Pencil available:** N/A (no UI surface)
+
+#### Findings
+
+This is a back-end WS-forwarding fix on the chat surface. It creates/edits **no**
+`components/**/*.tsx`, `app/**/page.tsx`, or `app/**/layout.tsx` file — the mechanical
+UI-surface override does not fire. The user-visible effect (no spurious terminal-error
+bubble) is a *correctness restoration* of existing rendered behavior, not a new
+interactive surface or copy change. The `chat-state-machine.ts` reducer that owns the
+bubble lifecycle is unchanged. No wireframe is required.
+
+## Infrastructure (IaC)
+
+None. The plan edits only files under `apps/web-platform/server/` and
+`apps/web-platform/`-adjacent test dirs against an already-provisioned surface. No
+server, service, cron, secret, DNS, vendor account, or persistent runtime process is
+introduced. Phase 2.8 detection scan run: no manual-provisioning, systemd, secret-write,
+terraform, cron, or vendor-dashboard pattern appears in the implementation steps. Skip.
+(The ack comment at the top of this file is for the negative-detection list in this
+section — the gate matched a literal token used only to assert its absence.)
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: cc tool_progress forward count is observable via the existing WS frame stream; a regression (forward stops) re-manifests as the terminal-error bubble it fixes — and the reverse direction (shape-guard trips) emits a Sentry breadcrumb (below).
+  cadence: per long-running tool (<=1 forward / 5s / toolUseId)
+  alert_target: Sentry (existing project) — no new alert needed; the shape-guard breadcrumb is the new signal.
+  configured_in: apps/web-platform/server/soleur-go-runner.ts (reportSilentFallback op tool-progress-shape) + cc-dispatcher onToolProgress wiring
+error_reporting:
+  destination: Sentry via reportSilentFallback (existing helper, already imported in both files)
+  fail_loud: true — a malformed SDKToolProgressMessage mirrors to Sentry (op tool-progress-shape) before being dropped; an onToolProgress callback throw mirrors (op onToolProgress) without blocking the stream.
+failure_modes:
+  - mode: SDK reshapes SDKToolProgressMessage (missing tool_use_id/tool_name/elapsed) -> forward silently dropped
+    detection: reportSilentFallback op "tool-progress-shape" in Sentry
+    alert_route: Sentry issue (existing inbound)
+  - mode: onToolProgress callback throws in cc-dispatcher (e.g., sendToClient closure error)
+    detection: reportSilentFallback op "onToolProgress" in Sentry
+    alert_route: Sentry issue (existing inbound)
+  - mode: includePartialMessages flips to false upstream -> tool_progress stops arriving (regression of precondition)
+    detection: the terminal-error bubble re-appears on >90s tools (user-reported); grep-discoverable comment cites agent-runner-query-options.ts:160 as the load-bearing line
+    alert_route: user report / QA on cc surface
+logs:
+  where: pino structured logs (existing) on the reportSilentFallback paths; no new log surface
+  retention: existing platform retention
+discoverability_test:
+  command: cd apps/web-platform && ./node_modules/.bin/vitest run test/cc-dispatcher-tool-progress-forwarding.test.ts
+  expected_output: forward + debounce + shape-guard assertions green (proves the emit path and the Sentry-mirror path are both reachable without remote shell access)
+```
+
+## Open Code-Review Overlap
+
+4 open `code-review` issues touch the edited files; **none** overlap the tool_progress
+concern — all acknowledged (no fold-in):
+
+- **#2220** (inject idFactory into applyStreamEvent — reducer purity) — different
+  concern; this plan does not touch `chat-state-machine.ts`. **Acknowledge.**
+- **#2224** (chat code-quality polish — JSX indentation, bubble factory) — different
+  concern; no chat-component edits. **Acknowledge.**
+- **#3242** (tool_use WS event lacks raw name field for agent consumers, Ref #3235) —
+  adjacent (`tool-labels.ts`), but it argues the OPPOSITE direction (expose raw name for
+  agents); this fix preserves the #2138 human-label-only invariant on the new
+  `tool_progress` forward. Not folded — distinct design question. **Acknowledge.**
+- **#3243** (decompose cc-dispatcher.ts into modules, Ref #3235) — architectural
+  refactor of the whole file; out of scope for a targeted forward fix. **Defer** (no
+  re-eval note needed; this fix does not affect the decomposition).
+
+## Hypotheses
+
+N/A — root cause is verified directly against code (zero `tool_progress` mentions in
+`cc-dispatcher.ts`; the runner branch comment confirms the pure-re-arm-no-emit
+behavior). Not a network/connectivity issue.
+
+## Risks & Mitigations
+
+- **Cadence invariant (inherited from PR #5208 plan):** the fix is correct only if the
+  SDK `tool_progress` emit interval `< STUCK_TIMEOUT_MS (45s)`. The <=5s debounce floor
+  (and the runner's own re-arm cadence) makes this hold with large margin. Named here so
+  a future SDK throttle is grep-discoverable.
+- **`includePartialMessages` precondition:** silently regresses if
+  `agent-runner-query-options.ts:160` flips to `false` (`tool_progress` would stop
+  arriving for BOTH surfaces). The runner branch already carries a comment citing that
+  line; the new emit code reuses the same branch, so the precondition note is co-located.
+- **Raw-name leak (#2138 / PR #2115):** mitigated by routing `tool_name` through
+  `buildToolLabel` in the shared `buildToolProgressWSMessage` — AC3 + server-test #2
+  assert the wire carries the human label, not the raw SDK name.
+- **DoS / absolute-ceiling (defense-relaxation, learning
+  `2026-05-05-defense-relaxation-must-name-new-ceiling.md`):** this plan does NOT relax
+  any server ceiling — the server `turnHardCap` (10-min, anchored on `firstToolUseAt`,
+  PR #3225) is untouched, and the client reducer's terminal-error path still fires when
+  `tool_progress` is ABSENT (AC9). The fix feeds an *existing* client watchdog; it adds
+  no new unbounded timer. The client `STUCK_TIMEOUT_MS` reset on `tool_progress` already
+  shipped for the agent-runner surface (#2861) and is itself bounded by the
+  second-consecutive-timeout terminal logic when heartbeats stop.
+- **Precedent-diff (deepen-plan Phase 4.4):** the pattern precedent is
+  `agent-runner.ts:1889-1948` (`tool_progress` forward) — diff the new runner-emit +
+  cc-dispatcher-forward against it for shape-guard / debounce / label parity.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty or placeholder fails
+  `deepen-plan` Phase 4.6 — this section carries a concrete artifact, vector, and the
+  `single-user incident` threshold (inherited verbatim from the PR #5208 follow-up).
+- The new test files MUST live at `apps/web-platform/test/*.test.ts` /
+  `test/*.test.tsx` — vitest collects `test/**/*.test.{ts,tsx}`, NOT co-located
+  `components/**` or `server/**` (`vitest.config.ts:44,60`).
+- Typecheck is `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` — NOT
+  `npm run -w` (no root `workspaces` field).
+- The issue's "~line 2107" cc-dispatcher anchor is approximate and points into a
+  helper region, NOT the forward site. The real wire-site is the `events: DispatchEvents`
+  object at ~line 2448 (where `onText`/`onToolUse` are wired). Do not patch line 2107.
+- The fix is **two-layer** (runner emit + dispatcher forward). A single `sendToClient`
+  line in cc-dispatcher would have nothing to call — the runner swallows `tool_progress`
+  today (`soleur-go-runner.ts:2170` pure re-arm). Both layers are required.
+- `chat-state-machine.ts` is **already complete** — adding a duplicate `tool_progress`
+  reset there would be wrong (double-reset / chip regression). The only client-side
+  change is the two new RED test files; AC10 enforces the reducer stays untouched.

--- a/knowledge-base/project/specs/feat-one-shot-fwd-tool-progress-cc-surface-5214/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-fwd-tool-progress-cc-surface-5214/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-12-fix-forward-tool-progress-cc-surface-plan.md
+- Status: complete
+
+### Errors
+- Pre-write hook blocked on the literal token `doppler secrets set` in Phase 2.8 negative-detection prose (asserting infra patterns absent). Resolved by adding `<!-- iac-routing-ack: plan-phase-2-8-reviewed -->` opt-out and rephrasing — plan introduces no infrastructure. No other errors.
+
+### Decisions
+- Two-layer fix, not one-line: cc-dispatcher delegates to soleur-go-runner.ts whose tool_progress branch is a pure re-arm emitting no event. Fix adds optional onToolProgress? to runner DispatchEvents + emits (shape-guarded), AND wires events.onToolProgress in cc-dispatcher to forward — mirroring agent-runner.ts:1889-1948.
+- chat-state-machine.ts + ws-constants.ts need NO change — client consumer, tool_progress WS variant, zod schema, cc_router leader registration already complete (used by agent-runner). AC10 git-diff-gates them unchanged.
+- Shared buildToolProgressWSMessage in tool-labels.ts (parity with #3235) to pin #2138 information-disclosure invariant (raw SDK tool_name never reaches wire; routed through buildToolLabel).
+- Test refinements: test #3 drives vi.setSystemTime() per heartbeat; test #4 adds positive control armRunaway fired; client tests #5-#7 re-labeled consumer-contract guards (GREEN pre-fix).
+- Single-user-incident threshold + CPO sign-off carried forward verbatim from PR #5208 follow-up; all 9 cited PR/issue refs verified live.
+
+### Components Invoked
+- Skill: soleur:plan
+- Skill: soleur:deepen-plan
+- Agents: repo-research-analyst, learnings-researcher, architecture-strategist, test-design-reviewer, general-purpose

--- a/knowledge-base/project/specs/feat-one-shot-fwd-tool-progress-cc-surface-5214/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-fwd-tool-progress-cc-surface-5214/tasks.md
@@ -1,0 +1,98 @@
+---
+title: "Tasks — fix: forward tool_progress to client on cc surface"
+issue: 5214
+branch: feat-one-shot-fwd-tool-progress-cc-surface-5214
+lane: cross-domain
+plan: knowledge-base/project/plans/2026-06-12-fix-forward-tool-progress-cc-surface-plan.md
+created: 2026-06-12
+---
+
+# Tasks — forward `tool_progress` to client on cc surface (#5214)
+
+Derived from `knowledge-base/project/plans/2026-06-12-fix-forward-tool-progress-cc-surface-plan.md`.
+Two-layer fix (runner emits `onToolProgress` DispatchEvent → cc-dispatcher forwards a
+`tool_progress` WS message), mirroring `agent-runner.ts:1889-1948`. Downstream consumer
+(`chat-state-machine.ts:490`, `ws-constants.ts`, WS variant) is already complete — DO NOT edit.
+
+## Phase 0 — Preconditions (verify, no edits)
+
+- [x] 0.1 Confirm `apps/web-platform/lib/chat-state-machine.ts:490` (`case "tool_progress"`)
+  resets the watchdog + clears `retrying` + has the #2886 no-chip guard — and stays UNCHANGED.
+- [x] 0.2 Confirm the `tool_progress` WS variant exists: `lib/types.ts:319`,
+  `lib/ws-zod-schemas.ts:280`, `lib/ws-known-types.ts:43`, `lib/ws-client.ts:688`. No edit.
+- [x] 0.3 Confirm `includePartialMessages: true` at `agent-runner-query-options.ts:160` and
+  that cc's `realSdkQueryFactory` (`cc-dispatcher.ts:~1811`) consumes `buildAgentQueryOptions`.
+- [x] 0.4 Read the precedent forward `agent-runner.ts:1889-1948` (shape-guard, debounce,
+  `buildToolLabel` routing) and the existing cc `tool_use` forward (`cc-dispatcher.ts:~2512`).
+
+## Phase 1 — RED tests (write first; must fail)
+
+- [x] 1.1 Create `apps/web-platform/test/cc-dispatcher-tool-progress-forwarding.test.ts`:
+  - [x] 1.1.1 Test #1 — runner emits `onToolProgress` (`makeRecordingEvents` +
+    `makeToolProgress("tu-1", 5)`); assert recorded `{ toolUseId, elapsedSeconds, toolName: "Read" }`.
+  - [x] 1.1.2 Test #2 — dispatcher forwards a `tool_progress` WS message via harness +
+    `mockSendToClient`; assert `{ type: "tool_progress", leaderId: "cc_router", toolUseId,
+    toolName: <human label, !== "Read">, elapsedSeconds }`. (Load-bearing RED for the bug.)
+  - [x] 1.1.3 Test #3 — debounce ≤1/5s per `toolUseId`; drive the clock via
+    `vi.setSystemTime()` per heartbeat (NOT `advanceTimersByTime` — debounce reads `Date.now()`;
+    precedent `tool-progress-forwarding.test.ts:204-209`); assert 2 forwards across t=0/2s/6s.
+  - [x] 1.1.4 Test #4 — malformed `tool_progress` (missing `tool_use_id`) as the SOLE
+    `tool_progress` in the test; assert no forward + `reportSilentFallback` `op:
+    "tool-progress-shape"` + POSITIVE CONTROL `armRunaway` fired (no `runner_runaway` after
+    the idle window; precedent `soleur-go-runner-tool-result-idle-reset.test.ts:132-140`).
+- [x] 1.2 Create `apps/web-platform/test/cc-soleur-go-tool-progress-no-terminal-error.test.tsx`
+  (consumer-contract guards — GREEN pre-fix; lock the reducer the forward feeds):
+  - [x] 1.2.1 Test #5 — >90s tool with `tool_progress` does NOT flip `cc_router` to
+    `state: "error"` and does NOT evict from `activeStreams`.
+  - [x] 1.2.2 Test #6 — first-timeout `retrying: true` is cleared by a `tool_progress`
+    event (do NOT duplicate the chip-no-spawn assertion already at
+    `cc-soleur-go-end-to-end-render.test.tsx:176-187`).
+  - [x] 1.2.3 Test #7 — control: a tool emitting NO `tool_progress` STILL flips to terminal
+    error after two timeouts (defense-pair).
+- [x] 1.3 Run both files; confirm server #1-#4 are RED (fail before the fix).
+
+## Phase 2 — Implementation (GREEN)
+
+- [x] 2.1 `soleur-go-runner.ts` — add optional `onToolProgress?: (block: { toolUseId:
+  string; toolName: string; elapsedSeconds: number }) => void;` to `DispatchEvents`
+  (~798-866) with JSDoc (when it fires, why optional, fire-and-forget, the #2138 raw-name
+  note, AND that it fires at SDK cadence so consumers MUST debounce).
+- [x] 2.2 `soleur-go-runner.ts:2170` `tool_progress` branch — AFTER the existing
+  `armRunaway`, shape-guard `tool_use_id`/`tool_name`/`elapsed_time_seconds` (mirror
+  `agent-runner.ts:1901-1927`; on mismatch `reportSilentFallback({ feature:
+  "soleur-go-runner", op: "tool-progress-shape" })` and skip the emit — NOT the re-arm),
+  then invoke `state.events.onToolProgress?.(...)` in `try/catch` →
+  `reportSilentFallback({ op: "onToolProgress" })`. Update the "reads NO fields" comment.
+- [x] 2.3 `tool-labels.ts` — add `export function buildToolProgressWSMessage(args: {
+  toolName; elapsedSeconds; toolUseId; workspacePath; leaderId })` returning
+  `{ type: "tool_progress", leaderId, toolUseId, toolName: buildToolLabel(toolName,
+  undefined, workspacePath), elapsedSeconds }`; JSDoc cites #3235 + the #2138 invariant.
+- [x] 2.4 `cc-dispatcher.ts` — import `buildToolProgressWSMessage`; declare per-dispatch
+  `const TOOL_PROGRESS_DEBOUNCE_MS = 5_000;` + `const toolProgressLastSentAt = new
+  Map<string, number>();` near the `events` object (~2448).
+- [x] 2.5 `cc-dispatcher.ts` — add `onToolProgress` to the `events: DispatchEvents` object:
+  debounce per `toolUseId` (first always forwards; subsequent wait 5s), then
+  `sendToClient(userId, buildToolProgressWSMessage({ toolName, elapsedSeconds, toolUseId,
+  workspacePath, leaderId: CC_ROUTER_LEADER_ID }))`. One-line comment: NO debug-event emit
+  for `tool_progress` (parity with agent-runner; debug panel has no `tool_progress` kind).
+- [x] 2.6 Run both new test files until green.
+
+## Phase 3 — Verification
+
+- [x] 3.1 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` — clean.
+- [x] 3.2 `cd apps/web-platform && ./node_modules/.bin/vitest run
+  test/cc-dispatcher-tool-progress-forwarding.test.ts
+  test/cc-soleur-go-tool-progress-no-terminal-error.test.ts` — green.
+- [x] 3.3 Regression: `./node_modules/.bin/vitest run test/tool-progress-forwarding.test.ts
+  test/chat-state-machine.test.ts test/cc-soleur-go-end-to-end-render.test.tsx` — green.
+- [x] 3.4 `git diff --stat` confirms `chat-state-machine.ts` and `ws-constants.ts` are
+  UNCHANGED (AC10).
+- [x] 3.5 `git grep -n "onToolProgress" apps/web-platform/` — only the runner (def+invoke)
+  and cc-dispatcher (wiring) reference it; agent-runner NOT touched.
+- [x] 3.6 Walk the Acceptance Criteria (AC1-AC13) in the plan; check each off.
+
+## Phase 4 — Ship
+
+- [x] 4.1 PR body uses `Closes #5214` (AC13).
+- [x] 4.2 No post-merge operator steps (pure code change; container restarts on merge via
+  `web-platform-release.yml`).


### PR DESCRIPTION
## Summary

Forward SDK `tool_progress` heartbeats to the client on the Concierge (cc / `soleur-go`) surface so the client-side stuck-watchdog (`STUCK_TIMEOUT_MS`, 45s) is heartbeat-fed during a long single-tool execution. Before this fix, a >90s single tool (routine `Read`/`Bash`/web-search on large input) timed out twice on the client and flipped the chat bubble to a terminal `error` state, evicting the leader; the real answer then rendered as a new bubble below the orphaned error bubble.

Two-layer fix mirroring the legacy `agent-runner.ts:1889-1948` forward, split across the runner/dispatcher seam:

- **`server/soleur-go-runner.ts`** — add an optional `onToolProgress?` to `DispatchEvents` and EMIT it (shape-guarded) from the `tool_progress` branch, after the existing `armRunaway` re-arm. The runner emits the RAW SDK fields at SDK cadence (un-debounced).
- **`server/tool-labels.ts`** — add `buildToolProgressWSMessage`, routing the raw `toolName` through `buildToolLabel` (#2138 human-label-only invariant).
- **`server/cc-dispatcher.ts`** — wire `events.onToolProgress` → `sendToClient(...)`, debounced 5s per `toolUseId`.

`chat-state-machine.ts` and `ws-constants.ts` are **unchanged** — the client consumer (`chat-state-machine.ts:490`), the `tool_progress` WS variant, and the zod schema already exist for the agent-runner surface and are reused.

Closes #5214

## User-Brand Impact

**If this lands broken, the user experiences:** on the Concierge chat surface, a >90s single tool paints a terminal "the agent failed" error bubble, immediately followed by the real answer rendered as a separate orphaned bubble below it — the product's core conversation surface looks broken on routine traffic.

**Information-disclosure invariant:** the raw SDK `tool_name` must NEVER reach the wire (#2138 / PR #2115). The forward routes `tool_name` through `buildToolLabel` (human label only); server test #2 asserts the wire carries the human label, not the raw name.

- **Brand-survival threshold:** single-user incident

## Changelog

- **Web Platform:** the Concierge chat surface no longer paints a spurious terminal-error bubble during long (>90s) single-tool turns; mid-tool progress now feeds the client watchdog. Genuinely hung tools (no heartbeat) still surface the error state after two timeouts.

## Test plan

- [x] 4 server-side tests: runner emits `onToolProgress`; dispatcher forwards a `tool_progress` WS frame with the human label (not the raw name); debounce ≤1/5s per `toolUseId` (clock-driven); malformed payload dropped with a Sentry mirror while the watchdog re-arm still fires.
- [x] 3 client consumer-contract guards: heartbeat between two timeouts prevents the terminal flip + eviction; `retrying` flag cleared on a heartbeat; control — no heartbeat still flips to terminal error after two timeouts.
- [x] `tsc --noEmit` clean; full `apps/web-platform` vitest suite green (9681 passed).
- [x] `chat-state-machine.ts` + `ws-constants.ts` confirmed unchanged (`git diff --stat`); `agent-runner.ts` untouched.

Generated with [Claude Code](https://claude.com/claude-code)
