### PR TITLE
feat(web): Workstream — collapse any content column (open by default)

### DIFF
--- a/apps/web-platform/components/workstream/issue-column.tsx
+++ b/apps/web-platform/components/workstream/issue-column.tsx
@@ -5,15 +5,21 @@
 // behind the cards, NOT a saturated block). Addendum item 2: the count is a
 // small rounded pill, right-aligned and typographically de-emphasized.
 //
-// Collapse rule (v5): a column's open/closed state is driven SOLELY by whether
-// it has content. A column with content is ALWAYS expanded; a column with 0
-// issues is ALWAYS collapsed (a thin w-10 strip with the dot, a 0 count, the
-// vertical label, and an sr-only "No issues"). There is NO manual collapse
-// toggle and no persisted state — emptiness is the only input. The width toggles
-// (w-72 ↔ w-10) on a SINGLE persistent <section> with a real transition-[width]
-// animation so filtering a column to/from empty glides rather than snapping (a
-// conditional-render swap would NOT animate — learning 2026-06-09 / SE1). Inner
-// content fades in via a rAF mount-reveal.
+// Collapsible (v6): a SINGLE persistent <section> whose width class toggles
+// (w-72 ↔ w-10) with a real transition-[width] animation — a conditional-render
+// swap would NOT animate (no prior committed frame; learning 2026-06-09 / SE1).
+// Only ONE control button exists at a time (Collapse when expanded / Expand when
+// collapsed). Inner content fades in via a rAF mount-reveal. The board owns the
+// persisted collapse choice.
+//
+// Default + override rule (v6):
+//   - A column WITH content is OPEN by default and CAN be collapsed by the user
+//     (Collapse toggle → persisted strip with an Expand toggle to reopen).
+//   - A column with 0 issues is COLLAPSED by default and has NO toggle (there is
+//     nothing to expand to). The persisted flag is left untouched while empty, so
+//     a column's prior choice re-applies once it repopulates.
+//   isCollapsed = isEmpty || collapsed  — empty forces the strip; otherwise the
+//   user's persisted choice decides.
 //
 // Render cap: at most COLUMN_RENDER_CAP cards render; beyond that the exact
 // COLUMN_CAP_NOTICE shows at the column bottom. The count pill always shows the
@@ -26,7 +32,9 @@ import {
   COLUMN_RENDER_CAP,
   type ColumnConfig,
   type WorkstreamIssue,
+  type WorkstreamStatus,
 } from "@/lib/workstream";
+import { ChevronDownIcon } from "@/components/icons";
 import { IssueCard } from "./issue-card";
 
 // ~15% accent wash — a visible soft tint behind the cards, not a saturated
@@ -34,9 +42,12 @@ import { IssueCard } from "./issue-card";
 // hex 0x26 = 38/255 ≈ 15% (tunable band 0x1f–0x33).
 const COLUMN_TINT_ALPHA = "26";
 
