### PR TITLE
fix(infra): registry tunnel ingress tcp:// not http:// — fixes zot push bridge handshake (#6122)

### DIFF
--- a/apps/web-platform/infra/dns.tf
+++ b/apps/web-platform/infra/dns.tf
@@ -52,7 +52,8 @@ resource "cloudflare_record" "ssh" {
 # #6122 (ADR-096) — registry PUSH ingress for CI via Cloudflare Tunnel (CTO ruling).
 # CI pushes container images to the private-net zot host through this hostname: it runs
 # `cloudflared access tcp --hostname registry.<base>` (CF Access service-token auth) → the
-# web host's cloudflared → http://10.0.1.30:5000 (the tunnel ingress_rule in tunnel.tf).
+# web host's cloudflared → tcp://10.0.1.30:5000 (the tunnel ingress_rule in tunnel.tf; raw
+# TCP, not http:// — cloudflared access tcp bridges a raw stream, see tunnel.tf for why).
 # Mirrors cloudflare_record.ssh 1:1. The Hetzner registry firewall stays deny-all-public —
 # push arrives via the tunnel, never a public port. Web hosts PULL direct on the private net.
 resource "cloudflare_record" "registry" {

--- a/apps/web-platform/infra/tunnel.tf
+++ b/apps/web-platform/infra/tunnel.tf
@@ -44,10 +44,19 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "web" {
     # #6122 (ADR-096) — registry PUSH ingress. The web host's cloudflared (already a
     # 10.0.1.0/24 member) proxies to the private-net zot host, so the registry host needs
     # NO cloudflared of its own. CI runs `cloudflared access tcp --hostname registry.<base>`
-    # → this rule → http://10.0.1.30:5000 (zot). First-match; MUST stay above the 404.
+    # → this rule → tcp://10.0.1.30:5000 (zot). First-match; MUST stay above the 404.
+    #
+    # `tcp://`, NOT `http://` (#6122 cutover fix): `cloudflared access tcp` bridges a RAW TCP
+    # stream over a WebSocket. With an `http://` service the origin cloudflared HTTP-proxies the
+    # WS-upgrade to zot, which doesn't speak it → the client dies "websocket: bad handshake"
+    # (the exact symptom the first live push runs hit). The sibling SSH bridge works precisely
+    # because it uses a raw-TCP service type (`ssh://localhost:22`); `tcp://` is the generic
+    # form for zot's plain-HTTP registry — crane/docker then speak HTTP over the raw forward
+    # (127.0.0.1:5000 is auto-insecure to docker). The CF Access app + service-token policy are
+    # unchanged (identical shape to the working ssh app); only the ingress transport was wrong.
     ingress_rule {
       hostname = "registry.${var.app_domain_base}"
-      service  = "http://${local.registry_endpoint}"
+      service  = "tcp://${local.registry_endpoint}"
     }
     # Catch-all rule (required by Cloudflare)
     ingress_rule {


### PR DESCRIPTION
## The real, final defect

Once doppler was installed (#6201), the zot CI push bridge got past the cred read and hit the exact failure the halt note predicted:

```
ERR failed to connect to origin error="websocket: bad handshake" originURL=https://registry.soleur.ai
Error response from daemon: Get "http://127.0.0.1:5000/v2/": ... connection reset by peer
```

`cloudflared access tcp` bridges a **raw TCP** stream over a WebSocket. The registry tunnel ingress was `http://10.0.1.30:5000`, so the origin cloudflared **HTTP-proxied** the WS-upgrade to zot (which doesn't speak it) → bad handshake. The sibling CI-SSH bridge works precisely because its ingress is a raw-TCP service type (`ssh://localhost:22`). The two CF Access apps are otherwise **structurally identical** (`self_hosted` + `non_identity` service-token policy) — the ingress transport was the only difference. The HTTP `/v2/` probe returning 401 worked *because* the ingress was `http://`, masking that the push path was broken.

## Fix

`service = "http://${local.registry_endpoint}"` → `"tcp://${local.registry_endpoint}"`. crane/docker then speak HTTP over the raw forward (`127.0.0.1:5000` is auto-insecure to docker).

## Verified live, end-to-end

Applied via targeted apply, then reproduced the bridge locally: `cloudflared access tcp --hostname registry.soleur.ai --url 127.0.0.1:<local>` now brings the WebSocket listener up and `curl http://127.0.0.1:<local>/v2/` returns **401** — zot reachable through the raw-TCP tunnel, the exact path that died "bad handshake" before.

## Blast radius: none beyond the push bridge

Every committed `/v2/` probe (`ci-deploy.sh`, `zot-entry-gate.sh`, cloud-init readiness) hits the **private IP `10.0.1.30:5000` directly**, not the tunnel — so none are affected. Only the CI push bridge (now fixed) traverses `registry.soleur.ai`.

## The full #6122 bridge fix chain

1. **#6198** — `REGISTRY_PUSH_*` in the `prd` root config.
2. **#6200** — bridge uses `DOPPLER_TOKEN_PRD` (prd-scoped), not the prd_terraform-scoped `DOPPLER_TOKEN`.
3. **#6201** — install the Doppler CLI (the binary was missing; `2>/dev/null` hid it).
4. **#6202 (this)** — `tcp://` tunnel ingress (the actual handshake defect).

Ref #6122