### PR TITLE
docs(blog): internal-link equity for 3 GSC-unindexed pages

### DIFF
--- a/knowledge-base/project/learnings/2026-07-06-gsc-coverage-report-is-playwright-pullable-after-operator-signin.md
+++ b/knowledge-base/project/learnings/2026-07-06-gsc-coverage-report-is-playwright-pullable-after-operator-signin.md
@@ -1,0 +1,65 @@
+# Learning: GSC "not indexed" reports are Playwright-pullable — don't ask the operator to paste URLs
+
+## Problem
+
+An operator (non-technical) forwarded "more failures from Google Search Console on
+not indexing pages." There is **no Search Console API wired into this repo** (no
+credential in `.env.example`, no integration), so the instinct is to ask the operator
+to open GSC, export the "Why pages aren't indexed" report, and paste the URLs. That is
+an operator-action deferral (`[[feedback_never_defer_operator_actions]]` — Soleur users
+are non-technical; automate everything). The coverage data lives in the operator's
+Google account, which *feels* un-automatable without stored credentials.
+
+## Solution
+
+**The GSC dashboard is Playwright-driveable end-to-end after a single sign-in handoff.**
+The only genuinely manual gate is the Google login (password + 2FA — a true operator-only
+gate you must never handle). Everything else — opening the property, navigating
+`Indexing → Pages`, drilling into each reason row, reading the affected URLs, paginating
+— runs under Playwright MCP.
+
+Workflow that worked:
+1. `browser_navigate` to `https://search.google.com/search-console/index?resource_id=sc-domain:<domain>`.
+   If it redirects to `accounts.google.com/.../signin`, there's no stored session.
+2. **Hand off ONLY the login**: park the browser on the Google sign-in page, ask the
+   operator to complete it in that browser, wait for "done". (This is the legitimate
+   operator-only gate per the Playwright-first audit — a real WebAuthn/password/2FA wall.)
+3. Re-navigate to the property index; the session now persists. Drill each reason row
+   via `browser_click` on the row, `browser_snapshot` to read the URL table, paginate
+   for the rest.
+4. **Verify every URL live with `curl -sIL -A Googlebot`** before acting — the GSC label
+   is a stale snapshot, not ground truth (see [[2026-06-15-gsc-crawled-not-indexed-remediation-is-internal-linking]]).
+
+Result: pulled the full 70-page "not indexed" breakdown, bucketed it live (legacy `.html`
+all 301 clean; www/http benign; `403` on `deploy.soleur.ai` correct; only 3 healthy blog
+pages actionable), and remediated with internal-link equity — without the operator pasting
+a single URL.
+
+## Key Insight
+
+A vendor dashboard behind an authenticated session is presumptively Playwright-automatable
+(`[[2026-06-17-vendor-dashboard-mint-presumed-playwright-automatable]]`). For GSC
+specifically: the "no API in the repo" fact does NOT imply "ask the operator to paste the
+report." Drive the dashboard yourself; hand off only the sign-in. This turns a multi-round
+operator-paste loop into a single "sign in, tell me when done" gate.
+
+## Session Errors
+
+- **Playwright browser context closed intermittently** ("Target page, context or browser
+  has been closed") ~3× mid-navigation. — Recovery: re-issue the same `browser_navigate`;
+  it succeeds on retry. — Prevention: one-off MCP flakiness; retry-once before treating as
+  a real failure (`[[workflow-issues]]` retry discipline). Not a rule gap.
+- **`git grep` run from the bare-repo root** failed ("must be run in a work tree") during
+  the read-only diagnosis phase. — Recovery: used `git grep <pat> main --` / `find`. —
+  Prevention: already covered by `hr-when-in-a-worktree-never-read-from-bare`; the
+  diagnosis was pre-worktree so this was expected.
+- **Playwright `browser_snapshot(filename:)` wrote files to the repo root** (`gsc-*.md`)
+  as stray untracked files. — Recovery: `rm` after extracting the URLs. — Prevention:
+  when using snapshot-to-file for scratch extraction, write under the scratchpad dir or
+  clean up before commit (the MCP resolves the path from repo root).
+- **ugrep rejected a `{{`-containing regex** in a diff-shape check. — Recovery: fixed-string
+  `grep -F`. — Prevention: one-off; use `-F` when the pattern contains Nunjucks braces.
+
+## Tags
+category: integration-issues
+module: docs-site / seo / gsc / playwright

--- a/knowledge-base/project/plans/2026-07-06-feat-gsc-internal-linking-equity-plan.md
+++ b/knowledge-base/project/plans/2026-07-06-feat-gsc-internal-linking-equity-plan.md
@@ -1,0 +1,254 @@
+---
+title: "Strengthen internal-link equity for 3 GSC 'Crawled – currently not indexed' blog pages"
+type: feat
+date: 2026-07-06
+branch: feat-one-shot-gsc-internal-linking
+lane: cross-domain
+brand_survival_threshold: none
+status: planned
+---
+
+# ✨ Strengthen internal-link equity for 3 structurally-healthy, unindexed blog pages
+
+## Overview
+
+Google Search Console (soleur.ai, report last updated 2026-06-30) flags three canonical
+blog pages as **"Crawled – currently not indexed."** All three are verified structurally
+healthy: HTTP 200, self-canonical, no robots `noindex`, present in `sitemap.xml`, listed
+on the blog index. For a healthy page, "Crawled – currently not indexed" is Google's
+*discretionary* call — the only lever we control in-repo is **contextual internal-link
+equity**. This is the exact remediation pattern documented in
+`knowledge-base/project/learnings/2026-06-15-gsc-crawled-not-indexed-remediation-is-internal-linking.md`
+(the prior run of this task class on a sibling set of pages).
+
+This PR adds a small number of *genuinely contextual* internal links from other,
+topically-related blog posts, anchored on precise topical phrases already present in the
+existing prose. It is **not** a keyword-stuffed link farm (that is an SEO negative). No
+`noindex` / canonical / sitemap changes — those surfaces are already correct.
+
+Indexing is Google-controlled and lags; this PR delivers the link-equity lever, not a
+guaranteed re-index. The tracking issue (if any) is referenced with **`Ref`, not
+`Closes`**.
+
+### Target pages (external inbound count today → after this PR)
+
+| # | File | URL | Inbound today | New | After |
+|---|------|-----|---------------|-----|-------|
+| 1 | `plugins/soleur/docs/blog/2026-03-26-soleur-vs-polsia.md` | `/blog/soleur-vs-polsia/` | **0** (top priority) | 3 | 3 |
+| 2 | `plugins/soleur/docs/blog/2026-03-29-your-ai-team-works-from-your-actual-codebase.md` | `/blog/your-ai-team-works-from-your-actual-codebase/` | 1 | 2 | 3 |
+| 3 | `plugins/soleur/docs/blog/2026-04-22-billion-dollar-solo-founder-stack.md` | `/blog/billion-dollar-solo-founder-stack/` | 2 | 1 | 3 |
+
+Inbound counts were verified empirically (self-references excluded):
+`grep -rln '<slug>' plugins/soleur/docs/blog/*.md` — matches the brief exactly.
+
+### Link idiom (verified against neighboring posts)
+
+The repo's blog cross-link idiom is **`{{ site.url }}/blog/<slug>/`** with a **leading
+slash** — confirmed via `grep -rEoh '\{\{ ?site\.url ?\}\}/?blog/...'` (9 distinct
+existing cross-links, all leading-slash; zero host-mangled `{{ site.url }}blog/...` in
+source today). The host-mangle bug (missing leading slash → `https://soleur.aiblog/...`)
+must NOT be reintroduced.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a broken internal link in a published
+blog post (e.g. a host-mangled `https://soleur.aiblog/...` 404, or a link to a
+nonexistent slug) on soleur.ai — a visible credibility papercut on a marketing surface.
+
+**If this leaks, the user's data / workflow / money is exposed via:** N/A — this change
+adds only Markdown hyperlinks between already-public blog posts. No data, auth, or PII
+surface is touched.
+
+**Brand-survival threshold:** none — content/SEO link insertion on already-public
+marketing pages; worst case is a broken hyperlink caught by the Phase-4 build grep before
+merge. `threshold: none, reason: pure Markdown internal-link insertion on public blog
+posts; no sensitive path, schema, auth, or PII surface touched.`
+
+## Implementation Phases
+
+### Phase 1 — Add contextual internal links (6 links across 5 source posts)
+
+Each link sits on an **existing** topical phrase in the source post's prose. Anchor text,
+source line (as of plan time — /work must re-confirm the phrase is present and unlinked
+before editing, since line numbers drift), and rationale below. Use the idiom
+`[<existing phrase>]({{ site.url }}/blog/<target-slug>/)`.
+
+**→ Target 1: `/blog/soleur-vs-polsia/`** (3 new inbound — the Polsia comparison is about
+autonomous-vs-human-in-the-loop CaaS architectures; every anchor below already discusses
+exactly that axis):
+
+1. `2026-03-31-soleur-vs-paperclip.md` (~line 134, PROSE Q&A body) — anchor the phrase
+   **"fully autonomous by design"** in the sentence that already names Polsia
+   ("Polsia is the fastest-growing proprietary alternative … but is cloud-hosted,
+   closed-source, and fully autonomous by design."). Strongest possible anchor: Polsia is
+   named in the same sentence.
+   ⚠️ **Do NOT edit the JSON-LD mirror of this sentence** (~line 178, inside
+   `<script type="application/ld+json">`) — that is structured data, not rendered prose; a
+   Markdown link there breaks the JSON-LD and is never rendered as a link.
+2. `2026-05-12-company-as-a-service-platform.md` (~line 62) — anchor **"fully autonomous
+   AI companies"** in "This is the distinction from fully autonomous AI companies."
+   (verified unlinked prose).
+3. `2026-04-21-one-person-billion-dollar-company.md` (~line 86) — anchor **"Human-in-the-loop
+   decision gates"** in "Human-in-the-loop decision gates are not a concession to AI
+   limitations…" (the exact opposite architecture the Polsia post compares against).
+
+**→ Target 2: `/blog/your-ai-team-works-from-your-actual-codebase/`** (2 new inbound — the
+target post is the answer to the "agent starts from a blank workspace / brief it from
+scratch every session" problem; both anchors name that problem):
+
+4. `2026-03-24-vibe-coding-vs-agentic-engineering.md` (~line 49) — anchor **"the same
+   blank slate"** in "…hand the codebase to another agent for review. And the first thing
+   you realize is that the hundredth session starts from the same blank slate as the
+   first." (mentions the codebase directly — tight fit for the target).
+5. `2026-03-24-ai-agents-for-solo-founders.md` (~line 80) — anchor **"start from a blank
+   slate on each session"** in "Agents that start from a blank slate on each session
+   require the founder to re-supply context manually every time."
+
+**→ Target 3: `/blog/billion-dollar-solo-founder-stack/`** (1 new inbound — already at 2;
++1 → 3, satisfies the ~2–3 target):
+
+6. `2026-05-12-company-as-a-service-platform.md` (~line 107) — anchor the unlinked clause
+   **"a structural outcome of AI agents extending beyond engineering into every function a
+   company needs"**. The existing external link in that sentence is on the *earlier*
+   clause ("forecast that a one-person billion-dollar company would emerge as soon as
+   2026"); the new internal link lands on the later, unlinked clause → the stack post
+   documents exactly that function-by-function stack (Medvi proof). No overlap/nesting
+   with the existing link.
+
+**In-scope expansion (conditional, same defect class):** if Phase 4's built-output grep
+surfaces any PRE-EXISTING host-mangled `https://soleur.ai<letter>` links in other posts
+(a known prior occurrence — the 2026-06-15 learning found and fixed 5), fix them inline in
+this PR with a trivial leading-slash insertion (`{{ site.url }}blog/` → `{{ site.url }}/blog/`)
+and add each edited file to §Files to Edit with rationale. Rationale for folding in:
+shipping a "strengthen internal links" PR while knowingly leaving broken internal links
+one grep away is incoherent (`rf-review-finding-default-fix-inline`,
+`hr-weigh-every-decision-against-target-user-impact`). Source is clean today, so this is
+expected to be a no-op — but the grep is the gate, not the assumption.
+
+### Phase 2 — (no code phase)
+
+Pure content change; no build-config, template, or code edits.
+
+### Phase 3 — (no test-authoring phase)
+
+No unit tests apply to prose links. Verification is the Phase-4 build grep (below).
+
+### Phase 4 — Build + host-mangle verification (blocking)
+
+1. Build the Eleventy site from repo root:
+   `npx @11ty/eleventy` (the `docs:build` script; `.eleventy.js` lives at repo root and
+   emits to `_site/`). Do not trust a stale `_site/` from a prior session — build fresh.
+2. **Locate the build dir dynamically** (per the learning's session error — the plan path
+   is a snapshot, not authority):
+   ```bash
+   SITE=""
+   for d in _site plugins/soleur/docs/_site; do [ -d "$d/blog" ] && SITE="$d" && break; done
+   echo "SITE=$SITE"
+   ```
+3. **Host-mangle grep — MUST be empty:**
+   ```bash
+   grep -rEoh 'https://soleur\.ai[a-zA-Z]' "$SITE"/blog/ || echo "CLEAN (no host-mangle)"
+   ```
+   Any hit = a missing leading slash. If the hit is in one of THIS PR's new links, fix the
+   source and rebuild. If the hit is a PRE-EXISTING link in an untouched post, apply the
+   in-scope expansion from Phase 1.
+4. **Confirm the 6 new links rendered as real anchors** to the correct absolute URLs:
+   ```bash
+   for slug in soleur-vs-polsia your-ai-team-works-from-your-actual-codebase billion-dollar-solo-founder-stack; do
+     echo "== $slug =="; grep -rl "https://soleur.ai/blog/$slug/" "$SITE"/blog/ | wc -l
+   done
+   ```
+   Expect ≥ the new-inbound count per target (3 / 2 / 1, plus any pre-existing inbound).
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] 6 new internal links added on existing topical phrases across the 5 named source
+      posts (T1×3, T2×2, T3×1); each uses the `{{ site.url }}/blog/<slug>/` leading-slash
+      idiom. Verify: `git diff` shows exactly 6 added `{{ site.url }}/blog/` occurrences
+      (net), one per link site.
+- [ ] No new link is inside a `<script type="application/ld+json">` block (the paperclip
+      JSON-LD mirror at ~line 178 is untouched). Verify: `git diff` shows no change inside
+      any `application/ld+json` block.
+- [ ] Each new anchor sits on the pre-existing phrase named in Phase 1 (no fabricated
+      sentences, no keyword-stuffed anchor lists).
+- [ ] Fresh Eleventy build succeeds.
+- [ ] `grep -rEoh 'https://soleur\.ai[a-zA-Z]' "$SITE"/blog/` returns **empty** (no
+      host-mangle) against the dynamically-located `$SITE`.
+- [ ] Built output contains the three target absolute URLs with inbound counts ≥ (3, 2, 1)
+      new respectively.
+- [ ] If any pre-existing host-mangled link surfaced, it is fixed inline and its file is
+      listed in §Files to Edit with rationale (else: grep was clean — no expansion).
+- [ ] No changes to `noindex`, `canonical`, `sitemap.xml`, or any frontmatter of the
+      target pages.
+- [ ] PR body uses **`Ref`** (not `Closes`) for any tracking issue and includes the GSC
+      diagnosis summary (below).
+
+## Files to Edit
+
+| File | Change | For target |
+|------|--------|-----------|
+| `plugins/soleur/docs/blog/2026-03-31-soleur-vs-paperclip.md` | +1 internal link on "fully autonomous by design" (prose ~L134 only; NOT the JSON-LD ~L178) | T1 |
+| `plugins/soleur/docs/blog/2026-05-12-company-as-a-service-platform.md` | +2 internal links: "fully autonomous AI companies" (~L62 → T1) and "…every function a company needs" (~L107 → T3) | T1, T3 |
+| `plugins/soleur/docs/blog/2026-04-21-one-person-billion-dollar-company.md` | +1 internal link on "Human-in-the-loop decision gates" (~L86) | T1 |
+| `plugins/soleur/docs/blog/2026-03-24-vibe-coding-vs-agentic-engineering.md` | +1 internal link on "the same blank slate" (~L49) | T2 |
+| `plugins/soleur/docs/blog/2026-03-24-ai-agents-for-solo-founders.md` | +1 internal link on "start from a blank slate on each session" (~L80) | T2 |
+| _(conditional)_ any post surfaced by Phase-4 grep | inline leading-slash fix, same defect class | corpus |
+
+Dup-check confirmed at plan time: none of these 5 source posts currently link their
+assigned target (`grep -l '<target-slug>' <source>` → no match for all pairs).
+
+## Open Code-Review Overlap
+
+None. No open `code-review`-labelled issues touch `plugins/soleur/docs/blog/*.md` link
+sites (this is a fresh content edit, not a refactor of reviewed code).
+
+## Domain Review
+
+**Domains relevant:** marketing (SEO) — advisory only.
+
+The change is mechanical insertion of contextual internal links on existing prose to
+strengthen the site's link graph for three unindexed pages. No new marketing *copy* is
+authored (every anchor is a pre-existing phrase), so no copywriter/brand review is
+triggered. No UI-surface files (`components/**`, `app/**/page.tsx`, `app/**/layout.tsx`)
+are in §Files to Edit → the mechanical Product/UX override does NOT fire; Product/UX Gate
+is NONE. No CPO/CMO fan-out warranted for a 6-link content edit.
+
+## GSC Diagnosis Summary (for the PR body)
+
+The GSC Coverage drilldown (soleur.ai, updated 2026-06-30) buckets into three groups; only
+one is actionable in-repo:
+
+- **Legacy `.html` / `/pages/` paths** — all **301 cleanly** to apex clean URLs; GSC
+  `Last crawled` dates predate the redirect deploy (stale snapshots, self-resolve on
+  re-crawl). Not actionable.
+- **`www.` / `http://` variants** — benign apex canonicalization consolidation. Not
+  actionable.
+- **`403` on the `deploy.soleur.ai` subdomain** — correct (that host is not meant to be
+  indexed). Not actionable.
+- **Three genuinely-healthy blog pages** (200 / self-canonical / in-sitemap / no-noindex)
+  — the ONLY actionable bucket. Fix = contextual internal-link equity (this PR).
+
+Because indexing is Google-controlled and lags, the PR uses **`Ref`** for any tracking
+issue and delivers the link-equity lever, not a re-index guarantee.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only TBD/placeholder, or
+  omits the threshold will fail `deepen-plan` Phase 4.6. This one is filled (threshold:
+  none, with reason).
+- **Edit prose, not JSON-LD.** `2026-03-31-soleur-vs-paperclip.md` repeats the Polsia
+  sentence inside a `<script type="application/ld+json">` block (~L178). Only the rendered
+  prose occurrence (~L134) gets the link.
+- **Line numbers drift.** The ~Lxx anchors are plan-time snapshots; /work must
+  `grep -n '<exact phrase>'` each source before editing and confirm the phrase is present
+  and NOT already inside a `[]()` link.
+- **Build dir is `_site/` at worktree root, not `plugins/soleur/docs/_site/`.** Probe both
+  dynamically (Phase 4 step 2) — the plan literal is not authority
+  (`hr-when-a-plan-specifies-relative-paths-e-g`).
+- **Host-mangle grep runs on BUILT output**, not source. Source is clean today; the grep
+  is the gate that also doubles as a corpus broken-link finder (fix any hit inline, same
+  defect class).
+- Don't over-link. 6 links / 5 posts / 3 targets keeps each target at 3 inbound — natural
+  editorial density, not a link farm. Resist adding more.

--- a/knowledge-base/project/plans/2026-07-06-feat-gsc-internal-linking-equity-plan.md
+++ b/knowledge-base/project/plans/2026-07-06-feat-gsc-internal-linking-equity-plan.md
@@ -10,6 +10,75 @@ status: planned
 
 # ✨ Strengthen internal-link equity for 3 structurally-healthy, unindexed blog pages
 
+## Enhancement Summary
+
+**Deepened on:** 2026-07-06
+**Change class:** docs-only (6 Markdown internal links across 5 blog posts) — right-sized
+deepen (deterministic fact-verification + one targeted SEO-best-practice research pass),
+not a full multi-agent fan-out (disproportionate for a 6-link content edit).
+
+### Deepen gate results (all pass)
+
+- **4.4 Precedent-diff (link idiom):** the `{{ site.url }}/blog/<slug>/` leading-slash
+  idiom is the established repo precedent (21 existing leading-slash `/blog/` cross-links).
+  Not novel; no host-mangle in source today.
+- **4.5 Network-outage / 4.55 Downtime & Cutover:** no triggers (no SSH/network/infra/DB
+  migration/deploy surface). Skip.
+- **4.6 User-Brand Impact halt:** section present; threshold `none` with a valid
+  scope-out reason (pure Markdown link insertion, no sensitive path). Pass.
+- **4.7 Observability gate:** pure-docs — every Files-to-Edit path is `.md` outside
+  `plugins/*/skills/` and `apps/*/`. Skip.
+- **4.8 PAT-shaped variable halt:** no PAT-shaped var/literal in plan. Pass.
+- **4.9 UI-wireframe halt:** no UI-surface file. Skip.
+
+### Load-bearing facts re-verified deterministically
+
+- **Permalink resolution:** `plugins/soleur/docs/blog/blog.json` sets
+  `permalink: "blog/{{ page.fileSlug }}/index.html"`. Eleventy's `fileSlug` strips the
+  `YYYY-MM-DD-` date prefix, so the three targets resolve to `/blog/soleur-vs-polsia/`,
+  `/blog/your-ai-team-works-from-your-actual-codebase/`, `/blog/billion-dollar-solo-founder-stack/`
+  — exactly the URLs in §Overview. `_data/pillars.js:16` independently confirms
+  `/blog/billion-dollar-solo-founder-stack/` as the canonical pillar URL. `blogRedirects.js`
+  also 301s the date-prefixed form to the clean slug, so the clean-slug links are canonical.
+- **All 6 anchor phrases** are present verbatim and **unlinked** at their sites (verified
+  by `sed`/`grep` at plan time). The company-as-a-service:107 anchor is the *unlinked tail
+  clause* — the existing external link occupies the earlier clause, so no nesting.
+- **Dup-check:** none of the 5 source posts currently link their assigned target.
+
+---
+
+# (original plan below)
+
+## Enhancement Summary
+
+**Deepened on:** 2026-07-06
+
+**Deepen-plan halt gates — all clear:**
+- Phase 4.6 User-Brand Impact — PASS (section present; threshold `none` with a
+  `threshold: none, reason:` scope-out; Files-to-Edit are non-sensitive blog `.md`).
+- Phase 4.7 Observability — SKIP (pure-docs; every Files-to-Edit path is `.md` outside
+  `plugins/*/skills/` and `apps/*/` — no production code/infra surface).
+- Phase 4.8 PAT-shaped variable — PASS (no `var.*_token`/`TF_VAR_*`/literal-token hits).
+- Phase 4.9 UI-wireframe — SKIP (no UI-surface file in Files-to-Edit).
+- Phase 4.5 network-outage / 4.55 downtime-cutover — SKIP (no SSH/network/infra/DB/deploy
+  triggers).
+
+**Deepen verification (deterministic — the load-bearing facts):**
+- **Permalink resolution confirmed.** `plugins/soleur/docs/blog/blog.json` sets
+  `permalink: "blog/{{ page.fileSlug }}/index.html"`; Eleventy's `fileSlug` strips the
+  `YYYY-MM-DD-` date prefix, so the three targets resolve to exactly
+  `/blog/soleur-vs-polsia/`, `/blog/your-ai-team-works-from-your-actual-codebase/`, and
+  `/blog/billion-dollar-solo-founder-stack/`. `pillars.js` independently pins
+  `/blog/billion-dollar-solo-founder-stack/` as the canonical pillar URL. The
+  date-prefixed form redirects to the clean slug (`blogRedirects.js`), so the clean-slug
+  links are canonical.
+- **Idiom precedent confirmed** (Phase 4.4 precedent-diff): 21 existing leading-slash
+  `{{ site.url }}/blog/<slug>/` cross-links in the corpus; the pattern is established, not
+  novel. Zero host-mangled `{{ site.url }}blog/...` in source today.
+- **All 6 anchor phrases verified present and unlinked** in their source posts at plan
+  time (exact strings quoted in Phase 1; /work must re-grep as line numbers drift).
+- **Dup-check confirmed:** none of the 5 source posts currently links its assigned target.
+
 ## Overview
 
 Google Search Console (soleur.ai, report last updated 2026-06-30) flags three canonical
@@ -173,6 +242,9 @@ No unit tests apply to prose links. Verification is the Phase-4 build grep (belo
       any `application/ld+json` block.
 - [ ] Each new anchor sits on the pre-existing phrase named in Phase 1 (no fabricated
       sentences, no keyword-stuffed anchor lists).
+- [ ] Anchor text is descriptive and varied, not identical exact-match repeated across
+      links (per Google Links best-practices). No two links to the same target use the
+      identical anchor string; each anchor is embedded in body prose (not a link widget).
 - [ ] Fresh Eleventy build succeeds.
 - [ ] `grep -rEoh 'https://soleur\.ai[a-zA-Z]' "$SITE"/blog/` returns **empty** (no
       host-mangle) against the dynamically-located `$SITE`.
@@ -198,6 +270,33 @@ No unit tests apply to prose links. Verification is the Phase-4 build grep (belo
 
 Dup-check confirmed at plan time: none of these 5 source posts currently link their
 assigned target (`grep -l '<target-slug>' <source>` → no match for all pairs).
+
+### Research Insights — contextual internal linking (Google Search Central, 2025-2026)
+
+Sources: [Google — SEO Link Best Practices](https://developers.google.com/search/docs/crawling-indexing/links-crawlable),
+[Google — Page indexing report](https://support.google.com/webmasters/answer/7440203),
+[Onely — Fixing "Crawled – currently not indexed"](https://www.onely.com/blog/how-to-fix-crawled-currently-not-indexed-in-google-search-console/).
+
+- **Internal linking is a Google-endorsed lever for this exact bucket.** For structurally
+  healthy pages, "Crawled – currently not indexed" reflects Google judging standalone
+  importance as low; links from already-indexed, higher-authority pages signal importance
+  and distribute crawl priority / link equity. Confirms the learning's Insight 2.
+- **Anchor text must be descriptive, concise, relevant — and VARIED.** Repeating one
+  exact-match keyword anchor across many links is an over-optimization signal Google can
+  discount. Our 6 anchors are sentence-embedded and varied per source; encoded as an AC
+  below. (Note: T1's three anchors include two "fully autonomous …" variants — acceptable
+  because they are different phrases in different posts and each descriptively names the
+  destination's autonomous-vs-human axis; T2's two "blank slate" anchors are likewise
+  partial-match, sentence-embedded, not identical.)
+- **~6 contextual internal links across 3 targets is conservative and natural.** Healthy
+  range for an under-linked page is ~5-10 inbound; manipulation comes from *irrelevance
+  and identical anchors*, not from count. Internal links between your own topically-related
+  pages carry no PBN/link-farm risk. Reinforces "don't over-link."
+- **Body prose beats widgets.** Contextual links inside relevant body copy pass more value
+  than footer/sidebar/"related links" widgets (template noise). All 6 links land in body
+  prose — correct by construction. Do NOT convert this into a related-links widget.
+- **Links are necessary, not sufficient.** Indexing also depends on content quality and is
+  Google-controlled + lagged — reinforces `Ref` (not `Closes`) framing.
 
 ## Open Code-Review Overlap
 

--- a/knowledge-base/project/specs/feat-one-shot-gsc-internal-linking/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-gsc-internal-linking/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: /home/jean/git-repositories/jikig-ai/soleur/.worktrees/feat-one-shot-gsc-internal-linking/knowledge-base/project/plans/2026-07-06-feat-gsc-internal-linking-equity-plan.md
+- Status: complete
+
+### Errors
+None. (One Edit missed on first attempt due to heading-text mismatch; re-read and re-applied cleanly. Background SEO-research agent completed successfully.)
+
+### Decisions
+- Six contextual links across five source posts, targets balanced to 3 inbound each (T1 soleur-vs-polsia 0→3, T2 your-ai-team-from-codebase 1→3, T3 billion-dollar-stack 2→3). Every anchor on a verified pre-existing unlinked topical phrase.
+- Idiom verified empirically: `{{ site.url }}/blog/<slug>/` (leading slash); source is host-mangle-clean today (prior 2026-06-15 PR fixed the 5 pre-existing ones). Target slugs resolve via blog.json permalink `blog/{{ page.fileSlug }}/index.html`.
+- Phase-4 verification: dynamic build-dir probe + `grep -rEoh 'https://soleur\.ai[a-zA-Z]'` on built output, with in-scope-expansion clause to fix any pre-existing host-mangle inline.
+- Framing: `Ref` not `Closes` (indexing Google-controlled/lagged); GSC diagnosis summary baked into plan for PR body.
+- Right-sized deepen: halt gates run (4.6 pass, 4.7/4.8/4.9 skip) + one targeted SEO best-practice research pass; added AC for varied/descriptive anchor text, body-prose placement, no link-widget conversion.
+
+### Components Invoked
+- Skill: soleur:plan
+- Skill: soleur:deepen-plan
+- Agent (Explore, background): SEO internal-linking best practices research

--- a/knowledge-base/project/specs/feat-one-shot-gsc-internal-linking/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-gsc-internal-linking/tasks.md
@@ -1,0 +1,28 @@
+# Tasks — GSC internal-link equity for 3 unindexed blog pages
+
+Plan: `knowledge-base/project/plans/2026-07-06-feat-gsc-internal-linking-equity-plan.md`
+Lane: cross-domain (no spec.md `lane:` present — TR2 fail-closed default)
+
+## Phase 1 — Add contextual internal links (edit prose only, use `{{ site.url }}/blog/<slug>/`)
+
+For each: `grep -n '<exact phrase>' <file>` first; confirm present and NOT already linked.
+
+- [ ] 1.1 `2026-03-31-soleur-vs-paperclip.md` — link **"fully autonomous by design"** → `/blog/soleur-vs-polsia/` (PROSE ~L134 only; do NOT touch JSON-LD ~L178)
+- [ ] 1.2 `2026-05-12-company-as-a-service-platform.md` — link **"fully autonomous AI companies"** (~L62) → `/blog/soleur-vs-polsia/`
+- [ ] 1.3 `2026-04-21-one-person-billion-dollar-company.md` — link **"Human-in-the-loop decision gates"** (~L86) → `/blog/soleur-vs-polsia/`
+- [ ] 1.4 `2026-03-24-vibe-coding-vs-agentic-engineering.md` — link **"the same blank slate"** (~L49) → `/blog/your-ai-team-works-from-your-actual-codebase/`
+- [ ] 1.5 `2026-03-24-ai-agents-for-solo-founders.md` — link **"start from a blank slate on each session"** (~L80) → `/blog/your-ai-team-works-from-your-actual-codebase/`
+- [ ] 1.6 `2026-05-12-company-as-a-service-platform.md` — link **"a structural outcome of AI agents extending beyond engineering into every function a company needs"** (~L107, unlinked clause) → `/blog/billion-dollar-solo-founder-stack/`
+
+## Phase 2 — Build + verify (blocking)
+
+- [ ] 2.1 Fresh build: `npx @11ty/eleventy`
+- [ ] 2.2 Locate build dir dynamically: `for d in _site plugins/soleur/docs/_site; do [ -d "$d/blog" ] && SITE="$d" && break; done`
+- [ ] 2.3 Host-mangle grep MUST be empty: `grep -rEoh 'https://soleur\.ai[a-zA-Z]' "$SITE"/blog/`
+- [ ] 2.4 If pre-existing host-mangle surfaces in untouched posts → fix inline (leading-slash), add file to plan §Files to Edit
+- [ ] 2.5 Confirm 3 target absolute URLs present with new inbound counts ≥ (3, 2, 1)
+
+## Phase 3 — Ship
+
+- [ ] 3.1 PR body: `Ref` (not `Closes`) for any tracking issue + GSC diagnosis summary
+- [ ] 3.2 Confirm no `noindex`/canonical/sitemap/frontmatter changes to target pages

--- a/plugins/soleur/docs/blog/2026-03-24-ai-agents-for-solo-founders.md
+++ b/plugins/soleur/docs/blog/2026-03-24-ai-agents-for-solo-founders.md
@@ -77,7 +77,7 @@ Not every AI agent is useful for a solo founder. The properties that matter most
 
 **Cross-domain context.** The most important question to ask about any AI agent stack: what does the marketing agent know about what the engineering agent decided last week? If the answer is "nothing," you have a collection of tools, not an organization.
 
-**Persistent knowledge.** Agents that start from a blank slate on each session require the founder to re-supply context manually every time. Agents with persistent memory across sessions accumulate knowledge and reduce the founder's coordination cost over time. This distinction compounds — a system that remembers three months of decisions is dramatically more useful than one that forgets at session end.
+**Persistent knowledge.** Agents that [start from a blank slate on each session]({{ site.url }}/blog/your-ai-team-works-from-your-actual-codebase/) require the founder to re-supply context manually every time. Agents with persistent memory across sessions accumulate knowledge and reduce the founder's coordination cost over time. This distinction compounds — a system that remembers three months of decisions is dramatically more useful than one that forgets at session end.
 
 **Verifiable output.** An agent's output should be checkable against a specification. Quality gates built into the workflow replace the code review, legal review, and editorial review that a team provides. Without those gates, the founder becomes the bottleneck for every domain, every time.
 

--- a/plugins/soleur/docs/blog/2026-03-24-vibe-coding-vs-agentic-engineering.md
+++ b/plugins/soleur/docs/blog/2026-03-24-vibe-coding-vs-agentic-engineering.md
@@ -46,7 +46,7 @@ The problem is not the approach. The problem is what happens after you decide to
 
 The plateau arrives fast.
 
-You have a working prototype. The vibes were good. Now you need to add a feature, fix a regression, or hand the codebase to another agent for review. And the first thing you realize is that the hundredth session starts from the same blank slate as the first.
+You have a working prototype. The vibes were good. Now you need to add a feature, fix a regression, or hand the codebase to another agent for review. And the first thing you realize is that the hundredth session starts from [the same blank slate]({{ site.url }}/blog/your-ai-team-works-from-your-actual-codebase/) as the first.
 
 The model does not remember why you made that architectural decision. It does not know that approach was tried and failed three days ago. It does not know which edge cases your tests cover or which parts of the codebase are fragile. Every session is a reconstruction.
 

--- a/plugins/soleur/docs/blog/2026-03-31-soleur-vs-paperclip.md
+++ b/plugins/soleur/docs/blog/2026-03-31-soleur-vs-paperclip.md
@@ -131,7 +131,7 @@ Yes. Soleur's domain agents could run as managed workers within Paperclip's orch
 
 **Q: What are the main open-source AI company platforms in 2026?**
 
-The two most prominent self-hosted platforms for AI company operation are Paperclip (open-source, MIT license, 14,600+ GitHub stars, governance infrastructure layer) and Soleur (source-available, BSL 1.1, {{ stats.agents }} agents, domain intelligence layer). Polsia is the fastest-growing proprietary alternative -- [$1.5M ARR with 2,000+ managed companies](https://www.teamday.ai/ai/polsia-solo-founder-million-arr-self-running-companies) as of March 2026 -- but is cloud-hosted, closed-source, and fully autonomous by design.
+The two most prominent self-hosted platforms for AI company operation are Paperclip (open-source, MIT license, 14,600+ GitHub stars, governance infrastructure layer) and Soleur (source-available, BSL 1.1, {{ stats.agents }} agents, domain intelligence layer). Polsia is the fastest-growing proprietary alternative -- [$1.5M ARR with 2,000+ managed companies](https://www.teamday.ai/ai/polsia-solo-founder-million-arr-self-running-companies) as of March 2026 -- but is cloud-hosted, closed-source, and [fully autonomous by design]({{ site.url }}/blog/soleur-vs-polsia/).
 
 <script type="application/ld+json">
 {

--- a/plugins/soleur/docs/blog/2026-04-21-one-person-billion-dollar-company.md
+++ b/plugins/soleur/docs/blog/2026-04-21-one-person-billion-dollar-company.md
@@ -83,7 +83,7 @@ The one-person billion-dollar company is not automatic. It requires three things
 
 **A lifecycle, not a prompt.** The founders who plateau at point solutions are using AI transactionally: here is a task, here is a response, done. The founders who build compound organizations treat each task as a step in a lifecycle — brainstorm, plan, implement, review, and compound. The compound step is not optional. It is what makes the next session better than this one.
 
-**Judgment at every gate.** The system executes. The founder decides. This is the design. Human-in-the-loop decision gates are not a concession to AI limitations — they are the architecture that lets a single person exercise judgment across all nine domains without being overwhelmed by execution. The founder who stays in the judgment role rather than the execution role is the founder who can actually manage a nine-department organization alone.
+**Judgment at every gate.** The system executes. The founder decides. This is the design. [Human-in-the-loop decision gates]({{ site.url }}/blog/soleur-vs-polsia/) are not a concession to AI limitations — they are the architecture that lets a single person exercise judgment across all nine domains without being overwhelmed by execution. The founder who stays in the judgment role rather than the execution role is the founder who can actually manage a nine-department organization alone.
 
 ## The Competitive Window
 

--- a/plugins/soleur/docs/blog/2026-05-12-company-as-a-service-platform.md
+++ b/plugins/soleur/docs/blog/2026-05-12-company-as-a-service-platform.md
@@ -59,7 +59,7 @@ Knowledge coherence is what makes compounding possible. Every decision, document
 
 A CaaS platform amplifies founder judgment — it does not replace it. The founder remains the decision-maker. Agents execute with domain expertise and full context, but they do not override the human at the top of the hierarchy.
 
-This is the distinction from fully autonomous AI companies. The founder's judgment is not a bug in the human-AI relationship. It is the product's core value proposition.
+This is the distinction from [fully autonomous AI companies]({{ site.url }}/blog/soleur-vs-polsia/). The founder's judgment is not a bug in the human-AI relationship. It is the product's core value proposition.
 
 ## How Soleur Implements CaaS
 
@@ -104,7 +104,7 @@ The most important property of Company-as-a-Service is not what it does on day o
 
 Every session captures learnings. Every document produced enters the knowledge base. Every decision made becomes available context for the next decision. The system does not reset. It accumulates.
 
-This is the mechanism behind the prediction. Dario Amodei, CEO of Anthropic, [forecast that a one-person billion-dollar company would emerge as soon as 2026](https://officechai.com/ai/the-first-one-person-billon-dollar-startup-will-be-a-reality-by-2026-anthropic-ceo-dario-amodei/) — not as a curiosity but as a structural outcome of AI agents extending beyond engineering into every function a company needs. The solo founder building with a CaaS platform today is not waiting for that future. They are already inside it.
+This is the mechanism behind the prediction. Dario Amodei, CEO of Anthropic, [forecast that a one-person billion-dollar company would emerge as soon as 2026](https://officechai.com/ai/the-first-one-person-billon-dollar-startup-will-be-a-reality-by-2026-anthropic-ceo-dario-amodei/) — not as a curiosity but as [a structural outcome of AI agents extending beyond engineering into every function a company needs]({{ site.url }}/blog/billion-dollar-solo-founder-stack/). The solo founder building with a CaaS platform today is not waiting for that future. They are already inside it.
 
 ---
 


### PR DESCRIPTION
## Summary

Google Search Console (soleur.ai, report updated 2026-06-30) flagged more pages as **"Crawled – currently not indexed."** I pulled the full "not indexed" breakdown live via Search Console and verified every bucket with `curl` (Googlebot UA). Net finding: of 70 not-indexed pages, almost all are benign or already-fixed — only **three genuinely-healthy blog pages** are actionable, and the sole in-repo lever for them is **contextual internal-link equity**.

This PR adds **6 genuinely contextual internal links** across 5 topically-related blog posts, each anchored on a pre-existing unlinked phrase, balancing all three target pages to 3 inbound links. Not a keyword-stuffed link farm; no `noindex`/canonical/sitemap/JSON-LD changes.

Indexing is Google-controlled and lags, so this delivers the link-equity **lever**, not a guaranteed re-index — tracked as a monitor, not a `Closes`.

### GSC diagnosis (each bucket verified live)

| Bucket | Verdict |
|---|---|
| Legacy `/pages/*.html` (agents, vision, changelog, cookie-policy, terms) | **Already fixed** — all 301 cleanly to apex clean URLs; GSC dates are stale pre-redirect snapshots |
| `www.` / `http://` variants | **Benign** — 301 to apex (canonicalization consolidation) |
| `403` on `deploy.soleur.ai` | **Correct** — infra subdomain, not meant to be indexed |
| Three healthy blog pages (200 / self-canonical / in-sitemap / no-noindex) | **Actionable** — this PR |

### Target pages (external inbound links: before → after)

| Page | Before | After |
|---|---|---|
| `/blog/soleur-vs-polsia/` | 0 | 3 |
| `/blog/your-ai-team-works-from-your-actual-codebase/` | 1 | 3 |
| `/blog/billion-dollar-solo-founder-stack/` | 2 | 3 |

## Changelog

- **Docs (blog):** Added 6 contextual internal links to strengthen the site's link graph for three structurally-healthy but unindexed blog pages, per the GSC "Crawled – currently not indexed" remediation pattern (internal linking, not infra).

## Test plan

- [x] All 6 anchors verified present + unlinked in source before editing; JSON-LD mirror in `soleur-vs-paperclip.md` left untouched
- [x] Fresh Eleventy build succeeds
- [x] Host-mangle grep on built output (`grep -rEoh 'https://soleur\.ai[a-zA-Z]' _site/blog/`) returns **clean** (no missing-leading-slash `https://soleur.ai<letter>`)
- [x] Rendered inbound counts ≥ new-link target (5 / 5 / 4 ≥ 3 / 2 / 1)
- [x] Multi-agent review clean (git-history, pattern-recognition, code-quality, security) — 0 findings; anchor variety + leading-slash idiom confirmed

_Re-indexing is Google's discretionary call and lags by design (no deterministic "request indexing" API for docs pages), so there is no mechanical post-merge gate — this PR ships the link-equity lever and the GSC report is the informational signal to glance at on the next natural review._

Generated with [Claude Code](https://claude.com/claude-code)
