### PR TITLE
fix(eval-harness): loadEnum handles promptfoo resolved-contents shape (repairs go/triage gate)

### DIFF
--- a/knowledge-base/project/learnings/build-errors/2026-06-15-cjs-required-for-commonjs-scripts-and-promptfoo-harness-gotchas.md
+++ b/knowledge-base/project/learnings/build-errors/2026-06-15-cjs-required-for-commonjs-scripts-and-promptfoo-harness-gotchas.md
@@ -50,14 +50,24 @@ asserts must be `.cjs` here.
   Lesson: `validate config` accepting a key does NOT mean the key is honored at eval
   time — only a live run proves it. Document `npx promptfoo eval --repeat N`; do not put
   `repeat:` in the YAML.
-- **CORRECTION (PR B.1): promptfoo passes a `defaultTest.vars` `file://...` value to a
-  custom JS assert as the LITERAL UNRESOLVED STRING** (`"file://enums/go-routes.json"`),
-  NOT the file contents and NOT a parsed array. The first live run failed 100% (0/36)
-  because the gate did `Array.isArray(vars.enum) ? vars.enum : []` → `[]` → every label
-  out-of-enum. Fix: the assert must read the SSOT file itself (strip `file://`, resolve
-  relative to the script, `JSON.parse`, fail closed to `[]`). The deterministic stub
-  tests missed this because they passed a real array — the exact fixture-realism gap.
-  **Always exercise the var shape promptfoo actually passes, not a convenient stand-in.**
+- **promptfoo's `defaultTest.vars` `file://*.json` handling is VERSION-DEPENDENT — it may
+  pass EITHER the literal unresolved ref string (`"file://enums/go-routes.json"`) OR the
+  RESOLVED FILE CONTENTS (the JSON array text as a string).** A custom JS assert must handle
+  both, plus a direct array, and fail closed to `[]`. (B.1's first run got the literal-ref
+  shape and failed 100% with `Array.isArray(vars.enum)?vars.enum:[]`→`[]`; a later run got
+  the resolved-contents shape.) `loadEnum` must: return a direct array; else if the string
+  starts with `[`, `JSON.parse` it (resolved contents / array literal); else strip `file://`
+  and read the file. **The stub tests must exercise EVERY shape promptfoo can send — a test
+  that passes only one shape (or a convenient stand-in array) hides the others.**
+- **A "no caller produces this shape" simplification is unsafe when the caller is an external
+  tool's undocumented / version-dependent behavior.** In B.1 a reviewer flagged loadEnum's
+  JSON-array-text branch as YAGNI ("nothing passes a JSON literal string") and it was dropped;
+  promptfoo's resolved-contents shape IS exactly that input, so dropping it silently vacuumed
+  the gate on the already-merged go/triage targets (100% out-of-enum) — caught only when the
+  next target was eval'd live. The unit tests passed (they used the OTHER shape). **Verify a
+  "dead branch" against the real external caller's actual output, not against the unit-test
+  fixtures, before deleting it.** Fixed in the follow-up that restored the branch + added a
+  contents-shape regression guard.
 - **Golden tasks must DISCRIMINATE skill from baseline, not merely be answerable.** The
   POC's first task set was too easy: the label-only baseline scored 89–100%, so the
   skill-vs-baseline delta was ~0 and the harness proved nothing. Hardening to adversarial
@@ -65,6 +75,17 @@ asserts must be `.cjs` here.
   `URGENT!!` cosmetic→P3; no-new-user-activation→P1) produced a real delta: go-routing
   +19pts (skill 100% vs baseline 81%), ticket-triage +6pts. **A near-zero delta means the
   tasks don't separate the arms — fix the tasks before concluding the prose is dead weight.**
+- **But after a genuine hardening attempt, a persistent +0 IS a valid finding — the harness is
+  saying this surface's prose adds no measurable model-behavior signal.** Two attempted expansion
+  targets (incident brand-survival threshold, ship semver bump) came back +0 / +0 even with
+  deliberately adversarial tasks (40-line-new-skill→`minor`, 600-line-refactor→`patch`,
+  token-in-logs→`single-user incident`): the models classify these correctly from the input
+  description alone, so the criteria/rules prose isn't producing the behavior. The
+  enum-LLM-classifier space worth harnessing is SMALL (routing discriminates strongly, triage
+  modestly, others not) — and the disciplined response to a +0 target is to NOT ship it as
+  permanent fixture-sync debt, per the "verify it pays off before investing in coverage" gate.
+  Also: most Soleur "classifiers" are deterministic scripts (gdpr-gate, skill-security-scan,
+  brainstorm lane) — already unit-tested; an LLM-arm eval there tests the wrong thing.
 - **Providers can load from a generated file** — `providers: file://models.generated.json`
   (a JSON array of `"anthropic:messages:<id>"` strings) validates. This keeps model-ID
   literals out of config-class files (and off the model-launch-review auto-fixer);

