### PR TITLE
chore(cloud-init): bump inngest-bootstrap pin to v1.1.16 (#5547)

### DIFF
--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -615,21 +615,23 @@ runcmd:
   # bootstrap-script SHAPE version), NOT the inngest-cli version (the latter is
   # sourced from the image's Config.Env at run time). This pin MUST be bumped to
   # the latest released bootstrap image on every bootstrap-script change, or
-  # fresh-host reprovision installs a stale script. Bumped to v1.1.15 for the
-  # #5499 host-script journald → Better Stack vector.toml source (#5526), on top
-  # of the #5450 durable-backend change (--postgres-uri/--redis-uri ExecStart +
-  # the inngest-redis.{conf,service} + inngest-redis-bootstrap.sh assets baked
-  # into the image) and the post-v1.1.14 cutover-op fixes (#5518/#5528/#5520).
+  # fresh-host reprovision installs a stale script. Bumped to v1.1.16 for the
+  # #5547 durable-Redis delivery-on-existing-host + SQLite fail-safe ExecStart
+  # (the bootstrap now branches the ExecStart on REDIS_READY), on top of the
+  # #5499 host-script journald → Better Stack vector.toml source (#5526), the
+  # #5450 durable-backend change (--postgres-uri/--redis-uri ExecStart + the
+  # inngest-redis.{conf,service} + inngest-redis-bootstrap.sh assets baked into
+  # the image), and the post-v1.1.14 cutover-op fixes (#5518/#5528/#5520).
   # Running hosts get it via the deploy webhook path: push
   # vinngest-vX.Y.Z tag → deploy inngest …:vX.Y.Z; cloud-init installs only on
   # fresh hosts.
   - |
     set -e
-    docker pull ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.15
+    docker pull ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.16
     EXTRACT_DIR=$(mktemp -d)
     cleanup() { docker rm -f soleur-inngest-bootstrap-extract >/dev/null 2>&1 || true; rm -rf "$EXTRACT_DIR"; }
     trap cleanup EXIT
-    docker create --name soleur-inngest-bootstrap-extract ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.15
+    docker create --name soleur-inngest-bootstrap-extract ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.16
     docker cp soleur-inngest-bootstrap-extract:/inngest-bootstrap.sh "$EXTRACT_DIR/inngest-bootstrap.sh"
     docker cp soleur-inngest-bootstrap-extract:/vector.toml /tmp/vector.toml 2>/dev/null || true
     # Durable Redis assets (#5450) — stage to /tmp like vector.toml so the
@@ -639,7 +641,7 @@ runcmd:
     docker cp soleur-inngest-bootstrap-extract:/inngest-redis.service /tmp/inngest-redis.service 2>/dev/null || true
     docker cp soleur-inngest-bootstrap-extract:/inngest-redis-bootstrap.sh /tmp/inngest-redis-bootstrap.sh 2>/dev/null || true
     chmod +x /tmp/inngest-redis-bootstrap.sh 2>/dev/null || true
-    image_env=$(docker inspect ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.15 -f '{{range .Config.Env}}{{println .}}{{end}}')
+    image_env=$(docker inspect ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.16 -f '{{range .Config.Env}}{{println .}}{{end}}')
     chmod +x "$EXTRACT_DIR/inngest-bootstrap.sh"
     INNGEST_CLI_VERSION=$(printf '%s\n' "$image_env" | grep '^INNGEST_CLI_VERSION=' | head -1 | cut -d= -f2-)
     INNGEST_CLI_SHA256=$(printf '%s\n' "$image_env" | grep '^INNGEST_CLI_SHA256=' | head -1 | cut -d= -f2-)


### PR DESCRIPTION
## Summary

Bumps the fresh-host cloud-init pin `soleur-inngest-bootstrap:v1.1.15` → `v1.1.16` to match the just-pushed `vinngest-v1.1.16` tag (carries the #5547 durable-Redis delivery + SQLite fail-safe bootstrap). Closes the AC6 drift-guard window (`cloud-init-inngest-bootstrap.test.sh` requires the pin == latest published `vinngest-v*` tag).

The existing prod host receives v1.1.16 via the `deploy inngest` webhook the tag build fires; cloud-init applies only to fresh-host provisioning (`lifecycle.ignore_changes=[user_data]`).

Ref #5547

## User-Brand Impact

- **Artifact at risk:** none — mechanical version-pin bump to keep fresh-host provisioning in sync with the published image.
- **Brand-survival threshold:** none, reason: a 4-line cloud-init image-tag pin bump with no behavior change; the drift-guard (`cloud-init-inngest-bootstrap.test.sh` 21/21) is the correctness gate.

## Test plan

- [x] `bash apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh` — 21/21 (AC6: pin v1.1.16 == latest tag v1.1.16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)