### PR TITLE
fix(kb-viewer): markdown table cells inherit overflow-wrap:anywhere — break-normal stops mid-word splits

### DIFF
--- a/apps/web-platform/components/ui/markdown-renderer.tsx
+++ b/apps/web-platform/components/ui/markdown-renderer.tsx
@@ -75,8 +75,12 @@ function buildComponents({ linkRel, preWrap, enableC4, c4DirPath }: BuildOptions
     // 8ch keeps single-token / empty cells visible; 45ch caps prose cells to the
     // bottom of the readable measure so a single long-paragraph cell doesn't blow
     // out the table. Header may exceed (whitespace-nowrap on th wins) by design.
+    // break-normal opts cells back to word-boundary wrapping: the root wrapper sets
+    // [overflow-wrap:anywhere] (issue #2229) and overflow-wrap is INHERITED, so without
+    // this override <td> text breaks short words mid-character ("active" → "activ e")
+    // and auto-layout collapses columns. <th> is already immune via whitespace-nowrap.
     td: ({ children }) => (
-      <td className="min-w-[8ch] max-w-[45ch] border border-soleur-border-default px-3 py-1.5 align-top text-soleur-text-secondary">{children}</td>
+      <td className="min-w-[8ch] max-w-[45ch] break-normal border border-soleur-border-default px-3 py-1.5 align-top text-soleur-text-secondary">{children}</td>
     ),
     pre: ({ children }) => {
       // A ```likec4-view block renders as a block-level diagram, not a <pre>.

--- a/apps/web-platform/test/markdown-renderer.test.tsx
+++ b/apps/web-platform/test/markdown-renderer.test.tsx
@@ -98,4 +98,20 @@ describe("MarkdownRenderer — table column widths (shared-doc readability)", ()
       expect(td.className).not.toMatch(/(^|\s)w-full(\s|$)/);
     });
   });
+
+  it("renders data cells with break-normal so inherited overflow-wrap:anywhere can't break words mid-character", () => {
+    const { container } = render(<MarkdownRenderer content={tableMd} />);
+    const cells = container.querySelectorAll("td");
+    expect(cells.length).toBeGreaterThan(0);
+    cells.forEach((td) => {
+      // The renderer's root wrapper sets [overflow-wrap:anywhere] for long prose/URLs
+      // (issue #2229). overflow-wrap is an INHERITED CSS property, so without an
+      // explicit override every <td> inherits `anywhere` and breaks short words
+      // ("active" → "activ e", "Cloudflare" → "Cloudflar e") mid-character — and the
+      // table's auto-layout sizes columns as if every char is a break opportunity.
+      // break-normal (= overflow-wrap: normal; word-break: normal) opts cells back to
+      // word-boundary wrapping. <th> is already immune via whitespace-nowrap.
+      expect(td.className).toContain("break-normal");
+    });
+  });
 });

--- a/apps/web-platform/test/markdown-renderer.test.tsx
+++ b/apps/web-platform/test/markdown-renderer.test.tsx
@@ -99,19 +99,27 @@ describe("MarkdownRenderer — table column widths (shared-doc readability)", ()
     });
   });
 
