### PR TITLE
fix(ci): repair infra-validation red on main from #5877 for_each (drift-guards + tftest)

### DIFF
--- a/apps/web-platform/infra/cron-egress-firewall.test.sh
+++ b/apps/web-platform/infra/cron-egress-firewall.test.sh
@@ -96,10 +96,10 @@ done
 # The template unit's `@` needs its own anchors (regex-escaping differs).
 assert_grep "delivers cron-egress-alarm@.service (source=)" 'source += +"\$\{path\.module\}/cron-egress-alarm@\.service"' "$SERVER_TF"
 SERVER_BLOCK="$(awk '/resource "terraform_data" "cron_egress_firewall"/,/^}/' "$SERVER_TF")"
-if echo "$SERVER_BLOCK" | grep -qE 'server_id += +hcloud_server\.web\.id'; then
-  PASS=$((PASS + 1)); echo "  PASS: cron_egress_firewall trigger folds hcloud_server.web.id"
+if echo "$SERVER_BLOCK" | grep -qE 'server_id += +hcloud_server\.web\["web-1"\]\.id'; then
+  PASS=$((PASS + 1)); echo "  PASS: cron_egress_firewall trigger folds hcloud_server.web[\"web-1\"].id"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: cron_egress_firewall trigger does not fold hcloud_server.web.id"
+  FAIL=$((FAIL + 1)); echo "  FAIL: cron_egress_firewall trigger does not fold hcloud_server.web[\"web-1\"].id"
 fi
 if echo "$SERVER_BLOCK" | grep -q 'mkdir -p /etc/soleur'; then
   PASS=$((PASS + 1)); echo "  PASS: parent dir created before file provisioners (scp does not mkdir)"

--- a/apps/web-platform/infra/infra-config-handler-bootstrap.test.sh
+++ b/apps/web-platform/infra/infra-config-handler-bootstrap.test.sh
@@ -79,8 +79,8 @@ echo ""
 echo "--- AC2: SSH connection block matches the 7-sibling shape ---"
 assert "SSH connection block (type = ssh)" \
   "printf '%s' \"\$BLOCK\" | grep -qE 'type[[:space:]]*=[[:space:]]*\"ssh\"'"
-assert "connection host = hcloud_server.web.ipv4_address" \
-  "printf '%s' \"\$BLOCK\" | grep -qE 'host[[:space:]]*=[[:space:]]*hcloud_server\.web\.ipv4_address'"
+assert "connection host = hcloud_server.web[\"web-1\"].ipv4_address" \
+  "printf '%s' \"\$BLOCK\" | grep -qE 'host[[:space:]]*=[[:space:]]*hcloud_server\.web\[\"web-1\"\]\.ipv4_address'"
 assert "connection user = root" \
   "printf '%s' \"\$BLOCK\" | grep -qE 'user[[:space:]]*=[[:space:]]*\"root\"'"
 # `agent = true` was stale post-#4845: server.tf now uses the dual-context

--- a/apps/web-platform/infra/journald-config.test.sh
+++ b/apps/web-platform/infra/journald-config.test.sh
@@ -117,8 +117,8 @@ assert "SSH connection block (type=ssh)" \
 # the #4829 dual-context comment (which reads literal `agent = true`).
 assert "connection uses the dual-context ssh-agent toggle agent = var.ci_ssh_private_key == null" \
   "printf '%s' \"\$BLOCK\" | grep -qE 'agent[[:space:]]*=[[:space:]]*var\.ci_ssh_private_key[[:space:]]*==[[:space:]]*null'"
-assert "connection host = hcloud_server.web.ipv4_address" \
-  "printf '%s' \"\$BLOCK\" | grep -qE 'host[[:space:]]*=[[:space:]]*hcloud_server\.web\.ipv4_address'"
+assert "connection host = hcloud_server.web[\"web-1\"].ipv4_address" \
+  "printf '%s' \"\$BLOCK\" | grep -qE 'host[[:space:]]*=[[:space:]]*hcloud_server\.web\[\"web-1\"\]\.ipv4_address'"
 assert "file provisioner pushes drop-in to /etc/systemd/journald.conf.d/00-soleur.conf" \
   "printf '%s' \"\$BLOCK\" | grep -qE 'destination[[:space:]]*=[[:space:]]*\"/etc/systemd/journald\.conf\.d/00-soleur\.conf\"'"
 # The drop-in dir is NOT created by default on Ubuntu and scp won't create

--- a/apps/web-platform/infra/tests/dummy-id_ed25519.pub
+++ b/apps/web-platform/infra/tests/dummy-id_ed25519.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICdummyTestFixtureKeyNotARealKey000000000000 terraform-test-fixture

--- a/apps/web-platform/infra/tests/web-hosts-eu-pin.tftest.hcl
+++ b/apps/web-platform/infra/tests/web-hosts-eu-pin.tftest.hcl
@@ -45,6 +45,11 @@ variables {
   resend_receiving_api_key     = "dummy"
   supabase_access_token        = "dummy"
   webhook_deploy_secret        = "dummy"
+  # command=plan evaluates file(var.ssh_key_path) (hcloud_ssh_key.default). The
+  # default ~/.ssh/id_ed25519.pub does not exist in CI, so point at a committed
+  # fixture (content is irrelevant — the hcloud provider is mocked). Path is
+  # CWD-relative (terraform test runs from the infra dir in CI + locally).
+  ssh_key_path = "tests/dummy-id_ed25519.pub"
 }
 
 # A non-EU location (ash = US) MUST be rejected (GDPR residency).


### PR DESCRIPTION
## Summary

Hotfix for **main** after PR #5877 (Phase 3 Sub-PR 3.A) merged **without** its CI-fix commit (auto-merge fired before the fixes landed on the required-check evaluation). #5877's `for_each` web-host refactor repointed the provisioner connections to `hcloud_server.web["web-1"]`, but 3 infra drift-guards still asserted the pre-`for_each` `hcloud_server.web.(ipv4_address|id)` form, and the new EU-pin tftest evaluated `file(~/.ssh/id_ed25519.pub)` which is absent in CI — so infra-validation went red on main.

This lands the exact fixes (cherry-picked from #5877's branch):
- 3 drift-guards (journald-config, infra-config-handler-bootstrap, cron-egress-firewall) → `web["web-1"]` indexed form.
- `web-hosts-eu-pin.tftest.hcl` overrides `ssh_key_path` to a committed fixture (`tests/dummy-id_ed25519.pub`; content irrelevant — provider mocked). Verified CI-safe via `HOME=/tmp/emptyhome`.

Ref #5274

## Test plan
- [x] All 4 infra drift-guards green
- [x] `terraform test` EU-pin 3/3 with empty HOME (CI-equivalent)

Generated with [Claude Code](https://claude.com/claude-code)