### PR TITLE
fix(concierge): runtime CWD-verify-loop guardrail — honest worktree_enter_failed status (#5313)

### DIFF
--- a/apps/web-platform/lib/types.ts
+++ b/apps/web-platform/lib/types.ts
@@ -40,6 +40,16 @@ export const WORKFLOW_END_STATUSES = [
   // `cc-dispatcher.onWorkflowEnded` routes it to the terminal
   // `session_ended` family (see TERMINAL_WORKFLOW_END_STATUSES).
   "session_revoked",
+  // #5313 (deferred #5240 FR-half) — the worktree-rebind loop. Emitted by
+  // the runner's command-pattern detector when N=3 consecutive
+  // near-identical `cd <path> && pwd` CWD-verification commands return a
+  // `pwd` that does not equal the expected worktree path (the Bash bwrap
+  // sandbox could not enter the worktree). A fast, honest terminal state
+  // so the operator sees "couldn't enter the workspace" in seconds instead
+  // of the agent looping the verify command until the 10-min runner_runaway
+  // breaker fires with a generic status. `z.enum(WORKFLOW_END_STATUSES)` in
+  // `ws-zod-schemas.ts` reuses this tuple — no duplicate enum to update.
+  "worktree_enter_failed",
 ] as const;
 export type WorkflowEndStatus = typeof WORKFLOW_END_STATUSES[number];
 

--- a/apps/web-platform/server/cc-dispatcher.ts
+++ b/apps/web-platform/server/cc-dispatcher.ts
@@ -446,6 +446,10 @@ const ABORT_FLUSH_STATUSES: ReadonlySet<WorkflowEndStatus> = new Set<
   // `aborted` BEFORE the terminal session_ended emit. Matches the
   // semantic of every other non-completed terminal status.
   "session_revoked",
+  // #5313 (deferred #5240 FR-half) — worktree-enter failure is a
+  // non-completed terminal status; flush partial text before the terminal
+  // emit like every sibling.
+  "worktree_enter_failed",
 ]);
 
 // Compile-time exhaustiveness rail for `ABORT_FLUSH_STATUSES`.
@@ -460,6 +464,7 @@ const _abortFlushExhaustive: Record<AbortFlushStatus, true> = {
   plugin_load_failure: true,
   internal_error: true,
   session_revoked: true,
+  worktree_enter_failed: true,
 };
 void _abortFlushExhaustive;
 

--- a/apps/web-platform/server/cc-workflow-end-messages.ts
+++ b/apps/web-platform/server/cc-workflow-end-messages.ts
@@ -42,6 +42,12 @@ export const WORKFLOW_END_USER_MESSAGES: Record<WorkflowEndStatus, string> = {
   // founder's perspective without context.
   session_revoked:
     "Your session was revoked by an operator. Contact support to restore access.",
+  // #5313 (deferred #5240 FR-half) — honest copy for the worktree-rebind
+  // loop. Routing this through the WorkflowEnd error path (not the client
+  // activity-watchdog) is what displaces the misleading "Agent stopped
+  // responding" banner: the operator sees an accurate, actionable status.
+  worktree_enter_failed:
+    "Couldn't open a workspace to run that step. Try sending your message again.",
 };
 
 // Compile-time exhaustiveness rail. If a new variant lands in

--- a/apps/web-platform/server/soleur-go-runner.ts
+++ b/apps/web-platform/server/soleur-go-runner.ts
@@ -532,6 +532,13 @@ export const DEFAULT_WALL_CLOCK_TRIGGER_MS = 90 * 1000;
 // activity; cost cap fires only at SDKResultMessage boundaries). Anchored
 // on `turnOriginAt` set once when the first block of a turn arrives.
 export const DEFAULT_MAX_TURN_DURATION_MS = 10 * 60 * 1000;
+// #5313 (deferred #5240 FR-half) — consecutive mismatched `cd <path> && pwd`
+// CWD-verification commands before the runner emits `worktree_enter_failed`.
+// The observed 4826-session loop ran 4+ identical iterations before the turn
+// died; 3 is below that and well above any single transient-fs jitter. A
+// bounded counter (modeled on LEADER_MAX_TURNS), not a duration — it fires in
+// seconds, where the `runner_runaway` duration breaker would take 10 min.
+export const CWD_VERIFY_LOOP_THRESHOLD = 3;
 
 // Recalibrated 2026-04-24 from stream-input rerun (see plan RERUN
 // §"Cost caps vs measured reality"). CFO gate at Stage 6.5.1.
@@ -737,6 +744,17 @@ function flattenToolResultText(content: unknown): string {
   return acc;
 }
 