-  it("renders data cells with break-normal so inherited overflow-wrap:anywhere can't break words mid-character", () => {
-    const { container } = render(<MarkdownRenderer content={tableMd} />);
+  it("renders data cells that opt out of the inherited overflow-wrap:anywhere so words don't break mid-character", () => {
+    // Single-token cells ("Cloudflare", "observability") are exactly the inputs the
+    // root wrapper's inherited [overflow-wrap:anywhere] (issue #2229) would mangle
+    // ("Cloudflar e"). overflow-wrap is INHERITED, so each <td> must override it or
+    // auto-layout sizes columns as if every char is a break point. <th> is immune
+    // via whitespace-nowrap.
+    const md =
+      "| Service | Status |\n" +
+      "|---|---|\n" +
+      "| Cloudflare | active |\n" +
+      "| BetterStack | observability |\n";
+    const { container } = render(<MarkdownRenderer content={md} />);
     const cells = container.querySelectorAll("td");
     expect(cells.length).toBeGreaterThan(0);
-    cells.forEach((td) => {
-      // The renderer's root wrapper sets [overflow-wrap:anywhere] for long prose/URLs
-      // (issue #2229). overflow-wrap is an INHERITED CSS property, so without an
-      // explicit override every <td> inherits `anywhere` and breaks short words
-      // ("active" → "activ e", "Cloudflare" → "Cloudflar e") mid-character — and the
-      // table's auto-layout sizes columns as if every char is a break opportunity.
-      // break-normal (= overflow-wrap: normal; word-break: normal) opts cells back to
-      // word-boundary wrapping. <th> is already immune via whitespace-nowrap.
-      expect(td.className).toContain("break-normal");
+    cells.forEach((td, i) => {
+      // Contract = "the cell does NOT inherit `anywhere`", expressed at the only layer
+      // happy-dom can see (className). Assert the word-boundary opt-out (break-normal
+      // or the arbitrary [overflow-wrap:normal] form — both survive an equivalent
+      // refactor) AND the negative: the cell never carries [overflow-wrap:anywhere].
+      expect(td.className, `td[${i}]`).toMatch(/break-normal|\[overflow-wrap:normal\]/);
+      expect(td.className, `td[${i}]`).not.toContain("[overflow-wrap:anywhere]");
     });
   });
 });

--- a/knowledge-base/project/learnings/ui-bugs/2026-06-16-inherited-overflow-wrap-anywhere-breaks-table-cell-words.md
+++ b/knowledge-base/project/learnings/ui-bugs/2026-06-16-inherited-overflow-wrap-anywhere-breaks-table-cell-words.md
@@ -1,0 +1,75 @@
+---
+date: 2026-06-16
+category: ui-bugs
+module: apps/web-platform/components/ui/markdown-renderer.tsx
+tags: [css, overflow-wrap, tailwind, markdown, tables, inheritance]
+branch: feat-one-shot-fix-md-table-cell-word-break
+pr: 5414
+---
+
+# Learning: `overflow-wrap: anywhere` is inherited — it breaks table-cell words mid-character
+
+## Problem
+
+Rendered markdown **table data cells** broke short words mid-character in the KB
+document viewer ("active" → "activ e", "Cloudflare" → "Cloudflar e", "deferred" →
+"deferre d", "observability" → "observabil ity"). Headers rendered fine. Reproduced
+on the operations/expenses.md view (both the dashboard KB viewer and the public
+shared-token viewer use the same `MarkdownRenderer`).
+
+A prior table-width fix (merged 2026-05-05) had already switched the table from
+`w-full` to `w-auto` and added a `min-w-[8ch] max-w-[45ch]` band — so the obvious
+"columns are too narrow" hypothesis was already addressed. The bug persisted.
+
+## Root Cause
+
+`markdown-renderer.tsx`'s root wrapper sets `<div className="min-w-0
+[overflow-wrap:anywhere]">` (issue #2229, intentional for long prose/URLs).
+**`overflow-wrap` is an INHERITED CSS property**, so `anywhere` cascades into every
+descendant — including each `<td>`, which had no override. `overflow-wrap: anywhere`
+(unlike `break-word`) also lets the table's auto-layout compute each cell's
+min-content width as if every character is a break opportunity, so columns collapse
+and short words break mid-character even when the table visually has room.
+
+`<th>` was immune only because it carried `whitespace-nowrap` (`white-space: nowrap`
+suppresses line-breaking entirely) — which is exactly why headers looked correct and
+data cells did not. The 2026-05-05 fix addressed `w-full` compression but never
+overrode the inherited `overflow-wrap` on cells.
+
+## Solution
+
+Add `break-normal` (Tailwind → `overflow-wrap: normal; word-break: normal`) to the
+`<td>` className. A value declared *directly on the element* always beats an
+*inherited* value (inheritance only supplies a value when the element has none of its
+own — no specificity contest), so the cell wraps at word boundaries again. The root
+wrapper's `[overflow-wrap:anywhere]` is preserved for non-table prose; only `<td>`
+opts back out. One-line change; one renderer fixes both viewers.
+
+## Key Insight
+
+`overflow-wrap` and `word-break` are **inherited** properties. When a markdown/prose
+container sets `overflow-wrap: anywhere` for long-URL safety, it silently cascades into
+any table cells inside it and breaks ordinary words mid-character. When you scope an
+"aggressive wrap" policy on a container, override it (`break-normal`) on structured
+descendants (table cells, code, badges) that must wrap at word boundaries. A fix that
+only adjusts column *width* (`w-auto`, min/max-width) will not address an inherited
+*wrapping-policy* bug.
+
+## Prevention / Testing
+
+happy-dom can't compute inherited CSS layout, so the regression guard asserts the
+className contract: each `<td>` carries a word-boundary opt-out (`break-normal` or the
+arbitrary `[overflow-wrap:normal]` form) AND does **not** carry
+`[overflow-wrap:anywhere]`. The negative assertion survives an equivalent refactor that
+scopes overflow-wrap differently. Fixture uses single long tokens
+("Cloudflare", "observability") — the exact inputs the bug mangles.
+
+## Session Errors
+
+1. **Edit-before-Read on the worktree copy of `markdown-renderer.tsx`** — Recovery:
+   Read the worktree path before editing. Prevention: a Read at the bare-root synced
+   copy does NOT satisfy the read-before-edit gate for the worktree copy — they are
+   distinct paths. (one-off)
+2. **Planning subagent cited a learning under the wrong subdirectory** — Recovery:
+   self-corrected before commit; the path-resolution gate confirmed all citations
+   resolve. (one-off)

--- a/knowledge-base/project/plans/2026-06-16-fix-md-table-cell-word-break-plan.md
+++ b/knowledge-base/project/plans/2026-06-16-fix-md-table-cell-word-break-plan.md
@@ -1,0 +1,290 @@
+---
+title: Fix markdown table data cells breaking short words mid-character
+type: fix
+date: 2026-06-16
+lane: single-domain
+brand_survival_threshold: none
+---
+
+# Fix: markdown table data cells break short words mid-character
+
+Rendered markdown **table** data cells break short words mid-character in the
+Concierge knowledge-base document viewer ("active" -> "activ e", "deferred" ->
+"deferre d", "Cloudflare" -> "Cloudflar e", "observability" -> "observabil
+ity"), while table **headers** render fine. Reproduced on the
+`operations/expenses.md` view.
+
+## Root Cause (verified against current `origin/main` file state)
+
+`apps/web-platform/components/ui/markdown-renderer.tsx:174-178` wraps all
+rendered markdown in:
+
+```tsx
+<div className="min-w-0 [overflow-wrap:anywhere]" data-narrow-wrap={...}>
+```
+
+`overflow-wrap` is an **inherited** CSS property, so `anywhere` cascades into
+every descendant — including each `<td>` (line 78-79):
+
+```tsx
+td: ({ children }) => (
+  <td className="min-w-[8ch] max-w-[45ch] border border-soleur-border-default px-3 py-1.5 align-top text-soleur-text-secondary">{children}</td>
+),
+```
+
+The `<td>` className does **not** override `overflow-wrap`. With
+`overflow-wrap: anywhere` inherited **and** the `max-w-[45ch]` width constraint,
+the browser treats every character as a break opportunity and computes the
+table-cell min-content width as if each character can wrap, collapsing columns
+and breaking short words mid-character.
+
+`<th>` cells (line 70-71) are immune **only** because they carry
+`whitespace-nowrap` (which forces `white-space: nowrap`, suppressing all
+wrapping) — which is exactly why headers look correct and data cells do not.
+
+This is a **residual** bug: the table-width fix (`w-full` -> `w-auto` + the
+`min-w-[8ch] max-w-[45ch]` band) fixed column compression but never overrode the
+inherited `overflow-wrap` on cells.
+
+### Premise Validation
+
+No GitHub issue / PR is cited by reference, so there are no external resolution
+premises to validate. The three file/line premises in the source description
+were each confirmed against the current worktree file:
+
+- L174-178 wrapper div carries `min-w-0 [overflow-wrap:anywhere]` — **confirmed**.
+- L78-79 `<td>` className has the `min-w-[8ch] max-w-[45ch] ... align-top` band
+  and **no** `overflow-wrap`/`word-break` override — **confirmed**.
+- L70-71 `<th>` carries `whitespace-nowrap` — **confirmed** (explains the
+  header-immune asymmetry).
+- L65-67 `<table className="w-auto border-collapse text-sm">` — **confirmed**
+  (the `w-auto` table-width fix is present).
+
+### `break-normal` semantics — verified against the INSTALLED Tailwind version
+
+The repo uses **Tailwind v4** (`apps/web-platform/package.json`:
+`"tailwindcss": "^4.1.0"`). The installed compiled source defines:
+
+```
+break-normal -> [["overflow-wrap","normal"],["word-break","normal"]]
+```
+
+(grepped from `apps/web-platform/node_modules/tailwindcss/dist/chunk-L5IEUH3R.mjs`).
+
+So `break-normal` emits exactly `overflow-wrap: normal; word-break: normal`. A
+direct child-element override of `overflow-wrap` defeats the inherited
+`anywhere` on `<td>`, which is the fix. The claim in the source description
+holds for the installed version — no drift.
+
+## User-Brand Impact
+
+- **If this lands broken, the user experiences:** unreadable knowledge-base
+  tables — short words like "active"/"deferred"/"Cloudflare" rendered with
+  mid-word breaks ("activ e") in every markdown table on the KB document viewer
+  and the public shared-doc viewer (and, since one renderer serves them all,
+  chat bubbles and file previews too).
+- **If this leaks, the user's data / workflow / money is exposed via:** N/A —
+  pure presentational CSS class change; no data, auth, or network surface is
+  touched.
+- **Brand-survival threshold:** `none`
+
+This change does not touch any sensitive path (no schema/migration/auth/API/SQL
+surface — only a leaf React component className), so no `threshold: none, reason:`
+scope-out bullet is required by preflight Check 6.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (source description) | Reality (verified) | Plan response |
+|---|---|---|
+| One renderer serves **both** the dashboard KB viewer and the shared-token viewer | True, but there are **more** consumers: `components/chat/message-bubble.tsx`, `components/kb/file-preview.tsx`, `components/kb/c4-workspace.tsx`, `components/kb/c4-shared.tsx` all render via `MarkdownRenderer` + `remarkGfm` (table-capable) | Single-renderer fix is correct and benefits all consumers; blast radius is "every markdown table", all in the desired direction. No per-consumer edits. |
+| Fix the `<td>` className; "apply to `<table>` if needed" | `<td>` override alone is **sufficient** — `overflow-wrap` is inherited, so `break-normal` on `<td>` lands `overflow-wrap:normal` on the cell and overrides the inherited `anywhere`. A `<table>`-level override is redundant for cell wrapping. | Edit `<td>` className **only**. Do not touch `<table>` (avoid redundant class). |
+| Test asserts `<td>` carries `break-normal` | The test runner is **happy-dom** (`vitest.config.ts`: `test/**/*.test.tsx` -> `environment: "happy-dom"`), which does **not** compute layout / computed-style / inherited CSS. Only className-contract assertions are reliable. | Test asserts className presence (`break-normal`) and absence of a literal `[overflow-wrap:anywhere]` class on the cell — never pixel width. Matches happy-dom's capabilities. |
+| (Implicit) wrapper `[overflow-wrap:anywhere]` should change | Prior-art learning `#2229` documents the wrapper-level `[overflow-wrap:anywhere]` as **intentional** for long prose/URLs/code outside tables | Do **NOT** remove the container's `[overflow-wrap:anywhere]`. Existing test (lines 6-16) guards it; keep that test green. |
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] `apps/web-platform/components/ui/markdown-renderer.tsx` `<td>` className
+      contains `break-normal` (the only source change).
+- [ ] The `<td>` className still contains `min-w-[8ch]`, `max-w-[45ch]`,
+      `align-top`, and the border/padding/text classes (the table-width-band fix
+      is preserved).
+- [ ] The container `<div>` className still contains `min-w-0` and
+      `[overflow-wrap:anywhere]` (long-prose/URL wrapping for non-table content
+      is preserved). Existing test at lines 6-16 stays green.
+- [ ] `<th>` className still contains `whitespace-nowrap` (header behavior
+      unchanged). Existing test at lines 78-87 stays green.
+- [ ] The `<table>` element is **not** modified (no redundant `break-normal`).
+- [ ] RED-first: the new `<td>`-asserts-`break-normal` assertion is added/run and
+      **fails** against the unmodified component, then passes after the className
+      edit (capture both states in the PR body or commit sequence).
+- [ ] `cd apps/web-platform && ./node_modules/.bin/vitest run test/markdown-renderer.test.tsx`
+      — all tests pass (existing 7 + new assertions).
+- [ ] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` — no **new**
+      type errors introduced by this change (pre-existing repo errors, if any,
+      are out of scope and noted, not fixed).
+
+### Post-merge (operator)
+
+- None. The `web-platform-release.yml` pipeline restarts the container on merge
+  to `main` touching `apps/web-platform/**`; no operator action.
+
+## Test Scenarios
+
+Extend `apps/web-platform/test/markdown-renderer.test.tsx`. The existing
+`MarkdownRenderer — table column widths` describe block (lines 64-101) already
+renders a GFM table and iterates `<td>` cells (lines 89-100); add the new
+assertion to that suite (and/or a focused new `it`), reusing the existing
+`tableMd` fixture or a fixture whose data cell contains a short word like
+`active` / `deferred`.
+
+- Given a GFM markdown table, when rendered by `MarkdownRenderer`, then every
+  `<td>` className contains `break-normal`.
+  - RED first: this assertion fails against the current component (the `<td>`
+    has no `break-normal`).
+- Given a GFM table whose data cell contains a short word (e.g. a row
+  `| active | deferred |`), when rendered, then the `<td>` carrying that word
+  does **not** carry a literal `[overflow-wrap:anywhere]` class (the cell opts
+  back to normal wrapping; it inherits `anywhere` only via the cascade, never as
+  its own class, and `break-normal` overrides that inheritance).
+  - Note (happy-dom): assert on `td.className` string membership only — do NOT
+    use `getComputedStyle`/`getBoundingClientRect`/width; happy-dom does not
+    compute layout or resolve the inherited cascade, so a computed-style
+    assertion would be a structural no-op (see learning
+    `best-practices/2026-04-18-test-mock-factory-drift-guard-and-jsdom-layout-traps.md`).
+- Regression (existing, keep green): container `<div>` retains `min-w-0` +
+  `[overflow-wrap:anywhere]`; `<pre>` retains `overflow-x-auto`; `<th>` retains
+  `whitespace-nowrap`; `<td>` retains `min-w-[8ch]`/`max-w-[45ch]`/`align-top`;
+  table retains `w-auto` and not `w-full`.
+
+## Context
+
+- **The change (single line):** in `buildComponents`, add `break-normal` to the
+  `<td>` className.
+
+  Before (`markdown-renderer.tsx:78-79`):
+  ```tsx
+  td: ({ children }) => (
+    <td className="min-w-[8ch] max-w-[45ch] border border-soleur-border-default px-3 py-1.5 align-top text-soleur-text-secondary">{children}</td>
+  ),
+  ```
+  After:
+  ```tsx
+  td: ({ children }) => (
+    <td className="min-w-[8ch] max-w-[45ch] break-normal border border-soleur-border-default px-3 py-1.5 align-top text-soleur-text-secondary">{children}</td>
+  ),
+  ```
+  (Exact intra-className position of `break-normal` is not load-bearing;
+  Tailwind class order does not affect specificity. Keep the comment block at
+  lines 75-77 intact.)
+
+- **Why `<td>` only and not `<table>`:** `overflow-wrap` is inherited.
+  `break-normal` on `<td>` sets `overflow-wrap: normal` directly on the cell,
+  overriding the inherited `anywhere`. With normal wrapping, `table-layout: auto`
+  computes each column's min-content width from whole words, so columns stop
+  collapsing and short words stop breaking. A `<table>`-level `break-normal`
+  would also propagate `overflow-wrap: normal` to cells via inheritance, but it
+  is redundant once the cells set it themselves — keep the diff minimal.
+
+- **Why NOT remove the container `[overflow-wrap:anywhere]`:** it is intentional
+  for long prose / unbroken URLs / inline code outside tables (issue #2229,
+  learning `ui-bugs/2026-04-15-flex-column-width-and-markdown-overflow-2229.md`).
+  Only table cells opt back to normal wrapping.
+
+- **Why NOT use `whitespace-nowrap` on `<td>` (the `<th>` approach):** headers
+  are short labels that benefit from never wrapping; data cells with
+  prose/longer values must still wrap at word boundaries within the
+  `max-w-[45ch]` band. `whitespace-nowrap` would force single-line cells and
+  blow out the table — wrong tool for `<td>`.
+
+## Files to Edit
+
+- `apps/web-platform/components/ui/markdown-renderer.tsx` — add `break-normal`
+  to the `<td>` className (line 78-79). Single-line change.
+- `apps/web-platform/test/markdown-renderer.test.tsx` — extend the
+  `table column widths` describe block (lines 64-101) with the RED-first
+  `break-normal` assertion (and the negative `[overflow-wrap:anywhere]`-class
+  assertion).
+
+## Files to Create
+
+- None.
+
+## Open Code-Review Overlap
+
+None checked against open `code-review` issues touching these two files (no
+network query run at plan time in this pipeline; the files are leaf
+component + its colocated test, low overlap risk). If `/work` or review surfaces
+an open scope-out on `markdown-renderer.tsx`, fold in or acknowledge per the
+overlap rule.
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected — leaf presentational CSS change in a
+shared React component. No finance/legal/marketing/ops/sales/support/engineering
+strategy surface.
+
+### Product/UX Gate
+
+**Tier:** advisory
+**Decision:** auto-accepted (pipeline)
+**Agents invoked:** none
+**Skipped specialists:** none
+**Pencil available:** N/A (no UI surface — modifies an existing leaf component's
+CSS class only; creates no new page, component file, modal, or flow)
+
+#### Findings
+
+Mechanical UI-surface override check: the only edited UI file is
+`components/ui/markdown-renderer.tsx`, which already exists and is **modified**,
+not created. No path under `## Files to Create` matches `components/**/*.tsx`,
+`app/**/page.tsx`, or `app/**/layout.tsx`, so the BLOCKING mechanical escalation
+does not fire. This is an ADVISORY-tier change (modifies an existing rendered
+surface's wrapping behavior without adding any interactive surface). Running in
+pipeline context (plan-file-path argument), so auto-accepted per the ADVISORY
+pipeline arm — no wireframe / spec-flow / copywriter pass needed for a
+word-wrap CSS fix.
+
+## Observability
+
+Skipped per plan Phase 2.9: this is a pure leaf-component CSS class change with
+no new error path, log call, server route, infra surface, or failure mode. The
+only "failure mode" is a wrong/missing className, which is gated by the vitest
+className-contract assertion at PR time (not a runtime-observability concern).
+No `apps/*/server/`, `apps/*/infra/`, or `plugins/*/scripts/` file is touched.
+
+## References
+
+- Component: `apps/web-platform/components/ui/markdown-renderer.tsx`
+- Test: `apps/web-platform/test/markdown-renderer.test.tsx`
+- Vitest config: `apps/web-platform/vitest.config.ts`
+  (`test/**/*.test.tsx` -> happy-dom)
+- Prior art (do not regress): `knowledge-base/project/learnings/ui-bugs/2026-04-15-flex-column-width-and-markdown-overflow-2229.md`
+- happy-dom layout limits: `knowledge-base/project/learnings/best-practices/2026-04-18-test-mock-factory-drift-guard-and-jsdom-layout-traps.md`
+- CSS-class-presence (not stylesheet) verification: `knowledge-base/project/learnings/2026-06-04-vendored-library-css-hook-must-be-verified-against-rendered-dom-not-stylesheet.md`
+- Behavior-reversal RED discipline: `knowledge-base/project/learnings/2026-06-01-behavior-reversal-fix-flip-existing-test-as-red.md`
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only
+  `TBD`/`TODO`/placeholder text, or omits the threshold will fail `deepen-plan`
+  Phase 4.6. (This plan fills it: threshold `none`.)
+- Test runner is **happy-dom**, not jsdom and not the browser. Assert
+  `td.className` string membership only. `getComputedStyle`, `getBoundingClientRect`,
+  `clientWidth`, and any inherited-cascade resolution are no-ops in happy-dom —
+  a computed-style assertion would pass vacuously and prove nothing.
+- Do **not** verify the fix by grepping compiled Tailwind CSS — a class existing
+  in the stylesheet does not prove the `<td>` element carries it. The load-bearing
+  proof is the runtime `td.className.includes("break-normal")` assertion.
+- Typecheck command MUST be `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit`,
+  NOT `npm run -w apps/web-platform typecheck` — the repo root `package.json` has
+  no `workspaces` field, so the `-w` form aborts.
+- Single-test command is `./node_modules/.bin/vitest run test/markdown-renderer.test.tsx`
+  from inside `apps/web-platform` (the package uses vitest, not bun test;
+  `apps/web-platform/bunfig.toml` ignores all test paths).
+- Keep the fixture's short word OUTSIDE any character that some other process
+  might treat as a token boundary — use a plain alpha word like `active` /
+  `deferred` in the test fixture.

--- a/knowledge-base/project/plans/2026-06-16-fix-md-table-cell-word-break-plan.md
+++ b/knowledge-base/project/plans/2026-06-16-fix-md-table-cell-word-break-plan.md
@@ -267,6 +267,55 @@ No `apps/*/server/`, `apps/*/infra/`, or `plugins/*/scripts/` file is touched.
 - CSS-class-presence (not stylesheet) verification: `knowledge-base/project/learnings/2026-06-04-vendored-library-css-hook-must-be-verified-against-rendered-dom-not-stylesheet.md`
 - Behavior-reversal RED discipline: `knowledge-base/project/learnings/2026-06-01-behavior-reversal-fix-flip-existing-test-as-red.md`
 
+## Research Insights (deepen-plan)
+
+**Deepened:** 2026-06-16. Leaf-component CSS fix — no external research warranted
+(strong local context: file, test, consumers, and Tailwind utility semantics all
+verified directly). Findings below are verification artifacts, not new scope.
+
+**Precedent-Diff Gate (Phase 4.4) — pattern is NOT novel.** The fix follows the
+file's own established per-element wrapping-override precedent:
+- `<pre>` (markdown-renderer.tsx:96) intentionally sets `break-words`
+  (`overflow-wrap: break-word`) + `[overflow-wrap:anywhere]` in wrap mode.
+- `<th>` (markdown-renderer.tsx:71) intentionally sets `whitespace-nowrap` to
+  override the inherited `anywhere`.
+- Adding `break-normal` to `<td>` is the same class of change — a per-element
+  wrapping override — applied to the one element that was missed. No new pattern;
+  reviewers need not scrutinize a novel approach.
+
+**Verify-the-negative pass (Phase 4.45).** The plan's load-bearing negative claim
+("do NOT remove the container `[overflow-wrap:anywhere]`") was checked:
+`grep -n overflow-wrap:anywhere` returns exactly two sites — L96 (`<pre>` wrap
+mode) and L176 (container wrapper). Both are intentional (long prose/URL/code
+wrapping); neither is the table-cell bug. **Confirmed.** The `<td>` (L79) has no
+`overflow-wrap`/`word-break` of its own today — **confirms the bug.** No other
+component or consumer overrides `<td>` wrapping downstream, so the single
+renderer change is authoritative across all consumers. **Confirmed.**
+
+**Installed-version semantics (Phase: SDK/lib runtime claim).** `break-normal`'s
+output was read verbatim from the installed Tailwind v4 source
+(`apps/web-platform/node_modules/tailwindcss/dist/chunk-L5IEUH3R.mjs`):
+`break-normal -> [["overflow-wrap","normal"],["word-break","normal"]]`. The
+class emits `overflow-wrap: normal; word-break: normal`, which (a) overrides the
+inherited `anywhere` on the cell and (b) keeps `word-break: normal` so
+`table-layout: auto` computes column min-content widths from whole words. The
+claim is correct against the pinned `tailwindcss@^4.1.0`.
+
+**Deepen-plan halt gates — all pass:**
+- 4.6 User-Brand Impact: present, threshold `none`, no sensitive-path diff. PASS.
+- 4.7 Observability: section present with a justified skip (pure leaf CSS, no
+  server/infra/error path). PASS.
+- 4.8 PAT-shaped variable: grep clean (no infra/token surface). PASS.
+- 4.9 UI-Wireframe Halt: **excluded — no `.pen` required.** The shared
+  UI-surface term list
+  (`plugins/soleur/skills/brainstorm/references/ui-surface-terms.md`) line 27
+  explicitly excludes "Pure copy or style tweaks with no structural/layout
+  change." This change adds one Tailwind wrapping utility to an existing `<td>`;
+  it adds no element, component, route, modal, or flow and makes no
+  structural/DOM change. The mechanical glob superset matches `components/**/*.tsx`,
+  but the governing prose exclusion for `wg-ui-feature-requires-pen-wireframe` is
+  the style-tweak carve-out. PASS (skip — wireframe not applicable).
+
 ## Sharp Edges
 
 - A plan whose `## User-Brand Impact` section is empty, contains only

--- a/knowledge-base/project/specs/feat-one-shot-fix-md-table-cell-word-break/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-md-table-cell-word-break/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-one-shot-fix-md-table-cell-word-break/knowledge-base/project/plans/2026-06-16-fix-md-table-cell-word-break-plan.md
+- Status: complete
+
+### Errors
+None. (Self-corrected one cited learning path before commit.)
+
+### Decisions
+- Root cause verified against current file: container `[overflow-wrap:anywhere]` (L176) inherited into `<td>` (L79, no override); `<th>` immune via `whitespace-nowrap` (L71); table `w-auto` (L67).
+- `break-normal` verified against installed Tailwind v4 (emits `overflow-wrap: normal; word-break: normal`).
+- Scope: `<td>` className only — NOT `<table>` (redundant; overflow-wrap inherits). One source line.
+- Test asserts className contract only (happy-dom can't compute layout); RED-first in the existing `<td>` suite. Container `[overflow-wrap:anywhere]` preserved (intentional for non-table prose).
+- One renderer serves 6+ consumers (KB viewer, shared-token viewer, chat bubbles, etc.) — single fix benefits all.
+- Deepen-plan UI-wireframe gate excluded (pure style tweak, no structural change) — no `.pen` required.
+
+### Components Invoked
+- Skill: soleur:plan, soleur:deepen-plan
+- learnings-researcher, repo-research-analyst (Task)

--- a/knowledge-base/project/specs/feat-one-shot-fix-md-table-cell-word-break/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-md-table-cell-word-break/tasks.md
@@ -1,0 +1,48 @@
+# Tasks — fix: markdown table data cells break short words mid-character
+
+Derived from `knowledge-base/project/plans/2026-06-16-fix-md-table-cell-word-break-plan.md`.
+
+Lane: `single-domain` (no spec.md present; set from plan frontmatter — leaf
+component CSS change in a single package).
+
+## Phase 1 — RED (failing test first)
+
+- [ ] 1.1 In `apps/web-platform/test/markdown-renderer.test.tsx`, extend the
+  `MarkdownRenderer — table column widths` describe block (lines 64-101) with a
+  new assertion that every rendered `<td>` className contains `break-normal`.
+  Reuse the existing `tableMd` fixture or add a fixture with a short-word data
+  cell (e.g. `| active | deferred |`). Assert on `td.className` string only
+  (happy-dom: no computed-style / layout).
+- [ ] 1.2 Add the negative assertion: the `<td>` does NOT carry a literal
+  `[overflow-wrap:anywhere]` class (it only inherits via cascade; `break-normal`
+  overrides it).
+- [ ] 1.3 Run `cd apps/web-platform && ./node_modules/.bin/vitest run test/markdown-renderer.test.tsx`
+  and confirm the new assertion(s) FAIL against the unmodified component
+  (capture RED output).
+
+## Phase 2 — GREEN (minimal fix)
+
+- [ ] 2.1 In `apps/web-platform/components/ui/markdown-renderer.tsx`, add
+  `break-normal` to the `<td>` className in `buildComponents` (line 78-79).
+  Single-line change. Do NOT modify the `<table>` element, the `<th>` className,
+  or the container `<div>`'s `[overflow-wrap:anywhere]`. Keep the explanatory
+  comment block (lines 75-77).
+- [ ] 2.2 Re-run the vitest file; confirm all tests pass (existing 7 + new).
+
+## Phase 3 — Verify
+
+- [ ] 3.1 `cd apps/web-platform && ./node_modules/.bin/vitest run test/markdown-renderer.test.tsx`
+  — full file green.
+- [ ] 3.2 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` — no NEW
+  type errors from this change (note any pre-existing errors; do not fix them).
+- [ ] 3.3 Confirm the AC checklist in the plan's `### Pre-merge (PR)` section is
+  satisfied (regression guards for container `min-w-0`/`[overflow-wrap:anywhere]`,
+  `<th>` `whitespace-nowrap`, `<td>` width band, table `w-auto` all still green).
+
+## Out of scope
+
+- No `<table>`-element class change (redundant; `<td>` override is sufficient).
+- No removal of the container `[overflow-wrap:anywhere]` (intentional for
+  non-table prose/URLs — #2229).
+- No Playwright/e2e pass required (pure CSS-class contract, `User-Brand Impact:
+  none`; unit className assertion is the gate).


### PR DESCRIPTION
## Summary

A CSS display bug in the knowledge-base document viewer: rendered markdown **table** data cells split short words mid-character ("active" → "activ e", "Cloudflare" → "Cloudflar e", "deferred" → "deferre d", "observability" → "observabil ity"), while table headers rendered fine.

**Root cause:** the renderer's root wrapper sets `[overflow-wrap:anywhere]` (issue #2229, intentional for long prose/URLs). `overflow-wrap` is an **inherited** CSS property, so it cascaded into every `<td>`, which had no override. `<th>` was immune only because it carries `whitespace-nowrap` — which is why headers looked correct and data cells did not. The May 2026 table-width fix (`w-full`→`w-auto` + `min-w-[8ch] max-w-[45ch]` band) addressed column compression but never overrode the inherited wrapping policy on cells.

**Fix:** add `break-normal` (`overflow-wrap: normal; word-break: normal`) to the `<td>` className in `markdown-renderer.tsx`. A value declared directly on the element beats the inherited one, so cells wrap at word boundaries again. The container's `[overflow-wrap:anywhere]` is preserved for non-table prose. One renderer serves both the dashboard KB viewer and the public shared-token viewer, so the single change fixes both.

## Changelog

### Web Platform
- Fix knowledge-base document-viewer markdown tables splitting words mid-character.

## Test plan

- [x] RED→GREEN: new regression test asserts each `<td>` opts out of the inherited `overflow-wrap:anywhere` (carries `break-normal` and not `[overflow-wrap:anywhere]`); fixture uses long single-token cells ("Cloudflare", "observability").
- [x] `markdown-renderer.test.tsx` 8/8; 10 `MarkdownRenderer`-consumer suites (106 tests) green; `tsc --noEmit` clean.

Generated with [Claude Code](https://claude.com/claude-code)
