### PR TITLE
fix(infra): bake GHCR read-creds for the host-bootstrap login (inngest-pull cold-boot)

### DIFF
--- a/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
+++ b/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
@@ -520,5 +520,28 @@ else
   no "AC20: /etc/default/soleur-ghcr-read must be chown deploy:deploy AND ci-deploy must unset GHCR_READ_TOKEN after sourcing"
 fi
 
+# ── AC21 (#6090): soleur-host-bootstrap's ghcr_login is baked too (3rd/final GHCR site) ──
+# The seed pull (AC19) + app pull (AC20) bakes weren't enough: soleur-host-bootstrap.sh had a
+# THIRD unhardened `timeout 15 doppler secrets get GHCR_READ_*` login for the inngest-bootstrap
+# image pull. On a cold host it skipped docker login → anonymous inngest pull → /var/lib/inngest
+# never created → webhook.service 226/NAMESPACE → :9000 unbound → peer fan-out degraded. Fix:
+# bootstrap prefers the baked /etc/default/soleur-ghcr-read, hardened doppler fallback.
+if grep -qF '/etc/default/soleur-ghcr-read' "$BOOT"; then
+  ok "AC21: soleur-host-bootstrap ghcr_login prefers the baked /etc/default/soleur-ghcr-read"
+else
+  no "AC21: soleur-host-bootstrap ghcr_login must prefer the baked /etc/default/soleur-ghcr-read"
+fi
+if grep -qE 'until GHCR_USER=\$\(timeout 45 doppler[^)]*GHCR_READ_USER' "$BOOT" \
+   && grep -qE 'until GHCR_TOKEN=\$\(timeout 45 doppler[^)]*GHCR_READ_TOKEN' "$BOOT"; then
+  ok "AC21: soleur-host-bootstrap doppler fallback hardened — timeout 45 + until-retry for both GHCR creds"
+else
+  no "AC21: soleur-host-bootstrap must harden the doppler fallback (timeout 45 + until-retry) for both GHCR creds"
+fi
+if grep -qE 'timeout 15 doppler secrets get GHCR_READ' "$BOOT"; then
+  no "AC21: stale un-hardened 'timeout 15 doppler secrets get GHCR_READ_*' still present in soleur-host-bootstrap"
+else
+  ok "AC21: no stale 'timeout 15 doppler secrets get GHCR_READ_*' in soleur-host-bootstrap"
+fi
+
 echo "=== soleur-host-bootstrap-observability: $pass passed, $fail failed ==="
 [ "$fail" -eq 0 ]

--- a/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
+++ b/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
@@ -542,6 +542,13 @@ if grep -qE 'timeout 15 doppler secrets get GHCR_READ' "$BOOT"; then
 else
   ok "AC21: no stale 'timeout 15 doppler secrets get GHCR_READ_*' in soleur-host-bootstrap"
 fi
+# Pin the Sentry warning emits to the same AC (so a future fetch/emit reorder keeps them):
+# both failure branches (credential_absent after retries, auth_denied on login reject) stay loud.
+if grep -qF 'ghcr_login_warn credential_absent' "$BOOT" && grep -qF 'ghcr_login_warn auth_denied' "$BOOT"; then
+  ok "AC21: bootstrap ghcr_login still emits ghcr_login_warn on both failure branches (no-SSH Sentry warning)"
+else
+  no "AC21: bootstrap ghcr_login must emit ghcr_login_warn credential_absent + auth_denied on failure"
+fi
 
 echo "=== soleur-host-bootstrap-observability: $pass passed, $fail failed ==="
 [ "$fail" -eq 0 ]

--- a/apps/web-platform/infra/soleur-host-bootstrap.sh
+++ b/apps/web-platform/infra/soleur-host-bootstrap.sh
@@ -184,8 +184,22 @@ STAGE=ghcr_login
     # preference + fail-open subshell as emit_fail; only the body differs.
     _sentry_emit "$(printf '{"message":"fresh-boot GHCR docker login failed","level":"warning","logger":"soleur-host-bootstrap","tags":{"feature":"supply-chain","op":"image-pull","stage":"ghcr_login","pull_result":"%s","host_id":"%s"}}' "$1" "$HOST_ID")"
   }
