### PR TITLE
fix(infra): earliest bootcmd beacon + repair the auto-read message: query (#6090)

### DIFF
--- a/.github/workflows/apply-web-platform-infra.yml
+++ b/.github/workflows/apply-web-platform-infra.yml
@@ -1245,27 +1245,26 @@ jobs:
           # (AC8) fails. Covers the seed/bootstrap fatals, the bootstrap_complete breadcrumb, and
           # every cloud-init stage emit (the stage lives in the event's `stage` tag).
           QUERY='message:"soleur-hostscript-seed failed" OR message:"soleur-host-bootstrap failed" OR message:"soleur-host-bootstrap complete" OR message:"soleur-cloud-init boot stage"'
-          # EU data plane (#6090 AC8b, LOAD-BEARING): the project is jikigai-eu / de.sentry.io.
-          # Querying the US host (sentry.io) against an EU-resident project returns empty — the
-          # whole auto-surface deliverable would be dark. Residency is authoritative per learning
-          # 2026-05-15-sentry-dsn-cluster-substring-authoritative-residency.md. Sort most-recent
-          # so the first row is the LAST-reached stage.
+          # #6090: the /projects/{org}/{proj}/events/ endpoint IGNORES the `message:` search prefix
+          # — a `message:"x"` query returns 0 even for events that provably exist (verified against a
+          # known event id: bare full-text = 1 hit, message:"x" = 0). So fetch RECENT events
+          # UNFILTERED and match client-side with a regex DERIVED from QUERY (single source, no
+          # drift). EU data plane (de.sentry.io) is LOAD-BEARING: a US sentry.io query against the
+          # EU-resident project returns empty. The endpoint returns newest-first, so the first match
+          # is the LAST-reached stage. `tee` so matches land in the LOG too (discoverability).
+          MSG_RE=$(printf '%s' "$QUERY" | grep -oE 'message:"[^"]+"' | sed -E 's/message:"([^"]+)"/\1/' | paste -sd'|' -)
           RESP=$(curl -s --max-time 20 -G \
             -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
-            --data-urlencode "query=${QUERY}" \
-            --data-urlencode "statsPeriod=1h" \
-            --data-urlencode "sort=-timestamp" \
+            --data-urlencode "per_page=100" \
             "https://de.sentry.io/api/0/projects/${SENTRY_ORG}/${SENTRY_PROJECT}/events/" 2>/dev/null)
-          if [[ -n "$RESP" ]] && echo "$RESP" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
-            echo "$RESP" | jq -r '
-              .[0:5][]
+          if [[ -n "$RESP" ]] && echo "$RESP" | jq -e --arg re "$MSG_RE" '[.[] | select((.message // .title) | test($re))] | length > 0' >/dev/null 2>&1; then
+            echo "$RESP" | jq -r --arg re "$MSG_RE" '
+              [.[] | select((.message // .title) | test($re))] | .[0:8][]
               | ( [ (.tags // [])[]? | select(.key=="stage") | .value ][0] // "?" ) as $stage
-              | "- `\(.title // .message)` — stage=`\($stage)` (\(.dateCreated // "?"))"
-            ' >> "$GITHUB_STEP_SUMMARY" 2>/dev/null \
-            || echo "$RESP" | jq -r '.[0:5][] | "- `\(.title // .message)` (\(.dateCreated // "?"))"' >> "$GITHUB_STEP_SUMMARY" 2>/dev/null \
-            || true
+              | "- `\(.message // .title)` — stage=`\($stage)` (\(.dateCreated // "?"))"
+            ' | tee -a "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
           else
-            echo "_No matching fresh-host boot-stage event in the last hour (or the query failed)._" | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "_No matching fresh-host boot-stage event in the recent-events scan (client-side filtered — the endpoint ignores message: search)._" | tee -a "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: web-2-recreate summary

--- a/.github/workflows/apply-web-platform-infra.yml
+++ b/.github/workflows/apply-web-platform-infra.yml
@@ -1253,18 +1253,39 @@ jobs:
           # EU-resident project returns empty. The endpoint returns newest-first, so the first match
           # is the LAST-reached stage. `tee` so matches land in the LOG too (discoverability).
           MSG_RE=$(printf '%s' "$QUERY" | grep -oE 'message:"[^"]+"' | sed -E 's/message:"([^"]+)"/\1/' | paste -sd'|' -)
-          RESP=$(curl -s --max-time 20 -G \
+          # Guard: an empty MSG_RE (QUERY reshaped so the message: extraction yields nothing) would
+          # make jq test("") match EVERY event → list arbitrary events as boot stages. Refuse.
+          if [[ -z "$MSG_RE" ]]; then
+            echo "_Sentry query skipped: QUERY message-literal extraction produced an empty regex — refusing to match-all (would mislabel arbitrary events as boot stages)._" | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          # Capture the HTTP status so a curl/auth/API failure is NAMED, not silently reported as
+          # "no events" — the whole point of this step is to not go dark on its own failure.
+          # statsPeriod + sort ARE honored by this endpoint (only the `message:` search prefix is
+          # broken) — keep both: the time bound stops the boot event being pushed past per_page on
+          # the SHARED project (which ingests all app events + verify_failed spam), and sort pins
+          # "first match = last-reached stage" instead of relying on undocumented default order.
+          HTTP=$(curl -s --max-time 20 -G -o /tmp/sentry-events.json -w '%{http_code}' \
             -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
             --data-urlencode "per_page=100" \
-            "https://de.sentry.io/api/0/projects/${SENTRY_ORG}/${SENTRY_PROJECT}/events/" 2>/dev/null)
-          if [[ -n "$RESP" ]] && echo "$RESP" | jq -e --arg re "$MSG_RE" '[.[] | select((.message // .title) | test($re))] | length > 0' >/dev/null 2>&1; then
+            --data-urlencode "statsPeriod=1h" \
+            --data-urlencode "sort=-timestamp" \
+            "https://de.sentry.io/api/0/projects/${SENTRY_ORG}/${SENTRY_PROJECT}/events/" 2>/dev/null || echo "000")
+          RESP=$(cat /tmp/sentry-events.json 2>/dev/null || echo "")
+          if [[ "$HTTP" != "200" ]] || ! echo "$RESP" | jq -e 'type == "array"' >/dev/null 2>&1; then
+            echo "_Sentry query FAILED (HTTP ${HTTP}) — the auto-read did NOT run; this is NOT a 'host emitted nothing' result. $(echo "$RESP" | jq -r '.detail // empty' 2>/dev/null | tr '\n' ' ' | head -c 160)_" | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          # `// ""` coalesces null message AND title so a malformed sibling event in the window
+          # can't throw jq ("null cannot be matched") and blank the whole read.
+          if echo "$RESP" | jq -e --arg re "$MSG_RE" '[.[] | select(((.message // .title) // "") | test($re))] | length > 0' >/dev/null 2>&1; then
             echo "$RESP" | jq -r --arg re "$MSG_RE" '
-              [.[] | select((.message // .title) | test($re))] | .[0:8][]
+              [.[] | select(((.message // .title) // "") | test($re))] | .[0:8][]
               | ( [ (.tags // [])[]? | select(.key=="stage") | .value ][0] // "?" ) as $stage
-              | "- `\(.message // .title)` — stage=`\($stage)` (\(.dateCreated // "?"))"
+              | "- `\((.message // .title) // "?")` — stage=`\($stage)` (\(.dateCreated // "?"))"
             ' | tee -a "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
           else
-            echo "_No matching fresh-host boot-stage event in the recent-events scan (client-side filtered — the endpoint ignores message: search)._" | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "_The scan RAN (HTTP 200, project ${SENTRY_PROJECT}) but no fresh-host boot-stage event matched in the recent events — the host genuinely emitted nothing in this window._" | tee -a "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: web-2-recreate summary

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -24,7 +24,9 @@ bootcmd:
       SHOST=$(printf '%s' "$DSN" | sed -E 's#https://[^@]+@([^/]+)/.*#\1#')
       PROJ=$(printf '%s' "$DSN" | sed -E 's#.*/([0-9]+)$#\1#')
       BODY=$(printf '{"message":"soleur-cloud-init boot stage","level":"info","tags":{"stage":"bootcmd_start","host_id":"%s"}}' "$HOST_ID")
-      curl -m 10 --retry 2 -sf -X POST "https://$SHOST/api/$PROJ/store/" \
+      # --connect-timeout 5 + --retry 1 caps the black-hole stall (no-egress is the exact case this
+      # beacon targets, and bootcmd runs every boot) to a few seconds instead of ~30s.
+      curl --connect-timeout 5 -m 8 --retry 1 -sf -X POST "https://$SHOST/api/$PROJ/store/" \
         -H 'Content-Type: application/json' \
         -H "X-Sentry-Auth: Sentry sentry_version=7, sentry_key=$KEY" \
         -d "$BODY" >/dev/null 2>&1 || true
@@ -299,6 +301,7 @@ runcmd:
     #   _emit <message> <stage> <level>. Prefers the BAKED DSN so it fires even when doppler is
     # the broken stage (and before doppler/docker install). Fully fail-open — never blocks boot.
     _emit() {
+      _m="$1"; _s="$2"; _l="$3"   # capture args before the subshell sources the env file
       ( set +e
         . /etc/default/webhook-deploy 2>/dev/null || true
         DSN='${sentry_dsn}'
@@ -308,8 +311,8 @@ runcmd:
           KEY=$(printf '%s' "$DSN" | sed -E 's#https://([^@]+)@.*#\1#')
           SHOST=$(printf '%s' "$DSN" | sed -E 's#https://[^@]+@([^/]+)/.*#\1#')
           PROJ=$(printf '%s' "$DSN" | sed -E 's#.*/([0-9]+)$#\1#')
-          BODY=$(printf '{"message":"%s","level":"%s","tags":{"stage":"%s","image_ref":"%s","host_id":"%s"}}' "$1" "$3" "$2" "$IMAGE_REF" "$HOST_ID")
-          curl -m 10 --retry 3 -sf -X POST "https://$SHOST/api/$PROJ/store/" \
+          BODY=$(printf '{"message":"%s","level":"%s","tags":{"stage":"%s","image_ref":"%s","host_id":"%s"}}' "$_m" "$_l" "$_s" "$IMAGE_REF" "$HOST_ID")
+          curl --connect-timeout 5 -m 8 --retry 1 -sf -X POST "https://$SHOST/api/$PROJ/store/" \
             -H 'Content-Type: application/json' \
             -H "X-Sentry-Auth: Sentry sentry_version=7, sentry_key=$KEY" \
             -d "$BODY" >/dev/null 2>&1 || true

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -6,6 +6,30 @@ packages:
   - jq
   - nftables
 
+# (#6090) Earliest boot beacon. bootcmd runs in cloud-init's network stage — BEFORE
+# package_update/packages: and runcmd — so if web-2 dies pre-runcmd (an apt hang in
+# package_update, a broken mirror, a wedged packages: install) this still reports that the
+# boot reached bootcmd AND has Sentry egress. Best-effort: curl may not exist until packages:
+# installs it (Hetzner ubuntu-24.04 ships curl, so it normally fires); fully fail-open, never
+# blocks boot. Reads the baked ${sentry_dsn} (no doppler yet). A landed bootcmd_start with no
+# later stage brackets the death to packages:/config; nothing landing → no-egress/pre-network.
+bootcmd:
+  - |
+    ( set +e
+      command -v curl >/dev/null 2>&1 || exit 0
+      DSN='${sentry_dsn}'
+      [ -n "$DSN" ] || exit 0
+      HOST_ID=$( (cat /var/lib/cloud/data/instance-id 2>/dev/null || hostname) | tr -d '"' )
+      KEY=$(printf '%s' "$DSN" | sed -E 's#https://([^@]+)@.*#\1#')
+      SHOST=$(printf '%s' "$DSN" | sed -E 's#https://[^@]+@([^/]+)/.*#\1#')
+      PROJ=$(printf '%s' "$DSN" | sed -E 's#.*/([0-9]+)$#\1#')
+      BODY=$(printf '{"message":"soleur-cloud-init boot stage","level":"info","tags":{"stage":"bootcmd_start","host_id":"%s"}}' "$HOST_ID")
+      curl -m 10 --retry 2 -sf -X POST "https://$SHOST/api/$PROJ/store/" \
+        -H 'Content-Type: application/json' \
+        -H "X-Sentry-Auth: Sentry sentry_version=7, sentry_key=$KEY" \
+        -d "$BODY" >/dev/null 2>&1 || true
+    ) || true
+
 groups:
   - docker
 
@@ -271,13 +295,12 @@ runcmd:
     IMAGE_REF='${image_name}'
     STAGE=pkg_audit
     HOST_ID=$( (cat /var/lib/cloud/data/instance-id 2>/dev/null || hostname) | tr -d '"' )
-    on_err() {
-      trap - EXIT
-      docker rm -f soleur-hostscript-seed >/dev/null 2>&1 || true
+    # (#6090) ONE transport, reused by on_err (fatal) + the runcmd_start breadcrumb (info):
+    #   _emit <message> <stage> <level>. Prefers the BAKED DSN so it fires even when doppler is
+    # the broken stage (and before doppler/docker install). Fully fail-open — never blocks boot.
+    _emit() {
       ( set +e
         . /etc/default/webhook-deploy 2>/dev/null || true
-        # Prefer the BAKED DSN so this fatal fires even when doppler is the broken stage (and
-        # even before doppler/docker are installed, which is exactly the region this now covers).
         DSN='${sentry_dsn}'
         [ -n "$DSN" ] || DSN=$(timeout 15 doppler secrets get SENTRY_DSN --plain --project soleur --config prd 2>/dev/null \
                || timeout 15 doppler secrets get NEXT_PUBLIC_SENTRY_DSN --plain --project soleur --config prd 2>/dev/null || true)
@@ -285,15 +308,24 @@ runcmd:
           KEY=$(printf '%s' "$DSN" | sed -E 's#https://([^@]+)@.*#\1#')
           SHOST=$(printf '%s' "$DSN" | sed -E 's#https://[^@]+@([^/]+)/.*#\1#')
           PROJ=$(printf '%s' "$DSN" | sed -E 's#.*/([0-9]+)$#\1#')
-          BODY=$(printf '{"message":"soleur-hostscript-seed failed","level":"fatal","tags":{"stage":"%s","image_ref":"%s","host_id":"%s"}}' "$STAGE" "$IMAGE_REF" "$HOST_ID")
+          BODY=$(printf '{"message":"%s","level":"%s","tags":{"stage":"%s","image_ref":"%s","host_id":"%s"}}' "$1" "$3" "$2" "$IMAGE_REF" "$HOST_ID")
           curl -m 10 --retry 3 -sf -X POST "https://$SHOST/api/$PROJ/store/" \
             -H 'Content-Type: application/json' \
             -H "X-Sentry-Auth: Sentry sentry_version=7, sentry_key=$KEY" \
             -d "$BODY" >/dev/null 2>&1 || true
         fi ) || true
+    }
+    on_err() {
+      trap - EXIT
+      docker rm -f soleur-hostscript-seed >/dev/null 2>&1 || true
+      _emit "soleur-hostscript-seed failed" "$STAGE" fatal
       exit 1
     }
     trap on_err EXIT
+    # (#6090) Positive breadcrumb: runcmd was REACHED (curl is guaranteed installed by now). A
+    # landed bootcmd_start (below) with NO runcmd_start brackets the death to the packages:/config
+    # phase; neither landing points at no-egress / a pre-network death → needs host console.
+    _emit "soleur-cloud-init boot stage" runcmd_start info
 
   # Apply SSH hardening immediately (drop-in written by write_files above).
   # Runs BEFORE the package audit so the operator always has hardened SSH

--- a/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
+++ b/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
@@ -338,5 +338,43 @@ else
   no "AC14: the recreate must assert SENTRY_DSN is non-empty before -replace (empty baked DSN = silent pre-extraction blind spot)"
 fi
 
+# ── AC15 (#6090): earliest bootcmd beacon + runcmd_start breadcrumb bracket a pre-runcmd death ──
+# recreate 28812931362 (on the merged pre-extraction fix) was STILL fully dark — web-2 emits
+# nothing, so the death is BEFORE the top-armed runcmd trap (the cloud-init packages:/config phase)
+# or the host has no Sentry egress. A bootcmd beacon (runs before packages:) + a runcmd_start
+# breadcrumb (curl guaranteed) bracket it: bootcmd-only = died in packages:; neither = no-egress.
+if grep -qE '^bootcmd:' "$CI" && grep -qF 'stage":"bootcmd_start"' "$CI"; then
+  ok "AC15: bootcmd beacon present (earliest pre-packages: boot signal)"
+else
+  no "AC15: cloud-init must emit a bootcmd_start beacon in a bootcmd: block (pre-runcmd bracket)"
+fi
+if grep -qF '_emit "soleur-cloud-init boot stage" runcmd_start info' "$CI"; then
+  ok "AC15: runcmd_start breadcrumb present (curl-guaranteed control vs the best-effort bootcmd beacon)"
+else
+  no "AC15: cloud-init must emit a runcmd_start breadcrumb right after arming the trap"
+fi
+# The runcmd transport is written ONCE (_emit), reused by on_err + the breadcrumb (no drift/bytes).
+n_emit_def=$(grep -cE '^\s*_emit\(\) \{' "$CI" || true)
+if [ "${n_emit_def:-0}" -eq 1 ]; then
+  ok "AC15: _emit transport helper defined once in runcmd ($n_emit_def) — shared by on_err + breadcrumb"
+else
+  no "AC15: _emit must be defined exactly once in cloud-init runcmd (found $n_emit_def)"
+fi
+
+# ── AC16 (#6090): the auto-read must NOT use the broken message: query ──
+# The /projects/../events/ endpoint ignores `message:"x"` search (returns 0 for events that exist).
+# The surface step must derive a client-side regex from QUERY and filter fetched events, NOT pass
+# `query=${QUERY}` to the endpoint.
+if grep -qF 'query=${QUERY}' "$WF"; then
+  no "AC16: surface step still passes the broken message: query to the events endpoint (returns 0)"
+else
+  ok "AC16: surface step no longer passes the broken message: query to the endpoint"
+fi
+if grep -qF 'MSG_RE=' "$WF" && grep -qF 'test($re)' "$WF"; then
+  ok "AC16: surface step filters recent events client-side via a regex derived from QUERY"
+else
+  no "AC16: surface step must derive MSG_RE from QUERY and filter events client-side (test(\$re))"
+fi
+
 echo "=== soleur-host-bootstrap-observability: $pass passed, $fail failed ==="
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

Third iteration of the #6090 fresh-boot observability probe. After the pre-extraction trap fix (#6116) merged and deployed, an operator-gated `web-2-recreate` (run `28812931362`, on the merge commit) **still failed to bind `:9000` and STILL produced zero Sentry telemetry** — even though the recreate's DSN-assertion and coherence-preflight both passed, so the trap + DSN are live.

That result **disproves the "death in the runcmd install region" hypothesis**: if the boot died anywhere in `runcmd`, the top-armed trap would have emitted. Zero emits (including zero `soleur-host-bootstrap complete` breadcrumbs) means the death is **before `runcmd` starts** — cloud-init's `package_update`/`packages:` config phase, where no trap exists — **or the fresh host has no Sentry egress**. A manual POST to the exact baked endpoint returns HTTP 200 and is queryable, and web-1's `ci-deploy` events land fine, so transport + DSN + project are all valid — only web-2's own boot is silent.

Along the way I found a second, independent bug: the auto-read's `message:"…"` query on the Sentry `/projects/{org}/{proj}/events/` endpoint **returns 0 even for events that provably exist** (verified against a known event id: bare full-text = 1 hit, `message:"x"` = 0). So the workflow's auto-surface could never have worked, and every "dark" verification in this issue's history used a broken read.

This PR makes the *earliest* boot observable and repairs the read. It does **not** claim to fix the boot — it makes the next recreate localize the failure to one of: packages: phase / no-egress / pre-network.

Prod unaffected: web-2 is a weight-0 non-serving standby; web-1 carries `ignore_changes=[user_data]` and is untouched. Every emit is `( … ) || true` fail-open and can never block or poweroff the host.

Ref #6090

## User-Brand Impact

- **Brand-survival threshold:** none
- threshold: none, reason: web-2 is a weight-0 non-serving standby; this is best-effort observability only. Every new emit (bootcmd beacon, runcmd_start breadcrumb, the refactored `_emit`) is fully fail-open (`( set +e … ) || true`) and never blocks or powers off the host; it never touches web-1's running host; it changes no serving behavior. Required because the diff touches the sensitive `apps/web-platform/infra/` path. The only new egress is a Sentry event carrying `stage`/`host_id` enums (a Hetzner instance-id + a stage name — no secrets, no PII) via the already-semi-public baked `${sentry_dsn}`.

## Changelog

### Earliest-possible boot beacon (bracket a pre-runcmd death)

- `cloud-init.yml`: a **`bootcmd` beacon** (`stage=bootcmd_start`) fires in cloud-init's network stage — **before** `package_update`/`packages:`/`runcmd` — so a death in the config phase (an apt hang, a broken mirror, a wedged `packages:` install) still reports. Best-effort (`command -v curl || exit 0`; Hetzner ubuntu-24.04 ships curl), fully fail-open. Plus a **`runcmd_start` breadcrumb** (curl guaranteed installed by then) as the control. Together they bracket the death: **bootcmd-only = died in packages:/config; neither landing = no-egress / pre-network → needs host console.** The `runcmd` on_err transport is refactored into a single **`_emit()`** helper reused by `on_err` (fatal) + the breadcrumb (info) — DRY, one transport copy.

### Repair the auto-read (the `message:` filter is ignored by the endpoint)

- `apply-web-platform-infra.yml`: the surface step no longer passes `query=${QUERY}` to the events endpoint (that `message:"…"` form returns 0). It now fetches recent events **unfiltered** (`per_page=100`) and filters **client-side** with a regex derived from `QUERY` (single source — no lockstep drift), `tee`'d to the log. The four message literals stay in `QUERY` for the AC8 lockstep.

### Guards

- `soleur-host-bootstrap-observability.test.sh`: **AC15** (bootcmd beacon + runcmd_start breadcrumb + single `_emit` transport), **AC16** (auto-read no longer uses the broken `message:` query; derives `MSG_RE` + client-side filter).

## Verification

- observability guard **48/48** (incl. AC15/AC16); siblings green (`cron-egress-enforce-probe` 38/38, `cloud-init-inngest-bootstrap`, `cloud-init-ghcr-seed-login` 6/6, `server-tf-set-e` 16/16, `cloud-init-plugin-seed`).
- `cloud-init-user-data-size.test.ts` **23/23** (base64gzip user_data under budget with the bootcmd block).
- cloud-init schema **Valid** (rendered); cloud-init + workflow YAML parse; actionlint clean.
- Query fix proven live: against known event id `f0c6716b…`, bare full-text query = 1 hit, `message:"x"` = 0; the new client-side filter surfaces it.

## What the next recreate will tell us (tracked in #6090)

`Ref #6090` — probe, not a boot fix. After merge (no image rebuild needed — the baked host scripts are untouched), one operator-gated `web-2-recreate` reads the earliest stage:
- **`bootcmd_start` present, nothing later** → death is in the `packages:`/config phase → fix there next.
- **`runcmd_start` present** → boot reaches runcmd; combine with the existing per-stage trap.
- **Nothing at all** → the fresh host cannot reach Sentry (no egress) or dies pre-network → escalate to host-console visibility.

## Test plan

- [x] `bash apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh` → 48/48
- [x] infra sibling guards + size guard green; cloud-init schema Valid; actionlint clean
- [x] query-fix validated against a known Sentry event id (bare = 1, `message:"x"` = 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
