### PR TITLE
fix(infra): allow GitHub git CIDR ranges in cron egress firewall

### DIFF
--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -208,6 +208,12 @@ write_files:
     owner: root:root
     permissions: '0644'
 
+  - path: /etc/soleur/cron-egress-allowlist-cidr.txt
+    encoding: b64
+    content: ${cron_egress_allowlist_cidr_b64}
+    owner: root:root
+    permissions: '0644'
+
   - path: /etc/systemd/system/cron-egress-firewall.service
     encoding: b64
     content: ${cron_egress_firewall_service_b64}

--- a/apps/web-platform/infra/cron-egress-allowlist-cidr.txt
+++ b/apps/web-platform/infra/cron-egress-allowlist-cidr.txt
@@ -1,0 +1,24 @@
+# Container egress CIDR allowlist (cron-egress-firewall; GitHub LB-range fix).
+# One IPv4 CIDR per line; `#` comments and blank lines ignored.
+#
+# WHY a separate CIDR file: cron-egress-allowlist.txt holds HOSTNAMES that
+# cron-egress-resolve.sh resolves to a SINGLE IPv4 per tick and pins in the
+# `soleur_egress_allow` set (type ipv4_addr, no interval). That works for
+# single-IP vendor APIs, but FAILS for hosts that load-balance across a large
+# rotating IP pool: the clone dials whatever the LB returns at connect time,
+# which is frequently NOT the one IP the resolver pinned that tick → dropped.
+#
+# These CIDRs are loaded by cron-egress-nftables.sh into the
+# `soleur_egress_allow_cidr` interval set (flags interval) and accepted by a
+# dedicated SOLEUR-EGRESS rule. Static because the ranges are published and
+# stable; refresh from api.github.com/meta `.git` if GitHub ever changes them.
+#
+# GitHub git + web ranges (api.github.com/meta `.git`, 2026-06-12). 21 crons
+# clone GitHub via buildAuthenticatedCloneUrl; github.com LB-rotates across
+# 140.82.112.0/20, so a clone frequently dials an unpinned IP. Evidence:
+# Sentry `egress-blocked` DST=140.82.121.5 (lb-140-82-121-5-fra.github.com)
+# correlated with `Cron failure: scheduled-content-publisher`, 2026-06-12.
+140.82.112.0/20
+185.199.108.0/22
+192.30.252.0/22
+143.55.64.0/20

--- a/apps/web-platform/infra/cron-egress-firewall.test.sh
+++ b/apps/web-platform/infra/cron-egress-firewall.test.sh
@@ -68,6 +68,7 @@ echo "--- cron-egress firewall drift-guard ---"
 
 echo "-- artifacts exist + parse --"
 for f in "$LOADER" "$RESOLVER" "$ALARM" "$ALLOWLIST" \
+  "$SCRIPT_DIR/cron-egress-allowlist-cidr.txt" \
   "$SCRIPT_DIR/cron-egress-firewall.service" \
   "$SCRIPT_DIR/cron-egress-resolve.service" \
   "$SCRIPT_DIR/cron-egress-resolve.timer" \
@@ -81,7 +82,7 @@ assert_cmd "alarm parses (bash -n)" bash -n "$ALARM"
 echo "-- server.tf delivery (anchored on the file-provisioner construct) --"
 assert_grep "resource exists" 'resource "terraform_data" "cron_egress_firewall"' "$SERVER_TF"
 for f in cron-egress-nftables.sh cron-egress-resolve.sh cron-egress-alarm.sh \
-  cron-egress-allowlist.txt cron-egress-firewall.service \
+  cron-egress-allowlist.txt cron-egress-allowlist-cidr.txt cron-egress-firewall.service \
   cron-egress-resolve.service cron-egress-resolve.timer; do
   assert_grep "delivers $f (source=)" "source += +\"\\\$\\{path\\.module\\}/$f\"" "$SERVER_TF"
   assert_grep "trigger folds $f hash" "file\\(\"\\\$\\{path\\.module\\}/$f\"\\)" "$SERVER_TF"
