### PR TITLE
fix(feature-tweet): bundle the draft into the shipping PR so it lands on main

### DIFF
--- a/plugins/soleur/skills/feature-tweet/SKILL.md
+++ b/plugins/soleur/skills/feature-tweet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feature-tweet
-description: "This skill should be used when converting a merged, verified-live PR into a draft short-form X post (single tweet or up-to-3-tweet thread) for operator approval."
+description: "This skill should be used when converting a shipping feature PR into a draft short-form X post (single tweet or up-to-3-tweet thread) for operator approval."
 ---
 
 # feature-tweet
@@ -11,8 +11,14 @@ into a **draft** short-form X post — written to the existing
 existing `content-publisher.sh` cron. No new publishing path; nothing
 reaches X until the operator flips `status: draft` → `scheduled`.
 
-Invoked by `/soleur:postmerge` after its production-health check passes (only
-tweet what actually deployed), and runnable standalone as a catch-up path:
+Invoked by `/soleur:ship` (Phase 6 "Feature-Tweet Draft (pre-merge bundle)")
+which commits the draft to the feature branch so it rides the PR into `main` —
+where `content-publisher.sh` reads from. `/soleur:postmerge` Phase 3.8 then
+verifies + displays the on-`main` draft (and warns if deploy health is
+unverified). The draft stays inert (`status: draft`) until the operator
+schedules it, so "only tweet what actually deployed" is preserved by the
+operator's post-deploy publish gate, not by withholding the draft. Also runnable
+standalone as a catch-up path:
 
 ```
 /soleur:feature-tweet #<pr>

--- a/plugins/soleur/skills/postmerge/SKILL.md
+++ b/plugins/soleur/skills/postmerge/SKILL.md
@@ -247,38 +247,52 @@ ROLLBACK_REASON=$(gh run view "$RELEASE_RUN_ID" --log 2>/dev/null \
 
 **Why a watch and not a pre-merge block:** the only faithful validation of a deploy gate is a real deploy, which by definition happens post-merge. The pre-merge half of the rule — ship the gate non-blocking first — lives in `wg-dark-launch-deploy-gates`; this phase is the safety net that catches a gate shipped blocking-first anyway, turning "every deploy silently rolls back" into a named, one-revert recovery. **Why:** #4932 — a canary bwrap probe validated only against an always-succeeding test mock failed on a healthy host and rolled back every web-platform deploy until reverted (#4941).
 
-## Phase 3.8: Feature-Tweet Draft (green-gated)
+## Phase 3.8: Feature-Tweet Draft (verify + display)
 
-Convert a feature **confirmed live** into a draft short-form X post. Runs
-eligibility FIRST, then gates the draft on `HEALTH_VERIFIED` (set in Phase 3).
+The draft is now generated **pre-merge by `/ship`** (Phase 6 "Feature-Tweet
+Draft (pre-merge bundle)") and committed to the feature branch, so for the
+normal `/one-shot` / `/ship` flow it ALREADY landed on `main` with this PR —
+where `content-publisher.sh` reads from. This phase **verifies** that on-`main`
+draft, **displays** it for approval, and warns when deploy health is unverified.
+It only *generates* a draft as a catch-up when `/ship` was hand-rolled and the
+draft never landed.
 
 ```bash
 bash scripts/lib/tweet-eligibility.sh <merged-pr-number>
 ```
 
-Branch on the result:
+Branch on eligibility, then on whether the draft is already on `main`:
 
 - **Ineligible** (exit non-zero, `excluded: <reason>`) → **silent no-op.** Most
   PRs land here (fixes, infra, non-product); exclusion is the designed outcome,
   not a fault. Do not surface it in the report.
-- **Eligible AND `HEALTH_VERIFIED=true`** → invoke the draft generator:
+- **Eligible AND a draft for this PR is on `main`** (the `/ship` pre-merge
+  bundle worked — detect via
+  `git grep -l 'pr_reference: "#<merged-pr-number>"' origin/main -- knowledge-base/marketing/distribution-content/`):
+  **display the draft's full content** (title + every X tweet + the Bluesky
+  post) inline for operator approval — read it back from `main`
+  (`git show origin/main:<path>`), never reproduce from memory. Then:
+  - `HEALTH_VERIFIED=true` → operator instruction: "the draft is on `main`; set
+    BOTH `publish_date` and `status: scheduled` to publish."
+  - `HEALTH_VERIFIED=false` → **warn, do not block:** "the draft is on `main`
+    but production health was NOT verified — do NOT set `status: scheduled`
+    until you confirm the deploy is live." (The draft is inert until then.)
+
+  The display-for-approval contract is owned by `feature-tweet` SKILL.md
+  §Output; the path alone is insufficient (the operator cannot approve copy they
+  cannot see).
+- **Eligible BUT no draft on `main`** (a hand-rolled `/ship` skipped the
+  pre-merge bundle) → catch-up: invoke the draft generator, display it, and note
+  it needs a follow-up commit to reach `main`:
 
   ```
   /soleur:feature-tweet #<merged-pr-number>
   ```
 
-  Display the resulting draft's **full content** (title + every X tweet + the
-  Bluesky post) inline for operator approval — not just the path — then surface
-  the path in the Phase 7 report with the operator instruction: "set BOTH
-  `publish_date` and `status: scheduled` to publish." The path alone is
-  insufficient: the operator cannot approve copy they cannot see, and a
-  worktree-resident draft can be discarded by cleanup before they open it
-  (`feature-tweet` SKILL.md §Output owns the display-for-approval contract).
-- **Eligible AND `HEALTH_VERIFIED=false`** → do NOT draft (no verified-live
-  signal). Print a catch-up instruction instead of silently skipping:
-
-  > Eligible PR #N shipped but no production-health signal was verified — no
-  > draft written. After confirming the deploy, run `/soleur:feature-tweet #N`.
+  > Eligible PR #N had no feature-tweet draft on `main` (the `/ship` pre-merge
+  > bundle was skipped). Generated a catch-up draft — commit it to `main` via a
+  > follow-up PR so `content-publisher.sh` can drain it, then set `publish_date`
+  > + `status: scheduled` once the deploy is confirmed.
 
 **Multi-PR contract (explicit v1):** one tweet per eligible PR, using postmerge's
 single bound PR number. If a deploy bundled multiple PRs, only the bound PR is

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -1153,6 +1153,43 @@ Replace `semver:patch` with `semver:minor` or `semver:major` as appropriate. Rep
 
 **Step 5:** Validate consistency -- if new agents, skills, or commands were detected in Step 1 but the label is `semver:patch`, warn the user that the label may be incorrect. New components typically warrant `semver:minor`.
 
