### PR TITLE
fix(ci): legal-doc gate — drop --depth=1 so the three-dot diff merge-base resolves

### DIFF
--- a/.github/workflows/legal-doc-cross-document-gate.yml
+++ b/.github/workflows/legal-doc-cross-document-gate.yml
@@ -66,7 +66,18 @@ jobs:
           # Collect changed files in the PR diff against the PR base.
           # BASE_REF arrives via env: + double-quoted in the command so
           # workflow-injection guidance is honoured.
-          git fetch --quiet --depth=1 origin "$BASE_REF"
+          #
+          # NO --depth=1: the three-dot `origin/BASE...HEAD` diff is computed
+          # from the MERGE-BASE of base and HEAD (so it lists only this PR's own
+          # changes, not commits that landed on base since the branch point — a
+          # two-dot diff would mis-flag those unrelated files). A shallow
+          # `--depth=1` fetch brings only base's tip commit, so when base has
+          # advanced past the branch point the merge-base is unreachable and the
+          # diff dies with `fatal: origin/BASE...HEAD: no merge base` (exit 128)
+          # — failing the gate on a branch-history artifact, not a real finding.
+          # Checkout already runs fetch-depth:0, so this fetch is a cheap
+          # incremental that just makes the merge-base reachable.
+          git fetch --quiet origin "$BASE_REF"
           changed_files=$(git diff --name-only "origin/${BASE_REF}"...HEAD)
           echo "Changed files in PR:"
           echo "$changed_files" | sed 's/^/  /'


### PR DESCRIPTION
## Problem

The `enforce` job (legal-doc cross-document lockstep — a **required** check) computes the PR's changed files like this:

```bash
git fetch --quiet --depth=1 origin "$BASE_REF"
changed_files=$(git diff --name-only "origin/${BASE_REF}"...HEAD)
```

A three-dot diff (`origin/BASE...HEAD`) is computed from the **merge-base** of base and HEAD — correct, because it lists only *this PR's own* changes. But `--depth=1` fetches **only base's tip commit**. When base has advanced past the branch point (the normal case for any branch that's a little behind), the merge-base isn't in the local object store and the diff aborts:

```
fatal: origin/main...HEAD: no merge base
Process completed with exit code 128
```

The required gate then **fails on a branch-history artifact** — it looks like a legal-doc violation, but the rule logic never executed.

**Observed this session:** PR #5383 failed `enforce` twice this way and only passed after I manually merged `main` into the branch (giving HEAD base's tip). Any PR whose branch predates the current base tip is exposed.

## Fix

Drop `--depth=1`. Checkout already runs `fetch-depth: 0`, so fetching the base ref in full is a **cheap incremental** that makes the merge-base reachable. Three-dot semantics are preserved — it still lists only the PR's own changes, so it won't mis-flag files that landed on base since the branch point (a two-dot diff *would*, spuriously tripping the DSAR-surface check).

## Verification

- YAML parses (`yaml.safe_load`)
- `actionlint` clean for this change (the one SC2001 note is a pre-existing style suggestion on an unchanged `sed` line)
- Preserves the `BASE_REF`-via-`env:` + double-quote injection-safe pattern

Found while shipping the #5380 follow-up observability fixes (the third of three sentry/CI fragilities surfaced during that go-live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)