### PR TITLE
fix(workspace): re-seed worktree config on session boot + mirror git-lock markers to Better Stack (#4826)

### DIFF
--- a/apps/web-platform/server/agent-runner-query-options.ts
+++ b/apps/web-platform/server/agent-runner-query-options.ts
@@ -31,6 +31,7 @@ import { buildAgentSandboxConfig } from "./agent-runner-sandbox-config";
 import { createSandboxHook } from "./sandbox-hook";
 import { createContextQueriesHook } from "./context-queries-hook";
 import { createPhaseSurfaceHook } from "./phase-surface-hook";
+import { createGitLockMarkerHook } from "./git-lock-marker-telemetry";
 import { createChildLogger } from "./logger";
 
 const log = createChildLogger("agent-query-options");
@@ -267,27 +268,27 @@ export function buildAgentQueryOptions(
           ],
         },
       ],
-      // PostToolUse(Skill) hints — two INDEPENDENT per-caller opt-ins, each a
-      // fail-open additive `additionalContext` only (never touch the tool floor):
-      //   - L3 phase-surface hint (#5772 lever 1, ADR-070);
-      //   - declarative context_queries injection (#6046, ADR-086).
-      // Both use matcher "Skill"; the SDK runs parallel matching hooks and
-      // delivers both `additionalContext` values (ADR-086 §Composition fallback).
-      // Built by concatenation so enabling one never gates the other; only the
-      // cc-soleur-go Concierge router opts in, so the legacy path stays
-      // zero-change (both undefined → `hooks.PostToolUse` is absent, preserving
-      // the AC5 drift snapshot).
-      ...(() => {
-        const postToolUse = [
-          ...(args.enablePhaseSurfaceHint
-            ? [{ matcher: "Skill", hooks: [createPhaseSurfaceHook()] }]
-            : []),
-          ...(args.enableContextQueries
-            ? [{ matcher: "Skill", hooks: [createContextQueriesHook(args.workspacePath)] }]
-            : []),
-        ];
-        return postToolUse.length ? { PostToolUse: postToolUse } : {};
-      })(),
+      // PostToolUse hooks (all fail-open, observe/additive-only — never touch the
+      // tool floor):
+      //   - ALWAYS: the #4826 git-lock marker mirror (matcher "Bash"). Observe-only;
+      //     re-emits the in-sandbox SOLEUR_GIT_LOCK_*/"worktree wedge" markers to the
+      //     server-side logger (→ Better Stack + Sentry breadcrumb), closing ADR-081's
+      //     "blind sandbox stdout, not mirrored to any queryable sink" gap. Path-agnostic
+      //     (a wedge can happen on any dispatch), so it is unconditional, not opt-in.
+      //   - Per-caller opt-ins (matcher "Skill"), each additive `additionalContext`:
+      //     the L3 phase-surface hint (#5772 lever 1, ADR-070) and the declarative
+      //     context_queries injection (#6046, ADR-086). Both use matcher "Skill"; the SDK
+      //     runs parallel matching hooks and delivers both values. Only the cc-soleur-go
+      //     Concierge router opts in.
+      PostToolUse: [
+        { matcher: "Bash", hooks: [createGitLockMarkerHook(args.workspacePath)] },
+        ...(args.enablePhaseSurfaceHint
+          ? [{ matcher: "Skill", hooks: [createPhaseSurfaceHook()] }]
+          : []),
+        ...(args.enableContextQueries
+          ? [{ matcher: "Skill", hooks: [createContextQueriesHook(args.workspacePath)] }]
+          : []),
+      ],
     },
     canUseTool: args.canUseTool,
   };

--- a/apps/web-platform/server/ensure-workspace-repo.ts
+++ b/apps/web-platform/server/ensure-workspace-repo.ts
@@ -19,6 +19,7 @@ import { withWorkspacePermissionLock } from "@/server/workspace-permission-lock"
 import { isGitDataStoreEnabled } from "@/server/workspace-resolver";
 import { fetchFromGitData } from "@/server/git-data-client";
 import { resolveWorktreeId } from "@/server/worktree-write-lease";
+import { seedWorktreeConfig } from "@/server/worktree-config-seed";
 
 const log = createChildLogger("ensure-workspace-repo");
 const execFileAsync = promisify(execFile);
