### PR TITLE
fix(infra): validate redeploy swap terminal + read loaded seccomp profile live

### DIFF
--- a/.github/workflows/apply-deploy-pipeline-fix.yml
+++ b/.github/workflows/apply-deploy-pipeline-fix.yml
@@ -499,26 +499,81 @@ jobs:
               "$STATUS_URL" 2>/dev/null || echo "000"
           }
 
-          # --- Read current loaded profile + running tag + baseline start_ts ---
+          # Read the seccomp state-invariant fields from a status JSON file into
+          # globals. #5960: the load-bearing proof is now the LIVE host+container
+          # discriminators (cat-deploy-state.sh seccomp_live_json), NOT the ephemeral
+          # recorded .seccomp_profile_sha256 (reboot-cleared, latch-blind).
+          read_frame() {
+            local f="$1"
+            HOST_PRESENT=$(jq -r '.seccomp_profile_host_present // false' "$f" 2>/dev/null || echo false)
+            HOST_SHA=$(jq -r '.seccomp_profile_host_sha256 // ""' "$f" 2>/dev/null || echo "")
+            LOADED_MATCHES=$(jq -r '.seccomp_profile_loaded_matches_host // false' "$f" 2>/dev/null || echo false)
+          }
+
+          # STATE invariant: the running container is enforcing the committed
+          # profile. Delivery leg host==committed is raw sha256sum on BOTH sides
+          # (version-independent); reload leg loaded==host is precomputed host-side
+          # (skew-immune). No cross-jq comparison anywhere on this path.
+          invariant_holds() {
+            [[ "$HOST_PRESENT" == "true" && -n "$HOST_SHA" \
+               && "$HOST_SHA" == "$COMMITTED_SHA" && "$LOADED_MATCHES" == "true" ]]
+          }
+
+          # Self-diagnosing failure: name the discriminator class (not-delivered /
+          # host-stale / not-reloaded) from the frozen frame, then fail loud.
+          diagnose_and_fail() {
+            if [[ "$HOST_PRESENT" != "true" ]]; then
+              echo "::error::seccomp profile NOT DELIVERED to the host at /etc/docker/seccomp-profiles/soleur-bwrap.json (seccomp_profile_host_present=false). The terraform apply did not place the file."
+            elif [[ "$HOST_SHA" != "$COMMITTED_SHA" ]]; then
+              echo "::error::Host has a STALE/WRONG seccomp profile: host sha256='${HOST_SHA:-<none>}' != committed '${COMMITTED_SHA}' — delivery/path drift."
+            elif [[ "$LOADED_MATCHES" != "true" ]]; then
+              echo "::error::Seccomp profile is on the host and matches committed, but the RUNNING container did NOT reload it (seccomp_profile_loaded_matches_host=false) — the redeploy did not swap the container onto the committed profile."
+            else
+              echo "::error::Seccomp loaded-profile invariant failed, unclassified (host_present=${HOST_PRESENT}, host_sha='${HOST_SHA:-<none>}', loaded_matches=${LOADED_MATCHES})."
+            fi
+            cat /tmp/redeploy-terminal.json >&2 2>/dev/null || true
+            exit 1
+          }
+
+          # --- Baseline: read live discriminators + running tag + prior start_ts ---
           HTTP=$(get_status)
           if [[ "$HTTP" != "200" ]]; then
             echo "::error::Cannot read /hooks/deploy-status (HTTP $HTTP) — refusing to assert loaded profile blind."
             cat /tmp/redeploy-status.json >&2 2>/dev/null || true
             exit 1
           fi
-          LOADED_SHA=$(jq -r '.seccomp_profile_sha256 // ""' /tmp/redeploy-status.json 2>/dev/null || echo "")
-          CURRENT_TAG=$(jq -r '.tag // ""' /tmp/redeploy-status.json 2>/dev/null || echo "")
-          PRIOR_START=$(jq -r '.start_ts // 0' /tmp/redeploy-status.json 2>/dev/null || echo 0)
+          cp /tmp/redeploy-status.json /tmp/redeploy-terminal.json
+          read_frame /tmp/redeploy-terminal.json
+          CURRENT_TAG=$(jq -r '.tag // ""' /tmp/redeploy-terminal.json 2>/dev/null || echo "")
+          PRIOR_START=$(jq -r '.start_ts // 0' /tmp/redeploy-terminal.json 2>/dev/null || echo 0)
           [[ "$PRIOR_START" =~ ^[0-9]+$ ]] || PRIOR_START=0
-          echo "Running container loaded seccomp sha256: '${LOADED_SHA:-<none>}' (tag='${CURRENT_TAG}')"
+          echo "Baseline: host_present=${HOST_PRESENT} host_sha256='${HOST_SHA:-<none>}' loaded_matches_host=${LOADED_MATCHES} (committed='${COMMITTED_SHA}', tag='${CURRENT_TAG}')."
 
-          # --- Fast path: already loaded → no swap needed ---
-          if [[ "$LOADED_SHA" == "$COMMITTED_SHA" ]]; then
-            echo "Loaded profile already equals committed — no profile change to load; skipping redeploy."
+          # --- Fast path: STATE invariant already holds → no swap needed ---
+          if invariant_holds; then
+            echo "Running container is already enforcing the committed profile (host==committed AND loaded==host) — no redeploy needed."
             exit 0
           fi
 
-          echo "Loaded ('${LOADED_SHA:-<none>}') != committed ('${COMMITTED_SHA}') — a seccomp change is applied but not loaded. Redeploying to load it."
+          # Settle-once guard: if the ONLY unmet condition is the reload leg (host
+          # already has the committed profile but the container reload is
+          # unconfirmed — e.g. an in-flight swap mid-window), settle 30s and re-read
+          # before triggering a ~70-min redeploy on a transient false-negative.
+          if [[ "$HOST_PRESENT" == "true" && "$HOST_SHA" == "$COMMITTED_SHA" && "$LOADED_MATCHES" != "true" ]]; then
+            echo "Host has the committed profile but the container reload is unconfirmed — settling 30s and re-reading before deciding to redeploy."
+            sleep 30
+            HTTP=$(get_status)
+            if [[ "$HTTP" == "200" ]]; then
+              cp /tmp/redeploy-status.json /tmp/redeploy-terminal.json
+              read_frame /tmp/redeploy-terminal.json
+              if invariant_holds; then
+                echo "Re-read confirms the container is now enforcing the committed profile — no redeploy needed."
+                exit 0
+              fi
+            fi
+          fi
+
+          echo "STATE invariant not satisfied — a seccomp change is applied but the running container is not enforcing it. Redeploying to load it."
 
           # Resolve the redeploy tag from the RUNNING container's real version, NOT from
           # /hooks/deploy-status .tag. That .tag is the ci-deploy STATE FILE's last-ATTEMPT
@@ -565,42 +620,92 @@ jobs:
           fi
           echo "Redeploy initiated (HTTP 202). Polling for completion (bounded by the ADR-078 cron drain)..."
 
-          # Poll until a deploy that STARTED after our trigger reaches a terminal
-          # exit_code (>=0). 160 × 30s = 4800s, inside the 90-min job ceiling and
-          # ≥ CRON_DRAIN_TIMEOUT (4200s). exit_code -1 == running (ci-deploy #2205).
-          FINAL_EXIT=""
-          FINAL_LOADED=""
-          FINAL_VERDICT=""
+          # Poll for a GENUINE web-platform swap terminal of OUR target tag that
+          # started after our trigger. lock_contention / adr027_prod_already_running
+          # / running(exit -1) are NON-TERMINAL: a flock loser stamps OUR
+          # component+tag with exit_code=1 (START_TS + COMPONENT/TAG are set
+          # pre-flock, ci-deploy.sh:207/:674) and that frame persists for the
+          # winner's whole multi-minute swap — failing on it would false-red under
+          # any concurrent web-platform deploy. The winner's ok/ok_peer_fanout_
+          # degraded terminal is authoritative (it loads the same committed profile);
+          # on poll exhaustion the STATE check below adjudicates. 160 × 30s = 4800s ≥
+          # CRON_DRAIN_TIMEOUT (4200s), inside the 90-min job ceiling.
+          ACCEPTED=""
           for attempt in $(seq 1 160); do
             sleep 30
             HTTP=$(get_status)
             [[ "$HTTP" == "200" ]] || { echo "Attempt $attempt: status HTTP $HTTP"; continue; }
+            COMPONENT=$(jq -r '.component // ""' /tmp/redeploy-status.json 2>/dev/null || echo "")
+            FRAME_TAG=$(jq -r '.tag // ""' /tmp/redeploy-status.json 2>/dev/null || echo "")
+            REASON=$(jq -r '.reason // ""' /tmp/redeploy-status.json 2>/dev/null || echo "")
             EXIT=$(jq -r '.exit_code // -99' /tmp/redeploy-status.json 2>/dev/null || echo -99)
             START=$(jq -r '.start_ts // 0' /tmp/redeploy-status.json 2>/dev/null || echo 0)
             [[ "$START" =~ ^[0-9]+$ ]] || START=0
-            if [[ "$EXIT" =~ ^-?[0-9]+$ ]] && [[ "$EXIT" -ge 0 ]] && [[ "$START" -gt "$PRIOR_START" ]]; then
-              FINAL_EXIT="$EXIT"
-              FINAL_LOADED=$(jq -r '.seccomp_profile_sha256 // ""' /tmp/redeploy-status.json 2>/dev/null || echo "")
-              FINAL_VERDICT=$(jq -r '.sandbox_canary.verdict // "unknown"' /tmp/redeploy-status.json 2>/dev/null || echo unknown)
-              echo "Redeploy terminal after ${attempt} poll(s): exit_code=${FINAL_EXIT} loaded=${FINAL_LOADED} canary=${FINAL_VERDICT}"
-              break
+
+            # Terminal acceptance gate: only OUR web-platform swap of the target
+            # tag, started after our POST. Foreign component / mismatched tag /
+            # stale start_ts → ignore and keep polling.
+            if [[ "$COMPONENT" != "web-platform" ]] || [[ "$FRAME_TAG" != "$TARGET_TAG" ]] || ! [[ "$START" -gt "$PRIOR_START" ]]; then
+              echo "Attempt $attempt/160: ignoring frame (component='${COMPONENT}' tag='${FRAME_TAG}' start_ts=${START}); waiting for our web-platform ${TARGET_TAG} swap (prior_start=${PRIOR_START})..."
+              continue
             fi
-            echo "Attempt $attempt/160: exit_code=${EXIT} start_ts=${START} (waiting for a post-trigger terminal state)..."
+
+            # Our frame — adjudicate on reason/exit_code (BLOCKING #5960 fix).
+            case "$REASON" in
+              lock_contention|adr027_prod_already_running)
+                echo "Attempt $attempt/160: reason=${REASON} (a concurrent deploy holds the lock) — NON-TERMINAL, keep polling for the winner's terminal..."
+                continue
+                ;;
+            esac
+            if [[ "$EXIT" =~ ^-?[0-9]+$ ]] && [[ "$EXIT" -lt 0 ]]; then
+              echo "Attempt $attempt/160: exit_code=${EXIT} reason=${REASON} (running) — keep polling..."
+              continue
+            fi
+            case "$REASON" in
+              ok|ok_peer_fanout_degraded)
+                cp /tmp/redeploy-status.json /tmp/redeploy-terminal.json
+                ACCEPTED="$REASON"
+                echo "Redeploy terminal after ${attempt} poll(s): reason=${REASON} exit_code=${EXIT}."
+                break
+                ;;
+              *)
+                cp /tmp/redeploy-status.json /tmp/redeploy-terminal.json
+                echo "::error::Redeploy FAILED: web-platform ${TARGET_TAG} terminal reason='${REASON}' exit_code=${EXIT}. The applied seccomp profile was NOT loaded."
+                cat /tmp/redeploy-terminal.json >&2 2>/dev/null || true
+                exit 1
+                ;;
+            esac
           done
 
-          # --- Fail-loud adjudication ---
-          if [[ -z "$FINAL_EXIT" ]]; then
-            echo "::error::Redeploy did not reach a terminal state within the poll window — profile load UNVERIFIED. Check /hooks/deploy-status + the ci-deploy.sh journald log."
-            exit 1
+          # --- Adjudicate from the FROZEN terminal frame ---
+          if [[ -z "$ACCEPTED" ]]; then
+            # Poll window exhausted with no accepted swap terminal (e.g. a concurrent
+            # release starved our tag via lock_contention for the whole window). Do
+            # ONE final STATE check: the invariant is about host state NOW, not which
+            # deploy caused it. If a concurrent deploy loaded the SAME committed
+            # profile, the invariant holds and we PASS; else fail loud UNVERIFIED.
+            echo "Poll window exhausted without an accepted web-platform ${TARGET_TAG} terminal — final STATE check (the committed profile may already be loaded by a concurrent deploy)."
+            HTTP=$(get_status)
+            if [[ "$HTTP" != "200" ]]; then
+              echo "::error::Poll exhausted AND final /hooks/deploy-status read failed (HTTP $HTTP) — profile load UNVERIFIED."
+              exit 1
+            fi
+            cp /tmp/redeploy-status.json /tmp/redeploy-terminal.json
+            read_frame /tmp/redeploy-terminal.json
+            if invariant_holds; then
+              echo "Final STATE check PASSES: host_present=true, host_sha256==committed, loaded_matches_host=true — the committed profile is loaded (a concurrent deploy satisfied the invariant). Profile is live."
+              exit 0
+            fi
+            echo "::error::Redeploy did not reach a terminal within the poll window AND the committed profile is NOT loaded now — profile load UNVERIFIED."
+            diagnose_and_fail
           fi
