### PR TITLE
fix(inngest cutover): on-host capture bridge so FALLBACK re-arm survives the SQLite→Postgres store switch (#5542)

### DIFF
--- a/.github/workflows/cutover-inngest.yml
+++ b/.github/workflows/cutover-inngest.yml
@@ -99,10 +99,13 @@ jobs:
               ;;
 
             rearm)
-              # POST hook → the host script self-enumerates and re-arms each via
-              # the schedule-reminder route. A 503 means INNGEST_CUTOVER_QUIESCE is
-              # still set (clear it first); the host script aborts loud on that.
-              PAYLOAD='{}'
+              # POST hook (mode=rearm-from-capture) → the host script CONSUMES the
+              # on-host capture persisted by op=capture (pre-deploy) and re-arms each
+              # via the schedule-reminder route, deleting the capture on full success.
+              # A missing/corrupt capture is FATAL (non-200) — it never silently
+              # self-enumerates the post-deploy empty backend (#5542). A 503 means
+              # INNGEST_CUTOVER_QUIESCE is still set (clear it first); aborts loud.
+              PAYLOAD='{"mode":"rearm-from-capture"}'
               SIG=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | sed 's/.*= //')
               rm -f /tmp/rearm-body
               CODE=$(curl -s --max-time 120 -o /tmp/rearm-body -w '%{http_code}' \
@@ -143,7 +146,7 @@ jobs:
                 CAUSE="${BODY//[$'\n\r']/ }"
                 echo "::error::capture returned HTTP $CODE: ${CAUSE:-<empty body>}"; exit 1
               fi
-              if ! echo "$BODY" | jq -e 'type == "object" and has("captured") and has("capture_file")' >/dev/null 2>&1; then
+              if ! echo "$BODY" | jq -e 'type == "object" and has("captured") and has("reminder_ids") and has("capture_file")' >/dev/null 2>&1; then
                 echo "::error::capture did not return the expected {captured,reminder_ids,capture_file} object"; echo "$BODY"; exit 1
               fi
               N=$(echo "$BODY" | jq -r '.captured')

--- a/.github/workflows/cutover-inngest.yml
+++ b/.github/workflows/cutover-inngest.yml
@@ -2,7 +2,8 @@
 # Drives the cutover's host-side steps through the deploy webhook (HMAC +
 # CF-Access), NEVER SSH (hr-no-ssh-fallback-in-runbooks):
 #   op=enumerate           → GET  /hooks/inngest-enumerate-reminders  (list still-armed reminders)
-#   op=rearm               → POST /hooks/inngest-rearm-reminders      (re-arm them post-quiesce-clear)
+#   op=capture             → POST /hooks/inngest-rearm-reminders (mode=capture) → persist records on-host PRE-deploy (#5542)
+#   op=rearm               → POST /hooks/inngest-rearm-reminders      (re-arm from the capture post-quiesce-clear)
 #   op=verify-wiped-volume → POST /hooks/inngest-wiped-volume-verify  (async; opt-in destructive proof)
 #   op=backup              → hcloud API create_image (no webhook; pre-cutover server snapshot) (#5509)
 #   op=inventory           → GET  /hooks/inngest-inventory            (full-state baseline for before/after diff) (#5509)
@@ -20,6 +21,7 @@ on:
         type: choice
         options:
           - enumerate
+          - capture
           - rearm
           - verify-wiped-volume
           - backup
@@ -116,6 +118,38 @@ jobs:
                 echo "::error::re-arm returned HTTP $CODE (a non-200 includes the host script's loud abort, e.g. quiesce still set)"; exit 1
               fi
               echo "::notice::re-arm completed"
+              ;;
+
+            capture)
+              # POST hook (mode=capture) → the host script self-enumerates the OLD
+              # server and persists the still-armed records to an on-host file
+              # (/var/lib/inngest/cutover-capture.json) for post-deploy re-arm. Run
+              # BEFORE the deploy: a post-deploy self-enumerate sees the empty new
+              # backend and would lose every reminder (#5542). Records stay on-host
+              # (P2-sec-a) — only counts + reminder_ids surface here.
+              PAYLOAD='{"mode":"capture"}'
+              SIG=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | sed 's/.*= //')
+              rm -f /tmp/capture-body
+              CODE=$(curl -s --max-time 60 -o /tmp/capture-body -w '%{http_code}' \
+                -X POST \
+                -H "Content-Type: application/json" \
+                -H "X-Signature-256: sha256=$SIG" \
+                -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+                -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
+                -d "$PAYLOAD" \
+                "$BASE/inngest-rearm-reminders" || echo "000")
+              BODY=$(cat /tmp/capture-body 2>/dev/null || echo "")
+              if [[ "$CODE" != "200" ]]; then
+                CAUSE="${BODY//[$'\n\r']/ }"
+                echo "::error::capture returned HTTP $CODE: ${CAUSE:-<empty body>}"; exit 1
+              fi
+              if ! echo "$BODY" | jq -e 'type == "object" and has("captured") and has("capture_file")' >/dev/null 2>&1; then
+                echo "::error::capture did not return the expected {captured,reminder_ids,capture_file} object"; echo "$BODY"; exit 1
+              fi
+              N=$(echo "$BODY" | jq -r '.captured')
+              IDS=$(echo "$BODY" | jq -r '.reminder_ids | join(",")')
+              FILE=$(echo "$BODY" | jq -r '.capture_file')
+              echo "::notice::capture: persisted $N reminder(s) to $FILE for post-deploy re-arm — [$IDS]"
               ;;
 
             verify-wiped-volume)