@@ -241,7 +242,16 @@ export async function ensureWorkspaceRepoCloned(
   // the heal the way bare `existsSync` did. (A STRANDING `.git` FILE pointer was
   // handled and removed just above; a non-stranding in-workspace pointer is a
   // valid linked tree we intentionally preserve here.)
-  if (isValidGitWorkTree(workspacePath)) return "ok";
+  if (isValidGitWorkTree(workspacePath)) {
+    // #4826 — re-seed the worktree-config prerequisites HOST-SIDE on every session
+    // boot of an EXISTING valid workspace. The #6064 provision-time seed only reaches
+    // workspaces created AFTER it shipped; a workspace provisioned earlier persists on
+    // the volume and would keep wedging in-sandbox worktree creation (the SDK masks
+    // `.git/config.lock`) forever. This heals that population idempotently. Best-effort
+    // (never throws); a failure just falls back to the in-sandbox write path.
+    seedWorktreeConfig(workspacePath);
+    return "ok";
+  }
 
   // `.git` EXISTS but is INVALID. The destructive removal is authorized ONLY by
   // the POSITIVE empty-corrupt fingerprint (`.git` dir + HEAD ENOENT + objects
@@ -298,6 +308,10 @@ export async function ensureWorkspaceRepoCloned(
 
   try {
     await graftFn(workspacePath, repoUrl, installationId);
+
+    // #4826 — seed worktree-config prerequisites into the freshly-grafted `.git`
+    // (host-side, before the sandbox mask), same as the provision-time clone path.
+    seedWorktreeConfig(workspacePath);
 
     // Sub-PR 3.D (#5274 Phase 3, ADR-068) — clone-from-git-data read-source
     // OVERLAY. Rehydration = clone(GitHub) → overlay(git-data). git-data ⊇ the

--- a/apps/web-platform/server/git-lock-marker-telemetry.ts
+++ b/apps/web-platform/server/git-lock-marker-telemetry.ts
@@ -1,0 +1,147 @@
+// Mirror the in-sandbox git-lock wedge markers to a QUERYABLE sink (#4826 follow-up).
+//
+// worktree-manager.sh (running INSIDE the agent sandbox) emits diagnostic markers to
+// the Bash tool's stdout/stderr when worktree creation is wedged by a masked
+// `.git/config.lock`:
+//   - SOLEUR_GIT_LOCK_DIAG        — forensic (file type, owner, perms, mtime, rdev, mount)
+//   - SOLEUR_GIT_LOCK_UNREMOVABLE — a lock that could not be cleared (the wedge)
+//   - SOLEUR_GIT_LOCK_TEMP_WEDGED — the lockless-writer temp lock was ALSO masked (glob mask)
+//   - "worktree wedge: ..."       — ensure_bare_config gave up
+//
+// Before this hook those lines went ONLY to blind agent-sandbox stdout — not mirrored
+// to any sink an operator can query (ADR-081's stated observability gap). Diagnosing the
+// #4826 wedge therefore required asking the operator to paste `findmnt` from the live
+// session. This PostToolUse(Bash) hook runs SERVER-SIDE (the Node dispatch process, where
+// the pino logger ships to stdout → journald → vector → Better Stack, plus a Sentry
+// breadcrumb), scans Bash output for the markers, and re-emits each as a structured log —
+// so the next wedge is self-diagnosable without a human round-trip.
+//
+// Design invariants:
+//   - Observe-only + fail-open: always returns `{}`, never throws into the SDK turn.
+//   - Privacy: emits ONLY the matched marker lines (device/path/mount forensic — no user
+//     content), never the surrounding Bash output. A bounded scan (line count + line
+//     length caps) prevents log spam / a pathological-output DoS.
+//   - The marker text is diagnostic constants + filesystem metadata the platform owns; it
+//     carries no repo contents, so re-logging it verbatim is safe.
+
+import type { HookCallback, PostToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { createChildLogger } from "./logger";
+import { reportSilentFallback } from "./observability";
+
+const log = createChildLogger("git-lock-marker-telemetry");
+
+// Matches the marker sentinels emitted by
+// plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh. Kept in sync with
+// that script; a drift test (git-lock-marker-telemetry.test.ts) pins the pattern set
+// against the live script so a renamed sentinel fails CI instead of going silently
+// unmirrored.
+const MARKER_RE =
+  /^(?:SOLEUR_GIT_LOCK_(?:DIAG|UNREMOVABLE|TEMP_WEDGED)\b.*|worktree wedge:.*)$/;
+
+// A wedge (vs. a benign DIAG) is any marker that indicates creation could not proceed.
+const WEDGE_RE = /^(?:SOLEUR_GIT_LOCK_(?:UNREMOVABLE|TEMP_WEDGED)\b|worktree wedge:)/;
+
+// Bounds: scan at most this many lines, keep at most this many matched markers, and
+// truncate any single marker line to this many chars. A wedged run emits a handful of
+// markers; these caps only fire on pathological/hostile output.
+const MAX_SCAN_LINES = 4000;
+const MAX_MARKERS = 12;
+const MAX_MARKER_LEN = 600;
+
+/**
+ * Coerce a PostToolUse `tool_response` (typed `unknown`) into scannable text. The Bash
+ * tool's response is commonly a string, or an object with `stdout`/`stderr`, or an array
+ * of `{ type: "text", text }` content blocks. Unknown shapes yield "" (no markers).
+ */
+export function toolResponseToText(resp: unknown): string {
+  if (typeof resp === "string") return resp;
+  if (Array.isArray(resp)) {
+    return resp
+      .map((b) =>
+        b && typeof b === "object" && typeof (b as { text?: unknown }).text === "string"
+          ? (b as { text: string }).text
+          : "",
+      )
+      .join("\n");
+  }
+  if (resp && typeof resp === "object") {
+    const o = resp as { stdout?: unknown; stderr?: unknown; content?: unknown };
+    if (typeof o.content === "string") return o.content;
+    if (Array.isArray(o.content)) return toolResponseToText(o.content);
+    const parts: string[] = [];
+    if (typeof o.stdout === "string") parts.push(o.stdout);
+    if (typeof o.stderr === "string") parts.push(o.stderr);
+    if (parts.length > 0) return parts.join("\n");
+  }
+  return "";
+}
+
+export interface GitLockMarker {
+  /** The marker line, trimmed + length-bounded. */
+  line: string;
+  /** true when the marker indicates worktree creation is wedged (not a benign DIAG). */
+  wedged: boolean;
+}
+
+/**
+ * Extract the git-lock marker lines from arbitrary Bash output. Pure + bounded so it is
+ * unit-testable and cannot be turned into a log-amplification vector by hostile output.
+ */
+export function extractGitLockMarkers(text: string): GitLockMarker[] {
+  if (!text) return [];
+  const out: GitLockMarker[] = [];
+  let scanned = 0;
+  for (const raw of text.split("\n")) {
+    if (scanned++ >= MAX_SCAN_LINES || out.length >= MAX_MARKERS) break;
+    const line = raw.trim();
+    if (!MARKER_RE.test(line)) continue;
+    out.push({
+      line: line.length > MAX_MARKER_LEN ? `${line.slice(0, MAX_MARKER_LEN)}…` : line,
+      wedged: WEDGE_RE.test(line),
+    });
+  }
+  return out;
+}
+
+/**
+ * Build the PostToolUse(Bash) hook that mirrors in-sandbox git-lock markers to the
+ * server-side logger. Factory is side-effect-free so a builder-time call inside the
+ * `options.hooks` literal can never throw into `query()` startup.
+ *
+ * @param workspacePath included in each structured log so a wedge is attributable to a
+ *   workspace without correlating separate lines.
+ */
+export function createGitLockMarkerHook(workspacePath: string): HookCallback {
+  return async (input) => {
+    try {
+      const i = input as PostToolUseHookInput;
+      if (i.tool_name !== "Bash") return {};
+      const markers = extractGitLockMarkers(toolResponseToText(i.tool_response));
+      if (markers.length === 0) return {};
+      const anyWedged = markers.some((m) => m.wedged);
+      const payload = {
+        // `sec: true` — this is a platform-integrity signal, not per-user noise.
+        sec: true,
+        workspacePath,
+        wedged: anyWedged,
+        markerCount: markers.length,
+        markers: markers.map((m) => m.line),
+      };
+      // A wedge is an error (a blocked session); a DIAG-only run is a warning. Both reach
+      // Better Stack (pino → stdout → journald → vector) and a Sentry breadcrumb.
+      if (anyWedged) {
+        log.error(payload, "in-sandbox git-lock wedge detected (worktree creation blocked)");
+      } else {
+        log.warn(payload, "in-sandbox git-lock diagnostic emitted (no wedge)");
+      }
+      return {};
+    } catch (err) {
+      // Fail-open: never throw into the SDK turn. The scanned text is model-adjacent, so
+      // keep the error message STATIC and route the detail through the silent-fallback
+      // mirror rather than interpolating tool output into the log line.
+      log.warn({ err, workspacePath }, "git-lock marker hook failed (fail-open: no mirror)");
+      reportSilentFallback(err, { feature: "git-lock-marker-telemetry", op: "scan" });
+      return {};
+    }
+  };
+}

--- a/apps/web-platform/server/workspace.ts
+++ b/apps/web-platform/server/workspace.ts
@@ -17,6 +17,7 @@ import {
 import { generateInstallationToken, checkRepoAccess } from "./github-app";
 import { getPluginPath } from "./plugin-path";
 import { reportSilentFallback } from "./observability";
+import { seedWorktreeConfig } from "./worktree-config-seed";
 
 // Minimal structural type for the Storage remove path — avoids dragging the
 // full SupabaseClient generic into this FS/git-focused module.
@@ -87,65 +88,6 @@ const DEFAULT_SETTINGS = {
     enabled: true,
   },
 };
-
-/**
- * Pre-seed the git config that in-sandbox worktree creation needs, HOST-SIDE at
- * provision time — BEFORE the agent sandbox bind-mounts /dev/null over
- * `.git/config.lock`.
- *
- * The Claude Agent SDK's bubblewrap masks the literal path `.git/config.lock`
- * with a read-only /dev/null bind mount (an in-sandbox, per-session guard against
- * git-config RCE via `core.hooksPath`/`core.sshCommand`; confirmed single-path via
- * `findmnt` = `tmpfs[/null]`). Inside the sandbox, any `git config` WRITE to the
- * shared config fails EEXIST against that masked lock. `worktree-manager.sh`'s
- * `ensure_bare_config` normally performs FOUR shared-config mutations before
- * `git worktree add` (set `core.repositoryformatversion=1`, set
- * `extensions.worktreeConfig=true`, unset `core.bare`, unset `core.worktree`); if
- * any needs a real write against the masked lock, worktree creation wedges (#4826).
- *
- * Performing that exact transformation here — on the host, before the mask exists —
- * makes the in-sandbox `ensure_bare_config` a ZERO-WRITE no-op: `atomic_git_config`
- * takes its read-first idempotent fast path for the two SETs (a read never takes the
- * lock) and skips both UNSETs because the keys are already absent. `git worktree add`
- * then reads `extensions.worktreeConfig` (a read) and writes only per-worktree config
- * (`config.worktree`, unmasked) — it never touches the masked `.git/config.lock`.
- *
- * Best-effort: a failure degrades to the in-sandbox write path (no worse than today),
- * so we log and continue rather than fail provisioning. Idempotent + safe to re-run.
- * Root cause + evidence: ADR-081 (corrected); this is the durable fix for #4826.
- */
-export function seedWorktreeConfig(workspacePath: string): void {
-  // Mirror ensure_bare_config's shared-config transformation exactly.
-  // SETs: log on failure (these gate in-sandbox success). repositoryformatversion=1
-  // MUST precede the extensions.* write for git to honor the extension namespace.
-  for (const [key, value] of [
-    ["core.repositoryformatversion", "1"],
-    ["extensions.worktreeConfig", "true"],
-  ] as const) {
-    try {
-      execFileSync("git", ["config", key, value], {
-        cwd: workspacePath,
-        stdio: "pipe",
-      });
-    } catch (err) {
-      log.warn({ err, workspacePath, key }, "Failed to pre-seed worktree git config");
-    }
-  }
-  // UNSETs: core.bare / core.worktree belong in per-worktree config, not shared
-  // (a normal clone/init carries `core.bare=false`). --unset on an already-absent
-  // key exits non-zero; that is expected, so these are silent best-effort — a
-  // present key that fails to unset just falls back to the in-sandbox path.
-  for (const key of ["core.bare", "core.worktree"] as const) {
-    try {
-      execFileSync("git", ["config", "--unset", key], {
-        cwd: workspacePath,
-        stdio: "pipe",
-      });
-    } catch {
-      // absent key (or already-unset) — nothing to do.
-    }
-  }
-}
 
 /**
  * Provisions a workspace directory.

--- a/apps/web-platform/server/worktree-config-seed.ts
+++ b/apps/web-platform/server/worktree-config-seed.ts
@@ -1,0 +1,69 @@
+// Host-side pre-seed of the git config that in-sandbox worktree creation needs —
+// applied BEFORE the agent sandbox bind-mounts /dev/null over `.git/config.lock`.
+//
+// The Claude Agent SDK's bubblewrap masks git-config write targets (`.git/config.lock`,
+// and per live evidence `.git/config.worktree`) with a read-only /dev/null bind mount —
+// a per-session in-sandbox guard against git-config RCE via `core.hooksPath`/
+// `core.sshCommand`. Inside the sandbox, any `git config` WRITE to the shared config
+// fails EEXIST against that masked lock, so `worktree-manager.sh`'s `ensure_bare_config`
+// (which sets `core.repositoryformatversion=1` + `extensions.worktreeConfig=true` and
+// clears `core.bare`/`core.worktree` before `git worktree add`) wedges (#4826).
+//
+// Performing that exact transformation HOST-SIDE, before the mask exists, makes the
+// in-sandbox `ensure_bare_config` a ZERO-WRITE no-op: `atomic_git_config` read-first-skips
+// the two SETs (a read never takes the lock) and skips both UNSETs (keys already absent);
+// `git worktree add` then writes only `.git/worktrees/<id>/` (a fresh, unmasked subdir).
+//
+// This module is standalone (only `child_process` + the logger) so the hot per-session
+// boot path (`ensureWorkspaceRepoCloned`) can call it WITHOUT pulling in workspace.ts's
+// full provisioning dependency graph.
+
+import { execFileSync } from "child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { createChildLogger } from "./logger";
+
+const log = createChildLogger("worktree-config-seed");
+
+/**
+ * Idempotently pre-seed the worktree-config prerequisites into `<workspacePath>/.git`.
+ *
+ * Best-effort by contract: a failure degrades to the in-sandbox write path (no worse
+ * than not calling it), so every step logs and continues rather than throwing. Safe to
+ * re-run every session — the values are set-to-target, so repeats are no-ops. A no-op
+ * when `<workspacePath>/.git` is absent (nothing to seed, and `git config` would fail).
+ *
+ * Runs at BOTH:
+ *   - provision time (`provisionWorkspace` / `provisionWorkspaceWithRepo`) — new workspaces
+ *   - session boot (`ensureWorkspaceRepoCloned`) — EXISTING workspaces provisioned before
+ *     this fix shipped, which would otherwise never be seeded and keep wedging (#4826).
+ */
+export function seedWorktreeConfig(workspacePath: string): void {
+  // A `.git` may be a directory (normal repo) or a file (linked-worktree pointer);
+  // either is seedable. Absent → nothing to do (a repo-less "Start Fresh" dir mid-init).
+  if (!existsSync(join(workspacePath, ".git"))) return;
+
+  // SETs mirror ensure_bare_config exactly. repositoryformatversion=1 MUST precede the
+  // extensions.* write for git to honor the extension namespace. Failures are logged
+  // (they gate in-sandbox success) but never thrown.
+  for (const [key, value] of [
+    ["core.repositoryformatversion", "1"],
+    ["extensions.worktreeConfig", "true"],
+  ] as const) {
+    try {
+      execFileSync("git", ["config", key, value], { cwd: workspacePath, stdio: "pipe" });
+    } catch (err) {
+      log.warn({ err, workspacePath, key }, "Failed to pre-seed worktree git config");
+    }
+  }
+  // UNSETs: core.bare / core.worktree belong in per-worktree config, not shared (a normal
+  // clone/init carries `core.bare=false`). `--unset` of an absent key exits non-zero;
+  // that is expected, so these are silent best-effort.
+  for (const key of ["core.bare", "core.worktree"] as const) {
+    try {
+      execFileSync("git", ["config", "--unset", key], { cwd: workspacePath, stdio: "pipe" });
+    } catch {
+      // absent key (or already-unset) — nothing to do.
+    }
+  }
+}

--- a/apps/web-platform/test/agent-runner-query-options.test.ts
+++ b/apps/web-platform/test/agent-runner-query-options.test.ts
@@ -68,43 +68,51 @@ describe("buildAgentQueryOptions — canonical shape (T1)", () => {
   });
 });
 
-describe("buildAgentQueryOptions — phase-surface hint per-caller opt-in (#5772 lever 1)", () => {
-  it("registers PostToolUse(Skill) only when enablePhaseSurfaceHint is true", () => {
-    const on = buildAgentQueryOptions({ ...minArgs, enablePhaseSurfaceHint: true });
-    expect(Array.isArray(on.hooks?.PostToolUse)).toBe(true);
-    expect(on.hooks!.PostToolUse![0].matcher).toBe("Skill");
-  });
-
-  it("omits PostToolUse entirely for the legacy caller (both flags absent)", () => {
+describe("buildAgentQueryOptions — PostToolUse(Bash) git-lock telemetry always-on (#4826)", () => {
+  it("ALWAYS registers the Bash git-lock marker hook, even for the legacy caller", () => {
     const off = buildAgentQueryOptions(minArgs);
-    expect(off.hooks?.PostToolUse).toBeUndefined();
-    // The PreToolUse + SubagentStart hooks remain regardless of the flag.
+    // PostToolUse is now always present: the #4826 telemetry hook is unconditional
+    // (a git-lock wedge is path-agnostic). The Bash entry is index 0; Skill hints append.
+    expect(Array.isArray(off.hooks?.PostToolUse)).toBe(true);
+    expect(off.hooks!.PostToolUse![0].matcher).toBe("Bash");
+    // The other hooks remain regardless.
     expect(off.hooks?.PreToolUse).toBeDefined();
     expect(off.hooks?.SubagentStart).toBeDefined();
+  });
+
+  it("registers ONLY the Bash hook when neither Skill opt-in is set", () => {
+    const off = buildAgentQueryOptions(minArgs);
+    expect(off.hooks!.PostToolUse!).toHaveLength(1);
+    expect(off.hooks!.PostToolUse![0].matcher).toBe("Bash");
+  });
+});
+
+describe("buildAgentQueryOptions — phase-surface hint per-caller opt-in (#5772 lever 1)", () => {
+  it("appends PostToolUse(Skill) after the always-on Bash hook when enablePhaseSurfaceHint is true", () => {
+    const on = buildAgentQueryOptions({ ...minArgs, enablePhaseSurfaceHint: true });
+    expect(on.hooks!.PostToolUse!).toHaveLength(2);
+    expect(on.hooks!.PostToolUse![0].matcher).toBe("Bash");
+    expect(on.hooks!.PostToolUse![1].matcher).toBe("Skill");
   });
 });
 
 describe("buildAgentQueryOptions — context_queries hook per-caller opt-in (#6046, AC9)", () => {
-  it("registers a PostToolUse(Skill) block when only enableContextQueries is true", () => {
+  it("appends one Skill entry after the Bash hook when only enableContextQueries is true", () => {
     const on = buildAgentQueryOptions({ ...minArgs, enableContextQueries: true });
-    expect(Array.isArray(on.hooks?.PostToolUse)).toBe(true);
-    expect(on.hooks!.PostToolUse!).toHaveLength(1);
-    expect(on.hooks!.PostToolUse![0].matcher).toBe("Skill");
+    expect(on.hooks!.PostToolUse!).toHaveLength(2);
+    expect(on.hooks!.PostToolUse![0].matcher).toBe("Bash");
+    expect(on.hooks!.PostToolUse![1].matcher).toBe("Skill");
   });
 
-  it("registers TWO independent Skill entries when both flags are true", () => {
+  it("registers the Bash hook + TWO independent Skill entries when both flags are true", () => {
     const both = buildAgentQueryOptions({
       ...minArgs,
       enablePhaseSurfaceHint: true,
       enableContextQueries: true,
     });
-    expect(both.hooks!.PostToolUse!).toHaveLength(2);
-    expect(both.hooks!.PostToolUse!.every((e: { matcher?: string }) => e.matcher === "Skill")).toBe(true);
-  });
-
-  it("leaves PostToolUse undefined when neither flag is set (AC5 drift snapshot)", () => {
-    const off = buildAgentQueryOptions(minArgs);
-    expect(off.hooks?.PostToolUse).toBeUndefined();
+    expect(both.hooks!.PostToolUse!).toHaveLength(3);
+    expect(both.hooks!.PostToolUse![0].matcher).toBe("Bash");
+    expect(both.hooks!.PostToolUse!.slice(1).every((e: { matcher?: string }) => e.matcher === "Skill")).toBe(true);
   });
 });
 

--- a/apps/web-platform/test/ensure-workspace-repo.test.ts
+++ b/apps/web-platform/test/ensure-workspace-repo.test.ts
@@ -20,6 +20,7 @@ const {
   mockFetchFromGitData,
   mockResolveWorktreeId,
   mockLocalGit,
+  mockSeedWorktreeConfig,
 } = vi.hoisted(() => ({
   mockExistsSync: vi.fn(),
   mockGraftRepoClone: vi.fn(),
@@ -35,6 +36,7 @@ const {
   mockFetchFromGitData: vi.fn(),
   mockResolveWorktreeId: vi.fn(),
   mockLocalGit: vi.fn(),
+  mockSeedWorktreeConfig: vi.fn(),
 }));
 
 vi.mock("node:fs", () => ({ existsSync: mockExistsSync }));
@@ -84,6 +86,12 @@ vi.mock("@/server/git-data-client", () => ({
 }));
 vi.mock("@/server/worktree-write-lease", () => ({
   resolveWorktreeId: mockResolveWorktreeId,
+}));
+// #4826 — the host-side worktree-config re-seed. Spied so the boot path's calls are
+// assertable without touching real git (the seeder's behavior is unit-tested in
+// worktree-config-seed.test.ts).
+vi.mock("@/server/worktree-config-seed", () => ({
+  seedWorktreeConfig: mockSeedWorktreeConfig,
 }));
 
 import {
@@ -238,6 +246,10 @@ describe("ensureWorkspaceRepoCloned", () => {
     await ensureWorkspaceRepoCloned({ userId: "u1", workspacePath: WS, installationId: 123, repoUrl: REPO });
     expect(mockGraftRepoClone).not.toHaveBeenCalled();
     expect(mockRm).not.toHaveBeenCalled();
+    // #4826 — an existing valid workspace must STILL be re-seeded every boot, so a
+    // workspace provisioned before the seed shipped stops wedging in-sandbox worktree
+    // creation. This is the fix for the "fresh session, existing workspace" failure.
+    expect(mockSeedWorktreeConfig).toHaveBeenCalledWith(WS);
   });
 
   // #5733 — a `.git` FILE pointer at a workspace ROOT is a stale gitdir pointer

--- a/apps/web-platform/test/git-lock-marker-telemetry.test.ts
+++ b/apps/web-platform/test/git-lock-marker-telemetry.test.ts
@@ -1,0 +1,127 @@
+// Unit tests for the git-lock marker telemetry hook (#4826 observability follow-up):
+// the pure extractor, tool_response coercion, and the PostToolUse hook's fail-open
+// classification (wedge → error, diag-only → warn, non-Bash → no-op).
+import { describe, test, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+import {
+  extractGitLockMarkers,
+  toolResponseToText,
+  createGitLockMarkerHook,
+} from "../server/git-lock-marker-telemetry";
+
+const DIAG =
+  "SOLEUR_GIT_LOCK_DIAG file=.git/config.lock type=chardevice owner=nobody perms=666 mtime=1 age=1140 mount=tmpfs rdev=1:3 whiteout=no";
+const UNREMOVABLE =
+  'SOLEUR_GIT_LOCK_UNREMOVABLE file=.git/config.lock type=chardevice rdev=1:3 errno=none reason=non-regular-lock hint="observed non-regular config lock"';
+const WEDGE =
+  "worktree wedge: could not apply shared-config prerequisites in .git (see errors above).";
+const TEMP_WEDGED =
+  'SOLEUR_GIT_LOCK_TEMP_WEDGED file=config.soleur-tmp type=temp-write-failed reason=lockless-temp-unwritable hint="glob mask"';
+
+describe("extractGitLockMarkers", () => {
+  test("pulls each marker sentinel out of surrounding bash noise", () => {
+    const text = ["Preparing worktree", DIAG, "  updating files", UNREMOVABLE, "done"].join("\n");
+    const markers = extractGitLockMarkers(text);
+    expect(markers.map((m) => m.line)).toEqual([DIAG, UNREMOVABLE]);
+  });
+
+  test("classifies UNREMOVABLE / TEMP_WEDGED / 'worktree wedge' as wedged; DIAG as not", () => {
+    expect(extractGitLockMarkers(DIAG)[0]?.wedged).toBe(false);
+    expect(extractGitLockMarkers(UNREMOVABLE)[0]?.wedged).toBe(true);
+    expect(extractGitLockMarkers(WEDGE)[0]?.wedged).toBe(true);
+    expect(extractGitLockMarkers(TEMP_WEDGED)[0]?.wedged).toBe(true);
+  });
+
+  test("returns [] for output with no markers, and for empty input", () => {
+    expect(extractGitLockMarkers("just some normal git output\nProsuming worktree")).toEqual([]);
+    expect(extractGitLockMarkers("")).toEqual([]);
+  });
+
+  test("does not match a marker token embedded mid-line (anchored to line start)", () => {
+    expect(extractGitLockMarkers("echo SOLEUR_GIT_LOCK_DIAG is the sentinel name")).toEqual([]);
+  });
+
+  test("bounds output: caps the number of markers even on a flood", () => {
+    const flood = Array.from({ length: 500 }, () => UNREMOVABLE).join("\n");
+    expect(extractGitLockMarkers(flood).length).toBeLessThanOrEqual(12);
+  });
+
+  test("truncates an over-long marker line", () => {
+    const long = `${UNREMOVABLE} ${"x".repeat(2000)}`;
+    const [m] = extractGitLockMarkers(long);
+    expect(m.line.length).toBeLessThanOrEqual(601);
+    expect(m.line.endsWith("…")).toBe(true);
+  });
+});
+
+describe("toolResponseToText", () => {
+  test("passes a string through", () => {
+    expect(toolResponseToText(DIAG)).toBe(DIAG);
+  });
+  test("joins stdout + stderr on an object response", () => {
+    expect(toolResponseToText({ stdout: "out", stderr: "err" })).toBe("out\nerr");
+  });
+  test("flattens an array of text content blocks", () => {
+    expect(toolResponseToText([{ type: "text", text: DIAG }, { type: "text", text: "x" }])).toBe(
+      `${DIAG}\nx`,
+    );
+  });
+  test("unknown shapes yield empty string (no markers)", () => {
+    expect(toolResponseToText(42)).toBe("");
+    expect(toolResponseToText(null)).toBe("");
+    expect(toolResponseToText({ foo: 1 })).toBe("");
+  });
+});
+
+describe("drift guard: every sentinel the shell script emits is mirrored", () => {
+  // The extractor's MARKER_RE is a hand-maintained copy of the sentinel names in
+  // worktree-manager.sh. If the script gains/renames a SOLEUR_GIT_LOCK_* sentinel and
+  // this copy is not updated, the new wedge signal would go silently unmirrored — the
+  // exact blindness this feature closes. Pin the two in sync: every `echo "SOLEUR_GIT_LOCK_*`
+  // literal in the script must be matched by extractGitLockMarkers.
+  test("extractor matches every SOLEUR_GIT_LOCK_* sentinel echoed by worktree-manager.sh", () => {
+    const script = readFileSync(
+      join(
+        __dirname,
+        "../../../plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh",
+      ),
+      "utf8",
+    );
+    const sentinels = [...script.matchAll(/echo "(SOLEUR_GIT_LOCK_[A-Z_]+)/g)].map((m) => m[1]);
+    const unique = [...new Set(sentinels)];
+    expect(unique.length).toBeGreaterThan(0); // non-vacuous: the script DOES emit sentinels
+    for (const name of unique) {
+      const sample = `${name} file=.git/config.lock type=chardevice rdev=1:3`;
+      expect(
+        extractGitLockMarkers(sample).length,
+        `sentinel ${name} echoed by worktree-manager.sh is not matched by the telemetry extractor — update MARKER_RE`,
+      ).toBe(1);
+    }
+  });
+});
+
+describe("createGitLockMarkerHook", () => {
+  const call = (input: unknown) =>
+    createGitLockMarkerHook("/ws/abc")(input as never, undefined, {} as never);
+
+  test("is a no-op for non-Bash tools", async () => {
+    const out = await call({ tool_name: "Read", tool_response: UNREMOVABLE });
+    expect(out).toEqual({});
+  });
+
+  test("is a no-op for Bash output with no markers", async () => {
+    const out = await call({ tool_name: "Bash", tool_response: "Preparing worktree\ndone" });
+    expect(out).toEqual({});
+  });
+
+  test("returns {} (observe-only) when markers ARE present", async () => {
+    const out = await call({ tool_name: "Bash", tool_response: `${DIAG}\n${UNREMOVABLE}` });
+    expect(out).toEqual({});
+  });
+
+  test("never throws — fail-open on a malformed input", async () => {
+    const weird = { get tool_name() { throw new Error("boom"); } };
+    await expect(call(weird)).resolves.toEqual({});
+  });
+});

--- a/apps/web-platform/test/worktree-config-seed.test.ts
+++ b/apps/web-platform/test/worktree-config-seed.test.ts
@@ -1,0 +1,68 @@
+// Unit tests for seedWorktreeConfig — the host-side pre-seed that makes in-sandbox
+// worktree creation a zero-write no-op past the SDK's `.git/config.lock` mask (#4826).
+import { describe, test, expect, afterEach } from "vitest";
+import { execFileSync } from "child_process";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { seedWorktreeConfig } from "../server/worktree-config-seed";
+
+const made: string[] = [];
+function freshRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "seed-test-"));
+  made.push(dir);
+  execFileSync("git", ["init", "-q"], { cwd: dir, stdio: "pipe" });
+  return dir;
+}
+function cfg(dir: string, key: string): string | null {
+  try {
+    return execFileSync("git", ["config", "--get", key], { cwd: dir, stdio: "pipe" })
+      .toString()
+      .trim();
+  } catch {
+    return null; // git config --get exits non-zero when the key is absent
+  }
+}
+
+afterEach(() => {
+  for (const d of made.splice(0)) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+});
+
+describe("seedWorktreeConfig", () => {
+  test("sets the two worktree-config prerequisites", () => {
+    const dir = freshRepo();
+    seedWorktreeConfig(dir);
+    expect(cfg(dir, "extensions.worktreeConfig")).toBe("true");
+    expect(cfg(dir, "core.repositoryformatversion")).toBe("1");
+  });
+
+  test("clears core.bare / core.worktree so they never live in shared config", () => {
+    const dir = freshRepo();
+    // A bare-ish leftover the in-sandbox ensure_bare_config would otherwise try to unset.
+    execFileSync("git", ["config", "core.bare", "false"], { cwd: dir, stdio: "pipe" });
+    seedWorktreeConfig(dir);
+    expect(cfg(dir, "core.bare")).toBeNull();
+    expect(cfg(dir, "core.worktree")).toBeNull();
+  });
+
+  test("is idempotent — a second run keeps the target state and does not throw", () => {
+    const dir = freshRepo();
+    seedWorktreeConfig(dir);
+    expect(() => seedWorktreeConfig(dir)).not.toThrow();
+    expect(cfg(dir, "extensions.worktreeConfig")).toBe("true");
+  });
+
+  test("no-ops (no throw) when the path has no .git — nothing to seed", () => {
+    const empty = mkdtempSync(join(tmpdir(), "seed-empty-"));
+    made.push(empty);
+    expect(() => seedWorktreeConfig(empty)).not.toThrow();
+    // No .git → git config would have errored; the guard skips it entirely.
+    expect(cfg(empty, "extensions.worktreeConfig")).toBeNull();
+  });
+});

--- a/knowledge-base/project/learnings/bug-fixes/2026-07-05-config-lock-mask-is-sdk-bwrap-not-substrate-preseed-host-side.md
+++ b/knowledge-base/project/learnings/bug-fixes/2026-07-05-config-lock-mask-is-sdk-bwrap-not-substrate-preseed-host-side.md
@@ -84,11 +84,35 @@ per-worktree config (`config.worktree`, unmasked).
   red in CI" gap by stripping the ambient state CI lacks
   (`env GIT_CONFIG_GLOBAL=/dev/null GIT_AUTHOR_NAME= …`) — don't assume flake.
 
+## Follow-up round 2 — a provision-time fix does not heal EXISTING workspaces
+
+The #6064 pre-seed ran ONLY in `provisionWorkspace`/`provisionWorkspaceWithRepo`
+(workspace-creation time). A fresh session on a workspace that was **provisioned before
+the fix shipped** still wedged: the persistent `/workspaces/<id>` `.git` was never
+seeded, so in-sandbox `ensure_bare_config` still tried to write the masked shared config.
+A fresh *session* is not a fresh *workspace* — the wedged `.git` persists on the volume.
+
+**Fix:** also call `seedWorktreeConfig` from `ensureWorkspaceRepoCloned` — the host-side,
+**per-session** boot path that already runs before the sandbox exists — on BOTH the
+existing-valid-workspace no-op return and the fresh-graft path. Idempotent; every boot
+heals the workspace. Extracted the seeder to its own module (`worktree-config-seed.ts`)
+so the hot boot path does not import workspace.ts's full provisioning graph.
+
+**Lesson:** when a fix mutates state at CREATE time, ask "what about the population that
+already exists?" A migration/boot-time re-apply is almost always also required — the
+install-time hook alone silently excludes every pre-existing entity. New evidence also
+showed `.git/config.worktree` masked as a char device (not just `.git/config.lock`),
+consistent with the SDK masking both git-config write targets; it does not block the fix
+because `git worktree add` writes to an unmasked `.git/worktrees/<id>/` subdir.
+
 ## Follow-ups
 
-- **Observability (open):** mirror the in-sandbox `SOLEUR_GIT_LOCK_*` markers to a
-  queryable sink so the next wedge is self-diagnosable without asking the operator to
-  paste `findmnt`. This blindness forced two round-trips and is the meta-bug.
+- **Observability (DONE, this PR):** a fail-open `PostToolUse(Bash)` hook
+  (`git-lock-marker-telemetry.ts`) scans Bash output for the `SOLEUR_GIT_LOCK_*` /
+  "worktree wedge" markers and re-emits them via the SERVER-SIDE logger (→ Better Stack +
+  Sentry breadcrumb). Closes ADR-081's "blind sandbox stdout, not mirrored to any
+  queryable sink" gap so the next wedge is self-diagnosable without a `findmnt`
+  round-trip. A drift guard pins the extractor's sentinel set against worktree-manager.sh.
 
 ## Tags
 category: bug-fixes


### PR DESCRIPTION
Follow-up to #6064 — closes two gaps a fresh-session retry exposed.

## Gap 1 — existing workspaces still wedged (the actual user-facing failure)

#6064's pre-seed ran ONLY at **provision** time (`provisionWorkspace` / `provisionWorkspaceWithRepo`). A workspace **created before #6064 shipped** persists on the `/workspaces/<id>` volume and was never seeded — so in-sandbox `ensure_bare_config` still tried to write the SDK-masked `.git/config.lock` and kept wedging. **A fresh session is not a fresh workspace.**

**Fix:** also call `seedWorktreeConfig` from `ensureWorkspaceRepoCloned` — the host-side, **per-session** boot path that runs before the sandbox mask exists — on both the existing-valid-workspace no-op return and the fresh-graft path. Idempotent; every boot heals the workspace. Extracted the seeder to `worktree-config-seed.ts` (with a `.git`-absent no-op guard) so the hot boot path doesn't pull in `workspace.ts`'s full provisioning graph.

## Gap 2 — the observability blind spot (ADR-081's open follow-up)

The in-sandbox `SOLEUR_GIT_LOCK_*` / `worktree wedge` markers went only to blind agent-sandbox stdout, so diagnosing #4826 twice required the operator to paste `findmnt`. New `git-lock-marker-telemetry.ts`: a **fail-open, observe-only `PostToolUse(Bash)` hook** that scans Bash output for the markers and re-emits them via the **server-side logger** (→ Better Stack + Sentry breadcrumb). A wedge (`UNREMOVABLE`/`TEMP_WEDGED`/`worktree wedge`) logs at `error`, a benign `DIAG` at `warn`. Always-on (a wedge is path-agnostic); privacy-bounded (emits only matched marker lines, capped count/length). A **drift guard** pins the extractor's sentinel set against `worktree-manager.sh` so a renamed sentinel fails CI instead of going silently unmirrored.

## New evidence folded in

The failing session showed `.git/config.worktree` *also* masked as a char device (not just `.git/config.lock`) — consistent with the SDK masking both git-config write targets. It does **not** block the fix: `git worktree add` writes to an unmasked `.git/worktrees/<id>/` subdir. The telemetry hook will now confirm this from real markers instead of a `findmnt` round-trip.

## Tests (72 pass, tsc clean)

- `worktree-config-seed.test.ts` — real temp git repo: the 4 transformations, `.git`-absent no-op, idempotence.
- `git-lock-marker-telemetry.test.ts` — extractor, `tool_response` coercion, hook fail-open/classification, bounded-output caps, + the shell-script drift guard.
- `ensure-workspace-repo.test.ts` — a valid-workspace boot re-seeds.
- `agent-runner-query-options.test.ts` — updated for the always-on Bash hook + opt-in Skill hints.

## Verification honesty

Tests pass, but the real test remains **a fresh Concierge session creating a worktree** after this deploys. I am not claiming end-to-end fixed until the operator confirms — and this time, if it still wedges, the telemetry hook captures the exact forensic automatically (no `findmnt` ask).

## Changelog

Heal existing workspaces' worktree git config on session boot, and mirror in-sandbox git-lock wedge markers to Better Stack for self-diagnosis (#4826).

🤖 Generated with [Claude Code](https://claude.com/claude-code)