@@ -134,6 +135,13 @@ assert_grep "bridge gateway derived, not hardcoded" 'docker network inspect brid
 assert_grep "IPv6 bypass guard" 'EnableIPv6' "$LOADER"
 assert_grep "jump rule scoped to the bridge interface" 'iifname "\$BRIDGE_IF" counter jump SOLEUR-EGRESS' "$LOADER"
 assert_not_grep "never flushes the shared DOCKER-USER chain" 'flush chain ip filter DOCKER-USER' "$LOADER"
+
+# GitHub LB-range fix: a static interval CIDR set parallel to the single-IP set.
+assert_grep "declares interval CIDR set" 'set soleur_egress_allow_cidr' "$LOADER"
+assert_grep "CIDR set uses flags interval" 'flags interval' "$LOADER"
+assert_grep "CIDR allowlist accept rule present" 'ip daddr @soleur_egress_allow_cidr accept' "$LOADER"
+assert_grep "loader reads the CIDR allowlist file" 'cron-egress-allowlist-cidr.txt' "$LOADER"
+assert_grep "CIDR file carries GitHub git /20" '140.82.112.0/20' "$SCRIPT_DIR/cron-egress-allowlist-cidr.txt"
 
 echo "-- resolver safety invariants --"
 # Anchored on the executable form (`flush set ip filter …`), not the bare
@@ -210,11 +218,15 @@ for host in api.anthropic.com github.com api.github.com api.doppler.com \
 done
 # Exact-set guard: a NEW host (the firewall's entire attack-surface dial)
 # must force a deliberate edit here carrying its evidence.
+# Count is 23 since #5199 (restore 7 Tier-2 crons) grew the allowlist with
+# evidence-gated hosts (e.g. hn.algolia.com, plausible.io) but did not bump
+# this guard — drift fixed here. The CIDR ranges live in a SEPARATE interval
+# set/file (cron-egress-allowlist-cidr.txt) and are NOT counted here.
 HOST_COUNT="$(grep -vcE '^[[:space:]]*#|^[[:space:]]*$' "$ALLOWLIST")"
