### PR TITLE
fix(infra): guard moved-block CI-apply wedge; unblock via operator cutover (#5887)

### DIFF
--- a/knowledge-base/engineering/architecture/decisions/ADR-068-multi-host-workspaces-shared-git-data-lease-coordinator.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-068-multi-host-workspaces-shared-git-data-lease-coordinator.md
@@ -414,7 +414,7 @@ fixes for every per-step plan:
 coordinator routing — GA)** → Phase 4a (Nomad + reclaim cron + Redis buffer) →
 Phase 4b (continuous checkpoint).
 
-> **Amendment (2026-07-02, #5877/#5887 — moved-block migration sequencing).** A
+> **Amendment (CTO ruling, 2026-07-02, #5877/#5887 — moved-block migration sequencing).** A
 > `moved {}` block that re-addresses a resource in `OPERATOR_APPLIED_EXCLUSIONS`
 > **wedges every target-scoped CI apply** (`apply-web-platform-infra.yml`,
 > `apply-deploy-pipeline-fix.yml`) until an operator full apply consumes the pending
@@ -437,7 +437,8 @@ Phase 4b (continuous checkpoint).
 > re-addresses an operator-excluded resource fails at plan-review time instead of
 > silently wedging CI. (Residual, deferred to a follow-up: the destroy-guard remains
 > blind to reboot-forcing in-place `update` on `hcloud_server.*` — a reboot-aware
-> apply guard is the interim gap the parity accounting-check does not mechanically close.)
+> apply guard is the interim gap the parity accounting-check does not mechanically
+> close; tracked in #5911.)
 
 ## Consequences
 

--- a/knowledge-base/engineering/architecture/decisions/ADR-068-multi-host-workspaces-shared-git-data-lease-coordinator.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-068-multi-host-workspaces-shared-git-data-lease-coordinator.md
@@ -414,6 +414,31 @@ fixes for every per-step plan:
 coordinator routing — GA)** → Phase 4a (Nomad + reclaim cron + Redis buffer) →
 Phase 4b (continuous checkpoint).
 
+> **Amendment (2026-07-02, #5877/#5887 — moved-block migration sequencing).** A
+> `moved {}` block that re-addresses a resource in `OPERATOR_APPLIED_EXCLUSIONS`
+> **wedges every target-scoped CI apply** (`apply-web-platform-infra.yml`,
+> `apply-deploy-pipeline-fix.yml`) until an operator full apply consumes the pending
+> move — Terraform requires every pending `moved` source/target base address to be
+> inside the `-target=` set on a targeted plan, or it aborts with `Error: Moved
+> resource instances excluded by targeting`. The Phase-3 GA singleton→`for_each`
+> migration (#5877) added four `moved` blocks to `placement-group.tf`
+> (`hcloud_server.web`, `hcloud_volume.workspaces`, `hcloud_volume_attachment.workspaces`,
+> `hcloud_server_network.web`) but shipped WITHOUT the cutover apply, so the targeted
+> CI plan went red on every run from 2026-07-01 18:03 (#5887). **Rule:** a
+> singleton→`for_each` migration on an operator-excluded host must ship **with** its
+> operator maintenance-window cutover, **never** as a routine per-PR `-target=`
+> allow-list edit — adding `hcloud_server.web` to the unattended per-PR target set
+> forces a power-off reboot of the running prod host (it carries `placement_group_id`
+> + `for_each`; see `server.tf`) and the Cloudflare-scoped, `delete`-only destroy-guard
+> is blind to that in-place reboot. After the operator apply consumes the moves, no
+> pending moves remain and the targeted CI plan self-heals with zero workflow change.
+> A recurrence guard lives in `plugins/soleur/test/terraform-target-parity.test.ts`
+> (`moved`/`-target` parity block, `MOVED_OPERATOR_CONSUMED`): a future migration that
+> re-addresses an operator-excluded resource fails at plan-review time instead of
+> silently wedging CI. (Residual, deferred to a follow-up: the destroy-guard remains
+> blind to reboot-forcing in-place `update` on `hcloud_server.*` — a reboot-aware
+> apply guard is the interim gap the parity accounting-check does not mechanically close.)
+
 ## Consequences
 
 - **Positive.** The serializable-vs-live-handle split (research reconciliation) kills

--- a/knowledge-base/project/learnings/2026-07-02-moved-block-on-operator-excluded-resource-wedges-targeted-ci-apply.md
+++ b/knowledge-base/project/learnings/2026-07-02-moved-block-on-operator-excluded-resource-wedges-targeted-ci-apply.md
@@ -1,0 +1,42 @@
+---
+title: "A `moved` block on an operator-excluded resource red-lines every target-scoped CI apply — the fix is the cutover, not an allow-list edit"
+date: 2026-07-02
+category: workflow-patterns
+tags: [terraform, moved-block, target-scoped-apply, ci, adr-068, sequencing, infra]
+issue: 5887
+---
+
+# Learning: a `moved` migration on an operator-excluded resource wedges targeted CI applies
+
+## Problem
+
+A singleton→`for_each` `moved {}` migration (#5877, ADR-068 Phase 3) added four
+`moved` blocks to `apps/web-platform/infra/placement-group.tf` but shipped without
+its operator cutover apply. Every subsequent target-scoped CI run
+(`apply-web-platform-infra.yml`, `apply-deploy-pipeline-fix.yml`) went red with
+`Error: Moved resource instances excluded by targeting` — Terraform requires every
+pending `moved` source/target base address to be inside the `-target=` set on a
+targeted plan, and these bases were deliberately in `OPERATOR_APPLIED_EXCLUSIONS`.
+
+## The trap
+
+The obvious fix — add the moved bases to the per-PR `-target=` allow-list — is
+unsafe: `hcloud_server.web` carries `placement_group_id` + `for_each` (`server.tf`),
+so targeting it in the unattended per-PR path forces a power-off reboot of the
+running prod host. The `delete`-only, Cloudflare-scoped destroy-guard is blind to
+that in-place reboot. The real root cause is operator-action-pending **sequencing**,
+not a forgotten allow-list entry.
+
+## The rule
+
+A singleton→`for_each` `moved` migration on an operator-excluded resource red-lines
+target-scoped CI applies until an operator maintenance-window full apply consumes the
+pending moves; the fix is the cutover **with** the migration + a `moved`/`-target`
+parity guard, **NOT** an allow-list edit. After the cutover, no pending moves remain
+and the targeted CI plan self-heals with zero workflow change.
+
+Authoritative record + full rationale (reboot evidence, blast radius across both
+targeted workflows, the recurrence guard): **ADR-068 §Amendment (2026-07-02,
+#5877/#5887)** and the `moved`/`-target` parity block in
+`plugins/soleur/test/terraform-target-parity.test.ts` (`MOVED_OPERATOR_CONSUMED`).
+Discoverable via `git grep 5887`.

--- a/knowledge-base/project/plans/2026-07-02-fix-web-platform-infra-moved-target-allowlist-plan.md
+++ b/knowledge-base/project/plans/2026-07-02-fix-web-platform-infra-moved-target-allowlist-plan.md
@@ -20,6 +20,21 @@ date: 2026-07-02
 
 > Spec lacks a `lane:` (no spec.md authored for this branch) — defaulted to `cross-domain` (TR2 fail-closed).
 
+## Enhancement Summary
+
+**Deepened on:** 2026-07-02
+**Sections enhanced:** Hypotheses (network-outage deep-dive), Risks (precedent-diff + verify-the-negative), Phase 1 guard design, Domain Review, Test Scenarios, Deferral Tracking, Apply path.
+**Agents used:** CTO (plan-phase), architecture-strategist + code-simplicity-reviewer (deepen-phase). Deepen gates run: 4.4 precedent-diff, 4.45 verify-the-negative, 4.5 network-outage, 4.6 user-brand-impact (pass), 4.7 observability (pass), 4.8 PAT-shape (clean), 4.9 UI-wireframe (n/a).
+
+### Key Improvements
+1. **Central decision hardened and independently confirmed:** reject the issue's literal `-target` extension (it would reboot prod web-1 unattended) — verified sound + no-P0 by architecture-strategist, with the reboot evidence (server.tf:40 `placement_group_id` + `for_each`) and the destroy-guard's blindness to in-place reboots (verify-the-negative: filter is `delete`-only + Cloudflare-scoped) both confirmed against the tree.
+2. **Guard design reconciled across two reviewers:** keep the separate `MOVED_OPERATOR_CONSUMED` set (forced-acknowledgment ledger) + add a `⊆ OPERATOR_APPLIED_EXCLUSIONS` subset test to close the sync-drift hazard; flat-regex parser; cut the tautological regression-anchor.
+3. **Residual blind spot recorded:** deferred follow-up for a reboot-aware apply guard (destroy-guard is blind to reboot-forcing `update` on `hcloud_server.*`).
+
+### New Considerations Discovered
+- Blast radius: `apply-deploy-pipeline-fix.yml` is wedged on the same R2 state; one cutover unwedges both. `scheduled-terraform-drift.yml` (full plan) is not wedged and is the working backstop.
+- The 4th moved block (`hcloud_server_network.web`) is not runtime-reported only because its Phase-2 resource is not yet in state; the guard accounts for all four.
+
 ## Overview
 
 `.github/workflows/apply-web-platform-infra.yml` auto-applies `apps/web-platform/infra/*.tf` on every merge to `main`, using a **target-scoped** `terraform plan -target=<addr>` allow-list (one `-target=` line per resource that is *intended* to be applied per-PR). It has been **red on every run since 2026-07-01 18:03** (#5877, Phase 3 Sub-PR 3.A), which added four `moved {}` blocks to `apps/web-platform/infra/placement-group.tf`. Terraform rejects a targeted plan when a pending `moved` source/target base address is excluded from the `-target` set:
@@ -63,6 +78,17 @@ This plan therefore delivers two independent, safe workstreams:
 
 **Network-outage / SSH gate (plan Phase 1.4):** evaluated and **does not fire**. The failure is a Terraform *plan-time move-targeting* error, not an SSH/connectivity/handshake failure. The moved resources (`hcloud_server.web`, `hcloud_volume.workspaces`, `hcloud_volume_attachment.workspaces`) have no `provisioner`/`connection { ssh }` block in their own definitions (the SSH-provisioned `terraform_data.*` siblings are separate resources applied over the CF Tunnel bridge in a later, separate step). No L3→L7 firewall/egress diagnosis is in scope; the `hr-ssh-diagnosis-verify-firewall` checklist is not required here.
 
+### Network-Outage Deep-Dive (deepen-plan Phase 4.5)
+
+The Phase 4.5 keyword trigger matched (the plan text mentions "SSH" / "handshake" / "connection" when describing the CF Tunnel bridge and when *excluding* the SSH gate). Layer-by-layer verification confirms this is **not** a connectivity outage:
+
+- **L3 firewall allow-list / egress IP:** N/A — the failing step is `terraform plan`, which reaches only the R2 state backend + provider APIs, not the host over SSH. The CF-Tunnel SSH apply step never runs (the plan step aborts the job first). No egress-IP drift is implicated.
+- **L3 DNS / routing:** N/A — no host dial occurs at the failing step.
+- **L7 TLS / proxy:** N/A — not an HTTPS/handshake failure; the error is a Terraform config-graph validation (`Moved resource instances excluded by targeting`).
+- **L7 application:** the "application" here is Terraform's move-processing under `-target`; the fix is at that layer (sequencing the migration + a CI guard), not a network layer.
+
+Verification artifact: the confirmed failure signature is the Terraform plan-step error, reproduced across 5 consecutive runs (28537711578 … 28581854943), each ~34-66s (fails fast at plan, before any SSH step). `hr-ssh-diagnosis-verify-firewall` telemetry emitted (gate consulted, concluded N/A).
+
 ## Implementation Phases
 
 ### Phase 0 — Preconditions (verify before editing)
@@ -72,17 +98,18 @@ This plan therefore delivers two independent, safe workstreams:
 4. Do NOT run `terraform plan/apply` from the agent (no prd_terraform creds / R2 state in-session). The migration dry-run/apply is an operator maintenance-window step (Phase 3).
 
 ### Phase 1 — Extend the `moved`/`-target` parity guard (the recurrence fix)
-Edit `plugins/soleur/test/terraform-target-parity.test.ts` (add a new `describe` block; do not disturb the existing SSH and #5566 blocks):
-- Add a `parseMovedBlocks(stripped)` helper: match `moved\s*\{ … from = <addr> … to = <addr> … \}`, extract both endpoints, reduce each to its **base address** (strip a trailing `["…"]` index).
-- Add a documented `MOVED_OPERATOR_CONSUMED` set — the four #5877 bases, each with a one-line rationale mirroring `OPERATOR_APPLIED_EXCLUSIONS` discipline: *"consumed by the ADR-068 Phase-3 maintenance-window apply; a routine per-PR `-target` add would reboot/replace the running host — see #5887."*
-- Assert: every moved base ∈ (`allTargets` ∪ `MOVED_OPERATOR_CONSUMED`). Uncovered ⟹ fail.
-- Add a **non-vacuity / synthetic-forgotten-moved-block** test mirroring the existing `synthetic_untargeted_ssh` pattern (lines 278-333): a synthetic `moved` block whose base is in neither set must be flagged uncovered (proves the guard bites).
-- Add a **regression anchor**: assert the four #5877 bases are each in `MOVED_OPERATOR_CONSUMED` (so a later un-accounting fails loudly).
-- Comment the WHY: the existing #5566 test treats "in `OPERATOR_APPLIED_EXCLUSIONS`" as sufficient coverage, which is **orthogonal** to Terraform's plan-time move-processing requirement — hence a new `moved`-keyed dimension, not a tweak to the existing check.
+Edit `plugins/soleur/test/terraform-target-parity.test.ts` (add a new `describe` block; do not disturb the existing SSH and #5566 blocks). Minimal shape (post code-simplicity review — 1 helper + 1 set + 2 tests):
+- Add a `parseMovedBlocks(stripped)` helper: **flat regex** `/moved\s*\{[^}]*\}/g` (the four `moved` blocks are flat — no nested braces — so the heavy `extractTerraformDataResources` depth-counter is NOT needed here), then two `from\s*=\s*<addr>` / `to\s*=\s*<addr>` captures per block; reduce each endpoint to its **base address** (strip a trailing `["…"]` index).
+- Add a documented `MOVED_OPERATOR_CONSUMED` set — the four #5877 bases, each with a one-line rationale mirroring `OPERATOR_APPLIED_EXCLUSIONS` discipline: *"consumed by the ADR-068 Phase-3 maintenance-window apply; a routine per-PR `-target` add would reboot/replace the running host — see #5887."* Add a cross-reference comment on BOTH `MOVED_OPERATOR_CONSUMED` and `OPERATOR_APPLIED_EXCLUSIONS` noting the four addresses live in two hand-maintained sets that must move in lockstep on a resource rename (dual-maintenance hazard flagged at review).
+- **Test 1 (coverage):** every moved base ∈ (`allTargets` ∪ `MOVED_OPERATOR_CONSUMED`). Uncovered ⟹ fail. This test IS the regression anchor — removing a #5877 base from the set turns it red (the base is not in `allTargets`), so a **separate** "the four bases are in the set" tautology test is redundant and is NOT added.
+- **Test 2 (non-vacuity):** a synthetic forgotten `moved` block (base in neither set) must be flagged uncovered — mirrors the existing `synthetic_untargeted_ssh` pattern (lines 278-333); proves the guard bites.
+- **Test 3 (drift guard — reconciles the two reviewers):** assert `MOVED_OPERATOR_CONSUMED ⊆ OPERATOR_APPLIED_EXCLUSIONS`. This is NOT the tautological regression-anchor that was cut — it closes the dual-maintenance sync-drift hazard the architecture review flagged (P1): a separate `MOVED_OPERATOR_CONSUMED` set keeps the forced-acknowledgment ledger value (code-simplicity), and the subset assertion guarantees the two hand-maintained sets can never diverge on a rename. Any address in `MOVED_OPERATOR_CONSUMED` that is not also operator-excluded fails loudly.
+- (Optional, trimmable) a "permit a genuinely `-target`ed move" positive-branch test is YAGNI today (no current targeted-move case) — omit unless a reviewer wants union-branch documentation.
+- Comment the WHY: the existing #5566 test treats "in `OPERATOR_APPLIED_EXCLUSIONS`" as sufficient coverage, which is **orthogonal** to Terraform's plan-time move-processing requirement (exclusion-membership is the wedge *precondition*, not evidence of safe handling) — hence a new `moved`-keyed set, not a reuse of `OPERATOR_APPLIED_EXCLUSIONS`. Reusing it would rubber-stamp the exact #5877 pattern green. **Known limitation (state in the comment):** this guard is a review-surfacing *accounting* check on the repo, not a mechanical safety interlock — it forces a conscious classification but cannot stop an author from making it pass the *wrong* way (adding a reboot-bearing base to `-target`); and it checks the repo, not live R2 state (an already-wedged state is caught by the drift cron + follow-through, not here).
 
 ### Phase 2 — ADR-068 amendment + learning (capture the sequencing rule)
 - Amend `knowledge-base/engineering/architecture/decisions/ADR-068-*.md` (append an `> **Amendment (2026-07-02, #5887)**` note under the existing Phase-3 amendment section): record that a `moved` block re-addressing a resource in `OPERATOR_APPLIED_EXCLUSIONS` **wedges every targeted CI apply** until an operator full apply consumes it; such migrations must ship **with** the operator cutover, never as a routine `-target` allow-list edit. Do NOT change the ADR's `status:` (still `adopting`).
-- Write a learning `knowledge-base/project/learnings/<topic>.md` (author picks date at write-time; directory = `knowledge-base/project/learnings/` root or `bug-fixes/`): "a singleton→`for_each` `moved` migration on an operator-excluded resource red-lines target-scoped CI applies; unblock via operator cutover + a moved/`-target` guard, not an allow-list edit."
+- Write a **concise** learning `knowledge-base/project/learnings/<topic>.md` (author picks date at write-time; directory = `knowledge-base/project/learnings/` root or `bug-fixes/`) that is a **pointer to the ADR-068 amendment**, not a restatement of it (code-simplicity Q2: the ADR is the authoritative, `git grep 5887`-discoverable record). One-paragraph capture: "a singleton→`for_each` `moved` migration on an operator-excluded resource red-lines target-scoped CI applies (`Moved resource instances excluded by targeting`); the fix is the maintenance-window cutover + a moved/`-target` guard, NOT an allow-list edit — see ADR-068 §Amendment (#5887)." This satisfies the compound/learnings convention without duplicating the rule prose.
 
 ### Phase 3 — Operator cutover runbook (post-merge, maintenance window)
 Author a `### Post-merge (operator)` runbook (below) for the Phase-3 migration apply. This clears the wedge. It is operator-gated (supervised prod reboot). Provide the canonical Doppler `tf-var` invocation triplet verbatim (per the drift-runbook Sharp Edge). Enroll a `follow-through` tracker so issue closure is gated on the apply succeeding (not on merge).
@@ -152,13 +179,17 @@ None. `gh issue list --label code-review --state open` (61 open) — no open sco
 
 Key CTO findings folded in: (a) Terraform move coverage is all-or-nothing (can't add the 2 safe bases and omit the reboot-bearing server); (b) targeting the server transitively drags in `hcloud_placement_group.web_spread`; (c) blast radius includes `apply-deploy-pipeline-fix.yml`; (d) guard must key on a new `moved` dimension (the #5566 exclusion check is orthogonal to plan-time move processing). No capability gaps.
 
+**Deepen-plan reviewers (architecture-strategist + code-simplicity-reviewer):** VERDICT **sound, no P0**. Both verified every load-bearing claim against the tree (reboot evidence server.tf:37-40; 4 moved blocks; destroy-guard delete-only + Cloudflare-scoped; guard CI-wired at `scripts/test-all.sh:180`). Folded in: (1) architecture P1 + simplicity Q1 reconciled — keep the separate `MOVED_OPERATOR_CONSUMED` set (forced-acknowledgment ledger) AND add a `⊆ OPERATOR_APPLIED_EXCLUSIONS` subset test (closes sync-drift); (2) simplicity — flat-regex `parseMovedBlocks` (blocks are flat), cut the tautological regression-anchor, ADR-authoritative / learning-as-pointer; (3) architecture P2 — reboot-aware apply guard deferred to a follow-up issue; (4) architecture P2c — dispatch-gated alternative recorded as consciously declined.
+
 ## Infrastructure (IaC)
 
 ### Terraform changes
 No `.tf` files are edited. This plan changes **who applies** the Phase-3 moved migration (operator maintenance window) and adds a CI **guard** — it introduces no new resource, provider, or `TF_VAR_*`.
 
 ### Apply path
-(c-variant: taint/replace-class → here, an operator maintenance-window apply) The singleton→`for_each` migration + placement-group attach is an **operator maintenance-window `terraform apply`** (supervised, expected web-1 power-off reboot; possible web-2 create per `var.web_hosts`). It is NOT routed through the per-PR auto-apply `-target` path, because that path is unattended and this change reboots the running host. Expected downtime: one web-1 reboot cycle within the operator's window. After the apply, no pending moves remain → the per-PR target-scoped plan self-heals with no workflow change.
+(c-variant: taint/replace-class → here, an operator maintenance-window apply) The singleton→`for_each` migration + placement-group attach is an **operator maintenance-window `terraform apply`** (supervised, expected web-1 power-off reboot; possible web-2 create per `var.web_hosts`). It is NOT routed through the per-PR auto-apply `-target` path, because that path is unattended and this change reboots the running host. Expected downtime: one web-1 reboot cycle within the maintenance window. After the apply, no pending moves remain → the per-PR target-scoped plan self-heals with no workflow change.
+
+**Consciously-declined alternative (architecture review P2c):** a `workflow_dispatch`-gated full apply (a human gates the go/no-go decision; CI runs the terraform mechanics behind the SSH bridge) would be more automation-aligned than the local supervised apply. It is declined here because the go/no-go on a supervised production power-cycle is a genuine risk-acceptance judgment best made at the keyboard watching the live plan, and the copy-paste runbook already satisfies the "don't label mechanics as manual" hard rule (the mechanics ARE scripted). The dispatch-gated shape is recorded as the preferred path IF this cutover recurs.
 
 ### Distinctness / drift safeguards
 `dev != prd`: this is prd (`prd_terraform`). The `moved` migration is 0-destroy **only if** web-1's `name`/`server_type`/`location` in `var.web_hosts` match current state (a location change force-REPLACES the live host — server.tf comment). The dry-run `terraform plan` MUST show `0 to destroy` before apply. `scheduled-terraform-drift.yml` (full plan) is the 12h backstop and is already surfacing this as drift (working as designed). State lands in the encrypted R2 backend (`use_lockfile = false` — the shared GHA concurrency group is the serializer, not relevant to an operator-local apply).
@@ -210,11 +241,11 @@ ADR-068 already recorded the multi-host C4 impact (its `## C4 impact` section, A
 
 ## Test Scenarios
 
-1. **Guard passes on current tree:** the four #5877 moved bases are covered by `MOVED_OPERATOR_CONSUMED` → suite green.
+1. **Guard passes on current tree:** the four #5877 moved bases are covered by `MOVED_OPERATOR_CONSUMED` → suite green (this test IS the regression anchor — dropping a base turns it red via the `allTargets` miss).
 2. **Guard fails on a forgotten moved block:** synthetic `moved { from = hcloud_foo.bar; to = hcloud_foo.bar["k"] }` with base in neither set → flagged uncovered (non-vacuity).
-3. **Guard permits a genuinely per-PR-targeted move:** a synthetic moved base that IS in `allTargets` → covered (does not false-fail).
+3. **Drift guard:** `MOVED_OPERATOR_CONSUMED ⊆ OPERATOR_APPLIED_EXCLUSIONS` — a base in the moved set but absent from the exclusion set fails loudly (closes the dual-maintenance sync-drift hazard).
 4. **No workflow drift:** `git diff .github/workflows/apply-web-platform-infra.yml` is empty.
-5. **Full suite:** `bun test plugins/soleur/test/` green (destroy-guard/parity siblings unaffected).
+5. **Full suite:** `bun test plugins/soleur/test/` green (destroy-guard/parity siblings unaffected). CI wiring: `scripts/test-all.sh:180` auto-discovers `plugins/soleur/**/*.test.ts`, so the new guard fires pre-merge.
 
 ## Risks & Mitigations
 
@@ -222,6 +253,14 @@ ADR-068 already recorded the multi-host C4 impact (its `## C4 impact` section, A
 - **R2 — Operator cutover not run → workflows stay red.** Drift accumulates (issue's stated impact); the 12h drift cron is the backstop and is already surfacing it. **Mitigation:** `follow-through` tracker + `Ref #5887` (close only after apply).
 - **R3 — Cutover apply shows unexpected destroy/replace.** A `var.web_hosts` web-1 attribute drift (location/server_type) would force-replace the live host. **Mitigation:** mandatory dry-run showing `0 to destroy` before apply (server.tf comment + ADR-068 NFR-016).
 - **R4 — 4th moved block (`hcloud_server_network.web`) joins the pending set later.** When the operator provisions the Phase-2 private network, its move becomes pending. **Mitigation:** the operator full apply consumes it in the same cutover; the guard already accounts for it via `MOVED_OPERATOR_CONSUMED`.
+
+### Precedent-diff — `-target` allow-list guard artifacts (deepen-plan Phase 4.4)
+
+The `-target=` allow-list / apply-safety surface for this root is asserted by several sibling artifacts:
+- `plugins/soleur/test/terraform-target-parity.test.ts` — SSH parity (#4844) + non-SSH `-target` coverage (#5566). **← the only file this plan edits.**
+- `tests/scripts/lib/destroy-guard-filter-web-platform.jq` + `tests/scripts/test-destroy-guard-counter-web-platform.sh` — count **destroys**, scoped to 5 Cloudflare resource types (verified: filter header lines 1-18; no `hcloud`/`moved` handling).
+
+**Determination:** only the parity test needs editing. The destroy-guard filter/counter count *destroys*, and a `moved` block is a state re-address (0 destroy) — out of their scope by construction. This plan also does **not** mutate the workflow `-target` list, so no counter/filter re-sync is required. The Sentry root has a dedicated `test-destroy-guard-sentry-scope-guard.sh` orphan suite; the web-platform root has **no** such scope-guard sibling, so there is no orphan suite to sweep here (unlike the #4591 case the `-target`-allowlist Sharp Edge warns about).
 
 ## Sharp Edges
 
@@ -233,4 +272,4 @@ ADR-068 already recorded the multi-host C4 impact (its `## C4 impact` section, A
 ## Deferral Tracking
 
 - The operator maintenance-window cutover is tracked via `Ref #5887` (stays open until applied) + a `follow-through` tracker — not a separate deferral issue (it IS the remediation, not out-of-scope).
-- No "Alternative Approaches / Non-Goals" items are deferred beyond the operator apply.
+- **Deferred follow-up (architecture review P2) — reboot-aware apply guard.** After this fix, the destroy-guard remains provably blind to reboot-forcing in-place `update` actions on `hcloud_server.*` (it counts only `delete` + 5 Cloudflare nested-block surfaces). The moved/`-target` parity guard is a review-surfacing accounting check, not a mechanical interlock against a misclassification that adds a reboot-bearing base to `-target`. File a follow-up issue (`domain/engineering`, `priority/p2-medium`, re-eval when the multi-host cluster stabilizes): extend the web-platform destroy-guard to flag `update` actions on `hcloud_server.*` that change reboot-forcing attributes (`placement_group_id`, `server_type`, `location`), gated by an `[ack-destroy]`-style acknowledgement. Out of scope for THIS PR; the parity guard + ADR amendment are the acceptable interim.

--- a/knowledge-base/project/plans/2026-07-02-fix-web-platform-infra-moved-target-allowlist-plan.md
+++ b/knowledge-base/project/plans/2026-07-02-fix-web-platform-infra-moved-target-allowlist-plan.md
@@ -1,0 +1,236 @@
+<!-- iac-routing-ack: plan-phase-2-8-reviewed -->
+<!-- Phase 2.8 reviewed: this plan edits NO .tf and provisions NO new resource. The only
+     "operator runs terraform" step is the ADR-068 Phase-3 maintenance-window cutover, which is
+     genuinely human-gated (a supervised production web-host power-off reboot = risk-acceptance
+     judgment, not an automatable tooling gap). It is documented as a runbook with the canonical
+     Doppler tf-var invocation triplet, gated on a 0-destroy dry-run, and tracked via follow-through.
+     A ## Infrastructure (IaC) section is present below. -->
+---
+title: "fix(infra): unblock apply-web-platform-infra — sequence #5877 moved-block migration + add moved/-target guard"
+issue: 5887
+branch: feat-one-shot-5887-moved-target-allowlist
+type: ops-remediation
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+date: 2026-07-02
+---
+
+# 🐛 fix(infra): unblock apply-web-platform-infra — sequence the #5877 moved-block migration + add a moved/`-target` parity guard
+
+> Spec lacks a `lane:` (no spec.md authored for this branch) — defaulted to `cross-domain` (TR2 fail-closed).
+
+## Overview
+
+`.github/workflows/apply-web-platform-infra.yml` auto-applies `apps/web-platform/infra/*.tf` on every merge to `main`, using a **target-scoped** `terraform plan -target=<addr>` allow-list (one `-target=` line per resource that is *intended* to be applied per-PR). It has been **red on every run since 2026-07-01 18:03** (#5877, Phase 3 Sub-PR 3.A), which added four `moved {}` blocks to `apps/web-platform/infra/placement-group.tf`. Terraform rejects a targeted plan when a pending `moved` source/target base address is excluded from the `-target` set:
+
+```
+Error: Moved resource instances excluded by targeting
+  … hcloud_server.web, hcloud_volume.workspaces, hcloud_volume_attachment.workspaces …
+```
+
+The issue proposes: extend the `-target=` allow-list with the three reported bases (mirroring the #5566 un-targeted-resource fix), and extend `terraform-target-parity.test.ts` to catch `moved`-block endpoints missing from the `-target` set.
+
+**Research + CTO review rejects the literal `-target` extension as unsafe** and reframes the fix. `hcloud_server.web` now carries `placement_group_id = hcloud_placement_group.web_spread.id` (server.tf:40) and `for_each = var.web_hosts`. Its own comment (server.tf:37-39) states attaching the placement group to the running web-1 **"forces a power-off → maintenance-window apply."** Adding `hcloud_server.web` to the *routine* per-PR `-target` list would, on the next arbitrary infra-PR merge, **reboot the production web host unattended** (and transitively create `hcloud_placement_group.web_spread`, and — via `for_each` — potentially provision web-2). The existing destroy-guard would NOT catch it (it is an in-place update, 0 destroy; the guard filter is Cloudflare-scoped). This is a `single-user incident` brand-survival regression, not a benign allow-list line.
+
+**The root cause is operator-action-pending sequencing, not a forgotten allow-list entry.** The four `moved` blocks are transient migration scaffolding for the singleton→`for_each` cutover that ADR-068 Phase 3 GA always implied but never executed. The correct unblock is the **operator's Phase-3 maintenance-window full `terraform apply`**, which consumes all four moves (state re-address to `["web-1"]`), creates `web_spread`, and performs the planned power-off attach in a supervised window. Afterward there are **no pending moves in state** and the targeted CI plan self-heals with **zero workflow change**. One operator apply also unwedges the sibling `apply-deploy-pipeline-fix.yml`, which is failing on the identical error against the same R2 state.
+
+This plan therefore delivers two independent, safe workstreams:
+
+1. **A recurrence guard (ships now, code/test/docs-only, safe to merge independently):** extend `terraform-target-parity.test.ts` with a `moved`-block dimension so a future singleton→`for_each` migration that re-addresses an operator-excluded resource FAILS at plan-review time instead of silently wedging every targeted CI apply. Record the sequencing rule as an ADR-068 amendment + a learning.
+2. **The operator cutover (post-merge, maintenance-window, operator-supervised):** a documented, gated runbook for the Phase-3 migration apply that actually clears the wedge. This is genuinely human-gated (a supervised production reboot / new-host provisioning = risk-acceptance judgment), not a tooling gap.
+
+**We do NOT extend the per-PR `-target` allow-list with the host/volume bases** — doing so is rejected (Risks §R1).
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (issue #5887) | Reality (verified) | Plan response |
+|---|---|---|
+| Add 3 moved bases to the per-PR `-target` allow-list, mirroring #5566 | `hcloud_server.web` carries `placement_group_id` (server.tf:40) + `for_each = var.web_hosts`; targeting it reboots prod web-1 unattended and creates `web_spread`/web-2. #5566 was a genuinely per-PR secret; these are deliberately `OPERATOR_APPLIED_EXCLUSIONS`. | **Reject** the `-target` extension. Unblock via operator maintenance-window apply (§Phase 3). |
+| Three resources are moved-implicated (`hcloud_server.web`, `hcloud_volume.workspaces`, `hcloud_volume_attachment.workspaces`) | **Four** `moved` blocks exist (placement-group.tf:23-41); the 4th is `hcloud_server_network.web`. Runtime error reports only 3 because `hcloud_server_network.web` is a Phase-2 resource **not yet in state** → its move is a no-op with nothing to move. | Guard covers **all four** moved bases via `MOVED_OPERATOR_CONSUMED`, not the runtime-reported subset. |
+| Impact: `apps/web-platform/infra/**` changes do not auto-apply | Confirmed, **plus** `apply-deploy-pipeline-fix.yml` (lines 239/254, same R2 state) is also wedged; this workflow's own SSH-apply step (525-536) would fail too (moot — plan step aborts first). `scheduled-terraform-drift.yml` (full plan, no `-target`, line 100) is **not** wedged and correctly surfaces the moves as drift — the 12h backstop works. | Note blast radius; one operator apply unwedges all targeted workflows at once. |
+| Extend the parity guard so moved endpoints must be in the `-target` set | Encoding "moved endpoint ⟹ must be in `-target`" would hard-code the *unsafe* fix as the required state. | Guard asserts each moved base ∈ (`allTargets` ∪ documented `MOVED_OPERATOR_CONSUMED`), failing only on an **unaccounted** moved block. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a production web-host reboot (or, worst case, a host replacement / a surprise web-2 provisioning) triggered by an *unrelated* infra PR merge — i.e. a mid-session outage of the Concierge/web-platform surface with no maintenance-window warning. This is exactly the failure mode the "reject the `-target` extension" decision prevents.
+
+**If this leaks, the user's workflow is exposed via:** N/A — no data surface; the exposure vector is availability (unattended reboot), not confidentiality.
+
+**Brand-survival threshold:** single-user incident — one operator whose live session dies on an unexpected host power-cycle is a brand-survival event. `requires_cpo_signoff: true`. CPO sign-off required at plan time before `/work` begins (Engineering/CTO review is complete; the product-owner ack is on the technical approach — reject the reboot-bearing `-target` edit). `user-impact-reviewer` runs at review time.
+
+## Hypotheses
+
+**Network-outage / SSH gate (plan Phase 1.4):** evaluated and **does not fire**. The failure is a Terraform *plan-time move-targeting* error, not an SSH/connectivity/handshake failure. The moved resources (`hcloud_server.web`, `hcloud_volume.workspaces`, `hcloud_volume_attachment.workspaces`) have no `provisioner`/`connection { ssh }` block in their own definitions (the SSH-provisioned `terraform_data.*` siblings are separate resources applied over the CF Tunnel bridge in a later, separate step). No L3→L7 firewall/egress diagnosis is in scope; the `hr-ssh-diagnosis-verify-firewall` checklist is not required here.
+
+## Implementation Phases
+
+### Phase 0 — Preconditions (verify before editing)
+1. `grep -n '^moved' apps/web-platform/infra/*.tf` — confirm the four `moved` bases and that they are the complete set (a future 5th block is exactly what the guard must catch).
+2. Confirm each of the four moved bases is present in `OPERATOR_APPLIED_EXCLUSIONS` in `plugins/soleur/test/terraform-target-parity.test.ts` (lines 370-423) — they are (`hcloud_server.web`, `hcloud_volume.workspaces`, `hcloud_volume_attachment.workspaces`, `hcloud_server_network.web`).
+3. Confirm the test runner: `plugins/soleur/test/*.ts` is `bun:test` (header line 48). Run the current suite green as a baseline: `bun test plugins/soleur/test/terraform-target-parity.test.ts`.
+4. Do NOT run `terraform plan/apply` from the agent (no prd_terraform creds / R2 state in-session). The migration dry-run/apply is an operator maintenance-window step (Phase 3).
+
+### Phase 1 — Extend the `moved`/`-target` parity guard (the recurrence fix)
+Edit `plugins/soleur/test/terraform-target-parity.test.ts` (add a new `describe` block; do not disturb the existing SSH and #5566 blocks):
+- Add a `parseMovedBlocks(stripped)` helper: match `moved\s*\{ … from = <addr> … to = <addr> … \}`, extract both endpoints, reduce each to its **base address** (strip a trailing `["…"]` index).
+- Add a documented `MOVED_OPERATOR_CONSUMED` set — the four #5877 bases, each with a one-line rationale mirroring `OPERATOR_APPLIED_EXCLUSIONS` discipline: *"consumed by the ADR-068 Phase-3 maintenance-window apply; a routine per-PR `-target` add would reboot/replace the running host — see #5887."*
+- Assert: every moved base ∈ (`allTargets` ∪ `MOVED_OPERATOR_CONSUMED`). Uncovered ⟹ fail.
+- Add a **non-vacuity / synthetic-forgotten-moved-block** test mirroring the existing `synthetic_untargeted_ssh` pattern (lines 278-333): a synthetic `moved` block whose base is in neither set must be flagged uncovered (proves the guard bites).
+- Add a **regression anchor**: assert the four #5877 bases are each in `MOVED_OPERATOR_CONSUMED` (so a later un-accounting fails loudly).
+- Comment the WHY: the existing #5566 test treats "in `OPERATOR_APPLIED_EXCLUSIONS`" as sufficient coverage, which is **orthogonal** to Terraform's plan-time move-processing requirement — hence a new `moved`-keyed dimension, not a tweak to the existing check.
+
+### Phase 2 — ADR-068 amendment + learning (capture the sequencing rule)
+- Amend `knowledge-base/engineering/architecture/decisions/ADR-068-*.md` (append an `> **Amendment (2026-07-02, #5887)**` note under the existing Phase-3 amendment section): record that a `moved` block re-addressing a resource in `OPERATOR_APPLIED_EXCLUSIONS` **wedges every targeted CI apply** until an operator full apply consumes it; such migrations must ship **with** the operator cutover, never as a routine `-target` allow-list edit. Do NOT change the ADR's `status:` (still `adopting`).
+- Write a learning `knowledge-base/project/learnings/<topic>.md` (author picks date at write-time; directory = `knowledge-base/project/learnings/` root or `bug-fixes/`): "a singleton→`for_each` `moved` migration on an operator-excluded resource red-lines target-scoped CI applies; unblock via operator cutover + a moved/`-target` guard, not an allow-list edit."
+
+### Phase 3 — Operator cutover runbook (post-merge, maintenance window)
+Author a `### Post-merge (operator)` runbook (below) for the Phase-3 migration apply. This clears the wedge. It is operator-gated (supervised prod reboot). Provide the canonical Doppler `tf-var` invocation triplet verbatim (per the drift-runbook Sharp Edge). Enroll a `follow-through` tracker so issue closure is gated on the apply succeeding (not on merge).
+
+## Files to Edit
+
+- `plugins/soleur/test/terraform-target-parity.test.ts` — add the `moved`/`-target` parity `describe` block + `MOVED_OPERATOR_CONSUMED` set + non-vacuity test (Phase 1).
+- `knowledge-base/engineering/architecture/decisions/ADR-068-multi-host-workspaces-shared-git-data-lease-coordinator.md` — append the #5887 sequencing amendment (Phase 2).
+
+## Files to Create
+
+- `knowledge-base/project/learnings/<topic>.md` — the sequencing-rule learning (Phase 2).
+- `knowledge-base/project/specs/feat-one-shot-5887-moved-target-allowlist/tasks.md` — task breakdown (generated by plan skill).
+- (operator, post-merge) no repo file — the migration is applied against live state; the runbook lives in this plan + the PR body.
+
+**Deliberately NOT edited:** `.github/workflows/apply-web-platform-infra.yml` — the `-target` allow-list is intentionally left unchanged (Risks §R1). The workflow self-heals once the operator cutover lands.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- [ ] `bun test plugins/soleur/test/terraform-target-parity.test.ts` passes with the new `moved`/`-target` block.
+- [ ] The new guard **fails** on a synthetic forgotten `moved` block (non-vacuity test asserts the uncovered base is flagged).
+- [ ] The four #5877 moved bases are each asserted present in `MOVED_OPERATOR_CONSUMED` (regression anchor).
+- [ ] `.github/workflows/apply-web-platform-infra.yml` diff is empty (no `-target` line added/removed) — verified by `git diff --stat` in the PR.
+- [ ] ADR-068 amendment present; `git grep -n '5887' knowledge-base/engineering/architecture/decisions/ADR-068-*.md` returns ≥1.
+- [ ] Learning file exists under `knowledge-base/project/learnings/`; `grep -rl 'moved' knowledge-base/project/learnings/ | head` includes it.
+- [ ] Full suite green: `bun test plugins/soleur/test/` (sweeps the sibling destroy-guard / parity suites the `-target` allow-list is asserted on — no other suite regresses).
+- [ ] PR body uses **`Ref #5887`** (NOT `Closes`) — the remediation completes in the post-merge operator apply, so auto-close on merge would produce a false-resolved state (`ops-remediation` class).
+
+### Post-merge (operator) — maintenance window
+- [ ] Operator runs a **dry-run** `terraform plan` (canonical invocation below) and confirms the plan is the expected Phase-3 cutover (`0 to destroy`; the only in-place change on `hcloud_server.web["web-1"]` is the placement-group attach; web-2 create iff `var.web_hosts` includes it). `Automation:` supervised prod reboot = human risk-acceptance judgment; the plan/apply itself is scriptable and provided as a copy-paste runbook (not a tooling gap).
+- [ ] Operator runs `terraform apply` in the maintenance window; confirms web-1 power-cycles and returns healthy; confirms `apply-web-platform-infra.yml` and `apply-deploy-pipeline-fix.yml` next runs are **green** (no pending moves).
+- [ ] `gh issue close 5887` after the apply succeeds (not before).
+- [ ] `follow-through` tracker verifies the two workflows are green post-apply.
+
+**Canonical operator invocation** (drift-runbook Sharp Edge — verbatim):
+```bash
+export AWS_ACCESS_KEY_ID=$(doppler secrets get AWS_ACCESS_KEY_ID -p soleur -c prd_terraform --plain)
+export AWS_SECRET_ACCESS_KEY=$(doppler secrets get AWS_SECRET_ACCESS_KEY -p soleur -c prd_terraform --plain)
+cd apps/web-platform/infra && terraform init -input=false
+# DRY-RUN first — confirm 0-destroy + expected cutover scope:
+doppler run -p soleur -c prd_terraform --name-transformer tf-var -- \
+  terraform plan -var="ssh_key_path=<pubkey>"
+# APPLY in the maintenance window (expect web-1 reboot):
+doppler run -p soleur -c prd_terraform --name-transformer tf-var -- \
+  terraform apply -var="ssh_key_path=<pubkey>"
+```
+
+## Open Code-Review Overlap
+
+None. `gh issue list --label code-review --state open` (61 open) — no open scope-out references `apply-web-platform-infra.yml`, `terraform-target-parity.test.ts`, or `placement-group.tf`.
+
+## Domain Review
+
+**Domains relevant:** Engineering (infra/CI). Product NONE (no UI-surface file in Files-to-Edit/Create — mechanical override does not fire). Legal/Finance/Sales/Marketing/Support/Ops: none.
+
+### Engineering (CTO)
+
+**Status:** reviewed
+**Assessment:** CTO assessment obtained and folded into this plan. Verdict table:
+
+| Option | Action | Verdict |
+|---|---|---|
+| 1 (recommended) | Operator Phase-3 maintenance-window full `terraform apply` consumes moves + PG attach; CI self-heals; no workflow edit | **Do** |
+| 2 | Add the (3 → transitively 4) bases to routine per-PR `-target` | **Reject** — unattended prod reboot, ADR-068 violation |
+| 3 (parallel) | `moved`-block guard in `terraform-target-parity.test.ts` (`MOVED_OPERATOR_CONSUMED` shape) | **Do** — prevents recurrence |
+
+Key CTO findings folded in: (a) Terraform move coverage is all-or-nothing (can't add the 2 safe bases and omit the reboot-bearing server); (b) targeting the server transitively drags in `hcloud_placement_group.web_spread`; (c) blast radius includes `apply-deploy-pipeline-fix.yml`; (d) guard must key on a new `moved` dimension (the #5566 exclusion check is orthogonal to plan-time move processing). No capability gaps.
+
+## Infrastructure (IaC)
+
+### Terraform changes
+No `.tf` files are edited. This plan changes **who applies** the Phase-3 moved migration (operator maintenance window) and adds a CI **guard** — it introduces no new resource, provider, or `TF_VAR_*`.
+
+### Apply path
+(c-variant: taint/replace-class → here, an operator maintenance-window apply) The singleton→`for_each` migration + placement-group attach is an **operator maintenance-window `terraform apply`** (supervised, expected web-1 power-off reboot; possible web-2 create per `var.web_hosts`). It is NOT routed through the per-PR auto-apply `-target` path, because that path is unattended and this change reboots the running host. Expected downtime: one web-1 reboot cycle within the operator's window. After the apply, no pending moves remain → the per-PR target-scoped plan self-heals with no workflow change.
+
+### Distinctness / drift safeguards
+`dev != prd`: this is prd (`prd_terraform`). The `moved` migration is 0-destroy **only if** web-1's `name`/`server_type`/`location` in `var.web_hosts` match current state (a location change force-REPLACES the live host — server.tf comment). The dry-run `terraform plan` MUST show `0 to destroy` before apply. `scheduled-terraform-drift.yml` (full plan) is the 12h backstop and is already surfacing this as drift (working as designed). State lands in the encrypted R2 backend (`use_lockfile = false` — the shared GHA concurrency group is the serializer, not relevant to an operator-local apply).
+
+### Vendor-tier reality check
+N/A — Hetzner placement groups are free (max 10 servers/group; ADR-068 Cost Impacts).
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: apply-web-platform-infra.yml + apply-deploy-pipeline-fix.yml run conclusion (green after operator cutover)
+  cadence: on every merge to main touching apps/web-platform/infra/** ; 12h drift cron backstop
+  alert_target: GitHub Actions run status (visible via `gh run list --workflow=apply-web-platform-infra.yml`); scheduled-terraform-drift.yml files an infra-drift issue
+  configured_in: .github/workflows/apply-web-platform-infra.yml, apply-deploy-pipeline-fix.yml, scheduled-terraform-drift.yml
+error_reporting:
+  destination: GitHub Actions job annotations (::error::) — the plan step already surfaces the terraform error loudly
+  fail_loud: true
+failure_modes:
+  - mode: a future singleton to for_each moved block re-addresses an operator-excluded resource and re-wedges targeted CI
+    detection: bun test plugins/soleur/test/terraform-target-parity.test.ts (new moved/-target block) FAILS at plan-review time
+    alert_route: CI required check on the PR (pre-merge, before the wedge reaches main)
+  - mode: operator cutover not yet run so workflows stay red
+    detection: gh run list shows failure; scheduled-terraform-drift.yml infra-drift issue
+    alert_route: follow-through tracker + infra-drift label
+logs:
+  where: GitHub Actions run logs (plan step); operator-local terraform plan/apply output during cutover
+  retention: GitHub default (90d)
+discoverability_test:
+  command: gh run list --workflow=apply-web-platform-infra.yml --limit 3
+  expected_output: post-cutover runs show success (pre-cutover show failure with the moved-targeting error)
+```
+
+### Soak follow-through enrollment
+Post-cutover close criterion (both workflows green) is time/action-gated on an operator apply → enroll a `follow-through` tracker with the `follow-through` label and a directive so #5887 closes only after the two workflows are observed green post-apply. Verification script (`scripts/followthroughs/<name>-5887.sh`): assert the most-recent `apply-web-platform-infra.yml` AND `apply-deploy-pipeline-fix.yml` runs on `main` are `success`.
+
+## Architecture Decision (ADR/C4)
+
+### ADR
+**Amend ADR-068** (do not create a new ADR; do not change `status: adopting`). Append `> **Amendment (2026-07-02, #5887)**`: a `moved` block that re-addresses a resource in `OPERATOR_APPLIED_EXCLUSIONS` wedges every target-scoped CI apply (`apply-web-platform-infra.yml`, `apply-deploy-pipeline-fix.yml`) until an operator full apply consumes the pending move; singleton→`for_each` migrations on operator-excluded hosts must ship **with** the operator cutover, never as a routine `-target` allow-list edit. This is an in-scope task of THIS plan (Phase 2), not a deferred follow-up.
+
+### C4 views
+**No C4 impact.** Checked all three model files (`model.c4`, `views.c4`, `spec.c4`). Enumeration:
+- **External human actors:** none added/changed (this is a CI-plumbing + operator-runbook change).
+- **External systems / vendors:** none added — Hetzner Cloud is already modeled (`model.c4:164` `hetzner = container "Compute"`, description already reads "Cluster of Hetzner Cloud hosts … spread placement (ADR-068)").
+- **Containers / data stores:** none added — the web-host cluster + placement spread is already in the `hetzner` container description; this change alters *which workflow applies* the hosts, not the topology.
+- **Access relationships:** none changed — no new actor↔surface edge.
+ADR-068 already recorded the multi-host C4 impact (its `## C4 impact` section, ADR-068:501). This fix does not add or move any C4 element.
+
+## Test Scenarios
+
+1. **Guard passes on current tree:** the four #5877 moved bases are covered by `MOVED_OPERATOR_CONSUMED` → suite green.
+2. **Guard fails on a forgotten moved block:** synthetic `moved { from = hcloud_foo.bar; to = hcloud_foo.bar["k"] }` with base in neither set → flagged uncovered (non-vacuity).
+3. **Guard permits a genuinely per-PR-targeted move:** a synthetic moved base that IS in `allTargets` → covered (does not false-fail).
+4. **No workflow drift:** `git diff .github/workflows/apply-web-platform-infra.yml` is empty.
+5. **Full suite:** `bun test plugins/soleur/test/` green (destroy-guard/parity siblings unaffected).
+
+## Risks & Mitigations
+
+- **R1 — Extending the per-PR `-target` allow-list (issue's literal ask) reboots prod.** `hcloud_server.web` carries `placement_group_id` (reboot on attach) + `for_each` (web-2 create); targeting it transitively creates `hcloud_placement_group.web_spread`. Destroy-guard does NOT catch an in-place reboot. **Mitigation:** reject the `-target` edit; unblock via operator cutover. This is the central decision.
+- **R2 — Operator cutover not run → workflows stay red.** Drift accumulates (issue's stated impact); the 12h drift cron is the backstop and is already surfacing it. **Mitigation:** `follow-through` tracker + `Ref #5887` (close only after apply).
+- **R3 — Cutover apply shows unexpected destroy/replace.** A `var.web_hosts` web-1 attribute drift (location/server_type) would force-replace the live host. **Mitigation:** mandatory dry-run showing `0 to destroy` before apply (server.tf comment + ADR-068 NFR-016).
+- **R4 — 4th moved block (`hcloud_server_network.web`) joins the pending set later.** When the operator provisions the Phase-2 private network, its move becomes pending. **Mitigation:** the operator full apply consumes it in the same cutover; the guard already accounts for it via `MOVED_OPERATOR_CONSUMED`.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty or placeholder fails `deepen-plan` Phase 4.6 — this one is filled (threshold `single-user incident`, `requires_cpo_signoff: true`).
+- Terraform `-target` move coverage is **all-or-nothing** — you cannot add the two safe bases (volume/attachment) and omit the reboot-bearing server; the error demands all three together. This is *why* the naive fix is unsafe (the server target is mandatory if you go that route).
+- The guard must NOT encode "moved endpoint ⟹ must be in `-target`" — that hard-codes the rejected fix as the required state. Key it on `allTargets ∪ MOVED_OPERATOR_CONSUMED`.
+- The learning filename must be date-picked at write-time (do not pin a date in tasks.md).
+
+## Deferral Tracking
+
+- The operator maintenance-window cutover is tracked via `Ref #5887` (stays open until applied) + a `follow-through` tracker — not a separate deferral issue (it IS the remediation, not out-of-scope).
+- No "Alternative Approaches / Non-Goals" items are deferred beyond the operator apply.

--- a/knowledge-base/project/specs/feat-one-shot-5887-moved-target-allowlist/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-5887-moved-target-allowlist/session-state.md
@@ -1,0 +1,26 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-02-fix-web-platform-infra-moved-target-allowlist-plan.md
+- Status: complete
+
+### Errors
+None. Two non-fatal write-hook interventions handled during planning: (1) IaC-routing gate fired on operator-apply framing — resolved with `iac-routing-ack: plan-phase-2-8-reviewed` opt-out + full `## Infrastructure (IaC)` section; (2) an initial full-file Write targeted the bare-root mirror — redirected to the correct worktree path.
+
+### Decisions
+- **Rejected the issue's literal ask** (extend the per-PR `-target=` allow-list). Verified against the tree: `hcloud_server.web` carries `placement_group_id` (server.tf:40) + `for_each = var.web_hosts` (server.tf:29); server.tf:38 states attaching the PG to the running host "forces a power-off → maintenance-window apply." Adding it to the routine auto-apply target set would reboot prod web-1 unattended on the next infra-PR merge — a `single-user incident` brand regression the destroy-guard is blind to (filter is delete-only + Cloudflare-scoped). CTO + architecture-strategist both confirmed sound, no P0.
+- **Root cause reframed as operator-action-pending sequencing**, not a forgotten allow-list entry. The four `moved{}` blocks (issue named 3; 4th is `hcloud_server_network.web`, a not-yet-in-state Phase-2 resource) are ADR-068 Phase-3 migration scaffolding. Correct unblock = operator maintenance-window full apply; targeted CI plan self-heals with zero workflow change (also unwedges `apply-deploy-pipeline-fix.yml`).
+- **Shippable now = code/test/docs-only:** extend `terraform-target-parity.test.ts` with a moved/`-target` parity guard (`MOVED_OPERATOR_CONSUMED` set + coverage/non-vacuity/drift-subset tests), amend ADR-068, write a learning pointer. Workflow `.yml` deliberately unchanged.
+- **Guard design reconciled across reviewers:** separate `MOVED_OPERATOR_CONSUMED` ledger (code-simplicity) + `⊆ OPERATOR_APPLIED_EXCLUSIONS` subset test (architecture P1 sync-drift); flat-regex parser; dropped the tautological regression-anchor.
+- Threshold `single-user incident`, `requires_cpo_signoff: true`; PR uses `Ref #5887` (not `Closes`) — remediation completes post-merge in the operator apply. `follow-through` tracker gates issue closure on both workflows going green.
+
+### Load-bearing facts verified by parent before /work
+- server.tf:29/38/40 reboot evidence — confirmed.
+- All 4 moved bases present in `OPERATOR_APPLIED_EXCLUSIONS` (test lines 371/373/374/387) — confirmed.
+- Runner `bun:test` (test line 50) — confirmed.
+- Scope clean: only plan + tasks files changed vs origin/main; workflow `.yml` untouched.
+
+### Components Invoked
+- Skills: soleur:plan, soleur:deepen-plan
+- Agents: soleur:engineering:cto (plan); architecture-strategist + code-simplicity-reviewer (deepen)
+- Deepen gates: 4.4 precedent-diff, 4.45 verify-the-negative, 4.5 network-outage, 4.6 user-brand-impact (pass), 4.7 observability (pass), 4.8 PAT-shape (clean), 4.9 UI-wireframe (n/a)

--- a/knowledge-base/project/specs/feat-one-shot-5887-moved-target-allowlist/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-5887-moved-target-allowlist/tasks.md
@@ -12,24 +12,25 @@ lane: cross-domain
 - [ ] 0.3 Baseline green: `bun test plugins/soleur/test/terraform-target-parity.test.ts`.
 - [ ] 0.4 Do NOT run terraform from the agent (no prd creds / R2 state in-session).
 
-## Phase 1 — moved/`-target` parity guard (recurrence fix)
-- [ ] 1.1 Add `parseMovedBlocks(stripped)` helper (extract `from`/`to`, reduce to base address, strip `["…"]`).
-- [ ] 1.2 Add documented `MOVED_OPERATOR_CONSUMED` set with the 4 #5877 bases + per-entry rationale (ADR-068 maintenance-window apply; #5887).
-- [ ] 1.3 Assert every moved base ∈ (`allTargets` ∪ `MOVED_OPERATOR_CONSUMED`); uncovered → fail.
-- [ ] 1.4 Add non-vacuity synthetic-forgotten-moved-block test (mirror `synthetic_untargeted_ssh`, lines 278-333).
-- [ ] 1.5 Add regression anchor: the 4 bases are each in `MOVED_OPERATOR_CONSUMED`.
-- [ ] 1.6 Comment WHY the #5566 exclusion check is orthogonal to plan-time move processing.
+## Phase 1 — moved/`-target` parity guard (recurrence fix) — minimal shape: 1 helper + 1 set + 3 tests
+- [ ] 1.1 Add `parseMovedBlocks(stripped)` helper — **flat regex** `/moved\s*\{[^}]*\}/g` (blocks are flat; no brace-matcher) + `from`/`to` captures, reduce to base address (strip `["…"]`).
+- [ ] 1.2 Add documented `MOVED_OPERATOR_CONSUMED` set with the 4 #5877 bases + per-entry rationale; add cross-ref comment on BOTH it and `OPERATOR_APPLIED_EXCLUSIONS` (dual-maintenance / lockstep-on-rename).
+- [ ] 1.3 Test 1 (coverage + regression anchor in one): every moved base ∈ (`allTargets` ∪ `MOVED_OPERATOR_CONSUMED`); uncovered → fail.
+- [ ] 1.4 Test 2 (non-vacuity): synthetic-forgotten-moved-block flagged uncovered (mirror `synthetic_untargeted_ssh`, lines 278-333).
+- [ ] 1.5 Test 3 (drift guard): assert `MOVED_OPERATOR_CONSUMED ⊆ OPERATOR_APPLIED_EXCLUSIONS` (closes sync-drift; replaces the cut tautological anchor).
+- [ ] 1.6 Comment WHY the #5566 exclusion check is orthogonal to plan-time move processing + the known-limitation note (accounting check, not interlock; repo not live state).
 - [ ] 1.7 `bun test plugins/soleur/test/terraform-target-parity.test.ts` green.
 
 ## Phase 2 — ADR amendment + learning
 - [ ] 2.1 Append `> **Amendment (2026-07-02, #5877/#5887)**` to ADR-068 (sequencing rule; do NOT change `status: adopting`).
-- [ ] 2.2 Write learning under `knowledge-base/project/learnings/` (date picked at write-time): moved-migration on operator-excluded resource wedges targeted CI; fix = operator cutover + guard, not allow-list edit.
+- [ ] 2.2 Write CONCISE learning under `knowledge-base/project/learnings/` (date picked at write-time) as a **pointer to the ADR amendment**, not a restatement.
 
 ## Phase 3 — Full suite + PR
 - [ ] 3.1 `bun test plugins/soleur/test/` green (no sibling suite regresses).
 - [ ] 3.2 Confirm `git diff .github/workflows/apply-web-platform-infra.yml` is EMPTY (no `-target` change).
 - [ ] 3.3 Open PR with `Ref #5887` (NOT `Closes`); labels `domain/engineering`, `priority/p1-high`; `semver:patch`; `## Changelog` section.
 - [ ] 3.4 Enroll `follow-through` tracker + `scripts/followthroughs/<name>-5887.sh` (both workflows green post-cutover).
+- [ ] 3.5 File deferred follow-up issue (`domain/engineering`, `priority/p2-medium`): reboot-aware destroy-guard for in-place `update` on `hcloud_server.*` reboot-forcing attrs (architecture review P2).
 
 ## Post-merge (operator — maintenance window; NOT agent-executed)
 - [ ] O.1 Dry-run `terraform plan` via canonical Doppler tf-var invocation; confirm `0 to destroy` + expected cutover scope.

--- a/knowledge-base/project/specs/feat-one-shot-5887-moved-target-allowlist/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-5887-moved-target-allowlist/tasks.md
@@ -30,7 +30,7 @@ lane: cross-domain
 - [x] 3.2 Confirm `git diff .github/workflows/apply-web-platform-infra.yml` is EMPTY (no `-target` change).
 - [ ] 3.3 Open PR with `Ref #5887` (NOT `Closes`); labels `domain/engineering`, `priority/p1-high`; `semver:patch`; `## Changelog` section.
 - [ ] 3.4 Enroll `follow-through` tracker + `scripts/followthroughs/<name>-5887.sh` (both workflows green post-cutover).
-- [ ] 3.5 File deferred follow-up issue (`domain/engineering`, `priority/p2-medium`): reboot-aware destroy-guard for in-place `update` on `hcloud_server.*` reboot-forcing attrs (architecture review P2).
+- [x] 3.5 File deferred follow-up issue (`domain/engineering`, `priority/p2-medium`): reboot-aware destroy-guard for in-place `update` on `hcloud_server.*` reboot-forcing attrs (architecture review P2).
 
 ## Post-merge (operator — maintenance window; NOT agent-executed)
 - [ ] O.1 Dry-run `terraform plan` via canonical Doppler tf-var invocation; confirm `0 to destroy` + expected cutover scope.

--- a/knowledge-base/project/specs/feat-one-shot-5887-moved-target-allowlist/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-5887-moved-target-allowlist/tasks.md
@@ -26,8 +26,8 @@ lane: cross-domain
 - [x] 2.2 Write CONCISE learning under `knowledge-base/project/learnings/` (date picked at write-time) as a **pointer to the ADR amendment**, not a restatement.
 
 ## Phase 3 — Full suite + PR
-- [ ] 3.1 `bun test plugins/soleur/test/` green (no sibling suite regresses).
-- [ ] 3.2 Confirm `git diff .github/workflows/apply-web-platform-infra.yml` is EMPTY (no `-target` change).
+- [x] 3.1 `bun test plugins/soleur/test/` green (no sibling suite regresses).
+- [x] 3.2 Confirm `git diff .github/workflows/apply-web-platform-infra.yml` is EMPTY (no `-target` change).
 - [ ] 3.3 Open PR with `Ref #5887` (NOT `Closes`); labels `domain/engineering`, `priority/p1-high`; `semver:patch`; `## Changelog` section.
 - [ ] 3.4 Enroll `follow-through` tracker + `scripts/followthroughs/<name>-5887.sh` (both workflows green post-cutover).
 - [ ] 3.5 File deferred follow-up issue (`domain/engineering`, `priority/p2-medium`): reboot-aware destroy-guard for in-place `update` on `hcloud_server.*` reboot-forcing attrs (architecture review P2).

--- a/knowledge-base/project/specs/feat-one-shot-5887-moved-target-allowlist/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-5887-moved-target-allowlist/tasks.md
@@ -22,8 +22,8 @@ lane: cross-domain
 - [x] 1.7 `bun test plugins/soleur/test/terraform-target-parity.test.ts` green.
 
 ## Phase 2 — ADR amendment + learning
-- [ ] 2.1 Append `> **Amendment (2026-07-02, #5877/#5887)**` to ADR-068 (sequencing rule; do NOT change `status: adopting`).
-- [ ] 2.2 Write CONCISE learning under `knowledge-base/project/learnings/` (date picked at write-time) as a **pointer to the ADR amendment**, not a restatement.
+- [x] 2.1 Append `> **Amendment (2026-07-02, #5877/#5887)**` to ADR-068 (sequencing rule; do NOT change `status: adopting`).
+- [x] 2.2 Write CONCISE learning under `knowledge-base/project/learnings/` (date picked at write-time) as a **pointer to the ADR amendment**, not a restatement.
 
 ## Phase 3 — Full suite + PR
 - [ ] 3.1 `bun test plugins/soleur/test/` green (no sibling suite regresses).

--- a/knowledge-base/project/specs/feat-one-shot-5887-moved-target-allowlist/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-5887-moved-target-allowlist/tasks.md
@@ -7,19 +7,19 @@ lane: cross-domain
 # Tasks — fix(infra) #5887 moved-block wedge + moved/`-target` guard
 
 ## Phase 0 — Preconditions
-- [ ] 0.1 `grep -n '^moved' apps/web-platform/infra/*.tf` — confirm 4 moved bases (server, volume, volume_attachment, server_network) are the complete set.
-- [ ] 0.2 Confirm all 4 bases are in `OPERATOR_APPLIED_EXCLUSIONS` (terraform-target-parity.test.ts:370-423).
-- [ ] 0.3 Baseline green: `bun test plugins/soleur/test/terraform-target-parity.test.ts`.
-- [ ] 0.4 Do NOT run terraform from the agent (no prd creds / R2 state in-session).
+- [x] 0.1 `grep -n '^moved' apps/web-platform/infra/*.tf` — confirm 4 moved bases (server, volume, volume_attachment, server_network) are the complete set.
+- [x] 0.2 Confirm all 4 bases are in `OPERATOR_APPLIED_EXCLUSIONS` (terraform-target-parity.test.ts:370-423).
+- [x] 0.3 Baseline green: `bun test plugins/soleur/test/terraform-target-parity.test.ts`.
+- [x] 0.4 Do NOT run terraform from the agent (no prd creds / R2 state in-session).
 
 ## Phase 1 — moved/`-target` parity guard (recurrence fix) — minimal shape: 1 helper + 1 set + 3 tests
-- [ ] 1.1 Add `parseMovedBlocks(stripped)` helper — **flat regex** `/moved\s*\{[^}]*\}/g` (blocks are flat; no brace-matcher) + `from`/`to` captures, reduce to base address (strip `["…"]`).
-- [ ] 1.2 Add documented `MOVED_OPERATOR_CONSUMED` set with the 4 #5877 bases + per-entry rationale; add cross-ref comment on BOTH it and `OPERATOR_APPLIED_EXCLUSIONS` (dual-maintenance / lockstep-on-rename).
-- [ ] 1.3 Test 1 (coverage + regression anchor in one): every moved base ∈ (`allTargets` ∪ `MOVED_OPERATOR_CONSUMED`); uncovered → fail.
-- [ ] 1.4 Test 2 (non-vacuity): synthetic-forgotten-moved-block flagged uncovered (mirror `synthetic_untargeted_ssh`, lines 278-333).
-- [ ] 1.5 Test 3 (drift guard): assert `MOVED_OPERATOR_CONSUMED ⊆ OPERATOR_APPLIED_EXCLUSIONS` (closes sync-drift; replaces the cut tautological anchor).
-- [ ] 1.6 Comment WHY the #5566 exclusion check is orthogonal to plan-time move processing + the known-limitation note (accounting check, not interlock; repo not live state).
-- [ ] 1.7 `bun test plugins/soleur/test/terraform-target-parity.test.ts` green.
+- [x] 1.1 Add `parseMovedBlocks(stripped)` helper — **flat regex** `/moved\s*\{[^}]*\}/g` (blocks are flat; no brace-matcher) + `from`/`to` captures, reduce to base address (strip `["…"]`).
+- [x] 1.2 Add documented `MOVED_OPERATOR_CONSUMED` set with the 4 #5877 bases + per-entry rationale; add cross-ref comment on BOTH it and `OPERATOR_APPLIED_EXCLUSIONS` (dual-maintenance / lockstep-on-rename).
+- [x] 1.3 Test 1 (coverage + regression anchor in one): every moved base ∈ (`allTargets` ∪ `MOVED_OPERATOR_CONSUMED`); uncovered → fail.
+- [x] 1.4 Test 2 (non-vacuity): synthetic-forgotten-moved-block flagged uncovered (mirror `synthetic_untargeted_ssh`, lines 278-333).
+- [x] 1.5 Test 3 (drift guard): assert `MOVED_OPERATOR_CONSUMED ⊆ OPERATOR_APPLIED_EXCLUSIONS` (closes sync-drift; replaces the cut tautological anchor).
+- [x] 1.6 Comment WHY the #5566 exclusion check is orthogonal to plan-time move processing + the known-limitation note (accounting check, not interlock; repo not live state).
+- [x] 1.7 `bun test plugins/soleur/test/terraform-target-parity.test.ts` green.
 
 ## Phase 2 — ADR amendment + learning
 - [ ] 2.1 Append `> **Amendment (2026-07-02, #5877/#5887)**` to ADR-068 (sequencing rule; do NOT change `status: adopting`).

--- a/knowledge-base/project/specs/feat-one-shot-5887-moved-target-allowlist/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-5887-moved-target-allowlist/tasks.md
@@ -1,0 +1,38 @@
+---
+plan: knowledge-base/project/plans/2026-07-02-fix-web-platform-infra-moved-target-allowlist-plan.md
+issue: 5887
+lane: cross-domain
+---
+
+# Tasks — fix(infra) #5887 moved-block wedge + moved/`-target` guard
+
+## Phase 0 — Preconditions
+- [ ] 0.1 `grep -n '^moved' apps/web-platform/infra/*.tf` — confirm 4 moved bases (server, volume, volume_attachment, server_network) are the complete set.
+- [ ] 0.2 Confirm all 4 bases are in `OPERATOR_APPLIED_EXCLUSIONS` (terraform-target-parity.test.ts:370-423).
+- [ ] 0.3 Baseline green: `bun test plugins/soleur/test/terraform-target-parity.test.ts`.
+- [ ] 0.4 Do NOT run terraform from the agent (no prd creds / R2 state in-session).
+
+## Phase 1 — moved/`-target` parity guard (recurrence fix)
+- [ ] 1.1 Add `parseMovedBlocks(stripped)` helper (extract `from`/`to`, reduce to base address, strip `["…"]`).
+- [ ] 1.2 Add documented `MOVED_OPERATOR_CONSUMED` set with the 4 #5877 bases + per-entry rationale (ADR-068 maintenance-window apply; #5887).
+- [ ] 1.3 Assert every moved base ∈ (`allTargets` ∪ `MOVED_OPERATOR_CONSUMED`); uncovered → fail.
+- [ ] 1.4 Add non-vacuity synthetic-forgotten-moved-block test (mirror `synthetic_untargeted_ssh`, lines 278-333).
+- [ ] 1.5 Add regression anchor: the 4 bases are each in `MOVED_OPERATOR_CONSUMED`.
+- [ ] 1.6 Comment WHY the #5566 exclusion check is orthogonal to plan-time move processing.
+- [ ] 1.7 `bun test plugins/soleur/test/terraform-target-parity.test.ts` green.
+
+## Phase 2 — ADR amendment + learning
+- [ ] 2.1 Append `> **Amendment (2026-07-02, #5877/#5887)**` to ADR-068 (sequencing rule; do NOT change `status: adopting`).
+- [ ] 2.2 Write learning under `knowledge-base/project/learnings/` (date picked at write-time): moved-migration on operator-excluded resource wedges targeted CI; fix = operator cutover + guard, not allow-list edit.
+
+## Phase 3 — Full suite + PR
+- [ ] 3.1 `bun test plugins/soleur/test/` green (no sibling suite regresses).
+- [ ] 3.2 Confirm `git diff .github/workflows/apply-web-platform-infra.yml` is EMPTY (no `-target` change).
+- [ ] 3.3 Open PR with `Ref #5887` (NOT `Closes`); labels `domain/engineering`, `priority/p1-high`; `semver:patch`; `## Changelog` section.
+- [ ] 3.4 Enroll `follow-through` tracker + `scripts/followthroughs/<name>-5887.sh` (both workflows green post-cutover).
+
+## Post-merge (operator — maintenance window; NOT agent-executed)
+- [ ] O.1 Dry-run `terraform plan` via canonical Doppler tf-var invocation; confirm `0 to destroy` + expected cutover scope.
+- [ ] O.2 `terraform apply` in maintenance window; confirm web-1 healthy after reboot.
+- [ ] O.3 Confirm `apply-web-platform-infra.yml` + `apply-deploy-pipeline-fix.yml` next runs green.
+- [ ] O.4 `gh issue close 5887` after apply succeeds.

--- a/plugins/soleur/test/terraform-target-parity.test.ts
+++ b/plugins/soleur/test/terraform-target-parity.test.ts
@@ -539,3 +539,122 @@ describe("concurrency-group + cloudflared-pin parity across the two workflows (#
     expect(wpi.cloudflaredSha256).toBe(dpf.cloudflaredSha256);
   });
 });
+
+// ─── `moved`-block / -target parity (#5887) ─────────────────────────────────
+// Terraform processes EVERY `moved {}` block on any plan/apply. Under a
+// target-scoped plan (`terraform plan -target=<addr>`, the shape both
+// apply-web-platform-infra.yml and apply-deploy-pipeline-fix.yml use), Terraform
+// REJECTS the plan if a pending `moved` source/target base address is excluded
+// from the `-target=` set:
+//     Error: Moved resource instances excluded by targeting
+// #5877 (ADR-068 Phase 3) added four `moved {}` blocks to placement-group.tf,
+// re-addressing the singleton web host + its volume/attachment/network to the
+// `["web-1"]` for_each key. That wedged the targeted CI plan RED on every run.
+//
+// The fix is NOT to add these bases to the per-PR `-target=` allow-list:
+// `hcloud_server.web` carries `placement_group_id` + `for_each = var.web_hosts`
+// (server.tf), so targeting it in the UNATTENDED per-PR path forces a power-off
+// reboot of the running prod host (and transitively creates the placement group
+// / a second host). They are consumed by the operator's ADR-068 Phase-3
+// MAINTENANCE-WINDOW apply, after which no pending moves remain and the targeted
+// CI plan self-heals with zero workflow change. This guard therefore asserts
+// every `moved` endpoint is EITHER `-target=`ed OR documented as operator-consumed
+// — it must NOT encode "moved endpoint ⟹ must be in -target" (that would hard-code
+// the rejected, reboot-bearing fix as the required state). See #5887 + the
+// ADR-068 §Amendment (#5887).
+
+/**
+ * Every `moved { from = <addr> to = <addr> }` endpoint reduced to its BASE
+ * resource address (a trailing `["key"]` for_each/index is dropped — the
+ * `[a-z0-9_]+\.[A-Za-z0-9_]+` capture stops at the word boundary before `[`).
+ * The four #5877 blocks are FLAT (no nested braces), so a flat
+ * `moved\s*\{[^}]*\}` match is sufficient — the depth-counting
+ * `extractTerraformDataResources` walker is not needed here.
+ */
+function extractMovedBases(stripped: string): string[] {
+  const bases = new Set<string>();
+  for (const block of stripped.match(/(?:^|\n)\s*moved\s*\{[^}]*\}/g) ?? []) {
+    for (const m of block.matchAll(
+      /\b(?:from|to)\s*=\s*([a-z0-9_]+\.[A-Za-z0-9_]+)/g,
+    )) {
+      bases.add(m[1]);
+    }
+  }
+  return [...bases];
+}
+
+// The four #5877 `moved` bases, consumed by the operator's ADR-068 Phase-3
+// maintenance-window apply (a routine per-PR `-target` add would reboot/replace
+// the running host — see #5887). The 4th (`hcloud_server_network.web`) is not in
+// the runtime error only because its Phase-2 resource is not yet in state → its
+// move is a no-op with nothing to move; the guard accounts for all four so a
+// future state-materialization does not re-wedge CI.
+//
+// DUAL-MAINTENANCE HAZARD: these four addresses also live in
+// OPERATOR_APPLIED_EXCLUSIONS above (they are operator-applied for the #5566
+// coverage guard too). The subset test below asserts the two hand-maintained
+// sets never diverge on a resource rename.
+const MOVED_OPERATOR_CONSUMED = new Set<string>([
+  "hcloud_server.web",
+  "hcloud_volume.workspaces",
+  "hcloud_volume_attachment.workspaces",
+  "hcloud_server_network.web",
+]);
+
+describe("terraform `moved`/-target parity — pending moves are accounted for (#5887)", () => {
+  let movedBases: string[];
+  let allTargets: Set<string>;
+
+  beforeAll(() => {
+    movedBases = listInfraTfFiles().flatMap((f) =>
+      extractMovedBases(stripComments(readFileSync(f, "utf8"))),
+    );
+    allTargets = new Set<string>([
+      ...extractAllTargets(readFileSync(WEB_PLATFORM_WORKFLOW, "utf8")),
+      ...extractAllTargets(readFileSync(DEPLOY_PIPELINE_FIX_WORKFLOW, "utf8")),
+    ]);
+  });
+
+  test("every `moved` endpoint base is `-target=`ed OR documented operator-consumed", () => {
+    expect(movedBases.length).toBeGreaterThan(0); // non-vacuity: the 4 #5877 bases
+    const uncovered = movedBases.filter(
+      (a) => !allTargets.has(a) && !MOVED_OPERATOR_CONSUMED.has(a),
+    );
+    // A non-empty list means a `moved {}` block re-addresses a resource that is
+    // NEITHER in the workflow `-target=` allow-list NOR classified as
+    // operator-consumed — i.e. it WEDGES every target-scoped CI apply with
+    // "Moved resource instances excluded by targeting" (the #5887 class). Fix:
+    // add a `-target=` line ONLY if the resource is safe to apply UNATTENDED
+    // per-PR; otherwise classify it into MOVED_OPERATOR_CONSUMED and ship the
+    // operator cutover WITH the migration. This test is also the regression
+    // anchor — dropping a #5877 base from MOVED_OPERATOR_CONSUMED turns it red
+    // (the base is not in allTargets), so no separate tautology test is added.
+    expect(uncovered).toEqual([]);
+  });
+
+  test("guard FAILS on a synthetic forgotten `moved` block (non-vacuity)", () => {
+    // Prove the guard bites: a moved block whose base is in NEITHER set is flagged.
+    const synthetic = `
+moved {
+  from = hcloud_foo.bar
+  to   = hcloud_foo.bar["k"]
+}
+`;
+    const parsed = extractMovedBases(stripComments(synthetic));
+    expect(parsed).toEqual(["hcloud_foo.bar"]); // base extracted, index stripped
+    const uncovered = parsed.filter(
+      (a) => !allTargets.has(a) && !MOVED_OPERATOR_CONSUMED.has(a),
+    );
+    expect(uncovered).toEqual(["hcloud_foo.bar"]);
+  });
+
+  test("MOVED_OPERATOR_CONSUMED is a subset of OPERATOR_APPLIED_EXCLUSIONS (dual-maintenance drift guard)", () => {
+    // Closes the sync-drift hazard: the four addresses live in two hand-maintained
+    // sets that must move in lockstep on a resource rename. Any moved-consumed base
+    // that is NOT also operator-excluded means the sets diverged.
+    const drifted = [...MOVED_OPERATOR_CONSUMED].filter(
+      (a) => !OPERATOR_APPLIED_EXCLUSIONS.has(a),
+    );
+    expect(drifted).toEqual([]);
+  });
+});

--- a/plugins/soleur/test/terraform-target-parity.test.ts
+++ b/plugins/soleur/test/terraform-target-parity.test.ts
@@ -616,7 +616,11 @@ describe("terraform `moved`/-target parity — pending moves are accounted for (
   });
 
   test("every `moved` endpoint base is `-target=`ed OR documented operator-consumed", () => {
-    expect(movedBases.length).toBeGreaterThan(0); // non-vacuity: the 4 #5877 bases
+    // non-vacuity: the 4 #5877 bases. NOTE: once the operator ADR-068 Phase-3
+    // cutover completes and the `moved {}` blocks are cleaned out of
+    // placement-group.tf, this assertion red-lines BY DESIGN — drop it (and
+    // MOVED_OPERATOR_CONSUMED) in that cleanup PR.
+    expect(movedBases.length).toBeGreaterThan(0);
     const uncovered = movedBases.filter(
       (a) => !allTargets.has(a) && !MOVED_OPERATOR_CONSUMED.has(a),
     );

--- a/scripts/followthroughs/moved-block-wedge-5887.sh
+++ b/scripts/followthroughs/moved-block-wedge-5887.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Follow-through verification for #5887 (the #5877 moved-block migration wedge).
+#
+# The four `moved {}` blocks #5877 added to placement-group.tf red-lined BOTH
+# target-scoped apply pipelines (apply-web-platform-infra.yml + apply-deploy-
+# pipeline-fix.yml). The wedge clears ONLY via the operator's ADR-068 Phase-3
+# maintenance-window `terraform apply`, which consumes the pending moves; the
+# workflow `.yml` is intentionally unchanged (adding hcloud_server.web to the
+# per-PR -target set would reboot the running prod host — see #5887 / ADR-068
+# §Amendment 2026-07-02). This probe closes #5887 once BOTH pipelines are green
+# on main again (i.e. the cutover has landed and the plans self-healed).
+#
+# Stateless read of the two workflows' most-recent COMPLETED run on main via the
+# GitHub Actions API — hr-no-dashboard-eyeball-pull-data-yourself compliant.
+#
+# Exit semantics (per scripts/sweep-followthroughs.sh contract):
+#   0 = PASS       (both pipelines' latest completed main run == success — cutover
+#                   landed; sweeper closes #5887)
+#   1 = FAIL       (one/both still red — the operator cutover has not been applied;
+#                   sweeper comments, leaves open)
+#   * = TRANSIENT  (no completed run yet / API error; sweeper retries next sweep)
+#
+# Required env (declared in the #5887 followthrough directive; GH_TOKEN is already
+# wired in scheduled-followthrough-sweeper.yml env:):
+#   GH_TOKEN
+
+set -uo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN must be set}"
+
+latest_completed_conclusion() {
+  # Most-recent COMPLETED run's conclusion for a workflow on main (empty if none
+  # completed yet). Returns non-zero on API failure so the caller can TRANSIENT.
+  gh run list --workflow "$1" --branch main --limit 5 \
+    --json conclusion,status \
+    --jq 'map(select(.status == "completed"))[0].conclusion // empty' 2>/dev/null
+}
+
+infra_concl=$(latest_completed_conclusion apply-web-platform-infra.yml) || {
+  echo "TRANSIENT: gh API error reading apply-web-platform-infra.yml" >&2; exit 2; }
+deploy_concl=$(latest_completed_conclusion apply-deploy-pipeline-fix.yml) || {
+  echo "TRANSIENT: gh API error reading apply-deploy-pipeline-fix.yml" >&2; exit 2; }
+
+if [[ -z "$infra_concl" || -z "$deploy_concl" ]]; then
+  echo "TRANSIENT: no completed run yet (infra='${infra_concl:-none}', deploy='${deploy_concl:-none}')" >&2
+  exit 2
+fi
+
+if [[ "$infra_concl" == "success" && "$deploy_concl" == "success" ]]; then
+  echo "PASS: both apply pipelines green on main — #5877 moved-block wedge cleared (operator cutover landed)."
+  exit 0
+fi
+
+echo "FAIL: apply-web-platform-infra=${infra_concl}, apply-deploy-pipeline-fix=${deploy_concl} — operator Phase-3 cutover not yet applied; both must be 'success'." >&2
+exit 1


### PR DESCRIPTION
## Summary

`apply-web-platform-infra.yml` **and** `apply-deploy-pipeline-fix.yml` have been red on every run since 2026-07-01 18:03: #5877 (ADR-068 Phase-3) added four `moved {}` blocks to `apps/web-platform/infra/placement-group.tf`, and Terraform rejects a target-scoped plan when a pending `moved` base is excluded from the `-target=` set (`Error: Moved resource instances excluded by targeting`).

**This PR rejects the issue's literal proposed fix** (extend the per-PR `-target=` allow-list). CTO + architecture-strategist confirmed: `hcloud_server.web` carries `placement_group_id` + `for_each = var.web_hosts` (`server.tf`), so adding it to the *unattended* per-PR target set would force a **power-off reboot of the running prod web host** (and transitively create the placement group / a second host). The `delete`-only, Cloudflare-scoped destroy-guard is blind to that in-place reboot.

So the workflow `.yml` files are **deliberately unchanged**. This PR ships the **recurrence guard + docs**; the wedge itself clears via the operator Phase-3 maintenance-window `terraform apply` (tracked in #5887 — hence `Ref`, not `Closes`).

Ref #5887

## Why this is p1 (gates #5875)

The wedge hits **both** targeted apply pipelines. `apply-deploy-pipeline-fix.yml` is the delivery path for every host-side deploy-orchestration change (`ci-deploy.sh`, `webhook.service`, canary scripts). While it is red: **PR2's canary is inert in prod, PR3 is blocked, and any host-script change silently does not reach the host.** One operator cutover apply unwedges both pipelines. #5887 re-scoped to `priority/p1-high` + `type/bug`.

## What ships here vs. what unblocks

| Ships in this PR (safe, code/test/docs-only) | Clears the wedge (operator, tracked in #5887) |
|---|---|
| `moved`/`-target` parity guard — reads **both** workflows' target sets; a future migration re-addressing an operator-excluded resource fails at plan-review time | Phase-3 maintenance-window `terraform apply` consumes the 4 pending moves + performs the supervised placement-group attach |
| ADR-068 §Amendment (sequencing rule) + pointer learning | After apply: **both** CI plans self-heal with zero workflow change |
| Workflow `.yml` deliberately unchanged | Post-cutover: canary verdict reappears on `/hooks/deploy-status` |

## Changelog

### Test / CI guard
- `terraform-target-parity.test.ts`: new `moved`/`-target` parity block — `extractMovedBases()` helper, `MOVED_OPERATOR_CONSUMED` set (the 4 #5877 bases), a coverage test (regression anchor), a non-vacuity test, and a `MOVED_OPERATOR_CONSUMED ⊆ OPERATOR_APPLIED_EXCLUSIONS` dual-maintenance drift guard. Covers both `apply-web-platform-infra.yml` and `apply-deploy-pipeline-fix.yml`.

### Docs
- ADR-068 amendment: a `moved` block on an operator-excluded resource wedges every target-scoped CI apply until the operator cutover consumes it; such migrations ship *with* the cutover, never as a routine `-target` edit.
- Learning: concise pointer to the ADR amendment.

## Follow-up

- Tracks #5911 — reboot-aware destroy-guard for in-place `update` on `hcloud_server.*` (architecture P2; the parity guard is an accounting check, not a mechanical interlock).

## Test plan

- [x] `bun test terraform-target-parity.test.ts` — 19/19 pass
- [x] Mutation-verified: dropping a #5877 base from `MOVED_OPERATOR_CONSUMED` turns the coverage test red
- [x] Full `plugins/soleur/` bun suite — 1907 pass, 0 fail
- [x] `git diff` of `apply-web-platform-infra.yml` + `apps/web-platform/infra/**` is empty (no `-target` change)
- Post-cutover (operator) is tracked by #5887's follow-through sweeper enrollment (`scripts/followthroughs/moved-block-wedge-5887.sh`, landed here): it auto-resolves issue #5887 once **both** `apply-web-platform-infra.yml` and `apply-deploy-pipeline-fix.yml` are green on `main` again. The canary verdict on `/hooks/deploy-status` returns as a consequence (PR2 canary live again).

Generated with [Claude Code](https://claude.com/claude-code)
