### PR TITLE
chore(live-verify): re-arm no-op trigger to validate the start_session-ack fix

### DIFF
--- a/apps/web-platform/middleware.ts
+++ b/apps/web-platform/middleware.ts
@@ -1,7 +1,8 @@
 // live-verify gate exercise: deliberate no-op to trigger the report-only
-// post-deploy harness for the first time in CI (this file matches
-// scripts/live-verify/trigger-paths.txt `^apps/web-platform/middleware\.ts`,
-// re-homed by PR #5488). No behavior change; report-only cannot block deploy.
+// post-deploy harness (this file matches scripts/live-verify/trigger-paths.txt
+// `^apps/web-platform/middleware\.ts`, re-homed by PR #5488). No behavior change;
+// report-only cannot block deploy. Re-armed to validate the start_session-ack
+// fix (PR #5573) — confirm the harness now reaches PASS rather than session-rejected.
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 import { TC_VERSION } from "@/lib/legal/tc-version";


### PR DESCRIPTION
## Summary
Comment-only no-op to `apps/web-platform/middleware.ts` (matches `trigger-paths.txt` `^apps/web-platform/middleware\.ts`) so the merge fires the report-only `live-verify:` job on a deploy whose checked-out harness includes the **start_session-acceptance fix (PR #5573)**.

Validates whether the harness now reaches `RESULT: PASS` instead of `CANT-RUN:session-rejected` (the first-CI-run result). Report-only — cannot block the deploy. This PR resolves no issues; the #5463 flip stays gated on observing a real PASS.

## Changelog
### Web Platform
- No runtime change; a comment line re-arms the live-verify trigger to validate the harness fix end-to-end in CI.

## Test plan
- [x] Comment-only diff; `tsc --noEmit` clean
- [ ] Post-merge: `live-verify:` job runs (triggered=1) on the fixed harness; capture RESULT + Sentry `gate=live-verify` event

Generated with [Claude Code](https://claude.com/claude-code)