### PR TITLE
fix(adr-044): verify/031 + verify/110 reference users.* cols dropped by mig 112 — deploy unblock

### DIFF
--- a/apps/web-platform/supabase/verify/031_normalize_repo_url.sql
+++ b/apps/web-platform/supabase/verify/031_normalize_repo_url.sql
@@ -8,12 +8,12 @@
 -- Idempotence probes replay the migration's WHERE clause as a SELECT — a
 -- second run would UPDATE zero rows when the data is canonical.
 
-SELECT 'users_sentinel' AS check_name,
-       count(*)::int AS bad
-  FROM public.users
- WHERE repo_url IS NOT NULL
-   AND (repo_url ~ '\.git$' OR repo_url ~ '\.GIT$'
-        OR repo_url ~ '/$' OR repo_url ~ '^https://[^/]*[A-Z]')
+-- users.repo_url was DROPPED by migration 112 (ADR-044 PR-2b). The users
+-- normalization sentinel + idempotence probe are obsolete (no column to inspect)
+-- and would error `column "repo_url" does not exist` if they still referenced it.
+-- Kept as named 0s for verify-summary stability. The conversations.repo_url
+-- checks remain live (that column was NOT dropped). See verify/112.
+SELECT 'users_sentinel' AS check_name, 0::int AS bad
 UNION ALL
 SELECT 'conversations_sentinel', count(*)::int
   FROM public.conversations
@@ -21,18 +21,8 @@ SELECT 'conversations_sentinel', count(*)::int
    AND (repo_url ~ '\.git$' OR repo_url ~ '\.GIT$'
         OR repo_url ~ '/$' OR repo_url ~ '^https://[^/]*[A-Z]')
 UNION ALL
-SELECT 'users_idempotence', count(*)::int
-  FROM public.users u
- WHERE u.repo_url IS NOT NULL
-   AND substring(trim(u.repo_url) from '^([^/]*//[^/]+)') IS NOT NULL
-   AND u.repo_url <> regexp_replace(
-     regexp_replace(
-       regexp_replace(
-         LOWER(substring(trim(u.repo_url) from '^([^/]*//[^/]+)'))
-         || COALESCE(substring(trim(u.repo_url) from '^[^/]*//[^/]+(/.*)$'), ''),
-         '/+$', '', 'g'),
-       '(\.git)+$', '', 'i'),
-     '/+$', '', 'g')
+-- users.repo_url dropped by mig 112 (see note above) — idempotence probe obsolete.
+SELECT 'users_idempotence', 0::int
 UNION ALL
 SELECT 'conversations_idempotence', count(*)::int
   FROM public.conversations c

--- a/apps/web-platform/supabase/verify/110_workspace_repo_error_and_comember_reconcile.sql
+++ b/apps/web-platform/supabase/verify/110_workspace_repo_error_and_comember_reconcile.sql
@@ -48,22 +48,15 @@ SELECT 'github_installation_id_leaked_to_authenticated',
            AND privilege_type = 'SELECT'
        ))::int AS bad
 UNION ALL
--- (4) SOLO drift-gate COUNT = 0. ADR-044's exact PR-2b gate query
---     (users JOIN workspaces ON w.id = u.id) scoped to SOLO (sole-member)
---     workspaces. Post-reconcile this must be 0; co-membered rows are excluded
---     (asserted separately in check 5).
-SELECT 'repo_drift_count',
-       (SELECT count(*)::int FROM public.users u
-          JOIN public.workspaces w ON w.id = u.id
-        WHERE (
-          (u.repo_url IS NOT NULL AND w.repo_url IS DISTINCT FROM u.repo_url)
-          OR (u.github_installation_id IS NOT NULL
-              AND w.github_installation_id IS DISTINCT FROM u.github_installation_id)
-        )
-        AND (
-          SELECT count(*) FROM public.workspace_members m2
-          WHERE m2.workspace_id = w.id
-        ) = 1) AS bad
+-- (4) SOLO drift-gate COUNT = 0. ADR-044's PR-2b gate (users JOIN workspaces
+--     ON w.id = u.id) compared users.{repo_url, github_installation_id} against
+--     workspaces.*. Migration 112 (ADR-044 PR-2b) DROPPED those users.* columns
+--     after a verified prod COUNT=0, so the drift gate is now VACUOUSLY satisfied
+--     — there are no users.* columns left to diverge. The check body must not
+--     reference the dropped columns (they no longer exist, so the old query
+--     errors `column u.repo_url does not exist`). Kept as a named 0 so the
+--     verify summary's check count stays stable. See verify/112.
+SELECT 'repo_drift_count', 0::int AS bad
 UNION ALL
 -- (5) 0 co-membered (sole-member COUNT > 1) workspaces that have an adopted
 --     repo connection WITHOUT a corresponding attestation row. This is the

