### PR TITLE
skill: reproduce-bug — check Sentry + Better Stack first when debugging

### DIFF
--- a/plugins/soleur/skills/reproduce-bug/SKILL.md
+++ b/plugins/soleur/skills/reproduce-bug/SKILL.md
@@ -25,7 +25,7 @@ Think about the places it could go wrong looking at the codebase. Look for loggi
    ```
    Then drill into the issue's latest event for `extra` (carries the operative detail — a blocked `DST=` IP, a vendor status, the failing arg). Note: a cron-monitor **error check-in** carries no stack trace; the real exception is a separate `reportSilentFallback`/`captureException` issue — query for it.
 
-2. **Better Stack** logs (the app's pino stream, historical) via `scripts/betterstack-query.sh` (ClickHouse SQL over the Telemetry warehouse). Runbook: `knowledge-base/engineering/operations/runbooks/betterstack-log-query.md`. The failing fetch's error (with the HOSTNAME) lives here.
+2. **Better Stack** logs (the app's pino stream, historical) via the repo-root [betterstack-query.sh](../../../../scripts/betterstack-query.sh) helper (ClickHouse SQL over the Telemetry warehouse). Runbook: `knowledge-base/engineering/operations/runbooks/betterstack-log-query.md`. The failing fetch's error (with the HOSTNAME) lives here.
 
 3. Check recent commits related to the affected area, then inspect the relevant code paths — now anchored on the real error, not a guess.
 

--- a/plugins/soleur/skills/reproduce-bug/SKILL.md
+++ b/plugins/soleur/skills/reproduce-bug/SKILL.md
@@ -11,11 +11,25 @@ Look at github issue #$ARGUMENTS and read the issue description and comments.
 
 Think about the places it could go wrong looking at the codebase. Look for logging output to search for.
 
-Search application logs, error tracking, and recent git history for clues:
+**Check the observability layer FIRST — before hypothesizing from code.** Server-side / cron / prod failures usually have the real error (the exact failing step, hostname, status, stack) already captured in Sentry or Better Stack. Pull it before theorizing — a code-trace guess can burn many cycles that one Sentry event resolves.
 
-1. Check recent commits related to the affected area
-2. Search for error messages or stack traces in logs
-3. Inspect the relevant code paths for potential failure points
+1. **Sentry** — query the project's issues for the error (the `incident` skill's toolchain). Tokens + slugs live in Doppler `prd`: `SENTRY_ISSUE_RW_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_API_HOST` (host needs the `https://` scheme). Example:
+
+   ```bash
+   ORG=$(doppler secrets get SENTRY_ORG -p soleur -c prd --plain)
+   PROJ=$(doppler secrets get SENTRY_PROJECT -p soleur -c prd --plain)
+   TOK=$(doppler secrets get SENTRY_ISSUE_RW_TOKEN -p soleur -c prd --plain)
+   curl -s -H "Authorization: Bearer $TOK" \
+     "https://jikigai-eu.sentry.io/api/0/projects/$ORG/$PROJ/issues/?query=<keyword>&statsPeriod=24h&limit=5" \
+     | jq -r '.[]? | "\(.lastSeen) | \(.title) | n=\(.count)"'
+   ```
+   Then drill into the issue's latest event for `extra` (carries the operative detail — a blocked `DST=` IP, a vendor status, the failing arg). Note: a cron-monitor **error check-in** carries no stack trace; the real exception is a separate `reportSilentFallback`/`captureException` issue — query for it.
+
+2. **Better Stack** logs (the app's pino stream, historical) via `scripts/betterstack-query.sh` (ClickHouse SQL over the Telemetry warehouse). Runbook: `knowledge-base/engineering/operations/runbooks/betterstack-log-query.md`. The failing fetch's error (with the HOSTNAME) lives here.
+
+3. Check recent commits related to the affected area, then inspect the relevant code paths — now anchored on the real error, not a guess.
+
+**Why (#5088):** a cron silently failed to publish; several turns went to code hypotheses before pulling the Sentry `egress-blocked` event, which pinpointed the firewall dropping a GitHub clone IP in one read. The observability layer already had the answer. See `knowledge-base/engineering/operations/runbooks/cron-egress-blocked.md` for the egress-specific diagnosis path.
 
 Keep investigating until a good understanding of the situation is reached.
 


### PR DESCRIPTION
## Summary

Adds concrete observability-first tooling to the reproduce-bug skill Phase 1: query Sentry (`SENTRY_ISSUE_RW_TOKEN` + org/project) and Better Stack (via the `scripts/betterstack-query.sh` helper) BEFORE hypothesizing from code. Operator feedback during #5088 debugging.

## Changelog

- reproduce-bug skill now prescribes checking Sentry + Better Stack logs first when debugging server/cron/prod failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)