### PR TITLE
fix(infra): zot capacity management — retention + grow volume 10→30 GB + disk-full alerting (#6122)

### DIFF
--- a/apps/web-platform/infra/cloud-init-registry.yml
+++ b/apps/web-platform/infra/cloud-init-registry.yml
@@ -108,6 +108,27 @@ write_files:
     owner: root:root
     permissions: '0644'
 
+  # Disk-capacity guard (#6122 follow-up): ping the disk-health heartbeat ONLY while /var/lib/zot
+  # is under 85% used. A filling store (or a down host / broken cron) stops the ping → Better Stack
+  # alerts BEFORE full, no SSH/df/dashboard (hr-no-dashboard-eyeball-pull-data-yourself). ${disk_heartbeat_url}
+  # is terraform-interpolated; $USE stays literal (templatefile only expands ${...}, not $VAR).
+  - path: /usr/local/bin/zot-disk-heartbeat.sh
+    content: |
+      #!/usr/bin/env bash
+      set -u
+      USE=$(df --output=pcent /var/lib/zot 2>/dev/null | tail -1 | tr -dc '0-9')
+      [ -n "$USE" ] || exit 0
+      [ "$USE" -lt 85 ] && curl -fsS -m 10 "${disk_heartbeat_url}" >/dev/null 2>&1 || true
+    owner: root:root
+    permissions: '0755'
+
+  - path: /etc/cron.d/zot-disk-heartbeat
+    content: |
+      # Emit the zot disk-health heartbeat every 5 min if /var/lib/zot has headroom (#6122 follow-up).
+      */5 * * * * root /usr/local/bin/zot-disk-heartbeat.sh
+    owner: root:root
+    permissions: '0644'
+
 runcmd:
   # Apply SSH hardening immediately.
   - systemctl restart sshd
@@ -197,3 +218,8 @@ runcmd:
       sleep 2
     done
     ZOTEOF
+
+  # Disk-capacity guard: ensure cron is active and emit the first disk heartbeat now that zot is
+  # up, so Better Stack goes green within the redeploy (not after the first 5-min cron tick).
+  - systemctl enable --now cron || true
+  - bash /usr/local/bin/zot-disk-heartbeat.sh || true

--- a/apps/web-platform/infra/cloud-init-registry.yml
+++ b/apps/web-platform/infra/cloud-init-registry.yml
@@ -110,8 +110,9 @@ write_files:
 
   # Disk-capacity guard (#6122 follow-up): ping the disk-health heartbeat ONLY while /var/lib/zot
   # is under 85% used. A filling store (or a down host / broken cron) stops the ping → Better Stack
-  # alerts BEFORE full, no SSH/df/dashboard (hr-no-dashboard-eyeball-pull-data-yourself). ${disk_heartbeat_url}
-  # is terraform-interpolated; $USE stays literal (templatefile only expands ${...}, not $VAR).
+  # alerts BEFORE full, no SSH/df/dashboard (hr-no-dashboard-eyeball-pull-data-yourself). The
+  # disk_heartbeat_url below is terraform-interpolated; the bash $USE stays literal (templatefile
+  # only expands dollar-brace references, not plain dollar-VAR).
   - path: /usr/local/bin/zot-disk-heartbeat.sh
     content: |
       #!/usr/bin/env bash

--- a/apps/web-platform/infra/cloud-init-registry.yml
+++ b/apps/web-platform/infra/cloud-init-registry.yml
@@ -41,6 +41,18 @@ write_files:
   # htpasswd auth, deny-by-default accessControl (pull user = read; push user =
   # read/create/update). Usernames are terraform-interpolated (non-secret constants).
   #
+  # storage.retention (#6122 follow-up): gc alone only reclaims DANGLING blobs, not old
+  # TAGS — every dual-pushed release tag (v* + its 40-hex commit-sha) is retained forever,
+  # so the store grows unbounded with each deploy and the 10 GB volume fills (observed: the
+  # web-platform image is ~1.5-2 GB/version). This policy bounds it: keep `latest`, the 10
+  # most-recently-pushed v* tags and 10 most-recent commit-sha tags per repo, and ALWAYS keep
+  # every `sha256-*` tag (the cosign .sig/.att triangulation tags — deleting them would break
+  # deploy-time `cosign verify`, which fetches the signature by tag from the SAME registry it
+  # pulls the image; see ADR-087). Non-matching tags are pruned; deleteUntagged + gc then
+  # reclaim their layers after `delay`. deleteReferrers=false: cosign here uses TAG-based sigs
+  # (kept above), not Subject-field OCI referrers, so leave Subject referrers untouched.
+  # dryRun=false: prune for real. Schema: project-zot examples/README.md (retention).
+  #
   # http.compat ["docker2s2"] (#6122): zot is OCI-native and REJECTS Docker manifest
   # schema2 pushes (application/vnd.docker.distribution.manifest.v2+json) with
   # MANIFEST_INVALID unless this compat flag is set. The inngest-bootstrap image is built by
@@ -55,7 +67,24 @@ write_files:
           "dedupe": true,
           "gc": true,
           "gcDelay": "1h",
-          "gcInterval": "24h"
+          "gcInterval": "24h",
+          "retention": {
+            "dryRun": false,
+            "delay": "24h",
+            "policies": [
+              {
+                "repositories": ["**"],
+                "deleteReferrers": false,
+                "deleteUntagged": true,
+                "keepTags": [
+                  { "patterns": ["latest"] },
+                  { "patterns": ["sha256-.*"] },
+                  { "patterns": ["v.*"], "mostRecentlyPushedCount": 10 },
+                  { "patterns": ["[0-9a-f]{7,64}"], "mostRecentlyPushedCount": 10 }
+                ]
+              }
+            ]
+          }
         },
         "http": {
           "address": "0.0.0.0",
@@ -88,6 +117,11 @@ runcmd:
   # and the volume mountpoint is root-owned, so no chown/chmod is needed.
   - mkdir -p /var/lib/zot
   - mount /dev/disk/by-id/scsi-0HC_Volume_${registry_volume_id} /var/lib/zot || true
+  # Grow the ext4 fs to fill the (possibly-enlarged) block device. A Hetzner volume resize
+  # (var.registry_volume_size bump) enlarges the DEVICE in place, but the pre-formatted ext4
+  # keeps its old size until resize2fs. Online-resize the mounted fs on every boot; it is a
+  # no-op when already at full size, so it is safe on an unchanged volume too (#6122 follow-up).
+  - resize2fs /dev/disk/by-id/scsi-0HC_Volume_${registry_volume_id} || true
   - echo '/dev/disk/by-id/scsi-0HC_Volume_${registry_volume_id} /var/lib/zot ext4 defaults,nofail 0 2' >> /etc/fstab
 
   # --- Doppler CLI (${doppler_arch}) — the ONLY channel for the ZOT_* tokens ------------

--- a/apps/web-platform/infra/variables.tf
+++ b/apps/web-platform/infra/variables.tf
@@ -124,9 +124,9 @@ variable "registry_server_type" {
 }
 
 variable "registry_volume_size" {
-  description = "Size of the zot storage block volume in GB (Hetzner minimum is 10 GB), mounted at /var/lib/zot. Holds the OCI blobs for both platform images + backfilled release tags + cosign .sig referrers — never tmpfs (reboot-durable; a wiped registry breaks cold-boot pulls). dedupe is on, so 10 GB is ample for two small images."
+  description = "Size of the zot storage block volume in GB (Hetzner minimum is 10 GB), mounted at /var/lib/zot. Holds the OCI blobs for both platform images + backfilled release tags + cosign .sig referrers — never tmpfs (reboot-durable; a wiped registry breaks cold-boot pulls). The web-platform image is ~1.5-2 GB/version and dedupe shares little across versions, so 10 GB filled at ~3 retained versions (#6122); 30 GB holds the storage.retention keep-set (10 v* + 10 sha + latest + sigs) with headroom. A bump resizes the volume in place (data survives); cloud-init-registry.yml resize2fs grows the fs on the next immutable redeploy."
   type        = number
-  default     = 10
+  default     = 30
 }
 
 # --- Epic #5274 Phase 3, Sub-PR 3.D (ADR-068) — LUKS-at-rest cutover volume ---

--- a/apps/web-platform/infra/zot-registry.tf
+++ b/apps/web-platform/infra/zot-registry.tf
@@ -217,6 +217,11 @@ resource "hcloud_server" "registry" {
     # Host arch (arm64/amd64) → the matching Doppler CLI release build + its checksum.
     doppler_arch   = local.registry_arch
     doppler_sha256 = local.doppler_sha256
+    # Disk-health heartbeat: the host pings this ONLY while /var/lib/zot is under 85% used, so
+    # a filling store (or a down host / broken cron) alerts via Better Stack absence — no SSH,
+    # no dashboard-eyeballing (hr-no-dashboard-eyeball-pull-data-yourself). Not a secret (a bare
+    # ping URL); baked into user_data like zot_image, retrievable via the hcloud metadata API.
+    disk_heartbeat_url = betteruptime_heartbeat.registry_disk_prd.url
   }))
 
   # Deliberately NO lifecycle.ignore_changes=[user_data]. A FRESH host has no spurious diff,
