### PR TITLE
fix(infra): zot push bridge uses DOPPLER_TOKEN_PRD (prd-scoped), not the prd_terraform-scoped DOPPLER_TOKEN

### DIFF
--- a/.github/actions/cf-tunnel-registry-bridge/action.yml
+++ b/.github/actions/cf-tunnel-registry-bridge/action.yml
@@ -85,21 +85,29 @@ runs:
       env:
         DOPPLER_TOKEN: ${{ inputs.doppler-token }}
         DOPPLER_PROJECT: soleur
-        # `prd` (root), same config the docker-login step below reads ZOT_PUSH_* from. The
-        # release DOPPLER_TOKEN is prd-scoped and CANNOT read the prd_terraform branch (#6122
-        # cutover fix); tunnel.tf writes REGISTRY_PUSH_* to the `prd` root accordingly.
+        # `prd` (root), same config the docker-login step below reads ZOT_PUSH_* from. The caller
+        # MUST pass a prd-scoped token (DOPPLER_TOKEN_PRD) — the generic DOPPLER_TOKEN is scoped to
+        # the `prd_terraform` branch and CANNOT read the prd root (#6122 cutover fix). tunnel.tf
+        # writes REGISTRY_PUSH_* to the `prd` root; zot-registry.tf writes ZOT_PUSH_* there too.
         DOPPLER_CONFIG: prd
       run: |
         set -euo pipefail
         TOKEN_ID=$(doppler secrets get REGISTRY_PUSH_ACCESS_TOKEN_ID --plain 2>/dev/null || true)
         TOKEN_SECRET=$(doppler secrets get REGISTRY_PUSH_ACCESS_TOKEN_SECRET --plain 2>/dev/null || true)
         if [[ -z "$TOKEN_ID" || -z "$TOKEN_SECRET" ]]; then
-          echo "::error::REGISTRY_PUSH_ACCESS_TOKEN_ID/_SECRET missing or empty in Doppler prd. Run the operator full terraform apply first (tunnel.tf writes both to the prd root config post-create)."
+          echo "::error::REGISTRY_PUSH_ACCESS_TOKEN_ID/_SECRET missing or empty reading Doppler soleur/prd. Confirm the caller passes the prd-scoped DOPPLER_TOKEN_PRD (not the prd_terraform-scoped DOPPLER_TOKEN) and that tunnel.tf wrote both to the prd root config."
+          # Diagnostic on failure (secret NAMES only — never values): shows whether this token can
+          # read soleur/prd at all and whether it resolves the expected keys. An auth/permission
+          # error here (captured via 2>&1) means the token is scoped to a different config.
+          echo "::group::doppler read diagnostic (names only, no values)"
+          doppler secrets --only-names 2>&1 | grep -iE 'REGISTRY_PUSH|ZOT_' | head -10 || true
+          doppler secrets --only-names 2>&1 | head -3 || true
+          echo "::endgroup::"
           exit 1
         fi
         printf '::add-mask::%s\n' "$TOKEN_ID"
         printf '::add-mask::%s\n' "$TOKEN_SECRET"
-        # APP_DOMAIN_BASE is not in prd_terraform — fall back to the canonical default exactly
+        # APP_DOMAIN_BASE is not in prd — fall back to the canonical default exactly
         # like the SSH bridge / caller verify steps (bare form exits non-zero under set -e).
         APP_DOMAIN_BASE=$(doppler secrets get APP_DOMAIN_BASE --plain 2>/dev/null || echo "soleur.ai")
 

--- a/.github/workflows/build-inngest-bootstrap-image.yml
+++ b/.github/workflows/build-inngest-bootstrap-image.yml
@@ -206,7 +206,11 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/cf-tunnel-registry-bridge
         with:
