### PR TITLE
fix(hooks): add hookEventName to SessionStart rules-loader output

### DIFF
--- a/.claude/hooks/hookeventname-coverage.test.sh
+++ b/.claude/hooks/hookeventname-coverage.test.sh
@@ -33,6 +33,19 @@ for h in "$HOOK_DIR"/*.sh; do
   pd=$(grep -vE '^[[:space:]]*#' "$h" | grep -cE 'permissionDecision"?[[:space:]]*:' || true)
   hen=$(grep -vE '^[[:space:]]*#' "$h" | grep -c 'hookEventName' || true)
 
+  # Same contract on the OTHER side: a SessionStart/UserPromptSubmit hook that
+  # emits `additionalContext` inside hookSpecificOutput must pair it with
+  # hookEventName, or Claude Code rejects the output ("hookSpecificOutput is
+  # missing required field hookEventName") and the injected context is dropped.
+  # This is the SessionStart analogue of the permissionDecision bug above —
+  # regressed once in session-rules-loader.sh, hence this guard.
+  ac=$(grep -vE '^[[:space:]]*#' "$h" | grep -cE 'additionalContext"?[[:space:]]*:' || true)
+  if [[ "$ac" -gt 0 && "$hen" -lt "$ac" ]]; then
+    echo "FAIL: $base emits $ac additionalContext(s) but only $hen hookEventName(s)."
+    echo "      Every hookSpecificOutput with additionalContext must include hookEventName (e.g. \"SessionStart\")."
+    fail=1
+  fi
+
   # Per-file count check (count(hookEventName) >= count(permissionDecision)),
   # not per-emission pairing. This catches the realistic regression — a new
   # decision block added without hookEventName bumps `pd` without `hen` and

--- a/.claude/hooks/session-rules-loader.sh
+++ b/.claude/hooks/session-rules-loader.sh
@@ -49,7 +49,7 @@ emit_core_only_fallback() {
   if [[ -r "$root/AGENTS.core.md" ]]; then
     fb="$(<"$root/AGENTS.core.md")"
   fi
-  printf '%s' "{\"hookSpecificOutput\":{\"additionalContext\":$(jq -Rs . <<<"[rules-loader] FALLBACK ($reason): loaded AGENTS.core.md only"$'\n'"$fb")}}"
+  printf '%s' "{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":$(jq -Rs . <<<"[rules-loader] FALLBACK ($reason): loaded AGENTS.core.md only"$'\n'"$fb")}}"
 }
 
 INPUT=$(cat 2>/dev/null || true)
@@ -271,5 +271,5 @@ jq -nc \
 # operator-glanceable header (STAMP/HINT/manifest, lines 1-3, which Test 11
 # byte-budgets via `head -3`) and before the rule bodies.
 OUT_BODY="${STAMP}"$'\n'"${HINT}"$'\n'"[rules-loader] manifest: ${MANIFEST}"$'\n'"${SESSION_CONTEXT}"$'\n'"${CONTEXT}"
-jq -nc --arg out "$OUT_BODY" '{ hookSpecificOutput: { additionalContext: $out } }'
+jq -nc --arg out "$OUT_BODY" '{ hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: $out } }'
 exit 0


### PR DESCRIPTION
## Problem

The `SessionStart` hook `session-rules-loader.sh` emitted `hookSpecificOutput` **without** the required `hookEventName` field. Claude Code rejected the output with:

> Hook JSON output validation failed — hookSpecificOutput is missing required field "hookEventName"

The consequence: the change-class-aware AGENTS.md rule bodies were never injected at session start (agent boots bodyless / on the fallback path).

## Fix

- Add `hookEventName: "SessionStart"` to **both** emission sites in `session-rules-loader.sh`:
  - the main output envelope (`jq -nc …`)
  - the `emit_core_only_fallback` path
- Extend `hookeventname-coverage.test.sh` to also guard the `additionalContext` ↔ `hookEventName` pairing. Previously it only checked the `permissionDecision` side of the contract, so this regression slipped through the exact meta-test designed to prevent this bug class (same violation as the earlier hook-deny-enforcement fix, different field/event).

## Verification

- `bash .claude/hooks/hookeventname-coverage.test.sh` → PASS
- Both output paths verified to emit valid JSON with `hookEventName == "SessionStart"` and non-empty `additionalContext` (main + fail-closed fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)