### PR TITLE
fix(infra): install Doppler CLI in zot bridge composite (the real #6122 root cause)

### DIFF
--- a/.github/actions/cf-tunnel-registry-bridge/action.yml
+++ b/.github/actions/cf-tunnel-registry-bridge/action.yml
@@ -63,6 +63,14 @@ inputs:
 runs:
   using: composite
   steps:
+    # The Doppler CLI is NOT pre-installed on the release/inngest runners (only jobs that
+    # explicitly install it — e.g. verify-doppler-secrets — have it). This composite's secret
+    # reads below shell out to `doppler`, so install it FIRST. Omitting this was the #6122 zot
+    # bridge failure: `doppler secrets get` errored `command not found`, which the `2>/dev/null`
+    # on the reads swallowed into an empty value → the guards misreported it as "missing secret".
+    - name: Install Doppler CLI
+      uses: dopplerhq/cli-action@014df23b1329b615816a38eb5f473bb9000700b1 # v3
+
     - name: Install cloudflared (SHA-pinned)
       shell: bash
       env:
@@ -92,8 +100,11 @@ runs:
         DOPPLER_CONFIG: prd
       run: |
         set -euo pipefail
-        TOKEN_ID=$(doppler secrets get REGISTRY_PUSH_ACCESS_TOKEN_ID --plain 2>/dev/null || true)
-        TOKEN_SECRET=$(doppler secrets get REGISTRY_PUSH_ACCESS_TOKEN_SECRET --plain 2>/dev/null || true)
+        # NO 2>/dev/null: a doppler error (command-not-found, auth, wrong config) must surface in
+        # the step log, not be swallowed into an empty value. `doppler secrets get --plain` writes
+        # the value only to stdout (captured), so unsuppressing stderr cannot leak it.
+        TOKEN_ID=$(doppler secrets get REGISTRY_PUSH_ACCESS_TOKEN_ID --plain || true)
+        TOKEN_SECRET=$(doppler secrets get REGISTRY_PUSH_ACCESS_TOKEN_SECRET --plain || true)
         if [[ -z "$TOKEN_ID" || -z "$TOKEN_SECRET" ]]; then
           echo "::error::REGISTRY_PUSH_ACCESS_TOKEN_ID/_SECRET missing or empty reading Doppler soleur/prd. Confirm the caller passes the prd-scoped DOPPLER_TOKEN_PRD (not the prd_terraform-scoped DOPPLER_TOKEN) and that tunnel.tf wrote both to the prd root config."
           # Diagnostic on failure (secret NAMES only — never values): shows whether this token can
@@ -144,8 +155,9 @@ runs:
       # over the tunnel. --password-stdin (never argv). 127.0.0.1 is auto-insecure to docker.
       run: |
         set -euo pipefail
-        ZOT_PUSH_USER=$(doppler secrets get ZOT_PUSH_USER --plain 2>/dev/null || true)
-        ZOT_PUSH_TOKEN=$(doppler secrets get ZOT_PUSH_TOKEN --plain 2>/dev/null || true)
+        # NO 2>/dev/null (see the bridge step): a doppler error must be visible, not swallowed.
+        ZOT_PUSH_USER=$(doppler secrets get ZOT_PUSH_USER --plain || true)
+        ZOT_PUSH_TOKEN=$(doppler secrets get ZOT_PUSH_TOKEN --plain || true)
         if [[ -z "$ZOT_PUSH_USER" || -z "$ZOT_PUSH_TOKEN" ]]; then
           echo "::error::ZOT_PUSH_USER/ZOT_PUSH_TOKEN missing or empty in Doppler prd (written by zot-registry.tf on the operator full apply)."
           exit 1


### PR DESCRIPTION
## The actual root cause

The zot CI push bridge failed on **three** live runs (`28879903059`, `28881833721`, `28884328215`) with `REGISTRY_PUSH_ACCESS_TOKEN_ID/_SECRET missing or empty`. The no-leak diagnostic added in #6200 finally surfaced the real error:

```
doppler: command not found
```

The Doppler CLI **isn't pre-installed** on the release/inngest runners (only jobs that explicitly install it — e.g. `verify-doppler-secrets` — have it). The composite shells out to `doppler secrets get` but never installed it, and the `2>/dev/null` on those reads **swallowed the command-not-found error into an empty value** — so the guards misreported a missing *binary* as a missing *secret*. That misdirection cost two cycles (#6198, #6200) before the diagnostic exposed the truth. The `DOPPLER_TOKEN: ***` line in the failing log (token present, non-empty) was the tell that it was never a secret/scope problem.

## Fix

- **Install the Doppler CLI** (`dopplerhq/cli-action`, SHA-pinned to the repo-canonical `v3`) as the composite's **first** step, before any `doppler` call.
- **Drop `2>/dev/null`** from the required-secret reads so a doppler error (command-not-found, auth, wrong config) surfaces in the step log instead of masquerading as an empty secret. `--plain` writes the value only to stdout (captured into the var), so unsuppressing stderr cannot leak it. (The optional `APP_DOMAIN_BASE` read keeps its suppression — it has an intended `soleur.ai` fallback.)

## Relationship to #6198 / #6200

All three are cumulatively required — the blind cycles were caused by the suppressed stderr, not wasted:
- **#6202 (this):** install doppler — the missing binary.
- **#6200:** `DOPPLER_TOKEN_PRD` — the generic `DOPPLER_TOKEN` is `prd_terraform`-scoped and can't read `prd`, which the docker-login step needs for `ZOT_PUSH_*`.
- **#6198:** `REGISTRY_PUSH_*` in the `prd` root — so a single `prd`-scoped token reads both creds.

End state: the bridge installs doppler, reads both creds from `prd` with a `prd`-capable token, and mirrors GHCR→zot.

## Verification plan

Action-only change → won't auto-trigger a release, so after merge I'll dispatch a `skip_deploy=true` release. Expect the bridge step to reach the **Mirror** step (`success`, not `skipped`) and the image to resolve in zot out-of-band. If cloudflared then fails the tunnel handshake (the originally-predicted failure mode), the teardown's `cloudflared-registry.log` tail will now show it.

Ref #6122