### PR TITLE
fix(inngest): enumerate success path must be pure JSON for the CombinedOutput webhook body (#5503)

### DIFF
--- a/apps/web-platform/infra/inngest-enumerate-reminders.sh
+++ b/apps/web-platform/infra/inngest-enumerate-reminders.sh
@@ -147,7 +147,11 @@ run_enumerate() {
   # AND stderr — even on a 200, and the cutover workflow parses that body as a JSON
   # array (`jq -e 'type == "array"'`). So on the SUCCESS path this script must write
   # NOTHING non-JSON to EITHER stream: stdout carries only the records array (below)
-  # and the summary goes to journald via `logger` ONLY (→ Vector → Better Stack).
+  # and the summary goes to on-host journald via `logger` ONLY (read with
+  # `journalctl -t inngest-enumerate-reminders`; it does NOT reach Better Stack —
+  # vector.toml's journald sources match inngest-server.service / CRIT-only, not this
+  # webhook.service notice line, see #5495). The no-SSH count+ids signal is the cutover
+  # workflow's own `::notice::`, recomputed from the parsed array (cutover-inngest.yml).
   # An `echo ... >&2` here would be merged ahead of the JSON and break the array parse
   # (the bug that left the cutover blocked even after the epoch-from fix). Internal
   # shell consumers use `$(...)`, which captures stdout only, so they were unaffected —

--- a/apps/web-platform/infra/inngest-enumerate-reminders.sh
+++ b/apps/web-platform/infra/inngest-enumerate-reminders.sh
@@ -143,11 +143,19 @@ run_enumerate() {
     ]')
 
   # --- Observability summary (P2-sec-a: counts + reminder_ids ONLY, never bodies) ---
+  # #5503: the webhook (adnanh/webhook v2.8.2) returns cmd.CombinedOutput() — stdout
+  # AND stderr — even on a 200, and the cutover workflow parses that body as a JSON
+  # array (`jq -e 'type == "array"'`). So on the SUCCESS path this script must write
+  # NOTHING non-JSON to EITHER stream: stdout carries only the records array (below)
+  # and the summary goes to journald via `logger` ONLY (→ Vector → Better Stack).
+  # An `echo ... >&2` here would be merged ahead of the JSON and break the array parse
+  # (the bug that left the cutover blocked even after the epoch-from fix). Internal
+  # shell consumers use `$(...)`, which captures stdout only, so they were unaffected —
+  # the merge happens solely at the webhook boundary.
   local count ids
   count=$(echo "$records" | jq 'length')
   ids=$(echo "$records" | jq -r '[.[].reminder_id] | join(",")')
   logger -t "$LOG_TAG" "armed reminders to re-arm: count=$count ids=[$ids]" 2>/dev/null || true
-  echo "inngest-enumerate-reminders: $count armed reminder(s) to re-arm: [$ids]" >&2
 
   echo "$records"
 }

--- a/apps/web-platform/infra/inngest-enumerate-reminders.test.sh
+++ b/apps/web-platform/infra/inngest-enumerate-reminders.test.sh
@@ -117,18 +117,27 @@ test_pagination_page2_captured() {
   assert_eq "page-2 reminder_id correct" "rem-p2" "$(echo "$out" | jq -r '.[0].reminder_id')"
 }
 
-# --- Test 6: P2-sec-a — comment bodies must NOT be on stdout's emitted records' top level... ---
-# The re-arm record carries action (incl. body — needed for re-arm fidelity), but
-# the script's STDERR/log summary must emit counts + reminder_ids only, never the
-# comment body. Assert the log line does not leak the body.
-test_log_no_body_leak() {
+# --- Test 6 (#5503): SUCCESS-path output must be PURE JSON on the webhook stream ---
+# adnanh/webhook v2.8.2 returns cmd.CombinedOutput() (stdout AND stderr) even on a 200,
+# and the cutover workflow parses that body as a JSON array (`jq -e 'type == "array"'`).
+# So the success path must write NOTHING non-JSON to EITHER stream; the observability
+# summary goes to journald via `logger` ONLY. RED before #5503 (the stderr summary was
+# merged ahead of the JSON → array parse failed → cutover blocked); GREEN after.
+# (Replaces the former stderr-summary assertion — that summary no longer exists on stderr.)
+test_success_combined_output_pure_json() {
   local d; d=$(mktemp -d); trap 'rm -rf "$d"' RETURN
   make_page false "" "[$(make_edge "01L" "rem-log" "$FUTURE_MS" "[]")]" > "$d/page-1.json"
+  # Combined stdout+stderr, mimicking the webhook CombinedOutput the workflow parses.
+  local combined; combined=$(INNGEST_GQL_FIXTURE_DIR="$d" ENUMERATE_NOW_MS="$NOW_MS" bash "$TARGET" 2>&1)
+  if echo "$combined" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    echo "  PASS: combined stdout+stderr parses as a JSON array"; PASS=$((PASS + 1));
+  else
+    echo "  FAIL: combined stdout+stderr is NOT a pure JSON array (success-path stream pollution)"; FAIL=$((FAIL + 1)); fi
+  assert_eq "combined output is the 1-record array" "1" "$(echo "$combined" | jq 'length' 2>/dev/null || echo BAD)"
+  # The summary is journald-only now: success-path stderr must be empty, so no prose
+  # (and so no reminder_id / comment body) can leak into the webhook response stream.
   local err; err=$(INNGEST_GQL_FIXTURE_DIR="$d" ENUMERATE_NOW_MS="$NOW_MS" bash "$TARGET" 2>&1 1>/dev/null)
-  assert_contains "log mentions the reminder_id" "$err" "rem-log"
-  if [[ "$err" == *"SECRET-BODY"* ]]; then
-    echo "  FAIL: comment body leaked into the log/stderr summary"; FAIL=$((FAIL + 1));
-  else echo "  PASS: comment body NOT leaked into the log/stderr summary"; PASS=$((PASS + 1)); fi
+  assert_eq "success-path stderr is empty (summary is journald-only)" "" "$err"
 }
 
 # --- Test 7: empty event set → emits [] (not an error) ---
@@ -202,7 +211,7 @@ test_completed_dropped
 test_past_dropped
 test_terminal_status_matrix
 test_pagination_page2_captured
-test_log_no_body_leak
+test_success_combined_output_pure_json
 test_empty_set
 test_no_shell_string_interpolation_in_gql
 test_default_from_is_recent_not_epoch

--- a/knowledge-base/project/learnings/best-practices/2026-06-17-webhook-combinedoutput-success-path-must-be-pure-json.md
+++ b/knowledge-base/project/learnings/best-practices/2026-06-17-webhook-combinedoutput-success-path-must-be-pure-json.md
@@ -1,0 +1,34 @@
+# Learning: when a webhook returns CombinedOutput and the consumer parses the response as JSON, the SUCCESS path must be pure-JSON on BOTH streams — and the success path must be the thing you test
+
+category: best-practices
+module: apps/web-platform/infra (adnanh/webhook host ops), .github/workflows, #5503
+
+## Problem
+
+#5492 fixed the epoch-`from` 500 in `inngest-enumerate-reminders.sh`, so `op=enumerate` finally queried prod and returned the armed reminders. But the cutover stayed blocked: the workflow step failed with `enumerate did not return a JSON array`. The script succeeded; the **consumer** rejected the body.
+
+## Root cause
+
+`adnanh/webhook` v2.8.2 returns `cmd.CombinedOutput()` — stdout **and** stderr — even on a 200. `cutover-inngest.yml` parses that body with `jq -e 'type == "array"'`. The enumerate **success** path wrote an observability summary to **stderr** (`echo "...N armed reminder(s)..." >&2`), which `CombinedOutput()` merged ahead of the stdout JSON array → the array parse failed.
+
+The merge happens **only at the webhook boundary**. Internal shell consumers (`records=$(enumerate)`, `post=$(enumerate 2>/dev/null)`) capture stdout only, so they were never affected — which is exactly why the bug hid: every internal path and every test saw clean stdout.
+
+## Solution / durable rule
+
+For a host script whose **webhook response is parsed as JSON** by the consumer: on the success path, write **nothing** non-JSON to **either** stream. stdout = the JSON only; route the observability summary to `logger`/journald (NOT stderr). The failure path is the opposite — it may (should) write the cause to both streams, because failure → non-2xx → the consumer dumps the body as an `::error::` cause, never parses it as JSON.
+
+Audit rule for the whole op set: the bug exists only where BOTH (a) the webhook returns CombinedOutput AND (b) the workflow `jq`-parses that response body. Map every op: enumerate (jq array → broken), rearm (body only `cat`'d + HTTP-code-checked → safe), verify (polls a pure-JSON cat-state with no stderr → safe).
+
+## Key Insight
+
+**Test the SUCCESS path's COMBINED stream, not just the failure path's.** #5492 added a no-leak test — but it only captured the *failure*-path combined stream. Three review agents + preflight + the no-leak test all passed because none of them exercised the *success*-path combined stdout+stderr the way the webhook actually returns it. The bug was caught only by the **post-merge read-only `op=enumerate` dry-run against prod** — which is also the payoff of #5492's observability fix: the failure was now diagnosable (`enumerate did not return a JSON array` + the data), where before it was an opaque 500. The regression test now captures `bash "$TARGET" 2>&1` and asserts it parses as a pure JSON array (RED with the stderr echo restored, GREEN without).
+
+## Session Errors
+
+1. **#5492's no-leak test and 3-agent review covered only the FAILURE-path combined stream; the SUCCESS-path combined-stream pollution passed every pre-merge gate.** **Recovery:** caught by the post-merge read-only prod verification; fixed in #5503 (drop the success-path stderr echo) with a test that asserts the success-path COMBINED stream is pure JSON. **Prevention:** for any CombinedOutput-webhook whose body is JSON-parsed, the canonical test is "combined stdout+stderr on the SUCCESS path parses as the expected JSON" — assert it for the happy path, not only the error path.
+2. **The justification comment over-claimed the observability layer** (`→ Vector → Better Stack`). **Recovery:** review (observability-coverage-reviewer, `hr-observability-layer-citation`) verified the `logger` line lands in on-host journald under `webhook.service` at notice priority, which no `vector.toml` source captures; comment corrected to on-host journald, broader Vector-source gap routed to #5495. **Prevention:** cite an observability layer only after confirming the signal's unit + priority actually matches a live Vector source filter.
+
+## Tags
+category: best-practices
+module: webhook, observability, no-ssh, combinedoutput, #5503
+related: [[2026-06-17-synchronous-webhook-consumer-must-dump-response-body]], [[2026-06-17-inngest-eventsv2-raw-payload-and-receivedat-filter]]


### PR DESCRIPTION
## Summary

Follow-up to #5492. After #5492 fixed the epoch-`from` 500, the read-only `op=enumerate` verification against prod succeeded at the script level (returned the 4 armed reminders) but the cutover stayed blocked: the workflow rejected the body with `enumerate did not return a JSON array`.

- **Root cause:** `adnanh/webhook` v2.8.2 returns `CombinedOutput()` (stdout+stderr) even on a 200, and `cutover-inngest.yml` parses that body with `jq -e 'type == "array"'`. The enumerate **success** path wrote its observability summary to **stderr** (`echo "...armed reminder(s)..." >&2`), which got merged ahead of the stdout JSON → array parse failed.
- **Fix:** drop the success-path stderr echo. count+ids stay in `logger` (on-host journald); the no-SSH count+ids signal for the operator is the cutover workflow's own `::notice::`, recomputed from the parsed array.
- **Audit:** enumerate was the only broken path — rearm's body is `cat`'d + HTTP-code-checked (not jq-parsed); verify polls a pure-JSON cat-state with no stderr. Internal shell consumers use `$(...)` (stdout only) and were unaffected — the stream merge is solely at the webhook boundary.
- **Test:** new regression test asserts the success-path **combined** stdout+stderr parses as a pure JSON array + stderr is empty (RED with the echo restored, GREEN without). The gap that let this through #5492: its no-leak test exercised only the *failure*-path combined stream.

## User-Brand Impact

- **Artifact at risk:** the operator's armed reminders (e.g. #5432) during the durable-backend cutover.
- **Failure vector:** the cutover cannot enumerate (and therefore re-arm) armed reminders while this bug stands, so a reminder could be silently dropped at cutover. This unblocks the read-only enumeration.
- **Brand-survival threshold:** single-user incident

This is a follow-up contributing-cause fix for the cutover-blocked event already documented in `knowledge-base/engineering/operations/post-mortems/inngest-cutover-enumerate-undiagnosable-500-postmortem.md` (merged with #5493). No new production event occurred — #5503 was found by a read-only verification with prod untouched.

## Changelog

### Web Platform (infra)
- `inngest-enumerate-reminders.sh`: remove the success-path stderr observability echo so the webhook CombinedOutput body the cutover workflow parses is pure JSON; summary stays in journald via `logger`.
- test: assert the success-path combined stdout+stderr is a pure JSON array (+ empty stderr).

## Test plan

- [x] `inngest-enumerate-reminders.test.sh` — 25/25 (new success-combined-stream test RED with echo restored / GREEN without)
- [x] shellcheck clean
- [x] `scripts/test-all.sh` (scripts shard) — running in CI

Closes #5503
Ref #5450

Generated with [Claude Code](https://claude.com/claude-code)
