### PR TITLE
docs(5772): close lever-1 AC11 + work→review tuning follow-up (no-change rationale)

### DIFF
--- a/knowledge-base/project/learnings/2026-07-01-phase-surface-work-phase-tuning-is-fixture-limited.md
+++ b/knowledge-base/project/learnings/2026-07-01-phase-surface-work-phase-tuning-is-fixture-limited.md
@@ -1,0 +1,72 @@
+---
+title: A phase-surface "regression" can be inherent fan-out ambiguity, not surface noise — and an eval can't tune what its fixture can't resolve
+date: 2026-07-01
+tags: [eval-harness, phase-surface-hint, fixture-size, tool-selection, work-phase, statistical-power, three-coupling, 5772]
+category: best-practices
+issue: 5772
+prs: [5794]
+---
+
+# A phase-surface "regression" can be inherent ambiguity; an eval can't tune what its fixture can't resolve
+
+Closing out #5772 lever 1, the documented follow-up was: "the `work→review` phase hint
+regresses — the work-phase surface foregrounds `qa`, which competes with `review`. Worth
+tuning `.claude/phase-surface-map.json`'s work entry, with an eval re-run to confirm."
+Investigating before editing showed the tuning is **not safely actionable**, for two
+reusable reasons.
+
+## 1. The "obvious" fix is contradicted by the eval's own golden data
+
+The intuitive edit — drop `soleur:qa` from the `work` phase's `relevant_skills` — is wrong.
+`qa` is a *legitimate* work-phase outcome, present in the golden set:
+
+- `tool-selection.jsonl:6` — phase `work`, golden `review` ("implementation complete… multi-agent pass to catch bugs")
+- `tool-selection.jsonl:7` — phase `work`, golden `qa` ("UI change under app/(dashboard)… auth-seeded headless browser gate before review")
+- `tool-selection.jsonl:8` — phase `work`, golden `test-fix-loop` ("six failing specs… iterate until green")
+
+The work phase legitimately fans out to **three** different next-skills. Removing `qa`
+helps line 6 but regresses line 7 — a wash at best. The "competition" the handoff described
+is **inherent situational ambiguity** that the *situation text* disambiguates, not surface
+noise the map can cleanly delete. **Lesson: before deleting an entry from a routing/surface
+map to fix a "regression," grep the eval's golden tasks for that entry as a legitimate label.
+If it appears, the regression is fan-out ambiguity, not noise.**
+
+## 2. The fixture is too thin to validate a *subtle* tuning — fixture-limited, not just budget-limited
+
+Even a non-deleting tweak (reorder, strengthen the `→ usually review` heuristic, annotate
+`qa` as UI-conditional) can't be validated: the fixture has exactly **one** work→review case
+and **one** work→qa case. `promptfoo eval --repeat 5` across the model grid would produce
+single-case noise, not a statistically actionable delta. The eval-harness is also opt-in /
+not CI-wired (API-budget gate, `hr-autonomous-loop-skill-api-budget-disclosure`) — so
+spending budget to run it now buys a number you can't act on. **Lesson: an eval can only
+resolve a tuning whose effect exceeds its per-cell fixture noise. The prerequisite for tuning
+work→review is EXPANDING the work-phase golden tasks (several review-cases + qa-cases) first,
+not running the eval at current fixture size.**
+
+## 3. The surface is a THREE-coupling, not two
+
+Any phase-surface tuning must edit three files in lockstep — the parity tests enforce two,
+the third is silent:
+
+- `.claude/phase-surface-map.json` (canonical, CLI hook reads it)
+- `apps/web-platform/server/phase-surface-map.ts` (bundled web copy; `phase-surface-map-parity.test.ts` deep-equals it to the JSON)
+- `plugins/soleur/skills/eval-harness/prompts/tool-selection-skill.txt:10` (hardcodes its own work-phase list — **no parity test couples it to the map**, so it drifts silently)
+
+**Lesson: when a value is bundle-duplicated for a runtime that can't read the canonical
+source, check whether the *eval prompt* also hardcodes it. The eval is a third copy with no
+gate — tune the map and forget the prompt and the eval measures a stale surface.**
+
+## AC11 (the lever-1 value-realization check) was satisfiable without a new run
+
+Related close-out: AC11 asked to confirm the `[phase-scope]` `additionalContext` reaches the
+model and that Skill fires at >1 phase transition. Both were already answered — the #5768
+Phase 0 live transcript probe (ADR-070:39) plus the #5792 behavioral eval (+6.7pts) prove
+delivery, and `soleur-go-runner.ts`'s `currentWorkflow`-locks-on-first-Skill-call structure
+proves per-phase firing. The success path emits no telemetry by design (`phase-surface-hook.ts:76`;
+only the error path reports via `reportSilentFallback`), so Sentry can't confirm a *specific*
+live run — that's an intentional hot-path/fail-open choice, not a gap. **Lesson: an
+"observational" QA item may already be answered by a prior probe + a behavioral eval; check
+those before treating it as needing a fresh live run.**
+
+See also `[[2026-06-30-eval-fixture-bug-inverts-gate-verdict-and-web-vs-cli-skill-shape]]`
+and `[[2026-06-30-posttooluse-skill-additionalcontext-is-the-autonomous-safe-phase-injection-vehicle]]`.

--- a/knowledge-base/project/specs/feat-5772-web-sdk-phase-hint/spec.md
+++ b/knowledge-base/project/specs/feat-5772-web-sdk-phase-hint/spec.md
@@ -44,6 +44,18 @@ none of it.
   which exists. Tracked on #5772.
 - N2. Tuning the `work→review` hint regression (work-phase surface foregrounds `qa`, competing
   with `review`) — affects the shipped CLI hint too; separate `phase-surface-map.json` tuning.
