### PR TITLE
feat(releases): flatten markdown in titles + search/sort/filter

### DIFF
--- a/apps/web-platform/components/releases/releases-surface.tsx
+++ b/apps/web-platform/components/releases/releases-surface.tsx
@@ -1,21 +1,23 @@
 "use client";
 
-// Releases feed surface (#5958). Client component rendered inside a <Suspense>
-// by the server page at app/(dashboard)/dashboard/releases. Fetches
-// /api/dashboard/releases (web-v* GitHub Releases, cleaned server-side, newest
-// first) and renders reverse-chronological cards. State handling mirrors
+// Releases feed surface (#5958; filters/sort/search follow-up). Client component
+// rendered inside a <Suspense> by the server page at
+// app/(dashboard)/dashboard/releases. Fetches /api/dashboard/releases (web-v*
+// GitHub Releases, cleaned server-side, newest first) and renders
+// reverse-chronological cards with client-side search, sort, and a release-type
+// filter (the full list is already in memory via SWR). State handling mirrors
 // inbox-surface (ADR-067): skeleton gates on `!data`, RefreshShimmer on warm
 // revalidation, StaleRefreshBar when a background refresh fails while stale data
 // is shown, ErrorCard only on the cold (`!data && error`) failure.
 
-import { useCallback } from "react";
+import { useCallback, useMemo, useState } from "react";
 import useSWR from "swr";
 import { ErrorCard } from "@/components/ui/error-card";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
 import { RefreshShimmer } from "@/components/ui/refresh-shimmer";
 import { StaleRefreshBar } from "@/components/ui/stale-refresh-bar";
 import { swrKeys } from "@/lib/swr-config";
-import type { ReleaseCard } from "@/server/release-notes";
+import type { ReleaseBump, ReleaseCard } from "@/server/release-notes";
 
 export async function fetchReleases(): Promise<ReleaseCard[]> {
   const res = await fetch("/api/dashboard/releases");
@@ -34,6 +36,12 @@ function formatDate(iso: string): string {
   }).format(new Date(t));
 }
 
