### PR TITLE
feat(plan-review): named CEO/design/devex panel with classifier-routed findings

### DIFF
--- a/knowledge-base/engineering/architecture/decisions/ADR-084-decision-classification-taxonomy-for-autonomous-question-surfacing.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-084-decision-classification-taxonomy-for-autonomous-question-surfacing.md
@@ -20,7 +20,7 @@ questions they can't answer or hang the pipeline on `AskUserQuestion`.
 
 ## Decision
 
-1. **A committed reference doc** — `plugins/soleur/skills/brainstorm-techniques/references/decision-principles.md` — defines the taxonomy, 2 surfacing principles (blast-radius, bias-to-action), classify-by-consequence with 4 never-Mechanical classes, the CTO-fork precedence carve-out, the mode-branch table, the 5-line frame, the consult scope, and the security exception. Consumed by `brainstorm-techniques`, `plan` Step 4.5, `work`, and `ship`.
+1. **A committed reference doc** — `plugins/soleur/skills/brainstorm-techniques/references/decision-principles.md` — defines the taxonomy, 2 surfacing principles (blast-radius, bias-to-action), classify-by-consequence with 4 never-Mechanical classes, the CTO-fork precedence carve-out, the mode-branch table, the 5-line frame, the consult scope, and the security exception. Consumed by **5 skills**: `brainstorm-techniques`, `plan` Step 4.5, `work`, `ship`, and `plan-review` (#5985 — plan-review classifies its consolidated *review findings* with the taxonomy so named-panel taste findings are surfaced, never auto-applied; a finding-classification use adjacent to the skills that classify their own intermediate decisions).
 2. **Classify by consequence, not surface-flavor.** Surface criterion = user-visible OR money/compliance (sub-processor / recurring cost / data egress / lawful-basis). Four classes are never Mechanical even when they look technical: dropping operator-requested scope; a new sub-processor/paid dependency; a new recurring cost; irreversible data ops.
 3. **Mode = execution context, not skill name.** Operator-attached ⟺ a real TTY (direct brainstorm/plan, no `HEADLESS_MODE`, not a plan-file arg, not inside a Task subagent). Any subagent / one-shot context is headless — a subagent returns the decision to its parent as structured text.
 4. **No-mid-pipeline-pause invariant**, with **one** sanctioned exception: a security/feasibility regression halts **terminally** before merge (a stop, not a per-phase pause) + an `action-required`+`security` issue.
@@ -30,9 +30,9 @@ questions they can't answer or hang the pipeline on `AskUserQuestion`.
 ## Consequences
 
 - Autonomous runs get principled surface-vs-auto decisions with an operator-legible async surface, and never hang or pause mid-pipeline.
-- A new SKILL.md-prose surface across 4 skills; drift-guarded by a `components.test.ts` assertion (doc exists + 4 consumers link it + `ship` emits the `action-required` issue).
+- A new SKILL.md-prose surface across 5 skills; drift-guarded by a `components.test.ts` assertion (doc exists + all consumers link it + `ship` emits the `action-required` issue).
 - The doc home (`brainstorm-techniques/references/`) is semantically inverted (the load-bearing consumers are `work`/`ship`), accepted because cross-skill reference-by-path is an established pattern (`deepen-plan` reads `plan/references/*`, `ux-audit` reads `ship/references/*`) and the drift-guard mitigates the rename-orphan risk.
-- Fully reversible: delete the doc + the 4 pointers + the ADR.
+- Fully reversible: delete the doc + the 5 pointers + the ADR.
 
 ## Alternatives considered
 

--- a/knowledge-base/project/learnings/best-practices/2026-07-04-testable-workflow-internal-logic-lib-plus-duplicate-plus-parity-guard.md
+++ b/knowledge-base/project/learnings/best-practices/2026-07-04-testable-workflow-internal-logic-lib-plus-duplicate-plus-parity-guard.md
@@ -1,0 +1,86 @@
+---
+title: "Deterministic no-live-agent tests of Workflow-internal logic: importable lib + self-contained duplicate + logic-parity drift guard"
+date: 2026-07-04
+category: best-practices
+module: plugins/soleur/skills/*/workflows
+tags: [workflow-tool, testing, self-contained-duplication, drift-guard, plan-review]
+pr: 6020
+issue: 5985
+---
+
+# Learning: Unit-testing decision logic that lives inside a `.workflow.js`
+
+## Problem
+
+`#5985` wired a relevance-gated named panel into `plan-review`, gated by a pure
+decision function `computeNamedPanel(signals) → lenses`. Two acceptance criteria
+(AC11 independent-activation, AC12 each-lens-exercised) required **deterministic
+fixture tests with NO live agents**. But a Workflow-tool script
+(`skills/*/workflows/*.workflow.js`) cannot be unit-tested by import:
+
+- It runs `export const meta` + top-level `await agent(...)` / `return report`,
+  so `await import("…workflow.js")` executes the body immediately → throws
+  (`requires a plan file path`) or hits `return` at module top level.
+- The Workflow runtime has **no filesystem/import access**, so the workflow
+  cannot itself `import` a shared helper (this is the documented reason
+  `safeTitle`/`safeId` are duplicated per script).
+
+So the logic that actually runs is unreachable from `bun test`.
+
+## Solution
+
+Three-part pattern (all three are load-bearing):
+
+1. **Extract the pure decision function into an importable ESM module** —
+   `skills/plan-review/lib/named-panel.mjs` exporting `computeNamedPanel` +
+   `NAMED_LENSES`. This is the copy the AC11/AC12 fixtures import and exercise.
+2. **Duplicate it verbatim into the `.workflow.js`** (self-contained convention
+   — the runtime can't import). This is the copy that actually runs.
+3. **Add a normalized logic-parity drift guard** — a test that extracts
+   `NAMED_LENSES = […]` and `function computeNamedPanel(…){…}` from BOTH source
+   files, strips comments/`export`/whitespace, and asserts the two bodies are
+   equal. Without it, a logic edit to the runtime copy passes CI while the tested
+   copy silently diverges (the copy that runs ≠ the copy that is tested).
+
+Keep design decisions that are ambiguous or fuzzy OUT of the pure function so it
+stays deterministic: the plan's "threshold bias" (Step 3) was wired at the
+**detect-prompt** layer (nudging the model's fuzzy signals) rather than inside
+`computeNamedPanel`, so the function remains a pure signals→lenses mapping and
+the fixtures stay deterministic.
+
+## Key Insight
+
+When a Workflow script contains decision logic that deserves a unit test, the
+testable unit is a **pure function of the agent-returned signals**, extracted to
+an importable module, duplicated into the (un-importable) workflow, and pinned by
+a **logic-parity** guard — not a mere presence grep. A `src.toContain("function
+foo(")` guard proves the function exists, not that the running copy matches the
+tested copy; normalize-and-compare both bodies.
+
+## Syntax-checking a `.workflow.js`
+
+`node --check path.workflow.js` reports a false-positive `Illegal return
+statement` because the top-level `return report` is legal only inside the
+Workflow runtime's async wrapper. To validate edits, wrap the body first:
+
+```bash
+node -e 'const fs=require("fs");let s=fs.readFileSync(F,"utf8").replace(/^export const meta/,"const meta");
+new Function("async function __wf(args,agent,parallel,pipeline,log,phase,budget,workflow){\n"+s+"\n}");'
+```
+
+## Session Errors
+
+1. **Planning subagent returned a garbled mid-stream snippet instead of its
+   `## Session Summary` block.** Recovery: read the on-disk plan artifact
+   (`plans/*.md`) directly and verify completeness. Prevention: one-shot's
+   partial-artifact recovery path already handles this — trust the on-disk
+   artifact over the subagent's return text. One-off.
+2. **Two review subagents' first `Read` calls hit the main-repo path (checked
+   out to `main`) instead of the worktree, returning stale pre-PR content.**
+   Recovery: the agents re-ran in the worktree cwd (grep/awk) and reported true
+   diff. Prevention: already documented in
+   `2026-05-19-bare-repo-grep-and-subagent-infra-claim-verification.md`; pass
+   worktree-absolute paths to review subagents. Recurring, already-covered.
+3. **`node --check` false-positive on the `.workflow.js` top-level `return`.**
+   Recovery: wrapped-async `new Function(...)` syntax check (above). Prevention:
+   this learning + the plugins AGENTS.md workflow-script note. Recurring, low-value.

--- a/knowledge-base/project/plans/2026-07-04-feat-named-plan-review-panel-plan.md
+++ b/knowledge-base/project/plans/2026-07-04-feat-named-plan-review-panel-plan.md
@@ -1,0 +1,264 @@
+---
+title: "feat(wave1): named multi-dimensional plan-review panel (CEO/design/devex)"
+date: 2026-07-04
+type: feat
+issue: 5985
+epic: 5983
+wave: 1
+fr: FR2
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+source_brainstorm: knowledge-base/project/brainstorms/2026-07-04-gstack-capability-adoption-brainstorm.md
+depends_on: decision-principles classifier (#5984, ADR-084 — MERGED to main as commit 7e5fb720a)
+---
+
+# ✨ feat(wave1): named multi-dimensional plan-review panel (CEO/design/devex)
+
+> **Note:** `lane:` defaulted to `cross-domain` — no `spec.md` exists for this branch to carry `lane:` from (TR fail-closed default).
+
+## Overview
+
+`plan-review` today spawns three **engineering** reviewers (DHH, Kieran, code-simplicity), escalating to five (`+architecture-strategist +spec-flow-analyzer`) when the plan declares the single-user-incident brand-survival threshold. Every lens is engineering-shaped: simplicity, convention, correctness, blast-radius, flow. A plan can be technically immaculate and still be a **product / market / design / developer-experience** mistake — and nothing reviews for that.
+
+This FR wires the **existing** `cpo` / `cmo` / `cto` / `ux-design-lead` agents into `plan-review` as a **named CEO/design/devex panel**, alongside (not replacing) the eng panel. Adapted from gstack's `plan-ceo` / `plan-eng` / `plan-design` / `plan-devex` review split, narrowed for Soleur's non-technical solo-founder operator.
+
+The **load-bearing constraint** (issue AC): the named panel's findings are frequently **taste** — user-visible / money / compliance choices where reasonable operators could disagree. Those MUST route through the **decision-principles classifier** (Mechanical / Taste / User-Challenge — `decision-principles.md`, ADR-084), **never silently auto-applied**. `plan-review` classifies each consolidated finding; the consumer (`plan`) auto-applies only **Mechanical** findings and **surfaces** Taste / User-Challenge ones through the *existing* legible-surface machinery (operator-attached: the "Apply these changes?" gate, User-Challenge with the 5-line frame; headless: persisted to `decision-challenges.md`, which `ship` Phase 6 renders + files as an `action-required` issue). No new pause, no new PR-body author, no new operator-notification path.
+
+### What this is NOT (scope discipline)
+
+- **NOT a duplicate of plan Phase 2.5 Domain Review.** Phase 2.5 runs *during authoring* as a forward **relevance assessment** (which domains matter; spawn leaders to shape the plan). This panel runs *after the plan is finalized* as an adversarial **critique of the finished artifact** through business/design/devex lenses. Different timing, different function (assess vs. review) — the gstack split exists for exactly this reason. The panel **reuses** Phase 2.5's output (the plan's `## Domain Review` section) as its relevance gate rather than re-deriving relevance.
+- **NOT always-run.** The named panel is **relevance-gated** off signals already written into the plan file, so a pure-infra plan pays for at most the devex lens, not four idle C-suite sessions (token-frugal for a solo founder — ADR-053 all-Claude, no new sub-processor).
+- **NOT a new classifier.** It **consumes** ADR-084's taxonomy (becomes its 5th linked consumer); it does not fork or extend the taxonomy's logic.
+
+## Premise Validation (Phase 0.6)
+
+Checked, all held except one correction:
+- **Issue #5985** — OPEN; body confirms "Wire the EXISTING cpo/cmo/cto/ux-design-lead agents … taste calls routed through the classifier, not auto-decided." Not stale.
+- **Epic #5983** — OPEN ("epic: adopt 12 gstack capabilities …").
+- **Dependency (decision-principles classifier)** — the brainstorm chains T1-3 → T1-4. T1-3 landed: `plugins/soleur/skills/brainstorm-techniques/references/decision-principles.md` exists (8190 bytes), **ADR-084 is Accepted**, and `git log` shows `7e5fb720a feat(skills): decision-principles engine (#5984)` on main. **The dependency is satisfied** — this plan builds atop a real, merged classifier, not a promised one.
+- **Mechanism vs. ADR corpus** — the mechanism (reuse ADR-084's `decision-challenges.md` → `ship` Phase 6 render, reuse the existing plan-review workflow, no new consult) is *endorsed* by ADR-084 §Consequences and ADR-083, not sitting in a rejected-alternatives table. The brainstorm's own D3/D4 explicitly reject building new mechanisms. Aligned.
+- **Correction carried from brainstorm:** the all-Claude model policy is **ADR-053**, not ADR-083 (ADR-083 = scoped strong-model consult). This plan cites ADR-053 for the model policy and ADR-084 for the taxonomy.
+
+## 🎯 User-Brand Impact
+
+**If this lands broken, the user experiences:** a `plan-review` run that **silently auto-applies a taste/scope change the operator would have wanted to weigh in on** (e.g. cuts an operator-requested feature on a domain-leader's "YAGNI" say-so) — reshaping their plan without surfacing it — OR a `one-shot` pipeline that **hangs** because a domain-leader agent emitted `AskUserQuestion` in a headless Task subagent that cannot answer it.
+
+**If this leaks, the user's workflow is exposed via:** the classifier-routing regression vector — a mis-classified Taste/User-Challenge finding applied as if Mechanical drops the operator's stated direction silently into the plan → tasks.md → work → PR, without the `decision-challenges.md` / `action-required` surface the operator actually reads. (No data/money egress: all reviewers are Anthropic-bound on operator-plan text already reviewed by the existing panel; no new sub-processor — CLO-confirmed.)
+
+**Brand-survival threshold:** single-user incident.
+
+*Rationale for the threshold (sharpened by CPO sign-off — honest, not ceremony):* the intrinsic blast radius of "a plan comes out subtly wrong" is normally recoverable downstream (review, QA, and — interactive — the "Apply these changes?" gate). What makes it a **single-user incident** is one specific path: **in a headless `one-shot` run there is no interactive apply-gate.** A mis-classified Taste finding that silently drops operator-requested scope rides Mechanical-auto-apply → plan → tasks.md → work → a merged PR that a non-technical founder cannot read-review; their requested capability vanishes, surfacing only at the weekly digest. That is a single-user incident by the exact brand definition. The threshold is earned by the **headless-autonomy × non-technical-operator** combination (which removes the human catch), and it is *honored* by CPO Conditions 1 & 2 (decorrelated activation + named-findings-default-to-Taste) — without them the threshold is asserted, not earned. It buys the 5-agent eng panel + `user-impact-reviewer` at review time. Not justified by data/money blast radius (there is none).
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (issue / brainstorm) | Codebase reality (verified) | Plan response |
+|---|---|---|
+| "Wire cpo/cmo/cto/ux-design-lead into plan-review" | All 4 agents exist: `agents/product/cpo.md`, `agents/marketing/cmo.md`, `agents/engineering/cto.md`, `agents/product/design/ux-design-lead.md` | Reuse via `agentType` (workflow) / `@agent-…` mention (prose) — no new agents. |
+| "taste calls routed through the classifier" | `decision-principles.md` exists; consumed by exactly 4 skills; drift-guarded by `components.test.ts` `CONSUMERS = ["brainstorm-techniques","plan","work","ship"]` (lines 287–310) | Add `plan-review` as the **5th** consumer: link the doc in `plan-review/SKILL.md` **and** add `"plan-review"` to `CONSUMERS`; amend ADR-084's consumer list (4→5). |
+| plan-review has two surfaces | prose `SKILL.md` (default, invoked by `plan` line 667 via `/plan_review`) + opt-in `workflows/plan-review.workflow.js` (REVIEWERS registry, BASELINE_PANEL + THRESHOLD_PANEL) | Edit **both** (AGENTS.md: keep prose+workflow in sync). Prose is load-bearing (what `plan` calls); workflow is parity. |
+| plan applies review findings | `plan/SKILL.md` "Plan Review (Always Runs)" (665–681): "Ask: Apply these changes? (Yes/Partially/Skip)" — **interactive-only, NO headless branch** | The classifier routing IS the missing headless branch: Mechanical→auto-apply; Taste/User-Challenge→surface (attached: gate; headless: `decision-challenges.md`). Fixes a pre-existing gap. |
+| domain leaders can review a plan | cpo/cmo are **orchestrators** whose default mode may emit `AskUserQuestion`; the plan Phase 2.5 Product/UX gate already scopes cpo with "Output a structured advisory — do not use AskUserQuestion." | Reuse that pattern: every named-panel prompt instructs **structured advisory only, NO AskUserQuestion** (Task-subagent text-only; `2026-05-12-task-subagent-prompt-text-only.md`, `2026-04-10-anonymous-task-spawning-loses-agent-context.md`). |
+| plan-review workflow model pins | `workflow-model-pins.test.ts` allows exactly `{"detect-threshold":"sonnet"}` | Named reviewers are C-suite / never-downgrade (ADR-053 tier 3) → stay `inherit`. **No pin changes.** Reuse the existing `detect-threshold` sonnet step to also read relevance (one detect call; no new allowlist entry). |
+
+## Design
+
+### Role → agent → lens mapping
+
+| gstack role | Soleur agent(s) | Panel axis | Lens (what it reviews the finished plan for) |
+|---|---|---|---|
+| `plan-ceo` (business/strategy) | `cpo` + `cmo` | **CEO / business** | cpo: product strategy, positioning, scope-vs-roadmap fit. cmo: market/GTM implications, brand-voice, messaging risk. |
+| `plan-design` | `ux-design-lead` | **design** | user-flow completeness, UX decay, design-taste risk in user-facing surfaces. |
+| `plan-devex` | `cto` | **devex / eng-strategy** | developer/operator experience, maintenance/DX cost, build-vs-buy, ongoing engineering strategy — **distinct** from `architecture-strategist`'s blast-radius/structural lens. |
+| `plan-eng` | DHH / Kieran / code-simplicity (+arch/spec-flow at threshold) | simplification + correctness | **unchanged** — the existing eng panel. |
+
+### Relevance gate (INDEPENDENT assessment — decorrelated from the authoring miss)
+
+**CPO Condition 1 (correlated-failure fix):** the named panel exists to catch what plan Phase 2.5 got wrong — so it MUST NOT trust Phase 2.5's `## Domain Review` verdict as its trigger. If Phase 2.5 mis-judges a UI plan `Product: NONE`, a panel that reads that verdict inherits the exact miss (the forward gate and the backward critique correlate-fail on the same misjudgment). Relevance is therefore computed by an **independent** assessment of the plan's actual content, with the Domain Review section used only as a *hint*, never as the sole gate:
+
+1. **Mechanical UI-surface scan (independent):** scan the plan's `## Files to Create` + `## Files to Edit` against the UI-surface glob superset (`components/**/*.tsx`, `app/**/page.tsx`, `app/**/layout.tsx`, and the shared UI-term list). Any hit → force `ux-design-lead` + `cpo` active regardless of the Domain Review verdict.
+2. **Fresh relevance read (independent):** the Load-phase detect step judges relevance from the plan *body* (Overview, Files, User-Brand Impact), not by parsing "Domains relevant: none": product/scope language → `cpo`; market/GTM/brand/user-copy language → `cmo`; user-facing/flow/visual language → `ux-design-lead`; code/infra/tooling Files-to-Edit → `cto`.
+3. **Threshold bias:** when `Brand-survival threshold: single-user incident` is declared, bias toward activating (the eng panel already escalated; stakes are high) — mirroring the existing 5-agent escalation that fires on the impact threshold *regardless* of Domain Review.
+4. If **none** activate (trivial non-engineering docs plan), only the eng panel runs — preserving today's behavior.
+
+*Worked example — THIS plan:* the independent scan finds no UI-surface file and no user-facing/product/market surface in the body (plugin-tooling only); it has plugin-tooling Files-to-Edit ⇒ only the **devex (`cto`)** lens activates. cmo/cpo/ux stay idle — reached via the *independent* path (not by trusting the "Product NONE" verdict), so a genuine Phase-2.5 misjudgment on some *other* plan would not be inherited here.
+
+### Classifier routing (the load-bearing AC)
+
+`plan-review` consolidation tags each consolidated decision with `decisionClass ∈ {mechanical, taste, user-challenge}` per `decision-principles.md`, routing through ADR-084's **four never-Mechanical classes** (dropping operator-requested scope; new sub-processor/paid dep; new recurring cost; irreversible data op) — NOT a fresh classification path (**CPO Condition 2**):
+
+- Eng-panel correctness/simplification findings (bug, convention-drift, flow-gap, blast-radius) → **Mechanical** (one right answer / purely-technical) — **auto-appliable**. Exception: a `simplify-cut` of **operator-requested scope** is never-Mechanical (class 1) → Taste/User-Challenge.
+- **Named-panel findings default to Taste** (fail-safe): a cpo/cmo/ux/cto finding touching **user-visible / money / scope** is Taste unless it is *clearly* Mechanical (a factual/typo/broken-link correction). Product/market/design findings are almost never Mechanical — the classifier must bias them to **surface**, never silently auto-apply. This is the single safety point of the whole feature; on ambiguity it fails toward `decision-challenges.md`.
+- Any finding arguing the operator's **stated scope/direction** should change (drop/merge/split/add) → **User-Challenge** — never auto-decide; 5-line frame.
+- **Security/feasibility regression** → the ADR-084 sanctioned exception: attached → urgent `AskUserQuestion`; headless → terminal halt before merge + `action-required`+`security` issue.
+
+**Single-signal context (important):** `plan-review` is NOT one of ADR-084's two "both-signals" consult gates (`plan` Step 4.5, `ship` Phase 5.5). It classifies with a **single** signal (the consolidator's judgment). Per `decision-principles.md`, ambiguity biases to the more-surfaced class (unsure Taste-vs-User-Challenge → treat as User-Challenge). The full both-signals User-Challenge adjudication stays owned by `plan` Step 4.5, which fires the second signal and writes the *same* `decision-challenges.md` artifact — so plan-review's surfaced findings and Step 4.5's converge into one artifact `ship` renders. The plan-review edit does **not** add a second consult (no cost/latency creep — `decision-principles.md` §"Both signals").
+
+### Consumer routing (`plan` "Plan Review (Always Runs)" apply step)
+
+- **Mechanical** → auto-apply to the plan file (both modes).
+- **Taste + User-Challenge** →
+  - *Operator-attached* (real TTY): present at the existing "Apply these changes?" gate; a User-Challenge uses the 5-line frame. (No new pause — the gate already exists.)
+  - *Headless* (`HEADLESS_MODE`, no-TTY, `/soleur:one-shot`, `--headless`, OR plan-file-path arg): auto-apply Mechanical; **persist** Taste + User-Challenge to `knowledge-base/project/specs/<branch>/decision-challenges.md` (append); never pause. `ship` Phase 6 already renders it + files the `action-required` issue. Mirrors the existing Step 4.5 wiring at `plan/SKILL.md:574` and the mode predicate at `plan/SKILL.md:330`.
+
+## Implementation Phases
+
+Ordered **contract-producer before consumer** (`2026-05-10-plan-phase-order-load-bearing-when-contract-changes.md`): plan-review produces classified findings; `plan` consumes them.
+
+### Phase 1 — Drift-guard first (RED), then producer wiring (`plan-review` prose)
+1. **(RED)** `plugins/soleur/test/components.test.ts` — add `"plan-review"` to the `CONSUMERS` array (line 291). Run the suite: the new `plan-review links decision-principles.md` case **fails** (plan-review/SKILL.md has no link yet).
+2. **(GREEN)** `plugins/soleur/skills/plan-review/SKILL.md` — add, after the existing threshold paragraph:
+   - A **Named CEO/design/devex panel** section: the role→agent→lens table, the **relevance gate** (read the plan's `## Domain Review` + Product/UX tier), and the instruction that every named-panel reviewer is prompted for **structured advisory only — NO `AskUserQuestion`** (Task-subagent text-only).
+   - A **Classifier routing** paragraph: consolidation tags each finding `mechanical | taste | user-challenge` per **[decision-principles.md](../brainstorm-techniques/references/decision-principles.md)** (this markdown link satisfies the `CONSUMERS` guard); Taste/User-Challenge findings are **surfaced/persisted by the consumer, never auto-applied**; note the single-signal context + security/feasibility exception.
+   - **Do NOT edit the `description:` frontmatter** (cumulative skill-description budget is ~1798/1800 words; adding words would require sibling-trim surgery — out of scope). Re-run `bun test plugins/soleur/test/components.test.ts` to confirm the word-budget test still passes after the body edit.
+
+### Phase 2 — Consumer wiring (`plan` "Plan Review (Always Runs)")
+3. `plugins/soleur/skills/plan/SKILL.md` (665–681) — rewrite the apply step to branch on `decisionClass`:
+   - Present consolidated feedback (agreements first).
+   - **Mechanical** findings → auto-apply.
+   - **Taste / User-Challenge** → attached: surface at the "Apply these changes?" gate (5-line frame for User-Challenge); **headless** (reuse the mode predicate at `:330`): persist to `decision-challenges.md`, never pause.
+   - Add the named panel to the reviewer bullet list (currently only DHH/Kieran/simplicity) with a one-line "relevance-gated" note.
+   - Cross-reference the existing Step 4.5 `decision-challenges.md` wiring (`:574`) so the two converge on one artifact.
+
+### Phase 3 — Workflow parity (`plan-review.workflow.js`)
+4. `plugins/soleur/skills/plan-review/workflows/plan-review.workflow.js`:
+   - Add `cpo`/`cmo`/`cto`/`ux-design-lead` to the `REVIEWERS` registry (`panel: 'named'`, per-lens `lens` strings, distinct `cto` lens vs `architecture`).
+   - Extend the **Load-phase `detect` step** (already `sonnet`-pinned, mechanical) to *also* return the relevance signals (`productRelevant`, `marketingRelevant`, `uxTier`, `engineeringRelevant`) read from the plan's `## Domain Review` — **one** detect call, no new pin/allowlist entry. Compute `NAMED_PANEL` from those signals.
+   - Add `decisionClass` (enum `mechanical|taste|user-challenge`) to `REVIEW_SCHEMA.findings` and `CONSOLIDATION_SCHEMA.decisions`; extend `consolidatePrompt` with the classify + never-auto-apply-taste rule + the single-signal caveat.
+   - Instruct named reviewers (in `reviewPrompt`) to emit **structured advisory only — no AskUserQuestion**.
+   - Update `meta.description` and the **API-budget disclosure comment** for the new (relevance-gated, ≤ eng + 4 named + 1 consolidator) panel size; named reviewers stay `inherit` (never-downgrade).
+
+### Phase 4 — ADR amendment
+5. `knowledge-base/engineering/architecture/decisions/ADR-084-…md` — amend §Decision-1 and §Consequences: consumer list `brainstorm-techniques, plan, work, ship` → **+ `plan-review`** ("4 consumers" → "5 consumers"); one-line note that plan-review consumes the taxonomy to classify *review findings* (a finding-classification use, adjacent to the skills that classify their own intermediate decisions). Status stays Accepted (extension, not reversal).
+
+## 📁 Files to Edit
+
+- `plugins/soleur/test/components.test.ts` — `CONSUMERS` array `+= "plan-review"` (line 291). **RED first.**
+- `plugins/soleur/skills/plan-review/SKILL.md` — named panel section + classifier-routing paragraph + `decision-principles.md` markdown link. **Do NOT touch `description:`.**
+- `plugins/soleur/skills/plan/SKILL.md` — "Plan Review (Always Runs)" apply step: `decisionClass` branch + headless arm; add named panel to the reviewer list.
+- `plugins/soleur/skills/plan-review/workflows/plan-review.workflow.js` — REVIEWERS registry, relevance detection, `decisionClass` schema fields, consolidate prompt, meta/budget comment.
+- `knowledge-base/engineering/architecture/decisions/ADR-084-decision-classification-taxonomy-for-autonomous-question-surfacing.md` — consumer list 4→5.
+
+## 📁 Files to Create
+
+- `knowledge-base/project/specs/feat-one-shot-5985-plan-review-panel/tasks.md` — generated by the plan skill's Save Tasks step (derived from this plan, post-review).
+- *(this plan file)*
+
+No new agents, skills, hooks, migrations, workflows, or infra.
+
+## ✅ Acceptance Criteria (Pre-merge / PR)
+
+1. `plugins/soleur/skills/plan-review/SKILL.md` names all four agents (`cpo`, `cmo`, `cto`, `ux-design-lead`) and maps them to the CEO/design/devex axes: `grep -c` for each agent token ≥ 1.
+2. Named-panel activation is **relevance-gated** (not always-on): plan-review/SKILL.md prose states the gate reads the plan's `## Domain Review` + Product/UX tier, and the workflow computes `NAMED_PANEL` from the detect step's relevance fields. `grep -n "Domain Review" plugins/soleur/skills/plan-review/SKILL.md` returns ≥ 1.
+3. Every named-panel reviewer is instructed **structured advisory only, no AskUserQuestion**: `grep -in "AskUserQuestion" plugins/soleur/skills/plan-review/SKILL.md plugins/soleur/skills/plan-review/workflows/plan-review.workflow.js` shows the prohibition (a "do not / no AskUserQuestion" instruction), not a use.
+4. `plan-review/SKILL.md` links `decision-principles.md` via a markdown link matching `/\]\([^)]*decision-principles\.md\)/`, AND `"plan-review"` is in the `CONSUMERS` array of `components.test.ts`. **`bun test plugins/soleur/test/components.test.ts` passes** (the `plan-review links decision-principles.md` case is GREEN).
+5. `plan-review` consolidation output carries a `decisionClass` (mechanical|taste|user-challenge) per finding: the workflow `REVIEW_SCHEMA` and/or `CONSOLIDATION_SCHEMA` include a `decisionClass` enum property (`grep -n "decisionClass" …workflow.js` ≥ 1), and the prose states taste findings are never auto-applied.
+6. `plan/SKILL.md` "Plan Review (Always Runs)" apply step branches on the class **and has a headless arm**: it auto-applies Mechanical and persists Taste/User-Challenge to `decision-challenges.md` in headless. `grep -n "decision-challenges\|Mechanical\|headless" plugins/soleur/skills/plan/SKILL.md` shows all three within the Plan-Review section.
+7. **No new model pins**: `bun test plugins/soleur/test/workflow-model-pins.test.ts` passes with the allowlist unchanged (`plan-review` still only `{"detect-threshold":"sonnet"}`).
+8. **Skill-description budget intact**: `bun test plugins/soleur/test/components.test.ts` word-budget assertion passes (no `description:` frontmatter was edited).
+9. ADR-084 consumer list reads 5 consumers including `plan-review`: `grep -n "plan-review" knowledge-base/engineering/architecture/decisions/ADR-084-*.md` ≥ 1.
+10. **Full suite green**: `bash scripts/test-all.sh` (or the repo's canonical suite) passes — catches any orphan drift-guard the named greps miss.
+11. **Independent activation (deterministic, no live agents — CPO Condition 1):** the panel-composition computation is driven by an *independent* content scan, not by parsing the plan's `## Domain Review` verdict line. Fixture proof: a plan whose body declares `Product: NONE` but whose `## Files to Edit` contains a `components/**/*.tsx` path STILL activates `ux-design-lead` + `cpo` (the verdict does not suppress the mechanical UI-surface hit). A pure plugin-tooling fixture activates only `cto`.
+12. **Each named lens is exercised (CPO Condition 3 — anti-rot):** across the fixtures, activation of **each** of the four named lenses (`cpo`, `cmo`, `cto`, `ux-design-lead`) is asserted at least once, so a broken REGISTRY entry or gate for any single lens fails CI — without spawning live agents.
+13. **Classifier fail-safe (CPO Condition 2):** the consolidation prose/schema states that named-panel findings touching user-visible/money/scope **default to Taste** and are never tagged Mechanical on ambiguity; `grep -in "default to Taste\|never.*auto-appl\|never-Mechanical" plugins/soleur/skills/plan-review/SKILL.md` returns ≥ 1.
+
+## 🧪 Test Scenarios
+
+- **Pure-infra plan (Domain Review = none):** only eng panel + devex(`cto`) run; cmo/cpo/ux idle. Eng correctness findings classify Mechanical → auto-apply.
+- **User-facing plan (Product + UX blocking):** full named panel activates. A cpo "cut this operator-requested feature" finding classifies **User-Challenge** → NOT auto-applied; headless → written to `decision-challenges.md`; attached → 5-line frame at the gate.
+- **cmo "brand-voice risk in this user copy" finding:** Taste → surfaced, not auto-applied.
+- **A named reviewer that would ask a question:** prompt forbids `AskUserQuestion`; agent returns structured text; pipeline does not hang.
+- **Delete-over-fix still fires:** when the simplification panel and correctness panel both fire on one scope, consolidation still prefers delete (unchanged behavior; named panel is additive/orthogonal).
+
+## Domain Review
+
+**Domains relevant:** none (Engineering-internal tooling)
+
+This is an orchestration change to the planning/review skills — no user-facing surface. Per the plan skill's own rule, "a plan that discusses UI concepts but implements orchestration changes (e.g., adding a UX gate to a skill) is NONE." The mechanical UI-surface override does not fire: Files-to-Create/Edit contain no `components/**/*.tsx`, `app/**/page.tsx`, or `app/**/layout.tsx`.
+
+### Product/UX Gate
+
+**Tier:** none — no UI surface created or modified.
+
+### CPO sign-off (threshold-driven — `requires_cpo_signoff: true`)
+
+The brainstorm spawned CTO + CLO (not CPO — it scoped Product out as internal tooling). Because this plan declares `single-user incident`, the plan-time CPO sign-off gate fires. CPO was invoked in-session for a scoped sign-off on the four approach decisions.
+
+**CPO verdict: approve-with-conditions.** The three conditions are **folded into this plan**:
+- **Condition 1 (correlated-failure) → applied** in the revised Relevance gate: the panel computes relevance by an *independent* content scan, not by trusting Phase 2.5's `## Domain Review` verdict (which is the very authoring step it exists to catch).
+- **Condition 2 (classifier is the single safety point) → applied** in the revised Classifier routing: named-panel findings **default to Taste** and route through ADR-084's four never-Mechanical classes, never a fresh path.
+- **Condition 3 (lens rot) → applied** as AC12: the deterministic panel-composition fixtures must exercise activation of **each** of the four named lenses at least once, so a broken registry/gate for any lens fails CI without live agents.
+- Condition 4 (operator-triage volume) and Condition 5 (cpo double-spend on product-heavy plans) are noted in Risks — flagged, accepted; no design change.
+
+CPO also confirmed the threshold is **honestly warranted, not inflated** — earned specifically by the headless-autonomy × non-technical-operator path (see User-Brand Impact). CLO's brainstorm finding (Anthropic-only, no new sub-processor, no privacy-doc/Art.30/SCC churn) carries forward. CTO concerns (shared-surface blast radius) do not apply to FR2 (touches no hook/loader).
+
+## 🏛️ Architecture Decision (ADR/C4)
+
+### ADR
+**Amend ADR-084** (do not author a new ADR): add `plan-review` to the consumer list (§Decision-1, §Consequences: "4 consumers" → "5 consumers"). This is an **extension** of an Accepted ADR (a new taxonomy consumer), not a new architectural decision or a reversal — the taxonomy logic, mode-branching, and both-signals scope are unchanged. Reusing the existing consult gates and `decision-challenges.md` artifact means no new substrate/trust/tenancy boundary is introduced. Amend in this feature's lifecycle (in-scope task, Phase 4) — **not** a deferred issue (`wg-architecture-decision-is-a-plan-deliverable`).
+
+### C4 views
+**No C4 impact.** Verified by reading all three model files (`knowledge-base/engineering/architecture/diagrams/{model.c4,views.c4,spec.c4}`). Enumeration checked against the change:
+- **External human actors:** none — no new human role (internal agent↔skill wiring for the existing solo-founder/agent).
+- **External systems / vendors:** none — all-Claude (ADR-053), no new sub-processor (CLO-confirmed).
+- **Containers / data-stores:** none new — `decision-challenges.md` is an existing artifact under `specs/`.
+- **Access relationships:** none changed — no user↔surface access boundary moves.
+- `plan-review` is **not** a modeled C4 component (the modeled skill components are `brainstorm/plan/work/review/compound/ship/one-shot/architecture` at `model.c4:95–123`; `review` at `:107` is the *code*-review skill's 8-reviewer component, unrelated). The model carries no per-reviewer wiring edge at this granularity, so wiring four existing agents into a non-modeled skill changes no view.
+
+*Implementer note:* re-read all three `.c4` before concluding, and if any edit touches them, run `apps/web-platform/test/c4-code-syntax.test.ts` + `c4-render.test.ts`. Expected: no `.c4` edit needed.
+
+### Sequencing
+The ADR amendment is true immediately on merge (no soak gate). Author in Phase 4, same PR.
+
+## 📡 Observability
+
+**Gate does not fire** — Files-to-Edit are prose `SKILL.md` / `.md` (ADR) / a `test.ts` / a `.workflow.js` under `skills/*/workflows/` (not `plugins/*/scripts/`, not `apps/*/server|src|infra`), and no new infrastructure surface is introduced (Phase 2.8 trigger set does not match). No new server error path, cron, or runtime process.
+
+The workflow's existing structured `log()` telemetry (panel composition, reviewers, findings, delete-over-fix outcome) is the discoverability surface; Phase 3 **extends** it to report the named-panel size + per-`decisionClass` counts (mechanical/taste/user-challenge). Discoverability test (no ssh): `bun test plugins/soleur/test/components.test.ts plugins/soleur/test/workflow-model-pins.test.ts` — a green run confirms the wiring; the workflow report object surfaces the panel + class counts to any caller.
+
+## Open Code-Review Overlap
+
+**None.** `gh issue list --label code-review --state open` cross-checked against every Files-to-Edit path (`plan-review/SKILL.md`, `plan-review.workflow.js`, `plan/SKILL.md`, `components.test.ts`, `ADR-084`, `decision-principles`) — zero matches.
+
+## 🛡️ Risks & Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| **Correlated failure** — panel trusts the Phase-2.5 verdict it exists to catch | High | Independent content-scan gate (Relevance gate + AC11). |
+| **Classifier mis-tags a taste finding Mechanical** → silent scope-drop in headless | High | Named findings default to Taste; route through ADR-084 four never-Mechanical classes; single-user-incident review + `user-impact-reviewer` (AC13). |
+| **Operator-triage volume** (CPO Condition 4) — a chatty named panel files many `action-required` issues into the founder's weekly digest | Medium | Consolidation already dedupes into one decision set per scope; `ship` files **one** idempotent `decision-challenge` issue per branch (existing ADR-084 behavior). Flag only — if volume proves noisy post-adoption, add a per-run surface cap in a follow-up; do NOT design a cap now (YAGNI). |
+| **cpo double-spend** (CPO Condition 5) — cpo runs at Phase 2.5 AND in the panel on product-heavy plans | Low | Accepted: assess-during-authoring vs. critique-finished-artifact catch different things; the post-hoc critique earns its cost at single-user-incident threshold. |
+| **Named reviewer hangs `one-shot`** via `AskUserQuestion` | High | Prompt forbids it (structured advisory only); AC3 greps the prohibition. |
+
+## ⚠️ Sharp Edges
+
+- **`## User-Brand Impact` must stay filled** — an empty/placeholder section fails `deepen-plan` Phase 4.6 and `ship` preflight Check 6. It is filled above with `single-user incident`.
+- **Skill-description budget is at the cap** (~1798/1800). Do NOT add any word to `plan-review/SKILL.md`'s `description:` frontmatter — all new prose goes in the body. Re-run the `components.test.ts` word-budget assertion after every SKILL.md edit.
+- **Domain leaders self-answer `AskUserQuestion` in a subagent** — cpo/cmo default to orchestrator mode. Every named-panel prompt MUST carry the "structured advisory only, no AskUserQuestion" instruction *in the prompt text* (the agent `.md` body doesn't reach anonymous Task spawns — `2026-04-10-anonymous-task-spawning-loses-agent-context.md`). Omitting it hangs `one-shot`.
+- **Persisting a challenge record targets `ship`, not `work`/`plan`** — `plan-review` and `plan` only *append* to `decision-challenges.md`; `ship` Phase 6 is the sole PR-body author and the sole filer of the `action-required` issue. Do not add a `gh pr edit --body` to plan-review/plan (`2026-07-04-plan-persisting-a-record-into-the-pr-body-must-target-ship-not-work.md`).
+- **`decisionClass` is a single-signal classification here** — plan-review is not an ADR-083 both-signals consult gate. Do NOT add a per-review `fable`→`opus` consult (cost/latency creep; `decision-principles.md` §"Both signals" forbids new per-decision consults). The both-signals adjudication stays in `plan` Step 4.5.
+- **Keep prose and workflow in sync** — both `plan-review/SKILL.md` and `plan-review.workflow.js` get the named panel + classifier routing (AGENTS.md plugin note). The prose is what `plan` actually invokes; the workflow is opt-in parity.
+- **`cto` devex lens ≠ `architecture-strategist` structural lens** — give `cto` a distinct `lens` string (DX / maintenance / build-vs-buy / eng-strategy) so the two don't produce duplicate blast-radius findings.
+
+## 🔀 Alternative Approaches Considered
+
+| Alternative | Rejected because |
+|---|---|
+| Always-run the full 4-agent named panel | Wasteful for a solo founder — a pure-infra plan would spawn 4 idle C-suite sessions. Relevance-gating reuses signals the plan already carries. |
+| Build a new operator-notification path for surfaced taste findings | ADR-084's `decision-challenges.md` → `ship` Phase 6 render + `action-required` issue already exists and is the only surface `operator-digest` harvests. Reuse it. |
+| Add plan-review as an ADR-083 both-signals consult gate | Would balloon the scoped 2-gate consult into per-review cost/latency creep. Single-signal classification + `plan` Step 4.5's existing second signal suffice. |
+| Author a new ADR for this feature | It extends ADR-084 (a new consumer), it does not make a new architectural decision. Amend, don't proliferate. |
+| Fold the named lenses into plan Phase 2.5 instead of plan-review | Phase 2.5 is forward relevance-assessment during authoring; this is post-hoc critique of the finished plan. Different function; gstack separates them deliberately. |
+
+## Non-Goals (deferred — file tracking issues per the plan checklist)
+
+- Wave-1 siblings T1-3 (done, #5984) and T3-12 (operator velocity metrics) — separate FRs.
+- Waves 2–4 (redaction hardening, context-injection, taste-learning, docs/PDF, canary/vitals) — separate issues under epic #5983.
+- A dedicated content-presence drift-guard asserting the named-panel prose exists — **intentionally not added** (content-presence tests "pass by construction and false-fail on a good-faith reword" per the components.test.ts contract). The `CONSUMERS` link guard is the load-bearing gate.
+
+## Resume
+
+```
+/soleur:work knowledge-base/project/plans/2026-07-04-feat-named-plan-review-panel-plan.md
+Context: branch feat-one-shot-5985-plan-review-panel, issue #5985, epic #5983 Wave 1 FR2. Plan written; decision-principles dependency (#5984) already merged. Implementation next.
+```

--- a/knowledge-base/project/specs/feat-one-shot-5985-plan-review-panel/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-5985-plan-review-panel/session-state.md
@@ -1,0 +1,18 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-04-feat-named-plan-review-panel-plan.md
+- Status: complete (plan body + deepen-plan on disk; subagent's Session Summary emission was garbled but the 264-line deepened artifact is intact with all required sections)
+
+### Errors
+- Planning subagent's final message returned a mid-stream snippet ("DHH is still running") instead of the `## Session Summary` block. Recovered by reading the on-disk artifact directly — plan is complete (frontmatter, Overview, Premise Validation, User-Brand Impact, Research Reconciliation, Design, 4 Implementation Phases, Files to Edit/Create, Acceptance Criteria, Test Scenarios, Domain Review, CPO sign-off, ADR amendment, Observability, Risks, Sharp Edges, Alternatives, Non-Goals, Resume).
+
+### Decisions
+- Wire existing cpo/cmo/cto/ux-design-lead as a **relevance-gated named panel** alongside (not replacing) the eng panel — no new agents.
+- Named-panel findings default to **Taste**; route every consolidated finding through the ADR-084 decision-principles classifier. Only **Mechanical** auto-applies; Taste/User-Challenge surface through existing machinery (interactive apply-gate; headless `decision-challenges.md` → ship Phase 6).
+- Add `plan-review` as the **5th** consumer of decision-principles.md (link doc + add to `CONSUMERS` in components.test.ts + amend ADR-084 4→5).
+- Edit **both** surfaces: prose `plan-review/SKILL.md` (load-bearing — what `plan` invokes) and `plan-review.workflow.js` (opt-in parity).
+- Brand-survival threshold `single-user incident`, earned by headless-autonomy × non-technical-operator (no interactive catch); `requires_cpo_signoff: true`.
+
+### Components Invoked
+- soleur:plan, soleur:deepen-plan (via isolated general-purpose planning subagent)

--- a/plugins/soleur/AGENTS.md
+++ b/plugins/soleur/AGENTS.md
@@ -67,9 +67,17 @@ plugin components — the skill loader does not recurse into subdirectories, so
 they are not counted in README component tables. Each script is **self-contained**
 (the Workflow runtime has no filesystem/import access, so shared helpers like
 `safeTitle`/`safeId` are duplicated per script by design — keep the metacharacter
-sets identical across copies). The parent `SKILL.md` links its workflow via an
-opt-in pointer; the prose skill stays the default. Decision record + the full
-migrate-vs-keep inventory: `knowledge-base/project/specs/feat-review-workflow-prototype/spec.md`.
+sets identical across copies). A script cannot be unit-tested by import (top-level
+`await agent(...)`/`return` throws on `import`; `node --check` also false-flags the
+top-level `return` — wrap the body in an async `new Function(...)` to syntax-check).
+So when a script carries decision logic worth a unit test, extract the pure
+function to an importable `lib/*.mjs`, duplicate it into the script, and pin the
+two copies with a **normalized logic-parity drift guard** (a presence grep is
+insufficient — the copy that runs must match the copy that is tested). Example:
+`plan-review/lib/named-panel.mjs` + `test/plan-review-named-panel.test.ts`. The
+parent `SKILL.md` links its workflow via an opt-in pointer; the prose skill stays
+the default. Decision record + the full migrate-vs-keep inventory:
+`knowledge-base/project/specs/feat-review-workflow-prototype/spec.md`.
 
 ### Adding a New Domain
 

--- a/plugins/soleur/skills/plan-review/SKILL.md
+++ b/plugins/soleur/skills/plan-review/SKILL.md
@@ -12,3 +12,33 @@ Have @agent-dhh-rails-reviewer @agent-kieran-rails-reviewer @agent-code-simplici
 When the plan declares `Brand-survival threshold: single-user incident` in its `## User-Brand Impact` section, also include @agent-soleur:engineering:review:architecture-strategist and @agent-soleur:product:spec-flow-analyzer in the parallel batch — the 3-agent baseline catches overengineering and convention drift; the 5-agent panel catches blast-radius and flow gaps.
 
 When consolidating a 5-agent panel's findings, treat the simplification panel (DHH + code-simplicity) and the correctness panel (Kieran + architecture-strategist + spec-flow) as orthogonal axes. **When BOTH panels fire on the same scope, prefer delete over fix** — a feature that simultaneously triggers "too complex, remove" and "has 4 specific bugs" is over-architected; cutting it dissolves the bugs. Many "paper-resolution" findings (FRs added without implementation) vanish when the cuts land. **Why:** 2026-05-11 #2720 plan v1→v2 — 953→829 lines, 4 P0 issues dissolved when the matrix-split cut landed; see `knowledge-base/project/learnings/2026-05-11-five-agent-plan-review-panel-and-architectural-false-trails.md`.
+
+## Named CEO/design/devex panel (relevance-gated)
+
+The eng panel above reviews for engineering quality (simplicity, convention, correctness, blast-radius, flow). A plan can be engineering-immaculate and still be a **product / market / design / developer-experience** mistake. Alongside (never replacing) the eng panel, include a **named panel** of the existing domain leaders — spawned only when the plan is *relevant* to their lens:
+
+| Panel axis | Agent(s) | Lens (reviews the finished plan for) |
+|---|---|---|
+| **CEO / business** | `@agent-soleur:product:cpo` + `@agent-soleur:marketing:cmo` | cpo: product strategy, positioning, scope-vs-roadmap fit. cmo: market/GTM implications, brand-voice, messaging risk. |
+| **design** | `@agent-soleur:product:design:ux-design-lead` | user-flow completeness, UX decay, design-taste risk in user-facing surfaces. |
+| **devex / eng-strategy** | `@agent-soleur:engineering:cto` | developer/operator experience, maintenance/DX cost, build-vs-buy, ongoing engineering strategy — **distinct** from `architecture-strategist`'s blast-radius/structural lens. Give `cto` a devex lens string, not a structural one, so the two do not duplicate. |
+
+**Relevance gate — INDEPENDENT of the plan's own `## Domain Review` verdict.** The named panel exists to catch what plan Phase 2.5 got wrong, so it MUST NOT trust that phase's verdict as its trigger (a UI plan mis-judged `Product: NONE` would inherit the exact miss). Compute activation from an **independent** read of the plan's actual content; use the `## Domain Review` + Product/UX Gate tier only as a *hint*, never as the sole gate:
+
+1. **Mechanical UI-surface scan (independent):** scan the plan's `## Files to Create` + `## Files to Edit` against the UI-surface glob superset (`components/**/*.tsx`, `app/**/page.tsx`, `app/**/layout.tsx`, plus the shared UI-term list). Any hit → force `ux-design-lead` + `cpo` active regardless of the Domain Review verdict.
+2. **Fresh relevance read (independent):** judge relevance from the plan *body* (Overview, Files, User-Brand Impact), not by parsing a "Domains relevant: none" line — product/scope language → `cpo`; market/GTM/brand/user-copy language → `cmo`; user-facing/flow/visual language → `ux-design-lead`; code/infra/tooling Files-to-Edit → `cto`.
+3. **Threshold bias:** when the plan declares `Brand-survival threshold: single-user incident`, bias toward activating (stakes are high — the eng panel already escalated).
+4. If **none** activate (trivial non-engineering docs plan), only the eng panel runs — today's behavior is preserved.
+
+**Every named-panel reviewer is prompted for structured advisory only — NO `AskUserQuestion`.** cpo/cmo default to orchestrator mode and will otherwise emit `AskUserQuestion`, which hangs a headless `one-shot` (a Task subagent cannot answer it, and the agent `.md` body does not reach anonymous Task spawns). The prohibition MUST live in the prompt text, mirroring the plan Phase 2.5 Product/UX gate's "Output a structured advisory — do not use AskUserQuestion."
+
+## Classifier routing (taste findings are surfaced, never silently applied)
+
+Consolidation tags **each** consolidated decision with `decisionClass ∈ {mechanical, taste, user-challenge}` per **[decision-principles.md](../brainstorm-techniques/references/decision-principles.md)** (ADR-084), routing through that doc's **four never-Mechanical classes** (dropping operator-requested scope; a new sub-processor/paid dep; a new recurring cost; an irreversible data op) — not a fresh classification path:
+
+- **Eng-panel** correctness/simplification findings (bug, convention-drift, flow-gap, blast-radius) → **Mechanical** (one right answer / purely-technical), **auto-appliable**. Exception: a `simplify-cut` of **operator-requested scope** is never-Mechanical → Taste / User-Challenge.
+- **Named-panel findings default to Taste** (fail-safe): a cpo/cmo/ux/cto finding touching **user-visible / money / scope** is Taste unless it is *clearly* Mechanical (a factual/typo/broken-link fix). Product/market/design findings are almost never Mechanical — bias them to **surface**, never silently auto-apply. This is the single safety point of the panel; on ambiguity it fails toward surfacing.
+- Any finding arguing the operator's **stated scope/direction** should change (drop/merge/split/add) → **User-Challenge** — never auto-decide.
+- **Security/feasibility regression** → the ADR-084 sanctioned exception: attached → urgent `AskUserQuestion`; headless → terminal halt before merge + an `action-required`+`security` issue.
+
+**Single-signal context.** `plan-review` is NOT one of ADR-084's two "both-signals" consult gates (`plan` Step 4.5, `ship` Phase 5.5); it classifies with a **single** signal (the consolidator's judgment). Per decision-principles.md, ambiguity biases to the more-surfaced class (unsure Taste-vs-User-Challenge → treat as User-Challenge). Do NOT add a per-review strong-model consult here (cost/latency creep — the both-signals adjudication stays owned by `plan` Step 4.5, which writes the *same* `decision-challenges.md` artifact). **The consumer applies the routing** (`plan` "Plan Review (Always Runs)"): Mechanical → auto-apply; Taste / User-Challenge → attached present at the "Apply these changes?" gate (5-line frame for User-Challenge), headless persist to `knowledge-base/project/specs/<branch>/decision-challenges.md` (append; `ship` Phase 6 renders it + files the `action-required` issue). `plan-review` only classifies + appends — it never authors the PR body.

--- a/plugins/soleur/skills/plan-review/lib/named-panel.mjs
+++ b/plugins/soleur/skills/plan-review/lib/named-panel.mjs
@@ -5,11 +5,13 @@
 // to the set of named-panel lenses to spawn. Kept in an importable module so it
 // is testable WITHOUT spawning live agents (AC11/AC12) — the Workflow runtime
 // cannot import (no filesystem/import access), so `plan-review.workflow.js`
-// carries a byte-identical duplicate of `computeNamedPanel` per the
-// self-contained-workflow convention (keep the two copies in sync, like
-// safeTitle/safeId). The drift guard in
-// `plugins/soleur/test/plan-review-named-panel.test.ts` asserts the workflow
-// copy stays wired.
+// carries a LOGIC-IDENTICAL duplicate of `computeNamedPanel` per the
+// self-contained-workflow convention. The drift guard in
+// `plugins/soleur/test/plan-review-named-panel.test.ts` normalizes away
+// comments/export/whitespace and asserts the two function bodies match, so a
+// logic edit to either copy fails CI. (Step 3 of the plan's relevance gate —
+// threshold bias — is applied upstream at the detect prompt, not here, so this
+// stays a pure signals→lenses mapping.)
 //
 // CPO Condition 1 (correlated-failure fix): activation is driven by an
 // INDEPENDENT content scan, never by trusting the plan's own `## Domain Review`

--- a/plugins/soleur/skills/plan-review/lib/named-panel.mjs
+++ b/plugins/soleur/skills/plan-review/lib/named-panel.mjs
@@ -1,0 +1,56 @@
+// ---------------------------------------------------------------------------
+// Named CEO/design/devex panel composition (ADR-084 / #5985).
+//
+// PURE decision function: maps the detect step's INDEPENDENT relevance signals
+// to the set of named-panel lenses to spawn. Kept in an importable module so it
+// is testable WITHOUT spawning live agents (AC11/AC12) — the Workflow runtime
+// cannot import (no filesystem/import access), so `plan-review.workflow.js`
+// carries a byte-identical duplicate of `computeNamedPanel` per the
+// self-contained-workflow convention (keep the two copies in sync, like
+// safeTitle/safeId). The drift guard in
+// `plugins/soleur/test/plan-review-named-panel.test.ts` asserts the workflow
+// copy stays wired.
+//
+// CPO Condition 1 (correlated-failure fix): activation is driven by an
+// INDEPENDENT content scan, never by trusting the plan's own `## Domain Review`
+// verdict — a UI plan mis-judged `Product: NONE` still activates ux+cpo via the
+// mechanical UI-surface hit.
+// ---------------------------------------------------------------------------
+
+// The four named lenses, in stable output order.
+export const NAMED_LENSES = ['cpo', 'cmo', 'cto', 'ux-design-lead']
+
+/**
+ * Compute the named panel from INDEPENDENT relevance signals.
+ *
+ * @param {object} signals
+ * @param {boolean} signals.uiSurfaceHit  - mechanical: `## Files to Create/Edit`
+ *   contains a UI-surface glob (components/**\/*.tsx, app/**\/page.tsx,
+ *   app/**\/layout.tsx, or a shared UI-term path). Overrides the Domain Review
+ *   verdict — this is the correlated-failure fix.
+ * @param {boolean} signals.productSignal - fresh read: product/scope language.
+ * @param {boolean} signals.marketingSignal - fresh read: market/GTM/brand/user-copy language.
+ * @param {boolean} signals.uxSignal - fresh read: user-facing/flow/visual language.
+ * @param {boolean} signals.devexSignal - fresh read: code/infra/tooling Files-to-Edit.
+ * @returns {string[]} activated lens keys, subset of NAMED_LENSES, stable order.
+ */
+export function computeNamedPanel(signals) {
+  const s = signals || {}
+  const active = new Set()
+
+  // Step 1 — mechanical UI-surface scan (independent). A UI-surface hit forces
+  // ux-design-lead + cpo regardless of the Domain Review verdict.
+  if (s.uiSurfaceHit) {
+    active.add('ux-design-lead')
+    active.add('cpo')
+  }
+
+  // Step 2 — fresh independent relevance read (NOT the verdict line).
+  if (s.productSignal) active.add('cpo')
+  if (s.marketingSignal) active.add('cmo')
+  if (s.uxSignal) active.add('ux-design-lead')
+  if (s.devexSignal) active.add('cto')
+
+  // Step 4 — if none activate, the named panel is empty (eng panel still runs).
+  return NAMED_LENSES.filter((k) => active.has(k))
+}

--- a/plugins/soleur/skills/plan-review/workflows/plan-review.workflow.js
+++ b/plugins/soleur/skills/plan-review/workflows/plan-review.workflow.js
@@ -1,25 +1,28 @@
 export const meta = {
   name: 'plan-review-workflow',
   description:
-    'Workflow-backed soleur:plan-review — read the plan, fan a FIXED specialist panel (DHH + Kieran + code-simplicity) in parallel, escalate to a 5-agent panel (+architecture-strategist +spec-flow-analyzer) when the plan declares the single-user-incident brand-survival threshold, then consolidate via the delete-over-fix rule when the simplification and correctness panels both fire on the same scope.',
+    'Workflow-backed soleur:plan-review — read the plan, fan a FIXED eng panel (DHH + Kieran + code-simplicity, +architecture-strategist +spec-flow-analyzer at the single-user-incident threshold) plus a relevance-gated NAMED CEO/design/devex panel (cpo/cmo/ux-design-lead/cto) in parallel, then consolidate via the delete-over-fix rule and tag each decision with a decisionClass (mechanical|taste|user-challenge) per decision-principles.md so taste findings are surfaced, never silently auto-applied.',
   // Phase titles mirror the phase() calls below so progress groups line up.
   phases: [
-    { title: 'Load', detail: 'read the plan file + detect the brand-survival threshold' },
-    { title: 'Review', detail: 'fixed reviewer panel (3 baseline, +2 when the threshold fires), in parallel' },
-    { title: 'Consolidate', detail: 'orthogonal-axis merge with delete-over-fix on co-fired scopes' },
+    { title: 'Load', detail: 'read the plan file + detect the brand-survival threshold + independent relevance signals for the named panel' },
+    { title: 'Review', detail: 'eng panel (3 baseline, +2 at threshold) + relevance-gated named panel (0–4), in parallel' },
+    { title: 'Consolidate', detail: 'orthogonal-axis merge with delete-over-fix on co-fired scopes + decisionClass tagging' },
   ],
 }
 
 // ---------------------------------------------------------------------------
 // API-budget disclosure (per hr-autonomous-loop-skill-api-budget-disclosure).
-// This workflow fans out ONE agent per reviewer in the panel: 3 in the
-// baseline case, 5 when the plan declares the single-user-incident
-// brand-survival threshold, plus 1 consolidation agent — i.e. 4 or 6 agents
-// total per run. Each agent is a real Anthropic API session billed against the
-// session key; BSL-1.1 disclaims runtime/API cost. The panel size is FIXED and
-// reported in the Load phase log before fan-out, so the count is confirmable
-// before any agent spawns. There is no per-item array here — the panel is a
-// small, bounded constant, not an unbounded N.
+// This workflow fans out ONE agent per reviewer in the panel. The ENG panel is
+// 3 (baseline) or 5 (single-user-incident threshold). The relevance-gated NAMED
+// panel adds 0–4 agents (cpo/cmo/ux-design-lead/cto), spawned ONLY when the
+// plan is relevant to the lens (independent content scan — never always-on, so
+// a pure-infra plan pays for at most the devex lens). Plus 1 consolidation
+// agent — i.e. between 4 (baseline, no named) and 10 (threshold + full named)
+// agents total per run. Named reviewers are C-suite / never-downgrade
+// (ADR-053 tier 3) → they stay `inherit`; no new model pin. Each agent is a real
+// Anthropic API session billed against the session key; BSL-1.1 disclaims
+// runtime/API cost. Both panel sizes are computed and reported in the Load phase
+// log before fan-out, so the count is confirmable before any agent spawns.
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
@@ -71,14 +74,70 @@ const REVIEWERS = {
     panel: 'correctness',
     lens: 'spec/flow gaps — FRs added without implementation, missing states, broken user flows',
   },
+  // --- named CEO/design/devex panel (relevance-gated; ADR-084 / #5985) ---
+  // These reviewers critique the FINISHED plan through business/design/devex
+  // lenses. Their findings are frequently TASTE, so consolidation routes them
+  // through decisionClass and never auto-applies. They are C-suite /
+  // never-downgrade (ADR-053 tier 3) → no model pin; they stay `inherit`.
+  cpo: {
+    agentType: 'soleur:product:cpo',
+    panel: 'named',
+    lens: 'product strategy, positioning, scope-vs-roadmap fit — is this the right thing to build for the operator and the roadmap?',
+  },
+  cmo: {
+    agentType: 'soleur:marketing:cmo',
+    panel: 'named',
+    lens: 'market/GTM implications, brand-voice, messaging risk in any user-facing copy the plan introduces',
+  },
+  'ux-design-lead': {
+    agentType: 'soleur:product:design:ux-design-lead',
+    panel: 'named',
+    lens: 'user-flow completeness, UX decay, design-taste risk in user-facing surfaces',
+  },
+  // cto's DEVEX lens is deliberately DISTINCT from architecture-strategist's
+  // structural/blast-radius lens so the two do not produce duplicate findings.
+  cto: {
+    agentType: 'soleur:engineering:cto',
+    panel: 'named',
+    lens: 'developer/operator experience, maintenance/DX cost, build-vs-buy, ongoing engineering strategy — NOT blast-radius/structural (that is architecture-strategist)',
+  },
 }
 
-// FIXED panels. The SCRIPT (not a model) owns who reviews: the 3-agent
+// FIXED eng panels. The SCRIPT (not a model) owns who reviews: the 3-agent
 // baseline catches overengineering and convention drift; the 5-agent panel
 // adds blast-radius (architecture-strategist) and flow gaps (spec-flow-analyzer)
 // when the single-user-incident threshold fires.
 const BASELINE_PANEL = ['dhh-rails', 'kieran-rails', 'code-simplicity']
 const THRESHOLD_PANEL = ['architecture', 'spec-flow']
+
+// ---------------------------------------------------------------------------
+// Named-panel composition (ADR-084 / #5985). DUPLICATE of
+// `../lib/named-panel.mjs` — the Workflow runtime has no import/filesystem
+// access, so the pure decision function is inlined here (self-contained
+// convention, like safeTitle/safeId). Keep this copy BYTE-IDENTICAL to the lib
+// module; the drift guard in test/plan-review-named-panel.test.ts checks the
+// wiring stays present. CPO Condition 1: activation is driven by an INDEPENDENT
+// content scan (the detect step's signals), never by trusting the plan's own
+// `## Domain Review` verdict.
+// ---------------------------------------------------------------------------
+const NAMED_LENSES = ['cpo', 'cmo', 'cto', 'ux-design-lead']
+function computeNamedPanel(signals) {
+  const s = signals || {}
+  const active = new Set()
+  // Step 1 — mechanical UI-surface scan (independent): a UI-surface hit forces
+  // ux-design-lead + cpo regardless of the Domain Review verdict.
+  if (s.uiSurfaceHit) {
+    active.add('ux-design-lead')
+    active.add('cpo')
+  }
+  // Step 2 — fresh independent relevance read (NOT the verdict line).
+  if (s.productSignal) active.add('cpo')
+  if (s.marketingSignal) active.add('cmo')
+  if (s.uxSignal) active.add('ux-design-lead')
+  if (s.devexSignal) active.add('cto')
+  // Step 4 — if none activate, the named panel is empty (eng panel still runs).
+  return NAMED_LENSES.filter((k) => active.has(k))
+}
 
 // ---------------------------------------------------------------------------
 // Schemas — validated at the tool-call layer, so agents retry on mismatch.
@@ -100,9 +159,10 @@ const REVIEW_SCHEMA = {
           title: { type: 'string' },
           severity: { type: 'string', enum: ['P0', 'P1', 'P2', 'P3'] },
           scope: { type: 'string', description: 'the plan section / feature / capability the finding targets (used to detect cross-panel co-fire)' },
-          kind: { type: 'string', enum: ['simplify-cut', 'correctness-bug', 'convention-drift', 'flow-gap', 'blast-radius', 'other'], description: 'classifies the finding so the consolidator can apply delete-over-fix' },
+          kind: { type: 'string', enum: ['simplify-cut', 'correctness-bug', 'convention-drift', 'flow-gap', 'blast-radius', 'product-strategy', 'market-gtm', 'ux-design', 'devex', 'other'], description: 'classifies the finding so the consolidator can apply delete-over-fix (eng) and decisionClass (named)' },
           description: { type: 'string' },
           suggestedChange: { type: 'string' },
+          decisionClass: { type: 'string', enum: ['mechanical', 'taste', 'user-challenge'], description: 'this reviewer\'s suggested class per decision-principles.md (the consolidator adjudicates the final class). Named-panel findings touching user-visible/money/scope default to taste; a finding arguing the operator\'s stated scope should change is user-challenge.' },
         },
       },
     },
@@ -120,7 +180,7 @@ const CONSOLIDATION_SCHEMA = {
       type: 'array',
       items: {
         type: 'object',
-        required: ['scope', 'resolution', 'rationale', 'sourceFindingIds'],
+        required: ['scope', 'resolution', 'rationale', 'sourceFindingIds', 'decisionClass'],
         additionalProperties: false,
         properties: {
           scope: { type: 'string' },
@@ -128,6 +188,7 @@ const CONSOLIDATION_SCHEMA = {
           rationale: { type: 'string' },
           sourceFindingIds: { type: 'array', items: { type: 'string' }, description: 'ids of the reviewer findings this decision consolidates' },
           coFired: { type: 'boolean', description: 'true when BOTH the simplification and correctness panels fired on this scope' },
+          decisionClass: { type: 'string', enum: ['mechanical', 'taste', 'user-challenge'], description: 'per decision-principles.md (ADR-084): mechanical = one right answer, auto-appliable by the consumer; taste = user-visible/money/scope call, surfaced never auto-applied; user-challenge = argues the operator\'s stated direction should change, never auto-decided. Named-panel findings default to taste; on ambiguity bias to the more-surfaced class (unsure taste-vs-user-challenge → user-challenge).' },
         },
       },
     },
@@ -139,15 +200,25 @@ const CONSOLIDATION_SCHEMA = {
 // ---------------------------------------------------------------------------
 function reviewPrompt(key) {
   const r = REVIEWERS[key]
+  const isNamed = r.panel === 'named'
+  const namedGuidance = isNamed
+    ? `
+
+You are a NAMED CEO/design/devex reviewer. TWO hard rules:
+1. **Structured advisory only — do NOT use AskUserQuestion.** Return your findings as structured output; never ask the operator a question. (This runs in a headless Task subagent that cannot answer — an AskUserQuestion would hang the pipeline.)
+2. **Set "decisionClass" on each finding.** Your findings touch user-visible / money / scope, so they DEFAULT to "taste" (surfaced to the operator, never silently auto-applied). Use "user-challenge" for any finding arguing the operator's STATED scope/direction should change (drop/merge/split/add). Reserve "mechanical" only for a clearly factual/typo/broken-link fix. On ambiguity, bias to the more-surfaced class.`
+    : `
+
+Set "decisionClass": eng correctness/simplification findings are "mechanical" (auto-appliable) — EXCEPT a simplify-cut of operator-requested scope, which is "user-challenge".`
   return `You are reviewing an IMPLEMENTATION PLAN (not code) through ONE lens: ${r.lens}.
 
 Read the plan at \`${planPath}\` in full (use your Read tool). Review the PLAN's design, scope, and approach — there is no diff and no code to run.
 
 Report ONLY findings within your lens. For each finding:
 - Assign severity P0 (plan-blocking) / P1 (must address) / P2 (should address) / P3 (nice-to-have).
-- Set "scope" to the specific plan section / feature / capability the finding targets. Be consistent and concrete: a downstream consolidator detects when the simplification panel and the correctness panel BOTH fire on the same scope, so name the scope the same way another reviewer naturally would.
-- Set "kind" to classify the finding (simplify-cut, correctness-bug, convention-drift, flow-gap, blast-radius, other).
-- In "suggestedChange", state the smallest correct change to the PLAN.
+- Set "scope" to the specific plan section / feature / capability the finding targets. Be consistent and concrete: a downstream consolidator detects when panels BOTH fire on the same scope, so name the scope the same way another reviewer naturally would.
+- Set "kind" to classify the finding (simplify-cut, correctness-bug, convention-drift, flow-gap, blast-radius, product-strategy, market-gtm, ux-design, devex, other).
+- In "suggestedChange", state the smallest correct change to the PLAN.${namedGuidance}
 Be precise and conservative. Return an empty findings array if the plan is clean for your lens, and set your overall verdict.`
 }
 
@@ -167,17 +238,25 @@ function consolidatePrompt(reviews, thresholdFired) {
       )
       .join('\n\n') || '(no reviewers in this panel)'
 
+  const hasNamed = byPanel('named').length > 0
   return `You are consolidating a ${reviews.length}-agent plan-review panel into ONE actionable set of decisions for the plan author.
 
-Treat the two panels as ORTHOGONAL AXES:
+Treat the ENG panels as ORTHOGONAL AXES:
 - SIMPLIFICATION panel (DHH + code-simplicity): "is this over-architected? what should be cut?"
 - CORRECTNESS panel (Kieran${thresholdFired ? ' + architecture-strategist + spec-flow' : ''}): "is this right? what are the bugs / convention drift / flow gaps / blast-radius?"
+${hasNamed ? '- NAMED CEO/design/devex panel (cpo/cmo/ux-design-lead/cto): "is this the right thing to build, positioned right, well-designed, and cheap to maintain?" These are business/design/devex critiques of the FINISHED plan.\n' : ''}
+THE DELETE-OVER-FIX RULE (apply it explicitly, ENG panels):
+When BOTH eng panels fire on the SAME scope — i.e. the simplification panel says "too complex, remove" AND the correctness panel raises specific bugs/gaps on that same scope — PREFER DELETE OVER FIX. A feature that simultaneously triggers "remove it" and "it has N specific bugs" is over-architected; cutting it DISSOLVES the bugs. Many correctness findings (e.g. FRs added without implementation) vanish when the cut lands. Precedent: 2026-05-11 #2720 plan v1→v2, 953→829 lines, 4 P0 issues dissolved when the matrix-split cut landed.
 
-THE DELETE-OVER-FIX RULE (apply it explicitly):
-When BOTH panels fire on the SAME scope — i.e. the simplification panel says "too complex, remove" AND the correctness panel raises specific bugs/gaps on that same scope — PREFER DELETE OVER FIX. A feature that simultaneously triggers "remove it" and "it has N specific bugs" is over-architected; cutting it DISSOLVES the bugs. Many correctness findings (e.g. FRs added without implementation) vanish when the cut lands. Precedent: 2026-05-11 #2720 plan v1→v2, 953→829 lines, 4 P0 issues dissolved when the matrix-split cut landed.
+CLASSIFY EACH DECISION with a decisionClass per decision-principles.md (ADR-084) — this is the load-bearing safety rule:
+- "mechanical" = one right answer / purely technical (bug, convention-drift, flow-gap, blast-radius). The consumer AUTO-APPLIES these. EXCEPTION: a simplify-cut of OPERATOR-REQUESTED scope is NOT mechanical → user-challenge.
+- "taste" = a user-visible / money / scope call where reasonable operators could disagree. NAMED-PANEL findings (cpo/cmo/ux/cto) DEFAULT TO TASTE — product/market/design findings are almost never mechanical. The consumer SURFACES these to the operator; it NEVER silently auto-applies them.
+- "user-challenge" = the finding argues the operator's STATED scope/direction should change (drop/merge/split/add). Never auto-decided.
+- This is a SINGLE-SIGNAL classification (your judgment only) — plan-review is NOT one of ADR-084's two both-signals consult gates. On ambiguity, bias to the MORE-SURFACED class (unsure taste-vs-user-challenge → user-challenge). Do NOT invent a second consult.
 
 For each distinct scope:
-- Decide resolution = delete | fix | keep. Set coFired=true when both panels fired on it; for a co-fired scope, default to "delete" and only choose "fix" if cutting the scope is clearly infeasible (state why in rationale).
+- Decide resolution = delete | fix | keep. Set coFired=true when both ENG panels fired on it; for a co-fired scope, default to "delete" and only choose "fix" if cutting the scope is clearly infeasible (state why in rationale).
+- Set decisionClass (mechanical | taste | user-challenge) per the rules above. Never tag a named-panel product/market/design/scope finding "mechanical" on ambiguity.
 - List the sourceFindingIds you are consolidating so dissolved findings are traceable.
 Set deleteOverFixApplied=true if you cut at least one co-fired scope, and write a short author-facing summary.
 
@@ -185,7 +264,8 @@ Set deleteOverFixApplied=true if you cut at least one co-fired scope, and write 
 ${block(byPanel('simplification'))}
 
 === CORRECTNESS PANEL ===
-${block(byPanel('correctness'))}`
+${block(byPanel('correctness'))}
+${hasNamed ? `\n=== NAMED CEO/design/devex PANEL (findings default to taste — surface, do not auto-apply) ===\n${block(byPanel('named'))}` : ''}`
 }
 
 // ---------------------------------------------------------------------------
@@ -223,29 +303,51 @@ phase('Load')
 // Read the plan ONCE via a lightweight agent so the threshold detection is a
 // real read of the file's `## User-Brand Impact` section, not a guess. The
 // agent returns only whether the literal sentinel is present.
-const THRESHOLD_SCHEMA = {
+const DETECT_SCHEMA = {
   type: 'object',
-  required: ['thresholdDeclared'],
+  required: ['thresholdDeclared', 'uiSurfaceHit', 'productSignal', 'marketingSignal', 'uxSignal', 'devexSignal'],
   additionalProperties: false,
   properties: {
     thresholdDeclared: { type: 'boolean', description: `true iff the plan literally declares "${THRESHOLD_SENTINEL}" (in its ## User-Brand Impact section)` },
-    evidence: { type: 'string', description: 'the matching line, or empty if absent' },
+    evidence: { type: 'string', description: 'the matching threshold line, or empty if absent' },
+    // INDEPENDENT relevance signals for the named panel (CPO Condition 1 — do
+    // NOT read the plan's `## Domain Review` verdict line; judge from the actual
+    // content of the Files sections + the plan body).
+    uiSurfaceHit: { type: 'boolean', description: 'true iff `## Files to Create` or `## Files to Edit` contains a UI-surface path (components/**/*.tsx, app/**/page.tsx, app/**/layout.tsx, or an .njk/.html/.vue/.svelte/.astro/email-template path). Judge from the FILE PATHS, not from any "Domains relevant" verdict line.' },
+    productSignal: { type: 'boolean', description: 'true iff the plan BODY (Overview, Files, User-Brand Impact) shows product/scope/roadmap-fit language — a product-strategy call is at stake.' },
+    marketingSignal: { type: 'boolean', description: 'true iff the plan introduces user-facing copy or has market/GTM/brand/messaging implications.' },
+    uxSignal: { type: 'boolean', description: 'true iff the plan touches user-facing flows / visual surfaces / UX.' },
+    devexSignal: { type: 'boolean', description: 'true iff the plan edits code/infra/tooling/build (developer or operator experience is affected).' },
   },
 }
 log('tier pins: detect-threshold→sonnet (mechanical step per ADR-053; reviewers + consolidate inherit the session model)')
 const detect = await agent(
-  `Read the implementation plan at \`${safePlan}\` (use your Read tool). Determine ONLY whether it literally declares the brand-survival threshold sentinel:
-"${THRESHOLD_SENTINEL}"
-(it would appear in a "## User-Brand Impact" section). Return thresholdDeclared=true only on a literal match; do not infer it from tone. Do not review the plan.`,
-  // Pinned 'sonnet': schema-constrained sentinel detection is mechanical (ADR-053).
-  { label: 'detect-threshold', phase: 'Load', schema: THRESHOLD_SCHEMA, model: 'sonnet' },
+  `Read the implementation plan at \`${safePlan}\` (use your Read tool), then return TWO independent judgments. Do NOT review the plan.
+
+1. thresholdDeclared: true ONLY on a LITERAL match of the sentinel
+   "${THRESHOLD_SENTINEL}"
+   (it would appear in a "## User-Brand Impact" section). Do not infer from tone.
+
+2. Relevance signals for a named CEO/design/devex review panel. Judge each INDEPENDENTLY from the plan's actual content — DO NOT read or trust any "Domains relevant: ..." verdict line (that line is the very authoring step this panel exists to double-check):
+   - uiSurfaceHit: does \`## Files to Create\`/\`## Files to Edit\` list a UI-surface path (components/**/*.tsx, app/**/page.tsx, app/**/layout.tsx, .njk/.html/.vue/.svelte/.astro/email template)? Judge from the file paths.
+   - productSignal: product/scope/roadmap-fit call at stake?
+   - marketingSignal: user-facing copy, or market/GTM/brand/messaging implications?
+   - uxSignal: user-facing flows / visual surfaces / UX touched?
+   - devexSignal: code/infra/tooling/build edited (developer/operator experience affected)?`,
+  // Pinned 'sonnet': schema-constrained detection/scan is mechanical (ADR-053).
+  { label: 'detect-threshold', phase: 'Load', schema: DETECT_SCHEMA, model: 'sonnet' },
 )
 
 const thresholdFired = !!detect?.thresholdDeclared
-const panel = thresholdFired ? [...BASELINE_PANEL, ...THRESHOLD_PANEL] : [...BASELINE_PANEL]
+const engPanel = thresholdFired ? [...BASELINE_PANEL, ...THRESHOLD_PANEL] : [...BASELINE_PANEL]
+// Named panel from the INDEPENDENT relevance signals (never the verdict line).
+const namedPanel = computeNamedPanel(detect || {})
+const panel = [...engPanel, ...namedPanel]
 log(
   `Plan: ${safePlan}. Brand-survival threshold ${thresholdFired ? 'DECLARED' : 'absent'} → ` +
-    `${panel.length}-agent panel (${panel.join(', ')}) + 1 consolidator = ${panel.length + 1} agents.`,
+    `eng panel ${engPanel.length} (${engPanel.join(', ')}); named panel ${namedPanel.length}` +
+    `${namedPanel.length ? ` (${namedPanel.join(', ')})` : ' (none — not relevant)'}` +
+    ` + 1 consolidator = ${panel.length + 1} agents.`,
 )
 
 phase('Review')
@@ -286,6 +388,7 @@ if (!reviewResults.length) {
 // Structured summary.
 // ---------------------------------------------------------------------------
 const decisions = consolidation?.decisions || []
+const classCount = (c) => decisions.filter((d) => d.decisionClass === c).length
 const report = {
   plan: safePlan,
   thresholdDeclared: thresholdFired,
@@ -294,6 +397,14 @@ const report = {
     reviewers: panel.map((k) => ({ key: k, agentType: REVIEWERS[k].agentType, panel: REVIEWERS[k].panel })),
     simplification: panel.filter((k) => REVIEWERS[k].panel === 'simplification'),
     correctness: panel.filter((k) => REVIEWERS[k].panel === 'correctness'),
+    named: namedPanel,
+  },
+  relevanceSignals: {
+    uiSurfaceHit: !!detect?.uiSurfaceHit,
+    productSignal: !!detect?.productSignal,
+    marketingSignal: !!detect?.marketingSignal,
+    uxSignal: !!detect?.uxSignal,
+    devexSignal: !!detect?.devexSignal,
   },
   budget: { total: budget.total, spent: budget.spent() },
   totals: {
@@ -305,6 +416,11 @@ const report = {
     deleted: decisions.filter((d) => d.resolution === 'delete').length,
     fixed: decisions.filter((d) => d.resolution === 'fix').length,
     kept: decisions.filter((d) => d.resolution === 'keep').length,
+    // Per-decisionClass counts — the surface the consumer routes on
+    // (mechanical → auto-apply; taste/user-challenge → surface, never auto-apply).
+    mechanical: classCount('mechanical'),
+    taste: classCount('taste'),
+    userChallenge: classCount('user-challenge'),
   },
   deleteOverFixApplied: !!consolidation?.deleteOverFixApplied,
   summary: consolidation?.summary || '(consolidation not run)',
@@ -313,9 +429,11 @@ const report = {
 }
 
 log(
-  `Done: ${reviewResults.length}/${panel.length} reviewers, ${totalFindings} findings → ` +
+  `Done: ${reviewResults.length}/${panel.length} reviewers (eng ${engPanel.length}, named ${namedPanel.length}), ${totalFindings} findings → ` +
     `${decisions.length} decisions (${report.totals.deleted} delete, ${report.totals.fixed} fix, ${report.totals.kept} keep; ` +
-    `${report.totals.coFiredScopes} co-fired). delete-over-fix ${report.deleteOverFixApplied ? 'applied' : 'not triggered'}.`,
+    `${report.totals.coFiredScopes} co-fired). class: ${report.totals.mechanical} mechanical (auto-apply), ` +
+    `${report.totals.taste} taste + ${report.totals.userChallenge} user-challenge (surface, never auto-apply). ` +
+    `delete-over-fix ${report.deleteOverFixApplied ? 'applied' : 'not triggered'}.`,
 )
 
 return report

--- a/plugins/soleur/skills/plan-review/workflows/plan-review.workflow.js
+++ b/plugins/soleur/skills/plan-review/workflows/plan-review.workflow.js
@@ -114,11 +114,12 @@ const THRESHOLD_PANEL = ['architecture', 'spec-flow']
 // Named-panel composition (ADR-084 / #5985). DUPLICATE of
 // `../lib/named-panel.mjs` — the Workflow runtime has no import/filesystem
 // access, so the pure decision function is inlined here (self-contained
-// convention, like safeTitle/safeId). Keep this copy BYTE-IDENTICAL to the lib
-// module; the drift guard in test/plan-review-named-panel.test.ts checks the
-// wiring stays present. CPO Condition 1: activation is driven by an INDEPENDENT
-// content scan (the detect step's signals), never by trusting the plan's own
-// `## Domain Review` verdict.
+// convention, like safeTitle/safeId). Keep this copy LOGIC-IDENTICAL to the lib
+// module: the drift guard in test/plan-review-named-panel.test.ts normalizes
+// away comments/export/whitespace and asserts the two function bodies match, so
+// a logic edit to either copy fails CI. CPO Condition 1: activation is driven by
+// an INDEPENDENT content scan (the detect step's signals), never by trusting the
+// plan's own `## Domain Review` verdict.
 // ---------------------------------------------------------------------------
 const NAMED_LENSES = ['cpo', 'cmo', 'cto', 'ux-design-lead']
 function computeNamedPanel(signals) {
@@ -130,7 +131,10 @@ function computeNamedPanel(signals) {
     active.add('ux-design-lead')
     active.add('cpo')
   }
-  // Step 2 — fresh independent relevance read (NOT the verdict line).
+  // Step 2 — fresh independent relevance read (NOT the verdict line). Step 3
+  // (threshold bias) is applied UPSTREAM at the detect prompt — it nudges the
+  // fuzzy signals toward true when the threshold is declared, keeping this
+  // function a pure, deterministic mapping of signals→lenses (AC11/AC12).
   if (s.productSignal) active.add('cpo')
   if (s.marketingSignal) active.add('cmo')
   if (s.uxSignal) active.add('ux-design-lead')
@@ -209,10 +213,10 @@ You are a NAMED CEO/design/devex reviewer. TWO hard rules:
 2. **Set "decisionClass" on each finding.** Your findings touch user-visible / money / scope, so they DEFAULT to "taste" (surfaced to the operator, never silently auto-applied). Use "user-challenge" for any finding arguing the operator's STATED scope/direction should change (drop/merge/split/add). Reserve "mechanical" only for a clearly factual/typo/broken-link fix. On ambiguity, bias to the more-surfaced class.`
     : `
 
-Set "decisionClass": eng correctness/simplification findings are "mechanical" (auto-appliable) — EXCEPT a simplify-cut of operator-requested scope, which is "user-challenge".`
+Structured advisory only — do NOT use AskUserQuestion (this runs in a headless Task subagent that cannot answer). Set "decisionClass": eng correctness/simplification findings are "mechanical" (auto-appliable) — EXCEPT a simplify-cut of operator-requested scope, which is "user-challenge".`
   return `You are reviewing an IMPLEMENTATION PLAN (not code) through ONE lens: ${r.lens}.
 
-Read the plan at \`${planPath}\` in full (use your Read tool). Review the PLAN's design, scope, and approach — there is no diff and no code to run.
+Read the plan at \`${safePlan}\` in full (use your Read tool). Review the PLAN's design, scope, and approach — there is no diff and no code to run.
 
 Report ONLY findings within your lens. For each finding:
 - Assign severity P0 (plan-blocking) / P1 (must address) / P2 (should address) / P3 (nice-to-have).
@@ -232,7 +236,7 @@ function consolidatePrompt(reviews, thresholdFired) {
           `### ${r.key} (${r.agentType}) — verdict: ${r.verdict}\n` +
           (r.findings.length
             ? r.findings
-                .map((f) => `- [${f.id}] (${f.severity}, ${f.kind}) scope="${f.scope}" :: ${f.title} — ${f.description}${f.suggestedChange ? ` | change: ${f.suggestedChange}` : ''}`)
+                .map((f) => `- [${f.id}] (${f.severity}, ${f.kind}${f.decisionClass ? `, suggested-class:${f.decisionClass}` : ''}) scope="${f.scope}" :: ${f.title} — ${f.description}${f.suggestedChange ? ` | change: ${f.suggestedChange}` : ''}`)
                 .join('\n')
             : '- (no findings)'),
       )
@@ -333,7 +337,9 @@ const detect = await agent(
    - productSignal: product/scope/roadmap-fit call at stake?
    - marketingSignal: user-facing copy, or market/GTM/brand/messaging implications?
    - uxSignal: user-facing flows / visual surfaces / UX touched?
-   - devexSignal: code/infra/tooling/build edited (developer/operator experience affected)?`,
+   - devexSignal: code/infra/tooling/build edited (developer/operator experience affected)?
+
+   Threshold bias: if you set thresholdDeclared=true, resolve any BORDERLINE relevance signal toward true (stakes are high — bias to surfacing a named lens rather than skipping it). Do NOT fabricate a signal with no basis in the plan — a pure-infra plan still activates only devex even at the threshold.`,
   // Pinned 'sonnet': schema-constrained detection/scan is mechanical (ADR-053).
   { label: 'detect-threshold', phase: 'Load', schema: DETECT_SCHEMA, model: 'sonnet' },
 )

--- a/plugins/soleur/skills/plan/SKILL.md
+++ b/plugins/soleur/skills/plan/SKILL.md
@@ -671,7 +671,7 @@ After writing the plan file, automatically run `/plan_review <plan_file_path>` t
 
 **After review completes**, present the consolidated feedback (agreements first, then disagreements), then apply by class:
 
-1. **Mechanical** findings → auto-apply to the plan file (both modes).
+1. **Mechanical** findings → auto-apply to the plan file (both modes). **Fail-closed default:** auto-apply *only* a decision **explicitly tagged `mechanical`**. Treat any decision that is **unclassified, ambiguous, or sourced from a named-panel (product/market/design/devex) finding** as **Taste** — surface it, never silently auto-apply. (The producer defaults named findings to Taste, but the consumer must not depend on producer-side tagging fidelity: an untagged decision on the prose path routes to surfacing, not to auto-apply.)
 2. **Taste / User-Challenge** findings →
    - *Operator-attached* (real TTY): present at the "Apply these changes?" gate below (Yes / Partially / Skip); a **User-Challenge** uses the 5-line frame (the operator's stated direction is the default).
    - *Headless* (reuse the mode predicate at [`plan/SKILL.md` §Product/UX Gate step 4b, ":330"] — `HEADLESS_MODE`, no-TTY, `/soleur:one-shot`, `--headless`, OR a plan-file-path arg): **do NOT pause.** Persist each Taste / User-Challenge to `knowledge-base/project/specs/<branch>/decision-challenges.md` (append), which `ship` Phase 6 renders into the PR body + files as an `action-required` issue. This converges with the Step 4.5 `decision-challenges.md` wiring (`:574`) onto one artifact.

--- a/plugins/soleur/skills/plan/SKILL.md
+++ b/plugins/soleur/skills/plan/SKILL.md
@@ -664,19 +664,24 @@ Examples:
 
 ## Plan Review (Always Runs)
 
-After writing the plan file, automatically run `/plan_review <plan_file_path>` to get feedback from three specialized reviewers in parallel:
+After writing the plan file, automatically run `/plan_review <plan_file_path>` to get feedback from the reviewer panel in parallel:
 
-- **DHH Rails Reviewer** - Challenges overengineering, enforces simplicity
-- **Kieran Rails Reviewer** - Checks correctness, completeness, convention adherence
-- **Code Simplicity Reviewer** - Ensures YAGNI, flags unnecessary complexity
+- **Eng panel (always):** DHH Rails Reviewer (challenges overengineering), Kieran Rails Reviewer (correctness, convention), Code Simplicity Reviewer (YAGNI) — escalating to +architecture-strategist +spec-flow-analyzer at the single-user-incident threshold.
+- **Named CEO/design/devex panel (relevance-gated):** `cpo`/`cmo` (business), `ux-design-lead` (design), `cto` (devex) — spawned only when the plan is relevant to the lens, by an independent content scan (see `plan-review/SKILL.md`). Their findings are frequently **taste**, so `plan-review` tags each consolidated decision `decisionClass ∈ {mechanical, taste, user-challenge}` per [decision-principles.md](../brainstorm-techniques/references/decision-principles.md) (ADR-084).
 
-**After review completes:**
+**After review completes**, present the consolidated feedback (agreements first, then disagreements), then apply by class:
 
-1. Present consolidated feedback (agreements first, then disagreements)
-2. Ask: "Apply these changes?" (Yes / Partially / Skip)
-3. If Yes: apply all changes to the plan file
-4. If Partially: ask which changes to apply, then apply selected changes
-5. If Skip: continue unchanged
+1. **Mechanical** findings → auto-apply to the plan file (both modes).
+2. **Taste / User-Challenge** findings →
+   - *Operator-attached* (real TTY): present at the "Apply these changes?" gate below (Yes / Partially / Skip); a **User-Challenge** uses the 5-line frame (the operator's stated direction is the default).
+   - *Headless* (reuse the mode predicate at [`plan/SKILL.md` §Product/UX Gate step 4b, ":330"] — `HEADLESS_MODE`, no-TTY, `/soleur:one-shot`, `--headless`, OR a plan-file-path arg): **do NOT pause.** Persist each Taste / User-Challenge to `knowledge-base/project/specs/<branch>/decision-challenges.md` (append), which `ship` Phase 6 renders into the PR body + files as an `action-required` issue. This converges with the Step 4.5 `decision-challenges.md` wiring (`:574`) onto one artifact.
+
+**Operator-attached apply gate** (Mechanical already applied above):
+
+1. Ask: "Apply these changes?" (Yes / Partially / Skip)
+2. If Yes: apply all remaining (Taste/User-Challenge) changes to the plan file
+3. If Partially: ask which changes to apply, then apply selected changes
+4. If Skip: continue unchanged
 
 **Why Plan Review runs BEFORE Save Tasks:** `tasks.md` is a derivative breakdown of the plan's phases. If review prompts material changes (phase cuts, deliverable rewrites), generating `tasks.md` beforehand would immediately go stale and require regeneration. Running review first → applying changes → then deriving tasks ensures `tasks.md` reflects the final plan as a single source of truth, and the commit below covers both files in one atomic history entry.
 

--- a/plugins/soleur/test/components.test.ts
+++ b/plugins/soleur/test/components.test.ts
@@ -288,7 +288,7 @@ describe("Decision-principles taxonomy wiring", () => {
   const DOC_REL = "skills/brainstorm-techniques/references/decision-principles.md";
   // Every consumer must reference the doc; markdown-link form only (backtick refs
   // are separately forbidden by "No backtick file references in skills").
-  const CONSUMERS = ["brainstorm-techniques", "plan", "work", "ship"];
+  const CONSUMERS = ["brainstorm-techniques", "plan", "work", "ship", "plan-review"];
   const LINK_RE = /\]\([^)]*decision-principles\.md\)/;
 
   test("decision-principles.md exists", () => {

--- a/plugins/soleur/test/plan-review-named-panel.test.ts
+++ b/plugins/soleur/test/plan-review-named-panel.test.ts
@@ -84,9 +84,39 @@ describe("plan-review named panel composition (pure, no live agents)", () => {
 
 describe("plan-review workflow keeps the named panel wired (drift guard)", () => {
   const src = readFileSync(WORKFLOW, "utf-8");
+  const LIB = resolve(PLUGIN_ROOT, "skills/plan-review/lib/named-panel.mjs");
+  const libSrc = readFileSync(LIB, "utf-8");
+
+  // Extract `NAMED_LENSES = [...]` + `function computeNamedPanel(...)` from a
+  // source file and normalize away comments, the `export` keyword, and
+  // whitespace — so the ONLY thing this compares is the activation logic. The
+  // Workflow runtime cannot import, so the workflow inlines a duplicate of the
+  // lib's decision function (self-contained convention). The lib copy is what
+  // the AC11/AC12 unit tests above exercise; the workflow copy is what actually
+  // runs. This guard fails if the two logic bodies diverge — the copy that runs
+  // must stay behaviorally identical to the copy that is tested.
+  const extractLogic = (source: string): string => {
+    const lenses = source.match(/NAMED_LENSES\s*=\s*\[[^\]]*\]/);
+    const fn = source.match(/function computeNamedPanel\(signals\)\s*\{[\s\S]*?\n\}/);
+    if (!lenses || !fn) return "";
+    const norm = (s: string) =>
+      s
+        .replace(/\/\/[^\n]*\n/g, "\n") // strip line comments
+        .replace(/\s+/g, " ")
+        .trim();
+    return `${norm(lenses[0])} || ${norm(fn[0])}`;
+  };
 
   test("workflow carries the computeNamedPanel duplicate", () => {
     expect(src).toContain("function computeNamedPanel(");
+  });
+
+  test("workflow copy is behaviorally identical to the lib copy (no logic drift)", () => {
+    const workflowLogic = extractLogic(src);
+    const libLogic = extractLogic(libSrc);
+    expect(workflowLogic).not.toBe(""); // both copies must be extractable
+    expect(libLogic).not.toBe("");
+    expect(workflowLogic).toBe(libLogic);
   });
 
   // The four named agents must each be referenced by agentType, or a lens is

--- a/plugins/soleur/test/plan-review-named-panel.test.ts
+++ b/plugins/soleur/test/plan-review-named-panel.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { computeNamedPanel, NAMED_LENSES } from "../skills/plan-review/lib/named-panel.mjs";
+
+// ---------------------------------------------------------------------------
+// Named CEO/design/devex panel composition (ADR-084 / #5985).
+//
+// Deterministic, NO live agents (AC11/AC12): the panel-composition decision is a
+// pure function of the detect step's INDEPENDENT relevance signals. These tests
+// prove the gate does not trust the plan's own `## Domain Review` verdict, and
+// that a broken registry/gate for ANY single lens fails CI.
+// ---------------------------------------------------------------------------
+
+const PLUGIN_ROOT = resolve(import.meta.dir, "..");
+const WORKFLOW = resolve(
+  PLUGIN_ROOT,
+  "skills/plan-review/workflows/plan-review.workflow.js",
+);
+
+describe("plan-review named panel composition (pure, no live agents)", () => {
+  // AC11 — INDEPENDENT activation: a plan whose Domain Review verdict says
+  // Product: NONE but whose Files-to-Edit contains a components/**/*.tsx path
+  // STILL activates ux-design-lead + cpo. The verdict does not suppress the
+  // mechanical UI-surface hit (CPO Condition 1 — correlated-failure fix).
+  test("AC11: UI-surface hit overrides a `Product: NONE` verdict → ux + cpo", () => {
+    const panel = computeNamedPanel({
+      uiSurfaceHit: true, // Files-to-Edit has components/**/*.tsx
+      // Fresh signals all false, mimicking a plan whose verdict said NONE:
+      productSignal: false,
+      marketingSignal: false,
+      uxSignal: false,
+      devexSignal: false,
+    });
+    expect(panel).toContain("ux-design-lead");
+    expect(panel).toContain("cpo");
+  });
+
+  // AC11 — a pure plugin-tooling fixture activates ONLY cto (the worked
+  // example for THIS plan: plugin-tooling Files-to-Edit, no UI surface).
+  test("AC11: pure plugin-tooling plan → only cto", () => {
+    const panel = computeNamedPanel({
+      uiSurfaceHit: false,
+      productSignal: false,
+      marketingSignal: false,
+      uxSignal: false,
+      devexSignal: true,
+    });
+    expect(panel).toEqual(["cto"]);
+  });
+
+  // AC12 — anti-rot: each of the four named lenses is activated by at least one
+  // fixture, so a broken registry entry or gate for any single lens fails CI.
+  test("AC12: each named lens (cpo, cmo, cto, ux-design-lead) activates ≥1×", () => {
+    const activatedAcrossFixtures = new Set<string>();
+    const fixtures = [
+      { uiSurfaceHit: true }, // → ux-design-lead + cpo
+      { marketingSignal: true }, // → cmo
+      { devexSignal: true }, // → cto
+      { productSignal: true }, // → cpo
+      { uxSignal: true }, // → ux-design-lead
+    ];
+    for (const f of fixtures) {
+      for (const lens of computeNamedPanel(f)) activatedAcrossFixtures.add(lens);
+    }
+    for (const lens of NAMED_LENSES) {
+      expect(
+        activatedAcrossFixtures.has(lens),
+        `named lens "${lens}" was never activated across the fixtures — its registry entry or gate is broken.`,
+      ).toBe(true);
+    }
+  });
+
+  test("no signals → empty named panel (eng panel still runs)", () => {
+    expect(computeNamedPanel({})).toEqual([]);
+    expect(computeNamedPanel(undefined)).toEqual([]);
+  });
+
+  test("output is stable-ordered and deduped (uiSurfaceHit + productSignal both → cpo once)", () => {
+    const panel = computeNamedPanel({ uiSurfaceHit: true, productSignal: true });
+    expect(panel).toEqual(["cpo", "ux-design-lead"]);
+  });
+});
+
+describe("plan-review workflow keeps the named panel wired (drift guard)", () => {
+  const src = readFileSync(WORKFLOW, "utf-8");
+
+  test("workflow carries the computeNamedPanel duplicate", () => {
+    expect(src).toContain("function computeNamedPanel(");
+  });
+
+  // The four named agents must each be referenced by agentType, or a lens is
+  // dead. Pairs with the pure-function AC12 (the function names lenses; this
+  // asserts the workflow can actually spawn each).
+  for (const agentType of [
+    "soleur:product:cpo",
+    "soleur:marketing:cmo",
+    "soleur:product:design:ux-design-lead",
+    "soleur:engineering:cto",
+  ]) {
+    test(`workflow references ${agentType}`, () => {
+      expect(src).toContain(agentType);
+    });
+  }
+
+  test("workflow classifies findings with decisionClass", () => {
+    expect(src).toContain("decisionClass");
+  });
+});


### PR DESCRIPTION
## Summary

Wire the existing `cpo`/`cmo`/`cto`/`ux-design-lead` agents into `plan-review` as a **relevance-gated named CEO/design/devex panel** alongside (not replacing) the engineering panel. Each consolidated review decision is tagged `decisionClass ∈ {mechanical, taste, user-challenge}` per [decision-principles.md](../blob/main/plugins/soleur/skills/brainstorm-techniques/references/decision-principles.md) (ADR-084) so that **taste findings are surfaced to the operator, never silently auto-applied**.

Closes #5985 (Wave 1 · FR2 of the gstack capability-adoption epic #5983).

## Changelog

### Plugin
- **plan-review/SKILL.md** — named-panel role→agent→lens table; an **independent** relevance gate (does not trust the plan's own `## Domain Review` verdict — CPO Condition 1); a structured-advisory-only / no-`AskUserQuestion` instruction; and a classifier-routing section (named findings default to Taste; consumer auto-applies only Mechanical).
- **plan-review/lib/named-panel.mjs** — pure `computeNamedPanel(signals)` decision function, importable so panel composition is unit-testable without live agents.
- **plan-review/workflows/plan-review.workflow.js** — named `REVIEWERS` entries (stay `inherit`, no new model pin); the detect step returns independent relevance signals + a threshold bias; `decisionClass` added to the review + consolidation schemas and the consolidate prompt; panel + per-class counts surfaced in the report; a self-contained duplicate of `computeNamedPanel`.
- **plan/SKILL.md** — the "Plan Review (Always Runs)" apply step branches on `decisionClass` with a **fail-closed headless arm**: only decisions explicitly tagged `mechanical` auto-apply; unclassified / ambiguous / named-panel-sourced decisions are surfaced (headless → persisted to `decision-challenges.md`, which `ship` renders + files as an `action-required` issue).
- **components.test.ts** — `plan-review` added to the decision-principles `CONSUMERS` drift guard.
- **plan-review-named-panel.test.ts** — deterministic AC11 (independent activation overrides a `Product: NONE` verdict) + AC12 (each of the four named lenses exercised) fixtures, plus a normalized logic-parity guard pinning the two `computeNamedPanel` copies.
- **plugins/soleur/AGENTS.md** — documented the testable-workflow-logic pattern in the Workflow-scripts convention note.

### Docs
- **ADR-084** — consumer list 4 → 5 (adds `plan-review` as a review-finding classifier).

## Test plan

- [x] `bun test plugins/soleur/test/components.test.ts` — CONSUMERS drift guard green (1249 pass)
- [x] `bun test plugins/soleur/test/plan-review-named-panel.test.ts` — AC11/AC12 + logic-parity guard green
- [x] `bun test plugins/soleur/test/workflow-model-pins.test.ts` — allowlist unchanged (named reviewers stay `inherit`)
- [x] `bash scripts/test-all.sh` — full suite green (144/144 suites)
- [x] Multi-agent review (pattern-recognition, security-sentinel, code-quality, code-simplicity, user-impact) — all findings fixed inline, 0 scope-outs

Generated with [Claude Code](https://claude.com/claude-code)
