### PR TITLE
fix(web): render support replies as markdown

### DIFF
--- a/apps/web-platform/components/support/canned-responder.ts
+++ b/apps/web-platform/components/support/canned-responder.ts
@@ -8,25 +8,28 @@
 
 import { SUPPORT_KB_HREF } from "./support-persona";
 
+// Rendered as markdown in the support bubble (MarkdownRenderer) — the KB ref is
+// a clickable link, not a bare path.
 const COMING_SOON =
-  "Live support chat is coming soon. In the meantime, you can browse your knowledge base for guides";
+  `Live support chat is coming soon. In the meantime, you can browse your ` +
+  `[knowledge base](${SUPPORT_KB_HREF}) for guides.`;
 
 // Keyed answers for the 3 starter chips. Each restates the coming-soon framing
 // and points at a real escape hatch so a stuck user is never dead-ended.
 const KEYED_REPLIES: Record<string, string> = {
   routines:
     `To create a routine, open **Routines** from the left sidebar and choose "New routine" — ` +
-    `you'll pick a schedule and the work it should run. ${COMING_SOON}: ${SUPPORT_KB_HREF}.`,
+    `you'll pick a schedule and the work it should run. ${COMING_SOON}`,
   "knowledge-base":
     `Your **Knowledge Base** lives in the left sidebar under "Knowledge Base" — it's where your ` +
-    `docs, conventions, and learnings are organized. ${COMING_SOON}: ${SUPPORT_KB_HREF}.`,
+    `docs, conventions, and learnings are organized. ${COMING_SOON}`,
   workstream:
     `The **Workstream** is your board for tracking work in progress across columns. ` +
-    `Open it from the left sidebar to see what's active. ${COMING_SOON}: ${SUPPORT_KB_HREF}.`,
+    `Open it from the left sidebar to see what's active. ${COMING_SOON}`,
 };
 
 const GENERIC_REPLY =
-  `Thanks for the question! ${COMING_SOON}: ${SUPPORT_KB_HREF}. ` +
+  `Thanks for the question! ${COMING_SOON} ` +
   `A teammate will be able to answer live questions here soon.`;
 
 /**

--- a/apps/web-platform/components/support/support-message.tsx
+++ b/apps/web-platform/components/support/support-message.tsx
@@ -4,6 +4,7 @@
 // vs support bubble (surface-1, left, with avatar + name + PREVIEW badge).
 // Mirrors components/chat/message-bubble.tsx token usage.
 
+import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
 import { SupportAvatar } from "./support-avatar";
 import { SUPPORT_NAME } from "./support-persona";
 import type { SupportMessage as SupportMessageType } from "./use-support-chat";
@@ -34,7 +35,7 @@ export function SupportMessage({ message }: { message: SupportMessageType }) {
           </span>
         </div>
         <div className="w-fit max-w-[85%] rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1 px-4 py-3 text-sm leading-relaxed text-soleur-text-primary">
-          {message.text}
+          <MarkdownRenderer content={message.text} />
         </div>
       </div>
     </div>

--- a/apps/web-platform/test/components/support/support-panel.test.tsx
+++ b/apps/web-platform/test/components/support/support-panel.test.tsx
@@ -64,6 +64,9 @@ describe("SupportPanel — interface shell", () => {
     // The chip text now appears as a user bubble (and chips are gone).
     expect(within(dialog).getAllByText(chip.label).length).toBeGreaterThan(0);
     expect(within(dialog).getByText("Preview")).toBeTruthy();
+    // Reply renders as markdown: bold renders as <strong>, no literal "**".
+    expect(dialog.querySelector("strong")).toBeTruthy();
+    expect(dialog.textContent ?? "").not.toContain("**");
   });
 
   it("Escape closes the panel", () => {


### PR DESCRIPTION
## Fix: support replies showed raw markdown

The support canned replies contain markdown (`**bold**`, a KB link), but the support reply bubble rendered the raw string — so `**Workstream**` displayed literally (see prod after enabling the `support` flag).

- Render the support bubble through `MarkdownRenderer` (same renderer the main chat uses) → bold/links render.
- Make the knowledge-base reference a clickable `[knowledge base](/dashboard/kb)` link instead of a bare path.
- Regression assertion: reply renders `<strong>` and contains no literal `**`.

Follow-up to #5741 (support interface shell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)