-          if [[ "$FINAL_EXIT" != "0" ]]; then
-            echo "::error::Redeploy failed (exit_code=${FINAL_EXIT}). The applied seccomp profile was NOT loaded. See /hooks/deploy-status .reason."
-            cat /tmp/redeploy-status.json >&2 2>/dev/null || true
-            exit 1
-          fi
-          if [[ "$FINAL_LOADED" != "$COMMITTED_SHA" ]]; then
-            echo "::error::LOADED != COMMITTED after redeploy: loaded='${FINAL_LOADED}' committed='${COMMITTED_SHA}'. The running container is NOT enforcing the committed seccomp profile (the exact 'applied ≠ loaded' failure #5875 item 4 exists to catch)."
-            exit 1
+
+          # Accepted an ok/ok_peer_fanout_degraded terminal — assert the STATE
+          # invariant from the FROZEN frame (get_status overwrites redeploy-status.json).
+          read_frame /tmp/redeploy-terminal.json
+          FINAL_VERDICT=$(jq -r '.sandbox_canary.verdict // "unknown"' /tmp/redeploy-terminal.json 2>/dev/null || echo unknown)
+          if ! invariant_holds; then
+            diagnose_and_fail
           fi
           # Per ADR-079 the faithful canary is still NON-BLOCKING dark-launch: pass /
           # canary_infra_error / fixture_uncaptured are all acceptable here; only a
@@ -610,7 +715,7 @@ jobs:
             echo "::error::Faithful sandbox canary verdict=sandbox_broken after redeploy — the committed seccomp profile EPERMs the real SDK bwrap argv. Do NOT leave this profile live."
             exit 1
           fi
-          echo "Loaded == committed (${COMMITTED_SHA}); canary verdict=${FINAL_VERDICT} (not sandbox_broken). Profile is live."
+          echo "STATE invariant holds: host_sha256==committed (${COMMITTED_SHA}) AND loaded_matches_host=true; canary verdict=${FINAL_VERDICT} (not sandbox_broken). Profile is live."
 
       - name: Check whether #4804 is still open (scopes the one-time self-heal verification)
         id: check_4804

--- a/apps/web-platform/infra/cat-deploy-state.sh
+++ b/apps/web-platform/infra/cat-deploy-state.sh
@@ -222,6 +222,69 @@ seccomp_profile_sha256_value() {
   printf '%s' "$sha"
 }
 
