### PR TITLE
test(ship): assert PR-title guard present in Phase 6

### DIFF
--- a/plugins/soleur/test/ship-pr-title-guard.test.ts
+++ b/plugins/soleur/test/ship-pr-title-guard.test.ts
@@ -1,0 +1,52 @@
+// PR-title guard — verifies plugins/soleur/skills/ship/SKILL.md Phase 6 keeps the
+// HARD GATE that blocks `gh pr ready` / auto-merge while the PR title is still the
+// `WIP: <branch>` draft default produced by worktree-manager.sh draft-pr.
+//
+// The squash-merge commit subject = PR title, so an un-updated WIP title lands a
+// `WIP: feat-… (#N)` commit in permanent history (the #5371/PR #5373 regression).
+// The guard is documentation an LLM agent executes at /ship time; this test is the
+// only safety net against the guard being silently dropped in a future SKILL.md edit.
+//
+// Test harness: bun:test (matches sibling tests in plugins/soleur/test/*.ts).
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { resolve } from "path";
+import { readFileSync } from "fs";
+
+// plugins/soleur/test/ → ../../.. is the worktree (repo) root
+const REPO_ROOT = resolve(import.meta.dir, "../../..");
+const SHIP_SKILL = resolve(REPO_ROOT, "plugins/soleur/skills/ship/SKILL.md");
+
+let skill: string;
+beforeAll(() => {
+  skill = readFileSync(SHIP_SKILL, "utf8");
+});
+
+describe("ship Phase 6 PR-title guard", () => {
+  test("the guard section is present", () => {
+    expect(skill).toContain("PR-title guard (HARD GATE");
+  });
+
+  test("the guard greps the live title for the WIP draft prefix and fails closed", () => {
+    // The detection pattern must anchor on the start of the title, case-insensitively.
+    expect(skill).toContain("grep -qiE '^WIP:'");
+    // Fail-closed: a still-WIP title must abort, not warn-and-continue.
+    expect(skill).toMatch(/title_guard[\s\S]*?exit 1/);
+  });
+
+  test("the guard fetches the live PR title (not the local commit subject)", () => {
+    expect(skill).toContain("gh pr view PR_NUMBER --json title --jq .title");
+  });
+
+  test("the guard runs BEFORE the `gh pr ready` step so it gates ready/merge", () => {
+    const guardIdx = skill.indexOf("PR-title guard (HARD GATE");
+    const readyIdx = skill.indexOf("gh pr ready PR_NUMBER");
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(readyIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(readyIdx);
+  });
+
+  test("Phase 6 states that --title is mandatory alongside --body", () => {
+    expect(skill).toContain("`--title` is mandatory");
+  });
+});

--- a/plugins/soleur/test/ship-pr-title-guard.test.ts
+++ b/plugins/soleur/test/ship-pr-title-guard.test.ts
@@ -30,8 +30,11 @@ describe("ship Phase 6 PR-title guard", () => {
   test("the guard greps the live title for the WIP draft prefix and fails closed", () => {
     // The detection pattern must anchor on the start of the title, case-insensitively.
     expect(skill).toContain("grep -qiE '^WIP:'");
-    // Fail-closed: a still-WIP title must abort, not warn-and-continue.
-    expect(skill).toMatch(/title_guard[\s\S]*?exit 1/);
+    // Fail-closed: a still-WIP title must abort, not warn-and-continue. Bound the
+    // window to ~500 chars so the match can ONLY bind to the guard's own `exit 1`
+    // (a few lines below `title_guard`), never a far-away `exit 1` elsewhere in the
+    // file — otherwise deleting the guard's exit would vacuously still pass.
+    expect(skill).toMatch(/\[ship\.phase6\.title_guard\][\s\S]{0,500}exit 1/);
   });
 
   test("the guard fetches the live PR title (not the local commit subject)", () => {


### PR DESCRIPTION
## Summary

Adds a regression test locking the #5382 WIP-title HARD GATE against silent removal in future `ship/SKILL.md` edits. The guard is agent-executed documentation, so a content-assertion test is its only drift safety net (same rationale + pattern as the sibling `ship-deploy-pipeline-fix-gate.test.ts`).

## Changes

- New `plugins/soleur/test/ship-pr-title-guard.test.ts` (bun:test, reads `ship/SKILL.md`). Asserts: the guard section exists; it greps the live title for `^WIP:`; it fails closed (`exit 1`); it fetches the live PR title; it runs **before** `gh pr ready`; and Phase 6 documents `--title` as mandatory.

## Changelog

### Plugin
- test: assert the ship Phase 6 PR-title guard is present and ordered before ready/merge.

## Test plan

- [x] `bun test plugins/soleur/test/ship-pr-title-guard.test.ts` → 5 pass / 0 fail
- [x] Assertions key on guard-unique strings (non-vacuous)

Generated with [Claude Code](https://claude.com/claude-code)