### PR TITLE
content: draft ship tweet for the repo-readiness dispatch gate

### DIFF
--- a/knowledge-base/marketing/distribution-content/2026-06-16-gate-dispatch-until-repo-ready.md
+++ b/knowledge-base/marketing/distribution-content/2026-06-16-gate-dispatch-until-repo-ready.md
@@ -1,0 +1,25 @@
+---
+title: "Start chatting before your repo finishes connecting? You get an honest 'still setting up' instead of a dead-end"
+type: feature-launch
+publish_date: ""
+channels: x, bluesky
+status: draft
+pr_reference: "#5405"
+issue_reference: "#5399"
+---
+
+<!-- To publish: set BOTH publish_date AND status: scheduled -->
+
+## X/Twitter Thread
+
+Connect a repo and fire off a task before it finishes cloning, and your AI team used to just... dead-end. No repo, no explanation.
+
+Shipped today: it now tells you it's still setting up — try again in a moment.
+
+2/ The fix: every way a task can start now checks whether your repo is actually ready first. If it's still cloning or the setup failed, you get a plain message instead of a confusing failure — and the conversation stays alive to resume.
+
+3/ Small thing, but it's the difference between "this is broken" and "oh, give it a sec." Reliability is a feature. #buildinpublic
+
+## Bluesky
+
+Connect a repo and start a task before it finishes cloning, and your AI team used to dead-end with no explanation. Shipped today: it tells you it's still setting up — try again in a moment — and keeps the conversation alive to resume. Reliability is a feature.


### PR DESCRIPTION
## Summary
- Parked ship-tweet draft (X + Bluesky) generated by `/soleur:feature-tweet` for the merged, verified-live PR #5405 (the legacy-leader `repo_status` dispatch gate).
- `status: draft`, `publish_date` empty — the content-publisher cron skips it until the operator flips BOTH `publish_date` and `status: scheduled`.

## Changelog
- Add a parked feature-launch distribution draft under `knowledge-base/marketing/distribution-content/`.

## Test plan
- [x] `validate-tweet-draft.sh` rc=0 (both `## X/Twitter Thread` + `## Bluesky` sections, status: draft, channels x+bluesky)
- [x] `lint-distribution-content.sh` rc=0
- [x] X tweets ≤280 chars; Bluesky ≤300 chars

Ref #5405

🤖 Generated with [Claude Code](https://claude.com/claude-code)