+/** #5313 — extract the target path from a CWD-verification command of the
+ *  one-shot/plan gate's canonical shape `cd <path> && pwd`. Returns null for
+ *  any other command (a real intervening command breaks the loop). Tolerates
+ *  surrounding whitespace and an optional trailing `&& …` continuation (the
+ *  live loop ran `cd <wt> && pwd && git branch …`). Pure — unit-tested
+ *  directly and exercised by the detector. */
+export function parseCwdVerifyTarget(command: string): string | null {
+  const m = command.match(/^\s*cd\s+(\S+)\s*&&\s*pwd\b/);
+  return m ? m[1] : null;
+}
+
 export type CostCaps = {
   perWorkflow: Partial<Record<WorkflowName, number>>;
   default: number;
@@ -773,7 +791,20 @@ export type WorkflowEnd =
   // `denied_jti.denied_at` timestamp), populated by a best-effort
   // `getMyRevocationStatus(userId)` lookup at emit time. Both nullable
   // because legacy deny rows pre-date the schema columns.
-  | { status: "session_revoked"; reason: string | null; deniedAt: string | null };
+  | { status: "session_revoked"; reason: string | null; deniedAt: string | null }
+  // #5313 (deferred #5240 FR-half) — Bash bwrap sandbox could not enter a
+  // git worktree. Emitted by the command-pattern CWD-verify-loop detector
+  // (`handleUserMessage`) after `CWD_VERIFY_LOOP_THRESHOLD` consecutive
+  // near-identical `cd <expectedPath> && pwd` commands returned a `pwd`
+  // (`observedCwd`) that did not equal `expectedPath`. `attempts` is the
+  // consecutive-mismatch count at fire time. Routes through the same honest
+  // terminal-error path as `runner_runaway` but fires in seconds, not 10 min.
+  | {
+      status: "worktree_enter_failed";
+      expectedPath: string;
+      observedCwd: string;
+      attempts: number;
+    };
 
 // Cardinality assert (#3827 + ADR-031 amendment 2026-05-15): the runner's
 // `WorkflowEnd["status"]` union MUST equal the wire-protocol
@@ -1608,6 +1639,16 @@ interface ActiveQuery {
    * tool_uses are never recorded here.
    */
   bashToolUses: Map<string, string>;
+  /**
+   * #5313 — CWD-verify-loop detector state. Tracks consecutive
+   * near-identical `cd <expectedPath> && pwd` commands whose observed `pwd`
+   * did not equal `expectedPath` (the Bash sandbox could not enter the
+   * worktree). Reset to `null` on any non-CWD-verify command, a different
+   * target path, or a successful verify. Fires `worktree_enter_failed` at
+   * `count >= CWD_VERIFY_LOOP_THRESHOLD`. Compliance-independent: keyed on
+   * observed Bash tool-results, not a cooperative agent marker.
+   */
+  cwdVerifyLoop: { expectedPath: string; count: number } | null;
 }
 
 /**
@@ -2067,6 +2108,65 @@ export function createSoleurGoRunner(deps: SoleurGoRunnerDeps): SoleurGoRunner {
   // `state.turnHardCap` — the 10-min absolute ceiling stays anchored on
   // `firstToolUseAt` (defense pair from PR #3225 + learning
   // 2026-05-05-defense-relaxation-must-name-new-ceiling.md).
+  // #5313 — command-pattern CWD-verify-loop detector. Compliance-independent:
+  // keyed on observed Bash command + result text, NOT a cooperative
+  // agent-emitted marker (the live agent ignored the prose "abort" contract).
+  // Returns true (and emits `worktree_enter_failed`) when `expectedPath`
+  // mismatches `observedCwd` for `CWD_VERIFY_LOOP_THRESHOLD` consecutive
+  // same-target commands. Routing through `emitWorkflowEnded` clears BOTH
+  // timers + sets `state.closed` (single-terminal invariant, FR2.4) — so the
+  // armed `runner_runaway` timer cannot double-fire a second WorkflowEnd.
+  function detectCwdVerifyLoop(
+    state: ActiveQuery,
+    command: string,
+    output: string,
+  ): boolean {
+    const expectedPath = parseCwdVerifyTarget(command);
+    if (expectedPath === null) {
+      // A real intervening command breaks the loop.
+      state.cwdVerifyLoop = null;
+      return false;
+    }
+    const observedCwd = output.trim();
+    if (observedCwd === expectedPath) {
+      // Verify succeeded — the sandbox entered the worktree. Reset.
+      state.cwdVerifyLoop = null;
+      return false;
+    }
+    if (
+      state.cwdVerifyLoop &&
+      state.cwdVerifyLoop.expectedPath === expectedPath
+    ) {
+      state.cwdVerifyLoop.count += 1;
+    } else {
+      state.cwdVerifyLoop = { expectedPath, count: 1 };
+    }
+    if (state.cwdVerifyLoop.count < CWD_VERIFY_LOOP_THRESHOLD) return false;
+    const attempts = state.cwdVerifyLoop.count;
+    state.cwdVerifyLoop = null;
+    log.warn(
+      { conversationId: state.conversationId, expectedPath, observedCwd, attempts },
+      "worktree_enter_failed (CWD-verify loop)",
+    );
+    // Operator-visible degraded-path error, not a write-boundary/GDPR breach
+    // → reportSilentFallback (error tier), NOT mirrorP0Deduped (fatal + page).
+    reportSilentFallback(
+      new Error("worktree enter failed: Bash sandbox could not enter the worktree"),
+      {
+        feature: "agent-sandbox",
+        op: "worktree_enter",
+        extra: { conversationId: state.conversationId, expectedPath, observedCwd, attempts },
+      },
+    );
+    emitWorkflowEnded(state, {
+      status: "worktree_enter_failed",
+      expectedPath,
+      observedCwd,
+      attempts,
+    });
+    return true;
+  }
+
   function handleUserMessage(state: ActiveQuery, msg: SDKUserMessage): void {
     if (msg.tool_use_result === undefined) return;
     if (state.closed || state.awaitingUser) return;
@@ -2084,6 +2184,10 @@ export function createSoleurGoRunner(deps: SoleurGoRunnerDeps): SoleurGoRunner {
         for (const result of extractBashToolResults(msg, state.bashToolUses)) {
           state.bashToolUses.delete(result.toolUseId);
           state.events.onToolResult(result);
+          // #5313 — fire the bounded CWD-verify-loop guardrail. On fire the
+          // turn is terminated (emitWorkflowEnded sets state.closed) — stop
+          // processing further results this message.
+          if (detectCwdVerifyLoop(state, result.command, result.output)) return;
         }
       } catch (err) {
         reportSilentFallback(err, {
@@ -2482,6 +2586,7 @@ export function createSoleurGoRunner(deps: SoleurGoRunnerDeps): SoleurGoRunner {
         chapterExtractionFailures: 0,
         _pendingPdfRotationNotice: false,
         bashToolUses: new Map(),
+        cwdVerifyLoop: null,
       };
       activeQueries.set(conversationId, state);
 

--- a/apps/web-platform/server/soleur-go-runner.ts
+++ b/apps/web-platform/server/soleur-go-runner.ts
@@ -745,13 +745,18 @@ function flattenToolResultText(content: unknown): string {
 }
 
 /** #5313 — extract the target path from a CWD-verification command of the
- *  one-shot/plan gate's canonical shape `cd <path> && pwd`. Returns null for
- *  any other command (a real intervening command breaks the loop). Tolerates
- *  surrounding whitespace and an optional trailing `&& …` continuation (the
- *  live loop ran `cd <wt> && pwd && git branch …`). Pure — unit-tested
- *  directly and exercised by the detector. */
+ *  one-shot/plan gate's canonical shape `cd <path> && pwd` (END-ANCHORED — the
+ *  gate at one-shot/SKILL.md is exactly this form, no trailing continuation).
+ *  Returns null for any other command — including a `cd … && pwd && <more>`
+ *  variant, which (correctly) breaks the loop and resets the counter. The
+ *  end-anchor is load-bearing for correctness, not just tightness: a successful
+ *  `cd <p> && pwd` prints exactly `<p>`, so the detector's `output.trim() ===
+ *  expectedPath` success-reset fires. A tolerated trailing `&& git branch`
+ *  would make a HEALTHY worktree's output a multi-line superset that never
+ *  equals the path, falsely accumulating mismatches toward the threshold
+ *  (review P2). Pure — unit-tested directly and exercised by the detector. */
 export function parseCwdVerifyTarget(command: string): string | null {
-  const m = command.match(/^\s*cd\s+(\S+)\s*&&\s*pwd\b/);
+  const m = command.match(/^\s*cd\s+(\S+)\s*&&\s*pwd\s*$/);
   return m ? m[1] : null;
 }
 
@@ -2127,7 +2132,10 @@ export function createSoleurGoRunner(deps: SoleurGoRunnerDeps): SoleurGoRunner {
       state.cwdVerifyLoop = null;
       return false;
     }
-    const observedCwd = output.trim();
+    // Cap at 256 (this file's log-field convention) — a real `pwd` is always
+    // short; a pathological huge output is bounded in the log/Sentry `extra`
+    // and correctly treated as a mismatch (fail-safe, not fail-open). (review P3)
+    const observedCwd = output.trim().slice(0, 256);
     if (observedCwd === expectedPath) {
       // Verify succeeded — the sandbox entered the worktree. Reset.
       state.cwdVerifyLoop = null;
@@ -2186,7 +2194,12 @@ export function createSoleurGoRunner(deps: SoleurGoRunnerDeps): SoleurGoRunner {
           state.events.onToolResult(result);
           // #5313 — fire the bounded CWD-verify-loop guardrail. On fire the
           // turn is terminated (emitWorkflowEnded sets state.closed) — stop
-          // processing further results this message.
+          // processing further results this message. NOTE: this whole block is
+          // gated on `onToolResult` being wired, which today only the cc-soleur-go
+          // (Concierge) path does — exactly the surface that hit the 4826 loop.
+          // A future runner consumer that streams tool-results must wire
+          // onToolResult to inherit this guard; the legacy agent-runner path
+          // relies on its own runaway breaker.
           if (detectCwdVerifyLoop(state, result.command, result.output)) return;
         }
       } catch (err) {

--- a/apps/web-platform/test/cc-workflow-end-messages.test.ts
+++ b/apps/web-platform/test/cc-workflow-end-messages.test.ts
@@ -26,6 +26,8 @@ describe("WORKFLOW_END_USER_MESSAGES", () => {
       // Routes to the terminal session_ended family via
       // TERMINAL_WORKFLOW_END_STATUSES in cc-dispatcher.ts.
       "session_revoked",
+      // #5313 (deferred #5240 FR-half) — worktree-rebind loop guardrail.
+      "worktree_enter_failed",
     ];
     const actualKeys = Object.keys(WORKFLOW_END_USER_MESSAGES).sort();
     expect(actualKeys).toEqual([...expectedKeys].sort());
@@ -48,6 +50,15 @@ describe("WORKFLOW_END_USER_MESSAGES", () => {
     );
     expect(WORKFLOW_END_USER_MESSAGES.session_revoked).toContain(
       "revoked",
+    );
+
+    // #5313 AC7 — the worktree-enter failure surfaces an honest, actionable
+    // status and NEVER the misleading "Agent stopped responding" banner.
+    expect(WORKFLOW_END_USER_MESSAGES.worktree_enter_failed).toContain(
+      "workspace",
+    );
+    expect(WORKFLOW_END_USER_MESSAGES.worktree_enter_failed).not.toContain(
+      "Agent stopped responding",
     );
 
     // Defense-in-depth: NO entry should leak the status token verbatim

--- a/apps/web-platform/test/soleur-go-runner-worktree-enter-failed.test.ts
+++ b/apps/web-platform/test/soleur-go-runner-worktree-enter-failed.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import {
+  createMockQueryScripted as createMockQuery,
+  makeAssistant,
+  makeRecordingEvents as makeEvents,
+  flushMicrotasks,
+} from "./helpers/soleur-go-fixtures";
+
+// Mock observability BEFORE importing the runner so `reportSilentFallback`
+// resolves to the mock (and doesn't pull pino into the test bundle).
+const { mockReportSilentFallback } = vi.hoisted(() => ({
+  mockReportSilentFallback: vi.fn(),
+}));
+vi.mock("@/server/observability", () => ({
+  reportSilentFallback: mockReportSilentFallback,
+  warnSilentFallback: vi.fn(),
+}));
+
+import { createSoleurGoRunner, type WorkflowEnd } from "@/server/soleur-go-runner";
+
+// RED tests for #5313 (deferred #5240 FR-half): the worktree-rebind loop.
+// The runner must detect a Bash CWD-verification loop — N=3 consecutive
+// near-identical `cd <path> && pwd` commands whose output does NOT equal the
+// expected worktree path — and terminate the turn with a `worktree_enter_failed`
+// WorkflowEnd (fast, honest), instead of letting the agent loop until the
+// 10-min runaway breaker. Detection is COMMAND-PATTERN-DRIVEN off observed Bash
+// tool-results (extractBashToolResults), NOT a cooperative agent-emitted marker
+// (the agent ignores prose contracts — it ignored "abort").
+
+const WORKTREE = "/workspaces/abc/.worktrees/feat-x";
+const VERIFY_CMD = `cd ${WORKTREE} && pwd`;
+const WRONG_CWD = "/home/soleur"; // bwrap fell back to $HOME — the bug signature
+
+/** A `tool_result` user message with a settable output string (the observed
+ *  `pwd`). Mirrors makeUserToolResult but parameterizes `content`. */
+function makeBashResult(toolUseId: string, output: string): SDKUserMessage {
+  return {
+    type: "user",
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: toolUseId, content: output }],
+      // biome-ignore lint/suspicious/noExplicitAny: minimal SDK fixture
+    } as any,
+    parent_tool_use_id: null,
+    isSynthetic: true,
+    tool_use_result: { ok: true },
+    session_id: "sess-1",
+  } as SDKUserMessage;
+}
+
+function bashToolUse(id: string, command: string) {
+  return makeAssistant({
+    content: [{ type: "tool_use", id, name: "Bash", input: { command } }],
+  });
+}
+
+async function dispatchRunner(conversationId: string) {
+  const mock = createMockQuery();
+  const runner = createSoleurGoRunner({
+    queryFactory: () => mock.query,
+    now: () => Date.now(),
+  });
+  const events = makeEvents();
+  // The runner only records Bash commands into bashToolUses (and runs the
+  // CWD-verify detector) when onToolResult is wired — the cc-soleur-go path.
+  events.onToolResult = vi.fn();
+  await runner.dispatch({
+    conversationId,
+    userId: "u1",
+    userMessage: "fix issue",
+    currentRouting: { kind: "soleur_go_pending" },
+    events,
+    persistActiveWorkflow: vi.fn().mockResolvedValue(undefined),
+  });
+  return { mock, events };
+}
+
+describe("soleur-go-runner — worktree-enter CWD-verify loop guardrail (#5313)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    mockReportSilentFallback.mockClear();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  // AC1: 3 consecutive identical `cd <wt> && pwd` with a mismatched pwd output
+  // → fast `worktree_enter_failed` with the diagnostic triple + Sentry mirror.
+  it("fires worktree_enter_failed after 3 mismatched CWD-verify commands", async () => {
+    const { mock, events } = await dispatchRunner("conv-loop");
+    for (let i = 1; i <= 3; i++) {
+      mock.emit(bashToolUse(`tu${i}`, VERIFY_CMD));
+      await flushMicrotasks();
+      mock.emit(makeBashResult(`tu${i}`, WRONG_CWD));
+      await flushMicrotasks();
+    }
+    const end = events._ended.find(
+      (e) => (e.status as string) === "worktree_enter_failed",
+    ) as (WorkflowEnd & { expectedPath?: string; observedCwd?: string; attempts?: number }) | undefined;
+    expect(end).toBeDefined();
+    expect(end!.expectedPath).toBe(WORKTREE);
+    expect(end!.observedCwd).toBe(WRONG_CWD);
+    expect(end!.attempts).toBe(3);
+    expect(mockReportSilentFallback).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ feature: "agent-sandbox", op: "worktree_enter" }),
+    );
+  });
+
+  // Counter-case: 2 mismatched then a MATCHING pwd resets the counter — no fire.
+  it("does NOT fire when the CWD-verify eventually succeeds", async () => {
+    const { mock, events } = await dispatchRunner("conv-ok");
+    for (let i = 1; i <= 2; i++) {
+      mock.emit(bashToolUse(`tu${i}`, VERIFY_CMD));
+      await flushMicrotasks();
+      mock.emit(makeBashResult(`tu${i}`, WRONG_CWD));
+      await flushMicrotasks();
+    }
+    // Third attempt SUCCEEDS (pwd === expected) → resets the loop counter.
+    mock.emit(bashToolUse("tu3", VERIFY_CMD));
+    await flushMicrotasks();
+    mock.emit(makeBashResult("tu3", WORKTREE));
+    await flushMicrotasks();
+    expect(
+      events._ended.find((e) => (e.status as string) === "worktree_enter_failed"),
+    ).toBeUndefined();
+  });
+
+  // Non-CWD-verify Bash commands must never trip the detector.
+  it("does NOT fire on unrelated repeated Bash commands", async () => {
+    const { mock, events } = await dispatchRunner("conv-ls");
+    for (let i = 1; i <= 4; i++) {
+      mock.emit(bashToolUse(`tu${i}`, "ls -la"));
+      await flushMicrotasks();
+      mock.emit(makeBashResult(`tu${i}`, "file1\nfile2"));
+      await flushMicrotasks();
+    }
+    expect(
+      events._ended.find((e) => (e.status as string) === "worktree_enter_failed"),
+    ).toBeUndefined();
+  });
+});

--- a/apps/web-platform/test/soleur-go-runner-worktree-enter-failed.test.ts
+++ b/apps/web-platform/test/soleur-go-runner-worktree-enter-failed.test.ts
@@ -126,6 +126,44 @@ describe("soleur-go-runner — worktree-enter CWD-verify loop guardrail (#5313)"
     ).toBeUndefined();
   });
 
+  // AC8 (FR2.4 single-terminal invariant): emitting worktree_enter_failed
+  // clears both timers (via emitWorkflowEnded -> closeQuery) and sets
+  // state.closed, so the armed runner_runaway timer cannot double-fire a
+  // second WorkflowEnd. After the loop fires, advancing past the runaway
+  // ceiling MUST still yield exactly ONE workflow_ended, and it is the
+  // worktree_enter_failed one — not runner_runaway.
+  it("does not double-fire runner_runaway after worktree_enter_failed (single terminal)", async () => {
+    const mock = createMockQuery();
+    const runner = createSoleurGoRunner({
+      queryFactory: () => mock.query,
+      now: () => Date.now(),
+      wallClockTriggerMs: 10_000,
+      maxTurnDurationMs: 30_000,
+    });
+    const events = makeEvents();
+    events.onToolResult = vi.fn();
+    await runner.dispatch({
+      conversationId: "conv-single",
+      userId: "u1",
+      userMessage: "fix",
+      currentRouting: { kind: "soleur_go_pending" },
+      events,
+      persistActiveWorkflow: vi.fn().mockResolvedValue(undefined),
+    });
+    // 3 mismatched verifies arm the timers (first tool_use) AND fire the loop.
+    for (let i = 1; i <= 3; i++) {
+      mock.emit(bashToolUse(`tu${i}`, VERIFY_CMD));
+      await flushMicrotasks();
+      mock.emit(makeBashResult(`tu${i}`, WRONG_CWD));
+      await flushMicrotasks();
+    }
+    // Advance well past both the idle window AND the absolute turn ceiling.
+    vi.advanceTimersByTime(60_000);
+    await flushMicrotasks();
+    expect(events._ended).toHaveLength(1);
+    expect((events._ended[0].status as string)).toBe("worktree_enter_failed");
+  });
+
   // Non-CWD-verify Bash commands must never trip the detector.
   it("does NOT fire on unrelated repeated Bash commands", async () => {
     const { mock, events } = await dispatchRunner("conv-ls");

--- a/knowledge-base/project/brainstorms/2026-06-15-bash-sandbox-worktree-rebind-brainstorm.md
+++ b/knowledge-base/project/brainstorms/2026-06-15-bash-sandbox-worktree-rebind-brainstorm.md
@@ -1,0 +1,144 @@
+---
+title: Bash sandbox worktree-rebind loop — make the bwrap sandbox reach git worktrees
+date: 2026-06-15
+status: brainstorm-complete
+issue: 5313
+parent_epic: 5240
+branch: feat-5240-bash-cwd-worktree-rebind
+pr: 5311
+lane: cross-domain
+brand_survival_threshold: single-user incident
+---
+
+# Brainstorm: Bash sandbox worktree-rebind loop (deferred #5240 FR-half)
+
+## What We're Building
+
+Make the production Concierge's **Bash bwrap sandbox able to enter and operate inside git
+worktrees**, so a worktree-creating session (e.g. `/soleur:go → one-shot → worktree-manager.sh`)
+can pass its CWD-verification gate instead of hanging. Plus a **bounded fail-loud guardrail** so a
+genuinely-unenterable worktree surfaces an honest error instead of looping forever.
+
+This is the **genuine backend stuck-loop** half of #5240, distinct from:
+- **#5256 (merged)** — logical workspace-id rebind + honest status on *reconnect* (FR1/FR4).
+- **#5306 (draft)** — the *UI* false-positive "Agent stopped responding" banner.
+
+The inciting failure: the "Fix Issue 4826" session created a worktree, but every Bash `pwd`
+returned `/home/soleur`, Bash couldn't `ls /workspaces/<uuid>/`, while Read/Edit/Grep read the repo
+fine. The agent looped `pwd && git branch --show-current && git log` 4+ times, then hung.
+
+## Why This Approach
+
+### Confirmed mechanism (code-verified, file:line)
+
+Two categorically different execution contexts:
+- **File tools (Read/Edit/Grep/Glob)** run **in-process** in the Claude Code CLI (Node `fs`) — full
+  container FS visibility, including the `/workspaces` bind-mount. Not bwrap-sandboxed.
+- **Bash** runs in a **bwrap sandbox** whose mount namespace + `cwd` are **frozen once per
+  `query()`**:
+  - `apps/web-platform/server/agent-runner-query-options.ts:149` — `cwd: args.workspacePath`, set
+    once at session start, never re-derived mid-session.
+  - `apps/web-platform/server/agent-runner-sandbox-config.ts:94` — `denyRead: ["/workspaces",
+    "/proc"]`; only the specific `allowWrite: [workspacePath]` is mounted (the `/workspaces` parent
+    is excluded for cross-tenant isolation).
+- **`EnterWorktree` is an SDK-native tool with NO Soleur server-side handler** — it flips a
+  logical/file-tool CWD notion but **cannot rebind the bwrap mount or the Bash subprocess cwd**. A
+  worktree (separate working tree + a `.git` pointer into the bare repo's gitdir) created after
+  session start is therefore unreachable from Bash.
+- **`plugins/soleur/skills/one-shot/SKILL.md:70-76`** — the CWD gate says "abort on mismatch" but
+  has **no bounded-retry escape**; the live agent looped and hung.
+
+**Key correction vs. the original hypothesis:** the fault is **in Soleur's own code** (sandbox
+config + skill gate), NOT the Claude Code harness — so the root cause is fixable in-repo.
+
+### Chosen approach: make the sandbox support worktrees + guardrail
+
+Operator-selected (over "skip worktrees in sandbox" and "guardrail-only"). Re-derive or extend the
+bwrap `cwd` + mount set on worktree entry so worktrees are reachable from Bash, **keeping the
+`/workspaces` cross-tenant `denyRead` intact**. Pairs with the bounded fail-loud guardrail. Most
+robust — preserves worktree branch-isolation inside the sandbox rather than removing the capability.
+
+**Why not the alternatives:**
+- *Skip worktrees in sandbox* — simpler, no security-config risk, but removes a capability the
+  operator wants to keep working in-product.
+- *Guardrail-only* — stops the hang but leaves worktree-creating sessions dead.
+
+## Key Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Root cause is Soleur sandbox config, NOT the harness — fixable in-repo | `agent-runner-sandbox-config.ts` + `agent-runner-query-options.ts` are Soleur code |
+| 2 | Chosen: make the bwrap sandbox reach worktrees (re-derive/extend cwd+mount on entry) | Operator choice; preserves in-product worktree isolation |
+| 3 | Keep `denyRead: ["/workspaces"]` cross-tenant isolation intact | Weakening it would let Bash list sibling tenants' workspaces — security regression |
+| 4 | Ship a bounded fail-loud guardrail regardless (ceiling ~3 → `WorktreeEnterFailed{expectedPath,observedCwd}` → Sentry + honest status) | Circuit breaker, never a mask; converts hang → loud fail; independent of root-cause fix |
+| 5 | Honest failure reuses #5306/#5256 honest-status vocabulary (no NEW UI surface) | Maps onto existing `reconnect-resume-states.pen` "unrecoverable" state |
+| 6 | Security-sentinel + CTO sign-off MANDATORY at plan/review (sandbox-config change) | Touches the bwrap mount/denyRead security boundary |
+| 7 | Capture an ADR for the bwrap-mount-namespace-for-worktrees decision | Cross-session blast radius; CTO flagged `/soleur:architecture create` |
+| 8 | Ref #5240 (keep epic OPEN); Closes the new focused sub-issue | #5240 is the umbrella per the 2026-06-14 parent brainstorm |
+
+## Open Questions
+
+1. **Exact failure trigger (needs runtime repro).** Why did even `ls /workspaces/<uuid>/` return
+   nothing? Three candidates, possibly compounding: (a) the worktree's gitdir pointer escaped the
+   mounted `workspacePath`; (b) `cwd` was frozen at the workspace root, not the worktree subdir, and
+   bwrap fell back to `$HOME` on a failed `chdir`; (c) `workspacePath` itself drifted to the empty
+   solo workspace (the #5240-core binding drift, compounding here). Trace before writing the fix.
+2. **Mount mechanism for re-derivation.** Can the bwrap mount/cwd be re-derived per-tool-call or
+   per-worktree-entry, or only per `query()`? If only per-query, the fix may need to mount the
+   *parent worktrees root* (under `workspacePath`, not `/workspaces`) up-front so any worktree
+   created later is already reachable — verify at plan time.
+3. **Worktree location.** `worktree-manager.sh` creates worktrees at `$GIT_ROOT/.worktrees/<branch>`.
+   Confirm `$GIT_ROOT` resolves *inside* the mounted `workspacePath` in the Concierge clone (not a
+   path under the denyRead'd `/workspaces` parent or the bare-repo gitdir).
+4. **Gitdir reachability.** A worktree's `.git` file points to `<bare>/.git/worktrees/<branch>`.
+   Ensure that gitdir target is inside the mounted namespace so `git -C <worktree>` works, not just
+   `ls`.
+
+## User-Brand Impact
+
+- **Artifact:** the Concierge backend agent-session worktree/Bash execution context
+  (`agent-runner` bwrap sandbox + the one-shot CWD-verification gate).
+- **Vector:** a worktree-creating session hangs indefinitely with no honest signal — the operator
+  watches the agent loop a verify command and die ("Agent stopped responding"), the single most
+  trust-destroying state a non-technical operator can see, on the brand's headline "AI org that does
+  real git work in your repo" path.
+- **Threshold:** single-user incident.
+
+## Domain Assessments
+
+**Assessed:** Engineering (CTO), Product (CPO — carry-forward from #5240 parent), Legal (CLO —
+carry-forward from #5240 parent)
+
+### Engineering (CTO)
+
+**Summary:** Fault is the EnterWorktree→Bash rebind contract at the sandbox boundary, not app-side
+resolution (`resolveActiveWorkspacePath` always returns a path, never throws — can't be the loop
+source). HIGH severity / MEDIUM likelihood (every worktree-creating session crossing a
+sandbox-(re)spawn boundary is exposed; one-shot/plan hard-gate on the CWD check so it's a guaranteed
+hang when triggered). Mandatory guardrail: bounded retries (ceiling 3) → loud `WorktreeEnterFailed`
+→ Sentry + honest status (`cq-silent-fallback-must-mirror-to-sentry`). YAGNI: do NOT redesign the
+workspace/sandbox layer — it's a mount-visibility bug, not a durability bug (volume is already
+persistent). Verify *where* the bwrap mount set is assembled before sizing — CONFIRMED in-repo at
+`agent-runner-sandbox-config.ts`. Capture an ADR for the mount-namespace decision.
+
+### Product (CPO)
+
+**Summary (carry-forward from #5240):** Honesty-first — the lie/hang is the brand breach, not the
+lost compute. Minimum the user must see on failure: no fake activity, an accurate "couldn't enter
+the workspace" state, and one honest actionable choice. Reuse the named-continuity honest-status
+family from #5256/#5306; do not invent a parallel state.
+
+### Legal (CLO)
+
+**Summary (carry-forward from #5240):** NOT a legal blocker. Operator-self-use (tenant-zero), single
+EU-region Hetzner substrate. The cross-tenant `/workspaces` `denyRead` is a load-bearing isolation
+control — **must remain intact** (Decision #3); weakening it would create a cross-tenant read surface
+that WOULD trigger residency/isolation obligations once arms-length tenants exist.
+
+## Capability Gaps
+
+None blocking. All seams exist in-repo: bwrap config (`agent-runner-sandbox-config.ts`), per-query
+cwd (`agent-runner-query-options.ts:149`), the CWD gate (`one-shot/SKILL.md:70-76`), and the
+honest-status render family (`reconnect-resume-states.pen` + `chat-state-machine.ts`). Note (CTO): the
+bwrap mount wiring is security-sensitive Soleur infra that no domain *leader* owns at review time —
+`security-sentinel` (review agent) + CTO sign-off are the gate (Decision #6), not a new build.

--- a/knowledge-base/project/learnings/2026-06-15-bash-bwrap-sandbox-mount-visibility-vs-cwd-persistence.md
+++ b/knowledge-base/project/learnings/2026-06-15-bash-bwrap-sandbox-mount-visibility-vs-cwd-persistence.md
@@ -38,10 +38,15 @@ The Concierge runs Bash and file tools in **two categorically different executio
   - `apps/web-platform/server/agent-runner-sandbox-config.ts:94` — `denyRead: ["/workspaces",
     "/proc"]`; only the specific `allowWrite: [workspacePath]` is mounted into the namespace (the
     `/workspaces` parent is excluded for cross-tenant isolation).
-- **`EnterWorktree` is an SDK-native Claude Code tool with NO Soleur server-side handler.** It
-  flips a logical/file-tool CWD notion but **cannot rebind the bwrap mount or the Bash subprocess
-  cwd**. A worktree created after session start (separate working tree + a `.git` pointer into the
-  bare repo's gitdir) is therefore unreachable from Bash even though file tools see it.
+- **`EnterWorktree` is a CLI-harness concept, NOT present in the Concierge's
+  `@anthropic-ai/claude-agent-sdk` surface** (grep of `sdk.d.ts` + the runners returns zero hits) — so
+  it is not a signal the backend can even key on. Either way, nothing rebinds the bwrap mount or the Bash
+  subprocess cwd after `query()` construction. A worktree created after session start (separate working
+  tree + a `.git` pointer into the bare repo's gitdir) is reachable from Bash ONLY when `workspacePath`
+  resolves correctly — worktrees land *inside* `workspacePath` (`/workspaces/<uuid>/.worktrees/<b>`), so
+  the failure reduces to **binding drift** (mount/cwd computed from a wrong-`workspace_id` path). The loop
+  is observable purely as repeated Bash `cd … && pwd` tool-calls — the compliance-independent signal a
+  guardrail should key on, not any worktree event.
 
 `/home/soleur` is the container HOME (`Dockerfile` `useradd ... soleur`, UID 1001), passed through
 to the agent env allowlist. When bwrap can't `chdir` to the requested path it falls back to `$HOME`.

--- a/knowledge-base/project/learnings/2026-06-15-bash-bwrap-sandbox-mount-visibility-vs-cwd-persistence.md
+++ b/knowledge-base/project/learnings/2026-06-15-bash-bwrap-sandbox-mount-visibility-vs-cwd-persistence.md
@@ -1,0 +1,70 @@
+---
+title: "Concierge Bash runs in a frozen bwrap sandbox; file tools run in-process — a file-vs-Bash path asymmetry is a MOUNT-visibility bug, not a CWD bug"
+date: 2026-06-15
+category: integration-issues
+tags: [bwrap, sandbox, mount-namespace, bash, worktree, cwd, agent-runner, web-platform, diagnosis]
+module: apps/web-platform/server (agent-runner sandbox)
+issue: 5313
+parent_epic: 5240
+related_pr: 5311
+---
+
+# Learning: Concierge Bash sandbox mount-visibility vs. CWD persistence
+
+## Problem
+
+A production Concierge session ("Fix Issue 4826") created a git worktree, then hung in a
+"rebind loop": every Bash `pwd` returned `/home/soleur`, Bash could not `ls /workspaces/<uuid>/`
+or `git -C <worktree>`, yet Read/Edit/Grep/Glob read the repo fine. The one-shot CWD-verification
+gate (`cd <worktree> && pwd` must equal the worktree path) could never pass; the agent looped
+`pwd && git branch --show-current && git log` 4+ times and died with "Agent stopped responding."
+
+The intuitive diagnosis — "Bash CWD didn't persist / `EnterWorktree` didn't move the CWD" — is
+**wrong** and sends you down the existing `2026-05-16-bash-cwd-persists-across-tool-calls.md` /
+`2026-05-15-one-shot-plan-subagent-cwd-divergence.md` path, which does not explain why Bash
+cannot even `ls` the workspace.
+
+## Root Cause (code-verified)
+
+The Concierge runs Bash and file tools in **two categorically different execution contexts**:
+
+- **File tools (Read/Edit/Grep/Glob/LS)** execute **in-process** in the Claude Code CLI (Node
+  `fs`). They have full container filesystem visibility, including the `/workspaces` bind-mount.
+  They are guarded only by an in-process PreToolUse path check (`sandbox-hook.ts`), NOT by bwrap.
+- **Bash** executes inside a **bubblewrap (`bwrap`) sandbox** whose mount namespace and working
+  directory are **frozen once per SDK `query()` call**:
+  - `apps/web-platform/server/agent-runner-query-options.ts:149` — `cwd: args.workspacePath`, set
+    once at session start, never re-derived mid-session.
+  - `apps/web-platform/server/agent-runner-sandbox-config.ts:94` — `denyRead: ["/workspaces",
+    "/proc"]`; only the specific `allowWrite: [workspacePath]` is mounted into the namespace (the
+    `/workspaces` parent is excluded for cross-tenant isolation).
+- **`EnterWorktree` is an SDK-native Claude Code tool with NO Soleur server-side handler.** It
+  flips a logical/file-tool CWD notion but **cannot rebind the bwrap mount or the Bash subprocess
+  cwd**. A worktree created after session start (separate working tree + a `.git` pointer into the
+  bare repo's gitdir) is therefore unreachable from Bash even though file tools see it.
+
+`/home/soleur` is the container HOME (`Dockerfile` `useradd ... soleur`, UID 1001), passed through
+to the agent env allowlist. When bwrap can't `chdir` to the requested path it falls back to `$HOME`.
+
+## Key Insight
+
+**A file-tool-vs-Bash filesystem asymmetry in the Concierge is a sandbox MOUNT-VISIBILITY problem,
+not a CWD-persistence problem.** Diagnostic rule: if Read/Edit can see a path but Bash cannot
+`ls`/`cd`/`git -C` it (and `pwd` is pinned to `/home/soleur`), look at the bwrap mount set
+(`agent-runner-sandbox-config.ts`) and the per-`query()` `cwd` (`agent-runner-query-options.ts`),
+NOT at CWD persistence across calls. The two tool classes do not share a filesystem view.
+
+Corollary: any agent gate that asserts "Bash is in directory X" (the one-shot/plan CWD-verification
+gate, `one-shot/SKILL.md:70-76`) must be **bounded and fail-loud** — it currently says "abort on
+mismatch" but has no retry ceiling, so a structurally-unsatisfiable gate loops until the turn dies.
+Bound it (~3 attempts) → raise an explicit error → Sentry + honest status; never silently loop.
+
+## Tags
+
+category: integration-issues
+module: apps/web-platform/server (agent-runner sandbox)
+
+## Session Errors
+
+Session error inventory: none detected. (Brainstorm + investigation session; correct routing,
+clean worktree/PR/sub-issue creation, three research agents returned without error.)

--- a/knowledge-base/project/learnings/2026-06-15-runtime-guardrail-observable-signal-not-cooperative-marker.md
+++ b/knowledge-base/project/learnings/2026-06-15-runtime-guardrail-observable-signal-not-cooperative-marker.md
@@ -1,0 +1,79 @@
+---
+title: "A runtime guardrail for agent-misbehavior must key on an OBSERVED side-effect, never the agent's own cooperative signal"
+date: 2026-06-15
+category: best-practices
+tags: [guardrail, agent-runtime, detector-design, union-widening, regex, cwd, web-platform, soleur-go-runner]
+module: apps/web-platform/server (soleur-go-runner)
+issue: 5313
+parent_epic: 5240
+related_pr: 5311
+---
+
+# Learning: runtime guardrails key on observed side-effects, not cooperative markers
+
+Four generalizable lessons from implementing the #5313 CWD-verify-loop guardrail (the runtime safety
+net for the Concierge worktree-rebind loop). The mechanism learning (file-tools-in-process vs Bash-bwrap)
+is in `2026-06-15-bash-bwrap-sandbox-mount-visibility-vs-cwd-persistence.md`; this captures the
+DESIGN+IMPLEMENTATION lessons.
+
+## 1. A guardrail for behavior X must detect X by an OBSERVABLE side-effect, never by a signal X must cooperatively emit
+
+The v1 plan keyed the runtime loop-breaker on a *structured marker the agent emits after 3 failed
+verifications*. But the entire premise of the bug is that **the agent ignores prose contracts** — the
+one-shot gate already said "abort on mismatch" and the live agent looped anyway. A marker the agent
+must emit is exactly as ignorable as the "abort" it already ignored. Three plan-review agents
+(Simplicity, SpecFlow, Kieran) independently converged on this as the load-bearing hole.
+
+**Fix:** the detector keys on **observed Bash tool-results** (`extractBashToolResults` in
+`soleur-go-runner.ts:handleUserMessage`) — it counts N=3 consecutive `cd <path> && pwd` commands whose
+`pwd` output mismatches the target, with zero agent cooperation. **Generalizable rule:** when building a
+runtime guard against an agent misbehaving, the trigger must be something the runtime *observes the
+agent doing*, never something the agent must *choose to report*. The misbehaving agent is, by
+definition, not a reliable reporter of its own misbehavior.
+
+## 2. A union member's blast radius = whether each consumer REFERENCES or INLINES the source enum
+
+Kieran (in plan-review, for the originally-considered `WSErrorCode` design) flagged that
+`ws-zod-schemas.ts` hand-maintains a *duplicate* `z.enum([...18 literals...])` that a `grep WSErrorCode`
+type-name search MISSES → a new variant passes `tsc` but throws at the wire-validation boundary at
+runtime. That risk is REAL for `WSErrorCode`. But the chosen design used a `WorkflowEnd` *status*, and
+`ws-zod-schemas.ts:501` does `z.enum(WORKFLOW_END_STATUSES)` — it REFERENCES the single-source tuple, so
+adding one member to `lib/types.ts` auto-propagates and three `tsc`-enforced rails
+(`_AssertWorkflowEndStatusMatches`, `WORKFLOW_END_USER_MESSAGES`, `_abortFlushExhaustive`) catch any
+miss. **Lesson:** before sizing a union-widening sweep, grep whether each consumer *references* the
+source symbol or *inlines* its literals. The design choice (which union to extend) can dissolve the
+sweep entirely — choosing the referencing union turned a 4-consumer manual sweep into a one-line tuple
+edit + compiler enforcement.
+
+## 3. A detector whose match-predicate is broader than its reset-predicate false-positives on the HEALTHY case
+
+`parseCwdVerifyTarget`'s regex initially tolerated a trailing `&& git branch …` continuation
+(`…&& pwd\b`), but the success-reset compared the FULL trimmed output to `expectedPath`. A *successful*
+`cd <wt> && pwd && git branch` prints `"<wt>\n<branch-output>"` — which never equals `<wt>` — so the
+counter would falsely accumulate toward the threshold on a **healthy** worktree. Caught by
+code-quality-analyst at review (P2). **Fix:** end-anchor the regex (`…&& pwd\s*$`) so the match-predicate
+and the success/reset-predicate are symmetric. **Generalizable:** whenever a detector has a "this is the
+pattern" predicate AND a "this is the success/reset" predicate, an asymmetry between them is a
+false-positive on the good case, not the bad case — keep the two predicates exactly as wide as each
+other.
+
+## Key Insight
+
+A guardrail's trust model is its design: it must observe, not ask; its detection and reset predicates
+must be symmetric; and the cheapest union-widening is the one whose consumers reference a single source.
+
+## Tags
+
+category: best-practices
+module: apps/web-platform/server (soleur-go-runner)
+
+## Session Errors
+
+1. **CWD-drift made semgrep + a diff-grep run against the bare root, not the branch** — a `cd` inside a
+   prior `git commit` Bash command persisted, so `cd /home/jean/.../soleur && semgrep apps/...` and
+   `git diff … -- apps/...` scanned MAIN's code (false "path.join findings", false "0 added lines").
+   Ironic given the feature fixes a CWD-confusion loop. **Recovery:** re-ran both with an explicit
+   `cd <worktree-abs> &&` prefix; semgrep on the branch was clean. **Prevention:** already covered — the
+   work skill mandates chaining `cd <worktree-abs> && <cmd>` in a single Bash call (the Bash tool does
+   not persist CWD reliably), and `test-all.sh` hard-refuses the bare root (that guard fired correctly).
+   One-off; no new rule warranted.

--- a/knowledge-base/project/plans/2026-06-15-fix-bash-sandbox-worktree-rebind-guardrail-plan.md
+++ b/knowledge-base/project/plans/2026-06-15-fix-bash-sandbox-worktree-rebind-guardrail-plan.md
@@ -56,6 +56,24 @@ speculative FR1.3 pre-built fix (→ a gated decision tree), dropped the `WSErro
 sweep (→ reuse `WorkflowEnd` error path), scoped the prose gate to one-shot only, added the Zod-enum
 duplicate (C2) and the two render surfaces (C3) to Files-to-Edit, fixed citations (I1/I2).
 
