### PR TITLE
feat(concierge): gate legacy startAgentSession leader path on repo_status

### DIFF
--- a/apps/web-platform/server/agent-runner.ts
+++ b/apps/web-platform/server/agent-runner.ts
@@ -61,13 +61,14 @@ import { buildAuthStatusTools } from "./auth-status-tools";
 import { buildAccountTools } from "./account-tools";
 import { buildRoutineTools } from "./routines-tools";
 import { buildWorkspaceSettingsTools } from "./workspace-settings-tools";
-import { getCurrentRepoUrl } from "./current-repo-url";
+import { getCurrentRepoUrl, getCurrentRepoStatus } from "./current-repo-url";
+import { evaluateRepoReadiness, type RepoReadiness } from "./repo-readiness";
 import { resolveActiveWorkspacePath } from "./workspace-resolver";
 import { resolveInstallationId } from "./resolve-installation-id";
 import { buildGithubTools } from "./github-tools";
 import { buildPlausibleTools } from "./plausible-tools";
 import { createCanUseTool } from "./permission-callback";
-import { reportSilentFallback } from "./observability";
+import { reportSilentFallback, hashUserId } from "./observability";
 import { persistTurnCost } from "./cost-writer";
 import { selectChapter } from "./pdf-chapter-router";
 import { extractPdfText } from "./pdf-text-extract";
