### PR TITLE
fix(cla): allowlist soleur-ai[bot] login + pin bot-fix commit author email

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -48,7 +48,14 @@ jobs:
           # (returns `claude[bot]` for the Anthropic GitHub App, DB ID 209825114).
           # REST-based gates (e.g. .github/workflows/scheduled-bug-fixer.yml) match `app/claude` —
           # do NOT harmonize the two; the surfaces are different. See #2907.
-          allowlist: "dependabot[bot],github-actions[bot],renovate[bot],deruelle,claude[bot]"
+          # `soleur-ai[bot]` (bot user ID 273333864) is Soleur's own automation app, which
+          # opens bot-fix PRs via `soleur:fix-issue`. For the login match to fire, the bot's
+          # commits MUST carry the `273333864+soleur-ai[bot]@users.noreply.github.com` author
+          # email (pinned in `plugins/soleur/skills/fix-issue/SKILL.md` Phase 5) — the cloud
+          # runtime's ambient `agent@soleur.ai` email resolves to a NULL login and never
+          # matches. Login-based (non-spoofable) by design; do NOT add a plain author-name
+          # entry like `Soleur Agent`. See #5520 (the PR that exposed the null-login gap).
+          allowlist: "dependabot[bot],github-actions[bot],renovate[bot],deruelle,claude[bot],soleur-ai[bot]"
           custom-notsigned-prcomment: |
             Thank you for your contribution! Before we can accept it, you need to sign our [Contributor License Agreement](https://soleur.ai/pages/legal/individual-cla.html).
 

--- a/apps/web-platform/test/cla-evidence/allowlist.test.ts
+++ b/apps/web-platform/test/cla-evidence/allowlist.test.ts
@@ -7,7 +7,7 @@ import {
   GITHUB_ACTIONS_BOT_DB_ID,
 } from "@/scripts/cla-evidence/allowlist";
 
-const SAMPLE_CLA_YML_ALLOWLIST = "dependabot[bot],github-actions[bot],renovate[bot],deruelle,claude[bot]";
+const SAMPLE_CLA_YML_ALLOWLIST = "dependabot[bot],github-actions[bot],renovate[bot],deruelle,claude[bot],soleur-ai[bot]";
 
 describe("parseAllowlistFromYaml", () => {
   it("splits comma-separated logins from cla.yml allowlist", () => {
@@ -18,6 +18,7 @@ describe("parseAllowlistFromYaml", () => {
       "renovate[bot]",
       "deruelle",
       "claude[bot]",
+      "soleur-ai[bot]",
     ]);
   });
 
@@ -39,6 +40,10 @@ describe("isAllowlistBypass — login + DB-id 41898282 filter", () => {
 
   it("returns true for claude[bot] (Anthropic GitHub App)", () => {
     expect(isAllowlistBypass("claude[bot]", 209825114, allowlist)).toBe(true);
+  });
+
+  it("returns true for soleur-ai[bot] (Soleur automation App, bot user id 273333864 — #5520)", () => {
+    expect(isAllowlistBypass("soleur-ai[bot]", 273333864, allowlist)).toBe(true);
   });
 
   it("returns FALSE for github-actions[bot] DB-id 41898282 even though login is allowlisted (learning #2)", () => {

--- a/plugins/soleur/skills/fix-issue/SKILL.md
+++ b/plugins/soleur/skills/fix-issue/SKILL.md
@@ -157,12 +157,14 @@ If no test baseline was established in Phase 2, treat any test failures as poten
 
 ## Phase 5: Commit, Push, and Open PR
 
-Stage, commit, and push. Stage ONLY the files this fix touched (the fixed file plus any test file from Phase 4) — never a blanket add: in bot/ephemeral workspaces the working tree can carry scaffolding that must not enter the commit (#5091, destructive PR #5026). Enumerate the changed files from `git status --porcelain` and pass each path **as a literal token** — do NOT use a shell variable (`$FIXED_FILE`) in the emitted command. Bot/cron invocations run under a containment hook whose tokenizer needs concrete paths; substitute the real path before emitting the command:
+Stage, commit, and push. Stage ONLY the files this fix touched (the fixed file plus any test file from Phase 4) — never a blanket add: in bot/ephemeral workspaces the working tree can carry scaffolding that must not enter the commit (#5091, destructive PR #5026). Enumerate the changed files from `git status --porcelain` and pass each path **as a literal token** — do NOT use a shell variable (`$FIXED_FILE`) in the emitted command. Bot/cron invocations run under a containment hook whose tokenizer needs concrete paths; substitute the real path before emitting the command.
+
+**Pin the commit author/committer to the bot's resolvable GitHub login.** The cloud runtime's ambient git config authors as `Soleur Agent <agent@soleur.ai>` — an email tied to NO GitHub account, so the commit resolves to a NULL `author.user.login` and the CLA gate (`contributor-assistant`, which keys on `author.user.login`) cannot match it against the allowlist. Override both author and committer to the `soleur-ai[bot]` GitHub-noreply email (user id `273333864`) so the commit resolves to login `soleur-ai[bot]`, which IS on the `cla.yml` allowlist. This is the login-based (non-spoofable) CLA path — do NOT rely on a plain author-name allowlist entry. See `.github/workflows/cla.yml` and #5520 (the bot-fix PR that exposed the null-login gap):
 
 ```bash
 git status --porcelain
 git add -- src/path/to/fixed-file.ts test/path/to/fixed-file.test.ts  # the ACTUAL paths, listed explicitly — never `git add -A`/`.`/`-u`
-git commit -m "[bot-fix] Fix #<N>: <short description>"
+git -c user.name="Soleur Agent" -c user.email="273333864+soleur-ai[bot]@users.noreply.github.com" commit -m "[bot-fix] Fix #<N>: <short description>"
 git push -u origin bot-fix/<N>-<SLUG>
 ```
 


### PR DESCRIPTION
## Summary

Bot-fix PRs opened by `soleur:fix-issue` (e.g. #5521 for #5520) fail `cla-check`: the cloud runtime authors commits as `Soleur Agent <agent@soleur.ai>`, an email tied to **no** GitHub account, so `contributor-assistant` resolves a `NULL` `author.user.login` and can't match any allowlist entry. PR #5521 had to be hand-reauthored to land.

This implements the **login-based (non-spoofable)** fix chosen over a plain author-name allowlist entry:

- **`.github/workflows/cla.yml`** — add `soleur-ai[bot]` (bot user id `273333864`) to the allowlist, with a comment explaining the noreply-email requirement.
- **`plugins/soleur/skills/fix-issue/SKILL.md`** (Phase 5) — pin the commit author/committer to `273333864+soleur-ai[bot]@users.noreply.github.com` so commits resolve to login `soleur-ai[bot]`. Overrides the ambient `agent@soleur.ai` config.
- **`apps/web-platform/test/cla-evidence/allowlist.test.ts`** — keep the sync fixture honest and assert `isAllowlistBypass("soleur-ai[bot]", 273333864, …)` is true (the cla-evidence sidecar keys on the same login, so bypass provenance is recorded).

## Why login-based, not a name entry

A plain `Soleur Agent` author-name entry would also pass `cla-check` today, but it is **spoofable** — any commit authored with name "Soleur Agent" and an unregistered email would bypass the CLA. The `soleur-ai[bot]` login is GitHub-authenticated and can't be spoofed, consistent with the existing `claude[bot]` entry.

## Verification

- `bunx vitest run test/cla-evidence/allowlist.test.ts test/cla-evidence/allowlist-bypass.test.ts` → 16 passed.
- The `build-bypass.ts` runtime regex still matches the `allowlist:` line; the parser is comma-split + trim, so the new `[bot]` entry needs no sidecar code change.

## Changelog

Fixed `cla-check` for `soleur:fix-issue` bot-fix PRs by allowlisting the `soleur-ai[bot]` GitHub login and pinning the bot's commit author email to the resolvable GitHub-noreply address.

Ref #5520

🤖 Generated with [Claude Code](https://claude.com/claude-code)