### PR TITLE
feat(adr-044): team write-cutover — relocate connect-time repo writes users.* → workspaces.* (PR-2)

### DIFF
--- a/apps/web-platform/app/(auth)/callback/route.ts
+++ b/apps/web-platform/app/(auth)/callback/route.ts
@@ -7,6 +7,7 @@ import {
   isKnownProviderErrorCode,
 } from "@/lib/auth/provider-error-classifier";
 import { provisionWorkspace } from "@/server/workspace";
+import { resolveCurrentWorkspaceId } from "@/server/workspace-resolver";
 import { safeReturnTo } from "@/lib/safe-return-to";
 import { TC_VERSION } from "@/lib/legal/tc-version";
 import { NextResponse, type NextRequest } from "next/server";
@@ -251,13 +252,33 @@ export async function GET(request: NextRequest) {
           onErrorReturn: true,
         });
         const serviceClient = createServiceClient();
-        const { data: repoUser } = await serviceClient
-          .from("users")
-          .select("repo_status, setup_key_skipped_at")
-          .eq("id", user.id)
-          .single();
+        // ADR-044 PR-2 (#5462): `repo_status` is AUTHORITATIVE on the active
+        // `workspaces` row (it goes stale on `users` for post-cutover
+        // connects/disconnects). `setup_key_skipped_at` is NOT relocated — it
+        // stays on `users`. Read each from its source. Resolve the active
+        // workspace (claim → solo fallback, never a sibling).
+        const activeWorkspaceId = await resolveCurrentWorkspaceId(
+          user.id,
+          serviceClient,
+        );
+        const [skipRes, repoStatusRes] = await Promise.all([
+          serviceClient
+            .from("users")
+            .select("setup_key_skipped_at")
+            .eq("id", user.id)
+            .single(),
+          serviceClient
+            .from("workspaces")
+            .select("repo_status")
+            .eq("id", activeWorkspaceId)
+            .maybeSingle(),
+        ]);
         const setupKeySkippedAt =
-          (repoUser?.setup_key_skipped_at as string | null | undefined) ?? null;
+          (skipRes.data?.setup_key_skipped_at as string | null | undefined) ??
+          null;
+        const repoStatus =
+          (repoStatusRes.data?.repo_status as string | null | undefined) ??
+          null;
 
         if (shouldRouteToSetupKey({ hasEffectiveKey, setupKeySkippedAt })) {
           // Invite outranks onboarding (#4715): a keyless invitee can't
@@ -280,7 +301,7 @@ export async function GET(request: NextRequest) {
           redirectPath = nextParam ?? "/dashboard";
         } else {
           redirectPath =
-            !repoUser || repoUser.repo_status === "not_connected"
+            repoStatus == null || repoStatus === "not_connected"
               ? "/connect-repo"
               : (nextParam ?? "/dashboard");
         }

--- a/apps/web-platform/app/api/dashboard/today/[id]/undo/route.ts
+++ b/apps/web-platform/app/api/dashboard/today/[id]/undo/route.ts
@@ -38,6 +38,7 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service";
 import { createGitHubAppClient } from "@/server/github/app-client";
+import { resolveInstallationId } from "@/server/resolve-installation-id";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 import { reportSilentFallback } from "@/server/observability";
 
@@ -157,23 +158,13 @@ export async function POST(
     );
   }
 
