### PR TITLE
fix(infra): mirror to zot under full jikig-ai/ namespace (match gate + pull path)

### DIFF
--- a/.github/workflows/build-inngest-bootstrap-image.yml
+++ b/.github/workflows/build-inngest-bootstrap-image.yml
@@ -221,7 +221,10 @@ jobs:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -euo pipefail
-          ZOT="127.0.0.1:5000/soleur-inngest-bootstrap"
+          # Full org namespace (jikig-ai/…) to match the ci-deploy.sh pull path
+          # (zot_ref="${ZOT_REGISTRY_URL}/${IMAGE#ghcr.io/}") + zot-entry-gate.sh. A bare
+          # `soleur-inngest-bootstrap` is an orphan repo nothing reads (#6122 namespace fix).
+          ZOT="127.0.0.1:5000/${IMAGE#ghcr.io/}"
           docker tag "$IMAGE:$TAG" "$ZOT:$TAG"
           docker push "$ZOT:$TAG"
           echo "Pushed $ZOT:$TAG"

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -684,8 +684,13 @@ jobs:
           sudo tar -xzf /tmp/crane.tgz -C /usr/local/bin crane
           rm /tmp/crane.tgz
 
-          BASE="$(basename "$IMAGE")"        # e.g. soleur-web-platform
-          ZOT="127.0.0.1:5000/${BASE}"
+          # Preserve the FULL org namespace (jikig-ai/…). The pull side
+          # (ci-deploy.sh: zot_ref="${ZOT_REGISTRY_URL}/${IMAGE#ghcr.io/}") and
+          # zot-entry-gate.sh both address `jikig-ai/soleur-web-platform`. `basename` dropped
+          # the org, pushing to an orphan `soleur-web-platform` repo nothing reads → the gate
+          # MISSED and every pull fell back to GHCR (#6122 namespace fix).
+          REPO="${IMAGE#ghcr.io/}"           # e.g. jikig-ai/soleur-web-platform
+          ZOT="127.0.0.1:5000/${REPO}"
           # crane reads ~/.docker/config.json for BOTH ghcr.io (Docker login step) and
           # 127.0.0.1:5000 (cf-tunnel-registry-bridge docker login). Copy every tag the GHCR
           # build-push wrote (digest preserved → zot manifest byte-identical).


### PR DESCRIPTION
## What / why

The #6122 zot push bridge now works end-to-end — the Mirror step succeeds and cosign-signs the zot digest. But an **out-of-band check of zot** (via the tunnel) showed the image landed at repo **`soleur-web-platform`** — *without* the `jikig-ai/` org namespace:

```
GET /v2/_catalog → {"repositories":["soleur-web-platform"]}
GET /v2/jikig-ai/soleur-web-platform/tags/list → NAME_UNKNOWN
```

Both consumers expect the **full** path:
- **Pull** — `ci-deploy.sh:725`: `zot_ref="${ZOT_REGISTRY_URL}/${IMAGE#ghcr.io/}"` → `…/jikig-ai/soleur-web-platform`
- **Gate** — `zot-entry-gate.sh`: probes `jikig-ai/soleur-web-platform` + `jikig-ai/soleur-inngest-bootstrap`

But the two mirror steps stripped the org:
- `reusable-release.yml`: `BASE="$(basename "$IMAGE")"` → `soleur-web-platform`
- `build-inngest-bootstrap-image.yml`: hardcoded `127.0.0.1:5000/soleur-inngest-bootstrap`

So the image was pushed to an **orphan repo nothing reads** → the entry gate would MISS and every deploy would silently fall back to GHCR. The cutover would report "mirror success" yet **never actually serve from zot**. Caught by verifying zot contents rather than trusting the green step.

## Fix

Both push sites now use `${IMAGE#ghcr.io/}` (= `jikig-ai/…`), matching the pull path + gate exactly. The zot `cosign sign` in `reusable-release.yml` now signs the correct `jikig-ai/…` digest.

## Follow-up (non-blocking)

The orphan `soleur-web-platform` repo (from the validation runs) is inert — nothing reads it. I'll prune it from zot out-of-band; it doesn't block the cutover.

Ref #6122