--- a/apps/web-platform/test/supabase-migrations/110-workspace-repo-error-and-comember-reconcile.test.ts
+++ b/apps/web-platform/test/supabase-migrations/110-workspace-repo-error-and-comember-reconcile.test.ts
@@ -134,18 +134,18 @@ describe("verify 110 contract", () => {
     expect(verifyExecutable).toMatch(/AS\s+bad/i);
   });
 
-  it("asserts the SOLO drift-gate COUNT scoped to sole-member workspaces", () => {
+  it("repo_drift_count is vacuously satisfied post-mig-112 (users.* repo cols dropped)", () => {
+    // Migration 112 (ADR-044 PR-2b) DROPPED users.{repo_url, github_installation_id}
+    // after a verified prod COUNT=0. The pre-drop SOLO drift-gate query
+    // (users JOIN workspaces) can no longer run — the columns don't exist — so the
+    // check is rewritten to a named `0::int` (vacuously satisfied), retained for
+    // verify-summary stability.
     expect(verifyExecutable).toMatch(/repo_drift_count/i);
-    // The drift query mirrors ADR-044's PR-2b gate (users JOIN workspaces).
-    expect(verifyExecutable).toMatch(/u\.repo_url\s+IS\s+NOT\s+NULL/i);
-    expect(verifyExecutable).toMatch(
-      /w\.repo_url\s+IS\s+DISTINCT\s+FROM\s+u\.repo_url/i,
-    );
-    expect(verifyExecutable).toMatch(
-      /w\.github_installation_id\s+IS\s+DISTINCT\s+FROM\s+u\.github_installation_id/i,
-    );
-    // Scoped to SOLO rows (sole-member).
-    expect(verifyExecutable).toMatch(/=\s*1/);
+    expect(verifyExecutable).toMatch(/repo_drift_count'?\s*,\s*0::int/i);
+    // Regression guard: the dropped columns MUST NOT be referenced (they no longer
+    // exist; a reference re-breaks the verify-migrations job → deploy pipeline).
+    expect(verifyExecutable).not.toMatch(/\bu\.repo_url\b/i);
+    expect(verifyExecutable).not.toMatch(/\bu\.github_installation_id\b/i);
   });
 
   it("asserts 0 co-membered rows adopted WITHOUT an attestation (not 0 SKIP rows)", () => {

--- a/knowledge-base/engineering/operations/post-mortems/mig112-verify-stale-column-refs-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/mig112-verify-stale-column-refs-postmortem.md
@@ -1,0 +1,71 @@
+---
+title: "mig 112 DROP broke verify/031 + verify/110 (stale users.* column refs) → deploy pipeline blocked"
+date: 2026-06-18
+brand_survival_threshold: single-user incident
+art_33_personal_data_breach: false
+art_33_rationale: "Availability/CI-pipeline incident only — no personal data was accessed, exfiltrated, altered, or lost. The DROP applied as designed against a verified COUNT=0 prod state; the failure was a CI verify-job error on two sibling verify files."
+art_34_high_risk_to_individuals: false
+art_34_rationale: "n/a — no personal-data breach (see Art. 33). No user-facing outage: prod kept serving the prior build, which has zero readers of the dropped columns."
+severity: P1
+status: resolved
+issue: 5437
+pr: 5508
+---
+
+# PIR — migration 112 DROP broke two sibling verify files → deploy pipeline blocked
+
+## Summary
+
+PR #5508 (ADR-044 PR-2b) dropped `users.{github_installation_id, repo_url, workspace_path}`
+via migration 112. The `migrate` job applied the DROP to prod successfully and all five
+`verify/112` sentinels passed. But the **`verify-migrations` job runs EVERY verify file on
+every deploy**, and two pre-existing sibling verify files — `verify/031_normalize_repo_url.sql`
+and `verify/110_workspace_repo_error_and_comember_reconcile.sql` — still referenced the
+just-dropped `users.repo_url` / `users.github_installation_id` columns. Those files errored
+(`column u.repo_url does not exist`), failing `verify-migrations`, which **gated `deploy`**
+(skipped) → the web-platform deploy pipeline was blocked for ALL subsequent PRs.
+
+## Impact
+
+- **Severity:** P1 (deploy-pipeline blocked) — NOT a user-facing outage.
+- **User-facing:** none. `deploy` was skipped, so prod kept serving the **prior** build, which
+  was already cut over to `workspaces.*` and has **zero readers** of the dropped columns. The
+  DROP + a no-readers build = a healthy prod that simply didn't advance to the newest build.
+- **Pipeline:** every web-platform release after the #5508 merge would have failed at
+  `verify-migrations` (stale 031/110) and skipped `deploy` until fixed.
+- **Window:** ~from the #5508 merge (2026-06-17T23:25Z) to the hotfix merge.
+
+## Root cause
+
+The pre-merge "exhaustive sweep" for live references to the dropped columns covered
+`apps/web-platform/{app,server,lib}` (app readers/writers) and
+`apps/web-platform/supabase/migrations/` (DB function/trigger/view/policy bodies — which
+caught the `handle_new_user` P1). It did **NOT** cover
+`apps/web-platform/supabase/verify/` — the sibling verify files that the CI `verify-migrations`
+job re-runs on every deploy. `verify/031` (the repo_url normalization sentinel) and `verify/110`
+(the ADR-044 pre-drop SOLO drift gate) both query `users.repo_url` / `users.github_installation_id`;
+once the columns were dropped those queries error at parse time, failing the job.
+
+This is the same class as the `handle_new_user` P1 (a surviving DB-side reference the app-layer
+sweep missed) — extended one directory further: **a column DROP's pre-drop sweep must include
+`supabase/verify/` AND `supabase/migrations/`, not just app code + migrations.**
+
+## Resolution
+
+`verify/031` and `verify/110` are pre-drop assertions about columns that no longer exist —
+vacuously satisfied post-DROP. The check bodies were rewritten to a named `0::int AS bad`
+(preserving each `check_name` for verify-summary stability) with a comment pointing at mig 112.
+The `conversations.repo_url` checks in 031 and the `workspaces.*` checks in 110 were left live
+(those columns were not dropped). Both files were re-run against **prod** (post-DROP):
+`031 = 4 checks bad=0`, `110 = 5 checks bad=0`, no errors. The hotfix PR re-runs
+`verify-migrations` green → `deploy` proceeds → the #5508 build deploys.
+
+## Detection
+
+The `web-platform-release` run for the #5508 merge was monitored to its terminal state and
+reported `failure`; reading `--log-failed` pinpointed `verify-migrations` failing on `verify/110`
+(`column u.repo_url does not exist`), with `verify/112` itself all-green and `migrate` succeeded.
+
+## Action Items & Follow-ups
+
+_No action items — incident fully resolved in this PR (verify/031 + verify/110 corrected, prod-verified bad=0; deploy pipeline unblocked). The recurrence-prevention lesson (a DROP's pre-drop sweep must include `supabase/verify/`) is captured in the session learning and folded into the existing "sweep DB-side writers" learning._

--- a/knowledge-base/project/learnings/security-issues/2026-06-18-drop-column-must-sweep-db-side-writers-not-just-app-readers.md
+++ b/knowledge-base/project/learnings/security-issues/2026-06-18-drop-column-must-sweep-db-side-writers-not-just-app-readers.md
@@ -48,6 +48,20 @@ rg -nU 'INTO public\.<table>[\s\S]{0,300}?\b<col>\b|UPDATE public\.<table>[\s\S]
 ```
 The signup trigger `handle_new_user` is the highest-frequency writer of `users.*` — always check it explicitly when dropping a `users` column.
 
+**The sweep MUST also include `apps/web-platform/supabase/verify/`** — the CI
+`verify-migrations` job re-runs EVERY verify file on every deploy, so a sibling
+verify file that asserts a property of the dropped column (a drift gate, a
+normalization sentinel) errors `column ... does not exist` post-DROP and BLOCKS
+the deploy pipeline for all PRs. (Follow-up incident to this same #5508 drop:
+`verify/031` + `verify/110` referenced the dropped `users.repo_url` /
+`users.github_installation_id`; `migrate` + `verify/112` were green but
+`verify-migrations` failed on the siblings → `deploy` skipped. See
+`knowledge-base/engineering/operations/post-mortems/mig112-verify-stale-column-refs-postmortem.md`.)
+Fix obsolete verify assertions to a named `0::int AS bad` + a `see verify/<N>`
+comment. Canonical sweep scope for a column DROP: `app/server/lib` (readers) +
+`supabase/migrations/` (function/trigger/view/policy bodies) +
+`supabase/verify/` (CI re-run assertions).
+
 **The fix lives in the SAME migration, ordered before the drop:** `CREATE OR REPLACE
 FUNCTION public.handle_new_user()` with the column removed from the INSERT (rest of the
 body verbatim — preserve SECURITY DEFINER + `SET search_path` + REVOKE + COMMENT), THEN


### PR DESCRIPTION
## Summary

**P1 deploy-pipeline unblock.** PR #5508 (ADR-044 PR-2b, mig 112) dropped `users.{github_installation_id, repo_url, workspace_path}`. The `migrate` job applied the DROP to prod and all `verify/112` sentinels passed — but the `verify-migrations` job re-runs **every** verify file on every deploy, and two pre-existing sibling files still queried the dropped columns:

- `verify/031_normalize_repo_url.sql` — `users_sentinel` + `users_idempotence` (`users.repo_url`)
- `verify/110_workspace_repo_error_and_comember_reconcile.sql` — check 4, the pre-drop SOLO drift gate (`u.repo_url` / `u.github_installation_id`)

Both errored `column u.repo_url does not exist` → `verify-migrations` failed → `deploy` skipped → **deploy pipeline blocked for all PRs**. Prod stayed healthy (the prior build has zero readers of the dropped columns).

## Fix

The obsolete pre-drop assertions are vacuously satisfied post-DROP. Each was rewritten to a named `0::int AS bad` (preserving `check_name` for verify-summary stability) + a `see verify/112` comment. The `conversations.repo_url` checks (031) and `workspaces.*` checks (110) stay live (those columns were not dropped).

## Verification

Both files re-run against **prod** (post-DROP): `031 = 4 checks bad=0`, `110 = 5 checks bad=0`, no errors. Re-sweep of `supabase/verify/` confirms 0 remaining references to the dropped columns.

## Changelog

- Fix `verify/031` + `verify/110` to not reference the `users.*` columns dropped by migration 112; unblocks `verify-migrations` → `deploy`.
- Add PIR `mig112-verify-stale-column-refs-postmortem.md`.
- Extend the "sweep DB-side writers" learning: a column DROP's pre-drop sweep must include `supabase/verify/` (CI re-runs every verify file on every deploy).

## Test plan

- [x] Both fixed verify files run against prod: all `bad=0`, no errors
- [x] `supabase/verify/` re-swept: 0 live references to dropped columns
- [ ] ⏳ verify-migrations green on this PR's release → deploy proceeds

Generated with [Claude Code](https://claude.com/claude-code)
