### PR TITLE
test(ci-deploy): make MOCK_DOPPLER_MISSING robust to a system-wide doppler

### DIFF
--- a/apps/web-platform/infra/ci-deploy.test.sh
+++ b/apps/web-platform/infra/ci-deploy.test.sh
@@ -978,9 +978,33 @@ run_deploy_doppler() {
     fi
     create_base_mocks "$MOCK_DIR"
 
+    # Effective tool PATH: mocks first, then standard system dirs.
+    local effective_path="$MOCK_DIR:$TEST_PATH_BASE"
+
     # Override: doppler mock with MOCK_DOPPLER_MISSING/MOCK_DOPPLER_FAIL support
     if [[ "${MOCK_DOPPLER_MISSING:-}" == "1" ]]; then
       rm -f "$MOCK_DIR/doppler"
+      # ci-deploy.sh gates on `command -v doppler`. Removing the MOCK_DIR mock is
+      # NOT enough on hosts that ALSO ship a system-wide doppler in a TEST_PATH_BASE
+      # dir (e.g. /usr/bin/doppler on many dev boxes — NOT the CI runner): it leaks
+      # past the removed mock, the real binary runs against the fake token, and the
+      # "not installed" branch is never exercised (false FAIL, local-only). When we
+      # detect such a leak, mirror the base dirs into a farm WITHOUT doppler so the
+      # negative path is reachable everywhere. No-op on CI (no system doppler).
+      if PATH="$TEST_PATH_BASE" command -v doppler >/dev/null 2>&1; then
+        local _farm="$MOCK_DIR/nodoppler-bin"; mkdir -p "$_farm"
+        local _d _f _b _oldifs="$IFS"; IFS=:
+        for _d in $TEST_PATH_BASE; do
+          [[ -d "$_d" ]] || continue
+          for _f in "$_d"/*; do
+            _b="${_f##*/}"
+            [[ "$_b" == doppler ]] && continue
+            [[ -e "$_farm/$_b" ]] || ln -s "$_f" "$_farm/$_b" 2>/dev/null || true
+          done
+        done
+        IFS="$_oldifs"
+        effective_path="$MOCK_DIR:$_farm"
+      fi
     elif [[ "${MOCK_DOPPLER_FAIL:-}" == "1" ]]; then
       cat > "$MOCK_DIR/doppler" << 'MOCK'
 #!/bin/bash
@@ -997,9 +1021,9 @@ MOCK
       unset DOPPLER_TOKEN
     fi
 
-    # Restrict PATH to mock dir + standard system dirs (excludes ~/.local/bin
-    # where real doppler lives, so MOCK_DOPPLER_MISSING=1 actually works)
-    export PATH="$MOCK_DIR:$TEST_PATH_BASE"
+    # MOCK_DIR mocks win over system tools; for MOCK_DOPPLER_MISSING on a host with
+    # a system doppler, effective_path is a doppler-free farm (see above).
+    export PATH="$effective_path"
     bash "$DEPLOY_SCRIPT" 2>&1
   )
 }


### PR DESCRIPTION
The two "doppler not installed" negative tests in `ci-deploy.test.sh` fail **locally** on any machine with a system-wide doppler in `/usr/bin` (or `/bin`), while passing in CI — a green-in-CI/red-locally split that burns investigation time on every local run.

## Root cause
`run_deploy_doppler` with `MOCK_DOPPLER_MISSING=1` only `rm -f`'d the `MOCK_DIR` mock and relied on `TEST_PATH_BASE` (`/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`) excluding `~/.local/bin` "where real doppler lives." But doppler is commonly installed system-wide in `/usr/bin` (this dev box: a 12 MB `/usr/bin/doppler` from Apr 22). `/usr/bin` is in `TEST_PATH_BASE` and can't be dropped (coreutils), so `command -v doppler` still found the real binary → ci-deploy.sh ran it against the fake token → exited with "Invalid Auth token" instead of the `doppler_unavailable` / "not installed" path → the negative branch was never exercised → false FAIL (98/100).

## Fix
When `MOCK_DOPPLER_MISSING=1` **and** a real doppler is detected in `TEST_PATH_BASE`, mirror the base dirs into a doppler-free symlink farm and point `PATH` at it, so `command -v doppler` genuinely fails everywhere. **No-op on CI** (no system doppler → original fast path, byte-identical behavior). The farm lives under `MOCK_DIR` so the existing `trap … EXIT` cleans it up.

## Verification
`bash apps/web-platform/infra/ci-deploy.test.sh` → **100/100** on a box with `/usr/bin/doppler` (was 98/100). Both previously-failing tests (`missing doppler CLI exits with error`, `missing doppler binary writes reason=doppler_unavailable`) now pass; all other 98 unchanged. CI (no system doppler) exercises the unchanged path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)