### PR TITLE
fix(inngest): correct op=inventory functions projection to /v0/gql functions query (GET /v1/functions is a 404)

### DIFF
--- a/apps/web-platform/infra/inngest-inventory.sh
+++ b/apps/web-platform/infra/inngest-inventory.sh
@@ -5,7 +5,7 @@
 # of everything the cutover could lose moving off the volume-based SQLite store, so
 # an operator can diff BEFORE vs AFTER and prove nothing was dropped:
 #
-#   { "functions":      [<registered function name/slug>, ...],   # /v1/functions
+#   { "functions":      [<registered function name/slug>, ...],   # /v0/gql functions
 #     "event_names":    [<distinct event name>, ...],             # eventsV2 (ALL)
 #     "armed_reminders": [{reminder_id,fire_at,actor,action}, ...] }  # enumerate proj.
 #
@@ -13,10 +13,13 @@
 #
 # Schema pinned (verified vs inngest v1.19.4):
 #   knowledge-base/project/specs/feat-one-shot-inngest-cutover-no-ssh-5450/inngest-graphql-schema.md
-# Loopback (127.0.0.1:8288, no auth in `start` mode): GET /v1/functions returns a
-# JSON array of registered functions; /v0/gql eventsV2 carries the event envelope in
-# `raw: String!` (parse with fromjson; `.ts` = future fire epoch-ms; `from`/`until`
-# bound receivedAt NOT fire-time → wide window + client-side future filter).
+# Loopback (127.0.0.1:8288, no auth in `start` mode): the /v0/gql `functions` query
+# returns {data:{functions:[{id,name,slug,triggers,...}]}}  # verified: 2026-06-18
+# (GET /v1/functions is an UNREGISTERED 404 in v1.19.4 → the old bare-number `shape`
+# was the "404 page not found" body's leading token, #5517); /v0/gql eventsV2 carries
+# the event envelope in `raw: String!` (parse with fromjson; `.ts` = future fire
+# epoch-ms; `from`/`until` bound receivedAt NOT fire-time → wide window + client-side
+# future filter).
 #
 # armed_reminders mirrors inngest-enumerate-reminders.sh's projection EXACTLY
 # (future fire `raw.ts > now` AND no terminal run) so the inventory's armed set and
@@ -33,13 +36,12 @@
 # (stdout only), so the merge happens solely at the webhook boundary.
 #
 # Test seam: INNGEST_GQL_FIXTURE_DIR (page-N.json for eventsV2), INVENTORY_FUNCTIONS_FIXTURE
-# (a file with the /v1/functions JSON), INVENTORY_NOW_MS (deterministic "now").
+# (a file with the /v0/gql functions-query response), INVENTORY_NOW_MS (deterministic "now").
 set -euo pipefail
 
 readonly LOG_TAG="inngest-inventory"
 
 GQL_URL="${INNGEST_GQL_URL:-http://127.0.0.1:8288/v0/gql}"
-FUNCTIONS_URL="${INNGEST_FUNCTIONS_URL:-http://127.0.0.1:8288/v1/functions}"
 PAGE_SIZE="${INNGEST_GQL_PAGE_SIZE:-50}"
 # receivedAt lower bound — same 365-day clamp as enumerate (#5492): the epoch is
 # rejected by inngest v1.19.4 as out-of-range. ENUMERATE_FROM widens it for a deeper
@@ -59,6 +61,12 @@ readonly GQL_QUERY='query InvEvents($first: Int!, $after: String, $filter: Event
     edges { cursor node { id name occurredAt receivedAt idempotencyKey raw runs { id status startedAt endedAt } } }
   }
 }'
+
+# Registered-function query (#5517). GET /v1/functions is an UNREGISTERED 404 in
+# v1.19.4; the top-level GraphQL `functions` field (same /v0/gql endpoint eventsV2
+# uses, no auth on loopback) returns the rich object array the devserver UI shows.
+# We project names only, so id/name/slug suffice (no appName discovery needed).
+readonly FUNCTIONS_GQL_QUERY='query InvFunctions { functions { id name slug } }'
 
 # Build the GraphQL request body for one page (ALL events — NO eventNames filter, so
 # event_names captures cron/* etc.). $1 = after-cursor ("" for first). Injection-safe
@@ -88,35 +96,43 @@ fetch_page() {
     --data-binary "$body" "$GQL_URL"
 }
 
-# Fetch the registered-function list (fixture or loopback). Echoes the raw JSON array.
+# Fetch the registered-function list via /v0/gql (fixture or loopback). Echoes the raw
+# GraphQL response {data:{functions:[...]}}. Injection-safe body via jq -n.
 fetch_functions() {
   if [[ -n "$FUNCTIONS_FIXTURE" ]]; then
     cat "$FUNCTIONS_FIXTURE"
     return 0
   fi
-  # On a real curl failure emit a NON-array sentinel (not "[]") so run_inventory
-  # fails LOUD below. A silent "[]" would record a false-clean empty `functions`
-  # baseline that the cutover before/after diff cannot distinguish from a real
-  # loss (#5509 review P3 — false-confidence on a degraded read).
-  curl -s --max-time 15 "$FUNCTIONS_URL" || echo '"__FETCH_FAILED__"'
+  local body
+  body=$(jq -nc --arg q "$FUNCTIONS_GQL_QUERY" '{query:$q}')
+  # On a real curl failure emit a GraphQL error envelope (no .data.functions) so
+  # run_inventory fails LOUD below. A silent "[]" would record a false-clean empty
+  # `functions` baseline that the cutover before/after diff cannot distinguish from a
+  # real loss (#5509 review P3 — false-confidence on a degraded read).
+  curl -s --max-time 15 -X POST -H "Content-Type: application/json" \
+    --data-binary "$body" "$GQL_URL" || echo '{"errors":[{"message":"__FETCH_FAILED__"}],"data":null}'
 }
 
 run_inventory() {
   # --- functions: names only (fall back to slug/id if the element lacks .name) ---
   local fn_body functions
   fn_body=$(fetch_functions)
-  # Fail LOUD (not false-clean []) if /v1/functions is unreachable or non-array.
-  # A legitimately-empty inngest returns a valid `[]` array → passes this gate and
-  # yields functions=[] correctly; only a fetch failure / non-array trips it.
-  if ! echo "$fn_body" | jq -e 'type == "array"' >/dev/null 2>&1; then
-    local fn_shape
-    fn_shape=$(echo "$fn_body" | jq -c 'if type=="object" then keys else type end' 2>/dev/null || echo '"non-json"')
-    logger -t "$LOG_TAG" "ERROR: /v1/functions unreachable or non-array (shape=$fn_shape)" 2>/dev/null || true
-    echo "inngest-inventory: FATAL /v1/functions unreachable or non-array (shape=$fn_shape); is inngest-server.service up? — refusing to emit a false-clean empty functions baseline"
-    echo "ERROR: /v1/functions non-array (shape=$fn_shape)" >&2
+  # Fail LOUD (not false-clean []) if the /v0/gql functions query failed or returned a
+  # non-array .data.functions. A legitimately-empty inngest returns {data:{functions:[]}}
+  # → passes this gate and yields functions=[] correctly; a fetch failure, a GraphQL
+  # error envelope, or any unexpected shape (incl. a bare array — the pre-#5517 wrong
+  # assumption) trips it. The guard is NOT loosened to accept any shape.
+  if ! echo "$fn_body" | jq -e '.data.functions | type == "array"' >/dev/null 2>&1; then
+    # #5503 purity: surface only GraphQL error MESSAGES + .data KEY NAMES, never values.
+    local fn_errs fn_keys
+    fn_errs=$(echo "$fn_body" | jq -c '[(.errors // [])[].message]' 2>/dev/null || echo '["<unparseable response>"]')
+    fn_keys=$(echo "$fn_body" | jq -c '((.data // {}) | keys)' 2>/dev/null || echo '[]')
+    logger -t "$LOG_TAG" "ERROR: /v0/gql functions unreachable or non-array: errors=$fn_errs data_keys=$fn_keys" 2>/dev/null || true
+    echo "inngest-inventory: FATAL /v0/gql functions query failed or non-array (errors=$fn_errs data_keys=$fn_keys); is inngest-server.service up? — refusing to emit a false-clean empty functions baseline"
+    echo "ERROR: /v0/gql functions non-array (errors=$fn_errs data_keys=$fn_keys)" >&2
     exit 1
   fi
-  functions=$(echo "$fn_body" | jq -c '[ .[] | (.name // .slug // .id // empty) ] | sort')
+  functions=$(echo "$fn_body" | jq -c '[ .data.functions[] | (.name // .slug // .id // empty) ] | sort')
 
   # --- eventsV2: paginate ALL events to exhaustion ---
   local all_edges="[]" after="" page=1 resp page_edges has_next end_cursor

--- a/apps/web-platform/infra/inngest-inventory.test.sh
+++ b/apps/web-platform/infra/inngest-inventory.test.sh
@@ -7,8 +7,8 @@
 # reminder.scheduled), and reuses enumerate's armed-reminder projection.
 #
 # Test seam: INNGEST_GQL_FIXTURE_DIR (page-N.json eventsV2 pages),
-# INVENTORY_FUNCTIONS_FIXTURE (a /v1/functions JSON file), INVENTORY_NOW_MS.
-# No network, no inngest, no root.
+# INVENTORY_FUNCTIONS_FIXTURE (a /v0/gql functions-query response file, #5517),
+# INVENTORY_NOW_MS. No network, no inngest, no root.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -50,8 +50,11 @@ make_edge() {
     '{cursor:$ulid,node:{id:$ulid,name:$nm,occurredAt:$occ,receivedAt:"2026-06-10T00:00:00Z",idempotencyKey:null,raw:$raw,runs:$runs}}'
 }
 
+# Build a /v0/gql `functions` query response (#5517). The captured real shape is
+# {"data":{"functions":[{id,name,slug,triggers}]}} — GET /v1/functions is a 404 in
+# inngest v1.19.4, so the projection reads the GraphQL envelope, not a bare array.
 make_functions() {  # $1 = JSON array of names
-  jq -nc --argjson names "$1" '[ $names[] | {name:., slug:., triggers:[]} ]'
+  jq -nc --argjson names "$1" '{data:{functions:[ $names[] | {id:., name:., slug:., triggers:[]} ]}}'
 }
 
 # Run the script with fixtures; $1=page-dir, $2=functions-fixture-file. Returns stdout only.
@@ -158,23 +161,45 @@ test_empty_state() {
   assert_eq "empty state → {functions:[],event_names:[],armed_reminders:[]}" '{"functions":[],"event_names":[],"armed_reminders":[]}' "$(echo "$out" | jq -c '.')"
 }
 
