### PR TITLE
fix(feature-tweet): always display the full draft inline for operator approval

### DIFF
--- a/plugins/soleur/skills/feature-tweet/SKILL.md
+++ b/plugins/soleur/skills/feature-tweet/SKILL.md
@@ -157,12 +157,29 @@ On non-zero exit, delete the file and abort.
 
 ## Output
 
-On success, print the draft path and the explicit operator instruction:
+On success, **display the full draft content inline for operator approval** —
+the path alone is not enough, because the operator cannot judge or approve copy
+they cannot see (and a worktree-resident draft may be discarded by cleanup
+before they open the file). Print, in this order:
 
-> Draft written to `<path>`. To publish: set BOTH `publish_date` and
-> `status: scheduled`. The existing content-publisher cron posts it on date.
+1. The draft path.
+2. The complete rendered draft: the `title`, every `## X/Twitter Thread` tweet,
+   and the full `## Bluesky` post — verbatim, exactly as written to the file
+   (read it back with the Read tool rather than reproducing from memory, so what
+   the operator approves is what is on disk).
+3. The explicit operator instruction:
 
-Headless mode never posts — it only writes the draft and prints the path.
+   > Draft written to `<path>`. To publish: set BOTH `publish_date` and
+   > `status: scheduled`. The existing content-publisher cron posts it on date.
+
+This display-for-approval step is mandatory in BOTH interactive and headless
+modes (headless still surfaces the copy in its returned summary so the
+orchestrator/operator sees it) — the draft is operator-gated content, and the
+approval gate is meaningless if the content is never shown. Never reduce the
+output to "draft written to `<path>`" without the copy.
+
+Headless mode never posts — it only writes the draft, displays it, and prints
+the path.
 
 ## Multi-PR contract (v1)
 

--- a/plugins/soleur/skills/postmerge/SKILL.md
+++ b/plugins/soleur/skills/postmerge/SKILL.md
@@ -267,8 +267,13 @@ Branch on the result:
   /soleur:feature-tweet #<merged-pr-number>
   ```
 
-  Surface the resulting draft path in the Phase 7 report with the operator
-  instruction: "set BOTH `publish_date` and `status: scheduled` to publish."
+  Display the resulting draft's **full content** (title + every X tweet + the
+  Bluesky post) inline for operator approval — not just the path — then surface
+  the path in the Phase 7 report with the operator instruction: "set BOTH
+  `publish_date` and `status: scheduled` to publish." The path alone is
+  insufficient: the operator cannot approve copy they cannot see, and a
+  worktree-resident draft can be discarded by cleanup before they open it
+  (`feature-tweet` SKILL.md §Output owns the display-for-approval contract).
 - **Eligible AND `HEALTH_VERIFIED=false`** → do NOT draft (no verified-live
   signal). Print a catch-up instruction instead of silently skipping:
 


### PR DESCRIPTION
## Summary

Feature-tweet drafts were written to disk but only the **path** was printed — so the operator was never shown the copy they were meant to approve, and a worktree-resident draft can be discarded by cleanup before they open the file. This closes that gap so every generated draft is displayed inline for approval.

- `feature-tweet` SKILL.md §Output: mandate displaying the **full rendered draft** (title + every X tweet + the Bluesky post), read back from disk, in BOTH interactive and headless modes, before the path + publish instruction.
- `postmerge` SKILL.md Phase 3.8: display the full draft content inline (not just the path) when the green-gated draft is generated; cross-references the feature-tweet Output contract as the single source of truth.

No behavior change to publishing — drafts remain inert (`status: draft`, empty `publish_date`) until the operator opts in.

## Changelog

### Plugin
- feature-tweet + postmerge skills now display the full feature-tweet draft inline for operator approval instead of only printing the file path.

## Test plan
- [x] `bun test plugins/soleur/test/components.test.ts` green (1226 pass) — frontmatter descriptions unchanged; edits are body-only.
- [x] Docs-only change to two existing SKILL.md files; no code paths touched.

Generated with [Claude Code](https://claude.com/claude-code)