### PR TITLE
fix(ci): allowlist ADR-068 ordinal collision to restore main green

### DIFF
--- a/scripts/check-adr-ordinals.sh
+++ b/scripts/check-adr-ordinals.sh
@@ -21,12 +21,19 @@ set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 ADR_DIR=knowledge-base/engineering/architecture/decisions
 
-# Known pre-existing collisions on main as of 2026-05-25, accepted as
-# tech debt (filed as cleanup follow-up issue post-PR-B; brainstorm flagged
-# at 2026-05-25-pr-b-anthropic-leader-loop-brainstorm.md "Sharp Edges").
+# Known pre-existing collisions on main, accepted as tech debt (renumber
+# deferred to a single cleanup PR; brainstorm flagged at
+# 2026-05-25-pr-b-anthropic-leader-loop-brainstorm.md "Sharp Edges").
 # Any NEW collision (e.g., a future ADR-042 duplicate) trips the gate.
 # When the cleanup issue lands, shrink this allowlist accordingly.
-ALLOWED_COLLISIONS=(ADR-027 ADR-030 ADR-031 ADR-033 ADR-038)
+#
+# ADR-068: two ADRs landed the same ordinal from parallel 2026-06-29/30 merges —
+# ADR-068-graceful-cron-drain-before-container-swap (#5669, merged 06-29) and
+# ADR-068-multi-host-workspaces-shared-git-data-lease-coordinator (#5274, merged
+# 06-30 at the tip, which left main red on this gate). Allowlisted to match the
+# established remediation for the five prior collisions; proper renumber tracked
+# in cleanup issue #5744.
+ALLOWED_COLLISIONS=(ADR-027 ADR-030 ADR-031 ADR-033 ADR-038 ADR-068)
 
 # (1) New (non-allowlisted) ordinal collisions.
 all_dups=$(ls "$ADR_DIR" | grep -oE '^ADR-[0-9]{3}' | sort | uniq -d || true)


### PR DESCRIPTION
## Restore `main` CI green

`main` (bf651d3e9) is red: the only failing required check is **`adr-ordinals`**, because the #5274 multi-host-workspaces ADR merged ordinal **ADR-068** while #5669 graceful-cron-drain already held it (parallel merges, 06-29 / 06-30).

This adds `ADR-068` to `ALLOWED_COLLISIONS` in `scripts/check-adr-ordinals.sh`, matching the established remediation for the five prior collisions (027/030/031/033/038) — the validator was built with this allowlist as the sanctioned escape for accepted collision tech debt.

Proper renumber of all six duplicate ordinals tracked in #5744.

Ref #5744

🤖 Generated with [Claude Code](https://claude.com/claude-code)