+## As-Built Reconciliation (post-implementation, 2026-06-15)
+
+The implemented design is simpler than C2/C3 anticipated — those plan sections are retained for
+provenance but are **stale vs. the shipped diff** (do not "restore" the edits they describe):
+- **C2 (Zod-enum duplicate):** dissolved. `WORKFLOW_END_STATUSES` (`lib/types.ts`) is a single-source
+  tuple that `ws-zod-schemas.ts:501` consumes via `z.enum(...)` — NO duplicate enum to update. The new
+  status propagates automatically; `_AssertWorkflowEndStatusMatches` + 2 exhaustive `Record` rails are
+  tsc-enforced.
+- **C3 (two render-surface edits):** not needed. `worktree_enter_failed` is intentionally NOT in
+  `TERMINAL_WORKFLOW_END_STATUSES`, so cc-dispatcher routes it through the existing *recoverable* `error`
+  frame carrying the `WORKFLOW_END_USER_MESSAGES` honest copy — no `chat-surface.tsx` /
+  `message-bubble.tsx` edit was required to displace the false "Agent stopped responding" banner.
+- **I2 (WSErrorCode if-chain):** N/A — the design uses a `WorkflowEnd` status, not a `WSErrorCode`
+  variant, so the `ws-client.ts:883` if-chain Kieran flagged is not a consumer.
+
+Verified by the 4-agent post-implementation review (security-sentinel + CTO APPROVE; user-impact +
+code-quality CONCUR after the one P2 regex-tightening fix). Net new issues filed: 0.
+
 ## User-Brand Impact
 
 **If this lands broken:** a worktree-creating turn loops and dies with "Agent stopped responding" — the

