### PR TITLE
fix(infra): monitor app.soleur.ai for uptime; retire the #5933 per-host probe

### DIFF
--- a/.github/workflows/apply-web-platform-infra.yml
+++ b/.github/workflows/apply-web-platform-infra.yml
@@ -358,6 +358,7 @@ jobs:
               -target=doppler_secret.ghcr_minter_doppler_token \
               -target=betteruptime_monitor.soleur_apex \
               -target=betteruptime_policy.uptime \
+              -target=betteruptime_monitor.app \
               -target=cloudflare_record.web_host \
               -target=betteruptime_monitor.web_host \
               -target=random_id.inngest_signing_key_prd \

--- a/apps/web-platform/infra/dns.tf
+++ b/apps/web-platform/infra/dns.tf
@@ -19,40 +19,12 @@ resource "cloudflare_record" "app" {
   ttl     = 1 # Auto when proxied
 }
 
-# Per-host CF-PROXIED probe hostname (web-<n>.soleur.ai → that host's origin IP),
-# the reach-target for the per-host uptime absence detector (betteruptime_monitor.web_host,
-# uptime-alerts.tf). #5933 Item 1. Proxied so the probe traverses CF edge → origin,
-# preserving the CF-IP-only origin firewall (firewall.tf:54-76) — a raw-origin-IP probe
-# would be firewall-dropped; an unproxied record would expose the origin.
-#
-# SINGLE-LABEL hostname is load-bearing: Cloudflare Universal SSL (free) covers only
-# `soleur.ai` and the ONE-label wildcard `*.soleur.ai`. A wildcard matches exactly one
-# subdomain label, so a two-level `web-<n>.app.soleur.ai` has NO edge certificate and
-# every proxied HTTPS probe fails the edge TLS handshake (SSL alert 40) before reaching
-# the origin — which is why Better Stack auto-paused the monitor. `web-<n>.soleur.ai` is one
-# label, covered by `*.soleur.ai`, so the handshake completes. Do NOT push this back to a
-# two-level name without a paid Advanced Certificate Manager / Total TLS cert.
-#
-# NOTE: the cloudflare provider treats `name` as ForceNew — changing it destroys and
-# recreates the record (NOT an in-place update), so a rename of this probe hostname trips
-# the apply-web-platform-infra destroy-guard and needs `[ack-destroy]` in the merge commit.
-# The replacement is safe: this is the monitoring PROBE record, not the app ingress
-# (`cloudflare_record.app`), and no user traffic flows through it.
-#
-# for_each gates on `if v.monitored` (NOT all of var.web_hosts): web-2's server is excluded
-# from the auto-apply -target set until the #5274 cutover, so an ungated for_each would drag
-# hcloud_server.web["web-2"] into a routine -target apply. web-2's record+monitor both land
-# when the cutover flips monitored=true. See variables.tf web_hosts comment.
-resource "cloudflare_record" "web_host" {
-  for_each = { for k, v in var.web_hosts : k => v if v.monitored }
-
-  zone_id = var.cf_zone_id
-  name    = each.key
-  content = hcloud_server.web[each.key].ipv4_address
-  type    = "A"
-  proxied = true
-  ttl     = 1 # Auto when proxied
-}
+# NOTE (#5933 retired): the per-host CF-proxied probe hostname (web-<n>.soleur.ai) and its
+# betteruptime_monitor.web_host were removed — uptime is now monitored at the LB-fronted
+# app.soleur.ai surface (betteruptime_monitor.app, uptime-alerts.tf). An external per-host
+# HTTP probe would require each host's origin to serve its own web-<n>.soleur.ai Host/SNI,
+# which it does not (the probe returned CF 521); per-host liveness is covered by CF LB origin
+# health checks + the resource-monitor.sh emails to ops@ instead.
 
 # Deploy webhook endpoint routed through Cloudflare Tunnel (see #749).
 # Protected by CF Access service token + HMAC signature validation.

--- a/apps/web-platform/infra/uptime-alerts.tf
+++ b/apps/web-platform/infra/uptime-alerts.tf
@@ -76,28 +76,30 @@ resource "betteruptime_monitor" "soleur_apex" {
   paused     = false
 }
 
-# Per-host origin absence detector (#5933 Item 1). Mirrors soleur_apex but targets
-# each host's CF-proxied probe hostname (web-<n>.soleur.ai/health, dns.tf) directly,
-# so a dead/never-booted host returns non-200 (CF 522) and pages — the apex/round-robin
-# monitors stay green because healthy hosts answer them, giving zero per-host attribution.
-# Single-label hostname is load-bearing (Cloudflare Universal SSL `*.soleur.ai` covers one
-# subdomain label only; a two-level probe name fails the edge TLS handshake — see dns.tf).
+# App dashboard uptime monitor (app.soleur.ai) — the LB-fronted surface users actually hit.
+# REPLACES the #5933 per-host absence detector (betteruptime_monitor.web_host): with the
+# multi-host cluster fronted by Cloudflare, an external per-host HTTP probe requires each
+# host's origin to serve its own web-<n>.soleur.ai Host/SNI — it does not (the probe returned
+# CF 521 because the origin only answers the app.soleur.ai Host, both records sharing one
+# origin IP). Per-host "is this specific host dead" is better covered by Cloudflare LB origin
+# health checks + the per-host resource-monitor.sh/container-restart-monitor.sh emails to
+# ops@ — not an external HTTP monitor that would need per-host origin vhosts/certs. So we
+# monitor app.soleur.ai directly; a dead host is drained by the LB and the remaining pool
+# keeps this green, which is the correct user-facing signal.
 #