+type SortOrder = "newest" | "oldest";
+type BumpFilter = "all" | Exclude<ReleaseBump, null>;
+
+const SELECT_CLASS =
+  "rounded-md border border-soleur-border-default bg-soleur-bg-surface-1 px-2.5 py-1.5 text-sm text-soleur-text-primary focus:border-amber-400/50 focus:outline-none";
+
 export function ReleasesSurface() {
   const {
     data: releases,
@@ -42,9 +50,37 @@ export function ReleasesSurface() {
     mutate,
   } = useSWR(swrKeys.releasesList(), fetchReleases);
 
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<SortOrder>("newest");
+  const [bumpFilter, setBumpFilter] = useState<BumpFilter>("all");
+
   const refetch = useCallback(() => {
     void mutate();
   }, [mutate]);
+
+  // The server returns newest-first, so the true latest is index 0 — pin the
+  // "Latest" badge to its tag so it stays correct under any sort/filter.
+  const latestTag = releases?.[0]?.tag;
+
+  const visible = useMemo(() => {
+    const all = releases ?? [];
+    const q = query.trim().toLowerCase();
+    const filtered = all.filter((r) => {
+      if (bumpFilter !== "all" && r.bump !== bumpFilter) return false;
+      if (!q) return true;
+      return (
+        r.tag.toLowerCase().includes(q) ||
+        r.title.toLowerCase().includes(q) ||
+        r.bodyMarkdown.toLowerCase().includes(q)
+      );
+    });
+    // Stable sort by publish time; `all` is already newest-first.
+    return sort === "newest"
+      ? filtered
+      : [...filtered].sort(
+          (a, b) => Date.parse(a.publishedAt) - Date.parse(b.publishedAt),
+        );
+  }, [releases, query, sort, bumpFilter]);
 
   // Cold failure (no data yet) — full error surface.
   if (error && releases === undefined) {
@@ -92,51 +128,105 @@ export function ReleasesSurface() {
           the last good feed — keep it, offer a retry (spec-flow Gap 2). */}
       {error && <StaleRefreshBar onRetry={refetch} />}
 
-      <ul className="space-y-4">
-        {releases.map((r, i) => (
-          <li
-            key={r.tag}
-            className="rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1 p-5"
+      {/* Controls: search + release-type filter + sort. */}
+      <div className="mb-5 flex flex-wrap items-center gap-2">
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search releases…"
+          aria-label="Search releases"
+          className="min-w-[12rem] flex-1 rounded-md border border-soleur-border-default bg-soleur-bg-surface-1 px-3 py-1.5 text-sm text-soleur-text-primary placeholder:text-soleur-text-muted focus:border-amber-400/50 focus:outline-none"
+        />
+        <select
+          value={bumpFilter}
+          onChange={(e) => setBumpFilter(e.target.value as BumpFilter)}
+          aria-label="Filter by release type"
+          className={SELECT_CLASS}
+        >
+          <option value="all">All releases</option>
+          <option value="major">Major</option>
+          <option value="minor">Minor</option>
+          <option value="patch">Patch</option>
+        </select>
+        <select
+          value={sort}
+          onChange={(e) => setSort(e.target.value as SortOrder)}
+          aria-label="Sort releases"
+          className={SELECT_CLASS}
+        >
+          <option value="newest">Newest first</option>
+          <option value="oldest">Oldest first</option>
+        </select>
+      </div>
+
+      <p className="mb-3 text-xs text-soleur-text-muted">
+        {visible.length === releases.length
+          ? `${releases.length} release${releases.length === 1 ? "" : "s"}`
+          : `${visible.length} of ${releases.length} releases`}
+      </p>
+
+      {visible.length === 0 ? (
+        <div className="py-8 text-sm text-soleur-text-secondary">
+          No releases match your search or filter.{" "}
+          <button
+            type="button"
+            onClick={() => {
+              setQuery("");
+              setBumpFilter("all");
+            }}
+            className="text-soleur-text-primary underline underline-offset-2 hover:text-amber-400"
           >
-            <div className="mb-2 flex items-baseline justify-between gap-3">
-              <div className="flex items-center gap-2">
-                <span className="font-mono text-sm text-soleur-text-primary">
-                  {r.tag}
-                </span>
-                {i === 0 && (
-                  <span className="rounded-full bg-amber-400/15 px-2 py-0.5 text-xs font-medium text-amber-400">
-                    Latest
+            Clear
+          </button>
+        </div>
+      ) : (
+        <ul className="space-y-4">
+          {visible.map((r) => (
+            <li
+              key={r.tag}
+              className="rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1 p-5"
+            >
+              <div className="mb-2 flex items-baseline justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  <span className="font-mono text-sm text-soleur-text-primary">
+                    {r.tag}
                   </span>
-                )}
+                  {r.tag === latestTag && (
+                    <span className="rounded-full bg-amber-400/15 px-2 py-0.5 text-xs font-medium text-amber-400">
+                      Latest
+                    </span>
+                  )}
+                </div>
+                <time
+                  dateTime={r.publishedAt}
+                  className="shrink-0 text-xs text-soleur-text-secondary"
+                >
+                  {formatDate(r.publishedAt)}
+                </time>
               </div>
-              <time
-                dateTime={r.publishedAt}
-                className="shrink-0 text-xs text-soleur-text-secondary"
-              >
-                {formatDate(r.publishedAt)}
-              </time>
-            </div>
-            {r.title && r.title !== r.tag && (
-              <h2 className="mb-2 text-base font-medium text-soleur-text-primary">
-                {r.title}
-              </h2>
-            )}
-            <div className="text-sm text-soleur-text-secondary">
-              <MarkdownRenderer content={r.bodyMarkdown} />
-            </div>
-            {r.htmlUrl && (
-              <a
-                href={r.htmlUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="mt-3 inline-block text-xs text-soleur-text-secondary underline-offset-2 hover:text-soleur-text-primary hover:underline"
-              >
-                View on GitHub
-              </a>
-            )}
-          </li>
-        ))}
-      </ul>
+              {r.title && r.title !== r.tag && (
+                <h2 className="mb-2 text-base font-medium text-soleur-text-primary">
+                  {r.title}
+                </h2>
+              )}
+              <div className="text-sm text-soleur-text-secondary">
+                <MarkdownRenderer content={r.bodyMarkdown} />
+              </div>
+              {r.htmlUrl && (
+                <a
+                  href={r.htmlUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-3 inline-block text-xs text-soleur-text-secondary underline-offset-2 hover:text-soleur-text-primary hover:underline"
+                >
+                  View on GitHub
+                </a>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/apps/web-platform/server/release-notes.ts
+++ b/apps/web-platform/server/release-notes.ts
@@ -59,15 +59,42 @@ function stripPii(s: string): string {
 // changelog line (the squashed PR title) is the real content.
 const VERSION_ONLY_TITLE_RE = /^[a-z-]*v?\d[\w.-]*$/i;
 
+// The card TITLE renders in a plain <h2>, NOT through the markdown renderer, so
+// any inline markdown in a derived title (a PR-title changelog line) would show
+// literal `**`/backticks (#5958 follow-up). Flatten it to readable plain text:
+// unwrap links, drop bold/italic/code/strikethrough markers, strip a leading
+// heading marker. Only `*`/`**`/double-`_` emphasis is touched — single `_` is
+// left intact so identifiers like `worktree_id` survive.
+function stripInlineMarkdown(s: string): string {
+  return s
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1") // images/links → their text
+    .replace(/`+/g, "") // inline code fences
+    .replace(/\*\*(.*?)\*\*/g, "$1") // bold **x**
+    .replace(/__(.*?)__/g, "$1") // bold __x__
+    .replace(/~~(.*?)~~/g, "$1") // strikethrough
+    .replace(/(^|[^*])\*([^*\s][^*]*?)\*/g, "$1$2") // italic *x*
+    .replace(/^#{1,6}\s+/, "") // leading heading marker
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// Truncate on a word boundary (never mid-word) with an ellipsis.
+function truncateAtWord(s: string, max: number): string {
+  if (s.length <= max) return s;
+  const cut = s.slice(0, max);
+  const lastSpace = cut.lastIndexOf(" ");
+  return `${(lastSpace > max * 0.6 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`;
+}
+
 function deriveTitle(base: string, body: string): string {
   if (!VERSION_ONLY_TITLE_RE.test(base)) return base;
   for (const raw of body.split("\n")) {
     const line = raw.trim().replace(/^[-*]\s+/, "");
     if (!line || line.startsWith("#")) continue;
-    // Strip BEFORE slicing — truncation could bisect an email and leave a
-    // local-part fragment the regexes no longer match (stripPii is idempotent).
-    const derived = stripPii(line).trim().slice(0, MAX_DERIVED_TITLE_CHARS);
-    return derived || base;
+    // Strip PII + inline markdown BEFORE truncating — truncation could bisect an
+    // email and leave a fragment the regexes no longer match (both are idempotent).
+    const derived = stripInlineMarkdown(stripPii(line)).trim();
+    return derived ? truncateAtWord(derived, MAX_DERIVED_TITLE_CHARS) : base;
   }
   return base;
 }
@@ -82,7 +109,11 @@ export function sanitizeReleases(releases: RawGithubRelease[]): SanitizedRelease
     const rawBody = (r.body ?? "").slice(0, MAX_RAW_BODY_CHARS);
     const securitySensitive = SECURITY_DOWN_DETAIL_RE.test(`${r.name ?? ""}\n${rawBody}`);
     const base = (r.name || r.tag_name).trim();
-    const title = stripPii(securitySensitive ? base : deriveTitle(base, rawBody)).trim();
+    // deriveTitle already flattens markdown; also flatten the security-case name
+    // (rendered title-only) so a name with markdown never shows literal markers.
+    const title = stripInlineMarkdown(
+      stripPii(securitySensitive ? base : deriveTitle(base, rawBody)),
+    ).trim();
     const body = securitySensitive
       ? ""
       : stripPii(rawBody).slice(0, MAX_RELEASE_BODY_CHARS);
@@ -97,6 +128,11 @@ const MAX_PAGES = 5;
 const DEFAULT_LIMIT = 50;
 const TOKEN_MIN_LIFETIME_MS = 60_000;
 
+/** Semver bump of a release relative to the previous one (`null` = the oldest
+ *  release in the fetched window, or a tag that doesn't parse). Powers the
+ *  release-type filter. */
+export type ReleaseBump = "major" | "minor" | "patch" | null;
+
 /** A single card in the in-app Releases feed. `bodyMarkdown` is ALWAYS non-empty
  *  (fallback applied) so a card never renders blank (spec-flow Gap 1+3). */
 export interface ReleaseCard {
@@ -106,6 +142,23 @@ export interface ReleaseCard {
   publishedAt: string;
   htmlUrl: string;
   securitySensitive: boolean;
+  bump: ReleaseBump;
+}
+
+function parseWebVersion(tag: string): [number, number, number] | null {
+  const m = /^web-v(\d+)\.(\d+)\.(\d+)/.exec(tag);
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+// Bump of `tag` relative to the next-older release `prevTag`. Web versions
+// increase monotonically, so a differing segment marks the bump kind.
+function computeBump(tag: string, prevTag: string | undefined): ReleaseBump {
+  const cur = parseWebVersion(tag);
+  const prev = prevTag ? parseWebVersion(prevTag) : null;
+  if (!cur || !prev) return null;
+  if (cur[0] !== prev[0]) return "major";
+  if (cur[1] !== prev[1]) return "minor";
+  return "patch";
 }
 
 // Web-platform releases only: anchor on the digit so plugin `v3.x` (which
@@ -185,6 +238,8 @@ export async function fetchWebReleases(opts?: {
       publishedAt: r.published_at,
       htmlUrl: r.html_url ?? "",
       securitySensitive: s.securitySensitive,
+      // `slice` is newest-first, so the next-older release is at i+1.
+      bump: computeBump(r.tag_name, slice[i + 1]?.tag_name),
     };
   });
 }

--- a/apps/web-platform/test/components/releases-surface.test.tsx
+++ b/apps/web-platform/test/components/releases-surface.test.tsx
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 
 // MarkdownRenderer is heavy (react-markdown + lazy c4 diagram); stub it to a
 // plain content passthrough so the surface test stays in jsdom.
@@ -19,6 +25,7 @@ function card(over: Partial<ReleaseCard> = {}): ReleaseCard {
     publishedAt: "2026-07-02T00:00:00Z",
     htmlUrl: "https://github.com/jikig-ai/soleur/releases/tag/web-v1.0.0",
     securitySensitive: false,
+    bump: "minor",
     ...over,
   };
 }
@@ -84,5 +91,62 @@ describe("ReleasesSurface", () => {
       expect(screen.getByText(/Couldn't load releases/i)).toBeTruthy(),
     );
     expect(screen.getByText("Try again")).toBeTruthy();
+  });
+
+  async function renderFeed(releases: ReleaseCard[]) {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ releases }) });
+    render(<Wrapped />);
+    await waitFor(() => expect(screen.getByText(releases[0].tag)).toBeTruthy());
+  }
+
+  it("filters cards by the search query (tag/title/body)", async () => {
+    await renderFeed([
+      card({ tag: "web-v2.0.0", title: "Alpha feature", bodyMarkdown: "x" }),
+      card({ tag: "web-v1.0.0", title: "Beta feature", bodyMarkdown: "y" }),
+    ]);
+    fireEvent.change(screen.getByLabelText("Search releases"), {
+      target: { value: "Alpha" },
+    });
+    expect(screen.getByText("web-v2.0.0")).toBeTruthy();
+    expect(screen.queryByText("web-v1.0.0")).toBeNull();
+    expect(screen.getByText("1 of 2 releases")).toBeTruthy();
+  });
+
+  it("filters by release type (major/minor/patch)", async () => {
+    await renderFeed([
+      card({ tag: "web-v2.0.0", bump: "major" }),
+      card({ tag: "web-v1.1.0", bump: "minor" }),
+      card({ tag: "web-v1.0.1", bump: "patch" }),
+    ]);
+    fireEvent.change(screen.getByLabelText("Filter by release type"), {
+      target: { value: "major" },
+    });
+    expect(screen.getByText("web-v2.0.0")).toBeTruthy();
+    expect(screen.queryByText("web-v1.1.0")).toBeNull();
+    expect(screen.queryByText("web-v1.0.1")).toBeNull();
+  });
+
+  it("sorts oldest-first when selected (Latest badge stays on the newest)", async () => {
+    await renderFeed([
+      card({ tag: "web-v2.0.0", publishedAt: "2026-07-02T00:00:00Z" }),
+      card({ tag: "web-v1.0.0", publishedAt: "2026-07-01T00:00:00Z" }),
+    ]);
+    fireEvent.change(screen.getByLabelText("Sort releases"), {
+      target: { value: "oldest" },
+    });
+    const tags = screen.getAllByText(/^web-v/).map((el) => el.textContent);
+    expect(tags).toEqual(["web-v1.0.0", "web-v2.0.0"]);
+    // "Latest" still pinned to the newest (web-v2.0.0), even at the bottom.
+    expect(screen.getAllByText("Latest")).toHaveLength(1);
+  });
+
+  it("shows a filtered-empty state with a Clear reset", async () => {
+    await renderFeed([card({ tag: "web-v2.0.0", title: "Alpha" })]);
+    fireEvent.change(screen.getByLabelText("Search releases"), {
+      target: { value: "zzz-no-match" },
+    });
+    expect(screen.getByText(/No releases match/i)).toBeTruthy();
+    fireEvent.click(screen.getByText("Clear"));
+    expect(screen.getByText("web-v2.0.0")).toBeTruthy();
   });
 });

--- a/apps/web-platform/test/release-notes.test.ts
+++ b/apps/web-platform/test/release-notes.test.ts
@@ -74,6 +74,37 @@ describe("sanitizeReleases", () => {
     ]);
     expect(s.title).toBe("Faster dashboard tab switching");
   });
+
+  it("flattens inline markdown in the derived title (no literal ** or backticks)", () => {
+    const [s] = sanitizeReleases([
+      rel({
+        tag_name: "web-v1.4.0",
+        name: "web-v1.4.0",
+        body: "- **ADR-068 amendments:** user-sticky routing via `worktree_id` and [a link](https://x.io)",
+      }),
+    ]);
+    expect(s.title).not.toContain("**");
+    expect(s.title).not.toContain("`");
+    expect(s.title).toContain("ADR-068 amendments: user-sticky routing via worktree_id");
+    expect(s.title).toContain("a link");
+    // Single underscores in identifiers survive.
+    expect(s.title).toContain("worktree_id");
+  });
+
+  it("truncates a long derived title on a word boundary with an ellipsis", () => {
+    const long = Array.from({ length: 40 }, (_, i) => `word${i}`).join(" ");
+    const [s] = sanitizeReleases([
+      rel({ tag_name: "web-v1.5.0", name: "web-v1.5.0", body: `- ${long}` }),
+    ]);
+    expect(s.title.length).toBeLessThanOrEqual(151); // 150 + ellipsis
+    expect(s.title.endsWith("…")).toBe(true);
+    // The stem (title minus ellipsis) is a clean word-boundary prefix of the
+    // original: it is a prefix, and the original's next char is a space — i.e.
+    // no word was bisected.
+    const stem = s.title.slice(0, -1);
+    expect(long.startsWith(stem)).toBe(true);
+    expect(long[stem.length]).toBe(" ");
+  });
 });
 
 describe("fetchWebReleases", () => {
@@ -161,6 +192,19 @@ describe("fetchWebReleases", () => {
       expect.any(Error),
       expect.objectContaining({ op: "releases-page-undercount" }),
     );
+  });
+
+  it("labels each release's bump (major/minor/patch) vs the next-older release", async () => {
+    fetchMock.mockResolvedValueOnce(
+      page([
+        rel({ tag_name: "web-v2.0.0" }), // vs 1.3.1 → major
+        rel({ tag_name: "web-v1.3.1" }), // vs 1.3.0 → patch
+        rel({ tag_name: "web-v1.3.0" }), // vs 1.2.0 → minor
+        rel({ tag_name: "web-v1.2.0" }), // oldest in window → null
+      ]),
+    );
+    const cards = await fetchWebReleases();
+    expect(cards.map((c) => c.bump)).toEqual(["major", "patch", "minor", null]);
   });
 
   it("throws on a non-200 GitHub response", async () => {


### PR DESCRIPTION
## Summary
Follow-up on the in-app Releases page (PR #5956). Fixes a markdown-rendering bug in card titles and adds the search / sort / filter affordances requested against the live page.

Closes #5961

## Changelog
### Web Platform
- **Title fix:** a derived card title (the first changelog line) rendered raw markdown literally (`**bold**`, backticks) in the plain `<h2>`. Now flattened to clean plain text via `stripInlineMarkdown` (links unwrapped; bold/italic/code/strikethrough markers dropped; single `_` preserved so `worktree_id` survives) with word-boundary truncation (`truncateAtWord`).
- **Search:** client-side search box filtering tag / title / body.
- **Sort:** Newest-first (default) / Oldest-first.
- **Filter:** release-type filter (All / Major / Minor / Patch) from a server-computed `bump` field (consecutive `web-vX.Y.Z` deltas). "Latest" badge stays pinned to the true newest under any sort/filter. Filtered-empty state with a Clear reset.

## Test plan
- [x] `tsc --noEmit` clean
- [x] 23 tests green (release-notes: title-strip, truncation, bump; surface: search, filter, sort, filtered-empty+clear)
- [x] Cron digest regression 37/37 (title-derivation change is backward-compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)