@@ -305,4 +310,33 @@ resource "doppler_secret" "zot_heartbeat_url_prd" {
   name       = "ZOT_HEARTBEAT_URL"
   value      = betteruptime_heartbeat.registry_prd.url
   visibility = "masked"
+}
+
+# --- Disk-capacity guard (#6122 follow-up) --------------------------------------------------
+# A SECOND heartbeat, distinct from the liveness beat above: the registry host's cron pings it
+# only while /var/lib/zot is < 85% used (cloud-init-registry.yml). A store that grows toward full
+# — the failure that #6122 hit (100% → all pushes 500 'no space left on device') — silently stops
+# the ping, and Better Stack alerts BEFORE the disk is full, without any SSH/df or dashboard poll
+# (hr-no-dashboard-eyeball-pull-data-yourself). Pairs with storage.retention (growth cap) + the
+# 30 GB volume (headroom): retention bounds growth, this catches it if bounding ever regresses.
+# period 900s / grace 600s: disk fills slowly, and 600s of grace covers the redeploy boot gap so
+# paused=false is safe (no operator UI unpause needed — the cron pings within cloud-init).
+resource "betteruptime_heartbeat" "registry_disk_prd" {
+  name       = "soleur-registry-disk-prd"
+  period     = 900
+  grace      = 600
+  call       = false
+  sms        = false
+  email      = true
+  push       = false
+  team_wait  = 0
+  team_name  = "Your team"
+  policy_id  = var.betterstack_paid_tier ? betteruptime_policy.inngest[0].id : null
+  paused     = false
+  sort_index = 0
+
+  lifecycle {
+    # Operator UI pause (e.g. during a planned volume resize) must survive subsequent applies.
+    ignore_changes = [paused]
+  }
 }