--- a/plugins/soleur/skills/eval-harness/scripts/parse-label.cjs
+++ b/plugins/soleur/skills/eval-harness/scripts/parse-label.cjs
@@ -15,18 +15,30 @@ const path = require("node:path");
 
 // loadEnum(vars): resolve the target's closed label set to a real array.
 //
-// promptfoo does NOT resolve a `file://...` value in `defaultTest.vars` for a
-// custom JS assert — it passes the literal string `"file://enums/go-routes.json"`
-// straight through. So the assert must read the SSOT file itself. Accepts a
-// direct array (unit tests) or a `file://`/relative/absolute path to a JSON array
-// file (the promptfoo case, resolved relative to the skill dir = this script's
-// parent). Returns [] on any failure so the gate fails closed (out-of-enum)
-// rather than throwing.
+// promptfoo's handling of a `defaultTest.vars` `file://*.json` value passed to a
+// custom JS assert is version-dependent — confirmed empirically that it may send
+// EITHER the RESOLVED FILE CONTENTS (the JSON array text as a string) OR the literal
+// unresolved ref `"file://enums/...json"`. The assert must handle both, plus a direct
+// array (unit tests). Returns [] on any failure so the gate fails closed (out-of-enum)
+// rather than throwing. (An earlier change dropped the JSON-array-text branch as
+// "speculative"; that silently broke the gate — promptfoo's resolved-contents shape IS
+// that branch's input. The regression guard lives in test/parse-label.test.sh.)
 function loadEnum(vars) {
   const raw = vars && vars.enum;
   if (Array.isArray(raw)) return raw;
   if (typeof raw !== "string" || raw.trim() === "") return [];
-  const ref = raw.trim().replace(/^file:\/\//, "");
+  const s = raw.trim();
+  // (a) JSON array literal / resolved file contents — starts with `[`, JSON.parse.
+  // (b) a `file://`/relative/absolute path — strip `file://`, read the file.
+  if (s.startsWith("[")) {
+    try {
+      const a = JSON.parse(s);
+      if (Array.isArray(a)) return a;
+    } catch {
+      /* not valid JSON — fall through to file resolution */
+    }
+  }
+  const ref = s.replace(/^file:\/\//, "");
   const p = path.isAbsolute(ref) ? ref : path.resolve(__dirname, "..", ref);
   try {
     const a = JSON.parse(fs.readFileSync(p, "utf8"));

--- a/plugins/soleur/skills/eval-harness/test/gate-classification.test.sh
+++ b/plugins/soleur/skills/eval-harness/test/gate-classification.test.sh
@@ -64,6 +64,11 @@ fileref() {
 fileref "fix"    "file://enums/go-routes.json"     "true"  "file:// enum + in-enum route passes"
 fileref "banana" "file://enums/go-routes.json"     "false" "file:// enum + out-of-enum route fails"
 fileref "P1"     "file://enums/triage-levels.json" "true"  "file:// enum + in-enum P-level passes"
+# Resolved-contents shape (JSON array text) — what promptfoo actually passes when it
+# resolves a defaultTest.vars file:// ref to file CONTENTS. Regression guard for the
+# gate-vacuous bug (the enum arrived as JSON-array-text, not a path/literal-ref).
+fileref "fix"    '["fix","drain","clo-attestation","review","legal-threshold","incident","default"]' "true"  "contents-string enum + in-enum passes"
+fileref "banana" '["fix","drain","clo-attestation","review","legal-threshold","incident","default"]' "false" "contents-string enum + out-of-enum fails"
 
 if [[ "$fails" -gt 0 ]]; then
   echo "gate-classification: $fails assertion(s) failed"

--- a/plugins/soleur/skills/eval-harness/test/parse-label.test.sh
+++ b/plugins/soleur/skills/eval-harness/test/parse-label.test.sh
@@ -78,10 +78,12 @@ run_empty "$GO" "" "empty string output" ""
 run_empty "$GO" "" "null output" "__NULL__"
 
 # --- loadEnum: the var shapes promptfoo actually passes ---
-# Regression for the #5358 live-run bug: promptfoo passes a `defaultTest.vars`
-# `file://...` value to a custom JS assert as the LITERAL STRING, unresolved.
-# loadEnum must read the SSOT file itself. Also accepts a JSON array literal and
-# a direct array; returns [] (gate fails closed) on anything unreadable.
+# promptfoo's handling of a `defaultTest.vars` `file://*.json` value is
+# version-dependent: it may pass the RESOLVED FILE CONTENTS (JSON array text as a
+# string) OR the literal unresolved `file://...` ref. loadEnum must handle BOTH
+# (plus a direct array), returning [] (gate fails closed) on anything else. The
+# resolved-contents case is the one a prior simplification dropped, vacuuming the
+# gate — these cases lock both shapes so it cannot recur.
 loadenum() {
   local enumval="$1" want_len="$2" want_first="$3" label="$4"
   local got

--- a/plugins/soleur/skills/eval-harness/test/parse-label.test.sh
+++ b/plugins/soleur/skills/eval-harness/test/parse-label.test.sh
@@ -104,11 +104,20 @@ loadenum() {
   fi
 }
 
-loadenum "file://enums/go-routes.json"     7 "fix" "loadEnum file:// go-routes (promptfoo shape — the #5358 bug)"
+# promptfoo's file:// var handling is version-dependent: it may pass the literal
+# `file://...` ref OR the RESOLVED FILE CONTENTS (JSON array text). Both must work.
+loadenum "file://enums/go-routes.json"     7 "fix" "loadEnum file:// literal ref (one promptfoo shape)"
 loadenum "file://enums/triage-levels.json" 3 "P1"  "loadEnum file:// triage-levels"
 loadenum "enums/go-routes.json"            7 "fix" "loadEnum bare relative path"
+# The resolved-contents shape — what promptfoo actually passes when it resolves a
+# defaultTest.vars file:// ref to the file's CONTENTS. Regression guard for the
+# gate-vacuous bug (loadEnum must JSON.parse a JSON-array-text string, not treat it
+# as a path). JSON array text as a string.
+loadenum '["fix","drain","clo-attestation","review","legal-threshold","incident","default"]' 7 "fix" "loadEnum JSON-array-text contents (promptfoo file:// resolved-contents shape)"
+loadenum '[ "a", "b", "c" ]'               3 "a"   "loadEnum whitespaced JSON-array-text contents"
 loadenum "__ARRAY__"                       3 "a"   "loadEnum direct array passthrough"
 loadenum "file://enums/does-not-exist.json" 0 "null" "loadEnum unreadable file -> [] (gate fails closed)"
+loadenum "not json and not a path"         0 "null" "loadEnum garbage -> [] (gate fails closed)"
 loadenum ""                                0 "null" "loadEnum empty string -> []"
 
 if [[ "$fails" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

A focused regression fix for the eval-harness `loadEnum`, plus a regression-guard test. This repairs the gate on the already-merged `soleur:go` routing + ticket-triage targets, which were silently broken by the #5377 review fix.

**The regression:** promptfoo's handling of a `defaultTest.vars` `file://*.json` value passed to a custom JS assert is **version-dependent** — it may send the literal unresolved ref string OR the **resolved file *contents*** (the JSON array text as a string). #5377 dropped `loadEnum`'s JSON-array-text branch as "speculative" (a reviewer's "no caller emits that shape" call), but promptfoo's resolved-contents shape *is* that branch's input. With the branch gone, `loadEnum` treated the JSON text as a file path → ENOENT → `[]` → the gate saw an empty enum and failed every cell (`out-of-enum`). The unit tests passed the *other* (file://-ref) shape, so they didn't catch it; #5377 re-ran the eval before the branch was dropped, never after.

**The fix:** restore the JSON-array-text branch so `loadEnum` accepts `array | JSON-array-text contents | file://-or-path`, failing closed to `[]`. Verified — a fresh go-routing run is back to 126/126 cells passing the gate (delta +19), ticket-triage 108/108 (+6).

**Why no new targets:** this branch began as a 2-target expansion sweep (incident threshold, ship semver). Both measured **+0 delta** even with deliberately adversarial golden tasks — the models classify those surfaces from the input alone, so the criteria/rules prose adds no measurable signal. Per the "verify it pays off before investing in coverage" gate, the +0 targets were dropped rather than shipped as fixture-sync debt. The empirical finding (and the enum-classifier-space-is-small conclusion) is recorded in the harness learning.

## Changelog

### Plugin (eval-harness skill)

- **Fix:** `loadEnum` handles promptfoo's resolved-file-contents var shape (JSON array text), restoring the branch #5377 dropped — repairs the vacuous gate on the merged go-routing + ticket-triage targets.
- Regression-guard tests: `parse-label.test.sh` + `gate-classification.test.sh` now exercise the JSON-array-text contents shape (what promptfoo actually sends), not just the `file://`-ref shape.
- Corrected the harness learning: promptfoo's `file://` var handling is version-dependent; "no caller emits this shape" is unsafe when the caller is an external tool's version-dependent behavior; the enum-classifier expansion past go/triage returned +0 (diminishing returns).

## Test plan

- [x] All 4 `.test.sh` pass; the new contents-shape cases fail against the pre-fix `loadEnum` (genuine regression guards — confirmed by review)
- [x] `bun test components.test.ts` — 1226 / 0
- [x] Re-run with the fix: go-routing 126/126 gate-pass (+19), ticket-triage 108/108 (+6)
- [x] `semgrep-sast` + `shellcheck` — 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
