### PR TITLE
feat(observability): outbound-email send-failure Sentry alert (#5325 follow-up)

### DIFF
--- a/.github/workflows/apply-sentry-infra.yml
+++ b/.github/workflows/apply-sentry-infra.yml
@@ -247,6 +247,7 @@ jobs:
             -target=sentry_issue_alert.kb_db_error \
             -target=sentry_issue_alert.egress_blocked \
             -target=sentry_issue_alert.stale_bot_pr \
+            -target=sentry_issue_alert.outbound_email_send_failure \
             -no-color -input=false -out=tfplan
           rc=$?
           if [[ $rc -ne 0 ]]; then

--- a/apps/web-platform/infra/sentry/issue-alerts.tf
+++ b/apps/web-platform/infra/sentry/issue-alerts.tf
@@ -749,3 +749,75 @@ resource "sentry_issue_alert" "stale_bot_pr" {
     ignore_changes = [environment]
   }
 }
+
+# server/email-triage/outbound.ts: agent-native cold-outbound email (#5325).
+# Pages on ANY failure in `sendCompliantOutbound`. The four emit sites all call
+# reportSilentFallback with `feature=outbound-email`:
+#   - outbound.suppression_check — suppression-lookup DB error (fail-closed: the
+#     send is BLOCKED, so a recurring failure silently halts all outbound).
+#   - outbound.dedup_check       — dedup-lookup DB error (also fail-closed).
+#   - outbound.send_error        — Resend API send failure (the email never went).
+#   - outbound.record_error      — record_outbound_send failed AFTER a successful
+#     send: the email WENT OUT but the WORM `outbound_sends` audit row is missing.
+#     This is a GDPR Art. 30 accountability gap (an un-logged send), so it must
+#     page even though the user-visible send "succeeded".
+# Detection already exists (reportSilentFallback → captureException); this is the
+# missing NOTIFICATION layer (hr-no-dashboard-eyeball-pull-data-yourself).
+#
+# feature-ONLY filter (no `op` IS_IN): `feature=outbound-email` is dedicated to
+# outbound.ts and EVERY emit site is an operator-actionable failure (all four are
+# reportSilentFallback — there is NO routine info/warn emit under this feature;
+# pinned by test/sentry-outbound-email-alert-op-contract.test.ts, which fails
+# closed if a non-error emit is ever added). Mirrors workspace_sync_health's
+# feature-only rationale and future-proofs new failure ops. A NEW non-error emit
+# under feature=outbound-email would over-page — the contract test guards that.
+#
+# `action_match="any"` + first_seen/reappeared/regression: lifecycle states are
+# mutually exclusive (a captured event is exactly one) so "all" is never
+# satisfiable; reappeared+regression re-page a recurrence after the founder
+# resolves the Sentry issue. Distinct `frequency=16` avoids Sentry POST-time
+# exact-duplicate dedup (taken: 5,10,11,12,13,14,15,30,60,61,62; 16 free
+# 2026-06-15) — dedup keys on action_match+filter_match+frequency+actions-shape,
+# NOT conditions.
+resource "sentry_issue_alert" "outbound_email_send_failure" {
+  organization = var.sentry_org
+  project      = data.sentry_project.web_platform.slug
+  name         = "outbound-email-send-failure"
+  action_match = "any"
+  filter_match = "all"
+  frequency    = 16
+
+  conditions_v2 = [
+    { first_seen_event = {} },
+    { reappeared_event = {} },
+    { regression_event = {} },
+  ]
+  filters_v2 = [
+    {
+      tagged_event = {
+        key   = "feature"
+        match = "EQUAL"
+        value = "outbound-email"
+      }
+    },
+  ]
+  # N=1 accepted risk (mirrors kb_sync_silent_failure / chat_message_save_failure):
+  # IssueOwners has no ownership rule on this project → falls through to
+  # ActiveMembers, paging the active founder + the ops@soleur.ai seat (added for
+  # this feature). The events carry only a recipient HASH (keyed HMAC), op, and
+  # pg_code/Resend-error tags — NO plaintext recipient or body — so the
+  # fallthrough does not over-disclose. Revisit recipient pinning
+  # (target_type="Member") before the first non-ops Sentry seat.
+  actions_v2 = [
+    {
+      notify_email = {
+        target_type      = "IssueOwners"
+        fallthrough_type = "ActiveMembers"
+      }
+    },
+  ]
+
+  lifecycle {
+    ignore_changes = [environment]
+  }
+}