--- a/apps/web-platform/infra/cutover-inngest-workflow.test.sh
+++ b/apps/web-platform/infra/cutover-inngest-workflow.test.sh
@@ -31,6 +31,8 @@ assert "choice includes rearm" "grep -qE '^[[:space:]]+-[[:space:]]*rearm$' '$WF
 assert "choice includes verify-wiped-volume" "grep -qE '^[[:space:]]+-[[:space:]]*verify-wiped-volume$' '$WF'"
 assert "choice includes backup (#5509)" "grep -qE '^[[:space:]]+-[[:space:]]*backup$' '$WF'"
 assert "choice includes inventory (#5509)" "grep -qE '^[[:space:]]+-[[:space:]]*inventory$' '$WF'"
+assert "choice includes capture (#5542)" "grep -qE '^[[:space:]]+-[[:space:]]*capture$' '$WF'"
+assert "capture arm POSTs mode=capture" "grep -qE '\"mode\":\"capture\"' '$WF'"
 
 # op is passed via env, never interpolated into a run: command (injection-safe)
 assert "op passed via env (OP: \${{ inputs.op }})" "grep -qE 'OP:[[:space:]]*\\\$\{\{[[:space:]]*inputs.op' '$WF'"
@@ -69,6 +71,11 @@ for hook in inngest-enumerate-reminders inngest-rearm-reminders inngest-wiped-vo
   assert "workflow targets \$BASE/$hook" "grep -qE 'BASE/$hook\"' '$WF'"
   assert "hook id '$hook' exists in hooks.json.tmpl" "grep -qE '\"id\": \"$hook\"' '$HOOKS_TMPL'"
 done
+
+# #5542 — the rearm hook bridges the cutover mode from the POST payload to the
+# host script via pass-environment (capture vs rearm). Without this, op=capture
+# cannot reach the script and the pre-deploy capture never persists.
+assert "rearm hook bridges mode via pass-environment (INNGEST_REARM_MODE)" "grep -qE 'INNGEST_REARM_MODE' '$HOOKS_TMPL'"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/apps/web-platform/infra/hooks.json.tmpl
+++ b/apps/web-platform/infra/hooks.json.tmpl
@@ -142,6 +142,9 @@
     "include-command-output-in-response-on-error": true,
     "http-methods": ["POST"],
     "trigger-rule-mismatch-http-response-code": 403,
