### PR TITLE
feat(inngest): external health watchdog + #5542 outage PIR

### DIFF
--- a/.github/workflows/scheduled-inngest-health.yml
+++ b/.github/workflows/scheduled-inngest-health.yml
@@ -73,26 +73,37 @@ jobs:
           # Health signal: the inngest-inventory hook GETs /v0/gql. HTTP 200 with a
           # JSON object carrying .functions == inngest is up. 500 / __FETCH_FAILED__
           # / non-JSON == inngest-server is down or /v0/gql unreachable.
+          # Probe up to 3x (8s apart) and only declare down if ALL fail — a single
+          # transient blip (CF Access hiccup, inventory timeout under load) must
+          # NOT trigger an unnecessary restart. Mirrors scheduled-realtime-probe's
+          # in-run retry resilience (its 5x SUBSCRIBED loop).
           if [[ -z "$fail_mode" ]]; then
             SIG=$(printf '' | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | sed 's/.*= //')
-            rm -f /tmp/health-body
-            CODE=$(curl -s --max-time 30 -o /tmp/health-body -w '%{http_code}' \
-              -X GET \
-              -H "X-Signature-256: sha256=$SIG" \
-              -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
-              -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
-              "https://deploy.soleur.ai/hooks/inngest-inventory" || echo "000")
-            BODY=$(cat /tmp/health-body 2>/dev/null || echo "")
-            if [[ "$CODE" != "200" ]]; then
-              cause=$(strip_log_injection "$(printf '%s' "$BODY" | tr '\n' ' ' | head -c 400)")
-              record_failure "inngest_down" "inventory hook HTTP ${CODE}: ${cause:-<empty body>}"
-            elif ! printf '%s' "$BODY" | jq -e 'type == "object" and (.functions | type == "array")' >/dev/null 2>&1; then
-              cause=$(strip_log_injection "$(printf '%s' "$BODY" | tr '\n' ' ' | head -c 400)")
-              record_failure "inngest_unhealthy" "inventory 200 but no functions array: ${cause}"
-            else
-              fn=$(printf '%s' "$BODY" | jq -r '.functions | length')
-              echo "Inngest healthy: functions=${fn}"
-            fi
+            last_mode=""; last_detail=""; healthy="no"
+            for attempt in 1 2 3; do
+              rm -f /tmp/health-body
+              CODE=$(curl -s --max-time 30 -o /tmp/health-body -w '%{http_code}' \
+                -X GET \
+                -H "X-Signature-256: sha256=$SIG" \
+                -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+                -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
+                "https://deploy.soleur.ai/hooks/inngest-inventory" || echo "000")
+              BODY=$(cat /tmp/health-body 2>/dev/null || echo "")
+              if [[ "$CODE" != "200" ]]; then
+                cause=$(strip_log_injection "$(printf '%s' "$BODY" | tr '\n' ' ' | head -c 400)")
+                last_mode="inngest_down"; last_detail="attempt ${attempt}/3: inventory hook HTTP ${CODE}: ${cause:-<empty body>}"
+              elif ! printf '%s' "$BODY" | jq -e 'type == "object" and (.functions | type == "array")' >/dev/null 2>&1; then
+                cause=$(strip_log_injection "$(printf '%s' "$BODY" | tr '\n' ' ' | head -c 400)")
+                last_mode="inngest_unhealthy"; last_detail="attempt ${attempt}/3: inventory 200 but no functions array: ${cause}"
+              else
+                fn=$(printf '%s' "$BODY" | jq -r '.functions | length')
+                echo "Inngest healthy on attempt ${attempt}/3: functions=${fn}"
+                healthy="yes"; break
+              fi
+              echo "Probe attempt ${attempt}/3 failed (${last_mode}); retrying…"
+              [[ "$attempt" -lt 3 ]] && sleep 8
+            done
+            [[ "$healthy" == "no" ]] && record_failure "$last_mode" "$last_detail"
           fi
 
           fail_mode_safe=$(strip_log_injection "$fail_mode")