+const TOGGLE_BTN_CLASS =
+  "flex h-5 w-5 items-center justify-center rounded-md text-soleur-text-tertiary transition-colors hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary focus-visible:bg-soleur-bg-surface-2 focus-visible:text-soleur-text-primary focus-visible:outline-none";
+
 /** Fades its children in on mount (opacity 0→1 via a rAF state flip). Pairs with
- *  the persistent-section width transition so a column gliding to/from its
- *  collapsed strip fades rather than snapping. `motion-reduce` makes it instant. */
+ *  the persistent-section width transition so collapsing/expanding glides rather
+ *  than snapping. `motion-reduce` makes it instant. */
 function MountReveal({ children }: { children: React.ReactNode }) {
   const [shown, setShown] = useState(false);
   useEffect(() => {
@@ -58,15 +69,21 @@ export function IssueColumn({
   column,
   issues,
   onOpen,
+  collapsed = false,
+  onToggleCollapse,
 }: {
   column: ColumnConfig;
   issues: WorkstreamIssue[];
   onOpen: (id: string) => void;
+  collapsed?: boolean;
+  onToggleCollapse?: (status: WorkstreamStatus) => void;
 }) {
   const isEmpty = issues.length === 0;
-  // Emptiness is the SOLE driver: content ⇒ open, empty ⇒ collapsed. No manual
-  // toggle, no persisted state.
-  const isCollapsed = isEmpty;
+  // Empty forces the collapsed strip (no content to show); otherwise the user's
+  // persisted choice decides. So content is OPEN by default (collapsed defaults
+  // false) but CAN be collapsed. The persisted flag is never mutated for empty
+  // columns, so a prior choice re-applies on repopulate.
+  const isCollapsed = isEmpty || collapsed;
   const tint = { backgroundColor: `${column.accent}${COLUMN_TINT_ALPHA}` };
   const overCap = issues.length > COLUMN_RENDER_CAP;
 
@@ -81,18 +98,31 @@ export function IssueColumn({
       {isCollapsed ? (
         <MountReveal key="collapsed">
           <div className="flex flex-col items-center">
+            {/* A user-collapsed NON-empty strip gets an Expand toggle; an empty
+                strip has none (nothing to expand to). */}
+            {!isEmpty ? (
+              <button
+                type="button"
+                aria-label={`Expand ${column.label}`}
+                aria-expanded={false}
+                onClick={() => onToggleCollapse?.(column.status)}
+                className={TOGGLE_BTN_CLASS}
+              >
+                {/* Down chevron rotated −90° points right = "expand". */}
+                <ChevronDownIcon className="h-3.5 w-3.5 -rotate-90" />
+              </button>
+            ) : null}
             {/* Empty strip: the sr-only text is the canonical empty announcement
                 so a screen reader doesn't hear a bare, ambiguous "0"; the visible
-                "0" pill is aria-hidden. There is no toggle — an empty column
-                cannot be expanded. */}
-            <span className="sr-only">No issues</span>
+                "0" pill is aria-hidden when empty. */}
+            {isEmpty ? <span className="sr-only">No issues</span> : null}
             <span
               aria-hidden="true"
-              className="h-2 w-2 rounded-full"
+              className="mt-2 h-2 w-2 rounded-full"
               style={{ backgroundColor: column.accent }}
             />
             <span
-              aria-hidden="true"
+              aria-hidden={isEmpty ? true : undefined}
               className="mt-2 rounded-md bg-soleur-bg-surface-2 px-1.5 py-0.5 text-[11px] font-medium text-soleur-text-tertiary"
             >
               {issues.length}
@@ -108,6 +138,19 @@ export function IssueColumn({
       ) : (
         <MountReveal key="expanded">
           <header className="flex items-center gap-2 px-1 py-2">
+            {/* The expanded branch only renders for NON-empty columns
+                (isEmpty ⇒ isCollapsed), so the Collapse toggle is always present
+                here — every content column can be collapsed. */}
+            <button
+              type="button"
+              aria-label={`Collapse ${column.label}`}
+              aria-expanded={true}
+              onClick={() => onToggleCollapse?.(column.status)}
+              className={TOGGLE_BTN_CLASS}
+            >
+              {/* Down chevron = "collapse". */}
+              <ChevronDownIcon className="h-3.5 w-3.5" />
+            </button>
             <span
               aria-hidden="true"
               className="h-2 w-2 rounded-full"

--- a/apps/web-platform/components/workstream/workstream-board.tsx
+++ b/apps/web-platform/components/workstream/workstream-board.tsx
@@ -29,8 +29,6 @@ import {
   type WorkstreamIssue,
   type WorkstreamStatus,
 } from "@/lib/workstream";
-// Column open/closed is driven SOLELY by emptiness in IssueColumn (content ⇒
-// open, empty ⇒ collapsed). The board owns no collapse state and no persistence.
 import { jsonFetcher, swrKeys } from "@/lib/swr-config";
 import { ErrorCard } from "@/components/ui/error-card";
 import { GoldButton } from "@/components/ui/gold-button";
@@ -41,6 +39,26 @@ import { IssueDetailSheet } from "./issue-detail-sheet";
 import { NewIssueDialog } from "./new-issue-dialog";
 
 type IssuesResponse = { issues: WorkstreamIssue[] };
+
+// v2 key: the v1 key ("workstream:collapsed-columns") stored a now-defunct
+// semantics where columns could be force-collapsed irrespective of the
+// content-open-by-default rule; starting fresh avoids resurrecting any stale
+// per-column collapse from that era. Empty columns are never written here — only
+// the user's explicit collapse of a CONTENT column is persisted.
+const COLLAPSED_STORAGE_KEY = "workstream:collapsed-columns-v2";
+
+function readCollapsedColumns(): Set<WorkstreamStatus> {
+  try {
+    const raw = window.localStorage.getItem(COLLAPSED_STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed as WorkstreamStatus[]);
+  } catch {
+    // private mode / quota / malformed — degrade to "nothing collapsed".
+    return new Set();
+  }
+}
 
 export function WorkstreamBoard() {
   const pathname = usePathname();
@@ -55,6 +73,16 @@ export function WorkstreamBoard() {
   const [activeId, setActiveId] = useState<string | null>(() =>
     searchParams.get("issue"),
   );
+
+  // Per-column collapse choice (content columns only), persisted in localStorage.
+  // Content is OPEN by default — a status is in this set ONLY if the user
+  // explicitly collapsed it. SSR-safe: read in an effect, never during render.
+  const [collapsed, setCollapsed] = useState<Set<WorkstreamStatus>>(
+    () => new Set(),
+  );
+  useEffect(() => {
+    setCollapsed(readCollapsedColumns());
+  }, []);
 
   // Reconcile the drawer with the URL on Back/Forward (and deep-link history).
   useEffect(() => {
@@ -151,6 +179,27 @@ export function WorkstreamBoard() {
       /* history unavailable — local state still drives the drawer */
     }
   }, [pathname]);
+
+  // Toggle a content column's collapse choice and persist it. Empty columns are
+  // collapsed by IssueColumn regardless and never reach this handler (they render
+  // no toggle), so the persisted set only ever holds user-collapsed CONTENT
+  // columns.
+  const toggleCollapse = useCallback((status: WorkstreamStatus) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(status)) next.delete(status);
+      else next.add(status);
+      try {
+        window.localStorage.setItem(
+          COLLAPSED_STORAGE_KEY,
+          JSON.stringify([...next]),
+        );
+      } catch {
+        /* localStorage unavailable — in-memory toggle still works this session */
+      }
+      return next;
+    });
+  }, []);
 
   // Faceted filter options derive from the FULL loaded set (stable, no thrash).
   const filterOptions = useMemo(
@@ -260,6 +309,8 @@ export function WorkstreamBoard() {
               column={column}
               issues={filtered.filter((i) => i.status === column.status)}
               onOpen={openIssue}
+              collapsed={collapsed.has(column.status)}
+              onToggleCollapse={toggleCollapse}
             />
           ))}
         </div>

--- a/apps/web-platform/test/components/workstream/issue-column.test.tsx
+++ b/apps/web-platform/test/components/workstream/issue-column.test.tsx
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import {
   COLUMN_CAP_NOTICE,
   type ColumnConfig,
@@ -7,9 +7,9 @@ import {
 } from "@/lib/workstream";
 import { IssueColumn } from "@/components/workstream/issue-column";
 
-// Collapse is driven SOLELY by emptiness (v5): content ⇒ expanded, empty ⇒
-// collapsed strip. There is no manual collapse/expand toggle and no persisted
-// state — so a content column is ALWAYS open and an empty one ALWAYS collapsed.
+// Default + override rule (v6): a CONTENT column is OPEN by default but CAN be
+// collapsed by the user (Collapse → strip with an Expand toggle). An EMPTY column
+// is COLLAPSED by default with NO toggle (nothing to expand to).
 
 const column: ColumnConfig = {
   status: "backlog",
@@ -33,22 +33,56 @@ function issue(over: Partial<WorkstreamIssue> = {}): WorkstreamIssue {
 
 afterEach(() => cleanup());
 
-describe("IssueColumn — emptiness drives open/closed; no manual toggle", () => {
-  it("a column WITH content is always expanded (w-72) and renders no collapse/expand toggle", () => {
+describe("IssueColumn — content open by default, collapsible", () => {
+  it("content + no collapse flag → expanded (w-72) with a Collapse toggle", () => {
     const { container } = render(
       <IssueColumn column={column} issues={[issue()]} onOpen={() => {}} />,
     );
     const cls = container.querySelector("section")?.getAttribute("class") ?? "";
     expect(cls).toContain("w-72");
     expect(cls).not.toContain("w-10");
-    // No toggle buttons exist at all anymore.
-    expect(screen.queryByRole("button", { name: "Collapse Backlog" })).toBeNull();
+    const btn = screen.getByRole("button", { name: "Collapse Backlog" });
+    expect(btn.getAttribute("aria-expanded")).toBe("true");
     expect(screen.queryByRole("button", { name: "Expand Backlog" })).toBeNull();
-    // The card itself is still rendered.
     expect(screen.getByText("Seed issue")).toBeTruthy();
   });
 
-  it("an empty column is always collapsed to the w-10 strip with no toggle", () => {
+  it("content + collapsed=true → collapsed strip (w-10) with an Expand toggle", () => {
+    const { container } = render(
+      <IssueColumn
+        column={column}
+        issues={[issue()]}
+        onOpen={() => {}}
+        collapsed
+        onToggleCollapse={() => {}}
+      />,
+    );
+    const cls = container.querySelector("section")?.getAttribute("class") ?? "";
+    expect(cls).toContain("w-10");
+    expect(cls).not.toContain("w-72");
+    const btn = screen.getByRole("button", { name: "Expand Backlog" });
+    expect(btn.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByRole("button", { name: "Collapse Backlog" })).toBeNull();
+  });
+
+  it("clicking the toggle calls onToggleCollapse with the column status", () => {
+    const onToggleCollapse = vi.fn();
+    render(
+      <IssueColumn
+        column={column}
+        issues={[issue()]}
+        onOpen={() => {}}
+        onToggleCollapse={onToggleCollapse}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Collapse Backlog" }));
+    expect(onToggleCollapse).toHaveBeenCalledTimes(1);
+    expect(onToggleCollapse).toHaveBeenCalledWith("backlog");
+  });
+});
+
+describe("IssueColumn — empty column collapses with no toggle", () => {
+  it("an empty column renders the w-10 strip and no toggle (collapsed flag unset)", () => {
     const { container } = render(
       <IssueColumn column={column} issues={[]} onOpen={() => {}} />,
     );
@@ -59,20 +93,32 @@ describe("IssueColumn — emptiness drives open/closed; no manual toggle", () =>
     expect(screen.queryByRole("button", { name: "Expand Backlog" })).toBeNull();
   });
 
-  it("the empty collapsed strip shows the 0 count pill and the column label", () => {
+  it("an empty column ignores collapsed=true the same way — strip, no toggle", () => {
+    const { container } = render(
+      <IssueColumn
+        column={column}
+        issues={[]}
+        onOpen={() => {}}
+        collapsed
+        onToggleCollapse={() => {}}
+      />,
+    );
+    const cls = container.querySelector("section")?.getAttribute("class") ?? "";
+    expect(cls).toContain("w-10");
+    expect(screen.queryByRole("button", { name: "Expand Backlog" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Collapse Backlog" })).toBeNull();
+  });
+
+  it("the empty collapsed strip shows the 0 count, the label, and an sr-only 'No issues'", () => {
     render(<IssueColumn column={column} issues={[]} onOpen={() => {}} />);
     expect(screen.getByText("0")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Backlog" })).toBeTruthy();
-  });
-
-  it("the empty collapsed strip announces 'No issues' for screen readers", () => {
-    render(<IssueColumn column={column} issues={[]} onOpen={() => {}} />);
     expect(screen.getByText("No issues")).toBeTruthy();
   });
 });
 
-describe("IssueColumn — visible column tint (both states)", () => {
-  it("content/expanded: section backgroundColor carries the accent with a non-0d alpha", () => {
+describe("IssueColumn — visible column tint", () => {
+  it("expanded: section backgroundColor carries the accent with a non-0d alpha", () => {
     const { container } = render(
       <IssueColumn column={column} issues={[issue()]} onOpen={() => {}} />,
     );
@@ -82,9 +128,15 @@ describe("IssueColumn — visible column tint (both states)", () => {
     expect(bg.toLowerCase()).toContain("#9aa3b2");
   });
 
-  it("empty/collapsed: section backgroundColor carries the same raised alpha (lockstep)", () => {
+  it("collapsed: section backgroundColor carries the same raised alpha (lockstep)", () => {
     const { container } = render(
-      <IssueColumn column={column} issues={[]} onOpen={() => {}} />,
+      <IssueColumn
+        column={column}
+        issues={[issue()]}
+        onOpen={() => {}}
+        collapsed
+        onToggleCollapse={() => {}}
+      />,
     );
     const bg =
       container.querySelector("section")?.getAttribute("style") ?? "";
@@ -100,8 +152,7 @@ describe("IssueColumn — 200 render cap", () => {
     );
   }
   function cardCount(container: HTMLElement): number {
-    // Card roots are <button> with NO aria-label (and there are no toggle
-    // buttons anymore), so every button is a card.
+    // Card roots are <button> with NO aria-label; the toggle button HAS one.
     return [...container.querySelectorAll("button")].filter(
       (b) => b.getAttribute("aria-label") === null,
     ).length;

--- a/apps/web-platform/test/components/workstream/workstream-board.test.tsx
+++ b/apps/web-platform/test/components/workstream/workstream-board.test.tsx
@@ -330,7 +330,35 @@ describe("WorkstreamBoard", () => {
     );
   });
 
-  it("content columns are expanded with no toggle; empty siblings collapse to a strip", async () => {
+  it("content columns open by default; a content column can be collapsed and the choice persists (v2 key)", async () => {
+    global.fetch = mockFetchOnce([
+      issue({ id: "SOLAA-1", title: "Card one", status: "backlog" }),
+    ]) as unknown as typeof fetch;
+
+    render(<Wrapped />);
+    await waitFor(() => expect(screen.getByText("Card one")).toBeTruthy());
+
+    // Backlog (content) is OPEN by default and offers a Collapse toggle.
+    const collapseBtn = screen.getByRole("button", { name: "Collapse Backlog" });
+    fireEvent.click(collapseBtn);
+
+    // After collapsing it becomes a strip with an Expand toggle...
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Expand Backlog" }),
+      ).toBeTruthy(),
+    );
+    // ...and the choice persists under the v2 key (NOT the legacy v1 key).
+    const stored = JSON.parse(
+      window.localStorage.getItem("workstream:collapsed-columns-v2") ?? "[]",
+    ) as string[];
+    expect(stored).toContain("backlog");
+    expect(
+      window.localStorage.getItem("workstream:collapsed-columns"),
+    ).toBeNull();
+  });
+
+  it("a sibling empty column collapses to a strip with no toggle", async () => {
     // Only Backlog has an issue; the other 6 columns are empty.
     global.fetch = mockFetchOnce([
       issue({ id: "SOLAA-1", title: "Card one", status: "backlog" }),
@@ -339,11 +367,8 @@ describe("WorkstreamBoard", () => {
     const { container } = render(<Wrapped />);
     await waitFor(() => expect(screen.getByText("Card one")).toBeTruthy());
 
-    // Backlog (content) is expanded (w-72) and carries NO collapse toggle.
-    const backlog = container.querySelector('section[aria-label="Backlog"]');
-    expect(backlog?.getAttribute("class") ?? "").toContain("w-72");
-    expect(screen.queryByRole("button", { name: "Collapse Backlog" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Expand Backlog" })).toBeNull();
+    // Backlog (content) is expanded by default with a working Collapse toggle.
+    expect(screen.getByRole("button", { name: "Collapse Backlog" })).toBeTruthy();
 
     // Todo (empty) renders as a w-10 collapsed strip and has no toggle.
     const todo = container.querySelector('section[aria-label="Todo"]');


### PR DESCRIPTION
## Summary
Restores per-column manual collapse for **content** columns while keeping the emptiness default. A column with content is **open by default** but can now be **collapsed** (Collapse toggle → strip with an Expand toggle to reopen) — so **Backlog, Done, and Cancelled** are all collapsible again. A column with **0 issues** stays collapsed with no toggle.

`isCollapsed = isEmpty || collapsed`. Persistence uses a fresh key `workstream:collapsed-columns-v2` so the legacy v1 set (which could hold stale force-collapsed content columns from earlier iterations) is ignored and every content column starts open.

## Changelog
### Web Platform
- Workstream kanban: content columns are collapsible again (Collapse/Expand toggle, persisted); empty columns remain collapsed-by-default with no toggle.
- Collapse state persists under a new v2 localStorage key so no content column resurfaces collapsed from stale state.

## Test plan
- [x] `vitest run test/components/workstream/` — 45 passed (content open-by-default + collapsible + persists under v2 key / legacy v1 key untouched; empty strip has no toggle; sr-only 'No issues')
- [x] Full `apps/web-platform` vitest suite — 10,879 passed, 0 failed
- [x] `tsc --noEmit` clean

Generated with [Claude Code](https://claude.com/claude-code)