### PR TITLE
test(observability): live semantic/atomicity test for check_and_record_byok_delegation_use

### DIFF
--- a/apps/web-platform/test/server/byok-delegation.atomicity.tenant-isolation.test.ts
+++ b/apps/web-platform/test/server/byok-delegation.atomicity.tenant-isolation.test.ts
@@ -241,11 +241,13 @@ describe.skipIf(!INTEGRATION_ENABLED)(
         CAP_CENTS % COST_CENTS,
         "CAP_CENTS must be an exact multiple of COST_CENTS",
       ).toBe(0);
+      // N must exceed K, else Test C's `tripped === N - K` expects ≤0 trips and
+      // the concurrency test proves nothing (localized guard, like the multiple
+      // check above, so a future tuner fails fast rather than silently).
+      expect(N, "N must exceed K for Test C to exercise the cap boundary").toBeGreaterThan(K);
 
       const url = requireEnv("SUPABASE_URL");
-      requireEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY");
       const serviceRoleKey = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
-      requireEnv("SUPABASE_JWT_SECRET");
 
       service = createClient(url, serviceRoleKey, {
         auth: { persistSession: false, autoRefreshToken: false },
@@ -428,7 +430,12 @@ describe.skipIf(!INTEGRATION_ENABLED)(
       async () => {
         // Hourly cap = CAP_CENTS; daily at the ceiling. Fan out N concurrent
         // uses (each a distinct invocation_id). Concurrency is client-side;
-        // serialization is DB-side via the row `FOR UPDATE` at 084:370.
+        // serialization is DB-side via the row `FOR UPDATE` at 084:370. The
+        // no-double-spend proof requires the N fetches to genuinely overlap in
+        // the DB — on a cold/contended pooler, transport-layer serialization
+        // could mask a dropped lock. This is an accepted limitation inherited
+        // from the b020ebecf precedent; the self-diagnosis banner surfaces any
+        // breach that does occur.
         const { delegationId, grantee } = await grantDelegation(
           CAP_CENTS,
           DAILY_CEILING,
@@ -460,7 +467,9 @@ describe.skipIf(!INTEGRATION_ENABLED)(
         // same pre-INSERT SUM snapshot would each pass the cap check and INSERT
         // → `> K` audit rows and spend `> cap` (double-spend). With FOR UPDATE
         // serializing the read+INSERT critical section, exactly K are admitted.
+        const allFulfilled = settled.every((r) => r.status === "fulfilled");
         const willFail =
+          !allFulfilled ||
           admitted !== K ||
           tripped !== N - K ||
           audit.length !== K ||
@@ -469,10 +478,7 @@ describe.skipIf(!INTEGRATION_ENABLED)(
           ? diagBanner(await fetchLiveDelegationRpcBody())
           : "";
 
-        expect(
-          settled.every((r) => r.status === "fulfilled"),
-          `all ${N} calls settled fulfilled${diag}`,
-        ).toBe(true);
+        expect(allFulfilled, `all ${N} calls settled fulfilled${diag}`).toBe(true);
         expect(admitted, `exactly K=${K} calls admitted${diag}`).toBe(K);
         expect(tripped, `exactly N−K=${N - K} calls raise the hourly marker${diag}`).toBe(
           N - K,

--- a/apps/web-platform/test/server/byok-delegation.atomicity.tenant-isolation.test.ts
+++ b/apps/web-platform/test/server/byok-delegation.atomicity.tenant-isolation.test.ts
@@ -1,0 +1,489 @@
+/**
+ * check_and_record_byok_delegation_use atomicity — DB-layer integration test
+ * (#5938, Ref #5920).
+ *
+ * Pins the delegation cap RPC's *semantic* invariants that the #5920
+ * dev-migration-drift body-marker probe cannot: marker presence
+ * (`byok_delegations:hourly_cap_exceeded` / `daily_cap_exceeded` + the row
+ * `FOR UPDATE`) is necessary-not-sufficient — a future RV rewrite could keep
+ * the RAISE strings while flipping the strict `>` comparison to `>=`, dropping
+ * the `FOR UPDATE` lock, or miscomputing the rolling cap SUM. This test is the
+ * live-DB semantic authority for `check_and_record_byok_delegation_use`
+ * (migration 084_byok_delegation_withdrawals.sql §7, cap checks at 449 / 463,
+ * `FOR UPDATE` at 370).
+ *
+ * Scope split (see plan Research Reconciliation):
+ *   - The cap-RPC precedent this mirrors is
+ *     `byok-kill-switch.atomicity.tenant-isolation.test.ts` (#5920 / b020ebecf,
+ *     Invariant C — the self-diagnosing FOR-UPDATE concurrency proof).
+ *   - An EXISTING partial hourly test already proves the hourly RAISE loosely
+ *     (`byok-delegations.tenant-isolation.test.ts:537` — cost 4 then cost 2 → 6
+ *     > 5; the `== cap` call is never exercised, sequential-only, no
+ *     self-diagnosis). This file does NOT duplicate it; it adds the genuine
+ *     delta: strict-`>` boundary precision (a call landing *exactly at cap*
+ *     passes, `+1` over trips) for BOTH hourly and daily, `daily_cap_exceeded`
+ *     marker coverage (via aged-seed isolation), and the concurrent
+ *     FOR-UPDATE / no-TOCTOU-double-spend proof.
+ *
+ * Load-bearing difference from the cap RPC (do NOT transfer its Invariant D):
+ * `record_byok_use_and_check_cap` returns a `kill_tripped` signal row and
+ * ALWAYS inserts an audit row (→ N audit rows). This RPC **throws** P0001 on a
+ * cap breach and inserts ONLY on the pass path (084:449-454 / 463-468 RAISE
+ * with no preceding INSERT), so the double-spend invariant is `audit == K`
+ * (admitted calls only), NOT `N`.
+ *
+ * Filename: `.tenant-isolation.test.ts` suffix is load-bearing for the path
+ * filter at `.github/workflows/tenant-integration.yml` — without it the heavy
+ * suite never fires on this file's own PR and the test silently never runs live.
+ *
+ * Opt-in via TENANT_INTEGRATION_TEST=1. Requires `doppler run -p soleur -c dev`.
+ *
+ *   cd apps/web-platform && \
+ *     doppler run -p soleur -c dev -- \
+ *     env TENANT_INTEGRATION_TEST=1 \
+ *     npm run test:ci -- test/server/byok-delegation.atomicity.tenant-isolation.test.ts --project unit
+ *
+ * Synthesized fixtures only (cq-test-fixtures-synthesized-only). WORM-protected
+ * rows accumulate as orphan rows per the closed-preview acceptance pattern
+ * (mirrors the byok-kill-switch + byok-delegations precedents; long-running CI
+ * adopts the synthetic-fixture sweeper deferred-scope-out #3934 — no duplicate
+ * scope-out filed).
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import postgres from "postgres";
+import { randomBytes, randomUUID } from "node:crypto";
+
+const INTEGRATION_ENABLED = process.env.TENANT_INTEGRATION_TEST === "1";
+
+const SYNTHETIC_EMAIL_PATTERN = /^tenant-isolation-[a-f0-9]{16}@soleur\.test$/;
+
+function syntheticEmail(): string {
+  return `tenant-isolation-${randomBytes(8).toString("hex")}@soleur.test`;
+}
+
+function assertSynthetic(email: string): void {
+  if (!SYNTHETIC_EMAIL_PATTERN.test(email)) {
+    throw new Error(
+      `Refusing to touch non-synthetic email "${email}" — this test only ` +
+        "manipulates tenant-isolation-*@soleur.test accounts.",
+    );
+  }
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`[byok-delegation-atomicity] ${name} is required`);
+  return value;
+}
+
+// Cost/cap constants tuned together — changing one without the others breaks
+// the boundary arithmetic (see plan Phase 1). The cap MUST be an exact multiple
+// of the per-call cost; otherwise the `== cap` boundary call lands at a
+// cumulative value the strict-`>` proof never exercises. Enforced via
+// `expect(CAP_CENTS % COST_CENTS).toBe(0)` in beforeAll.
+const COST_CENTS = 100; // p_token_count=10 × p_unit_cost_cents=10
+const CAP_CENTS = 500;
+const N = 10;
+const K = CAP_CENTS / COST_CENTS; // = 5 calls admitted before the boundary trips
+
+const DAILY_CEILING = 1_000_000; // table CHECK upper bound; "never trips" sentinel
+
+// Per-call RPC token args producing exactly COST_CENTS.
+const TOKEN_COUNT = 10;
+const UNIT_COST_CENTS = 10;
+
+interface SyntheticUser {
+  id: string;
+  email: string;
+  workspaceId: string;
+}
+
+describe.skipIf(!INTEGRATION_ENABLED)(
+  "check_and_record_byok_delegation_use atomicity (integration)",
+  () => {
+    let service: SupabaseClient;
+    // Direct pg connection (porsager) used ONLY to self-diagnose a failure by
+    // embedding the live pg_get_functiondef body in the failure message
+    // (#5920). Dev-only, same credential class as the service_role usage
+    // (DATABASE_URL_POOLER, present in the dev doppler env this test runs
+    // under). Never touched on a green run.
+    let sql: ReturnType<typeof postgres> | null = null;
+    let grantor: SyntheticUser;
+
+    async function createSyntheticUser(): Promise<SyntheticUser> {
+      const email = syntheticEmail();
+      assertSynthetic(email);
+      const { data, error } = await service.auth.admin.createUser({
+        email,
+        password: randomBytes(16).toString("hex"),
+        email_confirm: true,
+      });
+      expect(error, `createUser(${email}) failed`).toBeNull();
+      const id = data.user?.id ?? "";
+      expect(id).toBeTruthy();
+
+      // handle_new_user (mig 053 §1.1.8) auto-creates a workspace +
+      // workspace_members row for solo users. Read back the workspace_id so
+      // grants target the correct workspace.
+      const { data: wm, error: wmErr } = await service
+        .from("workspace_members")
+        .select("workspace_id")
+        .eq("user_id", id)
+        .limit(1)
+        .maybeSingle();
+      expect(wmErr, `workspace_members lookup for ${email}`).toBeNull();
+      expect(wm?.workspace_id, `workspace_id for ${email}`).toBeTruthy();
+
+      return { id, email, workspaceId: wm!.workspace_id as string };
+    }
+
+    async function addMember(workspaceId: string, userId: string): Promise<void> {
+      // service-role bypasses RLS. workspace_members.role is NOT NULL CHECK IN
+      // ('owner','member') per mig 053; 'member' is the canonical non-creator
+      // role.
+      const { error } = await service
+        .from("workspace_members")
+        .insert({ workspace_id: workspaceId, user_id: userId, role: "member" });
+      expect(error, `addMember(${userId} → ${workspaceId})`).toBeNull();
+    }
+
+    // Create a FRESH grantee + a fresh delegation from `grantor` for each test.
+    // A fresh grantee per test sidesteps the partial-unique on
+    // (grantor, grantee, workspace) WHERE revoked_at IS NULL, and a distinct
+    // delegation_id isolates each test's per-delegation cap SUM. NO acceptance
+    // or withdrawal rows are seeded: the RPC's per-turn consent re-gate
+    // (084:404) fires ONLY when a withdrawal exists, and check_and_record does
+    // not call the resolver — so zero withdrawals = re-gate is a no-op.
+    async function grantDelegation(
+      hourlyCapCents: number,
+      dailyCapCents: number,
+    ): Promise<{ delegationId: string; grantee: SyntheticUser }> {
+      const grantee = await createSyntheticUser();
+      await addMember(grantor.workspaceId, grantee.id);
+      const { data, error } = await service.rpc("grant_byok_delegation", {
+        p_grantor_user_id: grantor.id,
+        p_grantee_user_id: grantee.id,
+        p_workspace_id: grantor.workspaceId,
+        p_daily_usd_cap_cents: dailyCapCents,
+        p_hourly_usd_cap_cents: hourlyCapCents,
+        p_expires_at: null,
+        p_actor_user_id: grantor.id,
+      });
+      expect(error, "grant_byok_delegation").toBeNull();
+      const delegationId = data as unknown as string;
+      expect(delegationId, "delegation id returned").toBeTruthy();
+      return { delegationId, grantee };
+    }
+
+    // One RPC use at exactly COST_CENTS. supabase-js .rpc() resolves *fulfilled*
+    // with { data, error } even on a P0001 RAISE (it does not reject) — the
+    // pass/fail split lives in `.error`.
+    function recordUse(delegationId: string, callerUserId: string, role: string) {
+      return service.rpc("check_and_record_byok_delegation_use", {
+        p_delegation_id: delegationId,
+        p_invocation_id: randomUUID(),
+        p_token_count: TOKEN_COUNT,
+        p_unit_cost_cents: UNIT_COST_CENTS,
+        p_caller_user_id: callerUserId,
+        p_agent_role: role,
+      });
+    }
+
+    // Fetch the live delegation-RPC body for a failure message. Guarded so a
+    // fetch error NEVER masks the real assertion (returns a fallback string,
+    // never throws). Signature matches migration 084:344-351 + REVOKE 084:482.
+    async function fetchLiveDelegationRpcBody(): Promise<string> {
+      if (!sql) {
+        return "(live body unavailable: DATABASE_URL_POOLER unset)";
+      }
+      try {
+        const rows = await sql<Array<{ def: string | null }>>`
+          SELECT pg_get_functiondef(
+            'public.check_and_record_byok_delegation_use(uuid,uuid,int,int,uuid,text)'::regprocedure
+          ) AS def`;
+        return rows[0]?.def ?? "(live body unavailable: no rows)";
+      } catch (e) {
+        return `(live body fetch failed: ${
+          e instanceof Error ? e.message : String(e)
+        })`;
+      }
+    }
+
+    function diagBanner(body: string): string {
+      return (
+        "\n\n--- live pg_get_functiondef(public.check_and_record_byok_delegation_use) " +
+        `— drift self-diagnosis (#5938) ---\n${body}`
+      );
+    }
+
+    // audit_byok_use rows for this delegation: id + spend contribution.
+    async function auditRowsFor(
+      delegationId: string,
+    ): Promise<Array<{ token_count: number; unit_cost_cents: number }>> {
+      const { data, error } = await service
+        .from("audit_byok_use")
+        .select("token_count, unit_cost_cents")
+        .eq("delegation_id", delegationId);
+      expect(error, "audit_byok_use count").toBeNull();
+      return (data ?? []) as Array<{
+        token_count: number;
+        unit_cost_cents: number;
+      }>;
+    }
+
+    beforeAll(async () => {
+      // Constants integrity — a future tuner that breaks
+      // CAP_CENTS-is-multiple-of-COST_CENTS gets an immediate localized failure
+      // rather than a confused boundary mismatch (mirrors the cap test).
+      expect(
+        CAP_CENTS % COST_CENTS,
+        "CAP_CENTS must be an exact multiple of COST_CENTS",
+      ).toBe(0);
+
+      const url = requireEnv("SUPABASE_URL");
+      requireEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY");
+      const serviceRoleKey = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
+      requireEnv("SUPABASE_JWT_SECRET");
+
+      service = createClient(url, serviceRoleKey, {
+        auth: { persistSession: false, autoRefreshToken: false },
+      });
+
+      // Open the diagnostic pg connection if the pooler URL is available.
+      // Optional: the failure-path fetch guards on `sql === null`. The Supabase
+      // pooler presents a self-signed CA chain, so `rejectUnauthorized: false`
+      // (dev-only, mirrors run-migrations.sh `sslmode=require`; no committed
+      // code disables TLS verify on a prod runtime surface).
+      const poolerUrl = process.env.DATABASE_URL_POOLER;
+      if (poolerUrl) {
+        sql = postgres(poolerUrl, {
+          max: 1,
+          idle_timeout: 5,
+          ssl: { rejectUnauthorized: false },
+        });
+      }
+
+      grantor = await createSyntheticUser();
+    }, 60_000);
+
+    afterAll(async () => {
+      // audit_byok_use + byok_delegations rows for synthetic users are
+      // WORM-protected (UPDATE/DELETE raises P0001) and identity FKs are ON
+      // DELETE RESTRICT, so auth.admin.deleteUser would 23503 with this run's
+      // rows present. Per-run isolation is guaranteed by the per-run
+      // randomBytes-derived email, not by row cleanup (orphan-row acceptance,
+      // deferred sweeper #3934 — no duplicate scope-out).
+      if (sql) await sql.end({ timeout: 5 });
+    }, 30_000);
+
+    test(
+      "Test A — hourly strict-`>` boundary: `== cap` passes, `+1` trips (sequential)",
+      async () => {
+        // Hourly cap = CAP_CENTS; daily set to the ceiling so it never trips.
+        const { delegationId, grantee } = await grantDelegation(
+          CAP_CENTS,
+          DAILY_CEILING,
+        );
+
+        // Calls 1..K at COST_CENTS each: cumulative 100…500. Every one —
+        // INCLUDING call K where cumulative reaches EXACTLY CAP_CENTS — must
+        // pass. Call K is the load-bearing strict-`>` proof: a `>=` regression
+        // would make it raise.
+        const okErrors: Array<unknown> = [];
+        for (let i = 0; i < K; i++) {
+          const { error } = await recordUse(
+            delegationId,
+            grantee.id,
+            "test-hourly-boundary",
+          );
+          okErrors.push(error);
+        }
+
+        // Call K+1 would reach CAP_CENTS + COST_CENTS (= 600) > cap → RAISE.
+        const overCap = await recordUse(
+          delegationId,
+          grantee.id,
+          "test-hourly-boundary",
+        );
+
+        const audit = await auditRowsFor(delegationId);
+
+        const capCall = okErrors[K - 1]; // the `== cap` call
+        const willFail =
+          okErrors.some((e) => e !== null) ||
+          overCap.error === null ||
+          !/byok_delegations:hourly_cap_exceeded/.test(
+            overCap.error?.message ?? "",
+          ) ||
+          audit.length !== K;
+        const diag = willFail
+          ? diagBanner(await fetchLiveDelegationRpcBody())
+          : "";
+
+        okErrors.forEach((error, i) => {
+          expect(error, `call ${i + 1} (cumulative ${(i + 1) * COST_CENTS}) passes${diag}`).toBeNull();
+        });
+        expect(
+          capCall,
+          `the == cap call K (cumulative ${CAP_CENTS}) passes — strict-\`>\` proof${diag}`,
+        ).toBeNull();
+        expect(
+          overCap.error,
+          `call K+1 (would reach ${CAP_CENTS + COST_CENTS}) trips${diag}`,
+        ).not.toBeNull();
+        expect(overCap.error?.message, `hourly marker${diag}`).toMatch(
+          /byok_delegations:hourly_cap_exceeded/,
+        );
+        // The RAISE path writes no audit row for the over-cap call → K rows.
+        expect(audit.length, `audit count == K (admitted only)${diag}`).toBe(K);
+      },
+      60_000,
+    );
+
+    test(
+      "Test B — daily strict-`>` boundary via aged-seed isolation (sequential)",
+      async () => {
+        // hourly == daily == CAP_CENTS (the table CHECK forces hourly ≤ daily).
+        const { delegationId, grantee } = await grantDelegation(
+          CAP_CENTS,
+          CAP_CENTS,
+        );
+
+        // Pre-seed aged audit rows summing to CAP_CENTS − COST_CENTS (= 400)
+        // with ts = now() − 2h: INSIDE the 24h daily window (084:461), OUTSIDE
+        // the 1h hourly window (084:447). This is the ONLY way to load the
+        // daily window while leaving the hourly window empty — with all live
+        // calls in one hour, hourly (checked first, 084:449) always trips
+        // at-or-before daily. audit_byok_use.ts is insertable (037; only
+        // UPDATE/DELETE are WORM-blocked); workspace_id is NOT NULL (mig
+        // 055/059) so the seed carries the grantor workspace.
+        const agedTs = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+        const seedCount = (CAP_CENTS - COST_CENTS) / COST_CENTS; // = 4
+        const seedRows = Array.from({ length: seedCount }, () => ({
+          invocation_id: randomUUID(),
+          founder_id: grantor.id, // normal accounting attributes to grantor
+          workspace_id: grantor.workspaceId, // NOT NULL
+          agent_role: "test-daily-seed",
+          token_count: TOKEN_COUNT,
+          unit_cost_cents: UNIT_COST_CENTS,
+          delegation_id: delegationId,
+          ts: agedTs,
+        }));
+        const { error: seedErr } = await service
+          .from("audit_byok_use")
+          .insert(seedRows);
+        expect(seedErr, "aged-seed insert").toBeNull();
+
+        // Live call 1: hourly-window spend = 0 + 100 = 100 ≤ 500 (ok); daily
+        // spend = 400 (aged) + 100 = 500 ≤ 500 (ok, `== cap` boundary) → passes.
+        const call1 = await recordUse(
+          delegationId,
+          grantee.id,
+          "test-daily-boundary",
+        );
+
+        // Live call 2: hourly = 100 (call-1 live row) + 100 = 200 ≤ 500 (does
+        // NOT trip); daily = 400 aged + 100 live + 100 = 600 > 500 → RAISE. The
+        // error being the DAILY marker (not hourly) proves it is the daily
+        // branch that raises and pins the strict-`>` daily boundary.
+        const call2 = await recordUse(
+          delegationId,
+          grantee.id,
+          "test-daily-boundary",
+        );
+
+        const willFail =
+          call1.error !== null ||
+          call2.error === null ||
+          !/byok_delegations:daily_cap_exceeded/.test(
+            call2.error?.message ?? "",
+          ) ||
+          /byok_delegations:hourly_cap_exceeded/.test(
+            call2.error?.message ?? "",
+          );
+        const diag = willFail
+          ? diagBanner(await fetchLiveDelegationRpcBody())
+          : "";
+
+        expect(
+          call1.error,
+          `live call 1 at daily == cap (${CAP_CENTS}) passes${diag}`,
+        ).toBeNull();
+        expect(call2.error, `live call 2 (daily would reach ${CAP_CENTS + COST_CENTS}) trips${diag}`).not.toBeNull();
+        expect(call2.error?.message, `daily marker (not hourly)${diag}`).toMatch(
+          /byok_delegations:daily_cap_exceeded/,
+        );
+        expect(
+          call2.error?.message,
+          `hourly branch did NOT raise (hourly at 200 ≤ ${CAP_CENTS})${diag}`,
+        ).not.toMatch(/byok_delegations:hourly_cap_exceeded/);
+      },
+      60_000,
+    );
+
+    test(
+      "Test C — concurrency / FOR UPDATE / no-TOCTOU-double-spend",
+      async () => {
+        // Hourly cap = CAP_CENTS; daily at the ceiling. Fan out N concurrent
+        // uses (each a distinct invocation_id). Concurrency is client-side;
+        // serialization is DB-side via the row `FOR UPDATE` at 084:370.
+        const { delegationId, grantee } = await grantDelegation(
+          CAP_CENTS,
+          DAILY_CEILING,
+        );
+
+        const settled = await Promise.allSettled(
+          Array.from({ length: N }, () =>
+            recordUse(delegationId, grantee.id, "test-concurrency"),
+          ),
+        );
+
+        // supabase-js .rpc() does not reject on a P0001 RAISE — every entry is
+        // `fulfilled` with { data, error }; partition on `.error`.
+        const errors = settled.map((r) =>
+          r.status === "fulfilled" ? r.value.error : { message: "settled-rejected" },
+        );
+        const admitted = errors.filter((e) => e === null).length;
+        const tripped = errors.filter(
+          (e) => e !== null && /byok_delegations:hourly_cap_exceeded/.test(e.message ?? ""),
+        ).length;
+
+        const audit = await auditRowsFor(delegationId);
+        const recordedSpend = audit.reduce(
+          (sum, r) => sum + r.token_count * r.unit_cost_cents,
+          0,
+        );
+
+        // Atomicity signal: without FOR UPDATE, concurrent callers reading the
+        // same pre-INSERT SUM snapshot would each pass the cap check and INSERT
+        // → `> K` audit rows and spend `> cap` (double-spend). With FOR UPDATE
+        // serializing the read+INSERT critical section, exactly K are admitted.
+        const willFail =
+          admitted !== K ||
+          tripped !== N - K ||
+          audit.length !== K ||
+          recordedSpend !== CAP_CENTS;
+        const diag = willFail
+          ? diagBanner(await fetchLiveDelegationRpcBody())
+          : "";
+
+        expect(
+          settled.every((r) => r.status === "fulfilled"),
+          `all ${N} calls settled fulfilled${diag}`,
+        ).toBe(true);
+        expect(admitted, `exactly K=${K} calls admitted${diag}`).toBe(K);
+        expect(tripped, `exactly N−K=${N - K} calls raise the hourly marker${diag}`).toBe(
+          N - K,
+        );
+        expect(audit.length, `audit count == K (no double-spend)${diag}`).toBe(K);
+        expect(
+          recordedSpend,
+          `recorded spend == cap (${CAP_CENTS})${diag}`,
+        ).toBe(CAP_CENTS);
+      },
+      60_000,
+    );
+  },
+);

--- a/knowledge-base/project/learnings/best-practices/2026-07-03-live-cap-rpc-test-aged-seed-daily-isolation-and-audit-equals-K.md
+++ b/knowledge-base/project/learnings/best-practices/2026-07-03-live-cap-rpc-test-aged-seed-daily-isolation-and-audit-equals-K.md
@@ -1,0 +1,70 @@
+---
+title: "Live cap-RPC atomicity tests: aged-seed daily isolation + audit==K (not N) for throw-on-breach RPCs"
+date: 2026-07-03
+category: best-practices
+module: apps/web-platform/test/server
+tags: [byok, postgres, integration-test, cap-rpc, atomicity, for-update, tenant-isolation]
+issue: 5938
+ref: 5920
+---
+
+# Live cap-RPC atomicity tests: aged-seed daily isolation + audit==K
+
+## Problem
+
+Writing a live-DB semantic/atomicity test for a rolling-window cap RPC
+(`check_and_record_byok_delegation_use`, mig 084) that enforces BOTH an hourly
+and a daily cap. Two non-obvious traps make a naïvely-written test either
+impossible to trigger or assert the wrong invariant.
+
+## Key Insight
+
+**1. A daily cap that is checked AFTER the hourly cap can NEVER trip from live
+calls alone — you must aged-seed the daily window.**
+When the RPC sums an hourly window (`ts > clock_timestamp() - interval '1 hour'`)
+BEFORE the daily window (`- interval '24 hours'`), and a table CHECK forces
+`hourly_cap ≤ daily_cap`, any single-hour burst that would exceed `daily` first
+exceeds `hourly` — so the hourly branch always raises first and the daily branch
+is dead code from the test's perspective. Isolate the daily branch by
+pre-seeding `audit_byok_use` rows with `ts = now() − 2h`: **inside** the 24h
+daily window, **outside** the 1h hourly window. The RPC's cap SUM filters on
+`delegation_id` + `ts` only (not `founder_id`/`workspace_id`), so grantor-
+attributed seed rows count. `ts` is client-insertable (WORM triggers are
+`BEFORE UPDATE/DELETE` only); seed rows must still satisfy NOT NULL columns
+(`workspace_id` since mig 059, `founder_id`, `invocation_id` UNIQUE).
+
+**2. For a THROW-on-breach RPC, the double-spend invariant is `audit == K`
+(admitted calls), NOT `audit == N` (all calls).** This is the load-bearing
+difference from the cap-RPC precedent (`record_byok_use_and_check_cap`, #5920):
+that RPC returns a `kill_tripped` signal row and ALWAYS inserts an audit row
+first → its concurrency invariant is `N` rows. The delegation RPC `RAISE`s
+P0001 on breach with NO preceding INSERT (084:449-454 / 463-468), inserting
+only on the pass path — so under N concurrent `FOR UPDATE`-serialized calls,
+exactly `K = cap/cost` are admitted and audit rows == K. Copying the precedent's
+`N`-row assertion 1:1 would false-fail a correct RPC. **A passing 1:1 mirror is
+not proof of correctness; enumerate the new RPC's insert/raise control flow.**
+
+**3. Strict-`>` boundary needs the `== cap` call.** To prove `>` didn't drift to
+`>=`, the cumulative-at-exactly-cap call must be asserted to PASS (a `>=`
+regression makes it raise). Pick `cap` an exact multiple of per-call `cost`
+(assert `cap % cost === 0` in `beforeAll`) so the boundary call lands on a real
+cumulative value.
+
+## Solution
+
+`apps/web-platform/test/server/byok-delegation.atomicity.tenant-isolation.test.ts`
+— gated by `TENANT_INTEGRATION_TEST=1`, mirrors the #5920 self-diagnosing
+pattern (embed live `pg_get_functiondef` body in the failing `expect()` message
+via a guarded fetch that never throws / never runs on green). The
+`.tenant-isolation.test.ts` suffix is load-bearing for the
+`tenant-integration.yml` path filter. Verified live (3/3 pass against dev
+Supabase).
+
+## Session Errors
+
+- **CWD drift in worktree pipeline** — `cd apps/web-platform` / `./node_modules/.bin/vitest` / `git add apps/web-platform/...` variously failed because the Bash tool's CWD drifted between worktree-root and `apps/web-platform`. **Recovery:** prefix `cd <abs> &&` or use repo-root-relative paths. **Prevention:** already covered by work SKILL.md's `cd <worktree-abs> && <cmd>` rule — apply it to EVERY file/test/git command, not just test runs.
+- **Background trailing-echo exit masking** — a backgrounded `tsc … > log; echo "TSC_EXIT=$?"` reported the notification "exit code 0" (the echo's exit) while `tsc` itself exited 127. **Recovery:** read the redirected log for the real `*_EXIT=` line. **Prevention:** already covered — never trust the bg completion notification's exit for a command whose real status is in a redirected log; grep the log's own summary/exit line.
+
+## Tags
+category: best-practices
+module: apps/web-platform/test/server

--- a/knowledge-base/project/plans/2026-07-03-test-byok-delegation-atomicity-plan.md
+++ b/knowledge-base/project/plans/2026-07-03-test-byok-delegation-atomicity-plan.md
@@ -104,13 +104,13 @@ user data and has no runtime surface — its worst failure is a missed drift
 
 ### Phase 0 — Preconditions (verify before writing)
 
-- [ ] Confirm the RPC regprocedure resolves live:
+- [x] Confirm the RPC regprocedure resolves live:
       `pg_get_functiondef('public.check_and_record_byok_delegation_use(uuid,uuid,int,int,uuid,text)'::regprocedure)`
       returns a body (dev, via `DATABASE_URL_POOLER`). Fixed at `<date>` in
       the deepen-plan research phase.
-- [ ] Confirm `audit_byok_use` accepts a service-role INSERT with an explicit
+- [x] Confirm `audit_byok_use` accepts a service-role INSERT with an explicit
       backdated `ts` + `delegation_id` (needed for the daily-isolation seed).
-- [ ] Confirm the `unit` vitest project glob `test/**/*.test.ts`
+- [x] Confirm the `unit` vitest project glob `test/**/*.test.ts`
       (`vitest.config.ts:44`) matches the new path.
 
 ### Phase 1 — New test file
@@ -197,9 +197,9 @@ client-side, serialization is DB-side via `FOR UPDATE` at 084:370):
 
 ### Phase 3 — Verify
 
-- [ ] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (typecheck;
+- [x] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (typecheck;
       NOT `npm run -w` — repo root declares no `workspaces`).
-- [ ] Gated skip path is green by default (no env):
+- [x] Gated skip path is green by default (no env):
       `cd apps/web-platform && ./node_modules/.bin/vitest run test/server/byok-delegation.atomicity.tenant-isolation.test.ts --project unit`
       → suite reports `skipped` (describe.skipIf), does not error.
 - [ ] Live run (deepen-plan / QA phase, dev Doppler):

--- a/knowledge-base/project/plans/2026-07-03-test-byok-delegation-atomicity-plan.md
+++ b/knowledge-base/project/plans/2026-07-03-test-byok-delegation-atomicity-plan.md
@@ -1,0 +1,283 @@
+---
+title: "test(observability): live semantic/atomicity test for check_and_record_byok_delegation_use"
+issue: 5938
+ref: 5920
+branch: feat-one-shot-5938-byok-delegation-atomicity-test
+type: chore
+lane: cross-domain # no spec.md present — defaulted to cross-domain (TR2 fail-closed)
+brand_survival_threshold: none
+created: 2026-07-03
+---
+
+# 🧪 test(observability): live semantic/atomicity test for `check_and_record_byok_delegation_use` (Ref #5920)
+
+## Overview
+
+Add a **live-DB semantic/atomicity test** for the BYOK delegation cap RPC
+`check_and_record_byok_delegation_use` (migration
+`084_byok_delegation_withdrawals.sql`, §7 lines 344-480), gated by
+`TENANT_INTEGRATION_TEST=1` against dev Supabase.
+
+The prior byok RPC body-marker drift guard (merged 2026-07-03, commit
+`b020ebecf`, #5920) added a live *semantic* atomicity test only for the **cap**
+RPC `record_byok_use_and_check_cap`
+(`apps/web-platform/test/server/byok-kill-switch.atomicity.tenant-isolation.test.ts`,
+Invariant C). The **delegation** RPC's only live guards are:
+
+1. the #5920 body-marker probe (asserts the RAISE strings
+   `hourly_cap_exceeded` / `daily_cap_exceeded` and row `FOR UPDATE` are
+   *present* — a necessary-not-sufficient tripwire; marker presence does not
+   prove the `> v_row.<cap>_cap_cents` comparison is intact), and
+2. a **partial** sequential hourly-cap test that already exists (see Research
+   Reconciliation) — loose boundary, sequential-only, no self-diagnosis.
+
+This plan adds the missing **strict-`>` boundary precision**, **daily-cap
+marker coverage**, and **concurrency/FOR-UPDATE (no-TOCTOU-double-spend)**
+proof, reusing the #5920 self-diagnosing pattern (embed the live
+`pg_get_functiondef` body in the failing `expect()` message).
+
+**Scope:** one new test file. No production code, schema, or migration changes.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Issue claim | Reality (verified) | Plan response |
+| --- | --- | --- |
+| "The delegation RPC has **no companion live semantic test**." | Partly stale. `byok-delegations.tenant-isolation.test.ts:537-594` (`AC-hourly-cap-exceeded`) already proves the RPC RAISEs `hourly_cap_exceeded` and writes exactly one audit row — but with a **loose** boundary (cost 4 passes, then cost 2 → 6 > 5 trips; the `== cap` call is never exercised), **sequential-only**, and **no** self-diagnosis. | Do NOT duplicate the existing hourly raise. Scope the new file to the genuine delta: (a) strict-`>` boundary (a call landing **exactly at cap passes**, `+1` over trips) for BOTH hourly and daily; (b) `daily_cap_exceeded` marker (existing test never trips daily); (c) concurrent N-call FOR UPDATE / no-double-spend; (d) `pg_get_functiondef` self-diagnosis. Reference the existing test in the header so a future reader sees the split. |
+| "at the hourly/**daily** cap boundary … RAISEs `daily_cap_exceeded`" | The table CHECK `byok_delegations_hourly_le_daily` (064) forces `hourly ≤ daily`, and the RPC checks hourly **first** (084:449) then daily (084:463). With all calls in one hour, hourly always trips at-or-before daily → **daily can never trip in isolation from live calls alone.** | Isolate daily by **pre-seeding aged `audit_byok_use` rows** with `ts = now() − 2h` (inside the 24h daily window, outside the 1h hourly window). Verified insertable: `audit_byok_use.ts` is `timestamptz NOT NULL DEFAULT now()` and only UPDATE/DELETE are WORM-blocked (037); INSERT with an explicit `ts` + `delegation_id` is allowed and service_role bypasses RLS. See Sharp Edges. |
+| RPC signature for `pg_get_functiondef` | `check_and_record_byok_delegation_use(uuid, uuid, int, int, uuid, text)` — confirmed 084:344-351 + REVOKE 084:482. | Use `'public.check_and_record_byok_delegation_use(uuid,uuid,int,int,uuid,text)'::regprocedure`. |
+| porsager `postgres` devDep present | Confirmed `apps/web-platform/package.json:91` `"postgres": "^3.4.9"`. | Reuse the guarded diagnostic-connection pattern verbatim from the cap test. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a false-green CI signal — a
+future RV rewrite that keeps the RAISE strings (so the #5920 marker probe stays
+green) but silently flips `>` to `>=`, drops the `FOR UPDATE` lock, or
+miscomputes the cap SUM would ship undetected. The guarded RPC enforces BYOK
+delegation spend caps; a broken cap check bills the **grantor** for unbounded
+grantee usage (ADR-040 threshold = unauthorized invoice).
+
+**If this leaks, the user's data is exposed via:** N/A — test-only, reads the
+RPC and writes synthetic `tenant-isolation-*@soleur.test` fixtures against dev
+Supabase. No production data, no new processing activity, no user-facing
+surface.
+
+**Brand-survival threshold:** none, reason: this change is a test that *guards*
+a single-user-incident-class RPC; the test itself landing broken exposes no
+user data and has no runtime surface — its worst failure is a missed drift
+(caught additionally by the #5920 marker tripwire) or a false red.
+
+## Implementation Phases
+
+### Phase 0 — Preconditions (verify before writing)
+
+- [ ] Confirm the RPC regprocedure resolves live:
+      `pg_get_functiondef('public.check_and_record_byok_delegation_use(uuid,uuid,int,int,uuid,text)'::regprocedure)`
+      returns a body (dev, via `DATABASE_URL_POOLER`). Fixed at `<date>` in
+      the deepen-plan research phase.
+- [ ] Confirm `audit_byok_use` accepts a service-role INSERT with an explicit
+      backdated `ts` + `delegation_id` (needed for the daily-isolation seed).
+- [ ] Confirm the `unit` vitest project glob `test/**/*.test.ts`
+      (`vitest.config.ts:44`) matches the new path.
+
+### Phase 1 — New test file
+
+Create `apps/web-platform/test/server/byok-delegation.atomicity.tenant-isolation.test.ts`.
+
+**Header + gating (mirror the cap test):**
+- `describe.skipIf(!INTEGRATION_ENABLED)` on `TENANT_INTEGRATION_TEST === "1"`.
+- `.tenant-isolation.test.ts` suffix is **load-bearing** for the path filter in
+  `.github/workflows/tenant-integration.yml` (detect-changes → heavy suite).
+- Guarded porsager `postgres` diagnostic connection opened from
+  `DATABASE_URL_POOLER` with `ssl: { rejectUnauthorized: false }` (dev-only,
+  verbatim from the cap test), `null` when the URL is absent → fallback string.
+- `fetchLiveDelegationRpcBody()` — guarded (never throws), returns the live
+  `pg_get_functiondef` body or a fallback message. Embedded in failure
+  messages ONLY on the doomed path (green runs never open the query).
+- Synthesized fixtures only (`cq-test-fixtures-synthesized-only`); per-run
+  isolation via `randomBytes`-derived email. Orphan-row `afterAll` acceptance
+  pattern (WORM + ON DELETE RESTRICT), mirroring the cap + delegations tests
+  (deferred sweeper #3934 — no duplicate scope-out).
+
+**Fixture helper (`grantDelegation`):** reuse the merged pattern from
+`byok-delegations.tenant-isolation.test.ts` — `createSyntheticUser` (grantor +
+grantee, read back `workspace_members.workspace_id`), `addMember(grantee →
+grantor workspace)`, then `service.rpc("grant_byok_delegation", {...})` with
+per-test caps. Each test creates a **fresh delegation** (distinct
+`delegation_id`) so the per-`delegation_id` cap SUM isolates tests. **No
+acceptance or withdrawal rows** are seeded: the RPC's per-turn consent re-gate
+(084:404) only fires when a withdrawal EXISTS, and `check_and_record` does not
+call the resolver, so zero withdrawals = re-gate passes.
+
+**Named constants (tuned together; assert `CAP_CENTS % COST_CENTS === 0` in
+`beforeAll`, mirroring the cap test):** `COST_CENTS = 100`
+(`token_count=10 × unit_cost_cents=10`), `CAP_CENTS = 500`, `N = 10`, so the
+boundary passes at cumulative `== 500` (call 5) and trips at `600` (call 6);
+`K = CAP_CENTS / COST_CENTS = 5` calls admitted.
+
+### Phase 2 — Test cases
+
+**Test A — hourly strict-`>` boundary (sequential).** Grant with
+`hourly=CAP_CENTS`, `daily=1_000_000` (max ceiling, never trips). Fire calls
+one at a time, awaiting each:
+- Calls 1..K (cumulative 100…500) return `error === null` — including the
+  **`== cap` call K** (cumulative exactly 500), which is the load-bearing
+  strict-`>` proof (a `>=` regression would make call K raise).
+- Call K+1 (would reach 600) returns a non-null error whose `message` matches
+  `/byok_delegations:hourly_cap_exceeded/`.
+- `audit_byok_use` count for the delegation `== K` (the RAISE path writes no
+  audit row).
+- On any mismatch, embed `fetchLiveDelegationRpcBody()` in the `expect()`
+  message.
+
+**Test B — daily strict-`>` boundary (sequential, aged-seed isolation).** Grant
+with `daily=CAP_CENTS`, `hourly=CAP_CENTS` (CHECK forces `hourly ≤ daily`).
+Pre-seed aged `audit_byok_use` rows (`ts = now() − 2h`, `delegation_id` set)
+summing to `CAP_CENTS − COST_CENTS = 400` — inside the 24h window, outside the
+1h window. Then:
+- Live call 1: hourly-window spend `= 0 + 100 = 100 ≤ 500` (ok); daily-window
+  spend `= 400 + 100 = 500 ≤ 500` (ok, `== cap` boundary) → passes.
+- Live call 2: hourly `= 100 + 100 = 200 ≤ 500` (does NOT trip); daily
+  `= 500 + 100 = 600 > 500` → error matches
+  `/byok_delegations:daily_cap_exceeded/`. This proves it is the **daily**
+  branch (not hourly) that raises, and the strict-`>` boundary for daily.
+- Self-diagnosis embed on mismatch.
+
+**Test C — concurrency / FOR UPDATE / no-TOCTOU-double-spend.** Grant with
+`hourly=CAP_CENTS`, `daily=1_000_000`. Fan out `N=10` concurrent
+`service.rpc("check_and_record_byok_delegation_use", …)` via
+`Promise.allSettled` (each a distinct `invocation_id`; concurrency is
+client-side, serialization is DB-side via `FOR UPDATE` at 084:370):
+- Exactly `K = 5` calls settle with `error === null` (admitted).
+- Exactly `N − K = 5` calls settle with an error matching
+  `/byok_delegations:hourly_cap_exceeded/`.
+- `audit_byok_use` count for the delegation `== K` and total recorded spend
+  `== CAP_CENTS` — **the atomicity signal**: without `FOR UPDATE`, concurrent
+  callers reading the same pre-INSERT SUM snapshot would each pass and INSERT,
+  producing `> K` audit rows and spend `> cap` (double-spend).
+- supabase-js `.rpc()` resolves *fulfilled* with `{data, error}` (does not
+  reject); the pass/fail split lives in `.error`, so `allSettled` entries are
+  all `fulfilled` — partition on `error === null`.
+- Compute a single `willFail` predicate; embed `fetchLiveDelegationRpcBody()`
+  in every failing `expect()` message on the doomed path only.
+
+### Phase 3 — Verify
+
+- [ ] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (typecheck;
+      NOT `npm run -w` — repo root declares no `workspaces`).
+- [ ] Gated skip path is green by default (no env):
+      `cd apps/web-platform && ./node_modules/.bin/vitest run test/server/byok-delegation.atomicity.tenant-isolation.test.ts --project unit`
+      → suite reports `skipped` (describe.skipIf), does not error.
+- [ ] Live run (deepen-plan / QA phase, dev Doppler):
+      `cd apps/web-platform && doppler run -p soleur -c dev -- env TENANT_INTEGRATION_TEST=1 npm run test:ci -- test/server/byok-delegation.atomicity.tenant-isolation.test.ts --project unit`
+      → Tests A/B/C pass.
+- [ ] Deliberate-drift self-diagnosis smoke (optional, dev-only, ROLLBACK): in a
+      `BEGIN; CREATE OR REPLACE FUNCTION … (flip `>` to `>=`); <run Test A>;
+      ROLLBACK;` confirm the failure message contains the embedded live body.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- [ ] New file `apps/web-platform/test/server/byok-delegation.atomicity.tenant-isolation.test.ts`
+      exists with the `.tenant-isolation.test.ts` suffix.
+- [ ] Header references BOTH the cap-RPC precedent
+      (`byok-kill-switch.atomicity.tenant-isolation.test.ts`) AND the existing
+      partial hourly test (`byok-delegations.tenant-isolation.test.ts:537`) so
+      the scope split is discoverable.
+- [ ] Test A asserts the **`== cap` call passes** (strict-`>` proof) and call
+      K+1 errors with `byok_delegations:hourly_cap_exceeded`; audit count `== K`.
+- [ ] Test B trips `byok_delegations:daily_cap_exceeded` via aged-seed
+      isolation, and asserts the hourly branch did NOT raise.
+- [ ] Test C: exactly `K` calls admitted, `N−K` raise the hourly marker, and
+      `audit_byok_use` count for the delegation `== K` (no double-spend).
+- [ ] All three tests embed the live `pg_get_functiondef` body in the failing
+      `expect()` message via a guarded fetch that never throws and never runs on
+      a green path.
+- [ ] `tsc --noEmit` clean; default (un-gated) run reports the suite `skipped`.
+- [ ] `CAP_CENTS % COST_CENTS === 0` asserted in `beforeAll`.
+
+### Post-merge (operator)
+- None. The heavy suite runs automatically on the PR via
+  `tenant-integration.yml` (detect-changes → tenant job) with dev-Supabase
+  secrets; no separate operator step. `Automation: covered by tenant-integration.yml`.
+
+## Observability
+
+This change *is* an observability artifact (a semantic drift guard), but it adds
+no runtime code/infra surface (Files-to-Edit is a single file under
+`apps/web-platform/test/`, outside `server/`/`src/`/`infra/`), so the 5-field
+runtime schema (Phase 2.9) does not apply. Discoverability of a drift:
+
+- **Detection surface:** `tenant-integration.yml` job on the PR (and push-to-main
+  / merge_group), failing red with the live `pg_get_functiondef` body inline in
+  the CI log — no SSH, no manual pg introspection (the #5917 remediation cost
+  this closes for the delegation RPC).
+- **Complementary tripwire:** the #5920 dev-migration-drift body-marker probe
+  (`byok-rpc-markers.json` already lists `check_and_record_byok_delegation_use`)
+  remains the fast structural signal; this test is the semantic authority.
+
+## Domain Review
+
+**Domains relevant:** Engineering (advisory).
+
+Test-only change with no user-facing surface, no schema/migration change, no new
+infrastructure, and no new processing activity. It mirrors a merged precedent
+(#5920 / `b020ebecf`) reviewed under the same threshold. The substantive
+correctness lens (DB atomicity, `FOR UPDATE` serialization, strict-`>` boundary,
+aged-seed daily isolation) is carried by the deepen-plan triad
+(data-integrity-guardian + architecture-strategist + code-simplicity) invoked in
+the next pipeline step.
+
+No Product/UX surface (no files under `components/**`, `app/**/page.tsx`,
+`app/**/layout.tsx`) → Product/UX Gate: NONE.
+
+## GDPR / Compliance Gate
+
+Skipped: the change touches no schema, migration, auth flow, or API route. It
+reads the RPC and writes synthetic dev fixtures. `audit_byok_use` rows created
+by the test are synthetic and covered by the existing orphan-acceptance /
+deferred-sweeper posture (#3934). No new processing activity, no regulated-data
+surface introduced.
+
+## Infrastructure (IaC)
+
+Skipped: no server, service, cron, secret, vendor, DNS, cert, or firewall
+resource introduced. Pure test against already-provisioned dev Supabase.
+
+## Sharp Edges
+
+- **Daily-cap isolation is impossible from live calls alone** — the
+  `byok_delegations_hourly_le_daily` CHECK (064) forces `hourly ≤ daily` and the
+  RPC checks hourly first (084:449), so any spend that exceeds `daily` also
+  exceeds `hourly` in a single-hour test window. The aged-seed
+  (`ts = now() − 2h`) is the ONLY way to preload the 24h window while leaving the
+  1h window empty. If a future migration adds an INSERT trigger to
+  `audit_byok_use` or makes `ts` non-insertable, Test B must be re-approached
+  (e.g., a test-only `clock_timestamp()` shim is NOT available — do not attempt).
+- **The RAISE path writes no audit row for the over-cap call** (unlike the
+  grace/consent/expired branches which INSERT-then-RAISE, then get rolled back
+  by the RAISE anyway). So `audit count == K` (admitted calls only) is the
+  correct double-spend invariant — do NOT expect `N` audit rows (that is the cap
+  RPC's Invariant D, which does not transfer: `record_byok_use_and_check_cap`
+  returns a signal row and always inserts; the delegation RPC throws and inserts
+  only on pass).
+- **supabase-js `.rpc()` does not reject on a P0001 RAISE** — it resolves
+  fulfilled with `{data:null, error:{...}}`. `Promise.allSettled` entries are all
+  `fulfilled`; partition on `.error`, not on `status`.
+- **Do NOT set `hourly > daily`** to isolate daily — the grant RPC / table CHECK
+  rejects it (`hourly_usd_cap_cents out of range`, SQLSTATE 22003, per the
+  existing delegations test 214-227).
+- **`.tenant-isolation.test.ts` suffix is load-bearing** — without it the
+  `tenant-integration.yml` detect-changes filter never fires the heavy suite on
+  this file's own PR, so it would silently never run live.
+- A plan whose `## User-Brand Impact` section is empty or placeholder fails
+  `deepen-plan` Phase 4.6 — it is filled above (threshold `none` with reason).
+
+## References
+
+- Migration: `apps/web-platform/supabase/migrations/084_byok_delegation_withdrawals.sql` §7 (lines 344-480), cap checks 449 / 463, `FOR UPDATE` 370.
+- Precedent test (cap RPC): `apps/web-platform/test/server/byok-kill-switch.atomicity.tenant-isolation.test.ts` (Invariant C, self-diagnosing fetch, guarded pg connection).
+- Existing partial hourly test: `apps/web-platform/test/server/byok-delegations.tenant-isolation.test.ts:537-594`.
+- Marker map: `byok-rpc-markers.json` (already lists the delegation RPC).
+- Schema: `byok_delegations` 064:71 (caps + `hourly_le_daily` CHECK); `audit_byok_use` 037:31 (`ts` insertable, WORM UPDATE/DELETE only).
+- Workflow: `.github/workflows/tenant-integration.yml` (detect-changes → tenant job).
+- Prior commit: `b020ebecf` (#5920).

--- a/knowledge-base/project/plans/2026-07-03-test-byok-delegation-atomicity-plan.md
+++ b/knowledge-base/project/plans/2026-07-03-test-byok-delegation-atomicity-plan.md
@@ -11,6 +11,40 @@ created: 2026-07-03
 
 # 🧪 test(observability): live semantic/atomicity test for `check_and_record_byok_delegation_use` (Ref #5920)
 
+## Enhancement Summary
+
+**Deepened on:** 2026-07-03
+
+**Halt gates (all pass):** 4.6 User-Brand Impact present (threshold `none` +
+inline reason; the single test-file path `apps/web-platform/test/server/…` does
+NOT match the sensitive-path regex, so no scope-out bullet is even required).
+4.7 Observability present (no runtime surface → 5-field schema N/A, documented).
+4.8 no PAT-shaped variable. 4.9 no UI surface → skip.
+
+**Precedent-diff (Phase 4.4):** the test mirrors the merged cap-RPC precedent
+`byok-kill-switch.atomicity.tenant-isolation.test.ts` (#5920 / `b020ebecf`);
+the load-bearing *difference* between the two RPCs is documented in Sharp Edges
+(cap RPC returns a `kill_tripped` signal + always inserts → Invariant D expects
+`N` audit rows; delegation RPC **throws** on breach + inserts only on pass →
+invariant is `audit == K`). No novel pattern introduced.
+
+**Verified load-bearing claims (Phase 4.45 verify-the-negative):**
+1. Hourly/daily cap branches (084:449-454, 463-468) `RAISE` with **no** preceding
+   `INSERT` → the over-cap call persists nothing → `audit == K` (admitted calls
+   only). Confirmed against the RPC body.
+2. `check_and_record_byok_delegation_use` does **not** call the resolver; the
+   per-turn consent re-gate (084:404-425) fires **only if a withdrawal EXISTS**.
+   Zero withdrawals seeded ⇒ re-gate is a no-op. Confirmed.
+3. Cap predicate is single-clause strict `>` (`v_hourly_spent + v_this_cost >
+   v_row.hourly_usd_cap_cents`, 084:449) — the `== cap` call passes; a `>=`
+   regression makes it raise. This is the boundary the test pins.
+4. `audit_byok_use.workspace_id` is **NOT NULL** (mig 055/059) — the daily
+   isolation seed INSERT must carry the grantor's `workspace_id`. Seed columns:
+   `{invocation_id, founder_id (grantor), workspace_id (grantor workspace),
+   agent_role, token_count, unit_cost_cents, delegation_id, ts (now()−2h)}`;
+   `attribution_shift_reason` NULL. Only UPDATE/DELETE are WORM-blocked (037);
+   INSERT with explicit `ts` is allowed.
+
 ## Overview
 
 Add a **live-DB semantic/atomicity test** for the BYOK delegation cap RPC
@@ -131,9 +165,10 @@ one at a time, awaiting each:
 
 **Test B — daily strict-`>` boundary (sequential, aged-seed isolation).** Grant
 with `daily=CAP_CENTS`, `hourly=CAP_CENTS` (CHECK forces `hourly ≤ daily`).
-Pre-seed aged `audit_byok_use` rows (`ts = now() − 2h`, `delegation_id` set)
-summing to `CAP_CENTS − COST_CENTS = 400` — inside the 24h window, outside the
-1h window. Then:
+Pre-seed aged `audit_byok_use` rows (`ts = now() − 2h`, `delegation_id` set,
+`workspace_id` = grantor workspace — the column is NOT NULL per mig 055/059,
+`founder_id` = grantor) summing to `CAP_CENTS − COST_CENTS = 400` — inside the
+24h window, outside the 1h window. Then:
 - Live call 1: hourly-window spend `= 0 + 100 = 100 ≤ 500` (ok); daily-window
   spend `= 400 + 100 = 500 ≤ 500` (ok, `== cap` boundary) → passes.
 - Live call 2: hourly `= 100 + 100 = 200 ≤ 500` (does NOT trip); daily

--- a/knowledge-base/project/plans/2026-07-03-test-byok-delegation-atomicity-plan.md
+++ b/knowledge-base/project/plans/2026-07-03-test-byok-delegation-atomicity-plan.md
@@ -202,7 +202,7 @@ client-side, serialization is DB-side via `FOR UPDATE` at 084:370):
 - [x] Gated skip path is green by default (no env):
       `cd apps/web-platform && ./node_modules/.bin/vitest run test/server/byok-delegation.atomicity.tenant-isolation.test.ts --project unit`
       → suite reports `skipped` (describe.skipIf), does not error.
-- [ ] Live run (deepen-plan / QA phase, dev Doppler):
+- [x] Live run (deepen-plan / QA phase, dev Doppler):
       `cd apps/web-platform && doppler run -p soleur -c dev -- env TENANT_INTEGRATION_TEST=1 npm run test:ci -- test/server/byok-delegation.atomicity.tenant-isolation.test.ts --project unit`
       → Tests A/B/C pass.
 - [ ] Deliberate-drift self-diagnosis smoke (optional, dev-only, ROLLBACK): in a
@@ -212,23 +212,23 @@ client-side, serialization is DB-side via `FOR UPDATE` at 084:370):
 ## Acceptance Criteria
 
 ### Pre-merge (PR)
-- [ ] New file `apps/web-platform/test/server/byok-delegation.atomicity.tenant-isolation.test.ts`
+- [x] New file `apps/web-platform/test/server/byok-delegation.atomicity.tenant-isolation.test.ts`
       exists with the `.tenant-isolation.test.ts` suffix.
-- [ ] Header references BOTH the cap-RPC precedent
+- [x] Header references BOTH the cap-RPC precedent
       (`byok-kill-switch.atomicity.tenant-isolation.test.ts`) AND the existing
       partial hourly test (`byok-delegations.tenant-isolation.test.ts:537`) so
       the scope split is discoverable.
-- [ ] Test A asserts the **`== cap` call passes** (strict-`>` proof) and call
+- [x] Test A asserts the **`== cap` call passes** (strict-`>` proof) and call
       K+1 errors with `byok_delegations:hourly_cap_exceeded`; audit count `== K`.
-- [ ] Test B trips `byok_delegations:daily_cap_exceeded` via aged-seed
+- [x] Test B trips `byok_delegations:daily_cap_exceeded` via aged-seed
       isolation, and asserts the hourly branch did NOT raise.
-- [ ] Test C: exactly `K` calls admitted, `N−K` raise the hourly marker, and
+- [x] Test C: exactly `K` calls admitted, `N−K` raise the hourly marker, and
       `audit_byok_use` count for the delegation `== K` (no double-spend).
-- [ ] All three tests embed the live `pg_get_functiondef` body in the failing
+- [x] All three tests embed the live `pg_get_functiondef` body in the failing
       `expect()` message via a guarded fetch that never throws and never runs on
       a green path.
-- [ ] `tsc --noEmit` clean; default (un-gated) run reports the suite `skipped`.
-- [ ] `CAP_CENTS % COST_CENTS === 0` asserted in `beforeAll`.
+- [x] `tsc --noEmit` clean; default (un-gated) run reports the suite `skipped`.
+- [x] `CAP_CENTS % COST_CENTS === 0` asserted in `beforeAll`.
 
 ### Post-merge (operator)
 - None. The heavy suite runs automatically on the PR via

--- a/knowledge-base/project/specs/feat-one-shot-5938-byok-delegation-atomicity-test/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-5938-byok-delegation-atomicity-test/session-state.md
@@ -1,0 +1,17 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-03-test-byok-delegation-atomicity-plan.md
+- Status: complete
+
+### Errors
+None. CWD verified on first tool call. Branch safety passed. All four deepen-plan halt gates passed (4.6 User-Brand Impact, 4.7 Observability, 4.8 PAT-shaped, 4.9 UI-wireframe). Broken-citation gate clean. Both commits pushed.
+
+### Decisions
+- Scoped to the genuine delta, not a duplicate. Premise validation found the issue's "no companion live semantic test" claim is partly stale: `byok-delegations.tenant-isolation.test.ts` already proves the hourly-cap RAISE loosely (skips `==cap`, sequential-only, no self-diagnosis). New file `byok-delegation.atomicity.tenant-isolation.test.ts` targets real gaps: strict-`>` boundary precision, daily-cap marker coverage, concurrency/FOR-UPDATE no-double-spend, and `pg_get_functiondef` self-diagnosis.
+- Daily-cap isolation via aged-seed: pre-seed `audit_byok_use` rows backdated `ts = now()−2h` (inside 24h, outside 1h window); seed carries grantor workspace (workspace_id NOT NULL).
+- Correct atomicity invariant is `audit == K` (cap/cost admitted), not `N` — delegation RPC throws on breach and inserts only on pass path.
+- Proportional review: test-only single-file change mirroring merged precedent b020ebecf. Brand-survival threshold `none`.
+
+### Components Invoked
+- Bash CWD verification, Skill soleur:plan, Skill soleur:deepen-plan, direct research of migrations 084/064/037/055/059

--- a/knowledge-base/project/specs/feat-one-shot-5938-byok-delegation-atomicity-test/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-5938-byok-delegation-atomicity-test/tasks.md
@@ -1,0 +1,33 @@
+# Tasks — test(observability): byok delegation atomicity (#5938, Ref #5920)
+
+Plan: `knowledge-base/project/plans/2026-07-03-test-byok-delegation-atomicity-plan.md`
+Lane: cross-domain (no spec.md — TR2 fail-closed default)
+
+## Phase 0 — Preconditions
+- [ ] 0.1 Verify `pg_get_functiondef('public.check_and_record_byok_delegation_use(uuid,uuid,int,int,uuid,text)'::regprocedure)` returns a body (dev, `DATABASE_URL_POOLER`).
+- [ ] 0.2 Verify service-role INSERT into `audit_byok_use` with explicit backdated `ts` + `delegation_id` succeeds (daily-isolation seed).
+- [ ] 0.3 Confirm `unit` project glob `test/**/*.test.ts` (`vitest.config.ts:44`) matches the new path.
+
+## Phase 1 — New test file scaffold
+- [ ] 1.1 Create `apps/web-platform/test/server/byok-delegation.atomicity.tenant-isolation.test.ts`.
+- [ ] 1.2 Header: cite cap-RPC precedent + existing partial hourly test (`byok-delegations.tenant-isolation.test.ts:537`); `cq-test-fixtures-synthesized-only`.
+- [ ] 1.3 `describe.skipIf(!INTEGRATION_ENABLED)` on `TENANT_INTEGRATION_TEST === "1"`.
+- [ ] 1.4 Guarded porsager `postgres` diagnostic connection from `DATABASE_URL_POOLER` (`ssl.rejectUnauthorized:false`, dev-only, mirrors cap test); `null` when unset.
+- [ ] 1.5 `fetchLiveDelegationRpcBody()` — guarded, never throws, fallback string.
+- [ ] 1.6 Named constants `COST_CENTS=100`, `CAP_CENTS=500`, `N=10`, `K=5`; assert `CAP_CENTS % COST_CENTS === 0` in `beforeAll`.
+- [ ] 1.7 `grantDelegation` helper: `createSyntheticUser` (grantor+grantee) → `addMember` → `grant_byok_delegation`; fresh delegation per test; NO acceptance/withdrawal rows.
+- [ ] 1.8 `afterAll` orphan-acceptance (WORM + ON DELETE RESTRICT); `sql.end()`.
+
+## Phase 2 — Test cases
+- [ ] 2.1 Test A (hourly strict-`>` boundary, sequential): `== cap` call passes; K+1 raises `hourly_cap_exceeded`; audit count `== K`; self-diagnosis embed.
+- [ ] 2.2 Test B (daily strict-`>` boundary, aged-seed): pre-seed aged rows (`ts=now()−2h`) summing to `CAP_CENTS−COST_CENTS`; live call at `==cap` passes; next raises `daily_cap_exceeded`; assert hourly did NOT raise; self-diagnosis embed.
+- [ ] 2.3 Test C (concurrency/FOR UPDATE): `Promise.allSettled` N calls; exactly K admitted, N−K raise hourly marker; audit count `== K` and spend `== CAP_CENTS` (no double-spend); partition on `.error`; self-diagnosis embed.
+
+## Phase 3 — Verify
+- [ ] 3.1 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` clean.
+- [ ] 3.2 Un-gated run reports suite `skipped` (no env).
+- [ ] 3.3 Live gated run (dev Doppler, `TENANT_INTEGRATION_TEST=1`) → A/B/C pass.
+- [ ] 3.4 (Optional) deliberate-drift ROLLBACK smoke confirms embedded body appears on failure.
+
+## Acceptance
+- [ ] All Pre-merge ACs in the plan satisfied. No post-merge operator steps (tenant-integration.yml auto-runs the heavy suite on the PR).

--- a/knowledge-base/project/specs/feat-one-shot-5938-byok-delegation-atomicity-test/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-5938-byok-delegation-atomicity-test/tasks.md
@@ -20,7 +20,7 @@ Lane: cross-domain (no spec.md — TR2 fail-closed default)
 
 ## Phase 2 — Test cases
 - [ ] 2.1 Test A (hourly strict-`>` boundary, sequential): `== cap` call passes; K+1 raises `hourly_cap_exceeded`; audit count `== K`; self-diagnosis embed.
-- [ ] 2.2 Test B (daily strict-`>` boundary, aged-seed): pre-seed aged rows (`ts=now()−2h`) summing to `CAP_CENTS−COST_CENTS`; live call at `==cap` passes; next raises `daily_cap_exceeded`; assert hourly did NOT raise; self-diagnosis embed.
+- [ ] 2.2 Test B (daily strict-`>` boundary, aged-seed): pre-seed aged rows (`ts=now()−2h`; columns `{invocation_id, founder_id=grantor, workspace_id=grantor-ws (NOT NULL, mig 055/059), agent_role, token_count, unit_cost_cents, delegation_id}`) summing to `CAP_CENTS−COST_CENTS`; live call at `==cap` passes; next raises `daily_cap_exceeded`; assert hourly did NOT raise; self-diagnosis embed.
 - [ ] 2.3 Test C (concurrency/FOR UPDATE): `Promise.allSettled` N calls; exactly K admitted, N−K raise hourly marker; audit count `== K` and spend `== CAP_CENTS` (no double-spend); partition on `.error`; self-diagnosis embed.
 
 ## Phase 3 — Verify

--- a/knowledge-base/project/specs/feat-one-shot-5938-byok-delegation-atomicity-test/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-5938-byok-delegation-atomicity-test/tasks.md
@@ -26,8 +26,8 @@ Lane: cross-domain (no spec.md — TR2 fail-closed default)
 ## Phase 3 — Verify
 - [x] 3.1 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` clean.
 - [x] 3.2 Un-gated run reports suite `skipped` (no env).
-- [ ] 3.3 Live gated run (dev Doppler, `TENANT_INTEGRATION_TEST=1`) → A/B/C pass.
+- [x] 3.3 Live gated run (dev Doppler, `TENANT_INTEGRATION_TEST=1`) → A/B/C pass.
 - [ ] 3.4 (Optional) deliberate-drift ROLLBACK smoke confirms embedded body appears on failure.
 
 ## Acceptance
-- [ ] All Pre-merge ACs in the plan satisfied. No post-merge operator steps (tenant-integration.yml auto-runs the heavy suite on the PR).
+- [x] All Pre-merge ACs in the plan satisfied. No post-merge operator steps (tenant-integration.yml auto-runs the heavy suite on the PR).

--- a/knowledge-base/project/specs/feat-one-shot-5938-byok-delegation-atomicity-test/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-5938-byok-delegation-atomicity-test/tasks.md
@@ -4,28 +4,28 @@ Plan: `knowledge-base/project/plans/2026-07-03-test-byok-delegation-atomicity-pl
 Lane: cross-domain (no spec.md — TR2 fail-closed default)
 
 ## Phase 0 — Preconditions
-- [ ] 0.1 Verify `pg_get_functiondef('public.check_and_record_byok_delegation_use(uuid,uuid,int,int,uuid,text)'::regprocedure)` returns a body (dev, `DATABASE_URL_POOLER`).
-- [ ] 0.2 Verify service-role INSERT into `audit_byok_use` with explicit backdated `ts` + `delegation_id` succeeds (daily-isolation seed).
-- [ ] 0.3 Confirm `unit` project glob `test/**/*.test.ts` (`vitest.config.ts:44`) matches the new path.
+- [x] 0.1 Verify `pg_get_functiondef('public.check_and_record_byok_delegation_use(uuid,uuid,int,int,uuid,text)'::regprocedure)` returns a body (dev, `DATABASE_URL_POOLER`).
+- [x] 0.2 Verify service-role INSERT into `audit_byok_use` with explicit backdated `ts` + `delegation_id` succeeds (daily-isolation seed).
+- [x] 0.3 Confirm `unit` project glob `test/**/*.test.ts` (`vitest.config.ts:44`) matches the new path.
 
 ## Phase 1 — New test file scaffold
-- [ ] 1.1 Create `apps/web-platform/test/server/byok-delegation.atomicity.tenant-isolation.test.ts`.
-- [ ] 1.2 Header: cite cap-RPC precedent + existing partial hourly test (`byok-delegations.tenant-isolation.test.ts:537`); `cq-test-fixtures-synthesized-only`.
-- [ ] 1.3 `describe.skipIf(!INTEGRATION_ENABLED)` on `TENANT_INTEGRATION_TEST === "1"`.
-- [ ] 1.4 Guarded porsager `postgres` diagnostic connection from `DATABASE_URL_POOLER` (`ssl.rejectUnauthorized:false`, dev-only, mirrors cap test); `null` when unset.
-- [ ] 1.5 `fetchLiveDelegationRpcBody()` — guarded, never throws, fallback string.
-- [ ] 1.6 Named constants `COST_CENTS=100`, `CAP_CENTS=500`, `N=10`, `K=5`; assert `CAP_CENTS % COST_CENTS === 0` in `beforeAll`.
-- [ ] 1.7 `grantDelegation` helper: `createSyntheticUser` (grantor+grantee) → `addMember` → `grant_byok_delegation`; fresh delegation per test; NO acceptance/withdrawal rows.
-- [ ] 1.8 `afterAll` orphan-acceptance (WORM + ON DELETE RESTRICT); `sql.end()`.
+- [x] 1.1 Create `apps/web-platform/test/server/byok-delegation.atomicity.tenant-isolation.test.ts`.
+- [x] 1.2 Header: cite cap-RPC precedent + existing partial hourly test (`byok-delegations.tenant-isolation.test.ts:537`); `cq-test-fixtures-synthesized-only`.
+- [x] 1.3 `describe.skipIf(!INTEGRATION_ENABLED)` on `TENANT_INTEGRATION_TEST === "1"`.
+- [x] 1.4 Guarded porsager `postgres` diagnostic connection from `DATABASE_URL_POOLER` (`ssl.rejectUnauthorized:false`, dev-only, mirrors cap test); `null` when unset.
+- [x] 1.5 `fetchLiveDelegationRpcBody()` — guarded, never throws, fallback string.
+- [x] 1.6 Named constants `COST_CENTS=100`, `CAP_CENTS=500`, `N=10`, `K=5`; assert `CAP_CENTS % COST_CENTS === 0` in `beforeAll`.
+- [x] 1.7 `grantDelegation` helper: `createSyntheticUser` (grantor+grantee) → `addMember` → `grant_byok_delegation`; fresh delegation per test; NO acceptance/withdrawal rows.
+- [x] 1.8 `afterAll` orphan-acceptance (WORM + ON DELETE RESTRICT); `sql.end()`.
 
 ## Phase 2 — Test cases
-- [ ] 2.1 Test A (hourly strict-`>` boundary, sequential): `== cap` call passes; K+1 raises `hourly_cap_exceeded`; audit count `== K`; self-diagnosis embed.
-- [ ] 2.2 Test B (daily strict-`>` boundary, aged-seed): pre-seed aged rows (`ts=now()−2h`; columns `{invocation_id, founder_id=grantor, workspace_id=grantor-ws (NOT NULL, mig 055/059), agent_role, token_count, unit_cost_cents, delegation_id}`) summing to `CAP_CENTS−COST_CENTS`; live call at `==cap` passes; next raises `daily_cap_exceeded`; assert hourly did NOT raise; self-diagnosis embed.
-- [ ] 2.3 Test C (concurrency/FOR UPDATE): `Promise.allSettled` N calls; exactly K admitted, N−K raise hourly marker; audit count `== K` and spend `== CAP_CENTS` (no double-spend); partition on `.error`; self-diagnosis embed.
+- [x] 2.1 Test A (hourly strict-`>` boundary, sequential): `== cap` call passes; K+1 raises `hourly_cap_exceeded`; audit count `== K`; self-diagnosis embed.
+- [x] 2.2 Test B (daily strict-`>` boundary, aged-seed): pre-seed aged rows (`ts=now()−2h`; columns `{invocation_id, founder_id=grantor, workspace_id=grantor-ws (NOT NULL, mig 055/059), agent_role, token_count, unit_cost_cents, delegation_id}`) summing to `CAP_CENTS−COST_CENTS`; live call at `==cap` passes; next raises `daily_cap_exceeded`; assert hourly did NOT raise; self-diagnosis embed.
+- [x] 2.3 Test C (concurrency/FOR UPDATE): `Promise.allSettled` N calls; exactly K admitted, N−K raise hourly marker; audit count `== K` and spend `== CAP_CENTS` (no double-spend); partition on `.error`; self-diagnosis embed.
 
 ## Phase 3 — Verify
-- [ ] 3.1 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` clean.
-- [ ] 3.2 Un-gated run reports suite `skipped` (no env).
+- [x] 3.1 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` clean.
+- [x] 3.2 Un-gated run reports suite `skipped` (no env).
 - [ ] 3.3 Live gated run (dev Doppler, `TENANT_INTEGRATION_TEST=1`) → A/B/C pass.
 - [ ] 3.4 (Optional) deliberate-drift ROLLBACK smoke confirms embedded body appears on failure.
 


### PR DESCRIPTION
## Summary
- Adds a live-DB semantic/atomicity integration test for the BYOK delegation cap RPC `check_and_record_byok_delegation_use` (migration `084_byok_delegation_withdrawals.sql`), closing the gap left by the #5920 body-marker drift guard — which only asserts the RAISE-string + row `FOR UPDATE` are *present* (necessary-not-sufficient; a rewrite could keep the markers while flipping `>` to `>=`).
- New file `apps/web-platform/test/server/byok-delegation.atomicity.tenant-isolation.test.ts`, gated by `TENANT_INTEGRATION_TEST=1`. Scoped to the genuine delta over the existing partial hourly test (`byok-delegations.tenant-isolation.test.ts:537`).

Closes #5938

## Changelog
### Web Platform
- **test(observability):** live semantic/atomicity coverage for the byok delegation cap RPC:
  - **Test A** — hourly strict-`>` boundary: the `== cap` call passes, `+1` trips `byok_delegations:hourly_cap_exceeded`; audit count `== K` (the RAISE path writes no audit row).
  - **Test B** — daily strict-`>` boundary via aged-seed isolation (`ts = now()−2h` loads the 24h window while leaving the 1h window empty, since hourly is checked first and can never let daily trip from live calls alone); asserts the daily marker raises and the hourly branch did **not**.
  - **Test C** — concurrency / `FOR UPDATE`: N concurrent uses admit exactly `K`, `N−K` raise, audit count `== K` and recorded spend `== cap` (no TOCTOU double-spend).
  - All three embed the live `pg_get_functiondef` body in the failing `expect()` message via a guarded fetch that never throws and never runs on a green path (reuses the #5920 self-diagnosing pattern).

## Test plan
- [x] `tsc --noEmit` clean (web-platform)
- [x] Un-gated run reports the suite `skipped` (`describe.skipIf`)
- [x] Full web-platform unit suite green (733 files, 0 fail)
- [x] Live gated run against dev Supabase: **3/3 tests pass** (`doppler run -c dev -- env TENANT_INTEGRATION_TEST=1 vitest ... --project unit`)
- [ ] CI `tenant-integration.yml` runs the heavy suite on this PR (dev-Supabase secrets)

## Post-merge
None — the heavy suite runs automatically on the PR via `tenant-integration.yml` (detect-changes → tenant job); no separate operator step.

Ref #5920 (predecessor: the byok RPC body-marker drift guard, merged in commit b020ebecf).

Generated with [Claude Code](https://claude.com/claude-code)
