### PR TITLE
fix(worktree): stop bare-repo surgery on non-bare workspaces + heal the seed regression (#4826)

### DIFF
--- a/apps/web-platform/server/ensure-workspace-repo.ts
+++ b/apps/web-platform/server/ensure-workspace-repo.ts
@@ -243,12 +243,12 @@ export async function ensureWorkspaceRepoCloned(
   // handled and removed just above; a non-stranding in-workspace pointer is a
   // valid linked tree we intentionally preserve here.)
   if (isValidGitWorkTree(workspacePath)) {
-    // #4826 — re-seed the worktree-config prerequisites HOST-SIDE on every session
-    // boot of an EXISTING valid workspace. The #6064 provision-time seed only reaches
-    // workspaces created AFTER it shipped; a workspace provisioned earlier persists on
-    // the volume and would keep wedging in-sandbox worktree creation (the SDK masks
-    // `.git/config.lock`) forever. This heals that population idempotently. Best-effort
-    // (never throws); a failure just falls back to the in-sandbox write path.
+    // #4826 — HEAL the worktree git config HOST-SIDE on every session boot of an EXISTING
+    // valid workspace. Workspaces damaged by the earlier (#6064/#6068) seed carry a
+    // persisted `extensions.worktreeConfig=true` that makes in-sandbox git fatal on the
+    // masked/unreadable `.git/config.worktree`; this unsets it (host-side, where that path
+    // is readable) so git works and `git worktree add` runs natively. Idempotent +
+    // best-effort (never throws); a no-op on an already-healthy workspace.
     seedWorktreeConfig(workspacePath);
     return "ok";
   }
@@ -309,8 +309,8 @@ export async function ensureWorkspaceRepoCloned(
   try {
     await graftFn(workspacePath, repoUrl, installationId);
 
-    // #4826 — seed worktree-config prerequisites into the freshly-grafted `.git`
-    // (host-side, before the sandbox mask), same as the provision-time clone path.
+    // #4826 — heal worktree git config on the freshly-grafted `.git` (host-side),
+    // same as the provision-time clone path. A no-op on a clean clone.
     seedWorktreeConfig(workspacePath);
 
     // Sub-PR 3.D (#5274 Phase 3, ADR-068) — clone-from-git-data read-source

--- a/apps/web-platform/server/git-lock-marker-telemetry.ts
+++ b/apps/web-platform/server/git-lock-marker-telemetry.ts
@@ -30,16 +30,22 @@ import { reportSilentFallback } from "./observability";
 
 const log = createChildLogger("git-lock-marker-telemetry");
 
-// Matches the marker sentinels emitted by
-// plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh. Kept in sync with
-// that script; a drift test (git-lock-marker-telemetry.test.ts) pins the pattern set
-// against the live script so a renamed sentinel fails CI instead of going silently
-// unmirrored.
+// Matches the marker sentinels emitted by two in-sandbox surfaces:
+//   - worktree-manager.sh — the git-lock wedge markers (SOLEUR_GIT_LOCK_*, "worktree wedge:")
+//   - git-repo-readiness-diag.sh — the readiness-gate forensic (SOLEUR_GIT_REPO_DIAG),
+//     emitted by soleur:go Step 0.0 when git rejects the workspace repo (a layer ABOVE
+//     worktree creation, previously uninstrumented — #4826 round 3).
+// Kept in sync with those scripts; a drift test (git-lock-marker-telemetry.test.ts) pins
+// the pattern set against the live scripts so a renamed sentinel fails CI instead of going
+// silently unmirrored.
 const MARKER_RE =
-  /^(?:SOLEUR_GIT_LOCK_(?:DIAG|UNREMOVABLE|TEMP_WEDGED)\b.*|worktree wedge:.*)$/;
+  /^(?:SOLEUR_GIT_LOCK_(?:DIAG|UNREMOVABLE|TEMP_WEDGED)\b.*|SOLEUR_GIT_REPO_DIAG\b.*|worktree wedge:.*)$/;
 
-// A wedge (vs. a benign DIAG) is any marker that indicates creation could not proceed.
-const WEDGE_RE = /^(?:SOLEUR_GIT_LOCK_(?:UNREMOVABLE|TEMP_WEDGED)\b|worktree wedge:)/;
+// A wedge (vs. a benign DIAG) is any marker that indicates git operations could not
+// proceed: an unremovable/masked lock, a temp-wedge, an ensure_bare_config give-up, OR a
+// readiness-gate rejection (SOLEUR_GIT_REPO_DIAG is only emitted on the not-ready path).
+const WEDGE_RE =
+  /^(?:SOLEUR_GIT_LOCK_(?:UNREMOVABLE|TEMP_WEDGED)\b|SOLEUR_GIT_REPO_DIAG\b|worktree wedge:)/;
 
 // Bounds: scan at most this many lines, keep at most this many matched markers, and
 // truncate any single marker line to this many chars. A wedged run emits a handful of
@@ -127,12 +133,13 @@ export function createGitLockMarkerHook(workspacePath: string): HookCallback {
         markerCount: markers.length,
         markers: markers.map((m) => m.line),
       };
-      // A wedge is an error (a blocked session); a DIAG-only run is a warning. Both reach
-      // Better Stack (pino → stdout → journald → vector) and a Sentry breadcrumb.
+      // A wedge is an error (a blocked session — a git-lock wedge OR a readiness-gate
+      // rejection); a benign DIAG is a warning. Both reach Better Stack (pino → stdout →
+      // journald → vector) and a Sentry breadcrumb.
       if (anyWedged) {
-        log.error(payload, "in-sandbox git-lock wedge detected (worktree creation blocked)");
+        log.error(payload, "in-sandbox git wedge/rejection detected (worktree or readiness-gate blocked)");
       } else {
-        log.warn(payload, "in-sandbox git-lock diagnostic emitted (no wedge)");
+        log.warn(payload, "in-sandbox git diagnostic emitted (no wedge)");
       }
       return {};
     } catch (err) {

--- a/apps/web-platform/server/workspace.ts
+++ b/apps/web-platform/server/workspace.ts
@@ -130,13 +130,11 @@ export async function provisionWorkspace(workspaceId: string): Promise<string> {
     log.warn({ err, workspaceId }, "Git init failed");
   }
 
-  // Pre-seed worktree-config prerequisites HOST-SIDE, before the sandbox masks
-  // .git/config.lock, so in-sandbox worktree creation is a zero-write no-op (#4826).
-  // Deliberately OUTSIDE the init/commit try: it must run whenever `git init`
-  // produced a `.git/`, even if the initial `git add`/`git commit` failed — e.g. a
-  // runner (or prod host) with no git identity throws at commit, and gating the seed
-  // behind it would silently re-wedge worktree creation. seedWorktreeConfig is itself
-  // best-effort (per-call try/catch), so calling it when `.git/` is absent is a no-op.
+  // Heal worktree git config HOST-SIDE (#4826): remove any extensions.worktreeConfig
+  // that would force in-sandbox git to read the masked/unreadable .git/config.worktree
+  // and fatal. Deliberately OUTSIDE the init/commit try so it runs whenever `git init`
+  // produced a `.git/` even if `git add`/`git commit` failed (e.g. no git identity on a
+  // runner). Best-effort + no-op on a healthy/absent-`.git` workspace.
   seedWorktreeConfig(workspacePath);
 
   return workspacePath;
@@ -254,9 +252,9 @@ export async function provisionWorkspaceWithRepo(
     }
   }
 
-  // 6.5. Pre-seed worktree-config prerequisites HOST-SIDE, before the agent
-  // sandbox bind-mounts /dev/null over .git/config.lock, so the in-sandbox
-  // worktree creation path is a zero-write no-op and never wedges (#4826).
+  // 6.5. Heal worktree git config HOST-SIDE (#4826): a fresh clone has no
+  // extensions.worktreeConfig, so this is a no-op here — but keeps the provision and
+  // session-boot paths symmetric with ensureWorkspaceRepoCloned.
   seedWorktreeConfig(workspacePath);
 
   // 7-9. Overlay plugin symlink, .claude/settings.json, and KB scaffolding

--- a/apps/web-platform/server/worktree-config-seed.ts
+++ b/apps/web-platform/server/worktree-config-seed.ts
@@ -1,69 +1,90 @@
-// Host-side pre-seed of the git config that in-sandbox worktree creation needs —
-// applied BEFORE the agent sandbox bind-mounts /dev/null over `.git/config.lock`.
+// Host-side HEAL of a workspace's worktree git config (#4826).
 //
-// The Claude Agent SDK's bubblewrap masks git-config write targets (`.git/config.lock`,
-// and per live evidence `.git/config.worktree`) with a read-only /dev/null bind mount —
-// a per-session in-sandbox guard against git-config RCE via `core.hooksPath`/
-// `core.sshCommand`. Inside the sandbox, any `git config` WRITE to the shared config
-// fails EEXIST against that masked lock, so `worktree-manager.sh`'s `ensure_bare_config`
-// (which sets `core.repositoryformatversion=1` + `extensions.worktreeConfig=true` and
-// clears `core.bare`/`core.worktree` before `git worktree add`) wedges (#4826).
+// HISTORY (important — this file's behavior was INVERTED). #6064/#6068 shipped a
+// `seedWorktreeConfig` that SET `extensions.worktreeConfig=true` on the workspace, to
+// pre-empt worktree-manager.sh's `ensure_bare_config` config writes wedging on the
+// SDK-masked `.git/config.lock`. That was WRONG for a normal (non-bare) Concierge clone:
+// enabling worktreeConfig FORCES git to read `.git/config.worktree` on every command, and
+// in the agent sandbox that path is a /dev/null CHAR DEVICE owned by nobody:nogroup that
+// the agent user cannot read → `fatal: unable to access '.git/config.worktree': Permission
+// denied` → EVERY git command fails (readiness gate → "workspace isn't ready"). The seed
+// turned a deep worktree-creation wedge into total git breakage.
 //
-// Performing that exact transformation HOST-SIDE, before the mask exists, makes the
-// in-sandbox `ensure_bare_config` a ZERO-WRITE no-op: `atomic_git_config` read-first-skips
-// the two SETs (a read never takes the lock) and skips both UNSETs (keys already absent);
-// `git worktree add` then writes only `.git/worktrees/<id>/` (a fresh, unmasked subdir).
+// CORRECT MODEL: a Concierge workspace is a NORMAL working clone. `git worktree add` works
+// on it natively with ZERO shared-config surgery — the bare-repo `ensure_bare_config`
+// transformation (now guarded off for non-bare repos in worktree-manager.sh) is neither
+// needed nor safe here. So this function's job is the INVERSE of the old seed: HEAL a
+// non-bare workspace by UNSETTING the harmful `extensions.worktreeConfig` a prior version
+// wrote (and resetting the format version), restoring plain-repo semantics.
 //
-// This module is standalone (only `child_process` + the logger) so the hot per-session
-// boot path (`ensureWorkspaceRepoCloned`) can call it WITHOUT pulling in workspace.ts's
-// full provisioning dependency graph.
+// Runs HOST-SIDE (provision + every session boot via ensureWorkspaceRepoCloned), where
+// `.git/config.worktree` is NOT masked, so these git ops work even for a workspace that is
+// currently wedged in-sandbox. Idempotent + best-effort (never throws): a healthy workspace
+// has nothing to unset; a bare repo is left untouched.
 
 import { execFileSync } from "child_process";
-import { existsSync } from "node:fs";
+import { statSync } from "node:fs";
 import { join } from "node:path";
 import { createChildLogger } from "./logger";
 
 const log = createChildLogger("worktree-config-seed");
 
+/** True iff `<workspacePath>/.git` is a DIRECTORY — i.e. a normal working clone, not a
+ *  bare repo (no `.git` subdir) and not a linked-worktree pointer (`.git` is a FILE). */
+function isNonBareWorkingClone(workspacePath: string): boolean {
+  try {
+    return statSync(join(workspacePath, ".git")).isDirectory();
+  } catch {
+    return false; // absent / unreadable → nothing to heal here
+  }
+}
+
 /**
- * Idempotently pre-seed the worktree-config prerequisites into `<workspacePath>/.git`.
+ * Heal a normal (non-bare) workspace's worktree config so in-sandbox git works and
+ * `git worktree add` runs natively. Removes the `extensions.worktreeConfig` key (whose
+ * presence forces git to read the sandbox-masked `.git/config.worktree` and fatal) and
+ * resets `core.repositoryformatversion` to 0. No-op on a bare repo or a `.git`-less path.
  *
- * Best-effort by contract: a failure degrades to the in-sandbox write path (no worse
- * than not calling it), so every step logs and continues rather than throwing. Safe to
- * re-run every session — the values are set-to-target, so repeats are no-ops. A no-op
- * when `<workspacePath>/.git` is absent (nothing to seed, and `git config` would fail).
- *
- * Runs at BOTH:
- *   - provision time (`provisionWorkspace` / `provisionWorkspaceWithRepo`) — new workspaces
- *   - session boot (`ensureWorkspaceRepoCloned`) — EXISTING workspaces provisioned before
- *     this fix shipped, which would otherwise never be seeded and keep wedging (#4826).
+ * NOTE: retains the export name `seedWorktreeConfig` (its two call sites) though its
+ * behavior is now a heal, not a seed — a rename is deferred to avoid churn in this
+ * hotfix. Best-effort: every step logs on failure and continues.
  */
 export function seedWorktreeConfig(workspacePath: string): void {
-  // A `.git` may be a directory (normal repo) or a file (linked-worktree pointer);
-  // either is seedable. Absent → nothing to do (a repo-less "Start Fresh" dir mid-init).
-  if (!existsSync(join(workspacePath, ".git"))) return;
+  if (!isNonBareWorkingClone(workspacePath)) return;
 
-  // SETs mirror ensure_bare_config exactly. repositoryformatversion=1 MUST precede the
-  // extensions.* write for git to honor the extension namespace. Failures are logged
-  // (they gate in-sandbox success) but never thrown.
-  for (const [key, value] of [
-    ["core.repositoryformatversion", "1"],
-    ["extensions.worktreeConfig", "true"],
-  ] as const) {
-    try {
-      execFileSync("git", ["config", key, value], { cwd: workspacePath, stdio: "pipe" });
-    } catch (err) {
-      log.warn({ err, workspacePath, key }, "Failed to pre-seed worktree git config");
-    }
+  // The load-bearing heal: remove extensions.worktreeConfig. Probe presence first so a
+  // no-op on a healthy workspace stays silent, and a real failure to clear a PRESENT key
+  // is surfaced loudly (that key is what keeps in-sandbox git wedged).
+  let hadWorktreeConfig = false;
+  try {
+    execFileSync("git", ["config", "--get", "extensions.worktreeConfig"], {
+      cwd: workspacePath,
+      stdio: "pipe",
+    });
+    hadWorktreeConfig = true;
+  } catch {
+    // absent → healthy, nothing to unset.
   }
-  // UNSETs: core.bare / core.worktree belong in per-worktree config, not shared (a normal
-  // clone/init carries `core.bare=false`). `--unset` of an absent key exits non-zero;
-  // that is expected, so these are silent best-effort.
-  for (const key of ["core.bare", "core.worktree"] as const) {
-    try {
-      execFileSync("git", ["config", "--unset", key], { cwd: workspacePath, stdio: "pipe" });
-    } catch {
-      // absent key (or already-unset) — nothing to do.
-    }
+  if (!hadWorktreeConfig) return;
+
+  try {
+    execFileSync("git", ["config", "--unset-all", "extensions.worktreeConfig"], {
+      cwd: workspacePath,
+      stdio: "pipe",
+    });
+    // Reset the format version bumped alongside the old seed. Harmless if already 0.
+    execFileSync("git", ["config", "core.repositoryformatversion", "0"], {
+      cwd: workspacePath,
+      stdio: "pipe",
+    });
+    log.warn(
+      { workspacePath, sec: true },
+      "healed workspace: removed harmful extensions.worktreeConfig (#4826 regression)",
+    );
+  } catch (err) {
+    log.error(
+      { err, workspacePath },
+      "FAILED to heal extensions.worktreeConfig — in-sandbox git may stay wedged (#4826)",
+    );
   }
 }

--- a/apps/web-platform/test/git-lock-marker-telemetry.test.ts
+++ b/apps/web-platform/test/git-lock-marker-telemetry.test.ts
@@ -33,6 +33,15 @@ describe("extractGitLockMarkers", () => {
     expect(extractGitLockMarkers(TEMP_WEDGED)[0]?.wedged).toBe(true);
   });
 
+  test("matches the readiness-gate SOLEUR_GIT_REPO_DIAG forensic and treats it as wedged", () => {
+    const repoDiag =
+      'SOLEUR_GIT_REPO_DIAG ready=false git_dir=dir config_worktree=chardevice config_lock=chardevice rev_parse_rc=128 config_parse_rc=128 err="fatal: bad config line 1 in file .git/config"';
+    const [m] = extractGitLockMarkers(repoDiag);
+    expect(m?.line).toBe(repoDiag);
+    // SOLEUR_GIT_REPO_DIAG is emitted ONLY on the not-ready path → always a blocked session.
+    expect(m?.wedged).toBe(true);
+  });
+
   test("returns [] for output with no markers, and for empty input", () => {
     expect(extractGitLockMarkers("just some normal git output\nProsuming worktree")).toEqual([]);
     expect(extractGitLockMarkers("")).toEqual([]);
@@ -80,22 +89,25 @@ describe("drift guard: every sentinel the shell script emits is mirrored", () =>
   // this copy is not updated, the new wedge signal would go silently unmirrored — the
   // exact blindness this feature closes. Pin the two in sync: every `echo "SOLEUR_GIT_LOCK_*`
   // literal in the script must be matched by extractGitLockMarkers.
-  test("extractor matches every SOLEUR_GIT_LOCK_* sentinel echoed by worktree-manager.sh", () => {
-    const script = readFileSync(
-      join(
-        __dirname,
-        "../../../plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh",
-      ),
-      "utf8",
+  test("extractor matches every SOLEUR_GIT_* sentinel echoed by the two shell scripts", () => {
+    const scripts = [
+      "../../../plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh",
+      "../../../plugins/soleur/skills/git-worktree/scripts/git-repo-readiness-diag.sh",
+    ].map((p) => readFileSync(join(__dirname, p), "utf8"));
+    // Both scripts emit `echo "SOLEUR_GIT_..."` sentinels; collect the union.
+    const sentinels = scripts.flatMap((s) =>
+      [...s.matchAll(/echo "(SOLEUR_GIT_[A-Z_]+)/g)].map((m) => m[1]),
     );
-    const sentinels = [...script.matchAll(/echo "(SOLEUR_GIT_LOCK_[A-Z_]+)/g)].map((m) => m[1]);
     const unique = [...new Set(sentinels)];
-    expect(unique.length).toBeGreaterThan(0); // non-vacuous: the script DOES emit sentinels
+    expect(unique.length).toBeGreaterThan(0); // non-vacuous: the scripts DO emit sentinels
+    // Every emitted sentinel must be mirrored — except the readiness-READY status line,
+    // which is a control signal for go.md (ready path), not a forensic to log.
     for (const name of unique) {
+      if (name === "SOLEUR_GIT_REPO_READY") continue;
       const sample = `${name} file=.git/config.lock type=chardevice rdev=1:3`;
       expect(
         extractGitLockMarkers(sample).length,
-        `sentinel ${name} echoed by worktree-manager.sh is not matched by the telemetry extractor — update MARKER_RE`,
+        `sentinel ${name} echoed by a git-worktree script is not matched by the telemetry extractor — update MARKER_RE`,
       ).toBe(1);
     }
   });

--- a/apps/web-platform/test/workspace.test.ts
+++ b/apps/web-platform/test/workspace.test.ts
@@ -75,12 +75,12 @@ describe("workspace provisioning", () => {
     expect(existsSync(path1)).toBe(true);
   });
 
-  // #4826 — pre-seed the worktree-config prerequisites HOST-SIDE so in-sandbox
-  // worktree creation is a zero-write no-op and never wedges on the SDK's
-  // /dev/null mask over .git/config.lock. Asserts the exact state that makes
-  // ensure_bare_config's atomic_git_config calls take their read-first idempotent
-  // path (SETs already at target) and skip the UNSET block (keys already absent).
-  test("pre-seeds worktree-config prerequisites host-side (#4826 config.lock-mask bypass)", async () => {
+  // #4826 (corrected) — a provisioned NORMAL workspace must NOT have
+  // extensions.worktreeConfig set. Enabling it forces git to read the sandbox-masked
+  // (unreadable) .git/config.worktree and fatals every git command. The seed now HEALS
+  // (removes) that key rather than setting it; a fresh clone has it absent, and
+  // `git worktree add` works natively without any bare-repo surgery.
+  test("provisioned workspace has NO extensions.worktreeConfig (#4826 regression guard)", async () => {
     const userId = randomUUID();
     const path = await provisionWorkspace(userId);
     const cfg = (key: string): string | null => {
@@ -95,25 +95,19 @@ describe("workspace provisioning", () => {
         return null; // git config --get exits non-zero when the key is absent
       }
     };
-    // SETs pre-applied at their target values → in-sandbox writes become no-ops.
-    expect(cfg("extensions.worktreeConfig")).toBe("true");
-    expect(cfg("core.repositoryformatversion")).toBe("1");
-    // UNSET targets absent → in-sandbox ensure_bare_config skips them (no write).
-    expect(cfg("core.bare")).toBeNull();
-    expect(cfg("core.worktree")).toBeNull();
+    expect(cfg("extensions.worktreeConfig")).toBeNull();
+    expect(cfg("core.repositoryformatversion")).not.toBe("1");
   });
 
-  test("pre-seed is idempotent — re-provisioning keeps the target config state", async () => {
+  test("re-provisioning keeps extensions.worktreeConfig absent (idempotent heal)", async () => {
     const userId = randomUUID();
     await provisionWorkspace(userId);
     const path = await provisionWorkspace(userId);
-    expect(
+    expect(() =>
       execFileSync("git", ["config", "--get", "extensions.worktreeConfig"], {
         cwd: path,
         stdio: "pipe",
-      })
-        .toString()
-        .trim(),
-    ).toBe("true");
+      }),
+    ).toThrow(); // --get on an absent key exits non-zero
   });
 });

--- a/apps/web-platform/test/worktree-config-seed.test.ts
+++ b/apps/web-platform/test/worktree-config-seed.test.ts
@@ -1,5 +1,6 @@
-// Unit tests for seedWorktreeConfig — the host-side pre-seed that makes in-sandbox
-// worktree creation a zero-write no-op past the SDK's `.git/config.lock` mask (#4826).
+// Unit tests for seedWorktreeConfig — the host-side HEAL that removes the harmful
+// extensions.worktreeConfig a prior version wrote, so in-sandbox git (reading a masked
+// .git/config.worktree) stops fataling and `git worktree add` runs natively (#4826).
 import { describe, test, expect, afterEach } from "vitest";
 import { execFileSync } from "child_process";
 import { mkdtempSync, rmSync } from "fs";
@@ -34,35 +35,36 @@ afterEach(() => {
   }
 });
 
-describe("seedWorktreeConfig", () => {
-  test("sets the two worktree-config prerequisites", () => {
+describe("seedWorktreeConfig (heal)", () => {
+  test("removes the harmful extensions.worktreeConfig a prior seed wrote", () => {
     const dir = freshRepo();
+    // Simulate a workspace broken by the old seed.
+    execFileSync("git", ["config", "extensions.worktreeConfig", "true"], { cwd: dir, stdio: "pipe" });
+    execFileSync("git", ["config", "core.repositoryformatversion", "1"], { cwd: dir, stdio: "pipe" });
     seedWorktreeConfig(dir);
-    expect(cfg(dir, "extensions.worktreeConfig")).toBe("true");
-    expect(cfg(dir, "core.repositoryformatversion")).toBe("1");
+    expect(cfg(dir, "extensions.worktreeConfig")).toBeNull(); // unset → in-sandbox git works
+    expect(cfg(dir, "core.repositoryformatversion")).toBe("0"); // reset to plain-repo default
   });
 
-  test("clears core.bare / core.worktree so they never live in shared config", () => {
+  test("no-ops on a healthy normal repo (no worktreeConfig to remove)", () => {
     const dir = freshRepo();
-    // A bare-ish leftover the in-sandbox ensure_bare_config would otherwise try to unset.
-    execFileSync("git", ["config", "core.bare", "false"], { cwd: dir, stdio: "pipe" });
     seedWorktreeConfig(dir);
-    expect(cfg(dir, "core.bare")).toBeNull();
-    expect(cfg(dir, "core.worktree")).toBeNull();
+    expect(cfg(dir, "extensions.worktreeConfig")).toBeNull();
+    // A healthy clone is untouched — repositoryformatversion stays whatever git init set.
   });
 
-  test("is idempotent — a second run keeps the target state and does not throw", () => {
+  test("is idempotent — a second run does not throw and keeps it healed", () => {
     const dir = freshRepo();
+    execFileSync("git", ["config", "extensions.worktreeConfig", "true"], { cwd: dir, stdio: "pipe" });
     seedWorktreeConfig(dir);
     expect(() => seedWorktreeConfig(dir)).not.toThrow();
-    expect(cfg(dir, "extensions.worktreeConfig")).toBe("true");
+    expect(cfg(dir, "extensions.worktreeConfig")).toBeNull();
   });
 
-  test("no-ops (no throw) when the path has no .git — nothing to seed", () => {
+  test("no-ops (no throw) when the path has no .git directory", () => {
     const empty = mkdtempSync(join(tmpdir(), "seed-empty-"));
     made.push(empty);
     expect(() => seedWorktreeConfig(empty)).not.toThrow();
-    // No .git → git config would have errored; the guard skips it entirely.
     expect(cfg(empty, "extensions.worktreeConfig")).toBeNull();
   });
 });

--- a/knowledge-base/project/learnings/bug-fixes/2026-07-05-config-lock-mask-is-sdk-bwrap-not-substrate-preseed-host-side.md
+++ b/knowledge-base/project/learnings/bug-fixes/2026-07-05-config-lock-mask-is-sdk-bwrap-not-substrate-preseed-host-side.md
@@ -105,6 +105,43 @@ showed `.git/config.worktree` masked as a char device (not just `.git/config.loc
 consistent with the SDK masking both git-config write targets; it does not block the fix
 because `git worktree add` writes to an unmasked `.git/worktrees/<id>/` subdir.
 
+## Follow-up round 3 — the pre-seed was a self-inflicted REGRESSION; the real fix is "don't do bare surgery on a non-bare repo"
+
+The #6064/#6068 pre-seed set `extensions.worktreeConfig=true` on the workspace. That is
+the bare-repo `ensure_bare_config` transformation — and it is WRONG for a Concierge
+workspace, which is a **normal non-bare clone**. Enabling worktreeConfig forces git to read
+`.git/config.worktree` on EVERY command; in-sandbox that path is a `/dev/null` **char
+device owned by nobody:nogroup that the agent user cannot read** → `fatal: unable to access
+'.git/config.worktree': Permission denied` → every git command fails → the readiness gate
+fires ("workspace isn't ready"). **The pre-seed turned a deep worktree wedge into total git
+breakage.**
+
+Why it wasn't caught: the local repro used a **symlink to /dev/null** (readable → empty →
+git fine). The real mask is an **unreadable** char device, so git fatals. `chmod 000
+.git/config.worktree` + `worktreeConfig=true` reproduces the exact `Permission denied`
+fatal; without worktreeConfig, git ignores the file and works.
+
+The correct fix, three rounds late:
+- **`git worktree add` works natively on a normal repo** with ZERO shared-config surgery —
+  verified. The entire `ensure_bare_config` transformation is a BARE-repo accommodation.
+- **worktree-manager.sh:** `ensure_bare_config` now early-returns on a non-bare repo (a
+  `.git` DIRECTORY, filesystem check — never a git command, since git may be wedged).
+- **worktree-config-seed.ts:** inverted from SET to HEAL — for a non-bare workspace it
+  UNSETS `extensions.worktreeConfig` (host-side, where config.worktree is not masked),
+  repairing the population the bad seed already damaged.
+- **soleur:go readiness gate:** now runs `git-repo-readiness-diag.sh`, which captures git's
+  discarded stderr into a `SOLEUR_GIT_REPO_DIAG` marker mirrored to Better Stack — so a
+  readiness-gate rejection is self-diagnosing (this layer was above the worktree-wedge
+  instrumentation and previously blind).
+
+**Meta-lesson (the expensive one): a fix that ADDS state to work around a constraint can be
+worse than the bug.** Four rounds of "add config / add re-seed" each moved the failure to a
+new layer. The fix that finally worked REMOVED the intervention (don't run bare surgery on a
+non-bare repo). When a workaround keeps spawning new failure modes, question whether the
+intervention itself is the problem — and reproduce with the EXACT adversarial condition
+(an *unreadable* node, not a readable stand-in), because the permission bit was the whole
+difference between "repro passes" and "prod fatals".
+
 ## Follow-ups
 
 - **Observability (DONE, this PR):** a fail-open `PostToolUse(Bash)` hook

--- a/plugins/soleur/commands/go.md
+++ b/plugins/soleur/commands/go.md
@@ -18,13 +18,16 @@ Do not proceed until there is input from the user.
 
 ## Step 0.0: Workspace Readiness Gate
 
-Before the session-start preamble and before any routing, confirm a usable git repository exists. Run:
+Before the session-start preamble and before any routing, confirm a usable git repository exists. Run the readiness probe (it decides readiness AND, on failure, emits a `SOLEUR_GIT_REPO_DIAG` forensic line that the server-side telemetry hook mirrors to Better Stack — so a not-ready workspace is self-diagnosable without a manual probe):
 
 ```bash
-git rev-parse --is-bare-repository 2>/dev/null || true; git rev-parse --is-inside-work-tree 2>/dev/null || true
+bash ./plugins/soleur/skills/git-worktree/scripts/git-repo-readiness-diag.sh 2>&1 \
+  || { git rev-parse --is-bare-repository 2>/dev/null || true; git rev-parse --is-inside-work-tree 2>/dev/null || true; }
 ```
 
-If **neither** command prints `true` (no bare repo to make a worktree from AND not inside a working tree), the workspace has no git checkout. In the Soleur web (Concierge) environment this happens when a connected repository is still cloning in the background, or its setup failed — the CWD is then a repo-less `/workspaces/<id>` and **every** route (`go`/`brainstorm`/`plan`/`one-shot`/`fix`/`drain`) will fail: worktree creation, knowledge-base artifact writes, and the session-start preamble all need a real repo. Do NOT run the preamble, do NOT route, do NOT improvise filesystem exploration. STOP and reply with this honest, no-wait message:
+The `||` fallback runs the bare inline probes if the script is unavailable (e.g. a repo-less workspace whose plugin symlink was not scaffolded). Readiness = the output contains `SOLEUR_GIT_REPO_READY=true` (script path) OR a bare `true` (fallback path).
+
+If the output shows `SOLEUR_GIT_REPO_READY=false` (or, on the fallback, **neither** probe printed `true`), the workspace has no usable git checkout. In the Soleur web (Concierge) environment this happens when a connected repository is still cloning in the background, or its setup failed (the CWD is then a repo-less `/workspaces/<id>`), OR the `.git` is present but git rejects it (a corrupt/masked config — the emitted `SOLEUR_GIT_REPO_DIAG config_parse_rc`/`err=` fields distinguish these). **Every** route (`go`/`brainstorm`/`plan`/`one-shot`/`fix`/`drain`) will fail: worktree creation, knowledge-base artifact writes, and the session-start preamble all need a real repo. Do NOT run the preamble, do NOT route, do NOT improvise filesystem exploration. STOP and reply with this honest, no-wait message:
 
 > Your workspace isn't ready yet — its repository is still being set up, or its setup didn't finish. Please try again in a moment. If this keeps happening: if your project lives in a **team workspace**, switch to that workspace and try again; if this is your own workspace, check that a repository is connected in **Settings → Repository**.
 

--- a/plugins/soleur/skills/git-worktree/scripts/git-repo-readiness-diag.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/git-repo-readiness-diag.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Workspace git-repo readiness probe WITH forensic capture (#4826 follow-up).
+#
+# soleur:go's Step 0.0 readiness gate previously ran
+#   git rev-parse --is-bare-repository 2>/dev/null || true; git rev-parse --is-inside-work-tree 2>/dev/null || true
+# and DISCARDED git's stderr. When git rejected the repo (a masked/corrupt config,
+# a broken .git, an in-flight clone) the gate fired its "workspace isn't ready"
+# message with NO record of WHY — the exact blind spot that forced a manual
+# `git rev-parse` + `findmnt` round-trip to diagnose the #4826 config.worktree case.
+#
+# This script decides readiness identically (prints `SOLEUR_GIT_REPO_READY=true`
+# iff git considers the CWD a work tree or bare repo) AND, on the NOT-ready path,
+# emits a single-line `SOLEUR_GIT_REPO_DIAG` forensic to stdout. The server-side
+# PostToolUse(Bash) telemetry hook (git-lock-marker-telemetry.ts) mirrors that line
+# to Better Stack + Sentry, so the next readiness-gate failure is self-diagnosable
+# without asking the operator to paste terminal output.
+#
+# Output contract (go.md keys on these):
+#   ready   → prints `SOLEUR_GIT_REPO_READY=true`,  exit 0
+#   not     → prints `SOLEUR_GIT_REPO_READY=false` + a `SOLEUR_GIT_REPO_DIAG …` line, exit 0
+# Always exit 0: this is a diagnostic, never a hard failure that aborts the gate.
+#
+# Privacy: emits only git's own error text + filesystem type/mount metadata — no repo
+# contents. The stderr is sanitized to one line and length-bounded before emission.
+
+set -uo pipefail
+
+# ftype <path> — classify an inode for the forensic (mirrors worktree-manager.sh's
+# SOLEUR_GIT_LOCK_DIAG vocabulary so the two are greppable together).
+ftype() {
+  local p="$1"
+  if [[ ! -e "$p" && ! -L "$p" ]]; then echo "absent"; return; fi
+  if [[ -L "$p" ]]; then echo "symlink"; return; fi
+  if [[ -c "$p" ]]; then echo "chardevice"; return; fi
+  if [[ -b "$p" ]]; then echo "blockdevice"; return; fi
+  if [[ -d "$p" ]]; then echo "dir"; return; fi
+  if [[ -p "$p" ]]; then echo "fifo"; return; fi
+  if [[ -f "$p" ]]; then echo "regular"; return; fi
+  echo "other"
+}
+
+# sanitize <text> — collapse to a single line and bound length; strip the wrapping
+# so a hostile/huge stderr cannot bloat the mirrored log line.
+sanitize() {
+  printf '%s' "$1" | tr '\n\r\t' '   ' | sed 's/  */ /g' | cut -c1-400
+}
+
+# Readiness = git recognizes the CWD as a work tree OR a bare repo. Capture stderr.
+wt_err="$(git rev-parse --is-inside-work-tree 2>&1 >/dev/null)"; wt_rc=$?
+wt_out="$(git rev-parse --is-inside-work-tree 2>/dev/null)"
+bare_out="$(git rev-parse --is-bare-repository 2>/dev/null)"
+
+if [[ "$wt_out" == "true" || "$bare_out" == "true" ]]; then
+  echo "SOLEUR_GIT_REPO_READY=true"
+  exit 0
+fi
+
+# NOT ready — capture the forensic. `git config --list` re-run separately: a config
+# PARSE failure (e.g. an unreadable/masked config, an unknown extension under
+# repositoryformatversion=1) is the discriminator between "no repo yet" (clone
+# in-flight) and "repo present but git rejects it".
+cfg_err="$(git config --list 2>&1 >/dev/null)"; cfg_rc=$?
+
+git_dir_type="$(ftype ".git")"
+cw_type="$(ftype ".git/config.worktree")"
+cl_type="$(ftype ".git/config.lock")"
+
+# Prefer the config-parse error when git rejected the repo (more specific than the
+# generic rev-parse "not a git repository"); fall back to the rev-parse stderr.
+err_text="$cfg_err"
+[[ -z "$err_text" ]] && err_text="$wt_err"
+
+echo "SOLEUR_GIT_REPO_READY=false"
+echo "SOLEUR_GIT_REPO_DIAG ready=false git_dir=${git_dir_type} config_worktree=${cw_type} config_lock=${cl_type} rev_parse_rc=${wt_rc} config_parse_rc=${cfg_rc} err=\"$(sanitize "$err_text")\""
+exit 0

--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -434,23 +434,6 @@ atomic_git_config() {
 # Called before AND after git worktree add (add re-corrupts the shared config).
 # Safe for parallel sessions: all operations are idempotent.
 ensure_bare_config() {
-  # NON-BARE GUARD (#4826). This whole function is a BARE-repo accommodation: on a
-  # bare repo `git worktree add` corrupts the shared config (see header), and setting
-  # extensions.worktreeConfig=true is what steers those writes off the shared config.
-  # A NORMAL working clone (the Concierge workspace layout: a `.git` DIRECTORY,
-  # core.bare=false) needs NONE of this — `git worktree add` writes only to
-  # `.git/worktrees/<id>/` and never corrupts shared config. Worse, enabling
-  # worktreeConfig on such a repo FORCES git to read `.git/config.worktree` on every
-  # command; in the agent sandbox that path is a /dev/null char device the agent user
-  # CANNOT read → `fatal: unable to access '.git/config.worktree': Permission denied`
-  # breaks EVERY git command (the #4826 regression). So: skip entirely on a non-bare
-  # repo. Filesystem check only (a `.git` DIRECTORY ⇒ non-bare), never a git command —
-  # git may already be wedged by the very worktreeConfig this guard avoids. `git worktree
-  # add` on a normal repo is verified to work with zero shared-config surgery.
-  if [[ -d "$GIT_ROOT/.git" ]]; then
-    return 0
-  fi
-
   local git_dir="$GIT_ROOT/.git"
   # Only relevant for bare repos (git dir IS the repo root)
   if [[ ! -d "$git_dir" ]]; then
@@ -458,16 +441,34 @@ ensure_bare_config() {
   fi
 
   # Self-heal: sweep BEFORE the config writes below for its diagnostics + stale
-  # REGULAR-lock removal (the 2026-07-01 outage class). A NON-REGULAR (masked) lock
-  # is NO LONGER fatal here — atomic_git_config routes every write below around it
-  # via a lockless temp-copy+rename (#5912). So we intentionally ignore the sweep's
-  # non-zero return: the per-write gate in atomic_git_config makes the correct
-  # native-vs-lockless choice, and a genuinely stuck REGULAR lock (a real in-flight
-  # writer) still surfaces as a native `git config` EEXIST failure from
-  # atomic_git_config's clean-lock branch. `|| true` disarms set -e; the sweep's
-  # SOLEUR_GIT_LOCK_DIAG / SOLEUR_GIT_LOCK_UNREMOVABLE sentinels still print for
-  # the blind-surface forensic.
+  # REGULAR-lock removal (the 2026-07-01 outage class). Runs on EVERY repo (bare or
+  # normal) — it writes NO config, only removes stale regular locks and emits the
+  # blind-surface SOLEUR_GIT_LOCK_* forensic — so it stays ABOVE the non-bare guard
+  # below. A NON-REGULAR (masked) lock is NO LONGER fatal here — atomic_git_config
+  # routes every write below around it via a lockless temp-copy+rename (#5912). So we
+  # intentionally ignore the sweep's non-zero return: the per-write gate in
+  # atomic_git_config makes the correct native-vs-lockless choice, and a genuinely
+  # stuck REGULAR lock (a real in-flight writer) still surfaces as a native `git config`
+  # EEXIST failure from atomic_git_config's clean-lock branch. `|| true` disarms set -e.
   sweep_stale_git_locks "$git_dir" || true
+
+  # NON-BARE GUARD (#4826). Everything BELOW is a BARE-repo accommodation: on a bare
+  # repo `git worktree add` corrupts the shared config (see header), and setting
+  # extensions.worktreeConfig=true is what steers those writes off the shared config.
+  # A NORMAL working clone (the Concierge workspace layout: a `.git` DIRECTORY,
+  # core.bare=false) needs NONE of it — `git worktree add` writes only to
+  # `.git/worktrees/<id>/` and never corrupts shared config. Worse, enabling
+  # worktreeConfig on such a repo FORCES git to read `.git/config.worktree` on every
+  # command; in the agent sandbox that path is a /dev/null char device the agent user
+  # CANNOT read → `fatal: unable to access '.git/config.worktree': Permission denied`
+  # breaks EVERY git command (the #4826 regression). So: skip the config surgery on a
+  # non-bare repo (the diagnostic sweep above already ran). Filesystem check only (a
+  # `.git` DIRECTORY ⇒ non-bare), never a git command — git may already be wedged by
+  # the very worktreeConfig this guard avoids. Verified: `git worktree add` on a normal
+  # repo works with zero shared-config surgery.
+  if [[ -d "$GIT_ROOT/.git" ]]; then
+    return 0
+  fi
 
   local shared_config="$git_dir/config"
   local wt_config="$git_dir/config.worktree"

--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -434,6 +434,23 @@ atomic_git_config() {
 # Called before AND after git worktree add (add re-corrupts the shared config).
 # Safe for parallel sessions: all operations are idempotent.
 ensure_bare_config() {
+  # NON-BARE GUARD (#4826). This whole function is a BARE-repo accommodation: on a
+  # bare repo `git worktree add` corrupts the shared config (see header), and setting
+  # extensions.worktreeConfig=true is what steers those writes off the shared config.
+  # A NORMAL working clone (the Concierge workspace layout: a `.git` DIRECTORY,
+  # core.bare=false) needs NONE of this — `git worktree add` writes only to
+  # `.git/worktrees/<id>/` and never corrupts shared config. Worse, enabling
+  # worktreeConfig on such a repo FORCES git to read `.git/config.worktree` on every
+  # command; in the agent sandbox that path is a /dev/null char device the agent user
+  # CANNOT read → `fatal: unable to access '.git/config.worktree': Permission denied`
+  # breaks EVERY git command (the #4826 regression). So: skip entirely on a non-bare
+  # repo. Filesystem check only (a `.git` DIRECTORY ⇒ non-bare), never a git command —
+  # git may already be wedged by the very worktreeConfig this guard avoids. `git worktree
+  # add` on a normal repo is verified to work with zero shared-config surgery.
+  if [[ -d "$GIT_ROOT/.git" ]]; then
+    return 0
+  fi
+
   local git_dir="$GIT_ROOT/.git"
   # Only relevant for bare repos (git dir IS the repo root)
   if [[ ! -d "$git_dir" ]]; then

--- a/plugins/soleur/test/worktree-manager-atomic-config.test.sh
+++ b/plugins/soleur/test/worktree-manager-atomic-config.test.sh
@@ -246,28 +246,25 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-echo "Test 12: #4826 host-side pre-seed -> the in-sandbox ensure_bare_config sequence is a ZERO-WRITE no-op"
-# Mirrors seedWorktreeConfig (apps/web-platform/server/workspace.ts): pre-apply the
-# exact target state HOST-SIDE, then wedge config.lock non-regular (== the SDK's
-# /dev/null bind-mount mask). Each of the four mutations ensure_bare_config runs must
-# take its read-first / absent-key SKIP — rc 0, NO write past the mask, no temp. This
-# is why pre-seeding unblocks worktree creation without ever touching the masked lock.
-D=$(new_gitdir); seed_config "$D"
-git config --file "$D/config" core.repositoryformatversion 1     # pre-seed (host-side)
-git config --file "$D/config" extensions.worktreeConfig true     # pre-seed (host-side)
-# core.bare / core.worktree intentionally absent (seedWorktreeConfig unsets them).
-mkdir "$D/config.lock"                                           # non-regular lock == masked/wedged
-run_agc "$D/config" core.repositoryformatversion 1
-assert_eq "0" "$AGC_RC" "pre-seeded repositoryformatversion SET is a zero-write skip"
-run_agc "$D/config" extensions.worktreeConfig true
-assert_eq "0" "$AGC_RC" "pre-seeded worktreeConfig SET is a zero-write skip"
-run_agc "$D/config" --unset core.bare
-assert_eq "0" "$AGC_RC" "absent core.bare --unset is a zero-write skip"
-run_agc "$D/config" --unset core.worktree
-assert_eq "0" "$AGC_RC" "absent core.worktree --unset is a zero-write skip"
-no_temp_leftovers "$D" "#4826 pre-seed no-op (nothing written past the masked lock)"
-assert_eq "true" "$(get_val "$D" extensions.worktreeConfig)" "worktreeConfig value intact"
-rm -rf "$D/config.lock"
+echo "Test 12: #4826 ensure_bare_config is a NO-OP on a normal (non-bare) repo"
+# The #4826 regression: ensure_bare_config unconditionally enabled extensions.worktreeConfig,
+# which on a normal Concierge clone forces git to read the sandbox-masked (unreadable)
+# .git/config.worktree and fatals EVERY git command. Fix: a `.git` DIRECTORY ⇒ non-bare ⇒
+# the whole bare-accommodation is skipped, so `git worktree add` runs natively with NO
+# shared-config surgery (no worktreeConfig, no config.lock write, no masked-file read).
+WS12=$(mktemp -d "$TMP/nonbare.XXXXXX"); git init -q -b main "$WS12" >/dev/null 2>&1
+_SAVED_GIT_ROOT="$GIT_ROOT"
+GIT_ROOT="$WS12"
+set +e; ensure_bare_config >"$TMP/ebc.out" 2>&1; EBC_RC=$?; set -e
+GIT_ROOT="$_SAVED_GIT_ROOT"
+assert_eq "0" "$EBC_RC" "ensure_bare_config returns 0 (no-op) on a non-bare repo"
+assert_eq "__ABSENT__" "$(git config --file "$WS12/.git/config" --get extensions.worktreeConfig 2>/dev/null || echo __ABSENT__)" \
+  "extensions.worktreeConfig NOT set on the non-bare repo (the #4826 regression is gone)"
+if git config --file "$WS12/.git/config" --get core.repositoryformatversion 2>/dev/null | grep -qx 1; then
+  echo "  FAIL: repositoryformatversion bumped to 1 on a non-bare repo"; FAIL=$((FAIL + 1))
+else
+  echo "  PASS: repositoryformatversion left at plain-repo default on the non-bare repo"; PASS=$((PASS + 1))
+fi
 
 echo ""
 print_results


### PR DESCRIPTION
**This reverts a regression I introduced in #6064/#6068 and ships the actual #4826 fix.**

## Confirmed root cause (from the wedged session's own output)

A Concierge workspace is a **normal non-bare clone**. `worktree-manager.sh`'s `ensure_bare_config` unconditionally set `extensions.worktreeConfig=true` — a **bare-repo accommodation** — which forces git to read `.git/config.worktree` on *every* command. In the agent sandbox that path is a **`/dev/null` char device owned by `nobody:nogroup` that the agent user cannot read** → `fatal: unable to access '.git/config.worktree': Permission denied` on every git command → `soleur:go`'s readiness gate fires ("workspace isn't ready").

The #6064/#6068 pre-seed **made it worse**: it persisted `worktreeConfig=true` host-side, turning a deep worktree-creation wedge into *total git breakage*.

**`git worktree add` works natively on a normal repo with zero shared-config surgery** (verified). None of the bare surgery was ever needed here.

## Fix

1. **`worktree-manager.sh`** — `ensure_bare_config` early-returns on a non-bare repo (a `.git` **directory** — a filesystem check, never a git command, since git may be wedged). No worktreeConfig, no `config.lock` write, no masked-file read.
2. **`worktree-config-seed.ts`** — **inverted from set→heal.** For a non-bare workspace it *unsets* `extensions.worktreeConfig` (host-side, where `config.worktree` is readable), repairing the population the bad seed already damaged. Idempotent, best-effort, no-op on a healthy/bare repo.
3. **`soleur:go` readiness gate** — now runs `git-repo-readiness-diag.sh`, which captures git's *discarded stderr* into a `SOLEUR_GIT_REPO_DIAG` marker mirrored to Better Stack by the telemetry hook. The readiness-gate layer (above worktree creation, previously blind) is now self-diagnosing.
4. **`git-lock-marker-telemetry.ts`** — extended to mirror `SOLEUR_GIT_REPO_DIAG`; the drift guard now pins **both** shell scripts.

## Why it took four rounds (the honest bit)

My local repro used a **symlink** to /dev/null (readable → empty → git fine). The real mask is an **unreadable** char device, so git fatals. `chmod 000 .git/config.worktree` + `worktreeConfig=true` reproduces the exact `Permission denied` fatal. **The permission bit was the whole difference between "repro passes" and "prod breaks."** The meta-lesson (in the learning file): a fix that *adds* state to work around a constraint kept moving the failure to a new layer; the fix that worked *removed* the intervention.

## Tests (73 TS + 31 shell, tsc clean)

- `worktree-config-seed.test.ts` — heal removes worktreeConfig; no-op on healthy/bare/absent.
- `worktree-manager-atomic-config.test.sh` Test 12 — `ensure_bare_config` no-ops on a non-bare repo (regression gone).
- `git-lock-marker-telemetry.test.ts` — mirrors `SOLEUR_GIT_REPO_DIAG`; two-script drift guard.
- `workspace.test.ts` — provisioned workspace has NO worktreeConfig (regression guard).

## Verification

Reproduced end-to-end locally: broken state (worktreeConfig + unreadable config.worktree) → git fatals; **heal** (unset host-side) → git works even with config.worktree still unreadable → `git worktree add` succeeds. But the real test remains **a fresh Concierge session on the already-damaged workspace** after this deploys — the session-boot heal should repair it. I'll confirm via the `SOLEUR_GIT_REPO_DIAG` telemetry (should stop appearing) rather than declare success.

## Changelog

Fix #4826: stop applying bare-repo git surgery to normal Concierge workspaces (which broke all git commands via the sandbox-masked `.git/config.worktree`), heal already-damaged workspaces on session boot, and instrument the readiness gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)