### PR TITLE
fix(infra): restart cron-egress-firewall.service so new CIDR actually loads

### DIFF
--- a/apps/web-platform/infra/cron-egress-firewall.test.sh
+++ b/apps/web-platform/infra/cron-egress-firewall.test.sh
@@ -112,6 +112,15 @@ if echo "$SERVER_BLOCK" | grep -q 'egress-probe-positive'; then
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: post-apply positive container probe missing"
 fi
+# The service is Type=oneshot/RemainAfterExit=yes, so `enable --now` no-ops on an
+# already-active unit and the loader never re-reads a freshly-provisioned CIDR file
+# (the inert-fix bug behind incident 5516336). The provisioner MUST `restart` to
+# re-run the loader so file changes actually load into the live nft set.
+if echo "$SERVER_BLOCK" | grep -q 'systemctl restart cron-egress-firewall\.service'; then
+  PASS=$((PASS + 1)); echo "  PASS: provisioner restarts the firewall service (reloads new CIDR; not a no-op enable --now)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: provisioner must 'systemctl restart cron-egress-firewall.service' — enable --now no-ops on the active oneshot and a new CIDR file never loads"
+fi
 
 echo "-- apply workflow SSH -target --"
 assert_grep "workflow -targets cron_egress_firewall" 'target=terraform_data\.cron_egress_firewall' "$WORKFLOW"

--- a/apps/web-platform/infra/server.tf
+++ b/apps/web-platform/infra/server.tf
@@ -810,7 +810,17 @@ resource "terraform_data" "cron_egress_firewall" {
       "set -e",
       "chmod +x /usr/local/bin/cron-egress-nftables.sh /usr/local/bin/cron-egress-resolve.sh /usr/local/bin/cron-egress-alarm.sh",
       "systemctl daemon-reload",
-      "systemctl enable --now cron-egress-firewall.service",
+      # `enable` for boot-persistence; `restart` to RE-RUN the loader NOW. The
+      # service is Type=oneshot/RemainAfterExit=yes, so `enable --now` (= start)
+      # no-ops on an already-active unit — the loader never re-reads the
+      # freshly-provisioned cron-egress-allowlist-cidr.txt and the new CIDR
+      # ranges sit on disk but absent from the live nft set (the inert-fix bug
+      # behind the still-missed scheduled-ruleset-bypass-audit check-in,
+      # incident 5516336). The loader populates the sets BEFORE installing the
+      # default-drop (availability ordering, asserted in cron-egress-firewall.test.sh),
+      # so a restart carries no egress gap — it is the same operation that runs at boot.
+      "systemctl enable cron-egress-firewall.service",
+      "systemctl restart cron-egress-firewall.service",
       "systemctl enable --now cron-egress-resolve.timer",
       # Positive post-apply assertions (fail2ban_tuning pattern): structure...
       "nft list chain ip filter DOCKER-USER | grep -q 'jump SOLEUR-EGRESS'",


### PR DESCRIPTION
## Summary

Follow-up hotfix to #5281. That PR extended the GitHub `/meta` CIDR coverage and added a post-apply assert for a `20./4.` element, but the `apply-web-platform-infra.yml` terraform apply **failed**: `cron-egress-firewall.service` is `Type=oneshot RemainAfterExit=yes`, so `systemctl enable --now` is a **no-op on the already-active unit** — the loader never re-read the freshly-provisioned `cron-egress-allowlist-cidr.txt`, so the new 52-range set was on disk but **never loaded into the live nft set**. The cron stayed broken and #5281's post-apply assert correctly caught the inert fix.

This changes the remote-exec to `systemctl enable` + `systemctl restart cron-egress-firewall.service` so the loader re-runs with the new file. The loader populates the allow sets (atomic `flush set`+`add element`) BEFORE installing the default-drop (availability ordering, asserted in `cron-egress-firewall.test.sh`), so the restart carries no egress gap — it is the same operation that runs at boot. Reviewed by architecture-strategist (atomic transactions, flock serialization, fail-open+alarm unchanged): no P1/P2.

Ref #5284 (durable self-refreshing /meta generator follow-up)

## User-Brand Impact

- **Artifact exposed:** the `scheduled-ruleset-bypass-audit` CI-ruleset bypass-actor drift tripwire (still dark after #5281 because the new CIDR ranges never loaded into the running firewall).
- **Exposure vector:** silent control failure persists — without the loader restart, the firewall keeps the old 4-range allowlist and `api.github.com` calls landing on uncovered Azure IPs stay default-dropped, so the audit cron keeps missing check-ins and the recurring `apply-web-platform-infra.yml` apply keeps failing (tainted resource).
- **Brand-survival threshold:** single-user incident

## Changelog

### Web Platform (infra)
- Change the `cron_egress_firewall` remote-exec from `enable --now` to `enable` + `restart` so the loader re-runs and loads the current CIDR file on every apply.
- Add a drift-guard asserting the provisioner restarts the service (locks out regression to the inert `enable --now`).

## Test plan

- [x] `cron-egress-firewall.test.sh`: 139/0 (new restart drift-guard passes).
- [x] `server-tf-set-e.test.sh`: 13/13.
- [x] `terraform fmt -check` + `terraform validate` + `terraform-target-parity` (12/0) green.
- [x] architecture-strategist review: no egress gap, flock-serialized, fail-open+alarm unchanged, assert-ordering correct.
- Post-merge: `apply-web-platform-infra.yml` re-applies, loads the 52-range set, the post-apply `20./4.` assert passes, and the Sentry monitor recovers on the next fire.

Generated with [Claude Code](https://claude.com/claude-code)