### PR TITLE
feat(web): tour shows the conversation view + both New Issue options

### DIFF
--- a/apps/web-platform/components/chat/chat-surface.tsx
+++ b/apps/web-platform/components/chat/chat-surface.tsx
@@ -1073,7 +1073,10 @@ export function ChatSurface({
         </div>
       )}
 
-      <div className={`shrink-0 border-t border-soleur-border-default bg-soleur-bg-base py-3 ${inputPadX} ${isFull ? "safe-bottom md:px-6" : ""}`}>
+      <div
+        data-tour-id={isFull ? "action:conversation-composer" : undefined}
+        className={`shrink-0 border-t border-soleur-border-default bg-soleur-bg-base py-3 ${inputPadX} ${isFull ? "safe-bottom md:px-6" : ""}`}
+      >
         <div className={`relative min-w-0 ${widthWrapper}`}>
           <AtMentionDropdown
             query={atQuery}

--- a/apps/web-platform/components/tour/tour-provider.tsx
+++ b/apps/web-platform/components/tour/tour-provider.tsx
@@ -155,6 +155,26 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
     }
   }, [active, stepIndex, pathname, router]);
 
+  // Some steps reveal a component-owned modal (via a window event) so an in-modal
+  // control can be spotlit. Dispatch `{open:true}` on entering such a step and
+  // `{open:false}` when leaving to a step that doesn't share the same `reveal`
+  // (or when the tour ends). `revealRef` tracks what's currently open so moving
+  // between two steps that share a `reveal` doesn't close+reopen (flicker).
+  const revealRef = useRef<string | null>(null);
+  useEffect(() => {
+    const want = active ? (TOUR_STEPS[stepIndex]?.reveal ?? null) : null;
+    if (revealRef.current && revealRef.current !== want) {
+      window.dispatchEvent(
+        new CustomEvent(revealRef.current, { detail: { open: false } }),
+      );
+      revealRef.current = null;
+    }
+    if (want && revealRef.current !== want) {
+      window.dispatchEvent(new CustomEvent(want, { detail: { open: true } }));
+      revealRef.current = want;
+    }
+  }, [active, stepIndex]);
+
   const value: TourContextValue = {
     available: enabled,
     active,

--- a/apps/web-platform/components/tour/tour-steps.ts
+++ b/apps/web-platform/components/tour/tour-steps.ts
@@ -12,6 +12,8 @@
 // that carries NO `route` (see its note below). Welcome (first) + closing (last)
 // have no target.
 
+import { NEW_ISSUE_DIALOG_EVENT } from "@/components/workstream/new-issue-dialog-event";
+
 export interface TourStep {
   /** `data-tour-id` selector value, or null for a centered (no-spotlight) card. */
   target: string | null;
@@ -22,6 +24,13 @@ export interface TourStep {
    * `target` to mount after navigation. Omit only for the centered Welcome step.
    */
   route?: string;
+  /**
+   * Window event dispatched with `{ open: true }` when this step becomes active
+   * and `{ open: false }` when the tour leaves it (to a step that doesn't share
+   * the same `reveal`). Lets a step open a component-owned modal so its in-modal
+   * `target` can be spotlit (e.g. the New Issue dialog). Handled in TourProvider.
+   */
+  reveal?: string;
 }
 
 export const TOUR_STEPS: readonly TourStep[] = [
@@ -50,6 +59,12 @@ export const TOUR_STEPS: readonly TourStep[] = [
     title: "Meet your organization",
     body: "These are your agents — CTO, CFO, CPO, CRO and more. Click any leader to talk to them directly and hand off work by function.",
   },
+  {
+    target: "action:conversation-composer",
+    route: "/dashboard/chat/new",
+    title: "Inside a conversation",
+    body: "This is a conversation with your agents. Type here to reply or follow up — @-mention a leader to hand the thread to them.",
+  },
 
   // ── Inbox ───────────────────────────────────────────────────────────────────
   {
@@ -76,7 +91,24 @@ export const TOUR_STEPS: readonly TourStep[] = [
     target: "action:new-issue",
     route: "/dashboard/workstream",
     title: "Hand off work",
-    body: "Hit “+ New Issue” to hand your agents something to move forward.",
+    body: "Hit “+ New Issue” to hand your agents something to move forward. Let's open it.",
+  },
+  // These two steps open the New Issue dialog (via `reveal`) and spotlight the two
+  // ways to file work. Both carry the same `reveal` so the dialog stays open across
+  // them; leaving to the next (KB) step dispatches `{ open: false }` to close it.
+  {
+    target: "action:issue-create-manual",
+    route: "/dashboard/workstream",
+    reveal: NEW_ISSUE_DIALOG_EVENT,
+    title: "Write it yourself",
+    body: "Give the issue a title and description, then Create issue — it lands in your Backlog for an agent to pick up.",
+  },
+  {
+    target: "action:concierge-draft",
+    route: "/dashboard/workstream",
+    reveal: NEW_ISSUE_DIALOG_EVENT,
+    title: "Or let Concierge draft it",
+    body: "Prefer to describe the outcome? Concierge will draft and route the issue for you. This one's coming soon.",
   },
 
   // ── Knowledge Base ────────────────────────────────────────────────────────────

--- a/apps/web-platform/components/workstream/new-issue-dialog-event.ts
+++ b/apps/web-platform/components/workstream/new-issue-dialog-event.ts
@@ -1,0 +1,10 @@
+// Window event the guided tour dispatches to open/close the New Issue dialog so
+// its in-modal controls (manual "Create issue" + "Create with Concierge") can be
+// spotlit. Mirrors the RAIL_EXPAND_EVENT pattern: a component-owned piece of UI
+// exposes a window CustomEvent the tour can drive without importing its internals.
+// detail: { open: boolean }.
+export const NEW_ISSUE_DIALOG_EVENT = "soleur:new-issue-dialog";
+
+export interface NewIssueDialogEventDetail {
+  open: boolean;
+}

--- a/apps/web-platform/components/workstream/new-issue-dialog.tsx
+++ b/apps/web-platform/components/workstream/new-issue-dialog.tsx
@@ -98,6 +98,7 @@ export function NewIssueDialog({
           <input
             id="new-issue-title"
             ref={inputRef}
+            data-tour-id="action:issue-create-manual"
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
@@ -132,6 +133,7 @@ export function NewIssueDialog({
               silently no-op (CPO P0). Flip the flag + wire onClick to go live. */}
           <fieldset
             disabled={!CONCIERGE_ONLINE}
+            data-tour-id="action:concierge-draft"
             aria-describedby="concierge-offline-note"
             className="mb-4 rounded-md border border-dashed border-soleur-border-default bg-soleur-bg-surface-2/40 p-3 disabled:opacity-60"
           >

--- a/apps/web-platform/components/workstream/workstream-board.tsx
+++ b/apps/web-platform/components/workstream/workstream-board.tsx
@@ -37,6 +37,10 @@ import { FilterBar } from "./filter-bar";
 import { IssueColumn } from "./issue-column";
 import { IssueDetailSheet } from "./issue-detail-sheet";
 import { NewIssueDialog } from "./new-issue-dialog";
+import {
+  NEW_ISSUE_DIALOG_EVENT,
+  type NewIssueDialogEventDetail,
+} from "./new-issue-dialog-event";
 
 type IssuesResponse = { issues: WorkstreamIssue[] };
 
@@ -67,6 +71,18 @@ export function WorkstreamBoard() {
   const [search, setSearch] = useState("");
   const [filters, setFilters] = useState<WorkstreamFilters>(emptyFilters);
   const [newOpen, setNewOpen] = useState(false);
+
+  // The guided tour opens/closes the New Issue dialog to spotlight its in-modal
+  // controls. It drives us via a window event (same decoupled pattern as the rail
+  // expand) rather than importing board state — inert when no tour is running.
+  useEffect(() => {
+    function onTourToggle(e: Event) {
+      const detail = (e as CustomEvent<NewIssueDialogEventDetail>).detail;
+      setNewOpen(Boolean(detail?.open));
+    }
+    window.addEventListener(NEW_ISSUE_DIALOG_EVENT, onTourToggle);
+    return () => window.removeEventListener(NEW_ISSUE_DIALOG_EVENT, onTourToggle);
+  }, []);
 
   // Drawer is driven by LOCAL state (instant open/close). Hydrate from the
   // ?issue= param on mount (deep-link/reload support).

--- a/apps/web-platform/test/components/tour/tour-provider.test.tsx
+++ b/apps/web-platform/test/components/tour/tour-provider.test.tsx
@@ -130,7 +130,7 @@ describe("TourProvider", () => {
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 
-  it("navigates to an action step's route when advancing onto it", () => {
+  it("navigates to a step's route when advancing onto a different-route step", () => {
     onb.tourCompletedAt = "x"; // suppress auto-start; drive manually
     renderProvider();
     fireEvent.click(screen.getByText("start")); // step 0 Welcome (no route)
@@ -140,21 +140,44 @@ describe("TourProvider", () => {
     fireEvent.click(screen.getByText("next")); // step 2 start a conversation
     fireEvent.click(screen.getByText("next")); // step 3 org-panel
     expect(routerPush).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByText("next")); // step 4 Inbox tab → /dashboard/inbox
-    expect(routerPush).toHaveBeenCalledWith("/dashboard/inbox");
+    fireEvent.click(screen.getByText("next")); // step 4 Inside a conversation → /dashboard/chat/new
+    expect(routerPush).toHaveBeenCalledWith("/dashboard/chat/new");
   });
 
   it("does NOT navigate on the Knowledge Base TAB step — the rail is swapped once inside, so the tab is highlighted from the prior page; only the next (content) step opens the KB", () => {
     onb.tourCompletedAt = "x"; // suppress auto-start; drive manually
     renderProvider();
     fireEvent.click(screen.getByText("start")); // step 0 Welcome
-    // Advance to step 7 (Workstream action) — the step just before the KB tab.
-    for (let i = 0; i < 7; i++) fireEvent.click(screen.getByText("next"));
+    // Advance to step 10 (Concierge modal step) — the step just before the KB tab.
+    for (let i = 0; i < 10; i++) fireEvent.click(screen.getByText("next"));
     routerPush.mockClear();
-    fireEvent.click(screen.getByText("next")); // step 8 KB tab (no route)
+    fireEvent.click(screen.getByText("next")); // step 11 KB tab (no route)
     expect(routerPush).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByText("next")); // step 9 KB content → opens the KB
+    fireEvent.click(screen.getByText("next")); // step 12 KB content → opens the KB
     expect(routerPush).toHaveBeenCalledWith("/dashboard/kb");
+  });
+
+  it("opens the New Issue dialog on its modal steps and closes it on leave (reveal event, no flicker between the two)", () => {
+    onb.tourCompletedAt = "x"; // suppress auto-start; drive manually
+    const events: boolean[] = [];
+    const handler = (e: Event) =>
+      events.push((e as CustomEvent<{ open: boolean }>).detail.open);
+    window.addEventListener("soleur:new-issue-dialog", handler);
+    try {
+      renderProvider();
+      fireEvent.click(screen.getByText("start")); // step 0
+      // Steps 1-8 carry no `reveal` → nothing dispatched yet.
+      for (let i = 0; i < 8; i++) fireEvent.click(screen.getByText("next"));
+      expect(events).toEqual([]);
+      fireEvent.click(screen.getByText("next")); // step 9 manual create (reveal → open)
+      expect(events).toEqual([true]);
+      fireEvent.click(screen.getByText("next")); // step 10 concierge (same reveal → no re-dispatch)
+      expect(events).toEqual([true]);
+      fireEvent.click(screen.getByText("next")); // step 11 KB tab (no reveal → close)
+      expect(events).toEqual([true, false]);
+    } finally {
+      window.removeEventListener("soleur:new-issue-dialog", handler);
+    }
   });
 
   it("Finish persists completion via POST /api/tour/complete", () => {


### PR DESCRIPTION
Extends the guided tour with the elements you asked for. **Analytics was explicitly descoped** — it's admin-only (`/dashboard/admin/analytics`, rendered only for `isAdmin`), so a step there would dead-end (broken nav target + redirect) for every non-admin user.

## 1. Inside a conversation
New step navigates to the stable `/dashboard/chat/new` route and spotlights the **message composer**, so a newcomer sees where they reply and how to `@`-mention a leader to hand off the thread.

## 2. Workstream — "New issue" + "Draft with Concierge"
These two controls live **inside the New Issue modal**, not a visible menu — so the tour now opens that modal to show them:
- Added a `reveal` field to `TourStep`. The provider dispatches a window event (`NEW_ISSUE_DIALOG_EVENT`) to **open** the dialog on its modal steps and **close** it on leave. A `revealRef` prevents a close+reopen flicker between the two consecutive modal steps.
- The board listens for that event and toggles its own `newOpen` state — the same decoupled pattern the tour already uses for `RAIL_EXPAND_EVENT`, so nothing is imported across the boundary.
- Two steps spotlight the manual **title / Create issue** path and the **Create with Concierge** box. Per your call ("open modal, show both"), Concierge is included with copy noting it's coming soon (the `CONCIERGE_ONLINE` flag is currently off/disabled).
- Feasible because the tour overlay (`z-70`) sits **above** the modal (`z-50`), so the spotlight cuts a clean hole over the in-modal control.

Tour is now **18 steps**.

## Tests
- `vitest run test/components/tour test/components/workstream test/components/chat` → all green
- `tsc --noEmit` → clean
- Added a provider test asserting the reveal event opens on the modal steps, does **not** re-dispatch between the two (no flicker), and closes on leave. Updated the nav-advance + KB-tab tests for the new step indices.

## Note
Entering `/dashboard/chat/new` starts a chat session (creates an empty conversation row) each time the step is reached — acceptable for an onboarding tour, flagging it in case the empty rows are undesirable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)