### PR TITLE
fix(ci): finish verify/068 jti_deny per-table guard — add workspace_activity + kb_files (24 → 26)

### DIFF
--- a/apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql
+++ b/apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql
@@ -13,7 +13,11 @@
 --   * revoke_jti is NOT granted to authenticated (service-role-only).
 --   * my_revocation_status is granted TO authenticated.
 --   * Exactly 26 RESTRICTIVE policies named *_jti_not_denied exist.
---   * Each of the 26 tenant tables has its own policy.
+--   * Each of the 26 tenant tables has its own per-table presence
+--     assertion (21 base from mig 068 + workspace_activity (mig 076)
+--     + kb_files (mig 077) + beta_contacts / interview_notes /
+--     beta_contact_stage_transitions (mig 126)) — so the named set
+--     equals the aggregate count, not just the count.
 
 -- (1) revoke_jti present + SECURITY DEFINER
 SELECT 'revoke_jti_fn_present' AS check_name,
@@ -78,7 +82,7 @@ SELECT 'jti_deny_policies_count_26',
    AND policyname LIKE '%_jti_not_denied'
    AND permissive = 'RESTRICTIVE'
 UNION ALL
--- (8-28) Per-table presence assertions (one row per tenant table)
+-- (8-33) Per-table presence assertions (one row per tenant table; 26 total)
 SELECT 'conversations_jti_not_denied_policy_present',
        CASE WHEN count(*) = 1 THEN 0 ELSE 1 END::int
   FROM pg_policies WHERE schemaname='public' AND tablename='conversations'
@@ -184,7 +188,37 @@ SELECT 'workspace_member_removals_jti_not_denied_policy_present',
   FROM pg_policies WHERE schemaname='public' AND tablename='workspace_member_removals'
    AND policyname='workspace_member_removals_jti_not_denied' AND permissive='RESTRICTIVE'
 UNION ALL
--- (29-31) anon-role REVOKE matrix: none of the three 068 functions
+-- workspace_activity (mig 076)
+SELECT 'workspace_activity_jti_not_denied_policy_present',
+       CASE WHEN count(*) = 1 THEN 0 ELSE 1 END::int
+  FROM pg_policies WHERE schemaname='public' AND tablename='workspace_activity'
+   AND policyname='workspace_activity_jti_not_denied' AND permissive='RESTRICTIVE'
+UNION ALL
+-- kb_files (mig 077)
+SELECT 'kb_files_jti_not_denied_policy_present',
+       CASE WHEN count(*) = 1 THEN 0 ELSE 1 END::int
+  FROM pg_policies WHERE schemaname='public' AND tablename='kb_files'
+   AND policyname='kb_files_jti_not_denied' AND permissive='RESTRICTIVE'
+UNION ALL
+-- beta_contacts (mig 126)
+SELECT 'beta_contacts_jti_not_denied_policy_present',
+       CASE WHEN count(*) = 1 THEN 0 ELSE 1 END::int
+  FROM pg_policies WHERE schemaname='public' AND tablename='beta_contacts'
+   AND policyname='beta_contacts_jti_not_denied' AND permissive='RESTRICTIVE'
+UNION ALL
+-- interview_notes (mig 126)
+SELECT 'interview_notes_jti_not_denied_policy_present',
+       CASE WHEN count(*) = 1 THEN 0 ELSE 1 END::int
+  FROM pg_policies WHERE schemaname='public' AND tablename='interview_notes'
+   AND policyname='interview_notes_jti_not_denied' AND permissive='RESTRICTIVE'
+UNION ALL
+-- beta_contact_stage_transitions (mig 126)
+SELECT 'beta_contact_stage_transitions_jti_not_denied_policy_present',
+       CASE WHEN count(*) = 1 THEN 0 ELSE 1 END::int
+  FROM pg_policies WHERE schemaname='public' AND tablename='beta_contact_stage_transitions'
+   AND policyname='beta_contact_stage_transitions_jti_not_denied' AND permissive='RESTRICTIVE'
+UNION ALL
+-- (34-36) anon-role REVOKE matrix: none of the three 068 functions
 -- must be EXECUTE-able by anon. Pre-fix, the sentinel asserted only
 -- the authenticated REVOKE matrix; an accidental future GRANT TO anon
 -- (e.g. via PUBLIC) would slip past CI unobserved.

