### PR TITLE
fix(observability): retry audit fetches so a transient timeout can't silently skip sentry apply

### DIFF
--- a/apps/web-platform/scripts/sentry-monitors-audit.sh
+++ b/apps/web-platform/scripts/sentry-monitors-audit.sh
@@ -220,12 +220,20 @@ if [[ -n "$host_region" && "$host_region" != "$dsn_cluster" ]]; then
 fi
 
 # --- Fetch monitors (org-wide) -------------------------------------------
+# Both fetches use curl_retry (not bare curl): a transient timeout here under
+# `set -euo pipefail` would propagate curl's exit 28 and abort the whole audit
+# step, which in the apply-sentry-infra.yml workflow SKIPS the plan+apply steps —
+# a transient Sentry-EU blip silently darks the apply (observed on the #5325
+# go-live: the #5380 apply failed exit 28 on this exact path and only succeeded
+# on re-run). curl_retry always returns 0 (last attempt's output), so a genuine
+# persistent failure surfaces at the JSON-shape validation below with a clear
+# "response is not a JSON array" message + exit 1 — never a cryptic exit 28.
 fetch_monitors() {
   if [[ -n "${SENTRY_FIXTURE_MONITORS:-}" ]]; then
     cat "$SENTRY_FIXTURE_MONITORS"
     return
   fi
-  curl -s --max-time 10 \
+  curl_retry -s --max-time 10 \
     -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
     "https://${api_host}/api/0/organizations/${SENTRY_ORG}/monitors/"
 }
@@ -237,11 +245,11 @@ fetch_rules() {
   fi
   if [[ -z "$SENTRY_PROJECT" ]]; then
     # Org-wide alert-rules endpoint (metric alerts) — best-effort fallback.
-    curl -s --max-time 10 \
+    curl_retry -s --max-time 10 \
       -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
       "https://${api_host}/api/0/organizations/${SENTRY_ORG}/alert-rules/"
   else
-    curl -s --max-time 10 \
+    curl_retry -s --max-time 10 \
       -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
       "https://${api_host}/api/0/projects/${SENTRY_ORG}/${SENTRY_PROJECT}/rules/"
   fi


### PR DESCRIPTION
## Problem

The Sentry audit-gate script (`sentry-monitors-audit.sh`) is a **pre-apply step** in `apply-sentry-infra.yml`. Its `fetch_monitors` / `fetch_rules` used **bare `curl --max-time 10`** — no retry, no `|| true`. Under `set -euo pipefail`, a transient timeout propagates curl's **exit 28** and aborts the audit step, which **skips the plan + apply steps**. A transient Sentry-EU API blip therefore silently darks the entire apply (red run, **nothing applied**).

**Not hypothetical:** during the #5325 outbound-email go-live, the **#5380 post-merge apply failed `exit 28` on this exact fetch path** and only applied the new rule on a manual re-run. Had no one been watching, the rule would never have gone live.

## Why the gates didn't hit this

The script already has a `curl_retry` helper (3 attempts, 5s/10s backoff) — used by the four destination-controllability gates, which is why *those* fail with clear `exit 1` messages, never `exit 28`. The two fetches were the only network calls left on bare `curl`.

## Fix

Route both fetches through `curl_retry`. Since `curl_retry` always returns `0` (last attempt's output), a genuinely **persistent** failure now surfaces at the existing JSON-shape validation with a clear `response is not a JSON array` + `exit 1` — never a cryptic `exit 28` that silently skips apply.

## Verification

- `bash -n` clean
- `sentry-monitors-audit.test.sh` → **14/14 pass** (no behavior change under test mode — the `SENTRY_FIXTURE_*` branches short-circuit before the curl)

Companion to the `kb_sync` `-target` wiring fix (#5383) — both harden the sentry-apply path exposed during the #5380 go-live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)