### PR TITLE
fix(infra): seccomp redeploy resolves running semver from /health, not state-file .tag (#5955)

### DIFF
--- a/.github/workflows/apply-deploy-pipeline-fix.yml
+++ b/.github/workflows/apply-deploy-pipeline-fix.yml
@@ -520,18 +520,36 @@ jobs:
 
           echo "Loaded ('${LOADED_SHA:-<none>}') != committed ('${COMMITTED_SHA}') — a seccomp change is applied but not loaded. Redeploying to load it."
 
-          # Validate the tag we will redeploy (server-supplied state, but pinned to a
-          # safe charset before it reaches the payload — no shell/JSON injection).
-          if [[ -z "$CURRENT_TAG" || "$CURRENT_TAG" == "?" || ! "$CURRENT_TAG" =~ ^[A-Za-z0-9._-]+$ ]]; then
-            echo "::error::Cannot determine a valid current image tag from /hooks/deploy-status (.tag='${CURRENT_TAG}'). Trigger a normal web-platform deploy, then re-run this apply."
+          # Resolve the redeploy tag from the RUNNING container's real version, NOT from
+          # /hooks/deploy-status .tag. That .tag is the ci-deploy STATE FILE's last-ATTEMPT
+          # tag (cat-deploy-state.sh reads /var/lock/ci-deploy.state) — which the Terraform
+          # bootstrap default image (variables.tf `...:latest`) and any REJECTED attempt
+          # leave as a non-semver value. ci-deploy.sh:713 requires ^v[0-9]+\.[0-9]+\.[0-9]+$,
+          # so re-sending `latest` is rejected (reason=tag_malformed) AND re-stamps
+          # .tag=latest — a self-perpetuating wedge (#5955, ADR-079 amendment). /health
+          # returns the baked BUILD_VERSION (bare semver); the release pipeline pushes
+          # :v<version> and :latest to the SAME digest (reusable-release.yml), so v<version>
+          # is a true same-image reload that ci-deploy.sh accepts. Public endpoint, no
+          # CF-Access (same one web-platform-release.yml curls for its health gate).
+          HEALTH_URL="https://app.${APP_DOMAIN_BASE}/health"
+          RUNNING_VERSION=$(curl -sf --max-time 15 "$HEALTH_URL" 2>/dev/null | jq -r '.version // ""' 2>/dev/null || echo "")
+          TARGET_TAG="v${RUNNING_VERSION}"
+
+          # Fail fast with the SAME semver shape ci-deploy.sh:713 enforces — never POST a
+          # doomed non-semver tag (which ci-deploy.sh would reject AND re-stamp as .tag,
+          # perpetuating the wedge). A non-released image (BUILD_VERSION unset → "dev" →
+          # "vdev") is caught here with a clear remediation instead of a tag_malformed loop.
+          if [[ ! "$TARGET_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Cannot resolve a semver tag for the running container from ${HEALTH_URL} (.version='${RUNNING_VERSION}', state-file .tag='${CURRENT_TAG}'). The container is not reporting a released BUILD_VERSION. Trigger a normal web-platform release, then re-run this apply."
             exit 1
           fi
+          echo "Redeploying running version as ${TARGET_TAG} (state-file .tag was '${CURRENT_TAG}')."
 
-          # POST /hooks/deploy — redeploy the SAME image so the container restarts and
-          # loads the applied profile. No `peers` (single-host reload; fan-out is a
-          # dormant no-op at single-host, ADR-068). ci-deploy.sh's flock dedupes any
-          # concurrent web-platform-release deploy.
-          PAYLOAD=$(printf '{"command":"deploy web-platform ghcr.io/jikig-ai/soleur-web-platform %s"}' "$CURRENT_TAG")
+          # POST /hooks/deploy — redeploy the SAME image (same digest as the running
+          # :latest) so the container restarts and loads the applied profile. No `peers`
+          # (single-host reload; fan-out is a dormant no-op at single-host, ADR-068).
+          # ci-deploy.sh's flock dedupes any concurrent web-platform-release deploy.
+          PAYLOAD=$(printf '{"command":"deploy web-platform ghcr.io/jikig-ai/soleur-web-platform %s"}' "$TARGET_TAG")
           POST_SIG=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | sed 's/.*= //')
           POST_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 \
             -X POST \

--- a/knowledge-base/engineering/architecture/decisions/ADR-079-faithful-sandbox-canary-and-profile-redeploy-verification.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-079-faithful-sandbox-canary-and-profile-redeploy-verification.md
@@ -325,6 +325,34 @@ the helper uses `node:22-slim` + `npm ci` (the deploy `FROM` base), not the full
 built web-platform image; they share the base OS filesystem so the host-conditional
 token set is identical — a follow-up could pin to the built image for exactness.
 
+### Amendment (#5955, 2026-07-03) — the seccomp reload resolves the running semver from `/health`; the deploy contract stays semver-only
+
+The "item 4" redeploy step (`apply-deploy-pipeline-fix.yml`) originally read the tag to
+redeploy from `/hooks/deploy-status` `.tag`. That field is the ci-deploy **state file**'s
+last-ATTEMPT tag (`cat-deploy-state.sh` reads `/var/lock/ci-deploy.state`), not the running
+container's real image. The Terraform bootstrap default runs `...:latest` (`variables.tf`),
+and `ci-deploy.sh:713` requires `^v[0-9]+\.[0-9]+\.[0-9]+$` — so the redeploy re-sent
+`latest`, was rejected with `reason=tag_malformed`, and the rejection **re-stamped**
+`.tag=latest`, a self-perpetuating wedge that reddened the pipeline (surfaced once PR #5950
+cleared the #5877 reboot wedge that had masked it; #5955).
+
+**Decision (CTO ruling 2026-07-03).** The redeploy resolves the running container's version
+from the **public `/health` endpoint** (`.version` = the baked `BUILD_VERSION`, a bare
+semver) and redeploys `v<version>`. The release pipeline pushes `:v<version>` and `:latest`
+to the **same digest** (`reusable-release.yml`), so `v<version>` is a true same-image reload
+that `ci-deploy.sh` accepts — no version change, no risk beyond the already-intended graceful
+seccomp reload. The step's tag validation is **tightened to the exact `^v[0-9]+\.[0-9]+\.[0-9]+$`
+shape** so a non-released image (`BUILD_VERSION` unset → `"dev"` → `"vdev"`) fails loud with a
+remediation instead of perpetuating the loop.
+
+**Rejected:** (a) `docker inspect .Config.Image` — returns `:latest` for the bootstrap
+container, same unhelpful answer, and a digest-redeploy would force a `ci-deploy.sh` guard
+change; (b) relaxing `ci-deploy.sh`'s semver guard to accept `latest`/digest — the guard
+deliberately rejects floating tags and backs the wrong-image-tagged-with-right-version check
+(`web-platform-release.yml:683`); a resolution bug in one caller must not widen the deploy
+contract. **The deploy contract stays semver-only.** Single-file change:
+`.github/workflows/apply-deploy-pipeline-fix.yml`.
+
 ## Consequences
 
 - **Positive.** A future SDK bump that breaks the sandbox is caught pre-merge


### PR DESCRIPTION
## What

Fixes `apply-deploy-pipeline-fix.yml`'s "Redeploy to load applied profile and assert loaded==committed (#5875 item 4)" step, which fails with deploy-status `.reason=tag_malformed`. One file (+ ADR-079 amendment).

## Why

The step read the redeploy tag from `/hooks/deploy-status` `.tag` — the ci-deploy **state file**'s last-*attempt* tag (`cat-deploy-state.sh` reads `/var/lock/ci-deploy.state`), not the running container's real image. The Terraform bootstrap default runs `...:latest` (`variables.tf`), and `ci-deploy.sh:713` requires `^v[0-9]+\.[0-9]+\.[0-9]+$` — so the redeploy re-sent `latest`, was rejected as `tag_malformed`, and the rejection **re-stamped** `.tag=latest`: a self-perpetuating wedge. It surfaced only after **#5950** cleared the #5877 reboot wedge that had masked this step (it had never run green — see issue #5955).

## Fix (CTO ruling — ADR-079 amendment)

Resolve the running container's version from the **public `/health`** endpoint (`.version` = baked `BUILD_VERSION`, a bare semver) and redeploy `v<version>`. The release pipeline pushes `:v<version>` and `:latest` to the **same digest** (`reusable-release.yml`), so `v<version>` is a **true same-image reload** `ci-deploy.sh` accepts — no version change, no new prod risk beyond the intended graceful seccomp reload (ADR-078 cron-drain + faithful canary + single-replica invariant all still apply). Tighten the step's tag validation to the exact `^v[0-9]+\.[0-9]+\.[0-9]+$` shape so a non-released image (`BUILD_VERSION` unset → `vdev`) fails loud instead of looping.

**Rejected** (per ruling): relaxing `ci-deploy.sh`'s semver guard (it deliberately rejects floating tags + backs the wrong-image check at `web-platform-release.yml:683`) and `docker inspect` (returns `:latest` for the bootstrap container). The semver-only deploy contract is preserved — `ci-deploy.sh` is unchanged.

## Verification

- `actionlint` clean; `bash -n` on the extracted `run:` snippet clean.
- Adjacent gate tests (`terraform-target-parity`, `ship-deploy-pipeline-fix-gate`) **115 pass / 0 fail**.
- No untrusted `github.event.*` input; `RUNNING_VERSION` is semver-pinned before it reaches the payload (no injection).
- **Post-merge:** `apply-deploy-pipeline-fix.yml` runs on merge and should go green (one graceful same-digest redeploy that loads the committed seccomp profile). This is a `Ref` (not auto-close) issue — I'll close #5955 after the pipeline confirms green.

## Changelog

- fix(infra): seccomp-reload redeploy resolves the running semver from `/health` instead of the unreliable state-file `.tag`; tightens tag validation; ADR-079 amendment.

Ref #5955, #5875, #5950.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
