### PR TITLE
fix(infra): name web-2's fresh-boot death in the pre-extraction install region (#6090)

### DIFF
--- a/.github/workflows/apply-web-platform-infra.yml
+++ b/.github/workflows/apply-web-platform-infra.yml
@@ -1185,9 +1185,12 @@ jobs:
         if: always()
         env:
           JOB_STATUS: ${{ job.status }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          # #6090: source the Sentry read creds from Doppler prd_terraform (like every other
+          # step in this job), NOT GitHub repo secrets — the repo secret SENTRY_AUTH_TOKEN is
+          # unset, so recreate 28805034101 logged this step as "Sentry query skipped" and the
+          # auto-read never ran. prd_terraform holds SENTRY_AUTH_TOKEN (event:read → HTTP 200 on
+          # the events endpoint), SENTRY_ORG (jikigai-eu), SENTRY_PROJECT (web-platform).
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         # Runs on SUCCESS too (#6090 spec-flow F4): a green boot must still show the probe
         # fired + which stage was last reached (bootstrap_complete → cloudflared_ready →
         # webhook_bound → cloud_init_complete), else "verify passed" is indistinguishable from
@@ -1196,6 +1199,12 @@ jobs:
         # recent window — best-effort, may show an unrelated host / may be empty.
         run: |
           set +e
+          # Resolve the Sentry read creds from Doppler prd_terraform (doppler CLI installed +
+          # DOPPLER_TOKEN set earlier in this job). No command-substitution-into-run risk: these
+          # are Doppler-sourced, never github.event.* input.
+          SENTRY_AUTH_TOKEN=$(doppler secrets get SENTRY_AUTH_TOKEN --plain -p soleur -c prd_terraform 2>/dev/null || true)
+          SENTRY_ORG=$(doppler secrets get SENTRY_ORG --plain -p soleur -c prd_terraform 2>/dev/null || true)
+          SENTRY_PROJECT=$(doppler secrets get SENTRY_PROJECT --plain -p soleur -c prd_terraform 2>/dev/null || true)
           # Pointer to the LOG too (not only the summary) so
           # `gh run view <id> --log | grep 'fresh-host Sentry pointer'` works (discoverability_test).
           echo "web-2-recreate — fresh-host Sentry pointer (job=${JOB_STATUS})"

--- a/.github/workflows/apply-web-platform-infra.yml
+++ b/.github/workflows/apply-web-platform-infra.yml
@@ -995,6 +995,15 @@ jobs:
           printf '::add-mask::%s\n' "$SECRET"
           printf 'AWS_ACCESS_KEY_ID=%s\n' "$KEY_ID" >> "$GITHUB_ENV"
           printf 'AWS_SECRET_ACCESS_KEY=%s\n' "$SECRET" >> "$GITHUB_ENV"
+          # #6090: the baked ${sentry_dsn} (TF_VAR_sentry_dsn ← this SENTRY_DSN) is the SOLE
+          # fatal-emit path for the pre-extraction fresh-boot stages (pkg_audit/doppler_dl) —
+          # doppler isn't installed yet there, so its fallback is dead. An empty SENTRY_DSN
+          # (var.sentry_dsn's TF default) would silently revert those stages to the zero-emit
+          # abort #6090 exists to end. Assert non-empty before -replace; do NOT print the value.
+          if [[ -z "$(doppler secrets get SENTRY_DSN --plain 2>/dev/null || true)" ]]; then
+            echo "::error::SENTRY_DSN is empty in Doppler prd_terraform — the fresh-boot fatal-emit would be dark for pre-extraction stages. Set it before recreating web-2 (#6090)."
+            exit 1
+          fi
 
       - name: Terraform init
         working-directory: ${{ env.INFRA_DIR }}

--- a/.github/workflows/apply-web-platform-infra.yml
+++ b/.github/workflows/apply-web-platform-infra.yml
@@ -1201,8 +1201,11 @@ jobs:
           set +e
           # Resolve the Sentry read creds from Doppler prd_terraform (doppler CLI installed +
           # DOPPLER_TOKEN set earlier in this job). No command-substitution-into-run risk: these
-          # are Doppler-sourced, never github.event.* input.
-          SENTRY_AUTH_TOKEN=$(doppler secrets get SENTRY_AUTH_TOKEN --plain -p soleur -c prd_terraform 2>/dev/null || true)
+          # are Doppler-sourced, never github.event.* input. Capture the fetch stderr + rc so a
+          # FETCH FAILURE (bad/absent secrets.DOPPLER_TOKEN, wrong scope, doppler CLI/API/network
+          # error) is NAMED — not collapsed into "not configured", which would re-create the exact
+          # silent-dark class (#6090 recreate 28805034101) this auto-read step exists to end.
+          SENTRY_AUTH_TOKEN=$(doppler secrets get SENTRY_AUTH_TOKEN --plain -p soleur -c prd_terraform 2>/tmp/doppler-sentry.err); dop_rc=$?
           SENTRY_ORG=$(doppler secrets get SENTRY_ORG --plain -p soleur -c prd_terraform 2>/dev/null || true)
           SENTRY_PROJECT=$(doppler secrets get SENTRY_PROJECT --plain -p soleur -c prd_terraform 2>/dev/null || true)
           # Pointer to the LOG too (not only the summary) so
@@ -1218,8 +1221,14 @@ jobs:
             fi
             echo "_Best-effort: host_id is unknown to the runner, so this matches on message + recent window — it may show an unrelated host or be empty._"
           } >> "$GITHUB_STEP_SUMMARY"
