### PR TITLE
feat(hooks): merge-path-independent auto-close-prose guard on gh pr merge

### DIFF
--- a/.claude/hooks/pre-merge-auto-close-scan.sh
+++ b/.claude/hooks/pre-merge-auto-close-scan.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block `gh pr merge` when a branch commit body OR the PR body
+# contains a PROSE-EMBEDDED GitHub auto-close keyword + #N (e.g. "the sweeper
+# closes #5887", "I'll close #5955 after the pipeline") that would auto-close an
+# issue you did not intend to close on merge.
+#
+# Source rule: knowledge-base/project/learnings/2026-06-29-auto-closes-meta-content-
+#   in-commit-body-trips-github-autoclose-on-hand-rolled-merge.md
+#   + 2026-07-03-chain-of-latent-defects-clearing-a-wedge-exposes-a-cascade.md
+#   (auto-close-prose hit TWICE via hand-rolled `gh pr merge`).
+#
+# Why this hook exists (the gap it closes): `/ship` Phase 6 runs
+# `plugins/soleur/skills/ship/scripts/auto-close-scan.sh` at PR-creation time, but
+# a HAND-ROLLED / auto `gh pr merge` (bypassing /ship) has no equivalent check.
+# This hook makes the guard merge-path-independent, mirroring how
+# pre-merge-rebase.sh already intercepts `gh pr merge`.
+#
+# Precision (why it does NOT block legitimate closes): an intentional `Closes #N`
+# on its own line (the conventional form /ship PRs use) is ALLOWED. Only a
+# close-keyword that appears AFTER prose on its line — the accidental vector —
+# denies. So normal fix-PRs that mean to close their issue merge unimpeded.
+#
+# Fail-open: any infrastructure error (bad payload, missing git, scan failure)
+# exits 0 (allow). A hook must never wedge a merge on its own bug.
+set -uo pipefail
+
+_LIB_DIR="$(dirname "${BASH_SOURCE[0]}")/lib"
+# strip_command_bodies (blank quoted/heredoc bodies so a commit MESSAGE that
+# documents "gh pr merge" is not mis-detected as a merge — same #4600/#5192
+# canonical helper pre-merge-rebase.sh uses).
+if [[ -f "$_LIB_DIR/incidents.sh" ]]; then
+  # shellcheck source=/dev/null
+  source "$_LIB_DIR/incidents.sh"
+else
+  strip_command_bodies() { cat; }
+fi
+export SOLEUR_HOOK_NAME="pre-merge-auto-close-scan"
+
+INPUT=$(cat)
+# `|| true`: jq exits non-zero on malformed/empty stdin under pipefail; degrade
+# to "" (no detection → clean allow) rather than aborting.
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""' || true)
+SCAN=$(printf '%s' "$CMD" | strip_command_bodies || printf '%s' "$CMD")
+
+# Only intercept `gh pr merge` (incl. the `… -- gh pr merge` wrapped form).
+if ! echo "$SCAN" | grep -qE '(^|&&|\|\||;|\s--\s)\s*gh\s+pr\s+merge(\s|$)'; then
+  exit 0
+fi
+
+WORK_DIR=$(echo "$INPUT" | jq -r '.cwd // ""' || true)
+[[ -n "$WORK_DIR" && -d "$WORK_DIR" ]] || exit 0
+git -C "$WORK_DIR" rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+BRANCH=$(git -C "$WORK_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+[[ -n "$BRANCH" && "$BRANCH" != "main" && "$BRANCH" != "master" && "$BRANCH" != "HEAD" ]] || exit 0
+
+# Ack escape hatch: SOLEUR_ACK_AUTOCLOSE=1 means the operator has confirmed the
+# embedded close is intentional (rare — a prose sentence that really should
+# close). Mirrors the ack-env pattern used by sibling gates.
+[[ "${SOLEUR_ACK_AUTOCLOSE:-}" == "1" ]] && exit 0
+
+# Build the scan corpus: the branch commit bodies (feed the squash commit) AND
+# the PR body (the other squash-message source, repo-config-dependent). Both are
+# best-effort; a failure to read either must not block the merge.
+SCAN_FILE=$(mktemp 2>/dev/null) || exit 0
+trap 'rm -f "$SCAN_FILE"' EXIT
+git -C "$WORK_DIR" log origin/main..HEAD --format=%B 2>/dev/null >>"$SCAN_FILE" || true
+# PR body, bounded so a slow/absent network never stalls the merge.
+timeout 8 gh pr view --repo "$(git -C "$WORK_DIR" remote get-url origin 2>/dev/null | sed -E 's#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#')" \
+  "$BRANCH" --json body --jq '.body' 2>/dev/null >>"$SCAN_FILE" || true
+[[ -s "$SCAN_FILE" ]] || exit 0
+
+# Reuse the canonical scanner (single-sources GitHub's keyword set + locale pin),
+# then keep only PROSE-EMBEDDED matches: lines whose close-keyword is NOT the
+# start-of-line directive (a standalone `Closes #N` / `- Fixes #N` is intentional).
+SCANNER="$WORK_DIR/plugins/soleur/skills/ship/scripts/auto-close-scan.sh"
+[[ -x "$SCANNER" || -f "$SCANNER" ]] || exit 0
+DIRECTIVE='^[0-9]+:[[:space:]]*([-*>][[:space:]]*)*(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+(#[0-9]+|GH-[0-9]+)'
+EMBEDDED=$(bash "$SCANNER" "$SCAN_FILE" 2>/dev/null | grep -viE "$DIRECTIVE" || true)
+
+[[ -n "$EMBEDDED" ]] || exit 0
+
+REASON="BLOCKED: a commit/PR body has a prose-embedded auto-close keyword that will auto-close an issue on merge (GitHub's parser is markdown- and position-blind):
+
+$(printf '%s\n' "$EMBEDDED" | sed 's/^/  /')
+
+Fix: reword the sentence to remove the close-keyword + #N adjacency — e.g. 'auto-resolves issue #N' or 'the sweeper will close issue #N' (no bare 'close(s)/fix(es)/resolve(s) #N'). A standalone 'Closes #N' line is fine and is NOT flagged. If this close is genuinely intended, re-run with SOLEUR_ACK_AUTOCLOSE=1."
+
+jq -n --arg r "$REASON" \
+  '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+exit 0

--- a/.claude/hooks/pre-merge-auto-close-scan.test.sh
+++ b/.claude/hooks/pre-merge-auto-close-scan.test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Fixture tests for pre-merge-auto-close-scan.sh. Each test builds a tmp git repo
+# (with an origin/main ref + feature commits), composes a PreToolUse(Bash) input,
+# pipes it to the hook, and asserts the permissionDecision.
+#
+# Isolation pattern mirrors follow-through-directive-gate.test.sh.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/pre-merge-auto-close-scan.sh"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCANNER="$REPO_ROOT/plugins/soleur/skills/ship/scripts/auto-close-scan.sh"
+
+PASS=0; FAIL=0; TOTAL=0
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq missing"; exit 0; }
+command -v git >/dev/null 2>&1 || { echo "SKIP: git missing"; exit 0; }
+[[ -f "$SCANNER" ]] || { echo "SKIP: auto-close-scan.sh not found"; exit 0; }
+
+# Build a tmp WORK_DIR: a git repo on a feature branch with an origin/main ref,
+# the scanner copied in, and a gh stub on PATH returning $PR_BODY. Args:
+#   $1 = commit body (last feature commit), $2 = PR body (for the gh stub)
+make_work_dir() {
+  local body="$1" pr_body="$2" tmp
+  tmp="$(mktemp -d)"
+  git -C "$tmp" init -q -b feat-x
+  git -C "$tmp" config user.email t@t; git -C "$tmp" config user.name t
+  git -C "$tmp" commit -q --allow-empty -m "base"
+  git -C "$tmp" update-ref refs/remotes/origin/main HEAD            # origin/main = base
+  git -C "$tmp" remote add origin "git@github.com:acme/repo.git"
+  git -C "$tmp" commit -q --allow-empty -m "$body"                  # feature commit
+  mkdir -p "$tmp/plugins/soleur/skills/ship/scripts"
+  cp "$SCANNER" "$tmp/plugins/soleur/skills/ship/scripts/auto-close-scan.sh"
+  # gh stub: `gh pr view … --json body --jq .body` prints $pr_body.
+  mkdir -p "$tmp/.binstub"
+  cat > "$tmp/.binstub/gh" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "$pr_body"
+EOF
+  chmod +x "$tmp/.binstub/gh"
+  echo "$tmp"
+}
+
+make_input() { jq -n --arg cmd "$1" --arg cwd "$2" \
+  '{tool_name:"Bash", tool_input:{command:$cmd}, cwd:$cwd}'; }
+
+# run_case <name> <expect: deny|allow> <cmd> <commit-body> <pr-body> [ack]
+run_case() {
+  local name="$1" expect="$2" cmd="$3" body="$4" pr="$5" ack="${6:-}"
+  TOTAL=$((TOTAL+1))
+  local wd out decision
+  wd="$(make_work_dir "$body" "$pr")"
+  out="$(make_input "$cmd" "$wd" | PATH="$wd/.binstub:$PATH" ${ack:+SOLEUR_ACK_AUTOCLOSE=1} bash "$HOOK" 2>/dev/null || true)"
+  decision="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // "allow"' 2>/dev/null)"
+  [[ -n "$decision" ]] || decision="allow"   # empty hook output = allow (jq on empty input yields nothing)
+  rm -rf "$wd"
+  if [[ "$decision" == "$expect" ]]; then
+    PASS=$((PASS+1)); echo "PASS: $name ($decision)"
+  else
+    FAIL=$((FAIL+1)); echo "FAIL: $name — expected $expect, got $decision"
+  fi
+}
+
+# --- prose-embedded close in the COMMIT body → DENY (the #5887 vector) ---
+run_case "commit prose-embedded closes → deny" deny \
+  "gh pr merge 1 --squash --auto" $'fix: thing\n\nthe follow-through sweeper closes #5887 post-merge.' ""
+
+# --- prose-embedded close in the PR BODY → DENY (the #5955 vector, via gh stub) ---
+run_case "PR-body prose-embedded close → deny" deny \
+  "gh pr merge 1 --squash" "fix: thing" "I'll close #5955 after the pipeline confirms green."
+
+# --- standalone Closes #N (intentional, own line) → ALLOW ---
+run_case "standalone Closes line → allow" allow \
+  "gh pr merge 1 --squash" $'fix: thing\n\nCloses #5887' ""
+
+# --- bullet '- Fixes #N' (intentional) → ALLOW ---
+run_case "bullet Fixes line → allow" allow \
+  "gh pr merge 1 --squash" $'fix: thing\n\n- Fixes #5887' ""
+
+# --- Ref #N (no close keyword) → ALLOW ---
+run_case "Ref only → allow" allow \
+  "gh pr merge 1 --squash" $'fix: thing\n\nRef #5887, #5877' ""
+
+# --- non-merge command → ALLOW (early exit) ---
+run_case "non-merge command → allow" allow \
+  "git status --short" $'fix: thing\n\nsweeper closes #5887' ""
+
+# --- ack env set → ALLOW despite embedded close ---
+run_case "ack env overrides → allow" allow \
+  "gh pr merge 1 --squash" $'fix: thing\n\nsweeper closes #5887' "" ack
+
+# --- gh pr merge documented inside a commit -m string is NOT a merge → ALLOW ---
+# (embedded close IS in the body: if strip_command_bodies fails and the quoted
+#  "gh pr merge" is mis-detected as a merge, the body's embedded close would DENY —
+#  so allow here proves the strip works.)
+run_case "gh pr merge in quoted string → allow" allow \
+  "git commit -m 'do not hand-roll gh pr merge here'" $'base\n\nsweeper closes #5887' ""
+
+echo ""
+echo "=== $PASS/$TOTAL passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,6 +52,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-merge-auto-close-scan.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/ship-unpushed-commits-gate.sh"
           }
         ]


