### PR TITLE
docs(pir): mark fresh-host bake-and-extract verification complete (#5942 closed)

### DIFF
--- a/knowledge-base/engineering/operations/post-mortems/2026-07-03-hetzner-fresh-host-userdata-32kb-cap-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/2026-07-03-hetzner-fresh-host-userdata-32kb-cap-postmortem.md
@@ -92,8 +92,13 @@ installer which writes the fail-closed `/run/soleur-hostscripts.ok` sentinel the
 
 `bun test plugins/soleur/test/cloud-init-user-data-size.test.ts` — 21 pass (web < 30,500 B
 strict + structural extraction contract + Dockerfile↔server.tf baked-set parity; also pins
-git-data host at a no-further-growth ceiling). Live fresh-host verification is gated behind
-operator cutover #5887 and tracked as a ⏳ test-plan item on PR #5922.
+git-data host at a no-further-growth ceiling). Live fresh-host verification **completed
+2026-07-03** (#5942, closed): fresh `soleur-web-2` provisioned through the bake-and-extract
+path (created 07:13:22Z, 61s after #5922 merged) and healthy ~9h later — confirmed via
+self-pulled signals (no SSH): (1) host `running` not powered off ⇒ fail-closed
+`/run/soleur-hostscripts.ok` sentinel written; (2) **zero** `stage=extract|verify|install`
+(+5 other stages) Sentry bootstrap-trap events in 24h. Dedicated per-host Better Stack
+uptime alarm for future boots deferred to #5933.
 
 ---
 
@@ -164,4 +169,6 @@ Every action item and follow-up so this incident cannot recur.
 | Issue | Action | Status |
 |---|---|---|
 | #5927 | git-data host cloud-init `user_data` is ALSO over cap (~41.7 KB, no-docker host so bake-and-extract N/A) — resolve before ADR-068 Phase 2; size guard pins it at a no-further-growth ceiling in the meantime. | open |
-| #5887 | `apply-web-platform-infra.yml` red since #5877 (moved resources excluded by `-target` allow-list) — this blocked infra-apply pipeline gates any fresh-host provision reaching prod, so it must go green before this fix is exercised live (the ⏳ recovery-verification item confirming extraction + sentinel end-to-end). | open |
+| #5887 | `apply-web-platform-infra.yml` red since #5877 (moved resources excluded by `-target` allow-list) — this blocked infra-apply pipeline gated any fresh-host provision reaching prod, so it had to go green before this fix was exercised live. | **closed 2026-07-03** (unblocked via #5950 deferring the web-1 placement reboot with `ignore_changes`; infra-apply green). |
+| #5942 | Live fresh-host recovery-verification (extraction + content-hash + sentinel end-to-end on a real host). | **closed 2026-07-03** — verified on fresh `soleur-web-2` (running + zero Sentry stage-trap events). |
+| #5933 | Dedicated per-host Better Stack "provision-armed uptime absence" monitor (ADR-082 Item 1) — the PRIMARY fresh-boot alarm; not yet wired, so #5942 relied on the fail-closed running-state proxy + Sentry absence instead. | open |


### PR DESCRIPTION
## What

Updates the 32KB-cap fresh-host PIR (`2026-07-03-hetzner-fresh-host-userdata-32kb-cap-postmortem.md`) to reflect that the live recovery-verification is **done**. The action-items table listed #5887 and the ⏳ recovery-verification as `open`; both are now closed.

## Why

Doc drift: the PIR was written while the verification was still blocked. As of 2026-07-03:
- **#5887** (infra-apply blocker) — closed (unblocked via #5950 deferring the web-1 placement reboot with `ignore_changes`; `apply-web-platform-infra.yml` green).
- **#5942** (live fresh-host verification) — closed, verified.

## Verification evidence (self-pulled, no SSH, no dashboard)

Fresh `soleur-web-2` (Hetzner id `147422810`) provisioned through the bake-and-extract path — created `2026-07-03T07:13:22Z`, 61s after #5922 merged — and healthy ~9h later:
- **Signal 1 (fail-closed sentinel):** host `running`, not powered off ⇒ `/run/soleur-hostscripts.ok` was written (a failed bootstrap `poweroff -f`s the host).
- **Signal 2 (Sentry stage-trap absence):** zero `stage=extract|verify|install|hooks|assert|pull|reload|journald` events in 24h.

## Changes

- Recovery-verification paragraph: gated-behind-#5887 → completed-2026-07-03 with the two signals.
- Action-items table: #5887 + #5942 marked closed; added **#5933** (dedicated per-host Better Stack uptime monitor, ADR-082 Item 1) as the remaining open follow-up — it's the *named* primary fresh-boot alarm that isn't wired yet, so #5942 relied on the two proxy signals above.

Docs-only; no code or infra change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)