### PR TITLE
fix(ci): grant id-token: write to Version Bump and Release workflow caller

### DIFF
--- a/.github/workflows/version-bump-and-release.yml
+++ b/.github/workflows/version-bump-and-release.yml
@@ -22,6 +22,16 @@ permissions:
 jobs:
   release:
     uses: ./.github/workflows/reusable-release.yml
+    permissions:
+      # A reusable workflow can only USE permissions its CALLER grants. cosign
+      # keyless signing in reusable-release.yml needs id-token: write (#5933
+      # Item 4, added by #5977). A job-level block REPLACES the inherited
+      # workflow perms, so contents/packages are re-declared here. Absent
+      # id-token, the reusable workflow fails at dispatch with startup_failure
+      # (this fixes #6018; the sibling fix for web-platform-release.yml was #5981).
+      contents: write
+      packages: write
+      id-token: write
     with:
       component: plugin
       component_display: "Soleur"

--- a/knowledge-base/project/learnings/best-practices/2026-07-04-bash-yaml-drift-guard-must-mutation-test-fail-open-and-allow-trailing-comments.md
+++ b/knowledge-base/project/learnings/best-practices/2026-07-04-bash-yaml-drift-guard-must-mutation-test-fail-open-and-allow-trailing-comments.md
@@ -102,3 +102,19 @@ extended to YAML-structural drift guards.
 4. **shellcheck SC2034** on a doc-only variable after inlining its regex.
    **Recovery:** removed the dead variable, kept the rationale as a comment.
    **Prevention:** one-off.
+5. **Green locally, RED in CI: an `awk` that prints an ENTIRE large job block
+   passed on the dev machine's mawk (1.3.4) but failed the premise check on
+   CI's older mawk** — `named_job_block` extracted `reusable-release.yml`'s
+   ~700-line `release` job (with a 418-char inline line at :406) and the older
+   mawk did not surface the early `id-token: write` line, so the premise
+   grep returned no match (3/4, premise FAIL). The two caller checks passed
+   because caller release jobs are small. **Recovery:** replaced the premise's
+   whole-block extraction with a `permissions:`-sub-block extractor that
+   early-`exit`s at the next 4-space key (reads ~7 lines, never touches the
+   700-line body); also swapped the GNU-only `\b` in the id-token grep for a
+   POSIX `([[:space:]]|$|#)` boundary class. **Prevention (recurring):** a bash
+   test that `awk`-extracts and prints a LARGE block is a CI-portability risk —
+   scope the extraction to the smallest sub-region that answers the question and
+   `exit` early; never rely on the dev machine's awk build matching CI's. The
+   `test-all.sh scripts` shard green locally is necessary but NOT sufficient for
+   an awk-heavy `.test.sh` — the authoritative gate is CI's `test-scripts` job.

--- a/knowledge-base/project/learnings/best-practices/2026-07-04-bash-yaml-drift-guard-must-mutation-test-fail-open-and-allow-trailing-comments.md
+++ b/knowledge-base/project/learnings/best-practices/2026-07-04-bash-yaml-drift-guard-must-mutation-test-fail-open-and-allow-trailing-comments.md
@@ -1,0 +1,104 @@
+---
+title: "Bash YAML drift-guards must mutation-test the fail-OPEN direction and treat structural anchors as comment-tolerant"
+date: 2026-07-04
+category: best-practices
+module: ci-workflows
+tags: [drift-guard, bash, awk, github-actions, fail-open, test-authoring, mutation-test]
+issue: 6018
+pr: 6019
+---
+
+# Bash YAML drift-guards must mutation-test the fail-OPEN direction and treat structural anchors as comment-tolerant
+
+## Problem
+
+While fixing #6018 (the *Version Bump and Release* workflow concluding
+`startup_failure` because the plugin caller of `reusable-release.yml` never
+granted the `id-token: write` its reusable `release` job requires), I added a
+drift-guard test — `plugins/soleur/test/reusable-release-caller-permissions.test.sh`
+— asserting **every** caller of the reusable workflow grants `id-token: write`
+to its calling job.
+
+The first version passed 4/4 on the real tree AND satisfied the author-run
+negative test (remove `id-token` → FAIL). It looked done. Multi-agent review
+(`pattern-recognition-specialist` + `test-design-reviewer`, independently
+concurring) found it could pass GREEN while the invariant was violated:
+
+1. **Trailing-comment job header → fail-open.** The awk job-boundary regex
+   `^  [A-Za-z0-9_-]+:[[:space:]]*$` requires the line to end right after the
+   colon. `  release: # the release job` is legal YAML but is NOT recognised as
+   a new job, so its lines append to the *previous* job's buffer. A prior job's
+   `id-token: write` then satisfies the caller's check — green while the actual
+   calling job grants nothing (the exact #6018 defect the guard exists to catch).
+2. **Grep scoped to the whole job, not the `permissions:` sub-block → fail-open.**
+   An `id-token: write`-shaped line under `with:`/`env:` would satisfy the check
+   even though no permission was granted.
+3. Minor: an unanchored workflow-level fallback grep matched a commented-out
+   `# id-token: write`; only the first calling job per file was checked; the
+   remote (`owner/repo/...@ref`) `uses:` form was not enumerated.
+
+## Solution
+
+Harden the extractors (single-file, all fail-open closed):
+
+- Match job headers with an **optional trailing comment**:
+  `^  [A-Za-z0-9_-]+:[[:space:]]*(#.*)?$` — the `(#.*)?` tail is load-bearing.
+- Scope the id-token check to the job's `permissions:` **sub-block** (indent
+  deeper than the 4-space key, up to the next 4-space key), not the whole job.
+- Classify inline `permissions:` forms (`write-all`, flow-mapping
+  `{id-token: write}`) so a job broadened to inline perms is not mis-read.
+- Check **every** calling job per file; enumerate both `./…` and `…@ref` forms;
+  `^`-anchor every `id-token` grep so a comment never satisfies a check.
+
+Then **mutation-test the fail-OPEN direction explicitly** — not just "remove the
+grant → FAIL", but "inject the exact shapes that would let a broken caller pass":
+a trailing-comment header with the grant only in a prior job; the grant moved
+under `with:`; inline `write-all` (must still PASS, fail-safe). Run each against
+a scratch mirror of `.github/workflows/`.
+
+## Key Insight
+
+A static drift-guard's own **GREEN is only trustworthy if you've proven it goes
+RED on the fail-OPEN inputs**, not merely on the obvious "delete the thing" input.
+A guard that greps structured config (YAML/TOML/HCL) has two silent-pass vectors
+its author rarely tests:
+
+1. **Structural anchors must be comment-tolerant.** Any regex that recognises a
+   boundary (`^job:`, `^  key:`, a block delimiter) will silently mis-parse when
+   a human adds a legal trailing `# comment` — and mis-parse usually means
+   *merge two units and bleed one's property into the other* = fail-open.
+2. **Assertions must be scoped to the sub-structure they claim to check**, not a
+   whole-block grep — the target literal can appear in an adjacent, irrelevant
+   key.
+
+The cheap gate is a mutation harness that copies the config tree, injects each
+fail-open shape, and asserts the guard reports RED. The author-run "remove the
+line → FAIL" negative test is necessary but **not** sufficient; it only exercises
+the denied-and-detected path, never the present-but-mis-parsed path.
+
+Same family as [[2026-06-12-source-scan-containment-gate-call-detection-and-fail-closed-lexing]]
+(regex-not-lexer, proxy-not-behavior fail-open classes) and
+[[2026-06-29-bash-accumulate-then-exit-gate-test-three-footguns]] (verify-the-verifier),
+extended to YAML-structural drift guards.
+
+## Session Errors
+
+1. **iac-routing-ack hook rejected the plan's first write** because the prose
+   contained the literal token `doppler secrets set` while asserting it was NOT
+   used. **Recovery:** rephrased to "Doppler secret writes" + added the
+   `iac-routing-ack` ack comment. **Prevention:** one-off — when negating a
+   gated literal in prose, paraphrase the token rather than quoting it.
+2. **Plan AC1's `grep -A6 '^  release:' | grep -c 'id-token: write'` returns 0**
+   because the 6-line rationale comment pushes `id-token` past the window.
+   **Recovery:** re-derived with `-A9`; the drift-guard test is the authoritative
+   invariant. **Prevention:** already covered — plan-quoted AC verify commands
+   are preconditions to re-derive, not facts; a comment block ahead of the
+   asserted line invalidates a hardcoded `-AN` window.
+3. **Drift-guard test shipped fail-open in its first version** (trailing-comment
+   header + whole-job grep). **Recovery:** hardened the extractors + added a
+   3-shape mutation harness. **Prevention:** this learning — mutation-test the
+   fail-OPEN direction for any static config drift-guard, and make structural
+   anchors comment-tolerant.
+4. **shellcheck SC2034** on a doc-only variable after inlining its regex.
+   **Recovery:** removed the dead variable, kept the rationale as a comment.
+   **Prevention:** one-off.

