### PR TITLE
feat(canary): on-demand workflow to read faithful sandbox-canary soak state

### DIFF
--- a/.github/workflows/canary-status.yml
+++ b/.github/workflows/canary-status.yml
@@ -1,0 +1,71 @@
+# On-demand read of the faithful sandbox-canary soak state (#5875 / #5889 / ADR-079).
+#
+# The deploy-time canary replays the SDK-captured bwrap argv inside the prod canary
+# container each deploy and records a verdict to the host deploy-state, surfaced —
+# no-SSH (hr-no-ssh-fallback-in-runbooks) — on /hooks/deploy-status.sandbox_canary.
+# The scheduled follow-through sweeper only reads this after #5889's `earliest`
+# window opens; this workflow_dispatch lets an operator read the CURRENT verdict +
+# soak counters at any time (e.g. to confirm the fixture replays `pass` after an
+# SDK bump or a fresh capture). Read-only: it prints verdict / consecutive_pass /
+# span — no secrets in the output. Same authenticated GET as
+# scripts/followthroughs/canary-promotion-5875.sh (HMAC over an empty body +
+# CF-Access service token).
+name: canary-status
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  read-canary-status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read /hooks/deploy-status .sandbox_canary
+        env:
+          WEBHOOK_DEPLOY_SECRET: ${{ secrets.WEBHOOK_DEPLOY_SECRET }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          set -uo pipefail
+          : "${WEBHOOK_DEPLOY_SECRET:?}" "${CF_ACCESS_CLIENT_ID:?}" "${CF_ACCESS_CLIENT_SECRET:?}"
+          SIG="$(printf '' | openssl dgst -sha256 -hmac "$WEBHOOK_DEPLOY_SECRET" | sed 's/.*= //')"
+          RESP="$(curl -sS --max-time 20 -w '\nHTTP:%{http_code}' -X GET \
+            -H "X-Signature-256: sha256=$SIG" \
+            -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+            -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
+            https://deploy.soleur.ai/hooks/deploy-status)"
+          CODE="$(printf '%s' "$RESP" | sed -n 's/^HTTP://p' | tr -d '[:space:]')"
+          BODY="$(printf '%s' "$RESP" | sed '$d')"
+          if [[ "$CODE" != "200" ]]; then
+            echo "::error::deploy-status returned HTTP $CODE"; exit 1
+          fi
+          SC="$(printf '%s' "$BODY" | jq -c '.sandbox_canary // "MISSING"')"
+          if [[ "$SC" == '"MISSING"' ]]; then
+            echo "::warning::deploy-status has no .sandbox_canary field (old host / not yet written)"; echo "$BODY" | head -c 400; exit 0
+          fi
+          VERDICT="$(printf '%s' "$BODY" | jq -r '.sandbox_canary.verdict // "unknown"')"
+          CONSEC="$(printf '%s' "$BODY" | jq -r '.sandbox_canary.consecutive_pass // 0')"
+          FIRST="$(printf '%s' "$BODY" | jq -r '.sandbox_canary.first_pass_at // 0')"
+          CHECKED="$(printf '%s' "$BODY" | jq -r '.sandbox_canary.checked_at // 0')"
+          SDK="$(printf '%s' "$BODY" | jq -r '.sandbox_canary.sdk_version // ""')"
+          SPAN_D=0; [[ "$FIRST" =~ ^[0-9]+$ && "$CHECKED" =~ ^[0-9]+$ && "$FIRST" -gt 0 ]] && SPAN_D=$(( (CHECKED - FIRST) / 86400 ))
+          {
+            echo "## Faithful sandbox-canary soak state"
+            echo ""
+            echo "| field | value |"
+            echo "|---|---|"
+            echo "| verdict | \`$VERDICT\` |"
+            echo "| consecutive_pass | $CONSEC (promote needs ≥5) |"
+            echo "| span since first_pass | ${SPAN_D}d (promote needs ≥3d) |"
+            echo "| sdk_version | \`$SDK\` |"
+            echo ""
+            case "$VERDICT" in
+              pass) echo "✅ Green — the SDK's real argv replays cleanly under the committed profile in the prod canary container." ;;
+              sandbox_broken) echo "🚨 FAITHFUL FAIL — the canary disagreed with the legacy PASS gate; investigate the seccomp/apparmor profile before promoting." ;;
+              canary_infra_error) echo "⚠️ Infra-error (soak HOLDS, non-blocking) — e.g. fixture not yet baked, or a replay-env mismatch. Check the reason field." ;;
+              fixture_uncaptured) echo "⏳ Fixture not yet captured/baked — no real verdicts accruing yet." ;;
+              *) echo "Unknown verdict." ;;
+            esac
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "sandbox_canary=$SC"

