### PR TITLE
fix(worktree): normalize GIT_ROOT to absolute at init + observe verify failures (#5934)

### DIFF
--- a/apps/web-platform/server/git-lock-marker-telemetry.ts
+++ b/apps/web-platform/server/git-lock-marker-telemetry.ts
@@ -52,21 +52,27 @@ const log = createChildLogger("git-lock-marker-telemetry");
 //     bare surgery was correctly skipped and native `git worktree add` proceeds. NOT a wedge.
 //   - SOLEUR_FEATURE_PUSH_FAILED      — the -u push failed → local-only branch (was dropped at ingest).
 //   - NO_GIT_REPOSITORY               — the repo-readiness gate: a repo-less workspace exits 3 (was dropped).
+//   - SOLEUR_GIT_WORKTREE_VERIFY_FAILED — verify_worktree_created rejected the new worktree
+//     (reason=path-mismatch|not-a-worktree|dir-not-created|unregistered|branch-missing). The
+//     #5934 round-3 LIVE failure was reason=path-mismatch: a relative GIT_ROOT made the expected
+//     path relative while git reported it absolute. This exit was SILENT to every sink before
+//     round-3 (the round-2 wedge could only be seen via an operator paste). A wedge.
 // The optional leading `(?:\[[a-z]+\] )?` prefix tolerates the `[error] ` / `[warn] ` prefix that
 // headless_or_stderr stamps onto a marker when it reaches stderr instead of a bare stdout echo
 // (D1c) — so the existing `[error] worktree wedge:` give-up finally matches.
 const MARKER_RE =
-  /^(?:\[[a-z]+\]\s)?(?:SOLEUR_GIT_LOCK_(?:DIAG|UNREMOVABLE|TEMP_WEDGED)\b.*|SOLEUR_GIT_LOCK_IDENTITY_(?:WEDGED|DIAG)\b.*|SOLEUR_GIT_CONFIG_(?:TARGET_MASKED|MASK_SKIP)\b.*|SOLEUR_GIT_REPO_DIAG\b.*|SOLEUR_FEATURE_PUSH_FAILED\b.*|NO_GIT_REPOSITORY\b.*|worktree wedge:.*)$/;
+  /^(?:\[[a-z]+\]\s)?(?:SOLEUR_GIT_LOCK_(?:DIAG|UNREMOVABLE|TEMP_WEDGED)\b.*|SOLEUR_GIT_LOCK_IDENTITY_(?:WEDGED|DIAG)\b.*|SOLEUR_GIT_CONFIG_(?:TARGET_MASKED|MASK_SKIP)\b.*|SOLEUR_GIT_WORKTREE_VERIFY_FAILED\b.*|SOLEUR_GIT_REPO_DIAG\b.*|SOLEUR_FEATURE_PUSH_FAILED\b.*|NO_GIT_REPOSITORY\b.*|worktree wedge:.*)$/;
 
 // A wedge (vs. a benign DIAG) is any marker that indicates git operations could not
 // proceed: an unremovable/masked lock, a temp-wedge, a config-TARGET-masked give-up, an
 // ensure_bare_config give-up, a failed identity set-from-global write, a readiness-gate
 // rejection (SOLEUR_GIT_REPO_DIAG is only emitted on the not-ready path), a repo-less
 // workspace (NO_GIT_REPOSITORY), OR a failed feature push (SOLEUR_FEATURE_PUSH_FAILED →
-// local-only branch). EXCLUDED (benign, mirrored-not-paged): SOLEUR_GIT_LOCK_IDENTITY_DIAG
+// local-only branch), OR a rejected worktree (SOLEUR_GIT_WORKTREE_VERIFY_FAILED → creation
+// aborted with exit 1). EXCLUDED (benign, mirrored-not-paged): SOLEUR_GIT_LOCK_IDENTITY_DIAG
 // (precondition) and SOLEUR_GIT_CONFIG_MASK_SKIP (non-bare-skip-under-mask → creation proceeds).
 const WEDGE_RE =
-  /^(?:\[[a-z]+\]\s)?(?:SOLEUR_GIT_LOCK_(?:UNREMOVABLE|TEMP_WEDGED)\b|SOLEUR_GIT_LOCK_IDENTITY_WEDGED\b|SOLEUR_GIT_CONFIG_TARGET_MASKED\b|SOLEUR_GIT_REPO_DIAG\b|SOLEUR_FEATURE_PUSH_FAILED\b|NO_GIT_REPOSITORY\b|worktree wedge:)/;
+  /^(?:\[[a-z]+\]\s)?(?:SOLEUR_GIT_LOCK_(?:UNREMOVABLE|TEMP_WEDGED)\b|SOLEUR_GIT_LOCK_IDENTITY_WEDGED\b|SOLEUR_GIT_CONFIG_TARGET_MASKED\b|SOLEUR_GIT_WORKTREE_VERIFY_FAILED\b|SOLEUR_GIT_REPO_DIAG\b|SOLEUR_FEATURE_PUSH_FAILED\b|NO_GIT_REPOSITORY\b|worktree wedge:)/;
 
 // Bounds: scan at most this many lines, keep at most this many matched markers, and
 // truncate any single marker line to this many chars. A wedged run emits a handful of

--- a/apps/web-platform/test/git-lock-marker-telemetry.test.ts
+++ b/apps/web-platform/test/git-lock-marker-telemetry.test.ts
@@ -34,6 +34,11 @@ const WEDGE_PREFIXED =
 // where the bare surgery is correctly skipped — mirrored, but NOT a wedge (creation proceeds).
 const MASK_SKIP =
   'SOLEUR_GIT_CONFIG_MASK_SKIP file=config reason=non-bare-skip hint="masked config on a non-bare clone; bare surgery skipped"';
+// #5934 round-3: verify_worktree_created's path-mismatch exit — the LIVE round-2 failure
+// (a relative GIT_ROOT made the expected path relative while git reported it absolute). Was
+// silent to every sink; now a mirrored WEDGE.
+const WORKTREE_VERIFY_FAILED =
+  "SOLEUR_GIT_WORKTREE_VERIFY_FAILED reason=path-mismatch branch=feat-x expected=.git/.worktrees/feat-x actual=/workspaces/abc/.git/.worktrees/feat-x";
 
 describe("extractGitLockMarkers", () => {
   test("pulls each marker sentinel out of surrounding bash noise", () => {
@@ -81,6 +86,14 @@ describe("extractGitLockMarkers", () => {
   test("adds SOLEUR_FEATURE_PUSH_FAILED + NO_GIT_REPOSITORY to the ingest allowlist (D1b) as wedges", () => {
     expect(extractGitLockMarkers(FEATURE_PUSH_FAILED)[0]?.wedged).toBe(true);
     expect(extractGitLockMarkers(NO_GIT_REPO)[0]?.wedged).toBe(true);
+  });
+
+  test("matches SOLEUR_GIT_WORKTREE_VERIFY_FAILED (#5934 round-3) and classifies it as a wedge", () => {
+    const [m] = extractGitLockMarkers(WORKTREE_VERIFY_FAILED);
+    // The full marker (incl. the relative expected= and absolute actual= paths that name the
+    // round-2 root cause) survives verbatim for diagnosis.
+    expect(m?.line).toBe(WORKTREE_VERIFY_FAILED);
+    expect(m?.wedged).toBe(true);
   });
 
   test("tolerates a leading [error] prefix on the worktree wedge line (D1c, headless_or_stderr sink)", () => {

--- a/knowledge-base/project/learnings/2026-07-08-relative-gitroot-mask-corruption-has-many-victims-patch-the-source.md
+++ b/knowledge-base/project/learnings/2026-07-08-relative-gitroot-mask-corruption-has-many-victims-patch-the-source.md
@@ -1,0 +1,63 @@
+---
+title: "A mask-corrupted RELATIVE GIT_ROOT has many downstream victims — normalize it once at the source, not each victim; and verify_worktree_created was silent"
+date: 2026-07-08
+category: bug-fixes
+module: git-worktree
+issue: 5934
+tags: [git-worktree, gitroot, relative-path, char-device, mask-degraded, verify-worktree, telemetry, observability, patch-the-source, round-3]
+synced_to: [review, git-worktree]
+---
+
+# Learning: the relative-GIT_ROOT mask corruption is a SOURCE bug with many victims; patch the source
+
+## Context (round 3 on #5934)
+
+The Concierge workspace is a NON-bare clone whose `.git/config` family is masked by a
+char-device / bind-mount in the agent sandbox. Under that mask git's plumbing DEGRADES:
+`git rev-parse --git-common-dir` hands back the RELATIVE string `.git`, and
+`git -C .git rev-parse --is-bare-repository` falsely reports `true` (running from inside a
+`.git` dir looks bare when the config can't be read). PR #6206 (merged 2026-07-07) fixed
+`ensure_bare_config` to SKIP its bare surgery in this case — correct, but the failure just
+moved DOWNSTREAM to the next consumer of the same corrupted value.
+
+## Root cause
+
+In `worktree-manager.sh`'s init block the non-bare `else` branch set
+`GIT_ROOT="$_common_dir"` = the relative `.git` (the `*/.git` strip can't match a
+slash-less string), so `WORKTREE_DIR=".git/.worktrees"` (relative). `create_for_feature`
+runs from the workspace root and `git worktree add` succeeds, but `verify_worktree_created`
+then compares the RELATIVE expected path against git's ABSOLUTE `--show-toplevel` and dies:
+`Worktree path mismatch — expected .git/.worktrees/feat-…, got /workspaces/…/.git/.worktrees/feat-…`.
+Same location, relative-vs-absolute — a pure path-normalization bug.
+
+## The two lessons
+
+1. **A corrupted value has MANY victims — patch the SOURCE, not each victim.** The relative
+   `GIT_ROOT` had already claimed `ensure_bare_config` (round 2, #6206) and `WORKTREE_DIR` +
+   `verify_worktree_created` (round 3). Patching victims one at a time is a treadmill. The fix
+   normalizes `GIT_ROOT` to ABSOLUTE ONCE at init, so EVERY downstream consumer
+   (`WORKTREE_DIR`, `copy_env_files`, `ensure_bare_config`, `verify_worktree_created`) gets an
+   unambiguous path. Two layers: (a) resolve `_common_dir` to absolute BEFORE the `*/.git`
+   strip so the strip yields the true workspace ROOT (sibling `.worktrees`, not a path buried
+   inside `.git`); (b) a final `ensure_git_root_absolute` safety net after the branch that
+   normalizes ANY relative root against `$PWD` and falls back to `$PWD` when empty. Verified
+   non-regressing for: masked non-bare (the live case), genuine bare (local dev + CI), linked
+   worktree of a bare repo, and a normal unmasked clone (where `git -C .git is-bare` returns
+   `false`, so the misclassification never fires).
+
+2. **`verify_worktree_created` was SILENT to every sink.** The round-2 wedge could only be
+   diagnosed from the operator's pasted error — the failure printed `echo -e` colorized text
+   to stderr, invisible to the git-lock-marker telemetry scanner (stdout, server-side pino →
+   Better Stack). Every fatal exit now emits a bare-stdout `SOLEUR_GIT_WORKTREE_VERIFY_FAILED`
+   marker (`reason=path-mismatch|not-a-worktree|dir-not-created|unregistered|branch-missing`,
+   with `expected=` + `actual=` on the mismatch so the relative-vs-absolute shape is
+   self-diagnosable). Added to `git-lock-marker-telemetry.ts` `MARKER_RE`/`WEDGE_RE`; the
+   existing drift-guard test auto-collects every `echo "SOLEUR_*` sentinel, so an un-mirrored
+   marker fails CI.
+
+## Rule of thumb
+
+When a fix for a mask-degraded value only moves the failure to the next consumer, stop
+patching consumers: normalize the value at its single point of origin. And any fatal exit on
+a non-inspectable surface (agent sandbox) must emit a monitored stdout marker — colorized
+stderr is invisible.

--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -99,6 +99,17 @@ else
   GIT_ROOT=$(git rev-parse --show-toplevel)
   # Check if we're in a worktree of a bare repo
   _common_dir=$(git rev-parse --git-common-dir 2>/dev/null)
+  # #5934 round-3: under the Concierge char-device config mask (and, benignly, at the
+  # toplevel of ANY normal clone) git returns the RELATIVE string ".git" for
+  # --git-common-dir. Left relative, the `*/.git` strip below cannot match (no slash) and
+  # GIT_ROOT collapses to the relative ".git" — which makes WORKTREE_DIR ".git/.worktrees"
+  # and detonates verify_worktree_created's absolute-vs-relative --show-toplevel compare
+  # ("Worktree path mismatch"). Resolve to ABSOLUTE here, BEFORE the strip, so the strip
+  # yields the true absolute workspace ROOT (sibling .worktrees) rather than a path buried
+  # inside .git.
+  if [[ -n "$_common_dir" && "$_common_dir" != /* ]]; then
+    _common_dir="$(cd "$_common_dir" 2>/dev/null && pwd)" || _common_dir=""
+  fi
   if [[ -n "$_common_dir" ]] && git -C "$_common_dir" rev-parse --is-bare-repository 2>/dev/null | grep -q true; then
     IS_BARE=true
     # GIT_ROOT should point to the bare repo, not the worktree
@@ -109,6 +120,22 @@ else
     fi
   fi
 fi
+# #5934 round-3 defense-in-depth: GIT_ROOT MUST be absolute before it feeds WORKTREE_DIR
+# (and every other consumer: ensure_bare_config, copy_env_files, verify_worktree_created).
+# Any branch above can hand back a RELATIVE root (mask-degraded --show-toplevel /
+# --git-common-dir) or an EMPTY one; a relative WORKTREE_DIR then mismatches git's absolute
+# --show-toplevel in verify. Normalize a relative root against $PWD (create runs from the
+# workspace root); if it resolves empty, fall back to $PWD when that IS a real checkout. A
+# no-op for an already-absolute root (the common, healthy case).
+ensure_git_root_absolute() {
+  if [[ -n "$GIT_ROOT" && "$GIT_ROOT" != /* ]]; then
+    GIT_ROOT="$(cd "$GIT_ROOT" 2>/dev/null && pwd)" || GIT_ROOT=""
+  fi
+  if [[ -z "$GIT_ROOT" && -d "$PWD/.git" ]]; then
+    GIT_ROOT="$PWD"
+  fi
+}
+ensure_git_root_absolute
 WORKTREE_DIR="$GIT_ROOT/.worktrees"
 
 # Exit with error if running at the bare repo root (no working tree available).
@@ -644,6 +671,10 @@ verify_worktree_created() {
 
   # Check 0: Fast-fail if directory was not created at all
   if [[ ! -d "$worktree_path" ]]; then
+    # Bare stdout marker (D1a) so this failure reaches the git-lock-marker telemetry scanner
+    # — verify_worktree_created was SILENT to every sink before #5934 round-3, so the round-2
+    # relative-GIT_ROOT path-mismatch could only be diagnosed from an operator paste.
+    echo "SOLEUR_GIT_WORKTREE_VERIFY_FAILED reason=dir-not-created branch=$branch_name expected=$worktree_path"
     echo -e "${RED}Error: Worktree directory not created at $worktree_path${NC}"
     echo -e "${YELLOW}Hint: Try 'git worktree add $worktree_path -b $branch_name $from_branch' directly${NC}"
     exit 1
@@ -652,12 +683,17 @@ verify_worktree_created() {
   # Check 1: Verify the directory is a valid git worktree
   local actual_toplevel
   if ! actual_toplevel=$(git -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null); then
+    echo "SOLEUR_GIT_WORKTREE_VERIFY_FAILED reason=not-a-worktree branch=$branch_name expected=$worktree_path"
     echo -e "${RED}Error: Worktree creation failed — $worktree_path is not a valid git worktree${NC}"
     echo -e "${YELLOW}Hint: Try 'git worktree add $worktree_path -b $branch_name $from_branch' directly${NC}"
     git worktree remove "$worktree_path" --force 2>/dev/null || rm -rf "$worktree_path" 2>/dev/null || true
     exit 1
   fi
   if [[ "$actual_toplevel" != "$worktree_path" ]]; then
+    # The #5934 round-2 LIVE failure: a RELATIVE GIT_ROOT (".git") made WORKTREE_DIR relative,
+    # so the expected path is a relative string while git reports the same location ABSOLUTE.
+    # Emit both so the relative-vs-absolute mismatch is self-diagnosable from telemetry.
+    echo "SOLEUR_GIT_WORKTREE_VERIFY_FAILED reason=path-mismatch branch=$branch_name expected=$worktree_path actual=$actual_toplevel"
     echo -e "${RED}Error: Worktree path mismatch — expected $worktree_path, got $actual_toplevel${NC}"
     git worktree remove "$worktree_path" --force 2>/dev/null || rm -rf "$worktree_path" 2>/dev/null || true
     exit 1
@@ -668,6 +704,7 @@ verify_worktree_created() {
     echo -e "${YELLOW}Warning: Worktree not in git worktree list — attempting repair...${NC}"
     git worktree repair "$worktree_path" 2>/dev/null || true
     if ! git worktree list --porcelain | grep -qxF "worktree $worktree_path"; then
+      echo "SOLEUR_GIT_WORKTREE_VERIFY_FAILED reason=unregistered branch=$branch_name expected=$worktree_path"
       echo -e "${RED}Error: Worktree directory exists but is not registered after repair${NC}"
       git worktree remove "$worktree_path" --force 2>/dev/null || rm -rf "$worktree_path" 2>/dev/null || true
       exit 1
@@ -677,6 +714,7 @@ verify_worktree_created() {
 
   # Check 3: Verify the branch was actually created
   if ! git show-ref --verify --quiet "refs/heads/$branch_name"; then
+    echo "SOLEUR_GIT_WORKTREE_VERIFY_FAILED reason=branch-missing branch=$branch_name expected=$worktree_path"
     echo -e "${RED}Error: Branch $branch_name was not created despite successful worktree add${NC}"
     echo -e "${YELLOW}Hint: Try 'git worktree add $worktree_path -b $branch_name $from_branch' directly${NC}"
     git worktree remove "$worktree_path" --force 2>/dev/null || rm -rf "$worktree_path" 2>/dev/null || true

--- a/plugins/soleur/test/worktree-manager-atomic-config.test.sh
+++ b/plugins/soleur/test/worktree-manager-atomic-config.test.sh
@@ -626,5 +626,73 @@ fi
 assert_eq "__ABSENT__" "$(git config --file "$WS25/.git/config" --get extensions.worktreeConfig 2>/dev/null || echo __ABSENT__)" \
   "extensions.worktreeConfig NOT set (surgery correctly skipped on the relative-GIT_ROOT non-bare clone)"
 
+# ---------------------------------------------------------------------------
+echo "Test 25: #5934 round-3 SOURCE fix — ensure_git_root_absolute normalizes a RELATIVE/EMPTY GIT_ROOT"
+# The live round-2 wedge (post the merged-2026-07-07 non-bare-skip fix): the mask left GIT_ROOT
+# the RELATIVE string ".git", so WORKTREE_DIR became ".git/.worktrees" and verify_worktree_created
+# threw "Worktree path mismatch" (relative expected vs git's absolute --show-toplevel). Rather than
+# patch each downstream victim, the round-3 fix normalizes GIT_ROOT to ABSOLUTE ONCE at init via
+# ensure_git_root_absolute. RED (pre-fix): the helper does not exist.
+if declare -F ensure_git_root_absolute >/dev/null; then
+  WS_ABS=$(cd "$(mktemp -d "$TMP/absroot.XXXXXX")" && pwd -P); git init -q -b main "$WS_ABS" >/dev/null 2>&1
+  _SAVED_GIT_ROOT="$GIT_ROOT"; _SAVED_PWD="$PWD"
+  # (a) the operator's exact value: a relative ".git" resolves against $PWD to the absolute path.
+  cd "$WS_ABS"; GIT_ROOT=".git"; ensure_git_root_absolute
+  assert_eq "$WS_ABS/.git" "$GIT_ROOT" "relative '.git' GIT_ROOT normalized to an absolute path"
+  # (b) an EMPTY GIT_ROOT (the other mask degradation) falls back to $PWD when $PWD/.git is real.
+  GIT_ROOT=""; ensure_git_root_absolute
+  assert_eq "$WS_ABS" "$GIT_ROOT" "empty GIT_ROOT falls back to \$PWD when \$PWD/.git exists"
+  # (c) an already-absolute GIT_ROOT is left untouched (no-op on the healthy path — no regression).
+  GIT_ROOT="$WS_ABS"; ensure_git_root_absolute
+  assert_eq "$WS_ABS" "$GIT_ROOT" "already-absolute GIT_ROOT left untouched (healthy no-op)"
+  GIT_ROOT="$_SAVED_GIT_ROOT"; cd "$_SAVED_PWD"
+else
+  echo "  FAIL: ensure_git_root_absolute not defined — the round-3 SOURCE fix is missing (pre-fix RED)"; FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo "Test 26: #5934 round-3 — verify_worktree_created: RELATIVE path REJECTED + new marker; ABSOLUTE GREEN"
+# End-to-end proof of the round-2 symptom and its fix, at the exact compare that emitted the
+# operator's error. A REAL worktree is created at a sibling .worktrees/<name>; git reports it
+# ABSOLUTE. GREEN first (non-destructive): the absolute expected path — what the normalized
+# GIT_ROOT now yields — verifies clean with NO failure marker. Then RED: the relative expected
+# path (the shape a relative WORKTREE_DIR produced) mismatches git's absolute --show-toplevel,
+# rejects with exit 1, and — the observability gap this PR closes — emits the previously-SILENT
+# SOLEUR_GIT_WORKTREE_VERIFY_FAILED marker carrying BOTH paths. (RED destroys the worktree via
+# the branch's cleanup remove, so it runs last.)
+MAIN26=$(cd "$(mktemp -d "$TMP/verify26.XXXXXX")" && pwd -P); git init -q -b main "$MAIN26" >/dev/null 2>&1
+git -C "$MAIN26" -c user.email=t@t.local -c user.name=t commit -q --allow-empty -m init >/dev/null 2>&1
+_SAVED_PWD="$PWD"; cd "$MAIN26"
+git worktree add -q ".worktrees/feat-26" -b feat-26 >/dev/null 2>&1
+# GREEN — absolute expected path verifies clean.
+set +e
+( verify_worktree_created "$MAIN26/.worktrees/feat-26" "feat-26" "main" ) >"$TMP/vwc26_green.out" 2>&1
+VWC26_GREEN_RC=$?
+set -e
+assert_eq "0" "$VWC26_GREEN_RC" "absolute worktree_path verifies clean (rc 0) — the normalized-GIT_ROOT outcome"
+if grep -qF 'SOLEUR_GIT_WORKTREE_VERIFY_FAILED' "$TMP/vwc26_green.out"; then
+  echo "  FAIL: healthy verify must emit NO failure marker"; FAIL=$((FAIL + 1))
+else
+  echo "  PASS: healthy (absolute) verify emitted no failure marker"; PASS=$((PASS + 1))
+fi
+# RED — relative expected path mismatches git's absolute actual (destructive on the mismatch branch).
+set +e
+( verify_worktree_created ".worktrees/feat-26" "feat-26" "main" ) >"$TMP/vwc26_red.out" 2>&1
+VWC26_RED_RC=$?
+set -e
+if (( VWC26_RED_RC != 0 )); then echo "  PASS: relative worktree_path REJECTED (rc!=0) — the round-2 symptom reproduced"; PASS=$((PASS + 1));
+else echo "  FAIL: relative worktree_path must be rejected (rc!=0)"; FAIL=$((FAIL + 1)); fi
+if grep -qF 'Worktree path mismatch' "$TMP/vwc26_red.out"; then
+  echo "  PASS: emitted the 'Worktree path mismatch' error"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: expected the 'Worktree path mismatch' error on the relative path"; FAIL=$((FAIL + 1))
+fi
+if grep -qE '^SOLEUR_GIT_WORKTREE_VERIFY_FAILED reason=path-mismatch .*expected=\.worktrees/feat-26 actual=/' "$TMP/vwc26_red.out"; then
+  echo "  PASS: SOLEUR_GIT_WORKTREE_VERIFY_FAILED path-mismatch marker emitted (relative expected + absolute actual)"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: expected the SOLEUR_GIT_WORKTREE_VERIFY_FAILED path-mismatch marker (observability gap not closed)"; FAIL=$((FAIL + 1))
+fi
+cd "$_SAVED_PWD"
+
 echo ""
 print_results


### PR DESCRIPTION
## Root cause (round 3 on #5934)

The Concierge workspace is a **non-bare** clone whose `.git/config` family is masked by a char-device / bind-mount in the agent sandbox. Under that mask git's plumbing degrades: `git rev-parse --git-common-dir` returns the **relative** string `.git`, and `git -C .git rev-parse --is-bare-repository` falsely reports `true`.

The merged-2026-07-07 non-bare-skip fix (**#6206**) made `ensure_bare_config` correctly SKIP its bare surgery — but the failure just moved **downstream** to the next consumer of the same corrupted value:

- init set `GIT_ROOT="$_common_dir"` = the relative `.git` (the `*/.git` strip can't match a slash-less string)
- so `WORKTREE_DIR=".git/.worktrees"` (relative)
- `git worktree add` succeeds, but `verify_worktree_created` compares the **relative** expected path against git's **absolute** `--show-toplevel` and dies:
  `Worktree path mismatch — expected .git/.worktrees/feat-…, got /workspaces/…/.git/.worktrees/feat-…`

Same location, relative-vs-absolute — a pure path-normalization bug.

## Fix — patch the SOURCE, not each victim

The relative `GIT_ROOT` corruption has multiple downstream victims (`ensure_bare_config` in round 2, `WORKTREE_DIR` + `verify_worktree_created` in round 3). Normalize the value **once at its origin**:

1. Resolve `_common_dir` to **absolute before** the `*/.git` strip, so the strip yields the true workspace **ROOT** (sibling `.worktrees`, not a path buried inside `.git`).
2. Add `ensure_git_root_absolute` after the init branch: normalize any relative `GIT_ROOT` against `$PWD`, fall back to `$PWD` when empty. A no-op on an already-absolute root.

Verified non-regressing for: masked non-bare (the live case), genuine bare (local dev + CI), linked worktree of a bare repo, and a normal unmasked clone (`git -C .git is-bare` returns `false` there, so the misclassification never fires).

## Observability

`verify_worktree_created` was **silent to every sink** — the round-2 wedge could only be diagnosed from the operator's paste. Every fatal exit now emits a monitored bare-stdout `SOLEUR_GIT_WORKTREE_VERIFY_FAILED` marker (`reason=path-mismatch|not-a-worktree|dir-not-created|unregistered|branch-missing`, with `expected=`/`actual=` on the mismatch). Added to `git-lock-marker-telemetry.ts` `MARKER_RE`/`WEDGE_RE`; the drift-guard test auto-collects every `echo "SOLEUR_*` sentinel so an un-mirrored marker fails CI.

## Tests (RED→GREEN)

`plugins/soleur/test/worktree-manager-atomic-config.test.sh`:
- **T25** — `ensure_git_root_absolute` normalizes relative `.git`, empty→`$PWD`, and leaves an absolute root untouched. RED pre-fix (helper undefined).
- **T26** — `verify_worktree_created` rejects a relative path + emits the new marker (RED), verifies clean on the absolute path (GREEN). RED pre-fix (marker absent).

Confirmed: 2 failures on pre-fix `worktree-manager.sh`, 0 after. Full suite green — scripts shard 154/154, webplat 12106 passed / 0 failed, `tsc --noEmit` clean, 0 new shellcheck findings.

Ref #5934
Ref #6191