### PR TITLE
fix(docs): correct author X handle, add LinkedIn, social-link icons

### DIFF
--- a/plugins/soleur/docs/_data/site.json
+++ b/plugins/soleur/docs/_data/site.json
@@ -52,7 +52,8 @@
     ],
     "sameAs": [
       "https://github.com/deruelle",
-      "https://x.com/jeandev_"
+      "https://x.com/deruelle",
+      "https://www.linkedin.com/in/jeanderuelle/"
     ]
   },
   "footerColumns": [

--- a/plugins/soleur/docs/_includes/blog-post.njk
+++ b/plugins/soleur/docs/_includes/blog-post.njk
@@ -106,7 +106,15 @@ layout: base.njk
         {% if site.author.sameAs %}
         <ul class="author-card-links">
           {% for link in site.author.sameAs %}
+          {% if "github.com" in link %}
+          <li><a href="{{ link }}" rel="noopener noreferrer me" target="_blank" aria-label="GitHub"><svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg></a></li>
+          {% elif "x.com" in link or "twitter.com" in link %}
+          <li><a href="{{ link }}" rel="noopener noreferrer me" target="_blank" aria-label="X"><svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false"><path fill="currentColor" d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932 6.064-6.933Zm-1.29 19.494h2.039L6.486 3.24H4.298L17.611 20.647Z"/></svg></a></li>
+          {% elif "linkedin.com" in link %}
+          <li><a href="{{ link }}" rel="noopener noreferrer me" target="_blank" aria-label="LinkedIn"><svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path fill="currentColor" d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z"/></svg></a></li>
+          {% else %}
           <li><a href="{{ link }}" rel="noopener noreferrer me" target="_blank">{{ link | replace("https://", "") | replace("www.", "") }}</a></li>
+          {% endif %}
           {% endfor %}
         </ul>
         {% endif %}

--- a/plugins/soleur/docs/css/style.css
+++ b/plugins/soleur/docs/css/style.css
@@ -1798,20 +1798,29 @@
   margin: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-4);
+  align-items: center;
+  gap: var(--space-2);
 }
 .author-card-links a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  min-height: 36px;
+  padding: 0 4px;
   font-size: 0.8125rem;
   color: var(--color-text-secondary);
   text-decoration: none;
-  border-bottom: 1px solid var(--color-border);
-  padding-bottom: 2px;
-  transition: color 0.15s, border-color 0.15s;
+  border-radius: var(--radius-md, 8px);
+  transition: color 0.15s, background-color 0.15s;
+}
+.author-card-links a svg {
+  display: block;
 }
 .author-card-links a:hover,
 .author-card-links a:focus {
   color: var(--color-accent);
-  border-bottom-color: var(--color-accent);
+  background: var(--color-bg-tertiary);
 }
 @media (max-width: 480px) {
   .author-card {


### PR DESCRIPTION
## Summary

Fixes the author card that renders at the bottom of every blog post (from shared `site.json` data):

1. **Wrong X handle** — `x.com/jeandev_` → **`x.com/deruelle`**. This was incorrect on *every* post's author card and BlogPosting JSON-LD `sameAs`, since they all render from `site.author.sameAs`.
2. **Added LinkedIn** — `linkedin.com/in/jeanderuelle` to `sameAs` (the original author-card plan had reserved a LinkedIn slot).
3. **Icons instead of text links** — the author card now shows GitHub / X / LinkedIn brand icons (inline SVG, per-platform `aria-label`, decorative `aria-hidden` svg, 36px tap targets, accent-color hover). A text fallback remains for any future non-iconed `sameAs` entry.

## Changelog

- Correct author X handle, add LinkedIn, render blog author-card social links as icons.

## Verification

- Full `plugins/soleur` suite: **1678 pass / 0 fail** (incl. `seo-aeo-drift-guard` author `sameAs` + author-card assertions).
- Eleventy build green; visually confirmed via Playwright (3 icons render with correct hrefs + aria-labels).
- Company handle `x.com/soleur_ai` (footer) untouched.

Note: two `jeandev_` references remain in a closed historical planning doc (`knowledge-base/project/plans/2026-04-22-refactor-drain-seo-aeo-...-plan.md`) — point-in-time records, not a rendered surface; left as historical record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