--- a/knowledge-base/project/plans/2026-07-04-fix-version-bump-release-startup-failure-plan.md
+++ b/knowledge-base/project/plans/2026-07-04-fix-version-bump-release-startup-failure-plan.md
@@ -1,0 +1,295 @@
+---
+title: "fix(ci): Version Bump and Release startup_failure — plugin caller missing id-token: write"
+date: 2026-07-04
+type: fix
+issue: 6018
+branch: feat-one-shot-6018-version-bump-release-startup-failure
+lane: procedural
+brand_survival_threshold: none
+detail_level: minimal
+---
+
+# 🐛 fix(ci): Version Bump and Release workflow `startup_failure` on every merge
+
+Closes #6018.
+
+## Enhancement Summary
+
+**Deepened on:** 2026-07-04
+
+**Deepen-plan halt gates (all PASS):**
+- 4.6 User-Brand Impact — section present, threshold `none` + sensitive-path scope-out reason present (`.github/workflows/*version-bump*|*release*.yml` matches the sensitive-path regex, so the reason bullet is mandatory and is supplied).
+- 4.7 Observability — 5-field schema present; `discoverability_test.command` is `gh run list` (no SSH).
+- 4.8 PAT-shaped variable — none.
+- 4.9 UI-wireframe — no UI surface in Files to Edit/Create (only `.yml` + `.test.sh`); skip.
+- 4.4 Precedent-diff — pattern-bound (job-level `permissions:`); precedent = #5981, side-by-side below (not novel).
+
+**Key findings (root-cause replaces the issue's hypothesis):**
+1. The regression is **not** a parse error / moved ref / org-secret change (issue's guesses).
+   It is the caller (`version-bump-and-release.yml`) failing to grant `id-token: write`, a
+   permission the reusable `release` job began requiring in #5977 for cosign signing.
+2. #5981 already fixed the **sibling** caller (`web-platform-release.yml`) but missed this one.
+   The fix is a verbatim application of that precedent — low-risk, established pattern.
+3. **Self-verifying merge:** the new drift-guard test lands under `plugins/soleur/test/**`,
+   which matches the caller's `plugins/soleur/**` path filter — so merging this PR itself
+   re-triggers the workflow and confirms the fix (no forced `workflow_dispatch`, no operator step).
+4. Live-verified citations: `gh pr view 5977` → `60f203c50`; `gh pr view 5981` → `08555a944`.
+
+## Overview
+
+The **Version Bump and Release** workflow (`.github/workflows/version-bump-and-release.yml`,
+the plugin release tagger) has concluded `startup_failure` (empty `jobs`, run never
+starts) on every merge to `main` since **2026-07-04T12:20 UTC**. It succeeded through
+2026-07-03T20:09 UTC.
+
+**Root cause (verified, not the issue's hypothesis).** PR #5977 (commit `60f203c50`,
+merged 2026-07-04 **11:25 UTC**) added cosign keyless image signing to the shared
+`reusable-release.yml`. That change added `id-token: write` to the reusable workflow's
+single `release` job permissions block (`reusable-release.yml:66`) so cosign can mint an
+OIDC token for Fulcio. **A reusable workflow can only *use* a `GITHUB_TOKEN` permission
+that its caller grants** — if the called job declares a permission the caller omits, the
+run fails at dispatch with `startup_failure` and zero jobs (GitHub validates the
+permission ceiling before evaluating any step `if:`, so this fires even though the plugin
+release passes no `docker_image` and never actually runs the cosign steps).
+
+PR #5981 (commit `08555a944`, merged 2026-07-04 **11:38 UTC**) recognised this and added
+a **job-level** `permissions` block granting `id-token: write` to the **web-platform**
+caller (`web-platform-release.yml`) — but **missed the plugin caller**
+(`version-bump-and-release.yml`), whose only permissions are the workflow-level
+`contents: write` + `packages: write`. The first plugin-path merge after #5977 landed
+(the 12:20 UTC run) hit the ungranted permission and has failed identically ever since.
+
+**Fix.** Add a job-level `permissions` block to the `release` job in
+`version-bump-and-release.yml` granting `contents: write`, `packages: write`, and
+`id-token: write`, mirroring the exact remediation #5981 applied to the sibling caller.
+Add a drift-guard shell test asserting **every** `uses: ./.github/workflows/reusable-release.yml`
+caller grants `id-token: write`, so the next caller (or a future permission the reusable
+job adds) cannot silently re-introduce the same `startup_failure` class.
+
+This is the identical defect class as learning
+`knowledge-base/project/learnings/2026-05-04-schedule-once-template-missing-id-token.md`
+("OIDC permission belongs to the action/reusable-job, not the caller task") — which also
+prescribes pairing the fix with a regression assertion.
+
+**Impact / severity.** Release tags are not created on merge, so the plugin version does
+not advance and the release Slack notification does not fire. The issue explicitly records
+**no production/customer impact** — this is the plugin release tagger, not the
+web-platform deploy. Brand-survival threshold: **none**.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** the plugin release tag / version bump
+continues to not advance on merge, and the release Slack post stays silent — an
+operator-facing release-automation gap, not a customer-facing surface.
+
+**If this leaks, the user's data / workflow / money is exposed via:** N/A — the change
+grants an OIDC token-mint scope to a release job that already runs in the trusted
+`main`-push context; no data path, no secret, no external exposure is added. `id-token: write`
+only enables the cosign OIDC handshake, which for the plugin caller does not even execute
+(no `docker_image` input).
+
+**Brand-survival threshold:** none — CI release-tagging reliability; the issue records no
+production/customer impact. `threshold: none, reason: plugin release-tagger CI permission fix; issue #6018 explicitly records no production/customer impact and the change adds no data/secret path.`
+
+## Research Reconciliation — Issue Hypothesis vs. Codebase Reality
+
+| Issue claim | Reality (verified) | Plan response |
+| --- | --- | --- |
+| "reusable workflow has a **parse error**, or a pinned action/ref **moved**, or an **org-level permissions/secret** change landed ~12:20 UTC" | None of these. `reusable-release.yml` YAML is valid; the regression is a **new `id-token: write` job permission** added by #5977 (`60f203c50`, 11:25 UTC) that the caller does not grant. | Fix targets the **caller's** permission grant, not the reusable workflow. |
+| Caller "delegates to `reusable-release.yml` (#823)" and caller file "unchanged (last edit #942)" | Correct — caller unchanged is *why* it broke: the reusable job's permission ceiling rose under it. | Confirms the fix belongs in the caller. |
+| Failure began 2026-07-04T12:20 UTC | Consistent: #5977 (11:25) + #5981 (11:38) landed just before; 12:20 was the first plugin-path merge after. #5981 fixed the web-platform caller only. | — |
+| (implicit) fix is web-platform-side | The web-platform caller is **already fixed** (#5981). Only the plugin caller remains. | Single-caller edit + drift-guard for all callers. |
+
+## Affected callers of `reusable-release.yml` (enumerated via grep)
+
+- `.github/workflows/web-platform-release.yml` — **already fixed** by #5981 (job-level `id-token: write`).
+- `.github/workflows/version-bump-and-release.yml` — **BROKEN, this plan's target.**
+- `.github/workflows/apply-deploy-pipeline-fix.yml` — **not a caller.** The string
+  `reusable-release.yml` appears only in a code comment (line 586); there is no
+  `uses: ./.github/workflows/reusable-release.yml`. Not affected.
+
+## Files to Edit
+
+- `.github/workflows/version-bump-and-release.yml` — add a job-level `permissions:` block
+  to the `release:` job (the only job) mirroring `web-platform-release.yml` (#5981):
+
+  ```yaml
+  jobs:
+    release:
+      uses: ./.github/workflows/reusable-release.yml
+      # A reusable workflow can only USE permissions its CALLER grants. cosign
+      # keyless signing in reusable-release.yml needs id-token: write (#5977/#5933
+      # Item 4). A job-level block REPLACES the inherited workflow perms, so
+      # contents/packages are re-declared here. Absent id-token the reusable
+      # workflow fails at dispatch with startup_failure (this fixes #6018; sibling
+      # fix for web-platform-release.yml was #5981).
+      permissions:
+        contents: write
+        packages: write
+        id-token: write
+      with:
+        component: plugin
+        component_display: "Soleur"
+        # ... (existing inputs unchanged)
+      secrets: inherit
+  ```
+
+  (Job-level chosen to mirror #5981 verbatim and stay least-privilege-safe if a second
+  job is ever added; since `release` is currently the only job, a workflow-level
+  `id-token: write` would be functionally equivalent. `permissions:` is a sibling key of
+  `uses:`/`with:`/`secrets:` under `release:` — YAML key order is immaterial; keep the
+  existing `with:` inputs verbatim.)
+
+### Precedent Diff (deepen-plan Phase 4.4)
+
+The fix is a verbatim application of the **already-merged sibling** remediation #5981. Side
+by side — the target must reach the same shape the web-platform caller already has:
+
+| | `web-platform-release.yml` (post-#5981, live) | `version-bump-and-release.yml` (this plan) |
+| --- | --- | --- |
+| `release` job `permissions:` | `contents/packages/id-token: write` (job-level, lines 42–52) | **add** `contents/packages/id-token: write` (job-level) |
+| workflow-level `permissions:` | `contents/packages: write` (superseded for `release` by job block) | `contents/packages: write` (same; superseded once job block added) |
+
+No novel pattern — this is precedent-conformant. Citations verified live this pass:
+`gh pr view 5977` → mergeCommit `60f203c50` ("image signing … cosign"), `gh pr view 5981`
+→ mergeCommit `08555a944` ("grant id-token: write to web-platform-release caller"). The
+sibling's own comment block already names `startup_failure` and #5977 as the regression it
+fixes — this plan closes the caller it missed.
+
+## Files to Create
+
+- `plugins/soleur/test/reusable-release-caller-permissions.test.sh` — drift-guard.
+  Auto-discovered by the `scripts/test-all.sh` glob at `:188`
+  (`for f in plugins/soleur/test/*.test.sh ...`) — no manual runner registration needed.
+  Precedent: `plugins/soleur/test/reusable-release-idempotency.test.sh` (same file header
+  convention, static-assertion-over-workflow-YAML pattern). The test MUST:
+  1. Assert the reusable workflow (`reusable-release.yml`) declares `id-token: write` on
+     its `release` job (guards against the guard going stale if signing is later removed —
+     if the requirement disappears, the test's premise should be revisited, not silently pass).
+  2. Enumerate every `uses: ./.github/workflows/reusable-release.yml` caller under
+     `.github/workflows/` (grep, not a hardcoded list).
+  3. For each caller, assert `id-token: write` is granted at **workflow level OR at the
+     calling job's job level** (either satisfies the ceiling). FAIL naming the caller if absent.
+  4. Include a positive sanity check that the enumeration found ≥ 2 callers (so a future
+     grep-scope regression that finds zero callers fails loudly rather than passing vacuously).
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] `.github/workflows/version-bump-and-release.yml`'s `release` job declares
+      `id-token: write` (plus `contents: write`, `packages: write`).
+      Verify: `grep -A6 '^  release:' .github/workflows/version-bump-and-release.yml | grep -c 'id-token: write'` returns `1`.
+- [ ] `actionlint .github/workflows/version-bump-and-release.yml` exits 0 (YAML + job
+      shape valid). Note: actionlint does **not** validate the cross-workflow permission
+      ceiling (a GitHub-runtime check) — the drift-guard test covers that invariant.
+- [ ] New drift-guard test exists and passes:
+      `bash plugins/soleur/test/reusable-release-caller-permissions.test.sh` exits 0.
+- [ ] Drift-guard proves it catches the bug: temporarily removing the `id-token: write`
+      line from the plugin caller makes the test FAIL naming `version-bump-and-release.yml`
+      (author-run sanity; revert before commit).
+- [ ] `bash scripts/test-all.sh scripts` (or the local shard runner) discovers and runs
+      the new test green.
+- [ ] PR body uses `Closes #6018`.
+
+### Post-merge (verification — self-triggering)
+
+- [ ] This PR creates `plugins/soleur/test/reusable-release-caller-permissions.test.sh`,
+      which matches the caller workflow's path filter `plugins/soleur/**`. **Merging this
+      PR therefore itself triggers the Version Bump and Release workflow** — the natural,
+      no-forced-dispatch verification. Confirm the triggered run **does NOT conclude
+      `startup_failure`** and starts with a populated `jobs` object:
+      `gh run list --workflow "Version Bump and Release" --branch main --limit 1 --json conclusion,status,databaseId`
+      then `gh run view <id>` shows the `release` job present.
+      Automation: `gh` CLI (via Bash) — no operator action.
+- [ ] The run advances the plugin version / creates the release tag it had been failing to
+      create (release backlog since 2026-07-04 clears). If the run reaches the reusable
+      workflow but fails a *later* step (unrelated to permissions), that is out of scope
+      for #6018 (the `startup_failure` is fixed) — file a follow-up.
+
+## Observability
+
+The failure mode this plan fixes was itself an observability gap: `startup_failure`
+produces an empty `jobs` object and no step logs, so the release simply "didn't happen"
+silently. The remediation's durable detection is the **drift-guard test** (a CI gate that
+fails loudly at PR time if any caller of `reusable-release.yml` omits a permission the
+reusable job requires), not a runtime probe.
+
+- `liveness_signal`: the Version Bump and Release workflow run on each `plugins/soleur/**`
+  merge — visible via `gh run list --workflow "Version Bump and Release" --branch main`;
+  a `startup_failure` conclusion is the regression signal. Configured in
+  `.github/workflows/version-bump-and-release.yml`.
+- `error_reporting`: GitHub Actions run conclusion (`startup_failure` / `failure`) surfaced
+  in the Actions UI and `gh run list`; the reusable workflow already posts a release Slack
+  notification on success (`reusable-release.yml`, #5078/#5204), whose *absence* is the
+  operator-visible signal.
+- `failure_modes`:
+  - {mode: caller omits a permission the reusable job requires, detection:
+    `plugins/soleur/test/reusable-release-caller-permissions.test.sh` (CI, pre-merge),
+    alert_route: PR check failure blocks merge}
+  - {mode: reusable-release run concludes `startup_failure` at dispatch, detection:
+    `gh run list --workflow "Version Bump and Release" --branch main` conclusion field,
+    alert_route: absent release Slack post + red Actions run}
+- `logs`: GitHub Actions run logs (retained per repo Actions retention). `startup_failure`
+  runs have no step logs by definition — hence the pre-merge test is the primary guard.
+- `discoverability_test`:
+  - command (NO ssh): `gh run list --workflow "Version Bump and Release" --branch main --limit 1 --json conclusion`
+  - expected_output: `conclusion` is `success` (or at minimum not `startup_failure`) on the
+    post-merge trigger.
+
+## Infrastructure (IaC)
+
+<!-- iac-routing-ack: plan-phase-2-8-reviewed -->
+
+Not applicable. This change grants a `GITHUB_TOKEN` OIDC scope (`id-token: write`) to an
+existing workflow job — it provisions no server, secret, vendor account, DNS record, or
+persistent runtime process. No SSH, no Doppler secret writes, no Terraform. Phase 2.8 skip.
+
+## Architecture Decision (ADR / C4)
+
+No architectural decision. This restores parity with the **already-established** pattern
+from #5981 ("callers of `reusable-release.yml` must grant `id-token: write`") — it neither
+creates nor reverses an ADR. C4 completeness check: no external human actor, external
+system/vendor, container/data-store, or actor↔surface access relationship changes (the
+cosign OIDC edge — GitHub Actions → Fulcio/Rekor — was introduced by #5977 for the
+web-platform image, and does not execute for the plugin caller which passes no
+`docker_image`). "No C4 impact": the `model.c4`/`views.c4`/`spec.c4` scope is the running
+system's actors/containers; a CI permission grant on the plugin release tagger adds no
+modeled element. Phase 2.10 skip.
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications detected — CI/infrastructure-tooling change (a GitHub Actions
+permission grant + a drift-guard test). No UI surface (no `components/**`, `app/**/page.tsx`,
+or `app/**/layout.tsx` in Files to Create/Edit). No Product/UX Gate.
+
+## Test Scenarios
+
+1. **Regression (the bug):** With `id-token: write` absent from the plugin caller, a
+   `plugins/soleur/**` merge → `startup_failure`. After the fix → run starts with the
+   `release` job populated. (Verified post-merge via the self-triggering path.)
+2. **Drift-guard positive:** `reusable-release-caller-permissions.test.sh` passes with both
+   real callers granting `id-token: write`.
+3. **Drift-guard negative:** removing the grant from either caller makes the test FAIL
+   naming that caller.
+4. **Vacuous-pass guard:** if the caller-enumeration grep returns zero callers (e.g., a
+   future path/filename change), the ≥2-caller sanity assertion FAILs rather than passing.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`, or omits
+  the threshold will fail `deepen-plan` Phase 4.6. This plan's section is filled (threshold: none).
+- `actionlint` validates YAML/job shape only — it does **not** enforce the caller→reusable
+  permission ceiling. Do not treat a green `actionlint` as proof the `startup_failure` is
+  fixed; the drift-guard test + the post-merge self-triggering run are the real proofs.
+- The reusable job declares `id-token: write` **unconditionally at the job level**, while the
+  cosign steps that use it are `if:`-gated on `docker_image != ''`. The plugin caller passes
+  no `docker_image`, so it never signs anything — but it STILL must grant the permission,
+  because GitHub validates the permission ceiling at dispatch, before any `if:` runs. Do not
+  "optimise" by trying to make the grant conditional; it cannot be.
+- Job-level `permissions:` **replaces** (does not merge with) the inherited workflow-level
+  block for that job — so `contents: write` and `packages: write` must be re-declared
+  alongside `id-token: write`, or the release job loses tag-push/GHCR access. (This is the
+  exact note from #5981.)

--- a/knowledge-base/project/plans/2026-07-04-fix-version-bump-release-startup-failure-plan.md
+++ b/knowledge-base/project/plans/2026-07-04-fix-version-bump-release-startup-failure-plan.md
@@ -177,20 +177,26 @@ fixes — this plan closes the caller it missed.
 
 ### Pre-merge (PR)
 
-- [ ] `.github/workflows/version-bump-and-release.yml`'s `release` job declares
+- [x] `.github/workflows/version-bump-and-release.yml`'s `release` job declares
       `id-token: write` (plus `contents: write`, `packages: write`).
-      Verify: `grep -A6 '^  release:' .github/workflows/version-bump-and-release.yml | grep -c 'id-token: write'` returns `1`.
-- [ ] `actionlint .github/workflows/version-bump-and-release.yml` exits 0 (YAML + job
+      Verify: `grep -A9 '^  release:' .github/workflows/version-bump-and-release.yml | grep -c 'id-token: write'` returns `1`.
+      (Note: the plan's original `-A6` window underestimated the 6-line rationale comment
+      that precedes the perms — the sibling #5981 block carries the same comment length;
+      `-A9` reaches it. The authoritative invariant is the drift-guard test below, not the
+      window size.)
+- [x] `actionlint .github/workflows/version-bump-and-release.yml` exits 0 (YAML + job
       shape valid). Note: actionlint does **not** validate the cross-workflow permission
       ceiling (a GitHub-runtime check) — the drift-guard test covers that invariant.
-- [ ] New drift-guard test exists and passes:
+- [x] New drift-guard test exists and passes:
       `bash plugins/soleur/test/reusable-release-caller-permissions.test.sh` exits 0.
-- [ ] Drift-guard proves it catches the bug: temporarily removing the `id-token: write`
+- [x] Drift-guard proves it catches the bug: temporarily removing the `id-token: write`
       line from the plugin caller makes the test FAIL naming `version-bump-and-release.yml`
-      (author-run sanity; revert before commit).
-- [ ] `bash scripts/test-all.sh scripts` (or the local shard runner) discovers and runs
-      the new test green.
-- [ ] PR body uses `Closes #6018`.
+      (author-run sanity; reverted before commit). Confirmed: the guard fails even with the
+      job-level `permissions:` block still present (precise REPLACE semantics), proving
+      non-vacuity.
+- [x] `bash scripts/test-all.sh scripts` discovers and runs the new test green
+      (138/138 suites passed; new test `[ok] ... (27ms)`).
+- [ ] PR body uses `Closes #6018`. (Set at ship.)
 
 ### Post-merge (verification — self-triggering)
 

--- a/knowledge-base/project/specs/feat-one-shot-6018-version-bump-release-startup-failure/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-6018-version-bump-release-startup-failure/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-04-fix-version-bump-release-startup-failure-plan.md
+- Status: complete
+
+### Errors
+None. (One transient hook block on first write — prose contained literal `doppler secrets set` token while stating it was NOT used; rephrased and added `iac-routing-ack` comment; re-write succeeded.)
+
+### Decisions
+- Root cause: PR #5977 (60f203c50, 2026-07-04 11:25 UTC) added `id-token: write` to the reusable `release` job for cosign signing; a reusable workflow can only use permissions its caller grants, so the plugin caller (`version-bump-and-release.yml`, only `contents`+`packages`) fails at dispatch with `startup_failure`. This replaces the issue's parse-error/moved-ref/org-secret hypothesis.
+- Sibling-precedent fix: PR #5981 (08555a944) already applied the same fix (job-level `id-token: write`) to `web-platform-release.yml` but missed the plugin caller — the plan is a verbatim application of an established pattern (both verified live via `gh pr view`).
+- Added drift-guard test (`plugins/soleur/test/reusable-release-caller-permissions.test.sh`) asserting every `reusable-release.yml` caller grants `id-token: write`, to catch the next caller regression.
+- Self-verifying merge: the test file lands under `plugins/soleur/**`, matching the caller's path filter, so merging the PR re-triggers the workflow — post-merge verification needs no operator step.
+- Scope: confirmed only 2 real callers (`web-platform-release.yml` already fixed, `version-bump-and-release.yml` broken); `apply-deploy-pipeline-fix.yml` references the reusable workflow only in a comment.
+
+### Components Invoked
+- Skill: soleur:plan
+- Skill: soleur:deepen-plan
+- Deepen-plan halt gates (4.4 precedent-diff, 4.6 User-Brand Impact, 4.7 Observability, 4.8 PAT-shaped, 4.9 UI-wireframe) — all PASS

--- a/knowledge-base/project/specs/feat-one-shot-6018-version-bump-release-startup-failure/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6018-version-bump-release-startup-failure/tasks.md
@@ -1,0 +1,59 @@
+# Tasks — fix(ci): Version Bump and Release startup_failure (#6018)
+
+lane: procedural
+Plan: `knowledge-base/project/plans/2026-07-04-fix-version-bump-release-startup-failure-plan.md`
+
+Root cause: the plugin release caller `version-bump-and-release.yml` does not grant
+`id-token: write`, a permission the reusable `release` job began requiring in #5977 (cosign
+signing). #5981 fixed the sibling `web-platform-release.yml` caller but missed this one →
+`startup_failure` on every plugin-path merge since 2026-07-04T12:20 UTC.
+
+## Phase 1 — Core fix
+
+- [ ] 1.1 Edit `.github/workflows/version-bump-and-release.yml`: add a job-level
+      `permissions:` block to the `release:` job with `contents: write`, `packages: write`,
+      `id-token: write`, mirroring the #5981 block in `web-platform-release.yml` (lines
+      42–52). Include the explanatory comment (why job-level replaces inherited perms; why
+      id-token is required even though the plugin caller passes no `docker_image`). Keep the
+      existing `with:` inputs and `secrets: inherit` unchanged.
+- [ ] 1.2 `actionlint .github/workflows/version-bump-and-release.yml` exits 0.
+- [ ] 1.3 Verify: `grep -A8 '^  release:' .github/workflows/version-bump-and-release.yml | grep -c 'id-token: write'` returns `1`.
+
+## Phase 2 — Drift-guard test (prevents recurrence for the NEXT caller)
+
+- [ ] 2.1 Create `plugins/soleur/test/reusable-release-caller-permissions.test.sh`
+      (auto-discovered by `scripts/test-all.sh:188` glob; no runner registration needed).
+      Follow the header/assertion convention of `reusable-release-idempotency.test.sh`.
+      Assertions:
+      - (a) `reusable-release.yml` `release` job declares `id-token: write` (guard premise).
+      - (b) enumerate every `uses: ./.github/workflows/reusable-release.yml` caller via grep
+        (not a hardcoded list).
+      - (c) each caller grants `id-token: write` at workflow level OR its calling job's
+        job level; FAIL naming any caller that does not.
+      - (d) sanity: enumeration found ≥ 2 callers (fail loud on a zero-match grep regression).
+- [ ] 2.2 Run `bash plugins/soleur/test/reusable-release-caller-permissions.test.sh` — exits 0.
+- [ ] 2.3 Negative check (author sanity): temporarily delete the `id-token: write` line from
+      the plugin caller → test FAILs naming `version-bump-and-release.yml`; then revert.
+- [ ] 2.4 `bash scripts/test-all.sh scripts` discovers and runs the new test green.
+
+## Phase 3 — Ship
+
+- [ ] 3.1 PR body: `Closes #6018`.
+- [ ] 3.2 Post-merge (self-triggering, no operator step): the new `plugins/soleur/test/*.sh`
+      file matches the caller's `plugins/soleur/**` path filter, so the merge itself
+      triggers Version Bump and Release. Confirm via
+      `gh run list --workflow "Version Bump and Release" --branch main --limit 1 --json conclusion,status,databaseId`
+      that the run does NOT conclude `startup_failure` and starts with a populated `release`
+      job. If it fails a *later* (non-permission) step, that is out of scope for #6018 — file
+      a follow-up.
+
+## Notes / Sharp Edges
+
+- `actionlint` does NOT validate the caller→reusable permission ceiling (GitHub-runtime
+  check) — the Phase 2 drift-guard test is the real invariant enforcer.
+- Job-level `permissions:` REPLACES (not merges with) inherited workflow perms — re-declare
+  `contents`/`packages` alongside `id-token`, or the release job loses tag-push/GHCR access.
+- The reusable `release` job declares `id-token: write` unconditionally; the cosign steps
+  that use it are `if:`-gated on `docker_image != ''` (never runs for the plugin caller).
+  GitHub validates the permission ceiling at dispatch, before any `if:` — hence the grant is
+  still required even though nothing is signed.

--- a/plugins/soleur/test/reusable-release-caller-permissions.test.sh
+++ b/plugins/soleur/test/reusable-release-caller-permissions.test.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Drift-guard: every caller of reusable-release.yml must grant `id-token: write`
+# to the job that calls it.
+#
+# Background (#6018): a reusable workflow can only USE a GITHUB_TOKEN permission
+# that its CALLER grants. #5977 (60f203c50) added `id-token: write` to the
+# reusable `release` job for cosign keyless signing (#5933 Item 4). Any caller
+# whose calling job does NOT grant that permission fails at DISPATCH with
+# `startup_failure` (empty `jobs`, no step logs) — GitHub validates the caller's
+# permission ceiling before evaluating any step `if:`, so this fires even for the
+# plugin caller that passes no `docker_image` and never runs the cosign steps.
+# #5981 fixed the web-platform caller but missed the plugin caller — this guard
+# makes the next caller (or a future permission the reusable job adds) fail
+# loudly at PR time instead of silently at merge.
+#
+# Same defect class as
+# knowledge-base/project/learnings/2026-05-04-schedule-once-template-missing-id-token.md
+# ("OIDC permission belongs to the action/reusable-job, not the caller task").
+#
+# Static assertion over the workflow YAML (no live GitHub API). Semantics
+# enforced: a job-level `permissions:` block REPLACES the inherited workflow-level
+# block for that job, so the ceiling is granted iff EITHER the calling job has a
+# job-level `permissions:` containing `id-token: write`, OR the calling job has no
+# job-level block and the workflow-level `permissions:` contains it.
+#
+# Run via:  bash plugins/soleur/test/reusable-release-caller-permissions.test.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+WF_DIR="$REPO_ROOT/.github/workflows"
+REUSABLE="$WF_DIR/reusable-release.yml"
+
+PASS=0
+FAIL=0
+pass() {
+  echo "  pass: $1"
+  PASS=$((PASS + 1))
+}
+fail() {
+  echo "  FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+echo "=== reusable-release caller id-token drift guard (#6018) ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# Extract the lines of a named job block (from `^  <job>:` up to the next
+# 2-space-indented job header), scoped to content after the top-level `jobs:`
+# key so `on.push:` and workflow-level keys can never be mistaken for a job.
+# ---------------------------------------------------------------------------
+named_job_block() {
+  local file="$1" job="$2"
+  awk -v job="$job" '
+    /^jobs:[[:space:]]*$/ { injobs = 1; next }
+    !injobs { next }
+    /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {
+      cur = $0; sub(/^  /, "", cur); sub(/:.*/, "", cur)
+      inblock = (cur == job)
+    }
+    inblock { print }
+  ' "$file"
+}
+
+# The calling job block = the job whose block contains the `uses:` line pointing
+# at reusable-release.yml. Accumulate each job into a buffer; when the next job
+# header (or EOF) arrives, emit the buffer iff it was the caller.
+calling_job_block() {
+  local file="$1"
+  awk '
+    /^jobs:[[:space:]]*$/ { injobs = 1; next }
+    !injobs { next }
+    /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {
+      if (buf ~ /uses:[[:space:]]*\.\/\.github\/workflows\/reusable-release\.yml/) { printf "%s", buf; exit }
+      buf = $0 ORS; next
+    }
+    { buf = buf $0 ORS }
+    END { if (buf ~ /uses:[[:space:]]*\.\/\.github\/workflows\/reusable-release\.yml/) printf "%s", buf }
+  ' "$file"
+}
+
+# Workflow-level `permissions:` block (top-level key, entries indented 2 spaces),
+# terminated by the next top-level key.
+workflow_perms() {
+  local file="$1"
+  awk '
+    /^permissions:[[:space:]]*$/ { inblock = 1; next }
+    inblock && /^[A-Za-z]/ { exit }
+    inblock { print }
+  ' "$file"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Premise check: the reusable `release` job must itself declare
+#    `id-token: write`. If cosign signing is later removed and this permission
+#    disappears, this assertion should be revisited (the guard would otherwise
+#    keep enforcing a now-unneeded caller grant) — a loud FAIL here forces that
+#    review rather than the guard silently drifting stale.
+# ---------------------------------------------------------------------------
+echo "1. reusable-release.yml release job declares id-token: write"
+if [[ ! -f "$REUSABLE" ]]; then
+  fail "reusable-release.yml not found at $REUSABLE"
+  echo ""
+  echo "=== Results: $PASS/$((PASS + FAIL)) passed, $FAIL failed ==="
+  exit 1
+fi
+if named_job_block "$REUSABLE" release | grep -qE '^[[:space:]]+id-token:[[:space:]]*write\b'; then
+  pass "reusable release job requires id-token: write"
+else
+  fail "reusable release job no longer declares id-token: write — revisit this guard's premise (cosign signing removed?)"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Enumerate every caller (grep, not a hardcoded list). apply-deploy-pipeline-
+#    fix.yml mentions reusable-release.yml only in a comment (no `uses:`), so it
+#    is correctly excluded by matching the `uses:` construct.
+# ---------------------------------------------------------------------------
+echo ""
+echo "2. Enumerate callers of reusable-release.yml"
+mapfile -t callers < <(grep -rlE 'uses:[[:space:]]*\./\.github/workflows/reusable-release\.yml' "$WF_DIR" | sort)
+echo "   found ${#callers[@]} caller(s): $(printf '%s ' "${callers[@]##*/}")"
+
+# Vacuous-pass guard: a future grep-scope / path regression that finds zero (or
+# one) callers must FAIL loudly, not pass silently over an un-enumerated surface.
+if [[ "${#callers[@]}" -ge 2 ]]; then
+  pass "caller enumeration found >= 2 callers (not a vacuous grep)"
+else
+  fail "expected >= 2 callers of reusable-release.yml, found ${#callers[@]} — grep scope regressed?"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Each caller's calling job must grant id-token: write (job-level replaces
+#    workflow-level; either satisfies the ceiling per the replace semantics).
+# ---------------------------------------------------------------------------
+echo ""
+echo "3. Each caller grants id-token: write to its calling job"
+for file in "${callers[@]}"; do
+  name="${file##*/}"
+  block="$(calling_job_block "$file")"
+  if [[ -z "$block" ]]; then
+    fail "$name: could not locate the job that calls reusable-release.yml"
+    continue
+  fi
+  if grep -qE '^    permissions:[[:space:]]*$' <<<"$block"; then
+    # Job-level permissions block present → it REPLACES the workflow-level block,
+    # so id-token must be granted here or the ceiling is not met.
+    if grep -qE '^[[:space:]]+id-token:[[:space:]]*write\b' <<<"$block"; then
+      pass "$name: calling job grants id-token: write (job-level)"
+    else
+      fail "$name: calling job has a job-level permissions: block WITHOUT id-token: write (job-level REPLACES workflow-level → startup_failure)"
+    fi
+  else
+    # No job-level block → workflow-level permissions apply to this job.
+    if grep -qE 'id-token:[[:space:]]*write\b' <<<"$(workflow_perms "$file")"; then
+      pass "$name: calling job inherits workflow-level id-token: write"
+    else
+      fail "$name: no id-token: write at job level OR workflow level → the reusable release job will startup_failure"
+    fi
+  fi
+done
+
+echo ""
+echo "=== Results: $PASS/$((PASS + FAIL)) passed, $FAIL failed ==="
+if [[ "$FAIL" -gt 0 ]]; then exit 1; fi

--- a/plugins/soleur/test/reusable-release-caller-permissions.test.sh
+++ b/plugins/soleur/test/reusable-release-caller-permissions.test.sh
@@ -19,9 +19,23 @@
 #
 # Static assertion over the workflow YAML (no live GitHub API). Semantics
 # enforced: a job-level `permissions:` block REPLACES the inherited workflow-level
-# block for that job, so the ceiling is granted iff EITHER the calling job has a
-# job-level `permissions:` containing `id-token: write`, OR the calling job has no
-# job-level block and the workflow-level `permissions:` contains it.
+# block for that job, so the ceiling is granted iff EITHER the calling job's
+# job-level `permissions:` grants `id-token: write`, OR the calling job has no
+# job-level `permissions:` and the workflow-level `permissions:` grants it.
+#
+# Robustness (a drift guard must not itself fail open — review of #6018):
+#   - job headers are matched with an optional trailing comment (`release: # x`)
+#     so a legal YAML comment cannot merge two jobs and bleed a sibling's grant;
+#   - the job-level id-token check is scoped to the `permissions:` sub-block, not
+#     the whole job (an `id-token: write`-shaped line under `with:`/`env:` must
+#     not satisfy it);
+#   - inline `permissions:` forms (`write-all`, flow-mapping `{id-token: write}`)
+#     are classified, so a job broadened to inline perms is not mis-read;
+#   - EVERY calling job in a caller file is checked (not just the first);
+#   - both local (`./…`) and remote (`owner/repo/…@ref`) `uses:` reference forms
+#     are enumerated;
+#   - every id-token grep is `^`-anchored so a commented `# id-token: write`
+#     never satisfies a check.
 #
 # Run via:  bash plugins/soleur/test/reusable-release-caller-permissions.test.sh
 
@@ -45,17 +59,25 @@ fail() {
 echo "=== reusable-release caller id-token drift guard (#6018) ==="
 echo ""
 
-# ---------------------------------------------------------------------------
-# Extract the lines of a named job block (from `^  <job>:` up to the next
-# 2-space-indented job header), scoped to content after the top-level `jobs:`
-# key so `on.push:` and workflow-level keys can never be mistaken for a job.
-# ---------------------------------------------------------------------------
+# NOTE on job-header matching (inlined as `/^  [A-Za-z0-9_-]+:[[:space:]]*(#.*)?$/`
+# in the awk functions below): the `(#.*)?` tail is load-bearing — `release: # the
+# release job` is legal YAML and without it the header is unrecognised, silently
+# merging the job into its predecessor's block (a fail-open the guard must avoid).
+# An indented `uses:` key pointing at the reusable workflow, local (`./…`) or
+# remote (`owner/repo/…/reusable-release.yml@ref`). Anchored to `^<indent>uses:`
+# so a `# uses: …` comment line never matches.
+USES_GREP_ERE='^[[:space:]]+uses:[[:space:]]*[^[:space:]]*reusable-release\.yml'
+ID_TOKEN_ERE='^[[:space:]]+id-token:[[:space:]]*write\b'
+
+# Print the block of a named job (header through the line before the next job
+# header), scoped to content after the top-level `jobs:` key so `on.push:` and
+# workflow-level keys can never be mistaken for a job.
 named_job_block() {
   local file="$1" job="$2"
   awk -v job="$job" '
     /^jobs:[[:space:]]*$/ { injobs = 1; next }
     !injobs { next }
-    /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {
+    /^  [A-Za-z0-9_-]+:[[:space:]]*(#.*)?$/ {
       cur = $0; sub(/^  /, "", cur); sub(/:.*/, "", cur)
       inblock = (cur == job)
     }
@@ -63,25 +85,29 @@ named_job_block() {
   ' "$file"
 }
 
-# The calling job block = the job whose block contains the `uses:` line pointing
-# at reusable-release.yml. Accumulate each job into a buffer; when the next job
-# header (or EOF) arrives, emit the buffer iff it was the caller.
-calling_job_block() {
+# Print the NAME of every job in <file> whose block contains a `uses:` line
+# pointing at the reusable workflow. `(\n|^)[[:space:]]+uses:` matches the key
+# inside the accumulated multi-line buffer while still excluding `# uses:`
+# comment lines (a `#` immediately precedes the space in a comment, so no
+# newline/start-anchored whitespace run reaches `uses:`).
+calling_job_names() {
   local file="$1"
   awk '
     /^jobs:[[:space:]]*$/ { injobs = 1; next }
     !injobs { next }
-    /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {
-      if (buf ~ /uses:[[:space:]]*\.\/\.github\/workflows\/reusable-release\.yml/) { printf "%s", buf; exit }
-      buf = $0 ORS; next
+    /^  [A-Za-z0-9_-]+:[[:space:]]*(#.*)?$/ {
+      if (name != "" && buf ~ /(\n|^)[[:space:]]+uses:[[:space:]]*[^[:space:]]*reusable-release\.yml/) print name
+      name = $0; sub(/^  /, "", name); sub(/:.*/, "", name); buf = ""; next
     }
     { buf = buf $0 ORS }
-    END { if (buf ~ /uses:[[:space:]]*\.\/\.github\/workflows\/reusable-release\.yml/) printf "%s", buf }
+    END { if (name != "" && buf ~ /(\n|^)[[:space:]]+uses:[[:space:]]*[^[:space:]]*reusable-release\.yml/) print name }
   ' "$file"
 }
 
 # Workflow-level `permissions:` block (top-level key, entries indented 2 spaces),
-# terminated by the next top-level key.
+# terminated by the next top-level key. Block form only — a top-level inline
+# `permissions: write-all` is not extracted here (no current caller uses it; the
+# fail direction is a loud FAIL, not a silent pass).
 workflow_perms() {
   local file="$1"
   awk '
@@ -89,6 +115,44 @@ workflow_perms() {
     inblock && /^[A-Za-z]/ { exit }
     inblock { print }
   ' "$file"
+}
+
+# Classify a job block's OWN (job-level) id-token grant: granted | denied | none.
+#   none    → no job-level `permissions:` at all (workflow-level applies)
+#   granted → job-level perms include id-token: write (block or inline form)
+#   denied  → job-level perms present but WITHOUT id-token (REPLACES workflow-level)
+# stdin: the job block (from named_job_block).
+job_id_token_verdict() {
+  local block permline lineno value sub
+  block="$(cat)"
+  permline="$(printf '%s\n' "$block" | grep -nE '^    permissions:' | head -1)"
+  if [[ -z "$permline" ]]; then
+    echo "none"
+    return
+  fi
+  lineno="${permline%%:*}"
+  # Everything after `permissions:` on that line (strip trailing comment + ws).
+  value="$(printf '%s\n' "$block" | sed -n "${lineno}p" \
+    | sed -E 's/^    permissions:[[:space:]]*//; s/[[:space:]]*#.*$//; s/[[:space:]]*$//')"
+  if [[ -z "$value" ]]; then
+    # Block form: scan the sub-block (indent deeper than the 4-space key) until
+    # the next 4-space job key, and require id-token WITHIN it (not the whole job).
+    sub="$(printf '%s\n' "$block" | awk -v s="$lineno" 'NR > s { if ($0 ~ /^    [A-Za-z0-9_-]+:/) exit; print }')"
+    if printf '%s\n' "$sub" | grep -qE "$ID_TOKEN_ERE"; then
+      echo "granted"
+    else
+      echo "denied"
+    fi
+    return
+  fi
+  # Inline form: `write-all` grants everything incl. id-token; a flow-mapping that
+  # lists `id-token: write` grants it; anything else (`read-all`, `{}`, `read`)
+  # does not.
+  case "$value" in
+    write-all) echo "granted" ;;
+    *id-token*write*) echo "granted" ;;
+    *) echo "denied" ;;
+  esac
 }
 
 # ---------------------------------------------------------------------------
@@ -105,7 +169,7 @@ if [[ ! -f "$REUSABLE" ]]; then
   echo "=== Results: $PASS/$((PASS + FAIL)) passed, $FAIL failed ==="
   exit 1
 fi
-if named_job_block "$REUSABLE" release | grep -qE '^[[:space:]]+id-token:[[:space:]]*write\b'; then
+if named_job_block "$REUSABLE" release | grep -qE "$ID_TOKEN_ERE"; then
   pass "reusable release job requires id-token: write"
 else
   fail "reusable release job no longer declares id-token: write — revisit this guard's premise (cosign signing removed?)"
@@ -114,11 +178,11 @@ fi
 # ---------------------------------------------------------------------------
 # 2. Enumerate every caller (grep, not a hardcoded list). apply-deploy-pipeline-
 #    fix.yml mentions reusable-release.yml only in a comment (no `uses:`), so it
-#    is correctly excluded by matching the `uses:` construct.
+#    is correctly excluded by matching the anchored `uses:` construct.
 # ---------------------------------------------------------------------------
 echo ""
 echo "2. Enumerate callers of reusable-release.yml"
-mapfile -t callers < <(grep -rlE 'uses:[[:space:]]*\./\.github/workflows/reusable-release\.yml' "$WF_DIR" | sort)
+mapfile -t callers < <(grep -rlE "$USES_GREP_ERE" "$WF_DIR" | sort)
 echo "   found ${#callers[@]} caller(s): $(printf '%s ' "${callers[@]##*/}")"
 
 # Vacuous-pass guard: a future grep-scope / path regression that finds zero (or
@@ -130,34 +194,36 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 3. Each caller's calling job must grant id-token: write (job-level replaces
-#    workflow-level; either satisfies the ceiling per the replace semantics).
+# 3. Each caller's EVERY calling job must grant id-token: write (job-level
+#    replaces workflow-level; either satisfies the ceiling per replace semantics).
 # ---------------------------------------------------------------------------
 echo ""
-echo "3. Each caller grants id-token: write to its calling job"
+echo "3. Each caller grants id-token: write to its calling job(s)"
 for file in "${callers[@]}"; do
   name="${file##*/}"
-  block="$(calling_job_block "$file")"
-  if [[ -z "$block" ]]; then
+  mapfile -t jobs < <(calling_job_names "$file")
+  if [[ "${#jobs[@]}" -eq 0 ]]; then
     fail "$name: could not locate the job that calls reusable-release.yml"
     continue
   fi
-  if grep -qE '^    permissions:[[:space:]]*$' <<<"$block"; then
-    # Job-level permissions block present → it REPLACES the workflow-level block,
-    # so id-token must be granted here or the ceiling is not met.
-    if grep -qE '^[[:space:]]+id-token:[[:space:]]*write\b' <<<"$block"; then
-      pass "$name: calling job grants id-token: write (job-level)"
-    else
-      fail "$name: calling job has a job-level permissions: block WITHOUT id-token: write (job-level REPLACES workflow-level → startup_failure)"
-    fi
-  else
-    # No job-level block → workflow-level permissions apply to this job.
-    if grep -qE 'id-token:[[:space:]]*write\b' <<<"$(workflow_perms "$file")"; then
-      pass "$name: calling job inherits workflow-level id-token: write"
-    else
-      fail "$name: no id-token: write at job level OR workflow level → the reusable release job will startup_failure"
-    fi
-  fi
+  for job in "${jobs[@]}"; do
+    verdict="$(named_job_block "$file" "$job" | job_id_token_verdict)"
+    case "$verdict" in
+      granted)
+        pass "$name [$job]: calling job grants id-token: write (job-level)"
+        ;;
+      denied)
+        fail "$name [$job]: job-level permissions: WITHOUT id-token: write (job-level REPLACES workflow-level → startup_failure)"
+        ;;
+      none)
+        if workflow_perms "$file" | grep -qE "$ID_TOKEN_ERE"; then
+          pass "$name [$job]: calling job inherits workflow-level id-token: write"
+        else
+          fail "$name [$job]: no id-token: write at job level OR workflow level → the reusable release job will startup_failure"
+        fi
+        ;;
+    esac
+  done
 done
 
 echo ""

--- a/plugins/soleur/test/reusable-release-caller-permissions.test.sh
+++ b/plugins/soleur/test/reusable-release-caller-permissions.test.sh
@@ -67,7 +67,10 @@ echo ""
 # remote (`owner/repo/…/reusable-release.yml@ref`). Anchored to `^<indent>uses:`
 # so a `# uses: …` comment line never matches.
 USES_GREP_ERE='^[[:space:]]+uses:[[:space:]]*[^[:space:]]*reusable-release\.yml'
-ID_TOKEN_ERE='^[[:space:]]+id-token:[[:space:]]*write\b'
+# `write` terminated by whitespace, end-of-line, or a trailing `#` comment.
+# POSIX class (NOT the GNU-only `\b`) so the guard is portable across grep
+# implementations (BusyBox / mawk-adjacent CI environments).
+ID_TOKEN_ERE='^[[:space:]]+id-token:[[:space:]]*write([[:space:]]|$|#)'
 
 # Print the block of a named job (header through the line before the next job
 # header), scoped to content after the top-level `jobs:` key so `on.push:` and
@@ -82,6 +85,27 @@ named_job_block() {
       inblock = (cur == job)
     }
     inblock { print }
+  ' "$file"
+}
+
+# Print ONLY the entries of a named job's job-level `permissions:` sub-block.
+# Scoped + early-exit (stops at the next 4-space job key) so it processes a
+# handful of early lines regardless of how large the job body is — the whole-job
+# `named_job_block` extraction chokes some `awk` builds on the 700-line reusable
+# `release` job (a 418-char inline line at :406); this reads only lines ~61-67.
+named_job_permissions_block() {
+  local file="$1" job="$2"
+  awk -v job="$job" '
+    /^jobs:[[:space:]]*$/ { injobs = 1; next }
+    !injobs { next }
+    /^  [A-Za-z0-9_-]+:[[:space:]]*(#.*)?$/ {
+      cur = $0; sub(/^  /, "", cur); sub(/:.*/, "", cur)
+      inrel = (cur == job); next
+    }
+    inrel && /^  [A-Za-z0-9_-]+:/ { exit }
+    inrel && /^    permissions:[[:space:]]*(#.*)?$/ { inperm = 1; next }
+    inperm && /^    [A-Za-z0-9_-]+:/ { exit }
+    inperm { print }
   ' "$file"
 }
 
@@ -169,7 +193,7 @@ if [[ ! -f "$REUSABLE" ]]; then
   echo "=== Results: $PASS/$((PASS + FAIL)) passed, $FAIL failed ==="
   exit 1
 fi
-if named_job_block "$REUSABLE" release | grep -qE "$ID_TOKEN_ERE"; then
+if named_job_permissions_block "$REUSABLE" release | grep -qE "$ID_TOKEN_ERE"; then
   pass "reusable release job requires id-token: write"
 else
   fail "reusable release job no longer declares id-token: write — revisit this guard's premise (cosign signing removed?)"


### PR DESCRIPTION
## Summary

The **Version Bump and Release** workflow (`version-bump-and-release.yml`, the plugin release tagger) has concluded `startup_failure` on every merge to `main` since 2026-07-04T12:20 UTC. Root cause: a reusable workflow can only *use* a `GITHUB_TOKEN` permission its **caller** grants. PR #5977 added `id-token: write` to the reusable `release` job (`reusable-release.yml`) for cosign keyless signing; PR #5981 fixed the `web-platform-release.yml` caller but **missed the plugin caller**. Absent the grant, GitHub rejects the run at dispatch (empty `jobs`, no step logs) before any step `if:` is evaluated — so it fires even though the plugin release passes no `docker_image` and never runs the cosign steps.

This adds the job-level `permissions` block (`contents`/`packages`/`id-token: write`) to the plugin caller, mirroring the already-merged #5981 remediation verbatim, plus a drift-guard test so the next caller (or a future required permission) fails at PR time instead of silently at merge.

Closes #6018

## User-Brand Impact

**If this ships wrong, the user experiences:** the plugin release tag / version bump keeps not advancing on merge and the release Slack post stays silent — an operator-facing release-automation gap, not a customer-facing surface. (#6018 records no production/customer impact — the affected workflow is the plugin release *tagger*, not a serving surface.)

**If this leaks, the user's data / workflow / money is exposed via:** N/A — the change grants an OIDC token-mint scope (`id-token: write`) to a release job that already runs in the trusted `main`-push context; no data path, no secret, no external exposure is added. For the plugin caller the cosign OIDC handshake does not even execute (no `docker_image`); GitHub validates the permission ceiling at dispatch regardless.

- **Brand-survival threshold:** none — CI release-tagging reliability; issue #6018 explicitly records no production/customer impact.
- `threshold: none, reason: plugin release-tagger CI permission fix; issue #6018 explicitly records no production/customer impact and the change adds no data/secret path.`

## Changelog

### CI
- Grant `id-token: write` (job-level, alongside `contents`/`packages: write`) to the `release` job in `version-bump-and-release.yml`, fixing the `startup_failure`-on-every-merge regression introduced when the reusable release job began requiring the OIDC scope for cosign signing.
- Add `plugins/soleur/test/reusable-release-caller-permissions.test.sh`: a drift-guard asserting every caller of `reusable-release.yml` grants `id-token: write` to its calling job (auto-discovered by `scripts/test-all.sh`).

## Observability

The failure mode itself is an observability gap: `startup_failure` produces an empty `jobs` object and no step logs. The durable detection is the new drift-guard test (a pre-merge CI gate), not a runtime probe.

- **liveness_signal:** the Version Bump and Release run on each `plugins/soleur/**` merge — `gh run list --workflow "Version Bump and Release" --branch main`; a `startup_failure` conclusion is the regression signal.
- **error_reporting:** GitHub Actions run conclusion surfaced in the Actions UI / `gh run list`; the reusable workflow's release Slack post firing (or its absence) is the operator-visible signal.
- **discoverability_test** (NO ssh): `gh run list --workflow "Version Bump and Release" --branch main --limit 1 --json conclusion` → post-merge the conclusion is no longer `startup_failure`. This probe is inherently **post-merge** — merging this PR self-triggers the workflow (the new test lands under `plugins/soleur/**`, matching the caller's path filter), so verification needs no forced dispatch and no operator step.

## Test plan

- [x] `bash plugins/soleur/test/reusable-release-caller-permissions.test.sh` exits 0 (4/4).
- [x] `actionlint .github/workflows/version-bump-and-release.yml` exits 0.
- [x] Negative-test: removing the `id-token: write` line makes the guard FAIL naming the plugin caller — confirmed even with the job-level `permissions:` block still present (precise REPLACE semantics).
- [x] Hardening mutation proofs (review): trailing-comment job header + id-token-under-`with:` (both now correctly FAIL); inline `write-all` (correctly PASSes).
- [x] `bash scripts/test-all.sh scripts` green (138/138 suites; new test `[ok]`).
- Post-merge (verified inline by ship Phase 7): merging this PR self-triggers the Version Bump and Release workflow (the new test lands under `plugins/soleur/**`, matching the caller's path filter); the release-workflow verification confirms the run no longer concludes `startup_failure` and starts with a populated `release` job. Auto-verified via `gh run list` — no operator action.

Generated with [Claude Code](https://claude.com/claude-code)
