### PR TITLE
feat(reconnect): deterministic workspace re-provision on reconnect (#5240 item #2)

### DIFF
--- a/apps/web-platform/server/agent-runner.ts
+++ b/apps/web-platform/server/agent-runner.ts
@@ -45,6 +45,7 @@ import { abortableReviewGate, validateSelection, type AgentSession } from "./rev
 import { createChildLogger } from "./logger";
 import { syncPull, syncPush } from "./session-sync";
 import { ensureWorkspaceRepoCloned } from "./ensure-workspace-repo";
+import { resolveEffectiveInstallationId } from "./cc-effective-installation";
 import { tryCreateVision, buildVisionEnhancementPrompt } from "./vision-helpers";
 import { createRateLimiter } from "./trigger-workflow";
 import { githubApiGet } from "./github-api";
@@ -1038,17 +1039,27 @@ export async function startAgentSession(
     // gains the recovery it was missing; failures degrade exactly as today.
     //
     // The installation + repo are resolved LAZILY inside this `.git`-absent gate
-    // (NOT hoisted ~300 lines above the canonical reads at :1336/:1350) — they
-    // re-resolve the active workspace claim independently (documented drift
-    // caveat at :1341-1349), so resolving them only on the rare missing-repo
+    // (NOT hoisted ~300 lines above the canonical `resolveInstallationId` /
+    // `getCurrentRepoUrl` reads later in this function) — they re-resolve the
+    // active workspace claim independently (documented drift caveat at those
+    // canonical reads), so resolving them only on the rare missing-repo
     // path minimizes exposure. `ensureWorkspaceRepoCloned` is fail-soft (never
     // throws), membership-scoped (`repoUrl`/`installationId` are server-resolved,
     // never request input — ADR-044), and runs host-side outside the sandbox.
     if (!existsSync(path.join(workspacePath, ".git"))) {
-      const [reprovInstallationId, reprovRepoUrl] = await Promise.all([
+      const [storedInstallationId, reprovRepoUrl] = await Promise.all([
         resolveInstallationId(userId),
         getCurrentRepoUrl(userId),
       ]);
+      // Promote to the entitled repo-owner install (same selection the Concierge
+      // cold factory + per-dispatch re-provision make) so a cross-account org
+      // repo re-clones with the right credential instead of 403-ing. Fail-soft:
+      // returns the stored install on any probe failure, never widening access.
+      const reprovInstallationId = await resolveEffectiveInstallationId({
+        userId,
+        installationId: storedInstallationId,
+        repoUrl: reprovRepoUrl,
+      });
       await ensureWorkspaceRepoCloned({
         userId,
         workspacePath,

--- a/apps/web-platform/server/agent-runner.ts
+++ b/apps/web-platform/server/agent-runner.ts
@@ -1,6 +1,6 @@
 import { query, type tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
 import { randomUUID } from "crypto";
-import { readFileSync, mkdirSync } from "fs";
+import { readFileSync, mkdirSync, existsSync } from "fs";
 import { readFile } from "node:fs/promises";
 import path from "path";
 
@@ -44,6 +44,7 @@ import type { Provider } from "@/lib/types";
 import { abortableReviewGate, validateSelection, type AgentSession } from "./review-gate";
 import { createChildLogger } from "./logger";
 import { syncPull, syncPush } from "./session-sync";
+import { ensureWorkspaceRepoCloned } from "./ensure-workspace-repo";
 import { tryCreateVision, buildVisionEnhancementPrompt } from "./vision-helpers";
 import { createRateLimiter } from "./trigger-workflow";
 import { githubApiGet } from "./github-api";
@@ -1017,6 +1018,43 @@ export async function startAgentSession(
           extra: { userId },
         });
       }
+    }
+
+    // Deterministic workspace re-provision on reconnect (#5340 / #5240 design
+    // item #2). After a sandbox/host reclaim the resolved active-workspace path
+    // can be a fresh filesystem where the connected repo was never cloned (the
+    // "No Git repository / no worktrees" symptom). The Concierge (cc) path
+    // already self-heals via `ensureWorkspaceRepoCloned`; the LEADER path never
+    // did — so a leader turn dead-ended with no recovery. Add the recovery here.
+    //
+    // PLACEMENT (load-bearing — learning 2026-06-14-short-circuit-guard-must-
+    // sit-after-the-recovery-it-gates.md): this is the RECOVERY, placed BEFORE
+    // `patchWorkspacePermissions`/`syncPull` (both need a real repo on disk) and
+    // gated on `.git`-ABSENT so it no-ops on the common binding-drift case where
+    // the repo IS present. There is deliberately NO bespoke leader "it's gone"
+    // message — the leader has no `worktree_enter_failed` guardrail, so a failed
+    // recovery rides the existing `startAgentSession` catch (the honest reclaimed
+    // message is a Concierge-path post-recovery-failure concept). The leader
+    // gains the recovery it was missing; failures degrade exactly as today.
+    //
+    // The installation + repo are resolved LAZILY inside this `.git`-absent gate
+    // (NOT hoisted ~300 lines above the canonical reads at :1336/:1350) — they
+    // re-resolve the active workspace claim independently (documented drift
+    // caveat at :1341-1349), so resolving them only on the rare missing-repo
+    // path minimizes exposure. `ensureWorkspaceRepoCloned` is fail-soft (never
+    // throws), membership-scoped (`repoUrl`/`installationId` are server-resolved,
+    // never request input — ADR-044), and runs host-side outside the sandbox.
+    if (!existsSync(path.join(workspacePath, ".git"))) {
+      const [reprovInstallationId, reprovRepoUrl] = await Promise.all([
+        resolveInstallationId(userId),
+        getCurrentRepoUrl(userId),
+      ]);
+      await ensureWorkspaceRepoCloned({
+        userId,
+        workspacePath,
+        installationId: reprovInstallationId,
+        repoUrl: reprovRepoUrl,
+      });
     }
 
     // Migrate existing workspaces: remove pre-approved permissions that

--- a/apps/web-platform/server/cc-dispatcher.ts
+++ b/apps/web-platform/server/cc-dispatcher.ts
@@ -95,12 +95,8 @@ import {
 // per-workspace resolver (ADR-044) — NOT the soleur-monorepo-hardcoded
 // `mintInstallationToken` from the crons. Per hr-github-app-auth-not-pat.
 import { resolveInstallationId } from "./resolve-installation-id";
-import {
-  generateInstallationToken,
-  findRepoOwnerInstallationForUser,
-  getInstallationAccount,
-} from "./github-app";
-import { mirrorSelfHealSkip } from "./cc-self-heal-observability";
+import { generateInstallationToken } from "./github-app";
+import { resolveEffectiveInstallationId } from "./cc-effective-installation";
 // Session-start self-heal: if the active workspace has a connected repo but no
 // matching clone on disk, clone/repair it so the Concierge has a real git repo
 // to work in (fixes the "No git repository found" blocker). Generic per-user.
@@ -1386,72 +1382,18 @@ export const realSdkQueryFactory: QueryFactory = async (
     // solo-vs-active-workspace clobber risk) — the override re-applies on each
     // cold dispatch, which is bounded (cold-conversation factory). Best-effort:
     // any probe failure keeps the stored install and never blocks the chat.
-    let effectiveInstallationId = installationId;
-    if (installationId !== null && connectedOwner) {
-      try {
-        const storedAccount = await getInstallationAccount(installationId);
-        const alreadyCorrect =
-          storedAccount.login.toLowerCase() === connectedOwner.toLowerCase();
-        // `alreadyCorrect` is a no-op (the stored install already owns the
-        // connected repo), NOT a skip — do not mirror it. Every other
-        // not-already-correct branch either promotes (success log.info) or
-        // KEEPS the stored install, and a keep must be a queryable Sentry event
-        // (Bug B — cq-silent-fallback-must-mirror-to-sentry).
-        if (!alreadyCorrect) {
-          if (storedAccount.type === "User") {
-            // Only derive the user's login from a personal (User) install.
-            const { installationId: ownerInstall, outcome } =
-              await findRepoOwnerInstallationForUser(
-                connectedOwner,
-                storedAccount.login,
-              );
-            if (ownerInstall !== null && ownerInstall !== installationId) {
-              log.info(
-                {
-                  userId: args.userId,
-                  storedInstallationId: installationId,
-                  ownerInstallationId: ownerInstall,
-                  owner: connectedOwner,
-                },
-                "Concierge installation self-heal: stored personal install does not own the connected repo; switching to the entitled repo-owner installation for this dispatch",
-              );
-              effectiveInstallationId = ownerInstall;
-            } else if (ownerInstall === null) {
-              // Promotion denied (not-member / transient-indeterminate /
-              // token-mint-failed / no-owner-install) — keep the stored
-              // (possibly-wrong) install + surface the skip so a residual 403
-              // is explainable from Sentry without SSH.
-              mirrorSelfHealSkip({
-                userId: args.userId,
-                storedInstallationId: installationId,
-                owner: connectedOwner,
-                membershipProbeOutcome: outcome,
-                effectiveInstallationId: installationId,
-              });
-            }
-          } else {
-            // Org-type stored install whose account != the connected-repo
-            // owner: the user's login is not derivable without a service-role
-            // admin lookup, so keep the stored install (fail-safe). Mirror it.
-            mirrorSelfHealSkip({
-              userId: args.userId,
-              storedInstallationId: installationId,
-              owner: connectedOwner,
-              membershipProbeOutcome: "org-type-stored-install",
-              effectiveInstallationId: installationId,
-            });
-          }
-        }
-      } catch (probeErr) {
-        reportSilentFallback(probeErr, {
-          feature: "cc-dispatcher",
-          op: "installation-self-heal-probe",
-          extra: { userId: args.userId },
-          message:
-            "Repo-owner installation probe failed; keeping stored installation",
-        });
-      }
-    }
+    // Self-heal SELECTION extracted to `resolveEffectiveInstallationId`
+    // (cc-effective-installation.ts) so the per-dispatch warm re-provision
+    // (cc-reprovision.ts) selects the SAME promoted install as this cold factory
+    // — otherwise the warm re-clone would use the raw (possibly 403-ing) stored
+    // install and falsely report "workspace reclaimed — couldn't restore" for an
+    // org repo a cold turn could recover (#5340 review finding). Best-effort:
+    // returns the stored install on any probe failure, never widening access.
+    const effectiveInstallationId = await resolveEffectiveInstallationId({
+      userId: args.userId,
+      installationId,
+      repoUrl,
+    });
 
     // Session-start self-heal (generic, per-user, idempotent, fail-soft): if the
     // workspace has a connected repo but no matching clone on disk, clone/repair
@@ -2365,7 +2307,7 @@ export async function dispatchSoleurGo(
   // #5340 / #5240 design item #2 — deterministic workspace re-provision on
   // reconnect. After a sandbox/host reclaim the resolved workspace path can be a
   // fresh filesystem with no repo. The factory-internal self-heal
-  // (`ensureWorkspaceRepoCloned` at :1469) runs ONLY on a COLD conversation;
+  // (`ensureWorkspaceRepoCloned` in `realSdkQueryFactory`) runs ONLY on a COLD conversation;
   // warm-query reconnect (the epic's headline scenario) never re-invokes the
   // factory. Re-provision per-dispatch here — same fire-and-forget pattern as the
   // `setBashAutonomous` warm-query resolve above — so BOTH cold and warm turns
@@ -2827,7 +2769,7 @@ export async function dispatchSoleurGo(
         // `{ type: "error", message }` frame. When the per-dispatch
         // re-provision genuinely failed (`reprovisionOutcome === "failed"`),
         // surface the honest "workspace reclaimed" copy; otherwise the generic
-        // retryable copy. The recovery already ran (factory :1469 cold +
+        // retryable copy. The recovery already ran (factory `ensureWorkspaceRepoCloned` cold +
         // `reprovisionWorkspaceOnDispatch` cold/warm) — this branch sits AFTER
         // it (placement learning 2026-06-14-short-circuit-guard-must-sit-after-
         // the-recovery-it-gates.md), so the message never lies in the

--- a/apps/web-platform/server/cc-dispatcher.ts
+++ b/apps/web-platform/server/cc-dispatcher.ts
@@ -52,7 +52,12 @@ import {
   type WorkflowEnd,
 } from "./soleur-go-runner";
 import { readCcCostCaps } from "./cc-cost-caps";
-import { WORKFLOW_END_USER_MESSAGES } from "./cc-workflow-end-messages";
+import {
+  WORKFLOW_END_USER_MESSAGES,
+  resolveWorktreeEnterFailedMessage,
+} from "./cc-workflow-end-messages";
+import { reprovisionWorkspaceOnDispatch } from "./cc-reprovision";
+import type { ReprovisionOutcome } from "./ensure-workspace-repo";
 import { persistTurnCost } from "./cost-writer";
 import { PendingPromptRegistry } from "./pending-prompt-registry";
 import {
@@ -2357,6 +2362,37 @@ export async function dispatchSoleurGo(
       });
     });
 
+  // #5340 / #5240 design item #2 — deterministic workspace re-provision on
+  // reconnect. After a sandbox/host reclaim the resolved workspace path can be a
+  // fresh filesystem with no repo. The factory-internal self-heal
+  // (`ensureWorkspaceRepoCloned` at :1469) runs ONLY on a COLD conversation;
+  // warm-query reconnect (the epic's headline scenario) never re-invokes the
+  // factory. Re-provision per-dispatch here — same fire-and-forget pattern as the
+  // `setBashAutonomous` warm-query resolve above — so BOTH cold and warm turns
+  // recover AND publish the outcome the honest-message branch reads.
+  //
+  // `reprovisionOutcome` is the POST-recovery signal: `onWorkflowEnded` shows the
+  // honest "workspace reclaimed" message ONLY when a `worktree_enter_failed` turn
+  // is paired with `"failed"` here — the message is gated AFTER the recovery
+  // (placement learning 2026-06-14-short-circuit-guard-must-sit-after-the-
+  // recovery-it-gates.md), never before. Idempotent with the cold factory call
+  // (`.git`-absent-gated). Fail-closed `undefined` → generic retryable message.
+  let reprovisionOutcome: ReprovisionOutcome | undefined;
+  void reprovisionWorkspaceOnDispatch(userId)
+    .then((outcome) => {
+      reprovisionOutcome = outcome;
+    })
+    .catch((err) => {
+      // reprovisionWorkspaceOnDispatch is already fail-soft (returns "ok" on a
+      // resolver error); this catch is belt-and-suspenders for an unexpected
+      // synchronous throw and leaves the outcome unresolved (generic message).
+      reportSilentFallback(err, {
+        feature: "cc-dispatcher",
+        op: "reprovision-on-dispatch-publish",
+        extra: { userId, conversationId },
+      });
+    });
+
   // feat-debug-mode-stream — per-dispatch debug-stream gate. Two INDEPENDENT
   // conditions, BOTH required for any debug_event to emit (read as `let`
   // bindings, mirroring `bashAutonomousPosture`'s fire-and-forget resolve so
@@ -2783,6 +2819,22 @@ export async function dispatchSoleurGo(
           runnerRunawayReason: end.reason,
           runnerRunawayLastBlockKind: end.lastBlockKind,
           runnerRunawayLastBlockToolName: end.lastBlockToolName,
+        });
+      } else if (end.status === "worktree_enter_failed") {
+        // #5340 / #5240 design item #2 — post-recovery-failure honest message.
+        // `worktree_enter_failed` is NOT terminal (see
+        // TERMINAL_WORKFLOW_END_STATUSES), so it routes HERE to a
+        // `{ type: "error", message }` frame. When the per-dispatch
+        // re-provision genuinely failed (`reprovisionOutcome === "failed"`),
+        // surface the honest "workspace reclaimed" copy; otherwise the generic
+        // retryable copy. The recovery already ran (factory :1469 cold +
+        // `reprovisionWorkspaceOnDispatch` cold/warm) — this branch sits AFTER
+        // it (placement learning 2026-06-14-short-circuit-guard-must-sit-after-
+        // the-recovery-it-gates.md), so the message never lies in the
+        // recoverable case.
+        sendToClient(userId, {
+          type: "error",
+          message: resolveWorktreeEnterFailedMessage(reprovisionOutcome),
         });
       } else {
         sendToClient(userId, {

--- a/apps/web-platform/server/cc-effective-installation.ts
+++ b/apps/web-platform/server/cc-effective-installation.ts
@@ -1,0 +1,128 @@
+import {
+  findRepoOwnerInstallationForUser,
+  getInstallationAccount,
+} from "./github-app";
+import { mirrorSelfHealSkip } from "./cc-self-heal-observability";
+import { reportSilentFallback } from "./observability";
+import { createChildLogger } from "./logger";
+
+const log = createChildLogger("cc-effective-installation");
+
+const GITHUB_NAME_RE = /^[a-zA-Z0-9._-]+$/;
+
+/**
+ * Parse the connected repo's owner from a server-resolved github HTTPS URL.
+ * Returns `""` for a malformed URL (degrade silently — not a security gate;
+ * the caller treats an empty owner as "no promotion possible").
+ */
+function parseConnectedOwner(repoUrl: string | null): string {
+  if (!repoUrl) return "";
+  try {
+    const parts = new URL(repoUrl).pathname.split("/").filter(Boolean);
+    const o = parts[0];
+    if (o && GITHUB_NAME_RE.test(o)) return o;
+  } catch {
+    /* malformed repoUrl → no owner */
+  }
+  return "";
+}
+
+/**
+ * Concierge installation self-heal (feat-one-shot-concierge-gh-403): given the
+ * stored per-workspace installation id and the connected repo URL, return the
+ * EFFECTIVE installation id to authenticate repo operations with for this
+ * dispatch.
+ *
+ * The stored install can be a CROSS-ACCOUNT personal install that can READ the
+ * connected repo (so connect-time probe passed) but only holds `issues: read` —
+ * `git clone` / `gh issue create` then 403 with the stored install. The fix is
+ * SELECTION, not a permission change: when the stored install is a personal
+ * (User-type) install that does NOT own the connected repo, promote to the
+ * repo-owner installation — but ONLY when the user is ENTITLED to it
+ * (`findRepoOwnerInstallationForUser` gates org installs on verified membership,
+ * so a read-only outside collaborator cannot escalate to the org's write grant).
+ *
+ * Extracted from `cc-dispatcher.ts realSdkQueryFactory` (#5340 / #5240) so the
+ * COLD factory self-heal AND the per-dispatch warm re-provision
+ * (`cc-reprovision.ts`) select the SAME install — otherwise the warm/leader
+ * re-clone would use the raw (possibly 403-ing) install while the cold factory
+ * used the promoted one, producing a FALSE "workspace reclaimed — couldn't
+ * restore" message for org repos a cold turn could recover (review finding).
+ *
+ * Entirely GitHub-App-JWT driven — NO Supabase service-role. Best-effort: any
+ * probe failure keeps the stored install and never throws (mirrors to Sentry).
+ * In every non-promotion branch the return equals the stored `installationId`,
+ * so this NEVER widens access beyond what the stored install already had.
+ */
+export async function resolveEffectiveInstallationId(args: {
+  userId: string;
+  installationId: number | null;
+  repoUrl: string | null;
+}): Promise<number | null> {
+  const { userId, installationId, repoUrl } = args;
+  const connectedOwner = parseConnectedOwner(repoUrl);
+  if (installationId === null || !connectedOwner) return installationId;
+
+  let effectiveInstallationId = installationId;
+  try {
+    const storedAccount = await getInstallationAccount(installationId);
+    const alreadyCorrect =
+      storedAccount.login.toLowerCase() === connectedOwner.toLowerCase();
+    // `alreadyCorrect` is a no-op (stored install already owns the repo), NOT a
+    // skip — do not mirror it. Every not-already-correct branch either promotes
+    // (success log.info) or KEEPS the stored install, and a keep must be a
+    // queryable Sentry event (cq-silent-fallback-must-mirror-to-sentry).
+    if (!alreadyCorrect) {
+      if (storedAccount.type === "User") {
+        // Only derive the user's login from a personal (User) install.
+        const { installationId: ownerInstall, outcome } =
+          await findRepoOwnerInstallationForUser(
+            connectedOwner,
+            storedAccount.login,
+          );
+        if (ownerInstall !== null && ownerInstall !== installationId) {
+          log.info(
+            {
+              userId,
+              storedInstallationId: installationId,
+              ownerInstallationId: ownerInstall,
+              owner: connectedOwner,
+            },
+            "Concierge installation self-heal: stored personal install does not own the connected repo; switching to the entitled repo-owner installation for this dispatch",
+          );
+          effectiveInstallationId = ownerInstall;
+        } else if (ownerInstall === null) {
+          // Promotion denied (not-member / transient-indeterminate /
+          // token-mint-failed / no-owner-install) — keep the stored install +
+          // surface the skip so a residual 403 is explainable from Sentry.
+          mirrorSelfHealSkip({
+            userId,
+            storedInstallationId: installationId,
+            owner: connectedOwner,
+            membershipProbeOutcome: outcome,
+            effectiveInstallationId: installationId,
+          });
+        }
+      } else {
+        // Org-type stored install whose account != the connected-repo owner:
+        // the user's login is not derivable without a service-role admin lookup,
+        // so keep the stored install (fail-safe). Mirror it.
+        mirrorSelfHealSkip({
+          userId,
+          storedInstallationId: installationId,
+          owner: connectedOwner,
+          membershipProbeOutcome: "org-type-stored-install",
+          effectiveInstallationId: installationId,
+        });
+      }
+    }
+  } catch (probeErr) {
+    reportSilentFallback(probeErr, {
+      feature: "cc-dispatcher",
+      op: "installation-self-heal-probe",
+      extra: { userId },
+      message: "Repo-owner installation probe failed; keeping stored installation",
+    });
+  }
+  return effectiveInstallationId;
+}

--- a/apps/web-platform/server/cc-reprovision.ts
+++ b/apps/web-platform/server/cc-reprovision.ts
@@ -1,6 +1,7 @@
 import { fetchUserWorkspacePath } from "./kb-document-resolver";
 import { resolveInstallationId } from "./resolve-installation-id";
 import { getCurrentRepoUrl } from "./current-repo-url";
+import { resolveEffectiveInstallationId } from "./cc-effective-installation";
 import {
   ensureWorkspaceRepoCloned,
   type ReprovisionOutcome,
@@ -11,14 +12,14 @@ import { reportSilentFallback } from "./observability";
  * Per-dispatch workspace re-provision for the Concierge (cc-soleur-go) path
  * (#5340 / #5240 design item #2).
  *
- * WHY per-dispatch and not just the factory-internal self-heal at
- * `cc-dispatcher.ts:1469`: that call lives in `realSdkQueryFactory`, which runs
- * ONLY on a COLD conversation — warm-query reconnect (the epic's headline
+ * WHY per-dispatch and not just the factory-internal self-heal: the
+ * `ensureWorkspaceRepoCloned` call in `cc-dispatcher.ts realSdkQueryFactory`
+ * runs ONLY on a COLD conversation — warm-query reconnect (the epic's headline
  * scenario) does NOT re-invoke the factory, so the cold-path self-heal never
  * fires on a warm resume. This runs every dispatch (mirroring the fire-and-
- * forget `resolveBashAutonomous` warm-query resolve at `cc-dispatcher.ts:2348`)
- * and publishes the `ReprovisionOutcome` the post-recovery-failure honest
- * message branch reads on BOTH cold and warm turns.
+ * forget `resolveBashAutonomous` warm-query resolve in `dispatchSoleurGo`) and
+ * publishes the `ReprovisionOutcome` the post-recovery-failure honest message
+ * branch reads on BOTH cold and warm turns.
  *
  * Idempotent + safe to race the cold-path factory call: `ensureWorkspaceRepoCloned`
  * is `.git`-absent-gated and the graft re-checks the `.git` sentinel before its
@@ -35,11 +36,19 @@ export async function reprovisionWorkspaceOnDispatch(
   userId: string,
 ): Promise<ReprovisionOutcome> {
   try {
-    const [workspacePath, installationId, repoUrl] = await Promise.all([
+    const [workspacePath, storedInstallationId, repoUrl] = await Promise.all([
       fetchUserWorkspacePath(userId),
       resolveInstallationId(userId),
       getCurrentRepoUrl(userId),
     ]);
+    // Promote to the entitled repo-owner install (same selection the cold
+    // factory makes) so a cross-account org repo re-clones with the right
+    // credential instead of 403-ing and surfacing a false "couldn't restore".
+    const installationId = await resolveEffectiveInstallationId({
+      userId,
+      installationId: storedInstallationId,
+      repoUrl,
+    });
     return await ensureWorkspaceRepoCloned({
       userId,
       workspacePath,

--- a/apps/web-platform/server/cc-reprovision.ts
+++ b/apps/web-platform/server/cc-reprovision.ts
@@ -1,0 +1,59 @@
+import { fetchUserWorkspacePath } from "./kb-document-resolver";
+import { resolveInstallationId } from "./resolve-installation-id";
+import { getCurrentRepoUrl } from "./current-repo-url";
+import {
+  ensureWorkspaceRepoCloned,
+  type ReprovisionOutcome,
+} from "./ensure-workspace-repo";
+import { reportSilentFallback } from "./observability";
+
+/**
+ * Per-dispatch workspace re-provision for the Concierge (cc-soleur-go) path
+ * (#5340 / #5240 design item #2).
+ *
+ * WHY per-dispatch and not just the factory-internal self-heal at
+ * `cc-dispatcher.ts:1469`: that call lives in `realSdkQueryFactory`, which runs
+ * ONLY on a COLD conversation — warm-query reconnect (the epic's headline
+ * scenario) does NOT re-invoke the factory, so the cold-path self-heal never
+ * fires on a warm resume. This runs every dispatch (mirroring the fire-and-
+ * forget `resolveBashAutonomous` warm-query resolve at `cc-dispatcher.ts:2348`)
+ * and publishes the `ReprovisionOutcome` the post-recovery-failure honest
+ * message branch reads on BOTH cold and warm turns.
+ *
+ * Idempotent + safe to race the cold-path factory call: `ensureWorkspaceRepoCloned`
+ * is `.git`-absent-gated and the graft re-checks the `.git` sentinel before its
+ * move, so a double-invocation no-ops on the second.
+ *
+ * Fail-soft: a transient resolver failure (workspace path / installation / repo
+ * URL) is NOT a clone failure — it returns `"ok"` (the generic-message route)
+ * and mirrors to Sentry, so it never surfaces a FALSE "workspace reclaimed"
+ * honest message. A genuine clone failure returns `"failed"` (the honest-message
+ * signal). Inputs are server-resolved + membership-scoped (ADR-044), never
+ * request input.
+ */
+export async function reprovisionWorkspaceOnDispatch(
+  userId: string,
+): Promise<ReprovisionOutcome> {
+  try {
+    const [workspacePath, installationId, repoUrl] = await Promise.all([
+      fetchUserWorkspacePath(userId),
+      resolveInstallationId(userId),
+      getCurrentRepoUrl(userId),
+    ]);
+    return await ensureWorkspaceRepoCloned({
+      userId,
+      workspacePath,
+      installationId,
+      repoUrl,
+    });
+  } catch (err) {
+    reportSilentFallback(err, {
+      feature: "cc-dispatcher",
+      op: "reprovision-on-dispatch",
+      extra: { userId },
+      message:
+        "per-dispatch workspace re-provision resolve failed; falling back to the generic worktree-enter message (no false reclaim message)",
+    });
+    return "ok";
+  }
+}

--- a/apps/web-platform/server/cc-workflow-end-messages.ts
+++ b/apps/web-platform/server/cc-workflow-end-messages.ts
@@ -5,6 +5,7 @@
 // bidirectional `_AssertWorkflowEndStatusMatches` rail in `soleur-go-runner.ts`.
 
 import type { WorkflowEnd } from "./soleur-go-runner";
+import type { ReprovisionOutcome } from "./ensure-workspace-repo";
 
 type WorkflowEndStatus = WorkflowEnd["status"];
 
@@ -56,3 +57,41 @@ export const WORKFLOW_END_USER_MESSAGES: Record<WorkflowEndStatus, string> = {
 const _workflowEndExhaustive: Record<WorkflowEndStatus, string> =
   WORKFLOW_END_USER_MESSAGES;
 void _workflowEndExhaustive;
+
+/**
+ * Honest "workspace reclaimed" copy (#5340 / #5240 design item #2). Fires ONLY
+ * when a `worktree_enter_failed` turn is paired with a GENUINELY-failed
+ * re-provision recovery (`ReprovisionOutcome === "failed"`) — i.e. the repo was
+ * gone and the automatic re-clone could not restore it (token expired / network
+ * / repo deleted). NOT a new `WorkflowEndStatus` (that would trip the
+ * exhaustiveness rails) — just a distinct message for the existing status.
+ *
+ * Voice mirrors the existing honest copy: the `worktree_enter_failed` generic
+ * line above and the held-place reclaim banner in `chat-surface.tsx`
+ * ("Your place is held — your full conversation is intact. Start a new message
+ * to resume with full context."). Honest about the failure, actionable, and
+ * never leaks the internal status enum.
+ */
+export const WORKSPACE_RECLAIMED_MESSAGE =
+  "Your workspace was reclaimed and couldn't be restored automatically. Your conversation is intact — start a new message to resume with full context.";
+
+/**
+ * Routing decision for a `worktree_enter_failed` turn (the cc `onWorkflowEnded`
+ * else-branch — `worktree_enter_failed` is NOT terminal, so it emits a
+ * `{ type: "error", message }` frame, never `session_ended`).
+ *
+ * PLACEMENT (load-bearing — learning 2026-06-14-short-circuit-guard-must-sit-
+ * after-the-recovery-it-gates.md): the honest reclaimed message is a
+ * POST-recovery-failure concept. It is gated on `reprovisionOutcome === "failed"`
+ * — evaluated AFTER the recovery ran — so a successful/benign recovery ("ok") or
+ * an unresolved outcome (`undefined`, e.g. the per-dispatch resolve had not
+ * settled before the turn failed) falls through to the generic, retryable copy.
+ * This is what keeps the message from lying in the recoverable case.
+ */
+export function resolveWorktreeEnterFailedMessage(
+  reprovisionOutcome: ReprovisionOutcome | undefined,
+): string {
+  return reprovisionOutcome === "failed"
+    ? WORKSPACE_RECLAIMED_MESSAGE
+    : WORKFLOW_END_USER_MESSAGES.worktree_enter_failed;
+}

--- a/apps/web-platform/server/ensure-workspace-repo.ts
+++ b/apps/web-platform/server/ensure-workspace-repo.ts
@@ -31,6 +31,17 @@ export function __setGraftForTests(fn: GraftFn): void {
   graftFn = fn;
 }
 
+/**
+ * Result of a session-start re-provision attempt (#5340 / #5240 design item #2).
+ * Deliberately 2-variant: the only consumer (the cc reconnect honest-message
+ * branch) branches solely on `"failed"`. `"ok"` folds every benign exit
+ * (not-connected, `.git`-present no-op, skipped-bad-url, cloned) — four success
+ * shades nobody reads were cut at plan-review. `"failed"` is ONLY the genuine
+ * clone-catch, i.e. the post-recovery-failure signal that gates the honest
+ * "workspace reclaimed" message.
+ */
+export type ReprovisionOutcome = "failed" | "ok";
+
 export interface EnsureWorkspaceRepoArgs {
   userId: string;
   workspacePath: string;
@@ -69,13 +80,13 @@ export interface EnsureWorkspaceRepoArgs {
  */
 export async function ensureWorkspaceRepoCloned(
   args: EnsureWorkspaceRepoArgs,
-): Promise<void> {
+): Promise<ReprovisionOutcome> {
   const { userId, workspacePath, installationId, repoUrl } = args;
-  if (installationId === null || !repoUrl) return; // not connected → nothing to ensure
+  if (installationId === null || !repoUrl) return "ok"; // not connected → nothing to ensure
 
   // NEVER touch an existing repo (Start-Fresh, already-cloned, or a different
   // origin the user is intentionally using). Only heal the no-`.git` symptom.
-  if (existsSync(join(workspacePath, ".git"))) return;
+  if (existsSync(join(workspacePath, ".git"))) return "ok";
 
   if (!GITHUB_HTTPS_REPO_RE.test(repoUrl)) {
     reportSilentFallback(new Error("repo_url failed github-https allowlist"), {
@@ -84,7 +95,7 @@ export async function ensureWorkspaceRepoCloned(
       extra: { userId, hasInstallation: true },
       message: "connected repo_url is not a github.com HTTPS URL; skipping self-heal",
     });
-    return;
+    return "ok"; // benign skip — a malformed URL is NOT a recovery failure
   }
 
   try {
@@ -95,6 +106,7 @@ export async function ensureWorkspaceRepoCloned(
     // userId), so this is source-hygiene. The two reportSilentFallback sites
     // are guard-allowlisted (they hash via hashExtraUserId) and keep userId.
     log.info({ action: "cloned" }, "ensure-workspace-repo: cloned connected repo");
+    return "ok";
   } catch (err) {
     // Fail-soft: surface to Sentry, never crash the conversation. The token is
     // env-only inside gitWithInstallationAuth (never in argv/URL/stderr), so it
@@ -105,6 +117,10 @@ export async function ensureWorkspaceRepoCloned(
       extra: { userId, hasInstallation: true },
       message: "ensure-workspace-repo clone failed; Concierge proceeds degraded (no clone)",
     });
+    // The ONLY non-benign outcome: a genuine clone failure (token expired /
+    // network / repo gone). This is the post-recovery-failure signal the cc
+    // reconnect path threads to the honest "workspace reclaimed" message.
+    return "failed";
   }
 }
 

--- a/apps/web-platform/test/agent-runner-reprovision.test.ts
+++ b/apps/web-platform/test/agent-runner-reprovision.test.ts
@@ -1,0 +1,292 @@
+// #5340 / #5240 design item #2 — deterministic workspace re-provision on
+// reconnect, LEADER half. The Concierge (cc) path already calls the session-
+// start self-heal `ensureWorkspaceRepoCloned`; the leader path
+// (`startAgentSession` in agent-runner.ts) NEVER did. After a sandbox/host
+// reclaim the resolved active-workspace path can be a fresh filesystem with no
+// repo, and the leader had no recovery — every turn dead-ended.
+//
+// This adds the missing recovery: when the resolved workspace has NO `.git`,
+// lazily resolve the membership-scoped installation + repo and clone, BEFORE
+// `patchWorkspacePermissions` / `syncPull` (both of which need a real repo).
+//
+// Placement (LOAD-BEARING, learning 2026-06-14-short-circuit-guard-must-sit-
+// after-the-recovery-it-gates.md): the leader gains the RECOVERY only — NO
+// bespoke honest "it's gone" message (the leader has no `worktree_enter_failed`
+// guardrail; a failed recovery rides the existing `startAgentSession` catch).
+// The honest message is a Concierge-path post-recovery-failure concept.
+//
+// RED on origin/main: the leader never imports/calls `ensureWorkspaceRepoCloned`
+// → the recovery assertion fails.
+
+import { vi, describe, test, expect, beforeEach } from "vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL ??= "https://test.supabase.co";
+process.env.NEXT_PUBLIC_APP_URL ??= "https://app.soleur.ai";
+process.env.WORKSPACES_ROOT = "/tmp/soleur-leader-reprovision-root";
+
+const {
+  mockFrom,
+  mockRpc,
+  mockQuery,
+  mockReadFileSync,
+  mockExistsSync,
+  mockEnsureWorkspaceRepoCloned,
+  mockResolveInstallationId,
+  mockGetCurrentRepoUrl,
+  mockSyncPull,
+} = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockRpc: vi.fn(),
+  mockQuery: vi.fn(),
+  mockReadFileSync: vi.fn(),
+  mockExistsSync: vi.fn(),
+  mockEnsureWorkspaceRepoCloned: vi.fn(),
+  mockResolveInstallationId: vi.fn(),
+  mockGetCurrentRepoUrl: vi.fn(),
+  mockSyncPull: vi.fn(),
+}));
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: mockQuery,
+  tool: vi.fn(
+    (name: string, _desc: string, _schema: unknown, handler: Function) => ({
+      name,
+      handler,
+    }),
+  ),
+  createSdkMcpServer: vi.fn((opts: { name: string; tools: unknown[] }) => ({
+    type: "sdk",
+    name: opts.name,
+    instance: { tools: opts.tools },
+  })),
+}));
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return { ...actual, readFileSync: mockReadFileSync, existsSync: mockExistsSync };
+});
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/supabase/tenant", () => ({
+  getFreshTenantClient: vi.fn(async () => ({ from: mockFrom, rpc: mockRpc })),
+  mintFounderJwt: vi.fn(),
+  RuntimeAuthError: class RuntimeAuthError extends Error {
+    cause: string;
+    constructor(cause: string, msg: string) {
+      super(msg);
+      this.name = "RuntimeAuthError";
+      this.cause = cause;
+    }
+  },
+}));
+
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+vi.mock("../server/ws-handler", () => ({ sendToClient: vi.fn() }));
+vi.mock("../server/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  createChildLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock("../server/byok", () => ({
+  decryptKey: vi.fn(() => Buffer.from("sk-test-key", "utf8")),
+  decryptKeyLegacy: vi.fn(() => Buffer.from("sk-test-key", "utf8")),
+  zeroize: vi.fn(),
+  encryptKey: vi.fn(),
+}));
+vi.mock("../server/error-sanitizer", () => ({
+  sanitizeErrorForClient: vi.fn(() => "error"),
+}));
+vi.mock("../server/sandbox", () => ({ isPathInWorkspace: vi.fn(() => true) }));
+vi.mock("../server/tool-path-checker", () => ({
+  UNVERIFIED_PARAM_TOOLS: [],
+  extractToolPath: vi.fn(),
+  isFileTool: vi.fn(() => false),
+  isSafeTool: vi.fn(() => false),
+}));
+vi.mock("../server/agent-env", () => ({ buildAgentEnv: vi.fn(() => ({})) }));
+vi.mock("../server/sandbox-hook", () => ({
+  createSandboxHook: vi.fn(() => vi.fn()),
+}));
+vi.mock("../server/review-gate", () => ({
+  abortableReviewGate: vi.fn().mockResolvedValue("Approve"),
+  validateSelection: vi.fn(),
+  extractReviewGateInput: vi.fn(),
+  buildReviewGateResponse: vi.fn(),
+  MAX_SELECTION_LENGTH: 200,
+  REVIEW_GATE_TIMEOUT_MS: 300_000,
+}));
+vi.mock("../server/domain-leaders", () => {
+  const leaders = [
+    { id: "cpo", name: "CPO", title: "Chief Product Officer", description: "Product" },
+  ];
+  return { DOMAIN_LEADERS: leaders, ROUTABLE_DOMAIN_LEADERS: leaders };
+});
+vi.mock("../server/domain-router", () => ({ routeMessage: vi.fn() }));
+vi.mock("../server/session-sync", () => ({ syncPull: mockSyncPull, syncPush: vi.fn() }));
+vi.mock("../server/github-api", () => ({
+  githubApiGet: vi.fn().mockResolvedValue({ default_branch: "main" }),
+  githubApiGetText: vi.fn().mockResolvedValue(""),
+  githubApiPost: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("../server/service-tools", () => ({
+  plausibleCreateSite: vi.fn(),
+  plausibleAddGoal: vi.fn(),
+  plausibleGetStats: vi.fn(),
+}));
+vi.mock("../server/observability", () => ({
+  reportSilentFallback: vi.fn(),
+  reportSilentFallbackWarning: vi.fn(),
+  warnSilentFallback: vi.fn(),
+}));
+vi.mock("../server/vision-helpers", () => ({
+  tryCreateVision: vi.fn().mockResolvedValue(undefined),
+  buildVisionEnhancementPrompt: vi.fn().mockResolvedValue(""),
+}));
+// The recovery under test + its lazily-resolved inputs.
+vi.mock("../server/ensure-workspace-repo", () => ({
+  ensureWorkspaceRepoCloned: mockEnsureWorkspaceRepoCloned,
+}));
+vi.mock("../server/resolve-installation-id", () => ({
+  resolveInstallationId: mockResolveInstallationId,
+}));
+vi.mock("../server/current-repo-url", () => ({
+  getCurrentRepoUrl: mockGetCurrentRepoUrl,
+}));
+
+import { startAgentSession } from "../server/agent-runner";
+import { createApiKeysMock, createQueryMock } from "./helpers/agent-runner-mocks";
+
+const MEMBER_ID = "member-1";
+const ACTIVE_WS_ID = "team-workspace-99";
+const ROOT = "/tmp/soleur-leader-reprovision-root";
+const ACTIVE_DIR = `${ROOT}/${ACTIVE_WS_ID}`;
+const GIT_PATH = `${ACTIVE_DIR}/.git`;
+const REPO = "https://github.com/acme/widget";
+const INSTALL = 4242;
+
+function singleRowChain(row: unknown) {
+  const chain: Record<string, unknown> = {};
+  chain.select = () => chain;
+  chain.eq = () => chain;
+  chain.single = () => ({ data: row, error: null });
+  chain.maybeSingle = () => ({ data: row, error: null });
+  return chain;
+}
+
+function setupSupabaseMock() {
+  mockRpc.mockImplementation(() => Promise.resolve({ data: null, error: null }));
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "api_keys") return createApiKeysMock();
+    if (table === "users") {
+      return singleRowChain({ workspace_path: ACTIVE_DIR, repo_status: null, email: "member@example.com" });
+    }
+    if (table === "user_session_state") {
+      return singleRowChain({ current_workspace_id: ACTIVE_WS_ID });
+    }
+    if (table === "workspace_members") {
+      return singleRowChain({ user_id: MEMBER_ID });
+    }
+    if (table === "workspaces") {
+      return singleRowChain({ repo_url: REPO });
+    }
+    if (table === "conversations") {
+      const sel: Record<string, unknown> = {
+        eq: vi.fn(),
+        single: vi.fn(() => ({
+          data: { domain_leader: "cpo", session_id: null, workspace_id: ACTIVE_WS_ID },
+          error: null,
+        })),
+      };
+      (sel.eq as ReturnType<typeof vi.fn>).mockReturnValue(sel);
+      const upd: Record<string, unknown> = {
+        error: null,
+        eq: vi.fn(),
+        select: vi.fn(() => Promise.resolve({ data: [{ id: "mock" }], error: null })),
+      };
+      (upd.eq as ReturnType<typeof vi.fn>).mockReturnValue(upd);
+      return { update: vi.fn(() => upd), select: vi.fn(() => sel) };
+    }
+    if (table === "messages") {
+      return {
+        insert: () => ({ error: null }),
+        select: () => {
+          const chain: Record<string, unknown> = {
+            eq: () => chain,
+            order: () => Promise.resolve({ data: [], error: null }),
+            then: (resolve: (v: unknown) => void) => resolve({ data: [], error: null }),
+          };
+          return chain;
+        },
+      };
+    }
+    return singleRowChain(null);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockReadFileSync.mockImplementation((filePath: string) => {
+    if (String(filePath).includes("plugin.json")) return JSON.stringify({ mcpServers: {} });
+    throw new Error(`ENOENT: no such file ${filePath}`);
+  });
+  // Default: every other existsSync probe delegates to "present" so unrelated
+  // call sites are unaffected; the per-test override decides the `.git` probe.
+  mockExistsSync.mockReturnValue(true);
+  mockEnsureWorkspaceRepoCloned.mockResolvedValue("ok");
+  mockResolveInstallationId.mockResolvedValue(INSTALL);
+  mockGetCurrentRepoUrl.mockResolvedValue(REPO);
+});
+
+describe("agent-runner leader — deterministic workspace re-provision on reconnect", () => {
+  test("workspace has NO .git → clones the connected repo BEFORE syncPull", async () => {
+    setupSupabaseMock();
+    createQueryMock(mockQuery);
+    // The leader's active-workspace `.git` is absent (host reclaim symptom).
+    mockExistsSync.mockImplementation((p: unknown) => String(p) !== GIT_PATH);
+
+    await startAgentSession(MEMBER_ID, "conv-1", "cpo");
+
+    // Recovery ran with the lazily-resolved, membership-scoped inputs.
+    expect(mockEnsureWorkspaceRepoCloned).toHaveBeenCalledTimes(1);
+    expect(mockEnsureWorkspaceRepoCloned).toHaveBeenCalledWith({
+      userId: MEMBER_ID,
+      workspacePath: ACTIVE_DIR,
+      installationId: INSTALL,
+      repoUrl: REPO,
+    });
+
+    // Ordering: the recovery must precede syncPull (which needs a real repo).
+    const reprovOrder = mockEnsureWorkspaceRepoCloned.mock.invocationCallOrder[0];
+    const syncOrder = mockSyncPull.mock.invocationCallOrder[0];
+    expect(reprovOrder).toBeLessThan(syncOrder);
+  });
+
+  test("workspace HAS .git → recovery no-ops (never touches an existing repo)", async () => {
+    setupSupabaseMock();
+    createQueryMock(mockQuery);
+    // `.git` present → the recovery gate must not fire.
+    mockExistsSync.mockImplementation((p: unknown) => String(p) === GIT_PATH || true);
+
+    await startAgentSession(MEMBER_ID, "conv-1", "cpo");
+
+    expect(mockEnsureWorkspaceRepoCloned).not.toHaveBeenCalled();
+  });
+
+  test("NO bespoke leader honest-message path — a failed recovery does NOT emit a reclaim message (rides the existing catch)", async () => {
+    setupSupabaseMock();
+    createQueryMock(mockQuery);
+    mockExistsSync.mockImplementation((p: unknown) => String(p) !== GIT_PATH);
+    mockEnsureWorkspaceRepoCloned.mockResolvedValue("failed");
+
+    // The leader does not build a second detection path: a failed recovery is
+    // not converted into a bespoke reclaim message here. (The honest message is
+    // Concierge-only — asserted in cc-workflow-end-messages.test.ts.) The turn
+    // proceeds; a downstream failure rides the existing startAgentSession catch.
+    await expect(
+      startAgentSession(MEMBER_ID, "conv-1", "cpo"),
+    ).resolves.not.toThrow();
+    expect(mockEnsureWorkspaceRepoCloned).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web-platform/test/agent-runner-reprovision.test.ts
+++ b/apps/web-platform/test/agent-runner-reprovision.test.ts
@@ -33,6 +33,7 @@ const {
   mockEnsureWorkspaceRepoCloned,
   mockResolveInstallationId,
   mockGetCurrentRepoUrl,
+  mockResolveEffectiveInstallationId,
   mockSyncPull,
 } = vi.hoisted(() => ({
   mockFrom: vi.fn(),
@@ -43,6 +44,7 @@ const {
   mockEnsureWorkspaceRepoCloned: vi.fn(),
   mockResolveInstallationId: vi.fn(),
   mockGetCurrentRepoUrl: vi.fn(),
+  mockResolveEffectiveInstallationId: vi.fn(),
   mockSyncPull: vi.fn(),
 }));
 
@@ -154,6 +156,9 @@ vi.mock("../server/resolve-installation-id", () => ({
 vi.mock("../server/current-repo-url", () => ({
   getCurrentRepoUrl: mockGetCurrentRepoUrl,
 }));
+vi.mock("../server/cc-effective-installation", () => ({
+  resolveEffectiveInstallationId: mockResolveEffectiveInstallationId,
+}));
 
 import { startAgentSession } from "../server/agent-runner";
 import { createApiKeysMock, createQueryMock } from "./helpers/agent-runner-mocks";
@@ -237,6 +242,10 @@ beforeEach(() => {
   mockEnsureWorkspaceRepoCloned.mockResolvedValue("ok");
   mockResolveInstallationId.mockResolvedValue(INSTALL);
   mockGetCurrentRepoUrl.mockResolvedValue(REPO);
+  // Effective-install promotion pass-through by default (stored === owner).
+  mockResolveEffectiveInstallationId.mockImplementation(
+    async ({ installationId }: { installationId: number | null }) => installationId,
+  );
 });
 
 describe("agent-runner leader — deterministic workspace re-provision on reconnect", () => {
@@ -258,6 +267,11 @@ describe("agent-runner leader — deterministic workspace re-provision on reconn
     });
 
     // Ordering: the recovery must precede syncPull (which needs a real repo).
+    // Guard non-vacuity — both mocks MUST have fired or the comparison is
+    // meaningless (a NaN/undefined `toBeLessThan` would not read as "syncPull
+    // never ran"). See test-design review.
+    expect(mockEnsureWorkspaceRepoCloned).toHaveBeenCalled();
+    expect(mockSyncPull).toHaveBeenCalled();
     const reprovOrder = mockEnsureWorkspaceRepoCloned.mock.invocationCallOrder[0];
     const syncOrder = mockSyncPull.mock.invocationCallOrder[0];
     expect(reprovOrder).toBeLessThan(syncOrder);
@@ -266,11 +280,14 @@ describe("agent-runner leader — deterministic workspace re-provision on reconn
   test("workspace HAS .git → recovery no-ops (never touches an existing repo)", async () => {
     setupSupabaseMock();
     createQueryMock(mockQuery);
-    // `.git` present → the recovery gate must not fire.
-    mockExistsSync.mockImplementation((p: unknown) => String(p) === GIT_PATH || true);
+    // `.git` present → the recovery gate must not fire. (Default beforeEach
+    // already returns true for every probe; this test pins that the gate
+    // specifically probed the workspace `.git` path and then no-op'd.)
+    mockExistsSync.mockReturnValue(true);
 
     await startAgentSession(MEMBER_ID, "conv-1", "cpo");
 
+    expect(mockExistsSync).toHaveBeenCalledWith(GIT_PATH);
     expect(mockEnsureWorkspaceRepoCloned).not.toHaveBeenCalled();
   });
 

--- a/apps/web-platform/test/cc-dispatcher.test.ts
+++ b/apps/web-platform/test/cc-dispatcher.test.ts
@@ -87,6 +87,14 @@ vi.mock("@/lib/supabase/service", async () => {
   });
 });
 
+// #5340 / #5240 — stub the per-dispatch warm re-provision so the
+// honest-message wiring tests can drive `reprovisionOutcome` deterministically.
+// Default "ok" is a safe no-op for every other dispatch test (fire-and-forget,
+// no assertions on it).
+vi.mock("@/server/cc-reprovision", () => ({
+  reprovisionWorkspaceOnDispatch: vi.fn().mockResolvedValue("ok"),
+}));
+
 import {
   getPendingPromptRegistry,
   getCcStartSessionRateLimiter,
@@ -96,6 +104,11 @@ import {
   __resetCcPersistUsageObservationForTests,
   CC_OP_SLUGS,
 } from "@/server/cc-dispatcher";
+import { reprovisionWorkspaceOnDispatch } from "@/server/cc-reprovision";
+import {
+  WORKSPACE_RECLAIMED_MESSAGE,
+  WORKFLOW_END_USER_MESSAGES,
+} from "@/server/cc-workflow-end-messages";
 // #3603 W1 plan §2.2.3 — hook P0 dedup reset into the test reset chain so a
 // future test that exercises the real `mirrorP0Deduped` (vs. this file's spy
 // override) doesn't see state leak from a prior test. No-op against the spy
@@ -360,6 +373,64 @@ describe("cc-dispatcher singletons + orchestration", () => {
     expect(errMsg.runnerRunawayReason).toBe("idle_window");
     expect(errMsg.runnerRunawayLastBlockKind).toBe("tool_use");
     expect(errMsg.runnerRunawayLastBlockToolName).toBe("Read");
+  });
+
+  // #5340 / #5240 design item #2 — integration wiring for the post-recovery-
+  // failure honest message: the per-dispatch `reprovisionWorkspaceOnDispatch`
+  // result must populate the `reprovisionOutcome` closure cell, and the
+  // `onWorkflowEnded` `worktree_enter_failed` branch must read it via
+  // `resolveWorktreeEnterFailedMessage`. This closes the unit-vs-integration
+  // seam: the helper + pure function are unit-tested elsewhere; this proves the
+  // dispatcher actually wires them together. `worktree_enter_failed` is NOT
+  // terminal, so it routes to a `{type:"error", message}` frame (never
+  // session_ended). The stub flushes microtasks before emitting so the
+  // fire-and-forget re-provision resolves first (deterministic).
+  async function driveWorktreeEnterFailed(sendToClient: ReturnType<typeof vi.fn>) {
+    const { __setCcRunnerForTests } = await import("@/server/cc-dispatcher");
+    __setCcRunnerForTests({
+      dispatch: vi.fn(async (args: { events: { onWorkflowEnded: (end: unknown) => void } }) => {
+        // Let the fire-and-forget reprovision `.then` populate the cell first.
+        await Promise.resolve();
+        await Promise.resolve();
+        args.events.onWorkflowEnded({ status: "worktree_enter_failed" });
+      }),
+      hasActiveQuery: () => false,
+      activeQueriesSize: () => 0,
+      reapIdle: () => 0,
+      closeConversation: () => {},
+      respondToToolUse: () => false,
+      notifyAwaitingUser: () => {},
+      // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+    } as any);
+    await dispatchSoleurGo({
+      userId: "u1",
+      conversationId: "conv-reclaim",
+      userMessage: "resume",
+      currentRouting: { kind: "soleur_go_pending" },
+      sendToClient: sendToClient as unknown as (userId: string, message: WSMessage) => boolean,
+      persistActiveWorkflow: vi.fn().mockResolvedValue(undefined),
+    });
+    const errorCalls = sendToClient.mock.calls.filter(
+      ([, msg]) => msg && typeof msg === "object" && (msg as { type?: string }).type === "error",
+    );
+    return errorCalls.map((c) => c[1] as { type: string; message: string });
+  }
+
+  it("worktree_enter_failed + reprovision 'failed' → honest WORKSPACE_RECLAIMED_MESSAGE (#5340)", async () => {
+    vi.mocked(reprovisionWorkspaceOnDispatch).mockResolvedValueOnce("failed");
+    const sendToClient = vi.fn().mockReturnValue(true);
+    const errs = await driveWorktreeEnterFailed(sendToClient);
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs.some((e) => e.message === WORKSPACE_RECLAIMED_MESSAGE)).toBe(true);
+  });
+
+  it("worktree_enter_failed + reprovision 'ok' → generic retryable copy, NOT the reclaimed message (placement invariant)", async () => {
+    vi.mocked(reprovisionWorkspaceOnDispatch).mockResolvedValueOnce("ok");
+    const sendToClient = vi.fn().mockReturnValue(true);
+    const errs = await driveWorktreeEnterFailed(sendToClient);
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs.some((e) => e.message === WORKFLOW_END_USER_MESSAGES.worktree_enter_failed)).toBe(true);
+    expect(errs.some((e) => e.message === WORKSPACE_RECLAIMED_MESSAGE)).toBe(false);
   });
 
   it("T19: dispatchSoleurGo surfaces errorCode=key_invalid when runner throws KeyInvalidError", async () => {

--- a/apps/web-platform/test/cc-effective-installation.test.ts
+++ b/apps/web-platform/test/cc-effective-installation.test.ts
@@ -1,0 +1,105 @@
+// #5340 / #5240 — the Concierge installation self-heal SELECTION, extracted from
+// `cc-dispatcher.ts realSdkQueryFactory` (feat-one-shot-concierge-gh-403) so the
+// cold factory, the per-dispatch warm re-provision (cc-reprovision.ts), and the
+// leader recovery (agent-runner.ts) all select the SAME entitled install. The
+// extraction makes the promotion branches unit-testable for the first time (the
+// factory was impractical to invoke whole).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockGetInstallationAccount,
+  mockFindRepoOwnerInstallationForUser,
+  mockMirrorSelfHealSkip,
+  mockReportSilentFallback,
+} = vi.hoisted(() => ({
+  mockGetInstallationAccount: vi.fn(),
+  mockFindRepoOwnerInstallationForUser: vi.fn(),
+  mockMirrorSelfHealSkip: vi.fn(),
+  mockReportSilentFallback: vi.fn(),
+}));
+
+vi.mock("@/server/github-app", () => ({
+  getInstallationAccount: mockGetInstallationAccount,
+  findRepoOwnerInstallationForUser: mockFindRepoOwnerInstallationForUser,
+}));
+vi.mock("@/server/cc-self-heal-observability", () => ({
+  mirrorSelfHealSkip: mockMirrorSelfHealSkip,
+}));
+vi.mock("@/server/observability", () => ({
+  reportSilentFallback: mockReportSilentFallback,
+}));
+vi.mock("@/server/logger", () => ({
+  createChildLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { resolveEffectiveInstallationId } from "@/server/cc-effective-installation";
+
+const USER = "u1";
+const REPO = "https://github.com/acme-org/widget";
+const STORED = 100;
+const OWNER = 200;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("resolveEffectiveInstallationId", () => {
+  it("null stored install → returns null (no probe)", async () => {
+    const out = await resolveEffectiveInstallationId({ userId: USER, installationId: null, repoUrl: REPO });
+    expect(out).toBeNull();
+    expect(mockGetInstallationAccount).not.toHaveBeenCalled();
+  });
+
+  it("malformed / empty repoUrl (no owner) → returns the stored install, no probe", async () => {
+    const out = await resolveEffectiveInstallationId({ userId: USER, installationId: STORED, repoUrl: null });
+    expect(out).toBe(STORED);
+    expect(mockGetInstallationAccount).not.toHaveBeenCalled();
+  });
+
+  it("stored install already owns the repo → returns stored, NO skip mirror", async () => {
+    mockGetInstallationAccount.mockResolvedValue({ login: "acme-org", type: "Organization" });
+    const out = await resolveEffectiveInstallationId({ userId: USER, installationId: STORED, repoUrl: REPO });
+    expect(out).toBe(STORED);
+    expect(mockMirrorSelfHealSkip).not.toHaveBeenCalled();
+  });
+
+  it("personal install not owning the repo + entitled owner install found → PROMOTES", async () => {
+    mockGetInstallationAccount.mockResolvedValue({ login: "alice", type: "User" });
+    mockFindRepoOwnerInstallationForUser.mockResolvedValue({ installationId: OWNER, outcome: "member" });
+    const out = await resolveEffectiveInstallationId({ userId: USER, installationId: STORED, repoUrl: REPO });
+    expect(out).toBe(OWNER);
+    expect(mockMirrorSelfHealSkip).not.toHaveBeenCalled();
+  });
+
+  it("personal install, promotion denied (owner install null) → keeps stored + mirrors skip", async () => {
+    mockGetInstallationAccount.mockResolvedValue({ login: "alice", type: "User" });
+    mockFindRepoOwnerInstallationForUser.mockResolvedValue({ installationId: null, outcome: "not-member" });
+    const out = await resolveEffectiveInstallationId({ userId: USER, installationId: STORED, repoUrl: REPO });
+    expect(out).toBe(STORED);
+    expect(mockMirrorSelfHealSkip).toHaveBeenCalledTimes(1);
+    expect(mockMirrorSelfHealSkip.mock.calls[0][0]).toMatchObject({
+      membershipProbeOutcome: "not-member",
+      effectiveInstallationId: STORED,
+    });
+  });
+
+  it("org-type stored install not owning the repo → keeps stored + mirrors org-type skip", async () => {
+    mockGetInstallationAccount.mockResolvedValue({ login: "other-org", type: "Organization" });
+    const out = await resolveEffectiveInstallationId({ userId: USER, installationId: STORED, repoUrl: REPO });
+    expect(out).toBe(STORED);
+    expect(mockFindRepoOwnerInstallationForUser).not.toHaveBeenCalled();
+    expect(mockMirrorSelfHealSkip).toHaveBeenCalledWith(
+      expect.objectContaining({ membershipProbeOutcome: "org-type-stored-install" }),
+    );
+  });
+
+  it("probe throws → fail-soft: keeps stored install + mirrors to Sentry, never throws", async () => {
+    mockGetInstallationAccount.mockRejectedValue(new Error("probe boom"));
+    const out = await resolveEffectiveInstallationId({ userId: USER, installationId: STORED, repoUrl: REPO });
+    expect(out).toBe(STORED);
+    expect(mockReportSilentFallback).toHaveBeenCalledTimes(1);
+    expect(mockReportSilentFallback.mock.calls[0][1]).toMatchObject({
+      feature: "cc-dispatcher",
+      op: "installation-self-heal-probe",
+    });
+  });
+});

--- a/apps/web-platform/test/cc-reprovision.test.ts
+++ b/apps/web-platform/test/cc-reprovision.test.ts
@@ -17,12 +17,14 @@ const {
   mockFetchUserWorkspacePath,
   mockResolveInstallationId,
   mockGetCurrentRepoUrl,
+  mockResolveEffectiveInstallationId,
   mockEnsureWorkspaceRepoCloned,
   mockReportSilentFallback,
 } = vi.hoisted(() => ({
   mockFetchUserWorkspacePath: vi.fn(),
   mockResolveInstallationId: vi.fn(),
   mockGetCurrentRepoUrl: vi.fn(),
+  mockResolveEffectiveInstallationId: vi.fn(),
   mockEnsureWorkspaceRepoCloned: vi.fn(),
   mockReportSilentFallback: vi.fn(),
 }));
@@ -35,6 +37,9 @@ vi.mock("@/server/resolve-installation-id", () => ({
 }));
 vi.mock("@/server/current-repo-url", () => ({
   getCurrentRepoUrl: mockGetCurrentRepoUrl,
+}));
+vi.mock("@/server/cc-effective-installation", () => ({
+  resolveEffectiveInstallationId: mockResolveEffectiveInstallationId,
 }));
 vi.mock("@/server/ensure-workspace-repo", () => ({
   ensureWorkspaceRepoCloned: mockEnsureWorkspaceRepoCloned,
@@ -55,6 +60,10 @@ beforeEach(() => {
   mockFetchUserWorkspacePath.mockResolvedValue(WS);
   mockResolveInstallationId.mockResolvedValue(INSTALL);
   mockGetCurrentRepoUrl.mockResolvedValue(REPO);
+  // Default: effective-install promotion is a pass-through (stored === owner).
+  mockResolveEffectiveInstallationId.mockImplementation(
+    async ({ installationId }: { installationId: number | null }) => installationId,
+  );
   mockEnsureWorkspaceRepoCloned.mockResolvedValue("ok");
 });
 
@@ -71,6 +80,21 @@ describe("reprovisionWorkspaceOnDispatch (warm-query reconnect coverage)", () =>
       installationId: INSTALL,
       repoUrl: REPO,
     });
+  });
+
+  it("clones with the PROMOTED (effective) install, not the raw stored one — parity with the cold factory (review finding)", async () => {
+    const OWNER_INSTALL = 9999;
+    // Stored personal install does not own the org repo → promoted to owner.
+    mockResolveEffectiveInstallationId.mockResolvedValue(OWNER_INSTALL);
+    await reprovisionWorkspaceOnDispatch(USER);
+    expect(mockResolveEffectiveInstallationId).toHaveBeenCalledWith({
+      userId: USER,
+      installationId: INSTALL,
+      repoUrl: REPO,
+    });
+    expect(mockEnsureWorkspaceRepoCloned).toHaveBeenCalledWith(
+      expect.objectContaining({ installationId: OWNER_INSTALL }),
+    );
   });
 
   it("propagates the recovery outcome — 'ok' when the repo is present/cloned", async () => {

--- a/apps/web-platform/test/cc-reprovision.test.ts
+++ b/apps/web-platform/test/cc-reprovision.test.ts
@@ -1,0 +1,99 @@
+// #5340 / #5240 design item #2 — warm-query reconnect coverage for the
+// Concierge (cc) path.
+//
+// LOAD-BEARING (deepen finding): the cc `realSdkQueryFactory` (which holds the
+// existing `ensureWorkspaceRepoCloned` self-heal at cc-dispatcher.ts:1469) runs
+// ONLY on a COLD conversation — on warm-query reuse it is NOT re-invoked. The
+// reconnect scenario the epic targets is frequently a *warm* resume, so the
+// re-provision + result publish must run per-dispatch (not only inside the cold
+// factory). This module is the per-dispatch resolve, mirroring the
+// fire-and-forget `resolveBashAutonomous` warm-query resolve at
+// cc-dispatcher.ts:2348. It publishes the `ReprovisionOutcome` the
+// honest-message branch reads on BOTH cold and warm turns.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockFetchUserWorkspacePath,
+  mockResolveInstallationId,
+  mockGetCurrentRepoUrl,
+  mockEnsureWorkspaceRepoCloned,
+  mockReportSilentFallback,
+} = vi.hoisted(() => ({
+  mockFetchUserWorkspacePath: vi.fn(),
+  mockResolveInstallationId: vi.fn(),
+  mockGetCurrentRepoUrl: vi.fn(),
+  mockEnsureWorkspaceRepoCloned: vi.fn(),
+  mockReportSilentFallback: vi.fn(),
+}));
+
+vi.mock("@/server/kb-document-resolver", () => ({
+  fetchUserWorkspacePath: mockFetchUserWorkspacePath,
+}));
+vi.mock("@/server/resolve-installation-id", () => ({
+  resolveInstallationId: mockResolveInstallationId,
+}));
+vi.mock("@/server/current-repo-url", () => ({
+  getCurrentRepoUrl: mockGetCurrentRepoUrl,
+}));
+vi.mock("@/server/ensure-workspace-repo", () => ({
+  ensureWorkspaceRepoCloned: mockEnsureWorkspaceRepoCloned,
+}));
+vi.mock("@/server/observability", () => ({
+  reportSilentFallback: mockReportSilentFallback,
+}));
+
+import { reprovisionWorkspaceOnDispatch } from "@/server/cc-reprovision";
+
+const USER = "user-1";
+const WS = "/workspaces/ws-uuid";
+const REPO = "https://github.com/acme/widget";
+const INSTALL = 4242;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetchUserWorkspacePath.mockResolvedValue(WS);
+  mockResolveInstallationId.mockResolvedValue(INSTALL);
+  mockGetCurrentRepoUrl.mockResolvedValue(REPO);
+  mockEnsureWorkspaceRepoCloned.mockResolvedValue("ok");
+});
+
+describe("reprovisionWorkspaceOnDispatch (warm-query reconnect coverage)", () => {
+  it("resolves the membership-scoped inputs and calls the recovery once", async () => {
+    await reprovisionWorkspaceOnDispatch(USER);
+    expect(mockFetchUserWorkspacePath).toHaveBeenCalledWith(USER);
+    expect(mockResolveInstallationId).toHaveBeenCalledWith(USER);
+    expect(mockGetCurrentRepoUrl).toHaveBeenCalledWith(USER);
+    expect(mockEnsureWorkspaceRepoCloned).toHaveBeenCalledTimes(1);
+    expect(mockEnsureWorkspaceRepoCloned).toHaveBeenCalledWith({
+      userId: USER,
+      workspacePath: WS,
+      installationId: INSTALL,
+      repoUrl: REPO,
+    });
+  });
+
+  it("propagates the recovery outcome — 'ok' when the repo is present/cloned", async () => {
+    mockEnsureWorkspaceRepoCloned.mockResolvedValue("ok");
+    await expect(reprovisionWorkspaceOnDispatch(USER)).resolves.toBe("ok");
+  });
+
+  it("propagates 'failed' when the re-clone genuinely fails (the honest-message signal)", async () => {
+    mockEnsureWorkspaceRepoCloned.mockResolvedValue("failed");
+    await expect(reprovisionWorkspaceOnDispatch(USER)).resolves.toBe("failed");
+  });
+
+  it("fail-soft: a resolver error returns 'ok' (NOT 'failed') and mirrors to Sentry", async () => {
+    // A transient resolve failure is NOT a clone failure — returning "failed"
+    // would surface a false honest "workspace reclaimed" message. Fail closed to
+    // the generic route and mirror so it is queryable.
+    mockFetchUserWorkspacePath.mockRejectedValue(new Error("resolve boom"));
+    await expect(reprovisionWorkspaceOnDispatch(USER)).resolves.toBe("ok");
+    expect(mockEnsureWorkspaceRepoCloned).not.toHaveBeenCalled();
+    expect(mockReportSilentFallback).toHaveBeenCalledTimes(1);
+    expect(mockReportSilentFallback.mock.calls[0][1]).toMatchObject({
+      feature: "cc-dispatcher",
+      op: "reprovision-on-dispatch",
+    });
+  });
+});

--- a/apps/web-platform/test/cc-workflow-end-messages.test.ts
+++ b/apps/web-platform/test/cc-workflow-end-messages.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 
-import { WORKFLOW_END_USER_MESSAGES } from "@/server/cc-workflow-end-messages";
+import {
+  WORKFLOW_END_USER_MESSAGES,
+  WORKSPACE_RECLAIMED_MESSAGE,
+  resolveWorktreeEnterFailedMessage,
+} from "@/server/cc-workflow-end-messages";
 
 // Relocated from `test/cc-dispatcher.test.ts:723-769` as part of the
 // `cc-workflow-end-messages.ts` extraction (#3243, ADR-031).
@@ -66,5 +70,47 @@ describe("WORKFLOW_END_USER_MESSAGES", () => {
     for (const [key, msg] of Object.entries(WORKFLOW_END_USER_MESSAGES)) {
       expect(msg, `key=${key}`).not.toContain("Workflow ended (");
     }
+  });
+});
+
+// #5340 / #5240 design item #2 — the post-recovery-failure honest message.
+// `resolveWorktreeEnterFailedMessage` is the pure routing decision the cc
+// `onWorkflowEnded` else-branch consumes: `worktree_enter_failed` routes there
+// (it is NOT terminal — see TERMINAL_WORKFLOW_END_STATUSES) and emits a
+// `{ type: "error", message }` frame. Which message depends on whether the
+// re-provision recovery genuinely failed.
+describe("resolveWorktreeEnterFailedMessage — honest reclaimed message gating", () => {
+  it("recovery FAILED → the honest 'workspace reclaimed' message", () => {
+    expect(resolveWorktreeEnterFailedMessage("failed")).toBe(
+      WORKSPACE_RECLAIMED_MESSAGE,
+    );
+  });
+
+  // PLACEMENT INVARIANT (load-bearing — 2026-06-14-short-circuit-guard-must-sit-
+  // after-the-recovery-it-gates.md): the honest "it's gone" message is a
+  // POST-recovery-failure concept. A successful/benign recovery ("ok") — or an
+  // unresolved outcome (undefined) — must NEVER yield the reclaimed message;
+  // it falls through to the generic, retryable copy. This is what proves the
+  // branch sits AFTER the recovery, not before it.
+  it("recovery 'ok' → the generic retryable worktree-enter copy (NOT the reclaimed message)", () => {
+    expect(resolveWorktreeEnterFailedMessage("ok")).toBe(
+      WORKFLOW_END_USER_MESSAGES.worktree_enter_failed,
+    );
+    expect(resolveWorktreeEnterFailedMessage("ok")).not.toBe(
+      WORKSPACE_RECLAIMED_MESSAGE,
+    );
+  });
+
+  it("recovery outcome unresolved (undefined) → generic copy (fail-closed, never a false reclaim)", () => {
+    expect(resolveWorktreeEnterFailedMessage(undefined)).toBe(
+      WORKFLOW_END_USER_MESSAGES.worktree_enter_failed,
+    );
+  });
+
+  it("the reclaimed copy is honest + actionable (no internal enum leak, no 'Agent stopped responding')", () => {
+    expect(WORKSPACE_RECLAIMED_MESSAGE).toContain("workspace");
+    expect(WORKSPACE_RECLAIMED_MESSAGE).not.toContain("Agent stopped responding");
+    expect(WORKSPACE_RECLAIMED_MESSAGE).not.toContain("Workflow ended (");
+    expect(WORKSPACE_RECLAIMED_MESSAGE).not.toContain("worktree_enter_failed");
   });
 });

--- a/apps/web-platform/test/ensure-workspace-repo.test.ts
+++ b/apps/web-platform/test/ensure-workspace-repo.test.ts
@@ -48,6 +48,47 @@ describe("ensureWorkspaceRepoCloned", () => {
     expect(mockExistsSync).not.toHaveBeenCalled();
   });
 
+  // #5340 / #5240 item #2 — the return type widened from `void` to a typed
+  // `ReprovisionOutcome` ("failed" | "ok") so the cc reconnect path can thread
+  // the recovery result to the post-recovery-failure honest message. The fail-
+  // soft posture is unchanged (still never throws); only the return is added.
+  // "ok" folds every benign exit (not-connected, .git-present, skipped-bad-url,
+  // cloned); "failed" is ONLY the genuine clone-catch.
+  it("not connected → returns 'ok' (benign, nothing to ensure)", async () => {
+    const out = await ensureWorkspaceRepoCloned({ userId: "u1", workspacePath: WS, installationId: null, repoUrl: REPO });
+    expect(out).toBe("ok");
+  });
+
+  it("ANY existing .git → returns 'ok' (benign no-op)", async () => {
+    mockExistsSync.mockReturnValue(true);
+    const out = await ensureWorkspaceRepoCloned({ userId: "u1", workspacePath: WS, installationId: 123, repoUrl: REPO });
+    expect(out).toBe("ok");
+  });
+
+  it("malformed repo_url → returns 'ok' (benign skip, not a recovery failure)", async () => {
+    mockExistsSync.mockReturnValue(false);
+    const out = await ensureWorkspaceRepoCloned({
+      userId: "u1",
+      workspacePath: WS,
+      installationId: 123,
+      repoUrl: "https://evil.example.com/x/y --upload-pack=evil",
+    });
+    expect(out).toBe("ok");
+  });
+
+  it("successful clone → returns 'ok'", async () => {
+    mockExistsSync.mockReturnValue(false);
+    const out = await ensureWorkspaceRepoCloned({ userId: "u1", workspacePath: WS, installationId: 123, repoUrl: REPO });
+    expect(out).toBe("ok");
+  });
+
+  it("clone failure (catch) → returns 'failed' (the only non-benign outcome)", async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockGraftRepoClone.mockRejectedValue(new Error("clone boom"));
+    const out = await ensureWorkspaceRepoCloned({ userId: "u1", workspacePath: WS, installationId: 123, repoUrl: REPO });
+    expect(out).toBe("failed");
+  });
+
   it("not connected (repoUrl empty) → no-op", async () => {
     await ensureWorkspaceRepoCloned({ userId: "u1", workspacePath: WS, installationId: 123, repoUrl: null });
     expect(mockGraftRepoClone).not.toHaveBeenCalled();
@@ -96,9 +137,12 @@ describe("ensureWorkspaceRepoCloned", () => {
   it("clone failure → reportSilentFallback once AND does NOT throw (graceful degrade)", async () => {
     mockExistsSync.mockReturnValue(false);
     mockGraftRepoClone.mockRejectedValue(new Error("clone boom: token ghs_SECRET"));
+    // Fail-soft: resolves (never throws). The resolved value is the typed
+    // "failed" outcome (was `void` pre-#5340) — covered by the dedicated
+    // outcome test above; here we only assert the no-throw posture.
     await expect(
       ensureWorkspaceRepoCloned({ userId: "u1", workspacePath: WS, installationId: 123, repoUrl: REPO }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe("failed");
     expect(mockReportSilentFallback).toHaveBeenCalledTimes(1);
     expect(mockReportSilentFallback.mock.calls[0][1]).toMatchObject({
       feature: "ensure-workspace-repo",

--- a/knowledge-base/project/learnings/best-practices/2026-06-15-parallel-recovery-path-must-reuse-same-resource-selection.md
+++ b/knowledge-base/project/learnings/best-practices/2026-06-15-parallel-recovery-path-must-reuse-same-resource-selection.md
@@ -1,0 +1,67 @@
+# Learning: a new parallel recovery path must reuse the SAME resource-selection as the self-heal it mirrors
+
+## Problem
+
+#5340 / #5240 added deterministic workspace re-provision on reconnect across two
+divergent turn-start paths. The Concierge cold factory already self-healed a
+missing repo via `ensureWorkspaceRepoCloned`, but it cloned with
+`effectiveInstallationId` — the entitlement-PROMOTED repo-owner install computed
+by a ~60-line self-heal (feat-one-shot-concierge-gh-403) that exists precisely
+because the raw stored install can be a cross-account personal install that
+`403`s on an org repo.
+
+The new warm-query per-dispatch re-provision (`cc-reprovision.ts`) and the new
+leader recovery (`agent-runner.ts`) each resolved the install with the RAW
+`resolveInstallationId(userId)` — skipping the promotion. On a warm reconnect to
+a cross-account ORG repo with a genuinely-gone `.git`, the raw clone `403`s →
+`ReprovisionOutcome` `"failed"` → the user sees the honest "workspace reclaimed —
+couldn't restore automatically" message for a repo a COLD turn would have
+recovered with the promoted install. The message lies in exactly the case the
+promotion logic was built to fix.
+
+tsc was silent (raw vs promoted are both `number | null`); the unit tests passed
+(each path tested in isolation); only the multi-agent review's
+`architecture-strategist` (corroborated by `pattern-recognition-specialist`)
+caught the cross-path divergence.
+
+## Solution
+
+Extract the SELECTION into one shared helper and route every path through it:
+`resolveEffectiveInstallationId({ userId, installationId, repoUrl })` in
+`cc-effective-installation.ts`. The cold factory, the cc per-dispatch resolve,
+and the leader recovery all call it, so the credential selection cannot drift.
+The extraction was behavior-preserving for the factory (verified by the existing
+`cc-dispatcher-real-factory` / `cc-dispatcher-self-heal-observability` suites)
+AND made the promotion branches unit-testable for the first time (the factory
+was previously "impractical to invoke whole", so the promotion had no direct
+test).
+
+## Key Insight
+
+When you add a SECOND code path that performs the same operation as an existing
+self-heal (a parallel recovery, a warm-path mirror of a cold path, a leader
+mirror of a Concierge path), the new path must reuse the original's
+**resource/credential SELECTION**, not just its final primitive. Two paths that
+call the same `doThing(resource)` but resolve `resource` differently are NOT
+idempotent-equivalent — they diverge on exactly the edge case the original's
+selection logic was built to handle. The cheapest guard: extract the selection
+into a shared helper the moment a second caller appears, rather than re-resolving
+"the obvious way" at the new call site. Comments that call the two paths
+"idempotent" mask this — idempotent on the HAPPY path is not idempotent on the
+selection edge case.
+
+Corollary (placement, reinforced from
+[[2026-06-14-short-circuit-guard-must-sit-after-the-recovery-it-gates]]): an
+honest "it's gone" message gated on a recovery OUTCOME is only as honest as the
+recovery is strong. A weaker recovery on one path makes the same message lie.
+
+## Tags
+category: best-practices
+module: apps/web-platform/server (cc-dispatcher, cc-reprovision, agent-runner, cc-effective-installation)
+
+## Session Errors
+
+- **Review classification `set -uo pipefail` tripped the shell snapshot** (`ZSH_VERSION: unbound variable`). Recovery: re-ran the classification greps without `set -u`. Prevention: one-off / machine-specific (the host shell-snapshot references `ZSH_VERSION` under `set -u`); not a project-rule defect.
+- **Anti-slop scanner inline python heredoc syntax error.** Recovery: wrote the scanner JSON to a file, parsed separately. Prevention: one-off command-construction slip; prefer writing tool output to a file before piping to a multi-line parser.
+- **tsc type mismatch on the integration test's `sendToClient` passthrough** (`Mock` not assignable to `(userId, message) => boolean`). Recovery: cast at the `dispatchSoleurGo` call site. Prevention: expected TDD iteration; helper params typed as `ReturnType<typeof vi.fn>` need a cast when passed to a typed callback param.
+- **`Monitor` deferred tool called before its schema was loaded** → InputValidationError. Recovery: used the inline-returned schema params. Prevention: one-off; ToolSearch a deferred tool before first call.

--- a/knowledge-base/project/plans/2026-06-15-feat-workspace-reprovision-on-reconnect-plan.md
+++ b/knowledge-base/project/plans/2026-06-15-feat-workspace-reprovision-on-reconnect-plan.md
@@ -450,8 +450,8 @@ logs:
   where: pino child loggers "ensure-workspace-repo", "cc-dispatcher"; Sentry
   retention: existing Better Stack / Sentry retention (unchanged)
 discoverability_test:
-  command: cd apps/web-platform && ./node_modules/.bin/vitest run test/cc-dispatcher-reprovision-honest-message.test.ts
-  expected_output: all assertions pass (threading + both routing polarities)
+  command: cd apps/web-platform && ./node_modules/.bin/vitest run test/cc-dispatcher.test.ts test/cc-workflow-end-messages.test.ts test/cc-reprovision.test.ts test/cc-effective-installation.test.ts
+  expected_output: all assertions pass (cc honest-message wiring both polarities + warm-query resolve + effective-install promotion)
 ```
 
 ## Risks & Mitigations

--- a/knowledge-base/project/plans/2026-06-15-feat-workspace-reprovision-on-reconnect-plan.md
+++ b/knowledge-base/project/plans/2026-06-15-feat-workspace-reprovision-on-reconnect-plan.md
@@ -1,4 +1,5 @@
 ---
+deepened: 2026-06-15
 title: Deterministic workspace re-provision on reconnect (#5240 design item #2)
 issue: 5340
 epic: 5240
@@ -11,6 +12,38 @@ status: draft
 ---
 
 # Deterministic workspace re-provision on reconnect
+
+## Enhancement Summary
+
+**Deepened on:** 2026-06-15
+**Sections enhanced:** Files to Edit, Sharp Edges, Risks, Implementation Phases
+
+### Key improvements from the deepen pass
+1. **COLD-vs-WARM factory gap (load-bearing — caught at deepen).** The cc
+   `realSdkQueryFactory` (and therefore both `ensureWorkspaceRepoCloned` at
+   `:1469` AND the new `setReprovisionResult` publish) runs **only on a COLD
+   conversation** — on warm-query reuse it is NOT re-invoked
+   (`cc-dispatcher.ts:2336-2347`, the "FIX 6 warm-query posture" comment, which
+   re-resolves `setBashAutonomous` per-dispatch *precisely because* the factory
+   doesn't fire on warm turns). A reconnect that resumes a warm Query therefore
+   never re-runs the re-provision. **Design response:** the re-provision +
+   threaded result must follow the same per-dispatch fire-and-forget re-resolve
+   pattern as `setBashAutonomous`/`debugPosture` (`:2348`), OR be explicitly
+   scoped to cold turns with a documented rationale. See Sharp Edges.
+2. **Two type-hops confirmed** for the new sink (`soleur-go-runner.ts:1006`
+   runner-options interface AND `:1059` `QueryFactoryArgs`, forwarded at `:2516`)
+   — mirror `setBashAutonomous` exactly.
+3. **Name collisions checked:** `setReprovisionResult`, `ReprovisionOutcome`,
+   `WORKSPACE_RECLAIMED_MESSAGE` are unused in `apps/web-platform/` — safe to add.
+4. **Negative claim verified:** `denyRead: ["/workspaces", "/proc"]` lives at
+   `agent-runner-sandbox-config.ts:94`; none of the Files to Edit touch that file
+   — the "no isolation-boundary change" claim holds.
+
+### New consideration discovered
+- The reconnect case the epic targets is *by construction* often a warm-query
+  resume on the cc path. The re-provision must fire on that path or the feature
+  is a no-op for its headline scenario — this is the single most important
+  finding of the deepen pass.
 
 > Refs #5240 (do **NOT** `Closes` — epic stays open for design items #1-deeper, #3, #4).
 > Closes #5340 (the focused sub-issue for this design item).
@@ -251,13 +284,23 @@ touch `denyRead: ["/workspaces"]`.
 
 ### Phase 3 — Thread the reprovision result out of the cc factory (RED→GREEN)
 1. Write `test/cc-dispatcher-reprovision-honest-message.test.ts` (RED) for
-   threading + routing (cc path).
+   threading + routing (cc path), **including a warm-query reconnect case**
+   (the headline scenario) that asserts the re-provision + result fire even when
+   the factory body does not re-run.
 2. Add `setReprovisionResult?` to `QueryFactoryArgs` (`:1029`) AND its forward
-   at `:2512-2516` (two type-hops, mirror `setBashAutonomous`); capture the
-   outcome at `cc-dispatcher.ts:1469` and publish via the sink; add the
+   at `:2512-2516` (two type-hops, mirror `setBashAutonomous`); add the
    dispatcher closure cell + setter + deps-wiring (mirror `setBashAutonomous`
-   cell `:2332` / wiring `:2893`).
-3. GREEN for the threading assertions.
+   cell `:2332` / wiring `:2893`). **COLD-vs-WARM decision (deepen finding):**
+   because `realSdkQueryFactory` runs only on cold turns, do the re-provision +
+   result publish via the **per-dispatch fire-and-forget re-resolve** pattern in
+   the `dispatchSoleurGo` body (mirror `setBashAutonomous`'s warm-query resolve
+   at `:2348`), so warm reconnects are covered — NOT only inside the factory at
+   `:1469`. (The factory-internal `:1469` call may remain as the cold-path
+   self-heal; the per-dispatch resolve is what publishes the result for the
+   honest-message branch on both cold and warm turns. Keep them idempotent —
+   `ensureWorkspaceRepoCloned` is `.git`-absent-gated, so a double-invocation
+   no-ops on the second call.)
+3. GREEN for the threading assertions (cold + warm).
 
 ### Phase 4 — Honest post-recovery-failure message (cc path only) (RED→GREEN)
 1. Add `WORKSPACE_RECLAIMED_MESSAGE` to `cc-workflow-end-messages.ts`
@@ -306,6 +349,11 @@ touch `denyRead: ["/workspaces"]`.
 - [ ] No bespoke leader honest-message path is added (failed leader recovery
       rides the existing `startAgentSession` catch). *Verify:* no new
       `sendToClient` for a reclaim message in `agent-runner.ts`.
+- [ ] The cc re-provision + result publish fire on a **warm-query reconnect**
+      (not only cold turns) — covering the epic's headline scenario. *Verify:*
+      `cc-dispatcher-reprovision-honest-message.test.ts` includes a warm-query
+      case where the factory body does not re-run yet the result is still
+      published (mirrors `setBashAutonomous`'s per-dispatch resolve at `:2348`).
 - [ ] No change to `denyRead`/`allowWrite` in
       `agent-runner-sandbox-config.ts`. *Verify:*
       `git diff --stat origin/main -- apps/web-platform/server/agent-runner-sandbox-config.ts`
@@ -437,6 +485,17 @@ discoverability_test:
 - New test files MUST live under `apps/web-platform/test/` (vitest include globs
   `test/**/*.test.ts` / `test/**/*.test.tsx`) — a co-located server test would be
   silently skipped.
+- **COLD-vs-WARM factory gap (deepen-pass finding):** `realSdkQueryFactory` runs
+  ONLY on a cold conversation; warm-query reuse does not re-invoke it
+  (`cc-dispatcher.ts:2336-2347`). So `ensureWorkspaceRepoCloned` (`:1469`) and any
+  `setReprovisionResult` publish inside the factory body fire ONLY on cold turns.
+  The reconnect scenario the epic targets is frequently a *warm* resume — so the
+  re-provision + result publish MUST follow the per-dispatch fire-and-forget
+  re-resolve pattern that `setBashAutonomous` (`:2348`) and `debugPosture` use
+  (resolve in `dispatchSoleurGo` body, not only in the factory), OR be explicitly
+  scoped to cold turns with a documented rationale and a test asserting the
+  scope. Phase 3 step 2 must decide and encode this — do not assume the factory
+  body alone covers reconnect.
 
 ## Open Code-Review Overlap
 

--- a/knowledge-base/project/plans/2026-06-15-feat-workspace-reprovision-on-reconnect-plan.md
+++ b/knowledge-base/project/plans/2026-06-15-feat-workspace-reprovision-on-reconnect-plan.md
@@ -504,6 +504,35 @@ edited files (`ensure-workspace-repo.ts`, `agent-runner.ts`,
 `soleur-go-runner.ts`, `cc-dispatcher.ts`, `cc-workflow-end-messages.ts`); no
 open scope-out names these files for this concern. (Re-verify at /work time.)
 
+## Implementation Notes (as-built, 2026-06-15)
+
+- **The `QueryFactoryArgs.setReprovisionResult` sink was NOT built** — superseded
+  by the plan's own deepened Phase 3 step 2 conclusion: "the per-dispatch resolve
+  is what publishes the result for the honest-message branch on both cold and
+  warm turns." A new module `cc-reprovision.ts` (`reprovisionWorkspaceOnDispatch`)
+  runs every dispatch via the fire-and-forget pattern at `cc-dispatcher.ts:~2360`
+  (mirroring the `resolveBashAutonomous` warm-query resolve), publishing
+  `reprovisionOutcome` into a dispatcher closure cell. This covers BOTH cold and
+  warm turns with one mechanism, so the factory-args sink (and the two
+  soleur-go-runner type-hops) were redundant and dropped. The cold factory call
+  at `:1469` remains unchanged as the cold-path self-heal (ignores its now-typed
+  return; the per-dispatch resolve is idempotent with it via the `.git`-absent
+  gate). `soleur-go-runner.ts` was therefore NOT edited.
+- **Honest-message routing extracted to a pure function**
+  `resolveWorktreeEnterFailedMessage(outcome)` in `cc-workflow-end-messages.ts`,
+  unit-tested directly (mirrors the codebase precedent of extracting testable
+  helpers rather than driving the whole `dispatchSoleurGo` factory — see
+  `cc-dispatcher-self-heal-observability.test.ts`). The `onWorkflowEnded`
+  else-branch calls it for `worktree_enter_failed`.
+- **Copy** authored in-place against the established honest-copy voice (the
+  existing `worktree_enter_failed` line + the `chat-surface.tsx` held-place
+  banner) rather than via a separate copywriter dispatch — single-string surface.
+- **Tests as-built:** `agent-runner-reprovision.test.ts` (leader recovery +
+  ordering + no-bespoke-message), `cc-reprovision.test.ts` (warm-query resolve,
+  fail-soft), `cc-workflow-end-messages.test.ts` (+routing polarities/placement
+  invariant), `ensure-workspace-repo.test.ts` (+outcome contract). Full
+  web-platform suite: 9947 passed / 0 failed; `tsc --noEmit` clean.
+
 ## Alternative Approaches Considered
 
 | Approach | Why not |

--- a/knowledge-base/project/plans/2026-06-15-feat-workspace-reprovision-on-reconnect-plan.md
+++ b/knowledge-base/project/plans/2026-06-15-feat-workspace-reprovision-on-reconnect-plan.md
@@ -1,0 +1,458 @@
+---
+title: Deterministic workspace re-provision on reconnect (#5240 design item #2)
+issue: 5340
+epic: 5240
+branch: feat-one-shot-5240-workspace-reprovision-reconnect
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+created: 2026-06-15
+status: draft
+---
+
+# Deterministic workspace re-provision on reconnect
+
+> Refs #5240 (do **NOT** `Closes` — epic stays open for design items #1-deeper, #3, #4).
+> Closes #5340 (the focused sub-issue for this design item).
+
+## Overview
+
+On (re)connect, the agent-cwd resolver `resolveActiveWorkspacePath`
+(`apps/web-platform/server/workspace-resolver.ts:339`) returns a workspace
+id/path but **nothing guarantees the repo/worktree physically exists** at that
+path on disk. After a sandbox/host reclaim the resolved path can be a fresh
+filesystem where the repo was never cloned (the "no git repository / no
+worktrees" symptom from the 4826 session).
+
+The runtime CWD-verify guardrail merged 2026-06-14 (#5311) **detects** the
+failed worktree-enter and ends the turn with an honest retryable
+`worktree_enter_failed` status — but does **not re-provision**. This plan adds
+the re-provision (recovery) + the post-recovery-failure honest message.
+
+**This is genuinely new scope.** It is design item #2 on epic #5240, explicitly
+deferred by the merged v1 (#5256), and not covered by the prior epic PRs
+(#5256 durable-resume v1, #5290 stream-replay resume, #5311 CWD-verify
+guardrail). Verified against the FR status map comment on #5240 (item #2 =
+🔴 Outstanding) on 2026-06-15.
+
+**Scope guard:** physical re-provision + the post-failure honest message only.
+Do **NOT** change the cross-tenant `/workspaces` isolation boundary.
+
+### Two divergent paths (the central architectural fact)
+
+| Path | Entry | Resolver | Self-heal today | CWD-verify guardrail |
+|------|-------|----------|-----------------|----------------------|
+| **Concierge / cc-soleur-go** (dominant prod path) | `cc-dispatcher.ts` `realSdkQueryFactory` (`:1219`) | `fetchUserWorkspacePath` → `resolveActiveWorkspacePath` | ✅ calls `ensureWorkspaceRepoCloned` (`:1469`) | ✅ `detectCwdVerifyLoop` (`soleur-go-runner.ts:2124`) → `worktree_enter_failed` |
+| **Leader** | `agent-runner.ts` `startAgentSession` (`:852`) | `resolveActiveWorkspacePath` (`:995`) | ❌ **never calls** the self-heal | ❌ none (relies on its own runaway breaker) |
+
+So the work splits cleanly:
+- **Leader path: add the missing recovery only** (call `ensureWorkspaceRepoCloned`,
+  lazily resolving `repoUrl`/`installationId` *inside* the `.git`-absent gate,
+  before `patchWorkspacePermissions`/`syncPull`). When that recovery fails, the
+  turn rides the **existing** `startAgentSession` catch surface
+  (`ws-handler.ts:2098`) — no bespoke leader honest-message path is built (the
+  leader has no `worktree_enter_failed` guardrail, so a bespoke message would
+  mean building a second detection path from scratch — plan-review consensus
+  cut it).
+- **Concierge path: add the missing post-recovery-failure honest message**
+  (recovery already exists; thread its result out and surface the honest
+  reclaimed message when `worktree_enter_failed` fires *and* the re-clone
+  genuinely failed).
+
+[Updated 2026-06-15 after plan-review]
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (from feature description) | Reality (verified 2026-06-15) | Plan response |
+|---|---|---|
+| `ensureWorkspaceRepoCloned` imported at `cc-dispatcher.ts:103` | ✅ exact | Reuse; widen its return type. |
+| resolver called at `agent-runner.ts:995` | ✅ exact | Insert recovery in this scope. |
+| `syncPull` at `agent-runner.ts:1037` | ✅ exact | Recovery goes **before** `patchWorkspacePermissions` (`:1027`), not just before `syncPull`. |
+| "insert re-provision around `syncPull`" | The leader path resolves `repoUrl`/`installationId` ~300 lines **later** (`:1336`/`:1350`); they must be hoisted above `:1027`. | Hoist `resolveInstallationId` + `getCurrentRepoUrl` reads above the recovery call. |
+| `fetchUserWorkspacePath` lives in `workspace-resolver.ts` | ❌ it is in `kb-document-resolver.ts:91` (thin wrapper over `resolveActiveWorkspacePath`) | No change needed; both paths funnel through `resolveActiveWorkspacePath`. |
+| "the resolved path may be a fresh filesystem after host reclaim" | The `/workspaces` mount is a **persistent Hetzner volume on a single backend instance** (learning `2026-06-14-verify-storage-topology-before-accepting-durability-framing.md`). The dominant cause of the "fresh filesystem" symptom is **binding-resolution drift** (already fixed by #5256), NOT lost data. | Re-provision is still correct as the **last-resort recovery** for the genuine reclaim case; framed as defense-in-depth, not the primary durability mechanism. Documented in §Risks. |
+| `ensureWorkspaceRepoCloned` needs extension to create a missing dir | ❌ NOT needed — `realGraftRepoClone` does `git clone … <workspacePath>/.ensure-repo-tmp-<uuid>`, and `git clone` **creates the full leading path** including a missing `workspacePath` (empirically verified by research agent). | No dir-creation logic added; reuse the graft as-is. |
+| `ensureWorkspaceRepoCloned` returns a signal to thread out | ❌ it returns `Promise<void>` and is fail-soft (clone failure → `reportSilentFallback`, then resolves) | **Widen the return type** to a typed clone outcome so the result can be threaded out. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** on reconnect after a host
+reclaim, either (a) a permanent dead-end where every message re-trips the
+missing-repo guard and the conversation can never recover (the exact regression
+the placement learning warns about), or (b) a misleading fresh-session greeting
+on a conversation that had prior work.
+
+**If this leaks, the user's workspace/repo is exposed via:** a re-provision that
+cloned the wrong repo into a workspace, or a self-heal that crossed the
+`/workspaces` tenant boundary. Both are guarded: `repoUrl`/`installationId` are
+membership-scoped server-resolved values (ADR-044), never tool/request input;
+the self-heal runs host-side (outside the bwrap sandbox) and the plan does not
+touch `denyRead: ["/workspaces"]`.
+
+**Brand-survival threshold:** single-user incident.
+
+> CPO sign-off required at plan time before `/work` begins. CTO/CLO concerns from
+> the epic's brainstorm framing are reflected in §Risks and §Domain Review.
+> `user-impact-reviewer` will run at review-time.
+
+## Research Insights
+
+- **Placement learning (LOAD-BEARING):**
+  `knowledge-base/project/learnings/best-practices/2026-06-14-short-circuit-guard-must-sit-after-the-recovery-it-gates.md`
+  — the honest "it's gone" message is a post-recovery-failure concept. A
+  pre-recovery `.git` probe amputates the self-heal. Verified file exists.
+- **Storage topology / scope calibration:**
+  `knowledge-base/project/learnings/2026-06-14-verify-storage-topology-before-accepting-durability-framing.md`
+  — persistent volume + single instance ⇒ "fresh filesystem" is usually binding
+  drift; re-provision is defense-in-depth, not the primary fix.
+- **Both-paths wiring:**
+  `knowledge-base/project/learnings/integration-issues/2026-06-14-ws-lifecycle-hook-must-cover-both-legacy-and-cc-soleur-go-turn-boundaries.md`
+  — any turn-boundary hook must cover BOTH `sendUserMessage`/`startAgentSession`
+  (legacy) and `dispatchSoleurGo` (cc). cc-soleur-go is the dominant prod path;
+  green CI hides cc-path breakage because tests don't drive cc dispatch.
+- **Terminal-frame → UX validation:**
+  `knowledge-base/project/learnings/best-practices/2026-06-14-terminal-frame-to-terminal-ui-state-must-validate-reason-set-and-confirm-before-success.md`
+  — do not unconditionally map a terminal frame to an "unrecoverable" UI; key on
+  the specific `reason`.
+- **Exhaustiveness rails (ADR-031):** `WORKFLOW_END_USER_MESSAGES`
+  (`cc-workflow-end-messages.ts`) and `ABORT_FLUSH_STATUSES`/`_abortFlushExhaustive`
+  (`cc-dispatcher.ts:459`) are `Record<WorkflowEndStatus, …>` rails — a new
+  status forces a compile error. We do NOT add a new status (reuse
+  `worktree_enter_failed`); we add a new *message-routing* branch.
+- **Thread-out pattern:** the established mechanism is an optional
+  `args.set*` sink on `QueryFactoryArgs` (`soleur-go-runner.ts:1029`) — today
+  `setDelegationContext` (`:1050`) and `setBashAutonomous` (`:1059`). Producer
+  writes inside `realSdkQueryFactory`'s lease body; consumer (`onWorkflowEnded`/
+  `onResult`) reads a dispatcher closure cell.
+- **Test runner:** `vitest` (in-package); typecheck `tsc --noEmit` (in-package,
+  run as `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit`). Vitest
+  include globs: `test/**/*.test.ts` + `lib/**/*.test.ts` (node) and
+  `test/**/*.test.tsx` (jsdom). New test files MUST live under
+  `apps/web-platform/test/`.
+- **Labels verified to exist:** `type/feature`, `domain/engineering`,
+  `app:web-platform`, `priority/p1-high`.
+
+## Files to Edit
+
+- `apps/web-platform/server/ensure-workspace-repo.ts`
+  — widen `ensureWorkspaceRepoCloned` return type from `Promise<void>` to a
+  **2-variant** typed outcome `Promise<ReprovisionOutcome>` where
+  `ReprovisionOutcome = "failed" | "ok"` (`"ok"` folds every benign exit —
+  not-connected, noop-existing, skipped-bad-url, cloned — since the only consumer
+  branches solely on `"failed"`; plan-review cut the 5-variant union as
+  over-precise). Return `"ok"` at the benign exits (`:74`, `:78`, `:88`, `:97`)
+  and `"failed"` at the catch (`:108`). No behavior change — only the return
+  value is added (fail-soft posture preserved; still never throws). Per-exit
+  observability already exists via the distinct `reportSilentFallback` ops +
+  `log.info({action})` breadcrumb — it does not need to ride the return type.
+  *Note:* the race-loser early-return (`:165`) resolves without rename but the
+  caller still hits the `"ok"` path — correct, since the repo IS present.
+- `apps/web-platform/server/agent-runner.ts`
+  — import `ensureWorkspaceRepoCloned` (currently not imported). **Lazily**
+  resolve `resolveInstallationId(userId)` + `getCurrentRepoUrl(userId)` *inside*
+  the `.git`-absent gate (do NOT hoist them ~300 lines unconditionally — that
+  crosses the documented re-resolution caveat at `:1341-1349`; resolve only when
+  recovery is actually needed). Call `ensureWorkspaceRepoCloned({ userId,
+  workspacePath, installationId, repoUrl })` **before**
+  `patchWorkspacePermissions` (`:1027`) and `syncPull` (`:1037`). **No bespoke
+  leader honest message** — a failed leader recovery rides the existing
+  `startAgentSession` catch (`ws-handler.ts:2098`, which calls
+  `sanitizeErrorForClient` + emits an `error` frame). The leader gains the
+  *recovery* it was missing; failures degrade exactly as today (strict
+  improvement).
+- `apps/web-platform/server/soleur-go-runner.ts`
+  — add an optional `setReprovisionResult?: (r: ReprovisionOutcome) => void`
+  sink to `QueryFactoryArgs` (`:1029`), mirroring `setBashAutonomous` (`:1059`).
+  **Two type-hops** (mirror `setBashAutonomous` exactly): the field on
+  `QueryFactoryArgs` AND the forwarding site (`:2512-2516`). Import
+  `ReprovisionOutcome` from `ensure-workspace-repo`.
+- `apps/web-platform/server/cc-dispatcher.ts`
+  — at the existing `ensureWorkspaceRepoCloned` call (`:1469`), capture the
+  outcome and publish via `args.setReprovisionResult?.(outcome)`; add the
+  dispatcher-side closure cell + setter in `dispatchSoleurGo` (mirror the
+  `setBashAutonomous` cell at `:2332` / wiring at `:2893`). In `onWorkflowEnded`
+  (`:2718`), `worktree_enter_failed` is **NOT** in
+  `TERMINAL_WORKFLOW_END_STATUSES` (`:413-426`) — at runtime it falls through to
+  the **final `else` at `:2787-2792`** which emits `{ type: "error", message:
+  WORKFLOW_END_USER_MESSAGES["worktree_enter_failed"] }`. The new branch
+  intercepts **there**: when `end.status === "worktree_enter_failed"` **AND** the
+  captured reprovision result is `"failed"`, emit `{ type: "error", message:
+  WORKSPACE_RECLAIMED_MESSAGE }` instead of the generic copy. The honest-message
+  branch sits AFTER the recovery (the recovery already ran at `:1469`) — inline
+  comment cites the placement learning.
+- `apps/web-platform/server/cc-workflow-end-messages.ts`
+  — no new status; the honest reclaimed copy is a new exported constant
+  `WORKSPACE_RECLAIMED_MESSAGE` (string) consumed by the new `onWorkflowEnded`
+  branch. (Authored by copywriter — see Domain Review.)
+
+## Files to Create
+
+(Net **2** new test files — the outcome assertions fold into the existing
+`test/ensure-workspace-repo.test.ts` rather than a third file, per plan-review.)
+
+- `apps/web-platform/test/agent-runner-reprovision.test.ts`
+  — RED-first: asserts `startAgentSession` calls `ensureWorkspaceRepoCloned`
+  with the resolved `{ workspacePath, installationId, repoUrl }` **before**
+  `patchWorkspacePermissions`/`syncPull` when the workspace lacks a repo, and
+  no-ops (passes through) when `.git` exists. Also asserts the
+  `repoUrl`/`installationId` reads run ONLY inside the `.git`-absent gate (not on
+  the `.git`-present path).
+- `apps/web-platform/test/cc-dispatcher-reprovision-honest-message.test.ts`
+  — RED-first: drives the **cc-soleur-go path** (per the both-paths learning —
+  this is where green CI hides breakage). Asserts: (a) the reprovision result is
+  threaded out via the sink; (b) `worktree_enter_failed` + result `"failed"` →
+  client receives `{ type: "error", message: WORKSPACE_RECLAIMED_MESSAGE }`;
+  (c) `worktree_enter_failed` + result `"ok"` → existing generic
+  `WORKFLOW_END_USER_MESSAGES["worktree_enter_failed"]` route (no false reclaim
+  message); (d) the honest-message branch is gated AFTER recovery (a reprovision
+  result of `"ok"` never yields the reclaimed message — the placement invariant).
+
+## Files to Edit (tests)
+
+- `apps/web-platform/test/ensure-workspace-repo.test.ts`
+  — extend with 2 RED-first assertions: the catch path returns `"failed"`, the
+  benign exits return `"ok"` (uses the `__setGraftForTests` seam). Drives the
+  type-widening without a dedicated new file.
+
+## Implementation Phases
+
+> Phase order is load-bearing: the **contract-changing** edit (return-type
+> widening) ships before the **consumer** edits (both call sites + the sink).
+
+### Phase 0 — Preconditions (verify before coding)
+- `grep -n "ensureWorkspaceRepoCloned" apps/web-platform/server/agent-runner.ts`
+  → confirm ZERO (leader path does not import/call it).
+- `grep -n "resolveInstallationId\|getCurrentRepoUrl" apps/web-platform/server/agent-runner.ts`
+  → confirm both are imported and resolvable in the `startAgentSession` scope
+  (currently at `:1336`/`:1350`).
+- `grep -n "setBashAutonomous\|setDelegationContext" apps/web-platform/server/cc-dispatcher.ts`
+  → confirm the closure-cell + setter + deps-wiring pattern (the template for
+  `setReprovisionResult`).
+- Confirm `__setGraftForTests` seam exists in `ensure-workspace-repo.ts:30`.
+- Run baseline: `cd apps/web-platform && ./node_modules/.bin/vitest run test/ensure-workspace-repo.test.ts && ./node_modules/.bin/tsc --noEmit`.
+
+### Phase 1 — Contract: widen `ensureWorkspaceRepoCloned` return type (RED→GREEN)
+1. Extend `test/ensure-workspace-repo.test.ts` (RED): catch path → `"failed"`,
+   benign exits → `"ok"`.
+2. Add `export type ReprovisionOutcome = "failed" | "ok"`; return `"ok"` at the
+   benign exits (`:74`, `:78`, `:88`, `:97`) and `"failed"` at the catch (`:108`).
+3. GREEN. `tsc --noEmit` clean.
+
+### Phase 2 — Leader path recovery (RED→GREEN) [STANDALONE-VALUABLE]
+1. Write `test/agent-runner-reprovision.test.ts` (RED).
+2. Import `ensureWorkspaceRepoCloned`; inside a `.git`-absent gate, lazily
+   resolve `resolveInstallationId` + `getCurrentRepoUrl`, then call the recovery
+   — all before `patchWorkspacePermissions`/`syncPull`. Do NOT hoist the
+   resolutions unconditionally.
+3. GREEN. Verify the no-op pass-through (`.git` present — resolutions NOT run)
+   and the recovery (`.git` absent) cases. A failed leader recovery rides the
+   existing `startAgentSession` catch (no new emit). This phase alone is a strict
+   improvement (leader gains the self-heal the cc path already has).
+
+### Phase 3 — Thread the reprovision result out of the cc factory (RED→GREEN)
+1. Write `test/cc-dispatcher-reprovision-honest-message.test.ts` (RED) for
+   threading + routing (cc path).
+2. Add `setReprovisionResult?` to `QueryFactoryArgs` (`:1029`) AND its forward
+   at `:2512-2516` (two type-hops, mirror `setBashAutonomous`); capture the
+   outcome at `cc-dispatcher.ts:1469` and publish via the sink; add the
+   dispatcher closure cell + setter + deps-wiring (mirror `setBashAutonomous`
+   cell `:2332` / wiring `:2893`).
+3. GREEN for the threading assertions.
+
+### Phase 4 — Honest post-recovery-failure message (cc path only) (RED→GREEN)
+1. Add `WORKSPACE_RECLAIMED_MESSAGE` to `cc-workflow-end-messages.ts`
+   (copywriter-authored copy — NOT a new `WorkflowEndStatus`).
+2. In `onWorkflowEnded` (`:2718`), intercept at the **final `else` branch
+   (`:2787-2792`)** where `worktree_enter_failed` actually routes: when
+   `end.status === "worktree_enter_failed"` + result `"failed"` → emit
+   `{ type: "error", message: WORKSPACE_RECLAIMED_MESSAGE }`; else fall through
+   to the existing generic copy. Inline comment cites
+   `2026-06-14-short-circuit-guard-must-sit-after-the-recovery-it-gates.md` and
+   states "branch sits AFTER recovery (recovery ran at :1469)".
+3. GREEN for all routing assertions (including the negative: result `"ok"` never
+   yields the reclaimed message — the placement invariant).
+
+### Phase 5 — Full-suite + typecheck
+- `cd apps/web-platform && ./node_modules/.bin/vitest run` (full suite) and
+  `./node_modules/.bin/tsc --noEmit`. Confirm no exhaustiveness rail or
+  cross-consumer regressions.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- [ ] `ensureWorkspaceRepoCloned` returns `ReprovisionOutcome` (`"failed" | "ok"`,
+      not `void`); both call sites (`agent-runner.ts`, `cc-dispatcher.ts:1469`)
+      bind the result. *Verify:* `grep -n "ensureWorkspaceRepoCloned"
+      apps/web-platform/server/*.ts` returns ≥2 call sites, each binding the
+      return.
+- [ ] Leader `startAgentSession` calls the recovery **before**
+      `patchWorkspacePermissions`/`syncPull`, with `repoUrl`/`installationId`
+      resolved ONLY inside the `.git`-absent gate. *Verify:*
+      `agent-runner-reprovision.test.ts` asserts (a) recovery runs before
+      `patchWorkspacePermissions`/`syncPull`, (b) the resolutions do NOT run on
+      the `.git`-present path.
+- [ ] On the cc path, `worktree_enter_failed` + reprovision result `"failed"`
+      → client receives `{ type: "error", message: WORKSPACE_RECLAIMED_MESSAGE }`;
+      result `"ok"` → existing generic
+      `WORKFLOW_END_USER_MESSAGES["worktree_enter_failed"]` route. *Verify:*
+      `cc-dispatcher-reprovision-honest-message.test.ts` asserts both polarities
+      and that the interception is at the `type: "error"` branch (NOT
+      `session_ended` — `worktree_enter_failed` is not in
+      `TERMINAL_WORKFLOW_END_STATUSES`).
+- [ ] The honest-message branch sits AFTER the recovery — asserted by the
+      negative test (result `"ok"` never yields the reclaimed message). The
+      inline comment citing the placement learning is a code requirement, not a
+      CI-checked AC.
+- [ ] No bespoke leader honest-message path is added (failed leader recovery
+      rides the existing `startAgentSession` catch). *Verify:* no new
+      `sendToClient` for a reclaim message in `agent-runner.ts`.
+- [ ] No change to `denyRead`/`allowWrite` in
+      `agent-runner-sandbox-config.ts`. *Verify:*
+      `git diff --stat origin/main -- apps/web-platform/server/agent-runner-sandbox-config.ts`
+      shows no change.
+- [ ] No new `WorkflowEndStatus` added (reuse `worktree_enter_failed`).
+      *Verify:* `WORKFLOW_END_STATUSES` count unchanged; exhaustiveness rails
+      compile.
+- [ ] `cd apps/web-platform && ./node_modules/.bin/vitest run` green;
+      `./node_modules/.bin/tsc --noEmit` clean.
+
+### Post-merge (operator)
+- None. This is a pure code change against an already-provisioned surface; the
+  `web-platform-release.yml` pipeline restarts the container on merge to main
+  touching `apps/web-platform/**` (a merge IS the deploy). `/soleur:ship`
+  post-merge verification (`/health` build_sha match + Sentry delta) covers
+  liveness.
+
+## Domain Review
+
+**Domains relevant:** Engineering (CTO), Product/UX
+
+### Engineering (CTO)
+**Status:** carry-forward (epic-level CTO framing from #5240 brainstorm)
+**Assessment:** Re-provision is server-side host-side recovery; correctly placed
+AFTER the existing self-heal per the load-bearing placement learning. Both-paths
+wiring (leader + cc) is required; cc is the dominant prod path. Type-widening of
+`ensureWorkspaceRepoCloned` is the minimal contract change to thread the signal.
+No interaction with the `/workspaces` sandbox isolation boundary.
+
+### Product/UX Gate
+**Tier:** advisory
+**Decision:** auto-accepted (pipeline) — but Content Review Gate fires (below).
+**Agents invoked:** copywriter (Content Review Gate)
+**Skipped specialists:** none
+**Pencil available:** N/A (no UI surface — the change is a server-emitted WS
+message string consumed by the existing chat error/banner surface; no new
+component or page is created).
+
+#### Findings
+This plan emits a user-facing message string ("workspace reclaimed — resume with
+context?"). Per the Content Review Gate, **copywriter must author the final
+`WORKSPACE_RECLAIMED_MESSAGE` copy** against brand voice and the existing honest
+copy in `cc-workflow-end-messages.ts` (e.g. the `worktree_enter_failed` "Couldn't
+open a workspace…" line) and the existing State-3 reclaim banner copy in
+`chat-surface.tsx:631` ("Your place is held — your full conversation is intact.
+Start a new message to resume with full context."). No new interactive surface,
+so no wireframe / `ux-design-lead`.
+
+## Infrastructure (IaC)
+
+No new infrastructure. Pure code change against an already-provisioned surface
+(no server, service, secret, vendor, cron, DNS, or persistent runtime process
+introduced). Skipped per Phase 2.8.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: existing reprovision self-heal already mirrors clone success/failure
+  cadence: per cold dispatch (unchanged)
+  alert_target: Sentry (existing reportSilentFallback op "clone")
+  configured_in: apps/web-platform/server/ensure-workspace-repo.ts:102 (op "clone")
+error_reporting:
+  destination: Sentry via reportSilentFallback (existing, fail-loud-to-Sentry, fail-soft-to-user)
+  fail_loud: true
+failure_modes:
+  - mode: re-clone genuinely fails (token expired / network / repo gone)
+    detection: ReprovisionOutcome "failed" + (cc) worktree_enter_failed
+    alert_route: Sentry op "clone" (existing) + the honest user message (new)
+  - mode: reprovision result not threaded to dispatcher (sink unwired)
+    detection: cc-dispatcher-reprovision-honest-message.test.ts (negative + positive)
+    alert_route: CI (test failure)
+  - mode: leader path resolves repoUrl/installationId snapshot drift
+    detection: existing ADR-044 membership-scoped resolution; documented caveat
+    alert_route: Sentry (existing resolveInstallationId/getCurrentRepoUrl mirrors)
+logs:
+  where: pino child loggers "ensure-workspace-repo", "cc-dispatcher"; Sentry
+  retention: existing Better Stack / Sentry retention (unchanged)
+discoverability_test:
+  command: cd apps/web-platform && ./node_modules/.bin/vitest run test/cc-dispatcher-reprovision-honest-message.test.ts
+  expected_output: all assertions pass (threading + both routing polarities)
+```
+
+## Risks & Mitigations
+
+- **Persistent-volume reality:** the "fresh filesystem" symptom on a
+  single-instance persistent Hetzner volume is *usually* binding-resolution
+  drift (already fixed by #5256), not lost data. Re-provision is the last-resort
+  recovery for the genuine reclaim case — framed as defense-in-depth. Mitigation:
+  the recovery is gated on `.git`-absent (it never touches an existing repo), so
+  on the common binding-drift case where the repo IS present it correctly
+  no-ops. (Learning `2026-06-14-verify-storage-topology…`.)
+- **Placement regression (the load-bearing risk):** an honest message placed
+  BEFORE recovery amputates the self-heal and dead-ends connected-repo resume.
+  Mitigation: the message branch is gated on `ReprovisionOutcome === "failed"`
+  evaluated AFTER `ensureWorkspaceRepoCloned` ran; the negative test (`"cloned"`
+  never yields the message) locks it. (Learning
+  `2026-06-14-short-circuit-guard-must-sit-after-the-recovery-it-gates.md`.)
+- **Both-paths blind spot:** wiring only the leader path would leave the
+  dominant cc-soleur-go path uncovered (green CI hides it). Mitigation: the
+  honest-message test drives the cc path explicitly; the leader path gets its own
+  recovery + message test. (Learning
+  `2026-06-14-ws-lifecycle-hook-must-cover-both-legacy-and-cc-soleur-go-turn-boundaries.md`.)
+- **`repoUrl`/`installationId` snapshot drift (leader):** each read
+  independently re-resolves the active workspace (documented caveat at
+  `agent-runner.ts:1341-1349`). Mitigation (plan-review-hardened): the
+  resolutions run **lazily inside the `.git`-absent gate**, not hoisted ~300
+  lines unconditionally — so they fire only on the rare missing-repo path and
+  against the same `userId`/request, minimizing exposure to the documented
+  re-resolution drift.
+- **Type-widening blast radius:** `ensureWorkspaceRepoCloned` has exactly two
+  call sites (verified by grep). Widening `void → ReprovisionOutcome` is
+  additive; existing callers that ignore the return value still compile.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only
+  `TBD`/`TODO`/placeholder text, or omits the threshold will fail `deepen-plan`
+  Phase 4.6 and preflight Check 6. This plan's section is filled
+  (threshold: single-user incident).
+- Do NOT add a new `WorkflowEndStatus` for the reclaimed message — that would
+  trip the `WORKFLOW_END_USER_MESSAGES` and `ABORT_FLUSH_STATUSES` exhaustiveness
+  rails and the `_AssertWorkflowEndStatusMatches` bidirectional rail. Reuse
+  `worktree_enter_failed` and branch on the threaded `ReprovisionOutcome`.
+- The leader path has NO `worktree_enter_failed` guardrail (it is Concierge-only,
+  gated on `onToolResult`). Its honest message must ride the leader's existing
+  error surface, keyed on the `ReprovisionOutcome === "failed"` + still-no-`.git`
+  condition — do not assume the leader emits `worktree_enter_failed`.
+- New test files MUST live under `apps/web-platform/test/` (vitest include globs
+  `test/**/*.test.ts` / `test/**/*.test.tsx`) — a co-located server test would be
+  silently skipped.
+
+## Open Code-Review Overlap
+
+None — checked `gh issue list --label code-review --state open` against the
+edited files (`ensure-workspace-repo.ts`, `agent-runner.ts`,
+`soleur-go-runner.ts`, `cc-dispatcher.ts`, `cc-workflow-end-messages.ts`); no
+open scope-out names these files for this concern. (Re-verify at /work time.)
+
+## Alternative Approaches Considered
+
+| Approach | Why not |
+|---|---|
+| Pre-dispatch `.git` probe that short-circuits to the honest message | Explicitly the regression the load-bearing learning warns about — amputates the self-heal and dead-ends connected-repo resume. |
+| Add a new `workspace_reclaimed` `WorkflowEndStatus` | Trips three exhaustiveness rails for no benefit; the existing `worktree_enter_failed` already carries the terminal semantics — only the *message* differs. |
+| Re-provision inside the resolver (`resolveActiveWorkspacePath`) | The resolver is a pure DB-claim→path computation called from 6 sites (route handlers, attachment pipeline, doc resolvers); adding a clone side-effect there would fire on read-only callers. Keep recovery at the turn-start dispatch sites. |
+| Extend `ensureWorkspaceRepoCloned` to create the missing dir | Not needed — `git clone` already creates the full leading path (verified). Adds risk for zero benefit. |
+| 5-variant `ReprovisionOutcome` union | Cut at plan-review — the only consumer branches on `"failed"`; four success shades were precision nobody reads. Reduced to `"failed" | "ok"`. |
+| Build a bespoke leader honest-message path | Cut at plan-review (DHH + simplicity + Kieran convergent) — the leader has no `worktree_enter_failed` guardrail, so it would mean building a second detection path. Failed leader recovery rides the existing `startAgentSession` catch instead. |
+| **Defer the entire cc thread-out machinery (Phases 1/3/4)** until Sentry's existing `op:"clone"` signal proves a real user hit the genuine-reclaim case (DHH dissent) | **Not adopted.** The post-recovery-failure honest message is the *named deliverable* of #5240 design item #2 / #5340 (the FR status map's outstanding item), not speculative. DHH's deferral is recorded here; if the operator/CPO prefers the leaner ship-Phase-2-only path, Phases 1/3/4 can be split into a follow-up — but the issue scope as filed includes the honest message. |

--- a/knowledge-base/project/plans/2026-06-15-feat-workspace-reprovision-on-reconnect-plan.md
+++ b/knowledge-base/project/plans/2026-06-15-feat-workspace-reprovision-on-reconnect-plan.md
@@ -124,6 +124,23 @@ touch `denyRead: ["/workspaces"]`.
 
 **Brand-survival threshold:** single-user incident.
 
+**Known limitation (best-effort honest message — review finding, accepted).** The
+cc per-dispatch re-provision is fire-and-forget (a `git clone` up to 120s), while
+`worktree_enter_failed` can fire earlier in the turn. If the clone has not settled
+when the turn fails, `reprovisionOutcome` is `undefined` and the user sees the
+GENERIC retryable copy ("Couldn't open a workspace… try again") rather than the
+honest "workspace reclaimed" copy on that first turn. This is the SAFE direction
+— it never falsely claims "reclaimed" (only `"failed"` yields that), the generic
+copy is also true + actionable, and the next turn re-attempts recovery and can
+then surface the honest message. The honest reclaimed message is therefore
+best-effort, not guaranteed on the first failing turn; making it guaranteed would
+require awaiting the clone inside the (currently synchronous) `onWorkflowEnded`
+callback, which is out of scope. The cross-account-org false-message gap a review
+agent flagged is separately fixed: all three paths (cold factory, cc per-dispatch,
+leader) now select the SAME promoted install via `resolveEffectiveInstallationId`
+(`cc-effective-installation.ts`), so a recoverable org repo no longer 403s on the
+raw stored install and reports a false "couldn't restore".
+
 > CPO sign-off required at plan time before `/work` begins. CTO/CLO concerns from
 > the epic's brainstorm framing are reflected in §Risks and §Domain Review.
 > `user-impact-reviewer` will run at review-time.

--- a/knowledge-base/project/specs/feat-one-shot-5240-workspace-reprovision-reconnect/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-5240-workspace-reprovision-reconnect/session-state.md
@@ -1,0 +1,22 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-15-feat-workspace-reprovision-on-reconnect-plan.md
+- Sub-issue: #5340 (Refs #5240, not Closes)
+- Draft PR: #5339
+- Status: complete
+
+### Errors
+None.
+
+### Decisions
+- Epic #5240 OPEN; design item #2 confirmed 🔴 Outstanding, deferred by v1. Sub-issue #5340 filed with Refs #5240.
+- Architecture split: cc-dispatcher (Concierge) already calls `ensureWorkspaceRepoCloned`; agent-runner (leader) does NOT. Add recovery to leader path; add post-recovery-failure honest message to cc path. Re-clone reused/extended, never duplicated.
+- Honest "reclaimed" message sits AFTER recovery (load-bearing placement learning) — verified by negative test. `worktree_enter_failed` routes through `type:"error"` branch (cc-dispatcher.ts:2787-2792), not `session_ended`.
+- Load-bearing deepen finding: `realSdkQueryFactory` runs ONLY on cold conversations; warm-query reconnect needs per-dispatch fire-and-forget re-resolve (mirror `setBashAutonomous` at :2348) or feature is a no-op for reconnect.
+- Scope guard honored: no change to `/workspaces` denyRead isolation boundary. Threshold = single-user incident; requires_cpo_signoff: true.
+
+### Components Invoked
+- soleur:plan, soleur:deepen-plan
+- Agents: general-purpose (×2), learnings-researcher, kieran-rails-reviewer, code-simplicity-reviewer, dhh-rails-reviewer
+- gh issue create (#5340), git commit/push

--- a/knowledge-base/project/specs/feat-one-shot-5240-workspace-reprovision-reconnect/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-5240-workspace-reprovision-reconnect/tasks.md
@@ -1,0 +1,48 @@
+---
+title: Tasks — deterministic workspace re-provision on reconnect
+issue: 5340
+epic: 5240
+lane: cross-domain
+plan: knowledge-base/project/plans/2026-06-15-feat-workspace-reprovision-on-reconnect-plan.md
+created: 2026-06-15
+---
+
+# Tasks — workspace re-provision on reconnect (#5340, refs #5240)
+
+> Spec lacks a `spec.md` (entered via one-shot → plan, no brainstorm). `lane:`
+> defaulted to `cross-domain`. Plan is the source of truth.
+
+## Phase 0 — Preconditions
+- [ ] 0.1 Confirm `agent-runner.ts` does NOT import/call `ensureWorkspaceRepoCloned` (`grep -n` → zero).
+- [ ] 0.2 Confirm `resolveInstallationId` + `getCurrentRepoUrl` imported/resolvable in `startAgentSession` scope.
+- [ ] 0.3 Confirm `setBashAutonomous` closure-cell + setter + deps-wiring pattern in `cc-dispatcher.ts` (template for the new sink).
+- [ ] 0.4 Confirm `__setGraftForTests` seam at `ensure-workspace-repo.ts:30`.
+- [ ] 0.5 Baseline: `cd apps/web-platform && ./node_modules/.bin/vitest run test/ensure-workspace-repo.test.ts && ./node_modules/.bin/tsc --noEmit`.
+
+## Phase 1 — Widen `ensureWorkspaceRepoCloned` return type (contract first)
+- [ ] 1.1 RED: extend `test/ensure-workspace-repo.test.ts` — catch → `"failed"`, benign exits → `"ok"`.
+- [ ] 1.2 Add `export type ReprovisionOutcome = "failed" | "ok"`; return `"ok"` at `:74/:78/:88/:97`, `"failed"` at `:108`.
+- [ ] 1.3 GREEN + `tsc --noEmit`.
+
+## Phase 2 — Leader path recovery (standalone-valuable)
+- [ ] 2.1 RED: `test/agent-runner-reprovision.test.ts` — recovery runs before `patchWorkspacePermissions`/`syncPull` when `.git` absent; resolutions NOT run when `.git` present.
+- [ ] 2.2 Import `ensureWorkspaceRepoCloned`; inside a `.git`-absent gate, lazily resolve `resolveInstallationId` + `getCurrentRepoUrl`, then call recovery before `:1027`/`:1037`. No bespoke honest-message emit.
+- [ ] 2.3 GREEN. Verify pass-through and recovery cases.
+
+## Phase 3 — Thread reprovision result out of the cc factory
+- [ ] 3.1 RED: `test/cc-dispatcher-reprovision-honest-message.test.ts` — threading + routing (cc path).
+- [ ] 3.2 Add `setReprovisionResult?` to `QueryFactoryArgs` (`:1029`) AND the forward (`:2512-2516`); capture outcome at `:1469`, publish via sink; add dispatcher cell + setter + deps-wiring (mirror `setBashAutonomous`).
+- [ ] 3.3 GREEN for threading assertions.
+
+## Phase 4 — Honest post-recovery-failure message (cc path)
+- [ ] 4.1 Add `WORKSPACE_RECLAIMED_MESSAGE` to `cc-workflow-end-messages.ts` (copywriter copy; NOT a new status).
+- [ ] 4.2 In `onWorkflowEnded` final `else` branch (`:2787-2792`): `worktree_enter_failed` + `"failed"` → `{ type:"error", message: WORKSPACE_RECLAIMED_MESSAGE }`; else generic. Inline comment cites the placement learning.
+- [ ] 4.3 GREEN for routing (incl. negative: `"ok"` never yields reclaimed message).
+
+## Phase 5 — Full suite + typecheck
+- [ ] 5.1 `cd apps/web-platform && ./node_modules/.bin/vitest run` (full) + `./node_modules/.bin/tsc --noEmit`.
+
+## Ship
+- [ ] S.1 PR body uses `Closes #5340` and `Refs #5240` (NOT `Closes #5240`).
+- [ ] S.2 Review (incl. `user-impact-reviewer` — single-user-incident threshold).
+- [ ] S.3 `/soleur:ship` post-merge verification (no operator steps).

--- a/knowledge-base/project/specs/feat-one-shot-5240-workspace-reprovision-reconnect/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-5240-workspace-reprovision-reconnect/tasks.md
@@ -30,9 +30,9 @@ created: 2026-06-15
 - [ ] 2.3 GREEN. Verify pass-through and recovery cases.
 
 ## Phase 3 — Thread reprovision result out of the cc factory
-- [ ] 3.1 RED: `test/cc-dispatcher-reprovision-honest-message.test.ts` — threading + routing (cc path).
-- [ ] 3.2 Add `setReprovisionResult?` to `QueryFactoryArgs` (`:1029`) AND the forward (`:2512-2516`); capture outcome at `:1469`, publish via sink; add dispatcher cell + setter + deps-wiring (mirror `setBashAutonomous`).
-- [ ] 3.3 GREEN for threading assertions.
+- [ ] 3.1 RED: `test/cc-dispatcher-reprovision-honest-message.test.ts` — threading + routing (cc path), INCLUDING a warm-query reconnect case.
+- [ ] 3.2 Add `setReprovisionResult?` to `QueryFactoryArgs` (`:1029`) AND the forward (`:2512-2516`); add dispatcher cell + setter + deps-wiring (mirror `setBashAutonomous` `:2332`/`:2893`). **COLD-vs-WARM (deepen finding):** `realSdkQueryFactory` runs only on cold turns — do the re-provision + result publish via the per-dispatch fire-and-forget re-resolve in `dispatchSoleurGo` (mirror `setBashAutonomous` warm resolve at `:2348`), so warm reconnects are covered. Keep idempotent (`.git`-absent-gated). The `:1469` factory call may stay as the cold-path self-heal.
+- [ ] 3.3 GREEN for threading assertions (cold + warm).
 
 ## Phase 4 — Honest post-recovery-failure message (cc path)
 - [ ] 4.1 Add `WORKSPACE_RECLAIMED_MESSAGE` to `cc-workflow-end-messages.ts` (copywriter copy; NOT a new status).


### PR DESCRIPTION
## Summary

Deterministic workspace re-provision on reconnect — epic #5240 design item #2 (deferred by the durable-resume v1). On (re)connect after a sandbox/host reclaim, the resolved workspace path can be a fresh filesystem where the repo was never cloned (the "No Git repository / no worktrees" symptom). #5311 added detection (`worktree_enter_failed`) but no recovery. This adds the recovery + an honest post-recovery-failure message.

- **Leader path** (`agent-runner.ts` `startAgentSession`): adds the missing `.git`-absent recovery (the Concierge cc path already self-healed) before `patchWorkspacePermissions`/`syncPull`, resolving install+repo lazily inside the gate.
- **Concierge cc path**: per-dispatch re-provision (`cc-reprovision.ts`) covering **warm-query reconnect** — the cold factory self-heal only fires on cold turns; warm resume is the epic's headline scenario.
- **Honest message**: when the re-clone genuinely fails, a `worktree_enter_failed` turn surfaces `WORKSPACE_RECLAIMED_MESSAGE` instead of the generic retry copy. Branch is gated **after** the recovery (placement learning) so it never lies in the recoverable case.
- **Shared install selection** (`cc-effective-installation.ts`): all three recovery paths (cold factory, cc per-dispatch, leader) route through `resolveEffectiveInstallationId` so a cross-account org repo re-clones with the entitled repo-owner install instead of 403-ing and reporting a false "couldn't restore" (review finding).

`ensureWorkspaceRepoCloned` return widened `void → ReprovisionOutcome ("failed" | "ok")`.

Closes #5340
Refs #5240 (epic — stays open for design items #1-deeper, #3, #4; do not close)

## User-Brand Impact

- **Artifact:** a user's in-flight conversation resumability on reconnect; the `WORKSPACE_RECLAIMED_MESSAGE` shown to the user.
- **Vector:** (a) a permanent dead-end where every message re-trips the missing-repo guard and never recovers; (b) a misleading "reclaimed — start fresh" message on a conversation that was actually recoverable. Both mitigated: recovery fires on cold AND warm paths; the honest message is gated on `ReprovisionOutcome === "failed"` evaluated AFTER recovery. No existing repo is ever touched (`.git`-absent gated). `repoUrl`/`installationId` are server-resolved + membership-scoped (ADR-044), never request input; no change to the `/workspaces` `denyRead` isolation boundary.
- **Brand-survival threshold:** single-user incident

Known limitation (accepted): the honest message is best-effort — if `worktree_enter_failed` fires before the fire-and-forget re-provision settles, the generic retry copy shows (safe direction; self-corrects next turn).

## Changelog

### Web Platform

- Workspace re-provision recovery added to the leader session path (`agent-runner.ts`); previously only the Concierge path self-healed.
- Per-dispatch re-provision for the Concierge path covers warm-query reconnect.
- New honest "workspace reclaimed" message for genuine post-recovery failures.
- Shared `resolveEffectiveInstallationId` so all recovery paths select the entitled repo-owner installation.

## Test plan

- [x] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` clean
- [x] Full web-platform vitest suite: 9957 passed / 0 failed
- [x] New/extended tests: `agent-runner-reprovision`, `cc-reprovision`, `cc-effective-installation`, `cc-workflow-end-messages` (routing polarities + placement invariant), `cc-dispatcher` (honest-message integration wiring), `ensure-workspace-repo` (outcome contract)
- [x] Multi-agent review (security, architecture, pattern-recognition, user-impact, test-design, code-quality) + semgrep + anti-slop; all findings fixed inline

Generated with [Claude Code](https://claude.com/claude-code)
