### PR TITLE
fix(web): rectangular tour spotlight + KB tab highlights sidebar before opening

### DIFF
--- a/apps/web-platform/components/tour/guided-tour.tsx
+++ b/apps/web-platform/components/tour/guided-tour.tsx
@@ -262,10 +262,12 @@ export function GuidedTour({
         <div className="absolute inset-0 bg-black/60" aria-hidden="true" />
       ) : (
         // Single-element spotlight: a transparent hole with a viewport-filling
-        // dark box-shadow. rgba (not hex) satisfies no-raw-hex.
+        // dark box-shadow. rgba (not hex) satisfies no-raw-hex. A modest corner
+        // radius keeps the cutout a rectangle that traces the target — never a
+        // `rounded-full` pill/oval, which balloons on large targets (the KB tree).
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute rounded-full ring-2 ring-soleur-accent-gold-fill transition-all duration-200 motion-reduce:transition-none"
+          className="pointer-events-none absolute rounded-lg ring-2 ring-soleur-accent-gold-fill transition-all duration-200 motion-reduce:transition-none"
           style={{
             top: rect.top - PAD,
             left: rect.left - PAD,

--- a/apps/web-platform/components/tour/tour-steps.ts
+++ b/apps/web-platform/components/tour/tour-steps.ts
@@ -8,7 +8,9 @@
 // tab, the action step then spotlights the control. The overlay polls for the
 // `data-tour-id` target to mount after navigation (centered-card fallback if it
 // never appears, e.g. an empty/loading surface). Releases and Settings are
-// tab-only (no in-page action). Welcome (first) + closing (last) have no target.
+// tab-only (no in-page action). The Knowledge Base tab step is the one exception
+// that carries NO `route` (see its note below). Welcome (first) + closing (last)
+// have no target.
 
 export interface TourStep {
   /** `data-tour-id` selector value, or null for a centered (no-spotlight) card. */
@@ -78,17 +80,20 @@ export const TOUR_STEPS: readonly TourStep[] = [
   },
 
   // ── Knowledge Base ────────────────────────────────────────────────────────────
+  // Special case: opening the KB SWAPS the sidebar rail for its file tree, so the
+  // "Knowledge Base" nav tab only exists while you're OUTSIDE the KB. This tab step
+  // therefore has NO `route` — it highlights the sidebar button from the previous
+  // section's page (Workstream); the NEXT (content) step is what navigates in.
   {
     target: "/dashboard/kb",
-    route: "/dashboard/kb",
-    title: "Open the Knowledge Base",
-    body: "Click the Knowledge Base tab to reach your organization's shared memory.",
+    title: "Find the Knowledge Base",
+    body: "This tab in the sidebar opens your organization's shared memory — click it to go in.",
   },
   {
     target: "action:kb-tree",
     route: "/dashboard/kb",
     title: "Feed the Knowledge Base",
-    body: "Browse the tree and drop in docs and context every agent draws on to act for you.",
+    body: "Here's the KB — browse the tree and drop in the docs and context every agent draws on to act for you.",
   },
 
   // ── Routines ──────────────────────────────────────────────────────────────────

--- a/apps/web-platform/test/components/tour/tour-provider.test.tsx
+++ b/apps/web-platform/test/components/tour/tour-provider.test.tsx
@@ -144,6 +144,19 @@ describe("TourProvider", () => {
     expect(routerPush).toHaveBeenCalledWith("/dashboard/inbox");
   });
 
+  it("does NOT navigate on the Knowledge Base TAB step — the rail is swapped once inside, so the tab is highlighted from the prior page; only the next (content) step opens the KB", () => {
+    onb.tourCompletedAt = "x"; // suppress auto-start; drive manually
+    renderProvider();
+    fireEvent.click(screen.getByText("start")); // step 0 Welcome
+    // Advance to step 7 (Workstream action) — the step just before the KB tab.
+    for (let i = 0; i < 7; i++) fireEvent.click(screen.getByText("next"));
+    routerPush.mockClear();
+    fireEvent.click(screen.getByText("next")); // step 8 KB tab (no route)
+    expect(routerPush).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByText("next")); // step 9 KB content → opens the KB
+    expect(routerPush).toHaveBeenCalledWith("/dashboard/kb");
+  });
+
   it("Finish persists completion via POST /api/tour/complete", () => {
     onb.tourCompletedAt = "x"; // suppress auto-start; drive manually
     renderProvider();


### PR DESCRIPTION
Two guided-tour polish fixes from live-browser feedback.

## 1. Spotlight shape — rectangle, not a circle
The spotlight cutout used `rounded-full`, which renders as a huge oval/circle on large targets (most visible on the KB file tree — see the reported screenshot). Switched to `rounded-lg` so the spotlight traces the highlighted element as a tight rounded **rectangle**.

## 2. Knowledge Base tab step highlights the sidebar button *before* opening
Opening the KB **swaps the sidebar rail for its file tree**, so the "Knowledge Base" nav tab only exists while you're *outside* the KB. Previously the KB tab step carried `route: "/dashboard/kb"`, which navigated straight in — destroying the very tab it was trying to spotlight.

Now the KB **tab** step has no `route`: it highlights the sidebar button from the previous section's page (Workstream). The next **content** step keeps `route: "/dashboard/kb"` and is what actually opens the KB and spotlights the tree. This matches the requested flow: *show the sidebar button first, then open the KB on the next step.*

## Tests
- `npx vitest run test/components/tour` → 15 passed
- `npx tsc --noEmit` → clean
- Added a nav-provider test asserting the KB tab step does **not** navigate and the content step opens the KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)