### PR TITLE
feat(web): nest Settings as a ⌘K palette drill-in (not flat in the root)

### DIFF
--- a/apps/web-platform/components/command-palette/command-palette.tsx
+++ b/apps/web-platform/components/command-palette/command-palette.tsx
@@ -47,7 +47,7 @@ interface KbDoc {
 }
 
 // Which nested page is open. `null` = root menu.
-type Page = null | "kb" | "workflows";
+type Page = null | "kb" | "workflows" | "settings";
 
 function humanizeFnId(fnId: string): string {
   const s = fnId.replace(/^cron-/, "").replace(/-/g, " ");
@@ -208,6 +208,7 @@ export function CommandPalette() {
 
   const statics = buildCommands({ isAdmin });
   const navCmds = statics.filter((c) => c.group === "Navigation");
+  const settingsCmds = statics.filter((c) => c.group === "Settings");
   const askCmd = statics.find((c) => c.id === "ask-agent");
   const generalCmds = statics.filter((c) => c.group === "General");
   const trimmed = query.trim();
@@ -221,7 +222,9 @@ export function CommandPalette() {
       ? "Search knowledge base…"
       : page === "workflows"
         ? "Search workflows…"
-        : "Search commands… (Knowledge Base · Workflows)";
+        : page === "settings"
+          ? "Search settings…"
+          : "Search commands… (Knowledge Base · Workflows · Settings)";
 
   return (
     <>
@@ -315,6 +318,14 @@ export function CommandPalette() {
                 >
                   <span>Workflows</span>
                   <span className="cmdk-keys">Run a routine ›</span>
+                </Command.Item>
+                <Command.Item
+                  value="settings account team billing audit preferences browse"
+                  onSelect={() => goToPage("settings")}
+                  data-testid="cmd-page-settings"
+                >
+                  <span>Settings</span>
+                  <span className="cmdk-keys">Account & team ›</span>
                 </Command.Item>
               </Command.Group>
 
@@ -452,6 +463,23 @@ export function CommandPalette() {
                     )}
                   </Command.Item>
                 ))}
+            </Command.Group>
+          )}
+
+          {/* ---- SETTINGS SUB-PAGE ---------------------------------------- */}
+          {page === "settings" && (
+            <Command.Group heading="Settings">
+              <BackRow onBack={() => goToPage(null)} />
+              {settingsCmds.map((cmd) => (
+                <Command.Item
+                  key={cmd.id}
+                  value={cmd.label}
+                  onSelect={() => onSelectCommand(cmd)}
+                  data-testid={`cmd-settings-${cmd.id}`}
+                >
+                  {cmd.label}
+                </Command.Item>
+              ))}
             </Command.Group>
           )}
         </Command.List>

--- a/apps/web-platform/components/command-palette/nav-items.ts
+++ b/apps/web-platform/components/command-palette/nav-items.ts
@@ -21,12 +21,12 @@ export const ADMIN_NAV_ITEMS: readonly NavItem[] = [
   { href: "/dashboard/admin/analytics", label: "Analytics" },
 ] as const;
 