--- a/knowledge-base/engineering/operations/post-mortems/verify-068-jti-deny-count-sentinel-drift-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/verify-068-jti-deny-count-sentinel-drift-postmortem.md
@@ -1,0 +1,146 @@
+---
+title: "verify/068 jti_deny count-sentinel drift blocked Web Platform Release deploys on main"
+date: 2026-07-08
+incident_pr: "#6236"
+incident_window: "2026-07-08 12:38 UTC → 2026-07-08 13:19 UTC (~41 min)"
+recovery_at: "2026-07-08T13:19:44Z"
+suspected_change: "Migration 126 (beta-CRM, #6160 ee58951b) added 3 RESTRICTIVE *_jti_not_denied policies (live count 23→26) without updating verify/068's jti_deny_policies_count_23 sentinel."
+brand_survival_threshold: none
+status: resolved
+triggers:
+  - system
+art_33_triggered: false
+art_34_triggered: false
+art_33_deadline: "n/a"
+---
+
+## Actor key
+
+- `agent` — Claude Code did this autonomously (no operator ack required).
+- `agent-with-ack` — Claude Code did this AFTER operator confirmed via menu option per `hr-menu-option-ack-not-prod-write-auth`.
+- `human` — Operator did this directly.
+
+# Incident Overview
+
+`verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql` carries a drift sentinel
+`jti_deny_policies_count_23` asserting exactly 23 RESTRICTIVE `*_jti_not_denied`
+RLS policies. Migration 126 (beta-CRM, #6160) added 3 more such policies
+(`beta_contacts`, `interview_notes`, `beta_contact_stage_transitions`), moving
+the live count to 26 without updating the sentinel's expected value. From that
+merge onward, the `verify-migrations` job of every `Web Platform Release` run
+failed on `main`, and because `verify-migrations` gates the `deploy` job, all
+app-container deploys to production were blocked (production kept running the
+prior, healthy build — no user-facing outage).
+
+## Status
+
+resolved — the count sentinel was corrected 23→26 by #6229 (`a4d8208e`); this PR
+(#6236) completes the residual per-table half of the guard.
+
+## Symptom
+
+`Web Platform Release → verify-migrations` red on `main` at
+`068_jti_deny_rls_predicate_and_revoke_rpc.sql/jti_deny_policies_count_23: FAIL (bad=1)`
+across consecutive commits (`ee58951b` #6160, `409cf4fa` #6225, `957350d8` #6218),
+gating `deploy`.
+
+## Incident Timeline
+
+- **Start time (detected):** 2026-07-08 12:38 UTC (mig 126 merged; count drifted)
+- **End time (recovered):** 2026-07-08 13:19 UTC (#6229 bumped sentinel 23→26)
+- **Duration (MTTR):** ~41 minutes
+
+| Actor | Time (UTC) | Action |
+|---|---|---|
+| agent | 2026-07-08 12:38 | #6160 (`ee58951b`, mig 126 beta-CRM) merges; live `*_jti_not_denied` policy count moves 23→26 while `verify/068` still asserts 23. `verify-migrations` starts failing on main. |
+| agent | 2026-07-08 ~13:00 | Drift discovered incidentally during #6218 post-merge verification (that PR added no migrations; its own infra applies succeeded). |
+| agent | 2026-07-08 13:19 | #6229 (`a4d8208e`) bumps the sentinel 23→26; `Web Platform Release` goes green; deploys unblocked. |
+| agent | 2026-07-08 (this PR) | #6236 completes the residual per-table drift guard (21→26 named assertions) and closes the tracking issue #6233. |
+
+## Participants and Systems Involved
+
+CI (`Web Platform Release` workflow, `verify-migrations` job), Supabase Postgres
+RLS policy catalog (`pg_policies`), the jti-deny RLS model (migrations 068/069/076/077/126).
+
+## Detection (+ MTTD)
+
+- **How detected:** internal — surfaced incidentally during #6218 post-merge verification (the failing `verify-migrations` job on the release run), not by a dedicated monitor.
+- **MTTD:** ~22 min after the drift entered (12:38 → ~13:00).
+
+## Triggered by
+
+system — a sibling migration adding members to an aggregate-count-guarded set without updating the guard's expected count.
+
+## Root-cause hypothesis (triage)
+
+| Hypothesis | Supporting evidence | Disconfirming evidence | Status |
+|---|---|---|---|
+| Mig 126 added policies without bumping the 068 count sentinel | Live `pg_policies` = 26; sentinel asserted 23; failure began at `ee58951b` | none | confirmed |
+
+## Resolution
+
+#6229 (`a4d8208e`) bumped `jti_deny_policies_count_23` → `..._count_26`, matching
+the live schema (dev + prd both = 26). `verify-migrations` green from that commit
+onward. #6236 (this PR) adds the 5 missing per-table `*_jti_not_denied_policy_present`
+presence assertions so the named set equals the count, closing the count-vs-identity
+gap the hotfix left open.
+
+## Recovery verification
+
+`Web Platform Release` runs on `a4d8208e` (#6229), `1688bfee` (#6231) concluded
+`success`. Live read-only verify query against dev (`mlwiodleouzwniehynfz`) after
+#6236's change: 35 checks, 0 failing, 26 per-table checks pass.
+
+## Root Cause(s) — 5-Whys
+
+1. Why did verify-migrations go red? — The 068 count sentinel asserted 23 but the live count was 26.
+2. Why was the live count 26? — Mig 126 added 3 `*_jti_not_denied` policies.
+3. Why didn't the sentinel update? — It is a hardcoded magic-number count; adding a member to the guarded set does not force a same-PR update of the count.
+4. Why is that a recurring class? — "All-members drift guard turns main red when a sibling adds a member": the count and the per-table set are maintained by hand in a different file from the migration that changes the set.
+5. Why wasn't it caught pre-merge? — Mig 126's PR CI did not run the count sentinel against the post-merge combined schema; the drift only manifests once the policy lands on main.
+
+## Versions of Components
+
+- **Version(s) that triggered the outage:** `ee58951b` (#6160, mig 126).
+- **Version(s) that restored the service:** `a4d8208e` (#6229).
+
+## Impact details
+
+### Services Impacted
+
+`Web Platform Release` → `deploy` job (blocked). Production app container kept serving the prior healthy build.
+
+### Customer Impact (by role)
+
+- Prospect: none.
+- Authenticated app user: none (prod served the prior build throughout).
+- Legal-document signer: none.
+- Admin via Access: none.
+- Billing customer: none.
+- OAuth installation owner: none.
+
+### Revenue Impact
+
+None. No user-facing degradation; only new app-container deploys were paused for ~41 min.
+
+## Lessons Learned
+
+### Where we got lucky
+
+The drift guard itself fired correctly — the red `verify-migrations` job is exactly the signal it exists to produce. No broken schema shipped; deploys were blocked (fail-safe), not corrupted.
+
+### What went well
+
+The guard turned `main` red immediately on the drift, and #6229 restored green within ~41 min.
+
+### What went wrong
+
+The count-only hotfix (#6229) restored green but left the guard's per-table (identity) half incomplete — the count asserted 26 while only 21 tables were individually named, so a future "one dropped + one unrelated added" swap would pass the count while the set is wrong. It also did not `Closes #6233`, so the tracking issue stayed open.
+
+### What we changed
+
+#6236 completes the per-table half (26 named == 26 counted). Recurrence-prevention beyond that (deriving the expected count from a canonical table list to eliminate the magic number) was evaluated and deferred as YAGNI in the plan — low-frequency maintenance, already documented in the file header.
+
+## Action Items & Follow-ups
+
+_No action items — incident fully resolved in the source PR with no residual work._

--- a/knowledge-base/engineering/operations/post-mortems/verify-068-jti-deny-count-sentinel-drift-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/verify-068-jti-deny-count-sentinel-drift-postmortem.md
@@ -55,7 +55,8 @@ gating `deploy`.
 | agent | 2026-07-08 12:38 | #6160 (`ee58951b`, mig 126 beta-CRM) merges; live `*_jti_not_denied` policy count moves 23→26 while `verify/068` still asserts 23. `verify-migrations` starts failing on main. |
 | agent | 2026-07-08 ~13:00 | Drift discovered incidentally during #6218 post-merge verification (that PR added no migrations; its own infra applies succeeded). |
 | agent | 2026-07-08 13:19 | #6229 (`a4d8208e`) bumps the sentinel 23→26; `Web Platform Release` goes green; deploys unblocked. |
-| agent | 2026-07-08 (this PR) | #6236 completes the residual per-table drift guard (21→26 named assertions) and closes the tracking issue #6233. |
+| agent | 2026-07-08 15:31 | #6237 (`e656434f`, #6232 residual) adds the 3 beta-CRM per-table presence assertions (named set 21→24). |
+| agent | 2026-07-08 (this PR) | #6236 adds the final 2 per-table assertions (`workspace_activity` mig 076, `kb_files` mig 077) that #6237's beta-CRM scope left behind (named set 24→26 == count), and closes the tracking issue #6233. |
 
 ## Participants and Systems Involved
 
@@ -81,9 +82,11 @@ system — a sibling migration adding members to an aggregate-count-guarded set 
 
 #6229 (`a4d8208e`) bumped `jti_deny_policies_count_23` → `..._count_26`, matching
 the live schema (dev + prd both = 26). `verify-migrations` green from that commit
-onward. #6236 (this PR) adds the 5 missing per-table `*_jti_not_denied_policy_present`
-presence assertions so the named set equals the count, closing the count-vs-identity
-gap the hotfix left open.
+onward. The per-table (identity) half was then completed across two PRs: #6237
+(#6232 residual) added the 3 beta-CRM presence assertions (21→24), and #6236
+(this PR) added the final 2 (`workspace_activity` mig 076, `kb_files` mig 077),
+so the named set equals the count (24→26), closing the count-vs-identity gap the
+count-only hotfix left open.
 
 ## Recovery verification
 

--- a/knowledge-base/project/learnings/best-practices/2026-07-08-count-sentinel-hotfix-leaves-per-member-assertions-incomplete.md
+++ b/knowledge-base/project/learnings/best-practices/2026-07-08-count-sentinel-hotfix-leaves-per-member-assertions-incomplete.md
@@ -1,0 +1,57 @@
+# Learning: A count-only drift-sentinel hotfix leaves the per-member presence assertions incomplete
+
+## Problem
+
+Issue #6233 reported `verify-migrations` red on `main` at
+`068_jti_deny_rls_predicate_and_revoke_rpc.sql/jti_deny_policies_count_23` — an
+aggregate count sentinel asserting exactly 23 RESTRICTIVE `*_jti_not_denied`
+policies. A sibling migration (126, beta-CRM) had added 3 more policies, so the
+count drifted to 26 and the sentinel failed, gating `deploy`.
+
+PR #6229 (`a4d8208e8`) fixed the RED by bumping the count sentinel `23 → 26`
+(and renaming `count_23 → count_26`) — the minimum to unblock deploys. But
+#6229 used `Refs #6160`, never `Closes #6233`, so the issue stayed open, and the
+count bump left the guard's **other half** incomplete: the file's count sentinel
+now asserted `26` while only **21** per-table `*_jti_not_denied_policy_present`
+presence assertions existed. The 5 policies added after the mig-068 base array —
+`workspace_activity` (076), `kb_files` (077), and `beta_contacts` /
+`interview_notes` / `beta_contact_stage_transitions` (126) — had **no** per-table
+check, and the file header falsely claimed "each of the 26 tables has its own
+policy."
+
+## Solution
+
+Add the 5 missing per-table presence assertions (mirroring the existing 21
+verbatim, table name substituted), spliced mid-`UNION ALL`-chain before the
+terminal `;`-ended anon-REVOKE block, and correct the header comment so the
+**named set (26) equals the aggregate count (26)**. Verify-SQL only; no runtime,
+schema, or DDL change. Verified read-only against live dev before commit: the
+full query returned 35 checks, 0 failing, 26 per-table checks passing.
+
+## Key Insight
+
+An **aggregate count sentinel** (`..._count_N`) and its **per-member presence
+assertions** are two halves of the same drift guard, and they answer different
+questions: the count catches "a member was dropped/added" only in aggregate; the
+per-member checks catch "the count is right but the *set* is wrong" (one dropped
++ one unrelated added → count still passes, identity is wrong). A hotfix that
+bumps only the count to clear CI is a **legitimate but partial** fix — it
+restores green without restoring the guard's identity half. When you bump a
+count-N sentinel, either complete the per-member assertions in the same PR, or
+file/track the residual so the count-vs-identity gap does not silently persist.
+
+Corollary (already worked as designed here): a `#N` whose **literal** defect was
+already resolved by a sibling hotfix is not a no-op close — scope the work to the
+residual completeness gap the hotfix left behind (plan Phase 0.6 premise
+validation caught the stale premise and re-scoped correctly).
+
+## Session Errors
+
+None detected. Clean run — planning, work, review (4 agents, 0 findings), and
+QA (skipped: prose scenarios, behavior already live-verified) all passed first
+try.
+
+## Tags
+category: best-practices
+module: apps/web-platform/supabase/verify
+related: "#6233, #6229, #5280 (all-members drift guard must rebase before ship)"

--- a/knowledge-base/project/learnings/best-practices/2026-07-08-count-sentinel-hotfix-leaves-per-member-assertions-incomplete.md
+++ b/knowledge-base/project/learnings/best-practices/2026-07-08-count-sentinel-hotfix-leaves-per-member-assertions-incomplete.md
@@ -47,9 +47,24 @@ validation caught the stale premise and re-scoped correctly).
 
 ## Session Errors
 
-None detected. Clean run — planning, work, review (4 agents, 0 findings), and
-QA (skipped: prose scenarios, behavior already live-verified) all passed first
-try.
+- **Mid-pipeline sibling collision (#6237).** While this PR (#6236, for #6233)
+  was in its ship phase, sibling PR #6237 (for the sibling issue #6232) merged
+  the 3 beta-CRM per-table assertions to `main`, producing a content conflict in
+  `verify/068`. **Recovery:** per the `/soleur:ship` Phase 6.5 sharp edge ("a
+  sibling may have shipped your feature mid-pipeline — do NOT reflexively resolve
+  to mine"), I aborted the merge, read `origin/main`'s actual implementation,
+  found it added only 3 of the 5 tables (beta-CRM), and rebuilt this PR as the
+  **residual 2-table delta** (`workspace_activity`, `kb_files`) on top of #6237
+  rather than duplicating its work. **Prevention:** the one-shot Step 0a.5
+  collision gate only probes at pipeline START, so a sibling that ships the same
+  feature under a *different* issue (#6232 vs #6233) is invisible to it — the
+  Phase 6.5 mergeability check + read-main-before-resolving is the backstop.
+  Reinforces the Key Insight: the count-only #6229 hotfix left the per-table half
+  to be finished piecemeal (#6229 count → #6237 beta trio → #6236 last 2), which
+  is exactly the fragmentation a complete-the-guard-in-one-PR discipline avoids.
+
+Otherwise a clean run — planning, work, review (4 agents, 0 findings), and QA
+(skipped: prose scenarios, behavior live-verified) all passed first try.
 
 ## Tags
 category: best-practices

--- a/knowledge-base/project/plans/2026-07-08-fix-verify-068-jti-deny-per-table-assertions-plan.md
+++ b/knowledge-base/project/plans/2026-07-08-fix-verify-068-jti-deny-per-table-assertions-plan.md
@@ -13,6 +13,33 @@ detail_level: minimal
 
 > Spec lacks valid `lane:` (no `spec.md` for this branch) — defaulted to `cross-domain` (TR2 fail-closed).
 
+## Enhancement Summary
+
+**Deepened on:** 2026-07-08
+
+**Key improvements over the base plan:**
+1. **Corrected SQL insertion point** — the file's terminal SELECT is the `;`-ended
+   `is_jti_denied_from_jwt_anon_revoke_present` anon check (verified at lines ~186-201), NOT a
+   per-table assertion. The base plan wrongly suggested making a new row terminal / appending
+   at EOF. The 5 new rows must splice **mid-chain** after `workspace_member_removals` (~line
+   185) and before the anon-REVOKE-matrix block. Phase 1, Sharp Edges, and tasks.md updated.
+2. **Observability converted to the 5-field schema** (Phase 4.7 gate) — the verify sentinel
+   is the liveness signal; failure modes now enumerate both the single-drop and the
+   count-stable-but-set-wrong (count-vs-identity) cases.
+3. **Live + CI verification pinned** (see Verification Log below): dev+prd both = 26; verify
+   green on main since `a4d8208e` (#6229).
+
+**Verification Log (deepen-plan, live-resolved):**
+- `#6229` state: `MERGED` at `2026-07-08T13:19:44Z`, mergeCommit `a4d8208e887df48ff9d68382b68092e249e4dac3`; body says `Refs #6160` (does NOT `Closes #6233`) — #6233 stays open.
+- `Web Platform Release` on main: `ee58951b`/`409cf4fa`/`957350d8` = failure; `a4d8208e`(#6229) = success; `1688bfee`(#6231) = success. Fix landed at #6229.
+- Live `pg_policies` (RESTRICTIVE `%_jti_not_denied`): prd `ifsccnjhymdmidffkzhl` = 26 (all 5 newer tables present); dev `mlwiodleouzwniehynfz` = 26 (`newer5_present = 5`).
+- Migration policy sources: 068 (21 via `DO … FOREACH t IN ARRAY tenant_tables LOOP`), 076 (`workspace_activity`), 077 (`kb_files`), 126 (`beta_contacts`/`interview_notes`/`beta_contact_stage_transitions`) → 21+1+1+3 = 26.
+- Only `verify/068_...sql` carries the count sentinel (`grep -rln jti_deny_policies_count verify/` = 1 file).
+
+**Precedent-diff (Phase 4.4):** the per-table presence assertion is not a novel pattern — it
+is the canonical form already used 21× in this same file (each row: `SELECT '<t>_jti_not_denied_policy_present', CASE WHEN count(*)=1 THEN 0 ELSE 1 END::int FROM pg_policies WHERE schemaname='public' AND tablename='<t>' AND policyname='<t>_jti_not_denied' AND permissive='RESTRICTIVE'`).
+The 5 new rows mirror it verbatim with the table name substituted. No new SQL shape introduced.
+
 ## Overview
 
 `Web Platform Release → verify-migrations` was failing on `main` at
@@ -110,11 +137,17 @@ SELECT 'beta_contact_stage_transitions_jti_not_denied_policy_present',
    AND policyname='beta_contact_stage_transitions_jti_not_denied' AND permissive='RESTRICTIVE'
 ```
 
-**SQL structure sharp edge:** the assertions form one `UNION ALL` chain. The current file's
-**final** `SELECT` has no trailing `UNION ALL`. Insert the 5 new rows so exactly one `SELECT`
-remains terminal (either append all 5 after the current last assertion — making the 5th new
-row terminal — or splice mid-chain). Preserve any terminal `;`/`ORDER BY` the file already
-has. Read the file's tail before editing (`hr-always-read-a-file-before-editing-it`).
+**SQL structure sharp edge (verified against the file 2026-07-08):** the assertions form one
+`UNION ALL` chain. The per-table block is **mid-chain**, NOT at EOF — the 21st/last per-table
+assertion is `workspace_member_removals_jti_not_denied_policy_present` (~lines 182-185),
+immediately followed by `UNION ALL` and the `-- (29-31) anon-role REVOKE matrix` block, whose
+final SELECT (`is_jti_denied_from_jwt_anon_revoke_present`) is the file's terminal statement
+and ends with `;`. **Insert the 5 new rows between the `workspace_member_removals` assertion
+and the anon-REVOKE-matrix block**, each separated by `UNION ALL`; the existing `UNION ALL`
+that precedes the anon block chains the last new row into it. Do **not** append at EOF (that
+would sit after the `;` — a syntax error) and do **not** make a new row terminal (the terminal
+SELECT must remain the `;`-ended anon check). Read the file before editing
+(`hr-always-read-a-file-before-editing-it`).
 
 ### Phase 2 — Correct the header comment
 The header block already says "Exactly 26 RESTRICTIVE policies … Each of the 26 tenant tables
@@ -166,14 +199,32 @@ learnings/specs, no new distribution surface). Scope-out recorded per Phase 2.7.
 
 ## Observability
 
-`liveness_signal`: the `verify-migrations` job in `Web Platform Release` **is** the liveness
-signal for this guard — it runs on every push to `main` that migrates, fails the pipeline
-(gating `deploy`) on any `bad > 0` row, and surfaces the failing `check_name` in the job log.
-This change strengthens that existing signal (26 per-table pinpoints vs. a single aggregate
-count). `discoverability_test` (NO ssh): `gh run view <id> --log | grep jti_deny` — the per-table
-`*_jti_not_denied_policy_present` check names name the exact drifted table on failure. No new
-error path, log call, or infra surface is introduced (verify SQL only), so the 5-field infra
-schema is not otherwise applicable.
+This change strengthens an existing CI drift gate; the sentinel itself IS the observability
+surface. No new runtime error path, log call, or infra surface is introduced (verify SQL only).
+
+```yaml
+liveness_signal:
+  what: "verify-migrations job in Web Platform Release (asserts jti_deny_policies_count_26 + 26 per-table *_jti_not_denied_policy_present checks)"
+  cadence: "every push to main that runs the migrate job"
+  alert_target: "GitHub Actions run status (red pipeline gates the deploy job)"
+  configured_in: ".github/workflows (Web Platform Release) → verify-migrations; verify SQL apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql"
+error_reporting:
+  destination: "GitHub Actions job log (failing check_name + bad=1 row printed by the verify runner)"
+  fail_loud: "yes — any bad>0 row fails verify-migrations and gates deploy (no silent pass)"
+failure_modes:
+  - mode: "a future migration drops one of the 26 jti_not_denied policies"
+    detection: "count sentinel drops to 25 (bad=1) AND the dropped table's *_jti_not_denied_policy_present check returns bad=1, naming the exact table"
+    alert_route: "verify-migrations red → deploy gated → visible in Web Platform Release run"
+  - mode: "count stays 26 but the set is wrong (one dropped + one unrelated added)"
+    detection: "the dropped table's per-table presence check returns bad=1 even though the count passes (the count-vs-identity gap this plan closes)"
+    alert_route: "verify-migrations red → deploy gated"
+logs:
+  where: "GitHub Actions run logs for Web Platform Release → verify-migrations"
+  retention: "GitHub Actions default log retention (90 days)"
+discoverability_test:
+  command: "gh run list --workflow 'Web Platform Release' --branch main --limit 1 --json conclusion  # then: gh run view <id> --log | grep jti_deny"
+  expected_output: "conclusion=success; grep shows 26 per-table *_jti_not_denied_policy_present checks + jti_deny_policies_count_26 all passing (no bad=1)"
+```
 
 ## Architecture Decision (ADR / C4)
 
@@ -216,9 +267,12 @@ now — the recurring maintenance is already documented in the file header and i
   filled with threshold `none` + reason.)
 - **Do not touch the count sentinel** (`jti_deny_policies_count_26`). It is correct (live=26).
   The only edit is adding the 5 per-table rows + the header comment.
-- **Terminal `SELECT` in the `UNION ALL` chain:** appending a row with a trailing `UNION ALL`
-  and no following `SELECT` is a syntax error. Read the file tail; make exactly one `SELECT`
-  terminal; preserve any terminal `;`.
+- **Terminal `SELECT` in the `UNION ALL` chain:** the file's terminal SELECT is the
+  `;`-ended `is_jti_denied_from_jwt_anon_revoke_present` anon check — NOT a per-table
+  assertion. The per-table block is mid-chain. Insert the 5 new rows between
+  `workspace_member_removals_jti_not_denied_policy_present` and the `-- (29-31) anon-role
+  REVOKE matrix` block; keep the terminal `;` anon check terminal. Appending at EOF (after
+  the `;`) is a syntax error.
 - **Policy-name exactness:** each new assertion's `policyname` must match the migration's
   literal `CREATE POLICY <name>` (verified: `workspace_activity_jti_not_denied` mig 076,
   `kb_files_jti_not_denied` mig 077, `beta_contacts_jti_not_denied` /

--- a/knowledge-base/project/plans/2026-07-08-fix-verify-068-jti-deny-per-table-assertions-plan.md
+++ b/knowledge-base/project/plans/2026-07-08-fix-verify-068-jti-deny-per-table-assertions-plan.md
@@ -222,8 +222,11 @@ logs:
   where: "GitHub Actions run logs for Web Platform Release → verify-migrations"
   retention: "GitHub Actions default log retention (90 days)"
 discoverability_test:
-  command: "gh run list --workflow 'Web Platform Release' --branch main --limit 1 --json conclusion  # then: gh run view <id> --log | grep jti_deny"
-  expected_output: "conclusion=success; grep shows 26 per-table *_jti_not_denied_policy_present checks + jti_deny_policies_count_26 all passing (no bad=1)"
+  # Locally-runnable, no-auth proxy: proves the completed drift guard names all 26
+  # tables. The live CI liveness signal is the verify-migrations job status above
+  # (gh run list --workflow 'Web Platform Release' --branch main), verified post-merge.
+  command: grep -c _jti_not_denied_policy_present apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql
+  expected_output: "26"
 ```
 
 ## Architecture Decision (ADR / C4)

--- a/knowledge-base/project/plans/2026-07-08-fix-verify-068-jti-deny-per-table-assertions-plan.md
+++ b/knowledge-base/project/plans/2026-07-08-fix-verify-068-jti-deny-per-table-assertions-plan.md
@@ -1,0 +1,226 @@
+---
+title: "fix(ci): complete verify/068 jti_deny per-table drift guard (26 count / 21 named → 26/26)"
+issue: 6233
+branch: feat-one-shot-6233-verify-migrations-068-jti-deny-count
+type: bug
+date: 2026-07-08
+lane: cross-domain
+brand_survival_threshold: none
+detail_level: minimal
+---
+
+# 🐛 fix(ci): complete verify/068 jti_deny per-table drift guard
+
+> Spec lacks valid `lane:` (no `spec.md` for this branch) — defaulted to `cross-domain` (TR2 fail-closed).
+
+## Overview
+
+`Web Platform Release → verify-migrations` was failing on `main` at
+`068_jti_deny_rls_predicate_and_revoke_rpc.sql/jti_deny_policies_count_23: FAIL (bad=1)`,
+gating the `deploy` job (issue #6233).
+
+**The reported defect is already resolved on `main`.** PR **#6229** (`a4d8208e8`, merged
+2026-07-08 13:19 UTC) bumped the count sentinel `23 → 26` (renamed `count_23 → count_26`)
+to account for the 3 beta-CRM `*_jti_not_denied` policies added by migration `126`. Every
+`Web Platform Release` run since is green (`a4d8208e`, `1688bfee`, HEAD `94c7783e`). Live
+`pg_policies` on **dev and prd both return 26** matching RESTRICTIVE `*_jti_not_denied`
+policies (see Research Reconciliation). So the count is correct and CI is unblocked.
+
+#6229 did **not** `Closes #6233` (its body says only `Refs #6160`), so #6233 remained open
+after the fix — and #6229 was an explicit *hotfix* that did the minimum to unblock deploys
+(the count bump) **without** completing the guard's per-table half.
+
+**This plan's deliverable** is the residual completeness work #6229 left behind: the count
+sentinel now asserts **26** but the file only carries **21** per-table
+`*_jti_not_denied_policy_present` assertions (the mig-068 base array). The 5 later policies
+— `workspace_activity` (mig 076), `kb_files` (mig 077), `beta_contacts` /
+`interview_notes` / `beta_contact_stage_transitions` (mig 126) — have **no** per-table
+presence assertion, and the file header falsely claims "Each of the 26 tenant tables has its
+own policy." We add the 5 missing per-table assertions so the named set (26) equals the
+count (26), closing the count-vs-identity proxy gap the issue itself names ("the all-members
+drift guard turns main red when a sibling adds a member" class). Then close #6233.
+
+Verify-SQL-only change: no runtime code, no schema change, no DDL, no user-facing surface.
+
+## Research Reconciliation — Premise vs. Codebase / Live State
+
+| Premise (from #6233) | Reality (verified 2026-07-08) | Plan response |
+|---|---|---|
+| `068` verify sentinel asserts `= 23`, fails on main | Already `= 26` (`jti_deny_policies_count_26`) on main since #6229 `a4d8208e8` | Count is correct — no count change needed |
+| verify-migrations red on main, blocks deploy | Green since `a4d8208e`; `1688bfee` + HEAD `94c7783e` also green | Confirm CI stays green post-change (AC) |
+| "update the sentinel count OR fix a missing policy" | Live count dev=26, prd=26; all 5 newer tables present in both | Live schema correct — no policy fix needed |
+| #6233 tracks the count fix | #6229 fixed the count but is `Refs #6160`, never `Closes #6233` | Close #6233 in this PR |
+| (implicit) guard is complete | Count=26 but only **21** per-table assertions; 5 tables unnamed; header comment says "26 tables … own policy" (false) | **Add 5 per-table presence assertions; correct header comment** |
+
+Premise Validation note: The one external premise (the sentinel count) was validated and
+found **stale** — resolved by merged PR #6229. No blocker premises remain. The only in-scope
+work is the guard-completeness gap #6229's hotfix scope left open, which is squarely within
+#6233's stated root-cause framing.
+
+Live reconciliation queries (read-only, both returned 26):
+- prd `ifsccnjhymdmidffkzhl`: 26 policies incl. `workspace_activity, kb_files, beta_contacts, interview_notes, beta_contact_stage_transitions`.
+- dev `mlwiodleouzwniehynfz`: 26 policies; the 5 newer tables all present (`newer5_present = 5`).
+
+## User-Brand Impact
+
+- **If this lands broken, the user experiences:** nothing directly — this edits a CI
+  `verify/*.sql` drift sentinel only. A broken *assertion* (e.g., wrong policy name in a new
+  presence check) would turn `verify-migrations` red and re-gate `deploy`, delaying feature
+  rollout (same blast radius as the bug being fixed) — caught pre-merge by CI on the PR.
+- **If this leaks, the user's data is exposed via:** N/A — no data is read/written/exposed;
+  the change asserts on `pg_policies` catalog metadata only, no schema or RLS behavior change.
+- **Brand-survival threshold:** none, reason: CI-only change to a `verify/` drift-sentinel's
+  per-table presence assertions — no runtime code, no schema/RLS change, no user-facing
+  surface; it only strengthens a post-merge gate.
+
+## Implementation Phases
+
+### Phase 1 — Add the 5 missing per-table presence assertions
+Edit `apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql`.
+Append 5 `UNION ALL SELECT … _jti_not_denied_policy_present` rows mirroring the existing
+21-assertion style, for `workspace_activity`, `kb_files`, `beta_contacts`, `interview_notes`,
+`beta_contact_stage_transitions`. Each row asserts exactly one RESTRICTIVE policy of that
+name on that table:
+
+```sql
+UNION ALL
+SELECT 'workspace_activity_jti_not_denied_policy_present',
+       CASE WHEN count(*) = 1 THEN 0 ELSE 1 END::int
+  FROM pg_policies WHERE schemaname='public' AND tablename='workspace_activity'
+   AND policyname='workspace_activity_jti_not_denied' AND permissive='RESTRICTIVE'
+UNION ALL
+SELECT 'kb_files_jti_not_denied_policy_present',
+       CASE WHEN count(*) = 1 THEN 0 ELSE 1 END::int
+  FROM pg_policies WHERE schemaname='public' AND tablename='kb_files'
+   AND policyname='kb_files_jti_not_denied' AND permissive='RESTRICTIVE'
+UNION ALL
+SELECT 'beta_contacts_jti_not_denied_policy_present',
+       CASE WHEN count(*) = 1 THEN 0 ELSE 1 END::int
+  FROM pg_policies WHERE schemaname='public' AND tablename='beta_contacts'
+   AND policyname='beta_contacts_jti_not_denied' AND permissive='RESTRICTIVE'
+UNION ALL
+SELECT 'interview_notes_jti_not_denied_policy_present',
+       CASE WHEN count(*) = 1 THEN 0 ELSE 1 END::int
+  FROM pg_policies WHERE schemaname='public' AND tablename='interview_notes'
+   AND policyname='interview_notes_jti_not_denied' AND permissive='RESTRICTIVE'
+UNION ALL
+SELECT 'beta_contact_stage_transitions_jti_not_denied_policy_present',
+       CASE WHEN count(*) = 1 THEN 0 ELSE 1 END::int
+  FROM pg_policies WHERE schemaname='public' AND tablename='beta_contact_stage_transitions'
+   AND policyname='beta_contact_stage_transitions_jti_not_denied' AND permissive='RESTRICTIVE'
+```
+
+**SQL structure sharp edge:** the assertions form one `UNION ALL` chain. The current file's
+**final** `SELECT` has no trailing `UNION ALL`. Insert the 5 new rows so exactly one `SELECT`
+remains terminal (either append all 5 after the current last assertion — making the 5th new
+row terminal — or splice mid-chain). Preserve any terminal `;`/`ORDER BY` the file already
+has. Read the file's tail before editing (`hr-always-read-a-file-before-editing-it`).
+
+### Phase 2 — Correct the header comment
+The header block already says "Exactly 26 RESTRICTIVE policies … Each of the 26 tenant tables
+has its own policy." After Phase 1 that becomes literally true. Add the 5 table names to the
+per-table-provenance comment (mig 076 `workspace_activity`, mig 077 `kb_files`, mig 126
+`beta_contacts`/`interview_notes`/`beta_contact_stage_transitions`) so the file documents that
+all 26 are individually asserted, not just counted.
+
+### Phase 3 — Close #6233
+On merge, `gh issue close 6233` (via ship post-merge). PR body uses `Closes #6233` in the
+body (not title) so it auto-closes at merge — acceptable here because the fix is code-in-PR
+(not an ops-remediation that runs post-merge).
+
+## Files to Edit
+- `apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql` — add 5 per-table assertions (Phase 1) + correct header comment (Phase 2).
+
+## Files to Create
+- None.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- [ ] `grep -cE "_jti_not_denied_policy_present'" apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql` returns **26** (was 21).
+- [ ] The count sentinel line remains `jti_deny_policies_count_26` asserting `count(*) = 26` (unchanged — do not touch the count).
+- [ ] The file contains a per-table presence assertion for each of `workspace_activity`, `kb_files`, `beta_contacts`, `interview_notes`, `beta_contact_stage_transitions`.
+- [ ] The `UNION ALL` chain is well-formed: exactly one terminal `SELECT` (no trailing `UNION ALL`); verify by piping the file through a Postgres parse (`psql -f` against a scratch DB, or the repo's existing verify-runner harness) with **0 syntax errors**.
+- [ ] Header comment enumerates all 26 tables' provenance (21 base + 076/077 + 126); no claim in the file is falsified by the assertions.
+- [ ] PR body uses `Closes #6233`.
+
+### Post-merge (operator/automated)
+- [ ] `Web Platform Release → verify-migrations` on the merge commit is **green** and reports `22 passed, 0 failed`-style summary with the count now 26 checks + 26 per-table checks (verified via `gh run list --workflow "Web Platform Release" --branch main` — automatable, ship handles).
+- [ ] #6233 is closed (auto via `Closes`).
+
+## Domain Review
+
+**Domains relevant:** none
+
+CI drift-guard hardening on a `verify/*.sql` sentinel. No product/UX surface (no
+`components/**`, `app/**/page.tsx`, or UI-surface path in Files to Edit), no marketing/sales/
+finance/legal/support implication, no infrastructure provisioning. Engineering-only, verify-SQL.
+
+## GDPR / Compliance Gate
+
+Not materially triggered. The change edits a `.sql` file (surface the canonical regex flags),
+but it adds **read-only assertions on `pg_policies` catalog metadata** — no new processing
+activity, no schema change, no auth-flow change, no personal-data movement. No `(a)-(d)`
+expansion trigger fires (no LLM/external-API on session data, threshold=none, no cron reading
+learnings/specs, no new distribution surface). Scope-out recorded per Phase 2.7.
+
+## Observability
+
+`liveness_signal`: the `verify-migrations` job in `Web Platform Release` **is** the liveness
+signal for this guard — it runs on every push to `main` that migrates, fails the pipeline
+(gating `deploy`) on any `bad > 0` row, and surfaces the failing `check_name` in the job log.
+This change strengthens that existing signal (26 per-table pinpoints vs. a single aggregate
+count). `discoverability_test` (NO ssh): `gh run view <id> --log | grep jti_deny` — the per-table
+`*_jti_not_denied_policy_present` check names name the exact drifted table on failure. No new
+error path, log call, or infra surface is introduced (verify SQL only), so the 5-field infra
+schema is not otherwise applicable.
+
+## Architecture Decision (ADR / C4)
+
+None. This adds presence assertions to an existing drift sentinel for the already-shipped
+jti-deny RLS model (ADRs/migrations 068/069). No ownership/tenancy boundary move, no new
+substrate/integration, no resolver/trust-boundary change, no reversal/extension of an existing
+ADR. **C4 (all three `.c4` files checked):** the jti-deny RLS mechanism is an internal
+Postgres RLS invariant, not a C4 external actor / external system / data-store / access
+relationship — no new correspondent, vendor, container, or actor↔surface edge is introduced or
+changed. No C4 impact.
+
+## Test Scenarios
+
+1. **Happy path (live-correct):** all 26 policies present → all 26 per-table checks + count
+   check return `bad=0` → verify-migrations green. (Confirmed against dev+prd live: 26/26.)
+2. **Simulated single-table drift:** if a future migration drops (e.g.) `kb_files_jti_not_denied`,
+   the count sentinel drops to 25 (fails in aggregate) **and** `kb_files_jti_not_denied_policy_present`
+   returns `bad=1`, naming the exact table — the pinpoint this plan adds.
+3. **Count-vs-identity guard:** if a future migration drops one expected policy but adds an
+   unrelated `*_jti_not_denied` policy (count stays 26), the per-table presence check for the
+   dropped table fails even though the count passes — the proxy gap this plan closes.
+
+## Alternative Approaches Considered
+
+| Alternative | Why not chosen |
+|---|---|
+| Close #6233 as "resolved by #6229", no code change | Leaves the guard asymmetric (26 count / 21 named) and the header comment false; a bare `gh issue close` yields no mergeable pipeline artifact and no lasting improvement. |
+| Redesign the sentinel to derive the expected count from a canonical table list (eliminate the magic 26) | Larger blast radius, changes the file's established pattern, and is YAGNI for this issue. Deferred — see below. |
+| Auto-generate per-table assertions in a `DO` loop like mig 068 | Verify files are flat `UNION ALL` result sets (each row must be a static `check_name`); a loop can't emit result rows the harness reads. Not applicable. |
+
+**Deferred (optional, not blocking #6233):** derive the count from an enumerated canonical
+table array so the count and per-table set are maintained in one place. If pursued, file a
+follow-up issue with re-evaluation criteria (next time a jti-deny table is added). Not created
+now — the recurring maintenance is already documented in the file header and is low-frequency.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/`TODO`/placeholder
+  text, or omits the threshold will fail `deepen-plan` Phase 4.6. (This plan's section is
+  filled with threshold `none` + reason.)
+- **Do not touch the count sentinel** (`jti_deny_policies_count_26`). It is correct (live=26).
+  The only edit is adding the 5 per-table rows + the header comment.
+- **Terminal `SELECT` in the `UNION ALL` chain:** appending a row with a trailing `UNION ALL`
+  and no following `SELECT` is a syntax error. Read the file tail; make exactly one `SELECT`
+  terminal; preserve any terminal `;`.
+- **Policy-name exactness:** each new assertion's `policyname` must match the migration's
+  literal `CREATE POLICY <name>` (verified: `workspace_activity_jti_not_denied` mig 076,
+  `kb_files_jti_not_denied` mig 077, `beta_contacts_jti_not_denied` /
+  `interview_notes_jti_not_denied` / `beta_contact_stage_transitions_jti_not_denied` mig 126).
+  A typo turns verify red — the same class this plan hardens against.

--- a/knowledge-base/project/plans/2026-07-08-fix-verify-068-jti-deny-per-table-assertions-plan.md
+++ b/knowledge-base/project/plans/2026-07-08-fix-verify-068-jti-deny-per-table-assertions-plan.md
@@ -170,11 +170,11 @@ body (not title) so it auto-closes at merge — acceptable here because the fix 
 ## Acceptance Criteria
 
 ### Pre-merge (PR)
-- [ ] `grep -cE "_jti_not_denied_policy_present'" apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql` returns **26** (was 21).
-- [ ] The count sentinel line remains `jti_deny_policies_count_26` asserting `count(*) = 26` (unchanged — do not touch the count).
-- [ ] The file contains a per-table presence assertion for each of `workspace_activity`, `kb_files`, `beta_contacts`, `interview_notes`, `beta_contact_stage_transitions`.
-- [ ] The `UNION ALL` chain is well-formed: exactly one terminal `SELECT` (no trailing `UNION ALL`); verify by piping the file through a Postgres parse (`psql -f` against a scratch DB, or the repo's existing verify-runner harness) with **0 syntax errors**.
-- [ ] Header comment enumerates all 26 tables' provenance (21 base + 076/077 + 126); no claim in the file is falsified by the assertions.
+- [x] `grep -cE "_jti_not_denied_policy_present'" apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql` returns **26** (was 21).
+- [x] The count sentinel line remains `jti_deny_policies_count_26` asserting `count(*) = 26` (unchanged — do not touch the count).
+- [x] The file contains a per-table presence assertion for each of `workspace_activity`, `kb_files`, `beta_contacts`, `interview_notes`, `beta_contact_stage_transitions`.
+- [x] The `UNION ALL` chain is well-formed: verified by running the full query read-only against dev via Supabase MCP — 35 rows, 0 syntax errors, `failing_checks=0`.
+- [x] Header comment enumerates all 26 tables' provenance (21 base + 076/077 + 126); no claim in the file is falsified by the assertions.
 - [ ] PR body uses `Closes #6233`.
 
 ### Post-merge (operator/automated)

--- a/knowledge-base/project/specs/feat-one-shot-6233-verify-migrations-068-jti-deny-count/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-6233-verify-migrations-068-jti-deny-count/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-08-fix-verify-068-jti-deny-per-table-assertions-plan.md
+- Status: complete
+
+### Errors
+None.
+
+### Decisions
+- Premise validation: #6233's literal count-sentinel failure (`jti_deny_policies_count_23`) was already fixed by PR #6229 (`a4d8208e8`, bumped 23→26). verify-migrations is green on main from that commit onward; live dev+prd `pg_policies` both = 26.
+- Scoped the plan to the genuine residual gap: verify/068 asserts count=26 but carries only 21 per-table presence assertions; 5 newer policies (workspace_activity, kb_files, beta_contacts, interview_notes, beta_contact_stage_transitions) lack a per-table check. Plan adds the 5 missing assertions, then closes #6233.
+- Rejected gold-plating (deriving count from a canonical table list) as out-of-scope.
+- Deepen-plan corrected a load-bearing SQL error: the 5 rows must splice mid-chain after `workspace_member_removals` (~line 185), not append at EOF (terminal SELECT is the `;`-ended anon-revoke check). Verify-SQL-only; threshold=none.
+
+### Components Invoked
+- Skill: soleur:plan (`#6233`)
+- Skill: soleur:deepen-plan (plan file path)
+- Supabase MCP: list_projects, execute_sql (read-only dev + prd reconciliation)
+- gh CLI, git history/blame, Bash grep/analysis

--- a/knowledge-base/project/specs/feat-one-shot-6233-verify-migrations-068-jti-deny-count/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6233-verify-migrations-068-jti-deny-count/tasks.md
@@ -7,19 +7,19 @@ Plan: `knowledge-base/project/plans/2026-07-08-fix-verify-068-jti-deny-per-table
 > complete the per-table presence half of the drift guard (21 named → 26 named) and close #6233.
 
 ## Phase 1 — Setup / verify preconditions
-- [ ] 1.1 Read `apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql` in full, noting the terminal `SELECT` of the `UNION ALL` chain and any trailing `;`.
-- [ ] 1.2 Confirm the count sentinel is `jti_deny_policies_count_26` asserting `count(*) = 26` (do NOT modify it).
-- [ ] 1.3 Confirm current per-table assertion count is 21: `grep -cE "_jti_not_denied_policy_present'" <file>`.
+- [x] 1.1 Read `apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql` in full, noting the terminal `SELECT` of the `UNION ALL` chain and any trailing `;`.
+- [x] 1.2 Confirm the count sentinel is `jti_deny_policies_count_26` asserting `count(*) = 26` (do NOT modify it). — confirmed line 78, unchanged.
+- [x] 1.3 Confirm current per-table assertion count is 21: `grep -cE "_jti_not_denied_policy_present'" <file>`. — was 21, now 26.
 
 ## Phase 2 — Core implementation
-- [ ] 2.1 Insert 5 per-table presence assertions (mirroring existing style) for `workspace_activity`, `kb_files`, `beta_contacts`, `interview_notes`, `beta_contact_stage_transitions` — each `count(*) = 1`, RESTRICTIVE, exact `policyname` matching the migration's `CREATE POLICY` literal.
-- [ ] 2.2 Insertion point is MID-CHAIN: after the last per-table assertion `workspace_member_removals_jti_not_denied_policy_present` (~line 185) and BEFORE the `-- (29-31) anon-role REVOKE matrix` block. The file's terminal SELECT is the `;`-ended `is_jti_denied_from_jwt_anon_revoke_present` anon check — keep it terminal. Do NOT append at EOF (after the `;` = syntax error). Each new row separated by `UNION ALL`; the existing `UNION ALL` before the anon block chains the last new row in.
-- [ ] 2.3 Correct the header comment so it enumerates all 26 tables' provenance (21 base + 076 `workspace_activity` + 077 `kb_files` + 126 beta trio) — the "each of the 26 tables has its own policy" claim is now literally true.
+- [x] 2.1 Insert 5 per-table presence assertions (mirroring existing style) for `workspace_activity`, `kb_files`, `beta_contacts`, `interview_notes`, `beta_contact_stage_transitions` — each `count(*) = 1`, RESTRICTIVE, exact `policyname` matching the migration's `CREATE POLICY` literal.
+- [x] 2.2 Insertion point is MID-CHAIN: after the last per-table assertion `workspace_member_removals_jti_not_denied_policy_present` and BEFORE the anon-role REVOKE matrix block. Terminal `;` anon check kept terminal. Each new row separated by `UNION ALL`.
+- [x] 2.3 Correct the header comment so it enumerates all 26 tables' provenance (21 base + 076 `workspace_activity` + 077 `kb_files` + 126 beta trio) — the "each of the 26 tables has its own policy" claim is now literally true.
 
 ## Phase 3 — Testing / verification
-- [ ] 3.1 `grep -cE "_jti_not_denied_policy_present'" <file>` returns 26.
-- [ ] 3.2 Parse the verify SQL (repo verify-runner harness, or `psql -f` against a scratch DB) — 0 syntax errors.
-- [ ] 3.3 (Optional, read-only) re-confirm live dev+prd `pg_policies` count = 26 and the 5 tables present (already verified at plan time).
+- [x] 3.1 `grep -cE "_jti_not_denied_policy_present'" <file>` returns 26.
+- [x] 3.2 Parse the verify SQL — ran the full query read-only against dev via Supabase MCP: 35 rows returned (0 syntax errors), `failing_checks = 0`, `per_table_checks = 26`.
+- [x] 3.3 Live dev `pg_policies` re-confirmed: all 26 per-table checks + count check pass (bad=0); all 5 new tables resolve to their policies.
 
 ## Phase 4 — Ship
 - [ ] 4.1 PR body uses `Closes #6233`.

--- a/knowledge-base/project/specs/feat-one-shot-6233-verify-migrations-068-jti-deny-count/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6233-verify-migrations-068-jti-deny-count/tasks.md
@@ -12,8 +12,8 @@ Plan: `knowledge-base/project/plans/2026-07-08-fix-verify-068-jti-deny-per-table
 - [ ] 1.3 Confirm current per-table assertion count is 21: `grep -cE "_jti_not_denied_policy_present'" <file>`.
 
 ## Phase 2 — Core implementation
-- [ ] 2.1 Append 5 per-table presence assertions (mirroring existing style) for `workspace_activity`, `kb_files`, `beta_contacts`, `interview_notes`, `beta_contact_stage_transitions` — each `count(*) = 1`, RESTRICTIVE, exact `policyname` matching the migration's `CREATE POLICY` literal.
-- [ ] 2.2 Keep the `UNION ALL` chain well-formed: exactly one terminal `SELECT`, no trailing `UNION ALL`, preserve terminal `;`.
+- [ ] 2.1 Insert 5 per-table presence assertions (mirroring existing style) for `workspace_activity`, `kb_files`, `beta_contacts`, `interview_notes`, `beta_contact_stage_transitions` — each `count(*) = 1`, RESTRICTIVE, exact `policyname` matching the migration's `CREATE POLICY` literal.
+- [ ] 2.2 Insertion point is MID-CHAIN: after the last per-table assertion `workspace_member_removals_jti_not_denied_policy_present` (~line 185) and BEFORE the `-- (29-31) anon-role REVOKE matrix` block. The file's terminal SELECT is the `;`-ended `is_jti_denied_from_jwt_anon_revoke_present` anon check — keep it terminal. Do NOT append at EOF (after the `;` = syntax error). Each new row separated by `UNION ALL`; the existing `UNION ALL` before the anon block chains the last new row in.
 - [ ] 2.3 Correct the header comment so it enumerates all 26 tables' provenance (21 base + 076 `workspace_activity` + 077 `kb_files` + 126 beta trio) — the "each of the 26 tables has its own policy" claim is now literally true.
 
 ## Phase 3 — Testing / verification

--- a/knowledge-base/project/specs/feat-one-shot-6233-verify-migrations-068-jti-deny-count/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6233-verify-migrations-068-jti-deny-count/tasks.md
@@ -1,0 +1,27 @@
+# Tasks — fix(ci): complete verify/068 jti_deny per-table drift guard (#6233)
+
+Plan: `knowledge-base/project/plans/2026-07-08-fix-verify-068-jti-deny-per-table-assertions-plan.md`
+
+> Context: The reported count-sentinel defect (23→26) is already fixed on `main` by PR #6229
+> (verify-migrations green since `a4d8208e`; dev+prd live count = 26). Residual work only:
+> complete the per-table presence half of the drift guard (21 named → 26 named) and close #6233.
+
+## Phase 1 — Setup / verify preconditions
+- [ ] 1.1 Read `apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql` in full, noting the terminal `SELECT` of the `UNION ALL` chain and any trailing `;`.
+- [ ] 1.2 Confirm the count sentinel is `jti_deny_policies_count_26` asserting `count(*) = 26` (do NOT modify it).
+- [ ] 1.3 Confirm current per-table assertion count is 21: `grep -cE "_jti_not_denied_policy_present'" <file>`.
+
+## Phase 2 — Core implementation
+- [ ] 2.1 Append 5 per-table presence assertions (mirroring existing style) for `workspace_activity`, `kb_files`, `beta_contacts`, `interview_notes`, `beta_contact_stage_transitions` — each `count(*) = 1`, RESTRICTIVE, exact `policyname` matching the migration's `CREATE POLICY` literal.
+- [ ] 2.2 Keep the `UNION ALL` chain well-formed: exactly one terminal `SELECT`, no trailing `UNION ALL`, preserve terminal `;`.
+- [ ] 2.3 Correct the header comment so it enumerates all 26 tables' provenance (21 base + 076 `workspace_activity` + 077 `kb_files` + 126 beta trio) — the "each of the 26 tables has its own policy" claim is now literally true.
+
+## Phase 3 — Testing / verification
+- [ ] 3.1 `grep -cE "_jti_not_denied_policy_present'" <file>` returns 26.
+- [ ] 3.2 Parse the verify SQL (repo verify-runner harness, or `psql -f` against a scratch DB) — 0 syntax errors.
+- [ ] 3.3 (Optional, read-only) re-confirm live dev+prd `pg_policies` count = 26 and the 5 tables present (already verified at plan time).
+
+## Phase 4 — Ship
+- [ ] 4.1 PR body uses `Closes #6233`.
+- [ ] 4.2 Post-merge: `Web Platform Release → verify-migrations` green on the merge commit (26 count check + 26 per-table checks, 0 failed) via `gh run list --workflow "Web Platform Release" --branch main`.
+- [ ] 4.3 #6233 closed (auto via `Closes`).


### PR DESCRIPTION
## Summary

`verify/068`'s count sentinel asserts 26 (`jti_deny_policies_count_26`, bumped 23→26 by #6229) — the aggregate guard that a sibling migration blew up when mig 126 (#6160) added 3 `*_jti_not_denied` policies. Completing the **per-table (identity) half** of that guard took two PRs:

- **#6237** (`e656434f`, #6232 residual — merged mid-pipeline) added the 3 beta-CRM per-table presence assertions (`beta_contacts`, `interview_notes`, `beta_contact_stage_transitions`), taking the named set 21 → 24.
- **This PR** adds the final **2** tables #6237's beta-CRM-only scope left behind — `workspace_activity` (mig 076) and `kb_files` (mig 077) — taking the named set **24 → 26** so it equals the count. It also corrects the header/range comments (which claimed "each of the 26 tables has its own policy" while only 24 were named).

Net effect: the count-vs-identity drift guard is now whole (26 named == 26 counted). Verify-SQL only — no runtime code, schema, DDL, or user-facing surface.

Closes #6233

## Collision note (mid-pipeline sibling)

This branch was planned to add all 5 post-base tables. During the ship pipeline, sibling PR #6237 (for the sibling issue #6232) merged the 3 beta-CRM tables to `main`. Rather than resolve to "mine," I took main's version and rebuilt only the **residual 2-table delta**, so this PR builds on #6237 instead of duplicating it. Both PRs together close the count-vs-identity gap; neither is redundant.

## Verification

- Live read-only run of the full verify query against dev (`mlwiodleouzwniehynfz`): **35 checks, 0 failing, 26 per-table checks pass** (all 26 policies, incl. `workspace_activity` + `kb_files`, resolve on dev).
- `grep -c _jti_not_denied_policy_present …/068_*.sql` = 26; count sentinel unchanged at `= 26`.
- Merge with `main` (post-#6237) resolved cleanly to the 26-table union; net diff vs `main` = +`workspace_activity` +`kb_files`.
- Plan: `knowledge-base/project/plans/2026-07-08-fix-verify-068-jti-deny-per-table-assertions-plan.md`

## User-Brand Impact

- **If this lands broken, the user experiences:** nothing directly — this edits a CI `verify/*.sql` drift sentinel only. A wrong policy name would turn `verify-migrations` red and re-gate `deploy` (caught pre-merge by CI on this PR).
- **If this leaks, the user's data is exposed via:** N/A — asserts on `pg_policies` catalog metadata only; no schema or RLS behavior change.
- **Brand-survival threshold:** none, reason: CI-only change to a `verify/` drift-sentinel's per-table presence assertions — no runtime code, no schema/RLS change, no user-facing surface; it only strengthens a post-merge gate.

## Changelog

- fix(ci): finish the `verify/068` jti_deny per-table drift guard — add the last 2 per-table assertions (`workspace_activity`, `kb_files`) that #6237's beta-CRM scope left behind (named set 24 → 26 == count).

## Test plan

- [x] `grep -c _jti_not_denied_policy_present apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql` returns 26
- [x] Full verify query run read-only against dev: 35 checks, 0 failing, 26 per-table checks pass
- [x] Merge with post-#6237 `main` resolved to the 26-table union (net delta = the 2 residual tables)
- [ ] Post-merge (CI-automated): `verify-migrations` job green on the merge commit — no operator action

Generated with [Claude Code](https://claude.com/claude-code)
