### PR TITLE
fix(agent-sandbox): allow split-unshare in seccomp profile — restore Concierge under claude-agent-sdk 0.3.x (#5873)

### DIFF
--- a/.github/workflows/apply-deploy-pipeline-fix.yml
+++ b/.github/workflows/apply-deploy-pipeline-fix.yml
@@ -87,6 +87,15 @@ on:
       - "apps/web-platform/infra/inngest-wiped-volume-verify.sh"
       - "apps/web-platform/infra/cat-inngest-verify-state.sh"
       - "apps/web-platform/infra/inngest-inventory.sh"
+      # #5873 — the container seccomp profile is delivered by the
+      # docker_seccomp_config SSH provisioner (server.tf), whose triggers_replace
+      # hashes this file. A profile-only edit must fire this apply so the new
+      # profile reaches /etc/docker/seccomp-profiles/soleur-bwrap.json on the
+      # host. NOTE: the RUNNING container only loads a new seccomp profile at
+      # `docker run` (container start), so a redeploy is required AFTER this apply
+      # for a profile change to take effect — sequence apply→redeploy explicitly
+      # (do not rely on the concurrent web-platform-release run winning the race).
+      - "apps/web-platform/infra/seccomp-bwrap.json"
       - "apps/web-platform/infra/server.tf"
   workflow_dispatch:
     inputs:
@@ -229,6 +238,7 @@ jobs:
           doppler run --name-transformer tf-var -- \
             terraform plan -target=terraform_data.deploy_pipeline_fix \
             -target=terraform_data.infra_config_handler_bootstrap \
+            -target=terraform_data.docker_seccomp_config \
             -var="ssh_key_path=${CI_SSH_PUB}" \
             -no-color -input=false
 
@@ -243,6 +253,7 @@ jobs:
           doppler run --name-transformer tf-var -- \
             terraform apply -target=terraform_data.deploy_pipeline_fix \
             -target=terraform_data.infra_config_handler_bootstrap \
+            -target=terraform_data.docker_seccomp_config \
             -var="ssh_key_path=${CI_SSH_PUB}" \
             -auto-approve -input=false
 

--- a/apps/web-platform/infra/seccomp-bwrap.json
+++ b/apps/web-platform/infra/seccomp-bwrap.json
@@ -794,7 +794,7 @@
 				"unshare"
 			],
 			"action": "SCMP_ACT_ALLOW",
