### PR TITLE
docs(cron): correct stale TIER2_DEFERRED comment — LinkedIn collection is live

### DIFF
--- a/apps/web-platform/server/inngest/functions/cron-community-monitor.ts
+++ b/apps/web-platform/server/inngest/functions/cron-community-monitor.ts
@@ -143,11 +143,12 @@ const CLAUDE_CODE_FLAGS = [
 // across plan→work cycles.
 //
 // LinkedIn collection note (#4049): the "LinkedIn (if enabled): … fetch-metrics"
-// step below only fires once this cron is RESTORED from TIER2_DEFERRED_CRONS.
-// The handler currently early-returns via deferIfTier2Cron (no claude spawn), so
-// the prompt edit is source-shape-testable but NOT live-verifiable until restore.
-// Do NOT attempt to un-defer the cron here (out of scope — see the Tier-2
-// restore effort, #5018 / #5046 lineage).
+// step below is LIVE — it runs on every fire. TIER2_DEFERRED_CRONS is empty
+// (Tier-2 boundary fully restored, #5199), so deferIfTier2Cron is a defensive
+// no-op that does NOT gate this cron. Verified live 2026-06-15 (manual run →
+// digest #5357 carried real LinkedIn metrics: 3 followers, 2,137 impressions).
+// If a future Tier-2 deferral re-adds "community-monitor" to the set, collection
+// pauses behind the deferral heartbeat until restore.
 const COMMUNITY_MONITOR_PROMPT = `You are a community monitoring agent. Your job is to generate a daily
 community digest and create a GitHub Issue summarizing the findings.
 


### PR DESCRIPTION
## Summary

One-line comment cleanup in `cron-community-monitor.ts`. The `#4049` LinkedIn note claimed the fetch-metrics step "only fires once RESTORED from `TIER2_DEFERRED_CRONS`" and that the handler "early-returns via `deferIfTier2Cron` (no claude spawn)". Both are stale: `TIER2_DEFERRED_CRONS` is empty (Tier-2 boundary restored, #5199), so `deferIfTier2Cron` is a defensive no-op and LinkedIn collection runs on every fire.

Verified live 2026-06-15: a manual community-monitor run filed digest #5357 with real LinkedIn metrics (3 followers, 2,137 impressions). Comment-only; zero behavior change.

## Changelog

- Correct the stale Tier-2-deferral comment in `cron-community-monitor.ts` to reflect that LinkedIn data collection is live (set is empty), with the dogfood verification reference.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `cron-community-monitor.test.ts` 70/70 (comment is above the prompt const; no anchor strings touched)

Generated with [Claude Code](https://claude.com/claude-code)