+          # Name the cause; `tee` so it lands in the step LOG too (grep-able via
+          # `gh run view <id> --log`), not only the collapsible step summary (#6090 discoverability).
+          if [[ "$dop_rc" -ne 0 ]]; then
+            echo "_Sentry query skipped: DOPPLER FETCH FAILED (rc=${dop_rc}) — verify secrets.DOPPLER_TOKEN scope/validity for soleur/prd_terraform. doppler stderr: $(tr '\n' ' ' </tmp/doppler-sentry.err | tail -c 300)_" | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           if [[ -z "${SENTRY_AUTH_TOKEN:-}" || -z "${SENTRY_ORG:-}" || -z "${SENTRY_PROJECT:-}" ]]; then
-            echo "_Sentry query skipped: SENTRY_AUTH_TOKEN / SENTRY_ORG / SENTRY_PROJECT not configured._" >> "$GITHUB_STEP_SUMMARY"
+            echo "_Sentry query skipped: fetch succeeded but SENTRY_AUTH_TOKEN / SENTRY_ORG / SENTRY_PROJECT is empty in Doppler prd_terraform (secret genuinely absent)._" | tee -a "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           # Lockstep with the emit MESSAGE literals (soleur-host-bootstrap.sh + cloud-init.yml's
@@ -1247,7 +1256,7 @@ jobs:
             || echo "$RESP" | jq -r '.[0:5][] | "- `\(.title // .message)` (\(.dateCreated // "?"))"' >> "$GITHUB_STEP_SUMMARY" 2>/dev/null \
             || true
           else
-            echo "_No matching fresh-host boot-stage event in the last hour (or the query failed)._" >> "$GITHUB_STEP_SUMMARY"
+            echo "_No matching fresh-host boot-stage event in the last hour (or the query failed)._" | tee -a "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: web-2-recreate summary

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -265,7 +265,8 @@ runcmd:
   # live STAGE tag — docker IS the hostscript-seed prerequisite, so the message stays accurate.
   # NOTE: the trap fires only under `set -e`, which the package audit turns on — so emit coverage
   # effectively begins at the audit; the preceding `systemctl restart sshd` stays deliberately
-  # non-fatal (its own comment below) and is intentionally NOT emit-covered.
+  # non-fatal (its own comment below) and is intentionally NOT emit-covered. The emit is a curl
+  # POST, so a curl-less host (which dies everywhere) is an accepted residual.
   - |
     IMAGE_REF='${image_name}'
     STAGE=pkg_audit
