### PR TITLE
fix(web): Workstream columns — emptiness alone drives open/closed

### DIFF
--- a/apps/web-platform/components/workstream/issue-column.tsx
+++ b/apps/web-platform/components/workstream/issue-column.tsx
@@ -5,17 +5,15 @@
 // behind the cards, NOT a saturated block). Addendum item 2: the count is a
 // small rounded pill, right-aligned and typographically de-emphasized.
 //
-// Collapsible (v3): a SINGLE persistent <section> whose width class toggles
-// (w-72 ↔ w-10) with a real transition-[width] animation — a conditional-render
-// swap would NOT animate (no prior committed frame; learning 2026-06-09 / SE1).
-// Only ONE control button exists at a time (Collapse when expanded / Expand when
-// collapsed). Inner content fades in via a rAF mount-reveal. Collapsed state is
-// owned by the board (persisted in localStorage).
-//
-// Empty rule (v4): a column with 0 issues renders COLLAPSED by default — a thin
-// strip with the dot, a 0 count, and the vertical label, and NO toggle (you
-// cannot expand an empty column). The persisted collapsed flag is left untouched
-// while empty, so a populated column's prior choice re-applies on repopulate.
+// Collapse rule (v5): a column's open/closed state is driven SOLELY by whether
+// it has content. A column with content is ALWAYS expanded; a column with 0
+// issues is ALWAYS collapsed (a thin w-10 strip with the dot, a 0 count, the
+// vertical label, and an sr-only "No issues"). There is NO manual collapse
+// toggle and no persisted state — emptiness is the only input. The width toggles
+// (w-72 ↔ w-10) on a SINGLE persistent <section> with a real transition-[width]
+// animation so filtering a column to/from empty glides rather than snapping (a
+// conditional-render swap would NOT animate — learning 2026-06-09 / SE1). Inner
+// content fades in via a rAF mount-reveal.
 //
 // Render cap: at most COLUMN_RENDER_CAP cards render; beyond that the exact
 // COLUMN_CAP_NOTICE shows at the column bottom. The count pill always shows the
@@ -28,9 +26,7 @@ import {
   COLUMN_RENDER_CAP,
   type ColumnConfig,
   type WorkstreamIssue,
-  type WorkstreamStatus,
 } from "@/lib/workstream";
-import { ChevronDownIcon } from "@/components/icons";
 import { IssueCard } from "./issue-card";
 
 // ~15% accent wash — a visible soft tint behind the cards, not a saturated
@@ -38,12 +34,9 @@ import { IssueCard } from "./issue-card";
 // hex 0x26 = 38/255 ≈ 15% (tunable band 0x1f–0x33).
 const COLUMN_TINT_ALPHA = "26";
 
