### PR TITLE
fix(product-roadmap): next must not classify non-eng domain work as codeable

### DIFF
--- a/plugins/soleur/skills/product-roadmap/scripts/roadmap-reconcile.sh
+++ b/plugins/soleur/skills/product-roadmap/scripts/roadmap-reconcile.sh
@@ -33,6 +33,12 @@ ROADMAP_FILE="${ROADMAP_FILE:-knowledge-base/product/roadmap.md}"
 # tells the founder to /soleur:go a non-codeable task.
 CODEABLE_LABELS='"domain/engineering","type/bug","type/feature","type/refactor"'
 
+# A non-engineering domain-leader label means the work is operator-driven (marketing,
+# legal, ops, sales, finance, support, product) — it OVERRIDES a codeable type/* label.
+# Caught by dogfooding: #2603 ("Publish a case study") is type/feature + domain/marketing
+# and must classify OPERATOR, not CODEABLE — never tell the founder to /soleur:go it.
+OPERATOR_DOMAIN_LABELS='"domain/marketing","domain/legal","domain/operations","domain/sales","domain/finance","domain/support","domain/product"'
+
 # extract_phase_counts: read roadmap markdown on stdin, emit "N|open|closed"
 # for each `| Phase N (...) |` row in the `## Current State` table that carries
 # an "X open, Y closed" count. Rows without counts (prose, Beta users) are skipped.
@@ -98,7 +104,9 @@ pick_next_action() {
   num="$(printf '%s' "$first" | jq -r '.number')"
   title="$(printf '%s' "$first" | jq -r '.title')"
   codeable="$(printf '%s' "$first" | jq -r \
-    "if any(.labels[]?.name; IN($CODEABLE_LABELS)) then \"yes\" else \"no\" end")"
+    "if any(.labels[]?.name; IN($OPERATOR_DOMAIN_LABELS)) then \"no\"
+     elif any(.labels[]?.name; IN($CODEABLE_LABELS)) then \"yes\"
+     else \"no\" end")"
   if [[ "$codeable" == "yes" ]]; then
     printf 'CODEABLE|#%s|%s\n' "$num" "$title"
   else

--- a/plugins/soleur/test/roadmap-reconcile.test.sh
+++ b/plugins/soleur/test/roadmap-reconcile.test.sh
@@ -113,6 +113,20 @@ echo "TS6c: empty set -> explicit NONE (never silent)"
 OUT="$(pick_next_action <(printf '%s' '[]'))"
 assert_contains "$OUT" "NONE" "empty -> explicit NONE"
 
+echo "TS6d: non-engineering domain label overrides a codeable type label -> OPERATOR"
+# Real dogfood case: #2603 "Publish case study" is type/feature BUT domain/marketing.
+# A domain/* leader label (marketing/legal/ops/sales/finance/support/product) means the
+# work is operator-driven regardless of the type/* label — never tell the founder to build it.
+ISSUES_MKT='[{"number":2603,"title":"Publish first external case study","labels":[{"name":"type/feature"},{"name":"domain/marketing"}]}]'
+OUT="$(pick_next_action <(printf '%s' "$ISSUES_MKT"))"
+assert_contains "$OUT" "OPERATOR" "type/feature + domain/marketing -> OPERATOR (override)"
+assert_not_contains "$OUT" "CODEABLE" "marketing task not classified CODEABLE"
+
+echo "TS6e: engineering domain + type label still -> CODEABLE"
+ISSUES_ENG='[{"number":1500,"title":"refactor resolver","labels":[{"name":"type/feature"},{"name":"domain/engineering"}]}]'
+OUT="$(pick_next_action <(printf '%s' "$ISSUES_ENG"))"
+assert_contains "$OUT" "CODEABLE" "type/feature + domain/engineering -> CODEABLE"
+
 # --- TS7: ZERO file writes (brand-survival invariant) ---
 echo "TS7: module makes zero file writes"
 TMP_GIT="$(mktemp -d)"


### PR DESCRIPTION
## Summary

Dogfooding the just-shipped `product-roadmap next` (#5753, v3.179.0) surfaced a real mis-classification: issue #2603 *"Publish first external case study"* — labeled `type/feature` **`domain/marketing`** — was reported as a **codeable** `/soleur:go #2603`. That's exactly the mis-direction `next` exists to avoid: telling a non-technical founder to *build* marketing work.

**Fix:** a non-engineering `domain/*` leader label (`marketing`/`legal`/`operations`/`sales`/`finance`/`support`/`product`) now **overrides** the codeable `type/*` signal → classifies **OPERATOR**. Read-only, advisory; under-classifying to OPERATOR remains the safe failure.

## Changelog

- **product-roadmap:** `next` no longer mis-labels marketing/legal/ops/etc. work as codeable — a non-engineering `domain/*` label forces the operator-action classification.

## Test plan

- [x] `roadmap-reconcile.test.sh` — 20/20 (added TS6d: `type/feature`+`domain/marketing`→OPERATOR; TS6e: `+domain/engineering`→CODEABLE)
- [x] Live dogfood: `next` now reports #2603 as operator-driven, not codeable
- [x] shellcheck clean

Generated with [Claude Code](https://claude.com/claude-code)