### PR TITLE
fix(web): branded loading row in the ⌘K palette (replace bare 'Searching…')

### DIFF
--- a/apps/web-platform/app/globals.css
+++ b/apps/web-platform/app/globals.css
@@ -309,6 +309,37 @@
   font-size: 0.85rem;
   color: var(--soleur-text-muted, #8a8a8a);
 }
+/* Branded loading row (CommandLoading): a gold ring spinner + contextual copy,
+ * matching the muted row rhythm so it reads as a quiet status, not a heading. */
+.cmdk-loading {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.625rem;
+  font-size: 0.85rem;
+  color: var(--soleur-text-muted, #8a8a8a);
+}
+.cmdk-loading-spinner {
+  width: 0.85rem;
+  height: 0.85rem;
+  flex-shrink: 0;
+  border-radius: 9999px;
+  border: 2px solid var(--soleur-border-default, #2a2a2a);
+  border-top-color: var(--soleur-accent-gold-fg, #c9a962);
+  animation: cmdk-spin 0.7s linear infinite;
+}
+@keyframes cmdk-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cmdk-loading-spinner {
+    animation: none;
+    /* No sweep: a static gold ring still reads as "in progress". */
+    border-top-color: var(--soleur-accent-gold-fg, #c9a962);
+  }
+}
 .cmdk-routine-row {
   display: flex;
   min-width: 0;

--- a/apps/web-platform/components/command-palette/command-palette.tsx
+++ b/apps/web-platform/components/command-palette/command-palette.tsx
@@ -140,7 +140,7 @@ export function CommandPalette() {
   }, []);
 
   // Lazy fetch ON DRILL-IN (not on open): the data loads only when the operator
-  // actually enters that sub-page. "Searching…" shows while in-flight.
+  // actually enters that sub-page. The CommandLoading row shows while in-flight.
   useEffect(() => {
     if (page === "kb" && kbState.phase === "idle") void loadKb();
     if (page === "workflows" && routinesState.phase === "idle")
@@ -338,7 +338,10 @@ export function CommandPalette() {
             <Command.Group heading="Knowledge Base">
               <BackRow onBack={() => goToPage(null)} />
               {kbState.phase === "loading" && (
-                <Command.Loading>Searching…</Command.Loading>
+                <CommandLoading
+                  label="Loading your knowledge base…"
+                  testId="cmd-kb-loading"
+                />
               )}
               {kbState.phase === "needsReconnect" && (
                 <Command.Item
@@ -391,7 +394,10 @@ export function CommandPalette() {
             <Command.Group heading="Workflows">
               <BackRow onBack={() => goToPage(null)} />
               {routinesState.phase === "loading" && (
-                <Command.Loading>Searching…</Command.Loading>
+                <CommandLoading
+                  label="Loading your workflows…"
+                  testId="cmd-routines-loading"
+                />
               )}
               {routinesState.phase === "error" && (
                 <Command.Item
@@ -471,6 +477,28 @@ function BackRow({ onBack }: { onBack: () => void }) {
     <Command.Item value="← back" onSelect={onBack} data-testid="cmd-back">
       <span className="cmdk-keys">‹ Back</span>
     </Command.Item>
+  );
+}
+
+// A branded, accessible loading row shown while a sub-page's list is being
+// fetched. Replaces the bare, unstyled "Searching…" (which rendered as
+// oversized white text, out of place against the muted rows): a gold ring
+// spinner + contextual copy, styled to match the cmdk row rhythm. The fetch is
+// a one-time list load on drill-in (cmdk then filters client-side as you type),
+// so the copy says "Loading …", not "Searching …".
+function CommandLoading({ label, testId }: { label: string; testId: string }) {
+  return (
+    <Command.Loading>
+      <div
+        className="cmdk-loading"
+        role="status"
+        aria-live="polite"
+        data-testid={testId}
+      >
+        <span className="cmdk-loading-spinner" aria-hidden="true" />
+        <span>{label}</span>
+      </div>
+    </Command.Loading>
   );
 }
 

--- a/apps/web-platform/test/command-palette.test.tsx
+++ b/apps/web-platform/test/command-palette.test.tsx
@@ -251,6 +251,37 @@ describe("CommandPalette — nested pages (submenus)", () => {
   });
 });
 
+describe("CommandPalette — loading state", () => {
+  it("shows a branded, contextual loading row while the KB tree is in flight", async () => {
+    // A fetch that never resolves so the loading phase stays observable.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+    renderPalette();
+    pressKey("k", { meta: true });
+    fireEvent.click(await screen.findByTestId("cmd-page-kb"));
+
+    const loading = await screen.findByTestId("cmd-kb-loading");
+    expect(loading).toHaveTextContent(/loading your knowledge base/i);
+    // The bare, unstyled "Searching…" is gone.
+    expect(screen.queryByText("Searching…")).toBeNull();
+  });
+
+  it("shows a contextual loading row while workflows are in flight", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+    renderPalette();
+    pressKey("k", { meta: true });
+    fireEvent.click(await screen.findByTestId("cmd-page-workflows"));
+
+    const loading = await screen.findByTestId("cmd-routines-loading");
+    expect(loading).toHaveTextContent(/loading your workflows/i);
+  });
+});
+
 describe("CommandPalette — KB error states", () => {
   it("renders a reconnect row on needsReconnect inside the KB page", async () => {
     vi.stubGlobal(


### PR DESCRIPTION
## Better loading message + design for the ⌘K command palette

The Knowledge Base / Workflows sub-pages rendered an unstyled `<Command.Loading>Searching…</Command.Loading>` — oversized white text, out of place against the muted rows (see the reported screenshot). "Searching…" was also inaccurate: drilling in does a **one-time list load** (cmdk filters client-side after), nothing is searched server-side.

### Change
- **Copy:** `Searching…` → **"Loading your knowledge base…"** / **"Loading your workflows…"** (accurate + contextual).
- **Design:** a new `CommandLoading` row — a **gold ring spinner** (brand `--soleur-accent-gold-fg`) + the message, styled to the cmdk row rhythm (muted color, row padding) so it reads as a quiet status, not a heading.
- **A11y:** `role="status"` + `aria-live="polite"`; a `prefers-reduced-motion` fallback renders a static gold ring (no sweep).

### Verification
- `tsc --noEmit` clean.
- Full command-palette suite **17/17** green, including 2 new loading-state tests (deferred fetch → asserts the branded row + new copy is shown).

Pure client-side UI polish — no API/schema/data surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)