### PR TITLE
fix(infra): move package install into instrumented runcmd apt — name the config-phase hang (#6090)

### DIFF
--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -1,18 +1,16 @@
 #cloud-config
-package_update: true
-packages:
-  - curl
-  - fail2ban
-  - jq
-  - nftables
+# (#6090) package_update:/packages: were REMOVED here and moved into an instrumented early-runcmd
+# apt block (STAGE=apt_update/apt_install, under the top-armed trap + `timeout`s). recreate
+# 28819237402 proved web-2 dies in the opaque config phase (bootcmd_start fired, runcmd_start never
+# did) — running apt in runcmd converts a config-stage hang into a NAMED fatal, not a silent abort.
 
-# (#6090) Earliest boot beacon. bootcmd runs in cloud-init's network stage — BEFORE
-# package_update/packages: and runcmd — so if web-2 dies pre-runcmd (an apt hang in
-# package_update, a broken mirror, a wedged packages: install) this still reports that the
-# boot reached bootcmd AND has Sentry egress. Best-effort: curl may not exist until packages:
-# installs it (Hetzner ubuntu-24.04 ships curl, so it normally fires); fully fail-open, never
-# blocks boot. Reads the baked ${sentry_dsn} (no doppler yet). A landed bootcmd_start with no
-# later stage brackets the death to packages:/config; nothing landing → no-egress/pre-network.
+# (#6090) Earliest boot beacon. bootcmd runs in cloud-init's network stage — before runcmd (and
+# before any residual config-stage cc modules) — so even a very early death still reports that the
+# boot reached bootcmd AND has Sentry egress. CONFIRMED by recreate 28819237402: bootcmd_start
+# landed (host_id=148545005) but runcmd_start never did → egress works, death was in the config
+# phase → apt install was moved into instrumented runcmd (below). Best-effort: uses the base-image
+# curl (Hetzner ubuntu-24.04 ships it, proven by this beacon firing); fully fail-open, never blocks
+# boot. Reads the baked ${sentry_dsn} (no doppler yet).
 bootcmd:
   - |
     ( set +e
@@ -295,7 +293,7 @@ runcmd:
   # POST, so a curl-less host (which dies everywhere) is an accepted residual.
   - |
     IMAGE_REF='${image_name}'
-    STAGE=pkg_audit
+    STAGE=runcmd_early
     HOST_ID=$( (cat /var/lib/cloud/data/instance-id 2>/dev/null || hostname) | tr -d '"' )
     # (#6090) ONE transport, reused by on_err (fatal) + the runcmd_start breadcrumb (info):
     #   _emit <message> <stage> <level>. Prefers the BAKED DSN so it fires even when doppler is
@@ -335,42 +333,24 @@ runcmd:
   # access even if the audit exits non-zero and halts the rest of cloud-init.
   - systemctl restart sshd
 
-  # Audit that cloud-init's packages: stage actually installed every declared
-  # package. Cloud-init can silently drop package installs on transient
-  # failures (apt lock contention, network error, "No space left on device"
-  # during first boot) without failing the run. If any declared package is
-  # missing after packages:, fail loudly so the operator sees the root cause
-  # in /var/log/cloud-init-output.log (#2680).
-  #
-  # The required-package list is parsed at runtime from the rendered cloud
-  # config at /var/lib/cloud/instance/cloud-config.txt -- no hardcoded list
-  # to drift away from the packages: block at the top of this file.
+  # (#6090) Package install — MOVED here from cloud-config package_update:/packages:. recreate
+  # 28819237402 localized web-2's death to the opaque config phase (bootcmd_start fired,
+  # runcmd_start never did), and apt (update/install) is that phase's heavy op. Running it under
+  # the top-armed trap with explicit `timeout`s converts a HANG (the likely cause of the ~640s
+  # poll timeouts) into a NAMED fatal (stage=apt_update / apt_install) instead of a silent config-
+  # stage abort. Fail-CLOSED: a non-zero/timeout after retries trips `set -e` → on_err emits the
+  # live STAGE → exit 1. curl is base-image-provided (the bootcmd beacon already proved it), so
+  # the earlier runcmd _emit/breadcrumb don't depend on this install.
   - |
     set -e
-    required_packages=$(awk '/^packages:$/{flag=1; next} /^[^ ]/{flag=0} flag && /^  - /{sub(/^  - /, ""); print}' /var/lib/cloud/instance/cloud-config.txt)
-    if [ -z "$required_packages" ]; then
-      echo "FATAL: package audit could not parse packages: list from cloud-config.txt" >&2
-      exit 1
-    fi
-    missing=""
-    for pkg in $required_packages; do
-      dpkg -s "$pkg" >/dev/null 2>&1 || missing="$missing $pkg"
-    done
-    if [ -n "$missing" ]; then
-      echo "FATAL: cloud-init packages: stage did not install:$missing" >&2
-      # One-shot self-heal for transient apt failures. If this also fails we
-      # exit non-zero so cloud-init marks the boot failed and the operator
-      # investigates via the Hetzner console.
-      export DEBIAN_FRONTEND=noninteractive
-      apt-get update -qq
-      apt-get install -y -qq $missing
-      for pkg in $missing; do
-        dpkg -s "$pkg" >/dev/null 2>&1 || { echo "FATAL: $pkg still missing after recovery install" >&2; exit 1; }
-      done
-    fi
+    export DEBIAN_FRONTEND=noninteractive
+    STAGE=apt_update
+    n=0; until timeout 240 apt-get update -o Acquire::Retries=3; do n=$((n+1)); [ "$n" -ge 3 ] && exit 1; sleep 10; done
+    STAGE=apt_install
+    n=0; until timeout 300 apt-get install -y curl fail2ban jq nftables; do n=$((n+1)); [ "$n" -ge 3 ] && exit 1; sleep 10; done
 
   # Reload fail2ban so the jail.d/soleur-sshd.local drop-in applies (#2654).
-  # fail2ban is installed via `packages:` above; the service auto-starts on
+  # fail2ban is installed via the apt_install block above; the service auto-starts on
   # install with the defaults-debian.conf [sshd] jail enabled. The reload
   # picks up the bantime.maxtime cap before any login activity is recorded.
   - STAGE=fail2ban  # (#6090) exact stage attribution for the top-armed on_err fatal

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -344,10 +344,20 @@ runcmd:
   - |
     set -e
     export DEBIAN_FRONTEND=noninteractive
+    # cloudflare-main.list is active from boot (write_files) but its keyring is only fetched at the
+    # cloudflared install far below — so apt-get update here would DETERMINISTICALLY fail on the
+    # missing signed-by keyring (noble exit 100, NOT retryable by Acquire::Retries) and mask the
+    # real cause. Fetch it FIRST, before any apt-get update sees the cloudflare source.
+    STAGE=cf_apt_key
+    n=0; until curl --connect-timeout 5 -m 20 -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg -o /usr/share/keyrings/cloudflare-main.gpg; do n=$((n+1)); [ "$n" -ge 3 ] && exit 1; sleep 5; done
+    # DPkg::Lock::Timeout waits out the apt-daily timer (holds the lock minutes on a fresh boot)
+    # instead of hard-failing; the outer `timeout` still bounds a true hang → named fatal. 2
+    # attempts keeps the named fatal near the ~640s provision poll — the Sentry fatal is durable
+    # regardless (it may post-date the poll and is the authoritative signal).
     STAGE=apt_update
-    n=0; until timeout 240 apt-get update -o Acquire::Retries=3; do n=$((n+1)); [ "$n" -ge 3 ] && exit 1; sleep 10; done
+    n=0; until timeout 240 apt-get update -o Acquire::Retries=3 -o DPkg::Lock::Timeout=300; do n=$((n+1)); [ "$n" -ge 2 ] && exit 1; sleep 10; done
     STAGE=apt_install
-    n=0; until timeout 300 apt-get install -y curl fail2ban jq nftables; do n=$((n+1)); [ "$n" -ge 3 ] && exit 1; sleep 10; done
+    n=0; until timeout 300 apt-get install -y -o DPkg::Lock::Timeout=300 curl fail2ban jq nftables; do n=$((n+1)); [ "$n" -ge 2 ] && exit 1; sleep 10; done
 
   # Reload fail2ban so the jail.d/soleur-sshd.local drop-in applies (#2654).
   # fail2ban is installed via the apt_install block above; the service auto-starts on
@@ -468,9 +478,9 @@ runcmd:
   # Set after recursive chown so it isn't overridden
   - chown 1001:1001 /mnt/data/workspaces
 
-  # Install cloudflared from Cloudflare apt repository.
-  # GPG key downloaded at provision time (rotated Oct 2025).
-  - curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg -o /usr/share/keyrings/cloudflare-main.gpg
+  # Install cloudflared from Cloudflare apt repository. The signing keyring (rotated Oct 2025) is
+  # now fetched in the early apt block above (stage=cf_apt_key) — the cloudflare source is active
+  # from boot, so its key must precede the FIRST apt-get update, not just this cloudflared install.
   - apt-get update
   - apt-get install -y cloudflared
 

--- a/apps/web-platform/infra/cron-egress-firewall.test.sh
+++ b/apps/web-platform/infra/cron-egress-firewall.test.sh
@@ -534,7 +534,9 @@ assert_grep "bootstrap installs cron-egress allowlists into /etc/soleur (0644)" 
 assert_not_grep "cron-egress loader is NOT re-inlined in cloud-init write_files" '- path: /usr/local/bin/cron-egress-nftables\.sh' "$CLOUD_INIT"
 assert_grep "cloud-init enables the firewall unit" 'systemctl enable --now cron-egress-firewall\.service' "$CLOUD_INIT"
 assert_grep "cloud-init enables the resolve timer" 'systemctl enable --now cron-egress-resolve\.timer' "$CLOUD_INIT"
-assert_grep "cloud-init installs nftables" '^ *- nftables$' "$CLOUD_INIT"
+# #6090: package install moved from cloud-config packages: into an instrumented runcmd apt block
+# (so a config-phase apt hang becomes a named fatal). nftables is still installed — now via apt-get.
+assert_grep "cloud-init installs nftables (runcmd apt block, #6090)" 'apt-get install -y .*nftables' "$CLOUD_INIT"
 
 echo "-- Phase 2.1: assertion-block self-reporting sentinels (#5279) --"
 # The post-apply assertion block (server.tf, the 2nd remote-exec) runs under

--- a/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
+++ b/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
@@ -396,6 +396,25 @@ if grep -qE 'timeout [0-9]+ apt-get update' "$CI" && grep -qE 'timeout [0-9]+ ap
 else
   no "AC17: apt-get update/install must be timeout-wrapped so a hang trips the trap with a named stage"
 fi
+# Ordering: STAGE must be set BEFORE the hang-capable command (else the fatal mis-attributes), and
+# the apt block must sit AFTER the trap arm (else no emit coverage). Guards a silent regression.
+su_ln=$(grep -nE '^\s*STAGE=apt_update' "$CI" | head -1 | cut -d: -f1 || true)
+auu_ln=$(grep -nE 'timeout [0-9]+ apt-get update' "$CI" | head -1 | cut -d: -f1 || true)
+armln2=$(grep -nE '^\s*trap on_err EXIT' "$CI" | head -1 | cut -d: -f1 || true)
+if [ -n "$su_ln" ] && [ -n "$auu_ln" ] && [ -n "$armln2" ] && [ "$armln2" -lt "$su_ln" ] && [ "$su_ln" -lt "$auu_ln" ]; then
+  ok "AC17: trap-arm ($armln2) < STAGE=apt_update ($su_ln) < apt-get update ($auu_ln) — covered + correctly attributed"
+else
+  no "AC17: need trap-arm < STAGE=apt_update < apt-get update (arm=$armln2 stage=$su_ln update=$auu_ln)"
+fi
+# The cloudflare keyring must be fetched BEFORE the first apt-get update — the cloudflare source is
+# active from boot (write_files), so an update before the key deterministically fails (missing
+# signed-by keyring) and masks the real cause. (Anchor on the curl fetch, not the deb/signed-by line.)
+cfk_ln=$(grep -nE 'curl.*cloudflare-main\.gpg' "$CI" | head -1 | cut -d: -f1 || true)
+if [ -n "$cfk_ln" ] && [ -n "$auu_ln" ] && [ "$cfk_ln" -lt "$auu_ln" ]; then
+  ok "AC17: cloudflare keyring fetched (line $cfk_ln) BEFORE apt-get update ($auu_ln) — no missing-key fatal"
+else
+  no "AC17: cloudflare-main.gpg must be curl-fetched before the first apt-get update (cfk=$cfk_ln update=$auu_ln)"
+fi
 
 echo "=== soleur-host-bootstrap-observability: $pass passed, $fail failed ==="
 [ "$fail" -eq 0 ]

--- a/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
+++ b/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
@@ -376,5 +376,26 @@ else
   no "AC16: surface step must derive MSG_RE from QUERY and filter events client-side (test(\$re))"
 fi
 
+# ── AC17 (#6090): package install moved from the opaque config phase into instrumented runcmd ──
+# recreate 28819237402 localized web-2's death to the packages:/config phase (bootcmd_start fired,
+# runcmd_start never did). apt now runs under the top-armed trap with named stages + timeouts so a
+# HANG becomes a NAMED fatal (stage=apt_update/apt_install), and the cloud-config packages: block
+# is removed (else the hang would remain in the opaque config phase).
+if grep -qE 'STAGE=apt_update' "$CI" && grep -qE 'STAGE=apt_install' "$CI"; then
+  ok "AC17: apt runs in instrumented runcmd with named stages (apt_update/apt_install)"
+else
+  no "AC17: cloud-init must set STAGE=apt_update + STAGE=apt_install in the runcmd apt block"
+fi
+if grep -qE '^packages:' "$CI"; then
+  no "AC17: cloud-config packages: must be REMOVED (a config-phase hang would stay opaque) — install in runcmd"
+else
+  ok "AC17: no cloud-config packages: block (install moved to instrumented runcmd)"
+fi
+if grep -qE 'timeout [0-9]+ apt-get update' "$CI" && grep -qE 'timeout [0-9]+ apt-get install' "$CI"; then
+  ok "AC17: apt update+install are timeout-wrapped (a HANG becomes a named fatal, not a ~640s poll timeout)"
+else
+  no "AC17: apt-get update/install must be timeout-wrapped so a hang trips the trap with a named stage"
+fi
+
 echo "=== soleur-host-bootstrap-observability: $pass passed, $fail failed ==="
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

Fourth iteration of the #6090 fresh-boot work — and the first that acts on a **localized** cause. The earliest-beacon PR (#6119) paid off: recreate `28819237402` (on the beacon commit) emitted, from web-2's fresh host (`host_id=148545005`), **exactly one** boot event — `stage=bootcmd_start` — and **no `runcmd_start`**. That brackets the death precisely:

- **web-2 CAN reach Sentry** (egress works — the "no egress" theory is dead), and
- **the boot dies in cloud-init's opaque `packages:`/config phase** — between `bootcmd` (network stage) and `runcmd` (final stage). `package_update: true` + `packages: [curl, fail2ban, jq, nftables]` is that phase's heavy op, and cloud-init never reaches `runcmd`, so the webhook never installs and `:9000` never binds (every prior `ok_peer_fanout_degraded` timeout).

This PR **moves the package install out of the config phase into an instrumented early-`runcmd` apt block** so the next recreate NAMES the exact failing apt command — and, because it adds `timeout`s + retries, may fix a transient hang outright.

It is still a probe-and-harden, not a guaranteed boot fix. But the failure is no longer opaque.

Prod unaffected: web-2 is weight-0/non-serving; web-1 carries `ignore_changes=[user_data]` and is untouched (healthy v0.199.5 throughout).

Ref #6090

## User-Brand Impact

- **Brand-survival threshold:** none
- threshold: none, reason: web-2 is a weight-0 non-serving standby whose fresh boot is already broken; this change only relocates its package install into an instrumented, fail-closed runcmd block and cannot make a non-serving host more broken. It never touches web-1's running host (`ignore_changes=[user_data]`), changes no serving behavior, and every emit remains fail-open. Required because the diff touches the sensitive `apps/web-platform/infra/` path.

## Changelog

### Move package install into instrumented runcmd (name the config-phase hang)

- `cloud-init.yml`: remove `package_update: true` + the cloud-config `packages:` block; install `curl fail2ban jq nftables` in an early-`runcmd` apt block under the pre-existing top-armed `trap on_err EXIT`, with `STAGE=apt_update` / `STAGE=apt_install`, `timeout 240`/`timeout 300`, and a 3× retry loop. A **hang** now becomes a **named Sentry fatal** (`stage=apt_update`/`apt_install`) that fails fast (240/300s) instead of the ~640s poll timeout; a transient may survive the retry. `curl` is base-image-provided (the bootcmd beacon firing already proved it), so the earlier runcmd `_emit`/breadcrumb don't depend on this install. The stale package-audit block (which parsed the now-removed `packages:`) is replaced by this fail-closed install.
- `soleur-host-bootstrap-observability.test.sh`: **AC17** — apt runs with named stages, the cloud-config `packages:` block is gone, and both apt commands are `timeout`-wrapped.

## Verification

- observability guard **51/51** (incl. AC17); siblings green (`server-tf-set-e` 16/16, `cron-egress-enforce-probe` 38/38, `cloud-init-inngest-bootstrap`, `cloud-init-ghcr-seed-login` 6/6, `cloud-init-plugin-seed`).
- `cloud-init-user-data-size.test.ts` **23/23** (render shrank — packages: + audit removed).
- cloud-init schema **Valid** (rendered, `packages` key absent); YAML parses.
- The repaired auto-read (#6119) is confirmed working in the prior recreate's own step 15: it printed `stage=bootcmd_start`.

## What the next recreate will tell us (tracked in #6090)

`Ref #6090` — probe/harden, not a guaranteed fix. After merge (no image rebuild — baked host scripts untouched), one operator-gated `web-2-recreate`:
- **`:9000` binds** → the retry/timeout fixed a transient apt hang → close #6090.
- **`stage=apt_update` fatal** → `apt-get update` is the culprit (mirror/DNS/network) → fix there.
- **`stage=apt_install` fatal** → a specific package won't install → fix there.
- **`runcmd_start` but still no apt stage** → died in a *remaining* config-stage module (unlikely — the rest is trivial) → next narrowing.

## Test plan

- [x] `bash apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh` → 51/51
- [x] infra siblings + size guard green; cloud-init schema Valid (no `packages` key); YAML parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