@@ -337,6 +338,7 @@ runcmd:
   # fail2ban is installed via `packages:` above; the service auto-starts on
   # install with the defaults-debian.conf [sshd] jail enabled. The reload
   # picks up the bantime.maxtime cap before any login activity is recorded.
+  - STAGE=fail2ban  # (#6090) exact stage attribution for the top-armed on_err fatal
   - systemctl reload fail2ban || systemctl restart fail2ban
 
   # (#5921) journald persistence (mkdir /var/log/journal + systemd-tmpfiles + restart +

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -254,6 +254,43 @@ write_files:
   # terminal --log-driver journald app container, starts after extraction.
 
 runcmd:
+  # (#6090 follow-up) Arm the baked-${sentry_dsn} fatal-emit trap at the TOP of runcmd so it
+  # ALSO covers the package-audit + doppler + docker install region below. That region runs
+  # under the `set -e` leaked from the package audit but PRE-DATES the host-script extraction
+  # block where on_err used to be defined — the blind spot that silently aborted web-2's fresh
+  # boot (recreate 28805034101: 0 emits, :9000 unbound). STAGE is bumped per install step so the
+  # fatal names the exact dying command; the extraction block re-sets STAGE=pull onward and
+  # disarms this trap (trap - EXIT) before handing off to the trusted baked installer. on_err
+  # emits `soleur-hostscript-seed failed` (already in the workflow QUERY + AC8 lockstep) with the
+  # live STAGE tag — docker IS the hostscript-seed prerequisite, so the message stays accurate.
+  - |
+    IMAGE_REF='${image_name}'
+    STAGE=pkg_audit
+    HOST_ID=$( (cat /var/lib/cloud/data/instance-id 2>/dev/null || hostname) | tr -d '"' )
+    on_err() {
+      trap - EXIT
+      docker rm -f soleur-hostscript-seed >/dev/null 2>&1 || true
+      ( set +e
+        . /etc/default/webhook-deploy 2>/dev/null || true
+        # Prefer the BAKED DSN so this fatal fires even when doppler is the broken stage (and
+        # even before doppler/docker are installed, which is exactly the region this now covers).
+        DSN='${sentry_dsn}'
+        [ -n "$DSN" ] || DSN=$(timeout 15 doppler secrets get SENTRY_DSN --plain --project soleur --config prd 2>/dev/null \
+               || timeout 15 doppler secrets get NEXT_PUBLIC_SENTRY_DSN --plain --project soleur --config prd 2>/dev/null || true)
+        if [ -n "$DSN" ]; then
+          KEY=$(printf '%s' "$DSN" | sed -E 's#https://([^@]+)@.*#\1#')
+          SHOST=$(printf '%s' "$DSN" | sed -E 's#https://[^@]+@([^/]+)/.*#\1#')
+          PROJ=$(printf '%s' "$DSN" | sed -E 's#.*/([0-9]+)$#\1#')
+          BODY=$(printf '{"message":"soleur-hostscript-seed failed","level":"fatal","tags":{"stage":"%s","image_ref":"%s","host_id":"%s"}}' "$STAGE" "$IMAGE_REF" "$HOST_ID")
+          curl -m 10 --retry 3 -sf -X POST "https://$SHOST/api/$PROJ/store/" \
+            -H 'Content-Type: application/json' \
+            -H "X-Sentry-Auth: Sentry sentry_version=7, sentry_key=$KEY" \
+            -d "$BODY" >/dev/null 2>&1 || true
+        fi ) || true
+      exit 1
+    }
+    trap on_err EXIT
+
   # Apply SSH hardening immediately (drop-in written by write_files above).
   # Runs BEFORE the package audit so the operator always has hardened SSH
   # access even if the audit exits non-zero and halts the rest of cloud-init.
@@ -305,6 +342,7 @@ runcmd:
   # migrates this early boot's volatile journal into the persistent store (no logs lost).
 
   # Install Doppler CLI v3.75.3 (for secrets injection) with checksum verification
