### PR TITLE
fix(chat): show freshly-started conversation in Recent Conversations rail immediately

### DIFF
--- a/apps/web-platform/hooks/use-conversations.ts
+++ b/apps/web-platform/hooks/use-conversations.ts
@@ -443,7 +443,11 @@ export function useConversations(
   // transitions null → id AND such a drop was recorded, refetch ONCE to recover
   // the row deterministically (independent of the realtime SUBSCRIBED-callback
   // timing). Transition-gated via a ref — fires once per resolve, not per
-  // render — mirroring the canonical use-kb-layout-state.tsx:232-240 idiom.
+  // render — same shape as the canonical use-kb-layout-state.tsx:232-240 idiom.
+  // (That idiom seeds the ref with the CURRENT value; here we seed null because
+  // `workspaceId` always starts null — its useState init above is null and it is
+  // only set inside the async fetchConversations — so the null→id transition
+  // still fires exactly once and no spurious mount transition is manufactured.)
   const prevWorkspaceIdRef = useRef<string | null>(null);
   useEffect(() => {
     if (prevWorkspaceIdRef.current === workspaceId) return; // no transition

--- a/apps/web-platform/hooks/use-conversations.ts
+++ b/apps/web-platform/hooks/use-conversations.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { createClient } from "@/lib/supabase/client";
+import { warnSilentFallback } from "@/lib/client-observability";
 import type { Conversation, Message, ConversationStatus } from "@/lib/types";
 import { DOMAIN_LEADERS, type DomainLeaderId } from "@/server/domain-leaders";
 
@@ -145,6 +146,12 @@ export function useConversations(
   useEffect(() => {
     repoUrlRef.current = repoUrl;
   }, [repoUrl]);
+  // Set when an own-channel INSERT is dropped because the rail's scope has not
+  // resolved yet (workspaceId still null in the fresh-mount connect window).
+  // Consumed by the scope-resolve backfill effect below: the dropped row is
+  // recovered by a single refetch once workspaceId lands. See plan
+  // 2026-06-16-fix-recent-conversations-rail-optimistic-insert.
+  const pendingScopeRecoveryRef = useRef(false);
 
   const fetchConversations = useCallback(async () => {
     setLoading(true);
@@ -335,7 +342,30 @@ export function useConversations(
       channel: RealtimeChannelKind,
     ) => {
       const created = payload.new as Conversation;
-      if (shouldDropForScope(created, { repoUrl: repoUrlRef.current, workspaceId, channel, archiveFilter })) return;
+      if (shouldDropForScope(created, { repoUrl: repoUrlRef.current, workspaceId, channel, archiveFilter })) {
+        // An own-channel INSERT already matched this user server-side (the WAL
+        // filter is user_id). If it is dropped ONLY because workspaceId has not
+        // resolved yet — the fresh-mount connect window, since the rail portals
+        // per-drill (ADR-047) and workspaceId is set inside the async
+        // fetchConversations — then losing it with no recovery is the reported
+        // bug: the row would surface only after the conversation completes (the
+        // completion UPDATE is map-only and cannot add a missing row). Schedule
+        // the bounded scope-resolve backfill and mirror the silent drop to
+        // Sentry so the no-op is observable (cq-silent-fallback-must-mirror-to-sentry).
+        // A drop while scope is already resolved is a genuine cross-(repo|
+        // workspace) row — correctly silent (the F3 isolation invariant).
+        if (channel === "own" && workspaceId === null) {
+          pendingScopeRecoveryRef.current = true;
+          warnSilentFallback(null, {
+            feature: "conversations-rail",
+            op: "own-insert-deferred-unresolved-workspace",
+            message:
+              "own-channel conversation INSERT dropped while workspaceId unresolved; scheduled scope-resolve backfill recovery",
+            extra: { conversationId: created.id },
+          });
+        }
+        return;
+      }
 
       setConversations((prev) => {
         if (prev.some((c) => c.id === created.id)) return prev; // fill-only de-dup
@@ -402,6 +432,28 @@ export function useConversations(
       if (sharedChannel) supabase.removeChannel(sharedChannel);
     };
   }, [userId, workspaceId, archiveFilter, limit, fetchConversations]);
+
+  // Scope-resolve recovery backfill. The conversations rail portals per-drill
+  // (ADR-047) and mounts fresh on entry to /dashboard/chat/*, so its realtime
+  // own-channel can subscribe while `workspaceId` is still null (it is set
+  // inside the async fetchConversations). An own-channel INSERT arriving in that
+  // window is dropped by shouldDropForScope (workspace_id !== null) — and the
+  // completion UPDATE is map-only and cannot add the missing row, so it would
+  // surface only "after it completes" (the reported bug). When workspaceId
+  // transitions null → id AND such a drop was recorded, refetch ONCE to recover
+  // the row deterministically (independent of the realtime SUBSCRIBED-callback
+  // timing). Transition-gated via a ref — fires once per resolve, not per
+  // render — mirroring the canonical use-kb-layout-state.tsx:232-240 idiom.
+  const prevWorkspaceIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (prevWorkspaceIdRef.current === workspaceId) return; // no transition
+    const prev = prevWorkspaceIdRef.current;
+    prevWorkspaceIdRef.current = workspaceId;
+    if (prev === null && workspaceId !== null && pendingScopeRecoveryRef.current) {
+      pendingScopeRecoveryRef.current = false;
+      fetchConversations();
+    }
+  }, [workspaceId, fetchConversations]);
 
   // Note: there is no cross-tab `users` UPDATE channel. Repo scope now comes
   // from /api/workspace/active-repo (workspaces.repo_url), not users.repo_url,

--- a/apps/web-platform/test/conversations-rail-connect-race.test.tsx
+++ b/apps/web-platform/test/conversations-rail-connect-race.test.tsx
@@ -1,0 +1,383 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, render, screen, waitFor, act, cleanup } from "@testing-library/react";
+import type { Conversation } from "@/lib/types";
+
+// RED→GREEN regression for plan
+// 2026-06-16-fix-recent-conversations-rail-optimistic-insert.
+//
+// Bug (second attempt — the "still" in the report): a freshly-STARTED
+// conversation does not appear in the Recent Conversations rail until it
+// completes. PR #5391 added a Realtime INSERT subscription + a one-shot
+// SUBSCRIBED backfill, but the gap persists on the reported path
+// (/dashboard → /dashboard/chat/new) because the rail portals per-drill
+// (ADR-047) and mounts fresh, so its own `useConversations` instance hits a
+// connect-race:
+//
+//   - The realtime own-channel subscribes after `userId` resolves but while
+//     `workspaceId` is still `null` (it is set INSIDE the async
+//     fetchConversations). An own-channel INSERT arriving in that window is
+//     dropped by `shouldDropForScope` (conv.workspace_id !== null) — the code
+//     itself documents this at use-conversations.ts:98-99.
+//   - The completion UPDATE is `prev.map(...)` — it patches existing rows only
+//     and cannot ADD a missing one. So the row surfaces only on the next full
+//     refetch ("appears only after it completes").
+//
+// Contract (this fix), all on the rail's OWN hook instance:
+//   1. Backfill when `workspaceId` resolves (null → id): a row dropped during
+//      the null-workspace window is recovered by a bounded refetch (fires once
+//      on the transition, not per render).
+//   2. An own-channel INSERT dropped for an unresolved (null) workspace is NOT
+//      lost: it schedules the recovery backfill AND mirrors the silent drop to
+//      Sentry (cq-silent-fallback-must-mirror-to-sentry).
+//   3. Scope-guard parity preserved: a second workspace's rail never shows this
+//      workspace's new conversation (F3 cross-scope-leak containment).
+//   4. The UPDATE path stays map-only (membership is owned by insert/backfill).
+
+const ACTIVE_REPO_URL = "https://github.com/acme/active";
+const WS_ID = "ws-A";
+
+type RealtimeHandler = {
+  event: string;
+  filter?: string;
+  cb: (payload: { new: unknown; eventType?: string }) => void;
+};
+
+interface ChannelMock {
+  name: string;
+  handlers: RealtimeHandler[];
+  statusCb: ((status: string) => void) | null;
+  on: (type: string, config: { event: string; filter?: string }, cb: RealtimeHandler["cb"]) => ChannelMock;
+  subscribe: (cb?: (status: string) => void) => ChannelMock;
+}
+
+// Sentry mirror spy (the client-safe shim). Asserted by AC3.
+const warnSilentFallbackMock = vi.fn();
+vi.mock("@/lib/client-observability", () => ({
+  warnSilentFallback: (...args: unknown[]) => warnSilentFallbackMock(...args),
+  reportSilentFallback: vi.fn(),
+}));
+
+// next/navigation: useParams for the active-row highlight (no active row here).
+const paramsMock = vi.fn(() => ({}) as Record<string, string>);
+vi.mock("next/navigation", () => ({
+  useParams: () => paramsMock(),
+}));
+
+const state: {
+  // What the conversations list query returns, per call index (1-based).
+  // The connect-race tests want the INITIAL query to return [] (row not yet in
+  // the DB snapshot the first query saw) and the RECOVERY backfill to return
+  // the row — so the backfill is provably the mechanism that lands it.
+  convResultByCall: Conversation[][];
+  fallbackConvResult: Conversation[];
+  convCalls: number;
+  messages: { conversation_id: string; role: string; content: string; leader_id: string | null; created_at: string }[];
+  channels: ChannelMock[];
+  activeRepoCalls: number;
+  workspaceIdResponse: string | null;
+  repoUrlResponse: string | null;
+  // Gate the FIRST active-repo fetch so workspaceId stays null while we fire an
+  // own-channel INSERT into the connect-race window. Call `releaseActiveRepo()`
+  // to let it resolve (workspaceId → id).
+  deferFirstActiveRepo: boolean;
+  releaseActiveRepo: (() => void) | null;
+} = {
+  convResultByCall: [],
+  fallbackConvResult: [],
+  convCalls: 0,
+  messages: [],
+  channels: [],
+  activeRepoCalls: 0,
+  workspaceIdResponse: WS_ID,
+  repoUrlResponse: ACTIVE_REPO_URL,
+  deferFirstActiveRepo: false,
+  releaseActiveRepo: null,
+};
+
+function buildChannel(name: string): ChannelMock {
+  const ch: ChannelMock = {
+    name,
+    handlers: [],
+    statusCb: null,
+    on: vi.fn((_type: string, config: { event: string; filter?: string }, cb: RealtimeHandler["cb"]) => {
+      ch.handlers.push({ event: config.event, filter: config.filter, cb });
+      return ch;
+    }),
+    subscribe: vi.fn((cb?: (status: string) => void) => {
+      if (cb) ch.statusCb = cb;
+      return ch;
+    }),
+  };
+  state.channels.push(ch);
+  return ch;
+}
+
+function nextConvResult(): Conversation[] {
+  state.convCalls += 1;
+  const byCall = state.convResultByCall[state.convCalls - 1];
+  return byCall ?? state.fallbackConvResult;
+}
+
+function buildConversationsChain() {
+  const chain: Record<string, unknown> = {};
+  Object.assign(chain, {
+    select: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    is: vi.fn(() => chain),
+    not: vi.fn(() => chain),
+    order: vi.fn(() => chain),
+    limit: vi.fn(() => Promise.resolve({ data: nextConvResult(), error: null })),
+  });
+  return chain;
+}
+
+function buildMessagesChain() {
+  const chain: Record<string, unknown> = {};
+  Object.assign(chain, {
+    select: vi.fn(() => chain),
+    in: vi.fn(() => chain),
+    order: vi.fn(() => Promise.resolve({ data: state.messages, error: null })),
+  });
+  return chain;
+}
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: { id: "user-1" } }, error: null }),
+      ),
+    },
+    from: vi.fn((table: string) => {
+      if (table === "conversations") return buildConversationsChain();
+      if (table === "messages") return buildMessagesChain();
+      throw new Error(`unexpected table: ${table}`);
+    }),
+    channel: vi.fn((name: string) => buildChannel(name)),
+    removeChannel: vi.fn(),
+  }),
+}));
+
+function makeRow(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: "conv-new",
+    user_id: "user-1",
+    repo_url: ACTIVE_REPO_URL,
+    workspace_id: WS_ID,
+    visibility: "private",
+    domain_leader: null,
+    session_id: null,
+    status: "active",
+    total_cost_usd: 0,
+    input_tokens: 0,
+    output_tokens: 0,
+    last_active: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+    archived_at: null,
+    ...overrides,
+  };
+}
+
+function lastChannel(name: string): ChannelMock {
+  const matches = state.channels.filter((c) => c.name === name);
+  const ch = matches[matches.length - 1];
+  if (!ch) throw new Error(`channel ${name} was never created`);
+  return ch;
+}
+
+function handlerOn(channelName: string, event: string): RealtimeHandler["cb"] {
+  const ch = lastChannel(channelName);
+  const h = ch.handlers.find((x) => x.event === event);
+  if (!h) throw new Error(`no ${event} handler on ${channelName}`);
+  return h.cb;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  warnSilentFallbackMock.mockReset();
+  paramsMock.mockReturnValue({});
+  state.convResultByCall = [];
+  state.fallbackConvResult = [];
+  state.convCalls = 0;
+  state.messages = [];
+  state.channels = [];
+  state.activeRepoCalls = 0;
+  state.workspaceIdResponse = WS_ID;
+  state.repoUrlResponse = ACTIVE_REPO_URL;
+  state.deferFirstActiveRepo = false;
+  state.releaseActiveRepo = null;
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) => {
+      if (url === "/api/workspace/active-repo") {
+        state.activeRepoCalls += 1;
+        const body = {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              workspaceId: state.workspaceIdResponse,
+              repoUrl: state.repoUrlResponse,
+              repoName: "acme/active",
+              repoStatus: "connected",
+              fellBackToSolo: false,
+            }),
+        };
+        if (state.activeRepoCalls === 1 && state.deferFirstActiveRepo) {
+          return new Promise((resolve) => {
+            state.releaseActiveRepo = () => resolve(body);
+          });
+        }
+        return Promise.resolve(body);
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useConversations — fresh-mount connect-race (Recent Conversations rail)", () => {
+  it("AC1: the new conversation row renders in the REAL rail before completion (connect-race path)", async () => {
+    // Reproduce the reported path: the rail mounts while active-repo is still
+    // in flight (workspaceId null). An own-channel INSERT for the new
+    // conversation arrives in that window; the initial list query saw an empty
+    // snapshot. The fix must surface the row once scope resolves.
+    state.deferFirstActiveRepo = true;
+    state.convResultByCall = [[] /* initial query: empty */];
+    // Backfill (recovery) query returns the new row; its title derives from the
+    // first user message ("Fix Issue 4826", matching the reported screenshot).
+    const newRow = makeRow({ id: "conv-fix-4826" });
+    state.fallbackConvResult = [newRow];
+    state.messages = [
+      {
+        conversation_id: "conv-fix-4826",
+        role: "user",
+        content: "Fix Issue 4826",
+        leader_id: null,
+        created_at: new Date().toISOString(),
+      },
+    ];
+
+    const { ConversationsRail } = await import("@/components/chat/conversations-rail");
+    render(<ConversationsRail />);
+
+    // Wait until the own channel exists (userId resolved, subscribed) while
+    // active-repo is still deferred → workspaceId is still null.
+    await waitFor(() => expect(state.channels.some((c) => c.name === "command-center-own")).toBe(true));
+
+    // Fire the own-channel INSERT in the null-workspace window.
+    await act(async () => {
+      handlerOn("command-center-own", "INSERT")({
+        new: newRow,
+        eventType: "INSERT",
+      });
+    });
+
+    // Now scope resolves → the recovery backfill must land the row in the rail.
+    await act(async () => {
+      state.releaseActiveRepo?.();
+    });
+
+    await waitFor(() => expect(screen.getByText("Fix Issue 4826")).toBeInTheDocument());
+  });
+
+  it("AC2/AC3: a null-workspace own INSERT is recovered by the scope-resolve backfill (and mirrored to Sentry)", async () => {
+    state.deferFirstActiveRepo = true;
+    // Initial query (call 1) returns empty; the recovery backfill (call 2)
+    // returns the new row — so the backfill is provably what lands it.
+    const newRow = makeRow({ id: "conv-recovered" });
+    state.convResultByCall = [[], [newRow]];
+    state.fallbackConvResult = [newRow];
+
+    const { useConversations } = await import("@/hooks/use-conversations");
+    const view = renderHook(() => useConversations({ limit: 15 }));
+
+    await waitFor(() => expect(state.channels.some((c) => c.name === "command-center-own")).toBe(true));
+
+    // INSERT while workspaceId is still null → dropped, but recovery scheduled
+    // + silent drop mirrored to Sentry.
+    await act(async () => {
+      handlerOn("command-center-own", "INSERT")({ new: newRow, eventType: "INSERT" });
+    });
+    expect(view.result.current.conversations.map((c) => c.id)).not.toContain("conv-recovered");
+    expect(warnSilentFallbackMock).toHaveBeenCalledTimes(1);
+    expect(warnSilentFallbackMock.mock.calls[0]?.[1]).toMatchObject({ feature: "conversations-rail" });
+
+    // Resolve scope → recovery backfill lands the row.
+    await act(async () => {
+      state.releaseActiveRepo?.();
+    });
+
+    await waitFor(() =>
+      expect(view.result.current.conversations.map((c) => c.id)).toContain("conv-recovered"),
+    );
+  });
+
+  it("AC2 (bounded): the scope-resolve backfill fires once, not per render", async () => {
+    state.deferFirstActiveRepo = true;
+    const newRow = makeRow({ id: "conv-bounded" });
+    state.convResultByCall = [[], [newRow]];
+    state.fallbackConvResult = [newRow];
+
+    const { useConversations } = await import("@/hooks/use-conversations");
+    const view = renderHook(() => useConversations({ limit: 15 }));
+    await waitFor(() => expect(state.channels.some((c) => c.name === "command-center-own")).toBe(true));
+    await act(async () => {
+      handlerOn("command-center-own", "INSERT")({ new: newRow, eventType: "INSERT" });
+    });
+    await act(async () => {
+      state.releaseActiveRepo?.();
+    });
+    await waitFor(() =>
+      expect(view.result.current.conversations.map((c) => c.id)).toContain("conv-bounded"),
+    );
+
+    // active-repo calls so far: initial (1) + recovery backfill (2). A bare
+    // re-render must NOT trigger another backfill (transition-gated).
+    const callsAfterRecovery = state.activeRepoCalls;
+    expect(callsAfterRecovery).toBe(2);
+    view.rerender();
+    await Promise.resolve();
+    expect(state.activeRepoCalls).toBe(callsAfterRecovery);
+  });
+
+  it("AC4: a second workspace's rail does NOT show this workspace's new conversation (F3 containment)", async () => {
+    // This rail is scoped to workspace B; an own-channel INSERT for a workspace-A
+    // conversation on the SAME repo must be dropped (own-channel WAL filter is
+    // user_id only — repo_url alone cannot discriminate two same-repo workspaces).
+    state.workspaceIdResponse = "ws-B";
+    state.fallbackConvResult = [];
+
+    const { useConversations } = await import("@/hooks/use-conversations");
+    const view = renderHook(() => useConversations({ limit: 15 }));
+    await waitFor(() => expect(view.result.current.loading).toBe(false));
+
+    await act(async () => {
+      handlerOn("command-center-own", "INSERT")({
+        new: makeRow({ id: "ws-a-conv", workspace_id: WS_ID }),
+        eventType: "INSERT",
+      });
+    });
+
+    expect(view.result.current.conversations.map((c) => c.id)).not.toContain("ws-a-conv");
+  });
+
+  it("AC5: a completion UPDATE for a row NOT present does not resurrect it (map-only preserved)", async () => {
+    state.fallbackConvResult = [];
+    const { useConversations } = await import("@/hooks/use-conversations");
+    const view = renderHook(() => useConversations({ limit: 15 }));
+    await waitFor(() => expect(view.result.current.loading).toBe(false));
+
+    await act(async () => {
+      handlerOn("command-center-own", "UPDATE")({
+        new: makeRow({ id: "absent", status: "completed" }),
+        eventType: "UPDATE",
+      });
+    });
+
+    expect(view.result.current.conversations.map((c) => c.id)).not.toContain("absent");
+  });
+});