-# --- Test 9 (#5509 review P3): a degraded /v1/functions read fails LOUD, not false-clean ---
+# --- Test 9 (#5509 review P3): a degraded functions read fails LOUD, not false-clean ---
 test_functions_fetch_failure_is_loud() {
   local d; d=$(mktemp -d); local ff; ff=$(mktemp); trap 'rm -rf "$d" "$ff"' RETURN
-  # Non-array functions body (simulates curl-failure sentinel / error envelope).
-  printf '%s' '{"error":"connection refused"}' > "$ff"
+  # A GraphQL error envelope (no .data.functions) — simulates curl-failure sentinel /
+  # server error. The corrected guard (.data.functions | type=="array") must trip.
+  printf '%s' '{"errors":[{"message":"connection refused"}],"data":null}' > "$ff"
   make_page false "" "[]" > "$d/page-1.json"
   local out rc=0
   out=$(INNGEST_GQL_FIXTURE_DIR="$d" INVENTORY_FUNCTIONS_FIXTURE="$ff" INVENTORY_NOW_MS="$NOW_MS" bash "$TARGET" 2>/dev/null) || rc=$?
   assert_eq "non-array functions read exits non-zero (no false-clean baseline)" "1" "$rc"
-  if [[ "$out" == *"FATAL /v1/functions"* ]]; then echo "  PASS: emits a diagnosable FATAL cause"; PASS=$((PASS+1));
+  if [[ "$out" == *"FATAL /v0/gql functions"* ]]; then echo "  PASS: emits a diagnosable FATAL cause"; PASS=$((PASS+1));
   else echo "  FAIL: no FATAL cause on degraded functions read"; FAIL=$((FAIL+1)); fi
   if [[ "$out" == *'"functions":[]'* ]]; then echo "  FAIL: emitted a false-clean empty functions object"; FAIL=$((FAIL+1));
   else echo "  PASS: did NOT emit a false-clean functions baseline"; PASS=$((PASS+1)); fi
 }
 
+# --- Test 10 (#5517): functions projected from the captured /v0/gql functions shape ---
+# The real shape is {"data":{"functions":[{id,name,slug,...}]}} (GET /v1/functions is a
+# 404 in v1.19.4). The projection MUST read .data.functions, and a BARE array (the old
+# wrong assumption) must trip the guard rather than be silently accepted.
+test_functions_from_gql_shape() {
+  local d; d=$(mktemp -d); local ff; ff=$(mktemp); trap 'rm -rf "$d" "$ff"' RETURN
+  # Captured-shape fixture: a populated /v0/gql functions response (soleur crons).
+  printf '%s' '{"data":{"functions":[{"id":"01J","name":"cron-bug-fixer","slug":"cron-bug-fixer","triggers":[{"type":"CRON","value":"*/30 * * * *"}]},{"id":"01K","name":"cron-daily-triage","slug":"cron-daily-triage","triggers":[{"type":"CRON","value":"0 9 * * *"}]}]}}' > "$ff"
+  make_page false "" "[]" > "$d/page-1.json"
+  local out; out=$(run_inv "$d" "$ff")
+  assert_eq "functions = sorted names projected from .data.functions" "cron-bug-fixer,cron-daily-triage" "$(echo "$out" | jq -r '.functions | join(",")')"
+
+  # A BARE array (the pre-#5517 wrong assumption) has no .data.functions → must FATAL.
+  local bf; bf=$(mktemp); trap 'rm -rf "$d" "$ff" "$bf"' RETURN
+  printf '%s' '[{"name":"cron-x","slug":"cron-x"}]' > "$bf"
+  local brc=0
+  INNGEST_GQL_FIXTURE_DIR="$d" INVENTORY_FUNCTIONS_FIXTURE="$bf" INVENTORY_NOW_MS="$NOW_MS" bash "$TARGET" >/dev/null 2>&1 || brc=$?
+  assert_eq "a bare array (old shape) trips the guard (not silently accepted)" "1" "$brc"
+}
+
 test_combined_is_pure_json_object
 test_functions_fetch_failure_is_loud
+test_functions_from_gql_shape
 test_functions_names
 test_event_names_distinct_all
 test_armed_projection

--- a/apps/web-platform/infra/inngest-inventory.test.sh
+++ b/apps/web-platform/infra/inngest-inventory.test.sh
@@ -82,7 +82,7 @@ test_combined_is_pure_json_object() {
   assert_eq "success-path stderr is empty (summary journald-only)" "" "$err"
 }
 
-# --- Test 2: functions = sorted names from /v1/functions ---
+# --- Test 2: functions = sorted names from /v0/gql functions ---
 test_functions_names() {
   local d; d=$(mktemp -d); local ff; ff=$(mktemp); trap 'rm -rf "$d" "$ff"' RETURN
   make_functions '["cron-zeta","cron-alpha"]' > "$ff"

--- a/apps/web-platform/infra/inngest-wiped-volume-verify.sh
+++ b/apps/web-platform/infra/inngest-wiped-volume-verify.sh
@@ -45,7 +45,7 @@ ENUMERATE_CMD="${INNGEST_ENUMERATE_CMD:-${SCRIPT_DIR}/inngest-enumerate-reminder
 DATA_DIR="${INNGEST_DATA_DIR:-/var/lib/inngest}"
 STATE_FILE="${INNGEST_VERIFY_STATE:-/var/lock/inngest-wiped-volume-verify.state}"
 HEALTH_URL="${INNGEST_HEALTH_URL:-http://127.0.0.1:8288/health}"
-FUNCTIONS_URL="${INNGEST_FUNCTIONS_URL:-http://127.0.0.1:8288/v1/functions}"
+GQL_URL="${INNGEST_GQL_URL:-http://127.0.0.1:8288/v0/gql}"
 REARM_URL="${SCHEDULE_REMINDER_URL:-http://127.0.0.1:3000/api/internal/schedule-reminder}"
 SETTLE_SECS="${INNGEST_VERIFY_SETTLE_SECS:-120}"
 START_TS=$(date +%s)
@@ -128,10 +128,15 @@ sudo systemctl start inngest-server.service || abort "start_failed" "systemctl s
 health_code=$(curl -s --max-time 10 -o /dev/null -w '%{http_code}' "$HEALTH_URL" || echo "000")
 [[ "$health_code" == "200" ]] || abort "health_not_200" "inngest /health returned $health_code after wipe+restart"
 
-# /v1/functions has >= 1 cron (crons re-registered after restart)
-fn_body=$(curl -s --max-time 10 "$FUNCTIONS_URL" || echo "[]")
-fn_count=$(echo "$fn_body" | jq 'if type=="array" then length else 0 end' 2>/dev/null || echo 0)
-[[ "$fn_count" -ge 1 ]] || abort "no_functions" "inngest /v1/functions returned $fn_count functions after restart"
+# >= 1 cron re-registered after restart. Query /v0/gql `functions` — GET /v1/functions
+# is an UNREGISTERED 404 route in v1.19.4 (#5517): the old `if type=="array" else 0`
+# tolerated the 404 body as 0, so this assert would FALSELY fire `no_functions` on a
+# healthy restart. >= 1 proves the SDK re-synced (durability is in Postgres+Redis,
+# not the wiped /var/lib/inngest volume).
+fn_body=$(curl -s --max-time 10 -X POST -H "Content-Type: application/json" \
+  --data-binary '{"query":"query { functions { slug } }"}' "$GQL_URL" || echo '{"data":{"functions":[]}}')
+fn_count=$(echo "$fn_body" | jq '(.data.functions // []) | length' 2>/dev/null || echo 0)
+[[ "$fn_count" -ge 1 ]] || abort "no_functions" "inngest /v0/gql functions returned $fn_count functions after restart"
 
 # Marker fired: it is no longer in the still-armed set (its run reached terminal,
 # OR its fire-time passed). enumerate excludes terminal-run + past events, so a

--- a/apps/web-platform/infra/inngest-wiped-volume-verify.test.sh
+++ b/apps/web-platform/infra/inngest-wiped-volume-verify.test.sh
@@ -44,7 +44,9 @@ setup() {
   MOCKBIN=$(mktemp -d)
   ARM_LOG="${MOCKBIN}/arm.log"; : > "$ARM_LOG"
   # mock curl: arm POST → 202 and log the --data-binary body; GET health → 200 body
-  # {"status":200}; GET functions → a 1-cron array.
+  # {"status":200}; /v0/gql functions query → a 1-cron GraphQL response (#5517);
+  # GET /v1/functions (the unregistered route) → a 404 text body, so a script still
+  # using the old path reads 0 functions and aborts (the RED this drives).
   cat > "${MOCKBIN}/curl" <<MOCK
 #!/usr/bin/env bash
 url="\${!#}"
@@ -56,8 +58,12 @@ done
 case "\$url" in
   *schedule-reminder*) [[ -n "\$body" ]] && echo "ARM_BODY: \$body" >> "$ARM_LOG"; printf '202' ;;
   *health*)    [[ -n "\$outfile" ]] && printf '{"status":200,"message":"OK"}' > "\$outfile"; printf '200' ;;
-  # /v1/functions is fetched WITHOUT -o (body on stdout) → emit the array on stdout.
-  *functions*) printf '[{"slug":"cron-x"}]' ;;
+  # /v0/gql functions query (body on stdout) → wrapped GraphQL functions response.
+  # (Explicit if, not \${:-default}: a brace-heavy JSON default terminates the
+  # parameter expansion at its first '}'.)
+  *v0/gql*)      if [[ -n "\${WVV_FUNCTIONS_BODY:-}" ]]; then printf '%s' "\$WVV_FUNCTIONS_BODY"; else printf '%s' '{"data":{"functions":[{"slug":"cron-x"}]}}'; fi ;;
+  # /v1/functions is an UNREGISTERED 404 route in v1.19.4 (#5517).
+  *v1/functions*) printf '404 page not found' ;;
   *) printf '200' ;;
 esac
 MOCK
@@ -100,6 +106,7 @@ run_verify() {
     INNGEST_VERIFY_STATE="${MOCKBIN}/verify.state" \
     INNGEST_MANUAL_TRIGGER_SECRET="test-secret" \
     INNGEST_VERIFY_SETTLE_SECS=0 \
+    WVV_FUNCTIONS_BODY="${WVV_FUNCTIONS_BODY:-}" \
     bash "$TARGET" 2>&1
 }
 
@@ -193,11 +200,26 @@ test_abort_on_spoofed_prefix_real_reminder() {
   teardown
 }
 
+# --- Test 6 (#5517): post-restart functions probe reads /v0/gql, aborts on 0 ---
+# GET /v1/functions is a 404 in v1.19.4 (would always read 0 → false no_functions
+# abort after a healthy restart). The probe must read the GraphQL functions query;
+# an empty functions array (no SDK re-sync yet) still aborts loud (durability gate).
+test_no_functions_aborts_loud() {
+  setup
+  make_enum_stub '[]'
+  local out rc=0
+  out=$(WVV_FUNCTIONS_BODY='{"data":{"functions":[]}}' run_verify) || rc=$?
+  assert_eq "empty /v0/gql functions after restart → abort non-zero" "1" "$rc"
+  assert_contains "abort names the no_functions durability gate" "$out" "functions returned 0"
+  teardown
+}
+
 test_abort_on_real_reminder
 test_abort_on_spoofed_prefix_real_reminder
 test_abort_on_non_durable_backend
 test_throwaway_posts_no_comment
 test_happy_wipe_order
+test_no_functions_aborts_loud
 test_marker_unique
 
 echo ""

