### PR TITLE
fix(worktree): harden non-bare guard against empty GIT_ROOT (#4826 round 5)

### DIFF
--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -452,21 +452,30 @@ ensure_bare_config() {
   # EEXIST failure from atomic_git_config's clean-lock branch. `|| true` disarms set -e.
   sweep_stale_git_locks "$git_dir" || true
 
-  # NON-BARE GUARD (#4826). Everything BELOW is a BARE-repo accommodation: on a bare
-  # repo `git worktree add` corrupts the shared config (see header), and setting
-  # extensions.worktreeConfig=true is what steers those writes off the shared config.
-  # A NORMAL working clone (the Concierge workspace layout: a `.git` DIRECTORY,
-  # core.bare=false) needs NONE of it — `git worktree add` writes only to
-  # `.git/worktrees/<id>/` and never corrupts shared config. Worse, enabling
-  # worktreeConfig on such a repo FORCES git to read `.git/config.worktree` on every
-  # command; in the agent sandbox that path is a /dev/null char device the agent user
-  # CANNOT read → `fatal: unable to access '.git/config.worktree': Permission denied`
-  # breaks EVERY git command (the #4826 regression). So: skip the config surgery on a
-  # non-bare repo (the diagnostic sweep above already ran). Filesystem check only (a
-  # `.git` DIRECTORY ⇒ non-bare), never a git command — git may already be wedged by
-  # the very worktreeConfig this guard avoids. Verified: `git worktree add` on a normal
-  # repo works with zero shared-config surgery.
-  if [[ -d "$GIT_ROOT/.git" ]]; then
+  # NON-BARE GUARD (#4826, hardened round 5). Everything BELOW is a BARE-repo
+  # accommodation: on a bare repo `git worktree add` corrupts the shared config (see
+  # header), and setting extensions.worktreeConfig=true steers those writes off it. A
+  # NORMAL working clone (the Concierge workspace layout, core.bare=false) needs NONE of
+  # it — `git worktree add` writes only to `.git/worktrees/<id>/`. Worse, enabling
+  # worktreeConfig FORCES git to read `.git/config.worktree`, which in the agent sandbox
+  # is an unreadable /dev/null char device → `fatal: … Permission denied` on EVERY git
+  # command. So: proceed with the surgery ONLY when the repo is DEFINITIVELY bare;
+  # default to SKIP.
+  #
+  # WHY not just `[[ -d "$GIT_ROOT/.git" ]]`: that was the round-4 guard and it FAILED in
+  # the live sandbox — the surgery still ran and wedged despite the guard being present
+  # (verified: user's cleanup-merged, 2026-07-06). Root cause: `$GIT_ROOT` was empty
+  # there (its `git rev-parse --show-toplevel` resolution returned nothing under the
+  # masked config), so `[[ -d "$GIT_ROOT/.git" ]]` became `[[ -d "/.git" ]]` → false →
+  # the guard did not fire. Git's own `--is-bare-repository` is authoritative and
+  # independent of GIT_ROOT-path resolution; `${GIT_ROOT:-.}` falls back to the CWD (the
+  # workspace) when GIT_ROOT is empty. SKIP unless it returns exactly "true": a normal
+  # clone ("false"), an indeterminate/error (""), or a transiently-wedged git all skip
+  # safely — none of them want bare surgery. A genuine bare repo (CLI dev repo, no `.git`
+  # subdir) returns "true" AND has no `.git` dir, so it correctly proceeds.
+  local _bare_status
+  _bare_status="$(git -C "${GIT_ROOT:-.}" rev-parse --is-bare-repository 2>/dev/null || true)"
+  if [[ -d "$GIT_ROOT/.git" || "$_bare_status" != "true" ]]; then
     return 0
   fi
 

--- a/plugins/soleur/test/worktree-manager-atomic-config.test.sh
+++ b/plugins/soleur/test/worktree-manager-atomic-config.test.sh
@@ -266,5 +266,30 @@ else
   echo "  PASS: repositoryformatversion left at plain-repo default on the non-bare repo"; PASS=$((PASS + 1))
 fi
 
+# ---------------------------------------------------------------------------
+echo "Test 13: #4826 round-5 — guard STILL fires on a normal repo when GIT_ROOT is EMPTY"
+# The round-4 guard was `[[ -d "\$GIT_ROOT/.git" ]]` alone. In the live sandbox GIT_ROOT
+# resolved EMPTY (git rev-parse --show-toplevel returned nothing under the masked config),
+# so the check became `[[ -d "/.git" ]]` → false → the guard did NOT fire and the surgery
+# wedged on the masked config.lock (user's cleanup-merged, 2026-07-06). The hardened guard
+# adds git's authoritative `--is-bare-repository` with a `${GIT_ROOT:-.}` CWD fallback, so a
+# normal clone skips even when GIT_ROOT is empty. Simulate it: cd INTO the repo, blank
+# GIT_ROOT, plant a masked lock, and assert NO wedge + NO config write.
+WS13=$(mktemp -d "$TMP/emptyroot.XXXXXX"); git init -q -b main "$WS13" >/dev/null 2>&1
+mkdir "$WS13/.git/config.lock"   # non-regular (masked) lock — a write attempt would wedge
+_SAVED_GIT_ROOT="$GIT_ROOT"; _SAVED_PWD="$PWD"
+cd "$WS13"; GIT_ROOT=""          # the exact sandbox failure: empty GIT_ROOT, CWD is the repo
+set +e; ensure_bare_config >"$TMP/ebc13.out" 2>&1; EBC13_RC=$?; set -e
+GIT_ROOT="$_SAVED_GIT_ROOT"; cd "$_SAVED_PWD"
+assert_eq "0" "$EBC13_RC" "ensure_bare_config returns 0 with empty GIT_ROOT (git fallback fires)"
+if grep -qE "mv:|worktree wedge|config.soleur-tmp" "$TMP/ebc13.out"; then
+  echo "  FAIL: WEDGED on empty GIT_ROOT — the round-4 regression is NOT fixed"; FAIL=$((FAIL + 1))
+else
+  echo "  PASS: no config-write wedge on empty GIT_ROOT (hardened guard held)"; PASS=$((PASS + 1))
+fi
+assert_eq "__ABSENT__" "$(git config --file "$WS13/.git/config" --get extensions.worktreeConfig 2>/dev/null || echo __ABSENT__)" \
+  "worktreeConfig NOT set with empty GIT_ROOT (no surgery ran)"
+rm -rf "$WS13/.git/config.lock"
+
 echo ""
 print_results

--- a/plugins/soleur/test/worktree-manager-stale-lock-diag.test.sh
+++ b/plugins/soleur/test/worktree-manager-stale-lock-diag.test.sh
@@ -230,8 +230,12 @@ echo "        writer (#5912) -> prerequisites written, rc 0, wedge untouched, fo
 # no longer fails loud — atomic_git_config routes the shared-config writes around it
 # via a same-dir temp-copy+rename, so ensure_bare_config now SUCCEEDS and applies the
 # prerequisites that steer `git worktree add` off the wedged shared config.lock.
-BARE=$(new_lockdir)                    # acts as GIT_ROOT (no .git subdir -> git_dir=GIT_ROOT)
-printf '[core]\n\tsentinel = untouched\n' > "$BARE/config"
+BARE=$(new_lockdir); git init -q --bare "$BARE" >/dev/null 2>&1   # REAL bare repo (no .git
+                                       # subdir -> git_dir=GIT_ROOT). Must be a real bare repo
+                                       # so the #4826 hardened guard's `rev-parse
+                                       # --is-bare-repository` returns "true" and the surgery
+                                       # proceeds (the guard skips non-bare / fake dirs).
+printf '[core]\n\tbare = true\n\tsentinel = untouched\n' > "$BARE/config"   # keep bare=true
 mkdir "$BARE/config.lock"             # non-regular -> would EEXIST a native write
 touch -d "$OLD_MTIME" "$BARE/config.lock"
 GIT_ROOT="$BARE"
@@ -260,8 +264,8 @@ echo "Test 8b: a stale REGULAR lock that survives the sweep still FAILS LOUD (20
 # not-wedged for it, so atomic_git_config takes the NATIVE git-config branch, which
 # EEXISTs against the held regular lock and must make ensure_bare_config return non-zero
 # (a genuine in-flight writer / stuck lock must never be routed around).
-BARE2=$(new_lockdir)
-printf '[core]\n\tsentinel = untouched\n' > "$BARE2/config"
+BARE2=$(new_lockdir); git init -q --bare "$BARE2" >/dev/null 2>&1   # REAL bare repo (see Test 8)
+printf '[core]\n\tbare = true\n\tsentinel = untouched\n' > "$BARE2/config"
 printf 'held-by-a-real-writer\n' > "$BARE2/config.lock"   # REGULAR + fresh -> sweep leaves it
 GIT_ROOT="$BARE2"
 set +e


### PR DESCRIPTION
## The bug the last fix missed

#6071's guard was `if [[ -d "$GIT_ROOT/.git" ]]; then return 0; fi`. The user's fresh-session diagnostic proved it was **present in the live script** (`grep "NON-BARE GUARD" = 1`) yet `cleanup-merged` **still wedged** on the masked `config.lock`. 

Root cause: in the agent sandbox, **`GIT_ROOT` resolved empty** — `git rev-parse --show-toplevel` returned nothing under the masked config at resolution time — so the guard's check became `[[ -d "/.git" ]]` → false → **the guard never fired**, and the bare surgery ran and wedged. My local tests passed only because my filesystem resolves GIT_ROOT normally; the sandbox doesn't.

## Fix

Gate on git's **authoritative** `--is-bare-repository` instead of a fragile path check, with a `${GIT_ROOT:-.}` CWD fallback, defaulting to **skip**:

```bash
_bare_status="$(git -C "${GIT_ROOT:-.}" rev-parse --is-bare-repository 2>/dev/null || true)"
if [[ -d "$GIT_ROOT/.git" || "$_bare_status" != "true" ]]; then
  return 0   # non-bare / indeterminate / wedged-git → skip the surgery
fi
```

- **Normal clone** (even with empty GIT_ROOT): `git -C .` returns `false` → skip. **The exact sandbox failure, now fixed.**
- **Genuine bare repo** (CLI dev repo, no `.git` subdir, `core.bare=true`): returns `true` → proceeds. CLI workflow preserved.
- **Wedged/indeterminate git**: returns `""` → skip (safe default).

## Verified locally (the actual failure conditions)

- Normal repo + **empty GIT_ROOT** + masked `config.lock` → **no wedge**, no config write (was: wedge).
- Real bare repo → surgery still runs (worktreeConfig set, core.bare unset).
- Stale-lock self-heal + cleanup-merged sentinel still work.

## Tests

- `worktree-manager-atomic-config` **Test 13** — new: guard fires on empty GIT_ROOT (pins the regression).
- `worktree-manager-stale-lock-diag` **Test 8/8b** — fixtures upgraded to **real bare repos** (the hardened guard requires git to confirm bare; the old fake-dir fixtures couldn't).
- Both suites green (34 + 42).

## Why this keeps happening / honesty

This is round 5. Each fix was correct *for the condition I could reproduce* but the sandbox kept presenting a condition I couldn't see locally (unreadable char-device mask; then empty GIT_ROOT). The lesson (in the learning file): **a guard that depends on environment-derived state (`GIT_ROOT`) is only as reliable as that state** — anchoring to git's own authoritative answer is robust where a filesystem path check is not. After deploy, the true test is still a fresh Concierge session; and the `SOLEUR_GIT_LOCK_*` telemetry will now capture it if anything remains.

## Changelog

Harden the #4826 non-bare guard so it fires even when GIT_ROOT is empty in the agent sandbox (the condition that let bare-repo git surgery wedge a normal Concierge clone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)