+# Live loaded-vs-committed seccomp discriminators (#5960 / ADR-079 item-4 amend).
+# The recorded seccomp_profile_sha256_value above reads ONLY the ephemeral tmpfs
+# state file (reboot-cleared per #5877) — an empty value cannot distinguish
+# not-delivered / host-stale / not-reloaded, and apply-deploy-pipeline-fix.yml's
+# redeploy assert has no way to prove the RUNNING container is enforcing the
+# committed profile. These three live, read-only fields close that gap in ONE
+# deploy-status read (no SSH):
+#   seccomp_profile_host_present         : the on-host profile file exists.
+#   seccomp_profile_host_sha256          : RAW sha256sum of the on-host file — the
+#     DELIVERY leg. Matches the workflow's raw COMMITTED_SHA (sha256sum of the
+#     committed seccomp-bwrap.json); sha256sum is jq-version-independent, so
+#     host==committed is skew-free.
+#   seccomp_profile_loaded_matches_host  : the RUNNING container's inlined seccomp
+#     (docker inspect HostConfig.SecurityOpt) canonical-equals the on-host file —
+#     the RELOAD leg, computed with ONE host jq on BOTH sides so it never crosses
+#     jq versions (skew-immune by construction). #5875 item-4's real contract,
+#     "the container is enforcing the committed profile", decomposes into
+#     (host==committed) AND (loaded==host); this field is the second conjunct.
+# Reuses the audit-bwrap-uid.sh:105-146 docker-inspect + jq -cS + EMPTY_HASH-guard
+# technique. Best-effort + read-only: every failure collapses to a safe sentinel
+# (present=false, host_sha256="", matches=false) so the webhook never errors on a
+# non-docker / minimal host, and a jq failure that hashes the empty stream to
+# sha256("") never yields a false loaded==host match.
+seccomp_live_json() {
+  local host_path="${SECCOMP_PROFILE_HOST_PATH:-/etc/docker/seccomp-profiles/soleur-bwrap.json}"
+  local present=false host_sha="" matches=false
+  if [[ -f "$host_path" ]]; then
+    present=true
+    host_sha="$(sha256sum "$host_path" 2>/dev/null | cut -d' ' -f1 || true)"
+    [[ "$host_sha" =~ ^[0-9a-f]{64}$ ]] || host_sha=""
+  fi
+  # Reload leg — only meaningful once the host file is present and readable.
+  if [[ "$present" == true && -n "$host_sha" ]] && command -v docker >/dev/null 2>&1; then
+    local name="${CONTAINER_NAME:-soleur-web-platform}"
+    local entries entry
+    entries="$(docker inspect "$name" \
+      --format '{{range .HostConfig.SecurityOpt}}{{println .}}{{end}}' 2>/dev/null || true)"
+    entry="$(printf '%s\n' "$entries" | sed -n 's/^seccomp=//p' | head -n1)"
+    # A literal /path means Docker did not resolve --security-opt seccomp=<file>
+    # into inlined JSON at container-create (audit-bwrap-uid.sh:123 drift) → false.
+    if [[ -n "$entry" && "$entry" != /* ]]; then
+      local empty_hash inlined_hash file_hash
+      empty_hash="$(printf '' | sha256sum | cut -d' ' -f1)"
+      # `|| true` on both: a jq parse failure under set -euo pipefail would abort
+      # the script before the guard; instead let it hash the empty stream and let
+      # the EMPTY_HASH guard reject the sha256("") == sha256("") false-match.
+      inlined_hash="$(printf '%s' "$entry" | jq -cS . 2>/dev/null | sha256sum | cut -d' ' -f1 || true)"
+      file_hash="$(jq -cS . "$host_path" 2>/dev/null | sha256sum | cut -d' ' -f1 || true)"
+      if [[ -n "$inlined_hash" && "$inlined_hash" != "$empty_hash" \
+            && "$inlined_hash" == "$file_hash" ]]; then
+        matches=true
+      fi
+    fi
+  fi
+  jq -nc \
+    --argjson present "$present" \
+    --arg host_sha "$host_sha" \
+    --argjson matches "$matches" \
+    '{seccomp_profile_host_present: $present,
+      seccomp_profile_host_sha256: $host_sha,
+      seccomp_profile_loaded_matches_host: $matches}'
+}
+
 HEARTBEAT_STATUS="$(service_status inngest-heartbeat.service)"
 # inngest-heartbeat.service is a Type=oneshot unit (no RemainAfterExit) driven by
 # inngest-heartbeat.timer (OnUnitActiveSec=60s, inngest-bootstrap.sh:216-245). It
@@ -244,6 +307,7 @@ CONTAINER_RESTART="$(container_restart_json)"
 CRON_DRAIN="$(cron_drain_json)"
 SANDBOX_CANARY="$(sandbox_canary_json)"
 SECCOMP_PROFILE_SHA256="$(seccomp_profile_sha256_value)"
+SECCOMP_LIVE="$(seccomp_live_json)"
 
 STATE_FILE="${CI_DEPLOY_STATE:-/var/lock/ci-deploy.state}"
 
@@ -270,7 +334,8 @@ jq -nc \
   --argjson cd "$CRON_DRAIN" \
   --argjson sc "$SANDBOX_CANARY" \
   --arg sps "$SECCOMP_PROFILE_SHA256" \
-  '$base + $cr + $cd + {sandbox_canary: $sc, seccomp_profile_sha256: $sps, journald_storage: $js, services: (($base.services // {}) + {
+  --argjson sl "$SECCOMP_LIVE" \
+  '$base + $cr + $cd + $sl + {sandbox_canary: $sc, seccomp_profile_sha256: $sps, journald_storage: $js, services: (($base.services // {}) + {
     inngest_heartbeat: $hb,
     inngest_heartbeat_timer: $hbt,
     inngest_server: $is,

--- a/apps/web-platform/infra/cat-deploy-state.sh
+++ b/apps/web-platform/infra/cat-deploy-state.sh
@@ -259,7 +259,10 @@ seccomp_live_json() {
     local entries entry
     entries="$(docker inspect "$name" \
       --format '{{range .HostConfig.SecurityOpt}}{{println .}}{{end}}' 2>/dev/null || true)"
-    entry="$(printf '%s\n' "$entries" | sed -n 's/^seccomp=//p' | head -n1)"
+    # `|| true`: head closing the pipe early can SIGPIPE sed (141); under
+    # pipefail that would abort the whole webhook script at the SECCOMP_LIVE
+    # assignment. Uniform with every other pipe in this function.
+    entry="$(printf '%s\n' "$entries" | sed -n 's/^seccomp=//p' | head -n1 || true)"
     # A literal /path means Docker did not resolve --security-opt seccomp=<file>
     # into inlined JSON at container-create (audit-bwrap-uid.sh:123 drift) → false.
     if [[ -n "$entry" && "$entry" != /* ]]; then

--- a/apps/web-platform/infra/cat-deploy-state.test.sh
+++ b/apps/web-platform/infra/cat-deploy-state.test.sh
@@ -25,6 +25,33 @@ assert() {
   fi
 }
 
+# --- docker mock factory (#5960) ---------------------------------------------
+# PORTED from audit-bwrap-uid.test.sh:26 (this suite mocked nothing before).
+# Returns DOCKER_INSPECT_FIXTURE contents verbatim for ANY `docker inspect`
+# call, so the seccomp_live_json discriminators (and container_restart_json,
+# which safe-sentinels on garbage) can be exercised without a real daemon.
+FIXTURE_DIR="$SCRIPT_DIR/test-fixtures/audit-bwrap"
+
+create_docker_mock() {
+  cat > "$1/docker" << 'MOCK'
+#!/usr/bin/env bash
+case "$1" in
+  inspect)
+    if [[ -n "${DOCKER_INSPECT_FIXTURE:-}" && -r "${DOCKER_INSPECT_FIXTURE}" ]]; then
+      cat "$DOCKER_INSPECT_FIXTURE"
+    else
+      exit 1
+    fi
+    ;;
+  *)
+    echo "unexpected docker arg: $*" >&2
+    exit 99
+    ;;
+esac
+MOCK
+  chmod +x "$1/docker"
+}
+
 echo "=== cat-deploy-state.sh tests ==="
 echo ""
 
@@ -161,6 +188,104 @@ echo '{"verdict":"pass","reason":"ok","sdk_version":"0.3.197","checked_at":"not-
 SC_BAD=$(CI_DEPLOY_STATE="$TMP/ok.state" SANDBOX_CANARY_STATE_FILE="$TMP/bad-canary.json" bash "$TARGET")
 assert "malformed sandbox_canary.checked_at falls back to sentinel 0" \
   "[[ \$(printf '%s' '$SC_BAD' | jq -r .sandbox_canary.checked_at) == '0' ]]"
+
+# --- #5960 live seccomp loaded/host discriminators (Phase 1) ------------------
+# seccomp_profile_loaded_matches_host (reload leg, host-jq skew-immune),
+# seccomp_profile_host_sha256 (raw sha256sum — delivery leg), and
+# seccomp_profile_host_present. Mock docker; env-override SECCOMP_PROFILE_HOST_PATH
+# to a fixture; run against ok.state so top-level exit_code stays 0.
+VALID_SECCOMP="$FIXTURE_DIR/valid-seccomp.json"
+HOST_RAW_SHA=$(sha256sum "$VALID_SECCOMP" | cut -d' ' -f1)
+
+# Case 1: loaded == host. Inlined seccomp (inspect-pass.txt, different key order)
+# canonical-equals the on-host file after jq -cS; host fields populated.
+MOCK1=$(mktemp -d)
+create_docker_mock "$MOCK1"
+SL1=$(PATH="$MOCK1:$PATH" CI_DEPLOY_STATE="$TMP/ok.state" \
+  DOCKER_INSPECT_FIXTURE="$FIXTURE_DIR/inspect-pass.txt" \
+  SECCOMP_PROFILE_HOST_PATH="$VALID_SECCOMP" bash "$TARGET")
+rm -rf "$MOCK1"
+assert "case1 loaded==host → seccomp_profile_loaded_matches_host true" \
+  "[[ \$(printf '%s' '$SL1' | jq -r .seccomp_profile_loaded_matches_host) == 'true' ]]"
+assert "case1 seccomp_profile_host_present true" \
+  "[[ \$(printf '%s' '$SL1' | jq -r .seccomp_profile_host_present) == 'true' ]]"
+assert "case1 seccomp_profile_host_sha256 is the RAW sha256sum of the host file" \
+  "[[ \$(printf '%s' '$SL1' | jq -r .seccomp_profile_host_sha256) == '$HOST_RAW_SHA' ]]"
+
+# Case 2: loaded != host (drift fixture — defaultAction differs) → matches false.
+MOCK2=$(mktemp -d)
+create_docker_mock "$MOCK2"
+SL2=$(PATH="$MOCK2:$PATH" CI_DEPLOY_STATE="$TMP/ok.state" \
+  DOCKER_INSPECT_FIXTURE="$FIXTURE_DIR/inspect-drift.txt" \
+  SECCOMP_PROFILE_HOST_PATH="$VALID_SECCOMP" bash "$TARGET")
+rm -rf "$MOCK2"
+assert "case2 drift → seccomp_profile_loaded_matches_host false" \
+  "[[ \$(printf '%s' '$SL2' | jq -r .seccomp_profile_loaded_matches_host) == 'false' ]]"
+assert "case2 host_present still true (host file exists; only reload leg drifted)" \
+  "[[ \$(printf '%s' '$SL2' | jq -r .seccomp_profile_host_present) == 'true' ]]"
+
+# Case 3: literal-path seccomp entry (Docker did not resolve the flag) → matches false.
+MOCK3=$(mktemp -d)
+create_docker_mock "$MOCK3"
+SL3=$(PATH="$MOCK3:$PATH" CI_DEPLOY_STATE="$TMP/ok.state" \
+  DOCKER_INSPECT_FIXTURE="$FIXTURE_DIR/inspect-literal-path.txt" \
+  SECCOMP_PROFILE_HOST_PATH="$VALID_SECCOMP" bash "$TARGET")
+rm -rf "$MOCK3"
+assert "case3 literal-path entry → seccomp_profile_loaded_matches_host false" \
+  "[[ \$(printf '%s' '$SL3' | jq -r .seccomp_profile_loaded_matches_host) == 'false' ]]"
+
+# Case 4: container down / docker inspect fails (no fixture) → matches false, but
+# the host-file discriminators are still populated (delivery leg is docker-free).
+MOCK4=$(mktemp -d)
+create_docker_mock "$MOCK4"
+SL4=$(PATH="$MOCK4:$PATH" CI_DEPLOY_STATE="$TMP/ok.state" \
+  SECCOMP_PROFILE_HOST_PATH="$VALID_SECCOMP" bash "$TARGET")
+rm -rf "$MOCK4"
+assert "case4 container-down → seccomp_profile_loaded_matches_host false" \
+  "[[ \$(printf '%s' '$SL4' | jq -r .seccomp_profile_loaded_matches_host) == 'false' ]]"
+assert "case4 host fields still populated (present true, raw sha set)" \
+  "[[ \$(printf '%s' '$SL4' | jq -r .seccomp_profile_host_present) == 'true' \
+    && \$(printf '%s' '$SL4' | jq -r .seccomp_profile_host_sha256) == '$HOST_RAW_SHA' ]]"
+
+# Case 5: host file absent → present false, host_sha256 "", matches false.
+MOCK5=$(mktemp -d)
+create_docker_mock "$MOCK5"
+SL5=$(PATH="$MOCK5:$PATH" CI_DEPLOY_STATE="$TMP/ok.state" \
+  DOCKER_INSPECT_FIXTURE="$FIXTURE_DIR/inspect-pass.txt" \
+  SECCOMP_PROFILE_HOST_PATH="$TMP/no-such-seccomp.json" bash "$TARGET")
+rm -rf "$MOCK5"
+assert "case5 host-absent → seccomp_profile_host_present false" \
+  "[[ \$(printf '%s' '$SL5' | jq -r .seccomp_profile_host_present) == 'false' ]]"
+assert "case5 host-absent → seccomp_profile_host_sha256 empty string" \
+  "[[ \$(printf '%s' '$SL5' | jq -r .seccomp_profile_host_sha256) == '' ]]"
+assert "case5 host-absent → seccomp_profile_loaded_matches_host false" \
+  "[[ \$(printf '%s' '$SL5' | jq -r .seccomp_profile_loaded_matches_host) == 'false' ]]"
+
+# Case 6: merge integrity — new fields present AND top-level deploy exit_code (0)
+# NOT clobbered by any live-seccomp read.
+assert "case6 top-level deploy exit_code preserved (0) alongside seccomp fields" \
+  "[[ \$(printf '%s' '$SL1' | jq -r .exit_code) == '0' ]]"
+assert "case6 all three seccomp_profile_* live keys present" \
+  "printf '%s' '$SL1' | jq -e 'has(\"seccomp_profile_loaded_matches_host\") and has(\"seccomp_profile_host_sha256\") and has(\"seccomp_profile_host_present\")' >/dev/null"
+assert "case6 recorded seccomp_profile_sha256 diagnostic field still emitted" \
+  "printf '%s' '$SL1' | jq -e 'has(\"seccomp_profile_sha256\")' >/dev/null"
+
+# Case 7: empty-hash guard. Host file is NON-JSON (raw sha exists so the reload
+# leg runs) and the inlined entry is also non-JSON+non-path — BOTH jq -cS calls
+# fail and hash the empty stream to sha256(""). Without the `!= EMPTY_HASH` guard
+# that reads as loaded==host (empty==empty); the guard must force matches=false.
+NONJSON_HOST=$(mktemp --suffix=.json)
+printf 'not valid json at all\n' > "$NONJSON_HOST"
+NONJSON_INSPECT=$(mktemp)
+printf 'apparmor=soleur-bwrap\nseccomp=also-not-json\n' > "$NONJSON_INSPECT"
+MOCK7=$(mktemp -d)
+create_docker_mock "$MOCK7"
+SL7=$(PATH="$MOCK7:$PATH" CI_DEPLOY_STATE="$TMP/ok.state" \
+  DOCKER_INSPECT_FIXTURE="$NONJSON_INSPECT" \
+  SECCOMP_PROFILE_HOST_PATH="$NONJSON_HOST" bash "$TARGET")
+rm -rf "$MOCK7"; rm -f "$NONJSON_HOST" "$NONJSON_INSPECT"
+assert "case7 empty-hash guard → matches false (not a sha256(\"\") true-match)" \
+  "[[ \$(printf '%s' '$SL7' | jq -r .seccomp_profile_loaded_matches_host) == 'false' ]]"
 
 echo ""
 echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="

--- a/knowledge-base/engineering/architecture/decisions/ADR-079-faithful-sandbox-canary-and-profile-redeploy-verification.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-079-faithful-sandbox-canary-and-profile-redeploy-verification.md
@@ -353,6 +353,37 @@ deliberately rejects floating tags and backs the wrong-image-tagged-with-right-v
 contract. **The deploy contract stays semver-only.** Single-file change:
 `.github/workflows/apply-deploy-pipeline-fix.yml`.
 
+### Amendment (#5960, 2026-07-03) — loaded proof read live from the running container; poll validates the swap terminal and treats lock_contention as non-terminal
+
+Once #5955 cleared the `tag_malformed` wedge, the item-4 assert failed on
+`LOADED != COMMITTED` with an **empty** loaded hash. Two latent defects: (a) the redeploy
+poll accepted any `exit_code>=0` frame with `start_ts>PRIOR_START` — no `component`/`tag`/
+`reason` guard — so it latched a foreign-component, stale, or **`lock_contention`** terminal
+(a flock loser stamps *our* `component`+`tag` with `exit_code=1`, since `START_TS` and
+`COMPONENT`/`TAG` are set pre-flock at `ci-deploy.sh:207`/`:674`, and that frame persists for
+the winner's whole multi-minute swap); (b) the assert read only the **ephemeral recorded**
+`.seccomp_profile_sha256` (tmpfs, reboot-cleared per #5877), which cannot discriminate
+not-delivered / host-stale / not-reloaded.
+
+**Decision (CTO + 5-agent panel, 2026-07-03).** The "loaded" proof is read **live** from the
+running container: `cat-deploy-state.sh` adds `seccomp_profile_loaded_matches_host` (docker
+inspect `HostConfig.SecurityOpt` inlined JSON `jq -cS`-equals the on-host file, computed with
+ONE host jq — reusing the `audit-bwrap-uid.sh:105-146` technique), plus
+`seccomp_profile_host_sha256` (raw `sha256sum`) and `seccomp_profile_host_present`. The
+assert becomes the STATE invariant "*the running container is enforcing the committed
+profile*" = `host_sha256==COMMITTED_SHA` (raw==raw, delivery leg) **AND**
+`loaded_matches_host` (host-jq, reload leg) — **no cross-jq comparison** on the load-bearing
+path. The poll accepts a terminal only when `component==web-platform && tag==TARGET_TAG &&
+start_ts>PRIOR_START`, keeps polling on `lock_contention`/`adr027_prod_already_running`/
+`running`, and on exhaustion does one STATE check (a concurrent release loading the *same*
+committed profile satisfies the invariant). Adds a marginal second `docker inspect` per
+`/hooks/deploy-status` GET (same pattern as `container_restart_json`). The recorded
+`seccomp_profile_sha256` field/writer stays as a permanent inert diagnostic (no gate).
+**Rejected:** a deploy nonce for redeploy provenance — the assert verifies host STATE, not
+"our POST caused it"; the timeout STATE check achieves correctness without threading a nonce.
+No new `TF_VAR_*`; `aggregate pattern` threshold unchanged. Files:
+`apps/web-platform/infra/cat-deploy-state.sh` + `.github/workflows/apply-deploy-pipeline-fix.yml`.
+
 ## Consequences
 
 - **Positive.** A future SDK bump that breaks the sandbox is caught pre-merge

--- a/knowledge-base/project/learnings/best-practices/2026-07-03-content-drift-guard-passes-via-comment-coincidence-after-contract-change.md
+++ b/knowledge-base/project/learnings/best-practices/2026-07-03-content-drift-guard-passes-via-comment-coincidence-after-contract-change.md
@@ -1,0 +1,67 @@
+---
+date: 2026-07-03
+category: best-practices
+module: ci-workflow-drift-guards
+issue: 5960
+pr: 5963
+tags: [drift-guard, content-assertion, toContain, contract-change, false-pass, seccomp]
+---
+
+# Learning: a content-drift-guard test passes for the wrong reason when the removed field name survives in an explanatory comment
+
+## Problem
+
+#5960 rewrote `.github/workflows/apply-deploy-pipeline-fix.yml`'s redeploy step so its
+load-bearing "is the committed seccomp profile actually loaded?" assert reads NEW live
+discriminators (`seccomp_profile_loaded_matches_host`, `seccomp_profile_host_sha256`) instead
+of the OLD ephemeral recorded field `seccomp_profile_sha256`. AC6 required no
+`.seccomp_profile_sha256` equality gate remain.
+
+A drift-guard test — `plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts` — asserts the
+redeploy step's content with `expect(stepBlock).toContain("seccomp_profile_sha256")`. After the
+rewrite the suite still reported **89 pass / 0 fail**. But it passed only because the rewrite
+left an *explanatory comment* in the step: `# recorded .seccomp_profile_sha256 (reboot-cleared,
+latch-blind)`. The `toContain` matched the comment, not a live gate. The test now certified a
+contract the code no longer implements — a false-authoritative GREEN. Caught at review by
+`pattern-recognition-specialist`, not by the passing suite.
+
+## Solution
+
+When you change the load-bearing field/identifier that a **content-drift-guard** test asserts on
+(any `toContain("<literal>")` / `toMatch(/<literal>/)` over a source-text block), update the
+guard's assertions to the NEW contract in the **same** change:
+
+- Replaced `expect(stepBlock).toContain("seccomp_profile_sha256")` with assertions on the two
+  new load-bearing discriminators (`seccomp_profile_loaded_matches_host` +
+  `seccomp_profile_host_sha256`).
+- Re-ran: still 89 pass — but now for the *right* reason (the assertions track the real gate).
+
+## Key Insight
+
+A content-assertion drift guard (`toContain`/`toMatch` over source text) cannot distinguish a
+**live gate** from a **comment or dead reference** — the literal it greps for lives in both. So
+removing a field as a load-bearing gate while leaving the field name in an explanatory comment
+makes the guard pass *for the wrong reason*: it certifies a contract the code abandoned.
+
+Mechanical tripwire when editing a step/block that a content-drift-guard asserts on: after the
+edit, grep the test for every literal it asserts on the block, then confirm each literal appears
+in the block as **executable code**, not just prose. If the assert's intent moved to a new field,
+move the assertion too — don't rely on an incidental comment match to keep the suite green. Same
+class as "self-claimed cross-artifact contract drift" and "replicated literal without parity
+test" in `review/SKILL.md` — a passing content-grep test is necessary but not sufficient; the
+grepped literal must be load-bearing, not incidental.
+
+## Session Errors
+
+1. **ADR-079 amendment Edit failed on first attempt** (`String to replace not found`). The
+   `old_string` spanned a line-wrap ("...must not widen the deploy\ncontract...") that didn't
+   match the file's actual break. **Recovery:** re-anchored on a shorter unique string
+   (`**The deploy contract stays semver-only.** ...`). **Prevention:** for multi-line `old_string`
+   on prose files, anchor on the shortest unique single-line span rather than a wrapped sentence.
+   One-off — no recurrence vector.
+
+2. **Drift-guard test passed for the wrong reason** (the subject of this learning). **Recovery:**
+   updated `ship-deploy-pipeline-fix-gate.test.ts` to assert the new discriminators. **Prevention:**
+   when a `/work` change removes/renames a field that a content-drift-guard `toContain`s, update the
+   guard's assertions in the same commit; a comment retaining the old literal is a false-pass vector.
+   Recurring — captured here + routed to the review skill's defect-class catalogue.

--- a/knowledge-base/project/plans/2026-07-03-fix-seccomp-loaded-sha-deploy-status-discriminators-plan.md
+++ b/knowledge-base/project/plans/2026-07-03-fix-seccomp-loaded-sha-deploy-status-discriminators-plan.md
@@ -1,0 +1,654 @@
+---
+issue: 5960
+type: fix
+domain: engineering
+lane: single-domain
+brand_survival_threshold: aggregate pattern
+adr: ADR-079 (amend — item 4 redeploy/loaded-hash contract)
+created: 2026-07-03
+plan_review: 5-agent panel applied (DHH, Kieran, code-simplicity, architecture-strategist, spec-flow) — see "Plan-Review Reconciliation"
+branch: feat-one-shot-5960-seccomp-loaded-sha
+---
+
+# fix(infra): apply-deploy-pipeline-fix.yml — seccomp redeploy poll latches a foreign/lock-contention terminal; deploy-status can't prove the loaded profile
+
+Ops-remediation fix: the assert can only be proven green by a real
+`apply-deploy-pipeline-fix.yml` run, so use `Ref #5960` in the PR body, not
+`Closes #5960` — the workflow's own green run + `gh issue close` is the closure
+(ops-remediation Sharp Edge; `Closes` would false-close at merge before the run
+proves green).
+
+## Overview
+
+`.github/workflows/apply-deploy-pipeline-fix.yml`'s **"Redeploy to load applied
+profile and assert loaded==committed (#5875 item 4)"** step fails with
+`LOADED != COMMITTED` because `/hooks/deploy-status`'s `seccomp_profile_sha256`
+came back **empty**. After #5955/#5957 cleared the `tag_malformed` wedge, this
+third latent defect in the never-green #5875 item-4 mechanism surfaced.
+
+Two things are broken; the fix does both plus the discriminating probe the issue's
+"Next step" asks for:
+
+1. **The redeploy poll latches a terminal that is NOT the redeploy's swap**
+   (behavioral root cause). The run log shows the poll declared terminal after
+   **~31 s** — physically impossible for a real canary swap — so
+   `write_seccomp_profile_hash` (the only seccomp-hash write site) never ran for
+   the observed state. The poll accepts any `exit_code>=0` frame and does not
+   check `component`/`tag`/`reason`, so it latches stale, foreign-component, or —
+   as the review panel proved — **`lock_contention`** terminals (which the flock
+   loser stamps with *our* `component=web-platform` + *our* `tag`). Fix: accept
+   only a genuine web-platform swap terminal of the target tag; treat
+   `lock_contention`/`adr027_prod_already_running`/`running` as **non-terminal**
+   (keep polling — the flock winner loads the same profile).
+2. **`/hooks/deploy-status` exposes only the ephemeral recorded hash, never the
+   live loaded profile** (the affected-surface observability gap the issue names).
+   Add a live `docker inspect HostConfig.SecurityOpt` read of the running
+   container's actual loaded profile + a live host-file discriminator, reusing the
+   proven `audit-bwrap-uid.sh:105-146` technique. This lets the assert distinguish
+   *not-delivered* / *host-stale* / *not-reloaded* in **one** deploy-status read,
+   no SSH.
+3. **Assert a skew-immune, self-diagnosing STATE invariant.** #5875 item-4's real
+   contract is "the running container is enforcing the committed profile."
+   Decompose it into two comparisons that never cross jq versions:
+   `host_sha256(raw) == committed(raw sha256sum)` (**delivery** — byte-identical
+   file copy, `sha256sum` is version-independent) **AND**
+   `loaded == host` computed **host-side with one jq** (**reload** — skew-immune
+   by construction). No cross-machine `jq -cS` comparison anywhere; the committed
+   side stays raw `sha256sum` (unchanged from today).
+
+Detail level: **A LOT** (multi-file infra + workflow + ADR amendment + tests; a
+security-boundary verification gate at `aggregate pattern` threshold).
+
+## Plan-Review Reconciliation (5-agent panel)
+
+The v1 plan was reviewed by DHH, Kieran, code-simplicity, architecture-strategist,
+and spec-flow. Material changes folded into this v2:
+
+- **[BLOCKING — spec-flow + architecture-strategist]** `lock_contention` losers
+  write `component=web-platform, tag=$TARGET_TAG, exit_code=1` with a fresh
+  `start_ts` (`ci-deploy.sh:207` sets `START_TS` before flock; `:674` parses
+  COMPONENT/TAG before the flock at `:742`). v1's tightened predicate would
+  **match and fail-loud** on our own lock loss under a concurrent
+  web-platform-release deploy. **Fix:** treat `lock_contention` /
+  `adr027_prod_already_running` / `running` as non-terminal → keep polling.
+- **[DHH + Kieran + architecture-strategist consensus]** Make the load-bearing
+  equality `loaded == host` (both computed with the **host** jq, skew-immune) and
+  the delivery check raw `sha256sum(host) == sha256sum(committed)` (version-
+  independent). This **eliminates the cross-jq `jq -cS` comparison** that v1 put on
+  the load-bearing path — and with it SE-B1 (jq-version parity) and the
+  canonicalization ACs entirely. Committed side stays **raw** (`:487` unchanged).
+- **[DHH + code-simplicity consensus]** Trim scope: **drop** `seccomp_profile_host_path`
+  (a self-referential constant the script can't cross-check against the other
+  files that actually drift) and **drop** `seccomp_recorded_loaded_at` (telemetry
+  on a field being demoted). **Collapse the Phase-4 deprecate-then-remove ceremony**:
+  leave `write_seccomp_profile_hash` in place permanently as an inert raw
+  diagnostic (already `|| true`, never gates); the workflow simply stops asserting
+  it. No tracking issue, no soak-gated removal PR.
+- **[architecture-strategist]** Freeze the terminal snapshot (`cp
+  /tmp/redeploy-status.json /tmp/redeploy-terminal.json`) so the load-bearing read
+  and all discriminator reads share ONE frame (`get_status()` overwrites the file
+  each call).
+- **[Kieran]** Add an AC forbidding any leftover `.seccomp_profile_sha256` read on
+  the load-bearing/fast-path (guards the partial-migration false-red). Fix Phase 6
+  wording: the docker mock must be **ported** from `audit-bwrap-uid.test.sh:26`
+  (`create_docker_mock` PATH shim) — `cat-deploy-state.test.sh` currently mocks
+  nothing.
+- **[spec-flow Q2 + Q3]** Baseline fast-path: settle + re-read once on a
+  transient-empty loaded read before triggering a 70-min redeploy. **STATE-invariant
+  reframe** (see below) closes the concurrent-starvation false-red WITHOUT a deploy
+  nonce — nonce **considered and rejected** as over-build (the assert verifies a
+  STATE, "the committed profile is loaded now", not provenance, "our POST did it").
+
+**STATE-invariant framing (resolves the concurrency findings without a nonce):**
+the assert's true invariant is *"the running container is enforcing the committed
+seccomp profile,"* a property of current host state — not *"our specific redeploy
+caused it."* So a concurrent web-platform-release deploy that loads the **same**
+committed profile satisfies the invariant. The poll therefore (a) treats
+`lock_contention`/`running` as non-terminal, and (b) on poll-window exhaustion,
+does ONE final state check: if `host_present && host_sha==committed(raw) &&
+loaded==host` holds now, **PASS** (the profile is loaded regardless of which deploy
+loaded it); else fail-loud UNVERIFIED. This is strictly cheaper and more correct
+than threading a nonce through POST → `write_state` → deploy-status.
+
+## Premise Validation (Phase 0.6)
+
+- `#5955` **CLOSED**, `#5957` **MERGED** (tag resolution). `#5875` **CLOSED**,
+  `#5950` **MERGED**. `ADR-079` present with amendments (#5913, #5955) — this adds
+  a fourth (no new ordinal; collision risk = none).
+- **Failing run 28661894954 log inspected** (smoking gun below). Code anchors
+  confirmed by direct read: `ci-deploy.sh:207` `START_TS` (pre-flock), `:674`
+  COMPONENT/TAG parse (pre-flock), `:742-745` `lock_contention`, `:1132-1152` prod
+  `docker run`, `:1161` `write_seccomp_profile_hash` (sole call site), `:1211/1213`
+  `final_write_state 0 "ok"/"ok_peer_fanout_degraded"`. Committed side is **raw**
+  `sha256sum` (`apply-deploy-pipeline-fix.yml:487`); recorded write is **raw**
+  (`ci-deploy.sh:488`) — so raw==raw today (both `7654ef34…`).
+- **Own-capability claim verified** (`hr-verify-repo-capability-claim`): reading
+  the loaded seccomp via `docker inspect` is **not novel** —
+  `apps/web-platform/infra/audit-bwrap-uid.sh:105-146` already does it (Docker
+  inlines the resolved `--security-opt seccomp=<path>` as JSON into
+  `HostConfig.SecurityOpt`; hash-compares `jq -cS` canonical, with an EMPTY_HASH
+  guard at `:137-140` and literal-path drift detection at `:123`). The fix reuses
+  this pattern.
+
+## Root Cause Analysis
+
+### The smoking gun: a 31-second "terminal"
+
+From run 28661894954 (`workflow_dispatch` on `main` after #5957):
+
+```
+12:55:25  Running container loaded seccomp sha256: '<none>' (tag='v0.184.6')
+12:55:26  Redeploy initiated (HTTP 202). Polling for completion…
+12:55:57  Redeploy terminal after 1 poll(s): exit_code=0 loaded= canary=unknown
+12:55:57  ##[error]LOADED != COMMITTED after redeploy: loaded='' committed='7654ef34…'.
+```
+
+The poll (`apply-deploy-pipeline-fix.yml:574-589`) does `sleep 30` then checks. It
+declared terminal on the **first** iteration — ~31 s. A real `ci-deploy.sh`
+web-platform deploy **cannot** finish in 31 s (prune + pull + plugin-seed + canary
+`docker run` + 10-iteration health probe loop + bwrap + faithful canary + ADR-078
+cron drain + prod `docker run` = minutes). **There is no fast-path**: the only
+web-platform `final_write_state 0` is `:1211/1213` after the full swap;
+`write_seccomp_profile_hash` (`:1161`) runs immediately before it (verified: five
+`final_write_state 0` sites total — `:771`/`:1416`/`:1419` are inngest/restart, not
+web-platform). `canary=unknown` + `loaded=''` confirm the observed frame is **not**
+a completed swap.
+
+The poll's predicate is **only** `exit_code >= 0 && start_ts > PRIOR_START` (`:581`)
+— no `component`/`tag`/`reason` guard — so it latches stale, foreign-component
+(inngest/restart reach `final_write_state 0`), or **`lock_contention`** terminals.
+The `lock_contention` case is the sharpest: because `START_TS` is set pre-flock
+(`:207`) and COMPONENT/TAG are parsed pre-flock (`:674`), a flock loser under a
+concurrent web-platform-release deploy writes `component=web-platform,
+tag=$TARGET_TAG, exit_code=1, reason=lock_contention` with `start_ts>PRIOR_START`
+— and that frame **persists for the winner's entire multi-minute swap** (the state
+file is only re-written at terminals). This is the terminal-frame trap from
+`2026-06-14-terminal-frame-to-terminal-ui-state-must-validate-reason-set-and-confirm-before-success.md`.
+
+### The observability gap: recorded ≠ loaded
+
+`seccomp_profile_sha256_value()` reads **only** the ephemeral
+`/var/run/ci-deploy-seccomp-profile.json` (written by `write_seccomp_profile_hash`
+on the swap path, reboot-cleared per #5877). It never reads the **live** host
+profile nor the **running container's actually-loaded** profile, so an empty field
+cannot discriminate the failure classes:
+
+| Hypothesis | Old signal | New discriminator |
+|---|---|---|
+| Wrong/no-swap terminal latched | `seccomp_profile_sha256=''` | poll waits for a real swap; `loaded==host` read live |
+| Provisioner never delivered | `seccomp_profile_sha256=''` | `seccomp_profile_host_present` |
+| Host has stale/wrong profile | `seccomp_profile_sha256=''` | `seccomp_profile_host_sha256(raw) != committed` |
+| Container didn't reload | `seccomp_profile_sha256=''` | `seccomp_profile_loaded_matches_host == false` |
+
+Direct application of `2026-07-01-blind-surface-needs-structured-probe-before-nth-fix.md`
+(ship the discriminating probe FROM the blind surface first).
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** `apply-deploy-pipeline-fix.yml`
+stays red; every future seccomp/apparmor-profile change auto-applies to the host
+but the gate that proves the running container actually *loaded* the committed
+profile cannot confirm — so a #5874-style agent-sandbox seccomp regression could
+ship "applied but not loaded" and every tenant's Concierge Bash sandbox breaks
+(EPERM on `unshare`) with no CI signal, exactly the outage #5875 item-4 exists to
+prevent.
+
+**If this leaks, the user's data/workflow/money is exposed via:** N/A — no
+personal-data or credential surface is touched. The seccomp profile is a syscall
+allow/deny boundary; the risk is *under-restriction* (a permissive profile loaded
+and not caught), a security-posture regression, not a data leak.
+
+**Brand-survival threshold:** `aggregate pattern` — carried forward from ADR-079
+(CTO + architecture-strategist confirmed this fix does not alter it).
+`threshold: aggregate pattern, reason: security-posture verification gate for the
+shared agent-sandbox syscall boundary; no per-user data/credential surface.`
+
+## Research Reconciliation — Spec vs. Codebase
+
+No `spec.md` exists for this branch (direct one-shot → plan path). The issue body's
+three candidate root causes, tested against code + run log:
+
+| Issue-body candidate | Reality (verified) | Plan response |
+|---|---|---|
+| (1) success branch skipped `write_seccomp_profile_hash` | No web-platform fast-path; `:1161` always precedes `:1211`. The **poll latched a non-swap / lock_contention terminal** (31 s) | Fix the poll (Phase 3); live `loaded==host` read (Phase 1) also makes the skip-path moot |
+| (2) provisioner didn't deliver → file absent | `docker run --security-opt seccomp=<file>` succeeded ⇒ present | `seccomp_profile_host_present` proves it (Phase 1) |
+| (3) write ran before file in place / path mismatch | write path (`:195`) == run path (`:1140`) == provisioner dest (server.tf) — all `/etc/docker/seccomp-profiles/soleur-bwrap.json` | `host_sha(raw)==committed` + `loaded==host` catch any drift (Phase 1/2) |
+
+## Implementation Phases
+
+> **Phase order is load-bearing** (contract-before-consumer): the producer
+> (Phase 1) precedes the consumer (Phase 2/3). Both merge atomically; `/work`
+> reads phases sequentially.
+
+### Phase 1 — Add live loaded + host discriminators to `cat-deploy-state.sh`
+
+File: `apps/web-platform/infra/cat-deploy-state.sh`. Add read-only helpers
+mirroring the sibling `container_restart_json` (`docker inspect`), reusing the
+`audit-bwrap-uid.sh:105-146` technique. **Three new fields (all skew-safe):**
+
+- **`seccomp_profile_loaded_matches_host`** (bool) — the **reload** proof,
+  computed host-side so it never crosses jq versions:
+  1. `SECCOMP_ENTRY` from `docker inspect "${CONTAINER_NAME:-soleur-web-platform}"
+     --format '{{range .HostConfig.SecurityOpt}}{{println .}}{{end}}' 2>/dev/null
+     || true`, then `sed -n 's/^seccomp=//p' | head -n1`.
+  2. If the entry is inlined JSON (NOT a literal `/path` — `audit-bwrap-uid.sh:123`
+     drift), compute `INLINED=printf '%s' "$SECCOMP_ENTRY" | jq -cS . | sha256sum`
+     and `HOSTC=jq -cS . "$SECCOMP_PROFILE_HOST_PATH" | sha256sum`, both with the
+     **same host jq**. `matches = (INLINED == HOSTC && INLINED not empty-hash)`.
+  3. `false` on any failure (no docker, container down, literal-path, unparseable,
+     empty-hash). Apply the `audit-bwrap-uid.sh:137-140` EMPTY_HASH guard so a `jq`
+     failure never yields `sha256("")`.
+- **`seccomp_profile_host_sha256`** (raw) — the **delivery** discriminator:
+  `sha256sum "$SECCOMP_PROFILE_HOST_PATH" | cut -d' ' -f1` (RAW bytes, matches the
+  workflow's raw `COMMITTED_SHA`; `""` if absent). `sha256sum` is version-
+  independent, so `host==committed` is skew-free.
+- **`seccomp_profile_host_present`** (bool) — `[[ -f "$SECCOMP_PROFILE_HOST_PATH" ]]`.
+- `SECCOMP_PROFILE_HOST_PATH` default must match `ci-deploy.sh:195` exactly.
+- **Keep** the existing `seccomp_profile_sha256` (raw recorded) field untouched as
+  an inert diagnostic. **Do NOT** add `seccomp_recorded_loaded_at` or
+  `seccomp_profile_host_path` (review: constant / dying-field telemetry).
+- Extend the `jq` merge (`$base + $cr + $cd + { … }`) with the three new keys; do
+  NOT clobber the load-bearing top-level `exit_code`.
+
+**Why `loaded==host` not `loaded==committed`:** #5875 item-4 = "container enforcing
+the committed profile" = `(host==committed)` AND `(loaded==host)`. Splitting keeps
+each comparison within one hash space — raw `sha256sum` for the cross-machine
+delivery leg, host-jq `jq -cS` for the same-machine reload leg — so no cross-jq
+`jq -cS` comparison exists. Verified: the profile's largest ints (`4294967295`,
+`2114060288`) are < 2⁵³ and the file is ASCII, so even the reload leg is jq-version-
+robust today; the decomposition removes the hazard by construction regardless.
+
+### Phase 2 — Robust, self-diagnosing, snapshot-bound assert
+
+File: `.github/workflows/apply-deploy-pipeline-fix.yml` (the "Redeploy…" step,
+`:486-613`).
+
+- Keep `COMMITTED_SHA=$(sha256sum seccomp-bwrap.json | cut -d' ' -f1)` **raw**
+  (`:487` unchanged). There is NO canonical committed hash.
+- **Baseline / fast-path**: read `seccomp_profile_loaded_matches_host`,
+  `seccomp_profile_host_present`, `seccomp_profile_host_sha256`. Skip the redeploy
+  iff `host_present==true && host_sha256==COMMITTED_SHA && loaded_matches_host==true`
+  (state already correct). If `loaded_matches_host==false` at baseline, **settle
+  once** (short sleep) and re-read before deciding to redeploy — avoids a 70-min
+  redeploy triggered by a transient in-flight swap window (spec-flow Q2).
+- **Poll → freeze the terminal frame**: at terminal acceptance,
+  `cp /tmp/redeploy-status.json /tmp/redeploy-terminal.json` and read BOTH the
+  load-bearing fields AND all discriminators from that frozen frame (never a fresh
+  post-loop GET — architecture-strategist #2).
+- **Load-bearing assert** (from the frozen frame):
+  `host_present==true && host_sha256==COMMITTED_SHA && loaded_matches_host==true`.
+- **Fail-loud discriminator classes** (no leftover `.seccomp_profile_sha256` read
+  on this or the fast path — Kieran #1):
+  - `host_present==false` → "provisioner did not deliver profile to
+    `/etc/docker/seccomp-profiles/soleur-bwrap.json`".
+  - `host_sha256 != COMMITTED_SHA` → "host has a STALE/wrong profile
+    (`<host_sha>` != committed) — delivery/path drift".
+  - `loaded_matches_host==false` (host_sha ok) → "profile on host but running
+    container did NOT reload it".
+- **Timeout graceful-degradation** (STATE invariant): if the poll window exhausts
+  without an accepted swap terminal (e.g. a concurrent release starved our tag via
+  `lock_contention`), do ONE final `get_status` + freeze + state check — if
+  `host_present && host_sha256==COMMITTED_SHA && loaded_matches_host` holds now,
+  **PASS**; else fail-loud UNVERIFIED. No deploy nonce (considered, rejected).
+- Keep the existing `sandbox_canary.verdict == sandbox_broken` fatal branch and the
+  poll ceiling (160×30 s) unchanged.
+
+### Phase 3 — Fix the redeploy poll: accept only the genuine swap terminal; lock_contention is non-terminal
+
+File: `.github/workflows/apply-deploy-pipeline-fix.yml` (poll loop `:574-604`).
+
+- Read `component`, `tag`, `reason`, `exit_code`, `start_ts` from the status frame
+  (all emitted by `write_state`, `ci-deploy.sh:228` — no new plumbing).
+- **Terminal acceptance** requires `component=="web-platform" && tag=="$TARGET_TAG"
+  && exit_code>=0 && start_ts>PRIOR_START`.
+- **Adjudication** (this is the BLOCKING fix):
+  - `reason ∈ {ok, ok_peer_fanout_degraded}` (both permanently allowlisted; SE-C1)
+    → accept → run the Phase 2 assert.
+  - `reason ∈ {lock_contention, adr027_prod_already_running}` OR `exit_code==-1`
+    (`running`, `EXIT_RUNNING=-1`) → **NON-TERMINAL, keep polling** (the flock
+    winner produces the authoritative terminal loading the same committed profile).
+  - any other `component=web-platform && tag=$TARGET_TAG` terminal with a genuine
+    failure reason (`canary_health_failed`, `production_start_failed`, `timeout`,
+    `unhandled`, …) / `exit_code!=0` → **fail loud** with that reason.
+  - foreign `component` / mismatched `tag` / `start_ts<=PRIOR_START` → ignore
+    (keep polling).
+- On poll exhaustion → the Phase 2 timeout graceful-degradation state check.
+- Do NOT widen the poll wall-clock.
+
+### Phase 4 — Stop asserting the recorded field (no removal)
+
+- The workflow no longer reads `.seccomp_profile_sha256` on any load-bearing or
+  fast path (Phase 2/3 use the new fields). **Leave** `write_seccomp_profile_hash`
+  (`ci-deploy.sh:479/1161`) and the emitted `seccomp_profile_sha256` field in place
+  **permanently** as an inert raw diagnostic (already `|| true`, never gates,
+  mirrors `write_sandbox_canary_state`). No deprecation cycle, tracking issue, or
+  removal PR (review: the removal ceremony costs more than the ~15-line inert
+  helper it would delete).
+
+### Phase 5 — ADR-079 amendment
+
+File: `knowledge-base/engineering/architecture/decisions/ADR-079-…​.md`. Add
+**`### Amendment (#5960, 2026-07-03) — loaded proof read live from the running
+container; poll validates the swap terminal and treats lock_contention as
+non-terminal`** after the #5955 amendment. Terse (4-6 lines per architecture-
+strategist + code-simplicity): old contract (ephemeral recorded hash + latch-any-
+terminal poll) → new contract (`loaded==host` live via `docker inspect`, host-jq;
+`host==committed` raw `sha256sum`; poll requires `component=web-platform &&
+tag=TARGET_TAG` and keeps polling on `lock_contention`/`running`; STATE-invariant
+timeout fallback). Note the marginal second `docker inspect` per
+`/hooks/deploy-status` GET (same pattern as `container_restart_json`). No new
+`TF_VAR_*`, no topology change, `aggregate pattern` unchanged, amendment not a new
+ordinal.
+
+### Phase 6 — Tests
+
+File: `apps/web-platform/infra/cat-deploy-state.test.sh` (extend; `.test.sh`
+bash-with-mocks — **do NOT introduce bats**).
+
+- **PORT** the `create_docker_mock` PATH shim from `audit-bwrap-uid.test.sh:26`
+  (cat-deploy-state.test.sh currently mocks nothing — Kieran #3). Reuse
+  `test-fixtures/audit-bwrap/inspect-pass.txt`, `inspect-literal-path.txt`,
+  `valid-seccomp.json`.
+- New cases (mock `docker inspect`; env-override `SECCOMP_PROFILE_HOST_PATH` at a
+  tmp fixture):
+  1. Loaded == host (inlined JSON canonical-equals host file) →
+     `seccomp_profile_loaded_matches_host==true`, `seccomp_profile_host_sha256`
+     = raw sha of the fixture, `seccomp_profile_host_present==true`.
+  2. Loaded != host (drift fixture) → `matches==false`.
+  3. Literal-path seccomp entry → `matches==false`.
+  4. Container down / docker absent → `matches==false`, host fields still populated.
+  5. Host file absent → `host_present==false`, `host_sha256==""`, `matches==false`.
+  6. Merge integrity: new fields present AND top-level `exit_code` unchanged.
+  7. Empty-hash guard: a mocked `jq` failure yields `matches==false`, never a
+     `sha256("")` true-match.
+
+## Files to Edit
+
+- `.github/workflows/apply-deploy-pipeline-fix.yml` — Phase 2 (raw delivery +
+  `loaded==host` assert + frozen snapshot + discriminator diagnosis + timeout
+  state check), Phase 3 (poll predicate + lock_contention non-terminal), Phase 4
+  (stop reading recorded field). **In its own `paths:` trigger — re-fires on merge.**
+- `apps/web-platform/infra/cat-deploy-state.sh` — Phase 1 (3 discriminator fields).
+  Delivered by `terraform_data.deploy_pipeline_fix` FILE_MAP (`CAT_DEPLOY_STATE_SH_B64
+  → /usr/local/bin/cat-deploy-state.sh`); in the workflow `paths:` filter (`:69`)
+  → **auto-applies on merge**.
+- `knowledge-base/engineering/architecture/decisions/ADR-079-…​.md` — Phase 5.
+- `apps/web-platform/infra/cat-deploy-state.test.sh` — Phase 6.
+
+## Files to Create
+
+- None. (ADR amended; tests extend an existing suite; fixtures reused.)
+
+## Open Code-Review Overlap
+
+None. Checked open `code-review`-labelled issues touching
+`apply-deploy-pipeline-fix.yml`, `cat-deploy-state.sh`, `ci-deploy.sh`, ADR-079 —
+no overlap. (Recorded so the next planner sees the check ran.)
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: apply-deploy-pipeline-fix.yml "Redeploy … assert" step green;
+        /hooks/deploy-status exposes seccomp_profile_loaded_matches_host==true,
+        seccomp_profile_host_sha256==committed(raw), seccomp_profile_host_present==true
+  cadence: on every merge to main touching a #5875/#5505 trigger file, and on
+           manual workflow_dispatch
+  alert_target: GitHub Actions run status (red step) + the ::error:: discriminator
+                line in the run log
+  configured_in: .github/workflows/apply-deploy-pipeline-fix.yml
+error_reporting:
+  destination: GitHub Actions ::error:: annotations naming the discriminator class
+               (not-delivered / host-stale / not-reloaded / unverified);
+               ci-deploy.sh already mirrors sandbox_canary FAIL to Sentry (unchanged)
+  fail_loud: true
+failure_modes:
+  - mode: poll latches a foreign / lock_contention / stale terminal
+    detection: terminal accepted only when component=web-platform && tag=TARGET_TAG
+               && exit_code>=0 && start_ts>PRIOR_START; lock_contention/running →
+               keep polling; genuine failure reason → fail loud
+    alert_route: red step + ::error:: with the observed reason
+  - mode: provisioner did not deliver profile to host
+    detection: seccomp_profile_host_present==false
+    alert_route: red step + "provisioner did not deliver profile"
+  - mode: host has a stale/wrong profile (delivery/path drift)
+    detection: seccomp_profile_host_sha256(raw) != committed(raw sha256sum)
+    alert_route: red step + "host has STALE profile"
+  - mode: profile on host but running container did not reload it
+    detection: seccomp_profile_loaded_matches_host==false while host_sha==committed
+    alert_route: red step + "container did NOT reload"
+logs:
+  where: GitHub Actions run log; ci-deploy.sh journald (LOG_TAG) surfaced via
+         /hooks/deploy-status journal tails
+  retention: GitHub Actions default (90d); journald persistent (#4792)
+discoverability_test:
+  command: >
+    curl -s -H "X-Signature-256: sha256=$(printf '' | openssl dgst -sha256 -hmac
+    "$WEBHOOK_SECRET" | sed 's/.*= //')" -H "CF-Access-Client-Id: $CF_ACCESS_ID"
+    -H "CF-Access-Client-Secret: $CF_ACCESS_SECRET"
+    https://deploy.soleur.ai/hooks/deploy-status | jq
+    '{matches: .seccomp_profile_loaded_matches_host,
+      host_present: .seccomp_profile_host_present, host_sha: .seccomp_profile_host_sha256}'
+  expected_output: >
+    matches==true; host_present==true; host_sha == sha256sum(committed
+    seccomp-bwrap.json)  (NO ssh)
+```
+
+### Affected-surface observability (Phase 2.9.2)
+
+The prod host + `/hooks/deploy-status` are a **blind execution surface** (no SSH —
+`hr-no-ssh-fallback-in-runbooks`). Every `failure_modes` `detection` is an
+**in-surface** probe read live FROM the host (`docker inspect` of the running
+container; `sha256sum`/`jq -cS` of the host file), and the structured fields
+(`seccomp_profile_loaded_matches_host`, `seccomp_profile_host_present`,
+`seccomp_profile_host_sha256`) **discriminate all competing root-cause hypotheses
+in a single deploy-status read**. Direct application of
+`2026-07-01-blind-surface-needs-structured-probe-before-nth-fix.md`.
+
+## Architecture Decision (ADR/C4)
+
+### ADR
+
+**Amend ADR-079** (item-4 redeploy/loaded contract) — Phase 5. Within-scope
+verification-mechanism correction (how "loaded" is read; how the poll validates the
+terminal), not a binding-ruling reversal → amendment, not a new ADR (precedent:
+#5913, #5955 amend the same item-4 mechanism). CTO + architecture-strategist concur.
+
+### C4 views
+
+**No C4 impact.** All three model files were read
+(`knowledge-base/engineering/architecture/diagrams/{model.c4,views.c4,spec.c4}`):
+
+- **External human actors:** none added (the CI runner is not a modeled person).
+- **External systems / vendors:** none added; the CI↔prod-host deploy edge is
+  already `engine -> github "Git operations and CI"` (`model.c4:255`).
+- **Containers / data stores:** none added/falsified; the deploy webhook +
+  `cat-deploy-state.sh` live inside the existing `hetzner` container
+  (`model.c4:164`), below C4-container granularity.
+- **Access relationships:** none change; the seccomp boundary is verified, not
+  introduced or re-scoped.
+
+No `.c4` element description is falsified; no `view include` edit required.
+
+## Domain Review
+
+**Domains relevant:** Engineering (CTO)
+
+### Engineering (CTO)
+
+**Status:** reviewed
+**Assessment:** Small–medium infra/observability change (shell + workflow + ADR;
+no DB/product/paging). CTO confirmed the three precedents and ruled: live
+`docker inspect` read is architecturally sounder than the ephemeral state file
+(ground-truth, reboot-durable, precedent-parity with `audit-bwrap-uid.sh`); name
+the live signal distinctly (avoid overloading `seccomp_profile_sha256`);
+canonicalization must be consistent AND, per the subsequent 5-agent panel, is best
+avoided on the load-bearing path (raw delivery + host-jq reload); keep BOTH `ok`
+and `ok_peer_fanout_degraded`; negative-scope (no `seccomp-bwrap.json` byte change,
+no Sentry/paging change); amend ADR-079. Threshold stays `aggregate pattern`. All
+SE items encoded as ACs / Sharp Edges below.
+
+### Product/UX Gate
+
+Not applicable. Mechanical UI-surface override did not fire: `## Files to Edit` is
+`.yml`/`.sh`/`.md` only — no `components/**`, `app/**/page.tsx`, `app/**/layout.tsx`.
+Tier: **NONE**.
+
+## Infrastructure (IaC) / Apply-path
+
+<!-- iac-routing-ack: plan-phase-2-8-reviewed -->
+
+No **new** infrastructure. Both host-resident files are delivered by **existing**
+IaC and auto-apply on merge — no operator SSH, no Doppler secret mutation, no
+dashboard step:
+
+- `cat-deploy-state.sh` → `terraform_data.deploy_pipeline_fix` FILE_MAP
+  (`CAT_DEPLOY_STATE_SH_B64 → /usr/local/bin/cat-deploy-state.sh`), pushed via the
+  HTTPS `/hooks/infra-config` webhook path. Already in the workflow `paths:` filter
+  → the merge fires the apply.
+- `apply-deploy-pipeline-fix.yml` is itself a workflow; the merge updates CI directly.
+- Apply→verify sequence unchanged; no `terraform apply -replace`, no taint.
+
+(Phase 2.8 gate reviewed: pure edits to an already-provisioned, IaC-delivered
+surface — no `.tf` change. Ack comment above.)
+
+## GDPR / Compliance
+
+No regulated-data surface (no schema, migration, auth, API route, `.sql`, PII).
+None of the (a)-(d) expansion triggers fire. **Gate skipped.**
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] **AC1 (reload proof, host-side & skew-immune).** `cat-deploy-state.sh` emits
+  `seccomp_profile_loaded_matches_host` computed host-side (`jq -cS` docker-inlined
+  == `jq -cS` host file, same jq), guarded with `|| true`/`2>/dev/null` and the
+  EMPTY_HASH guard. Unit cases 1-4/7 cover equal/drift/literal-path/container-down/
+  empty-hash.
+- [ ] **AC2 (delivery proof, raw & skew-free).** `cat-deploy-state.sh` emits
+  `seccomp_profile_host_sha256` as **raw** `sha256sum` (matches the workflow's raw
+  `COMMITTED_SHA`), and `seccomp_profile_host_present` (bool). The workflow asserts
+  `host_sha256 == COMMITTED_SHA` with `COMMITTED_SHA` staying raw (`:487`
+  unchanged). No cross-jq `jq -cS` comparison exists anywhere in the assert.
+- [ ] **AC3 (poll: lock_contention non-terminal — BLOCKING).** The poll accepts a
+  terminal only when `component=="web-platform" && tag=="$TARGET_TAG" &&
+  exit_code>=0 && start_ts>PRIOR_START`; `reason ∈ {lock_contention,
+  adr027_prod_already_running}` and `exit_code==-1` (`running`) → **keep polling**;
+  `reason ∈ {ok, ok_peer_fanout_degraded}` → assert; any other genuine-failure
+  reason → fail loud. Verify the poll references `.component`, `.tag`, `.reason`;
+  baseline-0: `git show origin/main:.github/workflows/apply-deploy-pipeline-fix.yml
+  | grep -c '\.component'` == 0.
+- [ ] **AC4 (no-fast-path finding).** `grep -n 'final_write_state 0'
+  apps/web-platform/infra/ci-deploy.sh` (5 hits); PR notes `:1211/1213` are the
+  only web-platform arm, so the tightened poll cannot false-timeout a legitimate
+  swap.
+- [ ] **AC5 (frozen snapshot).** On terminal detection the workflow `cp`s the
+  status frame to a stable path and reads BOTH the load-bearing fields and all
+  discriminators from that frozen frame (no post-loop fresh GET for the assert).
+- [ ] **AC6 (no leftover recorded read — partial-migration guard).** No
+  `.seccomp_profile_sha256` read remains on any load-bearing or fast-path
+  comparison: `grep -n 'seccomp_profile_sha256' .github/workflows/apply-deploy-pipeline-fix.yml`
+  shows the field only in diagnostic/echo context, never in an equality gate.
+- [ ] **AC7 (self-diagnosing assert).** On mismatch the `::error::` names the
+  class (not-delivered / host-stale / not-reloaded) from `host_present` /
+  `host_sha256` / `loaded_matches_host`.
+- [ ] **AC8 (timeout STATE check).** On poll exhaustion the workflow does one final
+  state check and PASSES iff `host_present && host_sha256==COMMITTED_SHA &&
+  loaded_matches_host`, else fails loud UNVERIFIED (no nonce).
+- [ ] **AC9 (fast-path settle).** A transient-empty `loaded_matches_host` at
+  baseline triggers a single settle+re-read before deciding to redeploy.
+- [ ] **AC10 (no top-level clobber).** `exit_code` remains the DEPLOY sentinel;
+  new fields do not overwrite it (merge-integrity test, case 6).
+- [ ] **AC11 (negative scope).** The diff does NOT modify `seccomp-bwrap.json`
+  bytes (`git diff --stat origin/main -- apps/web-platform/infra/seccomp-bwrap.json`
+  empty) and does NOT touch `apps/web-platform/infra/sentry/` (dir exists — check
+  is meaningful).
+- [ ] **AC12 (tests green, mock ported).** `cat-deploy-state.test.sh` passes with
+  the `create_docker_mock` PATH shim **ported** from `audit-bwrap-uid.test.sh:26`
+  (not "reused" — the suite currently mocks nothing).
+- [ ] **AC13 (ADR amended).** ADR-079 has a `### Amendment (#5960, 2026-07-03)`
+  section; `grep -c '^# ADR-' <file>` stays 1.
+
+### Post-merge (operator / automated)
+
+- [ ] **AC14 (real green run — the only proof of "loaded").** After merge (or a
+  `workflow_dispatch`), the redeploy step passes on a REAL swap:
+  `loaded_matches_host==true && host_sha==committed`. Automation: `gh run
+  watch`/`gh run view` — no SSH. Automatable via `/soleur:ship` post-merge verify +
+  `gh workflow run`. This workflow has never run green (blocked by #5877 → #5955 →
+  this); the first green must be on a real swap, not the STATE-fallback no-op.
+- [ ] **AC15 (issue closure).** After AC14 green, `gh issue close 5960 --reason
+  completed`. (`Ref #5960` in the PR body, NOT `Closes`.)
+
+## Test Scenarios
+
+1. **Foreign-terminal:** completed `inngest` deploy (`component=inngest,
+   exit_code=0`, `start_ts>PRIOR_START`) → not accepted (component≠web-platform).
+2. **lock_contention (the review-caught bug):** `component=web-platform,
+   tag=v0.184.6, reason=lock_contention, exit_code=1, start_ts>PRIOR_START` →
+   **keep polling** (NOT fail-loud). Must appear as an explicit scenario.
+3. **Genuine swap terminal:** `component=web-platform, tag=v0.184.6, reason=ok` →
+   accepted → assert.
+4. **Genuine failure:** `component=web-platform, tag=v0.184.6,
+   reason=canary_health_failed, exit_code=1` → fail-loud with reason.
+5. **Concurrent starvation:** poll exhausts (release held the lock); final STATE
+   check passes because the winner loaded the same committed profile.
+6. **cat-deploy-state discriminators:** the 7 unit cases in Phase 6.
+
+## Sharp Edges
+
+- User-Brand Impact is filled (`aggregate pattern`) — clears deepen-plan 4.6.
+- **`lock_contention`/`running` are NON-TERMINAL.** The flock loser stamps *our*
+  `component`+`tag` with `exit_code=1` (`START_TS` pre-flock `:207`, parse pre-flock
+  `:674`), and that frame persists for the winner's whole swap. Failing on it is a
+  false-red under any concurrent web-platform deploy. Keep polling; the winner's
+  `ok` is authoritative (or the timeout STATE check passes).
+- **No cross-jq comparison on the load-bearing path.** Delivery = raw `sha256sum`
+  (`host==committed`, version-independent); reload = host-jq `jq -cS`
+  (`loaded==host`, same binary). Never compare a canonical loaded hash to the raw
+  committed hash (raw `7654ef34…` ≠ canonical `36e758eb…`) — that's why the gate is
+  `loaded==host`, not `loaded==committed`.
+- **Empty-hash false-match.** A `jq` failure must yield `matches=false`, never
+  `sha256("")`. Mirror `audit-bwrap-uid.sh:137-140`.
+- **Snapshot must be frozen.** `get_status()` overwrites `/tmp/redeploy-status.json`
+  each call — `cp` the terminal frame and read every field from the copy, or a
+  concurrent in-flight swap yields a misleading discriminator class.
+- **STATE not provenance (no nonce).** The assert verifies "the committed profile
+  is loaded now," not "our POST loaded it." A concurrent release loading the same
+  profile satisfies it; the timeout STATE check is the graceful path. A deploy
+  nonce was considered and rejected as over-build.
+- **`docker inspect … SecurityOpt` can return a literal path** (Docker didn't
+  resolve `--security-opt seccomp=<path>`). Treat as `matches=false`
+  (`audit-bwrap-uid.sh:123`), not a bogus hash.
+- **The recorded `/var/run/…` file is tmpfs** (reboot-cleared). It stays a
+  permanent inert diagnostic; never re-promote it to the gate.
+- **Do NOT prescribe `bats`.** Extend `cat-deploy-state.test.sh`; **PORT**
+  `create_docker_mock` from `audit-bwrap-uid.test.sh:26` (the suite mocks nothing
+  today).
+- **Do NOT prefix prose comments with `# shellcheck`** (`2026-06-02-shellcheck-comment-directives`).
+- **Do NOT use `awk '/A/,/B/'` ranges in ACs** (self-match papercut); use anchored
+  `grep -c` + baseline-0.
+- **Ordinal:** ADR-079 amendment, not a new ADR — expect no new ordinal minted.
+
+## Risks & Mitigations
+
+- **Risk:** the redeploy Phase 3 now correctly waits for takes the full ADR-078
+  cron drain (~70 min). **Mitigation:** poll ceiling 160×30 s (4800 s) ≥
+  CRON_DRAIN_TIMEOUT (4200 s), inside the 90-min job timeout.
+- **Risk:** `docker inspect` mid-swap → `matches=false`. **Mitigation:** the assert
+  reads the frozen post-`ok` frame (new container up); baseline settle+re-read; the
+  timeout STATE check re-evaluates.
+- **Risk:** a future profile Docker normalizes differently than host `jq -cS`
+  (64-bit `__u64` masks > 2⁵³, injected defaults). **Mitigation:** `loaded==host`
+  uses the SAME host jq on both sides (skew-immune); unit case 1 + AC14's real run
+  guard it. If AC14 is red, check Docker-injected defaults first.
+
+## Deferred / Non-Goals
+
+- **Deploy nonce** for redeploy provenance — **rejected** (not deferred): the
+  assert is a STATE invariant; the timeout STATE check achieves correctness without
+  it. No tracking issue.
+- **Removing `write_seccomp_profile_hash` / the recorded field** — **not done and
+  not scheduled**: kept permanently as an inert raw diagnostic (removal ceremony
+  exceeds the payload). No tracking issue.

--- a/knowledge-base/project/plans/2026-07-03-fix-seccomp-loaded-sha-deploy-status-discriminators-plan.md
+++ b/knowledge-base/project/plans/2026-07-03-fix-seccomp-loaded-sha-deploy-status-discriminators-plan.md
@@ -110,6 +110,56 @@ loaded==host` holds now, **PASS** (the profile is loaded regardless of which dep
 loaded it); else fail-loud UNVERIFIED. This is strictly cheaper and more correct
 than threading a nonce through POST → `write_state` → deploy-status.
 
+## Deepen-Plan Enhancement Summary
+
+**Deepened on:** 2026-07-03. The plan had already passed a 5-agent review panel
+(DHH, Kieran, code-simplicity, architecture-strategist, spec-flow) whose material
+findings are folded in above, so the deepen pass focused on the mandatory halt
+gates and live-verification of every load-bearing claim rather than adding new
+scope.
+
+**Halt gates — all PASS:**
+- **4.6 User-Brand Impact:** section present, threshold `aggregate pattern` (valid
+  enum), concrete body. Touches sensitive paths (`.github/workflows/*deploy*.yml`,
+  `apps/*/infra/`) but threshold ≠ `none`, so no scope-out line required.
+- **4.7 Observability:** all 5 fields (`liveness_signal`, `error_reporting`,
+  `failure_modes`, `logs`, `discoverability_test`) present, non-placeholder;
+  `discoverability_test.command` is a `curl` (no `ssh`).
+- **4.8 PAT-shaped variable:** no `var.*_token`/`var.*_pat`/`TF_VAR_GH_*`/literal
+  `ghp_`/`github_pat_` — no match.
+- **4.9 UI-wireframe:** no UI-surface file in Files-to-Edit (`.yml`/`.sh`/`.md`) —
+  gate does not fire.
+- **4.5 Network-Outage — N/A:** "SSH" appears only in "no SSH needed" context. The
+  plan diagnoses a poll-latch + observability gap, NOT a connectivity symptom, and
+  proposes NO sshd/firewall fix; it does not alter the terraform SSH provisioners
+  (`docker_seccomp_config` etc.) — only the post-apply verify step. No L3→L7
+  checklist obligation (nothing to verify a firewall against).
+- **4.55 Downtime & Cutover — N/A:** the fix introduces no new downtime op. Phase 3
+  makes the poll correctly wait for the **pre-existing** graceful, canary-validated,
+  ADR-078-cron-drained **blue-green** redeploy in `ci-deploy.sh` (zero-downtime by
+  construction). No `hcloud_server` reboot/replace, no lock-taking DDL, no
+  drain-less container swap in Files-to-Edit.
+
+**Live-verified load-bearing claims (deepen pass):**
+- Committed hash is **raw** `sha256sum` (`apply-deploy-pipeline-fix.yml:487`) and
+  recorded write is **raw** (`ci-deploy.sh:488`) → the `loaded==host`(host-jq) +
+  `host==committed`(raw) decomposition is skew-free as designed.
+- `lock_contention` (`ci-deploy.sh:745`) writes with `COMPONENT`/`TAG` parsed
+  pre-flock (`:674`) and `START_TS` set pre-flock (`:207`) → the BLOCKING poll fix
+  (non-terminal handling) is confirmed necessary.
+- Five `final_write_state 0` sites; only `:1211/1213` are the web-platform arm →
+  the tightened poll cannot false-timeout a legitimate swap (AC4 confirmed).
+- `cat-deploy-state.test.sh` mocks nothing (0 hits) and `create_docker_mock` exists
+  at `audit-bwrap-uid.test.sh:26` with `inspect-literal-path.txt` present → "PORT
+  not reuse" (Phase 6) is correct.
+- ADR-079 already carries `### Amendment (#5913)` + `### Amendment (#5955)` →
+  the #5960 amendment is the fourth (no new ordinal). Cited issues #5913 (CLOSED),
+  #5877 (MERGED), #4116 (CLOSED) all resolve with matching semantics.
+
+**No new material findings** — the 5-agent panel already closed the correctness
+gaps (lock_contention, jq-skew, scope trims, frozen snapshot, STATE-invariant). The
+plan is implementation-ready.
+
 ## Premise Validation (Phase 0.6)
 
 - `#5955` **CLOSED**, `#5957` **MERGED** (tag resolution). `#5875` **CLOSED**,

--- a/knowledge-base/project/specs/feat-one-shot-5960-seccomp-loaded-sha/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-5960-seccomp-loaded-sha/session-state.md
@@ -1,0 +1,21 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-03-fix-seccomp-loaded-sha-deploy-status-discriminators-plan.md
+- Status: complete
+
+### Errors
+None. All halt gates (4.6/4.7/4.8/4.9) passed; 4.5/4.55 documented N/A; all KB citations resolve; both commits pushed to `feat-one-shot-5960-seccomp-loaded-sha`.
+
+### Decisions
+- Root cause is a poll-latch, not a missing branch. The redeploy poll latched a foreign/stale/`lock_contention` terminal that never ran `write_seccomp_profile_hash`. Fix treats `lock_contention`/`running` as non-terminal (keep polling), not fail-loud.
+- Read the loaded profile live via `docker inspect HostConfig.SecurityOpt` in `cat-deploy-state.sh` (reusing `audit-bwrap-uid.sh:105-146` technique) — the affected-surface discriminator the issue's "Next step" asks for.
+- Skew-immune assert decomposition: load-bearing `loaded==host` (both host-jq) + delivery `host==committed` via raw `sha256sum` (version-independent). Eliminates the cross-jq comparison and jq-parity hazard.
+- STATE-invariant framing, not provenance — deploy nonce considered and rejected; the timeout final-state check handles concurrent-starvation.
+- Scope trims: dropped `seccomp_profile_host_path` and `seccomp_recorded_loaded_at`; leave the recorded writer as a permanent inert diagnostic. ADR-079 gets a fourth amendment (no new ordinal); no C4 impact.
+
+### Components Invoked
+- Skills: `soleur:plan`, `soleur:plan-review`, `soleur:deepen-plan`
+- Research agents: `repo-research-analyst`, `learnings-researcher`
+- Domain review: `cto`
+- 5-agent plan-review panel: `dhh-rails-reviewer`, `kieran-rails-reviewer`, `code-simplicity-reviewer`, `architecture-strategist`, `spec-flow-analyzer`

--- a/knowledge-base/project/specs/feat-one-shot-5960-seccomp-loaded-sha/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-5960-seccomp-loaded-sha/tasks.md
@@ -1,0 +1,89 @@
+---
+issue: 5960
+lane: single-domain
+plan: knowledge-base/project/plans/2026-07-03-fix-seccomp-loaded-sha-deploy-status-discriminators-plan.md
+brand_survival_threshold: aggregate pattern
+---
+
+# Tasks — fix(infra) #5960 seccomp redeploy loaded-sha discriminators
+
+Derived from the finalized (post-5-agent-review) plan. Phase order is load-bearing:
+producer (1) → workflow assert (2) → poll (3) → stop-asserting-recorded (4) → ADR (5) → tests (6).
+
+## Phase 0 — Preconditions
+
+- [ ] 0.1 Confirm on branch `feat-one-shot-5960-seccomp-loaded-sha` (not main).
+- [ ] 0.2 Re-read `apps/web-platform/infra/audit-bwrap-uid.sh:105-146` (the docker-inspect
+      + `jq -cS` + EMPTY_HASH-guard technique being reused) and
+      `apps/web-platform/infra/cat-deploy-state.sh` sibling helpers
+      (`container_restart_json`, `sandbox_canary_json`) + the final `jq` merge block.
+- [ ] 0.3 Confirm `SECCOMP_PROFILE_HOST_PATH` default at `ci-deploy.sh:195` =
+      `/etc/docker/seccomp-profiles/soleur-bwrap.json`.
+- [ ] 0.4 Grep every `final_write_state 0` in `ci-deploy.sh` (5 hits); confirm only
+      `:1211/1213` is the web-platform arm (AC4).
+
+## Phase 1 — cat-deploy-state.sh: live loaded + host discriminators (producer)
+
+- [ ] 1.1 Add `seccomp_profile_loaded_matches_host` (bool): docker-inspect
+      `HostConfig.SecurityOpt` → `sed -n 's/^seccomp=//p'` → literal-path guard →
+      `jq -cS | sha256sum` of inlined vs host file (SAME host jq) → equal + non-empty-hash.
+      `false` on any failure; EMPTY_HASH guard (audit-bwrap-uid.sh:137-140).
+- [ ] 1.2 Add `seccomp_profile_host_sha256` (RAW `sha256sum` of host file; `""` if absent).
+- [ ] 1.3 Add `seccomp_profile_host_present` (bool `-f`).
+- [ ] 1.4 Extend the final `jq` merge with the 3 keys; do NOT clobber top-level `exit_code`.
+- [ ] 1.5 Leave existing `seccomp_profile_sha256` (raw recorded) untouched (inert diagnostic).
+      Do NOT add `seccomp_profile_host_path` or `seccomp_recorded_loaded_at`.
+
+## Phase 2 — apply-deploy-pipeline-fix.yml: robust snapshot-bound assert (consumer)
+
+- [ ] 2.1 Keep `COMMITTED_SHA` raw `sha256sum` (`:487` unchanged).
+- [ ] 2.2 Fast-path: skip redeploy iff `host_present && host_sha256==COMMITTED_SHA &&
+      loaded_matches_host`. On transient-empty `loaded_matches_host` at baseline, settle+re-read once.
+- [ ] 2.3 On terminal detection `cp /tmp/redeploy-status.json /tmp/redeploy-terminal.json`;
+      read load-bearing + all discriminators from the frozen frame (AC5).
+- [ ] 2.4 Load-bearing assert: `host_present && host_sha256==COMMITTED_SHA && loaded_matches_host`.
+- [ ] 2.5 Fail-loud discriminator classes (not-delivered / host-stale / not-reloaded); no
+      `.seccomp_profile_sha256` equality gate remains (AC6/AC7).
+- [ ] 2.6 Timeout graceful-degradation: final STATE check → PASS iff invariant holds, else
+      fail-loud UNVERIFIED (AC8). No nonce.
+
+## Phase 3 — apply-deploy-pipeline-fix.yml: poll predicate (BLOCKING behavioral fix)
+
+- [ ] 3.1 Read `component`, `tag`, `reason` from the status frame.
+- [ ] 3.2 Terminal acceptance: `component=="web-platform" && tag=="$TARGET_TAG" &&
+      exit_code>=0 && start_ts>PRIOR_START`.
+- [ ] 3.3 Adjudicate: `lock_contention`/`adr027_prod_already_running`/`running`(exit -1) →
+      KEEP POLLING; `ok`/`ok_peer_fanout_degraded` → assert; other genuine-failure reason →
+      fail loud with reason (AC3).
+
+## Phase 4 — Stop asserting the recorded field (no removal)
+
+- [ ] 4.1 Ensure no load-bearing/fast-path read of `.seccomp_profile_sha256` remains.
+- [ ] 4.2 Leave `write_seccomp_profile_hash` (ci-deploy.sh) in place as inert raw diagnostic
+      (no deprecation cycle, no tracking issue).
+
+## Phase 5 — ADR-079 amendment
+
+- [ ] 5.1 Add `### Amendment (#5960, 2026-07-03) — …` (4-6 lines): old contract → new
+      (`loaded==host` live host-jq; `host==committed` raw; poll requires component+tag,
+      lock_contention non-terminal; STATE-invariant timeout). Note the second docker-inspect
+      per GET. No new ordinal (AC13).
+
+## Phase 6 — Tests
+
+- [ ] 6.1 PORT `create_docker_mock` from `audit-bwrap-uid.test.sh:26` into
+      `cat-deploy-state.test.sh` (suite currently mocks nothing).
+- [ ] 6.2 Cases: (1) loaded==host, (2) drift, (3) literal-path, (4) container-down,
+      (5) host-absent, (6) merge-integrity/exit_code, (7) empty-hash guard.
+- [ ] 6.3 Run `cat-deploy-state.test.sh` green via the infra `.test.sh` harness (no bats).
+
+## Phase 7 — Verify / negative-scope
+
+- [ ] 7.1 AC11 negative scope: no `seccomp-bwrap.json` byte change, no `apps/web-platform/infra/sentry/` change.
+- [ ] 7.2 Static AC checks (AC3 baseline-0 `.component`, AC4 grep, AC6 grep, AC13 ADR count).
+
+## Post-merge (operator / automated)
+
+- [ ] P.1 AC14: `apply-deploy-pipeline-fix.yml` real green run (loaded_matches_host && host==committed
+      on a real swap). `gh run watch`; no SSH.
+- [ ] P.2 AC15: `gh issue close 5960 --reason completed` after AC14 green. PR body uses `Ref #5960`.

--- a/knowledge-base/project/specs/feat-one-shot-5960-seccomp-loaded-sha/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-5960-seccomp-loaded-sha/tasks.md
@@ -12,75 +12,75 @@ producer (1) → workflow assert (2) → poll (3) → stop-asserting-recorded (4
 
 ## Phase 0 — Preconditions
 
-- [ ] 0.1 Confirm on branch `feat-one-shot-5960-seccomp-loaded-sha` (not main).
-- [ ] 0.2 Re-read `apps/web-platform/infra/audit-bwrap-uid.sh:105-146` (the docker-inspect
+- [x] 0.1 Confirm on branch `feat-one-shot-5960-seccomp-loaded-sha` (not main).
+- [x] 0.2 Re-read `apps/web-platform/infra/audit-bwrap-uid.sh:105-146` (the docker-inspect
       + `jq -cS` + EMPTY_HASH-guard technique being reused) and
       `apps/web-platform/infra/cat-deploy-state.sh` sibling helpers
       (`container_restart_json`, `sandbox_canary_json`) + the final `jq` merge block.
-- [ ] 0.3 Confirm `SECCOMP_PROFILE_HOST_PATH` default at `ci-deploy.sh:195` =
+- [x] 0.3 Confirm `SECCOMP_PROFILE_HOST_PATH` default at `ci-deploy.sh:195` =
       `/etc/docker/seccomp-profiles/soleur-bwrap.json`.
-- [ ] 0.4 Grep every `final_write_state 0` in `ci-deploy.sh` (5 hits); confirm only
+- [x] 0.4 Grep every `final_write_state 0` in `ci-deploy.sh` (5 hits); confirm only
       `:1211/1213` is the web-platform arm (AC4).
 
 ## Phase 1 — cat-deploy-state.sh: live loaded + host discriminators (producer)
 
-- [ ] 1.1 Add `seccomp_profile_loaded_matches_host` (bool): docker-inspect
+- [x] 1.1 Add `seccomp_profile_loaded_matches_host` (bool): docker-inspect
       `HostConfig.SecurityOpt` → `sed -n 's/^seccomp=//p'` → literal-path guard →
       `jq -cS | sha256sum` of inlined vs host file (SAME host jq) → equal + non-empty-hash.
       `false` on any failure; EMPTY_HASH guard (audit-bwrap-uid.sh:137-140).
-- [ ] 1.2 Add `seccomp_profile_host_sha256` (RAW `sha256sum` of host file; `""` if absent).
-- [ ] 1.3 Add `seccomp_profile_host_present` (bool `-f`).
-- [ ] 1.4 Extend the final `jq` merge with the 3 keys; do NOT clobber top-level `exit_code`.
-- [ ] 1.5 Leave existing `seccomp_profile_sha256` (raw recorded) untouched (inert diagnostic).
+- [x] 1.2 Add `seccomp_profile_host_sha256` (RAW `sha256sum` of host file; `""` if absent).
+- [x] 1.3 Add `seccomp_profile_host_present` (bool `-f`).
+- [x] 1.4 Extend the final `jq` merge with the 3 keys; do NOT clobber top-level `exit_code`.
+- [x] 1.5 Leave existing `seccomp_profile_sha256` (raw recorded) untouched (inert diagnostic).
       Do NOT add `seccomp_profile_host_path` or `seccomp_recorded_loaded_at`.
 
 ## Phase 2 — apply-deploy-pipeline-fix.yml: robust snapshot-bound assert (consumer)
 
-- [ ] 2.1 Keep `COMMITTED_SHA` raw `sha256sum` (`:487` unchanged).
-- [ ] 2.2 Fast-path: skip redeploy iff `host_present && host_sha256==COMMITTED_SHA &&
+- [x] 2.1 Keep `COMMITTED_SHA` raw `sha256sum` (`:487` unchanged).
+- [x] 2.2 Fast-path: skip redeploy iff `host_present && host_sha256==COMMITTED_SHA &&
       loaded_matches_host`. On transient-empty `loaded_matches_host` at baseline, settle+re-read once.
-- [ ] 2.3 On terminal detection `cp /tmp/redeploy-status.json /tmp/redeploy-terminal.json`;
+- [x] 2.3 On terminal detection `cp /tmp/redeploy-status.json /tmp/redeploy-terminal.json`;
       read load-bearing + all discriminators from the frozen frame (AC5).
-- [ ] 2.4 Load-bearing assert: `host_present && host_sha256==COMMITTED_SHA && loaded_matches_host`.
-- [ ] 2.5 Fail-loud discriminator classes (not-delivered / host-stale / not-reloaded); no
+- [x] 2.4 Load-bearing assert: `host_present && host_sha256==COMMITTED_SHA && loaded_matches_host`.
+- [x] 2.5 Fail-loud discriminator classes (not-delivered / host-stale / not-reloaded); no
       `.seccomp_profile_sha256` equality gate remains (AC6/AC7).
-- [ ] 2.6 Timeout graceful-degradation: final STATE check → PASS iff invariant holds, else
+- [x] 2.6 Timeout graceful-degradation: final STATE check → PASS iff invariant holds, else
       fail-loud UNVERIFIED (AC8). No nonce.
 
 ## Phase 3 — apply-deploy-pipeline-fix.yml: poll predicate (BLOCKING behavioral fix)
 
-- [ ] 3.1 Read `component`, `tag`, `reason` from the status frame.
-- [ ] 3.2 Terminal acceptance: `component=="web-platform" && tag=="$TARGET_TAG" &&
+- [x] 3.1 Read `component`, `tag`, `reason` from the status frame.
+- [x] 3.2 Terminal acceptance: `component=="web-platform" && tag=="$TARGET_TAG" &&
       exit_code>=0 && start_ts>PRIOR_START`.
-- [ ] 3.3 Adjudicate: `lock_contention`/`adr027_prod_already_running`/`running`(exit -1) →
+- [x] 3.3 Adjudicate: `lock_contention`/`adr027_prod_already_running`/`running`(exit -1) →
       KEEP POLLING; `ok`/`ok_peer_fanout_degraded` → assert; other genuine-failure reason →
       fail loud with reason (AC3).
 
 ## Phase 4 — Stop asserting the recorded field (no removal)
 
-- [ ] 4.1 Ensure no load-bearing/fast-path read of `.seccomp_profile_sha256` remains.
-- [ ] 4.2 Leave `write_seccomp_profile_hash` (ci-deploy.sh) in place as inert raw diagnostic
+- [x] 4.1 Ensure no load-bearing/fast-path read of `.seccomp_profile_sha256` remains.
+- [x] 4.2 Leave `write_seccomp_profile_hash` (ci-deploy.sh) in place as inert raw diagnostic
       (no deprecation cycle, no tracking issue).
 
 ## Phase 5 — ADR-079 amendment
 
-- [ ] 5.1 Add `### Amendment (#5960, 2026-07-03) — …` (4-6 lines): old contract → new
+- [x] 5.1 Add `### Amendment (#5960, 2026-07-03) — …` (4-6 lines): old contract → new
       (`loaded==host` live host-jq; `host==committed` raw; poll requires component+tag,
       lock_contention non-terminal; STATE-invariant timeout). Note the second docker-inspect
       per GET. No new ordinal (AC13).
 
 ## Phase 6 — Tests
 
-- [ ] 6.1 PORT `create_docker_mock` from `audit-bwrap-uid.test.sh:26` into
+- [x] 6.1 PORT `create_docker_mock` from `audit-bwrap-uid.test.sh:26` into
       `cat-deploy-state.test.sh` (suite currently mocks nothing).
-- [ ] 6.2 Cases: (1) loaded==host, (2) drift, (3) literal-path, (4) container-down,
+- [x] 6.2 Cases: (1) loaded==host, (2) drift, (3) literal-path, (4) container-down,
       (5) host-absent, (6) merge-integrity/exit_code, (7) empty-hash guard.
-- [ ] 6.3 Run `cat-deploy-state.test.sh` green via the infra `.test.sh` harness (no bats).
+- [x] 6.3 Run `cat-deploy-state.test.sh` green via the infra `.test.sh` harness (no bats).
 
 ## Phase 7 — Verify / negative-scope
 
-- [ ] 7.1 AC11 negative scope: no `seccomp-bwrap.json` byte change, no `apps/web-platform/infra/sentry/` change.
-- [ ] 7.2 Static AC checks (AC3 baseline-0 `.component`, AC4 grep, AC6 grep, AC13 ADR count).
+- [x] 7.1 AC11 negative scope: no `seccomp-bwrap.json` byte change, no `apps/web-platform/infra/sentry/` change.
+- [x] 7.2 Static AC checks (AC3 baseline-0 `.component`, AC4 grep, AC6 grep, AC13 ADR count).
 
 ## Post-merge (operator / automated)
 

--- a/plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts
+++ b/plugins/soleur/test/ship-deploy-pipeline-fix-gate.test.ts
@@ -666,11 +666,16 @@ describe("profile→redeploy loaded-verification guard (#5875 item 4)", () => {
     const nextStep = rest.indexOf("\n      - name:");
     const stepBlock =
       nextStep >= 0 ? yml.slice(redeployStepIdx, redeployStepIdx + 1 + nextStep) : yml.slice(redeployStepIdx);
-    // Committed hash: sha256 of the in-repo profile; loaded hash: the
-    // seccomp_profile_sha256 field surfaced on /hooks/deploy-status by
-    // cat-deploy-state.sh (recorded by ci-deploy.sh at container start).
+    // Committed hash: raw sha256 of the in-repo profile. #5960 reads the LOADED
+    // profile live from the running container via cat-deploy-state.sh's
+    // seccomp_profile_loaded_matches_host (reload leg) + seccomp_profile_host_sha256
+    // (raw delivery leg) — NOT the ephemeral recorded seccomp_profile_sha256, which
+    // is now an inert diagnostic (reboot-cleared, latch-blind). Assert the two
+    // load-bearing discriminators so this gate tracks the real contract, not a
+    // coincidental comment match.
     expect(stepBlock).toMatch(/sha256sum\s+.*seccomp-bwrap\.json/);
-    expect(stepBlock).toContain("seccomp_profile_sha256");
+    expect(stepBlock).toContain("seccomp_profile_loaded_matches_host");
+    expect(stepBlock).toContain("seccomp_profile_host_sha256");
     // Fail-loud on a loaded≠committed mismatch (the whole point of item 4).
     expect(stepBlock).toContain("::error::");
     expect(stepBlock).toMatch(/\bexit 1\b/);


### PR DESCRIPTION
## Summary

`apply-deploy-pipeline-fix.yml`'s "#5875 item-4" redeploy assert was red: it read the loaded seccomp profile from an ephemeral recorded field that came back empty, and its poll latched a foreign / `lock_contention` terminal (~31s — physically impossible for a real canary swap). This fixes both defects and adds the live discriminator the issue's "Next step" asked for.

- **Live loaded-profile proof** in `cat-deploy-state.sh`: `seccomp_profile_loaded_matches_host` (docker inspect `HostConfig.SecurityOpt` vs the on-host file, one host `jq`), `seccomp_profile_host_sha256` (raw `sha256sum`), `seccomp_profile_host_present`. Reuses the `audit-bwrap-uid.sh:105-146` technique.
- **STATE-invariant assert**: `host_sha256 == COMMITTED_SHA` (raw, delivery leg) AND `loaded_matches_host` (host-`jq`, reload leg) — no cross-jq comparison on the load-bearing path.
- **Poll fix (blocking)**: accept a terminal only for `component=web-platform && tag=TARGET_TAG && start_ts>PRIOR_START`; treat `lock_contention` / `adr027_prod_already_running` / `running` as non-terminal; freeze the terminal frame before reading; self-diagnose not-delivered / host-stale / not-reloaded; do one STATE check on poll exhaustion.
- Recorded `seccomp_profile_sha256` kept as an inert diagnostic (no gate). ADR-079 amended (item-4 loaded contract; no new ordinal).

On merge the workflow auto-fires (both edited files are `deploy_pipeline_fix` trigger files), delivering the new `cat-deploy-state.sh` to the host and running the redeploy assert. With no `seccomp-bwrap.json` byte change in this PR, the assert takes the fast path (committed profile already loaded → invariant holds → exit 0), which is the green run proving the empty-loaded-sha bug is fixed; the poll/swap path is exercised end-to-end by the next real seccomp change.

Ref #5960

## User-Brand Impact

- **Artifact:** the shared agent-sandbox seccomp syscall allow/deny boundary (no per-user data or credential surface).
- **Vector:** a permissive profile applied-but-not-loaded could ship unverified, re-opening the #5875 item-4 gap the assert exists to catch.
- **Brand-survival threshold:** aggregate pattern

## Changelog

### Web Platform (infra)

- Add live loaded-vs-committed seccomp discriminators to `/hooks/deploy-status`.
- Rewrite the post-apply redeploy assert to validate the swap terminal and read the loaded profile live from the running container.
- Amend ADR-079 (item-4 loaded-profile contract).

## Test plan

- [x] `cat-deploy-state.test.sh` — 52/52 (7 new cases: equal / drift / literal-path / container-down / host-absent / merge-integrity / empty-hash guard)
- [x] `ship-deploy-pipeline-fix-gate.test.ts` — 89/89 (updated to assert the new load-bearing discriminators)
- [x] infra guards (`infra-config-install` 29, `infra-config-apply` 59, `journald-config` 36) green
- [x] `actionlint` + `shellcheck` clean; embedded workflow bash `bash -n` clean
- [x] 6-agent review — security-sentinel + architecture-strategist CLEAN; 2 findings (P2 stale gate-test contract, P3 pipefail guard) fixed inline

Generated with [Claude Code](https://claude.com/claude-code)