@@ -869,6 +870,66 @@ export async function startAgentSession(
    *  session_ended after all leaders finish (see #2428). */
   skipSessionEnded?: boolean,
 ): Promise<void> {
+  // #5399 — legacy-leader repo-readiness gate (AC10 follow-up to #5395).
+  //
+  // This MUST be the FIRST statement of startAgentSession — ABOVE the
+  // supersede-abort (`const existing = getSession(...)` below) and ABOVE
+  // registerSession — so a blocked not-ready dispatch does NOT abort the
+  // user's in-flight prior session or register a dangling one before bailing
+  // (architecture review P1). It is also ABOVE the outer `try` further down,
+  // so the status read needs its OWN fail-open try/catch (silent-failure F1).
+  //
+  // getCurrentRepoStatus self-mints its tenant client, so this runs WITHOUT
+  // the BYOK lease: a `cloning`/`error` workspace never acquires a key, never
+  // spawns an agent, never attempts a clone. Server-authoritative for the
+  // WHOLE legacy surface (ws-handler pendingLeader + sendUserMessage call
+  // sites + dispatchToLeaders fan-out all funnel through startAgentSession).
+  // Mirrors the cc-dispatcher gate (#5395) — reuses the same primitives; no
+  // new predicate, error class, or copy.
+  let repoReadiness: RepoReadiness;
+  try {
+    const { repoStatus, repoError } = await getCurrentRepoStatus(userId);
+    repoReadiness = evaluateRepoReadiness(repoStatus, repoError);
+  } catch (err) {
+    // The read sits above the outer `try`, so a non-RuntimeAuthError throw
+    // from getCurrentRepoStatus would otherwise escape uncaught (no Sentry,
+    // no client error). Mirror and fail OPEN (proceed; degrade to the
+    // existing repo-less / #5392 path) — never block a dispatch on a
+    // readiness-read blip. (silent-failure review F1, HIGH.)
+    reportSilentFallback(err, {
+      feature: "agent-runner",
+      op: "repo-readiness-gate.read",
+      extra: { userId, conversationId },
+    });
+    repoReadiness = { ok: true };
+  }
+  if (!repoReadiness.ok) {
+    // Honest client message; SKIP Sentry (an expected transient/benign state,
+    // not an incident) and do NOT mark the conversation failed (a transient
+    // block must not nuke a resumable conversation — the early `return` never
+    // reaches the outer catch's failed-status write). The info breadcrumb
+    // keeps the rate observable in Better Stack (alert on a code=error spike,
+    // never on cloning). hashUserId for log parity with cc-dispatcher.ts.
+    log.info(
+      {
+        feature: "agent-runner",
+        op: "repo-readiness-gate",
+        code: repoReadiness.code,
+        userIdHash: hashUserId(userId),
+        conversationId,
+        leaderId,
+        reason: repoReadiness.message,
+      },
+      "repo-readiness gate: blocked legacy-leader dispatch (repo not ready)",
+    );
+    sendToClient(userId, {
+      type: "error",
+      message: repoReadiness.message,
+      ...(repoReadiness.errorCode ? { errorCode: repoReadiness.errorCode } : {}),
+    });
+    return; // no lease, no agent, no clone, no session mutation
+  }
+
   // Abort any existing session for this specific leader (or un-keyed
   // session). Tagged `superseded` so the existing session's
   // for-await catch branch classifies via the same code path as an

--- a/apps/web-platform/test/agent-runner-gate-ordering.test.ts
+++ b/apps/web-platform/test/agent-runner-gate-ordering.test.ts
@@ -1,0 +1,48 @@
+// #5399 AC10 — load-bearing ordering regression guard.
+//
+// The repo-readiness gate MUST be the FIRST statement of `startAgentSession`,
+// ABOVE the supersede-abort (`const existing = getSession(...)`) and ABOVE
+// `registerSession(...)`. If a future refactor moves the gate below either,
+// a blocked not-ready dispatch would first abort the user's in-flight prior
+// session (or register a dangling one) and THEN bail — silently breaking a
+// resumable conversation. The behavioral wiring test
+// (agent-runner-repo-readiness-gate.test.ts) cannot observe the internal
+// session map, so this structural source-order assertion is the only
+// mechanical guard for the invariant. Trimmed to the ordering check only
+// (the negative space the behavioral suite can't cover); it lives in a
+// standalone file because the wiring test mocks `fs`, which would clobber the
+// real `readFileSync` this guard needs.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, test, expect } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, "../server/agent-runner.ts"), "utf8");
+
+describe("agent-runner — repo-readiness gate ordering (#5399 AC10)", () => {
+  test("the gate read precedes getSession and registerSession inside startAgentSession", () => {
+    const fnStart = src.indexOf("export async function startAgentSession(");
+    expect(fnStart).toBeGreaterThan(-1);
+
+    const idxGate = src.indexOf("await getCurrentRepoStatus(userId)", fnStart);
+    const idxSupersede = src.indexOf(
+      "const existing = getSession(userId, conversationId, leaderId)",
+      fnStart,
+    );
+    const idxRegister = src.indexOf(
+      "registerSession(userId, conversationId, session, leaderId)",
+      fnStart,
+    );
+
+    // All three anchors must exist within the function.
+    expect(idxGate).toBeGreaterThan(fnStart);
+    expect(idxSupersede).toBeGreaterThan(fnStart);
+    expect(idxRegister).toBeGreaterThan(fnStart);
+
+    // The gate must come first — above both session-mutating statements.
+    expect(idxGate).toBeLessThan(idxSupersede);
+    expect(idxGate).toBeLessThan(idxRegister);
+  });
+});

--- a/apps/web-platform/test/agent-runner-repo-readiness-gate.test.ts
+++ b/apps/web-platform/test/agent-runner-repo-readiness-gate.test.ts
@@ -1,0 +1,353 @@
+// #5399 — legacy-leader repo-readiness gate (AC10 follow-up to #5395).
+//
+// #5395 gated the Concierge / `/soleur:go` dispatch path (cc-dispatcher.ts) on
+// `repo_status`. The legacy leader path — `startAgentSession` in
+// agent-runner.ts, reached from ws-handler `pendingLeader` AND `sendUserMessage`
+// — was explicitly deferred (the "No outer repo_status gate" seam). This wiring
+// test pins the same gate at the top of `startAgentSession`, REUSING the
+// already-shipped primitives (`getCurrentRepoStatus`, `evaluateRepoReadiness`):
+// a `cloning`/`error` workspace blocks BEFORE the BYOK lease / agent spawn /
+// clone, emits the honest `{ type: "error" }` frame, SKIPS the Sentry mirror,
+// and does NOT mark the conversation failed.
+//
+// RED on origin/main: there is no gate, so cases 1/2/5 fail (the SDK `query` is
+// spawned on a cloning/error workspace, and a status-read throw escapes uncaught
+// without `reportSilentFallback`).
+//
+// Harness lifted from agent-runner-reprovision.test.ts (same hoisted-mock set);
+// the only additions are `getCurrentRepoStatus` on the `current-repo-url` mock,
+// `hashUserId` on the `observability` mock, and the REAL `repo-readiness`
+// evaluator (not mocked) so the emitted message/errorCode shapes are validated.
+
+import { vi, describe, test, expect, beforeEach } from "vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL ??= "https://test.supabase.co";
+process.env.NEXT_PUBLIC_APP_URL ??= "https://app.soleur.ai";
+process.env.WORKSPACES_ROOT = "/tmp/soleur-repo-readiness-gate-root";
+
+const {
+  mockFrom,
+  mockRpc,
+  mockQuery,
+  mockReadFileSync,
+  mockExistsSync,
+  mockEnsureWorkspaceRepoCloned,
+  mockEnsureWorkspaceDirExists,
+  mockResolveInstallationId,
+  mockGetCurrentRepoUrl,
+  mockGetCurrentRepoStatus,
+  mockResolveEffectiveInstallationId,
+  mockSyncPull,
+  mockSendToClient,
+  mockCaptureException,
+  mockReportSilentFallback,
+} = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockRpc: vi.fn(),
+  mockQuery: vi.fn(),
+  mockReadFileSync: vi.fn(),
+  mockExistsSync: vi.fn(),
+  mockEnsureWorkspaceRepoCloned: vi.fn(),
+  mockEnsureWorkspaceDirExists: vi.fn(),
+  mockResolveInstallationId: vi.fn(),
+  mockGetCurrentRepoUrl: vi.fn(),
+  mockGetCurrentRepoStatus: vi.fn(),
+  mockResolveEffectiveInstallationId: vi.fn(),
+  mockSyncPull: vi.fn(),
+  mockSendToClient: vi.fn(),
+  mockCaptureException: vi.fn(),
+  mockReportSilentFallback: vi.fn(),
+}));
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: mockQuery,
+  tool: vi.fn(
+    (name: string, _desc: string, _schema: unknown, handler: Function) => ({
+      name,
+      handler,
+    }),
+  ),
+  createSdkMcpServer: vi.fn((opts: { name: string; tools: unknown[] }) => ({
+    type: "sdk",
+    name: opts.name,
+    instance: { tools: opts.tools },
+  })),
+}));
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return { ...actual, readFileSync: mockReadFileSync, existsSync: mockExistsSync };
+});
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/supabase/tenant", () => ({
+  getFreshTenantClient: vi.fn(async () => ({ from: mockFrom, rpc: mockRpc })),
+  mintFounderJwt: vi.fn(),
+  RuntimeAuthError: class RuntimeAuthError extends Error {
+    cause: string;
+    constructor(cause: string, msg: string) {
+      super(msg);
+      this.name = "RuntimeAuthError";
+      this.cause = cause;
+    }
+  },
+}));
+
+vi.mock("@sentry/nextjs", () => ({ captureException: mockCaptureException }));
+vi.mock("../server/ws-handler", () => ({ sendToClient: mockSendToClient }));
+vi.mock("../server/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  createChildLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock("../server/byok", () => ({
+  decryptKey: vi.fn(() => Buffer.from("sk-test-key", "utf8")),
+  decryptKeyLegacy: vi.fn(() => Buffer.from("sk-test-key", "utf8")),
+  zeroize: vi.fn(),
+  encryptKey: vi.fn(),
+}));
+vi.mock("../server/error-sanitizer", () => ({
+  sanitizeErrorForClient: vi.fn(() => "error"),
+}));
+vi.mock("../server/sandbox", () => ({ isPathInWorkspace: vi.fn(() => true) }));
+vi.mock("../server/tool-path-checker", () => ({
+  UNVERIFIED_PARAM_TOOLS: [],
+  extractToolPath: vi.fn(),
+  isFileTool: vi.fn(() => false),
+  isSafeTool: vi.fn(() => false),
+}));
+vi.mock("../server/agent-env", () => ({ buildAgentEnv: vi.fn(() => ({})) }));
+vi.mock("../server/sandbox-hook", () => ({
+  createSandboxHook: vi.fn(() => vi.fn()),
+}));
+vi.mock("../server/review-gate", () => ({
+  abortableReviewGate: vi.fn().mockResolvedValue("Approve"),
+  validateSelection: vi.fn(),
+  extractReviewGateInput: vi.fn(),
+  buildReviewGateResponse: vi.fn(),
+  MAX_SELECTION_LENGTH: 200,
+  REVIEW_GATE_TIMEOUT_MS: 300_000,
+}));
+vi.mock("../server/domain-leaders", () => {
+  const leaders = [
+    { id: "cpo", name: "CPO", title: "Chief Product Officer", description: "Product" },
+  ];
+  return { DOMAIN_LEADERS: leaders, ROUTABLE_DOMAIN_LEADERS: leaders };
+});
+vi.mock("../server/domain-router", () => ({ routeMessage: vi.fn() }));
+vi.mock("../server/session-sync", () => ({ syncPull: mockSyncPull, syncPush: vi.fn() }));
+vi.mock("../server/github-api", () => ({
+  githubApiGet: vi.fn().mockResolvedValue({ default_branch: "main" }),
+  githubApiGetText: vi.fn().mockResolvedValue(""),
+  githubApiPost: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("../server/service-tools", () => ({
+  plausibleCreateSite: vi.fn(),
+  plausibleAddGoal: vi.fn(),
+  plausibleGetStats: vi.fn(),
+}));
+vi.mock("../server/observability", () => ({
+  reportSilentFallback: mockReportSilentFallback,
+  reportSilentFallbackWarning: vi.fn(),
+  warnSilentFallback: vi.fn(),
+  hashUserId: vi.fn(() => "hashed-user-id"),
+}));
+vi.mock("../server/vision-helpers", () => ({
+  tryCreateVision: vi.fn().mockResolvedValue(undefined),
+  buildVisionEnhancementPrompt: vi.fn().mockResolvedValue(""),
+}));
+vi.mock("../server/ensure-workspace-repo", () => ({
+  ensureWorkspaceRepoCloned: mockEnsureWorkspaceRepoCloned,
+  ensureWorkspaceDirExists: mockEnsureWorkspaceDirExists,
+}));
+vi.mock("../server/resolve-installation-id", () => ({
+  resolveInstallationId: mockResolveInstallationId,
+}));
+// The gate under test reads `getCurrentRepoStatus`; the reprovision block still
+// reads `getCurrentRepoUrl`. Mock BOTH so neither hits supabase.
+vi.mock("../server/current-repo-url", () => ({
+  getCurrentRepoUrl: mockGetCurrentRepoUrl,
+  getCurrentRepoStatus: mockGetCurrentRepoStatus,
+}));
+vi.mock("../server/cc-effective-installation", () => ({
+  resolveEffectiveInstallationId: mockResolveEffectiveInstallationId,
+}));
+
+import { startAgentSession } from "../server/agent-runner";
+// REAL evaluator + copy — validates the emitted message/errorCode shapes.
+import { REPO_CLONING_MSG } from "../server/repo-readiness";
+import { createApiKeysMock, createQueryMock } from "./helpers/agent-runner-mocks";
+
+const MEMBER_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const ACTIVE_WS_ID = "44444444-4444-4444-8444-444444444444";
+const ROOT = "/tmp/soleur-repo-readiness-gate-root";
+const ACTIVE_DIR = `${ROOT}/${ACTIVE_WS_ID}`;
+const REPO = "https://github.com/acme/widget";
+const INSTALL = 4242;
+
+function singleRowChain(row: unknown) {
+  const chain: Record<string, unknown> = {};
+  chain.select = () => chain;
+  chain.eq = () => chain;
+  chain.single = () => ({ data: row, error: null });
+  chain.maybeSingle = () => ({ data: row, error: null });
+  return chain;
+}
+
+function setupSupabaseMock() {
+  mockRpc.mockImplementation(() => Promise.resolve({ data: null, error: null }));
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "api_keys") return createApiKeysMock();
+    if (table === "users") {
+      return singleRowChain({ workspace_path: ACTIVE_DIR, repo_status: null, email: "member@example.com" });
+    }
+    if (table === "user_session_state") {
+      return singleRowChain({ current_workspace_id: ACTIVE_WS_ID });
+    }
+    if (table === "workspace_members") {
+      return singleRowChain({ user_id: MEMBER_ID });
+    }
+    if (table === "workspaces") {
+      return singleRowChain({ repo_url: REPO });
+    }
+    if (table === "conversations") {
+      const sel: Record<string, unknown> = {
+        eq: vi.fn(),
+        single: vi.fn(() => ({
+          data: { domain_leader: "cpo", session_id: null, workspace_id: ACTIVE_WS_ID },
+          error: null,
+        })),
+      };
+      (sel.eq as ReturnType<typeof vi.fn>).mockReturnValue(sel);
+      const upd: Record<string, unknown> = {
+        error: null,
+        eq: vi.fn(),
+        select: vi.fn(() => Promise.resolve({ data: [{ id: "mock" }], error: null })),
+      };
+      (upd.eq as ReturnType<typeof vi.fn>).mockReturnValue(upd);
+      return { update: vi.fn(() => upd), select: vi.fn(() => sel) };
+    }
+    if (table === "messages") {
+      return {
+        insert: () => ({ error: null }),
+        select: () => {
+          const chain: Record<string, unknown> = {
+            eq: () => chain,
+            order: () => Promise.resolve({ data: [], error: null }),
+            then: (resolve: (v: unknown) => void) => resolve({ data: [], error: null }),
+          };
+          return chain;
+        },
+      };
+    }
+    return singleRowChain(null);
+  });
+}
+
+/** Did `sendToClient` receive the gate's OWN error frame (the block emit)?
+ *  Scoped to the gate's specific copy so a downstream/dispatch `type:"error"`
+ *  frame (which a no-op case may still emit further down the path) is NOT
+ *  miscounted as a gate block. */
+function gateErrorEmits() {
+  return mockSendToClient.mock.calls.filter(([, payload]) => {
+    if (!payload || typeof payload !== "object") return false;
+    const p = payload as { type?: string; message?: string };
+    if (p.type !== "error" || typeof p.message !== "string") return false;
+    return p.message === REPO_CLONING_MSG || p.message.startsWith("Repository setup failed:");
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockReadFileSync.mockImplementation((filePath: string) => {
+    if (String(filePath).includes("plugin.json")) return JSON.stringify({ mcpServers: {} });
+    throw new Error(`ENOENT: no such file ${filePath}`);
+  });
+  mockExistsSync.mockReturnValue(true);
+  mockEnsureWorkspaceRepoCloned.mockResolvedValue("ok");
+  mockEnsureWorkspaceDirExists.mockResolvedValue(undefined);
+  mockResolveInstallationId.mockResolvedValue(INSTALL);
+  mockGetCurrentRepoUrl.mockResolvedValue(REPO);
+  mockResolveEffectiveInstallationId.mockImplementation(
+    async ({ installationId }: { installationId: number | null }) => installationId,
+  );
+  // Default: ready (the gate no-ops). Each test overrides as needed.
+  mockGetCurrentRepoStatus.mockResolvedValue({ repoStatus: "ready", repoError: null });
+});
+
+describe("agent-runner leader — repo-readiness gate (#5399)", () => {
+  test("AC1: cloning workspace blocks — emits REPO_CLONING_MSG, spawns no agent, no Sentry", async () => {
+    setupSupabaseMock();
+    createQueryMock(mockQuery);
+    mockGetCurrentRepoStatus.mockResolvedValue({ repoStatus: "cloning", repoError: null });
+
+    await startAgentSession(MEMBER_ID, "conv-1", "cpo");
+
+    expect(mockSendToClient).toHaveBeenCalledWith(MEMBER_ID, {
+      type: "error",
+      message: REPO_CLONING_MSG,
+    });
+    // No agent spawned, no clone, no Sentry mirror.
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockEnsureWorkspaceRepoCloned).not.toHaveBeenCalled();
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  test("AC2: error workspace blocks — emits repo_setup_failed errorCode, spawns no agent, no Sentry", async () => {
+    setupSupabaseMock();
+    createQueryMock(mockQuery);
+    mockGetCurrentRepoStatus.mockResolvedValue({
+      repoStatus: "error",
+      repoError: "fatal: could not read Username for 'https://github.com'",
+    });
+
+    await startAgentSession(MEMBER_ID, "conv-1", "cpo");
+
+    const emits = gateErrorEmits();
+    expect(emits).toHaveLength(1);
+    const [, payload] = emits[0] as [string, { message: string; errorCode?: string }];
+    expect(payload.errorCode).toBe("repo_setup_failed");
+    expect(payload.message).toMatch(/^Repository setup failed:/);
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  test("AC5a: ready workspace is a no-op — gate emits nothing, dispatch proceeds", async () => {
+    setupSupabaseMock();
+    createQueryMock(mockQuery);
+    mockGetCurrentRepoStatus.mockResolvedValue({ repoStatus: "ready", repoError: null });
+
+    await startAgentSession(MEMBER_ID, "conv-1", "cpo");
+
+    expect(gateErrorEmits()).toHaveLength(0);
+    expect(mockQuery).toHaveBeenCalled();
+  });
+
+  test("AC5b: not_connected workspace is a no-op (fail-open default) — dispatch proceeds", async () => {
+    setupSupabaseMock();
+    createQueryMock(mockQuery);
+    mockGetCurrentRepoStatus.mockResolvedValue({ repoStatus: "not_connected", repoError: null });
+
+    await startAgentSession(MEMBER_ID, "conv-1", "cpo");
+
+    expect(gateErrorEmits()).toHaveLength(0);
+    expect(mockQuery).toHaveBeenCalled();
+  });
+
+  test("AC11: status-read throw fails OPEN — reportSilentFallback fires, gate emits nothing, dispatch proceeds", async () => {
+    setupSupabaseMock();
+    createQueryMock(mockQuery);
+    mockGetCurrentRepoStatus.mockRejectedValue(new Error("unexpected status-read blip"));
+
+    await startAgentSession(MEMBER_ID, "conv-1", "cpo");
+
+    expect(mockReportSilentFallback).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ op: "repo-readiness-gate.read" }),
+    );
+    expect(gateErrorEmits()).toHaveLength(0);
+    expect(mockQuery).toHaveBeenCalled();
+  });
+});

--- a/apps/web-platform/test/agent-runner-repo-readiness-gate.test.ts
+++ b/apps/web-platform/test/agent-runner-repo-readiness-gate.test.ts
@@ -293,6 +293,12 @@ describe("agent-runner leader — repo-readiness gate (#5399)", () => {
     expect(mockQuery).not.toHaveBeenCalled();
     expect(mockEnsureWorkspaceRepoCloned).not.toHaveBeenCalled();
     expect(mockCaptureException).not.toHaveBeenCalled();
+    // AC4 + AC10: the gate is the FIRST statement and early-returns, so a block
+    // performs ZERO DB side effects — no conversation marked failed, no
+    // session-state mutation (getSession/registerSession run below the gate and
+    // touch no table here). `getCurrentRepoStatus` is fully mocked, so any
+    // mockFrom call would mean execution fell through past the gate.
+    expect(mockFrom).not.toHaveBeenCalled();
   });
 
   test("AC2: error workspace blocks — emits repo_setup_failed errorCode, spawns no agent, no Sentry", async () => {
@@ -312,6 +318,8 @@ describe("agent-runner leader — repo-readiness gate (#5399)", () => {
     expect(payload.message).toMatch(/^Repository setup failed:/);
     expect(mockQuery).not.toHaveBeenCalled();
     expect(mockCaptureException).not.toHaveBeenCalled();
+    // AC4 + AC10: zero DB side effects on a block (see AC1 for rationale).
+    expect(mockFrom).not.toHaveBeenCalled();
   });
 
   test("AC5a: ready workspace is a no-op — gate emits nothing, dispatch proceeds", async () => {

--- a/knowledge-base/project/learnings/test-failures/2026-06-16-scope-noop-gate-emit-detector-to-gate-own-copy.md
+++ b/knowledge-base/project/learnings/test-failures/2026-06-16-scope-noop-gate-emit-detector-to-gate-own-copy.md
@@ -1,0 +1,81 @@
+---
+title: "A no-op-gate test's emit-detector must match the gate's OWN output, not any frame of that type"
+date: 2026-06-16
+category: test-failures
+module: apps/web-platform/test
+tags: [vitest, test-design, gating-primitive, vacuous-assertion, repo-readiness-gate]
+issue: 5399
+pr: 5405
+---
+
+# Learning: scope a no-op-gate's emit-detector to the gate's own copy
+
+## Problem
+
+The wiring test for the legacy-leader repo-readiness gate (#5399) has two classes of case:
+
+- **Block cases** (cloning / error): the gate emits `sendToClient({type:"error", message})` and early-returns.
+- **No-op cases** (ready / not_connected / read-throws-fail-open): the gate must emit
+  NOTHING and let dispatch proceed.
+
+To assert "the gate emitted nothing" on the no-op cases I wrote a helper that filtered
+`sendToClient` calls to `payload.type === "error"`. It false-failed AC5a/AC5b
+(`expected [ [ … ] ] to have a length of +0 but got 1`): on the no-op path the dispatch
+**proceeds** and a *downstream* failure (router/sandbox mock) emits its OWN
+`{type:"error", …}` frame — which the broad helper miscounted as a gate block.
+
+## Root cause
+
+`type:"error"` is not unique to the gate. The gate shares the WS error-frame shape with
+every other dispatch failure path. A detector keyed only on `type` cannot tell "the gate
+blocked" from "something downstream of a *proceeding* dispatch errored." So:
+
+- on a **no-op** case it FALSE-FAILS (counts a downstream frame as a gate emit), and
+- on a **block** case the same broad detector could FALSE-PASS vacuously (a downstream
+  error frame would satisfy it even if the gate itself never fired).
+
+## Solution
+
+Scope the emit-detector to the gate's OWN copy — the exact strings only the gate produces
+(here `REPO_CLONING_MSG` and the `repoErrorMsg(...)` `"Repository setup failed:"` prefix,
+imported from the REAL evaluator so they can't drift):
+
+```ts
+function gateErrorEmits() {
+  return mockSendToClient.mock.calls.filter(([, payload]) => {
+    if (!payload || typeof payload !== "object") return false;
+    const p = payload as { type?: string; message?: string };
+    if (p.type !== "error" || typeof p.message !== "string") return false;
+    return p.message === REPO_CLONING_MSG || p.message.startsWith("Repository setup failed:");
+  });
+}
+```
+
+Block cases assert `gateErrorEmits()` has the gate frame AND `query`/`mockFrom` were never
+called; no-op cases assert `gateErrorEmits()` is empty AND dispatch proceeded.
+
+## Key Insight
+
+When a gating primitive shares an output channel/shape with the code path it gates
+(a WS error frame, an HTTP status, a log line, a metric), a test that detects the gate's
+action by the SHARED shape is ambiguous in BOTH directions: it false-fails the no-op case
+(downstream output counts as the gate) and can vacuously pass the block case (downstream
+output satisfies the assertion without the gate firing). Key the detector on something only
+the gate emits — its specific copy/code/tag — imported from the real source so it can't
+drift. This is the emit-channel analogue of the existing "distinguish gate-absent from
+gate-present" RED-verification discipline.
+
+## Session Errors
+
+1. **Planning subagent Write blocked at bare-repo path** (forwarded) — Recovery: retried at
+   the worktree path. Prevention: already covered by `hr-when-in-a-worktree`; subagents must
+   `cd <worktree> && pwd`-verify first (one-shot Step 0 already prescribes this).
+2. **`gh pr view 5394` did not resolve** — one-off; #5394 is the issue, the gate merged as
+   PR #5395. Prevention: none needed — issue-vs-PR number divergence is expected; the plan's
+   Premise Validation already recorded it.
+3. **Bash CWD drift on an AC9 `git grep`** — the tool CWD was inside `apps/web-platform`
+   from a prior `cd`, so a repo-root-relative path errored `ambiguous argument`. Recovery:
+   re-ran with the app-relative path. Prevention: already documented — chain
+   `cd <abs> && <cmd>` in one Bash call; the Bash tool does not persist CWD.
+4. **No-op-gate emit-detector too broad** — Recovery: scoped `gateErrorEmits()` to the
+   gate's own copy. Prevention: this learning.

--- a/knowledge-base/project/plans/2026-06-16-feat-gate-legacy-leader-dispatch-on-repo-status-plan.md
+++ b/knowledge-base/project/plans/2026-06-16-feat-gate-legacy-leader-dispatch-on-repo-status-plan.md
@@ -13,6 +13,38 @@ brand_survival_threshold: single-user incident
 
 > Spec lacks valid `lane:` (no spec.md for this branch) — defaulted to `cross-domain` (TR2 fail-closed).
 
+## Enhancement Summary
+
+**Deepened on:** 2026-06-16
+**Agents:** verify-the-negative grep pass (7/7 claims CONFIRMED), architecture-strategist,
+silent-failure-hunter.
+
+### Key improvements (all findings applied)
+
+1. **F1 (HIGH, silent-failure):** Option A's gate sits ABOVE the outer `try` (`:930`), so a
+   non-RuntimeAuthError throw from `getCurrentRepoStatus` (`current-repo-url.ts:126`) would escape
+   uncaught (no Sentry, no client error). Added a fail-open try/catch around the gate read
+   (`reportSilentFallback` + proceed) — AC11 + wiring test case 5. The cc-dispatcher precedent
+   does NOT share this seam.
+2. **P1 (architecture):** "before registerSession" was under-specified — the gate must sit ABOVE
+   the supersede-abort (`getSession`/`abort` at `:876`), else a blocked dispatch kills the in-flight
+   prior session before bailing. Pinned the insertion point + AC10.
+3. **P1 (architecture):** documented the multi-leader `dispatchToLeaders` fan-out (`:2576/:2587`)
+   N-emit behavior — accepted, not gated pre-fan-out (AC12).
+4. **P2 (architecture):** use `hashUserId(userId)` in the breadcrumb for parity with
+   cc-dispatcher.ts:3352 (avoid raw-userId-in-logs divergence).
+5. **F2/F3 (silent-failure, MEDIUM):** breadcrumb now carries the sanitized `reason` for
+   self-contained triage; the Observability `error_reporting` claim was made precise about the
+   `users.repo_error` read's by-design silent fail-open carve-out.
+
+### Verify-the-negative pass
+
+All 7 load-bearing claims (getCurrentRepoStatus self-mints tenant; outer catch does
+Sentry+failed-write; resolveSessionErrorCode returns undefined for RepoNotReadyError;
+registerSession at ~:885 after supersede-abort at :876; all entry points funnel through
+startAgentSession; evaluator fail-open; cc-dispatcher emit/skip shape) CONFIRMED with file:line
+citations.
+
 ## Overview
 
 #5395 (PR for the issue keyed as #5394 in code comments) added a server-authoritative
@@ -111,30 +143,59 @@ threshold).
 ### The gate
 
 ```ts
-// apps/web-platform/server/agent-runner.ts — top of startAgentSession,
-// BEFORE resolveKeyOwnerThenLease (the lease body), before registerSession.
+// apps/web-platform/server/agent-runner.ts — the FIRST statement of
+// startAgentSession, ABOVE the supersede-abort `const existing = getSession(...)`
+// (:876) and ABOVE registerSession (:885). LOAD-BEARING ordering: the gate must
+// precede the supersede-abort so a blocked not-ready dispatch does NOT abort the
+// user's in-flight prior session before bailing (architecture review P1).
 //
 // #5399 — legacy-leader repo-readiness gate (follow-up to #5395 AC10).
 // getCurrentRepoStatus self-mints its tenant client, so this runs without
 // the BYOK lease — a cloning/error workspace never acquires a key, never
 // spawns an agent, never attempts a clone. Server-authoritative for the
 // WHOLE legacy surface (ws-handler pendingLeader :2241 + sendUserMessage
-// :2793/:2817/:2833 all funnel through startAgentSession).
-const { repoStatus, repoError } = await getCurrentRepoStatus(userId);
-const repoReadiness = evaluateRepoReadiness(repoStatus, repoError);
+// :2793/:2817/:2833 + dispatchToLeaders fan-out :2576/:2587 all funnel
+// through startAgentSession).
+//
+// FAIL-OPEN WRAPPER (silent-failure review F1, HIGH): this gate sits ABOVE the
+// outer `try` (:930), so a non-RuntimeAuthError throw from getCurrentRepoStatus
+// (the bare `throw err` at current-repo-url.ts:126 — e.g. a non-auth runtime
+// blip) would otherwise escape uncaught (no Sentry, no client error, no
+// failed-status). The cc-dispatcher precedent does NOT share this seam (its read
+// is inside an existing try). Wrap the read in a fail-open try/catch that mirrors
+// to Sentry and PROCEEDS (degrade to the existing repo-less / #5392 path) rather
+// than dead-ending the dispatch.
+let repoReadiness: RepoReadiness;
+try {
+  const { repoStatus, repoError } = await getCurrentRepoStatus(userId);
+  repoReadiness = evaluateRepoReadiness(repoStatus, repoError);
+} catch (err) {
+  // Unexpected status-read throw at this pre-try call site — mirror and
+  // fail OPEN (proceed). Never block a dispatch on a readiness-read blip.
+  reportSilentFallback(err, {
+    feature: "agent-runner",
+    op: "repo-readiness-gate.read",
+    extra: { userId, conversationId },
+  });
+  repoReadiness = { ok: true };
+}
 if (!repoReadiness.ok) {
   // Honest client message; SKIP Sentry (expected transient/benign, not an
   // incident); do NOT mark the conversation failed (a cloning/error block
   // must not nuke a resumable conversation). Info breadcrumb keeps the rate
   // observable in Better Stack (alert on a code=error spike, never cloning).
+  // Carry the sanitized message so the Better Stack line is self-contained for
+  // triage (silent-failure review F2 — the reason is sanitized by the evaluator,
+  // no leak). Use hashUserId for log parity with cc-dispatcher.ts:3352 (F-P2).
   log.info(
     {
       feature: "agent-runner",
       op: "repo-readiness-gate",
       code: repoReadiness.code,
-      userId,
+      userIdHash: hashUserId(userId),
       conversationId,
       leaderId,
+      reason: repoReadiness.message,
     },
     "repo-readiness gate: blocked legacy-leader dispatch (repo not ready)",
   );
@@ -147,20 +208,29 @@ if (!repoReadiness.ok) {
 }
 ```
 
+This wrapper needs imports `RepoReadiness` from `./repo-readiness`, `reportSilentFallback`
+(already imported at `agent-runner.ts:70`), and `hashUserId` (verify import — it is used by
+cc-dispatcher; confirm the same helper is importable in agent-runner at /work time, else fall back
+to the existing `userId` field shape but document the divergence).
+
 ### Placement decision — pre-lease early-return (Option A, recommended)
 
 Two placements were considered; this is a genuine architectural choice for plan-review to weigh.
 
-- **Option A — gate at the top of `startAgentSession`, before `registerSession` and before
-  `resolveKeyOwnerThenLease`, early-`return`ing on `!ok` (RECOMMENDED).** `getCurrentRepoStatus`
-  self-mints its tenant client, so the read does not need the lease or the in-callback
-  `sessionTenant`/`workspacePath`. Gating here means a not-ready dispatch acquires **no BYOK
-  lease**, fetches **no credential**, spawns **no agent**, and attempts **no clone** — the
-  faithful "close the race at the source" intent. The honest message + Sentry-skip are emitted
-  inline (no throw), so the existing outer catch is untouched. Cost: one early `sendToClient` +
-  `return` block that does not route through the existing catch ladder; must `return` (not
-  `throw`) so the lease body never runs. MUST sit before `registerSession` so a blocked turn
-  never leaves a dangling registered session (see Sharp Edges).
+- **Option A — gate as the FIRST statement of `startAgentSession`, ABOVE the supersede-abort
+  (`const existing = getSession(...)` at `:876`) and ABOVE `registerSession` (`:885`),
+  early-`return`ing on `!ok` (RECOMMENDED).** `getCurrentRepoStatus` self-mints its tenant client,
+  so the read does not need the lease or the in-callback `sessionTenant`/`workspacePath`. Gating
+  here means a not-ready dispatch acquires **no BYOK lease**, fetches **no credential**, spawns
+  **no agent**, attempts **no clone**, and (load-bearing) does **not abort the user's in-flight
+  prior session** — the faithful "close the race at the source" intent. The honest message +
+  Sentry-skip are emitted inline (no throw), so the existing outer catch is untouched. Costs/risks
+  the implementer MUST handle: (1) the gate sits ABOVE the outer `try` (`:930`), so the
+  `getCurrentRepoStatus` read MUST be wrapped in its own fail-open try/catch (a non-RuntimeAuthError
+  throw at `current-repo-url.ts:126` would otherwise escape uncaught — silent-failure review F1,
+  HIGH); (2) it must `return` (not `throw`) so the lease body never runs; (3) it must sit above
+  `getSession`/`abort` at `:876`, not merely above `registerSession`, so a blocked turn never
+  mutates session state (architecture review P1).
 
 - **Option B — gate inside the lease callback, after `workspacePath = resolveActiveWorkspacePath`
   (`:1004`) and before `ensureWorkspaceDirExists`/`.git`-absent reprovision, throwing
@@ -170,6 +240,19 @@ Two placements were considered; this is a genuine architectural choice for plan-
   (wasted work for a known-not-ready dispatch), and the catch branch must additionally skip the
   `updateConversationStatusIfActive(..., "failed")` write — which the cc-dispatcher catch does not
   have to think about (it has no failed-status write in that ladder).
+
+### Multi-leader fan-out (legacy-path-specific behavior)
+
+`sendUserMessage`'s multi-leader branch calls `dispatchToLeaders` (`agent-runner.ts:~2550`),
+which fans out to `startAgentSession` at `:2576` and `:2587` — one closure per leader. Because the
+gate lives INSIDE `startAgentSession`, every leader's dispatch is gated (good — full coverage), but
+a single not-ready multi-leader dispatch will emit **N identical `{ type: "error" }` frames** (one
+per leader). The Concierge path has no such fan-out, so this is a legacy-path-specific behavior the
+"single point" framing glosses (architecture review P1). **Disposition: accept the N-emit** — it is
+not a correctness bug (each frame is the honest message), the client already renders error toasts
+idempotently for a given conversation, and gating once before fan-out would re-introduce a second
+gate site the source plan deliberately rejected. AC10 documents the accepted behavior; do NOT add a
+pre-fan-out gate.
 
 **Recommendation: Option A.** It is cheaper (no lease/credential for a not-ready dispatch),
 matches the source-gate intent more faithfully ("before spawn/clone"), and avoids threading a new
@@ -218,6 +301,10 @@ existing `agent-runner-reprovision.test.ts` mock harness which already mocks `@s
   4. `getCurrentRepoStatus` → `{ repoStatus: "not_connected", repoError: null }` (fail-open
      default): gate is a no-op (same as case 3) — proves a not-connected workspace flows
      unchanged into the existing repo-less / #5392 path.
+  5. `getCurrentRepoStatus` mock REJECTS (throws a non-RuntimeAuthError): the gate's fail-open
+     try/catch fires — `reportSilentFallback` is called with
+     `op: "repo-readiness-gate.read"`, the gate does NOT emit an error frame, and dispatch
+     PROCEEDS (no dead-end). Verifies AC11 (the F1 fix).
 
 ## Acceptance Criteria
 
@@ -243,9 +330,23 @@ existing `agent-runner-reprovision.test.ts` mock harness which already mocks `@s
 - **AC8** — `cd apps/web-platform && ./node_modules/.bin/vitest run test/agent-runner-repo-readiness-gate.test.ts test/repo-readiness.test.ts` passes (the new wiring test + the unchanged evaluator suite).
 - **AC9** — The gate is the single point covering all legacy-leader entry points:
   `git grep -n "startAgentSession(" apps/web-platform/server` confirms the ws-handler
-  `pendingLeader` call (`ws-handler.ts:2241`) and the three `sendUserMessage` call sites
-  (`agent-runner.ts:2793/2817/2833`) all route through the gated function — no per-caller wiring
-  is added.
+  `pendingLeader` call (`ws-handler.ts:2241`), the three `sendUserMessage` call sites
+  (`agent-runner.ts:2793/2817/2833`), AND the `dispatchToLeaders` fan-out sites
+  (`agent-runner.ts:2576/2587`) all route through the gated function — no per-caller wiring is
+  added.
+- **AC10** — The gate sits ABOVE `const existing = getSession(...)` (`agent-runner.ts:~876`) and
+  ABOVE `registerSession` (`~:885`): a blocked dispatch must not abort the in-flight prior session
+  or register a dangling session. Verified by Phase 0 reading + a test assertion that a `cloning`
+  block does NOT call `getSession`/`registerSession` (mock assertion) — or, minimally, a code
+  review check that no session-mutating call precedes the gate.
+- **AC11** — The gate read is fail-open on an unexpected throw: if `getCurrentRepoStatus` rejects
+  (non-RuntimeAuthError), the gate mirrors via `reportSilentFallback`
+  (`op: "repo-readiness-gate.read"`) and PROCEEDS (does not block, does not dead-end). Verified by a
+  wiring test case 5: `getCurrentRepoStatus` mock rejects → dispatch proceeds + `reportSilentFallback`
+  called + no error frame emitted by the gate.
+- **AC12** — A not-ready multi-leader dispatch (`dispatchToLeaders`) emits one error frame per
+  leader (accepted N-emit). Documented, not gated pre-fan-out. (Behavioral note; no new test
+  required beyond AC1/AC2 which already cover the single-leader emit.)
 
 ### Post-merge (operator)
 
@@ -262,8 +363,8 @@ liveness_signal:
   alert_target: "Better Stack — alert on a code=error spike; NEVER alert on cloning (expected transient)"
   configured_in: "apps/web-platform/server/agent-runner.ts (gate block) + existing pino->Better Stack log pipeline"
 error_reporting:
-  destination: "Sentry — INTENTIONALLY SKIPPED for RepoNotReady blocks (expected transient/benign, not an incident); the underlying repo-setup error was already mirrored at the /api/repo/setup write boundary and getCurrentRepoStatus mirrors a status-read DB error via reportSilentFallback"
-  fail_loud: "the gate is fail-open (read blip -> not_connected -> no block); a genuine status-read DB error is mirrored inside getCurrentRepoStatus (reportSilentFallback, already shipped) — not silently swallowed"
+  destination: "Sentry — INTENTIONALLY SKIPPED for RepoNotReady blocks (expected transient/benign, not an incident); the underlying repo-setup error was already mirrored at the /api/repo/setup write boundary. An UNEXPECTED throw from the gate read (non-RuntimeAuthError, current-repo-url.ts:126) IS mirrored via the gate's own fail-open try/catch (reportSilentFallback op=repo-readiness-gate.read) — the F1 fix, NOT skipped."
+  fail_loud: "the gate is fail-open (read blip / unexpected throw -> proceed, never block). Precise carve-out: the STATUS read (workspaces.repo_status) mirrors a DB error via reportSilentFallback inside getCurrentRepoStatus (already shipped); the REASON read (users.repo_error, current-repo-url.ts:159-163) fails open to generic copy WITHOUT a mirror BY DESIGN — accepted because it only degrades message specificity, never readiness. AC6 forbids touching that file, so this carve-out is stated, not fixed."
 failure_modes:
   - mode: "false-positive block of a ready founder"
     detection: "evaluateRepoReadiness is fail-open by construction (only cloning/error block); a code=cloning breadcrumb for a user whose workspaces.repo_status is ready would indicate a status-read consistency bug"
@@ -313,14 +414,26 @@ No open issue touches `repo-readiness.ts` or the readiness-gate code path. No fo
 
 ## Risks & Mitigations
 
-- **Risk: Option A's early `return` leaves a registered session dangling.** `startAgentSession`
-  calls `registerSession(userId, conversationId, session, leaderId)` near its top (`~:884`,
-  preceded by a supersede-abort of any existing session). If the gate returns AFTER
-  `registerSession`, a blocked turn registers then immediately abandons a session entry.
-  **Mitigation:** place the gate BEFORE `registerSession` (and before the supersede-abort) so a
-  blocked dispatch never mutates session state. /work Phase 0 MUST read `agent-runner.ts:875-890`
-  and confirm the exact ordering; document the chosen ordering in the PR body. (This is the
-  load-bearing Option-A correctness detail — see Sharp Edges.)
+- **Risk (silent-failure review F1, HIGH): Option A's gate sits ABOVE the outer `try` (`:930`), so
+  an unexpected throw from `getCurrentRepoStatus` escapes uncaught.** `getCurrentRepoStatus`
+  fails-open only for `RuntimeAuthError` (`current-repo-url.ts:116-125`) and `statusRes.error`
+  (`:147-153`); any OTHER throw hits the bare `throw err` at `:126` and propagates UP — past the
+  new pre-`try` gate, out of `startAgentSession` entirely. The user gets no error frame, the
+  conversation is not marked failed, and Sentry may or may not see it depending on the caller's
+  await handling. The cc-dispatcher precedent does NOT share this seam (its read is inside an
+  existing `try`). **Mitigation (in the gate snippet above):** wrap the gate read in its own
+  fail-open try/catch — mirror via `reportSilentFallback` (`op: "repo-readiness-gate.read"`) and
+  set `repoReadiness = { ok: true }` (proceed; degrade to the existing repo-less / #5392 path).
+  AC11 + wiring test case 5 verify it.
+- **Risk (architecture review P1): Option A's early `return`/blocked dispatch must not abort the
+  in-flight prior session or leave a dangling registered one.** `startAgentSession` runs a
+  supersede-abort (`const existing = getSession(...)` at `:876`) then `registerSession` at `:885`.
+  If the gate sits BELOW `:876`, a blocked not-ready dispatch first kills the user's running prior
+  turn, then bails — leaving the conversation with no active session and no replacement.
+  **Mitigation:** place the gate as the FIRST statement of `startAgentSession`, ABOVE `:876` (not
+  merely above `registerSession`). /work Phase 0 MUST read `agent-runner.ts:870-890` and pin the
+  exact insertion point (immediately after the JSDoc/param list); AC10 asserts no session-mutating
+  call precedes the gate. (Load-bearing — see Sharp Edges.)
 - **Risk: extra DB read on the leader hot path.** `getCurrentRepoStatus` adds one tenant-mint +
   two parallel selects per leader dispatch. The cc-dispatcher path parallelized it into an
   existing `Promise.all`; the legacy path has no such pre-lease `Promise.all`, so under Option A it
@@ -342,10 +455,16 @@ No open issue touches `repo-readiness.ts` or the readiness-gate code path. No fo
 
 - A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder
   text, or omits the threshold will fail `deepen-plan` Phase 4.6. (Section is filled above.)
-- **Option A ordering is load-bearing.** The gate's early `return` must sit before
-  `registerSession`/the supersede-abort, or a blocked turn registers-then-abandons a session. The
-  cc-dispatcher gate did not face this because it lives inside the factory, not at a session-
-  registration boundary. /work Phase 0 must read `agent-runner.ts:875-890` and pin the ordering.
+- **Option A ordering is load-bearing.** The gate must sit ABOVE `const existing = getSession(...)`
+  (`:876`) — not merely above `registerSession` (`:885`). Placing it between the two still kills
+  the in-flight prior session before bailing. The cc-dispatcher gate did not face this because it
+  lives inside the factory, not at a session-registration boundary. /work Phase 0 must read
+  `agent-runner.ts:870-890` and pin the exact insertion point.
+- **Option A introduces a pre-`try` uncaught-throw seam the cc-dispatcher precedent lacks.** The
+  gate read sits above the outer `try` (`:930`); a non-RuntimeAuthError throw from
+  `getCurrentRepoStatus` (`current-repo-url.ts:126`) would escape uncaught (no Sentry, no client
+  error). The gate snippet's fail-open try/catch is NOT optional — it is the F1 fix. Do not drop
+  it as "defensive boilerplate."
 - **Do not add a new error-branch to the outer catch under Option A.** The early-return design
   intentionally bypasses the catch ladder (which marks conversations failed + clears session
   state). Adding both the early return AND a catch branch would double-handle the block. Choose

--- a/knowledge-base/project/plans/2026-06-16-feat-gate-legacy-leader-dispatch-on-repo-status-plan.md
+++ b/knowledge-base/project/plans/2026-06-16-feat-gate-legacy-leader-dispatch-on-repo-status-plan.md
@@ -1,0 +1,378 @@
+---
+title: "feat: Gate the legacy startAgentSession leader dispatch path on repo_status"
+issue: 5399
+type: enhancement
+branch: feat-one-shot-gate-legacy-leader-repo-status
+lane: cross-domain
+created: 2026-06-16
+requires_cpo_signoff: false
+brand_survival_threshold: single-user incident
+---
+
+# feat: Gate the legacy `startAgentSession` leader dispatch path on `repo_status`
+
+> Spec lacks valid `lane:` (no spec.md for this branch) — defaulted to `cross-domain` (TR2 fail-closed).
+
+## Overview
+
+#5395 (PR for the issue keyed as #5394 in code comments) added a server-authoritative
+repo-readiness gate to the **Concierge / `/soleur:go`** dispatch path — the
+`realSdkQueryFactory` choke point in `apps/web-platform/server/cc-dispatcher.ts`. It blocks a
+dispatch whose active workspace `repo_status` is `cloning` or `error` BEFORE spawning the agent
+or attempting a clone. That gate intentionally scoped to the Concierge surface and explicitly
+deferred the **legacy leader path** as AC10 (the follow-up issue is this one, #5399).
+
+The legacy leader path — `startAgentSession` (`apps/web-platform/server/agent-runner.ts:859`) —
+is a co-equal, still-un-gated dispatch subsystem. It runs its OWN workspace-prep +
+`ensureWorkspaceRepoCloned` (`~:1081`), reached from the ws-handler legacy `pendingLeader` branch
+(`ws-handler.ts:2241`) AND from `sendUserMessage` (`agent-runner.ts:2793/2817/2833`, multi-leader
+dispatch). `agent-runner.ts:1097` explicitly marks it "No outer `repo_status` gate" — a
+deliberate pre-existing seam. A dispatch through this path against a `cloning`/`error` workspace
+still reaches the repo-less / not-ready path (caught only by #5392's deterministic fail-loud
+fallback, not prevented at the source).
+
+**This plan** applies the same readiness gate to the legacy leader path, **reusing the primitives
+that #5395 already shipped and tested** — `getCurrentRepoStatus` (`current-repo-url.ts:106`),
+`evaluateRepoReadiness` + `RepoNotReadyError` (`repo-readiness.ts`). **No new predicate, no new
+error class, no new copy.** The work is wiring: read `repo_status` before `startAgentSession`
+spawns, evaluate readiness, and on `!ok` route an honest client message through the legacy path's
+error surface with the Sentry-mirror SKIP (a `cloning`/`error` block is an expected transient
+state, not an incident) and WITHOUT marking the conversation `failed` (a transient block must not
+nuke a resumable conversation).
+
+This is a pure code change against an already-provisioned surface: no new infrastructure, no UI,
+no schema/migration, no new dependency. The gate reads an existing column.
+
+## Premise Validation
+
+All references in the issue were verified against `origin/main` at plan time:
+
+- **#5399 is OPEN** (`gh issue view 5399`) — `closedByPullRequestsReferences: []`. Not stale; it
+  is the legitimate AC10 follow-up filed by the source plan (`...block-dispatch...plan.md:270`).
+- **#5392 is MERGED** (`fix(concierge): fail loud on repo-less workspace…`). The deterministic
+  fail-loud fallback exists.
+- **#5394 PR number does not resolve** (`gh pr view 5394` → "Could not resolve to a
+  PullRequest"). The gate work merged as **PR #5395** (`gh pr view 5395` → MERGED,
+  `feat(concierge): block dispatch until repo_status=ready…`, commit `867f77978`). Code comments
+  cite "#5394" (the issue), the PR was #5395. Not a fabricated reference — issue-vs-PR number
+  divergence, confirmed by both `gh pr view` and `git show origin/main`.
+- **Cited primitives all exist on `origin/main`:** `evaluateRepoReadiness` + `RepoNotReadyError`
+  + `RepoReadiness` + `REPO_CLONING_MSG` + `repoErrorMsg` in
+  `apps/web-platform/server/repo-readiness.ts`; `getCurrentRepoStatus` at
+  `apps/web-platform/server/current-repo-url.ts:106` returning
+  `{ repoStatus: string, repoError: string | null }`.
+- **Cited legacy-path sites all exist verbatim:** `startAgentSession` at `agent-runner.ts:859`;
+  `ensureWorkspaceRepoCloned` call inside the `.git`-absent block at `~:1081`; "No outer
+  `repo_status` gate" marker at `~:1097`; ws-handler `pendingLeader` → `startAgentSession` at
+  `ws-handler.ts:2241`.
+- **Mechanism is not in a rejected-alternatives ADR table:** the source plan's Reconciliation
+  table explicitly RECOMMENDS extending the same gate to the legacy path as a follow-up — this
+  plan executes that recommendation; it is not re-litigating a rejected design.
+
+No external premises remain unvalidated.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Spec/issue claim | Reality on `origin/main` | Plan response |
+| --- | --- | --- |
+| "read `repo_status` via `getCurrentRepoStatus` before `startAgentSession` spawns" | `getCurrentRepoStatus(userId)` does its OWN `getFreshTenantClient(userId)` (`current-repo-url.ts:113`) — it does NOT depend on the in-callback `sessionTenant` or the BYOK lease. | The gate CAN run at the **top of `startAgentSession`, before `resolveKeyOwnerThenLease`** (Option A below), so a not-ready dispatch never even acquires the BYOK lease. This is a cleaner placement than cc-dispatcher's (which is inside the lease body because it parallelizes the read into an existing `Promise.all`). |
+| "route through the legacy path's error surface" | The legacy outer catch (`agent-runner.ts:2475-2514`) ends in a generic `else` that `Sentry.captureException(err)` AND `updateConversationStatusIfActive(..., "failed")`. `resolveSessionErrorCode` (`:110`) returns `undefined` for `RepoNotReadyError`. | The honest message + `errorCode` must be emitted via a branch that SKIPS both the Sentry mirror and the failed-status write, reading `err.errorCode` directly (mirrors cc-dispatcher catch B at `:3422`). |
+| "single point of gating" | `startAgentSession` is the single function reached by BOTH ws-handler `pendingLeader` (`:2241`) and `sendUserMessage`'s three call sites (`:2793/2817/2833`). | A single gate inside (or at the top of) `startAgentSession` is server-authoritative for the ENTIRE legacy-leader surface — no per-caller wiring needed. |
+| `repo_status` lives on `users` (legacy SOLO column) | Post-ADR-044 it is read from `workspaces` (source of truth) by `getCurrentRepoStatus`; the sanitized reason comes from `users.repo_error`. | Reuse `getCurrentRepoStatus` verbatim — it already encodes the ADR-044 source-of-truth split, so an invited member on a shared `cloning` workspace is gated correctly (the #4543 divergence is not re-created). |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a leader/CPO chat turn dispatched against a
+still-`cloning` or `error`'d repository — the same flailing / dead-end "No Git repository" symptom
+the Concierge gate already closes — OR (false-positive) a `ready` founder's leader turn wrongly
+blocked with "your repository is still being set up." The pure evaluator is **fail-open** (only
+`cloning`/`error` block; a read blip → `not_connected` → `{ ok: true }`), so the false-positive
+mode is bounded to a genuine `cloning`/`error` state.
+
+**If this leaks, the user's workflow / data is exposed via:** the error-branch message embeds the
+repo-setup failure reason. The reason is sanitized at rest (`/api/repo/setup` → `sanitizeGitStderr`)
+AND re-sanitized defensively inside `evaluateRepoReadiness` (`repo-readiness.ts` `error` branch,
+via `parseErrorPayload` + `sanitizeGitStderr`), so a legacy plain-stderr row cannot leak an
+absolute path / raw stderr. This plan reuses that path unchanged — no new leak surface.
+
+**Brand-survival threshold:** `single-user incident`. A single founder hitting a broken dispatch
+on the leader surface is a brand-visible incident; the source gate was filed at the same
+threshold. Inherited from the source plan's framing (#5395).
+
+Per the threshold-driven requirement: `single-user incident` normally adds `requires_cpo_signoff:
+true`. Here the approach was already framed and CPO-acked at the source-gate brainstorm/plan
+(#5395), and this follow-up reuses the identical primitives + design with zero net-new decision
+surface — `requires_cpo_signoff: false`, with the rationale recorded here. `user-impact-reviewer`
+WILL run at review time (review-skill conditional-agent block fires on the `single-user incident`
+threshold).
+
+## Design
+
+### The gate
+
+```ts
+// apps/web-platform/server/agent-runner.ts — top of startAgentSession,
+// BEFORE resolveKeyOwnerThenLease (the lease body), before registerSession.
+//
+// #5399 — legacy-leader repo-readiness gate (follow-up to #5395 AC10).
+// getCurrentRepoStatus self-mints its tenant client, so this runs without
+// the BYOK lease — a cloning/error workspace never acquires a key, never
+// spawns an agent, never attempts a clone. Server-authoritative for the
+// WHOLE legacy surface (ws-handler pendingLeader :2241 + sendUserMessage
+// :2793/:2817/:2833 all funnel through startAgentSession).
+const { repoStatus, repoError } = await getCurrentRepoStatus(userId);
+const repoReadiness = evaluateRepoReadiness(repoStatus, repoError);
+if (!repoReadiness.ok) {
+  // Honest client message; SKIP Sentry (expected transient/benign, not an
+  // incident); do NOT mark the conversation failed (a cloning/error block
+  // must not nuke a resumable conversation). Info breadcrumb keeps the rate
+  // observable in Better Stack (alert on a code=error spike, never cloning).
+  log.info(
+    {
+      feature: "agent-runner",
+      op: "repo-readiness-gate",
+      code: repoReadiness.code,
+      userId,
+      conversationId,
+      leaderId,
+    },
+    "repo-readiness gate: blocked legacy-leader dispatch (repo not ready)",
+  );
+  sendToClient(userId, {
+    type: "error",
+    message: repoReadiness.message,
+    ...(repoReadiness.errorCode ? { errorCode: repoReadiness.errorCode } : {}),
+  });
+  return; // no lease, no agent, no clone
+}
+```
+
+### Placement decision — pre-lease early-return (Option A, recommended)
+
+Two placements were considered; this is a genuine architectural choice for plan-review to weigh.
+
+- **Option A — gate at the top of `startAgentSession`, before `registerSession` and before
+  `resolveKeyOwnerThenLease`, early-`return`ing on `!ok` (RECOMMENDED).** `getCurrentRepoStatus`
+  self-mints its tenant client, so the read does not need the lease or the in-callback
+  `sessionTenant`/`workspacePath`. Gating here means a not-ready dispatch acquires **no BYOK
+  lease**, fetches **no credential**, spawns **no agent**, and attempts **no clone** — the
+  faithful "close the race at the source" intent. The honest message + Sentry-skip are emitted
+  inline (no throw), so the existing outer catch is untouched. Cost: one early `sendToClient` +
+  `return` block that does not route through the existing catch ladder; must `return` (not
+  `throw`) so the lease body never runs. MUST sit before `registerSession` so a blocked turn
+  never leaves a dangling registered session (see Sharp Edges).
+
+- **Option B — gate inside the lease callback, after `workspacePath = resolveActiveWorkspacePath`
+  (`:1004`) and before `ensureWorkspaceDirExists`/`.git`-absent reprovision, throwing
+  `RepoNotReadyError`; add a new `else if (err instanceof RepoNotReadyError)` branch in the outer
+  catch (`:2475`) ABOVE the generic `else`.** This mirrors cc-dispatcher exactly (one throw, one
+  catch branch). Cost: the BYOK lease is acquired and a credential fetched before the gate fires
+  (wasted work for a known-not-ready dispatch), and the catch branch must additionally skip the
+  `updateConversationStatusIfActive(..., "failed")` write — which the cc-dispatcher catch does not
+  have to think about (it has no failed-status write in that ladder).
+
+**Recommendation: Option A.** It is cheaper (no lease/credential for a not-ready dispatch),
+matches the source-gate intent more faithfully ("before spawn/clone"), and avoids threading a new
+branch through the most delicate part of the runner (the outer catch that also clears
+session_id-adjacent state and marks conversations failed). The Sentry-skip + no-failed-write are
+satisfied by construction (the early return never reaches either). The trade-off — a second
+client-emit path that does not share the catch ladder — is acceptable because the emit is a single
+`sendToClient` reusing the exact shape cc-dispatcher catch B uses.
+
+### Why no new test for the evaluator
+
+`evaluateRepoReadiness`'s branches (`cloning` / `error` / fail-open default) are already fully
+covered by `apps/web-platform/test/repo-readiness.test.ts`. This plan adds only a **wiring** test
+for the legacy path (the gate read → block → honest emit → Sentry-skip → no-spawn), mirroring the
+existing `agent-runner-reprovision.test.ts` mock harness which already mocks `@sentry/nextjs`
+(`captureException`), `../server/ws-handler` (`sendToClient`), and `../server/current-repo-url`.
+
+## Files to Edit
+
+- `apps/web-platform/server/agent-runner.ts` — add the gate (Option A: top of `startAgentSession`
+  before `registerSession`/`resolveKeyOwnerThenLease`, early-return on `!ok`). Imports: verify
+  whether `getCurrentRepoStatus` is already in the existing `./current-repo-url` import line
+  (`getCurrentRepoUrl` is) and extend it rather than duplicate; add `evaluateRepoReadiness` from
+  `./repo-readiness`. Under Option A the early-return path does not throw the class, so
+  `RepoNotReadyError` import is **not** required — include it only if Option B is chosen at /work
+  time.
+- (Option B only, if chosen) `apps/web-platform/server/agent-runner.ts` outer catch (`:2475`) —
+  new `else if (err instanceof RepoNotReadyError)` branch above the generic `else`, emitting
+  `err.message` + `err.errorCode`, skipping Sentry + the failed-status write.
+
+## Files to Create
+
+- `apps/web-platform/test/agent-runner-repo-readiness-gate.test.ts` — wiring test (vitest, node
+  project; path matches the `test/**/*.test.ts` include glob in `vitest.config.ts`). Mirrors
+  `agent-runner-reprovision.test.ts` hoisted-mock harness (which already mocks `@sentry/nextjs`,
+  `../server/ws-handler`, `../server/current-repo-url`). Cases:
+  1. `getCurrentRepoStatus` → `{ repoStatus: "cloning", repoError: null }`: asserts `sendToClient`
+     receives `{ type: "error", message: REPO_CLONING_MSG }` (no `errorCode`); `query` (SDK) NOT
+     called; `captureException` NOT called; conversation NOT marked failed.
+  2. `getCurrentRepoStatus` → `{ repoStatus: "error", repoError: <sanitized JSON payload> }`:
+     asserts `sendToClient` message matches `repoErrorMsg(...)` AND carries
+     `errorCode: "repo_setup_failed"`; `query` NOT called; `captureException` NOT called.
+  3. `getCurrentRepoStatus` → `{ repoStatus: "ready", repoError: null }`: gate is a no-op — the
+     existing dispatch path proceeds (assert the gate's `sendToClient` error-emit is NOT fired;
+     downstream mocks may short-circuit the rest of the session).
+  4. `getCurrentRepoStatus` → `{ repoStatus: "not_connected", repoError: null }` (fail-open
+     default): gate is a no-op (same as case 3) — proves a not-connected workspace flows
+     unchanged into the existing repo-less / #5392 path.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- **AC1** — A leader dispatch (`startAgentSession`) against a `cloning` active workspace spawns NO
+  agent: `query`/SDK is not invoked, no clone is attempted, and the client receives
+  `{ type: "error", message: REPO_CLONING_MSG }`. Verified by the new wiring test case 1.
+- **AC2** — A leader dispatch against an `error` active workspace emits
+  `{ type: "error", message: repoErrorMsg(<sanitized reason>), errorCode: "repo_setup_failed" }`
+  and spawns no agent. Verified by wiring test case 2.
+- **AC3** — A `cloning`/`error` block does NOT mirror to Sentry: `Sentry.captureException` is not
+  called on the gate path. Verified by wiring test cases 1 + 2 asserting the mock is not called.
+- **AC4** — A `cloning`/`error` block does NOT mark the conversation `failed`
+  (`updateConversationStatusIfActive(..., "failed")` not invoked on the gate path) — a transient
+  block must not nuke a resumable conversation. Verified by the wiring test (mock assertion).
+- **AC5** — A `ready` and a `not_connected` workspace are no-ops for the gate: the gate's
+  error-emit does not fire and dispatch proceeds. Verified by wiring test cases 3 + 4.
+- **AC6** — No new predicate / error class / copy is introduced: `git diff origin/main --
+  apps/web-platform/server/repo-readiness.ts apps/web-platform/server/current-repo-url.ts` is
+  empty (the primitives are reused, not modified). Verified by `git diff --stat`.
+- **AC7** — `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` passes.
+- **AC8** — `cd apps/web-platform && ./node_modules/.bin/vitest run test/agent-runner-repo-readiness-gate.test.ts test/repo-readiness.test.ts` passes (the new wiring test + the unchanged evaluator suite).
+- **AC9** — The gate is the single point covering all legacy-leader entry points:
+  `git grep -n "startAgentSession(" apps/web-platform/server` confirms the ws-handler
+  `pendingLeader` call (`ws-handler.ts:2241`) and the three `sendUserMessage` call sites
+  (`agent-runner.ts:2793/2817/2833`) all route through the gated function — no per-caller wiring
+  is added.
+
+### Post-merge (operator)
+
+- None. Pure code change; the `web-platform-release.yml` pipeline restarts the container on merge
+  to main touching `apps/web-platform/**` (path-filtered `on.push`), so the merge itself is the
+  deploy. No migration, no Doppler change, no Terraform.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "structured logger.info breadcrumb on every gate block (op=repo-readiness-gate, code=cloning|error)"
+  cadence: "per blocked legacy-leader dispatch"
+  alert_target: "Better Stack — alert on a code=error spike; NEVER alert on cloning (expected transient)"
+  configured_in: "apps/web-platform/server/agent-runner.ts (gate block) + existing pino->Better Stack log pipeline"
+error_reporting:
+  destination: "Sentry — INTENTIONALLY SKIPPED for RepoNotReady blocks (expected transient/benign, not an incident); the underlying repo-setup error was already mirrored at the /api/repo/setup write boundary and getCurrentRepoStatus mirrors a status-read DB error via reportSilentFallback"
+  fail_loud: "the gate is fail-open (read blip -> not_connected -> no block); a genuine status-read DB error is mirrored inside getCurrentRepoStatus (reportSilentFallback, already shipped) — not silently swallowed"
+failure_modes:
+  - mode: "false-positive block of a ready founder"
+    detection: "evaluateRepoReadiness is fail-open by construction (only cloning/error block); a code=cloning breadcrumb for a user whose workspaces.repo_status is ready would indicate a status-read consistency bug"
+    alert_route: "Better Stack breadcrumb rate (code=cloning) cross-referenced against repo_status; no Sentry page (would flood)"
+  - mode: "status-read DB error"
+    detection: "getCurrentRepoStatus reportSilentFallback (op=read-current-repo-status) — already shipped in #5395"
+    alert_route: "Sentry (existing)"
+  - mode: "leaked raw stderr in error-branch message"
+    detection: "message is built by evaluateRepoReadiness via parseErrorPayload + sanitizeGitStderr (unchanged); covered by repo-readiness.test.ts AC9"
+    alert_route: "n/a — sanitized at rest + re-sanitized in the evaluator; no new surface"
+logs:
+  where: "pino structured logs -> Better Stack (existing web-platform log pipeline)"
+  retention: "existing Better Stack retention (no change)"
+discoverability_test:
+  command: "curl -s deploy.soleur.ai/hooks/deploy-status (deploy health) + Better Stack query feature=agent-runner op=repo-readiness-gate"
+  expected_output: "post-merge: deploy healthy; on a real cloning-window leader dispatch, a code=cloning breadcrumb appears in Better Stack with NO corresponding Sentry event"
+```
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected — this is a server-side dispatch-gating change reusing
+already-shipped primitives. No UI surface (the client receives an existing `{ type: "error" }` WS
+message shape with an existing `errorCode`; no new component, page, or flow). No
+Files-to-Edit/Create path matches the UI-surface term list (`components/**`, `app/**/page.tsx`,
+etc.) — the mechanical Product/UX override does not fire. No engineering-architecture decision
+beyond the Option A/B placement (surfaced for plan-review). Infrastructure: none (Phase 2.8 skip —
+edits only `apps/web-platform/server/` + `apps/web-platform/test/`). GDPR/compliance: the gate
+reads an existing `repo_status` column and reuses the already-audited sanitization path; no new
+regulated-data processing (Phase 2.7 skip — the (a)-(d) expansion triggers also do not fire: no
+new LLM processing, no new cron/distribution surface; brand-survival threshold is inherited from
+#5395, not net-new).
+
+## Open Code-Review Overlap
+
+Two open `code-review` issues mention `agent-runner.ts` in their bodies; both **acknowledged**
+(different concern — neither touches the dispatch-gate / `startAgentSession` entry path this plan
+edits):
+
+- **#3454** (`review: expose pdf_metadata as agent-callable MCP tool`) — PDF-metadata MCP tool
+  surface, unrelated to repo-readiness gating. Stays open.
+- **#3242** (`review: tool_use WS event lacks raw name field for agent consumers`) — WS `tool_use`
+  event shape, unrelated to the dispatch gate. Stays open.
+
+No open issue touches `repo-readiness.ts` or the readiness-gate code path. No fold-in needed.
+
+## Risks & Mitigations
+
+- **Risk: Option A's early `return` leaves a registered session dangling.** `startAgentSession`
+  calls `registerSession(userId, conversationId, session, leaderId)` near its top (`~:884`,
+  preceded by a supersede-abort of any existing session). If the gate returns AFTER
+  `registerSession`, a blocked turn registers then immediately abandons a session entry.
+  **Mitigation:** place the gate BEFORE `registerSession` (and before the supersede-abort) so a
+  blocked dispatch never mutates session state. /work Phase 0 MUST read `agent-runner.ts:875-890`
+  and confirm the exact ordering; document the chosen ordering in the PR body. (This is the
+  load-bearing Option-A correctness detail — see Sharp Edges.)
+- **Risk: extra DB read on the leader hot path.** `getCurrentRepoStatus` adds one tenant-mint +
+  two parallel selects per leader dispatch. The cc-dispatcher path parallelized it into an
+  existing `Promise.all`; the legacy path has no such pre-lease `Promise.all`, so under Option A it
+  is a sequential await at the top of `startAgentSession`. **Mitigation:** the read is fail-open
+  and gates BEFORE the (heavier) lease acquisition + agent spawn, so net latency for a `ready`
+  dispatch is one extra round-trip before work that already does several. Acceptable; note in the
+  PR body. Do NOT attempt to fold it into a `Promise.all` with the lease — the lease body resolves
+  `workspaceId` internally and the gate must precede the lease.
+- **Risk: `RepoNotReadyError` import unused under Option A.** Under the recommended early-return
+  design the class is not thrown, so importing it would be a dead import (lint/tsc noise). Import
+  only `evaluateRepoReadiness` — the message + `errorCode` come from the evaluator's return value,
+  so `REPO_CLONING_MSG`/`repoErrorMsg` are not needed at the gate site either. Verify imports at
+  /work time.
+- **Risk: `getCurrentRepoStatus` already imported?** `agent-runner.ts` imports `getCurrentRepoUrl`
+  from `./current-repo-url` (used in the reprovision block). Verify whether `getCurrentRepoStatus`
+  is already in that import statement; extend it rather than adding a duplicate import line.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder
+  text, or omits the threshold will fail `deepen-plan` Phase 4.6. (Section is filled above.)
+- **Option A ordering is load-bearing.** The gate's early `return` must sit before
+  `registerSession`/the supersede-abort, or a blocked turn registers-then-abandons a session. The
+  cc-dispatcher gate did not face this because it lives inside the factory, not at a session-
+  registration boundary. /work Phase 0 must read `agent-runner.ts:875-890` and pin the ordering.
+- **Do not add a new error-branch to the outer catch under Option A.** The early-return design
+  intentionally bypasses the catch ladder (which marks conversations failed + clears session
+  state). Adding both the early return AND a catch branch would double-handle the block. Choose
+  ONE placement (A or B) at /work time and implement only that one.
+- **`resolveSessionErrorCode` returns `undefined` for `RepoNotReadyError`** (`agent-runner.ts:110`).
+  Under Option B, the catch branch must read `err.errorCode` directly (mirroring cc-dispatcher
+  catch B at `cc-dispatcher.ts:3422`), NOT rely on `resolveSessionErrorCode`. Under Option A this
+  is moot (the evaluator's `errorCode` is spread directly).
+- **Reuse `getCurrentRepoStatus`, not a fresh `users.repo_status` read.** A naive inline
+  `users.repo_status` select would re-create the #4543 invited-member divergence the source plan
+  fixed — `repo_status` lives on `workspaces` post-ADR-044. `getCurrentRepoStatus` encodes the
+  correct source-of-truth split; do not bypass it.
+
+## Alternative Approaches Considered
+
+| Approach | Why not |
+| --- | --- |
+| **Option B (throw `RepoNotReadyError` inside the lease body + new catch branch)** | Acquires the BYOK lease + fetches a credential before the gate fires (wasted work for a known-not-ready dispatch); threads a new branch through the delicate outer catch that also marks conversations failed. Recommended fallback only if Option A's pre-`registerSession` ordering proves infeasible. |
+| **Gate in the ws-handler `pendingLeader` branch (`:2241`)** | Misses the `sendUserMessage` multi-leader entry points (`:2793/2817/2833`). Not server-authoritative for the whole legacy surface. The source plan explicitly dropped the redundant ws-handler short-circuit in favor of the single choke point. |
+| **Make the gate `throw` and rely on the existing generic `else`** | The generic `else` mirrors to Sentry AND marks the conversation failed — exactly the two behaviors a transient `cloning`/`error` block must avoid. Would page on every cloning-window turn and nuke resumable conversations. |
+| **Add a new predicate / error subtype for the legacy path** | Violates the issue's explicit "reuse existing primitives — no new predicate" constraint. The pure evaluator + error class already cover both states and are tested. |
+
+## Out of Scope
+
+- Synchronous clone-await / clone-progress reporting (the source plan's out-of-scope; the gate
+  shows a static "still being set up" message, not a progress bar).
+- Any change to `repo-readiness.ts`, `current-repo-url.ts`, or `/api/repo/setup` (reused
+  unchanged — AC6 enforces an empty diff).
+- Decommissioning the legacy `startAgentSession` path (the issue's re-evaluation note: if the
+  path is later retired, close that as a separate obsolescence task).

--- a/knowledge-base/project/plans/2026-06-16-feat-gate-legacy-leader-dispatch-on-repo-status-plan.md
+++ b/knowledge-base/project/plans/2026-06-16-feat-gate-legacy-leader-dispatch-on-repo-status-plan.md
@@ -121,6 +121,15 @@ blocked with "your repository is still being set up." The pure evaluator is **fa
 `cloning`/`error` block; a read blip → `not_connected` → `{ ok: true }`), so the false-positive
 mode is bounded to a genuine `cloning`/`error` state.
 
+**Degraded-UX mode (accepted, not a data/money/workflow incident):** a not-ready
+**multi-leader** dispatch (`dispatchToLeaders` fan-out) runs the gate once per leader, so the user
+sees **N identical honest error toasts** (one per leader) instead of one. This is bounded to a
+genuine `cloning`/`error` state, each frame carries the same honest copy, and the client renders
+error toasts idempotently per conversation; gating once pre-fan-out would re-introduce a second
+gate site the source plan deliberately rejected. Accepted as-is (AC12) — no data, money, or
+resumable-conversation loss. If the duplicate toasts ever prove noticeable, the fix is client-side
+per-turn dedup of identical `{ type: "error", errorCode }` frames, NOT a server pre-fan-out gate.
+
 **If this leaks, the user's workflow / data is exposed via:** the error-branch message embeds the
 repo-setup failure reason. The reason is sanitized at rest (`/api/repo/setup` → `sanitizeGitStderr`)
 AND re-sanitized defensively inside `evaluateRepoReadiness` (`repo-readiness.ts` `error` branch,

--- a/knowledge-base/project/specs/feat-one-shot-gate-legacy-leader-repo-status/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-gate-legacy-leader-repo-status/session-state.md
@@ -1,0 +1,22 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-06-16-feat-gate-legacy-leader-dispatch-on-repo-status-plan.md
+- Status: complete
+
+### Errors
+None. (`gh pr view 5394` does not resolve — the gate work merged as PR #5395; code comments cite issue #5394. Validated, not an error.)
+
+### Decisions
+- Reuse-only design confirmed against origin/main: `getCurrentRepoStatus`, `evaluateRepoReadiness`, `RepoNotReadyError` and legacy-path sites all exist verbatim; AC6 enforces an empty diff on the primitive files.
+- Recommended Option A (pre-lease early-return gate) over Option B (throw + new catch branch): gating at the top of `startAgentSession` avoids acquiring the BYOK lease for a known-not-ready dispatch.
+- Single choke point covers all legacy-leader entry points (ws-handler `pendingLeader`, three `sendUserMessage` sites, `dispatchToLeaders` fan-out) — no per-caller wiring.
+- Deepen-plan applied 3 substance findings: (HIGH/F1) fail-open try/catch wrapper around the `getCurrentRepoStatus` rethrow seam; (P1) gate must sit above the supersede-abort at :876; (P1) multi-leader fan-out N-emit documented. Plus P2 hashUserId log parity and a precise users.repo_error silent-fail-open carve-out.
+- No cross-domain / UI / infra / GDPR implications — pure server-side change reading an existing column.
+
+### Components Invoked
+- Skill soleur:plan
+- Skill soleur:deepen-plan
+- Agent general-purpose (verify-the-negative grep pass) — 7/7 claims CONFIRMED
+- Agent soleur:engineering:review:architecture-strategist
+- Agent pr-review-toolkit:silent-failure-hunter

--- a/knowledge-base/project/specs/feat-one-shot-gate-legacy-leader-repo-status/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-gate-legacy-leader-repo-status/tasks.md
@@ -5,66 +5,67 @@ Issue: #5399 (AC10 follow-up to #5395). Branch: `feat-one-shot-gate-legacy-leade
 
 ## Phase 0 — Preconditions (read-before-edit)
 
-- [ ] 0.1 Read `apps/web-platform/server/agent-runner.ts:870-930` and pin the exact lines of the
+- [x] 0.1 Read `apps/web-platform/server/agent-runner.ts:870-930` and pin the exact lines of the
       supersede-abort (`const existing = getSession(...)` ~:876), `registerSession` (~:885), and
       the outer `try` (~:930). The Option A gate MUST sit ABOVE the supersede-abort (~:876) — not
       merely above registerSession — and ABOVE the outer try (so the gate read needs its own
       fail-open try/catch; F1). Pin the insertion point as the first statement after the
       JSDoc/param list.
-- [ ] 0.2 Read `apps/web-platform/server/agent-runner.ts:2455-2514` (outer catch) — confirm the
+- [x] 0.2 Read `apps/web-platform/server/agent-runner.ts:2455-2514` (outer catch) — confirm the
       generic `else` mirrors to Sentry AND marks the conversation failed (the two behaviors the
       gate must avoid).
-- [ ] 0.3 Confirm imports: is `getCurrentRepoStatus` already in the `./current-repo-url` import
+- [x] 0.3 Confirm imports: is `getCurrentRepoStatus` already in the `./current-repo-url` import
       line (alongside `getCurrentRepoUrl`)? Extend, do not duplicate. Confirm `evaluateRepoReadiness`
       import path is `./repo-readiness`.
-- [ ] 0.4 `git diff origin/main --stat -- apps/web-platform/server/repo-readiness.ts
+- [x] 0.4 `git diff origin/main --stat -- apps/web-platform/server/repo-readiness.ts
       apps/web-platform/server/current-repo-url.ts` is empty before starting (baseline for AC6).
-- [ ] 0.5 Read `apps/web-platform/test/agent-runner-reprovision.test.ts` to lift the hoisted-mock
+- [x] 0.5 Read `apps/web-platform/test/agent-runner-reprovision.test.ts` to lift the hoisted-mock
       harness (mocks `@sentry/nextjs`, `../server/ws-handler`, `../server/current-repo-url`).
 
 ## Phase 1 — RED (failing wiring test)
 
-- [ ] 1.1 Create `apps/web-platform/test/agent-runner-repo-readiness-gate.test.ts` with cases 1-5
+- [x] 1.1 Create `apps/web-platform/test/agent-runner-repo-readiness-gate.test.ts` with cases 1-5
       from the plan (cloning / error / ready / not_connected / read-throws-fail-open). Assert:
       `sendToClient` shape, `query` (SDK) NOT called on block, `captureException` NOT called on
       block, conversation NOT marked failed on block, `getSession`/`registerSession` NOT called on
       block (AC10), and case 5 → `reportSilentFallback` called + dispatch proceeds (AC11).
-- [ ] 1.2 Run `cd apps/web-platform && ./node_modules/.bin/vitest run
+- [x] 1.2 Run `cd apps/web-platform && ./node_modules/.bin/vitest run
       test/agent-runner-repo-readiness-gate.test.ts` — cases 1/2/5 FAIL on origin/main (no gate yet).
 
 ## Phase 2 — GREEN (implement the gate, Option A)
 
-- [ ] 2.1 Add the gate as the FIRST statement of `startAgentSession`, ABOVE the supersede-abort
+- [x] 2.1 Add the gate as the FIRST statement of `startAgentSession`, ABOVE the supersede-abort
       (~:876) and the outer try: a fail-open try/catch wrapping `getCurrentRepoStatus(userId)` +
       `evaluateRepoReadiness(...)` (catch → `reportSilentFallback` op=repo-readiness-gate.read +
       `repoReadiness = { ok: true }`; F1), then on `!ok`: `log.info` breadcrumb
       (op=repo-readiness-gate, `userIdHash: hashUserId(userId)`, `reason: repoReadiness.message`),
       `sendToClient` honest message + optional errorCode, early `return` (no throw).
-- [ ] 2.2 Extend/add imports: `getCurrentRepoStatus` (verify if already in the `./current-repo-url`
+- [x] 2.2 Extend/add imports: `getCurrentRepoStatus` (verify if already in the `./current-repo-url`
       import), `evaluateRepoReadiness` + `RepoReadiness` from `./repo-readiness`, `reportSilentFallback`
       (already at :70), `hashUserId` (verify importable in agent-runner; else use existing `userId`
       field + document divergence). Do NOT import `RepoNotReadyError` under Option A (unused).
-- [ ] 2.3 Re-run the wiring test — all 4 cases PASS.
+- [x] 2.3 Re-run the wiring test — all 4 cases PASS.
 - [ ] 2.4 (Only if Option A's pre-`registerSession` ordering proves infeasible) pivot to Option B:
+      — NOT NEEDED: Option A's pre-supersede-abort placement worked; no pivot.
       throw `RepoNotReadyError` after `workspacePath` resolves; add `else if (err instanceof
       RepoNotReadyError)` in the outer catch ABOVE the generic `else`, reading `err.errorCode`
       directly, skipping Sentry + the failed-status write. Document the pivot in the PR body.
 
 ## Phase 3 — Verify (full AC sweep)
 
-- [ ] 3.1 AC7: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` passes.
-- [ ] 3.2 AC8: `cd apps/web-platform && ./node_modules/.bin/vitest run
+- [x] 3.1 AC7: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` passes.
+- [x] 3.2 AC8: `cd apps/web-platform && ./node_modules/.bin/vitest run
       test/agent-runner-repo-readiness-gate.test.ts test/repo-readiness.test.ts` passes.
-- [ ] 3.3 AC6: `git diff origin/main --stat -- apps/web-platform/server/repo-readiness.ts
+- [x] 3.3 AC6: `git diff origin/main --stat -- apps/web-platform/server/repo-readiness.ts
       apps/web-platform/server/current-repo-url.ts` is empty (primitives reused, not modified).
-- [ ] 3.4 AC9: `git grep -n "startAgentSession(" apps/web-platform/server` confirms ws-handler
+- [x] 3.4 AC9: `git grep -n "startAgentSession(" apps/web-platform/server` confirms ws-handler
       `pendingLeader` + the three `sendUserMessage` call sites all route through the gated function.
-- [ ] 3.5 Run the full web-platform suite (`./node_modules/.bin/vitest run`) as the exit gate to
+- [x] 3.5 Run the full web-platform suite (`./node_modules/.bin/vitest run`) as the exit gate to
       catch any orphan suite that imports the dispatch path.
 
 ## Phase 4 — Ship
 
-- [ ] 4.1 PR body uses `Closes #5399`. Note the Option A vs B choice + the registerSession
+- [x] 4.1 PR body uses `Closes #5399`. Note the Option A vs B choice + the registerSession
       ordering. Reference the source gate (#5395).
-- [ ] 4.2 No post-merge operator steps (container restart is automatic on merge to main touching
+- [x] 4.2 No post-merge operator steps (container restart is automatic on merge to main touching
       `apps/web-platform/**`).

--- a/knowledge-base/project/specs/feat-one-shot-gate-legacy-leader-repo-status/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-gate-legacy-leader-repo-status/tasks.md
@@ -1,0 +1,62 @@
+# Tasks — Gate the legacy `startAgentSession` leader dispatch path on `repo_status`
+
+Plan: `knowledge-base/project/plans/2026-06-16-feat-gate-legacy-leader-dispatch-on-repo-status-plan.md`
+Issue: #5399 (AC10 follow-up to #5395). Branch: `feat-one-shot-gate-legacy-leader-repo-status`.
+
+## Phase 0 — Preconditions (read-before-edit)
+
+- [ ] 0.1 Read `apps/web-platform/server/agent-runner.ts:859-920` (startAgentSession open,
+      supersede-abort, `registerSession`) and pin the exact line of `registerSession`. The Option A
+      gate MUST sit BEFORE it (Risk + Sharp Edge: dangling-session).
+- [ ] 0.2 Read `apps/web-platform/server/agent-runner.ts:2455-2514` (outer catch) — confirm the
+      generic `else` mirrors to Sentry AND marks the conversation failed (the two behaviors the
+      gate must avoid).
+- [ ] 0.3 Confirm imports: is `getCurrentRepoStatus` already in the `./current-repo-url` import
+      line (alongside `getCurrentRepoUrl`)? Extend, do not duplicate. Confirm `evaluateRepoReadiness`
+      import path is `./repo-readiness`.
+- [ ] 0.4 `git diff origin/main --stat -- apps/web-platform/server/repo-readiness.ts
+      apps/web-platform/server/current-repo-url.ts` is empty before starting (baseline for AC6).
+- [ ] 0.5 Read `apps/web-platform/test/agent-runner-reprovision.test.ts` to lift the hoisted-mock
+      harness (mocks `@sentry/nextjs`, `../server/ws-handler`, `../server/current-repo-url`).
+
+## Phase 1 — RED (failing wiring test)
+
+- [ ] 1.1 Create `apps/web-platform/test/agent-runner-repo-readiness-gate.test.ts` with cases 1-4
+      from the plan (cloning / error / ready / not_connected). Assert: `sendToClient` shape,
+      `query` (SDK) NOT called on block, `captureException` NOT called on block, conversation NOT
+      marked failed on block.
+- [ ] 1.2 Run `cd apps/web-platform && ./node_modules/.bin/vitest run
+      test/agent-runner-repo-readiness-gate.test.ts` — cases 1/2 FAIL on origin/main (no gate yet).
+
+## Phase 2 — GREEN (implement the gate, Option A)
+
+- [ ] 2.1 Add the gate to `startAgentSession` BEFORE `registerSession`/`resolveKeyOwnerThenLease`:
+      `getCurrentRepoStatus(userId)` → `evaluateRepoReadiness(...)` → on `!ok`: `log.info`
+      breadcrumb (op=repo-readiness-gate), `sendToClient` honest message + optional errorCode,
+      early `return` (no throw).
+- [ ] 2.2 Extend/add imports (`getCurrentRepoStatus`, `evaluateRepoReadiness`). Do NOT import
+      `RepoNotReadyError` under Option A (unused → lint/tsc noise).
+- [ ] 2.3 Re-run the wiring test — all 4 cases PASS.
+- [ ] 2.4 (Only if Option A's pre-`registerSession` ordering proves infeasible) pivot to Option B:
+      throw `RepoNotReadyError` after `workspacePath` resolves; add `else if (err instanceof
+      RepoNotReadyError)` in the outer catch ABOVE the generic `else`, reading `err.errorCode`
+      directly, skipping Sentry + the failed-status write. Document the pivot in the PR body.
+
+## Phase 3 — Verify (full AC sweep)
+
+- [ ] 3.1 AC7: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` passes.
+- [ ] 3.2 AC8: `cd apps/web-platform && ./node_modules/.bin/vitest run
+      test/agent-runner-repo-readiness-gate.test.ts test/repo-readiness.test.ts` passes.
+- [ ] 3.3 AC6: `git diff origin/main --stat -- apps/web-platform/server/repo-readiness.ts
+      apps/web-platform/server/current-repo-url.ts` is empty (primitives reused, not modified).
+- [ ] 3.4 AC9: `git grep -n "startAgentSession(" apps/web-platform/server` confirms ws-handler
+      `pendingLeader` + the three `sendUserMessage` call sites all route through the gated function.
+- [ ] 3.5 Run the full web-platform suite (`./node_modules/.bin/vitest run`) as the exit gate to
+      catch any orphan suite that imports the dispatch path.
+
+## Phase 4 — Ship
+
+- [ ] 4.1 PR body uses `Closes #5399`. Note the Option A vs B choice + the registerSession
+      ordering. Reference the source gate (#5395).
+- [ ] 4.2 No post-merge operator steps (container restart is automatic on merge to main touching
+      `apps/web-platform/**`).

--- a/knowledge-base/project/specs/feat-one-shot-gate-legacy-leader-repo-status/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-gate-legacy-leader-repo-status/tasks.md
@@ -5,9 +5,12 @@ Issue: #5399 (AC10 follow-up to #5395). Branch: `feat-one-shot-gate-legacy-leade
 
 ## Phase 0 — Preconditions (read-before-edit)
 
-- [ ] 0.1 Read `apps/web-platform/server/agent-runner.ts:859-920` (startAgentSession open,
-      supersede-abort, `registerSession`) and pin the exact line of `registerSession`. The Option A
-      gate MUST sit BEFORE it (Risk + Sharp Edge: dangling-session).
+- [ ] 0.1 Read `apps/web-platform/server/agent-runner.ts:870-930` and pin the exact lines of the
+      supersede-abort (`const existing = getSession(...)` ~:876), `registerSession` (~:885), and
+      the outer `try` (~:930). The Option A gate MUST sit ABOVE the supersede-abort (~:876) — not
+      merely above registerSession — and ABOVE the outer try (so the gate read needs its own
+      fail-open try/catch; F1). Pin the insertion point as the first statement after the
+      JSDoc/param list.
 - [ ] 0.2 Read `apps/web-platform/server/agent-runner.ts:2455-2514` (outer catch) — confirm the
       generic `else` mirrors to Sentry AND marks the conversation failed (the two behaviors the
       gate must avoid).
@@ -21,21 +24,26 @@ Issue: #5399 (AC10 follow-up to #5395). Branch: `feat-one-shot-gate-legacy-leade
 
 ## Phase 1 — RED (failing wiring test)
 
-- [ ] 1.1 Create `apps/web-platform/test/agent-runner-repo-readiness-gate.test.ts` with cases 1-4
-      from the plan (cloning / error / ready / not_connected). Assert: `sendToClient` shape,
-      `query` (SDK) NOT called on block, `captureException` NOT called on block, conversation NOT
-      marked failed on block.
+- [ ] 1.1 Create `apps/web-platform/test/agent-runner-repo-readiness-gate.test.ts` with cases 1-5
+      from the plan (cloning / error / ready / not_connected / read-throws-fail-open). Assert:
+      `sendToClient` shape, `query` (SDK) NOT called on block, `captureException` NOT called on
+      block, conversation NOT marked failed on block, `getSession`/`registerSession` NOT called on
+      block (AC10), and case 5 → `reportSilentFallback` called + dispatch proceeds (AC11).
 - [ ] 1.2 Run `cd apps/web-platform && ./node_modules/.bin/vitest run
-      test/agent-runner-repo-readiness-gate.test.ts` — cases 1/2 FAIL on origin/main (no gate yet).
+      test/agent-runner-repo-readiness-gate.test.ts` — cases 1/2/5 FAIL on origin/main (no gate yet).
 
 ## Phase 2 — GREEN (implement the gate, Option A)
 
-- [ ] 2.1 Add the gate to `startAgentSession` BEFORE `registerSession`/`resolveKeyOwnerThenLease`:
-      `getCurrentRepoStatus(userId)` → `evaluateRepoReadiness(...)` → on `!ok`: `log.info`
-      breadcrumb (op=repo-readiness-gate), `sendToClient` honest message + optional errorCode,
-      early `return` (no throw).
-- [ ] 2.2 Extend/add imports (`getCurrentRepoStatus`, `evaluateRepoReadiness`). Do NOT import
-      `RepoNotReadyError` under Option A (unused → lint/tsc noise).
+- [ ] 2.1 Add the gate as the FIRST statement of `startAgentSession`, ABOVE the supersede-abort
+      (~:876) and the outer try: a fail-open try/catch wrapping `getCurrentRepoStatus(userId)` +
+      `evaluateRepoReadiness(...)` (catch → `reportSilentFallback` op=repo-readiness-gate.read +
+      `repoReadiness = { ok: true }`; F1), then on `!ok`: `log.info` breadcrumb
+      (op=repo-readiness-gate, `userIdHash: hashUserId(userId)`, `reason: repoReadiness.message`),
+      `sendToClient` honest message + optional errorCode, early `return` (no throw).
+- [ ] 2.2 Extend/add imports: `getCurrentRepoStatus` (verify if already in the `./current-repo-url`
+      import), `evaluateRepoReadiness` + `RepoReadiness` from `./repo-readiness`, `reportSilentFallback`
+      (already at :70), `hashUserId` (verify importable in agent-runner; else use existing `userId`
+      field + document divergence). Do NOT import `RepoNotReadyError` under Option A (unused).
 - [ ] 2.3 Re-run the wiring test — all 4 cases PASS.
 - [ ] 2.4 (Only if Option A's pre-`registerSession` ordering proves infeasible) pivot to Option B:
       throw `RepoNotReadyError` after `workspacePath` resolves; add `else if (err instanceof


### PR DESCRIPTION
## Summary
- Extend the #5395 Concierge repo-readiness gate to the **legacy `startAgentSession` leader dispatch path** — the co-equal, previously-ungated subsystem reached from the ws-handler `pendingLeader` branch, `sendUserMessage`, and the `dispatchToLeaders` fan-out (`agent-runner.ts:1097` explicitly marked it "No outer `repo_status` gate").
- As the **first statement** of `startAgentSession` — above the supersede-abort, `registerSession`, and the outer `try` — read the active workspace `repo_status` via `getCurrentRepoStatus`, evaluate via `evaluateRepoReadiness`, and on `cloning`/`error` emit the honest `{ type: "error" }` frame then early-return: no BYOK lease, no agent spawn, no clone, no session mutation.
- Skip the Sentry mirror (an expected transient/benign state, not an incident) and do **not** mark the conversation `failed` (a transient block must stay resumable). A fail-open `try/catch` around the read mirrors an unexpected throw via `reportSilentFallback` and proceeds.
- **Reuses the already-shipped primitives unchanged** — no new predicate, error class, or copy (empty diff on `repo-readiness.ts` / `current-repo-url.ts`, AC6).

Closes #5399

## User-Brand Impact
- **Artifact exposed if broken:** a leader/CPO chat turn dispatched against a still-`cloning`/`error` workspace (the "No Git repository" dead-end the Concierge gate already closes), OR a false-positive block of a `ready` founder's turn.
- **Exposure vector:** the evaluator is fail-open (only `cloning`/`error` block; a read blip → `not_connected` → `{ ok: true }`), so the false-positive mode is bounded to a genuine not-ready state. The `error`-branch message reuses the already-sanitized reason path (`parseErrorPayload` + `sanitizeGitStderr`) — no new leak surface.
- **Brand-survival threshold:** single-user incident
- A not-ready **multi-leader** dispatch emits one honest error toast per leader (accepted N-emit — degraded-UX, not data/money loss; documented in the plan's User-Brand Impact and AC12).

## Changelog
### Web Platform
- feat(agent-runner): gate the legacy leader dispatch path (`startAgentSession`) on `repo_status`, reusing the #5395 readiness primitives. A `cloning`/`error` workspace is blocked before spawn with an honest client message, the Sentry mirror is skipped, and the conversation is not marked failed.

## Test plan
- [x] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` passes (AC7)
- [x] New wiring suite + unchanged evaluator suite green: `vitest run test/agent-runner-repo-readiness-gate.test.ts test/repo-readiness.test.ts` (AC8)
- [x] Empty diff on the reused primitives `repo-readiness.ts` / `current-repo-url.ts` (AC6)
- [x] Single choke point covers ws-handler `pendingLeader` + the three `sendUserMessage` sites + `dispatchToLeaders` fan-out (AC9)
- [x] Gate-ordering regression guard (AC10) + no-DB-side-effect-on-block assertions (AC4) added
- [x] Full `apps/web-platform` vitest suite (829 files / 10293 tests) and `scripts/test-all.sh` green (EXIT=0)

## Post-merge
- None. Pure server-side code change; the `web-platform-release.yml` pipeline restarts the container on merge to `main` touching `apps/web-platform/**`, so the merge itself is the deploy. No migration, no Doppler change, no Terraform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