--- a/apps/web-platform/test/sentry-outbound-email-alert-op-contract.test.ts
+++ b/apps/web-platform/test/sentry-outbound-email-alert-op-contract.test.ts
@@ -71,7 +71,10 @@ describe("outbound-email-send-failure alert feature contract", () => {
     // Every call carrying the feature tag must be a reportSilentFallback(...)
     // invocation. We assert no info/warn helper appears anywhere paired with the
     // feature in this file (the file's only emit helper is reportSilentFallback).
-    expect(producer).not.toContain("reportSilentInfo");
+    // Helper names verified against server/observability.ts exports
+    // (reportSilentFallback / warnSilentFallback / infoSilentFallback) — a typo'd
+    // name here would make the guard a silent no-op.
+    expect(producer).not.toContain("infoSilentFallback");
     expect(producer).not.toContain("warnSilentFallback");
     // And the feature tag must never be introduced without the error helper
     // being imported (defense against a future refactor swapping helpers).

--- a/apps/web-platform/test/sentry-outbound-email-alert-op-contract.test.ts
+++ b/apps/web-platform/test/sentry-outbound-email-alert-op-contract.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+// Cross-artifact contract test for the outbound-email send-failure alert (#5325
+// follow-up).
+//
+// The `outbound-email-send-failure` Sentry issue-alert filters on
+// `feature == "outbound-email"` ONLY (no `op` filter). Every event
+// server/email-triage/outbound.ts emits carries that feature tag via
+// `reportSilentFallback` and is operator-actionable:
+//   - outbound.suppression_check / outbound.dedup_check — fail-closed DB errors
+//     that silently HALT outbound sends.
+//   - outbound.send_error — the Resend send failed (email never went).
+//   - outbound.record_error — the email WENT OUT but the WORM `outbound_sends`
+//     audit row is missing (a GDPR Art. 30 accountability gap).
+// Feature-only matching covers all four and future-proofs new failure ops, the
+// same rationale as workspace_sync_health.
+//
+// Because the match is feature-only, two things are load-bearing and pinned here
+// so a regression breaks CI instead of silently zeroing the alert's matches
+// (the user-reports-it-before-we-know failure mode):
+//   1. The `feature` tag string itself must appear in BOTH artifacts (a rename
+//      in either silently darks the alert).
+//   2. The feature-only filter is SAFE ONLY IF every emit under
+//      `feature: "outbound-email"` is an error-level `reportSilentFallback`. A
+//      future routine `reportSilentInfo` / `warnSilentFallback` emit under the
+//      same feature would over-page the founder. The reverse-guard below fails
+//      closed if a non-error emit is ever added — forcing the author to either
+//      change the emit level or narrow the alert to an `op` IS_IN filter.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const tf = readFileSync(join(here, "../infra/sentry/issue-alerts.tf"), "utf8");
+const producer = readFileSync(
+  join(here, "../server/email-triage/outbound.ts"),
+  "utf8",
+);
+
+const FEATURE_TAG = "outbound-email";
+
+describe("outbound-email-send-failure alert feature contract", () => {
+  it("the feature tag appears in the outbound.ts emit sites", () => {
+    expect(producer).toContain(`feature: "${FEATURE_TAG}"`);
+  });
+
+  it("the feature tag appears in the alert filter in issue-alerts.tf", () => {
+    expect(tf).toContain(`value = "${FEATURE_TAG}"`);
+  });
+
+  it("issue-alerts.tf declares the outbound_email_send_failure alert resource", () => {
+    expect(tf).toContain(
+      'resource "sentry_issue_alert" "outbound_email_send_failure"',
+    );
+  });
+
+  it("the -target wiring guards that the apply workflow creates the rule", () => {
+    const wf = readFileSync(
+      join(here, "../../../.github/workflows/apply-sentry-infra.yml"),
+      "utf8",
+    );
+    expect(wf).toContain(
+      "-target=sentry_issue_alert.outbound_email_send_failure",
+    );
+  });
+
+  // Reverse-guard: feature-only matching is safe only while EVERY emit under
+  // feature: "outbound-email" is error-level. Non-error emit helpers must not
+  // carry this feature tag, or the alert would over-page on routine events.
+  it("emits feature: \"outbound-email\" only via error-level reportSilentFallback", () => {
+    // Every call carrying the feature tag must be a reportSilentFallback(...)
+    // invocation. We assert no info/warn helper appears anywhere paired with the
+    // feature in this file (the file's only emit helper is reportSilentFallback).
+    expect(producer).not.toContain("reportSilentInfo");
+    expect(producer).not.toContain("warnSilentFallback");
+    // And the feature tag must never be introduced without the error helper
+    // being imported (defense against a future refactor swapping helpers).
+    expect(producer).toContain("reportSilentFallback");
+  });
+});


### PR DESCRIPTION
## What

Adds the missing **NOTIFICATION layer** for the agent-native cold-outbound email feature (#5325 / merged in #5326). The outbound chokepoint already emits `reportSilentFallback` with `feature=outbound-email` on all four failure paths, but **no Sentry alert routed them** — they landed in Sentry un-notified (`hr-no-dashboard-eyeball-pull-data-yourself`).

## Why it matters

`server/email-triage/outbound.ts` fails on four operator-actionable paths, all worth paging:

| op | meaning | impact |
|---|---|---|
| `outbound.suppression_check` | suppression-lookup DB error | **fail-closed** — silently halts all outbound |
| `outbound.dedup_check` | dedup-lookup DB error | **fail-closed** — silently halts all outbound |
| `outbound.send_error` | Resend API send failed | email never went out |
| `outbound.record_error` | `record_outbound_send` failed *after* a successful send | email **went out** but the WORM `outbound_sends` audit row is missing — a **GDPR Art. 30 accountability gap** |

Without this rule, any of these sits latent until someone eyeballs the dashboard.

## Changes

- **`infra/sentry/issue-alerts.tf`** — new `sentry_issue_alert.outbound_email_send_failure`. **Feature-only filter** (every emit site is error-level `reportSilentFallback`; future-proofs new failure ops — same rationale as `workspace_sync_health`). `action_match=any` + first_seen/reappeared/regression re-pages recurrences after the founder resolves the issue. `frequency=16` (verified free). Notifies `IssueOwners → ActiveMembers`, which now includes the **`ops@soleur.ai`** seat added during the go-live.
- **`.github/workflows/apply-sentry-infra.yml`** — adds the rule to the plan `-target` list (APPLY-CREATED, not import-only).
- **`test/sentry-outbound-email-alert-op-contract.test.ts`** — pins the `feature` tag in both artifacts + the `-target` wiring, with a **reverse-guard** that fails closed if a non-error emit (`reportSilentInfo`/`warnSilentFallback`) is ever added under `feature=outbound-email` (which would make the feature-only filter over-page).

## Verification

- `vitest run test/sentry-outbound-email-alert-op-contract.test.ts` → 5/5 pass
- `terraform fmt -check` → clean; `terraform validate` → **Success** (only the pre-existing/accepted `sentry_issue_alert` deprecation warnings, documented in the file header until provider GA)

## Note (out of scope)

`sentry_issue_alert.kb_sync_silent_failure` is declared in `issue-alerts.tf` but **missing from the apply `-target` list** — a pre-existing latent gap (the rule is never applied). Not touched here; flagging for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)