### PR TITLE
fix(release): cap all lock-holding release jobs with timeout-minutes

### DIFF
--- a/.github/workflows/web-platform-release.yml
+++ b/.github/workflows/web-platform-release.yml
@@ -110,6 +110,10 @@ jobs:
     needs: release
     if: needs.release.outputs.version != '' && (github.event_name != 'workflow_dispatch' || !inputs.skip_deploy)
     runs-on: ubuntu-latest
+    # Holds the migrate-web-platform lock (cancel-in-progress: false), so an
+    # unbounded hang serializes all releases. Cap above any legitimate apply;
+    # DDL is transactional, so a timeout-kill rolls the in-flight migration back.
+    timeout-minutes: 30
     concurrency:
       group: migrate-web-platform
       cancel-in-progress: false
@@ -258,6 +262,10 @@ jobs:
     # secrets is present in Doppler prd. Closes #2769 (silent Doppler drift that
     # shipped NEXT_PUBLIC_APP_URL=undefined via PR #2767).
     runs-on: ubuntu-latest
+    # Holds the verify-secrets-web-platform lock (cancel-in-progress: false);
+    # cap so a hung doppler/network call can't serialize releases. This job is a
+    # fast secrets-existence check — 10 min is generous headroom.
+    timeout-minutes: 10
     concurrency:
       group: verify-secrets-web-platform
       cancel-in-progress: false
@@ -291,6 +299,13 @@ jobs:
        (github.event_name == 'workflow_dispatch' && needs.await-ci.result == 'skipped')) &&
       (github.event_name != 'workflow_dispatch' || !inputs.skip_deploy)
     runs-on: ubuntu-latest
+    # Holds the deploy-web-platform lock (cancel-in-progress: false). The job
+    # already self-bounds via the STATUS+HEALTH poll loops below (30m + 30m
+    # sequential ceiling) plus the image build; this 90m cap is the backstop for
+    # a hang BEFORE those loops (e.g. a buildx wedge per post-mortems/
+    # v0116-1-buildx-driver-full-repull-deploy-timeout) and MUST stay above the
+    # ~65m legitimate ceiling so it never kills a slow-but-healthy deploy.
+    timeout-minutes: 90
     concurrency:
       group: deploy-web-platform
       cancel-in-progress: false


### PR DESCRIPTION
## Summary
Follow-up to the `verify-migrations` hardening (PR #5568). The same wedge class — a job holding a `cancel-in-progress: false` concurrency lock under GitHub's 6h default timeout — applies to **every** lock-holding job in `web-platform-release.yml`, not just `verify-migrations`. Any of them hanging serializes all web-platform releases for hours (root incident: the #5559 `Install psql` hang, ~3h prod deploy stall).

## Changelog
### Web Platform
- All release-serializing jobs now self-bound, so a single hung job can no longer block the deploy queue for hours.

## Changes
| Job | Lock | Added cap | Rationale |
|-----|------|-----------|-----------|
| `migrate` | migrate-web-platform | `30m` | DDL is transactional — a timeout-kill rolls the in-flight migration back |
| `verify-doppler-secrets` | verify-secrets-web-platform | `10m` | fast secrets-existence check |
| `deploy` | deploy-web-platform | `90m` | backstop **above** the ~65m legit ceiling (STATUS 30m + HEALTH 30m sequential + build); catches a pre-poll buildx wedge without killing a slow-but-healthy deploy |

`verify-migrations` (15m, #5568) and `live-verify` (15m) already had caps. `release` is intentionally untouched — it holds no `cancel-in-progress:false` lock, so a hang there can't serialize other releases.

## Test plan
- [x] `actionlint` clean; all 4 lock-holding jobs confirmed to carry `timeout-minutes`
- [x] Static change only (no `github.event.*` in run blocks)
- [ ] Post-merge: next release exercises the jobs; all complete well under their caps

Generated with [Claude Code](https://claude.com/claude-code)