+### Feature-Tweet Draft (pre-merge bundle)
+
+Generate any eligible feature-tweet draft NOW — after the semver/`app:*` labels
+are applied (eligibility reads the PR labels + title) — and **commit it to the
+feature branch** so it rides this PR into `main`, where `content-publisher.sh`
+reads from. This replaces the old post-merge generation, which wrote the draft
+into a worktree that `cleanup-merged` reaps before it ever reaches `main` (so
+the cron never saw it). The draft is **inert** (`status: draft`, empty
+`publish_date`) and never posts until the operator sets `publish_date` +
+`status: scheduled` — their post-deploy confirmation gate — so bundling it
+pre-merge does NOT weaken the "only tweet what actually deployed" property;
+`/soleur:postmerge` Phase 3.8 still verifies deploy health and warns before the
+operator schedules.
+
+1. **Eligibility (fail-closed):** `bash scripts/lib/tweet-eligibility.sh <PR_NUMBER>`.
+   Ineligible (exit non-zero, `excluded: <reason>`) → **skip silently** (most PRs
+   land here: fixes, infra, non-product). Do not surface the exclusion.
+2. **Eligible →** invoke `skill: soleur:feature-tweet #<PR_NUMBER>` (writes +
+   displays the draft for approval per its §Output contract).
+3. **Commit + push the draft to the feature branch** so it lands on `main` with
+   the squash merge (stage ONLY the draft file — never `git add -A`):
+
+   ```bash
+   git add knowledge-base/marketing/distribution-content/<draft-file>.md
+   git commit -m "content: feature-tweet draft for #<PR_NUMBER> (inert — operator schedules post-deploy)"
+   git push
+   ```
+
+   The draft is a NEW commit, so the Phase 6.4 Unpushed-Commits Gate re-checks
+   clean before merge. Headless mode: same — generate + commit + push; never
+   schedule (the inert draft + operator gate are the publish control).
+
+If `/ship` is hand-rolled and this step is skipped, the draft never reaches
+`main`; `/soleur:postmerge` Phase 3.8 detects the missing on-`main` draft and
+runs the standalone catch-up (which then needs its own follow-up commit to land
+on `main`).
+
 ## Phase 6.5: Verify PR Mergeability
 
 After pushing (or after any subsequent push), verify the PR has no merge conflicts with the base branch:


### PR DESCRIPTION
## Summary

Feature-tweet drafts were generated **post-merge** into a worktree that `cleanup-merged` reaps before the draft reaches `main` — so `content-publisher.sh` (which reads from `main`) never saw them. The draft never landed where it needed to.

This bundles the draft into the **shipping PR (pre-merge)** so it rides the feature into `main`:

- **`ship` Phase 6** — new "Feature-Tweet Draft (pre-merge bundle)" step: after the semver/`app:*` labels are set (eligibility reads them), generate any eligible draft and commit it to the feature branch. It lands on `main` with the squash merge — no extra PR, reviewable alongside the feature. Stages only the draft file; the Phase 6.4 unpushed-commits gate re-checks before merge.
- **`postmerge` Phase 3.8** — shifts from *generate* to *verify + display* the on-`main` draft. Warns (does not block) when production health is unverified; only generates a catch-up draft when a hand-rolled `/ship` skipped the bundle.
- **`feature-tweet`** — intro + description updated for the pre-merge-bundle flow.

**The "only tweet what actually deployed" property is preserved** by the existing operator gate: the draft stays inert (`status: draft`, empty `publish_date`) and only posts when the operator sets `publish_date` + `status: scheduled` — which they do only after confirming the deploy. Postmerge's health check surfaces a warning before that point.

Follows up #5406 (which made the draft *displayed* for approval); together they make feature-tweet drafts both visible and persistent.

## Changelog

### Plugin
- feature-tweet drafts are now bundled into the shipping PR (committed pre-merge) so they land on `main` for the content-publisher cron, instead of being written into a worktree that gets reaped. Postmerge verifies + displays the on-`main` draft.

## Test plan
- [x] `bun test plugins/soleur/test/components.test.ts` green (1226 pass) — description budget within limit.
- [x] Docs-only change to three existing SKILL.md files; no code paths touched.

Generated with [Claude Code](https://claude.com/claude-code)
