### PR TITLE
fix(workstream): load ALL open issues (split read) so the board stops under-counting

### DIFF
--- a/apps/web-platform/server/github-read-tools.ts
+++ b/apps/web-platform/server/github-read-tools.ts
@@ -302,23 +302,73 @@ export async function listPullRequestComments(
 // ---------------------------------------------------------------------------
 
 // GitHub `GET /repos/{owner}/{repo}/issues` returns max 100 items/page (default
-// 30). We page until a short page, capped at MAX_ISSUE_PAGES so a huge repo can
-// never spin unbounded — 5 × 100 = 500 issues covers the board comfortably.
-// SOLEUR-DEBT: if a repo legitimately exceeds the cap we silently drop the tail;
-// switch to a "show open only" or windowed read when a >500-issue repo connects.
+// 30) and — critically — includes PULL REQUESTS alongside issues. A single
+// `state=all` newest-first scan therefore spends its page budget on PRs and
+// recently-closed noise, silently dropping still-OPEN issues older than the
+// window so the board's active columns under-count. (Measured on jikig-ai/soleur
+// 2026-07-07: 238 of the newest 500 raw items were PRs, so open issues older
+// than the newest ~500 items — 4 of 5 "In progress" cards — never loaded.)
+//
+// So we split the read the way the board is shaped: OPEN issues populate every
+// active column (Backlog/Ready/In progress/In review/Blocked/Pending) and must
+// load in FULL (bounded only by a large safety cap); CLOSED issues only feed the
+// Done column, where the recently-closed are what matter, so they're windowed.
 const BOARD_PER_PAGE = 100;
-const MAX_ISSUE_PAGES = 5;
+const MAX_OPEN_PAGES = 20; // ALL open issues (2000 headroom) — active columns must be complete
+const MAX_CLOSED_PAGES = 3; // Done column: most-recently-updated ~300 closed (old closures aren't actionable)
+
+function toBoardInput(item: GhIssueResponse): BoardIssueInput {
+  return {
+    number: item.number,
+    title: item.title,
+    body: item.body ?? null,
+    assignees: item.assignees.map((a) => a.login),
+    labels: item.labels.map(normalizeLabel),
+    state: item.state === "closed" ? "closed" : "open",
+    state_reason: item.state_reason ?? null,
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+  };
+}
+
+/**
+ * Page one issue `state` (query string) into `out`, skipping PRs. Returns true
+ * iff the page cap was reached with a still-FULL final page — i.e. a tail was
+ * likely dropped (a short page means we exhausted the list cleanly).
+ */
+async function pageIssuesInto(
+  out: BoardIssueInput[],
+  installationId: number,
+  owner: string,
+  repo: string,
+  query: string,
+  maxPages: number,
+): Promise<boolean> {
+  for (let page = 1; page <= maxPages; page++) {
+    const raw = await githubApiGet<GhIssueResponse[]>(
+      installationId,
+      `/repos/${owner}/${repo}/issues?${query}&per_page=${BOARD_PER_PAGE}&page=${page}`,
+    );
+    for (const item of raw) {
+      if (item.pull_request) continue; // skip PRs — board shows issues only
+      out.push(toBoardInput(item));
+    }
+    if (raw.length < BOARD_PER_PAGE) return false; // short page → exhausted, no tail
+    if (page === maxPages) return true; // full final page → tail likely dropped
+  }
+  return false;
+}
 
 /**
  * List a repo's issues for the Workstream board, narrowed to `BoardIssueInput`
  * (the shape the pure `githubIssueToWorkstreamIssue` mapper consumes).
  *
- * Contract (verified live against GitHub REST docs 2026-06-26):
- *   - `?state=all` (default is `open`) so closed → Done/Cancelled render.
- *   - `?per_page=100` (default 30) + pagination — silent truncation is a
- *     data-honesty bug; we cap explicitly (MAX_ISSUE_PAGES) and document it.
- *   - The endpoint ALSO returns pull requests — skip any item with a
- *     `pull_request` key (PRs are not board issues).
+ * Split read (see the note above BOARD_PER_PAGE):
+ *   - ALL open issues — `?state=open`, paged to completion (MAX_OPEN_PAGES is a
+ *     safety bound; hitting it is a real truncation of active work → Sentry).
+ *   - Recently-closed — `?state=closed&sort=updated&direction=desc`, windowed to
+ *     MAX_CLOSED_PAGES for the Done column (bounded BY DESIGN, not a data bug).
+ *   - The endpoint also returns PRs — items with a `pull_request` key are skipped.
  *
  * Errors PROPAGATE (githubApiGet throws on !ok) — the caller's empty-vs-throw
  * split must let a GitHub failure surface (route → 502 / tool → isError), never
@@ -330,51 +380,43 @@ export async function listRepoIssues(
   repo: string,
 ): Promise<BoardIssueInput[]> {
   const out: BoardIssueInput[] = [];
-  for (let page = 1; page <= MAX_ISSUE_PAGES; page++) {
-    const raw = await githubApiGet<GhIssueResponse[]>(
-      installationId,
-      `/repos/${owner}/${repo}/issues?state=all&per_page=${BOARD_PER_PAGE}&page=${page}`,
+
+  // Active columns: every OPEN issue must load, or the board under-counts.
+  const openTruncated = await pageIssuesInto(
+    out,
+    installationId,
+    owner,
+    repo,
+    "state=open",
+    MAX_OPEN_PAGES,
+  );
+  if (openTruncated) {
+    log.warn(
+      { owner, repo, loaded: out.length, cap: MAX_OPEN_PAGES * BOARD_PER_PAGE },
+      "Workstream OPEN-issue read hit the page cap — active columns may under-count (SOLEUR-DEBT)",
     );
-    for (const item of raw) {
-      if (item.pull_request) continue; // skip PRs — board shows issues only
-      out.push({
-        number: item.number,
-        title: item.title,
-        body: item.body ?? null,
-        assignees: item.assignees.map((a) => a.login),
-        labels: item.labels.map(normalizeLabel),
-        state: item.state === "closed" ? "closed" : "open",
-        state_reason: item.state_reason ?? null,
-        created_at: item.created_at,
-        updated_at: item.updated_at,
-      });
-    }
-    if (raw.length < BOARD_PER_PAGE) break; // short page → last page, no tail
-    if (page === MAX_ISSUE_PAGES) {
-      // We reached the page cap AND the final allowed page came back FULL
-      // (raw.length === BOARD_PER_PAGE — a short page would have broken above),
-      // so a tail beyond the cap is LIKELY and we may have dropped issues. (An
-      // exactly-full repo is indistinguishable from a real tail without a +1
-      // fetch, so we err toward signalling.) SOLEUR-DEBT: if a repo legitimately
-      // exceeds the cap we silently drop the tail; switch to a "show open only"
-      // or windowed read when a >500-issue repo connects.
-      log.warn(
-        { owner, repo, loaded: out.length, cap: MAX_ISSUE_PAGES * BOARD_PER_PAGE },
-        "Workstream issue read hit the page cap — tail issues may not be loaded (SOLEUR-DEBT)",
-      );
-      // Mirror to Sentry for parity with the no-installation reportSilentFallback
-      // path (get-workstream-issues.ts) so on-call sees the truncated read
-      // without SSH (cq-silent-fallback-must-mirror-to-sentry).
-      reportSilentFallback(
-        new Error("workstream issue read hit the page cap"),
-        {
-          feature: "github-read-tools",
-          op: "list-repo-issues-cap",
-          extra: { owner, repo, loaded: out.length },
-        },
-      );
-    }
+    // Mirror to Sentry (cq-silent-fallback-must-mirror-to-sentry) so an on-call
+    // sees a truncated active board without SSH.
+    reportSilentFallback(
+      new Error("workstream open-issue read hit the page cap"),
+      {
+        feature: "github-read-tools",
+        op: "list-repo-issues-open-cap",
+        extra: { owner, repo, loaded: out.length },
+      },
+    );
   }
+
+  // Done column only needs the recently-closed — windowed on purpose (no warn).
+  await pageIssuesInto(
+    out,
+    installationId,
+    owner,
+    repo,
+    "state=closed&sort=updated&direction=desc",
+    MAX_CLOSED_PAGES,
+  );
+
   return out;
 }
 

--- a/apps/web-platform/test/server/github-read-tools.workstream.test.ts
+++ b/apps/web-platform/test/server/github-read-tools.workstream.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // `listRepoIssues` is exercised against a mocked `githubApiGet` — there are NO
-// live network calls. We assert the PR-filter, the request shape (state=all +
-// per_page=100), pagination (full page → next fetch; short page → stop), and
-// the `name:null` label coercion via normalizeLabel.
+// live network calls. We assert the PR-filter, the SPLIT request shape (all open
+// issues via state=open, then a windowed state=closed for the Done column),
+// pagination (full page → next fetch; short page → stop), the open-cap Sentry
+// mirror, the closed-window bound, and `name:null` label coercion.
 
 const githubApiGet = vi.fn();
 const reportSilentFallback = vi.fn();
@@ -45,8 +46,18 @@ function rawIssue(over: Partial<RawIssue> = {}): RawIssue {
   };
 }
 
+const path = (i: number) => githubApiGet.mock.calls[i][1] as string;
+const paths = () => githubApiGet.mock.calls.map((c) => c[1] as string);
+const callsMatching = (needle: string) =>
+  githubApiGet.mock.calls.filter((c) => (c[1] as string).includes(needle));
+const fullPage = () => Array.from({ length: 100 }, (_, i) => rawIssue({ number: i + 1 }));
+// The real `page` param — matched with a leading `&` so it can't collide with
+// the `page=1` substring inside `per_page=100`.
+const pageOf = (p: string) => Number(/&page=(\d+)/.exec(p)?.[1] ?? 0);
+
 beforeEach(() => {
   githubApiGet.mockReset();
+  githubApiGet.mockResolvedValue([]); // default: every state/page empty
   reportSilentFallback.mockReset();
 });
 afterEach(() => {
@@ -55,10 +66,16 @@ afterEach(() => {
 
 describe("listRepoIssues", () => {
   it("filters out items carrying a pull_request key, keeps plain issues", async () => {
-    githubApiGet.mockResolvedValueOnce([
-      rawIssue({ number: 10, title: "A real issue" }),
-      rawIssue({ number: 11, title: "A PR masquerading", pull_request: { url: "x" } }),
-    ]);
+    githubApiGet.mockImplementation((_i: unknown, p: string) =>
+      Promise.resolve(
+        p.includes("state=open")
+          ? [
+              rawIssue({ number: 10, title: "A real issue" }),
+              rawIssue({ number: 11, title: "A PR", pull_request: { url: "x" } }),
+            ]
+          : [],
+      ),
+    );
 
     const out = await listRepoIssues(123, "acme", "widgets");
 
@@ -67,39 +84,79 @@ describe("listRepoIssues", () => {
     expect(out[0].title).toBe("A real issue");
   });
 
-  it("requests state=all and per_page=100", async () => {
-    githubApiGet.mockResolvedValueOnce([]);
-
+  it("reads ALL open issues, then a windowed recently-updated closed set", async () => {
     await listRepoIssues(123, "acme", "widgets");
 
-    expect(githubApiGet).toHaveBeenCalledTimes(1);
-    const path = githubApiGet.mock.calls[0][1] as string;
-    expect(path).toContain("/repos/acme/widgets/issues");
-    expect(path).toContain("state=all");
-    expect(path).toContain("per_page=100");
+    // Empty repo: open page 1 (short) + closed page 1 (short) = 2 calls.
+    expect(githubApiGet).toHaveBeenCalledTimes(2);
+    expect(path(0)).toContain("/repos/acme/widgets/issues");
+    expect(path(0)).toContain("state=open");
+    expect(path(1)).toContain("state=closed");
+    // Done column shows the most-recently-updated closures first.
+    expect(path(1)).toContain("sort=updated");
+    expect(path(1)).toContain("direction=desc");
+    // Both use the max page size.
+    expect(paths().every((p) => p.includes("per_page=100"))).toBe(true);
   });
 
-  it("pages: a full first page triggers a second fetch; a short page stops", async () => {
-    const fullPage = Array.from({ length: 100 }, (_, i) =>
-      rawIssue({ number: i + 1 }),
-    );
-    const shortPage = [rawIssue({ number: 101 })];
-    githubApiGet
-      .mockResolvedValueOnce(fullPage)
-      .mockResolvedValueOnce(shortPage);
+  it("pages open issues: a full first page triggers a second fetch; a short page stops", async () => {
+    const short = [rawIssue({ number: 101 })];
+    githubApiGet.mockImplementation((_i: unknown, p: string) => {
+      if (p.includes("state=open")) {
+        if (pageOf(p) === 1) return Promise.resolve(fullPage());
+        if (pageOf(p) === 2) return Promise.resolve(short);
+      }
+      return Promise.resolve([]);
+    });
 
     const out = await listRepoIssues(123, "acme", "widgets");
 
-    expect(githubApiGet).toHaveBeenCalledTimes(2);
-    expect((githubApiGet.mock.calls[0][1] as string)).toContain("page=1");
-    expect((githubApiGet.mock.calls[1][1] as string)).toContain("page=2");
-    expect(out).toHaveLength(101);
+    const openCalls = callsMatching("state=open");
+    expect(openCalls).toHaveLength(2);
+    expect(openCalls[0][1] as string).toContain("page=1");
+    expect(openCalls[1][1] as string).toContain("page=2");
+    expect(out.filter((i) => i.state === "open")).toHaveLength(101);
   });
 
-  it("coerces a label object with name:null to \"\" via normalizeLabel", async () => {
-    githubApiGet.mockResolvedValueOnce([
-      rawIssue({ number: 5, labels: [{ name: null }, { name: "blocked" }, "raw-string"] }),
-    ]);
+  it("mirrors a Sentry fallback when the OPEN read hits its page cap (active columns truncated)", async () => {
+    // Every open page comes back full → the 20-page open cap is hit.
+    githubApiGet.mockImplementation((_i: unknown, p: string) =>
+      Promise.resolve(p.includes("state=open") ? fullPage() : []),
+    );
+
+    await listRepoIssues(123, "acme", "widgets");
+
+    expect(callsMatching("state=open")).toHaveLength(20); // MAX_OPEN_PAGES
+    expect(reportSilentFallback).toHaveBeenCalledTimes(1);
+    const ctx = reportSilentFallback.mock.calls[0][1] as { op: string };
+    expect(ctx.op).toBe("list-repo-issues-open-cap");
+  });
+
+  it("windows the CLOSED read to a bounded page count WITHOUT a truncation warning", async () => {
+    // Every closed page comes back full → the closed window stops at its cap,
+    // but that is intentional (old closures aren't actionable) → no Sentry.
+    githubApiGet.mockImplementation((_i: unknown, p: string) =>
+      Promise.resolve(
+        p.includes("state=closed")
+          ? Array.from({ length: 100 }, (_, i) => rawIssue({ number: i + 1, state: "closed" }))
+          : [],
+      ),
+    );
+
+    await listRepoIssues(123, "acme", "widgets");
+
+    expect(callsMatching("state=closed")).toHaveLength(3); // MAX_CLOSED_PAGES
+    expect(reportSilentFallback).not.toHaveBeenCalled();
+  });
+
+  it('coerces a label object with name:null to "" via normalizeLabel', async () => {
+    githubApiGet.mockImplementation((_i: unknown, p: string) =>
+      Promise.resolve(
+        p.includes("state=open")
+          ? [rawIssue({ number: 5, labels: [{ name: null }, { name: "blocked" }, "raw-string"] })]
+          : [],
+      ),
+    );
 
     const out = await listRepoIssues(123, "acme", "widgets");
 


### PR DESCRIPTION
## Problem

The Workstream tab was **missing most issues** — e.g. the board showed 5 *In progress* cards (#3380, #4206, #5292, #5654, #5689) but the tab showed only **#5689**, and Backlog showed 126 vs the board's 551.

**Root cause (measured live against `jikig-ai/soleur` on 2026-07-07):** `listRepoIssues` paged `GET /issues?state=all` newest-first, capped at 500 raw items (`MAX_ISSUE_PAGES=5 × 100`). The REST issues endpoint returns **PRs alongside issues**, and on a PR-heavy repo **238 of the newest 500 raw items were PRs** — so the effective issue window only reached back to **#5662**. Every still-open issue older than that silently dropped. This is exactly the `SOLEUR-DEBT` the old code comment flagged, and it fired the 11-day-old `list-repo-issues-cap` Sentry warning.

## Fix

Split the read the way the board is shaped:

- **ALL open issues** — `state=open`, paged to completion (`MAX_OPEN_PAGES=20` is a safety bound; hitting it is a *real* truncation of active work → mirrored to Sentry as `list-repo-issues-open-cap`). Open issues populate every active column (Backlog/Ready/In progress/In review/Blocked/Pending), so they must be complete.
- **Recently-closed** — `state=closed&sort=updated&direction=desc`, windowed to `MAX_CLOSED_PAGES=3` for the Done column. Old closures aren't actionable, so this bound is **intentional** (no warning).

PRs are still skipped. Errors still propagate (route → 502), never masquerade as empty.

## Verification

- Reproduced the truncation with a minted App token: old path kept 262 issues, window `#6157..#5662`, dropping #3380/#4206/#5292/#5654. New split loads all open issues.
- `tsc --noEmit` clean; full web-platform vitest suite **11925 passed / 0 failed**.
- Tests updated: split request shape, open pagination, open-cap Sentry mirror, closed-window bound (no warn), PR filter, label coercion.

Context: surfaced while verifying the Kanban board ↔ Workstream sync post-deploy (ADR-097). The board-Status read itself works; this unblocks the tab from under-counting the issues it maps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)