### PR TITLE
fix(canary): persist faithful-canary soak state on durable storage, not tmpfs

### DIFF
--- a/apps/web-platform/infra/cat-deploy-state.sh
+++ b/apps/web-platform/infra/cat-deploy-state.sh
@@ -186,7 +186,10 @@ cron_drain_json() {
 # the canary. Best-effort + read-only. The canary-promotion follow-through
 # (scripts/followthroughs/canary-promotion-5875.sh) reads this field.
 sandbox_canary_json() {
-  local f="${SANDBOX_CANARY_STATE_FILE:-/var/run/ci-deploy-sandbox-canary.json}"
+  # DURABLE path (NOT /var/run tmpfs) — MUST match ci-deploy.sh
+  # SANDBOX_CANARY_STATE_FILE. The soak accumulator must survive host reboots or
+  # it silently resets to zero (#5889); see the writer's rationale.
+  local f="${SANDBOX_CANARY_STATE_FILE:-/mnt/data/ci-deploy-sandbox-canary.json}"
   if [[ -f "$f" ]]; then
     local v r s c cp fp
     v="$(jq -r '.verdict // "unknown"' "$f" 2>/dev/null || echo unknown)"

--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -180,9 +180,17 @@ CRON_DRAIN_PROBE_TIMEOUT="${CRON_DRAIN_PROBE_TIMEOUT:-10}"
 CRON_DEPLOY_LEASE_FILE="${CRON_DEPLOY_LEASE_FILE:-/mnt/data/workspaces/.deploy-lease}"
 CRON_DRAIN_STATE_FILE="${CRON_DRAIN_STATE_FILE:-/var/run/ci-deploy-cron-drain.json}"
 # Faithful sandbox canary verdict (#5875 / ADR-079). Written per deploy, surfaced
-# on /hooks/deploy-status by cat-deploy-state.sh (sandbox_canary_json). Separate
-# small state file — same pattern as CRON_DRAIN_STATE_FILE.
-SANDBOX_CANARY_STATE_FILE="${SANDBOX_CANARY_STATE_FILE:-/var/run/ci-deploy-sandbox-canary.json}"
+# on /hooks/deploy-status by cat-deploy-state.sh (sandbox_canary_json).
+# DURABLE on purpose (NOT /var/run tmpfs like CRON_DRAIN/SECCOMP below): this file
+# alone carries the CROSS-DEPLOY soak accumulator (consecutive_pass + first_pass_at,
+# see write_sandbox_canary_state). tmpfs is wiped on every reboot, which would
+# silently reset the "≥5 greens over ≥3 days" soak (#5889) to zero and lose the
+# span clock — the soak could then never complete on a host that reboots inside
+# the window. /mnt/data is the durable Hetzner volume (deploy-owned, cloud-init
+# `chown -R deploy:deploy /mnt/data`, in webhook.service ReadWritePaths), same
+# durability tier as CRON_DEPLOY_LEASE_FILE. Reader default MUST match
+# cat-deploy-state.sh sandbox_canary_json().
+SANDBOX_CANARY_STATE_FILE="${SANDBOX_CANARY_STATE_FILE:-/mnt/data/ci-deploy-sandbox-canary.json}"
 # Where the canary payload + fixture live INSIDE the image (Dockerfile COPY).
 SANDBOX_CANARY_MJS="${SANDBOX_CANARY_MJS:-/app/scripts/sandbox-canary.mjs}"
 # Loaded seccomp profile hash (#5875 item 4 / ADR-079). The host seccomp profile
@@ -191,7 +199,9 @@ SANDBOX_CANARY_MJS="${SANDBOX_CANARY_MJS:-/app/scripts/sandbox-canary.mjs}"
 # assert loaded==committed with NO SSH, ci-deploy.sh records the sha256 of the
 # profile file the prod container was JUST started with, surfaced on
 # /hooks/deploy-status by cat-deploy-state.sh (seccomp_profile_sha256). Separate
-# small state file — same pattern as SANDBOX_CANARY_STATE_FILE.
+# small state file — /var/run tmpfs is fine here (unlike SANDBOX_CANARY_STATE_FILE):
+# this is a per-deploy snapshot with no cross-reboot accumulator, so a reboot
+# wiping it before the next deploy re-records it is harmless.
 SECCOMP_PROFILE_HOST_PATH="${SECCOMP_PROFILE_HOST_PATH:-/etc/docker/seccomp-profiles/soleur-bwrap.json}"
 SECCOMP_PROFILE_STATE_FILE="${SECCOMP_PROFILE_STATE_FILE:-/var/run/ci-deploy-seccomp-profile.json}"
 

--- a/apps/web-platform/infra/sandbox-canary-soak.test.sh
+++ b/apps/web-platform/infra/sandbox-canary-soak.test.sh
@@ -64,6 +64,20 @@ write_sandbox_canary_state "pass" "ok" "0.3.198"
 assert "pass after reset ⇒ consecutive_pass=1" "[[ \$(field consecutive_pass) == 1 ]]"
 assert "pass after reset ⇒ first_pass_at re-pinned (>0)" "[[ \$(field first_pass_at) -gt 0 ]]"
 
+# 6. DURABILITY (#5889 regression guard): the soak accumulator survives reboots
+# ONLY if its DEFAULT path is on durable storage, not /var/run tmpfs (wiped every
+# reboot → consecutive_pass + first_pass_at silently reset → soak can never reach
+# "≥5 greens over ≥3 days"). Assert the writer (ci-deploy.sh) and the reader
+# (cat-deploy-state.sh) BOTH default to /mnt/data and NEITHER defaults to /var/run.
+CAT_TARGET="$SCRIPT_DIR/cat-deploy-state.sh"
+WRITER_DEFAULT="$(grep -oE 'SANDBOX_CANARY_STATE_FILE:-[^}]+' "$TARGET" | head -1 | sed 's/.*:-//')"
+READER_DEFAULT="$(grep -oE 'SANDBOX_CANARY_STATE_FILE:-[^}]+' "$CAT_TARGET" | head -1 | sed 's/.*:-//')"
+assert "writer default is durable (/mnt/data), not tmpfs" "[[ \"$WRITER_DEFAULT\" == /mnt/data/* ]]"
+assert "reader default is durable (/mnt/data), not tmpfs" "[[ \"$READER_DEFAULT\" == /mnt/data/* ]]"
+assert "writer default is NOT /var/run tmpfs" "[[ \"$WRITER_DEFAULT\" != /var/run/* ]]"
+assert "reader default is NOT /var/run tmpfs" "[[ \"$READER_DEFAULT\" != /var/run/* ]]"
+assert "writer + reader defaults MATCH" "[[ \"$WRITER_DEFAULT\" == \"$READER_DEFAULT\" ]]"
+
 echo ""
 echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
 if [[ "$FAIL" -gt 0 ]]; then exit 1; fi


### PR DESCRIPTION
The faithful sandbox-canary **soak accumulator** (`consecutive_pass` + `first_pass_at`) was written to `/var/run/ci-deploy-sandbox-canary.json`. `/var/run` is **tmpfs — wiped on every host reboot**, so any reboot inside the soak window silently reset the *"≥5 greens over ≥3 days"* soak (#5889) to zero and lost the span clock. On a host that reboots more often than that window, **the soak can never complete** — and it fails *open* (looks like "not enough greens yet," forever).

## How it surfaced
The new on-demand canary-status probe (#5953) read the empty `unknown` default from `/hooks/deploy-status` right after `web-1`'s placement reboot today — even though every current image ships the real captured `canonical-bwrap-v1` fixture and each release fires a deploy. The reboot had wiped the tmpfs soak file.

## Fix
Relocate the **default** state path in both the writer (`ci-deploy.sh`) and reader (`cat-deploy-state.sh`) to `/mnt/data/ci-deploy-sandbox-canary.json` — the durable Hetzner volume (deploy-owned via cloud-init `chown -R deploy:deploy /mnt/data`, and in `webhook.service` `ReadWritePaths`), the same durability tier as `CRON_DEPLOY_LEASE_FILE`.

- The per-deploy **seccomp** and **cron-drain** snapshots correctly **stay** on `/var/run` tmpfs — they carry no cross-reboot accumulator, so a reboot re-recording them is harmless. Comment updated to say why.
- **No migration**: the first post-fix deploy reseeds durably; the soak restarts once, then persists across reboots.

## Test
Adds a durability regression guard (§6) to `sandbox-canary-soak.test.sh` asserting both scripts default to `/mnt/data` and neither to `/var/run`, and that writer + reader defaults match. Suite: 16/16. Existing accumulator tests + `cat-deploy-state.test.sh` (52/52) unaffected (they override the path via env).

## Scope note
`/mnt/data` is host-local, so the verdict stays per-host. Cross-host soak aggregation under the multi-host topology (#5877) is a separate enhancement, not required for #5889's fleet-representative signal.

Refs #5889, #5875, #5953, ADR-079

🤖 Generated with [Claude Code](https://claude.com/claude-code)