### PR TITLE
fix(infra): zot docker2s2 compat + registry drift-fix → immutable redeploy (#6122)

### DIFF
--- a/apps/web-platform/infra/cloud-init-registry.yml
+++ b/apps/web-platform/infra/cloud-init-registry.yml
@@ -40,6 +40,12 @@ write_files:
   # dedupe + gc (safe on a singleton; gc retains the tagged sha256-<digest>.sig referrers),
   # htpasswd auth, deny-by-default accessControl (pull user = read; push user =
   # read/create/update). Usernames are terraform-interpolated (non-secret constants).
+  #
+  # http.compat ["docker2s2"] (#6122): zot is OCI-native and REJECTS Docker manifest
+  # schema2 pushes (application/vnd.docker.distribution.manifest.v2+json) with
+  # MANIFEST_INVALID unless this compat flag is set. The inngest-bootstrap image is built by
+  # plain `docker build` → docker-schema2, so it needs this; the web image is OCI (buildx) and
+  # does not. (project-zot pkg/compat/compat.go DockerManifestV2SchemaV2 = "docker2s2".)
   - path: /etc/zot/config.json
     content: |
       {
@@ -54,6 +60,7 @@ write_files:
         "http": {
           "address": "0.0.0.0",
           "port": "5000",
+          "compat": ["docker2s2"],
           "auth": { "htpasswd": { "path": "/etc/zot/htpasswd" } },
           "accessControl": {
             "repositories": {

--- a/apps/web-platform/infra/variables.tf
+++ b/apps/web-platform/infra/variables.tf
@@ -36,9 +36,15 @@ variable "server_type" {
 }
 
 variable "location" {
-  description = "Hetzner datacenter location"
+  description = "Hetzner datacenter location (web + git-data hosts). NOT the registry — that has its own var.registry_location so the two can diverge (#6122: the registry lives in nbg1, provisioned during a hel1 capacity outage)."
   type        = string
   default     = "hel1"
+}
+
+variable "registry_location" {
+  description = "Hetzner datacenter location for the zot registry host + its volume (#6122). Separate from var.location because the registry was provisioned in nbg1 (cx23 stock) during a hel1/eu-central capacity outage; keeping it independent lets a `terraform plan` show no registry drift and lets the registry move regions without disturbing the web/git-data hosts."
+  type        = string
+  default     = "nbg1"
 }
 
 variable "image_name" {
@@ -110,7 +116,11 @@ variable "git_data_volume_size" {
 variable "registry_server_type" {
   description = "Hetzner server type for the zot registry host. HOST ARCH IS DERIVED FROM THIS (zot-registry.tf local.registry_arch): cax11 (2 vCPU ARM64/Ampere, 4GB, €5.99/mo) or cx23 (2 vCPU x86, 4GB, €5.49/mo). A store-and-serve registry never RUNS the amd64 platform images it holds, so arch is functionally neutral — provisioning takes whichever has Hetzner stock. Recorded via ops-advisor (~€5/mo + volume)."
   type        = string
-  default     = "cax11"
+  # cx23 (x86), NOT cax11 (arm64): the live registry is cx23 in nbg1 — provisioned when both
+  # cax11 AND cx23 were out of stock in hel1 during a eu-central capacity outage (#6122). This
+  # default matches the live host so `terraform plan` shows no registry drift; arch is
+  # functionally neutral for a store-and-serve registry (it never runs the images it holds).
+  default = "cx23"
 }
 
 variable "registry_volume_size" {

--- a/apps/web-platform/infra/zot-registry.tf
+++ b/apps/web-platform/infra/zot-registry.tf
@@ -183,7 +183,7 @@ resource "doppler_secret" "zot_push_token" {
 resource "hcloud_server" "registry" {
   name        = "soleur-registry"
   server_type = var.registry_server_type # cax11 (arm64) / cx23 (amd64) — arch derived in locals
-  location    = var.location
+  location    = var.registry_location    # independent of var.location (#6122: registry is nbg1)
   image       = "ubuntu-24.04"
   keep_disk   = true
   ssh_keys    = [hcloud_ssh_key.default.id]
@@ -235,7 +235,7 @@ resource "hcloud_server" "registry" {
 resource "hcloud_volume" "registry" {
   name     = "soleur-registry-store"
   size     = var.registry_volume_size
-  location = var.location
+  location = var.registry_location # MUST match hcloud_server.registry (#6122: nbg1)
   format   = "ext4"
 
   labels = {


### PR DESCRIPTION
## What / why

Two coupled registry-host fixes that together enable an **immutable redeploy** to make the docker-schema2 inngest image mirrorable.

### 1. `docker2s2` compat (the inngest blocker)
The inngest-bootstrap image is built by plain `docker build` → a Docker manifest schema2 (`application/vnd.docker.distribution.manifest.v2+json`), which zot (OCI-native) **rejects** with `MANIFEST_INVALID` by default. Confirmed live: a `crane copy` of `soleur-inngest-bootstrap:v1.1.18` pushed all blobs then failed the manifest PUT. The web image mirrors fine because buildx emits OCI.

Fix: add `"compat": ["docker2s2"]` to the zot config `http` section (project-zot's supported switch — `pkg/compat/compat.go`). Chosen over converting inngest to OCI (operator decision): one-line, no inngest version churn, fixes the general case.

### 2. Registry drift-fix (handoff step 6) — enables a clean redeploy
Rather than SSH-mutating the live host (a "pet server" anti-pattern), we redeploy it immutably so the compat is baked into cloud-init. But a plain replace would use main's stale `cax11`/`hel1` defaults, so:
- `registry_server_type` default `cax11` → `cx23` (matches the live host).
- new `var.registry_location` (default `nbg1`), wired into the registry host + volume, decoupling the registry region from the shared `var.location` (web + git-data at hel1).

## The redeploy (applied after merge)

`terraform apply` targeted to the registry: the `user_data` (cloud-init) change forces `hcloud_server.registry` to **replace**; the volume **attachment** re-creates onto the new host; **`hcloud_volume.registry` is untouched** so the web backfill on the persistent volume survives. The registry is **dark (pre-flip)** → zero prod impact, and this validates that a fresh provision boots cleanly with every fix (compat + the #6196 `$HOME` fix).

Targeted plan confirmed: `2 to add, 0 to change, 2 to destroy` (server + attachment only; volume preserved; no git_data, no location/type drift).

Ref #6122