### PR TITLE
content(feature-tweet): record cc-checkpoint ship post as published (Bluesky live)

### DIFF
--- a/knowledge-base/marketing/distribution-content/2026-06-15-checkpoint-in-flight-work-on-disconnect.md
+++ b/knowledge-base/marketing/distribution-content/2026-06-15-checkpoint-in-flight-work-on-disconnect.md
@@ -1,9 +1,9 @@
 ---
 title: "Your in-progress work now survives a dropped connection"
 type: feature-launch
-publish_date: ""
+publish_date: "2026-06-15"
 channels: x, bluesky
-status: draft
+status: published
 pr_reference: "#5362"
 issue_reference: "#5356"
 ---


### PR DESCRIPTION
## Summary

Records the cc-soleur-go disconnect-checkpoint ship post (#5362) as `status: published` after `content-publisher.sh` posted it.

- **Bluesky: published live** (`at://did:plc:56qufk67vlhnn3sc2zraagph/.../3modxsmtvw72o`)
- **X: not posted** — `X_ALLOW_POST` gate off; fallback issue #5378 filed.

Merging this keeps main's distribution-content in sync with reality (prevents the stale-content duplicate-warning class).

## Changelog

### Marketing
- Mark the cc-checkpoint ship post published (Bluesky live).

## Test plan
- [x] content-publisher.sh rc=0 (Bluesky ok, X gated → fallback issue)

Generated with [Claude Code](https://claude.com/claude-code)