### PR TITLE
feat(adr-044): refuse repo connect/disconnect on team workspaces (PR-2a confused-deputy guard)

### DIFF
--- a/apps/web-platform/app/api/repo/disconnect/route.ts
+++ b/apps/web-platform/app/api/repo/disconnect/route.ts
@@ -4,6 +4,7 @@ import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 import { SlidingWindowCounter } from "@/server/rate-limiter";
 import { deleteWorkspace } from "@/server/workspace";
+import { resolveCurrentWorkspaceId } from "@/server/workspace-resolver";
 import logger from "@/server/logger";
 
 const disconnectLimiter = new SlidingWindowCounter({
@@ -35,6 +36,24 @@ export async function DELETE(request: Request) {
     return NextResponse.json(
       { error: "Too many requests. Please wait before trying again." },
       { status: 429 },
+    );
+  }
+
+  // ADR-044 PR-2a (confused-deputy honesty): disconnect still tears down the
+  // SOLO workspace (`deleteWorkspace(user.id)` + solo-keyed clears below — team
+  // on-disk teardown is #4560/Phase-5). If a TEAM workspace is active, the legacy
+  // path would SILENTLY disconnect the caller's PERSONAL repo instead of the
+  // team's. Refuse explicitly until #4560. Resolved server-side from session
+  // state (never request input) → IDOR-safe; a strict no-op for solo
+  // (activeWorkspaceId === user.id).
+  const activeWorkspaceId = await resolveCurrentWorkspaceId(user.id, supabase);
+  if (activeWorkspaceId !== user.id) {
+    return NextResponse.json(
+      {
+        error:
+          "Disconnecting a repository from a team workspace isn't supported yet. Switch to your personal workspace to disconnect.",
+      },
+      { status: 422 },
     );
   }
 

--- a/apps/web-platform/app/api/repo/setup/route.ts
+++ b/apps/web-platform/app/api/repo/setup/route.ts
@@ -39,6 +39,25 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  // ADR-044 PR-2a (confused-deputy honesty): repo setup still provisions the
+  // SOLO workspace on disk (`provisionWorkspaceWithRepo(user.id, …)` below — team
+  // on-disk provisioning is #4560/Phase-5). If a TEAM workspace is active, the
+  // legacy path would SILENTLY clone into the caller's PERSONAL solo workspace
+  // (the user believes they connected the team's repo but connected their own).
+  // Refuse explicitly until #4560 lands real team provisioning. Resolved
+  // server-side from session state (never request input) → IDOR-safe; a strict
+  // no-op for solo (activeWorkspaceId === user.id).
+  const activeWorkspaceId = await resolveCurrentWorkspaceId(user.id, supabase);
+  if (activeWorkspaceId !== user.id) {
+    return NextResponse.json(
+      {
+        error:
+          "Connecting a repository to a team workspace isn't supported yet. Switch to your personal workspace to connect a repository.",
+      },
+      { status: 422 },
+    );
+  }
+
   // ADR-044 PR-1 owner-gate (confused-deputy): only the OWNER of the workspace
   // this handler mutates may connect a repo to it. `p_workspace_id` MUST equal
   // the id the handler mutates — in PR-1 setup writes the solo `users` row + the

--- a/apps/web-platform/test/disconnect-route.test.ts
+++ b/apps/web-platform/test/disconnect-route.test.ts
@@ -5,19 +5,30 @@ import { mockQueryChain } from "./helpers/mock-supabase";
 // Mocks — vi.hoisted ensures these are available when vi.mock factories run
 // ---------------------------------------------------------------------------
 
-const { mockGetUser, mockFrom, mockDeleteWorkspace, mockIsAllowed, mockRpc } =
-  vi.hoisted(() => ({
-    mockGetUser: vi.fn(),
-    mockFrom: vi.fn(),
-    mockDeleteWorkspace: vi.fn(),
-    mockIsAllowed: vi.fn(),
-    mockRpc: vi.fn(),
-  }));
+const {
+  mockGetUser,
+  mockFrom,
+  mockDeleteWorkspace,
+  mockIsAllowed,
+  mockRpc,
+  mockTenantFrom,
+} = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+  mockDeleteWorkspace: vi.fn(),
+  mockIsAllowed: vi.fn(),
+  mockRpc: vi.fn(),
+  mockTenantFrom: vi.fn(),
+}));
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({
     auth: { getUser: mockGetUser },
     rpc: mockRpc,
+    // ADR-044 PR-2a: the tenant client now reads user_session_state via
+    // resolveCurrentWorkspaceId (active-workspace guard). Defaulted to solo
+    // in beforeEach so every existing test is a no-op for the new guard.
+    from: mockTenantFrom,
   })),
   createServiceClient: vi.fn(() => ({
     from: mockFrom,
@@ -119,6 +130,46 @@ describe("DELETE /api/repo/disconnect", () => {
     // ADR-044 PR-1 owner-gate: default to owner (solo users always own
     // workspace_id=user.id). The non-owner case overrides per-test.
     mockRpc.mockResolvedValue({ data: true, error: null });
+    // ADR-044 PR-2a: default the active-workspace resolver to SOLO
+    // (current_workspace_id null → resolveCurrentWorkspaceId returns user.id),
+    // so the team-workspace refusal guard is a no-op for every existing test.
+    mockTenantFrom.mockReturnValue(
+      mockQueryChain({ current_workspace_id: null }, null),
+    );
+  });
+
+  test("returns 422 and refuses when a TEAM workspace is active (ADR-044 PR-2a confused-deputy guard)", async () => {
+    const TEAM_WORKSPACE_ID = "11111111-2222-3333-4444-555555555555";
+    mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
+    // Active workspace is a TEAM (≠ user.id). Team on-disk provisioning is
+    // #4560/Phase-5; until then a disconnect would SILENTLY tear down the
+    // caller's PERSONAL solo connection (confused deputy). Refuse explicitly.
+    mockTenantFrom.mockReturnValue(
+      mockQueryChain({ current_workspace_id: TEAM_WORKSPACE_ID }, null),
+    );
+    const { mockUpdate } = setupUserMocks({ repoStatus: "ready" });
+
+    const res = await DELETE(makeRequest());
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toMatch(/team workspace/i);
+
+    // The refusal precedes the owner-gate AND every mutation.
+    expect(mockRpc).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockDeleteWorkspace).not.toHaveBeenCalled();
+  });
+
+  test("solo active workspace (current_workspace_id === user.id) is unaffected by the team guard", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
+    mockTenantFrom.mockReturnValue(
+      mockQueryChain({ current_workspace_id: TEST_USER_ID }, null),
+    );
+    setupUserMocks({ repoStatus: "ready" });
+    mockDeleteWorkspace.mockResolvedValue(undefined);
+
+    const res = await DELETE(makeRequest());
+    expect(res.status).toBe(200);
   });
 
   test("returns 403 when the caller is not the workspace owner (ADR-044 owner-gate)", async () => {

--- a/apps/web-platform/test/setup-route-health-scanner.test.ts
+++ b/apps/web-platform/test/setup-route-health-scanner.test.ts
@@ -78,6 +78,23 @@ vi.mock("@/lib/supabase/server", () => ({
     },
     // ADR-044 PR-1 owner-gate: default to owner.
     rpc: vi.fn().mockResolvedValue({ data: true, error: null }),
+    // ADR-044 PR-2a: tenant read of user_session_state for the active-workspace
+    // guard (resolveCurrentWorkspaceId). No session row → solo (== user-123), so
+    // the team-workspace refusal is a no-op for these health-scanner tests.
+    from: vi.fn((table: string) => {
+      if (table === "user_session_state") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi
+                .fn()
+                .mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    }),
   }),
   createServiceClient: vi.fn().mockReturnValue({
     from: vi.fn((table: string) => {

--- a/apps/web-platform/test/setup-route-install-resolution.test.ts
+++ b/apps/web-platform/test/setup-route-install-resolution.test.ts
@@ -1,10 +1,12 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
+import { mockQueryChain } from "./helpers/mock-supabase";
 
 // ---------------------------------------------------------------------------
 // Mocks (declared before the route import)
 // ---------------------------------------------------------------------------
 const mockGetUser = vi.fn();
 const mockRpc = vi.fn();
+const mockTenantFrom = vi.fn();
 const mockServiceFrom = vi.fn();
 const mockAdminGetUserById = vi.fn();
 const mockValidateOrigin = vi.fn();
@@ -19,6 +21,9 @@ vi.mock("@/lib/supabase/server", () => ({
   createClient: async () => ({
     auth: { getUser: mockGetUser },
     rpc: mockRpc,
+    // ADR-044 PR-2a: tenant read of user_session_state for the active-workspace
+    // guard (resolveCurrentWorkspaceId). Defaulted to solo in beforeEach.
+    from: mockTenantFrom,
   }),
   createServiceClient: () => ({
     from: mockServiceFrom,
@@ -159,7 +164,34 @@ describe("POST /api/repo/setup — install resolution", () => {
     mockProvisionWorkspaceWithRepo.mockResolvedValue("/workspaces/user-1");
     // ADR-044 PR-1 owner-gate: default owner; non-owner test overrides.
     mockRpc.mockResolvedValue({ data: true, error: null });
+    // ADR-044 PR-2a: default the active-workspace resolver to SOLO
+    // (current_workspace_id null → resolveCurrentWorkspaceId returns user.id),
+    // so the team-workspace refusal guard is a no-op for every existing test.
+    mockTenantFrom.mockReturnValue(
+      mockQueryChain({ current_workspace_id: null }, null),
+    );
     setupServiceClient();
+  });
+
+  test("ADR-044 PR-2a: TEAM workspace active → 422 refusal, no owner-gate, no clone", async () => {
+    const TEAM_WORKSPACE_ID = "11111111-2222-3333-4444-555555555555";
+    // Active workspace is a TEAM (≠ user.id). Team on-disk provisioning is
+    // #4560/Phase-5; until then setup would SILENTLY clone into the caller's
+    // PERSONAL solo workspace (confused deputy). Refuse explicitly.
+    mockTenantFrom.mockReturnValue(
+      mockQueryChain({ current_workspace_id: TEAM_WORKSPACE_ID }, null),
+    );
+
+    const res = await POST(
+      makeRequest({ repoUrl: "https://github.com/jikig-ai/soleur" }),
+    );
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toMatch(/team workspace/i);
+
+    // The refusal precedes the owner-gate AND the clone.
+    expect(mockRpc).not.toHaveBeenCalled();
+    expect(mockProvisionWorkspaceWithRepo).not.toHaveBeenCalled();
   });
 
   test("ADR-044 owner-gate: non-owner → 403, no clone", async () => {

--- a/knowledge-base/engineering/architecture/decisions/ADR-044-workspace-repo-ownership.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-044-workspace-repo-ownership.md
@@ -91,3 +91,54 @@ This amendment records the **always-enforce-workspace** invariant: every user ow
 
 - **Option A2 (chosen): membership-verified resolve-once + explicit db-error + non-member-claim reset-to-solo.** One `resolveActiveWorkspace` per dispatch threaded into every consumer (path/repo/install/self-heal); a probe DB error returns `{ok:false,"db-error"}` (transient, never dispatched); a non-member claim resets to the user's own workspace with a deduped divergence breadcrumb. Pros: structurally cross-tenant-safe (TR1); makes the formerly-invisible divergence queryable; non-destructive (read-path only). Cons: forward-places the owner-gate (no-op until PR-2).
 - **Option B2 (rejected): keep dual user/workspace keying with a silent solo fallback.** Retain the silent `resolveActiveWorkspaceIdWithMembership` (solo fallback on miss AND error, no Sentry). Rejected — **this is the #5437 incident**: the silent fallback masks a non-member claim as success, diverges the clone target from repo+install inside the same dispatch, and strands the member with no signal. A `MIN(created_at)`/first-membership fallback (the #4767 class) is rejected for the same reason: it can return a sibling tenant's workspace.
+
+## Amendment 2026-06-17 — PR-2 splits into PR-2a (refusal guard) + PR-2b (drop), gated on #4560
+
+`status` stays `adopting`. Implementing PR-2 surfaced that the plan's "additive
+write relocation (`users.*` → `workspaces.*`, then drop)" is **not a decoupled
+additive step** — it is structurally the deferred **#4560 / Phase-5
+team-workspace provisioning** effort. Evidence (verified in code, ruled on by the
+`cto` agent):
+
+- `app/api/repo/setup/route.ts` provisions the **solo** workspace on disk
+  (`provisionWorkspaceWithRepo(user.id, …)` clones into `/workspaces/<user.id>`);
+  relocating the write to an arbitrary team workspace id requires team on-disk
+  provisioning — the #4560 work. The route comment is explicit: *"Team-invite
+  repo-setup flows (Phase 5) will resolve the target workspace_id first."*
+- The owner-gate's own invariant — *"`p_workspace_id` MUST equal the id the
+  handler mutates"* — couples the gate change to the write relocation; one cannot
+  land without the other.
+- `repo_error` deliberately stays on `users` (read keyed on the dispatching
+  user); `current-repo-url.ts` assigns the team-workspace `repo_error`
+  relocation to #4560, and `workspaces.repo_error` is never written.
+- The genuinely-additive pre-drop steps were **already shipped**: mig 079 added
+  the `workspaces` repo columns AND the full credential protection
+  (`REVOKE SELECT ON workspaces FROM authenticated` + re-GRANT excluding
+  `github_installation_id` + `resolve_workspace_installation_id` reader RPC); PR-1
+  cut the read path over.
+
+**Decision — split PR-2:**
+
+- **PR-2a (this PR, shipped):** the confused-deputy honesty fix. `repo/setup` +
+  `repo/disconnect` resolve the active workspace server-side
+  (`resolveCurrentWorkspaceId`, IDOR-safe) and return **422** when a TEAM
+  workspace is active, instead of silently provisioning/disconnecting the
+  caller's PERSONAL solo workspace. Strict no-op for solo
+  (`activeWorkspaceId === user.id`). No `users.*` write change, no migration, no
+  column drop. `Refs #5437` (closes nothing). C4 connection edge **unchanged**:
+  still **read=Workspace / write=User (dual)** — PR-2a lands no write relocation.
+- **PR-2b (deferred, the destructive drop):** drops `users.repo_url` /
+  `workspace_path` / `github_installation_id` (+ the mig-052 partial-UNIQUE
+  index), with the pre-decommission drift gate above. **Blocked on BOTH** (a)
+  **#4560** delivering the team write-cutover so the `users.*` writes can stop,
+  AND (b) the PR-1 `repo-resolver-divergence` breadcrumb showing zero divergence
+  over a real prod soak window. At PR-2a authoring time the breadcrumb had **0
+  events** because PR-1 had merged ~28 min earlier — *no soak yet*, not
+  *proven clean*. `status: adopting → accepted` and the C4 edge → wholly-Workspace
+  move with PR-2b (when the write side actually relocates), not PR-2a.
+
+### Considered Options (amendment)
+
+- **Option A3 (chosen): ship the thin refusal guard now (PR-2a), defer the drop to PR-2b/#4560.** Converts a live silent confused-deputy (team-active connect/disconnect targeting the personal solo workspace) into an honest 422, decoupled from #4560, forward-compatible (#4560 replaces the refusal with real team provisioning). Small, testable, no one-way-door.
+- **Option B3 (rejected): fold #4560 into this PR and do the full write-cutover + drop now.** Large (team on-disk provisioning + gate/write co-relocation + `repo_error` re-key + co-membered backfill reconcile), couples the irreversible column drop to a large untested change, and discards the operator-confirmed soak deferral.
+- **Option C3 (rejected): ship zero code, only re-sequence the issues.** Correct bookkeeping but leaves the silent confused-deputy live; the refusal is cheap and strictly improves correctness.

--- a/knowledge-base/project/learnings/2026-06-17-zero-commit-worktree-reaped-and-plan-write-relocation-was-4560.md
+++ b/knowledge-base/project/learnings/2026-06-17-zero-commit-worktree-reaped-and-plan-write-relocation-was-4560.md
@@ -1,0 +1,99 @@
+# Learning: a zero-commit work branch is reaped by concurrent cleanup-merged; and ADR-044 PR-2's "additive write relocation" was structurally the deferred #4560
+
+## Problem
+
+Two distinct lessons from the ADR-044 PR-2a session.
+
+### 1. Zero-commit worktree + branch silently reaped mid-session
+
+A fresh `worktree-manager.sh create feat-adr-044-pr2-write-relocation` was made
+with the session-lease env vars (`SOLEUR_SKILL_NAME=work
+SOLEUR_EXPECTED_DURATION_MIN=240`). Reconnaissance (all read-only) ran for a
+while, then `cd` into the worktree failed: **the worktree directory AND the
+branch ref were both gone**, and a foreign sibling worktree had appeared. A
+concurrent session's `cleanup-merged` had reaped it.
+
+Root cause: `cleanup-merged` reaps branches that `git branch --merged main`
+reports as merged. **A branch with ZERO unique commits beyond `main` IS
+"merged"** by that definition (it has no commits `main` lacks). So a
+just-created, not-yet-committed work branch is indistinguishable from a
+fully-merged one — the lease did not protect it (or the sibling's cleanup
+predated/ignored the lease).
+
+### 2. The plan's "additive write relocation" did not exist as a decoupled step
+
+ADR-044 PR-2 was scoped as "relocate connect-time WRITES `users.* → workspaces.*`,
+then DROP the legacy columns." Implementation revealed the write relocation is
+structurally the **deferred #4560 / Phase-5 team-provisioning** effort, not a
+quick additive step.
+
+## Solution
+
+### 1. Land an immediate commit right after worktree creation
+
+After `worktree-manager.sh create`, commit a scaffolding artifact (the spec /
+decision record) BEFORE any long read-only phase, so the branch has ≥1 unique
+commit and never reads as "merged":
+
+```
+git add knowledge-base/project/specs/feat-<name>/spec.md
+LEFTHOOK=0 git commit -q -m "docs(<scope>): spec + decision record"
+git rev-list origin/main..HEAD --count   # must be ≥ 1
+```
+
+The durable fix belongs in the git-worktree subsystem (auto-create an initial
+empty/scaffold commit on `create`, OR have `cleanup-merged` refuse to reap a
+branch that is < N minutes old or holds an active lease) — filed as a separate
+issue (different subsystem; scope discipline) — filed as **#5454**.
+
+### 2. Trace the actual producer; route the fork to the CTO
+
+`git grep`/Read of the real code (not the plan's line numbers) showed:
+- `setup/route.ts` clones into `/workspaces/<user.id>` (solo on-disk
+  provisioning); team provisioning is explicitly "Phase 5".
+- the owner-gate invariant "`p_workspace_id` MUST equal the id the handler
+  mutates" couples the gate change to the write relocation.
+- mig 079 already did the `workspaces` repo columns + the credential protection
+  (`REVOKE SELECT ON workspaces FROM authenticated` + reader RPC); PR-1 did the
+  read cutover. The quick pre-drop steps were ALREADY shipped.
+
+The architecture/sequencing fork was routed to the `cto` agent, which split PR-2
+into **PR-2a** (a confused-deputy refusal guard: 422 when a team workspace is
+active on `repo/setup`/`disconnect`, no-op for solo) and **PR-2b** (the
+destructive drop, gated on #4560 + a real prod soak).
+
+### 3. Soak-gate discipline
+
+The drop's soak gate was evaluated via the Sentry issues API: **0
+`repo_resolver_divergence` breadcrumbs ~28 min after PR-1 merged**. Zero events
+with no soak window is *no data*, not *proven clean*. A one-way-door destructive
+migration must wait for a real prod soak window with traffic.
+
+## Key Insight
+
+- **A not-yet-committed work branch is "merged" to `git branch --merged` — commit
+  something immediately so concurrent `cleanup-merged` can't reap it.**
+- **A plan's "additive step" is a hypothesis; trace the actual producer. When the
+  real decoupling differs (here: the write relocation IS the deferred team-flow),
+  route the sequencing fork to the CTO, don't force the plan's shape.**
+- **Absence of an error signal shortly after deploy is not evidence of
+  correctness; a destructive one-way door needs a real soak window.**
+
+## Session Errors
+
+- **Zero-commit worktree+branch reaped by concurrent cleanup-merged** — Recovery:
+  recreated the worktree and landed an immediate spec commit. Prevention: commit a
+  scaffold artifact right after `create` (done this session); durable fix filed
+  against the git-worktree subsystem.
+- **Bare-repo-root `git grep` (`fatal: must be run in a work tree`) + a CWD drift
+  to the bare root** — Recovery: re-ran with `cd <worktree>` and `;` separators.
+  Prevention: already covered by `hr-when-in-a-worktree-never-read-from-bare`;
+  one-off operator slip.
+- **`&&`-chain short-circuited on a `git grep` exit-1 (no matches), hiding a
+  follow-on typecheck command** — Recovery: re-ran the steps separately.
+  Prevention: separate independent shell steps with `;` (or `|| true`) when an
+  intermediate grep legitimately returns non-zero. One-off.
+
+## Tags
+category: workflow-patterns
+module: git-worktree, adr-044

--- a/knowledge-base/project/specs/feat-adr-044-pr2-write-relocation/spec.md
+++ b/knowledge-base/project/specs/feat-adr-044-pr2-write-relocation/spec.md
@@ -1,0 +1,69 @@
+---
+feature: ADR-044 PR-2a — workspace-owned repo connection (additive write relocation)
+closes: 5437
+adr: ADR-044
+lane: cross-domain
+status: in-progress
+---
+
+# ADR-044 PR-2a — Additive repo-connection write relocation
+
+## Soak-gate finding (decision record)
+
+PR-2 (#5437) was scoped to relocate connect-time writes AND drop the legacy
+`users.*` fallback columns. The column drop is hard-gated on a prod soak of the
+PR-1 `repo-resolver-divergence` breadcrumb.
+
+**Gate evaluated `2026-06-16 ~23:34 UTC` via the Sentry issues API** (project
+`jikigai-eu/web-platform`, query `repo_resolver_divergence` and
+`feature:repo-resolver-divergence`, 14d window): **0 issues**. But PR-1 (#5435,
+`d83fca487`) merged `2026-06-16 23:06 UTC` — **~28 min earlier**. Zero
+breadcrumbs after <1h (build likely still deploying) is *no soak / no data*, not
+*proven clean*. The breadcrumb fires only on edge events
+(`non-member-claim-reset`, `self-heal-failed`) that need days of real traffic.
+
+**Decision (operator-confirmed):** the destructive drop is **DEFERRED** to a
+soak-gated **PR-2b**. This PR (PR-2a) does the soak-independent, additive half.
+Matches the plan's own Top-Risks mandate: *"additive-write-relocation must land +
+soak BEFORE the column drop (two migrations, two deploys)."*
+
+## PR-2a scope (this PR — additive only)
+
+The real ADR-044 gap is **team workspaces**: connect routes today write to
+`user.id` and gate on `is_workspace_owner(user.id, user.id)` (always true), so a
+team's repo connection can never be set via the UI and any member can "connect."
+Solo workspaces are already covered (the mirror keeps `workspaces` in sync; reads
+already come from `workspaces.repo_status`).
+
+1. **Migration 110 (additive):**
+   - `ALTER TABLE workspaces ADD COLUMN repo_error text` (the only missing
+     repo-connection column; `repo_url`/`github_installation_id`/`repo_status`/
+     `repo_last_synced_at` already exist per mig 079).
+   - Credential protection: `REVOKE SELECT (github_installation_id) ON
+     public.workspaces FROM authenticated, anon` + a membership-checked SECURITY
+     DEFINER reader RPC.
+   - Membership/owner-gated SECURITY DEFINER write RPC(s) for the repo-connection
+     columns keyed on `p_workspace_id` (precedent: mig 108 `set_repo_status`).
+   - `verify/110_*.sql` sentinel.
+2. **Owner-gate finalization:** `app/api/repo/setup` + `app/api/repo/disconnect`
+   resolve the active workspace and gate on `is_workspace_owner(activeWorkspaceId,
+   user.id)` → 403 for a non-owner member. (Confused-deputy fix.)
+3. **Write relocation (additive dual-write):** connect-time repo-connection writes
+   ALSO target the resolved active workspace (team or solo) via the RPC; the
+   existing `users.*` writes stay as the rollback net.
+4. **Consumer reads:** onboarding/connect-flow repo-state reads source the active
+   workspace's `workspaces.*`. (`dsar-export.ts` + `account-delete.ts` already
+   carry no legacy-column reads per recon.)
+
+## Out of scope (deferred to PR-2b, soak-gated)
+
+- DROP `users.repo_url`, `users.workspace_path`, `users.github_installation_id`
+  (+ mig-052 partial-UNIQUE index) with `.down.sql` + `verify/NNN`.
+- Removal of the `users`-side dual-write / the solo mirror's users-side write.
+- Onboarding `github_installation_id IS NOT NULL` → on-demand
+  `GET /user/installations`; connect-flow `GET /repos/{owner}/{repo}/installation`.
+- `workspace_path` / `workspace_status` relocation (these are solo-provisioning
+  columns, not the connection edge — they stay on `users`).
+- ADR-044 `status: adopting → accepted`; C4 edge → wholly-Workspace (PR-2b lands
+  the write-side fully).
+- Sentry `sentry_issue_alert` routing for the divergence fingerprint (fast-follow).

--- a/knowledge-base/project/specs/feat-adr-044-pr2-write-relocation/spec.md
+++ b/knowledge-base/project/specs/feat-adr-044-pr2-write-relocation/spec.md
@@ -1,6 +1,8 @@
 ---
-feature: ADR-044 PR-2a — workspace-owned repo connection (additive write relocation)
-closes: 5437
+feature: ADR-044 PR-2a — workspace-owned repo connection (confused-deputy refusal guard)
+refs: 5437
+closed_by: 5437 is closed by PR-2b (the column drop), not PR-2a
+depends_on: 4560
 adr: ADR-044
 lane: cross-domain
 status: in-progress
@@ -27,33 +29,42 @@ soak-gated **PR-2b**. This PR (PR-2a) does the soak-independent, additive half.
 Matches the plan's own Top-Risks mandate: *"additive-write-relocation must land +
 soak BEFORE the column drop (two migrations, two deploys)."*
 
-## PR-2a scope (this PR — additive only)
+## PR-2a scope (this PR — application-layer only, NO migration)
 
-The real ADR-044 gap is **team workspaces**: connect routes today write to
-`user.id` and gate on `is_workspace_owner(user.id, user.id)` (always true), so a
-team's repo connection can never be set via the UI and any member can "connect."
-Solo workspaces are already covered (the mirror keeps `workspaces` in sync; reads
-already come from `workspaces.repo_status`).
+The real ADR-044 gap is **team workspaces**: connect routes today write the
+workspaces-side repo state keyed on `user.id` (the solo mirror) and gate on
+`is_workspace_owner(user.id, user.id)` (always true post-mig-109), so a team's
+repo connection can never land on the team workspace and any member can "connect."
+Solo workspaces already work end-to-end (mirror keeps `workspaces` in sync; reads
+come from `workspaces.repo_status`).
 
-1. **Migration 110 (additive):**
-   - `ALTER TABLE workspaces ADD COLUMN repo_error text` (the only missing
-     repo-connection column; `repo_url`/`github_installation_id`/`repo_status`/
-     `repo_last_synced_at` already exist per mig 079).
-   - Credential protection: `REVOKE SELECT (github_installation_id) ON
-     public.workspaces FROM authenticated, anon` + a membership-checked SECURITY
-     DEFINER reader RPC.
-   - Membership/owner-gated SECURITY DEFINER write RPC(s) for the repo-connection
-     columns keyed on `p_workspace_id` (precedent: mig 108 `set_repo_status`).
-   - `verify/110_*.sql` sentinel.
-2. **Owner-gate finalization:** `app/api/repo/setup` + `app/api/repo/disconnect`
-   resolve the active workspace and gate on `is_workspace_owner(activeWorkspaceId,
-   user.id)` → 403 for a non-owner member. (Confused-deputy fix.)
-3. **Write relocation (additive dual-write):** connect-time repo-connection writes
-   ALSO target the resolved active workspace (team or solo) via the RPC; the
-   existing `users.*` writes stay as the rollback net.
-4. **Consumer reads:** onboarding/connect-flow repo-state reads source the active
-   workspace's `workspaces.*`. (`dsar-export.ts` + `account-delete.ts` already
-   carry no legacy-column reads per recon.)
+**No migration is required.** Recon of the live schema found mig 079 already:
+- added the repo-connection columns to `workspaces`
+  (`repo_url`/`repo_provider`/`github_installation_id`/`repo_status`/
+  `repo_last_synced_at`);
+- did the **credential protection** in full — `REVOKE SELECT ON workspaces FROM
+  authenticated` + re-GRANT of only the non-credential columns (excludes
+  `github_installation_id`), with `resolve_workspace_installation_id`
+  (membership-checked SECURITY DEFINER) as the sole reader.
+`repo_error` is deliberately NOT on `workspaces` and is NOT relocated here:
+`current-repo-url.ts:82-104` documents the error-reason staying on
+`users.repo_error` (read keyed on the dispatching user) as an accepted
+forward-looking limitation, with the team-workspace relocation explicitly
+assigned to **#4560**. So the "migration 110 + credential RPC" items from the
+original PR-2 sketch are already done / out-of-scope; dropping them shrinks the
+blast radius (no schema change) with the core fix intact.
+
+1. **Owner-gate finalization (the confused-deputy fix #5437 centers on):**
+   `app/api/repo/setup` + `app/api/repo/disconnect` resolve the active workspace
+   and gate on `is_workspace_owner(activeWorkspaceId, user.id)` → 403 for a
+   non-owner member. No-op for solo (`activeWorkspaceId === user.id`).
+2. **Write relocation (additive dual-write):** the connect-time workspaces-side
+   repo-connection writes (`setup`, `detect-installation`, `install`,
+   `disconnect`) target the resolved **active** workspace id (team or solo) rather
+   than always `user.id`; the existing `users.*` writes stay as the rollback net.
+   No-op for solo.
+3. **Consumer reads:** `dsar-export.ts` + `account-delete.ts` already carry no
+   legacy-column reads (recon-confirmed); no change needed there.
 
 ## Out of scope (deferred to PR-2b, soak-gated)
 


### PR DESCRIPTION
## Summary

ADR-044 PR-2a. `repo/setup` (POST) and `repo/disconnect` (DELETE) now resolve the caller's **active** workspace server-side (`resolveCurrentWorkspaceId`, IDOR-safe — never from request input) and return **422** when a **team** workspace is active, instead of writing to the caller's **personal solo** workspace.

This is the confused-deputy point the PR-1 owner-gate was forward-placed for. Today a team-active member who hits connect/disconnect passes the owner-gate (`is_workspace_owner(user.id, user.id)` is always true for one's own solo workspace) and the handler then provisions/tears down their **personal** workspace — the member believes they acted on the **team's** repo. The guard converts that silent misdirection into an honest, typed refusal. Strict no-op for solo (`activeWorkspaceId === user.id`). Team on-disk provisioning lands later in **#4560 / Phase-5**, which will replace the refusal with real team-workspace provisioning.

Refs #5437

This PR leaves #5437 **OPEN** — the destructive `users.*` column drop (PR-2b) is what finishes it, and PR-2b is gated on **#4560** (team write-cutover, so the `users.*` writes can stop) plus a real prod soak of the PR-1 `repo-resolver-divergence` breadcrumb. See the ADR-044 amendment "2026-06-17 — PR-2 splits into PR-2a + PR-2b, gated on #4560".

**No migration, no schema change, no `users.*` write change** — recon found mig 079 already added the `workspaces` repo columns + the full credential protection, and the read path was cut over in PR-1; the genuinely-additive pre-drop work was already shipped.

## User-Brand Impact

- **User-facing artifact:** the repo connection (the `workspaces.github_installation_id` GitHub App grant + `repo_url`) bound to the wrong workspace.
- **Exposure vector:** confused-deputy authorization — a team-active member's connect/disconnect silently targets their personal solo workspace; the member believes the team's repo is connected (or, on disconnect, tears down their own connection unexpectedly). The route is agent-reachable, not only UI-reachable.
- **Brand-survival threshold:** single-user incident
- **Mitigation:** server-side active-workspace resolution + an explicit 422 refusal until #4560 lands real team provisioning; the solo path is byte-identical (no regression for the only flow that works end-to-end today).

> Incident-PIR note: this is a **forward-hardening guard for a latent confused-deputy**, not a production-incident/outage fix — no outage occurred and no PIR is warranted. (The incident-signal heuristic would only match on the `single-user incident` brand-survival token, not an actual outage.)

## Changelog

- `repo/setup` + `repo/disconnect`: return 422 when a team workspace is active (confused-deputy guard); solo path unchanged.
- ADR-044: amended with the PR-2a / PR-2b split and the #4560 dependency for the destructive drop.
- Tests: team-active 422 + solo no-op coverage; tenant-`from` mock sweep across all three handler-importing route test files.

## Test plan

- [x] `vitest run` full web-platform suite green (846 files / 10,505 tests passed)
- [x] `tsc --noEmit` clean
- [x] RED→GREEN: team-active active workspace → 422; solo (`activeWorkspaceId === user.id`) → unchanged
- [x] Guard precedes the owner-gate and every mutation (asserted: no owner-gate RPC, no clone, no delete on the team path)
- [x] Multi-agent review clean — security-sentinel, pattern-recognition-specialist, semgrep-sast (0 findings)
- [x] GDPR gate clean (no migration; Art.17 erasure of legacy columns deferred to PR-2b)

Generated with [Claude Code](https://claude.com/claude-code)