--- a/.github/workflows/scheduled-inngest-health.yml
+++ b/.github/workflows/scheduled-inngest-health.yml
@@ -1,0 +1,174 @@
+# <!-- gate-override: new-scheduled-cron-prefer-inngest -->
+# Override justification: this monitor MUST be external to Inngest. An Inngest
+# cron cannot detect Inngest being down (a crash-looping server runs no crons) —
+# that blind spot is the exact #5542 failure this workflow closes. Pure-GH ops.
+#
+# External Inngest health watchdog (#5542 incident — the ~3.5h silent crash-loop).
+#
+# WHY THIS EXISTS: inngest-server crash-looped for hours with NO alert. The
+# existing self-healing watchdog (inngest-watchdog-restart-dispatch.yml) is
+# INTERNAL — it relies on an inngest cron firing the `inngest-desync-restart`
+# label, but a cron cannot run while inngest is fully DOWN. So a hard crash-loop
+# (e.g. durable ExecStart live but inngest-redis missing → connection refused) is
+# invisible: no internal cron, no external probe, no alert. vector ships the
+# crash logs to Better Stack but nothing alerts on them.
+#
+# This workflow is the EXTERNAL probe that runs independently of inngest: it hits
+# the loopback-health signal via the inngest-inventory deploy hook every 15 min.
+# On failure it (1) auto-dispatches restart-inngest-server.yml (github.token has
+# actions:write; a direct dispatch — NOT the label path, which github.token
+# cannot trigger due to GHA's same-token recursion guard), (2) files/updates a
+# P1 tracking issue, and (3) reports an error heartbeat to Sentry so a MISSING
+# check-in also alerts. Pattern mirrors scheduled-realtime-probe.yml.
+#
+# Security: all untrusted values (probe response body) flow through env vars +
+# strip_log_injection before any echo into ::error:: or $GITHUB_OUTPUT. No
+# github.event.* inputs are consumed. The deploy-webhook HMAC + CF Access gates
+# are unchanged (read-only GET of the inventory hook).
+#
+# Tracks #5542.
+
+name: "Scheduled: Inngest Health Watchdog"
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'   # every 15 min — inngest-down is a brand-survival outage
+  workflow_dispatch: {}
+
+concurrency:
+  group: scheduled-inngest-health
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  actions: write   # to dispatch restart-inngest-server.yml on failure
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - id: probe
+        env:
+          WEBHOOK_SECRET: ${{ secrets.WEBHOOK_DEPLOY_SECRET }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          set -uo pipefail
+          # shellcheck disable=SC2020  # tr char-set strip is intentional (verbatim from scheduled-realtime-probe.yml)
+
+          strip_log_injection() {
+            printf '%s' "$1" | tr -d '\r\n\f\v\x7f\x85' \
+              | sed -E 's/\xe2\x80\xa8//g; s/\xe2\x80\xa9//g; s/\xe2\x80\x8b//g; s/\xef\xbb\xbf//g'
+          }
+
+          fail_mode=""; fail_detail=""
+          record_failure() { if [[ -z "$fail_mode" ]]; then fail_mode="$1"; fail_detail="$2"; fi; }
+
+          if [[ -z "${WEBHOOK_SECRET:-}" || -z "${CF_ACCESS_CLIENT_ID:-}" || -z "${CF_ACCESS_CLIENT_SECRET:-}" ]]; then
+            record_failure "secret_unset" "WEBHOOK_DEPLOY_SECRET / CF_ACCESS_* not set — cannot probe the inngest health hook."
+          fi
+
+          # Health signal: the inngest-inventory hook GETs /v0/gql. HTTP 200 with a
+          # JSON object carrying .functions == inngest is up. 500 / __FETCH_FAILED__
+          # / non-JSON == inngest-server is down or /v0/gql unreachable.
+          if [[ -z "$fail_mode" ]]; then
+            SIG=$(printf '' | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | sed 's/.*= //')
+            rm -f /tmp/health-body
+            CODE=$(curl -s --max-time 30 -o /tmp/health-body -w '%{http_code}' \
+              -X GET \
+              -H "X-Signature-256: sha256=$SIG" \
+              -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+              -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
+              "https://deploy.soleur.ai/hooks/inngest-inventory" || echo "000")
+            BODY=$(cat /tmp/health-body 2>/dev/null || echo "")
+            if [[ "$CODE" != "200" ]]; then
+              cause=$(strip_log_injection "$(printf '%s' "$BODY" | tr '\n' ' ' | head -c 400)")
+              record_failure "inngest_down" "inventory hook HTTP ${CODE}: ${cause:-<empty body>}"
+            elif ! printf '%s' "$BODY" | jq -e 'type == "object" and (.functions | type == "array")' >/dev/null 2>&1; then
+              cause=$(strip_log_injection "$(printf '%s' "$BODY" | tr '\n' ' ' | head -c 400)")
+              record_failure "inngest_unhealthy" "inventory 200 but no functions array: ${cause}"
+            else
+              fn=$(printf '%s' "$BODY" | jq -r '.functions | length')
+              echo "Inngest healthy: functions=${fn}"
+            fi
+          fi
+
+          fail_mode_safe=$(strip_log_injection "$fail_mode")
+          fail_detail_safe=$(strip_log_injection "$fail_detail")
+          { echo "failure_mode=${fail_mode_safe}"; echo "failure_detail=${fail_detail_safe}"; } >> "$GITHUB_OUTPUT"
+          if [[ -n "$fail_mode_safe" ]]; then
+            echo "::error::Inngest health probe failed: ${fail_mode_safe} — ${fail_detail_safe}"
+          fi
+
+      - name: Auto-dispatch inngest restart (failure)
+        if: steps.probe.outputs.failure_mode == 'inngest_down' || steps.probe.outputs.failure_mode == 'inngest_unhealthy'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "Dispatching restart-inngest-server.yml (auto-recovery)…"
+          gh workflow run restart-inngest-server.yml --repo "$GH_REPO" --ref main || \
+            echo "::warning::restart dispatch failed — the tracking issue below carries the escalation."
+
+      - name: File or comment tracking issue (failure)
+        if: steps.probe.outputs.failure_mode != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          FAIL_MODE: ${{ steps.probe.outputs.failure_mode }}
+          FAIL_DETAIL: ${{ steps.probe.outputs.failure_detail }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # shellcheck disable=SC2016  # literal single-quoted GitHub search + backticked markdown are intentional
+          set -euo pipefail
+          ISSUE_TITLE="[ci/inngest-down] Inngest health watchdog failed"
+          ISSUE_SEARCH='in:title "[ci/inngest-down] Inngest health watchdog failed"'
+          gh label create "ci/inngest-down" --repo "$GH_REPO" \
+            --description "External watchdog detected inngest-server down/unhealthy" --color "B60205" 2>/dev/null || true
+          NOW=$(date -u '+%Y-%m-%d %H:%M UTC')
+          BODY_FILE=$(mktemp); trap 'rm -f "$BODY_FILE"' EXIT
+          {
+            printf '## Inngest health watchdog failed\n\n'
+            printf -- '- **Failure mode:** `%s`\n' "$FAIL_MODE"
+            printf -- '- **Detail:** %s\n' "$FAIL_DETAIL"
+            printf -- '- **Detected at:** %s\n' "$NOW"
+            printf -- '- **Run log:** %s\n\n' "$RUN_URL"
+            printf '### Auto-recovery\n\nThis run dispatched `restart-inngest-server.yml`. If inngest stays down after the restart, the durable backend likely lost its Redis (`inngest-redis.service` missing → crash-loop): the deploy must re-stage the redis assets, OR roll the ExecStart back to SQLite-only. See `knowledge-base/engineering/operations/runbooks/inngest-server.md` + the #5542 incident.\n'
+          } > "$BODY_FILE"
+          EXISTING=$(gh issue list --repo "$GH_REPO" --state open --search "$ISSUE_SEARCH" --json number --jq '.[0].number // empty')
+          if [[ -n "$EXISTING" ]]; then
+            gh issue comment "$EXISTING" --repo "$GH_REPO" --body "Still failing at ${NOW} — \`${FAIL_MODE}\`: ${FAIL_DETAIL}. Restart re-dispatched. Run: ${RUN_URL}"
+          else
+            gh issue create --repo "$GH_REPO" --title "$ISSUE_TITLE" \
+              --label "ci/inngest-down" --label "priority/p1-high" --body-file "$BODY_FILE"
+          fi
+
+      - name: Auto-close tracking issue (healthy)
+        if: steps.probe.outputs.failure_mode == ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2016  # literal single-quoted GitHub search string is intentional
+          NOW=$(date -u '+%Y-%m-%d %H:%M UTC')
+          STALE=$(gh issue list --repo "$GH_REPO" --state open \
+            --search 'in:title "[ci/inngest-down] Inngest health watchdog failed"' --json number --jq '.[0].number // empty')
+          if [[ -n "$STALE" ]]; then
+            gh issue close "$STALE" --repo "$GH_REPO" --comment "Inngest healthy again at ${NOW}. Run: ${RUN_URL}"
+          fi
+
+      - name: Sentry check-in (final)
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/sentry-heartbeat
+        with:
+          monitor-slug: scheduled-inngest-health
+          status: ${{ steps.probe.outputs.failure_mode == '' && 'ok' || 'error' }}
+          sentry-ingest-domain: ${{ secrets.SENTRY_INGEST_DOMAIN }}
+          sentry-project-id: ${{ secrets.SENTRY_PROJECT_ID }}
+          sentry-public-key: ${{ secrets.SENTRY_PUBLIC_KEY }}

--- a/knowledge-base/engineering/operations/post-mortems/inngest-durable-redis-missing-outage-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/inngest-durable-redis-missing-outage-postmortem.md
@@ -1,0 +1,47 @@
+---
+title: Inngest-server crash-loop — durable ExecStart live, inngest-redis never provisioned
+date: 2026-06-18
+brand_survival_threshold: single-user incident
+gdpr_art33_notifiable: false
+gdpr_art33_rationale: "Availability-only incident (inngest crons/reminders did not fire). No personal data was accessed, altered, disclosed, or lost — the Postgres/Redis backends contain queue/run-state, and no data store was breached."
+gdpr_art34_high_risk_to_individuals: false
+gdpr_art34_rationale: "n/a — availability outage, no personal-data exposure."
+incident: "#5542"
+status: resolved
+---
+
+# PIR: Inngest crash-loop — durable backend live without Redis
+
+## Summary
+
+On 2026-06-18, `inngest-server` on the prod Hetzner host crash-looped for ~3.5h (detected ~12:17 UTC, healthy as recently as 09:28 UTC). It was running the **durable-backend ExecStart** (`--postgres-uri --redis-uri`) but the host had **no Redis at all** — `inngest-redis.service` absent, no `redis-server` binary, no staged `/tmp/inngest-redis.*` assets — so it failed `dial tcp 127.0.0.1:6379: connect: connection refused` every ~9s. All crons + 4 armed reminders did not fire during the window.
+
+## Detection
+
+Found **incidentally** while verifying the #5542 cutover-capture bridge: `op=enumerate` returned an empty-body 500, then `op=inventory` returned `__FETCH_FAILED__` ("is inngest-server.service up?"). There was **no alert** — the gap that made this a multi-hour silent outage (see Action Items).
+
+## Root cause
+
+The durable backend's **Redis half was never provisioned on the host**. The durable ExecStart (from `inngest-bootstrap.sh`, #5459) was deployed, but `inngest-redis-bootstrap.sh` — which installs `redis-server` + the `inngest-redis.service` unit — only runs when the OCI image stages `/tmp/inngest-redis.{conf,service}`, and those assets were absent on the host even after deploying v1.1.15 (the redis-bearing tag). With no Redis listening on :6379, the durable inngest could not start. Compounding it: `verify_inngest_health` hard-requires the durable flags, so a SQLite-only rollback deploy "fails" verify and rolls back to the broken durable image — there was no fail-safe.
+
+## Resolution
+
+Recovered by running the canonical `inngest-redis-bootstrap.sh` (from the repo) over SSH against the host: installed `redis-server`, created `/mnt/data/redis`, installed + started `inngest-redis.service`, then restarted `inngest-server`. `op=inventory` → `functions=56` (healthy on Postgres + Redis). The durable cutover (#5450) is effectively complete on the current host.
+
+## Impact
+
+Availability only: inngest crons + reminders did not fire for ~3.5h. The `rebase-dependabot-5432` reminder (13:00) missed its window. No data loss/exposure. The 4 SQLite-era reminders did not migrate to the empty durable backend (re-arm tracked below).
+
+## Action Items & Follow-ups
+
+The **external inngest health watchdog** (`scheduled-inngest-health.yml`) is delivered in THIS PR — it closes the no-alert blind spot (the internal watchdog is an inngest cron and cannot detect inngest being down). Residual follow-ups:
+
+| Issue | Action | Owner |
+| --- | --- | --- |
+| #5547 | Fix the durable image's redis-asset delivery + add a fail-safe so the durable ExecStart is not applied unless `inngest-redis` is verifiably up (else keep SQLite). | open |
+| #5548 | Re-arm the reminders lost in the cutover (`verify-server-startup-rate-5417`, `reeval-5469`). | open |
+
+## Lessons
+
+- A self-monitoring watchdog hosted **inside** the monitored service has a blind spot for total-down — the monitor must be external (#5546).
+- A backend cutover that depends on a sidecar (Redis) must hard-gate on the sidecar being live BEFORE switching the primary to depend on it, and fail safe to the prior backend otherwise (#5547).


### PR DESCRIPTION
## Summary

Closes the observability gap exposed by #5542 (inngest crash-looped ~3.5h with **no alert**). Adds `scheduled-inngest-health.yml` — an **external** GH Actions watchdog (every 15m) that probes inngest via the `inngest-inventory` hook and, on failure: (1) auto-dispatches `restart-inngest-server.yml`, (2) files/updates a P1 tracking issue, (3) reports a Sentry error heartbeat (a *missing* check-in also alerts).

**Why external:** the existing `inngest-watchdog-restart-dispatch.yml` is driven by an inngest cron — which cannot run when inngest is fully down. An external probe is the only thing that can detect a total crash-loop. (Gate-overridden `new-scheduled-cron-prefer-inngest` with that justification.)

Includes the incident **PIR** (`inngest-durable-redis-missing-outage-postmortem.md`): root cause = durable ExecStart live but `inngest-redis` never provisioned on the host (image redis-asset delivery gap + no fail-safe). Recovered by running the canonical `inngest-redis-bootstrap.sh`; inngest is healthy on the durable backend.

## Test plan
- [x] YAML valid; actionlint info-only (not run in CI; mirrors `scheduled-realtime-probe.yml` which ships the same patterns)
- [x] No `github.event.*` inputs; probe body flows through `strip_log_injection`
- [ ] First scheduled run confirms green probe (post-merge)

## User-Brand Impact

**Brand-survival threshold:** single-user incident. inngest down = crons + reminders silently stop firing; this watchdog makes that detectable in <=15m instead of hours.

Ref #5542
Ref #5547
Ref #5548

Generated with [Claude Code](https://claude.com/claude-code)