### PR TITLE
fix(live-verify): assert DB persistence + rail materialization, not the dead waitForURL

### DIFF
--- a/apps/web-platform/scripts/live-verify/run.ts
+++ b/apps/web-platform/scripts/live-verify/run.ts
@@ -385,25 +385,55 @@ async function driveAndVerify(
       };
     }
 
-    // Start a fresh conversation and send ONE benign message — the only path
-    // that materializes the conversations row the rail observes via realtime
-    // (messages is not in the supabase_realtime publication; conversations is).
+    // Capture a high-water mark BEFORE the send so the materialization poll
+    // below only ever matches a FRESH row, never a leftover from a prior run.
+    const sinceIso = new Date().toISOString();
+
+    // Start a fresh conversation and send ONE benign message.
     await page.goto(`${cfg.productionUrl}${CHAT_NEW_PATH}`, {
       waitUntil: "domcontentloaded",
     });
     const input = page.getByRole("textbox").first();
     await input.waitFor({ state: "visible", timeout: 20_000 });
     await input.fill("live-verify rail check — automated, please ignore");
-    await page.getByRole("button", { name: "Send message" }).click();
 
-    // The app navigates to /dashboard/chat/<id> when the conversation
-    // materializes. Bound the wait on that observable state (no fixed sleep).
-    await page.waitForURL(/\/dashboard\/chat\/[0-9a-f-]{36}$/, {
-      timeout: 30_000,
-    });
-    const convId = page.url().split("/").pop() ?? "";
-    if (!/^[0-9a-f-]{36}$/.test(convId)) {
-      return { kind: "FAIL", detail: "conversation id not resolvable from URL" };
+    // The Send button is disabled until the WS reaches status === "connected"
+    // (chat-surface.tsx: `disabled={status !== "connected"}`); clicking a
+    // disabled Send is a silent no-op (handleSend early-returns when not
+    // connected). Playwright's click auto-waits for the button to be enabled,
+    // so a never-connect surfaces as a click timeout we convert into a clear
+    // CANT-RUN rather than a downstream "no conversation" false-FAIL.
+    try {
+      await page
+        .getByRole("button", { name: "Send message" })
+        .click({ timeout: 35_000 });
+    } catch {
+      return {
+        kind: "CANT-RUN",
+        reason: "send-button-never-enabled:ws-not-connected",
+      };
+    }
+
+    // Materialization signal #1 (authoritative, browser-independent): the
+    // conversations row persists. The deployed app no longer NAVIGATES to
+    // /dashboard/chat/<id> on a fresh send — it materializes the conversation
+    // IN PLACE by dispatching CONVERSATION_CREATED_EVENT so the rail refetches
+    // (the #5391/#5436 rail-race fix replaced the URL navigation). The old
+    // waitForURL(/dashboard/chat/<uuid>/) assertion therefore could NEVER match
+    // against the current app — poll the persisted row instead and derive the
+    // id from it (not from the URL).
+    const convId = await pollFreshConversationId(
+      supabase,
+      verified,
+      sinceIso,
+      30_000,
+    );
+    if (!convId) {
+      return {
+        kind: "FAIL",
+        detail:
+          "send did not persist a conversation within budget (workspace-binding / WS-auth)",
+      };
     }
 
     // Stamp the crash-reaper marker immediately (own session, RLS).
@@ -413,8 +443,8 @@ async function driveAndVerify(
       .eq("id", convId)
       .eq("user_id", verified.uid);
 
-    // THE assertion (#5391/#5436): the freshly-created conversation appears in
-    // the Recent Conversations rail. Bounded wait on the rail row link.
+    // Materialization signal #2 — THE assertion (#5391/#5436): the freshly
+    // persisted conversation appears in the Recent Conversations rail.
     const railRow = page.locator(`${RAIL} a[href$="/dashboard/chat/${convId}"]`);
     let railOk = false;
     try {
@@ -425,10 +455,13 @@ async function driveAndVerify(
     }
 
     const result: Result = railOk
-      ? { kind: "PASS", detail: "fresh conversation appeared in the rail" }
+      ? {
+          kind: "PASS",
+          detail: "fresh conversation persisted and appeared in the rail",
+        }
       : {
           kind: "FAIL",
-          detail: `conversation ${convId} did NOT appear in the rail within budget (the #5391/#5436 class)`,
+          detail: `conversation ${convId} persisted but did NOT appear in the rail within budget (the #5391/#5436 class)`,
         };
 
     // Teardown as the synthetic user's own session (RLS), regardless of result.
@@ -439,6 +472,37 @@ async function driveAndVerify(
   } finally {
     if (browser) await browser.close();
   }
+}
+
+/**
+ * Poll the conversations table for a row created by the synthetic principal
+ * AFTER `sinceIso` (the pre-send high-water mark). The deployed app materializes
+ * a fresh conversation IN PLACE (CONVERSATION_CREATED_EVENT → rail refetch), not
+ * via a URL navigation, so the persisted row — not the URL — is the authoritative
+ * "the send actually worked" signal. Returns the conversation id (uuid) or null
+ * on timeout. Uses the synthetic user's own session (RLS); never a broad scan.
+ */
+export async function pollFreshConversationId(
+  supabase: ReturnType<typeof createServerClient>,
+  verified: VerifiedPrincipal,
+  sinceIso: string,
+  timeoutMs: number,
+): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    const { data } = await supabase
+      .from("conversations")
+      .select("id")
+      .eq("user_id", verified.uid)
+      .gt("created_at", sinceIso)
+      .order("created_at", { ascending: false })
+      .limit(1);
+    const id = data?.[0]?.id;
+    if (typeof id === "string" && /^[0-9a-f-]{36}$/.test(id)) return id;
+    if (Date.now() >= deadline) break;
+    await new Promise((r) => setTimeout(r, 1_000));
+  } while (Date.now() < deadline);
+  return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web-platform/test/live-verify/cookie-injection.test.ts
+++ b/apps/web-platform/test/live-verify/cookie-injection.test.ts
@@ -9,7 +9,31 @@
 
 import { describe, expect, it } from "vitest";
 
-import { buildLaunchOptions, buildInjectedCookies } from "../../scripts/live-verify/run";
+import {
+  buildLaunchOptions,
+  buildInjectedCookies,
+  pollFreshConversationId,
+} from "../../scripts/live-verify/run";
+
+// Minimal supabase query-builder stub: every chained method returns the same
+// object; the terminal `.limit()` resolves to `{ data }`, shifting one response
+// per poll so a multi-iteration test can model "empty, then a row appears".
+function makeSupabaseStub(responses: Array<Array<{ id: string }>>) {
+  let call = 0;
+  const chain = {
+    from: () => chain,
+    select: () => chain,
+    eq: () => chain,
+    gt: () => chain,
+    order: () => chain,
+    limit: () =>
+      Promise.resolve({ data: responses[Math.min(call++, responses.length - 1)] ?? [] }),
+  };
+  return chain as never;
+}
+
+const VERIFIED = { __brand: "verified-live-verify-principal", uid: "u-1" } as never;
+const UUID = "0123abcd-1234-5678-9abc-def012345678";
 
 describe("buildLaunchOptions (runner-portability override)", () => {
   // Override branches carry the Wayland GPU-crash stabilization flags; the
@@ -52,6 +76,28 @@ describe("buildLaunchOptions (runner-portability override)", () => {
     const opts = buildLaunchOptions({ channel: "", executablePath: "" });
     expect(opts).toEqual({});
     expect("args" in opts).toBe(false);
+  });
+});
+
+describe("pollFreshConversationId (materialization signal, not URL nav)", () => {
+  it("returns the conversation id when a fresh row is present", async () => {
+    const supabase = makeSupabaseStub([[{ id: UUID }]]);
+    const id = await pollFreshConversationId(supabase, VERIFIED, "2026-01-01T00:00:00Z", 5_000);
+    expect(id).toBe(UUID);
+  });
+
+  it("returns null when no row materializes before the deadline", async () => {
+    // timeoutMs 0 → the do/while runs exactly once, sees no row, and breaks
+    // before any 1s sleep (keeps the unit test instant).
+    const supabase = makeSupabaseStub([[]]);
+    const id = await pollFreshConversationId(supabase, VERIFIED, "2026-01-01T00:00:00Z", 0);
+    expect(id).toBeNull();
+  });
+
+  it("ignores a non-uuid id shape (never returns a malformed id)", async () => {
+    const supabase = makeSupabaseStub([[{ id: "not-a-uuid" }]]);
+    const id = await pollFreshConversationId(supabase, VERIFIED, "2026-01-01T00:00:00Z", 0);
+    expect(id).toBeNull();
   });
 });
 

--- a/knowledge-base/project/learnings/workflow-patterns/2026-06-18-confirm-separately-items-must-be-empirically-confirmed-not-code-read.md
+++ b/knowledge-base/project/learnings/workflow-patterns/2026-06-18-confirm-separately-items-must-be-empirically-confirmed-not-code-read.md
@@ -1,0 +1,63 @@
+---
+title: "An issue's 'confirm separately' item must be EMPIRICALLY confirmed (run it), not reasoned away from a code-read — and a necessary-but-insufficient fix hides behind a broken verification path"
+date: 2026-06-18
+category: workflow-patterns
+module: apps/web-platform/scripts/live-verify
+tags: [live-verify, harness, plan-quality, verification, assertion-drift, e2e, 5501]
+related: 2026-06-18-live-verify-harness-needs-the-same-wayland-launch-flags-as-mcp.md
+---
+
+# Learning: confirm "confirm-separately" items by running them; don't reason them away
+
+## Problem
+
+Issue #5501 ("synthetic principal's chat send does not persist → harness can never emit PASS")
+listed three items; **item 3** explicitly said: *"Confirm separately whether the current app
+still navigates to `/dashboard/chat/<uuid>` on a persisted send, or whether the harness's
+`waitForURL` assertion also needs updating."* The #5501 plan's Research Reconciliation read the
+code, concluded *"No harness change needed; the seed fix restores the persist→nav chain,"* and
+shipped the binding fix alone.
+
+That conclusion was **wrong**. The deployed app no longer navigates to `/dashboard/chat/<uuid>`
+on a fresh send — since the #5391/#5436 rail-race fix it materializes the conversation **in
+place** by dispatching `CONVERSATION_CREATED_EVENT` so the rail refetches (`chat-surface.tsx:373-402`;
+`/dashboard/chat` redirects to `/new`; `onRealConversationId` navigates only in the KB-sidebar
+surface). So the harness's `page.waitForURL(/\/dashboard\/chat\/<uuid>$/)` could **never** match
+the current app and always timed out at `CANT-RUN:forURL`. The binding fix (#5501/#5502) was
+**necessary but insufficient**: the harness still could not emit PASS.
+
+This stayed hidden for two extra layers: the local harness first crashed (Wayland GPU — separate
+fix #5511) and then timed out under a CPU throttle — both masked the real assertion bug until the
+crash + throttle were cleared and the harness ran cleanly to the same `forURL` timeout every time.
+
+## Solution
+
+Fix the harness to assert what the app actually does: wait for the WS-connected Send button,
+**poll the persisted `conversations` row** (authoritative, browser-independent) as the
+materialization signal, derive the id from it (not the URL), and keep the rail-row assertion.
+Verified 3/3 live `RESULT: PASS` against prod.
+
+## Key Insight
+
+1. **A "confirm separately" / "verify X" item in an issue is a RUN-IT instruction, not a
+   reason-about-it one.** When the claim is about *live app behavior* (does it navigate? does the
+   selector still match? does the endpoint return shape Y?), a code-read is a hypothesis — confirm
+   it by executing the actual path. The #5501 plan's code-read reached the opposite of reality
+   because the app's behavior had changed under it (#5391). Cheapest gate: if an item says
+   "confirm whether the app still does X," the plan's Acceptance Criteria must include *running*
+   the thing, not a prose reconciliation.
+
+2. **"Necessary but insufficient" hides when the verification path itself is broken.** The binding
+   fix was real and correct, but the only way to *observe* its success — the harness — had its own
+   independent bug (stale assertion). A fix whose proof-of-success runs through a broken verifier
+   looks unverifiable, not wrong. When a fix "can't be confirmed," suspect the verifier before
+   concluding the fix failed: here the DB showed the binding live and a direct poll showed the
+   conversation persisting — the `waitForURL` was the only thing failing.
+
+3. **Layered failures mask the root one.** Crash (Wayland) → timeout (throttle) → stale assertion
+   were three independent issues stacked on one symptom. Peel them in order and re-observe after
+   each; don't assume the first cause you fix is the only one.
+
+## Tags
+category: workflow-patterns
+module: apps/web-platform/scripts/live-verify


### PR DESCRIPTION
## Summary

The live-verify harness asserted a post-send navigation to `/dashboard/chat/<uuid>` via `page.waitForURL(...)`. But the deployed app **no longer navigates on a fresh send** — since the #5391/#5436 rail-race fix it materializes the conversation **in place** by dispatching `CONVERSATION_CREATED_EVENT` so the rail refetches (`chat-surface.tsx:373-402`; `/dashboard/chat` redirects to `/new`; `onRealConversationId` navigates only in the KB-sidebar surface). So `waitForURL(/\/dashboard\/chat\/<uuid>$/)` could **never** match the current app and always timed out at `CANT-RUN:forURL` — the harness could not emit `RESULT: PASS` even with the synthetic principal's workspace binding seeded (#5502).

This was the true **"item 3"** of #5501 ("confirm whether the harness's `waitForURL` assertion needs updating") that the binding-fix plan reasoned away from a code-read instead of running. The binding fix (#5502) was necessary but **insufficient**; this completes the resolution.

### What changed in `driveAndVerify`
- **Wait for the WS-connected Send button** before clicking — `chat-surface` disables Send until `status === "connected"`, and `handleSend` early-returns when not connected, so a too-early click is a silent no-op. A never-connect is now a clear `CANT-RUN`, not a downstream false-FAIL.
- **Poll the persisted `conversations` row** (`pollFreshConversationId`, own-session RLS, `gt(created_at, <pre-send high-water mark>)`) as the authoritative, browser-independent materialization signal, and derive `convId` from it instead of the URL.
- **Keep** the rail-row assertion (the actual #5391/#5436 regression target) and teardown-by-`convId`.

## Verification

Verified **end-to-end against prod, 3/3**: `RESULT: PASS — fresh conversation persisted and appeared in the rail`, conversation torn down each run (0 rows remaining). This proves all three layers now work together: the #5501/#5502 binding fix (conversation persists), the #5511 Wayland launch-flags fix (no GPU crash), and this assertion fix.

Closes #5501

## Changelog

### Web Platform
- live-verify harness: assert DB persistence + in-place rail materialization (the app's actual fresh-send behavior) instead of a `/dashboard/chat/<uuid>` URL navigation the app no longer performs; wait for the WS-connected Send button before sending. The harness can now emit `RESULT: PASS`.

## Test plan

- [x] New unit tests for `pollFreshConversationId` (found / timeout / non-uuid branches); full `test/live-verify/` suite 45 passing; `tsc --noEmit` clean
- [x] Live `RESULT: PASS` against prod, 3/3 stable, with teardown verified (0 conversation rows remaining)
- [x] Reviewed (data-integrity-guardian + pattern-recognition): 0 findings — RLS-scoped poll (no cross-tenant read), fresh-row scoping sound, comments verified against the cited app code, no dead `waitForURL` path

Generated with [Claude Code](https://claude.com/claude-code)
