### PR TITLE
feat(web): tour shows how to create a routine

### DIFF
--- a/apps/web-platform/components/routines/routine-draft-tab-event.ts
+++ b/apps/web-platform/components/routines/routine-draft-tab-event.ts
@@ -1,0 +1,10 @@
+// Window event the guided tour dispatches to switch the Routines surface to its
+// "Draft a routine with Concierge" tab so the creation composer can be spotlit.
+// Same decoupled pattern as NEW_ISSUE_DIALOG_EVENT / RAIL_EXPAND_EVENT: the tour
+// drives component-owned UI without importing its state. detail: { open: boolean }
+// — open → show the draft tab, close → return to the default Routines tab.
+export const ROUTINE_DRAFT_TAB_EVENT = "soleur:routine-draft-tab";
+
+export interface RoutineDraftTabEventDetail {
+  open: boolean;
+}

--- a/apps/web-platform/components/routines/routines-surface.tsx
+++ b/apps/web-platform/components/routines/routines-surface.tsx
@@ -15,6 +15,10 @@ import useSWR from "swr";
 
 import { ChatSurface } from "@/components/chat/chat-surface";
 import { swrKeys } from "@/lib/swr-config";
+import {
+  ROUTINE_DRAFT_TAB_EVENT,
+  type RoutineDraftTabEventDetail,
+} from "./routine-draft-tab-event";
 
 // Delay before the single post-trigger reconciliation refetch that swaps the
 // optimistic "running" row for the real terminal routine_runs row.
@@ -139,6 +143,21 @@ function StatusPill({ status }: { status: string }) {
 
 export function RoutinesSurface() {
   const [tab, setTab] = useState<"routines" | "runs" | "draft">("routines");
+
+  // The guided tour switches to the "Draft a routine" tab to spotlight the
+  // creation composer, then switches back on leave. Driven by a window event
+  // (same decoupled pattern as the rail expand / New Issue dialog) — inert when
+  // no tour is running.
+  useEffect(() => {
+    function onTourToggle(e: Event) {
+      const detail = (e as CustomEvent<RoutineDraftTabEventDetail>).detail;
+      setTab(detail?.open ? "draft" : "routines");
+    }
+    window.addEventListener(ROUTINE_DRAFT_TAB_EVENT, onTourToggle);
+    return () =>
+      window.removeEventListener(ROUTINE_DRAFT_TAB_EVENT, onTourToggle);
+  }, []);
+
   return (
     <div>
       <div
@@ -259,7 +278,7 @@ function DraftRoutineTab() {
           the PR; it goes live on merge + deploy.
         </p>
       </div>
-      <div className="min-h-0 flex-1">
+      <div className="min-h-0 flex-1" data-tour-id="action:draft-routine-composer">
         <ChatSurface
           variant="sidebar"
           conversationId="new"

--- a/apps/web-platform/components/tour/tour-steps.ts
+++ b/apps/web-platform/components/tour/tour-steps.ts
@@ -13,6 +13,7 @@
 // have no target.
 
 import { NEW_ISSUE_DIALOG_EVENT } from "@/components/workstream/new-issue-dialog-event";
+import { ROUTINE_DRAFT_TAB_EVENT } from "@/components/routines/routine-draft-tab-event";
 
 export interface TourStep {
   /** `data-tour-id` selector value, or null for a centered (no-spotlight) card. */
@@ -139,7 +140,16 @@ export const TOUR_STEPS: readonly TourStep[] = [
     target: "action:draft-routine",
     route: "/dashboard/routines",
     title: "Automate the recurring",
-    body: "Draft a routine with Concierge to run agent work every day, week, or month.",
+    body: "Open “Draft a routine with Concierge” to set up agent work that runs every day, week, or month.",
+  },
+  // Opens the "Draft a routine" tab (via `reveal`) and spotlights the Concierge
+  // composer; leaving to the next step dispatches `{ open: false }` to switch back.
+  {
+    target: "action:draft-routine-composer",
+    route: "/dashboard/routines",
+    reveal: ROUTINE_DRAFT_TAB_EVENT,
+    title: "Create a routine",
+    body: "Describe the recurring work in plain language. The Concierge drafts and tests the routine, then opens a PR you approve — it goes live on merge.",
   },
 
   // ── Releases + Settings (tab-only) ────────────────────────────────────────────

--- a/apps/web-platform/test/components/tour/tour-provider.test.tsx
+++ b/apps/web-platform/test/components/tour/tour-provider.test.tsx
@@ -180,6 +180,28 @@ describe("TourProvider", () => {
     }
   });
 
+  it("switches to the Draft-a-routine tab on the creation step and switches back on leave (reveal event)", () => {
+    onb.tourCompletedAt = "x"; // suppress auto-start; drive manually
+    const events: boolean[] = [];
+    const handler = (e: Event) =>
+      events.push((e as CustomEvent<{ open: boolean }>).detail.open);
+    window.addEventListener("soleur:routine-draft-tab", handler);
+    try {
+      renderProvider();
+      fireEvent.click(screen.getByText("start")); // step 0
+      // Advance to step 14 (the "Draft a routine" tab-button step). Steps 9-10
+      // fire the *New Issue* reveal, not this one, so our handler stays empty.
+      for (let i = 0; i < 14; i++) fireEvent.click(screen.getByText("next"));
+      expect(events).toEqual([]);
+      fireEvent.click(screen.getByText("next")); // step 15 create routine (reveal → open)
+      expect(events).toEqual([true]);
+      fireEvent.click(screen.getByText("next")); // step 16 Releases tab (no reveal → close)
+      expect(events).toEqual([true, false]);
+    } finally {
+      window.removeEventListener("soleur:routine-draft-tab", handler);
+    }
+  });
+
   it("Finish persists completion via POST /api/tour/complete", () => {
     onb.tourCompletedAt = "x"; // suppress auto-start; drive manually
     renderProvider();


### PR DESCRIPTION
Adds the routine-**creation** flow to the guided tour.

Previously the Routines section spotlighted only the "Draft a routine with Concierge" tab *button*. This adds a follow-up step that switches to that tab and spotlights the **creation composer** — the Concierge chat where you describe the recurring work in plain language; it drafts and tests the routine, then opens a PR you approve (routines ship as code, so they go live on merge).

## How
Reuses the `reveal` mechanism introduced for the New Issue modal steps:
- New `ROUTINE_DRAFT_TAB_EVENT` window event. The provider dispatches `{open:true}` on the creation step and `{open:false}` on leave; `RoutinesSurface` listens and flips its tab state to `draft` / back — the same decoupled pattern as the rail-expand and New Issue dialog (no state imported across the boundary).
- New `action:draft-routine-composer` anchor wraps the `routine-authoring` `ChatSurface`.

Tour is now **19 steps**.

## Tests
- `vitest run test/components/tour test/components/routines` → 30 passed
- `tsc --noEmit` → clean
- Added a provider test asserting the draft-tab reveal fires on the creation step and reverts on leave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)