### PR TITLE
fix(infra): add github_actions_secret.supabase_access_token to apply -target allow-list

### DIFF
--- a/.github/workflows/apply-web-platform-infra.yml
+++ b/.github/workflows/apply-web-platform-infra.yml
@@ -346,6 +346,7 @@ jobs:
               -target=doppler_secret.inngest_heartbeat_url_prd \
               -target=random_password.inngest_redis_password_prd \
               -target=doppler_secret.inngest_redis_password_prd \
+              -target=github_actions_secret.supabase_access_token \
               -target=hcloud_firewall.web \
               -target=hcloud_firewall_attachment.web \
               -target=doppler_secret.resend_receiving_api_key


### PR DESCRIPTION
## Summary

#5562 added `github_actions_secret.supabase_access_token` to `inngest.tf` but not to the `-target=` allow-list in `apply-web-platform-infra.yml`. That workflow runs a **target-scoped** apply (not a full plan apply), so the new resource was skipped and the `SUPABASE_ACCESS_TOKEN` GH Actions secret was never created — the new inngest pool probe runs degraded (`pool_probe_unavailable`) until it exists.

Root cause of the miss: `terraform-target-parity.test.ts` only guards SSH-provisioned `terraform_data.*` resources, so a non-SSH resource added without a matching `-target` line passes CI and is only flagged by the 12h drift cron.

## Changelog
- Add `-target=github_actions_secret.supabase_access_token` alongside the other inngest resources in the allow-list.

## Test plan
- [x] One-line allow-list addition matching the established `github_actions_secret.doppler_token_write` pattern
- [ ] Post-merge: dispatch `apply-web-platform-infra.yml` → creates the secret → verify via `gh secret list`

Refs #5562

Generated with [Claude Code](https://claude.com/claude-code)