-// Destinations reachable from the palette that are NOT in the rail's primary
-// nav (footer/secondary surfaces). Kept here so the palette's navigation group
-// is dense without duplicating literals across components.
-export const SECONDARY_NAV_ITEMS: readonly NavItem[] = [
-  { href: "/dashboard/settings", label: "Settings" },
-  { href: "/dashboard/settings/team", label: "Team Settings" },
+// Settings destinations — surfaced under the palette's "Settings" drill-in
+// sub-page (NOT flat in the root command list), so the root stays scannable and
+// Settings reads like Knowledge Base / Workflows: click in to see the items.
+export const SETTINGS_NAV_ITEMS: readonly NavItem[] = [
+  { href: "/dashboard/settings", label: "All settings" },
+  { href: "/dashboard/settings/team", label: "Team" },
   { href: "/dashboard/billing", label: "Billing" },
-  { href: "/dashboard/audit", label: "Audit Log" },
+  { href: "/dashboard/audit", label: "Audit log" },
 ] as const;

--- a/apps/web-platform/components/command-palette/use-shortcuts.tsx
+++ b/apps/web-platform/components/command-palette/use-shortcuts.tsx
@@ -20,6 +20,7 @@ export type CommandGroup =
   | "Ask an agent"
   | "Knowledge Base"
   | "Workflows"
+  | "Settings"
   | "General";
 
 export type ShortcutContext = {
@@ -112,7 +113,7 @@ export function writeShortcutsEnabled(enabled: boolean): void {
   }
 }
 
-import { NAV_ITEMS, ADMIN_NAV_ITEMS, SECONDARY_NAV_ITEMS } from "./nav-items";
+import { NAV_ITEMS, ADMIN_NAV_ITEMS, SETTINGS_NAV_ITEMS } from "./nav-items";
 
 /**
  * The static command registry (navigation + hero actions). Routine and KB-doc
@@ -120,7 +121,10 @@ import { NAV_ITEMS, ADMIN_NAV_ITEMS, SECONDARY_NAV_ITEMS } from "./nav-items";
  * component — they are not part of this synchronous static set.
  */
 export function buildCommands(ctx: ShortcutContext): Command[] {
-  const nav: Command[] = [...NAV_ITEMS, ...SECONDARY_NAV_ITEMS, ...(ctx.isAdmin ? ADMIN_NAV_ITEMS : [])].map(
+  // Primary nav + admin stay in the root "Navigation" group. Settings
+  // destinations get their OWN "Settings" group, surfaced behind the palette's
+  // Settings drill-in sub-page (not flat in the root) — see command-palette.tsx.
+  const nav: Command[] = [...NAV_ITEMS, ...(ctx.isAdmin ? ADMIN_NAV_ITEMS : [])].map(
     (item) => ({
       id: `nav:${item.href}`,
       label: item.label,
@@ -128,6 +132,13 @@ export function buildCommands(ctx: ShortcutContext): Command[] {
       run: () => ({ kind: "navigate" as const, href: item.href }),
     }),
   );
+
+  const settings: Command[] = SETTINGS_NAV_ITEMS.map((item) => ({
+    id: `settings:${item.href}`,
+    label: item.label,
+    group: "Settings" as const,
+    run: () => ({ kind: "navigate" as const, href: item.href }),
+  }));
 
   const actions: Command[] = [
     {
@@ -153,7 +164,7 @@ export function buildCommands(ctx: ShortcutContext): Command[] {
     },
   ];
 
-  return [...nav, ...actions];
+  return [...nav, ...settings, ...actions];
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web-platform/test/command-palette.test.tsx
+++ b/apps/web-platform/test/command-palette.test.tsx
@@ -201,7 +201,9 @@ describe("CommandPalette — empty state", () => {
 // Render, open the palette, and drill into a nested sub-page via its parent
 // entry. (Callers stub a custom fetch BEFORE calling this; the drill triggers
 // the lazy fetch, so the stub must already be in place.)
-async function openAndDrill(parentTestId: "cmd-page-kb" | "cmd-page-workflows") {
+async function openAndDrill(
+  parentTestId: "cmd-page-kb" | "cmd-page-workflows" | "cmd-page-settings",
+) {
   renderPalette();
   pressKey("k", { meta: true });
   await screen.findByLabelText("Command palette search");
@@ -239,6 +241,36 @@ describe("CommandPalette — nested pages (submenus)", () => {
     expect(
       screen.getByTestId("cmd-run-cron-content-publisher"),
     ).toBeInTheDocument();
+  });
+
+  it("shows Settings as a single drill-in entry, with the settings items NOT flat on the root", async () => {
+    renderPalette();
+    pressKey("k", { meta: true });
+    await screen.findByLabelText("Command palette search");
+    // The Settings drill trigger is present on the root…
+    expect(screen.getByTestId("cmd-page-settings")).toBeInTheDocument();
+    // …but the individual settings destinations are NOT flat on the root.
+    expect(screen.queryByText("All settings")).not.toBeInTheDocument();
+    expect(screen.queryByText("Billing")).not.toBeInTheDocument();
+    expect(screen.queryByText("Audit log")).not.toBeInTheDocument();
+  });
+
+  it("drills into Settings on Enter/click and lists the settings items", async () => {
+    await openAndDrill("cmd-page-settings");
+    expect(
+      await screen.findByTestId("cmd-settings-settings:/dashboard/settings"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("All settings")).toBeInTheDocument();
+    expect(screen.getByText("Team")).toBeInTheDocument();
+    expect(screen.getByText("Billing")).toBeInTheDocument();
+    expect(screen.getByText("Audit log")).toBeInTheDocument();
+    expect(screen.getByTestId("cmd-back")).toBeInTheDocument();
+  });
+
+  it("navigates to a settings destination on select", async () => {
+    await openAndDrill("cmd-page-settings");
+    fireEvent.click(await screen.findByText("Team"));
+    expect(routerPush).toHaveBeenCalledWith("/dashboard/settings/team");
   });
 
   it("returns to the root menu via the Back row", async () => {


### PR DESCRIPTION
## Settings becomes a drill-in, like Knowledge Base / Workflows

The settings destinations (All settings, Team, Billing, Audit log) were listed **flat in the palette root** alongside the primary nav. Now they live behind a **Settings** entry in the Browse group — you click Settings to see them, exactly like Knowledge Base and Workflows. They no longer clutter the root or match the root search.

### Before → After
- **Root Browse group:** Knowledge Base › · Workflows › · **Settings › (Account & team)** ← new
- **Settings sub-page** (drill in): All settings · Team · Billing · Audit log + a Back row
- Settings items are no longer mounted at the root, so the root search stays focused on commands/nav (same model as KB docs / routines — you drill in first).

### Changes
- `nav-items.ts`: `SECONDARY_NAV_ITEMS` → `SETTINGS_NAV_ITEMS` (own group, clearer in-context labels).
- `use-shortcuts.tsx`: settings commands get `group: "Settings"` (removed from the root `"Navigation"` flatten).
- `command-palette.tsx`: new `page="settings"` sub-page + a Settings Browse drill entry + `"Search settings…"` placeholder.

### Verification
- `tsc --noEmit` clean.
- Full web-platform vitest suite **869 files / 10756 tests** green, incl. 3 new tests (Settings drill trigger present + items NOT flat on root; drill lists the items; select navigates).

Pure client-side UI restructure — no API/schema/data surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)