+    "pass-environment-to-command": [
+      { "source": "payload", "name": "mode", "envname": "INNGEST_REARM_MODE" }
+    ],
     "trigger-rule": {
       "match": {
         "type": "payload-hmac-sha256",

--- a/apps/web-platform/infra/inngest-rearm-reminders.sh
+++ b/apps/web-platform/infra/inngest-rearm-reminders.sh
@@ -53,8 +53,48 @@ fi
 # also keeps comment bodies on-host (never transiting the workflow log, P2-sec-a).
 # INNGEST_REARM_STDIN=1 switches to reading records from stdin (manual/test).
 ENUMERATE_CMD="${INNGEST_ENUMERATE_CMD:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/inngest-enumerate-reminders.sh}"
+
+# Cutover capture bridge (#5542). The FIRST SQLite→Postgres cutover replaces the
+# inngest event store, so a post-deploy self-enumerate queries the NEW (empty)
+# Redis queue and would re-arm NOTHING — silently losing every armed reminder
+# (verdict 0.2: the armed-event queue lives in Redis; the new durable Redis starts
+# empty). To bridge the gap WITHOUT transiting comment bodies through the workflow
+# (P2-sec-a), op=capture (INNGEST_REARM_MODE=capture) self-enumerates the OLD
+# server BEFORE the deploy and persists records to CAPTURE_FILE on-host; op=rearm
+# then consumes that file AFTER the deploy instead of self-enumerating the empty
+# server, and deletes it on full success. CAPTURE_FILE lives under the --sqlite-dir
+# volume, which survives the cutover's systemd restart (a config change, not a host
+# re-provision). Steady-state re-arm (no capture file) is unchanged.
+MODE="${INNGEST_REARM_MODE:-rearm}"
+CAPTURE_FILE="${INNGEST_CUTOVER_CAPTURE_FILE:-/var/lib/inngest/cutover-capture.json}"
+
+if [[ "$MODE" == "capture" ]]; then
+  cap="$("$ENUMERATE_CMD")" || { echo "ERROR: capture: enumeration failed; nothing persisted" >&2; exit 1; }
+  if ! echo "$cap" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    echo "ERROR: capture: enumerate did not return a JSON array" >&2
+    exit 1
+  fi
+  mkdir -p "$(dirname "$CAPTURE_FILE")"
+  printf '%s' "$cap" > "$CAPTURE_FILE"
+  cap_count=$(echo "$cap" | jq 'length')
+  cap_ids=$(echo "$cap" | jq -r '[.[].reminder_id] | join(",")')
+  logger -t "$LOG_TAG" "captured $cap_count reminder(s) to $CAPTURE_FILE" 2>/dev/null || true
+  # Status object to stdout — ids only, NEVER comment bodies (P2-sec-a); the
+  # webhook response carries this. Mirrors the enumerate/inventory purity contract.
+  jq -nc --argjson n "$cap_count" --arg ids "$cap_ids" --arg f "$CAPTURE_FILE" \
+    '{captured: $n, reminder_ids: ($ids | split(",") | map(select(length > 0)) | sort), capture_file: $f}'
+  exit 0
+fi
+
+# MODE=rearm. Records source priority: stdin (test/manual) > capture file (cutover
+# bridge) > self-enumerate (steady state).
+FROM_CAPTURE=0
 if [[ "${INNGEST_REARM_STDIN:-0}" == "1" ]]; then
   records="$(cat)"
+elif [[ -s "$CAPTURE_FILE" ]] && jq -e 'type == "array"' < "$CAPTURE_FILE" >/dev/null 2>&1; then
+  records="$(cat "$CAPTURE_FILE")"
+  FROM_CAPTURE=1
+  logger -t "$LOG_TAG" "consuming cutover capture file $CAPTURE_FILE (skipping self-enumerate)" 2>/dev/null || true
 else
   records="$("$ENUMERATE_CMD")" || { echo "ERROR: enumeration failed; cannot source re-arm records" >&2; exit 1; }
 fi
@@ -108,4 +148,13 @@ done
 
 echo "inngest-rearm-reminders: re-armed=$rearmed failed=$failed total=$count" >&2
 logger -t "$LOG_TAG" "done: re-armed=$rearmed failed=$failed total=$count" 2>/dev/null || true
+
+# On a fully-successful re-arm sourced from the cutover capture, delete the file so
+# a later steady-state re-arm self-enumerates the LIVE backend instead of replaying
+# a stale capture. Keep it on ANY failure so a retry can finish the set.
+if [[ "$FROM_CAPTURE" == "1" && "$failed" -eq 0 ]]; then
+  rm -f "$CAPTURE_FILE"
+  logger -t "$LOG_TAG" "consumed + removed capture file $CAPTURE_FILE" 2>/dev/null || true
+fi
+
 [[ "$failed" -gt 0 ]] && exit 1 || exit 0

--- a/apps/web-platform/infra/inngest-rearm-reminders.sh
+++ b/apps/web-platform/infra/inngest-rearm-reminders.sh
@@ -59,12 +59,20 @@ ENUMERATE_CMD="${INNGEST_ENUMERATE_CMD:-$(cd "$(dirname "${BASH_SOURCE[0]}")" &&
 # Redis queue and would re-arm NOTHING — silently losing every armed reminder
 # (verdict 0.2: the armed-event queue lives in Redis; the new durable Redis starts
 # empty). To bridge the gap WITHOUT transiting comment bodies through the workflow
-# (P2-sec-a), op=capture (INNGEST_REARM_MODE=capture) self-enumerates the OLD
-# server BEFORE the deploy and persists records to CAPTURE_FILE on-host; op=rearm
-# then consumes that file AFTER the deploy instead of self-enumerating the empty
-# server, and deletes it on full success. CAPTURE_FILE lives under the --sqlite-dir
-# volume, which survives the cutover's systemd restart (a config change, not a host
-# re-provision). Steady-state re-arm (no capture file) is unchanged.
+# (P2-sec-a). The mode is a TRISTATE (INNGEST_REARM_MODE, from the hook payload):
+#   capture            — self-enumerate the OLD server and persist records to
+#                        CAPTURE_FILE on-host (run BEFORE the deploy).
+#   rearm-from-capture — CUTOVER re-arm: the capture file is the ONLY valid source.
+#                        A missing/empty/corrupt capture is FATAL — never a silent
+#                        downgrade to self-enumerating the post-deploy EMPTY backend
+#                        (that is the precise reminder-loss this feature prevents).
+#                        Deletes the file on full success.
+#   rearm (default)    — STEADY-STATE re-arm: self-enumerate the live backend.
+#                        Deliberately IGNORES any capture file, so an orphaned
+#                        capture from an aborted cutover cannot hijack a routine
+#                        re-arm and replay a stale snapshot.
+# CAPTURE_FILE lives under the --sqlite-dir volume, which survives the cutover's
+# systemd restart (a config change, not a host re-provision).
 MODE="${INNGEST_REARM_MODE:-rearm}"
 CAPTURE_FILE="${INNGEST_CUTOVER_CAPTURE_FILE:-/var/lib/inngest/cutover-capture.json}"
 
@@ -74,8 +82,14 @@ if [[ "$MODE" == "capture" ]]; then
     echo "ERROR: capture: enumerate did not return a JSON array" >&2
     exit 1
   fi
-  mkdir -p "$(dirname "$CAPTURE_FILE")"
-  printf '%s' "$cap" > "$CAPTURE_FILE"
+  mkdir -p "$(dirname "$CAPTURE_FILE")" || { echo "ERROR: capture: cannot create $(dirname "$CAPTURE_FILE")" >&2; exit 1; }
+  # Atomic write: a partial/truncated capture that survived the cutover restart
+  # would otherwise be read back as corrupt. Write to a temp file + rename so the
+  # capture is either fully present or absent — never half-written.
+  cap_tmp="$(mktemp "${CAPTURE_FILE}.XXXXXX")" || { echo "ERROR: capture: mktemp failed" >&2; exit 1; }
+  if ! printf '%s' "$cap" > "$cap_tmp" || ! mv -f "$cap_tmp" "$CAPTURE_FILE"; then
+    rm -f "$cap_tmp"; echo "ERROR: capture: failed to persist $CAPTURE_FILE" >&2; exit 1
+  fi
   cap_count=$(echo "$cap" | jq 'length')
   cap_ids=$(echo "$cap" | jq -r '[.[].reminder_id] | join(",")')
   logger -t "$LOG_TAG" "captured $cap_count reminder(s) to $CAPTURE_FILE" 2>/dev/null || true
@@ -86,16 +100,26 @@ if [[ "$MODE" == "capture" ]]; then
   exit 0
 fi
 
-# MODE=rearm. Records source priority: stdin (test/manual) > capture file (cutover
-# bridge) > self-enumerate (steady state).
+# Records source by mode. stdin (test/manual) overrides everything.
 FROM_CAPTURE=0
 if [[ "${INNGEST_REARM_STDIN:-0}" == "1" ]]; then
   records="$(cat)"
-elif [[ -s "$CAPTURE_FILE" ]] && jq -e 'type == "array"' < "$CAPTURE_FILE" >/dev/null 2>&1; then
+elif [[ "$MODE" == "rearm-from-capture" ]]; then
+  # Cutover re-arm: the capture file is the ONLY valid source. Missing/empty/corrupt
+  # is FATAL — a self-enumerate here would query the post-deploy empty backend and
+  # lose every reminder. An empty JSON array ([]) IS valid (capture found none); a
+  # zero-byte/truncated/non-array file is the corruption case and fails loud.
+  if [[ ! -s "$CAPTURE_FILE" ]] || ! jq -e 'type == "array"' < "$CAPTURE_FILE" >/dev/null 2>&1; then
+    echo "ERROR: rearm-from-capture: $CAPTURE_FILE missing/empty/corrupt — refusing to self-enumerate the post-deploy backend (would silently lose reminders). Re-run op=capture against the OLD server before deploy." >&2
+    logger -t "$LOG_TAG" "FATAL: rearm-from-capture but capture file invalid; refusing silent self-enumerate" 2>/dev/null || true
+    exit 1
+  fi
   records="$(cat "$CAPTURE_FILE")"
   FROM_CAPTURE=1
-  logger -t "$LOG_TAG" "consuming cutover capture file $CAPTURE_FILE (skipping self-enumerate)" 2>/dev/null || true
+  logger -t "$LOG_TAG" "consuming cutover capture file $CAPTURE_FILE" 2>/dev/null || true
 else
+  # Steady-state self-enumerate. Ignores any capture file by design (a stale orphan
+  # from an aborted cutover must NOT hijack a routine re-arm).
   records="$("$ENUMERATE_CMD")" || { echo "ERROR: enumeration failed; cannot source re-arm records" >&2; exit 1; }
 fi
 if ! echo "$records" | jq -e 'type == "array"' >/dev/null 2>&1; then
@@ -107,6 +131,9 @@ count=$(echo "$records" | jq 'length')
 if [[ "$count" -eq 0 ]]; then
   logger -t "$LOG_TAG" "no reminders to re-arm (empty record set)" 2>/dev/null || true
   echo "inngest-rearm-reminders: nothing to re-arm" >&2
+  # A fully-consumed empty capture is a clean no-op success — remove it so it does
+  # not linger as an orphan for a later re-arm.
+  if [[ "$FROM_CAPTURE" == "1" ]]; then rm -f "$CAPTURE_FILE"; fi
   exit 0
 fi
 

--- a/apps/web-platform/infra/inngest-rearm-reminders.test.sh
+++ b/apps/web-platform/infra/inngest-rearm-reminders.test.sh
@@ -143,11 +143,75 @@ MOCK
   local rc=0 out
   out=$(PATH="${MOCKBIN}:$PATH" INNGEST_MANUAL_TRIGGER_SECRET="test-secret" \
     INNGEST_ENUMERATE_CMD="$enum_stub" \
+    INNGEST_CUTOVER_CAPTURE_FILE="${MOCKBIN}/no-such-capture.json" \
     SCHEDULE_REMINDER_URL="http://127.0.0.1:3000/api/internal/schedule-reminder" \
     bash "$TARGET" 2>&1) || rc=$?
   assert_eq "self-enumerate path exits 0" "0" "$rc"
   local bodies; bodies=$(grep '^BODY:' "$REQ_LOG")
   assert_contains "re-armed the self-enumerated record" "$bodies" '"reminder_id":"rem-enum"'
+  teardown_mock_curl
+}
+
+# --- Test 7: capture mode (#5542) — self-enumerate the OLD server + persist on-host ---
+test_capture_mode_persists() {
+  setup_mock_curl 200
+  local enum_stub cap_file; enum_stub="${MOCKBIN}/enum.sh"; cap_file="${MOCKBIN}/capture.json"
+  cat > "$enum_stub" <<MOCK
+#!/usr/bin/env bash
+printf '%s' '[{"reminder_id":"rem-cap","fire_at":"2026-07-01T00:00:00Z","actor":"platform","action":{"type":"named-check","check":"reeval"}}]'
+MOCK
+  chmod +x "$enum_stub"
+  local rc=0 out
+  out=$(PATH="${MOCKBIN}:$PATH" INNGEST_MANUAL_TRIGGER_SECRET="test-secret" \
+    INNGEST_REARM_MODE=capture \
+    INNGEST_ENUMERATE_CMD="$enum_stub" \
+    INNGEST_CUTOVER_CAPTURE_FILE="$cap_file" \
+    bash "$TARGET" 2>/dev/null) || rc=$?
+  assert_eq "capture mode exits 0" "0" "$rc"
+  assert_eq "capture wrote the on-host file" "1" "$([[ -s "$cap_file" ]] && echo 1 || echo 0)"
+  assert_contains "capture file holds the enumerated record" "$(cat "$cap_file")" '"reminder_id":"rem-cap"'
+  assert_contains "capture status reports count" "$out" '"captured":1'
+  assert_contains "capture status surfaces reminder_ids" "$out" 'rem-cap'
+  assert_eq "capture made NO re-arm POST (capture != rearm)" "0" "$(grep -c '^BODY:' "$REQ_LOG" 2>/dev/null || true)"
+  teardown_mock_curl
+}
+
+# --- Test 8: rearm consumes the capture file over self-enumerate, deletes on success ---
+test_rearm_consumes_capture_file() {
+  setup_mock_curl 202
+  local enum_stub cap_file; enum_stub="${MOCKBIN}/enum.sh"; cap_file="${MOCKBIN}/capture.json"
+  # self-enumerate would return a DIFFERENT record — prove the capture file wins.
+  cat > "$enum_stub" <<MOCK
+#!/usr/bin/env bash
+printf '%s' '[{"reminder_id":"rem-SELF","fire_at":"2026-06-19T00:00:00Z","actor":"platform","action":{"type":"x"}}]'
+MOCK
+  chmod +x "$enum_stub"
+  printf '%s' '[{"reminder_id":"rem-CAPTURED","fire_at":"2026-07-01T00:00:00Z","actor":"platform","action":{"type":"named-check","check":"reeval"}}]' > "$cap_file"
+  local rc=0
+  PATH="${MOCKBIN}:$PATH" INNGEST_MANUAL_TRIGGER_SECRET="test-secret" \
+    INNGEST_ENUMERATE_CMD="$enum_stub" \
+    INNGEST_CUTOVER_CAPTURE_FILE="$cap_file" \
+    bash "$TARGET" >/dev/null 2>&1 || rc=$?
+  assert_eq "rearm-from-capture exits 0" "0" "$rc"
+  local bodies; bodies=$(grep '^BODY:' "$REQ_LOG")
+  assert_contains "re-armed the CAPTURED record" "$bodies" '"reminder_id":"rem-CAPTURED"'
+  assert_eq "did NOT re-arm the self-enumerated record" "0" "$(echo "$bodies" | grep -c 'rem-SELF' || true)"
+  assert_eq "capture file deleted after full success" "0" "$([[ -e "$cap_file" ]] && echo 1 || echo 0)"
+  teardown_mock_curl
+}
+
+# --- Test 9: rearm RETAINS the capture file when a re-arm POST fails (retry-safe) ---
+test_rearm_keeps_capture_on_failure() {
+  setup_mock_curl 401
+  local cap_file; cap_file="${MOCKBIN}/capture.json"
+  printf '%s' '[{"reminder_id":"rem-X","fire_at":"2026-07-01T00:00:00Z","actor":"platform","action":{"type":"x"}}]' > "$cap_file"
+  local rc=0
+  PATH="${MOCKBIN}:$PATH" INNGEST_MANUAL_TRIGGER_SECRET="test-secret" \
+    INNGEST_ENUMERATE_CMD="/bin/false" \
+    INNGEST_CUTOVER_CAPTURE_FILE="$cap_file" \
+    bash "$TARGET" >/dev/null 2>&1 || rc=$?
+  assert_eq "rearm exits non-zero when a POST fails" "1" "$rc"
+  assert_eq "capture file RETAINED on failure (retry-safe)" "1" "$([[ -s "$cap_file" ]] && echo 1 || echo 0)"
   teardown_mock_curl
 }
 
@@ -157,6 +221,9 @@ test_other_failure
 test_empty_noop
 test_missing_secret_fails_closed
 test_self_enumerate_default
+test_capture_mode_persists
+test_rearm_consumes_capture_file
+test_rearm_keeps_capture_on_failure
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/apps/web-platform/infra/inngest-rearm-reminders.test.sh
+++ b/apps/web-platform/infra/inngest-rearm-reminders.test.sh
@@ -189,6 +189,7 @@ MOCK
   printf '%s' '[{"reminder_id":"rem-CAPTURED","fire_at":"2026-07-01T00:00:00Z","actor":"platform","action":{"type":"named-check","check":"reeval"}}]' > "$cap_file"
   local rc=0
   PATH="${MOCKBIN}:$PATH" INNGEST_MANUAL_TRIGGER_SECRET="test-secret" \
+    INNGEST_REARM_MODE=rearm-from-capture \
     INNGEST_ENUMERATE_CMD="$enum_stub" \
     INNGEST_CUTOVER_CAPTURE_FILE="$cap_file" \
     bash "$TARGET" >/dev/null 2>&1 || rc=$?
@@ -207,11 +208,86 @@ test_rearm_keeps_capture_on_failure() {
   printf '%s' '[{"reminder_id":"rem-X","fire_at":"2026-07-01T00:00:00Z","actor":"platform","action":{"type":"x"}}]' > "$cap_file"
   local rc=0
   PATH="${MOCKBIN}:$PATH" INNGEST_MANUAL_TRIGGER_SECRET="test-secret" \
+    INNGEST_REARM_MODE=rearm-from-capture \
     INNGEST_ENUMERATE_CMD="/bin/false" \
     INNGEST_CUTOVER_CAPTURE_FILE="$cap_file" \
     bash "$TARGET" >/dev/null 2>&1 || rc=$?
   assert_eq "rearm exits non-zero when a POST fails" "1" "$rc"
   assert_eq "capture file RETAINED on failure (retry-safe)" "1" "$([[ -s "$cap_file" ]] && echo 1 || echo 0)"
+  teardown_mock_curl
+}
+
+# --- Test 10 (#5542 review F1): rearm-from-capture with a MISSING capture is FATAL ---
+# (never silently self-enumerates the empty post-deploy backend).
+test_rearm_from_capture_missing_is_fatal() {
+  setup_mock_curl 202
+  local rc=0 out
+  out=$(PATH="${MOCKBIN}:$PATH" INNGEST_MANUAL_TRIGGER_SECRET="test-secret" \
+    INNGEST_REARM_MODE=rearm-from-capture \
+    INNGEST_ENUMERATE_CMD="/bin/false" \
+    INNGEST_CUTOVER_CAPTURE_FILE="${MOCKBIN}/absent-capture.json" \
+    bash "$TARGET" 2>&1) || rc=$?
+  assert_eq "missing capture is FATAL (exit 1)" "1" "$rc"
+  assert_contains "names the refusal-to-self-enumerate cause" "$out" "missing/empty/corrupt"
+  assert_eq "no re-arm POST attempted on fatal-missing-capture" "0" "$(grep -c '^BODY:' "$REQ_LOG" 2>/dev/null || true)"
+  teardown_mock_curl
+}
+
+# --- Test 11 (#5542 review F1): rearm-from-capture with a TRUNCATED (non-array) capture is FATAL ---
+test_rearm_from_capture_corrupt_is_fatal() {
+  setup_mock_curl 202
+  local cap_file; cap_file="${MOCKBIN}/capture.json"
+  printf '%s' '[{"reminder_id":"rem-trunc"' > "$cap_file"   # truncated mid-write, invalid JSON
+  local rc=0 out
+  out=$(PATH="${MOCKBIN}:$PATH" INNGEST_MANUAL_TRIGGER_SECRET="test-secret" \
+    INNGEST_REARM_MODE=rearm-from-capture \
+    INNGEST_ENUMERATE_CMD="/bin/false" \
+    INNGEST_CUTOVER_CAPTURE_FILE="$cap_file" \
+    bash "$TARGET" 2>&1) || rc=$?
+  assert_eq "corrupt capture is FATAL (exit 1)" "1" "$rc"
+  assert_eq "corrupt capture RETAINED (operator inspects)" "1" "$([[ -s "$cap_file" ]] && echo 1 || echo 0)"
+  teardown_mock_curl
+}
+
+# --- Test 12 (#5542 review F3): steady-state rearm IGNORES an orphan capture file ---
+# (an aborted cutover must not hijack a routine self-enumerate re-arm).
+test_steady_state_rearm_ignores_orphan_capture() {
+  setup_mock_curl 202
+  local enum_stub cap_file; enum_stub="${MOCKBIN}/enum.sh"; cap_file="${MOCKBIN}/capture.json"
+  cat > "$enum_stub" <<MOCK
+#!/usr/bin/env bash
+printf '%s' '[{"reminder_id":"rem-LIVE","fire_at":"2026-06-19T00:00:00Z","actor":"platform","action":{"type":"x"}}]'
+MOCK
+  chmod +x "$enum_stub"
+  # An orphaned capture from a prior aborted cutover sits on disk.
+  printf '%s' '[{"reminder_id":"rem-ORPHAN","fire_at":"2026-07-01T00:00:00Z","actor":"platform","action":{"type":"x"}}]' > "$cap_file"
+  local rc=0
+  PATH="${MOCKBIN}:$PATH" INNGEST_MANUAL_TRIGGER_SECRET="test-secret" \
+    INNGEST_ENUMERATE_CMD="$enum_stub" \
+    INNGEST_CUTOVER_CAPTURE_FILE="$cap_file" \
+    bash "$TARGET" >/dev/null 2>&1 || rc=$?
+  assert_eq "steady-state rearm exits 0" "0" "$rc"
+  local bodies; bodies=$(grep '^BODY:' "$REQ_LOG")
+  assert_contains "re-armed the LIVE self-enumerated record" "$bodies" '"reminder_id":"rem-LIVE"'
+  assert_eq "did NOT consume the orphan capture" "0" "$(echo "$bodies" | grep -c 'rem-ORPHAN' || true)"
+  assert_eq "orphan capture left intact (not deleted by steady-state)" "1" "$([[ -s "$cap_file" ]] && echo 1 || echo 0)"
+  teardown_mock_curl
+}
+
+# --- Test 13 (#5542 review F7): rearm-from-capture with an EMPTY [] capture is a clean no-op ---
+test_rearm_from_capture_empty_array_noop() {
+  setup_mock_curl 202
+  local cap_file; cap_file="${MOCKBIN}/capture.json"
+  printf '%s' '[]' > "$cap_file"
+  local rc=0
+  PATH="${MOCKBIN}:$PATH" INNGEST_MANUAL_TRIGGER_SECRET="test-secret" \
+    INNGEST_REARM_MODE=rearm-from-capture \
+    INNGEST_ENUMERATE_CMD="/bin/false" \
+    INNGEST_CUTOVER_CAPTURE_FILE="$cap_file" \
+    bash "$TARGET" >/dev/null 2>&1 || rc=$?
+  assert_eq "empty [] capture exits 0 (nothing to re-arm)" "0" "$rc"
+  assert_eq "empty [] capture made no POST" "0" "$(grep -c '^BODY:' "$REQ_LOG" 2>/dev/null || true)"
+  assert_eq "empty [] capture deleted after no-op success" "0" "$([[ -e "$cap_file" ]] && echo 1 || echo 0)"
   teardown_mock_curl
 }
 
@@ -224,6 +300,10 @@ test_self_enumerate_default
 test_capture_mode_persists
 test_rearm_consumes_capture_file
 test_rearm_keeps_capture_on_failure
+test_rearm_from_capture_missing_is_fatal
+test_rearm_from_capture_corrupt_is_fatal
+test_steady_state_rearm_ignores_orphan_capture
+test_rearm_from_capture_empty_array_noop
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/knowledge-base/engineering/operations/runbooks/inngest-server.md
+++ b/knowledge-base/engineering/operations/runbooks/inngest-server.md
@@ -318,18 +318,25 @@ setting).
      OLD SQLite server keep running until its already-armed reminders fire on their own. When the
      soonest pending fire-time has passed, proceed to deploy (step 4). No enumeration, no re-arm, no
      double-fire window. Best when only a few near-term reminders are armed.
