### PR TITLE
feat(multi-host): Phase 3 Sub-PR 3.C — membership-gated git-data fetch authz + D2 write sentinel (Ref #5274)

### DIFF
--- a/apps/web-platform/server/git-data-client.ts
+++ b/apps/web-platform/server/git-data-client.ts
@@ -1,0 +1,231 @@
+// Git-data READ-side client — epic #5274 Phase 3 Sub-PR 3.C / ADR-068 §6.
+//
+// The shared git-data bare store is reached over ONE cluster-wide SSH transport
+// key (`GIT_TRANSPORT_SSH_PRIVATE_KEY`). That key authorizes the *transport*, not
+// the *tenant*: nothing in the SSH layer (nor the agent sandbox bwrap, which only
+// isolates the filesystem — agent-runner-sandbox-config.ts) gates WHICH
+// workspace's objects a request may fetch. So the app MUST authorize membership
+// before it fetches a workspace's refs on a user's behalf — the boundary bwrap
+// cannot cover (ADR-068 §6 cross-tenant isolation; the fetch mirror of the
+// git-data-replication.ts D2 write-boundary sentinel).
+//
+// AUTHORIZATION AUTHORITY: `is_workspace_member(p_workspace_id, p_user_id)` — the
+// canonical SECURITY DEFINER membership substrate (migration 053; the same
+// predicate `resolve_workspace_installation_id` itself gates on, mig 079 §2).
+// It is used HERE — not `resolve_workspace_installation_id` directly — because
+// that RPC returns NULL for BOTH a non-member AND a member whose workspace has no
+// GitHub App installation; git-data is replicated for EVERY workspace (connected
+// or not), so keying on the installation-id RPC would wrongly deny a legitimate
+// member's own git-data. `is_workspace_member` returns a clean membership boolean.
+// (Plan D0/D2 spec: "membership shape … NULL→deny" — the faithful reading is the
+// membership predicate, not the credential resolver that conflates two states.)
+//
+// FAIL-CLOSED: any RPC error, any exception, a NULL/false result, or a missing
+// userId DENIES. A cross-tenant attempt (genuine non-member) is a security event
+// mirrored to Sentry; an RPC failure (membership indeterminable) is an error
+// mirrored to Sentry — both surface under `feature: "git-data-authz"` so on-call
+// can query `feature:git-data-authz op:*-deny` without SSH (Observability §).
+
+import { getFreshTenantClient, RuntimeAuthError } from "@/lib/supabase/tenant";
+import {
+  hashUserId,
+  reportSilentFallback,
+  warnSilentFallback,
+} from "@/server/observability";
+import { isGitDataStoreEnabled } from "@/server/workspace-resolver";
+import { gitWithPrivateKeyAuth } from "@/server/git-auth";
+// Pure transport helpers (call-time only) from the WRITE-side module. The two
+// modules reference each other exclusively inside async function bodies (this
+// file → gitDataRemoteUrl/assertSafeWorkspaceId; the write module →
+// authorizeGitDataAccess), so the ESM cycle resolves via live bindings and never
+// touches a partially-initialized export at module-eval time (intentional; keeps
+// a SINGLE URL builder + a SINGLE authz authority, no drift).
+import { assertSafeWorkspaceId, gitDataRemoteUrl } from "@/server/git-data-replication";
+import { assertSafeWorktreeId } from "@/server/worktree-write-lease";
+
+/**
+ * Thrown when a git-data access (fetch or push) is refused because the acting
+ * user is not a member of the target workspace, or membership could not be
+ * confirmed (fail-closed). Distinct type so callers/tests can assert the DENY
+ * reason rather than string-matching a generic error.
+ */
+export class GitDataAuthorizationError extends Error {
+  constructor(
+    readonly op: "fetch" | "write",
+    readonly reason: "not-member" | "indeterminate" | "missing-user",
+    message: string,
+  ) {
+    super(message);
+    this.name = "GitDataAuthorizationError";
+  }
+}
+
+/**
+ * Fail-closed membership authorization for shared git-data access.
+ *
+ * Returns `true` IFF `userId` is a confirmed member of `workspaceId`, verified
+ * via the `is_workspace_member` SECURITY DEFINER RPC through a fresh tenant
+ * client (the RPC is REVOKE'd from `service_role` and GRANTed to `authenticated`,
+ * so it MUST run under the user's own JWT — which is also why this module never
+ * imports the service-role client). Every non-affirmative outcome returns `false`
+ * (fail-closed) and mirrors telemetry:
+ *   - genuine non-member (data === false)  → `warnSilentFallback` (security)
+ *   - RPC/tenant error or exception         → `reportSilentFallback` (error)
+ *   - missing userId                        → `reportSilentFallback` (error)
+ *
+ * The check is keyed on the EXACT `workspaceId` the caller will use to build the
+ * transport URL (no re-derivation — hr-write-boundary-sentinel-sweep-all-write-sites).
+ */
+export async function authorizeGitDataAccess(params: {
+  userId: string | undefined;
+  workspaceId: string;
+  op: "fetch" | "write";
+}): Promise<boolean> {
+  const { userId, workspaceId, op } = params;
+  const workspaceIdHash = hashUserId(workspaceId);
+
+  if (!userId) {
+    // A push/fetch with no authorizing user is a logic bug once the flag is on
+    // (both call sites derive userId from the session). Fail closed + loud.
+    reportSilentFallback(
+      new Error("git-data access with no authorizing userId"),
+      {
+        feature: "git-data-authz",
+        op: `${op}-deny`,
+        extra: { workspaceIdHash, reason: "missing-user" },
+        tags: { sec: "true" },
+        message:
+          "git-data authorization refused — no userId to authorize the " +
+          `${op}; refusing to reach the shared store without a member check`,
+      },
+    );
+    return false;
+  }
+
+  try {
+    const tenant = await getFreshTenantClient(userId);
+    const { data, error } = await tenant.rpc("is_workspace_member", {
+      p_workspace_id: workspaceId,
+      p_user_id: userId,
+    });
+
+    if (error) {
+      reportSilentFallback(error, {
+        feature: "git-data-authz",
+        op: `${op}-deny`,
+        extra: { userId, workspaceIdHash, reason: "indeterminate" },
+        tags: { sec: "true" },
+        message:
+          "git-data membership RPC failed — authorization indeterminate; " +
+          "denying (fail-closed)",
+      });
+      return false;
+    }
+
+    if (data === true) return true;
+
+    // Genuine cross-tenant attempt: a confirmed non-member. Loud security event
+    // (Observability failure_mode: git-data denial {workspace_id_hash, member:false}).
+    warnSilentFallback(
+      new Error("git-data cross-tenant access denied (non-member)"),
+      {
+        feature: "git-data-authz",
+        op: `${op}-deny`,
+        extra: { userId, workspaceIdHash, member: false, reason: "not-member" },
+        tags: { sec: "true", cross_tenant: "true" },
+        message:
+          `git-data ${op} refused — user is not a member of the target ` +
+          "workspace (cross-tenant boundary, fail-closed)",
+      },
+    );
+    return false;
+  } catch (err) {
+    // RuntimeAuthError (JWT mint failed) or any other throw → indeterminate → deny.
+    if (!(err instanceof RuntimeAuthError)) {
+      // Non-auth throws are unexpected; still fail closed, still mirror.
+      reportSilentFallback(err, {
+        feature: "git-data-authz",
+        op: `${op}-deny`,
+        extra: { userId, workspaceIdHash, reason: "indeterminate" },
+        tags: { sec: "true" },
+        message: "git-data authorization threw — denying (fail-closed)",
+      });
+      return false;
+    }
+    reportSilentFallback(err, {
+      feature: "git-data-authz",
+      op: `${op}-deny`,
+      extra: { userId, workspaceIdHash, reason: "indeterminate" },
+      tags: { sec: "true" },
+      message:
+        "git-data authorization could not mint a tenant client — denying " +
+        "(fail-closed)",
+    });
+    return false;
+  }
+}
+
+/**
+ * Authorized fetch of a workspace's per-user worktree namespace from the shared
+ * git-data store into `destPath`'s local `refs/heads/*` (the reverse of the
+ * git-data-replication.ts write refspec: the write pushes local `refs/heads/*` →
+ * `refs/soleur/worktrees/<worktreeId>/heads/*`, so the read maps that namespace
+ * back). Membership is authorized FIRST (fail-closed); on a DENY nothing touches
+ * the transport and a {@link GitDataAuthorizationError} is thrown. NO-OP (returns
+ * without fetching) at flag-off — the whole read side is dark until the 3.D flip.
+ *
+ * `destPath` must already be a git work tree with a configured `git-data` remote
+ * (see `ensureGitDataRemote`). Retains `origin`→GitHub untouched — GitHub stays
+ * the canonical rehydration source (ADR-068 §1; never orphan).
+ */
+export async function fetchFromGitData(params: {
+  userId: string;
+  workspaceId: string;
+  worktreeId: string;
+  workspacePath: string;
+}): Promise<void> {
+  if (!isGitDataStoreEnabled()) return;
+  const { userId, workspaceId, worktreeId, workspacePath } = params;
+  assertSafeWorkspaceId(workspaceId);
+  assertSafeWorktreeId(worktreeId);
+
+  const authorized = await authorizeGitDataAccess({ userId, workspaceId, op: "fetch" });
+  if (!authorized) {
+    throw new GitDataAuthorizationError(
+      "fetch",
+      "not-member",
+      `git-data fetch refused for workspace ${workspaceId} (membership denied)`,
+    );
+  }
+
+  const transportKey = process.env.GIT_TRANSPORT_SSH_PRIVATE_KEY?.trim();
+  if (!transportKey) {
+    throw new Error(
+      "git-data: GIT_TRANSPORT_SSH_PRIVATE_KEY is unset — cannot fetch from the " +
+        "git-data host. It is delivered to the container from Doppler prd.",
+    );
+  }
+
+  // Fetch by the EXPLICIT URL built from the AUTHORIZED workspaceId — NOT the
+  // named `git-data` remote resolved from `workspacePath`'s local config. This
+  // binds the transport target to the exact workspaceId membership just authorized
+  // (mirror of the write path's inline `ensureGitDataRemote(workspacePath,
+  // workspaceId)`): a clone whose local `git-data` remote pointed at a DIFFERENT
+  // workspace could otherwise pull tenant-B objects while authz passed for tenant-A.
+  const remoteUrl = gitDataRemoteUrl(workspaceId);
+
+  // Map this user's OWN namespace back to local heads + tags. `+` allows a
+  // non-fast-forward local update (the fence, not ref ancestry, is the ordering
+  // authority — symmetric to the write's `--force`). Cross-user visibility is a
+  // separate explicit fetch of the peer namespace (ADR-068 D0-ref), not this call.
+  await gitWithPrivateKeyAuth(
+    [
+      "fetch",
+      remoteUrl,
+      `+refs/soleur/worktrees/${worktreeId}/heads/*:refs/heads/*`,
+      `+refs/soleur/worktrees/${worktreeId}/tags/*:refs/tags/*`,
+    ],
+    transportKey,
+    { cwd: workspacePath, timeout: 60_000 },
+  );
+}

--- a/apps/web-platform/server/git-data-replication.ts
+++ b/apps/web-platform/server/git-data-replication.ts
@@ -22,6 +22,12 @@ import { isGitDataStoreEnabled } from "./workspace-resolver";
 import { gitWithPrivateKeyAuth, sshWithPrivateKeyAuth } from "./git-auth";
 import { reportSilentFallback } from "./observability";
 import { assertSafeWorktreeId } from "./worktree-write-lease";
+// D2 write-boundary sentinel (ADR-068 §6, epic #5274 Sub-PR 3.C). The membership
+// authority is shared with the fetch side (git-data-client.ts) so a single check
+// gates both directions. Imported for call-time use only — the two modules form a
+// runtime-safe ESM cycle (git-data-client → gitDataRemoteUrl/assertSafeWorkspaceId
+// here; here → authorizeGitDataAccess there); neither is referenced at module-eval.
+import { authorizeGitDataAccess, GitDataAuthorizationError } from "./git-data-client";
 
 const log = createChildLogger("git-data-replication");
 
@@ -181,12 +187,35 @@ export async function replicateToGitData(params: {
    */
   worktreeId: string;
   leaseGeneration: number;
-  userId?: string;
+  /**
+   * The session user on whose behalf the push runs. MANDATORY + authorizing when
+   * `isGitDataStoreEnabled()` (D2 resolution, `hr-write-boundary-sentinel-sweep-all-write-sites`):
+   * the push is refused unless this user is a member of `workspaceId`, keyed on the
+   * EXACT `workspaceId` that builds the push URL (no re-derivation). Closes the
+   * logic-bug cross-tenant WRITE (TS-1). Both call sites (agent-runner,
+   * cc-dispatcher) already thread the session userId.
+   */
+  userId: string;
 }): Promise<void> {
   if (!isGitDataStoreEnabled()) return;
   const { workspacePath, workspaceId, worktreeId, leaseGeneration, userId } = params;
   assertSafeWorkspaceId(workspaceId);
   assertSafeWorktreeId(worktreeId);
+
+  // D2 write-boundary sentinel — authorize BEFORE any provision/remote/push so a
+  // cross-tenant write never touches the transport. Fail-closed: a non-member,
+  // an indeterminate RPC, or a missing userId denies. The deny telemetry (security
+  // vs error) is emitted inside authorizeGitDataAccess; throw here so the push is
+  // skipped. Placed OUTSIDE the push try/catch below so a DENY is not mislabeled
+  // as a generic "git_data_replication_push" transport failure.
+  const authorized = await authorizeGitDataAccess({ userId, workspaceId, op: "write" });
+  if (!authorized) {
+    throw new GitDataAuthorizationError(
+      "write",
+      "not-member",
+      `git-data push refused for workspace ${workspaceId} (membership denied — D2)`,
+    );
+  }
 
   try {
     await provisionGitDataRepo(workspaceId);
@@ -232,7 +261,7 @@ export async function replicateToGitData(params: {
     reportSilentFallback(err, {
       feature: "worktree_lease",
       op: "git_data_replication_push",
-      extra: { workspaceId, leaseGeneration, ...(userId ? { userId } : {}) },
+      extra: { workspaceId, leaseGeneration, userId },
       message:
         "git-data replication push failed — a fence reject (stale lease-gen) or " +
         "transport error; the workspace's objects were NOT replicated to the shared store",

--- a/apps/web-platform/test/git-data-client.test.ts
+++ b/apps/web-platform/test/git-data-client.test.ts
@@ -1,0 +1,192 @@
+// Tests for the git-data cross-tenant isolation boundary — epic #5274 Phase 3
+// Sub-PR 3.C / ADR-068 §6 (AC3). Security invariants asserted at the RPC/argv
+// entry (never via an LLM prompt): a non-member session (a) CANNOT read
+// tenant-B git-data (fetch authz, GitDataAuthorizationError, no transport call),
+// (b) CANNOT write tenant-B git-data (D2 write-boundary sentinel in
+// replicateToGitData — TS-1: no push), and (c) a non-member / indeterminate RPC
+// fails CLOSED. The whole boundary is inert at flag-off (dark until the 3.D flip).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const gitTransport = vi.fn().mockResolvedValue(Buffer.from("")); // push + fetch
+const sshProvision = vi.fn().mockResolvedValue(Buffer.from(""));
+const execFileSyncMock = vi.fn((..._args: unknown[]) => Buffer.from("")); // local `git remote`
+const rpcMock = vi.fn();
+const warnSpy = vi.fn();
+const reportSpy = vi.fn();
+
+vi.mock("@/server/git-auth", () => ({
+  gitWithPrivateKeyAuth: (...args: unknown[]) => gitTransport(...args),
+  sshWithPrivateKeyAuth: (...args: unknown[]) => sshProvision(...args),
+}));
+vi.mock("@/lib/supabase/tenant", () => ({
+  getFreshTenantClient: vi.fn(async () => ({ rpc: rpcMock })),
+  RuntimeAuthError: class RuntimeAuthError extends Error {},
+}));
+vi.mock("@/server/observability", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/server/observability")>()),
+  warnSilentFallback: (...args: unknown[]) => warnSpy(...args),
+  reportSilentFallback: (...args: unknown[]) => reportSpy(...args),
+}));
+vi.mock("child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("child_process")>()),
+  execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+}));
+
+import {
+  authorizeGitDataAccess,
+  fetchFromGitData,
+  GitDataAuthorizationError,
+} from "@/server/git-data-client";
+import { replicateToGitData } from "@/server/git-data-replication";
+import { RuntimeAuthError } from "@/lib/supabase/tenant";
+
+const WS_A = "11111111-1111-1111-1111-111111111111";
+const WS_B = "22222222-2222-2222-2222-222222222222";
+const USER_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const WT = "33333333-3333-3333-3333-333333333333";
+
+beforeEach(() => {
+  gitTransport.mockClear().mockResolvedValue(Buffer.from(""));
+  sshProvision.mockClear().mockResolvedValue(Buffer.from(""));
+  execFileSyncMock.mockClear().mockReturnValue(Buffer.from(""));
+  rpcMock.mockReset();
+  warnSpy.mockClear();
+  reportSpy.mockClear();
+  vi.stubEnv("GIT_DATA_STORE_ENABLED", "true");
+  vi.stubEnv("GIT_TRANSPORT_SSH_PRIVATE_KEY", "transport-key");
+  vi.stubEnv("GIT_PROVISION_SSH_PRIVATE_KEY", "provision-key");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("authorizeGitDataAccess — fail-closed membership gate", () => {
+  it("authorizes a confirmed member (RPC → true)", async () => {
+    rpcMock.mockResolvedValue({ data: true, error: null });
+    const ok = await authorizeGitDataAccess({ userId: USER_A, workspaceId: WS_A, op: "fetch" });
+    expect(ok).toBe(true);
+    expect(rpcMock).toHaveBeenCalledWith("is_workspace_member", {
+      p_workspace_id: WS_A,
+      p_user_id: USER_A,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(reportSpy).not.toHaveBeenCalled();
+  });
+
+  it("(c) DENIES a confirmed non-member (RPC → false) + security breadcrumb", async () => {
+    rpcMock.mockResolvedValue({ data: false, error: null });
+    const ok = await authorizeGitDataAccess({ userId: USER_A, workspaceId: WS_B, op: "fetch" });
+    expect(ok).toBe(false);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][1]).toMatchObject({
+      feature: "git-data-authz",
+      op: "fetch-deny",
+    });
+    // The raw workspaceId must NOT appear in telemetry extra (hashed).
+    expect(warnSpy.mock.calls[0][1].extra).not.toHaveProperty("workspaceId");
+  });
+
+  it("DENIES (fail-closed) on RPC error + error breadcrumb", async () => {
+    rpcMock.mockResolvedValue({ data: null, error: { message: "boom", code: "42501" } });
+    const ok = await authorizeGitDataAccess({ userId: USER_A, workspaceId: WS_A, op: "write" });
+    expect(ok).toBe(false);
+    expect(reportSpy).toHaveBeenCalledTimes(1);
+    expect(reportSpy.mock.calls[0][1]).toMatchObject({ feature: "git-data-authz", op: "write-deny" });
+  });
+
+  it("DENIES (fail-closed) when userId is missing", async () => {
+    const ok = await authorizeGitDataAccess({ userId: undefined, workspaceId: WS_A, op: "write" });
+    expect(ok).toBe(false);
+    expect(rpcMock).not.toHaveBeenCalled();
+    expect(reportSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("DENIES (fail-closed) when the tenant client throws RuntimeAuthError", async () => {
+    const { getFreshTenantClient } = await import("@/lib/supabase/tenant");
+    vi.mocked(getFreshTenantClient).mockRejectedValueOnce(new RuntimeAuthError("jwt_mint", "no jwt"));
+    const ok = await authorizeGitDataAccess({ userId: USER_A, workspaceId: WS_A, op: "fetch" });
+    expect(ok).toBe(false);
+    expect(reportSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("fetchFromGitData — authorized read", () => {
+  it("(a) a non-member CANNOT read tenant-B git-data (throws, no transport)", async () => {
+    rpcMock.mockResolvedValue({ data: false, error: null });
+    await expect(
+      fetchFromGitData({ userId: USER_A, workspaceId: WS_B, worktreeId: WT, workspacePath: "/tmp/ws" }),
+    ).rejects.toBeInstanceOf(GitDataAuthorizationError);
+    expect(gitTransport).not.toHaveBeenCalled();
+  });
+
+  it("a confirmed member fetches ONLY its own worktree namespace back to local heads/tags", async () => {
+    rpcMock.mockResolvedValue({ data: true, error: null });
+    await fetchFromGitData({ userId: USER_A, workspaceId: WS_A, worktreeId: WT, workspacePath: "/tmp/ws" });
+    expect(gitTransport).toHaveBeenCalledTimes(1);
+    const argv = gitTransport.mock.calls[0][0] as string[];
+    expect(argv).toContain("fetch");
+    expect(argv).toContain(`+refs/soleur/worktrees/${WT}/heads/*:refs/heads/*`);
+    expect(argv).toContain(`+refs/soleur/worktrees/${WT}/tags/*:refs/tags/*`);
+    // The transport target MUST be the EXPLICIT URL built from the authorized
+    // workspaceId — never a local remote NAME that could point at another tenant.
+    expect(argv).toContain(`ssh://git@10.0.1.20/repositories/${WS_A}.git`);
+    expect(argv).not.toContain("git-data");
+  });
+
+  it("is a NO-OP at flag-off (no authz, no transport)", async () => {
+    vi.stubEnv("GIT_DATA_STORE_ENABLED", "");
+    await fetchFromGitData({ userId: USER_A, workspaceId: WS_A, worktreeId: WT, workspacePath: "/tmp/ws" });
+    expect(rpcMock).not.toHaveBeenCalled();
+    expect(gitTransport).not.toHaveBeenCalled();
+  });
+});
+
+describe("replicateToGitData — D2 write-boundary sentinel (TS-1)", () => {
+  it("(b) a non-member CANNOT write tenant-B git-data (rejects, NO push)", async () => {
+    rpcMock.mockResolvedValue({ data: false, error: null });
+    await expect(
+      replicateToGitData({
+        workspacePath: "/tmp/ws",
+        workspaceId: WS_B,
+        worktreeId: WT,
+        leaseGeneration: 4,
+        userId: USER_A,
+      }),
+    ).rejects.toBeInstanceOf(GitDataAuthorizationError);
+    // TS-1: the transport push MUST NOT fire on a denied write.
+    expect(gitTransport).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][1]).toMatchObject({ feature: "git-data-authz", op: "write-deny" });
+  });
+
+  it("a confirmed member's write proceeds to the fenced push", async () => {
+    rpcMock.mockResolvedValue({ data: true, error: null });
+    await replicateToGitData({
+      workspacePath: "/tmp/ws",
+      workspaceId: WS_A,
+      worktreeId: WT,
+      leaseGeneration: 4,
+      userId: USER_A,
+    });
+    expect(gitTransport).toHaveBeenCalledTimes(1);
+    const argv = gitTransport.mock.calls[0][0] as string[];
+    expect(argv).toContain("push");
+    expect(argv).toContain(`refs/heads/*:refs/soleur/worktrees/${WT}/heads/*`);
+  });
+
+  it("DENIES (fail-closed) and does NOT push on an indeterminate RPC error", async () => {
+    rpcMock.mockResolvedValue({ data: null, error: { message: "db down" } });
+    await expect(
+      replicateToGitData({
+        workspacePath: "/tmp/ws",
+        workspaceId: WS_A,
+        worktreeId: WT,
+        leaseGeneration: 4,
+        userId: USER_A,
+      }),
+    ).rejects.toBeInstanceOf(GitDataAuthorizationError);
+    expect(gitTransport).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-platform/test/git-data-replication.test.ts
+++ b/apps/web-platform/test/git-data-replication.test.ts
@@ -10,13 +10,26 @@ const gitPush = vi.fn().mockResolvedValue(Buffer.from(""));
 const sshProvision = vi.fn().mockResolvedValue(Buffer.from(""));
 const reportSilentFallback = vi.fn();
 const execFileSyncMock = vi.fn((..._args: unknown[]) => Buffer.from("")); // local `git remote` calls
+// D2 write sentinel (Sub-PR 3.C): replicateToGitData now authorizes membership via
+// is_workspace_member through a fresh tenant client BEFORE the push. Default the RPC
+// to member=true so these WRITE-transport tests exercise the push; the cross-tenant
+// DENY path is covered in git-data-client.test.ts.
+const rpcMock = vi.fn(async () => ({ data: true, error: null }));
 
 vi.mock("../server/git-auth", () => ({
   gitWithPrivateKeyAuth: (...args: unknown[]) => gitPush(...args),
   sshWithPrivateKeyAuth: (...args: unknown[]) => sshProvision(...args),
 }));
-vi.mock("../server/observability", () => ({
+// Partial mock: keep warnSilentFallback + hashUserId REAL — git-data-replication
+// now transitively imports git-data-client, which uses them; a wholesale factory
+// would drop those exports and crash the sibling at call time.
+vi.mock("../server/observability", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../server/observability")>()),
   reportSilentFallback: (...args: unknown[]) => reportSilentFallback(...args),
+}));
+vi.mock("@/lib/supabase/tenant", () => ({
+  getFreshTenantClient: vi.fn(async () => ({ rpc: rpcMock })),
+  RuntimeAuthError: class RuntimeAuthError extends Error {},
 }));
 vi.mock("child_process", async (importOriginal) => ({
   ...(await importOriginal<typeof import("child_process")>()),
@@ -32,12 +45,14 @@ import {
 const WS = "ws-uuid-123";
 // Per-user worktree id (ADR-068 D0). A UUID in prod; any safe token here.
 const WT = "55555555-5555-5555-5555-555555555555";
+const USER = "44444444-4444-4444-4444-444444444444";
 
 beforeEach(() => {
   gitPush.mockClear().mockResolvedValue(Buffer.from(""));
   sshProvision.mockClear().mockResolvedValue(Buffer.from(""));
   reportSilentFallback.mockClear();
   execFileSyncMock.mockClear().mockReturnValue(Buffer.from(""));
+  rpcMock.mockClear().mockResolvedValue({ data: true, error: null });
   vi.stubEnv("GIT_TRANSPORT_SSH_PRIVATE_KEY", "transport-key");
   vi.stubEnv("GIT_PROVISION_SSH_PRIVATE_KEY", "provision-key");
 });
@@ -61,7 +76,7 @@ describe("gitDataRemoteUrl / assertSafeWorkspaceId", () => {
 describe("replicateToGitData — gated off (GIT_DATA_STORE_ENABLED unset)", () => {
   it("issues NO provision, no remote config, no push", async () => {
     vi.stubEnv("GIT_DATA_STORE_ENABLED", "");
-    await replicateToGitData({ workspacePath: "/tmp/ws", workspaceId: WS, worktreeId: WT, leaseGeneration: 4 });
+    await replicateToGitData({ workspacePath: "/tmp/ws", workspaceId: WS, worktreeId: WT, leaseGeneration: 4 , userId: USER });
     expect(sshProvision).not.toHaveBeenCalled();
     expect(gitPush).not.toHaveBeenCalled();
     expect(execFileSyncMock).not.toHaveBeenCalled();
@@ -72,7 +87,7 @@ describe("replicateToGitData — gated on", () => {
   beforeEach(() => vi.stubEnv("GIT_DATA_STORE_ENABLED", "true"));
 
   it("pushes to the PER-USER namespaced refspec (D0-ref) carrying lease-gen + per-user worktree-id", async () => {
-    await replicateToGitData({ workspacePath: "/tmp/ws", workspaceId: WS, worktreeId: WT, leaseGeneration: 7 });
+    await replicateToGitData({ workspacePath: "/tmp/ws", workspaceId: WS, worktreeId: WT, leaseGeneration: 7 , userId: USER });
 
     // Provision ran first (idempotent init before the first push).
     expect(sshProvision).toHaveBeenCalledTimes(1);
@@ -100,7 +115,7 @@ describe("replicateToGitData — gated on", () => {
 
   it("rejects an unsafe worktree_id BEFORE any provision/push (CWE-22)", async () => {
     await expect(
-      replicateToGitData({ workspacePath: "/tmp/ws", workspaceId: WS, worktreeId: "../evil", leaseGeneration: 1 }),
+      replicateToGitData({ workspacePath: "/tmp/ws", workspaceId: WS, worktreeId: "../evil", leaseGeneration: 1 , userId: USER }),
     ).rejects.toThrow(/worktree.?id/i);
     expect(sshProvision).not.toHaveBeenCalled();
     expect(gitPush).not.toHaveBeenCalled();
@@ -112,7 +127,7 @@ describe("replicateToGitData — gated on", () => {
     );
 
     await expect(
-      replicateToGitData({ workspacePath: "/tmp/ws", workspaceId: WS, worktreeId: WT, leaseGeneration: 3 }),
+      replicateToGitData({ workspacePath: "/tmp/ws", workspaceId: WS, worktreeId: WT, leaseGeneration: 3 , userId: USER }),
     ).rejects.toThrow(/stale lease generation/);
 
     expect(reportSilentFallback).toHaveBeenCalledTimes(1);
@@ -123,7 +138,7 @@ describe("replicateToGitData — gated on", () => {
 
   it("rejects an unsafe workspace_id BEFORE any provision/push", async () => {
     await expect(
-      replicateToGitData({ workspacePath: "/tmp/ws", workspaceId: "../evil", worktreeId: WT, leaseGeneration: 1 }),
+      replicateToGitData({ workspacePath: "/tmp/ws", workspaceId: "../evil", worktreeId: WT, leaseGeneration: 1 , userId: USER }),
     ).rejects.toThrow();
     expect(sshProvision).not.toHaveBeenCalled();
     expect(gitPush).not.toHaveBeenCalled();

--- a/knowledge-base/project/learnings/best-practices/2026-07-02-membership-authz-bind-to-substrate-not-conflating-resolver.md
+++ b/knowledge-base/project/learnings/best-practices/2026-07-02-membership-authz-bind-to-substrate-not-conflating-resolver.md
@@ -1,0 +1,91 @@
+# Learning: authorize on the membership *substrate*, and bind the transport target to the *authorized* id
+
+category: best-practices
+module: apps/web-platform/server (git-data cross-tenant isolation, ADR-068 §6)
+date: 2026-07-02
+pr: #5893 (Sub-PR 3.C, Ref #5274)
+
+## Problem
+
+Building the cross-tenant isolation boundary for the shared git-data store (3.C),
+two subtly-wrong-but-plausible authorization designs were on the table — one
+prescribed by the plan, one that passed a naïve reading of "authorize before you
+transport." Both would have shipped green.
+
+## Insight 1 — "reuse RPC X's membership shape (NULL→deny)" must be checked against what X *actually* returns NULL for
+
+The plan said to authorize git-data access via the
+`resolve_workspace_installation_id` "membership shape (NULL→deny)". But that RPC
+returns NULL for **two** distinct states:
+- a genuine non-member (the deny path the plan meant), AND
+- a legitimate **member whose workspace has no GitHub App installation**.
+
+git-data is replicated for *every* workspace (connected to GitHub or not), so
+keying the git-data authz on that resolver would **wrongly deny a legitimate
+member's own git-data** — and worst in the common **solo** case (most workspaces
+have no GitHub install).
+
+The fix was to authorize on the *substrate* the resolver itself gates on:
+`is_workspace_member(p_workspace_id, p_user_id)` (mig 053) — the canonical
+SECURITY DEFINER membership predicate that returns a clean boolean, which mig 079's
+`resolve_workspace_installation_id` calls internally. Verified the solo case:
+`handle_new_user` inserts a `workspace_members(role='owner')` row for every
+signup's solo workspace (`workspace_id === userId`), so
+`is_workspace_member(userId, userId)` is TRUE.
+
+**Generalizable rule:** when a plan says "reuse X's membership/authz shape," X is a
+*starting hypothesis*, not the authority. Trace X to the predicate it's built on and
+enumerate every input for which X returns the deny sentinel. If X conflates the
+real invariant (membership) with an orthogonal state (credential presence), reuse
+the underlying substrate, not the conflating resolver. Same family as
+"trace the ACTUAL producer / plan hypotheses are starting points."
+
+## Insight 2 — a membership gate must bind the transport target to the *authorized* id, not a name resolved elsewhere
+
+The read path `fetchFromGitData` first authorized membership on `workspaceId`,
+then fetched from the git remote **named** `"git-data"` — a name resolved from the
+workspace clone's *local* git config, which the function does not set. Authorizing
+on an id but transporting via a name resolved from mutable local state **decouples
+the authz subject from the transport target**: a clone whose local `git-data`
+remote pointed at workspace B would pull tenant-B objects while authz passed for
+tenant-A. (Dark today — flag-off, no callers — but a latent cross-tenant confusion
+vector.) Caught by `security-sentinel` review.
+
+Fix: fetch by the **explicit URL built from the authorized id**
+(`gitDataRemoteUrl(workspaceId)`), mirroring the write path's inline
+`ensureGitDataRemote(workspacePath, workspaceId)`. The id that was authorized is the
+id that names the transport target — no indirection through mutable local config.
+
+**Generalizable rule:** after an `authorize(id)` check, the very next side effect
+must consume that same `id` to build the resource address. If it instead consumes a
+name/handle resolved from separate mutable state, the check is decorative. Same
+family as `hr-write-boundary-sentinel` "keyed on the exact id, no re-derivation."
+
+## Session Errors
+
+- **`git status` at bare-repo root failed** ("must be run in a work tree").
+  Recovery: operate from the worktree. **Prevention:** in a `core.bare=true` repo,
+  never run working-tree git at the bare root; `cd` into the worktree first
+  (already covered by the CWD rule).
+- **CWD drift across Bash calls** — a `sed`/`grep` ran against the bare root after
+  a prior `cd`. Recovery: prefix each call with `cd <worktree-abs> &&`.
+  **Prevention:** existing rule ("chain `cd <abs> && cmd` in a single Bash call");
+  no new enforcement needed.
+- **tsc TS2554 on a mocked class constructor** — `new RuntimeAuthError("no jwt")`
+  in the test used 1 arg, but the REAL `RuntimeAuthError(cause, message)` takes 2;
+  vitest was green (it uses the mock's 1-arg class) but `tsc --noEmit` checks
+  against the real type. Recovery: `new RuntimeAuthError("jwt_mint", "no jwt")`.
+  **Prevention:** when a test instantiates a class imported from a mocked module,
+  match the REAL type's constructor arity — run standalone `tsc --noEmit`, not just
+  vitest (adjacent to the "vitest green, tsc red" learning class).
+- **Comment containing the literal `createServiceClient` would have tripped the
+  `service-role-allowlist-gate`** (the gate greps the whole file, comments
+  included). Recovery: reworded the comment to "the service-role client".
+  **Prevention:** existing learning (grep-over-body false-matches own comments);
+  when writing a comment that names a token a whole-file grep-gate keys on, avoid
+  the literal.
+
+## Tags
+category: best-practices
+module: authz, git-data, membership
+related: hr-write-boundary-sentinel-sweep-all-write-sites, ADR-068, ADR-044, mig-053, mig-079


### PR DESCRIPTION
## Summary

Sub-PR **3.C** of the multi-host `/workspaces` epic (**Ref #5274**, ADR-068 §6): the **cross-tenant isolation boundary** for the shared git-data store. The store is reached over ONE cluster-wide SSH transport key that authorizes the *transport*, not the *tenant* — and the agent sandbox bwrap only isolates the filesystem — so the app must gate **membership** before it reads or writes a workspace's refs. This ships the read-side authorization + the D2 write-boundary sentinel. **Inert until the 3.D flag flip** (`isGitDataStoreEnabled()` is off).

> ✅ **3.B (#5885) merged; this PR is now based on `main`.** 3.C was originally stacked on 3.B (its D2 sentinel + fetch client build on 3.B's per-user `worktree_id` + namespaced refspec). 3.B has since landed on main; 3.C was rebased onto main (clean — the base `git-data-replication.ts` is identical) and its base re-targeted from `multi-host-phase3-3b-router` to `main`. Ready to merge on its own.

## What changed

- **`server/git-data-client.ts` (new)** — read-side authorization:
  - `authorizeGitDataAccess({ userId, workspaceId, op })` — fail-closed membership check via the `is_workspace_member(p_workspace_id, p_user_id)` SECURITY DEFINER RPC through a fresh tenant client. Any error / `null` / `false` / missing userId → **deny**. Denials mirror to Sentry under `feature:git-data-authz` (`op:*-deny`) — a confirmed non-member is a `warnSilentFallback` security event (`sec`, `cross_tenant` tags); an indeterminate RPC is a `reportSilentFallback` error. No service-role client import.
  - `fetchFromGitData(...)` — authorized read; on deny throws `GitDataAuthorizationError` and never touches the transport. Fetches the user's own `refs/soleur/worktrees/<worktreeId>/…` namespace back into local heads/tags, by the **explicit URL built from the authorized workspaceId** (not a local remote name).
- **`server/git-data-replication.ts`** — **D2 write-boundary sentinel** (`hr-write-boundary-sentinel-sweep-all-write-sites`): `userId` is now **mandatory + authorizing**. Before any provision/remote/push, `replicateToGitData` asserts membership on the exact `workspaceId` that builds the push URL (no re-derivation), fail-closed. Placed outside the push `try/catch` so a deny is never mislabeled as a transport failure. Closes the logic-bug cross-tenant WRITE (TS-1).

## Design decision — `is_workspace_member`, not `resolve_workspace_installation_id`

The plan says authorize via the `resolve_workspace_installation_id` "membership shape (NULL→deny)". That RPC returns NULL for **both** a non-member **and** a member whose workspace has no GitHub App installation — so keying on it would wrongly deny a legitimate member's own git-data (git-data is replicated for *every* workspace, connected or not). I used `is_workspace_member` — the canonical membership substrate that `resolve_workspace_installation_id` itself gates on (mig 079 §2) — which returns a clean membership boolean. Verified the common **solo** case: `handle_new_user` (mig 053) inserts a `workspace_members(role='owner')` row for every signup's solo workspace (`workspace_id === userId`), so `is_workspace_member(userId, userId)` is TRUE. Confirmed correct + strictly safer by the security + data-integrity reviewers.

## Scope note — `ensure-workspace-repo.ts` clone-source wiring → 3.D

The plan lists a "clone-from-git-data when flag on" edit to `ensure-workspace-repo.ts` under 3.C. I **deferred that consumer wiring to 3.D**: AC3 (3.C's pre-merge gate) tests only the authorization boundary (delivered), while the read-source *behavior* is inert until the 3.D flag flip and its correctness (which refs are authoritative, checkout consistency) is entangled with 3.D's cutover design (freeze-rsync + set-identity verify + AC7 "FETCHABLE by peer"). The reusable authorized-read primitive it needs — `fetchFromGitData` — ships here, test-covered. Wiring a behavior-changing hook into that dense self-heal path under uncertainty, untested by any 3.C AC, is avoided by design.

## Acceptance criteria (AC3)

- ✅ A non-member session **cannot read** tenant-B git-data (`fetchFromGitData` throws, no transport touch).
- ✅ The **app-side write sentinel rejects** a push for a workspace the session-user isn't a member of (fail-closed, no push — TS-1).
- ✅ Non-member RPC → deny; indeterminate RPC / missing userId → deny (fail-closed).
- ℹ️ Host-compromise cross-tenant write remains a documented GA residual (per-workspace keys post-GA) — NOT asserted here.

## Review

Three reviewers ran against the 3.C diff:
- **Observability: clean** — every deny path is Sentry-reachable without SSH; write-deny not mislabeled.
- **Data-integrity: clean** — D2 keys on the same workspaceId; solo case not denied; refspec is the correct inverse of 3.B's write; both call sites intact; inert at flag-off. (Its "raw userId in telemetry" note was a false positive — `warn/reportSilentFallback` hash `userId`→`userIdHash` at the emit boundary, the sanctioned convention.)
- **Security: one MEDIUM, fixed inline** — `fetchFromGitData` was authorizing on `workspaceId` but fetching from the local remote *named* `git-data` (which it doesn't configure). Now it fetches by the explicit `gitDataRemoteUrl(workspaceId)`, binding the transport target to the authorized workspaceId. Test tightened to assert the URL target and reject a bare remote name.

**3.D watch-item (from data-integrity):** when 3.D wires a caller for `fetchFromGitData`, assert the checkout state it fetches into — a `+refs/…:refs/heads/*` fetch refuses to update the currently-checked-out branch and can discard local-only commits on non-current ahead branches. Intended for fresh/rehydrated worktrees.

## Test / verification

- New `test/git-data-client.test.ts` (11) + updated `test/git-data-replication.test.ts` (7) — RED→GREEN, security invariants asserted at the RPC/argv entry.
- Full web-platform suite: **11,497 passed, 0 failed**; `tsc --noEmit` clean.

## Changelog

- Add membership-gated cross-tenant isolation for the shared git-data store (read authz + D2 write sentinel), inert behind `isGitDataStoreEnabled()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
