### PR TITLE
fix(infra): set HOME=/root for doppler run in dedicated-host cloud-init

### DIFF
--- a/apps/web-platform/infra/cloud-init-git-data.yml
+++ b/apps/web-platform/infra/cloud-init-git-data.yml
@@ -133,7 +133,10 @@ runcmd:
     rm /tmp/doppler.tar.gz
   # Restricted (0600 root) env file with the Doppler service token — NOT written to
   # world-readable /etc/environment (mirrors the web host's /etc/default/webhook-deploy).
-  - printf 'DOPPLER_TOKEN=%s\nDOPPLER_CONFIG_DIR=/tmp/.doppler\nDOPPLER_ENABLE_VERSION_CHECK=false\n' '${doppler_token}' > /etc/default/git-data-doppler
+  # HOME is REQUIRED: cloud-init runcmd runs with no $HOME, and the Doppler CLI aborts with
+  # "Doppler Error: $HOME is not defined" even when DOPPLER_CONFIG_DIR is set — so `doppler run`
+  # below fails and the git-data host never bootstraps (same latent bug fixed for zot in #6122).
+  - printf 'HOME=/root\nDOPPLER_TOKEN=%s\nDOPPLER_CONFIG_DIR=/tmp/.doppler\nDOPPLER_ENABLE_VERSION_CHECK=false\n' '${doppler_token}' > /etc/default/git-data-doppler
   - chmod 600 /etc/default/git-data-doppler
 
   # --- FRESH LUKS-at-rest volume (Sub-PR 3.D cutover target) --------------------

--- a/apps/web-platform/infra/cloud-init-registry.yml
+++ b/apps/web-platform/infra/cloud-init-registry.yml
@@ -101,7 +101,10 @@ runcmd:
   # /etc/environment (mirrors git-data's /etc/default/git-data-doppler). The token is scoped to
   # the isolated `soleur-registry` project's `prd` root config (a SEPARATE project — NO
   # inheritance path to soleur/prd), so a host compromise reads ONLY the two ZOT tokens.
-  - printf 'DOPPLER_TOKEN=%s\nDOPPLER_CONFIG_DIR=/tmp/.doppler\nDOPPLER_ENABLE_VERSION_CHECK=false\n' '${doppler_token}' > /etc/default/registry-doppler
+  # HOME is REQUIRED: cloud-init runcmd runs with no $HOME, and the Doppler CLI aborts with
+  # "Doppler Error: $HOME is not defined" even when DOPPLER_CONFIG_DIR is set — so `doppler run`
+  # below (and its nested `doppler secrets` self-check) fail and zot never launches (#6122 boot fix).
+  - printf 'HOME=/root\nDOPPLER_TOKEN=%s\nDOPPLER_CONFIG_DIR=/tmp/.doppler\nDOPPLER_ENABLE_VERSION_CHECK=false\n' '${doppler_token}' > /etc/default/registry-doppler
   - chmod 600 /etc/default/registry-doppler
 
   # Ensure docker is up before the container launch.


### PR DESCRIPTION
## Summary

**Critical boot fix.** Both dedicated-host cloud-inits (`cloud-init-registry.yml`, `cloud-init-git-data.yml`) invoke `doppler run` in a `runcmd`, which runs with **no $HOME**. The Doppler CLI aborts with `Doppler Error: $HOME is not defined` (`DOPPLER_CONFIG_DIR` alone does not satisfy it), so the htpasswd build + boot self-check never run and **zot never launches**.

Diagnosed via **Hetzner rescue-mode disk inspection** of the failed registry host: `cloud-init-output.log` showed `$HOME is not defined` and `/etc/zot/htpasswd` was absent. Both hosts were DARK/never-booted, so the latent bug never surfaced until the #6122 provisioning.

**Fix:** add `HOME=/root` to the sourced `/etc/default/*-doppler` env file.

## Verified live
Re-provisioned the registry host (cx23) with this fix → **zot came up (`/v2/` = HTTP 401, healthy)**. The prior two boots (without the fix) deterministically failed at 502.

## Test plan
- [x] `terraform validate` green; fixed registry cloud-init renders valid schema with `HOME=/root`
- [x] Live: re-provisioned host boots zot successfully

Ref #6122

Generated with [Claude Code](https://claude.com/claude-code)