### PR TITLE
fix(infra): doppler_project.inngest description ≤255 chars — unblock inngest-host provisioning (#6178)

### DIFF
--- a/apps/web-platform/infra/inngest-host.tf
+++ b/apps/web-platform/infra/inngest-host.tf
@@ -78,8 +78,9 @@ resource "random_password" "inngest_redis_password_dedicated" {
 # the project once via the dashboard (New PROJECT `soleur-inngest` — NOT a config under
 # `prd`), TF then managing only the secrets + token inside it.
 resource "doppler_project" "inngest" {
-  name        = "soleur-inngest"
-  description = "Isolated boot-credential project for the dedicated single-host Inngest singleton (#6178, ADR-100) — its `prd` root config holds ONLY the inngest secret set (signing/event keys, Redis password, and the out-of-band Postgres URI); cross-project isolation from soleur/prd (no shared root-secret resolution path, unlike a `prd` branch config; #6122 precedent)."
+  name = "soleur-inngest"
+  # Doppler caps description at 255 chars — keep concise; full rationale is in the comments above.
+  description = "Isolated boot-credential project for the dedicated Inngest singleton (#6178, ADR-100). Its prd root config holds ONLY the inngest secret set (signing/event keys, Redis password, out-of-band Postgres URI); cross-project isolation from soleur/prd."
 }
 
 # A TF-created doppler_project is created BARE — no default dev/stg/prd configs that the


### PR DESCRIPTION
## Summary

Unblock the `apply_target=inngest-host` provisioning dispatch. `doppler_project.inngest`'s
`description` was 355 chars, exceeding Doppler's **255-char hard limit**, so `terraform apply`
failed (`Doppler Error: "description" length must be less than or equal to 255 characters`,
inngest-host.tf). Shortened to 245 chars; the full rationale already lives in the adjacent `#`
comments. `terraform validate`/`fmt` do not enforce provider field-length constraints — only a
live apply surfaces it (caught when the Phase-2 host-provisioning dispatch failed).

Ref #6178

## Changelog

- fix(infra): shorten `doppler_project.inngest` description to ≤255 chars so the dedicated
  Inngest host provisioning apply (ADR-100, #6178) no longer fails on Doppler's length limit.

## User-Brand Impact

- **Artifact touched:** dedicated Inngest control-plane provisioning (Terraform).
- **Failure vector:** the over-long description hard-fails the provisioning apply, blocking the
  dedicated scheduler from coming up at all; this fix removes that blocker (a mis/never-provisioned
  scheduler risks duplicate reminders for a user once cut over).
- **Brand-survival threshold:** single-user incident

## Test plan

- [x] Doppler `description` length asserted ≤255 (245 chars)
- [x] `terraform fmt` clean
- [x] Re-provision dispatch will complete the additive host set (idempotent partial state from the failed apply: firewall/volume/keys)

Generated with [Claude Code](https://claude.com/claude-code)