--- a/.github/workflows/canary-status.yml
+++ b/.github/workflows/canary-status.yml
@@ -14,8 +14,9 @@ name: canary-status
 on:
   workflow_dispatch: {}
 
-permissions:
-  contents: read
+# No repo checkout or contents access is needed — this job only makes one
+# outbound authenticated GET and writes a summary.
+permissions: {}
 
 jobs:
   read-canary-status:
@@ -40,7 +41,10 @@ jobs:
           if [[ "$CODE" != "200" ]]; then
             echo "::error::deploy-status returned HTTP $CODE"; exit 1
           fi
-          SC="$(printf '%s' "$BODY" | jq -c '.sandbox_canary // "MISSING"')"
+          # -e: a non-JSON 200 body (e.g. a CF Access interstitial) must fall into
+          # the MISSING branch, not silently through to "unknown" (parity with
+          # scripts/followthroughs/canary-promotion-5875.sh).
+          SC="$(printf '%s' "$BODY" | jq -ce '.sandbox_canary // "MISSING"' 2>/dev/null || echo '"MISSING"')"
           if [[ "$SC" == '"MISSING"' ]]; then
             echo "::warning::deploy-status has no .sandbox_canary field (old host / not yet written)"; echo "$BODY" | head -c 400; exit 0
           fi
@@ -53,6 +57,9 @@ jobs:
           {
             echo "## Faithful sandbox-canary soak state"
             echo ""
+            # NOTE: the \` escapes below are load-bearing — inside double quotes an
+            # UNescaped backtick is command substitution, so a compromised deploy
+            # host could inject via .verdict/.sdk_version. Keep them escaped.
             echo "| field | value |"
             echo "|---|---|"
             echo "| verdict | \`$VERDICT\` |"


### PR DESCRIPTION
Adds a read-only `workflow_dispatch` workflow that reads the live per-deploy faithful sandbox-canary verdict from `deploy.soleur.ai/hooks/deploy-status` on demand.

## Why
The deploy-time canary (ADR-079, #5875) replays the SDK's real captured bwrap argv under the committed seccomp profile inside the prod canary container each deploy, and records a verdict to the host deploy-state (surfaced no-SSH on `/hooks/deploy-status.sandbox_canary`). Today that state is only read by the scheduled follow-through sweeper, and only after #5889's `earliest` window opens. This workflow lets an operator read the CURRENT verdict + soak counters at any time — e.g. to confirm the fixture landed by #5913 actually replays `pass` in prod.

## What it does
- `workflow_dispatch` (no inputs), `permissions: contents: read`.
- Same authenticated GET as `scripts/followthroughs/canary-promotion-5875.sh`: HMAC-SHA256 over an empty body (`WEBHOOK_DEPLOY_SECRET`) + CF-Access service token (`CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET`), all GH Actions secrets.
- Parses `.sandbox_canary` and writes a human-readable job summary: `verdict`, `consecutive_pass` (promote needs ≥5), span since `first_pass_at` (promote needs ≥3d), `sdk_version`, plus a verdict interpretation line.
- No secrets in output. Fails loud on non-200; warns (non-fatal) if the host has no `.sandbox_canary` field yet.

## Verification
Must merge to `main` before it is dispatchable (GitHub `workflow_dispatch` only runs workflows present on the default branch). After merge I'll `gh workflow run canary-status.yml` and report the live verdict.

Refs #5875, #5889, ADR-079

🤖 Generated with [Claude Code](https://claude.com/claude-code)