### PR TITLE
docs(adr-044): correct PR-2b blocker #4560 → #5462 + record soak baseline

### DIFF
--- a/apps/web-platform/app/api/repo/disconnect/route.ts
+++ b/apps/web-platform/app/api/repo/disconnect/route.ts
@@ -41,9 +41,9 @@ export async function DELETE(request: Request) {
 
   // ADR-044 PR-2a (confused-deputy honesty): disconnect still tears down the
   // SOLO workspace (`deleteWorkspace(user.id)` + solo-keyed clears below — team
-  // on-disk teardown is #4560/Phase-5). If a TEAM workspace is active, the legacy
+  // on-disk teardown is #5462/Phase-5). If a TEAM workspace is active, the legacy
   // path would SILENTLY disconnect the caller's PERSONAL repo instead of the
-  // team's. Refuse explicitly until #4560. Resolved server-side from session
+  // team's. Refuse explicitly until #5462. Resolved server-side from session
   // state (never request input) → IDOR-safe; a strict no-op for solo
   // (activeWorkspaceId === user.id).
   const activeWorkspaceId = await resolveCurrentWorkspaceId(user.id, supabase);

--- a/apps/web-platform/app/api/repo/setup/route.ts
+++ b/apps/web-platform/app/api/repo/setup/route.ts
@@ -41,10 +41,10 @@ export async function POST(request: Request) {
 
   // ADR-044 PR-2a (confused-deputy honesty): repo setup still provisions the
   // SOLO workspace on disk (`provisionWorkspaceWithRepo(user.id, …)` below — team
-  // on-disk provisioning is #4560/Phase-5). If a TEAM workspace is active, the
+  // on-disk provisioning is #5462/Phase-5). If a TEAM workspace is active, the
   // legacy path would SILENTLY clone into the caller's PERSONAL solo workspace
   // (the user believes they connected the team's repo but connected their own).
-  // Refuse explicitly until #4560 lands real team provisioning. Resolved
+  // Refuse explicitly until #5462 lands real team provisioning. Resolved
   // server-side from session state (never request input) → IDOR-safe; a strict
   // no-op for solo (activeWorkspaceId === user.id).
   const activeWorkspaceId = await resolveCurrentWorkspaceId(user.id, supabase);

--- a/apps/web-platform/server/agent-runner.ts
+++ b/apps/web-platform/server/agent-runner.ts
@@ -1483,8 +1483,9 @@ recipient, and suppression is permanent (no un-suppress).`;
     // pair workspace A's installation with workspace B's repo_url — both
     // workspaces the SAME user belongs to (not cross-tenant). The window is
     // sub-ms and the switcher reloads the page (restarting this context), so
-    // it is not fixed here; when #4560 makes mid-run switches plausible,
-    // resolve the workspace ONCE and thread it into both via their existing
+    // it is not fixed here; when #5462 gives workspaces distinct repo
+    // connections (making A-install/B-repo pairing reachable), resolve the
+    // workspace ONCE and thread it into both via their existing
     // `workspaceId` override params so installation + repo share one snapshot.
     const repoUrl = await getCurrentRepoUrl(userId);
 

--- a/apps/web-platform/server/current-repo-url.ts
+++ b/apps/web-platform/server/current-repo-url.ts
@@ -94,11 +94,11 @@ export async function getCurrentRepoUrl(
  * through to the existing repo-less path / #5392 fallback (the safety net this
  * gate layers on top of).
  *
- * Source-key note (forward-looking, for the #4560 team-workspace author): the
+ * Source-key note (forward-looking, for the #5462 team-workspace author): the
  * `repo_status` key is the active WORKSPACE while the `repo_error` key is the
  * dispatching USER. Today connect/disconnect is solo-only
  * (`workspace.id === user.id`), so the two keys coincide. Once team-invite repo
- * flows land (#4560), a member dispatching against a workspace whose `error`
+ * flows land (#5462), a member dispatching against a workspace whose `error`
  * status was caused by ANOTHER member reads their own (null) `repo_error` → the
  * gate's message degrades to the generic `"setup failed"` fallback (NOT a
  * misclassification and NOT a cross-member leak — readiness is still correct).

--- a/apps/web-platform/server/workspace-repo-mirror.ts
+++ b/apps/web-platform/server/workspace-repo-mirror.ts
@@ -29,7 +29,7 @@ interface ServiceClientLike {
  * `workspaces`, showing a stale/absent repo.
  *
  * Connect/disconnect flows are SOLO-ONLY today (team-invite repo flows are
- * deferred to #4560 / Phase 5 — they will resolve the target workspace
+ * deferred to #5462 / Phase 5 — they will resolve the target workspace
  * first), so the solo workspace id equals the user id.
  *
  * Service-role write: members cannot UPDATE `workspaces` directly (no

--- a/apps/web-platform/test/disconnect-route.test.ts
+++ b/apps/web-platform/test/disconnect-route.test.ts
@@ -142,7 +142,7 @@ describe("DELETE /api/repo/disconnect", () => {
     const TEAM_WORKSPACE_ID = "11111111-2222-3333-4444-555555555555";
     mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
     // Active workspace is a TEAM (≠ user.id). Team on-disk provisioning is
-    // #4560/Phase-5; until then a disconnect would SILENTLY tear down the
+    // #5462/Phase-5; until then a disconnect would SILENTLY tear down the
     // caller's PERSONAL solo connection (confused deputy). Refuse explicitly.
     mockTenantFrom.mockReturnValue(
       mockQueryChain({ current_workspace_id: TEAM_WORKSPACE_ID }, null),

--- a/apps/web-platform/test/setup-route-install-resolution.test.ts
+++ b/apps/web-platform/test/setup-route-install-resolution.test.ts
@@ -176,7 +176,7 @@ describe("POST /api/repo/setup — install resolution", () => {
   test("ADR-044 PR-2a: TEAM workspace active → 422 refusal, no owner-gate, no clone", async () => {
     const TEAM_WORKSPACE_ID = "11111111-2222-3333-4444-555555555555";
     // Active workspace is a TEAM (≠ user.id). Team on-disk provisioning is
-    // #4560/Phase-5; until then setup would SILENTLY clone into the caller's
+    // #5462/Phase-5; until then setup would SILENTLY clone into the caller's
     // PERSONAL solo workspace (confused deputy). Refuse explicitly.
     mockTenantFrom.mockReturnValue(
       mockQueryChain({ current_workspace_id: TEAM_WORKSPACE_ID }, null),

--- a/knowledge-base/engineering/architecture/decisions/ADR-044-workspace-repo-ownership.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-044-workspace-repo-ownership.md
@@ -92,25 +92,36 @@ This amendment records the **always-enforce-workspace** invariant: every user ow
 - **Option A2 (chosen): membership-verified resolve-once + explicit db-error + non-member-claim reset-to-solo.** One `resolveActiveWorkspace` per dispatch threaded into every consumer (path/repo/install/self-heal); a probe DB error returns `{ok:false,"db-error"}` (transient, never dispatched); a non-member claim resets to the user's own workspace with a deduped divergence breadcrumb. Pros: structurally cross-tenant-safe (TR1); makes the formerly-invisible divergence queryable; non-destructive (read-path only). Cons: forward-places the owner-gate (no-op until PR-2).
 - **Option B2 (rejected): keep dual user/workspace keying with a silent solo fallback.** Retain the silent `resolveActiveWorkspaceIdWithMembership` (solo fallback on miss AND error, no Sentry). Rejected — **this is the #5437 incident**: the silent fallback masks a non-member claim as success, diverges the clone target from repo+install inside the same dispatch, and strands the member with no signal. A `MIN(created_at)`/first-membership fallback (the #4767 class) is rejected for the same reason: it can return a sibling tenant's workspace.
 
-## Amendment 2026-06-17 — PR-2 splits into PR-2a (refusal guard) + PR-2b (drop), gated on #4560
+## Amendment 2026-06-17 — PR-2 splits into PR-2a (refusal guard) + PR-2b (drop), gated on the team write-cutover (#5462)
+
+> **Correction 2026-06-17 (citation fix).** An earlier draft of this amendment
+> cited **#4560** as the issue "delivering the team write-cutover" that PR-2b is
+> blocked on. That was a mis-citation: **#4560 is journey-state UI polish**
+> (J1/J2/J3/J7 — empty-workspace CTAs, mid-flight-switch prompts, failure copy,
+> deferred from #4558) and will never relocate the connect-time writes. The team
+> write-cutover (team on-disk provisioning + `users.*` → `workspaces.*` write
+> relocation + `repo_error` re-key + co-membered backfill reconcile) was
+> **untracked**; it is now filed as **#5462**. All "the write-cutover work"
+> references below have been corrected #4560 → #5462. Genuine journey-state
+> deferrals (the #4558 plan's J1/J2/J3/J7) correctly remain #4560.
 
 `status` stays `adopting`. Implementing PR-2 surfaced that the plan's "additive
 write relocation (`users.*` → `workspaces.*`, then drop)" is **not a decoupled
-additive step** — it is structurally the deferred **#4560 / Phase-5
+additive step** — it is structurally the **#5462 / Phase-5
 team-workspace provisioning** effort. Evidence (verified in code, ruled on by the
 `cto` agent):
 
 - `app/api/repo/setup/route.ts` provisions the **solo** workspace on disk
   (`provisionWorkspaceWithRepo(user.id, …)` clones into `/workspaces/<user.id>`);
   relocating the write to an arbitrary team workspace id requires team on-disk
-  provisioning — the #4560 work. The route comment is explicit: *"Team-invite
+  provisioning — the #5462 work. The route comment is explicit: *"Team-invite
   repo-setup flows (Phase 5) will resolve the target workspace_id first."*
 - The owner-gate's own invariant — *"`p_workspace_id` MUST equal the id the
   handler mutates"* — couples the gate change to the write relocation; one cannot
   land without the other.
 - `repo_error` deliberately stays on `users` (read keyed on the dispatching
   user); `current-repo-url.ts` assigns the team-workspace `repo_error`
-  relocation to #4560, and `workspaces.repo_error` is never written.
+  relocation to #5462, and `workspaces.repo_error` is never written.
 - The genuinely-additive pre-drop steps were **already shipped**: mig 079 added
   the `workspaces` repo columns AND the full credential protection
   (`REVOKE SELECT ON workspaces FROM authenticated` + re-GRANT excluding
@@ -130,7 +141,7 @@ team-workspace provisioning** effort. Evidence (verified in code, ruled on by th
 - **PR-2b (deferred, the destructive drop):** drops `users.repo_url` /
   `workspace_path` / `github_installation_id` (+ the mig-052 partial-UNIQUE
   index), with the pre-decommission drift gate above. **Blocked on BOTH** (a)
-  **#4560** delivering the team write-cutover so the `users.*` writes can stop,
+  **#5462** delivering the team write-cutover so the `users.*` writes can stop,
   AND (b) the PR-1 `repo-resolver-divergence` breadcrumb showing zero divergence
   over a real prod soak window. At PR-2a authoring time the breadcrumb had **0
   events** because PR-1 had merged ~28 min earlier — *no soak yet*, not
@@ -139,6 +150,45 @@ team-workspace provisioning** effort. Evidence (verified in code, ruled on by th
 
 ### Considered Options (amendment)
 
-- **Option A3 (chosen): ship the thin refusal guard now (PR-2a), defer the drop to PR-2b/#4560.** Converts a live silent confused-deputy (team-active connect/disconnect targeting the personal solo workspace) into an honest 422, decoupled from #4560, forward-compatible (#4560 replaces the refusal with real team provisioning). Small, testable, no one-way-door.
-- **Option B3 (rejected): fold #4560 into this PR and do the full write-cutover + drop now.** Large (team on-disk provisioning + gate/write co-relocation + `repo_error` re-key + co-membered backfill reconcile), couples the irreversible column drop to a large untested change, and discards the operator-confirmed soak deferral.
+- **Option A3 (chosen): ship the thin refusal guard now (PR-2a), defer the drop to PR-2b/#5462.** Converts a live silent confused-deputy (team-active connect/disconnect targeting the personal solo workspace) into an honest 422, decoupled from #5462, forward-compatible (#5462 replaces the refusal with real team provisioning). Small, testable, no one-way-door.
+- **Option B3 (rejected): fold #5462 into this PR and do the full write-cutover + drop now.** Large (team on-disk provisioning + gate/write co-relocation + `repo_error` re-key + co-membered backfill reconcile), couples the irreversible column drop to a large untested change, and discards the operator-confirmed soak deferral.
 - **Option C3 (rejected): ship zero code, only re-sequence the issues.** Correct bookkeeping but leaves the silent confused-deputy live; the refusal is cheap and strictly improves correctness.
+
+## Amendment 2026-06-17 — PR-2b prerequisite verification (soak baseline + drift-gate authority)
+
+A `/soleur:go` PR-2b attempt on 2026-06-17 ran the prerequisite gates **before**
+creating any migration and **halted** — neither precondition was met. Recorded
+here so the next attempt starts from verified facts, not assumptions.
+
+**Prereq (1) — team write-cutover merged + soaked: NOT MET (hard block).**
+Connect-time writes on `main` still target `users.*`: `repo/setup/route.ts:213-214`
+(`repo_url`, `github_installation_id`), `repo/setup/route.ts:257` (`workspace_path`),
+`repo/install/route.ts:120` + `repo/detect-installation/route.ts:141`
+(`github_installation_id`). The write-cutover (#5462) has not merged; dropping the
+columns now would make every connect/install write throw — a single-user incident.
+
+**Prereq (2) — PR-1 divergence zero-over-soak: baseline only, not yet a pass.**
+Pulled from the Sentry issues API on 2026-06-17 (org `jikigai-eu`, project
+`web-platform`, EU host, via the `SENTRY_ISSUE_RW_TOKEN` Doppler secret —
+the alert-rule IaC `SENTRY_AUTH_TOKEN` lacks `event:read` and 403s on `/issues/`):
+
+- `query=feature:repo-resolver-divergence` over the max `14d` window (spans the
+  entire post-PR-1 period; PR-1/#5435 merged **2026-06-16 23:06 UTC**) →
+  **0 matching issues**. Token read-capability confirmed by a control query
+  returning real project issues. So the breadcrumb has fired **zero times** since
+  the read-path cutover.
+- **Caveat (do not mistake this for a pass):** 0 events over ~1 day with an
+  **internal-only** user population is consistent with *both* "read path is clean"
+  *and* "no team/member dispatch traffic exercised the path at all." Absence of the
+  breadcrumb is weak evidence. The breadcrumb only fires on
+  `non-member-claim-reset` / `self-heal-failed`, which require an actual joined
+  member dispatching.
+
+**Authoritative gate for an internal-only population.** Because the breadcrumb
+soak is a *proxy*, with only internal users the calendar-soak requirement is
+substitutable by **direct enumeration**: run the pre-decommission drift-gate query
+(see Consequences §"Pre-decommission drift gate") against prod and require
+`COUNT = 0`, plus synthetically exercise the member/team dispatch path. Treat the
+drift-gate COUNT as authoritative and the breadcrumb as informational. This retires
+the *calendar*-soak requirement for internal-only — it does **not** unblock PR-2b,
+which still waits on the #5462 write-cutover (prereq 1) regardless of soak.

--- a/knowledge-base/project/specs/feat-adr-044-pr2-write-relocation/spec.md
+++ b/knowledge-base/project/specs/feat-adr-044-pr2-write-relocation/spec.md
@@ -2,7 +2,7 @@
 feature: ADR-044 PR-2a — workspace-owned repo connection (confused-deputy refusal guard)
 refs: 5437
 closed_by: 5437 is closed by PR-2b (the column drop), not PR-2a
-depends_on: 4560
+depends_on: 5462
 adr: ADR-044
 lane: cross-domain
 status: in-progress
@@ -50,7 +50,8 @@ come from `workspaces.repo_status`).
 `current-repo-url.ts:82-104` documents the error-reason staying on
 `users.repo_error` (read keyed on the dispatching user) as an accepted
 forward-looking limitation, with the team-workspace relocation explicitly
-assigned to **#4560**. So the "migration 110 + credential RPC" items from the
+assigned to **#5462** (the team write-cutover; #4560 is journey-state polish, not
+this). So the "migration 110 + credential RPC" items from the
 original PR-2 sketch are already done / out-of-scope; dropping them shrinks the
 blast radius (no schema change) with the core fix intact.
 


### PR DESCRIPTION
## What

Two non-destructive follow-ups from a halted `/soleur:go` PR-2b (drop legacy `users.*` repo columns) attempt — PR-2b itself **did not proceed** because its prerequisites are unmet.

### 1. Corrected mis-citation + filed the missing tracking issue (#5462)
ADR-044 said PR-2b is "blocked on #4560 delivering the team write-cutover." **#4560 is journey-state UI polish** (J1/J2/J3/J7), not the write-cutover. The actual write-cutover (connect-time `users.*` → `workspaces.*` relocation + team on-disk provisioning + `repo_error` re-key + co-membered backfill reconcile) was **untracked** → filed as **#5462**.

Corrected #4560 → #5462 in:
- ADR-044 amendment (with a dated correction note preserving the history) + Considered Options
- `feat-adr-044-pr2-write-relocation/spec.md` `depends_on` + body
- forward-looking code comments: `repo/setup`, `repo/disconnect`, `current-repo-url`, `workspace-repo-mirror`, `agent-runner`, and two route tests

Genuine journey-state `#4560` refs (the #4558 plan's J1/J2/J3/J7) left intact. Migration 108's comment left as-is — editing an applied migration trips the `_schema_migrations` content_sha drift probe.

### 2. Recorded the PR-2b prerequisite-verification baseline (new ADR amendment)
- **Prereq (1) team write-cutover — HARD FAIL.** Connect-time writes still target `users.*` (`repo/setup/route.ts:213-214,257`; `install:120`; `detect-installation:141`); #5462 unmerged. Dropping the columns now would break every repo connect.
- **Prereq (2) divergence soak — baseline, not a pass.** Pulled `feature:repo-resolver-divergence` from the Sentry issues API (org `jikigai-eu`, project `web-platform`, via `SENTRY_ISSUE_RW_TOKEN`) → **0 events over 14d** (spans the full post-PR-1 window; #5435 merged 2026-06-16 23:06 UTC). With **internal-only users** that is weak evidence; the ADR now records the **drift-gate COUNT as authoritative** and retires the *calendar*-soak requirement for an internal-only population — but that does **not** unblock PR-2b, which still waits on #5462.

## Verification
- `tsc --noEmit` clean
- `disconnect-route.test.ts` + `setup-route-install-resolution.test.ts` → 22 passed
- Source edits are comment-only (no behavior change)

Refs #5437, #5462. Closes nothing (correction + tracking only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)