+  - STAGE=doppler_dl  # (#6090) name the stage for the top-armed on_err fatal
   - |
     DOPPLER_VERSION="3.75.3"
     DOPPLER_SHA256="9c840cdd32cffff06d048329549ba2fa908146b385f21cd1d54bf34a0082d0db"
@@ -321,6 +359,7 @@ runcmd:
 
   # Install Docker via official APT repository with GPG key verification (#1615).
   # Replaces pipe-to-shell (curl | sh) with signed APT repo -- same pattern as cloudflared above.
+  - STAGE=docker_apt  # (#6090) name the stage for the top-armed on_err fatal
   - install -m 0755 -d /etc/apt/keyrings
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
   - chmod a+r /etc/apt/keyrings/docker.asc
@@ -339,6 +378,7 @@ runcmd:
       }
     }
     DOCKEREOF
+  - STAGE=docker_restart  # (#6090) name the stage for the top-armed on_err fatal
   - systemctl restart docker
 
   # BEGIN host-script extraction (#5921) — verify + launch the baked bootstrap installer.
@@ -348,37 +388,14 @@ runcmd:
   # combined content-hash, compare to host_scripts_content_hash, and ONLY THEN run the
   # now-trusted soleur-host-bootstrap.sh. FAIL-CLOSED: runcmd is ONE /bin/sh, so `set -e` +
   # `exit 1` aborts the whole runcmd (the app `docker run` never starts) + the terminal block
-  # gates on /run/soleur-hostscripts.ok; do NOT add a `set +e`. Pre-verify failures emit a
-  # discriminating Sentry event here (on_err); install-stage failures from the bootstrap.
+  # gates on /run/soleur-hostscripts.ok; do NOT add a `set +e`. Pull/extract/verify failures are
+  # named by the top-armed on_err trap (STAGE=pull/ghcr_login/extract/verify); install-stage
+  # failures come from the bootstrap's own emit_fail after the trap is disarmed below.
   - |
     set -e
     IMAGE_REF='${image_name}'
     HOST_SCRIPTS_HASH='${host_scripts_content_hash}'
     STAGE=pull
-    HOST_ID=$( (cat /var/lib/cloud/data/instance-id 2>/dev/null || hostname) | tr -d '"' )
-    on_err() {
-      trap - EXIT
-      docker rm -f soleur-hostscript-seed >/dev/null 2>&1 || true
-      ( set +e
-        . /etc/default/webhook-deploy 2>/dev/null || true
-        # Prefer the BAKED DSN so this fatal emit fires even when doppler is the broken
-        # stage (the blind spot that hid the private-GHCR seed-pull 401). Doppler fallback.
-        DSN='${sentry_dsn}'
-        [ -n "$DSN" ] || DSN=$(timeout 15 doppler secrets get SENTRY_DSN --plain --project soleur --config prd 2>/dev/null \
-               || timeout 15 doppler secrets get NEXT_PUBLIC_SENTRY_DSN --plain --project soleur --config prd 2>/dev/null || true)
-        if [ -n "$DSN" ]; then
-          KEY=$(printf '%s' "$DSN" | sed -E 's#https://([^@]+)@.*#\1#')
-          SHOST=$(printf '%s' "$DSN" | sed -E 's#https://[^@]+@([^/]+)/.*#\1#')
-          PROJ=$(printf '%s' "$DSN" | sed -E 's#.*/([0-9]+)$#\1#')
-          BODY=$(printf '{"message":"soleur-hostscript-seed failed","level":"fatal","tags":{"stage":"%s","image_ref":"%s","host_id":"%s"}}' "$STAGE" "$IMAGE_REF" "$HOST_ID")
-          curl -m 10 --retry 3 -sf -X POST "https://$SHOST/api/$PROJ/store/" \
-            -H 'Content-Type: application/json' \
-            -H "X-Sentry-Auth: Sentry sentry_version=7, sentry_key=$KEY" \
-            -d "$BODY" >/dev/null 2>&1 || true
-        fi ) || true
-      exit 1
-    }
-    trap on_err EXIT
     for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 2; done
     docker rm -f soleur-hostscript-seed >/dev/null 2>&1 || true
     # ROOT FIX (#6005): the seed image is now a PRIVATE GHCR package, so this early seed-pull

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -263,6 +263,9 @@ runcmd:
   # disarms this trap (trap - EXIT) before handing off to the trusted baked installer. on_err
   # emits `soleur-hostscript-seed failed` (already in the workflow QUERY + AC8 lockstep) with the
   # live STAGE tag — docker IS the hostscript-seed prerequisite, so the message stays accurate.
