### PR TITLE
fix(infra): grant sweep sudoers + harden observability-probe ergonomics (Ref #5934)

### DIFF
--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -84,13 +84,9 @@ write_files:
       Cmnd_Alias INFRA_CONFIG_INSTALL = /usr/local/bin/infra-config-install
       deploy ALL=(root) NOPASSWD: INFRA_CONFIG_INSTALL
 
-      # #5934 / ADR-081 — permits ci-deploy.sh's pre-canary durable substrate
-      # sweep to clear a residual CHARACTER-DEVICE .git/config.lock on
-      # /mnt/data/workspaces (the #5912 worktree-creation wedge). Without it sudo
-      # denies the sweep and the durable fix is a silent no-op (ci-deploy.sh's
-      # `|| true` hides the denial). Pins the exact argv including the resolved
-      # /usr/bin/timeout 60 prefix; no wildcards (sudo-rs safe). Mirror of
-      # deploy-inngest-bootstrap.sudoers — keep the two in sync.
+      # #5934 — char-device sweep grant (full rationale in the mirrored
+      # deploy-inngest-bootstrap.sudoers; keep the two in sync). Pins the exact
+      # argv ci-deploy.sh invokes; no wildcards (sudo-rs safe).
       Cmnd_Alias GIT_LOCK_CHARDEVICE_SWEEP = /usr/bin/timeout 60 /usr/local/bin/git-lock-chardevice-sweep.sh
       deploy ALL=(root) NOPASSWD: GIT_LOCK_CHARDEVICE_SWEEP
     owner: root:root

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -83,6 +83,16 @@ write_files:
       # hardcoded dest allowlist + TOCTOU guards are the security boundary.
       Cmnd_Alias INFRA_CONFIG_INSTALL = /usr/local/bin/infra-config-install
       deploy ALL=(root) NOPASSWD: INFRA_CONFIG_INSTALL
+
+      # #5934 / ADR-081 — permits ci-deploy.sh's pre-canary durable substrate
+      # sweep to clear a residual CHARACTER-DEVICE .git/config.lock on
+      # /mnt/data/workspaces (the #5912 worktree-creation wedge). Without it sudo
+      # denies the sweep and the durable fix is a silent no-op (ci-deploy.sh's
+      # `|| true` hides the denial). Pins the exact argv including the resolved
+      # /usr/bin/timeout 60 prefix; no wildcards (sudo-rs safe). Mirror of
+      # deploy-inngest-bootstrap.sudoers — keep the two in sync.
+      Cmnd_Alias GIT_LOCK_CHARDEVICE_SWEEP = /usr/bin/timeout 60 /usr/local/bin/git-lock-chardevice-sweep.sh
+      deploy ALL=(root) NOPASSWD: GIT_LOCK_CHARDEVICE_SWEEP
     owner: root:root
     permissions: '0440'
 

--- a/apps/web-platform/infra/deploy-inngest-bootstrap.sudoers
+++ b/apps/web-platform/infra/deploy-inngest-bootstrap.sudoers
@@ -49,3 +49,18 @@ deploy ALL=(root) NOPASSWD: INNGEST_START
 # TOCTOU-guards the staged source, so the bare-command grant is the safe form.
 Cmnd_Alias INFRA_CONFIG_INSTALL = /usr/local/bin/infra-config-install
 deploy ALL=(root) NOPASSWD: INFRA_CONFIG_INSTALL
+
+# #5934 / ADR-081 — permits ci-deploy.sh's pre-canary durable substrate sweep
+# (`sudo timeout 60 /usr/local/bin/git-lock-chardevice-sweep.sh`) to run as root.
+# The sweep clears any residual CHARACTER-DEVICE .git/config.lock the container
+# substrate leaves on /mnt/data/workspaces, which otherwise wedges worktree
+# creation for every agent session (#5912). WITHOUT this grant sudo denies the
+# sweep ("command not allowed") and the durable remediation is a SILENT no-op —
+# ci-deploy.sh's `|| true` swallows the denial, so the wedge persists into live
+# sessions and #5934's soak probe never sees a DONE marker. The alias pins the
+# EXACT argv ci-deploy.sh invokes, including the resolved `/usr/bin/timeout 60`
+# prefix (sudo matches the full resolved command) — no wildcards, sudo-rs safe.
+# The `timeout 60` value is COUPLED to ci-deploy.sh's invocation; the two must
+# change in lockstep (git-lock-chardevice-sweep.test.sh asserts consistency).
+Cmnd_Alias GIT_LOCK_CHARDEVICE_SWEEP = /usr/bin/timeout 60 /usr/local/bin/git-lock-chardevice-sweep.sh
+deploy ALL=(root) NOPASSWD: GIT_LOCK_CHARDEVICE_SWEEP

--- a/apps/web-platform/infra/git-lock-chardevice-sweep.test.sh
+++ b/apps/web-platform/infra/git-lock-chardevice-sweep.test.sh
@@ -191,6 +191,24 @@ assert_contains "invocation is -x guarded (inert until delivered)" "$(cat "$CID"
 assert_contains "invocation is wall-clock bounded (no fleet-wide deploy hang)" "$(cat "$CID")" "timeout"
 assert_contains "invocation is best-effort (never blocks a deploy)" "$(cat "$CID")" "git-lock-chardevice-sweep.sh || true"
 
+# ---------------------------------------------------------------------------
+# #5934 regression: the sweep is invoked via `sudo`, so it needs a matching
+# NOPASSWD sudoers grant. Its ABSENCE is the exact defect that made the durable
+# fix a silent no-op (sudo denied every deploy; `|| true` hid it). Pin BOTH that
+# the invocation is sudo-elevated with the timeout value the grant pins, AND that
+# both sudoers sources carry the grant for the EXACT resolved argv — so the two
+# can never drift apart again.
+echo "Test (sudoers grant): the sudo-invoked sweep has a matching NOPASSWD grant, drift-locked to ci-deploy.sh"
+SUDOERS="$SCRIPT_DIR/deploy-inngest-bootstrap.sudoers"
+CLOUD_INIT="$SCRIPT_DIR/cloud-init.yml"
+# The exact command ci-deploy.sh runs (sudo resolves `timeout` → /usr/bin/timeout).
+SWEEP_CMD="/usr/bin/timeout 60 /usr/local/bin/git-lock-chardevice-sweep.sh"
+assert_contains "ci-deploy.sh invokes the sweep as sudo timeout 60 <script>" "$(cat "$CID")" "sudo timeout 60 /usr/local/bin/git-lock-chardevice-sweep.sh"
+assert_contains "repo sudoers grants the exact sweep argv" "$(cat "$SUDOERS")" "Cmnd_Alias GIT_LOCK_CHARDEVICE_SWEEP = $SWEEP_CMD"
+assert_contains "repo sudoers activates the grant for deploy" "$(cat "$SUDOERS")" "deploy ALL=(root) NOPASSWD: GIT_LOCK_CHARDEVICE_SWEEP"
+assert_contains "cloud-init inline sudoers grants the exact sweep argv" "$(cat "$CLOUD_INIT")" "Cmnd_Alias GIT_LOCK_CHARDEVICE_SWEEP = $SWEEP_CMD"
+assert_contains "cloud-init inline sudoers activates the grant for deploy" "$(cat "$CLOUD_INIT")" "deploy ALL=(root) NOPASSWD: GIT_LOCK_CHARDEVICE_SWEEP"
+
 echo ""
 echo "=== Results ==="
 echo "Passed: $PASS"

--- a/apps/web-platform/infra/server.tf
+++ b/apps/web-platform/infra/server.tf
@@ -680,6 +680,10 @@ resource "terraform_data" "infra_config_handler_bootstrap" {
       # The sudoers grant landed and parses (the INFRA_CONFIG_INSTALL alias is
       # what makes the webhook handler's prod-mode escalation work).
       "grep -q INFRA_CONFIG_INSTALL /etc/sudoers.d/deploy-inngest-bootstrap",
+      # #5934 — the char-device sweep grant landed (without it ci-deploy.sh's
+      # pre-canary sweep is sudo-denied and the durable #5912 wedge remediation is
+      # a silent no-op). Fail the provisioner loud rather than ship it missing.
+      "grep -q GIT_LOCK_CHARDEVICE_SWEEP /etc/sudoers.d/deploy-inngest-bootstrap",
       # hooks.json re-registers the status hook + maps the state-reporter key (the
       # exact host drift that caused the #4804 freeze: stale hooks.json had neither).
       "grep -q infra-config-status /etc/webhook/hooks.json",

--- a/knowledge-base/engineering/architecture/decisions/ADR-068-multi-host-workspaces-shared-git-data-lease-coordinator.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-068-multi-host-workspaces-shared-git-data-lease-coordinator.md
@@ -624,6 +624,22 @@ Phase 4b (continuous checkpoint).
 >   NOT relax (c) or by itself unlock pooling. Plan:
 >   `knowledge-base/project/plans/2026-07-03-feat-deep-readiness-endpoint-workspaces-mount-plan.md`.
 
+> **Amendment (2026-07-05, #6055 — web-2 must boot post-#6055 cloud-init before pooling).** A new
+> pre-pool gate, layered on the §(c) hard invariant above (necessary, not sufficient — does NOT
+> relax (c)): web-2 MUST be (re)created from a cloud-init dated on or after #6055 before its pool is
+> added to `default_pool_ids`. #6055 adds the `GIT_LOCK_CHARDEVICE_SWEEP` NOPASSWD grant that lets
+> `ci-deploy.sh`'s pre-canary char-device `.git/config.lock` sweep (#5934 / ADR-081) run as root;
+> WITHOUT it the sweep is sudo-DENIED (and `ci-deploy.sh`'s `|| true` hides the denial), so the
+> residual char-device node is never cleared and the #5912 worktree-creation wedge can strand every
+> agent session on that host. **Delivery asymmetry (the load-bearing reason this is a gate):** the 11
+> SSH provisioners are web-1-scoped by design (`server.tf` §"web-2 is fresh — provisioned entirely
+> by cloud-init at boot"), so a RUNNING web-2 gets **no live grant push** from `apply-deploy-pipeline-fix.yml`
+> — cloud-init at (re)create is the sole delivery path. A web-2 whose cloud-init predates #6055 boots
+> grant-less and MUST be **recreated** (the #6030 CI-driven `-replace` recreate), not merely
+> LB-undrained, before pooling. Enforcement today = this checklist item + #6030; making it
+> programmatic (a `/internal/readyz` pre-pool assertion that `grep -q GIT_LOCK_CHARDEVICE_SWEEP
+> /etc/sudoers.d/deploy-inngest-bootstrap` succeeds on-host) is a deep-readiness follow-up.
+
 > **Correction to §(b) (2026-07-03, gaplessness verification — PR #5968).** The §(b) remedy
 > ("verify against CF docs + a staging convert before the GA window") was executed via a
 > verification runbook + two agent pressure-tests (infra-security against the live CF DNS/zone

--- a/knowledge-base/engineering/operations/runbooks/betterstack-log-query.md
+++ b/knowledge-base/engineering/operations/runbooks/betterstack-log-query.md
@@ -13,6 +13,25 @@ doppler run -p soleur -c prd_terraform -- \
   'SELECT count() AS n FROM remote($BS_TABLE) WHERE dt >= now() - INTERVAL 2 HOUR FORMAT JSONEachRow'
 ```
 
+## ⚠️ A "no creds" / TRANSIENT error is NOT "no access" (repeat misdiagnosis)
+
+`betterstack-query.sh` does **not** read Doppler itself — it needs the query creds
+**injected** via `doppler run`. Run it in a bare shell and it exits with
+`BETTERSTACK_QUERY_{HOST,USERNAME,PASSWORD} not set`; a follow-through that wraps it
+(e.g. `chardevice-wedge-nonrecurrence-5934.sh`) then reports `TRANSIENT: … auth/config/network`.
+
+**Neither means this session lacks Better Stack access.** Both mean the call was not
+wrapped in `doppler run`. The fix is always the same — re-run:
+
+```bash
+doppler run -p soleur -c prd_terraform -- scripts/betterstack-query.sh <args>
+```
+
+Do NOT conclude "I can't verify from here" and stop. This mistake has now happened
+twice (the note below, and #5934); the script's error message itself now spells out
+the correct invocation. See hard rule `hr-verify-repo-capability-claim-before-assert`
+— a fail-safe/degraded probe output is *inconclusive*, never proof of a capability gap.
+
 ## Why this exists (the three-token trap)
 
 Better Stack has **three** distinct credentials and it is easy to reach for the

--- a/plugins/soleur/test/cloud-init-user-data-size.test.ts
+++ b/plugins/soleur/test/cloud-init-user-data-size.test.ts
@@ -35,9 +35,14 @@ const INFRA = join(REPO_ROOT, "apps", "web-platform", "infra");
 const DOCKERFILE = join(REPO_ROOT, "apps", "web-platform", "Dockerfile");
 
 // Hetzner hard cap; we enforce a sub-cap budget on WEB so a partial re-inlining still fails
-// CI with headroom (measured web ~29,256 B).
+// CI with headroom (measured web ~30,800 B as of #6055 — organic growth from ~29,256 B plus the
+// char-device sweep sudoers grant). The budget stays ~1,268 B under the hard cap, so a re-inlining
+// regression (KB-scale — the failure mode this guards) still trips it. NOTE: web user_data uses
+// the #5921 bake-and-extract approach (not git-data's base64gzip); as it keeps growing toward the
+// cap, a future base64gzip wrap (like #5927 did for git-data) will be needed — track before the
+// next multi-KB cloud-init addition.
 const HETZNER_CAP = 32_768;
-const WEB_BUDGET = 30_500;
+const WEB_BUDGET = 31_500;
 const WEB_FLOOR = 5_000; // non-vacuity
 // git-data base64gzip'd budget (#5927). Measured base64gzip output ~21,929 B; the 28,000 B
 // budget leaves ~6 KB headroom over that — loose enough for Go(terraform)-vs-node(zlib) header/

--- a/scripts/betterstack-query.sh
+++ b/scripts/betterstack-query.sh
@@ -35,9 +35,29 @@
 # Output: JSONEachRow (one JSON object per line) on stdout. Errors to stderr.
 set -uo pipefail
 
-: "${BETTERSTACK_QUERY_HOST:?set BETTERSTACK_QUERY_HOST (Doppler soleur/prd_terraform)}"
-: "${BETTERSTACK_QUERY_USERNAME:?set BETTERSTACK_QUERY_USERNAME}"
-: "${BETTERSTACK_QUERY_PASSWORD:?set BETTERSTACK_QUERY_PASSWORD}"
+# Credential guard. These are Doppler-managed secrets that must be INJECTED into
+# the env — this script does not read Doppler itself. A bare-shell run (no
+# `doppler run` wrapper) trips this. The message is deliberately explicit that the
+# fix is the invocation, NOT a missing capability: an agent that reads "unset" as
+# "this session lacks Better Stack access" and gives up is the exact misdiagnosis
+# this hint exists to prevent (see hr-observability-probe-transient-is-not-no-access).
+if [[ -z "${BETTERSTACK_QUERY_HOST:-}" || -z "${BETTERSTACK_QUERY_USERNAME:-}" || -z "${BETTERSTACK_QUERY_PASSWORD:-}" ]]; then
+  cat >&2 <<'EOF'
+betterstack-query.sh: BETTERSTACK_QUERY_{HOST,USERNAME,PASSWORD} not set.
+
+You are NOT missing Better Stack access — these creds live in Doppler and this
+script needs them INJECTED. Re-run wrapped in `doppler run`:
+
+  doppler run -p soleur -c prd_terraform -- scripts/betterstack-query.sh <args>
+
+e.g.  doppler run -p soleur -c prd_terraform -- scripts/betterstack-query.sh --since 1h --grep <marker>
+
+Do NOT conclude "no access / can't verify" from this message — the correct next
+step is the doppler-wrapped re-run above. (Creds provisioning: see
+knowledge-base/engineering/operations/runbooks/betterstack-log-query.md)
+EOF
+  exit 3
+fi
 
 # Table identifier — overridable for other sources via BS_TABLE.
 export BS_TABLE="${BS_TABLE:-t520508_soleur_inngest_vector_prd_3_logs}"

--- a/scripts/followthroughs/chardevice-wedge-nonrecurrence-5934.sh
+++ b/scripts/followthroughs/chardevice-wedge-nonrecurrence-5934.sh
@@ -68,10 +68,39 @@ count_marker() {
   return 0
 }
 
+# denied_count — rows that mention the sweep path AND are a sudo denial. This is
+# the failure mode that shipped #5934 blind: the sweep IS invoked every deploy
+# (`sudo timeout 60 …/git-lock-chardevice-sweep.sh`) but sudo had NO NOPASSWD grant,
+# so it was denied and ci-deploy.sh's `|| true` swallowed it — the script never ran,
+# so it emitted NEITHER a DONE nor its own FAILED marker, and the "no DONE" case below
+# read as a benign TRANSIENT ("no deploys"). The denial ("command not allowed") IS in
+# Better Stack under SYSLOG_IDENTIFIER sudo; a fetch of sweep-path rows post-filtered
+# to denials distinguishes "invoked-but-denied" (a hard FAIL) from "never invoked".
+denied_count() {
+  local out rc
+  out="$("$BQ" --since "$WINDOW" --grep "git-lock-chardevice-sweep" --limit 1000 2>/dev/null)"; rc=$?
+  [[ "$rc" -ne 0 ]] && return 1
+  # Among sweep-path rows, count sudo denials. Empty ⇒ 0.
+  printf '%s\n' "$out" | grep -c "command not allowed" || true
+  return 0
+}
+
 done_count="$(count_marker SOLEUR_CHARDEV_SWEEP_DONE)" || {
   echo "TRANSIENT: Better Stack query failed (liveness/DONE) — auth/config/network" >&2; exit 2; }
 failed_count="$(count_marker SOLEUR_CHARDEV_SWEEP_FAILED)" || {
   echo "TRANSIENT: Better Stack query failed (FAILED marker) — auth/config/network" >&2; exit 2; }
+denied="$(denied_count)" || {
+  echo "TRANSIENT: Better Stack query failed (sudo-denial marker) — auth/config/network" >&2; exit 2; }
+
+# Invoked-but-sudo-denied with zero successful runs = the durable fix is a SILENT
+# no-op (the #5934 shipped-blind defect). This must be a hard FAIL, never TRANSIENT —
+# a TRANSIENT here would leave #5934 "open, inconclusive" forever while the wedge is
+# live. Gated on done_count==0 so it self-clears once the sudoers grant lands and a
+# real DONE marker appears (a later working deploy supersedes earlier denials).
+if [[ "$done_count" -eq 0 && "$denied" -gt 0 ]]; then
+  echo "FAIL: sweep invoked but sudo-DENIED ${denied}x in ${WINDOW} with zero SOLEUR_CHARDEV_SWEEP_DONE — the durable char-device remediation is a silent no-op (missing NOPASSWD grant for git-lock-chardevice-sweep.sh; ci-deploy.sh's \`|| true\` hides the denial). The #5912 wedge is live."
+  exit 1
+fi
 
 if [[ "$done_count" -eq 0 ]]; then
   echo "TRANSIENT: no SOLEUR_CHARDEV_SWEEP_DONE marker in ${WINDOW} — sweep not observed running yet (no deploys in window, or delivery not live); inconclusive" >&2


### PR DESCRIPTION
## Why

The durable char-device `.git/config.lock` sweep (#5935 / ADR-081) — the fix meant to stop Concierge worktree-creation from wedging (#5912) — is a **silent no-op in prod**. `ci-deploy.sh` invokes it as:

```
sudo timeout 60 /usr/local/bin/git-lock-chardevice-sweep.sh || true
```

but the `deploy` user has **no matching NOPASSWD grant**, so `sudo` denies it on every deploy and `|| true` swallows the denial. The residual char-device node is never cleared, so agent worktree creation stays wedged.

**Confirmed live via Better Stack** (queried under `doppler run -p soleur -c prd_terraform`):
```
sudo: deploy : command not allowed ; COMMAND=/usr/bin/timeout 60 /usr/local/bin/git-lock-chardevice-sweep.sh
```
6 denials in 7 days, **zero** `SOLEUR_CHARDEV_SWEEP_DONE`.

This surfaced while debugging a stranded web session. Two failures of the same shape — *a fail-safe TRANSIENT masking a hard failure* — are fixed here.

## Changes

**Root-cause fix (why sessions strand):**
1. **`deploy-inngest-bootstrap.sudoers` + `cloud-init.yml`** — add the `GIT_LOCK_CHARDEVICE_SWEEP` NOPASSWD grant, pinning the exact argv `ci-deploy.sh` invokes (resolved `/usr/bin/timeout 60` prefix, no wildcards → sudo-rs safe).
2. **`server.tf`** — post-install `grep -q GIT_LOCK_CHARDEVICE_SWEEP` verify so the provisioner fails loud if the grant doesn't land.
3. **`git-lock-chardevice-sweep.test.sh`** — drift-lock: assert `ci-deploy.sh`'s invocation matches the granted command in both sudoers sources, so they can't silently diverge again.

**Observability-probe hardening (why the dead fix went unnoticed / why it was misdiagnosed):**
4. **`chardevice-wedge-nonrecurrence-5934.sh`** — a sudo-**denied** sweep (denials present, zero DONE) now returns **FAIL**, not the benign `TRANSIENT` that masked the dead fix and kept #5934 "open, inconclusive" forever. Self-clears to PASS once a real DONE appears.
5. **`betterstack-query.sh`** — the unset-creds guard now names the exact `doppler run -p soleur -c prd_terraform --` invocation and states *"you are NOT missing access"* — countering the exact misdiagnosis (a bare-shell error read as "no Better Stack access"). Exits `3` (callers still treat non-zero as inconclusive).
6. **`betterstack-log-query.md`** — prominent repeat-misdiagnosis callout.

## Verification

- `git-lock-chardevice-sweep.test.sh`: **26 passed / 0 failed** (incl. 5 new sudoers-grant assertions).
- `visudo -cf deploy-inngest-bootstrap.sudoers`: parsed OK.
- Hardened follow-through, run against live telemetry, now returns:
  `FAIL: sweep invoked but sudo-DENIED 6x in 7d with zero SOLEUR_CHARDEV_SWEEP_DONE …` (exit 1) — previously a silent TRANSIENT.
- `betterstack-query.sh` bare-shell run prints the doppler-run hint and exits 3.

## Prod apply path

The sudoers grant reaches the running host via `terraform_data.infra_config_handler_bootstrap` (sha256-triggered on the `.sudoers` file) + `apply-deploy-pipeline-fix.yml`. **Expected:** the #5934 soak probe reports **FAIL** until this deploys — that is correct (the fix is dead in prod *right now*); it flips to PASS on the first deploy where the sweep actually runs.

## Not closing #5934

`Ref #5934`, not `Closes` — this makes the durable sweep actually execute, but the AC10 7-day non-recurrence soak must still confirm it post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)