### PR TITLE
docs(inngest): bootstrap-image release flow (tag→build→deploy→verify) + runbook SSH fix

### DIFF
--- a/knowledge-base/engineering/operations/runbooks/inngest-server.md
+++ b/knowledge-base/engineering/operations/runbooks/inngest-server.md
@@ -63,19 +63,14 @@ After `terraform apply` against a fresh `hcloud_server.web`, the inngest-server 
    ```
    gh api repos/jikig-ai/soleur/actions/workflows/build-inngest-bootstrap-image.yml/runs --jq '.workflow_runs[0]'
    ```
-   If no run exists, push a `vinngest-vX.Y.Z` tag (operator decides the X.Y.Z of the bootstrap image; current is `v1.0.0`):
+   If no run exists, release a bootstrap image — see [§ Bootstrap-image release](#bootstrap-image-release-tag--build--deploy--verify) below for the canonical 4-step tag→build→deploy→verify flow.
+2. Deploy the published image (NO SSH — `deploy-inngest-image.yml` is
+   `workflow_dispatch`-only; it POSTs the deploy webhook → on-host `ci-deploy.sh`
+   `case "inngest")` runs the bootstrap):
    ```
-   git tag vinngest-v1.0.0 && git push origin vinngest-v1.0.0
+   gh workflow run deploy-inngest-image.yml -f tag=<TAG>   # e.g. tag=v1.1.16
    ```
-2. Fire the deploy webhook (replace `<TAG>` with the OCI tag, e.g. `v1.0.0`):
-   ```
-   doppler run -p soleur -c prd_terraform -- bash -c 'echo "deploy inngest ghcr.io/jikig-ai/soleur-inngest-bootstrap <TAG>" | ssh -o StrictHostKeyChecking=accept-new deploy@$(terraform -chdir=apps/web-platform/infra output -raw server_ip)'
-   ```
-   The webhook spawns `ci-deploy.sh` which runs the OCI image's entrypoint `/inngest-bootstrap.sh` against the host's systemd via bind-mounts.
-3. Verify the service is active:
-   ```
-   ssh root@$(terraform -chdir=apps/web-platform/infra output -raw server_ip) systemctl status inngest-server.service inngest-heartbeat.timer
-   ```
+3. Verify via the deploy-status webhook (NO SSH) — see [§ Bootstrap-image release](#bootstrap-image-release-tag--build--deploy--verify) step 4. Expect `{component:"inngest", tag:"<TAG>", reason:"success"}`.
 4. [§ Unpause heartbeat](#unpause-heartbeat) once you've confirmed the heartbeat timer is firing.
 
 ## Heartbeat-miss triage
@@ -137,13 +132,53 @@ Inngest CLI version is pinned in `apps/web-platform/infra/inngest.tf` `locals` b
    inngest_cli_version = "vX.Y.Z"
    inngest_cli_sha256  = "<64-hex>"
    ```
-3. Tag + push to trigger the OCI image rebuild:
+3. Release the new bootstrap-image semver (N.N.N — separate from the embedded
+   inngest-cli version) via the canonical flow below
+   ([§ Bootstrap-image release](#bootstrap-image-release-tag--build--deploy--verify)):
+   annotated tag → build → cloud-init pin bump → `workflow_dispatch` deploy →
+   verify. On deploy, `inngest-bootstrap.sh` detects the version mismatch,
+   pauses → drains → restarts → resumes (~5s downtime on loopback).
+
+## Bootstrap-image release (tag → build → deploy → verify)
+
+Releasing a new `soleur-inngest-bootstrap` image (changed `inngest-bootstrap.sh`,
+`inngest-redis.*`, or bumped `inngest_cli_version`) is a **4-step coordinated
+flow — the image build does NOT auto-deploy**. None of these steps use SSH
+(`hr-no-ssh-fallback-in-runbooks`). Full context + gotchas:
+`knowledge-base/project/learnings/workflow-patterns/2026-06-18-inngest-bootstrap-release-tag-then-dispatch-deploy.md`.
+
+1. **Push an ANNOTATED `vinngest-vX.Y.Z` tag** on the commit carrying the change
+   (the repo forces annotated tags — a bare `git tag <name> <sha>` fails
+   `fatal: no tag message?`):
    ```
-   git tag vinngest-vN.N.N && git push origin vinngest-vN.N.N
+   git tag -a vinngest-v1.1.16 <main-sha> -m "inngest-bootstrap v1.1.16: <what>"
+   git push origin vinngest-v1.1.16
    ```
-   (where N.N.N is the bootstrap-image semver — separate from the embedded inngest-cli version.)
-4. Wait for the GHA workflow to complete + the image to land in GHCR.
-5. Fire the deploy webhook with the new image tag. `inngest-bootstrap.sh` detects the version mismatch, pauses → drains → restarts → resumes (~5s downtime on loopback).
+   Fires `build-inngest-bootstrap-image.yml` → builds + SHA-verifies + pushes the
+   image. It does NOT deploy.
+2. **Bump the cloud-init pin in lockstep** — `apps/web-platform/infra/cloud-init.yml`
+   (the 3 `soleur-inngest-bootstrap:vX.Y.Z` refs) → `v1.1.16` in a PR. AC6 of
+   `cloud-init-inngest-bootstrap.test.sh` asserts pin == the semver-max published
+   `vinngest-v*` tag, so the tag in step 1 MUST exist first (else the bump PR's CI
+   fails AC6); pushing the tag without bumping turns `main` red until this PR merges.
+3. **Dispatch the deploy** (workflow_dispatch-only; the build never chains into it):
+   ```
+   gh workflow run deploy-inngest-image.yml -f tag=v1.1.16
+   ```
+4. **Verify via the deploy-status webhook (NO SSH)** — single authenticated GET:
+   ```
+   WS=$(doppler secrets get WEBHOOK_DEPLOY_SECRET -p soleur -c prd_terraform --plain)
+   CID=$(doppler secrets get CF_ACCESS_CLIENT_ID -p soleur -c prd_terraform --plain)
+   CSEC=$(doppler secrets get CF_ACCESS_CLIENT_SECRET -p soleur -c prd_terraform --plain)
+   HMAC=$(printf '' | openssl dgst -sha256 -hmac "$WS" | sed 's/.*= //')
+   curl -fsS -H "X-Signature-256: sha256=${HMAC}" \
+     -H "CF-Access-Client-Id: ${CID}" -H "CF-Access-Client-Secret: ${CSEC}" \
+     "https://deploy.soleur.ai/hooks/deploy-status" | jq '{component, tag, reason, exit_code}'
+   ```
+   Expect `{component:"inngest", tag:"v1.1.16", reason:"success"}` (durable backend
+   live). `reason:"success_degraded_durability"` = the SQLite fail-safe fired
+   (Redis not ready, #5547). Use the literal host `deploy.soleur.ai` — do NOT
+   interpolate `$(doppler secrets get APP_DOMAIN_BASE …)` (reads empty / races).
 
 ## FR5 flag flip
 

--- a/knowledge-base/project/learnings/workflow-patterns/2026-06-18-inngest-bootstrap-release-tag-then-dispatch-deploy.md
+++ b/knowledge-base/project/learnings/workflow-patterns/2026-06-18-inngest-bootstrap-release-tag-then-dispatch-deploy.md
@@ -1,0 +1,106 @@
+---
+title: "Inngest bootstrap-image release is a 4-step tag→build→dispatch→pin flow — the build does NOT auto-deploy"
+date: 2026-06-18
+category: workflow-patterns
+module: apps/web-platform/infra
+tags: [inngest, deploy, release, vinngest, cloud-init, ci-deploy, no-ssh]
+issue: 5547
+pr: 5550
+---
+
+# Learning: releasing a new inngest-bootstrap image is a 4-step coordinated flow
+
+## Problem
+
+After merging a fix to `inngest-bootstrap.sh` (#5547), I needed to verify it
+live (AC9: a real `deploy inngest` installs Redis + the durable ExecStart on
+the prod host). I assumed pushing the `vinngest-vX.Y.Z` tag would
+build-AND-deploy in one shot. It did not — `build-inngest-bootstrap-image.yml`
+only **builds + pushes** the OCI image; the deploy stayed un-triggered, and the
+deploy-status webhook kept showing the *previous* (web-platform) deploy.
+
+## Solution — the actual 4-step flow
+
+A new inngest-bootstrap image (carrying a changed `inngest-bootstrap.sh`,
+`inngest-redis.*`, or a bumped `inngest_cli_version`) reaches the prod host via
+FOUR coordinated steps. None of them are SSH (`hr-no-ssh-fallback-in-runbooks`):
+
+1. **Push an ANNOTATED `vinngest-vX.Y.Z` tag** on the commit that carries the
+   change. The repo config forces annotated tags — a bare `git tag <name> <sha>`
+   fails `fatal: no tag message?`. Use:
+   ```bash
+   git tag -a vinngest-v1.1.16 <main-sha> -m "inngest-bootstrap v1.1.16: <what>"
+   git push origin vinngest-v1.1.16
+   ```
+   This fires `build-inngest-bootstrap-image.yml` (`on: push: tags: vinngest-v*`),
+   which builds + SHA-verifies + pushes `ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.16`.
+   **It does NOT deploy.**
+
+2. **Bump the cloud-init pin IN LOCKSTEP** (`apps/web-platform/infra/cloud-init.yml`,
+   the 3 `soleur-inngest-bootstrap:vX.Y.Z` refs). `cloud-init-inngest-bootstrap.test.sh`
+   AC6 asserts **pin == the semver-max published `vinngest-v*` git tag**. Pushing
+   the tag without the pin bump turns `main` red (pin v1.1.15 ≠ latest tag v1.1.16);
+   bumping the pin *before* the tag exists also fails AC6 on the bump PR's own CI.
+   So: **push the tag first** (per `hr-tagged-build-workflow-needs-initial-tag-push`),
+   then open + merge the pin-bump PR — the bump PR passes AC6 because the tag now
+   exists. A brief AC6-red window on `main` exists between the two; the bump PR
+   closes it.
+
+3. **Dispatch the deploy explicitly** — `deploy-inngest-image.yml` is
+   `workflow_dispatch`-only (its `push: branches: [main]` trigger exists ONLY to
+   surface it in the Actions UI; the deploy job is `if: github.event_name ==
+   "workflow_dispatch"`). The build never chains into it.
+   ```bash
+   gh workflow run deploy-inngest-image.yml -f tag=v1.1.16
+   ```
+   This POSTs `deploy inngest ghcr.io/jikig-ai/soleur-inngest-bootstrap v1.1.16`
+   to the prod deploy webhook → the on-host `ci-deploy.sh` `case "inngest")` pulls
+   + extracts + runs the bootstrap (NO SSH — the old runbook's
+   `ssh deploy@<host>` form is stale and violates the no-SSH rule).
+
+4. **Verify via the deploy-status webhook (no SSH)** — a single authenticated GET:
+   ```bash
+   WS=$(doppler secrets get WEBHOOK_DEPLOY_SECRET -p soleur -c prd_terraform --plain)
+   CID=$(doppler secrets get CF_ACCESS_CLIENT_ID -p soleur -c prd_terraform --plain)
+   CSEC=$(doppler secrets get CF_ACCESS_CLIENT_SECRET -p soleur -c prd_terraform --plain)
+   HMAC=$(printf '' | openssl dgst -sha256 -hmac "$WS" | sed 's/.*= //')
+   curl -fsS -H "X-Signature-256: sha256=${HMAC}" \
+     -H "CF-Access-Client-Id: ${CID}" -H "CF-Access-Client-Secret: ${CSEC}" \
+     "https://deploy.soleur.ai/hooks/deploy-status" | jq '{component, tag, reason, exit_code}'
+   ```
+   Expect `{component:"inngest", tag:"v1.1.16", reason:"success", exit_code:0}`.
+   `reason:"success"` = durable backend live; `reason:"success_degraded_durability"`
+   = the SQLite fail-safe fired (Redis not ready, #5547).
+
+## Key Insight
+
+- **Build ≠ deploy.** The OCI image build and the host deploy are two separate
+  workflows; the deploy is a manual `workflow_dispatch`. Verifying any
+  bootstrap/CLI change live requires step 3 explicitly — a green build is not a
+  deploy.
+- **The tag must precede the cloud-init pin bump** (AC6 chicken-and-egg). Tag →
+  build → pin-bump-PR, in that order.
+- **Use `deploy.soleur.ai` as the deploy-status host.** `APP_DOMAIN_BASE` in
+  Doppler `prd_terraform` read empty under rapid sequential `doppler secrets get`
+  (and a presence-check `&& echo ""` gives a misleading non-zero length); the
+  canonical host is documented in `postmerge` Production Debugging — hardcode it
+  rather than interpolating a flaky fetch into the URL.
+
+## Session Errors
+
+1. **Assumed the image build auto-fires the deploy.** — Recovery: `gh workflow
+   run deploy-inngest-image.yml -f tag=v1.1.16` (the deploy is workflow_dispatch-only).
+   **Prevention:** documented as step 3 of the release flow here + in
+   `inngest-server.md`; the build workflow only builds+pushes.
+2. **`git tag vinngest-v1.1.16 <sha>` → `fatal: no tag message?`.** — Recovery:
+   `git tag -a … -m`. **Prevention:** the runbook now prescribes `-a -m`.
+3. **`APP_DOMAIN_BASE` (Doppler prd_terraform) read empty → deploy-status URL
+   `deploy.` → "Could not resolve host" (monitor fetch-error).** — Recovery: used
+   the canonical `deploy.soleur.ai`. **Prevention:** Key Insight above + the
+   runbook hardcodes the host.
+4. **AC6 drift-guard turns `main` red if the cloud-init pin and the latest
+   vinngest tag disagree.** — Recovery: pin-bump PR #5555 after the tag push.
+   **Prevention:** step 2 documents the tag-first ordering.
+5. **`session-state.md` (untracked one-shot scratch) blocked `cleanup-merged`.** —
+   Recovery: `rm` it. **Prevention:** one-off; the next session's idempotent
+   cleanup also handles it.


### PR DESCRIPTION
## Summary

Compounds the inngest bootstrap-image release flow learned while verifying #5547 live (AC9). Two artifacts:

- **New learning** `knowledge-base/project/learnings/workflow-patterns/2026-06-18-inngest-bootstrap-release-tag-then-dispatch-deploy.md` — the 4-step flow + 5 session-error preventions.
- **Runbook correction** `inngest-server.md` — the release/deploy/verify steps were stale: plain `git tag` (now fails `no tag message?` under the annotated-tag config), an **SSH** deploy webhook + **SSH** `systemctl status` verify (violated `hr-no-ssh-fallback-in-runbooks`), no cloud-init AC6 pin-bump step, no deploy-status verification. Replaced with the canonical no-SSH flow + a new `## Bootstrap-image release` section.

Key correction: **the image build does NOT auto-deploy.** `build-inngest-bootstrap-image.yml` only builds+pushes; the deploy is a separate `workflow_dispatch` of `deploy-inngest-image.yml`.

Ref #5547

## Changelog
- Captured the inngest bootstrap-image release flow as a workflow-patterns learning.
- Corrected `inngest-server.md` release/deploy/verify steps to the no-SSH form (annotated tag, cloud-init AC6 pin-bump lockstep, `gh workflow run deploy-inngest-image.yml`, deploy-status webhook verify).

## Test plan
- [x] Docs-only (knowledge-base + runbook markdown); no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)