-  GHCR_USER=$(timeout 15 doppler secrets get GHCR_READ_USER --plain --project soleur --config prd 2>/dev/null || true)
-  GHCR_TOKEN=$(timeout 15 doppler secrets get GHCR_READ_TOKEN --plain --project soleur --config prd 2>/dev/null || true)
+  # (#6090) Prefer the BAKED creds (cloud-init writes /etc/default/soleur-ghcr-read early in
+  # runcmd, deploy:deploy 0600) so the inngest-bootstrap + app image pulls authenticate on a
+  # cold host even when Doppler answers EMPTY at the boot instant — the same failure class the
+  # cloud-init ghcr_login (#6090) and the ci-deploy prelude (#6161) already bake against. An
+  # empty fetch here skipped docker login → anonymous inngest pull → /var/lib/inngest never
+  # created → webhook.service fails 226/NAMESPACE (it ReadWritePaths=/var/lib/inngest) → :9000
+  # never binds → the peer fan-out degrades. Hardened Doppler fallback (timeout 45 + 3-try retry).
+  GHCR_USER=""; GHCR_TOKEN=""
+  if [ -r /etc/default/soleur-ghcr-read ]; then
+    # shellcheck disable=SC1091
+    . /etc/default/soleur-ghcr-read 2>/dev/null || true
+    GHCR_USER="${GHCR_READ_USER:-}"; GHCR_TOKEN="${GHCR_READ_TOKEN:-}"
+    unset GHCR_READ_TOKEN   # keep the token out of this process env + its children
+  fi
+  [ -n "$GHCR_USER" ] || { n=0; until GHCR_USER=$(timeout 45 doppler secrets get GHCR_READ_USER --plain --project soleur --config prd 2>/dev/null); [ -n "$GHCR_USER" ]; do n=$((n+1)); [ "$n" -ge 3 ] && break; sleep 5; done; }
+  [ -n "$GHCR_TOKEN" ] || { n=0; until GHCR_TOKEN=$(timeout 45 doppler secrets get GHCR_READ_TOKEN --plain --project soleur --config prd 2>/dev/null); [ -n "$GHCR_TOKEN" ]; do n=$((n+1)); [ "$n" -ge 3 ] && break; sleep 5; done; }
   if [ -n "$GHCR_USER" ] && [ -n "$GHCR_TOKEN" ]; then
     if printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin >/dev/null 2>&1; then
       echo "soleur-host-bootstrap: docker login ghcr.io ok"


### PR DESCRIPTION
## Summary

Third and final GHCR-login hardening for the web-2 cold boot (after #6136 seed-pull and #6161 app-pull). Surfaced by direct on-host inspection of the fresh web-2 during the #6090 recreate.

`soleur-host-bootstrap.sh`'s `STAGE=ghcr_login` did a bare `timeout 15 doppler secrets get GHCR_READ_*` with **no baked fallback and no retry**. On the cold host it answered empty → skipped `docker login` (Sentry: `fresh-boot GHCR docker login failed`, logger=`soleur-host-bootstrap`) → the **inngest-bootstrap image pull went anonymous and failed** → **`/var/lib/inngest` was never created** → `webhook.service` fails **226/NAMESPACE** (its `ReadWritePaths` requires `/var/lib/inngest`) → `:9000` never binds → the deploy fan-out degrades (`ok_peer_fanout_degraded`). The boot died **here, before #6161's app-pull path could even run** (verified on-host: #6161's baked file + patched `ci-deploy.sh` are both present on web-2, but ci-deploy never ran because the webhook never bound).

The fix mirrors #6136/#6161: the bootstrap **prefers the baked `/etc/default/soleur-ghcr-read`** (written by cloud-init early in runcmd), falls back to a **hardened Doppler fetch** (`timeout 45` + 3-try retry), and **unsets the token** so no child env carries it. AC21 added.

Ref #6090

Related: the inngest co-location on web backends (which makes inngest's bootstrap a hard gate on the web host even booting) is tracked for a durable architectural fix in #6178.

## User-Brand Impact

- **If this lands broken, the user experiences:** nothing directly — web-2 is a weight-0, non-serving warm-standby; the change is prefer-baked-else-hardened-Doppler, behaviorally identical when creds resolve (web-1, the sole serving host, is warm and unaffected).
- **If this leaks, the user's data is exposed via:** no new vector — reads the same `deploy:deploy 0600` baked file (beside `webhook-deploy`, which already holds the stronger `DOPPLER_TOKEN`); scoped read-only `read:packages` PAT, token unset from child envs.
- **Brand-survival threshold:** none
- Scope-out: threshold: none, reason: web-2 is weight-0 non-serving; web-1's bootstrap login behavior is unchanged when Doppler answers (the fix only adds a cold-boot-empty fallback), so no user-facing serving surface changes.

## Changelog

### Web Platform (infra)
- Harden the host-bootstrap GHCR login (baked-cred preference + hardened Doppler fallback) so the fresh-boot inngest-bootstrap image pull authenticates on a cold host — was empty-failing and leaving `/var/lib/inngest` uncreated, which broke `webhook.service` (226/NAMESPACE) and made the host un-provisionable.

## Test plan

- [x] `soleur-host-bootstrap-observability.test.sh` — 68/68 incl. 3 new AC21 assertions
- [x] `cloud-init-inngest-bootstrap.test.sh` — 22/22 (no regression)
- [x] `shellcheck -S error soleur-host-bootstrap.sh` — clean
- [x] siblings `server-tf-set-e`, `cloud-init-ghcr-seed-login` — green
- [x] 2 reviewers (silent-failure-hunter + observability-coverage-reviewer)
- [ ] Post-merge (autonomous): rebuild image → web-1 on new tag → re-dispatch `web-2-recreate`; expect the inngest bootstrap to authenticate, `/var/lib/inngest` created, webhook binds, app deploys via #6161, `:9000` binds → then #6090 resolved on a green boot

Generated with [Claude Code](https://claude.com/claude-code)
