### PR TITLE
fix(postmerge): probe /health not /api/health in Phase 3 deploy verification

### DIFF
--- a/plugins/soleur/skills/postmerge/SKILL.md
+++ b/plugins/soleur/skills/postmerge/SKILL.md
@@ -85,8 +85,10 @@ echo "${PRODUCTION_URL:-not_set}"
 If a production URL is available, verify the deployment:
 
 ```bash
-curl -sf --max-time 10 "<production-url>/api/health" | jq .
+curl -sf --max-time 10 "<production-url>/health" | jq .
 ```
+
+Use `/health` (the public, middleware-/CSP-bypassed health route returning `{"status":"ok","version","build_sha","supabase","sentry",...}`), NOT `/api/health` — the latter is an authenticated API route that 307-redirects an unauthenticated probe to `/login`, so `curl -sf` fails and `HEALTH_VERIFIED` is left `false` even when production is healthy. The `build_sha` field also confirms the merge commit is the live build.
 
 **If health check succeeds:** Record the response, set `HEALTH_VERIFIED=true`, and proceed.
 


### PR DESCRIPTION
## Summary

Postmerge Phase 3 verified production health by curling `<production-url>/api/health`, but that is an authenticated API route — an unauthenticated probe gets a 307 redirect to `/login`, so `curl -sf` fails and `HEALTH_VERIFIED` is left `false` even when the deploy is healthy. The public, middleware-/CSP-bypassed health route is `/health`, which returns JSON (`status`/`version`/`build_sha`/`supabase`/`sentry`).

Switches the Phase 3 probe to `/health` and adds a one-line note so it is not reverted. `| jq .` stays valid (the route returns JSON).

## Changelog

- postmerge skill Phase 3: probe `/health` instead of `/api/health` for production deploy verification.

## Test plan

- [x] `curl https://app.soleur.ai/health` returns 200 + JSON; `/api/health` returns 307 → /login (verified live during PR #5338 postmerge run).

Generated with [Claude Code](https://claude.com/claude-code)