+  # NOTE: the trap fires only under `set -e`, which the package audit turns on — so emit coverage
+  # effectively begins at the audit; the preceding `systemctl restart sshd` stays deliberately
+  # non-fatal (its own comment below) and is intentionally NOT emit-covered.
   - |
     IMAGE_REF='${image_name}'
     STAGE=pkg_audit

--- a/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
+++ b/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
@@ -290,5 +290,43 @@ else
   no "AC11: webhook 'sha256sum -c -' must be '|| { … fatal; exit 1; }' (H3 set +e un-gates it otherwise)"
 fi
 
+# ── AC12 (#6090 follow-up): the fatal-emit trap covers the PRE-extraction install region ──
+# recreate 28805034101 died with ZERO emits + :9000 unbound while every post-extraction guard
+# was green — because on_err was defined/armed only inside the extraction block, leaving the
+# package-audit/doppler/docker install region (which runs under the leaked `set -e`) a blind
+# spot. The fix moves on_err to the TOP of runcmd and bumps STAGE per install step. Guard that:
+#   (a) on_err is armed BEFORE the doppler download (early coverage), and
+#   (b) on_err is defined exactly ONCE (moved, not duplicated — no transport drift / no bytes).
+armln=$(grep -nE '^\s*trap on_err EXIT' "$CI" | head -1 | cut -d: -f1 || true)
+dopplerln=$(line_of "$CI" 'tar xzf /tmp/doppler.tar.gz')
+if [ -n "$armln" ] && [ -n "$dopplerln" ] && [ "$armln" -lt "$dopplerln" ]; then
+  ok "AC12: on_err trap armed (line $armln) BEFORE the doppler install ($dopplerln) — pre-extraction covered"
+else
+  no "AC12: 'trap on_err EXIT' must precede the doppler install (arm=$armln doppler=$dopplerln); the install region is the blind spot"
+fi
+n_onerr=$(grep -cE '^\s*on_err\(\) \{' "$CI" || true)
+if [ "${n_onerr:-0}" -eq 1 ]; then
+  ok "AC12: on_err defined exactly once in cloud-init ($n_onerr) — moved to the top, not duplicated"
+else
+  no "AC12: on_err must be defined exactly once (found $n_onerr) — a second copy drifts + burns user_data bytes"
+fi
+# Per-step stage names so the fatal points at the exact dying install command.
+for st in doppler_dl docker_apt docker_restart; do
+  if grep -qE "STAGE=$st\b" "$CI"; then
+    ok "AC12: install region bumps STAGE=$st (fatal names the exact command)"
+  else
+    no "AC12: cloud-init must set STAGE=$st in the pre-extraction install region"
+  fi
+done
+
+# ── AC13 (#6090 follow-up): the recreate auto-read sources its Sentry token from Doppler ──
+# The GitHub repo secret SENTRY_AUTH_TOKEN is unset, so the surface step self-skipped. It must
+# now fetch the token (+org+project) from Doppler prd_terraform like every other step in the job.
+if grep -qE 'doppler secrets get SENTRY_AUTH_TOKEN .*-c prd_terraform' "$WF"; then
+  ok "AC13: surface step resolves SENTRY_AUTH_TOKEN from Doppler prd_terraform (not the unset repo secret)"
+else
+  no "AC13: the fresh-host Sentry surface step must fetch SENTRY_AUTH_TOKEN via doppler -c prd_terraform"
+fi
+
 echo "=== soleur-host-bootstrap-observability: $pass passed, $fail failed ==="
 [ "$fail" -eq 0 ]

