### PR TITLE
fix(canary): unblank soak sdk_version — read the key the mjs emits (sdkVersion)

### DIFF
--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -464,7 +464,12 @@ run_faithful_sandbox_canary() {
   else
     verdict="$(printf '%s' "$out" | jq -r '.verdict // "canary_infra_error"' 2>/dev/null || echo canary_infra_error)"
     reason="$(printf '%s' "$out" | jq -r '.reason // "unparseable"' 2>/dev/null || echo unparseable)"
-    sdk_version="$(printf '%s' "$out" | jq -r '.sdk_version // ""' 2>/dev/null || echo '')"
+    # sandbox-canary.mjs emits the SDK version as the camelCase key `sdkVersion`
+    # (JS-idiomatic); this deploy-state chain is snake_case, so translate at the
+    # boundary here. Accept snake_case too so a future mjs rename can't silently
+    # re-blank it. Missing key ⇒ "" (the soak surface's sdk_version was empty
+    # before this — the key never matched).
+    sdk_version="$(printf '%s' "$out" | jq -r '.sdkVersion // .sdk_version // ""' 2>/dev/null || echo '')"
   fi
   if [[ "$err_file" != "/dev/null" ]]; then rm -f "$err_file" 2>/dev/null || true; fi
   write_sandbox_canary_state "$verdict" "$reason" "$sdk_version"

--- a/apps/web-platform/scripts/sandbox-canary-regression.test.sh
+++ b/apps/web-platform/scripts/sandbox-canary-regression.test.sh
@@ -198,6 +198,49 @@ else
   fi
 fi
 
+# ---------------------------------------------------------------------------
+# C. CROSS-FILE CONTRACT — the mjs `--replay` stdout ⇄ ci-deploy.sh reader.
+# Deterministic, always runs. Guards the JS/shell key-name seam that silently
+# blanked the soak's sdk_version: sandbox-canary.mjs emits camelCase `sdkVersion`,
+# but ci-deploy.sh read snake_case `.sdk_version`, so the value never propagated
+# to /hooks/deploy-status (#5889). A rename on either side re-breaks it.
+# ---------------------------------------------------------------------------
+echo "C: mjs↔ci-deploy sdk_version key contract"
+MJS="$SCRIPT_DIR/sandbox-canary.mjs"
+CI_DEPLOY="$INFRA_DIR/ci-deploy.sh"
+REPLAY_FIXTURE="$INFRA_DIR/sandbox-canary-argv.json"
+for f in "$MJS" "$CI_DEPLOY" "$REPLAY_FIXTURE"; do
+  [[ -f "$f" ]] || { echo "ERROR: missing $f" >&2; exit 1; }
+done
+
+# C1 — the replay path emits the version under the camelCase key `sdkVersion`.
+if grep -qE 'emitVerdict\(\{ \.\.\.verdict, sdkVersion:' "$MJS"; then
+  pass "C1 mjs runReplay emits key sdkVersion"
+else
+  fail "C1 mjs runReplay no longer emits 'sdkVersion' in its verdict — update the ci-deploy.sh reader key in lockstep"
+fi
+
+# C2 — ci-deploy.sh's sdk_version read accepts exactly that emitted key.
+if grep -qE "jq -r '\.sdkVersion // \.sdk_version" "$CI_DEPLOY"; then
+  pass "C2 ci-deploy.sh reads .sdkVersion (matches the mjs key)"
+else
+  fail "C2 ci-deploy.sh sdk_version read does not accept the mjs 'sdkVersion' key — the soak surface will blank sdk_version"
+fi
+
+# C3 — the committed captured fixture carries a non-empty sdkVersion, so a real
+# pass actually populates the field (an empty fixture version = silent blank).
+FIX_VER="$(jq -r '.sdkVersion // ""' "$REPLAY_FIXTURE" 2>/dev/null || echo '')"
+if [[ -n "$FIX_VER" && "$FIX_VER" != "null" ]]; then
+  pass "C3 committed fixture carries sdkVersion ($FIX_VER)"
+else
+  # Only required once the fixture is captured; an uncaptured sentinel is exempt.
+  if [[ "$(jq -r '.status // ""' "$REPLAY_FIXTURE" 2>/dev/null)" == "captured" ]]; then
+    fail "C3 captured fixture has empty sdkVersion — a real pass would report an empty version"
+  else
+    skip "C3 fixture is uncaptured — sdkVersion not required yet"
+  fi
+fi
+
 echo ""
 echo "=== Results: $PASS/$((PASS + FAIL)) passed, $FAIL failed ==="
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
The soak surface reported `sdk_version: ""` even on a green `pass` verdict (observed 2026-07-03 via the #5953 probe: `{"verdict":"pass",...,"sdk_version":""}`). Root cause: a JS↔shell key-name mismatch.

## Cause
`sandbox-canary.mjs --replay` emits the version under the camelCase key **`sdkVersion`** (JS-idiomatic; it's also the key the committed fixture carries: `sdkVersion: "0.3.197"`). But `ci-deploy.sh`'s `run_faithful_sandbox_canary` read snake_case **`.sdk_version`** — so `jq` returned null → `""`, and the empty value flowed through `write_sandbox_canary_state` → `cat-deploy-state.sh` → `/hooks/deploy-status`. The verdict/soak counters were unaffected (this was purely cosmetic telemetry), which is why the soak still accrued greens.

## Fix
Translate at the boundary: `ci-deploy.sh` now reads `.sdkVersion // .sdk_version // ""` — it accepts the emitted camelCase key, tolerates a future snake_case rename, and stores the snake_case `sdk_version` the rest of the deploy-state chain already speaks. The mjs output contract is **unchanged** (its unit tests and the `--verify`/`--capture` consumers keep camelCase).

## Regression guard
Adds an always-on cross-file contract layer (C) to `sandbox-canary-regression.test.sh` (runs in the `test` gate):
- **C1** the mjs replay path emits `sdkVersion`
- **C2** `ci-deploy.sh` reads that exact key
- **C3** the captured fixture carries a non-empty version

A rename on either side of the JS/shell seam now fails the gate instead of silently re-blanking the telemetry. Suite: 11/11 (was 8/8). Soak accumulator tests: 16/16 unaffected. (The mjs itself is untouched, so its vitest suite is unchanged; it runs in the `test` gate.)

Refs #5889, #5875, ADR-079

🤖 Generated with [Claude Code](https://claude.com/claude-code)