### PR TITLE
chore(inngest): bump bootstrap pin v1.1.17→v1.1.18 (argv→env secrets) + fix redis-rotation comment

### DIFF
--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -630,11 +630,11 @@ runcmd:
   # fresh hosts.
   - |
     set -e
-    docker pull ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.17
+    docker pull ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.18
     EXTRACT_DIR=$(mktemp -d)
     cleanup() { docker rm -f soleur-inngest-bootstrap-extract >/dev/null 2>&1 || true; rm -rf "$EXTRACT_DIR"; }
     trap cleanup EXIT
-    docker create --name soleur-inngest-bootstrap-extract ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.17
+    docker create --name soleur-inngest-bootstrap-extract ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.18
     docker cp soleur-inngest-bootstrap-extract:/inngest-bootstrap.sh "$EXTRACT_DIR/inngest-bootstrap.sh"
     docker cp soleur-inngest-bootstrap-extract:/vector.toml /tmp/vector.toml 2>/dev/null || true
     # Durable Redis assets (#5450) — stage to /tmp like vector.toml so the
@@ -644,7 +644,7 @@ runcmd:
     docker cp soleur-inngest-bootstrap-extract:/inngest-redis.service /tmp/inngest-redis.service 2>/dev/null || true
     docker cp soleur-inngest-bootstrap-extract:/inngest-redis-bootstrap.sh /tmp/inngest-redis-bootstrap.sh 2>/dev/null || true
     chmod +x /tmp/inngest-redis-bootstrap.sh 2>/dev/null || true
-    image_env=$(docker inspect ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.17 -f '{{range .Config.Env}}{{println .}}{{end}}')
+    image_env=$(docker inspect ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.18 -f '{{range .Config.Env}}{{println .}}{{end}}')
     chmod +x "$EXTRACT_DIR/inngest-bootstrap.sh"
     INNGEST_CLI_VERSION=$(printf '%s\n' "$image_env" | grep '^INNGEST_CLI_VERSION=' | head -1 | cut -d= -f2-)
     INNGEST_CLI_SHA256=$(printf '%s\n' "$image_env" | grep '^INNGEST_CLI_SHA256=' | head -1 | cut -d= -f2-)

--- a/apps/web-platform/infra/inngest.tf
+++ b/apps/web-platform/infra/inngest.tf
@@ -155,7 +155,15 @@ resource "doppler_secret" "inngest_redis_password_prd" {
   visibility = "masked"
 
   lifecycle {
-    ignore_changes = [value] # rotate via `terraform taint random_password.inngest_redis_password_prd`.
+    # ROTATE by replacing BOTH resources together (verified #5560):
+    #   terraform apply -replace=random_password.inngest_redis_password_prd \
+    #                   -replace=doppler_secret.inngest_redis_password_prd
+    # A lone `taint random_password` regenerates the value in tfstate but
+    # ignore_changes=[value] below SUPPRESSES the doppler_secret update, so Doppler
+    # (and the running inngest) keep the OLD password — an incomplete rotation.
+    # Re-creating the doppler_secret (the second -replace) writes the new value on
+    # create (ignore_changes applies to updates, not create). Redeploy inngest after.
+    ignore_changes = [value]
   }
 }
 


### PR DESCRIPTION
## Summary
Bumps the cloud-init fresh-host pin to `v1.1.18` (built from main / #5561 — durable secrets delivered via env, not argv). Running hosts get it via `deploy-inngest-image.yml -f tag=v1.1.18`, executed as the supervised rotation+redeploy op (#5560).

Also corrects the `INNGEST_REDIS_PASSWORD` rotation comment: a lone `terraform taint random_password` does NOT reach Doppler (the `doppler_secret` has `ignore_changes=[value]`); rotation needs `-replace` on BOTH resources — verified while executing #5560's Redis rotation.

## User-Brand Impact
- **If broken:** a fresh-host rebuild would bootstrap the wrong inngest image. No end-user UI surface (backend infra). Running hosts unaffected by the pin (they deploy via webhook).
- **Brand-survival threshold:** `aggregate pattern`.

## Test plan
- [x] `terraform fmt -check` clean; `inngest.test.sh` 71/71
- [x] v1.1.18 image build succeeded (GHCR)

Refs #5560 #5450

Generated with [Claude Code](https://claude.com/claude-code)