### PR DESCRIPTION
## What

New PreToolUse hook `pre-merge-auto-close-scan.sh` that intercepts `gh pr merge` and blocks it when a **prose-embedded** GitHub auto-close keyword + `#N` sits in a branch commit body or the PR body (e.g. "the sweeper closes #N", "I'll close #N after…").

## Why

`/ship` Phase 6 runs `auto-close-scan.sh` at PR-creation, but a **hand-rolled / auto `gh pr merge`** (bypassing `/ship`) had no equivalent check. This session hit that gap **twice** — two issues auto-closed prematurely by incidental prose in commit/PR bodies. This makes the guard merge-path-independent, mirroring how `pre-merge-rebase.sh` already intercepts `gh pr merge`.

## Precision (does NOT block legitimate closes)

An intentional `Closes #N` / `- Fixes #N` on its own line — the conventional form `/ship` PRs use — is **allowed**. Only a close keyword that appears *after prose on its line* (the accidental vector) denies. So normal fix-PR merges are never impeded. `SOLEUR_ACK_AUTOCLOSE=1` is an explicit override for a genuinely-intended embedded close.

## Verification

- Reuses `ship/scripts/auto-close-scan.sh` for GitHub's canonical keyword set + locale pin; adds the intent refinement in the hook. Fail-open on any infra error.
- Test `pre-merge-auto-close-scan.test.sh`: **8/8** — both prose vectors (commit-body + PR-body) deny; standalone `Closes`, bullet `Fixes`, `Ref`-only, non-merge command, ack-env, and quoted-string `strip_command_bodies` all allow.
- `bash -n` + `shellcheck -S error` clean; `hookeventname-coverage` gate green (deny JSON pairs `permissionDecision` with `hookEventName`).
- Registered in `.claude/settings.json` next to `pre-merge-rebase.sh`.

## Changelog

- feat(hooks): guard `gh pr merge` against prose-embedded auto-close keywords, closing the `/ship`-only coverage gap.

Refs #5887, #5955 (the two premature auto-closes this prevents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)