### PR TITLE
fix(workspace): pre-seed worktree git config host-side to bypass the SDK config.lock mask (#4826)

### DIFF
--- a/apps/web-platform/server/workspace.ts
+++ b/apps/web-platform/server/workspace.ts
@@ -89,6 +89,65 @@ const DEFAULT_SETTINGS = {
 };
 
 /**
+ * Pre-seed the git config that in-sandbox worktree creation needs, HOST-SIDE at
+ * provision time — BEFORE the agent sandbox bind-mounts /dev/null over
+ * `.git/config.lock`.
+ *
+ * The Claude Agent SDK's bubblewrap masks the literal path `.git/config.lock`
+ * with a read-only /dev/null bind mount (an in-sandbox, per-session guard against
+ * git-config RCE via `core.hooksPath`/`core.sshCommand`; confirmed single-path via
+ * `findmnt` = `tmpfs[/null]`). Inside the sandbox, any `git config` WRITE to the
+ * shared config fails EEXIST against that masked lock. `worktree-manager.sh`'s
+ * `ensure_bare_config` normally performs FOUR shared-config mutations before
+ * `git worktree add` (set `core.repositoryformatversion=1`, set
+ * `extensions.worktreeConfig=true`, unset `core.bare`, unset `core.worktree`); if
+ * any needs a real write against the masked lock, worktree creation wedges (#4826).
+ *
+ * Performing that exact transformation here — on the host, before the mask exists —
+ * makes the in-sandbox `ensure_bare_config` a ZERO-WRITE no-op: `atomic_git_config`
+ * takes its read-first idempotent fast path for the two SETs (a read never takes the
+ * lock) and skips both UNSETs because the keys are already absent. `git worktree add`
+ * then reads `extensions.worktreeConfig` (a read) and writes only per-worktree config
+ * (`config.worktree`, unmasked) — it never touches the masked `.git/config.lock`.
+ *
+ * Best-effort: a failure degrades to the in-sandbox write path (no worse than today),
+ * so we log and continue rather than fail provisioning. Idempotent + safe to re-run.
+ * Root cause + evidence: ADR-081 (corrected); this is the durable fix for #4826.
+ */
+export function seedWorktreeConfig(workspacePath: string): void {
+  // Mirror ensure_bare_config's shared-config transformation exactly.
+  // SETs: log on failure (these gate in-sandbox success). repositoryformatversion=1
+  // MUST precede the extensions.* write for git to honor the extension namespace.
+  for (const [key, value] of [
+    ["core.repositoryformatversion", "1"],
+    ["extensions.worktreeConfig", "true"],
+  ] as const) {
+    try {
+      execFileSync("git", ["config", key, value], {
+        cwd: workspacePath,
+        stdio: "pipe",
+      });
+    } catch (err) {
+      log.warn({ err, workspacePath, key }, "Failed to pre-seed worktree git config");
+    }
+  }
+  // UNSETs: core.bare / core.worktree belong in per-worktree config, not shared
+  // (a normal clone/init carries `core.bare=false`). --unset on an already-absent
+  // key exits non-zero; that is expected, so these are silent best-effort — a
+  // present key that fails to unset just falls back to the in-sandbox path.
+  for (const key of ["core.bare", "core.worktree"] as const) {
+    try {
+      execFileSync("git", ["config", "--unset", key], {
+        cwd: workspacePath,
+        stdio: "pipe",
+      });
+    } catch {
+      // absent key (or already-unset) — nothing to do.
+    }
+  }
+}
+
+/**
  * Provisions a workspace directory.
  *
  * Creates the directory structure, symlinks the Soleur plugin,
@@ -125,6 +184,9 @@ export async function provisionWorkspace(workspaceId: string): Promise<string> {
       cwd: workspacePath,
       stdio: "pipe",
     });
+    // Pre-seed worktree-config prerequisites HOST-SIDE, before the sandbox masks
+    // .git/config.lock, so in-sandbox worktree creation is a zero-write no-op (#4826).
+    seedWorktreeConfig(workspacePath);
   } catch (err) {
     log.warn({ err, workspaceId }, "Git init failed");
   }
@@ -243,6 +305,11 @@ export async function provisionWorkspaceWithRepo(
       log.warn({ err, workspaceId }, "Failed to set git user.email");
     }
   }
+
+  // 6.5. Pre-seed worktree-config prerequisites HOST-SIDE, before the agent
+  // sandbox bind-mounts /dev/null over .git/config.lock, so the in-sandbox
+  // worktree creation path is a zero-write no-op and never wedges (#4826).
+  seedWorktreeConfig(workspacePath);
 
   // 7-9. Overlay plugin symlink, .claude/settings.json, and KB scaffolding
   // via the shared helper. Missing entries are created; existing directories

--- a/apps/web-platform/server/workspace.ts
+++ b/apps/web-platform/server/workspace.ts
@@ -184,12 +184,18 @@ export async function provisionWorkspace(workspaceId: string): Promise<string> {
       cwd: workspacePath,
       stdio: "pipe",
     });
-    // Pre-seed worktree-config prerequisites HOST-SIDE, before the sandbox masks
-    // .git/config.lock, so in-sandbox worktree creation is a zero-write no-op (#4826).
-    seedWorktreeConfig(workspacePath);
   } catch (err) {
     log.warn({ err, workspaceId }, "Git init failed");
   }
+
+  // Pre-seed worktree-config prerequisites HOST-SIDE, before the sandbox masks
+  // .git/config.lock, so in-sandbox worktree creation is a zero-write no-op (#4826).
+  // Deliberately OUTSIDE the init/commit try: it must run whenever `git init`
+  // produced a `.git/`, even if the initial `git add`/`git commit` failed — e.g. a
+  // runner (or prod host) with no git identity throws at commit, and gating the seed
+  // behind it would silently re-wedge worktree creation. seedWorktreeConfig is itself
+  // best-effort (per-call try/catch), so calling it when `.git/` is absent is a no-op.
+  seedWorktreeConfig(workspacePath);
 
   return workspacePath;
 }

--- a/apps/web-platform/test/workspace.test.ts
+++ b/apps/web-platform/test/workspace.test.ts
@@ -10,6 +10,7 @@ delete process.env.GIT_INDEX_FILE;
 delete process.env.GIT_WORK_TREE;
 
 import { describe, test, expect, afterEach } from "vitest";
+import { execFileSync } from "child_process";
 import { existsSync, readFileSync, rmSync } from "fs";
 import { join } from "path";
 import { randomUUID } from "crypto";
@@ -72,5 +73,47 @@ describe("workspace provisioning", () => {
 
     expect(path1).toBe(path2);
     expect(existsSync(path1)).toBe(true);
+  });
+
+  // #4826 — pre-seed the worktree-config prerequisites HOST-SIDE so in-sandbox
+  // worktree creation is a zero-write no-op and never wedges on the SDK's
+  // /dev/null mask over .git/config.lock. Asserts the exact state that makes
+  // ensure_bare_config's atomic_git_config calls take their read-first idempotent
+  // path (SETs already at target) and skip the UNSET block (keys already absent).
+  test("pre-seeds worktree-config prerequisites host-side (#4826 config.lock-mask bypass)", async () => {
+    const userId = randomUUID();
+    const path = await provisionWorkspace(userId);
+    const cfg = (key: string): string | null => {
+      try {
+        return execFileSync("git", ["config", "--get", key], {
+          cwd: path,
+          stdio: "pipe",
+        })
+          .toString()
+          .trim();
+      } catch {
+        return null; // git config --get exits non-zero when the key is absent
+      }
+    };
+    // SETs pre-applied at their target values → in-sandbox writes become no-ops.
+    expect(cfg("extensions.worktreeConfig")).toBe("true");
+    expect(cfg("core.repositoryformatversion")).toBe("1");
+    // UNSET targets absent → in-sandbox ensure_bare_config skips them (no write).
+    expect(cfg("core.bare")).toBeNull();
+    expect(cfg("core.worktree")).toBeNull();
+  });
+
+  test("pre-seed is idempotent — re-provisioning keeps the target config state", async () => {
+    const userId = randomUUID();
+    await provisionWorkspace(userId);
+    const path = await provisionWorkspace(userId);
+    expect(
+      execFileSync("git", ["config", "--get", "extensions.worktreeConfig"], {
+        cwd: path,
+        stdio: "pipe",
+      })
+        .toString()
+        .trim(),
+    ).toBe("true");
   });
 });

--- a/knowledge-base/engineering/architecture/decisions/ADR-081-chardevice-config-lock-substrate-sweep.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-081-chardevice-config-lock-substrate-sweep.md
@@ -5,6 +5,27 @@
 **Deciders:** Engineering (CTO carry-forward from the 2026-07-03 config.lock-wedge-fix brainstorm)
 **Related:** #5934 (this durable fix), #5912 / PR #5932 (in-session `atomic_git_config` self-heal), PR #5907 (instrument), ADR-068 (multi-host git-data), ADR-075 (agent-sandbox tenant read isolation), ADR-079 (faithful sandbox canary)
 
+> **CORRECTION (2026-07-05, #4826 — the root cause below is WRONG).** A fresh Concierge
+> session still wedged after this ADR's host sweep shipped and ran clean (DONE markers,
+> zero FAILED). Live probing from the wedged session (`findmnt -T .git/config.lock`)
+> proved the node is **`tmpfs[/null]` — a deliberate, per-path, read-only `/dev/null`
+> bind-mount on the literal `.git/config.lock`**, with an arbitrary `config.soleur-probe.lock`
+> beside it left a normal writable file (⇒ **single-path, not glob**). That is the Claude
+> Agent SDK's **bubblewrap file-mask (candidate "b" below), applied per-session INSIDE the
+> sandbox** as a git-config-RCE guard — **NOT** a container-filesystem residual inode on the
+> persistent volume (candidate "c", which this ADR adopted). Candidate (b) was ruled out
+> here on the assumption the repo passes only directory paths to `denyRead`; the live mount
+> evidence overturns that. **Consequences:** (1) the host-side `-type c` sweep (#5934) clears
+> a real but effectively non-occurring case — it can never see a per-session in-sandbox bwrap
+> mount; keep it as cheap insurance but it does NOT unblock live sessions. (2) The durable fix
+> is to make the in-sandbox worktree path **need no config write at all**: pre-seed
+> `core.repositoryformatversion=1` + `extensions.worktreeConfig=true` (and clear `core.bare`/
+> `core.worktree`) **host-side at workspace provision time, before the mask exists**
+> (`apps/web-platform/server/workspace.ts` `seedWorktreeConfig`), so the in-sandbox
+> `ensure_bare_config` takes `atomic_git_config`'s read-first/absent-key skip and never
+> touches the masked lock. See the #4826 PR. (3) #5912's in-session temp-file bypass remains
+> correct for a genuine single-path mask but is defence-in-depth, not the primary path.
+
 ## Context
 
 The confirmed root cause of the Concierge worktree-creation wedge (tracker #5912) is

--- a/knowledge-base/project/learnings/bug-fixes/2026-07-05-config-lock-mask-is-sdk-bwrap-not-substrate-preseed-host-side.md
+++ b/knowledge-base/project/learnings/bug-fixes/2026-07-05-config-lock-mask-is-sdk-bwrap-not-substrate-preseed-host-side.md
@@ -75,6 +75,14 @@ per-worktree config (`config.worktree`, unmasked).
 - **Declared the wedge fixed end-to-end after verifying only the sweep ran.** See Key
   Insight 1. **Prevention:** for a blind surface, reproduce the user action; if you
   cannot (Concierge session), say so and gate the "fixed" claim on the user's retry.
+- **Seed passed locally, failed in CI (`extensions.worktreeConfig` null).** The seed
+  was placed INSIDE `provisionWorkspace`'s `git init → add → commit` try, after the
+  commit. A CI runner (and a prod host) with no git identity throws at `git commit`,
+  so the catch swallowed it and the seed never ran — invisible locally where a global
+  identity exists. **Prevention:** a best-effort step that must run regardless of an
+  earlier step's failure belongs OUTSIDE that step's try. Reproduce a "works locally,
+  red in CI" gap by stripping the ambient state CI lacks
+  (`env GIT_CONFIG_GLOBAL=/dev/null GIT_AUTHOR_NAME= …`) — don't assume flake.
 
 ## Follow-ups
 

--- a/knowledge-base/project/learnings/bug-fixes/2026-07-05-config-lock-mask-is-sdk-bwrap-not-substrate-preseed-host-side.md
+++ b/knowledge-base/project/learnings/bug-fixes/2026-07-05-config-lock-mask-is-sdk-bwrap-not-substrate-preseed-host-side.md
@@ -1,0 +1,87 @@
+---
+date: 2026-07-05
+category: bug-fixes
+module: workspace-provisioning
+tags: [config-lock, sandbox, bubblewrap, git-worktree, concierge, root-cause, observability]
+issue: 4826
+related:
+  - 2026-07-03-lockless-git-config-writer-bypasses-masked-config-lock.md
+---
+
+# Learning: the `.git/config.lock` wedge is an SDK bwrap per-path /dev/null mask, not a filesystem residual — fix it host-side before the mask exists
+
+## Problem
+
+Concierge worktree creation wedges because `.git/config.lock` is a **character
+device** and every in-sandbox `git config` write fails against it. ADR-081 concluded
+the root cause was a **container-filesystem residual inode** on the persistent volume
+(candidate "c") and shipped a **host-side, deploy-time `-type c` sweep** (#5934) to
+clear it. That sweep was verified *running* (Better Stack `SOLEUR_CHARDEV_SWEEP_DONE`
+markers, zero FAILED) — yet a **fresh session still wedged**.
+
+## Solution
+
+Live probing from the wedged session (which we could not do from telemetry — the
+in-sandbox `SOLEUR_GIT_LOCK_*` markers are **not mirrored to any queryable sink**)
+was decisive:
+
+- `ls -la .git/config.lock` → `crw-rw-rw- … 1, 3` (a `/dev/null` char device).
+- `findmnt -T .git/config.lock` → `tmpfs[/null]  ro` — a **deliberate per-path bind
+  mount** on the *literal* path, not a residual inode and not a mount over `.git`.
+- `touch .git/config.soleur-probe.lock` → a **normal writable file** ⇒ the mask is
+  **single-path**, not a `*.lock` glob.
+
+So the node is the **Claude Agent SDK's bubblewrap file-mask (ADR-081 candidate "b"),
+applied per-session INSIDE the sandbox** as a git-config-RCE guard — *not* a
+host-volume residual. The deploy-time host sweep can never see a per-session
+in-sandbox mount, which is why it ran clean while sessions still wedged.
+
+The durable fix makes the in-sandbox path **need no config write at all**:
+`seedWorktreeConfig()` in `apps/web-platform/server/workspace.ts` pre-applies the exact
+transformation `ensure_bare_config` performs (`core.repositoryformatversion=1`,
+`extensions.worktreeConfig=true`, clear `core.bare`/`core.worktree`) **host-side at
+provision time, before the sandbox mask exists**. In-sandbox, `atomic_git_config`
+then takes its read-first / absent-key **skip** for all four — zero writes, the masked
+lock is never touched — and `git worktree add` reads `worktreeConfig` and writes only
+per-worktree config (`config.worktree`, unmasked).
+
+## Key Insight
+
+1. **"The fix runs" is not "the fix works." Verify the USER-FACING symptom, not the
+   mechanism.** The host sweep emitted DONE markers (mechanism verified) while the
+   actual outcome (a session creating a worktree) stayed broken. A green internal
+   signal conflated with the outcome produced two false "it's fixed" claims. For a
+   blind execution surface, the only sound verification is reproducing the user's
+   exact action — here, a fresh session — not a proxy telemetry marker.
+
+2. **When a masked file is a `.lock` sidecar, the robust fix is to remove the NEED to
+   write it, not to fight the mask.** #5912's in-sandbox temp-file bypass fights the
+   mask (and is fail-closed correct for a genuine single-path mask). Pre-seeding the
+   target state on the host, before the mask exists, makes the write idempotent-skip —
+   strictly more robust, and independent of whether the in-session bypass fires.
+
+3. **A root-cause ADR built on a ruled-out candidate must be re-probed against live
+   ground truth.** ADR-081 ruled out the SDK bwrap mask (b) by *reading the sandbox
+   config* (only directory paths passed to `denyRead`). One `findmnt` from a wedged
+   session overturned it. Prefer a live mount/inode probe over config-reading when the
+   artifact is a mount.
+
+## Session Errors
+
+- **Claimed "no Better Stack access"** from a bare-shell probe that needed
+  `doppler run -p soleur -c prd_terraform`. Fixed in #6055 (the script now names the
+  invocation). **Prevention:** a fail-safe TRANSIENT/auth error from an infra probe is
+  inconclusive, never proof of a capability gap — re-run wrapped in `doppler run`.
+- **Declared the wedge fixed end-to-end after verifying only the sweep ran.** See Key
+  Insight 1. **Prevention:** for a blind surface, reproduce the user action; if you
+  cannot (Concierge session), say so and gate the "fixed" claim on the user's retry.
+
+## Follow-ups
+
+- **Observability (open):** mirror the in-sandbox `SOLEUR_GIT_LOCK_*` markers to a
+  queryable sink so the next wedge is self-diagnosable without asking the operator to
+  paste `findmnt`. This blindness forced two round-trips and is the meta-bug.
+
+## Tags
+category: bug-fixes
+module: workspace-provisioning

--- a/plugins/soleur/test/worktree-manager-atomic-config.test.sh
+++ b/plugins/soleur/test/worktree-manager-atomic-config.test.sh
@@ -245,5 +245,29 @@ else
   assert_eq "v11" "$(get_val "$D" section.keep)" "original config content intact after cp failure"
 fi
 
+# ---------------------------------------------------------------------------
+echo "Test 12: #4826 host-side pre-seed -> the in-sandbox ensure_bare_config sequence is a ZERO-WRITE no-op"
+# Mirrors seedWorktreeConfig (apps/web-platform/server/workspace.ts): pre-apply the
+# exact target state HOST-SIDE, then wedge config.lock non-regular (== the SDK's
+# /dev/null bind-mount mask). Each of the four mutations ensure_bare_config runs must
+# take its read-first / absent-key SKIP — rc 0, NO write past the mask, no temp. This
+# is why pre-seeding unblocks worktree creation without ever touching the masked lock.
+D=$(new_gitdir); seed_config "$D"
+git config --file "$D/config" core.repositoryformatversion 1     # pre-seed (host-side)
+git config --file "$D/config" extensions.worktreeConfig true     # pre-seed (host-side)
+# core.bare / core.worktree intentionally absent (seedWorktreeConfig unsets them).
+mkdir "$D/config.lock"                                           # non-regular lock == masked/wedged
+run_agc "$D/config" core.repositoryformatversion 1
+assert_eq "0" "$AGC_RC" "pre-seeded repositoryformatversion SET is a zero-write skip"
+run_agc "$D/config" extensions.worktreeConfig true
+assert_eq "0" "$AGC_RC" "pre-seeded worktreeConfig SET is a zero-write skip"
+run_agc "$D/config" --unset core.bare
+assert_eq "0" "$AGC_RC" "absent core.bare --unset is a zero-write skip"
+run_agc "$D/config" --unset core.worktree
+assert_eq "0" "$AGC_RC" "absent core.worktree --unset is a zero-write skip"
+no_temp_leftovers "$D" "#4826 pre-seed no-op (nothing written past the masked lock)"
+assert_eq "true" "$(get_val "$D" extensions.worktreeConfig)" "worktreeConfig value intact"
+rm -rf "$D/config.lock"
+
 echo ""
 print_results


### PR DESCRIPTION
## Why

Concierge worktree creation wedges because `.git/config.lock` is a **character device** — every in-sandbox `git config` write to the shared config fails `EEXIST`.

**Corrected root cause (this PR).** Live probing from a wedged session proved the node is **`tmpfs[/null]` — a deliberate, per-path, read-only `/dev/null` bind mount on the literal `.git/config.lock`**, applied **per-session inside the sandbox** by the Claude Agent SDK's bubblewrap as a git-config-RCE guard. It is **single-path** (a `config.soleur-probe.lock` beside it is a normal writable file), **not** a filesystem residual inode and **not** a glob.

ADR-081 mis-attributed this to a container-filesystem substrate residual (candidate "c") and shipped a host-side `-type c` deploy-time sweep (#5934). That sweep **runs clean yet sessions still wedge** — a deploy-time host sweep can never see a per-session in-sandbox bwrap mount. (Verifying the sweep *ran* was mistaken for verifying sessions *work* — see the learning file.)

## Fix

Make the in-sandbox path **need no config write at all**. `seedWorktreeConfig()` pre-applies `ensure_bare_config`'s exact transformation **host-side at provision time, before the mask exists**:

- set `core.repositoryformatversion=1`, `extensions.worktreeConfig=true`
- clear `core.bare`, `core.worktree`

Wired into **both** provisioning paths (`provisionWorkspace` git-init, `provisionWorkspaceWithRepo` clone). In-sandbox, `atomic_git_config` then takes its **read-first / absent-key skip** for all four (zero writes — the masked lock is never touched), and `git worktree add` reads `worktreeConfig` and writes only per-worktree config (`config.worktree`, unmasked).

Best-effort: a seed failure degrades to the existing in-sandbox path (no worse than today). #5912's in-session temp-file bypass remains as defence-in-depth.

## Tests

- **`workspace.test.ts`** (6 pass) — asserts the seeded config state via the *real* `provisionWorkspace` path + idempotence.
- **`worktree-manager-atomic-config.test.sh` Test 12** (34 pass) — pre-seed → all four `ensure_bare_config` mutations are **zero-write skips against a masked (non-regular) `config.lock`**, no temp leftovers. This is the exact in-sandbox mechanism, proven.
- Typecheck clean.

## Verification honesty

Unit/integration tests pass, but the true test is **a fresh Concierge web session creating a worktree** — only reproducible in that environment after deploy. I am **not** claiming end-to-end fixed until the operator confirms a fresh session works. (This caveat is deliberate: the prior #5934 fix's "verified" claim conflated "sweep runs" with "sessions work.")

## Follow-up (tracked, not in this PR)

The in-sandbox `SOLEUR_GIT_LOCK_*` markers are **not mirrored to any queryable sink**, so this diagnosis required asking the operator to paste `findmnt`. Mirroring them to Better Stack is the observability gap to close next.

## Changelog

Pre-seed worktree git config host-side so agent-sandbox worktree creation no longer wedges on the SDK's `.git/config.lock` mask (#4826).

🤖 Generated with [Claude Code](https://claude.com/claude-code)