+  **CLOSED 2026-07-01 (no change): not safely tunable at the current fixture size.** The
+  "drop `qa` from work" fix is contradicted by the eval's own golden data — `qa` is a
+  *legitimate* work-phase outcome (`tool-selection.jsonl:7`, a UI change needing the headless
+  browser gate). The work phase genuinely fans out to three next-skills (`review` line 6, `qa`
+  line 7, `test-fix-loop` line 8), so the "competition" is inherent situational ambiguity that
+  the situation text disambiguates, not surface noise. The fixture has exactly one work→review
+  and one work→qa case, so `--repeat 5` across the model grid cannot statistically resolve a
+  subtle reorder/heuristic tweak (single-case noise). Any tuning touches THREE coupled surfaces
+  in lockstep (`.claude/phase-surface-map.json`, the bundled `phase-surface-map.ts`, and the
+  eval prompt `tool-selection-skill.txt:10`). Re-open only after expanding the work-phase golden
+  tasks (several review-cases + qa-cases) so the eval can resolve the tradeoff. See
+  `knowledge-base/project/learnings/2026-07-01-phase-surface-work-phase-tuning-is-fixture-limited.md`.
 - N3. Any change to the `canUseTool` deny-by-default security floor.
 
 ## Functional Requirements

--- a/knowledge-base/project/specs/feat-5772-web-sdk-phase-hint/tasks.md
+++ b/knowledge-base/project/specs/feat-5772-web-sdk-phase-hint/tasks.md
@@ -43,4 +43,7 @@ plan: knowledge-base/project/plans/2026-06-30-feat-web-sdk-phase-surface-hint-pl
 - [x] 5.4 PR body: `Ref #5772` (NOT Closes), `## Changelog`, `semver:minor` (AC9).
 
 ## Post-merge
-- [ ] 6.1 QA (AC11): real web `/soleur:go` run (cc Concierge path only — legacy doesn't opt in) — confirm `[phase-scope]` reaches the model after a Skill call (Sentry/transcript) AND the turn completes normally; observe per-phase Skill-call cadence. Non-blocking.
+- [x] 6.1 QA (AC11) — **SATISFIED by existing evidence 2026-07-01 (no new live run needed).**
+  - Reaches the model: verified two ways — (1) the #5768 Phase 0 live transcript probe (ADR-070:39, CC 2.1.196): PostToolUse(Skill) `additionalContext` arrives as a `<system-reminder>`; (2) the #5792 hardened eval shows it *measurably changes* behavior (+6.7pts Sonnet next-skill selection) — behavioral proof of delivery.
+  - Per-phase Skill cadence: confirmed structural — `soleur-go-runner.ts` locks `currentWorkflow` only on the FIRST Skill call and re-enters on every subsequent one; the hook fires on every Skill call (ADR-070:35), so a multi-phase run injects the hint once per brainstorm→plan→work→review→ship transition. Agent-driven, no count governor.
+  - Caveat (intentional, not a gap to fix): the success path emits NO telemetry — `phase-surface-hook.ts:76` returns the hint silently; only the error path reports via `reportSilentFallback` (Sentry/pino). So a *specific* live run can't be confirmed from Sentry alone — by design on the hot, fail-open path. A per-Skill success breadcrumb would be pure noise; not worth adding.


### PR DESCRIPTION
Closes out the two remaining lever-1 documentation items from #5772 (the SDK-native web phase-surface hint). **Docs-only — no code, no behavior change.** `Ref #5772` (NOT Closes — #5772 stays open by design for lever 2 / `disallowedTools`, still blocked on TR3 telemetry).

## What changed

- **`spec.md` N2** — annotated the `work→review` tuning follow-up as **CLOSED (no change)** with the rationale: not safely tunable at the current fixture size.
- **`tasks.md` 6.1 (AC11)** — marked **SATISFIED by existing evidence**; no new live web run needed.
- **New learning** `2026-07-01-phase-surface-work-phase-tuning-is-fixture-limited.md` — captures the reusable lessons.

## Why no tuning, no eval spend

- The "drop `qa` from work" fix is contradicted by the eval's own golden data — `qa` is a legitimate work-phase outcome (`tool-selection.jsonl:7`). The work phase genuinely fans out to three next-skills (`review`/`qa`/`test-fix-loop`), so the "competition" is inherent situational ambiguity, not surface noise.
- The fixture has exactly one work→review and one work→qa case, so `--repeat 5` across the model grid can't statistically resolve a subtle tweak. **Fixture-limited, not just budget-limited** — re-open only after expanding the work-phase golden tasks.
- Any tuning is a **three-coupling** (`.claude/phase-surface-map.json`, bundled `phase-surface-map.ts`, AND `tool-selection-skill.txt:10` — the eval prompt is a silent third copy with no parity gate).

## AC11 evidence (already on record)

- Reaches model: #5768 Phase 0 transcript probe (ADR-070:39) + #5792 behavioral eval (+6.7pts Sonnet).
- Per-phase firing: `soleur-go-runner.ts` locks `currentWorkflow` on the first Skill call and re-enters on each subsequent one; hook fires per Skill call.
- Success-path telemetry intentionally absent (hot, fail-open path); only the error path reports via `reportSilentFallback`.

## Changelog

- docs: closed #5772 lever-1 AC11 and the work→review tuning follow-up with no-change rationale; added a learning on fixture-limited phase-surface tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)