### PR TITLE
fix(inngest): cap --postgres-max-open-conns at 10 (under session-pooler pool_size 15)

### DIFF
--- a/apps/web-platform/infra/inngest-bootstrap.sh
+++ b/apps/web-platform/infra/inngest-bootstrap.sh
@@ -297,8 +297,10 @@ fi
 # Postgres-ALONE loses armed future-ts reminders on a host re-provision; durable
 # external Redis is what survives. Both secrets inject from Doppler prd via the
 # `doppler run` wrapper (same $${...} pattern as the keys; avoids the #4116
-# EnvironmentFile-empty trap). --postgres-max-open-conns 25 bounds the pooler
-# budget. Inngest FAILS CLOSED on an unreachable/empty backend (verdict 0.3) —
+# EnvironmentFile-empty trap). --postgres-max-open-conns 10 stays UNDER the
+# dedicated project's session-mode pooler pool_size (15) so inngest cannot
+# self-exhaust the pool under load — #5558: 25 exceeded 15 → EMAXCONNSESSION.
+# Inngest FAILS CLOSED on an unreachable/empty backend (verdict 0.3) —
 # #5547 Gap 2: rather than write the durable flags unconditionally (which
 # crash-loops when Redis is unprovisioned), the ExecStart below carries a literal
 # @@BACKEND_FLAGS@@ sentinel that is substituted (just after the heredoc) with
@@ -349,7 +351,7 @@ UNITEOF
 # stays literal until systemd unescapes $$→$ and the doppler-wrapped bash -c
 # expands the injected env (same $${...} contract as the keys).
 if [[ "$REDIS_READY" == "1" ]]; then
-  BACKEND_FLAGS='--postgres-uri "$${INNGEST_POSTGRES_URI}" --redis-uri "redis://:$${INNGEST_REDIS_PASSWORD}@127.0.0.1:6379" --postgres-max-open-conns 25'
+  BACKEND_FLAGS='--postgres-uri "$${INNGEST_POSTGRES_URI}" --redis-uri "redis://:$${INNGEST_REDIS_PASSWORD}@127.0.0.1:6379" --postgres-max-open-conns 10'
   log "inngest-server ExecStart: durable backend (--postgres-uri + --redis-uri)"
 else
   BACKEND_FLAGS=''


### PR DESCRIPTION
## Summary

Fixes #5558: inngest's durable ExecStart set `--postgres-max-open-conns 25`, but the dedicated Supabase project's **session-mode pooler** (port 5432, required for sqlc prepared statements per Phase-0 verdict 0.5) caps at **`pool_size 15`**. Under connection load — `op=inventory`'s paginated enumerate, concurrent cron/reminder execution — inngest scaled past 15 and hit `FATAL (EMAXCONNSESSION) max clients reached in session mode`, degrading the durable backend.

Caps `--postgres-max-open-conns` at **10** (clear headroom under 15; alpha volume <10 events/sec needs nowhere near 25). Bounding the client is safer than relying on a raised server cap.

This is the **last blocker for #5450** (durable-backend durability evaluation) — after this image (v1.1.17) deploys + `op=inventory` returns 200 under the heavy enumerate, #5450 closes.

## Test plan
- [x] `inngest.test.sh` 70/70 (asserts `--postgres-max-open-conns [0-9]+`, value-agnostic)
- [x] shellcheck (pre-existing SC2016 `$${...}` Doppler pattern only)
- [ ] Post-merge: tag `vinngest-v1.1.17` → build → deploy → `op=inventory` returns 200 (the heavy enumerate that was failing)

## User-Brand Impact

**Brand-survival threshold:** single-user incident. A pool-exhausted durable backend drops crons/reminders under load. Capping connections keeps inngest healthy under its dedicated pooler's hard limit.

Closes #5558
Ref #5450

Generated with [Claude Code](https://claude.com/claude-code)