--- a/knowledge-base/project/plans/2026-06-15-fix-bash-sandbox-worktree-rebind-guardrail-plan.md
+++ b/knowledge-base/project/plans/2026-06-15-fix-bash-sandbox-worktree-rebind-guardrail-plan.md
@@ -1,0 +1,366 @@
+---
+title: "fix: Bash sandbox worktree-rebind loop — runtime bounded fail-loud guardrail"
+type: fix
+date: 2026-06-15
+issue: 5313
+parent_epic: 5240
+branch: feat-5240-bash-cwd-worktree-rebind
+pr: 5311
+app: web-platform
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+requires_security_signoff: true
+brainstorm: knowledge-base/project/brainstorms/2026-06-15-bash-sandbox-worktree-rebind-brainstorm.md
+spec: knowledge-base/project/specs/feat-5240-bash-cwd-worktree-rebind/spec.md
+---
+
+# 🐛 fix: Bash sandbox worktree-rebind loop hangs Concierge sessions (#5313, deferred #5240 FR-half)
+
+## Overview
+
+A worktree-creating Concierge session (`/soleur:go → one-shot → worktree-manager.sh`) hung in a
+"rebind loop": after creating a worktree the Bash tool's `pwd` stayed at `/home/soleur`, `ls
+/workspaces/<uuid>/` returned nothing, `git -C <worktree>` failed — while Read/Edit/Grep read the repo
+fine. The one-shot CWD-verification gate (`cd <worktree> && pwd`) could never pass; the agent looped
+the verify command 4+ times and the turn died ("Agent stopped responding"). Deferred backend FR-half
+of epic #5240; distinct from #5256 (logical reconnect rebind, merged) and #5306 (UI banner, draft).
+
+**Scope (re-scoped twice — see Reconciliation + Review Revisions):** ship a **runtime,
+compliance-independent bounded fail-loud guardrail** (the durable core) that detects the looping
+CWD-verify pattern from observed Bash tool-results and terminates the turn fast with an honest status,
+plus a **lightweight repro** confirming whether #5256 already fixed the binding-drift root cause. **No
+`allowWrite`/`denyRead` change** (worktrees are already inside the mount — verified). No new
+`WSErrorCode` variant (reuse the existing `WorkflowEnd` error path).
+
+## Research Reconciliation — Premise vs. Codebase (two corrections)
+
+| Premise | Reality (verified) | Plan response |
+| --- | --- | --- |
+| Worktree unreachable from Bash; needs a mount fix | Worktrees land at `/workspaces/<uuid>/.worktrees/<branch>` — **inside** `allowWrite:[workspacePath]` (`ensure-workspace-repo.ts:143,168`; `worktree-manager.sh:94`). gitdir → inside workspacePath. `isPathInWorkspace` (`sandbox.ts:110`, `startsWith`) passes. | **No `allowWrite` change.** |
+| Fix = re-derive bwrap mount/cwd on worktree entry | SDK takes `cwd` only at `query()` (`sdk.d.ts:874`); no per-turn remount. | Config-value remount is not available; guardrail is the fix. |
+| `EnterWorktree` is the SDK signal to key on | **`EnterWorktree` is NOT in `@anthropic-ai/claude-agent-sdk`** (Kieran grep: zero hits in `sdk.d.ts`/runner). It is a CLI-harness concept, absent from the Concierge SDK and irrelevant to the fix. | **Detector keys on observed Bash `cd … && pwd` tool-results, not any worktree event.** |
+| Root cause is the sandbox config | Computed from `args.workspacePath`, which flows from the resolver **#5256 fixed**. Remaining failure mode is **binding drift** → likely already fixed. | Lightweight repro confirms; guardrail is root-cause-independent. |
+| New `WSErrorCode` variant needed for honest status | `runner_runaway` already maps to a `{type:"error"}` honest wire event (`types.ts:438`); operator action is identical ("turn stopped, retry"). | **Reuse the `WorkflowEnd` error path**; add at most one `WorkflowEnd` *status*, NOT a `WSErrorCode` variant + 4-consumer sweep. |
+
+**Net durable deliverable:** a **runtime detector** (compliance-independent) that fires on the looping
+CWD-verify pattern. The mount work the brainstorm imagined is unnecessary.
+
+## Review Revisions (4-agent plan-review: DHH, Kieran, Simplicity, SpecFlow)
+
+The v1 plan keyed FR2.2 on a *cooperative marker the agent emits* — but the whole premise is the agent
+**ignores prose contracts** (it ignored "abort"). Simplicity + SpecFlow + Kieran all flagged this as the
+load-bearing hole. **The detector is now command-pattern-driven** off `extractBashToolResults`
+(`soleur-go-runner.ts:696`), requiring zero agent cooperation. Other applied cuts: dropped the
+speculative FR1.3 pre-built fix (→ a gated decision tree), dropped the `WSErrorCode` variant + union
+sweep (→ reuse `WorkflowEnd` error path), scoped the prose gate to one-shot only, added the Zod-enum
+duplicate (C2) and the two render surfaces (C3) to Files-to-Edit, fixed citations (I1/I2).
+
+## User-Brand Impact
+
+**If this lands broken:** a worktree-creating turn loops and dies with "Agent stopped responding" — the
+most trust-destroying state a non-technical operator sees, on the brand's headline "AI org that does
+real git work in your repo" path. The guardrail's over-suppression failure mode would hide a genuine
+hang behind a spinner; the genuine-hang exit MUST be preserved (FR2.4).
+
+**If this leaks:** N/A for data — but the cross-tenant `denyRead:["/workspaces"]` boundary is
+load-bearing isolation; letting Bash read sibling `/workspaces/<other>` would be a cross-tenant
+incident. This plan does NOT touch that boundary (AC5).
+
+**Brand-survival threshold:** `single-user incident` → `requires_cpo_signoff: true` (CPO covered by
+#5240 brainstorm carry-forward); `requires_security_signoff: true` (security-sentinel at review);
+`user-impact-reviewer` at PR time.
+
+## Root Cause (verified)
+
+File tools run **in-process** (Node `fs`, full FS visibility, not bwrap-sandboxed); **Bash runs in a
+bwrap sandbox** with mount + `cwd` frozen once per `query()` (`agent-runner-query-options.ts:149`;
+`agent-runner-sandbox-config.ts:92-95`). Worktrees live *inside* `workspacePath`, so they are reachable
+when `workspacePath` resolves correctly — the failure reduces to **binding drift** (mount/cwd computed
+from a wrong-`workspace_id` path), the physical sibling of #5256's logical fix. Separately, the one-shot
+CWD gate (`one-shot/SKILL.md:70-76`) says "abort on mismatch" but has **no enforced bound**, so a
+non-compliant agent loops until the 10-min runaway breaker fires with a generic status.
+
+## Desired Fix
+
+### FR1 — Lightweight repro + root-cause confirmation (gates FR1.3 only)
+
+- **FR1.1 (repro, Phase 0):** confirm whether a mid-session worktree at
+  `/workspaces/<uuid>/.worktrees/<b>` is `cd`/`ls`/`git -C`-able from the Bash sandbox under the
+  **current (post-#5256)** resolver. Record the verdict. Lightweight — read-through + a targeted check,
+  not a heavy bwrap harness (the guardrail tests are the durable artifact).
+- **FR1.2 (guardrail regression test — re-aimed):** the durable test asserts the **guardrail behavior**
+  (bounded detection → honest terminal status), NOT worktree-reachability (a `startsWith` tautology that
+  can't catch resolver drift — that is #5256's territory). Covered by AC4/AC6.
+- **FR1.3 (gated decision tree — NO pre-built fix):** act on FR1.1's verdict:
+  - **(i) reachable post-#5256:** FR1.3 is a no-op; document "root cause fixed by #5256; #5313 ships the
+    safety net." (Most likely outcome.)
+  - **(ii) residual binding drift (wrong `workspace_id`):** add the minimal physical companion to #5256
+    (ensure the value flowing to `cwd`/`allowWrite` is the same resolved `workspace_id`). Narrow.
+  - **(iii) cwd-frozen-at-root (the original symptom) — NO in-scope fix exists** (cwd is `query()`-only,
+    no remount API): **STOP, do not expand this PR**, file a follow-up routing to the deferred
+    *skip-worktrees-in-sandbox* re-scope.
+  - **(iv) `allowWrite`-child-vs-`denyRead`-parent precedence:** document the precedence + add a test;
+    no code fix (boundary stays untouched, AC5).
+
+### FR2 — Runtime bounded fail-loud guardrail (durable core, compliance-independent)
+
+- **FR2.1 (prose gate — advisory, cheap, NOT load-bearing):** the one-shot CWD gate
+  (`one-shot/SKILL.md:70-76` only — not a repo-wide sweep) SHOULD stop after ≤3 attempts. This is a
+  near-free comment edit; it is explicitly NOT counted as protection (the live agent ignored "abort").
+- **FR2.2 (runtime detector — LOAD-BEARING, agent-independent):** in the runner's existing Bash
+  tool-result path (`extractBashToolResults`, `soleur-go-runner.ts:696`), detect **N=3 consecutive
+  near-identical CWD-verification commands** (the `cd <path> && pwd` / `git -C <path>` verification
+  shape) whose output shows a persistent mismatch (`pwd` ≠ expected worktree path), and terminate the
+  turn. **N=3 rationale:** the observed loop ran 4+ identical iterations; 3 is below that and well above
+  transient-fs jitter (model the counter on the existing `LEADER_MAX_TURNS` pattern,
+  `agent-on-spawn-requested.ts:323`). No agent-emitted marker — the detector keys on observed commands,
+  so it fires even when the agent ignores the prose gate.
+- **FR2.3 (honest terminal status — reuse `WorkflowEnd`, single new status):** emit a `WorkflowEnd`
+  with a new `status: "worktree_enter_failed"` (extend the discriminator union at
+  `soleur-go-runner.ts:748-762`; the `_AssertWorkflowEndStatusMatches` rail at `:789` forces
+  exhaustiveness — one compiler-enforced site, NOT the `WSErrorCode` 4-consumer sweep). Mirror via
+  `reportSilentFallback(err, { feature: "agent-sandbox", op: "worktree_enter", extra: { expectedPath,
+  observedCwd, attempts } })` — error tier, NOT `mirrorP0Deduped` (that pages oncall; this is a
+  degraded-path operator error, safe because AC5 keeps the cross-tenant boundary intact).
+  - **C2 — update the Zod duplicate:** `WorkflowEnd`/wire status has a hand-maintained `z.enum` duplicate
+    in `ws-zod-schemas.ts` (the `WSErrorCode` precedent is at `:439-468`). A type-symbol grep MISSES it
+    (it inlines literals). Add `worktree_enter_failed` to the Zod enum or the server emits a status that
+    fails wire validation and never reaches the client.
+  - **C3 — honest render, name both surfaces:** the failure must NOT render the literal "Agent stopped
+    responding after: …" at `message-bubble.tsx:369-391`. Determine which surface fires for a
+    `WorkflowEnd`-error and add an explicit honest title ("Couldn't enter the workspace — retry?") at
+    `chat-surface.tsx:699-711` (the if/else title chain currently falls through to "Connection Error").
+- **FR2.4 (single-terminal invariant + preserve genuine-hang exit):** emitting `worktree_enter_failed`
+  MUST `clearTurnHardCap` (`soleur-go-runner.ts:1730`) so the armed 10-min runaway timer cannot
+  double-fire a second `WorkflowEnd`. A turn with NO CWD-verify-loop signal still terminates via the
+  existing runaway breaker — we add a *faster, more specific* exit, we do not remove the existing one
+  (`2026-05-05-defense-relaxation-must-name-new-ceiling.md`).
+
+## Files to Edit
+
+- `plugins/soleur/skills/one-shot/SKILL.md:70-76` (FR2.1) — bound the CWD gate prose to ≤3. **Scoped to
+  this one gate**; if a literal Task-prompt copy of the gate exists in plan/work/deepen-plan, fix only an
+  exact copy (no broad `&& pwd` grep — it false-matches 10+ unrelated scripts).
+- `apps/web-platform/server/soleur-go-runner.ts` (FR2.2/2.3/2.4) — detector in the
+  `extractBashToolResults` path (`:696`); new `WorkflowEnd` status in the discriminator union
+  (`:748-762`, assert at `:789`); emission + `clearTurnHardCap` (`:1730`); `reportSilentFallback`.
+- `apps/web-platform/lib/types.ts` — add `worktree_enter_failed` to the `WorkflowEnd` status union
+  (NOT `WSErrorCode`, which ends at `:161`).
+- `apps/web-platform/lib/ws-zod-schemas.ts` (**C2**) — add `worktree_enter_failed` to the hand-maintained
+  `z.enum` for the `WorkflowEnd`/wire status. **Sweep by grepping the literal status members, not the
+  type symbol** (the enum inlines literals; a type-name grep misses it).
+- `apps/web-platform/components/chat/chat-surface.tsx:699-711` (**C3**) — add the honest ErrorCard title
+  branch for the worktree-enter failure.
+- `apps/web-platform/components/chat/message-bubble.tsx:369-391` (**C3**) — ensure the worktree-enter
+  failure does NOT render the false "Agent stopped responding" literal; confirm which surface fires.
+- `apps/web-platform/lib/ws-client.ts:883-931` (**I2**) — if the status surfaces here, this is an
+  **if-chain, NOT an exhaustive switch** → `tsc` will NOT flag a missing branch; add it by hand.
+- `apps/web-platform/test/` — guardrail detector test + double-fire/single-terminal test (`.test.ts`,
+  node project); honest-render test (`.test.tsx`, **DOM project**, `setup-dom.ts` — I3).
+- `apps/web-platform/test/agent-runner-helpers.test.ts` — **must stay GREEN unchanged** (AC5 proof the
+  sandbox config is untouched; NOT edited unless FR1.3(ii) fires, which must not touch `allowWrite`/`denyRead`).
+
+## Files to Create
+
+None expected (tests append to `test/`).
+
+## Open Code-Review Overlap
+
+7 open `code-review` issues touch the planned files; **none overlap the guardrail / `WorkflowEnd` /
+runaway logic** — all Acknowledge:
+- `#3243` decompose cc-dispatcher (Ref #3235) — Acknowledge (structural refactor; orthogonal).
+- `#3242` tool_use raw-name field (types.ts) — Acknowledge (different concern).
+- `#2224` / `#2220` chat-state-machine reducer purity — Acknowledge.
+- `#2221` message-bubble memo test — Acknowledge.
+- `#3739` observability `reportSilentFallbackWithUser` extraction — Acknowledge (we only *call*
+  `reportSilentFallback`; either merge order is conflict-free).
+- `#4254` / `#3820` cc-dispatcher fixture / safe-bash — Acknowledge.
+
+None met the fold-in bar. Backlog not net-grown.
+
+## Domain Review
+
+**Domains relevant:** Engineering (CTO — carry-forward from #5240 brainstorm), Product (NONE),
+Legal (NONE — see GDPR note).
+
+### Engineering (CTO) — carry-forward
+
+**Status:** reviewed (brainstorm 2026-06-15). **Assessment:** fault is the verification gate looping
+with no bound; bounded fail-loud guardrail is the durable fix. YAGNI: mount-visibility, not durability —
+no sandbox redesign. Research since confirmed no mount change (worktrees inside `allowWrite`) and the
+detector must be runtime/command-pattern-driven (not a cooperative marker). ADR only if FR1.3(ii) fires.
+
+### Product/UX Gate
+
+**Tier:** none. The only user-facing output is an honest error title reusing the existing ErrorCard
+render path (`chat-surface.tsx`); `## Files to Create` is empty; no new `components/**/*.tsx` /
+`app/**/page.tsx` / `app/**/layout.tsx`. C3 adds ONE title-branch literal to an existing card — not a
+new surface. Phase 3.55 visual-design not triggered.
+
+### GDPR / Compliance
+
+Considered (single-user-incident trigger). **No regulated-data surface touched.** No
+schema/migration/auth/API-PII change; the error message carries a worktree path (not PII);
+`reportSilentFallback` already hashes userId. The cross-tenant `denyRead:["/workspaces"]` boundary is
+explicitly **preserved (AC5)** — the fix never weakens isolation.
+
+## Infrastructure (IaC)
+
+None. No `allowWrite`/`denyRead`/seccomp/AppArmor/Docker-bind change (AC5). Pure TS + skill-prose change
+against already-provisioned infra. Phase 2.8 scan: no new server/secret/cron/vendor/DNS.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "worktree_enter_failed WorkflowEnd emitted when the runtime detector sees N=3 looping CWD-verify commands; PLUS a detection-rate metric so a silently-dead detector (zero fires when loops occur) is visible"
+  cadence: "per-occurrence (event-driven)"
+  alert_target: "Sentry feature:agent-sandbox, op:worktree_enter (error tier, no page)"
+  configured_in: "apps/web-platform/server/soleur-go-runner.ts (detector + emit) + observability.ts reportSilentFallback (existing)"
+error_reporting:
+  destination: "Sentry via reportSilentFallback(err, { feature:'agent-sandbox', op:'worktree_enter', extra:{ expectedPath, observedCwd, attempts } }) — error tier, no oncall page"
+  fail_loud: "yes — runtime detector fires after ≤3 looping commands → explicit worktree_enter_failed WorkflowEnd + honest render; never a silent loop, never a silent solo-fallback"
+failure_modes:
+  - mode: "Detector silently dead (loop occurs but never fires — e.g., command-shape match drifts)"
+    detection: "detection-rate metric + AC: a unit test feeds 3 real looping cd&&pwd tool-results through extractBashToolResults → asserts exactly one worktree_enter_failed WorkflowEnd"
+    alert_route: "CI round-trip test; Sentry op:worktree_enter zero-rate is the runtime canary"
+  - mode: "Guardrail too aggressive — suppresses a genuine hang"
+    detection: "AC6: a turn with no CWD-verify-loop signal still terminates via the runaway breaker"
+    alert_route: "CI test + existing runner_runaway Sentry path (unchanged)"
+  - mode: "Double-terminal: worktree_enter_failed + runaway both fire"
+    detection: "AC: marker arrives while runaway armed → exactly one WorkflowEnd; emission calls clearTurnHardCap"
+    alert_route: "CI test"
+  - mode: "False 'Agent stopped responding' rendered instead of honest title"
+    detection: "AC7 render test (.test.tsx, DOM project): asserts the honest title, not the message-bubble literal"
+    alert_route: "CI render test"
+  - mode: "Binding drift recurs post-#5256"
+    detection: "FR1.1 repro verdict; Sentry op:worktree_enter if it fires at runtime"
+    alert_route: "Sentry + repro"
+logs:
+  where: "Sentry (reportSilentFallback) + pino structured log with expectedPath/observedCwd/attempts. No new persisted store; debug-stream events stay ephemeral."
+  retention: "Sentry default (conversation-class); no new retention surface"
+discoverability_test:
+  command: "cd apps/web-platform && ./node_modules/.bin/vitest run test/<detector-test>.test.ts test/<render-test>.test.tsx test/agent-runner-helpers.test.ts"
+  expected_output: "detector + double-fire + render tests green; agent-runner-helpers GREEN UNCHANGED (AC5)"
+```
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] **AC1 (FR2.2 round-trip — the load-bearing test):** a unit test feeds **3 real consecutive
+      `cd <path> && pwd` Bash tool-results with mismatched `pwd`** through the detector
+      (`extractBashToolResults` path) and asserts exactly one `worktree_enter_failed` `WorkflowEnd` is
+      emitted. (Closes the v1 gap where the prose marker and the detector could diverge silently.)
+- [ ] **AC2 (FR1.1):** repro verdict recorded (reachable post-#5256 → FR1.3 no-op; or a named residual
+      routed per the FR1.3 decision tree). A *behavioral* note, paired with AC1/AC6 tests — not a
+      standalone "we wrote it down" check.
+- [ ] **AC3 (FR2.1):** the one-shot CWD gate prose bounds to ≤3 (advisory layer; not the enforcement).
+- [ ] **AC4 (FR2.3 — honest status + Zod):** `worktree_enter_failed` is a valid `WorkflowEnd` status,
+      added to BOTH `lib/types.ts` AND the `ws-zod-schemas.ts` `z.enum` duplicate; a test emits it and
+      asserts it passes wire-schema validation (guards the C2 runtime-Zod-throw class).
+- [ ] **AC5 (G3 — boundary untouched):** `agent-runner-helpers.test.ts` GREEN UNCHANGED; `git diff`
+      touches no `allowWrite`/`denyRead`/seccomp/AppArmor/Docker-bind; security-sentinel confirms no new
+      cross-tenant read surface.
+- [ ] **AC6 (FR2.4 — genuine-hang preserved):** a turn with no CWD-verify-loop signal still terminates
+      via the runaway breaker (no permanent suppression).
+- [ ] **AC7 (C3 — honest render):** render test (`.test.tsx`, DOM project) asserts the failure shows the
+      honest title, NOT "Agent stopped responding" (`message-bubble.tsx:369-391`).
+- [ ] **AC8 (FR2.4 — single terminal):** test proves emitting `worktree_enter_failed` clears the hardcap
+      timer (`clearTurnHardCap`) → exactly one `WorkflowEnd` when the runaway timer was armed.
+- [ ] **AC9 (consumer sweep — tsc + manual if-chains):** `WorkflowEnd` status exhaustiveness via
+      `_AssertWorkflowEndStatusMatches` + `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit`
+      clean; AND manually verify `ws-client.ts:883-931` (if-chain, `tsc`-blind) handles the status if it
+      surfaces there.
+- [ ] **AC10 (full suite):** `cd apps/web-platform && ./node_modules/.bin/vitest run <changed-test-files>`
+      green (node `.test.ts` + DOM `.test.tsx` projects).
+- [ ] **AC11 (PR body):** `Ref #5240` (epic stays OPEN) + `Closes #5313`.
+
+### Post-merge (operator)
+
+- [ ] **AC12:** None. Client+server TS + skill-prose change shipped via `web-platform-release.yml`
+      (path-filtered on `apps/web-platform/**`; merge IS the deploy + container restart); skill-prose
+      ships in the plugin. No migration/infra/secret/operator step. (Automation-feasibility gate:
+      nothing to automate post-merge.)
+
+## Test Scenarios
+
+1. **Detector fires (AC1):** 3 mismatched `cd && pwd` tool-results → one `worktree_enter_failed`.
+2. **Detector does NOT over-fire:** 2 mismatched then a matching `pwd` → no termination.
+3. **Genuine-hang preserved (AC6):** no CWD-verify-loop signal → runaway breaker still terminates.
+4. **Single terminal (AC8):** loop detected while runaway armed → exactly one `WorkflowEnd`, hardcap cleared.
+5. **Honest render (AC7):** `worktree_enter_failed` → honest title, not the false banner.
+6. **Wire-schema (AC4):** status passes `ws-zod-schemas.ts` validation (C2 guard).
+7. **Boundary untouched (AC5):** `agent-runner-helpers.test.ts` unchanged + green.
+
+## Hypotheses
+
+Not a network/SSH issue (Phase 1.4 N/A). File-vs-Bash sandbox asymmetry; root cause binding drift
+(likely #5256-fixed) + an unbounded gate. The fix is detection+termination, independent of root cause.
+
+## Alternative Approaches Considered
+
+| Approach | Why not chosen |
+| --- | --- |
+| Widen `allowWrite` to add a worktrees mount | Worktrees already inside `allowWrite` — redundant; trips the drift-guard; needs security review for nothing. |
+| Per-turn bwrap cwd/mount remount | SDK exposes `cwd` only at `query()`; no remount API. Infeasible. |
+| Cooperative marker emitted by the agent (v1 design) | The agent ignores prose contracts (it ignored "abort"); a marker is equally ignorable. Detector must key on observed commands. |
+| New `WSErrorCode` variant + 4-consumer sweep | `runner_runaway` already carries an honest error wire path; one `WorkflowEnd` status is the minimal honest distinction. |
+| Skip worktree creation in the sandbox | Rejected at brainstorm; the fallback for FR1.3(iii) if cwd-frozen-at-root proves unfixable in scope. |
+| Rely only on the 10-min runaway breaker | Too slow — 10 min of a visibly-looping agent is the brand-trust catastrophe; a ≤3 fast exit is the point. |
+| Build a new stuck-loop detector subsystem | YAGNI — reuse `extractBashToolResults` + the `WorkflowEnd` discriminator + `LEADER_MAX_TURNS` counter pattern. |
+
+## Sharp Edges
+
+- **The detector MUST be command-pattern-driven, not a cooperative marker** — the agent ignores prose
+  (it ignored "abort"). Key on `extractBashToolResults` observed commands. This is the whole fix; do not
+  regress it to a marker.
+- **The wire status union has a hand-maintained Zod `z.enum` duplicate** (`ws-zod-schemas.ts`, precedent
+  `:439-468`). A `grep <TypeName>` MISSES it (literals inlined). Grep the literal members; a missing
+  entry passes `tsc` and THROWS at the wire boundary (`2026-04-15-sdk-v0.2.80-zoderror-allow-shape.md`).
+- **Two render surfaces, different copy:** `chat-surface.tsx:699-711` (if/else title chain → "Connection
+  Error" fallthrough) vs `message-bubble.tsx:369-391` (hard-coded "Agent stopped responding"). Name which
+  fires; do NOT let the worktree failure render the false banner (AC7).
+- **`ws-client.ts:883-931` is an if-chain, not an exhaustive switch** — `tsc` will NOT flag a missing
+  branch (AC9 manual check); the union-widening grep convention assumes switches.
+- **Render test is `.test.tsx` in the DOM project** (`vitest.config.ts` split projects; `setup-dom.ts`);
+  a `.test.ts` or co-located component test is silently not run.
+- **Single-terminal invariant:** emit `worktree_enter_failed` → `clearTurnHardCap` (`:1730`) or the armed
+  runaway timer double-fires a second `WorkflowEnd` (AC8).
+- **`reportSilentFallback`, NOT `mirrorP0Deduped`** — degraded-path operator error, not a write-boundary
+  breach; `mirrorP0Deduped` pages oncall. Safe because AC5 keeps the boundary intact.
+- **Test runner is vitest** (`./node_modules/.bin/vitest run`), typecheck `cd apps/web-platform &&
+  ./node_modules/.bin/tsc --noEmit` (no root `workspaces` — `npm run -w` fails).
+- A plan whose `## User-Brand Impact` is empty/placeholder fails `deepen-plan` Phase 4.6 — filled
+  (threshold `single-user incident`).
+
+## Deferred / Out of Scope
+
+- Physical workspace durability (#5240 item #2), in-flight work durability (#4) — under epic #5240.
+- Skip-worktrees-in-sandbox — only if FR1.3(iii) (cwd-frozen-at-root, unfixable in scope) fires.
+
+## References
+
+- `apps/web-platform/server/agent-runner-sandbox-config.ts:92-95`; `agent-runner-query-options.ts:149,188`
+- `apps/web-platform/server/ensure-workspace-repo.ts:143,168`; `worktree-manager.sh:94,191`; `sandbox.ts:110`
+- `apps/web-platform/server/soleur-go-runner.ts:696` (`extractBashToolResults`), `:748-762`
+  (`runner_runaway` discriminator), `:789` (`_AssertWorkflowEndStatusMatches`), `:1730`
+  (`clearTurnHardCap`), `:1736` (`armTurnHardCap`), emission `:1771-1780,1866-1875`, iterator `:2196`
+- `apps/web-platform/lib/types.ts:130-161` (`WSErrorCode`), `:438` (`runner_runaway`→error wire),
+  `WorkflowEnd` status union
+- `apps/web-platform/lib/ws-zod-schemas.ts:439-468` (hand-maintained `z.enum` duplicate — C2)
+- `apps/web-platform/components/chat/chat-surface.tsx:699-711`; `message-bubble.tsx:369-391`;
+  `ws-client.ts:883-931`
+- `apps/web-platform/server/observability.ts:183` (`reportSilentFallback`), `:550` (`mirrorP0Deduped`)
+- `apps/web-platform/server/inngest/functions/agent-on-spawn-requested.ts:323` (`LEADER_MAX_TURNS`);
+  `constants.ts:17`
+- `apps/web-platform/test/agent-runner-helpers.test.ts:36-119` (sandbox drift-guard — AC5);
+  `vitest.config.ts` (split node/DOM projects)
+- `plugins/soleur/skills/one-shot/SKILL.md:56,70-76` (CWD gate)
+- Learnings: `2026-06-15-bash-bwrap-sandbox-mount-visibility-vs-cwd-persistence.md`;
+  `2026-03-18-ralph-loop-stuck-detection-hardening.md` + `2026-03-05-ralph-loop-stuck-detection-shell-counter.md`
+  (bounded stuck-detection pattern); `2026-04-15-sdk-v0.2.80-zoderror-allow-shape.md` (Zod authoritative);
+  `2026-05-05-defense-relaxation-must-name-new-ceiling.md` (preserve genuine-hang exit);
+  `2026-05-13-claude-agent-sdk-canusetool-not-invoked-for-unknown-mcp-tools.md` (detect at the iterator)
+- Parent: `2026-06-14-durable-session-resume-brainstorm.md` (#5240); #5256 (merged logical rebind)

--- a/knowledge-base/project/specs/feat-5240-bash-cwd-worktree-rebind/spec.md
+++ b/knowledge-base/project/specs/feat-5240-bash-cwd-worktree-rebind/spec.md
@@ -1,0 +1,104 @@
+---
+title: Bash sandbox worktree-rebind — make the bwrap sandbox reach git worktrees
+status: draft
+date: 2026-06-15
+issue: 5313
+parent_epic: 5240
+branch: feat-5240-bash-cwd-worktree-rebind
+pr: 5311
+app: web-platform
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_security_signoff: true
+brainstorm: knowledge-base/project/brainstorms/2026-06-15-bash-sandbox-worktree-rebind-brainstorm.md
+---
+
+# Spec: Bash sandbox worktree-rebind loop (deferred #5240 FR-half)
+
+## Problem Statement
+
+In the production Concierge, a worktree-creating session (`/soleur:go → one-shot →
+worktree-manager.sh`) hangs in a "rebind loop": after the worktree is created, the Bash tool's
+`pwd` stays at `/home/soleur`, Bash cannot `ls /workspaces/<uuid>/` or `git -C <worktree>`, while
+Read/Edit/Grep tools read the repo fine. The one-shot CWD-verification gate
+(`cd <worktree> && pwd` must equal the worktree path) can never pass, the agent loops the verify
+command, and the turn dies with "Agent stopped responding" — the most trust-destroying state a
+non-technical operator can see.
+
+Root cause (code-verified): Bash runs in a **bwrap sandbox** whose mount namespace + `cwd` are
+**frozen once per `query()`** (`agent-runner-query-options.ts:149`, `cwd: args.workspacePath`),
+with `denyRead: ["/workspaces", "/proc"]` (`agent-runner-sandbox-config.ts:94`). `EnterWorktree`
+is an SDK-native tool with no Soleur handler and cannot rebind that mount/cwd. File tools run
+in-process (not bwrap-sandboxed), which is why they see the worktree and Bash does not.
+
+Distinct from #5256 (reconnect logical rebind, merged) and #5306 (UI false-positive banner, draft).
+
+## Goals
+
+- **G1.** A worktree created mid-session is **reachable from the Bash sandbox** (`cd`, `ls`,
+  `git -C` all succeed) so the CWD-verification gate passes.
+- **G2.** When a worktree is genuinely unenterable, the agent **fails loud and bounded** — never
+  loops, never silently masks — surfacing an honest operator status and a Sentry event.
+- **G3.** Preserve the `/workspaces` cross-tenant `denyRead` isolation boundary unchanged.
+
+## Non-Goals
+
+- **NG1.** No workspace/sandbox-layer redesign. This is a mount-visibility fix, not a durability fix
+  (the `/mnt/data/workspaces` volume is already persistent).
+- **NG2.** Not the reconnect logical-rebind path (#5256, merged) nor the UI watchdog banner (#5306).
+- **NG3.** No weakening of `denyRead`/seccomp/AppArmor cross-tenant controls.
+- **NG4.** No new user-facing UI surface — honest failure reuses `reconnect-resume-states.pen`.
+
+## Functional Requirements
+
+- **FR1 — Sandbox reaches worktrees.** Re-derive or extend the bwrap mount set + `cwd` so that
+  worktrees created under the mounted `workspacePath` (and their gitdir target) are visible and
+  enterable from Bash, without mounting the `/workspaces` parent. Decide at plan time whether to
+  mount the worktrees-root up-front (per-query) or re-derive on worktree entry.
+- **FR2 — Bounded fail-loud gate.** The CWD-verification gate retries at most ~3 times, then raises
+  `WorktreeEnterFailed{worktreeId, expectedPath, observedCwd}`, aborts the loop, and does NOT fall
+  back silently.
+- **FR3 — Honest operator status.** On FR2 failure, surface an accurate "couldn't enter the
+  workspace/worktree" status reusing the #5256/#5306 honest-status family — never fake activity,
+  never a fresh-session greeting.
+- **FR4 — Sentry mirror.** FR2 failure mirrors to Sentry (`cq-silent-fallback-must-mirror-to-sentry`,
+  `hr-observability-as-plan-quality-gate`) with the diagnostic triple.
+
+## Technical Requirements
+
+- **TR1.** Confirm via runtime repro the exact failure trigger (gitdir-escapes-mount vs.
+  cwd-frozen-at-root vs. workspace-id binding drift) before finalizing FR1 — see Open Questions.
+- **TR2.** Capture an ADR for the bwrap-mount-namespace-for-worktrees decision
+  (`/soleur:architecture create`).
+- **TR3.** `security-sentinel` + CTO sign-off REQUIRED before PR ready (sandbox-config change).
+- **TR4.** Verify `$GIT_ROOT` for the Concierge clone resolves inside the mounted `workspacePath`
+  (`worktree-manager.sh` creates worktrees at `$GIT_ROOT/.worktrees/<branch>`).
+
+## Acceptance Criteria
+
+- **AC1 (FR1):** A test/repro shows a mid-session worktree is `cd`-able, `ls`-able, and `git -C`-able
+  from the Bash sandbox; the one-shot CWD gate passes.
+- **AC2 (FR2):** An unenterable worktree triggers `WorktreeEnterFailed` after ≤3 attempts; no
+  infinite loop; the genuine-hang exit is preserved (no permanent suppression).
+- **AC3 (FR3):** The failure renders the honest "unrecoverable" status, not "Agent stopped
+  responding"/fresh-session greeting.
+- **AC4 (FR4):** The failure path emits a Sentry event with `worktreeId/expectedPath/observedCwd`.
+- **AC5 (G3):** `denyRead: ["/workspaces", "/proc"]` and the seccomp/AppArmor profiles are unchanged
+  for the cross-tenant boundary; security-sentinel confirms no new cross-tenant read surface.
+- **AC6 (PR body):** `Ref #5240` (epic stays OPEN) + `Closes #<new-sub-issue>`.
+
+## References
+
+- `apps/web-platform/server/agent-runner-sandbox-config.ts:94` — `denyRead`/`allowWrite`
+- `apps/web-platform/server/agent-runner-query-options.ts:149` — `cwd: args.workspacePath`
+- `apps/web-platform/server/agent-runner.ts:852+` — `startAgentSession`
+- `apps/web-platform/server/workspace-resolver.ts:339-348,668` — path resolution (NOT loop source)
+- `apps/web-platform/infra/cloud-init.yml:632` — `-v /mnt/data/workspaces:/workspaces`
+- `apps/web-platform/infra/server.tf:585-647` — seccomp + AppArmor bwrap profiles
+- `plugins/soleur/skills/one-shot/SKILL.md:56,70-76` — CWD-verification gate
+- `plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh` — worktree creation
+- Learnings: `2026-05-15-one-shot-plan-subagent-cwd-divergence.md`,
+  `2026-05-16-bash-cwd-persists-across-tool-calls.md`,
+  `2026-06-04-cron-silence-was-bwrap-userns-drift-not-turn-budget.md`,
+  `2026-06-03-sandbox-helper-cleanup-on-transient-controller-and-worktree-residency.md`
+- Parent: `knowledge-base/project/brainstorms/2026-06-14-durable-session-resume-brainstorm.md` (#5240)

--- a/knowledge-base/project/specs/feat-5240-bash-cwd-worktree-rebind/spec.md
+++ b/knowledge-base/project/specs/feat-5240-bash-cwd-worktree-rebind/spec.md
@@ -80,8 +80,12 @@ Distinct from #5256 (reconnect logical rebind, merged) and #5306 (UI false-posit
   from the Bash sandbox; the one-shot CWD gate passes.
 - **AC2 (FR2):** An unenterable worktree triggers `WorktreeEnterFailed` after ≤3 attempts; no
   infinite loop; the genuine-hang exit is preserved (no permanent suppression).
-- **AC3 (FR3):** The failure renders the honest "unrecoverable" status, not "Agent stopped
-  responding"/fresh-session greeting.
+- **AC3 (FR3):** The failure renders the honest, **retryable** status ("Couldn't open a workspace
+  to run that step. Try sending your message again."), not "Agent stopped responding"/fresh-session
+  greeting. [Reconciled at review: as-built routes `worktree_enter_failed` through cc-dispatcher's
+  *recoverable* `else` branch — intentionally NOT in `TERMINAL_WORKFLOW_END_STATUSES` — since the
+  failure is per-turn and retryable. The original "unrecoverable" wording was looser; recoverable-
+  retry is the endorsed UX (CTO + user-impact review).]
 - **AC4 (FR4):** The failure path emits a Sentry event with `worktreeId/expectedPath/observedCwd`.
 - **AC5 (G3):** `denyRead: ["/workspaces", "/proc"]` and the seccomp/AppArmor profiles are unchanged
   for the cross-tenant boundary; security-sentinel confirms no new cross-tenant read surface.

--- a/knowledge-base/project/specs/feat-5240-bash-cwd-worktree-rebind/tasks.md
+++ b/knowledge-base/project/specs/feat-5240-bash-cwd-worktree-rebind/tasks.md
@@ -1,0 +1,74 @@
+---
+title: Tasks — Bash sandbox worktree-rebind guardrail (#5313)
+spec: knowledge-base/project/specs/feat-5240-bash-cwd-worktree-rebind/spec.md
+plan: knowledge-base/project/plans/2026-06-15-fix-bash-sandbox-worktree-rebind-guardrail-plan.md
+issue: 5313
+parent_epic: 5240
+lane: cross-domain
+brand_survival_threshold: single-user incident
+---
+
+# Tasks: Bash sandbox worktree-rebind guardrail
+
+Runtime, compliance-independent bounded fail-loud guardrail + repro-verify. **No `allowWrite`/`denyRead`
+change.** Test runner: `cd apps/web-platform && ./node_modules/.bin/vitest run <path>`. Typecheck:
+`cd apps/web-platform && ./node_modules/.bin/tsc --noEmit`.
+
+## Phase 0 — Repro / root-cause confirmation (gates Phase 4 only)
+
+- [ ] 0.1 (FR1.1) Confirm whether a mid-session worktree at `/workspaces/<uuid>/.worktrees/<b>` is
+  `cd`/`ls`/`git -C`-able from the Bash sandbox under the current (post-#5256) resolver. Lightweight
+  (read-through + targeted check, not a heavy bwrap harness). Record verdict.
+- [ ] 0.2 (FR1.3) Select the decision-tree leaf from 0.1: (i) reachable → no-op, document "root cause
+  fixed by #5256"; (ii) workspace_id drift → narrow companion fix in Phase 4; (iii) cwd-frozen-at-root →
+  STOP, file follow-up (skip-worktrees re-scope), do NOT expand this PR; (iv) precedence → document + test.
+
+## Phase 1 — Runtime detector (FR2.2, the durable core)
+
+- [ ] 1.1 (RED, AC1) Write the failing round-trip test: feed 3 consecutive `cd <path> && pwd` Bash
+  tool-results with mismatched `pwd` through the `extractBashToolResults` path
+  (`soleur-go-runner.ts:696`); assert exactly one `worktree_enter_failed` `WorkflowEnd`. (`.test.ts`, node project.)
+- [ ] 1.2 (RED) Counter-case test: 2 mismatched then 1 matching `pwd` → no termination.
+- [ ] 1.3 (GREEN) Implement the N=3 near-identical-CWD-verify detector in the `extractBashToolResults`
+  path. Counter modeled on `LEADER_MAX_TURNS` (`agent-on-spawn-requested.ts:323`). No cooperative marker.
+
+## Phase 2 — Honest terminal status + wire + render (FR2.3; C2, C3)
+
+- [ ] 2.1 (FR2.3) Add `worktree_enter_failed` to the `WorkflowEnd` status discriminator union
+  (`lib/types.ts`; `soleur-go-runner.ts:748-762`); `_AssertWorkflowEndStatusMatches` (`:789`) forces
+  exhaustiveness.
+- [ ] 2.2 (**C2**, AC4) Add `worktree_enter_failed` to the hand-maintained `z.enum` duplicate in
+  `ws-zod-schemas.ts` (precedent `:439-468`). **Grep the literal status members, not the type symbol.**
+  Test: emitted status passes wire-schema validation.
+- [ ] 2.3 (FR2.3 emit) Emit the status from the detector; mirror via `reportSilentFallback(err,
+  {feature:"agent-sandbox", op:"worktree_enter", extra:{expectedPath, observedCwd, attempts}})` — NOT
+  `mirrorP0Deduped`. Add the detection-rate metric (Observability).
+- [ ] 2.4 (**C3**, AC7) Honest render: add the title branch at `chat-surface.tsx:699-711`; ensure
+  `message-bubble.tsx:369-391` does NOT render "Agent stopped responding" for this status. Render test
+  is `.test.tsx` in the **DOM project** (`setup-dom.ts`).
+- [ ] 2.5 (**I2**, AC9) If the status surfaces in `ws-client.ts:883-931` (if-chain, `tsc`-blind), add the
+  branch by hand.
+
+## Phase 3 — Single-terminal invariant + genuine-hang preservation (FR2.4)
+
+- [ ] 3.1 (AC8) On emit, call `clearTurnHardCap` (`soleur-go-runner.ts:1730`). Test: status emitted while
+  the runaway timer is armed → exactly one `WorkflowEnd`.
+- [ ] 3.2 (AC6) Test: a turn with NO CWD-verify-loop signal still terminates via the runaway breaker (no
+  permanent suppression).
+
+## Phase 4 — Prose gate (FR2.1, advisory) + conditional residual fix
+
+- [ ] 4.1 (FR2.1, AC3) Bound the one-shot CWD gate prose to ≤3 (`one-shot/SKILL.md:70-76` only; no broad
+  grep). Not load-bearing — the detector (Phase 1) is the enforcement.
+- [ ] 4.2 (FR1.3(ii), conditional) ONLY if Phase 0.2 selected leaf (ii): the narrow workspace_id-tracking
+  fix. Must NOT touch `allowWrite`/`denyRead`.
+
+## Phase 5 — Verify + sign-off
+
+- [ ] 5.1 (AC5) `agent-runner-helpers.test.ts` GREEN UNCHANGED; `git diff` touches no
+  `allowWrite`/`denyRead`/seccomp/AppArmor/Docker-bind.
+- [ ] 5.2 (AC9) `tsc --noEmit` clean (incl. `_AssertWorkflowEndStatusMatches` exhaustiveness).
+- [ ] 5.3 (AC10) Full changed-test run green (node `.test.ts` + DOM `.test.tsx`).
+- [ ] 5.4 security-sentinel + CTO sign-off (sandbox-adjacent change, `requires_security_signoff`); ADR
+  only if 4.2 fired.
+- [ ] 5.5 (AC11) PR body: `Ref #5240` + `Closes #5313`.

--- a/plugins/soleur/skills/one-shot/SKILL.md
+++ b/plugins/soleur/skills/one-shot/SKILL.md
@@ -73,7 +73,7 @@ BRANCH: [insert current branch name]
 ARGUMENTS: $ARGUMENTS
 
 STEPS:
-0. **CWD verification (first tool call):** run `cd <WORKING_DIRECTORY> && pwd`. The output MUST equal the WORKING DIRECTORY value above. If it does not, abort and return an error in the Session Summary — do NOT proceed; the plan will land in the bare-root synced mirror (gets clobbered on next sync) instead of the worktree. Bash CWD is per-agent and does NOT inherit from the parent's persistent `cd`.
+0. **CWD verification (first tool call):** run `cd <WORKING_DIRECTORY> && pwd`. The output MUST equal the WORKING DIRECTORY value above. If it does not, **retry at most 3 times** — and if `pwd` still mismatches after the third attempt, STOP and abort with an error in the Session Summary. Do NOT keep re-running the verification command in a loop (#5313: that loop hung a Concierge session; the runtime detector now surfaces a `worktree_enter_failed` status after 3 mismatched `cd … && pwd` commands, but do not rely on it — fail loud here too). Do NOT proceed; the plan will land in the bare-root synced mirror (gets clobbered on next sync) instead of the worktree. Bash CWD is per-agent and does NOT inherit from the parent's persistent `cd`.
 1. Use the Skill tool: skill: soleur:plan, args: "$ARGUMENTS"
 2. After plan is created, use the Skill tool: skill: soleur:deepen-plan, args: "<plan_file_path>"
 


### PR DESCRIPTION
## Summary

Runtime safety-net guardrail for the Concierge **worktree-rebind loop** (the deferred backend FR-half of epic #5240). When a worktree-creating turn loops the one-shot CWD-verification command (`cd <path> && pwd`) because the Bash bwrap sandbox can't enter the worktree, the runner now detects the loop and ends the turn fast with an honest, retryable status — instead of the agent looping until the 10-minute `runner_runaway` breaker fires with a generic "Agent stopped responding".

- **Command-pattern detector** (`detectCwdVerifyLoop` in `soleur-go-runner.ts`, keyed on observed Bash tool-results via `extractBashToolResults`) — fires after 3 consecutive near-identical `cd <path> && pwd` commands with a mismatched `pwd`. **Compliance-independent**: keyed on what the runtime observes, not a cooperative marker the (misbehaving) agent must emit.
- **New `worktree_enter_failed` `WorkflowEnd` status** — added to the single-source `WORKFLOW_END_STATUSES` tuple (Zod auto-picks it up via `z.enum`); routed through the existing **recoverable** error path with honest operator copy ("Couldn't open a workspace to run that step. Try sending your message again."), displacing the false "Agent stopped responding" banner.
- **Single-terminal invariant** — `emitWorkflowEnded → closeQuery` clears both timers + sets `closed`, so the armed `runner_runaway` timer can't double-fire.
- Advisory ≤3 bound on the one-shot CWD-gate prose (the runtime detector is the real enforcement).
- **No `allowWrite`/`denyRead`/seccomp/AppArmor change** — the cross-tenant `/workspaces` isolation boundary is untouched; `agent-runner-helpers.test.ts` drift-guard stays green.

Root cause (binding drift) was the physical sibling of #5256's logical rebind and is most likely already fixed by it; this PR ships the durable safety net so the loop can never re-hang silently regardless of cause.

Closes #5313
Ref #5240

## Changelog

- Concierge: fast, honest "couldn't open a workspace" status when a worktree-creating turn can't enter its worktree, replacing the silent multi-minute hang.

## Test plan

- [x] 4 detector tests (fire on 3 mismatches; no-fire on success-reset; no-fire on unrelated commands; AC8 single-terminal — no double-fire with armed runaway timer)
- [x] `cc-workflow-end-messages` snapshot incl. AC7 honest-copy assertion (NOT "Agent stopped responding")
- [x] Full suite 111/111 + `tsc --noEmit` clean; `agent-runner-helpers` drift-guard green (AC5)
- [x] 4-agent review: security-sentinel + architecture-strategist (CTO) APPROVE; user-impact + code-quality CONCUR (1 P2 fixed inline; 0 issues filed)

## Review

4-agent post-implementation review complete. Mandatory `requires_security_signoff` gate (single-user-incident threshold) satisfied: **security-sentinel APPROVED + CTO APPROVE**. Net new issues filed: 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