-const TOGGLE_BTN_CLASS =
-  "flex h-5 w-5 items-center justify-center rounded-md text-soleur-text-tertiary transition-colors hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary focus-visible:bg-soleur-bg-surface-2 focus-visible:text-soleur-text-primary focus-visible:outline-none";
-
 /** Fades its children in on mount (opacity 0→1 via a rAF state flip). Pairs with
- *  the persistent-section width transition so collapsing/expanding glides rather
- *  than snapping. `motion-reduce` makes it instant. */
+ *  the persistent-section width transition so a column gliding to/from its
+ *  collapsed strip fades rather than snapping. `motion-reduce` makes it instant. */
 function MountReveal({ children }: { children: React.ReactNode }) {
   const [shown, setShown] = useState(false);
   useEffect(() => {
@@ -65,22 +58,15 @@ export function IssueColumn({
   column,
   issues,
   onOpen,
-  collapsed = false,
-  onToggleCollapse,
 }: {
   column: ColumnConfig;
   issues: WorkstreamIssue[];
   onOpen: (id: string) => void;
-  collapsed?: boolean;
-  onToggleCollapse?: (status: WorkstreamStatus) => void;
 }) {
   const isEmpty = issues.length === 0;
-  // Empty columns render COLLAPSED by default (a thin strip), regardless of the
-  // persisted flag; a populated column honors the user's persisted choice.
-  // INVARIANT: isEmpty ⇒ isCollapsed, so the expanded branch never sees an empty
-  // column (relied on below — do not add empty-handling to that branch without
-  // re-checking this line).
-  const isCollapsed = isEmpty || collapsed;
+  // Emptiness is the SOLE driver: content ⇒ open, empty ⇒ collapsed. No manual
+  // toggle, no persisted state.
+  const isCollapsed = isEmpty;
   const tint = { backgroundColor: `${column.accent}${COLUMN_TINT_ALPHA}` };
   const overCap = issues.length > COLUMN_RENDER_CAP;
 
@@ -95,32 +81,18 @@ export function IssueColumn({
       {isCollapsed ? (
         <MountReveal key="collapsed">
           <div className="flex flex-col items-center">
-            {/* Empty columns have NO toggle — you cannot expand an empty column.
-                Only a user-collapsed NON-empty strip gets the Expand chevron. */}
-            {!isEmpty ? (
-              <button
-                type="button"
-                aria-label={`Expand ${column.label}`}
-                aria-expanded={false}
-                onClick={() => onToggleCollapse?.(column.status)}
-                className={TOGGLE_BTN_CLASS}
-              >
-                {/* Down chevron rotated −90° points right = "expand". */}
-                <ChevronDownIcon className="h-3.5 w-3.5 -rotate-90" />
-              </button>
-            ) : null}
-            {/* Keep the empty state announced after the visible "No issues" text
-                is gone — a bare "0" count alone is ambiguous to a screen reader.
-                When empty, the sr-only text is the canonical announcement and the
-                visible "0" pill is aria-hidden so SRs don't hear "No issues, 0". */}
-            {isEmpty ? <span className="sr-only">No issues</span> : null}
+            {/* Empty strip: the sr-only text is the canonical empty announcement
+                so a screen reader doesn't hear a bare, ambiguous "0"; the visible
+                "0" pill is aria-hidden. There is no toggle — an empty column
+                cannot be expanded. */}
+            <span className="sr-only">No issues</span>
             <span
               aria-hidden="true"
-              className="mt-2 h-2 w-2 rounded-full"
+              className="h-2 w-2 rounded-full"
               style={{ backgroundColor: column.accent }}
             />
             <span
-              aria-hidden={isEmpty ? true : undefined}
+              aria-hidden="true"
               className="mt-2 rounded-md bg-soleur-bg-surface-2 px-1.5 py-0.5 text-[11px] font-medium text-soleur-text-tertiary"
             >
               {issues.length}
@@ -136,19 +108,6 @@ export function IssueColumn({
       ) : (
         <MountReveal key="expanded">
           <header className="flex items-center gap-2 px-1 py-2">
-            {/* The expanded branch only renders for NON-empty columns
-                (INVARIANT: isEmpty ⇒ isCollapsed), so the Collapse toggle is
-                always present here. */}
-            <button
-              type="button"
-              aria-label={`Collapse ${column.label}`}
-              aria-expanded={true}
-              onClick={() => onToggleCollapse?.(column.status)}
-              className={TOGGLE_BTN_CLASS}
-            >
-              {/* Down chevron = "collapse". */}
-              <ChevronDownIcon className="h-3.5 w-3.5" />
-            </button>
             <span
               aria-hidden="true"
               className="h-2 w-2 rounded-full"

--- a/apps/web-platform/components/workstream/workstream-board.tsx
+++ b/apps/web-platform/components/workstream/workstream-board.tsx
@@ -29,6 +29,8 @@ import {
   type WorkstreamIssue,
   type WorkstreamStatus,
 } from "@/lib/workstream";
+// Column open/closed is driven SOLELY by emptiness in IssueColumn (content ⇒
+// open, empty ⇒ collapsed). The board owns no collapse state and no persistence.
 import { jsonFetcher, swrKeys } from "@/lib/swr-config";
 import { ErrorCard } from "@/components/ui/error-card";
 import { GoldButton } from "@/components/ui/gold-button";
@@ -39,21 +41,6 @@ import { IssueDetailSheet } from "./issue-detail-sheet";
 import { NewIssueDialog } from "./new-issue-dialog";
 
 type IssuesResponse = { issues: WorkstreamIssue[] };
-
-const COLLAPSED_STORAGE_KEY = "workstream:collapsed-columns";
-
-function readCollapsedColumns(): Set<WorkstreamStatus> {
-  try {
-    const raw = window.localStorage.getItem(COLLAPSED_STORAGE_KEY);
-    if (!raw) return new Set();
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) return new Set();
-    return new Set(parsed as WorkstreamStatus[]);
-  } catch {
-    // private mode / quota / malformed — degrade to "nothing collapsed".
-    return new Set();
-  }
-}
 
 export function WorkstreamBoard() {
   const pathname = usePathname();
@@ -68,15 +55,6 @@ export function WorkstreamBoard() {
   const [activeId, setActiveId] = useState<string | null>(() =>
     searchParams.get("issue"),
   );
-
-  // Collapsed columns (persisted in localStorage). SSR-safe: read in an effect,
-  // never during render.
-  const [collapsed, setCollapsed] = useState<Set<WorkstreamStatus>>(
-    () => new Set(),
-  );
-  useEffect(() => {
-    setCollapsed(readCollapsedColumns());
-  }, []);
 
   // Reconcile the drawer with the URL on Back/Forward (and deep-link history).
   useEffect(() => {
@@ -173,23 +151,6 @@ export function WorkstreamBoard() {
       /* history unavailable — local state still drives the drawer */
     }
   }, [pathname]);
-
-  const toggleCollapse = useCallback((status: WorkstreamStatus) => {
-    setCollapsed((prev) => {
-      const next = new Set(prev);
-      if (next.has(status)) next.delete(status);
-      else next.add(status);
-      try {
-        window.localStorage.setItem(
-          COLLAPSED_STORAGE_KEY,
-          JSON.stringify([...next]),
-        );
-      } catch {
-        /* localStorage unavailable — in-memory toggle still works this session */
-      }
-      return next;
-    });
-  }, []);
 
   // Faceted filter options derive from the FULL loaded set (stable, no thrash).
   const filterOptions = useMemo(
@@ -299,8 +260,6 @@ export function WorkstreamBoard() {
               column={column}
               issues={filtered.filter((i) => i.status === column.status)}
               onOpen={openIssue}
-              collapsed={collapsed.has(column.status)}
-              onToggleCollapse={toggleCollapse}
             />
           ))}
         </div>

--- a/apps/web-platform/test/components/workstream/issue-column.test.tsx
+++ b/apps/web-platform/test/components/workstream/issue-column.test.tsx
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
 import {
   COLUMN_CAP_NOTICE,
   type ColumnConfig,
@@ -7,9 +7,9 @@ import {
 } from "@/lib/workstream";
 import { IssueColumn } from "@/components/workstream/issue-column";
 
-// Visual-polish coverage (PR follow-up to #5659): the glyph→icon swap and the
-// raised column tint. The collapse/persist behaviour itself is covered by
-// workstream-board.test.tsx (queries by aria-label, which this change preserves).
+// Collapse is driven SOLELY by emptiness (v5): content ⇒ expanded, empty ⇒
+// collapsed strip. There is no manual collapse/expand toggle and no persisted
+// state — so a content column is ALWAYS open and an empty one ALWAYS collapsed.
 
 const column: ColumnConfig = {
   status: "backlog",
@@ -33,107 +33,30 @@ function issue(over: Partial<WorkstreamIssue> = {}): WorkstreamIssue {
 
 afterEach(() => cleanup());
 
-describe("IssueColumn — collapse icon-button", () => {
-  it("expanded: renders a Collapse button with aria-expanded=true and an <svg> icon (not a bare glyph)", () => {
-    render(
-      <IssueColumn column={column} issues={[issue()]} onOpen={() => {}} />,
-    );
-    const btn = screen.getByRole("button", { name: "Collapse Backlog" });
-    expect(btn.getAttribute("aria-expanded")).toBe("true");
-    expect(btn.querySelector("svg")).toBeTruthy();
-    expect(btn.textContent).not.toContain("⌄");
-  });
-
-  it("collapsed: renders an Expand button with aria-expanded=false and an <svg> icon (not a bare glyph)", () => {
-    render(
-      <IssueColumn
-        column={column}
-        issues={[issue()]}
-        onOpen={() => {}}
-        collapsed
-        onToggleCollapse={() => {}}
-      />,
-    );
-    const btn = screen.getByRole("button", { name: "Expand Backlog" });
-    expect(btn.getAttribute("aria-expanded")).toBe("false");
-    expect(btn.querySelector("svg")).toBeTruthy();
-    expect(btn.textContent).not.toContain("›");
-  });
-
-  it("clicking the toggle calls onToggleCollapse with the column status", () => {
-    const onToggleCollapse = vi.fn();
-    render(
-      <IssueColumn
-        column={column}
-        issues={[issue()]}
-        onOpen={() => {}}
-        onToggleCollapse={onToggleCollapse}
-      />,
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Collapse Backlog" }));
-    expect(onToggleCollapse).toHaveBeenCalledTimes(1);
-    expect(onToggleCollapse).toHaveBeenCalledWith("backlog");
-  });
-});
-
-describe("IssueColumn — visible column tint", () => {
-  it("expanded: section backgroundColor carries the accent with a non-0d alpha", () => {
+describe("IssueColumn — emptiness drives open/closed; no manual toggle", () => {
+  it("a column WITH content is always expanded (w-72) and renders no collapse/expand toggle", () => {
     const { container } = render(
       <IssueColumn column={column} issues={[issue()]} onOpen={() => {}} />,
     );
-    const section = container.querySelector("section");
-    const bg = section?.getAttribute("style") ?? "";
-    // The accent must be present, but NOT at the old ~5% (0d) alpha.
-    expect(bg.toLowerCase()).not.toContain("#9aa3b20d");
-    expect(bg.toLowerCase()).toContain("#9aa3b2");
+    const cls = container.querySelector("section")?.getAttribute("class") ?? "";
+    expect(cls).toContain("w-72");
+    expect(cls).not.toContain("w-10");
+    // No toggle buttons exist at all anymore.
+    expect(screen.queryByRole("button", { name: "Collapse Backlog" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Expand Backlog" })).toBeNull();
+    // The card itself is still rendered.
+    expect(screen.getByText("Seed issue")).toBeTruthy();
   });
 
-  it("collapsed: section backgroundColor carries the same raised alpha (lockstep)", () => {
-    const { container } = render(
-      <IssueColumn
-        column={column}
-        issues={[issue()]}
-        onOpen={() => {}}
-        collapsed
-        onToggleCollapse={() => {}}
-      />,
-    );
-    const section = container.querySelector("section");
-    const bg = section?.getAttribute("style") ?? "";
-    expect(bg.toLowerCase()).not.toContain("#9aa3b20d");
-    expect(bg.toLowerCase()).toContain("#9aa3b2");
-  });
-});
-
-describe("IssueColumn — empty column collapses by default", () => {
-  it("an empty column (collapsed flag unset) renders the collapsed strip with no toggle", () => {
+  it("an empty column is always collapsed to the w-10 strip with no toggle", () => {
     const { container } = render(
       <IssueColumn column={column} issues={[]} onOpen={() => {}} />,
     );
-    // No toggle in either direction.
-    expect(screen.queryByRole("button", { name: "Collapse Backlog" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Expand Backlog" })).toBeNull();
-    // It collapsed: the section is the w-10 strip, not the w-72 card list.
     const cls = container.querySelector("section")?.getAttribute("class") ?? "";
     expect(cls).toContain("w-10");
     expect(cls).not.toContain("w-72");
-  });
-
-  it("an empty column ignores collapsed=true the same way — still a collapsed strip, no toggle", () => {
-    const { container } = render(
-      <IssueColumn
-        column={column}
-        issues={[]}
-        onOpen={() => {}}
-        collapsed
-        onToggleCollapse={() => {}}
-      />,
-    );
-    expect(screen.queryByRole("button", { name: "Expand Backlog" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Collapse Backlog" })).toBeNull();
-    const cls = container.querySelector("section")?.getAttribute("class") ?? "";
-    expect(cls).toContain("w-10");
-    expect(cls).not.toContain("w-72");
+    expect(screen.queryByRole("button", { name: "Expand Backlog" })).toBeNull();
   });
 
   it("the empty collapsed strip shows the 0 count pill and the column label", () => {
@@ -148,24 +71,25 @@ describe("IssueColumn — empty column collapses by default", () => {
   });
 });
 
-describe("IssueColumn — one control at a time (cross-fade regression lock)", () => {
-  it("expanded: the Expand button is ABSENT", () => {
-    render(<IssueColumn column={column} issues={[issue()]} onOpen={() => {}} />);
-    expect(screen.getByRole("button", { name: "Collapse Backlog" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Expand Backlog" })).toBeNull();
-  });
-  it("collapsed: the Collapse button is ABSENT", () => {
-    render(
-      <IssueColumn
-        column={column}
-        issues={[issue()]}
-        onOpen={() => {}}
-        collapsed
-        onToggleCollapse={() => {}}
-      />,
+describe("IssueColumn — visible column tint (both states)", () => {
+  it("content/expanded: section backgroundColor carries the accent with a non-0d alpha", () => {
+    const { container } = render(
+      <IssueColumn column={column} issues={[issue()]} onOpen={() => {}} />,
     );
-    expect(screen.getByRole("button", { name: "Expand Backlog" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Collapse Backlog" })).toBeNull();
+    const bg =
+      container.querySelector("section")?.getAttribute("style") ?? "";
+    expect(bg.toLowerCase()).not.toContain("#9aa3b20d");
+    expect(bg.toLowerCase()).toContain("#9aa3b2");
+  });
+
+  it("empty/collapsed: section backgroundColor carries the same raised alpha (lockstep)", () => {
+    const { container } = render(
+      <IssueColumn column={column} issues={[]} onOpen={() => {}} />,
+    );
+    const bg =
+      container.querySelector("section")?.getAttribute("style") ?? "";
+    expect(bg.toLowerCase()).not.toContain("#9aa3b20d");
+    expect(bg.toLowerCase()).toContain("#9aa3b2");
   });
 });
 
@@ -176,7 +100,8 @@ describe("IssueColumn — 200 render cap", () => {
     );
   }
   function cardCount(container: HTMLElement): number {
-    // Card roots are <button> with NO aria-label; the toggle button HAS one.
+    // Card roots are <button> with NO aria-label (and there are no toggle
+    // buttons anymore), so every button is a card.
     return [...container.querySelectorAll("button")].filter(
       (b) => b.getAttribute("aria-label") === null,
     ).length;

--- a/apps/web-platform/test/components/workstream/workstream-board.test.tsx
+++ b/apps/web-platform/test/components/workstream/workstream-board.test.tsx
@@ -330,30 +330,7 @@ describe("WorkstreamBoard", () => {
     );
   });
 
-  it("collapses a column to a strip and persists the choice in localStorage", async () => {
-    global.fetch = mockFetchOnce([
-      issue({ id: "SOLAA-1", title: "Card one" }),
-    ]) as unknown as typeof fetch;
-
-    render(<Wrapped />);
-    await waitFor(() => expect(screen.getByText("Card one")).toBeTruthy());
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Collapse Backlog" }),
-    );
-    // Now an Expand control is present (collapsed strip state).
-    await waitFor(() =>
-      expect(
-        screen.getByRole("button", { name: "Expand Backlog" }),
-      ).toBeTruthy(),
-    );
-    const stored = JSON.parse(
-      window.localStorage.getItem("workstream:collapsed-columns") ?? "[]",
-    ) as string[];
-    expect(stored).toContain("backlog");
-  });
-
-  it("renders a sibling empty column as a collapsed strip with no toggle", async () => {
+  it("content columns are expanded with no toggle; empty siblings collapse to a strip", async () => {
     // Only Backlog has an issue; the other 6 columns are empty.
     global.fetch = mockFetchOnce([
       issue({ id: "SOLAA-1", title: "Card one", status: "backlog" }),
@@ -362,8 +339,11 @@ describe("WorkstreamBoard", () => {
     const { container } = render(<Wrapped />);
     await waitFor(() => expect(screen.getByText("Card one")).toBeTruthy());
 
-    // Backlog (non-empty) stays expanded with a working Collapse toggle.
-    expect(screen.getByRole("button", { name: "Collapse Backlog" })).toBeTruthy();
+    // Backlog (content) is expanded (w-72) and carries NO collapse toggle.
+    const backlog = container.querySelector('section[aria-label="Backlog"]');
+    expect(backlog?.getAttribute("class") ?? "").toContain("w-72");
+    expect(screen.queryByRole("button", { name: "Collapse Backlog" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Expand Backlog" })).toBeNull();
 
     // Todo (empty) renders as a w-10 collapsed strip and has no toggle.
     const todo = container.querySelector('section[aria-label="Todo"]');


### PR DESCRIPTION
## Summary
Fixes a bug where content columns could render collapsed. On the Workstream board, a column's open/closed state is now driven **solely by whether it has content**: content columns are **always expanded**, empty columns are **always collapsed** to a thin strip. The previous behavior persisted a per-column collapse choice in localStorage, so columns like **Done (129)** and **Cancelled (1)** showed as collapsed strips — contradicting "content open by default, empty closed by default."

## Changelog
### Web Platform
- Workstream kanban: `isCollapsed = isEmpty` — content ⇒ open, empty ⇒ collapsed, with no manual toggle and no saved state.
- Removed the per-column collapse/expand toggle buttons, the `workstream:collapsed-columns` localStorage persistence, and the board-level collapse handler (reverts the manual-collapse machinery from #5659/#5660/#5661 in favor of pure emptiness-driven behavior).
- Empty strips keep the colored dot, `0` count, vertical label, and `sr-only` "No issues"; the width `transition-[width]` still animates a column gliding to/from its strip on filter/search.

## Test plan
- [x] `vitest run test/components/workstream/` — 42 passed (content ⇒ w-72/no-toggle, empty ⇒ w-10 strip/no-toggle, 0-count, sr-only, board sibling-empty; dropped obsolete toggle/persist tests)
- [x] Full `apps/web-platform` vitest suite — 10,857 passed, 0 failed
- [x] `tsc --noEmit` clean
- [x] Stale-reference sweep: no `onToggleCollapse`/`workstream:collapsed-columns` refs remain (sidebar collapse in layout.tsx is unrelated)

Generated with [Claude Code](https://claude.com/claude-code)