### PR TITLE
fix(adr-044): verify/110 UNION type mismatch blocked the release deploy

### DIFF
--- a/apps/web-platform/supabase/verify/110_workspace_repo_error_and_comember_reconcile.sql
+++ b/apps/web-platform/supabase/verify/110_workspace_repo_error_and_comember_reconcile.sql
@@ -13,36 +13,40 @@
 
 -- (1) workspaces.repo_error column exists (the schema precondition for the
 --     write relocation + getCurrentRepoStatus read).
+-- NOTE: every UNION branch's `bad` column MUST be the SAME type (Postgres rejects
+-- a boolean/integer UNION: "UNION types boolean and integer cannot be matched").
+-- run-verify.sh reports `bad=N` and fails on `bad <> 0`, so `bad` is INTEGER
+-- throughout — the boolean predicate checks (1-3) are cast `::int` (true→1, false→0).
 SELECT 'workspaces_repo_error_missing' AS check_name,
-       (SELECT count(*) FROM information_schema.columns
+       ((SELECT count(*) FROM information_schema.columns
         WHERE table_schema = 'public'
           AND table_name   = 'workspaces'
-          AND column_name  = 'repo_error') = 0 AS bad
+          AND column_name  = 'repo_error') = 0)::int AS bad
 UNION ALL
 -- (2) repo_error is in the `authenticated` column-level SELECT grant (it is a
 --     sanitized reason, non-credential). A tenant read of it must not be
 --     permission-denied (getCurrentRepoStatus reads it via the tenant client).
 SELECT 'repo_error_not_in_authenticated_grant',
-       NOT EXISTS (
+       (NOT EXISTS (
          SELECT 1 FROM information_schema.column_privileges
          WHERE table_schema = 'public'
            AND table_name   = 'workspaces'
            AND column_name  = 'repo_error'
            AND grantee      = 'authenticated'
            AND privilege_type = 'SELECT'
-       ) AS bad
+       ))::int AS bad
 UNION ALL
 -- (3) github_installation_id stays REVOKE'd from `authenticated` (credential —
 --     readable only via resolve_workspace_installation_id RPC).
 SELECT 'github_installation_id_leaked_to_authenticated',
-       EXISTS (
+       (EXISTS (
          SELECT 1 FROM information_schema.column_privileges
          WHERE table_schema = 'public'
            AND table_name   = 'workspaces'
            AND column_name  = 'github_installation_id'
            AND grantee      = 'authenticated'
            AND privilege_type = 'SELECT'
-       ) AS bad
+       ))::int AS bad
 UNION ALL
 -- (4) SOLO drift-gate COUNT = 0. ADR-044's exact PR-2b gate query
 --     (users JOIN workspaces ON w.id = u.id) scoped to SOLO (sole-member)


### PR DESCRIPTION
## Summary

Hotfix: the post-merge `verify-migrations` job for ADR-044 PR-2 (#5466) failed on prd with `UNION types boolean and integer cannot be matched`, which **skipped the deploy** (the code cutover never shipped). `verify/110` mixed `bad` column types across its `UNION ALL` — checks 1–3 boolean (`= 0` / `NOT EXISTS` / `EXISTS`), checks 4–5 integer (`count(*)::int`). Postgres rejects the mixed-type union before any row evaluates. Cast the three boolean checks `::int` so `bad` is uniformly integer (matching the `run-verify.sh` `bad=N` contract).

## Production state (no incident)

- `migrate: success` — **mig 110 applied to prd** (column + GRANT + backfill).
- `verify-migrations: failure` — this type bug (no assertion ran).
- `deploy: skipped` — cutover did NOT ship; prd runs the **old** code against a DB with an additive, unused `repo_error` column. Old code keeps `users.*` + the workspaces mirror consistent. Safe gate, not a half-deploy.

## Verification

Ran the fixed `verify/110` against **both dev and prd** via the Doppler pooler (read-only). **prd: all five checks `bad=0`** — column present, `repo_error` in the `authenticated` grant, `github_installation_id` REVOKE'd, SOLO `repo_drift_count=0`, `comembered_adopted_without_attestation=0`. So the re-run passes and the gated deploy proceeds.

## Root cause of the miss

`verify/*.sql` is only psql-executed by `run-verify.sh` post-merge against prd; the migration unit test does not execute it. Deferring the live-DB verify (the plan's own AC6) let the type bug reach main. Captured in the session learning.

## Changelog

- Fixed: `verify/110` UNION type mismatch that blocked the ADR-044 PR-2 release deploy.

Ref #5462

🤖 Generated with [Claude Code](https://claude.com/claude-code)
