### PR TITLE
fix(infra): bake GHCR read-creds for ci-deploy's app-pull login (cold-boot cosign verify)

### DIFF
--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -612,22 +612,42 @@ zot_gate_degraded_event() {
 # token is captured into a var and piped via --password-stdin — NEVER argv/logs, and
 # unset immediately after login so it never reaches a child process env.
 ghcr_prelude_and_login() {
-  command -v doppler >/dev/null 2>&1 || { logger -t "$LOG_TAG" "PRELUDE: doppler unavailable — skipping GHCR login + SENTRY prefetch"; return 0; }
-  [[ -n "${DOPPLER_TOKEN:-}" ]] || { logger -t "$LOG_TAG" "PRELUDE: DOPPLER_TOKEN unset — skipping GHCR login + SENTRY prefetch"; return 0; }
-  # Export only what downstream CHILDREN legitimately read from the env (SENTRY_* for
-  # the verify/pull telemetry curls; GHCR_READ_USER is a username, not a secret). The
-  # TOKEN is deliberately NOT exported — it reaches `docker login` via --password-stdin,
-  # so no child process ever gets it in its environment.
-  local k
-  for k in SENTRY_INGEST_DOMAIN SENTRY_PROJECT_ID SENTRY_PUBLIC_KEY GHCR_READ_USER; do
-    # `secrets get <NAME> --plain` returns the bare value on stdout (never argv).
-    printf -v "$k" '%s' "$(doppler secrets get "$k" --plain --project soleur --config prd 2>/dev/null || true)"
-    export "$k"
-  done
-  local ghcr_token
-  ghcr_token="$(doppler secrets get GHCR_READ_TOKEN --plain --project soleur --config prd 2>/dev/null || true)"
-  if [[ -n "${GHCR_READ_USER:-}" && -n "$ghcr_token" ]]; then
-    if printf '%s' "$ghcr_token" | docker login ghcr.io -u "$GHCR_READ_USER" --password-stdin >/dev/null 2>&1; then
+  # (#6090) Prefer BAKED GHCR read-creds (cloud-init writes /etc/default/soleur-ghcr-read,
+  # deploy:deploy 0600 — the app-pull analogue of the seed-pull bake) so the app pull +
+  # cosign verify authenticate on a cold host even when Doppler answers EMPTY at the boot
+  # instant (the exact #6090 failure class, one layer down: an empty fetch here skipped the
+  # login → anonymous private pull → cosign .sig fetch 401 → verify_failed → app never binds
+  # :9000 → peer fan-out degraded). Doppler stays the fallback, HARDENED (timeout 45 + 3-try
+  # retry) to match cloud-init's ghcr_login. GHCR_READ_USER is a username (safe to export);
+  # the TOKEN reaches `docker login` via --password-stdin only and is unset so no child env
+  # (docker/cosign subprocess) ever carries it.
+  local k n ghcr_user="" ghcr_token=""
+  if [[ -r /etc/default/soleur-ghcr-read ]]; then
+    # shellcheck disable=SC1091
+    . /etc/default/soleur-ghcr-read 2>/dev/null || true
+    ghcr_user="${GHCR_READ_USER:-}"; ghcr_token="${GHCR_READ_TOKEN:-}"
+    unset GHCR_READ_TOKEN   # keep the token out of THIS process env + its children
+  fi
+  if command -v doppler >/dev/null 2>&1 && [[ -n "${DOPPLER_TOKEN:-}" ]]; then
+    # SENTRY_* prefetch for the verify/pull telemetry curls (dark event if absent, as today).
+    for k in SENTRY_INGEST_DOMAIN SENTRY_PROJECT_ID SENTRY_PUBLIC_KEY; do
+      # `secrets get <NAME> --plain` returns the bare value on stdout (never argv).
+      printf -v "$k" '%s' "$(doppler secrets get "$k" --plain --project soleur --config prd 2>/dev/null || true)"
+      export "$k"
+    done
+    # Hardened Doppler fallback for any GHCR cred the bake did not supply.
+    if [[ -z "$ghcr_user" ]]; then
+      n=0; until ghcr_user="$(timeout 45 doppler secrets get GHCR_READ_USER --plain --project soleur --config prd 2>/dev/null)"; [[ -n "$ghcr_user" ]]; do n=$((n + 1)); [[ "$n" -ge 3 ]] && break; sleep 5; done
+    fi
+    if [[ -z "$ghcr_token" ]]; then
+      n=0; until ghcr_token="$(timeout 45 doppler secrets get GHCR_READ_TOKEN --plain --project soleur --config prd 2>/dev/null)"; [[ -n "$ghcr_token" ]]; do n=$((n + 1)); [[ "$n" -ge 3 ]] && break; sleep 5; done
+    fi
+  elif [[ -z "$ghcr_user" || -z "$ghcr_token" ]]; then
+    logger -t "$LOG_TAG" "PRELUDE: doppler/DOPPLER_TOKEN unavailable and baked GHCR creds incomplete — skipping GHCR login + SENTRY prefetch"
+  fi
+  export GHCR_READ_USER="$ghcr_user"   # username, not a secret (matches prior exported behavior)
+  if [[ -n "$ghcr_user" && -n "$ghcr_token" ]]; then
+    if printf '%s' "$ghcr_token" | docker login ghcr.io -u "$ghcr_user" --password-stdin >/dev/null 2>&1; then
       logger -t "$LOG_TAG" "PRELUDE: docker login ghcr.io ok (private-package pull authenticated)"
     else
       logger -t "$LOG_TAG" "PRELUDE: docker login ghcr.io FAILED — private pull may fail-closed"
@@ -636,7 +656,7 @@ ghcr_prelude_and_login() {
     logger -t "$LOG_TAG" "PRELUDE: GHCR_READ_{USER,TOKEN} not both present — skipping docker login (pre-provisioning?)"
   fi
   # The mounted $GHCR_DOCKER_CONFIG (inline auths entry) is what the cosign verifier
-  # reuses; the non-exported token local goes out of scope when the function returns.
+  # reuses; the token local goes out of scope when the function returns.
   ghcr_token=""
 }
 

--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -653,7 +653,7 @@ ghcr_prelude_and_login() {
       logger -t "$LOG_TAG" "PRELUDE: docker login ghcr.io FAILED — private pull may fail-closed"
     fi
   else
-    logger -t "$LOG_TAG" "PRELUDE: GHCR_READ_{USER,TOKEN} not both present — skipping docker login (pre-provisioning?)"
+    logger -t "$LOG_TAG" "PRELUDE: GHCR_READ_{USER,TOKEN} not both present (baked file absent + doppler empty/unavailable) — skipping docker login"
   fi
   # The mounted $GHCR_DOCKER_CONFIG (inline auths entry) is what the cosign verifier
   # reuses; the token local goes out of scope when the function returns.

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -390,6 +390,14 @@ runcmd:
   - printf 'DOPPLER_TOKEN=%s\nDOPPLER_CONFIG_DIR=/tmp/.doppler\nDOPPLER_ENABLE_VERSION_CHECK=false\n' '${doppler_token}' > /etc/default/webhook-deploy
   - chmod 600 /etc/default/webhook-deploy
   - chown deploy:deploy /etc/default/webhook-deploy
+  # (#6090) Bake the scoped GHCR read-creds so ci-deploy.sh's ghcr_prelude_and_login (the
+  # app-pull + cosign-verify login) authenticates on a cold host even when Doppler answers
+  # empty at the boot instant — the app-deploy analogue of the seed-pull bake above. Same
+  # protection as webhook-deploy (deploy:deploy 0600, which already holds the strictly
+  # stronger DOPPLER_TOKEN), so no new trust boundary. ci-deploy runs as the deploy user.
+  - printf 'GHCR_READ_USER=%s\nGHCR_READ_TOKEN=%s\n' '${ghcr_read_user}' '${ghcr_read_token}' > /etc/default/soleur-ghcr-read
+  - chmod 600 /etc/default/soleur-ghcr-read
+  - chown deploy:deploy /etc/default/soleur-ghcr-read
 
   # Install Docker via official APT repository with GPG key verification (#1615).
   # Replaces pipe-to-shell (curl | sh) with signed APT repo -- same pattern as cloudflared above.

--- a/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
+++ b/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
@@ -512,6 +512,13 @@ if grep -qE 'until ghcr_user="?\$\(timeout 45 doppler[^)]*GHCR_READ_USER' "$CD" 
 else
   no "AC20: ci-deploy ghcr_prelude_and_login must harden the doppler fallback (timeout 45 + until-retry) for both GHCR creds"
 fi
+# (5) token hygiene: baked file is deploy-owned + ci-deploy unsets the token from its env/children
+if grep -qE 'chown deploy:deploy /etc/default/soleur-ghcr-read' "$CI" \
+   && grep -qE 'unset GHCR_READ_TOKEN' "$CD"; then
+  ok "AC20: baked file is chown deploy:deploy + ci-deploy unsets GHCR_READ_TOKEN (token not in child env)"
+else
+  no "AC20: /etc/default/soleur-ghcr-read must be chown deploy:deploy AND ci-deploy must unset GHCR_READ_TOKEN after sourcing"
+fi
 
 echo "=== soleur-host-bootstrap-observability: $pass passed, $fail failed ==="
 [ "$fail" -eq 0 ]

--- a/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
+++ b/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
@@ -478,5 +478,40 @@ else
   no "AC19: server.tf web-host templatefile map must pass ghcr_read_user + ghcr_read_token (coupled to the cloud-init bake)"
 fi
 
+# ── AC20 (#6090): the app-pull GHCR login (ci-deploy ghcr_prelude_and_login) is baked too ──
+# The seed-pull fix (AC19) got the host to webhook_bound, but the recreate still RED'd at
+# ok_peer_fanout_degraded: ci-deploy's ghcr_prelude_and_login did a bare `doppler secrets get`
+# for the app pull + cosign verify, empty on the cold host → docker login skipped → anonymous
+# pull → cosign .sig 401 → verify_failed → app never binds :9000. Fix: cloud-init bakes
+# /etc/default/soleur-ghcr-read; ghcr_prelude_and_login prefers it, hardened doppler fallback.
+CD="$DIR/ci-deploy.sh"
+# (1) cloud-init bakes the deploy-readable GHCR cred file with the interpolated vars
+if grep -qF 'GHCR_READ_USER=%s\nGHCR_READ_TOKEN=%s' "$CI" \
+   && grep -qF '/etc/default/soleur-ghcr-read' "$CI" \
+   && grep -qE "'\\\$\{ghcr_read_user\}'[[:space:]]+'\\\$\{ghcr_read_token\}'" "$CI"; then
+  ok "AC20: cloud-init bakes /etc/default/soleur-ghcr-read from \${ghcr_read_user}/\${ghcr_read_token}"
+else
+  no "AC20: cloud-init must bake /etc/default/soleur-ghcr-read with the interpolated GHCR read-creds"
+fi
+# (2) the baked file is protected like webhook-deploy (deploy:deploy 0600)
+if grep -qE 'chmod 600 /etc/default/soleur-ghcr-read' "$CD" 2>/dev/null || grep -qE 'chmod 600 /etc/default/soleur-ghcr-read' "$CI"; then
+  ok "AC20: baked GHCR cred file is chmod 600 (deploy-only)"
+else
+  no "AC20: /etc/default/soleur-ghcr-read must be chmod 600"
+fi
+# (3) ci-deploy ghcr_prelude_and_login PREFERS the baked file before Doppler
+if grep -qF '/etc/default/soleur-ghcr-read' "$CD"; then
+  ok "AC20: ci-deploy ghcr_prelude_and_login sources the baked /etc/default/soleur-ghcr-read"
+else
+  no "AC20: ci-deploy ghcr_prelude_and_login must prefer the baked /etc/default/soleur-ghcr-read"
+fi
+# (4) the Doppler fallback in ci-deploy is HARDENED (timeout 45 + retry) for both GHCR creds
+if grep -qE 'until ghcr_user="?\$\(timeout 45 doppler[^)]*GHCR_READ_USER' "$CD" \
+   && grep -qE 'until ghcr_token="?\$\(timeout 45 doppler[^)]*GHCR_READ_TOKEN' "$CD"; then
+  ok "AC20: ci-deploy doppler fallback hardened — timeout 45 + until-retry for GHCR_READ_USER and GHCR_READ_TOKEN"
+else
+  no "AC20: ci-deploy ghcr_prelude_and_login must harden the doppler fallback (timeout 45 + until-retry) for both GHCR creds"
+fi
+
 echo "=== soleur-host-bootstrap-observability: $pass passed, $fail failed ==="
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

Follow-up to #6136 (the #6090 seed-pull fix). That fix got a fresh web-2 host to boot successfully to `webhook_bound`, but the operator-gated **web-2 recreate still RED'd** at `ok_peer_fanout_degraded` — the host boots, but the **app** deploy onto it fails.

Root cause, confirmed **off-host** via EU Sentry during the recreate:

```
fresh-boot GHCR docker login failed
image signature verify verify_failed (ghcr.io/…/soleur-web-platform@sha256:6ddc88bf… = the pinned app image)
```

`ci-deploy.sh:ghcr_prelude_and_login()` did a bare `doppler secrets get GHCR_READ_USER/TOKEN` for the app-image pull + cosign verify — **no baked fallback, no hardened retry** (unlike the cloud-init seed pull). On the cold host it empties → `docker login` skipped → anonymous private pull → cosign can't fetch the `.sig` → 401 → `verify_failed` → ci-deploy fail-closes on the unverified image → app never binds `:9000` → peer fan-out degrades. **The exact #6090 failure class, one layer down** (app pull vs seed pull).

The fix mirrors the seed-pull bake:
- cloud-init writes `/etc/default/soleur-ghcr-read` (`deploy:deploy 0600` — same protection as `/etc/default/webhook-deploy`, which already holds the strictly stronger `DOPPLER_TOKEN`).
- `ghcr_prelude_and_login` **prefers** the baked creds, falls back to a **hardened** Doppler fetch (`timeout 45` + 3-try retry), and **unsets** the token so no child (docker/cosign) env carries it.
- `server.tf` already plumbs `ghcr_read_user`/`ghcr_read_token` into cloud-init (from #6136) — **no server.tf change**.
- AC20 added to the observability suite.

Ref #6090

## User-Brand Impact

- **If this lands broken, the user experiences:** nothing directly — web-2 is a **weight-0, non-serving** warm-standby; the change is prefer-baked-else-hardened-Doppler, behaviorally identical when creds resolve (which they do on web-1, the sole serving host). `ci-deploy.sh` auto-applies to web-1 on merge, but the app-pull path is unchanged when Doppler answers (web-1 is warm, not cold-booting).
- **If this leaks, the user's data is exposed via:** no new vector — the baked file (`deploy:deploy 0600`) sits beside `/etc/default/webhook-deploy`, which already holds `DOPPLER_TOKEN` (reads all `prd` secrets); a scoped read-only `read:packages` PAT adds no new secret class, and the token is unset from child envs.
- **Brand-survival threshold:** none
- Scope-out: threshold: none, reason: web-2 is weight-0 non-serving; web-1's app-pull behavior is unchanged when Doppler answers (the fix only adds a cold-boot-empty fallback), so no user-facing serving surface changes.

## Changelog

### Web Platform (infra)
- Fix web-2 recreate `ok_peer_fanout_degraded`: bake GHCR read-creds so `ci-deploy.sh`'s app-image pull + cosign verify authenticate on a cold host (was failing when Doppler answered empty), with a hardened Doppler fallback.

## Test plan

- [x] `soleur-host-bootstrap-observability.test.sh` — 65/65 incl. 5 new AC20 assertions
- [x] `ci-deploy.test.sh` — 110/110 (no regression to ghcr_prelude_and_login)
- [x] cloud-init schema renders **Valid**
- [x] `cloud-init-user-data-size.test.ts` — 23/23 (baked file fits the budget)
- [x] `cloud-init-ghcr-seed-login`, `server-tf-set-e` — green
- [x] `shellcheck -S error ci-deploy.sh` — clean
- [x] 2 reviewers (silent-failure-hunter CLEAN, observability-coverage-reviewer COMPLETE); 2 findings fixed inline
- [ ] Post-merge (autonomous, operator-authorized): re-dispatch `web-2-recreate`, confirm `cloud_init_complete` + `:9000` bind via EU Sentry, then mark #6090 resolved on a green boot

Generated with [Claude Code](https://claude.com/claude-code)
