### PR TITLE
feat(web): direct g-then-key shortcuts for command-palette destinations

### DIFF
--- a/apps/web-platform/components/command-palette/command-palette.tsx
+++ b/apps/web-platform/components/command-palette/command-palette.tsx
@@ -278,7 +278,11 @@ export function CommandPalette() {
               {askCmd && (
                 <Command.Group heading="Ask an agent">
                   <Command.Item
-                    value={trimmed ? `ask agent ${trimmed}` : "ask an agent"}
+                    value={
+                      trimmed
+                        ? `ask agent ${trimmed}`
+                        : `ask an agent ${askCmd.keys ?? ""}`
+                    }
                     onSelect={() =>
                       runEffect({ kind: "openChat", query: trimmed || undefined })
                     }

--- a/apps/web-platform/components/command-palette/command-palette.tsx
+++ b/apps/web-platform/components/command-palette/command-palette.tsx
@@ -285,6 +285,9 @@ export function CommandPalette() {
                     data-testid="cmd-ask-agent"
                   >
                     {trimmed ? `Ask an agent about “${trimmed}”` : askCmd.label}
+                    {!trimmed && askCmd.keys && (
+                      <span className="cmdk-keys"> {askCmd.keys}</span>
+                    )}
                   </Command.Item>
                 </Command.Group>
               )}
@@ -293,10 +296,11 @@ export function CommandPalette() {
                 {navCmds.map((cmd) => (
                   <Command.Item
                     key={cmd.id}
-                    value={cmd.label}
+                    value={`${cmd.label} ${cmd.keys ?? ""}`}
                     onSelect={() => onSelectCommand(cmd)}
                   >
                     {cmd.label}
+                    {cmd.keys && <span className="cmdk-keys"> {cmd.keys}</span>}
                   </Command.Item>
                 ))}
               </Command.Group>

--- a/apps/web-platform/components/command-palette/help-overlay.tsx
+++ b/apps/web-platform/components/command-palette/help-overlay.tsx
@@ -2,20 +2,28 @@
 
 // feat-web-app-shortcuts — the `?` / `⌘/` help overlay (FR4). A searchable
 // cheat-sheet sharing the palette's cmdk Command.Dialog (Radix-backed focus
-// trap/restore), NOT a parallel a11y impl. Lists ONLY shortcuts that actually
-// DO something in v1 — the wireframe's `G`-then-I/K/R/D nav sequences are
-// NG2-deferred (#5636) and would document dead keys, so they are omitted.
+// trap/restore), NOT a parallel a11y impl. Lists the chords plus the direct
+// "go-to" sequences (`G` `D` …) and the Ask-an-agent summon (`G` `C`) — the
+// wireframe's design, un-deferred from #5636. Sequence rows derive from the
+// single-source `seq` field on NAV_ITEMS/ADMIN_NAV_ITEMS, so a documented key
+// can never drift from the live binding.
 
 import { Command } from "cmdk";
-import { useShortcuts } from "./use-shortcuts";
+import {
+  useShortcuts,
+  formatSeqHint,
+  ASK_AGENT_SEQ,
+  type CommandEffect,
+} from "./use-shortcuts";
+import { NAV_ITEMS, ADMIN_NAV_ITEMS } from "./nav-items";
 import { useTour } from "@/components/tour/tour-provider";
 
-// Each row carries the action it performs, so selecting it (click or ↵) RUNS
-// the shortcut rather than only dismissing the overlay — the overlay doubles as
-// a clickable launcher, not just a cheat-sheet.
+// Each chord row carries the action it performs, so selecting it (click or ↵)
+// RUNS the shortcut rather than only dismissing the overlay — the overlay
+// doubles as a clickable launcher, not just a cheat-sheet.
 type HelpAction = "palette" | "help" | "sidebar" | "close";
 
-const SHORTCUTS: ReadonlyArray<{
+const CHORDS: ReadonlyArray<{
   keys: string;
   label: string;
   action: HelpAction;
@@ -27,12 +35,38 @@ const SHORTCUTS: ReadonlyArray<{
   { keys: "Esc", label: "Close palette / overlay / drawer", action: "close" },
 ];
 
+// "Go to" sequence rows — derived from the single-source `seq` field. Each runs
+// its navigate effect. Admin rows render only when the operator is an admin.
+type SeqRow = { keys: string; label: string; effect: CommandEffect };
+
+const NAV_ROWS: readonly SeqRow[] = NAV_ITEMS.filter((i) => i.seq).map((i) => ({
+  keys: formatSeqHint(i.seq as string),
+  label: `Go to ${i.label}`,
+  effect: { kind: "navigate", href: i.href },
+}));
+
+const ADMIN_NAV_ROWS: readonly SeqRow[] = ADMIN_NAV_ITEMS.filter((i) => i.seq).map(
+  (i) => ({
+    keys: formatSeqHint(i.seq as string),
+    label: `Go to ${i.label}`,
+    effect: { kind: "navigate", href: i.href },
+  }),
+);
+
+// The Ask-an-agent hero summon — grouped as an ACTION ("Ask an agent"), not
+// navigation, so it reads as the hero verb it is.
+const AGENT_ROW: SeqRow = {
+  keys: formatSeqHint(ASK_AGENT_SEQ),
+  label: "Ask an agent",
+  effect: { kind: "openChat" },
+};
+
 export function HelpOverlay() {
-  const { enabled, helpOpen, closeHelp, openPalette, runEffect } =
+  const { enabled, helpOpen, closeHelp, openPalette, runEffect, isAdmin } =
     useShortcuts();
   const tour = useTour();
 
-  function runShortcut(action: HelpAction) {
+  function runChord(action: HelpAction) {
     switch (action) {
       case "palette":
         // Dismiss the overlay first so the palette opens as the top layer.
@@ -53,6 +87,14 @@ export function HelpOverlay() {
     }
   }
 
+  // Dismiss the overlay first so the destination mounts as the top layer.
+  function runRow(effect: CommandEffect) {
+    closeHelp();
+    runEffect(effect);
+  }
+
+  const navRows = isAdmin ? [...NAV_ROWS, ...ADMIN_NAV_ROWS] : NAV_ROWS;
+
   if (!enabled) return null;
   return (
     <Command.Dialog
@@ -70,13 +112,36 @@ export function HelpOverlay() {
       <Command.List>
         <Command.Empty>No matching shortcuts.</Command.Empty>
         <Command.Group heading="Keyboard shortcuts">
-          {SHORTCUTS.map((s) => (
+          {CHORDS.map((s) => (
             <Command.Item
               key={s.keys + s.label}
               value={`${s.label} ${s.keys}`}
               // Selecting a row RUNS its shortcut (open palette / toggle sidebar
               // / close), not just dismiss the overlay.
-              onSelect={() => runShortcut(s.action)}
+              onSelect={() => runChord(s.action)}
+              data-testid={`help-row-${s.keys}`}
+            >
+              <span className="cmdk-help-label">{s.label}</span>
+              <kbd className="cmdk-keys">{s.keys}</kbd>
+            </Command.Item>
+          ))}
+        </Command.Group>
+        <Command.Group heading="Ask an agent">
+          <Command.Item
+            value={`${AGENT_ROW.label} ${AGENT_ROW.keys}`}
+            onSelect={() => runRow(AGENT_ROW.effect)}
+            data-testid={`help-row-${AGENT_ROW.keys}`}
+          >
+            <span className="cmdk-help-label">{AGENT_ROW.label}</span>
+            <kbd className="cmdk-keys">{AGENT_ROW.keys}</kbd>
+          </Command.Item>
+        </Command.Group>
+        <Command.Group heading="Go to">
+          {navRows.map((s) => (
+            <Command.Item
+              key={s.keys + s.label}
+              value={`${s.label} ${s.keys}`}
+              onSelect={() => runRow(s.effect)}
               data-testid={`help-row-${s.keys}`}
             >
               <span className="cmdk-help-label">{s.label}</span>

--- a/apps/web-platform/components/command-palette/nav-items.ts
+++ b/apps/web-platform/components/command-palette/nav-items.ts
@@ -8,18 +8,28 @@
 export type NavItem = {
   readonly href: string;
   readonly label: string;
+  /**
+   * Optional two-key "go-to" sequence (e.g. `"g d"` — the `g` prefix then `d`).
+   * The SINGLE source of truth for this destination's global keyboard binding:
+   * the resolver, the palette key hint, and the `?` overlay row all derive from
+   * it, so a documented key can never drift from the live binding (no separate
+   * NAV_SEQUENCES table). `g`-prefixed sequences (never a bare letter) are
+   * collision-free with browser chords — the wireframe's design, un-deferred
+   * from #5636.
+   */
+  readonly seq?: string;
 };
 
 export const NAV_ITEMS: readonly NavItem[] = [
-  { href: "/dashboard", label: "Dashboard" },
-  { href: "/dashboard/inbox", label: "Inbox" },
-  { href: "/dashboard/workstream", label: "Workstream" },
-  { href: "/dashboard/kb", label: "Knowledge Base" },
-  { href: "/dashboard/routines", label: "Routines" },
+  { href: "/dashboard", label: "Dashboard", seq: "g d" },
+  { href: "/dashboard/inbox", label: "Inbox", seq: "g i" },
+  { href: "/dashboard/workstream", label: "Workstream", seq: "g w" },
+  { href: "/dashboard/kb", label: "Knowledge Base", seq: "g k" },
+  { href: "/dashboard/routines", label: "Routines", seq: "g r" },
 ] as const;
 
 export const ADMIN_NAV_ITEMS: readonly NavItem[] = [
-  { href: "/dashboard/admin/analytics", label: "Analytics" },
+  { href: "/dashboard/admin/analytics", label: "Analytics", seq: "g a" },
 ] as const;
 
 // Settings destinations — surfaced under the palette's "Settings" drill-in

--- a/apps/web-platform/components/command-palette/use-shortcuts.tsx
+++ b/apps/web-platform/components/command-palette/use-shortcuts.tsx
@@ -120,9 +120,15 @@ import { NAV_ITEMS, ADMIN_NAV_ITEMS, SETTINGS_NAV_ITEMS } from "./nav-items";
 // ---------------------------------------------------------------------------
 // Direct "go-to" keyboard sequences (`g` prefix + a letter) — #5636, the
 // wireframe's design. The `seq` field on NAV_ITEMS/ADMIN_NAV_ITEMS is the SINGLE
-// source: the resolver map, the palette key hint, and the `?` overlay rows all
-// derive from it, so a documented key can never drift from the live binding.
+// source for the SECOND key: the resolver map, the palette key hint, and the
+// `?` overlay rows all derive from it, so the destination letter can never drift
+// from the live binding. The shared `g` PREFIX is the fixed `SEQUENCE_PREFIX`
+// constant below (every `seq` starts with it by construction).
 // ---------------------------------------------------------------------------
+
+/** The one shared "go-to" prefix. The arm matcher keys on this, and every `seq`
+ * (incl. ASK_AGENT_SEQ) is authored `"<SEQUENCE_PREFIX> <letter>"`. */
+export const SEQUENCE_PREFIX = "g";
 
 /** The Ask-an-agent hero sequence ("go to chat"). Not a nav route, so it lives
  * here rather than on a nav array. Rebound from the requested `Ctrl+C` (a hard
@@ -132,11 +138,6 @@ export const ASK_AGENT_SEQ = "g c";
 
 /** Window between the two keystrokes of a sequence (GitHub `hotkey`'s value). */
 export const SEQUENCE_WINDOW_MS = 1500;
-
-/** A pending "go-to" prefix — armed by `g`, resolved by the next key or cleared
- * on expiry/unmapped/Escape/editable-focus. `at` is the arm timestamp so expiry
- * is a timestamp compare on the next keydown (no `setTimeout`, TR2 preserved). */
-export type PendingPrefix = { at: number };
 
 /** Format a `seq` for display: `"g d"` → `"G D"` (the palette/overlay hint). */
 export function formatSeqHint(seq: string): string {
@@ -173,16 +174,17 @@ const ADMIN_SEQUENCE_EFFECTS: Readonly<Record<string, CommandEffect>> =
 
 /**
  * Pure keystroke → sequence outcome, the DOM-free companion to `resolveShortcut`.
- * `pending === null` → the arm phase: a bare `g` (no modifier, not editable)
- * returns `"arm"`; anything else `null`. `pending` set → the resolve phase: a
+ * `armed === false` → the arm phase: a bare `g` (no modifier, not editable)
+ * returns `"arm"`; anything else `null`. `armed === true` → the resolve phase: a
  * mapped second key returns its `CommandEffect` (admin-gated for `g a`); an
  * unmapped key / second `g` / chord / editable focus returns `null` (the caller
  * clears the prefix and lets the key fall through to its own binding). Auto-repeat
  * never arms or resolves. Shares `isEditable` with `resolveShortcut` so both are
- * tested without a DOM. Expiry is the caller's concern (timestamp on `pending`).
+ * tested without a DOM. The 1500 ms expiry is the caller's concern (it tracks the
+ * arm timestamp; a pure matcher cannot see wall-clock).
  */
 export function resolveSequence(
-  pending: PendingPrefix | null,
+  armed: boolean,
   e: ShortcutKeyEvent,
   ctx: ShortcutContext,
 ): CommandEffect | "arm" | null {
@@ -190,9 +192,9 @@ export function resolveSequence(
   if (e.repeat) return null;
   const mod = e.metaKey || e.ctrlKey;
   const k = e.key.toLowerCase();
-  if (pending === null) {
-    // Arm phase — only a bare `g` starts a sequence.
-    return !mod && k === "g" ? "arm" : null;
+  if (!armed) {
+    // Arm phase — only a bare `g` prefix starts a sequence.
+    return !mod && k === SEQUENCE_PREFIX ? "arm" : null;
   }
   // Resolve phase — a modifier chord aborts (falls through to resolveShortcut).
   if (mod) return null;
@@ -401,9 +403,10 @@ export function ShortcutsProvider({
     runEffect,
   };
 
-  // The pending "go-to" prefix, held in a ref so the ONE listener never
-  // re-subscribes (TR2). Armed by `g`, resolved/cleared on the next key.
-  const pendingPrefixRef = useRef<PendingPrefix | null>(null);
+  // The pending "go-to" prefix as its arm timestamp (null = none), held in a ref
+  // so the ONE listener never re-subscribes (TR2). Armed by `g`; resolved/cleared
+  // on the next key. Expiry is `Date.now() - armedAt > SEQUENCE_WINDOW_MS`.
+  const pendingPrefixRef = useRef<number | null>(null);
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -413,17 +416,27 @@ export function ShortcutsProvider({
       if (!s.shortcutsEnabled) return;
       // Auto-repeat (held key) never arms, advances, or clears a sequence.
       if (e.repeat) return;
+      // A lone modifier keydown (Shift/Ctrl/Alt/Meta) is never a shortcut and must
+      // not clear a pending prefix — so `g` then Shift-hold then `d` still works.
+      if (
+        e.key === "Shift" ||
+        e.key === "Control" ||
+        e.key === "Alt" ||
+        e.key === "Meta"
+      )
+        return;
 
       // --- Pending go-to prefix: resolve or clear. Runs BEFORE the Escape
       // drawer branch and the chord matcher so `g` then <key> is handled as one
       // sequence (FR1). ---
-      const pending = pendingPrefixRef.current;
-      if (pending) {
-        const expired = Date.now() - pending.at > SEQUENCE_WINDOW_MS;
+      const armedAt = pendingPrefixRef.current;
+      if (armedAt !== null) {
         // The second key always ends the sequence, mapped or not.
         pendingPrefixRef.current = null;
-        if (!expired) {
-          const effect = resolveSequence(pending, e, { isAdmin: s.isAdmin });
+        if (Date.now() - armedAt <= SEQUENCE_WINDOW_MS) {
+          const effect = resolveSequence(true, e, { isAdmin: s.isAdmin });
+          // `armed === true` cannot return "arm" at runtime, but the union type
+          // includes it — the `!== "arm"` check narrows it out for `runEffect`.
           if (effect && effect !== "arm") {
             e.preventDefault();
             s.runEffect(effect);
@@ -470,27 +483,23 @@ export function ShortcutsProvider({
       }
 
       // --- Arm a new go-to prefix on `g`. Gated on the command-palette flag
-      // (`enabled`) — these are new flag-gated bindings — AND suppressed while an
-      // overlay is open (FR7: the help overlay has no focused input, so isEditable
-      // alone would let `g d` navigate from underneath it). ---
+      // (`enabled`) — these are new flag-gated bindings — AND suppressed while the
+      // palette/help overlay is open. ---
       if (s.enabled && !s.paletteOpen && !s.helpOpen) {
-        if (resolveSequence(null, e, { isAdmin: s.isAdmin }) === "arm") {
+        if (resolveSequence(false, e, { isAdmin: s.isAdmin }) === "arm") {
+          // Also suppress while ANY app modal is open (generalizes FR7 beyond
+          // palette/help): a go-sequence fired from a button inside a modal —
+          // where focus is non-editable — would navigate away and silently
+          // discard the modal's unsaved input. Cheap: only runs on a `g` press.
+          if (document.querySelector('[role="dialog"][aria-modal="true"]'))
+            return;
           e.preventDefault();
-          pendingPrefixRef.current = { at: Date.now() };
+          pendingPrefixRef.current = Date.now();
         }
       }
     }
-    // Focusing an editable element clears a stale prefix — never trap the user
-    // mid-sequence (belt-and-suspenders; the 1500 ms window already bounds it).
-    function handleFocusIn(e: FocusEvent) {
-      if (isEditable(e.target)) pendingPrefixRef.current = null;
-    }
     document.addEventListener("keydown", handleKeyDown);
-    document.addEventListener("focusin", handleFocusIn);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-      document.removeEventListener("focusin", handleFocusIn);
-    };
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, []);
 
   const value = useMemo<ShortcutsContextValue>(

--- a/apps/web-platform/components/command-palette/use-shortcuts.tsx
+++ b/apps/web-platform/components/command-palette/use-shortcuts.tsx
@@ -62,6 +62,8 @@ export type ShortcutKeyEvent = {
   ctrlKey: boolean;
   shiftKey: boolean;
   target: unknown;
+  /** Auto-repeat (held key). A repeat never arms/advances a sequence (MDN std). */
+  repeat?: boolean;
 };
 
 /** The trigger a keystroke maps to (null = no shortcut / suppressed). */
@@ -115,6 +117,92 @@ export function writeShortcutsEnabled(enabled: boolean): void {
 
 import { NAV_ITEMS, ADMIN_NAV_ITEMS, SETTINGS_NAV_ITEMS } from "./nav-items";
 
+// ---------------------------------------------------------------------------
+// Direct "go-to" keyboard sequences (`g` prefix + a letter) — #5636, the
+// wireframe's design. The `seq` field on NAV_ITEMS/ADMIN_NAV_ITEMS is the SINGLE
+// source: the resolver map, the palette key hint, and the `?` overlay rows all
+// derive from it, so a documented key can never drift from the live binding.
+// ---------------------------------------------------------------------------
+
+/** The Ask-an-agent hero sequence ("go to chat"). Not a nav route, so it lives
+ * here rather than on a nav array. Rebound from the requested `Ctrl+C` (a hard
+ * copy/SIGINT conflict `isEditable` cannot protect) to the collision-free
+ * `g`-family — `c` = chat, the closest surviving letter. */
+export const ASK_AGENT_SEQ = "g c";
+
+/** Window between the two keystrokes of a sequence (GitHub `hotkey`'s value). */
+export const SEQUENCE_WINDOW_MS = 1500;
+
+/** A pending "go-to" prefix — armed by `g`, resolved by the next key or cleared
+ * on expiry/unmapped/Escape/editable-focus. `at` is the arm timestamp so expiry
+ * is a timestamp compare on the next keydown (no `setTimeout`, TR2 preserved). */
+export type PendingPrefix = { at: number };
+
+/** Format a `seq` for display: `"g d"` → `"G D"` (the palette/overlay hint). */
+export function formatSeqHint(seq: string): string {
+  return seq
+    .split(" ")
+    .map((k) => k.toUpperCase())
+    .join(" ");
+}
+
+/** The letter that follows the `g` prefix (`"g d"` → `"d"`), lower-cased. */
+function seqSecondKey(seq: string): string {
+  return (seq.split(" ")[1] ?? "").toLowerCase();
+}
+
+// Second-key → effect, derived once from the single-source `seq` fields.
+const NAV_SEQUENCE_EFFECTS: Readonly<Record<string, CommandEffect>> = {
+  ...Object.fromEntries(
+    NAV_ITEMS.filter((i) => i.seq).map((i) => [
+      seqSecondKey(i.seq as string),
+      { kind: "navigate", href: i.href } as CommandEffect,
+    ]),
+  ),
+  [seqSecondKey(ASK_AGENT_SEQ)]: { kind: "openChat" },
+};
+
+// Admin-only second keys (`g a` → Analytics), resolved only when `ctx.isAdmin`.
+const ADMIN_SEQUENCE_EFFECTS: Readonly<Record<string, CommandEffect>> =
+  Object.fromEntries(
+    ADMIN_NAV_ITEMS.filter((i) => i.seq).map((i) => [
+      seqSecondKey(i.seq as string),
+      { kind: "navigate", href: i.href } as CommandEffect,
+    ]),
+  );
+
+/**
+ * Pure keystroke → sequence outcome, the DOM-free companion to `resolveShortcut`.
+ * `pending === null` → the arm phase: a bare `g` (no modifier, not editable)
+ * returns `"arm"`; anything else `null`. `pending` set → the resolve phase: a
+ * mapped second key returns its `CommandEffect` (admin-gated for `g a`); an
+ * unmapped key / second `g` / chord / editable focus returns `null` (the caller
+ * clears the prefix and lets the key fall through to its own binding). Auto-repeat
+ * never arms or resolves. Shares `isEditable` with `resolveShortcut` so both are
+ * tested without a DOM. Expiry is the caller's concern (timestamp on `pending`).
+ */
+export function resolveSequence(
+  pending: PendingPrefix | null,
+  e: ShortcutKeyEvent,
+  ctx: ShortcutContext,
+): CommandEffect | "arm" | null {
+  if (isEditable(e.target)) return null;
+  if (e.repeat) return null;
+  const mod = e.metaKey || e.ctrlKey;
+  const k = e.key.toLowerCase();
+  if (pending === null) {
+    // Arm phase — only a bare `g` starts a sequence.
+    return !mod && k === "g" ? "arm" : null;
+  }
+  // Resolve phase — a modifier chord aborts (falls through to resolveShortcut).
+  if (mod) return null;
+  const navEffect = NAV_SEQUENCE_EFFECTS[k];
+  if (navEffect) return navEffect;
+  const adminEffect = ADMIN_SEQUENCE_EFFECTS[k];
+  if (adminEffect) return ctx.isAdmin ? adminEffect : null;
+  return null;
+}
+
 /**
  * The static command registry (navigation + hero actions). Routine and KB-doc
  * commands are async (fetched when the palette opens) and built in the palette
@@ -129,6 +217,8 @@ export function buildCommands(ctx: ShortcutContext): Command[] {
       id: `nav:${item.href}`,
       label: item.label,
       group: "Navigation" as const,
+      // Key hint derived from the single-source `seq` field (`"g d"` → `G D`).
+      ...(item.seq ? { keys: formatSeqHint(item.seq) } : {}),
       run: () => ({ kind: "navigate" as const, href: item.href }),
     }),
   );
@@ -145,7 +235,9 @@ export function buildCommands(ctx: ShortcutContext): Command[] {
       id: "ask-agent",
       label: "Ask an agent",
       group: "Ask an agent",
-      keys: "⌘↵",
+      // Show the GLOBAL summon binding (`G C`), not the palette-only `⌘↵` — the
+      // latter only fires with the palette already open.
+      keys: formatSeqHint(ASK_AGENT_SEQ),
       run: () => ({ kind: "openChat" as const }),
     },
     {
@@ -293,24 +385,62 @@ export function ShortcutsProvider({
     shortcutsEnabled,
     paletteOpen,
     helpOpen,
+    isAdmin,
     onToggleSidebar,
     onEscape,
+    runEffect,
   });
   stateRef.current = {
     enabled,
     shortcutsEnabled,
     paletteOpen,
     helpOpen,
+    isAdmin,
     onToggleSidebar,
     onEscape,
+    runEffect,
   };
+
+  // The pending "go-to" prefix, held in a ref so the ONE listener never
+  // re-subscribes (TR2). Armed by `g`, resolved/cleared on the next key.
+  const pendingPrefixRef = useRef<PendingPrefix | null>(null);
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       const s = stateRef.current;
       // `shortcutsEnabled` is the WCAG SC 2.1.4 turn-off — when off it disables
-      // the WHOLE listener (⌘K/⌘//?/⌘B), per FR9/AC10.
+      // the WHOLE listener (⌘K/⌘//?/⌘B AND the go-to sequences), per FR9/AC10.
       if (!s.shortcutsEnabled) return;
+      // Auto-repeat (held key) never arms, advances, or clears a sequence.
+      if (e.repeat) return;
+
+      // --- Pending go-to prefix: resolve or clear. Runs BEFORE the Escape
+      // drawer branch and the chord matcher so `g` then <key> is handled as one
+      // sequence (FR1). ---
+      const pending = pendingPrefixRef.current;
+      if (pending) {
+        const expired = Date.now() - pending.at > SEQUENCE_WINDOW_MS;
+        // The second key always ends the sequence, mapped or not.
+        pendingPrefixRef.current = null;
+        if (!expired) {
+          const effect = resolveSequence(pending, e, { isAdmin: s.isAdmin });
+          if (effect && effect !== "arm") {
+            e.preventDefault();
+            s.runEffect(effect);
+            return;
+          }
+          // Escape aborts the prefix and is SWALLOWED so it does not also close
+          // the mobile drawer (AC9). Any other unmapped key falls through below
+          // so it still runs its own binding (`g` then `⌘K` opens the palette).
+          if (e.key === "Escape") {
+            e.preventDefault();
+            return;
+          }
+        }
+        // Expired, or unmapped non-Escape key: prefix cleared; fall through and
+        // handle THIS key normally.
+      }
+
       // Esc closes the mobile drawer ONLY when no overlay is layered above it
       // (the palette/help own their own Esc via Radix). Not gated by isEditable
       // — Esc must escape an input too. A pre-existing capability, not flag-gated.
@@ -319,26 +449,48 @@ export function ShortcutsProvider({
         return;
       }
       const action = resolveShortcut(e);
-      if (!action) return;
-      // The palette + help overlay are the NEW flag-gated surfaces. ⌘B (sidebar
-      // toggle) is a pre-existing capability (since #2415) migrated into this one
-      // listener — it must keep working even when the command-palette flag is OFF,
-      // so it is NOT gated on `enabled` (only on `shortcutsEnabled`, above).
-      if (action === "openPalette") {
-        if (!s.enabled) return;
-        e.preventDefault();
-        setPaletteOpen(true);
-      } else if (action === "openHelp") {
-        if (!s.enabled) return;
-        e.preventDefault();
-        setHelpOpen(true);
-      } else if (action === "toggleSidebar") {
-        e.preventDefault();
-        s.onToggleSidebar();
+      if (action) {
+        // The palette + help overlay are the NEW flag-gated surfaces. ⌘B (sidebar
+        // toggle) is a pre-existing capability (since #2415) migrated into this one
+        // listener — it must keep working even when the command-palette flag is OFF,
+        // so it is NOT gated on `enabled` (only on `shortcutsEnabled`, above).
+        if (action === "openPalette") {
+          if (!s.enabled) return;
+          e.preventDefault();
+          setPaletteOpen(true);
+        } else if (action === "openHelp") {
+          if (!s.enabled) return;
+          e.preventDefault();
+          setHelpOpen(true);
+        } else if (action === "toggleSidebar") {
+          e.preventDefault();
+          s.onToggleSidebar();
+        }
+        return;
+      }
+
+      // --- Arm a new go-to prefix on `g`. Gated on the command-palette flag
+      // (`enabled`) — these are new flag-gated bindings — AND suppressed while an
+      // overlay is open (FR7: the help overlay has no focused input, so isEditable
+      // alone would let `g d` navigate from underneath it). ---
+      if (s.enabled && !s.paletteOpen && !s.helpOpen) {
+        if (resolveSequence(null, e, { isAdmin: s.isAdmin }) === "arm") {
+          e.preventDefault();
+          pendingPrefixRef.current = { at: Date.now() };
+        }
       }
     }
+    // Focusing an editable element clears a stale prefix — never trap the user
+    // mid-sequence (belt-and-suspenders; the 1500 ms window already bounds it).
+    function handleFocusIn(e: FocusEvent) {
+      if (isEditable(e.target)) pendingPrefixRef.current = null;
+    }
     document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
+    document.addEventListener("focusin", handleFocusIn);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("focusin", handleFocusIn);
+    };
   }, []);
 
   const value = useMemo<ShortcutsContextValue>(

--- a/apps/web-platform/test/command-palette.test.tsx
+++ b/apps/web-platform/test/command-palette.test.tsx
@@ -104,11 +104,15 @@ function mockFetch(opts: {
 }
 
 function renderPalette(
-  props: Partial<{ isAdmin: boolean; onToggleSidebar: () => void }> = {},
+  props: Partial<{
+    isAdmin: boolean;
+    enabled: boolean;
+    onToggleSidebar: () => void;
+  }> = {},
 ) {
   return render(
     <ShortcutsProvider
-      enabled
+      enabled={props.enabled ?? true}
       isAdmin={props.isAdmin ?? false}
       onToggleSidebar={props.onToggleSidebar ?? (() => {})}
     >
@@ -180,6 +184,131 @@ describe("CommandPalette — open / suppression", () => {
     pressKey("k", { meta: true });
     await screen.findByLabelText("Command palette search");
     expect(screen.getByText("Analytics")).toBeInTheDocument();
+  });
+});
+
+describe("CommandPalette — direct shortcut hints (FR3/AC4)", () => {
+  it("renders the go-to key hint on each nav row and G C on the ask hero", async () => {
+    renderPalette();
+    pressKey("k", { meta: true });
+    await screen.findByLabelText("Command palette search");
+    // Each nav row shows its `G <letter>` hint.
+    expect(screen.getByText("G D")).toBeInTheDocument(); // Dashboard
+    expect(screen.getByText("G I")).toBeInTheDocument(); // Inbox
+    expect(screen.getByText("G W")).toBeInTheDocument(); // Workstream
+    expect(screen.getByText("G K")).toBeInTheDocument(); // Knowledge Base
+    expect(screen.getByText("G R")).toBeInTheDocument(); // Routines
+    // The ask hero shows its GLOBAL summon binding, not the palette-only ⌘↵.
+    const ask = screen.getByTestId("cmd-ask-agent");
+    expect(ask).toHaveTextContent("G C");
+    expect(ask).not.toHaveTextContent("⌘↵");
+  });
+
+  it("omits the Analytics row + hint for a non-admin, shows G A for an admin", async () => {
+    const { unmount } = renderPalette({ isAdmin: false });
+    pressKey("k", { meta: true });
+    await screen.findByLabelText("Command palette search");
+    expect(screen.queryByText("Analytics")).not.toBeInTheDocument();
+    expect(screen.queryByText("G A")).not.toBeInTheDocument();
+    unmount();
+
+    renderPalette({ isAdmin: true });
+    pressKey("k", { meta: true });
+    await screen.findByLabelText("Command palette search");
+    expect(screen.getByText("Analytics")).toBeInTheDocument();
+    expect(screen.getByText("G A")).toBeInTheDocument();
+  });
+});
+
+describe("CommandPalette — direct go-to sequences (FR1/FR2/AC2/AC3/AC9)", () => {
+  it("navigates on `g` then `d`", () => {
+    renderPalette();
+    pressKey("g");
+    pressKey("d");
+    expect(routerPush).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("routes every mapped second key, including `g c` → chat", () => {
+    renderPalette();
+    for (const [k, href] of [
+      ["i", "/dashboard/inbox"],
+      ["w", "/dashboard/workstream"],
+      ["k", "/dashboard/kb"],
+      ["r", "/dashboard/routines"],
+      ["c", "/dashboard/chat/new"],
+    ] as const) {
+      routerPush.mockClear();
+      pressKey("g");
+      pressKey(k);
+      expect(routerPush).toHaveBeenCalledWith(href);
+    }
+  });
+
+  it("does not navigate on `g` then Escape (prefix cleared, drawer untouched)", () => {
+    renderPalette();
+    pressKey("g");
+    pressKey("Escape");
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+
+  it("does not arm while focus is in an editable element", () => {
+    renderPalette();
+    const input = screen.getByTestId("outside-input");
+    pressKey("g", { target: input });
+    pressKey("d", { target: input });
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+
+  it("`g` then an unmapped key aborts, and a fresh `g d` still works", () => {
+    renderPalette();
+    pressKey("g");
+    pressKey("x");
+    expect(routerPush).not.toHaveBeenCalled();
+    pressKey("g");
+    pressKey("d");
+    expect(routerPush).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("expires the prefix after the 1500ms window", () => {
+    vi.useFakeTimers();
+    try {
+      renderPalette();
+      pressKey("g");
+      vi.advanceTimersByTime(1600);
+      pressKey("d");
+      expect(routerPush).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("admin-gates `g a`: inert for a non-admin, navigates for an admin", () => {
+    const { unmount } = renderPalette({ isAdmin: false });
+    pressKey("g");
+    pressKey("a");
+    expect(routerPush).not.toHaveBeenCalled();
+    unmount();
+
+    renderPalette({ isAdmin: true });
+    pressKey("g");
+    pressKey("a");
+    expect(routerPush).toHaveBeenCalledWith("/dashboard/admin/analytics");
+  });
+
+  it("is inert when shortcutsEnabled=false (WCAG turn-off)", async () => {
+    localStorage.setItem("soleur:shortcuts.enabled", "0");
+    renderPalette();
+    await act(async () => {});
+    pressKey("g");
+    pressKey("d");
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+
+  it("is inert when the command-palette flag is off (enabled=false)", () => {
+    renderPalette({ enabled: false });
+    pressKey("g");
+    pressKey("d");
+    expect(routerPush).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web-platform/test/command-palette.test.tsx
+++ b/apps/web-platform/test/command-palette.test.tsx
@@ -108,6 +108,7 @@ function renderPalette(
     isAdmin: boolean;
     enabled: boolean;
     onToggleSidebar: () => void;
+    onEscape: () => void;
   }> = {},
 ) {
   return render(
@@ -115,6 +116,7 @@ function renderPalette(
       enabled={props.enabled ?? true}
       isAdmin={props.isAdmin ?? false}
       onToggleSidebar={props.onToggleSidebar ?? (() => {})}
+      onEscape={props.onEscape}
     >
       <input data-testid="outside-input" />
       <CommandPalette />
@@ -244,11 +246,35 @@ describe("CommandPalette — direct go-to sequences (FR1/FR2/AC2/AC3/AC9)", () =
     }
   });
 
-  it("does not navigate on `g` then Escape (prefix cleared, drawer untouched)", () => {
-    renderPalette();
+  it("`g` then Escape aborts the prefix and SWALLOWS Escape (drawer not closed, AC9)", () => {
+    const onEscape = vi.fn();
+    renderPalette({ onEscape });
     pressKey("g");
     pressKey("Escape");
     expect(routerPush).not.toHaveBeenCalled();
+    // The swallowed Escape must NOT fall through to the drawer-close handler…
+    expect(onEscape).not.toHaveBeenCalled();
+    // …but a bare Escape (no pending prefix) still closes the drawer.
+    pressKey("Escape");
+    expect(onEscape).toHaveBeenCalledTimes(1);
+  });
+
+  it("`g` then a chord (⌘K) still opens the palette (listener fall-through)", async () => {
+    renderPalette();
+    pressKey("g");
+    pressKey("k", { meta: true });
+    expect(
+      await screen.findByLabelText("Command palette search"),
+    ).toBeInTheDocument();
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+
+  it("a lone modifier keydown mid-sequence does not break `g` … `d`", () => {
+    renderPalette();
+    pressKey("g");
+    pressKey("Shift");
+    pressKey("d");
+    expect(routerPush).toHaveBeenCalledWith("/dashboard");
   });
 
   it("does not arm while focus is in an editable element", () => {
@@ -269,7 +295,20 @@ describe("CommandPalette — direct go-to sequences (FR1/FR2/AC2/AC3/AC9)", () =
     expect(routerPush).toHaveBeenCalledWith("/dashboard");
   });
 
-  it("expires the prefix after the 1500ms window", () => {
+  it("navigates when the second key lands within the 1500ms window", () => {
+    vi.useFakeTimers();
+    try {
+      renderPalette();
+      pressKey("g");
+      vi.advanceTimersByTime(1400);
+      pressKey("d");
+      expect(routerPush).toHaveBeenCalledWith("/dashboard");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("expires the prefix when the second key comes after the 1500ms window", () => {
     vi.useFakeTimers();
     try {
       renderPalette();
@@ -279,6 +318,23 @@ describe("CommandPalette — direct go-to sequences (FR1/FR2/AC2/AC3/AC9)", () =
       expect(routerPush).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
+    }
+  });
+
+  it("does not arm while an app modal (role=dialog aria-modal) is open", () => {
+    renderPalette();
+    // Simulate an open app modal (e.g. new-issue-dialog) — a go-sequence fired
+    // from a button inside it must NOT navigate away and discard unsaved input.
+    const modal = document.createElement("div");
+    modal.setAttribute("role", "dialog");
+    modal.setAttribute("aria-modal", "true");
+    document.body.appendChild(modal);
+    try {
+      pressKey("g");
+      pressKey("d");
+      expect(routerPush).not.toHaveBeenCalled();
+    } finally {
+      document.body.removeChild(modal);
     }
   });
 

--- a/apps/web-platform/test/help-overlay.test.tsx
+++ b/apps/web-platform/test/help-overlay.test.tsx
@@ -10,14 +10,20 @@ import { ShortcutsProvider } from "@/components/command-palette/use-shortcuts";
 import { HelpOverlay } from "@/components/command-palette/help-overlay";
 import { CommandPalette } from "@/components/command-palette/command-palette";
 
+// next/navigation router — capture push() for go-to navigate-effect assertions.
+const routerPush = vi.hoisted(() => vi.fn());
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  useRouter: () => ({ push: routerPush, replace: vi.fn(), prefetch: vi.fn() }),
 }));
 vi.mock("@/lib/client-observability", () => ({ reportSilentFallback: vi.fn() }));
 
-function renderHelp() {
+function renderHelp(props: Partial<{ isAdmin: boolean }> = {}) {
   return render(
-    <ShortcutsProvider enabled isAdmin={false} onToggleSidebar={() => {}}>
+    <ShortcutsProvider
+      enabled
+      isAdmin={props.isAdmin ?? false}
+      onToggleSidebar={() => {}}
+    >
       <input data-testid="outside-input" />
       <HelpOverlay />
     </ShortcutsProvider>,
@@ -63,6 +69,7 @@ function pressKey(
 }
 
 beforeEach(() => {
+  routerPush.mockClear();
   Element.prototype.scrollIntoView = vi.fn();
   vi.stubGlobal("fetch", vi.fn());
   try {
@@ -77,7 +84,7 @@ afterEach(() => {
 });
 
 describe("HelpOverlay", () => {
-  it("opens on ⌘/ and lists only the working v1 shortcuts (no G-sequence rows)", async () => {
+  it("opens on ⌘/ and lists the chords, the go-to sequences, and the agent summon", async () => {
     renderHelp();
     pressKey("/", { meta: true });
     expect(
@@ -85,9 +92,45 @@ describe("HelpOverlay", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Open command palette")).toBeInTheDocument();
     expect(screen.getByText("Toggle sidebar")).toBeInTheDocument();
-    // NG2-deferred nav sequences must NOT be documented.
-    expect(screen.queryByText(/then/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Go to/i)).not.toBeInTheDocument();
+    // #5636 go-to sequences are now un-deferred and documented.
+    expect(screen.getByText("Go to Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Go to Inbox")).toBeInTheDocument();
+    expect(screen.getByText("Go to Knowledge Base")).toBeInTheDocument();
+    expect(screen.getByTestId("help-row-G D")).toBeInTheDocument();
+    // The agent summon is grouped as an action (G C), not navigation.
+    expect(screen.getByTestId("help-row-G C")).toHaveTextContent("Ask an agent");
+    // Admin-only Analytics row is absent for a non-admin.
+    expect(screen.queryByText("Go to Analytics")).not.toBeInTheDocument();
+  });
+
+  it("shows the Go to Analytics row only for an admin", async () => {
+    renderHelp({ isAdmin: true });
+    pressKey("/", { meta: true });
+    await screen.findByLabelText("Search keyboard shortcuts");
+    expect(screen.getByText("Go to Analytics")).toBeInTheDocument();
+    expect(screen.getByTestId("help-row-G A")).toBeInTheDocument();
+  });
+
+  it("selecting a go-to row navigates and closes the overlay", async () => {
+    renderHelp();
+    pressKey("/", { meta: true });
+    await screen.findByLabelText("Search keyboard shortcuts");
+    fireEvent.click(screen.getByTestId("help-row-G D"));
+    expect(routerPush).toHaveBeenCalledWith("/dashboard");
+    expect(
+      screen.queryByLabelText("Search keyboard shortcuts"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("selecting the agent row opens chat and closes the overlay", async () => {
+    renderHelp();
+    pressKey("/", { meta: true });
+    await screen.findByLabelText("Search keyboard shortcuts");
+    fireEvent.click(screen.getByTestId("help-row-G C"));
+    expect(routerPush).toHaveBeenCalledWith("/dashboard/chat/new");
+    expect(
+      screen.queryByLabelText("Search keyboard shortcuts"),
+    ).not.toBeInTheDocument();
   });
 
   it("opens on a bare ? from the body", async () => {

--- a/apps/web-platform/test/shortcuts-registry.test.ts
+++ b/apps/web-platform/test/shortcuts-registry.test.ts
@@ -3,11 +3,19 @@ import {
   isEditable,
   buildCommands,
   resolveShortcut,
+  resolveSequence,
+  formatSeqHint,
+  ASK_AGENT_SEQ,
+  SEQUENCE_WINDOW_MS,
   readShortcutsEnabled,
   writeShortcutsEnabled,
   SHORTCUTS_STORAGE_KEY,
   type Command,
 } from "@/components/command-palette/use-shortcuts";
+import {
+  NAV_ITEMS,
+  ADMIN_NAV_ITEMS,
+} from "@/components/command-palette/nav-items";
 
 function byId(cmds: Command[], id: string): Command | undefined {
   return cmds.find((c) => c.id === id);
@@ -88,6 +96,104 @@ describe("buildCommands", () => {
   it("exposes the help command (opens the ? overlay) as a serializable effect", () => {
     const help = byId(buildCommands({ isAdmin: false }), "help");
     expect(help?.run().kind).toBe("openHelp");
+  });
+});
+
+describe("resolveSequence", () => {
+  const admin = { isAdmin: true };
+  const nonAdmin = { isAdmin: false };
+  // A pending prefix (the resolve phase). `at` is irrelevant to the pure
+  // resolver — expiry is the listener's concern.
+  const pending = { at: 0 };
+
+  it("arms on a bare g when no prefix is pending", () => {
+    expect(resolveSequence(null, key("g"), nonAdmin)).toBe("arm");
+    expect(resolveSequence(null, key("G"), nonAdmin)).toBe("arm");
+  });
+
+  it("does not arm on g with a modifier, or while focus is editable", () => {
+    expect(resolveSequence(null, key("g", { meta: true }), nonAdmin)).toBeNull();
+    expect(resolveSequence(null, key("g", { ctrl: true }), nonAdmin)).toBeNull();
+    expect(
+      resolveSequence(null, key("g", { target: { tagName: "INPUT" } }), nonAdmin),
+    ).toBeNull();
+  });
+
+  it("does not arm or resolve on auto-repeat", () => {
+    expect(resolveSequence(null, { ...key("g"), repeat: true }, nonAdmin)).toBeNull();
+    expect(
+      resolveSequence(pending, { ...key("d"), repeat: true }, nonAdmin),
+    ).toBeNull();
+  });
+
+  it("resolves each mapped second key to its navigate/openChat effect", () => {
+    expect(resolveSequence(pending, key("d"), nonAdmin)).toEqual({
+      kind: "navigate",
+      href: "/dashboard",
+    });
+    expect(resolveSequence(pending, key("i"), nonAdmin)).toEqual({
+      kind: "navigate",
+      href: "/dashboard/inbox",
+    });
+    expect(resolveSequence(pending, key("w"), nonAdmin)).toEqual({
+      kind: "navigate",
+      href: "/dashboard/workstream",
+    });
+    expect(resolveSequence(pending, key("k"), nonAdmin)).toEqual({
+      kind: "navigate",
+      href: "/dashboard/kb",
+    });
+    expect(resolveSequence(pending, key("r"), nonAdmin)).toEqual({
+      kind: "navigate",
+      href: "/dashboard/routines",
+    });
+    // `g c` — Ask an agent (the rebound-from-Ctrl+C hero summon).
+    expect(resolveSequence(pending, key("c"), nonAdmin)).toEqual({
+      kind: "openChat",
+    });
+  });
+
+  it("gates g a (Analytics) on ctx.isAdmin", () => {
+    expect(resolveSequence(pending, key("a"), admin)).toEqual({
+      kind: "navigate",
+      href: "/dashboard/admin/analytics",
+    });
+    expect(resolveSequence(pending, key("a"), nonAdmin)).toBeNull();
+  });
+
+  it("returns null for an unmapped second key, a second g, and a chord", () => {
+    expect(resolveSequence(pending, key("x"), admin)).toBeNull();
+    expect(resolveSequence(pending, key("g"), admin)).toBeNull();
+    expect(resolveSequence(pending, key("k", { meta: true }), admin)).toBeNull();
+  });
+
+  it("is suppressed while focus is editable even mid-sequence", () => {
+    expect(
+      resolveSequence(pending, key("d", { target: { tagName: "TEXTAREA" } }), admin),
+    ).toBeNull();
+  });
+});
+
+describe("seq single-source (AC7) + formatSeqHint", () => {
+  it("upcases a sequence for display (g d -> G D)", () => {
+    expect(formatSeqHint("g d")).toBe("G D");
+    expect(formatSeqHint(ASK_AGENT_SEQ)).toBe("G C");
+  });
+
+  it("uses GitHub's proven 1500 ms sequence window", () => {
+    expect(SEQUENCE_WINDOW_MS).toBe(1500);
+  });
+
+  it("derives every nav command's keys hint from the seq field on the arrays", () => {
+    const cmds = buildCommands({ isAdmin: true });
+    for (const item of [...NAV_ITEMS, ...ADMIN_NAV_ITEMS]) {
+      const cmd = byId(cmds, `nav:${item.href}`);
+      expect(item.seq).toBeTruthy();
+      expect(cmd?.keys).toBe(formatSeqHint(item.seq as string));
+    }
+    // The ask hero shows its GLOBAL summon binding, not the palette-only ⌘↵.
+    expect(byId(cmds, "ask-agent")?.keys).toBe("G C");
+    expect(byId(cmds, "ask-agent")?.keys).not.toBe("⌘↵");
   });
 });
 

--- a/apps/web-platform/test/shortcuts-registry.test.ts
+++ b/apps/web-platform/test/shortcuts-registry.test.ts
@@ -102,74 +102,73 @@ describe("buildCommands", () => {
 describe("resolveSequence", () => {
   const admin = { isAdmin: true };
   const nonAdmin = { isAdmin: false };
-  // A pending prefix (the resolve phase). `at` is irrelevant to the pure
-  // resolver — expiry is the listener's concern.
-  const pending = { at: 0 };
+  // `armed` is the phase discriminant: false = arm phase, true = resolve phase.
+  // Expiry (the arm timestamp) is the listener's concern, not the pure resolver's.
 
   it("arms on a bare g when no prefix is pending", () => {
-    expect(resolveSequence(null, key("g"), nonAdmin)).toBe("arm");
-    expect(resolveSequence(null, key("G"), nonAdmin)).toBe("arm");
+    expect(resolveSequence(false, key("g"), nonAdmin)).toBe("arm");
+    expect(resolveSequence(false, key("G"), nonAdmin)).toBe("arm");
   });
 
   it("does not arm on g with a modifier, or while focus is editable", () => {
-    expect(resolveSequence(null, key("g", { meta: true }), nonAdmin)).toBeNull();
-    expect(resolveSequence(null, key("g", { ctrl: true }), nonAdmin)).toBeNull();
+    expect(resolveSequence(false, key("g", { meta: true }), nonAdmin)).toBeNull();
+    expect(resolveSequence(false, key("g", { ctrl: true }), nonAdmin)).toBeNull();
     expect(
-      resolveSequence(null, key("g", { target: { tagName: "INPUT" } }), nonAdmin),
+      resolveSequence(false, key("g", { target: { tagName: "INPUT" } }), nonAdmin),
     ).toBeNull();
   });
 
   it("does not arm or resolve on auto-repeat", () => {
-    expect(resolveSequence(null, { ...key("g"), repeat: true }, nonAdmin)).toBeNull();
+    expect(resolveSequence(false, { ...key("g"), repeat: true }, nonAdmin)).toBeNull();
     expect(
-      resolveSequence(pending, { ...key("d"), repeat: true }, nonAdmin),
+      resolveSequence(true, { ...key("d"), repeat: true }, nonAdmin),
     ).toBeNull();
   });
 
   it("resolves each mapped second key to its navigate/openChat effect", () => {
-    expect(resolveSequence(pending, key("d"), nonAdmin)).toEqual({
+    expect(resolveSequence(true, key("d"), nonAdmin)).toEqual({
       kind: "navigate",
       href: "/dashboard",
     });
-    expect(resolveSequence(pending, key("i"), nonAdmin)).toEqual({
+    expect(resolveSequence(true, key("i"), nonAdmin)).toEqual({
       kind: "navigate",
       href: "/dashboard/inbox",
     });
-    expect(resolveSequence(pending, key("w"), nonAdmin)).toEqual({
+    expect(resolveSequence(true, key("w"), nonAdmin)).toEqual({
       kind: "navigate",
       href: "/dashboard/workstream",
     });
-    expect(resolveSequence(pending, key("k"), nonAdmin)).toEqual({
+    expect(resolveSequence(true, key("k"), nonAdmin)).toEqual({
       kind: "navigate",
       href: "/dashboard/kb",
     });
-    expect(resolveSequence(pending, key("r"), nonAdmin)).toEqual({
+    expect(resolveSequence(true, key("r"), nonAdmin)).toEqual({
       kind: "navigate",
       href: "/dashboard/routines",
     });
     // `g c` — Ask an agent (the rebound-from-Ctrl+C hero summon).
-    expect(resolveSequence(pending, key("c"), nonAdmin)).toEqual({
+    expect(resolveSequence(true, key("c"), nonAdmin)).toEqual({
       kind: "openChat",
     });
   });
 
   it("gates g a (Analytics) on ctx.isAdmin", () => {
-    expect(resolveSequence(pending, key("a"), admin)).toEqual({
+    expect(resolveSequence(true, key("a"), admin)).toEqual({
       kind: "navigate",
       href: "/dashboard/admin/analytics",
     });
-    expect(resolveSequence(pending, key("a"), nonAdmin)).toBeNull();
+    expect(resolveSequence(true, key("a"), nonAdmin)).toBeNull();
   });
 
   it("returns null for an unmapped second key, a second g, and a chord", () => {
-    expect(resolveSequence(pending, key("x"), admin)).toBeNull();
-    expect(resolveSequence(pending, key("g"), admin)).toBeNull();
-    expect(resolveSequence(pending, key("k", { meta: true }), admin)).toBeNull();
+    expect(resolveSequence(true, key("x"), admin)).toBeNull();
+    expect(resolveSequence(true, key("g"), admin)).toBeNull();
+    expect(resolveSequence(true, key("k", { meta: true }), admin)).toBeNull();
   });
 
   it("is suppressed while focus is editable even mid-sequence", () => {
     expect(
-      resolveSequence(pending, key("d", { target: { tagName: "TEXTAREA" } }), admin),
+      resolveSequence(true, key("d", { target: { tagName: "TEXTAREA" } }), admin),
     ).toBeNull();
   });
 });

--- a/knowledge-base/marketing/distribution-content/2026-07-01-command-palette-keyboard-shortcuts.md
+++ b/knowledge-base/marketing/distribution-content/2026-07-01-command-palette-keyboard-shortcuts.md
@@ -1,0 +1,23 @@
+---
+title: "Jump anywhere in the app with two keystrokes"
+type: feature-launch
+publish_date: ""
+channels: x, bluesky
+status: draft
+pr_reference: "#5867"
+issue_reference: "#5636"
+---
+
+<!-- To publish: set BOTH publish_date AND status: scheduled -->
+
+## X/Twitter Thread
+
+Just shipped: jump anywhere in the app without touching your mouse. Press G then D for your dashboard, G then I for your inbox, G then K for your knowledge base. Muscle memory beats menu-hunting.
+
+2/ Every destination now has a two-key shortcut — with the hint shown right next to it, so you learn them as you go. Still love the command palette? ⌘K is right where you left it.
+
+3/ Small detail, big feel. The kind of thing that makes the software get out of your way so you can just work.
+
+## Bluesky
+
+Just shipped keyboard shortcuts for jumping straight to any part of the app — press G then D for the dashboard, G then I for the inbox, and so on. Each shortcut shows a hint next to it, so you pick them up as you go. Less menu-hunting, more doing.

--- a/knowledge-base/project/learnings/ui-bugs/2026-07-01-global-go-sequences-must-suppress-under-any-app-modal.md
+++ b/knowledge-base/project/learnings/ui-bugs/2026-07-01-global-go-sequences-must-suppress-under-any-app-modal.md
@@ -1,0 +1,81 @@
+---
+title: "Global keyboard go-sequences must suppress while ANY app modal is open, not just the palette/help overlay"
+date: 2026-07-01
+category: ui-bugs
+module: apps/web-platform/components/command-palette
+tags: [keyboard-shortcuts, command-palette, modals, data-loss, user-impact-review]
+pr: 5867
+closes: 5636
+---
+
+# Global go-sequences must suppress under any app modal
+
+## Problem
+
+PR #5867 added global two-key "go-to" sequences (`g d`, `g i`, … `g c`) to the
+command palette. The plan's FR7 suppressed sequences only while `paletteOpen ||
+helpOpen` — reasoning that the help overlay has no focused input, so `isEditable`
+alone would let `g d` navigate from underneath it.
+
+The `user-impact-reviewer` (fired by the plan's `single-user incident` threshold)
+found the guard was too narrow: the app has ~17 OTHER modals (`new-issue-dialog`,
+`cancel-retention-modal`, `transfer-ownership-dialog`, …). With focus on a
+**button** inside one of those (non-editable, so `isEditable` does not suppress),
+`g d` would arm + resolve → `router.push` → unmount the modal → **silently discard
+the modal's unsaved input**. The plan's own "navigating from underneath an open
+overlay is surprising" reasoning was never generalized past palette/help.
+
+## Solution
+
+Generalize the arm guard to also suppress while any app modal is mounted, using
+the app's consistent `[role="dialog"][aria-modal="true"]` convention:
+
+```ts
+if (s.enabled && !s.paletteOpen && !s.helpOpen) {
+  if (resolveSequence(false, e, { isAdmin: s.isAdmin }) === "arm") {
+    // Suppress while ANY app modal is open — a go-sequence fired from a button
+    // inside a modal would navigate away and discard unsaved input. Cheap: the
+    // querySelector only runs on a `g` press (the arm candidate).
+    if (document.querySelector('[role="dialog"][aria-modal="true"]')) return;
+    e.preventDefault();
+    pendingPrefixRef.current = Date.now();
+  }
+}
+```
+
+The DOM query is gated behind the `=== "arm"` check so it runs only on a `g`
+keypress, not every keystroke. The palette/help overlays are also `[role=dialog]`
+[aria-modal] when open, but they're already excluded by the explicit
+`!paletteOpen && !helpOpen` state and aren't in the DOM when closed, so there's
+no double-count.
+
+## Key Insight
+
+**A global keyboard-navigation binding is a document-level action, so its
+suppression set must be document-level too.** `isEditable(target)` only covers the
+*focused typing surface*; it does NOT cover "focus is on a non-editable control
+inside a modal that holds unsaved state." When you add any global go-to / navigate
+shortcut, enumerate every surface that holds unsaved user input — modals, drawers,
+wizards — not just text inputs, and suppress the shortcut while any is open. The
+app's `[role="dialog"][aria-modal="true"]` convention makes this a one-line DOM
+check.
+
+Corollary: `user-impact-reviewer` reliably surfaces this class where
+simplicity-biased plan-time review does not — its "name the artifact + name the
+vector" mandate forces enumeration of the unsaved-input surfaces the arm guard
+must respect.
+
+## Session Errors
+
+1. **Removed a load-bearing union-narrowing guard on a "redundant" review note.**
+   The code-quality reviewer flagged `if (effect && effect !== "arm")` as
+   redundant defensive code (true at runtime — the resolve phase can't return
+   `"arm"`). Collapsing `resolveSequence`'s pending arg to a boolean and dropping
+   the `!== "arm"` check broke `tsc` (TS2345: `CommandEffect | "arm"` not
+   assignable to `CommandEffect` at `runEffect(effect)`). The guard is
+   runtime-impossible but TYPE-required. — Recovery: restored `!== "arm"` with a
+   comment explaining it narrows the union for the compiler. — **Prevention:** a
+   union-narrowing guard flagged "redundant / always true" by a reviewer is often
+   load-bearing for the type system; run `tsc --noEmit` before removing it, and
+   keep it with a comment rather than deleting. Caught here by the Phase-6 tsc
+   gate before commit.

--- a/knowledge-base/project/plans/2026-07-01-feat-command-palette-direct-shortcuts-plan.md
+++ b/knowledge-base/project/plans/2026-07-01-feat-command-palette-direct-shortcuts-plan.md
@@ -1,0 +1,532 @@
+---
+title: "feat: Direct keyboard shortcuts for command-palette destinations"
+date: 2026-07-01
+branch: feat-one-shot-palette-page-shortcuts
+lane: cross-domain
+type: feature
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+closes: [5636]
+partially_addresses: ["#5637 (dedicated agent binding facet)", "brainstorm 2026-06-22 Open Question #1"]
+---
+
+# feat: Direct keyboard shortcuts for command-palette destinations ✨
+
+## Enhancement Summary
+
+**Deepened on:** 2026-07-01
+**Agents:** spec-flow-analyzer (binding/collision flows), framework-docs-researcher (sequence
+timing + WCAG 2.1.4 + cmdk hint rendering), code-simplicity-reviewer (YAGNI pass).
+
+**Key improvements folded in:**
+1. Bumped the sequence window to **1500 ms** (GitHub `hotkey`'s proven value; 1000 ms felt tight).
+2. Confirmed **WCAG 2.1.4 DOES apply to two-key sequences** (they are not modifier-exempt) — the
+   existing `shortcutsEnabled` turn-off is a valid, sufficient compliance path (W3C: turn-off OR
+   remap OR focus-only; we have turn-off).
+3. **Simplified per the YAGNI pass:** dropped the separate `NAV_SEQUENCES` table + bidirectional
+   drift test in favor of a `seq` field on the existing `NAV_ITEMS`/`ADMIN_NAV_ITEMS` arrays
+   (single-source by construction — drift structurally impossible, no test needed); relaxed the
+   guarded-no-op to "Next.js dedupes a same-route push"; collapsed `resolveSequence`'s return to
+   `CommandEffect | "arm" | null`.
+4. Grounded `<kbd>`-pair hint rendering for sequences (`G` `I` as two `<kbd>`) vs a single glyph
+   for chords, matching cmdk/Linear convention.
+5. Kept (justified, not YAGNI): the `paletteOpen || helpOpen` modal guard (overlay has no focused
+   input), resolver-level admin gating, no-new-dependency in-house buffer, `e.repeat` skip +
+   focusin-clear (both industry-standard, one line each).
+
+## Overview
+
+The shipped command layer (`⌘K` palette + `?` overlay, PR #5633) makes every destination
+reachable via **⌘K → type → Enter**. This feature adds **direct global shortcuts** so an
+operator can jump straight to a destination without opening the palette, shows each key hint
+inline in the palette, and lists them in the `?` overlay.
+
+Destinations to bind (from the palette registry):
+
+| Palette item | Group | Route | Requested binding |
+|---|---|---|---|
+| Ask an agent | Ask an agent | `/dashboard/chat/new` | `Ctrl+C` (conflicts — rebound, see §Binding Decision) |
+| Dashboard | Navigation | `/dashboard` | dedicated |
+| Inbox | Navigation | `/dashboard/inbox` | dedicated |
+| Workstream | Navigation | `/dashboard/workstream` | dedicated |
+| Knowledge Base | Navigation | `/dashboard/kb` | dedicated |
+| Routines | Navigation | `/dashboard/routines` | dedicated |
+| Analytics | Navigation (admin-only) | `/dashboard/admin/analytics` | dedicated |
+
+**This feature realizes deferred issue #5636** ("two-key navigation sequences — G then I"),
+whose re-evaluation criterion was *"Palette shipped and adopted; operators ask for faster nav
+than ⌘K-then-type. Build through the existing registry, not a parallel handler."* The palette
+shipped; this is that follow-up. It also resolves the parent brainstorm's Open Question #1
+("should 'Ask an agent' get a dedicated direct binding") for the agent hero action.
+
+Crucially: **the `G`-then-key nav-sequence design already exists in the shipped `#5633`
+wireframe.** `help-overlay.tsx:5-7` documents it verbatim — *"the wireframe's `G`-then-I/K/R/D
+nav sequences are NG2-deferred (#5636) and would document dead keys, so they are omitted."*
+This plan un-defers exactly that design: build the sequences, then surface them in the overlay.
+
+### Non-goals
+
+- **Single-key unmodified verbs** (bare `c`=create etc., #5637) — still deferred; chat-typing
+  collisions + no object model. This feature uses a `g`-**prefix**, never a bare letter.
+- **Rebinding / remap UI** — WCAG 2.1.4 is satisfied by the existing turn-off toggle (§Legal).
+- **Agent-invocable command surface** (#5638) — unchanged; the registry stays structured for it.
+- **New Flagsmith flag** — the new shortcuts ride the existing `command-palette` `enabled` gate.
+- **`tinykeys` or any new keyboard dependency** — the sequence buffer is ~30 lines in-house,
+  matching the existing pure-matcher philosophy (and avoids the `cmdk` lockfile-sync pain from
+  #5633; see §Sharp Edges).
+
+## Binding Decision (documented per request)
+
+The request said *"Ask an agent → Ctrl+C … Note: Ctrl+C is normally browser copy/interrupt — if
+it conflicts, pick the closest non-conflicting binding and document the choice"* and left the six
+nav bindings unspecified ("each get their own dedicated shortcut"). Here is the chosen scheme and
+why.
+
+### Why NOT modifier chords for the six nav items
+
+Every mnemonic `Ctrl/⌘+<letter>` collides with a browser shortcut on at least one major browser,
+and the `isEditable` guard cannot protect chords the browser handles before our listener:
+
+| Candidate | Collision |
+|---|---|
+| Ctrl/⌘+D (Dashboard) | Bookmark this page (all browsers) |
+| Ctrl/⌘+I (Inbox) | Firefox page-info / italic |
+| Ctrl/⌘+K (KB) | already taken (palette) |
+| Ctrl/⌘+R (Routines) | Reload page (all browsers) |
+| Ctrl/⌘+1..6 (by index) | Switch to tab N (Chrome/Firefox) |
+| Ctrl/⌘+J (agent, per brainstorm ⌘J idea) | Downloads (Chrome/Firefox, Win/Linux) |
+
+This collision minefield is precisely why Linear/GitHub/Slack — and Soleur's own #5633
+wireframe — use a **`g` "go-to" prefix** for navigation: `g` alone and each target letter alone
+do nothing, so there is nothing to collide with, and the sequence is mnemonic ("**g**o to **d**ashboard").
+
+### Chosen scheme
+
+**Navigation — two-key `g`-then-letter sequences** (mnemonic; the wireframe's design):
+
+| Sequence | Destination | Route | Gate |
+|---|---|---|---|
+| `g` `d` | Dashboard | `/dashboard` | always |
+| `g` `i` | Inbox | `/dashboard/inbox` | always |
+| `g` `w` | Workstream | `/dashboard/workstream` | always |
+| `g` `k` | Knowledge Base | `/dashboard/kb` | always |
+| `g` `r` | Routines | `/dashboard/routines` | always |
+| `g` `a` | Analytics | `/dashboard/admin/analytics` | **admin only** |
+
+**Ask an agent (hero action) — rebound from `Ctrl+C` to `g` `c`** ("go to chat"). Rationale:
+`Ctrl+C` is a hard, non-negotiable conflict — copying a selection from non-editable page content
+must keep working, and `isEditable` does NOT cover a text selection outside an input, so
+intercepting `Ctrl+C` would silently break copy (a `single-user incident`-class trust erosion).
+Folding the agent action into the same collision-free `g`-family keeps **one coherent, learnable,
+WCAG-safe scheme** rather than a chord that works on some browsers and breaks on others. `c` =
+**c**hat, closest surviving letter to the requested `Ctrl+C`.
+
+**Open UX call for CPO sign-off (the one flagged decision).** spec-flow (G12) argues the agent
+action is the *highest-value* shortcut and that `g c` semantically **demotes** it — it reframes
+"start a new agent conversation" (a hero *verb*) as mere *navigation to a page*, and buries it in
+the `g`-nav family. Linear reserves single-key `c` (create) precisely to give the hero verb
+distinct weight. The counter-arguments for `g c`: (a) a browser-safe single chord does not exist
+(`⌘J`=Downloads, `Ctrl+C`=copy, most `⌘+letter` are browser-claimed); (b) a bare single-key `c`
+is exactly deferred #5637 (chat-typing collision surface + WCAG 2.1.4 single-char shortcut) and
+re-opening it is out of scope; (c) one coherent `g`-family is more learnable than a mixed scheme.
+**Recommendation: `g c`, grouped under "Ask an agent" (NOT "Navigation") in the overlay so it
+reads as an action**, with the global hint shown as `G C` (not the palette-only `⌘↵`). If CPO
+prefers hero-weight, the only defensible single-keystroke fallback is documented-and-accepted
+`Ctrl+Shift+K` (browser-safe on Chrome; note Firefox uses it for the console) — awkward, hence
+not recommended. This is the sole item requiring CPO sign-off before `/work`.
+
+### Why this satisfies the request literally
+
+- "Register these global shortcuts" → six nav sequences + `g c` in the one global listener.
+- "Ask an agent → Ctrl+C … if it conflicts pick the closest non-conflicting binding and document"
+  → Ctrl+C conflicts; `g c` is the closest coherent non-conflicting binding; documented here.
+- "show the key hint next to each item in the command palette" → §FR3.
+- "surface them in the ? keyboard-shortcuts overlay" → §FR4.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a shortcut that navigates to the wrong page, or a
+`g`-prefix that swallows the next keystroke inside chat/search, or a bound `Ctrl+C` that stops
+copying selected text — on a keyboard surface the operator drives constantly.
+
+**If this leaks, the user's data is exposed via:** N/A — no data surface; client-side navigation
+only. The only "leak" vector is admin-gated `g a` navigating a non-admin toward an admin route
+(mitigated: the sequence is inert for non-admins AND the route is server-guarded regardless).
+
+**Brand-survival threshold:** single-user incident (inherited from the parent
+`2026-06-22-keyboard-shortcuts` brainstorm, tagged user-brand-critical per #5175).
+
+> CPO sign-off required at plan time before `/work` begins (the one open call is the hero-action
+> binding: `g c` vs a chord — §Binding Decision). `user-impact-reviewer` runs at review time.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim | Reality (verified) | Plan response |
+|---|---|---|
+| "Add global shortcuts" implies a new handler | One global listener already exists (`use-shortcuts.tsx`); `resolveShortcut` is a pure single-event matcher | Extend the ONE listener with a small `pendingPrefixRef` + a companion `resolveSequence`; no parallel handler, no new dep (honors #5636 criterion) |
+| Nav commands carry a `keys` hint today | They do NOT — only the General group commands set `keys`; the Navigation group maps `NAV_ITEMS` without `keys` and `command-palette.tsx` does not render hints for the Navigation group | Add `keys` to the nav + ask commands AND render the hint in the Navigation + Ask groups |
+| Ask-an-agent binding | Palette hero hint is `⌘↵` (Cmd+Enter, palette-open only); there is no global summon binding | Add a global `g c` summon + set the item's `keys` hint |
+| A new flag is needed | Command layer already gated by `command-palette` (`enabled`) | Reuse `enabled`; no flag-create |
+| Analytics is a normal nav item | It is `ADMIN_NAV_ITEMS`, admin-gated; `isAdmin` fetched via `/api/admin/check` and passed to the provider | `g a` reads `ctx.isAdmin`; inert + hidden from hints for non-admins |
+| `?`/`g`-sequences risk WCAG 2.1.4 | Existing `shortcutsEnabled` localStorage turn-off gates the WHOLE listener | Sequences inherit the turn-off; WCAG exception (a) satisfied |
+
+## Functional Requirements
+
+- **FR1 — Sequence resolution.** A `g` keydown (when not suppressed) arms a pending "go-to"
+  prefix for a short window (`SEQUENCE_WINDOW_MS = 1500` — GitHub `hotkey`'s proven value). A
+  subsequent mapped letter within the window resolves to the destination `CommandEffect`
+  (`navigate`/`openChat`) and clears the prefix. Any of: an unmapped key, a second `g`, `Escape`,
+  or window expiry → clears the prefix with **no navigation** (no dead-key surprise). Two subtleties
+  from the spec-flow pass (G2/G5), both industry-standard one-liners: (a) an **unmapped second key
+  falls through** — it aborts the prefix but is NOT swallowed, so `g` then `⌘K` still opens the
+  palette and `g` then `?` still opens help; (b) **auto-repeat is ignored** — `e.repeat === true`
+  never arms/advances (MDN-standard). A `focusin` into an editable also clears any pending prefix
+  (standard "don't trap the user" pattern; the 1500 ms window already bounds the stale-prefix
+  worst case to a sub-second window, so this is cheap belt-and-suspenders, not load-bearing).
+  Implemented as a DOM-free, unit-testable `resolveSequence(pending, event, ctx)` companion to
+  `resolveShortcut` returning `CommandEffect | "arm" | null` (three outcomes: navigate / arm-prefix
+  / clear), so both share the `isEditable` suppression and are tested without a DOM (matching
+  `shortcuts-registry.test.ts`).
+- **FR2 — Suppression parity.** Sequences obey the exact same guards as ⌘K/⌘B: suppressed while
+  `isEditable(target)` (chat input, palette/overlay search), while `!shortcutsEnabled` (WCAG
+  turn-off), and — for the *new nav/agent* bindings — while the `command-palette` flag is OFF
+  (`enabled === false`). (⌘B stays flag-independent as today.)
+- **FR3 — Palette key hints.** Each Navigation command and the Ask-an-agent hero item render their
+  key hint inline via the existing `.cmdk-keys` slot already used by the General group. Sequences
+  render as **two adjacent `<kbd>` elements** (`G` `D`) per cmdk/Linear convention; chords stay a
+  single glyph. Admin-only `g a` hint renders only when `isAdmin` (buildCommands already omits the
+  Analytics command for non-admins, so the hint is naturally absent).
+- **FR4 — Help overlay rows.** The `?`/`⌘/` overlay lists the six nav sequences + the agent
+  sequence (removing the `#5636`-deferred omission note in `help-overlay.tsx`), matching the
+  committed wireframe `knowledge-base/product/design/command-palette/command-shortcuts-wireframes.pen`
+  (the design of record from #5633). The admin-only Analytics row renders only when `isAdmin`. Rows
+  keep the existing "selecting a row runs the shortcut" behavior (each new row's action navigates /
+  opens chat via `runEffect`).
+- **FR5 — Admin gating.** `g a` navigates only when `ctx.isAdmin`; for a non-admin it is a
+  cleared prefix with no navigation, and neither the palette hint nor the overlay row appear.
+- **FR6 — Idempotent navigation.** A nav sequence resolved while already on the target route is a
+  harmless same-route `router.push` — Next.js App Router de-dupes it (no full reload). No explicit
+  `pathname === href` guard is warranted (the YAGNI pass confirmed the loading-flash it would
+  prevent is not reproducible for a static route); if one ever surfaces it is a one-line addition.
+- **FR7 — Overlay/palette modal suppression.** Go-sequences are fully suppressed while
+  `paletteOpen || helpOpen` (G6). The palette's search `Command.Input` already makes `isEditable`
+  true (so `g d` types literally into the palette search), but the **help overlay's list has no
+  focused input** — without an explicit `paletteOpen || helpOpen` guard, `g d` could navigate from
+  underneath the open overlay, which is surprising. Treat both overlays as modal w.r.t. sequences.
+
+## Technical Requirements / Implementation Phases
+
+### Phase 0 — Preconditions (grep-verify before coding)
+- Confirm `resolveShortcut`'s pure-matcher shape and that `ShortcutAction` is a string union
+  (`use-shortcuts.tsx:67-93`) — the sequence resolver returns a `CommandEffect | null` instead of
+  extending that union, so `navigate`/`openChat` flow through the existing `runEffect`.
+- Confirm vitest include globs: node `test/**/*.test.ts` + jsdom `test/**/*.test.tsx`
+  (`vitest.config.ts:44,64`). New unit tests → `test/shortcuts-registry.test.ts` (node); component
+  tests → `test/command-palette.test.tsx` / `test/help-overlay.test.tsx` (jsdom).
+- Confirm `isAdmin` reaches the provider (`layout.tsx:253` `isAdmin={isAdmin}`) and is in
+  `ShortcutsContextValue` (`use-shortcuts.tsx:204`).
+
+### Phase 1 — Registry: bindings + hints (`use-shortcuts.tsx`, `nav-items.ts`)
+- Add a `seq` field (e.g. `"g d"`) directly to each entry in the existing `NAV_ITEMS` /
+  `ADMIN_NAV_ITEMS` arrays (admin-ness is already implied by which array). `buildCommands` derives
+  the `keys` hint from `seq` (`"g d"` → display `G` `D`), so palette hints, overlay rows, and the
+  resolver **all read one field on one array** — single source by construction, no separate table,
+  no drift test needed (YAGNI pass). Add `seq: "g c"` on the `ask-agent` action too — **show `G C`**
+  as its hint (the global binding), since the current `⌘↵` only works with the palette already open.
+- Add `resolveSequence(pending, e, ctx)` (pure, DOM-free) returning `CommandEffect | "arm" | null`:
+  a matched second key → its `CommandEffect`; a bare `g` (not editable, not mid-sequence) → `"arm"`;
+  any terminating non-match / `e.repeat` → `null`. Reuses `isEditable`; `g a` returns `null` unless
+  `ctx.isAdmin`.
+
+### Phase 2 — Listener: the sequence buffer (`ShortcutsProvider`, `use-shortcuts.tsx`)
+- Add a `pendingPrefixRef` (`{ key: "g"; at: number } | null`) + window constant
+  (`SEQUENCE_WINDOW_MS = 1500`) inside the ONE existing `keydown` handler. Order of checks (the
+  pending-prefix check must PRECEDE the Escape drawer branch — G3): `shortcutsEnabled` → **if a
+  prefix is pending: `Escape`/expiry/unmapped/editable clear it (and Escape is swallowed so it does
+  NOT also run the `onEscape` drawer-close); a mapped key resolves** → else `Escape` drawer branch
+  (unchanged) → `resolveShortcut` (chords, unchanged) → `resolveSequence` arm-on-`g` (only if
+  `enabled` AND not `paletteOpen || helpOpen` — FR7 modal guard). The matched second key
+  `preventDefault()`s and calls `runEffect(effect)` (admin-gated for `g a` via
+  `stateRef.current.isAdmin` — thread `isAdmin` into `stateRef`).
+- Prefix clears on: window expiry (checked on next keydown via `at` timestamp — no `setTimeout`
+  needed, keeps the "read state via ref, never re-subscribe" TR2 invariant), unmapped key
+  (fall-through, not swallowed), second `g`, `Escape` (swallowed), or focus-in-editable.
+  Auto-repeat (`e.repeat`) never arms/advances. **No new listener; no re-subscription.**
+
+### Phase 3 — Palette hints render (`command-palette.tsx`)
+- Render `cmd.keys` for the Navigation group rows (mirror the General group's
+  `{cmd.keys && <span className="cmdk-keys"> {cmd.keys}</span>}` at lines 332-343) and for the
+  Ask-an-agent hero item. Non-admin: `buildCommands({isAdmin:false})` already omits the Analytics
+  nav command, so its hint is naturally absent — assert this.
+
+### Phase 4 — Help overlay rows (`help-overlay.tsx`)
+- Extend `SHORTCUTS` with the six nav rows + the agent row, each carrying a new `HelpAction`
+  variant that runs the corresponding `CommandEffect` via `runEffect`. Gate the Analytics row on
+  `isAdmin` (read from `useShortcuts()`). Remove the `#5636`-deferred omission comment (lines 5-7).
+- Keep WCAG note: rows are display + click launcher; the disable path is the Settings toggle.
+
+### Phase 5 — Tests (write failing first — `cq-write-failing-tests-before`)
+- `test/shortcuts-registry.test.ts` (node): `resolveSequence` truth table — `"arm"` on `g`;
+  each mapped second key → correct effect; unmapped/second-`g`/`e.repeat` → `null`; `g a` gated by
+  `ctx.isAdmin` (admin→navigate, non-admin→`null`). One structural assertion that `buildCommands`
+  hints derive from the `seq` field on `NAV_ITEMS` (AC7 — single source).
+- `test/command-palette.test.tsx` (jsdom): Navigation rows + Ask row show their `keys` hint;
+  non-admin has no Analytics hint.
+- `test/help-overlay.test.tsx` (jsdom): overlay lists the new rows; Analytics row present for
+  admin, absent for non-admin; selecting a nav row calls the navigate effect.
+- Integration (jsdom, existing provider harness): `g` then `d` navigates; `g` then Escape does
+  not; `g` while focus in an input types literally; sequence no-ops when `shortcutsEnabled=false`
+  and when `enabled=false`.
+
+### Phase 6 — Verify
+- `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (NOT `npm run -w …` — no root
+  `workspaces`; per Sharp Edges).
+- `cd apps/web-platform && ./node_modules/.bin/vitest run test/shortcuts-registry.test.ts test/command-palette.test.tsx test/help-overlay.test.tsx`
+  then the full suite.
+
+## Files to Edit
+- `apps/web-platform/components/command-palette/use-shortcuts.tsx` — `resolveSequence`, sequence
+  buffer in the listener, `keys` hints in `buildCommands`, thread `isAdmin` into `stateRef`.
+- `apps/web-platform/components/command-palette/nav-items.ts` — add a `seq` field to the existing
+  `NAV_ITEMS`/`ADMIN_NAV_ITEMS` entries + `seq` on the ask-agent action (single source; no new table).
+- `apps/web-platform/components/command-palette/command-palette.tsx` — render nav + ask key hints.
+- `apps/web-platform/components/command-palette/help-overlay.tsx` — new overlay rows + admin gate;
+  remove the #5636-deferred omission comment.
+- `apps/web-platform/test/shortcuts-registry.test.ts` — sequence resolver + hint-sync tests.
+- `apps/web-platform/test/command-palette.test.tsx` — hint-render tests.
+- `apps/web-platform/test/help-overlay.test.tsx` — overlay-row + admin-gate tests.
+
+## Files to Create
+- None (all changes extend existing command-layer files). New tests land in existing test files.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- **AC1** `resolveSequence` unit tests pass: `g` arms; `g d|i|w|k|r|c` → correct effect; `g a` →
+  navigate iff `ctx.isAdmin`; unmapped/second-`g`/Escape/timeout/editable → null effect + cleared.
+- **AC2** Integration: `g d` navigates to `/dashboard`; `g` then a 1.2 s pause then `d` does NOT
+  navigate (window expired); `g` while focus in an `<input>` types `g` literally (no arm).
+- **AC3** Sequences are inert when `shortcutsEnabled=false` (WCAG turn-off) AND when the
+  `command-palette` flag `enabled=false`; ⌘B remains functional at `enabled=false` (unchanged).
+- **AC4** Palette Navigation rows and the Ask-an-agent row render their key hint (`G D` … `G C`);
+  non-admin render shows no Analytics row/hint. (jsdom render assertion on `.cmdk-keys`.)
+- **AC5** `?`/`⌘/` overlay lists all six nav rows + the agent row; the Analytics row is present
+  for `isAdmin=true`, absent for `isAdmin=false`; selecting a nav row invokes its navigate effect.
+- **AC6** No new keyboard dependency added (`git diff package.json` shows no additions);
+  `tsc --noEmit` clean; full web-platform vitest suite green.
+- **AC7 (single source)** The `seq` field lives on the existing `NAV_ITEMS`/`ADMIN_NAV_ITEMS`
+  arrays and the resolver, palette hints, and overlay rows all derive from it — a structural
+  assertion (one test reads the arrays and confirms the resolver map + rendered hints match the
+  `seq` values) rather than a separate table + bidirectional drift test.
+- **AC8 (modal)** While `paletteOpen || helpOpen`, no go-sequence navigates (help overlay has no
+  input, so this needs an explicit guard beyond `isEditable`).
+- **AC9 (abort semantics)** `g` + Escape cancels the prefix and does NOT close the mobile drawer;
+  `g` + an unmapped key aborts silently and that key still runs its own binding (`g` then `⌘K`
+  opens the palette).
+- **AC10 (editable audit)** All typing surfaces (chat composer, KB editor) satisfy `isEditable`
+  (INPUT/TEXTAREA/SELECT/contentEditable). If any uses `role="textbox"` on a non-`contentEditable`
+  node, extend the predicate before merge — a `g` armed outside it could otherwise navigate on the
+  next letter typed there. (Bounded here since sequences require the `g` prefix first, but audit.)
+
+### Post-merge (operator)
+- None. No flag-create (rides existing `command-palette` flag), no migration, no infra. The change
+  is client-only under `apps/web-platform/components/**` and deploys via the standard
+  `web-platform-release.yml` container restart on merge to main.
+
+## Domain Review
+
+**Domains relevant:** Product, Engineering, Legal
+
+### Engineering
+**Status:** reviewed (inline — registry extension, no new substrate)
+**Assessment:** Extend the ONE global listener with an in-house sequence buffer + a pure
+`resolveSequence` companion; route through the existing serializable `CommandEffect`/`runEffect`
+so the agent-native seam (#5638) is untouched. No new keyboard lib (avoids the #5633 lockfile-sync
+pain). State read via the existing `stateRef` (no listener re-subscription, TR2 preserved).
+
+### Legal
+**Status:** reviewed (inline)
+**Assessment:** WCAG 2.1.4 *Character Key Shortcuts* (Level A). Framework research confirms two-key
+sequences (`g i`) **ARE in scope** for SC 2.1.4 (only modifier-key chords are exempt), so a
+compliance path is required — one of turn-off / remap / focus-only (W3C). We satisfy **turn-off**:
+the existing device-local `shortcutsEnabled` toggle gates the whole listener (default ON,
+Settings → Keyboard shortcuts). CLO's hard requirement from #5637 (disable/remap/focus-only) is met
+by that toggle + the `isEditable` focus guard. No new IP exposure (functional key bindings; no
+Linear help-text/branding copied). No regulated-data surface.
+Sources: W3C Understanding SC 2.1.4; GitHub `hotkey` (1500 ms sequence window).
+
+### Product/UX Gate
+**Tier:** advisory
+**Decision:** auto-accepted (pipeline) — references existing shipped wireframe
+**Agents invoked:** spec-flow-analyzer (binding/collision flow analysis)
+**Skipped specialists:** ux-design-lead — N/A: no new page/component/interactive surface is
+created; the visual delta is (a) inline `.cmdk-keys` text hints on existing rows and (b) new rows
+in the existing `?` overlay, both matching the **already-committed #5633 wireframe**
+`knowledge-base/product/design/command-palette/command-shortcuts-wireframes.pen` (verified present
+in `git ls-files`), whose `G`-then-I/K/R/D nav-sequence design this feature un-defers
+(`help-overlay.tsx:5-7` documents that the overlay *omitted* those sequences pending #5636). No new
+`.pen` required; that committed wireframe is the design of record.
+**Pencil available:** N/A (no new UI surface)
+
+#### Findings
+See §Binding Decision (collision matrix) and the spec-flow gaps folded into FR1/FR5/FR7 + AC2/AC5.
+
+## Architecture Decision (ADR/C4)
+
+**No ADR.** This is a within-component extension of the existing command registry — no new
+substrate, ownership/tenancy boundary, resolver/trust boundary, or ADR reversal.
+
+**No C4 impact.** Verified against all three model files
+(`knowledge-base/engineering/architecture/diagrams/{model.c4,views.c4,spec.c4}`): a grep for
+`palette|keyboard|shortcut|command layer` returns zero — the client-side command layer is not a
+C4 element, and this feature introduces **no** new external human actor (no new correspondent /
+reviewer / recipient), **no** external system/vendor (no webhook/API/store), **no** container or
+data store, and **no** actor↔surface access-relationship change (admin gating on `g a` is an
+existing, already-modeled authz boundary — `/api/admin/check`, unchanged). Checked and
+found-not-applicable; nothing to add or render.
+
+## Observability
+
+This is a **client-only** UI change (no `apps/*/server|src|infra` edits, no new runtime process),
+so there is no server heartbeat to declare; the schema is filled honestly for the client surface —
+CI is the regression liveness gate and the existing client-observability hook is the error channel.
+
+```yaml
+liveness_signal:
+  what: the web-platform vitest suite exercising the shortcut resolver + palette/overlay render
+        (test/shortcuts-registry.test.ts, test/command-palette.test.tsx, test/help-overlay.test.tsx)
+  cadence: every CI run (per PR) and every deploy of apps/web-platform
+  alert_target: CI red blocks the PR / release; visible in the GitHub Actions run + PR checks
+  configured_in: apps/web-platform/vitest.config.ts + the web-platform CI workflow
+error_reporting:
+  destination: Sentry via the existing client hook reportSilentFallback (@/lib/client-observability)
+               — reused, not extended (nav via router.push has no server error path)
+  fail_loud: true (existing routine-run failures in command-palette.tsx:187 already mirror to Sentry
+             with the fnId tag; this feature adds no new swallow-the-error path)
+failure_modes:
+  - mode: sequence resolves to the wrong route
+    detection: resolveSequence unit tests assert exact effect per key (AC1); component nav test (AC5)
+    alert_route: CI red (pre-merge)
+  - mode: g-prefix leaks into typing (fires while focus is in chat/search)
+    detection: isEditable-suppression unit + integration tests (AC2/FR2)
+    alert_route: CI red (pre-merge)
+  - mode: hint/resolver drift (a documented key does not match the live binding)
+    detection: structurally prevented — hint + overlay + resolver all read the `seq` field on
+               NAV_ITEMS (AC7 single-source assertion)
+    alert_route: CI red (pre-merge)
+  - mode: non-admin triggers admin g a
+    detection: admin-gating unit + render tests (AC1/AC4/AC5); route is server-guarded regardless
+    alert_route: CI red (pre-merge)
+logs:
+  where: browser console only in dev; no server logs (client-side navigation). Sentry captures any
+         reused reportSilentFallback event as today.
+  retention: Sentry default retention for the web-platform project (unchanged)
+discoverability_test:
+  command: "cd apps/web-platform && ./node_modules/.bin/vitest run test/shortcuts-registry.test.ts test/command-palette.test.tsx test/help-overlay.test.tsx"
+  expected_output: all suites pass (0 failures) — the shortcut resolver, palette hints, and overlay
+                   rows behave as specified; no ssh, no prod access required
+```
+
+## GDPR / Compliance
+
+Skipped — no regulated-data surface (no schema/migration/auth flow/API route/`.sql`); no LLM
+processing of session data; client keyboard bindings only.
+
+## Infrastructure (IaC)
+
+Skipped — no new server, service, secret, vendor, DNS, cert, or cron. Pure code change against an
+already-provisioned surface (`apps/web-platform/components/**`).
+
+## Open Code-Review Overlap
+
+None. Ran `gh issue list --label code-review --state open` (200-limit) and `contains()`-matched
+each edited file path against issue bodies — zero hits for `use-shortcuts.tsx`, `nav-items.ts`,
+`command-palette.tsx`, `help-overlay.tsx`. No open scope-out touches this feature's files.
+
+## Test Scenarios
+
+1. `g` `d` → `/dashboard`; `g` `i` → `/dashboard/inbox`; … `g` `c` → `/dashboard/chat/new`.
+2. `g` then 1.2 s then `d` → no nav (window expired).
+3. `g` then `x` (unmapped) → prefix cleared, no nav; a later `g` `d` still works.
+4. `g` then `Escape` → prefix cleared, no nav, no overlay side-effect.
+5. Focus in chat input → `g` `d` types "gd" literally, no nav (isEditable).
+6. Palette open, focus in search → `g` types literally into search (isEditable).
+7. Non-admin `g` `a` → no nav; no Analytics palette hint; no Analytics overlay row.
+8. Admin `g` `a` → `/dashboard/admin/analytics`; hint + overlay row present.
+9. `shortcutsEnabled=false` → every sequence inert; ⌘B also inert (whole listener off).
+10. `command-palette` flag OFF (`enabled=false`) → sequences inert; ⌘B still toggles (unchanged).
+11. Already on `/dashboard`, press `g` `d` → harmless same-route `router.push` (Next.js de-dupes),
+    no error. (No guard asserted — see FR6.)
+
+## Research Insights
+
+**Sequence timing (framework-docs):** GitHub's `hotkey` uses a **1500 ms** window between keys;
+`keyboard-shortcut` defaults to 1000 ms (both configurable). 1500 ms is the more forgiving,
+production-proven value → `SEQUENCE_WINDOW_MS = 1500`. When the first key arms, other single-key
+shortcuts are blocked for the window (irrelevant here — we have no bare single-key bindings).
+- github/hotkey · npm `keyboard-shortcut`
+
+**WCAG 2.1.4 (framework-docs, load-bearing):** two-key `g i` sequences **are in scope** for SC
+2.1.4 Level A — they are treated as character-key shortcuts (only modifier chords like `⌘K` are
+exempt). Compliance requires **one** of: turn-off, remap, or focus-only. We ship **turn-off** via
+the existing `shortcutsEnabled` toggle → compliant. (This closes the CLO hard requirement carried
+on #5637.)
+- W3C Understanding SC 2.1.4 · TestParty WCAG 2.1.4 (2025)
+
+**Auto-repeat + focus (framework-docs):** ignore `e.repeat` at the top of the handler (MDN
+`KeyboardEvent.repeat`); clear the pending prefix on `focusin` into an input to avoid trapping the
+user mid-sequence. Both are one-liners and standard.
+
+**cmdk hint rendering (framework-docs):** render each key as a `<kbd>`; a **sequence** = two
+adjacent `<kbd>` (`G` `I`), a **chord** = a single glyph — matches cmdk's Linear example + shadcn
+Command. The overlay already uses `<kbd className="cmdk-keys">`; the palette General group uses a
+`<span className="cmdk-keys">` — reuse that slot, rendering two `<kbd>` for sequences.
+- cmdk Linear example · shadcn/ui Command
+
+**Simplicity pass (code-simplicity-reviewer):** for a 7-entry static keymap, a dedicated
+`NAV_SEQUENCES` table + bidirectional drift test is over-built — a `seq` field on the existing nav
+arrays makes drift structurally impossible. The guarded-no-op is defensive code for a
+non-reproducible flash (Next.js already de-dupes). Both cut. Kept the modal guard, resolver-level
+admin gating, and the no-new-dependency buffer as genuinely load-bearing.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, is `TBD`/placeholder, or omits the
+  threshold will fail `deepen-plan` Phase 4.6. This one is filled (threshold: single-user incident).
+- **Do not add `tinykeys` or any keyboard dep.** #5636 *mentioned* `tinykeys`, but a ~30-line
+  in-house prefix buffer fits the existing pure-matcher architecture and avoids the exact
+  lockfile-sync failure that bit #5633 (`cmdk` added to `package.json`+`bun.lock` but not
+  `package-lock.json` → CI `npm ci`/`lockfile-sync` failed). No new dep = no lockfile risk.
+- **Typecheck is `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit`**, NOT
+  `npm run -w apps/web-platform typecheck` (repo root declares no `workspaces`).
+- **Tests must live in `apps/web-platform/test/`** to match vitest include globs
+  (`test/**/*.test.ts` node, `test/**/*.test.tsx` jsdom) — a co-located `components/**/*.test.tsx`
+  is silently never run.
+- **Do not gate the sequence buffer on `setTimeout`.** Track the arm timestamp in the ref and
+  check elapsed on the next keydown, preserving TR2 (one listener, never re-subscribes).
+- **`Ctrl+C` must never be intercepted** — copying a non-editable selection is sacred and
+  `isEditable` does not cover it. This is the core reason the hero action is rebound to `g c`.
+- **Admin gating must be enforced in the resolver, not just the UI hint** — `g a` reads
+  `ctx.isAdmin`; hiding the hint alone would still let a non-admin trigger the push (route is
+  server-guarded, but the sequence should be a clean dead key for non-admins).
+
+## Alternative Approaches Considered
+
+| Approach | Verdict | Why |
+|---|---|---|
+| Modifier chords per nav item (`⌘D`, `⌘I`, …) | Rejected | Browser-shortcut collisions (bookmark/reload/tab-switch); `isEditable` can't protect browser-handled chords |
+| Keep `Ctrl+C` for Ask-an-agent | Rejected | Hard conflict with copy/SIGINT; breaks selection-copy (single-user-incident class) |
+| `⌘J` for Ask-an-agent (brainstorm idea) | Rejected | Ctrl/⌘+J = Downloads (Chrome/Firefox, Win/Linux) |
+| Dedicated chord for the hero action | Offered as CPO-signoff fallback | Ergonomically awkward (Ctrl+Shift+digit) or per-browser risky; `g c` recommended |
+| Add `tinykeys` for sequences | Rejected | New dep + lockfile-sync risk; ~30-line in-house buffer suffices |
+| Bare single-key nav (`d`,`i`,…) | Rejected | Chat-typing collisions + WCAG 2.1.4 (this is #5637, still deferred) |
+
+## References
+- `apps/web-platform/components/command-palette/use-shortcuts.tsx` (registry, listener, resolver)
+- `apps/web-platform/components/command-palette/nav-items.ts` (nav source of truth)
+- `apps/web-platform/components/command-palette/command-palette.tsx` (palette render, `.cmdk-keys`)
+- `apps/web-platform/components/command-palette/help-overlay.tsx` (overlay; #5636 omission note)
+- `apps/web-platform/app/(dashboard)/layout.tsx` (`ShortcutsProvider` wiring, `isAdmin`)
+- `apps/web-platform/test/shortcuts-registry.test.ts`, `test/command-palette.test.tsx`, `test/help-overlay.test.tsx`
+- Deferred issues: **#5636** (nav sequences — this closes it), #5637 (single-key verbs — stays deferred), #5638 (agent surface — unchanged)
+- Parent brainstorm: `knowledge-base/project/brainstorms/2026-06-22-keyboard-shortcuts-brainstorm.md` (Open Question #1: dedicated agent binding)

--- a/knowledge-base/project/plans/2026-07-01-feat-command-palette-direct-shortcuts-plan.md
+++ b/knowledge-base/project/plans/2026-07-01-feat-command-palette-direct-shortcuts-plan.md
@@ -147,7 +147,14 @@ not recommended. This is the sole item requiring CPO sign-off before `/work`.
 
 **If this lands broken, the user experiences:** a shortcut that navigates to the wrong page, or a
 `g`-prefix that swallows the next keystroke inside chat/search, or a bound `Ctrl+C` that stops
-copying selected text — on a keyboard surface the operator drives constantly.
+copying selected text, or a go-sequence fired from a button *inside an open app modal*
+(new-issue-dialog, cancel-retention, etc.) that navigates away and discards unsaved input — on a
+keyboard surface the operator drives constantly.
+
+**Modal-underneath surface (review FINDING 5, fixed inline).** FR7 originally suppressed sequences
+only while the palette/help overlay was open. The arm guard is generalized to also suppress while
+any `[role="dialog"][aria-modal="true"]` app modal is mounted, so a `g d` cannot fire from a
+non-editable button inside a modal that holds unsaved input. Covered by a modal-suppression test.
 
 **If this leaks, the user's data is exposed via:** N/A — no data surface; client-side navigation
 only. The only "leak" vector is admin-gated `g a` navigating a non-admin toward an admin route

--- a/knowledge-base/project/specs/feat-one-shot-palette-page-shortcuts/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-palette-page-shortcuts/session-state.md
@@ -1,0 +1,19 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-01-feat-command-palette-direct-shortcuts-plan.md
+- Status: complete
+
+### Errors
+None. All deepen-plan enforcement gates passed (4.6 User-Brand Impact, 4.7 Observability, 4.8 PAT-shaped, 4.9 UI-wireframe). Code-review overlap check and KB citation check clean.
+
+### Decisions
+- Realizes deferred #5636 (two-key `g`-then-key nav sequences from the shipped #5633 wireframe). Scoped `Closes #5636`.
+- Binding scheme: `Ctrl+C` is a hard conflict (copy/SIGINT, unprotectable by isEditable) → rebound. Linear-style `g`-then-letter sequences: `g d/i/w/k/r/a` (nav) + `g c` (Ask an agent, "go to chat"). Every browser-safe `Ctrl+<letter>` collides on some browser.
+- No new flag, no new dependency: rides existing `command-palette` flag; ~30-line in-house `pendingPrefixRef` buffer (no `tinykeys`).
+- WCAG 2.1.4 applies to two-key sequences; satisfied by existing `shortcutsEnabled` turn-off toggle.
+- CPO sign-off item (`g c` hero binding vs distinct chord): AUTO-ACCEPTED at one-shot orchestration — low-stakes, reversible keybinding; user pre-authorized rebinding; recommendation is `g c`. Documented in PR for trivial operator override.
+
+### Components Invoked
+- Skill: soleur:plan, soleur:deepen-plan
+- Agents: spec-flow-analyzer, framework-docs-researcher, code-simplicity-reviewer

--- a/knowledge-base/project/specs/feat-one-shot-palette-page-shortcuts/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-palette-page-shortcuts/tasks.md
@@ -1,0 +1,54 @@
+---
+title: "Tasks — Direct keyboard shortcuts for command-palette destinations"
+plan: knowledge-base/project/plans/2026-07-01-feat-command-palette-direct-shortcuts-plan.md
+branch: feat-one-shot-palette-page-shortcuts
+lane: cross-domain
+brand_survival_threshold: single-user incident
+---
+
+# Tasks: Direct keyboard shortcuts for command-palette destinations
+
+Derived from `2026-07-01-feat-command-palette-direct-shortcuts-plan.md`. Wireframe of record:
+`knowledge-base/product/design/command-palette/command-shortcuts-wireframes.pen` (from #5633).
+This work **closes #5636**. CPO sign-off gate: the hero-action binding (`g c` vs a chord) — §Binding Decision.
+
+## Phase 0 — Preconditions (grep-verify, no code)
+- [ ] 0.1 Confirm `resolveShortcut` pure-matcher shape + `ShortcutAction` union (`use-shortcuts.tsx:67-93`); sequence resolver returns `CommandEffect | null` (flows through existing `runEffect`).
+- [ ] 0.2 Confirm vitest include globs (`vitest.config.ts:44,64`): node `test/**/*.test.ts`, jsdom `test/**/*.test.tsx`. Tests land in `apps/web-platform/test/`.
+- [ ] 0.3 Confirm `isAdmin` reaches provider (`layout.tsx:253`) and is in `ShortcutsContextValue` (`use-shortcuts.tsx:204`).
+- [ ] 0.4 Audit typing surfaces (chat composer, KB editor) satisfy `isEditable` (INPUT/TEXTAREA/SELECT/contentEditable); flag any `role="textbox"` non-contentEditable node (AC11).
+
+## Phase 1 — Registry: bindings + hints
+- [ ] 1.1 Add a `seq` field to each existing `NAV_ITEMS`/`ADMIN_NAV_ITEMS` entry (`"g d"` … `"g a"`) + `seq: "g c"` on the `ask-agent` action. Single source — no separate `NAV_SEQUENCES` table.
+- [ ] 1.2 `buildCommands` derives the `keys` hint from `seq` (`"g d"` → `G` `D`) for nav + ask; show `G C` for the hero (not `⌘↵`).
+- [ ] 1.3 Add pure `resolveSequence(pending, e, ctx): CommandEffect | "arm" | null` (DOM-free): `"arm"` on bare `g`; mapped 2nd key → effect; `null` on unmapped/second-g/`e.repeat`; `g a` → `null` unless `ctx.isAdmin`. Reuses `isEditable`.
+
+## Phase 2 — Listener: sequence buffer
+- [ ] 2.1 Add `pendingPrefixRef` + `SEQUENCE_WINDOW_MS = 1500` inside the ONE existing keydown handler; thread `isAdmin` into `stateRef`; ignore `e.repeat` at the top.
+- [ ] 2.2 Order checks: `shortcutsEnabled` → pending-prefix branch (PRECEDES Escape drawer branch; Escape clears prefix + is swallowed) → `resolveShortcut` (chords) → `resolveSequence` arm (only if `enabled` AND not `paletteOpen || helpOpen`).
+- [ ] 2.3 Prefix clears on window-expiry (timestamp check on next keydown — NO setTimeout), unmapped-key (fall-through, not swallowed), second-`g`, Escape (swallowed); `focusin` into editable clears it.
+- [ ] 2.4 Matched 2nd key `preventDefault()` + `runEffect(effect)`. No `pathname === href` guard (Next.js de-dupes same-route push — FR6).
+
+## Phase 3 — Palette hints render (`command-palette.tsx`)
+- [ ] 3.1 Render `cmd.keys` for Navigation-group rows (mirror General group lines 332-343) and the Ask-an-agent hero item, via `.cmdk-keys`.
+- [ ] 3.2 Confirm non-admin render omits the Analytics nav row/hint (buildCommands already filters admin nav).
+
+## Phase 4 — Help overlay rows (`help-overlay.tsx`)
+- [ ] 4.1 Extend `SHORTCUTS` with six nav rows + agent row; each new `HelpAction` variant runs the matching `CommandEffect` via `runEffect`.
+- [ ] 4.2 Gate the Analytics row on `isAdmin` (from `useShortcuts()`); group the agent row under "Ask an agent", not "Navigation".
+- [ ] 4.3 Remove the `#5636`-deferred omission comment (`help-overlay.tsx:5-7`).
+
+## Phase 5 — Tests (write failing first)
+- [ ] 5.1 `test/shortcuts-registry.test.ts` (node): `resolveSequence` truth table (`"arm"`/resolve/`null` on unmapped/second-g/`e.repeat`); `g a` admin gating; one structural assertion that `buildCommands` hints derive from the `seq` field (AC7 — single source, no drift table).
+- [ ] 5.2 `test/command-palette.test.tsx` (jsdom): nav + ask rows show `keys` hint; non-admin has no Analytics hint (AC4).
+- [ ] 5.3 `test/help-overlay.test.tsx` (jsdom): overlay lists new rows; Analytics row present iff admin; selecting a nav row runs navigate effect (AC5).
+- [ ] 5.4 Integration (jsdom provider harness): `g d` navigates; `g`+Escape / `g`+timeout / `g` in input do not; inert when `shortcutsEnabled=false` and when `enabled=false`; ⌘B still works at `enabled=false` (AC2/AC3/AC8/AC9).
+
+## Phase 6 — Verify
+- [ ] 6.1 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (NOT `npm run -w …`).
+- [ ] 6.2 `cd apps/web-platform && ./node_modules/.bin/vitest run test/shortcuts-registry.test.ts test/command-palette.test.tsx test/help-overlay.test.tsx` then full suite.
+- [ ] 6.3 Confirm `git diff package.json` shows NO new dependency (no `tinykeys`) — AC6.
+
+## Ship
+- [ ] S.1 PR body: `Closes #5636`; note #5637/#5638 remain deferred (unchanged).
+- [ ] S.2 No flag-create (rides existing `command-palette` flag); no migration/infra. No post-merge operator steps.

--- a/knowledge-base/project/specs/feat-one-shot-palette-page-shortcuts/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-palette-page-shortcuts/tasks.md
@@ -13,41 +13,41 @@ Derived from `2026-07-01-feat-command-palette-direct-shortcuts-plan.md`. Wirefra
 This work **closes #5636**. CPO sign-off gate: the hero-action binding (`g c` vs a chord) — §Binding Decision.
 
 ## Phase 0 — Preconditions (grep-verify, no code)
-- [ ] 0.1 Confirm `resolveShortcut` pure-matcher shape + `ShortcutAction` union (`use-shortcuts.tsx:67-93`); sequence resolver returns `CommandEffect | null` (flows through existing `runEffect`).
-- [ ] 0.2 Confirm vitest include globs (`vitest.config.ts:44,64`): node `test/**/*.test.ts`, jsdom `test/**/*.test.tsx`. Tests land in `apps/web-platform/test/`.
-- [ ] 0.3 Confirm `isAdmin` reaches provider (`layout.tsx:253`) and is in `ShortcutsContextValue` (`use-shortcuts.tsx:204`).
-- [ ] 0.4 Audit typing surfaces (chat composer, KB editor) satisfy `isEditable` (INPUT/TEXTAREA/SELECT/contentEditable); flag any `role="textbox"` non-contentEditable node (AC11).
+- [x] 0.1 Confirm `resolveShortcut` pure-matcher shape + `ShortcutAction` union (`use-shortcuts.tsx:67-93`); sequence resolver returns `CommandEffect | null` (flows through existing `runEffect`).
+- [x] 0.2 Confirm vitest include globs (`vitest.config.ts:44,64`): node `test/**/*.test.ts`, jsdom `test/**/*.test.tsx`. Tests land in `apps/web-platform/test/`.
+- [x] 0.3 Confirm `isAdmin` reaches provider (`layout.tsx:253`) and is in `ShortcutsContextValue` (`use-shortcuts.tsx:204`).
+- [x] 0.4 Audit typing surfaces (chat composer, KB editor) satisfy `isEditable` (INPUT/TEXTAREA/SELECT/contentEditable); flag any `role="textbox"` non-contentEditable node (AC11).
 
 ## Phase 1 — Registry: bindings + hints
-- [ ] 1.1 Add a `seq` field to each existing `NAV_ITEMS`/`ADMIN_NAV_ITEMS` entry (`"g d"` … `"g a"`) + `seq: "g c"` on the `ask-agent` action. Single source — no separate `NAV_SEQUENCES` table.
-- [ ] 1.2 `buildCommands` derives the `keys` hint from `seq` (`"g d"` → `G` `D`) for nav + ask; show `G C` for the hero (not `⌘↵`).
-- [ ] 1.3 Add pure `resolveSequence(pending, e, ctx): CommandEffect | "arm" | null` (DOM-free): `"arm"` on bare `g`; mapped 2nd key → effect; `null` on unmapped/second-g/`e.repeat`; `g a` → `null` unless `ctx.isAdmin`. Reuses `isEditable`.
+- [x] 1.1 Add a `seq` field to each existing `NAV_ITEMS`/`ADMIN_NAV_ITEMS` entry (`"g d"` … `"g a"`) + `seq: "g c"` on the `ask-agent` action. Single source — no separate `NAV_SEQUENCES` table.
+- [x] 1.2 `buildCommands` derives the `keys` hint from `seq` (`"g d"` → `G` `D`) for nav + ask; show `G C` for the hero (not `⌘↵`).
+- [x] 1.3 Add pure `resolveSequence(pending, e, ctx): CommandEffect | "arm" | null` (DOM-free): `"arm"` on bare `g`; mapped 2nd key → effect; `null` on unmapped/second-g/`e.repeat`; `g a` → `null` unless `ctx.isAdmin`. Reuses `isEditable`.
 
 ## Phase 2 — Listener: sequence buffer
-- [ ] 2.1 Add `pendingPrefixRef` + `SEQUENCE_WINDOW_MS = 1500` inside the ONE existing keydown handler; thread `isAdmin` into `stateRef`; ignore `e.repeat` at the top.
-- [ ] 2.2 Order checks: `shortcutsEnabled` → pending-prefix branch (PRECEDES Escape drawer branch; Escape clears prefix + is swallowed) → `resolveShortcut` (chords) → `resolveSequence` arm (only if `enabled` AND not `paletteOpen || helpOpen`).
-- [ ] 2.3 Prefix clears on window-expiry (timestamp check on next keydown — NO setTimeout), unmapped-key (fall-through, not swallowed), second-`g`, Escape (swallowed); `focusin` into editable clears it.
-- [ ] 2.4 Matched 2nd key `preventDefault()` + `runEffect(effect)`. No `pathname === href` guard (Next.js de-dupes same-route push — FR6).
+- [x] 2.1 Add `pendingPrefixRef` + `SEQUENCE_WINDOW_MS = 1500` inside the ONE existing keydown handler; thread `isAdmin` into `stateRef`; ignore `e.repeat` at the top.
+- [x] 2.2 Order checks: `shortcutsEnabled` → pending-prefix branch (PRECEDES Escape drawer branch; Escape clears prefix + is swallowed) → `resolveShortcut` (chords) → `resolveSequence` arm (only if `enabled` AND not `paletteOpen || helpOpen`).
+- [x] 2.3 Prefix clears on window-expiry (timestamp check on next keydown — NO setTimeout), unmapped-key (fall-through, not swallowed), second-`g`, Escape (swallowed); `focusin` into editable clears it.
+- [x] 2.4 Matched 2nd key `preventDefault()` + `runEffect(effect)`. No `pathname === href` guard (Next.js de-dupes same-route push — FR6).
 
 ## Phase 3 — Palette hints render (`command-palette.tsx`)
-- [ ] 3.1 Render `cmd.keys` for Navigation-group rows (mirror General group lines 332-343) and the Ask-an-agent hero item, via `.cmdk-keys`.
-- [ ] 3.2 Confirm non-admin render omits the Analytics nav row/hint (buildCommands already filters admin nav).
+- [x] 3.1 Render `cmd.keys` for Navigation-group rows (mirror General group lines 332-343) and the Ask-an-agent hero item, via `.cmdk-keys`.
+- [x] 3.2 Confirm non-admin render omits the Analytics nav row/hint (buildCommands already filters admin nav).
 
 ## Phase 4 — Help overlay rows (`help-overlay.tsx`)
-- [ ] 4.1 Extend `SHORTCUTS` with six nav rows + agent row; each new `HelpAction` variant runs the matching `CommandEffect` via `runEffect`.
-- [ ] 4.2 Gate the Analytics row on `isAdmin` (from `useShortcuts()`); group the agent row under "Ask an agent", not "Navigation".
-- [ ] 4.3 Remove the `#5636`-deferred omission comment (`help-overlay.tsx:5-7`).
+- [x] 4.1 Extend `SHORTCUTS` with six nav rows + agent row; each new `HelpAction` variant runs the matching `CommandEffect` via `runEffect`.
+- [x] 4.2 Gate the Analytics row on `isAdmin` (from `useShortcuts()`); group the agent row under "Ask an agent", not "Navigation".
+- [x] 4.3 Remove the `#5636`-deferred omission comment (`help-overlay.tsx:5-7`).
 
 ## Phase 5 — Tests (write failing first)
-- [ ] 5.1 `test/shortcuts-registry.test.ts` (node): `resolveSequence` truth table (`"arm"`/resolve/`null` on unmapped/second-g/`e.repeat`); `g a` admin gating; one structural assertion that `buildCommands` hints derive from the `seq` field (AC7 — single source, no drift table).
-- [ ] 5.2 `test/command-palette.test.tsx` (jsdom): nav + ask rows show `keys` hint; non-admin has no Analytics hint (AC4).
-- [ ] 5.3 `test/help-overlay.test.tsx` (jsdom): overlay lists new rows; Analytics row present iff admin; selecting a nav row runs navigate effect (AC5).
-- [ ] 5.4 Integration (jsdom provider harness): `g d` navigates; `g`+Escape / `g`+timeout / `g` in input do not; inert when `shortcutsEnabled=false` and when `enabled=false`; ⌘B still works at `enabled=false` (AC2/AC3/AC8/AC9).
+- [x] 5.1 `test/shortcuts-registry.test.ts` (node): `resolveSequence` truth table (`"arm"`/resolve/`null` on unmapped/second-g/`e.repeat`); `g a` admin gating; one structural assertion that `buildCommands` hints derive from the `seq` field (AC7 — single source, no drift table).
+- [x] 5.2 `test/command-palette.test.tsx` (jsdom): nav + ask rows show `keys` hint; non-admin has no Analytics hint (AC4).
+- [x] 5.3 `test/help-overlay.test.tsx` (jsdom): overlay lists new rows; Analytics row present iff admin; selecting a nav row runs navigate effect (AC5).
+- [x] 5.4 Integration (jsdom provider harness): `g d` navigates; `g`+Escape / `g`+timeout / `g` in input do not; inert when `shortcutsEnabled=false` and when `enabled=false`; ⌘B still works at `enabled=false` (AC2/AC3/AC8/AC9).
 
 ## Phase 6 — Verify
-- [ ] 6.1 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (NOT `npm run -w …`).
-- [ ] 6.2 `cd apps/web-platform && ./node_modules/.bin/vitest run test/shortcuts-registry.test.ts test/command-palette.test.tsx test/help-overlay.test.tsx` then full suite.
-- [ ] 6.3 Confirm `git diff package.json` shows NO new dependency (no `tinykeys`) — AC6.
+- [x] 6.1 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (NOT `npm run -w …`).
+- [x] 6.2 `cd apps/web-platform && ./node_modules/.bin/vitest run test/shortcuts-registry.test.ts test/command-palette.test.tsx test/help-overlay.test.tsx` then full suite.
+- [x] 6.3 Confirm `git diff package.json` shows NO new dependency (no `tinykeys`) — AC6.
 
 ## Ship
 - [ ] S.1 PR body: `Closes #5636`; note #5637/#5638 remain deferred (unchanged).


### PR DESCRIPTION
## Summary

Adds direct global keyboard shortcuts so operators can jump straight to a
command-palette destination without opening the palette (`⌘K`). Realizes the
`G`-then-key nav-sequence design already drawn in the shipped #5633 wireframe
(which `help-overlay.tsx` explicitly deferred).

| Sequence | Destination |
|---|---|
| `G` `D` | Dashboard |
| `G` `I` | Inbox |
| `G` `W` | Workstream |
| `G` `K` | Knowledge Base |
| `G` `R` | Routines |
| `G` `A` | Analytics (admin only) |
| `G` `C` | Ask an agent |

Each key hint renders inline in the palette, and the `?` / `⌘/` overlay lists
every sequence.

Closes #5636

## Binding decision (the requested "document your choice")

The request asked for `Ctrl+C` on **Ask an agent**, noting it may conflict.
`Ctrl+C` is a hard, non-negotiable conflict — copying a non-editable text
selection must keep working and `isEditable` cannot protect it — so it's rebound
to the collision-free `G` `C` ("**g**o to **c**hat"). Every browser-safe
`Ctrl+<letter>` collides on some browser (bookmark / reload / tab-switch /
downloads); the `g`-prefix family is exactly why Linear/GitHub/Slack — and
Soleur's own #5633 wireframe — use it for navigation. `#5637` (bare single-key
verbs) and `#5638` (agent surface) stay deferred.

## Changelog

### Web Platform
- New global `g`-then-key go-to sequences for all command-palette destinations
  + the Ask-an-agent hero (`G C`), with a 1500 ms sequence window.
- Palette rows and the `?` overlay now show each destination's key hint.
- Sequences ride the existing `command-palette` flag + the `shortcutsEnabled`
  WCAG 2.1.4 turn-off; **no new flag, no new dependency** (~in-house prefix
  buffer, not `tinykeys`).
- Suppressed while typing (`isEditable`), while the palette/help overlay is open,
  and — from review — while **any** app modal (`[role=dialog][aria-modal]`) is
  open, so a sequence can't fire from a button inside a modal and discard unsaved
  input.

## Test plan
- [x] `resolveSequence` unit truth-table (arm / resolve / null; admin-gated `g a`; hint derives from the single-source `seq` field) — `test/shortcuts-registry.test.ts`
- [x] Palette hint render + non-admin omits Analytics — `test/command-palette.test.tsx`
- [x] Integration on the real provider listener: `g d` navigates; `g`+Escape swallowed (drawer untouched); `g`+`⌘K` falls through to open palette; window boundary (1400 ms navigates / 1600 ms expires); editable + modal suppression; inert at `shortcutsEnabled=false` and flag `enabled=false`; lone-modifier mid-sequence tolerated
- [x] Overlay lists all sequences; Analytics row admin-gated; selecting a row runs its effect — `test/help-overlay.test.tsx`
- [x] `tsc --noEmit` clean; full web-platform vitest suite green (11394 passed); `test-all.sh` 136/136
- [x] No new dependency (`git diff package.json` empty)

## Review
7-agent review (security, pattern, code-quality, agent-native, user-impact,
test-design, simplicity) found **no P1/P2 bugs**; all P3 findings fixed inline
(commit `review:`): modal-underneath guard, lone-modifier robustness, buffer
simplification, drift-comment scoping, search parity, + 5 test-coverage
additions.

Generated with [Claude Code](https://claude.com/claude-code)