-# for_each gates on `if v.monitored` (SAME filter as cloudflare_record.web_host): web-1 now;
-# web-2 activates when the #5274 cutover flips monitored=true (pointing a monitor at a
-# not-yet-created hostname would page immediately on 522/NXDOMAIN).
-resource "betteruptime_monitor" "web_host" {
-  for_each = { for k, v in var.web_hosts : k => v if v.monitored }
-
+# follow_redirects = true: app.soleur.ai/ 307s to /login for an unauthenticated probe, so
+# the monitor succeeds only if the full chain / -> 307 -> /login -> 200 returns 200 (proves
+# the app is actually serving, not just that the CF edge answered).
+resource "betteruptime_monitor" "app" {
   monitor_type       = "status"
-  url                = "https://${each.key}.soleur.ai/health"
-  pronounceable_name = "soleur uptime ${each.key}" # unique per host (hard provider constraint)
+  url                = "https://app.soleur.ai/"
+  pronounceable_name = "soleur app dashboard"
 
   check_frequency     = 180
   request_timeout     = 10
   confirmation_period = 60
   recovery_period     = 60
-  # No follow_redirects: /health serves 200 directly (no apex→www 301 to chase).
+  follow_redirects    = true
 
   email = true
   call  = false

--- a/apps/web-platform/infra/variables.tf
+++ b/apps/web-platform/infra/variables.tf
@@ -68,22 +68,16 @@ variable "cf_api_token" {
 # GDPR residency (CLO T-1, GA-blocking).
 variable "web_hosts" {
   description = "Web-host cluster (multi-host /workspaces, ADR-068 Phase 3). web-1 = pre-existing host; keys immutable post-migration; EU-location-pinned (CLO T-1)."
-  # `monitored` gates BOTH the per-host uptime monitor AND its CF-proxied probe
-  # record (dns.tf / uptime-alerts.tf, #5933 Item 1). It doubles as an EXISTENCE
-  # flag: web-2's backing hcloud_server.web["web-2"] is excluded from the auto-apply
-  # -target set (managed by the #5274 operator cutover), so a probe record/monitor
-  # for web-2 must NOT materialise until that cutover flips this to true — else the
-  # record's `content = hcloud_server.web["web-2"].ipv4_address` transitively drags
-  # the excluded server into a routine -target apply and provisions it out-of-window.
+  # (The former `monitored` per-host flag was removed with the #5933 per-host uptime
+  # probe/monitor — uptime is now monitored at app.soleur.ai, see uptime-alerts.tf.)
   type = map(object({
     location    = string
     private_ip  = string
     server_type = optional(string, "cx33")
-    monitored   = optional(bool, true)
   }))
   default = {
     "web-1" = { location = "hel1", private_ip = "10.0.1.10" }
-    "web-2" = { location = "hel1", private_ip = "10.0.1.11", monitored = false }
+    "web-2" = { location = "hel1", private_ip = "10.0.1.11" }
   }
   validation {
     condition     = alltrue([for h in values(var.web_hosts) : contains(["nbg1", "fsn1", "hel1"], h.location)])

--- a/knowledge-base/project/learnings/2026-07-06-cloudflare-universal-ssl-wildcard-depth-breaks-two-level-proxied-probe.md
+++ b/knowledge-base/project/learnings/2026-07-06-cloudflare-universal-ssl-wildcard-depth-breaks-two-level-proxied-probe.md
@@ -60,6 +60,25 @@ destroy, and an infra PR that renames one must ship `[ack-destroy]` in its PR bo
 re-enables the monitor in the same run. The record stays `proxied = true`, preserving the
 CF-IP-only origin firewall.
 
+## Resolution superseded — the per-host probe was the wrong tool
+
+Fixing the cert depth (single-label rename) got the TLS handshake to succeed, but the probe
+then returned **CF 521**: `web-1.soleur.ai` and `app.soleur.ai` share one origin IP, and the
+origin's web server accepts the `app.soleur.ai` Host but **closes the connection for the
+`web-1.soleur.ai` Host/SNI**. So the per-host probe was *doubly* broken — the cert bug masked an
+origin-vhost gap. Making the per-host probe green would require every host's origin to serve its
+own `web-<n>.soleur.ai` vhost/cert.
+
+The operator's call (correct): **retire the per-host external HTTP probe entirely and monitor
+`app.soleur.ai` instead.** For an LB-fronted multi-host cluster, "is a specific host dead" is the
+job of the load balancer's origin health checks + host-level metric emails (`resource-monitor.sh`
+→ ops@), NOT an external per-host HTTP monitor that has to be told every host's hostname and
+needs per-host origin vhosts. Removed `betteruptime_monitor.web_host` + `cloudflare_record.web_host`
++ the dead `monitored` flag; added `betteruptime_monitor.app` probing `https://app.soleur.ai/`
+(307→/login→200, `follow_redirects = true`). **Broader lesson: before fixing a monitor's probe
+URL, ask whether the monitor's *target layer* is right at all — an external HTTP probe of a
+specific backend host is usually the wrong altitude when a load balancer fronts the pool.**
+
 ## Key Insight
 
 **A paused/red uptime monitor is not proof the target is down — verify the probe URL is


### PR DESCRIPTION
## Summary

Retire the #5933 per-host Better Stack uptime probe and monitor **`app.soleur.ai`** — the load-balancer-fronted surface users actually hit — instead.

Context: after PRs #6128/#6130 fixed the probe's TLS cert-depth so the handshake succeeded, the per-host probe surfaced a **CF 521**: `web-1.soleur.ai` and `app.soleur.ai` share one origin IP (`135.181.45.178`), but the origin's web server accepts the `app.soleur.ai` Host and closes the connection for the `web-1.soleur.ai` Host/SNI. Making the per-host probe reach a serving origin would require every host to serve its own `web-<n>.soleur.ai` vhost/cert — the wrong burden for an LB-fronted multi-host cluster. Per-host "is this specific host alive" is the job of Cloudflare LB origin health checks + the per-host `resource-monitor.sh`/`container-restart-monitor.sh` emails to `ops@`, not an external per-host HTTP monitor.

Changes:
- `uptime-alerts.tf`: remove `betteruptime_monitor.web_host` (per-host); add `betteruptime_monitor.app` probing `https://app.soleur.ai/` with `follow_redirects = true` (`/` → 307 → `/login` → 200, so it succeeds only if the app is actually serving).
- `dns.tf`: remove `cloudflare_record.web_host` (the per-host probe hostname `web-1.soleur.ai`).
- `variables.tf`: drop the now-dead `web_hosts.monitored` flag (its only two consumers are removed).
- `learning`: record that the monitor's *target layer* — not the probe URL — was the real issue.

`terraform validate` passes; `curl -L https://app.soleur.ai/` → 200 verified live.

Removing `cloudflare_record.web_host` is **1 Cloudflare resource delete**, so the apply destroy-guard requires acknowledgement:

[ack-destroy]

## User-Brand Impact

**If this lands incorrectly, the user experiences:** uptime coverage of the dashboard could regress — but this ADDS an `app.soleur.ai` monitor (the surface users hit) while removing a per-host probe that could never go green. The apex + Sentry monitors remain. Worst case is a mis-scoped monitor, not a user-facing regression.

**If this leaks, the user's data is exposed via:** N/A — removes a DNS probe record + a monitor and adds a monitor of a public URL. No user data, secrets, auth, or PII are touched.

- **Brand-survival threshold:** none
- `threshold: none, reason: retires an unreachable per-host monitoring probe and points uptime at the public app.soleur.ai URL; the diff touches apps/web-platform/infra/ (sensitive-path regex) but changes only DNS/monitor resource definitions and a variable flag — no user data, auth, schema, API, or secret surface.`

## Deploy path

Merging fires `apply-web-platform-infra.yml`; with `[ack-destroy]` in the squash commit the destroy-guard passes, and the `-target` apply removes the per-host record + monitor and creates the `app.soleur.ai` monitor in one run. No SSH, no operator step, no reboot.

## Changelog

- fix(infra): monitor `app.soleur.ai` (LB-fronted) for uptime and retire the unreachable #5933 per-host probe; the per-host "is a host dead" signal is covered by Cloudflare LB health checks + host-metric emails to ops@.

## Test plan

- [x] `terraform validate` → Success
- [x] `terraform fmt -check` clean
- [x] `curl -L https://app.soleur.ai/` → 200 (307 → /login → 200); `follow_redirects = true` set to match
- [x] No dangling refs to `web_host`/`.monitored`; both web-hosts test files (eu-pin, fanout-parity) read `location`/`private_ip` only and are unaffected
- [ ] (post-merge, automatic) apply removes per-host record+monitor, creates `betteruptime_monitor.app`, no web-2 create
- [ ] (post-merge, automatic) "soleur app dashboard" monitor reports up against app.soleur.ai

Generated with [Claude Code](https://claude.com/claude-code)


## CI note (apply -target list)

`apply-web-platform-infra.yml` updated: `-target=betteruptime_monitor.app` added (new resource — required by `terraform-target-parity` #5566). The `-target=cloudflare_record.web_host` / `-target=betteruptime_monitor.web_host` lines are **kept as destroy-targets** — a `-target` apply won't destroy a removed-from-config resource unless it stays targeted, and the per-host monitor must be destroyed so it stops probing web-1.soleur.ai → 521. They become no-ops after this applies (the parity test's reverse direction is out of scope) and can be pruned in a later cleanup.
