### PR TITLE
fix(infra): defer web-1 placement reboot via ignore_changes — unwedge CI zero-downtime (#5887)

### DIFF
--- a/apps/web-platform/infra/server.tf
+++ b/apps/web-platform/infra/server.tf
@@ -138,8 +138,19 @@ resource "hcloud_server" "web" {
   # template interpolation differs from the original user_data, and
   # ssh_keys forces replacement. Both are safe to ignore (#967).
   # TODO: remove ignore_changes after clean reprovisioning (import artifact)
+  #
+  # placement_group_id — TEMPORARY GA-deferral (#5887, ADR-068 blue-green ingress
+  # prereqs). web-1 pre-dates the web_spread group; attaching it to the RUNNING host
+  # forces a Hetzner power-off reboot (see the placement_group_id comment above).
+  # Ignoring it keeps the pending 0 -> web_spread attach OUT of every plan so the
+  # destroy-guard `reboot_updates` counter (#5911) does not halt the targeted CI
+  # applies — unwedging #5887 with ZERO reboot. web-2 was born INTO the group at
+  # create time, so this defers ONLY web-1. REMOVE this entry in the GA maintenance-
+  # window PR as its FIRST diff, then take the reboot on a drained host (blue-green).
+  # Guarded by plugins/soleur/test/terraform-target-parity.test.ts so it is not
+  # dropped silently.
   lifecycle {
-    ignore_changes = [user_data, ssh_keys, image]
+    ignore_changes = [user_data, ssh_keys, image, placement_group_id]
   }
 
   labels = {

--- a/knowledge-base/engineering/architecture/decisions/ADR-068-multi-host-workspaces-shared-git-data-lease-coordinator.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-068-multi-host-workspaces-shared-git-data-lease-coordinator.md
@@ -538,6 +538,42 @@ Phase 4b (continuous checkpoint).
 > caught by the pre-existing `resource_deletes` counter; the reboot clause deliberately
 > does not compare them (a REPLACE never matches `actions==["update"]`).)
 
+> **Amendment (2026-07-03, #5887 — blue-green ingress prerequisites & reboot deferral).**
+> Refines the moved-block amendment above: by 2026-07-03 the four `moved` blocks were
+> already consumed in state and web-2 existed (bare), so the CI red was NOT the moved
+> error but the `reboot_updates` guard halting on web-1's pending `placement_group_id`
+> attach. **(a) Reboot deferral (zero-downtime CI unwedge).** Adding `placement_group_id`
+> to `hcloud_server.web`'s `lifecycle.ignore_changes` (`server.tf`) removes web-1's
+> pending `0 → web_spread` attach from **every** plan (verified: a full plan drops from
+> `31 add, 2 change` to `31 add, 1 change, 0 destroy` — the only residual change is the
+> in-place `hcloud_firewall_attachment.web` server-id update). The `reboot_updates`
+> counter then reads 0, so both targeted apply pipelines self-heal green with **zero
+> reboot**, via a normal PR merge — no maintenance window. web-2 was born INTO the group
+> at create time, so this defers ONLY web-1. **GA-window removal trigger:** the GA
+> maintenance-window PR removes this `ignore_changes` entry as its FIRST diff and takes
+> the reboot on a **drained** host (blue-green), never on the sole live origin. A static
+> guard in `plugins/soleur/test/terraform-target-parity.test.ts` fails if the entry is
+> dropped silently. **(b) Deferred GA ingress design.** The multi-host ingress is a
+> **Cloudflare Load Balancer** (v4 provider syntax — the repo pins `cloudflare ~> 4.0`,
+> NOT v5; drain via origin `weight = 0`, not the v5-only `endpoint_drain_duration`),
+> health-checked. Its monitor MUST be **reachability-only** (`expected_codes = "2xx"`
+> against `/health`) and MUST NOT parse the `supabase` body field: `/health` always
+> returns 200 (`server/index.ts`) and both hosts share one Supabase, so a body-coupled
+> monitor would eject the sole live origin on a DB blip → full ingress outage. The A→LB
+> record migration is a live-record operation (no `moved` block / stable import id on
+> `cloudflare_record.app`) and its gaplessness is an **unverified** Cloudflare-behavior
+> claim — verify against CF docs + a staging convert before the GA window. The LB is a
+> paid add-on (~$5/mo) — record the recurring expense. web-2 sits in the pool at
+> **weight 0** (drained) until GA. **(c) Hard invariant.** NO live LB weight to web-2
+> before BOTH the owner-side relay is active (`SOLEUR_PROXY_BIND`/`PEER_ALLOWLIST`/
+> `HOST_ROSTER` set → `session-proxy.ts createProxyServer` binds) AND the git-data store
+> is cut over (`isGitDataStoreEnabled()` true, 3.C write-boundary sentinel merged, 3.D
+> LUKS cutover soak-verified). Rationale: with the router gated off (default) each host
+> serves purely locally on its own `/workspaces` volume, so any live request round-robined
+> to web-2 hits an empty workspace — a single-user (workspace-gone) incident. A truly
+> zero-downtime web-1 reboot therefore requires (b)+(c), i.e. it IS the GA line (§8), not
+> a prerequisite. Plan: `knowledge-base/project/plans/2026-07-03-feat-multi-host-blue-green-ingress-prereqs-plan.md`.
+
 ## Consequences
 
 - **Positive.** The serializable-vs-live-handle split (research reconciliation) kills

--- a/knowledge-base/project/plans/2026-07-03-feat-multi-host-blue-green-ingress-prereqs-plan.md
+++ b/knowledge-base/project/plans/2026-07-03-feat-multi-host-blue-green-ingress-prereqs-plan.md
@@ -1,0 +1,296 @@
+---
+title: "Multi-host blue-green ingress prerequisites (ADR-068 GA) — unwedge CI zero-downtime + warm web-2 standby"
+date: 2026-07-03
+type: feat
+branch: feat-multi-host-blue-green-ingress
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+closes: []
+refs: [5887, 5877, 5274]
+---
+
+# Multi-host blue-green ingress prerequisites (ADR-068 GA)
+
+## Overview
+
+ADR-068's multi-host GA needs web-2 to be able to serve traffic so that the pending
+web-1 placement-group reboot (and the git-data cutover) can happen **zero-downtime**.
+This plan delivers the *safe, additive prerequisites* and the *design* for the GA — it
+does **not** perform the ingress cutover, the git-data LUKS migration, or the web-1
+reboot (all deferred to the GA maintenance window, tracked separately).
+
+Two shippable deliverables + one design deliverable:
+
+- **Phase 1 — Unwedge CI, zero reboot (normal PR).** Add `lifecycle { ignore_changes =
+  [placement_group_id] }` to `hcloud_server.web`. **Verified today:** this drops the full
+  plan from `31 add, 2 change` to `31 add, 1 change, 0 destroy` — web-1's
+  `~ placement_group_id = 0 → 1739811` (the reboot-forcer, and the sole trigger of the
+  `reboot_updates` destroy-guard from #5911) **disappears from every plan**. The CI
+  targeted apply drags web-1 in only as a no-op → the guard passes → both apply pipelines
+  go green with **zero reboot**. The follow-through sweeper (`moved-block-wedge-5887.sh`)
+  then closes **#5887**. This is the true zero-downtime resolution of the CI wedge.
+- **Phase 2 — Warm web-2 standby (operator maintenance-window apply, zero user impact).**
+  Provision the private network + web-2 `/workspaces` volume/attachment + deploy the app
+  container to web-2 + verify `/health` **on web-2's private IP**. Ingress stays untouched
+  (single proxied A record → web-1). web-2 becomes a warm, deploy-current standby that is
+  **in no public serving pool**. Records the new recurring expense.
+- **Design deliverable — ADR-068 amendment (no apply).** Capture the deferred GA ingress
+  design (Cloudflare Load Balancer, health-checked, web-2 weight 0→1 gated on GA), the
+  reboot-deferral invariant, and the sequencing that makes the eventual web-1 reboot
+  zero-downtime. File the `/health` deep-readiness follow-up (see Sharp Edges C1).
+
+**Why not build the load balancer now?** The domain review (CTO + spec-flow) converged:
+before the in-process user-sticky router is activated **and** the git-data store is cut
+over, web-2 physically cannot serve a web-1 user's session (each host has its own
+`/workspaces` volume; the router that would proxy to the lease-holder is gated off by
+`isGitDataStoreEnabled()`, default off). So any live traffic to web-2 = workspace-gone
+**single-user incident**, and building the LB now buys no serving value while taking on the
+A→LB live-record migration hazard + a paid recurring cost + a health-green-lie failover
+risk. The LB therefore belongs to the GA cutover window, not to "prerequisites."
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (issue #5887 / initial framing) | Reality (verified 2026-07-03) | Plan response |
+|---|---|---|
+| CI is wedged on pending `moved` blocks ("Moved resource instances excluded by targeting") | **Stale.** `moved` blocks already consumed in state (full plan shows no pending moves). CI's *current* red cause is the `reboot_updates` destroy-guard (#5911) halting on web-1's pending `placement_group_id` change. | Phase 1 defers the placement change via `ignore_changes` → guard passes → green. |
+| The wedge clears only via an operator full apply that reboots web-1 | **False now.** `ignore_changes = [placement_group_id]` clears it with zero reboot (verified: `31 add, 1 change, 0 destroy`, no `placement_group_id` diff). | Phase 1 is the zero-downtime clear; the reboot is deferred to GA. |
+| web-2 needs provisioning | web-2 **server already exists** in TF state (`hcloud_server.web["web-2"]`, id 147422810, running). Its `/workspaces` volume + private-net attach are pending creates. | Phase 2 creates the volume/attach only; no server create. |
+| Convert `cloudflare_record.app` singleton→for_each for multi-host ingress | dns.tf comment: this is a destroy+recreate of the LIVE app record (no `moved`, no stable import id). spec-flow H2: a CF hostname is *either* a proxied A record *or* an LB — the swap has an inherent gap. | Ingress **untouched** this plan; LB/record migration deferred to GA and flagged for CF-behavior verification (Sharp Edge). |
+| `/health` can gate web-2 readiness | **False.** `server/health.ts` hardcodes `status:"ok"` and only probes shared Supabase; returns 200 with an empty `/workspaces`. A routing lie. | web-2 verified on private IP only; deep-readiness endpoint filed as follow-up (Sharp Edge C1). |
+| Cloudflare provider is v5 (research note) | **Repo pins `cloudflare ~> 4.0`** (`.terraform.lock.hcl` → 4.52.7). | Any deferred LB stanza uses v4 syntax; drain via origin `weight=0` (not v5 `endpoint_drain_duration`). |
+
+**Premise validation:** #5887 OPEN; #5908 (`MOVED_OPERATOR_CONSUMED`) merged; #5911
+(`reboot_updates`) live (its error text appears in the current red CI run 28648411099);
+#5922 (web-2 user_data 32KB fix) merged; runbook PR #5946 open. No stale blockers.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a web-1 reboot or a live request routed to
+web-2 (empty `/workspaces`) → a fresh-session greeting with their repo/conversation state
+gone (the #5240-class workspace-gone incident).
+
+**If this leaks, the user's workflow is exposed via:** N/A for this plan — no new
+data-processing path is activated (web-2 is warm-but-drained; the git-data store stays off,
+`isGitDataStoreEnabled()=false`). The Article-30 / EU-residency lockstep for git-data
+processing lands with the GA cutover, not here. web-2 stays EU-pinned (`hel1`).
+
+**Brand-survival threshold:** single-user incident. → `requires_cpo_signoff: true`.
+`user-impact-reviewer` runs at review time.
+
+## Implementation Phases
+
+### Phase 1 — Defer the web-1 placement reboot; unwedge CI (zero reboot)
+
+**Files to edit:**
+- `apps/web-platform/infra/server.tf` — extend the `hcloud_server.web` `lifecycle`
+  block (currently `ignore_changes = [user_data, ssh_keys, image]`, server.tf:135-137) to
+  `ignore_changes = [user_data, ssh_keys, image, placement_group_id]`. Add a comment: this
+  is a **temporary GA-deferral** — web-1 stays out of the `web_spread` placement group
+  until the GA window, whose first diff is removing this entry to take the reboot on a
+  drained host. web-2 already carries `placement_group_id = 1739811` (born into the group),
+  so this ignore only defers web-1.
+- `plugins/soleur/test/terraform-target-parity.test.ts` and
+  `tests/scripts/lib/destroy-guard-filter-web-platform.jq` — **verify only, likely no
+  edit.** The `reboot_updates` clause keys on `placement_group_id`/`server_type` changes;
+  with the attribute ignored there is nothing to detect. Add a test asserting a plan with
+  the ignore present yields `reboot_updates = 0` for `hcloud_server.web` (guards against a
+  future removal of the ignore silently re-wedging CI).
+
+**Phase 0 verification gate (already run — record in the PR):**
+```
+# read-only, no mutation; runbook worktree, prd_terraform creds
+terraform plan → BEFORE: "Plan: 31 to add, 2 to change, 0 to destroy" (web-1 ~placement_group_id 0→1739811)
+terraform plan (with ignore_changes) → AFTER: "Plan: 31 to add, 1 to change, 0 to destroy" (only hcloud_firewall_attachment.web in-place; NO placement_group_id diff)
+```
+
+**Apply path:** normal PR → merge → `apply-web-platform-infra.yml` auto-applies the
+`-target`-scoped set. With the reboot gone, the destroy-guard passes and the in-place
+`hcloud_firewall_attachment.web` update (server_ids += web-2) applies cleanly. **Both** red
+pipelines (`apply-web-platform-infra.yml`, `apply-deploy-pipeline-fix.yml`) go green →
+`moved-block-wedge-5887.sh` closes #5887. Zero reboot, zero downtime, no operator-local
+apply required.
+
+### Phase 2 — Warm web-2 standby (operator maintenance-window apply; deferred until expense approved)
+
+> Operator-local apply (these resources are `OPERATOR_APPLIED_EXCLUSIONS`, not in CI).
+> Zero user impact — web-2 is not in ingress. Gated on recurring-expense approval.
+
+**Step 0 — State reconciliation (blocking, read-only).** Confirm `hcloud_server.web["web-2"]`
+is in state (VERIFIED: refreshes with id 147422810). Confirm the plan shows `0 to destroy`
+and **no** `placement_group_id`/reboot diff on `hcloud_server.web["web-1"]` before `yes`.
+
+**Step 1 — Additive infra, precisely targeted.** `terraform apply` with `-target` limited to:
+`hcloud_network.private`, `hcloud_network_subnet.private`,
+`hcloud_server_network.web["web-1"]` (online attach, no reboot),
+`hcloud_server_network.web["web-2"]`, `hcloud_volume.workspaces["web-2"]`,
+`hcloud_volume_attachment.workspaces["web-2"]`. Canonical invocation (raw `AWS_*` for the
+R2 backend + `doppler -p soleur -c prd_terraform --name-transformer tf-var`). Do NOT
+`-target` `hcloud_placement_group.web_spread` or the git_data resources.
+
+**Step 2 — Deploy app to web-2 + verify on PRIVATE IP.** Use the existing fan-out
+(`ci-deploy.sh fan_out_to_peers` over the private net; `WEB_HOST_PRIVATE_IPS` already
+carries `10.0.1.11`) or a targeted deploy. **Gate:** `GET http://10.0.1.11:3000/health` →
+`200`, `supabase:"connected"`, from a private-net probe — never via a public hostname/pool.
+
+**Step 3 — Verify safe end-state (read-only).** web-1 still serves 100% via the unchanged
+A record; web-2 health-green on private IP; web-2 in no serving pool. Record the recurring
+expense (see IaC §Vendor-tier).
+
+### Deferred to the GA maintenance window (NOT this plan — captured in the ADR)
+
+Ingress cutover (LB or in-place CF convert), `GIT_DATA_STORE_ENABLED=true` flip, owner-side
+relay env activation (`SOLEUR_PROXY_BIND`/`PEER_ALLOWLIST`/`HOST_ROSTER`), git-data LUKS
+cutover, remove `ignore_changes=[placement_group_id]` → drain web-1 → reboot web-1 → restore.
+
+## Infrastructure (IaC)
+
+### Terraform changes
+- **Phase 1:** `apps/web-platform/infra/server.tf` `lifecycle.ignore_changes += placement_group_id`. No provider, variable, or resource additions. No cost.
+- **Phase 2:** creates `hcloud_network.private`, `hcloud_network_subnet.private`,
+  `hcloud_server_network.web[*]`, `hcloud_volume.workspaces["web-2"]` (20 GB) + attachment.
+  All already defined in `network.tf`/`server.tf`; no new `.tf` authoring.
+- **Deferred (ADR only, not applied):** `cloudflare_load_balancer` + `_pool` + `_monitor`
+  in **v4 syntax** (repo pins `cloudflare ~> 4.0`), `count = var.cf_load_balancing_enabled
+  ? 1 : 0`, a dedicated narrow `cf_api_token_load_balancing` token (default token lacks LB
+  scope), monitor `path=/health expected_codes="2xx"` **reachability-only — MUST NOT parse
+  the `supabase` body field** (both hosts share one Supabase; a body-coupled monitor would
+  eject the sole live origin on a DB blip), pool with web-1 weight 1 / web-2 weight 0.
+
+### Apply path
+- Phase 1: CI auto-apply on merge (in-place firewall update, `0 reboot`, `0 destroy`).
+- Phase 2: operator-local `-target` apply; expected downtime **zero** (private-net attach is
+  online; web-2 volume touches a non-serving host; no reboot-bearing change targeted).
+- Reboot-exclusion mechanism (load-bearing): the `moved` blocks force `hcloud_server.web`
+  into any targeted plan, so it cannot be `-target`-excluded — `ignore_changes =
+  [placement_group_id]` (Phase 1) is what makes it a 0-change no-op. Phase 1 must merge
+  before Phase 2's operator apply.
+
+### Distinctness / drift safeguards
+- `ignore_changes=[placement_group_id]` is **temporary** — the GA PR removes it to take the
+  reboot. Document with the removal trigger inline.
+- Any deferred LB carries `count = var.cf_load_balancing_enabled ? 1 : 0`, default `false`
+  → no accidental spend in dev; fully reversible.
+
+### Vendor-tier reality check
+- **New recurring cost from Phase 2:** web-2 `/workspaces` 20 GB Hetzner volume ≈ €0.88/mo.
+  (web-2 server itself already exists/accrues ~€13/mo — not created here.)
+- **Deferred (GA):** Cloudflare Load Balancing paid add-on ≈ $5/mo (60s health interval at
+  base tier) + git-data host (`cax11` ≈ €3.79/mo) + LUKS/git-data volumes.
+- Record Phase 2's volume expense in `knowledge-base/finance/expenses.md` before PR-ready
+  (`wg-record-recurring-vendor-expense-before-ready`). *Verify live pricing before budget
+  decisions.*
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: web-2 /health on private IP 10.0.1.11:3000 (200 + supabase:connected)
+  cadence: on-deploy (Phase 2 step 2) + existing web-1 public /health poll (release workflow)
+  alert_target: Better Stack (existing web-1 monitor); web-2 private-IP probe is deploy-gate only until GA
+  configured_in: apps/web-platform/server/health.ts + web-platform-release.yml health gate
+error_reporting:
+  destination: Sentry (existing web-platform DSN)
+  fail_loud: Phase 2 deploy-to-web-2 failure aborts the operator apply loudly (non-200 /health)
+failure_modes:
+  - mode: web-2 /health never green after deploy
+    detection: private-IP curl in Phase 2 step 2 (deploy gate)
+    alert_route: operator apply halts; no ingress change made
+  - mode: Phase 1 ignore_changes silently re-wedges CI if later removed without the reboot
+    detection: terraform-target-parity test asserting reboot_updates=0 with ignore present
+    alert_route: CI red on the parity suite
+  - mode: web-2 accidentally added to a public serving pool pre-GA (workspace-gone)
+    detection: ADR gate — no cloudflare_load_balancer resource ships this plan; grep guard
+    alert_route: review-time (user-impact-reviewer) + ADR hard gate
+logs:
+  where: host pino → stdout (existing); Sentry breadcrumbs
+  retention: existing web-platform retention
+discoverability_test:
+  command: "gh run list --workflow=apply-web-platform-infra.yml --branch main --limit 1 --json conclusion  (expect success post-Phase-1)"
+  expected_output: '"conclusion":"success"'
+```
+
+## Architecture Decision (ADR/C4)
+
+### ADR
+Amend **ADR-068** (`/soleur:architecture`) with a "Blue-green ingress prerequisites &
+reboot deferral" section recording: (1) the temporary `ignore_changes=[placement_group_id]`
+web-1 reboot-deferral and its GA-window removal trigger; (2) the deferred GA ingress design
+— Cloudflare LB, health-checked, **monitor must be reachability-only (not supabase-body-
+coupled)**, web-2 weight 0 until 3.C merged + 3.D git-data cutover soak-verified; (3) the
+hard invariant: **no live LB weight to web-2 before the router owner-side relay is active
+AND git-data is cut over.** This is squarely within the ADR-068 multi-host arc — amend, do
+not create a new ADR.
+
+### C4 views
+Checked `model.c4`/`views.c4`/`spec.c4`: web-1/web-2 as web-host containers and the
+Cloudflare ingress edge are already modeled from the Phase-3 work; this plan adds no new
+external actor/system/data-store (web-2 warm standby, ingress unchanged). The LB element +
+git-data replication edges land with the GA amendment, not here. **No C4 edit this plan**
+(actors checked: end user, Cloudflare edge, Hetzner hosts, Supabase — all already modeled;
+no new access relationship until GA activates cross-host serving).
+
+### Sequencing
+The ADR is authored now (status: adopting) describing the target GA ingress; the LB/relay/
+git-data activation is the GA window, gated as above.
+
+## Domain Review
+
+**Domains relevant:** Engineering (CTO), Finance/Ops (expense), Legal (deferred to GA).
+
+### Engineering (CTO)
+**Status:** reviewed. **Assessment:** Ruled Candidate A's *live* form unsafe (weight-0-in-a-
+live-pool still takes the A→LB migration + health-green-lie risk); confirmed the router is
+gated off by `isGitDataStoreEnabled()` (default off) so round-robin to web-2 = data-loss;
+zero-downtime web-1 reboot requires BOTH the owner-side relay AND git-data cutover (the GA
+line). Recommended: ship the additive prereqs + defer the LB/ingress to the GA window.
+Flagged the `/health` monitor-coupling hazard (adopted into Sharp Edges + the ADR).
+
+### Finance/Ops
+**Status:** deferred to COO/CFO. Phase 2 adds ~€0.88/mo (web-2 volume); GA adds the CF LB
+(~$5/mo) + git-data host. Record before PR-ready.
+
+### Product/UX Gate
+**Tier:** none. No user-facing surface (infra/ingress only; no `components/**`, no
+`app/**/page.tsx`).
+
+## Acceptance Criteria
+
+### Pre-merge (Phase 1 PR)
+- [ ] `hcloud_server.web` `lifecycle.ignore_changes` includes `placement_group_id` with a temporary-deferral comment naming the GA removal trigger.
+- [ ] `terraform-target-parity.test.ts` asserts a plan with the ignore present yields `reboot_updates = 0` on `hcloud_server.web`.
+- [ ] PR body uses `Ref #5887` (NOT `Closes` — the follow-through sweeper closes it post-merge once both pipelines are green; ops-remediation class).
+- [ ] No `cloudflare_load_balancer*` resource is added (grep-verified in review — LB is GA-deferred).
+- [ ] ADR-068 amendment committed in this PR (reboot-deferral + deferred ingress design + monitor-coupling rule).
+
+### Post-merge (operator)
+- [ ] Both `apply-web-platform-infra.yml` and `apply-deploy-pipeline-fix.yml` latest `main` runs = `success` (pull via `gh run list`, no dashboard).
+- [ ] `moved-block-wedge-5887.sh` PASS → #5887 auto-closed.
+- [ ] **(Phase 2, gated on expense approval)** operator `-target` apply provisions private net + web-2 volume/attach; plan showed `0 to destroy` + no web-1 reboot; web-2 `/health` green on `10.0.1.11`; expense recorded.
+
+## Sharp Edges
+
+- **C1 — `/health` is a routing lie (follow-up issue required).** `server/health.ts`
+  hardcodes `status:"ok"` and only probes shared Supabase → returns 200 with an empty
+  `/workspaces`. web-2 must therefore NEVER be a monitored member of a public serving pool
+  until a **deep-readiness** endpoint exists (fails when the host cannot serve — pre-git-data-
+  GA that is *always* for web-2). File the deep-readiness endpoint as a GA-blocking follow-up.
+- **A→LB migration is a live-record operation (verify CF behavior before GA).** A CF hostname
+  is either a proxied A record or an LB. best-practices research claims the LB takes DNS
+  precedence gaplessly if both proxied; spec-flow warns of an NXDOMAIN/409 window. This is a
+  load-bearing vendor-behavior claim — **verify against Cloudflare docs + a staging convert
+  before the GA window** (do not assert gapless). Never do the A→LB swap under a "prereq" banner.
+- **firewall_attachment for_each drag-in.** `firewall.tf` `server_ids = [for h in
+  hcloud_server.web : h.id]` references the whole map; `-target`ing it pulls
+  `hcloud_server.web["web-1"]` into the closure. Safe now (Phase 1's `ignore_changes` makes
+  the server a no-op) — but never `[ack-destroy]` through a reboot on the unattended path.
+- **`moved` blocks evaluate globally at plan time** regardless of `-target` — the operator
+  must read the plan and not mistake the (already-consumed) re-address for a change.
+- **Do not `[ack-destroy]` the CI wedge.** The correct fix is Phase 1's `ignore_changes`
+  (zero reboot), never acking the reboot through the unattended apply (#5911's whole point).
+- **`ignore_changes` removal is the GA PR's first diff** — leaving it forever means web-1
+  never joins the HA spread group. Track its removal as a GA deliverable.
+
+## Open Questions
+1. Expense approval for Phase 2 (web-2 20 GB volume ~€0.88/mo) and the deferred GA CF LB (~$5/mo) — COO/CFO sign-off before Phase 2 apply.
+2. GA ingress primitive: Cloudflare LB (health-checked drain, paid) vs. in-place CF convert — decide in the ADR/GA plan after verifying the CF record→LB migration behavior.

--- a/knowledge-base/project/specs/feat-multi-host-blue-green-ingress/tasks.md
+++ b/knowledge-base/project/specs/feat-multi-host-blue-green-ingress/tasks.md
@@ -1,0 +1,26 @@
+# Tasks — Multi-host blue-green ingress prerequisites (ADR-068 GA)
+
+Plan: `knowledge-base/project/plans/2026-07-03-feat-multi-host-blue-green-ingress-prereqs-plan.md`
+Lane: cross-domain · Threshold: single-user incident (CPO sign-off) · Refs #5887 #5877 #5274
+
+## Phase 1 — Unwedge CI, zero reboot (normal PR)
+- [ ] 1.1 Edit `apps/web-platform/infra/server.tf`: `hcloud_server.web` `lifecycle.ignore_changes += placement_group_id` with a temporary-GA-deferral comment (names the GA removal trigger; notes web-2 already in the group).
+- [ ] 1.2 Add `terraform-target-parity.test.ts` assertion: plan with the ignore present → `reboot_updates = 0` on `hcloud_server.web` (guards future silent removal).
+- [ ] 1.3 Amend ADR-068 via `/soleur:architecture`: reboot-deferral + deferred GA ingress design + monitor-must-not-couple-to-supabase rule + no-live-weight-before-GA invariant.
+- [ ] 1.4 PR body: `Ref #5887` (NOT `Closes`); note the zero-reboot verification (`31 add, 1 change, 0 destroy`).
+- [ ] 1.5 Review gate: grep-verify no `cloudflare_load_balancer*` added; run user-impact-reviewer (single-user threshold).
+
+## Phase 1 — Post-merge (operator, automated)
+- [ ] 1.6 Confirm both apply pipelines green on `main` (`gh run list`, no dashboard).
+- [ ] 1.7 Confirm `moved-block-wedge-5887.sh` PASS → #5887 auto-closed.
+
+## Phase 2 — Warm web-2 standby (operator maintenance-window apply; gated on expense approval)
+- [ ] 2.1 COO/CFO: approve + record web-2 20 GB volume (~€0.88/mo) in `knowledge-base/finance/expenses.md`.
+- [ ] 2.2 State reconciliation (read-only): confirm `hcloud_server.web["web-2"]` in state; plan shows `0 to destroy` + no web-1 placement/reboot diff.
+- [ ] 2.3 `-target` apply: private net + subnet + `hcloud_server_network.web[*]` + `hcloud_volume.workspaces["web-2"]` + attachment (canonical raw-AWS_* + tf-var invocation).
+- [ ] 2.4 Deploy app to web-2; verify `GET http://10.0.1.11:3000/health` = 200 + `supabase:connected` (private IP only).
+- [ ] 2.5 Verify safe end-state: web-1 serves 100% via unchanged A record; web-2 warm, in no serving pool.
+
+## Follow-ups (GA-blocking; separate issues/plan)
+- [ ] F1 File `/health` deep-readiness endpoint issue (Sharp Edge C1) — required before web-2 can be pooled.
+- [ ] F2 GA cutover plan/window: LB (verify CF record→LB migration behavior) + router owner-side relay activation + git-data LUKS cutover + remove `ignore_changes=[placement_group_id]` → drain → reboot web-1 → restore.

--- a/knowledge-base/project/specs/feat-multi-host-blue-green-ingress/tasks.md
+++ b/knowledge-base/project/specs/feat-multi-host-blue-green-ingress/tasks.md
@@ -4,11 +4,11 @@ Plan: `knowledge-base/project/plans/2026-07-03-feat-multi-host-blue-green-ingres
 Lane: cross-domain · Threshold: single-user incident (CPO sign-off) · Refs #5887 #5877 #5274
 
 ## Phase 1 — Unwedge CI, zero reboot (normal PR)
-- [ ] 1.1 Edit `apps/web-platform/infra/server.tf`: `hcloud_server.web` `lifecycle.ignore_changes += placement_group_id` with a temporary-GA-deferral comment (names the GA removal trigger; notes web-2 already in the group).
-- [ ] 1.2 Add `terraform-target-parity.test.ts` assertion: plan with the ignore present → `reboot_updates = 0` on `hcloud_server.web` (guards future silent removal).
-- [ ] 1.3 Amend ADR-068 via `/soleur:architecture`: reboot-deferral + deferred GA ingress design + monitor-must-not-couple-to-supabase rule + no-live-weight-before-GA invariant.
+- [x] 1.1 Edit `apps/web-platform/infra/server.tf`: `hcloud_server.web` `lifecycle.ignore_changes += placement_group_id` with a temporary-GA-deferral comment (names the GA removal trigger; notes web-2 already in the group). — verified via `terraform validate` + live plan `31 add, 1 change, 0 destroy`.
+- [x] 1.2 Add `terraform-target-parity.test.ts` static guard: `hcloud_server.web` `ignore_changes` includes `placement_group_id` (guards future silent removal that would re-trip `reboot_updates`). — RED→GREEN, 1942 plugins tests pass.
+- [x] 1.3 Amend ADR-068: reboot-deferral + deferred GA ingress design (CF LB v4, monitor reachability-only) + no-live-weight-before-GA invariant.
 - [ ] 1.4 PR body: `Ref #5887` (NOT `Closes`); note the zero-reboot verification (`31 add, 1 change, 0 destroy`).
-- [ ] 1.5 Review gate: grep-verify no `cloudflare_load_balancer*` added; run user-impact-reviewer (single-user threshold).
+- [ ] 1.5 Review gate: grep-verify no `cloudflare_load_balancer*` added (done); run user-impact-reviewer (single-user threshold).
 
 ## Phase 1 — Post-merge (operator, automated)
 - [ ] 1.6 Confirm both apply pipelines green on `main` (`gh run list`, no dashboard).

--- a/plugins/soleur/test/terraform-target-parity.test.ts
+++ b/plugins/soleur/test/terraform-target-parity.test.ts
@@ -817,3 +817,47 @@ moved {
     expect(drifted).toEqual([]);
   });
 });
+
+describe("hcloud_server.web reboot deferral — placement_group_id stays in ignore_changes (#5887 zero-downtime CI unwedge)", () => {
+  // Removing `placement_group_id` from hcloud_server.web's lifecycle.ignore_changes
+  // re-introduces the pending web-1 placement-group attach (0 -> web_spread) into
+  // every targeted plan. That attach is a reboot-forcing in-place `update` on the
+  // RUNNING prod host, which the destroy-guard `reboot_updates` counter (#5911,
+  // tests/scripts/lib/destroy-guard-filter-web-platform.jq) HALTS with rc=2 —
+  // re-wedging BOTH apply pipelines (the #5887 wedge). The GA maintenance-window PR
+  // removes this entry ON PURPOSE to take the reboot on a drained host (blue-green);
+  // until then it must stay. This static guard fails if a future edit drops it.
+  function hcloudServerWebBody(): string {
+    const stripped = stripComments(
+      readFileSync(resolve(INFRA_DIR, "server.tf"), "utf8"),
+    );
+    const header = /resource\s+"hcloud_server"\s+"web"\s*\{/g;
+    const m = header.exec(stripped);
+    if (!m) throw new Error("hcloud_server.web block not found in server.tf");
+    // Brace-match the body (terraform ${...} interpolations are balanced, so
+    // string-embedded braces net to zero — same approach as extractTerraformDataResources).
+    let depth = 1;
+    let i = m.index + m[0].length;
+    const start = i;
+    for (; i < stripped.length && depth > 0; i++) {
+      if (stripped[i] === "{") depth++;
+      else if (stripped[i] === "}") depth--;
+    }
+    if (depth !== 0) throw new Error("Unbalanced braces for hcloud_server.web");
+    return stripped.slice(start, i - 1);
+  }
+
+  test("lifecycle.ignore_changes includes placement_group_id", () => {
+    const body = hcloudServerWebBody();
+    const ic = /ignore_changes\s*=\s*\[([^\]]*)\]/.exec(body);
+    expect(ic).not.toBeNull();
+    const entries = (ic as RegExpExecArray)[1]
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    expect(entries).toContain("placement_group_id");
+    // Non-vacuity: the pre-existing import-artifact entries (#967) are still present,
+    // proving we parsed the real ignore_changes list, not an empty/wrong block.
+    expect(entries).toContain("user_data");
+  });
+});


### PR DESCRIPTION
## What

Adds `placement_group_id` to `hcloud_server.web`'s `lifecycle.ignore_changes` (`apps/web-platform/infra/server.tf`) to **unwedge the red web-platform apply pipelines with zero reboot**, plus a static guard and an ADR-068 amendment.

## Why

`apply-web-platform-infra.yml` + `apply-deploy-pipeline-fix.yml` have been red because web-1 has a pending `placement_group_id` attach (`0 → web_spread`) that the `reboot_updates` destroy-guard (#5911) correctly halts — attaching a placement group to the **running** host forces a Hetzner power-off reboot. (The four `moved{}` blocks #5877 added are already consumed in state; the reboot is now the sole red-maker — the #5887 wedge has moved from the moved-error to the reboot-guard.)

Ignoring `placement_group_id` removes that pending attach from **every** plan, so the guard passes and both targeted CI applies self-heal green — **no maintenance window, no reboot**.

## Verification (read-only prod `terraform plan`)

| | Plan result |
|---|---|
| before (main) | `31 add, 2 change, 0 destroy` — web-1 `~ placement_group_id 0 → 1739811` (reboot) |
| after (this PR) | **`31 add, 1 change, 0 destroy`** — only the in-place `hcloud_firewall_attachment.web` server-id update remains |

- `terraform validate`: valid. `terraform fmt`: clean.
- `plugins/soleur/test/terraform-target-parity.test.ts`: RED→GREEN; full plugins bun suite **1942 pass / 0 fail**.
- `user-impact-reviewer` (single-user-incident threshold): **CONCUR — user-impact-neutral** (defers a reboot; additively hardens the non-serving web-2 via the firewall attach; no live traffic to web-2, no git-data touch).

web-2 was born **into** the group at create time, so this defers **only** web-1.

## Scope — what this does NOT do

Explicitly deferred to the GA maintenance window (see the ADR-068 amendment + the plan): the Cloudflare LB / ingress cutover, the git-data LUKS cutover, the owner-side router relay activation, and the web-1 reboot itself. The GA PR **removes** this `ignore_changes` entry as its first diff and takes the reboot on a **drained** host (blue-green). A static guard fails if the entry is dropped silently before then.

## Changelog

- fix(infra): defer the web-1 placement-group reboot via `ignore_changes` to unwedge the web-platform apply pipelines with zero downtime; guard + ADR-068 amendment.

Ref #5887, #5877, #5274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