-			"comment": "Allow unshare of a NEW PID namespace (CLONE_NEWPID=0x20000000) WITHOUT CLONE_NEWUSER \u2014 companion to the mount-namespace rule above for the same #5849 split-unshare sequence (soleur #5873). Hardened: also requires CLONE_NEWUSER unset (arg0 & 0x10000000 == 0) so this rule matches ONLY the post-userns namespace unshare and cannot be used to smuggle a user-namespace creation (defense-in-depth; the userns unshare is already handled by the #1557 CLONE_NEWUSER rule).",
+			"comment": "Allow unshare of a NEW PID namespace (CLONE_NEWPID=0x20000000) WITHOUT CLONE_NEWUSER. FORWARD-LOOKING: the observed #5849 call is the COMBINED unshare(CLONE_NEWPID|CLONE_NEWNS)=0x20020000, which the mount-namespace rule above already matches (it gates on the NEWNS bit and ignores NEWPID). This rule additionally covers a hypothetical pid-only unshare(CLONE_NEWPID) the current SDK does not emit \u2014 do NOT assume the mount-ns rule is removable because this exists (soleur #5873).",
 			"args": [
 				{
 					"index": 0,

--- a/apps/web-platform/infra/seccomp-bwrap.json
+++ b/apps/web-platform/infra/seccomp-bwrap.json
@@ -765,6 +765,58 @@
 		},
 		{
 			"names": [
+				"unshare"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"comment": "Allow unshare of a NEW MOUNT namespace (CLONE_NEWNS=0x20000) WITHOUT CLONE_NEWUSER. claude-agent-sdk 0.3.x / claude-code 2.1.197 (#5849) split sandbox setup into unshare(CLONE_NEWUSER) then unshare(CLONE_NEWPID|CLONE_NEWNS); the 0.2.85 builder combined them so CLONE_NEWUSER was always present. The split second call lacks CLONE_NEWUSER and fell through to defaultAction ERRNO, breaking the sandbox for every tenant. Minimal broadening: the process is already in its own user namespace here, so a nested mount-namespace unshare adds no capability beyond the Docker boundary (soleur #5873). Hardened: also requires CLONE_NEWUSER unset (arg0 & 0x10000000 == 0) so this rule matches ONLY the post-userns namespace unshare and cannot be used to smuggle a user-namespace creation (defense-in-depth; the userns unshare is already handled by the #1557 CLONE_NEWUSER rule).",
+			"args": [
+				{
+					"index": 0,
+					"value": 131072,
+					"valueTwo": 131072,
+					"op": "SCMP_CMP_MASKED_EQ"
+				},
+				{
+					"index": 0,
+					"value": 268435456,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_MASKED_EQ"
+				}
+			],
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			}
+		},
+		{
+			"names": [
+				"unshare"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"comment": "Allow unshare of a NEW PID namespace (CLONE_NEWPID=0x20000000) WITHOUT CLONE_NEWUSER \u2014 companion to the mount-namespace rule above for the same #5849 split-unshare sequence (soleur #5873). Hardened: also requires CLONE_NEWUSER unset (arg0 & 0x10000000 == 0) so this rule matches ONLY the post-userns namespace unshare and cannot be used to smuggle a user-namespace creation (defense-in-depth; the userns unshare is already handled by the #1557 CLONE_NEWUSER rule).",
+			"args": [
+				{
+					"index": 0,
+					"value": 536870912,
+					"valueTwo": 536870912,
+					"op": "SCMP_CMP_MASKED_EQ"
+				},
+				{
+					"index": 0,
+					"value": 268435456,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_MASKED_EQ"
+				}
+			],
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			}
+		},
+		{
+			"names": [
 				"clone3"
 			],
 			"action": "SCMP_ACT_ERRNO",

--- a/knowledge-base/engineering/operations/post-mortems/2026-07-01-concierge-bwrap-seccomp-sdk-0-3-outage-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/2026-07-01-concierge-bwrap-seccomp-sdk-0-3-outage-postmortem.md
@@ -1,0 +1,62 @@
+---
+title: "Concierge Bash sandbox down for all tenants — claude-agent-sdk 0.2.85→0.3.197 split-unshare blocked by the container seccomp profile"
+date: 2026-07-01
+incident_pr: 5874
+incident_window: "2026-07-01T13:20Z (#5849 deploy) → 2026-07-01 (fix shipping in #5874)"
+recovery_at: "pending — closes when a real Bash command succeeds in a fresh /soleur:go post-deploy (PR #5874 restoration gate)"
+suspected_change: "#5849 (feat(sonnet-5): migrate toolchain, deployed ~13:20Z) bumped @anthropic-ai/claude-agent-sdk 0.2.85→0.3.197 / claude-code 2.1.163→2.1.197, re-validating nothing about the bwrap sandbox"
+brand_survival_threshold: single-user incident
+status: resolved
+triggers:
+  - operator-reported (Concierge /soleur:go debug stream: every Bash call, incl. `echo test`, failed)
+art_33_triggered: false
+art_34_triggered: false
+art_33_deadline: "n/a"
+---
+
+## Actor key
+
+- `agent` — Claude Code did this autonomously (no operator ack required).
+- `agent-with-ack` — Claude Code did this AFTER operator confirmed via menu option.
+- `human` — Operator did this directly.
+
+# Incident Overview
+
+The hosted Concierge `/soleur:go` agent (app.soleur.ai) could not run **any** Bash tool call for **any** tenant: every invocation — even `echo test` — failed at bwrap sandbox startup with `apply-seccomp: unshare(CLONE_NEWPID|CLONE_NEWNS) after userns: Operation not permitted`. The agent was fully stranded (no git, build, or file operations possible). No customer data was exposed; this is a pure availability outage.
+
+## Status
+
+resolved — root cause identified and fixed in PR #5874; restoration is gated on a post-deploy real-Bash verification (see Action Items).
+
+## Symptom
+
+`apply-seccomp: unshare(CLONE_NEWPID|CLONE_NEWNS) after userns: Operation not permitted` on every sandboxed Bash call. Distinct from the earlier #5733/#5848/#5864 lineage (those were about what the agent could *read inside* a working sandbox); this was bwrap **failing to start at all**.
+
+## Incident Timeline
+
+- **Start time (detected):** ~2026-07-01T13:20Z — #5849 (sonnet-5 toolchain migration) deployed, bumping the agent SDK 0.2.85→0.3.197.
+- The strand changed character from the prior read-strand ("not a git repository") to a bwrap-won't-start seccomp EPERM; persisted through the #5864 deploy (14:35Z), which was unrelated.
+- **Detection:** operator pasted the stranded `/soleur:go` debug stream ("Still stranded").
+- **Diagnosis (no-SSH):** ruled out the 2026-06-04 userns-sysctl-drift class (`BWRAP_USERNS_SYSCTL_CHECK: ok` at 14:48Z); confirmed via `git show` that #5849 bumped the SDK; read the container seccomp profile rules to prove the mechanism.
+- **Fix authored + reviewed:** PR #5874 (5-agent review, bit-math verified).
+- **Recovery:** pending post-deploy verification.
+
+## Root Cause
+
+The container seccomp profile `apps/web-platform/infra/seccomp-bwrap.json` only allowed `unshare` when the `CLONE_NEWUSER` bit was set (the #1557 rule). The **0.2.85** SDK's sandbox combined all namespaces into one `unshare(CLONE_NEWUSER|CLONE_NEWNS|CLONE_NEWPID)`, so `CLONE_NEWUSER` was always present → allowed. **0.3.197 splits** it into `unshare(CLONE_NEWUSER)` then `unshare(CLONE_NEWPID|CLONE_NEWNS)` (= `0x20020000`, no `CLONE_NEWUSER` bit) → no rule matched → fell through to `defaultAction: SCMP_ACT_ERRNO` → EPERM → sandbox never started. #5849 bumped the SDK across a 0.2→0.3 boundary while re-validating nothing about the bwrap sandbox, and the deploy canary only exercised `bwrap --unshare-pid` (never the real split-unshare), so it shipped green.
+
+## Resolution
+
+PR #5874: two additive `SCMP_ACT_ALLOW` rules for `unshare` of a new mount (`CLONE_NEWNS`) and new pid (`CLONE_NEWPID`) namespace, each AND-requiring `CLONE_NEWUSER` unset (matches only the post-userns namespace unshare; cannot smuggle a userns) and `CAP_SYS_ADMIN`-excluded like the existing rule. Purely additive — no isolation regression. Also wired `docker_seccomp_config` into the merge auto-apply so the profile reaches the host over the CF tunnel (it was never in `deploy_pipeline_fix`'s `depends_on`, so profile changes silently never reached prod).
+
+## Action Items & Follow-ups
+
+| Issue | Item | Owner |
+| --- | --- | --- |
+| #5875 | Harden the agent sandbox against SDK-bump breakage: faithful split-unshare canary (dark-launched non-blocking first), Sentry-alertable sandbox-start-failure observability (this outage produced zero server-side signal), an SDK-bump-requires-canary guard, and profile-change→redeploy automation. | agent |
+
+## Lessons
+
+- A minor-version SDK bump (0.2→0.3) changed the sandbox's syscall sequence; **any `claude-agent-sdk`/`claude-code` bump must re-validate the bwrap sandbox against the real invocation**, not a synthetic `--unshare-pid` probe.
+- The outage was invisible server-side (zero Sentry/Better Stack signal) — the agent-sandbox Bash-tool surface needs a structured, alertable sandbox-start-failure event (tracked in #5875).
+- The seccomp profile reaches prod via a Terraform resource (`docker_seccomp_config`) that was not in the merge auto-apply, so profile edits silently never deployed — now wired (#5874).

--- a/plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts
+++ b/plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts
@@ -365,10 +365,16 @@ describe("apply-deploy-pipeline-fix.yml on.push.paths in sync with TRIGGER_FILES
     expect(paths.length).toBeGreaterThan(0);
   });
 
-  test("paths filter equals TRIGGER_FILES ∪ {server.tf} (set equality)", () => {
+  test("paths filter equals TRIGGER_FILES ∪ {server.tf, seccomp-bwrap.json} (set equality)", () => {
     const expected = new Set([
       ...TRIGGER_FILES,
       "apps/web-platform/infra/server.tf",
+      // #5873 — seccomp-bwrap.json is hashed by docker_seccomp_config's OWN
+      // triggers_replace (server.tf), NOT by deploy_pipeline_fix, so it is
+      // deliberately absent from TRIGGER_FILES. The workflow still applies
+      // docker_seccomp_config (see the seccomp coupling describe below), so a
+      // profile-only edit must fire this workflow — hence it IS in paths:.
+      "apps/web-platform/infra/seccomp-bwrap.json",
     ]);
     expect(new Set(paths)).toEqual(expected);
   });
@@ -492,5 +498,50 @@ describe("deploy_pipeline_fix orders after the handler bridge (#5515)", () => {
     const inner = blockMatch![1];
     expect(inner).toContain('file("${path.module}/infra-config-apply.sh")');
     expect(inner).toContain("local.hooks_json");
+  });
+});
+
+// #5873 — the seccomp coupling triangle. The container seccomp profile
+// (seccomp-bwrap.json) is delivered by terraform_data.docker_seccomp_config,
+// a DIFFERENT resource from deploy_pipeline_fix. For a profile-only edit to
+// reach prod, three facts must hold together — and terraform-target-parity.test.ts
+// does NOT guard them for THIS workflow (docker_seccomp_config is also covered by
+// apply-web-platform-infra.yml's union, so dropping it here fails no existing test).
+// This closes that gap the same way #5505/#5515 did for deploy_pipeline_fix.
+describe("seccomp profile auto-apply coupling (#5873)", () => {
+  test("apply-deploy-pipeline-fix.yml co-targets docker_seccomp_config in BOTH plan and apply", () => {
+    expect(existsSync(APPLY_DPF_WORKFLOW)).toBe(true);
+    const yml = readFileSync(APPLY_DPF_WORKFLOW, "utf8");
+    const planIdx = yml.indexOf("terraform plan -target=");
+    const applyIdx = yml.indexOf("terraform apply -target=");
+    expect(planIdx).toBeGreaterThanOrEqual(0);
+    expect(applyIdx).toBeGreaterThanOrEqual(0);
+    // Bound each invocation to its own -target= run of lines (generous 800 chars).
+    expect(yml.slice(planIdx, planIdx + 800)).toContain(
+      "-target=terraform_data.docker_seccomp_config",
+    );
+    expect(yml.slice(applyIdx, applyIdx + 800)).toContain(
+      "-target=terraform_data.docker_seccomp_config",
+    );
+  });
+
+  test("docker_seccomp_config triggers_replace hashes seccomp-bwrap.json (edit re-fires the apply)", () => {
+    expect(existsSync(SERVER_TF)).toBe(true);
+    const serverTf = readFileSync(SERVER_TF, "utf8");
+    const resourceStart = serverTf.indexOf(
+      'resource "terraform_data" "docker_seccomp_config"',
+    );
+    expect(resourceStart).toBeGreaterThanOrEqual(0);
+    const TOP_LEVEL_BLOCK_RE =
+      /\n(resource|data|module|output|locals|variable|provider|terraform)\b/;
+    const tail = serverTf.slice(resourceStart + 1);
+    const tailMatch = tail.match(TOP_LEVEL_BLOCK_RE);
+    const resourceBlock =
+      tailMatch && tailMatch.index !== undefined
+        ? serverTf.slice(resourceStart, resourceStart + 1 + tailMatch.index)
+        : serverTf.slice(resourceStart);
+    expect(resourceBlock).toContain(
+      'sha256(file("${path.module}/seccomp-bwrap.json"))',
+    );
   });
 });


### PR DESCRIPTION
## P0 incident fix — restores the Concierge Bash sandbox

Closes #5873.

**Root cause:** #5849 bumped `@anthropic-ai/claude-agent-sdk` 0.2.85→0.3.197 / `claude-code` 2.1.163→2.1.197 (~13:20Z). The 0.3.x sandbox splits namespace setup into `unshare(CLONE_NEWUSER)` then `unshare(CLONE_NEWPID|CLONE_NEWNS)`; the 0.2.85 builder combined them so `CLONE_NEWUSER` was always present. The container seccomp profile only allowed `unshare` when `(arg0 & CLONE_NEWUSER)` was set, so the split second call (`0x20020000`, no CLONE_NEWUSER) fell through to `defaultAction: SCMP_ACT_ERRNO` → `apply-seccomp: unshare(CLONE_NEWPID|CLONE_NEWNS) after userns: Operation not permitted` → the sandbox failed to start for **every tenant**. Not caused by #5864 (that fixed read-isolation *inside* a working sandbox — upstream of this).

## Changes

- **`seccomp-bwrap.json`** — two additive `SCMP_ACT_ALLOW` rules for `unshare` of a new mount (`CLONE_NEWNS`) and new pid (`CLONE_NEWPID`) namespace, each AND-requiring `CLONE_NEWUSER` **unset** (matches only the post-userns namespace unshare; cannot smuggle a userns — hardening per the commit security review). Scoped `excludes: CAP_SYS_ADMIN` exactly like the existing #1557 rule. Purely additive; no deny rule or `defaultAction` changed. `clone3` already returns ENOSYS — unchanged.
- **`apply-deploy-pipeline-fix.yml`** — add `seccomp-bwrap.json` to `paths:` and `-target=terraform_data.docker_seccomp_config` to plan+apply, so a profile edit auto-applies to the host over the CF tunnel (it was never in `deploy_pipeline_fix`'s `depends_on`, so profile changes silently never reached prod).

## Restoration sequence (post-merge)

1. Merge → `apply-deploy-pipeline-fix` pushes the new profile to `/etc/docker/seccomp-profiles/soleur-bwrap.json`.
2. **Redeploy** (explicit, apply→restart ordered) — a running container only loads a new seccomp profile at `docker run`.
3. Verify a real Bash call succeeds in a fresh `/soleur:go`.

## Verification

- Bit-math: the failing `unshare(0x20020000)` now matches both new rules; a `CLONE_NEWUSER`-bearing call does not.
- Purely additive (63 insertions, 0 deletions).

## Follow-ups (fast-follow, non-blocking — do not delay restoration)

- **Faithful sandbox canary**: the current canary tests only `--unshare-pid`, which is *why #5849 shipped green*. Add a dark-launched (non-blocking, per `wg-dark-launch-deploy-gates` / #4932→#4941) canary that exercises the real split-unshare sequence, promoted to blocking once proven on a healthy host.
- **Observability**: emit a Sentry-alertable event on sandbox-start failure — this full outage produced zero server-side signal (only visible in the agent transcript).
- **SDK-bump guard**: any `claude-agent-sdk`/`claude-code` bump must run the sandbox canary before deploy.

## User-Brand Impact

- **Artifact:** The Concierge agent's ability to run any Bash command (git, build, file ops) in `/soleur:go` — i.e., the core product working at all for a tenant.
- **Vector:** A too-restrictive seccomp `unshare` rule blocks sandbox startup → total Concierge outage (the current incident). A too-*permissive* fix could weaken the tenant sandbox; this change is scoped to post-userns namespace unshares with `CLONE_NEWUSER` explicitly excluded, adding no capability beyond the existing Docker + userns boundary.
- **Brand-survival threshold:** single-user incident


## Review addendum (#5874 multi-agent review)

Five agents reviewed; the seccomp fix is confirmed correct (security-sentinel bit-math) and the terraform/workflow wiring correct (git-history). Two additional user-facing failure modes surfaced by `user-impact-reviewer` (extending the `## User-Brand Impact` section above):

- **Incomplete unshare coverage → sandbox still EPERMs → tenants stay down.** The two rules cover a post-userns `unshare` that includes `CLONE_NEWNS` or `CLONE_NEWPID`. The observed #5849 call is the combined `unshare(CLONE_NEWPID|CLONE_NEWNS)` (matched). security-sentinel + code-quality + pattern-recognition concur this is likely first-time-right (bwrap folds its non-user namespaces into one NEWNS-bearing unshare). **Mitigation: restoration is NOT declared on merge+apply — it is gated on a post-deploy real Bash call succeeding in a fresh `/soleur:go` (§Restoration step 3). If that surfaces a residual EPERM on another namespace, the minimal follow-up is one more rule keyed on the offending bit.**
- **Profile delivered to host but not loaded by the running container → tenants stay down.** `docker_seccomp_config` writes the file; a running container only loads a seccomp profile at `docker run`. **Mitigation: the redeploy is sequenced explicitly AFTER the apply (operator-driven, apply→restart), and the same post-deploy Bash verification is the backstop — if the container is still on the old profile, the Bash call fails and restoration is not declared.** A follow-up will make profile-change→redeploy automated/gated (tracked with the faithful-canary follow-up).

**Restoration gate (explicit):** merge → auto-apply pushes the profile → redeploy → **a real Bash command succeeds in a fresh `/soleur:go`**. Only the last step closes #5873.