-if [[ "$HOST_COUNT" -eq 22 ]]; then
-  PASS=$((PASS + 1)); echo "  PASS: allowlist host count is exactly 22"
+if [[ "$HOST_COUNT" -eq 23 ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: allowlist host count is exactly 23"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: allowlist host count is $HOST_COUNT (expected 22 — update BOTH the allowlist and this test with evidence)"
+  FAIL=$((FAIL + 1)); echo "  FAIL: allowlist host count is $HOST_COUNT (expected 23 — update BOTH the allowlist and this test with evidence)"
 fi
 assert_not_grep "Better Stack is HOST egress (must not be in the container allowlist)" '^(logs\.)?(betterstack|betteruptime)' "$ALLOWLIST"
 assert_not_grep "GHCR is HOST egress (must not be in the container allowlist)" '^ghcr\.io$' "$ALLOWLIST"

--- a/apps/web-platform/infra/cron-egress-nftables.sh
+++ b/apps/web-platform/infra/cron-egress-nftables.sh
@@ -50,6 +50,17 @@ fi
 BRIDGE_GW="$(docker network inspect bridge -f '{{(index .IPAM.Config 0).Gateway}}' 2>/dev/null || true)"
 [[ -n "$BRIDGE_GW" ]] || BRIDGE_GW="172.17.0.1"
 
+# Static CIDR allowlist for hosts that LB git/web traffic across a rotating IP
+# pool the per-tick single-IP resolver cannot cover (GitHub git ranges). These
+# are populated into an INTERVAL set (type ipv4_addr + flags interval) — the
+# dynamic single-IP set (soleur_egress_allow) is left untouched. See
+# cron-egress-allowlist-cidr.txt. Empty/missing file → empty set (no effect).
+CIDR_FILE="${CIDR_FILE:-/etc/soleur/cron-egress-allowlist-cidr.txt}"
+CIDR_ELEMENTS=""
+if [[ -f "$CIDR_FILE" ]]; then
+  CIDR_ELEMENTS="$(grep -vE '^[[:space:]]*(#|$)' "$CIDR_FILE" | paste -sd, -)"
+fi
+
 # --- Phase 1: declare table/sets/chains (additive, idempotent) -----------------
 # `nft -f` table declarations MERGE into existing state — safe to re-run.
 # DOCKER-USER is declared too so this works even before dockerd starts
@@ -58,6 +69,10 @@ nft -f - <<EOF
 table ip filter {
   set soleur_egress_allow {
     type ipv4_addr
+  }
+  set soleur_egress_allow_cidr {
+    type ipv4_addr
+    flags interval
   }
   set soleur_egress_dns {
     type ipv4_addr
@@ -68,6 +83,18 @@ table ip filter {
   }
 }
 EOF
+
+# --- Phase 1.5: populate the static CIDR set (atomic flush+repopulate) ----------
+# Unlike the dynamic single-IP set (whose flush would open an empty-drop window
+# mid-tick), this set is STATIC, so an atomic one-transaction flush+add is safe
+# and idempotent across loader re-runs (avoids "element already exists" on the
+# interval set). Skipped when the file is empty/absent.
+if [[ -n "$CIDR_ELEMENTS" ]]; then
+  nft -f - <<EOF
+flush set ip filter soleur_egress_allow_cidr
+add element ip filter soleur_egress_allow_cidr { $CIDR_ELEMENTS }
+EOF
+fi
 
 # --- Phase 2: populate the sets BEFORE any drop rule exists --------------------
 # CRON_EGRESS_FROM_LOADER=1 suppresses the resolver's enforcement self-heal
@@ -91,6 +118,7 @@ add rule ip filter SOLEUR-EGRESS tcp dport 53 limit rate 10/minute burst 50 pack
 add rule ip filter SOLEUR-EGRESS tcp dport 53 counter drop comment "soleur-egress: dns exfil drop tcp"
 add rule ip filter SOLEUR-EGRESS ip daddr $BRIDGE_GW tcp dport 8288 accept comment "soleur-egress: host-gateway inngest"
 add rule ip filter SOLEUR-EGRESS ip daddr @soleur_egress_allow accept comment "soleur-egress: allowlist"
+add rule ip filter SOLEUR-EGRESS ip daddr @soleur_egress_allow_cidr accept comment "soleur-egress: cidr allowlist (github git LB ranges)"
 add rule ip filter SOLEUR-EGRESS limit rate 10/minute burst 50 packets log prefix "egress-blocked: " level notice comment "soleur-egress: default drop log"
 add rule ip filter SOLEUR-EGRESS counter drop comment "soleur-egress: default drop"
 EOF

--- a/apps/web-platform/infra/server.tf
+++ b/apps/web-platform/infra/server.tf
@@ -44,6 +44,7 @@ resource "hcloud_server" "web" {
     cron_egress_resolve_script_b64       = base64encode(file("${path.module}/cron-egress-resolve.sh"))
     cron_egress_alarm_script_b64         = base64encode(file("${path.module}/cron-egress-alarm.sh"))
     cron_egress_allowlist_b64            = base64encode(file("${path.module}/cron-egress-allowlist.txt"))
+    cron_egress_allowlist_cidr_b64       = base64encode(file("${path.module}/cron-egress-allowlist-cidr.txt"))
     cron_egress_firewall_service_b64     = base64encode(file("${path.module}/cron-egress-firewall.service"))
     cron_egress_resolve_service_b64      = base64encode(file("${path.module}/cron-egress-resolve.service"))
     cron_egress_resolve_timer_b64        = base64encode(file("${path.module}/cron-egress-resolve.timer"))
@@ -725,6 +726,7 @@ resource "terraform_data" "cron_egress_firewall" {
       file("${path.module}/cron-egress-resolve.sh"),
       file("${path.module}/cron-egress-alarm.sh"),
       file("${path.module}/cron-egress-allowlist.txt"),
+      file("${path.module}/cron-egress-allowlist-cidr.txt"),
       file("${path.module}/cron-egress-firewall.service"),
       file("${path.module}/cron-egress-resolve.service"),
       file("${path.module}/cron-egress-resolve.timer"),
@@ -773,6 +775,11 @@ resource "terraform_data" "cron_egress_firewall" {
   }
 
   provisioner "file" {
+    source      = "${path.module}/cron-egress-allowlist-cidr.txt"
+    destination = "/etc/soleur/cron-egress-allowlist-cidr.txt"
+  }
+
+  provisioner "file" {
     source      = "${path.module}/cron-egress-firewall.service"
     destination = "/etc/systemd/system/cron-egress-firewall.service"
   }
@@ -811,6 +818,8 @@ resource "terraform_data" "cron_egress_firewall" {
       "nft list chain ip filter SOLEUR-EGRESS | grep -q 'egress-dns-exfil'",
       "nft list chain ip filter SOLEUR-EGRESS | grep -q 'dport 8288 accept'",
       "nft list set ip filter soleur_egress_allow | grep -qE '[0-9]+[.][0-9]+[.][0-9]+[.][0-9]+'",
+      "nft list chain ip filter SOLEUR-EGRESS | grep -q 'cidr allowlist'",
+      "nft list set ip filter soleur_egress_allow_cidr | grep -q '140.82.112.0/20'",
       "docker network inspect bridge -f '{{.EnableIPv6}}' | grep -qx false",
       "systemctl is-active cron-egress-firewall.service cron-egress-resolve.timer",
       # ...and ENFORCEMENT: egress-probe-positive — an allowlisted host reaches


### PR DESCRIPTION
## Summary

The container egress firewall is dropping `git clone` for **21 GitHub-cloning crons** (content-publisher, content-generator, bug-fixer, legal-audit, …) because it pins `github.com` to a single resolved IP per tick while GitHub load-balances git across `140.82.112.0/20`. This surfaced as the loop-engineering social posts never publishing (#5088).

## Root cause (Sentry-evidenced)

- `soleur_egress_allow` is `type ipv4_addr` (single IPs); `cron-egress-resolve.sh` pins one IP per host per tick.
- GitHub git LB rotates across `140.82.112.0/20`; a clone dials an unpinned IP → firewall default-drop.
- Evidence: Sentry `egress-blocked` `DST=140.82.121.5` (`lb-140-82-121-5-fra.github.com`) correlated with `Cron failure: scheduled-content-publisher` (2026-06-12, n=305 / n=2).

## Fix

- New `cron-egress-allowlist-cidr.txt` with GitHub's published git CIDRs (`api.github.com/meta .git`).
- `cron-egress-nftables.sh`: static **interval** set `soleur_egress_allow_cidr` (`flags interval`) + accept rule, populated atomically. Dynamic single-IP set + resolver untouched.
- `server.tf` + `cloud-init.yml`: deliver the new file (trigger + file provisioner + post-apply set-populated assertion + fresh-host mirror).
- Count-guard `22 → 23` (pre-existing drift from #5199; not caused here).

## Verification

- `cron-egress-firewall.test.sh`: **109 passed / 0 failed** (new interval-set/rule/file assertions + bumped count).
- `nft -c` syntax-valid; `terraform validate` Success; `terraform fmt` clean.

## Apply

Merging fires `apply-web-platform-infra.yml` (push trigger) → `terraform apply` → the `cron_egress_firewall` `terraform_data` re-applies (delivers files + re-runs the loader, with the live container egress probes). After apply, the `content-publisher` cron is re-fired to publish #5088's posts.

## Changelog

- Allow GitHub git CIDR ranges in the cron egress firewall so GitHub-cloning crons stop intermittently failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
