### PR TITLE
fix(chat): bounded retry on conversation-created so the lazily-committed row appears (#5449 follow-up)

### DIFF
--- a/apps/web-platform/components/chat/chat-surface.tsx
+++ b/apps/web-platform/components/chat/chat-surface.tsx
@@ -392,8 +392,9 @@ export function ChatSurface({
     ) {
       window.dispatchEvent(
         new CustomEvent(CONVERSATION_CREATED_EVENT, {
-          // `detail` is informational only — the rail listener ignores it and
-          // refetches its full scoped list (more robust than trusting a payload).
+          // `detail.conversationId` is LOAD-BEARING: the rail listener keys its
+          // bounded retry's stop-condition on it (refetch until this id appears,
+          // since the row commits lazily after this event). Do not remove it.
           detail: { conversationId: realConversationId },
         }),
       );

--- a/apps/web-platform/hooks/use-conversations.ts
+++ b/apps/web-platform/hooks/use-conversations.ts
@@ -172,7 +172,7 @@ export function useConversations(
       if (authError || !authData.user) {
         setError("Authentication required");
         setLoading(false);
-        return;
+        return null;
       }
       const currentUserId = authData.user.id;
       setUserId(currentUserId);
@@ -197,7 +197,7 @@ export function useConversations(
         // flashing the empty state (which reads as "you have no conversations").
         setError("Failed to resolve the active repository");
         setLoading(false);
-        return;
+        return null;
       }
       const activeRepo = (await res.json()) as {
         workspaceId: string;
@@ -211,7 +211,7 @@ export function useConversations(
       if (!currentRepoUrl) {
         setConversations([]);
         setLoading(false);
-        return;
+        return [];
       }
 
       // visibility-sweep: RLS policies conversations_owner_select +
@@ -254,12 +254,12 @@ export function useConversations(
       if (convError) {
         setError(convError.message);
         setLoading(false);
-        return;
+        return null;
       }
       if (!convData || convData.length === 0) {
         setConversations([]);
         setLoading(false);
-        return;
+        return [];
       }
 
       // Query 2: Fetch messages for displayed conversations
@@ -273,7 +273,7 @@ export function useConversations(
       if (msgError) {
         setError(msgError.message);
         setLoading(false);
-        return;
+        return null;
       }
 
       const messages = (msgData ?? []) as Message[];
@@ -292,9 +292,11 @@ export function useConversations(
 
       setConversations(enriched);
       setLoading(false);
+      return enriched;
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load conversations");
       setLoading(false);
+      return null;
     }
   }, [statusFilter, domainFilter, archiveFilter, limit]);
 
@@ -470,19 +472,47 @@ export function useConversations(
   // in the pre-SUBSCRIBED window supabase-js never replays — while the rail's
   // mount-time backfills already ran before the row existed. So the row would
   // surface only after a reload (the reported bug; client-timing fixes
-  // #5391/#5421/#5436 could not close a race they cannot observe). On the event,
-  // refetch ONCE via the quiet/background path so the new conversation appears
-  // without a reload, independent of realtime timing. Idempotent: the
-  // fill-only/replace fetch de-dups, and the scoped query preserves F3 isolation
-  // (a refetch can only ever return rows the list query already permits). See
+  // #5391/#5421/#5436 could not close a race they cannot observe).
+  //
+  // COMMIT-TIMING RACE (#5449 follow-up, found via a live headless-browser
+  // repro): the event fires at `session_started` — but the conversation ROW is
+  // created LAZILY on the first persisted message (ws-handler.ts), which lands
+  // slightly AFTER `session_started`. A single refetch on the event therefore
+  // runs before the row is committed and misses it. So we refetch with a SMALL
+  // BOUNDED RETRY keyed on the event's concrete `conversationId`: refetch, and
+  // if that id is not visible yet, retry on a short backoff until it appears or
+  // the bound is hit. This is deterministic (gated on the actual id, never a
+  // blind clock) and self-cancelling — if no row ever commits (e.g. the message
+  // was never sent) the retries exhaust harmlessly (nothing to show is correct).
+  // F3 isolation preserved (every refetch is the scoped list query). See
   // knowledge-base learning 2026-06-17 rail-realtime-race.
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const onCreated = () => {
-      fetchConversations({ background: true });
+    const MAX_ATTEMPTS = 6;
+    const BACKOFF_MS = [0, 600, 1000, 1500, 2500, 4000]; // ≈ cumulative 9.6s bound
+    let cancelled = false;
+    const onCreated = (ev: Event) => {
+      const targetId =
+        (ev as CustomEvent<{ conversationId?: string }>).detail?.conversationId ?? null;
+      let attempt = 0;
+      const run = async () => {
+        if (cancelled) return;
+        const rows = await fetchConversations({ background: true });
+        attempt += 1;
+        // Stop once the new conversation is visible (or there is no id to wait
+        // for, or the bound is hit). `rows === null` is a transient fetch error
+        // — keep retrying within the bound.
+        const present = !targetId || (rows?.some((c) => c.id === targetId) ?? false);
+        if (cancelled || present || attempt >= MAX_ATTEMPTS) return;
+        setTimeout(run, BACKOFF_MS[attempt] ?? 4000);
+      };
+      void run();
     };
     window.addEventListener(CONVERSATION_CREATED_EVENT, onCreated);
-    return () => window.removeEventListener(CONVERSATION_CREATED_EVENT, onCreated);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(CONVERSATION_CREATED_EVENT, onCreated);
+    };
   }, [fetchConversations]);
 
   // Note: there is no cross-tab `users` UPDATE channel. Repo scope now comes

--- a/apps/web-platform/test/conversations-rail-connect-race.test.tsx
+++ b/apps/web-platform/test/conversations-rail-connect-race.test.tsx
@@ -449,6 +449,44 @@ describe("useConversations — fresh-mount connect-race (Recent Conversations ra
     );
   });
 
+  it("retries the event refetch until the LAZILY-committed conversation row appears (commit-timing race, #5449 follow-up)", async () => {
+    // The real-world race (found via live headless-browser repro, 2026-06-17):
+    // the event fires at session_started, but the conversation ROW is created
+    // lazily on the first persisted message — slightly LATER. So the FIRST
+    // refetch on the event runs before the row is committed and misses it; the
+    // bounded retry (keyed on the event's conversationId) must keep refetching
+    // until the row appears. Non-vacuous: a single refetch leaves the row absent
+    // forever (the bug this enhancement fixes).
+    const existing = makeRow({ id: "conv-existing" });
+    const late = makeRow({ id: "conv-late-commit" });
+    state.fallbackConvResult = [existing]; // row NOT committed yet
+    const { useConversations, CONVERSATION_CREATED_EVENT } = await import(
+      "@/hooks/use-conversations"
+    );
+    const view = renderHook(() => useConversations({ limit: 15 }));
+    await waitFor(() =>
+      expect(view.result.current.conversations.map((c) => c.id)).toEqual(["conv-existing"]),
+    );
+
+    // Event fires before the row commits — the first refetch misses it.
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent(CONVERSATION_CREATED_EVENT, {
+          detail: { conversationId: "conv-late-commit" },
+        }),
+      );
+      await Promise.resolve();
+    });
+    expect(view.result.current.conversations.map((c) => c.id)).not.toContain("conv-late-commit");
+
+    // The row commits a beat later; the bounded retry must surface it.
+    state.fallbackConvResult = [late, existing];
+    await waitFor(
+      () => expect(view.result.current.conversations.map((c) => c.id)).toContain("conv-late-commit"),
+      { timeout: 5000 },
+    );
+  });
+
   it("AC2 (bounded): the scope-resolve backfill fires once, not per render", async () => {
     state.deferFirstActiveRepo = true;
     const newRow = makeRow({ id: "conv-bounded" });

--- a/knowledge-base/project/learnings/bug-fixes/2026-06-17-rail-realtime-race-needs-deterministic-signal-not-timing-tweaks.md
+++ b/knowledge-base/project/learnings/bug-fixes/2026-06-17-rail-realtime-race-needs-deterministic-signal-not-timing-tweaks.md
@@ -71,3 +71,23 @@ backstop.
 ## Tags
 category: bug-fixes
 module: apps/web-platform/hooks/use-conversations
+
+## Follow-up (#5449 → next PR): the deterministic signal also has a commit-timing race
+
+Live post-deploy verification of #5449 (the headless-browser harness driving the deployed app)
+revealed the deterministic signal was necessary but **not sufficient**: `chat-surface` emits the
+event at `session_started`, but the conversation **row is created lazily on the first persisted
+message — slightly AFTER `session_started`**. So the single refetch on the event runs *before* the
+row is committed and misses it (confirmed: the `realConversationId` the event carried had no
+`conversations` row yet).
+
+Fix: a **small bounded retry keyed on the event's concrete `conversationId`** — `fetchConversations`
+now returns the enriched list; the listener refetches, and if the target id isn't visible yet,
+retries on a short backoff (≈9.6s bound) until it appears or the bound is hit. Deterministic (gated
+on the actual id, never a blind clock), self-cancelling (if no row ever commits — e.g. the message
+was never sent — the retries exhaust harmlessly).
+
+**Meta-lesson reinforced:** post-deploy live verification is not optional theatre — it caught a real
+residual race that the (passing, mutation-verified) unit test could not, because the unit test
+modeled "row exists at event time." The browser harness modeled the true server timing. Verify the
+deployed artifact against reality, not just the model.


### PR DESCRIPTION
## Summary

Follow-up to #5449. **Post-deploy live verification** of #5449 (a headless-browser harness driving the deployed app) revealed the deterministic signal was necessary but **not sufficient**: `chat-surface` emits `soleur:conversation-created` at `session_started`, but the conversation **row is created lazily on the first persisted message — slightly *after* `session_started`**. So the single refetch on the event ran before the row was committed and missed it (confirmed: the `realConversationId` the event carried had no `conversations` row yet at event time).

**Fix — a small bounded retry keyed on the new conversation's concrete id.** `fetchConversations` now returns the enriched list; the event listener refetches, and if the event's `conversationId` isn't visible yet, retries on a short backoff (6 attempts, ≈9.6s bound) until it appears or the bound is hit. This is deterministic (gated on the actual id becoming visible, never a blind clock — the exact failure mode the prior three fixes fell into) and self-cancelling: if no row ever commits (e.g. the message was never sent), the retries exhaust harmlessly (nothing to show is correct). F3 isolation preserved — every refetch is the scoped list query, and the id is used only as a read-only stop-condition.

## Changelog

### Web Platform
- fix(chat): a freshly-started conversation now reliably appears in the Recent Conversations rail without a reload, even though its row is created lazily after the session starts — the rail's event-driven refetch retries (bounded, keyed on the new conversation id) until the row is committed and visible.

## Test plan

- [x] Non-vacuous unit test: the lazily-committed conversation appears **only via the retry** (the first refetch misses it; a later attempt surfaces it) — **mutation-verified** (the test fails when the retry is neutralized to a single attempt) — `test/conversations-rail-connect-race.test.tsx`.
- [x] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` exits 0 (the `fetchConversations` void→`ConversationWithPreview[] | null` return change; `refetch: () => void` stays assignment-compatible).
- [x] 102 tests green across the chat-surface + use-conversations blast radius.
- [x] Reviewed: security-sentinel (F3 + retry resource-safety clean), architecture-strategist (retry lifecycle bounded + unmount-safe; design correct). The one finding (stale dispatch comment) fixed inline.
- Post-deploy: I re-run the browser harness against production to confirm a freshly-started conversation appears live within the retry window (automated; no operator step).

Builds on #5449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
