### PR TITLE
fix(web): support reply internal links open in-app, not a new tab

### DIFF
--- a/apps/web-platform/components/support/support-panel.tsx
+++ b/apps/web-platform/components/support/support-panel.tsx
@@ -5,6 +5,7 @@
 // Reduced-motion aware. Mobile: full-width bottom-anchored sheet.
 
 import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { SupportComposer } from "./support-composer";
 import { SupportConversation } from "./support-conversation";
 import { SUPPORT_NAME, SUPPORT_PANEL_SUBTITLE } from "./support-persona";
@@ -23,10 +24,26 @@ export function SupportPanel({
 }) {
   const panelRef = useRef<HTMLDivElement>(null);
   const onCloseRef = useRef(onClose);
+  const router = useRouter();
   const [entered, setEntered] = useState(false);
   useEffect(() => {
     onCloseRef.current = onClose;
   });
+
+  // Reply links render via MarkdownRenderer, which opens every anchor in a new
+  // tab (correct for the main chat's external links). For an INTERNAL app path
+  // (e.g. the knowledge-base link) that's wrong — intercept the click and do a
+  // same-tab client-side navigation, closing the panel so the user lands on it.
+  function handleReplyLinkClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey) return;
+    const anchor = (e.target as HTMLElement).closest("a");
+    const href = anchor?.getAttribute("href");
+    if (href && href.startsWith("/") && !href.startsWith("//")) {
+      e.preventDefault();
+      onClose();
+      router.push(href);
+    }
+  }
 
   useEffect(() => {
     if (!open) {
@@ -130,10 +147,14 @@ export function SupportPanel({
           </button>
         </header>
 
-        <SupportConversation
-          messages={messages}
-          onChipSelect={(label, chipKey) => onSend(label, chipKey)}
-        />
+        {/* display:contents keeps the flex layout while letting the click
+            handler intercept internal reply links (bubbles from descendants). */}
+        <div style={{ display: "contents" }} onClick={handleReplyLinkClick}>
+          <SupportConversation
+            messages={messages}
+            onChipSelect={(label, chipKey) => onSend(label, chipKey)}
+          />
+        </div>
 
         <SupportComposer onSend={(text) => onSend(text)} />
       </div>

--- a/apps/web-platform/test/components/support/support-launcher.test.tsx
+++ b/apps/web-platform/test/components/support/support-launcher.test.tsx
@@ -8,6 +8,10 @@ vi.mock("@/components/feature-flags/provider", () => ({
     name === "support" ? flagState.support : false,
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+}));
+
 import { SupportLauncher } from "@/components/support/support-launcher";
 
 describe("SupportLauncher — flag gating", () => {

--- a/apps/web-platform/test/components/support/support-panel.test.tsx
+++ b/apps/web-platform/test/components/support/support-panel.test.tsx
@@ -7,6 +7,11 @@ vi.mock("@/components/feature-flags/provider", () => ({
     name === "support" ? flagState.support : false,
 }));
 
+const routerPush = vi.hoisted(() => vi.fn());
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPush, replace: vi.fn(), prefetch: vi.fn() }),
+}));
+
 import { SupportLauncher } from "@/components/support/support-launcher";
 import { SUPPORT_STARTER_CHIPS } from "@/components/support/support-persona";
 
@@ -19,6 +24,7 @@ function openPanel() {
 describe("SupportPanel — interface shell", () => {
   beforeEach(() => {
     flagState.support = true;
+    routerPush.mockClear();
   });
   afterEach(() => cleanup());
 
@@ -67,6 +73,17 @@ describe("SupportPanel — interface shell", () => {
     // Reply renders as markdown: bold renders as <strong>, no literal "**".
     expect(dialog.querySelector("strong")).toBeTruthy();
     expect(dialog.textContent ?? "").not.toContain("**");
+  });
+
+  it("clicking an internal reply link navigates in-app (router.push) + closes, not a new tab", () => {
+    const dialog = openPanel();
+    fireEvent.click(within(dialog).getByText(SUPPORT_STARTER_CHIPS[0].label));
+    const kbLink = within(dialog).getByText("knowledge base").closest("a");
+    expect(kbLink?.getAttribute("href")).toBe("/dashboard/kb");
+    fireEvent.click(kbLink as Element);
+    expect(routerPush).toHaveBeenCalledWith("/dashboard/kb");
+    // Panel closed so the user lands on the KB (not the dimmed overlay).
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 
   it("Escape closes the panel", () => {


### PR DESCRIPTION
## Fix: KB link in support replies opened a new tab

`MarkdownRenderer` renders every anchor with `target="_blank"` (correct for the main chat's external links), so the in-app **knowledge base** link in support replies opened a new browser tab instead of navigating directly.

The support panel now intercepts clicks on **internal** app paths (href starting with `/`) → same-tab `router.push` + closes the panel, so the user lands directly on the KB. Plain modified clicks (cmd/ctrl/middle-click) fall through to the default behavior.

Follow-up to #5741 (support shell) / #5748 (markdown render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)