### PR TITLE
fix(live-verify): gate Send on start_session acceptance, not WS-connect

### DIFF
--- a/apps/web-platform/scripts/live-verify/run.ts
+++ b/apps/web-platform/scripts/live-verify/run.ts
@@ -389,6 +389,7 @@ async function driveAndVerify(
     // realtime socket /realtime/v1/websocket). Only the parsed {errorCode,message}
     // is retained; raw frame payloads (the auth frame carries a token) never leak.
     let latestWsError: WsErrorFrame | null = null;
+    let sessionStarted = false;
     page.on("websocket", (ws) => {
       let pathname: string;
       try {
@@ -398,8 +399,13 @@ async function driveAndVerify(
       }
       if (pathname !== "/ws") return;
       ws.on("framereceived", ({ payload }) => {
-        const parsed = parseWsErrorFrame(payload.toString());
+        const text = payload.toString();
+        const parsed = parseWsErrorFrame(text);
         if (parsed) latestWsError = parsed;
+        // `session_started` is the server's acceptance of `start_session`; the
+        // Send gate below waits for it so the chat never races ahead of the
+        // established session (the #5463 session-rejected class).
+        if (isSessionStartedFrame(text)) sessionStarted = true;
       });
     });
 
@@ -433,6 +439,38 @@ async function driveAndVerify(
     const input = page.getByRole("textbox").first();
     await input.waitFor({ state: "visible", timeout: 20_000 });
     await input.fill("live-verify rail check — automated, please ignore");
+
+    // Gate the Send on start_session ACCEPTANCE, not merely WS-connect. The Send
+    // button enables on `status === "connected"` (chat-surface.tsx) — strictly
+    // weaker than session acceptance — so clicking the instant it enables can race
+    // ahead of the server's `session_started` reply and land the chat with no
+    // active session ("Send start_session first" → session-rejected, the #5463
+    // class observed on the first real CI run). The client auto-fires start_session
+    // on WS-connect during hydration, so we poll the frame-listener flags here:
+    //   - `session_started` seen      → session established, safe to Send
+    //   - rate-limited / rejected     → bail with the precise reason BEFORE sending
+    //   - neither within budget       → distinct `session-not-acked` CANT-RUN
+    // (so a never-acked session is diagnosable, not misattributed downstream).
+    const ackDeadline = Date.now() + 20_000;
+    while (!sessionStarted) {
+      const rejection = sendRejectionReason(latestWsError);
+      if (rejection) {
+        return { kind: "CANT-RUN", reason: rejection };
+      }
+      if (Date.now() >= ackDeadline) {
+        // latestWsError is mutated only inside the framereceived closure, which
+        // TS's control-flow analysis cannot model — it narrows the variable to
+        // `null` here (so `?.field` errors on the `never` non-null branch). The
+        // assertion re-states the true declared type; the closure does set it.
+        const lastErr = latestWsError as WsErrorFrame | null;
+        const hint = lastErr?.errorCode ?? lastErr?.message;
+        return {
+          kind: "CANT-RUN",
+          reason: hint ? `session-not-acked:${hint}` : "session-not-acked",
+        };
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
 
     // The Send button is disabled until the WS reaches status === "connected"
     // (chat-surface.tsx: `disabled={status !== "connected"}`); clicking a
@@ -545,6 +583,28 @@ export function parseWsErrorFrame(payload: string): WsErrorFrame | null {
     errorCode: typeof errorCode === "string" ? errorCode : undefined,
     message: typeof message === "string" ? message : undefined,
   };
+}
+
+/**
+ * True ONLY for a `{type:"session_started"}` frame — the server's acceptance of
+ * `start_session` (ws-handler.ts emits it with a conversationId + capabilities).
+ * The drive loop waits for this before clicking Send, because the Send button
+ * enables on the weaker `status === "connected"` (chat-surface.tsx) and a click
+ * can otherwise race ahead of session acceptance. Pure + side-effect-free for unit
+ * tests; only the `type` discriminant is read, so no payload field escapes.
+ */
+export function isSessionStartedFrame(payload: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payload);
+  } catch {
+    return false;
+  }
+  return (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    (parsed as { type?: unknown }).type === "session_started"
+  );
 }
 
 // The genuine no-persist FAIL detail (session accepted but no row materialized —

--- a/apps/web-platform/test/live-verify/drive-result-ws-error.test.ts
+++ b/apps/web-platform/test/live-verify/drive-result-ws-error.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   classifyDriveResult,
+  isSessionStartedFrame,
   parseWsErrorFrame,
   sendRejectionReason,
 } from "../../scripts/live-verify/run";
@@ -59,6 +60,41 @@ describe("parseWsErrorFrame", () => {
       parseWsErrorFrame(JSON.stringify(["1", "1", "realtime:command-center-own", "phx_reply", {}])),
     ).toBeNull();
     expect(parseWsErrorFrame(JSON.stringify("error"))).toBeNull();
+  });
+});
+
+describe("isSessionStartedFrame", () => {
+  // The Send gate waits for this frame so the chat never races ahead of session
+  // acceptance (the #5463 session-rejected class observed on the first real CI run).
+  it("returns true ONLY for a {type:'session_started'} frame", () => {
+    expect(
+      isSessionStartedFrame(
+        JSON.stringify({
+          type: "session_started",
+          conversationId: "11111111-1111-1111-1111-111111111111",
+          capabilities: { promptKinds: [], incomingTypes: [] },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for other frames (auth_ok / chat / error / session_resumed)", () => {
+    expect(isSessionStartedFrame(JSON.stringify({ type: "auth_ok" }))).toBe(false);
+    expect(isSessionStartedFrame(JSON.stringify({ type: "chat", content: "hi" }))).toBe(false);
+    expect(
+      isSessionStartedFrame(JSON.stringify({ type: "error", errorCode: "rate_limited" })),
+    ).toBe(false);
+    // session_resumed is a distinct accept frame; the fresh-send gate keys on
+    // session_started specifically — guard against a future loosening to substring.
+    expect(isSessionStartedFrame(JSON.stringify({ type: "session_resumed" }))).toBe(false);
+  });
+
+  it("returns false for non-JSON / non-object payloads (Phoenix arrays, bare strings)", () => {
+    expect(isSessionStartedFrame("not json at all")).toBe(false);
+    expect(
+      isSessionStartedFrame(JSON.stringify(["1", "1", "realtime:x", "phx_reply", {}])),
+    ).toBe(false);
+    expect(isSessionStartedFrame(JSON.stringify("session_started"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
The first real CI execution of the live-verify harness (run [27777534129](https://github.com/jikig-ai/soleur/actions/runs/27777534129), via the no-op trigger #5564) returned `CANT-RUN:session-rejected`. Root cause: the harness clicks Send as soon as the composer enables, but the Send button gates on `status === "connected"` (`chat-surface.tsx`) — WS open — which is **strictly weaker** than `start_session` being **accepted**. The synthetic principal's `start_session` budget was fresh at run time, so this is an **acceptance race, not a rate limit**: the `chat` frame lands before `session_started`, and the server replies *"Send start_session first"*.

## Changelog
### Web Platform
- The post-deploy live-verify harness now waits for the server to accept the chat session before sending, removing a race that prevented a real `PASS` and making a genuine session rejection a precise, deterministic signal.

## Fix (harness-only — no app change)
- New pure helper `isSessionStartedFrame` detects the server's `{type:"session_started"}` accept frame on the app `/ws` (via the existing `framereceived` listener).
- Before clicking Send, wait up to 20s for session acceptance:
  - `session_started` seen → session established, safe to Send
  - rate-limited / rejected → bail with the precise reason **before** sending
  - neither within budget → distinct `CANT-RUN:session-not-acked` (a never-acked session is now diagnosable, not misattributed downstream)

## Validation note
This diff touches `scripts/live-verify/` + `test/`, which are **not** in `trigger-paths.txt`, so this PR's own release SKIPs the live-verify job. The harness runs from the checked-out repo, so once merged, the **next** trigger-path merge exercises the fixed harness — a follow-up no-op trigger will confirm whether it now reaches `RESULT: PASS`. Toward the #5463 report-only→blocking flip prerequisite (still gated on observing a real PASS).

## Test plan
- [x] `tsc --noEmit` clean; full `test/live-verify/` suite green (58 tests, +4 new for `isSessionStartedFrame`)
- [x] Fixtures synthesized only (no real tokens)
- [ ] Post-merge: a no-op trigger runs the fixed harness in CI; observe PASS vs. a now-precise CANT-RUN

Generated with [Claude Code](https://claude.com/claude-code)