-          doppler-token: ${{ secrets.DOPPLER_TOKEN }}
+          # DOPPLER_TOKEN_PRD, NOT the generic DOPPLER_TOKEN (#6122 cutover fix): the bridge
+          # reads REGISTRY_PUSH_* + ZOT_PUSH_* from the `prd` root config; DOPPLER_TOKEN is
+          # scoped to the `prd_terraform` branch and cannot read prd root. DOPPLER_TOKEN_PRD is
+          # the prd-scoped token (see reusable-release.yml for the full rationale).
+          doppler-token: ${{ secrets.DOPPLER_TOKEN_PRD }}
           cloudflared-version: "2026.5.0"
           cloudflared-sha256: "0095e46fdc88855d801c4d304cb1f5dd4bd656116c47ab94c2ad0ae7cda1c7ec"
 

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -656,7 +656,13 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/cf-tunnel-registry-bridge
         with:
-          doppler-token: ${{ secrets.DOPPLER_TOKEN }}
+          # DOPPLER_TOKEN_PRD, NOT the generic DOPPLER_TOKEN (#6122 cutover fix): the bridge
+          # reads REGISTRY_PUSH_* + ZOT_PUSH_* from the `prd` root config, but DOPPLER_TOKEN is
+          # scoped to the `prd_terraform` branch (apply-web-platform-infra.yml documents it
+          # "prd_terraform READ-only") and cannot read the prd root. DOPPLER_TOKEN_PRD is the
+          # prd-scoped token the verify-doppler-secrets required check already uses (doppler run
+          # -c prd). Available here via the caller's `secrets: inherit`.
+          doppler-token: ${{ secrets.DOPPLER_TOKEN_PRD }}
           cloudflared-version: "2026.5.0"
           cloudflared-sha256: "0095e46fdc88855d801c4d304cb1f5dd4bd656116c47ab94c2ad0ae7cda1c7ec"
 


### PR DESCRIPTION
## What / why

Follow-up to #6198. The **second** live bridge run (release `web-v0.200.20`, run [28881833721](https://github.com/jikig-ai/soleur/actions/runs/28881833721)) **still failed identically** — `REGISTRY_PUSH_ACCESS_TOKEN_ID/_SECRET missing or empty in Doppler prd` — even though the tokens are verifiably in `prd` (39/64 chars; the `prd` copy authenticates to `registry.soleur.ai/v2/` → 401). #6198 corrected the wrong axis.

**Root cause (corrected):** the bridge composite reads its creds with the caller-supplied `secrets.DOPPLER_TOKEN`, which is scoped to the **`prd_terraform` branch** config — `apply-web-platform-infra.yml` documents it verbatim as *"`prd_terraform` READ-only"*, and every apply workflow pairs it with `DOPPLER_CONFIG: prd_terraform`. It **cannot read the `prd` root**, so *both* the `REGISTRY_PUSH_*` read (bridge step) and the `ZOT_PUSH_*` read (docker-login step) fail. The composite was handed the wrong token from day one; the docker-login step just never got a chance to fail because the bridge step failed first.

## Fix

- Both callers — `reusable-release.yml` and `build-inngest-bootstrap-image.yml` — now pass **`secrets.DOPPLER_TOKEN_PRD`**, the `prd`-scoped token the **required** `verify-doppler-secrets` check already uses (`doppler run -c prd`, blocks deploy on failure). Available in the reusable workflow via the caller's `secrets: inherit`.
- Combined with #6198 (which placed `REGISTRY_PUSH_*` in the `prd` root alongside `ZOT_PUSH_*`), the bridge now reads **both** creds from `prd` with a `prd`-capable token.
- Added a **no-leak diagnostic** (secret **names** only, never values) on the empty-cred failure path, so any further failure is diagnosable rather than blind (doppler stderr was suppressed — this was the 2nd blind cycle).

## Why higher-confidence than #6198

`DOPPLER_TOKEN_PRD` reading `prd` is proven by the required `verify-doppler-secrets` job passing on every release; the creds' presence in `prd` is verified out-of-band (tunnel auth 401). Both halves are independently confirmed. The merge auto-triggers the next release to exercise the bridge end-to-end; if the cred read now passes and cloudflared then fails, the teardown log surfaces that next-layer error.

Ref #6122