### PR TITLE
fix(security): add beta-CRM per-table jti-deny presence assertions to verify/068 (#6232 residual)

### DIFF
--- a/apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql
+++ b/apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql
@@ -184,6 +184,25 @@ SELECT 'workspace_member_removals_jti_not_denied_policy_present',
   FROM pg_policies WHERE schemaname='public' AND tablename='workspace_member_removals'
    AND policyname='workspace_member_removals_jti_not_denied' AND permissive='RESTRICTIVE'
 UNION ALL
+-- beta-CRM tenant tables from mig 126 (#6160): each carries the ADR-068
+-- <table>_jti_not_denied RESTRICTIVE policy. Presence-asserted like every other
+-- tenant table above so a dropped policy fails CI even when the aggregate count
+-- (sentinel above) still reads 26 (#6229 bumped the count; #6232 adds these).
+SELECT 'beta_contacts_jti_not_denied_policy_present',
+       CASE WHEN count(*) = 1 THEN 0 ELSE 1 END::int
+  FROM pg_policies WHERE schemaname='public' AND tablename='beta_contacts'
+   AND policyname='beta_contacts_jti_not_denied' AND permissive='RESTRICTIVE'
+UNION ALL
+SELECT 'interview_notes_jti_not_denied_policy_present',
+       CASE WHEN count(*) = 1 THEN 0 ELSE 1 END::int
+  FROM pg_policies WHERE schemaname='public' AND tablename='interview_notes'
+   AND policyname='interview_notes_jti_not_denied' AND permissive='RESTRICTIVE'
+UNION ALL
+SELECT 'beta_contact_stage_transitions_jti_not_denied_policy_present',
+       CASE WHEN count(*) = 1 THEN 0 ELSE 1 END::int
+  FROM pg_policies WHERE schemaname='public' AND tablename='beta_contact_stage_transitions'
+   AND policyname='beta_contact_stage_transitions_jti_not_denied' AND permissive='RESTRICTIVE'
+UNION ALL
 -- (29-31) anon-role REVOKE matrix: none of the three 068 functions
 -- must be EXECUTE-able by anon. Pre-fix, the sentinel asserted only
 -- the authenticated REVOKE matrix; an accidental future GRANT TO anon


### PR DESCRIPTION
## Summary

Completes the #6232 residual. #6229 unblocked the deploy pipeline by bumping the aggregate `jti_deny_policies_count` sentinel 23→26, but left the 3 new beta-CRM tenant tables (from mig 126 / #6160) without the **per-table presence assertions** that section (8-28) of `verify/068` maintains for every other tenant table.

This adds presence assertions for `beta_contacts`, `interview_notes`, and `beta_contact_stage_transitions`, so a dropped jti-deny RLS policy on any of them fails CI even when the aggregate count still reads 26 (the count-vs-specific-table gap the per-table assertions exist to close).

Ref #6232

## User-Brand Impact

- **Exposed artifact / failure mode:** none new. This is an additive, **read-only** CI verify assertion — it does not change any RLS policy, schema, or data. The jti-deny policies themselves (the revoked-JWT defense on the beta-CRM tables) are already live in prod.
- **Value:** closes a coverage asymmetry — the 3 beta-CRM tables were the only tenant tables lacking a per-table jti-deny presence guard. Now a silent drop of one of these policies (that keeps the aggregate at 26 by coincidence) fails CI instead of shipping.
- **If this lands wrong:** a mismatched table/policy name would make `verify-migrations` red (deploy-gated, visible) — no silent regression. Verified against the prd pooler before merge (see Test plan).
- **Brand-survival threshold:** aggregate pattern

## Changelog

### Web Platform
- `verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql` — add per-table jti-deny presence assertions for the 3 beta-CRM tenant tables (`beta_contacts`, `interview_notes`, `beta_contact_stage_transitions`), mirroring the existing per-table guards.

## Test plan
- [x] Ran the full edited `verify/068` against the **prd pooler**: 33 assertions, **0 failures**; the 3 new presence assertions all return `bad=0` (policies present). This is the exact query CI's `verify-migrations` job runs.
- [x] SQL structure verified: `UNION ALL` chaining intact between `workspace_member_removals` and the anon-revoke matrix; query still terminates with `;`.
- [x] data-integrity-guardian review.

Generated with [Claude Code](https://claude.com/claude-code)
