### PR TITLE
fix(shortcuts): help-overlay rows run their command, not just close

### DIFF
--- a/apps/web-platform/components/command-palette/help-overlay.tsx
+++ b/apps/web-platform/components/command-palette/help-overlay.tsx
@@ -9,16 +9,48 @@
 import { Command } from "cmdk";
 import { useShortcuts } from "./use-shortcuts";
 
-const SHORTCUTS: ReadonlyArray<{ keys: string; label: string }> = [
-  { keys: "⌘K", label: "Open command palette" },
-  { keys: "⌘/", label: "Open keyboard shortcuts (this overlay)" },
-  { keys: "?", label: "Open keyboard shortcuts" },
-  { keys: "⌘B", label: "Toggle sidebar" },
-  { keys: "Esc", label: "Close palette / overlay / drawer" },
+// Each row carries the action it performs, so selecting it (click or ↵) RUNS
+// the shortcut rather than only dismissing the overlay — the overlay doubles as
+// a clickable launcher, not just a cheat-sheet.
+type HelpAction = "palette" | "help" | "sidebar" | "close";
+
+const SHORTCUTS: ReadonlyArray<{
+  keys: string;
+  label: string;
+  action: HelpAction;
+}> = [
+  { keys: "⌘K", label: "Open command palette", action: "palette" },
+  { keys: "⌘/", label: "Open keyboard shortcuts (this overlay)", action: "help" },
+  { keys: "?", label: "Open keyboard shortcuts", action: "help" },
+  { keys: "⌘B", label: "Toggle sidebar", action: "sidebar" },
+  { keys: "Esc", label: "Close palette / overlay / drawer", action: "close" },
 ];
 
 export function HelpOverlay() {
-  const { enabled, helpOpen, closeHelp } = useShortcuts();
+  const { enabled, helpOpen, closeHelp, openPalette, runEffect } =
+    useShortcuts();
+
+  function runShortcut(action: HelpAction) {
+    switch (action) {
+      case "palette":
+        // Dismiss the overlay first so the palette opens as the top layer.
+        closeHelp();
+        openPalette();
+        break;
+      case "sidebar":
+        closeHelp();
+        runEffect({ kind: "toggleSidebar" });
+        break;
+      case "help":
+        // This overlay is already open — selecting its own row keeps it open
+        // (a no-op) rather than the confusing "open shortcuts → instantly close".
+        break;
+      case "close":
+        closeHelp();
+        break;
+    }
+  }
+
   if (!enabled) return null;
   return (
     <Command.Dialog
@@ -40,8 +72,9 @@ export function HelpOverlay() {
             <Command.Item
               key={s.keys + s.label}
               value={`${s.label} ${s.keys}`}
-              // Informational rows — selecting simply dismisses the overlay.
-              onSelect={() => closeHelp()}
+              // Selecting a row RUNS its shortcut (open palette / toggle sidebar
+              // / close), not just dismiss the overlay.
+              onSelect={() => runShortcut(s.action)}
               data-testid={`help-row-${s.keys}`}
             >
               <span className="cmdk-help-label">{s.label}</span>

--- a/apps/web-platform/test/help-overlay.test.tsx
+++ b/apps/web-platform/test/help-overlay.test.tsx
@@ -8,16 +8,44 @@ import {
 } from "@testing-library/react";
 import { ShortcutsProvider } from "@/components/command-palette/use-shortcuts";
 import { HelpOverlay } from "@/components/command-palette/help-overlay";
+import { CommandPalette } from "@/components/command-palette/command-palette";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
 }));
+vi.mock("@/lib/client-observability", () => ({ reportSilentFallback: vi.fn() }));
 
 function renderHelp() {
   return render(
     <ShortcutsProvider enabled isAdmin={false} onToggleSidebar={() => {}}>
       <input data-testid="outside-input" />
       <HelpOverlay />
+    </ShortcutsProvider>,
+  );
+}
+
+// For the "selecting a row runs the command" tests we mount the palette too, so
+// a row that opens the palette is observable. fetch is stubbed because the
+// palette lazy-fetches KB/routines on open.
+function renderHelpAndPalette(onToggleSidebar = () => {}) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          url.includes("/routines")
+            ? { routines: [] }
+            : { tree: { children: [] }, needsReconnect: false },
+      } as Response;
+    }),
+  );
+  return render(
+    <ShortcutsProvider enabled isAdmin={false} onToggleSidebar={onToggleSidebar}>
+      <HelpOverlay />
+      <CommandPalette />
     </ShortcutsProvider>,
   );
 }
@@ -74,6 +102,35 @@ describe("HelpOverlay", () => {
     renderHelp();
     const input = screen.getByTestId("outside-input");
     pressKey("?", { target: input });
+    expect(
+      screen.queryByLabelText("Search keyboard shortcuts"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("HelpOverlay — rows run their command (not just close)", () => {
+  it("selecting the ⌘K row opens the command palette and closes the overlay", async () => {
+    renderHelpAndPalette();
+    pressKey("/", { meta: true }); // open help overlay
+    await screen.findByLabelText("Search keyboard shortcuts");
+    fireEvent.click(screen.getByTestId("help-row-⌘K"));
+    // The command palette is now open…
+    expect(
+      await screen.findByLabelText("Command palette search"),
+    ).toBeInTheDocument();
+    // …and the help overlay closed.
+    expect(
+      screen.queryByLabelText("Search keyboard shortcuts"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("selecting the ⌘B row toggles the sidebar and closes the overlay", async () => {
+    const onToggleSidebar = vi.fn();
+    renderHelpAndPalette(onToggleSidebar);
+    pressKey("/", { meta: true });
+    await screen.findByLabelText("Search keyboard shortcuts");
+    fireEvent.click(screen.getByTestId("help-row-⌘B"));
+    expect(onToggleSidebar).toHaveBeenCalledTimes(1);
     expect(
       screen.queryByLabelText("Search keyboard shortcuts"),
     ).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

Follow-up to the command palette (#5635). In the `?` / `⌘/` help overlay, selecting a shortcut row (click or **Enter**) now **runs that shortcut** instead of only dismissing the overlay:

- **Open command palette** → closes the overlay and opens the ⌘K palette
- **Toggle sidebar** → closes the overlay and toggles the rail
- **Esc** → closes the overlay
- The two "open keyboard shortcuts" rows (⌘/, ?) are a no-op (the overlay is already open) rather than the confusing open→instant-close

## Changelog

### Web Platform
- Help-overlay rows are now actionable launchers: each carries its `HelpAction` and `onSelect` runs it via the shortcuts context (`openPalette` / `runEffect({kind:'toggleSidebar'})` / `closeHelp`).

## Test plan

- [x] New tests: selecting the ⌘K row opens the palette + closes the overlay; selecting the ⌘B row toggles the sidebar (spy ×1) + closes the overlay
- [x] Existing help-overlay / palette / registry tests still green
- [x] Full web-platform vitest suite: 10747 passed, 0 failed
- [x] `tsc --noEmit` clean

Generated with [Claude Code](https://claude.com/claude-code)