--- a/knowledge-base/project/learnings/integration-issues/2026-06-18-inngest-v1-functions-is-404-graphql-functions-is-the-path-and-sweep-all-consumers.md
+++ b/knowledge-base/project/learnings/integration-issues/2026-06-18-inngest-v1-functions-is-404-graphql-functions-is-the-path-and-sweep-all-consumers.md
@@ -1,0 +1,76 @@
+---
+title: "inngest GET /v1/functions is an unregistered 404; /v0/gql functions is the path — and sweep ALL endpoint consumers, not just the plan's named two"
+date: 2026-06-18
+category: integration-issues
+module: apps/web-platform/infra
+issue: 5517
+tags: [inngest, graphql, external-api-shape, captured-fixture, sweep-discipline, no-ssh]
+related:
+  - knowledge-base/project/learnings/integration-issues/2026-06-16-external-api-shape-ac-must-land-captured-fixture-not-probed-claim.md
+  - knowledge-base/project/learnings/best-practices/2026-05-18-sweep-class-fixes-grep-enumerated-not-intuited.md
+---
+
+# Learning: inngest `/v1/functions` is a 404; the registered path is `/v0/gql { functions }` — and grep ALL consumers
+
+## Problem
+
+`op=inventory` (host-side cutover diagnostics) failed loud:
+`FATAL /v1/functions unreachable or non-array (shape="number")`. The script assumed
+`GET /v1/functions` returns a JSON array of function objects. The shape was **mirrored**
+from a sibling (`inngest-wiped-volume-verify.sh`) whose `jq 'if type=="array" then length
+else 0 end'` *tolerated* a non-array — so no path ever captured the real bytes.
+
+## Root cause (captured against the exact prod pin)
+
+Spun up `inngest/inngest:v1.19.4` in Docker and probed directly:
+
+- `GET /v1/functions` → **HTTP 404**, body `404 page not found` (literal text). `curl -s | jq`
+  parses the leading token `404` as a JSON number → the FATAL reports `shape="number"`.
+  The route is **UNREGISTERED** in v1.19.4 (the v1 router registers
+  `GET /v1/apps/{appName}/functions`, not a bare `/v1/functions`).
+- `/health` → 200 (confirms the number is a wrong-path artifact on a HEALTHY server, not a
+  degraded read).
+- `POST /v0/gql { functions { id name slug } }` → `{"data":{"functions":[…]}}` — a clean
+  object array, registered top-level Query field, no auth on loopback (same endpoint
+  `eventsV2` already uses).
+
+## Solution
+
+Re-point the `functions` projection to the GraphQL `functions` query (mirrors enumerate's
+`eventsV2` fetch): guard on `.data.functions | type == "array"`, project
+`[.data.functions[] | (.name // .slug // .id)] | sort`. The emitted object's `functions`
+field stays a sorted **name array**, so the workflow consumer
+(`cutover-inngest.yml:239` `.functions | length`) needs no change.
+
+## Key Insight
+
+1. **A quoted external-API shape is a hypothesis, not a fact** (reinforces
+   [[2026-06-16-external-api-shape-ac-must-land-captured-fixture-not-probed-claim]]). The
+   version-determined route registration is reproducible in local Docker WITHOUT touching
+   prod — the `/v1/functions` 404 and the `/v0/gql functions` field are functions of the
+   inngest binary version, not prod data. Local-Docker capture is the authoritative,
+   no-SSH-needed method (same way the `eventsV2` schema was pinned).
+2. **Sweep ALL consumers of the broken endpoint via grep — the plan's named set is a
+   starting hypothesis.** `git grep '/v1/functions'` found **three** consumers; the plan
+   named two. The third (`ci-deploy.sh:302`, an advisory cron-plan probe using `curl -sf`)
+   was permanently dead (404 → empty → advisory always fires). It was a different
+   subsystem (the hard deploy gate + a 2000-line test, needs an advisory-probe redesign) →
+   filed as its own issue (#5520), not folded in. Reinforces
+   [[2026-05-18-sweep-class-fixes-grep-enumerated-not-intuited]].
+
+## Session Errors
+
+1. **inngest container start failed twice during Phase-0 capture.** `--signing-key
+   signkey-prod-<64hex>` → `signing-key must be hex string with even number of chars` (the
+   v1.19.4 `start` parser hex-decodes the WHOLE value, prefix included); starting with no
+   keys → `signing-key is required`. **Recovery:** pure-hex signing key
+   (`$(printf 'ab%.0s' {1..32})`). **Prevention:** documented in
+   `inngest-graphql-schema.md` §"runbook gotcha (image invocation)".
+2. **`${WVV_FUNCTIONS_BODY:-<brace-heavy JSON>}` in the sibling test mock** terminated the
+   parameter-expansion default at the first `}` inside the JSON → malformed output →
+   sibling GREEN failed on first run. **Recovery:** explicit `if [[ -n "$VAR" ]]; then …
+   else printf '<json>'; fi`. **Prevention:** never put brace-heavy JSON in a `${:-default}`;
+   documented inline in the test mock comment.
+3. **(forwarded from session-state.md)** two deepen-plan gate false-positives (4.7 SSH check
+   tripped on a `# NO ssh` annotation; 4.9 UI check matched negative prose) — self-resolved
+   during planning. One-off; no recurrence vector.

--- a/knowledge-base/project/plans/2026-06-18-fix-inngest-inventory-functions-shape-plan.md
+++ b/knowledge-base/project/plans/2026-06-18-fix-inngest-inventory-functions-shape-plan.md
@@ -1,0 +1,334 @@
+<!-- iac-routing-ack: this plan edits an EXISTING on-host script (inngest-inventory.sh)
+     delivered through the ALREADY-PROVISIONED no-SSH infra-config push + webhook hook.
+     It introduces NO new server, service, secret, vendor, DNS, or persistent process.
+     The `systemctl`/`/v1/functions`/`curl` strings below are descriptions of an
+     existing runtime surface, not new provisioning. No new Terraform is required. -->
+---
+title: "fix(inngest): correct op=inventory /v1/functions projection to the real host shape (captured fixture, not probed claim)"
+type: fix
+issue: 5517
+branch: feat-one-shot-fix-5517-inngest-functions-shape
+date: 2026-06-18
+lane: single-domain
+brand_survival_threshold: none
+requires_cpo_signoff: false
+---
+
+# fix(inngest): op=inventory `/v1/functions` returns a non-array (number) on host — correct the functions projection
+
+🐛 **Bug fix.** Single on-host infra script + its unit test. No new infrastructure, no new dependency, no UI surface.
+
+## Overview
+
+`op=inventory` (delivered by `inngest-inventory.sh`, run on the durable-backend host
+via the no-SSH `/hooks/inngest-inventory` GET hook and consumed by
+`cutover-inngest.yml`) now deploys and runs end-to-end, but **correctly fails loud**:
+
+```
+FATAL /v1/functions unreachable or non-array (shape="number"); is inngest-server.service up?
+```
+
+The `#5509` fail-loud guard (`inngest-inventory.sh:111-118`) is **working as intended** —
+it refuses to emit a false-clean empty `functions` baseline. The defect is upstream of
+the guard: the `functions` projection at `inngest-inventory.sh:119`
+(`[ .[] | (.name // .slug // .id // empty) ] | sort`) assumes `GET 127.0.0.1:8288/v1/functions`
+returns a **JSON array** of function objects. The live host endpoint returns a bare JSON
+**number** (`shape="number"`).
+
+### Root cause (captured-fixture-vs-probed-assumption class)
+
+The array assumption was **mirrored** from `inngest-wiped-volume-verify.sh:132-134`, whose
+`jq 'if type=="array" then length else 0 end'` *tolerates* a non-array (treats it as `0`).
+So the verify path never validated the shape and never captured the real bytes; the
+inventory path inherited a sibling's assumption rather than the endpoint's real response.
+This is exactly `knowledge-base/project/learnings/integration-issues/2026-06-16-external-api-shape-ac-must-land-captured-fixture-not-probed-claim.md`
+and its sibling `…/2026-06-17-inngest-eventsv2-raw-payload-and-receivedat-filter.md`: a
+quoted external-API shape is a **hypothesis**, not a fact. The fix is not deployable until
+the REAL `/v1/functions` response is **captured and landed as a test fixture**.
+
+### The hard constraint this plan is built around
+
+**The real `/v1/functions` shape is currently UNKNOWN.** The host's fail-loud guard tells us
+only `type=="number"` — it does NOT capture the number's *value* or confirm what the number
+means (function count? a status code? something else?). Two candidate semantics:
+
+1. **A bare function count** (e.g. `7`) — `/v1/functions` may return `{count}` flattened, or
+   the endpoint path differs from what we assume. If it is a count, the inventory cannot
+   recover per-function *names* from this endpoint at all.
+2. **A wrapped/object shape** the guard's `type` check collapsed — *ruled out* by the captured
+   evidence (`shape="number"`, not `"object"`), but re-confirm against the captured bytes.
+
+The issue body suggests a GraphQL fallback (`/v0/gql functions` field "like enumerate does for
+events"). **This is itself an unverified assumption** and must NOT be adopted on faith: the
+verified schema pin (`knowledge-base/project/specs/feat-one-shot-inngest-cutover-no-ssh-5450/inngest-graphql-schema.md`)
+documents ONLY `eventsV2` — it does **not** document a top-level `functions` GraphQL query field.
+Adopting GraphQL requires the same live-probe + schema-pin discipline that produced the
+`eventsV2` shape. See §Research Reconciliation and §Sharp Edges.
+
+## Research Reconciliation — Issue Claims vs. Codebase / Schema Reality
+
+| Claim (issue / prose) | Reality (verified this session) | Plan response |
+| --- | --- | --- |
+| `/v1/functions` returns a JSON array of function objects (`inngest-inventory.sh:8,16,119`) | Live host returns a bare JSON **number** (`shape="number"` in the FATAL line) | Capture the real bytes (Phase 0), then correct the projection to the captured shape (Phase 2). |
+| GraphQL `/v0/gql functions` field is "likely more reliable" (issue Fix step 1) | The verified schema pin documents ONLY `eventsV2`; **no** top-level `functions` query field is pinned | Do NOT adopt GraphQL on faith. If chosen, it requires its own live schema-pin (same discipline as `eventsV2`). REST-shape-correction is the default; GraphQL is a fallback gated on Phase 0 evidence. |
+| The `#5509` fail-loud guard is the bug | Guard is **working as intended** (no false-clean baseline) | Keep the guard verbatim. Only the *array assumption upstream of it* changes. |
+| `#5515 -replace workaround landed inngest-inventory.sh` | `#5515` is an unrelated OPEN bug (webhook FILE_MAP one-apply-late); the inventory script landed via PR `#5510` (commit `b8850c968`) | Loose prose in the issue; not load-bearing. Delivery is verified end-to-end per the issue Summary. No action. |
+| `op=backup` / `op=enumerate` / `re-arm` affected | Issue states these are **live/unaffected** | Out of scope. This PR touches only the `functions` projection + its fixture/test. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** nothing user-facing. This is an operator-only
+cutover-diagnostics surface (`op=inventory` before/after baseline). A wrong `functions`
+projection degrades the operator's ability to *diff* the cutover, not any end-user flow. The
+`#5509` guard already prevents the worst case (a silent false-clean baseline) by failing loud.
+
+**If this leaks, the user's data is exposed via:** N/A — the inventory summary is counts +
+reminder_ids only (no bodies) per the `#5503` purity invariant, which this PR preserves.
+
+**Brand-survival threshold:** none. *Reason:* operator-only cutover-diagnostics script; no
+end-user-facing surface, no regulated-data surface, no persistence. The existing fail-loud
+guard bounds the worst outcome to a loud, diagnosable abort (not silent corruption).
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] **AC1 — Captured fixture lands in the diff.** A real `/v1/functions` response (the actual
+  host bytes, captured per Phase 0 via the no-SSH path) is committed as a test fixture under
+  `apps/web-platform/infra/` (e.g. inline in `inngest-inventory.test.sh` `make_functions` /
+  a `fixtures/` file). The fixture's shape is the captured shape, NOT a hand-authored array.
+  Grep gate: the test references the captured shape, and the PR body quotes the captured bytes.
+- [ ] **AC2 — Projection matches the captured shape.** `inngest-inventory.sh`'s `functions`
+  projection (`:119`) is corrected so that, given the captured fixture, `functions` in the
+  emitted object is the correct value for the real shape:
+  - if the real shape is a **count**, `functions` surfaces the count (and the header comment +
+    the emitted object's contract are updated to say "count", not "array of names");
+  - if the real shape is `{data:[…]}` or another wrapped array, `functions` unwraps to the
+    name/slug/id list as before;
+  - if GraphQL is adopted (only on Phase 0 evidence + a schema-pin), `functions` projects names
+    from the pinned GraphQL field.
+- [ ] **AC3 — Fail-loud guard preserved.** The `#5509` guard at `:111-118` still trips on a
+  genuine fetch failure / unparseable body (Test 9 `test_functions_fetch_failure_is_loud` still
+  passes), AND the guard's `type=="array"` check is replaced with the correct shape check for
+  the captured shape (so the REAL response no longer trips the guard). The guard must NOT be
+  loosened to silently accept *any* shape — it must accept the captured shape and reject
+  fetch-failure / unexpected shapes.
+- [ ] **AC4 — `#5503` combined-stream purity preserved.** Test 1 (`test_combined_is_pure_json_object`)
+  still passes: success-path stdout+stderr is a single pure JSON object with the 3 keys, and
+  success-path stderr is empty (summary stays journald-only).
+- [ ] **AC5 — Header/contract docs corrected.** The script header (`:8`, `:16-19`) and the
+  emitted-object contract comment are updated to describe the REAL `/v1/functions` shape, with a
+  `# verified: 2026-06-18` annotation citing the Phase-0 capture. No stale "JSON array of
+  registered functions" prose remains. Grep gate: `grep -n 'JSON array of registered functions' inngest-inventory.sh` returns 0.
+- [ ] **AC6 — Test suite green.** `bash apps/web-platform/infra/inngest-inventory.test.sh` exits 0
+  (all tests pass, including a NEW test that drives the corrected projection against the captured
+  fixture and asserts the right `functions` value).
+- [ ] **AC7 — shellcheck clean.** `shellcheck apps/web-platform/infra/inngest-inventory.sh` is clean
+  (or only the pre-existing SC2016 disables remain).
+- [ ] **AC8 — Workflow consumer compatibility.** If the `functions` value changes type
+  (array → count number), `cutover-inngest.yml:239` (`FN=$(echo "$BODY" | jq '.functions | length')`)
+  and `:246` (`{functions, …}`) are reconciled in the SAME PR so the `::notice::` and the
+  before/after diff block render correctly. Grep gate: `grep -n '.functions | length' .github/workflows/cutover-inngest.yml`
+  is updated if `.functions` is no longer an array.
+
+### Post-merge (operator)
+
+- [ ] **AC9 — Re-run `op=inventory` and confirm a clean baseline.** After merge (the script is
+  delivered on the next infra-config push), trigger `op=inventory` via
+  `gh workflow run cutover-inngest.yml -f op=inventory` and confirm the `::notice::inventory: functions=…`
+  line reports the corrected value (no FATAL). *Automation:* `gh workflow run` + `gh run watch` —
+  bake into `/work` Phase 2 verification or `/soleur:ship` post-merge (see §Sharp Edges; this is
+  the SAME no-SSH path Phase 0 uses, so it is automatable, not operator-manual).
+
+## Implementation Phases
+
+> **Phase ordering is load-bearing.** Phase 0 (capture) MUST complete before Phase 2
+> (projection), because the projection's correctness is defined by the captured bytes. Writing
+> the projection before capturing the shape would re-commit the original sin (assuming a shape).
+
+### Phase 0 — Capture the REAL `/v1/functions` shape (no-SSH; BLOCKING gate)
+
+**This phase is the whole point.** Do not write any projection code until the real bytes are in hand.
+
+The host is reachable ONLY via the no-SSH path (`hr-no-ssh-fallback-in-runbooks`). Two automatable
+options; prefer (A):
+
+- **(A) Workflow-mediated raw-body capture (preferred).** Add a one-shot diagnostic to the
+  non-array branch of `fetch_functions` / the guard so the FATAL path *also* logs the raw body
+  (bounded, e.g. first 512 bytes) to journald via `logger` — NOT to stdout (preserves `#5503`
+  purity). Ship that single diagnostic commit, let it deliver, trigger `op=inventory`, then read
+  the captured bytes. **Reachability:** journald is on-host; but the cutover workflow already
+  surfaces the FATAL *cause line* in the `::error::` (`cutover-inngest.yml:234`) — extend the
+  cause line (stderr) to carry the bounded raw shape so it reaches the workflow run-log no-SSH.
+  Mind `#5503`: the bounded raw bytes go to **stderr/journald**, never the success-path stdout.
+- **(B) Direct GraphQL/REST probe via an existing host hook.** If a hook can echo the raw
+  `/v1/functions` body to the workflow response (read-only), use it. Confirm no body-leak concern
+  (`/v1/functions` carries function metadata, not reminder payloads — low sensitivity, but keep it
+  bounded).
+
+**Capture target:** the literal bytes of `GET 127.0.0.1:8288/v1/functions` on the prod host, plus
+(if pursuing the GraphQL fallback) the live `/v0/gql` introspection of any `functions` query field.
+
+**Output of Phase 0:** the captured bytes pasted into the PR body + landed as the AC1 fixture, and
+a one-line determination: "real shape is `<X>`; projection will `<Y>`."
+
+> If Phase 0 reveals the endpoint genuinely returns only a count (no names recoverable from REST),
+> evaluate the GraphQL fallback — but ONLY after live-probing `/v0/gql` for a `functions` field and
+> pinning it in the schema doc (same discipline as `eventsV2`). If neither REST nor GraphQL can
+> recover names, the inventory's `functions` becomes a count-only signal and the header/contract +
+> AC2 are scoped to "count" — document this explicitly rather than faking a names array.
+
+### Phase 1 — RED: write the failing test against the captured fixture
+
+Per `cq-write-failing-tests-before`. Add a test to `inngest-inventory.test.sh` that:
+- builds `make_functions` from the **captured shape** (not the current `[{name,slug,triggers}]` array helper);
+- asserts the corrected `functions` value in the emitted object;
+- keeps Test 9 (fail-loud on genuine failure) and Test 1 (`#5503` purity) green.
+The new test must FAIL against the current `:119` projection (proving it drives the fix).
+
+### Phase 2 — GREEN: correct the projection + guard + contract
+
+- Update the guard shape check (`:111`) from `type == "array"` to the captured-shape check.
+- Update the projection (`:119`) to the captured shape.
+- Update the header comment (`:8`, `:16-19`) + emitted-object contract + add `# verified: 2026-06-18`.
+- If the `functions` type changed, update `cutover-inngest.yml:239,246` in the same commit (AC8).
+
+### Phase 3 — REFACTOR + cross-check the sibling
+
+- Consider whether `inngest-wiped-volume-verify.sh:132-134` (the source of the bad assumption)
+  needs the same correction. Its `if type=="array" then length else 0 end` *tolerates* a number
+  by treating it as `0` — which means its `fn_count >= 1` durability assert (`:134`) **silently
+  fails** on the real (number) shape: a successful restart would report `0 functions` and abort
+  the verify with `no_functions`. **This is a latent bug in the sibling, surfaced by this issue.**
+  Fold the same shape-correction into `inngest-wiped-volume-verify.sh` in this PR (it shares the
+  endpoint and the wrong assumption) OR file a tracking issue. Default: **fold in** — it is the
+  same endpoint, same fix, and leaving it produces a false `no_functions` abort on the real shape.
+  Add/extend `inngest-wiped-volume-verify.test.sh` accordingly.
+
+## Files to Edit
+
+- `apps/web-platform/infra/inngest-inventory.sh` — correct guard shape check (`:111`), projection
+  (`:119`), header/contract comments (`:8`, `:16-19`); add Phase-0 raw-shape diagnostic to the
+  FATAL/stderr path (bounded, `#5503`-safe).
+- `apps/web-platform/infra/inngest-inventory.test.sh` — `make_functions` rewritten to the captured
+  shape; new test driving the corrected projection; keep Tests 1 & 9 green.
+- `apps/web-platform/infra/inngest-wiped-volume-verify.sh` — fold the same shape correction (`:132-134`)
+  so the `fn_count >= 1` durability assert is correct on the real shape (Phase 3; fold-in default).
+- `apps/web-platform/infra/inngest-wiped-volume-verify.test.sh` — cover the corrected sibling shape.
+- `.github/workflows/cutover-inngest.yml` — ONLY IF the `functions` value type changes
+  (`:239` `.functions | length`, `:246` diff block) — reconcile the consumer (AC8).
+
+## Files to Create
+
+- A captured-fixture file under `apps/web-platform/infra/` IF the captured bytes are large enough
+  to warrant a file over inline `make_functions` (decided at Phase 0). Otherwise none.
+
+## Open Code-Review Overlap
+
+None. (`gh issue list --label code-review --state open` checked against the files above; no open
+scope-out names `inngest-inventory.sh`, `inngest-wiped-volume-verify.sh`, or `cutover-inngest.yml`.)
+
+## Infrastructure (IaC)
+
+Skip — no new infrastructure. This PR edits an EXISTING on-host script already delivered through the
+provisioned no-SSH infra-config push + `adnanh/webhook` hook (`hooks.json.tmpl:100-101`). No new
+server, service, secret, vendor, DNS record, TLS cert, firewall rule, or persistent process. No
+Terraform change. (See the iac-routing-ack comment at the top of this file.)
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "op=inventory emits a `::notice::inventory: functions=N event_names=M armed_reminders=K` line on the cutover-inngest.yml run"
+  cadence: "on-demand (operator triggers op=inventory before/after the cutover)"
+  alert_target: "the GitHub Actions run log (no-SSH); FATAL path also reaches host journald via `logger -t inngest-inventory`"
+  configured_in: ".github/workflows/cutover-inngest.yml:242 (::notice::), inngest-inventory.sh:167 (logger summary)"
+error_reporting:
+  destination: "FATAL cause line on stdout → webhook response body → cutover-inngest.yml `::error::` (run log); journald `logger` on host"
+  fail_loud: true  # the #5509 guard exits 1 → webhook non-200 → workflow ::error::; this PR PRESERVES it
+failure_modes:
+  - mode: "/v1/functions returns an unexpected shape (the bug this PR fixes)"
+    detection: "guard shape check (inngest-inventory.sh:111, corrected this PR) → FATAL exit 1"
+    alert_route: "cutover-inngest.yml ::error:: with the bounded raw shape in the cause line (added Phase 0)"
+  - mode: "/v1/functions unreachable (inngest-server.service down)"
+    detection: "curl failure → __FETCH_FAILED__ sentinel → guard trips (preserved)"
+    alert_route: "same ::error:: path"
+logs:
+  where: "host journald (`journalctl -t inngest-inventory`); GitHub Actions run log for the cause line"
+  retention: "journald host-local (rotated); Actions logs per GH retention"
+discoverability_test:
+  command: "gh workflow run cutover-inngest.yml -f op=inventory && gh run watch"  # NO ssh
+  expected_output: "::notice::inventory: functions=<corrected value> … (no FATAL line)"
+```
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications — operator-only infrastructure/tooling change to a cutover-diagnostics
+script. No Product/UX surface (no file under `components/**`, `app/**/page.tsx`, etc.), no marketing,
+legal, finance, sales, ops, or support implications.
+
+## Architecture Decision (ADR/C4)
+
+Skip — no architectural decision. This is a shape-correction bug fix on an existing endpoint
+projection within an already-decided cutover architecture (ADR-030/ADR-033 self-hosted inngest,
+`#5450`). No ownership/tenancy boundary move, no new substrate, no resolver/trust-boundary change,
+no reversal/extension of an existing ADR. A competent engineer reading the existing ADRs + C4 would
+NOT be misled about the system after this fix. **C4 completeness check:** read
+`knowledge-base/engineering/architecture/diagrams/{model.c4,views.c4,spec.c4}` — the inngest host
+and its loopback endpoints are an internal implementation detail of the already-modeled cutover; no
+new external actor, external system, container, or access relationship is introduced by correcting a
+JSON-shape assumption. No `.c4` edit required.
+
+## GDPR / Compliance
+
+Skip — no regulated-data surface. The inventory summary is counts + reminder_ids only (no bodies,
+per `#5503`); `/v1/functions` carries function metadata (names/slugs), not user data. No schema,
+migration, auth flow, or API-route change. None of the (a)–(d) expansion triggers fire (no new
+LLM/external-API processing of session data, threshold is `none`, no new learnings-reading cron, no
+new artifact-distribution surface).
+
+## Hypotheses
+
+The bug-report keyword scan matches none of the network-outage trigger set as a *root-cause*
+hypothesis — the FATAL is a deliberate fail-loud, not a connectivity failure. But the FATAL message
+itself asks "is inngest-server.service up?", so Phase 0 must distinguish two states before correcting
+the projection:
+
+1. **H1 (most likely): `/v1/functions` genuinely returns a number on a HEALTHY server** — the
+   endpoint shape differs from the mirrored assumption (the real bug). Phase 0 capture confirms by
+   pairing the `/v1/functions` probe with a `/health` 200 in the same run.
+2. **H2 (rule out): the number is an error/status artifact of a degraded read** — the guard already
+   distinguishes a curl failure (sentinel string, non-JSON) from a parseable JSON number, so a clean
+   JSON `number` on a `/health`-200 host points to H1. Phase 0 MUST capture `/health` alongside
+   `/v1/functions` to settle this before writing the projection.
+
+## Sharp Edges
+
+- **A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder
+  text, or omits the threshold will fail `deepen-plan` Phase 4.6.** (Filled above; threshold = none
+  with a reason, required because the diff touches an infra path.)
+- **The captured `/v1/functions` shape MUST land as a fixture in the diff — a "probed" annotation is
+  not evidence** (`2026-06-16-external-api-shape-ac-must-land-captured-fixture-not-probed-claim`).
+  Review must re-confirm the fixture matches the captured bytes, not trust prose.
+- **The GraphQL fallback the issue suggests is NOT a verified path.** The schema pin documents only
+  `eventsV2`; there is no pinned `functions` GraphQL query field. Adopting GraphQL requires a live
+  `/v0/gql` introspection + a schema-doc pin first (same discipline that produced `eventsV2`).
+  Default to correcting the REST projection unless Phase 0 proves REST cannot recover names.
+- **The sibling `inngest-wiped-volume-verify.sh` has the SAME latent bug** (`type=="array" → length else 0`
+  silently reports `0` on the real number shape → false `no_functions` abort after a successful
+  restart). Fold the correction in (default) or file a tracking issue — do not leave the sibling
+  asserting on a tolerated-zero.
+- **`#5503` combined-stream purity is load-bearing.** The Phase-0 raw-shape diagnostic and any new
+  echo MUST go to stderr/journald, never the success-path stdout — the webhook returns
+  `cmd.CombinedOutput()` and the workflow jq-parses the body as an object. An accidental stdout echo
+  breaks the parse (the exact regression that blocked the cutover before).
+- **AC8 type-change reconciliation:** if `functions` changes from an array to a count number,
+  `cutover-inngest.yml:239` (`.functions | length`) becomes wrong (length of a number is null) — it
+  must be reconciled in the same PR or the `::notice::` silently mis-reports.
+- **No-SSH host-op delivery is a multi-file lockstep**, but this PR does NOT add or rename a delivered
+  script (it edits an existing one), so the FILE_MAP↔DEST_SPEC parity test does not need a count bump.
+  Confirm by grepping the parity test for `inngest-inventory` (already present) — no new entry.
+- **Post-merge `op=inventory` re-run is automatable** via `gh workflow run cutover-inngest.yml -f op=inventory`
+  + `gh run watch` — it is NOT operator-manual. Bake AC9 into `/work` Phase 2 or `/soleur:ship`.

--- a/knowledge-base/project/plans/2026-06-18-fix-inngest-inventory-functions-shape-plan.md
+++ b/knowledge-base/project/plans/2026-06-18-fix-inngest-inventory-functions-shape-plan.md
@@ -65,12 +65,59 @@ documents ONLY `eventsV2` — it does **not** document a top-level `functions` G
 Adopting GraphQL requires the same live-probe + schema-pin discipline that produced the
 `eventsV2` shape. See §Research Reconciliation and §Sharp Edges.
 
+## Research Insights (deepen-plan, 2026-06-18)
+
+Two parallel research agents (inngest-API-contract + verify-the-negative/precedent-diff) ran on
+2026-06-18. Key findings that **materially change the recommended fix path**:
+
+- **`GET /v1/functions` is NOT a registered route in inngest v1.19.4.** Source-code inspection of
+  `pkg/devserver/api.go`, `pkg/api/apiv1/apiv1.go`, and `pkg/coreapi/coreapi.go` shows the `/v1`
+  router registers `GET /v1/apps/{appName}/functions` — there is **no bare `/v1/functions`**. The
+  observed bare-number response is almost certainly a **router 404/fallback body** (or a pre-refactor
+  artifact), NOT a function payload. *Hypothesis to confirm against the Phase-0 live capture* — but it
+  reframes the bug: the script is hitting a **wrong/unregistered path**, not parsing a real shape wrong.
+  - Correct REST: `GET /v1/apps/{appName}/functions` → a **bare JSON array** `[{...}]` of
+    `cqrs.Function` objects (direct `json.NewEncoder(w).Encode(fns)`, NOT `{data:[…]}`-wrapped). But
+    this requires knowing the `appName`(s) first.
+  - **GraphQL `functions` field EXISTS and is the cleanest path** (contradicts the issue's
+    "likely more reliable" hedge AND my plan-v1 claim that the schema pin lacks it): `pkg/coreapi/gql.query.graphql`
+    declares top-level `functions: [Function!]` at `POST /v0/gql` — a rich object array (the same
+    source the devserver UI uses), no auth on loopback. This is the SAME GraphQL endpoint enumerate
+    already uses for `eventsV2`, so the script already has the curl+jq+`#5503`-purity machinery.
+  - **Verdict: prefer the GraphQL `functions` query** (single endpoint, no `appName` discovery needed,
+    object array → names project cleanly). Phase 0 MUST still live-probe BOTH `/v0/gql { functions { ... } }`
+    AND introspect the live `Function` type's fields (the v1.19.4 `Function` field set is the unknown
+    to pin in the schema doc — `slug`/`name`/`triggers` are likely but unconfirmed).
+- **The schema-pin doc gap is real and must be closed:** `inngest-graphql-schema.md` documents only
+  `eventsV2`. Adding the `functions` query field requires the SAME live-probe + schema-pin discipline
+  (`2026-06-17-inngest-eventsv2-raw-payload-and-receivedat-filter`). Pin the captured `Function` field
+  set in that doc as part of this PR.
+- **Phase-0 option (A) has NO precedent and risks `#5503` purity** (precedent-diff agent): neither
+  `inngest-inventory.sh` nor `inngest-enumerate-reminders.sh` echoes bounded raw bytes to stderr; the
+  `#5503` block at `inngest-enumerate-reminders.sh:146-158` explicitly PROHIBITS success-path stderr
+  echoes (webhook `CombinedOutput()` merges streams). The existing FATAL stderr lines surface only
+  derived metadata (`shape=`), never raw bytes. **Re-prefer Phase-0 option (A) only on the FATAL/exit-1
+  path** (where stdout is already non-JSON and the body is not parsed as success), bounding to a short
+  prefix — OR, better, capture via a **read-only GraphQL probe through an existing host hook / a one-shot
+  diagnostic that runs the `/v0/gql { functions }` query and surfaces its shape on the FATAL line**. Do
+  NOT add any success-path stderr echo.
+- **All 6 verify-the-negative claims confirmed** (citations): projection `:119`, guard `:111-118`,
+  sibling latent bug `inngest-wiped-volume-verify.sh:132-134` (bare-number → `jq … else 0` → false
+  `no_functions` abort after a healthy restart — Phase 3 fold-in is justified), consumer
+  `cutover-inngest.yml:239,246`, and the FATAL diagnostic captures `type` only, never the value.
+
+**Net effect on the plan:** Phase 2's default projection switches from "correct the REST array parse"
+to "**re-point to the GraphQL `functions` query** (paralleling enumerate's `eventsV2`), pin the
+`Function` field set in the schema doc, project names." The REST `/v1/apps/{appName}/functions` array
+path remains a documented fallback if GraphQL `functions` proves unavailable on the live host. Phase 0
+remains the BLOCKING gate — confirm the live shape before committing the projection.
+
 ## Research Reconciliation — Issue Claims vs. Codebase / Schema Reality
 
 | Claim (issue / prose) | Reality (verified this session) | Plan response |
 | --- | --- | --- |
 | `/v1/functions` returns a JSON array of function objects (`inngest-inventory.sh:8,16,119`) | Live host returns a bare JSON **number** (`shape="number"` in the FATAL line) | Capture the real bytes (Phase 0), then correct the projection to the captured shape (Phase 2). |
-| GraphQL `/v0/gql functions` field is "likely more reliable" (issue Fix step 1) | The verified schema pin documents ONLY `eventsV2`; **no** top-level `functions` query field is pinned | Do NOT adopt GraphQL on faith. If chosen, it requires its own live schema-pin (same discipline as `eventsV2`). REST-shape-correction is the default; GraphQL is a fallback gated on Phase 0 evidence. |
+| GraphQL `/v0/gql functions` field is "likely more reliable" (issue Fix step 1) | **Confirmed by source-code research:** `pkg/coreapi/gql.query.graphql` declares top-level `functions: [Function!]` at `POST /v0/gql` (rich object array, no auth on loopback). The schema PIN doc lacks it, but the field exists. Separately, `GET /v1/functions` is NOT a registered route in v1.19.4 (correct REST is `/v1/apps/{appName}/functions`). | **GraphQL `functions` is now the PREFERRED path** (single endpoint, reuses enumerate's `eventsV2` machinery, no `appName` discovery). Still requires a Phase-0 live probe + a schema-doc pin of the v1.19.4 `Function` field set. REST `/v1/apps/{appName}/functions` array is the documented fallback. |
 | The `#5509` fail-loud guard is the bug | Guard is **working as intended** (no false-clean baseline) | Keep the guard verbatim. Only the *array assumption upstream of it* changes. |
 | `#5515 -replace workaround landed inngest-inventory.sh` | `#5515` is an unrelated OPEN bug (webhook FILE_MAP one-apply-late); the inventory script landed via PR `#5510` (commit `b8850c968`) | Loose prose in the issue; not load-bearing. Delivery is verified end-to-end per the issue Summary. No action. |
 | `op=backup` / `op=enumerate` / `re-arm` affected | Issue states these are **live/unaffected** | Out of scope. This PR touches only the `functions` projection + its fixture/test. |
@@ -166,17 +213,26 @@ options; prefer (A):
   (`/v1/functions` carries function metadata, not reminder payloads — low sensitivity, but keep it
   bounded).
 
-**Capture target:** the literal bytes of `GET 127.0.0.1:8288/v1/functions` on the prod host, plus
-(if pursuing the GraphQL fallback) the live `/v0/gql` introspection of any `functions` query field.
+**Capture target (per deepen-plan research — PREFER GraphQL):**
+1. **GraphQL (preferred):** probe `POST 127.0.0.1:8288/v0/gql` with `query { functions { slug name triggers } }`
+   (the exact `Function` field set is the unknown — start minimal, introspect). Capture the response +
+   the live `Function` type fields. This is the same endpoint enumerate already uses for `eventsV2`.
+2. **REST diagnostic (confirm the bug's true cause):** capture the literal bytes of
+   `GET 127.0.0.1:8288/v1/functions` (the bare number — almost certainly a 404/fallback body since the
+   route is unregistered) AND, if pursuing the REST fallback, `GET /v1/apps/{appName}/functions` after
+   discovering the app name(s).
+3. **`/health` 200** alongside, to settle H1 vs H2 (healthy server returning the number → confirms the
+   wrong-path hypothesis, not a degraded read).
 
-**Output of Phase 0:** the captured bytes pasted into the PR body + landed as the AC1 fixture, and
-a one-line determination: "real shape is `<X>`; projection will `<Y>`."
+**Output of Phase 0:** the captured GraphQL `functions` response + `Function` field set pasted into the
+PR body, landed as the AC1 fixture, pinned in `inngest-graphql-schema.md`; and a one-line determination:
+"projection will re-point to GraphQL `functions` (or REST `/v1/apps/{appName}/functions` fallback)."
 
-> If Phase 0 reveals the endpoint genuinely returns only a count (no names recoverable from REST),
-> evaluate the GraphQL fallback — but ONLY after live-probing `/v0/gql` for a `functions` field and
-> pinning it in the schema doc (same discipline as `eventsV2`). If neither REST nor GraphQL can
-> recover names, the inventory's `functions` becomes a count-only signal and the header/contract +
-> AC2 are scoped to "count" — document this explicitly rather than faking a names array.
+> Decision tree after Phase 0: (a) GraphQL `functions` returns a name-bearing object array → re-point
+> the projection there (DEFAULT, paralleling `eventsV2`); (b) GraphQL unavailable but REST
+> `/v1/apps/{appName}/functions` works → use it (requires `appName` discovery); (c) neither recovers
+> names → `functions` becomes a count-only signal, header/contract + AC2 scoped to "count" — document
+> explicitly rather than faking a names array.
 
 ### Phase 1 — RED: write the failing test against the captured fixture
 
@@ -217,6 +273,9 @@ The new test must FAIL against the current `:119` projection (proving it drives 
 - `apps/web-platform/infra/inngest-wiped-volume-verify.test.sh` — cover the corrected sibling shape.
 - `.github/workflows/cutover-inngest.yml` — ONLY IF the `functions` value type changes
   (`:239` `.functions | length`, `:246` diff block) — reconcile the consumer (AC8).
+- `knowledge-base/project/specs/feat-one-shot-inngest-cutover-no-ssh-5450/inngest-graphql-schema.md`
+  — pin the live-probed v1.19.4 GraphQL `functions: [Function!]` query field + the `Function` type's
+  field set (the doc currently covers only `eventsV2`). Required if the GraphQL path is adopted.
 
 ## Files to Create
 
@@ -257,7 +316,7 @@ logs:
   where: "host journald (`journalctl -t inngest-inventory`); GitHub Actions run log for the cause line"
   retention: "journald host-local (rotated); Actions logs per GH retention"
 discoverability_test:
-  command: "gh workflow run cutover-inngest.yml -f op=inventory && gh run watch"  # NO ssh
+  command: "gh workflow run cutover-inngest.yml -f op=inventory && gh run watch"  # no-SSH; runs through the existing GitHub Actions + webhook hook path
   expected_output: "::notice::inventory: functions=<corrected value> … (no FATAL line)"
 ```
 
@@ -312,10 +371,19 @@ the projection:
 - **The captured `/v1/functions` shape MUST land as a fixture in the diff — a "probed" annotation is
   not evidence** (`2026-06-16-external-api-shape-ac-must-land-captured-fixture-not-probed-claim`).
   Review must re-confirm the fixture matches the captured bytes, not trust prose.
-- **The GraphQL fallback the issue suggests is NOT a verified path.** The schema pin documents only
-  `eventsV2`; there is no pinned `functions` GraphQL query field. Adopting GraphQL requires a live
-  `/v0/gql` introspection + a schema-doc pin first (same discipline that produced `eventsV2`).
-  Default to correcting the REST projection unless Phase 0 proves REST cannot recover names.
+- **GraphQL `functions` IS a real field but its v1.19.4 `Function` field set is unpinned.** Research
+  confirmed `functions: [Function!]` exists at `/v0/gql`, but the schema PIN doc
+  (`inngest-graphql-schema.md`) documents only `eventsV2`. Phase 0 MUST live-probe the `Function`
+  fields and pin them in that doc as part of this PR (same discipline as `eventsV2`) — do NOT assume
+  `slug`/`name`/`triggers` without confirming.
+- **`GET /v1/functions` is an unregistered route in v1.19.4 (root cause refinement).** The correct REST
+  path is `/v1/apps/{appName}/functions`. The bare number the script reads is almost certainly a
+  router fallback body, not a real projection target. Phase 0 confirms; this is why GraphQL is preferred
+  (no `appName` discovery needed).
+- **Phase-0 raw-shape diagnostic is a NOVEL stderr pattern — confine it to the FATAL/exit-1 path.** No
+  precedent exists for echoing bounded raw bytes to stderr; the `#5503` block PROHIBITS success-path
+  stderr echoes. Any diagnostic MUST live on the already-non-JSON FATAL/exit-1 path (bounded prefix),
+  never the success path.
 - **The sibling `inngest-wiped-volume-verify.sh` has the SAME latent bug** (`type=="array" → length else 0`
   silently reports `0` on the real number shape → false `no_functions` abort after a successful
   restart). Fold the correction in (default) or file a tracking issue — do not leave the sibling

--- a/knowledge-base/project/specs/feat-one-shot-fix-5517-inngest-functions-shape/phase0-capture.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-5517-inngest-functions-shape/phase0-capture.md
@@ -1,0 +1,55 @@
+# Phase 0 capture — real /v1/functions + GraphQL functions shape (inngest v1.19.4)
+
+Captured 2026-06-18 against `inngest/inngest:v1.19.4` running `inngest start` locally in
+Docker (the exact prod pin; the SAME authoritative method that pinned the eventsV2 schema in
+`inngest-graphql-schema.md`). The `/v1/functions` route registration and the `/v0/gql`
+`functions` field are determined by the inngest binary version, not by prod data, so a local
+v1.19.4 reproduces the prod shape exactly. This is the AC1 captured evidence.
+
+## (1) GET /v1/functions — the bug
+
+    HTTP 404
+    body: `404 page not found`     (literal text, not JSON)
+
+The route is UNREGISTERED in v1.19.4. The inventory script's `curl -s` reads the 404 text body;
+`jq 'if type=="object" then keys else type end'` parses the leading token `404` as a JSON number
+→ emits `"number"` → the FATAL line reports `shape="number"`. This reproduces the issue's exact
+symptom (`shape="number"`). Confirms H1 (healthy server, wrong-path artifact) — /health = 200
+alongside.
+
+## (2) /health — H1 vs H2
+
+    HTTP 200    (healthy server; the number is a wrong-path 404 artifact, not a degraded read)
+
+## (3) POST /v0/gql — the fix path
+
+`Query.functions` IS a registered top-level field (Query introspection lists
+`eventsV2, functions, functionRun`). Probe:
+
+    request:  {"query":"query { functions { id name slug } }"}
+    response (empty state): {"data":{"functions":[]}}
+
+    request:  {"query":"query { functions { slug name triggers { type value } } }"}
+    response (empty state): {"data":{"functions":[]}}
+
+A populated host returns `{"data":{"functions":[{"id":"...","name":"...","slug":"...","triggers":[...]}]}}`.
+
+### `Function` type field set (introspected, v1.19.4)
+`id: String!`, `name: String!`, `slug: String!`, `failureHandler: Function`, `config: String!`,
+`configuration: FunctionConfiguration!`, `concurrency: Int!`, `triggers: [FunctionTrigger!]`,
+`url: String!`, `appID: String!`, `app: App!`.
+
+### `FunctionTrigger` type field set
+`type: FunctionTriggerTypes`, `value: String`, `condition: String`.
+
+No auth on loopback `/v0/gql` in `start` mode (HTTP 200, no auth header) — same as eventsV2.
+
+## Determination (decision tree branch (a))
+
+Re-point the `functions` projection to the GraphQL `functions` query
+(`POST /v0/gql { query: "query { functions { id name slug } }" }`), mirroring enumerate's
+eventsV2 fetch. The emitted object's `functions` field stays a **sorted array of name strings**
+(`[.data.functions[] | (.name // .slug // .id)] | sort`), so the workflow consumer
+(`cutover-inngest.yml:239` `.functions | length`) needs NO change (AC8 satisfied without a
+workflow edit). Pin the `functions` query + `Function`/`FunctionTrigger` field set in
+`inngest-graphql-schema.md`.

--- a/knowledge-base/project/specs/feat-one-shot-fix-5517-inngest-functions-shape/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-5517-inngest-functions-shape/session-state.md
@@ -1,0 +1,22 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-one-shot-fix-5517-inngest-functions-shape/knowledge-base/project/plans/2026-06-18-fix-inngest-inventory-functions-shape-plan.md
+- Status: complete
+
+### Errors
+None. (Two deepen-plan gate false-positives self-resolved: 4.7 SSH check tripped on a `# NO ssh` comment annotation — reworded; 4.9 UI check matched a negative prose statement, not a Files-list entry — confirmed skip-correct.)
+
+### Decisions
+- Phase 0 (capture the real `/v1/functions` shape on the host) is a BLOCKING gate before any projection code — correctness is defined by live host bytes, captured as a test fixture (not a probed annotation).
+- GraphQL `functions: [Function!]` at `/v0/gql` is the PREFERRED fix path: `GET /v1/functions` is an unregistered route in inngest v1.19.4 (bare number = router fallback); GraphQL field exists, reuses enumerate's `eventsV2` machinery, no `appName` discovery needed. Reverses the original plan's REST-correction default.
+- Sibling `inngest-wiped-volume-verify.sh:132-134` has the same latent bug (`jq … else 0` tolerates the number → false `no_functions` abort after a healthy restart) — folded into scope (Phase 3).
+- The #5509 fail-loud guard is kept verbatim — worked as intended; only the upstream array assumption changes.
+- Brand-survival threshold = none (operator-only cutover-diagnostics; no end-user/regulated surface), scope-out reason recorded since the diff touches an infra path. No new infrastructure, no ADR, no GDPR surface.
+
+### Components Invoked
+- Skill: soleur:plan (#5517)
+- Skill: soleur:deepen-plan (plan file path)
+- Agent ×2 (general-purpose, sonnet, parallel): inngest-API-contract research; verify-the-negative + precedent-diff
+- deepen-plan halt gates 4.6/4.7/4.8/4.9 — all pass/skip
+- gh premise-validation (#5509 CLOSED, #5450 OPEN, #5515 unrelated), code-review-overlap check (None)

--- a/knowledge-base/project/specs/feat-one-shot-fix-5517-inngest-functions-shape/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-5517-inngest-functions-shape/tasks.md
@@ -7,16 +7,23 @@ plan: knowledge-base/project/plans/2026-06-18-fix-inngest-inventory-functions-sh
 
 # Tasks — fix(inngest): op=inventory /v1/functions shape correction (#5517)
 
-## Phase 0 — Capture the REAL /v1/functions shape (BLOCKING; no-SSH)
+## Phase 0 — Capture the real functions shape (BLOCKING; no-SSH)
 
-- [ ] 0.1 Add a bounded raw-shape diagnostic to `inngest-inventory.sh` FATAL/stderr path
-      (bytes → stderr/journald only, NOT success-path stdout — #5503 purity).
+> deepen-plan research (2026-06-18): `GET /v1/functions` is an UNREGISTERED route in v1.19.4 (bare
+> number = router fallback). GraphQL `functions: [Function!]` at `/v0/gql` EXISTS and is PREFERRED
+> (reuses enumerate's eventsV2 machinery, no appName discovery). REST `/v1/apps/{appName}/functions`
+> is the array fallback.
+
+- [ ] 0.1 Add a bounded raw-shape diagnostic ONLY on the `inngest-inventory.sh` FATAL/exit-1 path
+      (novel stderr pattern — never success-path; #5503 purity prohibits success stderr).
 - [ ] 0.2 Ship that diagnostic commit; let it deliver via the infra-config push.
-- [ ] 0.3 Trigger `op=inventory` (`gh workflow run cutover-inngest.yml -f op=inventory`); read
-      the captured raw `/v1/functions` bytes from the `::error::` cause line / journald.
-- [ ] 0.4 Capture `/health` 200 alongside (settle H1 vs H2 — healthy-server-returns-number).
-- [ ] 0.5 Determine the real shape + paste the captured bytes into the PR body. Decide:
-      REST-shape-correction (default) vs GraphQL fallback (requires its own /v0/gql schema-pin).
+- [ ] 0.3 Trigger `op=inventory` (`gh workflow run cutover-inngest.yml -f op=inventory`); read the
+      captured raw bytes from the `::error::` cause line / journald.
+- [ ] 0.4 Live-probe `POST /v0/gql { functions { slug name triggers } }` (introspect the real
+      `Function` field set) AND `/health` 200 alongside (settle H1 vs H2).
+- [ ] 0.5 Decide per the plan's decision tree: GraphQL `functions` (default) → REST
+      `/v1/apps/{appName}/functions` → count-only. Paste captured bytes + `Function` fields into PR body;
+      pin the GraphQL `functions` shape in `inngest-graphql-schema.md`.
 
 ## Phase 1 — RED: failing test against the captured fixture
 
@@ -28,7 +35,9 @@ plan: knowledge-base/project/plans/2026-06-18-fix-inngest-inventory-functions-sh
 ## Phase 2 — GREEN: correct projection + guard + contract
 
 - [ ] 2.1 Update guard shape check `inngest-inventory.sh:111` (`type=="array"` → captured-shape check).
-- [ ] 2.2 Update projection `:119` to the captured shape (names / count / unwrap / GraphQL-pinned).
+- [ ] 2.2 Re-point projection `:119` to the GraphQL `functions` query (default; mirror enumerate's
+      eventsV2 fetch+jq) — or REST `/v1/apps/{appName}/functions` array / count-only per Phase 0.
+      Pin the GraphQL `functions` + `Function` field set in `inngest-graphql-schema.md`.
 - [ ] 2.3 Update header (`:8`, `:16-19`) + emitted-object contract + add `# verified: 2026-06-18`;
       remove stale "JSON array of registered functions" prose.
 - [ ] 2.4 IF `functions` type changed: reconcile `cutover-inngest.yml:239` (`.functions | length`)

--- a/knowledge-base/project/specs/feat-one-shot-fix-5517-inngest-functions-shape/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-5517-inngest-functions-shape/tasks.md
@@ -1,0 +1,55 @@
+---
+issue: 5517
+branch: feat-one-shot-fix-5517-inngest-functions-shape
+lane: single-domain
+plan: knowledge-base/project/plans/2026-06-18-fix-inngest-inventory-functions-shape-plan.md
+---
+
+# Tasks — fix(inngest): op=inventory /v1/functions shape correction (#5517)
+
+## Phase 0 — Capture the REAL /v1/functions shape (BLOCKING; no-SSH)
+
+- [ ] 0.1 Add a bounded raw-shape diagnostic to `inngest-inventory.sh` FATAL/stderr path
+      (bytes → stderr/journald only, NOT success-path stdout — #5503 purity).
+- [ ] 0.2 Ship that diagnostic commit; let it deliver via the infra-config push.
+- [ ] 0.3 Trigger `op=inventory` (`gh workflow run cutover-inngest.yml -f op=inventory`); read
+      the captured raw `/v1/functions` bytes from the `::error::` cause line / journald.
+- [ ] 0.4 Capture `/health` 200 alongside (settle H1 vs H2 — healthy-server-returns-number).
+- [ ] 0.5 Determine the real shape + paste the captured bytes into the PR body. Decide:
+      REST-shape-correction (default) vs GraphQL fallback (requires its own /v0/gql schema-pin).
+
+## Phase 1 — RED: failing test against the captured fixture
+
+- [ ] 1.1 Land the captured shape as a fixture (inline `make_functions` rewrite or `fixtures/` file).
+- [ ] 1.2 Add a test driving the corrected projection against the captured fixture; assert the
+      correct `functions` value. Must FAIL against the current `:119` array projection.
+- [ ] 1.3 Confirm Test 1 (#5503 purity) and Test 9 (fail-loud) still pass.
+
+## Phase 2 — GREEN: correct projection + guard + contract
+
+- [ ] 2.1 Update guard shape check `inngest-inventory.sh:111` (`type=="array"` → captured-shape check).
+- [ ] 2.2 Update projection `:119` to the captured shape (names / count / unwrap / GraphQL-pinned).
+- [ ] 2.3 Update header (`:8`, `:16-19`) + emitted-object contract + add `# verified: 2026-06-18`;
+      remove stale "JSON array of registered functions" prose.
+- [ ] 2.4 IF `functions` type changed: reconcile `cutover-inngest.yml:239` (`.functions | length`)
+      and `:246` (diff block) in the SAME commit (AC8).
+- [ ] 2.5 Run `bash apps/web-platform/infra/inngest-inventory.test.sh` → exit 0 (AC6).
+- [ ] 2.6 `shellcheck apps/web-platform/infra/inngest-inventory.sh` clean (AC7).
+
+## Phase 3 — REFACTOR + sibling cross-check
+
+- [ ] 3.1 Fold the same shape correction into `inngest-wiped-volume-verify.sh:132-134` (the
+      `type=="array" → length else 0` tolerated-zero → false `no_functions` abort on real shape).
+- [ ] 3.2 Extend `inngest-wiped-volume-verify.test.sh` for the corrected shape.
+- [ ] 3.3 Confirm FILE_MAP↔DEST_SPEC parity test needs NO count bump (no new/renamed delivered script).
+
+## Phase 4 — Verify + ship
+
+- [ ] 4.1 Full suite green for touched infra scripts.
+- [ ] 4.2 PR body: `Ref #5517` (NOT Closes — see below); quote captured bytes; pre/post-merge AC split.
+- [ ] 4.3 Post-merge (AC9): re-run `op=inventory` via `gh workflow run` + `gh run watch`; confirm
+      `::notice::inventory: functions=<corrected>` with no FATAL. Then `gh issue close 5517` if clean.
+
+> Use `Ref #5517` in the PR body if the AC9 confirmation is post-merge-operator-style; otherwise
+> `Closes #5517` is fine since all behavioral ACs (AC1–AC8) are pre-merge and AC9 is an automatable
+> re-run, not a manual gate.

--- a/knowledge-base/project/specs/feat-one-shot-fix-5517-inngest-functions-shape/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-fix-5517-inngest-functions-shape/tasks.md
@@ -14,47 +14,47 @@ plan: knowledge-base/project/plans/2026-06-18-fix-inngest-inventory-functions-sh
 > (reuses enumerate's eventsV2 machinery, no appName discovery). REST `/v1/apps/{appName}/functions`
 > is the array fallback.
 
-- [ ] 0.1 Add a bounded raw-shape diagnostic ONLY on the `inngest-inventory.sh` FATAL/exit-1 path
+- [x] 0.1 Add a bounded raw-shape diagnostic ONLY on the `inngest-inventory.sh` FATAL/exit-1 path
       (novel stderr pattern — never success-path; #5503 purity prohibits success stderr).
-- [ ] 0.2 Ship that diagnostic commit; let it deliver via the infra-config push.
-- [ ] 0.3 Trigger `op=inventory` (`gh workflow run cutover-inngest.yml -f op=inventory`); read the
+- [x] 0.2 Ship that diagnostic commit; let it deliver via the infra-config push.
+- [x] 0.3 Trigger `op=inventory` (`gh workflow run cutover-inngest.yml -f op=inventory`); read the
       captured raw bytes from the `::error::` cause line / journald.
-- [ ] 0.4 Live-probe `POST /v0/gql { functions { slug name triggers } }` (introspect the real
+- [x] 0.4 Live-probe `POST /v0/gql { functions { slug name triggers } }` (introspect the real
       `Function` field set) AND `/health` 200 alongside (settle H1 vs H2).
-- [ ] 0.5 Decide per the plan's decision tree: GraphQL `functions` (default) → REST
+- [x] 0.5 Decide per the plan's decision tree: GraphQL `functions` (default) → REST
       `/v1/apps/{appName}/functions` → count-only. Paste captured bytes + `Function` fields into PR body;
       pin the GraphQL `functions` shape in `inngest-graphql-schema.md`.
 
 ## Phase 1 — RED: failing test against the captured fixture
 
-- [ ] 1.1 Land the captured shape as a fixture (inline `make_functions` rewrite or `fixtures/` file).
-- [ ] 1.2 Add a test driving the corrected projection against the captured fixture; assert the
+- [x] 1.1 Land the captured shape as a fixture (inline `make_functions` rewrite or `fixtures/` file).
+- [x] 1.2 Add a test driving the corrected projection against the captured fixture; assert the
       correct `functions` value. Must FAIL against the current `:119` array projection.
-- [ ] 1.3 Confirm Test 1 (#5503 purity) and Test 9 (fail-loud) still pass.
+- [x] 1.3 Confirm Test 1 (#5503 purity) and Test 9 (fail-loud) still pass.
 
 ## Phase 2 — GREEN: correct projection + guard + contract
 
-- [ ] 2.1 Update guard shape check `inngest-inventory.sh:111` (`type=="array"` → captured-shape check).
-- [ ] 2.2 Re-point projection `:119` to the GraphQL `functions` query (default; mirror enumerate's
+- [x] 2.1 Update guard shape check `inngest-inventory.sh:111` (`type=="array"` → captured-shape check).
+- [x] 2.2 Re-point projection `:119` to the GraphQL `functions` query (default; mirror enumerate's
       eventsV2 fetch+jq) — or REST `/v1/apps/{appName}/functions` array / count-only per Phase 0.
       Pin the GraphQL `functions` + `Function` field set in `inngest-graphql-schema.md`.
-- [ ] 2.3 Update header (`:8`, `:16-19`) + emitted-object contract + add `# verified: 2026-06-18`;
+- [x] 2.3 Update header (`:8`, `:16-19`) + emitted-object contract + add `# verified: 2026-06-18`;
       remove stale "JSON array of registered functions" prose.
-- [ ] 2.4 IF `functions` type changed: reconcile `cutover-inngest.yml:239` (`.functions | length`)
+- [x] 2.4 IF `functions` type changed: reconcile `cutover-inngest.yml:239` (`.functions | length`)
       and `:246` (diff block) in the SAME commit (AC8).
-- [ ] 2.5 Run `bash apps/web-platform/infra/inngest-inventory.test.sh` → exit 0 (AC6).
-- [ ] 2.6 `shellcheck apps/web-platform/infra/inngest-inventory.sh` clean (AC7).
+- [x] 2.5 Run `bash apps/web-platform/infra/inngest-inventory.test.sh` → exit 0 (AC6).
+- [x] 2.6 `shellcheck apps/web-platform/infra/inngest-inventory.sh` clean (AC7).
 
 ## Phase 3 — REFACTOR + sibling cross-check
 
-- [ ] 3.1 Fold the same shape correction into `inngest-wiped-volume-verify.sh:132-134` (the
+- [x] 3.1 Fold the same shape correction into `inngest-wiped-volume-verify.sh:132-134` (the
       `type=="array" → length else 0` tolerated-zero → false `no_functions` abort on real shape).
-- [ ] 3.2 Extend `inngest-wiped-volume-verify.test.sh` for the corrected shape.
-- [ ] 3.3 Confirm FILE_MAP↔DEST_SPEC parity test needs NO count bump (no new/renamed delivered script).
+- [x] 3.2 Extend `inngest-wiped-volume-verify.test.sh` for the corrected shape.
+- [x] 3.3 Confirm FILE_MAP↔DEST_SPEC parity test needs NO count bump (no new/renamed delivered script).
 
 ## Phase 4 — Verify + ship
 
-- [ ] 4.1 Full suite green for touched infra scripts.
+- [x] 4.1 Full suite green for touched infra scripts.
 - [ ] 4.2 PR body: `Ref #5517` (NOT Closes — see below); quote captured bytes; pre/post-merge AC split.
 - [ ] 4.3 Post-merge (AC9): re-run `op=inventory` via `gh workflow run` + `gh run watch`; confirm
       `::notice::inventory: functions=<corrected>` with no FATAL. Then `gh issue close 5517` if clean.

--- a/knowledge-base/project/specs/feat-one-shot-inngest-cutover-no-ssh-5450/inngest-graphql-schema.md
+++ b/knowledge-base/project/specs/feat-one-shot-inngest-cutover-no-ssh-5450/inngest-graphql-schema.md
@@ -30,8 +30,16 @@ Variables: `{ first, after, filter: { from: "<wide receivedAt lower bound>", eve
 
 Re-armable record reconstructed from `JSON.parse(node.raw)`: `{reminder_id, fire_at, actor, action}` (= `.data`) — exactly the `schedule-reminder` route's input (it recomputes `id`/`ts` from `reminder_id`/`fire_at`, so re-arm through the route preserves the dedup keys automatically).
 
+## `functions` query (registered-function list, #5517)
+- **`Query.functions: [Function!]`** is a registered top-level field at `POST /v0/gql` (Query introspection lists `eventsV2, functions, functionRun`). It returns the rich object array the devserver UI shows — the same loopback endpoint + no-auth as `eventsV2`.
+- **`GET /v1/functions` is an UNREGISTERED route in v1.19.4 → HTTP 404, body `404 page not found`.** A `curl -s | jq type` on that body parses the leading token `404` as a number, which is why the old inventory guard reported `shape="number"`. The correct REST path is `GET /v1/apps/{appName}/functions` (requires app-name discovery) — the GraphQL `functions` query avoids that and is preferred.
+- **`Function` field set** (introspected, v1.19.4): `id: String!`, `name: String!`, `slug: String!`, `failureHandler: Function`, `config: String!`, `configuration: FunctionConfiguration!`, `concurrency: Int!`, `triggers: [FunctionTrigger!]`, `url: String!`, `appID: String!`, `app: App!`.
+- **`FunctionTrigger` field set**: `type: FunctionTriggerTypes`, `value: String`, `condition: String`.
+- **Working names query** (what `inngest-inventory.sh` uses): `query { functions { id name slug } }` → `{"data":{"functions":[{...}]}}`; empty state → `{"data":{"functions":[]}}`. Project names with `[.data.functions[] | (.name // .slug // .id)] | sort`.
+- `triggers` is `[FunctionTrigger!]` — a selection of subfields is REQUIRED (`triggers { type value }`), a bare `triggers` is a `GRAPHQL_VALIDATION_FAILED` error.
+
 ## auth
-- **None on loopback `/v0/gql` in `start` mode** (HTTP 200 with no auth header). `--signing-key`/`--event-key` gate only SDK-sync + `/e/<key>` ingest, not the GraphQL read API.
+- **None on loopback `/v0/gql` in `start` mode** (HTTP 200 with no auth header). `--signing-key`/`--event-key` gate only SDK-sync + `/e/<key>` ingest, not the GraphQL read API. Verified for both `eventsV2` and `functions`.
 
 ## runbook gotcha (image invocation)
 - `inngest/inngest:v1.19.4` has `ENTRYPOINT=null`, `CMD=["inngest"]` → must invoke `docker run … inngest/inngest:v1.19.4 inngest start --host 0.0.0.0 --port 8288 --sqlite-dir <dir> --signing-key <k> --event-key <k>`.

--- a/knowledge-base/project/specs/feat-one-shot-inngest-cutover-no-ssh-5450/inngest-graphql-schema.md
+++ b/knowledge-base/project/specs/feat-one-shot-inngest-cutover-no-ssh-5450/inngest-graphql-schema.md
@@ -43,3 +43,4 @@ Re-armable record reconstructed from `JSON.parse(node.raw)`: `{reminder_id, fire
 
 ## runbook gotcha (image invocation)
 - `inngest/inngest:v1.19.4` has `ENTRYPOINT=null`, `CMD=["inngest"]` → must invoke `docker run … inngest/inngest:v1.19.4 inngest start --host 0.0.0.0 --port 8288 --sqlite-dir <dir> --signing-key <k> --event-key <k>`.
+- `--signing-key` is REQUIRED and must be a **pure even-length hex string** (e.g. `$(printf 'ab%.0s' {1..32})` = 64 hex chars) — a prefixed form like `signkey-prod-<hex>` fails with `signing-key must be hex string with even number of chars` (the v1.19.4 `start` parser hex-decodes the entire value, prefix included). Omitting it fails with `signing-key is required`. The loopback `/v0/gql` read API needs no auth regardless of the key value (#5517 capture).


### PR DESCRIPTION
## Summary

`op=inventory` (the no-SSH cutover-diagnostics baseline) emitted a loud `FATAL /v1/functions
unreachable or non-array (shape="number")`. The `functions` projection assumed `GET /v1/functions`
returns a JSON array of function objects. Captured against the exact prod pin (`inngest/inngest:v1.19.4`
in Docker): **`GET /v1/functions` is an UNREGISTERED route → HTTP 404, body `404 page not found`**
(`curl -s | jq` parses the leading token `404` as a number, hence `shape="number"`). `/health` returns
200 alongside, confirming a healthy server hitting a wrong path — not a degraded read.

The registered path is the top-level GraphQL `functions` query at `POST /v0/gql` (the same loopback
endpoint `eventsV2` already uses, no auth on loopback):

```
query { functions { id name slug } }   →   {"data":{"functions":[{...}]}}
```

This PR re-points both the inventory projection and the sibling wiped-volume-verify durability probe to
that query. The emitted object's `functions` field stays a sorted **name array**, so the workflow
consumer (`cutover-inngest.yml` `.functions | length`) is unchanged. The `#5509` fail-loud guard is
preserved (now keyed on `.data.functions | type == "array"`); a bare array (the old wrong assumption)
and GraphQL error envelopes both trip it.

## Changelog

### Web Platform (infra)
- `inngest-inventory.sh`: `functions` projection re-pointed from the dead `GET /v1/functions` (404 in
  v1.19.4) to the `/v0/gql` `functions` query; guard tightened to `.data.functions | type == "array"`;
  header/contract comments corrected (`# verified: 2026-06-18`).
- `inngest-wiped-volume-verify.sh`: same latent bug folded in — its post-restart `fn_count >= 1`
  durability assert polled the same dead route (`type=="array" else 0` tolerated the 404 as `0`, a
  false `no_functions` abort on a healthy restart). Re-pointed to the `/v0/gql` functions query.
- `inngest-graphql-schema.md`: pinned the `functions` query + `Function`/`FunctionTrigger` field set
  (the doc previously documented only `eventsV2`); documented the pure-hex `--signing-key` requirement.

## User-Brand Impact

- **Artifact exposed:** none — `op=inventory` emits counts + reminder_ids only (no bodies; the `#5503`
  combined-stream purity invariant is preserved).
- **Exposure vector:** N/A — operator-only cutover-diagnostics surface; no end-user flow, no cross-tenant
  read, no credential path. The `#5509` fail-loud guard bounds the worst case to a diagnosable abort,
  not silent corruption.
- **Brand-survival threshold:** none.

threshold: none, reason: operator-only cutover-diagnostics script; no end-user-facing surface, no
regulated-data surface, no persistence (scope-out required because the diff touches an
`apps/web-platform/infra/` path).

## Discovered defect (separate subsystem — filed, not folded)

A third consumer of the dead route surfaced via `git grep '/v1/functions'`: `ci-deploy.sh`'s advisory
cron-plan probe (`curl -sf .../v1/functions` → 404 → empty → the probe is permanently dead, always
logging the "no cron re-armed" advisory). It is advisory-only (returns 0 regardless — never fails a
deploy), lives in the hard deploy gate with a ~2000-line test, and needs an advisory-probe redesign, so
it is a separate work-stream filed as #5520 rather than folded into this cutover-script fix.

## Test plan

- [x] `inngest-inventory.test.sh` — 18/18 (new Test 10 drives the corrected projection from
  `.data.functions` AND asserts a bare array trips the guard; Test 9 fail-loud preserved).
- [x] `inngest-wiped-volume-verify.test.sh` — 23/23 (new Test 6 asserts an empty `/v0/gql` functions
  array still aborts loud).
- [x] `shellcheck` clean on both scripts.
- [x] End-to-end against live local `inngest v1.19.4`: `{"functions":[],...}`, rc=0 (FATAL gone).
- Post-merge verification (AC9) is automatable and handled by `/soleur:postmerge`: once the corrected
  script is delivered, `gh workflow run cutover-inngest.yml -f op=inventory` reports
  `::notice::inventory: functions=N` with no FATAL.

Ref #5517

Generated with [Claude Code](https://claude.com/claude-code)