--- a/apps/web-platform/test/conversations-rail-connect-race.test.tsx
+++ b/apps/web-platform/test/conversations-rail-connect-race.test.tsx
@@ -112,6 +112,13 @@ function buildChannel(name: string): ChannelMock {
   return ch;
 }
 
+// Per-call conversations-query result, indexed by COMPLETION order at
+// `.limit()`-resolution time. In the connect-race tests call 1 is the resumed
+// initial fetch (already past its deferred active-repo await when released) and
+// call 2 is the recovery backfill (starts from scratch), so call 1 reliably
+// reaches the query first — `[[], [newRow]]` therefore maps initial→[] and
+// backfill→[newRow] deterministically. A no-op backfill never produces a call 2,
+// so the recovery `waitFor` times out and the test fails (non-vacuous).
 function nextConvResult(): Conversation[] {
   state.convCalls += 1;
   const byCall = state.convResultByCall[state.convCalls - 1];
@@ -281,7 +288,9 @@ describe("useConversations — fresh-mount connect-race (Recent Conversations ra
       state.releaseActiveRepo?.();
     });
 
-    await waitFor(() => expect(screen.getByText("Fix Issue 4826")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("Fix Issue 4826")).toBeInTheDocument(), {
+      timeout: 3000,
+    });
   });
 
   it("AC2/AC3: a null-workspace own INSERT is recovered by the scope-resolve backfill (and mirrored to Sentry)", async () => {
@@ -311,8 +320,9 @@ describe("useConversations — fresh-mount connect-race (Recent Conversations ra
       state.releaseActiveRepo?.();
     });
 
-    await waitFor(() =>
-      expect(view.result.current.conversations.map((c) => c.id)).toContain("conv-recovered"),
+    await waitFor(
+      () => expect(view.result.current.conversations.map((c) => c.id)).toContain("conv-recovered"),
+      { timeout: 3000 },
     );
   });
 