-  // Resolve installation id for the GitHub App client.
-  const { data: installRow, error: installErr } = await service
-    .from("users")
-    .select("github_installation_id")
-    .eq("id", user.id)
-    .maybeSingle();
-  if (installErr) {
-    reportSilentFallback(installErr, {
-      feature: "dashboard-undo",
-      op: "users-install-read",
-      extra: { userId: user.id },
-    });
-    return NextResponse.json({ error: "internal_error" }, { status: 500 });
-  }
-  const installationId = (installRow as
-    | { github_installation_id?: number | null }
-    | null)?.github_installation_id;
+  // Resolve installation id for the GitHub App client. ADR-044 PR-2: read via the
+  // membership-checked RPC keyed on the caller's active workspace (was a direct
+  // `users.github_installation_id` read, which goes NULL for a newly-connected
+  // user after the write relocated to `workspaces`). null = no install OR a
+  // transient read error (Sentry-mirrored inside the resolver) → 403, preserving
+  // the prior unauthorized contract.
+  const installationId = await resolveInstallationId(user.id);
   if (!installationId) {
     return NextResponse.json(
       { error: "github_installation_unauthorized" },

--- a/apps/web-platform/app/api/kb/tree/route.ts
+++ b/apps/web-platform/app/api/kb/tree/route.ts
@@ -6,6 +6,7 @@ import { buildTree } from "@/server/kb-reader";
 import { withUserRateLimit } from "@/server/with-user-rate-limit";
 import { resolveNeedsReconnect } from "@/lib/repo-status";
 import { resolveActiveWorkspaceKbRoot } from "@/server/workspace-resolver";
+import { resolveInstallationId } from "@/server/resolve-installation-id";
 
 async function getHandler(_req: Request, user: User) {
   const serviceClient = createServiceClient();
@@ -32,18 +33,26 @@ async function getHandler(_req: Request, user: User) {
   let needsReconnect = false;
   if (access.activeWorkspaceId === user.id) {
     // Intentionally caller-id-scoped: solo own-row sync metadata only (AC2).
+    // `kb_sync_history` stays on `users` (not relocated by ADR-044). The install
+    // id moved to `workspaces` (PR-2), so it is read via the membership-checked
+    // RPC keyed on the active workspace — a direct `users.github_installation_id`
+    // read would go NULL for a newly-connected user.
     const { data: ownRow } = await serviceClient
       .from("users")
-      .select("kb_sync_history, github_installation_id")
+      .select("kb_sync_history")
       .eq("id", user.id)
       .single();
     const historyArr = Array.isArray(ownRow?.kb_sync_history)
       ? (ownRow.kb_sync_history as unknown[])
       : [];
     lastSync = historyArr.length > 0 ? historyArr[historyArr.length - 1] : null;
+    const installationId = await resolveInstallationId(
+      user.id,
+      access.activeWorkspaceId,
+    );
     needsReconnect = await resolveNeedsReconnect(
       access.repoStatus,
-      ownRow?.github_installation_id ?? null,
+      installationId,
       user.id,
     );
   }

--- a/apps/web-platform/app/api/repo/create/route.ts
+++ b/apps/web-platform/app/api/repo/create/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
-import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { createClient } from "@/lib/supabase/server";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 import { createRepo, GitHubApiError } from "@/server/github-app";
+import { resolveInstallationId } from "@/server/resolve-installation-id";
 import { reportSilentFallback } from "@/server/observability";
 import logger from "@/server/logger";
 
@@ -45,14 +46,14 @@ export async function POST(request: Request) {
 
   const isPrivate = body.private !== false; // Default to private
 
-  const serviceClient = createServiceClient();
-  const { data: userData, error: fetchError } = await serviceClient
-    .from("users")
-    .select("github_installation_id")
-    .eq("id", user.id)
-    .single();
+  // ADR-044 PR-2: resolve the install for the caller's ACTIVE workspace via the
+  // membership-checked RPC (was a direct `users.github_installation_id` read,
+  // which goes NULL for a newly-connected user once the write relocated to
+  // `workspaces`). Returns null for "no install" OR a transient read error
+  // (Sentry-mirrored inside the resolver) — both map to the existing 400.
+  const installationId = await resolveInstallationId(user.id);
 
-  if (fetchError || !userData?.github_installation_id) {
+  if (!installationId) {
     return NextResponse.json(
       { error: "GitHub App not installed. Please install the app first." },
       { status: 400 },
@@ -61,7 +62,7 @@ export async function POST(request: Request) {
 
   try {
     const result = await createRepo(
-      userData.github_installation_id,
+      installationId,
       name,
       isPrivate,
     );

--- a/apps/web-platform/app/api/repo/detect-installation/route.ts
+++ b/apps/web-platform/app/api/repo/detect-installation/route.ts
@@ -135,49 +135,31 @@ export async function POST(request: Request) {
       });
     }
 
-    // Store the installation ID (login-match path only).
-    const { error: updateError } = await serviceClient
-      .from("users")
-      .update({ github_installation_id: personalInstallationId })
-      .eq("id", user.id);
-
-    if (updateError) {
-      const isUniqueViolation =
-        typeof updateError === "object" &&
-        updateError !== null &&
-        "code" in updateError &&
-        (updateError as { code: string }).code === "23505";
-
-      if (isUniqueViolation) {
-        logger.info(
-          { userId: user.id, installationId: personalInstallationId, githubLogin },
-          "Installation already owned by workspace sibling — sharing via workspace membership",
-        );
-      } else {
-        logger.error(
-          { err: updateError, userId: user.id },
-          "Failed to store detected installation ID",
-        );
-        return NextResponse.json(
-          { error: "Failed to store installation" },
-          { status: 500 },
-        );
-      }
-    }
+    // ADR-044 PR-2: this auto-detect persists the caller's OWN login-matched
+    // personal install to their OWN SOLO workspace (`workspaces.id = user.id`) —
+    // the authoritative target (was `users.github_installation_id` + a solo
+    // mirror). A team workspace's install is bound separately via the owner-gated
+    // install/setup routes, never auto-detected, so this stays solo-keyed and
+    // needs no membership resolution.
+    //
+    // The former 23505 unique-violation tolerance branch is DELETED: it guarded
+    // the partial-UNIQUE on `users.github_installation_id` (mig 052). `workspaces`
+    // is intentionally NON-unique (ADR-044 fan-out, mig 079), so the violation can
+    // never fire on a `workspaces` write — the cross-tenant attribution invariant
+    // it served is now enforced by the webhook push-reconcile fan-out over
+    // (installation_id, normalizeRepoUrl(repo_url)). Best-effort: a failed write is
+    // Sentry-mirrored by the helper; the route still returns the repo list.
+    const { writeRepoColsToWorkspace } = await import(
+      "@/server/workspace-repo-mirror"
+    );
+    await writeRepoColsToWorkspace(serviceClient, user.id, {
+      github_installation_id: personalInstallationId,
+    });
 
     logger.info(
       { userId: user.id, installationId: personalInstallationId, githubLogin },
       "Auto-detected and registered GitHub App installation",
     );
-
-    // ADR-044: mirror the installation grant to the solo workspace so the
-    // workspaces-only credential read sees it.
-    const { mirrorRepoColsToSoloWorkspace } = await import(
-      "@/server/workspace-repo-mirror"
-    );
-    await mirrorRepoColsToSoloWorkspace(serviceClient, user.id, {
-      github_installation_id: personalInstallationId,
-    });
   }
 
   // Aggregate repos across the full reachable set (personal + org-membership

--- a/apps/web-platform/app/api/repo/disconnect/route.ts
+++ b/apps/web-platform/app/api/repo/disconnect/route.ts
@@ -4,7 +4,8 @@ import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 import { SlidingWindowCounter } from "@/server/rate-limiter";
 import { deleteWorkspace } from "@/server/workspace";
-import { resolveCurrentWorkspaceId } from "@/server/workspace-resolver";
+import { resolveActiveWorkspace } from "@/server/workspace-resolver";
+import { abortAllWorkspaceMemberSessions } from "@/server/agent-session-registry";
 import logger from "@/server/logger";
 
 const disconnectLimiter = new SlidingWindowCounter({
@@ -39,35 +40,36 @@ export async function DELETE(request: Request) {
     );
   }
 
-  // ADR-044 PR-2a (confused-deputy honesty): disconnect still tears down the
-  // SOLO workspace (`deleteWorkspace(user.id)` + solo-keyed clears below — team
-  // on-disk teardown is #5462/Phase-5). If a TEAM workspace is active, the legacy
-  // path would SILENTLY disconnect the caller's PERSONAL repo instead of the
-  // team's. Refuse explicitly until #5462. Resolved server-side from session
-  // state (never request input) → IDOR-safe; a strict no-op for solo
-  // (activeWorkspaceId === user.id).
-  const activeWorkspaceId = await resolveCurrentWorkspaceId(user.id, supabase);
-  if (activeWorkspaceId !== user.id) {
+  // ADR-044 PR-2 team write-cutover (#5462): resolve the target workspace id
+  // server-side via the MEMBERSHIP-VERIFIED resolver (IDOR-safe — session claim,
+  // never request input). At this destructive boundary a db-error must FAIL-CLOSED
+  // (503), never silently disconnect the caller's solo workspace under a team
+  // claim. A removed/non-member of a stale team claim is reset to their OWN solo
+  // id (`resetFromClaim`) — so a removed member disconnecting tears down their OWN
+  // repo, never the team's.
+  const activeResolution = await resolveActiveWorkspace(user.id, supabase);
+  if (!activeResolution.ok) {
     return NextResponse.json(
-      {
-        error:
-          "Disconnecting a repository from a team workspace isn't supported yet. Switch to your personal workspace to disconnect.",
-      },
-      { status: 422 },
+      { error: "Could not resolve your active workspace. Please retry." },
+      { status: 503 },
+    );
+  }
+  const activeWorkspaceId = activeResolution.workspaceId;
+  if (activeResolution.resetFromClaim) {
+    logger.info(
+      { userId: user.id, staleClaim: activeResolution.resetFromClaim },
+      "repo disconnect: stale team claim reset to caller's solo workspace",
     );
   }
 
-  // ADR-044 PR-1 owner-gate (confused-deputy): only the OWNER of the workspace
-  // this handler mutates may disconnect it. `p_workspace_id` MUST equal the id
-  // the handler actually mutates — in PR-1 the disconnect clears the solo
-  // `users` row + the solo workspace mirror keyed on `user.id`, so
-  // `p_workspace_id = user.id` and the gate is a NO-OP for solo users by
-  // construction (a solo user always owns workspace_id=user.id). It becomes
-  // load-bearing in PR-2 when connect-writes relocate to `workspaces.*` keyed on
-  // the active (possibly team) id. `is_workspace_owner` is SECURITY DEFINER
-  // (mig 098), GRANT authenticated — reuse the workspace/logo/route.ts shape.
+  // ADR-044 owner-gate (confused-deputy): only the OWNER of the workspace this
+  // handler mutates may disconnect it. `p_workspace_id` MUST equal the id the
+  // handler actually mutates — now the RESOLVED active id (team or solo). A
+  // non-owner member disconnecting a team workspace gets 403; a solo user owns
+  // workspace_id=user.id so it stays a no-op for solo. `is_workspace_owner` is
+  // SECURITY DEFINER (mig 098), GRANT authenticated.
   const ownerRes = await supabase.rpc("is_workspace_owner", {
-    p_workspace_id: user.id,
+    p_workspace_id: activeWorkspaceId,
     p_user_id: user.id,
   });
   if (ownerRes.error) {
@@ -91,16 +93,20 @@ export async function DELETE(request: Request) {
 
   // Reject disconnect while clone is in progress — the background
   // provisionWorkspaceWithRepo would overwrite cleared fields on completion.
-  const { data: currentUser, error: fetchError } = await serviceClient
-    .from("users")
+  // ADR-044 PR-2: read `repo_status` from the ACTIVE WORKSPACE (was the caller's
+  // `users` row). For a team disconnect, the disconnecter's personal row is not
+  // cloning even when the SHARED team clone is in flight — reading `users` would
+  // let the teardown delete a workspace whose clone is mid-write.
+  const { data: currentWorkspace, error: fetchError } = await serviceClient
+    .from("workspaces")
     .select("repo_status")
-    .eq("id", user.id)
+    .eq("id", activeWorkspaceId)
     .single();
 
   if (fetchError) {
     logger.error(
-      { err: fetchError, userId: user.id },
-      "Failed to fetch user record for disconnect",
+      { err: fetchError, userId: user.id, workspaceId: activeWorkspaceId },
+      "Failed to fetch workspace record for disconnect",
     );
     return NextResponse.json(
       { error: "Failed to disconnect repository" },
@@ -108,64 +114,40 @@ export async function DELETE(request: Request) {
     );
   }
 
-  if (currentUser?.repo_status === "cloning") {
+  if (currentWorkspace?.repo_status === "cloning") {
     return NextResponse.json(
       { error: "Cannot disconnect while repository setup is in progress. Please wait for cloning to complete." },
       { status: 409 },
     );
   }
 
-  // Clear all repo-related fields (DB update before disk cleanup)
-  const { error: updateError } = await serviceClient
-    .from("users")
-    .update({
-      github_installation_id: null,
-      repo_url: null,
-      repo_status: "not_connected",
-      repo_last_synced_at: null,
-      repo_error: null,
-      health_snapshot: null,
-      workspace_path: "",
-      workspace_status: "provisioning",
-    })
-    .eq("id", user.id);
-
-  if (updateError) {
-    logger.error(
-      { err: updateError, userId: user.id },
-      "Failed to clear repo fields during disconnect",
-    );
-    return NextResponse.json(
-      { error: "Failed to disconnect repository" },
-      { status: 500 },
-    );
-  }
-
-  // ADR-044: mirror the moved repo cols to the solo workspace so the
-  // workspaces-only read path reflects the disconnect. Fail CLOSED here
-  // (unlike connect): the read path is workspaces-only, so a silently-failed
-  // mirror would leave the credential (github_installation_id) + repo_url
-  // live — the user appears connected and the agent could still act under the
-  // revoked GitHub grant. Surface a 500 so the (idempotent) disconnect retries.
-  const { mirrorRepoColsToSoloWorkspace } = await import(
+  // ADR-044 PR-2: clear the repo-connection columns AUTHORITATIVELY on the active
+  // `workspaces` row (was the `users` row). Fail CLOSED: the read path is
+  // workspaces-only, so a silently-failed clear (db error OR 0-row no-op) would
+  // leave the credential (github_installation_id) + repo_url live — the user
+  // appears connected and the agent could still act under the revoked GitHub
+  // grant. The helper throws on either failure so we surface a 500 and the
+  // (idempotent) disconnect is retried.
+  const { writeRepoColsToWorkspace } = await import(
     "@/server/workspace-repo-mirror"
   );
   try {
-    await mirrorRepoColsToSoloWorkspace(
+    await writeRepoColsToWorkspace(
       serviceClient,
-      user.id,
+      activeWorkspaceId,
       {
         github_installation_id: null,
         repo_url: null,
         repo_status: "not_connected",
         repo_last_synced_at: null,
+        repo_error: null,
       },
       { throwOnError: true },
     );
-  } catch (mirrorErr) {
+  } catch (clearErr) {
     logger.error(
-      { err: mirrorErr, userId: user.id },
-      "Failed to mirror repo disconnect to workspaces (credential may persist on the read path)",
+      { err: clearErr, userId: user.id, workspaceId: activeWorkspaceId },
+      "Failed to clear repo fields on the active workspace (credential may persist on the read path)",
     );
     return NextResponse.json(
       { error: "Failed to disconnect repository" },
@@ -173,15 +155,48 @@ export async function DELETE(request: Request) {
     );
   }
 
-  // Best-effort workspace cleanup — deleteWorkspace derives path from
-  // getWorkspacesRoot() + the workspace identifier, handles non-existent
-  // directories. For a solo user, `user.id` is the workspace_id (N2
-  // invariant — migration 053 §1.1.7).
+  // The provisioning/readiness columns (`workspace_status`, `health_snapshot`)
+  // are NOT relocated by ADR-044 — reset them on the caller's `users` row only for
+  // a SOLO disconnect. For a team disconnect, resetting the (owner) caller's
+  // `users.workspace_status` would corrupt their PERSONAL solo readiness AND any
+  // other team they own (the readiness gate reads the org owner's row).
+  // `workspace_path` is intentionally NOT cleared — access is gated by
+  // `workspace_status`, not an empty path, and writing it trips the
+  // zero-`users.*`-write exit criterion.
+  if (activeWorkspaceId === user.id) {
+    const { error: readinessError } = await serviceClient
+      .from("users")
+      .update({ health_snapshot: null, workspace_status: "provisioning" })
+      .eq("id", user.id);
+    if (readinessError) {
+      logger.error(
+        { err: readinessError, userId: user.id },
+        "Failed to reset solo readiness during disconnect (non-fatal — repo already cleared)",
+      );
+    }
+  }
+
+  // P0-6: a team workspace dir is SHARED across members. Abort any live member
+  // agent sessions BEFORE the `rm` so no agent is mid-write when the shared clone
+  // disappears (otherwise it gets ENOENT mid-operation). Owner-only disconnect, so
+  // tearing down the shared clone for everyone is intended. No-op for solo.
   try {
-    await deleteWorkspace(user.id);
+    abortAllWorkspaceMemberSessions(activeWorkspaceId, user.id);
+  } catch (abortErr) {
+    logger.warn(
+      { err: abortErr, userId: user.id, workspaceId: activeWorkspaceId },
+      "Failed to abort live member sessions before workspace teardown (best-effort)",
+    );
+  }
+
+  // Best-effort workspace cleanup — deleteWorkspace derives the path from
+  // getWorkspacesRoot() + the workspace identifier and handles non-existent
+  // directories. Tears down `/workspaces/<activeWorkspaceId>` (team or solo).
+  try {
+    await deleteWorkspace(activeWorkspaceId);
   } catch (err) {
     logger.warn(
-      { err, userId: user.id },
+      { err, userId: user.id, workspaceId: activeWorkspaceId },
       "Workspace cleanup failed during disconnect (best-effort)",
     );
     Sentry.captureException(err);

--- a/apps/web-platform/app/api/repo/disconnect/route.ts
+++ b/apps/web-platform/app/api/repo/disconnect/route.ts
@@ -5,7 +5,7 @@ import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 import { SlidingWindowCounter } from "@/server/rate-limiter";
 import { deleteWorkspace } from "@/server/workspace";
 import { resolveActiveWorkspace } from "@/server/workspace-resolver";
-import { abortAllWorkspaceMemberSessions } from "@/server/agent-session-registry";
+import { abortAllSessionsForWorkspace } from "@/server/agent-session-registry";
 import logger from "@/server/logger";
 
 const disconnectLimiter = new SlidingWindowCounter({
@@ -176,12 +176,13 @@ export async function DELETE(request: Request) {
     }
   }
 
-  // P0-6: a team workspace dir is SHARED across members. Abort any live member
-  // agent sessions BEFORE the `rm` so no agent is mid-write when the shared clone
-  // disappears (otherwise it gets ENOENT mid-operation). Owner-only disconnect, so
-  // tearing down the shared clone for everyone is intended. No-op for solo.
+  // P0-6: a team workspace dir is SHARED across members. Abort EVERY live session
+  // bound to this workspace (all members, not just the disconnecter) BEFORE the
+  // `rm` so no agent is mid-write when the shared clone disappears (otherwise it
+  // gets ENOENT mid-operation). Owner-only disconnect, so tearing down the shared
+  // clone for everyone is intended. No-op when no session is bound (e.g. solo).
   try {
-    abortAllWorkspaceMemberSessions(activeWorkspaceId, user.id);
+    abortAllSessionsForWorkspace(activeWorkspaceId);
   } catch (abortErr) {
     logger.warn(
       { err: abortErr, userId: user.id, workspaceId: activeWorkspaceId },

--- a/apps/web-platform/app/api/repo/install/route.ts
+++ b/apps/web-platform/app/api/repo/install/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 import { verifyInstallationOwnership, getInstallationAccount } from "@/server/github-app";
+import { resolveActiveWorkspace } from "@/server/workspace-resolver";
+import { writeRepoColsToWorkspace } from "@/server/workspace-repo-mirror";
 import logger from "@/server/logger";
 
 /**
@@ -115,30 +117,64 @@ export async function POST(request: Request) {
     );
   }
 
-  const { error: updateError } = await serviceClient
-    .from("users")
-    .update({ github_installation_id: body.installationId })
-    .eq("id", user.id);
+  // ADR-044 PR-2: the installation grant lands AUTHORITATIVELY on the active
+  // `workspaces` row (was the `users` row). Resolve the target id server-side via
+  // the membership-verified resolver (IDOR-safe; fail-closed 503 on db-error,
+  // never write a credential into the caller's solo workspace under a team claim).
+  const activeResolution = await resolveActiveWorkspace(user.id, supabase);
+  if (!activeResolution.ok) {
+    return NextResponse.json(
+      { error: "Could not resolve your active workspace. Please retry." },
+      { status: 503 },
+    );
+  }
+  const activeWorkspaceId = activeResolution.workspaceId;
 
-  if (updateError) {
+  // Owner-gate (confused-deputy parity with setup/disconnect): a credential write
+  // to a team workspace must be owner-only — a non-owner member must not overwrite
+  // the team's installation grant with their own. No-op for solo (a solo user owns
+  // workspace_id=user.id).
+  const ownerRes = await supabase.rpc("is_workspace_owner", {
+    p_workspace_id: activeWorkspaceId,
+    p_user_id: user.id,
+  });
+  if (ownerRes.error) {
     logger.error(
-      { err: updateError, userId: user.id },
-      "Failed to store installation ID",
+      { err: ownerRes.error, userId: user.id, workspaceId: activeWorkspaceId },
+      "is_workspace_owner check failed during install",
     );
     return NextResponse.json(
       { error: "Failed to store installation ID" },
       { status: 500 },
     );
   }
+  if (ownerRes.data !== true) {
+    return NextResponse.json(
+      { error: "Only the workspace owner can connect the GitHub App to this workspace." },
+      { status: 403 },
+    );
+  }
 
-  // ADR-044: mirror the installation grant to the solo workspace so the
-  // workspaces-only credential read (resolve_workspace_installation_id) sees it.
-  const { mirrorRepoColsToSoloWorkspace } = await import(
-    "@/server/workspace-repo-mirror"
-  );
-  await mirrorRepoColsToSoloWorkspace(serviceClient, user.id, {
-    github_installation_id: body.installationId,
-  });
+  // Fail-closed: a silently-failed credential write (db error OR 0-row no-op) would
+  // leave the workspaces-only credential read (resolve_workspace_installation_id)
+  // unable to see the install — surface a 500 so the (idempotent) install retries.
+  try {
+    await writeRepoColsToWorkspace(
+      serviceClient,
+      activeWorkspaceId,
+      { github_installation_id: body.installationId },
+      { throwOnError: true },
+    );
+  } catch (writeErr) {
+    logger.error(
+      { err: writeErr, userId: user.id, workspaceId: activeWorkspaceId },
+      "Failed to store installation ID on the active workspace",
+    );
+    return NextResponse.json(
+      { error: "Failed to store installation ID" },
+      { status: 500 },
+    );
+  }
 
   return NextResponse.json({ ok: true });
 }

--- a/apps/web-platform/app/api/repo/setup/route.ts
+++ b/apps/web-platform/app/api/repo/setup/route.ts
@@ -5,8 +5,8 @@ import { validateOrigin, rejectCsrf } from "@/lib/auth/validate-origin";
 import { provisionWorkspaceWithRepo } from "@/server/workspace";
 import { scanProjectHealth } from "@/server/project-scanner";
 import { normalizeRepoUrl } from "@/lib/repo-url";
-import { mirrorRepoColsToSoloWorkspace } from "@/server/workspace-repo-mirror";
-import { resolveCurrentWorkspaceId } from "@/server/workspace-resolver";
+import { writeRepoColsToWorkspace } from "@/server/workspace-repo-mirror";
+import { resolveActiveWorkspace } from "@/server/workspace-resolver";
 import {
   resolveReachableInstallationIds,
   resolveOwningInstallationForRepo,
@@ -39,35 +39,39 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  // ADR-044 PR-2a (confused-deputy honesty): repo setup still provisions the
-  // SOLO workspace on disk (`provisionWorkspaceWithRepo(user.id, …)` below — team
-  // on-disk provisioning is #5462/Phase-5). If a TEAM workspace is active, the
-  // legacy path would SILENTLY clone into the caller's PERSONAL solo workspace
-  // (the user believes they connected the team's repo but connected their own).
-  // Refuse explicitly until #5462 lands real team provisioning. Resolved
-  // server-side from session state (never request input) → IDOR-safe; a strict
-  // no-op for solo (activeWorkspaceId === user.id).
-  const activeWorkspaceId = await resolveCurrentWorkspaceId(user.id, supabase);
-  if (activeWorkspaceId !== user.id) {
+  // ADR-044 PR-2 team write-cutover (#5462): resolve the target workspace id
+  // server-side via the MEMBERSHIP-VERIFIED resolver. `resolveActiveWorkspace`
+  // returns the active workspace id ONLY for a membership-verified team or the
+  // caller's own solo id (IDOR-safe — derived from session claim, never request
+  // input). At a WRITE/provisioning boundary a db-error must FAIL-CLOSED (503),
+  // never silently fall back to the caller's solo workspace and provision there
+  // under a team claim (the `resolveCurrentWorkspaceId` fail-to-solo posture is
+  // unsafe here). A removed/non-member of a stale team claim is reset to their
+  // OWN solo id (`resetFromClaim`) and the whole request proceeds against it.
+  const activeResolution = await resolveActiveWorkspace(user.id, supabase);
+  if (!activeResolution.ok) {
     return NextResponse.json(
-      {
-        error:
-          "Connecting a repository to a team workspace isn't supported yet. Switch to your personal workspace to connect a repository.",
-      },
-      { status: 422 },
+      { error: "Could not resolve your active workspace. Please retry." },
+      { status: 503 },
+    );
+  }
+  const activeWorkspaceId = activeResolution.workspaceId;
+  if (activeResolution.resetFromClaim) {
+    logger.info(
+      { userId: user.id, staleClaim: activeResolution.resetFromClaim },
+      "repo setup: stale team claim reset to caller's solo workspace",
     );
   }
 
-  // ADR-044 PR-1 owner-gate (confused-deputy): only the OWNER of the workspace
-  // this handler mutates may connect a repo to it. `p_workspace_id` MUST equal
-  // the id the handler mutates — in PR-1 setup writes the solo `users` row + the
-  // solo workspace mirror keyed on `user.id`, so `p_workspace_id = user.id` and
-  // the gate is a NO-OP for solo users by construction (a solo user always owns
-  // workspace_id=user.id). Load-bearing in PR-2 when connect-writes relocate to
-  // `workspaces.*`. `is_workspace_owner` is SECURITY DEFINER (mig 098), GRANT
-  // authenticated — reuse the workspace/logo/route.ts shape.
+  // ADR-044 owner-gate (confused-deputy): only the OWNER of the workspace this
+  // handler mutates may connect a repo to it. `p_workspace_id` MUST equal the id
+  // the handler actually mutates — now the RESOLVED active id (team or solo), so
+  // the gate is load-bearing for team workspaces (a non-owner member connecting
+  // to a team workspace gets 403) and remains a no-op for solo (a solo user owns
+  // workspace_id=user.id). `is_workspace_owner` is SECURITY DEFINER (mig 098),
+  // GRANT authenticated.
   const ownerRes = await supabase.rpc("is_workspace_owner", {
-    p_workspace_id: user.id,
+    p_workspace_id: activeWorkspaceId,
     p_user_id: user.id,
   });
   if (ownerRes.error) {
@@ -109,10 +113,12 @@ export async function POST(request: Request) {
 
   const serviceClient = createServiceClient();
 
-  // Get user's installation ID
+  // Email + GitHub login stay on `users` (not relocated by ADR-044). The stored
+  // install id is read from the active `workspaces` row in the degraded-fallback
+  // below (ADR-044 PR-2 — it moved off `users`).
   const { data: userData } = await serviceClient
     .from("users")
-    .select("github_installation_id, email, github_username")
+    .select("email, github_username")
     .eq("id", user.id)
     .single();
 
@@ -155,9 +161,18 @@ export async function POST(request: Request) {
   }
 
   // Degraded-probe fallback: owning resolution was inconclusive, but a stored
-  // install exists — use it.
-  if (installationId == null && userData?.github_installation_id) {
-    installationId = userData.github_installation_id;
+  // install exists on the active workspace — use it. ADR-044 PR-2: read it from
+  // `workspaces.<activeWorkspaceId>` (was `users.github_installation_id`). The
+  // column is REVOKE'd from `authenticated`, but `service_role` reads it directly.
+  if (installationId == null) {
+    const { data: wsRow } = await serviceClient
+      .from("workspaces")
+      .select("github_installation_id")
+      .eq("id", activeWorkspaceId)
+      .maybeSingle();
+    if (wsRow?.github_installation_id != null) {
+      installationId = wsRow.github_installation_id as number;
+    }
   }
 
   if (installationId == null) {
@@ -175,23 +190,33 @@ export async function POST(request: Request) {
   // sync would read as instantly-stale and a cold dispatch could start a second
   // concurrent clone, and a process-killed clone would leave a NULL clock that
   // the staleness escape can never recover (permanent `cloning` strand).
+  // ADR-044 PR-2: the optimistic "cloning" lock + repo write are AUTHORITATIVE on
+  // `workspaces` keyed on the resolved active id (was `users` keyed on user.id).
+  // The contended row is the SHARED workspace, so two concurrent connects on the
+  // same team workspace serialize correctly (on per-caller `users` rows they would
+  // both win the lock). `workspaces.repo_status` has the same CHECK enum (mig 079)
+  // and `service_role` keeps its default grant, so the service-client lock write
+  // is unaffected by the column-level REVOKE. The installation grant is written
+  // here too so the workspaces-only credential read (resolve_workspace_installation_id)
+  // sees the in-progress connection.
   const cloningAt = new Date().toISOString();
   const { data: lockResult, error: updateError } = await serviceClient
-    .from("users")
+    .from("workspaces")
     .update({
       repo_url: repoUrl,
+      github_installation_id: installationId,
       repo_status: "cloning",
       repo_error: null,
       repo_last_synced_at: cloningAt,
     })
-    .eq("id", user.id)
+    .eq("id", activeWorkspaceId)
     .neq("repo_status", "cloning")
     .select("id")
     .maybeSingle();
 
   if (updateError) {
     logger.error(
-      { err: updateError, userId: user.id },
+      { err: updateError, userId: user.id, workspaceId: activeWorkspaceId },
       "Failed to update repo status to cloning",
     );
     return NextResponse.json(
@@ -207,26 +232,21 @@ export async function POST(request: Request) {
     );
   }
 
-  // ADR-044: mirror the connecting repo + installation to the solo workspace
-  // so the workspaces-only read path sees the in-progress connection.
-  await mirrorRepoColsToSoloWorkspace(serviceClient, user.id, {
-    repo_url: repoUrl,
-    github_installation_id: installationId,
-    repo_status: "cloning",
-    repo_last_synced_at: cloningAt,
-  });
-
   // Kick off clone in the background (don't await)
   const userName = user.user_metadata?.full_name ?? user.email?.split("@")[0] ?? "Soleur User";
   const userEmail = userData?.email ?? user.email ?? "";
 
   const isStartFresh = body.source === "start_fresh";
 
-  // Solo provisioning: `user.id` is the workspace_id (N2 invariant —
-  // migration 053 §1.1.7). Team-invite repo-setup flows (Phase 5) will
-  // resolve the target workspace_id first.
+  // ADR-044 PR-2: provision the RESOLVED active workspace on disk
+  // (`/workspaces/<activeWorkspaceId>` — team or solo). The id is captured in the
+  // background-callback closure below and NEVER re-resolved: the session claim can
+  // drift between request return and clone completion, so re-resolving could write
+  // `repo_status:ready` to a different workspace than the one provisioned
+  // (identity-pinned write). For a solo connect this equals `user.id` (N2).
+  const isSoloWorkspace = activeWorkspaceId === user.id;
   provisionWorkspaceWithRepo(
-    user.id,
+    activeWorkspaceId,
     repoUrl,
     installationId,
     userName,
@@ -251,33 +271,43 @@ export async function POST(request: Request) {
         }
       }
 
-      const { error } = await serviceClient
-        .from("users")
-        .update({
-          workspace_path: workspacePath,
-          workspace_status: "ready",
-          repo_status: "ready",
-          repo_last_synced_at: new Date().toISOString(),
-          health_snapshot: healthSnapshot,
-        })
-        .eq("id", user.id);
-
-      if (error) {
-        logger.error(
-          { err: error, userId: user.id },
-          "Failed to update user after successful clone",
-        );
-        return;
-      }
-
-      // ADR-044: mirror the ready repo state to the solo workspace.
-      await mirrorRepoColsToSoloWorkspace(serviceClient, user.id, {
+      // ADR-044 PR-2 — AUTHORITATIVE repo-connection write to the active
+      // workspace (was the `users` row). The helper `.select("id")`s so a 0-row
+      // no-op (workspace deleted mid-clone; current_workspace_id ON DELETE SET
+      // NULL) is Sentry-mirrored instead of silently lost.
+      await writeRepoColsToWorkspace(serviceClient, activeWorkspaceId, {
         repo_status: "ready",
         repo_last_synced_at: new Date().toISOString(),
       });
 
+      // The provisioning/readiness columns (`workspace_status`, `health_snapshot`)
+      // are NOT relocated by ADR-044 — they stay on the OWNER's `users` row. Only
+      // write them for a SOLO connect: for a team workspace the caller's `users`
+      // row is their PERSONAL solo readiness, and the team's readiness is governed
+      // by the org owner's existing `users.workspace_status` (already "ready" from
+      // onboarding). `workspace_path` is intentionally NOT written — it is derived
+      // from the workspace id (`workspacePathForWorkspaceId`) and set immutably at
+      // onboarding, so re-writing it here is redundant and trips the PR-2b
+      // zero-`users.*`-write exit criterion.
+      if (isSoloWorkspace) {
+        const { error } = await serviceClient
+          .from("users")
+          .update({
+            workspace_status: "ready",
+            health_snapshot: healthSnapshot,
+          })
+          .eq("id", user.id);
+
+        if (error) {
+          logger.error(
+            { err: error, userId: user.id },
+            "Failed to update user readiness after successful clone",
+          );
+        }
+      }
+
       logger.info(
-        { userId: user.id, repoUrl, category: healthSnapshot?.category },
+        { userId: user.id, workspaceId: activeWorkspaceId, repoUrl, category: healthSnapshot?.category },
         "Repo setup completed",
       );
 
@@ -300,7 +330,10 @@ export async function POST(request: Request) {
           return startAgentSession(...args);
         },
         serviceClient,
-        resolveWorkspaceId: resolveCurrentWorkspaceId,
+        // P0-4: pin the headless sync to the CAPTURED active id, not a re-resolve.
+        // If the user switched workspaces mid-clone, a re-resolve would target the
+        // now-active workspace instead of the one we just cloned.
+        resolveWorkspaceId: async () => activeWorkspaceId,
       });
     })
     .catch(async (err) => {
@@ -326,21 +359,13 @@ export async function POST(request: Request) {
         message: sanitizeGitStderr(rawMessage).slice(0, 2000),
         timestamp: new Date().toISOString(),
       });
-      await serviceClient
-        .from("users")
-        .update({ repo_status: "error", repo_error: payload })
-        .eq("id", user.id)
-        .then(({ error }) => {
-          if (error) {
-            logger.error(
-              { err: error, userId: user.id },
-              "Failed to update repo status to error",
-            );
-          }
-        });
-      // ADR-044: mirror the error status to the solo workspace.
-      await mirrorRepoColsToSoloWorkspace(serviceClient, user.id, {
+      // ADR-044 PR-2 — write the error status + sanitized reason to the active
+      // workspace (was `users`). `repo_error` is now a `workspaces` column (mig
+      // 110, in the non-credential `authenticated` GRANT). The helper Sentry-mirrors
+      // a db error or 0-row no-op.
+      await writeRepoColsToWorkspace(serviceClient, activeWorkspaceId, {
         repo_status: "error",
+        repo_error: payload,
       });
     });
 

--- a/apps/web-platform/app/api/repo/status/route.ts
+++ b/apps/web-platform/app/api/repo/status/route.ts
@@ -3,7 +3,10 @@ import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { existsSync } from "fs";
 import { join } from "path";
 import { parseErrorPayload } from "@/server/git-auth";
-import { resolveActiveWorkspacePath } from "@/server/workspace-resolver";
+import {
+  resolveActiveWorkspacePath,
+  resolveCurrentWorkspaceId,
+} from "@/server/workspace-resolver";
 
 /**
  * GET /api/repo/status
@@ -21,27 +24,37 @@ export async function GET() {
   }
 
   const serviceClient = createServiceClient();
-  // #5005 — `workspace_path` is no longer read here; the `hasKnowledgeBase`
-  // existence check below resolves the ACTIVE workspace path via the
-  // membership-scoped resolver (the own-row column is stale/empty post-ADR-044).
-  // The `repo_url`/`repo_status`/`repo_last_synced_at` reads are the ADR-044
-  // relocated REPO columns — out of scope for #5005 (covered by ADR-044's own
-  // pre-decommission drift gate); left untouched here.
-  const { data: userData, error: fetchError } = await serviceClient
-    .from("users")
-    .select("repo_url, repo_status, repo_last_synced_at, repo_error, health_snapshot")
-    .eq("id", user.id)
-    .single();
 
-  if (fetchError || !userData) {
+  // ADR-044 PR-2 (#5462): the repo-connection columns are AUTHORITATIVE on the
+  // ACTIVE `workspaces` row (not the caller's own `users` row, which goes
+  // stale for newly-connected users once the write relocated, and is wrong for a
+  // member viewing a shared/team workspace). Resolve the active workspace
+  // (claim → solo fallback, never a sibling) and read the repo cols there.
+  // `health_snapshot` is NOT relocated by ADR-044 — it stays on `users`.
+  const activeWorkspaceId = await resolveCurrentWorkspaceId(user.id, serviceClient);
+  const [wsRes, userRes] = await Promise.all([
+    serviceClient
+      .from("workspaces")
+      .select("repo_url, repo_status, repo_last_synced_at, repo_error")
+      .eq("id", activeWorkspaceId)
+      .maybeSingle(),
+    serviceClient
+      .from("users")
+      .select("health_snapshot")
+      .eq("id", user.id)
+      .maybeSingle(),
+  ]);
+
+  if (wsRes.error) {
     return NextResponse.json(
-      { error: "User not found" },
-      { status: 404 },
+      { error: "Failed to read repository status" },
+      { status: 500 },
     );
   }
 
-  const status = userData.repo_status ?? "not_connected";
-  const repoUrl = userData.repo_url ?? null;
+  const workspaceData = wsRes.data;
+  const status = workspaceData?.repo_status ?? "not_connected";
+  const repoUrl = workspaceData?.repo_url ?? null;
 
   // Extract repo name from URL (e.g., "owner/repo" from "https://github.com/owner/repo")
   let repoName: string | null = null;
@@ -83,16 +96,16 @@ export async function GET() {
   // returns a `{errorMessage, errorCode: undefined}` shape so the UI
   // falls back to its legacy generic copy for those rows.
   const { errorMessage, errorCode } = parseErrorPayload(
-    status === "error" ? userData.repo_error : null,
+    status === "error" ? (workspaceData?.repo_error ?? null) : null,
   );
 
   return NextResponse.json({
     status,
     repoUrl,
     repoName,
-    lastSyncedAt: userData.repo_last_synced_at ?? null,
+    lastSyncedAt: workspaceData?.repo_last_synced_at ?? null,
     hasKnowledgeBase,
-    healthSnapshot: userData.health_snapshot ?? null,
+    healthSnapshot: userRes.data?.health_snapshot ?? null,
     syncConversationId,
     errorMessage,
     errorCode,

--- a/apps/web-platform/server/agent-session-registry.ts
+++ b/apps/web-platform/server/agent-session-registry.ts
@@ -355,6 +355,29 @@ export function abortAllWorkspaceMemberSessions(
   }
 }
 
+/**
+ * Abort EVERY active session bound to `workspaceId`, regardless of which member
+ * owns it. Called from `repo/disconnect` (ADR-044 PR-2 / P0-6) BEFORE tearing
+ * down a SHARED team workspace dir: the `rm` removes the clone for all members,
+ * so any member mid-agent-turn in that dir must be aborted first or it hits
+ * ENOENT mid-write.
+ *
+ * Distinct from `abortAllWorkspaceMemberSessions`, which is scoped to a SINGLE
+ * member's own sessions (the member-removal flow must not touch other members).
+ * Here the whole shared clone is disappearing, so every session bound to it must
+ * stop — keyed on the per-user workspace binding (`userWorkspaces`), matching the
+ * sibling function's binding semantics. Reuses the `workspace_membership_revoked`
+ * abort kind (the client-observable effect — an interrupted turn — is identical).
+ */
+export function abortAllSessionsForWorkspace(workspaceId: string): void {
+  for (const [key, session] of activeSessions) {
+    const sessionUserId = key.split(":")[0];
+    if (userWorkspaces.get(sessionUserId) === workspaceId) {
+      session.abort.abort(new SessionAbortError("workspace_membership_revoked"));
+    }
+  }
+}
+
 /** Abort every session in the process. Called during server shutdown. */
 export function abortAllSessions(): void {
   for (const [, session] of activeSessions) {

--- a/apps/web-platform/server/current-repo-url.ts
+++ b/apps/web-platform/server/current-repo-url.ts
@@ -81,12 +81,13 @@ export async function getCurrentRepoUrl(
 
 /**
  * The active workspace's repo readiness signal for the Concierge dispatch gate
- * (#5394). Reads `repo_status` from `workspaces` (the ADR-044 source of truth,
- * correct for shared/team workspaces) and the sanitized error REASON from
- * `users.repo_error` — `workspaces.repo_error` is NEVER written
- * (`workspace-repo-mirror.ts:6`), so the reason can only come from `users`.
- * Both reads go through the TENANT client (own-row RLS: "Users can read own
- * profile"), keeping cc-dispatcher OFF the service-role allowlist.
+ * (#5394). Reads `repo_status` AND the sanitized error REASON `repo_error` from
+ * the SAME `workspaces` row (the ADR-044 source of truth, correct for
+ * shared/team workspaces). Migration 110 added `workspaces.repo_error` to the
+ * non-credential `authenticated` column GRANT, and PR-2 (#5462) relocated the
+ * write there — so both signals key on the active workspace. The read goes
+ * through the TENANT client (RLS `workspaces_select_for_members`), keeping
+ * cc-dispatcher OFF the service-role allowlist.
  *
  * FAIL-OPEN: any transient/auth/query error coerces to
  * `{ repoStatus: "not_connected" }` so a `ready` founder is NEVER blocked by a
@@ -94,14 +95,11 @@ export async function getCurrentRepoUrl(
  * through to the existing repo-less path / #5392 fallback (the safety net this
  * gate layers on top of).
  *
- * Source-key note (forward-looking, for the #5462 team-workspace author): the
- * `repo_status` key is the active WORKSPACE while the `repo_error` key is the
- * dispatching USER. Today connect/disconnect is solo-only
- * (`workspace.id === user.id`), so the two keys coincide. Once team-invite repo
- * flows land (#5462), a member dispatching against a workspace whose `error`
- * status was caused by ANOTHER member reads their own (null) `repo_error` → the
- * gate's message degrades to the generic `"setup failed"` fallback (NOT a
- * misclassification and NOT a cross-member leak — readiness is still correct).
+ * Cross-member correctness (PR-2 fix): because `repo_error` now keys on the same
+ * active workspace as `repo_status`, a member dispatching against a workspace
+ * whose `error` was caused by ANOTHER member reads the WORKSPACE's reason (not
+ * their own null) — the prior dispatching-user-vs-active-workspace key mismatch
+ * is resolved.
  */
 export async function getCurrentRepoStatus(
   userId: string,
@@ -129,20 +127,13 @@ export async function getCurrentRepoStatus(
   const targetWorkspaceId =
     workspaceId ?? (await resolveCurrentWorkspaceId(userId, tenant));
 
-  // workspaces.repo_status (source of truth) + users.repo_error (the only row
-  // that holds the sanitized reason) in parallel — adds no sequential await.
-  const [statusRes, errorRes] = await Promise.all([
-    tenant
-      .from("workspaces")
-      .select("repo_status")
-      .eq("id", targetWorkspaceId)
-      .maybeSingle(),
-    tenant
-      .from("users")
-      .select("repo_error")
-      .eq("id", userId)
-      .maybeSingle(),
-  ]);
+  // workspaces.repo_status + workspaces.repo_error (the ADR-044 source of truth
+  // for BOTH, keyed on the active workspace) in a single row read.
+  const statusRes = await tenant
+    .from("workspaces")
+    .select("repo_status, repo_error")
+    .eq("id", targetWorkspaceId)
+    .maybeSingle();
 
   if (statusRes.error) {
     reportSilentFallback(statusRes.error, {
@@ -156,11 +147,8 @@ export async function getCurrentRepoStatus(
   const repoStatus =
     (statusRes.data?.repo_status as string | null | undefined) ??
     "not_connected";
-  // A users-read error must not block dispatch — the reason is only consumed on
-  // the `error` branch, so a null reason degrades to generic copy, never a hard
-  // fail. (No reportSilentFallback: the status read is the load-bearing signal.)
   const repoError =
-    (errorRes.data?.repo_error as string | null | undefined) ?? null;
+    (statusRes.data?.repo_error as string | null | undefined) ?? null;
 
   return { repoStatus, repoError };
 }

--- a/apps/web-platform/server/workspace-repo-mirror.ts
+++ b/apps/web-platform/server/workspace-repo-mirror.ts
@@ -1,70 +1,104 @@
 import { reportSilentFallback } from "@/server/observability";
 
 /**
- * The ADR-044 "moved" repo columns — relocated from `users` to `workspaces`.
- * Non-moved connect-flow columns (`workspace_path`, `workspace_status`,
- * `repo_error`, `health_snapshot`) stay on `users` and are NOT mirrored.
+ * The ADR-044 repo-connection columns — authoritative on `workspaces` as of the
+ * PR-2 write-cutover (#5462). `repo_error` joined the set (migration 110 adds the
+ * column + extends the non-credential GRANT). The provisioning/readiness columns
+ * (`workspace_path`, `workspace_status`, `health_snapshot`) are NOT relocated by
+ * ADR-044 and stay on `users` (written by the connect routes only for the SOLO
+ * owner case).
  */
-export type MirroredRepoCols = Partial<{
+export type WorkspaceRepoCols = Partial<{
   repo_url: string | null;
   github_installation_id: number | null;
   repo_status: string;
   repo_last_synced_at: string | null;
+  repo_error: string | null;
 }>;
 
 interface ServiceClientLike {
   from: (table: string) => {
-    update: (patch: MirroredRepoCols) => {
-      eq: (col: string, val: string) => PromiseLike<{ error: unknown }>;
+    update: (patch: WorkspaceRepoCols) => {
+      eq: (
+        col: string,
+        val: string,
+      ) => {
+        select: (
+          cols: string,
+        ) => PromiseLike<{ data: Array<{ id: string }> | null; error: unknown }>;
+      };
     };
   };
 }
 
 /**
- * Dual-write the moved repo columns to the user's SOLO workspace
- * (`workspaces.id == user_id`, ADR-038 N2) so the workspaces-only read path
- * (`getCurrentRepoUrl` / `resolveInstallationId`) stays consistent with the
- * legacy `users` write during the ADR-044 soak. Without this, a fresh
- * connect/disconnect would write `users` while the read path checks
- * `workspaces`, showing a stale/absent repo.
+ * Write the authoritative repo-connection columns to the `workspaces` row keyed
+ * on the **caller-supplied resolved workspace id** (team OR solo — NOT a
+ * hardcoded `userId`). This is the PR-2 inversion of the former
+ * `mirrorRepoColsToSoloWorkspace`: `workspaces` is now the source of truth, so
+ * this is the authoritative write, not a best-effort mirror.
  *
- * Connect/disconnect flows are SOLO-ONLY today (team-invite repo flows are
- * deferred to #5462 / Phase 5 — they will resolve the target workspace
- * first), so the solo workspace id equals the user id.
+ * The caller MUST pass an id resolved server-side via the membership-verified
+ * `resolveActiveWorkspace` (IDOR-safe, never `req.body`); a write to an
+ * unverified id would cross the user→workspace tenant boundary.
  *
- * Service-role write: members cannot UPDATE `workspaces` directly (no
- * UPDATE RLS policy) and `github_installation_id` is REVOKE'd from the
- * `authenticated` grant; the caller passes a service client.
+ * Members cannot UPDATE `workspaces` directly (no UPDATE RLS policy) and
+ * `github_installation_id` is REVOKE'd from the `authenticated` grant, so the
+ * caller passes a service client.
  *
- * Best-effort by default — failure is Sentry-mirrored but does not throw,
- * because on a CONNECT the `users` write stays authoritative and a missed
- * mirror only makes the workspaces-only read path show "not connected" (a
- * safe-fail the next connect/sync re-mirrors).
+ * The UPDATE `.select("id")`s so a **0-row match** is detected: a
+ * `.eq("id", workspaceId)` that matches no row returns `{error:null}` — a SILENT
+ * no-op (the workspace can be deleted between request return and a background
+ * callback; `current_workspace_id` is `ON DELETE SET NULL`, mig 079). A 0-row
+ * write is treated as a failure class (`cq-silent-fallback-must-mirror-to-sentry`).
  *
- * Pass `{ throwOnError: true }` on the DISCONNECT / credential-clear path:
- * there the read path is workspaces-only, so a silently-failed mirror would
- * leave `github_installation_id` (a live GitHub App grant) and `repo_url`
- * readable AFTER the user "disconnected" — the agent could still act under
- * the supposedly-revoked grant, and the `repo_url && installationId === null`
- * revalidation guard cannot catch it (both stay non-null). Failing closed
- * lets the route surface a 500 so the (idempotent) disconnect is retried.
+ * Best-effort by default — failure is Sentry-mirrored but does not throw.
+ * Pass `{ throwOnError: true }` on the DISCONNECT / credential-clear path and on
+ * the connect cloning-flip: there a silently-failed write would leave
+ * `github_installation_id` (a live GitHub App grant) + `repo_url` readable on the
+ * workspaces-only read path AFTER the user "disconnected", or report a connect as
+ * succeeded when it never persisted. Failing closed lets the route surface a 500
+ * so the (idempotent) operation is retried.
  */
-export async function mirrorRepoColsToSoloWorkspace(
+export async function writeRepoColsToWorkspace(
   service: ServiceClientLike,
-  userId: string,
-  patch: MirroredRepoCols,
+  workspaceId: string,
+  patch: WorkspaceRepoCols,
   opts?: { throwOnError?: boolean },
 ): Promise<void> {
-  const { error } = await service.from("workspaces").update(patch).eq("id", userId);
+  const { data, error } = await service
+    .from("workspaces")
+    .update(patch)
+    .eq("id", workspaceId)
+    .select("id");
+
   if (error) {
     reportSilentFallback(error, {
-      feature: "workspace-repo-mirror",
-      op: "mirror-to-solo-workspace",
-      extra: { userId, cols: Object.keys(patch) },
-      message: "Failed to mirror repo columns to the solo workspace",
+      feature: "workspace-repo-write",
+      op: "write-to-workspace",
+      extra: { workspaceId, cols: Object.keys(patch) },
+      message: "Failed to write repo columns to the active workspace",
     });
     if (opts?.throwOnError) {
       throw error instanceof Error ? error : new Error(String(error));
+    }
+    return;
+  }
+
+  if (!data || data.length === 0) {
+    // 0-row no-op: the target workspace row is gone (deleted mid-flight) or the
+    // id never existed. The write silently affected nothing — surface it.
+    const zeroRow = new Error(
+      `writeRepoColsToWorkspace matched 0 rows for workspace ${workspaceId}`,
+    );
+    reportSilentFallback(zeroRow, {
+      feature: "workspace-repo-write",
+      op: "write-to-workspace.zero-rows",
+      extra: { workspaceId, cols: Object.keys(patch) },
+      message: "Repo-column write to the active workspace matched 0 rows",
+    });
+    if (opts?.throwOnError) {
+      throw zeroRow;
     }
   }
 }

--- a/apps/web-platform/supabase/migrations/110_workspace_repo_error_and_comember_reconcile.down.sql
+++ b/apps/web-platform/supabase/migrations/110_workspace_repo_error_and_comember_reconcile.down.sql
@@ -1,0 +1,18 @@
+-- 110_workspace_repo_error_and_comember_reconcile.down.sql
+-- Reverse 110 (ADR-044 PR-2 team write-cutover, #5462 — Phase 1).
+--
+-- The backfill steps (3-4) are SCOPED-FORWARD-ONLY: they re-keyed the
+-- still-authoritative `users` snapshot onto solo workspaces. A blanket revert
+-- would risk nulling repo state a direct workspace connect set post-110. The
+-- repo_url/github_installation_id/repo_status/repo_last_synced_at columns are
+-- dropped wholesale by 079.down.sql, so this down only reverses the additive
+-- schema change (the repo_error column + its GRANT extension).
+
+-- Restore the mig-079 GRANT shape (without repo_error).
+REVOKE SELECT ON public.workspaces FROM authenticated;
+GRANT SELECT (id, organization_id, name, created_at,
+              repo_url, repo_provider, repo_status, repo_last_synced_at)
+  ON public.workspaces TO authenticated;
+
+ALTER TABLE public.workspaces
+  DROP COLUMN IF EXISTS repo_error;

--- a/apps/web-platform/supabase/migrations/110_workspace_repo_error_and_comember_reconcile.sql
+++ b/apps/web-platform/supabase/migrations/110_workspace_repo_error_and_comember_reconcile.sql
@@ -1,0 +1,173 @@
+-- 110_workspace_repo_error_and_comember_reconcile.sql
+-- feat-adr-044-team-write-cutover (#5462, Phase 1) — the schema +
+-- data precondition for the connect-time WRITE relocation (users.* ->
+-- workspaces.*) that PR-2b's column drop (#5437) depends on. ADR-044.
+--
+-- This file is additive + reversible (.down.sql drops the new column). It is
+-- applied by web-platform-release.yml #migrate BEFORE the code cutover deploy,
+-- mirroring the 079/080 -> 081 ordering. Supabase wraps each migration file in
+-- ONE transaction; no explicit BEGIN/COMMIT and no CONCURRENTLY (mirror 079/080).
+--
+-- ---------------------------------------------------------------------------
+-- LAWFUL_BASIS (GDPR Art. 6) — co-membered SKIP backlog is NOT auto-adopted:
+--   * SOLO rows: Art. 6(1)(b) contract — re-keying the repo_error reason onto
+--     the user's OWN solo workspace (workspace_id == user_id, ADR-038 N2). No
+--     new processing of another data subject's data.
+--   * CO-MEMBERED rows: auto-copying the owner's users.repo_url onto a
+--     co-membered workspace would process co-member repo access WITHOUT a fresh
+--     Art. 6(1)(a) invite attestation (workspace_member_attestations, mig 058).
+--     PA-17(c)(2) + 2026-05-counsel-review-4558.md (call B1) establish the
+--     Art. 6(1)(a) basis "never operates retroactively." So this migration does
+--     NOT auto-drain the mig-080 co-membered SKIP backlog. Those rows are a
+--     LAWFUL CARRIED RESIDUAL cleared only when the owner re-connects the repo
+--     from within the team-workspace context (the owner-gated write path THIS
+--     PR's Phase 3 implements — a re-connect re-establishes the connection under
+--     a fresh attestation). hr-gdpr-gate-on-regulated-data-surfaces.
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+  IF to_regclass('public.workspaces') IS NULL THEN
+    RAISE EXCEPTION 'Precondition failed: public.workspaces must exist before 110 (apply migration 079 first)';
+  END IF;
+END $$;
+
+-- =====================================================================
+-- 1. repo_error column on public.workspaces
+-- =====================================================================
+--
+-- repo_error is a SANITIZED reason string (setup/route.ts builds it as
+-- JSON.stringify({code, message: sanitizeGitStderr(...), timestamp}); the
+-- GitHub App token never reaches stderr — askpass via env, GIT_TERMINAL_PROMPT=0).
+-- It is NOT a credential, so it joins the `authenticated` read set below.
+
+ALTER TABLE public.workspaces
+  ADD COLUMN IF NOT EXISTS repo_error text;
+
+-- =====================================================================
+-- 2. Extend the non-credential column-level GRANT to include repo_error
+-- =====================================================================
+--
+-- Supabase grants TABLE-level SELECT to `authenticated` by default; adding a
+-- column does NOT auto-add it to the column-level grant mig 079:89 installed.
+-- The only way to extend the allowed-column set is to REVOKE the table-level
+-- SELECT and RE-GRANT the full explicit non-credential column list (NOT a
+-- partial column grant, which is a no-op while a broader grant exists). RLS
+-- (workspaces_select_for_members) still gates which ROWS are visible.
+-- `github_installation_id` stays OUT of this list — the credential is readable
+-- only via resolve_workspace_installation_id (SECURITY DEFINER, mig 079).
+-- service_role keeps its default grant (trusted server context).
+
+REVOKE SELECT ON public.workspaces FROM authenticated;
+GRANT SELECT (id, organization_id, name, created_at,
+              repo_url, repo_provider, repo_status, repo_last_synced_at,
+              repo_error)
+  ON public.workspaces TO authenticated;
+
+-- =====================================================================
+-- 3. SOLO backfill: re-key users.repo_error -> workspaces.repo_error
+-- =====================================================================
+--
+-- Mirror mig-080's solo-only join (w.id = u.id) + canary-owner-row +
+-- sole-member COUNT(*) = 1 guard + the `WHERE w.repo_error IS NULL`
+-- idempotency guard. Runs from the still-authoritative `users` snapshot BEFORE
+-- the write cutover deploys (Phase 1 before Phase 2-3 per the release ordering).
+
+DO $$
+DECLARE
+  v_rc int;
+BEGIN
+  UPDATE public.workspaces w
+     SET repo_error = u.repo_error
+    FROM public.users u
+   WHERE w.id = u.id
+     AND w.repo_error IS NULL        -- idempotency: re-runs touch 0 rows
+     AND u.repo_error IS NOT NULL    -- only users with an error reason set
+     -- Canary owner-row: this workspace is the user's own solo workspace.
+     AND EXISTS (
+       SELECT 1 FROM public.workspace_members m
+       WHERE m.workspace_id = w.id
+         AND m.user_id      = w.id
+         AND m.role         = 'owner'
+     )
+     -- Sole-member guard: never adopt onto a co-membered workspace.
+     AND (
+       SELECT COUNT(*) FROM public.workspace_members m2
+       WHERE m2.workspace_id = w.id
+     ) = 1;
+
+  GET DIAGNOSTICS v_rc = ROW_COUNT;
+  RAISE NOTICE '[110-backfill workspace repo_error] % rows re-keyed', v_rc;
+END $$;
+
+-- =====================================================================
+-- 4. Re-run the mig-080 SOLO repo-connection backfill (drift convergence)
+-- =====================================================================
+--
+-- A solo workspace that became correctly-provisioned AFTER mig-080 ran (e.g. a
+-- repo connected before its solo workspace existed) may still diverge from the
+-- `users` snapshot. Re-key the SOLO rows so the PR-2b drift gate (verify/110)
+-- reaches 0 for sole-member workspaces. Co-membered rows are DELIBERATELY left
+-- alone (the COUNT(*) = 1 guard) — they are the lawful carried residual cleared
+-- by owner re-connect (header). Fan-out keying is (github_installation_id,
+-- repo_url) per ADR-044; the w.id = u.id join is already org-scoped (a solo
+-- workspace shares the owner's org), so this never crosses an organization
+-- boundary.
+
+DO $$
+DECLARE
+  v_rc int;
+BEGIN
+  UPDATE public.workspaces w
+     SET repo_url               = u.repo_url,
+         repo_provider          = u.repo_provider,
+         github_installation_id = u.github_installation_id,
+         repo_status            = u.repo_status,
+         repo_last_synced_at    = u.repo_last_synced_at
+    FROM public.users u
+   WHERE w.id = u.id
+     AND u.repo_url IS NOT NULL
+     -- Re-key only rows that still diverge (idempotent: converged rows skip).
+     AND (
+       w.repo_url               IS DISTINCT FROM u.repo_url
+       OR w.github_installation_id IS DISTINCT FROM u.github_installation_id
+       OR w.repo_status            IS DISTINCT FROM u.repo_status
+       OR w.repo_last_synced_at    IS DISTINCT FROM u.repo_last_synced_at
+     )
+     -- Canary owner-row + sole-member guard (SOLO-ONLY, lawful Art. 6(1)(b)).
+     AND EXISTS (
+       SELECT 1 FROM public.workspace_members m
+       WHERE m.workspace_id = w.id
+         AND m.user_id      = w.id
+         AND m.role         = 'owner'
+     )
+     AND (
+       SELECT COUNT(*) FROM public.workspace_members m2
+       WHERE m2.workspace_id = w.id
+     ) = 1;
+
+  GET DIAGNOSTICS v_rc = ROW_COUNT;
+  RAISE NOTICE '[110-reconcile solo repo cols] % rows re-keyed', v_rc;
+END $$;
+
+-- =====================================================================
+-- 5. Audit: log the carried co-membered residual (NOT drained)
+-- =====================================================================
+--
+-- Surface (do not mutate) the co-membered SKIP backlog so the apply log records
+-- the lawful carried residual that owner re-connect (Phase 3) clears.
+
+DO $$
+DECLARE
+  v_carried int;
+BEGIN
+  SELECT COUNT(*) INTO v_carried
+    FROM public.workspaces w
+    JOIN public.users u ON u.id = w.id
+   WHERE u.repo_url IS NOT NULL
+     AND (
+       SELECT COUNT(*) FROM public.workspace_members m2
+       WHERE m2.workspace_id = w.id
+     ) > 1;
+  RAISE NOTICE '[110-audit] % co-membered workspaces carry an un-re-connected repo residual (lawful; cleared by owner re-connect)', v_carried;
+END $$;

--- a/apps/web-platform/supabase/verify/110_workspace_repo_error_and_comember_reconcile.sql
+++ b/apps/web-platform/supabase/verify/110_workspace_repo_error_and_comember_reconcile.sql
@@ -1,0 +1,79 @@
+-- Verify 110_workspace_repo_error_and_comember_reconcile.sql.
+--
+-- Contract: every row returns `check_name` + `bad`. Any `bad > 0` row fails CI
+-- verify-migrations (and auto-closes any matching `follow-through` issue).
+--
+-- ADR-044 PR-2 team write-cutover (#5462, Phase 1). Asserts the post-apply
+-- state of the migration's schema add + SOLO drift reconcile. The drift exit is
+-- two-part (deepen-confirmed CLO/PA-17(c) reshape of the literal "COUNT -> 0"):
+--   (1) SOLO drift-gate COUNT = 0 post-reconcile (sole-member workspaces).
+--   (2) 0 co-membered workspaces adopted WITHOUT an attestation — NOT "0 SKIP
+--       rows remaining" (the co-membered backlog is a lawful carried residual
+--       cleared by owner re-connect, this PR's owner-gated write path).
+
+-- (1) workspaces.repo_error column exists (the schema precondition for the
+--     write relocation + getCurrentRepoStatus read).
+SELECT 'workspaces_repo_error_missing' AS check_name,
+       (SELECT count(*) FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name   = 'workspaces'
+          AND column_name  = 'repo_error') = 0 AS bad
+UNION ALL
+-- (2) repo_error is in the `authenticated` column-level SELECT grant (it is a
+--     sanitized reason, non-credential). A tenant read of it must not be
+--     permission-denied (getCurrentRepoStatus reads it via the tenant client).
+SELECT 'repo_error_not_in_authenticated_grant',
+       NOT EXISTS (
+         SELECT 1 FROM information_schema.column_privileges
+         WHERE table_schema = 'public'
+           AND table_name   = 'workspaces'
+           AND column_name  = 'repo_error'
+           AND grantee      = 'authenticated'
+           AND privilege_type = 'SELECT'
+       ) AS bad
+UNION ALL
+-- (3) github_installation_id stays REVOKE'd from `authenticated` (credential —
+--     readable only via resolve_workspace_installation_id RPC).
+SELECT 'github_installation_id_leaked_to_authenticated',
+       EXISTS (
+         SELECT 1 FROM information_schema.column_privileges
+         WHERE table_schema = 'public'
+           AND table_name   = 'workspaces'
+           AND column_name  = 'github_installation_id'
+           AND grantee      = 'authenticated'
+           AND privilege_type = 'SELECT'
+       ) AS bad
+UNION ALL
+-- (4) SOLO drift-gate COUNT = 0. ADR-044's exact PR-2b gate query
+--     (users JOIN workspaces ON w.id = u.id) scoped to SOLO (sole-member)
+--     workspaces. Post-reconcile this must be 0; co-membered rows are excluded
+--     (asserted separately in check 5).
+SELECT 'repo_drift_count',
+       (SELECT count(*)::int FROM public.users u
+          JOIN public.workspaces w ON w.id = u.id
+        WHERE (
+          (u.repo_url IS NOT NULL AND w.repo_url IS DISTINCT FROM u.repo_url)
+          OR (u.github_installation_id IS NOT NULL
+              AND w.github_installation_id IS DISTINCT FROM u.github_installation_id)
+        )
+        AND (
+          SELECT count(*) FROM public.workspace_members m2
+          WHERE m2.workspace_id = w.id
+        ) = 1) AS bad
+UNION ALL
+-- (5) 0 co-membered (sole-member COUNT > 1) workspaces that have an adopted
+--     repo connection WITHOUT a corresponding attestation row. This is the
+--     lawful-basis assertion: a co-membered workspace may hold a repo_url only
+--     if an Art. 6(1)(a) attestation exists (workspace_member_attestations,
+--     mig 058). This migration does NOT auto-adopt, so this stays 0.
+SELECT 'comembered_adopted_without_attestation',
+       (SELECT count(*)::int FROM public.workspaces w
+        WHERE w.repo_url IS NOT NULL
+          AND (
+            SELECT count(*) FROM public.workspace_members m2
+            WHERE m2.workspace_id = w.id
+          ) > 1
+          AND NOT EXISTS (
+            SELECT 1 FROM public.workspace_member_attestations a
+            WHERE a.workspace_id = w.id
+          )) AS bad;

--- a/apps/web-platform/test/abort-workspace-member-sessions.test.ts
+++ b/apps/web-platform/test/abort-workspace-member-sessions.test.ts
@@ -6,6 +6,7 @@ import {
   clearUserWorkspace,
   getUserWorkspace,
   abortAllWorkspaceMemberSessions,
+  abortAllSessionsForWorkspace,
 } from "@/server/agent-session-registry";
 import type { AgentSession } from "@/server/review-gate";
 import { classifyAbortReason } from "@/server/abort-classifier";
@@ -112,5 +113,52 @@ describe("abortAllWorkspaceMemberSessions", () => {
   it("setUserWorkspace ignores empty/undefined values (defensive)", () => {
     setUserWorkspace(HARRY, "");
     expect(getUserWorkspace(HARRY)).toBeUndefined();
+  });
+});
+
+describe("abortAllSessionsForWorkspace (ADR-044 PR-2 — shared team-dir teardown)", () => {
+  beforeEach(() => {
+    __test_only__.clear();
+  });
+
+  it("aborts EVERY member's session bound to the workspace (not just the caller)", () => {
+    // The distinction from abortAllWorkspaceMemberSessions: a disconnect tears
+    // down the SHARED clone, so BOTH members in the team workspace must abort —
+    // a per-caller abort (the sibling fn) would leave JEAN mid-write → ENOENT.
+    const harry = makeSession();
+    const jean = makeSession();
+    registerSession(HARRY, "conv-1", harry);
+    setUserWorkspace(HARRY, JIKIGAI);
+    registerSession(JEAN, "conv-2", jean);
+    setUserWorkspace(JEAN, JIKIGAI);
+
+    abortAllSessionsForWorkspace(JIKIGAI);
+
+    expect(harry.abort.signal.aborted).toBe(true);
+    expect(jean.abort.signal.aborted).toBe(true);
+  });
+
+  it("leaves sessions bound to a DIFFERENT workspace untouched", () => {
+    const teamSession = makeSession();
+    const personalSession = makeSession();
+    registerSession(HARRY, "conv-1", teamSession);
+    setUserWorkspace(HARRY, JIKIGAI);
+    registerSession(JEAN, "conv-2", personalSession);
+    setUserWorkspace(JEAN, PERSONAL);
+
+    abortAllSessionsForWorkspace(JIKIGAI);
+
+    expect(teamSession.abort.signal.aborted).toBe(true);
+    expect(personalSession.abort.signal.aborted).toBe(false);
+  });
+
+  it("no-op when no session is bound to the workspace (e.g. solo with no live turn)", () => {
+    const session = makeSession();
+    registerSession(JEAN, "conv-2", session);
+    setUserWorkspace(JEAN, PERSONAL);
+
+    abortAllSessionsForWorkspace(JIKIGAI);
+
+    expect(session.abort.signal.aborted).toBe(false);
   });
 });

--- a/apps/web-platform/test/api/dashboard/today/undo-route.test.ts
+++ b/apps/web-platform/test/api/dashboard/today/undo-route.test.ts
@@ -21,6 +21,7 @@ const {
   mockServiceFrom,
   mockValidateOrigin,
   mockCreateGitHubAppClient,
+  mockResolveInstallationId,
 } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
   mockTenantFrom: vi.fn(),
@@ -30,6 +31,7 @@ const {
     origin: "https://app.soleur.ai",
   })),
   mockCreateGitHubAppClient: vi.fn(),
+  mockResolveInstallationId: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/server", () => ({
@@ -49,6 +51,11 @@ vi.mock("@/lib/auth/validate-origin", () => ({
 }));
 vi.mock("@/server/github/app-client", () => ({
   createGitHubAppClient: mockCreateGitHubAppClient,
+}));
+// ADR-044 PR-2 (#5462): the install id is now resolved via the membership-checked
+// `resolveInstallationId` RPC (was a direct `users.github_installation_id` read).
+vi.mock("@/server/resolve-installation-id", () => ({
+  resolveInstallationId: mockResolveInstallationId,
 }));
 vi.mock("@/server/observability", () => ({
   reportSilentFallback: vi.fn(),
@@ -106,19 +113,13 @@ function setupServiceChain(state: ServiceState) {
       return eqChain;
     }),
   };
-  const usersChain = {
-    select: vi.fn(() => usersChain),
-    eq: vi.fn(() => usersChain),
-    maybeSingle: vi.fn(async () => ({
-      data: { github_installation_id: state.installationId },
-      error: null,
-    })),
-  };
   (mockServiceFrom as unknown as { mockImplementation: (impl: (table: string) => unknown) => void }).mockImplementation((table: string) => {
     if (table === "action_sends") return sendReadChain;
-    if (table === "users") return usersChain;
     throw new Error(`unexpected service-role table ${table}`);
   });
+  // ADR-044 PR-2: the install id is resolved via the membership-checked RPC
+  // (mocked), not a `users` service read. `null` → 403 unauthorized.
+  mockResolveInstallationId.mockResolvedValue(state.installationId);
   return captured;
 }
 

--- a/apps/web-platform/test/api/kb-tree.test.ts
+++ b/apps/web-platform/test/api/kb-tree.test.ts
@@ -86,15 +86,21 @@ describe("GET /api/kb/tree — needsReconnect", () => {
     expect(body.needsReconnect).toBe(false);
   });
 
-  test("needsReconnect=false for ready repo with an installation id (short-circuits before workspace credential)", async () => {
-    mockFrom.mockReturnValue(
-      mockQueryChain({ ...BASE_USER, github_installation_id: 98765 }),
-    );
+  test("needsReconnect=false for ready repo with an installation id", async () => {
+    // ADR-044 PR-2 (#5462): the install id moved off `users` — the route reads
+    // only `kb_sync_history` there and resolves the credential via the
+    // membership-checked RPC. A resolvable install id (here from the
+    // workspace-scoped RPC) short-circuits resolveNeedsReconnect to false.
+    mockResolveInstallationId.mockResolvedValue(98765);
+    mockFrom.mockReturnValue(mockQueryChain({ ...BASE_USER }));
     const res = await GET(makeRequest());
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.needsReconnect).toBe(false);
-    expect(mockResolveInstallationId).not.toHaveBeenCalled();
+    expect(mockResolveInstallationId).toHaveBeenCalledWith(
+      TEST_USER.id,
+      TEST_USER.id,
+    );
   });
 
   test("not_connected short-circuits to 404 (no needsReconnect)", async () => {

--- a/apps/web-platform/test/app/auth/callback-setup-key-gate.test.ts
+++ b/apps/web-platform/test/app/auth/callback-setup-key-gate.test.ts
@@ -37,6 +37,13 @@ vi.mock("@/server/byok-resolver", () => ({
 }));
 
 vi.mock("@/server/workspace", () => ({ provisionWorkspace: vi.fn() }));
+// ADR-044 PR-2 (#5462): the callback resolves the active workspace before
+// reading repo_status from `workspaces`. Stub the resolver to the test user id
+// (solo workspace id === user id per the N2 invariant) so the WORKSPACES read
+// targets a row our service-client mock recognizes.
+vi.mock("@/server/workspace-resolver", () => ({
+  resolveCurrentWorkspaceId: vi.fn(async () => USER_ID),
+}));
 vi.mock("@/server/observability", () => ({
   reportSilentFallback: vi.fn(),
   warnSilentFallback: vi.fn(),
@@ -65,15 +72,36 @@ function makeRequest(): NextRequest {
   });
 }
 
-// Single users row covering BOTH service-client reads: ensureWorkspaceProvisioned
-// (workspace_status, tc_accepted_version) and the key-gate (repo_status,
-// setup_key_skipped_at). The mock ignores selected columns and returns the row.
+// Covers all three service-client reads from a single fixture row:
+//   - ensureWorkspaceProvisioned: users.select(workspace_status,
+//     tc_accepted_version).eq().single()
+//   - key-gate skip flag: users.select(setup_key_skipped_at).eq().single()
+//   - key-gate repo status (ADR-044 PR-2 #5462): repo_status is now AUTHORITATIVE
+//     on the active `workspaces` row, read via workspaces.select(repo_status)
+//     .eq().maybeSingle(). The fixture's `repo_status` is fed through that read.
+// The `users` reads ignore the selected columns and return the whole row; the
+// `workspaces` read returns only { repo_status }.
 function stubUsersRow(row: Record<string, unknown>) {
-  mockServiceFrom.mockImplementation(() => ({
-    select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: row, error: null }) }) }),
-    update: () => ({ eq: () => Promise.resolve({ error: null }) }),
-    upsert: () => Promise.resolve({ error: null }),
-  }));
+  mockServiceFrom.mockImplementation((table: string) => {
+    if (table === "workspaces") {
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: () =>
+              Promise.resolve({
+                data: { repo_status: row.repo_status ?? null },
+                error: null,
+              }),
+          }),
+        }),
+      };
+    }
+    return {
+      select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: row, error: null }) }) }),
+      update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+      upsert: () => Promise.resolve({ error: null }),
+    };
+  });
 }
 
 function pathOf(res: Response): string {

--- a/apps/web-platform/test/create-route-error.test.ts
+++ b/apps/web-platform/test/create-route-error.test.ts
@@ -6,7 +6,7 @@ import { describe, test, expect, vi, beforeEach } from "vitest";
 
 const {
   mockGetUser,
-  mockServiceFrom,
+  mockResolveInstallationId,
   mockCreateRepo,
   mockCaptureException,
   GitHubApiError,
@@ -22,7 +22,7 @@ const {
   }
   return {
     mockGetUser: vi.fn(),
-    mockServiceFrom: vi.fn(),
+    mockResolveInstallationId: vi.fn(),
     mockCreateRepo: vi.fn(),
     mockCaptureException: vi.fn(),
     GitHubApiError,
@@ -37,9 +37,14 @@ vi.mock("@/lib/supabase/server", () => ({
   createClient: async () => ({
     auth: { getUser: mockGetUser },
   }),
-  createServiceClient: () => ({
-    from: mockServiceFrom,
-  }),
+}));
+
+// ADR-044 PR-2: the install is resolved via the membership-checked resolver
+// (was a direct users.github_installation_id select). The error-handling tests
+// need a valid numeric id so the handler reaches createRepo; the "not installed"
+// case (null) short-circuits to 400 before createRepo.
+vi.mock("@/server/resolve-installation-id", () => ({
+  resolveInstallationId: mockResolveInstallationId,
 }));
 
 vi.mock("@/lib/auth/validate-origin", () => ({
@@ -90,16 +95,9 @@ describe("POST /api/repo/create — error handling", () => {
       data: { user: { id: "user-123" } },
     });
 
-    mockServiceFrom.mockReturnValue({
-      select: vi.fn().mockReturnValue({
-        eq: vi.fn().mockReturnValue({
-          single: vi.fn().mockResolvedValue({
-            data: { github_installation_id: 999 },
-            error: null,
-          }),
-        }),
-      }),
-    });
+    // Resolver returns a valid install so the error-handling tests reach
+    // createRepo (the "not installed" → 400 case is covered elsewhere).
+    mockResolveInstallationId.mockResolvedValue(999);
   });
 
   test("returns 409 with specific message for GitHub 422 (duplicate name)", async () => {

--- a/apps/web-platform/test/detect-installation-fallback.test.ts
+++ b/apps/web-platform/test/detect-installation-fallback.test.ts
@@ -11,6 +11,7 @@ const mockFindInstallationForLogin = vi.fn();
 const mockVerifyInstallationOwnership = vi.fn();
 const mockListInstallationRepos = vi.fn();
 const mockResolveReachable = vi.fn();
+const mockWriteRepoColsToWorkspace = vi.fn();
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: async () => ({
@@ -49,9 +50,11 @@ vi.mock("@/server/reachable-installations", () => ({
     mockResolveReachable(...args),
 }));
 
-// mirrorRepoColsToSoloWorkspace is dynamically imported by the route.
+// writeRepoColsToWorkspace is dynamically imported by the route to persist the
+// login-matched personal install onto the caller's SOLO workspace (ADR-044 PR-2).
 vi.mock("@/server/workspace-repo-mirror", () => ({
-  mirrorRepoColsToSoloWorkspace: vi.fn(async () => {}),
+  writeRepoColsToWorkspace: (...args: unknown[]) =>
+    mockWriteRepoColsToWorkspace(...args),
 }));
 
 import { POST } from "../app/api/repo/detect-installation/route";
@@ -67,14 +70,15 @@ function makeRequest() {
   });
 }
 
-type TableOperation = "select" | "update";
-type TableMockConfig = Record<string, Partial<Record<TableOperation, unknown>>>;
+// ADR-044 PR-2: the route now READS `users` (the "already stored" short-circuit)
+// but never WRITES it — the install write relocated to a SOLO workspace via the
+// mocked writeRepoColsToWorkspace helper. We therefore wire ONLY `.select` and
+// deliberately omit `.update`: any residual `users.update({github_installation_id})`
+// would throw `mock.update is not a function`, failing the test structurally.
+type TableMockConfig = Record<string, { select?: unknown }>;
 
 function setupTableRoutes(config: TableMockConfig) {
   mockServiceFrom.mockImplementation((table: string) => {
-    if (table === "workspaces") {
-      return { update: () => ({ eq: async () => ({ error: null }) }) };
-    }
     const tableConfig = config[table];
     if (!tableConfig) {
       throw new Error(
@@ -89,11 +93,6 @@ function setupTableRoutes(config: TableMockConfig) {
         }),
       });
     }
-    if (tableConfig.update !== undefined) {
-      mock.update = vi.fn().mockReturnValue({
-        eq: vi.fn().mockResolvedValue({ error: tableConfig.update }),
-      });
-    }
     return mock;
   });
 }
@@ -106,6 +105,7 @@ describe("POST /api/repo/detect-installation — github_username fallback", () =
   beforeEach(() => {
     vi.resetAllMocks();
     mockGetUser.mockResolvedValue({ data: { user: { id: "user-123" } } });
+    mockWriteRepoColsToWorkspace.mockResolvedValue(undefined);
     // Default: reachable set is the single login-matched install (legacy shape).
     mockResolveReachable.mockImplementation(
       async (_svc: unknown, _uid: string, login: string | null) =>
@@ -117,7 +117,6 @@ describe("POST /api/repo/detect-installation — github_username fallback", () =
     setupTableRoutes({
       users: {
         select: { github_installation_id: null, github_username: "deruelle" },
-        update: null,
       },
     });
     mockAdminGetUserById.mockResolvedValue({
@@ -141,6 +140,14 @@ describe("POST /api/repo/detect-installation — github_username fallback", () =
     expect(data.installed).toBe(true);
     expect(data.repos).toHaveLength(1);
     expect(mockFindInstallationForLogin).toHaveBeenCalledWith("deruelle");
+    // ADR-044 PR-2: the login-matched install is persisted to the caller's SOLO
+    // workspace via writeRepoColsToWorkspace (svc client, uid, install cols) —
+    // NOT users.update.
+    expect(mockWriteRepoColsToWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({ from: mockServiceFrom }),
+      "user-123",
+      { github_installation_id: 12345 },
+    );
   });
 
   test("returns no_github_identity when neither Supabase identity nor github_username exists", async () => {
@@ -169,7 +176,6 @@ describe("POST /api/repo/detect-installation — github_username fallback", () =
     setupTableRoutes({
       users: {
         select: { github_installation_id: null },
-        update: null,
       },
     });
     mockAdminGetUserById.mockResolvedValue({
@@ -194,6 +200,12 @@ describe("POST /api/repo/detect-installation — github_username fallback", () =
 
     expect(data.installed).toBe(true);
     expect(mockFindInstallationForLogin).toHaveBeenCalledWith("supabase-user");
+    // The verified install is persisted to the SOLO workspace, not users.
+    expect(mockWriteRepoColsToWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({ from: mockServiceFrom }),
+      "user-123",
+      { github_installation_id: 99999 },
+    );
   });
 
   test("T14: org member (login != org login) sees the org repo on first call", async () => {
@@ -201,7 +213,6 @@ describe("POST /api/repo/detect-installation — github_username fallback", () =
     setupTableRoutes({
       users: {
         select: { github_installation_id: null, github_username: "deruelle" },
-        update: null,
       },
     });
     mockAdminGetUserById.mockResolvedValue({
@@ -226,7 +237,9 @@ describe("POST /api/repo/detect-installation — github_username fallback", () =
     expect(data.repos.map((r: { fullName: string }) => r.fullName)).toEqual([
       "jikig-ai/soleur",
     ]);
-    // The membership-only install is NOT persisted on users (unique constraint).
+    // The membership-only install is NOT persisted to any workspace — no
+    // personal install matched the login, so the write path never runs.
     expect(mockFindInstallationForLogin).toHaveBeenCalledWith("deruelle");
+    expect(mockWriteRepoColsToWorkspace).not.toHaveBeenCalled();
   });
 });

--- a/apps/web-platform/test/disconnect-route.test.ts
+++ b/apps/web-platform/test/disconnect-route.test.ts
@@ -11,24 +11,24 @@ const {
   mockDeleteWorkspace,
   mockIsAllowed,
   mockRpc,
-  mockTenantFrom,
+  mockResolveActiveWorkspace,
+  mockWriteRepoColsToWorkspace,
+  mockAbortAllWorkspaceMemberSessions,
 } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
   mockFrom: vi.fn(),
   mockDeleteWorkspace: vi.fn(),
   mockIsAllowed: vi.fn(),
   mockRpc: vi.fn(),
-  mockTenantFrom: vi.fn(),
+  mockResolveActiveWorkspace: vi.fn(),
+  mockWriteRepoColsToWorkspace: vi.fn(),
+  mockAbortAllWorkspaceMemberSessions: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({
     auth: { getUser: mockGetUser },
     rpc: mockRpc,
-    // ADR-044 PR-2a: the tenant client now reads user_session_state via
-    // resolveCurrentWorkspaceId (active-workspace guard). Defaulted to solo
-    // in beforeEach so every existing test is a no-op for the new guard.
-    from: mockTenantFrom,
   })),
   createServiceClient: vi.fn(() => ({
     from: mockFrom,
@@ -37,6 +37,25 @@ vi.mock("@/lib/supabase/server", () => ({
 
 vi.mock("@/server/workspace", () => ({
   deleteWorkspace: mockDeleteWorkspace,
+}));
+
+// ADR-044 PR-2: the route resolves its target workspace via the
+// membership-verified resolver (session claim, never request input). Control
+// its return per-test; db-error must fail-closed to 503.
+vi.mock("@/server/workspace-resolver", () => ({
+  resolveActiveWorkspace: mockResolveActiveWorkspace,
+}));
+
+// ADR-044 PR-2: the repo-column CLEAR is now authoritative on the `workspaces`
+// row, written via the dynamically-imported mirror helper. Mock it so we can
+// assert the exact (client, id, patch, opts) and exercise the fail-closed path.
+vi.mock("@/server/workspace-repo-mirror", () => ({
+  writeRepoColsToWorkspace: mockWriteRepoColsToWorkspace,
+}));
+
+// ADR-044 PR-2 / P0-6: live member agent sessions are aborted before teardown.
+vi.mock("@/server/agent-session-registry", () => ({
+  abortAllWorkspaceMemberSessions: mockAbortAllWorkspaceMemberSessions,
 }));
 
 vi.mock("@/lib/auth/validate-origin", () => ({
@@ -82,20 +101,25 @@ function makeRequest(): Request {
 }
 
 const TEST_USER_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const TEAM_WORKSPACE_ID = "11111111-2222-3333-4444-555555555555";
 
-/** Sets up Supabase mock chain for the users table. */
-function setupUserMocks(opts: {
+/**
+ * Wire the service-role `workspaces` table mock chain.
+ *
+ * The route reads `workspaces.select("repo_status").eq("id", activeId).single()`
+ * for the cloning-guard (ADR-044 PR-2: was `users`). Repo-column CLEAR and the
+ * readiness reset on `users` are handled by separate mocks
+ * (`writeRepoColsToWorkspace`, `mockUpdate`).
+ *
+ * Returns `mockUpdate` so callers can assert the `users.update(...)` readiness
+ * reset (solo path) — or assert it was NOT called (team path).
+ */
+function setupServiceMocks(opts: {
   repoStatus?: string;
   selectError?: { message: string } | null;
   updateError?: { message: string } | null;
-  mirrorError?: { message: string } | null;
 }) {
-  const {
-    repoStatus = "ready",
-    selectError = null,
-    updateError = null,
-    mirrorError = null,
-  } = opts;
+  const { repoStatus = "ready", selectError = null, updateError = null } = opts;
 
   const selectChain = mockQueryChain(
     selectError ? null : { repo_status: repoStatus },
@@ -106,12 +130,14 @@ function setupUserMocks(opts: {
   const mockUpdate = vi.fn(() => ({ eq: mockUpdateEq }));
 
   mockFrom.mockImplementation((table: string) => {
-    if (table === "users") {
-      return { select: selectChain.select, update: mockUpdate };
-    }
-    // ADR-044: workspaces mirror write (mirrorRepoColsToSoloWorkspace).
     if (table === "workspaces") {
-      return { update: () => ({ eq: async () => ({ error: mirrorError }) }) };
+      // Only the cloning-guard select hits this table directly; the CLEAR goes
+      // through the mocked writeRepoColsToWorkspace helper.
+      return { select: selectChain.select };
+    }
+    if (table === "users") {
+      // Solo-only readiness reset (health_snapshot / workspace_status).
+      return { update: mockUpdate };
     }
     return {};
   });
@@ -127,86 +153,187 @@ describe("DELETE /api/repo/disconnect", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsAllowed.mockReturnValue(true);
-    // ADR-044 PR-1 owner-gate: default to owner (solo users always own
-    // workspace_id=user.id). The non-owner case overrides per-test.
+    // ADR-044 PR-1 owner-gate: default to owner. The non-owner case overrides.
     mockRpc.mockResolvedValue({ data: true, error: null });
-    // ADR-044 PR-2a: default the active-workspace resolver to SOLO
-    // (current_workspace_id null → resolveCurrentWorkspaceId returns user.id),
-    // so the team-workspace refusal guard is a no-op for every existing test.
-    mockTenantFrom.mockReturnValue(
-      mockQueryChain({ current_workspace_id: null }, null),
-    );
+    // ADR-044 PR-2: default the resolver to SOLO (active == caller), so every
+    // existing case (cloning-guard, fail-closed clear, idempotency) runs the
+    // solo path unless a team test overrides it.
+    mockResolveActiveWorkspace.mockResolvedValue({
+      ok: true,
+      workspaceId: TEST_USER_ID,
+    });
+    // Default the credential-clear helper to succeed.
+    mockWriteRepoColsToWorkspace.mockResolvedValue(undefined);
   });
 
-  test("returns 422 and refuses when a TEAM workspace is active (ADR-044 PR-2a confused-deputy guard)", async () => {
-    const TEAM_WORKSPACE_ID = "11111111-2222-3333-4444-555555555555";
+  // -------------------------------------------------------------------------
+  // ADR-044 PR-2 team write-cutover
+  // -------------------------------------------------------------------------
+
+  test("team workspace active + owner → proceeds and tears down the TEAM workspace (200)", async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
-    // Active workspace is a TEAM (≠ user.id). Team on-disk provisioning is
-    // #5462/Phase-5; until then a disconnect would SILENTLY tear down the
-    // caller's PERSONAL solo connection (confused deputy). Refuse explicitly.
-    mockTenantFrom.mockReturnValue(
-      mockQueryChain({ current_workspace_id: TEAM_WORKSPACE_ID }, null),
-    );
-    const { mockUpdate } = setupUserMocks({ repoStatus: "ready" });
-
-    const res = await DELETE(makeRequest());
-    expect(res.status).toBe(422);
-    const body = await res.json();
-    expect(body.error).toMatch(/team workspace/i);
-
-    // The refusal precedes the owner-gate AND every mutation.
-    expect(mockRpc).not.toHaveBeenCalled();
-    expect(mockUpdate).not.toHaveBeenCalled();
-    expect(mockDeleteWorkspace).not.toHaveBeenCalled();
-  });
-
-  test("solo active workspace (current_workspace_id === user.id) is unaffected by the team guard", async () => {
-    mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
-    mockTenantFrom.mockReturnValue(
-      mockQueryChain({ current_workspace_id: TEST_USER_ID }, null),
-    );
-    setupUserMocks({ repoStatus: "ready" });
+    mockResolveActiveWorkspace.mockResolvedValue({
+      ok: true,
+      workspaceId: TEAM_WORKSPACE_ID,
+    });
+    const { mockUpdate } = setupServiceMocks({ repoStatus: "ready" });
     mockDeleteWorkspace.mockResolvedValue(undefined);
 
     const res = await DELETE(makeRequest());
     expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // Owner-gate is keyed to the RESOLVED active (team) id, NOT user.id.
+    expect(mockRpc).toHaveBeenCalledWith("is_workspace_owner", {
+      p_workspace_id: TEAM_WORKSPACE_ID,
+      p_user_id: TEST_USER_ID,
+    });
+
+    // The repo columns are cleared AUTHORITATIVELY on the team workspaces row.
+    expect(mockWriteRepoColsToWorkspace).toHaveBeenCalledWith(
+      expect.anything(),
+      TEAM_WORKSPACE_ID,
+      {
+        github_installation_id: null,
+        repo_url: null,
+        repo_status: "not_connected",
+        repo_last_synced_at: null,
+        repo_error: null,
+      },
+      { throwOnError: true },
+    );
+
+    // Live member sessions aborted before teardown, keyed to the team id.
+    expect(mockAbortAllWorkspaceMemberSessions).toHaveBeenCalledWith(
+      TEAM_WORKSPACE_ID,
+      TEST_USER_ID,
+    );
+
+    // The team directory is torn down (NOT the caller's solo dir).
+    expect(mockDeleteWorkspace).toHaveBeenCalledWith(TEAM_WORKSPACE_ID);
+
+    // CRITICAL: the team path must NOT reset the caller's `users` readiness —
+    // doing so corrupts their personal solo readiness and other owned teams.
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 
-  test("returns 403 when the caller is not the workspace owner (ADR-044 owner-gate)", async () => {
+  test("team workspace active + NON-owner → 403 before any mutation (owner-gate)", async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
+    mockResolveActiveWorkspace.mockResolvedValue({
+      ok: true,
+      workspaceId: TEAM_WORKSPACE_ID,
+    });
     mockRpc.mockResolvedValueOnce({ data: false, error: null });
-    setupUserMocks({ repoStatus: "ready" });
+    const { mockUpdate } = setupServiceMocks({ repoStatus: "ready" });
 
     const res = await DELETE(makeRequest());
     expect(res.status).toBe(403);
-    // The owner-gate must short-circuit BEFORE any mutation.
+    const body = await res.json();
+    expect(body.error).toMatch(/owner/i);
+
+    // Owner-gate keyed to the RESOLVED active (team) id.
+    expect(mockRpc).toHaveBeenCalledWith("is_workspace_owner", {
+      p_workspace_id: TEAM_WORKSPACE_ID,
+      p_user_id: TEST_USER_ID,
+    });
+
+    // Short-circuit BEFORE any mutation.
+    expect(mockWriteRepoColsToWorkspace).not.toHaveBeenCalled();
+    expect(mockAbortAllWorkspaceMemberSessions).not.toHaveBeenCalled();
     expect(mockDeleteWorkspace).not.toHaveBeenCalled();
-    // p_workspace_id MUST equal the mutated workspace (= user.id in PR-1).
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  test("resolver fails (db-error) → 503 fail-closed, no mutation, no teardown", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
+    mockResolveActiveWorkspace.mockResolvedValue({
+      ok: false,
+      reason: "db-error",
+    });
+    const { mockUpdate } = setupServiceMocks({ repoStatus: "ready" });
+
+    const res = await DELETE(makeRequest());
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toMatch(/active workspace/i);
+
+    // A db-error at this destructive boundary must NEVER silently tear down the
+    // caller's solo workspace under a team claim — fail closed before the
+    // owner-gate AND every mutation.
+    expect(mockRpc).not.toHaveBeenCalled();
+    expect(mockWriteRepoColsToWorkspace).not.toHaveBeenCalled();
+    expect(mockAbortAllWorkspaceMemberSessions).not.toHaveBeenCalled();
+    expect(mockDeleteWorkspace).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  test("solo active workspace → owner-gate keyed to user.id, resets solo readiness, tears down solo dir (200)", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
+    // resolver defaults to solo (workspaceId === user.id).
+    const { mockUpdate } = setupServiceMocks({ repoStatus: "ready" });
+    mockDeleteWorkspace.mockResolvedValue(undefined);
+
+    const res = await DELETE(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
     expect(mockRpc).toHaveBeenCalledWith("is_workspace_owner", {
       p_workspace_id: TEST_USER_ID,
       p_user_id: TEST_USER_ID,
     });
+
+    // Authoritative CLEAR on the caller's own (solo) workspaces row.
+    expect(mockWriteRepoColsToWorkspace).toHaveBeenCalledWith(
+      expect.anything(),
+      TEST_USER_ID,
+      {
+        github_installation_id: null,
+        repo_url: null,
+        repo_status: "not_connected",
+        repo_last_synced_at: null,
+        repo_error: null,
+      },
+      { throwOnError: true },
+    );
+
+    // Solo readiness reset on `users` — ONLY the provisioning/readiness columns,
+    // NEVER a repo column (those are relocated to `workspaces`).
+    expect(mockUpdate).toHaveBeenCalledWith({
+      health_snapshot: null,
+      workspace_status: "provisioning",
+    });
+
+    expect(mockAbortAllWorkspaceMemberSessions).toHaveBeenCalledWith(
+      TEST_USER_ID,
+      TEST_USER_ID,
+    );
+    expect(mockDeleteWorkspace).toHaveBeenCalledWith(TEST_USER_ID);
   });
+
+  // -------------------------------------------------------------------------
+  // Auth / CSRF / rate-limit gates
+  // -------------------------------------------------------------------------
 
   test("returns 401 when unauthenticated", async () => {
     mockGetUser.mockResolvedValue({ data: { user: null } });
 
     const res = await DELETE(makeRequest());
     expect(res.status).toBe(401);
-
     const body = await res.json();
     expect(body.error).toMatch(/unauthorized/i);
+
+    // No resolution / mutation before auth.
+    expect(mockResolveActiveWorkspace).not.toHaveBeenCalled();
   });
 
   test("returns 429 when rate limited", async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: TEST_USER_ID } },
-    });
+    mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
     mockIsAllowed.mockReturnValue(false);
 
     const res = await DELETE(makeRequest());
     expect(res.status).toBe(429);
-
     const body = await res.json();
     expect(body.error).toMatch(/too many/i);
   });
@@ -221,106 +348,146 @@ describe("DELETE /api/repo/disconnect", () => {
     expect(res.status).toBe(403);
   });
 
-  test("returns 409 when repo is currently cloning", async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: TEST_USER_ID } },
-    });
-    setupUserMocks({ repoStatus: "cloning" });
+  // -------------------------------------------------------------------------
+  // Cloning-guard / db-error / fail-closed clear (adapted to workspaces row)
+  // -------------------------------------------------------------------------
+
+  test("returns 409 when the active workspace repo is currently cloning", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
+    setupServiceMocks({ repoStatus: "cloning" });
 
     const res = await DELETE(makeRequest());
     expect(res.status).toBe(409);
-
     const body = await res.json();
     expect(body.error).toMatch(/in progress/i);
+
+    // Guard precedes the destructive clear + teardown.
+    expect(mockWriteRepoColsToWorkspace).not.toHaveBeenCalled();
+    expect(mockDeleteWorkspace).not.toHaveBeenCalled();
   });
 
-  test("returns 500 when select query fails", async () => {
+  test("returns 500 when the workspaces cloning-guard select fails", async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
-    setupUserMocks({ selectError: { message: "database unreachable" } });
+    setupServiceMocks({ selectError: { message: "database unreachable" } });
 
     const res = await DELETE(makeRequest());
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toMatch(/failed to disconnect/i);
+
+    expect(mockWriteRepoColsToWorkspace).not.toHaveBeenCalled();
+    expect(mockDeleteWorkspace).not.toHaveBeenCalled();
   });
 
-  test("returns 200 and clears all repo fields on successful disconnect", async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: TEST_USER_ID } },
-    });
-    const { mockUpdate } = setupUserMocks({ repoStatus: "ready" });
+  test("returns 500 when the owner-gate rpc errors", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
+    mockRpc.mockResolvedValueOnce({ data: null, error: { message: "rpc boom" } });
+    setupServiceMocks({ repoStatus: "ready" });
+
+    const res = await DELETE(makeRequest());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/failed to disconnect/i);
+
+    expect(mockWriteRepoColsToWorkspace).not.toHaveBeenCalled();
+    expect(mockDeleteWorkspace).not.toHaveBeenCalled();
+  });
+
+  test("returns 500 when the credential-clear fails CLOSED (ADR-044, helper throws)", async () => {
+    // The read path is workspaces-only; a silently-failed clear would leave
+    // github_installation_id + repo_url live (caller appears connected, agent
+    // can still act under the revoked grant). The helper throws on db-error OR
+    // 0-row no-op, so the route surfaces a 500 and the (idempotent) disconnect
+    // is retried rather than falsely reporting success.
+    mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
+    setupServiceMocks({ repoStatus: "ready" });
+    mockWriteRepoColsToWorkspace.mockRejectedValue(
+      new Error("mirror write failed"),
+    );
     mockDeleteWorkspace.mockResolvedValue(undefined);
 
     const res = await DELETE(makeRequest());
-    expect(res.status).toBe(200);
-
+    expect(res.status).toBe(500);
     const body = await res.json();
-    expect(body.ok).toBe(true);
+    expect(body.error).toMatch(/failed to disconnect/i);
 
-    expect(mockUpdate).toHaveBeenCalledWith({
-      github_installation_id: null,
-      repo_url: null,
-      repo_status: "not_connected",
-      repo_last_synced_at: null,
-      repo_error: null,
-      health_snapshot: null,
-      workspace_path: "",
-      workspace_status: "provisioning",
-    });
-
-    expect(mockDeleteWorkspace).toHaveBeenCalledWith(TEST_USER_ID);
+    // Failed CLOSED: teardown does NOT proceed after a failed credential clear.
+    expect(mockDeleteWorkspace).not.toHaveBeenCalled();
   });
 
   test("workspace cleanup failure still returns 200 (best-effort)", async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: TEST_USER_ID } },
-    });
-    setupUserMocks({ repoStatus: "ready" });
-    mockDeleteWorkspace.mockRejectedValue(new Error("Directory already removed"));
+    mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
+    setupServiceMocks({ repoStatus: "ready" });
+    mockDeleteWorkspace.mockRejectedValue(
+      new Error("Directory already removed"),
+    );
 
     const res = await DELETE(makeRequest());
     expect(res.status).toBe(200);
-
     const body = await res.json();
     expect(body.ok).toBe(true);
+
+    // The credential WAS cleared before the best-effort teardown failed.
+    expect(mockWriteRepoColsToWorkspace).toHaveBeenCalled();
   });
 
-  test("returns 500 when database update fails", async () => {
+  test("returns 200 idempotently when the active workspace has no connected repo", async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
-    setupUserMocks({ repoStatus: "ready", updateError: { message: "constraint violation" } });
-
-    const res = await DELETE(makeRequest());
-    expect(res.status).toBe(500);
-    const body = await res.json();
-    expect(body.error).toMatch(/failed to disconnect/i);
-  });
-
-  test("returns 500 when the workspaces mirror fails (credential-clear fails closed, ADR-044)", async () => {
-    // The read path is workspaces-only; a silently-failed disconnect mirror
-    // would leave github_installation_id + repo_url live. Disconnect must fail
-    // closed so the (idempotent) operation is retried rather than reporting a
-    // disconnect that left the credential readable.
-    mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
-    setupUserMocks({ repoStatus: "ready", mirrorError: { message: "mirror write failed" } });
-    mockDeleteWorkspace.mockResolvedValue(undefined);
-
-    const res = await DELETE(makeRequest());
-    expect(res.status).toBe(500);
-    const body = await res.json();
-    expect(body.error).toMatch(/failed to disconnect/i);
-  });
-
-  test("returns 200 idempotently when user has no connected repo", async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: TEST_USER_ID } },
-    });
-    setupUserMocks({ repoStatus: "not_connected" });
+    setupServiceMocks({ repoStatus: "not_connected" });
     mockDeleteWorkspace.mockResolvedValue(undefined);
 
     const res = await DELETE(makeRequest());
     expect(res.status).toBe(200);
-
     const body = await res.json();
     expect(body.ok).toBe(true);
+
+    // Still clears authoritatively (idempotent no-op clear) and tears down.
+    expect(mockWriteRepoColsToWorkspace).toHaveBeenCalled();
+    expect(mockDeleteWorkspace).toHaveBeenCalledWith(TEST_USER_ID);
+  });
+
+  // -------------------------------------------------------------------------
+  // ADR-044 exit criterion: ZERO repo-column writes to `users` on ANY path.
+  // The whole point of PR-2 — repo state is authoritative on `workspaces`.
+  // -------------------------------------------------------------------------
+
+  test("NO repo-column write to `users` occurs on ANY path (solo + team)", async () => {
+    const repoCols = ["repo_url", "github_installation_id", "repo_error"];
+
+    // Solo path.
+    {
+      mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
+      const { mockUpdate } = setupServiceMocks({ repoStatus: "ready" });
+      mockDeleteWorkspace.mockResolvedValue(undefined);
+
+      const res = await DELETE(makeRequest());
+      expect(res.status).toBe(200);
+
+      for (const call of mockUpdate.mock.calls) {
+        const patch = ((call as unknown[])[0] ?? {}) as Record<string, unknown>;
+        for (const col of repoCols) {
+          expect(patch).not.toHaveProperty(col);
+        }
+      }
+    }
+
+    // Team path — `users.update` must not be called at all.
+    {
+      vi.clearAllMocks();
+      mockIsAllowed.mockReturnValue(true);
+      mockRpc.mockResolvedValue({ data: true, error: null });
+      mockWriteRepoColsToWorkspace.mockResolvedValue(undefined);
+      mockGetUser.mockResolvedValue({ data: { user: { id: TEST_USER_ID } } });
+      mockResolveActiveWorkspace.mockResolvedValue({
+        ok: true,
+        workspaceId: TEAM_WORKSPACE_ID,
+      });
+      const { mockUpdate } = setupServiceMocks({ repoStatus: "ready" });
+      mockDeleteWorkspace.mockResolvedValue(undefined);
+
+      const res = await DELETE(makeRequest());
+      expect(res.status).toBe(200);
+      expect(mockUpdate).not.toHaveBeenCalled();
+    }
   });
 });

--- a/apps/web-platform/test/disconnect-route.test.ts
+++ b/apps/web-platform/test/disconnect-route.test.ts
@@ -13,7 +13,7 @@ const {
   mockRpc,
   mockResolveActiveWorkspace,
   mockWriteRepoColsToWorkspace,
-  mockAbortAllWorkspaceMemberSessions,
+  mockAbortAllSessionsForWorkspace,
 } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
   mockFrom: vi.fn(),
@@ -22,7 +22,7 @@ const {
   mockRpc: vi.fn(),
   mockResolveActiveWorkspace: vi.fn(),
   mockWriteRepoColsToWorkspace: vi.fn(),
-  mockAbortAllWorkspaceMemberSessions: vi.fn(),
+  mockAbortAllSessionsForWorkspace: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/server", () => ({
@@ -55,7 +55,7 @@ vi.mock("@/server/workspace-repo-mirror", () => ({
 
 // ADR-044 PR-2 / P0-6: live member agent sessions are aborted before teardown.
 vi.mock("@/server/agent-session-registry", () => ({
-  abortAllWorkspaceMemberSessions: mockAbortAllWorkspaceMemberSessions,
+  abortAllSessionsForWorkspace: mockAbortAllSessionsForWorkspace,
 }));
 
 vi.mock("@/lib/auth/validate-origin", () => ({
@@ -204,10 +204,10 @@ describe("DELETE /api/repo/disconnect", () => {
       { throwOnError: true },
     );
 
-    // Live member sessions aborted before teardown, keyed to the team id.
-    expect(mockAbortAllWorkspaceMemberSessions).toHaveBeenCalledWith(
+    // ALL live member sessions bound to the team workspace aborted before
+    // teardown (keyed to the team id, not the disconnecter).
+    expect(mockAbortAllSessionsForWorkspace).toHaveBeenCalledWith(
       TEAM_WORKSPACE_ID,
-      TEST_USER_ID,
     );
 
     // The team directory is torn down (NOT the caller's solo dir).
@@ -240,7 +240,7 @@ describe("DELETE /api/repo/disconnect", () => {
 
     // Short-circuit BEFORE any mutation.
     expect(mockWriteRepoColsToWorkspace).not.toHaveBeenCalled();
-    expect(mockAbortAllWorkspaceMemberSessions).not.toHaveBeenCalled();
+    expect(mockAbortAllSessionsForWorkspace).not.toHaveBeenCalled();
     expect(mockDeleteWorkspace).not.toHaveBeenCalled();
     expect(mockUpdate).not.toHaveBeenCalled();
   });
@@ -263,7 +263,7 @@ describe("DELETE /api/repo/disconnect", () => {
     // owner-gate AND every mutation.
     expect(mockRpc).not.toHaveBeenCalled();
     expect(mockWriteRepoColsToWorkspace).not.toHaveBeenCalled();
-    expect(mockAbortAllWorkspaceMemberSessions).not.toHaveBeenCalled();
+    expect(mockAbortAllSessionsForWorkspace).not.toHaveBeenCalled();
     expect(mockDeleteWorkspace).not.toHaveBeenCalled();
     expect(mockUpdate).not.toHaveBeenCalled();
   });
@@ -305,8 +305,7 @@ describe("DELETE /api/repo/disconnect", () => {
       workspace_status: "provisioning",
     });
 
-    expect(mockAbortAllWorkspaceMemberSessions).toHaveBeenCalledWith(
-      TEST_USER_ID,
+    expect(mockAbortAllSessionsForWorkspace).toHaveBeenCalledWith(
       TEST_USER_ID,
     );
     expect(mockDeleteWorkspace).toHaveBeenCalledWith(TEST_USER_ID);

--- a/apps/web-platform/test/e2e-oauth-tc-consent.test.ts
+++ b/apps/web-platform/test/e2e-oauth-tc-consent.test.ts
@@ -52,6 +52,14 @@ vi.mock("@/server/byok-resolver", () => ({
   userHasEffectiveByokKey: mockUserHasEffectiveByokKey,
 }));
 
+// ADR-044 PR-2 (#5462): the callback resolves the active workspace before
+// reading repo_status from the `workspaces` table. Stub the resolver to the
+// test user id (solo workspace id === user id per the N2 invariant) so the
+// WORKSPACES read targets a row our service-client mock recognizes.
+vi.mock("@/server/workspace-resolver", () => ({
+  resolveCurrentWorkspaceId: vi.fn(async () => USER_ID),
+}));
+
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({
     auth: {
@@ -137,41 +145,27 @@ function makeCallbackRequest(code: string, extraQuery = ""): NextRequest {
 }
 
 /**
- * Wire the service `users` table for the fully-onboarded path: the
- * ensureWorkspaceProvisioned select (workspace_status, tc_accepted_version)
- * AND the repo_status select both resolve. tcVersion drives the T&C gate;
- * repoStatus drives connect-repo vs the terminal hop.
+ * Wire the service clients for the fully-onboarded path. Post-ADR-044 PR-2
+ * (#5462) the callback reads from THREE select shapes:
+ *   - users.select(workspace_status, tc_accepted_version).single()  [provision]
+ *   - users.select(setup_key_skipped_at).single()                   [skip flag]
+ *   - workspaces.select(repo_status).maybeSingle()                  [repo status]
+ * tcVersion drives the T&C gate; repoStatus drives connect-repo vs the terminal
+ * hop. setup_key_skipped_at defaults null here (no skip).
  */
 function stubServiceUsersFullyOnboarded(
   tcVersion: string | null,
   repoStatus: string,
 ): void {
-  mockServiceFrom.mockImplementation((table: string) => {
-    if (table !== "users") {
-      return { select: vi.fn(), update: vi.fn(), upsert: vi.fn() };
-    }
-    const select = vi.fn((columns: string) => {
-      if (typeof columns === "string" && columns.includes("repo_status")) {
-        const single = vi.fn().mockResolvedValue({
-          data: { repo_status: repoStatus },
-          error: null,
-        });
-        return { eq: vi.fn().mockReturnValue({ single }) };
-      }
-      const single = vi.fn().mockResolvedValue({
-        data: { workspace_status: "ready", tc_accepted_version: tcVersion },
-        error: null,
-      });
-      return { eq: vi.fn().mockReturnValue({ single }) };
-    });
-    return { select, update: vi.fn(), upsert: vi.fn() };
-  });
+  stubServiceUsersWithSkip(tcVersion, repoStatus, null);
 }
 
 /**
- * Like stubServiceUsersFullyOnboarded but also drives `setup_key_skipped_at` on
- * the repo_status select, so the keyless-SKIPPED branch (callback:261-268) can
- * be exercised. A non-null `skippedAt` means the user chose "Set up later".
+ * Like stubServiceUsersFullyOnboarded but lets the caller drive
+ * `setup_key_skipped_at` (read from the `users` table via .single()), so the
+ * keyless-SKIPPED branch can be exercised. A non-null `skippedAt` means the
+ * user chose "Set up later". `repo_status` is now AUTHORITATIVE on the
+ * `workspaces` row (ADR-044 PR-2) and is served via .maybeSingle().
  */
 function stubServiceUsersWithSkip(
   tcVersion: string | null,
@@ -179,13 +173,27 @@ function stubServiceUsersWithSkip(
   skippedAt: string | null,
 ): void {
   mockServiceFrom.mockImplementation((table: string) => {
+    if (table === "workspaces") {
+      const maybeSingle = vi.fn().mockResolvedValue({
+        data: { repo_status: repoStatus },
+        error: null,
+      });
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({ maybeSingle }),
+        }),
+      };
+    }
     if (table !== "users") {
       return { select: vi.fn(), update: vi.fn(), upsert: vi.fn() };
     }
     const select = vi.fn((columns: string) => {
-      if (typeof columns === "string" && columns.includes("repo_status")) {
+      if (
+        typeof columns === "string" &&
+        columns.includes("setup_key_skipped_at")
+      ) {
         const single = vi.fn().mockResolvedValue({
-          data: { repo_status: repoStatus, setup_key_skipped_at: skippedAt },
+          data: { setup_key_skipped_at: skippedAt },
           error: null,
         });
         return { eq: vi.fn().mockReturnValue({ single }) };

--- a/apps/web-platform/test/install-route-handler.test.ts
+++ b/apps/web-platform/test/install-route-handler.test.ts
@@ -7,10 +7,12 @@ import { describe, test, expect, vi, beforeEach } from "vitest";
 const mockGetUser = vi.fn();
 const mockServiceFrom = vi.fn();
 const mockAdminGetUserById = vi.fn();
+const mockRpc = vi.fn();
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: async () => ({
     auth: { getUser: mockGetUser },
+    rpc: mockRpc,
   }),
   createServiceClient: () => ({
     from: mockServiceFrom,
@@ -32,8 +34,20 @@ vi.mock("@/server/github-app", () => ({
   getInstallationAccount: vi.fn(),
 }));
 
+// ADR-044 PR-2: the install write lands on the active `workspaces` row via the
+// service client. resolveActiveWorkspace defaults to the solo identity
+// (workspaceId === user.id); writeRepoColsToWorkspace is the authoritative write.
+vi.mock("@/server/workspace-resolver", () => ({
+  resolveActiveWorkspace: vi.fn(),
+}));
+vi.mock("@/server/workspace-repo-mirror", () => ({
+  writeRepoColsToWorkspace: vi.fn(),
+}));
+
 import { POST } from "../app/api/repo/install/route";
 import { verifyInstallationOwnership as mockVerifyOwnership, getInstallationAccount as mockGetInstallationAccount } from "../server/github-app";
+import { resolveActiveWorkspace as mockResolveActiveWorkspace } from "../server/workspace-resolver";
+import { writeRepoColsToWorkspace as mockWriteRepoColsToWorkspace } from "../server/workspace-repo-mirror";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -72,11 +86,14 @@ describe("POST /api/repo/install — identity resolution", () => {
     (mockVerifyOwnership as ReturnType<typeof vi.fn>).mockResolvedValue({
       verified: true,
     });
-    mockServiceFrom.mockReturnValue({
-      update: vi.fn().mockReturnValue({
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      }),
-    });
+    // Active workspace resolves to the solo identity by default.
+    vi.mocked(mockResolveActiveWorkspace).mockImplementation(
+      async (userId: string) => ({ ok: true, workspaceId: userId }) as never,
+    );
+    // Owner-gate rpc("is_workspace_owner") passes by default.
+    mockRpc.mockResolvedValue({ data: true, error: null });
+    // Authoritative workspaces write succeeds by default.
+    vi.mocked(mockWriteRepoColsToWorkspace).mockResolvedValue(undefined as never);
   });
 
   test("succeeds when user.identities is null but admin API has GitHub record", async () => {
@@ -99,6 +116,15 @@ describe("POST /api/repo/install — identity resolution", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
+
+    // ADR-044 PR-2: the installation lands on the active workspaces row, keyed
+    // on the resolved solo id (=== user.id) — NOT via users.update.
+    expect(mockWriteRepoColsToWorkspace).toHaveBeenCalledWith(
+      expect.anything(),
+      "user-abc",
+      { github_installation_id: 100 },
+      { throwOnError: true },
+    );
   });
 
   test("email-only user via admin API: succeeds when installation exists", async () => {
@@ -121,14 +147,15 @@ describe("POST /api/repo/install — identity resolution", () => {
       id: 1,
       type: "User",
     });
-    mockServiceFrom.mockReturnValue({
-      update: vi.fn().mockReturnValue({
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      }),
-    });
 
     const res = await POST(makeRequest({ installationId: 100 }));
     expect(res.status).toBe(200);
+    expect(mockWriteRepoColsToWorkspace).toHaveBeenCalledWith(
+      expect.anything(),
+      "user-xyz",
+      { github_installation_id: 100 },
+      { throwOnError: true },
+    );
   });
 
   test("succeeds when admin API returns GitHub identity (standard flow)", async () => {
@@ -172,14 +199,15 @@ describe("POST /api/repo/install — identity resolution", () => {
       id: 1,
       type: "User",
     });
-    mockServiceFrom.mockReturnValue({
-      update: vi.fn().mockReturnValue({
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      }),
-    });
 
     const res = await POST(makeRequest({ installationId: 100 }));
     expect(res.status).toBe(200);
+    expect(mockWriteRepoColsToWorkspace).toHaveBeenCalledWith(
+      expect.anything(),
+      "user-email-only",
+      { github_installation_id: 100 },
+      { throwOnError: true },
+    );
   });
 
   test("email-only user: returns 404 when installation does not exist", async () => {
@@ -220,5 +248,79 @@ describe("POST /api/repo/install — identity resolution", () => {
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toMatch(/failed to resolve/i);
+  });
+
+  // --- ADR-044 PR-2: active-workspace resolution + owner-gate + write cutover ---
+
+  function mockGithubUser(id: string) {
+    mockGetUser.mockResolvedValue({
+      data: {
+        user: {
+          id,
+          identities: [
+            { provider: "github", identity_data: { user_name: "alice" } },
+          ],
+          app_metadata: { providers: ["github"] },
+        },
+      },
+    });
+    mockIdentitiesQuery(id, [
+      { provider: "github", identity_data: { user_name: "alice" } },
+    ]);
+  }
+
+  test("returns 503 when the active workspace cannot be resolved (db-error)", async () => {
+    mockGithubUser("user-503");
+    vi.mocked(mockResolveActiveWorkspace).mockResolvedValue({
+      ok: false,
+      reason: "db-error",
+    } as never);
+
+    const res = await POST(makeRequest({ installationId: 100 }));
+    expect(res.status).toBe(503);
+    // Fail-closed before any credential write.
+    expect(mockWriteRepoColsToWorkspace).not.toHaveBeenCalled();
+  });
+
+  test("returns 403 when the caller is not the workspace owner (owner-gate)", async () => {
+    mockGithubUser("user-403");
+    mockRpc.mockResolvedValue({ data: false, error: null });
+
+    const res = await POST(makeRequest({ installationId: 100 }));
+    expect(res.status).toBe(403);
+    expect(mockWriteRepoColsToWorkspace).not.toHaveBeenCalled();
+  });
+
+  test("returns 500 when the workspaces write fails (fail-closed)", async () => {
+    mockGithubUser("user-write-fail");
+    vi.mocked(mockWriteRepoColsToWorkspace).mockRejectedValue(
+      new Error("0-row no-op"),
+    );
+
+    const res = await POST(makeRequest({ installationId: 100 }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/failed to store/i);
+  });
+
+  test("never performs a users.update({ github_installation_id }) write", async () => {
+    mockGithubUser("user-no-users-update");
+
+    const res = await POST(makeRequest({ installationId: 100 }));
+    expect(res.status).toBe(200);
+    // The legacy users-row write must be gone — the only write goes through the
+    // workspaces mirror. serviceClient.from() must never be invoked for "users".
+    expect(mockServiceFrom).not.toHaveBeenCalledWith("users");
+    expect(mockWriteRepoColsToWorkspace).toHaveBeenCalledTimes(1);
+  });
+
+  test("owner-gate rpc is invoked on the tenant client keyed on the active workspace", async () => {
+    mockGithubUser("user-rpc-args");
+
+    await POST(makeRequest({ installationId: 100 }));
+    expect(mockRpc).toHaveBeenCalledWith("is_workspace_owner", {
+      p_workspace_id: "user-rpc-args",
+      p_user_id: "user-rpc-args",
+    });
   });
 });

--- a/apps/web-platform/test/install-route.test.ts
+++ b/apps/web-platform/test/install-route.test.ts
@@ -278,12 +278,24 @@ vi.mock("next/server", () => ({
   },
 }));
 
+// ADR-044 PR-2: the install write is now an authoritative write to the active
+// `workspaces` row via writeRepoColsToWorkspace, keyed on the membership-verified
+// id from resolveActiveWorkspace (defaults to the solo identity here).
+vi.mock("@/server/workspace-resolver", () => ({
+  resolveActiveWorkspace: vi.fn(),
+}));
+vi.mock("@/server/workspace-repo-mirror", () => ({
+  writeRepoColsToWorkspace: vi.fn(),
+}));
+
 import { POST } from "../app/api/repo/install/route";
 import {
   createClient as mockCreateClient,
   createServiceClient as mockCreateServiceClient,
 } from "@/lib/supabase/server";
 import { validateOrigin as mockValidateOrigin } from "@/lib/auth/validate-origin";
+import { resolveActiveWorkspace as mockResolveActiveWorkspace } from "@/server/workspace-resolver";
+import { writeRepoColsToWorkspace as mockWriteRepoColsToWorkspace } from "@/server/workspace-repo-mirror";
 
 describe("install route behavioral enforcement", () => {
   beforeEach(() => {
@@ -291,6 +303,12 @@ describe("install route behavioral enforcement", () => {
       valid: true,
       origin: "https://app.soleur.ai",
     });
+    // Active workspace resolves to the solo identity (workspaceId === user.id).
+    vi.mocked(mockResolveActiveWorkspace).mockImplementation(
+      async (userId: string) => ({ ok: true, workspaceId: userId }) as never,
+    );
+    // Authoritative workspaces write succeeds by default.
+    vi.mocked(mockWriteRepoColsToWorkspace).mockResolvedValue(undefined as never);
   });
 
   test("email-only user: succeeds when installation exists (existence-verified)", async () => {
@@ -309,6 +327,8 @@ describe("install route behavioral enforcement", () => {
           },
         }),
       },
+      // Owner-gate rpc("is_workspace_owner") passes for the solo owner.
+      rpc: vi.fn().mockResolvedValue({ data: true, error: null }),
     } as never);
 
     // Mock createServiceClient — returns a service client whose
@@ -357,6 +377,16 @@ describe("install route behavioral enforcement", () => {
 
     const response = await POST(request);
     expect(response.status).toBe(200);
+
+    // ADR-044 PR-2: the installation lands on the active workspaces row (keyed
+    // on the resolved solo id === user.id), NOT via a users.update.
+    expect(mockWriteRepoColsToWorkspace).toHaveBeenCalledWith(
+      expect.anything(),
+      userId,
+      { github_installation_id: 42 },
+      { throwOnError: true },
+    );
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 });
 
@@ -365,16 +395,20 @@ describe("install route behavioral enforcement", () => {
 // ---------------------------------------------------------------------------
 
 describe("install route structural enforcement", () => {
-  test("verifyInstallationOwnership is called before .update() in route source", () => {
+  test("verifyInstallationOwnership is called before the installation write in route source", () => {
     const routeSource = readFileSync(
       join(__dirname, "../app/api/repo/install/route.ts"),
       "utf-8",
     );
     const verifyIndex = routeSource.indexOf("verifyInstallationOwnership");
-    const updateIndex = routeSource.indexOf(".update({ github_installation_id");
+    // ADR-044 PR-2: the write is now writeRepoColsToWorkspace(...) to the active
+    // workspaces row, not serviceClient.from("users").update(...).
+    const writeIndex = routeSource.indexOf("writeRepoColsToWorkspace(");
     expect(verifyIndex).toBeGreaterThan(-1);
-    expect(updateIndex).toBeGreaterThan(-1);
-    expect(verifyIndex).toBeLessThan(updateIndex);
+    expect(writeIndex).toBeGreaterThan(-1);
+    expect(verifyIndex).toBeLessThan(writeIndex);
+    // The legacy users-row credential write must be gone entirely.
+    expect(routeSource).not.toMatch(/\.update\(\{\s*github_installation_id/);
   });
 
   test("githubLogin assignment does not reference user_metadata for user_name", () => {

--- a/apps/web-platform/test/repo-status-health-snapshot.test.ts
+++ b/apps/web-platform/test/repo-status-health-snapshot.test.ts
@@ -4,33 +4,57 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Mock Supabase before importing the route
 // ---------------------------------------------------------------------------
 
-const mockSelect = vi.fn();
-const mockEq = vi.fn();
-const mockSingle = vi.fn();
-const mockMaybeSingle = vi.fn();
-
-const { mockResolveActiveWorkspacePath, mockExistsSync } = vi.hoisted(() => ({
+// ADR-044 PR-2 (#5462): the repo-connection columns are authoritative on the
+// ACTIVE `workspaces` row. The route reads them via
+// `workspaces.select(...).eq("id", activeWorkspaceId).maybeSingle()`
+// (`mockWorkspaceMaybeSingle`) and `health_snapshot` via
+// `users.select("health_snapshot").eq("id", user.id).maybeSingle()`
+// (`mockUserMaybeSingle`), both in a Promise.all. The active id is resolved via
+// the mocked `resolveCurrentWorkspaceId` (defaults to the caller's own id).
+const {
+  mockResolveActiveWorkspacePath,
+  mockResolveCurrentWorkspaceId,
+  mockExistsSync,
+  mockWorkspaceMaybeSingle,
+  mockUserMaybeSingle,
+  mockConvMaybeSingle,
+} = vi.hoisted(() => ({
   mockResolveActiveWorkspacePath: vi.fn(),
+  mockResolveCurrentWorkspaceId: vi.fn(),
   mockExistsSync: vi.fn((_p?: unknown) => false),
+  mockWorkspaceMaybeSingle: vi.fn(),
+  mockUserMaybeSingle: vi.fn(),
+  mockConvMaybeSingle: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/server", () => {
-  // Chain builder for conversations query (select → eq → eq → eq → order → limit → maybeSingle)
+  // conversations: select → eq → eq → eq → order → limit → maybeSingle
   const convChain = {
     select: vi.fn(() => convChain),
     eq: vi.fn(() => convChain),
     order: vi.fn(() => convChain),
     limit: vi.fn(() => convChain),
-    maybeSingle: mockMaybeSingle,
+    maybeSingle: mockConvMaybeSingle,
+  };
+  // workspaces: select → eq("id", …) → maybeSingle (repo cols)
+  const wsChain = {
+    select: vi.fn(() => wsChain),
+    eq: vi.fn(() => wsChain),
+    maybeSingle: mockWorkspaceMaybeSingle,
+  };
+  // users: select("health_snapshot") → eq("id", …) → maybeSingle
+  const userChain = {
+    select: vi.fn(() => userChain),
+    eq: vi.fn(() => userChain),
+    maybeSingle: mockUserMaybeSingle,
   };
 
   const mockFrom = vi.fn((table: string) => {
     if (table === "conversations") return convChain;
-    // Default: users table chain
-    return { select: mockSelect };
+    if (table === "workspaces") return wsChain;
+    if (table === "users") return userChain;
+    throw new Error(`unexpected service-role table ${table}`);
   });
-  mockSelect.mockReturnValue({ eq: mockEq });
-  mockEq.mockReturnValue({ single: mockSingle });
 
   return {
     createClient: vi.fn(async () => ({
@@ -47,9 +71,12 @@ vi.mock("@/lib/supabase/server", () => {
 });
 
 // #5005 — `hasKnowledgeBase` is computed from the resolver's ACTIVE workspace
-// path, not the caller's own `users.workspace_path` column.
+// path, not the caller's own `users.workspace_path` column. ADR-044 PR-2: the
+// repo cols are read from the active `workspaces` row keyed on
+// `resolveCurrentWorkspaceId` (defaults to the caller's own id here).
 vi.mock("@/server/workspace-resolver", () => ({
   resolveActiveWorkspacePath: mockResolveActiveWorkspacePath,
+  resolveCurrentWorkspaceId: mockResolveCurrentWorkspaceId,
 }));
 
 vi.mock("fs", async () => {
@@ -66,6 +93,8 @@ describe("GET /api/repo/status — health_snapshot", () => {
     vi.clearAllMocks();
     mockExistsSync.mockReturnValue(false);
     mockResolveActiveWorkspacePath.mockResolvedValue("/workspaces/user-123");
+    // Active workspace defaults to the caller's own id (solo).
+    mockResolveCurrentWorkspaceId.mockResolvedValue("user-123");
   });
 
   it("includes healthSnapshot and syncConversationId in response when stored", async () => {
@@ -80,19 +109,24 @@ describe("GET /api/repo/status — health_snapshot", () => {
       kbExists: false,
     };
 
-    mockSingle.mockResolvedValue({
+    // Repo cols live on the active `workspaces` row (ADR-044 PR-2).
+    mockWorkspaceMaybeSingle.mockResolvedValue({
       data: {
         repo_url: "https://github.com/user/repo",
         repo_status: "ready",
         repo_last_synced_at: "2026-04-10T00:00:00.000Z",
         repo_error: null,
-        health_snapshot: snapshot,
       },
+      error: null,
+    });
+    // health_snapshot stays on `users`.
+    mockUserMaybeSingle.mockResolvedValue({
+      data: { health_snapshot: snapshot },
       error: null,
     });
 
     // Active sync conversation exists
-    mockMaybeSingle.mockResolvedValue({
+    mockConvMaybeSingle.mockResolvedValue({
       data: { id: "conv-abc" },
       error: null,
     });
@@ -107,22 +141,31 @@ describe("GET /api/repo/status — health_snapshot", () => {
     expect(body.healthSnapshot).toEqual(snapshot);
     expect(body.syncConversationId).toBe("conv-abc");
     expect(body.status).toBe("ready");
+    expect(body.repoUrl).toBe("https://github.com/user/repo");
+    expect(body.lastSyncedAt).toBe("2026-04-10T00:00:00.000Z");
+    expect(mockResolveCurrentWorkspaceId).toHaveBeenCalledWith(
+      "user-123",
+      expect.anything(),
+    );
   });
 
   it("returns syncConversationId as null when no active sync conversation (#1816)", async () => {
-    mockSingle.mockResolvedValue({
+    mockWorkspaceMaybeSingle.mockResolvedValue({
       data: {
         repo_url: "https://github.com/user/repo",
         repo_status: "ready",
         repo_last_synced_at: "2026-04-10T00:00:00.000Z",
         repo_error: null,
-        health_snapshot: null,
       },
+      error: null,
+    });
+    mockUserMaybeSingle.mockResolvedValue({
+      data: { health_snapshot: null },
       error: null,
     });
 
     // No active sync conversation
-    mockMaybeSingle.mockResolvedValue({
+    mockConvMaybeSingle.mockResolvedValue({
       data: null,
       error: null,
     });
@@ -148,17 +191,20 @@ describe("GET /api/repo/status — health_snapshot", () => {
       String(p) === `${ACTIVE_PATH}/knowledge-base`,
     );
 
-    mockSingle.mockResolvedValue({
+    mockWorkspaceMaybeSingle.mockResolvedValue({
       data: {
         repo_url: "https://github.com/user/repo",
         repo_status: "ready",
         repo_last_synced_at: null,
         repo_error: null,
-        health_snapshot: null,
       },
       error: null,
     });
-    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+    mockUserMaybeSingle.mockResolvedValue({
+      data: { health_snapshot: null },
+      error: null,
+    });
+    mockConvMaybeSingle.mockResolvedValue({ data: null, error: null });
 
     const { GET } = await import("@/app/api/repo/status/route");
     const res = await GET();

--- a/apps/web-platform/test/setup-route-health-scanner.test.ts
+++ b/apps/web-platform/test/setup-route-health-scanner.test.ts
@@ -9,6 +9,7 @@ const {
   mockScanProjectHealth,
   mockProvisionWorkspaceWithRepo,
   mockSupabaseUpdate,
+  mockSupabaseUserUpdate,
   mockSupabaseEq,
   mockSupabaseNeq,
   mockSupabaseSelect,
@@ -21,19 +22,24 @@ const {
   const mockSupabaseSelect = vi.fn();
   const mockSupabaseMaybeSingle = vi.fn();
   const mockSupabaseInsert = vi.fn();
+  // ADR-044 PR-2: the workspaces cloning-flip lock update.
   const mockSupabaseUpdate = vi.fn();
+  // The solo readiness write on `users`: .update({...}).eq("id", user.id).
+  const mockSupabaseUserUpdate = vi.fn();
 
-  // Chain: .update().eq().neq().select().maybeSingle()
+  // workspaces lock chain: .update().eq().neq().select().maybeSingle()
   mockSupabaseMaybeSingle.mockResolvedValue({
     data: { id: "user-123" },
     error: null,
   });
   mockSupabaseSelect.mockReturnValue({ maybeSingle: mockSupabaseMaybeSingle });
   mockSupabaseNeq.mockReturnValue({ select: mockSupabaseSelect });
-  // First .eq() in the lock chain returns the neq chain
-  // Subsequent .eq() calls (in the post-provision update) return { error: null }
   mockSupabaseEq.mockReturnValue({ neq: mockSupabaseNeq });
   mockSupabaseUpdate.mockReturnValue({ eq: mockSupabaseEq });
+  // users readiness chain: .update().eq() → { error: null }
+  mockSupabaseUserUpdate.mockReturnValue({
+    eq: vi.fn().mockResolvedValue({ error: null }),
+  });
   mockSupabaseInsert.mockResolvedValue({ error: null });
 
   return {
@@ -46,6 +52,7 @@ const {
     }),
     mockProvisionWorkspaceWithRepo: vi.fn().mockResolvedValue("/tmp/workspace"),
     mockSupabaseUpdate,
+    mockSupabaseUserUpdate,
     mockSupabaseEq,
     mockSupabaseNeq,
     mockSupabaseSelect,
@@ -57,6 +64,24 @@ const {
 
 vi.mock("@/server/byok-resolver", () => ({
   userHasEffectiveByokKey: mockUserHasEffectiveByokKey,
+}));
+
+// ADR-044 PR-2: the active workspace id is resolved server-side via the
+// membership-verified resolver. Default to SOLO (== user-123) so these
+// health-scanner tests exercise the solo readiness-write split. The team /
+// db-error branches are covered in the install-resolution suite.
+vi.mock("@/server/workspace-resolver", () => ({
+  resolveActiveWorkspace: vi.fn(async (userId: string) => ({
+    ok: true,
+    workspaceId: userId,
+  })),
+  resolveCurrentWorkspaceId: vi.fn(async (userId: string) => userId),
+}));
+
+// ADR-044 PR-2: the authoritative repo-connection write now targets the
+// `workspaces` row via writeRepoColsToWorkspace (was the solo-`users` mirror).
+vi.mock("@/server/workspace-repo-mirror", () => ({
+  writeRepoColsToWorkspace: vi.fn(async () => {}),
 }));
 
 // ---------------------------------------------------------------------------
@@ -76,55 +101,45 @@ vi.mock("@/lib/supabase/server", () => ({
         },
       }),
     },
-    // ADR-044 PR-1 owner-gate: default to owner.
+    // ADR-044 owner-gate: default to owner.
     rpc: vi.fn().mockResolvedValue({ data: true, error: null }),
-    // ADR-044 PR-2a: tenant read of user_session_state for the active-workspace
-    // guard (resolveCurrentWorkspaceId). No session row → solo (== user-123), so
-    // the team-workspace refusal is a no-op for these health-scanner tests.
-    from: vi.fn((table: string) => {
-      if (table === "user_session_state") {
-        return {
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              maybeSingle: vi
-                .fn()
-                .mockResolvedValue({ data: null, error: null }),
-            }),
-          }),
-        };
-      }
-      return {};
-    }),
   }),
   createServiceClient: vi.fn().mockReturnValue({
     from: vi.fn((table: string) => {
       if (table === "conversations") {
         return { insert: mockSupabaseInsert };
       }
-      if (table === "user_session_state") {
-        // resolveCurrentWorkspaceId (conversations.workspace_id resolution):
-        // no session row → falls back to userId.
+      if (table === "workspaces") {
+        // ADR-044 PR-2: the degraded install fallback reads
+        // workspaces.select(github_installation_id).eq(id).maybeSingle(); the
+        // cloning-flip lock is .update().eq().neq().select().maybeSingle().
         return {
           select: vi.fn().mockReturnValue({
             eq: vi.fn().mockReturnValue({
               maybeSingle: vi
                 .fn()
-                .mockResolvedValue({ data: null, error: null }),
+                .mockResolvedValue({
+                  data: { github_installation_id: 42 },
+                  error: null,
+                }),
             }),
           }),
+          update: mockSupabaseUpdate,
         };
       }
-      // "users" table
+      // "users" table — ADR-044 PR-2 reads only email + github_username; the
+      // solo readiness write (.update({workspace_status, health_snapshot}))
+      // still targets users.
       return {
         select: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
             single: vi.fn().mockResolvedValue({
-              data: { github_installation_id: 42, email: "test@example.com" },
+              data: { email: "test@example.com", github_username: "tester" },
               error: null,
             }),
           }),
         }),
-        update: mockSupabaseUpdate,
+        update: mockSupabaseUserUpdate,
       };
     }),
   }),
@@ -222,7 +237,8 @@ describe("setup route — health scanner guard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Reset the Supabase mock chain for the optimistic lock
+    // Reset the workspaces optimistic-lock chain:
+    // .update().eq().neq().select().maybeSingle()
     mockSupabaseMaybeSingle.mockResolvedValue({
       data: { id: "user-123" },
       error: null,
@@ -233,6 +249,11 @@ describe("setup route — health scanner guard", () => {
     mockSupabaseNeq.mockReturnValue({ select: mockSupabaseSelect });
     mockSupabaseEq.mockReturnValue({ neq: mockSupabaseNeq });
     mockSupabaseUpdate.mockReturnValue({ eq: mockSupabaseEq });
+
+    // Reset the solo readiness write on `users`: .update().eq() → { error: null }
+    mockSupabaseUserUpdate.mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    });
 
     // Reset provision mock
     mockProvisionWorkspaceWithRepo.mockResolvedValue("/tmp/workspace");
@@ -256,9 +277,6 @@ describe("setup route — health scanner guard", () => {
   // conversation insert + sync trigger on an effective key (fail-open).
   test("keyless user → no orphaned sync conversation is created", async () => {
     mockUserHasEffectiveByokKey.mockResolvedValue(false);
-    mockSupabaseEq
-      .mockReturnValueOnce({ neq: mockSupabaseNeq })
-      .mockResolvedValue({ error: null });
 
     const response = await POST(
       makeRequest({ repoUrl: "https://github.com/test/repo", source: "connect_existing" }),
@@ -275,9 +293,6 @@ describe("setup route — health scanner guard", () => {
 
   test("user with an effective key → sync conversation IS created", async () => {
     mockUserHasEffectiveByokKey.mockResolvedValue(true);
-    mockSupabaseEq
-      .mockReturnValueOnce({ neq: mockSupabaseNeq })
-      .mockResolvedValue({ error: null });
 
     const response = await POST(
       makeRequest({ repoUrl: "https://github.com/test/repo", source: "connect_existing" }),
@@ -289,13 +304,6 @@ describe("setup route — health scanner guard", () => {
   });
 
   test('does NOT call scanProjectHealth when source is "start_fresh"', async () => {
-    // The post-provision .then() handler needs the update chain to work for the DB update
-    // After provision, it calls .update({...}).eq("id", user.id)
-    // We need the second .eq() call (post-provision update) to resolve
-    mockSupabaseEq
-      .mockReturnValueOnce({ neq: mockSupabaseNeq }) // first call: optimistic lock chain
-      .mockResolvedValue({ error: null }); // second call: post-provision update
-
     const request = makeRequest({
       repoUrl: "https://github.com/test/repo",
       source: "start_fresh",
@@ -311,10 +319,6 @@ describe("setup route — health scanner guard", () => {
   });
 
   test('calls scanProjectHealth when source is "connect_existing"', async () => {
-    mockSupabaseEq
-      .mockReturnValueOnce({ neq: mockSupabaseNeq })
-      .mockResolvedValue({ error: null });
-
     const request = makeRequest({
       repoUrl: "https://github.com/test/repo",
       source: "connect_existing",
@@ -329,10 +333,6 @@ describe("setup route — health scanner guard", () => {
   });
 
   test("calls scanProjectHealth when source field is missing (backward compatible)", async () => {
-    mockSupabaseEq
-      .mockReturnValueOnce({ neq: mockSupabaseNeq })
-      .mockResolvedValue({ error: null });
-
     const request = makeRequest({
       repoUrl: "https://github.com/test/repo",
     });

--- a/apps/web-platform/test/setup-route-install-resolution.test.ts
+++ b/apps/web-platform/test/setup-route-install-resolution.test.ts
@@ -1,29 +1,25 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
-import { mockQueryChain } from "./helpers/mock-supabase";
 
 // ---------------------------------------------------------------------------
 // Mocks (declared before the route import)
 // ---------------------------------------------------------------------------
 const mockGetUser = vi.fn();
 const mockRpc = vi.fn();
-const mockTenantFrom = vi.fn();
 const mockServiceFrom = vi.fn();
 const mockAdminGetUserById = vi.fn();
 const mockValidateOrigin = vi.fn();
 const mockProvisionWorkspaceWithRepo = vi.fn();
-const mockMirror = vi.fn();
+const mockWriteRepoColsToWorkspace = vi.fn();
 const mockResolveReachable = vi.fn();
 const mockResolveOwning = vi.fn();
+const mockResolveActiveWorkspace = vi.fn();
 
 vi.mock("@/lib/supabase/server", () => ({
-  // ADR-044 PR-1 owner-gate: default to owner (solo users always own
+  // ADR-044 owner-gate: default to owner (solo users always own
   // workspace_id=user.id); the non-owner test overrides mockRpc.
   createClient: async () => ({
     auth: { getUser: mockGetUser },
     rpc: mockRpc,
-    // ADR-044 PR-2a: tenant read of user_session_state for the active-workspace
-    // guard (resolveCurrentWorkspaceId). Defaulted to solo in beforeEach.
-    from: mockTenantFrom,
   }),
   createServiceClient: () => ({
     from: mockServiceFrom,
@@ -58,8 +54,20 @@ vi.mock("@/lib/repo-url", () => ({
   normalizeRepoUrl: (u: string) => u,
 }));
 
+// ADR-044 PR-2: the route's authoritative repo-connection write now targets the
+// `workspaces` row via writeRepoColsToWorkspace (was the solo-`users` mirror).
 vi.mock("@/server/workspace-repo-mirror", () => ({
-  mirrorRepoColsToSoloWorkspace: (...a: unknown[]) => mockMirror(...a),
+  writeRepoColsToWorkspace: (...a: unknown[]) =>
+    mockWriteRepoColsToWorkspace(...a),
+}));
+
+// ADR-044 PR-2: the active workspace id is resolved server-side via the
+// membership-verified resolver. Default to SOLO (== user.id) in beforeEach; the
+// team / db-error tests override. `resolveCurrentWorkspaceId` is re-exported so
+// any sibling import resolves under the mock too.
+vi.mock("@/server/workspace-resolver", () => ({
+  resolveActiveWorkspace: (...a: unknown[]) => mockResolveActiveWorkspace(...a),
+  resolveCurrentWorkspaceId: vi.fn(async (userId: string) => userId),
 }));
 
 vi.mock("@/server/git-auth", () => ({
@@ -100,18 +108,32 @@ import { POST } from "../app/api/repo/setup/route";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+// Stored install id read from the active `workspaces` row in the degraded
+// fallback (ADR-044 PR-2 — it moved off `users.github_installation_id`).
 let storedInstallationId: number | null = null;
+// Captures every `workspaces.update(patch)` patch + the id it was `.eq("id", ·)`
+// scoped to, so tests can assert the AUTHORITATIVE install write lands on the
+// workspaces row (was a users.update of github_installation_id pre-PR-2).
+let workspacesUpdateCalls: Array<{
+  patch: Record<string, unknown>;
+  id: string;
+}> = [];
+// Records whether the `users` table was ever `.update()`d (the install path must
+// never write the install id to users).
+let usersUpdateCalled = false;
 
 function setupServiceClient() {
   mockServiceFrom.mockImplementation((table: string) => {
     if (table === "users") {
+      // ADR-044 PR-2: the user read selects ONLY email + github_username (the
+      // install id no longer lives here). The solo readiness write
+      // (.update({workspace_status, health_snapshot}).eq("id", user.id)) still
+      // targets users — but NEVER github_installation_id.
       return {
-        // .select(...).eq(...).single() — initial read
         select: () => ({
           eq: () => ({
             single: async () => ({
               data: {
-                github_installation_id: storedInstallationId,
                 email: "user@example.com",
                 github_username: "deruelle",
               },
@@ -119,16 +141,39 @@ function setupServiceClient() {
             }),
           }),
         }),
-        // .update(...).eq(...).neq(...).select(...).maybeSingle() — clone lock
-        // .update(...).eq(...).then(...) — error path
-        update: () => {
+        update: (patch: Record<string, unknown>) => {
+          usersUpdateCalled = true;
+          // The route asserts: a users write must NEVER carry the install id.
+          expect(patch).not.toHaveProperty("github_installation_id");
+          return { eq: async () => ({ error: null }) };
+        },
+      };
+    }
+    if (table === "workspaces") {
+      return {
+        // Degraded install fallback: .select(github_installation_id).eq(id).maybeSingle()
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({
+              data:
+                storedInstallationId == null
+                  ? null
+                  : { github_installation_id: storedInstallationId },
+              error: null,
+            }),
+          }),
+        }),
+        // Optimistic cloning-flip lock:
+        // .update(patch).eq("id", activeId).neq("repo_status","cloning").select("id").maybeSingle()
+        update: (patch: Record<string, unknown>) => {
           const chain: Record<string, unknown> = {
-            eq: () => chain,
+            eq: (_col: string, id: string) => {
+              workspacesUpdateCalls.push({ patch, id });
+              return chain;
+            },
             neq: () => chain,
             select: () => chain,
             maybeSingle: async () => ({ data: { id: "user-1" }, error: null }),
-            then: (resolve: (v: { error: null }) => void) =>
-              resolve({ error: null }),
           };
           return chain;
         },
@@ -150,6 +195,8 @@ describe("POST /api/repo/setup — install resolution", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     storedInstallationId = null;
+    workspacesUpdateCalls = [];
+    usersUpdateCalled = false;
     mockValidateOrigin.mockReturnValue({
       valid: true,
       origin: "https://app.soleur.ai",
@@ -162,39 +209,87 @@ describe("POST /api/repo/setup — install resolution", () => {
       error: null,
     });
     mockProvisionWorkspaceWithRepo.mockResolvedValue("/workspaces/user-1");
-    // ADR-044 PR-1 owner-gate: default owner; non-owner test overrides.
+    mockWriteRepoColsToWorkspace.mockResolvedValue(undefined);
+    // ADR-044 owner-gate: default owner; non-owner test overrides.
     mockRpc.mockResolvedValue({ data: true, error: null });
-    // ADR-044 PR-2a: default the active-workspace resolver to SOLO
-    // (current_workspace_id null → resolveCurrentWorkspaceId returns user.id),
-    // so the team-workspace refusal guard is a no-op for every existing test.
-    mockTenantFrom.mockReturnValue(
-      mockQueryChain({ current_workspace_id: null }, null),
-    );
+    // ADR-044 PR-2: default the active-workspace resolver to SOLO (== user.id),
+    // so the team-provisioning / db-error branches are no-ops for the install
+    // tests below.
+    mockResolveActiveWorkspace.mockResolvedValue({
+      ok: true,
+      workspaceId: "user-1",
+    });
     setupServiceClient();
   });
 
-  test("ADR-044 PR-2a: TEAM workspace active → 422 refusal, no owner-gate, no clone", async () => {
+  test("ADR-044 PR-2: TEAM workspace active + owner → PROVISIONS the team workspace (200, no 422)", async () => {
     const TEAM_WORKSPACE_ID = "11111111-2222-3333-4444-555555555555";
-    // Active workspace is a TEAM (≠ user.id). Team on-disk provisioning is
-    // #5462/Phase-5; until then setup would SILENTLY clone into the caller's
-    // PERSONAL solo workspace (confused deputy). Refuse explicitly.
-    mockTenantFrom.mockReturnValue(
-      mockQueryChain({ current_workspace_id: TEAM_WORKSPACE_ID }, null),
-    );
+    // PR-2 team write-cutover (#5462): an owner connecting a repo while a TEAM
+    // workspace is active now provisions THAT workspace on disk (was a PR-2a 422
+    // refusal). The owner-gate runs against the resolved team id and passes.
+    mockResolveActiveWorkspace.mockResolvedValue({
+      ok: true,
+      workspaceId: TEAM_WORKSPACE_ID,
+    });
+    mockResolveReachable.mockResolvedValue([122213433]);
+    mockResolveOwning.mockResolvedValue(122213433);
 
     const res = await POST(
       makeRequest({ repoUrl: "https://github.com/jikig-ai/soleur" }),
     );
-    expect(res.status).toBe(422);
+    expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.error).toMatch(/team workspace/i);
+    expect(body.status).toBe("cloning");
 
-    // The refusal precedes the owner-gate AND the clone.
+    // Owner-gate ran against the RESOLVED TEAM id (load-bearing for teams).
+    expect(mockRpc).toHaveBeenCalledWith("is_workspace_owner", {
+      p_workspace_id: TEAM_WORKSPACE_ID,
+      p_user_id: "user-1",
+    });
+    // Provisioning targets the RESOLVED TEAM id, not the caller's solo id.
+    expect(mockProvisionWorkspaceWithRepo.mock.calls[0][0]).toBe(
+      TEAM_WORKSPACE_ID,
+    );
+  });
+
+  test("ADR-044 PR-2: TEAM workspace active + NON-owner → 403, no clone", async () => {
+    const TEAM_WORKSPACE_ID = "11111111-2222-3333-4444-555555555555";
+    mockResolveActiveWorkspace.mockResolvedValue({
+      ok: true,
+      workspaceId: TEAM_WORKSPACE_ID,
+    });
+    // is_workspace_owner returns false for a non-owner member.
+    mockRpc.mockResolvedValueOnce({ data: false, error: null });
+
+    const res = await POST(
+      makeRequest({ repoUrl: "https://github.com/jikig-ai/soleur" }),
+    );
+    expect(res.status).toBe(403);
+    expect(mockProvisionWorkspaceWithRepo).not.toHaveBeenCalled();
+    // The owner-gate ran against the RESOLVED TEAM id.
+    expect(mockRpc).toHaveBeenCalledWith("is_workspace_owner", {
+      p_workspace_id: TEAM_WORKSPACE_ID,
+      p_user_id: "user-1",
+    });
+  });
+
+  test("ADR-044 PR-2: resolver db-error → 503 (fail-closed at the write boundary), no clone", async () => {
+    mockResolveActiveWorkspace.mockResolvedValue({
+      ok: false,
+      reason: "db-error",
+    });
+
+    const res = await POST(
+      makeRequest({ repoUrl: "https://github.com/jikig-ai/soleur" }),
+    );
+    expect(res.status).toBe(503);
+    // Fail-closed BEFORE the owner-gate and the clone (never silently provision
+    // into the caller's solo workspace under a team claim).
     expect(mockRpc).not.toHaveBeenCalled();
     expect(mockProvisionWorkspaceWithRepo).not.toHaveBeenCalled();
   });
 
-  test("ADR-044 owner-gate: non-owner → 403, no clone", async () => {
+  test("ADR-044 owner-gate: non-owner (solo) → 403, no clone", async () => {
     mockRpc.mockResolvedValueOnce({ data: false, error: null });
 
     const res = await POST(
@@ -224,30 +319,35 @@ describe("POST /api/repo/setup — install resolution", () => {
       "jikig-ai",
       "soleur",
     );
-    // provisionWorkspaceWithRepo(userId, repoUrl, installationId, ...)
+    // provisionWorkspaceWithRepo(workspaceId, repoUrl, installationId, ...)
     expect(mockProvisionWorkspaceWithRepo.mock.calls[0][2]).toBe(122213433);
   });
 
-  test("T10: membership-fallback path mirrors the RESOLVED install (never a users.update of github_installation_id)", async () => {
+  test("T10: membership-fallback path writes the RESOLVED install to the WORKSPACES cloning-flip lock (never a users.update of github_installation_id)", async () => {
     storedInstallationId = null;
     mockResolveReachable.mockResolvedValue([122213433]);
     mockResolveOwning.mockResolvedValue(122213433);
 
     await POST(makeRequest({ repoUrl: "https://github.com/jikig-ai/soleur" }));
 
-    // Mirror to the solo WORKSPACE may carry the install (ADR-044 — allowed).
-    // The install written is the RESOLVED id, never persisted to users.
-    const mirrorInstallWrites = mockMirror.mock.calls.filter(
-      (c) =>
-        (c[2] as { github_installation_id?: number }).github_installation_id !=
-        null,
+    // ADR-044 PR-2: the install grant is persisted on the cloning-flip lock to
+    // WORKSPACES (service-role update), keyed on the resolved active id — NOT a
+    // `users.update` of github_installation_id. The patch carries the RESOLVED
+    // id, never any other value.
+    const installWrites = workspacesUpdateCalls.filter(
+      (c) => c.patch.github_installation_id != null,
     );
-    expect(mirrorInstallWrites.length).toBeGreaterThan(0);
-    for (const c of mirrorInstallWrites) {
-      expect(
-        (c[2] as { github_installation_id: number }).github_installation_id,
-      ).toBe(122213433);
+    expect(installWrites.length).toBeGreaterThan(0);
+    for (const c of installWrites) {
+      expect(c.patch.github_installation_id).toBe(122213433);
+      // Scoped to the resolved active id (solo == user-1 here).
+      expect(c.id).toBe("user-1");
     }
+
+    // The install id is NEVER written to `users` (the setupServiceClient mock
+    // hard-asserts no users.update carries github_installation_id; this confirms
+    // any users write that did happen was the readiness write, not the install).
+    void usersUpdateCalled;
   });
 
   test("T11: personal happy path — stored id present, owning probe 'ok' → clones with stored id", async () => {
@@ -278,7 +378,7 @@ describe("POST /api/repo/setup — install resolution", () => {
     expect(mockProvisionWorkspaceWithRepo).not.toHaveBeenCalled();
   });
 
-  test("T13: degraded probe (owning null) but stored id present → falls back to stored id", async () => {
+  test("T13: degraded probe (owning null) but stored id present on the active workspace → falls back to stored id", async () => {
     storedInstallationId = 999;
     mockResolveReachable.mockResolvedValue([999]);
     mockResolveOwning.mockResolvedValue(null); // degraded — inconclusive

--- a/apps/web-platform/test/setup-route-install-resolution.test.ts
+++ b/apps/web-platform/test/setup-route-install-resolution.test.ts
@@ -344,10 +344,12 @@ describe("POST /api/repo/setup — install resolution", () => {
       expect(c.id).toBe("user-1");
     }
 
-    // The install id is NEVER written to `users` (the setupServiceClient mock
-    // hard-asserts no users.update carries github_installation_id; this confirms
-    // any users write that did happen was the readiness write, not the install).
-    void usersUpdateCalled;
+    // The install id is NEVER written to `users`: the setupServiceClient `users`
+    // mock (line ~147) hard-asserts `expect(patch).not.toHaveProperty(
+    // "github_installation_id")` on EVERY users.update, so any stray install
+    // write throws and fails this test. No separate assertion needed here
+    // (`usersUpdateCalled` is set by the async readiness callback, which this
+    // synchronous `await POST` does not await — asserting its value would race).
   });
 
   test("T11: personal happy path — stored id present, owning probe 'ok' → clones with stored id", async () => {

--- a/apps/web-platform/test/supabase-migrations/110-workspace-repo-error-and-comember-reconcile.test.ts
+++ b/apps/web-platform/test/supabase-migrations/110-workspace-repo-error-and-comember-reconcile.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// Migration-shape test for 110_workspace_repo_error_and_comember_reconcile.sql
+// (ADR-044 PR-2 team write-cutover, #5462 — Phase 1).
+//
+// Offline lint — runs without a live database. The live-DB drift proof (SOLO
+// drift COUNT=0 post-reconcile + idempotency) runs at apply time via the
+// verify/110_*.sql `check_name`/`bad` contract in CI verify-migrations and was
+// also verified in a rolled-back dev txn at /work time. This source-shape test
+// guards the load-bearing invariants a regression could silently drop:
+//   - `workspaces.repo_error` column added IF NOT EXISTS (idempotent).
+//   - the full non-credential GRANT is RE-ISSUED with `repo_error` appended
+//     after a REVOKE SELECT (mirror 079 — NOT a partial column GRANT), and
+//     `github_installation_id` stays OUT of the grant set (credential).
+//   - the SOLO backfill carries the mig-080 canary-owner-row + sole-member
+//     COUNT(*)=1 guards + the `WHERE w.repo_error IS NULL` idempotency guard.
+//   - the co-membered SKIP backlog is NOT auto-adopted (no blind copy onto a
+//     COUNT(*)>1 workspace) — CLO/PA-17(c) lawful-basis block.
+//   - NO CONCURRENTLY (Supabase wraps each migration file in one txn).
+//   - the down migration drops the column reversibly.
+
+const MIGRATION_PATH = path.join(
+  __dirname,
+  "../../supabase/migrations/110_workspace_repo_error_and_comember_reconcile.sql",
+);
+const DOWN_PATH = path.join(
+  __dirname,
+  "../../supabase/migrations/110_workspace_repo_error_and_comember_reconcile.down.sql",
+);
+const VERIFY_PATH = path.join(
+  __dirname,
+  "../../supabase/verify/110_workspace_repo_error_and_comember_reconcile.sql",
+);
+
+const sql = readFileSync(MIGRATION_PATH, "utf8");
+const downSql = readFileSync(DOWN_PATH, "utf8");
+const verifySql = readFileSync(VERIFY_PATH, "utf8");
+// Strip line-comments so prose `--` lines don't false-match the patterns.
+const executable = sql.replace(/--[^\n]*/g, "");
+const verifyExecutable = verifySql.replace(/--[^\n]*/g, "");
+
+describe("migration 110_workspace_repo_error_and_comember_reconcile", () => {
+  it("adds workspaces.repo_error idempotently (ADD COLUMN IF NOT EXISTS)", () => {
+    expect(executable).toMatch(
+      /ALTER\s+TABLE\s+public\.workspaces\s+ADD\s+COLUMN\s+IF\s+NOT\s+EXISTS\s+repo_error\s+text/i,
+    );
+  });
+
+  it("re-issues the FULL non-credential GRANT with repo_error after a REVOKE (not a partial column grant)", () => {
+    expect(executable).toMatch(
+      /REVOKE\s+SELECT\s+ON\s+public\.workspaces\s+FROM\s+authenticated/i,
+    );
+    // The full column list mirrors mig 079:89 + repo_error appended.
+    const grant = executable.match(
+      /GRANT\s+SELECT\s*\(([^)]*)\)\s+ON\s+public\.workspaces\s+TO\s+authenticated/i,
+    );
+    expect(grant).not.toBeNull();
+    const cols = grant![1].replace(/\s+/g, " ");
+    for (const c of [
+      "id",
+      "organization_id",
+      "name",
+      "created_at",
+      "repo_url",
+      "repo_provider",
+      "repo_status",
+      "repo_last_synced_at",
+      "repo_error",
+    ]) {
+      expect(cols).toMatch(new RegExp(`\\b${c}\\b`));
+    }
+  });
+
+  it("keeps github_installation_id OUT of the authenticated GRANT (credential)", () => {
+    const grant = executable.match(
+      /GRANT\s+SELECT\s*\(([^)]*)\)\s+ON\s+public\.workspaces\s+TO\s+authenticated/i,
+    );
+    expect(grant![1]).not.toMatch(/github_installation_id/);
+  });
+
+  it("backfills repo_error for SOLO rows with the canary-owner + sole-member + idempotency guards", () => {
+    // Idempotency: re-runs touch 0 rows.
+    expect(executable).toMatch(/w\.repo_error\s+IS\s+NULL/i);
+    // Canary owner-row (the workspace is the user's own solo workspace).
+    expect(executable).toMatch(/m\.user_id\s*=\s*w\.id/i);
+    expect(executable).toMatch(/m\.role\s*=\s*'owner'/i);
+    // Sole-member guard COUNT(*) = 1 — never adopt onto a co-membered workspace.
+    expect(executable).toMatch(/COUNT\(\*\)[\s\S]*?\)\s*=\s*1/i);
+  });
+
+  it("does NOT auto-adopt the co-membered SKIP backlog (every repo-col UPDATE carries the sole-member = 1 guard)", () => {
+    // Every UPDATE ... SET repo_url/repo_error/github_installation_id on
+    // workspaces must be SOLO-guarded (COUNT(*) ... = 1). A COUNT(*) > 1 paired
+    // with a repo-col copy would be the unlawful co-member auto-adoption. The
+    // `> 1` audit block (step 5) is a read-only SELECT COUNT INTO, never an
+    // UPDATE, so it is allowed.
+    const updateBlocks = executable.match(
+      /UPDATE\s+public\.workspaces[\s\S]*?(?=DO\s+\$\$|$)/gi,
+    );
+    expect(updateBlocks).not.toBeNull();
+    for (const block of updateBlocks!) {
+      if (/SET\s+repo_(url|error)|github_installation_id\s*=/i.test(block)) {
+        expect(block).toMatch(/=\s*1/);
+        expect(block).not.toMatch(/COUNT\(\*\)[\s\S]{0,40}>\s*1/i);
+      }
+    }
+  });
+
+  it("uses GET DIAGNOSTICS + RAISE NOTICE for the backfill row-count audit", () => {
+    expect(executable).toMatch(/GET\s+DIAGNOSTICS\s+\w+\s*=\s*ROW_COUNT/i);
+    expect(executable).toMatch(/RAISE\s+NOTICE/i);
+  });
+
+  it("uses no CONCURRENTLY (Supabase wraps the file in one txn)", () => {
+    expect(executable).not.toMatch(/CONCURRENTLY/i);
+  });
+
+  it("documents the lawful basis (Art. 6) in the migration header", () => {
+    expect(sql).toMatch(/LAWFUL_BASIS|Art\.\s*6/i);
+  });
+
+  it("down migration drops repo_error reversibly", () => {
+    expect(downSql).toMatch(
+      /ALTER\s+TABLE\s+public\.workspaces\s+DROP\s+COLUMN\s+IF\s+EXISTS\s+repo_error/i,
+    );
+  });
+});
+
+describe("verify 110 contract", () => {
+  it("emits check_name + bad rows (CI verify-migrations contract)", () => {
+    expect(verifyExecutable).toMatch(/AS\s+check_name/i);
+    expect(verifyExecutable).toMatch(/AS\s+bad/i);
+  });
+
+  it("asserts the SOLO drift-gate COUNT scoped to sole-member workspaces", () => {
+    expect(verifyExecutable).toMatch(/repo_drift_count/i);
+    // The drift query mirrors ADR-044's PR-2b gate (users JOIN workspaces).
+    expect(verifyExecutable).toMatch(/u\.repo_url\s+IS\s+NOT\s+NULL/i);
+    expect(verifyExecutable).toMatch(
+      /w\.repo_url\s+IS\s+DISTINCT\s+FROM\s+u\.repo_url/i,
+    );
+    expect(verifyExecutable).toMatch(
+      /w\.github_installation_id\s+IS\s+DISTINCT\s+FROM\s+u\.github_installation_id/i,
+    );
+    // Scoped to SOLO rows (sole-member).
+    expect(verifyExecutable).toMatch(/=\s*1/);
+  });
+
+  it("asserts 0 co-membered rows adopted WITHOUT an attestation (not 0 SKIP rows)", () => {
+    expect(verifyExecutable).toMatch(/comember/i);
+    expect(verifyExecutable).toMatch(/attestation/i);
+  });
+});

--- a/apps/web-platform/test/workspace-repo-mirror.test.ts
+++ b/apps/web-platform/test/workspace-repo-mirror.test.ts
@@ -4,21 +4,31 @@ vi.mock("@/server/observability", () => ({
   reportSilentFallback: vi.fn(),
 }));
 
-import { mirrorRepoColsToSoloWorkspace } from "@/server/workspace-repo-mirror";
+import { writeRepoColsToWorkspace } from "@/server/workspace-repo-mirror";
 
-function makeService(error: unknown = null) {
-  const eq = vi.fn(async () => ({ error }));
+// The write chain is `from("workspaces").update(patch).eq("id", id).select("id")`
+// resolving to `{ data, error }`. `data` is the rows the UPDATE matched — an
+// empty array is the silent-0-row no-op the helper must surface (ADR-044: the
+// workspace can be deleted mid-flight, current_workspace_id ON DELETE SET NULL).
+function makeService(
+  result: { data?: Array<{ id: string }> | null; error?: unknown } = {},
+) {
+  const data = result.data === undefined ? [{ id: "ws-1" }] : result.data;
+  const error = result.error ?? null;
+  const select = vi.fn(async () => ({ data, error }));
+  const eq = vi.fn(() => ({ select }));
   const update = vi.fn(() => ({ eq }));
   const from = vi.fn(() => ({ update }));
-  return { client: { from }, from, update, eq };
+  return { client: { from }, from, update, eq, select };
 }
 
-describe("mirrorRepoColsToSoloWorkspace", () => {
+describe("writeRepoColsToWorkspace", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("writes the moved cols to workspaces WHERE id = userId (solo workspace)", async () => {
+  it("writes the repo cols to workspaces WHERE id = the SUPPLIED workspace id (team id)", async () => {
     const svc = makeService();
-    await mirrorRepoColsToSoloWorkspace(svc.client, "user-1", {
+    const TEAM = "11111111-2222-3333-4444-555555555555";
+    await writeRepoColsToWorkspace(svc.client, TEAM, {
       repo_url: "https://github.com/foo/bar",
       github_installation_id: 42,
       repo_status: "cloning",
@@ -29,60 +39,104 @@ describe("mirrorRepoColsToSoloWorkspace", () => {
       github_installation_id: 42,
       repo_status: "cloning",
     });
+    // Keyed on the supplied (team) id — NOT a hardcoded userId.
+    expect(svc.eq).toHaveBeenCalledWith("id", TEAM);
+  });
+
+  it("writes keyed on a solo id when that is what the caller resolved", async () => {
+    const svc = makeService();
+    await writeRepoColsToWorkspace(svc.client, "user-1", {
+      repo_status: "ready",
+    });
     expect(svc.eq).toHaveBeenCalledWith("id", "user-1");
   });
 
-  it("mirrors a disconnect (all moved cols nulled)", async () => {
+  it("round-trips repo_error (now a workspaces column)", async () => {
     const svc = makeService();
-    await mirrorRepoColsToSoloWorkspace(svc.client, "user-1", {
+    await writeRepoColsToWorkspace(svc.client, "ws-1", {
+      repo_status: "error",
+      repo_error: '{"code":"CLONE_FAILED","message":"boom"}',
+    });
+    expect(svc.update).toHaveBeenCalledWith({
+      repo_status: "error",
+      repo_error: '{"code":"CLONE_FAILED","message":"boom"}',
+    });
+  });
+
+  it("clears the credential + repo cols on disconnect (all nulled)", async () => {
+    const svc = makeService();
+    await writeRepoColsToWorkspace(svc.client, "ws-1", {
       github_installation_id: null,
       repo_url: null,
       repo_status: "not_connected",
       repo_last_synced_at: null,
+      repo_error: null,
     });
     expect(svc.update).toHaveBeenCalledWith({
       github_installation_id: null,
       repo_url: null,
       repo_status: "not_connected",
       repo_last_synced_at: null,
+      repo_error: null,
     });
   });
 
-  it("Sentry-mirrors on error without throwing (users write stays authoritative)", async () => {
+  it("Sentry-mirrors on db error without throwing by default", async () => {
     const { reportSilentFallback } = await import("@/server/observability");
-    const svc = makeService({ message: "boom" });
+    const svc = makeService({ error: { message: "boom" } });
     await expect(
-      mirrorRepoColsToSoloWorkspace(svc.client, "user-1", { repo_status: "error" }),
+      writeRepoColsToWorkspace(svc.client, "ws-1", { repo_status: "error" }),
     ).resolves.toBeUndefined();
     expect(reportSilentFallback).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ feature: "workspace-repo-mirror" }),
+      expect.objectContaining({ feature: "workspace-repo-write", op: "write-to-workspace" }),
     );
   });
 
-  it("with throwOnError, rethrows on error AND still Sentry-mirrors (disconnect credential-clear fails closed)", async () => {
+  it("treats a 0-row UPDATE as a silent no-op failure (workspace deleted mid-flight) and Sentry-mirrors", async () => {
     const { reportSilentFallback } = await import("@/server/observability");
-    const svc = makeService({ message: "boom" });
+    const svc = makeService({ data: [] });
     await expect(
-      mirrorRepoColsToSoloWorkspace(
+      writeRepoColsToWorkspace(svc.client, "ws-gone", { repo_status: "ready" }),
+    ).resolves.toBeUndefined();
+    expect(reportSilentFallback).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ op: "write-to-workspace.zero-rows" }),
+    );
+  });
+
+  it("with throwOnError, rethrows on db error AND Sentry-mirrors (disconnect credential-clear fails closed)", async () => {
+    const { reportSilentFallback } = await import("@/server/observability");
+    const svc = makeService({ error: { message: "boom" } });
+    await expect(
+      writeRepoColsToWorkspace(
         svc.client,
-        "user-1",
+        "ws-1",
         { github_installation_id: null, repo_url: null, repo_status: "not_connected" },
         { throwOnError: true },
       ),
     ).rejects.toThrow();
-    expect(reportSilentFallback).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ feature: "workspace-repo-mirror" }),
-    );
+    expect(reportSilentFallback).toHaveBeenCalled();
   });
 
-  it("with throwOnError, does NOT throw on success", async () => {
+  it("with throwOnError, rethrows on a 0-row no-op (the clear did not land on any row)", async () => {
+    const svc = makeService({ data: [] });
+    await expect(
+      writeRepoColsToWorkspace(
+        svc.client,
+        "ws-gone",
+        { github_installation_id: null, repo_url: null, repo_status: "not_connected" },
+        { throwOnError: true },
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("with throwOnError, does NOT throw on a successful 1-row write", async () => {
     const svc = makeService();
     await expect(
-      mirrorRepoColsToSoloWorkspace(
+      writeRepoColsToWorkspace(
         svc.client,
-        "user-1",
+        "ws-1",
         { github_installation_id: null, repo_url: null, repo_status: "not_connected" },
         { throwOnError: true },
       ),

--- a/knowledge-base/engineering/architecture/decisions/ADR-044-workspace-repo-ownership.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-044-workspace-repo-ownership.md
@@ -192,3 +192,64 @@ substitutable by **direct enumeration**: run the pre-decommission drift-gate que
 drift-gate COUNT as authoritative and the breadcrumb as informational. This retires
 the *calendar*-soak requirement for internal-only — it does **not** unblock PR-2b,
 which still waits on the #5462 write-cutover (prereq 1) regardless of soak.
+
+## Amendment 2026-06-17 — PR-2 write-cutover lands (#5462)
+
+The connect-time **write** path is relocated `users.*` → `workspaces.*`. This is the
+prereq-(1) the prior amendment recorded as the hard block on PR-2b.
+
+`status` stays **`adopting`** (NOT `accepted`): the `adopting → accepted` flip lands
+with PR-2b's destructive column drop after a real prod soak. This PR moves the write
+edge but does not drop the legacy `users` columns (they survive as the revert net).
+
+**C4 edge moves: `read=Workspace / write=User (dual)` → `read=Workspace /
+write=Workspace`.** The four `app/api/repo/**` routes (`setup`, `disconnect`,
+`install`, `detect-installation`) now write the authoritative repo-connection
+columns to the `workspaces` row keyed on the **membership-verified resolved active
+workspace id**; the owner-gate `p_workspace_id` equals that mutation-target id; team
+on-disk provisioning + teardown (with live-member-session abort before the shared-dir
+`rm`) replaces the PR-2a 422 refusal. `repo_error` was relocated by migration 110
+(non-credential `authenticated` GRANT). The `users` columns are now **un-written
+legacy** until PR-2b drops them.
+
+### Read-cutover scope correction (the "read path is already cut over" claim was false)
+
+The PR-1 amendment and the #5462 plan asserted the read path was fully on `workspaces`.
+Implementing PR-2 surfaced FIVE+ surviving `users.{github_installation_id, repo_url,
+repo_status}` readers. The binding ruling (engineering CTO):
+
+- **Chosen (Option D): migrate the authenticated *interactive* readers in this PR,
+  defer the *service-role* readers to PR-2b's blocker set.** Migrated here:
+  `repo/status`, `repo/create`, `kb/tree`, `dashboard/today/[id]/undo`,
+  `(auth)/callback`, and `repo/setup`'s degraded install-fallback — each now reads
+  `workspaces` (via the `resolve_workspace_installation_id` RPC / `resolveInstallationId`
+  for the credential, or a service-role `workspaces` read for the non-credential cols).
+  Without this, a *newly-connected* user would strand on stale-NULL `users.*`
+  (a `single-user incident`: broken GitHub-App git auth / "no repo connected" UI).
+- **Rejected: migrate all readers in-PR (pure Option A)** — three readers are
+  service-role/cron contexts where `resolve_workspace_installation_id` is structurally
+  unusable (it gates on `auth.uid()` and is `REVOKE`'d from `service_role`, mig
+  079:114/126); cutting them needs a *net-new* service-role-safe resolver, outside a
+  write-cutover's blast radius.
+- **Rejected: dark-launch flag (Option C)** — a write-relocation flag gates the wrong
+  layer (the reads are the hazard); default-off leaves dual-writes live, which is
+  Option B and re-blocks the PR-2b drift gate. Loud failure (`reportSilentFallback` /
+  throw) + the whole-PR git-revert already satisfy the `single-user incident`
+  threshold without a second drift surface (flag-state vs deploy-state).
+- **Rejected: keep `users.*` dual-writes (Option B)** — re-introduces the
+  dual-source-of-truth divergence ADR-044 forbids and makes the PR-2b drift gate
+  unreachable.
+
+**PR-2b (#5437) precondition set is amended:** PR-2b is blocked on the soak **AND** the
+two deferred service-role-reader migrations (`server/inngest/functions/agent-on-spawn-requested.ts`,
+`server/inngest/functions/cron-workspace-sync-health.ts`), because both read
+`users.github_installation_id` and PR-2b drops that column. They need a new
+service-role-safe founder→workspace installation resolver (membership-bypass justified
+by trusted server context). Tracked in **#5470** (PR-2b-blocker).
+
+### Considered Options (amendment)
+
+- **Option D (chosen):** above.
+- **Capability gap recorded:** there is no service-role-safe installation-id resolver
+  (the only one is `auth.uid()`-gated). It must be built before PR-2b can drop
+  `users.github_installation_id`.

--- a/knowledge-base/engineering/architecture/decisions/ADR-044-workspace-repo-ownership.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-044-workspace-repo-ownership.md
@@ -241,11 +241,28 @@ repo_status}` readers. The binding ruling (engineering CTO):
   unreachable.
 
 **PR-2b (#5437) precondition set is amended:** PR-2b is blocked on the soak **AND** the
-two deferred service-role-reader migrations (`server/inngest/functions/agent-on-spawn-requested.ts`,
-`server/inngest/functions/cron-workspace-sync-health.ts`), because both read
-`users.github_installation_id` and PR-2b drops that column. They need a new
-service-role-safe founder→workspace installation resolver (membership-bypass justified
-by trusted server context). Tracked in **#5470** (PR-2b-blocker).
+deferred service-role-context migrations, all tracked in **#5470** (PR-2b-blocker).
+PR #5466 multi-agent review found these are **three** read sites + one write site, not
+two — all service-role contexts where the `auth.uid()`-gated RPC is unusable:
+- `server/inngest/functions/agent-on-spawn-requested.ts` — reads `users.github_installation_id`.
+- `server/inngest/functions/cron-workspace-sync-health.ts` — reads `users.github_installation_id`.
+- `app/api/webhooks/github/route.ts` — resolves `founderId` via `.eq("github_installation_id", …)`
+  (a lookup, missed by the original `.select(…)` grep). They need a service-role-safe
+  founder→workspace installation resolver (membership-bypass, trusted server context); the
+  webhook additionally needs the fan-out reconcile because `workspaces.github_installation_id`
+  is non-unique (ADR-044 fan-out).
+- `server/session-sync.ts` `updateLastSynced` — writes `users.repo_last_synced_at`; PR #5466
+  moved the `repo/status` read to `workspaces.repo_last_synced_at`, so the timestamp display
+  freezes at connect time until this write relocates (needs `session-sync` on the
+  service-role allowlist).
+
+**Soak limitation (documented, accepted):** until #5470 lands, a user who connects via the
+new workspaces-authoritative path during the soak does **not** get push auto-sync (the
+webhook founder-resolver reads NULL `users.github_installation_id`) and shows a stale
+last-synced timestamp. The soak population is internal-only, so this is an accepted
+internal-dogfood limitation, consistent with the Option-D deferral logic (loud-failure +
+revert-net for the interactive paths; the service-role paths fail in low-frequency
+background contexts surfaced by the soak itself).
 
 ### Considered Options (amendment)
 

--- a/knowledge-base/project/learnings/2026-06-17-column-relocation-reader-sweep-and-stranded-eq-lookups.md
+++ b/knowledge-base/project/learnings/2026-06-17-column-relocation-reader-sweep-and-stranded-eq-lookups.md
@@ -1,0 +1,46 @@
+# Learning: column-relocation reader sweeps must cover `.eq("col", val)` lookups, not just `.select("col")`
+
+**Date:** 2026-06-17 · **Feature:** ADR-044 PR-2 team write-cutover (#5462, PR #5466)
+
+## Problem
+
+Relocating connect-time repo state from `users.*` to `workspaces.*` (the write side of ADR-044). The plan asserted "the read path is already cut over." It was **false**: a `git grep` of `.select(...github_installation_id...)` / `.select(...repo_url...)` found 5+ surviving `users.*` readers, and a *sixth* — the GitHub push-webhook founder-resolver — was missed by EVERY `.select()`-shaped grep (the CTO's and mine) because it reads the relocated column as a **WHERE filter**:
+
+```ts
+.from("users").select("id").eq("github_installation_id", installationId)   // ← lookup BY the column
+```
+
+A `.select("...github_installation_id...")` grep never matches this; the column name appears only inside `.eq(...)`. Relocating the write without migrating this reader strands push auto-sync for every newly-connected user (their `users.github_installation_id` is now NULL).
+
+## Solution / Key Insight
+
+**When relocating a column, the consumer sweep must grep BOTH shapes:**
+1. `.select(` lists that name the column (projection readers).
+2. `.eq("<col>", …)` / `.in("<col>", …)` / `.match({<col>: …})` filters that *look up by* the column (lookup readers).
+
+A column used as a lookup key is the most load-bearing kind of reader (it routes/joins on the value), yet it's invisible to the projection grep. Canonical sweep for a relocated column `C`:
+
+```bash
+git grep -nE "\.(eq|in|match|or|filter)\([\"']?$C|select\([^)]*\b$C\b" -- '<scope>'
+```
+
+**Two more durable insights from the same session:**
+
+- **Architectural-fork → CTO worked as designed.** The plan-vs-codebase contradiction ("read path cut over" was false) + a resolution with material trade-offs (migrate-all vs defer-service-role vs dark-launch flag) is an *engineering* decision. Routing it to `soleur:engineering:cto` (not the operator) produced a clean binding ruling (Option D: migrate interactive readers in-PR, defer service-role readers — the `auth.uid()`-gated RPC is unusable from cron/webhook/inngest contexts). Re-route to the CTO when a *later* discovery (the `.eq()` reader) widens the same decision.
+
+- **Reusing a function whose scope doesn't match the need is a silent bug.** `abortAllWorkspaceMemberSessions(workspaceId, userId)` *reads* like "abort the workspace's member sessions" but is **member-scoped** (only the passed user's own sessions — built for member-removal). Calling it for a shared-team-dir teardown left co-members mid-write → ENOENT. Before reusing a registry/util function for a new caller, read its body and confirm its *scope* matches (here: needed a workspace-wide `abortAllSessionsForWorkspace`). security-sentinel caught the overclaiming comment.
+
+## Session Errors
+
+1. **Both resume-state premises were stale.** The resume prompt said "all work is uncommitted" and "Sibling-set sweep CI failing" — both false (work was committed+pushed; the check passed). **Recovery:** verified actual state (`git status`, `gh pr checks`) before acting. **Prevention:** covered by the work-skill rules "plan-quoted numbers are preconditions to verify" + "on resume, prior-session artifacts are UNVERIFIED" — apply them to *session-state claims* too, not just file artifacts.
+2. **Plan claimed "read path already cut over" — false (5+ readers).** **Recovery:** verify-the-negative grep + CTO ruling. **Prevention:** treat any plan "X is already done/safe" claim as a precondition to grep, never a fact.
+3. **`.eq()` lookup reader missed by `.select()` grep.** **Recovery:** caught at multi-agent review (data-integrity-guardian). **Prevention:** the dual-shape sweep above (route-to-definition → work skill).
+4. **`abortAllWorkspaceMemberSessions` member-scoped, used for workspace-wide need.** **Recovery:** added `abortAllSessionsForWorkspace` + tests; caught by security-sentinel. **Prevention:** read a reused function's body for scope before wiring a new caller.
+5. **Hit the `vitest > log; echo "RC=$?"` tail-masking trap twice** — the trailing `echo` made the shell exit 0 while vitest failed. **Recovery:** read the summary line / `VITEST_FINAL_RC` directly. **Prevention:** ALREADY a documented learning (`2026-05-18-test-all-tail-masking`); capture vitest's rc with `vitest run; rc=$?` as the *last* statement, or grep the summary — don't trust a trailing-echo'd "exit 0".
+6. **Bash CWD persistence:** used `apps/web-platform/test/...` paths while CWD was already `apps/web-platform` → file-not-found. **Prevention:** the Bash tool persists CWD across calls — anchor paths to the known CWD or use absolute paths.
+7. **One-offs:** `Monitor` tool called without its schema loaded (needs ToolSearch first); an `Edit` failed "modified since read" after a `perl -i` edit to the same file (re-read before editing). No recurrence vector.
+
+## Tags
+category: integration-issues
+module: apps/web-platform (ADR-044), workflow (compound/work consumer-sweep)
+related: ADR-044, #5462, #5437, #5470

--- a/knowledge-base/project/plans/2026-06-17-feat-adr-044-team-write-cutover-plan.md
+++ b/knowledge-base/project/plans/2026-06-17-feat-adr-044-team-write-cutover-plan.md
@@ -53,9 +53,21 @@ User-Brand Impact, 4.7 Observability, 4.8 PAT-shaped, 4.9 UI-wireframe) PASS.
 ## Overview
 
 ADR-044 relocates GitHub repo-connection state from `users.*` to `workspaces.*`.
-The **read** path is already cut over (`current-repo-url.ts`, `workspace-resolver.ts`
-read `workspaces.repo_url` / the `resolve_workspace_installation_id` SECURITY DEFINER
-RPC). The **write** path is still `users`-authoritative: the four connect routes write
+
+> **Implementation correction (2026-06-17, engineering CTO ruling — see ADR-044
+> amendment "PR-2 write-cutover lands").** This plan's claim that "the read path is
+> already cut over" was **false**: implementing PR-2 surfaced 5+ surviving `users.*`
+> readers. Per the binding Option-D ruling, the authenticated *interactive* readers
+> were migrated in THIS PR (`repo/status`, `repo/create`, `kb/tree`,
+> `dashboard/undo`, `(auth)/callback`, the `repo/setup` install-fallback); the two
+> *service-role* readers (`agent-on-spawn-requested`, `cron-workspace-sync-health`)
+> are deferred to PR-2b's blocker set (the membership-checked RPC is `auth.uid()`-gated
+> and unusable from service-role contexts; they need a new service-role-safe resolver).
+
+The **read** path was PARTIALLY cut over by PR-1 (`current-repo-url.ts`,
+`workspace-resolver.ts` read `workspaces.repo_url` / the
+`resolve_workspace_installation_id` SECURITY DEFINER RPC); this PR completes the
+interactive readers (above). The **write** path was still `users`-authoritative: the four connect routes write
 `users.{repo_url, workspace_path, github_installation_id, repo_error}` and best-effort
 *mirror* a subset to `workspaces` via `mirrorRepoColsToSoloWorkspace`, always keyed on
 `user.id` (the solo workspace). PR-2a (#5455, shipped) added a **422 refusal** when a
@@ -508,7 +520,10 @@ explicit edge; route any `.c4` edit through the Concierge `c4-edit` path.
   `gh` post-merge, not a dashboard eyeball.
 - [ ] AC14: Open the PR-2b soak window — confirm `repo_resolver_divergence` breadcrumb
   volume in Sentry (issues API query, deterministic verdict) before #5437 proceeds. `Ref
-  #5437` (do not `Closes` — PR-2b is the closer).
+  #5437` (do not `Closes` — PR-2b is the closer). **PR-2b precondition set amended (CTO
+  ruling):** PR-2b is blocked on the soak AND the two deferred service-role-reader
+  migrations (`agent-on-spawn-requested`, `cron-workspace-sync-health`) — both read
+  `users.github_installation_id`, which PR-2b drops. Tracked in #5470 (PR-2b-blocker).
 
 ## Observability
 

--- a/knowledge-base/project/plans/2026-06-17-feat-adr-044-team-write-cutover-plan.md
+++ b/knowledge-base/project/plans/2026-06-17-feat-adr-044-team-write-cutover-plan.md
@@ -1,0 +1,677 @@
+---
+title: "ADR-044 team write-cutover — relocate connect-time repo writes users.* → workspaces.* + team on-disk provisioning"
+issue: 5462
+branch: feat-one-shot-5462-team-write-cutover
+worktree: .worktrees/feat-one-shot-5462-team-write-cutover
+adr: ADR-044
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+spec: knowledge-base/project/specs/feat-adr-044-pr2-write-relocation/spec.md
+blocks: 5437
+type: enhancement
+---
+
+# ADR-044 Team Write-Cutover (#5462)
+
+## Enhancement Summary
+
+**Deepened:** 2026-06-17 · **Agents:** repo-research-analyst, learnings-researcher,
+spec-flow-analyzer (7 P0 / 6 P1 / 4 P2), data-integrity-guardian (credential boundary).
+Precedent-diff (4.4), verify-the-negative, and all four mandatory halt gates (4.6
+User-Brand Impact, 4.7 Observability, 4.8 PAT-shaped, 4.9 UI-wireframe) PASS.
+
+**Load-bearing corrections (deepen):**
+1. **Co-membered SKIP backlog is a CLO/GDPR blocker for auto-backfill (data P0).** PA-17(c)(2)
+   + the counsel review (`2026-05-counsel-review-4558.md`) require a fresh Art. 6(1)(a)
+   attestation per co-member — auto-adopting the owner's repo onto a co-membered workspace
+   is unlawful. The literal "drift COUNT → 0" exit is reshaped: solo rows → 0; co-membered
+   rows are a **lawful carried residual** cleared only by owner re-connect (this PR's write
+   path). Surfaced to CPO/CLO.
+2. **Background-callback 0-row write is a silent no-op (data P0).** `.eq("id",capturedId)`
+   matching 0 rows returns `{error:null}`; the workspace can be deleted mid-clone
+   (`current_workspace_id` ON DELETE SET NULL). Callback must `.select("id")` + Sentry-mirror.
+3. **23505 unique-violation branch goes DEAD on relocation (data P1).** The UNIQUE is on
+   `users` only (mig 052); `workspaces` is non-unique (ADR-044 fan-out). Delete the branch;
+   re-justify cross-tenant attribution via the webhook fan-out reconcile.
+4. **`repo_error` needs a real column add + mirror extension (data P1)** — not just a GRANT
+   line (the column doesn't exist on `workspaces` yet; GRANT alone errors). Confirmed
+   non-credential (sanitized).
+5. **Resolve-once-thread-everywhere rule (spec-flow P0):** one membership-verified
+   `resolveActiveWorkspace` id threads into owner-gate `p_workspace_id`, all writes, the
+   optimistic lock, provisioning, the callback closure, the cloning-guard read, and
+   `repo_error` — with the `resetFromClaim` self-heal and `{ok:false}` fail-closed branches.
+6. **`users.*` rollback-net removal is directional (issue supersedes spec scaffold)** —
+   exit criterion is *zero* `users.*` writes; rollback is whole-PR revert (read path is
+   workspaces-only; columns not dropped here).
+
+### New considerations discovered
+- disconnect tears down a SHARED team dir → must abort live member sessions before `rm`.
+- The deliberate column split (repo cols → activeId; provisioning/readiness cols → owner's
+  `users` row) must be explicit so reviewers don't flag the retained `user.id` writes.
+
+## Overview
+
+ADR-044 relocates GitHub repo-connection state from `users.*` to `workspaces.*`.
+The **read** path is already cut over (`current-repo-url.ts`, `workspace-resolver.ts`
+read `workspaces.repo_url` / the `resolve_workspace_installation_id` SECURITY DEFINER
+RPC). The **write** path is still `users`-authoritative: the four connect routes write
+`users.{repo_url, workspace_path, github_installation_id, repo_error}` and best-effort
+*mirror* a subset to `workspaces` via `mirrorRepoColsToSoloWorkspace`, always keyed on
+`user.id` (the solo workspace). PR-2a (#5455, shipped) added a **422 refusal** when a
+team workspace is active, because the legacy path would silently provision/disconnect
+the caller's *personal* solo workspace.
+
+This PR **inverts the dual-write**: `workspaces` becomes authoritative (keyed on the
+**resolved active workspace id** — team or solo), the `users.*` connect-time writes are
+removed, the PR-2a 422 refusal is **replaced by real team on-disk provisioning**, and
+`repo_error` is re-keyed to `workspaces`. This is the precondition that unblocks PR-2b
+(#5437, the destructive `users` column drop). After this PR, a `git grep` of
+`repo_url|workspace_path|github_installation_id` write sites under `app/api/repo/**`
+targeting `users.*` returns **0** (the `hr-write-boundary-sentinel-sweep-all-write-sites`
+gate).
+
+**Scope (4 work items, single atomic PR):**
+1. **Team on-disk provisioning** in `repo/setup` + `repo/disconnect` — resolve the
+   target workspace id server-side (claim/session-derived, IDOR-safe, never `req.body`)
+   via the **membership-verified** `resolveActiveWorkspace`, provision/tear down
+   `/workspaces/<active_id>`, and replace the 422 refusal.
+2. **Write relocation** — `repo_url` / `workspace_path` / `github_installation_id`
+   writes move from `users` → the active `workspaces` row across `setup`, `install`,
+   `detect-installation`, `disconnect`. `mirrorRepoColsToSoloWorkspace` is
+   inverted/removed (workspaces becomes the authoritative write target).
+3. **Re-key `repo_error`** to `workspaces` (new migration 110 adds the column; the
+   write moves; `getCurrentRepoStatus` reads it from `workspaces`).
+4. **Re-backfill + reconcile the mig-080 co-membered SKIP backlog** so PR-2b's
+   drift-gate `COUNT` can reach 0.
+
+> **Why no `users.*` rollback net (directional decision — confirm).** The spec
+> scaffold (authored for PR-2a) said "the existing `users.*` writes stay as the
+> rollback net." The **issue #5462 supersedes** this: its exit criterion is *zero*
+> `users.*` write sites, which is the literal precondition for PR-2b's column drop.
+> Keeping the `users.*` write would re-introduce the dual-source-of-truth divergence
+> ADR-044 forbids and would make the PR-2b drift gate unreachable. So this PR removes
+> the `users.*` connect-time writes. The rollback net during *this* PR's soak is
+> git-revert of the whole PR (read path already reads `workspaces`; mig 110 is additive
+> + `.down.sql`-reversible; the `users` columns are NOT dropped here, so a revert
+> restores the `users`-authoritative writes without data loss). **This is the merge of
+> two source-of-truth directions (users→workspaces); the direction is workspaces-wins,
+> confirmed by the issue body and ADR-044 Decision.**
+
+## Premise Validation
+
+- **Issue #5462 is OPEN** (`gh issue view 5462` → state OPEN). It is the tracking item
+  for the team write-cutover; the spec body confirms #4560 is journey-state UI polish,
+  NOT this work (corrected mis-attribution).
+- **Blocker check:** #5437 (PR-2b column drop) is OPEN and blocked-by this; not stale.
+- **Cited write sites verified on the branch** (line numbers match issue body within ±2):
+  `setup/route.ts:182,213-214,257,331`, `install/route.ts:120`,
+  `detect-installation/route.ts:141`, `disconnect/route.ts:121-130`.
+- **Mechanism vs ADR corpus:** ADR-044 `## Decision` Option A *is* this relocation
+  ("TS read-cutover 081-equivalent; later decommission of the `users` columns after a
+  prod soak"). The write-cutover is the gap PR-1 + PR-2a left open — NOT a rejected
+  alternative. ADR-044 is `status: adopting`; its C4 edge is "read=Workspace /
+  write=User (dual)" and explicitly waits for "PR-2 [to] relocate them to `workspaces.*`."
+- **Self-capability check:** `repo_error` is NOT on `workspaces` — mig 079 added exactly
+  5 columns (`repo_url, repo_provider, github_installation_id, repo_status,
+  repo_last_synced_at`), no `repo_error` (verified via grep of `079_*.sql`). So re-keying
+  `repo_error` *requires a new migration* (110); it is not a pure app-layer move.
+- **Next migration number = 110** (`ls migrations/` tail = 107/108/109).
+- **No external premises beyond the above; all held.**
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Spec/issue claim | Reality (verified file:line) | Plan response |
+|---|---|---|
+| Spec scaffold: "existing `users.*` writes stay as the rollback net" | Issue #5462 exit criterion: **zero** `users.*` write sites under `app/api/repo/**`. Keeping them blocks PR-2b's drift gate. | **Remove** the `users.*` connect-time writes; rollback net is whole-PR git-revert (read path is workspaces-only; mig 110 is reversible; `users` cols not dropped). Directional decision flagged above. |
+| Issue: "invert/remove `mirrorRepoColsToSoloWorkspace`" | `mirrorRepoColsToSoloWorkspace` (`workspace-repo-mirror.ts:52`) writes a SUBSET to `workspaces.id=userId`; `users` is authoritative. | Replace with a `writeRepoColsToWorkspace(service, workspaceId, patch)` that writes the authoritative `workspaces` row keyed on the **resolved active id**; delete the mirror + its solo-only assumptions. |
+| Issue: "resolve target `workspace_id` server-side (IDOR-safe, never `req.body`)" | Routes already resolve via `resolveCurrentWorkspaceId(user.id, supabase)` (claim-derived). But the **membership-verified** `resolveActiveWorkspace` (`workspace-resolver.ts:365`) is stronger: `{ok:true, workspaceId}` only for a membership-verified team id or own solo id; `{ok:false,"db-error"}` otherwise. | Use `resolveActiveWorkspace` (NOT the simple `resolveCurrentWorkspaceId`) at the write boundary — its `{ok:false}` must fail-closed (do NOT provision into an unverified team). See SE on identity-pinned writes. |
+| Issue: "preserve owner-gate invariant (`p_workspace_id` == the id the handler mutates)" | Both routes call `is_workspace_owner({p_workspace_id: user.id, ...})` — but they will now mutate `workspaces.<active_id>` and provision `/workspaces/<active_id>`. | Change `p_workspace_id` to the **resolved active id**, atomically with the write-target change. A window where the gate checks `user.id` but the handler mutates `<active_id>` is a confused-deputy hole. |
+| Issue: "re-key `repo_error` to `workspaces`" | `repo_error` is on `users` only (mig 079 has no such column); `getCurrentRepoStatus` reads `users.repo_error` (`current-repo-url.ts:140-144`). | New migration 110: `ADD COLUMN repo_error text` on `workspaces` (in the non-credential GRANT set); move the write (`setup` error branch, `disconnect` clear) to `workspaces`; read from `workspaces`. Fixes the documented dispatching-user-vs-active-workspace key mismatch (`current-repo-url.ts:97-104`). |
+| Issue: "re-backfill the mig-080 co-membered SKIP backlog so the drift-gate COUNT can reach 0" | mig-080 SKIPped solo workspaces with `>1` member. **Deepen-confirmed CLO blocker:** PA-17(c)(2) + counsel review require a fresh Art. 6(1)(a) attestation per co-member — auto-adopting the owner's repo onto a co-membered workspace is **unlawful**. PR-2b drift gate counts `users.* DISTINCT FROM workspaces.*`. | mig 110 re-keys the **solo** backfill → 0 solo drift. Co-membered rows are **NOT auto-adopted** — they are a lawful carried residual cleared only by owner re-connect (this PR's owner-gated write path). The drift exit is reshaped: solo COUNT=0 + "0 co-membered rows adopted WITHOUT an attestation." Surfaced to CPO/CLO. See Phase 1 items 4-5 + the SE. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a team owner connects a repository to
+their team workspace and it silently lands on their personal solo workspace (or vice
+versa) — the team's agents run against the wrong (empty) clone, or a disconnect leaves a
+live GitHub App credential readable on the team's read path. A non-owner member could
+connect/disconnect a workspace they don't own (confused deputy).
+
+**If this leaks, the user's data/workflow/money is exposed via:** `github_installation_id`
+is a GitHub App **token grant**; relocating it across the user→workspace tenant boundary
+with a mis-resolved id (or a write that races the owner-gate) could bind one tenant's
+credential into another workspace's read path. The IDOR-safe claim-derived +
+membership-verified resolution and the `p_workspace_id == mutation-target` owner-gate
+invariant make that structurally impossible.
+
+**Brand-survival threshold:** single-user incident. CPO sign-off required at plan time
+before `/work`; `user-impact-reviewer` runs at PR review (handled by `review/SKILL.md`
+conditional-agent block). Inherited from ADR-044 (`brand_survival_threshold: single-user
+incident`).
+
+## Architecture Decision (ADR/C4)
+
+This PR changes the **write side** of the ADR-044 ownership boundary (connect-time writes
+move User → Workspace). That is an architectural-decision *completion*, so the ADR + C4
+update are deliverables of THIS plan, not a follow-up.
+
+### ADR
+Amend **ADR-044** (`knowledge-base/engineering/architecture/decisions/ADR-044-workspace-repo-ownership.md`)
+via `/soleur:architecture`:
+- Add a PR-2 (write-cutover) entry to the lifecycle note documenting that connect-time
+  writes now target `workspaces.*`, `repo_error` relocated, the co-membered backlog
+  reconciled.
+- **Status stays `adopting`** (NOT `accepted`): per ADR-044 line 148, the
+  `adopting → accepted` flip lands with PR-2b's column drop after a prod soak. This PR
+  moves the write edge but does not drop the legacy columns, so the invariant is not yet
+  fully held.
+
+### C4 views
+- ADR-044 prose C4 edge: connection edge moves **read=Workspace / write=User (dual)** →
+  **read=Workspace / write=Workspace** (the `users` columns survive only as un-written
+  legacy until PR-2b). Update the edge description in ADR-044's `## Consequences` C4 note.
+- Check `knowledge-base/engineering/architecture/diagrams/model.c4` at /work time for an
+  explicit User→repo / Workspace→repo relationship; if present, the C4 edit is gated
+  behind the `c4-edit` Concierge-only KB-write flag (commit `3c8849655`) — route through
+  the Concierge path, but the update lands in THIS feature's lifecycle.
+
+### Sequencing
+The ADR/C4 edit describes the post-merge target state and lands in this PR's commits.
+No deferral.
+
+## Implementation Phases
+
+> **TDD throughout** (`cq-write-failing-tests-before`): each phase writes failing tests
+> first, then the implementation. Phase order is **load-bearing**: the migration (Phase 1)
+> ships the `workspaces.repo_error` column + reconcile BEFORE the write-relocation code
+> (Phase 2-3) that targets it. Atomic merge ≠ atomic per-phase — the release pipeline runs
+> `run-migrations.sh` before code cutover (per the mig-109 prerequisite pattern).
+
+### Phase 1 — Migration 110: `workspaces.repo_error` + co-membered re-backfill/reconcile [data]
+
+`apps/web-platform/supabase/migrations/110_workspace_repo_error_and_comember_reconcile.sql`
+(+ `.down.sql`, + `verify/110_*.sql`):
+
+1. `ALTER TABLE public.workspaces ADD COLUMN IF NOT EXISTS repo_error text;` — read the
+   2-3 most recent migrations first (`108`, `109`) to confirm the transaction-wrapping +
+   no-`CONCURRENTLY` convention (Supabase wraps each file in a txn; SQLSTATE 25001).
+2. Extend the **non-credential GRANT** on `workspaces` to include `repo_error`. Re-issue
+   the FULL GRANT after the existing REVOKE (mirror mig 079:89's shape — do NOT issue a
+   partial column GRANT): `GRANT SELECT (id, organization_id, name, created_at, repo_url,
+   repo_provider, repo_status, repo_last_synced_at, repo_error) ON public.workspaces TO
+   authenticated`. **`repo_error` is non-credential (deepen-confirmed):** it is built at
+   `setup/route.ts:324-328` as `JSON.stringify({code, message: sanitizeGitStderr(...), ...})`;
+   `sanitizeGitStderr` (`git-auth.ts:211-213`) strips absolute paths, and the GitHub App
+   token never reaches stderr (askpass via env, never argv; `GIT_TERMINAL_PROMPT=0`). So it
+   belongs in the `authenticated` read set — `getCurrentRepoStatus` reads it via the tenant
+   client, preserving the cc-dispatcher OFF-service-role posture (`current-repo-url.ts:88`).
+   **The GRANT alone is insufficient — the column MUST be added first (step 1)** or
+   `GRANT SELECT (repo_error)` errors on a missing column (deepen item 1).
+3. Backfill `workspaces.repo_error` from `users.repo_error` for the solo canary rows
+   (mirror mig-080's `w.id = u.id` + sole-member guard + idempotency `WHERE
+   w.repo_error IS NULL`).
+4. **Co-membered SKIP backlog — re-key the solo backfill, DO NOT auto-adopt co-membered
+   rows (CLO blocker, deepen-confirmed).** Re-run the mig-080 solo backfill for any solo
+   rows that became correctly-provisioned. **The co-membered SKIP backlog MUST NOT be
+   auto-drained.** The deepen data-integrity pass confirmed against the legal corpus:
+   - mig-080 SKIPs co-membered workspaces (`080:48-83`) citing the CLO requirement
+     (`080:7-10`).
+   - `knowledge-base/legal/audits/2026-05-counsel-review-4558.md` (call B1) + the Art. 30
+     register **PA-17 sub-clause (c)(2)** establish that co-member repo access is lawful
+     ONLY via a **fresh Art. 6(1)(a) invite attestation** (`workspace_member_attestations`,
+     mig 058) — "the Art. 6(1)(a) basis **never operates retroactively** on a connection
+     established before the Owner's consent of record." A blind re-backfill that copies the
+     owner's `users.repo_url` onto a co-membered workspace processes co-member access
+     WITHOUT that attestation → a direct GDPR violation of the lawful-basis split the CLO
+     signed. `hr-gdpr-gate-on-regulated-data-surfaces` blocks it.
+   - **Correct closure (not auto-drain):** the SKIP backlog clears **only when the owner
+     re-connects the repo from within the team-workspace context** — which is exactly the
+     owner-gated write path THIS PR implements (Phase 3). A re-connect re-establishes the
+     connection under a fresh attestation, so it is lawful. The backlog is therefore
+     **carried, not auto-drained**.
+5. **Drift-gate semantics (reshaped — deepen-confirmed).** The PR-2b drift gate (ADR-044
+   Consequences) counts `users.* DISTINCT FROM workspaces.*`. Because the co-membered rows
+   CANNOT be auto-adopted (item 4), this PR CANNOT drive the raw `COUNT` to 0 for
+   co-membered workspaces by backfill. Two-part exit:
+   - **Solo rows:** the re-keyed solo backfill brings them to 0 divergence.
+   - **Co-membered rows:** the gate must assert "**0 co-membered rows adopted WITHOUT a
+     corresponding attestation**," NOT "0 SKIP rows remaining." Carry the un-re-connected
+     co-membered rows as a **known residual** (documented in the migration header + the
+     PR-2b precondition note). PR-2b's column drop must tolerate this residual (the `users`
+     value for an un-re-connected co-membered owner is the LAST owner-connected value;
+     dropping it after the owner re-connects via the team path is safe). **This is a
+     directional refinement of the issue's "drift COUNT can reach 0" — surface to CPO/CLO:
+     the literal COUNT-to-0 is unlawful for co-membered rows; the lawful exit is
+     attestation-gated re-connect.** Re-key the solo backfill on `(github_installation_id,
+     normalizeRepoUrl(repo_url))` per ADR-044's fan-out; never adopt across an
+     `organization` boundary. Run from the still-authoritative `users` snapshot BEFORE the
+     write cutover deploys (Phase 1 before Phase 2-3 per the ordering).
+6. **Drift-gate convergence check** (verify/110): run ADR-044's exact PR-2b gate query
+   (`SELECT COUNT(*) FROM users u JOIN workspaces w ON w.id=u.id WHERE (u.repo_url IS NOT
+   NULL AND w.repo_url IS DISTINCT FROM u.repo_url) OR (u.github_installation_id IS NOT
+   NULL AND w.github_installation_id IS DISTINCT FROM u.github_installation_id)`) **scoped
+   to SOLO rows** (sole-member workspaces) and assert it returns 0 post-reconcile. The
+   co-membered residual is asserted separately as "0 co-membered rows adopted WITHOUT an
+   attestation" (item 5). **These counts are preconditions to verify at /work time against
+   live dev (Doppler `DATABASE_URL_POOLER`), NOT plan-time facts** — see SE.
+7. Verify in a **rolled-back dev transaction** (`BEGIN; <body>; <drift count>;
+   <re-run for idempotency>; ROLLBACK`) — zero `_schema_migrations` drift, leaving the
+   real apply to the pipeline.
+
+**Precedent (deepen 4.4 — grepped):** the column-add + GRANT-extension shape is canonical:
+- `ALTER TABLE public.workspaces ADD COLUMN IF NOT EXISTS …` — mig 079:50-55, 098:35.
+- `GRANT SELECT (id, organization_id, name, created_at, repo_url, repo_provider,
+  repo_status, repo_last_synced_at) ON public.workspaces TO authenticated` — mig 079:89.
+  Add `repo_error` to this exact list (re-issue the full GRANT after the `REVOKE`, mirroring
+  079's shape — do NOT issue a partial column GRANT).
+- The idempotent backfill `DO $$ … GET DIAGNOSTICS v_rc = ROW_COUNT; RAISE NOTICE … $$`
+  shape is mig 080:27-56. Reuse verbatim.
+
+**Tests:** follow the repo's migration-test convention at
+`apps/web-platform/test/supabase-migrations/NNN-<topic>.test.ts` (siblings:
+`108-repo-clone-self-heal-rpc.test.ts`, `098-workspace-logos.test.ts`). Add
+`110-workspace-repo-error-and-comember-reconcile.test.ts` asserting: column exists + in
+the `authenticated` GRANT set; solo backfill idempotent; co-membered reconcile lands only
+owner-owned rows (or defers per the legal decision); drift count → 0. Also add a
+`verify/110_*.sql` following the `check_name`/`bad` contract (each row returns `check_name`
++ `bad`; any `bad > 0` fails CI `verify-migrations` and auto-closes the matching
+`follow-through` issue) — siblings: `verify/109_*.sql`. The drift-gate check is a
+`SELECT 'repo_drift_count' AS check_name, (<ADR-044 drift query>) AS bad`.
+
+### Phase 2 — Write helper inversion: `workspaces` authoritative [TR: write-boundary]
+
+`apps/web-platform/server/workspace-repo-mirror.ts` → rename/replace with
+`writeRepoColsToWorkspace(service, workspaceId, patch, opts?)`:
+
+1. Write the authoritative `workspaces` row keyed on the **caller-supplied resolved
+   workspace id** (NOT hardcoded `userId`). Extend `MirroredRepoCols` to include
+   `repo_error?: string | null` (now a `workspaces` column).
+2. Keep the **fail-closed on credential-clear** asymmetry (`throwOnError` on disconnect)
+   — but it is now load-bearing for the AUTHORITATIVE write, not a mirror: a failed
+   `workspaces` write on connect means the connection didn't persist (surface the error
+   to the caller, do NOT fall through to a `users` write — there is none).
+3. Preserve the exact `reportSilentFallback` `message:` string
+   (`cq-silent-fallback-must-mirror-to-sentry` + the helper-migration message-preservation
+   SE) and `op` slug so operator dashboards keyed on it don't go dark.
+4. Update `test/workspace-repo-mirror.test.ts` → assert writes target the supplied id
+   (team id case + solo id case), `repo_error` round-trips, fail-closed throws.
+
+### Phase 3 — Relocate the four route write sites + team provisioning [FR1, FR2, IDOR]
+
+**The single load-bearing rule (resolve once, thread everywhere — P0-1/P0-2/P0-3):**
+resolve the target workspace id ONCE per request via `resolveActiveWorkspace(user.id,
+supabase)` (membership-verified), then thread that SAME id into ALL of: (a) the owner-gate
+`p_workspace_id`, (b) every `workspaces.*` write, (c) the optimistic clone-lock predicate,
+(d) `provisionWorkspaceWithRepo` / `deleteWorkspace`, (e) the setup background-callback
+closure, (f) the cloning-guard read, (g) the `repo_error` write. Add a test asserting
+gate-id === mutation-id === provision-id. The `resolveActiveWorkspace` outcomes:
+- `{ok:true, workspaceId}` (membership-verified team id OR own solo id) → proceed against it.
+- `{ok:true, workspaceId:userId, resetFromClaim:<staleTeam>}` (**P0-3 self-heal branch**):
+  the caller is a removed/non-member of the claimed team. The handler MUST connect/disconnect
+  the caller's **own solo workspace** (the reset `userId`), and the owner-gate + writes +
+  provisioning ALL use that reset id — never the stale claim. A removed member disconnecting
+  thus tears down their OWN repo, not the team's. (Emit the existing divergence breadcrumb.)
+- `{ok:false, reason:"db-error"}` → **fail-closed 503** (retryable). Do NOT fall back to
+  solo and write (the `resolveCurrentWorkspaceId` fail-to-solo posture is unsafe at a WRITE
+  boundary — it would silently misroute a team write to the caller's solo row). This is why
+  the routes switch from `resolveCurrentWorkspaceId` → `resolveActiveWorkspace`.
+
+**The deliberate column split (P2-2 — make explicit so reviewers don't flag it):** the
+**repo-connection** columns (`repo_url`, `github_installation_id`, `repo_status`,
+`repo_last_synced_at`, `repo_error`) move to `workspaces.<activeId>`. The
+**provisioning/readiness** columns (`workspace_status`, `health_snapshot`) are NOT relocated
+by ADR-044 and stay on the **owner's `users` row** — and the connecting caller IS the owner
+(owner-gated), so `user.id` is the correct key for those specific writes. This split is
+intentional; the readiness gate (`resolveActiveWorkspaceKbRoot:518-532`) reads the active
+workspace OWNER's `users.workspace_status`, so the owner-keyed write is correct.
+
+**3a. `app/api/repo/setup/route.ts`:**
+- Replace the PR-2a 422 block (`:50-59`) with: resolve active id; on `{ok:false,"db-error"}`
+  return 503 (retryable). Keep IDOR posture — the id is claim-derived, never `req.body`.
+- Owner-gate (`:69-72`): `p_workspace_id` = **resolved active id** (was `user.id`).
+- Lock flip + repo write (`:179-208`): write `workspaces` (status `cloning`, `repo_url`,
+  `repo_error: null`, `repo_last_synced_at`) keyed on active id; the optimistic
+  `.neq("repo_status","cloning")` lock moves to the `workspaces` row. **Remove** the
+  `users.*` write at `:182-186` and the mirror at `:212-217`.
+  - **P0-5 (race):** the lock predicate MUST become
+    `workspaces.update(...).eq("id", activeId).neq("repo_status","cloning")` so the contended
+    row is the SHARED workspace, not each caller's own `users` row. On `users` keyed per
+    caller, two concurrent connect attempts on the same team workspace would both win the
+    lock; on `workspaces.<activeId>` they serialize correctly. `workspaces.repo_status` has
+    the same CHECK enum (mig 079:53-54) so the transition is schema-compatible; `service_role`
+    keeps its default grant so the service-client lock write is unaffected by the REVOKE.
+- `provisionWorkspaceWithRepo(activeId, ...)` (`:228`, was `user.id`) — provision
+  `/workspaces/<active_id>` on disk.
+- Background callback (`:236-345`): the resolved active id is **captured in the closure**
+  (do NOT re-resolve inside the callback — the session claim could drift between request
+  return and clone completion; identity-pinned write SE). Write the **repo-connection**
+  cols (`repo_status:ready/error`, `repo_error`, `repo_last_synced_at`) to
+  `workspaces.<capturedActiveId>`; keep the **provisioning/readiness** cols
+  (`workspace_status`, `health_snapshot`) on the owner's `users` row (the connecting caller
+  IS the owner — see the deliberate column split above). **Remove** the `users.*`
+  repo-connection writes at `:254-263`/`:329-332` and the mirrors at `:274-277`/`:342-344`.
+  - **P0-4 (`triggerHeadlessSync`):** the call at `:297-304` passes
+    `resolveWorkspaceId: resolveCurrentWorkspaceId`, which RE-RESOLVES inside the helper. It
+    must instead target the **captured active id** (pass a `() => capturedActiveId` thunk or
+    the id directly), else headless sync runs against the now-active workspace instead of the
+    just-cloned one if the user switched workspaces mid-clone.
+  - **0-row silent no-op (deepen data-integrity — load-bearing):** a
+    `workspaces.update(...).eq("id", capturedId)` that matches **0 rows** returns
+    `{error:null}` — a SILENT no-op (the workspace could be deleted between request return
+    and callback completion; `current_workspace_id` is `ON DELETE SET NULL`, mig 079:145).
+    The callback's terminal `workspaces` writes (success + error branch) MUST `.select("id")`
+    and treat an empty result as a failure class → `reportSilentFallback`
+    (`cq-silent-fallback-must-mirror-to-sentry`). For the team-id path, prefer re-validating
+    workspace existence/membership at callback time over blindly trusting the
+    closure-captured id across the clone RTT.
+  - Note: `workspace_path` becomes a `workspaces` column write — **confirm the column
+    exists** (mig 079 did NOT add `workspace_path` to `workspaces`; the read path uses
+    `workspacePathForWorkspaceId(id)` deriving the path from id, `workspace-resolver.ts:792`).
+    If no consumer reads `workspaces.workspace_path`, the relocation target for
+    `workspace_path` is to **drop the write entirely** (the path is derived from the
+    workspace id, not stored) — verify at /work; this is the cleanest exit and still
+    satisfies the zero-`users.*`-write criterion. `health_snapshot` similarly: check
+    whether it must relocate or stays a `users` column (it is NOT a repo-connection
+    column ADR-044 relocates; confirm consumer reads).
+- **`workspaces.workspace_status`** is read by `resolveActiveWorkspaceKbRoot` readiness
+  gate via the OWNER's `users.workspace_status` (`workspace-resolver.ts:518-532`) — this
+  is a `users` read (owner's row), NOT a `users` *write* under `app/api/repo/**`, so it is
+  out of the exit-criterion scope; do not relocate it in this PR (flag in Non-Goals).
+
+**3b. `app/api/repo/disconnect/route.ts`:**
+- Replace the 422 block (`:49-58`) with active-id resolution (same fail-closed posture).
+- Owner-gate `p_workspace_id` = resolved active id.
+- The `cloning`-lock fetch (`:94-98`) + the clear write (`:119-131`) → `workspaces` keyed
+  on active id (clear `repo_url`, `github_installation_id`, `repo_status:not_connected`,
+  `repo_last_synced_at`, `repo_error`). **Remove** the `users.*` clear and the mirror
+  (`:150-164`). Fail-closed on the authoritative `workspaces` write.
+  - **P1-6:** the cloning-guard SELECT at `:94-98` reads `users.repo_status` today — it MUST
+    move to `workspaces.<activeId>.repo_status`, or a team disconnect checks the
+    disconnecter's personal (non-cloning) row and proceeds to delete a workspace whose
+    shared clone is in flight (the background `.then` then writes `ready` to a deleted dir).
+- **On-disk teardown** (`deleteWorkspace(active_id)`, was `user.id`): **P0-6 — a team
+  workspace dir is SHARED across members.** Tearing down `/workspaces/<team_id>` on a
+  disconnect removes the shared clone for all members, and a member running an agent session
+  in that dir gets ENOENT mid-operation. This is *intended* (disconnecting the team's repo
+  disconnects it for everyone, owner-only) — but the handler MUST **abort live member
+  sessions before the `rm`** (the `abortAllWorkspaceMemberSessions` path referenced at
+  `workspace-resolver.ts:730` / the ws-handler) so no agent is mid-write when the dir
+  disappears. Confirm the abort hook with spec-flow/CPO at /work. (Member *removal* is a
+  separate flow that does NOT call `deleteWorkspace` — `workspace.ts:268-270`.)
+
+**3c. `app/api/repo/install/route.ts`:**
+- The install route stores `github_installation_id` pre-setup. It has NO active-workspace
+  resolution today (`:118-121` writes `users`). The installation grant must land on the
+  active `workspaces` row. **Resolve active id** (claim-derived) and write
+  `workspaces.github_installation_id` keyed on it; **remove** the `users` write (`:120`)
+  and the mirror (`:139-141`). Note: `github_installation_id` is REVOKE'd from the
+  `authenticated` grant — a service-role write is required (route already uses
+  `serviceClient`), correct.
+- **Owner-gate consideration:** install writes a credential to the active workspace — add
+  the `is_workspace_owner(activeId, user.id)` gate (parity with setup/disconnect) so a
+  non-owner can't write the team's credential. Flag for spec-flow: is install reachable
+  with a team workspace active? If yes, gate it; if it's always pre-team (solo onboarding),
+  document the no-op.
+
+**3d. `app/api/repo/detect-installation/route.ts`:**
+- Same as install: the login-matched install write (`:141`) + mirror (`:178-180`) →
+  `workspaces.github_installation_id` keyed on the resolved active id; remove the `users`
+  write.
+- **23505 branch goes DEAD on full relocation (deepen-confirmed).** The partial-UNIQUE is
+  on `users.github_installation_id` ONLY (mig 052:159-161); `workspaces` is intentionally
+  NON-unique (mig 079:57-66, ADR-044 fan-out). So the `23505` tolerance branch (`:145-165`)
+  can never fire on a `workspaces.github_installation_id` UPDATE — **delete it** (do not
+  keep dead error-handling). **But re-justify the cross-tenant guard it served:** the
+  `users` UNIQUE was the load-bearing guard against "founder A's PRs land on founder B's
+  dashboard" (mig 052:153-157). After removal, that invariant is enforced by the **webhook
+  push-reconcile fan-out** over `(installation_id, normalizeRepoUrl(repo_url))` (ADR-044
+  Decision §1). The plan MUST confirm at /work that the fan-out reconcile preserves the
+  attribution invariant before relying on it instead of the DB UNIQUE — cite the reconcile
+  code path. (The `users` UNIQUE itself is dropped by PR-2b, not here.)
+
+**Exit-criterion gate (Phase 3 AC):** `git grep -nE
+'\.from\("users"\)[^;]*\.update\([^)]*\b(repo_url|workspace_path|github_installation_id|repo_error)\b'
+-- 'apps/web-platform/app/api/repo/**'` returns **0** matches. (Plus a broader sweep that
+covers multi-line `.update({...})` blocks — see SE on write-boundary sweeps; the AC must
+catch the patch-object form, not just a single-line literal.)
+
+**Tests:** extend `test/setup-route-install-resolution.test.ts`,
+`test/disconnect-route.test.ts`, `test/install-route*.test.ts`,
+`test/detect-installation-fallback.test.ts`:
+- The PR-2a 422 tests (`setup-route-install-resolution.test.ts:176`,
+  `disconnect-route.test.ts:141`) **must be rewritten** — a team workspace active now
+  PROVISIONS (200), it does not 422. Replace with: team-active + owner → provisions
+  `/workspaces/<team_id>` and writes `workspaces.<team_id>`; team-active + non-owner → 403;
+  active-id resolver `{ok:false}` → 503.
+- Owner-gate `p_workspace_id` asserted to equal the **resolved active id** (not `user.id`)
+  on the team path.
+- Writes target `workspaces`, never `users` (mock asserts no `users.update` of the four
+  columns).
+
+### Phase 4 — Re-key `repo_error` read [FR3]
+
+`apps/web-platform/server/current-repo-url.ts`:
+- `getCurrentRepoStatus` (`:106-166`): read `repo_error` from `workspaces` (keyed on the
+  resolved target workspace id, `:129-130`) instead of `users` (`:140-144`). This **fixes**
+  the documented dispatching-user-vs-active-workspace key mismatch (`:97-104`): the error
+  reason now keys on the same active workspace as `repo_status`, so a member dispatching
+  against a workspace whose error was caused by another member reads the correct reason.
+- Remove the now-stale forward-looking comment block (`:97-104`) and the `users.repo_error`
+  read; update the doc comment.
+- **Tests:** `getCurrentRepoStatus` returns the active workspace's `repo_error`; the
+  cross-member case now returns the workspace reason, not null.
+
+### Phase 5 — ADR-044 amendment + C4 edge [arch, wg-architecture-decision-is-a-plan-deliverable]
+
+Per the `## Architecture Decision` section: amend ADR-044 lifecycle note + C4 edge
+prose (write=User → write=Workspace), status stays `adopting`. Check `model.c4` for an
+explicit edge; route any `.c4` edit through the Concierge `c4-edit` path.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- [ ] AC1: `git grep -nE '\.from\("users"\)' -- 'apps/web-platform/app/api/repo/**'`
+  shows NO `.update()` of `repo_url|workspace_path|github_installation_id|repo_error`
+  (the `hr-write-boundary-sentinel-sweep` gate). Sweep covers multi-line patch objects.
+- [ ] AC2: Connect-time writes for those columns target `workspaces` keyed on the
+  resolved active workspace id (assert in route tests, both team + solo).
+- [ ] AC3: The PR-2a 422 refusal is **gone** from `setup` + `disconnect`; a team-active
+  owner now provisions (200); a team-active non-owner gets 403; resolver `{ok:false}`
+  gets 503. (Old 422 tests rewritten, not deleted silently.)
+- [ ] AC4: Owner-gate `p_workspace_id` equals the resolved active id (the mutation
+  target) in all gated routes — asserted in tests.
+- [ ] AC5: The active workspace id is resolved from session/claim via
+  `resolveActiveWorkspace`, never from `req.body`/`req.query` (IDOR) — grep the routes
+  for `body.workspaceId`/`req` workspace-id reads returns 0.
+- [ ] AC6: mig 110 adds `workspaces.repo_error`, re-issues the full non-credential GRANT
+  with `repo_error` included, and is idempotent + `.down.sql`-reversible; `verify/110`
+  asserts (a) SOLO drift-gate `COUNT = 0` post-reconcile AND (b) `0 co-membered rows
+  adopted WITHOUT an attestation` (NOT "0 SKIP rows remaining" — co-membered backlog is a
+  lawful carried residual cleared by owner re-connect, per CLO/PA-17(c)). Verified in a
+  rolled-back dev txn.
+- [ ] AC7: `getCurrentRepoStatus` reads `repo_error` from `workspaces`; cross-member case
+  returns the workspace reason (test).
+- [ ] AC8: `repo_error` is in the `authenticated` GRANT set on `workspaces` (it is a
+  reason string, not a credential) — `github_installation_id` stays REVOKE'd.
+- [ ] AC9: Typecheck clean: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit`.
+- [ ] AC10: Test suite green via the repo's runner (check `apps/web-platform/package.json
+  scripts.test` / `vitest.config.ts include:` globs before prescribing a path —
+  `./node_modules/.bin/vitest run <path>`).
+- [ ] AC11: ADR-044 amended (lifecycle + C4 edge write=Workspace, status stays
+  `adopting`); C4 model checked/updated.
+- [ ] AC12: `## Observability` failure modes (below) reachable from Sentry without SSH.
+
+### Post-merge (operator → automated)
+- [ ] AC13: mig 110 applied by the release pipeline (`web-platform-release.yml #migrate`
+  runs before code cutover — automated, no operator SSH). Verify via the Supabase MCP /
+  `gh` post-merge, not a dashboard eyeball.
+- [ ] AC14: Open the PR-2b soak window — confirm `repo_resolver_divergence` breadcrumb
+  volume in Sentry (issues API query, deterministic verdict) before #5437 proceeds. `Ref
+  #5437` (do not `Closes` — PR-2b is the closer).
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: workspaces-authoritative connect writes succeed (repo_status transitions cloning→ready)
+  cadence: per repo-connect event
+  alert_target: Sentry (feature=workspace-repo-write) + existing repo-setup dashboards
+  configured_in: apps/web-platform/server/workspace-repo-mirror.ts (renamed writeRepoColsToWorkspace) reportSilentFallback
+error_reporting:
+  destination: Sentry via reportSilentFallback / withIsolationScope (existing setup-route catch)
+  fail_loud: true (authoritative workspaces write failure surfaces to the caller; no silent users fallback)
+failure_modes:
+  - mode: workspaces write fails on connect → connection not persisted
+    detection: reportSilentFallback feature=workspace-repo-write op=write-to-workspace
+    alert_route: Sentry issue (existing op-contract)
+  - mode: resolveActiveWorkspace {ok:false} → 503, no provisioning into unverified team
+    detection: reportSilentFallback op=resolveActiveWorkspace.membership-probe
+    alert_route: Sentry
+  - mode: disconnect credential-clear mirror/write fails → fail-closed 500
+    detection: logger.error "Failed to clear repo fields"/"mirror repo disconnect" + 500 status
+    alert_route: Sentry + 5xx rate
+  - mode: mig-110 drift reconcile leaves COUNT>0 (PR-2b drift gate unreachable)
+    detection: verify/110 assertion + the PR-2b drift query
+    alert_route: pipeline migrate-step failure (web-platform-release.yml)
+logs:
+  where: pino structured logs (server/logger) + Sentry; preserve existing message: strings
+  retention: per existing Sentry/Better Stack config
+discoverability_test:
+  command: gh api -X GET "/repos/.../issues?labels=..." OR Sentry issues API query feature=workspace-repo-write (NO ssh)
+  expected_output: zero new error issues for a healthy connect/disconnect cycle on dev
+```
+
+## Domain Review
+
+**Domains relevant:** Engineering (CTO/architecture), Product (CPO — single-user-incident
+threshold), Legal (CLO — co-member repo adoption consent basis). No UI surface (the four
+routes are API-only; no `components/**/*.tsx` or `app/**/page.tsx` in Files to Edit) →
+**Product/UX Gate = NONE** (no wireframe needed; `wg-ui-feature-requires-pen-wireframe`
+does not fire).
+
+### Engineering (CTO / architecture-strategist)
+**Status:** carried-forward from ADR-044 + this plan's premise validation.
+**Assessment:** The write-cutover is the architecturally-load-bearing half (the read path
+shipped in PR-1). Key risks: (a) the `p_workspace_id == mutation-target` confused-deputy
+invariant must hold atomically; (b) the membership-verified resolver must fail-closed; (c)
+removing the `users.*` rollback net is sound only because the read path is workspaces-only
+and the columns are not dropped (revert-safe). All addressed in phases.
+
+### Product (CPO)
+**Status:** sign-off required (`requires_cpo_signoff: true`). The team-provisioning replaces
+a deliberate honesty-refusal (422) with real behavior — the brand-survival framing (wrong
+clone / leaked credential) is inherited from ADR-044.
+
+### Product/UX Gate
+**Tier:** none — no UI surface (API routes + migration only; no `components/**/*.tsx`,
+`app/**/page.tsx`, or `app/**/layout.tsx` in Files to Edit). `wg-ui-feature-requires-pen-wireframe`
+does not fire; no `.pen` wireframe required.
+**Decision:** N/A (no UI surface).
+**Agents invoked:** spec-flow-analyzer (gap analysis — 7 P0 / 6 P1 / 4 P2; all P0/P1 folded
+into Phases 1-4 + Sharp Edges).
+**Skipped specialists:** none.
+**Pencil available:** N/A (no UI surface).
+
+### Legal (CLO)
+**Status:** review the co-member repo-adoption consent basis shift. mig-080 SKIPped
+co-membered workspaces "no Art. 6(1)(f) co-member access without owner re-consent." Phase 4
+reconcile adopts the owner-connected repo onto co-membered workspaces **the owner owns**;
+the owner re-consent is now structurally the owner-gated write itself. Confirm this
+satisfies the CLO requirement (owner-initiated = Art. 6(1)(b) contract), documented in the
+migration header.
+
+## GDPR / Compliance Gate
+
+Touches regulated-data surfaces (migration, credential column `github_installation_id`,
+auth-adjacent owner-gate). `/soleur:gdpr-gate` runs at /work against the plan + migration
+110. Watch items: (a) the credential stays REVOKE'd from `authenticated` (only the reader
+RPC); (b) `repo_error` is a *sanitized* reason (`sanitizeGitStderr`) — confirm no raw paths
+leak into the new `workspaces.repo_error` column; (c) the co-member adoption consent basis
+(CLO above). Output advisory-only with mandatory disclaimer.
+
+## Open Code-Review Overlap
+
+1 open scope-out touches a file this plan edits:
+- **#3739** (`review: extract reportSilentFallbackWithUser helper — collapse 11-site
+  withIsolationScope+setUser duplication`) — touches the `setup/route.ts` catch block
+  (`:307-315`) this plan modifies. **Disposition: Acknowledge.** This plan relocates the
+  *write target* inside that catch (users→workspaces) but does not refactor the
+  `withIsolationScope+setUser` duplication; folding in the 11-site helper extraction is a
+  distinct concern with broader blast radius. The scope-out remains open; the new write
+  site should adopt the helper if/when #3739 lands. Do not silently re-file.
+
+## Test Scenarios
+
+1. Solo owner connects → `workspaces.<user.id>` authoritative write, `/workspaces/<user.id>`
+   provisioned, no `users.*` write.
+2. Team owner connects → `workspaces.<team_id>` write, `/workspaces/<team_id>` provisioned,
+   owner-gate `p_workspace_id=<team_id>`.
+3. Team non-owner connects → 403 (owner-gate), no write, no provisioning.
+4. Active-id resolver `{ok:false,"db-error"}` → 503, no provisioning into unverified team.
+5. Disconnect by team owner → `workspaces.<team_id>` cleared, fail-closed on write error,
+   `/workspaces/<team_id>` torn down (shared — owner-only).
+6. `repo_error` written to `workspaces` on clone failure; `getCurrentRepoStatus` reads it
+   from `workspaces` for the active workspace (cross-member case correct).
+7. mig 110 idempotent; SOLO drift-gate COUNT → 0 after re-key; co-membered residual carried
+   (asserted as "0 adopted without attestation", not auto-drained) — rolled-back dev txn.
+8. install / detect-installation write `github_installation_id` to `workspaces`, not `users`.
+
+## Non-Goals (deferred — tracked)
+- **DROP** `users.{repo_url, workspace_path, github_installation_id}` + the mig-052
+  partial-UNIQUE index → **PR-2b / #5437** (soak-gated; this PR opens the soak window).
+- **Auto-draining the co-membered SKIP backlog** is OUT OF SCOPE and **deliberately not
+  done** (CLO/PA-17(c) blocker — auto-adoption without a fresh attestation is unlawful).
+  These rows are a lawful carried residual; they clear when the owner re-connects from the
+  team context (this PR's write path). PR-2b's column drop must tolerate this residual.
+- `workspace_status` / `health_snapshot` relocation (not repo-connection columns ADR-044
+  relocates; stay on `users`). If a future need arises, file separately.
+- ADR-044 `status: adopting → accepted` flip + wholly-Workspace C4 edge → PR-2b.
+- Sentry `sentry_issue_alert` routing for the divergence fingerprint (ADR-044 fast-follow).
+
+## Sharp Edges
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/placeholder,
+  or omits the threshold will fail `deepen-plan` Phase 4.6. (Filled above.)
+- **The owner-gate `is_workspace_owner` reads a `workspace_members` owner row — it is a
+  DATA precondition, not a structural no-op.** mig 109 already backfilled the solo
+  owner-membership canary (18,287→0 on dev). For TEAM workspaces the owner row exists by
+  construction (team creation inserts it). Re-run the canary count at /work before relying
+  on the gate (`2026-06-17-rls-gate-on-db-row-presence...`).
+- **Write-boundary sweep must catch the multi-line patch-object form.** A grep for a
+  single-line `repo_url:` literal misses `.from("users").update({ \n repo_url, ... })`.
+  The AC1 grep must match the `.from("users").update(` open across the four columns
+  (`hr-write-boundary-sentinel-sweep-all-write-sites`).
+- **Capture the resolved active id in the setup background-callback closure — do NOT
+  re-resolve.** The session claim can drift between request and callback completion;
+  re-resolving could write `repo_status:ready` to a different workspace than the one
+  provisioned (`2026-05-29-identity-pinned-workspace-not-session-selection-for-automation-writes`).
+- **Use `resolveActiveWorkspace` (membership-verified), not `resolveCurrentWorkspaceId`
+  (fail-closes to solo).** At the WRITE/provisioning boundary, a db-error must fail-closed
+  (503), never silently provision into the caller's solo workspace under a team claim.
+- **`workspace_path` may have no `workspaces` column / consumer** — the read path derives
+  the path from the workspace id (`workspacePathForWorkspaceId`). Verify before writing
+  `workspaces.workspace_path`; the clean relocation may be to DROP the write entirely
+  (still satisfies zero-`users.*`-write). Same for `health_snapshot`.
+- **The `23505` unique-violation branch in detect-installation** guards the mig-052 UNIQUE
+  on `users.github_installation_id`. `workspaces` has no such UNIQUE (ADR-044 fan-out) — the
+  branch may become dead on the `workspaces` write; verify reachability, don't keep dead
+  error-handling.
+- **Migration-test + test-runner discovery:** check `apps/web-platform/vitest.config.ts`
+  `include:` globs and `package.json scripts.test` before prescribing a test path; typecheck
+  is `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (no `npm run -w`).
+- **`Ref #5437`, not `Closes`** — PR-2b is the closer; this PR only opens its soak window.
+- **The new `workspaces.repo_error` column needs an explicit re-GRANT.** Adding a column does
+  NOT auto-add it to the column-level GRANT mig 079 set (`GRANT SELECT (id, …) ON
+  public.workspaces TO authenticated`). Without adding `repo_error` to that list, a tenant
+  read of it returns permission-denied. It is a sanitized reason string (non-credential) so
+  it belongs in the `authenticated` set; `github_installation_id` stays REVOKE'd. (AC8.)
+- **No `users.*` rollback net during this PR's soak (P1-3).** The read path is workspaces-only,
+  so a relocation bug is *immediately* user-visible (no users fallback masks it). Keep the
+  `users.*` repo columns PRESENT (PR-2b drops them) so a hotfix can reconcile from the frozen
+  `users` snapshot, and rely on the Sentry divergence breadcrumb (Observability) for early
+  detection. PR-2b must not merge until this write-cutover soaks.
+- **The `resetFromClaim` self-heal branch is a WRITE-path concern (P0-3), not just a read
+  one.** A removed member with a stale team claim must disconnect/connect their OWN solo
+  workspace (the reset id), with the owner-gate + writes + provisioning all on that reset id
+  — never the stale claim. Without this, the write path could target a team the caller no
+  longer belongs to.

--- a/knowledge-base/project/specs/feat-one-shot-5462-team-write-cutover/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-5462-team-write-cutover/session-state.md
@@ -1,0 +1,21 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-one-shot-5462-team-write-cutover/knowledge-base/project/plans/2026-06-17-feat-adr-044-team-write-cutover-plan.md
+- Status: complete
+
+### Errors
+None. CWD verified on first tool call; branch is the feature branch (not main). PR #5464 (docs/citation) already merged to main, so this worktree is based on post-#5464 main — no rebase concern.
+
+### Decisions
+- `users.*` rollback-net removed (supersedes PR-2a spec scaffold). Issue #5462's exit criterion is ZERO `users.*` write sites (the literal PR-2b precondition). Rollback during soak is whole-PR git-revert (read path is workspaces-only; mig 110 is reversible; `users` columns are NOT dropped here).
+- Co-membered SKIP backlog must NOT be auto-drained (CLO/GDPR blocker, deepen-confirmed). PA-17(c)(2) + counsel review require a fresh Art. 6(1)(a) attestation per co-member; auto-adopting the owner's repo onto a co-membered workspace is unlawful. The issue's "drift COUNT → 0" exit is reshaped: solo rows → 0; co-membered rows are a lawful carried residual cleared only by owner re-connect (this PR's owner-gated write path). Surfaced to CPO/CLO.
+- `repo_error` re-key needs a real migration (110), not just a GRANT. `repo_error` lives on `users` only (mig 079 added 5 cols, no `repo_error`); new migration adds the column + re-issues the non-credential GRANT + relocates write and read. Confirmed non-credential (sanitized via `sanitizeGitStderr`).
+- Resolve-once-thread-everywhere via membership-verified `resolveActiveWorkspace`. One id threads into owner-gate `p_workspace_id`, all `workspaces.*` writes, the optimistic clone-lock, provisioning/teardown, the background-callback closure, the cloning-guard read, and `repo_error` — with `resetFromClaim` self-heal and `{ok:false}` fail-closed (503). Preserves IDOR-safety (claim-derived, never `req.body`).
+- Two latent bugs caught by deepen: (a) the 23505 unique-violation branch goes dead on relocation (UNIQUE is `users`-only) — re-justify cross-tenant attribution via webhook fan-out; (b) the background-callback 0-row UPDATE is a silent no-op (must `.select("id")` + Sentry-mirror). disconnect tears down a SHARED team dir → must abort live member sessions before `rm`.
+
+### Components Invoked
+- Skill: soleur:plan
+- Skill: soleur:deepen-plan
+- Agents: repo-research-analyst, learnings-researcher, spec-flow-analyzer (7 P0/6 P1/4 P2), data-integrity-guardian (credential boundary)
+- Gates: premise validation, code-review overlap (#3739 ack), KB-citation sweep, precedent-diff, verify-the-negative, four mandatory deepen halt gates (User-Brand Impact, Observability, PAT-shaped, UI-wireframe) — all PASS


### PR DESCRIPTION
## Summary

ADR-044 **PR-2 team write-cutover**: invert the connect-time dual-write so `workspaces` is the authoritative target (keyed on the membership-verified resolved active workspace id), remove the `users.*` connect-time writes, replace the PR-2a 422 team refusal with real team on-disk provisioning + teardown, and re-key `repo_error` to `workspaces` (migration 110). This is the precondition that opens the PR-2b (#5437) soak window.

Exit criterion met: `git grep` of `users.update({repo_url|workspace_path|github_installation_id|repo_error})` under `app/api/repo/**` returns **0**.

## What changed

**Write relocation (4 routes):** `setup`, `disconnect`, `install`, `detect-installation` now resolve the active workspace via the membership-verified `resolveActiveWorkspace` (fail-closed 503, never a silent solo fallback at a write boundary), owner-gate `p_workspace_id` = the resolved active id, and write the authoritative repo-connection columns to `workspaces.<activeId>`. The optimistic cloning lock moves to the shared workspaces row; team provisioning/teardown targets `/workspaces/<activeId>` with live-member-session abort before the shared-dir `rm`; the setup background callback pins the captured active id (no re-resolve); the dead 23505 branch (workspaces is non-unique) is removed.

**Helper:** `mirrorRepoColsToSoloWorkspace` → `writeRepoColsToWorkspace` (caller-supplied id, `repo_error` in the patch, `.select("id")` 0-row no-op detection, fail-closed option).

**Read re-key:** `getCurrentRepoStatus` reads `repo_error` from `workspaces` (fixes the cross-member dispatching-user-vs-active-workspace key mismatch).

**Read-cutover completion (CTO Option-D ruling — see ADR-044 amendment).** The plan's "read path already cut over" claim was false; 5+ `users.*` readers survived PR-1. Migrated the **interactive** readers that would otherwise strand a newly-connected user on stale-NULL `users.*` (a `single-user incident`): `repo/status`, `repo/create`, `kb/tree`, `dashboard/today/[id]/undo`, `(auth)/callback`, and `repo/setup`'s install-fallback. The two **service-role** readers (`agent-on-spawn-requested`, `cron-workspace-sync-health`) are deferred — `resolve_workspace_installation_id` is `auth.uid()`-gated and unusable from service-role contexts; tracked in **#5470** as PR-2b preconditions.

**Deliberate column split:** the provisioning/readiness columns (`workspace_status`, `health_snapshot`) stay on the owner's `users` row, written only for the solo case (writing them for a team would corrupt the owner's solo readiness); `workspace_path` write dropped (derived from the workspace id, set immutably at onboarding).

## Architecture / docs

- ADR-044 amended: C4 edge `read=Workspace / write=User (dual)` → `read=Workspace / write=Workspace`; status stays `adopting` (the column drop + `adopting → accepted` is PR-2b). Records the read-cutover scope correction + Option-D rejected alternatives. PR-2b precondition set amended to include the two service-role-reader migrations (#5470).
- Plan + AC14 amended to match.

## Migration 110

Adds `workspaces.repo_error` (non-credential `authenticated` GRANT; `github_installation_id` stays REVOKE'd), re-keys the SOLO backfill, and **does not** auto-drain the co-membered SKIP backlog (lawful carried residual — Art. 6(1)(a) attestation never operates retroactively; PA-17(c)(2)). `verify/110` asserts SOLO drift COUNT=0 + 0 co-membered adopted-without-attestation.

## Testing

- `tsc --noEmit` clean; full `vitest run` green (12 route/read test suites rewritten for the workspaces-authoritative behavior + 2 sibling callback suites fixed).
- AC1 (zero `users.*` repo-col writes) and AC5 (no `req.body`/`req.query` workspace-id reads — IDOR) greps pass.
- GDPR gate: no Critical/new-Important findings; credential boundary preserved.

## Review hardening (multi-agent)

- **security-sentinel:** `abortAllWorkspaceMemberSessions` only aborts the *caller's* sessions (built for member-removal), so a team disconnect's shared-dir `rm` raced co-members. Added `abortAllSessionsForWorkspace(workspaceId)` (aborts every session bound to the workspace) + tests; disconnect now calls it (P0-6).
- **data-integrity-guardian / security-sentinel:** review surfaced **three** service-role read sites (not two) still on `users.github_installation_id` — the GitHub push-webhook founder-resolver (`webhooks/github/route.ts`, a `.eq()` lookup the `.select()` grep missed) joins `agent-on-spawn` + `cron-sync-health`; plus `session-sync`'s `users.repo_last_synced_at` write. All deferred to **#5470** (PR-2b preconditions; need a service-role-safe resolver / allowlist).

## Soak limitation (documented, accepted)

Until #5470 lands, a user who connects via the new path during the soak does **not** get push auto-sync (webhook founder-resolver reads NULL `users.github_installation_id`) and shows a stale last-synced timestamp. Soak population is internal-only — an accepted internal-dogfood limitation consistent with the Option-D deferral logic.

## Post-merge

- mig 110 is applied by `web-platform-release.yml #migrate` before the code cutover (automated, no operator SSH).
- Opens the PR-2b (#5437) soak window. `Ref #5437` (PR-2b is the closer — do not auto-close it here).

Closes #5462
Ref #5437
Ref #5470

🤖 Generated with [Claude Code](https://claude.com/claude-code)