--- a/plugins/soleur/test/terraform-target-parity.test.ts
+++ b/plugins/soleur/test/terraform-target-parity.test.ts
@@ -551,6 +551,7 @@ const OPERATOR_APPLIED_EXCLUSIONS = new Set<string>([
   "doppler_secret.zot_push_user",
   "doppler_secret.zot_push_token",
   "betteruptime_heartbeat.registry_prd",
+  "betteruptime_heartbeat.registry_disk_prd",
   "doppler_secret.zot_heartbeat_url_prd",
   "doppler_service_token.registry",
   // #6122 (ADR-096) — the CI-push ingress (CTO ruling 2026-07-06): CI reaches the private-net


### PR DESCRIPTION
## Why

The self-hosted zot store filled to **100% (9.5 / 9.8 GB)** and returned `500` on every web-image push (`no space left on device`). Three gaps, three fixes:

## 1. Retention policy (don't grow unbounded)

`gc` only reclaims *dangling blobs*, never old **tags** — every dual-pushed release (`v*` + its commit-sha) was kept forever. Added `storage.retention`: keep `latest`, the **10 most-recently-pushed `v*` + 10 most-recent commit-sha** tags per repo, and **always** keep every `sha256-*` tag (the cosign `.sig`/`.att` triangulation tags — deleting them breaks deploy-time `cosign verify`; ADR-087). `deleteUntagged` + `gc` reclaim pruned layers after 24h. `deleteReferrers: false`.

## 2. Grow the volume (headroom)

`registry_volume_size` 10 → 30 GB (the web image is ~1.5–2 GB/version; dedupe shares little across versions). Plus an online `resize2fs` in cloud-init so the enlarged volume's ext4 actually expands (the volume resizes in place; data survives). Cost: **+~€0.9/mo** Hetzner block storage.

## 3. Disk-full alerting (catch it before it fills)

A second Better Stack heartbeat (`registry_disk_prd`) + a registry-host cron that pings it **only while `/var/lib/zot` is <85% used**. A filling store (or down host / broken cron) stops the ping → Better Stack alerts **before** the disk is full — no SSH, no `df`, no dashboard-eyeballing (`hr-no-dashboard-eyeball-pull-data-yourself`). `paused=false` with 600s grace covers the redeploy boot gap, so no operator UI unpause is needed.

Retention bounds growth; the alert catches it if bounding ever regresses; the volume buys headroom.

## Rollout / caveats

- Takes effect on the **next immutable-redeploy** of the registry host (`hr-prod-host-config-change-immutable-redeploy`, from #6207). The volume resizes in place; cloud-init `resize2fs` grows the fs.
- Does **not** retroactively free the currently-full disk — the immediate reclaim is deleting the one-off **4.7 GB bare `soleur-web-platform` duplicate** (mis-namespaced early backfill; verified unreferenced in-repo), handled as a separate ops action.

Ref #6122

🤖 Generated with [Claude Code](https://claude.com/claude-code)