### PR TITLE
perf(live-verify): run the trigger-paths gate before bun/playwright setup

### DIFF
--- a/.github/workflows/web-platform-release.yml
+++ b/.github/workflows/web-platform-release.yml
@@ -554,21 +554,12 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@014df23b1329b615816a38eb5f473bb9000700b1 # v3
-      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
-      - name: Install web-platform deps
-        working-directory: apps/web-platform
-        run: bun install --frozen-lockfile
-      - name: Install Playwright chromium (+ OS deps)
-        working-directory: apps/web-platform
-        # Use the @playwright/test version bun just installed (package.json pins
-        # 1.58.2). --with-deps installs the OS shared libs ubuntu-latest lacks; a
-        # bare install would leave chromium.launch() failing on missing libs
-        # (spurious CANT-RUN). The harness's optional system-browser override
-        # env vars are deliberately left unset here so run.ts uses the bundled
-        # chromium that ubuntu-latest installs cleanly.
-        run: npx playwright install --with-deps chromium
+      # The trigger-paths gate runs FIRST (it needs only `gh` + the committed
+      # trigger-paths.txt). The bun/doppler/playwright setup + harness below are
+      # gated on `triggered == '1'`, so a SKIP release (most merges — no
+      # realtime/WS/auth/DOM-timing surface changed) never pays the ~10min
+      # `playwright install --with-deps chromium`, and a triggering release does
+      # not let that install compete with the harness for the 15-min budget (#5497).
       - name: Changed-file trigger gate
         id: gate
         env:
@@ -600,6 +591,26 @@ jobs:
             echo "triggered=$triggered"
             echo "gate_failed=0"
           } >> "$GITHUB_OUTPUT"
+      - name: Install Doppler CLI
+        if: steps.gate.outputs.triggered == '1'
+        uses: dopplerhq/cli-action@014df23b1329b615816a38eb5f473bb9000700b1 # v3
+      - name: Install bun
+        if: steps.gate.outputs.triggered == '1'
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+      - name: Install web-platform deps
+        if: steps.gate.outputs.triggered == '1'
+        working-directory: apps/web-platform
+        run: bun install --frozen-lockfile
+      - name: Install Playwright chromium (+ OS deps)
+        if: steps.gate.outputs.triggered == '1'
+        working-directory: apps/web-platform
+        # Use the @playwright/test version bun just installed (package.json pins
+        # 1.58.2). --with-deps installs the OS shared libs ubuntu-latest lacks; a
+        # bare install would leave chromium.launch() failing on missing libs
+        # (spurious CANT-RUN). The harness's optional system-browser override
+        # env vars are deliberately left unset here so run.ts uses the bundled
+        # chromium that ubuntu-latest installs cleanly.
+        run: npx playwright install --with-deps chromium
       - name: Run live-verify harness (report-only)
         id: harness
         if: steps.gate.outputs.triggered == '1'


### PR DESCRIPTION
## Summary
The report-only `live-verify:` job (shipped #5488) ran `bun install` + `npx playwright install --with-deps chromium` (~10-12 min on a cold runner) **before** the trigger-paths gate. Most merges change no realtime/WS/auth/DOM-timing surface, so the harness SKIPs — but the chromium install already ran (observed on the #5488 merge run: ~12 min install, then gate → SKIPPED).

Reorder: the trigger-paths gate now runs first (it needs only `gh` + the committed `trigger-paths.txt`), and the Doppler/setup-bun/bun-install/playwright-install/harness steps are gated on `if: steps.gate.outputs.triggered == '1'`. The Sentry emit stays `if: always()` and still classifies SKIPPED/PASS/FAIL/CANT-RUN.

Result: a SKIP release is checkout + gate + emit (~30s, no chromium). On a genuinely-triggering release the chromium install no longer competes with the harness for the 15-min budget. Report-only invariants (topology — no job `needs:` live-verify — + `continue-on-error`) unchanged.

Closes #5497

## User-Brand Impact
- **Artifact / vector:** N/A — this is a CI runner-time reorder of a report-only post-deploy gate. It changes no end-user route, schema, auth flow, or data surface; the job remains report-only by topology and cannot affect whether a deploy ships.
- **Brand-survival threshold:** none
- threshold: none, reason: pure CI-workflow step-ordering change to a report-only gate; no end-user surface, no data processing, no effect on deploy success.

## Changelog
### Web Platform
- The report-only live-verify CI gate now evaluates its trigger-paths gate before installing chromium, so releases that don't touch a realtime surface skip the ~10-min browser install.

## Test plan
- [x] `actionlint` clean; step order verified (gate before all bun/doppler/playwright setup)
- [x] Architecture review traced all five paths (SKIPPED / triggered / gate-diff-failed / checkout-fail / setup-step-fail) — one queryable Sentry event per run preserved; report-only invariants unchanged

Generated with [Claude Code](https://claude.com/claude-code)