--- a/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
+++ b/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
@@ -328,5 +328,15 @@ else
   no "AC13: the fresh-host Sentry surface step must fetch SENTRY_AUTH_TOKEN via doppler -c prd_terraform"
 fi
 
+# ── AC14 (#6090 P2-1): the recreate asserts the baked DSN is non-empty before -replace ──
+# The pre-extraction fresh-boot stages depend SOLELY on the baked ${sentry_dsn} (doppler isn't
+# installed yet, so its fallback is dead). An empty SENTRY_DSN (var.sentry_dsn's TF default) would
+# silently re-open the zero-emit blind spot. The recreate must fail loudly, not boot dark.
+if grep -qE 'SENTRY_DSN is empty in Doppler prd_terraform' "$WF"; then
+  ok "AC14: web-2-recreate asserts baked SENTRY_DSN non-empty before -replace (pre-extraction can't go dark)"
+else
+  no "AC14: the recreate must assert SENTRY_DSN is non-empty before -replace (empty baked DSN = silent pre-extraction blind spot)"
+fi
+
 echo "=== soleur-host-bootstrap-observability: $pass passed, $fail failed ==="
 [ "$fail" -eq 0 ]

--- a/apps/web-platform/infra/variables.tf
+++ b/apps/web-platform/infra/variables.tf
@@ -204,7 +204,7 @@ variable "doppler_token" {
 }
 
 variable "sentry_dsn" {
-  description = "Sentry DSN baked into cloud-init so the fresh-boot fatal emit fires WITHOUT depending on doppler (which may itself be the broken stage). Semi-public (already in the client bundle). Injected via TF_VAR_sentry_dsn from Doppler prd_terraform SENTRY_DSN; empty default keeps bare `terraform validate` working (emit falls back to the doppler fetch when unset)."
+  description = "Sentry DSN baked into cloud-init so the fresh-boot fatal emit fires WITHOUT depending on doppler (which may itself be the broken stage). Semi-public (already in the client bundle). Injected via TF_VAR_sentry_dsn from Doppler prd_terraform SENTRY_DSN; empty default keeps bare `terraform validate` working. NOTE: the doppler fallback only applies AFTER doppler is installed — the pre-extraction fresh-boot stages (pkg_audit/doppler_dl, #6090) depend SOLELY on this baked value, so an empty DSN there silently reverts to a zero-emit abort. The web-2-recreate job's 'Extract backend credentials' step asserts this is non-empty before -replace so that coverage cannot regress unnoticed."
   type        = string
   default     = ""
   sensitive   = true


### PR DESCRIPTION
## Summary

Follow-up to the #6090 fresh-boot observability probe. The first probe (merged) instrumented the **post-extraction** boot sequence, and the operator-gated `web-2-recreate` (run `28805034101`) then ran — **web-2 still failed to bind `:9000`**, identical `ok_peer_fanout_degraded`. Crucially the probe was **dark**: zero Sentry events across 24h, even though the pinned image contained the baked helpers, the user_data carried the H3 fix + gates, and the baked `${sentry_dsn}` was verifiably wired (`TF_VAR_sentry_dsn` len 95, pointing at exactly the queried EU project).

Triangulating the emit instrumentation proved the death is **upstream of all of it** — in the **doppler/docker package-install region** of `cloud-init.yml` (the old lines 256–343), which runs under the `set -e` leaked from the package audit but **pre-dates** the host-script extraction block where `on_err` was armed. A non-zero from the doppler download/checksum, docker apt-repo/install, `apt-get update`, or `systemctl restart docker` aborts the single-`/bin/sh` runcmd **silently** — no emit, webhook never installed, `:9000` never binds. The shipped #6090 H3 `set +e` fix was a real errexit-leak bug but **not** this failure's cause.

This PR closes that blind spot so the next recreate names the exact dying command. It does **not** claim the boot is fixed — it makes the failure legible.

Prod is unaffected: web-2 is a weight-0, non-serving standby; web-1 stayed 200 (`v0.199.0`) throughout. This cloud-init change only exercises on the operator-gated web-2 recreate (web-1 carries `lifecycle.ignore_changes=[user_data]`).

Ref #6090

## User-Brand Impact

- **Brand-survival threshold:** none
- threshold: none, reason: web-2 is a weight-0 non-serving standby; this is best-effort observability only. Every emit is `( set +e … ) || true` fail-open and can never poweroff the host; it never touches web-1's running host; it changes no serving behavior. Required because the diff touches the sensitive `apps/web-platform/infra/` path. The only new egress is a Sentry event carrying `stage`/`image_ref`/`host_id` enums (a Hetzner instance-id + a stage name — no secrets, no PII) via the already-semi-public baked `${sentry_dsn}`.

## Changelog

### Fresh-boot observability — cover the pre-extraction install region

- `cloud-init.yml`: move the `on_err` fatal-emit function to the **top of `runcmd`** and arm `trap on_err EXIT` before the package audit, so the baked-`${sentry_dsn}` fatal covers the previously-untrapped `pkg_audit` / `doppler_dl` / `docker_apt` / `docker_restart` install region. `STAGE` is bumped per install step so the emit names the exact dying command; the extraction block re-sets `STAGE=pull` onward and disarms the trap (`trap - EXIT`) before handing off to the trusted baked installer. The emit body is **moved, not duplicated** — DRY, no transport drift, ~+0.2 KB gzip.
- `apply-web-platform-infra.yml`: the recreate's auto-read step now sources `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT` from **Doppler `prd_terraform`** (like every other step in the job) instead of the **unset** GitHub repo secret `SENTRY_AUTH_TOKEN` — which is why run `28805034101` logged the step as "Sentry query skipped". `prd_terraform`'s token has `event:read` (verified HTTP 200 on the events endpoint).
- `soleur-host-bootstrap-observability.test.sh`: **AC12** guards early-arming (`trap on_err EXIT` precedes the doppler install) + a single `on_err` definition (moved, not duplicated) + the per-step `STAGE` bumps; **AC13** guards the Doppler-sourced token.

## Why one runcmd shell makes this correct

cloud-init concatenates all `runcmd` items into **one `/bin/sh`** — the exact property behind the H3 `set -e` leak. So a function defined + a trap armed in the first item persist across every later item until disarmed. The top-armed `on_err` therefore covers the whole install region; the extraction block's `trap - EXIT` (line 428) disarms it before the bootstrap handoff so bootstrap-stage failures are named by the bootstrap's own `emit_fail`, not mislabeled here.

## Verification

- `soleur-host-bootstrap-observability.test.sh` → **42/42** (incl. new AC12/AC13).
- Sibling guards green: `cron-egress-enforce-probe` (38/38, transport parity), `cloud-init-inngest-bootstrap`, `cloud-init-plugin-seed`, `cloud-init-ghcr-seed-login` (6/6), `server-tf-set-e` (16/16).
- `cloud-init-user-data-size.test.ts` → **23/23** (base64gzip user_data under the 18,000 guard budget / 32,768 cap; proxy render 15,388 B).
- cloud-init schema **Valid** (rendered); both workflow + cloud-init YAML parse; actionlint clean; shellcheck clean.

## Verification after merge (tracked in #6090)

This is a probe, so `Ref #6090` — the tracker stays open until `:9000` binds on a fresh web-2 boot. Once `web-platform-release.yml` rebuilds the image and the pinned known-good digest advances, reading the named stage requires one operator-gated `web-2-recreate` (menu-ack dispatch in a quiet window per `hr-menu-option-ack-not-prod-write-auth`). That recreate + Sentry stage-read is tracked by #6090.

## Test plan

- [x] `bash apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh` → 42/42
- [x] infra sibling guards + `server-tf-set-e` + size guard green
- [x] cloud-init schema `Valid`; workflow + cloud-init YAML parse; actionlint/shellcheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
