### PR TITLE
fix(git-worktree): age-guarded stale git-lock sweep to self-heal wedged Concierge workspaces

### DIFF
--- a/knowledge-base/engineering/operations/post-mortems/concierge-worktree-creation-stale-lock-wedge-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/concierge-worktree-creation-stale-lock-wedge-postmortem.md
@@ -1,0 +1,81 @@
+---
+title: "Concierge worktree creation permanently wedged by a stale .git/config.lock"
+date: 2026-07-01
+severity: high
+status: resolved
+brand_survival_threshold: single-user incident
+art_33_notifiable: false
+art_33_rationale: "Availability-only incident (worktree creation blocked). No personal data was accessed, altered, lost, or disclosed — the failure was a config-write lock, not a data-plane event. GDPR Art. 33 breach-notification clock does not start."
+art_34_notifiable: false
+art_34_rationale: "No high-risk to data subjects' rights/freedoms — no personal-data exposure. Art. 34 individual notification not triggered."
+originating_incident: knowledge-base/engineering/operations/post-mortems/2026-07-01-concierge-bwrap-seccomp-sdk-0-3-outage-postmortem.md
+remediation_pr: 5880
+---
+
+# PIR: Concierge worktree creation wedged by stale `.git/config.lock`
+
+## Summary
+
+After the 2026-07-01 seccomp outage
+([postmortem](2026-07-01-concierge-bwrap-seccomp-sdk-0-3-outage-postmortem.md)),
+affected Concierge workspaces could no longer create git worktrees. Every attempt
+failed with `could not lock config file .git/config: File exists`. Because worktree
+creation is the first thing every `/soleur:go` session does, the workspace was
+**permanently unusable** — the tenant could do no work at all.
+
+This is a distinct, remediation-worthy failure mode from the originating seccomp
+outage: the outage *created* the condition, but the *permanence* was caused by a
+separate latent gap — **no stale-git-lock cleanup existed anywhere in the worktree
+tooling**, so a lock left by a killed git process persisted on the mounted
+`/workspaces` volume indefinitely.
+
+## Impact
+
+- **Scope:** any Concierge workspace whose git process was killed mid-config-write
+  during the seccomp outage window (before #5874 restored git).
+- **User-facing effect:** worktree creation — the first action of every session —
+  failed permanently; the workspace was wedged until an operator manually deleted
+  the lock over SSH.
+- **Data:** none. Availability-only; no personal data accessed/altered/lost/exposed
+  (see Art. 33/34 frontmatter rationale).
+
+## Root Cause
+
+1. The seccomp outage killed every `git config` / `git worktree add` mid-write
+   (`unshare` EPERM), leaving `.git/config.lock` on disk.
+2. Git's atomic-write protocol (`config.lock` → rename over `config`) treats a
+   pre-existing `config.lock` as EEXIST: `could not lock config file … File exists`.
+3. **The lock persisted on the mounted volume after git was restored** (#5874), so
+   every subsequent config write failed forever.
+4. **Latent gap:** no code path swept stale git locks — not `worktree-manager.sh`,
+   not the session-start preamble, not the git-data provisioner.
+
+Misdiagnosis note: the in-sandbox agent's debug stream attributed the failure to a
+bind-mounted `.git/config`. That was wrong — the sandbox binds the whole workspace
+read-write; the cause was the stale lock. Verifying against the sandbox code + git
+error semantics found the real cause. Captured in
+`knowledge-base/project/learnings/bug-fixes/2026-07-01-git-eexist-file-exists-is-stale-lock-not-mount.md`.
+
+## Resolution
+
+PR #5880 added an age-guarded `sweep_stale_git_locks()` to
+`plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh`, called from
+`ensure_bare_config()` before its first config write. It removes `config.lock` /
+`config.worktree.lock` older than 60s (age-guard prevents clobbering a live
+sub-second writer; clock-skew guard preserves future-dated locks). Because
+`ensure_bare_config` runs on every create path AND the session-start
+`cleanup-merged` path, an affected workspace **self-heals on its next session** —
+no operator SSH required.
+
+## Detection & Prevention
+
+- **Detection (prod):** the original EEXIST error reappears in the `/soleur:go`
+  debug stream if the sweep ever fails to clear a lock (it is its own alert — the
+  surface has no server-side telemetry, by design).
+- **Prevention:** the sweep is now a permanent chokepoint; the
+  `stale-lock-sweep.test.sh` suite pins removal, preservation, clock-skew, scope
+  (config-locks-only), and the black-box wiring through `ensure_bare_config`.
+
+## Action Items & Follow-ups
+
+_No action items — incident fully resolved by PR #5880's stale-lock sweep, which self-heals affected workspaces on next session with no operator action.

--- a/knowledge-base/project/learnings/bug-fixes/2026-07-01-git-eexist-file-exists-is-stale-lock-not-mount.md
+++ b/knowledge-base/project/learnings/bug-fixes/2026-07-01-git-eexist-file-exists-is-stale-lock-not-mount.md
@@ -1,0 +1,88 @@
+---
+title: "git 'could not lock config file … File exists' is a stale lock, not a mount/permission problem"
+date: 2026-07-01
+category: bug-fixes
+module: git-worktree
+tags: [git, worktree, agent-sandbox, concierge, eexist, stale-lock, diagnosis]
+pr: 5880
+---
+
+# Learning: `File exists` from git config is a stale lock, not a bind-mount
+
+## Problem
+
+Concierge (the Soleur web app) ran agents in a bwrap sandbox. After the
+2026-07-01 seccomp outage, worktree creation began failing permanently on
+affected workspaces. The in-sandbox agent's pasted debug stream concluded the
+cause was: "`.git/config` is bind-mounted at the sandbox level, so any write
+attempt fails with 'File exists'." Every subsequent `git config` / `git worktree
+add` failed with `could not lock config file .git/config: File exists`.
+
+## Root Cause
+
+The debug stream's self-diagnosis was **wrong**. Reading the actual sandbox code
+(`apps/web-platform/server/agent-runner-sandbox-config.ts:213-221`) showed the
+bwrap config binds the **entire workspace read-write** (`allowWrite:
+[workspacePath]`). `.git/config` lives inside that dir, so writes to it are
+permitted — there is no per-file bind mount of `.git/config`.
+
+`File exists` (EEXIST) is git's exact signature for a **stale lock file**: git
+writes `config.lock`, then renames it over `config`. If the `git config` / `git
+worktree add` process is **killed mid-write** (which the seccomp outage did to
+every git call via `unshare` EPERM), the `.git/config.lock` is left behind on the
+mounted `/workspaces` volume. After git was restored, the stale lock persisted on
+disk, so every later config write failed EEXIST **forever**. Worktree creation is
+the first config-writer in a session, so it broke first.
+
+Confirmed gap: no stale-git-lock cleanup existed anywhere in the tooling.
+
+## Solution
+
+Add an **age-guarded** `sweep_stale_git_locks()` to
+`plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh`, called from
+`ensure_bare_config()` **before** its first `git config` write. It removes
+`config.lock` / `config.worktree.lock` older than 60s (mtime vs now; future-dated
+= fresh, clock-skew guard mirroring `cleanup_merged_worktrees`). Because
+`ensure_bare_config` is the chokepoint on every create path AND the session-start
+`cleanup-merged` path, an affected workspace **self-heals on its next session** —
+no operator SSH into the live volume. The fix is entirely in the worktree tooling;
+the bwrap/tenant-isolation layer is untouched.
+
+## Key Insight
+
+1. **`git ... : File exists` == stale `*.lock`, not a filesystem/permission/mount
+   fault.** Reach for `rm` of the stale lock (age-guarded), not a mount change.
+2. **An agent's hypothesis in a pasted debug stream is a hypothesis, not a
+   diagnosis.** The Concierge agent's "bind-mounted config" theory would have sent
+   a fix into the tenant-isolation layer (a red herring, and a dangerous surface).
+   Verifying against the actual sandbox code + git error semantics before
+   implementing found the real, far cheaper cause.
+3. **`git config`/`git worktree add` on a bare repo write the shared config
+   unavoidably**, so the wedge cannot be dodged at the script level by skipping
+   *our* writes — the durable fix is to clear the stale lock before any write.
+4. **Review lens (index/HEAD live-lock trap):** the first cut swept `index.lock`
+   and `HEAD.lock` "for completeness." `user-impact-reviewer` caught that on a
+   **non-bare** `git_dir` those are the *live* working-tree locks a concurrent
+   >60s commit/rebase legitimately holds — sweeping them adds live-clobber risk
+   with zero wedge-fix value (they never block a config write). Scope a
+   destructive sweep to exactly the failure class it fixes; do not include
+   "harmless-looking" siblings that are load-bearing on another layout.
+
+## Session Errors
+
+- **Unauthored plan-file edits appeared mid-draft** (planning subagent) — a
+  "Lock-file set (revised per CTO)" heading showed up the subagent hadn't
+  written; transient concurrent-writer / harness re-entry. Recovery: re-read
+  before each edit; final file coherent, no stray artifacts. **Prevention:** on
+  resume/handoff, re-read an artifact before editing (already standard); one-off.
+- **`test-all.sh` full-suite gate was killed mid-run twice** under background
+  execution before emitting its summary. Recovery: re-ran foreground with
+  `timeout 560 bash scripts/test-all.sh > log; rc=$?` + grep for the
+  `=== N/N suites passed ===` line (green, 139/139). **Prevention:** for the long
+  vitest+shell suite, prefer a foreground `timeout` run with explicit `rc`
+  capture over trusting a backgrounded "exit 0" (mirrors
+  [2026-05-18-test-all-tail-masking-and-monitor-exit-condition-tightness]);
+  environmental one-off, no code fix.
+- **Plan file "modified on disk since last read"** during a checkbox `Edit`
+  (concurrent `sed` flip + subagent write). Applied cleanly. **Prevention:**
+  benign; one-off.

--- a/knowledge-base/project/plans/2026-07-01-fix-stale-git-lock-sweep-worktree-plan.md
+++ b/knowledge-base/project/plans/2026-07-01-fix-stale-git-lock-sweep-worktree-plan.md
@@ -153,20 +153,26 @@ file at `cleanup_merged_worktrees:989-999` (which uses `date +%s` + a `git log
 (negative age) is treated as fresh and never removed** — same clock-skew posture as
 the existing code.
 
-### Lock-file set (revised per CTO)
+### Lock-file set (revised per CTO, then narrowed at review)
 
-Sweep these files in the resolved common `git_dir`:
-**`config.lock`, `config.worktree.lock`** (the confirmed config-write wedge — both
-live in the common dir), plus `index.lock`, `HEAD.lock` for completeness against the
-same stale-lock class. Per CTO: `index.lock`/`HEAD.lock` do **not** block `git
-config` writes and, on a bare repo, the common dir has no index at all, so those two
-are near-inert (harmless, low value) — they stay in the list only because the brief
-names them. **Do NOT** expand the sweep to per-worktree lock dirs
-(`.git/worktrees/*/index.lock`): that is a *different* failure class (a wedged
-commit/checkout inside one worktree), unrelated to the config-write wedge, and
-sweeping those enlarges blast radius onto paths where a >60s hold is more plausible
-(large checkout/rebase). Scope stays on the common `git_dir`. `packed-refs.lock` is
-**out** — not the wedge class, not in the brief.
+Sweep ONLY the config-write locks in the resolved common `git_dir`:
+**`config.lock`, `config.worktree.lock`** — the confirmed EEXIST wedge that blocks
+`ensure_bare_config`'s writes.
+
+**`index.lock` / `HEAD.lock` dropped at review time (user-impact P2).** The CTO
+pass had kept them "for completeness / near-inert." Review found they are worse than
+inert on the **non-bare** path: when `ensure_bare_config` resolves
+`git_dir="$GIT_ROOT/.git"`, `index.lock`/`HEAD.lock` are the **live working-tree
+locks** a concurrent >60s `git commit`/`checkout`/`rebase` legitimately holds —
+removing one mid-op tears that tenant's index. They also never block a `git config`
+write, so they carried live-clobber risk with zero wedge-fix value. Dropping them
+eliminates the race and the dead weight; the actual self-heal (config writes) is
+unaffected. Test AC3b pins the exclusion (aged `index.lock`/`HEAD.lock` preserved).
+
+**Do NOT** expand the sweep to per-worktree lock dirs (`.git/worktrees/*/index.lock`):
+a *different* failure class (a wedged commit/checkout inside one worktree), unrelated
+to the config-write wedge, with a larger blast radius. `packed-refs.lock` is **out** —
+not the wedge class.
 
 ## Files to Edit
 
@@ -189,10 +195,10 @@ sweeping those enlarges blast radius onto paths where a >60s hold is more plausi
       [[ -d "$git_dir" ]] || return 0
       local now lock mtime age swept=0
       now=$(date +%s)
-      for lock in config.lock config.worktree.lock index.lock HEAD.lock; do
+      for lock in config.lock config.worktree.lock; do  # config-write wedge only (index/HEAD dropped at review)
         local path="$git_dir/$lock"
         [[ -f "$path" ]] || continue
-        mtime=$(stat -c %Y "$path" 2>/dev/null) || continue
+        mtime=$(stat -c%Y "$path" 2>/dev/null) || continue
         age=$(( now - mtime ))
         # Remove only stale (age >= threshold). Skips fresh AND future-dated
         # (age < 0, clock skew). Arithmetic nested in `if` so a false `(( ))`

--- a/knowledge-base/project/plans/2026-07-01-fix-stale-git-lock-sweep-worktree-plan.md
+++ b/knowledge-base/project/plans/2026-07-01-fix-stale-git-lock-sweep-worktree-plan.md
@@ -10,6 +10,33 @@ requires_cpo_signoff: true
 
 # 🐛 fix: age-guarded stale git-lock sweep in worktree tooling
 
+## Enhancement Summary
+
+**Deepened on:** 2026-07-01
+**Passes run:** CTO engineering domain review; verify-the-negative + implementation-realism
+(inline, single-file scope); empirical root-cause + anchor verification.
+
+### Key confirmations (all verified live, not from memory)
+
+1. **EEXIST wedge reproduced empirically.** In a scratch repo, planting a
+   `.git/config.lock` then running `git config --file .git/config test.key val`
+   yields `error: could not lock config file .git/config: File exists` (exit 255).
+   This confirms both the root cause (a residual on-disk lock) and that removing the
+   lock before the config write is the correct fix.
+2. **All cited anchors verified at exact lines:** first config write is
+   `worktree-manager.sh:144`; the clock-skew age-guard precedent is `:995`
+   (`if (( _delta < 0 || _delta < 600 ))`); `stat -c%s` already used at `:1186`;
+   `ensure_bare_config` defined at `:132`, called at `:452 / :513 / :535 / :589`
+   (create paths) and `:888` (cleanup-merged / session-start). Single chokepoint
+   confirmed.
+3. **`set -e` hardening applied** to the code snippet (arithmetic nested in `if`,
+   guarded `rm`/`stat`) per CTO — the real implementation risk for this fix.
+4. **Scope boundary verified:** no bwrap-layer file
+   (`agent-runner-sandbox-config.ts`, seccomp profile, SDK) appears in Files to
+   Edit — only in Overview/Non-Goals as context.
+5. **Test recipe portability verified:** `touch -d '120 seconds ago'` and
+   `touch -d '+120 seconds'` both work on GNU (the target/CI/dev platform).
+
 ## Overview
 
 Concierge worktree creation can be **permanently wedged** by a stale git lock file
@@ -350,6 +377,34 @@ Not applicable — no user-facing surface. No files under `components/**/*.tsx`,
 | `find -mmin +1 -delete` | Coarse whole-minute granularity; can't express a clean 60s threshold and has no clock-skew guard. mtime comparison mirrors the existing in-file pattern. |
 | Unconditional `rm -f config.lock` (no age guard) | Would clobber a legitimately in-flight concurrent config writer on a parallel Concierge session — the exact race the age-guard exists to prevent (brand-survival brake). |
 | Fix in the bwrap/sandbox layer | Out of scope — sandbox hardening is `feat-harden-agent-sandbox-5875` (ADR-075). This plan stays out of those files to avoid collision. |
+
+## Risks & Mitigations
+
+### Precedent-diff (age-guarded cleanup pattern)
+
+The age-guard is a lock/cleanup pattern with an established in-repo precedent —
+`cleanup_merged_worktrees:989-999`. The new sweep mirrors it:
+
+| Aspect | Precedent (`:989-999`, recent-commit skip) | New sweep (`sweep_stale_git_locks`) |
+|---|---|---|
+| Now source | `_now=$(date +%s)` | `now=$(date +%s)` |
+| mtime source | `git log -1 --format=%ct HEAD` | `stat -c %Y "$path"` |
+| Delta | `_delta=$(( _now - last_commit_age ))` | `age=$(( now - mtime ))` |
+| Clock-skew guard | `if (( _delta < 0 || _delta < 600 ))` → skip | `if (( age >= threshold ))` → remove (skips fresh AND negative/future-dated) |
+| set-e safety | arithmetic nested in `if` | arithmetic nested in `if` (same) |
+
+The sweep is the **inverse polarity** of the precedent (precedent *skips* fresh
+things; sweep *removes* stale things) but uses the identical now/mtime/delta/skew
+machinery. Not a novel pattern.
+
+### Other risks
+
+| Risk | Mitigation |
+|---|---|
+| Clobbering a live concurrent config writer | Age-guard: a real `git config` write holds the lock for single-digit ms, so its mtime always reads fresh (< 60s) and is skipped. CTO: no meaningful parallel-session race. |
+| `stat -c %Y` is GNU-only (BSD/macOS differ) | Acceptable — Concierge runs Linux containers, CI is ubuntu, dev is Linux; the file already depends on GNU `stat -c%s` at `:1186`. One-line comment notes the assumption. |
+| Lock vanishes between `stat` and `rm` (racing sibling) | `stat … 2>/dev/null || continue` and `rm -f … 2>/dev/null` guarded by `if` — both non-fatal under `set -e`. |
+| Empty lock set aborts under `set -e` | Fixed list + `[[ -f ]]` per-file guard (no glob); AC7 covers the no-lock no-op case. |
 
 ## Non-Goals
 

--- a/knowledge-base/project/plans/2026-07-01-fix-stale-git-lock-sweep-worktree-plan.md
+++ b/knowledge-base/project/plans/2026-07-01-fix-stale-git-lock-sweep-worktree-plan.md
@@ -1,0 +1,358 @@
+---
+title: "fix: age-guarded stale git-lock sweep in worktree tooling (self-heal wedged Concierge workspaces)"
+date: 2026-07-01
+type: bug
+branch: feat-one-shot-stale-git-lock-sweep
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+---
+
+# 🐛 fix: age-guarded stale git-lock sweep in worktree tooling
+
+## Overview
+
+Concierge worktree creation can be **permanently wedged** by a stale git lock file
+left behind when a `git config` / `git worktree add` process is killed mid-write.
+This is exactly what happened during the 2026-07-01 seccomp outage
+([postmortem](../../engineering/operations/post-mortems/2026-07-01-concierge-bwrap-seccomp-sdk-0-3-outage-postmortem.md)):
+every Bash/git call died on `unshare` EPERM, leaving a stale `config.lock` on the
+mounted `/workspaces` volume. After git was restored, the stale lock **persists on
+disk**, so every subsequent config write fails forever with
+`could not lock config file .git/config: File exists` (EEXIST). Worktree creation
+is the first config-writer in a session, so it is the first thing to break.
+
+**Fix (scope = lock-sweep ONLY):** add an **age-guarded** sweep of stale git lock
+files to `plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh`. The
+sweep removes only locks **older than a small threshold** (default 60s) so a
+legitimately in-flight sub-second config writer is never clobbered. Because the
+sweep is wired into `ensure_bare_config()` — the chokepoint that runs before every
+`git config` write on both the create path and the session-start `cleanup-merged`
+path — an affected workspace **self-heals on the next Concierge session**, with no
+operator SSH into the live volume required. The single chokepoint (rather than a
+second explicit call in `cleanup_merged_worktrees`) is confirmed correct by CTO
+domain review: `cleanup_merged_worktrees:888` already calls `ensure_bare_config`,
+so the session-start path is covered transitively.
+
+This is a pure bug fix on existing shell tooling. It makes **no** change to the
+bwrap/tenant-isolation layer.
+
+## Root Cause (confirmed, not the debug stream's guess)
+
+- The Concierge agent-sandbox binds the **entire** workspace read-write
+  (`allowWrite: [workspacePath]` in
+  `apps/web-platform/server/agent-runner-sandbox-config.ts:213-221`) via bwrap
+  `--bind`. `.git/config` lives inside that dir, so writes to it **are** permitted
+  — the debug stream's "`.git/config` is bind-mounted, writes fail" theory is
+  **wrong**.
+- `File exists` (EEXIST) is git's signature for a **stale lock file**
+  (`could not lock config file .git/config: File exists`), left when a
+  `git config` / `git worktree add` process is killed mid-write.
+- During the 2026-07-01 seccomp outage all git calls died on `unshare` EPERM,
+  leaving a stale `.git/config.lock` on the mounted `/workspaces` volume. After git
+  was restored, the stale lock persists on disk, so every subsequent config write
+  fails forever.
+- **Confirmed gap:** NO stale-git-lock cleanup exists anywhere. Grep of
+  `worktree-manager.sh`, `.claude/hooks/`, `plugins/soleur/hooks/` returns zero
+  matches for `config.lock` / `config.worktree.lock` / `index.lock` / `HEAD.lock`
+  (only an unrelated `yarn.lock` string in `install_deps`).
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (from feature description) | Codebase reality (verified) | Plan response |
+|---|---|---|
+| Sweep in `ensure_bare_config()` (~lines 132-172) runs before every worktree create | `create_worktree:452`, `create_worktree:513`, `create_for_feature:535`, `create_for_feature:589` all call `ensure_bare_config` | Wire the sweep into `ensure_bare_config` right after `git_dir` is resolved, before the first `git config --file` write |
+| Sweep in `cleanup-merged` path (session-start preamble) | `cleanup_merged_worktrees:888` calls `ensure_bare_config` | A single call site inside `ensure_bare_config` covers **both** required paths. See "Design Decision: single chokepoint" below |
+| Handle both bare (`$GIT_ROOT/config.lock`) and non-bare (`$GIT_ROOT/.git/config.lock`) layouts | `ensure_bare_config:133-137` already resolves `git_dir` = `$GIT_ROOT/.git` (non-bare) or `$GIT_ROOT` (bare) | Pass the already-resolved `git_dir` into the sweep helper — no duplicated layout logic |
+| New test auto-discovered | `scripts/test-all.sh:188` globs `plugins/soleur/skills/*/test/*.test.sh` | New file `plugins/soleur/skills/git-worktree/test/stale-lock-sweep.test.sh` is picked up automatically; no runner wiring needed |
+| Scope boundary: do not touch bwrap layer | `feat-harden-agent-sandbox-5875` worktree is handling ADR-075 sandbox hardening in parallel | This plan touches **only** `worktree-manager.sh` + a new test file |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a Concierge session whose very
+first action — worktree creation — fails with `could not lock config file
+.git/config: File exists`, permanently, for every subsequent session on that
+workspace, until an operator manually SSHes into the live `/workspaces` volume and
+deletes the lock. The tenant cannot do any work.
+
+**If this leaks, the user's data is exposed via:** N/A — this change reads/removes
+only git lock files under the workspace's own `.git` dir; it moves no user data and
+opens no new read/write surface. (No leak vector.)
+
+**Brand-survival threshold:** `single-user incident` — a single stale lock wedges
+one tenant's workspace indefinitely, and a broken sweep (see Risks) could
+theoretically `rm` a lock during an unusually-long-but-live config write on that
+one tenant's volume. The **age-guard is the brand-survival brake**: it removes only
+locks older than the threshold, so a normal sub-second config write (lock lifetime
+in milliseconds) is never in scope. This threshold and the artifact/vector framing
+are carried forward from the postmortem, which set
+`brand_survival_threshold: single-user incident` for this exact surface.
+
+> CPO sign-off required at plan time before `/work` begins. `user-impact-reviewer`
+> will be invoked at review-time (handled by the review skill's conditional-agent
+> block).
+
+## Design Decisions
+
+### Single chokepoint: sweep inside `ensure_bare_config()`
+
+The feature brief asks for a sweep "in the cleanup-merged path AND in
+`ensure_bare_config()`". These collapse to **one** call site because
+`cleanup_merged_worktrees` (the session-start preamble path) already calls
+`ensure_bare_config` at line 888, and every create path calls it at entry and after
+`git worktree add`. Wiring the sweep into `ensure_bare_config` — immediately after
+`git_dir` is resolved and **before** the first `git config --file` write — makes
+the fix fire on both required paths with no duplication (KISS / DRY). The sweep
+runs *before* the writes that would otherwise hit EEXIST, which is the whole point:
+self-heal, then write. **CTO-resolved:** single chokepoint only — no second
+explicit call in `cleanup_merged_worktrees` (it would be redundant since :888
+already routes through `ensure_bare_config`). Note: the create paths call
+`ensure_bare_config` *without* a lock while :888 calls it under `acquire_lock
+cleanup-merged`; the sweep therefore runs both locked and unlocked, which is fine
+because the **age-guard, not the flock, is the real safety mechanism**.
+
+The sweep MUST land after `git_dir` is resolved (line 137) and before the **first**
+config write, which is line 144 (`git config --file "$shared_config"
+core.repositoryformatversion 1`) — not the `core.bare` logic. Line 144 is itself a
+writer that hits the EEXIST wedge first, so the sweep must precede it.
+
+### Age-guard via mtime comparison (not `find -mmin`)
+
+Use an explicit `stat -c %Y` (mtime epoch) vs `date +%s` (now) comparison so the
+threshold is expressed in **seconds** (60s), not `find -mmin`'s coarse whole-minute
+granularity. This mirrors the existing clock-skew-guarded age check already in this
+file at `cleanup_merged_worktrees:989-999` (which uses `date +%s` + a `git log
+--format=%ct` mtime and treats a negative delta as "fresh"). A **future-dated lock
+(negative age) is treated as fresh and never removed** — same clock-skew posture as
+the existing code.
+
+### Lock-file set (revised per CTO)
+
+Sweep these files in the resolved common `git_dir`:
+**`config.lock`, `config.worktree.lock`** (the confirmed config-write wedge — both
+live in the common dir), plus `index.lock`, `HEAD.lock` for completeness against the
+same stale-lock class. Per CTO: `index.lock`/`HEAD.lock` do **not** block `git
+config` writes and, on a bare repo, the common dir has no index at all, so those two
+are near-inert (harmless, low value) — they stay in the list only because the brief
+names them. **Do NOT** expand the sweep to per-worktree lock dirs
+(`.git/worktrees/*/index.lock`): that is a *different* failure class (a wedged
+commit/checkout inside one worktree), unrelated to the config-write wedge, and
+sweeping those enlarges blast radius onto paths where a >60s hold is more plausible
+(large checkout/rebase). Scope stays on the common `git_dir`. `packed-refs.lock` is
+**out** — not the wedge class, not in the brief.
+
+## Files to Edit
+
+- `plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh`
+  - **Add** a new function `sweep_stale_git_locks()` (near `ensure_bare_config`,
+    ~line 124):
+
+    ```bash
+    # Remove stale git lock files left when a git process is killed mid-write
+    # (e.g., the 2026-07-01 seccomp outage killed git under `unshare` EPERM,
+    # leaving `.git/config.lock` on the mounted /workspaces volume; every later
+    # `git config` write then fails EEXIST forever). Age-guarded: only removes
+    # locks older than $threshold seconds so a legitimately in-flight sub-second
+    # config writer is never clobbered. Clock-skew guard: a future-dated lock
+    # (negative age) is treated as fresh and preserved, matching the existing
+    # guard in cleanup_merged_worktrees. Idempotent; safe for parallel sessions.
+    sweep_stale_git_locks() {
+      local git_dir="$1"
+      local threshold="${2:-60}"   # seconds
+      [[ -d "$git_dir" ]] || return 0
+      local now lock mtime age swept=0
+      now=$(date +%s)
+      for lock in config.lock config.worktree.lock index.lock HEAD.lock; do
+        local path="$git_dir/$lock"
+        [[ -f "$path" ]] || continue
+        mtime=$(stat -c %Y "$path" 2>/dev/null) || continue
+        age=$(( now - mtime ))
+        # Remove only stale (age >= threshold). Skips fresh AND future-dated
+        # (age < 0, clock skew). Arithmetic nested in `if` so a false `(( ))`
+        # returning exit 1 never trips `set -e` (mirrors :989-999).
+        if (( age >= threshold )); then
+          if rm -f "$path" 2>/dev/null; then
+            swept=$((swept + 1))
+          fi
+        fi
+      done
+      if (( swept > 0 )); then
+        echo -e "${YELLOW}Swept $swept stale git lock file(s) from $git_dir${NC}"
+      fi
+    }
+    ```
+
+  - **Call** the helper from `ensure_bare_config()` immediately after `git_dir` is
+    resolved (after line 137, before the `git config --file "$shared_config"
+    core.repositoryformatversion 1` write at line 144):
+
+    ```bash
+      # Self-heal: remove stale git locks BEFORE any config write, or the writes
+      # below fail EEXIST forever (2026-07-01 outage class).
+      sweep_stale_git_locks "$git_dir"
+    ```
+
+  - **No second call site** (CTO-resolved): do NOT add an explicit sweep to
+    `cleanup_merged_worktrees` — it already routes through `ensure_bare_config` at
+    :888, so a second call would be redundant.
+
+## Files to Create
+
+- `plugins/soleur/skills/git-worktree/test/stale-lock-sweep.test.sh` — source-based
+  unit test (the script's `BASH_SOURCE`/`$0` guard at line 1490 explicitly supports
+  sourcing without running `main`), plus one black-box integration assertion.
+  Follows the structure of the sibling `create-from-origin-main.test.sh`.
+
+## Test Scenarios
+
+New test file `stale-lock-sweep.test.sh`:
+
+1. **Setup** — stand up a bare repo + a linked worktree (mirrors the soleur bare
+   layout, same pattern as `create-from-origin-main.test.sh`); `cd` into the
+   worktree so the script's top-level init resolves `GIT_ROOT`/`IS_BARE`; `source`
+   the script. Compute `git_dir` the same way `ensure_bare_config` does.
+2. **AC1 — aged lock removed:** plant `config.lock` with mtime 120s in the past
+   (`touch -d '120 seconds ago' "$git_dir/config.lock"`), call
+   `sweep_stale_git_locks "$git_dir" 60`, assert the file is gone.
+3. **AC2 — fresh lock preserved:** plant a fresh `config.worktree.lock` (`touch`),
+   call the sweep, assert it still exists (age < 60s).
+4. **AC3 — multiple patterns:** plant an aged `HEAD.lock` (removed) and a fresh
+   `index.lock` (preserved) in the same run; assert both outcomes.
+5. **AC4 — clock-skew guard:** plant a **future-dated** lock
+   (`touch -d '+120 seconds' "$git_dir/config.lock"`), call the sweep, assert it is
+   **preserved** (negative age treated as fresh).
+6. **AC5 — self-heal wiring (black-box):** plant an aged `config.lock` in the
+   bare git dir, run `bash "$WM" --yes cleanup-merged` (or a `create`) as a
+   subprocess, assert the aged `config.lock` is gone afterward — proves the sweep
+   actually fires through `ensure_bare_config` on the real session-start path.
+7. **AC6 — no false wedge:** after a sweep with a fresh lock present, assert a real
+   `git config --file "$git_dir/config" test.key val` still succeeds (sweep did not
+   corrupt config).
+8. **AC7 — no-op when no lock present (CTO):** call the sweep against a `git_dir`
+   with no lock files; assert exit 0 and no error (guards against a `set -e` /
+   glob-miss regression when the lock set is empty).
+
+Standard results footer (`PASS`/`FAIL`, `exit 1` on any fail), matching the sibling
+tests. Auto-discovered by `scripts/test-all.sh` via the
+`plugins/soleur/skills/*/test/*.test.sh` glob.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] `sweep_stale_git_locks()` exists in `worktree-manager.sh` and is called from
+      `ensure_bare_config()` **before** the first `git config --file` write.
+- [ ] Sweep removes only locks with `age >= threshold` (default 60s); fresh and
+      future-dated locks are preserved (verified by AC2/AC4).
+- [ ] Sweep operates on the `git_dir` resolved by the existing bare/non-bare logic
+      (no duplicated layout computation).
+- [ ] New test `plugins/soleur/skills/git-worktree/test/stale-lock-sweep.test.sh`
+      passes and is discovered by `bash scripts/test-all.sh`.
+- [ ] `bash -n plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh`
+      passes (and `shellcheck` clean if available).
+- [ ] The three sibling tests
+      (`create-from-origin-main`, `lease-protects-active`, `no-repo-fail-loud`)
+      still pass (no regression to `ensure_bare_config`'s existing behavior).
+- [ ] No file outside `worktree-manager.sh` + the new test is modified (scope
+      boundary: bwrap layer untouched).
+
+## Observability
+
+This is a shell tool that runs inside the Concierge sandbox — a blind execution
+surface. Its observability model is the **session-start / debug-stream stdout** the
+operator already pastes when a session strands (no Sentry/Better Stack path exists
+for this surface; SSH is explicitly not required).
+
+```yaml
+liveness_signal:
+  what: "`Swept N stale git lock file(s) from <git_dir>` line on stdout when the sweep removes a lock"
+  cadence: "every worktree create + every session-start cleanup-merged"
+  alert_target: "operator-visible in the /soleur:go debug stream (grep-able marker), same visibility model as SOLEUR_FEATURE_PUSH_FAILED"
+  configured_in: "plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh (sweep_stale_git_locks echo)"
+error_reporting:
+  destination: "stdout/stderr in the session preamble output (the surface has no server-side telemetry path)"
+  fail_loud: "rm failure is non-fatal by design (idempotent self-heal); a persisting wedge re-surfaces as the original EEXIST error on the next config write, which is itself the alert"
+failure_modes:
+  - mode: "aged lock NOT removed (threshold/mtime bug)"
+    detection: "stale-lock-sweep.test.sh AC1/AC3 fail; in prod the original `could not lock config file .git/config: File exists` reappears in the debug stream"
+    alert_route: "test suite (pre-merge) + operator-pasted debug stream (prod)"
+  - mode: "fresh/live lock wrongly removed (age-guard bug)"
+    detection: "stale-lock-sweep.test.sh AC2/AC4/AC6 fail"
+    alert_route: "test suite (pre-merge)"
+logs:
+  where: "session-start preamble stdout captured in the Concierge debug stream"
+  retention: "per-session (transcript)"
+discoverability_test:
+  command: "plant an aged config.lock, run `bash plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh --yes cleanup-merged`, then `test ! -f <git_dir>/config.lock` (NO ssh)"
+  expected_output: "exit 0 — lock removed and `Swept 1 stale git lock file(s)` printed"
+```
+
+## Architecture Decision (ADR/C4)
+
+**No architectural decision.** This is a bug fix on existing internal worktree
+tooling — no ownership/tenancy boundary move, no new substrate/integration, no
+resolver/dispatch/trust-boundary change, and it neither reverses nor extends any
+ADR. A competent engineer reading the existing ADR corpus + C4 would not be misled
+about the system after this ships. No C4 impact: the change introduces no external
+human actor, no external system/vendor, no new data store, and no
+actor↔surface access-relationship change (worktree-manager.sh is internal tooling
+already within the modeled boundary). ADR/C4 gate: **skip**.
+
+## Domain Review
+
+**Domains relevant:** engineering
+
+### Engineering (CTO)
+
+**Status:** reviewed
+**Assessment:** Complexity Small (hours); overall risk **Low**. CTO independently
+verified every plan claim against the code:
+- `ensure_bare_config:132-172` resolves `git_dir` for both bare/non-bare at
+  :133-137; its **first** config write is :144 (`repositoryformatversion`), which is
+  itself a writer that hits the EEXIST wedge — the sweep must land after :137 and
+  before :144. Placement correct.
+- Single call-site is correct — `cleanup_merged_worktrees:888` covers the
+  session-start path transitively; a second call would be redundant. Create paths
+  call `ensure_bare_config` unlocked, :888 calls it under `acquire_lock`; both are
+  fine because the **age-guard, not the flock, is the safety mechanism**.
+- 60s age-guard is sound; **no meaningful parallel-session race** — a live config
+  write holds the lock for single-digit ms, so its mtime always reads fresh; the
+  only way to clobber a live writer is a >60s config write, which does not occur.
+  Keep `>= threshold` (strictly older), mirroring :995.
+- **Scope to common `git_dir` config locks only** — `config.lock` /
+  `config.worktree.lock` are load-bearing; `index.lock` / `HEAD.lock` don't block
+  config writes and are near-inert in the common dir (kept only because the brief
+  names them). Do NOT expand to per-worktree lock dirs (different failure class,
+  larger blast radius).
+- `stat -c %Y` is GNU-only but acceptable (Linux containers + CI ubuntu + existing
+  GNU `stat -c%s` at :1186); add a one-line GNU-assumption comment.
+- **`set -e` discipline is the real implementation risk**: `stat … 2>/dev/null ||
+  continue`, `rm -f … 2>/dev/null` guarded by `if`, and nest the arithmetic
+  comparison inside `if (( … ))` (a bare `(( expr ))` evaluating to 0 returns exit 1
+  and aborts under `set -e` — the exact reason :995 nests it). Incorporated into the
+  code snippet above.
+- **No ADR required** — agreed; bugfix reusing an established in-repo pattern.
+- Additional: log every removal (already in the snippet via the color echo) so the
+  self-heal is not invisible in headless/CI logs; add a no-op-when-no-lock test case
+  (added as AC7). No capability gaps — the `.test.sh` harness and discovery already
+  exist.
+
+### Product/UX Gate
+
+Not applicable — no user-facing surface. No files under `components/**/*.tsx`,
+`app/**/page.tsx`, or `app/**/layout.tsx`. Product tier: **NONE**.
+
+## Alternatives Considered
+
+| Approach | Why not |
+|---|---|
+| Separate SessionStart hook that sweeps locks | Extra moving part; `ensure_bare_config` is already the pre-write chokepoint on every relevant path. Keeping it in `worktree-manager.sh` avoids a new hook (per brief). |
+| `find -mmin +1 -delete` | Coarse whole-minute granularity; can't express a clean 60s threshold and has no clock-skew guard. mtime comparison mirrors the existing in-file pattern. |
+| Unconditional `rm -f config.lock` (no age guard) | Would clobber a legitimately in-flight concurrent config writer on a parallel Concierge session — the exact race the age-guard exists to prevent (brand-survival brake). |
+| Fix in the bwrap/sandbox layer | Out of scope — sandbox hardening is `feat-harden-agent-sandbox-5875` (ADR-075). This plan stays out of those files to avoid collision. |
+
+## Non-Goals
+
+- No change to the bwrap sandbox, seccomp profile, or vendored SDK.
+- No new SessionStart hook.
+- No broad "git repair" logic — sweep is limited to the named stale lock files.

--- a/knowledge-base/project/plans/2026-07-01-fix-stale-git-lock-sweep-worktree-plan.md
+++ b/knowledge-base/project/plans/2026-07-01-fix-stale-git-lock-sweep-worktree-plan.md
@@ -267,20 +267,20 @@ tests. Auto-discovered by `scripts/test-all.sh` via the
 
 ### Pre-merge (PR)
 
-- [ ] `sweep_stale_git_locks()` exists in `worktree-manager.sh` and is called from
+- [x] `sweep_stale_git_locks()` exists in `worktree-manager.sh` and is called from
       `ensure_bare_config()` **before** the first `git config --file` write.
-- [ ] Sweep removes only locks with `age >= threshold` (default 60s); fresh and
+- [x] Sweep removes only locks with `age >= threshold` (default 60s); fresh and
       future-dated locks are preserved (verified by AC2/AC4).
-- [ ] Sweep operates on the `git_dir` resolved by the existing bare/non-bare logic
+- [x] Sweep operates on the `git_dir` resolved by the existing bare/non-bare logic
       (no duplicated layout computation).
-- [ ] New test `plugins/soleur/skills/git-worktree/test/stale-lock-sweep.test.sh`
+- [x] New test `plugins/soleur/skills/git-worktree/test/stale-lock-sweep.test.sh`
       passes and is discovered by `bash scripts/test-all.sh`.
-- [ ] `bash -n plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh`
+- [x] `bash -n plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh`
       passes (and `shellcheck` clean if available).
-- [ ] The three sibling tests
+- [x] The three sibling tests
       (`create-from-origin-main`, `lease-protects-active`, `no-repo-fail-loud`)
       still pass (no regression to `ensure_bare_config`'s existing behavior).
-- [ ] No file outside `worktree-manager.sh` + the new test is modified (scope
+- [x] No file outside `worktree-manager.sh` + the new test is modified (scope
       boundary: bwrap layer untouched).
 
 ## Observability

--- a/knowledge-base/project/specs/feat-one-shot-stale-git-lock-sweep/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-stale-git-lock-sweep/session-state.md
@@ -1,0 +1,18 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-01-fix-stale-git-lock-sweep-worktree-plan.md
+- Status: complete
+
+### Errors
+None. Notable: mid-drafting the plan file briefly showed on-disk edits the subagent had not authored (a "Lock-file set (revised per CTO)" heading), suggesting a transient concurrent writer/harness re-entry. It converged with intent; final committed file is coherent; git status showed only the plan + tasks files.
+
+### Decisions
+- Single chokepoint: new `sweep_stale_git_locks()` helper called once from `ensure_bare_config()` (before its first `git config` write at :144). All create paths + `cleanup_merged_worktrees:888` already route through `ensure_bare_config`, so one call covers both session-start self-heal and pre-create paths.
+- Age-guard via mtime comparison (default 60s), mirroring the clock-skew-guarded age check at :989-999; future-dated locks treated as fresh — the brake against clobbering a live sub-second config writer.
+- Scope to common `git_dir` config locks (`config.lock`, `config.worktree.lock`) as load-bearing; `index.lock`/`HEAD.lock` as defense-in-depth. Per-worktree lock dirs out of scope. bwrap/seccomp/SDK layer untouched (owned by feat-harden-agent-sandbox-5875).
+- `set -e` hardening (arithmetic in `if`, guarded `rm`/`stat`) is the real implementation risk — folded into snippet + tasks.
+- Root cause verified empirically (reproduced EEXIST wedge; "File exists", exit 255), disproving the bind-mount theory. Brand-survival threshold: single-user incident; requires_cpo_signoff: true.
+
+### Components Invoked
+- soleur:plan, soleur:engineering:cto, soleur:deepen-plan

--- a/knowledge-base/project/specs/feat-one-shot-stale-git-lock-sweep/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-stale-git-lock-sweep/tasks.md
@@ -13,57 +13,57 @@ Derived from
 
 ## Phase 1 — Test first (RED)
 
-- [ ] 1.1 Create `plugins/soleur/skills/git-worktree/test/stale-lock-sweep.test.sh`
+- [x] 1.1 Create `plugins/soleur/skills/git-worktree/test/stale-lock-sweep.test.sh`
   following the structure of the sibling `create-from-origin-main.test.sh`
   (bare-repo + linked-worktree setup, `PASS`/`FAIL` counters, `exit 1` on any fail,
   `mktemp -d` + EXIT-trap cleanup).
-- [ ] 1.2 In setup: stand up a bare repo + linked worktree, `cd` into the worktree,
+- [x] 1.2 In setup: stand up a bare repo + linked worktree, `cd` into the worktree,
   `source` the manager script (its `BASH_SOURCE`/`$0` guard at :1490 supports
   sourcing without running `main`), and resolve `git_dir` the same way
   `ensure_bare_config` does.
-- [ ] 1.3 Assertions (see plan Test Scenarios):
-  - AC1 aged `config.lock` (`touch -d '120 seconds ago'`) → removed by
+- [x] 1.3 Assertions (see plan Test Scenarios):
+  - [x] AC1 aged `config.lock` (`touch -d '120 seconds ago'`) → removed by
     `sweep_stale_git_locks "$git_dir" 60`.
-  - AC2 fresh `config.worktree.lock` (`touch`) → preserved.
-  - AC3 aged `HEAD.lock` removed + fresh `index.lock` preserved in one run.
-  - AC4 future-dated lock (`touch -d '+120 seconds'`) → preserved (clock-skew).
-  - AC5 black-box: aged `config.lock` planted, `bash "$WM" --yes cleanup-merged`
+  - [x] AC2 fresh `config.worktree.lock` (`touch`) → preserved.
+  - [x] AC3 aged `HEAD.lock` removed + fresh `index.lock` preserved in one run.
+  - [x] AC4 future-dated lock (`touch -d '+120 seconds'`) → preserved (clock-skew).
+  - [x] AC5 black-box: aged `config.lock` planted, `bash "$WM" --yes cleanup-merged`
     run as a subprocess → lock gone (proves wiring through `ensure_bare_config`).
-  - AC6 after a sweep with a fresh lock present, a real
+  - [x] AC6 after a sweep with a fresh lock present, a real
     `git config --file "$git_dir/config" test.key val` still succeeds.
-  - AC7 no-op when no lock present → exit 0, no error (`set -e` / empty-set guard).
-- [ ] 1.4 Run the new test; confirm it FAILS (function does not yet exist).
+  - [x] AC7 no-op when no lock present → exit 0, no error (`set -e` / empty-set guard).
+- [x] 1.4 Run the new test; confirm it FAILS (function does not yet exist).
 
 ## Phase 2 — Implement (GREEN)
 
-- [ ] 2.1 Add `sweep_stale_git_locks()` to
+- [x] 2.1 Add `sweep_stale_git_locks()` to
   `plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh` (near
   `ensure_bare_config`, ~line 124). Signature `sweep_stale_git_locks <git_dir>
   [threshold_secs=60]`.
-- [ ] 2.2 Iterate the fixed lock set `config.lock config.worktree.lock index.lock
+- [x] 2.2 Iterate the fixed lock set `config.lock config.worktree.lock index.lock
   HEAD.lock` in `$git_dir`; for each present file, `mtime=$(stat -c %Y … 2>/dev/null)
   || continue`; compute `age=$(( now - mtime ))`; remove only when
   `if (( age >= threshold ))` (nested in `if` for `set -e` safety), with `rm -f …
   2>/dev/null` guarded by `if`. Echo `Swept N stale git lock file(s) …` when
   `swept > 0`. Add a one-line comment noting the GNU `stat -c` assumption.
-- [ ] 2.3 Call `sweep_stale_git_locks "$git_dir"` inside `ensure_bare_config()`
+- [x] 2.3 Call `sweep_stale_git_locks "$git_dir"` inside `ensure_bare_config()`
   immediately after `git_dir` is resolved (after :137) and BEFORE the first
   `git config --file "$shared_config" core.repositoryformatversion 1` write (:144).
-- [ ] 2.4 Do NOT add a second call site in `cleanup_merged_worktrees` (it routes
+- [x] 2.4 Do NOT add a second call site in `cleanup_merged_worktrees` (it routes
   through `ensure_bare_config` at :888 — covered transitively).
-- [ ] 2.5 Do NOT touch the bwrap/tenant-isolation layer
+- [x] 2.5 Do NOT touch the bwrap/tenant-isolation layer
   (`agent-runner-sandbox-config.ts`, seccomp profile, vendored SDK) — scope boundary
   owned by `feat-harden-agent-sandbox-5875`.
 
 ## Phase 3 — Verify
 
-- [ ] 3.1 `bash plugins/soleur/skills/git-worktree/test/stale-lock-sweep.test.sh`
+- [x] 3.1 `bash plugins/soleur/skills/git-worktree/test/stale-lock-sweep.test.sh`
   passes (all ACs green).
-- [ ] 3.2 `bash -n plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh`
+- [x] 3.2 `bash -n plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh`
   passes; `shellcheck` clean if available.
-- [ ] 3.3 Sibling tests still pass: `create-from-origin-main.test.sh`,
+- [x] 3.3 Sibling tests still pass: `create-from-origin-main.test.sh`,
   `lease-protects-active.test.sh`, `no-repo-fail-loud.test.sh`.
-- [ ] 3.4 `bash scripts/test-all.sh` discovers and runs the new test (via the
+- [x] 3.4 `bash scripts/test-all.sh` discovers and runs the new test (via the
   `plugins/soleur/skills/*/test/*.test.sh` glob).
-- [ ] 3.5 Confirm `git status` shows only `worktree-manager.sh` + the new test
+- [x] 3.5 Confirm `git status` shows only `worktree-manager.sh` + the new test
   changed (scope boundary respected).

--- a/knowledge-base/project/specs/feat-one-shot-stale-git-lock-sweep/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-stale-git-lock-sweep/tasks.md
@@ -1,0 +1,69 @@
+---
+title: "Tasks: age-guarded stale git-lock sweep in worktree tooling"
+branch: feat-one-shot-stale-git-lock-sweep
+lane: cross-domain
+plan: knowledge-base/project/plans/2026-07-01-fix-stale-git-lock-sweep-worktree-plan.md
+brand_survival_threshold: single-user incident
+---
+
+# Tasks — Stale git-lock sweep (worktree self-heal)
+
+Derived from
+[2026-07-01-fix-stale-git-lock-sweep-worktree-plan.md](../../plans/2026-07-01-fix-stale-git-lock-sweep-worktree-plan.md).
+
+## Phase 1 — Test first (RED)
+
+- [ ] 1.1 Create `plugins/soleur/skills/git-worktree/test/stale-lock-sweep.test.sh`
+  following the structure of the sibling `create-from-origin-main.test.sh`
+  (bare-repo + linked-worktree setup, `PASS`/`FAIL` counters, `exit 1` on any fail,
+  `mktemp -d` + EXIT-trap cleanup).
+- [ ] 1.2 In setup: stand up a bare repo + linked worktree, `cd` into the worktree,
+  `source` the manager script (its `BASH_SOURCE`/`$0` guard at :1490 supports
+  sourcing without running `main`), and resolve `git_dir` the same way
+  `ensure_bare_config` does.
+- [ ] 1.3 Assertions (see plan Test Scenarios):
+  - AC1 aged `config.lock` (`touch -d '120 seconds ago'`) → removed by
+    `sweep_stale_git_locks "$git_dir" 60`.
+  - AC2 fresh `config.worktree.lock` (`touch`) → preserved.
+  - AC3 aged `HEAD.lock` removed + fresh `index.lock` preserved in one run.
+  - AC4 future-dated lock (`touch -d '+120 seconds'`) → preserved (clock-skew).
+  - AC5 black-box: aged `config.lock` planted, `bash "$WM" --yes cleanup-merged`
+    run as a subprocess → lock gone (proves wiring through `ensure_bare_config`).
+  - AC6 after a sweep with a fresh lock present, a real
+    `git config --file "$git_dir/config" test.key val` still succeeds.
+  - AC7 no-op when no lock present → exit 0, no error (`set -e` / empty-set guard).
+- [ ] 1.4 Run the new test; confirm it FAILS (function does not yet exist).
+
+## Phase 2 — Implement (GREEN)
+
+- [ ] 2.1 Add `sweep_stale_git_locks()` to
+  `plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh` (near
+  `ensure_bare_config`, ~line 124). Signature `sweep_stale_git_locks <git_dir>
+  [threshold_secs=60]`.
+- [ ] 2.2 Iterate the fixed lock set `config.lock config.worktree.lock index.lock
+  HEAD.lock` in `$git_dir`; for each present file, `mtime=$(stat -c %Y … 2>/dev/null)
+  || continue`; compute `age=$(( now - mtime ))`; remove only when
+  `if (( age >= threshold ))` (nested in `if` for `set -e` safety), with `rm -f …
+  2>/dev/null` guarded by `if`. Echo `Swept N stale git lock file(s) …` when
+  `swept > 0`. Add a one-line comment noting the GNU `stat -c` assumption.
+- [ ] 2.3 Call `sweep_stale_git_locks "$git_dir"` inside `ensure_bare_config()`
+  immediately after `git_dir` is resolved (after :137) and BEFORE the first
+  `git config --file "$shared_config" core.repositoryformatversion 1` write (:144).
+- [ ] 2.4 Do NOT add a second call site in `cleanup_merged_worktrees` (it routes
+  through `ensure_bare_config` at :888 — covered transitively).
+- [ ] 2.5 Do NOT touch the bwrap/tenant-isolation layer
+  (`agent-runner-sandbox-config.ts`, seccomp profile, vendored SDK) — scope boundary
+  owned by `feat-harden-agent-sandbox-5875`.
+
+## Phase 3 — Verify
+
+- [ ] 3.1 `bash plugins/soleur/skills/git-worktree/test/stale-lock-sweep.test.sh`
+  passes (all ACs green).
+- [ ] 3.2 `bash -n plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh`
+  passes; `shellcheck` clean if available.
+- [ ] 3.3 Sibling tests still pass: `create-from-origin-main.test.sh`,
+  `lease-protects-active.test.sh`, `no-repo-fail-loud.test.sh`.
+- [ ] 3.4 `bash scripts/test-all.sh` discovers and runs the new test (via the
+  `plugins/soleur/skills/*/test/*.test.sh` glob).
+- [ ] 3.5 Confirm `git status` shows only `worktree-manager.sh` + the new test
+  changed (scope boundary respected).

--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -121,6 +121,46 @@ require_working_tree() {
   fi
 }
 
+# Remove stale git lock files left when a git process is killed mid-write
+# (e.g., the 2026-07-01 seccomp outage killed git under `unshare` EPERM, leaving
+# `.git/config.lock` on the mounted /workspaces volume; every later `git config`
+# write then fails EEXIST — "could not lock config file …: File exists" — forever).
+# Age-guarded: removes ONLY locks older than $threshold seconds, so a legitimately
+# in-flight sub-second config writer (lock lifetime is single-digit ms) is never
+# clobbered. Clock-skew guard: a future-dated lock (negative age) is treated as
+# fresh and preserved, matching cleanup_merged_worktrees' age check (~:995).
+# GNU-only `stat -c %Y` (Linux containers + CI ubuntu + dev; mirrors the existing
+# GNU `stat -c%s` at ~:1186). Idempotent; safe for parallel sessions — the
+# age-guard, not a flock, is the safety mechanism.
+sweep_stale_git_locks() {
+  local git_dir="$1"
+  local threshold="${2:-60}"   # seconds
+  [[ -d "$git_dir" ]] || return 0
+  local now lock path mtime age swept=0
+  now=$(date +%s)
+  # Scope: the common git_dir's config-write locks (the confirmed wedge) plus
+  # index/HEAD locks for completeness against the same stale-lock class. NOT the
+  # per-worktree lock dirs (.git/worktrees/*/index.lock) — a different failure
+  # class (a wedged checkout/rebase) with a larger blast radius.
+  for lock in config.lock config.worktree.lock index.lock HEAD.lock; do
+    path="$git_dir/$lock"
+    [[ -f "$path" ]] || continue
+    mtime=$(stat -c %Y "$path" 2>/dev/null) || continue
+    age=$(( now - mtime ))
+    # Remove only stale (age >= threshold). Skips fresh AND future-dated
+    # (age < 0, clock skew). Arithmetic nested in `if` so a false `(( ))`
+    # exit status never trips `set -e` (mirrors the guard at ~:995).
+    if (( age >= threshold )); then
+      if rm -f "$path" 2>/dev/null; then
+        swept=$(( swept + 1 ))
+      fi
+    fi
+  done
+  if (( swept > 0 )); then
+    echo -e "${YELLOW}Swept $swept stale git lock file(s) from $git_dir${NC}"
+  fi
+}
+
 # Ensure bare repo config uses per-worktree core.bare (defense-in-depth).
 # Fixes TWO broken states that git worktree add creates on bare repos:
 #   1. core.bare=true in shared config — bleeds into worktrees, breaks git commit/push
@@ -135,6 +175,12 @@ ensure_bare_config() {
   if [[ ! -d "$git_dir" ]]; then
     git_dir="$GIT_ROOT"
   fi
+
+  # Self-heal: remove stale git locks BEFORE any config write below, or those
+  # writes fail EEXIST forever (2026-07-01 outage class). This chokepoint runs on
+  # every create path and on the session-start cleanup-merged path (:888), so an
+  # affected workspace self-heals on its next session — no operator SSH required.
+  sweep_stale_git_locks "$git_dir"
 
   local shared_config="$git_dir/config"
   local wt_config="$git_dir/config.worktree"

--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -128,28 +128,32 @@ require_working_tree() {
 # Age-guarded: removes ONLY locks older than $threshold seconds, so a legitimately
 # in-flight sub-second config writer (lock lifetime is single-digit ms) is never
 # clobbered. Clock-skew guard: a future-dated lock (negative age) is treated as
-# fresh and preserved, matching cleanup_merged_worktrees' age check (~:995).
-# GNU-only `stat -c %Y` (Linux containers + CI ubuntu + dev; mirrors the existing
-# GNU `stat -c%s` at ~:1186). Idempotent; safe for parallel sessions — the
-# age-guard, not a flock, is the safety mechanism.
+# fresh and preserved, matching cleanup_merged_worktrees' clock-skew age check.
+# GNU-only `stat -c%Y` (Linux containers + CI ubuntu + dev; mirrors the existing
+# GNU `stat -c%s` in cleanup_claude_tmp). Idempotent; safe for parallel sessions
+# — the age-guard, not a flock, is the safety mechanism.
 sweep_stale_git_locks() {
   local git_dir="$1"
   local threshold="${2:-60}"   # seconds
   [[ -d "$git_dir" ]] || return 0
   local now lock path mtime age swept=0
   now=$(date +%s)
-  # Scope: the common git_dir's config-write locks (the confirmed wedge) plus
-  # index/HEAD locks for completeness against the same stale-lock class. NOT the
-  # per-worktree lock dirs (.git/worktrees/*/index.lock) — a different failure
-  # class (a wedged checkout/rebase) with a larger blast radius.
-  for lock in config.lock config.worktree.lock index.lock HEAD.lock; do
+  # Scope: ONLY the config-write locks (`config.lock`, `config.worktree.lock`) —
+  # the confirmed EEXIST wedge that blocks ensure_bare_config's writes below.
+  # Deliberately NOT index.lock / HEAD.lock: on a NON-bare git_dir those are the
+  # LIVE working-tree locks a concurrent >60s commit/checkout/rebase legitimately
+  # holds (removing one mid-op tears that tenant's index), and they never block a
+  # `git config` write, so they add live-clobber risk with zero wedge-fix value.
+  # Also NOT the per-worktree lock dirs (.git/worktrees/*/index.lock) — a
+  # different failure class (a wedged checkout/rebase) with a larger blast radius.
+  for lock in config.lock config.worktree.lock; do
     path="$git_dir/$lock"
     [[ -f "$path" ]] || continue
-    mtime=$(stat -c %Y "$path" 2>/dev/null) || continue
+    mtime=$(stat -c%Y "$path" 2>/dev/null) || continue
     age=$(( now - mtime ))
     # Remove only stale (age >= threshold). Skips fresh AND future-dated
     # (age < 0, clock skew). Arithmetic nested in `if` so a false `(( ))`
-    # exit status never trips `set -e` (mirrors the guard at ~:995).
+    # exit status never trips `set -e` (mirrors cleanup_merged_worktrees).
     if (( age >= threshold )); then
       if rm -f "$path" 2>/dev/null; then
         swept=$(( swept + 1 ))
@@ -178,8 +182,8 @@ ensure_bare_config() {
 
   # Self-heal: remove stale git locks BEFORE any config write below, or those
   # writes fail EEXIST forever (2026-07-01 outage class). This chokepoint runs on
-  # every create path and on the session-start cleanup-merged path (:888), so an
-  # affected workspace self-heals on its next session — no operator SSH required.
+  # every create path and on the session-start cleanup_merged_worktrees path, so
+  # an affected workspace self-heals on its next session — no operator SSH.
   sweep_stale_git_locks "$git_dir"
 
   local shared_config="$git_dir/config"
@@ -280,6 +284,10 @@ verify_worktree_created() {
 # onto the worktree's local config so every commit made from inside the worktree
 # is authored as the real human. Idempotent: skips silently if no global identity
 # exists, or if the worktree already has a matching local identity.
+# NOTE: its `git config --local` writes can hit the shared config's lock on a bare
+# repo; it relies on a preceding ensure_bare_config() (which runs the stale-lock
+# sweep) on every current call path. A future config-writing subcommand added
+# without that precedence would reopen the EEXIST wedge — keep sweep coverage in mind.
 ensure_worktree_identity() {
   local worktree_path="$1"
   local global_email global_name

--- a/plugins/soleur/skills/git-worktree/test/stale-lock-sweep.test.sh
+++ b/plugins/soleur/skills/git-worktree/test/stale-lock-sweep.test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# 2026-07-01 reproducer: worktree-manager.sh must self-heal a stale git lock
+# file left when a git process is killed mid-write (the 2026-07-01 seccomp
+# outage class — a residual .git/config.lock wedges every later `git config`
+# write with EEXIST forever). Age-guarded sweep: aged locks removed, fresh and
+# future-dated locks preserved.
+#
+# Plan: knowledge-base/project/plans/2026-07-01-fix-stale-git-lock-sweep-worktree-plan.md
+#
+# Run via:  bash plugins/soleur/skills/git-worktree/test/stale-lock-sweep.test.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+WM="$REPO_ROOT/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh"
+
+PASS=0; FAIL=0
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
+pass() { echo "  pass: $1"; PASS=$((PASS+1)); }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# --- Stand up upstream + local bare clone (mirrors the soleur bare-repo layout,
+# same pattern as create-from-origin-main.test.sh) ---
+UPSTREAM="$TMP/upstream.git"
+git init --bare -b main "$UPSTREAM" >/dev/null
+SEED="$TMP/seed"
+git clone "$UPSTREAM" "$SEED" >/dev/null 2>&1
+( cd "$SEED" && git -c user.email=t@t -c user.name=t commit --allow-empty -m seed >/dev/null && git push origin main >/dev/null 2>&1 )
+rm -rf "$SEED"
+
+LOCAL="$TMP/local.git"
+git init --bare -b main "$LOCAL" >/dev/null
+( cd "$LOCAL" && git remote add origin "$UPSTREAM" && git fetch origin main:main >/dev/null 2>&1 )
+
+# For a bare repo, `ensure_bare_config` resolves git_dir == GIT_ROOT (the bare
+# dir itself), so the config locks live directly under $LOCAL.
+GIT_DIR="$LOCAL"
+
+# --- Source the script to unit-test sweep_stale_git_locks() directly. The
+# script's BASH_SOURCE guard (worktree-manager.sh:1490) suppresses main() when
+# sourced. The script sets `set -euo pipefail`; disable errexit afterward so the
+# harness's && / || assertion style behaves like the sibling tests. ---
+cd "$LOCAL"
+# shellcheck source=/dev/null
+source "$WM"
+set +e
+
+# Plant a lock file with a specific mtime. $2 = seconds in the PAST
+# (a negative value via the caller means the future — used for the skew guard).
+plant() { : > "$GIT_DIR/$1"; touch -d "$2 seconds ago" "$GIT_DIR/$1"; }
+present() { [[ -f "$GIT_DIR/$1" ]]; }
+
+# --- AC1: aged config.lock removed ---
+plant config.lock 120
+sweep_stale_git_locks "$GIT_DIR" 60 >/dev/null
+present config.lock \
+  && fail "AC1: aged config.lock was NOT removed" \
+  || pass "AC1: aged config.lock removed"
+
+# --- AC2: fresh config.worktree.lock preserved ---
+: > "$GIT_DIR/config.worktree.lock"   # mtime = now
+sweep_stale_git_locks "$GIT_DIR" 60 >/dev/null
+present config.worktree.lock \
+  && pass "AC2: fresh config.worktree.lock preserved (age < threshold)" \
+  || fail "AC2: fresh config.worktree.lock was WRONGLY removed"
+rm -f "$GIT_DIR/config.worktree.lock"
+
+# --- AC3: multiple patterns in one run — aged HEAD.lock removed, fresh index.lock kept ---
+plant HEAD.lock 120
+: > "$GIT_DIR/index.lock"
+sweep_stale_git_locks "$GIT_DIR" 60 >/dev/null
+if ! present HEAD.lock && present index.lock; then
+  pass "AC3: aged HEAD.lock removed AND fresh index.lock preserved"
+else
+  fail "AC3: mixed-age sweep wrong (HEAD.lock present=$(present HEAD.lock && echo y || echo n), index.lock present=$(present index.lock && echo y || echo n))"
+fi
+rm -f "$GIT_DIR/index.lock"
+
+# --- AC4: clock-skew guard — future-dated lock preserved (negative age = fresh) ---
+: > "$GIT_DIR/config.lock"
+touch -d "+120 seconds" "$GIT_DIR/config.lock"
+sweep_stale_git_locks "$GIT_DIR" 60 >/dev/null
+present config.lock \
+  && pass "AC4: future-dated lock preserved (clock-skew guard)" \
+  || fail "AC4: future-dated lock was WRONGLY removed"
+rm -f "$GIT_DIR/config.lock"
+
+# --- AC6: sweep does not corrupt config — a real git config write still works ---
+rm -f "$GIT_DIR"/*.lock 2>/dev/null
+sweep_stale_git_locks "$GIT_DIR" 60 >/dev/null
+if git config --file "$GIT_DIR/config" test.key val >/dev/null 2>&1 \
+   && [[ "$(git config --file "$GIT_DIR/config" test.key 2>/dev/null)" == "val" ]]; then
+  pass "AC6: git config write succeeds after sweep (config uncorrupted)"
+else
+  fail "AC6: git config write FAILED after sweep"
+fi
+git config --file "$GIT_DIR/config" --unset test.key 2>/dev/null
+
+# --- AC7: no-op is safe under `set -e` (empty lock set + missing dir) ---
+rm -f "$GIT_DIR"/*.lock 2>/dev/null
+( set -e; sweep_stale_git_locks "$GIT_DIR" 60 >/dev/null ) \
+  && pass "AC7a: no-op sweep exits 0 under set -e (empty lock set)" \
+  || fail "AC7a: no-op sweep aborted under set -e"
+( set -e; sweep_stale_git_locks "$TMP/does-not-exist" 60 >/dev/null ) \
+  && pass "AC7b: sweep on missing dir exits 0 under set -e" \
+  || fail "AC7b: sweep on missing dir aborted under set -e"
+
+# --- AC5: black-box self-heal wiring — an aged config.lock is swept when
+# cleanup-merged (the session-start preamble path) runs through ensure_bare_config ---
+: > "$GIT_DIR/config.lock"; touch -d "120 seconds ago" "$GIT_DIR/config.lock"
+( cd "$LOCAL" && bash "$WM" --yes cleanup-merged >"$TMP/cm.log" 2>&1 ) || true
+present config.lock \
+  && fail "AC5: config.lock survived cleanup-merged (ensure_bare_config wiring; log: $(cat "$TMP/cm.log"))" \
+  || pass "AC5: aged config.lock swept via cleanup-merged (ensure_bare_config wiring)"
+
+echo
+echo "=== Results ==="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/plugins/soleur/skills/git-worktree/test/stale-lock-sweep.test.sh
+++ b/plugins/soleur/skills/git-worktree/test/stale-lock-sweep.test.sh
@@ -2,8 +2,8 @@
 # 2026-07-01 reproducer: worktree-manager.sh must self-heal a stale git lock
 # file left when a git process is killed mid-write (the 2026-07-01 seccomp
 # outage class — a residual .git/config.lock wedges every later `git config`
-# write with EEXIST forever). Age-guarded sweep: aged locks removed, fresh and
-# future-dated locks preserved.
+# write with EEXIST forever). Age-guarded sweep: aged config locks removed,
+# fresh and future-dated locks preserved; index/HEAD locks out of scope.
 #
 # Plan: knowledge-base/project/plans/2026-07-01-fix-stale-git-lock-sweep-worktree-plan.md
 #
@@ -20,6 +20,16 @@ pass() { echo "  pass: $1"; PASS=$((PASS+1)); }
 
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
+
+# GNU coreutils preflight — the sweep + this test use GNU `stat -c%Y` and
+# `touch -d '<rel>'` (Linux/CI ubuntu target). Skip cleanly on a non-GNU host
+# (e.g. BSD/macOS dev box) instead of hard-erroring at plant() with a confusing
+# "invalid date format".
+if ! stat -c%Y "$TMP" >/dev/null 2>&1 || ! touch -d '1 second ago' "$TMP/.probe" 2>/dev/null; then
+  echo "SKIP: GNU coreutils (stat -c / touch -d relative) required — non-GNU host"
+  exit 0
+fi
+rm -f "$TMP/.probe"
 
 # --- Stand up upstream + local bare clone (mirrors the soleur bare-repo layout,
 # same pattern as create-from-origin-main.test.sh) ---
@@ -41,79 +51,106 @@ GIT_DIR="$LOCAL"
 # --- Source the script to unit-test sweep_stale_git_locks() directly. The
 # script's BASH_SOURCE guard (worktree-manager.sh:1490) suppresses main() when
 # sourced. The script sets `set -euo pipefail`; disable errexit afterward so the
-# harness's && / || assertion style behaves like the sibling tests. ---
+# harness's if/else assertion style behaves like the sibling tests. ---
 cd "$LOCAL"
 # shellcheck source=/dev/null
 source "$WM"
 set +e
 
-# Plant a lock file with a specific mtime. $2 = seconds in the PAST
-# (a negative value via the caller means the future — used for the skew guard).
+# Plant a lock file with a specific mtime. $2 = seconds in the PAST.
 plant() { : > "$GIT_DIR/$1"; touch -d "$2 seconds ago" "$GIT_DIR/$1"; }
 present() { [[ -f "$GIT_DIR/$1" ]]; }
 
 # --- AC1: aged config.lock removed ---
 plant config.lock 120
 sweep_stale_git_locks "$GIT_DIR" 60 >/dev/null
-present config.lock \
-  && fail "AC1: aged config.lock was NOT removed" \
-  || pass "AC1: aged config.lock removed"
+if present config.lock; then
+  fail "AC1: aged config.lock was NOT removed"
+else
+  pass "AC1: aged config.lock removed"
+fi
 
 # --- AC2: fresh config.worktree.lock preserved ---
 : > "$GIT_DIR/config.worktree.lock"   # mtime = now
 sweep_stale_git_locks "$GIT_DIR" 60 >/dev/null
-present config.worktree.lock \
-  && pass "AC2: fresh config.worktree.lock preserved (age < threshold)" \
-  || fail "AC2: fresh config.worktree.lock was WRONGLY removed"
+if present config.worktree.lock; then
+  pass "AC2: fresh config.worktree.lock preserved (age < threshold)"
+else
+  fail "AC2: fresh config.worktree.lock was WRONGLY removed"
+fi
 rm -f "$GIT_DIR/config.worktree.lock"
 
-# --- AC3: multiple patterns in one run — aged HEAD.lock removed, fresh index.lock kept ---
-plant HEAD.lock 120
-: > "$GIT_DIR/index.lock"
+# --- AC3: per-file age discrimination in one run — aged config.lock removed,
+# fresh config.worktree.lock preserved (fails against both a no-op and an
+# over-broad "delete every lock" impl) ---
+plant config.lock 120
+: > "$GIT_DIR/config.worktree.lock"
 sweep_stale_git_locks "$GIT_DIR" 60 >/dev/null
-if ! present HEAD.lock && present index.lock; then
-  pass "AC3: aged HEAD.lock removed AND fresh index.lock preserved"
+if ! present config.lock && present config.worktree.lock; then
+  pass "AC3: aged config.lock removed AND fresh config.worktree.lock preserved in one run"
 else
-  fail "AC3: mixed-age sweep wrong (HEAD.lock present=$(present HEAD.lock && echo y || echo n), index.lock present=$(present index.lock && echo y || echo n))"
+  fail "AC3: mixed-age sweep wrong (config.lock present=$(present config.lock && echo y || echo n), config.worktree.lock present=$(present config.worktree.lock && echo y || echo n))"
 fi
-rm -f "$GIT_DIR/index.lock"
+rm -f "$GIT_DIR/config.worktree.lock"
+
+# --- AC3b: index.lock / HEAD.lock are OUT of scope — even aged instances are
+# preserved (on a non-bare git_dir these are LIVE working-tree locks; removing
+# one mid-op would tear the tenant's index — and they never block config writes) ---
+plant index.lock 120
+plant HEAD.lock 120
+sweep_stale_git_locks "$GIT_DIR" 60 >/dev/null
+if present index.lock && present HEAD.lock; then
+  pass "AC3b: aged index.lock/HEAD.lock preserved (deliberately out of sweep scope)"
+else
+  fail "AC3b: index.lock/HEAD.lock were swept (should be out of scope)"
+fi
+rm -f "$GIT_DIR/index.lock" "$GIT_DIR/HEAD.lock"
 
 # --- AC4: clock-skew guard — future-dated lock preserved (negative age = fresh) ---
 : > "$GIT_DIR/config.lock"
 touch -d "+120 seconds" "$GIT_DIR/config.lock"
 sweep_stale_git_locks "$GIT_DIR" 60 >/dev/null
-present config.lock \
-  && pass "AC4: future-dated lock preserved (clock-skew guard)" \
-  || fail "AC4: future-dated lock was WRONGLY removed"
+if present config.lock; then
+  pass "AC4: future-dated lock preserved (clock-skew guard)"
+else
+  fail "AC4: future-dated lock was WRONGLY removed"
+fi
 rm -f "$GIT_DIR/config.lock"
 
-# --- AC6: sweep does not corrupt config — a real git config write still works ---
-rm -f "$GIT_DIR"/*.lock 2>/dev/null
+# --- AC6: sweep clears an aged config.lock so a real git config write succeeds
+# (the exact prod EEXIST symptom, at the unit level — discriminating, not vacuous) ---
+plant config.lock 120
 sweep_stale_git_locks "$GIT_DIR" 60 >/dev/null
 if git config --file "$GIT_DIR/config" test.key val >/dev/null 2>&1 \
    && [[ "$(git config --file "$GIT_DIR/config" test.key 2>/dev/null)" == "val" ]]; then
-  pass "AC6: git config write succeeds after sweep (config uncorrupted)"
+  pass "AC6: aged config.lock swept → git config write succeeds (no EEXIST)"
 else
-  fail "AC6: git config write FAILED after sweep"
+  fail "AC6: git config write FAILED after sweep (config.lock not cleared?)"
 fi
 git config --file "$GIT_DIR/config" --unset test.key 2>/dev/null
 
 # --- AC7: no-op is safe under `set -e` (empty lock set + missing dir) ---
 rm -f "$GIT_DIR"/*.lock 2>/dev/null
-( set -e; sweep_stale_git_locks "$GIT_DIR" 60 >/dev/null ) \
-  && pass "AC7a: no-op sweep exits 0 under set -e (empty lock set)" \
-  || fail "AC7a: no-op sweep aborted under set -e"
-( set -e; sweep_stale_git_locks "$TMP/does-not-exist" 60 >/dev/null ) \
-  && pass "AC7b: sweep on missing dir exits 0 under set -e" \
-  || fail "AC7b: sweep on missing dir aborted under set -e"
+if ( set -e; sweep_stale_git_locks "$GIT_DIR" 60 >/dev/null ); then
+  pass "AC7a: no-op sweep exits 0 under set -e (empty lock set)"
+else
+  fail "AC7a: no-op sweep aborted under set -e"
+fi
+if ( set -e; sweep_stale_git_locks "$TMP/does-not-exist" 60 >/dev/null ); then
+  pass "AC7b: sweep on missing dir exits 0 under set -e"
+else
+  fail "AC7b: sweep on missing dir aborted under set -e"
+fi
 
 # --- AC5: black-box self-heal wiring — an aged config.lock is swept when
 # cleanup-merged (the session-start preamble path) runs through ensure_bare_config ---
 : > "$GIT_DIR/config.lock"; touch -d "120 seconds ago" "$GIT_DIR/config.lock"
 ( cd "$LOCAL" && bash "$WM" --yes cleanup-merged >"$TMP/cm.log" 2>&1 ) || true
-present config.lock \
-  && fail "AC5: config.lock survived cleanup-merged (ensure_bare_config wiring; log: $(cat "$TMP/cm.log"))" \
-  || pass "AC5: aged config.lock swept via cleanup-merged (ensure_bare_config wiring)"
+if present config.lock; then
+  fail "AC5: config.lock survived cleanup-merged (ensure_bare_config wiring; log: $(cat "$TMP/cm.log"))"
+else
+  pass "AC5: aged config.lock swept via cleanup-merged (ensure_bare_config wiring)"
+fi
 
 echo
 echo "=== Results ==="


### PR DESCRIPTION
## Summary

Concierge worktree creation could be **permanently wedged** by a stale
`.git/config.lock` left when a `git config` / `git worktree add` process was
killed mid-write (the 2026-07-01 seccomp outage class). After git was restored,
the stale lock persisted on the mounted `/workspaces` volume, so every subsequent
config write failed forever with `could not lock config file .git/config: File
exists` (EEXIST). Worktree creation is the first config-writer in a session, so it
was the first thing to break — and there was **no stale-lock cleanup anywhere** in
the tooling.

This adds an **age-guarded** `sweep_stale_git_locks()` to `worktree-manager.sh`,
called from `ensure_bare_config()` before its first config write. It removes
`config.lock` / `config.worktree.lock` older than 60s. Because `ensure_bare_config`
is the chokepoint on every create path AND the session-start `cleanup-merged` path,
an affected workspace **self-heals on its next session** — no operator SSH into the
live volume.

The debug stream's "`.git/config` is bind-mounted, writes fail" theory was a
misdiagnosis: the sandbox binds the whole workspace read-write, so `.git/config` is
writable — the real cause was the stale lock. Scope is worktree tooling only; the
bwrap/tenant-isolation layer is untouched (owned separately by
`feat-harden-agent-sandbox-5875`).

## Changelog

### Plugin — git-worktree

- Add `sweep_stale_git_locks()` — age-guarded (default 60s, clock-skew safe) removal
  of stale `config.lock` / `config.worktree.lock` before config writes, wired into
  `ensure_bare_config()` so wedged workspaces self-heal on next session.
- New test `stale-lock-sweep.test.sh` (9 assertions: aged-removed, fresh-preserved,
  per-file age discrimination, scope-exclusion of index/HEAD locks, clock-skew guard,
  no-corruption, `set -e` no-op safety, black-box wiring through `ensure_bare_config`).

## Test plan

- [x] New `stale-lock-sweep.test.sh` passes (9/9), incl. black-box AC that reproduces
      the exact prod EEXIST error in RED and confirms self-heal in GREEN.
- [x] `bash -n` clean; zero new shellcheck findings from the added function.
- [x] All 3 sibling git-worktree tests still pass.
- [x] Full suite green (`scripts/test-all.sh`: 139/139 suites).
- [x] Multi-agent review (7 agents): P2 (index/HEAD live-lock on non-bare path)
      fixed inline by scoping the sweep to config-write locks; all P3s fixed inline;
      0 issues filed / 0 scope-outs.

Generated with [Claude Code](https://claude.com/claude-code)
