### PR TITLE
fix(observability): wire kb_sync_silent_failure into the sentry apply -target list

### DIFF
--- a/.github/workflows/apply-sentry-infra.yml
+++ b/.github/workflows/apply-sentry-infra.yml
@@ -248,6 +248,7 @@ jobs:
             -target=sentry_issue_alert.egress_blocked \
             -target=sentry_issue_alert.stale_bot_pr \
             -target=sentry_issue_alert.outbound_email_send_failure \
+            -target=sentry_issue_alert.kb_sync_silent_failure \
             -no-color -input=false -out=tfplan
           rc=$?
           if [[ $rc -ne 0 ]]; then

--- a/apps/web-platform/test/sentry-kb-sync-silent-failure-alert-op-contract.test.ts
+++ b/apps/web-platform/test/sentry-kb-sync-silent-failure-alert-op-contract.test.ts
@@ -96,4 +96,21 @@ describe("kb-sync-silent-failure alert op/feature contract", () => {
     const isInValue = OP_SLUGS.map((o) => o.slug).join(",");
     expect(tfBlock).toContain(isInValue);
   });
+
+  // Regression guard (PR follow-up to #5380): this rule is APPLY-CREATED, so it
+  // is inert unless the apply workflow `-target`s it. It was declared in
+  // issue-alerts.tf (#4918, re-pointed #5005) but never added to the apply
+  // -target list, so the live Sentry rule was never created and the alert sat
+  // dark — the exact "user reports it before we know" failure mode the rule
+  // exists to prevent. A declared-but-untargeted alert is silently inert; pin
+  // the wiring so dropping it breaks CI.
+  it("is wired into the apply-sentry-infra.yml -target list (else it never applies)", () => {
+    const wf = readFileSync(
+      join(here, "../../../.github/workflows/apply-sentry-infra.yml"),
+      "utf8",
+    );
+    expect(wf).toContain(
+      "-target=sentry_issue_alert.kb_sync_silent_failure",
+    );
+  });
 });


### PR DESCRIPTION
## Problem

`sentry_issue_alert.kb_sync_silent_failure` (added #4918, re-pointed #5005) is **APPLY-CREATED** — like `kb_db_error`, `workspace_sync_health`, etc., it only exists in Sentry if the apply workflow `-target`s it. But it was declared in `issue-alerts.tf` and **never added to `apply-sentry-infra.yml`'s `-target` list**, and there is no untargeted apply covering issue-alerts (the untargeted apply is scoped to monitors per the file header).

**Consequence:** the live Sentry rule was never created. The kb/sync silent-failure alert — which exists *because* PIR #4913 sat **~19 days latent** before the founder hit a dead button — has itself been **dark** since it was declared. A declared-but-untargeted alert is silently inert.

Found while verifying the #5380 apply.

## Fix

- **`.github/workflows/apply-sentry-infra.yml`** — add the missing `-target=sentry_issue_alert.kb_sync_silent_failure` (placed inside the backslash-continued command, after the merged `outbound_email_send_failure`). On next apply terraform **creates** the rule (`frequency=12` is unique → no POST-time dedup collision; a create is not a destroy → no `[ack-destroy]` needed).
- **`test/sentry-kb-sync-silent-failure-alert-op-contract.test.ts`** — regression guard asserting the rule is in the `-target` list, so a declared-but-untargeted alert breaks CI. Mirrors the guard added for `outbound_email_send_failure` in #5380.

## Verification

- `vitest run test/sentry-kb-sync-silent-failure-alert-op-contract.test.ts` → 5/5 pass
- The PR `plan` CI step will show terraform planning to **create** the rule cleanly; post-merge apply will report `1 added`.

Companion to the audit-gate-retry fix (separate PR) — both harden the sentry-apply path that silently skipped apply during the #5380 go-live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)