### PR TITLE
test(tenant-integration): fix stale visibility assertions + GoTrue rate-limit determinism

### DIFF
--- a/apps/web-platform/test/README.md
+++ b/apps/web-platform/test/README.md
@@ -8,6 +8,11 @@ This directory holds the unit + integration test files for the web platform. Tes
 |---|---|---|
 | `byok.integration.test.ts` | `BYOK_INTEGRATION_TEST=1` | Per-tenant ciphertext isolation against the real `api_keys` table + crypto round-trip. |
 | `conversations-rail-cross-tenant.integration.test.ts` | `SUPABASE_DEV_INTEGRATION=1` | User A's `command-center` Realtime subscription receives ZERO `postgres_changes` payloads from user B's INSERT/UPDATE/DELETE on `conversations`. Load-bearing case is DELETE (bypasses RLS by Postgres design). |
+| `server/conversation-visibility.tenant-isolation.test.ts` | `SUPABASE_DEV_INTEGRATION=1` | Dual-predicate visibility RLS (mig 075) + `set_conversation_visibility` SECURITY DEFINER RPC: owner-only writes, workspace-shared reads, cross-workspace deny. Asserts the **RLS-effective** write contract, not the column-level REVOKE (a no-op against any real Supabase project — see the test's AC8 `SOLEUR-DEBT` note). |
+
+> **Two env-flag conventions (historical).** `SUPABASE_DEV_INTEGRATION=1` gates the suites above; the broader `*.tenant-isolation.test.ts` family (~55 suites) gates on `TENANT_INTEGRATION_TEST=1`. Both exist; neither was renamed. Set whichever a given file reads (the file's header docstring states it), or set both when running a mixed batch.
+
+> **Run behavioral suites against a DEDICATED, freshly-migrated Supabase project — NOT the shared `dev` project.** The shared `dev` project accumulates manual dashboard state and partial-teardown cruft, and its grant state can diverge from the migration files (e.g. Supabase's blanket `GRANT ALL ON public.<table> TO authenticated` silently subsumes a targeted column `REVOKE`). Assertions that depend on exact grant/trigger/FK state — and the mass synthetic-user create/delete these suites perform — are only reliable on a clean replica. This mirrors the guidance already documented in `test/supabase-migrations/079-workspace-rls-isolation.test.ts`. GoTrue's per-IP/per-email rate limits and the opaque "Database error deleting user" transient are absorbed by `helpers/gotrue-retry.ts` (`withGoTrueRetry`) **at the wrapped call sites** — the shared-workspace fixture's create/delete (`helpers/workspace-members-fixtures.ts`), `tearDownTenantUser`'s delete (`helpers/tenant-isolation-teardown.ts`), and the conversation-visibility sign-ins. Suites that mint users via a direct inline `auth.admin.createUser` loop in their own `beforeAll` are NOT yet wrapped, so a dedicated, freshly-migrated project remains the correct substrate for a deterministic full-batch run.
 
 ### Running
 
@@ -21,6 +26,10 @@ doppler run -p soleur -c dev -- env BYOK_INTEGRATION_TEST=1 \
 # Cross-tenant Realtime isolation (Phase 5b for feat-command-center-conversation-nav)
 doppler run -p soleur -c dev -- env SUPABASE_DEV_INTEGRATION=1 \
   ./node_modules/.bin/vitest run test/conversations-rail-cross-tenant.integration.test.ts
+
+# Conversation visibility RLS + RPC (mig 075)
+doppler run -p soleur -c dev -- env SUPABASE_DEV_INTEGRATION=1 \
+  ./node_modules/.bin/vitest run test/server/conversation-visibility.tenant-isolation.test.ts
 ```
 
 CI without the env flag runs the suite with `it.skipIf(...)` short-circuiting these files cleanly. Operators MUST run the cross-tenant suite locally before marking the rail PR ready — it's the merge-gate per the plan's HARD ACCEPTANCE CRITERION.

--- a/apps/web-platform/test/helpers/gotrue-retry.test.ts
+++ b/apps/web-platform/test/helpers/gotrue-retry.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for the GoTrue rate-limit retry helper.
+ *
+ * These run in CI WITHOUT any opt-in env flag or live Supabase — the
+ * predicate + backoff logic is pure and the wrapper takes an injectable
+ * `sleep` so no real time elapses. This is the deterministic core of the
+ * Fix-3 harness-determinism work; the wiring into the live integration
+ * suites is exercised only under SUPABASE_DEV_INTEGRATION/TENANT_INTEGRATION_TEST.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { isRetryableGoTrueError, withGoTrueRetry } from "./gotrue-retry";
+
+describe("isRetryableGoTrueError", () => {
+  it("returns false for null/undefined (the success path)", () => {
+    expect(isRetryableGoTrueError(null)).toBe(false);
+    expect(isRetryableGoTrueError(undefined)).toBe(false);
+  });
+
+  it("retries on HTTP 429 regardless of code/message", () => {
+    expect(isRetryableGoTrueError({ status: 429 })).toBe(true);
+  });
+
+  it("retries on over_*_rate_limit codes", () => {
+    expect(isRetryableGoTrueError({ code: "over_request_rate_limit" })).toBe(
+      true,
+    );
+    expect(
+      isRetryableGoTrueError({ code: "over_email_send_rate_limit" }),
+    ).toBe(true);
+  });
+
+  it("retries on rate-limit / too-many-requests messages", () => {
+    expect(
+      isRetryableGoTrueError({ message: "Request rate limit reached" }),
+    ).toBe(true);
+    expect(isRetryableGoTrueError({ message: "Too Many Requests" })).toBe(
+      true,
+    );
+  });
+
+  it("retries on the opaque 'Database error deleting user' transient", () => {
+    expect(
+      isRetryableGoTrueError({
+        status: 500,
+        message: "Database error deleting user",
+      }),
+    ).toBe(true);
+  });
+
+  it("does NOT retry on a genuine non-rate-limit error", () => {
+    expect(
+      isRetryableGoTrueError({ status: 422, code: "user_already_exists" }),
+    ).toBe(false);
+    expect(
+      isRetryableGoTrueError({ status: 400, message: "Invalid login" }),
+    ).toBe(false);
+  });
+});
+
+describe("withGoTrueRetry", () => {
+  const noSleep = vi.fn(async () => {});
+
+  it("returns immediately on first success (no retry, no sleep)", async () => {
+    const fn = vi.fn(async () => ({ data: { id: "u1" }, error: null }));
+    const result = await withGoTrueRetry("createUser", fn, { sleep: noSleep });
+    expect(result.error).toBeNull();
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(noSleep).not.toHaveBeenCalled();
+  });
+
+  it("retries on a rate-limit error then succeeds", async () => {
+    const sleep = vi.fn(async () => {});
+    let calls = 0;
+    const fn = vi.fn(async () => {
+      calls += 1;
+      if (calls < 3) return { data: null, error: { status: 429 } };
+      return { data: { id: "u1" }, error: null };
+    });
+    const result = await withGoTrueRetry("signIn", fn, { sleep, baseDelayMs: 1 });
+    expect(result.error).toBeNull();
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns the last (still-erroring) result after exhausting attempts", async () => {
+    const sleep = vi.fn(async () => {});
+    const fn = vi.fn(async () => ({
+      data: null,
+      error: { status: 429, message: "Request rate limit reached" },
+    }));
+    const result = await withGoTrueRetry("deleteUser", fn, {
+      sleep,
+      maxAttempts: 3,
+      baseDelayMs: 1,
+    });
+    expect(result.error).not.toBeNull();
+    expect(fn).toHaveBeenCalledTimes(3);
+    // sleeps between attempts only — not after the final failed attempt
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry a non-rate-limit error (returns it on first call)", async () => {
+    const sleep = vi.fn(async () => {});
+    const fn = vi.fn(async () => ({
+      data: null,
+      error: { status: 422, code: "user_already_exists" },
+    }));
+    const result = await withGoTrueRetry("createUser", fn, { sleep });
+    expect(result.error).not.toBeNull();
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("retries a THROWN retryable error, then rethrows if it never clears", async () => {
+    const sleep = vi.fn(async () => {});
+    const fn = vi.fn(async () => {
+      throw Object.assign(new Error("Request rate limit reached"), {
+        status: 429,
+      });
+    });
+    await expect(
+      withGoTrueRetry("signIn", fn, { sleep, maxAttempts: 2, baseDelayMs: 1 }),
+    ).rejects.toThrow(/rate limit/i);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web-platform/test/helpers/gotrue-retry.ts
+++ b/apps/web-platform/test/helpers/gotrue-retry.ts
@@ -1,0 +1,118 @@
+/**
+ * GoTrue rate-limit retry helper for the opt-in integration suites.
+ *
+ * The tenant-integration / workspace-fixture suites mass-create, sign in,
+ * and delete synthetic GoTrue users. Run as a batch (or against the SHARED
+ * dev project, which the README explicitly warns against for behavioral
+ * suites), they trip GoTrue's per-IP/per-email rate limits and the opaque
+ * 500-class "Database error deleting user" transient. That made the suite
+ * non-deterministic — identical runs failed 7 vs 16 tests purely on
+ * rate-limit timing, NOT on any code regression.
+ *
+ * `isRetryableGoTrueError` is the grounded predicate (auth-js@2.99.2:
+ * `AuthError`/`AuthApiError` expose `.status` + `.code`); `withGoTrueRetry`
+ * is a bounded exponential-backoff-with-jitter wrapper around any
+ * supabase-js auth call that returns the `{ data, error }` shape (it also
+ * tolerates auth-js paths that THROW the error). Non-rate-limit errors are
+ * returned/rethrown immediately — the wrapper never masks a real failure,
+ * which is the exact regression class tenant-integration exists to catch.
+ *
+ * The wrapper takes an injectable `sleep` so the unit test
+ * (`gotrue-retry.test.ts`) runs with zero real elapsed time. Defaults keep
+ * the worst-case cumulative wait well under the suites' 20-60s hookTimeout.
+ */
+
+export interface GoTrueErrorLike {
+  status?: number;
+  code?: string;
+  message?: string;
+}
+
+const RATE_LIMIT_MESSAGE_RE = /rate limit|too many requests/i;
+// Opaque 500-class transient GoTrue returns when a concurrent/locked
+// auth.users DELETE briefly fails; safe to retry (the FK-reverse cascade
+// is idempotent).
+const TRANSIENT_DELETE_RE = /database error deleting user/i;
+// over_request_rate_limit, over_email_send_rate_limit, over_sms_send_rate_limit, …
+const OVER_RATE_LIMIT_CODE_RE = /^over_[a-z_]*rate_limit$/;
+
+/**
+ * True when `error` is a transient GoTrue condition worth retrying.
+ * Returns false for null/undefined (the success path) and for genuine
+ * client errors (422 user_already_exists, 400 invalid-login, …).
+ */
+export function isRetryableGoTrueError(
+  error: GoTrueErrorLike | null | undefined,
+): boolean {
+  if (!error) return false;
+  if (error.status === 429) return true;
+  if (typeof error.code === "string" && OVER_RATE_LIMIT_CODE_RE.test(error.code))
+    return true;
+  const msg = error.message ?? "";
+  if (RATE_LIMIT_MESSAGE_RE.test(msg)) return true;
+  if (TRANSIENT_DELETE_RE.test(msg)) return true;
+  return false;
+}
+
+export interface WithGoTrueRetryOpts {
+  /** Max total attempts (including the first). Default 5. */
+  maxAttempts?: number;
+  /** Base backoff in ms; doubles per attempt, capped at 4000ms. Default 250. */
+  baseDelayMs?: number;
+  /** Injectable sleep (unit tests pass a no-op). Default real setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable jitter in [0,1); defaults to Math.random. */
+  jitter?: () => number;
+}
+
+function backoffMs(attempt: number, base: number, jitter: number): number {
+  const exp = Math.min(4000, base * 2 ** (attempt - 1));
+  return Math.round(exp + jitter * base);
+}
+
+/**
+ * Wrap a supabase-js auth call (returns `{ data, error }`) with bounded
+ * retry on rate-limit / transient errors. Returns the final result (which
+ * may still carry a non-retryable or attempts-exhausted error — the caller
+ * keeps its existing error handling). Rethrows a thrown error that is not
+ * retryable, or that persists past `maxAttempts`.
+ */
+export async function withGoTrueRetry<
+  T extends { error: GoTrueErrorLike | null },
+>(label: string, fn: () => Promise<T>, opts: WithGoTrueRetryOpts = {}): Promise<T> {
+  const maxAttempts = opts.maxAttempts ?? 5;
+  const baseDelayMs = opts.baseDelayMs ?? 250;
+  const sleep =
+    opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const jitter = opts.jitter ?? Math.random;
+
+  let lastResult: T | undefined;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let result: T;
+    try {
+      result = await fn();
+    } catch (thrown) {
+      if (
+        isRetryableGoTrueError(thrown as GoTrueErrorLike) &&
+        attempt < maxAttempts
+      ) {
+        await sleep(backoffMs(attempt, baseDelayMs, jitter()));
+        continue;
+      }
+      throw thrown;
+    }
+    if (!isRetryableGoTrueError(result.error) || attempt === maxAttempts) {
+      return result;
+    }
+    lastResult = result;
+    // eslint-disable-next-line no-console
+    console.warn(
+      `withGoTrueRetry[${label}]: retryable error on attempt ${attempt}/${maxAttempts} ` +
+        `(code=${result.error?.code ?? "?"} status=${result.error?.status ?? "?"})`,
+    );
+    await sleep(backoffMs(attempt, baseDelayMs, jitter()));
+  }
+  // Unreachable in practice (the attempt === maxAttempts branch returns),
+  // but satisfies the type checker.
+  return lastResult as T;
+}

--- a/apps/web-platform/test/helpers/tenant-isolation-teardown.ts
+++ b/apps/web-platform/test/helpers/tenant-isolation-teardown.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { withGoTrueRetry } from "./gotrue-retry";
 
 /**
  * Synthetic-only allowlist gate for tenant-isolation test users.
@@ -91,7 +92,12 @@ export async function tearDownTenantUser(
     }
   }
 
-  const { error } = await service.auth.admin.deleteUser(user.id);
+  // Retry past GoTrue rate limits and the opaque transient
+  // "Database error deleting user" (the FK-reverse anonymise above is
+  // idempotent, so a retried delete is safe).
+  const { error } = await withGoTrueRetry(`deleteUser:${user.email}`, () =>
+    service.auth.admin.deleteUser(user.id!),
+  );
   if (error && !/not found/i.test(error.message)) {
     throw new Error(
       `tearDownTenantUser: deleteUser(${user.email}) failed: ${error.message}`,

--- a/apps/web-platform/test/helpers/workspace-members-fixtures.ts
+++ b/apps/web-platform/test/helpers/workspace-members-fixtures.ts
@@ -21,6 +21,7 @@
 
 import { randomBytes } from "node:crypto";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { withGoTrueRetry } from "./gotrue-retry";
 
 export const WORKSPACE_FIXTURE_EMAIL_RE =
   /^workspace-fixture-[a-f0-9]{16}@soleur\.test$/;
@@ -77,11 +78,13 @@ export async function createSharedWorkspaceMembers(
   for (let i = 0; i < count; i++) {
     const email = syntheticWorkspaceFixtureEmail();
     assertSyntheticWorkspaceFixture(email);
-    const { data, error } = await service.auth.admin.createUser({
-      email,
-      password: randomBytes(16).toString("hex"),
-      email_confirm: true,
-    });
+    const { data, error } = await withGoTrueRetry(`createUser:${email}`, () =>
+      service.auth.admin.createUser({
+        email,
+        password: randomBytes(16).toString("hex"),
+        email_confirm: true,
+      }),
+    );
     if (error) throw new Error(`createUser failed: ${error.message}`);
     const userId = data.user?.id;
     if (!userId) throw new Error("createUser returned no user.id");
@@ -167,10 +170,13 @@ export async function tearDownSharedWorkspace(
       .eq("id", fixture.organizationId);
   } catch {}
 
-  // 4. Auth users (CASCADE to public.users).
+  // 4. Auth users (CASCADE to public.users). Retry past GoTrue rate limits
+  // and the opaque transient "Database error deleting user".
   for (const m of fixture.members) {
     try {
-      await service.auth.admin.deleteUser(m.userId);
+      await withGoTrueRetry(`deleteUser:${m.userId}`, () =>
+        service.auth.admin.deleteUser(m.userId),
+      );
     } catch {}
   }
 }

--- a/apps/web-platform/test/server/conversation-visibility.tenant-isolation.test.ts
+++ b/apps/web-platform/test/server/conversation-visibility.tenant-isolation.test.ts
@@ -23,6 +23,7 @@ import {
   tearDownSharedWorkspace,
   type SharedWorkspaceFixture,
 } from "../helpers/workspace-members-fixtures";
+import { withGoTrueRetry } from "../helpers/gotrue-retry";
 
 const INTEGRATION_ENABLED =
   process.env.SUPABASE_DEV_INTEGRATION === "1";
@@ -126,28 +127,34 @@ describe.skipIf(!INTEGRATION_ENABLED)(
         expect(error, `set password for ${user.email}`).toBeNull();
       }
 
-      const { error: signInA } = await userAClient.auth.signInWithPassword({
-        email: userA.email,
-        password: knownPassword,
-      });
+      const { error: signInA } = await withGoTrueRetry("signIn:userA", () =>
+        userAClient.auth.signInWithPassword({
+          email: userA.email,
+          password: knownPassword,
+        }),
+      );
       expect(signInA, "userA sign-in").toBeNull();
 
       userBClient = createClient(supabaseUrl, anonKey, {
         auth: { persistSession: false, autoRefreshToken: false },
       });
-      const { error: signInB } = await userBClient.auth.signInWithPassword({
-        email: userB.email,
-        password: knownPassword,
-      });
+      const { error: signInB } = await withGoTrueRetry("signIn:userB", () =>
+        userBClient.auth.signInWithPassword({
+          email: userB.email,
+          password: knownPassword,
+        }),
+      );
       expect(signInB, "userB sign-in").toBeNull();
 
       userCClient = createClient(supabaseUrl, anonKey, {
         auth: { persistSession: false, autoRefreshToken: false },
       });
-      const { error: signInC } = await userCClient.auth.signInWithPassword({
-        email: userC.email,
-        password: knownPassword,
-      });
+      const { error: signInC } = await withGoTrueRetry("signIn:userC", () =>
+        userCClient.auth.signInWithPassword({
+          email: userC.email,
+          password: knownPassword,
+        }),
+      );
       expect(signInC, "userC sign-in").toBeNull();
     }, 60_000);
 
@@ -235,25 +242,105 @@ describe.skipIf(!INTEGRATION_ENABLED)(
     });
 
     // ------------------------------------------------------------------
-    // AC8: RESTRICTIVE policy — client UPDATE on visibility rejected
+    // AC8: effective write-isolation contract for the visibility column.
+    //
+    // Mig 075's `REVOKE UPDATE(visibility) ON conversations FROM
+    // authenticated` is a NO-OP on a real Supabase project: the table-level
+    // `GRANT ... ON public.conversations TO authenticated` subsumes the
+    // narrower column REVOKE, so `authenticated` retains column UPDATE.
+    // (Confirmed live on dev AND prd; see the SOLEUR-DEBT marker in
+    // mig 075_conversation_visibility.sql.) The ENFORCED contract is the
+    // RLS policy `conversations_owner_update` — owner-only writes. These
+    // tests assert that effective contract, not the defense-in-depth column
+    // grant a clean-migration replica would have. A test that asserts the
+    // column REVOKE cannot pass against any real Supabase project.
+    //
+    // SOLEUR-DEBT: mig 075 column REVOKE on conversations.visibility is a no-op (Supabase's table-level GRANT to authenticated subsumes it); RLS conversations_owner_update is the enforced guard so impact is nil; restore real column protection only if a non-owner write path to visibility that RLS does not cover is ever introduced, by GRANTing conversations at column granularity instead of ALL. (Marker lives here, not in mig 075 — editing an applied migration trips the content_sha drift probe.)
     // ------------------------------------------------------------------
-    it("Client UPDATE on visibility column is rejected", async () => {
-      const { error } = await userAClient
+    it("Owner CAN UPDATE own conversation visibility directly (RLS allows)", async () => {
+      // Use a DEDICATED row, not the shared privateConvId — this is the only
+      // destructive test in the suite, and coupling it to a shared row that
+      // downstream tests assert on means a mid-test failure would cascade into
+      // misleading downstream failures. Self-contained insert + finally-delete.
+      const ownConvId = randomUUID();
+      const userA = ws1.members[0];
+      const { error: insErr } = await service.from("conversations").insert({
+        id: ownConvId,
+        user_id: userA.userId,
+        workspace_id: ws1.workspaceId,
+        repo_url: REPO_URL,
+        status: "active",
+        last_active: new Date().toISOString(),
+        visibility: "private",
+      });
+      expect(insErr, "insert owner-update fixture row").toBeNull();
+
+      try {
+        const { error } = await userAClient
+          .from("conversations")
+          .update({ visibility: "workspace" } as Record<string, unknown>)
+          .eq("id", ownConvId);
+        expect(error).toBeNull();
+
+        const { data: after } = await service
+          .from("conversations")
+          .select("visibility")
+          .eq("id", ownConvId)
+          .single();
+        expect(after?.visibility).toBe("workspace");
+      } finally {
+        await service.from("conversations").delete().eq("id", ownConvId);
+      }
+    });
+
+    it("Non-owner CANNOT UPDATE another owner's conversation visibility (RLS blocks)", async () => {
+      const { data, error } = await userBClient
+        .from("conversations")
+        .update({ visibility: "private" } as Record<string, unknown>)
+        .eq("id", sharedConvId)
+        .select("id");
+
+      // RLS owner-only UPDATE deny is dual-shape: a 42501 error, OR a 0-row
+      // match (PostgREST returns no error when the USING clause filters all
+      // candidate rows). Either is a correct deny.
+      if (error) {
+        expect(error.code).toBe("42501");
+      } else {
+        expect(data).toEqual([]);
+      }
+
+      // Load-bearing proof: service-role read-back confirms unchanged.
+      const { data: unchanged } = await service
+        .from("conversations")
+        .select("visibility")
+        .eq("id", sharedConvId)
+        .single();
+      expect(unchanged?.visibility).toBe("workspace");
+    });
+
+    it("anon CANNOT UPDATE visibility (RLS blocks)", async () => {
+      const anonClient = createClient(supabaseUrl, anonKey, {
+        auth: { persistSession: false, autoRefreshToken: false },
+      });
+      const { data, error } = await anonClient
         .from("conversations")
         .update({ visibility: "workspace" } as Record<string, unknown>)
-        .eq("id", privateConvId);
+        .eq("id", privateConvId)
+        .select("id");
 
-      // Column-level REVOKE produces 42501 (insufficient_privilege)
-      expect(error).not.toBeNull();
-      expect(error!.code).toBe("42501");
+      // anon has no auth.uid(); the owner-update USING clause matches 0 rows.
+      // Accept either an error or an empty result — both deny the write.
+      if (!error) {
+        expect(data).toEqual([]);
+      }
 
-      // Verify row unchanged
-      const { data } = await service
+      // Load-bearing proof: read-back confirms unchanged.
+      const { data: unchanged } = await service
         .from("conversations")
         .select("visibility")
         .eq("id", privateConvId)
         .single();
-      expect(data?.visibility).toBe("private");
+      expect(unchanged?.visibility).toBe("private");
     });
 
     // ------------------------------------------------------------------
@@ -309,8 +396,11 @@ describe.skipIf(!INTEGRATION_ENABLED)(
       );
 
       expect(error).not.toBeNull();
-      // RPC raises insufficient_privilege
-      expect(error!.code).toBe("P0001");
+      // RPC raises USING ERRCODE = 'insufficient_privilege' → SQLSTATE 42501
+      // (mig 075's NOT-FOUND branch). The prior P0001 assertion was wrong
+      // since #4521 — the RPC has never raised the default raise_exception
+      // code; it was hidden because this opt-in suite never runs in CI.
+      expect(error!.code).toBe("42501");
 
       // Verify unchanged
       const { data } = await service

--- a/knowledge-base/project/learnings/2026-06-15-tenant-integration-breakage-is-shared-dev-grant-drift-not-code-regression.md
+++ b/knowledge-base/project/learnings/2026-06-15-tenant-integration-breakage-is-shared-dev-grant-drift-not-code-regression.md
@@ -1,0 +1,106 @@
+# Learning: "tenant-integration breakage on main" was test-correctness + shared-dev grant drift, not a code regression
+
+## Problem
+
+Running the opt-in tenant-integration suite (`TENANT_INTEGRATION_TEST=1` /
+`SUPABASE_DEV_INTEGRATION=1`) against the **shared dev** Supabase project
+failed 7–16 tests with run-to-run variance. CI was green the whole time
+(these suites are opt-in and never run in CI). Framed as "a breakage on main."
+
+## Root cause — three independent causes, none a production code regression
+
+1. **Latent test bug (deterministic).** `conversation-visibility.tenant-isolation.test.ts`
+   asserted the non-owner RPC raises `P0001`, but migration 075 has ALWAYS
+   raised `USING ERRCODE = 'insufficient_privilege'` → SQLSTATE **42501**.
+   `P0001` is the *default* `RAISE EXCEPTION` code; an explicit `USING ERRCODE`
+   overrides it. The assertion was wrong since the migration+test landed in the
+   same commit (#4521) and stayed hidden because the suite is opt-in.
+
+2. **Shared-dev grant state diverges from the migration files (deterministic).**
+   Migration 075's `REVOKE UPDATE(visibility) ON conversations FROM authenticated`
+   is a **no-op on a real Supabase project**: Supabase's blanket
+   `GRANT ALL ON public.<table> TO anon, authenticated` subsumes the narrower
+   column REVOKE. Read-only catalog introspection confirmed `authenticated` AND
+   `anon` retain UPDATE on `conversations.visibility` on BOTH dev and prd. The
+   enforced write guard is the RLS policy `conversations_owner_update`
+   (`user_id = auth.uid()`), not the REVOKE — so the security impact is nil (a
+   user can only change their own conversation's visibility either way), but a
+   test asserting the column REVOKE cannot pass against any real project.
+
+3. **GoTrue rate limits / transient "Database error deleting user" (flaky).**
+   The suites mass-create/sign-in/delete synthetic users; under batch load they
+   trip per-IP/per-email rate limits and an opaque 500-class delete transient.
+   This is the 7↔16 run-to-run variance.
+
+The account-delete cascade (migs 065/066) was suspected but **verified correct
+on both dev and prd** via read-only `pg_constraint`/`pg_proc` introspection:
+`organizations.owner_user_id` and `audit_byok_use.founder_id` FKs are both
+`ON DELETE SET NULL`, the WORM carve-out function is present, and
+`set_conversation_visibility` is SECURITY DEFINER. No GDPR Art-17 incident.
+
+## Solution
+
+- Fixed the stale assertion (`P0001` → `42501`).
+- Reframed the column-REVOKE test to assert the **RLS-effective** contract
+  (owner CAN write own; non-owner + anon CANNOT, proven by service-role
+  read-back of the unchanged value) instead of the dead defense-in-depth REVOKE.
+- Added `test/helpers/gotrue-retry.ts` (`withGoTrueRetry` + grounded
+  `isRetryableGoTrueError`, unit-tested) and wrapped the synthetic-user
+  create/sign-in/delete sites; documented the dedicated-project requirement in
+  `test/README.md`.
+- Recorded the column-REVOKE no-op as a `SOLEUR-DEBT` marker.
+
+## Key Insights
+
+- **Integration tests against the shared dev project must assert RLS-EFFECTIVE
+  behavior, not raw column grants.** Shared dev accumulates manual dashboard
+  state, and Supabase's blanket table GRANT silently subsumes targeted column
+  REVOKEs. Prove deny via service-role read-back of the unchanged value (dual
+  shape: a 42501 error OR a 0-row match are both correct RLS denies), never via
+  an assertion on a column privilege a clean-migration replica would have.
+- **Behavioral integration suites need a DEDICATED, freshly-migrated project**
+  (the repo already says so in `test/supabase-migrations/079-*.test.ts`). The
+  shared dev project's grant/trigger/FK enforcement state is not a faithful
+  replica of the migration files.
+- **An applied migration file is byte-frozen.** The dev-migration-drift probe
+  compares the dev/prd `_schema_migrations.content_sha` (git blob SHA-1 captured
+  at apply time) against `origin/main`'s blob. ANY byte change to an applied
+  migration — *including comments* — diverges the hash and raises a standing
+  content-drift warning requiring a prod ledger reconciliation. Put debt
+  markers / explanatory notes in the consuming artifact (here: the test), NEVER
+  in the applied migration. The plan prescribed a "comment-only edit to mig
+  075" — that assumption was wrong and had to be reverted.
+- **Opt-in suites that never run in CI accumulate latent-wrong assertions.** The
+  `P0001` bug survived from day one. When touching such a suite, run it against
+  live dev and treat every deterministic failure as a real signal.
+
+## Session Errors
+
+1. **Plan prescribed editing applied migration 075's comment; it trips the
+   content_sha drift probe.** — Recovery: reverted mig 075 to byte-identical,
+   relocated the `SOLEUR-DEBT` marker to the reframed test's AC8 comment block.
+   — Prevention: applied migrations are immutable down to bytes; debt markers
+   and notes go in the consuming source, not the migration. (Routed to the work
+   skill's migration guidance.)
+2. **Edit-before-Read on mig 075** (read in a sibling worktree, not this one). —
+   Recovery: Read then Edit. — Prevention: the Read requirement is per-worktree;
+   re-Read after switching worktrees.
+3. **`node` probe run from `/tmp` failed `ERR_MODULE_NOT_FOUND`.** — Recovery:
+   ran the script from `apps/web-platform` so node_modules resolves. — Prevention:
+   ad-hoc node scripts must live under the package whose deps they import.
+4. **`npm install pg --no-save` pruned node_modules and the restoring
+   `npm install` dirtied `package-lock.json` in a SIBLING worktree.** — Recovery:
+   `git checkout -- package-lock.json`. — Prevention: run transient/`--no-save`
+   installs in a throwaway dir or the worktree you own, and restore the lockfile
+   before leaving; better, use a read-only introspection path that needs no new
+   dep.
+5. **Two-dot `git diff origin/main` after `git fetch` showed sibling
+   feature-tweet files as deletions.** — Recovery: confirmed via `git status` +
+   three-dot `origin/main...HEAD` that my working tree never touched them
+   (stale-ref artifact: origin/main advanced past the branch point). — Prevention:
+   use three-dot / `git status` for "what did I change," never two-dot vs a
+   moved ref (already documented in the review diff-direction learning).
+
+## Tags
+category: integration-issues
+module: apps/web-platform/test

--- a/knowledge-base/project/plans/2026-06-15-fix-tenant-integration-test-suite-breakage-plan.md
+++ b/knowledge-base/project/plans/2026-06-15-fix-tenant-integration-test-suite-breakage-plan.md
@@ -1,0 +1,296 @@
+---
+title: "fix: tenant-integration test-suite breakage (stale assertion, column-REVOKE reframe, harness determinism)"
+type: fix
+date: 2026-06-15
+lane: cross-domain
+semver: patch
+requires_cpo_signoff: false
+brand_survival_threshold: none
+---
+
+# fix: tenant-integration test-suite breakage
+
+## Overview
+
+Running `apps/web-platform` tenant-integration suites against the shared dev Supabase
+project surfaced failures. **This is NOT a production-code regression** — the prod + dev
+DB cascade machinery (account-delete cascade migs 065/066: `organizations.owner_user_id`
++ `audit_byok_use.founder_id` FK SET NULL, the WORM carve-out, and
+`set_conversation_visibility` SECURITY DEFINER) was verified CORRECT and live on both
+prd and dev via read-only catalog introspection. **Do NOT touch migs 065/066.**
+
+The failures are test-correctness + test-harness issues in
+`test/server/conversation-visibility.tenant-isolation.test.ts` and the shared
+synthetic-user harness. Three fixes:
+
+1. **Stale assertion** (clear bug): the non-owner RPC test asserts `P0001`, but mig 075
+   raises `insufficient_privilege` (SQLSTATE `42501`). Wrong since day one; hidden because
+   the suite is opt-in and never runs in CI.
+2. **Column-REVOKE assertion cannot pass on a real Supabase project**: `authenticated`
+   actually HAS UPDATE on `conversations.visibility`; the column-REVOKE in mig 075 is a
+   silent no-op. Reframe the test to assert the RLS-effective contract (owner-only writes).
+3. **Harness determinism**: synthetic-user create/sign-in/delete against the SHARED dev
+   project hits GoTrue rate limits non-deterministically. Add rate-limit-aware
+   backoff/retry around the create + delete paths and document/gate the behavioral suites
+   to target a dedicated freshly-migrated project.
+
+Pure test + docs change. No production code path, no UI surface, no new dependency, no
+new infrastructure. The only `.sql` touched is a comment (SOLEUR-DEBT marker) — see the
+GDPR-gate note in Domain Review for the conditional case where a durable-fix migration is
+chosen instead.
+
+## Research Reconciliation — Argument premises vs. codebase reality
+
+The investigation handed three premises. All three conclusions hold, but two mechanisms
+were imprecise and one file target was incomplete. Correcting these at plan time prevents
+the implementation from inheriting the imprecise framing.
+
+| Premise (from arguments) | Codebase reality (verified) | Plan response |
+|---|---|---|
+| Fix 1: test line ~313 asserts `error.code === "P0001"`, mig 075 raises `insufficient_privilege` (42501). | **Exact.** `test:313` = `expect(error!.code).toBe("P0001")`; adjacent comment `:312` = "RPC raises insufficient_privilege". Mig `075:100` = `RAISE EXCEPTION … USING ERRCODE = 'insufficient_privilege'`. | Change `P0001` → `42501`. No reframe needed. |
+| Fix 2: `authenticated` has UPDATE on `conversations.visibility` because **Supabase's blanket `GRANT ALL ON ALL TABLES … TO authenticated` clobbers the column REVOKE**. | Conclusion correct (authenticated CAN update visibility), but the precise mechanism is the **table-level UPDATE grant subsumes the column-level REVOKE** (silent no-op) — the exact pathology in learning `2026-03-20-supabase-column-level-grant-override.md`. `075.down.sql:20` re-GRANTs `UPDATE(visibility)`, confirming the column toggle is the only lever. Supabase's `ALTER DEFAULT PRIVILEGES` is the *function*-grant gotcha (learning `2026-05-06-…`); for *tables* it's the table-grant-subsumes-column-revoke rule. | Reframe the test to the RLS-effective contract. **Surface the durable-fix option honestly** (see Fix 2 §): a mig-006-style "REVOKE table-level UPDATE + re-GRANT all-cols-except-visibility" IS durable (not re-clobbered) — the arguments' "would be re-clobbered" claim is the imprecise part. The debt-marker route is still defensible (wide hot table + per-column GRANT maintenance burden); the plan presents BOTH and lets deepen-plan/plan-review weigh. |
+| Fix 2: test currently exercises the REVOKE via an `authenticated` client. | The client is **`userAClient` — the OWNER** (`test:241`) updating their OWN private conversation. Under RLS `conversations_owner_update` (`075:67-70`, `user_id = auth.uid()`), the owner IS permitted. The column-REVOKE was the *only* thing the test relied on to produce the deny. | Reframe MUST switch the deny-actor to a **non-owner (userB)** and/or **anon** client. An owner-update assertion now correctly SUCCEEDS (RLS allows it). This is a real test-logic change, not a one-line code swap. |
+| Fix 3: add backoff to `test/helpers/tenant-isolation-teardown.ts` (`tearDownTenantUser`). | The **conversation-visibility test does NOT use `tearDownTenantUser`.** It uses `createSharedWorkspaceMembers` + `tearDownSharedWorkspace` (`workspace-members-fixtures.ts`) + 3× `signInWithPassword`. The rate-limit `AuthApiError: Request rate limit reached` fires on the **create + sign-in** path, not teardown. `tearDownTenantUser` is one of TWO delete helpers; `tearDownSharedWorkspace` is the other (12 caller suites). | Backoff must wrap **both** create helpers' `auth.admin.createUser`, both delete helpers' `auth.admin.deleteUser`, AND `signInWithPassword`. Centralize in a shared `withGoTrueRetry` wrapper. Existing mitigation is JWT caching (`mint-once.ts`), not backoff — the new wrapper complements it. |
+| Fix 3: suite gated by `TENANT_INTEGRATION_TEST=1`. | The target test gates on **`SUPABASE_DEV_INTEGRATION=1`** (`test:28`). The repo has TWO conventions: `TENANT_INTEGRATION_TEST=1` (~55 files) and `SUPABASE_DEV_INTEGRATION=1` (6 files). No shared `INTEGRATION_ENABLED` module. | Gating/doc work must address both env conventions. Do NOT silently rename the target test's gate (would mask it from any existing CI/operator invocation keyed on `SUPABASE_DEV_INTEGRATION`). Document the dedicated-project requirement in `test/README.md` for both conventions. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** nothing user-facing — this is a test-suite
+and harness change. The production conversation-visibility behavior (owner-only visibility
+writes via RLS + SECURITY DEFINER RPC) is unchanged and already verified live on prd/dev.
+
+**If this leaks, the user's data is exposed via:** N/A — no data-handling code path changes.
+The reframed Fix 2 test asserts the SAME effective security contract that already holds in
+prod (owner-only writes; non-owner/anon blocked); it does not relax any production grant or
+policy. The accepted defense-in-depth gap (column-REVOKE no-op) is pre-existing and is being
+*documented*, not introduced.
+
+**Brand-survival threshold:** none — test-correctness + test-harness change; no production
+behavior, schema, or grant is modified (the durable-fix migration option, if chosen, would
+*strengthen* defense-in-depth, never weaken it). The sensitive-path note: the SOLEUR-DEBT
+marker lives in a `.sql` comment; if Implementation chooses Option B (durable migration)
+the GDPR-gate fires (see Domain Review) — but Option A (default) touches only a comment.
+
+## Implementation Phases
+
+### Phase 0 — Preconditions (verify, do not assume)
+
+0.1. Confirm the three cited line anchors still hold (paraphrase-without-verification gate):
+   - `git grep -n 'toBe("P0001")' test/server/conversation-visibility.tenant-isolation.test.ts` → expect 1 hit (~`:313`).
+   - `git grep -n "ERRCODE = 'insufficient_privilege'" supabase/migrations/075_conversation_visibility.sql` → expect 1 hit (`:100`).
+   - `git grep -n "REVOKE UPDATE(visibility)" supabase/migrations/075_conversation_visibility.sql` → expect 1 hit (`:38`).
+0.2. Enumerate every GoTrue rate-limit-prone call site to size Fix 3 (do not trust this plan's count):
+   - `git grep -n "auth.admin.createUser" test/helpers/` and `git grep -rn "auth.admin.createUser" test/server/*.tenant-isolation.test.ts` (inline loops).
+   - `git grep -n "auth.admin.deleteUser" test/helpers/`.
+   - `git grep -n "signInWithPassword" test/`.
+0.3. Read the existing JWT-cache helper `test/helpers/mint-once.ts` to confirm the new retry
+   wrapper composes with (does not duplicate) the cache, and to match its rate-limit-budget
+   commentary style.
+
+### Phase 1 — Fix 1: stale assertion (RED→GREEN trivial)
+
+`test/server/conversation-visibility.tenant-isolation.test.ts`, the "Non-owner cannot toggle
+visibility via RPC" test (~`:302-322`):
+- Change `expect(error!.code).toBe("P0001");` → `expect(error!.code).toBe("42501");`
+- The adjacent comment `// RPC raises insufficient_privilege` is now consistent with the
+  assertion (it already said so — the assertion was the lie).
+- Mig 075 raises with `USING ERRCODE = 'insufficient_privilege'` → PostgREST surfaces SQLSTATE
+  `42501`. Confirm supabase-js maps this to `error.code === "42501"` (the SELECT-deny tests at
+  `:178` and `:231` already assert `42501` for the same mapping — consistent precedent in this
+  very file).
+
+### Phase 2 — Fix 2: reframe the column-REVOKE test to RLS-effective contract
+
+Rename/rewrite the "Client UPDATE on visibility column is rejected" test (~`:240-257`). The
+current test uses the OWNER (`userAClient`) and relies on the no-op column-REVOKE. Replace
+with assertions on the contract that actually holds in prod:
+
+2.1. **Owner CAN update own visibility via RLS direct UPDATE** (new positive control —
+   documents that the column-REVOKE is a no-op and RLS governs):
+   - `userAClient.from("conversations").update({ visibility: "workspace" }).eq("id", privateConvId)`
+   - Expect `error` to be null (RLS `conversations_owner_update` allows `user_id = auth.uid()`).
+   - Restore to `private` afterward (or use a throwaway conversation id) so later tests'
+     fixtures are not disturbed — verify ordering against the RPC toggle test at `:262`.
+2.2. **Non-owner (userB) UPDATE on another user's conversation is blocked by RLS** (the real
+   security contract — workspace member cannot mutate owner's row):
+   - `userBClient.from("conversations").update({ visibility: "private" }).eq("id", sharedConvId)`
+   - Dual-shape deny (TR5 precedent in this file, `:177-181`): either `error.code === "42501"`
+     OR `data === []` / zero rows affected (PostgREST UPDATE matching 0 rows is not an error).
+     Assert: row unchanged via service-role read-back (`sharedConvId` still `"workspace"`).
+2.3. **anon UPDATE matches 0 rows** (anon has the grant but no RLS-passing rows):
+   - A fresh anon client (`createClient(supabaseUrl, anonKey)`, no sign-in) UPDATE on any conv id
+     affects 0 rows; assert row unchanged via service-role read-back.
+2.4. **SOLEUR-DEBT marker** documenting the accepted defense-in-depth gap. Place it in
+   `supabase/migrations/075_conversation_visibility.sql` adjacent to the REVOKE at `:38`
+   (the marker must live where the no-op defense lives, so `harvest-debt` surfaces it next to
+   the code). Canonical form (ceiling before `;`, trigger after — per
+   `knowledge-base/project/learnings/technical-debt/README.md`):
+   ```sql
+   -- SOLEUR-DEBT: column-level REVOKE UPDATE(visibility) is a silent no-op — the table-level
+   -- UPDATE grant on conversations subsumes it (see learning 2026-03-20-supabase-column-level-grant-override),
+   -- so authenticated/anon retain raw UPDATE on this column; effective protection is RLS
+   -- (conversations_owner_update, user_id = auth.uid()) + the SECURITY DEFINER RPC, both verified live.
+   -- Upgrade trigger: if a non-owner write path to conversations is ever added, OR if defense-in-depth
+   -- column protection becomes required, invert to "REVOKE UPDATE ON public.conversations FROM authenticated;
+   -- GRANT UPDATE(<all columns except visibility>) ... TO authenticated" (mig-006 pattern) in a new migration.
+   REVOKE UPDATE(visibility) ON public.conversations FROM authenticated;
+   ```
+   - Update the comment block at `075:31-38` ("Column-level REVOKE is the correct defense") which
+     is now factually wrong — it should say the REVOKE is retained as documentation-of-intent but
+     is a no-op, with RLS as the effective control.
+   - **Do NOT add a new migration** rewriting history (`075` is shipped/applied on prd+dev). The
+     marker + corrected comment is Option A (default).
+
+2.5. **Option B (durable migration) — present but do NOT implement by default.** A mig-006-style
+   inversion (`REVOKE UPDATE ON public.conversations FROM authenticated; GRANT UPDATE(<safe cols>)
+   …`) in a NEW migration (e.g. `086_*`) IS durable — Supabase's blanket grant runs once at
+   project init; a later migration's REVOKE wins (proven by mig 006 on `public.users`). Trade-off:
+   `conversations` is a wide, hot, frequently-extended table; every future column add must be added
+   to the GRANT allowlist or it becomes silently read-only for tenants (the exact failure mode in
+   learning `2026-05-21-rls-restrictive-policy-plus-column-grant-blocks-tenant-writes`). Given the
+   RLS owner-only policy already enforces the effective contract, the marginal defense-in-depth value
+   is low against a real maintenance/regression cost. **Recommendation: Option A.** If plan-review or
+   deepen-plan (data-integrity-guardian) argues Option B, it requires: a new forward migration + `.down.sql`,
+   a file-parse contract test, the GDPR-gate (new `.sql`), and enumerating every current `conversations`
+   column into the re-GRANT. Escalate via AskUserQuestion before implementing Option B.
+
+### Phase 3 — Fix 3: harness determinism
+
+3.1. **Shared GoTrue retry wrapper.** Add `withGoTrueRetry<T>(label, fn)` to a shared helper
+   (new `test/helpers/gotrue-retry.ts`, or extend `mint-once.ts` to keep rate-limit logic in one
+   place — decide at Phase 0.3 after reading `mint-once.ts`). Behavior:
+   - Retries on rate-limit signals: `AuthApiError` with `status === 429`, or message matching
+     `/rate limit|too many requests/i`, or the opaque `"Database error deleting user"` transient.
+     Verify the actual error shape supabase-js returns for GoTrue 429 (read
+     `node_modules/@supabase/auth-js` types or capture once) — do not assume the field names.
+   - Exponential backoff with jitter, bounded (e.g. base 500ms, factor 2, max ~5 attempts, cap ~8s),
+     under the existing `hookTimeout: 20_000` ceiling (vitest.config.ts:37) — the total backoff
+     budget MUST stay under hookTimeout or the fixture times out instead of recovering.
+   - Non-rate-limit errors rethrow immediately (do not mask real failures — preserves the
+     `cq-silent-fallback-must-mirror-to-sentry` spirit already honored in `tearDownTenantUser`).
+3.2. **Wrap the create + sign-in + delete call sites:**
+   - `workspace-members-fixtures.ts:80` (`createUser` in `createSharedWorkspaceMembers`).
+   - `workspace-members-fixtures.ts:173` (`deleteUser` in `tearDownSharedWorkspace`).
+   - `tenant-isolation-teardown.ts:94` (`deleteUser` in `tearDownTenantUser`).
+   - The 3× `signInWithPassword` in the target test (`:129/:138/:147`) — wrap, OR migrate to the
+     `mint-once.ts` JWT-cache path if it covers password sign-in (check at Phase 0.3).
+   - Inline `createUser` loops in `*.tenant-isolation.test.ts` suites are out of scope for the
+     wrapper unless trivial; the target failing suite uses the shared helpers, which is the
+     load-bearing path. Note the broader inline-loop migration as a follow-up SOLEUR-DEBT marker
+     if not folded in (per `wg-defer-only-after-inline-triage`).
+3.3. **Document + gate the dedicated-project requirement.** Update `test/README.md`:
+   - State that behavioral tenant-integration suites (both `TENANT_INTEGRATION_TEST=1` and
+     `SUPABASE_DEV_INTEGRATION=1` conventions) MUST target a DEDICATED freshly-migrated dev
+     Supabase project — NEVER the shared dev pre-merge — mirroring the
+     `079-workspace-rls-isolation.test.ts:30-32` header guidance and `hr-dev-prd-distinct-supabase-projects`.
+   - Add the `conversation-visibility.tenant-isolation.test.ts` row + run command to the
+     integration-tests table (currently missing).
+   - Cross-reference the rate-limit budget: the retry wrapper recovers from transient throttle,
+     but the durable answer is project isolation; backoff is the seatbelt, not the fix.
+
+### Phase 4 — Verify
+
+4.1. Typecheck: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (NOT `npm run -w`).
+4.2. Default (no env flag) run stays green via `describe.skipIf` — confirm the suite still
+   skips cleanly without `SUPABASE_DEV_INTEGRATION=1`:
+   `cd apps/web-platform && ./node_modules/.bin/vitest run test/server/conversation-visibility.tenant-isolation.test.ts`
+   (expect "skipped", not failures).
+4.3. Behavioral run against a dedicated dev project (operator/automation step — see Domain
+   Review / IaC note): the conversation-visibility suite passes deterministically across ≥2
+   consecutive runs (failure count must be 0, not swing 7↔16).
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- [ ] `git grep -c 'toBe("P0001")' test/server/conversation-visibility.tenant-isolation.test.ts` returns `0`; `git grep -c 'toBe("42501")'` on the non-owner RPC test region returns ≥1.
+- [ ] The reframed Fix 2 test exercises a **non-owner (userB) and/or anon** actor for the deny assertion, and asserts the row is unchanged via a service-role read-back. (Verify: the deny-path client in the test is NOT `userAClient`.)
+- [ ] A `SOLEUR-DEBT:` marker with a `;`-delimited upgrade trigger exists adjacent to the `REVOKE UPDATE(visibility)` in `supabase/migrations/075_conversation_visibility.sql`; the stale "Column-level REVOKE is the correct defense" comment is corrected. (Verify: `git grep -n "SOLEUR-DEBT:" supabase/migrations/075_conversation_visibility.sql` returns 1 hit containing a `;`.)
+- [ ] No new migration file is added (Option A) UNLESS Option B was explicitly approved via AskUserQuestion. (Verify: `git status --porcelain supabase/migrations/` shows no new `.sql` file under default Option A.)
+- [ ] A `withGoTrueRetry` (or equivalently named) wrapper exists and wraps `createUser` in `createSharedWorkspaceMembers`, `deleteUser` in both `tearDownSharedWorkspace` and `tearDownTenantUser`, and the target test's `signInWithPassword` calls. (Verify: `git grep -n "withGoTrueRetry" test/` covers ≥4 distinct call sites + the definition.)
+- [ ] The retry wrapper rethrows non-rate-limit errors (does not mask real failures). (Verify by reading the wrapper: a non-429/non-throttle error is not swallowed.)
+- [ ] Total retry backoff budget is bounded under `hookTimeout` (20_000ms). (Verify: max attempts × max delay < 20s.)
+- [ ] `test/README.md` documents the dedicated-project requirement for behavioral suites (both env conventions) and adds the `conversation-visibility.tenant-isolation.test.ts` row + run command.
+- [ ] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` passes.
+- [ ] Default `vitest run` of the target file with NO env flag skips cleanly (no failures).
+
+### Post-merge (operator / automation)
+- [ ] Behavioral run of `conversation-visibility.tenant-isolation.test.ts` against a DEDICATED freshly-migrated dev Supabase project passes deterministically across ≥2 consecutive runs (0 failures both runs). Automation: gated by Supabase project provisioning; if a dedicated project is not yet stood up, this is the genuine operator step — but the migrate+run is `doppler run … vitest run …`, scriptable once the project exists (not a dashboard click).
+
+## Domain Review
+
+**Domains relevant:** Engineering (test-correctness), Legal/compliance (conditional — only if Option B migration touches grants).
+
+### Engineering
+**Status:** reviewed
+**Assessment:** Pure test + docs change. No production code path, route, or schema is modified
+under Option A. The reframed Fix 2 test asserts the SAME effective security contract that
+already holds in prod (verified live), so it strengthens the suite's fidelity without changing
+behavior. The harness retry wrapper is a determinism seatbelt; the durable fix is dedicated-project
+isolation (documented). Precedent-diff for the RLS/column-grant pattern is fully covered by the
+three cited learnings (2026-03-20, 2026-05-06, 2026-05-21) — no novel DB pattern introduced.
+
+### GDPR / Compliance Gate (conditional)
+**Status:** not invoked under Option A (default). Option A touches only a `.sql` *comment* (SOLEUR-DEBT
+marker) + corrected prose — no schema, grant, or policy change. If Implementation escalates to
+**Option B** (new durable migration altering `conversations` grants), `/soleur:gdpr-gate` MUST be
+invoked at that point (new `.sql` + grant surface crosses the `hr-gdpr-gate-on-regulated-data-surfaces`
+regex). Recorded here so the gate is not silently skipped if the option flips.
+
+### Product/UX Gate
+**Tier:** N/A — no UI surface. No file under `components/**`, `app/**/page.tsx`, or `app/**/layout.tsx`
+is created or edited (Files lists below are test/`.sql`-comment/`.md` only). Mechanical UI-surface
+override does not fire.
+
+## Observability
+
+Skipped — this is a test-suite + docs change. No Files-to-Edit under `apps/*/server/`,
+`apps/*/src/`, `apps/*/infra/`, or `plugins/*/scripts/`; no new infrastructure surface. The
+suite's own failure signal IS the observability (a red vitest run); the retry wrapper preserves
+real-failure visibility by rethrowing non-rate-limit errors (per `cq-silent-fallback-must-mirror-to-sentry`,
+the existing `tearDownTenantUser` console.warn-on-anonymise-error pattern is retained).
+
+## Infrastructure (IaC)
+
+Skipped — no new server, service, cron, secret, vendor, or persistent runtime process. The
+"dedicated dev Supabase project" referenced in Fix 3 is a documentation/gating requirement for
+*running* behavioral suites, not a resource this PR provisions. If/when a dedicated test project
+is provisioned, that is its own infra change governed by `hr-all-infrastructure-provisioning-servers`
+and out of scope here.
+
+## Files to Edit
+
+- `apps/web-platform/test/server/conversation-visibility.tenant-isolation.test.ts` — Fix 1 (P0001→42501); Fix 2 reframe (owner-CAN positive control + non-owner/anon deny); wrap `signInWithPassword` (Fix 3).
+- `apps/web-platform/supabase/migrations/075_conversation_visibility.sql` — SOLEUR-DEBT marker + correct the stale "column-level REVOKE is the correct defense" comment (Fix 2). **Comment-only edit; no DDL change.**
+- `apps/web-platform/test/helpers/workspace-members-fixtures.ts` — wrap `createUser` (`:80`) + `deleteUser` (`:173`) in `withGoTrueRetry` (Fix 3).
+- `apps/web-platform/test/helpers/tenant-isolation-teardown.ts` — wrap `deleteUser` (`:94`) in `withGoTrueRetry` (Fix 3).
+- `apps/web-platform/test/README.md` — dedicated-project gating doc + new suite row (Fix 3).
+
+## Files to Create
+
+- `apps/web-platform/test/helpers/gotrue-retry.ts` — `withGoTrueRetry` wrapper (OR fold into `mint-once.ts` per Phase 0.3 decision; if folded, this create entry drops).
+
+## Open Code-Review Overlap
+
+None — to be confirmed at /work via `gh issue list --label code-review --state open` against the
+Files-to-Edit paths (run the two-stage `--json` + standalone `jq --arg` form, not single-stage
+`gh --jq`).
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder text, or omits the threshold will fail `deepen-plan` Phase 4.6. (Present and filled: threshold `none`, with sensitive-`.sql`-path reason recorded.)
+- **Fix 2 is NOT a one-line swap.** The current test uses the OWNER client and relies on the no-op column-REVOKE. The reframe must change the deny-actor to non-owner/anon, or it asserts the wrong thing. A naive "expect 42501 → expect no error on owner" without adding the non-owner deny path silently drops the security assertion the test exists to make.
+- **PostgREST UPDATE matching 0 rows is NOT an error.** The non-owner/anon deny assertions must read the row back via service-role to prove it is unchanged — `error === null` with 0 rows affected is the RLS-deny shape for writes (mirrors the dual-shape SELECT-deny precedent at `:177-181`), not a test failure.
+- **Two env-var conventions exist** (`TENANT_INTEGRATION_TEST=1` vs `SUPABASE_DEV_INTEGRATION=1`). Do NOT rename the target test's `SUPABASE_DEV_INTEGRATION` gate — an existing operator/CI invocation may key on it. Document both; rename neither.
+- **The arguments named only `tenant-isolation-teardown.ts` for Fix 3**, but the failing suite's rate-limit hits are on `createSharedWorkspaceMembers` + `signInWithPassword` in `workspace-members-fixtures.ts` and the target test. Wrapping only the named teardown helper would leave the actual failure path (create/sign-in throttle) unprotected.
+- **Retry backoff budget must fit under `hookTimeout: 20_000`** (vitest.config.ts:37). An unbounded or too-generous backoff converts a recoverable throttle into a hook timeout — a worse failure mode.
+- **The column-REVOKE durable fix (Option B) IS achievable** (mig-006 pattern on `public.users` proves Supabase's blanket grant does not re-clobber a later migration's table-level REVOKE). The arguments' "would be re-clobbered" is imprecise. Option A (debt marker) is recommended on maintenance-cost grounds, not impossibility — present the trade-off honestly; escalate Option B via AskUserQuestion rather than silently choosing.
+- **Do NOT touch migs 065/066** (account-delete cascade) — verified correct and live; out of scope.
+
+## Test Scenarios
+
+1. **Fix 1**: non-owner RPC call → `error.code === "42501"` (was P0001).
+2. **Fix 2a**: owner direct UPDATE of own conversation visibility → succeeds (RLS allows).
+3. **Fix 2b**: non-owner (userB) UPDATE of owner's shared conversation → blocked (42501 OR 0 rows); row unchanged on service-role read-back.
+4. **Fix 2c**: anon UPDATE → 0 rows; row unchanged.
+5. **Fix 3**: simulate/observe a GoTrue 429 during create or sign-in → wrapper retries with backoff and the fixture succeeds (no AuthApiError surfaced to the test). Non-429 errors still propagate.
+6. **Skip path**: with no env flag, the whole `describe` skips cleanly (CI stays green).

--- a/knowledge-base/project/plans/2026-06-15-fix-tenant-integration-test-suite-breakage-plan.md
+++ b/knowledge-base/project/plans/2026-06-15-fix-tenant-integration-test-suite-breakage-plan.md
@@ -10,6 +10,60 @@ brand_survival_threshold: none
 
 # fix: tenant-integration test-suite breakage
 
+## Enhancement Summary
+
+**Deepened on:** 2026-06-15
+**Halt gates passed:** 4.6 User-Brand Impact (threshold `none`, sensitive-`.sql`-path scope-out present), 4.7 Observability (skip — test/docs only), 4.8 PAT-shaped var (no match), 4.9 UI-wireframe (no UI surface in Files lists).
+
+### Key Improvements
+1. **Fix 3 retry predicate is now grounded against the installed `@supabase/auth-js@2.99.2`** — was the load-bearing unknown. HTTP 429 surfaces as `AuthApiError` with `.status === 429` (the library does NOT auto-retry 429 — only 502/503/504 via `AuthRetryableFetchError`, `node_modules/@supabase/auth-js/dist/module/lib/fetch.js:6-14`), so the wrapper IS required. Canonical detect predicate pinned below.
+2. **Precedent-diff (Phase 4.4) confirms Option B (durable column protection) is achievable** — it is the exact mig-006 pattern, proving the arguments' "would be re-clobbered" is imprecise. The recommendation stays Option A (debt marker) on maintenance-cost grounds, but now honestly.
+3. **Verify-negative pass confirms Phase 2.1** — no table-level UPDATE revoke exists on `conversations`, so owner direct UPDATE succeeds under RLS (the original test relied solely on the no-op column-REVOKE).
+
+### New Considerations Discovered
+- The opaque `"Database error deleting user"` is a 500-class admin error (not a 429); the retry predicate must match it by message too, not only by 429 status.
+- mig 075's SECURITY DEFINER RPC grant shape (`REVOKE ALL … FROM PUBLIC, anon, authenticated, service_role; GRANT EXECUTE … TO authenticated`) is already correct — no RPC change in scope, consistent with "do not touch the RPC".
+
+## Research Insights — grounded findings
+
+### GoTrue retry predicate (Fix 3, auth-js@2.99.2)
+
+Verified against `node_modules/@supabase/auth-js/dist/module/lib/errors.d.ts:13-40` + `error-codes.d.ts:6` + `fetch.js:6-14`:
+
+- `AuthApiError.status` is always a `number` (required ctor arg); `.code` is `string | undefined`.
+- HTTP 429 → `AuthApiError` (`.status === 429`), NOT auto-retried by the library.
+- Rate-limit `code` enum values: `over_request_rate_limit`, `over_email_send_rate_limit`, `over_sms_send_rate_limit`.
+- `createUser`/`deleteUser`/`signInWithPassword` all resolve `{ data, error }` with `error: AuthError | AuthApiError` on failure.
+
+Canonical detect predicate for `withGoTrueRetry`:
+
+```ts
+function isRetryableGoTrueError(err: unknown): boolean {
+  const e = err as { status?: number; code?: string; message?: string } | null;
+  if (!e) return false;
+  const RATE_CODES = ["over_request_rate_limit", "over_email_send_rate_limit", "over_sms_send_rate_limit"];
+  return (
+    e.status === 429 ||
+    (e.code != null && RATE_CODES.includes(e.code)) ||
+    /rate limit|too many requests/i.test(e.message ?? "") ||
+    /database error deleting user/i.test(e.message ?? "") // opaque 500-class transient seen on shared dev
+  );
+}
+```
+
+### Precedent-Diff (Phase 4.4)
+
+| Pattern in plan | Repo precedent | Diff / verdict |
+|---|---|---|
+| Option B durable column protection (Phase 2.5) | `mig 006_restrict_tc_accepted_at_update.sql`: `REVOKE UPDATE ON TABLE public.users FROM authenticated; GRANT UPDATE (email) … TO authenticated;` | **Identical pattern.** Confirms Option B is durable (Supabase blanket grant runs once at init; later migration REVOKE wins). The arguments' "re-clobbered" claim is wrong; Option A is chosen on maintenance cost, not impossibility. |
+| SECURITY DEFINER RPC (NOT being changed) | `mig 075:105-108`: `REVOKE ALL … FROM PUBLIC, anon, authenticated, service_role; GRANT EXECUTE … TO authenticated` | Already canonical (matches `cq-pg-security-definer-search-path-pin-pg-temp` + the 2026-05-06 named-role-revoke learning). No change. |
+| SOLEUR-DEBT marker (Phase 2.4) | `knowledge-base/project/learnings/technical-debt/README.md` `// SOLEUR-DEBT: <ceiling>; <upgrade trigger>` | Marker form matches; `harvest-debt` will surface it. |
+
+### Verify-the-Negative pass
+
+- Plan claim "owner CAN update visibility via RLS" (Phase 2.1): **confirmed** — `conversations_owner_update` is `USING (user_id = auth.uid())` and there is NO table-level UPDATE revoke on `conversations` (`git grep "REVOKE.*conversations" supabase/migrations/` returns only the visibility column-REVOKE). Owner direct UPDATE succeeds.
+- Plan claim "non-owner/anon write blocked by RLS" (Phase 2.2/2.3): **confirmed** — no PERMISSIVE UPDATE policy admits a non-owner; userB/anon UPDATE matches 0 rows (write deny shape).
+
 ## Overview
 
 Running `apps/web-platform` tenant-integration suites against the shared dev Supabase
@@ -159,10 +213,11 @@ with assertions on the contract that actually holds in prod:
 3.1. **Shared GoTrue retry wrapper.** Add `withGoTrueRetry<T>(label, fn)` to a shared helper
    (new `test/helpers/gotrue-retry.ts`, or extend `mint-once.ts` to keep rate-limit logic in one
    place — decide at Phase 0.3 after reading `mint-once.ts`). Behavior:
-   - Retries on rate-limit signals: `AuthApiError` with `status === 429`, or message matching
-     `/rate limit|too many requests/i`, or the opaque `"Database error deleting user"` transient.
-     Verify the actual error shape supabase-js returns for GoTrue 429 (read
-     `node_modules/@supabase/auth-js` types or capture once) — do not assume the field names.
+   - Retries on rate-limit signals using the **grounded predicate from Research Insights**
+     (`isRetryableGoTrueError`): `err.status === 429`, OR `err.code ∈ {over_request_rate_limit,
+     over_email_send_rate_limit, over_sms_send_rate_limit}`, OR message matching
+     `/rate limit|too many requests/i`, OR the opaque `/database error deleting user/i` 500-class
+     transient. Verified against `@supabase/auth-js@2.99.2` (`errors.d.ts:13-40`, `error-codes.d.ts:6`).
    - Exponential backoff with jitter, bounded (e.g. base 500ms, factor 2, max ~5 attempts, cap ~8s),
      under the existing `hookTimeout: 20_000` ceiling (vitest.config.ts:37) — the total backoff
      budget MUST stay under hookTimeout or the fixture times out instead of recovering.

--- a/knowledge-base/project/specs/feat-one-shot-tenant-integration-test-fixes/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-tenant-integration-test-fixes/session-state.md
@@ -1,0 +1,18 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-15-fix-tenant-integration-test-suite-breakage-plan.md
+- Status: complete
+
+### Errors
+None. CWD verified on first call. Both soleur:plan and soleur:deepen-plan ran to completion; all four deepen-plan halt gates (4.6/4.7/4.8/4.9) passed.
+
+### Decisions
+- Premise reconciliation corrected three framings: (1) Fix 2 mechanism is table-level UPDATE grant subsuming the column-level REVOKE (silent no-op), not Supabase blanket-grant re-clobber; (2) the durable fix (Option B, mig-006 pattern) IS achievable — plan recommends Option A (debt marker) on maintenance-cost grounds with an AskUserQuestion escalation for Option B; (3) Fix 3 rate-limit hits are on create + sign-in path (createSharedWorkspaceMembers + signInWithPassword), not only tenant-isolation-teardown.ts.
+- Fix 2 reframe: move deny assertion from owner client to non-owner(userB)/anon with service-role read-back (PostgREST UPDATE matching 0 rows is the write-deny shape, not an error).
+- Two env-var conventions documented (SUPABASE_DEV_INTEGRATION=1 vs TENANT_INTEGRATION_TEST=1); renamed neither.
+- GoTrue retry predicate grounded against @supabase/auth-js@2.99.2 (429 AuthApiError.status; over_*_rate_limit codes; opaque "Database error deleting user" 500-class transient via message match).
+- Scoped out: no production-code change, no touching migs 065/066, no UI, no infra, no new dependency; threshold none.
+
+### Components Invoked
+soleur:plan, soleur:deepen-plan, Explore x2, Bash/Read/Write/Edit

--- a/knowledge-base/project/specs/feat-one-shot-tenant-integration-test-fixes/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-tenant-integration-test-fixes/tasks.md
@@ -1,0 +1,41 @@
+---
+title: "Tasks: fix tenant-integration test-suite breakage"
+plan: knowledge-base/project/plans/2026-06-15-fix-tenant-integration-test-suite-breakage-plan.md
+lane: cross-domain
+date: 2026-06-15
+---
+
+# Tasks — fix tenant-integration test-suite breakage
+
+Derived from `2026-06-15-fix-tenant-integration-test-suite-breakage-plan.md`. Do NOT touch
+account-delete cascade migs 065/066 — verified correct/live, out of scope.
+
+## Phase 0 — Preconditions
+
+- [ ] 0.1 Confirm line anchors: `toBe("P0001")` in target test; `ERRCODE = 'insufficient_privilege'` + `REVOKE UPDATE(visibility)` in mig 075.
+- [ ] 0.2 Enumerate all GoTrue call sites: `createUser`/`deleteUser` in `test/helpers/`, inline `createUser` loops in `*.tenant-isolation.test.ts`, all `signInWithPassword`.
+- [ ] 0.3 Read `test/helpers/mint-once.ts`; decide whether `withGoTrueRetry` is a new file or folds into mint-once.
+
+## Phase 1 — Fix 1: stale assertion
+
+- [ ] 1.1 In `conversation-visibility.tenant-isolation.test.ts` "Non-owner cannot toggle visibility via RPC", change `toBe("P0001")` → `toBe("42501")`.
+
+## Phase 2 — Fix 2: reframe column-REVOKE test
+
+- [ ] 2.1 Replace owner-relies-on-REVOKE test with owner-CAN positive control (RLS allows; restore fixture state).
+- [ ] 2.2 Add non-owner (userB) UPDATE deny: dual-shape (42501 OR 0 rows) + service-role read-back confirms unchanged.
+- [ ] 2.3 Add anon UPDATE matches-0-rows + read-back unchanged.
+- [ ] 2.4 Add SOLEUR-DEBT marker (ceiling`;`trigger) adjacent to `REVOKE UPDATE(visibility)` in mig 075; correct the stale "column-level REVOKE is the correct defense" comment. Comment-only — no DDL change, no new migration.
+- [ ] 2.5 (Conditional) If Option B (durable migration) is argued by review/deepen-plan, escalate via AskUserQuestion BEFORE implementing; Option A (marker) is the default.
+
+## Phase 3 — Fix 3: harness determinism
+
+- [ ] 3.1 Add `withGoTrueRetry(label, fn)` — retry on 429/rate-limit/"Database error deleting user"; bounded exp-backoff+jitter under hookTimeout(20s); rethrow non-rate-limit errors.
+- [ ] 3.2 Wrap: `createUser` (workspace-members-fixtures:80), `deleteUser` (workspace-members-fixtures:173 + tenant-isolation-teardown:94), `signInWithPassword` (target test ×3).
+- [ ] 3.3 Update `test/README.md`: dedicated-project requirement for behavioral suites (both env conventions); add conversation-visibility suite row + run command.
+
+## Phase 4 — Verify
+
+- [ ] 4.1 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` passes.
+- [ ] 4.2 No-env-flag `vitest run` of target file skips cleanly (no failures).
+- [ ] 4.3 (Post-merge / dedicated project) Behavioral run passes deterministically ×2 (0 failures both).

--- a/knowledge-base/project/specs/feat-one-shot-tenant-integration-test-fixes/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-tenant-integration-test-fixes/tasks.md
@@ -12,30 +12,30 @@ account-delete cascade migs 065/066 — verified correct/live, out of scope.
 
 ## Phase 0 — Preconditions
 
-- [ ] 0.1 Confirm line anchors: `toBe("P0001")` in target test; `ERRCODE = 'insufficient_privilege'` + `REVOKE UPDATE(visibility)` in mig 075.
-- [ ] 0.2 Enumerate all GoTrue call sites: `createUser`/`deleteUser` in `test/helpers/`, inline `createUser` loops in `*.tenant-isolation.test.ts`, all `signInWithPassword`.
-- [ ] 0.3 Read `test/helpers/mint-once.ts`; decide whether `withGoTrueRetry` is a new file or folds into mint-once.
+- [x] 0.1 Confirm line anchors: `toBe("P0001")` in target test; `ERRCODE = 'insufficient_privilege'` + `REVOKE UPDATE(visibility)` in mig 075.
+- [x] 0.2 Enumerate all GoTrue call sites: `createUser`/`deleteUser` in `test/helpers/`, inline `createUser` loops in `*.tenant-isolation.test.ts`, all `signInWithPassword`.
+- [x] 0.3 Read `test/helpers/mint-once.ts`; decide whether `withGoTrueRetry` is a new file or folds into mint-once.
 
 ## Phase 1 — Fix 1: stale assertion
 
-- [ ] 1.1 In `conversation-visibility.tenant-isolation.test.ts` "Non-owner cannot toggle visibility via RPC", change `toBe("P0001")` → `toBe("42501")`.
+- [x] 1.1 In `conversation-visibility.tenant-isolation.test.ts` "Non-owner cannot toggle visibility via RPC", change `toBe("P0001")` → `toBe("42501")`.
 
 ## Phase 2 — Fix 2: reframe column-REVOKE test
 
-- [ ] 2.1 Replace owner-relies-on-REVOKE test with owner-CAN positive control (RLS allows; restore fixture state).
-- [ ] 2.2 Add non-owner (userB) UPDATE deny: dual-shape (42501 OR 0 rows) + service-role read-back confirms unchanged.
-- [ ] 2.3 Add anon UPDATE matches-0-rows + read-back unchanged.
-- [ ] 2.4 Add SOLEUR-DEBT marker (ceiling`;`trigger) adjacent to `REVOKE UPDATE(visibility)` in mig 075; correct the stale "column-level REVOKE is the correct defense" comment. Comment-only — no DDL change, no new migration.
-- [ ] 2.5 (Conditional) If Option B (durable migration) is argued by review/deepen-plan, escalate via AskUserQuestion BEFORE implementing; Option A (marker) is the default.
+- [x] 2.1 Replace owner-relies-on-REVOKE test with owner-CAN positive control (RLS allows; restore fixture state).
+- [x] 2.2 Add non-owner (userB) UPDATE deny: dual-shape (42501 OR 0 rows) + service-role read-back confirms unchanged.
+- [x] 2.3 Add anon UPDATE matches-0-rows + read-back unchanged.
+- [x] 2.4 Add SOLEUR-DEBT marker (ceiling`;`trigger). **Deviation:** marker placed in the reframed test's AC8 comment block, NOT in mig 075 — editing an already-applied migration's bytes (even a comment) trips the `content_sha` drift probe (dev/prd `_schema_migrations` ledger hash would diverge from origin/main, requiring a prod ledger reconciliation). mig 075 left byte-identical to origin/main.
+- [x] 2.5 (Conditional) N/A — went with Option A (debt marker) per plan default; no Option B escalation needed.
 
 ## Phase 3 — Fix 3: harness determinism
 
-- [ ] 3.1 Add `withGoTrueRetry(label, fn)` using the grounded `isRetryableGoTrueError` predicate (auth-js@2.99.2: `status===429` | `code ∈ over_*_rate_limit` | `/rate limit|too many requests/i` | `/database error deleting user/i`); bounded exp-backoff+jitter under hookTimeout(20s); rethrow non-rate-limit errors.
-- [ ] 3.2 Wrap: `createUser` (workspace-members-fixtures:80), `deleteUser` (workspace-members-fixtures:173 + tenant-isolation-teardown:94), `signInWithPassword` (target test ×3).
-- [ ] 3.3 Update `test/README.md`: dedicated-project requirement for behavioral suites (both env conventions); add conversation-visibility suite row + run command.
+- [x] 3.1 Add `withGoTrueRetry(label, fn)` using the grounded `isRetryableGoTrueError` predicate (auth-js@2.99.2: `status===429` | `code ∈ over_*_rate_limit` | `/rate limit|too many requests/i` | `/database error deleting user/i`); bounded exp-backoff+jitter under hookTimeout(20s); rethrow non-rate-limit errors.
+- [x] 3.2 Wrap: `createUser` (workspace-members-fixtures:80), `deleteUser` (workspace-members-fixtures:173 + tenant-isolation-teardown:94), `signInWithPassword` (target test ×3).
+- [x] 3.3 Update `test/README.md`: dedicated-project requirement for behavioral suites (both env conventions); add conversation-visibility suite row + run command.
 
 ## Phase 4 — Verify
 
-- [ ] 4.1 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` passes.
-- [ ] 4.2 No-env-flag `vitest run` of target file skips cleanly (no failures).
-- [ ] 4.3 (Post-merge / dedicated project) Behavioral run passes deterministically ×2 (0 failures both).
+- [x] 4.1 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` passes.
+- [x] 4.2 No-env-flag `vitest run` of target file skips cleanly (no failures).
+- [x] 4.3 Ran ×1 against live dev (`SUPABASE_DEV_INTEGRATION=1`): 11/11 pass (was 2/9 failing pre-fix). Full web-platform vitest suite: 10115 passed / 0 failed. The stricter ×2-on-dedicated-project determinism check remains the post-merge form (rate-limit-heavy full batch).

--- a/knowledge-base/project/specs/feat-one-shot-tenant-integration-test-fixes/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-tenant-integration-test-fixes/tasks.md
@@ -30,7 +30,7 @@ account-delete cascade migs 065/066 — verified correct/live, out of scope.
 
 ## Phase 3 — Fix 3: harness determinism
 
-- [ ] 3.1 Add `withGoTrueRetry(label, fn)` — retry on 429/rate-limit/"Database error deleting user"; bounded exp-backoff+jitter under hookTimeout(20s); rethrow non-rate-limit errors.
+- [ ] 3.1 Add `withGoTrueRetry(label, fn)` using the grounded `isRetryableGoTrueError` predicate (auth-js@2.99.2: `status===429` | `code ∈ over_*_rate_limit` | `/rate limit|too many requests/i` | `/database error deleting user/i`); bounded exp-backoff+jitter under hookTimeout(20s); rethrow non-rate-limit errors.
 - [ ] 3.2 Wrap: `createUser` (workspace-members-fixtures:80), `deleteUser` (workspace-members-fixtures:173 + tenant-isolation-teardown:94), `signInWithPassword` (target test ×3).
 - [ ] 3.3 Update `test/README.md`: dedicated-project requirement for behavioral suites (both env conventions); add conversation-visibility suite row + run command.
 


### PR DESCRIPTION
## Summary

Test-correctness and harness-determinism fixes to the opt-in tenant-integration suite (`SUPABASE_DEV_INTEGRATION=1` / `TENANT_INTEGRATION_TEST=1`). No production code paths change; the account-delete cascade DDL (migrations 065/066) was verified correct on dev and prd via read-only catalog introspection and is untouched.

- **Stale assertion** — `conversation-visibility.tenant-isolation.test.ts` asserted the non-owner RPC raises `P0001`; migration 075 has always raised `insufficient_privilege` (SQLSTATE `42501`). Latent since the suite landed, hidden because it is opt-in and never runs in CI. Fixed to `42501`.
- **RLS-effective reframe** — the column-REVOKE test now asserts the enforced contract (`conversations_owner_update` — owner-only writes; non-owner + anon denied, proven by service-role read-back of the unchanged value). Migration 075's `REVOKE UPDATE(visibility)` is a no-op on a real Supabase project (the table-level `GRANT` subsumes it; confirmed live on dev + prd). Recorded as a `SOLEUR-DEBT` marker in the test — **not** in the applied migration, since a byte change there would diverge the `content_sha` drift probe.
- **Determinism** — new `test/helpers/gotrue-retry.ts` (`withGoTrueRetry` + `isRetryableGoTrueError`, unit-tested 11/11) wraps synthetic-user create / sign-in / delete to absorb GoTrue rate limits and the transient `Database error deleting user`; `test/README.md` documents the dedicated-project requirement for behavioral suites.

## Changelog

### Web Platform (tests only)
- Fixed a stale SQLSTATE assertion and reframed the conversation-visibility RLS test to the enforced owner-only-write contract.
- Added a bounded GoTrue retry helper and wired it into the synthetic-user fixtures to make the opt-in integration suites deterministic under rate limits.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full web-platform vitest: **10115 passed / 0 failed**
- [x] `gotrue-retry` unit test: **11/11**
- [x] Reframed conversation-visibility suite against live dev: **11/11** (was 2/9 pre-fix)

Generated with [Claude Code](https://claude.com/claude-code)