@@ -331,12 +341,17 @@ describe("useConversations — fresh-mount connect-race (Recent Conversations ra
     await act(async () => {
       state.releaseActiveRepo?.();
     });
-    await waitFor(() =>
-      expect(view.result.current.conversations.map((c) => c.id)).toContain("conv-bounded"),
+    await waitFor(
+      () => expect(view.result.current.conversations.map((c) => c.id)).toContain("conv-bounded"),
+      { timeout: 3000 },
     );
 
     // active-repo calls so far: initial (1) + recovery backfill (2). A bare
-    // re-render must NOT trigger another backfill (transition-gated).
+    // re-render must NOT trigger another backfill (transition-gated). The exact
+    // count is 2 (not 3) because the channel mock never fires the own-channel
+    // SUBSCRIBED callback — in production that path adds its own backfill, but
+    // this test isolates the SCOPE-RESOLVE backfill. A third call here would be
+    // a real defect (an un-gated refetch); do not loosen this assertion.
     const callsAfterRecovery = state.activeRepoCalls;
     expect(callsAfterRecovery).toBe(2);
     view.rerender();

--- a/knowledge-base/engineering/operations/post-mortems/recent-conversations-rail-connect-race-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/recent-conversations-rail-connect-race-postmortem.md
@@ -1,0 +1,83 @@
+---
+title: "Recent Conversations rail omits a freshly-started conversation (connect-race; #5391 follow-up)"
+date: 2026-06-16
+incident_pr: 5421
+incident_window: "since before #5391 (2026-06-16); #5391 reduced but did not close it"
+recovery_at: "2026-06-16 (PR #5421 merge)"
+suspected_change: "rail per-drill portal (ADR-047) + realtime own-channel subscribe-before-scope-resolve; #5391 INSERT subscription was insufficient for the fresh-mount connect window"
+brand_survival_threshold: single-user incident
+status: resolved
+triggers:
+  - user-facing UX defect on the most common path (start a new conversation)
+art_33_triggered: false
+art_34_triggered: false
+art_33_deadline: "n/a — no personal-data breach; UX read-freshness/completeness defect, no exposure, no data loss"
+---
+
+## Actor key
+
+- `agent` — Claude Code did this autonomously.
+- `human` — Operator did this directly.
+
+# Incident Overview
+
+A newly-started conversation did not appear in the left **Recent Conversations** rail until it *completed*. This is the **second** attempt at the bug — PR #5391 added a Supabase Realtime INSERT subscription + a one-shot `SUBSCRIBED` backfill, but the omission persisted on the reported `/dashboard → /dashboard/chat/new` path. Not an operational outage (no downtime, error-rate spike, data loss, or Sentry alert) — a user-facing read-freshness/completeness defect on the operator's most common surface, recorded as a PIR because it recurred across two PRs (the "first fix didn't fully fix it" learning).
+
+## Status
+
+resolved
+
+## Symptom
+
+After starting a new conversation (Concierge "Routing to the right experts…"), the left rail showed only previously-completed conversations; the freshly-started one appeared only after it completed or after a navigation/refetch.
+
+## Incident Timeline
+
+| Actor | Time (UTC) | Action |
+|---|---|---|
+| human | 2026-06-16 | Operator reported the rail still omits new conversations (screenshot), after #5391. |
+| agent | 2026-06-16 | Root-caused the fresh-mount connect-race; fixed in PR #5421 with a transition-gated scope-resolve backfill + Sentry mirror. |
+
+## Detection (+ MTTD)
+
+- **How detected:** external/manual — operator report with screenshot.
+- **MTTD:** n/a (latent UX defect, not monitor-detected — read-freshness gaps do not fire Sentry/Better Stack per #5391).
+
+## Triggered by
+
+user (user-facing UX defect surfaced on the new-conversation path).
+
+## Root-cause hypothesis (triage)
+
+| Hypothesis | Supporting evidence | Disconfirming evidence | Status |
+|---|---|---|---|
+| Connect-race: rail subscribes before workspaceId resolves; own-channel INSERT dropped with no recovery; completion UPDATE is map-only | Code trace use-conversations.ts:288-404; ADR-047 per-drill portal; #5391 PIR's "rail stays mounted" framing was wrong | verify-the-negative confirmed 10/10 claims against origin/main | confirmed |
+
+## Resolution
+
+PR #5421: on the rail's own `useConversations` instance, record an own-channel INSERT dropped solely because `workspaceId` is unresolved (`pendingScopeRecoveryRef`), then refetch once when `workspaceId` transitions `null → id` (transition-gated, mirroring `use-kb-layout-state.tsx:232-240`). The silent drop is mirrored to Sentry via `warnSilentFallback`. Scope-guard parity preserved: every insert path still routes through `shouldDropForScope` (F3 cross-workspace containment).
+
+## Recovery verification
+
+Pre-merge: RED→GREEN regression `test/conversations-rail-connect-race.test.tsx` (5 cases, mutation-verified non-vacuous by test-design-reviewer); full blast radius 96 tests + `scripts/test-all.sh` 119/119 green; `tsc --noEmit` clean. Post-deploy: AC8 Playwright MCP live check (tracked as a ⏳ follow-through + `/soleur:postmerge`).
+
+---
+
+# Incident Post-Mortem Analysis
+
+## Root Cause(s) — 5-Whys
+
+1. **Why didn't the new conversation appear?** Its own-channel realtime INSERT was dropped during the fresh-mount connect window and never recovered.
+2. **Why was it dropped?** `shouldDropForScope` correctly drops an INSERT whose `workspace_id` mismatches the rail's `workspaceId`, which is `null` until the async `fetchConversations` resolves it.
+3. **Why no recovery?** The only backfill was a single pre-`SUBSCRIBED` snapshot (could run before the row existed) and the completion UPDATE handler is `map`-only (patches existing rows, cannot add one).
+4. **Why did #5391 miss it?** Its PIR assumed the rail stays permanently mounted (ADR-047); in fact the rail portals **per-drill** and remounts on chat entry, so the connect-race fires fresh on the dominant path — a framing the first fix never addressed.
+5. **Root cause:** a realtime subscription whose scope filter resolves asynchronously *after* subscribe has a silent drop-zone for own-channel events; recovery must be a deterministic backfill keyed on the scope-state transition, not a wider drop guard or a map-only UPDATE.
+
+## Versions of Components
+
+- **Version(s) that triggered:** all builds since the rail's per-drill portal + realtime subscription (#5391 reduced but did not close it).
+- **Version(s) that restored:** PR #5421.
+
+## Action Items & Follow-ups
+
+_No action items — incident fully resolved in the source PR with no residual work._

--- a/knowledge-base/project/learnings/bug-fixes/2026-06-16-realtime-connect-race-recover-via-scope-resolve-backfill.md
+++ b/knowledge-base/project/learnings/bug-fixes/2026-06-16-realtime-connect-race-recover-via-scope-resolve-backfill.md
@@ -1,0 +1,97 @@
+# Learning: a realtime hook that subscribes before its scope filter resolves drops own-channel INSERTs; recover with a scope-resolve backfill, not a wider guard
+
+## Problem
+
+A freshly-started conversation did not appear in the web-platform **Recent
+Conversations** rail until it *completed* — the reported "still doesn't show"
+bug (PR #5421, follow-up to #5391). The rail's `useConversations` hook
+(`apps/web-platform/hooks/use-conversations.ts`) subscribes to a Supabase
+Realtime own-channel as soon as `userId` resolves, but `workspaceId` is set
+later inside the same async `fetchConversations` (after an
+`/api/workspace/active-repo` round-trip). Because the conversations rail
+**portals per-drill** (ADR-047) and mounts fresh on entry to
+`/dashboard/chat/*`, this connect-race fires on the dominant path
+(`/dashboard` → new conversation):
+
+- An own-channel INSERT arriving while `workspaceId` is still `null` is dropped
+  by `shouldDropForScope` (`conv.workspace_id !== null`) — a correct guard, but
+  with **no recovery**.
+- Pre-`SUBSCRIBED` INSERTs are not replayed by supabase-js; the single
+  `if (status === "SUBSCRIBED") fetchConversations()` backfill can run *before*
+  the row exists and never re-runs.
+- The completion UPDATE handler is `prev.map(...)` — it patches existing rows
+  only and **cannot add a missing one**. So the row surfaced only on the next
+  full refetch (nav away/back), i.e. "after it completes".
+
+## Solution
+
+Two changes, both on the rail's own hook instance (a cross-instance optimistic
+insert was deliberately **deferred** — the rail and dashboard page are separate
+`useConversations` instances and the chat surface holds none, so there is no
+in-process writer path to the rail):
+
+1. **Transition-gated scope-resolve backfill.** When `workspaceId` transitions
+   `null → id` AND an own-channel INSERT was dropped during the unresolved
+   window (`pendingScopeRecoveryRef`), refetch **once**. Transition-gated via a
+   `prevWorkspaceIdRef` (same shape as the canonical
+   `use-kb-layout-state.tsx:232-240` idiom). Seed the ref `null` (not the
+   current value the canonical idiom uses) because `workspaceId` always starts
+   `null` here — so the `null→id` edge still fires exactly once and no spurious
+   mount transition is manufactured.
+2. **Observable drop.** The dropped own-channel INSERT is mirrored to Sentry via
+   `warnSilentFallback(null, { feature: "conversations-rail", … })`
+   (`cq-silent-fallback-must-mirror-to-sentry`), gated on
+   `channel === "own" && workspaceId === null` so it fires only in the brief
+   connect window, never per-conversation in steady state.
+
+The fix does **not** widen `shouldDropForScope` — every insert path (realtime
+INSERT + the recovery backfill via the scoped list query) still routes through
+the one guard, preserving the F3 cross-workspace containment invariant (a second
+workspace's rail never shows this workspace's conversation).
+
+## Key Insight
+
+When a realtime subscription's scope filter resolves *asynchronously after*
+the channel subscribes, the connect-window is a silent drop zone for
+own-channel events. The fix is a **deterministic backfill keyed on the
+scope-state transition** (independent of the realtime `SUBSCRIBED` callback
+timing) — NOT widening the drop guard (which would re-open the cross-scope leak
+the guard exists to prevent) and NOT a `map`-only UPDATE handler (which can
+patch but never add a row). Recovery belongs on the *insert/backfill* path; the
+UPDATE path owns membership-preserving patches only.
+
+This is the membership-completeness companion to
+[[2026-06-16-realtime-event-guard-must-equal-fetch-query-scope]] (#5391, which
+established guard-equals-fetch-scope parity): #5391 made the guard *correct*;
+this makes the *recovery* complete when the guard correctly drops a connect-race
+event.
+
+## Session Errors
+
+1. **`git add` exit 128 ("pathspec did not match a file").** The Bash tool's
+   CWD persists across calls; after a `cd apps/web-platform` for `tsc`/`vitest`,
+   a later `git add apps/web-platform/...` ran from `apps/web-platform` and the
+   doubled path didn't exist. **Recovery:** `cd <worktree-root> && git add …` in
+   one call. **Prevention:** for git/test commands in a worktree pipeline,
+   always prefix `cd <worktree-abs-path> &&` in the same Bash call (already in
+   work/SKILL.md guidance — operator slip, not a new rule).
+2. **`tsc` TS2322 — invalid `ConversationStatus` literal `"done"` in a test
+   fixture.** **Recovery:** changed to `"completed"`. **Prevention:** the
+   pinned `./node_modules/.bin/tsc --noEmit` gate caught it pre-commit; keep
+   running it before the per-task commit (worked as designed).
+3. **`user-impact-reviewer` first spawn misfired** — returned a meta agent-list
+   message with 0 tool uses instead of reviewing. **Recovery:** re-ran the same
+   `subagent_type` cleanly → CONCUR. **Prevention:** treat a 0-tool-use agent
+   reply that echoes the available-agents list as a non-result and re-spawn;
+   not deterministically reproducible, so no rule change.
+4. **Cross-agent contamination: `architecture-strategist` reported a HIGH
+   `if (false && …)` dead-code finding** that was `test-design-reviewer`'s
+   transient in-place RED mutant on the same worktree. **Recovery:** ran
+   `git diff HEAD` (empty) + re-ran the suite (15/15 green) and dismissed.
+   **Prevention:** already documented in `review/SKILL.md` Sharp Edges — verify
+   any "uncommitted working-tree / reverted-fix" finding against committed HEAD
+   before trusting it. Followed correctly; no new rule.
+
+## Tags
+category: bug-fixes
+module: apps/web-platform/hooks/use-conversations.ts

--- a/knowledge-base/project/plans/2026-06-16-fix-recent-conversations-rail-optimistic-insert-plan.md
+++ b/knowledge-base/project/plans/2026-06-16-fix-recent-conversations-rail-optimistic-insert-plan.md
@@ -10,6 +10,34 @@ lane: single-domain
 
 # 🐛 fix(chat): Recent Conversations rail does not show a freshly-started conversation immediately
 
+## Enhancement Summary
+
+**Deepened on:** 2026-06-16
+**Passes run:** spec-flow-analyzer (Product gate), CPO sign-off, verify-the-negative
+(10/10 claims confirmed), precedent-diff + Realtime best-practices research.
+
+### Key Improvements (vs. v1 plan)
+1. **Ruled out the naive client-optimistic insert** — spec-flow confirmed the rail and
+   dashboard page are separate `useConversations` instances and the chat surface holds none,
+   so a client insert has no in-process writer path to the rail. Re-scoped to Realtime +
+   backfill hardening on the rail's own instance; the zero-latency optimistic insert is
+   deferred (tracked).
+2. **Converted proxy ACs to invariant ACs** — AC1/AC8 now render the real
+   `ConversationsRail` and assert the **row**, not a refetch call; AC2/AC3 assert the
+   resulting `conversations` array; AC4 adds the cross-workspace isolation case.
+3. **Grounded the implementation idiom** — the transition-gated backfill should reuse the
+   canonical `prevRef.current !== x` guard pattern from
+   `apps/web-platform/hooks/use-kb-layout-state.tsx:232-240` (the single in-repo precedent
+   for "fire once on an async-resolved value transition").
+
+### New Considerations Discovered
+- All 10 load-bearing negative claims verified against `origin/main` (visibility gating,
+  map-only UPDATE, single-shot SUBSCRIBED backfill, null-workspaceId drop, two-instance
+  reality, deferred lazy INSERT with no `visibility:` key).
+- supabase-js confirmed: INSERTs buffered before `SUBSCRIBED` are NOT replayed (the exact
+  gap this fix closes); fetch-after-subscribe + fill-only de-dup is the canonical pattern,
+  already present and to be extended (not rewritten).
+
 ## Overview
 
 When a user starts a new conversation in the web platform, it does **not** appear in the
@@ -32,10 +60,11 @@ the conversations rail is **portaled per-drill** (it mounts fresh on entry to
 "start a new conversation" path frequently does this:
 
 1. User clicks "New conversation" on `/dashboard` → `router.push("/dashboard/chat/new")`
-   (`app/(dashboard)/dashboard/page.tsx:622, :741`). The conversations rail is mounted by
-   `chat/layout.tsx:71` (it wraps `/dashboard/chat/*` ONLY — it is **not present on
-   `/dashboard`**), so it **mounts fresh on this entry**. Within `/dashboard/chat/*` it then
-   stays mounted; the fresh mount + connect-race happens **once**, on entry from `/dashboard`.
+   (`app/(dashboard)/dashboard/page.tsx:622, :741`). The conversations rail is mounted (via
+   `ConversationsRailPortal`) by `chat/layout.tsx:71` (it wraps `/dashboard/chat/*` ONLY —
+   it is **not present on `/dashboard`**), so it **mounts fresh on this entry**. Within
+   `/dashboard/chat/*` it then stays mounted; the fresh mount + connect-race happens
+   **once**, on entry from `/dashboard`.
 2. `useConversations` runs `fetchConversations()` (`hooks/use-conversations.ts:288-290`):
    `auth.getUser()` → `/api/workspace/active-repo` round-trip → sets `userId`, then
    `workspaceId`, then `repoUrl`, then the list query. The realtime effect subscribes only
@@ -221,10 +250,32 @@ row the list query would not (the #5391 workspace_id-guard-parity invariant —
    the connect-race actually arises). Reuse the channel-mock-chain harness.
 3. **Phase 2 (GREEN) — hook fix.** In `hooks/use-conversations.ts`:
    - Re-run the bounded backfill when `workspaceId` resolves (Race B). Transition-gate it
-     (fire once on `null → id`), not per-render; add a guard ref.
+     (fire once on `null → id`), not per-render; add a guard ref. **Reuse the canonical
+     in-repo idiom** from `apps/web-platform/hooks/use-kb-layout-state.tsx:232-240`
+     (`prevRef.current !== x` guard, update the ref inside the effect, dep on the transitioned
+     value) — it is the single established precedent for "fire once on an async-resolved
+     value transition". Mirror the existing `repoUrlRef` ref-mirror pattern
+     (`use-conversations.ts:140-147`).
    - On an own-channel INSERT with unresolved scope, schedule a bounded recovery refetch
      instead of a silent drop with no recovery (Race A/B residue). If a drop with no recovery
      is ever taken, mirror to Sentry (`cq-silent-fallback-must-mirror-to-sentry`).
+
+   ### Research Insights (precedent + supabase-js semantics)
+
+   - **Transition-gate precedent** (`use-kb-layout-state.tsx:232-240`):
+     ```ts
+     const prevWorkspaceIdRef = useRef<string | null>(null);
+     useEffect(() => {
+       if (prevWorkspaceIdRef.current === workspaceId) return; // no transition
+       prevWorkspaceIdRef.current = workspaceId;
+       if (workspaceId !== null) fetchConversations();        // fire once on null → id
+     }, [workspaceId, fetchConversations]);
+     ```
+   - **supabase-js Realtime:** INSERTs buffered before `SUBSCRIBED` are NOT replayed (the
+     exact gap). Canonical pattern = subscribe → backfill on `SUBSCRIBED` → fill-only de-dup
+     by id (`use-conversations.ts:340-351`) → route every insert through `shouldDropForScope`.
+     The fix **extends** this (adds the scope-resolve + null-scope-recovery backfill triggers),
+     it does not rewrite it.
 4. **Phase 3 (REFACTOR).** Collapse the backfill triggers (SUBSCRIBED + scope-resolve +
    null-scope-recovery) behind one bounded helper; keep `shouldDropForScope`/`deriveRailTitle`
    as the single guard/title source so INSERT/UPDATE/backfill cannot drift.

--- a/knowledge-base/project/plans/2026-06-16-fix-recent-conversations-rail-optimistic-insert-plan.md
+++ b/knowledge-base/project/plans/2026-06-16-fix-recent-conversations-rail-optimistic-insert-plan.md
@@ -1,0 +1,371 @@
+---
+title: "fix(chat): Recent Conversations rail — optimistic insert for freshly-started conversations"
+date: 2026-06-16
+type: bug
+branch: feat-one-shot-recent-conversations-sidebar-optimistic-insert
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+lane: single-domain
+---
+
+# 🐛 fix(chat): Recent Conversations rail does not show a freshly-started conversation immediately
+
+## Overview
+
+When a user starts a new conversation in the web platform, it does **not** appear in the
+left **Recent Conversations** rail until it completes. The word "still" in the report is
+literal: this is the **second** attempt. PR #5391 (merged 2026-06-16) added a Supabase
+Realtime INSERT subscription + a one-shot `SUBSCRIBED`-status backfill to
+`apps/web-platform/hooks/use-conversations.ts`, but the gap persists in the reported
+scenario — the rail shows the *previous* "Fix issue 4826" (Done, 3h ago) yet the freshly
+started "Fix Issue 4826" (Concierge "Working / Routing to the right experts") never lands.
+
+### Root cause (traced read-only against `origin/main` HEAD)
+
+The conversation row is created **lazily, server-side, on the first WS message**
+(`apps/web-platform/server/ws-handler.ts:2165 → :2191 → :897`), NOT on navigation. The
+client already knows the final UUID from the `session_started` WS frame
+(`apps/web-platform/lib/ws-client.ts:122-123, :1133`; surfaced via `ChatSurface`'s
+`onRealConversationId`, `components/chat/chat-surface.tsx:156, :373-376`). Per **ADR-047**
+the conversations rail is **portaled per-drill** (it mounts fresh on entry to
+`/dashboard/chat/*`, it is NOT permanently mounted — only the context *band* is). So the
+"start a new conversation" path frequently does this:
+
+1. User clicks "New conversation" on `/dashboard` → `router.push("/dashboard/chat/new")`
+   (`app/(dashboard)/dashboard/page.tsx:622, :741`). The conversations rail is mounted by
+   `chat/layout.tsx:71` (it wraps `/dashboard/chat/*` ONLY — it is **not present on
+   `/dashboard`**), so it **mounts fresh on this entry**. Within `/dashboard/chat/*` it then
+   stays mounted; the fresh mount + connect-race happens **once**, on entry from `/dashboard`.
+2. `useConversations` runs `fetchConversations()` (`hooks/use-conversations.ts:288-290`):
+   `auth.getUser()` → `/api/workspace/active-repo` round-trip → sets `userId`, then
+   `workspaceId`, then `repoUrl`, then the list query. The realtime effect subscribes only
+   **after** `userId` resolves (`use-conversations.ts:297-298, :404`).
+3. The user's first message lands the server INSERT during this connect window.
+   - **Race A — pre-`SUBSCRIBED` INSERT:** Realtime does **not** replay INSERTs buffered
+     before `SUBSCRIBED` (`use-conversations.ts:354-360`), and the only recovery — the
+     single-shot `if (status === "SUBSCRIBED") fetchConversations()`
+     (`use-conversations.ts:373-375`) — can land *just before* the row exists and never
+     re-runs. The own-channel INSERT falls in the gap.
+   - **Race B — null `workspaceId` in the closure:** The realtime effect can subscribe
+     while `workspaceId` is still `null` (it is set inside the same async
+     `fetchConversations`). An own-channel INSERT arriving then is **dropped** by
+     `shouldDropForScope` at `use-conversations.ts:112` (`conv.workspace_id !== null`), as
+     the code itself documents at `:98-99` — relying on the same single-shot backfill that
+     Race A defeats.
+4. When the conversation later **completes**, an UPDATE fires, but
+   `handleConversationUpdate` is `prev.map(...)` (`use-conversations.ts:318-324`) — it
+   **patches existing rows only and cannot add a missing one**. The row finally surfaces
+   only on the next full refetch (navigation away/back, section switch, or reconnect).
+   This is exactly the "appears only after it completes" symptom.
+
+This is a **behavioral fix**, not a build — the rail, the hook, the Realtime publication
+(`migrations/034`, `015` REPLICA IDENTITY FULL), and the INSERT path all exist and are
+wired. The defect is that the optimistic-insert path depends on a single pre-INSERT
+backfill snapshot and a possibly-`null` `workspaceId`.
+
+### Chosen approach (hook-scoped Realtime + backfill hardening — the viable path)
+
+**Spec-flow analysis (2026-06-16) ruled out a naive client-optimistic insert as the
+primary fix.** The rail (`conversations-rail.tsx:88`) and the dashboard page
+(`app/(dashboard)/dashboard/page.tsx:117`) are **two SEPARATE `useConversations`
+instances**, and the **chat surface holds NO instance** of the hook. The full-route chat
+page (`app/(dashboard)/dashboard/chat/[conversationId]/page.tsx:56-61`) does **not** even
+pass `onRealConversationId`. So a client-side optimistic insert invoked from the chat
+surface has **no in-process path to the rail's React state** — it would require lifting the
+hook into a shared store/Context above both mount sites, or a cross-instance broadcast the
+rail subscribes to. That cross-instance refactor is disproportionate to a read-freshness
+fix and is the wrong altitude. **The fix is therefore Realtime + backfill hardening on the
+rail's own hook instance** — which is exactly where the bug lives:
+
+1. **Re-run the backfill when `workspaceId` resolves** (not only on the first
+   `SUBSCRIBED`). This closes Race B at its root: the row INSERTed with a real
+   `workspace_id` is recovered by a refetch once the rail's own `workspaceId` is known.
+2. **Make the own-channel INSERT tolerant of an unresolved-scope window**: if `repoUrl`
+   or `workspaceId` is still `null` at INSERT time, do **not** silently drop the event with
+   no recovery — schedule a bounded recovery refetch once scope resolves (the refetch is
+   authoritative; the dropped payload need not be buffered). Keep shared-channel drop
+   semantics unchanged. Per `cq-silent-fallback-must-mirror-to-sentry`, if an own-channel
+   INSERT is dropped for unresolved scope with no recovery scheduled, mirror it to Sentry
+   so the no-op is observable.
+
+These two land on the rail's own instance and **always** apply. They make the new
+conversation appear within Realtime/backfill latency (sub-second to a few seconds) — not
+"only after it completes". The honest framing: this delivers **"appears within Realtime
+latency before completion"**, not a zero-latency client-optimistic insert.
+
+**Deferred (cross-instance optimistic insert — separate follow-up).** A true zero-latency
+optimistic insert keyed on the `session_started` UUID (`ws-client.ts:122-123`) requires the
+shared-store/Context refactor above. It is filed as a tracking issue (see Deferral Tracking
+below), NOT attempted here — the deterministic-race fixes (1)+(2) resolve the reported
+symptom without it.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (from report / prior PIR) | Reality on `origin/main` | Plan response |
+|---|---|---|
+| "Newly-created conversations appear only after they complete" | Confirmed — completion UPDATE is `map`-only (`use-conversations.ts:318-324`), cannot add a missing row | Fix the insert path, not the update path |
+| PIR #5391: "the rail stays mounted (ADR-047) and never re-runs its mount fetch" | **Partly wrong.** ADR-047 keeps the context *band* mounted; the conversations rail **portals per-drill** and remounts on chat entry (`ADR-047-nav-context-band-outside-swap.md` Decision §2; `components/dashboard/rail-slot.tsx:53-62`) | Fix must handle the **fresh-mount connect-race**, which the "always-mounted" framing missed — this is why #5391 was insufficient |
+| "INSERT subscription closes the gap" (#5391) | INSERT subscription depends on a single pre-INSERT `SUBSCRIBED` backfill AND a non-null `workspaceId`; both can fail in the fresh-mount window | Re-backfill on `workspaceId` resolve + tolerate null-scope INSERT + client-side optimistic insert on known UUID |
+| Conversation row exists at navigation time | **No** — created lazily on first WS message (`ws-handler.ts:2165→2191→897`); URL stays `/dashboard/chat/new` (no remount) | Optimistic insert must key on the `session_started` UUID the client already holds, not assume a DB row |
+| `conversations.visibility` blocks the own rail | **No** — default `'private'` (`migrations/075:23-29`); own channel does NOT check visibility (`use-conversations.ts:113` is shared-only). Not the cause | Leave own-channel visibility semantics unchanged |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** they start a new conversation, the
+Concierge begins working, but the left Recent Conversations rail does not show it — so they
+cannot navigate back to their in-progress work from the rail and the product looks broken
+on the single most common path. A regression here (e.g. an optimistic row that never
+reconciles, or a row inserted into the wrong workspace's rail) would surface a *phantom* or
+*cross-scope* conversation — worse than the current omission.
+
+**If this leaks, the user's workflow is exposed via:** an insert path that bypasses the
+`shouldDropForScope` repo_url + workspace_id guard could surface a conversation title in the
+wrong repo's / wrong workspace's rail. The fix MUST route every insert path (realtime INSERT
+AND the recovery backfill) through the same scope-equivalent guard so the rail never shows a
+row the list query would not (the #5391 workspace_id-guard-parity invariant —
+`knowledge-base/project/learnings/best-practices/2026-06-16-realtime-event-guard-must-equal-fetch-query-scope.md`).
+
+**Brand-survival threshold:** single-user incident.
+(CPO sign-off required at plan time before `/work` begins — `requires_cpo_signoff: true`.
+`user-impact-reviewer` runs at review-time.)
+
+## Acceptance Criteria
+
+> **Invariant, not proxy (spec-flow correction):** ACs that render a bare `renderHook`
+> instance and assert a *refetch call fired* are proxies — they can pass while the real
+> rail (a separate, late-mounting instance) shows nothing. AC1 (vitest) and AC8 (Playwright)
+> MUST render/drive the real `ConversationsRail` and assert the **row appears**; AC2/AC3 MUST
+> assert the **resulting `conversations` array contains the row**, not merely that
+> `fetchConversations` was called (drive the mock so the refetch returns a row set that
+> includes the new conversation).
+
+- [ ] **AC1 — Row renders in the real rail on the reported path.** A vitest test renders the
+  **real `ConversationsRail`** component (not a bare `renderHook`), drives the mock so the
+  rail mounts during the connect window (the reported `/dashboard` → `/dashboard/chat/new`
+  entry: `active-repo` resolves AFTER an own-channel INSERT fires, and `workspaceId` starts
+  `null` then transitions), and asserts the new conversation **row is present in the rail's
+  rendered DOM before any completion UPDATE** (assert on the row title / rail rows under
+  `data-testid="conversations-rail"`). Covers both sub-races (pre-`SUBSCRIBED` INSERT and
+  null-`workspaceId` INSERT). File: `apps/web-platform/test/conversations-rail-insert.test.tsx`.
+- [ ] **AC2 — Backfill on `workspaceId` resolve lands the row.** A test asserts that when
+  `workspaceId` transitions `null → <id>` after subscribe, the recovery refetch fires AND
+  the refetched row set (mock returns the new conversation) lands in
+  `result.current.conversations` (or the rendered rail) — assert the **row**, not just the
+  refetch call. The backfill is **bounded**: fires once on the scope-resolve transition, not
+  per-render (guard-ref / transition-gate).
+- [ ] **AC3 — Null-scope INSERT recovers (not silently lost).** A test asserts an own-channel
+  INSERT arriving while `repoUrl`/`workspaceId` are `null` results in the row appearing once
+  scope resolves (via the bounded recovery refetch), rather than being dropped with no
+  recovery. (May be folded into AC2 if the recovery mechanism is the same scope-resolve
+  refetch — keep one test that asserts the **row**.) If a drop with no recovery is ever
+  taken, it is mirrored to Sentry (`cq-silent-fallback-must-mirror-to-sentry`).
+- [ ] **AC4 — Scope-guard parity preserved (the cross-scope-leak containment).** Every insert
+  path (realtime INSERT, backfill) is gated by `shouldDropForScope` (repo_url **AND**
+  workspace_id **AND** channel-visibility **AND** archive) — the rail never shows a row the
+  list query (`use-conversations.ts:215-239`, `.eq(repo_url).eq(workspace_id)`) would
+  exclude. Tests: (a) an out-of-(repo|workspace)-scope INSERT is dropped; (b) a second
+  workspace's rail does NOT show this workspace's new conversation. This is the F3
+  cross-tenant-context-exposure containment invariant — non-negotiable at the single-user
+  threshold.
+- [ ] **AC5 — UPDATE path unchanged for membership.** The completion UPDATE still only
+  patches existing rows; the fix does not add an "UPDATE can resurrect a row" path (the
+  insert/backfill path owns membership). Regression test for `handleConversationUpdate`
+  map-only semantics (`use-conversations.ts:318-324`) stays green.
+- [ ] **AC6 — Hook-source-swap test sweep.** Per
+  `learnings/best-practices/2026-06-15-hook-source-swap-sweep-all-real-hook-renderers-not-name-filtered.md`,
+  derive the blast radius via
+  `git grep -l 'useConversations' apps/web-platform/test/` **minus**
+  `git grep -l 'vi.mock("@/hooks/use-conversations"' apps/web-platform/test/`; every
+  real-hook renderer (and every channel-mock-chain mock) still passes. Paste the two grep
+  outputs in the PR body.
+- [ ] **AC7 — Typecheck + suite green.** `cd apps/web-platform && ./node_modules/.bin/tsc
+  --noEmit` exits 0, and `cd apps/web-platform && ./node_modules/.bin/vitest run
+  test/conversations-rail-insert.test.tsx test/conversations-rail.test.tsx
+  test/use-conversations-limit.test.tsx` is green; full `scripts/test-all.sh` exits 0.
+
+### Post-merge (operator / automated)
+
+- [ ] **AC8 — Live confirmation (Playwright MCP).** After the web-platform release, drive a
+  real session **starting from `/dashboard`** (the reported path — the rail is NOT mounted
+  on `/dashboard`, so this exercises the fresh-mount connect-race): open `/dashboard`,
+  navigate into a new conversation, send the first message, and assert the new conversation
+  row appears in the Recent Conversations rail **within seconds and before completion**,
+  without a reload. Also assert **scope isolation** (the row does not appear in a different
+  workspace's rail — the F3 containment). `Automation: feasible via mcp__playwright__*
+  against the deployed app` — run it; do not punt to a manual operator step.
+
+## Implementation Phases
+
+> Scope is **hook-only**: the rail's own `useConversations` instance. No chat-surface
+> wiring (the optimistic cross-instance path is deferred — see Deferral Tracking).
+
+1. **Phase 0 — Preconditions (verify, do not assume).**
+   - Re-confirm the two-instance reality: `git grep -n "useConversations(" apps/web-platform`
+     — exactly the rail (`conversations-rail.tsx:88`) + dashboard page
+     (`app/(dashboard)/dashboard/page.tsx:117`); chat surface holds none. (Verified at plan
+     time by spec-flow-analyzer.) This is why the fix is hook-only.
+   - Confirm the rail mount boundary: `chat/layout.tsx:71` mounts the rail for
+     `/dashboard/chat/*` only (not `/dashboard`) — the fresh-mount connect-race fires on
+     entry.
+   - Re-read `use-conversations.ts:288-404` (fetch + realtime effect) and confirm the
+     `SUBSCRIBED` backfill (`:373-375`) + `shouldDropForScope` (`:102-118`) shapes are
+     unchanged from this plan's citations.
+   - Confirm the active-repo route self-heal divergence (PIR Race C, latent edge):
+     `app/api/workspace/active-repo/route.ts:48-65` self-heals a removed-from-workspace user
+     to solo, but `createConversation` (`ws-handler.ts:865, :892`) does not — note as a
+     latent out-of-scope edge unless deepen-plan elevates it.
+2. **Phase 1 (RED) — failing tests.** Add AC1–AC5 cases to
+   `test/conversations-rail-insert.test.tsx`. AC1 must render the **real `ConversationsRail`**
+   and drive the mock so `active-repo` resolves AFTER the INSERT and `workspaceId` starts
+   `null` (the existing harness resolves scope synchronously — extend it to defer/reorder so
+   the connect-race actually arises). Reuse the channel-mock-chain harness.
+3. **Phase 2 (GREEN) — hook fix.** In `hooks/use-conversations.ts`:
+   - Re-run the bounded backfill when `workspaceId` resolves (Race B). Transition-gate it
+     (fire once on `null → id`), not per-render; add a guard ref.
+   - On an own-channel INSERT with unresolved scope, schedule a bounded recovery refetch
+     instead of a silent drop with no recovery (Race A/B residue). If a drop with no recovery
+     is ever taken, mirror to Sentry (`cq-silent-fallback-must-mirror-to-sentry`).
+4. **Phase 3 (REFACTOR).** Collapse the backfill triggers (SUBSCRIBED + scope-resolve +
+   null-scope-recovery) behind one bounded helper; keep `shouldDropForScope`/`deriveRailTitle`
+   as the single guard/title source so INSERT/UPDATE/backfill cannot drift.
+5. **Phase 4 — verify.** AC6 sweep, AC7 typecheck + suite, AC8 Playwright MCP post-deploy.
+
+## Files to Edit
+
+- `apps/web-platform/hooks/use-conversations.ts` — backfill-on-`workspaceId`-resolve +
+  bounded null-scope INSERT recovery + (if a drop is unavoidable) Sentry mirror.
+- `apps/web-platform/test/conversations-rail-insert.test.tsx` — AC1–AC5 tests; extend the
+  harness so the connect-race (deferred `active-repo`, null→id `workspaceId`) is reproducible,
+  and add a real-`ConversationsRail` render case.
+
+## Files to Create
+
+- (none expected) — new tests land in the existing
+  `test/conversations-rail-insert.test.tsx`. A new test file is created only if deepen-plan
+  splits a focused backfill unit out; if so it lives under `apps/web-platform/test/` to
+  satisfy the vitest `test/**/*.test.tsx` happy-dom glob (`vitest.config.ts:63-64`).
+
+## Deferral Tracking
+
+- **Zero-latency client-optimistic insert (cross-instance).** A true optimistic insert keyed
+  on the `session_started` UUID (`ws-client.ts:122-123`) is **deferred**. Why: the rail and
+  chat surface are separate `useConversations` instances (the chat surface holds none), so it
+  requires lifting the hook into a shared store/Context above both mount sites — a refactor
+  disproportionate to a read-freshness fix. Re-evaluation criteria: if Realtime+backfill
+  latency proves perceptibly slow in dogfooding (AC8 shows > a few seconds), or if a future
+  feature already lifts `useConversations` into a shared store. **Action for /work:** file a
+  GitHub issue (label `domain/engineering`, `priority/p3-low`) capturing this with the
+  re-evaluation criteria and a roadmap pointer; do NOT leave the deferral untracked.
+
+## Open Code-Review Overlap
+
+None. (`gh issue list --label code-review --state open` returns no scope-outs touching
+`use-conversations.ts` or `conversations-rail.tsx`. Open issues #3026
+cursor-pagination/virtualization and #3027 pin-conversations are feature follow-ups on the
+rail, not this bug, and touch different concerns — acknowledged, left open.)
+
+## Risks & Mitigations
+
+- **R1 — Two `useConversations` instances (confirmed).** The rail
+  (`conversations-rail.tsx:88`) and dashboard page (`page.tsx:117`) are separate hook
+  instances; the chat surface holds none. This is why a client-optimistic insert is NOT the
+  fix here. Mitigation: scope to the rail's own instance (Realtime + backfill hardening),
+  which is where the bug lives; defer the cross-instance optimistic insert (Deferral
+  Tracking). No mitigation needed for the chosen approach — the risk is what *ruled out* the
+  naive approach.
+- **R2 — Backfill amplification.** Re-running the backfill on `workspaceId` resolve must not
+  create a refetch loop. Mitigation: transition-gate it (fire once when `null → id`), keep
+  the existing `[userId, workspaceId, archiveFilter, limit, fetchConversations]` dep shape
+  and a guard ref (AC2 asserts bounded).
+- **R3 — Scope-guard drift / cross-scope leak (F3).** Any insert path (INSERT, backfill)
+  that bypasses `shouldDropForScope` reintroduces the #5391 workspace_id-parity bug and can
+  surface a conversation in the wrong workspace's rail — a cross-tenant context exposure that
+  exceeds the single-user threshold. Mitigation: AC4 (both the drop test AND the
+  second-workspace-rail isolation test) + the realtime-guard-equals-fetch-scope learning;
+  route every insert through the one guard. The most important invariant in this plan.
+- **R4 — Latency framing.** The chosen approach delivers "appears within Realtime/backfill
+  latency", not zero-latency. Mitigation: AC8 measures the live latency post-deploy; if it is
+  perceptibly slow, the Deferral Tracking item's re-evaluation criterion fires.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/
+  placeholder text, or omits the threshold will fail `deepen-plan` Phase 4.6. (It is filled.)
+- ADR-047 keeps the **context band** mounted, NOT the conversations rail — do not inherit
+  the #5391 PIR's "rail stays mounted" framing; the rail remounts per chat-drill, which is
+  the source of the connect-race.
+- The conversation row is **deferred** (created on first WS message), so any optimistic
+  insert keyed on the `session_started` UUID precedes the DB row — the row is not yet
+  fetchable by a backfill until the first message lands.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "Recent Conversations rail populates a freshly-started conversation before completion"
+  cadence: "on every new-conversation start (user-interactive)"
+  alert_target: "none (read-freshness UX; not an error-path event — PIR #5391 established read-freshness gaps do not fire Sentry/Better Stack)"
+  configured_in: "n/a — verified by the AC8 Playwright MCP post-deploy check, not a monitor"
+error_reporting:
+  destination: "Sentry (browser SDK) — genuine error paths only: a backfill refetch that fails surfaces via the existing useConversations error state (use-conversations.ts:240-243, :281-283); plus a NEW mirror if an own-channel INSERT is dropped for unresolved scope with no recovery scheduled (cq-silent-fallback-must-mirror-to-sentry)"
+  fail_loud: "existing rail error state (conversations-rail.tsx:113-132 'Couldn't load conversations / Retry') — unchanged"
+failure_modes:
+  - mode: "own-channel INSERT dropped by stale-null scope with no recovery"
+    detection: "AC1-AC3 vitest regression + AC8 Playwright MCP live check + Sentry mirror on the drop"
+    alert_route: "CI (test failure) pre-merge; post-deploy Playwright run; Sentry on live drop"
+  - mode: "backfill refetch loop (amplification)"
+    detection: "AC2 transition-gate test asserts backfill fires once on null→id, not per-render"
+    alert_route: "CI (test failure)"
+  - mode: "cross-scope leak (row in wrong workspace's rail)"
+    detection: "AC4 scope-isolation test (second workspace's rail does not show the row)"
+    alert_route: "CI (test failure)"
+logs:
+  where: "browser console (dev only); no new server-side logging — the fix is client-hook-scoped"
+  retention: "n/a (no new persistent log surface)"
+discoverability_test:
+  command: "cd apps/web-platform && ./node_modules/.bin/vitest run test/conversations-rail-insert.test.tsx"
+  expected_output: "all AC1-AC5 cases pass (exit 0); the connect-race + backfill-on-resolve + scope-guard/isolation cases are green"
+```
+
+## Test Scenarios
+
+1. Real `ConversationsRail` rendered; `active-repo` resolves AFTER an own-channel INSERT;
+   `workspaceId` starts `null` → row renders in the rail before completion (AC1).
+2. `workspaceId` transitions `null → id` after subscribe → recovery backfill returns the row,
+   row lands in `conversations` (AC2/AC3).
+3. Out-of-(repo|workspace)-scope INSERT → dropped; second workspace's rail does NOT show this
+   workspace's row (AC4 — the F3 isolation invariant).
+4. Completion UPDATE for a row NOT present → does not resurrect it (AC5, map-only preserved).
+
+## Domain Review
+
+**Domains relevant:** Product (UI surface)
+
+### Product/UX Gate
+
+**Tier:** advisory
+**Decision:** reviewed (CPO signed off on the single-user-incident framing; spec-flow-analyzer
+ran with the UI-flow-aware proxy-vs-invariant lens and materially reshaped the plan)
+**Agents invoked:** cpo, spec-flow-analyzer
+**Skipped specialists:** ux-design-lead (N/A — no new/changed visual surface; this is a
+data-freshness behavioral fix on the existing rail, creates no new page/component/flow);
+copywriter (no domain leader recommended one — no copy change)
+**Pencil available:** N/A (no UI surface to wireframe)
+
+#### Findings
+
+- **CPO:** Signed off on the `single-user incident` threshold (correct tier — most common
+  path on the operator's daily surface; the one place blast radius could exceed the tier is a
+  cross-scope leak into the wrong workspace's rail, contained by AC4). Confirmed the fix
+  reinforces the brand's "memory-first / the AI that already knows your business" wedge.
+  `wg-ui-feature-requires-pen-wireframe` does NOT fire (no new page/component/form). Conditions
+  (all in-plan): AC4 scope-parity holds; AC8 Playwright not punted to manual; phantom/reconcile
+  handled (now moot — optimistic path deferred).
+- **spec-flow-analyzer:** Found AC1–AC4 (v1) were hook-instance **proxies** that could pass
+  while the real rail (separate, late-mounting instance, no writer wired) showed nothing;
+  confirmed the rail/chat-surface are separate `useConversations` instances and the full-route
+  chat page passes no `onRealConversationId` (so a client-optimistic insert has no writer path
+  to the rail). Plan revised: optimistic path **deferred**, fix re-scoped to Realtime+backfill
+  hardening on the rail's own instance, AC1/AC8 re-anchored to render the **real**
+  `ConversationsRail` and assert the **row** (not a refetch call), AC4 adds the cross-workspace
+  isolation case, AC1 premise corrected (rail not mounted on `/dashboard`).

--- a/knowledge-base/project/specs/feat-one-shot-recent-conversations-sidebar-optimistic-insert/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-recent-conversations-sidebar-optimistic-insert/session-state.md
@@ -1,0 +1,21 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-one-shot-recent-conversations-sidebar-optimistic-insert/knowledge-base/project/plans/2026-06-16-fix-recent-conversations-rail-optimistic-insert-plan.md
+- Status: complete
+
+### Errors
+None. (One Write initially targeted the bare checkout while worktrees exist — corrected to the worktree path. `gh pr view` for prior PRs returned empty, non-blocking.)
+
+### Decisions
+- Root cause: the rail portals per-drill via `ConversationsRailPortal` and remounts on chat entry, so a new conversation's INSERT races the Realtime channel connect window — dropped pre-`SUBSCRIBED` (no replay) or while `workspaceId` is still `null` (`shouldDropForScope`). The map-only completion UPDATE can't add it back → "appears only after completion".
+- Ruled out the naive client-optimistic insert: rail and dashboard page are separate `useConversations` instances; chat surface holds none. Re-scoped to Realtime + backfill hardening on the rail's own hook instance (backfill-on-`workspaceId`-resolve + bounded null-scope INSERT recovery). Zero-latency cross-instance optimistic insert deferred with a tracking-issue requirement.
+- Converted proxy ACs to invariant ACs: AC1/AC8 render the real `ConversationsRail` and assert the row; AC4 adds cross-workspace scope-isolation containment. CPO signed off on `single-user incident` framing.
+- Grounded on canonical in-repo transition-gate idiom (`use-kb-layout-state.tsx:232-240`); verified all 10 load-bearing negative claims against origin/main.
+- Scope is hook-only (2 files: `use-conversations.ts` + its test); wireframe gate does not fire; GDPR/IaC/PAT gates skip; Observability section added.
+
+### Components Invoked
+- Skill: soleur:plan
+- Skill: soleur:deepen-plan
+- Agents: general-purpose (flow trace), learnings-researcher, cpo (sign-off), spec-flow-analyzer, general-purpose (verify-the-negative), Explore (precedent-diff + Realtime best-practices)
+- Deepen-plan halt gates 4.6/4.7/4.8/4.9 — all pass/skip

--- a/knowledge-base/project/specs/feat-one-shot-recent-conversations-sidebar-optimistic-insert/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-recent-conversations-sidebar-optimistic-insert/tasks.md
@@ -1,0 +1,38 @@
+# Tasks — fix: Recent Conversations rail shows freshly-started conversation immediately
+
+Plan: `knowledge-base/project/plans/2026-06-16-fix-recent-conversations-rail-optimistic-insert-plan.md`
+Lane: single-domain. Brand-survival threshold: single-user incident (CPO signed off).
+
+## Phase 0 — Preconditions (verify, do not assume)
+
+- [ ] 0.1 Re-confirm two `useConversations` instances: `git grep -n "useConversations(" apps/web-platform` (rail `conversations-rail.tsx:88` + dashboard `page.tsx:117`; chat surface none).
+- [ ] 0.2 Confirm rail mount boundary `chat/layout.tsx:71` (mounts for `/dashboard/chat/*` only; not `/dashboard`).
+- [ ] 0.3 Re-read `use-conversations.ts:288-404`; confirm `SUBSCRIBED` backfill (`:373-375`) + `shouldDropForScope` (`:102-118`) shapes unchanged.
+- [ ] 0.4 Note latent active-repo self-heal divergence (`active-repo/route.ts:48-65` vs `ws-handler.ts:865,:892`) — out of scope unless deepen-plan elevates.
+
+## Phase 1 — RED (failing tests)
+
+- [ ] 1.1 Extend `test/conversations-rail-insert.test.tsx` harness so `active-repo` resolves AFTER the INSERT and `workspaceId` starts `null` (the existing harness resolves scope synchronously).
+- [ ] 1.2 AC1: render real `ConversationsRail`; INSERT during connect window; assert row in rail DOM before completion (both sub-races).
+- [ ] 1.3 AC2/AC3: `workspaceId` null→id transition → recovery backfill returns row; assert row lands in `conversations`; backfill bounded (fires once).
+- [ ] 1.4 AC4: out-of-scope INSERT dropped; second workspace's rail does NOT show the row (F3 isolation).
+- [ ] 1.5 AC5: completion UPDATE for a row NOT present does not resurrect it (map-only preserved).
+
+## Phase 2 — GREEN (hook fix in `hooks/use-conversations.ts`)
+
+- [ ] 2.1 Re-run bounded backfill when `workspaceId` resolves (`null → id`); transition-gate via guard ref (not per-render).
+- [ ] 2.2 On own-channel INSERT with unresolved scope, schedule bounded recovery refetch instead of silent drop; if a drop with no recovery is taken, mirror to Sentry (`cq-silent-fallback-must-mirror-to-sentry`).
+
+## Phase 3 — REFACTOR
+
+- [ ] 3.1 Collapse backfill triggers (SUBSCRIBED + scope-resolve + null-scope-recovery) behind one bounded helper; keep `shouldDropForScope`/`deriveRailTitle` as single guard/title source.
+
+## Phase 4 — Verify
+
+- [ ] 4.1 AC6 hook-source-swap sweep: `git grep -l 'useConversations' apps/web-platform/test/` minus `git grep -l 'vi.mock("@/hooks/use-conversations"' apps/web-platform/test/`; paste both in PR body.
+- [ ] 4.2 AC7: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` exit 0; `./node_modules/.bin/vitest run test/conversations-rail-insert.test.tsx test/conversations-rail.test.tsx test/use-conversations-limit.test.tsx` green; `scripts/test-all.sh` exit 0.
+- [ ] 4.3 AC8 (post-deploy): Playwright MCP from `/dashboard` → new conversation → assert row appears before completion + scope isolation. Do not punt to manual.
+
+## Deferral
+
+- [ ] D.1 File GitHub issue (labels `domain/engineering`, `priority/p3-low`) for the deferred zero-latency cross-instance optimistic insert (shared-store/Context refactor), with re-evaluation criteria and roadmap pointer.


### PR DESCRIPTION
## Summary

A freshly-started conversation did not appear in the left **Recent Conversations** rail until it *completed* (the reported "still doesn't show" bug — follow-up to #5391).

Root cause: the rail portals per-drill (ADR-047) and mounts fresh on entry to `/dashboard/chat/*`, so its `useConversations` instance subscribes to the Supabase Realtime own-channel while `workspaceId` is still `null` (it's set inside the async `fetchConversations`). An own-channel INSERT arriving in that connect window is dropped by `shouldDropForScope` (`workspace_id !== null`) **with no recovery**, and the completion UPDATE is `map`-only and cannot add a missing row — so the conversation surfaced only after it completed.

Fix (rail's own hook instance only — the cross-instance optimistic insert is deferred, see plan):
- Record an own-channel INSERT dropped solely because `workspaceId` is unresolved, and refetch **once** when `workspaceId` transitions `null → id` (transition-gated via a ref, mirroring the canonical `use-kb-layout-state.tsx` idiom) to recover the row deterministically.
- Mirror the silent drop to Sentry via `warnSilentFallback` (`cq-silent-fallback-must-mirror-to-sentry`), gated to the brief connect window.
- Scope-guard parity unchanged: every insert path (realtime INSERT + recovery backfill) still routes through `shouldDropForScope`, so a second workspace's rail never shows this workspace's conversation (F3 containment).

Plan: `knowledge-base/project/plans/2026-06-16-fix-recent-conversations-rail-optimistic-insert-plan.md`

## User-Brand Impact

- **Artifact:** the freshly-started conversation row in the Recent Conversations rail.
- **Vector:** a connect-race own-channel INSERT dropped with no recovery → the row appears only after completion; a regression could surface a phantom row or a cross-workspace row.
- **Brand-survival threshold:** single-user incident (CPO signed off at plan time; `user-impact-reviewer` ran at review → CONCUR; all 4 failure modes — phantom/duplicate, cross-scope leak, amplification, Sentry noise — mitigated).

## Changelog

### Web Platform
- Recent Conversations rail now shows a newly-started conversation within Realtime/backfill latency (before it completes), recovering own-channel INSERTs dropped during the fresh-mount connect window.

## Test plan

- [x] `tsc --noEmit` clean
- [x] New RED→GREEN regression `test/conversations-rail-connect-race.test.tsx` (AC1 renders the real `ConversationsRail` and asserts the row; AC2/AC3 recovery + Sentry mirror; AC4 cross-workspace isolation; AC5 map-only UPDATE preserved) — 5/5 green
- [x] Existing `test/conversations-rail-insert.test.tsx` + full hook-source-swap blast radius (11 files, 96 tests) green
- [x] `scripts/test-all.sh` — 119/119 suites
- [ ] ⏳ AC8 (post-deploy): drive a real session from `/dashboard` → new conversation, assert the row appears in the rail within seconds before completion, and assert cross-workspace scope isolation (Playwright MCP against the deployed app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