-   - **FALLBACK — enumerate + re-arm (when draining is not viable):** when too many reminders are armed
-     or they fire too far out to wait, enumerate the still-armed set with no remote shell:
+   - **FALLBACK — capture + re-arm (when draining is not viable):** when too many reminders are armed
+     or they fire too far out to wait, **persist the still-armed set ON-HOST BEFORE the deploy** — a
+     post-deploy `op=rearm` self-enumerate would query the NEW (empty) Postgres+Redis backend and
+     silently lose every reminder (#5542):
      ```bash
-     gh workflow run cutover-inngest.yml --field op=enumerate    # logs count + reminder_ids
+     gh workflow run cutover-inngest.yml --field op=enumerate   # OPTIONAL visibility: logs count + reminder_ids
+     gh workflow run cutover-inngest.yml --field op=capture     # MANDATORY: persists records on-host pre-deploy
      ```
-     This drives `/hooks/inngest-enumerate-reminders` (host script queries the OLD server's
-     `eventsV2`, reconstructs the FULL re-armable payload from each event's `raw` envelope — the legacy
-     `id name receivedAt` query was payload-incomplete — drops already-fired events via the `runs`
-     cross-ref, and paginates to exhaustion). Review the logged `reminder_id`s, then re-arm AFTER the
-     deploy + quiesce-clear in step 6 (`op=rearm`). The re-arm routes back through
-     `schedule-reminder`, which recomputes the Inngest dedup `id`/`ts` so an event that ALSO survived
-     in state dedups instead of double-firing.
+     `op=capture` drives `/hooks/inngest-rearm-reminders` with `mode=capture`: the host script queries
+     the OLD server's `eventsV2`, reconstructs the FULL re-armable payload from each event's `raw`
+     envelope (the legacy `id name receivedAt` query was payload-incomplete), drops already-fired events
+     via the `runs` cross-ref, paginates to exhaustion, and writes the records to
+     `/var/lib/inngest/cutover-capture.json` — under the `--sqlite-dir` volume, which survives the
+     cutover's systemd restart (a config change, not a host re-provision). Records stay on-host
+     (P2-sec-a) — only counts + `reminder_id`s surface in the run log. Then re-arm AFTER the deploy +
+     quiesce-clear in step 6 (`op=rearm`), which **consumes the capture file** (NOT a post-deploy
+     self-enumerate) and deletes it on full success. The re-arm routes back through `schedule-reminder`,
+     which recomputes the Inngest dedup `id`/`ts` so an event that ALSO survived in state dedups instead
+     of double-firing.
 3. **Drain in-flight runs** — confirm zero `Running` status for ~60s (or accept-and-document that
    in-flight runs are abandoned; the reminder `post-comment`/`run-check` steps are not idempotent on
    replay, so a re-arm of an already-fired reminder would double-post).
@@ -367,11 +374,13 @@ setting).
 6. **Re-open arming + re-arm recovered work** (no remote shell):
    ```bash
    doppler secrets set INNGEST_CUTOVER_QUIESCE= -p soleur -c prd --no-interactive  # clears the flag
-   # FALLBACK path only: re-arm the reminders enumerated in step 2.
+   # FALLBACK path only: re-arm from the on-host capture persisted in step 2 (op=capture).
    gh workflow run cutover-inngest.yml --field op=rearm
    ```
    Run `op=rearm` ONLY after the quiesce flag is cleared — the host script aborts loud (does not
-   silently drop) if it gets a 503 because quiesce is still set.
+   silently drop) if it gets a 503 because quiesce is still set. `op=rearm` consumes
+   `/var/lib/inngest/cutover-capture.json` (from step 2's `op=capture`) when present and deletes it on
+   full success; absent a capture file it self-enumerates the live backend (steady-state behaviour).
 7. **Rollback tripwire** — reverting ExecStart to `--sqlite-dir` is data-safe ONLY before any *real*
    (non-throwaway) reminder is armed against Postgres. After that the stale SQLite is missing those
    reminders AND could double-fire ones Postgres recorded → **forward-fix only**. On a committed

--- a/knowledge-base/engineering/operations/runbooks/inngest-server.md
+++ b/knowledge-base/engineering/operations/runbooks/inngest-server.md
@@ -378,9 +378,19 @@ setting).
    gh workflow run cutover-inngest.yml --field op=rearm
    ```
    Run `op=rearm` ONLY after the quiesce flag is cleared — the host script aborts loud (does not
-   silently drop) if it gets a 503 because quiesce is still set. `op=rearm` consumes
-   `/var/lib/inngest/cutover-capture.json` (from step 2's `op=capture`) when present and deletes it on
-   full success; absent a capture file it self-enumerates the live backend (steady-state behaviour).
+   silently drop) if it gets a 503 because quiesce is still set. `op=rearm` (mode `rearm-from-capture`)
+   consumes `/var/lib/inngest/cutover-capture.json` from step 2 and deletes it on FULL success; a
+   missing/corrupt capture is FATAL (non-200), never a silent self-enumerate of the empty new backend.
+   - **Retry window (re-arm is replay-on-full-set).** On a partial failure the capture is RETAINED and a
+     re-run re-POSTs the entire set; `schedule-reminder` recomputes the dedup `id`/`ts` so a
+     still-pending reminder dedups instead of double-arming — but a reminder that *fires* between attempts
+     is non-idempotent (it double-posts its comment, same hazard as step 3). So retry `op=rearm` promptly
+     and only while quiesce is cleared; do not let hours pass between a partial re-arm and its retry.
+   - **Aborted cutover leaves a landmine.** If you run `op=capture` then ABORT before `op=rearm`, the
+     capture file persists on-host. A steady-state `op=rearm` (mode `rearm`, the default) deliberately
+     IGNORES it (self-enumerates the live backend), so it will not hijack a routine re-arm — but it is
+     stale clutter. After an aborted cutover, re-run the cutover from `op=capture` (which overwrites it),
+     or let the next successful cutover `op=rearm` consume it.
 7. **Rollback tripwire** — reverting ExecStart to `--sqlite-dir` is data-safe ONLY before any *real*
    (non-throwaway) reminder is armed against Postgres. After that the stale SQLite is missing those
    reminders AND could double-fire ones Postgres recorded → **forward-fix only**. On a committed

--- a/knowledge-base/project/learnings/best-practices/2026-06-18-self-enumerate-cannot-bridge-a-store-switching-cutover.md
+++ b/knowledge-base/project/learnings/best-practices/2026-06-18-self-enumerate-cannot-bridge-a-store-switching-cutover.md
@@ -1,0 +1,33 @@
+# Learning: a "self-enumerate the current server" recovery step cannot bridge a cutover that REPLACES the server's state store
+
+category: best-practices
+module: apps/web-platform/infra (inngest cutover), #5542
+
+## Problem
+
+The no-SSH Inngest SQLite→Postgres cutover had a FALLBACK reminder-preservation path: `op=enumerate` the still-armed reminders, deploy, then `op=rearm`. The rearm host script **self-enumerated the current server** to source its records (a deliberate design choice — adnanh/webhook can't pipe a stdin body, and self-enumerate keeps comment bodies on-host per P2-sec-a). That self-enumerate is correct for a STEADY-STATE restart (durable Redis preserves the queue, so the events are still there). But for the FIRST cutover it is fatal: the step-4 deploy switches the event store to a fresh Postgres+Redis backend whose queue starts **empty** (spike verdict 0.2 — the armed `reminder.scheduled` queue lives in Redis, not Postgres). So `op=rearm` post-deploy self-enumerates the new empty server → 0 records → re-arms nothing → every armed reminder silently lost, and the run reports green. The exact brand-survival data-loss the feature existed to prevent.
+
+The runbook even documented the broken order ("enumerate before, re-arm after") without noticing the rearm script didn't persist the before-capture across the store switch.
+
+## Solution / durable rule
+
+When a recovery/migration step sources its work-list by **reading live state**, and a later step in the same procedure **replaces or wipes that state**, the read MUST be captured to a medium that survives the replacement and the later step must consume the capture — never re-read the (now-mutated) source. Here: `op=capture` self-enumerates the OLD server and persists records to an on-host file under the volume that survives the systemd restart; `op=rearm` (mode `rearm-from-capture`) consumes that file. Three modes, not "presence of a file":
+
+- `capture` — persist (atomic temp+rename so a partial write can't survive as readable-but-corrupt).
+- `rearm-from-capture` — the capture is the ONLY valid source; missing/empty/corrupt is **FATAL**, never a silent downgrade to self-enumerate the post-switch empty store.
+- `rearm` (default/steady-state) — self-enumerate; deliberately IGNORE any capture file so an orphan from an aborted cutover can't hijack a routine re-arm and replay a stale snapshot.
+
+## Key Insight
+
+"Self-enumerate the current server" silently assumes the server's state is invariant across the procedure. A cutover whose entire point is to REPLACE the state store violates that assumption — the recovery read and the destructive write straddle the boundary. The presence-of-a-file heuristic isn't enough either: it conflates "mid-cutover, consume this" with "orphaned stale capture, ignore this." Make the intent explicit (a mode), make the corrupt/missing case loud (the whole feature is loss-prevention, so a silent fall-through is the anti-feature), and make the write atomic (the capture crosses a restart that can truncate an un-synced write).
+
+## Session Errors
+
+1. **Built the FALLBACK re-arm to self-enumerate the post-deploy server — would have lost all 4 armed prod reminders on the first cutover.** Caught by reading `inngest-rearm-reminders.sh:59` against spike verdict 0.2/0.4 DURING execution, before firing any mutation (backup + read-only ops only). Recovery: halted the cutover, filed #5542, built the capture bridge. Prevention: this learning + the tristate design; the runbook FALLBACK now leads with `op=capture` pre-deploy.
+2. **First capture-bridge cut had a HIGH silent-data-loss vector** (present-but-corrupt capture fell through to self-enumerating the empty backend, reported success). Caught by the adversarial silent-failure-hunter review, not by my own tests. Recovery: fatal-on-invalid + atomic write + 4 new RED cases. Prevention: for a loss-prevention feature, a reviewer prompted to REFUTE ("how does this still lose data?") earns its cost — the green happy-path suite did not surface it.
+3. **The original `functions` projection (#5517, sibling-fixed) and this re-arm path both trusted a sibling/plan ASSUMPTION about an external shape instead of the captured reality** — the recurring `2026-06-16-external-api-shape-...captured-fixture-not-probed-claim` class, one layer up (a behavioral assumption about state lifetime, not a JSON shape).
+
+## Tags
+category: best-practices
+module: inngest, cutover, datastore-migration, reminder-survival, #5542, #5450
+related: [[2026-06-18-destructive-datastore-migration-backup-inventory-after-diff]]


### PR DESCRIPTION
## Summary

Fixes the brand-survival reminder-loss flaw (#5542) in the no-SSH Inngest cutover: the FALLBACK re-arm self-enumerated the **current** server, which after the step-4 deploy is the **new Postgres+Redis instance with an empty queue** (verdict 0.2 — the armed `reminder.scheduled` queue lives in Redis, which starts empty). So `op=rearm` post-deploy found 0 reminders and **silently lost all of them**.

## Fix — on-host capture bridge

- **`op=capture`** (new): drives `/hooks/inngest-rearm-reminders` with `mode=capture` — self-enumerate the OLD server BEFORE the deploy and persist records to `/var/lib/inngest/cutover-capture.json` (under the `--sqlite-dir` volume that survives the cutover *restart*). Records stay **on-host** (P2-sec-a — only counts + `reminder_id`s surface in the run log).
- **`op=rearm`** now **consumes the capture file** when present (deleting it on full success, retaining it on any failure for a safe retry) and falls back to self-enumerate for steady-state restarts.
- Reuses the existing rearm hook via a `mode` **pass-environment** input — **no new managed file**, so no delivery-chain registration / count-assertion blast radius.

## User-Brand Impact

**Brand-survival threshold:** single-user incident. A dropped `reeval`/`rebase`/`verify` reminder silently fails to fire post-cutover. This fix is the prerequisite for running #5450 via the FALLBACK path with reminders preserved.

## Changelog

- `inngest-rearm-reminders.sh`: `INNGEST_REARM_MODE` (capture|rearm) + `INNGEST_CUTOVER_CAPTURE_FILE` source priority (stdin > capture > self-enumerate); delete-on-success.
- `hooks.json.tmpl`: rearm hook `mode` → `INNGEST_REARM_MODE` pass-environment.
- `cutover-inngest.yml`: `op=capture` choice + arm.
- Runbook FALLBACK: capture-before-deploy sequence.

## Test plan

- [x] `inngest-rearm-reminders.test.sh` — 29 pass incl. 3 new (capture persists + ids-only status; rearm prefers capture over self-enumerate + deletes on success; retains on failure). RED-proven.
- [x] `cutover-inngest-workflow.test.sh` — 37 pass incl. capture choice + `mode=capture` POST + hook `mode` bridge.
- [x] `infra-config-apply.test.sh` parity unaffected (mode is not a b64-file key).
- [x] shellcheck clean · actionlint clean · `terraform validate` Success · scripts shard ALL PASSED.

Closes #5542
Ref #5450
